### PR TITLE
Add SVG marble race track with zigzag, loop-the-loop and funnel

### DIFF
--- a/web/src/components/minigames/MarbleRace.tsx
+++ b/web/src/components/minigames/MarbleRace.tsx
@@ -1,5 +1,6 @@
 // ─── Marble Race ──────────────────────────────────────────────────────────────
-// Pick one of 4 coloured marbles, then watch all 4 race down a 20-row track.
+// Pick one of 4 coloured marbles, then watch all 4 race down a 20-row SVG track
+// with zigzag curves, a loop-the-loop, and a funnel section.
 // Obstacles randomly pause marbles for a tick. Prize is based on finishing place.
 
 import React, { useState, useEffect, useRef } from 'react'
@@ -8,50 +9,117 @@ interface Props {
   onDone: (ticketsEarned: number) => void
 }
 
-const TRACK_LENGTH  = 20    // rows in the track (0 = top, TRACK_LENGTH = finish)
-const OBSTACLE_CHANCE = 0.22 // probability of a pause obstacle per row per marble
-const TICK_MS       = 160   // ms between animation frames
+const TRACK_LENGTH    = 20     // checkpoints (0 = start, 20 = finish)
+const OBSTACLE_CHANCE = 0.22   // probability of a pause obstacle per checkpoint
+const TICK_MS         = 160    // ms between animation frames
 
-const MARBLE_NAMES   = ['Red',  'Blue',  'Green', 'Yellow'] as const
-const MARBLE_EMOJIS  = ['🔴',  '🔵',   '🟢',    '🟡']   as const
-const PLACE_PRIZES   = [40, 20, 10, 5] // tickets for 1st / 2nd / 3rd / 4th
+const MARBLE_NAMES   = ['Red',    'Blue',   'Green',  'Yellow'] as const
+const MARBLE_EMOJIS  = ['🔴',    '🔵',     '🟢',     '🟡']    as const
+const MARBLE_COLORS  = ['#ff4444','#4488ff','#44cc44','#ffcc00'] as const
+const PLACE_PRIZES   = [40, 20, 10, 5]
 const PLACE_LABELS   = ['1st 🥇', '2nd 🥈', '3rd 🥉', '4th']
 
