### PR TITLE
Fix avatar Y axis: replace offset-path with CSS transition

### DIFF
--- a/web/src/components/NodeMap.tsx
+++ b/web/src/components/NodeMap.tsx
@@ -716,7 +716,6 @@ export function NodeMap({ act, run, onSelectNode, onUseConsumable, onBack }: Pro
 
   // Avatar state
   const [avatarPos, setAvatarPos] = useState<{ x: number; y: number } | null>(null)
-  const [walkPath,  setWalkPath]  = useState<string | null>(null)
   const [isWalking, setIsWalking] = useState(false)
   const [walkFrame, setWalkFrame] = useState(0)
 
@@ -760,21 +759,16 @@ export function NodeMap({ act, run, onSelectNode, onUseConsumable, onBack }: Pro
     const mapInnerEl = mapInnerRef.current
     const nodeBtn    = nodeButtonRefs.current[node.id]
     if (!mapInnerEl || !nodeBtn) return
-    const target  = getRelativeCenter(nodeBtn, mapInnerEl)
-    const from    = avatarPos ?? startPosition(mapHeight)
-    const midX    = (from.x + target.x) / 2
-    const path    = `M ${from.x},${from.y} C ${midX},${from.y} ${midX},${target.y} ${target.x},${target.y}`
+    const target = getRelativeCenter(nodeBtn, mapInnerEl)
 
-    setWalkPath(path)
     setIsWalking(true)
+    setAvatarPos(target)  // CSS transition animates the move
     const frameTimer = setInterval(() => setWalkFrame(f => (f % 3) + 1), 175)
 
     setTimeout(() => {
       clearInterval(frameTimer)
       setWalkFrame(0)
       setIsWalking(false)
-      setAvatarPos(target)
-      setWalkPath(null)
       setPeekNode(node)
     }, WALK_DURATION)
   }
@@ -861,10 +855,13 @@ export function NodeMap({ act, run, onSelectNode, onUseConsumable, onBack }: Pro
           {avatarPos && (
             <div
               className={isWalking ? 'nm-avatar nm-avatar--walking' : 'nm-avatar'}
-              style={isWalking && walkPath
-                ? { offsetPath: `path('${walkPath}')`, animation: `nm-avatar-walk ${WALK_DURATION}ms ease-in-out forwards` }
-                : { left: avatarPos.x - AVATAR_SIZE / 2, top: avatarPos.y - AVATAR_SIZE / 2 }
-              }
+              style={{
+                left: avatarPos.x - AVATAR_SIZE / 2,
+                top:  avatarPos.y - AVATAR_SIZE / 2,
+                transition: isWalking
+                  ? `left ${WALK_DURATION}ms ease-in-out, top ${WALK_DURATION}ms ease-in-out`
+                  : undefined,
+              }}
             >
               <img
                 src={isWalking ? `/sprites/jarv-${walkFrame || 1}.svg` : '/sprites/jarv.svg'}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4050,15 +4050,6 @@ body {
   pointer-events: none;
 }
 
-.nm-avatar--walking {
-  offset-distance: 0%;
-}
-
-@keyframes nm-avatar-walk {
-  from { offset-distance: 0%; }
-  to   { offset-distance: 100%; }
-}
-
 @keyframes nm-avatar-idle {
   0%, 100% { transform: translateY(0); }
   50%       { transform: translateY(-2px); }


### PR DESCRIPTION
## Summary

- Removes `offset-path` / `@keyframes nm-avatar-walk` CSS approach for the walking animation
- Replaces with CSS `transition: left ${WALK_DURATION}ms, top ${WALK_DURATION}ms` on the avatar's `left`/`top` absolute position
- Avatar position is now set to the target immediately on click; the browser animates the transition using the same coordinate system as the idle position

## Why

`offset-path: path(...)` uses SVG user-space coordinates which don't share the same Y-axis origin as CSS `top`/`left` within the relatively-positioned `nm-map-inner` container. This caused the avatar to appear offset downward (as if Y was measured from the bottom) during walking, while the idle position was correct.

## Test plan

- [ ] On act start (no completed nodes): Jarv stands at campfire on the left edge
- [ ] Tap an available node: Jarv smoothly slides along a straight-line path to the node, walk frames cycle, peek modal opens on arrival
- [ ] Avatar lands exactly on the tapped node (no Y offset)
- [ ] On return to map mid-run: Jarv stands at last completed node
- [ ] Clicking is blocked during animation

https://claude.ai/code/session_01EUannpJz42CqWNsyn2cAyy