### PR TITLE
fix/feat: address high-priority issues #742, #758, #773, #774, #779

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3,6 +3,7 @@ import { useRegisterSW } from 'virtual:pwa-register/react'
 import { GameState, Card } from './game/types'
 import { newGame, NewGameOptions, MAX_HANDICAP } from './game/engine'
 import { playCard, playAoeCard } from './game/engine/cards'
+import { shuffle } from './game/engine/helpers'
 import { makeNodeDeck } from './game/cards'
 import { battleReducer, INITIAL_BATTLE_STATE, TICK_MS } from './game/battleReducer'
 import {
@@ -379,6 +380,8 @@ export default function App() {
   const isCampaignRef       = useRef(_startup.isCampaign)   // true while playing a campaign battle
   const isDailyChallengeRef = useRef(false)                  // true while playing the daily challenge
   const isTrainingModeRef   = useRef(false)                  // true while playing a training battle
+  const isEasyModeRef       = useRef(false)                  // true when Quick Battle Easy Mode is active
+  const [quickBattleMode, setQuickBattleMode] = useState<'normal' | 'easy'>('normal')
 
   // Cutscenes & boss dialogue
   const [cutscenePanels, setCutscenePanels]   = useState<CutscenePanel[]>([])
@@ -791,7 +794,7 @@ export default function App() {
 
   // Trigger SW update check whenever the title screen is shown
   useEffect(() => {
-    if (screen === 'title') swRegRef.current?.update()
+    if (screen === 'title') swRegRef.current?.update().catch(() => {})
   }, [screen])
 
   useMusic(screen, gameState, run)
@@ -801,6 +804,7 @@ export default function App() {
   const handlePlay = useCallback(() => {
     isCampaignRef.current = false
     isDailyChallengeRef.current = false
+    isEasyModeRef.current = quickBattleMode === 'easy'
     battleFlawlessRef.current = true
     battleUsedStructure.current = false
     battleUsedMobileUnit.current = false
@@ -817,11 +821,31 @@ export default function App() {
     // Give a handicap boost scaled to deck size: fewer cards = easier opponent
     // (maxes out at +10 for an empty deck, scales to 0 at DECK_MAX cards)
     const deckBonus = Math.round(Math.max(0, DECK_MAX - deckCount) / DECK_MAX * 10)
+
+    let gameOpts: NewGameOptions
+    if (quickBattleMode === 'easy') {
+      // Easy Mode: opponent mirrors the player's own deck; max handicap so they play slowly
+      gameOpts = {
+        playerCards,
+        opponentHandicap: MAX_HANDICAP,
+        prebuiltOpponentDeck: shuffle([...playerCards]),
+      }
+    } else {
+      // Limit opponent to cards the player actually owns (#773)
+      const ownedNames = new Set(collection.filter(e => e.count > 0).map(e => e.cardName))
+      const collectionPool = getCardCatalog().filter(c => ownedNames.has(c.name))
+      const opponentCardPool = collectionPool.length >= 20 ? collectionPool : undefined
+      gameOpts = {
+        playerCards,
+        opponentHandicap: Math.min(MAX_HANDICAP, handicap + deckBonus),
+        opponentCardPool,
+      }
+    }
     // Debatable as to whether the reducer state here should be called "START_FREE_PLAY" instead of "START"
-    dispatch({ type: 'START', gameState: newGame(playerCards, Math.min(MAX_HANDICAP, handicap + deckBonus)) })
+    dispatch({ type: 'START', gameState: newGame(gameOpts) })
     setScreen('playing') // TODO — move this into the reducer so the transition is atomic and can't be interrupted by a re-render
     rollRareEvent()
-  }, [handicap])
+  }, [handicap, quickBattleMode])
 
   const handleEndless = useCallback(() => {
     isCampaignRef.current = false
@@ -2125,7 +2149,9 @@ export default function App() {
 
   const handleOpenPack = useCallback(() => {
     packBackScreenRef.current = 'title'
-    setPack(generatePack())
+    // Easy Mode rewards only 1 card (#774)
+    const pack = generatePack()
+    setPack(isEasyModeRef.current ? pack.slice(0, 1) : pack)
     setScreen('pack')
   }, [])
 
@@ -2281,6 +2307,8 @@ export default function App() {
           <TitleScreen
             crystals={crystals}
             onPlay={handlePlay}
+            quickBattleMode={quickBattleMode}
+            onSetQuickBattleMode={setQuickBattleMode}
             onEndless={handleEndless}
             onCampaign={handleCampaign}
             onCollection={() => setScreen('collection')}

--- a/web/src/components/TitleScreen.tsx
+++ b/web/src/components/TitleScreen.tsx
@@ -24,6 +24,8 @@ function markKonamiUsed(): void   { try { localStorage.setItem(KONAMI_KEY, '1') 
 interface Props {
   crystals: number
   onPlay: () => void
+  quickBattleMode?: 'normal' | 'easy'
+  onSetQuickBattleMode?: (mode: 'normal' | 'easy') => void
   onEndless: () => void
   onCampaign: () => void
   onCollection: () => void
@@ -49,7 +51,7 @@ interface Props {
   onSignIn: () => void
 }
 
-export function TitleScreen({ crystals, onPlay, onEndless, onCampaign, onCollection, onShop, onDeckBuilder, onSettings, onInventory, onAchievements, onHeroCards, onCharacter, on8bitUnlocked, onDailyChallenge, onEndlessLeaderboard, onCommander, commanderName, onTraining, onNews, hasUnreadNews, onMiniGames, onPlayerStats, user, onSignOut, onSignIn }: Props) {
+export function TitleScreen({ crystals, onPlay, quickBattleMode = 'normal', onSetQuickBattleMode, onEndless, onCampaign, onCollection, onShop, onDeckBuilder, onSettings, onInventory, onAchievements, onHeroCards, onCharacter, on8bitUnlocked, onDailyChallenge, onEndlessLeaderboard, onCommander, commanderName, onTraining, onNews, hasUnreadNews, onMiniGames, onPlayerStats, user, onSignOut, onSignIn }: Props) {
   const deck             = loadDeck()
   const count            = deckTotalCards(deck)
   const valid            = isDeckValid(deck)
@@ -197,6 +199,23 @@ export function TitleScreen({ crystals, onPlay, onEndless, onCampaign, onCollect
         >
           {valid ? '▶  QUICK BATTLE' : `⚠ DECK (${count}/10)`}
         </TitleButton>
+
+        {valid && onSetQuickBattleMode && (
+          <div className="qb-mode-toggle" title="Easy Mode: opponent uses your deck · 1 card reward">
+            <button
+              className={`filter-btn${quickBattleMode === 'normal' ? ' filter-btn--active' : ''}`}
+              onClick={() => onSetQuickBattleMode('normal')}
+            >
+              Normal
+            </button>
+            <button
+              className={`filter-btn${quickBattleMode === 'easy' ? ' filter-btn--active' : ''}`}
+              onClick={() => onSetQuickBattleMode('easy')}
+            >
+              Easy (1 card)
+            </button>
+          </div>
+        )}
 
         <TitleButton
           onClick={onEndless}

--- a/web/src/components/minigames/FruitMachine.tsx
+++ b/web/src/components/minigames/FruitMachine.tsx
@@ -2,6 +2,11 @@
 // 3-reel slot machine. Spin costs 1 credit; hold reels between spins.
 // Cash out at any time to convert remaining credits to tickets (2 per credit).
 // Buy +5 credits for 25 crystals when running low.
+//
+// Special symbols:
+//   🃏 Wild    — substitutes for any standard symbol; triple-wild pays 40 credits
+//   🌟 Feature — accumulates toward a feature bonus; at 5 triggers: +15 credits
+//   💰 Bonus   — scatter: 2+ anywhere pays 4 credits; 3 pays 15 credits
 
 import React, { useState, useRef, useEffect } from 'react'
 import { loadCrystals, saveCrystals } from '../../game/collection'
@@ -10,14 +15,21 @@ interface Props {
   onDone: (ticketsEarned: number) => void
 }
 
-const SYMBOLS = ['🍒', '🍋', '🍊', '🍇', '⭐', '🔔', '💎']
-const WEIGHTS  = [ 30,   20,   20,   15,    8,    5,    2]  // must sum to 100
-const STARTING_CREDITS  = 10
-const BUY_COST          = 25   // crystals to buy more credits
-const BUY_AMOUNT        = 5    // credits per purchase
-const MAX_CREDITS       = 20   // cap on held credits
-const TICKETS_PER_CREDIT = 2
-const SPIN_DURATION_MS  = 1200
+const SYMBOLS = ['🍒', '🍋', '🍊', '🍇', '⭐', '🔔', '💎', '🃏', '🌟', '💰']
+const WEIGHTS  = [ 25,   17,   17,   12,    7,    5,    2,    3,    4,    8]
+
+const WILD    = '🃏'
+const FEATURE = '🌟'
+const BONUS   = '💰'
+
+const STARTING_CREDITS     = 10
+const BUY_COST             = 25   // crystals to buy more credits
+const BUY_AMOUNT           = 5    // credits per purchase
+const MAX_CREDITS          = 20   // cap on held credits
+const TICKETS_PER_CREDIT   = 2
+const SPIN_DURATION_MS     = 1200
+const FEATURE_THRESHOLD    = 5    // feature triggers needed for bonus
+const FEATURE_BONUS_CREDITS = 15  // credits awarded when feature fires
 
 function pickSymbol(): string {
   let r = Math.random() * WEIGHTS.reduce((s, w) => s + w, 0)
@@ -28,7 +40,8 @@ function pickSymbol(): string {
   return SYMBOLS[SYMBOLS.length - 1]
 }
 
-function calcPayout(s: [string, string, string]): number {
+// Base payout for a 3-symbol line — no wilds, bonus handled separately
+function calcPayoutBase(s: [string, string, string]): number {
   const [a, b, c] = s
   if (a === b && b === c) {
     if (a === '💎') return 50
@@ -46,6 +59,37 @@ function calcPayout(s: [string, string, string]): number {
   return 0
 }
 
+type WinType = 'wild' | 'bonus' | 'feature' | null
+
+function calcPayout(s: [string, string, string]): { credits: number; winType: WinType } {
+  // Scatter: 2+ Bonus symbols anywhere pay regardless of position
+  const bonusCount = s.filter(x => x === BONUS).length
+  if (bonusCount >= 2) {
+    return { credits: bonusCount === 3 ? 15 : 4, winType: 'bonus' }
+  }
+
+  const wildCount = s.filter(x => x === WILD).length
+
+  // Triple wild pays a fixed jackpot
+  if (wildCount === 3) return { credits: 40, winType: 'wild' }
+
+  if (wildCount > 0) {
+    // Substitute each Wild with the best-matching standard symbol
+    const nonWild = s.filter(x => x !== WILD && x !== FEATURE && x !== BONUS)
+    if (nonWild.length === 0) return { credits: 0, winType: null }
+    const candidates = [...new Set(nonWild)]
+    let best = 0
+    for (const sub of candidates) {
+      const subbed = s.map(x => x === WILD ? sub : x) as [string, string, string]
+      const pay = calcPayoutBase(subbed)
+      if (pay > best) best = pay
+    }
+    return { credits: best, winType: best > 0 ? 'wild' : null }
+  }
+
+  return { credits: calcPayoutBase(s), winType: null }
+}
+
 export function FruitMachine({ onDone }: Props) {
   const [reels, setReels]         = useState<[string, string, string]>(() => [pickSymbol(), pickSymbol(), pickSymbol()])
   const [display, setDisplay]     = useState<[string, string, string]>(() => [pickSymbol(), pickSymbol(), pickSymbol()])
@@ -54,11 +98,14 @@ export function FruitMachine({ onDone }: Props) {
   const [phase, setPhase]         = useState<'idle' | 'spinning' | 'done'>('idle')
   const [credits, setCredits]     = useState(STARTING_CREDITS)
   const [lastWin, setLastWin]     = useState<number | null>(null)
+  const [winLabel, setWinLabel]   = useState<string | null>(null)
   const [cashOutTickets, setCashOutTickets] = useState(0)
   const [availCrystals, setAvailCrystals]  = useState(() => loadCrystals())
+  const [featureTriggerCount, setFeatureTriggerCount] = useState(0)
 
-  const spinningRef  = useRef<[boolean, boolean, boolean]>([false, false, false])
-  const intervalRef  = useRef<ReturnType<typeof setInterval> | null>(null)
+  const spinningRef     = useRef<[boolean, boolean, boolean]>([false, false, false])
+  const intervalRef     = useRef<ReturnType<typeof setInterval> | null>(null)
+  const featureCountRef = useRef(0)  // mirrors featureTriggerCount for use inside setTimeout
 
   // Sync display with reels on first mount
   useEffect(() => {
@@ -97,6 +144,7 @@ export function FruitMachine({ onDone }: Props) {
     setPhase('spinning')
     setCredits(c => c - 1)
     setLastWin(null)
+    setWinLabel(null)
 
     // Rapidly cycle display for non-held reels
     intervalRef.current = setInterval(() => {
@@ -112,13 +160,35 @@ export function FruitMachine({ onDone }: Props) {
       if (intervalRef.current) clearInterval(intervalRef.current)
       spinningRef.current = [false, false, false]
 
-      const win = calcPayout(nextReels)
+      const { credits: win, winType } = calcPayout(nextReels)
+      const featureHits = nextReels.filter(x => x === FEATURE).length
+
+      // Compute feature bonus imperatively so we don't need current state in an updater
+      let featureBonus = 0
+      const newFeatureCount = featureCountRef.current + featureHits
+      if (featureHits > 0 && newFeatureCount >= FEATURE_THRESHOLD) {
+        featureBonus = FEATURE_BONUS_CREDITS
+        featureCountRef.current = newFeatureCount % FEATURE_THRESHOLD
+      } else {
+        featureCountRef.current = newFeatureCount
+      }
+      setFeatureTriggerCount(featureCountRef.current)
+
       setReels(nextReels)
       setDisplay(nextReels)
-      setLastWin(win)
+      setLastWin(win + featureBonus)
       setHeld([false, false, false])
       // recentlyHeld stays set — blocks those reels from being held next spin
-      setCredits(c => Math.max(0, c + win))
+      setCredits(c => Math.max(0, c + win + featureBonus))
+
+      if (featureBonus > 0) {
+        setWinLabel(`🌟 FEATURE! +${featureBonus} credits!`)
+      } else if (winType === 'wild') {
+        setWinLabel('🃏 WILD!')
+      } else if (winType === 'bonus') {
+        setWinLabel('💰 BONUS!')
+      }
+
       setPhase('idle')
     }, SPIN_DURATION_MS)
   }
@@ -170,6 +240,7 @@ export function FruitMachine({ onDone }: Props) {
 
   const isSpinning = phase === 'spinning'
   const canBuy = phase === 'idle' && credits > 0 && credits < MAX_CREDITS && availCrystals >= BUY_COST
+  const totalWin = lastWin ?? 0
 
   return (
     <div className="minigame-screen">
@@ -177,8 +248,13 @@ export function FruitMachine({ onDone }: Props) {
 
       <div className="fm-header">
         <span className="fm-credits">Credits: {credits}</span>
-        {lastWin !== null && lastWin > 0 && (
-          <span className="fm-win-flash">+{lastWin} credit{lastWin !== 1 ? 's' : ''}!</span>
+        <span className="fm-feature-counter" title="Land 🌟 symbols to fill the feature meter">
+          Feature: {featureCountRef.current}/{FEATURE_THRESHOLD} 🌟
+        </span>
+        {lastWin !== null && totalWin > 0 && (
+          <span className="fm-win-flash">
+            {winLabel ?? `+${totalWin} credit${totalWin !== 1 ? 's' : ''}!`}
+          </span>
         )}
         {lastWin === 0 && <span className="fm-no-win">No win</span>}
       </div>
@@ -239,6 +315,7 @@ export function FruitMachine({ onDone }: Props) {
         <summary>Payout table</summary>
         <table className="fm-paytable-table">
           <tbody>
+            <tr><td>🃏🃏🃏</td><td>40 credits (triple wild)</td></tr>
             <tr><td>💎💎💎</td><td>50 credits</td></tr>
             <tr><td>⭐⭐⭐</td><td>30 credits</td></tr>
             <tr><td>🔔🔔🔔</td><td>20 credits</td></tr>
@@ -247,6 +324,10 @@ export function FruitMachine({ onDone }: Props) {
             <tr><td>⭐⭐ pair</td><td>3 credits</td></tr>
             <tr><td>Any pair</td><td>2 credits</td></tr>
             <tr><td>🍒 on reel 1</td><td>1 credit</td></tr>
+            <tr><td>🃏 Wild</td><td>substitutes for any symbol</td></tr>
+            <tr><td>💰💰 Bonus</td><td>4 credits (scatter)</td></tr>
+            <tr><td>💰💰💰 Bonus</td><td>15 credits (scatter)</td></tr>
+            <tr><td>🌟 Feature ×{FEATURE_THRESHOLD}</td><td>+{FEATURE_BONUS_CREDITS} credits</td></tr>
           </tbody>
         </table>
       </details>

--- a/web/src/game/cards.ts
+++ b/web/src/game/cards.ts
@@ -114,7 +114,7 @@ function resolveCardDef(raw: RawCardDef): CardDef {
     if (!resolved) {
       const msg = `cards.json: unknown unitRef '${raw.unitRef}' for card '${raw.name}' — card will be undeployable`
       console.error('[cards]', msg)
-      // TODO: log to Rollbar so we know what units cannot be resolved 
+      // Deferred: logged to Rollbar via flushCardValidationErrors() called at newGame() time
       _pendingValidationErrors.push({ msg, ctx: { cardName: raw.name, unitRef: raw.unitRef } })
     }
     unit = resolved ? resolveUnit(resolved) : undefined

--- a/web/src/game/engine.ts
+++ b/web/src/game/engine.ts
@@ -45,8 +45,8 @@ const QUICKPLAY_MIN_UNITS    = 3
 const QUICKPLAY_MIN_LOW_COST = 3
 const QUICKPLAY_MAX_AVG_COST = 4.0
 
-function generateBalancedOpponentDeck(maxRarity: CardRarity): Card[] {
-  const catalog = getCardCatalog().filter(c => RARITY_RANK[c.rarity] <= RARITY_RANK[maxRarity])
+function generateBalancedOpponentDeck(maxRarity: CardRarity, cardPool?: Card[]): Card[] {
+  const catalog = (cardPool ?? getCardCatalog()).filter(c => RARITY_RANK[c.rarity] <= RARITY_RANK[maxRarity])
   for (let attempt = 0; attempt < 10; attempt++) {
     const pool = shuffle([...catalog])
     const seen = new Set<string>()
@@ -126,6 +126,8 @@ export interface NewGameOptions {
   bossSpawnKillPct?: number
   /** Reduce the initial opponent timer so the first card is played within ~25% of the normal interval. */
   quickStart?: boolean
+  /** Limit the opponent's card pool to these cards (Quick Battle: collection-based matching). Falls back to full catalog if pool is too small. */
+  opponentCardPool?: Card[]
 }
 
 export function newGame(
@@ -162,6 +164,7 @@ export function newGame(
     opponentIntervalMs: intervalOverride,
     opponentBaseHp: hpOverride,
     bossSpawnKillPct,
+    opponentCardPool,
   } = opts
 
   // Pre-built decks are already in seeded order — don't re-shuffle with Math.random()
@@ -187,7 +190,15 @@ export function newGame(
     }
   } else {
     const maxRarity = maxRarityForHandicap(clamp)
-    opponentDeck = generateBalancedOpponentDeck(maxRarity)
+    // If a collection-limited pool is provided and large enough, use it instead of the full catalog
+    const MIN_POOL_SIZE = 20
+    if (opponentCardPool && opponentCardPool.length >= MIN_POOL_SIZE) {
+      const filtered = opponentCardPool.filter(c => RARITY_RANK[c.rarity] <= RARITY_RANK[maxRarity])
+      const pool = filtered.length >= MIN_POOL_SIZE ? filtered : opponentCardPool
+      opponentDeck = generateBalancedOpponentDeck(maxRarity, pool)
+    } else {
+      opponentDeck = generateBalancedOpponentDeck(maxRarity)
+    }
   }
 
   // Inject one hero card per side (not for bosses — they have their own identity)

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1310,6 +1310,13 @@ body {
   border-color: rgba(51, 255, 51, 0.65) !important;
 }
 
+.qb-mode-toggle {
+  display: flex;
+  gap: 6px;
+  justify-content: center;
+  margin-top: -6px;
+}
+
 /* Secondary nav section: bordered panel with floating label */
 .title-nav-section {
   position: relative;
@@ -9606,6 +9613,12 @@ html.light-mode .action-btn {
   font-size: 15px;
   font-weight: bold;
   color: #ffd700;
+}
+
+.fm-feature-counter {
+  font-size: 13px;
+  color: #aaddff;
+  opacity: 0.85;
 }
 
 .fm-win-flash {


### PR DESCRIPTION
## Summary

- **fix #742** — `InvalidStateError: newestWorker is null`: add `.catch(() => {})` to the Service Worker update call on title screen, matching the same guard already used at registration time
- **fix #758** — Log unresolvable units to Rollbar: stale TODO removed; the deferred-logging path (`_pendingValidationErrors` → `flushCardValidationErrors()` → `logError()`) was already correctly wired in `newGame()` — no code change needed beyond cleaning up the comment
- **feat #773** — Quick Battle: opponent deck limited to player's collection: `generateBalancedOpponentDeck` now accepts an optional `cardPool`; `handlePlay` builds a pool of owned cards and passes it via the new `opponentCardPool` field in `NewGameOptions`; falls back to the full catalog if the player owns fewer than 20 cards
- **feat #774** — Quick Battle Easy Mode: Normal/Easy toggle appears below the Quick Battle button; Easy Mode uses the player's own deck as the opponent (shuffled, max handicap) and rewards only 1 card on win
- **feat #779** — Fruit machine special symbols: adds Wild 🃏 (substitutes any standard symbol; triple wild = 40 credits), Feature Trigger 🌟 (accumulates — every 5 triggers awards 15 bonus credits, shown as a meter), and Bonus 💰 (scatter: 2+ pays 4 credits, 3 pays 15); win labels distinguish WILD/BONUS/FEATURE wins

## Test plan

- [ ] Navigate to title screen repeatedly — no `InvalidStateError` in console or Rollbar
- [ ] Start a Quick Battle (Normal) with a small collection — confirm opponent only plays owned cards in battle log
- [ ] Toggle to Easy Mode on title screen — start battle, confirm opponent plays cards from your deck; win and confirm pack shows exactly 1 card
- [ ] Open Fruit Machine — spin until 🃏/🌟/💰 appear; verify WILD pays via substitution, 2+ 💰 pays scatter, feature meter increments on 🌟 and fires bonus at 5
- [ ] Full build passes: `npm run build` ✓

https://claude.ai/code/session_01Vj6zv4phhoXWU9WKxt79gp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vj6zv4phhoXWU9WKxt79gp)_