### PR TITLE
feat(cardrest): show already-resting cards with deck update prompt

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2288,6 +2288,7 @@ export default function App() {
         <CardRestSelect
           candidates={cardRestCandidates}
           playCounts={cardRestPlayCounts}
+          alreadyResting={fatiguedCards}
           onConfirm={handleCardRestConfirm}
         />
       )}

--- a/web/src/components/CardRestSelect.tsx
+++ b/web/src/components/CardRestSelect.tsx
@@ -5,10 +5,12 @@ interface Props {
   candidates: string[]
   /** Plays-per-card for display (keyed by name). */
   playCounts: Record<string, number>
+  /** Cards already resting from previous acts — shown as informational. */
+  alreadyResting?: string[]
   onConfirm: (resting: string[]) => void
 }
 
-export function CardRestSelect({ candidates, playCounts, onConfirm }: Props) {
+export function CardRestSelect({ candidates, playCounts, alreadyResting = [], onConfirm }: Props) {
   const required = Math.min(2, candidates.length)
   // Pre-select the top `required` candidates
   const [selected, setSelected] = useState<Set<string>>(
@@ -36,6 +38,20 @@ export function CardRestSelect({ candidates, playCounts, onConfirm }: Props) {
           They will be unavailable in your deck until the act after.
         </div>
       </div>
+
+      {alreadyResting.length > 0 && (
+        <div className="card-rest-already">
+          <div className="card-rest-already-label">ALREADY RESTING</div>
+          <div className="card-rest-already-list">
+            {alreadyResting.map(name => (
+              <span key={name} className="card-rest-already-item">[ZZZ] {name}</span>
+            ))}
+          </div>
+          <div className="card-rest-already-note">
+            These cards are still unavailable — update your deck before the next act.
+          </div>
+        </div>
+      )}
 
       <div className="card-rest-candidates">
         {candidates.map((name, i) => {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4764,6 +4764,45 @@ body {
   line-height: 1.7;
 }
 
+.card-rest-already {
+  border: 1px solid #333;
+  border-radius: 4px;
+  padding: 10px 14px;
+  margin-bottom: 16px;
+  background: #111;
+  width: 100%;
+  max-width: 560px;
+}
+
+.card-rest-already-label {
+  font-size: 10px;
+  color: #555;
+  letter-spacing: 0.1em;
+  margin-bottom: 6px;
+}
+
+.card-rest-already-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+
+.card-rest-already-item {
+  font-size: 11px;
+  color: #888;
+  background: #1a1a1a;
+  border: 1px solid #333;
+  padding: 2px 8px;
+  border-radius: 3px;
+}
+
+.card-rest-already-note {
+  font-size: 10px;
+  color: #555;
+  font-style: italic;
+}
+
 .card-rest-candidates {
   display: flex;
   gap: 16px;


### PR DESCRIPTION
- CardRestSelect: add alreadyResting prop; renders a panel listing
  cards still unavailable from previous acts with a note to update deck
- App.tsx: pass fatiguedCards as alreadyResting to CardRestSelect
- styles.css: add card-rest-already block styles