### PR TITLE
feat(battle): add VictoryPanel overlay for celebration phase

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -92,6 +92,7 @@ import FingerSmash from './components/FingerSmash'
 import BossShockwave from './components/BossShockwave'
 import { ShopScreen }        from './components/ShopScreen'
 import { BattleSummary }    from './components/BattleSummary'
+import { VictoryPanel }     from './components/VictoryPanel'
 import { RelicSpinScreen }  from './components/RelicSpinScreen'
 import { CampaignVictoryScreen } from './components/CampaignVictoryScreen'
 import { CampaignFailedScreen }  from './components/CampaignFailedScreen'
@@ -2428,12 +2429,18 @@ export default function App() {
           && failCount >= 2
         if (gameState.phase.type === 'celebration') {
           return (
-            <div style={{ position: 'relative', width: '100%', height: '100%' }}>
+            <>
               <Battlefield state={gameState} onPlayCard={handlePlayCard} onGiveUp={handleGiveUp} onPause={setIsUserPaused} actTheme={actTheme} activeRelic={run?.activeRelic} showBossSplash={false} activeModifiers={run ? getModifiersByCount(ACTS[run.actId], run.activeModifierCount) : []} />
-              <div className="victory-overlay">
-                <div className="victory-text">YOU WIN!</div>
-              </div>
-            </div>
+              <VictoryPanel
+                playerScore={gameState.playerScore}
+                opponentScore={gameState.opponentScore}
+                playerBaseHp={gameState.playerBase.hp}
+                playerBaseMaxHp={gameState.playerBase.maxHp}
+                unitsDefeated={gameState.battleStats.playerKills}
+                gameTime={gameState.gameTime}
+                onContinue={() => dispatch({ type: 'SET_GAME_STATE', gameState: { ...gameState, phase: { type: 'gameOver', winner: 'player' } } })}
+              />
+            </>
           )
         }
         if (gameState.phase.type === 'fingerSmash') {

--- a/web/src/components/VictoryPanel.tsx
+++ b/web/src/components/VictoryPanel.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import { StatRow } from './StatRow'
+
+interface Props {
+  playerScore: number
+  opponentScore: number
+  playerBaseHp: number
+  playerBaseMaxHp: number
+  unitsDefeated: number
+  gameTime: number
+  onContinue: () => void
+}
+
+function formatTime(ms: number): string {
+  const s = Math.floor(ms / 1000)
+  const m = Math.floor(s / 60)
+  return m > 0 ? `${m}m ${s % 60}s` : `${s}s`
+}
+
+export function VictoryPanel({ playerScore, opponentScore, playerBaseHp, playerBaseMaxHp, unitsDefeated, gameTime, onContinue }: Props) {
+  return (
+    <div className="bsummary-backdrop">
+      <div className="bsummary-panel vpanel">
+        <div className="victory-text vpanel-headline">YOU WIN!</div>
+
+        <div className="bsummary-stats">
+          <StatRow accent label="SCORE"          value={`${playerScore} — ${opponentScore}`} />
+          <StatRow accent label="BASE HP"        value={`${playerBaseHp} / ${playerBaseMaxHp}`} />
+          <StatRow accent label="UNITS DEFEATED" value={unitsDefeated} />
+          <StatRow accent label="TIME"           value={formatTime(gameTime)} />
+        </div>
+
+        <button className="action-btn action-btn--large bsummary-continue" onClick={onContinue}>
+          Continue →
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -6635,6 +6635,18 @@ body {
   margin-top: 4px;
 }
 
+/* ── Victory Panel overlay (celebration phase) ────────────── */
+.vpanel {
+  border-color: #2a6a2a;
+  box-shadow: 0 0 48px rgba(51, 255, 51, 0.18);
+  text-align: center;
+  align-items: center;
+}
+.vpanel-headline {
+  font-size: clamp(2rem, 8vw, 3.5rem);
+  margin-bottom: 4px;
+}
+
 /* ─── 8-Bit Mode ──────────────────────────────────────── */
 
 /* ─── 8-Bit Mode ──────────────────────────────────────── */


### PR DESCRIPTION
Replace the bare "YOU WIN!" text overlay with a proper victory panel
that shows score, base HP, units defeated and time. Renders over the
live battlefield (units still celebrating behind it); player clicks
Continue to proceed to the GameOver screen.

- VictoryPanel.tsx: new component using existing bsummary/stat-row classes
- App.tsx: celebration phase now renders <VictoryPanel> instead of plain text overlay
- styles.css: .vpanel modifier for green-glow border; .vpanel-headline size override

https://claude.ai/code/session_01Tsx1dXuVaBVGfWUZCgmfij