### PR TITLE
Fix campaign Give Up to count as a loss and decrement a life

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1747,8 +1747,52 @@ export default function App() {
       return
     }
     if (isCampaignRef.current) {
+      isCampaignRef.current = false
+      const currentRun = runRef.current
       dispatch({ type: 'END' })
-      setScreen('title')
+      if (!currentRun) {
+        setScreen('title')
+        return
+      }
+      // Treat give-up as a loss: decrement a life and record the node failure
+      battleLossRecordedRef.current = true
+      const nodeId = currentRun.pendingNodeId
+      const prevCount = nodeId ? (currentRun.nodeFailCounts[nodeId] ?? 0) : 0
+      const newLives = Math.max(0, currentRun.livesRemaining - 1)
+      const withFail: RunState = {
+        ...currentRun,
+        nodeFailCounts: nodeId
+          ? { ...currentRun.nodeFailCounts, [nodeId]: prevCount + 1 }
+          : currentRun.nodeFailCounts,
+        livesRemaining: newLives,
+      }
+      saveRun(withFail)
+      setRun(withFail)
+      if (newLives === 0) {
+        stopBattleMusic()
+        const next = loadCrystals() + 50
+        saveCrystals(next)
+        setCrystals(next)
+        const failUnlocked = incrementAchievementProgress('misc:campaign_failed')
+        if (failUnlocked.length > 0) setAchievementToasts(prev => [...prev, ...failUnlocked])
+        resetWinStreak()
+        setLastRunFailed()
+        clearRun()
+        setRun(null)
+        clearFatigued()
+        setFatiguedCards([])
+        setBonusPackCards([])
+        setScreen('campaignfailed')
+      } else {
+        // Clear pendingNodeId so the node is selectable again on the node map
+        if (withFail.pendingNodeId) {
+          const cleared = { ...withFail, pendingNodeId: null }
+          saveRun(cleared)
+          setRun(cleared)
+        }
+        setScreen('title')
+      }
+      return
     } else {
       // Exiting endless mode mid-run counts as a defeat: log achievements and publish result
       const gs = gameStateRef.current


### PR DESCRIPTION
## Summary

- Give Up during a campaign battle now decrements a life and records the node failure, matching the normal loss path
- If lives reach zero, transitions to the campaign-failed screen (awards 50 crystals, resets win streak, etc.)
- If lives remain, clears `pendingNodeId` and returns to the title screen so the player can continue from the node map
- Sets `battleLossRecordedRef` to prevent the game-over effect from double-counting the loss

Fixes #695

## Test plan

- [ ] Start a campaign battle, pause, and press Give Up — confirm a life is deducted on the node map
- [ ] Give Up with exactly 1 life remaining — confirm campaign-failed screen appears
- [ ] Give Up with 2+ lives remaining — confirm return to title/node map with life decremented
- [ ] Verify normal battle loss (reaching 0 HP) still works correctly and doesn't double-decrement
- [ ] Verify Give Up in training and endless modes is unaffected

https://claude.ai/code/session_01NnLTDiErSKiveU5DzD5LRw