### PR TITLE
Fix older issues: close stale GitHub issues + SW update guard

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -280,8 +280,8 @@ export default function App() {
       // checks on each launch the way a normal tab does, so we kick one off
       // immediately and then repeat every hour.
       if (r) {
-        r.update()
-        setInterval(() => r.update(), 60 * 60 * 1000)
+        r.update().catch(() => {})
+        setInterval(() => r.update().catch(() => {}), 60 * 60 * 1000)
       }
     },
   })


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Closed already-fixed issues that were never closed on GitHub: #412, #416, #417, #418, #674, #694
- Fixed #684: `r.update()` calls on the ServiceWorker registration now use `.catch(() => {})` to silently swallow the rejection thrown when a registration becomes null/invalid after setup

## Test plan

- [ ] Build passes (`npm run build`)
- [ ] No new Rollbar errors for SW update failures after deploy

https://claude.ai/code/session_01UmwSTG7sQvxow2fYKjqo24
EOF
)