+// ── SVG layout ────────────────────────────────────────────────────────────────
+const SVG_W       = 380
+const SVG_H       = 620
+const LANE_XS     = [55, 135, 215, 295] // 4 lane centres, 80 px apart
+const LOOP_CY     = 310                 // loop circle centre Y
+const LOOP_R      = 35                  // loop radius
+const FUNNEL_CX   = 175                 // x-midpoint of all 4 lanes
+
+function lerp(a: number, b: number, t: number) { return a + (b - a) * t }
+
+// Returns 21 waypoints (rows 0–20) for one lane.
+function getLaneWaypoints(lx: number): { x: number; y: number }[] {
+  const ZZ = 22  // zigzag amplitude
+  return [
+    // ── straight start (rows 0-2) ────────────────────────────────────────
+    { x: lx,       y: 30  },  // 0 start
+    { x: lx,       y: 58  },  // 1
+    { x: lx,       y: 86  },  // 2 zigzag begins
+    // ── zigzag (rows 3-7) ────────────────────────────────────────────────
+    { x: lx + ZZ,  y: 114 },  // 3
+    { x: lx - ZZ,  y: 142 },  // 4
+    { x: lx + ZZ,  y: 170 },  // 5
+    { x: lx - ZZ,  y: 198 },  // 6
+    { x: lx,       y: 226 },  // 7 zigzag ends
+    // ── approach loop (row 8) ────────────────────────────────────────────
+    { x: lx,       y: 258 },  // 8
+    // ── loop-the-loop (rows 9-13, clockwise: bottom→right→top→left→bottom)
+    { x: lx,            y: LOOP_CY + LOOP_R },  // 9  entry (bottom)
+    { x: lx + LOOP_R,   y: LOOP_CY          },  // 10 right
+    { x: lx,            y: LOOP_CY - LOOP_R },  // 11 top
+    { x: lx - LOOP_R,   y: LOOP_CY          },  // 12 left
+    { x: lx,            y: LOOP_CY + LOOP_R },  // 13 exit (same as entry)
+    // ── funnel (rows 14-17) ──────────────────────────────────────────────
+    { x: lx,                          y: 362 },  // 14 below loop
+    { x: lerp(lx, FUNNEL_CX, 0.3),   y: 398 },  // 15 converging
+    { x: lerp(lx, FUNNEL_CX, 0.65),  y: 432 },  // 16 funnel centre
+    { x: lerp(lx, FUNNEL_CX, 0.3),   y: 462 },  // 17 diverging
+    // ── straight finish (rows 18-20) ─────────────────────────────────────
+    { x: lx,       y: 490 },  // 18
+    { x: lx,       y: 522 },  // 19
+    { x: lx,       y: 554 },  // 20 FINISH
+  ]
+}
+
+// Build a smooth SVG path string through waypoints using catmull-rom → cubic bezier.
+function getLanePath(lx: number): string {
+  const pts = getLaneWaypoints(lx)
+  let d = `M ${pts[0].x} ${pts[0].y}`
+  for (let i = 1; i < pts.length; i++) {
+    const p0 = pts[Math.max(i - 2, 0)]
+    const p1 = pts[i - 1]
+    const p2 = pts[i]
+    const p3 = pts[Math.min(i + 1, pts.length - 1)]
+    const cp1x = p1.x + (p2.x - p0.x) * 0.25
+    const cp1y = p1.y + (p2.y - p0.y) * 0.25
+    const cp2x = p2.x - (p3.x - p1.x) * 0.25
+    const cp2y = p2.y - (p3.y - p1.y) * 0.25
+    d += ` C ${cp1x.toFixed(1)} ${cp1y.toFixed(1)} ${cp2x.toFixed(1)} ${cp2y.toFixed(1)} ${p2.x} ${p2.y}`
+  }
+  return d
+}
+
+// Return the (x,y) position for a marble at a given row.
+function getMarblePos(lx: number, row: number): { x: number; y: number } {
+  return getLaneWaypoints(lx)[Math.min(row, TRACK_LENGTH)]
+}
+
 // ── Race simulation ───────────────────────────────────────────────────────────
-// Returns a path array for one marble: each element is the row position at that
-// tick.  Repeated values represent obstacle pauses.
 function simulatePath(): number[] {
   const path: number[] = [0]
   let row = 0
   while (row < TRACK_LENGTH) {
-    if (Math.random() < OBSTACLE_CHANCE) {
-      path.push(row) // stall for one extra tick
-    }
+    if (Math.random() < OBSTACLE_CHANCE) path.push(row)
     row++
     path.push(row)
   }
   return path
 }
 
-// Simulate all 4 marble paths and return finishing order (marble indices, 1st→4th).
 function simulateRace(): { paths: number[][]; order: number[] } {
   const paths = Array.from({ length: 4 }, simulatePath)
-  // Finishing tick = index of first occurrence of TRACK_LENGTH in each path.
-  // Break ties by the marble index (lower = earlier draw).
   const finishTicks = paths.map(p => p.indexOf(TRACK_LENGTH))
   const order = [0, 1, 2, 3].sort((a, b) => finishTicks[a] - finishTicks[b])
   return { paths, order }
 }
 
