### PR TITLE
feat(news): add What's New section with admin panel

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -68,6 +68,9 @@ import { LoginModal }        from './components/LoginModal'
 import { InventoryScreen }   from './components/InventoryScreen'
 import { peekDailyReward, markDailyRewardClaimed, addToInventory, computeReward, loadInventory, RewardDef, ALL_ITEMS } from './game/dailyLogin'
 import { getUnclaimedGifts, applyGiftRewards, GiftDef } from './game/gifts'
+import { getUnreadCount as getNewsUnreadCount } from './game/news'
+import { NewsScreen }      from './components/NewsScreen'
+import { NewsAdminScreen } from './components/NewsAdminScreen'
 import { getDailyPlayerDeck, getDailyOpponentDeck, getDailyChallengeState, saveDailyChallengeResult, recordDailyWin, publishDailyResult, publishEndlessResult, DailyChallengeState } from './game/dailyChallenge'
 import { getRelicDef, addEarnedRelic, removeEarnedRelic, loadEarnedRelics, addBrokenRelic } from './game/relics'
 import { playCardPlay, playButtonClick, playBattleEvent, playCardFlip, playRestHeal, stopBattleMusic, stopGameOverMusic } from './game/sound'
@@ -242,6 +245,8 @@ type Screen =
   | 'commander'
   | 'giftAdmin'
   | 'training'
