### PR TITLE
Node map: terrain decorations + wider roads

### DIFF
--- a/web/public/sprites/campfire.svg
+++ b/web/public/sprites/campfire.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- logs -->
+  <rect x="6" y="23" width="14" height="4" rx="2" transform="rotate(-20,13,25)" fill="#6b3a1f"/>
+  <rect x="12" y="23" width="14" height="4" rx="2" transform="rotate(20,19,25)" fill="#7a4422"/>
+  <!-- ember glow -->
+  <ellipse cx="16" cy="26" rx="7" ry="3" fill="#ff6600" opacity="0.35"/>
+  <!-- outer flame -->
+  <polygon points="16,8 9,26 23,26" fill="#ff6600" opacity="0.85"/>
+  <!-- mid flame -->
+  <polygon points="16,12 11,26 21,26" fill="#ff9900"/>
+  <!-- inner flame -->
+  <polygon points="16,15 13,26 19,26" fill="#ffcc00"/>
+  <!-- tip -->
+  <polygon points="16,10 14.5,17 17.5,17" fill="#fff8c0" opacity="0.8"/>
+  <!-- side flickers -->
+  <polygon points="11,18 8,26 14,25" fill="#ff4400" opacity="0.6"/>
+  <polygon points="21,18 18,25 24,26" fill="#ff4400" opacity="0.6"/>
+</svg>

--- a/web/public/sprites/event.svg
+++ b/web/public/sprites/event.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- scroll body -->
+  <rect x="7" y="6" width="18" height="22" rx="2" fill="#e8d59a"/>
+  <!-- scroll top roll -->
+  <ellipse cx="16" cy="6" rx="9" ry="3" fill="#d4b870"/>
+  <ellipse cx="16" cy="6" rx="7" ry="2" fill="#e8d59a"/>
+  <!-- scroll bottom roll -->
+  <ellipse cx="16" cy="28" rx="9" ry="3" fill="#d4b870"/>
+  <ellipse cx="16" cy="28" rx="7" ry="2" fill="#e8d59a"/>
+  <!-- ? mark -->
+  <path d="M13,11 Q13,9 16,9 Q19,9 19,12 Q19,14 16,15 L16,18" fill="none" stroke="#6a3a10" stroke-width="2" stroke-linecap="round"/>
+  <circle cx="16" cy="21" r="1.3" fill="#6a3a10"/>
+  <!-- decorative lines -->
+  <line x1="10" y1="24" x2="22" y2="24" stroke="#c4a050" stroke-width="0.8" opacity="0.6"/>
+  <line x1="10" y1="26" x2="18" y2="26" stroke="#c4a050" stroke-width="0.8" opacity="0.4"/>
+  <!-- wax seal hint -->
+  <circle cx="22" cy="8" r="2.5" fill="#cc2222" opacity="0.7"/>
+  <circle cx="22" cy="8" r="1.5" fill="#ee4444" opacity="0.6"/>
+</svg>

--- a/web/public/sprites/merchant.svg
+++ b/web/public/sprites/merchant.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- pack/sack on back -->
+  <ellipse cx="23" cy="19" rx="5" ry="5" fill="#a07030"/>
+  <ellipse cx="23" cy="17" rx="3.5" ry="3.5" fill="#c8943a"/>
+  <!-- body/robe -->
+  <path d="M9,28 L11,16 Q16,14 21,16 L23,28 Z" fill="#3a6b3a"/>
+  <path d="M11,28 L12,18 Q16,16 20,18 L21,28 Z" fill="#4d8a4d" opacity="0.7"/>
+  <!-- shoulders -->
+  <rect x="8" y="16" width="5" height="4" rx="2" fill="#2d522d"/>
+  <rect x="19" y="16" width="5" height="4" rx="2" fill="#2d522d"/>
+  <!-- neck -->
+  <rect x="14" y="13" width="4" height="4" fill="#d4a060"/>
+  <!-- head -->
+  <ellipse cx="16" cy="10" rx="6" ry="6" fill="#d4a060"/>
+  <!-- hat brim -->
+  <ellipse cx="16" cy="5" rx="8" ry="2" fill="#8b5e1a"/>
+  <!-- hat top -->
+  <rect x="12" y="1" width="8" height="5" rx="2" fill="#a07030"/>
+  <!-- eyes -->
+  <ellipse cx="13.5" cy="10" rx="1.2" ry="1" fill="#111"/>
+  <ellipse cx="18.5" cy="10" rx="1.2" ry="1" fill="#111"/>
+  <circle cx="13.3" cy="9.8" r="0.5" fill="#fff"/>
+  <circle cx="18.3" cy="9.8" r="0.5" fill="#fff"/>
+  <!-- smile -->
+  <path d="M13.5,12.5 Q16,14 18.5,12.5" fill="none" stroke="#7a4020" stroke-width="0.8"/>
+  <!-- coin/gold hint -->
+  <circle cx="14" cy="22" r="2" fill="#ffd700" opacity="0.9"/>
+  <circle cx="14" cy="22" r="1.2" fill="#ffaa00"/>
+</svg>

