### PR TITLE
Make boss deck selection data-driven via act JSON

### DIFF
--- a/web/src/data/acts/act1.json
+++ b/web/src/data/acts/act1.json
@@ -1043,7 +1043,16 @@
         "\"You will not pass. The Verdant Shard does not need another wandering tactician.\""
       ],
       "opponentIntervalMs": 5000,
-      "opponentBaseHp": 95
+      "opponentBaseHp": 95,
+      "enemyDeck": [
+        "Stone Wall","Stone Wall","Stone Wall","Stone Wall","Stone Wall","Stone Wall",
+        "Barracks","Barracks","Barracks",
+        "Farm","Farm",
+        "Crypt","Crypt",
+        "Shield Guard","Shield Guard",
+        "Knight","Knight",
+        "Fortify"
+      ]
     },
     "deep-crossing": {
       "id": "deep-crossing",

--- a/web/src/data/acts/act2.json
+++ b/web/src/data/acts/act2.json
@@ -859,7 +859,18 @@
         "\"You will not pass. The Iron Citadel does not fall to a card player.\""
       ],
       "opponentIntervalMs": 5000,
-      "opponentBaseHp": 95
+      "opponentBaseHp": 95,
+      "enemyDeck": [
+        "Stone Wall","Stone Wall","Stone Wall","Stone Wall",
+        "Catapult","Catapult","Catapult",
+        "Knight","Knight","Knight",
+        "Shield Guard","Shield Guard",
+        "Ballista","Ballista",
+        "Siege Works",
+        "War Drums",
+        "Fortify",
+        "Crossbow","Crossbow"
+      ]
     },
     "citadel-crossing": {
       "id": "citadel-crossing",

--- a/web/src/game/cards.ts
+++ b/web/src/game/cards.ts
@@ -220,37 +220,6 @@ export function makeDeck(): Card[] {
 }
 
 /**
- * The Thornlord boss deck — wall-heavy with spawner structures and sturdy defenders.
- * 6× Stone Wall ensures walls go down every turn via thornlordAI priority routing.
- */
-export function makeThorlordDeck(): Card[] {
-  const make = (name: string, count: number): Card[] => {
-    const def = CARD_DEFS.find(d => d.name === name)
-    if (!def) return []
-    return Array.from({ length: count }, () => ({
-      id: uid(),
-      name: def.name,
-      rarity: def.rarity,
-      cost: def.cost,
-      cardType: def.cardType,
-      unit: def.unit,
-      upgradeEffect: def.upgradeEffect,
-      description: def.description,
-      lore: def.lore,
-    }))
-  }
-  return [
-    ...make('Stone Wall',   6),
-    ...make('Barracks',     3),
-    ...make('Farm',         2),
-    ...make('Crypt',        2),
-    ...make('Shield Guard', 2),
-    ...make('Knight',       2),
-    ...make('Fortify',      1),
-  ]
-}
-
-/**
  * Build a deck from an ordered list of card names.
  * Unknown names are silently skipped.
  * Used for node-specific deterministic enemy decks.
@@ -271,57 +240,6 @@ export function makeNodeDeck(names: string[]): Card[] {
       lore: def.lore,
     }]
   })
-}
-
-/**
- * Kragg boss deck — heavy siege weapons, fortified walls, and disciplined infantry.
- */
-export function makeKraggDeck(): Card[] {
-  const make = (name: string, count: number): Card[] => {
-    const def = CARD_DEFS.find(d => d.name === name)
-    if (!def) return []
-    return Array.from({ length: count }, () => ({
-      id: uid(), name: def.name, rarity: def.rarity, cost: def.cost,
-      cardType: def.cardType, unit: def.unit, upgradeEffect: def.upgradeEffect,
-      description: def.description, lore: def.lore,
-    }))
-  }
-  return [
-    ...make('Stone Wall',   4),
-    ...make('Catapult',     3),
-    ...make('Knight',       3),
-    ...make('Shield Guard', 2),
-    ...make('Ballista',     2),
-    ...make('Siege Works',  1),
-    ...make('War Drums',    1),
-    ...make('Fortify',      1),
-    ...make('Crossbow',     2),
-  ]
-}
-
-/**
- * Ashwalker boss deck — undead horde with necromantic support and revenant swarms.
- */
-export function makeAshwalkerDeck(): Card[] {
-  const make = (name: string, count: number): Card[] => {
-    const def = CARD_DEFS.find(d => d.name === name)
-    if (!def) return []
-    return Array.from({ length: count }, () => ({
-      id: uid(), name: def.name, rarity: def.rarity, cost: def.cost,
-      cardType: def.cardType, unit: def.unit, upgradeEffect: def.upgradeEffect,
-      description: def.description, lore: def.lore,
-    }))
-  }
-  return [
-    ...make('Skeleton',    5),
-    ...make('Specter',     3),
-    ...make('Bat',         3),
-    ...make('Crypt',       2),
-    ...make('Necromancer', 2),
-    ...make('Dark Shrine', 2),
-    ...make('Bloodlust',   1),
-    ...make('Vampire',     1),
-  ]
 }
 
 export function getCardUnit(cardName: string): UnitTemplate | undefined {

--- a/web/src/game/engine.ts
+++ b/web/src/game/engine.ts
@@ -1,5 +1,5 @@
 import { GameState, Card, UnitTemplate, CardRarity } from './types'
-import { makeDeck, makeThorlordDeck, makeKraggDeck, makeAshwalkerDeck, makeNodeDeck, HERO_CARDS, getCardUnit, getCardCatalog, flushCardValidationErrors } from './cards'
+import { makeDeck, makeNodeDeck, HERO_CARDS, getCardUnit, getCardCatalog, flushCardValidationErrors } from './cards'
 import { loadPlayerStats } from './playerStats'
 
 import { moveUnits, processAffinities } from './engine/units'
@@ -174,12 +174,6 @@ export function newGame(
   let opponentDeck: Card[]
   if (prebuiltOpponentDeck && prebuiltOpponentDeck.length > 0) {
     opponentDeck = [...prebuiltOpponentDeck]   // already seeded — preserve order
-  } else if (boss === 'thornlord') { // TODO: this should be using enemyDeckNames from the act JSON, but currently the thornlord node doesn't have that field populated
-    opponentDeck = shuffle(makeThorlordDeck())
-  } else if (boss === 'kragg') { // TODO: this should be using enemyDeckNames from the act JSON, but currently the thornlord node doesn't have that field populated
-    opponentDeck = shuffle(makeKraggDeck())
-  } else if (boss === 'ashwalker') { // TODO: this should be using enemyDeckNames from the act JSON, but currently the thornlord node doesn't have that field populated
-    opponentDeck = shuffle(makeAshwalkerDeck())
   } else if (enemyDeckNames && enemyDeckNames.length > 0) {
     // Preset node deck — deterministic and learnable
     const nodeDeck = makeNodeDeck(enemyDeckNames)


### PR DESCRIPTION
## Summary

Closes #755

- Added `enemyDeck` to the `thornlord` node in `act1.json` (was missing entirely)
- Added `enemyDeck` to the `kragg` node in `act2.json` (was missing entirely)
- The `ashwalker` node in `act3.json` already had `enemyDeck` — no change needed there
- Removed the three hardcoded `boss === 'thornlord'` / `'kragg'` / `'ashwalker'` conditionals from `engine.ts` — all three now fall through to the existing `enemyDeckNames` path
- Deleted `makeThorlordDeck`, `makeKraggDeck`, and `makeAshwalkerDeck` from `cards.ts` (no longer referenced anywhere)

Adding a new boss now requires only a JSON change in the act file — no engine code changes needed.

## Test plan

- [ ] Play Act 1 to the Thornlord boss and verify the opponent plays the expected deck (Stone Walls, Barracks, Knights, etc.)
- [ ] Play Act 2 to Kragg and verify the opponent plays the expected deck (Catapults, Ballista, Knights, etc.)
- [ ] Play Act 3 to the Ashwalker and verify the opponent plays the deck defined in `act3.json` (Wight Knight, Skeleton, Revenant, etc.)
- [ ] Confirm normal battle nodes still use their `enemyDeck` from JSON as before
- [ ] Build passes: `npm run build` ✅

https://claude.ai/code/session_01G1eGmryfrwUgJ7vw3ReP25