### PR TITLE
Replace "Skip Reward" with "Continue" that auto-claims a random card

### DIFF
--- a/web/src/components/PostBattleReward.tsx
+++ b/web/src/components/PostBattleReward.tsx
@@ -85,8 +85,15 @@ export function PostBattleReward({ choices, nodeType, crystals, onPick, onSkip, 
       </div>
 
       {allFlipped && !picked && (
-        <button className="action-btn reward-skip-btn" onClick={onSkip}>
-          SKIP REWARD
+        <button className="action-btn reward-skip-btn" onClick={() => {
+          if (choices.length > 0) {
+            const randomCard = choices[Math.floor(Math.random() * choices.length)]
+            handlePick(randomCard)
+          } else {
+            onSkip()
+          }
+        }}>
+          Continue
         </button>
       )}
     </div>


### PR DESCRIPTION
The old "SKIP REWARD" button was easy to accidentally press and would
forfeit the reward entirely. The new "Continue" button picks a random
card from the available choices before advancing, so the player always
claims their reward.

https://claude.ai/code/session_01XqJFgKxHF59QRsfSjRpiTr