### PR TITLE
Guard against undefined unitTemplate in buildDeckCards (fixes #562 #563 #564)

### DIFF
--- a/web/src/game/collection.ts
+++ b/web/src/game/collection.ts
@@ -484,6 +484,7 @@ export function buildDeckCards(entries: DeckEntry[], collection?: CollectionEntr
     let withSpawnMastery = boosted
     if (collection && boosted.unit?.structureEffect?.type === 'spawn') {
       const se = boosted.unit.structureEffect as { type: 'spawn'; unitTemplate: import('./types').UnitTemplate; intervalMs: number }
+      if (!se.unitTemplate) continue
       const spawnXp = getMasteryXp(collection, se.unitTemplate.name)
       const spawnLvl = masteryLevel(spawnXp)
       if (spawnLvl > 0) {


### PR DESCRIPTION
Stale or corrupt saved player data can persist a spawn structureEffect
without a unitTemplate property, causing a crash when collection.ts
accesses se.unitTemplate.name.  Skip the spawn-mastery block when
unitTemplate is absent so the card is still built using its base stats.

https://claude.ai/code/session_01958YMcHcpj4vSQ9cVVVXxR