### PR TITLE
fix: reload commander state from localStorage when leaving commander screen

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2375,7 +2375,7 @@ export default function App() {
       {screen === 'commander' && commander && (
         <CommanderScreen
           commander={commander}
-          onBack={() => setScreen('title')}
+          onBack={() => { setCommander(loadCommander()); setScreen('title') }}
           onRewardXp={(cardName, amount) => {
             const col = loadCollection()
             const updated = col.map(e =>


### PR DESCRIPTION
App.tsx's `commander` state was not updated when interactions happened inside
CommanderScreen (only localStorage was written). On re-entry the stale prop
caused cooldowns to re-initialise from pre-interaction timestamps, making
timeouts appear reset.

https://claude.ai/code/session_01WrchAiBCJRusg9b67hWb1H