### PR TITLE
Node map: walking avatar + node-0 start position (#737)

### DIFF
--- a/web/public/sprites/jarv-1.svg
+++ b/web/public/sprites/jarv-1.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- cloak/body — 1px higher -->
+  <path d="M8,27 L10,15 Q16,13 22,15 L24,27 Z" fill="#2a3d66"/>
+  <path d="M10,27 L11,17 Q16,15 21,17 L22,27 Z" fill="#3a5088" opacity="0.6"/>
+  <!-- shoulders/pauldrons -->
+  <rect x="7" y="15" width="5" height="4" rx="2" fill="#1e2e50"/>
+  <rect x="20" y="15" width="5" height="4" rx="2" fill="#1e2e50"/>
+  <!-- neck -->
+  <rect x="14" y="12" width="4" height="4" fill="#c8a080"/>
+  <!-- hood -->
+  <ellipse cx="16" cy="10" rx="7" ry="7" fill="#1e2e50"/>
+  <ellipse cx="16" cy="9" rx="5" ry="5" fill="#2a3d66" opacity="0.7"/>
+  <!-- face -->
+  <ellipse cx="16" cy="11" rx="4" ry="4" fill="#c8a080"/>
+  <!-- eyes -->
+  <ellipse cx="14" cy="10" rx="1.2" ry="1" fill="#224488"/>
+  <ellipse cx="18" cy="10" rx="1.2" ry="1" fill="#224488"/>
+  <ellipse cx="14" cy="10" rx="0.5" ry="0.5" fill="#aaccff"/>
+  <ellipse cx="18" cy="10" rx="0.5" ry="0.5" fill="#aaccff"/>
+  <!-- hood shadow -->
+  <path d="M9,7 Q16,3 23,7 Q20,5 16,5 Q12,5 9,7" fill="#111a33" opacity="0.5"/>
+  <!-- belt buckle -->
+  <rect x="14" y="20" width="4" height="3" rx="1" fill="#d4a820"/>
+  <!-- legs: left forward, right back -->
+  <rect x="11" y="22" width="4" height="7" rx="1" fill="#449922"/>
+  <rect x="17" y="25" width="4" height="4" rx="1" fill="#449922"/>
+</svg>

--- a/web/public/sprites/jarv-2.svg
+++ b/web/public/sprites/jarv-2.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- cloak/body — 1px higher, mid-stride -->
+  <path d="M8,27 L10,15 Q16,13 22,15 L24,27 Z" fill="#2a3d66"/>
+  <path d="M10,27 L11,17 Q16,15 21,17 L22,27 Z" fill="#3a5088" opacity="0.6"/>
+  <!-- shoulders/pauldrons -->
+  <rect x="7" y="15" width="5" height="4" rx="2" fill="#1e2e50"/>
+  <rect x="20" y="15" width="5" height="4" rx="2" fill="#1e2e50"/>
+  <!-- neck -->
+  <rect x="14" y="12" width="4" height="4" fill="#c8a080"/>
+  <!-- hood -->
+  <ellipse cx="16" cy="10" rx="7" ry="7" fill="#1e2e50"/>
+  <ellipse cx="16" cy="9" rx="5" ry="5" fill="#2a3d66" opacity="0.7"/>
+  <!-- face -->
+  <ellipse cx="16" cy="11" rx="4" ry="4" fill="#c8a080"/>
+  <!-- eyes -->
+  <ellipse cx="14" cy="10" rx="1.2" ry="1" fill="#224488"/>
+  <ellipse cx="18" cy="10" rx="1.2" ry="1" fill="#224488"/>
+  <ellipse cx="14" cy="10" rx="0.5" ry="0.5" fill="#aaccff"/>
+  <ellipse cx="18" cy="10" rx="0.5" ry="0.5" fill="#aaccff"/>
+  <!-- hood shadow -->
+  <path d="M9,7 Q16,3 23,7 Q20,5 16,5 Q12,5 9,7" fill="#111a33" opacity="0.5"/>
+  <!-- belt buckle -->
+  <rect x="14" y="20" width="4" height="3" rx="1" fill="#d4a820"/>
+  <!-- legs: mid-stride, both even -->
+  <rect x="11" y="23" width="4" height="6" rx="1" fill="#449922"/>
+  <rect x="17" y="23" width="4" height="6" rx="1" fill="#449922"/>
+</svg>

--- a/web/public/sprites/jarv-3.svg
+++ b/web/public/sprites/jarv-3.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- cloak/body — 1px higher -->
+  <path d="M8,27 L10,15 Q16,13 22,15 L24,27 Z" fill="#2a3d66"/>
+  <path d="M10,27 L11,17 Q16,15 21,17 L22,27 Z" fill="#3a5088" opacity="0.6"/>
+  <!-- shoulders/pauldrons -->
+  <rect x="7" y="15" width="5" height="4" rx="2" fill="#1e2e50"/>
+  <rect x="20" y="15" width="5" height="4" rx="2" fill="#1e2e50"/>
+  <!-- neck -->
+  <rect x="14" y="12" width="4" height="4" fill="#c8a080"/>
+  <!-- hood -->
+  <ellipse cx="16" cy="10" rx="7" ry="7" fill="#1e2e50"/>
+  <ellipse cx="16" cy="9" rx="5" ry="5" fill="#2a3d66" opacity="0.7"/>
+  <!-- face -->
+  <ellipse cx="16" cy="11" rx="4" ry="4" fill="#c8a080"/>
+  <!-- eyes -->
+  <ellipse cx="14" cy="10" rx="1.2" ry="1" fill="#224488"/>
+  <ellipse cx="18" cy="10" rx="1.2" ry="1" fill="#224488"/>
+  <ellipse cx="14" cy="10" rx="0.5" ry="0.5" fill="#aaccff"/>
+  <ellipse cx="18" cy="10" rx="0.5" ry="0.5" fill="#aaccff"/>
+  <!-- hood shadow -->
+  <path d="M9,7 Q16,3 23,7 Q20,5 16,5 Q12,5 9,7" fill="#111a33" opacity="0.5"/>
+  <!-- belt buckle -->
+  <rect x="14" y="20" width="4" height="3" rx="1" fill="#d4a820"/>
+  <!-- legs: right forward, left back -->
+  <rect x="17" y="22" width="4" height="7" rx="1" fill="#449922"/>
+  <rect x="11" y="25" width="4" height="4" rx="1" fill="#449922"/>
+</svg>

--- a/web/src/components/NodeMap.tsx
+++ b/web/src/components/NodeMap.tsx
@@ -20,8 +20,38 @@ const NODE_ICON: Record<string, string> = {
   merchant: '⚖',
 }
 
-const COL_WIDTH  = 112 // fixed pixel width per map column slot
-const ROW_HEIGHT = 112 // fixed pixel height per vertical node slot within a column
+const COL_WIDTH      = 112 // fixed pixel width per map column slot
+const ROW_HEIGHT     = 112 // fixed pixel height per vertical node slot within a column
+const AVATAR_PADDING = 72  // left space in nm-map-inner for the "node 0" start position
+const AVATAR_SIZE    = 36  // px avatar width/height
+const WALK_DURATION  = 700 // ms for the walk animation
+
+function nodeCenter(
+  rowIndex: number,
+  node: QuestNode,
+  rowCols: number,
+  maxRowCols: number,
+): { x: number; y: number } {
+  const x  = AVATAR_PADDING + rowIndex * (COL_WIDTH + 44) + COL_WIDTH / 2
+  const vr = (maxRowCols - rowCols) / 2 + node.col
+  const y  = vr * ROW_HEIGHT + ROW_HEIGHT / 2
+  return { x, y }
+}
+
+function startPosition(mapHeight: number): { x: number; y: number } {
+  return { x: AVATAR_PADDING / 2, y: mapHeight / 2 }
+}
+
+function lastCompletedNode(act: Act, run: RunState): QuestNode | null {
+  if (run.completedNodeIds.length === 0) return null
+  const completed = new Set(run.completedNodeIds)
+  for (const id of run.completedNodeIds) {
+    const node = act.nodes[id]
+    if (!node) continue
+    if (!node.childIds.some(cid => completed.has(cid))) return node
+  }
+  return act.nodes[run.completedNodeIds[run.completedNodeIds.length - 1]] ?? null
+}
 
 const NODE_LABEL: Record<string, string> = {
   battle:   'BATTLE',
@@ -678,11 +708,34 @@ export function NodeMap({ act, run, onSelectNode, onUseConsumable, onBack }: Pro
   const hpPct         = Math.max(0, run.playerHp / run.maxHp)
   const reachableIds  = useMemo(() => computeReachableIds(act, run), [act, run])
 
+  const mapHeight = maxRowCols * ROW_HEIGHT
+  const mapWidth  = AVATAR_PADDING + rows.length * COL_WIDTH + Math.max(0, rows.length - 1) * 44
+
   const statusOf = (id: string): NodeStatus => getNodeStatus(id, availableIds, run)
 
   // Node peek state
   const [peekNode, setPeekNode] = useState<QuestNode | null>(null)
   const nodeHistory = useMemo(() => loadNodeHistory(), [])
+
+  // Avatar state
+  const [avatarPos, setAvatarPos] = useState<{ x: number; y: number } | null>(null)
+  const [walkPath,  setWalkPath]  = useState<string | null>(null)
+  const [isWalking, setIsWalking] = useState(false)
+  const [walkFrame, setWalkFrame] = useState(0)
+
+  // Initialise avatar at last completed node (or start position) on mount
+  useEffect(() => {
+    const lastNode = lastCompletedNode(act, run)
+    if (lastNode) {
+      const ri = rows.findIndex(r => r.some(n => n.id === lastNode.id))
+      if (ri >= 0) {
+        const rowCols = rows[ri][0]?.rowCols ?? rows[ri].length
+        setAvatarPos(nodeCenter(ri, lastNode, rowCols, maxRowCols))
+        return
+      }
+    }
+    setAvatarPos(startPosition(mapHeight))
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   // Scroll to the current node (pending or first available) on mount
   const mapRef     = useRef<HTMLDivElement>(null)
@@ -700,8 +753,26 @@ export function NodeMap({ act, run, onSelectNode, onUseConsumable, onBack }: Pro
       - (mapRect.width - nodeRect.width) / 2
   }, [])
 
-  const handleNodeClick = (node: QuestNode) => {
-    setPeekNode(node)
+  const handleNodeClick = (node: QuestNode, rowIndex: number) => {
+    if (isWalking) return
+    const rowCols = rows[rowIndex][0]?.rowCols ?? rows[rowIndex].length
+    const target  = nodeCenter(rowIndex, node, rowCols, maxRowCols)
+    const from    = avatarPos ?? startPosition(mapHeight)
+    const midX    = (from.x + target.x) / 2
+    const path    = `M ${from.x},${from.y} C ${midX},${from.y} ${midX},${target.y} ${target.x},${target.y}`
+
+    setWalkPath(path)
+    setIsWalking(true)
+    const frameTimer = setInterval(() => setWalkFrame(f => (f % 3) + 1), 175)
+
+    setTimeout(() => {
+      clearInterval(frameTimer)
+      setWalkFrame(0)
+      setIsWalking(false)
+      setAvatarPos(target)
+      setWalkPath(null)
+      setPeekNode(node)
+    }, WALK_DURATION)
   }
 
   const handlePeekEnter = () => {
@@ -761,13 +832,43 @@ export function NodeMap({ act, run, onSelectNode, onUseConsumable, onBack }: Pro
 
       {/* Map — left-to-right: each act row renders as a vertical column */}
       <div className={`nm-map${act.environment ? ` nm-map--${act.environment}` : ''}`} ref={mapRef}>
-        <div className="nm-map-inner" style={{ height: `${maxRowCols * ROW_HEIGHT}px`, position: 'relative' }}>
+        <div className="nm-map-inner" style={{ height: `${mapHeight}px`, paddingLeft: `${AVATAR_PADDING}px`, position: 'relative' }}>
           <MapTerrain
             environment={act.environment}
             actId={act.id}
-            width={rows.length * COL_WIDTH + Math.max(0, rows.length - 1) * 44}
-            height={maxRowCols * ROW_HEIGHT}
+            width={mapWidth}
+            height={mapHeight}
           />
+          {/* Node-0 campfire marker */}
+          <img
+            src="/sprites/campfire.svg"
+            alt=""
+            style={{
+              position: 'absolute',
+              left: startPosition(mapHeight).x - 18,
+              top:  startPosition(mapHeight).y - 18,
+              width: 36, height: 36,
+              opacity: 0.75,
+              pointerEvents: 'none',
+              zIndex: 1,
+            }}
+          />
+          {/* Player avatar */}
+          {avatarPos && (
+            <div
+              className={isWalking ? 'nm-avatar nm-avatar--walking' : 'nm-avatar'}
+              style={isWalking && walkPath
+                ? { offsetPath: `path('${walkPath}')`, animation: `nm-avatar-walk ${WALK_DURATION}ms ease-in-out forwards` }
+                : { left: avatarPos.x - AVATAR_SIZE / 2, top: avatarPos.y - AVATAR_SIZE / 2 }
+              }
+            >
+              <img
+                src={isWalking ? `/sprites/jarv-${walkFrame || 1}.svg` : '/sprites/jarv.svg'}
+                alt="Jarv"
+                style={{ width: AVATAR_SIZE, height: AVATAR_SIZE, imageRendering: 'pixelated' }}
+              />
+            </div>
+          )}
           {rows.map((rowNodes, rowIndex) => {
             const rowCols = rowNodes[0]?.rowCols ?? rowNodes.length
             return (
@@ -805,7 +906,7 @@ export function NodeMap({ act, run, onSelectNode, onUseConsumable, onBack }: Pro
                             `nm-node--${status}`,
                             dim ? 'nm-node--dim' : '',
                           ].filter(Boolean).join(' ')}
-                          onClick={clickable ? () => handleNodeClick(node) : undefined}
+                          onClick={clickable && !isWalking ? () => handleNodeClick(node, rowIndex) : undefined}
                           disabled={!clickable}
                           title={node.description}
                         >

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4042,6 +4042,32 @@ body {
   box-shadow: 0 0 12px rgba(255, 170, 50, 0.2);
 }
 
+/* ── Player avatar ── */
+
+.nm-avatar {
+  position: absolute;
+  z-index: 2;
+  pointer-events: none;
+}
+
+.nm-avatar--walking {
+  offset-distance: 0%;
+}
+
+@keyframes nm-avatar-walk {
+  from { offset-distance: 0%; }
+  to   { offset-distance: 100%; }
+}
+
+@keyframes nm-avatar-idle {
+  0%, 100% { transform: translateY(0); }
+  50%       { transform: translateY(-2px); }
+}
+
+.nm-avatar:not(.nm-avatar--walking) img {
+  animation: nm-avatar-idle 2s ease-in-out infinite;
+}
+
 .nm-back-btn {
   margin-top: auto;
   margin-bottom: 8px;


### PR DESCRIPTION
Closes #737

## Summary

- **Node-0 start position** — a campfire marker sits at the left edge of the map (`x = AVATAR_PADDING/2`); Jarv's avatar starts here at the beginning of an act before any node is selected
- **Avatar initialisation** — on map mount, `lastCompletedNode()` finds the leaf of the completed subgraph (the most recent completed node with no completed children); avatar is placed at that node's pixel coordinates, or at the start position if the act hasn't begun
- **Walk animation** — tapping an available node triggers Jarv to walk along the bezier road (`offset-path` CSS animation, same cubic bezier as `SVGConnector`); walk frames cycle `jarv-1/2/3.svg` at 175 ms each; the peek modal opens only after the 700 ms walk completes
- **Click guard** — node buttons are disabled while walking (`isWalking` state)
- **Idle animation** — Jarv bobs gently up/down when standing still
- **Walk frame sprites** — `jarv-1.svg` (left leg forward), `jarv-2.svg` (mid-stride), `jarv-3.svg` (right leg forward), all derived from the existing `jarv.svg` style

## Test plan

- [ ] Fresh act start: Jarv stands at the campfire on the left edge of the map
- [ ] Tap an available node: Jarv walks along the road bezier, walk frames cycle, peek modal opens on arrival
- [ ] Return to map mid-run: Jarv stands at the last completed node
- [ ] Clicking during walk does nothing (nodes are unresponsive while walking)
- [ ] Jarv bobs gently when idle
- [ ] MapTerrain fills the full width including the new left padding area

https://claude.ai/code/session_01EUannpJz42CqWNsyn2cAyy