### PR TITLE
Fix deck builder search height and card detail modal issues

### DIFF
--- a/web/src/components/ModalBackdrop.tsx
+++ b/web/src/components/ModalBackdrop.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import ReactDOM from 'react-dom'
 
 interface Props {
   onClose: () => void
@@ -7,7 +8,7 @@ interface Props {
 }
 
 export function ModalBackdrop({ onClose, children, zIndex }: Props) {
-  return (
+  return ReactDOM.createPortal(
     <div
       className="modal-backdrop"
       style={zIndex !== undefined ? { zIndex } : undefined}
@@ -16,6 +17,7 @@ export function ModalBackdrop({ onClose, children, zIndex }: Props) {
       <div onClick={e => e.stopPropagation()}>
         {children}
       </div>
-    </div>
+    </div>,
+    document.body
   )
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2288,7 +2288,6 @@ body {
 .deckbuilder-search-wrap {
   padding: 6px 8px 4px;
   flex-shrink: 0;
-  flex: 1;
   display: flex;
   flex-direction: row;
 }
@@ -7448,9 +7447,8 @@ html.light-mode body {
   background: var(--game-bg);
 }
 
-/* Overlay screens and modals */
-html.light-mode .overlay-screen,
-html.light-mode .modal-backdrop {
+/* Overlay screens */
+html.light-mode .overlay-screen {
   background: var(--game-bg);
 }
 


### PR DESCRIPTION
- Remove flex:1 from .deckbuilder-search-wrap so the search input
  renders as a fixed-height row instead of expanding to ~25% of the screen
- Render ModalBackdrop via ReactDOM.createPortal to document.body,
  fixing the modal appearing off-screen and uncloseable (caused by
  position:fixed being contained by .overlay-screen's fadeIn transform)
- Remove .modal-backdrop from the light-mode background override so the
  dim backdrop is visible in light mode instead of blending into the bg

https://claude.ai/code/session_01C9TEuBbogqB2LxXJrghXMU