### PR TITLE
feat(ux): add quit confirmation dialog

### DIFF
--- a/web/src/components/Battlefield.tsx
+++ b/web/src/components/Battlefield.tsx
@@ -10,6 +10,7 @@ import { MAX_UPGRADE_LEVEL } from '../game/engine'
 import { getRelicDef } from '../game/relics'
 import { getUnitLore, getCardCatalog } from '../game/cards'
 import { Button } from './Button'
+import { ConfirmModal } from './ConfirmModal'
 import { loadPlayerName, loadPlayerAvatar } from '../game/questline'
 
 interface Props {
@@ -608,6 +609,7 @@ export function Battlefield({ state, onPlayCard, onGiveUp, onPause, actTheme, ac
   const [paused, setPaused] = useState(false)
   const [inspectedUnit, setInspectedUnit] = useState<Unit | null>(null)
   const [showDeckViewer, setShowDeckViewer] = useState(false)
+  const [confirmGiveUp, setConfirmGiveUp] = useState(false)
   const playerName   = loadPlayerName()
   const playerAvatar = loadPlayerAvatar()
 
@@ -1038,12 +1040,21 @@ export function Battlefield({ state, onPlayCard, onGiveUp, onPause, actTheme, ac
                   <Button size="lg" onClick={() => doPause(false)}>▶ Resume</Button>
                   <Button size="md" onClick={() => setShowDeckViewer(true)}>📋 My Deck</Button>
                   {onGiveUp && (
-                    <Button size="md" variant="danger" onClick={onGiveUp}>✕ Give Up</Button>
+                    <Button size="md" variant="danger" onClick={() => setConfirmGiveUp(true)}>✕ Give Up</Button>
                   )}
                 </div>
               </>
             )}
           </div>
+      )}
+      {confirmGiveUp && onGiveUp && (
+        <ConfirmModal
+          title="Abandon Run?"
+          body="All progress for this run will be lost."
+          confirmLabel="[ Yes, Abandon ]"
+          onConfirm={onGiveUp}
+          onCancel={() => setConfirmGiveUp(false)}
+        />
       )}
     </div>
   )

--- a/web/src/components/ConfirmModal.tsx
+++ b/web/src/components/ConfirmModal.tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import { ModalBackdrop } from './ModalBackdrop'
+
+interface Props {
+  title: string
+  body: string
+  confirmLabel: string
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+export function ConfirmModal({ title, body, confirmLabel, onConfirm, onCancel }: Props) {
+  return (
+    <ModalBackdrop onClose={onCancel}>
+      <div className="confirm-modal">
+        <div className="confirm-modal-title">{title}</div>
+        <div className="confirm-modal-body">{body}</div>
+        <div className="confirm-modal-actions">
+          <button className="action-btn" onClick={onCancel}>[ Cancel ]</button>
+          <button className="action-btn action-btn--danger" onClick={onConfirm}>{confirmLabel}</button>
+        </div>
+      </div>
+    </ModalBackdrop>
+  )
+}

--- a/web/src/components/GameOver.tsx
+++ b/web/src/components/GameOver.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react'
+import { ConfirmModal } from './ConfirmModal'
 import { GameState } from '../game/types'
 import { MAX_HANDICAP } from '../game/engine'
 import { loadWinStreak } from '../game/collection'
@@ -56,6 +57,7 @@ export function GameOver({ state, winner, handicap, onOpenPack, onPlayAgain, onM
   const isEndlessDefeat = !!state.endlessMode && !won && !draw
 
   const [endlessLb, setEndlessLb] = useState<EndlessLeaderboardEntry[] | null>(null)
+  const [confirmAbandon, setConfirmAbandon] = useState(false)
   const endlessBest = isEndlessDefeat ? getEndlessPersonalBest() : null
 
   useEffect(() => {
@@ -191,7 +193,7 @@ export function GameOver({ state, winner, handicap, onOpenPack, onPlayAgain, onM
           {campaignAbandon ? (won ? '[ Claim Reward ]' : '[ Retry Node ]') : '[ Play Again ]'}
         </button>
         {campaignAbandon && (
-          <button className="action-btn action-btn--danger gameover-abandon-btn" onClick={campaignAbandon}>
+          <button className="action-btn action-btn--danger gameover-abandon-btn" onClick={() => setConfirmAbandon(true)}>
             [ Abandon Run ]
           </button>
         )}
@@ -199,6 +201,15 @@ export function GameOver({ state, winner, handicap, onOpenPack, onPlayAgain, onM
           [ Main Menu ]
         </button>
       </div>
+      {confirmAbandon && campaignAbandon && (
+        <ConfirmModal
+          title="Abandon Run?"
+          body="All progress for this run will be lost."
+          confirmLabel="[ Yes, Abandon ]"
+          onConfirm={campaignAbandon}
+          onCancel={() => setConfirmAbandon(false)}
+        />
+      )}
     </div>
   )
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2882,6 +2882,40 @@ body {
   animation: fadeIn 0.15s ease-out;
 }
 
+/* ─── Confirm Modal ─────────────────────────────────── */
+
+.confirm-modal {
+  background: var(--game-bg, #0a0a0a);
+  border: 1px solid var(--game-border, #333);
+  padding: 24px 20px;
+  max-width: 320px;
+  width: 100%;
+  text-align: center;
+  font-family: var(--font-mono, monospace);
+}
+
+.confirm-modal-title {
+  font-size: 1.1rem;
+  font-weight: bold;
+  color: var(--game-accent, #f0c040);
+  margin-bottom: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.confirm-modal-body {
+  font-size: 0.85rem;
+  color: var(--game-text, #ccc);
+  margin-bottom: 20px;
+  line-height: 1.4;
+}
+
+.confirm-modal-actions {
+  display: flex;
+  gap: 10px;
+  justify-content: center;
+}
+
 /* ─── Card Detail Modal ──────────────────────────────── */
 
 .cdm-backdrop {


### PR DESCRIPTION
Intercepts the "Give Up" and "Abandon Run" buttons with a confirmation modal to prevent accidental campaign abandonment.

**Changes:**
- `ConfirmModal.tsx` — new reusable "Are you sure?" modal using `ModalBackdrop`
- `Battlefield.tsx` — intercept Give Up button with confirmation before calling `onGiveUp`
- `GameOver.tsx` — intercept Abandon Run button with confirmation before calling `campaignAbandon`
- `styles.css` — `.confirm-modal` styles