### PR TITLE
Add 3-card reward choice after winning battles

### DIFF
--- a/AsciiCardGame/GameViewModel.swift
+++ b/AsciiCardGame/GameViewModel.swift
@@ -41,6 +41,16 @@ final class GameViewModel: ObservableObject {
         state = GameEngine.collectReward(state: state)
     }
 
+    // MARK: - Battle Reward Phase Actions
+
+    func collectBattleReward(cardId: UUID) {
+        state = GameEngine.collectBattleReward(state: state, chosenCardId: cardId)
+    }
+
+    func skipBattleReward() {
+        state = GameEngine.skipBattleReward(state: state)
+    }
+
     // MARK: - Game Control
 
     func resetGame() {

--- a/AsciiCardGame/Models/GameState.swift
+++ b/AsciiCardGame/Models/GameState.swift
@@ -18,6 +18,7 @@ enum GamePhase: Equatable {
     case movement
     case battle
     case reward
+    case battleReward
     case bossFight
     case gameOver(won: Bool)
 }
@@ -33,6 +34,7 @@ struct GameState: Equatable {
     var hand: [Card]
     var drawPile: [Card]
     var discardPile: [Card]
+    var rewardChoices: [Card] = []
 
     // Player
     var playerHP: Int = 20

--- a/AsciiCardGame/Views/BattleRewardView.swift
+++ b/AsciiCardGame/Views/BattleRewardView.swift
@@ -1,0 +1,97 @@
+import SwiftUI
+
+struct BattleRewardView: View {
+    @EnvironmentObject var vm: GameViewModel
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 16) {
+                Spacer().frame(height: 16)
+
+                Text("=== BATTLE REWARD ===")
+                    .foregroundColor(.yellow)
+
+                Text(victoryASCII)
+                    .font(.system(size: 14, design: .monospaced))
+                    .foregroundColor(.yellow)
+
+                Text("Choose 1 of \(vm.state.rewardChoices.count) cards:")
+                    .foregroundColor(.cyan)
+
+                ForEach(vm.state.rewardChoices) { card in
+                    VStack(spacing: 8) {
+                        HStack(spacing: 16) {
+                            VStack {
+                                Text("Side A")
+                                    .foregroundColor(.cyan)
+                                    .font(.system(size: 10, design: .monospaced))
+                                Text(card.asciiArt(showSideA: true))
+                                    .font(.system(size: 10, design: .monospaced))
+                            }
+                            VStack {
+                                Text("Side B")
+                                    .foregroundColor(.red)
+                                    .font(.system(size: 10, design: .monospaced))
+                                Text(card.asciiArt(showSideA: false))
+                                    .font(.system(size: 10, design: .monospaced))
+                            }
+                        }
+
+                        Text("\(card.name) (\(card.rarity.rawValue))")
+                            .foregroundColor(.white)
+                            .font(.system(size: 12, design: .monospaced))
+
+                        Button(action: {
+                            vm.collectBattleReward(cardId: card.id)
+                        }) {
+                            Text("[ Pick this card ]")
+                                .foregroundColor(.green)
+                                .padding(.vertical, 6)
+                                .padding(.horizontal, 12)
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: 2)
+                                        .stroke(Color.green, lineWidth: 1)
+                                )
+                        }
+                    }
+                    .padding(10)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 4)
+                            .stroke(Color.green.opacity(0.3), lineWidth: 1)
+                    )
+                }
+
+                // Player stats
+                Text(vm.playerHPBar)
+                Text(vm.deckStatusLine)
+                    .font(.system(size: 11, design: .monospaced))
+
+                Button(action: {
+                    vm.skipBattleReward()
+                }) {
+                    Text("[ Skip Reward >> ]")
+                        .foregroundColor(.green)
+                        .padding(.vertical, 8)
+                        .padding(.horizontal, 16)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 2)
+                                .stroke(Color.green, lineWidth: 1)
+                        )
+                }
+
+                Spacer().frame(height: 16)
+            }
+            .padding()
+        }
+    }
+
+    var victoryASCII: String {
+        """
+        ╔═══════╗
+        ║ ★ ★ ★ ║
+        ║VICTORY!║
+        ║ ★ ★ ★ ║
+        ╚═══════╝
+        """
+    }
+}

