### PR TITLE
feat: add playtime tracking, achievements, and settings display

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -85,6 +85,7 @@ import { TrainingScreen }  from './components/TrainingScreen'
 import {
   incrementAchievementProgress, setAchievementProgress, AchievementDef,
 } from './game/achievements'
+import { addPlaytime } from './game/playtime'
 import { AchievementsScreen } from './components/AchievementsScreen'
 import { HeroCardsScreen }   from './components/HeroCardsScreen'
 import FingerSmash from './components/FingerSmash'
@@ -489,6 +490,46 @@ export default function App() {
     function handleVisibility() { setIsTabHidden(document.hidden) }
     document.addEventListener('visibilitychange', handleVisibility)
     return () => document.removeEventListener('visibilitychange', handleVisibility)
+  }, [])
+
+  // ── Playtime tracking ─────────────────────────────────────────────────────
+  // Both refs are null when no timing segment is active (tab hidden).
+  // When active: gameTimerRef = segment start; battleTimerRef = battle start or null.
+  const gameTimerRef   = useRef<number | null>(document.hidden ? null : Date.now())
+  const battleTimerRef = useRef<number | null>(null)
+
+  // Save whatever has accumulated since the last reset, then apply the new state.
+  // newScreen / newHidden describe the *incoming* state (after the transition).
+  const applyPlaytimeTransition = useCallback((newScreen: string, newHidden: boolean) => {
+    const now = Date.now()
+
+    // Compute deltas from the outgoing segment (whatever was running before).
+    const totalDelta  = gameTimerRef.current !== null ? Math.max(0, now - gameTimerRef.current) : 0
+    const battleDelta = battleTimerRef.current !== null ? Math.max(0, now - battleTimerRef.current) : 0
+
+    // Set up refs for the incoming state.
+    if (newHidden) {
+      gameTimerRef.current   = null   // stop all timing while hidden
+      battleTimerRef.current = null
+    } else {
+      gameTimerRef.current   = now
+      battleTimerRef.current = newScreen === 'playing' ? now : null
+    }
+
+    if (totalDelta <= 0 && battleDelta <= 0) return
+    const newlyUnlocked = addPlaytime(totalDelta, battleDelta)
+    if (newlyUnlocked.length > 0) setAchievementToasts(prev => [...prev, ...newlyUnlocked])
+  }, [setAchievementToasts])
+
+  useEffect(() => {
+    applyPlaytimeTransition(screen, isTabHidden)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [screen, isTabHidden])
+
+  // Flush on unmount (best-effort — page may close before this runs).
+  useEffect(() => {
+    return () => { applyPlaytimeTransition(screen, isTabHidden) }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   // ── Game loop ────────────────────────────────────────────

--- a/web/src/components/AchievementsScreen.tsx
+++ b/web/src/components/AchievementsScreen.tsx
@@ -20,9 +20,10 @@ const CATEGORY_LABELS: Record<AchievementCategory, string> = {
   campaign:   '🗺  CAMPAIGN',
   misc:       '✨  MISC',
   daily:      '📅  DAILY CHALLENGE',
+  playtime:   '⏱  PLAY TIME',
 }
 
-const CATEGORY_ORDER: AchievementCategory[] = ['daily', 'campaign', 'misc', 'events', 'kills', 'structures']
+const CATEGORY_ORDER: AchievementCategory[] = ['daily', 'campaign', 'playtime', 'misc', 'events', 'kills', 'structures']
 
 function formatReward(def: AchievementDef): string {
   const r = def.reward

--- a/web/src/components/SettingsScreen.tsx
+++ b/web/src/components/SettingsScreen.tsx
@@ -12,6 +12,7 @@ import { uploadSave, applySave, getLastSyncTime, type CloudSave } from '../game/
 import { isDevMode } from '../game/debug'
 import { DevMenu } from './DevMenu'
 import { GIFT_OWNER_UID } from '../game/gifts'
+import { loadPlaytime, formatPlaytime } from '../game/playtime'
 
 interface Props {
   onBack: () => void
@@ -538,6 +539,25 @@ export function SettingsScreen({ onBack, onResetGame, user, authLoading, onDevCr
               <div className="settings-sublabel">{new Date(__BUILD_DATE__).toLocaleString()}</div>
             </div>
           </div>
+          {(() => {
+            const { totalMs, battleMs } = loadPlaytime()
+            return (
+              <>
+                <div className="settings-row">
+                  <div>
+                    <div className="settings-label">Time in game</div>
+                    <div className="settings-sublabel">{formatPlaytime(totalMs)}</div>
+                  </div>
+                </div>
+                <div className="settings-row">
+                  <div>
+                    <div className="settings-label">Time in battle</div>
+                    <div className="settings-sublabel">{formatPlaytime(battleMs)}</div>
+                  </div>
+                </div>
+              </>
+            )
+          })()}
         </Section>
       </div>
       {showLoginModal && (

--- a/web/src/game/achievements.ts
+++ b/web/src/game/achievements.ts
@@ -5,7 +5,7 @@
 //   event:<eventId>       — special event outcomes
 //   campaign:<actId>      — act completion counts
 
-export type AchievementCategory = 'kills' | 'structures' | 'events' | 'campaign' | 'misc' | 'daily'
+export type AchievementCategory = 'kills' | 'structures' | 'events' | 'campaign' | 'misc' | 'daily' | 'playtime'
 
 export interface AchievementReward {
   type: 'cards' | 'crystals' | 'item' | 'avatar'
@@ -1730,5 +1730,76 @@ export const ACHIEVEMENT_DEFS: AchievementDef[] = [
     target: 1,
     reward: { type: 'crystals', crystals: 150 },
     tier: 1,
+  },
+
+  // ── Play Time ─────────────────────────────────────────────────────────────
+  // Progress keys store cumulative milliseconds played.
+  // Targets are in ms: 10h = 36_000_000, 100h = 360_000_000, 1000h = 3_600_000_000
+
+  {
+    id: 'playtime:total:10h',
+    name: 'Dedicated Player',
+    description: 'Spend 10 hours in the game',
+    category: 'playtime',
+    progressKey: 'playtime:total',
+    target: 36_000_000,
+    reward: { type: 'crystals', crystals: 100 },
+    tier: 1,
+  },
+  {
+    id: 'playtime:total:100h',
+    name: 'Veteran Tactician',
+    description: 'Spend 100 hours in the game',
+    category: 'playtime',
+    progressKey: 'playtime:total',
+    target: 360_000_000,
+    reward: { type: 'crystals', crystals: 500 },
+    tier: 2,
+  },
+  {
+    id: 'playtime:total:1000h',
+    name: 'Legendary Commander',
+    description: 'Spend 1,000 hours in the game',
+    category: 'playtime',
+    progressKey: 'playtime:total',
+    target: 3_600_000_000,
+    reward: {
+      type: 'item',
+      item: { id: 'no_life_trophy', name: 'No-Life Trophy', icon: '🏆', desc: 'A participation trophy for spending 1,000 hours in a browser game. Please go outside.' },
+    },
+    tier: 2,
+  },
+  {
+    id: 'playtime:battle:10h',
+    name: 'Battle-Hardened',
+    description: 'Spend 10 hours in battles',
+    category: 'playtime',
+    progressKey: 'playtime:battle',
+    target: 36_000_000,
+    reward: { type: 'crystals', crystals: 100 },
+    tier: 1,
+  },
+  {
+    id: 'playtime:battle:100h',
+    name: 'Warmaster',
+    description: 'Spend 100 hours in battles',
+    category: 'playtime',
+    progressKey: 'playtime:battle',
+    target: 360_000_000,
+    reward: { type: 'crystals', crystals: 500 },
+    tier: 2,
+  },
+  {
+    id: 'playtime:battle:1000h',
+    name: 'Eternal Warlord',
+    description: 'Spend 1,000 hours in battles',
+    category: 'playtime',
+    progressKey: 'playtime:battle',
+    target: 3_600_000_000,
+    reward: {
+      type: 'item',
+      item: { id: 'battle_worn_medal', name: 'Battle-Worn Medal', icon: '🎖', desc: 'Awarded for 1,000 hours of combat. At this point the battlefield is basically your home.' },
+    },
+    tier: 2,
   },
 ]

--- a/web/src/game/playtime.ts
+++ b/web/src/game/playtime.ts
@@ -1,0 +1,65 @@
+// ─── Playtime Tracking ───────────────────────────────────────────────────────
+//
+// Tracks two independent counters (in milliseconds):
+//   totalMs   — time spent anywhere in the game (any screen)
+//   battleMs  — time spent in active battles ('playing' screen)
+//
+// Both are stored in localStorage and never reset unless the player wipes their
+// save. The addPlaytime() function also fires achievement progress checks and
+// returns any newly-unlocked AchievementDefs so the caller can surface toasts.
+
+import { incrementAchievementProgress, AchievementDef } from './achievements'
+import { logError } from '../logger'
+
+const TOTAL_KEY  = 'jarv_playtime_total_ms'
+const BATTLE_KEY = 'jarv_playtime_battle_ms'
+
+export interface PlaytimeStats {
+  totalMs:  number
+  battleMs: number
+}
+
+export function loadPlaytime(): PlaytimeStats {
+  try {
+    const totalMs  = parseInt(localStorage.getItem(TOTAL_KEY)  ?? '0', 10) || 0
+    const battleMs = parseInt(localStorage.getItem(BATTLE_KEY) ?? '0', 10) || 0
+    return { totalMs, battleMs }
+  } catch {
+    return { totalMs: 0, battleMs: 0 }
+  }
+}
+
+/**
+ * Add elapsed milliseconds to the stored playtime totals, check for newly
+ * unlocked achievements, and return any that were just unlocked.
+ */
+export function addPlaytime(totalDelta: number, battleDelta: number): AchievementDef[] {
+  if (totalDelta <= 0 && battleDelta <= 0) return []
+
+  const { totalMs, battleMs } = loadPlaytime()
+  const newTotal  = totalMs  + totalDelta
+  const newBattle = battleMs + battleDelta
+
+  try {
+    if (totalDelta  > 0) localStorage.setItem(TOTAL_KEY,  String(newTotal))
+    if (battleDelta > 0) localStorage.setItem(BATTLE_KEY, String(newBattle))
+  } catch (e) {
+    logError('playtime: failed to save', { e })
+  }
+
+  const unlocked: AchievementDef[] = []
+  if (totalDelta  > 0) unlocked.push(...incrementAchievementProgress('playtime:total',  totalDelta))
+  if (battleDelta > 0) unlocked.push(...incrementAchievementProgress('playtime:battle', battleDelta))
+  return unlocked
+}
+
+/** Format a millisecond duration as "Xh Ym", "Ym", or "< 1m". */
+export function formatPlaytime(ms: number): string {
+  const totalMins = Math.floor(ms / 60_000)
+  if (totalMins < 1) return '< 1m'
+  const h = Math.floor(totalMins / 60)
+  const m = totalMins % 60
+  if (h === 0) return `${m}m`
+  if (m === 0) return `${h}h`
+  return `${h}h ${m}m`
+}


### PR DESCRIPTION
- playtime.ts: new module tracking total and battle time in ms via
  localStorage (jarv_playtime_total_ms / jarv_playtime_battle_ms);
  addPlaytime() fires achievement checks and returns newly unlocked defs
- achievements.ts: add 'playtime' category; 6 new achievements —
  Dedicated Player / Veteran Tactician / Legendary Commander (10h/100h/1000h
  total), Battle-Hardened / Warmaster / Eternal Warlord (10h/100h/1000h
  battle); crystal rewards at 10h & 100h, joke item at 1000h
- AchievementsScreen.tsx: register 'playtime' label and insert category
  between campaign and misc in the tab order
- App.tsx: visibility-aware timer using two refs (gameTimerRef,
  battleTimerRef); flushes on screen change, tab hide/show, and unmount;
  routes newly unlocked achievements to the toast queue
- SettingsScreen.tsx: About section now shows "Time in game" and
  "Time in battle" read from localStorage on each render

https://claude.ai/code/session_01WhTRLLBPbLWXFTcAh9sN1u