### PR TITLE
chore(todo): session 42 issue sync — #742, #725, #719

### DIFF
--- a/todo.md
+++ b/todo.md
@@ -1,6 +1,17 @@
 # Jarv's Amazing Web Game — Todo List
 
-Issues sourced from GitHub. Last synced: 2026-04-19 (session 41).
+Issues sourced from GitHub. Last synced: 2026-04-21 (session 42).
+
+## 🔴 Bugs — New (from GitHub, session 42 sync)
+
+- [ ] **#742** `InvalidStateError: newestWorker is null` — Bug | Priority: Low — `App.tsx:790`: `swRegRef.current?.update()` throws when the SW registration has no `newestWorker`; wrap in try/catch with `logError`. Related to (but distinct from) closed noise issues #581/#582.
+
+## 🔵 Improvements — New (from GitHub, session 42 sync)
+
+- [ ] **#725** Quick Battle opponent deck improvements — Improvement | Priority: Medium — Two parts tracked as sub-issues:
+  - [ ] **#773** Limit opponent deck to cards in the player's collection only (fallback to base deck if collection too small)
+  - [ ] **#774** Add Easy Mode: opponent uses only cards from player's active deck; rewards 1 card on win; mode selector on Quick Battle setup screen
+- [ ] **#719** Card Mastery for buildings — Improvement | Priority: Low-Medium — Mastery on buff/structure cards has no visible effect; card inspector implies it does (affinity/damage boost). Define and implement meaningful mastery bonuses for building-type cards.
 
 ## 🔵 Improvements — New (from GitHub, session 41 sync — TODO sweep, issue #733)
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Synced 3 new GitHub issues not yet in `todo.md` (session 42, 2026-04-21)
- Created and linked sub-issues #773 and #774 under parent #725

## New issues added

| # | Category | Priority | Title |
|---|----------|----------|-------|
| #742 | Bug | Low | `InvalidStateError: newestWorker is null` in `App.tsx:790` — wrap SW update call in try/catch |
| #725 | Improvement | Medium | Quick Battle opponent deck improvements (sub-issues #773 + #774) |
| #719 | Improvement | Low-Medium | Building card mastery has no real effect — define meaningful bonuses |

## Sub-issues created for #725
- **#773** Limit opponent deck to player's collection cards
- **#774** Add Easy Mode (opponent uses player's deck, 1-card reward)

## Duplicate check
- #742 is related to closed noise issues #581/#582 (ServiceWorker errors) but is distinct — it points to a specific actionable line in `App.tsx` rather than a network failure
- #725 is distinct from #674 (AI balanced deck variety) — different concern
- #719 has no prior duplicate

https://claude.ai/code/session_011i148Vdecex5n2dVMawEYy
EOF
)