### PR TITLE
Node map visual overhaul: L→R orientation, road paths, themed backgrounds

### DIFF
--- a/web/src/components/NodeMap.tsx
+++ b/web/src/components/NodeMap.tsx
@@ -107,6 +107,7 @@ interface ConnProps {
   maxRows:      number
   statusOf:     (id: string) => NodeStatus
   reachableIds: Set<string>
+  environment?: string
 }
 
 type LineVariant = 'trail' | 'frontier' | 'future' | 'dead'
@@ -124,17 +125,27 @@ function lineVariant(
   return 'future'
 }
 
-const LINE_STROKE: Record<LineVariant, string> = {
-  trail:    'rgba(51,255,51,0.35)',
-  frontier: 'rgba(51,255,51,0.75)',
-  future:   'rgba(255,255,255,0.1)',
-  dead:     'rgba(255,255,255,0.03)',
-}
-const LINE_WIDTH: Record<LineVariant, number> = {
-  trail: 1.5, frontier: 2, future: 1.5, dead: 1,
+function envColors(env?: string): { trail: string; frontier: string } {
+  switch (env) {
+    case 'forest':   return { trail: 'rgba(80,140,60,0.6)',   frontier: 'rgba(100,220,80,0.9)'  }
+    case 'citadel':
+    case 'ruins':    return { trail: 'rgba(120,120,140,0.55)', frontier: 'rgba(180,180,210,0.9)' }
+    case 'ashen':    return { trail: 'rgba(160,80,40,0.55)',   frontier: 'rgba(240,120,60,0.9)'  }
+    case 'farmland': return { trail: 'rgba(140,160,60,0.55)',  frontier: 'rgba(200,220,80,0.9)'  }
+    case 'frost':    return { trail: 'rgba(80,160,200,0.55)',  frontier: 'rgba(120,220,255,0.9)' }
+    case 'volcano':  return { trail: 'rgba(200,80,20,0.6)',    frontier: 'rgba(255,120,30,0.95)' }
+    case 'sand':     return { trail: 'rgba(200,160,60,0.55)',  frontier: 'rgba(240,200,80,0.9)'  }
+    case 'reef':
+    case 'coast':    return { trail: 'rgba(40,140,180,0.55)',  frontier: 'rgba(60,200,240,0.9)'  }
+    case 'sky':      return { trail: 'rgba(100,140,200,0.55)', frontier: 'rgba(140,190,255,0.9)' }
+    case 'fungal':   return { trail: 'rgba(120,60,160,0.55)',  frontier: 'rgba(180,80,240,0.9)'  }
+    case 'vault':
+    case 'camp':     return { trail: 'rgba(140,120,80,0.55)',  frontier: 'rgba(200,180,100,0.9)' }
+    default:         return { trail: 'rgba(120,120,120,0.45)', frontier: 'rgba(51,255,51,0.85)'  }
+  }
 }
 
-function SVGConnector({ prevRow, nextRow, maxRows, statusOf, reachableIds }: ConnProps) {
+function SVGConnector({ prevRow, nextRow, maxRows, statusOf, reachableIds, environment }: ConnProps) {
   const prevRowCols = prevRow[0]?.rowCols ?? prevRow.length
   const nextRowCols = nextRow[0]?.rowCols ?? nextRow.length
 
@@ -172,6 +183,8 @@ function SVGConnector({ prevRow, nextRow, maxRows, statusOf, reachableIds }: Con
     }
   }
 
+  const colors = envColors(environment)
+
   return (
     <svg
       viewBox={`0 0 1 ${maxRows}`}
@@ -180,17 +193,33 @@ function SVGConnector({ prevRow, nextRow, maxRows, statusOf, reachableIds }: Con
     >
       {Array.from(best.values()).map(({ variant, pr, cr }, i) => {
         const y1 = cy(pr), y2 = cy(cr)
-        // Cubic bezier: depart/arrive horizontally, smooth vertical transition
         const d = `M 0,${y1} C 0.5,${y1} 0.5,${y2} 1,${y2}`
+
+        if (variant === 'future') {
+          return (
+            <path key={i} d={d} fill="none"
+              stroke="rgba(255,255,255,0.13)" strokeWidth={2}
+              strokeDasharray="0.04 0.06" strokeLinecap="round"
+              vectorEffect="non-scaling-stroke" />
+          )
+        }
+        if (variant === 'dead') {
+          return (
+            <path key={i} d={d} fill="none"
+              stroke="rgba(255,255,255,0.04)" strokeWidth={1}
+              vectorEffect="non-scaling-stroke" />
+          )
+        }
+        // trail / frontier — two-layer road look
+        const surfaceColor = variant === 'frontier' ? colors.frontier : colors.trail
+        const edgeColor    = variant === 'frontier' ? 'rgba(0,0,0,0.55)' : 'rgba(0,0,0,0.4)'
+        const outerWidth   = variant === 'frontier' ? 7 : 6
+        const innerWidth   = variant === 'frontier' ? 4 : 3
         return (
-          <path
-            key={i}
-            d={d}
-            fill="none"
-            stroke={LINE_STROKE[variant]}
-            strokeWidth={LINE_WIDTH[variant]}
-            vectorEffect="non-scaling-stroke"
-          />
+          <React.Fragment key={i}>
+            <path d={d} fill="none" stroke={edgeColor}    strokeWidth={outerWidth} strokeLinecap="round" vectorEffect="non-scaling-stroke" />
+            <path d={d} fill="none" stroke={surfaceColor} strokeWidth={innerWidth} strokeLinecap="round" vectorEffect="non-scaling-stroke" />
+          </React.Fragment>
         )
       })}
     </svg>
@@ -434,7 +463,7 @@ export function NodeMap({ act, run, onSelectNode, onUseConsumable, onBack }: Pro
       </div>
 
       {/* Map — left-to-right: each act row renders as a vertical column */}
-      <div className="nm-map" ref={mapRef}>
+      <div className={`nm-map${act.environment ? ` nm-map--${act.environment}` : ''}`} ref={mapRef}>
         <div className="nm-map-inner" style={{ height: `${maxRowCols * ROW_HEIGHT}px` }}>
           {rows.map((rowNodes, rowIndex) => {
             const rowCols = rowNodes[0]?.rowCols ?? rowNodes.length
@@ -502,6 +531,7 @@ export function NodeMap({ act, run, onSelectNode, onUseConsumable, onBack }: Pro
                     maxRows={maxRowCols}
                     statusOf={statusOf}
                     reachableIds={reachableIds}
+                    environment={act.environment}
                   />
                 )}
               </React.Fragment>

--- a/web/src/components/NodeMap.tsx
+++ b/web/src/components/NodeMap.tsx
@@ -19,7 +19,8 @@ const NODE_ICON: Record<string, string> = {
   merchant: '⚖',
 }
 
-const COL_WIDTH = 112 // fixed pixel width per map column slot
+const COL_WIDTH  = 112 // fixed pixel width per map column slot
+const ROW_HEIGHT = 112 // fixed pixel height per vertical node slot within a column
 
 const NODE_LABEL: Record<string, string> = {
   battle:   'BATTLE',
@@ -96,14 +97,14 @@ function buildRows(act: Act): QuestNode[][] {
 }
 
 // ── SVG connector ────────────────────────────────────────────────────────────
-// Renders cubic-bezier curves between adjacent rows.
-// viewBox is maxCols×1; column centres at col+0.5, matching the CSS grid.
+// Renders cubic-bezier curves between adjacent columns (L→R layout).
+// viewBox is 1×maxRows; row centres at row+0.5, matching the CSS grid.
 // Each path is coloured by the status of its parent→child pair.
 
 interface ConnProps {
   prevRow:      QuestNode[]
   nextRow:      QuestNode[]
-  maxCols:      number
+  maxRows:      number
   statusOf:     (id: string) => NodeStatus
   reachableIds: Set<string>
 }
@@ -133,55 +134,54 @@ const LINE_WIDTH: Record<LineVariant, number> = {
   trail: 1.5, frontier: 2, future: 1.5, dead: 1,
 }
 
-function SVGConnector({ prevRow, nextRow, maxCols, statusOf, reachableIds }: ConnProps) {
+function SVGConnector({ prevRow, nextRow, maxRows, statusOf, reachableIds }: ConnProps) {
   const prevRowCols = prevRow[0]?.rowCols ?? prevRow.length
   const nextRowCols = nextRow[0]?.rowCols ?? nextRow.length
 
-  // Absolute column position within the maxCols-wide container
-  const visualCol = (node: QuestNode, rowCols: number) =>
-    (maxCols - rowCols) / 2 + node.col
+  // Absolute row position within the maxRows-tall container
+  const visualRow = (node: QuestNode, rowCols: number) =>
+    (maxRows - rowCols) / 2 + node.col
 
   const nextById = new Map(nextRow.map(n => [n.id, n]))
 
-  // Build connections from parent.childIds — fixes missing connectors when only
-  // one direction of the edge is populated in the act JSON.
+  // Build connections from parent.childIds
   const connections: [string, string, number, number][] = []
   for (const parent of prevRow) {
     for (const childId of parent.childIds) {
       const child = nextById.get(childId)
       if (child) {
-        connections.push([parent.id, child.id, visualCol(parent, prevRowCols), visualCol(child, nextRowCols)])
+        connections.push([parent.id, child.id, visualRow(parent, prevRowCols), visualRow(child, nextRowCols)])
       }
     }
   }
 
   if (connections.length === 0) return null
 
-  // Column i centre in viewBox units (viewBox is maxCols wide, 1 tall)
-  const cx = (vc: number) => vc + 0.5
+  // Row i centre in viewBox units (viewBox is 1 wide, maxRows tall)
+  const cy = (vr: number) => vr + 0.5
 
-  // Deduplicate by visual column pair (keep highest-priority variant)
+  // Deduplicate by visual row pair (keep highest-priority variant)
   const variantPriority: Record<LineVariant, number> = { frontier: 3, trail: 2, future: 1, dead: 0 }
-  const best = new Map<string, { variant: LineVariant; pc: number; cc: number }>()
-  for (const [pid, cid, pc, cc] of connections) {
-    const key = `${pc}:${cc}`
+  const best = new Map<string, { variant: LineVariant; pr: number; cr: number }>()
+  for (const [pid, cid, pr, cr] of connections) {
+    const key = `${pr}:${cr}`
     const v = lineVariant(pid, cid, statusOf, reachableIds)
     const existing = best.get(key)
     if (!existing || variantPriority[v] > variantPriority[existing.variant]) {
-      best.set(key, { variant: v, pc, cc })
+      best.set(key, { variant: v, pr, cr })
     }
   }
 
   return (
     <svg
-      viewBox={`0 0 ${maxCols} 1`}
+      viewBox={`0 0 1 ${maxRows}`}
       preserveAspectRatio="none"
-      style={{ width: '100%', height: '44px', display: 'block', overflow: 'visible' }}
+      style={{ width: '44px', height: '100%', display: 'block', overflow: 'visible', alignSelf: 'stretch', flexShrink: 0 }}
     >
-      {Array.from(best.values()).map(({ variant, pc, cc }, i) => {
-        const x1 = cx(pc), x2 = cx(cc)
-        // Cubic bezier: depart/arrive vertically, smooth horizontal transition
-        const d = `M ${x1},0 C ${x1},0.5 ${x2},0.5 ${x2},1`
+      {Array.from(best.values()).map(({ variant, pr, cr }, i) => {
+        const y1 = cy(pr), y2 = cy(cr)
+        // Cubic bezier: depart/arrive horizontally, smooth vertical transition
+        const d = `M 0,${y1} C 0.5,${y1} 0.5,${y2} 1,${y2}`
         return (
           <path
             key={i}
@@ -370,8 +370,8 @@ export function NodeMap({ act, run, onSelectNode, onUseConsumable, onBack }: Pro
     if (!mapEl || !nodeEl) return
     const mapRect  = mapEl.getBoundingClientRect()
     const nodeRect = nodeEl.getBoundingClientRect()
-    mapEl.scrollTop = mapEl.scrollTop + nodeRect.top - mapRect.top
-      - (mapRect.height - nodeRect.height) / 2
+    mapEl.scrollLeft = mapEl.scrollLeft + nodeRect.left - mapRect.left
+      - (mapRect.width - nodeRect.width) / 2
   }, [])
 
   const handleNodeClick = (node: QuestNode) => {
@@ -433,32 +433,21 @@ export function NodeMap({ act, run, onSelectNode, onUseConsumable, onBack }: Pro
         })}
       </div>
 
-      {/* Map */}
+      {/* Map — left-to-right: each act row renders as a vertical column */}
       <div className="nm-map" ref={mapRef}>
-        <div className="nm-map-inner" style={{ width: `${maxRowCols * COL_WIDTH}px` }}>
+        <div className="nm-map-inner" style={{ height: `${maxRowCols * ROW_HEIGHT}px` }}>
           {rows.map((rowNodes, rowIndex) => {
             const rowCols = rowNodes[0]?.rowCols ?? rowNodes.length
             return (
               <React.Fragment key={rowIndex}>
-                {/* Connector above this row */}
-                {rowIndex > 0 && (
-                  <SVGConnector
-                    prevRow={rows[rowIndex - 1]}
-                    nextRow={rowNodes}
-                    maxCols={maxRowCols}
-                    statusOf={statusOf}
-                    reachableIds={reachableIds}
-                  />
-                )}
-
-                {/* Row of nodes — fixed-width columns, centred in the container */}
+                {/* Column of nodes — fixed-height rows, centred in the container */}
                 <div
-                  className="nm-row"
+                  className="nm-col"
                   style={{
-                    gridTemplateColumns: `repeat(${rowCols}, ${COL_WIDTH}px)`,
-                    width: `${rowCols * COL_WIDTH}px`,
-                    margin: '0 auto',
-                    gap: 0,
+                    gridTemplateRows: `repeat(${rowCols}, ${ROW_HEIGHT}px)`,
+                    height: `${rowCols * ROW_HEIGHT}px`,
+                    width: `${COL_WIDTH}px`,
+                    margin: 'auto 0',
                   }}
                 >
                   {rowNodes.map((node) => {
@@ -473,7 +462,7 @@ export function NodeMap({ act, run, onSelectNode, onUseConsumable, onBack }: Pro
                       <div
                         key={node.id}
                         ref={isCurrent ? currentRef : undefined}
-                        style={{ gridColumn: node.col + 1, display: 'flex', justifyContent: 'center' }}
+                        style={{ gridRow: node.col + 1, display: 'flex', justifyContent: 'center', alignItems: 'center' }}
                       >
                         <button
                           className={[
@@ -504,6 +493,17 @@ export function NodeMap({ act, run, onSelectNode, onUseConsumable, onBack }: Pro
                     )
                   })}
                 </div>
+
+                {/* Connector to the right of this column */}
+                {rowIndex < rows.length - 1 && (
+                  <SVGConnector
+                    prevRow={rowNodes}
+                    nextRow={rows[rowIndex + 1]}
+                    maxRows={maxRowCols}
+                    statusOf={statusOf}
+                    reachableIds={reachableIds}
+                  />
+                )}
               </React.Fragment>
             )
           })}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -3838,6 +3838,22 @@ body {
   align-items: center;
 }
 
+/* Act-environment themed backgrounds */
+.nm-map--forest   { background: radial-gradient(ellipse at center, #0d1f0a 0%, #071208 100%); }
+.nm-map--citadel  { background: radial-gradient(ellipse at center, #16181e 0%, #0e0f13 100%); }
+.nm-map--ruins    { background: radial-gradient(ellipse at center, #141214 0%, #0c0a0c 100%); }
+.nm-map--ashen    { background: radial-gradient(ellipse at center, #1e100a 0%, #100808 100%); }
+.nm-map--farmland { background: radial-gradient(ellipse at center, #131a07 0%, #0a1005 100%); }
+.nm-map--frost    { background: radial-gradient(ellipse at center, #0a1520 0%, #060e18 100%); }
+.nm-map--volcano  { background: radial-gradient(ellipse at center, #1e0a05 0%, #110505 100%); }
+.nm-map--sand     { background: radial-gradient(ellipse at center, #1e1608 0%, #120e05 100%); }
+.nm-map--reef     { background: radial-gradient(ellipse at center, #081820 0%, #04101a 100%); }
+.nm-map--coast    { background: radial-gradient(ellipse at center, #081620 0%, #050e18 100%); }
+.nm-map--sky      { background: radial-gradient(ellipse at center, #0a1220 0%, #070c18 100%); }
+.nm-map--fungal   { background: radial-gradient(ellipse at center, #130a20 0%, #0a0614 100%); }
+.nm-map--vault    { background: radial-gradient(ellipse at center, #181410 0%, #100e0a 100%); }
+.nm-map--camp     { background: radial-gradient(ellipse at center, #161210 0%, #0e0a08 100%); }
+
 .nm-map-inner {
   margin: auto;
   display: flex;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -3831,22 +3831,28 @@ body {
 
 .nm-map {
   display: flex;
-  flex-direction: column;
   flex: 1;
-  overflow: auto;
+  overflow-x: auto;
+  overflow-y: auto;
   padding: 16px 8px 8px;
+  align-items: center;
 }
 
 .nm-map-inner {
-  margin: 0 auto;
+  margin: auto;
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
+  align-items: center;
+  flex-shrink: 0;
 }
 
-/* ── Rows ── */
+/* ── Columns (each act-row renders as a vertical column in L→R layout) ── */
 
-.nm-row {
+.nm-col {
   display: grid;
+  align-items: center;
+  justify-items: center;
+  flex-shrink: 0;
 }
 
 /* ── Node buttons ── */


### PR DESCRIPTION
Closes #716, closes #715, closes #701

## Summary

- **Left-to-right orientation (#716)** — map now scrolls horizontally; start node on the left, boss on the right. Each act row renders as a vertical column; SVG connectors draw horizontal S-curves between columns; auto-scroll centres the current node horizontally on mount.

- **Road-style paths + environment backgrounds (#715)** — visited edges use a two-layer path (dark outer edge + coloured surface) for a road look; frontier edges are brighter; unvisited paths use dashed lines; dead/unreachable edges are near-invisible. Path colours are tinted to the act's environment (14 environments covered). The map canvas gets a dark radial-gradient background matching the act environment.

## Test plan

- [ ] Open the campaign map — nodes appear left-to-right, start on left, boss on right
- [ ] Completed path segments show as solid coloured roads; the next available node's connecting path is brighter
- [ ] Unvisited/future paths show as faint dashed lines
- [ ] Map background colour matches the act's environment (e.g. green tint for forest, red for volcano)
- [ ] Horizontal scroll works on both desktop and mobile
- [ ] Auto-scroll positions the current/available node near the centre of the view on load

https://claude.ai/code/session_01EUannpJz42CqWNsyn2cAyy