### PR TITLE
feat: add error logging to all unprotected storage writes (#325)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,16 @@ npm run preview  # Preview production build locally
 - **Opponent AI:** Plays 1–2 affordable cards per turn from its own shuffled deck
 - **Win:** Destroy the enemy base (20 HP). **Lose:** Your base reaches 0 HP.
 
+## Error Logging Standard
+
+All error handling must follow this pattern:
+
+- **React components / App.tsx:** import `rollbar` from `./rollbar` and call `rollbar.error(msg, context)` directly.
+- **Game logic files (`src/game/`):** import `logError` from `'../logger'` — never import rollbar directly (keeps game files free of browser dependencies and safe for Node.js scripts like `balance-test`).
+- **localStorage writes** must always be wrapped in `try/catch` with `logError` in the catch. Reads already have fallbacks.
+- **Silent swallowing is banned** for anything user-impacting: `catch { /* ignore */ }` is only acceptable for truly fire-and-forget operations (e.g. analytics pings). For saves and state mutations, always log.
+- `logger.ts` is initialised in `main.tsx` with the real Rollbar instance. In tests or Node scripts it is a no-op by default.
+
 ## CSS Styling Rules
 Always reuse existing CSS classes rather than writing new ones unless the required functionality is genuinely different. Before adding a new button style, check whether an existing class (e.g. `action-btn`, `action-btn--gold`, `action-btn--danger`) can be used or extended with a small modifier. Duplicate CSS leads to visual inconsistency and maintenance burden. when considering adding new css if there is an existing attribute that could be used that has a specific name, rename and refactor to something more generic. eg "title-screen-button" is specific and could be standardised with a style called "normal-button".
 Better still would be to create a component such as "Button" that has props tha allow for some variation, but generally consistent.

--- a/web/src/game/collection.ts
+++ b/web/src/game/collection.ts
@@ -1,5 +1,6 @@
 import { Card, CardRarity } from './types'
 import { getCardCatalog } from './cards'
+import { logError } from '../logger'
 
 // ─── Types ────────────────────────────────────────────────
 
@@ -171,7 +172,8 @@ export function loadCardStats(): Record<string, CardStats> {
 }
 
 function saveCardStats(stats: Record<string, CardStats>): void {
-  localStorage.setItem(STATS_KEY, JSON.stringify(stats))
+  try { localStorage.setItem(STATS_KEY, JSON.stringify(stats)) }
+  catch (e) { logError('saveCardStats failed', { error: String(e) }) }
 }
 
 export function recordCardPlayed(cardName: string): void {
@@ -204,7 +206,8 @@ export function loadCrystals(): number {
 }
 
 export function saveCrystals(n: number): void {
-  localStorage.setItem(CRYSTALS_KEY, String(Math.max(0, n)))
+  try { localStorage.setItem(CRYSTALS_KEY, String(Math.max(0, n))) }
+  catch (e) { logError('saveCrystals failed', { error: String(e) }) }
 }
 
 // ─── Mastery math ─────────────────────────────────────────
@@ -339,7 +342,8 @@ export function loadCollection(): CollectionEntry[] {
 }
 
 export function saveCollection(c: CollectionEntry[]): void {
-  localStorage.setItem(COLLECTION_KEY, JSON.stringify(c))
+  try { localStorage.setItem(COLLECTION_KEY, JSON.stringify(c)) }
+  catch (e) { logError('saveCollection failed', { count: c.length, error: String(e) }) }
 }
 
 export function addCardsToCollection(newCards: CollectionEntry[]): CollectionEntry[] {
@@ -372,7 +376,8 @@ export function loadDeck(): DeckEntry[] {
 }
 
 export function saveDeck(d: DeckEntry[]): void {
-  localStorage.setItem(DECK_KEY, JSON.stringify(d))
+  try { localStorage.setItem(DECK_KEY, JSON.stringify(d)) }
+  catch (e) { logError('saveDeck failed', { count: d.length, error: String(e) }) }
 }
 
 export function deckTotalCards(d: DeckEntry[]): number {

--- a/web/src/game/dailyLogin.ts
+++ b/web/src/game/dailyLogin.ts
@@ -1,5 +1,6 @@
 // ─── Daily Login Rewards ──────────────────────────────────────────────────────
 
+import { logError } from '../logger'
 import itemsJson   from '../data/items.json'
 import rewardsJson from '../data/rewards.json'
 import { getCardCatalog } from './cards'
@@ -455,7 +456,7 @@ export function addToInventory(item: Omit<UselessItem, 'acquiredDate'>): void {
         incrementAchievementProgress('misc:unique_items')
       })
     }
-  } catch { /* ignore */ }
+  } catch (e) { logError('addToInventory failed', { itemId: item.id, error: String(e) }) }
 }
 
 export function loadInventory(): UselessItem[] {

--- a/web/src/game/questline.ts
+++ b/web/src/game/questline.ts
@@ -1,4 +1,5 @@
 import { CardRarity } from './types'
+import { logError } from '../logger'
 import { getCardCatalog } from './cards'
 import act1Data from '../data/acts/act1.json'
 import act2Data from '../data/acts/act2.json'
@@ -427,7 +428,8 @@ export function loadRun(): RunState | null {
 }
 
 export function saveRun(run: RunState): void {
-  localStorage.setItem(RUN_KEY, JSON.stringify(run))
+  try { localStorage.setItem(RUN_KEY, JSON.stringify(run)) }
+  catch (e) { logError('saveRun failed', { actId: run.actId, error: String(e) }) }
 }
 
 export function clearRun(): void {
@@ -465,7 +467,8 @@ export function loadFatigued(): string[] {
 }
 
 export function saveFatigued(names: string[]): void {
-  localStorage.setItem(FATIGUED_KEY, JSON.stringify(names))
+  try { localStorage.setItem(FATIGUED_KEY, JSON.stringify(names)) }
+  catch (e) { logError('saveFatigued failed', { error: String(e) }) }
 }
 
 export function clearFatigued(): void {

--- a/web/src/logger.ts
+++ b/web/src/logger.ts
@@ -1,0 +1,17 @@
+/**
+ * Thin error-logging facade used by game logic files.
+ * Initialised with the Rollbar instance in main.tsx so game files
+ * stay free of direct browser/Rollbar dependencies.
+ */
+
+type ErrorLogger = (msg: string, ctx?: Record<string, unknown>) => void
+
+let _logError: ErrorLogger = () => {}
+
+export function setErrorLogger(fn: ErrorLogger): void {
+  _logError = fn
+}
+
+export function logError(msg: string, ctx?: Record<string, unknown>): void {
+  _logError(msg, ctx)
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,7 +1,10 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
-import './rollbar'
+import rollbar from './rollbar'
+import { setErrorLogger } from './logger'
 import App from './App'
+
+setErrorLogger((msg, ctx) => rollbar.error(msg, ctx as object))
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>


### PR DESCRIPTION
- Add src/logger.ts: thin facade so game files can log errors without importing rollbar directly (keeps game/ free of browser deps)
- Wire logger to Rollbar in main.tsx
- Wrap saveRun, saveFatigued (questline.ts), saveCollection, saveDeck, saveCardStats, saveCrystals (collection.ts), addToInventory (dailyLogin.ts) — all were previously unprotected localStorage writes
- Update CLAUDE.md with error logging standard for future consistency