### PR TITLE
Fix #702: Weak Deck Warning fires incorrectly with 30 cards

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1139,7 +1139,7 @@ export default function App() {
       const allEntries   = loadDeck()
       const fat          = loadFatigued()
       const restingCount = allEntries.filter(e => fat.includes(e.cardName)).length
-      const isUnderMax   = allEntries.length < DECK_MAX
+      const isUnderMax   = deckTotalCards(allEntries) < DECK_MAX
       if (restingCount > 0 || isUnderMax) {
         setDeckWarningNode(node)
         return
@@ -2350,12 +2350,13 @@ export default function App() {
         const allEntries   = loadDeck()
         const fat          = loadFatigued()
         const restingCount = allEntries.filter(e => fat.includes(e.cardName)).length
-        const isUnderMax   = allEntries.length < DECK_MAX
+        const totalCards   = deckTotalCards(allEntries)
+        const isUnderMax   = totalCards < DECK_MAX
         const parts: string[] = []
         if (restingCount > 0)
           parts.push(`${restingCount} resting card${restingCount !== 1 ? 's' : ''} won't be available in battle`)
         if (isUnderMax)
-          parts.push(`Your deck has only ${allEntries.length} of ${DECK_MAX} cards. Consider adding more cards in the Deck Builder for more consistency.`)
+          parts.push(`Your deck has only ${totalCards} of ${DECK_MAX} cards. Consider adding more cards in the Deck Builder for more consistency.`)
         return (
           <ConfirmModal
             title="Weak Deck"


### PR DESCRIPTION
## Summary

- `allEntries.length` was counting unique card *types* (e.g. 10 entries with 3 copies each = 10), not total card *copies* (30)
- Replace both occurrences with `deckTotalCards(allEntries)` which sums the `count` field across all `DeckEntry` objects
- Also fixes the warning message to show the correct total card count

## Test plan

- [ ] Build a deck with 10 card types × 3 copies = 30 total — no warning should appear before battle
- [ ] Build a deck with fewer than 30 total cards — warning should appear
- [ ] Warning message shows correct card count (e.g. "29 of 30 cards")

Closes #702

https://claude.ai/code/session_01NnLTDiErSKiveU5DzD5LRw