### PR TITLE
feat: issues #744, #745, #746, #720, #721

### DIFF
--- a/web/public/sprites/rob-1.svg
+++ b/web/public/sprites/rob-1.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Robe - stride A (left foot forward) -->
+  <polygon points="10,18 22,18 25,30 10,30" fill="#6a0dad"/>
+  <!-- Arms -->
+  <rect x="4" y="18" width="5" height="3" rx="1" fill="#6a0dad" transform="rotate(-15,6,20)"/>
+  <rect x="23" y="18" width="5" height="3" rx="1" fill="#6a0dad" transform="rotate(15,25,20)"/>
+  <!-- Staff -->
+  <rect x="26" y="11" width="2" height="12" rx="1" fill="#8B4513" transform="rotate(10,27,17)"/>
+  <circle cx="27" cy="10" r="3" fill="#00ccff" opacity="0.85"/>
+  <!-- Wizard hat -->
+  <polygon points="16,2 11,12 21,12" fill="#4b0082"/>
+  <rect x="9" y="12" width="14" height="3" rx="1" fill="#4b0082"/>
+  <!-- Head -->
+  <circle cx="16" cy="18" r="6" fill="#f4c08a"/>
+  <!-- Glasses -->
+  <circle cx="13" cy="17" r="2.2" fill="none" stroke="#333" stroke-width="0.8"/>
+  <circle cx="19" cy="17" r="2.2" fill="none" stroke="#333" stroke-width="0.8"/>
+  <line x1="15.2" y1="17" x2="16.8" y2="17" stroke="#333" stroke-width="0.8"/>
+  <!-- Big smile -->
+  <path d="M13,20 Q16,23 19,20" fill="none" stroke="#333" stroke-width="1"/>
+  <circle cx="12" cy="19" r="1.2" fill="#ff9999" opacity="0.6"/>
+  <circle cx="20" cy="19" r="1.2" fill="#ff9999" opacity="0.6"/>
+</svg>

--- a/web/public/sprites/rob-2.svg
+++ b/web/public/sprites/rob-2.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Robe - mid-stride, body 1px higher -->
+  <polygon points="10,17 22,17 24,30 8,30" fill="#6a0dad"/>
+  <!-- Arms -->
+  <rect x="5" y="18" width="5" height="3" rx="1" fill="#6a0dad"/>
+  <rect x="22" y="18" width="5" height="3" rx="1" fill="#6a0dad"/>
+  <!-- Staff -->
+  <rect x="25" y="11" width="2" height="12" rx="1" fill="#8B4513"/>
+  <circle cx="26" cy="10" r="3" fill="#00ccff" opacity="0.85"/>
+  <!-- Wizard hat -->
+  <polygon points="16,1 11,11 21,11" fill="#4b0082"/>
+  <rect x="9" y="11" width="14" height="3" rx="1" fill="#4b0082"/>
+  <!-- Head -->
+  <circle cx="16" cy="17" r="6" fill="#f4c08a"/>
+  <!-- Glasses -->
+  <circle cx="13" cy="16" r="2.2" fill="none" stroke="#333" stroke-width="0.8"/>
+  <circle cx="19" cy="16" r="2.2" fill="none" stroke="#333" stroke-width="0.8"/>
+  <line x1="15.2" y1="16" x2="16.8" y2="16" stroke="#333" stroke-width="0.8"/>
+  <!-- Big smile -->
+  <path d="M13,19 Q16,22 19,19" fill="none" stroke="#333" stroke-width="1"/>
+  <circle cx="12" cy="18" r="1.2" fill="#ff9999" opacity="0.6"/>
+  <circle cx="20" cy="18" r="1.2" fill="#ff9999" opacity="0.6"/>
+</svg>

