### PR TITLE
Fix #696 #697 #698: death health bar, buff healing dead units, sudden death

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2605,7 +2605,7 @@ export default function App() {
         if (gameState.phase.type === 'celebration') {
           return (
             <>
-              <Battlefield state={gameState} onPlayCard={handlePlayCard} onPlayAoeCard={handlePlayAoeCard} onGiveUp={handleGiveUp} onPause={setIsUserPaused} actTheme={actTheme} activeRelic={run?.activeRelic} showBossSplash={false} activeModifiers={run ? getModifiersByCount(ACTS[run.actId], run.activeModifierCount) : []} />
+              <Battlefield state={gameState} onPlayCard={handlePlayCard} onPlayAoeCard={handlePlayAoeCard} onGiveUp={handleGiveUp} onPause={setIsUserPaused} actTheme={actTheme} activeRelic={run?.activeRelic} showBossSplash={false} activeModifiers={run ? getModifiersByCount(ACTS[run.actId], run.activeModifierCount) : []} isCampaign={isCampaign} />
               <VictoryPanel
                 playerScore={gameState.playerScore}
                 opponentScore={gameState.opponentScore}
@@ -2622,7 +2622,7 @@ export default function App() {
           const fp = gameState.phase as { type: 'fingerSmash'; wave: number; smashedNames: string[]; rewardDue: boolean }
           return (
             <>
-              <Battlefield state={gameState} onPlayCard={handlePlayCard} onPlayAoeCard={handlePlayAoeCard} onGiveUp={handleGiveUp} onPause={setIsUserPaused} actTheme={actTheme} activeRelic={run?.activeRelic} showBossSplash={showBossSplash} activeModifiers={run ? getModifiersByCount(ACTS[run.actId], run.activeModifierCount) : []} />
+              <Battlefield state={gameState} onPlayCard={handlePlayCard} onPlayAoeCard={handlePlayAoeCard} onGiveUp={handleGiveUp} onPause={setIsUserPaused} actTheme={actTheme} activeRelic={run?.activeRelic} showBossSplash={showBossSplash} activeModifiers={run ? getModifiersByCount(ACTS[run.actId], run.activeModifierCount) : []} isCampaign={isCampaign} />
               <FingerSmash
                 smashedNames={fingerSmashNames}
                 onDone={() => {
@@ -2678,7 +2678,7 @@ export default function App() {
           />
         ) : (
           <>
-            <Battlefield state={gameState} onPlayCard={handlePlayCard} onPlayAoeCard={handlePlayAoeCard} onGiveUp={handleGiveUp} onPause={setIsUserPaused} actTheme={actTheme} activeRelic={run?.activeRelic} showBossSplash={showBossSplash} activeModifiers={run ? getModifiersByCount(ACTS[run.actId], run.activeModifierCount) : []} />
+            <Battlefield state={gameState} onPlayCard={handlePlayCard} onPlayAoeCard={handlePlayAoeCard} onGiveUp={handleGiveUp} onPause={setIsUserPaused} actTheme={actTheme} activeRelic={run?.activeRelic} showBossSplash={showBossSplash} activeModifiers={run ? getModifiersByCount(ACTS[run.actId], run.activeModifierCount) : []} isCampaign={isCampaign} />
             {showBossShockwave && <BossShockwave onDone={() => dispatch({ type: 'HIDE_BOSS_SHOCKWAVE' })} />}
             {activeRareEvent === 'fakeCrash'   && <FakeCrashEvent   onDone={handleRareEventDone} />}
             {activeRareEvent === 'blackjack'   && <BlackjackEvent   onDone={handleRareEventDone} />}

--- a/web/src/components/Battlefield.tsx
+++ b/web/src/components/Battlefield.tsx
@@ -6,7 +6,7 @@ import { useCardDetail } from './useCardDetail'
 import { SpriteImg, AnimatedSpriteImg } from './SpriteImg'
 import { BattleEventOverlay } from './BattleEventOverlay'
 import { isNoDamageMode, isDebugMode } from '../game/debug'
-import { MAX_UPGRADE_LEVEL } from '../game/engine'
+import { MAX_UPGRADE_LEVEL, SUDDEN_DEATH_FORCE_MS } from '../game/engine'
 import { getRelicDef } from '../game/relics'
 import { getUnitLore, getCardCatalog } from '../game/cards'
 import { Button } from './Button'
@@ -23,6 +23,7 @@ interface Props {
   activeRelic?: string | null  // relic name currently equipped, if any
   showBossSplash?: boolean
   activeModifiers?: { label: string }[]  // replay modifiers active this run
+  isCampaign?: boolean
 }
 
 const SPAWN_GROW_MS = 1500
@@ -252,16 +253,18 @@ function LaneUnit({ unit, stackIndex = 0, wallStack, onInspect, showName, celebr
           {unit.name}
         </div>
       )}
-      <div className="lane-unit-hp-row">
-        <div className="lane-unit-hp-bar">
-          <div className="lane-unit-hp-fill" style={{ width: `${hpPct}%` }} />
+      {!isDying && (
+        <div className="lane-unit-hp-row">
+          <div className="lane-unit-hp-bar">
+            <div className="lane-unit-hp-fill" style={{ width: `${hpPct}%` }} />
+          </div>
+          {unit.upgradeLevel != null && unit.upgradeLevel >= 1 && (
+            <span className={`lane-unit-level lane-unit-level--${Math.min(unit.upgradeLevel, MAX_UPGRADE_LEVEL)}`}>
+              {'★'.repeat(unit.upgradeLevel)}
+            </span>
+          )}
         </div>
-        {unit.upgradeLevel != null && unit.upgradeLevel >= 1 && (
-          <span className={`lane-unit-level lane-unit-level--${Math.min(unit.upgradeLevel, MAX_UPGRADE_LEVEL)}`}>
-            {'★'.repeat(unit.upgradeLevel)}
-          </span>
-        )}
-      </div>
+      )}
     </div>
   )
 }
@@ -604,7 +607,7 @@ function opponentPortraitSlug(bossAI: string | undefined, actTheme: string | und
   return 'bandit'
 }
 
-export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPause, actTheme, activeRelic, showBossSplash, activeModifiers }: Props) {
+export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPause, actTheme, activeRelic, showBossSplash, activeModifiers, isCampaign }: Props) {
   const { openDetail, cardDetailNode } = useCardDetail()
   const [heroLightning, setHeroLightning] = useState<{ owner: 'player' | 'opponent'; key: number } | null>(null)
   const [paused, setPaused] = useState(false)
@@ -645,7 +648,13 @@ export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPaus
   const gameTimeSec = Math.floor(state.gameTime / 1000)
   const minutes = Math.floor(gameTimeSec / 60)
   const seconds = gameTimeSec % 60
-  const timeStr = `${minutes}:${String(seconds).padStart(2, '0')}`
+  const elapsedStr = `${minutes}:${String(seconds).padStart(2, '0')}`
+  const countdownMs = Math.max(0, SUDDEN_DEATH_FORCE_MS - state.gameTime)
+  const cdSec = Math.ceil(countdownMs / 1000)
+  const cdMin = Math.floor(cdSec / 60)
+  const cdSecRem = cdSec % 60
+  const countdownStr = `${cdMin}:${String(cdSecRem).padStart(2, '0')}`
+  const timeStr = (isCampaign && !state.suddenDeath) ? countdownStr : elapsedStr
   const sdSec = Math.ceil(state.suddenDeathTimer / 1000)
   const event = state.activeBattleEvent
 

--- a/web/src/game/engine.ts
+++ b/web/src/game/engine.ts
@@ -92,7 +92,7 @@ const MANA_REGEN_MS = 3000       // 1 mana every 3 seconds
 const BASE_MAX_MANA = 5
 const SUDDEN_DEATH_MS = 60000
 const SUDDEN_DEATH_BUILDING_INTERVAL_MS = 2000  // building damage tick during sudden death
-const SUDDEN_DEATH_FORCE_MS = 5 * 60 * 1000    // force sudden death after 5 minutes
+export const SUDDEN_DEATH_FORCE_MS = 5 * 60 * 1000    // force sudden death after 5 minutes
 const BATTLE_EVENT_BASE_MS = 30000  // first event after 30s, then every 24-32s
 const SPAWN_GROW_MS = 1500           // building-spawn grow-in animation duration
 const DEATH_LINGER_MS = 1200         // how long a dying unit stays visible
@@ -581,13 +581,13 @@ function applyUpgrade(s: GameState, effect: UpgradeEffect, owner: 'player' | 'op
     for (const u of units) { u.attack += effect.amount; addBuff(u, 'atk') }
     log.push(`${label} units gain +${effect.amount} attack!`)
   } else if (effect.type === 'healUnits') {
-    for (const u of units) u.hp = Math.min(u.maxHp, u.hp + effect.amount)
+    for (const u of units) if (u.hp >= 1) u.hp = Math.min(u.maxHp, u.hp + effect.amount)
     log.push(`${label} units healed ${effect.amount} HP.`)
   } else if (effect.type === 'buffSpeed') {
     for (const u of units) if (u.moveSpeed > 0) { u.moveSpeed += effect.amount; addBuff(u, 'spd') }
     log.push(`${label} units surge +${effect.amount} speed!`)
   } else if (effect.type === 'buffMaxHp') {
-    for (const u of units) if (u.moveSpeed > 0) { u.maxHp += effect.amount; u.hp = Math.min(u.hp + effect.amount, u.maxHp); addBuff(u, 'hp') }
+    for (const u of units) if (u.moveSpeed > 0 && u.hp >= 1) { u.maxHp += effect.amount; u.hp = Math.min(u.hp + effect.amount, u.maxHp); addBuff(u, 'hp') }
     log.push(`${label} units gain +${effect.amount} max HP!`)
   } else if (effect.type === 'buffRange') {
     for (const u of units) if (u.attackRange > 0) { u.attackRange += effect.amount; addBuff(u, 'range') }
@@ -607,13 +607,13 @@ function applyUpgrade(s: GameState, effect: UpgradeEffect, owner: 'player' | 'op
     }
     log.push(`${label} AOE! ${targets.length} enem${targets.length === 1 ? 'y' : 'ies'} hit for ${dmg} damage.`)
   } else if (effect.type === 'buffHp') {
-    for (const u of units) u.hp = Math.min(u.maxHp, u.hp + effect.amount)
+    for (const u of units) if (u.hp >= 1) u.hp = Math.min(u.maxHp, u.hp + effect.amount)
     log.push(`${label} units gain +${effect.amount} HP!`)
   } else if (effect.type === 'buffAttackCooldown') {
     for (const u of units) u.attackCooldownMs = Math.max(500, u.attackCooldownMs + effect.amount)
     log.push(`${label} units attack ${effect.amount < 0 ? 'faster' : 'slower'}!`)
   } else if (effect.type === 'buffHeal') {
-    for (const u of units) u.hp = Math.min(u.maxHp, u.hp + effect.amount)
+    for (const u of units) if (u.hp >= 1) u.hp = Math.min(u.maxHp, u.hp + effect.amount)
     log.push(`${label} units healed for ${effect.amount} HP.`)
   }
 }
@@ -2088,10 +2088,10 @@ export function tick(state: GameState, deltaMs: number): GameState {
     while (s.opponentHand.length < 4 && s.opponentDeck.length > 0) drawCard(s.opponentDeck, s.opponentHand)
   }
   // 10. Sudden death — suppressed in endless mode (death only by base reaching 0)
-  else if (s.bossCardActive) { /* skip sudden death */ }
   else if (!s.suddenDeath) {
     const oppMaxMana = Math.min(10, BASE_MAX_MANA + getManaBonus(s.field, 'opponent'))
     const allExhausted =
+      !s.bossCardActive &&   // boss phase 2 intentionally clears opponent deck; skip exhaustion check
       s.playerDeck.length === 0 && s.opponentDeck.length === 0 &&
       s.playerHand.every(c => c.cost > s.maxMana) &&
       s.opponentHand.every(c => c.cost > oppMaxMana)


### PR DESCRIPTION
## Summary

Three battle/campaign bugs fixed in one PR.

**#696 — Hide health bar during death animation**
The HP row (`lane-unit-hp-row`) is now suppressed when `isDying` is true, so it disappears the moment a unit reaches 0 HP and begins its rotate/fade animation.

**#697 — Prevent buffs from healing dead units ("back from the dead")**
Added `u.hp >= 1` guard to all four healing paths in `applyUpgrade()`: `healUnits`, `buffMaxHp`, `buffHp`, `buffHeal`. Units in the dying animation (hp ≤ 0) can no longer be revived by upgrade cards.

**#698 — Ensure sudden death kicks in + campaign countdown timer**
- Removed the blanket `bossCardActive` sudden-death skip. Instead, only the `allExhausted` check is guarded with `!s.bossCardActive` (the opponent deck is intentionally empty during boss phase 2), so the 5-minute time-based force trigger still fires during boss fights.
- Added a campaign countdown clock (5:00 → 0:00) to the Battlefield top bar via a new `isCampaign` prop. Elapsed time is still shown in all other modes (quickplay, endless, training).

## Files changed

| File | Change |
|---|---|
| `web/src/components/Battlefield.tsx` | HP bar conditional on `!isDying`; `isCampaign` prop; countdown clock logic |
| `web/src/game/engine.ts` | Export `SUDDEN_DEATH_FORCE_MS`; 4 healing guards; fix boss SD skip |
| `web/src/App.tsx` | Pass `isCampaign` to 3 Battlefield instances |

## Test plan

- [ ] Kill a unit — health bar should vanish instantly, rotation/fade animation continues
- [ ] Play a heal upgrade card while an enemy unit is dying at 0 HP — unit should stay dead
- [ ] Start a campaign battle — top-bar clock should count down from 5:00
- [ ] Non-campaign battle (quickplay) — clock should count up as before
- [ ] Boss fight reaching 5 minutes — sudden death should trigger

https://claude.ai/code/session_01NnLTDiErSKiveU5DzD5LRw