### PR TITLE
Fix campaign event HP loss and add compound effect support

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1223,58 +1223,63 @@ export default function App() {
     if (!currentRun) return
     const nodeId = currentRun.pendingNodeId!
 
-    // Apply the effect
     let updatedRun: RunState = {
       ...currentRun,
       completedNodeIds: [...currentRun.completedNodeIds, nodeId],
       pendingNodeId: null,
     }
 
-    const effect = choice.effect
-    if (effect.type === 'healHp') {
-      updatedRun = { ...updatedRun, playerHp: Math.min(updatedRun.maxHp, updatedRun.playerHp + effect.amount) }
-    } else if (effect.type === 'damageHp') {
-      if (!isNoDamageMode()) {
-        updatedRun = { ...updatedRun, playerHp: Math.max(1, updatedRun.playerHp - effect.amount) }
-      }
-    } else if (effect.type === 'gainCrystals') {
-      const next = loadCrystals() + effect.amount
-      saveCrystals(next)
-      setCrystals(next)
-    } else if (effect.type === 'gainCard') {
-      const catalog = getCardCatalog()
-      const pool = catalog.filter(c => c.rarity === effect.rarity)
-      const card = pool[Math.floor(Math.random() * pool.length)]
-      if (card) {
-        addCardsToCollection([{ cardName: card.name, count: 1 }])
-        saveRun(updatedRun)
-        setRun(updatedRun)
-        setActiveEvent(null)
-        setScreen('nodemap')
-        setPendingEventCard(card.name)
-        playCardFlip()
-        return   // show card reveal before going to nodemap
-      }
-    } else if (effect.type === 'gainItem') {
-      const item = effect.itemId
-        ? ALL_ITEMS.find(i => i.id === effect.itemId)
-        : computeReward(loadInventory(), ALL_ITEMS)
-      if (item) {
-        recordNodeComplete(updatedRun.actId, nodeId)
-        saveRun(updatedRun)
-        setRun(updatedRun)
-        setActiveEvent(null)
-        setFoundItem(item)
-        setScreen('itemfound')
-        return
-      }
-    } else if (effect.type === 'gainLife') {
-      const newMax   = Math.min(LIVES_MAX, updatedRun.maxLives + effect.amount)
-      const newLives = Math.min(newMax, updatedRun.livesRemaining + effect.amount)
-      updatedRun = { ...updatedRun, livesRemaining: newLives, maxLives: newMax }
-      if (newLives >= LIVES_MAX) {
-        const newlyUnlocked = incrementAchievementProgress('misc:nine_lives', 1)
-        if (newlyUnlocked.length > 0) setAchievementToasts(prev => [...prev, ...newlyUnlocked])
+    // Flatten compound effects into a list of single effects
+    const effects = choice.effect.type === 'compound'
+      ? choice.effect.effects
+      : [choice.effect]
+
+    for (const effect of effects) {
+      if (effect.type === 'healHp') {
+        updatedRun = { ...updatedRun, playerHp: Math.min(updatedRun.maxHp, updatedRun.playerHp + effect.amount) }
+      } else if (effect.type === 'damageHp') {
+        if (!isNoDamageMode()) {
+          updatedRun = { ...updatedRun, playerHp: Math.max(1, updatedRun.playerHp - effect.amount) }
+        }
+      } else if (effect.type === 'gainCrystals') {
+        const next = loadCrystals() + effect.amount
+        saveCrystals(next)
+        setCrystals(next)
+      } else if (effect.type === 'gainCard') {
+        const catalog = getCardCatalog()
+        const pool = catalog.filter(c => c.rarity === effect.rarity)
+        const card = pool[Math.floor(Math.random() * pool.length)]
+        if (card) {
+          addCardsToCollection([{ cardName: card.name, count: 1 }])
+          saveRun(updatedRun)
+          setRun(updatedRun)
+          setActiveEvent(null)
+          setScreen('nodemap')
+          setPendingEventCard(card.name)
+          playCardFlip()
+          return   // show card reveal before going to nodemap
+        }
+      } else if (effect.type === 'gainItem') {
+        const item = effect.itemId
+          ? ALL_ITEMS.find(i => i.id === effect.itemId)
+          : computeReward(loadInventory(), ALL_ITEMS)
+        if (item) {
+          recordNodeComplete(updatedRun.actId, nodeId)
+          saveRun(updatedRun)
+          setRun(updatedRun)
+          setActiveEvent(null)
+          setFoundItem(item)
+          setScreen('itemfound')
+          return
+        }
+      } else if (effect.type === 'gainLife') {
+        const newMax   = Math.min(LIVES_MAX, updatedRun.maxLives + effect.amount)
+        const newLives = Math.min(newMax, updatedRun.livesRemaining + effect.amount)
+        updatedRun = { ...updatedRun, livesRemaining: newLives, maxLives: newMax }
+        if (newLives >= LIVES_MAX) {
+          const newlyUnlocked = incrementAchievementProgress('misc:nine_lives', 1)
+          if (newlyUnlocked.length > 0) setAchievementToasts(prev => [...prev, ...newlyUnlocked])
+        }
       }
     }
 

--- a/web/src/components/EventScreen.tsx
+++ b/web/src/components/EventScreen.tsx
@@ -27,10 +27,13 @@ export function EventScreen({ event, onChoice, playerHp, maxHp }: Props) {
   // Preview HP after applying the picked choice's effect
   const previewHp: number = (() => {
     if (!picked) return playerHp
-    const { effect } = picked
-    if (effect.type === 'healHp') return Math.min(maxHp, playerHp + effect.amount)
-    if (effect.type === 'damageHp') return Math.max(1, playerHp - effect.amount)
-    return playerHp
+    const effects = picked.effect.type === 'compound' ? picked.effect.effects : [picked.effect]
+    let hp = playerHp
+    for (const effect of effects) {
+      if (effect.type === 'healHp') hp = Math.min(maxHp, hp + effect.amount)
+      if (effect.type === 'damageHp') hp = Math.max(1, hp - effect.amount)
+    }
+    return hp
   })()
 
   const displayHp  = previewHp

--- a/web/src/data/acts/act1.json
+++ b/web/src/data/acts/act1.json
@@ -42,7 +42,7 @@
   "intro": [
     {
       "title": "THE FRACTURE",
-      "text": "Three years ago, the Grand Dominion shattered.\n\nNot in war. Not gradually. In a single catastrophic instant \u2014 a magical detonation the scholars call the Fracture Event. The realm split into isolated shards, each one sealed behind walls of warped space and collapsed ley lines.\n\nNobody knows who caused it. Nobody knows how to undo it."
+      "text": "Three years ago, the Grand Dominion shattered.\n\nNot in war. Not gradually. In a single catastrophic instant — a magical detonation the scholars call the Fracture Event. The realm split into isolated shards, each one sealed behind walls of warped space and collapsed ley lines.\n\nNobody knows who caused it. Nobody knows how to undo it."
     },
     {
       "title": "THE WANDERER",
@@ -50,17 +50,17 @@
     },
     {
       "title": "THE VERDANT SHARD",
-      "text": "Your compass points to the nearest reachable shard \u2014 a dense, ancient forest realm that has grown wild and hostile since the Fracture closed its borders.\n\nThe shard's guardian, a being called the Thornlord, has sealed its internal pathways. Local traders say he was old before the Dominion was founded.\n\nLocal traders also say he hasn't spoken to anyone in forty years. You're choosing to interpret that as optimistically as possible."
+      "text": "Your compass points to the nearest reachable shard — a dense, ancient forest realm that has grown wild and hostile since the Fracture closed its borders.\n\nThe shard's guardian, a being called the Thornlord, has sealed its internal pathways. Local traders say he was old before the Dominion was founded.\n\nLocal traders also say he hasn't spoken to anyone in forty years. You're choosing to interpret that as optimistically as possible."
     },
     {
       "title": "YOUR MISSION",
-      "text": "Break through the shard. Reach the Thornlord. Defeat him. Earn passage.\n\nTake whatever cards and crystals you can carry out the other side \u2014 your collection grows with every run, your mastery deepens, and somewhere in the Fractured Core the answer to all of this is waiting.\n\nProbably."
+      "text": "Break through the shard. Reach the Thornlord. Defeat him. Earn passage.\n\nTake whatever cards and crystals you can carry out the other side — your collection grows with every run, your mastery deepens, and somewhere in the Fractured Core the answer to all of this is waiting.\n\nProbably."
     }
   ],
   "outro": [
     {
       "title": "THE THORNLORD FALLS",
-      "text": "The ancient guardian crumples. Roots unravel. Bark splits along fracture lines older than the Dominion.\n\nFor a moment the whole forest holds its breath \u2014 then it exhales. The sealed pathways glow faintly and open like doors that have been waiting for exactly this."
+      "text": "The ancient guardian crumples. Roots unravel. Bark splits along fracture lines older than the Dominion.\n\nFor a moment the whole forest holds its breath — then it exhales. The sealed pathways glow faintly and open like doors that have been waiting for exactly this."
     },
     {
       "title": "WHAT HE WAS",
@@ -68,7 +68,7 @@
     },
     {
       "title": "THE ROAD AHEAD",
-      "text": "One shard cleared. The ley lines pulse \u2014 faint, but connected.\n\nYour deck returns to its bones. Your collection carries forward. Somewhere beyond the Verdant Shard, the Iron Citadel waits \u2014 and whoever controls it will not be glad to see you.\n\nGood."
+      "text": "One shard cleared. The ley lines pulse — faint, but connected.\n\nYour deck returns to its bones. Your collection carries forward. Somewhere beyond the Verdant Shard, the Iron Citadel waits — and whoever controls it will not be glad to see you.\n\nGood."
     }
   ],
   "variantPools": {
@@ -77,7 +77,7 @@
       "Now, technically, a free agent.",
       "Now, effectively, between employers.",
       "Now, in the administrative sense, without portfolio.",
-      "Now \u2014 if you were being generous \u2014 on sabbatical."
+      "Now — if you were being generous — on sabbatical."
     ],
     "jarvIntros": [
       "You have a deck of cards, a vague sense of mission, and the navigational instincts of someone who has been lost before and considers it acceptable.",
@@ -87,10 +87,10 @@
       "You have a deck of cards. You always have a deck of cards. That, at least, has been consistent."
     ],
     "forestDesc": [
-      "Your compass points to the nearest reachable shard \u2014 a dense, ancient forest realm that has grown wild and hostile since the Fracture closed its borders.",
-      "Your compass points to the Verdant Shard \u2014 a place that smells of pine resin and old magic, where the trees remember things the people forgot.",
+      "Your compass points to the nearest reachable shard — a dense, ancient forest realm that has grown wild and hostile since the Fracture closed its borders.",
+      "Your compass points to the Verdant Shard — a place that smells of pine resin and old magic, where the trees remember things the people forgot.",
       "Your compass points toward the Verdant Shard. The forest ahead is old enough to have opinions about you.",
-      "The Verdant Shard pulses at the edge of your compass bearing \u2014 a realm of old growth and older grudges, sealed since the Fracture."
+      "The Verdant Shard pulses at the edge of your compass bearing — a realm of old growth and older grudges, sealed since the Fracture."
     ],
     "thornlordDesc": [
       "The shard's guardian, a being called the Thornlord, has sealed its internal pathways. Local traders say he was old before the Dominion was founded.\n\nLocal traders also say he hasn't spoken to anyone in forty years. You're choosing to interpret that as optimistically as possible.",
@@ -99,16 +99,16 @@
       "The Thornlord seals every path through the Verdant Shard. Traders who've survived say he is patient, thorough, and has never once reconsidered a decision.\n\nYou have a plan. You've had plans before."
     ],
     "priorRunSummaries": [
-      "The path felt familiar \u2014 the way a dream feels familiar, just before it turns wrong.",
+      "The path felt familiar — the way a dream feels familiar, just before it turns wrong.",
       "You stepped into the Verdant Shard with the uneasy sense that you'd stepped here before. You pushed the feeling aside. There was work to do.",
-      "Something about the first battle. The angle of the light. The particular way the Goblins charged. A d\u00e9j\u00e0 vu so precise it was almost a memory.",
+      "Something about the first battle. The angle of the light. The particular way the Goblins charged. A déjà vu so precise it was almost a memory.",
       "The forest seemed quieter than it should have been. As though it recognised you, and was deciding whether to be pleased about it."
     ],
     "priorRunOpenings": [
-      "You remember \u2014 and here is the strange part \u2014 getting this far before. Not the same choices. But the same road.",
+      "You remember — and here is the strange part — getting this far before. Not the same choices. But the same road.",
       "The scholar on the boulder didn't look up when you approached. 'Again?' he said. 'You're ahead of schedule.'",
       "The Thornlord, when you finally stood before him, was already watching you. As though he had been expecting you. As though he had been expecting this for some time.",
-      "The goblins at the first barricade looked familiar. Not familiar the way people are familiar \u2014 familiar the way furniture in a childhood home is familiar. Something about the arrangement of them."
+      "The goblins at the first barricade looked familiar. Not familiar the way people are familiar — familiar the way furniture in a childhood home is familiar. Something about the arrangement of them."
     ],
     "milestoneOpenings5": [
       "The fifth time through the Verdant Shard, a bird called out your name. That was new.",
@@ -136,7 +136,7 @@
     "{n} campaigns in. The goblins at the first barricade have started placing bets on how quickly you'll get past them.",
     "{n} times you've stood at this shard's edge. The trees have started leaning away slightly when you approach.",
     "Run {n}. You walk in before dawn, which is new. Everything else is exactly as you left it.",
-    "The {ordinalLower} attempt. You recognise the smell now. Damp bark and old magic and something else \u2014 familiarity.",
+    "The {ordinalLower} attempt. You recognise the smell now. Damp bark and old magic and something else — familiarity.",
     "{n} campaigns. The Wandering Scholar has started making tea before you arrive. He knows the timing by heart."
   ],
   "introRules": [
@@ -337,7 +337,7 @@
         },
         {
           "title": "A FEELING",
-          "text": "And yet \u2014 {pool:priorRunOpenings:0}\n\nYou push the feeling aside. You've always pushed the feeling aside.\n\nThat's how you dreamt it happened, as you step out into the battlefield for the first time."
+          "text": "And yet — {pool:priorRunOpenings:0}\n\nYou push the feeling aside. You've always pushed the feeling aside.\n\nThat's how you dreamt it happened, as you step out into the battlefield for the first time."
         }
       ]
     }
@@ -448,7 +448,7 @@
           [
             {
               "label": "Leave an offering",
-              "consequence": "The shrine accepts your gift \u2014 restored 12 HP",
+              "consequence": "The shrine accepts your gift — restored 12 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 12
@@ -456,7 +456,7 @@
             },
             {
               "label": "Leave an offering",
-              "consequence": "The glow brightens \u2014 +15 crystals",
+              "consequence": "The glow brightens — +15 crystals",
               "effect": {
                 "type": "gainCrystals",
                 "amount": 15
@@ -471,7 +471,7 @@
             },
             {
               "label": "Leave an offering",
-              "consequence": "Something drains your offering \u2014 lose 5 HP",
+              "consequence": "Something drains your offering — lose 5 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 5
@@ -479,14 +479,14 @@
             },
             {
               "label": "Leave an offering",
-              "consequence": "Something small materialises at the altar's base \u2014 added to inventory",
+              "consequence": "Something small materialises at the altar's base — added to inventory",
               "effect": {
                 "type": "gainItem"
               }
             },
             {
               "label": "Leave an offering",
-              "consequence": "The shrine blesses you with renewed fortune \u2014 +1 life",
+              "consequence": "The shrine blesses you with renewed fortune — +1 life",
               "effect": {
                 "type": "gainLife",
                 "amount": 1
@@ -496,7 +496,7 @@
           [
             {
               "label": "Pray for strength",
-              "consequence": "A card materialises from the glow \u2014 uncommon",
+              "consequence": "A card materialises from the glow — uncommon",
               "effect": {
                 "type": "gainCard",
                 "rarity": "uncommon"
@@ -504,7 +504,7 @@
             },
             {
               "label": "Pray for strength",
-              "consequence": "The magic guides your wounds \u2014 restored 8 HP",
+              "consequence": "The magic guides your wounds — restored 8 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 8
@@ -512,7 +512,7 @@
             },
             {
               "label": "Pray for strength",
-              "consequence": "The shrine tests you \u2014 lose 10 HP",
+              "consequence": "The shrine tests you — lose 10 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 10
@@ -520,7 +520,7 @@
             },
             {
               "label": "Pray for strength",
-              "consequence": "You feel oddly lucky \u2014 +20 crystals",
+              "consequence": "You feel oddly lucky — +20 crystals",
               "effect": {
                 "type": "gainCrystals",
                 "amount": 20
@@ -528,14 +528,14 @@
             },
             {
               "label": "Pray for strength",
-              "consequence": "Something small and inexplicable materialises in your palm \u2014 added to inventory",
+              "consequence": "Something small and inexplicable materialises in your palm — added to inventory",
               "effect": {
                 "type": "gainItem"
               }
             },
             {
               "label": "Pray for strength",
-              "consequence": "A strange object appears in your hand from nowhere \u2014 added to inventory",
+              "consequence": "A strange object appears in your hand from nowhere — added to inventory",
               "effect": {
                 "type": "gainItem"
               }
@@ -544,10 +544,19 @@
           [
             {
               "label": "Pocket the ritual stones",
-              "consequence": "You grab them and run \u2014 +18 crystals, lose 8 HP",
+              "consequence": "You grab them and run — +18 crystals, lose 8 HP",
               "effect": {
-                "type": "damageHp",
-                "amount": 8
+                "type": "compound",
+                "effects": [
+                  {
+                    "type": "gainCrystals",
+                    "amount": 18
+                  },
+                  {
+                    "type": "damageHp",
+                    "amount": 8
+                  }
+                ]
               }
             },
             {
@@ -567,7 +576,7 @@
             },
             {
               "label": "Pocket the ritual stones",
-              "consequence": "The shrine curses you \u2014 lose 15 HP",
+              "consequence": "The shrine curses you — lose 15 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 15
@@ -575,7 +584,7 @@
             },
             {
               "label": "Pocket the ritual stones",
-              "consequence": "One of the stones turns out to be something stranger \u2014 added to inventory",
+              "consequence": "One of the stones turns out to be something stranger — added to inventory",
               "effect": {
                 "type": "gainItem"
               }
@@ -598,12 +607,12 @@
       "environment": "forest",
       "eventConfig": {
         "title": "The Watching Wood",
-        "description": "A great creature steps from the treeline. Not hostile \u2014 not yet. It tilts its head and watches you with ancient, patient eyes.",
+        "description": "A great creature steps from the treeline. Not hostile — not yet. It tilts its head and watches you with ancient, patient eyes.",
         "pools": [
           [
             {
               "label": "Stand your ground",
-              "consequence": "It respects the stillness \u2014 +15 crystals from its abandoned cache",
+              "consequence": "It respects the stillness — +15 crystals from its abandoned cache",
               "effect": {
                 "type": "gainCrystals",
                 "amount": 15
@@ -611,14 +620,14 @@
             },
             {
               "label": "Stand your ground",
-              "consequence": "It steps forward and presses something into your hand \u2014 added to inventory",
+              "consequence": "It steps forward and presses something into your hand — added to inventory",
               "effect": {
                 "type": "gainItem"
               }
             },
             {
               "label": "Stand your ground",
-              "consequence": "It growls and charges \u2014 lose 12 HP",
+              "consequence": "It growls and charges — lose 12 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 12
@@ -633,7 +642,7 @@
             },
             {
               "label": "Stand your ground",
-              "consequence": "Something in its posture says: not today \u2014 restored 10 HP",
+              "consequence": "Something in its posture says: not today — restored 10 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 10
@@ -643,7 +652,7 @@
           [
             {
               "label": "Offer it food",
-              "consequence": "It takes your offering gently \u2014 restored 12 HP",
+              "consequence": "It takes your offering gently — restored 12 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 12
@@ -666,7 +675,7 @@
             },
             {
               "label": "Offer it food",
-              "consequence": "It lashes out \u2014 lose 8 HP",
+              "consequence": "It lashes out — lose 8 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 8
@@ -674,7 +683,7 @@
             },
             {
               "label": "Offer it food",
-              "consequence": "It drops something from its mouth \u2014 a common card",
+              "consequence": "It drops something from its mouth — a common card",
               "effect": {
                 "type": "gainCard",
                 "rarity": "common"
@@ -684,14 +693,14 @@
           [
             {
               "label": "Back away slowly",
-              "consequence": "It lets you go \u2014 nothing happens",
+              "consequence": "It lets you go — nothing happens",
               "effect": {
                 "type": "nothing"
               }
             },
             {
               "label": "Back away slowly",
-              "consequence": "It follows you to the edge of its territory and leaves a crystal cache \u2014 +12 crystals",
+              "consequence": "It follows you to the edge of its territory and leaves a crystal cache — +12 crystals",
               "effect": {
                 "type": "gainCrystals",
                 "amount": 12
@@ -699,7 +708,7 @@
             },
             {
               "label": "Back away slowly",
-              "consequence": "It pounces \u2014 lose 15 HP",
+              "consequence": "It pounces — lose 15 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 15
@@ -707,14 +716,14 @@
             },
             {
               "label": "Back away slowly",
-              "consequence": "You find something in the grass as you retreat \u2014 added to inventory",
+              "consequence": "You find something in the grass as you retreat — added to inventory",
               "effect": {
                 "type": "gainItem"
               }
             },
             {
               "label": "Back away slowly",
-              "consequence": "It watches you leave and seems almost disappointed \u2014 restored 6 HP",
+              "consequence": "It watches you leave and seems almost disappointed — restored 6 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 6
@@ -743,7 +752,7 @@
           [
             {
               "label": "Rest in the shelter",
-              "consequence": "The quiet heals \u2014 restored 15 HP",
+              "consequence": "The quiet heals — restored 15 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 15
@@ -759,7 +768,7 @@
             },
             {
               "label": "Rest in the shelter",
-              "consequence": "Something bites you in the night \u2014 lose 6 HP",
+              "consequence": "Something bites you in the night — lose 6 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 6
@@ -767,7 +776,7 @@
             },
             {
               "label": "Rest in the shelter",
-              "consequence": "You find a pouch under the floorboards \u2014 +14 crystals",
+              "consequence": "You find a pouch under the floorboards — +14 crystals",
               "effect": {
                 "type": "gainCrystals",
                 "amount": 14
@@ -775,14 +784,14 @@
             },
             {
               "label": "Rest in the shelter",
-              "consequence": "You wake to find a small curiosity beside you \u2014 added to inventory",
+              "consequence": "You wake to find a small curiosity beside you — added to inventory",
               "effect": {
                 "type": "gainItem"
               }
             },
             {
               "label": "Rest in the shelter",
-              "consequence": "Something rolls under your hand in the dark \u2014 added to inventory",
+              "consequence": "Something rolls under your hand in the dark — added to inventory",
               "effect": {
                 "type": "gainItem"
               }
@@ -799,7 +808,7 @@
             },
             {
               "label": "Search the armory",
-              "consequence": "A rare weapon contract \u2014 add a rare card",
+              "consequence": "A rare weapon contract — add a rare card",
               "effect": {
                 "type": "gainCard",
                 "rarity": "rare"
@@ -807,7 +816,7 @@
             },
             {
               "label": "Search the armory",
-              "consequence": "Old coin cache \u2014 +20 crystals",
+              "consequence": "Old coin cache — +20 crystals",
               "effect": {
                 "type": "gainCrystals",
                 "amount": 20
@@ -815,7 +824,7 @@
             },
             {
               "label": "Search the armory",
-              "consequence": "A rusted trap springs \u2014 lose 10 HP",
+              "consequence": "A rusted trap springs — lose 10 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 10
@@ -823,14 +832,14 @@
             },
             {
               "label": "Search the armory",
-              "consequence": "You find a curious object among the debris \u2014 added to inventory",
+              "consequence": "You find a curious object among the debris — added to inventory",
               "effect": {
                 "type": "gainItem"
               }
             },
             {
               "label": "Search the armory",
-              "consequence": "Something rolls out of the rubble \u2014 added to inventory",
+              "consequence": "Something rolls out of the rubble — added to inventory",
               "effect": {
                 "type": "gainItem"
               }
@@ -839,7 +848,7 @@
           [
             {
               "label": "Climb the watchtower",
-              "consequence": "Good vantage point \u2014 +12 crystals from spotted supply cache",
+              "consequence": "Good vantage point — +12 crystals from spotted supply cache",
               "effect": {
                 "type": "gainCrystals",
                 "amount": 12
@@ -855,7 +864,7 @@
             },
             {
               "label": "Climb the watchtower",
-              "consequence": "The stairs collapse \u2014 lose 12 HP",
+              "consequence": "The stairs collapse — lose 12 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 12
@@ -870,14 +879,14 @@
             },
             {
               "label": "Climb the watchtower",
-              "consequence": "Something is jammed in the bell \u2014 you pocket it \u2014 added to inventory",
+              "consequence": "Something is jammed in the bell — you pocket it — added to inventory",
               "effect": {
                 "type": "gainItem"
               }
             },
             {
               "label": "Climb the watchtower",
-              "consequence": "You spot a hidden passage to a safe camp below \u2014 +1 life",
+              "consequence": "You spot a hidden passage to a safe camp below — +1 life",
               "effect": {
                 "type": "gainLife",
                 "amount": 1
@@ -930,7 +939,7 @@
       "id": "captain",
       "type": "elite",
       "label": "Forest Captain",
-      "description": "A hardened veteran with well-drilled siege troops \u2014 and something the forest has been teaching him about patience.",
+      "description": "A hardened veteran with well-drilled siege troops — and something the forest has been teaching him about patience.",
       "row": 3,
       "col": 0,
       "rowCols": 2,
@@ -1046,12 +1055,23 @@
       "opponentIntervalMs": 5000,
       "opponentBaseHp": 95,
       "enemyDeck": [
-        "Stone Wall","Stone Wall","Stone Wall","Stone Wall","Stone Wall","Stone Wall",
-        "Barracks","Barracks","Barracks",
-        "Farm","Farm",
-        "Crypt","Crypt",
-        "Shield Guard","Shield Guard",
-        "Knight","Knight",
+        "Stone Wall",
+        "Stone Wall",
+        "Stone Wall",
+        "Stone Wall",
+        "Stone Wall",
+        "Stone Wall",
+        "Barracks",
+        "Barracks",
+        "Barracks",
+        "Farm",
+        "Farm",
+        "Crypt",
+        "Crypt",
+        "Shield Guard",
+        "Shield Guard",
+        "Knight",
+        "Knight",
         "Fortify"
       ]
     },

--- a/web/src/data/acts/act11.json
+++ b/web/src/data/acts/act11.json
@@ -120,10 +120,12 @@
             {
               "label": "Offer blood (lose 8 HP, gain a rare card)",
               "effect": {
-                "type": "gainCard",
-                "rarity": "rare"
+                "type": "compound",
+                "effects": [
+                  { "type": "damageHp", "amount": 8 },
+                  { "type": "gainCard", "rarity": "rare" }
+                ]
               },
-              "hpCost": 8,
               "consequence": "You receive a rare card."
             }
           ],
@@ -269,10 +271,12 @@
             {
               "label": "Draw from the ley line (gain a rare card, take 5 damage)",
               "effect": {
-                "type": "gainCard",
-                "rarity": "rare"
+                "type": "compound",
+                "effects": [
+                  { "type": "damageHp", "amount": 5 },
+                  { "type": "gainCard", "rarity": "rare" }
+                ]
               },
-              "hpCost": 5,
               "consequence": "You receive a rare card."
             }
           ],
@@ -404,10 +408,12 @@
             {
               "label": "Leave an offering (lose 15 HP, gain 100 crystals)",
               "effect": {
-                "type": "gainCrystals",
-                "amount": 100
+                "type": "compound",
+                "effects": [
+                  { "type": "gainCrystals", "amount": 100 },
+                  { "type": "damageHp", "amount": 15 }
+                ]
               },
-              "hpCost": 15,
               "consequence": "You gain 100 crystals."
             }
           ],

--- a/web/src/data/acts/act12.json
+++ b/web/src/data/acts/act12.json
@@ -113,10 +113,12 @@
               "label": "Leave an offering (lose 8 HP, gain a rare card)",
               "consequence": "You receive a rare card.",
               "effect": {
-                "type": "gainCard",
-                "rarity": "rare"
-              },
-              "hpCost": 8
+                "type": "compound",
+                "effects": [
+                  { "type": "damageHp", "amount": 8 },
+                  { "type": "gainCard", "rarity": "rare" }
+                ]
+              }
             }
           ],
           [
@@ -244,10 +246,12 @@
               "label": "Force the crossing (gain a rare card, take 6 HP)",
               "consequence": "You receive a rare card.",
               "effect": {
-                "type": "gainCard",
-                "rarity": "rare"
-              },
-              "hpCost": 6
+                "type": "compound",
+                "effects": [
+                  { "type": "damageHp", "amount": 6 },
+                  { "type": "gainCard", "rarity": "rare" }
+                ]
+              }
             }
           ],
           [
@@ -374,10 +378,12 @@
               "label": "Take his coin (gain 100 crystals, lose 15 HP)",
               "consequence": "You gain 100 crystals.",
               "effect": {
-                "type": "gainCrystals",
-                "amount": 100
-              },
-              "hpCost": 15
+                "type": "compound",
+                "effects": [
+                  { "type": "gainCrystals", "amount": 100 },
+                  { "type": "damageHp", "amount": 15 }
+                ]
+              }
             }
           ],
           [

--- a/web/src/data/acts/act13.json
+++ b/web/src/data/acts/act13.json
@@ -113,10 +113,12 @@
               "label": "Offer metal (lose 8 HP, gain a rare card)",
               "consequence": "You receive a rare card.",
               "effect": {
-                "type": "gainCard",
-                "rarity": "rare"
-              },
-              "hpCost": 8
+                "type": "compound",
+                "effects": [
+                  { "type": "damageHp", "amount": 8 },
+                  { "type": "gainCard", "rarity": "rare" }
+                ]
+              }
             }
           ],
           [
@@ -244,10 +246,12 @@
               "label": "Draw from the rift (gain a rare card, take 5 HP)",
               "consequence": "You receive a rare card.",
               "effect": {
-                "type": "gainCard",
-                "rarity": "rare"
-              },
-              "hpCost": 5
+                "type": "compound",
+                "effects": [
+                  { "type": "damageHp", "amount": 5 },
+                  { "type": "gainCard", "rarity": "rare" }
+                ]
+              }
             }
           ],
           [
@@ -374,10 +378,12 @@
               "label": "Download the crystal cache (gain 100 crystals, lose 15 HP)",
               "consequence": "You gain 100 crystals.",
               "effect": {
-                "type": "gainCrystals",
-                "amount": 100
-              },
-              "hpCost": 15
+                "type": "compound",
+                "effects": [
+                  { "type": "gainCrystals", "amount": 100 },
+                  { "type": "damageHp", "amount": 15 }
+                ]
+              }
             }
           ],
           [

--- a/web/src/data/events.json
+++ b/web/src/data/events.json
@@ -5,9 +5,38 @@
       "title": "A Suspicious Offer",
       "description": "A goblin scout, notably clean for his kind, sidles up to you from behind a stump. He speaks quickly, gesturing toward a cloth bag that clinks suspiciously.",
       "choices": [
-        { "label": "Take the deal",                  "consequence": "+15 crystals, but lose 8 HP (he bites you on the way out)", "effect": { "type": "damageHp",     "amount": 8  } },
-        { "label": "Trade him a card tip for info",  "consequence": "Add a common card to your collection",                    "effect": { "type": "gainCard",     "rarity": "common" } },
-        { "label": "Chase him off",                  "consequence": "He runs. You feel smart but slightly bored.",              "effect": { "type": "nothing" } }
+        {
+          "label": "Take the deal",
+          "consequence": "+15 crystals, but lose 8 HP (he bites you on the way out)",
+          "effect": {
+            "type": "compound",
+            "effects": [
+              {
+                "type": "gainCrystals",
+                "amount": 15
+              },
+              {
+                "type": "damageHp",
+                "amount": 8
+              }
+            ]
+          }
+        },
+        {
+          "label": "Trade him a card tip for info",
+          "consequence": "Add a common card to your collection",
+          "effect": {
+            "type": "gainCard",
+            "rarity": "common"
+          }
+        },
+        {
+          "label": "Chase him off",
+          "consequence": "He runs. You feel smart but slightly bored.",
+          "effect": {
+            "type": "nothing"
+          }
+        }
       ]
     },
     "wanderer": {
@@ -15,9 +44,30 @@
       "title": "The Wandering Scholar",
       "description": "A robed scholar sits cross-legged on a boulder, annotating a crackling tome. He glances up without surprise. \"Ah. Another one of Jarv's campaigns. Sit.\"",
       "choices": [
-        { "label": "Ask him to heal you",       "consequence": "Restore 8 HP",                                    "effect": { "type": "healHp",       "amount": 8  } },
-        { "label": "Ask about rare tactics",    "consequence": "Add a rare card to your collection",             "effect": { "type": "gainCard",     "rarity": "rare" } },
-        { "label": "Ask for the short version", "consequence": "+12 crystals (he charges for advice)",           "effect": { "type": "gainCrystals", "amount": 12 } }
+        {
+          "label": "Ask him to heal you",
+          "consequence": "Restore 8 HP",
+          "effect": {
+            "type": "healHp",
+            "amount": 8
+          }
+        },
+        {
+          "label": "Ask about rare tactics",
+          "consequence": "Add a rare card to your collection",
+          "effect": {
+            "type": "gainCard",
+            "rarity": "rare"
+          }
+        },
+        {
+          "label": "Ask for the short version",
+          "consequence": "+12 crystals (he charges for advice)",
+          "effect": {
+            "type": "gainCrystals",
+            "amount": 12
+          }
+        }
       ]
     },
     "ambush-merchant": {
@@ -25,9 +75,29 @@
       "title": "Waylaid Merchant",
       "description": "A merchant's cart lists sideways in a ditch, one wheel spinning. The merchant waves you over frantically. \"Help me up and I'll make it worth your while.\"",
       "choices": [
-        { "label": "Help right the cart",              "consequence": "He rewards you — +20 crystals",                                          "effect": { "type": "gainCrystals", "amount": 20 } },
-        { "label": "Take what you need from the cart", "consequence": "Add an uncommon card to your collection (ethically complicated)",        "effect": { "type": "gainCard",     "rarity": "uncommon" } },
-        { "label": "Leave him be",                     "consequence": "You are definitely the villain in his story.",                           "effect": { "type": "nothing" } }
+        {
+          "label": "Help right the cart",
+          "consequence": "He rewards you — +20 crystals",
+          "effect": {
+            "type": "gainCrystals",
+            "amount": 20
+          }
+        },
+        {
+          "label": "Take what you need from the cart",
+          "consequence": "Add an uncommon card to your collection (ethically complicated)",
+          "effect": {
+            "type": "gainCard",
+            "rarity": "uncommon"
+          }
+        },
+        {
+          "label": "Leave him be",
+          "consequence": "You are definitely the villain in his story.",
+          "effect": {
+            "type": "nothing"
+          }
+        }
       ]
     },
     "supply-cache": {
@@ -35,65 +105,338 @@
       "title": "Supply Cache",
       "description": "A Citadel supply depot, hastily abandoned. Crates lie open and torn sacks spill their contents.",
       "choices": [
-        { "label": "Search the crates", "consequence": "+12 crystals from scavenged supplies", "effect": { "type": "gainCrystals", "amount": 12 } },
-        { "label": "Pocket something useful", "consequence": "You find an uncommon card among the spoils", "effect": { "type": "gainCard", "rarity": "uncommon" } },
-        { "label": "Leave quickly", "consequence": "Nothing of use remains — you move on.", "effect": { "type": "nothing" } }
+        {
+          "label": "Search the crates",
+          "consequence": "+12 crystals from scavenged supplies",
+          "effect": {
+            "type": "gainCrystals",
+            "amount": 12
+          }
+        },
+        {
+          "label": "Pocket something useful",
+          "consequence": "You find an uncommon card among the spoils",
+          "effect": {
+            "type": "gainCard",
+            "rarity": "uncommon"
+          }
+        },
+        {
+          "label": "Leave quickly",
+          "consequence": "Nothing of use remains — you move on.",
+          "effect": {
+            "type": "nothing"
+          }
+        }
       ]
     }
   },
-
   "pools": {
     "shrine": {
       "offering": [
-        { "label": "Leave an offering", "consequence": "The shrine accepts your gift — restored 12 HP",                 "effect": { "type": "healHp",       "amount": 12 } },
-        { "label": "Leave an offering", "consequence": "The glow brightens — +15 crystals",                             "effect": { "type": "gainCrystals", "amount": 15 } },
-        { "label": "Leave an offering", "consequence": "The shrine is silent. Nothing happens.",                         "effect": { "type": "nothing" } },
-        { "label": "Leave an offering", "consequence": "Something drains your offering — lose 5 HP",                    "effect": { "type": "damageHp",     "amount": 5  } },
-        { "label": "Leave an offering", "consequence": "The shrine returns your kindness with a curious trinket — added to inventory", "effect": { "type": "gainItem" } },
-        { "label": "Leave an offering", "consequence": "Something small materialises at the altar's base — added to inventory",       "effect": { "type": "gainItem" } },
-        { "label": "Leave an offering", "consequence": "The shrine blesses you with renewed fortune — +1 life",          "effect": { "type": "gainLife",     "amount": 1  } }
+        {
+          "label": "Leave an offering",
+          "consequence": "The shrine accepts your gift — restored 12 HP",
+          "effect": {
+            "type": "healHp",
+            "amount": 12
+          }
+        },
+        {
+          "label": "Leave an offering",
+          "consequence": "The glow brightens — +15 crystals",
+          "effect": {
+            "type": "gainCrystals",
+            "amount": 15
+          }
+        },
+        {
+          "label": "Leave an offering",
+          "consequence": "The shrine is silent. Nothing happens.",
+          "effect": {
+            "type": "nothing"
+          }
+        },
+        {
+          "label": "Leave an offering",
+          "consequence": "Something drains your offering — lose 5 HP",
+          "effect": {
+            "type": "damageHp",
+            "amount": 5
+          }
+        },
+        {
+          "label": "Leave an offering",
+          "consequence": "The shrine returns your kindness with a curious trinket — added to inventory",
+          "effect": {
+            "type": "gainItem"
+          }
+        },
+        {
+          "label": "Leave an offering",
+          "consequence": "Something small materialises at the altar's base — added to inventory",
+          "effect": {
+            "type": "gainItem"
+          }
+        },
+        {
+          "label": "Leave an offering",
+          "consequence": "The shrine blesses you with renewed fortune — +1 life",
+          "effect": {
+            "type": "gainLife",
+            "amount": 1
+          }
+        }
       ],
       "pray": [
-        { "label": "Pray for strength", "consequence": "A card materialises from the glow — uncommon",                  "effect": { "type": "gainCard",     "rarity": "uncommon" } },
-        { "label": "Pray for strength", "consequence": "The magic guides your wounds — restored 8 HP",                  "effect": { "type": "healHp",       "amount": 8  } },
-        { "label": "Pray for strength", "consequence": "The shrine tests you — lose 10 HP",                             "effect": { "type": "damageHp",     "amount": 10 } },
-        { "label": "Pray for strength", "consequence": "You feel oddly lucky — +20 crystals",                           "effect": { "type": "gainCrystals", "amount": 20 } },
-        { "label": "Pray for strength", "consequence": "Something small and inexplicable materialises in your palm — added to inventory", "effect": { "type": "gainItem" } },
-        { "label": "Pray for strength", "consequence": "A strange object appears in your hand from nowhere — added to inventory",           "effect": { "type": "gainItem" } }
+        {
+          "label": "Pray for strength",
+          "consequence": "A card materialises from the glow — uncommon",
+          "effect": {
+            "type": "gainCard",
+            "rarity": "uncommon"
+          }
+        },
+        {
+          "label": "Pray for strength",
+          "consequence": "The magic guides your wounds — restored 8 HP",
+          "effect": {
+            "type": "healHp",
+            "amount": 8
+          }
+        },
+        {
+          "label": "Pray for strength",
+          "consequence": "The shrine tests you — lose 10 HP",
+          "effect": {
+            "type": "damageHp",
+            "amount": 10
+          }
+        },
+        {
+          "label": "Pray for strength",
+          "consequence": "You feel oddly lucky — +20 crystals",
+          "effect": {
+            "type": "gainCrystals",
+            "amount": 20
+          }
+        },
+        {
+          "label": "Pray for strength",
+          "consequence": "Something small and inexplicable materialises in your palm — added to inventory",
+          "effect": {
+            "type": "gainItem"
+          }
+        },
+        {
+          "label": "Pray for strength",
+          "consequence": "A strange object appears in your hand from nowhere — added to inventory",
+          "effect": {
+            "type": "gainItem"
+          }
+        }
       ],
       "take": [
-        { "label": "Pocket the ritual stones", "consequence": "You grab them and run — +18 crystals, lose 8 HP",        "effect": { "type": "damageHp",  "amount": 8  } },
-        { "label": "Pocket the ritual stones", "consequence": "A common card falls from the stones",                    "effect": { "type": "gainCard",  "rarity": "common" } },
-        { "label": "Pocket the ritual stones", "consequence": "The stones crumble to dust. Nothing.",                   "effect": { "type": "nothing" } },
-        { "label": "Pocket the ritual stones", "consequence": "The shrine curses you — lose 15 HP",                     "effect": { "type": "damageHp",  "amount": 15 } },
-        { "label": "Pocket the ritual stones", "consequence": "One of the stones turns out to be something stranger — added to inventory", "effect": { "type": "gainItem" } }
+        {
+          "label": "Pocket the ritual stones",
+          "consequence": "You grab them and run — +18 crystals, lose 8 HP",
+          "effect": {
+            "type": "compound",
+            "effects": [
+              {
+                "type": "gainCrystals",
+                "amount": 18
+              },
+              {
+                "type": "damageHp",
+                "amount": 8
+              }
+            ]
+          }
+        },
+        {
+          "label": "Pocket the ritual stones",
+          "consequence": "A common card falls from the stones",
+          "effect": {
+            "type": "gainCard",
+            "rarity": "common"
+          }
+        },
+        {
+          "label": "Pocket the ritual stones",
+          "consequence": "The stones crumble to dust. Nothing.",
+          "effect": {
+            "type": "nothing"
+          }
+        },
+        {
+          "label": "Pocket the ritual stones",
+          "consequence": "The shrine curses you — lose 15 HP",
+          "effect": {
+            "type": "damageHp",
+            "amount": 15
+          }
+        },
+        {
+          "label": "Pocket the ritual stones",
+          "consequence": "One of the stones turns out to be something stranger — added to inventory",
+          "effect": {
+            "type": "gainItem"
+          }
+        }
       ]
     },
     "ruins": {
       "rest": [
-        { "label": "Rest in the shelter", "consequence": "The quiet heals — restored 15 HP",                            "effect": { "type": "healHp",       "amount": 15 } },
-        { "label": "Rest in the shelter", "consequence": "You sleep badly. Restored 8 HP",                              "effect": { "type": "healHp",       "amount": 8  } },
-        { "label": "Rest in the shelter", "consequence": "Something bites you in the night — lose 6 HP",               "effect": { "type": "damageHp",     "amount": 6  } },
-        { "label": "Rest in the shelter", "consequence": "You find a pouch under the floorboards — +14 crystals",      "effect": { "type": "gainCrystals", "amount": 14 } },
-        { "label": "Rest in the shelter", "consequence": "You wake to find a small curiosity beside you — added to inventory",          "effect": { "type": "gainItem" } },
-        { "label": "Rest in the shelter", "consequence": "Something rolls under your hand in the dark — added to inventory",             "effect": { "type": "gainItem" } }
+        {
+          "label": "Rest in the shelter",
+          "consequence": "The quiet heals — restored 15 HP",
+          "effect": {
+            "type": "healHp",
+            "amount": 15
+          }
+        },
+        {
+          "label": "Rest in the shelter",
+          "consequence": "You sleep badly. Restored 8 HP",
+          "effect": {
+            "type": "healHp",
+            "amount": 8
+          }
+        },
+        {
+          "label": "Rest in the shelter",
+          "consequence": "Something bites you in the night — lose 6 HP",
+          "effect": {
+            "type": "damageHp",
+            "amount": 6
+          }
+        },
+        {
+          "label": "Rest in the shelter",
+          "consequence": "You find a pouch under the floorboards — +14 crystals",
+          "effect": {
+            "type": "gainCrystals",
+            "amount": 14
+          }
+        },
+        {
+          "label": "Rest in the shelter",
+          "consequence": "You wake to find a small curiosity beside you — added to inventory",
+          "effect": {
+            "type": "gainItem"
+          }
+        },
+        {
+          "label": "Rest in the shelter",
+          "consequence": "Something rolls under your hand in the dark — added to inventory",
+          "effect": {
+            "type": "gainItem"
+          }
+        }
       ],
       "search": [
-        { "label": "Search the armory", "consequence": "An uncommon card hidden behind a loose brick",                  "effect": { "type": "gainCard",     "rarity": "uncommon" } },
-        { "label": "Search the armory", "consequence": "A rare weapon contract — add a rare card",                      "effect": { "type": "gainCard",     "rarity": "rare" } },
-        { "label": "Search the armory", "consequence": "Old coin cache — +20 crystals",                                 "effect": { "type": "gainCrystals", "amount": 20 } },
-        { "label": "Search the armory", "consequence": "A rusted trap springs — lose 10 HP",                           "effect": { "type": "damageHp",     "amount": 10 } },
-        { "label": "Search the armory", "consequence": "You find a curious object among the debris — added to inventory",   "effect": { "type": "gainItem" } },
-        { "label": "Search the armory", "consequence": "Something rolls out of the rubble — added to inventory",           "effect": { "type": "gainItem" } }
+        {
+          "label": "Search the armory",
+          "consequence": "An uncommon card hidden behind a loose brick",
+          "effect": {
+            "type": "gainCard",
+            "rarity": "uncommon"
+          }
+        },
+        {
+          "label": "Search the armory",
+          "consequence": "A rare weapon contract — add a rare card",
+          "effect": {
+            "type": "gainCard",
+            "rarity": "rare"
+          }
+        },
+        {
+          "label": "Search the armory",
+          "consequence": "Old coin cache — +20 crystals",
+          "effect": {
+            "type": "gainCrystals",
+            "amount": 20
+          }
+        },
+        {
+          "label": "Search the armory",
+          "consequence": "A rusted trap springs — lose 10 HP",
+          "effect": {
+            "type": "damageHp",
+            "amount": 10
+          }
+        },
+        {
+          "label": "Search the armory",
+          "consequence": "You find a curious object among the debris — added to inventory",
+          "effect": {
+            "type": "gainItem"
+          }
+        },
+        {
+          "label": "Search the armory",
+          "consequence": "Something rolls out of the rubble — added to inventory",
+          "effect": {
+            "type": "gainItem"
+          }
+        }
       ],
       "climb": [
-        { "label": "Climb the watchtower", "consequence": "Good vantage point — +12 crystals from spotted supply cache", "effect": { "type": "gainCrystals", "amount": 12 } },
-        { "label": "Climb the watchtower", "consequence": "A common card is wedged in the battlements",                  "effect": { "type": "gainCard",     "rarity": "common" } },
-        { "label": "Climb the watchtower", "consequence": "The stairs collapse — lose 12 HP",                           "effect": { "type": "damageHp",     "amount": 12 } },
-        { "label": "Climb the watchtower", "consequence": "Nothing up there. Wind. Old regrets.",                        "effect": { "type": "nothing" } },
-        { "label": "Climb the watchtower", "consequence": "Something is jammed in the bell — you pocket it — added to inventory",   "effect": { "type": "gainItem" } },
-        { "label": "Climb the watchtower", "consequence": "Something is stuck to the iron door — you take it — added to inventory", "effect": { "type": "gainItem" } },
-        { "label": "Climb the watchtower", "consequence": "You spot a hidden passage to a safe camp below — +1 life",   "effect": { "type": "gainLife",     "amount": 1  } }
+        {
+          "label": "Climb the watchtower",
+          "consequence": "Good vantage point — +12 crystals from spotted supply cache",
+          "effect": {
+            "type": "gainCrystals",
+            "amount": 12
+          }
+        },
+        {
+          "label": "Climb the watchtower",
+          "consequence": "A common card is wedged in the battlements",
+          "effect": {
+            "type": "gainCard",
+            "rarity": "common"
+          }
+        },
+        {
+          "label": "Climb the watchtower",
+          "consequence": "The stairs collapse — lose 12 HP",
+          "effect": {
+            "type": "damageHp",
+            "amount": 12
+          }
+        },
+        {
+          "label": "Climb the watchtower",
+          "consequence": "Nothing up there. Wind. Old regrets.",
+          "effect": {
+            "type": "nothing"
+          }
+        },
+        {
+          "label": "Climb the watchtower",
+          "consequence": "Something is jammed in the bell — you pocket it — added to inventory",
+          "effect": {
+            "type": "gainItem"
+          }
+        },
+        {
+          "label": "Climb the watchtower",
+          "consequence": "Something is stuck to the iron door — you take it — added to inventory",
+          "effect": {
+            "type": "gainItem"
+          }
+        },
+        {
+          "label": "Climb the watchtower",
+          "consequence": "You spot a hidden passage to a safe camp below — +1 life",
+          "effect": {
+            "type": "gainLife",
+            "amount": 1
+          }
+        }
       ]
     }
   }

--- a/web/src/game/questline.ts
+++ b/web/src/game/questline.ts
@@ -158,7 +158,7 @@ export interface QuestNode {
 
 // ─── Event system ─────────────────────────────────────────
 
-export type EventEffect =
+export type SingleEventEffect =
   | { type: 'healHp';          amount: number }
   | { type: 'damageHp';        amount: number }
   | { type: 'gainCrystals';    amount: number }
@@ -166,6 +166,9 @@ export type EventEffect =
   | { type: 'gainItem';        itemId?: string }
   | { type: 'gainLife';        amount: number }
   | { type: 'nothing' }
+
+/** An effect that applies multiple SingleEventEffects in sequence. */
+export type EventEffect = SingleEventEffect | { type: 'compound'; effects: SingleEventEffect[] }
 
 export interface EventChoice {
   label: string        // short action label e.g. "Leave an offering"


### PR DESCRIPTION
## Summary

Closes #740

Two categories of broken HP-loss events, both now fixed:

### 1. `hpCost` field silently ignored (acts 11–13)
Nine event choices used an `hpCost` field alongside a `gainCard` or `gainCrystals` effect. The `hpCost` was never read by `handleEventChoice` — it was an orphaned JSON field with no code counterpart. The player was promised HP loss ("lose 8 HP, gain a rare card") but nothing happened. All nine entries have been converted to compound effects.

### 2. Missing crystals on "take crystals + lose HP" choices (act 1)
One `forest-path` choice said "+18 crystals, lose 8 HP" but the effect was only `damageHp: 8` — crystals were never awarded.

### Changes

**`questline.ts`** — Split `EventEffect` into `SingleEventEffect` (the original union) and a new `compound` wrapper:
```ts
export type EventEffect = SingleEventEffect | { type: 'compound'; effects: SingleEventEffect[] }
```

**`App.tsx`** — `handleEventChoice` now flattens compound effects into a loop, applying each in sequence. For `gainCard` (which does an early `return`), `damageHp` is ordered first so HP is deducted before the return fires.

**`EventScreen.tsx`** — HP preview accumulates `healHp`/`damageHp` across all effects in a compound.

**Data fixes:**
- `act1.json` — forest-path pool[2][0]: `gainCrystals: 18` + `damageHp: 8`
- `act11.json` — root-shrine, canopy-rift, warden-vigil: hpCost → compound damageHp
- `act12.json` — tidal-shrine, storm-crossing, gale-watch: hpCost → compound damageHp
- `act13.json` — gear-shrine, calibration-rift, automaton-watch: hpCost → compound damageHp

## Test plan

- [ ] Acts 11–13: "lose 8 HP, gain a rare card" choices now actually deduct 8 HP
- [ ] Acts 11–13: "gain 100 crystals, lose 15 HP" choices now actually deduct 15 HP
- [ ] Act 1 forest-path: "grab the ritual stones" grants +18 crystals AND loses 8 HP
- [ ] HP preview in EventScreen shows correct reduced HP for all compound damageHp choices
- [ ] All other event effects (healHp, gainCard without HP cost, gainLife, gainItem, nothing) unaffected
- [ ] Build passes: `npm run build` ✅

https://claude.ai/code/session_01G1eGmryfrwUgJ7vw3ReP25