--- a/web/public/sprites/rob-3.svg
+++ b/web/public/sprites/rob-3.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Robe - stride B (right foot forward) -->
+  <polygon points="10,18 22,18 22,30 7,30" fill="#6a0dad"/>
+  <!-- Arms -->
+  <rect x="4" y="18" width="5" height="3" rx="1" fill="#6a0dad" transform="rotate(15,6,20)"/>
+  <rect x="23" y="18" width="5" height="3" rx="1" fill="#6a0dad" transform="rotate(-15,25,20)"/>
+  <!-- Staff -->
+  <rect x="24" y="11" width="2" height="12" rx="1" fill="#8B4513" transform="rotate(-10,25,17)"/>
+  <circle cx="24" cy="10" r="3" fill="#00ccff" opacity="0.85"/>
+  <!-- Wizard hat -->
+  <polygon points="16,2 11,12 21,12" fill="#4b0082"/>
+  <rect x="9" y="12" width="14" height="3" rx="1" fill="#4b0082"/>
+  <!-- Head -->
+  <circle cx="16" cy="18" r="6" fill="#f4c08a"/>
+  <!-- Glasses -->
+  <circle cx="13" cy="17" r="2.2" fill="none" stroke="#333" stroke-width="0.8"/>
+  <circle cx="19" cy="17" r="2.2" fill="none" stroke="#333" stroke-width="0.8"/>
+  <line x1="15.2" y1="17" x2="16.8" y2="17" stroke="#333" stroke-width="0.8"/>
+  <!-- Big smile -->
+  <path d="M13,20 Q16,23 19,20" fill="none" stroke="#333" stroke-width="1"/>
+  <circle cx="12" cy="19" r="1.2" fill="#ff9999" opacity="0.6"/>
+  <circle cx="20" cy="19" r="1.2" fill="#ff9999" opacity="0.6"/>
+</svg>

