### PR TITLE
feat: add Firestore security rules for minigame leaderboards

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -33,5 +33,17 @@ service cloud.firestore {
       allow write: if request.auth.uid == "pAB2tLH049PCOI73cQpFlisKpDw1";
     }
 
+    // ── Minigame leaderboards ────────────────────────────────────────────────
+    // Anyone can read leaderboard entries.
+    // Authenticated users can only write their own entry (keyed by their uid).
+    match /miniGameLeaderboard/{gameId}/allTime/{uid} {
+      allow read: if true;
+      allow write: if request.auth != null && request.auth.uid == uid;
+    }
+    match /miniGameLeaderboard/{gameId}/today/{date}/{uid} {
+      allow read: if true;
+      allow write: if request.auth != null && request.auth.uid == uid;
+    }
+
   }
 }


### PR DESCRIPTION
Authenticated users can write only their own score entry (uid-keyed);
everyone can read. Covers both allTime and today subcollections.

https://claude.ai/code/session_01W796JMjdQ4CVeYaNJu7GS2