+  | 'news'
+  | 'newsAdmin'
 
 
 function formatTimeAgo(date: Date): string {
@@ -412,6 +417,9 @@ export default function App() {
   // Developer gifts
   const [pendingGifts, setPendingGifts] = useState<GiftDef[]>([])
 
+  // News unread count
+  const [newsUnreadCount, setNewsUnreadCount] = useState(0)
+
   // Cloud sync prompt: shown when a newer remote save is detected on the title screen
   const [syncPrompt, setSyncPrompt] = useState<{ remoteDate: Date; data: Record<string, string> } | null>(null)
   const syncPromptedRef = useRef(false)
@@ -452,6 +460,12 @@ export default function App() {
     getUnclaimedGifts().then(unclaimed => {
       if (unclaimed.length > 0) setPendingGifts(unclaimed)
     }).catch(() => {})
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  // ── News unread count ─────────────────────────────────────
+  useEffect(() => {
+    getNewsUnreadCount().then(setNewsUnreadCount).catch(() => {})
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
@@ -1940,6 +1954,8 @@ export default function App() {
             onCommander={commander ? () => setScreen('commander') : undefined}
             commanderName={commander?.cardName ?? null}
             onTraining={() => setScreen('training')}
+            onNews={() => setScreen('news')}
+            hasUnreadNews={newsUnreadCount > 0}
             user={user}
             onSignOut={() => { import('firebase/auth').then(({ signOut }) => signOut(auth)) }}
             onSignIn={() => setShowTitleLoginModal(true)}
@@ -1967,11 +1983,20 @@ export default function App() {
             try { localStorage.setItem(HANDICAP_KEY, String(n)) } catch { /* ignore */ }
           }}
           onGiftAdmin={() => setScreen('giftAdmin')}
+          onNewsAdmin={() => setScreen('newsAdmin')}
         />
       )}
 
       {screen === 'giftAdmin' && (
         <GiftAdminScreen onBack={() => setScreen('settings')} />
+      )}
+
+      {screen === 'news' && (
+        <NewsScreen onBack={() => { setNewsUnreadCount(0); setScreen('title') }} />
+      )}
+
+      {screen === 'newsAdmin' && (
+        <NewsAdminScreen onBack={() => setScreen('settings')} />
       )}
 
       {screen === 'nodemap' && run && actData && (

--- a/web/src/components/NewsAdminScreen.tsx
+++ b/web/src/components/NewsAdminScreen.tsx
@@ -1,0 +1,165 @@
+import React, { useState, useEffect } from 'react'
+import { OverlayScreen } from './OverlayScreen'
+import { Section } from './Section'
+import { NewsItem, NEWS_TAGS, getAllNews, saveNewsToFirestore, deleteNewsFromFirestore } from '../game/news'
+
+interface Props {
+  onBack: () => void
+}
+
+function slugify(s: string): string {
+  return s.toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_|_$/g, '')
+}
+
+function blankItem(): Omit<NewsItem, 'id'> & { id: string } {
+  return {
+    id: '',
+    title: '',
+    body: '',
+    date: new Date().toISOString().slice(0, 10),
+    tag: 'NEW FEATURE',
+  }
+}
+
+export function NewsAdminScreen({ onBack }: Props) {
+  const [items, setItems] = useState<NewsItem[]>([])
+  const [loading, setLoading] = useState(true)
+  const [draft, setDraft] = useState(blankItem())
+  const [saving, setSaving] = useState(false)
+  const [status, setStatus] = useState<string | null>(null)
+
+  function refresh() {
+    setLoading(true)
+    getAllNews().then(all => { setItems(all); setLoading(false) })
+  }
+
+  useEffect(() => { refresh() }, [])
+
+  function handleTitleChange(title: string) {
+    setDraft(d => ({
+      ...d,
+      title,
+      id: d.id === '' || d.id === slugify(d.title) ? slugify(title) : d.id,
+    }))
+  }
+
+  async function handleCreate() {
+    if (!draft.id || !draft.title || !draft.body) {
+      setStatus('ID, title, and body are required.')
+      return
+    }
+    setSaving(true)
+    setStatus(null)
+    try {
+      await saveNewsToFirestore(draft as NewsItem)
+      setDraft(blankItem())
+      setStatus('Saved!')
+      refresh()
+    } catch (e) {
+      setStatus(`Error: ${String(e)}`)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function handleDelete(id: string) {
+    if (!confirm(`Delete news item "${id}"?`)) return
+    try {
+      await deleteNewsFromFirestore(id)
+      setStatus(`Deleted ${id}`)
+      refresh()
+    } catch (e) {
+      setStatus(`Error: ${String(e)}`)
+    }
+  }
+
+  return (
+    <OverlayScreen title="NEWS ADMIN" onBack={onBack}>
+
+      <Section title="Create Post">
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+          <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
+            <div style={{ flex: 1, minWidth: '140px' }}>
+              <div className="settings-label">ID (auto)</div>
+              <input
+                className="settings-text-input"
+                value={draft.id}
+                onChange={e => setDraft(d => ({ ...d, id: e.target.value }))}
+                placeholder="auto-generated"
+              />
+            </div>
+            <div style={{ flex: 1, minWidth: '80px' }}>
+              <div className="settings-label">Date</div>
+              <input
+                type="date"
+                className="settings-text-input"
+                value={draft.date}
+                onChange={e => setDraft(d => ({ ...d, date: e.target.value }))}
+              />
+            </div>
+            <div>
+              <div className="settings-label">Tag</div>
+              <select
+                className="settings-select"
+                value={draft.tag ?? ''}
+                onChange={e => setDraft(d => ({ ...d, tag: e.target.value || undefined }))}
+              >
+                <option value="">(none)</option>
+                {NEWS_TAGS.map(t => <option key={t} value={t}>{t}</option>)}
+              </select>
+            </div>
+          </div>
+
+          <div>
+            <div className="settings-label">Title</div>
+            <input
+              className="settings-text-input"
+              style={{ width: '100%' }}
+              value={draft.title}
+              onChange={e => handleTitleChange(e.target.value)}
+              placeholder="Post title…"
+            />
+          </div>
+
+          <div>
+            <div className="settings-label">Body</div>
+            <textarea
+              className="settings-text-input"
+              style={{ width: '100%', minHeight: '80px', resize: 'vertical', fontFamily: 'inherit', fontSize: 'inherit' }}
+              value={draft.body}
+              onChange={e => setDraft(d => ({ ...d, body: e.target.value }))}
+              placeholder="Post content…"
+            />
+          </div>
+
+          <button className="action-btn" onClick={handleCreate} disabled={saving}>
+            {saving ? 'SAVING…' : 'CREATE POST'}
+          </button>
+          {status && <div className="settings-label" style={{ color: status.startsWith('Error') ? '#ff4444' : '#33ff33' }}>{status}</div>}
+        </div>
+      </Section>
+
+      <Section title={`Active Posts (${items.length})`}>
+        {loading && <div className="news-loading">Loading…</div>}
+        {!loading && items.length === 0 && <div className="news-empty">No posts yet.</div>}
+        {!loading && items.map(item => (
+          <div key={item.id} className="news-item">
+            <div className="news-item__meta">
+              <span className="news-item__date">{item.date}</span>
+              {item.tag && <span className="news-item__tag">{item.tag}</span>}
+              <button
+                className="action-btn action-btn--danger"
+                style={{ marginLeft: 'auto', padding: '2px 10px', fontSize: '11px' }}
+                onClick={() => handleDelete(item.id)}
+              >
+                DELETE
+              </button>
+            </div>
+            <div className="news-item__title">{item.title}</div>
+            <div className="news-item__body">{item.body}</div>
+          </div>
+        ))}
+      </Section>
+    </OverlayScreen>
+  )
+}

--- a/web/src/components/NewsScreen.tsx
+++ b/web/src/components/NewsScreen.tsx
@@ -1,0 +1,39 @@
+import React, { useEffect, useState } from 'react'
+import { OverlayScreen } from './OverlayScreen'
+import { getAllNews, markNewsRead, NewsItem } from '../game/news'
+
+interface Props {
+  onBack: () => void
+}
+
+export function NewsScreen({ onBack }: Props) {
+  const [items, setItems] = useState<NewsItem[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    getAllNews().then(all => {
+      setItems(all)
+      markNewsRead(all.map(n => n.id))
+      setLoading(false)
+    })
+  }, [])
+
+  return (
+    <OverlayScreen title="WHAT'S NEW" onBack={onBack}>
+      {loading && <div className="news-loading">Loading…</div>}
+      {!loading && items.length === 0 && (
+        <div className="news-empty">No news yet.</div>
+      )}
+      {!loading && items.map(item => (
+        <div key={item.id} className="news-item">
+          <div className="news-item__meta">
+            <span className="news-item__date">{item.date}</span>
+            {item.tag && <span className="news-item__tag">{item.tag}</span>}
+          </div>
+          <div className="news-item__title">{item.title}</div>
+          <div className="news-item__body">{item.body}</div>
+        </div>
+      ))}
+    </OverlayScreen>
+  )
+}

--- a/web/src/components/SettingsScreen.tsx
+++ b/web/src/components/SettingsScreen.tsx
@@ -21,6 +21,7 @@ interface Props {
   onDevCrystalsChanged?: (n: number) => void
   onDevHandicapChanged?: (n: number) => void
   onGiftAdmin?: () => void
+  onNewsAdmin?: () => void
 }
 
 const TEXT_SIZE_KEY      = 'jarv_text_size'
@@ -129,7 +130,7 @@ function exportLocalStorage(): void {
   URL.revokeObjectURL(url)
 }
 
-export function SettingsScreen({ onBack, onResetGame, user, authLoading, onDevCrystalsChanged, onDevHandicapChanged, onGiftAdmin }: Props) {
+export function SettingsScreen({ onBack, onResetGame, user, authLoading, onDevCrystalsChanged, onDevHandicapChanged, onGiftAdmin, onNewsAdmin }: Props) {
   const [soundOn,       setSoundOn]       = useState(isSoundEnabled)
   const [textSize,      setTextSize]      = useState(loadTextSize)
   const [textColor,     setTextColor]     = useState(loadTextColor)
@@ -494,15 +495,26 @@ export function SettingsScreen({ onBack, onResetGame, user, authLoading, onDevCr
           </Section>
         )}
 
-        {user?.uid === GIFT_OWNER_UID && onGiftAdmin && (
+        {user?.uid === GIFT_OWNER_UID && (onGiftAdmin || onNewsAdmin) && (
           <Section bordered title="ADMIN">
-            <div className="settings-row">
-              <div>
-                <div className="settings-label">Gift management</div>
-                <div className="settings-sublabel">Create and delete one-off player gifts</div>
+            {onGiftAdmin && (
+              <div className="settings-row">
+                <div>
+                  <div className="settings-label">Gift management</div>
+                  <div className="settings-sublabel">Create and delete one-off player gifts</div>
+                </div>
+                <button className="action-btn action-btn--gold" onClick={onGiftAdmin}>OPEN</button>
               </div>
-              <button className="action-btn action-btn--gold" onClick={onGiftAdmin}>OPEN</button>
-            </div>
+            )}
+            {onNewsAdmin && (
+              <div className="settings-row">
+                <div>
+                  <div className="settings-label">News / What's New</div>
+                  <div className="settings-sublabel">Post new feature announcements and patch notes</div>
+                </div>
+                <button className="action-btn action-btn--gold" onClick={onNewsAdmin}>OPEN</button>
+              </div>
+            )}
           </Section>
         )}
 

--- a/web/src/components/TitleScreen.tsx
+++ b/web/src/components/TitleScreen.tsx
@@ -40,12 +40,14 @@ interface Props {
   onCommander?: () => void
   commanderName?: string | null
   onTraining: () => void
+  onNews: () => void
+  hasUnreadNews: boolean
   user: User | null
   onSignOut: () => void
   onSignIn: () => void
 }
 
-export function TitleScreen({ crystals, onPlay, onEndless, onCampaign, onCollection, onShop, onDeckBuilder, onSettings, onInventory, onAchievements, onHeroCards, onCharacter, on8bitUnlocked, onDailyChallenge, onEndlessLeaderboard, onCommander, commanderName, onTraining, user, onSignOut, onSignIn }: Props) {
+export function TitleScreen({ crystals, onPlay, onEndless, onCampaign, onCollection, onShop, onDeckBuilder, onSettings, onInventory, onAchievements, onHeroCards, onCharacter, on8bitUnlocked, onDailyChallenge, onEndlessLeaderboard, onCommander, commanderName, onTraining, onNews, hasUnreadNews, user, onSignOut, onSignIn }: Props) {
   const deck             = loadDeck()
   const count            = deckTotalCards(deck)
   const valid            = isDeckValid(deck)
@@ -233,6 +235,7 @@ export function TitleScreen({ crystals, onPlay, onEndless, onCampaign, onCollect
           <TitleButton onClick={onInventory}>🎒 INVENTORY</TitleButton>
           <TitleButton onClick={onAchievements} badge={achievementAlert}>🏆 ACHIEVEMENTS</TitleButton>
           <TitleButton onClick={onCharacter}>👤 CHARACTER</TitleButton>
+          <TitleButton onClick={onNews} badge={hasUnreadNews}>📰 WHAT'S NEW</TitleButton>
           <TitleButton onClick={onSettings} extraClass="title-settings-btn">⚙ SETTINGS</TitleButton>
           {commanderName && onCommander && (
             <TitleButton onClick={onCommander} extraClass="title-commander-btn">

--- a/web/src/data/news.json
+++ b/web/src/data/news.json
@@ -1,0 +1,9 @@
+[
+  {
+    "id": "news_launch_2026",
+    "title": "Welcome to Jarv's Amazing Web Game!",
+    "body": "The game is live! Build your deck, battle through acts, and collect cards from across the Shattered Dominion. More content is on the way — check back here for updates, new features, and patch notes.",
+    "date": "2026-03-29",
+    "tag": "NEW FEATURE"
+  }
+]

--- a/web/src/game/news.ts
+++ b/web/src/game/news.ts
@@ -1,0 +1,101 @@
+// ─── News / What's New System ─────────────────────────────────────────────────
+// Admin-authored news posts stored in Firestore `news/` collection.
+// Falls back to news.json if Firestore is unavailable.
+//
+// Firestore rules required (add to firestore.rules):
+//   match /news/{newsId} {
+//     allow read: if true;
+//     allow write: if request.auth.uid == "pAB2tLH049PCOI73cQpFlisKpDw1";
+//   }
+//
+// Document schema (matches NewsItem):
+//   title:  string
+//   body:   string
+//   date:   string  (ISO date, e.g. "2026-03-29")
+//   tag:    string  (optional, e.g. "NEW FEATURE", "BUG FIX", "UPDATE", "EVENT")
+
+import { collection, getDocs, doc, setDoc, deleteDoc } from 'firebase/firestore'
+import { db } from '../firebase'
+import { logError } from '../logger'
+import newsData from '../data/news.json'
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export interface NewsItem {
+  id: string
+  title: string
+  body: string
+  date: string
+  tag?: string
+}
+
+export const NEWS_TAGS = ['NEW FEATURE', 'UPDATE', 'BUG FIX', 'EVENT'] as const
+
+// ── Storage ──────────────────────────────────────────────────────────────────
+
+const READ_NEWS_KEY = 'jarv_read_news'
+
+export function loadReadNewsIds(): string[] {
+  try {
+    const raw = localStorage.getItem(READ_NEWS_KEY)
+    if (raw) return JSON.parse(raw) as string[]
+  } catch { /* ignore */ }
+  return []
+}
+
+export function markNewsRead(ids: string[]): void {
+  try {
+    const existing = loadReadNewsIds()
+    const merged = Array.from(new Set([...existing, ...ids]))
+    localStorage.setItem(READ_NEWS_KEY, JSON.stringify(merged))
+  } catch (e) {
+    logError('markNewsRead failed', { error: String(e) })
+  }
+}
+
+// ── Firestore fetch ───────────────────────────────────────────────────────────
+
+async function fetchNewsFromFirestore(): Promise<NewsItem[]> {
+  const snap = await getDocs(collection(db, 'news'))
+  return snap.docs.map(d => ({ id: d.id, ...d.data() } as NewsItem))
+}
+
+// ── Registry ─────────────────────────────────────────────────────────────────
+
+/**
+ * Fetch all news: Firestore first, local news.json as fallback.
+ * Merges both sources; Firestore items take precedence over local ones.
+ */
+export async function getAllNews(): Promise<NewsItem[]> {
+  let remote: NewsItem[] = []
+  try {
+    remote = await fetchNewsFromFirestore()
+  } catch (e) {
+    logError('fetchNewsFromFirestore failed, using local fallback', { error: String(e) })
+  }
+
+  const remoteIds = new Set(remote.map(n => n.id))
+  const local = (newsData as NewsItem[]).filter(n => !remoteIds.has(n.id))
+  const all = [...remote, ...local]
+  return all.sort((a, b) => b.date.localeCompare(a.date))
+}
+
+/** Returns the number of news items not yet read by this player. */
+export async function getUnreadCount(): Promise<number> {
+  const all = await getAllNews()
+  const read = new Set(loadReadNewsIds())
+  return all.filter(n => !read.has(n.id)).length
+}
+
+// ── Admin CRUD ────────────────────────────────────────────────────────────────
+
+/** Write a news document to Firestore. Uses the item's `id` as the document ID. */
+export async function saveNewsToFirestore(item: NewsItem): Promise<void> {
+  const { id, ...fields } = item
+  await setDoc(doc(db, 'news', id), fields)
+}
+
+/** Delete a news document from Firestore. */
+export async function deleteNewsFromFirestore(id: string): Promise<void> {
+  await deleteDoc(doc(db, 'news', id))
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -8060,3 +8060,57 @@ html.light-mode .action-btn {
 }
 .el-lb-ghost .el-lb-name { color: #999; }
 .el-lb-ghost .el-lb-rank { color: #666; }
+
+/* ── News / What's New ────────────────────────────────────────────────── */
+.news-item {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 12px 0;
+  border-bottom: 1px solid var(--game-border);
+}
+.news-item:last-child { border-bottom: none; }
+
+.news-item__meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.news-item__date {
+  font-size: 11px;
+  color: #888;
+  letter-spacing: 0.5px;
+}
+
+.news-item__tag {
+  font-size: 10px;
+  font-weight: bold;
+  letter-spacing: 1px;
+  padding: 1px 6px;
+  border-radius: 2px;
+  background: rgba(255,204,0,0.12);
+  color: #ffcc00;
+  border: 1px solid rgba(255,204,0,0.3);
+}
+
+.news-item__title {
+  font-size: 14px;
+  font-weight: bold;
+  color: var(--game-text-color);
+}
+
+.news-item__body {
+  font-size: 12px;
+  color: #aaa;
+  line-height: 1.5;
+  white-space: pre-wrap;
+}
+
+.news-loading,
+.news-empty {
+  font-size: 12px;
+  color: #666;
+  padding: 16px 0;
+  text-align: center;
+}


### PR DESCRIPTION
- news.json: local seed with launch announcement post
- news.ts: Firestore CRUD + localStorage read tracking (jarv_read_news)
- NewsScreen.tsx: player-facing reader overlay; marks all read on open
- NewsAdminScreen.tsx: admin panel to create/delete news posts
- TitleScreen.tsx: add 📰 WHAT'S NEW button with unread badge
- App.tsx: add 'news'/'newsAdmin' screens, newsUnreadCount state, wire callbacks
- SettingsScreen.tsx: add News Admin button in admin section alongside Gift Admin
- styles.css: .news-item, .news-item__tag, .news-item__date, .news-item__meta styles

https://claude.ai/code/session_01UjXTPC4e4bQTtG6meYWyJo