### PR TITLE
fix(campaign): drain consumable stash into active run on load

### DIFF
--- a/web/src/game/questline.ts
+++ b/web/src/game/questline.ts
@@ -498,6 +498,7 @@ export function loadRun(): RunState | null {
     // Migrate: lives system (added later — default 3/3 for old saves)
     if (typeof parsed.crystalBonus !== 'number') parsed.crystalBonus = 0
     if (!Array.isArray(parsed.consumables)) parsed.consumables = []
+    parsed.consumables = drainStashIntoRun(parsed.consumables)
     if (typeof parsed.activeModifierCount !== 'number') parsed.activeModifierCount = 0
     if (typeof parsed.maxLives !== 'number' || parsed.maxLives < 1) parsed.maxLives = 3
     if (typeof parsed.livesRemaining !== 'number') parsed.livesRemaining = parsed.maxLives


### PR DESCRIPTION
## Summary

- Consumable buttons in the campaign NodeMap were not appearing even when consumables were owned
- The stash was only ever drained into `run.consumables` on new run creation — loading an existing run left stash items stranded
- Fix: `loadRun()` now calls `drainStashIntoRun()` so any stashed consumables are merged into the active run on the next page load

## Test plan

- [ ] Own a consumable (buy from merchant or earn from daily login/mystery node)
- [ ] Reload the game with an active campaign run in progress
- [ ] Confirm the consumable button appears on the campaign map
- [ ] Use the consumable and confirm it applies its effect and the button disappears

https://claude.ai/code/session_01BvJsQ1JLnNW3wrVoe2YTBz