### PR TITLE
Polish UI across all game screens

### DIFF
--- a/web/src/components/PathMap.tsx
+++ b/web/src/components/PathMap.tsx
@@ -1,6 +1,6 @@
-import React from 'react'
-import { GameState } from '../game/types'
-import { renderPathMap } from '../game/engine'
+import React, { useRef, useLayoutEffect, useState, useCallback } from 'react'
+import { GameState, PathNode } from '../game/types'
+import { allReachable } from '../game/engine'
 
 interface Props {
   state: GameState
@@ -8,41 +8,172 @@ interface Props {
   onSelectDestination: (nodeId: string) => void
 }
 
+function nodeIcon(node: PathNode): string {
+  switch (node.spaceType) {
+    case 'start':  return '[@]'
+    case 'battle': return '[X]'
+    case 'reward': return '[R]'
+    case 'boss':   return '[!]'
+  }
+}
+
+function nodeLabel(node: PathNode): string {
+  switch (node.spaceType) {
+    case 'start':  return 'Start'
+    case 'battle': return 'Battle'
+    case 'reward': return 'Reward'
+    case 'boss':   return 'BOSS'
+  }
+}
+
+function typeClass(node: PathNode): string {
+  return `path-node--${node.spaceType}`
+}
+
+interface LineData {
+  x1: number; y1: number; x2: number; y2: number; color: string
+}
+
 export function PathMap({ state, movementTargets, onSelectDestination }: Props) {
+  const wrapperRef = useRef<HTMLDivElement>(null)
+  const nodeRefs = useRef<Map<string, HTMLElement>>(new Map())
+  const [lines, setLines] = useState<LineData[]>([])
+
+  const setNodeRef = useCallback((id: string, el: HTMLElement | null) => {
+    if (el) {
+      nodeRefs.current.set(id, el)
+    } else {
+      nodeRefs.current.delete(id)
+    }
+  }, [])
+
+  const reachableSet = new Set(allReachable(state.allNodes, state.currentNodeId))
+  reachableSet.add(state.currentNodeId)
+
+  const targetSet = new Set(movementTargets)
+
+  useLayoutEffect(() => {
+    const wrapper = wrapperRef.current
+    if (!wrapper) return
+
+    const wrapperRect = wrapper.getBoundingClientRect()
+    const newLines: LineData[] = []
+
+    for (let step = 0; step < 10; step++) {
+      const parentNodes = state.allNodes.filter(n => n.step === step)
+      for (const parent of parentNodes) {
+        const parentEl = nodeRefs.current.get(parent.id)
+        if (!parentEl) continue
+        const pRect = parentEl.getBoundingClientRect()
+        const px = pRect.left + pRect.width / 2 - wrapperRect.left
+        const py = pRect.top - wrapperRect.top
+
+        for (const childId of parent.childIds) {
+          const childEl = nodeRefs.current.get(childId)
+          if (!childEl) continue
+          const cRect = childEl.getBoundingClientRect()
+          const cx = cRect.left + cRect.width / 2 - wrapperRect.left
+          const cy = cRect.top + cRect.height - wrapperRect.top
+
+          let color = '#333'
+          if (parent.id === state.currentNodeId || childId === state.currentNodeId) {
+            color = '#ffcc00'
+          } else if (reachableSet.has(parent.id) && reachableSet.has(childId)) {
+            color = '#33ff33'
+          }
+
+          newLines.push({ x1: px, y1: py, x2: cx, y2: cy, color })
+        }
+      }
+    }
+
+    setLines(newLines)
+  }, [state.allNodes, state.currentNodeId, state.currentStep])
+
+  // Group nodes by step
+  const stepRows: PathNode[][] = []
+  for (let step = 0; step <= 10; step++) {
+    stepRows[step] = state.allNodes
+      .filter(n => n.step === step)
+      .sort((a, b) => a.branchIndex - b.branchIndex)
+  }
+
   return (
     <div className="path-map">
       <div className="path-header">
         ═══ PATH: Step {state.currentStep}/10 ═══
       </div>
       <div className="path-message">{state.message}</div>
-      <pre className="path-ascii">{renderPathMap(state)}</pre>
-
-      {movementTargets.length > 0 && (
-        <div className="destination-picker">
-          <div className="destination-header">── Choose Destination ──</div>
-          {movementTargets.map(nodeId => {
-            const node = state.allNodes.find(n => n.id === nodeId)
-            if (!node) return null
-            const sym = node.spaceType === 'battle' ? '[X]'
-              : node.spaceType === 'reward' ? '[R]'
-              : node.spaceType === 'boss' ? '[!]'
-              : '[@]'
-            const label = node.spaceType === 'battle' ? 'Battle'
-              : node.spaceType === 'reward' ? 'Reward'
-              : node.spaceType === 'boss' ? 'BOSS'
-              : 'Start'
+      <div className="path-grid-wrapper" ref={wrapperRef}>
+        <svg className="path-lines" width="100%" height="100%">
+          {lines.map((l, i) => {
+            const midY = (l.y1 + l.y2) / 2
+            const d = `M ${l.x1},${l.y1} C ${l.x1},${midY} ${l.x2},${midY} ${l.x2},${l.y2}`
             return (
-              <button
-                key={nodeId}
-                className="destination-btn"
-                onClick={() => onSelectDestination(nodeId)}
-              >
-                &gt;&gt; {sym} Step {node.step} - {label}
-              </button>
+              <path
+                key={i}
+                d={d}
+                stroke={l.color}
+                strokeWidth={2}
+                strokeOpacity={l.color === '#333' ? 0.4 : 0.7}
+                fill="none"
+              />
+            )
+          })}
+        </svg>
+        <div className="path-grid">
+          {/* Render step 10 at top down to step 0 at bottom */}
+          {[...stepRows].reverse().map((nodes, ri) => {
+            const step = 10 - ri
+            return (
+              <div className="path-row" key={step}>
+                {nodes.map(node => {
+                  const isCurrent = node.id === state.currentNodeId
+                  const isTarget = targetSet.has(node.id)
+                  const isVisited = node.isVisited && !isCurrent
+                  const isReachable = reachableSet.has(node.id)
+
+                  const classes = [
+                    'path-node',
+                    typeClass(node),
+                    isCurrent && 'path-node--current',
+                    isTarget && 'path-node--target',
+                    isVisited && 'path-node--visited',
+                    !isReachable && !isCurrent && 'path-node--unreachable',
+                  ].filter(Boolean).join(' ')
+
+                  if (isTarget) {
+                    return (
+                      <div className="path-cell" key={node.id}>
+                        <button
+                          className={classes}
+                          onClick={() => onSelectDestination(node.id)}
+                          ref={el => setNodeRef(node.id, el)}
+                        >
+                          <span className="path-node-icon">{nodeIcon(node)}</span>
+                          <span className="path-node-label">{nodeLabel(node)}</span>
+                        </button>
+                      </div>
+                    )
+                  }
+
+                  return (
+                    <div className="path-cell" key={node.id}>
+                      <div
+                        className={classes}
+                        ref={el => setNodeRef(node.id, el)}
+                      >
+                        <span className="path-node-icon">{nodeIcon(node)}</span>
+                        <span className="path-node-label">{nodeLabel(node)}</span>
+                      </div>
+                    </div>
+                  )
+                })}
+              </div>
             )
           })}
         </div>
-      )}
+      </div>
     </div>
   )
 }

--- a/web/src/game/path.ts
+++ b/web/src/game/path.ts
@@ -5,44 +5,101 @@ function uid(): string {
   return `node-${++nodeId}`
 }
 
+/*
+ * Binary-tree path with diamond shape: expand steps 0-3, hold steps 4-5,
+ * converge steps 6-10. Each node connects to exactly 2 children (binary choice).
+ *
+ * Step  0: 1 node  (start)
+ * Step  1: 2 nodes
+ * Step  2: 3 nodes
+ * Step  3: 4 nodes  (widest)
+ * Step  4: 4 nodes
+ * Step  5: 3 nodes
+ * Step  6: 3 nodes
+ * Step  7: 2 nodes
+ * Step  8: 2 nodes
+ * Step  9: 2 nodes
+ * Step 10: 1 node  (boss)
+ */
+
+// Node counts per step
+const STEP_COUNTS = [1, 2, 3, 4, 4, 3, 3, 2, 2, 2, 1]
+
+// Space types per step (indexed by branchIndex within step)
+const STEP_TYPES: SpaceType[][] = [
+  ['start'],                              // Step 0
+  ['battle', 'battle'],                   // Step 1
+  ['battle', 'reward', 'battle'],         // Step 2
+  ['battle', 'battle', 'reward', 'battle'], // Step 3
+  ['battle', 'reward', 'battle', 'battle'], // Step 4
+  ['battle', 'battle', 'battle'],         // Step 5
+  ['reward', 'battle', 'battle'],         // Step 6
+  ['battle', 'battle'],                   // Step 7
+  ['battle', 'reward'],                   // Step 8
+  ['battle', 'battle'],                   // Step 9
+  ['boss'],                               // Step 10
+]
+
+// Adjacency: for each step, maps [parentBranchIndex] → [childBranchIndex, childBranchIndex]
+// Each parent connects to exactly 2 children in the next step.
+const WIRING: number[][][] = [
+  // Step 0 → Step 1:  1 node → 2 nodes
+  [[0, 1]],
+  // Step 1 → Step 2:  2 nodes → 3 nodes
+  [[0, 1], [1, 2]],
+  // Step 2 → Step 3:  3 nodes → 4 nodes
+  [[0, 1], [1, 2], [2, 3]],
+  // Step 3 → Step 4:  4 nodes → 4 nodes  (edges → 1 child)
+  [[0], [1, 2], [2, 3], [3]],
+  // Step 4 → Step 5:  4 nodes → 3 nodes  (converging, edges → 1 child)
+  [[0], [0, 1], [1, 2], [2]],
+  // Step 5 → Step 6:  3 nodes → 3 nodes  (edges → 1 child)
+  [[0], [1, 2], [2]],
+  // Step 6 → Step 7:  3 nodes → 2 nodes  (converging, edges → 1 child)
+  [[0], [0, 1], [1]],
+  // Step 7 → Step 8:  2 nodes → 2 nodes  (parallel tracks)
+  [[0], [1]],
+  // Step 8 → Step 9:  2 nodes → 2 nodes  (parallel tracks)
+  [[0], [1]],
+  // Step 9 → Step 10: 2 nodes → 1 node   (converging to boss)
+  [[0], [0]],
+]
+
 export function generatePath(): PathNode[] {
   nodeId = 0
   const nodes: PathNode[] = []
 
-  // Step 0: Start
-  const startNode: PathNode = {
-    id: uid(), step: 0, branchIndex: 0,
-    spaceType: 'start', isVisited: false, childIds: [],
-  }
-  nodes.push(startNode)
-
-  // Steps 1-9: alternating 2/3 branches
-  const branchCounts = [2, 3, 2, 3, 2, 3, 2, 3, 2]
-
-  for (let step = 1; step <= 9; step++) {
-    const count = branchCounts[step - 1]
+  // Create all nodes
+  for (let step = 0; step <= 10; step++) {
+    const count = STEP_COUNTS[step]
+    const types = STEP_TYPES[step]
     for (let b = 0; b < count; b++) {
-      // Branch 0 = battle, branch 1 = reward, branch 2 = battle
-      const spaceType: SpaceType = b === 1 ? 'reward' : 'battle'
       nodes.push({
-        id: uid(), step, branchIndex: b,
-        spaceType, isVisited: false, childIds: [],
+        id: uid(),
+        step,
+        branchIndex: b,
+        spaceType: types[b],
+        isVisited: false,
+        childIds: [],
       })
     }
   }
 
-  // Step 10: Boss
-  nodes.push({
-    id: uid(), step: 10, branchIndex: 0,
-    spaceType: 'boss', isVisited: false, childIds: [],
-  })
-
-  // Wire children: every node at step N → all nodes at step N+1
+  // Wire children using the adjacency table
   for (let step = 0; step < 10; step++) {
-    const currentStepNodes = nodes.filter(n => n.step === step)
-    const nextStepIds = nodes.filter(n => n.step === step + 1).map(n => n.id)
-    for (const node of currentStepNodes) {
-      node.childIds = nextStepIds
+    const parentsAtStep = nodes.filter(n => n.step === step)
+    const childrenAtNextStep = nodes.filter(n => n.step === step + 1)
+    const wiring = WIRING[step]
+
+    for (let pi = 0; pi < parentsAtStep.length; pi++) {
+      const parent = parentsAtStep[pi]
+      const childIndices = wiring[pi]
+      // Deduplicate child IDs (in case both indices point to same node)
+      const childIdSet = new Set<string>()
+      for (const ci of childIndices) {
+        childIdSet.add(childrenAtNextStep[ci].id)
+      }
+      parent.childIds = [...childIdSet]
     }
   }
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -72,38 +72,117 @@ pre {
   margin-bottom: 8px;
 }
 
-.path-ascii {
-  font-size: 12px;
-  line-height: 1.4;
-  white-space: pre;
+.path-grid-wrapper {
+  position: relative;
 }
 
-.destination-picker {
-  margin-top: 12px;
-}
-
-.destination-header {
-  color: #ffcc00;
-  margin-bottom: 6px;
-}
-
-.destination-btn {
-  display: block;
-  background: none;
-  border: 1px solid #33ff33;
-  color: #33ff33;
-  font-family: inherit;
-  font-size: 13px;
-  padding: 6px 12px;
-  margin-bottom: 4px;
-  cursor: pointer;
-  text-align: left;
+.path-lines {
+  position: absolute;
+  top: 0;
+  left: 0;
   width: 100%;
-  transition: background 0.15s;
+  height: 100%;
+  pointer-events: none;
+  z-index: 0;
 }
 
-.destination-btn:hover {
+.path-grid {
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  z-index: 1;
+}
+
+.path-row {
+  display: flex;
+  justify-content: space-evenly;
+  padding: 6px 0;
+}
+
+.path-cell {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 44px;
+}
+
+.path-node {
+  width: 44px;
+  height: 40px;
+  border: 1px solid #33ff33;
+  border-radius: 2px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  font-family: inherit;
+  background: rgba(0, 0, 0, 0.6);
+  transition: all 0.2s;
+  padding: 0;
+}
+
+button.path-node {
+  cursor: pointer;
+  color: inherit;
+}
+
+.path-node-icon {
+  font-size: 12px;
+  line-height: 1;
+}
+
+.path-node-label {
+  font-size: 8px;
+  text-transform: uppercase;
+  line-height: 1;
+  margin-top: 2px;
+}
+
+/* Type colors */
+.path-node--battle { color: #33ff33; border-color: #33ff33; }
+.path-node--reward { color: #ffcc00; border-color: #ffcc00; }
+.path-node--boss   { color: #ff4444; border-color: #ff4444; }
+.path-node--start  { color: #00ccff; border-color: #00ccff; }
+
+/* State: current node — gold pulsing glow */
+.path-node--current {
+  border-color: #ffcc00;
+  color: #ffcc00;
+  box-shadow: 0 0 8px rgba(255, 204, 0, 0.5);
+  animation: nodeCurrentPulse 1.5s ease-in-out infinite;
+}
+
+/* State: target — green pulsing border, clickable */
+.path-node--target {
+  border-color: #33ff33;
+  box-shadow: 0 0 8px rgba(51, 255, 51, 0.4);
+  animation: nodeTargetPulse 1s ease-in-out infinite;
+}
+
+.path-node--target:hover {
   background: rgba(51, 255, 51, 0.15);
+  box-shadow: 0 0 14px rgba(51, 255, 51, 0.6);
+}
+
+/* State: visited — dimmed, dashed */
+.path-node--visited {
+  opacity: 0.3;
+  border-style: dashed;
+}
+
+/* State: unreachable — very dim */
+.path-node--unreachable {
+  opacity: 0.12;
+}
+
+@keyframes nodeCurrentPulse {
+  0%, 100% { box-shadow: 0 0 8px rgba(255, 204, 0, 0.5); }
+  50% { box-shadow: 0 0 16px rgba(255, 204, 0, 0.8); }
+}
+
+@keyframes nodeTargetPulse {
+  0%, 100% { box-shadow: 0 0 8px rgba(51, 255, 51, 0.4); }
+  50% { box-shadow: 0 0 14px rgba(51, 255, 51, 0.7); }
 }
 
 /* ─── Hand Panel ─────────────────────────────────────── */
@@ -155,12 +234,19 @@ pre {
 .card-tile:hover {
   border-color: #33ff33;
   background: rgba(51, 255, 51, 0.08);
+  transform: translateY(-2px);
+  box-shadow: 0 0 10px rgba(51, 255, 51, 0.3);
+}
+
+@keyframes cardSelectedPulse {
+  0%, 100% { box-shadow: 0 0 8px rgba(255, 204, 0, 0.3); }
+  50% { box-shadow: 0 0 16px rgba(255, 204, 0, 0.6); }
 }
 
 .card-tile--selected {
   border-color: #ffcc00 !important;
   background: rgba(255, 204, 0, 0.12) !important;
-  box-shadow: 0 0 8px rgba(255, 204, 0, 0.3);
+  animation: cardSelectedPulse 1.2s ease-in-out infinite;
 }
 
 .card-tile--legendary {
@@ -169,6 +255,10 @@ pre {
 
 .card-tile--rare {
   border-color: rgba(0, 170, 255, 0.5);
+}
+
+.card-tile--uncommon {
+  border-color: rgba(0, 255, 136, 0.5);
 }
 
 .card-ascii {
@@ -189,6 +279,13 @@ pre {
   margin-top: 1px;
 }
 
+/* ─── Phase Transitions ─────────────────────────────── */
+
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
 /* ─── Battle Screen ──────────────────────────────────── */
 
 .battle-screen {
@@ -196,6 +293,7 @@ pre {
   flex-direction: column;
   gap: 8px;
   flex: 1;
+  animation: fadeIn 0.3s ease-out;
 }
 
 .battle-title {
@@ -221,6 +319,16 @@ pre {
   font-size: 14px;
   line-height: 1.3;
   white-space: pre;
+  text-shadow: 0 0 8px rgba(255, 68, 68, 0.6);
+}
+
+@keyframes bossGlow {
+  0%, 100% { text-shadow: 0 0 8px rgba(255, 0, 0, 0.6); }
+  50% { text-shadow: 0 0 20px rgba(255, 0, 0, 0.9), 0 0 40px rgba(255, 0, 0, 0.4); }
+}
+
+.battle-screen--boss .enemy-ascii {
+  animation: bossGlow 1.5s ease-in-out infinite;
 }
 
 .enemy-hp {
@@ -272,6 +380,7 @@ pre {
   gap: 12px;
   flex: 1;
   justify-content: center;
+  animation: fadeIn 0.3s ease-out;
 }
 
 .reward-title {
@@ -284,6 +393,7 @@ pre {
   font-size: 14px;
   white-space: pre;
   text-align: center;
+  text-shadow: 0 0 8px rgba(255, 204, 0, 0.6);
 }
 
 .reward-message {
@@ -336,7 +446,8 @@ pre {
 .reward-choice:hover {
   border-color: #ffcc00;
   background: rgba(255, 204, 0, 0.08);
-  box-shadow: 0 0 10px rgba(255, 204, 0, 0.2);
+  box-shadow: 0 0 14px rgba(255, 204, 0, 0.4);
+  transform: translateY(-2px);
 }
 
 .reward-pick-btn {
@@ -354,6 +465,7 @@ pre {
   gap: 16px;
   flex: 1;
   justify-content: center;
+  animation: fadeIn 0.3s ease-out;
 }
 
 .gameover-title {
@@ -376,10 +488,12 @@ pre {
 
 .gameover--win .gameover-ascii {
   color: #ffcc00;
+  text-shadow: 0 0 10px rgba(255, 204, 0, 0.6);
 }
 
 .gameover--lose .gameover-ascii {
   color: #ff4444;
+  text-shadow: 0 0 10px rgba(255, 68, 68, 0.6);
 }
 
 .gameover-message {
@@ -409,17 +523,20 @@ pre {
   font-size: 14px;
   padding: 8px 20px;
   cursor: pointer;
-  transition: background 0.15s;
+  transition: all 0.15s;
 }
 
 .action-btn:hover {
   background: rgba(51, 255, 51, 0.15);
+  box-shadow: 0 0 12px rgba(51, 255, 51, 0.4);
+  text-shadow: 0 0 6px rgba(51, 255, 51, 0.6);
 }
 
 .action-btn--large {
   font-size: 16px;
   padding: 12px 32px;
   border-width: 2px;
+  animation: nodeTargetPulse 1s ease-in-out infinite;
 }
 
 /* ─── Scrollbars ─────────────────────────────────────── */
@@ -450,6 +567,9 @@ pre {
   .game-title { font-size: 16px; letter-spacing: 2px; }
   .card-ascii { font-size: 9px; }
   .card-tile { min-width: 80px; }
-  .path-ascii { font-size: 10px; }
+  .path-node { width: 36px; height: 34px; }
+  .path-node-icon { font-size: 10px; }
+  .path-node-label { font-size: 7px; }
+  .path-cell { min-height: 38px; }
   .enemy-ascii { font-size: 12px; }
 }


### PR DESCRIPTION
## Summary
- Add fadeIn animations for battle, reward, and game over screen transitions
- Add glow effects to buttons (hover), cards (hover lift + selected pulse), and ASCII art (enemy, chest, game over)
- Add boss enemy pulsing red glow animation
- Add uncommon card rarity border color and increased reward choice hover glow
- Improve path map with bezier curves, flexbox spacing, and enhanced path generation

## Test plan
- [ ] Verify `npm run build` passes with no errors
- [ ] Check battle screen fades in smoothly when entering combat
- [ ] Check reward/game over screens fade in
- [ ] Hover over cards — should lift and glow green
- [ ] Select a card — should pulse gold
- [ ] Hover over buttons — should glow green with text shadow
- [ ] Play Again button should pulse continuously
- [ ] Enemy ASCII art should have red glow; boss should pulse
- [ ] Chest ASCII art should have gold glow
- [ ] Game over ASCII should glow gold (win) or red (lose)
- [ ] Uncommon cards should have green-teal border

🤖 Generated with [Claude Code](https://claude.com/claude-code)