### PR TITLE
feat(camp): show outcome feedback after choosing a rest node option

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -404,6 +404,7 @@ export default function App() {
   const merchantBoughtRef = useRef(0)
   const [mysteryReward, setMysteryReward] = useState<RewardDef | null>(null)
   const [campNode, setCampNode] = useState<QuestNode | null>(null)
+  const [campResult, setCampResult] = useState<string | null>(null)
   // Replay briefing state — stored so onBegin can proceed with the correct context
   const replayBriefingRef = useRef<{
     actId: string
@@ -1479,13 +1480,16 @@ export default function App() {
     if (!currentRun || !campNode) return
     const healAmount = campNode.restHeal ?? 5
     let updatedRun = { ...currentRun }
+    let resultMessage = ''
 
     if (choice === 'heal') {
       if (updatedRun.playerHp >= updatedRun.maxHp) {
-        // At max — grant bonus HP above the cap
         updatedRun.playerHp = updatedRun.playerHp + healAmount
+        resultMessage = `Already at full health — gained +${healAmount} bonus HP above your maximum!`
       } else {
+        const gained = Math.min(healAmount, updatedRun.maxHp - updatedRun.playerHp)
         updatedRun.playerHp = Math.min(updatedRun.playerHp + healAmount, updatedRun.maxHp)
+        resultMessage = `Healed ${gained} HP. (${currentRun.playerHp} → ${updatedRun.playerHp})`
       }
       playRestHeal()
     } else if (choice === 'rest') {
@@ -1496,10 +1500,16 @@ export default function App() {
         const newFatigued = fatigued.filter((_, i) => i !== idx)
         saveFatigued(newFatigued)
         setFatiguedCards(newFatigued)
+        resultMessage = `${recovered} has recovered and returned to your deck!`
+      } else {
+        resultMessage = `The troops couldn't recover this time. Better luck next camp.`
       }
     } else if (choice === 'meditate') {
       if (updatedRun.livesRemaining < updatedRun.maxLives && Math.random() < 0.5) {
         updatedRun.livesRemaining = Math.min(updatedRun.maxLives, updatedRun.livesRemaining + 1)
+        resultMessage = `Your focus deepens — gained +1 life!`
+      } else {
+        resultMessage = `Your mind wanders. No extra life gained this time.`
       }
     }
 
@@ -1511,9 +1521,14 @@ export default function App() {
     recordNodeComplete(updatedRun.actId, campNode.id)
     saveRun(updatedRun)
     setRun(updatedRun)
-    setCampNode(null)
-    setScreen('nodemap')
+    setCampResult(resultMessage)
   }, [run, campNode])
+
+  const handleCampContinue = useCallback(() => {
+    setCampNode(null)
+    setCampResult(null)
+    setScreen('nodemap')
+  }, [])
 
   const handleWaveRewardPick = useCallback((cardName: string) => {
     // Add to collection permanently and inject into the current run deck
@@ -2424,6 +2439,8 @@ export default function App() {
           fatiguedCards={fatiguedCards}
           healAmount={campNode.restHeal ?? 5}
           onChoose={handleCampChoice}
+          result={campResult}
+          onContinue={handleCampContinue}
         />
       )}
 

--- a/web/src/components/CampScreen.tsx
+++ b/web/src/components/CampScreen.tsx
@@ -10,6 +10,8 @@ interface Props {
   fatiguedCards: string[]
   healAmount: number
   onChoose: (choice: CampChoice) => void
+  result: string | null
+  onContinue: () => void
 }
 
 export function CampScreen({
@@ -20,10 +22,30 @@ export function CampScreen({
   fatiguedCards,
   healAmount,
   onChoose,
+  result,
+  onContinue,
 }: Props) {
   const atMaxHp = playerHp >= maxHp
   const atMaxLives = livesRemaining >= maxLives
   const hasRestingCards = fatiguedCards.length > 0
+
+  if (result) {
+    return (
+      <div className="overlay-screen camp-screen">
+        <div className="camp-header">
+          <div className="camp-title">— CAMP —</div>
+          <div className="camp-stats">
+            <span>HP: {playerHp}/{maxHp}</span>
+            <span>Lives: {livesRemaining}/{maxLives}</span>
+          </div>
+        </div>
+        <div className="camp-result">
+          <div className="camp-result-message">{result}</div>
+          <button className="camp-continue" onClick={onContinue}>CONTINUE</button>
+        </div>
+      </div>
+    )
+  }
 
   return (
     <div className="overlay-screen camp-screen">

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -9917,6 +9917,42 @@ html.light-mode .action-btn {
   line-height: 1.5;
 }
 
+.camp-result {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 24px;
+  padding: 28px 24px;
+  border: 1px solid #444;
+  border-radius: 4px;
+  width: 100%;
+  text-align: center;
+}
+
+.camp-result-message {
+  font-size: 15px;
+  color: #ddd;
+  line-height: 1.6;
+}
+
+.camp-continue {
+  background: transparent;
+  border: 1px solid #ff9944;
+  border-radius: 4px;
+  color: #ff9944;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: bold;
+  letter-spacing: 2px;
+  padding: 10px 28px;
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.camp-continue:hover {
+  background: rgba(255, 153, 68, 0.1);
+}
+
 /* ─── Post-battle summary stats inside reward screen (#721) ─ */
 
 .reward-battle-summary {


### PR DESCRIPTION
## Summary

- After tapping HEAL, REST, or MEDITATE at a camp node, the screen now shows a result panel before returning to the node map
- The panel displays exactly what happened: HP gained, which card recovered, or whether the 50% roll succeeded/failed
- A CONTINUE button dismisses the panel and proceeds to the node map

## Test plan

- [ ] Visit a rest node and choose HEAL — confirm the result shows HP gained (e.g. "Healed 5 HP. (12 → 17)") or bonus HP message if already at max
- [ ] Choose REST with fatigued cards — confirm the result shows either the card name that recovered, or the failure message
- [ ] Choose MEDITATE — confirm the result shows either "+1 life!" or "no extra life gained"
- [ ] Tap CONTINUE and confirm you land back on the node map with the node marked complete

Fixes #777

https://claude.ai/code/session_0174TcrN96FGkwgPXew67u8q