### PR TITLE
feat(sprites): Batch 1/17 — Units A SVGs (#601)

### DIFF
--- a/web/public/sprites/air-sprite-1.svg
+++ b/web/public/sprites/air-sprite-1.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Glow aura -->
+  <ellipse cx="16" cy="17" rx="10" ry="10" fill="#C8E8FF" opacity="0.4"/>
+  <!-- Body core (lower — stride A) -->
+  <ellipse cx="16" cy="15" rx="6" ry="7" fill="#87CEEB"/>
+  <!-- Face -->
+  <circle cx="14" cy="14" r="0.9" fill="#1A6B9A"/>
+  <circle cx="18" cy="14" r="0.9" fill="#1A6B9A"/>
+  <path d="M14,17 Q16,19 18,17" stroke="#1A6B9A" stroke-width="0.8" fill="none"/>
+  <!-- Wing wisps -->
+  <path d="M10,13 Q4,9 6,15" stroke="#AADDFF" stroke-width="2" fill="none"/>
+  <path d="M22,13 Q28,9 26,15" stroke="#AADDFF" stroke-width="2" fill="none"/>
+  <!-- Trailing wisps (angled left) -->
+  <path d="M13,21 Q10,26 11,29" stroke="#87CEEB" stroke-width="1.5" fill="none"/>
+  <path d="M16,22 Q15,27 14,30" stroke="#87CEEB" stroke-width="1.5" fill="none"/>
+  <path d="M19,21 Q19,26 18,29" stroke="#87CEEB" stroke-width="1.5" fill="none"/>
+</svg>

--- a/web/public/sprites/air-sprite-2.svg
+++ b/web/public/sprites/air-sprite-2.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Glow aura (body 1px higher) -->
+  <ellipse cx="16" cy="15" rx="10" ry="10" fill="#C8E8FF" opacity="0.4"/>
+  <!-- Body core -->
+  <ellipse cx="16" cy="13" rx="6" ry="7" fill="#87CEEB"/>
+  <!-- Face -->
+  <circle cx="14" cy="12" r="0.9" fill="#1A6B9A"/>
+  <circle cx="18" cy="12" r="0.9" fill="#1A6B9A"/>
+  <path d="M14,15 Q16,17 18,15" stroke="#1A6B9A" stroke-width="0.8" fill="none"/>
+  <!-- Wing wisps -->
+  <path d="M10,11 Q4,7 6,13" stroke="#AADDFF" stroke-width="2" fill="none"/>
+  <path d="M22,11 Q28,7 26,13" stroke="#AADDFF" stroke-width="2" fill="none"/>
+  <!-- Trailing wisps (symmetric — mid-stride) -->
+  <path d="M13,19 Q11,24 13,27" stroke="#87CEEB" stroke-width="1.5" fill="none"/>
+  <path d="M16,20 Q16,25 15,28" stroke="#87CEEB" stroke-width="1.5" fill="none"/>
+  <path d="M19,19 Q21,24 19,27" stroke="#87CEEB" stroke-width="1.5" fill="none"/>
+</svg>

--- a/web/public/sprites/air-sprite-3.svg
+++ b/web/public/sprites/air-sprite-3.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Glow aura -->
+  <ellipse cx="16" cy="17" rx="10" ry="10" fill="#C8E8FF" opacity="0.4"/>
+  <!-- Body core (lower — stride B) -->
+  <ellipse cx="16" cy="15" rx="6" ry="7" fill="#87CEEB"/>
+  <!-- Face -->
+  <circle cx="14" cy="14" r="0.9" fill="#1A6B9A"/>
+  <circle cx="18" cy="14" r="0.9" fill="#1A6B9A"/>
+  <path d="M14,17 Q16,19 18,17" stroke="#1A6B9A" stroke-width="0.8" fill="none"/>
+  <!-- Wing wisps -->
+  <path d="M10,13 Q4,9 6,15" stroke="#AADDFF" stroke-width="2" fill="none"/>
+  <path d="M22,13 Q28,9 26,15" stroke="#AADDFF" stroke-width="2" fill="none"/>
+  <!-- Trailing wisps (angled right) -->
+  <path d="M13,21 Q14,26 13,29" stroke="#87CEEB" stroke-width="1.5" fill="none"/>
+  <path d="M16,22 Q17,27 17,30" stroke="#87CEEB" stroke-width="1.5" fill="none"/>
+  <path d="M19,21 Q21,26 20,29" stroke="#87CEEB" stroke-width="1.5" fill="none"/>
+</svg>

--- a/web/public/sprites/air-sprite.svg
+++ b/web/public/sprites/air-sprite.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Glow aura -->
+  <ellipse cx="16" cy="16" rx="10" ry="10" fill="#C8E8FF" opacity="0.4"/>
+  <!-- Body core -->
+  <ellipse cx="16" cy="14" rx="6" ry="7" fill="#87CEEB"/>
+  <!-- Face -->
+  <circle cx="14" cy="13" r="0.9" fill="#1A6B9A"/>
+  <circle cx="18" cy="13" r="0.9" fill="#1A6B9A"/>
+  <path d="M14,16 Q16,18 18,16" stroke="#1A6B9A" stroke-width="0.8" fill="none"/>
+  <!-- Wing wisps -->
+  <path d="M10,12 Q4,8 6,14" stroke="#AADDFF" stroke-width="2" fill="none"/>
+  <path d="M22,12 Q28,8 26,14" stroke="#AADDFF" stroke-width="2" fill="none"/>
+  <!-- Trailing wisps -->
+  <path d="M13,20 Q11,25 13,28" stroke="#87CEEB" stroke-width="1.5" fill="none"/>
+  <path d="M16,21 Q16,26 15,29" stroke="#87CEEB" stroke-width="1.5" fill="none"/>
+  <path d="M19,20 Q21,25 19,28" stroke="#87CEEB" stroke-width="1.5" fill="none"/>
+</svg>

--- a/web/public/sprites/ancient-sprite-1.svg
+++ b/web/public/sprites/ancient-sprite-1.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <ellipse cx="16" cy="17" rx="10" ry="10" fill="#C8FFC8" opacity="0.4"/>
+  <ellipse cx="16" cy="15" rx="6" ry="7" fill="#5AAA5A"/>
+  <ellipse cx="16" cy="9" rx="5" ry="2" fill="none" stroke="#FFD700" stroke-width="1.2"/>
+  <circle cx="14" cy="14" r="0.9" fill="#1A5A1A"/>
+  <circle cx="18" cy="14" r="0.9" fill="#1A5A1A"/>
+  <path d="M14,17 Q16,19 18,17" stroke="#1A5A1A" stroke-width="0.8" fill="none"/>
+  <path d="M10,13 Q4,8 7,15" stroke="#228B22" stroke-width="2" fill="#90EE90" opacity="0.8"/>
+  <path d="M22,13 Q28,8 25,15" stroke="#228B22" stroke-width="2" fill="#90EE90" opacity="0.8"/>
+  <path d="M13,21 Q10,26 11,29" stroke="#5AAA5A" stroke-width="1.5" fill="none"/>
+  <path d="M16,22 Q15,27 14,30" stroke="#FFD700" stroke-width="1.2" fill="none"/>
+  <path d="M19,21 Q19,26 18,29" stroke="#5AAA5A" stroke-width="1.5" fill="none"/>
+</svg>

--- a/web/public/sprites/ancient-sprite-2.svg
+++ b/web/public/sprites/ancient-sprite-2.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <ellipse cx="16" cy="15" rx="10" ry="10" fill="#C8FFC8" opacity="0.4"/>
+  <ellipse cx="16" cy="13" rx="6" ry="7" fill="#5AAA5A"/>
+  <ellipse cx="16" cy="7" rx="5" ry="2" fill="none" stroke="#FFD700" stroke-width="1.2"/>
+  <circle cx="14" cy="12" r="0.9" fill="#1A5A1A"/>
+  <circle cx="18" cy="12" r="0.9" fill="#1A5A1A"/>
+  <path d="M14,15 Q16,17 18,15" stroke="#1A5A1A" stroke-width="0.8" fill="none"/>
+  <path d="M10,11 Q4,6 7,13" stroke="#228B22" stroke-width="2" fill="#90EE90" opacity="0.8"/>
+  <path d="M22,11 Q28,6 25,13" stroke="#228B22" stroke-width="2" fill="#90EE90" opacity="0.8"/>
+  <path d="M13,19 Q11,24 13,27" stroke="#5AAA5A" stroke-width="1.5" fill="none"/>
+  <path d="M16,20 Q16,25 15,28" stroke="#FFD700" stroke-width="1.2" fill="none"/>
+  <path d="M19,19 Q21,24 19,27" stroke="#5AAA5A" stroke-width="1.5" fill="none"/>
+</svg>

--- a/web/public/sprites/ancient-sprite-3.svg
+++ b/web/public/sprites/ancient-sprite-3.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <ellipse cx="16" cy="17" rx="10" ry="10" fill="#C8FFC8" opacity="0.4"/>
+  <ellipse cx="16" cy="15" rx="6" ry="7" fill="#5AAA5A"/>
+  <ellipse cx="16" cy="9" rx="5" ry="2" fill="none" stroke="#FFD700" stroke-width="1.2"/>
+  <circle cx="14" cy="14" r="0.9" fill="#1A5A1A"/>
+  <circle cx="18" cy="14" r="0.9" fill="#1A5A1A"/>
+  <path d="M14,17 Q16,19 18,17" stroke="#1A5A1A" stroke-width="0.8" fill="none"/>
+  <path d="M10,13 Q4,8 7,15" stroke="#228B22" stroke-width="2" fill="#90EE90" opacity="0.8"/>
+  <path d="M22,13 Q28,8 25,15" stroke="#228B22" stroke-width="2" fill="#90EE90" opacity="0.8"/>
+  <path d="M13,21 Q14,26 13,29" stroke="#5AAA5A" stroke-width="1.5" fill="none"/>
+  <path d="M16,22 Q17,27 17,30" stroke="#FFD700" stroke-width="1.2" fill="none"/>
+  <path d="M19,21 Q21,26 20,29" stroke="#5AAA5A" stroke-width="1.5" fill="none"/>
+</svg>

--- a/web/public/sprites/ancient-sprite.svg
+++ b/web/public/sprites/ancient-sprite.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Glow aura -->
+  <ellipse cx="16" cy="16" rx="10" ry="10" fill="#C8FFC8" opacity="0.4"/>
+  <!-- Body core -->
+  <ellipse cx="16" cy="14" rx="6" ry="7" fill="#5AAA5A"/>
+  <!-- Golden ring / halo -->
+  <ellipse cx="16" cy="8" rx="5" ry="2" fill="none" stroke="#FFD700" stroke-width="1.2"/>
+  <!-- Face -->
+  <circle cx="14" cy="13" r="0.9" fill="#1A5A1A"/>
+  <circle cx="18" cy="13" r="0.9" fill="#1A5A1A"/>
+  <path d="M14,16 Q16,18 18,16" stroke="#1A5A1A" stroke-width="0.8" fill="none"/>
+  <!-- Leaf wings -->
+  <path d="M10,12 Q4,7 7,14" stroke="#228B22" stroke-width="2" fill="#90EE90" opacity="0.8"/>
+  <path d="M22,12 Q28,7 25,14" stroke="#228B22" stroke-width="2" fill="#90EE90" opacity="0.8"/>
+  <!-- Trailing wisps -->
+  <path d="M13,20 Q11,25 13,28" stroke="#5AAA5A" stroke-width="1.5" fill="none"/>
+  <path d="M16,21 Q16,26 15,29" stroke="#FFD700" stroke-width="1.2" fill="none"/>
+  <path d="M19,20 Q21,25 19,28" stroke="#5AAA5A" stroke-width="1.5" fill="none"/>
+</svg>

--- a/web/public/sprites/ancient-treant-1.svg
+++ b/web/public/sprites/ancient-treant-1.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Trunk / body -->
+  <rect x="12" y="15" width="8" height="13" rx="3" fill="#6B3A1F"/>
+  <line x1="14" y1="17" x2="14" y2="26" stroke="#4A2810" stroke-width="0.8"/>
+  <line x1="17" y1="16" x2="17" y2="25" stroke="#4A2810" stroke-width="0.8"/>
+  <!-- Head -->
+  <ellipse cx="16" cy="11" rx="6" ry="5" fill="#6B3A1F"/>
+  <ellipse cx="16" cy="11" rx="5" ry="4" fill="#7A4525"/>
+  <circle cx="14" cy="10" r="1.2" fill="#90EE90"/>
+  <circle cx="18" cy="10" r="1.2" fill="#90EE90"/>
+  <circle cx="14" cy="10" r="0.5" fill="#228B22"/>
+  <circle cx="18" cy="10" r="0.5" fill="#228B22"/>
+  <!-- Left branch arm (raised) -->
+  <path d="M12,18 Q5,12 3,7" stroke="#6B3A1F" stroke-width="3" fill="none" stroke-linecap="round"/>
+  <path d="M3,7 Q1,4 4,3" stroke="#6B3A1F" stroke-width="2" fill="none"/>
+  <path d="M3,7 Q2,5 5,5" stroke="#6B3A1F" stroke-width="2" fill="none"/>
+  <!-- Right branch arm (lowered) -->
+  <path d="M20,18 Q27,15 28,11" stroke="#6B3A1F" stroke-width="3" fill="none" stroke-linecap="round"/>
+  <path d="M28,11 Q30,9 27,8" stroke="#6B3A1F" stroke-width="2" fill="none"/>
+  <!-- Leaf clusters -->
+  <circle cx="3" cy="5" r="3" fill="#228B22" opacity="0.9"/>
+  <circle cx="6" cy="3" r="2.5" fill="#2EAA2E" opacity="0.9"/>
+  <circle cx="28" cy="9" r="3" fill="#228B22" opacity="0.9"/>
+  <!-- Roots — left forward -->
+  <path d="M12,28 Q7,30 5,32" stroke="#6B3A1F" stroke-width="2.5" fill="none"/>
+  <path d="M20,28 Q23,28 24,30" stroke="#6B3A1F" stroke-width="2.5" fill="none"/>
+  <path d="M16,28 Q15,30 14,32" stroke="#6B3A1F" stroke-width="2" fill="none"/>
+</svg>

--- a/web/public/sprites/ancient-treant-2.svg
+++ b/web/public/sprites/ancient-treant-2.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Trunk / body (1px higher) -->
+  <rect x="12" y="13" width="8" height="15" rx="3" fill="#6B3A1F"/>
+  <line x1="14" y1="15" x2="14" y2="26" stroke="#4A2810" stroke-width="0.8"/>
+  <line x1="17" y1="14" x2="17" y2="25" stroke="#4A2810" stroke-width="0.8"/>
+  <!-- Head -->
+  <ellipse cx="16" cy="9" rx="6" ry="5" fill="#6B3A1F"/>
+  <ellipse cx="16" cy="9" rx="5" ry="4" fill="#7A4525"/>
+  <circle cx="14" cy="8" r="1.2" fill="#90EE90"/>
+  <circle cx="18" cy="8" r="1.2" fill="#90EE90"/>
+  <circle cx="14" cy="8" r="0.5" fill="#228B22"/>
+  <circle cx="18" cy="8" r="0.5" fill="#228B22"/>
+  <!-- Arms symmetric (mid-stride) -->
+  <path d="M12,16 Q5,12 4,7" stroke="#6B3A1F" stroke-width="3" fill="none" stroke-linecap="round"/>
+  <path d="M4,7 Q2,4 5,3" stroke="#6B3A1F" stroke-width="2" fill="none"/>
+  <path d="M20,16 Q27,12 28,7" stroke="#6B3A1F" stroke-width="3" fill="none" stroke-linecap="round"/>
+  <path d="M28,7 Q30,4 27,3" stroke="#6B3A1F" stroke-width="2" fill="none"/>
+  <!-- Leaf clusters -->
+  <circle cx="4" cy="5" r="3" fill="#228B22" opacity="0.9"/>
+  <circle cx="7" cy="3" r="2.5" fill="#2EAA2E" opacity="0.9"/>
+  <circle cx="28" cy="5" r="3" fill="#228B22" opacity="0.9"/>
+  <circle cx="25" cy="3" r="2.5" fill="#2EAA2E" opacity="0.9"/>
+  <!-- Roots symmetric -->
+  <path d="M12,28 Q8,29 7,32" stroke="#6B3A1F" stroke-width="2.5" fill="none"/>
+  <path d="M20,28 Q24,29 25,32" stroke="#6B3A1F" stroke-width="2.5" fill="none"/>
+  <path d="M16,28 Q16,30 15,32" stroke="#6B3A1F" stroke-width="2" fill="none"/>
+</svg>

--- a/web/public/sprites/ancient-treant-3.svg
+++ b/web/public/sprites/ancient-treant-3.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect x="12" y="15" width="8" height="13" rx="3" fill="#6B3A1F"/>
+  <line x1="14" y1="17" x2="14" y2="26" stroke="#4A2810" stroke-width="0.8"/>
+  <line x1="17" y1="16" x2="17" y2="25" stroke="#4A2810" stroke-width="0.8"/>
+  <ellipse cx="16" cy="11" rx="6" ry="5" fill="#6B3A1F"/>
+  <ellipse cx="16" cy="11" rx="5" ry="4" fill="#7A4525"/>
+  <circle cx="14" cy="10" r="1.2" fill="#90EE90"/>
+  <circle cx="18" cy="10" r="1.2" fill="#90EE90"/>
+  <circle cx="14" cy="10" r="0.5" fill="#228B22"/>
+  <circle cx="18" cy="10" r="0.5" fill="#228B22"/>
+  <!-- Left arm lowered, right arm raised -->
+  <path d="M12,18 Q5,15 4,11" stroke="#6B3A1F" stroke-width="3" fill="none" stroke-linecap="round"/>
+  <path d="M4,11 Q2,9 5,8" stroke="#6B3A1F" stroke-width="2" fill="none"/>
+  <path d="M20,18 Q27,12 28,7" stroke="#6B3A1F" stroke-width="3" fill="none" stroke-linecap="round"/>
+  <path d="M28,7 Q30,4 27,3" stroke="#6B3A1F" stroke-width="2" fill="none"/>
+  <path d="M28,7 Q29,5 26,5" stroke="#6B3A1F" stroke-width="2" fill="none"/>
+  <circle cx="4" cy="9" r="3" fill="#228B22" opacity="0.9"/>
+  <circle cx="28" cy="5" r="3" fill="#228B22" opacity="0.9"/>
+  <circle cx="25" cy="3" r="2.5" fill="#2EAA2E" opacity="0.9"/>
+  <!-- Roots — right forward -->
+  <path d="M12,28 Q9,28 8,30" stroke="#6B3A1F" stroke-width="2.5" fill="none"/>
+  <path d="M20,28 Q25,30 27,32" stroke="#6B3A1F" stroke-width="2.5" fill="none"/>
+  <path d="M16,28 Q17,30 18,32" stroke="#6B3A1F" stroke-width="2" fill="none"/>
+</svg>

--- a/web/public/sprites/ancient-treant.svg
+++ b/web/public/sprites/ancient-treant.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Trunk / body -->
+  <rect x="12" y="14" width="8" height="14" rx="3" fill="#6B3A1F"/>
+  <!-- Bark texture lines -->
+  <line x1="14" y1="16" x2="14" y2="26" stroke="#4A2810" stroke-width="0.8"/>
+  <line x1="17" y1="15" x2="17" y2="25" stroke="#4A2810" stroke-width="0.8"/>
+  <!-- Head (gnarled) -->
+  <ellipse cx="16" cy="10" rx="6" ry="5" fill="#6B3A1F"/>
+  <ellipse cx="16" cy="10" rx="5" ry="4" fill="#7A4525"/>
+  <!-- Glowing eyes -->
+  <circle cx="14" cy="9" r="1.2" fill="#90EE90"/>
+  <circle cx="18" cy="9" r="1.2" fill="#90EE90"/>
+  <circle cx="14" cy="9" r="0.5" fill="#228B22"/>
+  <circle cx="18" cy="9" r="0.5" fill="#228B22"/>
+  <!-- Left branch arm -->
+  <path d="M12,17 Q5,13 4,8" stroke="#6B3A1F" stroke-width="3" fill="none" stroke-linecap="round"/>
+  <path d="M4,8 Q2,5 5,4" stroke="#6B3A1F" stroke-width="2" fill="none"/>
+  <path d="M4,8 Q3,6 6,6" stroke="#6B3A1F" stroke-width="2" fill="none"/>
+  <!-- Right branch arm -->
+  <path d="M20,17 Q27,13 28,8" stroke="#6B3A1F" stroke-width="3" fill="none" stroke-linecap="round"/>
+  <path d="M28,8 Q30,5 27,4" stroke="#6B3A1F" stroke-width="2" fill="none"/>
+  <path d="M28,8 Q29,6 26,6" stroke="#6B3A1F" stroke-width="2" fill="none"/>
+  <!-- Leaf clusters -->
+  <circle cx="4" cy="6" r="3" fill="#228B22" opacity="0.9"/>
+  <circle cx="7" cy="4" r="2.5" fill="#2EAA2E" opacity="0.9"/>
+  <circle cx="28" cy="6" r="3" fill="#228B22" opacity="0.9"/>
+  <circle cx="25" cy="4" r="2.5" fill="#2EAA2E" opacity="0.9"/>
+  <!-- Roots / feet -->
+  <path d="M12,28 Q8,29 7,32" stroke="#6B3A1F" stroke-width="2.5" fill="none"/>
+  <path d="M20,28 Q24,29 25,32" stroke="#6B3A1F" stroke-width="2.5" fill="none"/>
+  <path d="M16,28 Q16,30 15,32" stroke="#6B3A1F" stroke-width="2" fill="none"/>
+</svg>

--- a/web/public/sprites/bark-hound-1.svg
+++ b/web/public/sprites/bark-hound-1.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect x="7" y="17" width="18" height="9" rx="3" fill="#8B5A2B"/>
+  <line x1="10" y1="18" x2="10" y2="25" stroke="#5C3010" stroke-width="0.8"/>
+  <line x1="14" y1="17" x2="14" y2="25" stroke="#5C3010" stroke-width="0.8"/>
+  <line x1="18" y1="17" x2="18" y2="25" stroke="#5C3010" stroke-width="0.8"/>
+  <line x1="22" y1="18" x2="22" y2="25" stroke="#5C3010" stroke-width="0.8"/>
+  <ellipse cx="24" cy="15" rx="5" ry="4" fill="#8B5A2B"/>
+  <ellipse cx="24" cy="15" rx="4" ry="3.5" fill="#A0693A"/>
+  <ellipse cx="27" cy="16" rx="2.5" ry="2" fill="#A0693A"/>
+  <circle cx="28" cy="15.5" r="0.8" fill="#333"/>
+  <ellipse cx="28" cy="17" rx="1" ry="0.7" fill="#5C3010"/>
+  <path d="M22,12 Q20,9 23,11" fill="#6B3A1F"/>
+  <circle cx="25" cy="14" r="1" fill="#FFD700"/>
+  <circle cx="25" cy="14" r="0.5" fill="#333"/>
+  <path d="M7,18 Q2,14 3,11" stroke="#8B5A2B" stroke-width="3" fill="none" stroke-linecap="round"/>
+  <!-- Legs — stride A: front-left forward, back-right forward -->
+  <rect x="7"  y="25" width="4" height="7" rx="2" fill="#6B3A1F"/>
+  <rect x="14" y="24" width="4" height="5" rx="2" fill="#6B3A1F"/>
+  <rect x="18" y="25" width="4" height="7" rx="2" fill="#6B3A1F"/>
+  <rect x="23" y="24" width="4" height="5" rx="2" fill="#6B3A1F"/>
+</svg>

--- a/web/public/sprites/bark-hound-2.svg
+++ b/web/public/sprites/bark-hound-2.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Body 1px higher (mid-stride) -->
+  <rect x="7" y="15" width="18" height="10" rx="3" fill="#8B5A2B"/>
+  <line x1="10" y1="16" x2="10" y2="24" stroke="#5C3010" stroke-width="0.8"/>
+  <line x1="14" y1="15" x2="14" y2="24" stroke="#5C3010" stroke-width="0.8"/>
+  <line x1="18" y1="15" x2="18" y2="24" stroke="#5C3010" stroke-width="0.8"/>
+  <line x1="22" y1="16" x2="22" y2="24" stroke="#5C3010" stroke-width="0.8"/>
+  <ellipse cx="24" cy="13" rx="5" ry="4" fill="#8B5A2B"/>
+  <ellipse cx="24" cy="13" rx="4" ry="3.5" fill="#A0693A"/>
+  <ellipse cx="27" cy="14" rx="2.5" ry="2" fill="#A0693A"/>
+  <circle cx="28" cy="13.5" r="0.8" fill="#333"/>
+  <ellipse cx="28" cy="15" rx="1" ry="0.7" fill="#5C3010"/>
+  <path d="M22,10 Q20,7 23,9" fill="#6B3A1F"/>
+  <circle cx="25" cy="12" r="1" fill="#FFD700"/>
+  <circle cx="25" cy="12" r="0.5" fill="#333"/>
+  <path d="M7,16 Q2,12 3,9" stroke="#8B5A2B" stroke-width="3" fill="none" stroke-linecap="round"/>
+  <!-- Legs — all together (mid-stride) -->
+  <rect x="9"  y="24" width="4" height="6" rx="2" fill="#6B3A1F"/>
+  <rect x="14" y="24" width="4" height="6" rx="2" fill="#6B3A1F"/>
+  <rect x="18" y="24" width="4" height="6" rx="2" fill="#6B3A1F"/>
+  <rect x="22" y="24" width="4" height="6" rx="2" fill="#6B3A1F"/>
+</svg>

--- a/web/public/sprites/bark-hound-3.svg
+++ b/web/public/sprites/bark-hound-3.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect x="7" y="17" width="18" height="9" rx="3" fill="#8B5A2B"/>
+  <line x1="10" y1="18" x2="10" y2="25" stroke="#5C3010" stroke-width="0.8"/>
+  <line x1="14" y1="17" x2="14" y2="25" stroke="#5C3010" stroke-width="0.8"/>
+  <line x1="18" y1="17" x2="18" y2="25" stroke="#5C3010" stroke-width="0.8"/>
+  <line x1="22" y1="18" x2="22" y2="25" stroke="#5C3010" stroke-width="0.8"/>
+  <ellipse cx="24" cy="15" rx="5" ry="4" fill="#8B5A2B"/>
+  <ellipse cx="24" cy="15" rx="4" ry="3.5" fill="#A0693A"/>
+  <ellipse cx="27" cy="16" rx="2.5" ry="2" fill="#A0693A"/>
+  <circle cx="28" cy="15.5" r="0.8" fill="#333"/>
+  <ellipse cx="28" cy="17" rx="1" ry="0.7" fill="#5C3010"/>
+  <path d="M22,12 Q20,9 23,11" fill="#6B3A1F"/>
+  <circle cx="25" cy="14" r="1" fill="#FFD700"/>
+  <circle cx="25" cy="14" r="0.5" fill="#333"/>
+  <path d="M7,18 Q2,14 3,11" stroke="#8B5A2B" stroke-width="3" fill="none" stroke-linecap="round"/>
+  <!-- Legs — stride B: front-right forward, back-left forward -->
+  <rect x="9"  y="24" width="4" height="5" rx="2" fill="#6B3A1F"/>
+  <rect x="14" y="25" width="4" height="7" rx="2" fill="#6B3A1F"/>
+  <rect x="18" y="24" width="4" height="5" rx="2" fill="#6B3A1F"/>
+  <rect x="23" y="25" width="4" height="7" rx="2" fill="#6B3A1F"/>
+</svg>

--- a/web/public/sprites/bark-hound.svg
+++ b/web/public/sprites/bark-hound.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Body (bark-textured) -->
+  <rect x="7" y="16" width="18" height="9" rx="3" fill="#8B5A2B"/>
+  <line x1="10" y1="17" x2="10" y2="24" stroke="#5C3010" stroke-width="0.8"/>
+  <line x1="14" y1="16" x2="14" y2="24" stroke="#5C3010" stroke-width="0.8"/>
+  <line x1="18" y1="16" x2="18" y2="24" stroke="#5C3010" stroke-width="0.8"/>
+  <line x1="22" y1="17" x2="22" y2="24" stroke="#5C3010" stroke-width="0.8"/>
+  <!-- Head -->
+  <ellipse cx="24" cy="14" rx="5" ry="4" fill="#8B5A2B"/>
+  <ellipse cx="24" cy="14" rx="4" ry="3.5" fill="#A0693A"/>
+  <!-- Snout -->
+  <ellipse cx="27" cy="15" rx="2.5" ry="2" fill="#A0693A"/>
+  <circle cx="28" cy="14.5" r="0.8" fill="#333"/>
+  <ellipse cx="28" cy="16" rx="1" ry="0.7" fill="#5C3010"/>
+  <!-- Ear -->
+  <path d="M22,11 Q20,8 23,10" fill="#6B3A1F"/>
+  <!-- Eye -->
+  <circle cx="25" cy="13" r="1" fill="#FFD700"/>
+  <circle cx="25" cy="13" r="0.5" fill="#333"/>
+  <!-- Tail -->
+  <path d="M7,17 Q2,13 3,10" stroke="#8B5A2B" stroke-width="3" fill="none" stroke-linecap="round"/>
+  <!-- Legs (standing) -->
+  <rect x="9"  y="24" width="4" height="6" rx="2" fill="#6B3A1F"/>
+  <rect x="14" y="24" width="4" height="6" rx="2" fill="#6B3A1F"/>
+  <rect x="18" y="24" width="4" height="6" rx="2" fill="#6B3A1F"/>
+  <rect x="22" y="24" width="4" height="6" rx="2" fill="#6B3A1F"/>
+</svg>

--- a/web/public/sprites/bone-merchant-1.svg
+++ b/web/public/sprites/bone-merchant-1.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <ellipse cx="16" cy="9" rx="5" ry="5" fill="#E8DCC8"/>
+  <ellipse cx="16" cy="11" rx="4" ry="3" fill="#D4C8A8"/>
+  <ellipse cx="13.5" cy="8.5" rx="1.8" ry="1.5" fill="#333"/>
+  <ellipse cx="18.5" cy="8.5" rx="1.8" ry="1.5" fill="#333"/>
+  <path d="M12,12 L13,14 L16,13 L19,14 L20,12" stroke="#BBB" stroke-width="0.8" fill="none"/>
+  <path d="M10,15 L10,22 L22,22 L22,15 Q16,18 10,15 Z" fill="#6B5A3E"/>
+  <rect x="10" y="20" width="12" height="2" fill="#8B6914"/>
+  <ellipse cx="21" cy="23" rx="3" ry="3.5" fill="#8B6914"/>
+  <ellipse cx="21" cy="23" rx="2" ry="2.5" fill="#B8860B"/>
+  <line x1="10" y1="17" x2="5" y2="23" stroke="#E8DCC8" stroke-width="2.5"/>
+  <line x1="22" y1="17" x2="27" y2="21" stroke="#E8DCC8" stroke-width="2.5"/>
+  <ellipse cx="27" cy="22" rx="2.5" ry="2.5" fill="#B8860B"/>
+  <!-- Legs — stride A: left forward, right back -->
+  <rect x="9"  y="22" width="4" height="9" rx="1" fill="#E8DCC8"/>
+  <rect x="19" y="22" width="4" height="7" rx="1" fill="#E8DCC8"/>
+  <!-- Foot left -->
+  <rect x="8"  y="29" width="6" height="3" rx="1" fill="#6B5A3E"/>
+  <rect x="19" y="27" width="5" height="3" rx="1" fill="#6B5A3E"/>
+</svg>

--- a/web/public/sprites/bone-merchant-2.svg
+++ b/web/public/sprites/bone-merchant-2.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Body 1px higher -->
+  <ellipse cx="16" cy="8" rx="5" ry="5" fill="#E8DCC8"/>
+  <ellipse cx="16" cy="10" rx="4" ry="3" fill="#D4C8A8"/>
+  <ellipse cx="13.5" cy="7.5" rx="1.8" ry="1.5" fill="#333"/>
+  <ellipse cx="18.5" cy="7.5" rx="1.8" ry="1.5" fill="#333"/>
+  <path d="M12,11 L13,13 L16,12 L19,13 L20,11" stroke="#BBB" stroke-width="0.8" fill="none"/>
+  <path d="M10,14 L10,22 L22,22 L22,14 Q16,17 10,14 Z" fill="#6B5A3E"/>
+  <rect x="10" y="19" width="12" height="2" fill="#8B6914"/>
+  <ellipse cx="21" cy="22" rx="3" ry="3.5" fill="#8B6914"/>
+  <ellipse cx="21" cy="22" rx="2" ry="2.5" fill="#B8860B"/>
+  <line x1="10" y1="16" x2="5" y2="22" stroke="#E8DCC8" stroke-width="2.5"/>
+  <line x1="22" y1="16" x2="27" y2="20" stroke="#E8DCC8" stroke-width="2.5"/>
+  <ellipse cx="27" cy="21" rx="2.5" ry="2.5" fill="#B8860B"/>
+  <!-- Legs together (mid-stride) -->
+  <rect x="11" y="22" width="4" height="8" rx="1" fill="#E8DCC8"/>
+  <rect x="17" y="22" width="4" height="8" rx="1" fill="#E8DCC8"/>
+  <rect x="10" y="28" width="6" height="3" rx="1" fill="#6B5A3E"/>
+  <rect x="16" y="28" width="6" height="3" rx="1" fill="#6B5A3E"/>
+</svg>

--- a/web/public/sprites/bone-merchant-3.svg
+++ b/web/public/sprites/bone-merchant-3.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <ellipse cx="16" cy="9" rx="5" ry="5" fill="#E8DCC8"/>
+  <ellipse cx="16" cy="11" rx="4" ry="3" fill="#D4C8A8"/>
+  <ellipse cx="13.5" cy="8.5" rx="1.8" ry="1.5" fill="#333"/>
+  <ellipse cx="18.5" cy="8.5" rx="1.8" ry="1.5" fill="#333"/>
+  <path d="M12,12 L13,14 L16,13 L19,14 L20,12" stroke="#BBB" stroke-width="0.8" fill="none"/>
+  <path d="M10,15 L10,22 L22,22 L22,15 Q16,18 10,15 Z" fill="#6B5A3E"/>
+  <rect x="10" y="20" width="12" height="2" fill="#8B6914"/>
+  <ellipse cx="21" cy="23" rx="3" ry="3.5" fill="#8B6914"/>
+  <ellipse cx="21" cy="23" rx="2" ry="2.5" fill="#B8860B"/>
+  <line x1="10" y1="17" x2="5" y2="23" stroke="#E8DCC8" stroke-width="2.5"/>
+  <line x1="22" y1="17" x2="27" y2="21" stroke="#E8DCC8" stroke-width="2.5"/>
+  <ellipse cx="27" cy="22" rx="2.5" ry="2.5" fill="#B8860B"/>
+  <!-- Legs — stride B: right forward, left back -->
+  <rect x="11" y="22" width="4" height="7" rx="1" fill="#E8DCC8"/>
+  <rect x="19" y="22" width="4" height="9" rx="1" fill="#E8DCC8"/>
+  <rect x="11" y="27" width="5" height="3" rx="1" fill="#6B5A3E"/>
+  <rect x="18" y="29" width="6" height="3" rx="1" fill="#6B5A3E"/>
+</svg>

--- a/web/public/sprites/bone-merchant.svg
+++ b/web/public/sprites/bone-merchant.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Skull head -->
+  <ellipse cx="16" cy="8" rx="5" ry="5" fill="#E8DCC8"/>
+  <ellipse cx="16" cy="10" rx="4" ry="3" fill="#D4C8A8"/>
+  <!-- Eye sockets -->
+  <ellipse cx="13.5" cy="7.5" rx="1.8" ry="1.5" fill="#333"/>
+  <ellipse cx="18.5" cy="7.5" rx="1.8" ry="1.5" fill="#333"/>
+  <!-- Jaw line -->
+  <path d="M12,11 L13,13 L16,12 L19,13 L20,11" stroke="#BBB" stroke-width="0.8" fill="none"/>
+  <!-- Tattered robe/cloak body -->
+  <path d="M10,14 Q9,22 10,30 L22,30 Q23,22 22,14 Q16,17 10,14 Z" fill="#6B5A3E"/>
+  <!-- Torn cloak edges -->
+  <path d="M10,30 Q9,28 11,27 Q10,29 12,28 Q11,30 13,29" fill="#5A4A30"/>
+  <path d="M22,30 Q23,28 21,27 Q22,29 20,28 Q21,30 19,29" fill="#5A4A30"/>
+  <!-- Belt with coin pouch -->
+  <rect x="10" y="19" width="12" height="2" fill="#8B6914"/>
+  <ellipse cx="21" cy="22" rx="3" ry="3.5" fill="#8B6914"/>
+  <ellipse cx="21" cy="22" rx="2" ry="2.5" fill="#B8860B"/>
+  <!-- Bone arms -->
+  <line x1="10" y1="16" x2="5" y2="22" stroke="#E8DCC8" stroke-width="2.5"/>
+  <line x1="22" y1="16" x2="27" y2="20" stroke="#E8DCC8" stroke-width="2.5"/>
+  <!-- Coin bag in right hand -->
+  <ellipse cx="27" cy="21" rx="2.5" ry="2.5" fill="#B8860B"/>
+</svg>

--- a/web/public/sprites/brass-sentry-1.svg
+++ b/web/public/sprites/brass-sentry-1.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect x="11" y="5" width="10" height="9" rx="2" fill="#B8860B"/>
+  <rect x="12" y="6" width="8" height="7" rx="1" fill="#DAA520"/>
+  <rect x="12" y="8" width="8" height="3" rx="1" fill="#333"/>
+  <rect x="13" y="9" width="6" height="1" fill="#FF4400" opacity="0.9"/>
+  <rect x="14" y="14" width="4" height="2" fill="#B8860B"/>
+  <rect x="10" y="15" width="12" height="9" rx="1" fill="#B8860B"/>
+  <rect x="11" y="16" width="10" height="7" fill="#DAA520"/>
+  <circle cx="13" cy="18" r="0.8" fill="#B8860B"/>
+  <circle cx="19" cy="18" r="0.8" fill="#B8860B"/>
+  <rect x="13" y="20" width="6" height="1.5" rx="0.5" fill="#B8860B"/>
+  <rect x="7"  y="15" width="4" height="5" rx="2" fill="#DAA520"/>
+  <rect x="21" y="15" width="4" height="5" rx="2" fill="#DAA520"/>
+  <!-- Arms stride A -->
+  <rect x="5"  y="20" width="3" height="7" rx="1" fill="#B8860B"/>
+  <rect x="24" y="20" width="3" height="7" rx="1" fill="#B8860B"/>
+  <line x1="26" y1="6" x2="26" y2="27" stroke="#888" stroke-width="1.5"/>
+  <polygon points="26,5 24,10 28,10" fill="#DAA520"/>
+  <rect x="10" y="24" width="12" height="2" fill="#8B6914"/>
+  <!-- Legs stride A: left forward -->
+  <rect x="9"  y="26" width="4" height="6" rx="1" fill="#B8860B"/>
+  <rect x="18" y="26" width="4" height="4" rx="1" fill="#B8860B"/>
+  <rect x="8"  y="30" width="6" height="2" rx="1" fill="#8B6914"/>
+  <rect x="18" y="28" width="5" height="2" rx="1" fill="#8B6914"/>
+</svg>

--- a/web/public/sprites/brass-sentry-2.svg
+++ b/web/public/sprites/brass-sentry-2.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Body 1px higher -->
+  <rect x="11" y="4" width="10" height="9" rx="2" fill="#B8860B"/>
+  <rect x="12" y="5" width="8" height="7" rx="1" fill="#DAA520"/>
+  <rect x="12" y="7" width="8" height="3" rx="1" fill="#333"/>
+  <rect x="13" y="8" width="6" height="1" fill="#FF4400" opacity="0.9"/>
+  <rect x="14" y="13" width="4" height="2" fill="#B8860B"/>
+  <rect x="10" y="14" width="12" height="9" rx="1" fill="#B8860B"/>
+  <rect x="11" y="15" width="10" height="7" fill="#DAA520"/>
+  <circle cx="13" cy="17" r="0.8" fill="#B8860B"/>
+  <circle cx="19" cy="17" r="0.8" fill="#B8860B"/>
+  <rect x="13" y="19" width="6" height="1.5" rx="0.5" fill="#B8860B"/>
+  <rect x="7"  y="14" width="4" height="5" rx="2" fill="#DAA520"/>
+  <rect x="21" y="14" width="4" height="5" rx="2" fill="#DAA520"/>
+  <rect x="6"  y="19" width="3" height="8" rx="1" fill="#B8860B"/>
+  <rect x="23" y="19" width="3" height="8" rx="1" fill="#B8860B"/>
+  <line x1="25" y1="5" x2="25" y2="27" stroke="#888" stroke-width="1.5"/>
+  <polygon points="25,4 23,9 27,9" fill="#DAA520"/>
+  <rect x="10" y="23" width="12" height="2" fill="#8B6914"/>
+  <!-- Legs together (mid) -->
+  <rect x="11" y="25" width="4" height="7" rx="1" fill="#B8860B"/>
+  <rect x="17" y="25" width="4" height="7" rx="1" fill="#B8860B"/>
+  <rect x="10" y="30" width="6" height="2" rx="1" fill="#8B6914"/>
+  <rect x="16" y="30" width="6" height="2" rx="1" fill="#8B6914"/>
+</svg>

--- a/web/public/sprites/brass-sentry-3.svg
+++ b/web/public/sprites/brass-sentry-3.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect x="11" y="5" width="10" height="9" rx="2" fill="#B8860B"/>
+  <rect x="12" y="6" width="8" height="7" rx="1" fill="#DAA520"/>
+  <rect x="12" y="8" width="8" height="3" rx="1" fill="#333"/>
+  <rect x="13" y="9" width="6" height="1" fill="#FF4400" opacity="0.9"/>
+  <rect x="14" y="14" width="4" height="2" fill="#B8860B"/>
+  <rect x="10" y="15" width="12" height="9" rx="1" fill="#B8860B"/>
+  <rect x="11" y="16" width="10" height="7" fill="#DAA520"/>
+  <circle cx="13" cy="18" r="0.8" fill="#B8860B"/>
+  <circle cx="19" cy="18" r="0.8" fill="#B8860B"/>
+  <rect x="13" y="20" width="6" height="1.5" rx="0.5" fill="#B8860B"/>
+  <rect x="7"  y="15" width="4" height="5" rx="2" fill="#DAA520"/>
+  <rect x="21" y="15" width="4" height="5" rx="2" fill="#DAA520"/>
+  <rect x="5"  y="20" width="3" height="7" rx="1" fill="#B8860B"/>
+  <rect x="24" y="20" width="3" height="7" rx="1" fill="#B8860B"/>
+  <line x1="26" y1="6" x2="26" y2="27" stroke="#888" stroke-width="1.5"/>
+  <polygon points="26,5 24,10 28,10" fill="#DAA520"/>
+  <rect x="10" y="24" width="12" height="2" fill="#8B6914"/>
+  <!-- Legs stride B: right forward -->
+  <rect x="11" y="26" width="4" height="4" rx="1" fill="#B8860B"/>
+  <rect x="18" y="26" width="4" height="6" rx="1" fill="#B8860B"/>
+  <rect x="11" y="28" width="5" height="2" rx="1" fill="#8B6914"/>
+  <rect x="17" y="30" width="6" height="2" rx="1" fill="#8B6914"/>
+</svg>

--- a/web/public/sprites/brass-sentry.svg
+++ b/web/public/sprites/brass-sentry.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Helm (angular) -->
+  <rect x="11" y="4" width="10" height="9" rx="2" fill="#B8860B"/>
+  <rect x="12" y="5" width="8" height="7" rx="1" fill="#DAA520"/>
+  <!-- Visor -->
+  <rect x="12" y="7" width="8" height="3" rx="1" fill="#333"/>
+  <!-- Glowing eye-slit -->
+  <rect x="13" y="8" width="6" height="1" fill="#FF4400" opacity="0.9"/>
+  <!-- Neck -->
+  <rect x="14" y="13" width="4" height="2" fill="#B8860B"/>
+  <!-- Body plate -->
+  <rect x="10" y="14" width="12" height="9" rx="1" fill="#B8860B"/>
+  <rect x="11" y="15" width="10" height="7" fill="#DAA520"/>
+  <!-- Chest rivet details -->
+  <circle cx="13" cy="17" r="0.8" fill="#B8860B"/>
+  <circle cx="19" cy="17" r="0.8" fill="#B8860B"/>
+  <rect x="13" y="19" width="6" height="1.5" rx="0.5" fill="#B8860B"/>
+  <!-- Shoulder guards -->
+  <rect x="7"  y="14" width="4" height="5" rx="2" fill="#DAA520"/>
+  <rect x="21" y="14" width="4" height="5" rx="2" fill="#DAA520"/>
+  <!-- Arms -->
+  <rect x="6"  y="19" width="3" height="8" rx="1" fill="#B8860B"/>
+  <rect x="23" y="19" width="3" height="8" rx="1" fill="#B8860B"/>
+  <!-- Spear (right hand) -->
+  <line x1="25" y1="5" x2="25" y2="27" stroke="#888" stroke-width="1.5"/>
+  <polygon points="25,4 23,9 27,9" fill="#DAA520"/>
+  <!-- Belt -->
+  <rect x="10" y="23" width="12" height="2" fill="#8B6914"/>
+  <!-- Legs -->
+  <rect x="11" y="25" width="4" height="7" rx="1" fill="#B8860B"/>
+  <rect x="17" y="25" width="4" height="7" rx="1" fill="#B8860B"/>
+  <!-- Heavy boots -->
+  <rect x="10" y="30" width="6" height="2" rx="1" fill="#8B6914"/>
+  <rect x="16" y="30" width="6" height="2" rx="1" fill="#8B6914"/>
+</svg>

--- a/web/public/sprites/canopy-archer-1.svg
+++ b/web/public/sprites/canopy-archer-1.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <path d="M10,10 Q16,3 22,10" fill="#2D6A2D"/>
+  <ellipse cx="16" cy="11" rx="5" ry="5" fill="#c8955a"/>
+  <circle cx="14" cy="10.5" r="0.8" fill="#333"/>
+  <circle cx="18" cy="10.5" r="0.8" fill="#333"/>
+  <path d="M11,16 L11,23 L21,23 L21,16 Q16,19 11,16 Z" fill="#2D6A2D"/>
+  <rect x="11" y="21" width="10" height="2" fill="#5C3A10"/>
+  <rect x="21" y="14" width="3" height="9" rx="1" fill="#5C3A10"/>
+  <line x1="22" y1="13" x2="22" y2="15" stroke="#DAA520" stroke-width="1"/>
+  <line x1="23.5" y1="13" x2="23.5" y2="15" stroke="#DAA520" stroke-width="1"/>
+  <path d="M5,9 Q1,16 5,23" stroke="#5C3A10" stroke-width="2" fill="none"/>
+  <line x1="5" y1="9" x2="5" y2="23" stroke="#D4C090" stroke-width="0.8"/>
+  <line x1="5" y1="16" x2="13" y2="16" stroke="#5C3A10" stroke-width="1.5"/>
+  <polygon points="13,16 11,14.5 11,17.5" fill="#CCBBAA"/>
+  <!-- Legs stride A: left forward -->
+  <rect x="9"  y="23" width="5" height="8" rx="1" fill="#1E4A1E"/>
+  <rect x="18" y="23" width="5" height="6" rx="1" fill="#1E4A1E"/>
+  <rect x="8"  y="29" width="7" height="3" rx="1" fill="#3A2010"/>
+  <rect x="18" y="27" width="6" height="3" rx="1" fill="#3A2010"/>
+</svg>

--- a/web/public/sprites/canopy-archer-2.svg
+++ b/web/public/sprites/canopy-archer-2.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Body 1px higher -->
+  <path d="M10,8 Q16,1 22,8" fill="#2D6A2D"/>
+  <ellipse cx="16" cy="9" rx="5" ry="5" fill="#c8955a"/>
+  <circle cx="14" cy="8.5" r="0.8" fill="#333"/>
+  <circle cx="18" cy="8.5" r="0.8" fill="#333"/>
+  <path d="M11,14 L11,21 L21,21 L21,14 Q16,17 11,14 Z" fill="#2D6A2D"/>
+  <rect x="11" y="19" width="10" height="2" fill="#5C3A10"/>
+  <rect x="21" y="12" width="3" height="9" rx="1" fill="#5C3A10"/>
+  <line x1="22" y1="11" x2="22" y2="13" stroke="#DAA520" stroke-width="1"/>
+  <line x1="23.5" y1="11" x2="23.5" y2="13" stroke="#DAA520" stroke-width="1"/>
+  <path d="M5,7 Q1,14 5,21" stroke="#5C3A10" stroke-width="2" fill="none"/>
+  <line x1="5" y1="7" x2="5" y2="21" stroke="#D4C090" stroke-width="0.8"/>
+  <line x1="5" y1="14" x2="13" y2="14" stroke="#5C3A10" stroke-width="1.5"/>
+  <polygon points="13,14 11,12.5 11,15.5" fill="#CCBBAA"/>
+  <!-- Legs together (mid-stride) -->
+  <rect x="11" y="21" width="5" height="9" rx="1" fill="#1E4A1E"/>
+  <rect x="17" y="21" width="5" height="9" rx="1" fill="#1E4A1E"/>
+  <rect x="10" y="28" width="7" height="3" rx="1" fill="#3A2010"/>
+  <rect x="16" y="28" width="7" height="3" rx="1" fill="#3A2010"/>
+</svg>

--- a/web/public/sprites/canopy-archer-3.svg
+++ b/web/public/sprites/canopy-archer-3.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <path d="M10,10 Q16,3 22,10" fill="#2D6A2D"/>
+  <ellipse cx="16" cy="11" rx="5" ry="5" fill="#c8955a"/>
+  <circle cx="14" cy="10.5" r="0.8" fill="#333"/>
+  <circle cx="18" cy="10.5" r="0.8" fill="#333"/>
+  <path d="M11,16 L11,23 L21,23 L21,16 Q16,19 11,16 Z" fill="#2D6A2D"/>
+  <rect x="11" y="21" width="10" height="2" fill="#5C3A10"/>
+  <rect x="21" y="14" width="3" height="9" rx="1" fill="#5C3A10"/>
+  <line x1="22" y1="13" x2="22" y2="15" stroke="#DAA520" stroke-width="1"/>
+  <line x1="23.5" y1="13" x2="23.5" y2="15" stroke="#DAA520" stroke-width="1"/>
+  <path d="M5,9 Q1,16 5,23" stroke="#5C3A10" stroke-width="2" fill="none"/>
+  <line x1="5" y1="9" x2="5" y2="23" stroke="#D4C090" stroke-width="0.8"/>
+  <line x1="5" y1="16" x2="13" y2="16" stroke="#5C3A10" stroke-width="1.5"/>
+  <polygon points="13,16 11,14.5 11,17.5" fill="#CCBBAA"/>
+  <!-- Legs stride B: right forward -->
+  <rect x="11" y="23" width="5" height="6" rx="1" fill="#1E4A1E"/>
+  <rect x="18" y="23" width="5" height="8" rx="1" fill="#1E4A1E"/>
+  <rect x="11" y="27" width="6" height="3" rx="1" fill="#3A2010"/>
+  <rect x="17" y="29" width="7" height="3" rx="1" fill="#3A2010"/>
+</svg>

--- a/web/public/sprites/canopy-archer.svg
+++ b/web/public/sprites/canopy-archer.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Green hood -->
+  <path d="M10,9 Q16,2 22,9" fill="#2D6A2D"/>
+  <!-- Head -->
+  <ellipse cx="16" cy="10" rx="5" ry="5" fill="#c8955a"/>
+  <!-- Eyes -->
+  <circle cx="14" cy="9.5" r="0.8" fill="#333"/>
+  <circle cx="18" cy="9.5" r="0.8" fill="#333"/>
+  <!-- Body (green tunic, torso only) -->
+  <path d="M11,15 L11,22 L21,22 L21,15 Q16,18 11,15 Z" fill="#2D6A2D"/>
+  <!-- Belt -->
+  <rect x="11" y="20" width="10" height="2" fill="#5C3A10"/>
+  <!-- Quiver -->
+  <rect x="21" y="13" width="3" height="9" rx="1" fill="#5C3A10"/>
+  <line x1="22" y1="12" x2="22" y2="14" stroke="#DAA520" stroke-width="1"/>
+  <line x1="23.5" y1="12" x2="23.5" y2="14" stroke="#DAA520" stroke-width="1"/>
+  <!-- Bow (left side) -->
+  <path d="M5,8 Q1,15 5,22" stroke="#5C3A10" stroke-width="2" fill="none"/>
+  <line x1="5" y1="8" x2="5" y2="22" stroke="#D4C090" stroke-width="0.8"/>
+  <!-- Arrow drawn -->
+  <line x1="5" y1="15" x2="13" y2="15" stroke="#5C3A10" stroke-width="1.5"/>
+  <polygon points="13,15 11,13.5 11,16.5" fill="#CCBBAA"/>
+  <!-- Legs together (static = frame 2) -->
+  <rect x="11" y="22" width="5" height="8" rx="1" fill="#1E4A1E"/>
+  <rect x="17" y="22" width="5" height="8" rx="1" fill="#1E4A1E"/>
+  <rect x="10" y="28" width="7" height="3" rx="1" fill="#3A2010"/>
+  <rect x="16" y="28" width="7" height="3" rx="1" fill="#3A2010"/>
+</svg>

--- a/web/public/sprites/canopy-drake-1.svg
+++ b/web/public/sprites/canopy-drake-1.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <path d="M7,22 Q3,20 2,16 Q3,14 5,15" stroke="#1A6B1A" stroke-width="3" fill="none" stroke-linecap="round"/>
+  <ellipse cx="16" cy="20" rx="8" ry="6" fill="#228B22"/>
+  <ellipse cx="16" cy="20" rx="6" ry="5" fill="#2EAA2E"/>
+  <path d="M11,18 Q13,16 15,18" stroke="#1A6B1A" stroke-width="0.8" fill="none"/>
+  <path d="M17,18 Q19,16 21,18" stroke="#1A6B1A" stroke-width="0.8" fill="none"/>
+  <path d="M12,21 Q14,19 16,21 Q18,19 20,21" stroke="#1A6B1A" stroke-width="0.8" fill="none"/>
+  <rect x="14" y="12" width="5" height="8" rx="2" fill="#228B22"/>
+  <ellipse cx="20" cy="11" rx="6" ry="4" fill="#228B22"/>
+  <path d="M24,10 L28,9 L28,13 L24,12 Z" fill="#1A6B1A"/>
+  <circle cx="27" cy="10" r="0.8" fill="#FFD700"/>
+  <circle cx="27" cy="10" r="0.4" fill="#333"/>
+  <path d="M21,8 L22,5 L23,8" fill="#556B2F"/>
+  <path d="M18,7 L19,4 L20,7" fill="#556B2F"/>
+  <!-- Wings — left raised, right lowered (stride A) -->
+  <path d="M13,14 Q6,6 4,10 Q8,15 13,18" fill="#1A6B1A" opacity="0.9"/>
+  <path d="M17,14 Q22,10 24,13 Q21,16 17,18" fill="#1A6B1A" opacity="0.7"/>
+  <!-- Legs stride A -->
+  <rect x="8"  y="24" width="4" height="7" rx="2" fill="#1A6B1A"/>
+  <rect x="19" y="24" width="4" height="5" rx="2" fill="#1A6B1A"/>
+  <path d="M8,31 L6,33 M10,31 L9,33 M12,31 L13,33" stroke="#556B2F" stroke-width="1"/>
+  <path d="M19,29 L18,31 M21,29 L21,31 M23,29 L24,31" stroke="#556B2F" stroke-width="1"/>
+</svg>

--- a/web/public/sprites/canopy-drake-2.svg
+++ b/web/public/sprites/canopy-drake-2.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Body 1px higher -->
+  <path d="M7,21 Q3,19 2,15 Q3,13 5,14" stroke="#1A6B1A" stroke-width="3" fill="none" stroke-linecap="round"/>
+  <ellipse cx="16" cy="19" rx="8" ry="6" fill="#228B22"/>
+  <ellipse cx="16" cy="19" rx="6" ry="5" fill="#2EAA2E"/>
+  <path d="M11,17 Q13,15 15,17" stroke="#1A6B1A" stroke-width="0.8" fill="none"/>
+  <path d="M17,17 Q19,15 21,17" stroke="#1A6B1A" stroke-width="0.8" fill="none"/>
+  <path d="M12,20 Q14,18 16,20 Q18,18 20,20" stroke="#1A6B1A" stroke-width="0.8" fill="none"/>
+  <rect x="14" y="11" width="5" height="8" rx="2" fill="#228B22"/>
+  <ellipse cx="20" cy="10" rx="6" ry="4" fill="#228B22"/>
+  <path d="M24,9 L28,8 L28,12 L24,11 Z" fill="#1A6B1A"/>
+  <circle cx="27" cy="9" r="0.8" fill="#FFD700"/>
+  <circle cx="27" cy="9" r="0.4" fill="#333"/>
+  <path d="M21,7 L22,4 L23,7" fill="#556B2F"/>
+  <path d="M18,6 L19,3 L20,6" fill="#556B2F"/>
+  <!-- Wings symmetric (mid-stride) -->
+  <path d="M13,13 Q7,7 5,11 Q9,14 13,17" fill="#1A6B1A" opacity="0.9"/>
+  <path d="M17,13 Q23,7 25,11 Q21,14 17,17" fill="#1A6B1A" opacity="0.9"/>
+  <!-- Legs together -->
+  <rect x="10" y="23" width="4" height="6" rx="2" fill="#1A6B1A"/>
+  <rect x="18" y="23" width="4" height="6" rx="2" fill="#1A6B1A"/>
+  <path d="M10,29 L8,31 M12,29 L11,31 M14,29 L15,31" stroke="#556B2F" stroke-width="1"/>
+  <path d="M18,29 L17,31 M20,29 L20,31 M22,29 L23,31" stroke="#556B2F" stroke-width="1"/>
+</svg>

--- a/web/public/sprites/canopy-drake-3.svg
+++ b/web/public/sprites/canopy-drake-3.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <path d="M7,22 Q3,20 2,16 Q3,14 5,15" stroke="#1A6B1A" stroke-width="3" fill="none" stroke-linecap="round"/>
+  <ellipse cx="16" cy="20" rx="8" ry="6" fill="#228B22"/>
+  <ellipse cx="16" cy="20" rx="6" ry="5" fill="#2EAA2E"/>
+  <path d="M11,18 Q13,16 15,18" stroke="#1A6B1A" stroke-width="0.8" fill="none"/>
+  <path d="M17,18 Q19,16 21,18" stroke="#1A6B1A" stroke-width="0.8" fill="none"/>
+  <path d="M12,21 Q14,19 16,21 Q18,19 20,21" stroke="#1A6B1A" stroke-width="0.8" fill="none"/>
+  <rect x="14" y="12" width="5" height="8" rx="2" fill="#228B22"/>
+  <ellipse cx="20" cy="11" rx="6" ry="4" fill="#228B22"/>
+  <path d="M24,10 L28,9 L28,13 L24,12 Z" fill="#1A6B1A"/>
+  <circle cx="27" cy="10" r="0.8" fill="#FFD700"/>
+  <circle cx="27" cy="10" r="0.4" fill="#333"/>
+  <path d="M21,8 L22,5 L23,8" fill="#556B2F"/>
+  <path d="M18,7 L19,4 L20,7" fill="#556B2F"/>
+  <!-- Wings — left lowered, right raised (stride B) -->
+  <path d="M13,14 Q7,10 5,13 Q9,16 13,18" fill="#1A6B1A" opacity="0.7"/>
+  <path d="M17,14 Q24,6 26,10 Q22,15 17,18" fill="#1A6B1A" opacity="0.9"/>
+  <!-- Legs stride B -->
+  <rect x="10" y="24" width="4" height="5" rx="2" fill="#1A6B1A"/>
+  <rect x="19" y="24" width="4" height="7" rx="2" fill="#1A6B1A"/>
+  <path d="M10,29 L9,31 M12,29 L11,31 M14,29 L15,31" stroke="#556B2F" stroke-width="1"/>
+  <path d="M19,31 L18,33 M21,31 L21,33 M23,31 L24,33" stroke="#556B2F" stroke-width="1"/>
+</svg>

--- a/web/public/sprites/canopy-drake.svg
+++ b/web/public/sprites/canopy-drake.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Tail -->
+  <path d="M7,22 Q3,20 2,16 Q3,14 5,15" stroke="#1A6B1A" stroke-width="3" fill="none" stroke-linecap="round"/>
+  <!-- Body -->
+  <ellipse cx="16" cy="20" rx="8" ry="6" fill="#228B22"/>
+  <ellipse cx="16" cy="20" rx="6" ry="5" fill="#2EAA2E"/>
+  <!-- Scale texture -->
+  <path d="M11,18 Q13,16 15,18" stroke="#1A6B1A" stroke-width="0.8" fill="none"/>
+  <path d="M17,18 Q19,16 21,18" stroke="#1A6B1A" stroke-width="0.8" fill="none"/>
+  <path d="M12,21 Q14,19 16,21 Q18,19 20,21" stroke="#1A6B1A" stroke-width="0.8" fill="none"/>
+  <!-- Neck -->
+  <rect x="14" y="12" width="5" height="8" rx="2" fill="#228B22"/>
+  <!-- Head -->
+  <ellipse cx="20" cy="11" rx="6" ry="4" fill="#228B22"/>
+  <!-- Snout -->
+  <path d="M24,10 L28,9 L28,13 L24,12 Z" fill="#1A6B1A"/>
+  <circle cx="27" cy="10" r="0.8" fill="#FFD700"/>
+  <circle cx="27" cy="10" r="0.4" fill="#333"/>
+  <!-- Horn -->
+  <path d="M21,8 L22,5 L23,8" fill="#556B2F"/>
+  <path d="M18,7 L19,4 L20,7" fill="#556B2F"/>
+  <!-- Wings (folded) -->
+  <path d="M13,14 Q8,8 6,12 Q9,15 13,18" fill="#1A6B1A" opacity="0.9"/>
+  <path d="M17,14 Q22,8 24,12 Q21,15 17,18" fill="#1A6B1A" opacity="0.9"/>
+  <!-- Legs -->
+  <rect x="10" y="24" width="4" height="6" rx="2" fill="#1A6B1A"/>
+  <rect x="18" y="24" width="4" height="6" rx="2" fill="#1A6B1A"/>
+  <!-- Claws -->
+  <path d="M10,30 L8,32 M12,30 L11,32 M14,30 L15,32" stroke="#556B2F" stroke-width="1"/>
+  <path d="M18,30 L17,32 M20,30 L20,32 M22,30 L23,32" stroke="#556B2F" stroke-width="1"/>
+</svg>

--- a/web/public/sprites/canopy-scout-1.svg
+++ b/web/public/sprites/canopy-scout-1.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <path d="M12,10 Q16,3 20,10" fill="#556B2F"/>
+  <ellipse cx="16" cy="11" rx="4.5" ry="4.5" fill="#c8a070"/>
+  <circle cx="14" cy="10.5" r="0.7" fill="#333"/>
+  <circle cx="18" cy="10.5" r="0.7" fill="#333"/>
+  <path d="M12,16 L12,23 L20,23 L20,16 Q16,18 12,16 Z" fill="#6B7A3A"/>
+  <line x1="12" y1="16" x2="20" y2="23" stroke="#4A5220" stroke-width="1"/>
+  <line x1="20" y1="16" x2="12" y2="23" stroke="#4A5220" stroke-width="1"/>
+  <rect x="12" y="21" width="8" height="1.5" fill="#4A3A18"/>
+  <rect x="9" y="20" width="1.5" height="5" rx="0.5" fill="#888"/>
+  <rect x="8.5" y="18" width="2.5" height="3" rx="0.5" fill="#5C3A10"/>
+  <!-- Legs stride A: left forward -->
+  <rect x="10" y="23" width="4" height="8" rx="1" fill="#4A5220"/>
+  <rect x="17" y="23" width="4" height="6" rx="1" fill="#4A5220"/>
+  <rect x="9"  y="29" width="6" height="3" rx="1" fill="#2A2A10"/>
+  <rect x="17" y="27" width="5" height="3" rx="1" fill="#2A2A10"/>
+</svg>

--- a/web/public/sprites/canopy-scout-2.svg
+++ b/web/public/sprites/canopy-scout-2.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Body 1px higher -->
+  <path d="M12,8 Q16,1 20,8" fill="#556B2F"/>
+  <ellipse cx="16" cy="9" rx="4.5" ry="4.5" fill="#c8a070"/>
+  <circle cx="14" cy="8.5" r="0.7" fill="#333"/>
+  <circle cx="18" cy="8.5" r="0.7" fill="#333"/>
+  <path d="M12,14 L12,21 L20,21 L20,14 Q16,16 12,14 Z" fill="#6B7A3A"/>
+  <line x1="12" y1="14" x2="20" y2="21" stroke="#4A5220" stroke-width="1"/>
+  <line x1="20" y1="14" x2="12" y2="21" stroke="#4A5220" stroke-width="1"/>
+  <rect x="12" y="19" width="8" height="1.5" fill="#4A3A18"/>
+  <rect x="9" y="18" width="1.5" height="5" rx="0.5" fill="#888"/>
+  <rect x="8.5" y="16" width="2.5" height="3" rx="0.5" fill="#5C3A10"/>
+  <!-- Legs together (mid-stride) -->
+  <rect x="12" y="21" width="4" height="9" rx="1" fill="#4A5220"/>
+  <rect x="17" y="21" width="4" height="9" rx="1" fill="#4A5220"/>
+  <rect x="11" y="28" width="6" height="3" rx="1" fill="#2A2A10"/>
+  <rect x="16" y="28" width="6" height="3" rx="1" fill="#2A2A10"/>
+</svg>

--- a/web/public/sprites/canopy-scout-3.svg
+++ b/web/public/sprites/canopy-scout-3.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <path d="M12,10 Q16,3 20,10" fill="#556B2F"/>
+  <ellipse cx="16" cy="11" rx="4.5" ry="4.5" fill="#c8a070"/>
+  <circle cx="14" cy="10.5" r="0.7" fill="#333"/>
+  <circle cx="18" cy="10.5" r="0.7" fill="#333"/>
+  <path d="M12,16 L12,23 L20,23 L20,16 Q16,18 12,16 Z" fill="#6B7A3A"/>
+  <line x1="12" y1="16" x2="20" y2="23" stroke="#4A5220" stroke-width="1"/>
+  <line x1="20" y1="16" x2="12" y2="23" stroke="#4A5220" stroke-width="1"/>
+  <rect x="12" y="21" width="8" height="1.5" fill="#4A3A18"/>
+  <rect x="9" y="20" width="1.5" height="5" rx="0.5" fill="#888"/>
+  <rect x="8.5" y="18" width="2.5" height="3" rx="0.5" fill="#5C3A10"/>
+  <!-- Legs stride B: right forward -->
+  <rect x="12" y="23" width="4" height="6" rx="1" fill="#4A5220"/>
+  <rect x="17" y="23" width="4" height="8" rx="1" fill="#4A5220"/>
+  <rect x="12" y="27" width="5" height="3" rx="1" fill="#2A2A10"/>
+  <rect x="16" y="29" width="6" height="3" rx="1" fill="#2A2A10"/>
+</svg>

--- a/web/public/sprites/canopy-scout.svg
+++ b/web/public/sprites/canopy-scout.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Leaf-tip hood -->
+  <path d="M12,9 Q16,2 20,9" fill="#556B2F"/>
+  <!-- Head -->
+  <ellipse cx="16" cy="10" rx="4.5" ry="4.5" fill="#c8a070"/>
+  <circle cx="14" cy="9.5" r="0.7" fill="#333"/>
+  <circle cx="18" cy="9.5" r="0.7" fill="#333"/>
+  <!-- Light leather body -->
+  <path d="M12,15 L12,22 L20,22 L20,15 Q16,17 12,15 Z" fill="#6B7A3A"/>
+  <!-- Crossed chest straps -->
+  <line x1="12" y1="15" x2="20" y2="22" stroke="#4A5220" stroke-width="1"/>
+  <line x1="20" y1="15" x2="12" y2="22" stroke="#4A5220" stroke-width="1"/>
+  <!-- Belt -->
+  <rect x="12" y="20" width="8" height="1.5" fill="#4A3A18"/>
+  <!-- Dagger (left hip) -->
+  <rect x="9" y="19" width="1.5" height="5" rx="0.5" fill="#888"/>
+  <rect x="8.5" y="17" width="2.5" height="3" rx="0.5" fill="#5C3A10"/>
+  <!-- Legs together (static = frame 2) -->
+  <rect x="12" y="22" width="4" height="8" rx="1" fill="#4A5220"/>
+  <rect x="17" y="22" width="4" height="8" rx="1" fill="#4A5220"/>
+  <rect x="11" y="28" width="6" height="3" rx="1" fill="#2A2A10"/>
+  <rect x="16" y="28" width="6" height="3" rx="1" fill="#2A2A10"/>
+</svg>

--- a/web/public/sprites/cinderwarlord-1.svg
+++ b/web/public/sprites/cinderwarlord-1.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect x="10" y="6" width="12" height="8" rx="2" fill="#1A0A0A"/>
+  <rect x="11" y="7" width="10" height="6" rx="1" fill="#3A1010"/>
+  <path d="M11,7 L8,3 L13,8" fill="#CC2200"/>
+  <path d="M21,7 L24,3 L19,8" fill="#CC2200"/>
+  <rect x="12" y="9" width="8" height="2" rx="1" fill="#FF4400"/>
+  <path d="M9,8 Q5,5 7,10" stroke="#FF6600" stroke-width="1.5" fill="none" opacity="0.7"/>
+  <path d="M23,8 Q27,5 25,10" stroke="#FF6600" stroke-width="1.5" fill="none" opacity="0.7"/>
+  <rect x="9" y="14" width="14" height="10" rx="2" fill="#2A0A0A"/>
+  <rect x="10" y="15" width="12" height="8" fill="#3A1010"/>
+  <path d="M16,16 Q14,19 15,21 Q16,18 17,21 Q18,19 16,16" fill="#FF4400"/>
+  <rect x="5"  y="14" width="5" height="6" rx="2" fill="#CC2200"/>
+  <rect x="22" y="14" width="5" height="6" rx="2" fill="#CC2200"/>
+  <!-- Arms stride A -->
+  <rect x="4"  y="20" width="4" height="7" rx="1" fill="#2A0A0A"/>
+  <rect x="24" y="20" width="4" height="7" rx="1" fill="#2A0A0A"/>
+  <rect x="2"  y="7" width="2" height="22" rx="0.5" fill="#888"/>
+  <rect x="1.5" y="7" width="3" height="1" fill="#555"/>
+  <path d="M2,7 Q0,4 3,5 Q4,3 3,7" fill="#FF4400" opacity="0.9"/>
+  <rect x="9" y="24" width="14" height="2" fill="#5C1010"/>
+  <!-- Legs stride A: left forward -->
+  <rect x="8"  y="26" width="5" height="6" rx="1" fill="#2A0A0A"/>
+  <rect x="18" y="26" width="5" height="4" rx="1" fill="#2A0A0A"/>
+  <rect x="7"  y="30" width="7" height="2" rx="1" fill="#1A0000"/>
+  <rect x="18" y="28" width="6" height="2" rx="1" fill="#1A0000"/>
+</svg>

--- a/web/public/sprites/cinderwarlord-2.svg
+++ b/web/public/sprites/cinderwarlord-2.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Body 1px higher -->
+  <rect x="10" y="4" width="12" height="8" rx="2" fill="#1A0A0A"/>
+  <rect x="11" y="5" width="10" height="6" rx="1" fill="#3A1010"/>
+  <path d="M11,5 L8,1 L13,6" fill="#CC2200"/>
+  <path d="M21,5 L24,1 L19,6" fill="#CC2200"/>
+  <rect x="12" y="7" width="8" height="2" rx="1" fill="#FF4400"/>
+  <path d="M9,6 Q5,3 7,8" stroke="#FF6600" stroke-width="1.5" fill="none" opacity="0.7"/>
+  <path d="M23,6 Q27,3 25,8" stroke="#FF6600" stroke-width="1.5" fill="none" opacity="0.7"/>
+  <rect x="9" y="12" width="14" height="10" rx="2" fill="#2A0A0A"/>
+  <rect x="10" y="13" width="12" height="8" fill="#3A1010"/>
+  <path d="M16,14 Q14,17 15,19 Q16,16 17,19 Q18,17 16,14" fill="#FF4400"/>
+  <rect x="5"  y="12" width="5" height="6" rx="2" fill="#CC2200"/>
+  <rect x="22" y="12" width="5" height="6" rx="2" fill="#CC2200"/>
+  <rect x="5"  y="18" width="4" height="8" rx="1" fill="#2A0A0A"/>
+  <rect x="23" y="18" width="4" height="8" rx="1" fill="#2A0A0A"/>
+  <rect x="2"  y="5" width="2" height="22" rx="0.5" fill="#888"/>
+  <rect x="1.5" y="5" width="3" height="1" fill="#555"/>
+  <path d="M2,5 Q0,2 3,3 Q4,1 3,5" fill="#FF4400" opacity="0.9"/>
+  <path d="M3,5 Q5,2 3,3" fill="#FF6600" opacity="0.7"/>
+  <rect x="9" y="22" width="14" height="2" fill="#5C1010"/>
+  <!-- Legs together -->
+  <rect x="10" y="24" width="5" height="8" rx="1" fill="#2A0A0A"/>
+  <rect x="17" y="24" width="5" height="8" rx="1" fill="#2A0A0A"/>
+  <rect x="9"  y="30" width="7" height="2" rx="1" fill="#1A0000"/>
+  <rect x="16" y="30" width="7" height="2" rx="1" fill="#1A0000"/>
+</svg>

--- a/web/public/sprites/cinderwarlord-3.svg
+++ b/web/public/sprites/cinderwarlord-3.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect x="10" y="6" width="12" height="8" rx="2" fill="#1A0A0A"/>
+  <rect x="11" y="7" width="10" height="6" rx="1" fill="#3A1010"/>
+  <path d="M11,7 L8,3 L13,8" fill="#CC2200"/>
+  <path d="M21,7 L24,3 L19,8" fill="#CC2200"/>
+  <rect x="12" y="9" width="8" height="2" rx="1" fill="#FF4400"/>
+  <path d="M9,8 Q5,5 7,10" stroke="#FF6600" stroke-width="1.5" fill="none" opacity="0.7"/>
+  <path d="M23,8 Q27,5 25,10" stroke="#FF6600" stroke-width="1.5" fill="none" opacity="0.7"/>
+  <rect x="9" y="14" width="14" height="10" rx="2" fill="#2A0A0A"/>
+  <rect x="10" y="15" width="12" height="8" fill="#3A1010"/>
+  <path d="M16,16 Q14,19 15,21 Q16,18 17,21 Q18,19 16,16" fill="#FF4400"/>
+  <rect x="5"  y="14" width="5" height="6" rx="2" fill="#CC2200"/>
+  <rect x="22" y="14" width="5" height="6" rx="2" fill="#CC2200"/>
+  <rect x="4"  y="20" width="4" height="7" rx="1" fill="#2A0A0A"/>
+  <rect x="24" y="20" width="4" height="7" rx="1" fill="#2A0A0A"/>
+  <rect x="2"  y="7" width="2" height="22" rx="0.5" fill="#888"/>
+  <rect x="1.5" y="7" width="3" height="1" fill="#555"/>
+  <path d="M2,7 Q0,4 3,5 Q4,3 3,7" fill="#FF4400" opacity="0.9"/>
+  <rect x="9" y="24" width="14" height="2" fill="#5C1010"/>
+  <!-- Legs stride B: right forward -->
+  <rect x="10" y="26" width="5" height="4" rx="1" fill="#2A0A0A"/>
+  <rect x="18" y="26" width="5" height="6" rx="1" fill="#2A0A0A"/>
+  <rect x="10" y="28" width="6" height="2" rx="1" fill="#1A0000"/>
+  <rect x="17" y="30" width="7" height="2" rx="1" fill="#1A0000"/>
+</svg>

--- a/web/public/sprites/cinderwarlord.svg
+++ b/web/public/sprites/cinderwarlord.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Horned helm -->
+  <rect x="10" y="5" width="12" height="8" rx="2" fill="#1A0A0A"/>
+  <rect x="11" y="6" width="10" height="6" rx="1" fill="#3A1010"/>
+  <!-- Horns -->
+  <path d="M11,6 L8,2 L13,7" fill="#CC2200"/>
+  <path d="M21,6 L24,2 L19,7" fill="#CC2200"/>
+  <!-- Eye slit glowing orange -->
+  <rect x="12" y="8" width="8" height="2" rx="1" fill="#FF4400"/>
+  <!-- Flame glow around head -->
+  <path d="M9,7 Q5,4 7,9" stroke="#FF6600" stroke-width="1.5" fill="none" opacity="0.7"/>
+  <path d="M23,7 Q27,4 25,9" stroke="#FF6600" stroke-width="1.5" fill="none" opacity="0.7"/>
+  <!-- Heavy armoured body -->
+  <rect x="9" y="13" width="14" height="10" rx="2" fill="#2A0A0A"/>
+  <rect x="10" y="14" width="12" height="8" fill="#3A1010"/>
+  <!-- Chest fire emblem -->
+  <path d="M16,15 Q14,18 15,20 Q16,17 17,20 Q18,18 16,15" fill="#FF4400"/>
+  <!-- Shoulder plates -->
+  <rect x="5"  y="13" width="5" height="6" rx="2" fill="#CC2200"/>
+  <rect x="22" y="13" width="5" height="6" rx="2" fill="#CC2200"/>
+  <!-- Arms -->
+  <rect x="5"  y="19" width="4" height="8" rx="1" fill="#2A0A0A"/>
+  <rect x="23" y="19" width="4" height="8" rx="1" fill="#2A0A0A"/>
+  <!-- Flaming greatsword -->
+  <rect x="2"  y="6" width="2" height="22" rx="0.5" fill="#888"/>
+  <rect x="1.5" y="6" width="3" height="1" fill="#555"/>
+  <path d="M2,6 Q0,3 3,4 Q4,2 3,6" fill="#FF4400" opacity="0.9"/>
+  <path d="M3,6 Q5,3 3,4" fill="#FF6600" opacity="0.7"/>
+  <!-- Belt -->
+  <rect x="9" y="23" width="14" height="2" fill="#5C1010"/>
+  <!-- Legs (static = frame 2) -->
+  <rect x="10" y="25" width="5" height="7" rx="1" fill="#2A0A0A"/>
+  <rect x="17" y="25" width="5" height="7" rx="1" fill="#2A0A0A"/>
+  <rect x="9"  y="30" width="7" height="2" rx="1" fill="#1A0000"/>
+  <rect x="16" y="30" width="7" height="2" rx="1" fill="#1A0000"/>
+</svg>


### PR DESCRIPTION
Adds 40 SVG sprite files (10 units × 4 walk frames each) for Batch 1.

## Cards
| Unit | Files |
|---|---|
| Air Sprite | `air-sprite.svg` + frames 1–3 |
| Ancient Sprite | `ancient-sprite.svg` + frames 1–3 |
| Ancient Treant | `ancient-treant.svg` + frames 1–3 |
| Bark Hound | `bark-hound.svg` + frames 1–3 |
| Bone Merchant | `bone-merchant.svg` + frames 1–3 |
| Brass Sentry | `brass-sentry.svg` + frames 1–3 |
| Canopy Archer | `canopy-archer.svg` + frames 1–3 |
| Canopy Drake | `canopy-drake.svg` + frames 1–3 |
| Canopy Scout | `canopy-scout.svg` + frames 1–3 |
| Cinderwarlord | `cinderwarlord.svg` + frames 1–3 |

Closes #601