### PR TITLE
fix(cards): resolve unitTemplate for unitRef-based spawn structures (re-fixes #563 #564)

### DIFF
--- a/web/src/game/cards.ts
+++ b/web/src/game/cards.ts
@@ -116,7 +116,7 @@ function resolveCardDef(raw: RawCardDef): CardDef {
       console.error('[cards]', msg)
       _pendingValidationErrors.push({ msg, ctx: { cardName: raw.name, unitRef: raw.unitRef } })
     }
-    unit = resolved as UnitTemplate
+    unit = resolved ? resolveUnit(resolved) : undefined
   } else if (raw.unit) {
     unit = resolveUnit(raw.unit)
   }


### PR DESCRIPTION
Cards using unitRef pointing to a spawn-type structure template were not
having their structureEffect.unitTemplateRef resolved into an actual
unitTemplate object. resolveCardDef now calls resolveUnit() for unitRef
cards, matching the raw.unit path, so Fungal Den, Rot Shrine, etc. all
have a valid unitTemplate when the opponent deploys them.

https://claude.ai/code/session_01Q725P7GBDNhy7me8q1Syk4