### PR TITLE
fix(campaign): always show consumable buttons, disabled when empty

### DIFF
--- a/web/src/components/NodeMap.tsx
+++ b/web/src/components/NodeMap.tsx
@@ -309,27 +309,26 @@ export function NodeMap({ act, run, onSelectNode, onUseConsumable, onBack }: Pro
       </div>
 
       {/* Consumables bar */}
-      {run.consumables && run.consumables.length > 0 && (
-        <div className="nm-consumables-bar">
-          <span className="nm-consumables-label">ITEMS</span>
-          {run.consumables.map(rc => {
-            const def = ALL_CONSUMABLES.find(c => c.id === rc.id)
-            if (!def) return null
-            return (
-              <button
-                key={rc.id}
-                className="nm-consumable-btn"
-                title={`${def.name}: ${def.desc}`}
-                onClick={() => onUseConsumable(rc.id)}
-              >
-                <span className="nm-consumable-icon">{def.icon}</span>
-                <span className="nm-consumable-name">{def.name}</span>
-                {rc.count > 1 && <span className="nm-consumable-count">×{rc.count}</span>}
-              </button>
-            )
-          })}
-        </div>
-      )}
+      <div className="nm-consumables-bar">
+        <span className="nm-consumables-label">ITEMS</span>
+        {ALL_CONSUMABLES.map(def => {
+          const rc = run.consumables?.find(c => c.id === def.id)
+          const count = rc?.count ?? 0
+          return (
+            <button
+              key={def.id}
+              className={`nm-consumable-btn${count === 0 ? ' nm-consumable-btn--empty' : ''}`}
+              title={count > 0 ? `${def.name}: ${def.desc}` : `${def.name} (none)`}
+              disabled={count === 0}
+              onClick={() => onUseConsumable(def.id)}
+            >
+              <span className="nm-consumable-icon">{def.icon}</span>
+              <span className="nm-consumable-name">{def.name}</span>
+              <span className="nm-consumable-count">×{count}</span>
+            </button>
+          )
+        })}
+      </div>
 
       {/* Map */}
       <div className="nm-map">

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -3532,10 +3532,15 @@ body {
   transition: background 0.15s, border-color 0.15s;
 }
 
-.nm-consumable-btn:hover {
+.nm-consumable-btn:hover:not(:disabled) {
   background: #252525;
   border-color: #33ff88;
   color: #fff;
+}
+
+.nm-consumable-btn--empty {
+  opacity: 0.35;
+  cursor: default;
 }
 
 .nm-consumable-icon { font-size: 14px; }


### PR DESCRIPTION
## Summary

- Consumable buttons were hidden when `run.consumables` was empty, making it impossible to tell if the bar was rendering at all
- Now all consumables from the catalog are always shown — greyed out with ×0 when not owned, active when owned
- Hover effect is suppressed on disabled buttons

## Test plan

- [ ] Open campaign map — both Health Potion and Second Wind buttons should always be visible
- [ ] With no consumables: buttons show ×0, are dimmed, and cannot be clicked
- [ ] After buying/earning a consumable: button shows the correct count and is clickable
- [ ] Using a consumable decrements the count (back to ×0 / disabled when depleted)

https://claude.ai/code/session_01BvJsQ1JLnNW3wrVoe2YTBz