### PR TITLE
chore: sync new GitHub issues (session 42)

### DIFF
--- a/todo.md
+++ b/todo.md
@@ -1,6 +1,27 @@
 # Jarv's Amazing Web Game — Todo List
 
-Issues sourced from GitHub. Last synced: 2026-04-19 (session 41).
+Issues sourced from GitHub. Last synced: 2026-04-22 (session 42).
+
+## 🟣 Features — New (from GitHub, session 42 sync)
+
+- [ ] **#776** Minigame: fruit machine — Feature Request | Priority: Medium — Extend existing fruit machine with full reels engine, persistent feature board, jackpot tiers, holds/nudges/bonus games, and data-driven config. Sub-issues:
+  - [ ] **#779** Core reels system (symbols, paylines, spin resolution)
+  - [ ] **#780** Stake system and game-state machine (IDLE→SPINNING→EVALUATING→…)
+  - [ ] **#781** Feature board (persistent state, advancement triggers, prize nodes)
+  - [ ] **#782** Special features — holds, nudges, and bonus games
+  - [ ] **#783** Jackpot system (Mini/Minor/Major/Grand, fixed + progressive)
+  - [ ] **#784** Data-driven configuration (symbol weights, paytables, board layout)
+
+## 🔵 Improvements — New (from GitHub, session 42 sync)
+
+- [ ] **#725** Quick Battle improvements — Improvement | Priority: Medium — Limit opponent deck to player's collection; add Easy Mode. Sub-issues:
+  - [ ] **#773** Limit opponent deck to cards in player's collection (fallback if collection < N cards)
+  - [ ] **#774** Add Easy Mode: opponent uses player's own deck; rewards only 1 card on win
+- [ ] **#719** Card Mastery: building card mastery should do something — Improvement | Priority: Low — Mastery on buff/building cards currently has no gameplay effect; define and implement a meaningful mastery bonus for building cards
+
+## 🔴 Bugs — New (from GitHub, session 42 sync)
+
+- [ ] **#742** InvalidStateError: newestWorker is null — Bug | Priority: Low — `swRegRef.current?.update()` at `App.tsx:790` throws when ServiceWorker `newestWorker` is null; guard the call or catch the error
 
 ## 🔵 Improvements — New (from GitHub, session 41 sync — TODO sweep, issue #733)
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Updated `todo.md` to reflect last synced date as 2026-04-22 (session 42)
- Added 6 newly found GitHub issues, categorized and prioritized

## New Issues Added

| # | Title | Category | Priority |
|---|-------|----------|----------|
| #776 | Minigame: fruit machine | Feature Request | Medium |
| #725 | Quick Battle improvements (parent) | Improvement | Medium |
| #773 | Quick Battle: limit opponent deck to player's collection | Improvement | Medium |
| #774 | Quick Battle: add Easy Mode | Feature Request | Medium |
| #719 | Card Mastery: building cards should have meaningful mastery effect | Improvement | Low |
| #742 | InvalidStateError: newestWorker is null (ServiceWorker) | Bug | Low |

## GitHub Actions Taken

- Created 6 sub-issues (#779–#784) for #776 (fruit machine) covering: reels, stake/state-machine, feature board, holds/nudges/bonus games, jackpot system, data-driven config
- Linked all 6 as sub-issues of #776
- Applied `feature` + `minigame` labels to #776
- #725 already had #773 and #774 correctly linked as sub-issues

## Duplicates Check

- #742 (ServiceWorker error) is distinct from the previously closed noise issues (#581, #582) — it has a specific code location (`App.tsx:790`) and a fixable root cause
- No other duplicates found

https://claude.ai/code/session_01CzGMpi4gTjsKuy8WVHyWkX
EOF
)