--- a/AsciiCardGame/Views/ContentView.swift
+++ b/AsciiCardGame/Views/ContentView.swift
@@ -17,6 +17,9 @@ struct ContentView: View {
             case .reward:
                 RewardView()
                     .environmentObject(vm)
+            case .battleReward:
+                BattleRewardView()
+                    .environmentObject(vm)
             case .bossFight:
                 BossFightView()
                     .environmentObject(vm)

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -6,11 +6,14 @@ import {
   playCardForMovement,
   playCardForCombat,
   collectReward,
+  collectBattleReward,
+  skipBattleReward,
 } from './game/engine'
 import { PathMap } from './components/PathMap'
 import { Hand } from './components/Hand'
 import { Battle } from './components/Battle'
 import { Reward } from './components/Reward'
+import { BattleReward } from './components/BattleReward'
 import { GameOver } from './components/GameOver'
 import './styles.css'
 
@@ -37,6 +40,14 @@ export default function App() {
 
   const handleCollectReward = useCallback(() => {
     setState(s => collectReward(s))
+  }, [])
+
+  const handleCollectBattleReward = useCallback((cardId: string) => {
+    setState(s => collectBattleReward(s, cardId))
+  }, [])
+
+  const handleSkipBattleReward = useCallback(() => {
+    setState(s => skipBattleReward(s))
   }, [])
 
   const handleRestart = useCallback(() => {
@@ -77,6 +88,10 @@ export default function App() {
 
       {phase.type === 'reward' && (
         <Reward state={state} onCollect={handleCollectReward} />
+      )}
+
+      {phase.type === 'battleReward' && (
+        <BattleReward state={state} onPick={handleCollectBattleReward} onSkip={handleSkipBattleReward} />
       )}
 
       {phase.type === 'gameOver' && (

--- a/web/src/components/BattleReward.tsx
+++ b/web/src/components/BattleReward.tsx
@@ -1,0 +1,60 @@
+import React from 'react'
+import { GameState } from '../game/types'
+import { CardTile } from './CardTile'
+import { hpBar } from '../game/engine'
+
+interface Props {
+  state: GameState
+  onPick: (cardId: string) => void
+  onSkip: () => void
+}
+
+const VICTORY_ART = `  ╔═══════╗
+  ║ ★ ★ ★ ║
+  ║VICTORY!║
+  ║ ★ ★ ★ ║
+  ╚═══════╝`
+
+export function BattleReward({ state, onPick, onSkip }: Props) {
+  const choices = state.rewardChoices
+
+  return (
+    <div className="reward-screen">
+      <div className="reward-title">═══ BATTLE REWARD ═══</div>
+
+      <pre className="chest-ascii">{VICTORY_ART}</pre>
+
+      <div className="reward-message">
+        Choose 1 of {choices.length} cards to add to your hand:
+      </div>
+
+      <div className="reward-choices">
+        {choices.map(card => (
+          <div key={card.id} className="reward-choice" onClick={() => onPick(card.id)}>
+            <div className="reward-card-sides">
+              <div>
+                <div className="side-label">Side A</div>
+                <CardTile card={card} showSideA={true} />
+              </div>
+              <div>
+                <div className="side-label">Side B</div>
+                <CardTile card={card} showSideA={false} />
+              </div>
+            </div>
+            <div className="reward-card-name">{card.name} ({card.rarity})</div>
+            <button className="action-btn reward-pick-btn">[ Pick this card ]</button>
+          </div>
+        ))}
+      </div>
+
+      <div className="player-stats">
+        <div>{hpBar(state.playerHP, state.playerMaxHP, 'HP')}</div>
+        <div>Draw:{state.drawPile.length} | Discard:{state.discardPile.length} | Hand:{state.hand.length}</div>
+      </div>
+
+      <button className="action-btn" onClick={onSkip}>
+        [ Skip Reward &gt;&gt; ]
+      </button>
+    </div>
+  )
+}

--- a/web/src/game/types.ts
+++ b/web/src/game/types.ts
@@ -48,6 +48,7 @@ export type GamePhase =
   | { type: 'movement' }
   | { type: 'battle' }
   | { type: 'reward' }
+  | { type: 'battleReward' }
   | { type: 'bossFight' }
   | { type: 'gameOver'; won: boolean }
 
@@ -60,6 +61,7 @@ export interface GameState {
   hand: Card[]
   drawPile: Card[]
   discardPile: Card[]
+  rewardChoices: Card[]
 
   playerHP: number
   playerMaxHP: number

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -315,6 +315,36 @@ pre {
   color: #888;
 }
 
+/* ─── Battle Reward Choices ─────────────────────────── */
+
+.reward-choices {
+  display: flex;
+  gap: 16px;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.reward-choice {
+  border: 1px solid rgba(51, 255, 51, 0.3);
+  padding: 10px;
+  cursor: pointer;
+  transition: all 0.15s;
+  text-align: center;
+  border-radius: 2px;
+}
+
+.reward-choice:hover {
+  border-color: #ffcc00;
+  background: rgba(255, 204, 0, 0.08);
+  box-shadow: 0 0 10px rgba(255, 204, 0, 0.2);
+}
+
+.reward-pick-btn {
+  margin-top: 8px;
+  font-size: 12px !important;
+  padding: 4px 12px !important;
+}
+
 /* ─── Game Over Screen ───────────────────────────────── */
 
 .gameover-screen {


### PR DESCRIPTION
After defeating an enemy in battle, players are now offered 3 cards from the draw pile and can pick 1 to add to their hand. Unchosen cards return to the draw pile. Reward spaces still give 1 random card, making battles the more rewarding path.

https://claude.ai/code/session_01FNtmRV5tfdmnwcYtwRR11e