### PR TITLE
feat(economy): centralise prices in economy.json + economy.ts with invariant tests

### DIFF
--- a/web/src/data/economy.json
+++ b/web/src/data/economy.json
@@ -1,0 +1,47 @@
+{
+  "_comment": "Single source of truth for all economy values. Edit numbers here, not in .ts files.",
+
+  "crystalPackCost": 250,
+
+  "disenchantValue": {
+    "common":    5,
+    "uncommon": 15,
+    "rare":     40,
+    "legendary": 100
+  },
+
+  "merchantPrices": {
+    "common":    40,
+    "uncommon":  90,
+    "rare":     200,
+    "legendary": 400
+  },
+
+  "miniGameCosts": {
+    "marble":       50,
+    "tileflip":     30,
+    "crystalcatch": 40,
+    "spinner":      25
+  },
+
+  "ticketPrizes": [
+    { "id": "card_1",             "cost":   25, "reward": { "type": "card",     "count": 1 } },
+    { "id": "crystal_50",         "cost":   25, "reward": { "type": "crystals", "amount": 50 } },
+    { "id": "card_uncommon",      "cost":   75, "reward": { "type": "card",     "count": 1, "rarity": "uncommon" } },
+    { "id": "crystal_150",        "cost":   70, "reward": { "type": "crystals", "amount": 150 } },
+    { "id": "card_5pack",         "cost":  200, "reward": { "type": "cards",    "count": 5 } },
+    { "id": "card_rare",          "cost":  150, "reward": { "type": "card",     "count": 1, "rarity": "rare" } },
+    { "id": "card_10pack",        "cost":  350, "reward": { "type": "cards",    "count": 10 } },
+    { "id": "rare_trio",          "cost":  400, "reward": { "type": "cards",    "count": 3, "rarity": "rare" } },
+    { "id": "crystal_500_bundle", "cost":  220, "reward": { "type": "crystals", "amount": 500 } },
+    { "id": "legendary",          "cost": 1000, "reward": { "type": "card",     "count": 1, "rarity": "legendary" } }
+  ],
+
+  "cardBulkTiers": [
+    { "count":  1, "totalCost": 100 },
+    { "count":  2, "totalCost": 195 },
+    { "count":  3, "totalCost": 275 },
+    { "count":  5, "totalCost": 450 },
+    { "count": 10, "totalCost": 900 }
+  ]
+}

--- a/web/src/game/collection.ts
+++ b/web/src/game/collection.ts
@@ -82,15 +82,7 @@ export const DECK_MIN  = 10
 export const DECK_MAX  = 30
 export const COPIES_MAX = 4
 
-export const CRYSTAL_PACK_COST = 250
-
-/** Crystals gained per card dismantled, by rarity. */
-export const DISENCHANT_VALUE: Record<CardRarity, number> = {
-  common:    5,
-  uncommon: 15,
-  rare:     40,
-  legendary: 100,
-}
+export { CRYSTAL_PACK_COST, DISENCHANT_VALUE } from './economy'
 
 // ─── Starter data ─────────────────────────────────────────
 

