### PR TITLE
fix: video poker returns stake on win (#747); campaign rewards from enemy deck (#726)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1444,7 +1444,11 @@ export default function App() {
 
     // Go directly to reward screen with battle stats embedded (single screen)
     dispatch({ type: 'SET_SUMMARY_STATS', stats: gameState.battleStats, gameTime: gameState.gameTime, playerScore: gameState.playerScore })
-    const choices = generateRewardChoices(node.type, act.rewardTags)
+    const catalog = getCardCatalog()
+    const uniqueValid = [...new Set(node.enemyDeck ?? [])].filter(name => catalog.some(c => c.name === name))
+    const choices = uniqueValid.length >= 3
+      ? uniqueValid.sort(() => Math.random() - 0.5).slice(0, 3)
+      : generateRewardChoices(node.type, act.rewardTags)
     setRewardChoices(choices)
     setRewardCrystals(crystalReward)
     setScreen('reward')

--- a/web/src/components/minigames/VideoPoker.tsx
+++ b/web/src/components/minigames/VideoPoker.tsx
@@ -130,7 +130,8 @@ export function VideoPoker({ onDone }: Props) {
     let deckIdx = 0
     const newHand = hand.map((card, i) => held[i] ? card : drawDeck[deckIdx++])
     const handResult = evaluateHand(newHand)
-    const win = wager * handResult.multiplier
+    // Return stake + winnings on a win; lose stake on no-win
+    const win = handResult.multiplier > 0 ? wager + wager * handResult.multiplier : 0
     setHand(newHand)
     setResult(handResult)
     setCredits(c => c + win)
@@ -214,7 +215,7 @@ export function VideoPoker({ onDone }: Props) {
       <div className="fm-header">
         <span className="fm-credits">Credits: {credits}</span>
         {phase === 'result' && result && result.multiplier > 0 && (
-          <span className="fm-win-flash">+{wager * result.multiplier}!</span>
+          <span className="fm-win-flash">+{wager + wager * result.multiplier}!</span>
         )}
         {phase === 'result' && result && result.multiplier === 0 && result.name !== 'Fold' && (
           <span className="fm-no-win">No win</span>
@@ -295,7 +296,7 @@ export function VideoPoker({ onDone }: Props) {
           </div>
           {isWin && (
             <div className="minigame-result-breakdown">
-              <div>{wager} × {result.multiplier} = {wager * result.multiplier} credit{wager * result.multiplier !== 1 ? 's' : ''}</div>
+              <div>Stake returned: {wager} + winnings: {wager} × {result.multiplier} = {wager + wager * result.multiplier} credit{wager + wager * result.multiplier !== 1 ? 's' : ''}</div>
             </div>
           )}
           <div className="vp-controls">


### PR DESCRIPTION
## Summary

- **#747 Video Poker:** `draw()` now returns `wager + wager × multiplier` on a win instead of `wager × multiplier` only. The stake was previously never returned, making Jacks or Better (1×) a break-even at best and all other wins undervalued. Win flash and result breakdown updated to show the correct total returned.
- **#726 Campaign Rewards:** Post-battle reward now picks 3 random unique cards from the node's `enemyDeck` (catalog-validated). Falls back to the existing `generateRewardChoices` logic only when the enemy deck has fewer than 3 valid unique cards.

## Test plan

- [ ] Play video poker, bet ×5, land Jacks or Better — confirm credits increase by 10 (5 stake + 5 winnings)
- [ ] Play video poker, bet ×5, land Two Pair — confirm credits increase by 15 (5 stake + 10 winnings)
- [ ] Win a campaign battle node — confirm the 3 reward cards are all from the enemy's deck
- [ ] Confirm the skip / claim flow still works normally on the reward screen

https://claude.ai/code/session_018DDyPSmbJUDotpEQQyZP85