### PR TITLE
Fix #535: scrollable news screen with per-item dismiss; Fix #533: victory celebration animation

### DIFF
--- a/web/src/components/Battlefield.tsx
+++ b/web/src/components/Battlefield.tsx
@@ -139,7 +139,7 @@ function spriteDamageClass(hp: number, maxHp: number): string {
   return ' lane-unit-sprite--damaged'
 }
 
-function LaneUnit({ unit, stackIndex = 0, wallStack, onInspect, showName }: { unit: Unit; stackIndex?: number; wallStack?: Unit[]; onInspect?: (u: Unit) => void; showName?: boolean }) {
+function LaneUnit({ unit, stackIndex = 0, wallStack, onInspect, showName, celebrating = false }: { unit: Unit; stackIndex?: number; wallStack?: Unit[]; onInspect?: (u: Unit) => void; showName?: boolean; celebrating?: boolean }) {
   const hpPct = Math.max(0, (unit.hp / unit.maxHp) * 100)
   const isStructure = unit.moveSpeed === 0
 
@@ -187,6 +187,7 @@ function LaneUnit({ unit, stackIndex = 0, wallStack, onInspect, showName }: { un
   const isDying = unit.dyingTimer != null
   const isDamageFlash = unit.damageFlashTimer != null && unit.damageFlashTimer > 0
   const isKillFlash = unit.killFlashTimer != null && unit.killFlashTimer > 0
+  const isCelebrating = celebrating && !isDying && !isStructure && !unit.isWall
 
   return (
     <div
@@ -204,8 +205,9 @@ function LaneUnit({ unit, stackIndex = 0, wallStack, onInspect, showName }: { un
         isKillFlash ? 'lane-unit--kill-flash' : '',
         unit.climbing ? 'lane-unit--climbing' : '',
         unit.size ? `lane-unit--size-${unit.size}` : '',
+        isCelebrating ? 'lane-unit--celebrating' : '',
       ].filter(Boolean).join(' ')}
-      style={style}
+      style={isCelebrating ? { ...style, animationDelay: `${(unit.id.charCodeAt(0) % 7) * 0.1}s` } : style}
       title={`${unit.name} — ${unit.hp}/${unit.maxHp} HP, ${unit.attack} ATK`}
       onClick={onInspect ? (e) => { e.stopPropagation(); onInspect(unit) } : undefined}
     >
@@ -791,18 +793,19 @@ export function Battlefield({ state, onPlayCard, onGiveUp, onPause, actTheme, ac
           }
           const renderedWallIds = new Set<string>()
 
+          const playerWon = state.phase.type === 'gameOver' && state.phase.winner === 'player'
           return state.field.map((u, i) => {
             if (u.isWall) {
               const key = `${u.owner}:${Math.round(u.x)}`
               const group = wallGroups.get(key)!
               if (group[0].id !== u.id) return null  // only render the first in each group
               renderedWallIds.add(u.id)
-              return <LaneUnit key={u.id} unit={u} wallStack={group} onInspect={paused ? u => { setInspectedUnit(u) } : undefined} showName={paused} />
+              return <LaneUnit key={u.id} unit={u} wallStack={group} onInspect={paused ? u => { setInspectedUnit(u) } : undefined} showName={paused} celebrating={playerWon && u.owner === 'player'} />
             }
             const stackIndex = u.moveSpeed === 0
               ? state.field.slice(0, i).filter(o => o.moveSpeed === 0 && !o.isWall && o.owner === u.owner).length
               : 0
-            return <LaneUnit key={u.id} unit={u} stackIndex={stackIndex} onInspect={paused ? u => { setInspectedUnit(u) } : undefined} showName={paused} />
+            return <LaneUnit key={u.id} unit={u} stackIndex={stackIndex} onInspect={paused ? u => { setInspectedUnit(u) } : undefined} showName={paused} celebrating={playerWon && u.owner === 'player'} />
           })
         })()}
         {/* Animation events: projectiles and hit sparks */}

--- a/web/src/components/NewsScreen.tsx
+++ b/web/src/components/NewsScreen.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import { OverlayScreen } from './OverlayScreen'
-import { getAllNews, markNewsRead, NewsItem } from '../game/news'
+import { getAllNews, markNewsRead, dismissNewsItem, loadDismissedNewsIds, NewsItem } from '../game/news'
 
 interface Props {
   onBack: () => void
@@ -8,9 +8,12 @@ interface Props {
 
 export function NewsScreen({ onBack }: Props) {
   const [items, setItems] = useState<NewsItem[]>([])
+  const [dismissed, setDismissed] = useState<Set<string>>(new Set())
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
+    const existingDismissed = new Set(loadDismissedNewsIds())
+    setDismissed(existingDismissed)
     getAllNews().then(all => {
       setItems(all)
       markNewsRead(all.map(n => n.id))
@@ -18,22 +21,36 @@ export function NewsScreen({ onBack }: Props) {
     })
   }, [])
 
+  function handleDismiss(id: string) {
+    dismissNewsItem(id)
+    setDismissed(prev => new Set([...prev, id]))
+  }
+
+  const visible = items.filter(n => !dismissed.has(n.id))
+
   return (
     <OverlayScreen title="WHAT'S NEW" onBack={onBack}>
-      {loading && <div className="news-loading">Loading…</div>}
-      {!loading && items.length === 0 && (
-        <div className="news-empty">No news yet.</div>
-      )}
-      {!loading && items.map(item => (
-        <div key={item.id} className="news-item">
-          <div className="news-item__meta">
-            <span className="news-item__date">{item.date}</span>
-            {item.tag && <span className="news-item__tag">{item.tag}</span>}
+      <div className="news-list">
+        {loading && <div className="news-loading">Loading…</div>}
+        {!loading && visible.length === 0 && (
+          <div className="news-empty">No news yet.</div>
+        )}
+        {!loading && visible.map(item => (
+          <div key={item.id} className="news-item">
+            <div className="news-item__meta">
+              <span className="news-item__date">{item.date}</span>
+              {item.tag && <span className="news-item__tag">{item.tag}</span>}
+              <button
+                className="news-item__dismiss"
+                onClick={() => handleDismiss(item.id)}
+                title="Dismiss"
+              >✕</button>
+            </div>
+            <div className="news-item__title">{item.title}</div>
+            <div className="news-item__body">{item.body}</div>
           </div>
-          <div className="news-item__title">{item.title}</div>
-          <div className="news-item__body">{item.body}</div>
-        </div>
-      ))}
+        ))}
+      </div>
     </OverlayScreen>
   )
 }

--- a/web/src/game/news.ts
+++ b/web/src/game/news.ts
@@ -34,6 +34,7 @@ export const NEWS_TAGS = ['NEW FEATURE', 'UPDATE', 'BUG FIX', 'EVENT'] as const
 // ── Storage ──────────────────────────────────────────────────────────────────
 
 const READ_NEWS_KEY = 'jarv_read_news'
+const DISMISSED_NEWS_KEY = 'jarv_dismissed_news'
 
 export function loadReadNewsIds(): string[] {
   try {
@@ -41,6 +42,25 @@ export function loadReadNewsIds(): string[] {
     if (raw) return JSON.parse(raw) as string[]
   } catch { /* ignore */ }
   return []
+}
+
+export function loadDismissedNewsIds(): string[] {
+  try {
+    const raw = localStorage.getItem(DISMISSED_NEWS_KEY)
+    if (raw) return JSON.parse(raw) as string[]
+  } catch { /* ignore */ }
+  return []
+}
+
+export function dismissNewsItem(id: string): void {
+  try {
+    const existing = loadDismissedNewsIds()
+    if (!existing.includes(id)) {
+      localStorage.setItem(DISMISSED_NEWS_KEY, JSON.stringify([...existing, id]))
+    }
+  } catch (e) {
+    logError('dismissNewsItem failed', { error: String(e) })
+  }
 }
 
 export function markNewsRead(ids: string[]): void {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -7166,6 +7166,21 @@ html.light-mode .action-btn {
   animation: damage-flash-anim 0.2s ease-out forwards;
 }
 
+/* Victory celebration: units jump and dance when the player wins */
+@keyframes celebrate-jump {
+  0%   { transform: translateX(-50%) translateY(-50%) rotate(0deg) scale(1); }
+  15%  { transform: translateX(-50%) translateY(calc(-50% - 18px)) rotate(-8deg) scale(1.08); }
+  30%  { transform: translateX(-50%) translateY(-50%) rotate(6deg) scale(1); }
+  45%  { transform: translateX(-50%) translateY(calc(-50% - 14px)) rotate(-5deg) scale(1.06); }
+  60%  { transform: translateX(-50%) translateY(-50%) rotate(4deg) scale(1); }
+  75%  { transform: translateX(-50%) translateY(calc(-50% - 10px)) rotate(-3deg) scale(1.04); }
+  90%  { transform: translateX(-50%) translateY(-50%) rotate(2deg) scale(1); }
+  100% { transform: translateX(-50%) translateY(-50%) rotate(0deg) scale(1); }
+}
+.lane-unit--celebrating {
+  animation: celebrate-jump 0.7s ease-in-out infinite;
+}
+
 /* Death linger: unit tips/falls sideways then fades into a blood pool */
 @keyframes dying-anim {
   0%   { opacity: 1;   transform: translateX(-50%) translateY(-50%) rotate(0deg); }
@@ -8062,6 +8077,13 @@ html.light-mode .action-btn {
 .el-lb-ghost .el-lb-rank { color: #666; }
 
 /* ── News / What's New ────────────────────────────────────────────────── */
+.news-list {
+  overflow-y: auto;
+  flex: 1;
+  min-height: 0;
+  padding-right: 4px;
+}
+
 .news-item {
   display: flex;
   flex-direction: column;
@@ -8093,6 +8115,19 @@ html.light-mode .action-btn {
   color: #ffcc00;
   border: 1px solid rgba(255,204,0,0.3);
 }
+
+.news-item__dismiss {
+  margin-left: auto;
+  background: none;
+  border: none;
+  color: #555;
+  font-size: 12px;
+  cursor: pointer;
+  padding: 2px 4px;
+  line-height: 1;
+  flex-shrink: 0;
+}
+.news-item__dismiss:hover { color: #ff4444; }
 
 .news-item__title {
   font-size: 14px;


### PR DESCRIPTION
- news.ts: add dismissNewsItem() / loadDismissedNewsIds() backed by localStorage
- NewsScreen: wrap items in scrollable .news-list, add ✕ dismiss button per item
- styles.css: .news-list scroll container, .news-item__dismiss button styles
- styles.css: @keyframes celebrate-jump + .lane-unit--celebrating class
- Battlefield: apply lane-unit--celebrating to living player mobile units on player win, with per-unit stagger via animationDelay

https://claude.ai/code/session_01KyPwqa9KtdeckyS9zNP9J8