### PR TITLE
High priority issues: bugs, fruit machine specials, QB collection limit, difficulty screen

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -44,6 +44,7 @@ import { BossDialogueScreen }   from './components/BossDialogueScreen'
 import { Battlefield }        from './components/Battlefield'
 import { GameOver }           from './components/GameOver'
 import { TitleScreen }        from './components/TitleScreen'
+import { QuickBattleScreen }  from './components/QuickBattleScreen'
 import { CollectionScreen }   from './components/CollectionScreen'
 import { DeckBuilder }        from './components/DeckBuilder'
 import { PackOpening }        from './components/PackOpening'
@@ -262,6 +263,7 @@ type Screen =
   | 'campaignAdmin'
   | 'minigames'
   | 'playerstats'
+  | 'quickbattle'
   | 'statupgrade'
   | 'camp'
 
@@ -381,7 +383,6 @@ export default function App() {
   const isDailyChallengeRef = useRef(false)                  // true while playing the daily challenge
   const isTrainingModeRef   = useRef(false)                  // true while playing a training battle
   const isEasyModeRef       = useRef(false)                  // true when Quick Battle Easy Mode is active
-  const [quickBattleMode, setQuickBattleMode] = useState<'normal' | 'easy'>('normal')
 
   // Cutscenes & boss dialogue
   const [cutscenePanels, setCutscenePanels]   = useState<CutscenePanel[]>([])
@@ -802,10 +803,10 @@ export default function App() {
 
   // ── Free play ────────────────────────────────────────────
 
-  const handlePlay = useCallback(() => {
+  const handlePlay = useCallback((mode: 'normal' | 'easy') => {
     isCampaignRef.current = false
     isDailyChallengeRef.current = false
-    isEasyModeRef.current = quickBattleMode === 'easy'
+    isEasyModeRef.current = mode === 'easy'
     battleFlawlessRef.current = true
     battleUsedStructure.current = false
     battleUsedMobileUnit.current = false
@@ -824,7 +825,7 @@ export default function App() {
     const deckBonus = Math.round(Math.max(0, DECK_MAX - deckCount) / DECK_MAX * 10)
 
     let gameOpts: NewGameOptions
-    if (quickBattleMode === 'easy') {
+    if (mode === 'easy') {
       // Easy Mode: opponent mirrors the player's own deck; max handicap so they play slowly
       gameOpts = {
         playerCards,
@@ -846,7 +847,7 @@ export default function App() {
     dispatch({ type: 'START', gameState: newGame(gameOpts) })
     setScreen('playing') // TODO — move this into the reducer so the transition is atomic and can't be interrupted by a re-render
     rollRareEvent()
-  }, [handicap, quickBattleMode])
+  }, [handicap])
 
   const handleEndless = useCallback(() => {
     isCampaignRef.current = false
@@ -2307,9 +2308,7 @@ export default function App() {
         <>
           <TitleScreen
             crystals={crystals}
-            onPlay={handlePlay}
-            quickBattleMode={quickBattleMode}
-            onSetQuickBattleMode={setQuickBattleMode}
+            onPlay={() => setScreen('quickbattle')}
             onEndless={handleEndless}
             onCampaign={handleCampaign}
             onCollection={() => setScreen('collection')}
@@ -2639,6 +2638,10 @@ export default function App() {
 
       {screen === 'campaignfailed' && (
         <CampaignFailedScreen onReturnToMenu={() => { stopBattleMusic(); stopGameOverMusic(); setScreen('title') }} />
+      )}
+
+      {screen === 'quickbattle' && (
+        <QuickBattleScreen onStartBattle={handlePlay} onBack={() => setScreen('title')} />
       )}
 
       {screen === 'dailychallenge' && (

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -427,6 +427,7 @@ export default function App() {
   const [timeCapsuleVisible, setTimeCapsuleVisible] = useState(false)
   // Secret 10 — 100 Wins Celebration
   const [showWinCelebration, setShowWinCelebration] = useState(false)
+  const [celebrationMilestone, setCelebrationMilestone] = useState(100)
   const campaignPlayCountsRef = useRef<Record<string, number>>({})  // per-battle play tracking
   const gameStateRef = useRef<GameState | null>(null)  // always-current snapshot for callbacks
 
@@ -2017,8 +2018,7 @@ export default function App() {
     if (timeCapsuleCheckedRef.current) return
     timeCapsuleCheckedRef.current = true
     const count = incrementBattleCount()
-    // TODO: make this on any multiple of 100, not just the first 100
-    if (count === 100) setTimeCapsuleVisible(true)
+    if (count > 0 && count % 100 === 0) setTimeCapsuleVisible(true)
   }, [screen])
 
   // Track card play types for per-battle misc achievements
@@ -2110,11 +2110,12 @@ export default function App() {
     }
     if (toasts.length > 0) setAchievementToasts(prev => [...prev, ...toasts])
 
-    // Secret 10 — 100 Wins Celebration
+    // Secret 10 — Wins Celebration: fires at every 100-win milestone, scales with tier
     const totalWins = incrementTotalWins()
-    if (totalWins === 100) setShowWinCelebration(true)
-    // TODO: Celebrate a win every 100 wins, make the animation bigger for each milestone! Grant a special reward at 1000 wins? Grant Rewards every 100 wins?
-    if (totalWins === 1000) setShowWinCelebration(true)
+    if (totalWins > 0 && totalWins % 100 === 0) {
+      setCelebrationMilestone(totalWins)
+      setShowWinCelebration(true)
+    }
     
   }, [gameState?.phase.type])
 
@@ -2873,37 +2874,70 @@ export default function App() {
         />
       )}
 
-      {/* Secret 10 — 100 Wins Celebration */}
-      {showWinCelebration && (
-        <div className="win-celebration-backdrop">
-          <div className="win-celebration-modal">
-            <div className="win-celebration-confetti" aria-hidden="true">
-              {Array.from({ length: 30 }, (_, i) => (
-                <span key={i} className="confetti-char" style={{ '--i': i } as React.CSSProperties}>
-                  {['★', '✦', '◆', '▲', '●', '✿'][i % 6]}
-                </span>
-              ))}
+      {/* Secret 10 — Wins Milestone Celebration */}
+      {showWinCelebration && (() => {
+        const isGrand = celebrationMilestone % 1000 === 0
+        const isMajor = !isGrand && celebrationMilestone % 500 === 0
+        const tier = isGrand ? 'grand' : isMajor ? 'major' : 'standard'
+        const confettiCount = isGrand ? 60 : isMajor ? 45 : 30
+        const crystalBonus = isGrand ? 100 : isMajor ? 50 : 0
+        const legendaryCount = isGrand ? 2 : 1
+        const modalClass = `win-celebration-modal${isGrand ? ' win-celebration-modal--grand' : isMajor ? ' win-celebration-modal--major' : ''}`
+        return (
+          <div className="win-celebration-backdrop">
+            <div className={modalClass}>
+              <div className="win-celebration-confetti" aria-hidden="true">
+                {Array.from({ length: confettiCount }, (_, i) => (
+                  <span key={i} className="confetti-char" style={{ '--i': i } as React.CSSProperties}>
+                    {['★', '✦', '◆', '▲', '●', '✿'][i % 6]}
+                  </span>
+                ))}
+              </div>
+              <div className="win-celebration-header">
+                🎉 {celebrationMilestone.toLocaleString()} VICTORIES! 🎉
+              </div>
+              <div className="win-celebration-body">
+                {isGrand ? (
+                  <>
+                    <p>{celebrationMilestone.toLocaleString()} battles won. A true legend.</p>
+                    <p>The world bows. History remembers.</p>
+                    <p>You have earned {legendaryCount} legendary cards and {crystalBonus} 💎.</p>
+                  </>
+                ) : isMajor ? (
+                  <>
+                    <p>{celebrationMilestone.toLocaleString()} battles won. An epic achievement.</p>
+                    <p>The enemy despairs. The chronicles take note.</p>
+                    <p>You have earned a legendary card and {crystalBonus} 💎.</p>
+                  </>
+                ) : (
+                  <>
+                    <p>{celebrationMilestone.toLocaleString()} battles won.</p>
+                    <p>The enemy trembles. The game developers are impressed.</p>
+                    <p>You have earned a legendary card.</p>
+                  </>
+                )}
+              </div>
+              <button className="action-btn" onClick={() => {
+                const pool = getCardCatalog().filter(c => c.rarity === 'legendary')
+                if (pool.length > 0) {
+                  const picks = Array.from({ length: legendaryCount }, () =>
+                    ({ cardName: pool[Math.floor(Math.random() * pool.length)].name, count: 1 })
+                  )
+                  addCardsToCollection(picks)
+                }
+                if (crystalBonus > 0) {
+                  const next = loadCrystals() + crystalBonus
+                  saveCrystals(next)
+                  setCrystals(next)
+                }
+                setShowWinCelebration(false)
+              }}>
+                {tier === 'grand' ? 'CLAIM GRAND REWARD' : tier === 'major' ? 'CLAIM EPIC REWARD' : 'CLAIM REWARD'}
+              </button>
             </div>
-            <div className="win-celebration-header">🎉 100 VICTORIES! 🎉</div>
-            <div className="win-celebration-body">
-              <p>One hundred battles won.</p>
-              <p>The enemy trembles. The game developers are impressed.</p>
-              <p>You have earned a legendary card.</p>
-            </div>
-            <button className="action-btn" onClick={() => {
-              const catalog = getCardCatalog()
-              const pool = catalog.filter(c => c.rarity === 'legendary')
-              if (pool.length > 0) {
-                const card = pool[Math.floor(Math.random() * pool.length)]
-                addCardsToCollection([{ cardName: card.name, count: 1 }])
-              }
-              setShowWinCelebration(false)
-            }}>
-              CLAIM REWARD
-            </button>
           </div>
-        </div>
-      )}
+        )
+      })()}
 
       {/* Secret 5 — Time Capsule: 100th battle milestone overlay */}
       {timeCapsuleVisible && (

--- a/web/src/components/QuickBattleScreen.tsx
+++ b/web/src/components/QuickBattleScreen.tsx
@@ -1,0 +1,43 @@
+import React from 'react'
+
+interface Props {
+  onStartBattle: (mode: 'normal' | 'easy') => void
+  onBack: () => void
+}
+
+export function QuickBattleScreen({ onStartBattle, onBack }: Props) {
+  return (
+    <div className="qb-screen">
+      <div className="qb-header">
+        <div className="qb-title">⚔  QUICK BATTLE</div>
+        <div className="qb-subtitle">Choose your difficulty</div>
+      </div>
+
+      <div className="qb-options">
+        <div className="qb-option">
+          <div className="qb-option-name">Normal</div>
+          <div className="qb-option-desc">
+            <p>Opponent builds their deck from cards you own.</p>
+            <p>Reward: standard card pack (5 cards).</p>
+          </div>
+          <button className="action-btn action-btn--large" onClick={() => onStartBattle('normal')}>
+            ▶  PLAY NORMAL
+          </button>
+        </div>
+
+        <div className="qb-option qb-option--easy">
+          <div className="qb-option-name">Easy</div>
+          <div className="qb-option-desc">
+            <p>Opponent uses a copy of your own deck.</p>
+            <p>Reward: 1 card.</p>
+          </div>
+          <button className="action-btn" onClick={() => onStartBattle('easy')}>
+            ▶  PLAY EASY
+          </button>
+        </div>
+      </div>
+
+      <button className="action-btn action-btn--danger" onClick={onBack}>← BACK</button>
+    </div>
+  )
+}

--- a/web/src/components/TitleScreen.tsx
+++ b/web/src/components/TitleScreen.tsx
@@ -24,8 +24,6 @@ function markKonamiUsed(): void   { try { localStorage.setItem(KONAMI_KEY, '1') 
 interface Props {
   crystals: number
   onPlay: () => void
-  quickBattleMode?: 'normal' | 'easy'
-  onSetQuickBattleMode?: (mode: 'normal' | 'easy') => void
   onEndless: () => void
   onCampaign: () => void
   onCollection: () => void
@@ -51,7 +49,7 @@ interface Props {
   onSignIn: () => void
 }
 
-export function TitleScreen({ crystals, onPlay, quickBattleMode = 'normal', onSetQuickBattleMode, onEndless, onCampaign, onCollection, onShop, onDeckBuilder, onSettings, onInventory, onAchievements, onHeroCards, onCharacter, on8bitUnlocked, onDailyChallenge, onEndlessLeaderboard, onCommander, commanderName, onTraining, onNews, hasUnreadNews, onMiniGames, onPlayerStats, user, onSignOut, onSignIn }: Props) {
+export function TitleScreen({ crystals, onPlay, onEndless, onCampaign, onCollection, onShop, onDeckBuilder, onSettings, onInventory, onAchievements, onHeroCards, onCharacter, on8bitUnlocked, onDailyChallenge, onEndlessLeaderboard, onCommander, commanderName, onTraining, onNews, hasUnreadNews, onMiniGames, onPlayerStats, user, onSignOut, onSignIn }: Props) {
   const deck             = loadDeck()
   const count            = deckTotalCards(deck)
   const valid            = isDeckValid(deck)
@@ -199,23 +197,6 @@ export function TitleScreen({ crystals, onPlay, quickBattleMode = 'normal', onSe
         >
           {valid ? '▶  QUICK BATTLE' : `⚠ DECK (${count}/10)`}
         </TitleButton>
-
-        {valid && onSetQuickBattleMode && (
-          <div className="qb-mode-toggle" title="Easy Mode: opponent uses your deck · 1 card reward">
-            <button
-              className={`filter-btn${quickBattleMode === 'normal' ? ' filter-btn--active' : ''}`}
-              onClick={() => onSetQuickBattleMode('normal')}
-            >
-              Normal
-            </button>
-            <button
-              className={`filter-btn${quickBattleMode === 'easy' ? ' filter-btn--active' : ''}`}
-              onClick={() => onSetQuickBattleMode('easy')}
-            >
-              Easy (1 card)
-            </button>
-          </div>
-        )}
 
         <TitleButton
           onClick={onEndless}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1310,13 +1310,6 @@ body {
   border-color: rgba(51, 255, 51, 0.65) !important;
 }
 
-.qb-mode-toggle {
-  display: flex;
-  gap: 6px;
-  justify-content: center;
-  margin-top: -6px;
-}
-
 /* Secondary nav section: bordered panel with floating label */
 .title-nav-section {
   position: relative;
@@ -7297,6 +7290,41 @@ html.eightbit-mode .lane-layer {
   max-width: 260px;
   margin-top: 4px;
 }
+
+/* ── Quick Battle Screen ────────────────────────────────────────────────── */
+
+.qb-screen {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 18px;
+  padding: 24px 16px;
+  max-width: 440px;
+  margin: 0 auto;
+  font-family: var(--game-font);
+  color: var(--game-text-color);
+}
+.qb-header { text-align: center; }
+.qb-title { font-size: 20px; font-weight: bold; letter-spacing: 2px; }
+.qb-subtitle { font-size: 12px; color: var(--game-text-color-dim); margin-top: 4px; }
+.qb-options {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  width: 100%;
+}
+.qb-option {
+  border: 1px solid rgba(51,255,51,0.25);
+  border-radius: 6px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.qb-option--easy { border-color: rgba(51,255,51,0.15); opacity: 0.9; }
+.qb-option-name { font-size: 15px; font-weight: bold; letter-spacing: 1px; }
+.qb-option-desc { font-size: 12px; line-height: 1.6; color: var(--game-text-color-dim); }
+.qb-option-desc p { margin: 0; }
 
 /* ── Endless Leaderboard Screen ─────────────────────────────────────────── */
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -8489,6 +8489,22 @@ html.light-mode .action-btn {
   color: #eee;
   overflow: hidden;
 }
+.win-celebration-modal--major {
+  border-color: #55ddaa;
+  box-shadow: 0 0 24px rgba(85, 221, 170, 0.35);
+}
+.win-celebration-modal--grand {
+  border-color: #ffd700;
+  box-shadow: 0 0 36px rgba(255, 215, 0, 0.45);
+}
+.win-celebration-modal--grand .win-celebration-header {
+  color: #ffd700;
+  font-size: 1.4rem;
+}
+.win-celebration-modal--major .win-celebration-header {
+  color: #55ddaa;
+  font-size: 1.3rem;
+}
 .win-celebration-header {
   font-size: 1.2rem;
   letter-spacing: 0.1em;


### PR DESCRIPTION
## Summary

- **Bug #742** — Suppress `InvalidStateError` from `swRegRef.current?.update()` when service worker `newestWorker` is null (add `.catch(() => {})`)
- **Bug #758** — Remove stale Rollbar TODO in `cards.ts`; the deferred-logging mechanism was already complete
- **Feature #779** — Fruit machine: add Wild 🃏 (substitution), Feature Trigger 🌟 (meter toward bonus), and Bonus 💰 (scatter) symbols with corresponding payout logic and UI
- **Feature #773** — Quick Battle: opponent deck is now built only from cards the player owns (falls back to full catalog if collection < 20 cards)
- **Feature #774 / UX** — Quick Battle difficulty selection: replaced inline Normal/Easy toggle on the title screen with a dedicated `QuickBattleScreen` shown when tapping QUICK BATTLE, matching the UX pattern of Daily Challenge and Training Mode

## Test plan

- [ ] Navigate to title screen; confirm no `InvalidStateError` in console
- [ ] Open Fruit Machine; verify 🃏/🌟/💰 symbols appear, Wild substitution pays correctly, 2+ 💰 pays scatter prize, feature meter increments on 🌟
- [ ] Start Quick Battle with a small collection; confirm opponent only plays owned cards
- [ ] Tap QUICK BATTLE on title screen → QuickBattleScreen appears with Normal/Easy options
- [ ] Choose Normal → battle starts with standard opponent pool; win gives 5-card pack
- [ ] Choose Easy → battle starts with mirrored deck; win gives 1 card
- [ ] Back button returns to title screen without starting a battle

https://claude.ai/code/session_01Vj6zv4phhoXWU9WKxt79gp