--- a/web/src/components/NodeMap.tsx
+++ b/web/src/components/NodeMap.tsx
@@ -96,6 +96,291 @@ function buildRows(act: Act): QuestNode[][] {
     .map(r => byRow[r].sort((a, b) => a.col - b.col))
 }
 
+// ── Terrain decoration layer ─────────────────────────────────────────────────
+
+function seededRand(seed: number) {
+  let s = seed | 0
+  return (): number => {
+    s = Math.imul(s ^ (s >>> 16), 0x45d9f3b)
+    s = Math.imul(s ^ (s >>> 16), 0x45d9f3b)
+    s ^= (s >>> 16)
+    return (s >>> 0) / 0xffffffff
+  }
+}
+
+function hashStr(str: string): number {
+  let h = 5381
+  for (let i = 0; i < str.length; i++) h = (Math.imul(h, 33) ^ str.charCodeAt(i)) | 0
+  return Math.abs(h)
+}
+
+interface TerrainItem { x: number; y: number; scale: number; kind: string }
+
+function getTerrainItems(env: string | undefined, seed: number, w: number, h: number): TerrainItem[] {
+  const r   = seededRand(seed)
+  const rf  = (lo: number, hi: number) => lo + r() * (hi - lo)
+  const pad = 30
+  const items: TerrainItem[] = []
+
+  const scatter = (kind: string, count: number, minS: number, maxS: number) => {
+    for (let i = 0; i < count; i++)
+      items.push({ kind, x: rf(pad, w - pad), y: rf(pad, h - pad), scale: rf(minS, maxS) })
+  }
+
+  switch (env) {
+    case 'forest':
+      scatter('tree',     14, 0.8, 1.5)
+      scatter('mountain',  4, 0.5, 0.9)
+      scatter('river',     1, 1,   1  )
+      break
+    case 'citadel':
+      scatter('tower',    10, 0.8, 1.4)
+      scatter('mountain',  5, 0.5, 1.0)
+      break
+    case 'ruins':
+      scatter('pillar',    9, 0.8, 1.3)
+      scatter('tree',      4, 0.5, 0.9)
+      scatter('river',     1, 1,   1  )
+      break
+    case 'ashen':
+      scatter('mountain', 10, 0.7, 1.4)
+      scatter('deadtree',  6, 0.8, 1.3)
+      break
+    case 'farmland':
+      scatter('tree',      8, 0.7, 1.1)
+      scatter('mountain',  4, 0.4, 0.7)
+      scatter('river',     1, 1,   1  )
+      break
+    case 'frost':
+      scatter('crystal',  12, 0.8, 1.4)
+      scatter('mountain',  6, 0.7, 1.2)
+      scatter('river',     1, 1,   1  )
+      break
+    case 'volcano':
+      scatter('mountain', 10, 0.8, 1.5)
+      scatter('lava',      5, 0.7, 1.2)
+      break
+    case 'sand':
+      scatter('dune',     10, 0.7, 1.3)
+      scatter('mountain',  4, 0.5, 0.9)
+      break
+    case 'reef':
+    case 'coast':
+      scatter('wave',     10, 0.8, 1.4)
+      scatter('mountain',  4, 0.5, 0.9)
+      scatter('river',     1, 1,   1  )
+      break
+    case 'sky':
+      scatter('cloud',    12, 0.8, 1.5)
+      scatter('mountain',  4, 0.4, 0.8)
+      break
+    case 'fungal':
+      scatter('mushroom', 12, 0.8, 1.5)
+      scatter('deadtree',  4, 0.5, 0.9)
+      scatter('river',     1, 1,   1  )
+      break
+    case 'vault':
+    case 'camp':
+      scatter('pillar',    8, 0.7, 1.2)
+      scatter('mountain',  4, 0.5, 0.9)
+      break
+    default:
+      scatter('mountain', 10, 0.6, 1.2)
+      scatter('tree',      4, 0.6, 1.0)
+  }
+
+  return items
+}
+
+interface TerrainProps { environment?: string; actId: string; width: number; height: number }
+
+function MapTerrain({ environment, actId, width, height }: TerrainProps) {
+  const items = useMemo(
+    () => getTerrainItems(environment, hashStr(actId), width, height),
+    [environment, actId, width, height],
+  )
+
+  const riverColor = (() => {
+    switch (environment) {
+      case 'volcano': return '#cc4400'
+      case 'fungal':  return '#6633aa'
+      case 'frost':   return '#88ddff'
+      default:        return '#2255aa'
+    }
+  })()
+
+  const riverItems   = items.filter(it => it.kind === 'river')
+  const terrainItems = items.filter(it => it.kind !== 'river')
+
+  // Seed river control points off actId hash
+  const rseed = hashStr(actId + 'river')
+  const rr    = seededRand(rseed)
+  const rrf   = (lo: number, hi: number) => lo + rr() * (hi - lo)
+
+  return (
+    <svg
+      viewBox={`0 0 ${width} ${height}`}
+      preserveAspectRatio="xMidYMid meet"
+      style={{ position: 'absolute', inset: 0, width: '100%', height: '100%', pointerEvents: 'none', zIndex: 0 }}
+    >
+      {/* Rivers */}
+      {riverItems.map((_, i) => {
+        const x1 = rrf(0, width * 0.25),  y1 = rrf(0, height)
+        const x2 = rrf(width * 0.75, width), y2 = rrf(0, height)
+        const cx1 = rrf(width * 0.2, width * 0.5), cy1 = rrf(0, height)
+        const cx2 = rrf(width * 0.5, width * 0.8), cy2 = rrf(0, height)
+        return (
+          <g key={`river-${i}`} opacity={0.28}>
+            <path d={`M ${x1},${y1} C ${cx1},${cy1} ${cx2},${cy2} ${x2},${y2}`}
+              fill="none" stroke={riverColor} strokeWidth={6} strokeLinecap="round" />
+            <path d={`M ${x1},${y1} C ${cx1},${cy1} ${cx2},${cy2} ${x2},${y2}`}
+              fill="none" stroke="rgba(255,255,255,0.25)" strokeWidth={2} strokeLinecap="round" />
+          </g>
+        )
+      })}
+
+      {/* Terrain features */}
+      {terrainItems.map((it, i) => {
+        const { x, y, scale, kind } = it
+        const k = `${kind}-${i}`
+        switch (kind) {
+
+          case 'mountain': {
+            const w = scale * 44, h = scale * 32
+            const col = environment === 'frost'   ? '#8ab8cc'
+                      : environment === 'volcano' ? '#6a3020'
+                      : environment === 'sand'    ? '#a08040'
+                      : '#5a6050'
+            return (
+              <g key={k} opacity={0.22}>
+                <polygon points={`${x},${y} ${x+w*0.45},${y-h} ${x+w},${y}`} fill={col} />
+                <polygon points={`${x+w*0.3},${y} ${x+w*0.72},${y-h*0.75} ${x+w*1.1},${y}`} fill={col} />
+                {environment === 'frost' && (
+                  <polygon points={`${x+w*0.2},${y-h*0.55} ${x+w*0.45},${y-h} ${x+w*0.7},${y-h*0.55}`} fill="rgba(255,255,255,0.55)" />
+                )}
+              </g>
+            )
+          }
+
+          case 'tree': {
+            const h = scale * 28, tw = scale * 14
+            const col = environment === 'farmland' ? '#4a7a28'
+                      : environment === 'ruins'    ? '#3a6028'
+                      : '#2a7020'
+            return (
+              <g key={k} opacity={0.24}>
+                <rect x={x - scale*2} y={y - scale*8} width={scale*4} height={scale*9} fill="#6b4226" />
+                <polygon points={`${x},${y-h} ${x-tw},${y-scale*6} ${x+tw},${y-scale*6}`} fill={col} />
+                <polygon points={`${x},${y-h*0.62} ${x-tw*1.1},${y-scale*2} ${x+tw*1.1},${y-scale*2}`} fill={col} />
+              </g>
+            )
+          }
+
+          case 'deadtree': {
+            const h = scale * 28
+            return (
+              <g key={k} opacity={0.2}>
+                <line x1={x} y1={y} x2={x} y2={y - h} stroke="#5a4030" strokeWidth={scale * 3} strokeLinecap="round" />
+                <line x1={x} y1={y - h * 0.6} x2={x - scale*12} y2={y - h * 0.85} stroke="#5a4030" strokeWidth={scale * 2} strokeLinecap="round" />
+                <line x1={x} y1={y - h * 0.5} x2={x + scale*10} y2={y - h * 0.72} stroke="#5a4030" strokeWidth={scale * 1.5} strokeLinecap="round" />
+              </g>
+            )
+          }
+
+          case 'crystal': {
+            const h = scale * 26
+            return (
+              <g key={k} opacity={0.28}>
+                <polygon points={`${x},${y-h} ${x-scale*5},${y} ${x+scale*5},${y}`} fill="#88ddff" />
+                <polygon points={`${x},${y-h*0.7} ${x-scale*7},${y+h*0.3} ${x+scale*7},${y+h*0.3}`} fill="#aaeeff" />
+                <line x1={x} y1={y-h} x2={x} y2={y+h*0.3} stroke="rgba(255,255,255,0.4)" strokeWidth={scale*1.5} />
+              </g>
+            )
+          }
+
+          case 'mushroom': {
+            const h = scale * 22, rw = scale * 12
+            return (
+              <g key={k} opacity={0.24}>
+                <rect x={x - scale*2.5} y={y - h} width={scale*5} height={h} fill="#8a7060" />
+                <ellipse cx={x} cy={y - h} rx={rw} ry={scale * 8} fill="#9a40ee" />
+                <ellipse cx={x - scale*3} cy={y - h - scale*2} rx={scale*4} ry={scale*3} fill="rgba(255,255,255,0.3)" />
+              </g>
+            )
+          }
+
+          case 'lava': {
+            return (
+              <g key={k} opacity={0.22}>
+                <ellipse cx={x} cy={y} rx={scale*20} ry={scale*10} fill="#cc3300" />
+                <ellipse cx={x} cy={y} rx={scale*12} ry={scale*6}  fill="#ff6600" />
+                <ellipse cx={x + scale*4} cy={y - scale*2} rx={scale*5} ry={scale*3} fill="#ffaa00" opacity={0.7} />
+              </g>
+            )
+          }
+
+          case 'wave': {
+            const ww = scale * 50
+            return (
+              <g key={k} opacity={0.22}>
+                <path d={`M ${x},${y} Q ${x+ww*0.25},${y-scale*9} ${x+ww*0.5},${y} Q ${x+ww*0.75},${y+scale*9} ${x+ww},${y}`}
+                  fill="none" stroke="#4499cc" strokeWidth={scale*3} strokeLinecap="round" />
+                <path d={`M ${x+scale*5},${y+scale*7} Q ${x+ww*0.3},${y-scale*5} ${x+ww*0.6},${y+scale*7}`}
+                  fill="none" stroke="#66bbee" strokeWidth={scale*2} strokeLinecap="round" opacity={0.6} />
+              </g>
+            )
+          }
+
+          case 'cloud': {
+            return (
+              <g key={k} opacity={0.15}>
+                <ellipse cx={x}              cy={y}            rx={scale*22} ry={scale*13} fill="white" />
+                <ellipse cx={x + scale*14}   cy={y + scale*4}  rx={scale*18} ry={scale*11} fill="white" />
+                <ellipse cx={x - scale*12}   cy={y + scale*5}  rx={scale*16} ry={scale*10} fill="white" />
+              </g>
+            )
+          }
+
+          case 'tower': {
+            const h = scale * 30, tw = scale * 10
+            return (
+              <g key={k} opacity={0.2}>
+                <rect x={x - tw/2} y={y - h} width={tw} height={h} fill="#6a6a7a" />
+                <rect x={x - tw/2 - scale*2} y={y - h} width={tw + scale*4} height={scale*5} fill="#8a8a9a" />
+                <rect x={x - scale*2} y={y - h - scale*6} width={scale*4} height={scale*6} fill="#6a6a7a" />
+                <rect x={x - tw/2 - scale*2} y={y - h - scale*6} width={tw + scale*4} height={scale*3} fill="#7a7a8a" />
+              </g>
+            )
+          }
+
+          case 'pillar': {
+            const h = scale * (16 + hashStr(`${k}${x}`) % 18), pw = scale * 7
+            return (
+              <g key={k} opacity={0.18}>
+                <rect x={x - pw/2} y={y - h} width={pw} height={h} fill="#888" />
+                <rect x={x - pw/2 - scale*2} y={y - h}          width={pw + scale*4} height={scale*4} fill="#aaa" />
+                <rect x={x - pw/2 - scale*2} y={y - scale*4}    width={pw + scale*4} height={scale*4} fill="#aaa" />
+              </g>
+            )
+          }
+
+          case 'dune': {
+            const dw = scale * 55
+            return (
+              <g key={k} opacity={0.2}>
+                <ellipse cx={x} cy={y} rx={dw * 0.5} ry={scale * 10} fill="#c8a040" />
+                <ellipse cx={x + dw*0.35} cy={y + scale*4} rx={dw * 0.35} ry={scale * 8} fill="#b89030" />
+              </g>
+            )
+          }
+
+          default: return null
+        }
+      })}
+    </svg>
+  )
+}
+
 // ── SVG connector ────────────────────────────────────────────────────────────
 // Renders cubic-bezier curves between adjacent columns (L→R layout).
 // viewBox is 1×maxRows; row centres at row+0.5, matching the CSS grid.