--- a/web/src/game/economy.test.ts
+++ b/web/src/game/economy.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect } from 'vitest'
+import {
+  CRYSTAL_PACK_COST,
+  DISENCHANT_VALUE,
+  MERCHANT_PRICES,
+  MINI_GAME_COSTS,
+  bulkCardCost,
+  ticketPrizeCrystalValue,
+  ticketPrizeRoi,
+} from './economy'
+import economyRaw from '../data/economy.json'
+import type { CardRarity } from './types'
+
+const RARITIES: CardRarity[] = ['common', 'uncommon', 'rare', 'legendary']
+
+// ── JSON shape ────────────────────────────────────────────────────────────────
+
+describe('economy.json shape', () => {
+  it('crystalPackCost is a positive number', () => {
+    expect(CRYSTAL_PACK_COST).toBeGreaterThan(0)
+  })
+
+  it('has all four rarities in disenchantValue', () => {
+    for (const r of RARITIES) {
+      expect(typeof DISENCHANT_VALUE[r]).toBe('number')
+      expect(DISENCHANT_VALUE[r]).toBeGreaterThan(0)
+    }
+  })
+
+  it('has all four rarities in merchantPrices', () => {
+    for (const r of RARITIES) {
+      expect(typeof MERCHANT_PRICES[r]).toBe('number')
+      expect(MERCHANT_PRICES[r]).toBeGreaterThan(0)
+    }
+  })
+
+  it('has all four mini games in miniGameCosts', () => {
+    const games = ['marble', 'tileflip', 'crystalcatch', 'spinner']
+    for (const g of games) {
+      expect(typeof MINI_GAME_COSTS[g]).toBe('number')
+      expect(MINI_GAME_COSTS[g]).toBeGreaterThan(0)
+    }
+  })
+
+  it('every ticket prize has a positive cost and a valid reward type', () => {
+    const validTypes = ['card', 'cards', 'crystals', 'bundle']
+    for (const prize of economyRaw.ticketPrizes) {
+      expect(prize.cost).toBeGreaterThan(0)
+      expect(validTypes).toContain(prize.reward.type)
+    }
+  })
+})
+
+// ── Disenchant vs merchant (no buy-then-disenchant arbitrage) ─────────────────
+
+describe('disenchant vs merchant prices', () => {
+  it('disenchant value is strictly less than merchant price for every rarity', () => {
+    for (const r of RARITIES) {
+      expect(DISENCHANT_VALUE[r]).toBeLessThan(MERCHANT_PRICES[r])
+    }
+  })
+})
+
+// ── Merchant price monotonicity ───────────────────────────────────────────────
+
+describe('merchant prices monotonicity', () => {
+  it('prices increase strictly with rarity', () => {
+    expect(MERCHANT_PRICES.common).toBeLessThan(MERCHANT_PRICES.uncommon)
+    expect(MERCHANT_PRICES.uncommon).toBeLessThan(MERCHANT_PRICES.rare)
+    expect(MERCHANT_PRICES.rare).toBeLessThan(MERCHANT_PRICES.legendary)
+  })
+})
+
+// ── Crystal bundle monotonicity (ticket economy invariants) ───────────────────
+
+describe('Ticket economy invariants', () => {
+  type CrystalPrize = {
+    id: string
+    cost: number
+    reward: { type: 'crystals'; amount: number }
+  }
+
+  const crystalPrizes = (economyRaw.ticketPrizes as Array<{
+    id: string; cost: number; reward: { type: string; amount?: number }
+  }>).filter((p): p is CrystalPrize => p.reward.type === 'crystals')
+
+  it('crystal bundles must be monotonic (no arbitrage)', () => {
+    for (let i = 0; i < crystalPrizes.length; i++) {
+      for (let j = 0; j < crystalPrizes.length; j++) {
+        if (i === j) continue
+
+        const a = crystalPrizes[i]
+        const b = crystalPrizes[j]
+
+        if (a.reward.amount > b.reward.amount) {
+          const rateA = a.reward.amount / a.cost
+          const rateB = b.reward.amount / b.cost
+          expect(rateA).toBeGreaterThanOrEqual(rateB)
+        }
+      }
+    }
+  })
+
+  it('crystal amount grows with ticket cost', () => {
+    const sorted = [...crystalPrizes].sort((a, b) => a.cost - b.cost)
+    for (let i = 1; i < sorted.length; i++) {
+      expect(sorted[i].reward.amount).toBeGreaterThan(sorted[i - 1].reward.amount)
+    }
+  })
+})
+
+// ── Bulk card pricing ─────────────────────────────────────────────────────────
+
+describe('bulkCardCost', () => {
+  it('returns 0 for 0 cards', () => {
+    expect(bulkCardCost(0)).toBe(0)
+  })
+
+  it('is monotonically increasing', () => {
+    const counts = [1, 2, 3, 5, 10]
+    for (let i = 1; i < counts.length; i++) {
+      expect(bulkCardCost(counts[i])).toBeGreaterThan(bulkCardCost(counts[i - 1]))
+    }
+  })
+
+  it('per-card cost decreases with larger quantities (bulk discount exists)', () => {
+    const counts = [1, 2, 3, 5, 10]
+    for (let i = 1; i < counts.length; i++) {
+      const perPrev = bulkCardCost(counts[i - 1]) / counts[i - 1]
+      const perCurr = bulkCardCost(counts[i]) / counts[i]
+      expect(perCurr).toBeLessThanOrEqual(perPrev)
+    }
+  })
+
+  it('matches known tier values exactly', () => {
+    expect(bulkCardCost(1)).toBe(100)
+    expect(bulkCardCost(2)).toBe(195)
+    expect(bulkCardCost(3)).toBe(275)
+    expect(bulkCardCost(5)).toBe(450)
+    expect(bulkCardCost(10)).toBe(900)
+  })
+
+  it('interpolates between tiers', () => {
+    // 4 cards is between tier 3 (275) and tier 5 (450)
+    const cost4 = bulkCardCost(4)
+    expect(cost4).toBeGreaterThan(bulkCardCost(3))
+    expect(cost4).toBeLessThan(bulkCardCost(5))
+  })
+})
+
+// ── ticketPrizeCrystalValue ───────────────────────────────────────────────────
+
+describe('ticketPrizeCrystalValue', () => {
+  it('returns face value for crystal prizes', () => {
+    expect(ticketPrizeCrystalValue({ type: 'crystals', amount: 150 })).toBe(150)
+  })
+
+  it('returns merchant price for a single card with rarity', () => {
+    expect(ticketPrizeCrystalValue({ type: 'card', count: 1, rarity: 'rare' })).toBe(
+      MERCHANT_PRICES.rare,
+    )
+  })
+
+  it('defaults to common price when no rarity given', () => {
+    expect(ticketPrizeCrystalValue({ type: 'card', count: 1 })).toBe(MERCHANT_PRICES.common)
+  })
+
+  it('multiplies merchant price by count for card packs', () => {
+    expect(ticketPrizeCrystalValue({ type: 'cards', count: 5 })).toBe(
+      MERCHANT_PRICES.common * 5,
+    )
+  })
+
+  it('returns 0 for bundle type', () => {
+    expect(ticketPrizeCrystalValue({ type: 'bundle' })).toBe(0)
+  })
+})
+
+// ── ticketPrizeRoi ────────────────────────────────────────────────────────────
+
+describe('ticketPrizeRoi', () => {
+  it('crystal prize ROI equals crystals / ticketCost', () => {
+    const roi = ticketPrizeRoi(25, { type: 'crystals', amount: 50 })
+    expect(roi).toBeCloseTo(2.0)
+  })
+
+  it('returns Infinity when ticketCost is 0', () => {
+    expect(ticketPrizeRoi(0, { type: 'crystals', amount: 10 })).toBe(Infinity)
+  })
+})

