### PR TITLE
Randomise node sprite wander: independent 4-direction JS movement

### DIFF
--- a/web/src/components/NodeMap.tsx
+++ b/web/src/components/NodeMap.tsx
@@ -611,6 +611,36 @@ function collapseModifiers(modifiers: ReplayModifier[]): ReplayModifier[] {
   })
 }
 
+// ── Wandering sprite ─────────────────────────────────────────────────────────
+
+const WANDER_RANGE = 10 // px radius from centre
+
+function WanderingSprite({ name }: { name: string }) {
+  const [pos, setPos] = useState({ x: 0, y: 0 })
+  const [dur, setDur] = useState(1200)
+
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout>
+    function step() {
+      const x = (Math.random() * 2 - 1) * WANDER_RANGE
+      const y = (Math.random() * 2 - 1) * WANDER_RANGE
+      const d = 600 + Math.random() * 1200
+      setPos({ x, y })
+      setDur(d)
+      timer = setTimeout(step, d + 80)
+    }
+    // Stagger startup so sprites don't all move in sync
+    timer = setTimeout(step, Math.random() * 1200)
+    return () => clearTimeout(timer)
+  }, [])
+
+  return (
+    <div style={{ transform: `translate(${pos.x}px,${pos.y}px)`, transition: `transform ${dur}ms ease-in-out` }}>
+      <AnimatedSpriteImg name={name} frameCount={3} fps={6} className="nm-node-sprite" />
+    </div>
+  )
+}
+
 // ── Node Peek Modal ──────────────────────────────────────────────────────────
 
 interface PeekModalProps {
@@ -918,12 +948,7 @@ export function NodeMap({ act, run, onSelectNode, onUseConsumable, onBack }: Pro
                           </span>
                           {(() => {
                             if ((node.type === 'battle' || node.type === 'elite') && node.enemyDeck?.length) {
-                              return <AnimatedSpriteImg
-                                name={node.enemyDeck[0]}
-                                frameCount={3}
-                                fps={6}
-                                className="nm-node-sprite nm-node-sprite--animated"
-                              />
+                              return <WanderingSprite name={node.enemyDeck[0]} />
                             }
                             const sprite = nodeSprite(node)
                             return sprite

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -3905,13 +3905,6 @@ body {
 
 .nm-node-icon   { font-size: 22px; line-height: 1; }
 .nm-node-sprite { width: 38px; height: 38px; object-fit: contain; image-rendering: pixelated; }
-.nm-node-sprite--animated { animation: nm-sprite-wander 2.5s ease-in-out infinite; }
-@keyframes nm-sprite-wander {
-  0%        { transform: translateX(0); }
-  30%       { transform: translateX(3px); }
-  70%       { transform: translateX(-3px); }
-  100%      { transform: translateX(0); }
-}
 .nm-node-name  { font-size: 11px; color: var(--game-text-color-dim); letter-spacing: 0.5px; text-align: center; line-height: 1.3; }
 .nm-node-status { font-size: 9px; letter-spacing: 1px; min-height: 12px; }
 


### PR DESCRIPTION
## Summary

Replaces the CSS `nm-sprite-wander` keyframe (which made every sprite drift left/right in lockstep) with a `WanderingSprite` React component that gives each enemy sprite its own independent random walk.

- Picks a random `(x, y)` target within ±10px of centre every 600–1800ms — covers all 4 directions
- Random startup delay (0–1200ms) staggers sprites so they don't all move simultaneously
- Random step duration means each sprite has its own tempo
- CSS `transition: transform` handles smooth interpolation between positions
- Old CSS `nm-sprite-wander` keyframe removed

## Test plan

- [ ] Open node map — battle/elite sprites should each drift in different directions
- [ ] No two sprites should move in sync or at the same speed
- [ ] Sprites should stay visually within the node area (±10px of their slot centre)
- [ ] Static sprites (rest/campfire, merchant, event) are unaffected
- [ ] Tapping a node still opens the peek dialogue normally

https://claude.ai/code/session_01Jvg5QNuUV8im7y5V7CDd4j