### PR TITLE
Reset fatigued units and bonus pack cards when abandoning a campaign

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1731,6 +1731,9 @@ export default function App() {
   const handleAbandonRun = useCallback(() => {
     clearRun()
     setRun(null)
+    clearFatigued()
+    setFatiguedCards([])
+    setBonusPackCards([])
     setScreen('title')
   }, [])
 


### PR DESCRIPTION
Abandoning a run now calls clearFatigued()/setFatiguedCards([])/setBonusPackCards([])
alongside clearRun(), matching the behaviour of the defeat (all-lives-lost) path so
the player starts a fresh campaign with their full card pool available.

https://claude.ai/code/session_0183R7EAC5WcEMosxMDvijVn