### PR TITLE
fix(#447): make replay modifier screen scrollable

### DIFF
--- a/web/src/components/ReplayBriefingScreen.tsx
+++ b/web/src/components/ReplayBriefingScreen.tsx
@@ -139,8 +139,8 @@ export function ReplayBriefingScreen({ act, completionCount, lastRunFailed, onBe
             >
               <div className="rb-tier-top">
                 <span className="rb-tier-label">{tier.label}</span>
-                {tier.isBase && <span className="rb-tier-tag rb-tier-tag--auto">REQUIRED</span>}
-                {!tier.isBase && <span className="rb-tier-tag rb-tier-tag--bonus">OPTIONAL</span>}
+                {tier.isBase && <span className="rb-tier-tag rb-tier-tag--required">REQUIRED</span>}
+                {!tier.isBase && <span className="rb-tier-tag rb-tier-tag--optional">OPTIONAL</span>}
                 {tier.extraCrystals > 0 && (
                   <span className="rb-tier-crystal">+{tier.extraCrystals} ◆/battle</span>
                 )}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -6977,7 +6977,10 @@ html.eightbit-mode .lane-layer {
   padding: 24px 16px;
   max-width: 480px;
   margin: 0 auto;
-  min-height: 100%;
+  width: 100%;
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
   box-sizing: border-box;
 }
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Fixes #447 — campaign replay modifier selection screen was broken on small screens.

- **Scrolling**: `.replay-briefing` now uses `flex: 1; min-height: 0; overflow-y: auto` so it scrolls within the fixed-height `.game-container`. The "Begin Run" button is now always reachable regardless of screen height.
- **"Picking a modifier does nothing"**: Root cause was the same — optional tier buttons were below the fold and inaccessible. With scrolling enabled they are now clickable.
- **Tag styling**: Fixed CSS class name mismatches (`rb-tier-tag--auto` → `rb-tier-tag--required`, `rb-tier-tag--bonus` → `rb-tier-tag--optional`) so the REQUIRED/OPTIONAL badges render in their intended yellow/green colours.

## Test plan

- [ ] On a short viewport, open an act replay briefing — confirm the screen scrolls and "Begin Run" is reachable
- [ ] Confirm clicking optional tier buttons visually selects them (border turns green)
- [ ] Confirm REQUIRED tag is yellow and OPTIONAL tag is green

https://claude.ai/code/session_01N3spUCvB4MhEA8NM8pX9Rx
EOF
)