### PR TITLE
fix(ui): enable scrolling on relic select screen (fixes #567)

### DIFF
--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4124,7 +4124,8 @@ body {
   padding: 24px 16px;
   max-width: 480px;
   margin: 0 auto;
-  min-height: 100%;
+  flex: 1;
+  overflow-y: auto;
   box-sizing: border-box;
 }
 


### PR DESCRIPTION
Replace min-height: 100% with flex: 1 + overflow-y: auto on
.relic-select-screen so the grid scrolls on small mobile screens
instead of being clipped by the overflow: hidden game container.

https://claude.ai/code/session_01GkDJvEZAphtLRHf1oquMFV