### PR TITLE
Fix support/buff cards doing nothing when played (#647)

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -4312,6 +4312,102 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "node_modules/@vitest/browser-playwright/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/@vitest/browser-playwright/node_modules/vite": {
+      "version": "8.0.8",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
+      "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.8",
+        "rolldown": "1.0.0-rc.15",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/browser/node_modules/@vitest/mocker": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.3.tgz",
@@ -4357,6 +4453,102 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/browser/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/@vitest/browser/node_modules/vite": {
+      "version": "8.0.8",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
+      "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.8",
+        "rolldown": "1.0.0-rc.15",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
       }
     },
     "node_modules/@vitest/coverage-v8": {

--- a/web/src/game/engine.ts
+++ b/web/src/game/engine.ts
@@ -560,6 +560,29 @@ function applyUpgrade(s: GameState, effect: UpgradeEffect, owner: 'player' | 'op
   } else if (effect.type === 'buffRange') {
     for (const u of units) if (u.attackRange > 0) { u.attackRange += effect.amount; addBuff(u, 'range') }
     log.push(`${label} units gain +${effect.amount} attack range!`)
+  } else if (effect.type === 'aoe') {
+    const dmg = effect.damage ?? effect.amount ?? 0
+    const enemies = s.field.filter(u => u.owner !== owner && !u.isWall)
+    const targets = effect.range != null
+      ? enemies.filter(e =>
+          owner === 'player'
+            ? e.x <= effect.range!
+            : (LANE_WIDTH - e.x) <= effect.range!)
+      : enemies
+    for (const u of targets) {
+      u.hp -= dmg
+      u.damageFlashTimer = 200
+    }
+    log.push(`${label} AOE! ${targets.length} enem${targets.length === 1 ? 'y' : 'ies'} hit for ${dmg} damage.`)
+  } else if (effect.type === 'buffHp') {
+    for (const u of units) u.hp = Math.min(u.maxHp, u.hp + effect.amount)
+    log.push(`${label} units gain +${effect.amount} HP!`)
+  } else if (effect.type === 'buffAttackCooldown') {
+    for (const u of units) u.attackCooldownMs = Math.max(500, u.attackCooldownMs + effect.amount)
+    log.push(`${label} units attack ${effect.amount < 0 ? 'faster' : 'slower'}!`)
+  } else if (effect.type === 'buffHeal') {
+    for (const u of units) u.hp = Math.min(u.maxHp, u.hp + effect.amount)
+    log.push(`${label} units healed for ${effect.amount} HP.`)
   }
 }
 

--- a/web/src/game/types.ts
+++ b/web/src/game/types.ts
@@ -12,9 +12,13 @@ export type StructureEffect =
 export type UpgradeEffect =
   | { type: 'buffAttack'; amount: number }
   | { type: 'healUnits';  amount: number }
-  | { type: 'buffSpeed';  amount: number }   // adds to moveSpeed of all mobile units
-  | { type: 'buffMaxHp';  amount: number }   // increases maxHp and heals by same amount
-  | { type: 'buffRange';  amount: number }   // increases attackRange of all attacking units
+  | { type: 'buffSpeed';  amount: number }         // adds to moveSpeed of all mobile units
+  | { type: 'buffMaxHp';  amount: number }         // increases maxHp and heals by same amount
+  | { type: 'buffRange';  amount: number }         // increases attackRange of all attacking units
+  | { type: 'aoe'; damage?: number; range?: number; amount?: number }  // AOE damage: range-limited or global
+  | { type: 'buffHp'; amount: number }             // increases current HP of all friendly units (not maxHp)
+  | { type: 'buffAttackCooldown'; amount: number } // adjusts attackCooldownMs for all friendly units (negative = faster)
+  | { type: 'buffHeal'; amount: number }           // one-time heal of all friendly units
 
 // ─── Cards ───────────────────────────────────────────────
 


### PR DESCRIPTION
Add missing UpgradeEffect types (aoe, buffHp, buffAttackCooldown, buffHeal)
to the type union in types.ts and implement their handlers in applyUpgrade()
in engine.ts. Cards like Maelstrom, Root Surge, Vault Burst, and Overload
were silently no-ops because the engine had no branch for their effect types.

https://claude.ai/code/session_01Fd8Jws7Gnw6eU8hnf3rj4F