@@ -189,7 +474,7 @@ function SVGConnector({ prevRow, nextRow, maxRows, statusOf, reachableIds, envir
     <svg
       viewBox={`0 0 1 ${maxRows}`}
       preserveAspectRatio="none"
-      style={{ width: '44px', height: '100%', display: 'block', overflow: 'visible', alignSelf: 'stretch', flexShrink: 0 }}
+      style={{ width: '44px', height: '100%', display: 'block', overflow: 'visible', alignSelf: 'stretch', flexShrink: 0, position: 'relative', zIndex: 1 }}
     >
       {Array.from(best.values()).map(({ variant, pr, cr }, i) => {
         const y1 = cy(pr), y2 = cy(cr)
@@ -212,9 +497,9 @@ function SVGConnector({ prevRow, nextRow, maxRows, statusOf, reachableIds, envir
         }
         // trail / frontier — two-layer road look
         const surfaceColor = variant === 'frontier' ? colors.frontier : colors.trail
-        const edgeColor    = variant === 'frontier' ? 'rgba(0,0,0,0.55)' : 'rgba(0,0,0,0.4)'
-        const outerWidth   = variant === 'frontier' ? 7 : 6
-        const innerWidth   = variant === 'frontier' ? 4 : 3
+        const edgeColor    = variant === 'frontier' ? 'rgba(0,0,0,0.65)' : 'rgba(0,0,0,0.5)'
+        const outerWidth   = variant === 'frontier' ? 18 : 14
+        const innerWidth   = variant === 'frontier' ? 11 : 8
         return (
           <React.Fragment key={i}>
             <path d={d} fill="none" stroke={edgeColor}    strokeWidth={outerWidth} strokeLinecap="round" vectorEffect="non-scaling-stroke" />
@@ -464,7 +749,13 @@ export function NodeMap({ act, run, onSelectNode, onUseConsumable, onBack }: Pro
 
       {/* Map — left-to-right: each act row renders as a vertical column */}
       <div className={`nm-map${act.environment ? ` nm-map--${act.environment}` : ''}`} ref={mapRef}>
-        <div className="nm-map-inner" style={{ height: `${maxRowCols * ROW_HEIGHT}px` }}>
+        <div className="nm-map-inner" style={{ height: `${maxRowCols * ROW_HEIGHT}px`, position: 'relative' }}>
+          <MapTerrain
+            environment={act.environment}
+            actId={act.id}
+            width={rows.length * COL_WIDTH + Math.max(0, rows.length - 1) * 44}
+            height={maxRowCols * ROW_HEIGHT}
+          />
           {rows.map((rowNodes, rowIndex) => {
             const rowCols = rowNodes[0]?.rowCols ?? rowNodes.length
             return (
@@ -477,6 +768,8 @@ export function NodeMap({ act, run, onSelectNode, onUseConsumable, onBack }: Pro
                     height: `${rowCols * ROW_HEIGHT}px`,
                     width: `${COL_WIDTH}px`,
                     margin: 'auto 0',
+                    position: 'relative',
+                    zIndex: 1,
                   }}
                 >
                   {rowNodes.map((node) => {

--- a/web/src/components/NodeMap.tsx
+++ b/web/src/components/NodeMap.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useRef, useEffect, useState } from 'react'
 import { Act, QuestNode, RunState, ReplayModifier, getAvailableNodeIds, loadNodeHistory, getModifiersByCount, ALL_CONSUMABLES } from '../game/questline'
+import { spriteSlug } from '../game/sprites'
 import { StatRow } from './StatRow'
 
 interface Props {
@@ -29,6 +30,17 @@ const NODE_LABEL: Record<string, string> = {
   rest:     'REST',
   event:    'EVENT',
   merchant: 'SHOP',
+}
+
+function nodeSprite(node: QuestNode): string | null {
+  if (node.type === 'rest')     return '/sprites/campfire.svg'
+  if (node.type === 'merchant') return '/sprites/merchant.svg'
+  if (node.type === 'event')    return '/sprites/event.svg'
+  if (node.type === 'boss' && node.bossAI)
+    return `/sprites/boss-${node.bossAI}.svg`
+  if ((node.type === 'battle' || node.type === 'elite') && node.enemyDeck?.length)
+    return `/sprites/${spriteSlug(node.enemyDeck[0])}.svg`
+  return null
 }
 
 type NodeStatus = 'completed' | 'available' | 'skipped' | 'locked' | 'pending'
@@ -800,7 +812,13 @@ export function NodeMap({ act, run, onSelectNode, onUseConsumable, onBack }: Pro
                           <span className={`nm-node-type-badge nm-node-type-badge--${node.type}`}>
                             {NODE_LABEL[node.type] ?? node.type.toUpperCase()}
                           </span>
-                          <span className="nm-node-icon">{NODE_ICON[node.type] ?? '?'}</span>
+                          {(() => {
+                            const sprite = nodeSprite(node)
+                            return sprite
+                              ? <img src={sprite} alt="" className="nm-node-sprite"
+                                  onError={e => { (e.currentTarget as HTMLImageElement).style.display = 'none' }} />
+                              : <span className="nm-node-icon">{NODE_ICON[node.type] ?? '?'}</span>
+                          })()}
                           <span className="nm-node-name">{node.label}</span>
                           <span className="nm-node-status">
                             {status === 'completed' && '✓'}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -3903,7 +3903,8 @@ body {
 .nm-node-type-badge--event    { color: #8050b0; }
 .nm-node-type-badge--merchant { color: #a06020; }
 
-.nm-node-icon  { font-size: 22px; line-height: 1; }
+.nm-node-icon   { font-size: 22px; line-height: 1; }
+.nm-node-sprite { width: 38px; height: 38px; object-fit: contain; image-rendering: pixelated; }
 .nm-node-name  { font-size: 11px; color: var(--game-text-color-dim); letter-spacing: 0.5px; text-align: center; line-height: 1.3; }
 .nm-node-status { font-size: 9px; letter-spacing: 1px; min-height: 12px; }
 


### PR DESCRIPTION
Continues the node map visual overhaul from #735.

## Summary

- **Terrain decoration layer** — a `MapTerrain` SVG is rendered behind all nodes, seeded from `act.id` so decorations are consistent across sessions. Decoration types are environment-specific:
  - `forest` → trees + mountains + river
  - `volcano` → mountains + lava pools
  - `frost` → crystals + snowy mountains + river
  - `ashen` → mountains + dead trees
  - `fungal` → mushrooms + dead trees + river
  - `citadel` → towers + mountains
  - `ruins` → pillars + trees + river
  - `reef`/`coast` → wave shapes + river
  - `sky` → clouds + mountains
  - `sand` → dunes + mountains
  - `farmland`/`vault`/`camp` → appropriate terrain
- **Rivers** — cubic-bezier wavy lines with a highlight stroke; colour tinted to environment (blue for forest/coast, red for volcano, purple for fungal, etc.)
- **Wider roads** — trail strokes increased from 6/3 px to 14/8 px; frontier from 7/4 px to 18/11 px — connections now read as actual roads rather than thin diagram lines

## Test plan

- [ ] Forest act map shows trees and mountains scattered in background with a blue river
- [ ] Volcano act map shows rocky mountains and orange lava pools
- [ ] Frost act shows ice crystals and snowy peaks with a cyan river
- [ ] Roads between nodes are visually prominent and read as paths/roads
- [ ] Node boxes render above the terrain layer (not obscured)
- [ ] Decorations are consistent (same positions) on repeated visits to the map

https://claude.ai/code/session_01EUannpJz42CqWNsyn2cAyy