### PR TITLE
fix(economy): import DISENCHANT_VALUE locally in collection.ts

### DIFF
--- a/web/src/game/collection.ts
+++ b/web/src/game/collection.ts
@@ -82,7 +82,8 @@ export const DECK_MIN  = 10
 export const DECK_MAX  = 30
 export const COPIES_MAX = 4
 
-export { CRYSTAL_PACK_COST, DISENCHANT_VALUE } from './economy'
+import { CRYSTAL_PACK_COST, DISENCHANT_VALUE } from './economy'
+export { CRYSTAL_PACK_COST, DISENCHANT_VALUE }
 
 // ─── Starter data ─────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- `export { X } from '...'` only creates an external binding; `DISENCHANT_VALUE` was undefined inside `collection.ts` where `disenchantCard` and `disenchantAllExtras` use it
- Changed to `import { CRYSTAL_PACK_COST, DISENCHANT_VALUE } from './economy'` + `export { CRYSTAL_PACK_COST, DISENCHANT_VALUE }` to satisfy both local use and external consumers

## Test plan

- [ ] CI build passes (fixes the `error TS2304: Cannot find name 'DISENCHANT_VALUE'` errors on lines 278 and 295 of `collection.ts`)

https://claude.ai/code/session_01A7ApXxf4v3r1fRCRrrhVzC