### PR TITLE
Gravestone on completed nodes; static sprite for building units

### DIFF
--- a/web/src/components/NodeMap.tsx
+++ b/web/src/components/NodeMap.tsx
@@ -3,6 +3,7 @@ import { Act, QuestNode, RunState, ReplayModifier, getAvailableNodeIds, loadNode
 import { spriteSlug } from '../game/sprites'
 import { StatRow } from './StatRow'
 import { AnimatedSpriteImg } from './SpriteImg'
+import { getCardUnit } from '../game/cards'
 
 interface Props {
   act: Act
@@ -948,7 +949,17 @@ export function NodeMap({ act, run, onSelectNode, onUseConsumable, onBack }: Pro
                           </span>
                           {(() => {
                             if ((node.type === 'battle' || node.type === 'elite') && node.enemyDeck?.length) {
-                              return <WanderingSprite name={node.enemyDeck[0]} />
+                              const unitName = node.enemyDeck[0]
+                              if (status === 'completed') {
+                                return <span className="nm-node-icon">🪦</span>
+                              }
+                              const isBuilding = (getCardUnit(unitName)?.moveSpeed ?? 1) === 0
+                              if (isBuilding) {
+                                const slug = spriteSlug(unitName)
+                                return <img src={`/sprites/${slug}.svg`} alt="" className="nm-node-sprite"
+                                  onError={e => { (e.currentTarget as HTMLImageElement).style.display = 'none' }} />
+                              }
+                              return <WanderingSprite name={unitName} />
                             }
                             const sprite = nodeSprite(node)
                             return sprite


### PR DESCRIPTION
## Summary

- **Gravestone on completion**: battle/elite nodes that have been cleared now show 🪦 instead of the enemy sprite
- **No wander for buildings**: units with `moveSpeed === 0` (structures/towers) render as a static sprite — only walkers use `WanderingSprite`

## Test plan

- [ ] Complete a battle node — sprite should switch to 🪦
- [ ] A node with a building unit (e.g. Arcane Tower) should show a static sprite, not wander
- [ ] A node with a walking unit (e.g. Goblin) should still wander
- [ ] Skipped nodes still show ╳ status, no regression

https://claude.ai/code/session_01Jvg5QNuUV8im7y5V7CDd4j