### PR TITLE
Fix older issues: SW guard, integrity checksums, secrets (#52, #55, #684)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -77,6 +77,7 @@ import { getDailyPlayerDeck, getDailyOpponentDeck, getDailyChallengeState, saveD
 import { getRelicDef, addEarnedRelic, removeEarnedRelic, loadEarnedRelics, addBrokenRelic } from './game/relics'
 import { playCardPlay, playButtonClick, playBattleEvent, playCardFlip, playRestHeal, stopBattleMusic, stopGameOverMusic } from './game/sound'
 import { useMusic } from './hooks/useMusic'
+import { getIntegrityViolations, clearIntegrityViolations } from './game/integrity'
 import { useRareEvents } from './hooks/useRareEvents'
 import { useAchievements } from './hooks/useAchievements'
 import { isNoDamageMode } from './game/debug'
@@ -427,6 +428,13 @@ export default function App() {
 
   // Achievement toast notifications
   const { achievementToasts, setAchievementToasts } = useAchievements()
+
+  // Integrity warning (set on mount if tampered data is detected)
+  const [integrityWarning, setIntegrityWarning] = useState(() => {
+    const v = getIntegrityViolations()
+    if (v.length > 0) { clearIntegrityViolations(); return true }
+    return false
+  })
 
   // Firebase auth
   const { user, authLoading } = useAuth()
@@ -2582,6 +2590,14 @@ export default function App() {
           brokenDesc={relicSpinData.brokenDesc}
           onContinue={relicSpinData.onContinue}
         />
+      )}
+
+      {/* Integrity warning */}
+      {integrityWarning && (
+        <div className="integrity-warning" role="alert">
+          <span>⚠ Inventory data was modified externally. Play nice!</span>
+          <button className="integrity-warning-dismiss" onClick={() => setIntegrityWarning(false)}>✕</button>
+        </div>
       )}
 
       {/* Achievement unlock toast */}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -280,8 +280,8 @@ export default function App() {
       // checks on each launch the way a normal tab does, so we kick one off
       // immediately and then repeat every hour.
       if (r) {
-        r.update()
-        setInterval(() => r.update(), 60 * 60 * 1000)
+        r.update().catch(() => {})
+        setInterval(() => r.update().catch(() => {}), 60 * 60 * 1000)
       }
     },
   })

--- a/web/src/components/CollectionScreen.tsx
+++ b/web/src/components/CollectionScreen.tsx
@@ -17,6 +17,7 @@ import {
   COPIES_MAX,
 } from '../game/collection'
 import { promotionsRemainingToday } from '../game/commander'
+import { incrementAchievementProgress } from '../game/achievements'
 import { CardTile } from './CardTile'
 import { CardDetailModal } from './CardDetailModal'
 import { OverlayScreen } from './OverlayScreen'
