### PR TITLE
fix: exclude arcade tickets from drainStashIntoRun

### DIFF
--- a/web/src/game/questline.ts
+++ b/web/src/game/questline.ts
@@ -57,12 +57,17 @@ export function loadRunConsumables(): RunConsumable[] {
   }
 }
 
-/** Drain the stash into a run's consumables list and clear the stash. */
+/** Drain the stash into a run's consumables list and clear the stash.
+ *  Only drains items that are valid battle consumables (present in ALL_CONSUMABLES).
+ *  Persistent currencies like arcade tickets are intentionally excluded. */
 function drainStashIntoRun(consumables: RunConsumable[]): RunConsumable[] {
   const stash = loadConsumableStash()
   if (stash.length === 0) return consumables
+  const battleIds = new Set(ALL_CONSUMABLES.map(c => c.id))
+  const battleStash = stash.filter(s => battleIds.has(s.id))
+  if (battleStash.length === 0) return consumables
   const merged = [...consumables]
-  for (const s of stash) {
+  for (const s of battleStash) {
     const existing = merged.find(c => c.id === s.id)
     if (existing) {
       existing.count += s.count


### PR DESCRIPTION
Arcade tickets (id: 'arcade-ticket') are stored as type 'consumable' in
the item store, just like Health Potions and Second Wind. However, they
are a persistent currency — not battle consumables — so they should never
be drained into an active run's consumables list.

drainStashIntoRun now filters the stash against ALL_CONSUMABLES before
processing, ensuring only valid battle consumables (health_potion,
extra_life) are moved into the run. Arcade tickets remain in the item
store and persist correctly across page refreshes and campaign runs.

https://claude.ai/code/session_01FWNJhVrEBuXtTJiAJL3NUT