### PR TITLE
feat(achievements): add backfill routine for newly-added achievements

### DIFF
--- a/web/src/game/achievements.ts
+++ b/web/src/game/achievements.ts
@@ -107,6 +107,26 @@ export function hasUnclaimedAchievements(): boolean {
   return ACHIEVEMENT_DEFS.some(d => save.unlocked[d.id] && !save.claimed[d.id])
 }
 
+/**
+ * Backfill: unlock any achievement whose progress target is already met but
+ * wasn't unlocked (e.g. achievements added after the player accumulated progress).
+ * Safe to call on every page load — already-unlocked achievements are skipped.
+ * Returns the newly unlocked defs so callers can surface toasts if desired.
+ */
+export function backfillAchievements(): AchievementDef[] {
+  const save = loadAchievementSave()
+  const newlyUnlocked: AchievementDef[] = []
+  for (const def of ACHIEVEMENT_DEFS) {
+    if (save.unlocked[def.id]) continue
+    if ((save.progress[def.progressKey] ?? 0) >= def.target) {
+      save.unlocked[def.id] = true
+      newlyUnlocked.push(def)
+    }
+  }
+  if (newlyUnlocked.length > 0) saveAchievementSave(save)
+  return newlyUnlocked
+}
+
 /** Claim the reward for an achievement. Returns the reward if claimable, null otherwise. */
 export function claimAchievementReward(achievementId: string): AchievementReward | null {
   const save = loadAchievementSave()

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -6,6 +6,10 @@ import App from './App'
 
 setErrorLogger((msg, ctx) => rollbar.error(msg, ctx as object))
 
+// Unlock any achievements whose progress target was already met before the
+// achievement was added (e.g. after a game update adds new achievements).
+import('./game/achievements').then(({ backfillAchievements }) => backfillAchievements())
+
 // Firebase uses IndexedDB internally for Firestore caching. If the browser
 // drops that connection (common in Safari / backgrounded tabs), Firebase throws
 // an UnknownError that would otherwise surface as an unhandled rejection in


### PR DESCRIPTION
Adds backfillAchievements() to achievements.ts — iterates all defs,
unlocks any where saved progress already meets the target but the
achievement was never marked unlocked (e.g. added after the player
accumulated qualifying progress). Called once at startup in main.tsx
via a dynamic import so it runs on every page load without blocking
the render path.

https://claude.ai/code/session_01XmdfAohbwWHePfM2Tb6tSj