### PR TITLE
Fruit machine: feature board, holds/nudges/bonus game, jackpot system (#781–783)

### DIFF
--- a/web/src/components/minigames/FruitMachine.tsx
+++ b/web/src/components/minigames/FruitMachine.tsx
@@ -67,6 +67,13 @@ const BOARD_NODES: BoardNode[] = [
 
 const BOARD_SIZE = BOARD_NODES.length
 
+// Reel strip — fixed sequence for nudge up/down support
+const REEL_STRIP = [
+  '🍒','🍋','🍊','🍇','⭐','🔔','💎','🃏','🌟','💰',
+  '🍒','🍋','🍊','🍇','⭐','🔔','💎','🍒','🌟','💰',
+  '🍒','🍋','🍊','🍇','⭐','🔔','💎','🃏','🍒','💰',
+]
+
 function pickSymbol(): string {
   let r = Math.random() * WEIGHTS.reduce((s, w) => s + w, 0)
   for (let i = 0; i < SYMBOLS.length; i++) {
@@ -74,6 +81,10 @@ function pickSymbol(): string {
     if (r <= 0) return SYMBOLS[i]
   }
   return SYMBOLS[SYMBOLS.length - 1]
+}
+
+function pickReelPos(): number {
+  return Math.floor(Math.random() * REEL_STRIP.length)
 }
 
 // Base payout for a 3-symbol line — no wilds, bonus handled separately
@@ -148,8 +159,10 @@ export function FruitMachine({ onDone }: Props) {
   const [boardMult, setBoardMult]   = useState<number>(() => {
     try { return parseInt(localStorage.getItem('fm_board_mult') ?? '1', 10) } catch { return 1 }
   })
-  const [boardMessage, setBoardMessage] = useState<string | null>(null)
-  const [freeSpin, setFreeSpin]         = useState(false)
+  const [boardMessage, setBoardMessage]     = useState<string | null>(null)
+  const [freeSpin, setFreeSpin]             = useState(false)
+  const [nudgesAvailable, setNudgesAvailable] = useState(0)
+  const [reelPositions, setReelPositions]   = useState<[number, number, number]>([0, 3, 6])
 
   const spinningRef     = useRef<[boolean, boolean, boolean]>([false, false, false])
   const intervalRef     = useRef<ReturnType<typeof setInterval> | null>(null)
@@ -205,6 +218,7 @@ export function FruitMachine({ onDone }: Props) {
       }
       case 'nudge':
         pendingBoardNodeRef.current = node
+        setNudgesAvailable(node.value ?? 1)
         setPhase('nudge')
         break
       case 'bonus-game':
@@ -254,14 +268,50 @@ export function FruitMachine({ onDone }: Props) {
     setTimeout(stepOnce, 400)
   }
 
+  function nudgeReel(i: 0 | 1 | 2, dir: 1 | -1) {
+    if (nudgesAvailable <= 0) return
+    setReelPositions(prev => {
+      const next = [...prev] as [number, number, number]
+      next[i] = ((next[i] + dir) + REEL_STRIP.length) % REEL_STRIP.length
+      return next
+    })
+    setNudgesAvailable(n => n - 1)
+  }
+
+  function finishNudge() {
+    const nudgedReels: [string, string, string] = [
+      REEL_STRIP[reelPositions[0]],
+      REEL_STRIP[reelPositions[1]],
+      REEL_STRIP[reelPositions[2]],
+    ]
+    setReels(nudgedReels)
+    setDisplay(nudgedReels)
+    const { credits: win, winType } = calcPayout(nudgedReels)
+    if (win > 0) {
+      setLastWin(win)
+      setCredits(c => Math.max(0, c + win))
+      if (winType === 'wild') setWinLabel('🃏 WILD! (nudge)')
+      else if (winType === 'bonus') setWinLabel('💰 BONUS! (nudge)')
+      else setWinLabel(`+${win} credits! (nudge)`)
+    }
+    setNudgesAvailable(0)
+    setPhase('idle')
+  }
+
   function spin() {
     if (phase !== 'idle' || (credits < 1 && !freeSpin)) return
 
-    const nextReels: [string, string, string] = [
-      held[0] ? reels[0] : pickSymbol(),
-      held[1] ? reels[1] : pickSymbol(),
-      held[2] ? reels[2] : pickSymbol(),
+    const nextPositions: [number, number, number] = [
+      held[0] ? reelPositions[0] : pickReelPos(),
+      held[1] ? reelPositions[1] : pickReelPos(),
+      held[2] ? reelPositions[2] : pickReelPos(),
     ]
+    const nextReels: [string, string, string] = [
+      REEL_STRIP[nextPositions[0]],
+      REEL_STRIP[nextPositions[1]],
+      REEL_STRIP[nextPositions[2]],
+    ]
+    setReelPositions(nextPositions)
     spinningRef.current = [!held[0], !held[1], !held[2]]
     setRecentlyHeld([...held] as [boolean, boolean, boolean])
 
@@ -376,6 +426,42 @@ export function FruitMachine({ onDone }: Props) {
     saveCrystals(availCrystals - BUY_COST)
     setAvailCrystals(c => c - BUY_COST)
     setCredits(c => Math.min(MAX_CREDITS, c + BUY_AMOUNT))
+  }
+
+  // ── Nudge screen ─────────────────────────────────────────────────────────────
+
+  if (phase === 'nudge') {
+    const nudgeReels: [string, string, string] = [
+      REEL_STRIP[reelPositions[0]],
+      REEL_STRIP[reelPositions[1]],
+      REEL_STRIP[reelPositions[2]],
+    ]
+    return (
+      <div className="minigame-screen">
+        <div className="minigame-title">🎰 FRUIT MACHINE</div>
+        <div className="fm-nudge-ui">
+          <div className="fm-nudge-header">NUDGE — {nudgesAvailable} remaining</div>
+          <div className="fm-reels">
+            {([0, 1, 2] as const).map(i => (
+              <div key={i} className="fm-reel">
+                <div className="fm-symbol">{nudgeReels[i]}</div>
+              </div>
+            ))}
+          </div>
+          <div className="fm-nudge-controls">
+            {([0, 1, 2] as const).map(i => (
+              <div key={i} className="fm-nudge-reel">
+                <button className="fm-nudge-btn" onClick={() => nudgeReel(i, -1)} disabled={nudgesAvailable <= 0}>▲</button>
+                <button className="fm-nudge-btn" onClick={() => nudgeReel(i, 1)} disabled={nudgesAvailable <= 0}>▼</button>
+              </div>
+            ))}
+          </div>
+          <button className="action-btn action-btn--gold" onClick={finishNudge}>
+            DONE
+          </button>
+        </div>
+      </div>
+    )
   }
 
   // ── Jackpot win screen ────────────────────────────────────────────────────────

--- a/web/src/components/minigames/FruitMachine.tsx
+++ b/web/src/components/minigames/FruitMachine.tsx
@@ -39,6 +39,34 @@ const JACKPOT_TIERS = [
   { name: 'Grand', credits: 0,   progressive: true,  base: 500 },
 ] as const
 
+type BoardNodeType = 'credit' | 'multiplier' | 'extra-spin' | 'nudge' | 'bonus-game' | 'jackpot-mini' | 'jackpot-major' | 'jackpot-grand'
+interface BoardNode { type: BoardNodeType; label: string; value?: number }
+
+const BOARD_NODES: BoardNode[] = [
+  { type: 'credit',       label: '+5cr',    value: 5   },
+  { type: 'extra-spin',   label: 'FREE'              },
+  { type: 'multiplier',   label: '×2',      value: 2   },
+  { type: 'credit',       label: '+8cr',    value: 8   },
+  { type: 'nudge',        label: 'NUDGE',   value: 1   },
+  { type: 'credit',       label: '+3cr',    value: 3   },
+  { type: 'jackpot-mini', label: 'MINI 💰'            },
+  { type: 'credit',       label: '+10cr',   value: 10  },
+  { type: 'multiplier',   label: '×3',      value: 3   },
+  { type: 'extra-spin',   label: 'FREE'              },
+  { type: 'credit',       label: '+5cr',    value: 5   },
+  { type: 'bonus-game',   label: 'BONUS'             },
+  { type: 'credit',       label: '+12cr',   value: 12  },
+  { type: 'nudge',        label: 'NUDGE×2', value: 2   },
+  { type: 'multiplier',   label: '×2',      value: 2   },
+  { type: 'credit',       label: '+6cr',    value: 6   },
+  { type: 'jackpot-major',label: 'MAJOR 🏆'           },
+  { type: 'extra-spin',   label: 'FREE'              },
+  { type: 'credit',       label: '+15cr',   value: 15  },
+  { type: 'jackpot-grand',label: 'GRAND ⭐'           },
+]
+
+const BOARD_SIZE = BOARD_NODES.length
+
 function pickSymbol(): string {
   let r = Math.random() * WEIGHTS.reduce((s, w) => s + w, 0)
   for (let i = 0; i < SYMBOLS.length; i++) {
@@ -114,11 +142,22 @@ export function FruitMachine({ onDone }: Props) {
     try { return parseInt(localStorage.getItem('fm_grand') ?? '500', 10) } catch { return 500 }
   })
   const [jackpotWon, setJackpotWon] = useState<{ tier: string; amount: number } | null>(null)
+  const [boardPos, setBoardPos]     = useState<number>(() => {
+    try { return parseInt(localStorage.getItem('fm_board_pos') ?? '0', 10) } catch { return 0 }
+  })
+  const [boardMult, setBoardMult]   = useState<number>(() => {
+    try { return parseInt(localStorage.getItem('fm_board_mult') ?? '1', 10) } catch { return 1 }
+  })
+  const [boardMessage, setBoardMessage] = useState<string | null>(null)
+  const [freeSpin, setFreeSpin]         = useState(false)
 
   const spinningRef     = useRef<[boolean, boolean, boolean]>([false, false, false])
   const intervalRef     = useRef<ReturnType<typeof setInterval> | null>(null)
   const featureCountRef = useRef(0)  // mirrors featureTriggerCount for use inside setTimeout
   const grandJackpotRef = useRef(grandJackpot)
+  const boardPosRef     = useRef(boardPos)
+  const boardMultRef    = useRef(boardMult)
+  const pendingBoardNodeRef = useRef<BoardNode | null>(null)
 
   // Sync display with reels on first mount
   useEffect(() => {
@@ -143,8 +182,80 @@ export function FruitMachine({ onDone }: Props) {
     })
   }
 
+  function resolveBoardNode(node: BoardNode) {
+    switch (node.type) {
+      case 'credit':
+        setCredits(c => c + (node.value ?? 0))
+        setBoardMessage(`+${node.value} credits!`)
+        setPhase('idle')
+        break
+      case 'extra-spin':
+        setFreeSpin(true)
+        setBoardMessage('Free spin!')
+        setPhase('idle')
+        break
+      case 'multiplier': {
+        const m = node.value ?? 2
+        boardMultRef.current = m
+        setBoardMult(m)
+        try { localStorage.setItem('fm_board_mult', String(m)) } catch (e) { logError('fm_board_mult', { error: String(e) }) }
+        setBoardMessage(`×${m} multiplier active!`)
+        setPhase('idle')
+        break
+      }
+      case 'nudge':
+        pendingBoardNodeRef.current = node
+        setPhase('nudge')
+        break
+      case 'bonus-game':
+        pendingBoardNodeRef.current = node
+        setPhase('bonus')
+        break
+      case 'jackpot-mini':
+        setCredits(c => c + JACKPOT_TIERS[0].credits)
+        setJackpotWon({ tier: 'Mini', amount: JACKPOT_TIERS[0].credits })
+        setPhase('jackpot-win')
+        break
+      case 'jackpot-major':
+        setCredits(c => c + JACKPOT_TIERS[2].credits)
+        setJackpotWon({ tier: 'Major', amount: JACKPOT_TIERS[2].credits })
+        setPhase('jackpot-win')
+        break
+      case 'jackpot-grand': {
+        const amount = grandJackpotRef.current
+        const resetVal = JACKPOT_TIERS[3].base
+        grandJackpotRef.current = resetVal
+        setGrandJackpot(resetVal)
+        try { localStorage.setItem('fm_grand', String(resetVal)) } catch (e) { logError('fm_grand reset', { error: String(e) }) }
+        setCredits(c => c + amount)
+        setJackpotWon({ tier: 'Grand', amount })
+        setPhase('jackpot-win')
+        break
+      }
+    }
+  }
+
+  function advanceBoardBy(steps: number) {
+    if (steps <= 0) { setPhase('idle'); return }
+    setPhase('board-moving')
+    let stepsLeft = steps
+    function stepOnce() {
+      const newPos = (boardPosRef.current + 1) % BOARD_SIZE
+      boardPosRef.current = newPos
+      setBoardPos(newPos)
+      try { localStorage.setItem('fm_board_pos', String(newPos)) } catch (e) { logError('fm_board_pos', { error: String(e) }) }
+      stepsLeft--
+      if (stepsLeft > 0) {
+        setTimeout(stepOnce, 400)
+      } else {
+        resolveBoardNode(BOARD_NODES[newPos])
+      }
+    }
+    setTimeout(stepOnce, 400)
+  }
+
   function spin() {
-    if (phase !== 'idle' || credits < 1) return
+    if (phase !== 'idle' || (credits < 1 && !freeSpin)) return
 
     const nextReels: [string, string, string] = [
       held[0] ? reels[0] : pickSymbol(),
@@ -164,9 +275,12 @@ export function FruitMachine({ onDone }: Props) {
     const isTripleStar = nextReels[0] === '⭐' && nextReels[1] === '⭐' && nextReels[2] === '⭐'
 
     setPhase('spinning')
-    setCredits(c => c - 1)
+    const spinCost = freeSpin ? 0 : 1
+    setFreeSpin(false)
+    setCredits(c => c - spinCost)
     setLastWin(null)
     setWinLabel(null)
+    setBoardMessage(null)
 
     // Rapidly cycle display for non-held reels
     intervalRef.current = setInterval(() => {
@@ -213,19 +327,35 @@ export function FruitMachine({ onDone }: Props) {
       }
       setFeatureTriggerCount(featureCountRef.current)
 
-      setLastWin(win + featureBonus)
-      // recentlyHeld stays set — blocks those reels from being held next spin
-      setCredits(c => Math.max(0, c + win + featureBonus))
-
-      if (featureBonus > 0) {
-        setWinLabel(`🌟 FEATURE! +${featureBonus} credits!`)
-      } else if (winType === 'wild') {
-        setWinLabel('🃏 WILD!')
-      } else if (winType === 'bonus') {
-        setWinLabel('💰 BONUS!')
+      // Apply board multiplier
+      const mult = boardMultRef.current
+      const totalWin = (win + featureBonus) * mult
+      if (mult > 1) {
+        boardMultRef.current = 1
+        setBoardMult(1)
+        try { localStorage.setItem('fm_board_mult', '1') } catch (e) { logError('fm_board_mult reset', { error: String(e) }) }
       }
 
-      setPhase('idle')
+      setLastWin(totalWin)
+      // recentlyHeld stays set — blocks those reels from being held next spin
+      setCredits(c => Math.max(0, c + totalWin))
+
+      if (featureBonus > 0) {
+        setWinLabel(`🌟 FEATURE!${mult > 1 ? ` ×${mult}` : ''} +${totalWin} credits!`)
+      } else if (winType === 'wild') {
+        setWinLabel(`🃏 WILD!${mult > 1 ? ` ×${mult}` : ''}`)
+      } else if (winType === 'bonus') {
+        setWinLabel('💰 BONUS!')
+      } else if (mult > 1 && totalWin > 0) {
+        setWinLabel(`×${mult} MULTIPLIER! +${totalWin} credits!`)
+      }
+
+      // Board advancement triggers
+      const hasTriple = nextReels[0] === nextReels[1] && nextReels[1] === nextReels[2]
+      const bellHits = nextReels.filter(r => r === '🔔').length
+      const boardSteps = bellHits + (featureBonus > 0 ? 2 : 0) + (hasTriple ? 1 : 0)
+
+      advanceBoardBy(boardSteps)
     }, SPIN_DURATION_MS)
   }
 
@@ -297,8 +427,16 @@ export function FruitMachine({ onDone }: Props) {
   // ── Playing screen ────────────────────────────────────────────────────────────
 
   const isSpinning = phase === 'spinning'
+  const isBusy = phase !== 'idle'
+  const canSpin = !isBusy && (credits >= 1 || freeSpin)
   const canBuy = phase === 'idle' && credits > 0 && credits < MAX_CREDITS && availCrystals >= BUY_COST
   const totalWin = lastWin ?? 0
+
+  // Board display window: 5 nodes centred on current position
+  const boardWindow = [-2, -1, 0, 1, 2].map(offset => {
+    const idx = ((boardPos + offset) % BOARD_SIZE + BOARD_SIZE) % BOARD_SIZE
+    return { idx, node: BOARD_NODES[idx], isCurrent: offset === 0 }
+  })
 
   return (
     <div className="minigame-screen">
@@ -327,6 +465,18 @@ export function FruitMachine({ onDone }: Props) {
         {lastWin === 0 && <span className="fm-no-win">No win</span>}
       </div>
 
+      {/* Feature board trail */}
+      <div className="fm-board">
+        {boardWindow.map(({ idx, node, isCurrent }) => (
+          <div key={idx} className={`fm-board-node${isCurrent ? ' fm-board-node--current' : ''}`}>
+            <div className="fm-board-node-label">{node.label}</div>
+          </div>
+        ))}
+      </div>
+      {boardMessage && <div className="fm-board-message">{boardMessage}</div>}
+      {boardMult > 1 && <div className="fm-board-mult-banner">×{boardMult} multiplier active!</div>}
+      {freeSpin && <div className="fm-board-free-spin">FREE SPIN ready!</div>}
+
       {/* Reels */}
       <div className="fm-reels">
         {([0, 1, 2] as const).map(i => (
@@ -346,7 +496,7 @@ export function FruitMachine({ onDone }: Props) {
             key={i}
             className={`fm-hold-btn${held[i] ? ' fm-hold-btn--active' : ''}${recentlyHeld[i] && !held[i] ? ' fm-hold-btn--blocked' : ''}`}
             onClick={() => toggleHold(i)}
-            disabled={isSpinning || recentlyHeld[i]}
+            disabled={isBusy || recentlyHeld[i]}
             title={recentlyHeld[i] ? 'Already held last spin' : undefined}
           >
             {held[i] ? 'HELD' : recentlyHeld[i] ? '—' : 'HOLD'}
@@ -359,14 +509,14 @@ export function FruitMachine({ onDone }: Props) {
         <button
           className="action-btn action-btn--gold"
           onClick={spin}
-          disabled={!(!isSpinning && credits >= 1)}
+          disabled={!canSpin}
         >
-          SPIN (1 credit)
+          {freeSpin ? 'FREE SPIN' : 'SPIN (1 credit)'}
         </button>
         <button
           className="action-btn"
           onClick={cashOut}
-          disabled={isSpinning}
+          disabled={isBusy}
         >
           CASH OUT ({credits * TICKETS_PER_CREDIT} 🎫)
         </button>

--- a/web/src/components/minigames/FruitMachine.tsx
+++ b/web/src/components/minigames/FruitMachine.tsx
@@ -163,6 +163,9 @@ export function FruitMachine({ onDone }: Props) {
   const [freeSpin, setFreeSpin]             = useState(false)
   const [nudgesAvailable, setNudgesAvailable] = useState(0)
   const [reelPositions, setReelPositions]   = useState<[number, number, number]>([0, 3, 6])
+  const [bonusTiles, setBonusTiles] = useState<Array<{ value: number; collect: boolean; revealed: boolean }>>([])
+  const [bonusPicksLeft, setBonusPicksLeft] = useState(0)
+  const [bonusTotalWin, setBonusTotalWin]   = useState(0)
 
   const spinningRef     = useRef<[boolean, boolean, boolean]>([false, false, false])
   const intervalRef     = useRef<ReturnType<typeof setInterval> | null>(null)
@@ -221,10 +224,17 @@ export function FruitMachine({ onDone }: Props) {
         setNudgesAvailable(node.value ?? 1)
         setPhase('nudge')
         break
-      case 'bonus-game':
-        pendingBoardNodeRef.current = node
+      case 'bonus-game': {
+        // Build 9 tiles: 7 credit prizes (2–20), 2 collect-early tiles
+        const prizes = Array.from({ length: 7 }, () => ({ value: Math.floor(Math.random() * 19) + 2, collect: false, revealed: false }))
+        const collects = [{ value: 0, collect: true, revealed: false }, { value: 0, collect: true, revealed: false }]
+        const shuffled = [...prizes, ...collects].sort(() => Math.random() - 0.5)
+        setBonusTiles(shuffled)
+        setBonusPicksLeft(3)
+        setBonusTotalWin(0)
         setPhase('bonus')
         break
+      }
       case 'jackpot-mini':
         setCredits(c => c + JACKPOT_TIERS[0].credits)
         setJackpotWon({ tier: 'Mini', amount: JACKPOT_TIERS[0].credits })
@@ -409,6 +419,35 @@ export function FruitMachine({ onDone }: Props) {
     }, SPIN_DURATION_MS)
   }
 
+  function pickBonusTile(idx: number) {
+    if (bonusPicksLeft <= 0) return
+    const tile = bonusTiles[idx]
+    if (tile.revealed) return
+    const newTiles = bonusTiles.map((t, i) => i === idx ? { ...t, revealed: true } : t)
+    setBonusTiles(newTiles)
+    const earned = tile.collect ? 0 : tile.value
+    const newTotal = bonusTotalWin + earned
+    setBonusTotalWin(newTotal)
+    const newPicks = tile.collect ? 0 : bonusPicksLeft - 1
+    setBonusPicksLeft(newPicks)
+    if (newPicks <= 0) {
+      // Reveal remaining tiles after a brief delay then finish
+      setTimeout(() => {
+        setBonusTiles(prev => prev.map(t => ({ ...t, revealed: true })))
+        setTimeout(() => finishBonusWithWin(newTotal), 800)
+      }, 400)
+    }
+  }
+
+  function finishBonusWithWin(total: number) {
+    setCredits(c => c + total)
+    setLastWin(total)
+    setWinLabel(`🎁 BONUS! +${total} credits!`)
+    setBonusTiles([])
+    setBonusPicksLeft(0)
+    setPhase('idle')
+  }
+
   function dismissJackpotWin() {
     setJackpotWon(null)
     setPhase('idle')
@@ -426,6 +465,34 @@ export function FruitMachine({ onDone }: Props) {
     saveCrystals(availCrystals - BUY_COST)
     setAvailCrystals(c => c - BUY_COST)
     setCredits(c => Math.min(MAX_CREDITS, c + BUY_AMOUNT))
+  }
+
+  // ── Bonus game screen ────────────────────────────────────────────────────────
+
+  if (phase === 'bonus' && bonusTiles.length > 0) {
+    return (
+      <div className="minigame-screen">
+        <div className="minigame-title">🎰 FRUIT MACHINE</div>
+        <div className="fm-bonus-game">
+          <div className="fm-bonus-header">BONUS GAME — pick {bonusPicksLeft} {bonusPicksLeft === 1 ? 'prize' : 'prizes'}!</div>
+          {bonusTotalWin > 0 && <div className="fm-bonus-running-total">Running total: +{bonusTotalWin} credits</div>}
+          <div className="fm-bonus-tiles">
+            {bonusTiles.map((tile, i) => (
+              <button
+                key={i}
+                className={`fm-bonus-tile${tile.revealed ? ' fm-bonus-tile--revealed' : ''}`}
+                onClick={() => pickBonusTile(i)}
+                disabled={tile.revealed || bonusPicksLeft <= 0}
+              >
+                {tile.revealed
+                  ? (tile.collect ? '⛔ COLLECT' : `+${tile.value}`)
+                  : '?'}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+    )
   }
 
   // ── Nudge screen ─────────────────────────────────────────────────────────────

--- a/web/src/components/minigames/FruitMachine.tsx
+++ b/web/src/components/minigames/FruitMachine.tsx
@@ -10,6 +10,7 @@
 
 import React, { useState, useRef, useEffect } from 'react'
 import { loadCrystals, saveCrystals } from '../../game/collection'
+import { logError } from '../../logger'
 
 interface Props {
   onDone: (ticketsEarned: number) => void
@@ -30,6 +31,13 @@ const TICKETS_PER_CREDIT   = 2
 const SPIN_DURATION_MS     = 1200
 const FEATURE_THRESHOLD    = 5    // feature triggers needed for bonus
 const FEATURE_BONUS_CREDITS = 15  // credits awarded when feature fires
+
+const JACKPOT_TIERS = [
+  { name: 'Mini',  credits: 50,  progressive: false, base: 50  },
+  { name: 'Minor', credits: 100, progressive: false, base: 100 },
+  { name: 'Major', credits: 250, progressive: false, base: 250 },
+  { name: 'Grand', credits: 0,   progressive: true,  base: 500 },
+] as const
 
 function pickSymbol(): string {
   let r = Math.random() * WEIGHTS.reduce((s, w) => s + w, 0)
@@ -95,17 +103,22 @@ export function FruitMachine({ onDone }: Props) {
   const [display, setDisplay]     = useState<[string, string, string]>(() => [pickSymbol(), pickSymbol(), pickSymbol()])
   const [held, setHeld]           = useState<[boolean, boolean, boolean]>([false, false, false])
   const [recentlyHeld, setRecentlyHeld] = useState<[boolean, boolean, boolean]>([false, false, false])
-  const [phase, setPhase]         = useState<'idle' | 'spinning' | 'done'>('idle')
+  const [phase, setPhase]         = useState<'idle' | 'spinning' | 'board-moving' | 'nudge' | 'bonus' | 'jackpot-win' | 'done'>('idle')
   const [credits, setCredits]     = useState(STARTING_CREDITS)
   const [lastWin, setLastWin]     = useState<number | null>(null)
   const [winLabel, setWinLabel]   = useState<string | null>(null)
   const [cashOutTickets, setCashOutTickets] = useState(0)
   const [availCrystals, setAvailCrystals]  = useState(() => loadCrystals())
   const [featureTriggerCount, setFeatureTriggerCount] = useState(0)
+  const [grandJackpot, setGrandJackpot] = useState<number>(() => {
+    try { return parseInt(localStorage.getItem('fm_grand') ?? '500', 10) } catch { return 500 }
+  })
+  const [jackpotWon, setJackpotWon] = useState<{ tier: string; amount: number } | null>(null)
 
   const spinningRef     = useRef<[boolean, boolean, boolean]>([false, false, false])
   const intervalRef     = useRef<ReturnType<typeof setInterval> | null>(null)
   const featureCountRef = useRef(0)  // mirrors featureTriggerCount for use inside setTimeout
+  const grandJackpotRef = useRef(grandJackpot)
 
   // Sync display with reels on first mount
   useEffect(() => {
@@ -141,6 +154,15 @@ export function FruitMachine({ onDone }: Props) {
     spinningRef.current = [!held[0], !held[1], !held[2]]
     setRecentlyHeld([...held] as [boolean, boolean, boolean])
 
+    // Grand jackpot grows by 1 every spin
+    const newGrand = grandJackpotRef.current + 1
+    grandJackpotRef.current = newGrand
+    setGrandJackpot(newGrand)
+    try { localStorage.setItem('fm_grand', String(newGrand)) } catch (e) { logError('fm_grand save', { error: String(e) }) }
+
+    // Detect ⭐⭐⭐ for Grand jackpot trigger
+    const isTripleStar = nextReels[0] === '⭐' && nextReels[1] === '⭐' && nextReels[2] === '⭐'
+
     setPhase('spinning')
     setCredits(c => c - 1)
     setLastWin(null)
@@ -160,6 +182,23 @@ export function FruitMachine({ onDone }: Props) {
       if (intervalRef.current) clearInterval(intervalRef.current)
       spinningRef.current = [false, false, false]
 
+      setReels(nextReels)
+      setDisplay(nextReels)
+      setHeld([false, false, false])
+
+      if (isTripleStar) {
+        const amount = grandJackpotRef.current
+        const resetVal = JACKPOT_TIERS[3].base
+        grandJackpotRef.current = resetVal
+        setGrandJackpot(resetVal)
+        try { localStorage.setItem('fm_grand', String(resetVal)) } catch (e) { logError('fm_grand reset', { error: String(e) }) }
+        setLastWin(amount)
+        setCredits(c => Math.max(0, c + amount))
+        setJackpotWon({ tier: 'Grand', amount })
+        setPhase('jackpot-win')
+        return
+      }
+
       const { credits: win, winType } = calcPayout(nextReels)
       const featureHits = nextReels.filter(x => x === FEATURE).length
 
@@ -174,10 +213,7 @@ export function FruitMachine({ onDone }: Props) {
       }
       setFeatureTriggerCount(featureCountRef.current)
 
-      setReels(nextReels)
-      setDisplay(nextReels)
       setLastWin(win + featureBonus)
-      setHeld([false, false, false])
       // recentlyHeld stays set — blocks those reels from being held next spin
       setCredits(c => Math.max(0, c + win + featureBonus))
 
@@ -193,6 +229,11 @@ export function FruitMachine({ onDone }: Props) {
     }, SPIN_DURATION_MS)
   }
 
+  function dismissJackpotWin() {
+    setJackpotWon(null)
+    setPhase('idle')
+  }
+
   function cashOut() {
     if (phase !== 'idle') return
     const tickets = credits * TICKETS_PER_CREDIT
@@ -205,6 +246,23 @@ export function FruitMachine({ onDone }: Props) {
     saveCrystals(availCrystals - BUY_COST)
     setAvailCrystals(c => c - BUY_COST)
     setCredits(c => Math.min(MAX_CREDITS, c + BUY_AMOUNT))
+  }
+
+  // ── Jackpot win screen ────────────────────────────────────────────────────────
+
+  if (phase === 'jackpot-win' && jackpotWon) {
+    return (
+      <div className="minigame-screen">
+        <div className="minigame-title">🎰 FRUIT MACHINE</div>
+        <div className="fm-jackpot-win-overlay">
+          <div className="fm-jackpot-win-tier">{jackpotWon.tier} JACKPOT!</div>
+          <div className="fm-jackpot-win-amount">+{jackpotWon.amount} credits!</div>
+          <button className="action-btn action-btn--gold" onClick={dismissJackpotWin}>
+            COLLECT
+          </button>
+        </div>
+      </div>
+    )
   }
 
   // ── Done screen ───────────────────────────────────────────────────────────────
@@ -245,6 +303,16 @@ export function FruitMachine({ onDone }: Props) {
   return (
     <div className="minigame-screen">
       <div className="minigame-title">🎰 FRUIT MACHINE</div>
+
+      {/* Jackpot tiers */}
+      <div className="fm-jackpots">
+        {JACKPOT_TIERS.map(t => (
+          <div key={t.name} className={`fm-jackpot-tier${t.progressive ? ' fm-jackpot-tier--grand' : ''}`}>
+            <div className="fm-jackpot-name">{t.name}</div>
+            <div className="fm-jackpot-amount">{t.progressive ? grandJackpot : t.credits}</div>
+          </div>
+        ))}
+      </div>
 
       <div className="fm-header">
         <span className="fm-credits">Credits: {credits}</span>
@@ -317,7 +385,7 @@ export function FruitMachine({ onDone }: Props) {
           <tbody>
             <tr><td>🃏🃏🃏</td><td>40 credits (triple wild)</td></tr>
             <tr><td>💎💎💎</td><td>50 credits</td></tr>
-            <tr><td>⭐⭐⭐</td><td>30 credits</td></tr>
+            <tr><td>⭐⭐⭐</td><td>GRAND JACKPOT 🌠</td></tr>
             <tr><td>🔔🔔🔔</td><td>20 credits</td></tr>
             <tr><td>Any triple</td><td>10 credits</td></tr>
             <tr><td>💎💎 pair</td><td>5 credits</td></tr>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -9893,6 +9893,57 @@ html.light-mode .action-btn {
   font-weight: bold;
 }
 
+/* Nudge UI */
+.fm-nudge-ui {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 0;
+}
+
+.fm-nudge-header {
+  font-size: 14px;
+  font-weight: bold;
+  color: #ffd700;
+  letter-spacing: 1px;
+}
+
+.fm-nudge-controls {
+  display: flex;
+  gap: 12px;
+}
+
+.fm-nudge-reel {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  align-items: center;
+}
+
+.fm-nudge-btn {
+  width: 80px;
+  padding: 6px 0;
+  background: #0d0d1e;
+  border: 1px solid #555;
+  color: #ccc;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 16px;
+  transition: background 0.15s;
+}
+
+.fm-nudge-btn:hover:not(:disabled) {
+  background: #1a1a2e;
+  border-color: #ffd700;
+  color: #ffd700;
+}
+
+.fm-nudge-btn:disabled {
+  opacity: 0.3;
+  cursor: default;
+}
+
 /* Jackpot tiers bar */
 .fm-jackpots {
   display: flex;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -9833,6 +9833,86 @@ html.light-mode .action-btn {
   color: #ffd700;
 }
 
+/* Jackpot tiers bar */
+.fm-jackpots {
+  display: flex;
+  gap: 6px;
+  justify-content: center;
+  margin-bottom: 6px;
+}
+
+.fm-jackpot-tier {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background: #0d0d1e;
+  border: 1px solid #333;
+  border-radius: 4px;
+  padding: 3px 8px;
+  min-width: 56px;
+}
+
+.fm-jackpot-name {
+  font-size: 10px;
+  color: #aaa;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.fm-jackpot-amount {
+  font-size: 13px;
+  font-weight: bold;
+  color: #ffd700;
+}
+
+.fm-jackpot-tier--grand .fm-jackpot-name {
+  color: #ff9900;
+}
+
+.fm-jackpot-tier--grand .fm-jackpot-amount {
+  color: #ff9900;
+  animation: fm-grand-pulse 1.8s ease-in-out infinite;
+}
+
+@keyframes fm-grand-pulse {
+  0%, 100% { opacity: 1; text-shadow: 0 0 6px #ff9900; }
+  50%       { opacity: 0.7; text-shadow: 0 0 12px #ffcc00; }
+}
+
+/* Jackpot win overlay */
+.fm-jackpot-win-overlay {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  padding: 32px 16px;
+  background: linear-gradient(135deg, #1a0a00 0%, #0d0d1e 100%);
+  border: 2px solid #ff9900;
+  border-radius: 8px;
+  margin: 12px 0;
+  animation: fm-jackpot-appear 0.4s ease-out;
+}
+
+@keyframes fm-jackpot-appear {
+  from { transform: scale(0.8); opacity: 0; }
+  to   { transform: scale(1);   opacity: 1; }
+}
+
+.fm-jackpot-win-tier {
+  font-size: 28px;
+  font-weight: bold;
+  color: #ff9900;
+  text-shadow: 0 0 20px #ff6600;
+  letter-spacing: 2px;
+  animation: fm-grand-pulse 0.8s ease-in-out infinite;
+}
+
+.fm-jackpot-win-amount {
+  font-size: 22px;
+  color: #ffd700;
+  font-weight: bold;
+}
+
 /* ── Video Poker ──────────────────────────────────────────────────────────── */
 
 .vp-subtitle {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -9893,6 +9893,68 @@ html.light-mode .action-btn {
   font-weight: bold;
 }
 
+/* Bonus pick-and-win game */
+.fm-bonus-game {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 0;
+}
+
+.fm-bonus-header {
+  font-size: 14px;
+  font-weight: bold;
+  color: #ffd700;
+  letter-spacing: 1px;
+}
+
+.fm-bonus-running-total {
+  font-size: 13px;
+  color: #55ff55;
+  font-weight: bold;
+}
+
+.fm-bonus-tiles {
+  display: grid;
+  grid-template-columns: repeat(3, 80px);
+  gap: 8px;
+}
+
+.fm-bonus-tile {
+  width: 80px;
+  height: 60px;
+  background: #0d0d1e;
+  border: 2px solid #555;
+  border-radius: 6px;
+  color: #aaa;
+  font-size: 18px;
+  cursor: pointer;
+  transition: all 0.15s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.fm-bonus-tile:hover:not(:disabled) {
+  border-color: #ffd700;
+  background: #1a1a00;
+  color: #ffd700;
+}
+
+.fm-bonus-tile:disabled {
+  cursor: default;
+  opacity: 0.5;
+}
+
+.fm-bonus-tile--revealed {
+  border-color: #333;
+  color: #55ff55;
+  font-size: 12px;
+  font-weight: bold;
+  background: #0a1a0a;
+}
+
 /* Nudge UI */
 .fm-nudge-ui {
   display: flex;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -9833,6 +9833,66 @@ html.light-mode .action-btn {
   color: #ffd700;
 }
 
+/* Feature board trail */
+.fm-board {
+  display: flex;
+  gap: 4px;
+  justify-content: center;
+  margin: 4px 0;
+}
+
+.fm-board-node {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 52px;
+  height: 36px;
+  background: #0d0d1e;
+  border: 1px solid #333;
+  border-radius: 4px;
+  font-size: 10px;
+  color: #888;
+  transition: all 0.3s ease;
+}
+
+.fm-board-node--current {
+  border-color: #ffd700;
+  color: #ffd700;
+  background: #1a1a00;
+  box-shadow: 0 0 8px #ffd70066;
+  font-weight: bold;
+  font-size: 11px;
+  transform: scale(1.08);
+}
+
+.fm-board-node-label {
+  text-align: center;
+  line-height: 1.2;
+}
+
+.fm-board-message {
+  text-align: center;
+  font-size: 12px;
+  color: #aaddff;
+  margin: 2px 0;
+  min-height: 16px;
+}
+
+.fm-board-mult-banner {
+  text-align: center;
+  font-size: 12px;
+  color: #ff9900;
+  font-weight: bold;
+}
+
+.fm-board-free-spin {
+  text-align: center;
+  font-size: 12px;
+  color: #55ff55;
+  font-weight: bold;
+}
+
 /* Jackpot tiers bar */
 .fm-jackpots {
   display: flex;


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Implements issues #781, #782, and #783 — the three major fruit machine extensions — built on top of the existing FruitMachine component.

- **#783 Jackpot system**: 4 tiers (Mini 50cr / Minor 100cr / Major 250cr / Grand progressive). Grand jackpot grows +1 every spin, persisted to `localStorage`. Landing ⭐⭐⭐ triggers the Grand jackpot. A dedicated `jackpot-win` celebration screen shows before returning to play. All four tiers displayed live in a header bar; Grand pulses in gold.

- **#781 Feature board**: 20-node linear trail (credit prizes, ×2/×3 multipliers, free spins, nudge awards, bonus-game trigger, jackpot nodes). Board advances after each spin based on: 🔔 Bell landed (+1 step), feature bonus fires (+2 steps), any triple win (+1 step). Each step animates at 400 ms. Board position and active multiplier persisted to `localStorage`. A 5-node window centred on current position is displayed above the reels.

- **#782 Nudges**: Each reel now has a strip-index (`reelPositions`); nudging shifts the index ±1. Board nudge nodes award 1 or 2 nudges and enter the `nudge` phase, which shows ▲/▼ buttons per reel. Pressing "DONE" re-evaluates the payout from the final positions.

- **#782 Bonus game**: Board node 11 (and node 11 looped) triggers a pick-and-win: 9 face-down tiles (7 credit prizes 2–20 cr, 2 COLLECT tiles). Player picks 3; hitting COLLECT ends picking early. All remaining tiles are revealed before returning to play.

## Test plan

- [ ] Spin until a 🔔 Bell lands → board advances 1 step, correct node highlighted
- [ ] Spin until feature meter fires → board advances 2 extra steps
- [ ] Spin a triple (non-star) → board advances 1 step
- [ ] Board reaches a `credit` node → credits added, message shown
- [ ] Board reaches a `multiplier` node → next spin win is multiplied; banner shows active mult
- [ ] Board reaches an `extra-spin` node → "FREE SPIN" button shown; next spin costs 0 cr
- [ ] Board reaches a `nudge` node → nudge phase opens; ▲/▼ move symbols; DONE re-scores
- [ ] Board reaches `bonus-game` node → 9-tile grid shown; pick 3 tiles; credits awarded
- [ ] Board reaches `jackpot-mini` (pos 6) → Mini jackpot win screen (50 cr)
- [ ] Board reaches `jackpot-major` (pos 16) → Major jackpot win screen (250 cr)
- [ ] Land ⭐⭐⭐ → Grand jackpot fires for current progressive value; resets to 500
- [ ] Grand jackpot counter in header increments each spin
- [ ] `localStorage['fm_grand']`, `fm_board_pos`, `fm_board_mult` persist across page reload
- [ ] Existing: triple wild still pays 40 cr; bonus scatter still pays; cash-out still works

https://claude.ai/code/session_015ngtyyriGXhinL1jypeQkE
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_015ngtyyriGXhinL1jypeQkE)_