### PR TITLE
refactor(campaign): derive parentIds from childIds; remove redundant parentIds

### DIFF
--- a/web/src/components/CampaignAdminScreen.tsx
+++ b/web/src/components/CampaignAdminScreen.tsx
@@ -220,8 +220,7 @@ export function CampaignAdminScreen({ onBack }: Props) {
       if (key === oldId) continue
       updatedNodes[key] = {
         ...n,
-        parentIds: n.parentIds.map(id => id === oldId ? newId : id),
-        childIds:  n.childIds.map(id => id === oldId ? newId : id),
+        childIds: n.childIds.map(id => id === oldId ? newId : id),
       }
     }
     updatedNodes[newId] = { ...act.nodes[oldId], id: newId }
@@ -243,7 +242,7 @@ export function CampaignAdminScreen({ onBack }: Props) {
     const newId = `node-${Date.now()}`
     const newNode: QuestNode = {
       id: newId, type: 'battle', label: 'New Node', description: '',
-      row: maxRow, col: 0, rowCols: 1, parentIds: [], childIds: [],
+      row: maxRow, col: 0, rowCols: 1, childIds: [],
     }
     const updated = recalculateCols({ ...act.nodes, [newId]: newNode })
     setAct(prev => ({ ...prev, nodes: updated }))
@@ -255,8 +254,7 @@ export function CampaignAdminScreen({ onBack }: Props) {
     const cleaned: Record<string, QuestNode> = Object.fromEntries(
       (Object.entries(rest) as [string, QuestNode][]).map(([k, n]) => [k, {
         ...n,
-        parentIds: n.parentIds.filter(id => id !== nodeId),
-        childIds:  n.childIds.filter(id => id !== nodeId),
+        childIds: n.childIds.filter(id => id !== nodeId),
       }])
     )
     const updated = recalculateCols(cleaned)
@@ -317,7 +315,7 @@ export function CampaignAdminScreen({ onBack }: Props) {
       color: '#ff5555',
       marginTop: '8px',
     }}>
-      Cycle detected — node <strong>{cycleNodeId}</strong> is part of a loop. Fix childIds/parentIds before downloading.
+      Cycle detected — node <strong>{cycleNodeId}</strong> is part of a loop. Fix childIds before downloading.
     </div>
   ) : null
 
@@ -500,20 +498,6 @@ export function CampaignAdminScreen({ onBack }: Props) {
                   value={selectedNode.rowCols}
                   onChange={e => updateNode(selectedNode.id, { rowCols: Math.max(1, parseInt(e.target.value) || 1) })} />
               </div>
-            </div>
-
-            {/* Parent IDs */}
-            <div className="settings-row" style={{ flexDirection: 'column', alignItems: 'flex-start', gap: '6px' }}>
-              <div>
-                <div className="settings-label">Parent nodes</div>
-                <div className="settings-sublabel">Nodes that must be completed before this one unlocks</div>
-              </div>
-              <NodeIdPicker
-                allNodes={sortedNodes}
-                excludeId={selectedNode.id}
-                selectedIds={selectedNode.parentIds}
-                onChange={ids => updateNode(selectedNode.id, { parentIds: ids })}
-              />
             </div>
 
             {/* Child IDs */}

--- a/web/src/components/NodeMap.tsx
+++ b/web/src/components/NodeMap.tsx
@@ -64,8 +64,13 @@ function computeReachableIds(act: Act, run: RunState): Set<string> {
     }
   }
 
-  for (const [id, node] of Object.entries(act.nodes)) {
-    if (node.parentIds.length === 0 && !skipped.has(id)) visit(id)
+  // Build reverse map to find start nodes (those with no parents)
+  const hasParent = new Set<string>()
+  for (const node of Object.values(act.nodes)) {
+    for (const cid of node.childIds) hasParent.add(cid)
+  }
+  for (const [id] of Object.entries(act.nodes)) {
+    if (!hasParent.has(id) && !skipped.has(id)) visit(id)
   }
   return reachable
 }

--- a/web/src/data/acts/act1.json
+++ b/web/src/data/acts/act1.json
@@ -41,7 +41,7 @@
   "intro": [
     {
       "title": "THE FRACTURE",
-      "text": "Three years ago, the Grand Dominion shattered.\n\nNot in war. Not gradually. In a single catastrophic instant — a magical detonation the scholars call the Fracture Event. The realm split into isolated shards, each one sealed behind walls of warped space and collapsed ley lines.\n\nNobody knows who caused it. Nobody knows how to undo it."
+      "text": "Three years ago, the Grand Dominion shattered.\n\nNot in war. Not gradually. In a single catastrophic instant \u2014 a magical detonation the scholars call the Fracture Event. The realm split into isolated shards, each one sealed behind walls of warped space and collapsed ley lines.\n\nNobody knows who caused it. Nobody knows how to undo it."
     },
     {
       "title": "THE WANDERER",
@@ -49,17 +49,17 @@
     },
     {
       "title": "THE VERDANT SHARD",
-      "text": "Your compass points to the nearest reachable shard — a dense, ancient forest realm that has grown wild and hostile since the Fracture closed its borders.\n\nThe shard's guardian, a being called the Thornlord, has sealed its internal pathways. Local traders say he was old before the Dominion was founded.\n\nLocal traders also say he hasn't spoken to anyone in forty years. You're choosing to interpret that as optimistically as possible."
+      "text": "Your compass points to the nearest reachable shard \u2014 a dense, ancient forest realm that has grown wild and hostile since the Fracture closed its borders.\n\nThe shard's guardian, a being called the Thornlord, has sealed its internal pathways. Local traders say he was old before the Dominion was founded.\n\nLocal traders also say he hasn't spoken to anyone in forty years. You're choosing to interpret that as optimistically as possible."
     },
     {
       "title": "YOUR MISSION",
-      "text": "Break through the shard. Reach the Thornlord. Defeat him. Earn passage.\n\nTake whatever cards and crystals you can carry out the other side — your collection grows with every run, your mastery deepens, and somewhere in the Fractured Core the answer to all of this is waiting.\n\nProbably."
+      "text": "Break through the shard. Reach the Thornlord. Defeat him. Earn passage.\n\nTake whatever cards and crystals you can carry out the other side \u2014 your collection grows with every run, your mastery deepens, and somewhere in the Fractured Core the answer to all of this is waiting.\n\nProbably."
     }
   ],
   "outro": [
     {
       "title": "THE THORNLORD FALLS",
-      "text": "The ancient guardian crumples. Roots unravel. Bark splits along fracture lines older than the Dominion.\n\nFor a moment the whole forest holds its breath — then it exhales. The sealed pathways glow faintly and open like doors that have been waiting for exactly this."
+      "text": "The ancient guardian crumples. Roots unravel. Bark splits along fracture lines older than the Dominion.\n\nFor a moment the whole forest holds its breath \u2014 then it exhales. The sealed pathways glow faintly and open like doors that have been waiting for exactly this."
     },
     {
       "title": "WHAT HE WAS",
@@ -67,7 +67,7 @@
     },
     {
       "title": "THE ROAD AHEAD",
-      "text": "One shard cleared. The ley lines pulse — faint, but connected.\n\nYour deck returns to its bones. Your collection carries forward. Somewhere beyond the Verdant Shard, the Iron Citadel waits — and whoever controls it will not be glad to see you.\n\nGood."
+      "text": "One shard cleared. The ley lines pulse \u2014 faint, but connected.\n\nYour deck returns to its bones. Your collection carries forward. Somewhere beyond the Verdant Shard, the Iron Citadel waits \u2014 and whoever controls it will not be glad to see you.\n\nGood."
     }
   ],
   "variantPools": {
@@ -76,7 +76,7 @@
       "Now, technically, a free agent.",
       "Now, effectively, between employers.",
       "Now, in the administrative sense, without portfolio.",
-      "Now — if you were being generous — on sabbatical."
+      "Now \u2014 if you were being generous \u2014 on sabbatical."
     ],
     "jarvIntros": [
       "You have a deck of cards, a vague sense of mission, and the navigational instincts of someone who has been lost before and considers it acceptable.",
@@ -86,10 +86,10 @@
       "You have a deck of cards. You always have a deck of cards. That, at least, has been consistent."
     ],
     "forestDesc": [
-      "Your compass points to the nearest reachable shard — a dense, ancient forest realm that has grown wild and hostile since the Fracture closed its borders.",
-      "Your compass points to the Verdant Shard — a place that smells of pine resin and old magic, where the trees remember things the people forgot.",
+      "Your compass points to the nearest reachable shard \u2014 a dense, ancient forest realm that has grown wild and hostile since the Fracture closed its borders.",
+      "Your compass points to the Verdant Shard \u2014 a place that smells of pine resin and old magic, where the trees remember things the people forgot.",
       "Your compass points toward the Verdant Shard. The forest ahead is old enough to have opinions about you.",
-      "The Verdant Shard pulses at the edge of your compass bearing — a realm of old growth and older grudges, sealed since the Fracture."
+      "The Verdant Shard pulses at the edge of your compass bearing \u2014 a realm of old growth and older grudges, sealed since the Fracture."
     ],
     "thornlordDesc": [
       "The shard's guardian, a being called the Thornlord, has sealed its internal pathways. Local traders say he was old before the Dominion was founded.\n\nLocal traders also say he hasn't spoken to anyone in forty years. You're choosing to interpret that as optimistically as possible.",
@@ -98,16 +98,16 @@
       "The Thornlord seals every path through the Verdant Shard. Traders who've survived say he is patient, thorough, and has never once reconsidered a decision.\n\nYou have a plan. You've had plans before."
     ],
     "priorRunSummaries": [
-      "The path felt familiar — the way a dream feels familiar, just before it turns wrong.",
+      "The path felt familiar \u2014 the way a dream feels familiar, just before it turns wrong.",
       "You stepped into the Verdant Shard with the uneasy sense that you'd stepped here before. You pushed the feeling aside. There was work to do.",
-      "Something about the first battle. The angle of the light. The particular way the Goblins charged. A déjà vu so precise it was almost a memory.",
+      "Something about the first battle. The angle of the light. The particular way the Goblins charged. A d\u00e9j\u00e0 vu so precise it was almost a memory.",
       "The forest seemed quieter than it should have been. As though it recognised you, and was deciding whether to be pleased about it."
     ],
     "priorRunOpenings": [
-      "You remember — and here is the strange part — getting this far before. Not the same choices. But the same road.",
+      "You remember \u2014 and here is the strange part \u2014 getting this far before. Not the same choices. But the same road.",
       "The scholar on the boulder didn't look up when you approached. 'Again?' he said. 'You're ahead of schedule.'",
       "The Thornlord, when you finally stood before him, was already watching you. As though he had been expecting you. As though he had been expecting this for some time.",
-      "The goblins at the first barricade looked familiar. Not familiar the way people are familiar — familiar the way furniture in a childhood home is familiar. Something about the arrangement of them."
+      "The goblins at the first barricade looked familiar. Not familiar the way people are familiar \u2014 familiar the way furniture in a childhood home is familiar. Something about the arrangement of them."
     ],
     "milestoneOpenings5": [
       "The fifth time through the Verdant Shard, a bird called out your name. That was new.",
@@ -135,7 +135,7 @@
     "{n} campaigns in. The goblins at the first barricade have started placing bets on how quickly you'll get past them.",
     "{n} times you've stood at this shard's edge. The trees have started leaning away slightly when you approach.",
     "Run {n}. You walk in before dawn, which is new. Everything else is exactly as you left it.",
-    "The {ordinalLower} attempt. You recognise the smell now. Damp bark and old magic and something else — familiarity.",
+    "The {ordinalLower} attempt. You recognise the smell now. Damp bark and old magic and something else \u2014 familiarity.",
     "{n} campaigns. The Wandering Scholar has started making tea before you arrive. He knows the timing by heart."
   ],
   "introRules": [
@@ -336,7 +336,7 @@
         },
         {
           "title": "A FEELING",
-          "text": "And yet — {pool:priorRunOpenings:0}\n\nYou push the feeling aside. You've always pushed the feeling aside.\n\nThat's how you dreamt it happened, as you step out into the battlefield for the first time."
+          "text": "And yet \u2014 {pool:priorRunOpenings:0}\n\nYou push the feeling aside. You've always pushed the feeling aside.\n\nThat's how you dreamt it happened, as you step out into the battlefield for the first time."
         }
       ]
     }
@@ -350,7 +350,6 @@
       "row": 0,
       "col": 0,
       "rowCols": 1,