--- a/web/public/sprites/rob.svg
+++ b/web/public/sprites/rob.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Robe -->
+  <polygon points="10,18 22,18 24,30 8,30" fill="#6a0dad"/>
+  <!-- Arms -->
+  <rect x="5" y="19" width="5" height="3" rx="1" fill="#6a0dad"/>
+  <rect x="22" y="19" width="5" height="3" rx="1" fill="#6a0dad"/>
+  <!-- Staff (right hand) -->
+  <rect x="25" y="12" width="2" height="12" rx="1" fill="#8B4513"/>
+  <circle cx="26" cy="11" r="3" fill="#00ccff" opacity="0.85"/>
+  <!-- Wizard hat -->
+  <polygon points="16,2 11,12 21,12" fill="#4b0082"/>
+  <rect x="9" y="12" width="14" height="3" rx="1" fill="#4b0082"/>
+  <!-- Head -->
+  <circle cx="16" cy="18" r="6" fill="#f4c08a"/>
+  <!-- Glasses left -->
+  <circle cx="13" cy="17" r="2.2" fill="none" stroke="#333" stroke-width="0.8"/>
+  <!-- Glasses right -->
+  <circle cx="19" cy="17" r="2.2" fill="none" stroke="#333" stroke-width="0.8"/>
+  <!-- Glasses bridge -->
+  <line x1="15.2" y1="17" x2="16.8" y2="17" stroke="#333" stroke-width="0.8"/>
+  <!-- Big smile -->
+  <path d="M13,20 Q16,23 19,20" fill="none" stroke="#333" stroke-width="1"/>
+  <!-- Cheeks -->
+  <circle cx="12" cy="19" r="1.2" fill="#ff9999" opacity="0.6"/>
+  <circle cx="20" cy="19" r="1.2" fill="#ff9999" opacity="0.6"/>
+</svg>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1442,15 +1442,12 @@ export default function App() {
     saveCrystals(newCrystals)
     setCrystals(newCrystals)
 
-    // Capture stats snapshot then show summary; summary → reward
+    // Go directly to reward screen with battle stats embedded (single screen)
     dispatch({ type: 'SET_SUMMARY_STATS', stats: gameState.battleStats, gameTime: gameState.gameTime, playerScore: gameState.playerScore })
-    summaryDoneRef.current = () => {
-      const choices = generateRewardChoices(node.type, act.rewardTags)
-      setRewardChoices(choices)
-      setRewardCrystals(crystalReward)
-      setScreen('reward')
-    }
-    setScreen('battlesummary')
+    const choices = generateRewardChoices(node.type, act.rewardTags)
+    setRewardChoices(choices)
+    setRewardCrystals(crystalReward)
+    setScreen('reward')
   }, [run, gameState])
 
   const handleRewardPick = useCallback((cardName: string) => {
@@ -2354,6 +2351,7 @@ export default function App() {
           nodeType={run ? ACTS[run.actId].nodes[run.completedNodeIds[run.completedNodeIds.length - 1]]?.type ?? 'battle' : 'battle'}
           onPick={handleRewardPick}
           onSkip={handleRewardSkip}
+          battleSummary={summaryStats ?? undefined}
         />
       )}
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -32,6 +32,7 @@ import {
   setLastRunFailed, loadLastRunFailed, clearLastRunFailed,
 } from './game/questline'
 import { CardRestSelect }       from './components/CardRestSelect'
+import { CampScreen, CampChoice } from './components/CampScreen'
 import { EventScreen }          from './components/EventScreen'
 import { MerchantScreen, MerchantItem, cardMerchantItem } from './components/MerchantScreen'
 import { MysteryScreen } from './components/MysteryScreen'
@@ -261,6 +262,7 @@ type Screen =
   | 'minigames'
   | 'playerstats'
   | 'statupgrade'
+  | 'camp'
 
 
 function formatTimeAgo(date: Date): string {
@@ -401,6 +403,7 @@ export default function App() {
   const [merchantItems, setMerchantItems] = useState<MerchantItem[]>([])
   const merchantBoughtRef = useRef(0)
   const [mysteryReward, setMysteryReward] = useState<RewardDef | null>(null)
+  const [campNode, setCampNode] = useState<QuestNode | null>(null)
   // Replay briefing state — stored so onBegin can proceed with the correct context
   const replayBriefingRef = useRef<{
     actId: string
@@ -1112,18 +1115,8 @@ export default function App() {
     setRun(updatedRun)
 
     if (node.type === 'rest') {
-      // Instantly heal, mark complete, stay on map
-      // Heal up to maxHp, but never reduce HP that's already above maxHp (bonus HP).
-      const healed = Math.max(updatedRun.playerHp, Math.min(updatedRun.playerHp + (node.restHeal ?? 5), updatedRun.maxHp))
-      const afterRest: RunState = {
-        ...updatedRun,
-        playerHp: healed,
-        completedNodeIds: [...updatedRun.completedNodeIds, node.id],
-        pendingNodeId: null,
-      }
-      recordNodeComplete(updatedRun.actId, node.id)
-      saveRun(afterRest)
-      setRun(afterRest)
+      setCampNode(node)
+      setScreen('camp')
       return
     }
 
@@ -1474,6 +1467,47 @@ export default function App() {
   const handleRewardSkip = useCallback(() => {
     setScreen('nodemap')
   }, [])
+
+  const handleCampChoice = useCallback((choice: CampChoice) => {
+    const currentRun = run
+    if (!currentRun || !campNode) return
+    const healAmount = campNode.restHeal ?? 5
+    let updatedRun = { ...currentRun }
+
+    if (choice === 'heal') {
+      if (updatedRun.playerHp >= updatedRun.maxHp) {
+        // At max — grant bonus HP above the cap
+        updatedRun.playerHp = updatedRun.playerHp + healAmount
+      } else {
+        updatedRun.playerHp = Math.min(updatedRun.playerHp + healAmount, updatedRun.maxHp)
+      }
+      playRestHeal()
+    } else if (choice === 'rest') {
+      const fatigued = loadFatigued()
+      if (fatigued.length > 0 && Math.random() < 0.5) {
+        const idx = Math.floor(Math.random() * fatigued.length)
+        const recovered = fatigued[idx]
+        const newFatigued = fatigued.filter((_, i) => i !== idx)
+        saveFatigued(newFatigued)
+        setFatiguedCards(newFatigued)
+      }
+    } else if (choice === 'meditate') {
+      if (updatedRun.livesRemaining < updatedRun.maxLives && Math.random() < 0.5) {
+        updatedRun.livesRemaining = Math.min(updatedRun.maxLives, updatedRun.livesRemaining + 1)
+      }
+    }
+
+    updatedRun = {
+      ...updatedRun,
+      completedNodeIds: [...updatedRun.completedNodeIds, campNode.id],
+      pendingNodeId: null,
+    }
+    recordNodeComplete(updatedRun.actId, campNode.id)
+    saveRun(updatedRun)
+    setRun(updatedRun)
+    setCampNode(null)
+    setScreen('nodemap')
+  }, [run, campNode])
 
   const handleWaveRewardPick = useCallback((cardName: string) => {
     // Add to collection permanently and inject into the current run deck
@@ -2371,6 +2405,18 @@ export default function App() {
         <MysteryScreen
           reward={mysteryReward}
           onCollect={handleMysteryCollect}
+        />
+      )}
+
+      {screen === 'camp' && campNode && run && (
+        <CampScreen
+          playerHp={run.playerHp}
+          maxHp={run.maxHp}
+          livesRemaining={run.livesRemaining}
+          maxLives={run.maxLives}
+          fatiguedCards={fatiguedCards}
+          healAmount={campNode.restHeal ?? 5}
+          onChoose={handleCampChoice}
         />
       )}
 

--- a/web/src/components/CampScreen.tsx
+++ b/web/src/components/CampScreen.tsx
@@ -1,0 +1,83 @@
+import React from 'react'
+
+export type CampChoice = 'heal' | 'rest' | 'meditate'
+
+interface Props {
+  playerHp: number
+  maxHp: number
+  livesRemaining: number
+  maxLives: number
+  fatiguedCards: string[]
+  healAmount: number
+  onChoose: (choice: CampChoice) => void
+}
+
+export function CampScreen({
+  playerHp,
+  maxHp,
+  livesRemaining,
+  maxLives,
+  fatiguedCards,
+  healAmount,
+  onChoose,
+}: Props) {
+  const atMaxHp = playerHp >= maxHp
+  const atMaxLives = livesRemaining >= maxLives
+  const hasRestingCards = fatiguedCards.length > 0
+
+  return (
+    <div className="overlay-screen camp-screen">
+      <div className="camp-header">
+        <div className="camp-title">— CAMP —</div>
+        <div className="camp-sub">Rest your weary troops. Choose wisely.</div>
+        <div className="camp-stats">
+          <span>HP: {playerHp}/{maxHp}</span>
+          <span>Lives: {livesRemaining}/{maxLives}</span>
+          {fatiguedCards.length > 0 && <span>Resting: {fatiguedCards.join(', ')}</span>}
+        </div>
+      </div>
+
+      <div className="camp-choices">
+        <button className="camp-choice" onClick={() => onChoose('heal')}>
+          <div className="camp-choice-icon">⛺</div>
+          <div className="camp-choice-name">HEAL</div>
+          <div className="camp-choice-desc">
+            {atMaxHp
+              ? `You're already at full health — gain +${healAmount} bonus HP above your maximum.`
+              : `Restore ${healAmount} HP. (${playerHp} → ${Math.min(playerHp + healAmount, maxHp)})`}
+          </div>
+        </button>
+
+        <button
+          className="camp-choice"
+          onClick={() => onChoose('rest')}
+          disabled={!hasRestingCards}
+          title={!hasRestingCards ? 'No resting cards to recover' : undefined}
+        >
+          <div className="camp-choice-icon">💤</div>
+          <div className="camp-choice-name">REST</div>
+          <div className="camp-choice-desc">
+            {hasRestingCards
+              ? '50% chance to recover one of your resting cards and return it to the deck.'
+              : 'No cards are currently resting — nothing to recover.'}
+          </div>
+        </button>
+
+        <button
+          className="camp-choice"
+          onClick={() => onChoose('meditate')}
+          disabled={atMaxLives}
+          title={atMaxLives ? 'Already at maximum lives' : undefined}
+        >
+          <div className="camp-choice-icon">🧘</div>
+          <div className="camp-choice-name">MEDITATE</div>
+          <div className="camp-choice-desc">
+            {atMaxLives
+              ? 'You are already at maximum lives.'
+              : '50% chance to gain an extra life.'}
+          </div>
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/PostBattleReward.tsx
+++ b/web/src/components/PostBattleReward.tsx
@@ -3,7 +3,13 @@ import { CardTile } from './CardTile'
 import { CardDetailModal } from './CardDetailModal'
 import { getCardCatalog } from '../game/cards'
 import { NodeType } from '../game/questline'
-import { Card } from '../game/types'
+import { BattleStats, Card } from '../game/types'
+
+function formatDuration(ms: number): string {
+  const s = Math.floor(ms / 1000)
+  const m = Math.floor(s / 60)
+  return m > 0 ? `${m}m ${s % 60}s` : `${s}s`
+}
 
 interface Props {
   choices: string[]     // 3 card names
@@ -12,6 +18,8 @@ interface Props {
   onPick: (cardName: string) => void
   onSkip: () => void
   headerOverride?: { title: string; sub: string }
+  /** When provided, battle stats are shown above the reward cards. */
+  battleSummary?: { stats: BattleStats; gameTime: number; playerScore: number }
 }
 
 const NODE_FLAVOUR: Record<NodeType, string> = {
@@ -23,7 +31,7 @@ const NODE_FLAVOUR: Record<NodeType, string> = {
   merchant: '',
 }
 
-export function PostBattleReward({ choices, nodeType, crystals, onPick, onSkip, headerOverride }: Props) {
+export function PostBattleReward({ choices, nodeType, crystals, onPick, onSkip, headerOverride, battleSummary }: Props) {
   const catalog = getCardCatalog()
   const cards   = choices.map(name => catalog.find(c => c.name === name)).filter(Boolean) as ReturnType<typeof getCardCatalog>[number][]
 
@@ -74,6 +82,15 @@ export function PostBattleReward({ choices, nodeType, crystals, onPick, onSkip, 
         <div className="reward-sub">{headerOverride?.sub ?? NODE_FLAVOUR[nodeType]}</div>
         {crystals > 0 && <div className="reward-crystals">+{crystals} ◆</div>}
       </div>
+
+      {battleSummary && (
+        <div className="reward-battle-summary">
+          <div className="reward-summary-row"><span>UNITS DEFEATED</span><span>{battleSummary.stats.playerKills}</span></div>
+          <div className="reward-summary-row"><span>UNITS LOST</span><span>{battleSummary.stats.playerUnitsLost}</span></div>
+          <div className="reward-summary-row"><span>DAMAGE DEALT</span><span>{battleSummary.playerScore}</span></div>
+          <div className="reward-summary-row"><span>DURATION</span><span>{formatDuration(battleSummary.gameTime)}</span></div>
+        </div>
+      )}
 
       <div className="reward-cards">
         {cards.map((card, i) => {

--- a/web/src/data/cards.json
+++ b/web/src/data/cards.json
@@ -19504,6 +19504,32 @@
       },
       "description": "HERO: Deploys Skeleton Archers!",
       "lore": "Sees all. Knows all. Still can't find his keys. Play tested by Graham, who is indeed all seeing."
+    },
+    {
+      "id": "hero-rob-the-reckless",
+      "name": "Rob The Reckless",
+      "rarity": "legendary",
+      "cost": 5,
+      "cardType": "unit",
+      "isHero": true,
+      "unit": {
+        "name": "Rob",
+        "attack": 9,
+        "maxHp": 50,
+        "isWall": false,
+        "bypassWall": true,
+        "moveSpeed": 20,
+        "attackRange": 55,
+        "attackCooldownMs": 2200,
+        "halfHealthEffect": { "damage": 12, "range": 80 },
+        "tags": ["magic", "ranged"]
+      },
+      "heroEffect": {
+        "type": "buffAttack",
+        "amount": 3
+      },
+      "description": "HERO: Deploys Rob — a reckless wizard who explodes at half health, blasting nearby enemies! Also grants all units +3 attack.",
+      "lore": "Big smile. Bigger explosions. The glasses are purely decorative."
     }
   ]
 }

--- a/web/src/game/engine/cards.ts
+++ b/web/src/game/engine/cards.ts
@@ -17,7 +17,7 @@ export function deployCard(s: GameState, card: Card, owner: 'player' | 'opponent
       const existing = s.field.find(u => u.owner === owner && u.name === template.name);
       if (existing) {
         existing.maxHp *= 2;
-        existing.hp = Math.min(existing.hp * 2, existing.maxHp);
+        existing.hp = existing.maxHp;
         existing.upgradeLevel = (existing.upgradeLevel ?? 1) + 1;
         let note = 'HP×2';
         if (existing.structureEffect?.type === 'spawn') {

--- a/web/src/game/engine/combat.ts
+++ b/web/src/game/engine/combat.ts
@@ -88,6 +88,25 @@ export function processAttacks(s: GameState, deltaMs: number, log: string[]): vo
           toX: target.x,   toY: target.y,
           expiresAt: s.gameTime + 300,
         })
+        // Half-health explosion: fires once when unit first drops to ≤50% HP
+        if (
+          !target.halfHealthFired &&
+          target.halfHealthEffect &&
+          target.hp > 0 &&
+          target.hp <= target.maxHp / 2
+        ) {
+          target.halfHealthFired = true
+          const { damage: aoeDmg, range: aoeRange } = target.halfHealthEffect
+          const enemies = s.field.filter(
+            e => e.owner !== target.owner && e.hp > 0 &&
+                 Math.hypot(e.x - target.x, e.y - target.y) <= aoeRange
+          )
+          for (const e of enemies) {
+            e.hp -= aoeDmg
+            e.damageFlashTimer = DAMAGE_FLASH_MS
+          }
+          log.push(`💥 ${target.name} erupts! AOE blast hits ${enemies.length} enemy unit${enemies.length !== 1 ? 's' : ''}!`)
+        }
         if (target.hp <= 0) {
           log.push(`${unit.name} destroyed ${target.name}!`)
           if (target.moveSpeed === 0) playBuildingDestroyed()

--- a/web/src/game/engine/combat.ts
+++ b/web/src/game/engine/combat.ts
@@ -3,7 +3,7 @@ import { playBuildingDestroyed, playUnitDeath } from '../sound'
 import { AnimEvent, GameState, LANE_WIDTH, Unit } from '../types'
 import { DAMAGE_FLASH_MS, BLOOD_POOL_MAX } from './constants'
 import { getAttackAura } from './bonusEffects'
-import { animUid } from './helpers'
+import { animUid, spawnUnit } from './helpers'
 import { findAttackTarget, unitDist } from './targeting'
 
 // ─── Combat Constants ─────────────────────────────────────
@@ -181,6 +181,18 @@ export function processAttacks(s: GameState, deltaMs: number, log: string[]): vo
     if (u.hp <= 0 && u.moveSpeed > 0 && !u.isWall) {
       if (u.owner === 'opponent') s.battleStats.playerKills++
       else                        s.battleStats.playerUnitsLost++
+    }
+  }
+
+  // Spawn buildings: leave a unit behind when destroyed
+  for (const u of s.field) {
+    if (u.hp <= 0 && u.moveSpeed === 0 && u.structureEffect?.type === 'spawn') {
+      const se = u.structureEffect as { type: 'spawn'; unitTemplate: { name: string; maxHp: number } & Parameters<typeof spawnUnit>[0]; intervalMs: number }
+      const survivor = spawnUnit(se.unitTemplate, u.owner)
+      survivor.x = u.x
+      survivor.y = u.y
+      s.field.push(survivor)
+      log.push(`${u.name} collapses — a ${survivor.name} emerges from the rubble!`)
     }
   }
 

--- a/web/src/game/types.ts
+++ b/web/src/game/types.ts
@@ -62,6 +62,8 @@ export interface UnitTemplate {
   size?: 'small' | 'medium' | 'large'
   /** Mastery level of this card from the player's collection (0 = unmastered). */
   masteryLevel?: number
+  /** AOE explosion triggered once when this unit first drops to ≤50% HP. */
+  halfHealthEffect?: { damage: number; range: number }
 }
 
 export type BuffTag = 'atk' | 'spd' | 'hp' | 'range'
@@ -120,6 +122,8 @@ export interface Unit extends UnitTemplate {
   targetId?: string
   /** ID of the last enemy unit that dealt damage to this unit (used for target-switch on hit). */
   lastAttackerId?: string
+  /** True once the halfHealthEffect has fired — prevents re-triggering. */
+  halfHealthFired?: boolean
 }
 
 // ─── Animation Events ─────────────────────────────────────

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -9876,3 +9876,91 @@ html.light-mode .action-btn {
   color: #ffd700;
   text-shadow: 0 0 10px rgba(255, 215, 0, 0.5);
 }
+
+/* ─── Camp Screen (#720) ─────────────────────────────────── */
+
+.camp-screen {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 28px;
+  padding: 32px 16px;
+  max-width: 600px;
+  margin: 0 auto;
+  width: 100%;
+}
+
+.camp-header {
+  text-align: center;
+}
+
+.camp-title {
+  font-size: 22px;
+  font-weight: bold;
+  color: #ff9944;
+  letter-spacing: 3px;
+  margin-bottom: 8px;
+}
+
+.camp-sub {
+  font-size: 11px;
+  color: #777;
+  margin-bottom: 10px;
+}
+
+.camp-stats {
+  display: flex;
+  gap: 20px;
+  justify-content: center;
+  font-size: 11px;
+  color: #aaa;
+}
+
+.camp-choices {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  width: 100%;
+}
+
+.camp-choice {
+  background: transparent;
+  border: 1px solid #444;
+  border-radius: 4px;
+  color: #ccc;
+  cursor: pointer;
+  padding: 16px 20px;
+  text-align: left;
+  transition: border-color 0.15s, background 0.15s;
+  font-family: inherit;
+  width: 100%;
+}
+
+.camp-choice:hover:not(:disabled) {
+  border-color: #ff9944;
+  background: rgba(255, 153, 68, 0.06);
+}
+
+.camp-choice:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.camp-choice-icon {
+  font-size: 20px;
+  margin-bottom: 4px;
+}
+
+.camp-choice-name {
+  font-size: 14px;
+  font-weight: bold;
+  letter-spacing: 2px;
+  color: #ff9944;
+  margin-bottom: 4px;
+}
+
+.camp-choice-desc {
+  font-size: 11px;
+  color: #888;
+  line-height: 1.5;
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -9964,3 +9964,34 @@ html.light-mode .action-btn {
   color: #888;
   line-height: 1.5;
 }
+
+/* ─── Post-battle summary stats inside reward screen (#721) ─ */
+
+.reward-battle-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 24px;
+  justify-content: center;
+  padding: 10px 16px;
+  border: 1px solid #333;
+  border-radius: 4px;
+  margin-bottom: 4px;
+  width: 100%;
+  max-width: 400px;
+}
+
+.reward-summary-row {
+  display: flex;
+  gap: 8px;
+  font-size: 10px;
+  color: #888;
+  letter-spacing: 1px;
+}
+
+.reward-summary-row span:first-child {
+  color: #555;
+}
+
+.reward-summary-row span:last-child {
+  color: #aaa;
+}


### PR DESCRIPTION
## Summary

- **#744** — New hero card: Rob The Reckless (50hp, 9atk wizard) with a half-health AOE explosion mechanic and +3 attack hero effect. Includes 4 walk-frame sprites.
- **#745** — Upgrading a building/wall now fully restores it to the new (doubled) max HP instead of only doubling its current HP.
- **#746** — When a spawn-type building is destroyed, one of its unit templates is spawned at the building's position before it's removed.
- **#720** — Rest/camp nodes now show a choice screen (Heal / Rest / Meditate) instead of instantly healing. Heal grants HP (bonus HP if at max); Rest has a 50% chance to recover a resting card; Meditate has a 50% chance to grant +1 life.
- **#721** — Post-battle condensed into a single screen. Battle stats (kills, units lost, damage, duration) are now shown inline at the top of the reward card selection screen.

## Test plan

- [ ] Play a campaign battle — confirm win goes directly to reward screen with stats shown above cards (no separate summary screen)
- [ ] Select a rest/camp node on the map — confirm choice screen appears with all 3 options; test each path
- [ ] Build a spawn structure, let it take damage, then play the same card again — confirm it upgrades to full HP
- [ ] Let an enemy destroy a spawn building — confirm a unit appears at its position
- [ ] Add Rob The Reckless to deck via Hero Cards screen — deploy him, let him take damage past 50% HP, confirm AOE log message fires once

https://claude.ai/code/session_01D6cb4TiUoUCWTmB1S7YAVx