@@ -76,6 +77,8 @@ export function CollectionScreen({ crystals, onCrystalsChanged, onBack, commande
   const [disenchantModal, setDisenchantModal] = useState<Array<{cardName: string, crystals: number}> | null>(null)
   const [detailCard, setDetailCard] = useState<import('../game/types').Card | null>(null)
   const [levelUpCard, setLevelUpCard] = useState<string | null>(null)
+  const [secretToast, setSecretToast] = useState<string | null>(null)
+  const legendaryViewCount = useRef(0)
   const filterMenuRef = useRef<HTMLDivElement>(null)
   const sortMenuRef   = useRef<HTMLDivElement>(null)
   const groupMenuRef  = useRef<HTMLDivElement>(null)
@@ -308,6 +311,7 @@ export function CollectionScreen({ crystals, onCrystalsChanged, onBack, commande
           ★ Upgrade all ({totalUpgradeable})
         </Button>
         {flash && <span className="collection-flash">{flash}</span>}
+        {secretToast && <div className="collection-secret-toast">{secretToast}</div>}
       </div>
 
       {/* Filter / Sort / Group bar */}
@@ -528,7 +532,17 @@ export function CollectionScreen({ crystals, onCrystalsChanged, onBack, commande
                     card={card}
                     canAfford={true}
                     upgradeable={extras > 0}
-                    onClick={() => setDetailCard(card)}
+                    onClick={() => {
+                      setDetailCard(card)
+                      if (card.rarity === 'legendary') {
+                        legendaryViewCount.current += 1
+                        if (legendaryViewCount.current === 10) {
+                          incrementAchievementProgress('misc:legend_stare')
+                          setSecretToast('✦ The legendaries have noticed your gaze.')
+                          setTimeout(() => setSecretToast(null), 3500)
+                        }
+                      }
+                    }}
                   />
 
                   <div className="cell-footer">

--- a/web/src/game/achievements.ts
+++ b/web/src/game/achievements.ts
@@ -384,6 +384,36 @@ export const ACHIEVEMENT_DEFS: AchievementDef[] = [
     reward: { type: 'crystals', crystals: 50 },
     tier: 1,
   },
+  {
+    id: 'event:dev_build',
+    name: 'You Weren\'t Supposed to See That',
+    description: 'Witness an internal debug build during a battle',
+    category: 'events',
+    progressKey: 'event:dev_build',
+    target: 1,
+    reward: { type: 'crystals', crystals: 75 },
+    tier: 1,
+  },
+  {
+    id: 'event:glitched_card',
+    name: 'It Was a Goblin All Along',
+    description: 'Reveal the corrupted card in the Glitched Card rare event',
+    category: 'events',
+    progressKey: 'event:glitched_card',
+    target: 1,
+    reward: { type: 'crystals', crystals: 50 },
+    tier: 1,
+  },
+  {
+    id: 'event:confused_tourist',
+    name: 'Most Welcoming Battlefield',
+    description: 'Receive a visit from a Confused Traveller',
+    category: 'events',
+    progressKey: 'event:confused_tourist',
+    target: 1,
+    reward: { type: 'crystals', crystals: 30 },
+    tier: 1,
+  },
 
   // ── Campaign ──────────────────────────────────────────────────────────────
 
@@ -1668,6 +1698,16 @@ export const ACHIEVEMENT_DEFS: AchievementDef[] = [
     target: 1,
     reward: { type: 'crystals', crystals: 400 },
     tier: 2,
+  },
+  {
+    id: 'misc:legend_stare',
+    name: 'Drawn to Power',
+    description: 'Open the detail view of legendary cards 10 times',
+    category: 'misc',
+    progressKey: 'misc:legend_stare',
+    target: 10,
+    reward: { type: 'crystals', crystals: 100 },
+    tier: 1,
   },
 
   // ── Mini Games ────────────────────────────────────────────────────────────

--- a/web/src/game/collection.ts
+++ b/web/src/game/collection.ts
@@ -1,6 +1,7 @@
 import { Card, CardRarity } from './types'
 import { getCardCatalog } from './cards'
 import { logError } from '../logger'
+import { validateIntegrity, updateChecksum } from './integrity'
 
 // ─── Types ────────────────────────────────────────────────
 
@@ -360,15 +361,21 @@ function applyMasteryBonus(card: Card, lvl: number): Card {
 export function loadCollection(): CollectionEntry[] {
   try {
     const raw = localStorage.getItem(COLLECTION_KEY)
-    if (raw) return migrateCollectionNames(JSON.parse(raw) as CollectionEntry[])
+    if (raw) {
+      validateIntegrity(COLLECTION_KEY, raw)
+      return migrateCollectionNames(JSON.parse(raw) as CollectionEntry[])
+    }
   } catch { /* ignore */ }
   saveCollection(STARTER_COLLECTION)
   return [...STARTER_COLLECTION.map(e => ({ ...e }))]
 }
 
 export function saveCollection(c: CollectionEntry[]): void {
-  try { localStorage.setItem(COLLECTION_KEY, JSON.stringify(c)) }
-  catch (e) { logError('saveCollection failed', { count: c.length, error: String(e) }) }
+  try {
+    const data = JSON.stringify(c)
+    localStorage.setItem(COLLECTION_KEY, data)
+    updateChecksum(COLLECTION_KEY, data)
+  } catch (e) { logError('saveCollection failed', { count: c.length, error: String(e) }) }
 }
 
 export function addCardsToCollection(newCards: CollectionEntry[]): CollectionEntry[] {

--- a/web/src/game/integrity.ts
+++ b/web/src/game/integrity.ts
@@ -1,0 +1,73 @@
+import { logError } from '../logger'
+
+const CHECKSUMS_KEY = 'jarv_checksums'
+
+function djb2(str: string): string {
+  let h = 5381
+  for (let i = 0; i < str.length; i++) {
+    h = (((h << 5) + h) ^ str.charCodeAt(i)) >>> 0
+  }
+  return h.toString(36)
+}
+
+function readChecksums(): Record<string, string> {
+  try {
+    const raw = localStorage.getItem(CHECKSUMS_KEY)
+    if (raw) return JSON.parse(raw) as Record<string, string>
+  } catch { /* ignore */ }
+  return {}
+}
+
+function writeChecksums(sums: Record<string, string>): void {
+  try {
+    localStorage.setItem(CHECKSUMS_KEY, JSON.stringify(sums))
+  } catch { /* ignore */ }
+}
+
+const _violations: string[] = []
+
+export function getIntegrityViolations(): string[] {
+  return [..._violations]
+}
+
+export function clearIntegrityViolations(): void {
+  _violations.length = 0
+}
+
+/**
+ * Validate the raw serialised string for a localStorage key against its stored
+ * checksum.  Returns true if intact.  On first call for a key (no stored checksum)
+ * silently writes the checksum and returns true — this is the migration guard that
+ * prevents existing saves from being flagged on first deploy.
+ */
+export function validateIntegrity(storageKey: string, data: string): boolean {
+  const sums = readChecksums()
+  const stored = sums[storageKey]
+  const actual = djb2(data)
+
+  if (!stored) {
+    sums[storageKey] = actual
+    writeChecksums(sums)
+    return true
+  }
+
+  if (stored !== actual) {
+    logError('integrity check failed — data may have been modified externally', {
+      key: storageKey,
+    })
+    _violations.push(storageKey)
+    // Update so we don't re-fire on subsequent loads
+    sums[storageKey] = actual
+    writeChecksums(sums)
+    return false
+  }
+
+  return true
+}
+
+/** Call after every legitimate write to keep the stored checksum current. */
+export function updateChecksum(storageKey: string, data: string): void {
+  const sums = readChecksums()
+  sums[storageKey] = djb2(data)
+  writeChecksums(sums)
+}

--- a/web/src/game/itemStore.ts
+++ b/web/src/game/itemStore.ts
@@ -47,6 +47,7 @@
 // ─────────────────────────────────────────────────────────────────────────────
 
 import { logError } from '../logger'
+import { validateIntegrity, updateChecksum } from './integrity'
 
 export type ItemType = 'consumable' | 'relic' | 'item'
 
@@ -159,7 +160,10 @@ export function loadItemStore(): ItemEntry[] {
   let store: ItemEntry[] = []
   try {
     const raw = localStorage.getItem(ITEM_STORE_KEY)
-    store = raw ? (JSON.parse(raw) as ItemEntry[]) : []
+    if (raw) {
+      validateIntegrity(ITEM_STORE_KEY, raw)
+      store = JSON.parse(raw) as ItemEntry[]
+    }
   } catch {
     store = []
   }
@@ -179,7 +183,9 @@ export function loadItemStore(): ItemEntry[] {
 
 export function saveItemStore(store: ItemEntry[]): void {
   try {
-    localStorage.setItem(ITEM_STORE_KEY, JSON.stringify(store))
+    const data = JSON.stringify(store)
+    localStorage.setItem(ITEM_STORE_KEY, data)
+    updateChecksum(ITEM_STORE_KEY, data)
   } catch (e) {
     logError('saveItemStore failed', { error: String(e) })
   }

--- a/web/src/hooks/useRareEvents.ts
+++ b/web/src/hooks/useRareEvents.ts
@@ -122,11 +122,14 @@ export function useRareEvents({
     }
     if (completedEvent) {
       const eventKey: Record<string, string> = {
-        blackjack:   'event:blackjack_win',
-        liarsDice:   'event:liarsdice_win',
-        narrator:    'event:narrator_befriend',
-        wrongNumber: 'event:wrong_number',
-        fakeCrash:   'event:fake_crash',
+        blackjack:       'event:blackjack_win',
+        liarsDice:       'event:liarsdice_win',
+        narrator:        'event:narrator_befriend',
+        wrongNumber:     'event:wrong_number',
+        fakeCrash:       'event:fake_crash',
+        devBuild:        'event:dev_build',
+        glitchedCard:    'event:glitched_card',
+        confusedTourist: 'event:confused_tourist',
       }
       const key = eventKey[completedEvent]
       if (key) {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -6780,6 +6780,35 @@ body {
   border-color: #88ff88;
 }
 
+/* ── Integrity warning banner ────────────────────────────── */
+
+.integrity-warning {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 14px;
+  background: #1a0000;
+  border-bottom: 2px solid #ff3333;
+  color: #ff6666;
+  font-size: 13px;
+  font-family: inherit;
+}
+
+.integrity-warning-dismiss {
+  background: none;
+  border: 1px solid #ff3333;
+  color: #ff6666;
+  cursor: pointer;
+  padding: 2px 8px;
+  font-size: 12px;
+  font-family: inherit;
+}
+
 /* ── Achievement toast notifications ─────────────────────── */
 
 .ach-toast-stack {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2737,6 +2737,23 @@ body {
   animation: fadeFlash 2s ease-out forwards;
   white-space: nowrap;
 }
+
+.collection-secret-toast {
+  position: fixed;
+  bottom: 60px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #0a0a1a;
+  border: 1px solid #aa88ff;
+  color: #cc99ff;
+  font-size: 13px;
+  padding: 8px 18px;
+  border-radius: 4px;
+  pointer-events: none;
+  z-index: 500;
+  animation: fadeFlash 3.5s ease-out forwards;
+  white-space: nowrap;
+}
 @keyframes fadeFlash {
   0%, 60% { opacity: 1; }
   100%     { opacity: 0; }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **#684** — Guard `r.update()` calls in PWA service worker registration with `.catch(() => {})` to prevent unhandled rejections when the registration becomes invalid
- **#55** — Inventory integrity checksums: new `integrity.ts` (djb2 hash), `validateIntegrity` on load + `updateChecksum` on save for collection and item store; dismissable red warning banner in App if tampered data is detected on startup; first-load silently seeds the checksum so existing saves are safe
- **#52** — Secrets: wire achievements for the 3 previously untracked rare events (`devBuild`, `glitchedCard`, `confusedTourist`); add `misc:legend_stare` achievement (open legendary card detail 10 times in a session → purple toast + 100 crystals reward)
- Closed stale/already-fixed issues: #412, #416, #417, #418, #674, #684, #694

## Test plan

- [ ] Play a quick battle and verify no unhandled SW rejection errors appear in the console
- [ ] Load the game normally — no integrity warning should appear (checksum seeds on first load)
- [ ] Manually edit `jarv_collection` in DevTools → reload → confirm red warning banner appears and dismisses
- [ ] Trigger one of the new rare events (force via DevMenu) and verify its achievement fires
- [ ] Open legendary card details 10 times in Collection → purple "The legendaries have noticed your gaze" toast appears

https://claude.ai/code/session_01UmwSTG7sQvxow2fYKjqo24
EOF
)