--- a/web/src/game/economy.ts
+++ b/web/src/game/economy.ts
@@ -1,0 +1,96 @@
+// ─── Economy ──────────────────────────────────────────────────────────────────
+//
+// Single source of truth for game economy calculations.
+// All magic numbers come from ../../data/economy.json — edit them there.
+// No side-effects: every export is a pure value or a pure function.
+
+import raw from '../data/economy.json'
+import type { CardRarity } from './types'
+
+// ── Typed constants ───────────────────────────────────────────────────────────
+
+export const CRYSTAL_PACK_COST: number = raw.crystalPackCost
+
+export const DISENCHANT_VALUE: Record<CardRarity, number> =
+  raw.disenchantValue as Record<CardRarity, number>
+
+export const MERCHANT_PRICES: Record<CardRarity, number> =
+  raw.merchantPrices as Record<CardRarity, number>
+
+// Exported as Record<string, number> to avoid a circular dependency with
+// miniGames.ts, which re-casts it to Record<MiniGameId, number>.
+export const MINI_GAME_COSTS: Record<string, number> = raw.miniGameCosts
+
+// ── Ticket prize types ────────────────────────────────────────────────────────
+
+export interface PrizeReward {
+  type: 'card' | 'cards' | 'crystals' | 'bundle'
+  count?: number
+  amount?: number
+  rarity?: CardRarity
+}
+
+export interface EconomyPrize {
+  id: string
+  cost: number
+  reward: PrizeReward
+}
+
+export const TICKET_PRIZE_COSTS: Record<string, number> = Object.fromEntries(
+  (raw.ticketPrizes as Array<{ id: string; cost: number }>).map(p => [p.id, p.cost]),
+)
+
+// ── Bulk card pricing ─────────────────────────────────────────────────────────
+
+interface BulkTier { count: number; totalCost: number }
+const BULK_TIERS: BulkTier[] = [...(raw.cardBulkTiers as BulkTier[])].sort(
+  (a, b) => a.count - b.count,
+)
+
+/**
+ * Returns the total crystal cost to bulk-buy `n` cards of the same rarity.
+ * Uses the tiers in economy.json; linearly interpolates between defined points.
+ * Returns 0 for n ≤ 0 and Infinity for counts beyond the largest tier.
+ */
+export function bulkCardCost(n: number): number {
+  if (n <= 0) return 0
+  const exact = BULK_TIERS.find(t => t.count === n)
+  if (exact) return exact.totalCost
+
+  const below = [...BULK_TIERS].reverse().find(t => t.count < n)
+  const above = BULK_TIERS.find(t => t.count > n)
+  if (!below) return above ? above.totalCost : Infinity
+  if (!above) return Infinity
+
+  const frac = (n - below.count) / (above.count - below.count)
+  return Math.round(below.totalCost + frac * (above.totalCost - below.totalCost))
+}
+
+// ── Ticket prize valuation ────────────────────────────────────────────────────
+
+/**
+ * Returns the crystal value of a ticket prize reward.
+ * - `crystals` prizes → face value.
+ * - `card` / `cards` prizes → merchant price for that rarity (conservative peg).
+ */
+export function ticketPrizeCrystalValue(reward: PrizeReward): number {
+  if (reward.type === 'crystals') {
+    return reward.amount ?? 0
+  }
+  if (reward.type === 'card') {
+    return MERCHANT_PRICES[(reward.rarity ?? 'common') as CardRarity]
+  }
+  if (reward.type === 'cards') {
+    return MERCHANT_PRICES[(reward.rarity ?? 'common') as CardRarity] * (reward.count ?? 1)
+  }
+  return 0
+}
+
+/**
+ * Returns the crystal value per ticket for a given prize:
+ *   ticketPrizeCrystalValue(reward) / ticketCost
+ */
+export function ticketPrizeRoi(ticketCost: number, reward: PrizeReward): number {
+  if (ticketCost <= 0) return Infinity
+  return ticketPrizeCrystalValue(reward) / ticketCost
+}

