### PR TITLE
Add Rollbar info logs throughout Google login flow

### DIFF
--- a/web/src/components/SettingsScreen.tsx
+++ b/web/src/components/SettingsScreen.tsx
@@ -142,15 +142,18 @@ export function SettingsScreen({ onBack, onResetGame, user, authLoading }: Props
   const [emailBusy,     setEmailBusy]     = useState(false)
 
   async function finishSignIn(linkedUser: User) {
+    rollbar.info('finishSignIn: checking for cloud save', { uid: linkedUser.uid })
     try {
       const cloud = await downloadSave(linkedUser.uid)
       if (cloud) {
-        rollbar.info('Cloud save found after sign-in, prompting user', { uid: linkedUser.uid })
+        rollbar.info('finishSignIn: cloud save found, prompting user', { uid: linkedUser.uid })
         setPendingCloudSave(cloud)
       } else {
+        rollbar.info('finishSignIn: no cloud save found, uploading local save', { uid: linkedUser.uid })
         await uploadSave(linkedUser.uid)
         setLastSync(new Date())
         setSyncMsg('Save synced to cloud.')
+        rollbar.info('finishSignIn: local save uploaded successfully', { uid: linkedUser.uid })
       }
     } catch (err) {
       rollbar.error('finishSignIn: cloud save check/upload failed', { err })
@@ -244,15 +247,18 @@ export function SettingsScreen({ onBack, onResetGame, user, authLoading }: Props
 
   async function handleSignIn() {
     if (!user) return
+    rollbar.info('Google sign-in: initiated', { uid: user.uid, isAnonymous: user.isAnonymous })
     setSigningIn(true)
     setSyncMsg(null)
     const provider = new GoogleAuthProvider()
     try {
       let linkedUser: User
       if (user.isAnonymous) {
+        rollbar.info('Google sign-in: attempting linkWithPopup for anonymous user', { uid: user.uid })
         try {
           const result = await linkWithPopup(user, provider)
           linkedUser = result.user
+          rollbar.info('Google sign-in: linkWithPopup succeeded', { uid: linkedUser.uid })
         } catch (linkErr: unknown) {
           const err = linkErr as { code?: string }
           if (err.code === 'auth/credential-already-in-use') {
@@ -261,13 +267,16 @@ export function SettingsScreen({ onBack, onResetGame, user, authLoading }: Props
             if (!credential) throw linkErr
             const result = await signInWithCredential(auth, credential)
             linkedUser = result.user
+            rollbar.info('Google sign-in: signInWithCredential succeeded', { uid: linkedUser.uid })
           } else {
             throw linkErr
           }
         }
       } else {
+        rollbar.info('Google sign-in: attempting signInWithPopup for existing user', { uid: user.uid })
         const result = await signInWithPopup(auth, provider)
         linkedUser = result.user
+        rollbar.info('Google sign-in: signInWithPopup succeeded', { uid: linkedUser.uid })
       }
       await finishSignIn(linkedUser)
     } catch (err: unknown) {

--- a/web/src/hooks/useAuth.ts
+++ b/web/src/hooks/useAuth.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import { onAuthStateChanged, signInAnonymously, type User } from 'firebase/auth'
 import { auth } from '../firebase'
+import rollbar from '../rollbar'
 
 export interface AuthState {
   user: User | null
@@ -14,13 +15,17 @@ export function useAuth(): AuthState {
   useEffect(() => {
     const unsub = onAuthStateChanged(auth, async (u) => {
       if (u) {
+        rollbar.info('useAuth: auth state changed — user present', { uid: u.uid, isAnonymous: u.isAnonymous })
         setUser(u)
         setLoading(false)
       } else {
         // No session — sign in anonymously so we always have a uid available.
+        rollbar.info('useAuth: no session, signing in anonymously')
         try {
           await signInAnonymously(auth)
-        } catch {
+          rollbar.info('useAuth: anonymous sign-in succeeded')
+        } catch (err) {
+          rollbar.error('useAuth: anonymous sign-in failed', { err })
           setLoading(false)
         }
       }


### PR DESCRIPTION
Adds step-by-step info logging so the full login path is visible in Rollbar: anonymous sign-in in useAuth, each branch of handleSignIn (linkWithPopup, signInWithCredential, signInWithPopup), and each step of finishSignIn (download check, upload, success).

https://claude.ai/code/session_01L2t4EbsSNiUsMv4frvGb2Y