+// ── Derived SVG constants ─────────────────────────────────────────────────────
+const START_Y   = getLaneWaypoints(LANE_XS[0])[0].y           // 30
+const FINISH_Y  = getLaneWaypoints(LANE_XS[0])[TRACK_LENGTH].y // 554
+const FUNNEL_Y14 = getLaneWaypoints(LANE_XS[0])[14].y          // 362
+const FUNNEL_Y16 = getLaneWaypoints(LANE_XS[0])[16].y          // 432
+const FUNNEL_Y18 = getLaneWaypoints(LANE_XS[0])[18].y          // 490
+
 // ── Component ─────────────────────────────────────────────────────────────────
 type Phase = 'choose' | 'racing' | 'result'
 
 export function MarbleRace({ onDone }: Props) {
-  const [phase, setPhase]             = useState<Phase>('choose')
-  const [chosen, setChosen]           = useState<number | null>(null)
-  // rows[i] = current display row of marble i during animation
-  const [rows, setRows]               = useState<number[]>([0, 0, 0, 0])
-  const [finishOrder, setFinishOrder] = useState<number[]>([])
+  const [phase, setPhase]               = useState<Phase>('choose')
+  const [chosen, setChosen]             = useState<number | null>(null)
+  const [rows, setRows]                 = useState<number[]>([0, 0, 0, 0])
+  const [finishOrder, setFinishOrder]   = useState<number[]>([])
   const [ticketsEarned, setTicketsEarned] = useState(0)
 
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
@@ -63,9 +131,9 @@ export function MarbleRace({ onDone }: Props) {
   function startRace() {
     if (chosen === null) return
     const { paths, order } = simulateRace()
-    pathsRef.current  = paths
-    orderRef.current  = order
-    tickRef.current   = 0
+    pathsRef.current   = paths
+    orderRef.current   = order
+    tickRef.current    = 0
     maxTickRef.current = Math.max(...paths.map(p => p.length - 1))
     setRows([0, 0, 0, 0])
     setFinishOrder([])
@@ -74,26 +142,20 @@ export function MarbleRace({ onDone }: Props) {
 
   useEffect(() => {
     if (phase !== 'racing') return
-
     intervalRef.current = setInterval(() => {
       const t = tickRef.current
-      const paths = pathsRef.current
-
-      setRows(paths.map(p => p[Math.min(t, p.length - 1)]))
-
+      setRows(pathsRef.current.map(p => p[Math.min(t, p.length - 1)]))
       if (t >= maxTickRef.current) {
         clearInterval(intervalRef.current!)
-        const order = orderRef.current
-        setFinishOrder(order)
-        const place = order.indexOf(chosen!)
+        const order  = orderRef.current
+        const place  = order.indexOf(chosen!)
         const tickets = PLACE_PRIZES[place]
+        setFinishOrder(order)
         setTicketsEarned(tickets)
         setPhase('result')
       }
-
       tickRef.current++
     }, TICK_MS)
-
     return () => { if (intervalRef.current) clearInterval(intervalRef.current) }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [phase])
@@ -121,6 +183,7 @@ export function MarbleRace({ onDone }: Props) {
               className={`race-pick-btn${chosen === i ? ' race-pick-btn--active' : ''}`}
               onClick={() => setChosen(i)}
               aria-pressed={chosen === i}
+              style={chosen === i ? { borderColor: MARBLE_COLORS[i], color: MARBLE_COLORS[i] } : {}}
             >
               <span className="race-pick-emoji">{MARBLE_EMOJIS[i]}</span>
               <span className="race-pick-name">{name}</span>
@@ -142,8 +205,8 @@ export function MarbleRace({ onDone }: Props) {
   }
 
   // ── Racing / result phase ────────────────────────────────────────────────────
-  const place       = finishOrder.indexOf(chosen ?? 0)
-  const placeLabel  = phase === 'result' ? PLACE_LABELS[place] : null
+  const place      = finishOrder.indexOf(chosen ?? 0)
+  const placeLabel = phase === 'result' ? PLACE_LABELS[place] : null
 
   return (
     <div className="minigame-screen">
@@ -160,52 +223,102 @@ export function MarbleRace({ onDone }: Props) {
         </p>
       )}
 
-      {/* Track */}
-      <div className="race-track">
-        {/* Header: marble emoji per lane */}
-        <div className="race-track-header">
-          {MARBLE_NAMES.map((name, i) => (
-            <div
+      {/* SVG Track */}
+      <div className="race-svg-wrap">
+        <svg viewBox={`0 0 ${SVG_W} ${SVG_H}`} className="race-svg" aria-label="Marble race track">
+
+          {/* ── Section labels ── */}
+          <text x="6" y="158" className="race-section-label">ZIGZAG</text>
+          <text x="6" y="313" className="race-section-label">LOOP</text>
+          <text x="6" y="435" className="race-section-label">FUNNEL</text>
+
+          {/* ── Track paths ── */}
+          {LANE_XS.map((lx, i) => (
+            <path key={i} d={getLanePath(lx)} className="race-lane-track" />
+          ))}
+
+          {/* ── Loop ring decorations ── */}
+          {LANE_XS.map((lx, i) => (
+            <circle key={i} cx={lx} cy={LOOP_CY} r={LOOP_R} className="race-loop-ring" />
+          ))}
+
+          {/* ── Funnel guide lines (converge & diverge) ── */}
+          {/* left outer → centre */}
+          <line x1={LANE_XS[0] - 10} y1={FUNNEL_Y14} x2={FUNNEL_CX - 14} y2={FUNNEL_Y16}
+                className="race-funnel-guide" />
+          {/* right outer → centre */}
+          <line x1={LANE_XS[3] + 10} y1={FUNNEL_Y14} x2={FUNNEL_CX + 14} y2={FUNNEL_Y16}
+                className="race-funnel-guide" />
+          {/* centre → left outer (exit) */}
+          <line x1={FUNNEL_CX - 14} y1={FUNNEL_Y16} x2={LANE_XS[0] - 10} y2={FUNNEL_Y18}
+                className="race-funnel-guide" />
+          {/* centre → right outer (exit) */}
+          <line x1={FUNNEL_CX + 14} y1={FUNNEL_Y16} x2={LANE_XS[3] + 10} y2={FUNNEL_Y18}
+                className="race-funnel-guide" />
+
+          {/* ── Start line ── */}
+          <line x1={LANE_XS[0] - 22} y1={START_Y} x2={LANE_XS[3] + 22} y2={START_Y}
+                className="race-start-line" />
+          <text x={SVG_W / 2} y={START_Y - 7} textAnchor="middle" className="race-line-label">
+            START
+          </text>
+
+          {/* ── Finish line (striped) ── */}
+          {Array.from({ length: 10 }, (_, k) => {
+            const segW = (LANE_XS[3] + 22 - (LANE_XS[0] - 22)) / 10
+            const x1 = LANE_XS[0] - 22 + k * segW
+            return (
+              <rect key={k} x={x1} y={FINISH_Y - 4} width={segW} height={8}
+                    fill={k % 2 === 0 ? '#ffffff18' : '#00000030'} />
+            )
+          })}
+          <line x1={LANE_XS[0] - 22} y1={FINISH_Y} x2={LANE_XS[3] + 22} y2={FINISH_Y}
+                className="race-finish-line-svg" />
+          <text x={SVG_W / 2} y={FINISH_Y + 13} textAnchor="middle" className="race-line-label">
+            FINISH
+          </text>
+
+          {/* ── Lane headers (marble emoji above start) ── */}
+          {LANE_XS.map((lx, i) => (
+            <text
               key={i}
-              className={`race-lane-header${chosen === i ? ' race-lane-header--chosen' : ''}`}
+              x={lx} y={START_Y - 16}
+              textAnchor="middle"
+              className={`race-lane-label${chosen === i ? ' race-lane-label--chosen' : ''}`}
             >
               {MARBLE_EMOJIS[i]}
-            </div>
+            </text>
           ))}
-        </div>
 
-        {/* Rows */}
-        {Array.from({ length: TRACK_LENGTH }, (_, rowIdx) => (
-          <div key={rowIdx} className="race-row">
-            {MARBLE_NAMES.map((_, marbleIdx) => {
-              const marbleRow = rows[marbleIdx]
-              const isHere    = marbleRow === rowIdx
-              const isChosen  = chosen === marbleIdx
-              return (
-                <div
-                  key={marbleIdx}
-                  className={`race-cell${isHere ? ' race-cell--marble' : ''}${isChosen && isHere ? ' race-cell--chosen' : ''}`}
-                >
-                  {isHere
-                    ? <span className="race-marble">{MARBLE_EMOJIS[marbleIdx]}</span>
-                    : <span className="race-track-dot">·</span>}
-                </div>
-              )
-            })}
-          </div>
-        ))}
+          {/* ── Marble circles ── */}
+          {LANE_XS.map((lx, i) => {
+            const pos = getMarblePos(lx, rows[i])
+            return (
+              <g
+                key={i}
+                style={{
+                  transform: `translate(${pos.x}px, ${pos.y}px)`,
+                  transition: `transform ${Math.round(TICK_MS * 0.88)}ms ease-out`,
+                }}
+              >
+                {/* glow ring for chosen marble */}
+                {chosen === i && (
+                  <circle r={14} className="race-marble-glow"
+                          style={{ stroke: MARBLE_COLORS[i] }} />
+                )}
+                <circle
+                  r={chosen === i ? 10 : 8}
+                  className={`race-marble-circle${chosen === i ? ' race-marble--chosen' : ''}`}
+                  style={{ fill: MARBLE_COLORS[i] }}
+                />
+              </g>
+            )
+          })}
 
-        {/* Finish line */}
-        <div className="race-finish-line">
-          {MARBLE_NAMES.map((_, i) => (
-            <div key={i} className={`race-finish-cell${rows[i] >= TRACK_LENGTH ? ' race-finish-cell--arrived' : ''}`}>
-              {rows[i] >= TRACK_LENGTH ? MARBLE_EMOJIS[i] : '▭'}
-            </div>
-          ))}
-        </div>
+        </svg>
       </div>
 
-      {/* Finishing order (shown progressively as marbles arrive) */}
+      {/* ── Finishing order ── */}
       {phase === 'result' && finishOrder.length > 0 && (
         <div className="race-results">
           {finishOrder.map((marbleIdx, pos) => (
@@ -214,7 +327,9 @@ export function MarbleRace({ onDone }: Props) {
               className={`race-result-row${marbleIdx === chosen ? ' race-result-row--chosen' : ''}`}
             >
               <span className="race-result-place">{PLACE_LABELS[pos]}</span>
-              <span className="race-result-marble">{MARBLE_EMOJIS[marbleIdx]} {MARBLE_NAMES[marbleIdx]}</span>
+              <span className="race-result-marble">
+                {MARBLE_EMOJIS[marbleIdx]} {MARBLE_NAMES[marbleIdx]}
+              </span>
               {marbleIdx === chosen && (
                 <span className="race-result-prize">+{ticketsEarned} 🎫</span>
               )}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -8941,3 +8941,213 @@ html.light-mode .action-btn {
   color: #ffcc44;
   font-weight: bold;
 }
+
+/* ── Marble Race ──────────────────────────────────────────────────────────── */
+
+.race-prize-table {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  border: 1px solid #2a2a5a;
+  background: #0a0a1e;
+  padding: 10px 16px;
+  margin-bottom: 12px;
+  min-width: 180px;
+}
+
+.race-prize-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  font-size: 12px;
+  color: #8888bb;
+}
+
+.race-prize-place {
+  color: #aaaacc;
+}
+
+.race-prize-tickets {
+  color: #ffcc44;
+  font-weight: bold;
+}
+
+.race-pick-row {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: center;
+  margin: 12px 0;
+}
+
+.race-pick-btn {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  width: 72px;
+  padding: 10px 4px;
+  border: 1px solid #3a3a6a;
+  background: #0e0e22;
+  color: #8888aa;
+  cursor: pointer;
+  font-size: 12px;
+  transition: border-color 0.1s, background 0.1s, color 0.1s;
+}
+
+.race-pick-btn:hover {
+  background: #16163a;
+  border-color: #6060aa;
+  color: #ccccee;
+}
+
+.race-pick-btn--active {
+  background: #12120e;
+}
+
+.race-pick-emoji {
+  font-size: 20px;
+  line-height: 1;
+}
+
+.race-pick-name {
+  font-size: 11px;
+  letter-spacing: 0.5px;
+}
+
+/* ── SVG track container ── */
+
+.race-svg-wrap {
+  width: 100%;
+  max-width: 380px;
+  background: #06060f;
+  border: 1px solid #1e1e44;
+  overflow: hidden;
+  margin: 8px 0;
+}
+
+.race-svg {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+/* ── Track elements ── */
+
+.race-lane-track {
+  fill: none;
+  stroke: #252560;
+  stroke-width: 5;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.race-loop-ring {
+  fill: none;
+  stroke: #1c1c50;
+  stroke-width: 2;
+  stroke-dasharray: 5 4;
+}
+
+.race-funnel-guide {
+  stroke: #181844;
+  stroke-width: 1.5;
+  fill: none;
+}
+
+.race-start-line {
+  stroke: #3a3a7a;
+  stroke-width: 1.5;
+}
+
+.race-finish-line-svg {
+  stroke: #5a5aaa;
+  stroke-width: 2;
+}
+
+.race-section-label {
+  fill: #282866;
+  font-size: 7.5px;
+  letter-spacing: 1.2px;
+  font-family: monospace;
+  text-transform: uppercase;
+}
+
+.race-lane-label {
+  fill: #444488;
+  font-size: 13px;
+}
+
+.race-lane-label--chosen {
+  fill: #ffd700;
+}
+
+.race-line-label {
+  fill: #383878;
+  font-size: 8px;
+  letter-spacing: 1.5px;
+  font-family: monospace;
+}
+
+/* ── Marble circles ── */
+
+.race-marble-circle {
+  stroke: #00000066;
+  stroke-width: 1.5;
+}
+
+.race-marble--chosen {
+  stroke: #ffd700;
+  stroke-width: 2.5;
+}
+
+.race-marble-glow {
+  fill: none;
+  stroke-width: 2;
+  opacity: 0.35;
+}
+
+/* ── Result table ── */
+
+.race-results {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  width: 100%;
+  max-width: 320px;
+  margin: 10px 0 4px;
+}
+
+.race-result-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 10px;
+  border: 1px solid #2a2a4a;
+  background: #0c0c20;
+  font-size: 13px;
+  color: #9999bb;
+}
+
+.race-result-row--chosen {
+  border-color: #9a8020;
+  background: #141008;
+  color: #ffd700;
+}
+
+.race-result-place {
+  width: 52px;
+  flex-shrink: 0;
+  font-size: 12px;
+}
+
+.race-result-marble {
+  flex: 1;
+}
+
+.race-result-prize {
+  color: #ffd700;
+  font-weight: bold;
+  font-size: 12px;
+  white-space: nowrap;
+}


### PR DESCRIPTION
Replaces the plain text-grid track with a full SVG animated track.
Four parallel lanes each wind through: a zigzag section (rows 3-7),
a full loop-the-loop circle (rows 9-13), and a funnel that converges
all lanes toward the centre then spreads back (rows 14-17). Marble
circles animate smoothly via CSS transform transitions. Adds all
previously-missing race UI CSS (pick screen, SVG container, marbles,
results table). Physics simulation is unchanged.

https://claude.ai/code/session_016xeTguf16LZtBxgvEi9riE