--- a/web/src/game/miniGames.ts
+++ b/web/src/game/miniGames.ts
@@ -9,6 +9,7 @@ import {
   doc, setDoc, getDocs, collection, query, orderBy, limit, where, Timestamp,
 } from 'firebase/firestore'
 import { db } from '../firebase'
+import { MINI_GAME_COSTS as _MINI_GAME_COSTS, TICKET_PRIZE_COSTS } from './economy'
 
 // ── Ticket Storage ────────────────────────────────────────────────────────────
 // Ticket logic lives in itemStore.ts (see the ARCADE TICKETS section there).
@@ -21,12 +22,7 @@ export { getTickets as loadTickets, addTickets, spendTickets }
 
 export type MiniGameId = 'marble' | 'tileflip' | 'crystalcatch' | 'spinner'
 
-export const MINI_GAME_COSTS: Record<MiniGameId, number> = {
-  marble:       50,
-  tileflip:     30,
-  crystalcatch: 40,
-  spinner:      25,
-}
+export const MINI_GAME_COSTS = _MINI_GAME_COSTS as Record<MiniGameId, number>
 
 export const MINI_GAME_LABELS: Record<MiniGameId, string> = {
   marble:       'Marble Run',
@@ -65,10 +61,15 @@ export interface TicketPrize {
   reward: PrizeRewardType
 }
 
+// Prize costs come from economy.json via TICKET_PRIZE_COSTS — edit them there.
+function prizeCost(id: string): number {
+  return TICKET_PRIZE_COSTS[id] ?? 0
+}
+
 export const TICKET_PRIZES: TicketPrize[] = [
   {
     id:     'card_1',
-    cost:   25,
+    cost:   prizeCost('card_1'),
     label:  '1 Card',
     desc:   'A random card from the catalog.',
     reward: { type: 'card', count: 1 },
@@ -76,7 +77,7 @@ export const TICKET_PRIZES: TicketPrize[] = [
 
   {
     id:     'crystal_50',
-    cost:   25,
+    cost:   prizeCost('crystal_50'),
     label:  '50 Crystals',
     desc:   'A small handful of crystals.',
     reward: { type: 'crystals', amount: 50 },
@@ -84,7 +85,7 @@ export const TICKET_PRIZES: TicketPrize[] = [
 
   {
     id:     'card_uncommon',
-    cost:   75,
+    cost:   prizeCost('card_uncommon'),
     label:  '1 Uncommon Card',
     desc:   'A guaranteed uncommon card.',
     reward: { type: 'card', count: 1, rarity: 'uncommon' },
@@ -92,7 +93,7 @@ export const TICKET_PRIZES: TicketPrize[] = [
 
   {
     id:     'crystal_150',
-    cost:   70,
+    cost:   prizeCost('crystal_150'),
     label:  '150 Crystals',
     desc:   'A decent bag of crystals.',
     reward: { type: 'crystals', amount: 150 },
@@ -100,7 +101,7 @@ export const TICKET_PRIZES: TicketPrize[] = [
 
   {
     id:     'card_5pack',
-    cost:   200,
+    cost:   prizeCost('card_5pack'),
     label:  '5-Pack of Cards',
     desc:   'Five random cards.',
     reward: { type: 'cards', count: 5 },
@@ -108,7 +109,7 @@ export const TICKET_PRIZES: TicketPrize[] = [
 
   {
     id:     'card_rare',
-    cost:   150,
+    cost:   prizeCost('card_rare'),
     label:  '1 Rare Card',
     desc:   'A guaranteed rare card.',
     reward: { type: 'card', count: 1, rarity: 'rare' },
@@ -116,7 +117,7 @@ export const TICKET_PRIZES: TicketPrize[] = [
 
   {
     id:     'card_10pack',
-    cost:   350,
+    cost:   prizeCost('card_10pack'),
     label:  '10-Pack of Cards',
     desc:   'Ten random cards — a hefty haul.',
     reward: { type: 'cards', count: 10 },
@@ -124,7 +125,7 @@ export const TICKET_PRIZES: TicketPrize[] = [
 
   {
     id:     'rare_trio',
-    cost:   400,
+    cost:   prizeCost('rare_trio'),
     label:  '3 Rare Cards',
     desc:   'Three guaranteed rare cards.',
     reward: { type: 'cards', count: 3, rarity: 'rare' },
@@ -132,7 +133,7 @@ export const TICKET_PRIZES: TicketPrize[] = [
 
   {
     id:     'crystal_500_bundle',
-    cost:   220,
+    cost:   prizeCost('crystal_500_bundle'),
     label:  '500 Crystals',
     desc:   'A large stash of crystals.',
     reward: { type: 'crystals', amount: 500 },
@@ -140,7 +141,7 @@ export const TICKET_PRIZES: TicketPrize[] = [
 
   {
     id:     'legendary',
-    cost:   1000,
+    cost:   prizeCost('legendary'),
     label:  '1 Legendary Card',
     desc:   'The rarest of the rare. Worth the grind.',
     reward: { type: 'card', count: 1, rarity: 'legendary' },

--- a/web/src/game/questline.ts
+++ b/web/src/game/questline.ts
@@ -205,12 +205,7 @@ function pickRandom<T>(arr: T[]): T { return arr[Math.floor(Math.random() * arr.
 
 // ─── Merchant ─────────────────────────────────────────────
 
-export const MERCHANT_PRICES: Record<CardRarity, number> = {
-  common:    40,
-  uncommon:  90,
-  rare:      200,
-  legendary: 400,
-}
+export { MERCHANT_PRICES } from './economy'
 
 /** Generates 3 card names for a merchant node: 1 common, 1 uncommon, 1 rare (shuffled). */
 export function generateMerchantCards(): string[] {


### PR DESCRIPTION
- economy.json: single source of truth for crystalPackCost, disenchantValue,
  merchantPrices, miniGameCosts, ticketPrizes, and cardBulkTiers
- economy.ts: typed re-exports + bulkCardCost() (interpolated bulk pricing),
  ticketPrizeCrystalValue(), ticketPrizeRoi() pure functions
- economy.test.ts: 21 invariant tests — JSON shape, disenchant < merchant
  (arbitrage guard), merchant price monotonicity, crystal bundle monotonicity
  (no-arbitrage test from issue), bulk discount invariants, prize ROI helpers
- collection.ts: replace CRYSTAL_PACK_COST + DISENCHANT_VALUE literals with
  re-exports from economy.ts
- questline.ts: replace MERCHANT_PRICES literal with re-export from economy.ts
- miniGames.ts: replace MINI_GAME_COSTS literal with re-export from economy.ts;
  TICKET_PRIZES costs hydrated from economy.json via TICKET_PRIZE_COSTS map

Closes #558

https://claude.ai/code/session_01A7ApXxf4v3r1fRCRrrhVzC