### PR TITLE
feat(editor): add copy node button

### DIFF
--- a/web/src/components/CampaignAdminScreen.tsx
+++ b/web/src/components/CampaignAdminScreen.tsx
@@ -388,6 +388,16 @@ export function CampaignAdminScreen({ onBack }: Props) {
     setSelectedNodeId(newId)
   }
 
+  function handleCopyNode(nodeId: string) {
+    const source = act.nodes[nodeId]
+    const newId = `node-${Date.now()}`
+    const copy: QuestNode = { ...JSON.parse(JSON.stringify(source)), id: newId, childIds: [] }
+    const updated = recalculateCols({ ...act.nodes, [newId]: copy })
+    setAct(prev => ({ ...prev, nodes: updated }))
+    setSelectedNodeId(newId)
+    flash(`Copied "${nodeId}" → "${newId}".`)
+  }
+
   function handleDeleteNode(nodeId: string) {
     const { [nodeId]: _removed, ...rest } = act.nodes
     const cleaned: Record<string, QuestNode> = Object.fromEntries(
@@ -581,6 +591,8 @@ export function CampaignAdminScreen({ onBack }: Props) {
                       onClick={() => setSelectedNodeId(selectedNodeId === node.id ? null : node.id)}>
                       {selectedNodeId === node.id ? 'CLOSE' : 'EDIT'}
                     </button>
+                    <button className="action-btn action-btn--xs" title="Duplicate node"
+                      onClick={() => handleCopyNode(node.id)}>⧉</button>
                     <button className="action-btn action-btn--xs" title="Move to earlier row"
                       onClick={() => handleMoveNodeRow(node.id, -1)} disabled={node.row === 0}>▲</button>
                     <button className="action-btn action-btn--xs" title="Move to later row"


### PR DESCRIPTION
## Summary

- Adds a ⧉ (duplicate) button next to each node's action buttons in the campaign editor node list
- Creates a deep copy of the node with a new unique ID, placed in the same row; `childIds` are cleared since the copied connections would be stale
- The copy is immediately selected and opens in the editor for renaming/tweaking

## Test plan

- [ ] Click ⧉ on any node — a copy appears in the same row, selected for editing
- [ ] Flash message confirms the copy with old → new ID
- [ ] The copy has all fields from the source (type, label, deck, handicap, etc.) but no child connections
- [ ] Map preview updates to show the new node

https://claude.ai/code/session_01YZEqfh7arDPF7hhJSSpguV