### PR TITLE
fix(daily-challenge): show local reset time to clarify UTC midnight boundary

### DIFF
--- a/web/src/components/DailyChallengeScreen.tsx
+++ b/web/src/components/DailyChallengeScreen.tsx
@@ -6,6 +6,16 @@ interface Props {
   onBack: () => void
 }
 
+function getResetTimeLocal(): string {
+  const now = new Date()
+  const nextMidnightUTC = new Date(Date.UTC(
+    now.getUTCFullYear(),
+    now.getUTCMonth(),
+    now.getUTCDate() + 1,
+  ))
+  return nextMidnightUTC.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' })
+}
+
 export function DailyChallengeScreen({ onStart, onBack }: Props) {
   const state   = getDailyChallengeState()
   const deck    = getDailyPlayerDeck()
@@ -31,6 +41,7 @@ export function DailyChallengeScreen({ onStart, onBack }: Props) {
       <div className="dc-header">
         <div className="dc-label">DAILY CHALLENGE</div>
         <div className="dc-date">{today}</div>
+        <div className="dc-reset-time">Resets at {getResetTimeLocal()}</div>
       </div>
 
       <div className="dc-rule">

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -6862,6 +6862,11 @@ html.eightbit-mode .lane-layer {
   color: var(--game-text-color-muted);
   margin-top: 4px;
 }
+.dc-reset-time {
+  font-size: 0.7rem;
+  opacity: 0.5;
+  letter-spacing: 0.05em;
+}
 .dc-rule {
   font-size: 12px;
   color: var(--game-text-color-muted);


### PR DESCRIPTION
Players in UTC+ timezones (e.g. BST) saw yesterday's attempt count
carry over until 1 AM local time because getDailyDate() uses UTC.
No behaviour change — adds a subtle "Resets at HH:MM" label on the
Daily Challenge screen so players know exactly when the count resets.

https://claude.ai/code/session_01RDn5THkYZBikyWG6bjYiAF