### PR TITLE
fix: ensure opponents and daily challenge can play high-mana cards

### DIFF
--- a/web/src/components/DeckBuilder.tsx
+++ b/web/src/components/DeckBuilder.tsx
@@ -269,6 +269,12 @@ export function DeckBuilder({ onBack, fatiguedCards = [] }: Props) {
       })
   }, [catalog, collection, search, typeFilter, rarityFilter, sortBy])
 
+  // Mana warning: deck has high-cost cards but no mana structure to unlock them
+  const deckCardObjects = deck.flatMap(e => { const c = catalog.find(x => x.name === e.cardName); return c ? [c] : [] })
+  const hasManaStructure = deckCardObjects.some(c => c.unit?.structureEffect?.type === 'mana')
+  const maxDeckCost = deckCardObjects.reduce((m, c) => Math.max(m, c.cost), 0)
+  const showManaWarning = maxDeckCost > 5 && !hasManaStructure
+
   // Deck list sorted by cost then name (skip any cards not in catalog)
   const deckList = deck
     .filter(e => catalog.some(c => c.name === e.cardName))
@@ -421,6 +427,11 @@ export function DeckBuilder({ onBack, fatiguedCards = [] }: Props) {
           )}
 
           <div className="deckbuilder-footer">
+            {showManaWarning && (
+              <div style={{ fontSize: '11px', color: '#ffcc00', padding: '4px 0', lineHeight: 1.4 }}>
+                ⚠ Deck has {maxDeckCost}-cost cards but no mana structure. Add a Farm or mana building to exceed 5 max mana.
+              </div>
+            )}
             <ProgressBar pct={(total / DECK_MAX) * 100} />
             <div className="deckbuilder-footer-row">
               <button

--- a/web/src/game/dailyChallenge.ts
+++ b/web/src/game/dailyChallenge.ts
@@ -88,6 +88,20 @@ function buildChallengeCards(xorSeed: number): Card[] {
       if (result.length >= DECK_SIZE) break
     }
   }
+  // If the deck has cards costing > 5 but no mana structure, inject the cheapest one.
+  // Players can't edit the daily deck, so we must ensure it's always self-sufficient.
+  const BASE_MAX_MANA = 5
+  const hasManaStructure = result.some(c => c.unit?.structureEffect?.type === 'mana')
+  const maxCost = result.reduce((m, c) => Math.max(m, c.cost), 0)
+  if (maxCost > BASE_MAX_MANA && !hasManaStructure) {
+    const manaStructure = catalog
+      .filter(c => c.unit?.structureEffect?.type === 'mana')
+      .sort((a, b) => a.cost - b.cost)[0]
+    if (manaStructure && !seen.has(manaStructure.name)) {
+      result[result.length - 1] = { ...manaStructure, id: `dc-${(xorSeed >>> 0).toString(16)}-mana` }
+    }
+  }
+
   return result
 }
 

--- a/web/src/game/engine.ts
+++ b/web/src/game/engine.ts
@@ -1398,7 +1398,9 @@ function isPlayable(card: Card, gameTime: number): boolean {
 function opponentAI(s: GameState, log: string[]): void {
   const manaBonus = getManaBonus(s.field, 'opponent')
   const manaMult = s.endlessOpponentManaMult ?? 1
-  let mana = Math.min(15, Math.round((BASE_MAX_MANA + manaBonus) * manaMult))
+  // Floor mana to the most expensive card in hand so opponents can always play their cards
+  const maxHandCost = s.opponentHand.reduce((m, c) => Math.max(m, c.cost), 0)
+  let mana = Math.min(15, Math.round((Math.max(BASE_MAX_MANA, maxHandCost) + manaBonus) * manaMult))
 
   const strategy = s.opponentStrategy
   const wave = s.endlessMode ? (s.endlessWave ?? 1) : 1
@@ -1495,7 +1497,9 @@ function genericBossAI(s: GameState, log: string[], def: BossAIDef): void {
     }
   }
 
-  let mana = phase.manaOverride ?? Math.min(10, BASE_MAX_MANA + manaBonus)
+  // Floor mana to the most expensive card in hand so boss can always play its signature cards
+  const maxHandCost = s.opponentHand.reduce((m, c) => Math.max(m, c.cost), 0)
+  let mana = phase.manaOverride ?? Math.min(10, Math.max(BASE_MAX_MANA, maxHandCost) + manaBonus)
   const maxPlays = phase.maxPlaysOverride ?? def.maxPlaysPerTurn
 
   function tryPlay(): boolean {


### PR DESCRIPTION
- engine.ts: floor opponent mana to max hand card cost in opponentAI()
  and genericBossAI() — fixes act 12 Harbormaster (cost-6 card) and
  any future deck where max cost exceeds BASE_MAX_MANA (5)
- DeckBuilder.tsx: show warning when deck has cards costing > 5 but no
  mana structure to unlock them
- dailyChallenge.ts: inject cheapest mana structure into player/opponent
  daily deck when max card cost > 5 and no mana structure present

https://claude.ai/code/session_01HnV2pz2EWN8GZLAWfoPjsf