-      "parentIds": [],
       "childIds": [
         "shrine",
         "camp"
@@ -384,9 +383,6 @@
       "row": 1,
       "col": 1,
       "rowCols": 2,
-      "parentIds": [
-        "goblin-raid"
-      ],
       "childIds": [
         "node-1776083922801",
         "market"
@@ -415,9 +411,6 @@
       "row": 1,
       "col": 0,
       "rowCols": 2,
-      "parentIds": [
-        "goblin-raid"
-      ],
       "childIds": [
         "forest-path",
         "node-the-lonely-field"
@@ -447,9 +440,6 @@
       "row": 2,
       "col": 0,
       "rowCols": 4,
-      "parentIds": [
-        "shrine"
-      ],
       "childIds": [
         "captain"
       ],
@@ -461,7 +451,7 @@
           [
             {
               "label": "Leave an offering",
-              "consequence": "The shrine accepts your gift — restored 12 HP",
+              "consequence": "The shrine accepts your gift \u2014 restored 12 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 12
@@ -469,7 +459,7 @@
             },
             {
               "label": "Leave an offering",
-              "consequence": "The glow brightens — +15 crystals",
+              "consequence": "The glow brightens \u2014 +15 crystals",
               "effect": {
                 "type": "gainCrystals",
                 "amount": 15
@@ -484,7 +474,7 @@
             },
             {
               "label": "Leave an offering",
-              "consequence": "Something drains your offering — lose 5 HP",
+              "consequence": "Something drains your offering \u2014 lose 5 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 5
@@ -492,14 +482,14 @@
             },
             {
               "label": "Leave an offering",
-              "consequence": "Something small materialises at the altar's base — added to inventory",
+              "consequence": "Something small materialises at the altar's base \u2014 added to inventory",
               "effect": {
                 "type": "gainItem"
               }
             },
             {
               "label": "Leave an offering",
-              "consequence": "The shrine blesses you with renewed fortune — +1 life",
+              "consequence": "The shrine blesses you with renewed fortune \u2014 +1 life",
               "effect": {
                 "type": "gainLife",
                 "amount": 1
@@ -509,7 +499,7 @@
           [
             {
               "label": "Pray for strength",
-              "consequence": "A card materialises from the glow — uncommon",
+              "consequence": "A card materialises from the glow \u2014 uncommon",
               "effect": {
                 "type": "gainCard",
                 "rarity": "uncommon"
@@ -517,7 +507,7 @@
             },
             {
               "label": "Pray for strength",
-              "consequence": "The magic guides your wounds — restored 8 HP",
+              "consequence": "The magic guides your wounds \u2014 restored 8 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 8
@@ -525,7 +515,7 @@
             },
             {
               "label": "Pray for strength",
-              "consequence": "The shrine tests you — lose 10 HP",
+              "consequence": "The shrine tests you \u2014 lose 10 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 10
@@ -533,7 +523,7 @@
             },
             {
               "label": "Pray for strength",
-              "consequence": "You feel oddly lucky — +20 crystals",
+              "consequence": "You feel oddly lucky \u2014 +20 crystals",
               "effect": {
                 "type": "gainCrystals",
                 "amount": 20
@@ -541,14 +531,14 @@
             },
             {
               "label": "Pray for strength",
-              "consequence": "Something small and inexplicable materialises in your palm — added to inventory",
+              "consequence": "Something small and inexplicable materialises in your palm \u2014 added to inventory",
               "effect": {
                 "type": "gainItem"
               }
             },
             {
               "label": "Pray for strength",
-              "consequence": "A strange object appears in your hand from nowhere — added to inventory",
+              "consequence": "A strange object appears in your hand from nowhere \u2014 added to inventory",
               "effect": {
                 "type": "gainItem"
               }
@@ -557,7 +547,7 @@
           [
             {
               "label": "Pocket the ritual stones",
-              "consequence": "You grab them and run — +18 crystals, lose 8 HP",
+              "consequence": "You grab them and run \u2014 +18 crystals, lose 8 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 8
@@ -580,7 +570,7 @@
             },
             {
               "label": "Pocket the ritual stones",
-              "consequence": "The shrine curses you — lose 15 HP",
+              "consequence": "The shrine curses you \u2014 lose 15 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 15
@@ -588,7 +578,7 @@
             },
             {
               "label": "Pocket the ritual stones",
-              "consequence": "One of the stones turns out to be something stranger — added to inventory",
+              "consequence": "One of the stones turns out to be something stranger \u2014 added to inventory",
               "effect": {
                 "type": "gainItem"
               }
@@ -605,21 +595,18 @@
       "row": 4,
       "col": 1,
       "rowCols": 4,
-      "parentIds": [
-        "war-camp"
-      ],
       "childIds": [
         "deep-crossing"
       ],
       "environment": "forest",
       "eventConfig": {
         "title": "The Watching Wood",
-        "description": "A great creature steps from the treeline. Not hostile — not yet. It tilts its head and watches you with ancient, patient eyes.",
+        "description": "A great creature steps from the treeline. Not hostile \u2014 not yet. It tilts its head and watches you with ancient, patient eyes.",
         "pools": [
           [
             {
               "label": "Stand your ground",
-              "consequence": "It respects the stillness — +15 crystals from its abandoned cache",
+              "consequence": "It respects the stillness \u2014 +15 crystals from its abandoned cache",
               "effect": {
                 "type": "gainCrystals",
                 "amount": 15
@@ -627,14 +614,14 @@
             },
             {
               "label": "Stand your ground",
-              "consequence": "It steps forward and presses something into your hand — added to inventory",
+              "consequence": "It steps forward and presses something into your hand \u2014 added to inventory",
               "effect": {
                 "type": "gainItem"
               }
             },
             {
               "label": "Stand your ground",
-              "consequence": "It growls and charges — lose 12 HP",
+              "consequence": "It growls and charges \u2014 lose 12 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 12
@@ -649,7 +636,7 @@
             },
             {
               "label": "Stand your ground",
-              "consequence": "Something in its posture says: not today — restored 10 HP",
+              "consequence": "Something in its posture says: not today \u2014 restored 10 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 10
@@ -659,7 +646,7 @@
           [
             {
               "label": "Offer it food",
-              "consequence": "It takes your offering gently — restored 12 HP",
+              "consequence": "It takes your offering gently \u2014 restored 12 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 12
@@ -682,7 +669,7 @@
             },
             {
               "label": "Offer it food",
-              "consequence": "It lashes out — lose 8 HP",
+              "consequence": "It lashes out \u2014 lose 8 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 8
@@ -690,7 +677,7 @@
             },
             {
               "label": "Offer it food",
-              "consequence": "It drops something from its mouth — a common card",
+              "consequence": "It drops something from its mouth \u2014 a common card",
               "effect": {
                 "type": "gainCard",
                 "rarity": "common"
@@ -700,14 +687,14 @@
           [
             {
               "label": "Back away slowly",
-              "consequence": "It lets you go — nothing happens",
+              "consequence": "It lets you go \u2014 nothing happens",
               "effect": {
                 "type": "nothing"
               }
             },
             {
               "label": "Back away slowly",
-              "consequence": "It follows you to the edge of its territory and leaves a crystal cache — +12 crystals",
+              "consequence": "It follows you to the edge of its territory and leaves a crystal cache \u2014 +12 crystals",
               "effect": {
                 "type": "gainCrystals",
                 "amount": 12
@@ -715,7 +702,7 @@
             },
             {
               "label": "Back away slowly",
-              "consequence": "It pounces — lose 15 HP",
+              "consequence": "It pounces \u2014 lose 15 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 15
@@ -723,14 +710,14 @@
             },
             {
               "label": "Back away slowly",
-              "consequence": "You find something in the grass as you retreat — added to inventory",
+              "consequence": "You find something in the grass as you retreat \u2014 added to inventory",
               "effect": {
                 "type": "gainItem"
               }
             },
             {
               "label": "Back away slowly",
-              "consequence": "It watches you leave and seems almost disappointed — restored 6 HP",
+              "consequence": "It watches you leave and seems almost disappointed \u2014 restored 6 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 6
@@ -748,9 +735,6 @@
       "row": 4,
       "col": 2,
       "rowCols": 4,
-      "parentIds": [
-        "captain"
-      ],
       "childIds": [
         "deep-crossing"
       ],
@@ -762,7 +746,7 @@
           [
             {
               "label": "Rest in the shelter",
-              "consequence": "The quiet heals — restored 15 HP",
+              "consequence": "The quiet heals \u2014 restored 15 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 15
@@ -778,7 +762,7 @@
             },
             {
               "label": "Rest in the shelter",
-              "consequence": "Something bites you in the night — lose 6 HP",
+              "consequence": "Something bites you in the night \u2014 lose 6 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 6
@@ -786,7 +770,7 @@
             },
             {
               "label": "Rest in the shelter",
-              "consequence": "You find a pouch under the floorboards — +14 crystals",
+              "consequence": "You find a pouch under the floorboards \u2014 +14 crystals",
               "effect": {
                 "type": "gainCrystals",
                 "amount": 14
@@ -794,14 +778,14 @@
             },
             {
               "label": "Rest in the shelter",
-              "consequence": "You wake to find a small curiosity beside you — added to inventory",
+              "consequence": "You wake to find a small curiosity beside you \u2014 added to inventory",
               "effect": {
                 "type": "gainItem"
               }
             },
             {
               "label": "Rest in the shelter",
-              "consequence": "Something rolls under your hand in the dark — added to inventory",
+              "consequence": "Something rolls under your hand in the dark \u2014 added to inventory",
               "effect": {
                 "type": "gainItem"
               }
@@ -818,7 +802,7 @@
             },
             {
               "label": "Search the armory",
-              "consequence": "A rare weapon contract — add a rare card",
+              "consequence": "A rare weapon contract \u2014 add a rare card",
               "effect": {
                 "type": "gainCard",
                 "rarity": "rare"
@@ -826,7 +810,7 @@
             },
             {
               "label": "Search the armory",
-              "consequence": "Old coin cache — +20 crystals",
+              "consequence": "Old coin cache \u2014 +20 crystals",
               "effect": {
                 "type": "gainCrystals",
                 "amount": 20
@@ -834,7 +818,7 @@
             },
             {
               "label": "Search the armory",
-              "consequence": "A rusted trap springs — lose 10 HP",
+              "consequence": "A rusted trap springs \u2014 lose 10 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 10
@@ -842,14 +826,14 @@
             },
             {
               "label": "Search the armory",
-              "consequence": "You find a curious object among the debris — added to inventory",
+              "consequence": "You find a curious object among the debris \u2014 added to inventory",
               "effect": {
                 "type": "gainItem"
               }
             },
             {
               "label": "Search the armory",
-              "consequence": "Something rolls out of the rubble — added to inventory",
+              "consequence": "Something rolls out of the rubble \u2014 added to inventory",
               "effect": {
                 "type": "gainItem"
               }
@@ -858,7 +842,7 @@
           [
             {
               "label": "Climb the watchtower",
-              "consequence": "Good vantage point — +12 crystals from spotted supply cache",
+              "consequence": "Good vantage point \u2014 +12 crystals from spotted supply cache",
               "effect": {
                 "type": "gainCrystals",
                 "amount": 12
@@ -874,7 +858,7 @@
             },
             {
               "label": "Climb the watchtower",
-              "consequence": "The stairs collapse — lose 12 HP",
+              "consequence": "The stairs collapse \u2014 lose 12 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 12
@@ -889,14 +873,14 @@
             },
             {
               "label": "Climb the watchtower",
-              "consequence": "Something is jammed in the bell — you pocket it — added to inventory",
+              "consequence": "Something is jammed in the bell \u2014 you pocket it \u2014 added to inventory",
               "effect": {
                 "type": "gainItem"
               }
             },
             {
               "label": "Climb the watchtower",
-              "consequence": "You spot a hidden passage to a safe camp below — +1 life",
+              "consequence": "You spot a hidden passage to a safe camp below \u2014 +1 life",
               "effect": {
                 "type": "gainLife",
                 "amount": 1
@@ -914,9 +898,6 @@
       "row": 4,
       "col": 0,
       "rowCols": 4,
-      "parentIds": [
-        "captain"
-      ],
       "childIds": [
         "deep-crossing"
       ],
@@ -946,9 +927,6 @@
       "row": 2,
       "col": 3,
       "rowCols": 4,
-      "parentIds": [
-        "camp"
-      ],
       "childIds": [
         "deep-woods"
       ],
@@ -958,14 +936,10 @@
       "id": "captain",
       "type": "elite",
       "label": "Forest Captain",
-      "description": "A hardened veteran with well-drilled siege troops — and something the forest has been teaching him about patience.",
+      "description": "A hardened veteran with well-drilled siege troops \u2014 and something the forest has been teaching him about patience.",
       "row": 3,
       "col": 0,
       "rowCols": 2,
-      "parentIds": [
-        "forest-path",
-        "ruins"
-      ],
       "childIds": [
         "war-camp",
         "ambush"
@@ -1004,10 +978,6 @@
       "row": 3,
       "col": 1,
       "rowCols": 2,
-      "parentIds": [
-        "ambush",
-        "market"
-      ],
       "childIds": [
         "troll-bridge",
         "ruins"
@@ -1043,9 +1013,6 @@
       "row": 4,
       "col": 3,
       "rowCols": 4,
-      "parentIds": [
-        "deep-woods"
-      ],
       "childIds": [
         "deep-crossing"
       ],
@@ -1075,9 +1042,6 @@
       "row": 6,
       "col": 0,
       "rowCols": 1,
-      "parentIds": [
-        "deep-crossing"
-      ],
       "childIds": [],
       "handicap": 0,
       "environment": "ruins",
@@ -1100,10 +1064,6 @@
       "row": 5,
       "col": 0,
       "rowCols": 1,
-      "parentIds": [
-        "war-camp",
-        "troll-bridge"
-      ],
       "childIds": [
         "thornlord"
       ],
@@ -1132,9 +1092,6 @@
       "row": 2,
       "col": 2,
       "rowCols": 4,
-      "parentIds": [
-        "camp"
-      ],
       "childIds": [
         "captain"
       ],
@@ -1162,9 +1119,6 @@
       "row": 2,
       "col": 1,
       "rowCols": 4,
-      "parentIds": [
-        "shrine"
-      ],
       "childIds": [
         "deep-woods"
       ],

--- a/web/src/data/acts/act10.json
+++ b/web/src/data/acts/act10.json
@@ -42,7 +42,7 @@
   "intro": [
     {
       "title": "THE SAND MARKET",
-      "text": "The ley lines run straight through the desert, which the Sand Market has spent decades making commercially relevant. The market grew up around the ley convergence — vendors first, then traders, then mercenaries, then the Dune Baron, who saw the strategic value and started charging for it.\n\nEverything here has a price. Including passage through it."
+      "text": "The ley lines run straight through the desert, which the Sand Market has spent decades making commercially relevant. The market grew up around the ley convergence \u2014 vendors first, then traders, then mercenaries, then the Dune Baron, who saw the strategic value and started charging for it.\n\nEverything here has a price. Including passage through it."
     },
     {
       "title": "THE DUNE BARON",
@@ -50,13 +50,13 @@
     },
     {
       "title": "THE MARKET ROUTE",
-      "text": "The ley lines converge beneath the market's central spire — the Dune Baron uses the energy surplus to power the lights, the forges, and the contract-binding seals that make his mercenary arrangements legally enforceable.\n\nYou need the convergence point. He isn't selling it.\n\nYou're going to take it. He'll probably factor this into his pricing for the next traveller."
+      "text": "The ley lines converge beneath the market's central spire \u2014 the Dune Baron uses the energy surplus to power the lights, the forges, and the contract-binding seals that make his mercenary arrangements legally enforceable.\n\nYou need the convergence point. He isn't selling it.\n\nYou're going to take it. He'll probably factor this into his pricing for the next traveller."
     }
   ],
   "outro": [
     {
       "title": "THE DUNE BARON SETTLES",
-      "text": "The Dune Baron doesn't lose gracefully. He loses expensively — which means he calculates the cost of the outcome, determines it was within acceptable parameters, and files the result under 'resolved.'\n\nThe ley lines pulse through the market floor. The convergence point opens.\n\nHe's already thinking about what to charge the next person who shows up."
+      "text": "The Dune Baron doesn't lose gracefully. He loses expensively \u2014 which means he calculates the cost of the outcome, determines it was within acceptable parameters, and files the result under 'resolved.'\n\nThe ley lines pulse through the market floor. The convergence point opens.\n\nHe's already thinking about what to charge the next person who shows up."
     },
     {
       "title": "WHAT HE SAID",
@@ -64,7 +64,7 @@
     },
     {
       "title": "THE GOLDEN COMPASS",
-      "text": "The Golden Compass sits warm in your palm — the Baron's personal navigation tool, used to track ley line convergences across the desert. It still points to them.\n\nIt also, apparently, makes you faster off the mark. The Baron claims he hadn't noticed that. You don't believe him.\n\nThe ley lines point on. The market recedes. The desert is, for once, quiet."
+      "text": "The Golden Compass sits warm in your palm \u2014 the Baron's personal navigation tool, used to track ley line convergences across the desert. It still points to them.\n\nIt also, apparently, makes you faster off the mark. The Baron claims he hadn't noticed that. You don't believe him.\n\nThe ley lines point on. The market recedes. The desert is, for once, quiet."
     }
   ],
   "nodes": {
@@ -76,7 +76,6 @@
       "row": 0,
       "col": 0,
       "rowCols": 1,
-      "parentIds": [],
       "childIds": [
         "sand-shrine",
         "dune-hollow"
@@ -110,9 +109,6 @@
       "row": 1,
       "col": 0,
       "rowCols": 4,
-      "parentIds": [
-        "dune-approach"
-      ],
       "childIds": [
         "market-crossing",
         "mirage-vent"
@@ -125,7 +121,7 @@
           [
             {
               "label": "Drink from the spring",
-              "consequence": "The water restores — healed 14 HP",
+              "consequence": "The water restores \u2014 healed 14 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 14
@@ -133,7 +129,7 @@
             },
             {
               "label": "Drink from the spring",
-              "consequence": "Something in it stings — lose 6 HP",
+              "consequence": "Something in it stings \u2014 lose 6 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 6
@@ -159,7 +155,7 @@
           [
             {
               "label": "Search the offering-stones",
-              "consequence": "Something useful left behind — uncommon card",
+              "consequence": "Something useful left behind \u2014 uncommon card",
               "effect": {
                 "type": "gainCard",
                 "rarity": "uncommon"
@@ -167,7 +163,7 @@
             },
             {
               "label": "Search the offering-stones",
-              "consequence": "Coins left as offerings — +22 crystals",
+              "consequence": "Coins left as offerings \u2014 +22 crystals",
               "effect": {
                 "type": "gainCrystals",
                 "amount": 22
@@ -184,7 +180,7 @@
           [
             {
               "label": "Fill your reserves",
-              "consequence": "The water heals on the road — healed 8 HP",
+              "consequence": "The water heals on the road \u2014 healed 8 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 8
@@ -218,9 +214,6 @@
       "row": 1,
       "col": 3,
       "rowCols": 4,
-      "parentIds": [
-        "dune-approach"
-      ],
       "childIds": [
         "trade-archive",
         "outer-bazaar"
@@ -236,9 +229,6 @@
       "row": 2,
       "col": 3,
       "rowCols": 4,
-      "parentIds": [
-        "dune-hollow"
-      ],
       "childIds": [
         "market-rest"
       ],
@@ -252,9 +242,6 @@
       "row": 2,
       "col": 0,
       "rowCols": 4,
-      "parentIds": [
-        "sand-shrine"
-      ],
       "childIds": [
         "caravan-elite"
       ],
@@ -287,9 +274,6 @@
       "row": 4,
       "col": 0,
       "rowCols": 4,
-      "parentIds": [
-        "caravan-elite"
-      ],
       "childIds": [
         "baron-approach"
       ],
@@ -323,21 +307,18 @@
       "row": 2,
       "col": 1,
       "rowCols": 4,
-      "parentIds": [
-        "sand-shrine"
-      ],
       "childIds": [
         "caravan-elite"
       ],
       "environment": "sand",
       "eventConfig": {
         "title": "The Mirage Cache",
-        "description": "A concealed depot in the dune face — the Baron's forces maintain several, and not all of them are decoys. This one is real. The lock is good but not insurmountable.",
+        "description": "A concealed depot in the dune face \u2014 the Baron's forces maintain several, and not all of them are decoys. This one is real. The lock is good but not insurmountable.",
         "pools": [
           [
             {
               "label": "Open the cache",
-              "consequence": "Weapons inside — rare card",
+              "consequence": "Weapons inside \u2014 rare card",
               "effect": {
                 "type": "gainCard",
                 "rarity": "rare"
@@ -345,7 +326,7 @@
             },
             {
               "label": "Open the cache",
-              "consequence": "Supplies — healed 15 HP",
+              "consequence": "Supplies \u2014 healed 15 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 15
@@ -353,7 +334,7 @@
             },
             {
               "label": "Open the cache",
-              "consequence": "It was a decoy — lose 12 HP",
+              "consequence": "It was a decoy \u2014 lose 12 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 12
@@ -379,7 +360,7 @@
             },
             {
               "label": "Sell the contents",
-              "consequence": "One item worth keeping — uncommon card",
+              "consequence": "One item worth keeping \u2014 uncommon card",
               "effect": {
                 "type": "gainCard",
                 "rarity": "uncommon"
@@ -404,10 +385,6 @@
       "row": 3,
       "col": 0,
       "rowCols": 4,
-      "parentIds": [
-        "market-crossing",
-        "mirage-vent"
-      ],
       "childIds": [
         "sand-battery"
       ],
@@ -441,10 +418,6 @@
       "row": 5,
       "col": 0,
       "rowCols": 1,
-      "parentIds": [
-        "sand-battery",
-        "baron-vanguard"
-      ],
       "childIds": [
         "dunebaron"
       ],
@@ -477,21 +450,18 @@
       "row": 2,
       "col": 2,
       "rowCols": 4,
-      "parentIds": [
-        "dune-hollow"
-      ],
       "childIds": [
         "market-rest"
       ],
       "environment": "sand",
       "eventConfig": {
         "title": "The Baron's Ledger",
-        "description": "The Dune Baron's transaction records — every contract, every sale, every mercenary hired and dismissed since the market was established. His notes on the Fracture are in here. He logged it as a business disruption.",
+        "description": "The Dune Baron's transaction records \u2014 every contract, every sale, every mercenary hired and dismissed since the market was established. His notes on the Fracture are in here. He logged it as a business disruption.",
         "pools": [
           [
             {
               "label": "Study the contracts",
-              "consequence": "Exploitable intel — rare card",
+              "consequence": "Exploitable intel \u2014 rare card",
               "effect": {
                 "type": "gainCard",
                 "rarity": "rare"
@@ -499,7 +469,7 @@
             },
             {
               "label": "Study the contracts",
-              "consequence": "Supply chain map — +28 crystals",
+              "consequence": "Supply chain map \u2014 +28 crystals",
               "effect": {
                 "type": "gainCrystals",
                 "amount": 28
@@ -509,7 +479,7 @@
           [
             {
               "label": "Rest in the records room",
-              "consequence": "Quiet and warm — healed 15 HP",
+              "consequence": "Quiet and warm \u2014 healed 15 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 15
@@ -535,10 +505,6 @@
       "row": 3,
       "col": 3,
       "rowCols": 4,
-      "parentIds": [
-        "trade-archive",
-        "outer-bazaar"
-      ],
       "childIds": [
         "baron-vanguard"
       ],
@@ -553,9 +519,6 @@
       "row": 4,
       "col": 3,
       "rowCols": 4,
-      "parentIds": [
-        "market-rest"
-      ],
       "childIds": [
         "baron-approach"
       ],
@@ -588,9 +551,6 @@
       "row": 6,
       "col": 0,
       "rowCols": 1,
-      "parentIds": [
-        "baron-approach"
-      ],
       "childIds": [],
       "handicap": 32,
       "opponentIntervalMs": 3500,

--- a/web/src/data/acts/act11.json
+++ b/web/src/data/acts/act11.json
@@ -42,29 +42,29 @@
   "intro": [
     {
       "title": "THE VERDANT CANOPY",
-      "text": "The ley lines rise into the high canopy here, threading through root systems older than memory. The forest above the treeline moves differently. It doesn't react to you — it notices you.\n\nThe Elder Warden has kept this canopy since before the Fracture. It has watched dozens of expeditions attempt passage. None returned changed for the better."
+      "text": "The ley lines rise into the high canopy here, threading through root systems older than memory. The forest above the treeline moves differently. It doesn't react to you \u2014 it notices you.\n\nThe Elder Warden has kept this canopy since before the Fracture. It has watched dozens of expeditions attempt passage. None returned changed for the better."
     },
     {
       "title": "THE ELDER WARDEN",
-      "text": "It is not a creature in any familiar sense. The Warden is the canopy made sovereign — a convergence of root and memory and something older that has no name in any language you speak.\n\nIt does not hate you. Hatred requires noticing something as a peer. The Warden sees you as disruption. Disruptions are removed."
+      "text": "It is not a creature in any familiar sense. The Warden is the canopy made sovereign \u2014 a convergence of root and memory and something older that has no name in any language you speak.\n\nIt does not hate you. Hatred requires noticing something as a peer. The Warden sees you as disruption. Disruptions are removed."
     },
     {
       "title": "THE PATH THROUGH",
-      "text": "The ley convergence runs through the ancient heartwood at the canopy's centre. Scholars have theorised about it for decades. None have gotten close enough to verify.\n\nYou will need to fight through layers of living defence — root walls, grove-spawned treants, flying watchers — before the Warden descends. And then you will need to convince it, by force, that disruption can be useful."
+      "text": "The ley convergence runs through the ancient heartwood at the canopy's centre. Scholars have theorised about it for decades. None have gotten close enough to verify.\n\nYou will need to fight through layers of living defence \u2014 root walls, grove-spawned treants, flying watchers \u2014 before the Warden descends. And then you will need to convince it, by force, that disruption can be useful."
     }
   ],
   "outro": [
     {
       "title": "THE CANOPY YIELDS",
-      "text": "The Elder Warden does not fall. It withdraws — slowly, deliberately, as though choosing to end the engagement rather than being forced to. The distinction matters to it.\n\nThe ley convergence is exposed. The heartwood pulses with calm energy, older than anything you've touched before."
+      "text": "The Elder Warden does not fall. It withdraws \u2014 slowly, deliberately, as though choosing to end the engagement rather than being forced to. The distinction matters to it.\n\nThe ley convergence is exposed. The heartwood pulses with calm energy, older than anything you've touched before."
     },
     {
       "title": "LIVING BARK",
-      "text": "Where the Warden stood, a strip of bark remains — thick, warm to the touch, and inexplicably alive. It hardens in your hands into something like armour, or maybe a shield, or maybe just the canopy saying: you've earned a layer of protection.\n\nYou don't question it. The canopy rewards results."
+      "text": "Where the Warden stood, a strip of bark remains \u2014 thick, warm to the touch, and inexplicably alive. It hardens in your hands into something like armour, or maybe a shield, or maybe just the canopy saying: you've earned a layer of protection.\n\nYou don't question it. The canopy rewards results."
     },
     {
       "title": "THE ROAD AHEAD",
-      "text": "The Verdant Canopy recedes behind you as you descend. Above, you hear the canopy resume its ordinary rhythms — something enormous moving between branches, watchers returning to their posts.\n\nThe Warden is already repairing the damage. It won't hold a grudge. It's too old for that. It will simply be ready when you return."
+      "text": "The Verdant Canopy recedes behind you as you descend. Above, you hear the canopy resume its ordinary rhythms \u2014 something enormous moving between branches, watchers returning to their posts.\n\nThe Warden is already repairing the damage. It won't hold a grudge. It's too old for that. It will simply be ready when you return."
     }
   ],
   "nodes": {
@@ -76,7 +76,6 @@
       "row": 0,
       "col": 0,
       "rowCols": 1,
-      "parentIds": [],
       "childIds": [
         "root-shrine",
         "canopy-hollow"
@@ -108,16 +107,13 @@
       "row": 1,
       "col": 0,
       "rowCols": 4,
-      "parentIds": [
-        "canopy-approach"
-      ],
       "childIds": [
         "deep-crossing",
         "canopy-rift"
       ],
       "eventConfig": {
         "title": "The Root Shrine",
-        "description": "A gnarled shrine wrapped in glowing roots. You can feel something ancient in it. The options it presents are simple — give something, take something, or leave it alone.",
+        "description": "A gnarled shrine wrapped in glowing roots. You can feel something ancient in it. The options it presents are simple \u2014 give something, take something, or leave it alone.",
         "pools": [
           [
             {
@@ -172,9 +168,6 @@
       "col": 3,
       "rowCols": 4,
       "restHeal": 8,
-      "parentIds": [
-        "canopy-approach"
-      ],
       "childIds": [
         "warden-vigil",
         "vine-market"
@@ -188,9 +181,6 @@
       "row": 2,
       "col": 3,
       "rowCols": 4,
-      "parentIds": [
-        "canopy-hollow"
-      ],
       "childIds": [
         "canopy-rest"
       ]
@@ -203,9 +193,6 @@
       "row": 2,
       "col": 0,
       "rowCols": 4,
-      "parentIds": [
-        "root-shrine"
-      ],
       "childIds": [
         "ancient-garrison"
       ],
@@ -238,9 +225,6 @@
       "row": 4,
       "col": 0,
       "rowCols": 4,
-      "parentIds": [
-        "ancient-garrison"
-      ],
       "childIds": [
         "heartwood-path"
       ],
@@ -273,15 +257,12 @@
       "row": 2,
       "col": 1,
       "rowCols": 4,
-      "parentIds": [
-        "root-shrine"
-      ],
       "childIds": [
         "ancient-garrison"
       ],
       "eventConfig": {
         "title": "The Canopy Rift",
-        "description": "A gap in the ancient canopy shows the raw ley lines beneath — shimmering, strange, and old. You can attempt to draw on them, or simply study them from a safe distance.",
+        "description": "A gap in the ancient canopy shows the raw ley lines beneath \u2014 shimmering, strange, and old. You can attempt to draw on them, or simply study them from a safe distance.",
         "pools": [
           [
             {
@@ -335,10 +316,6 @@
       "row": 3,
       "col": 0,
       "rowCols": 4,
-      "parentIds": [
-        "deep-crossing",
-        "canopy-rift"
-      ],
       "childIds": [
         "elder-watch"
       ],
@@ -372,10 +349,6 @@
       "row": 5,
       "col": 0,
       "rowCols": 1,
-      "parentIds": [
-        "elder-watch",
-        "deep-grove"
-      ],
       "childIds": [
         "elder-warden"
       ],
@@ -409,15 +382,12 @@
       "row": 2,
       "col": 2,
       "rowCols": 4,
-      "parentIds": [
-        "canopy-hollow"
-      ],
       "childIds": [
         "canopy-rest"
       ],
       "eventConfig": {
         "title": "The Warden's Gaze",
-        "description": "You feel it before you see it — a presence older than stone watching from the high branches. It hasn't moved. It's waiting to see what you do. Your choice here will define what follows.",
+        "description": "You feel it before you see it \u2014 a presence older than stone watching from the high branches. It hasn't moved. It's waiting to see what you do. Your choice here will define what follows.",
         "pools": [
           [
             {
@@ -472,10 +442,6 @@
       "col": 3,
       "rowCols": 4,
       "restHeal": 10,
-      "parentIds": [
-        "warden-vigil",
-        "vine-market"
-      ],
       "childIds": [
         "deep-grove"
       ]
@@ -488,9 +454,6 @@
       "row": 4,
       "col": 3,
       "rowCols": 4,
-      "parentIds": [
-        "canopy-rest"
-      ],
       "childIds": [
         "heartwood-path"
       ],
@@ -525,9 +488,6 @@
       "row": 6,
       "col": 0,
       "rowCols": 1,
-      "parentIds": [
-        "heartwood-path"
-      ],
       "childIds": [],
       "handicap": 30,
       "opponentIntervalMs": 3500,

--- a/web/src/data/acts/act12.json
+++ b/web/src/data/acts/act12.json
@@ -42,15 +42,15 @@
   "intro": [
     {
       "title": "THE SHATTERED COAST",
-      "text": "The Shattered Coast was once a thriving port city — before the Fracture split it across seven separate shards.\n\nNow the channels between shards are controlled by a single authority: the Harbormaster. Nothing moves without his iron seal. No cargo. No people. No information."
+      "text": "The Shattered Coast was once a thriving port city \u2014 before the Fracture split it across seven separate shards.\n\nNow the channels between shards are controlled by a single authority: the Harbormaster. Nothing moves without his iron seal. No cargo. No people. No information."
     },
     {
       "title": "THE HARBORMASTER",
-      "text": "He was a port inspector once, before the Fracture. Now he is something else — a man who discovered that chaos could be administered, and administration could be power.\n\nHis fleet patrols the shattered channels. His flags are the only law. The wreck divers answer to him. The storm hawks circle his flagship."
+      "text": "He was a port inspector once, before the Fracture. Now he is something else \u2014 a man who discovered that chaos could be administered, and administration could be power.\n\nHis fleet patrols the shattered channels. His flags are the only law. The wreck divers answer to him. The storm hawks circle his flagship."
     },
     {
       "title": "NO PERMIT",
-      "text": "You don't have his permit. You don't intend to get one.\n\nThe coast is the only route forward, and the Harbormaster blocks it. Fight through his patrols, his reef wardens, his iron anchorage — and put an end to the toll."
+      "text": "You don't have his permit. You don't intend to get one.\n\nThe coast is the only route forward, and the Harbormaster blocks it. Fight through his patrols, his reef wardens, his iron anchorage \u2014 and put an end to the toll."
     }
   ],
   "outro": [
@@ -60,7 +60,7 @@
     },
     {
       "title": "SALVAGE HOOK",
-      "text": "Among the wreckage, half-buried in sand, you find a salvage hook — the symbol of passage along this coast. It's old. Pre-Fracture. It means something.\n\nYou pocket it. The channels open around you."
+      "text": "Among the wreckage, half-buried in sand, you find a salvage hook \u2014 the symbol of passage along this coast. It's old. Pre-Fracture. It means something.\n\nYou pocket it. The channels open around you."
     },
     {
       "title": "THE HORIZON",
@@ -76,7 +76,6 @@
       "row": 0,
       "col": 1,
       "rowCols": 3,
-      "parentIds": [],
       "childIds": [
         "tidal-shrine",
         "wreck-camp"
@@ -100,9 +99,6 @@
       "row": 1,
       "col": 0,
       "rowCols": 4,
-      "parentIds": [
-        "shore-landing"
-      ],
       "childIds": [
         "deep-waters",
         "storm-crossing"
@@ -163,9 +159,6 @@
       "row": 1,
       "col": 3,
       "rowCols": 4,
-      "parentIds": [
-        "shore-landing"
-      ],
       "childIds": [
         "gale-watch",
         "salvage-market"
@@ -180,9 +173,6 @@
       "row": 2,
       "col": 3,
       "rowCols": 4,
-      "parentIds": [
-        "wreck-camp"
-      ],
       "childIds": [
         "shipwreck-rest"
       ]
@@ -195,9 +185,6 @@
       "row": 2,
       "col": 0,
       "rowCols": 4,
-      "parentIds": [
-        "tidal-shrine"
-      ],
       "childIds": [
         "diver-cove"
       ],
@@ -221,9 +208,6 @@
       "row": 4,
       "col": 0,
       "rowCols": 4,
-      "parentIds": [
-        "diver-cove"
-      ],
       "childIds": [
         "stormwall"
       ],
@@ -247,9 +231,6 @@
       "row": 2,
       "col": 1,
       "rowCols": 4,
-      "parentIds": [
-        "tidal-shrine"
-      ],
       "childIds": [
         "diver-cove"
       ],
@@ -309,10 +290,6 @@
       "row": 3,
       "col": 0,
       "rowCols": 4,
-      "parentIds": [
-        "deep-waters",
-        "storm-crossing"
-      ],
       "childIds": [
         "reef-outpost"
       ],
@@ -337,10 +314,6 @@
       "row": 5,
       "col": 0,
       "rowCols": 1,
-      "parentIds": [
-        "reef-outpost",
-        "iron-anchorage"
-      ],
       "childIds": [
         "the-harbormaster-node"
       ],
@@ -365,10 +338,6 @@
       "row": 3,
       "col": 3,
       "rowCols": 4,
-      "parentIds": [
-        "gale-watch",
-        "salvage-market"
-      ],
       "childIds": [
         "iron-anchorage"
       ],
@@ -382,9 +351,6 @@
       "row": 2,
       "col": 2,
       "rowCols": 4,
-      "parentIds": [
-        "wreck-camp"
-      ],
       "childIds": [
         "shipwreck-rest"
       ],
@@ -440,13 +406,10 @@
       "id": "iron-anchorage",
       "type": "elite",
       "label": "Iron Anchorage",
-      "description": "The Harbormaster's advance guard — iron-hulled and merciless.",
+      "description": "The Harbormaster's advance guard \u2014 iron-hulled and merciless.",
       "row": 4,
       "col": 3,
       "rowCols": 4,
-      "parentIds": [
-        "shipwreck-rest"
-      ],
       "childIds": [
         "stormwall"
       ],
@@ -471,9 +434,6 @@
       "row": 6,
       "col": 0,
       "rowCols": 1,
-      "parentIds": [
-        "stormwall"
-      ],
       "childIds": [],
       "handicap": 32,
       "opponentIntervalMs": 4800,

--- a/web/src/data/acts/act13.json
+++ b/web/src/data/acts/act13.json
@@ -42,11 +42,11 @@
   "intro": [
     {
       "title": "THE CLOCKWORK VAULTS",
-      "text": "Deep beneath the shattered earth, the Clockwork Vaults hum with ancient machinery — built before the Fracture by an artificer order that no longer exists.\n\nThe Grand Automaton maintains it all. Has maintained it for two hundred years. No one knows if it was told to stop."
+      "text": "Deep beneath the shattered earth, the Clockwork Vaults hum with ancient machinery \u2014 built before the Fracture by an artificer order that no longer exists.\n\nThe Grand Automaton maintains it all. Has maintained it for two hundred years. No one knows if it was told to stop."
     },
     {
       "title": "THE GRAND AUTOMATON",
-      "text": "It is not hostile. Hostility implies intent. The Automaton simply optimises — calculating minimum-force resolutions for all threats to vault integrity.\n\nYou are a threat to vault integrity."
+      "text": "It is not hostile. Hostility implies intent. The Automaton simply optimises \u2014 calculating minimum-force resolutions for all threats to vault integrity.\n\nYou are a threat to vault integrity."
     },
     {
       "title": "WHAT LIES WITHIN",
@@ -60,7 +60,7 @@
     },
     {
       "title": "GEAR HEART",
-      "text": "Amid the cooling machinery, you find a small gear-shaped crystal — the Automaton's drive core, still faintly warm.\n\nA fitting trophy. It pulses with each heartbeat."
+      "text": "Amid the cooling machinery, you find a small gear-shaped crystal \u2014 the Automaton's drive core, still faintly warm.\n\nA fitting trophy. It pulses with each heartbeat."
     },
     {
       "title": "ONWARD",
@@ -76,7 +76,6 @@
       "row": 0,
       "col": 1,
       "rowCols": 3,
-      "parentIds": [],
       "childIds": [
         "gear-shrine",
         "assembly-rest"
@@ -100,9 +99,6 @@
       "row": 1,
       "col": 0,
       "rowCols": 4,
-      "parentIds": [
-        "vault-entrance"
-      ],
       "childIds": [
         "second-chamber",
         "calibration-rift"
@@ -163,9 +159,6 @@
       "row": 1,
       "col": 3,
       "rowCols": 4,
-      "parentIds": [
-        "vault-entrance"
-      ],
       "childIds": [
         "automaton-watch",
         "cog-market"
@@ -180,9 +173,6 @@
       "row": 2,
       "col": 3,
       "rowCols": 4,
-      "parentIds": [
-        "assembly-rest"
-      ],
       "childIds": [
         "repair-bay"
       ]
@@ -195,9 +185,6 @@
       "row": 2,
       "col": 0,
       "rowCols": 4,
-      "parentIds": [
-        "gear-shrine"
-      ],
       "childIds": [
         "forge-vault"
       ],
@@ -221,9 +208,6 @@
       "row": 4,
       "col": 0,
       "rowCols": 4,
-      "parentIds": [
-        "forge-vault"
-      ],
       "childIds": [
         "core-approach"
       ],
@@ -247,9 +231,6 @@
       "row": 2,
       "col": 1,
       "rowCols": 4,
-      "parentIds": [
-        "gear-shrine"
-      ],
       "childIds": [
         "forge-vault"
       ],
@@ -309,10 +290,6 @@
       "row": 3,
       "col": 0,
       "rowCols": 4,
-      "parentIds": [
-        "second-chamber",
-        "calibration-rift"
-      ],
       "childIds": [
         "piston-wing"
       ],
@@ -337,10 +314,6 @@
       "row": 5,
       "col": 0,
       "rowCols": 1,
-      "parentIds": [
-        "piston-wing",
-        "titan-garrison"
-      ],
       "childIds": [
         "the-grand-automaton-node"
       ],
@@ -361,14 +334,10 @@
       "id": "repair-bay",
       "type": "rest",
       "label": "Salvaged Repair Bay",
-      "description": "Abandoned repair alcove — still functional.",
+      "description": "Abandoned repair alcove \u2014 still functional.",
       "row": 3,
       "col": 3,
       "rowCols": 4,
-      "parentIds": [
-        "automaton-watch",
-        "cog-market"
-      ],
       "childIds": [
         "titan-garrison"
       ],
@@ -382,9 +351,6 @@
       "row": 2,
       "col": 2,
       "rowCols": 4,
-      "parentIds": [
-        "assembly-rest"
-      ],
       "childIds": [
         "repair-bay"
       ],
@@ -444,9 +410,6 @@
       "row": 4,
       "col": 3,
       "rowCols": 4,
-      "parentIds": [
-        "repair-bay"
-      ],
       "childIds": [
         "core-approach"
       ],
@@ -471,9 +434,6 @@
       "row": 6,
       "col": 0,
       "rowCols": 1,
-      "parentIds": [
-        "core-approach"
-      ],
       "childIds": [],
       "handicap": 33,
       "opponentIntervalMs": 5000,

--- a/web/src/data/acts/act2.json
+++ b/web/src/data/acts/act2.json
@@ -43,7 +43,7 @@
   "intro": [
     {
       "title": "THE IRON CITADEL",
-      "text": "The Fracture spared the Iron Citadel its chaos — or so the stories go. In truth, the Citadel's warlords sealed the shard themselves, the moment they realised sealing it kept everyone else out.\n\nFor three years they have ruled the rubble with a disciplined fist. Trade routes closed. Refugees turned back at the walls. The shard hoards its iron and feeds on order."
+      "text": "The Fracture spared the Iron Citadel its chaos \u2014 or so the stories go. In truth, the Citadel's warlords sealed the shard themselves, the moment they realised sealing it kept everyone else out.\n\nFor three years they have ruled the rubble with a disciplined fist. Trade routes closed. Refugees turned back at the walls. The shard hoards its iron and feeds on order."
     },
     {
       "title": "THE WANDERER",
@@ -61,11 +61,11 @@
   "outro": [
     {
       "title": "THE WALL FALLS",
-      "text": "Kragg's banner comes down.\n\nFor a long moment, nothing happens. Then, from somewhere in the rubble, a single soldier begins to move — not toward you, but toward the sealed gate. Others follow.\n\nThe gate opens for the first time in three years. You watch from the rampart as light floods into the canyon."
+      "text": "Kragg's banner comes down.\n\nFor a long moment, nothing happens. Then, from somewhere in the rubble, a single soldier begins to move \u2014 not toward you, but toward the sealed gate. Others follow.\n\nThe gate opens for the first time in three years. You watch from the rampart as light floods into the canyon."
     },
     {
       "title": "IRON STANDARD",
-      "text": "Among the Citadel's armoury, you find it — the Iron Standard. The banner carried at the front of every Dominion march before the Fracture.\n\nIt no longer represents anything. But the iron in it remembers.\n\nYou take it with you."
+      "text": "Among the Citadel's armoury, you find it \u2014 the Iron Standard. The banner carried at the front of every Dominion march before the Fracture.\n\nIt no longer represents anything. But the iron in it remembers.\n\nYou take it with you."
     }
   ],
   "variantPools": {
@@ -73,7 +73,7 @@
       "Currently, technically, between warlords.",
       "Presently operating without a formal command structure.",
       "In the professional sense, unaffiliated.",
-      "Now — by the Citadel's own accounting — a hostile foreign element.",
+      "Now \u2014 by the Citadel's own accounting \u2014 a hostile foreign element.",
       "Technically trespassing, but with excellent documentation."
     ],
     "jarvIntros": [
@@ -84,10 +84,10 @@
       "You have a deck of cards and a very reasonable request for passage that you fully expect to be answered with siege weapons."
     ],
     "citadelDesc": [
-      "The Iron Citadel sits across a shattered canyon — garrison points chained together by rope bridges and old discipline. From the outside it looks impregnable. From the inside, you suspect, it merely looks expensive.",
+      "The Iron Citadel sits across a shattered canyon \u2014 garrison points chained together by rope bridges and old discipline. From the outside it looks impregnable. From the inside, you suspect, it merely looks expensive.",
       "The shard is a vertical maze of fortified positions and supply routes. The Citadel's defenders know every route. You have a map drawn by someone who was here six years ago.",
       "Three years of isolation have made the Citadel's garrison meticulous. Every approach is covered. Every gap is intentional. You intend to use the intentional gaps.",
-      "The Iron Citadel is less a building than a doctrine — a belief that fortified positions solve problems. You've spent your career proving that belief wrong from the outside."
+      "The Iron Citadel is less a building than a doctrine \u2014 a belief that fortified positions solve problems. You've spent your career proving that belief wrong from the outside."
     ],
     "kraggDesc": [
       "Warlord Kragg sealed the shard the week after the Fracture. He said it was to protect the population. He is, by any reasonable accounting, still saying this.\n\nThe population has stopped asking.",
@@ -97,13 +97,13 @@
     ],
     "priorRunSummaries": [
       "The garrison gate looked exactly as you remembered it. Which was suspicious. Walls shouldn't look familiar.",
-      "You'd climbed this canyon approach before — or something very much like it. The rope bridges swayed in the same pattern. The guards paused at the same moment.",
+      "You'd climbed this canyon approach before \u2014 or something very much like it. The rope bridges swayed in the same pattern. The guards paused at the same moment.",
       "Something about the second garrison checkpoint. The way the signal fire was positioned. The particular angle of the crossbow emplacements. It felt rehearsed.",
       "The Citadel's outer walls were exactly as your notes described them. Your notes, which you'd written this morning."
     ],
     "priorRunOpenings": [
       "You remember, faintly, walking this route before. Not the same choices. But the same canyon. The same smell of iron and old stone.",
-      "The gate guard hesitated when you approached. Not with suspicion — with recognition. He covered it quickly. So did you.",
+      "The gate guard hesitated when you approached. Not with suspicion \u2014 with recognition. He covered it quickly. So did you.",
       "Kragg, when you finally reached him, was already in his armour. As though he'd been expecting an appointment.",
       "The rope bridge at the third garrison crossing had been repaired since your last attempt. Except you'd never been here before. You were fairly certain you'd never been here before."
     ],
@@ -131,7 +131,7 @@
     "The {ordinalLower} approach to the Iron Citadel. The canyon looks exactly the same. Kragg has probably moved the crossbow emplacements.",
     "Campaign {n}. The garrison at the outer wall has your description posted. It is not flattering.",
     "{n} campaigns through the canyon. The rope bridges have been reinforced. You take that personally.",
-    "{n} times past this gate. The duty guard no longer calls an alarm — he just notes the time.",
+    "{n} times past this gate. The duty guard no longer calls an alarm \u2014 he just notes the time.",
     "Run {n}. You arrive at dawn. The garrison is ready. They are always ready now.",
     "The {ordinalLower} time through the Citadel. The supply officer has started noting your visits as 'irregular procurement events.'",
     "{n} campaigns. The signal fires light before you reach the first checkpoint. Kragg has good scouts."
@@ -334,7 +334,7 @@
         },
         {
           "title": "A MEMORY",
-          "text": "And yet — {pool:priorRunOpenings:0}\n\nYou push the feeling aside. You've always pushed the feeling aside.\n\nThe canyon waits."
+          "text": "And yet \u2014 {pool:priorRunOpenings:0}\n\nYou push the feeling aside. You've always pushed the feeling aside.\n\nThe canyon waits."
         }
       ]
     }
@@ -347,11 +347,10 @@
       "id": "iron-gate",
       "type": "battle",
       "label": "Iron Gate",
-      "description": "The Citadel's outer garrison blocks the canyon road. A disciplined force — but thin.",
+      "description": "The Citadel's outer garrison blocks the canyon road. A disciplined force \u2014 but thin.",
       "row": 0,
       "col": 0,
       "rowCols": 1,
-      "parentIds": [],
       "childIds": [
         "supply-cache",
         "soldiers-camp"
@@ -379,13 +378,10 @@
       "id": "soldiers-camp",
       "type": "rest",
       "label": "Soldier's Camp",
-      "description": "An abandoned forward camp — rations still warm. Rest and recover.",
+      "description": "An abandoned forward camp \u2014 rations still warm. Rest and recover.",
       "row": 1,
       "col": 3,
       "rowCols": 4,
-      "parentIds": [
-        "iron-gate"
-      ],
       "childIds": [
         "siege-trenches",
         "quartermaster"
@@ -401,9 +397,6 @@
       "row": 1,
       "col": 0,
       "rowCols": 4,
-      "parentIds": [
-        "iron-gate"
-      ],
       "childIds": [
         "outer-wall",
         "war-council"
@@ -424,7 +417,7 @@
             },
             {
               "label": "Search the crates",
-              "consequence": "A trap springs — lose 8 HP",
+              "consequence": "A trap springs \u2014 lose 8 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 8
@@ -455,7 +448,7 @@
             },
             {
               "label": "Search the crates",
-              "consequence": "Something rolls out of the straw packing — added to inventory",
+              "consequence": "Something rolls out of the straw packing \u2014 added to inventory",
               "effect": {
                 "type": "gainItem"
               }
@@ -480,7 +473,7 @@
             },
             {
               "label": "Pocket something useful",
-              "consequence": "The case is booby-trapped — lose 12 HP",
+              "consequence": "The case is booby-trapped \u2014 lose 12 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 12
@@ -496,7 +489,7 @@
             },
             {
               "label": "Pocket something useful",
-              "consequence": "Something personal and inexplicable — added to inventory",
+              "consequence": "Something personal and inexplicable \u2014 added to inventory",
               "effect": {
                 "type": "gainItem"
               }
@@ -512,7 +505,7 @@
             },
             {
               "label": "Leave quickly",
-              "consequence": "You trip an alarm on the way out — lose 6 HP",
+              "consequence": "You trip an alarm on the way out \u2014 lose 6 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 6
@@ -520,7 +513,7 @@
             },
             {
               "label": "Leave quickly",
-              "consequence": "You spot a coin pouch by the door — +10 crystals",
+              "consequence": "You spot a coin pouch by the door \u2014 +10 crystals",
               "effect": {
                 "type": "gainCrystals",
                 "amount": 10
@@ -528,7 +521,7 @@
             },
             {
               "label": "Leave quickly",
-              "consequence": "You grab something off a shelf reflexively — added to inventory",
+              "consequence": "You grab something off a shelf reflexively \u2014 added to inventory",
               "effect": {
                 "type": "gainItem"
               }
@@ -541,13 +534,10 @@
       "id": "outer-wall",
       "type": "battle",
       "label": "Outer Wall",
-      "description": "The first proper fortified position — archers on the ramparts and a gate that won't open.",
+      "description": "The first proper fortified position \u2014 archers on the ramparts and a gate that won't open.",
       "row": 2,
       "col": 0,
       "rowCols": 4,
-      "parentIds": [
-        "supply-cache"
-      ],
       "childIds": [
         "siege-captain"
       ],
@@ -577,9 +567,6 @@
       "row": 2,
       "col": 2,
       "rowCols": 4,
-      "parentIds": [
-        "soldiers-camp"
-      ],
       "childIds": [
         "command-tent"
       ],
@@ -608,9 +595,6 @@
       "row": 4,
       "col": 0,
       "rowCols": 4,
-      "parentIds": [
-        "siege-captain"
-      ],
       "childIds": [
         "citadel-crossing"
       ],
@@ -640,9 +624,6 @@
       "row": 2,
       "col": 3,
       "rowCols": 4,
-      "parentIds": [
-        "soldiers-camp"
-      ],
       "childIds": [
         "command-tent"
       ],
@@ -656,10 +637,6 @@
       "row": 3,
       "col": 0,
       "rowCols": 4,
-      "parentIds": [
-        "outer-wall",
-        "war-council"
-      ],
       "childIds": [
         "iron-guard"
       ],
@@ -694,10 +671,6 @@
       "row": 3,
       "col": 3,
       "rowCols": 4,
-      "parentIds": [
-        "siege-trenches",
-        "quartermaster"
-      ],
       "childIds": [
         "last-stand"
       ],
@@ -712,9 +685,6 @@
       "row": 4,
       "col": 3,
       "rowCols": 4,
-      "parentIds": [
-        "command-tent"
-      ],
       "childIds": [
         "citadel-crossing"
       ],
@@ -741,20 +711,17 @@
       "id": "war-council",
       "type": "event",
       "label": "War Council",
-      "description": "A sealed briefing room — the Citadel's last tactical maps still spread across the table, the officers' chairs still warm.",
+      "description": "A sealed briefing room \u2014 the Citadel's last tactical maps still spread across the table, the officers' chairs still warm.",
       "row": 2,
       "col": 1,
       "rowCols": 4,
-      "parentIds": [
-        "supply-cache"
-      ],
       "childIds": [
         "siege-captain"
       ],
       "environment": "citadel",
       "eventConfig": {
         "title": "The War Council Chamber",
-        "description": "The Citadel's last tactical briefing still covers the table — casualty projections, siege lines, contingency codes. No signature. No date. The officers left in a hurry and didn't come back.",
+        "description": "The Citadel's last tactical briefing still covers the table \u2014 casualty projections, siege lines, contingency codes. No signature. No date. The officers left in a hurry and didn't come back.",
         "pools": [
           [
             {
@@ -775,14 +742,14 @@
             },
             {
               "label": "Study the tactical maps",
-              "consequence": "The strategies are outdated — they describe your own deck. Nothing useful.",
+              "consequence": "The strategies are outdated \u2014 they describe your own deck. Nothing useful.",
               "effect": {
                 "type": "nothing"
               }
             },
             {
               "label": "Study the tactical maps",
-              "consequence": "The data is encoded. Hours wasted — lose 6 HP from exhaustion.",
+              "consequence": "The data is encoded. Hours wasted \u2014 lose 6 HP from exhaustion.",
               "effect": {
                 "type": "damageHp",
                 "amount": 6
@@ -808,7 +775,7 @@
             },
             {
               "label": "Search the officers' packs",
-              "consequence": "A booby-trap springs — lose 10 HP.",
+              "consequence": "A booby-trap springs \u2014 lose 10 HP.",
               "effect": {
                 "type": "damageHp",
                 "amount": 10
@@ -824,7 +791,7 @@
             },
             {
               "label": "Search the officers' packs",
-              "consequence": "+1 life — someone left a spare compass. You needed that.",
+              "consequence": "+1 life \u2014 someone left a spare compass. You needed that.",
               "effect": {
                 "type": "gainLife",
                 "amount": 1
@@ -832,7 +799,7 @@
             },
             {
               "label": "Search the officers' packs",
-              "consequence": "Something personal left behind — added to inventory",
+              "consequence": "Something personal left behind \u2014 added to inventory",
               "effect": {
                 "type": "gainItem"
               }
@@ -882,9 +849,6 @@
       "row": 6,
       "col": 0,
       "rowCols": 1,
-      "parentIds": [
-        "citadel-crossing"
-      ],
       "childIds": [],
       "handicap": 0,
       "environment": "citadel",
@@ -903,14 +867,10 @@
       "id": "citadel-crossing",
       "type": "battle",
       "label": "Citadel Crossing",
-      "description": "The only way through the inner wall — a fortified gatehouse held by Kragg's elite guard.",
+      "description": "The only way through the inner wall \u2014 a fortified gatehouse held by Kragg's elite guard.",
       "row": 5,
       "col": 0,
       "rowCols": 1,
-      "parentIds": [
-        "iron-guard",
-        "last-stand"
-      ],
       "childIds": [
         "kragg"
       ],

--- a/web/src/data/acts/act3.json
+++ b/web/src/data/acts/act3.json
@@ -48,7 +48,7 @@
   "intro": [
     {
       "title": "THE ASHEN WASTES",
-      "text": "Before the Fracture, the Ashen Wastes were a mining region — coal seams, slag heaps, villages built around the work. Ordinary.\n\nThe Fracture hit differently here. The shard didn't just shatter. It burned. And whatever dark energy poured into the gap found the dead an accommodating host.\n\nThe Wastes are not quiet. The Wastes have never been quiet since."
+      "text": "Before the Fracture, the Ashen Wastes were a mining region \u2014 coal seams, slag heaps, villages built around the work. Ordinary.\n\nThe Fracture hit differently here. The shard didn't just shatter. It burned. And whatever dark energy poured into the gap found the dead an accommodating host.\n\nThe Wastes are not quiet. The Wastes have never been quiet since."
     },
     {
       "title": "THE WANDERER",
@@ -56,7 +56,7 @@
     },
     {
       "title": "THE ASHEN WASTES",
-      "text": "The shard is a landscape of grey ash and collapsed mineshafts, lit by fires that burn without fuel and voices that carry without wind.\n\nAt its centre, the Ashwalker — a figure that predates the Fracture, that may predate the Dominion itself. It does not rule the Wastes. The Wastes simply organise themselves around it."
+      "text": "The shard is a landscape of grey ash and collapsed mineshafts, lit by fires that burn without fuel and voices that carry without wind.\n\nAt its centre, the Ashwalker \u2014 a figure that predates the Fracture, that may predate the Dominion itself. It does not rule the Wastes. The Wastes simply organise themselves around it."
     },
     {
       "title": "YOUR MISSION",
@@ -66,7 +66,7 @@
   "outro": [
     {
       "title": "THE ASHES SETTLE",
-      "text": "The Ashwalker collapses inward — not destroyed, exactly. Diminished. The fires that burned without fuel go out one by one.\n\nFor the first time in three years, the Ashen Wastes are quiet. Not silent. Quiet. There is a difference.\n\nYou stand in the ash and wait to see if anything gets back up. Nothing does. You consider this a victory."
+      "text": "The Ashwalker collapses inward \u2014 not destroyed, exactly. Diminished. The fires that burned without fuel go out one by one.\n\nFor the first time in three years, the Ashen Wastes are quiet. Not silent. Quiet. There is a difference.\n\nYou stand in the ash and wait to see if anything gets back up. Nothing does. You consider this a victory."
     },
     {
       "title": "SOULSTONE",
@@ -78,7 +78,7 @@
       "Currently, technically, in a place that shouldn't exist.",
       "Professionally speaking, operating outside recommended parameters.",
       "In the occupational sense, doing something the guild specifically warned against.",
-      "Now — by any reasonable safety assessment — somewhere else.",
+      "Now \u2014 by any reasonable safety assessment \u2014 somewhere else.",
       "Technically alive, which puts you in a minority out here."
     ],
     "jarvIntros": [
@@ -89,25 +89,25 @@
       "You have a deck of cards. Something in the ash is watching you. You choose to treat that as an audience."
     ],
     "wastesDesc": [
-      "The Ashen Wastes spread across the shard like a wound that never healed — grey plains dotted with collapsed shafts, burning slag heaps, and the occasional structure that shouldn't still be standing. The silence is the worst part. Not quiet. Silent.",
+      "The Ashen Wastes spread across the shard like a wound that never healed \u2014 grey plains dotted with collapsed shafts, burning slag heaps, and the occasional structure that shouldn't still be standing. The silence is the worst part. Not quiet. Silent.",
       "The Wastes are navigable if you know the routes and avoid the unstable ground. Your map marks both. Your map was also drawn three years ago, before the dead started moving the landmarks.",
-      "Grey ash in every direction, fires that burn cold, and voices that carry meaning without words. The Wastes are not hostile — they are simply indifferent to whether you survive them.",
+      "Grey ash in every direction, fires that burn cold, and voices that carry meaning without words. The Wastes are not hostile \u2014 they are simply indifferent to whether you survive them.",
       "The shard smells of coal and old smoke and something older beneath both. The Wandering Scholar called it 'entropy made ambient.' You call it 'bad.'"
     ],
     "ashwalkerDesc": [
-      "The Ashwalker has no name in any record that predates the Fracture, which suggests it either wasn't important enough to name or was important enough to not name. Neither is reassuring.\n\nIt doesn't command the dead. It simply exists, and the dead — finding something more coherent than entropy to organise around — follow.",
+      "The Ashwalker has no name in any record that predates the Fracture, which suggests it either wasn't important enough to name or was important enough to not name. Neither is reassuring.\n\nIt doesn't command the dead. It simply exists, and the dead \u2014 finding something more coherent than entropy to organise around \u2014 follow.",
       "No one knows what the Ashwalker was before the Fracture. The current theory, held by exactly one scholar who has since stopped talking about it, is that it wasn't anything before the Fracture. That the Fracture made it.\n\nYou are choosing not to find this interesting.",
-      "The Ashwalker moves through the Wastes like weather — present everywhere, localised nowhere, and arriving at inconvenient moments. The dead it commands are an afterthought. The Ashwalker itself is the problem.\n\nYou have a plan for the problem. The plan involves cards.",
+      "The Ashwalker moves through the Wastes like weather \u2014 present everywhere, localised nowhere, and arriving at inconvenient moments. The dead it commands are an afterthought. The Ashwalker itself is the problem.\n\nYou have a plan for the problem. The plan involves cards.",
       "Old stories about the Ashwalker agree on one detail: it doesn't fight. It consumes. It converts. It uses what's already there.\n\nYou have made a professional decision to not be there when it arrives."
     ],
     "priorRunSummaries": [
       "The first ashfield looked exactly as you'd imagined it. Which was alarming, because you'd never been here before.",
       "You stepped into the Wastes with the specific sensation of having already made a mistake you couldn't identify yet.",
-      "Something about the first encounter — the way the risen dead were positioned, the angle of the burning slag heaps — felt rehearsed. Like a re-run.",
+      "Something about the first encounter \u2014 the way the risen dead were positioned, the angle of the burning slag heaps \u2014 felt rehearsed. Like a re-run.",
       "The Wastes felt familiar the way a recurring nightmare feels familiar: not pleasant, but navigable, and carrying a sense that you know how it ends."
     ],
     "priorRunOpenings": [
-      "You remember — and this is the strange part — walking this ash field before. Not recently. Not clearly. But the memory is there.",
+      "You remember \u2014 and this is the strange part \u2014 walking this ash field before. Not recently. Not clearly. But the memory is there.",
       "The Revenant Witch looked at you before you'd said anything. 'Again?' she said. You didn't ask what she meant.",
       "The Ashwalker, when you reached it, didn't seem surprised. It turned toward you with the deliberate patience of something that has been expecting a specific visitor.",
       "The first risen dead you encountered stopped. Just stopped. Then stepped aside. You kept walking and chose not to investigate why."
@@ -129,7 +129,7 @@
       "Fifty approaches. The Ashwalker sends an escort now. You follow the escort. The escort knows the shortest route."
     ],
     "milestoneOpenings100": [
-      "The Ashwalker is already waiting.\n\nNot in its usual position — at the centre of the Wastes, surrounded by the dead. Here, at the edge. Where you enter.\n\n'I have been counting,' it says. The voice comes from everywhere and nowhere simultaneously. 'A hundred times you have come. A hundred times the fire goes out.'\n\nThe ash around it moves in a slow circle.\n\n'I am beginning to think you might be a habit.'"
+      "The Ashwalker is already waiting.\n\nNot in its usual position \u2014 at the centre of the Wastes, surrounded by the dead. Here, at the edge. Where you enter.\n\n'I have been counting,' it says. The voice comes from everywhere and nowhere simultaneously. 'A hundred times you have come. A hundred times the fire goes out.'\n\nThe ash around it moves in a slow circle.\n\n'I am beginning to think you might be a habit.'"
     ]
   },
   "midRunTemplates": [
@@ -339,7 +339,7 @@
         },
         {
           "title": "A MEMORY",
-          "text": "And yet — {pool:priorRunOpenings:0}\n\nYou push the feeling aside. The Wastes are waiting.\n\nThey are always waiting."
+          "text": "And yet \u2014 {pool:priorRunOpenings:0}\n\nYou push the feeling aside. The Wastes are waiting.\n\nThey are always waiting."
         }
       ]
     }
@@ -352,11 +352,10 @@
       "id": "ashfield-scouts",
       "type": "battle",
       "label": "Ashfield Scouts",
-      "description": "The dead that patrol the Wastes' edge — faster than they should be, coordinated in ways the dead shouldn't be.",
+      "description": "The dead that patrol the Wastes' edge \u2014 faster than they should be, coordinated in ways the dead shouldn't be.",
       "row": 0,
       "col": 0,
       "rowCols": 1,
-      "parentIds": [],
       "childIds": [
         "soul-shrine",
         "bone-fire"
@@ -388,9 +387,6 @@
       "row": 1,
       "col": 0,
       "rowCols": 4,
-      "parentIds": [
-        "ashfield-scouts"
-      ],
       "childIds": [
         "plague-front",
         "cursed-altar"
@@ -398,7 +394,7 @@
       "environment": "ruins",
       "eventConfig": {
         "title": "The Soul Shrine",
-        "description": "A shrine built from miners' tools — pickaxes crossed at the base, lanterns fused into its flanks with old soot. The flame inside is black. Whatever souls it was built to honour, they haven't left.",
+        "description": "A shrine built from miners' tools \u2014 pickaxes crossed at the base, lanterns fused into its flanks with old soot. The flame inside is black. Whatever souls it was built to honour, they haven't left.",
         "pools": [
           [
             {
@@ -426,7 +422,7 @@
             },
             {
               "label": "Leave an offering",
-              "consequence": "The shrine takes more than offered — lose 10 HP.",
+              "consequence": "The shrine takes more than offered \u2014 lose 10 HP.",
               "effect": {
                 "type": "damageHp",
                 "amount": 10
@@ -434,7 +430,7 @@
             },
             {
               "label": "Leave an offering",
-              "consequence": "A miner's spirit grants you another chance — +1 life.",
+              "consequence": "A miner's spirit grants you another chance \u2014 +1 life.",
               "effect": {
                 "type": "gainLife",
                 "amount": 1
@@ -486,7 +482,7 @@
             },
             {
               "label": "Reach into the black flame",
-              "consequence": "It burns after all — lose 16 HP.",
+              "consequence": "It burns after all \u2014 lose 16 HP.",
               "effect": {
                 "type": "damageHp",
                 "amount": 16
@@ -510,7 +506,7 @@
             },
             {
               "label": "Reach into the black flame",
-              "consequence": "Something small and cold falls into your palm — added to inventory",
+              "consequence": "Something small and cold falls into your palm \u2014 added to inventory",
               "effect": {
                 "type": "gainItem"
               }
@@ -523,13 +519,10 @@
       "id": "bone-fire",
       "type": "rest",
       "label": "Bone Fire",
-      "description": "A fire that burns cold — but it burns, and in the Wastes that's enough. Rest here.",
+      "description": "A fire that burns cold \u2014 but it burns, and in the Wastes that's enough. Rest here.",
       "row": 1,
       "col": 3,
       "rowCols": 4,
-      "parentIds": [
-        "ashfield-scouts"
-      ],
       "childIds": [
         "risen-horde",
         "grave-merchant"
@@ -545,9 +538,6 @@
       "row": 2,
       "col": 0,
       "rowCols": 4,
-      "parentIds": [
-        "soul-shrine"
-      ],
       "childIds": [
         "revenant-witch"
       ],
@@ -573,14 +563,10 @@
       "id": "ash-grotto",
       "type": "rest",
       "label": "Ash Grotto",
-      "description": "A hollow in the ash-field — sheltered from the wind, the dead, and whatever else the Wastes have decided to send today. Rest here.",
+      "description": "A hollow in the ash-field \u2014 sheltered from the wind, the dead, and whatever else the Wastes have decided to send today. Rest here.",
       "row": 3,
       "col": 3,
       "rowCols": 4,
-      "parentIds": [
-        "risen-horde",
-        "grave-merchant"
-      ],
       "childIds": [
         "death-knight"
       ],
@@ -591,13 +577,10 @@
       "id": "risen-horde",
       "type": "battle",
       "label": "Risen Horde",
-      "description": "The Wastes' standing army — numberless, tireless, and pointed in your direction.",
+      "description": "The Wastes' standing army \u2014 numberless, tireless, and pointed in your direction.",
       "row": 2,
       "col": 2,
       "rowCols": 4,
-      "parentIds": [
-        "bone-fire"
-      ],
       "childIds": [
         "ash-grotto"
       ],
@@ -624,13 +607,10 @@
       "id": "shadow-guard",
       "type": "battle",
       "label": "Shadow Guard",
-      "description": "Risen soldiers who remember their discipline — the most dangerous kind of dead.",
+      "description": "Risen soldiers who remember their discipline \u2014 the most dangerous kind of dead.",
       "row": 4,
       "col": 0,
       "rowCols": 4,
-      "parentIds": [
-        "revenant-witch"
-      ],
       "childIds": [
         "ash-crossing"
       ],
@@ -660,9 +640,6 @@
       "row": 2,
       "col": 3,
       "rowCols": 4,
-      "parentIds": [
-        "bone-fire"
-      ],
       "childIds": [
         "ash-grotto"
       ],
@@ -676,10 +653,6 @@
       "row": 3,
       "col": 0,
       "rowCols": 4,
-      "parentIds": [
-        "plague-front",
-        "cursed-altar"
-      ],
       "childIds": [
         "shadow-guard"
       ],
@@ -713,20 +686,17 @@
       "id": "cursed-altar",
       "type": "event",
       "label": "Cursed Altar",
-      "description": "A makeshift altar built from the bones of something large — whatever the Wastes worshipped before the Fracture gave it something better to do.",
+      "description": "A makeshift altar built from the bones of something large \u2014 whatever the Wastes worshipped before the Fracture gave it something better to do.",
       "row": 2,
       "col": 1,
       "rowCols": 4,
-      "parentIds": [
-        "soul-shrine"
-      ],
       "childIds": [
         "revenant-witch"
       ],
       "environment": "ashen",
       "eventConfig": {
         "title": "The Cursed Altar",
-        "description": "A makeshift altar built from the bones of something large — whatever the Wastes worshipped before the Fracture gave it something better to do. Dark ichor seeps between the joints. The altar hums.",
+        "description": "A makeshift altar built from the bones of something large \u2014 whatever the Wastes worshipped before the Fracture gave it something better to do. Dark ichor seeps between the joints. The altar hums.",
         "pools": [
           [
             {
@@ -739,7 +709,7 @@
             },
             {
               "label": "Make a blood offering",
-              "consequence": "Dark energy surges through you — +1 life, lose 8 HP.",
+              "consequence": "Dark energy surges through you \u2014 +1 life, lose 8 HP.",
               "effect": {
                 "type": "damageHp",
                 "amount": 8
@@ -796,7 +766,7 @@
             },
             {
               "label": "Pray to the bones",
-              "consequence": "The altar grants you one more chance — +1 life.",
+              "consequence": "The altar grants you one more chance \u2014 +1 life.",
               "effect": {
                 "type": "gainLife",
                 "amount": 1
@@ -804,7 +774,7 @@
             },
             {
               "label": "Pray to the bones",
-              "consequence": "A bone fragment shifts loose and lands in your hand — added to inventory",
+              "consequence": "A bone fragment shifts loose and lands in your hand \u2014 added to inventory",
               "effect": {
                 "type": "gainItem"
               }
@@ -813,7 +783,7 @@
           [
             {
               "label": "Desecrate the altar",
-              "consequence": "The altar shatters — +28 crystals from the gem fragments.",
+              "consequence": "The altar shatters \u2014 +28 crystals from the gem fragments.",
               "effect": {
                 "type": "gainCrystals",
                 "amount": 28
@@ -829,7 +799,7 @@
             },
             {
               "label": "Desecrate the altar",
-              "consequence": "The altar retaliates — lose 22 HP.",
+              "consequence": "The altar retaliates \u2014 lose 22 HP.",
               "effect": {
                 "type": "damageHp",
                 "amount": 22
@@ -850,13 +820,10 @@
       "id": "death-knight",
       "type": "elite",
       "label": "Death Knight",
-      "description": "A Dominion officer who fell in the Fracture and rose again — armoured, organised, and entirely without mercy.",
+      "description": "A Dominion officer who fell in the Fracture and rose again \u2014 armoured, organised, and entirely without mercy.",
       "row": 4,
       "col": 3,
       "rowCols": 4,
-      "parentIds": [
-        "ash-grotto"
-      ],
       "childIds": [
         "ash-crossing"
       ],
@@ -895,9 +862,6 @@
       "row": 6,
       "col": 0,
       "rowCols": 1,
-      "parentIds": [
-        "ash-crossing"
-      ],
       "childIds": [],
       "handicap": 0,
       "environment": "ashen",
@@ -940,10 +904,6 @@
       "row": 5,
       "col": 0,
       "rowCols": 1,
-      "parentIds": [
-        "shadow-guard",
-        "death-knight"
-      ],
       "childIds": [
         "ashwalker"
       ],

--- a/web/src/data/acts/act4.json
+++ b/web/src/data/acts/act4.json
@@ -49,7 +49,7 @@
   "intro": [
     {
       "title": "THE CRYSTAL SPIRE",
-      "text": "Before the Fracture, the Crystal Spire was the Dominion's arcane research division — a floating fortress of compressed ley-line energy, staffed by scholars who were very important and knew it.\n\nThe Fracture didn't destroy the Spire. It crystallised it. The entire shard froze mid-operation: experiments running, libraries mid-catalogue, staff mid-sentence. The crystal grew inward. The scholars who survived became part of the archive.\n\nThe Archivist survived better than most."
+      "text": "Before the Fracture, the Crystal Spire was the Dominion's arcane research division \u2014 a floating fortress of compressed ley-line energy, staffed by scholars who were very important and knew it.\n\nThe Fracture didn't destroy the Spire. It crystallised it. The entire shard froze mid-operation: experiments running, libraries mid-catalogue, staff mid-sentence. The crystal grew inward. The scholars who survived became part of the archive.\n\nThe Archivist survived better than most."
     },
     {
       "title": "THE WANDERER",
@@ -57,7 +57,7 @@
     },
     {
       "title": "THE CRYSTAL SPIRE",
-      "text": "The Spire is a labyrinth of crystallised corridors, arcane constructs, and rooms that echo with the voices of people who stopped speaking three years ago.\n\nAt its heart, the Archivist — scholar, archivist, and now something considerably more and considerably less than either — catalogues everything that enters. He has been cataloguing you since you entered the shard.\n\nHe has extensive notes."
+      "text": "The Spire is a labyrinth of crystallised corridors, arcane constructs, and rooms that echo with the voices of people who stopped speaking three years ago.\n\nAt its heart, the Archivist \u2014 scholar, archivist, and now something considerably more and considerably less than either \u2014 catalogues everything that enters. He has been cataloguing you since you entered the shard.\n\nHe has extensive notes."
     },
     {
       "title": "YOUR MISSION",
@@ -67,11 +67,11 @@
   "outro": [
     {
       "title": "THE ARCHIVE FALLS SILENT",
-      "text": "The Archivist's crystal matrix collapses. Not violently — methodically. Each facet dims in order, as though even his defeat is being filed.\n\nThe Spire holds its breath. Then, for the first time in three years, a window opens somewhere deep in the structure. Not because it was unlocked. Because whoever had been locking it is no longer in a position to care.\n\nLight comes through. Ordinary, unremarkable light. In the Crystal Spire, it looks like a miracle."
+      "text": "The Archivist's crystal matrix collapses. Not violently \u2014 methodically. Each facet dims in order, as though even his defeat is being filed.\n\nThe Spire holds its breath. Then, for the first time in three years, a window opens somewhere deep in the structure. Not because it was unlocked. Because whoever had been locking it is no longer in a position to care.\n\nLight comes through. Ordinary, unremarkable light. In the Crystal Spire, it looks like a miracle."
     },
     {
       "title": "PRISM LENS",
-      "text": "Among the Archivist's collection — catalogued, cross-referenced, annotated in a hand that had become increasingly less human — you find it.\n\nA lens ground from the Spire's heart crystal. It refracts mana the way a prism refracts light: input, multiplied, redirected.\n\nThe Archivist's note reads: *'Item 7,441: Prism Lens. Effect: mana amplification. Recommendation: do not give to wandering tactician.'\n\nYou take it."
+      "text": "Among the Archivist's collection \u2014 catalogued, cross-referenced, annotated in a hand that had become increasingly less human \u2014 you find it.\n\nA lens ground from the Spire's heart crystal. It refracts mana the way a prism refracts light: input, multiplied, redirected.\n\nThe Archivist's note reads: *'Item 7,441: Prism Lens. Effect: mana amplification. Recommendation: do not give to wandering tactician.'\n\nYou take it."
     }
   ],
   "variantPools": {
@@ -79,7 +79,7 @@
       "Currently, technically, trespassing in a building that has documented every trespasser since the Dominion era.",
       "Professionally speaking, now classified as a hostile anomaly in an active archive.",
       "In the scholarly sense, an unscheduled variable in someone else's extremely long experiment.",
-      "Now — by the Archivist's own notation — Specimen 7,441-B, Category: Recurring.",
+      "Now \u2014 by the Archivist's own notation \u2014 Specimen 7,441-B, Category: Recurring.",
       "Technically unenrolled, which puts you in a narrow category of people who have entered the Spire and stayed that way."
     ],
     "jarvIntros": [
@@ -91,15 +91,15 @@
     ],
     "spireDesc": [
       "The Crystal Spire floats above the shard floor on compressed ley lines, its corridors refracting light into colours that don't have names. The scholars called it the height of Dominion achievement. From the outside it looks like someone built a fortress out of a prism and forgot to add doors.",
-      "The Spire's outer lattice is a maze of crystallised arcane energy — walls that shift, corridors that echo with old spells still running, and constructs that patrol with the cheerful persistence of things that have never been told to stop.",
+      "The Spire's outer lattice is a maze of crystallised arcane energy \u2014 walls that shift, corridors that echo with old spells still running, and constructs that patrol with the cheerful persistence of things that have never been told to stop.",
       "Three years of isolation have given the Spire's internal systems time to optimise themselves. Every approach is monitored. Every intrusion is logged. The Archivist receives notification of your exact position in real time.",
       "The Crystal Spire hums. Constantly. A low, harmonic resonance that carries meaning if you listen long enough. You have been listening for forty minutes. The meaning is 'leave.'"
     ],
     "archivistDesc": [
-      "The Archivist was the Dominion's head of magical research before the Fracture — a precise, methodical scholar who believed that anything worth knowing was worth cataloguing and anything worth cataloguing was worth defending.\n\nThe Fracture gave him more to catalogue than he'd expected. He adapted.",
+      "The Archivist was the Dominion's head of magical research before the Fracture \u2014 a precise, methodical scholar who believed that anything worth knowing was worth cataloguing and anything worth cataloguing was worth defending.\n\nThe Fracture gave him more to catalogue than he'd expected. He adapted.",
       "No surviving record of the Archivist exists outside the Spire. This is because the Archivist controls all the surviving records.\n\nHe is, by his own notation, entry 1 in the archive. The entry runs to forty-seven pages and is still being updated.",
       "The Archivist doesn't fight. He categorises. He processes. He applies the appropriate countermeasures from the section labelled 'threats, external, category: persistent.'\n\nYou are in that section. You have been in that section since you crossed the shard boundary. You have a case number.",
-      "In the Spire's early catalogues, the Archivist noted that magic follows rules and rules can be mastered. His later entries — written after the Fracture, in a hand that grew steadily less human — simply note that mastery takes time.\n\nHe has had time."
+      "In the Spire's early catalogues, the Archivist noted that magic follows rules and rules can be mastered. His later entries \u2014 written after the Fracture, in a hand that grew steadily less human \u2014 simply note that mastery takes time.\n\nHe has had time."
     ],
     "priorRunSummaries": [
       "The outer lattice looked exactly as the recovered schematics described it. Which was suspicious, because the schematics were three years old and the lattice was known to rearrange itself.",
@@ -130,12 +130,12 @@
       "Fifty approaches. The crystal walls show you all your previous visits simultaneously. It looks like a gallery. The Archivist has curated it."
     ],
     "milestoneOpenings100": [
-      "The Archivist is at the entrance.\n\nNot in his chamber — at the entrance. Waiting.\n\n'One hundred visits,' he says. The crystal in his voice has grown, over the years, into something almost warm. 'Do you know what that means, in terms of the archive?'\n\nA pause. A soft chime, somewhere deep in the Spire.\n\n'You have generated more data than the Dominion's entire eastern campaign. I have seventeen volumes dedicated exclusively to your methodology. You are, empirically, the most significant external variable this archive has ever processed.'\n\nHe tilts his crystalline head.\n\n'I have decided to consider this a collaboration.'"
+      "The Archivist is at the entrance.\n\nNot in his chamber \u2014 at the entrance. Waiting.\n\n'One hundred visits,' he says. The crystal in his voice has grown, over the years, into something almost warm. 'Do you know what that means, in terms of the archive?'\n\nA pause. A soft chime, somewhere deep in the Spire.\n\n'You have generated more data than the Dominion's entire eastern campaign. I have seventeen volumes dedicated exclusively to your methodology. You are, empirically, the most significant external variable this archive has ever processed.'\n\nHe tilts his crystalline head.\n\n'I have decided to consider this a collaboration.'"
     ]
   },
   "midRunTemplates": [
     "The {ordinalLower} visit to the Crystal Spire. The archive has updated your file. It is now cross-referenced under seventeen categories.",
-    "Campaign {n}. The constructs recognise you on sight. The Archivist has stopped logging your entry time — he predicts it accurately enough to not bother.",
+    "Campaign {n}. The constructs recognise you on sight. The Archivist has stopped logging your entry time \u2014 he predicts it accurately enough to not bother.",
     "{n} campaigns through the lattice. The crystal corridors look the same. They always look the same. The Archivist prefers consistency.",
     "{n} times past the outer lattice. Your case number has gained a suffix: 'See also: the persistent one.'",
     "Run {n}. The Archivist's notes on you are now longer than his notes on the Fracture itself. He considers this an appropriate allocation of resources.",
@@ -340,7 +340,7 @@
         },
         {
           "title": "A NOTIFICATION",
-          "text": "And yet — {pool:priorRunOpenings:0}\n\nYou push the feeling aside. The Spire is waiting.\n\nIt has always been waiting. It files everything."
+          "text": "And yet \u2014 {pool:priorRunOpenings:0}\n\nYou push the feeling aside. The Spire is waiting.\n\nIt has always been waiting. It files everything."
         }
       ]
     }
@@ -353,11 +353,10 @@
       "id": "crystal-approach",
       "type": "battle",
       "label": "Crystal Approach",
-      "description": "The Spire's outer lattice crackles with automated defences — constructs running on three-year-old orders.",
+      "description": "The Spire's outer lattice crackles with automated defences \u2014 constructs running on three-year-old orders.",
       "row": 0,
       "col": 0,
       "rowCols": 1,
-      "parentIds": [],
       "childIds": [
         "arcane-library",
         "crystal-wellspring"
@@ -382,13 +381,10 @@
       "id": "arcane-library",
       "type": "event",
       "label": "Arcane Library",
-      "description": "A crystallised reading room — shelves frozen mid-reorganisation, books still open at the chapter the scholars were reading when the Fracture hit.",
+      "description": "A crystallised reading room \u2014 shelves frozen mid-reorganisation, books still open at the chapter the scholars were reading when the Fracture hit.",
       "row": 1,
       "col": 0,
       "rowCols": 4,
-      "parentIds": [
-        "crystal-approach"
-      ],
       "childIds": [
         "spire-flank",
         "arcane-vault"
@@ -396,12 +392,12 @@
       "environment": "ruins",
       "eventConfig": {
         "title": "The Arcane Library",
-        "description": "A crystallised reading room — shelves frozen mid-reorganisation, books still open at the chapter the scholars were reading when the Fracture hit. The pages are still turning.",
+        "description": "A crystallised reading room \u2014 shelves frozen mid-reorganisation, books still open at the chapter the scholars were reading when the Fracture hit. The pages are still turning.",
         "pools": [
           [
             {
               "label": "Study the open books",
-              "consequence": "A tactical insight crystallises — +18 crystals.",
+              "consequence": "A tactical insight crystallises \u2014 +18 crystals.",
               "effect": {
                 "type": "gainCrystals",
                 "amount": 18
@@ -424,7 +420,7 @@
             },
             {
               "label": "Study the open books",
-              "consequence": "The knowledge overwhelms you — lose 8 HP.",
+              "consequence": "The knowledge overwhelms you \u2014 lose 8 HP.",
               "effect": {
                 "type": "damageHp",
                 "amount": 8
@@ -442,7 +438,7 @@
             },
             {
               "label": "Search the crystal shelves",
-              "consequence": "Gem dust spills from a cracked volume — +22 crystals.",
+              "consequence": "Gem dust spills from a cracked volume \u2014 +22 crystals.",
               "effect": {
                 "type": "gainCrystals",
                 "amount": 22
@@ -466,7 +462,7 @@
             },
             {
               "label": "Search the crystal shelves",
-              "consequence": "+1 life — the last entry in the register reads your name.",
+              "consequence": "+1 life \u2014 the last entry in the register reads your name.",
               "effect": {
                 "type": "gainLife",
                 "amount": 1
@@ -474,7 +470,7 @@
             },
             {
               "label": "Search the crystal shelves",
-              "consequence": "A small crystal object falls from a shelf — added to inventory",
+              "consequence": "A small crystal object falls from a shelf \u2014 added to inventory",
               "effect": {
                 "type": "gainItem"
               }
@@ -499,7 +495,7 @@
             },
             {
               "label": "Take the restricted volumes",
-              "consequence": "The warding spell triggers — lose 16 HP.",
+              "consequence": "The warding spell triggers \u2014 lose 16 HP.",
               "effect": {
                 "type": "damageHp",
                 "amount": 16
@@ -520,13 +516,10 @@
       "id": "spire-flank",
       "type": "battle",
       "label": "Spire Flank",
-      "description": "The Spire's eastern rampart — aerial constructs patrol a corridor of crystalline towers.",
+      "description": "The Spire's eastern rampart \u2014 aerial constructs patrol a corridor of crystalline towers.",
       "row": 2,
       "col": 0,
       "rowCols": 4,
-      "parentIds": [
-        "arcane-library"
-      ],
       "childIds": [
         "echo-sentinel"
       ],
@@ -550,13 +543,10 @@
       "id": "crystal-wellspring",
       "type": "rest",
       "label": "Crystal Wellspring",
-      "description": "A ley-line junction frozen mid-flow. The mana still seeps — enough to rest beside, enough to heal.",
+      "description": "A ley-line junction frozen mid-flow. The mana still seeps \u2014 enough to rest beside, enough to heal.",
       "row": 1,
       "col": 3,
       "rowCols": 4,
-      "parentIds": [
-        "crystal-approach"
-      ],
       "childIds": [
         "crystal-bridge",
         "void-merchant"
@@ -568,13 +558,10 @@
       "id": "crystal-bridge",
       "type": "battle",
       "label": "Crystal Bridge",
-      "description": "The only crossing between the outer lattice and the inner sanctum — a kilometre of suspended crystal with something very large waiting on the other side.",
+      "description": "The only crossing between the outer lattice and the inner sanctum \u2014 a kilometre of suspended crystal with something very large waiting on the other side.",
       "row": 2,
       "col": 2,
       "rowCols": 4,
-      "parentIds": [
-        "crystal-wellspring"
-      ],
       "childIds": [
         "mana-forge"
       ],
@@ -600,13 +587,10 @@
       "id": "golem-works",
       "type": "battle",
       "label": "Golem Works",
-      "description": "The Spire's construct foundry — still running, still producing, with nobody left to give the golems new orders.",
+      "description": "The Spire's construct foundry \u2014 still running, still producing, with nobody left to give the golems new orders.",
       "row": 4,
       "col": 0,
       "rowCols": 4,
-      "parentIds": [
-        "echo-sentinel"
-      ],
       "childIds": [
         "spire-crossing"
       ],
@@ -635,9 +619,6 @@
       "row": 2,
       "col": 3,
       "rowCols": 4,
-      "parentIds": [
-        "crystal-wellspring"
-      ],
       "childIds": [
         "mana-forge"
       ],
@@ -647,14 +628,10 @@
       "id": "echo-sentinel",
       "type": "elite",
       "label": "Echo Sentinel",
-      "description": "A construct that absorbed enough ambient magic to develop something like strategy — and has been applying it to the same corridor for three years.",
+      "description": "A construct that absorbed enough ambient magic to develop something like strategy \u2014 and has been applying it to the same corridor for three years.",
       "row": 3,
       "col": 0,
       "rowCols": 4,
-      "parentIds": [
-        "spire-flank",
-        "arcane-vault"
-      ],
       "childIds": [
         "golem-works"
       ],
@@ -691,10 +668,6 @@
       "row": 3,
       "col": 3,
       "rowCols": 4,
-      "parentIds": [
-        "crystal-bridge",
-        "void-merchant"
-      ],
       "childIds": [
         "arcanist-champion"
       ],
@@ -705,20 +678,17 @@
       "id": "arcane-vault",
       "type": "event",
       "label": "Arcane Vault",
-      "description": "A sealed research chamber — the lock corroded three years ago, but nobody has been past to notice.",
+      "description": "A sealed research chamber \u2014 the lock corroded three years ago, but nobody has been past to notice.",
       "row": 2,
       "col": 1,
       "rowCols": 4,
-      "parentIds": [
-        "arcane-library"
-      ],
       "childIds": [
         "echo-sentinel"
       ],
       "environment": "ruins",
       "eventConfig": {
         "title": "The Arcane Vault",
-        "description": "A sealed research chamber — the lock corroded three years ago, but nobody has been past to notice. Inside: containment circles drawn in silver, a humming obelisk, and a single chair facing it.",
+        "description": "A sealed research chamber \u2014 the lock corroded three years ago, but nobody has been past to notice. Inside: containment circles drawn in silver, a humming obelisk, and a single chair facing it.",
         "pools": [
           [
             {
@@ -731,7 +701,7 @@
             },
             {
               "label": "Examine the containment circles",
-              "consequence": "A circle activates and discharges — lose 12 HP.",
+              "consequence": "A circle activates and discharges \u2014 lose 12 HP.",
               "effect": {
                 "type": "damageHp",
                 "amount": 12
@@ -764,7 +734,7 @@
             },
             {
               "label": "Approach the obelisk",
-              "consequence": "The hum intensifies — restored 12 HP from ambient energy.",
+              "consequence": "The hum intensifies \u2014 restored 12 HP from ambient energy.",
               "effect": {
                 "type": "healHp",
                 "amount": 12
@@ -780,7 +750,7 @@
             },
             {
               "label": "Approach the obelisk",
-              "consequence": "It pulses and knocks you back — lose 14 HP.",
+              "consequence": "It pulses and knocks you back \u2014 lose 14 HP.",
               "effect": {
                 "type": "damageHp",
                 "amount": 14
@@ -788,7 +758,7 @@
             },
             {
               "label": "Approach the obelisk",
-              "consequence": "+1 life — the obelisk was built to protect its visitor.",
+              "consequence": "+1 life \u2014 the obelisk was built to protect its visitor.",
               "effect": {
                 "type": "gainLife",
                 "amount": 1
@@ -796,7 +766,7 @@
             },
             {
               "label": "Approach the obelisk",
-              "consequence": "A crystallised fragment detaches from the base — added to inventory",
+              "consequence": "A crystallised fragment detaches from the base \u2014 added to inventory",
               "effect": {
                 "type": "gainItem"
               }
@@ -805,7 +775,7 @@
           [
             {
               "label": "Sit in the lone chair",
-              "consequence": "A vision floods you — a legendary card surfaces.",
+              "consequence": "A vision floods you \u2014 a legendary card surfaces.",
               "effect": {
                 "type": "gainCard",
                 "rarity": "legendary"
@@ -828,7 +798,7 @@
             },
             {
               "label": "Sit in the lone chair",
-              "consequence": "The vision is catastrophic — lose 22 HP.",
+              "consequence": "The vision is catastrophic \u2014 lose 22 HP.",
               "effect": {
                 "type": "damageHp",
                 "amount": 22
@@ -842,13 +812,10 @@
       "id": "arcanist-champion",
       "type": "elite",
       "label": "Arcanist Champion",
-      "description": "The Archivist's original research assistant — crystallised into a construct, but retaining enough memory to be methodical, dangerous, and extremely thorough.",
+      "description": "The Archivist's original research assistant \u2014 crystallised into a construct, but retaining enough memory to be methodical, dangerous, and extremely thorough.",
       "row": 4,
       "col": 3,
       "rowCols": 4,
-      "parentIds": [
-        "mana-forge"
-      ],
       "childIds": [
         "spire-crossing"
       ],
@@ -889,9 +856,6 @@
       "row": 6,
       "col": 0,
       "rowCols": 1,
-      "parentIds": [
-        "spire-crossing"
-      ],
       "childIds": [],
       "handicap": 0,
       "environment": "citadel",
@@ -900,7 +864,7 @@
       "bossName": "The Archivist",
       "bossDialogue": [
         "\"I have been expecting you. I have been expecting you since you crossed the shard boundary. I have a file.\"",
-        "\"You should know: after turn eight, I stop being patient. The archive opens. Everything I have collected — everything — becomes available simultaneously.\"",
+        "\"You should know: after turn eight, I stop being patient. The archive opens. Everything I have collected \u2014 everything \u2014 becomes available simultaneously.\"",
         "\"This is not a threat. It is a statement of methodology. I am, above all things, methodical.\""
       ],
       "opponentIntervalMs": 5000,
@@ -937,10 +901,6 @@
       "row": 5,
       "col": 0,
       "rowCols": 1,
-      "parentIds": [
-        "golem-works",
-        "arcanist-champion"
-      ],
       "childIds": [
         "archivist"
       ],

--- a/web/src/data/acts/act5.json
+++ b/web/src/data/acts/act5.json
@@ -41,21 +41,21 @@
   "intro": [
     {
       "title": "THE SUNKEN REEF",
-      "text": "The shard hangs half-submerged — a lattice of coral, sunken ships, and old magic squeezed between two impossible tides.\n\nSomething large lives at its centre. Something old. The traders who escaped this shard don't talk about what they saw, but they all flinch at the same sounds: deep water, and bells."
+      "text": "The shard hangs half-submerged \u2014 a lattice of coral, sunken ships, and old magic squeezed between two impossible tides.\n\nSomething large lives at its centre. Something old. The traders who escaped this shard don't talk about what they saw, but they all flinch at the same sounds: deep water, and bells."
     },
     {
       "title": "THE TIDAL SOVEREIGN",
-      "text": "The Reef's guardian calls itself the Tidal Sovereign — a being of compressed sea-memory and slow, grinding patience.\n\nIt does not distinguish between invaders and travellers. The ocean, it once said, does not distinguish between ships it sinks and ships it simply forgets about.\n\nYou have decided not to be forgotten."
+      "text": "The Reef's guardian calls itself the Tidal Sovereign \u2014 a being of compressed sea-memory and slow, grinding patience.\n\nIt does not distinguish between invaders and travellers. The ocean, it once said, does not distinguish between ships it sinks and ships it simply forgets about.\n\nYou have decided not to be forgotten."
     },
     {
       "title": "THE PASSAGE",
-      "text": "The ley lines that thread through the Sunken Reef are old — older than the Fracture, older than the Dominion. They connect, somewhere in the deep, to the Fractured Core.\n\nIf you can break through the Sovereign's grip on the pathways, you might finally understand what the Fracture Event actually was.\n\nIf. The word is doing significant structural work in that sentence."
+      "text": "The ley lines that thread through the Sunken Reef are old \u2014 older than the Fracture, older than the Dominion. They connect, somewhere in the deep, to the Fractured Core.\n\nIf you can break through the Sovereign's grip on the pathways, you might finally understand what the Fracture Event actually was.\n\nIf. The word is doing significant structural work in that sentence."
     }
   ],
   "outro": [
     {
       "title": "THE SOVEREIGN FALLS",
-      "text": "The Tidal Sovereign does not collapse. It recedes — like a wave pulling back from shore, leaving behind silence and the smell of deep ocean.\n\nThe coral pathways glow. Sealed ley lines crack open. The Reef's memory of the Fracture is vivid and specific and terrifying, and you carry it with you as you leave."
+      "text": "The Tidal Sovereign does not collapse. It recedes \u2014 like a wave pulling back from shore, leaving behind silence and the smell of deep ocean.\n\nThe coral pathways glow. Sealed ley lines crack open. The Reef's memory of the Fracture is vivid and specific and terrifying, and you carry it with you as you leave."
     },
     {
       "title": "WHAT YOU LEARNED",
@@ -63,7 +63,7 @@
     },
     {
       "title": "ONWARD",
-      "text": "The Coral Mantle settles around you — a gift from the Reef, or a remnant of the Sovereign's dissolved form. Either way it fits.\n\nAhead: the Sky Dominion, where the aerial shards drift above clouds no map has ever charted. The ley lines point upward.\n\nYou have always been bad at taking hints."
+      "text": "The Coral Mantle settles around you \u2014 a gift from the Reef, or a remnant of the Sovereign's dissolved form. Either way it fits.\n\nAhead: the Sky Dominion, where the aerial shards drift above clouds no map has ever charted. The ley lines point upward.\n\nYou have always been bad at taking hints."
     }
   ],
   "nodes": {
@@ -75,7 +75,6 @@
       "row": 0,
       "col": 0,
       "rowCols": 1,
-      "parentIds": [],
       "childIds": [
         "tidal-shrine",
         "wreck-camp"
@@ -109,9 +108,6 @@
       "row": 1,
       "col": 0,
       "rowCols": 4,
-      "parentIds": [
-        "coral-breach"
-      ],
       "childIds": [
         "sunken-passage",
         "deep-current"
@@ -124,7 +120,7 @@
           [
             {
               "label": "Leave an offering",
-              "consequence": "The tide takes it — and returns 12 HP",
+              "consequence": "The tide takes it \u2014 and returns 12 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 12
@@ -132,7 +128,7 @@
             },
             {
               "label": "Leave an offering",
-              "consequence": "The shrine accepts the gift — +15 crystals",
+              "consequence": "The shrine accepts the gift \u2014 +15 crystals",
               "effect": {
                 "type": "gainCrystals",
                 "amount": 15
@@ -147,7 +143,7 @@
             },
             {
               "label": "Leave an offering",
-              "consequence": "Something beneath pulls harder than expected — lose 5 HP",
+              "consequence": "Something beneath pulls harder than expected \u2014 lose 5 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 5
@@ -157,7 +153,7 @@
           [
             {
               "label": "Read the carvings",
-              "consequence": "The glyphs resolve into a card — uncommon",
+              "consequence": "The glyphs resolve into a card \u2014 uncommon",
               "effect": {
                 "type": "gainCard",
                 "rarity": "uncommon"
@@ -165,7 +161,7 @@
             },
             {
               "label": "Read the carvings",
-              "consequence": "The pattern heals old wounds — restored 8 HP",
+              "consequence": "The pattern heals old wounds \u2014 restored 8 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 8
@@ -173,7 +169,7 @@
             },
             {
               "label": "Read the carvings",
-              "consequence": "The knowledge is expensive — lose 10 HP",
+              "consequence": "The knowledge is expensive \u2014 lose 10 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 10
@@ -181,7 +177,7 @@
             },
             {
               "label": "Read the carvings",
-              "consequence": "Salt and old magic — +20 crystals",
+              "consequence": "Salt and old magic \u2014 +20 crystals",
               "effect": {
                 "type": "gainCrystals",
                 "amount": 20
@@ -191,7 +187,7 @@
           [
             {
               "label": "Smash it for components",
-              "consequence": "The components are worth something — +18 crystals",
+              "consequence": "The components are worth something \u2014 +18 crystals",
               "effect": {
                 "type": "gainCrystals",
                 "amount": 18
@@ -207,7 +203,7 @@
             },
             {
               "label": "Smash it for components",
-              "consequence": "The shrine curses you for the disrespect — lose 15 HP",
+              "consequence": "The shrine curses you for the disrespect \u2014 lose 15 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 15
@@ -225,9 +221,6 @@
       "row": 1,
       "col": 3,
       "rowCols": 4,
-      "parentIds": [
-        "coral-breach"
-      ],
       "childIds": [
         "drowned-shrine",
         "reef-bazaar"
@@ -243,9 +236,6 @@
       "row": 2,
       "col": 3,
       "rowCols": 4,
-      "parentIds": [
-        "wreck-camp"
-      ],
       "childIds": [
         "depth-rest"
       ],
@@ -259,9 +249,6 @@
       "row": 2,
       "col": 0,
       "rowCols": 4,
-      "parentIds": [
-        "tidal-shrine"
-      ],
       "childIds": [
         "reef-patrol-elite"
       ],
@@ -294,9 +281,6 @@
       "row": 4,
       "col": 0,
       "rowCols": 4,
-      "parentIds": [
-        "reef-patrol-elite"
-      ],
       "childIds": [
         "kelp-crossing"
       ],
@@ -325,20 +309,17 @@
       "id": "deep-current",
       "type": "event",
       "label": "Deep Current",
-      "description": "A ley-line current surfaces here — warm, electric, and full of lost things.",
+      "description": "A ley-line current surfaces here \u2014 warm, electric, and full of lost things.",
       "row": 2,
       "col": 1,
       "rowCols": 4,
-      "parentIds": [
-        "tidal-shrine"
-      ],
       "childIds": [
         "reef-patrol-elite"
       ],
       "environment": "reef",
       "eventConfig": {
         "title": "The Deep Current",
-        "description": "A ley-line current surfaces from a crack in the reef floor. It carries the smell of the Fractured Core — sharp, electric, and ancient. Fragments of Dominion magic swirl in its flow.",
+        "description": "A ley-line current surfaces from a crack in the reef floor. It carries the smell of the Fractured Core \u2014 sharp, electric, and ancient. Fragments of Dominion magic swirl in its flow.",
         "pools": [
           [
             {
@@ -351,7 +332,7 @@
             },
             {
               "label": "Reach in",
-              "consequence": "The current pulls you briefly under — lose 12 HP",
+              "consequence": "The current pulls you briefly under \u2014 lose 12 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 12
@@ -359,7 +340,7 @@
             },
             {
               "label": "Reach in",
-              "consequence": "Something warm and healing — restored 15 HP",
+              "consequence": "Something warm and healing \u2014 restored 15 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 15
@@ -377,7 +358,7 @@
           [
             {
               "label": "Follow it downstream",
-              "consequence": "You find a Dominion salvage cache — +30 crystals",
+              "consequence": "You find a Dominion salvage cache \u2014 +30 crystals",
               "effect": {
                 "type": "gainCrystals",
                 "amount": 30
@@ -385,7 +366,7 @@
             },
             {
               "label": "Follow it downstream",
-              "consequence": "The current ends at a dead drop — uncommon card",
+              "consequence": "The current ends at a dead drop \u2014 uncommon card",
               "effect": {
                 "type": "gainCard",
                 "rarity": "uncommon"
@@ -410,10 +391,6 @@
       "row": 3,
       "col": 0,
       "rowCols": 4,
-      "parentIds": [
-        "sunken-passage",
-        "deep-current"
-      ],
       "childIds": [
         "abyssal-ambush"
       ],
@@ -446,10 +423,6 @@
       "row": 5,
       "col": 0,
       "rowCols": 1,
-      "parentIds": [
-        "abyssal-ambush",
-        "deep-elite"
-      ],
       "childIds": [
         "tidal-sovereign"
       ],
@@ -482,21 +455,18 @@
       "row": 2,
       "col": 2,
       "rowCols": 4,
-      "parentIds": [
-        "wreck-camp"
-      ],
       "childIds": [
         "depth-rest"
       ],
       "environment": "reef",
       "eventConfig": {
         "title": "The Drowned Archive",
-        "description": "A Dominion archive sits perfectly preserved inside a sealed air pocket — marble shelves, brass fixtures, and a thousand books that have become coral. The card drawers, however, are watertight.",
+        "description": "A Dominion archive sits perfectly preserved inside a sealed air pocket \u2014 marble shelves, brass fixtures, and a thousand books that have become coral. The card drawers, however, are watertight.",
         "pools": [
           [
             {
               "label": "Search the drawers",
-              "consequence": "A rare card, preserved in wax — yours",
+              "consequence": "A rare card, preserved in wax \u2014 yours",
               "effect": {
                 "type": "gainCard",
                 "rarity": "rare"
@@ -504,7 +474,7 @@
             },
             {
               "label": "Search the drawers",
-              "consequence": "Only common finds, but several — +20 crystals",
+              "consequence": "Only common finds, but several \u2014 +20 crystals",
               "effect": {
                 "type": "gainCrystals",
                 "amount": 20
@@ -512,7 +482,7 @@
             },
             {
               "label": "Search the drawers",
-              "consequence": "A pressure seal breaks — lose 8 HP",
+              "consequence": "A pressure seal breaks \u2014 lose 8 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 8
@@ -522,7 +492,7 @@
           [
             {
               "label": "Rest among the stacks",
-              "consequence": "Dry floor, still air — restored 15 HP",
+              "consequence": "Dry floor, still air \u2014 restored 15 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 15
@@ -530,7 +500,7 @@
             },
             {
               "label": "Rest among the stacks",
-              "consequence": "A forgotten card falls from a shelf — uncommon",
+              "consequence": "A forgotten card falls from a shelf \u2014 uncommon",
               "effect": {
                 "type": "gainCard",
                 "rarity": "uncommon"
@@ -548,10 +518,6 @@
       "row": 3,
       "col": 3,
       "rowCols": 4,
-      "parentIds": [
-        "drowned-shrine",
-        "reef-bazaar"
-      ],
       "childIds": [
         "deep-elite"
       ],
@@ -566,9 +532,6 @@
       "row": 4,
       "col": 3,
       "rowCols": 4,
-      "parentIds": [
-        "depth-rest"
-      ],
       "childIds": [
         "kelp-crossing"
       ],
@@ -601,9 +564,6 @@
       "row": 6,
       "col": 0,
       "rowCols": 1,
-      "parentIds": [
-        "kelp-crossing"
-      ],
       "childIds": [],
       "handicap": 22,
       "opponentIntervalMs": 3400,

--- a/web/src/data/acts/act6.json
+++ b/web/src/data/acts/act6.json
@@ -41,15 +41,15 @@
   "intro": [
     {
       "title": "THE SKY DOMINION",
-      "text": "You've climbed out of the sea and into the air.\n\nThe Sky Dominion exists on drifting islands — chunks of terrain that broke loose during the Fracture and simply refused to come back down. They've been up here so long they've built cities on them. Militarised them. Connected them with rope-bridges and siege platforms and weapons specifically designed to hit things that are also in the air.\n\nThey do not like visitors."
+      "text": "You've climbed out of the sea and into the air.\n\nThe Sky Dominion exists on drifting islands \u2014 chunks of terrain that broke loose during the Fracture and simply refused to come back down. They've been up here so long they've built cities on them. Militarised them. Connected them with rope-bridges and siege platforms and weapons specifically designed to hit things that are also in the air.\n\nThey do not like visitors."
     },
     {
       "title": "THE CLOUDMARSHAL",
-      "text": "Command of the Sky Dominion belongs to the Cloudmarshal — a general who has never lost a battle because, practically speaking, her armies have always had the high ground.\n\nShe does not consider a tactician without wings a credible threat. She's said this, publicly, several times.\n\nYou are going to prove her wrong. You always find this kind of statement motivating."
+      "text": "Command of the Sky Dominion belongs to the Cloudmarshal \u2014 a general who has never lost a battle because, practically speaking, her armies have always had the high ground.\n\nShe does not consider a tactician without wings a credible threat. She's said this, publicly, several times.\n\nYou are going to prove her wrong. You always find this kind of statement motivating."
     },
     {
       "title": "THE LEY BRIDGE",
-      "text": "The ley lines rise here — thick, crackling columns of energy that punch up through the clouds and connect to something far above. If the Fractured Core exists anywhere, the ley lines suggest it's in a direction the Cloudmarshal considers her personal airspace.\n\nYou will need to break through her defences to reach it.\n\nAt least the view will be good."
+      "text": "The ley lines rise here \u2014 thick, crackling columns of energy that punch up through the clouds and connect to something far above. If the Fractured Core exists anywhere, the ley lines suggest it's in a direction the Cloudmarshal considers her personal airspace.\n\nYou will need to break through her defences to reach it.\n\nAt least the view will be good."
     }
   ],
   "outro": [
@@ -63,7 +63,7 @@
     },
     {
       "title": "HIGHER STILL",
-      "text": "The Stormcaller's Badge sits in your hand — a Sky Dominion medal, given to the first enemy officer who ever reached the upper platforms.\n\nYou aren't an officer. Close enough.\n\nThe ley lines point upward. They always do. You've stopped being surprised by that."
+      "text": "The Stormcaller's Badge sits in your hand \u2014 a Sky Dominion medal, given to the first enemy officer who ever reached the upper platforms.\n\nYou aren't an officer. Close enough.\n\nThe ley lines point upward. They always do. You've stopped being surprised by that."
     }
   ],
   "nodes": {
@@ -75,7 +75,6 @@
       "row": 0,
       "col": 0,
       "rowCols": 1,
-      "parentIds": [],
       "childIds": [
         "wind-shrine",
         "skyport-camp"
@@ -109,9 +108,6 @@
       "row": 1,
       "col": 0,
       "rowCols": 4,
-      "parentIds": [
-        "cloudbreach"
-      ],
       "childIds": [
         "gale-crossing",
         "thermal-vent"
@@ -147,7 +143,7 @@
             },
             {
               "label": "Offer something to the wind",
-              "consequence": "A downdraft hits you — lose 5 HP",
+              "consequence": "A downdraft hits you \u2014 lose 5 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 5
@@ -157,7 +153,7 @@
           [
             {
               "label": "Read the wind patterns",
-              "consequence": "The patterns describe a rare card's construction — yours",
+              "consequence": "The patterns describe a rare card's construction \u2014 yours",
               "effect": {
                 "type": "gainCard",
                 "rarity": "rare"
@@ -165,7 +161,7 @@
             },
             {
               "label": "Read the wind patterns",
-              "consequence": "The patterns heal — restored 8 HP",
+              "consequence": "The patterns heal \u2014 restored 8 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 8
@@ -183,7 +179,7 @@
           [
             {
               "label": "Pocket the shrine parts",
-              "consequence": "Sold in the next port — +18 crystals",
+              "consequence": "Sold in the next port \u2014 +18 crystals",
               "effect": {
                 "type": "gainCrystals",
                 "amount": 18
@@ -199,7 +195,7 @@
             },
             {
               "label": "Pocket the shrine parts",
-              "consequence": "Something electrical discharges — lose 12 HP",
+              "consequence": "Something electrical discharges \u2014 lose 12 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 12
@@ -217,9 +213,6 @@
       "row": 1,
       "col": 3,
       "rowCols": 4,
-      "parentIds": [
-        "cloudbreach"
-      ],
       "childIds": [
         "archive-isle",
         "sky-bazaar"
@@ -235,9 +228,6 @@
       "row": 2,
       "col": 3,
       "rowCols": 4,
-      "parentIds": [
-        "skyport-camp"
-      ],
       "childIds": [
         "high-rest"
       ],
@@ -251,9 +241,6 @@
       "row": 2,
       "col": 0,
       "rowCols": 4,
-      "parentIds": [
-        "wind-shrine"
-      ],
       "childIds": [
         "sky-elite"
       ],
@@ -286,9 +273,6 @@
       "row": 4,
       "col": 0,
       "rowCols": 4,
-      "parentIds": [
-        "sky-elite"
-      ],
       "childIds": [
         "upper-platform"
       ],
@@ -321,16 +305,13 @@
       "row": 2,
       "col": 1,
       "rowCols": 4,
-      "parentIds": [
-        "wind-shrine"
-      ],
       "childIds": [
         "sky-elite"
       ],
       "environment": "sky",
       "eventConfig": {
         "title": "The Thermal Column",
-        "description": "A powerful updraft punches through a gap in the island's floor. It carries the smell of the shards below — and loose objects that fell off other islands during the Fracture.",
+        "description": "A powerful updraft punches through a gap in the island's floor. It carries the smell of the shards below \u2014 and loose objects that fell off other islands during the Fracture.",
         "pools": [
           [
             {
@@ -343,7 +324,7 @@
             },
             {
               "label": "Reach in",
-              "consequence": "The updraft carries something warm — healed 15 HP",
+              "consequence": "The updraft carries something warm \u2014 healed 15 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 15
@@ -351,7 +332,7 @@
             },
             {
               "label": "Reach in",
-              "consequence": "Something comes up fast and hits you — lose 10 HP",
+              "consequence": "Something comes up fast and hits you \u2014 lose 10 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 10
@@ -369,7 +350,7 @@
           [
             {
               "label": "Follow the column up",
-              "consequence": "You find a supply cache on the way — +30 crystals",
+              "consequence": "You find a supply cache on the way \u2014 +30 crystals",
               "effect": {
                 "type": "gainCrystals",
                 "amount": 30
@@ -402,10 +383,6 @@
       "row": 3,
       "col": 0,
       "rowCols": 4,
-      "parentIds": [
-        "gale-crossing",
-        "thermal-vent"
-      ],
       "childIds": [
         "storm-battery"
       ],
@@ -434,14 +411,10 @@
       "id": "upper-platform",
       "type": "battle",
       "label": "Upper Platform",
-      "description": "The highest inhabited island. From here you can see the ley bridge — and everything defending it.",
+      "description": "The highest inhabited island. From here you can see the ley bridge \u2014 and everything defending it.",
       "row": 5,
       "col": 0,
       "rowCols": 1,
-      "parentIds": [
-        "storm-battery",
-        "summit-elite"
-      ],
       "childIds": [
         "cloudmarshal"
       ],
@@ -474,21 +447,18 @@
       "row": 2,
       "col": 2,
       "rowCols": 4,
-      "parentIds": [
-        "skyport-camp"
-      ],
       "childIds": [
         "high-rest"
       ],
       "environment": "sky",
       "eventConfig": {
         "title": "The Command Post",
-        "description": "An abandoned Dominion command post, still warm from use. Maps, tactical notes, and a half-eaten ration. The logs describe the Fracture from above — and something the Cloudmarshal calls 'the signal.'",
+        "description": "An abandoned Dominion command post, still warm from use. Maps, tactical notes, and a half-eaten ration. The logs describe the Fracture from above \u2014 and something the Cloudmarshal calls 'the signal.'",
         "pools": [
           [
             {
               "label": "Read the tactical logs",
-              "consequence": "The strategy is useful — rare card",
+              "consequence": "The strategy is useful \u2014 rare card",
               "effect": {
                 "type": "gainCard",
                 "rarity": "rare"
@@ -496,7 +466,7 @@
             },
             {
               "label": "Read the tactical logs",
-              "consequence": "You find supply caches marked on the map — +25 crystals",
+              "consequence": "You find supply caches marked on the map \u2014 +25 crystals",
               "effect": {
                 "type": "gainCrystals",
                 "amount": 25
@@ -506,7 +476,7 @@
           [
             {
               "label": "Rest in the shelter",
-              "consequence": "First proper shelter in hours — healed 15 HP",
+              "consequence": "First proper shelter in hours \u2014 healed 15 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 15
@@ -532,10 +502,6 @@
       "row": 3,
       "col": 3,
       "rowCols": 4,
-      "parentIds": [
-        "archive-isle",
-        "sky-bazaar"
-      ],
       "childIds": [
         "summit-elite"
       ],
@@ -550,9 +516,6 @@
       "row": 4,
       "col": 3,
       "rowCols": 4,
-      "parentIds": [
-        "high-rest"
-      ],
       "childIds": [
         "upper-platform"
       ],
@@ -585,9 +548,6 @@
       "row": 6,
       "col": 0,
       "rowCols": 1,
-      "parentIds": [
-        "upper-platform"
-      ],
       "childIds": [],
       "handicap": 24,
       "opponentIntervalMs": 3300,

--- a/web/src/data/acts/act7.json
+++ b/web/src/data/acts/act7.json
@@ -42,15 +42,15 @@
   "intro": [
     {
       "title": "THE EMBERFALL PEAKS",
-      "text": "The ley lines cut through the mountains here — through layers of volcanic rock still warm from the last eruption. This is the Emberfall Peaks: a chain of active volcanoes that the Fracture cracked open and left to simmer.\n\nThings live here. Heat-adapted things. Things that were dangerous before the Fracture made them angrier.\n\nThe ley path goes through the caldera. There's no route around."
+      "text": "The ley lines cut through the mountains here \u2014 through layers of volcanic rock still warm from the last eruption. This is the Emberfall Peaks: a chain of active volcanoes that the Fracture cracked open and left to simmer.\n\nThings live here. Heat-adapted things. Things that were dangerous before the Fracture made them angrier.\n\nThe ley path goes through the caldera. There's no route around."
     },
     {
       "title": "THE CINDERWARLORD",
-      "text": "The Peaks are held by the Cinderwarlord — a commander who built an army out of whatever the volcanoes threw up: crawlers, hounds, archers who fire molten shot, constructs assembled from cooled lava-flow.\n\nHe has not lost the mountains once. The mountains are on his side. Literally. He has an understanding with them.\n\nYou are going to walk through his territory regardless."
+      "text": "The Peaks are held by the Cinderwarlord \u2014 a commander who built an army out of whatever the volcanoes threw up: crawlers, hounds, archers who fire molten shot, constructs assembled from cooled lava-flow.\n\nHe has not lost the mountains once. The mountains are on his side. Literally. He has an understanding with them.\n\nYou are going to walk through his territory regardless."
     },
     {
       "title": "HEAT AND PRESSURE",
-      "text": "The deeper you go, the hotter it gets. The ley lines are visible here — they glow faintly orange, like metal near a forge, and they point straight toward the caldera at the heart of the range.\n\nWhatever is at the Fracture Core, the ley lines think this is the way.\n\nYou have learned to trust the ley lines. You have also learned to bring extra water."
+      "text": "The deeper you go, the hotter it gets. The ley lines are visible here \u2014 they glow faintly orange, like metal near a forge, and they point straight toward the caldera at the heart of the range.\n\nWhatever is at the Fracture Core, the ley lines think this is the way.\n\nYou have learned to trust the ley lines. You have also learned to bring extra water."
     }
   ],
   "outro": [
@@ -64,7 +64,7 @@
     },
     {
       "title": "DEEPER IN",
-      "text": "The Magma Core sits in your hand — a solid chunk of volcanic glass with something still burning at the centre. The Cinderwarlord's mark of command.\n\nThe ley lines glow brighter past the caldera. Whatever the Fracture Core is, it's warmer on this side.\n\nYou move forward. The mountains stop objecting."
+      "text": "The Magma Core sits in your hand \u2014 a solid chunk of volcanic glass with something still burning at the centre. The Cinderwarlord's mark of command.\n\nThe ley lines glow brighter past the caldera. Whatever the Fracture Core is, it's warmer on this side.\n\nYou move forward. The mountains stop objecting."
     }
   ],
   "nodes": {
@@ -76,7 +76,6 @@
       "row": 0,
       "col": 0,
       "rowCols": 1,
-      "parentIds": [],
       "childIds": [
         "ash-shrine",
         "lava-camp"
@@ -110,9 +109,6 @@
       "row": 1,
       "col": 0,
       "rowCols": 4,
-      "parentIds": [
-        "cinder-approach"
-      ],
       "childIds": [
         "magma-ford",
         "cinder-vent"
@@ -120,12 +116,12 @@
       "environment": "volcano",
       "eventConfig": {
         "title": "The Ash Shrine",
-        "description": "A ring of fused volcanic rock, still warm. Ash coils upward in slow spirals — too slow for the wind to explain. Whatever was worshipped here, something is still paying attention.",
+        "description": "A ring of fused volcanic rock, still warm. Ash coils upward in slow spirals \u2014 too slow for the wind to explain. Whatever was worshipped here, something is still paying attention.",
         "pools": [
           [
             {
               "label": "Leave an offering",
-              "consequence": "The ash spirals outward — healed 12 HP",
+              "consequence": "The ash spirals outward \u2014 healed 12 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 12
@@ -133,7 +129,7 @@
             },
             {
               "label": "Leave an offering",
-              "consequence": "Hot ash stings your hands — lose 6 HP",
+              "consequence": "Hot ash stings your hands \u2014 lose 6 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 6
@@ -159,7 +155,7 @@
           [
             {
               "label": "Read the ash patterns",
-              "consequence": "The patterns describe something useful — uncommon card",
+              "consequence": "The patterns describe something useful \u2014 uncommon card",
               "effect": {
                 "type": "gainCard",
                 "rarity": "uncommon"
@@ -167,7 +163,7 @@
             },
             {
               "label": "Read the ash patterns",
-              "consequence": "The patterns heal — restored 8 HP",
+              "consequence": "The patterns heal \u2014 restored 8 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 8
@@ -185,7 +181,7 @@
           [
             {
               "label": "Pocket the shrine stones",
-              "consequence": "Still warm — good for +18 crystals in the next market",
+              "consequence": "Still warm \u2014 good for +18 crystals in the next market",
               "effect": {
                 "type": "gainCrystals",
                 "amount": 18
@@ -201,7 +197,7 @@
             },
             {
               "label": "Pocket the shrine stones",
-              "consequence": "One stone discharges — lose 10 HP",
+              "consequence": "One stone discharges \u2014 lose 10 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 10
@@ -219,9 +215,6 @@
       "row": 1,
       "col": 3,
       "rowCols": 4,
-      "parentIds": [
-        "cinder-approach"
-      ],
       "childIds": [
         "forge-log",
         "ember-bazaar"
@@ -237,9 +230,6 @@
       "row": 2,
       "col": 3,
       "rowCols": 4,
-      "parentIds": [
-        "lava-camp"
-      ],
       "childIds": [
         "crater-rest"
       ],
@@ -253,9 +243,6 @@
       "row": 2,
       "col": 0,
       "rowCols": 4,
-      "parentIds": [
-        "ash-shrine"
-      ],
       "childIds": [
         "pyroclast-elite"
       ],
@@ -288,9 +275,6 @@
       "row": 4,
       "col": 0,
       "rowCols": 4,
-      "parentIds": [
-        "pyroclast-elite"
-      ],
       "childIds": [
         "caldera-gate"
       ],
@@ -323,9 +307,6 @@
       "row": 2,
       "col": 1,
       "rowCols": 4,
-      "parentIds": [
-        "ash-shrine"
-      ],
       "childIds": [
         "pyroclast-elite"
       ],
@@ -345,7 +326,7 @@
             },
             {
               "label": "Reach into the column",
-              "consequence": "The heat is a balm — healed 15 HP",
+              "consequence": "The heat is a balm \u2014 healed 15 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 15
@@ -353,7 +334,7 @@
             },
             {
               "label": "Reach into the column",
-              "consequence": "Something comes out hot — lose 12 HP",
+              "consequence": "Something comes out hot \u2014 lose 12 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 12
@@ -371,7 +352,7 @@
           [
             {
               "label": "Follow the vent up the slope",
-              "consequence": "Supply cache wedged in the cooled rim — +30 crystals",
+              "consequence": "Supply cache wedged in the cooled rim \u2014 +30 crystals",
               "effect": {
                 "type": "gainCrystals",
                 "amount": 30
@@ -404,10 +385,6 @@
       "row": 3,
       "col": 0,
       "rowCols": 4,
-      "parentIds": [
-        "magma-ford",
-        "cinder-vent"
-      ],
       "childIds": [
         "volcanic-battery"
       ],
@@ -440,10 +417,6 @@
       "row": 5,
       "col": 0,
       "rowCols": 1,
-      "parentIds": [
-        "volcanic-battery",
-        "summit-elite"
-      ],
       "childIds": [
         "cinderwarlord"
       ],
@@ -476,21 +449,18 @@
       "row": 2,
       "col": 2,
       "rowCols": 4,
-      "parentIds": [
-        "lava-camp"
-      ],
       "childIds": [
         "crater-rest"
       ],
       "environment": "volcano",
       "eventConfig": {
         "title": "The Forge Post",
-        "description": "A Cinderwarlord field post, evacuated in the fighting. Forge tools, tactical slates, and a map of the caldera. The slate shows the Cinderwarlord's actual position — and something he marked 'signal origin' in the deep caldera.",
+        "description": "A Cinderwarlord field post, evacuated in the fighting. Forge tools, tactical slates, and a map of the caldera. The slate shows the Cinderwarlord's actual position \u2014 and something he marked 'signal origin' in the deep caldera.",
         "pools": [
           [
             {
               "label": "Study the tactical slates",
-              "consequence": "Useful knowledge — rare card",
+              "consequence": "Useful knowledge \u2014 rare card",
               "effect": {
                 "type": "gainCard",
                 "rarity": "rare"
@@ -498,7 +468,7 @@
             },
             {
               "label": "Study the tactical slates",
-              "consequence": "The supply caches are marked — +25 crystals",
+              "consequence": "The supply caches are marked \u2014 +25 crystals",
               "effect": {
                 "type": "gainCrystals",
                 "amount": 25
@@ -508,7 +478,7 @@
           [
             {
               "label": "Use the forge rest area",
-              "consequence": "Proper heat for once — healed 15 HP",
+              "consequence": "Proper heat for once \u2014 healed 15 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 15
@@ -534,10 +504,6 @@
       "row": 3,
       "col": 3,
       "rowCols": 4,
-      "parentIds": [
-        "forge-log",
-        "ember-bazaar"
-      ],
       "childIds": [
         "summit-elite"
       ],
@@ -552,9 +518,6 @@
       "row": 4,
       "col": 3,
       "rowCols": 4,
-      "parentIds": [
-        "crater-rest"
-      ],
       "childIds": [
         "caldera-gate"
       ],
@@ -587,9 +550,6 @@
       "row": 6,
       "col": 0,
       "rowCols": 1,
-      "parentIds": [
-        "caldera-gate"
-      ],
       "childIds": [],
       "handicap": 26,
       "opponentIntervalMs": 3600,

--- a/web/src/data/acts/act8.json
+++ b/web/src/data/acts/act8.json
@@ -46,7 +46,7 @@
     },
     {
       "title": "THE ROOT QUEEN",
-      "text": "The Fungal Deep is not ruled. It is tended.\n\nThe Root Queen is not a person in any conventional sense — she's the oldest node in the mycelium network, the point everything connects back to. She doesn't give orders. She pulses. Things respond.\n\nShe has been aware of you since you entered the first cavern. She has been deciding what to do about you. She has decided."
+      "text": "The Fungal Deep is not ruled. It is tended.\n\nThe Root Queen is not a person in any conventional sense \u2014 she's the oldest node in the mycelium network, the point everything connects back to. She doesn't give orders. She pulses. Things respond.\n\nShe has been aware of you since you entered the first cavern. She has been deciding what to do about you. She has decided."
     },
     {
       "title": "GOING UNDER",
@@ -56,7 +56,7 @@
   "outro": [
     {
       "title": "THE ROOT QUEEN STILLS",
-      "text": "The network doesn't die. That would be too simple.\n\nIt stills — a long, slow reduction, like a fire burning down rather than going out. The Root Queen doesn't speak exactly, but something that constitutes speech passes through the mycelium and reaches you: something that means 'enough.'\n\nThe ley lines pulse clear. The way opens downward."
+      "text": "The network doesn't die. That would be too simple.\n\nIt stills \u2014 a long, slow reduction, like a fire burning down rather than going out. The Root Queen doesn't speak exactly, but something that constitutes speech passes through the mycelium and reaches you: something that means 'enough.'\n\nThe ley lines pulse clear. The way opens downward."
     },
     {
       "title": "WHAT SHE UNDERSTOOD",
@@ -64,7 +64,7 @@
     },
     {
       "title": "THE SPORE BLOOM",
-      "text": "The Spore Bloom sits in your hand — a dense, warm cluster of something that is technically a seed but feels considerably more significant than that.\n\nThe mycelium connected to it as you left, briefly. You got the impression it was saying goodbye.\n\nThe ley lines run deeper. They always run deeper. That, at least, is consistent."
+      "text": "The Spore Bloom sits in your hand \u2014 a dense, warm cluster of something that is technically a seed but feels considerably more significant than that.\n\nThe mycelium connected to it as you left, briefly. You got the impression it was saying goodbye.\n\nThe ley lines run deeper. They always run deeper. That, at least, is consistent."
     }
   ],
   "nodes": {
@@ -76,7 +76,6 @@
       "row": 0,
       "col": 0,
       "rowCols": 1,
-      "parentIds": [],
       "childIds": [
         "spore-shrine",
         "root-hollow"
@@ -110,9 +109,6 @@
       "row": 1,
       "col": 0,
       "rowCols": 4,
-      "parentIds": [
-        "dark-descent"
-      ],
       "childIds": [
         "mycelium-crossing",
         "bloom-vent"
@@ -125,7 +121,7 @@
           [
             {
               "label": "Touch the largest cap",
-              "consequence": "The network sends something back — healed 12 HP",
+              "consequence": "The network sends something back \u2014 healed 12 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 12
@@ -133,7 +129,7 @@
             },
             {
               "label": "Touch the largest cap",
-              "consequence": "The spores sting — lose 6 HP",
+              "consequence": "The spores sting \u2014 lose 6 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 6
@@ -159,7 +155,7 @@
           [
             {
               "label": "Listen to the network",
-              "consequence": "Something useful echoes back — uncommon card",
+              "consequence": "Something useful echoes back \u2014 uncommon card",
               "effect": {
                 "type": "gainCard",
                 "rarity": "uncommon"
@@ -167,7 +163,7 @@
             },
             {
               "label": "Listen to the network",
-              "consequence": "The pulse heals — restored 10 HP",
+              "consequence": "The pulse heals \u2014 restored 10 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 10
@@ -185,7 +181,7 @@
           [
             {
               "label": "Harvest the caps",
-              "consequence": "Valuable in the right market — +18 crystals",
+              "consequence": "Valuable in the right market \u2014 +18 crystals",
               "effect": {
                 "type": "gainCrystals",
                 "amount": 18
@@ -201,7 +197,7 @@
             },
             {
               "label": "Harvest the caps",
-              "consequence": "The network objects — lose 10 HP",
+              "consequence": "The network objects \u2014 lose 10 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 10
@@ -219,9 +215,6 @@
       "row": 1,
       "col": 3,
       "rowCols": 4,
-      "parentIds": [
-        "dark-descent"
-      ],
       "childIds": [
         "root-archive",
         "deep-trader"
@@ -237,9 +230,6 @@
       "row": 2,
       "col": 3,
       "rowCols": 4,
-      "parentIds": [
-        "root-hollow"
-      ],
       "childIds": [
         "deep-rest"
       ],
@@ -253,9 +243,6 @@
       "row": 2,
       "col": 0,
       "rowCols": 4,
-      "parentIds": [
-        "spore-shrine"
-      ],
       "childIds": [
         "deep-elite"
       ],
@@ -288,9 +275,6 @@
       "row": 4,
       "col": 0,
       "rowCols": 4,
-      "parentIds": [
-        "deep-elite"
-      ],
       "childIds": [
         "queen-approach"
       ],
@@ -323,21 +307,18 @@
       "row": 2,
       "col": 1,
       "rowCols": 4,
-      "parentIds": [
-        "spore-shrine"
-      ],
       "childIds": [
         "deep-elite"
       ],
       "environment": "fungal",
       "eventConfig": {
         "title": "The Bloom Vent",
-        "description": "A wide fissure in the cavern floor, releasing slow pulses of warm spores. The clouds carry bioluminescent fragments — and, somehow, impressions. The network remembers everything that died down here.",
+        "description": "A wide fissure in the cavern floor, releasing slow pulses of warm spores. The clouds carry bioluminescent fragments \u2014 and, somehow, impressions. The network remembers everything that died down here.",
         "pools": [
           [
             {
               "label": "Walk through the bloom",
-              "consequence": "The spores knit wounds — healed 15 HP",
+              "consequence": "The spores knit wounds \u2014 healed 15 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 15
@@ -353,7 +334,7 @@
             },
             {
               "label": "Walk through the bloom",
-              "consequence": "The bloom is toxic here — lose 12 HP",
+              "consequence": "The bloom is toxic here \u2014 lose 12 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 12
@@ -404,10 +385,6 @@
       "row": 3,
       "col": 0,
       "rowCols": 4,
-      "parentIds": [
-        "mycelium-crossing",
-        "bloom-vent"
-      ],
       "childIds": [
         "rot-cavern"
       ],
@@ -440,10 +417,6 @@
       "row": 5,
       "col": 0,
       "rowCols": 1,
-      "parentIds": [
-        "rot-cavern",
-        "vanguard-elite"
-      ],
       "childIds": [
         "rootqueen"
       ],
@@ -476,21 +449,18 @@
       "row": 2,
       "col": 2,
       "rowCols": 4,
-      "parentIds": [
-        "root-hollow"
-      ],
       "childIds": [
         "deep-rest"
       ],
       "environment": "fungal",
       "eventConfig": {
         "title": "The Root Archive",
-        "description": "Columns of crystallised mycelium, each one preserving impressions of things the network witnessed. The Root Queen's full memory of the Fracture is here — she saw it from below. It reads differently from down here.",
+        "description": "Columns of crystallised mycelium, each one preserving impressions of things the network witnessed. The Root Queen's full memory of the Fracture is here \u2014 she saw it from below. It reads differently from down here.",
         "pools": [
           [
             {
               "label": "Absorb the archive",
-              "consequence": "The memory includes something useful — rare card",
+              "consequence": "The memory includes something useful \u2014 rare card",
               "effect": {
                 "type": "gainCard",
                 "rarity": "rare"
@@ -498,7 +468,7 @@
             },
             {
               "label": "Absorb the archive",
-              "consequence": "The network supply routes are mapped — +25 crystals",
+              "consequence": "The network supply routes are mapped \u2014 +25 crystals",
               "effect": {
                 "type": "gainCrystals",
                 "amount": 25
@@ -508,7 +478,7 @@
           [
             {
               "label": "Rest in the archive chamber",
-              "consequence": "The spores here are restorative — healed 15 HP",
+              "consequence": "The spores here are restorative \u2014 healed 15 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 15
@@ -534,10 +504,6 @@
       "row": 3,
       "col": 3,
       "rowCols": 4,
-      "parentIds": [
-        "root-archive",
-        "deep-trader"
-      ],
       "childIds": [
         "vanguard-elite"
       ],
@@ -552,9 +518,6 @@
       "row": 4,
       "col": 3,
       "rowCols": 4,
-      "parentIds": [
-        "deep-rest"
-      ],
       "childIds": [
         "queen-approach"
       ],
@@ -587,9 +550,6 @@
       "row": 6,
       "col": 0,
       "rowCols": 1,
-      "parentIds": [
-        "queen-approach"
-      ],
       "childIds": [],
       "handicap": 28,
       "opponentIntervalMs": 3600,

--- a/web/src/data/acts/act9.json
+++ b/web/src/data/acts/act9.json
@@ -46,17 +46,17 @@
     },
     {
       "title": "THE PALE ENGINE",
-      "text": "Nobody built the Pale Engine — or if they did, they did it so long ago that the Engine has stopped caring about the distinction. It runs on cold and purpose. Its purpose is to hold the Expanse against everything that isn't ice.\n\nIt doesn't sleep. It doesn't negotiate. It processes.\n\nYou represent an input it hasn't encountered before. It is in the process of developing a protocol."
+      "text": "Nobody built the Pale Engine \u2014 or if they did, they did it so long ago that the Engine has stopped caring about the distinction. It runs on cold and purpose. Its purpose is to hold the Expanse against everything that isn't ice.\n\nIt doesn't sleep. It doesn't negotiate. It processes.\n\nYou represent an input it hasn't encountered before. It is in the process of developing a protocol."
     },
     {
       "title": "INTO THE WHITE",
-      "text": "The cold here isn't just weather. It's structural. It holds the landscape together in a way that makes you understand why the Pale Engine defends it — remove the cold and the whole Expanse would need to rethink what it is.\n\nYou aren't here to take the cold. You're here to pass through it.\n\nThe Pale Engine will need to understand that distinction. You will need to explain it forcefully."
+      "text": "The cold here isn't just weather. It's structural. It holds the landscape together in a way that makes you understand why the Pale Engine defends it \u2014 remove the cold and the whole Expanse would need to rethink what it is.\n\nYou aren't here to take the cold. You're here to pass through it.\n\nThe Pale Engine will need to understand that distinction. You will need to explain it forcefully."
     }
   ],
   "outro": [
     {
       "title": "THE PALE ENGINE HALTS",
-      "text": "The Pale Engine doesn't fall. It stops — a precise, deliberate cessation, like a machine completing a cycle rather than failing. The cold continues around it. The Expanse doesn't care who won.\n\nThe ley lines pulse through the ice and keep going. They were never going to stop for this."
+      "text": "The Pale Engine doesn't fall. It stops \u2014 a precise, deliberate cessation, like a machine completing a cycle rather than failing. The cold continues around it. The Expanse doesn't care who won.\n\nThe ley lines pulse through the ice and keep going. They were never going to stop for this."
     },
     {
       "title": "WHAT IT PROCESSED",
@@ -64,7 +64,7 @@
     },
     {
       "title": "THE FROST MANTLE",
-      "text": "The Frost Mantle is a layer of something that was once the Engine's outer casing — dense, cold, and almost ornamental in the way it's settled into a shape that fits across your shoulders.\n\nThe cold doesn't bother you as much as it did. That's the point.\n\nThe ley lines run on. The Expanse recedes behind you."
+      "text": "The Frost Mantle is a layer of something that was once the Engine's outer casing \u2014 dense, cold, and almost ornamental in the way it's settled into a shape that fits across your shoulders.\n\nThe cold doesn't bother you as much as it did. That's the point.\n\nThe ley lines run on. The Expanse recedes behind you."
     }
   ],
   "nodes": {
@@ -76,7 +76,6 @@
       "row": 0,
       "col": 0,
       "rowCols": 1,
-      "parentIds": [],
       "childIds": [
         "frost-shrine",
         "ice-hollow"
@@ -110,9 +109,6 @@
       "row": 1,
       "col": 0,
       "rowCols": 4,
-      "parentIds": [
-        "glacier-gate"
-      ],
       "childIds": [
         "ice-crossing",
         "glacier-vent"
@@ -120,12 +116,12 @@
       "environment": "frost",
       "eventConfig": {
         "title": "The Frost Shrine",
-        "description": "A pillar of ancient ice, perfectly clear. Something is frozen at the centre — hard to identify, but clearly significant. The cold radiates outward in a way that feels intentional.",
+        "description": "A pillar of ancient ice, perfectly clear. Something is frozen at the centre \u2014 hard to identify, but clearly significant. The cold radiates outward in a way that feels intentional.",
         "pools": [
           [
             {
               "label": "Touch the ice",
-              "consequence": "The cold passes through you — healed 12 HP",
+              "consequence": "The cold passes through you \u2014 healed 12 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 12
@@ -133,7 +129,7 @@
             },
             {
               "label": "Touch the ice",
-              "consequence": "The cold bites — lose 6 HP",
+              "consequence": "The cold bites \u2014 lose 6 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 6
@@ -159,7 +155,7 @@
           [
             {
               "label": "Study the preserved form",
-              "consequence": "Useful information — uncommon card",
+              "consequence": "Useful information \u2014 uncommon card",
               "effect": {
                 "type": "gainCard",
                 "rarity": "uncommon"
@@ -167,7 +163,7 @@
             },
             {
               "label": "Study the preserved form",
-              "consequence": "The study restores focus — healed 10 HP",
+              "consequence": "The study restores focus \u2014 healed 10 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 10
@@ -185,7 +181,7 @@
           [
             {
               "label": "Chip away the ice",
-              "consequence": "Valuable residue — +18 crystals",
+              "consequence": "Valuable residue \u2014 +18 crystals",
               "effect": {
                 "type": "gainCrystals",
                 "amount": 18
@@ -201,7 +197,7 @@
             },
             {
               "label": "Chip away the ice",
-              "consequence": "The ice discharges — lose 10 HP",
+              "consequence": "The ice discharges \u2014 lose 10 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 10
@@ -219,9 +215,6 @@
       "row": 1,
       "col": 3,
       "rowCols": 4,
-      "parentIds": [
-        "glacier-gate"
-      ],
       "childIds": [
         "engine-log",
         "cold-trader"
@@ -237,9 +230,6 @@
       "row": 2,
       "col": 3,
       "rowCols": 4,
-      "parentIds": [
-        "ice-hollow"
-      ],
       "childIds": [
         "deep-freeze"
       ],
@@ -253,9 +243,6 @@
       "row": 2,
       "col": 0,
       "rowCols": 4,
-      "parentIds": [
-        "frost-shrine"
-      ],
       "childIds": [
         "pale-elite"
       ],
@@ -288,9 +275,6 @@
       "row": 4,
       "col": 0,
       "rowCols": 4,
-      "parentIds": [
-        "pale-elite"
-      ],
       "childIds": [
         "engine-approach"
       ],
@@ -323,16 +307,13 @@
       "row": 2,
       "col": 1,
       "rowCols": 4,
-      "parentIds": [
-        "frost-shrine"
-      ],
       "childIds": [
         "pale-elite"
       ],
       "environment": "frost",
       "eventConfig": {
         "title": "The Glacier Vent",
-        "description": "A wide crack in the ice shelf, venting cold air at high pressure. Debris from collapsed structures circulates in the column — and occasionally something more useful.",
+        "description": "A wide crack in the ice shelf, venting cold air at high pressure. Debris from collapsed structures circulates in the column \u2014 and occasionally something more useful.",
         "pools": [
           [
             {
@@ -345,7 +326,7 @@
             },
             {
               "label": "Reach into the vent",
-              "consequence": "The cold air clears wounds — healed 15 HP",
+              "consequence": "The cold air clears wounds \u2014 healed 15 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 15
@@ -353,7 +334,7 @@
             },
             {
               "label": "Reach into the vent",
-              "consequence": "The pressure hits hard — lose 12 HP",
+              "consequence": "The pressure hits hard \u2014 lose 12 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 12
@@ -371,7 +352,7 @@
           [
             {
               "label": "Follow the vent upward",
-              "consequence": "Supply cache at the top — +30 crystals",
+              "consequence": "Supply cache at the top \u2014 +30 crystals",
               "effect": {
                 "type": "gainCrystals",
                 "amount": 30
@@ -404,10 +385,6 @@
       "row": 3,
       "col": 0,
       "rowCols": 4,
-      "parentIds": [
-        "ice-crossing",
-        "glacier-vent"
-      ],
       "childIds": [
         "blizzard-battery"
       ],
@@ -440,10 +417,6 @@
       "row": 5,
       "col": 0,
       "rowCols": 1,
-      "parentIds": [
-        "blizzard-battery",
-        "engine-vanguard"
-      ],
       "childIds": [
         "paleengine"
       ],
@@ -476,21 +449,18 @@
       "row": 2,
       "col": 2,
       "rowCols": 4,
-      "parentIds": [
-        "ice-hollow"
-      ],
       "childIds": [
         "deep-freeze"
       ],
       "environment": "frost",
       "eventConfig": {
         "title": "The Engine Archive",
-        "description": "An access node to the Pale Engine's memory lattice — a crystalline storage of everything it has processed since the Fracture. Its record of the event is purely numerical. That's oddly clarifying.",
+        "description": "An access node to the Pale Engine's memory lattice \u2014 a crystalline storage of everything it has processed since the Fracture. Its record of the event is purely numerical. That's oddly clarifying.",
         "pools": [
           [
             {
               "label": "Access the archive",
-              "consequence": "Useful data — rare card",
+              "consequence": "Useful data \u2014 rare card",
               "effect": {
                 "type": "gainCard",
                 "rarity": "rare"
@@ -498,7 +468,7 @@
             },
             {
               "label": "Access the archive",
-              "consequence": "Supply routes documented — +25 crystals",
+              "consequence": "Supply routes documented \u2014 +25 crystals",
               "effect": {
                 "type": "gainCrystals",
                 "amount": 25
@@ -508,7 +478,7 @@
           [
             {
               "label": "Rest at the node",
-              "consequence": "The warmth of computation — healed 15 HP",
+              "consequence": "The warmth of computation \u2014 healed 15 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 15
@@ -534,10 +504,6 @@
       "row": 3,
       "col": 3,
       "rowCols": 4,
-      "parentIds": [
-        "engine-log",
-        "cold-trader"
-      ],
       "childIds": [
         "engine-vanguard"
       ],
@@ -552,9 +518,6 @@
       "row": 4,
       "col": 3,
       "rowCols": 4,
-      "parentIds": [
-        "deep-freeze"
-      ],
       "childIds": [
         "engine-approach"
       ],
@@ -586,9 +549,6 @@
       "row": 6,
       "col": 0,
       "rowCols": 1,
-      "parentIds": [
-        "engine-approach"
-      ],
       "childIds": [],
       "handicap": 30,
       "opponentIntervalMs": 3600,

--- a/web/src/data/acts/actfinale.json
+++ b/web/src/data/acts/actfinale.json
@@ -39,11 +39,11 @@
   "intro": [
     {
       "title": "THE FRACTURED CORE",
-      "text": "You have crossed thirteen shards, faced their champions, and collected their secrets. The path has always led here — to the wound at the world's heart.\n\nThe Fracture Event tore reality apart and scattered the Dominion into pieces. Something caused it. Something remains at the centre."
+      "text": "You have crossed thirteen shards, faced their champions, and collected their secrets. The path has always led here \u2014 to the wound at the world's heart.\n\nThe Fracture Event tore reality apart and scattered the Dominion into pieces. Something caused it. Something remains at the centre."
     },
     {
       "title": "THE FORCE WITHIN",
-      "text": "The Fractured Core does not feel like a place. It feels like the absence of one — a scar where the world used to be whole.\n\nThe entity within has no name. No origin. It simply is the fracture, given will and hunger."
+      "text": "The Fractured Core does not feel like a place. It feels like the absence of one \u2014 a scar where the world used to be whole.\n\nThe entity within has no name. No origin. It simply is the fracture, given will and hunger."
     },
     {
       "title": "THE END OF THE ROAD",
@@ -53,7 +53,7 @@
   "outro": [
     {
       "title": "THE FRACTURE CLOSES",
-      "text": "The entity shudders. Writhes. And then — for the first time since the cataclysm — something at the heart of the world goes quiet.\n\nThe wound begins to close."
+      "text": "The entity shudders. Writhes. And then \u2014 for the first time since the cataclysm \u2014 something at the heart of the world goes quiet.\n\nThe wound begins to close."
     },
     {
       "title": "HEALING",
@@ -73,7 +73,6 @@
       "row": 0,
       "col": 0,
       "rowCols": 1,
-      "parentIds": [],
       "childIds": [
         "shattered-halls"
       ],
@@ -97,9 +96,6 @@
       "row": 1,
       "col": 0,
       "rowCols": 1,
-      "parentIds": [
-        "last-bridge"
-      ],
       "childIds": [
         "echo-of-the-core"
       ],
@@ -123,9 +119,6 @@
       "row": 2,
       "col": 0,
       "rowCols": 1,
-      "parentIds": [
-        "shattered-halls"
-      ],
       "childIds": [
         "fractures-herald"
       ],
@@ -145,13 +138,10 @@
       "id": "fractures-herald",
       "type": "elite",
       "label": "The Fracture's Herald",
-      "description": "A projection of the Fracture itself — testing your limits before the end.",
+      "description": "A projection of the Fracture itself \u2014 testing your limits before the end.",
       "row": 3,
       "col": 0,
       "rowCols": 1,
-      "parentIds": [
-        "echo-of-the-core"
-      ],
       "childIds": [
         "the-fracture-node"
       ],
@@ -172,13 +162,10 @@
       "id": "the-fracture-node",
       "type": "boss",
       "label": "The Fracture",
-      "description": "The source of the cataclysm. The end of the world — or yours.",
+      "description": "The source of the cataclysm. The end of the world \u2014 or yours.",
       "row": 4,
       "col": 0,
       "rowCols": 1,
-      "parentIds": [
-        "fractures-herald"
-      ],
       "childIds": [],
       "handicap": 36,
       "opponentIntervalMs": 5000,

--- a/web/src/game/questline.ts
+++ b/web/src/game/questline.ts
@@ -137,7 +137,6 @@ export interface QuestNode {
   row: number        // 0 = start row; increases toward boss
   col: number        // column index within this row
   rowCols: number    // total columns in this row (for layout)
-  parentIds: string[]
   childIds: string[]
   handicap?: number  // opponent handicap for battle/elite/boss
   restHeal?: number  // HP healed at rest nodes
@@ -649,6 +648,18 @@ export function getTopPlayedCards(counts: Record<string, number>, n = 3): string
 
 // ─── Map logic ────────────────────────────────────────────
 
+/** Derives a reverse map { nodeId → parentIds[] } from childIds. */
+function buildParentMap(act: Act): Record<string, string[]> {
+  const map: Record<string, string[]> = {}
+  for (const node of Object.values(act.nodes)) {
+    for (const cid of node.childIds) {
+      if (!map[cid]) map[cid] = []
+      map[cid].push(node.id)
+    }
+  }
+  return map
+}
+
 /**
  * Returns the IDs of nodes the player can currently select.
  * A node is available if it is not done and at least one parent is completed.
@@ -658,13 +669,15 @@ export function getAvailableNodeIds(act: Act, run: RunState): string[] {
   const completed = new Set(run.completedNodeIds)
   const skipped   = new Set(run.skippedNodeIds)
   const done      = new Set([...completed, ...skipped])
+  const parentMap = buildParentMap(act)
 
   return Object.values(act.nodes)
     .filter(node => {
-      if (done.has(node.id))           return false
+      if (done.has(node.id))            return false
       if (node.id === run.pendingNodeId) return false
-      if (node.parentIds.length === 0)   return completed.size === 0
-      return node.parentIds.some(pid => completed.has(pid))
+      const parents = parentMap[node.id] ?? []
+      if (parents.length === 0)         return completed.size === 0
+      return parents.some(pid => completed.has(pid))
     })
     .map(n => n.id)
 }
@@ -674,9 +687,10 @@ export function getAvailableNodeIds(act: Act, run: RunState): string[] {
  * in the same parent→children group get marked as skipped.
  */
 export function skipSiblings(act: Act, chosenId: string, run: RunState): RunState {
-  const node = act.nodes[chosenId]
+  const parentMap = buildParentMap(act)
+  const parents = parentMap[chosenId] ?? []
   const siblings: string[] = []
-  for (const pid of node.parentIds) {
+  for (const pid of parents) {
     const parent = act.nodes[pid]
     for (const cid of parent.childIds) {
       if (cid !== chosenId && !run.completedNodeIds.includes(cid) && !run.skippedNodeIds.includes(cid)) {


### PR DESCRIPTION
The redundant parentIds field was error-prone - act1.json had 'ruins'
(Watchtower Ruins) listing 'captain' as its only parent instead of
'deep-woods' (The Pack Leader), making it unselectable after that fight.

- questline.ts: remove parentIds from QuestNode type; add buildParentMap()
  to derive parent relationships from childIds at runtime; update
  getAvailableNodeIds and skipSiblings to use the derived map
- NodeMap.tsx: replace parentIds.length === 0 start-node check with a
  childIds-derived hasParent set
- CampaignAdminScreen.tsx: remove parentIds editor panel and all
  parentIds mutations (rename, delete, new node)
- All 14 act JSON files: strip parentIds from every node

https://claude.ai/code/session_01MhuFr1csJtEZ3qLGLdKLM8