### PR TITLE
Fix #693: Video Poker rework — blind/bet-multiplier, ace high/low, multi-hand

### DIFF
--- a/web/src/components/minigames/VideoPoker.tsx
+++ b/web/src/components/minigames/VideoPoker.tsx
@@ -1,8 +1,10 @@
 // ─── Video Poker ──────────────────────────────────────────────────────────────
-// Jacks or Better. Dealt 5 cards, hold any, draw to replace the rest.
-// Payout based on the final poker hand.
+// Blind + bet-multiplier variant of Jacks or Better.
+// Pay 1-credit blind to see your hand, then Fold | ×1 | ×2 | ×5.
+// Ace plays both high (A-K-Q-J-10) and low (A-2-3-4-5).
 
-import React, { useState } from 'react'
+import React, { useState, useCallback } from 'react'
+import { loadCrystals, saveCrystals } from '../../game/collection'
 
 interface Props {
   onDone: (ticketsEarned: number) => void
@@ -15,10 +17,18 @@ interface PlayingCard {
 
 interface HandResult {
   name: string
-  tickets: number
+  multiplier: number
 }
 
+type Phase = 'wager' | 'hold' | 'result' | 'done'
+
 const SUITS = ['♠', '♥', '♦', '♣']
+const BLIND              = 1
+const STARTING_CREDITS   = 5
+const BUY_COST           = 25
+const BUY_AMOUNT         = 10
+const MAX_CREDITS        = 50
+const TICKETS_PER_CREDIT = 2
 
 function rankLabel(rank: number): string {
   if (rank === 1)  return 'A'
@@ -46,76 +56,172 @@ function buildShuffledDeck(): PlayingCard[] {
   return deck
 }
 
-function evaluateHand(cards: PlayingCard[]): HandResult {
-  const ranks = cards.map(c => c.rank).sort((a, b) => a - b)
-  const suits = cards.map(c => c.suit)
+function isNaturalStraight(r: number[]): boolean {
+  return new Set(r).size === 5 && r[4] - r[0] === 4
+}
 
-  const isFlush = suits.every(s => s === suits[0])
-  const allDifferent = new Set(ranks).size === 5
-  const normalStraight = allDifferent && ranks[4] - ranks[0] === 4
-  const aceHighStraight = JSON.stringify(ranks) === '[1,10,11,12,13]'
-  const isStraight = normalStraight || aceHighStraight
+function evaluateHand(cards: PlayingCard[]): HandResult {
+  const ranks       = cards.map(c => c.rank).sort((a, b) => a - b)
+  const aceHighRanks = ranks.map(r => r === 1 ? 14 : r).sort((a, b) => a - b)
+  const suits       = cards.map(c => c.suit)
+
+  const isFlush     = suits.every(s => s === suits[0])
+  const isStraight  = isNaturalStraight(ranks) || isNaturalStraight(aceHighRanks)
+  const isRoyal     = isFlush && isNaturalStraight(aceHighRanks) && aceHighRanks[0] === 10
 
   const rankCounts = new Map<number, number>()
   for (const r of ranks) rankCounts.set(r, (rankCounts.get(r) ?? 0) + 1)
   const counts = [...rankCounts.values()].sort((a, b) => b - a)
 
-  if (isFlush && aceHighStraight)              return { name: 'Royal Flush',     tickets: 250 }
-  if (isFlush && isStraight)                   return { name: 'Straight Flush',  tickets: 100 }
-  if (counts[0] === 4)                         return { name: 'Four of a Kind',  tickets: 50 }
-  if (counts[0] === 3 && counts[1] === 2)      return { name: 'Full House',      tickets: 35 }
-  if (isFlush)                                 return { name: 'Flush',           tickets: 25 }
-  if (isStraight)                              return { name: 'Straight',        tickets: 20 }
-  if (counts[0] === 3)                         return { name: 'Three of a Kind', tickets: 15 }
-  if (counts[0] === 2 && counts[1] === 2)      return { name: 'Two Pair',        tickets: 10 }
+  if (isRoyal)                                  return { name: 'Royal Flush',     multiplier: 250 }
+  if (isFlush && isStraight)                    return { name: 'Straight Flush',  multiplier: 50  }
+  if (counts[0] === 4)                          return { name: 'Four of a Kind',  multiplier: 25  }
+  if (counts[0] === 3 && counts[1] === 2)       return { name: 'Full House',      multiplier: 9   }
+  if (isFlush)                                  return { name: 'Flush',           multiplier: 6   }
+  if (isStraight)                               return { name: 'Straight',        multiplier: 4   }
+  if (counts[0] === 3)                          return { name: 'Three of a Kind', multiplier: 3   }
+  if (counts[0] === 2 && counts[1] === 2)       return { name: 'Two Pair',        multiplier: 2   }
   if (counts[0] === 2) {
     const pairedRank = [...rankCounts.entries()].find(([, c]) => c === 2)?.[0]
     if (pairedRank === 1 || (pairedRank !== undefined && pairedRank >= 11)) {
-      return { name: 'Jacks or Better', tickets: 5 }
+      return { name: 'Jacks or Better', multiplier: 1 }
     }
   }
-  return { name: 'No Win', tickets: 0 }
+  return { name: 'No Win', multiplier: 0 }
 }
 
-function dealHand(deck: PlayingCard[]): { hand: PlayingCard[]; remaining: PlayingCard[] } {
-  return { hand: deck.slice(0, 5), remaining: deck.slice(5) }
+function freshDeal(fromDeck: PlayingCard[]): { hand: PlayingCard[]; remaining: PlayingCard[] } {
+  return { hand: fromDeck.slice(0, 5), remaining: fromDeck.slice(5) }
 }
 
 export function VideoPoker({ onDone }: Props) {
-  const initialDeck = buildShuffledDeck()
-  const { hand: initialHand, remaining: initialRemaining } = dealHand(initialDeck)
+  const initialDeck                = buildShuffledDeck()
+  const { hand: h0, remaining: r0 } = freshDeal(initialDeck)
 
-  const [hand, setHand]       = useState<PlayingCard[]>(initialHand)
-  const [deck, setDeck]       = useState<PlayingCard[]>(initialRemaining)
-  const [held, setHeld]       = useState<boolean[]>([false, false, false, false, false])
-  const [phase, setPhase]     = useState<'deal' | 'result'>('deal')
-  const [result, setResult]   = useState<HandResult | null>(null)
+  const [phase, setPhase]           = useState<Phase>('wager')
+  const [hand, setHand]             = useState<PlayingCard[]>(h0)
+  const [drawDeck, setDrawDeck]     = useState<PlayingCard[]>(r0)
+  const [held, setHeld]             = useState<boolean[]>([false, false, false, false, false])
+  const [credits, setCredits]       = useState(STARTING_CREDITS - BLIND)
+  const [wager, setWager]           = useState(BLIND)
+  const [result, setResult]         = useState<HandResult | null>(null)
+  const [cashOutTickets, setCashOutTickets] = useState(0)
+  const [availCrystals, setAvailCrystals]  = useState(() => loadCrystals())
 
   function toggleHold(i: number) {
-    if (phase !== 'deal') return
+    if (phase !== 'hold') return
     setHeld(prev => prev.map((h, idx) => idx === i ? !h : h))
   }
 
+  const fold = useCallback(() => {
+    setResult({ name: 'Fold', multiplier: 0 })
+    setPhase('result')
+  }, [])
+
+  const playAt = useCallback((n: number) => {
+    const extra = n - wager
+    setCredits(c => c - extra)
+    setWager(n)
+    setHeld([false, false, false, false, false])
+    setPhase('hold')
+  }, [wager])
+
   function draw() {
     let deckIdx = 0
-    const newHand = hand.map((card, i) => {
-      if (held[i]) return card
-      return deck[deckIdx++]
-    })
+    const newHand = hand.map((card, i) => held[i] ? card : drawDeck[deckIdx++])
     const handResult = evaluateHand(newHand)
+    const win = wager * handResult.multiplier
     setHand(newHand)
     setResult(handResult)
+    setCredits(c => c + win)
     setPhase('result')
   }
 
-  const isWin = result !== null && result.tickets > 0
+  function dealAgain() {
+    if (credits < BLIND) {
+      cashOut()
+      return
+    }
+    const newDeck = buildShuffledDeck()
+    const { hand: newHand, remaining } = freshDeal(newDeck)
+    setHand(newHand)
+    setDrawDeck(remaining)
+    setHeld([false, false, false, false, false])
+    setResult(null)
+    setCredits(c => c - BLIND)
+    setWager(BLIND)
+    setPhase('wager')
+  }
+
+  function cashOut() {
+    const tickets = credits * TICKETS_PER_CREDIT
+    setCashOutTickets(tickets)
+    setPhase('done')
+  }
+
+  function buyCredits() {
+    if (availCrystals < BUY_COST || credits >= MAX_CREDITS) return
+    saveCrystals(availCrystals - BUY_COST)
+    setAvailCrystals(c => c - BUY_COST)
+    setCredits(c => Math.min(MAX_CREDITS, c + BUY_AMOUNT))
+  }
+
+  // ── Done screen ───────────────────────────────────────────────────────────────
+
+  if (phase === 'done') {
+    return (
+      <div className="minigame-screen">
+        <div className="minigame-title">♠ VIDEO POKER</div>
+        <div className="minigame-result-panel">
+          <div className="minigame-result-headline">
+            {cashOutTickets > 0 ? 'Cashed out!' : 'Out of credits!'}
+          </div>
+          <div className="minigame-result-breakdown">
+            {cashOutTickets > 0 ? (
+              <>
+                <div>Credits: {cashOutTickets / TICKETS_PER_CREDIT}</div>
+                <div>× {TICKETS_PER_CREDIT} tickets per credit</div>
+              </>
+            ) : (
+              <div>No credits remaining.</div>
+            )}
+            <div className="minigame-result-total">Total: {cashOutTickets} 🎫</div>
+          </div>
+          <button className="action-btn action-btn--gold" onClick={() => onDone(cashOutTickets)}>
+            COLLECT &amp; EXIT
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  // ── Playing screen ────────────────────────────────────────────────────────────
+
+  const isWin    = result !== null && result.multiplier > 0
+  const canBuy   = phase !== 'done' && credits < MAX_CREDITS && availCrystals >= BUY_COST
+
+  const subtitleText = (() => {
+    if (phase === 'wager')  return `Blind paid (${BLIND} credit). Fold or choose your bet.`
+    if (phase === 'hold')   return `Wager: ${wager} credit${wager !== 1 ? 's' : ''}. Click cards to hold, then DRAW.`
+    if (phase === 'result') return result?.name ?? ''
+    return ''
+  })()
 
   return (
     <div className="minigame-screen">
       <div className="minigame-title">♠ VIDEO POKER</div>
-      <div className="vp-subtitle">
-        {phase === 'deal' ? 'Click cards to hold, then DRAW' : result?.name}
+
+      <div className="fm-header">
+        <span className="fm-credits">Credits: {credits}</span>
+        {phase === 'result' && result && result.multiplier > 0 && (
+          <span className="fm-win-flash">+{wager * result.multiplier}!</span>
+        )}
+        {phase === 'result' && result && result.multiplier === 0 && result.name !== 'Fold' && (
+          <span className="fm-no-win">No win</span>
+        )}
       </div>
+
+      <div className="vp-subtitle">{subtitleText}</div>
 
       {/* Hand */}
       <div className="vp-hand">
@@ -142,8 +248,38 @@ export function VideoPoker({ onDone }: Props) {
         ))}
       </div>
 
-      {/* Controls */}
-      {phase === 'deal' && (
+      {/* Wager phase controls */}
+      {phase === 'wager' && (
+        <div className="vp-controls">
+          <button className="action-btn action-btn--danger" onClick={fold}>
+            FOLD
+          </button>
+          <button
+            className="action-btn"
+            onClick={() => playAt(1)}
+            disabled={credits < 0}
+          >
+            ×1
+          </button>
+          <button
+            className="action-btn"
+            onClick={() => playAt(2)}
+            disabled={credits < 2 - wager}
+          >
+            ×2
+          </button>
+          <button
+            className="action-btn action-btn--gold"
+            onClick={() => playAt(5)}
+            disabled={credits < 5 - wager}
+          >
+            ×5
+          </button>
+        </div>
+      )}
+
+      {/* Hold phase controls */}
+      {phase === 'hold' && (
         <div className="vp-controls">
           <button className="action-btn action-btn--gold action-btn--large" onClick={draw}>
             DRAW
@@ -151,37 +287,48 @@ export function VideoPoker({ onDone }: Props) {
         </div>
       )}
 
+      {/* Result phase controls */}
       {phase === 'result' && result && (
         <div className="minigame-result-panel">
           <div className={`vp-result-name${isWin ? ' vp-result-name--win' : ''}`}>
             {result.name}
           </div>
-          <div className="minigame-result-breakdown">
-            {isWin
-              ? <div className="minigame-result-total">{result.tickets} 🎫</div>
-              : <div style={{ color: 'var(--game-text-color-dim)' }}>Better luck next time!</div>
-            }
+          {isWin && (
+            <div className="minigame-result-breakdown">
+              <div>{wager} × {result.multiplier} = {wager * result.multiplier} credit{wager * result.multiplier !== 1 ? 's' : ''}</div>
+            </div>
+          )}
+          <div className="vp-controls">
+            <button className="action-btn action-btn--gold" onClick={dealAgain}>
+              DEAL AGAIN
+            </button>
+            <button className="action-btn" onClick={cashOut}>
+              CASH OUT ({credits * TICKETS_PER_CREDIT} 🎫)
+            </button>
           </div>
-          <button className="action-btn action-btn--gold" onClick={() => onDone(result.tickets)}>
-            COLLECT &amp; EXIT
-          </button>
         </div>
+      )}
+
+      {canBuy && (
+        <button className="fm-buy-credits" onClick={buyCredits}>
+          + Buy {BUY_AMOUNT} credits — {BUY_COST} 💎 (you have {availCrystals})
+        </button>
       )}
 
       {/* Payout reference */}
       <details className="fm-paytable">
-        <summary>Payout table</summary>
+        <summary>Payout table (× your wager)</summary>
         <table className="fm-paytable-table">
           <tbody>
-            <tr><td>Royal Flush</td><td>250 🎫</td></tr>
-            <tr><td>Straight Flush</td><td>100 🎫</td></tr>
-            <tr><td>Four of a Kind</td><td>50 🎫</td></tr>
-            <tr><td>Full House</td><td>35 🎫</td></tr>
-            <tr><td>Flush</td><td>25 🎫</td></tr>
-            <tr><td>Straight</td><td>20 🎫</td></tr>
-            <tr><td>Three of a Kind</td><td>15 🎫</td></tr>
-            <tr><td>Two Pair</td><td>10 🎫</td></tr>
-            <tr><td>Jacks or Better</td><td>5 🎫</td></tr>
+            <tr><td>Royal Flush</td><td>250×</td></tr>
+            <tr><td>Straight Flush</td><td>50×</td></tr>
+            <tr><td>Four of a Kind</td><td>25×</td></tr>
+            <tr><td>Full House</td><td>9×</td></tr>
+            <tr><td>Flush</td><td>6×</td></tr>
+            <tr><td>Straight</td><td>4×</td></tr>
+            <tr><td>Three of a Kind</td><td>3×</td></tr>
+            <tr><td>Two Pair</td><td>2×</td></tr>
+            <tr><td>Jacks or Better</td><td>1×</td></tr>
           </tbody>
         </table>
       </details>

--- a/web/src/data/economy.json
+++ b/web/src/data/economy.json
@@ -25,7 +25,7 @@
     "marblerace":     25,
     "higherOrLower":  5,
     "fruitMachine":   50,
-    "videoPoker":     10
+    "videoPoker":     0
   },
 
   "ticketPrizes": [


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Free entry**: `economy.json` video poker cost changed from 10 → 0; players buy credits in-game
- **Blind + bet-multiplier mechanic**: pay 1-credit blind to see your hand, then choose Fold | ×1 | ×2 | ×5 (like Casino Hold'em)
- **Ace plays high and low**: A-2-3-4-5 and A-K-Q-J-10 straights both detected correctly
- **Multiplier payouts**: Royal 250×, Str. Flush 50×, Quads 25×, Full House 9×, Flush 6×, Straight 4×, Trips 3×, Two Pair 2×, Jacks+ 1×
- **Multi-hand loop**: Deal Again or Cash Out after each hand (like Fruit Machine)
- **Credit economy**: 5 starting credits; buy 10 more for 25 crystals; cash out at 2 tickets/credit

## Test plan

- [ ] Enter video poker from minigames menu — costs 0 crystals
- [ ] 5 cards dealt, blind (1 credit) deducted immediately
- [ ] Fold button works — loses only the blind
- [ ] ×1 / ×2 / ×5 disabled correctly when insufficient credits
- [ ] Hold cards and draw replacements work
- [ ] A-2-3-4-5 evaluated as Straight
- [ ] A-K-Q-J-10 flush evaluated as Royal Flush (not Straight Flush)
- [ ] Win = wager × multiplier credited correctly
- [ ] DEAL AGAIN re-deals fresh hand, wager resets
- [ ] Buy 10 credits for 25 crystals; crystal count decrements
- [ ] CASH OUT → done screen → COLLECT & EXIT returns correct ticket count

Closes #693

https://claude.ai/code/session_01NnLTDiErSKiveU5DzD5LRw
EOF
)