### PR TITLE
feat(feedback): add player feedback/bug submission screen (#118)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -78,6 +78,8 @@ import { getUnreadCount as getNewsUnreadCount } from './game/news'
 import { NewsScreen }      from './components/NewsScreen'
 import { NewsAdminScreen } from './components/NewsAdminScreen'
 import { CampaignAdminScreen } from './components/CampaignAdminScreen'
+import { FeedbackModal } from './components/FeedbackModal'
+import { FeedbackAdminScreen } from './components/FeedbackAdminScreen'
 import { getDailyPlayerDeck, getDailyOpponentDeck, getDailyChallengeState, saveDailyChallengeResult, recordDailyWin, publishDailyResult, publishEndlessResult, DailyChallengeState } from './game/dailyChallenge'
 import { getRelicDef, addEarnedRelic, removeEarnedRelic, loadEarnedRelics, addBrokenRelic } from './game/relics'
 import { playCardPlay, playButtonClick, playBattleEvent, playCardFlip, playRestHeal, stopBattleMusic, stopGameOverMusic } from './game/sound'
@@ -262,6 +264,7 @@ type Screen =
   | 'news'
   | 'newsAdmin'
   | 'campaignAdmin'
+  | 'feedbackAdmin'
   | 'minigames'
   | 'playerstats'
   | 'quickbattle'
@@ -344,6 +347,7 @@ export default function App() {
 
   const [screen, setScreen]             = useState<Screen>(_startup.screen)
   const [showTitleLoginModal, setShowTitleLoginModal] = useState(false)
+  const [feedbackOpen, setFeedbackOpen] = useState(false)
   // ── Battle state (all ephemeral state that exists only during a battle) ──────
   const [battle, dispatch] = useReducer(battleReducer, {
     ...INITIAL_BATTLE_STATE,
@@ -2454,7 +2458,11 @@ export default function App() {
             user={user}
             onSignOut={() => { import('firebase/auth').then(({ signOut }) => signOut(auth)) }}
             onSignIn={() => setShowTitleLoginModal(true)}
+            onFeedback={() => setFeedbackOpen(true)}
           />
+          {feedbackOpen && (
+            <FeedbackModal user={user} onClose={() => setFeedbackOpen(false)} />
+          )}
           {showTitleLoginModal && (
             <LoginModal
               user={user}
@@ -2480,6 +2488,7 @@ export default function App() {
           onGiftAdmin={() => setScreen('giftAdmin')}
           onNewsAdmin={() => setScreen('newsAdmin')}
           onCampaignAdmin={() => setScreen('campaignAdmin')}
+          onFeedbackAdmin={() => setScreen('feedbackAdmin')}
         />
       )}
 
@@ -2497,6 +2506,10 @@ export default function App() {
 
       {screen === 'campaignAdmin' && (
         <CampaignAdminScreen onBack={() => setScreen('settings')} />
+      )}
+
+      {screen === 'feedbackAdmin' && (
+        <FeedbackAdminScreen onBack={() => setScreen('settings')} />
       )}
 
       {screen === 'nodemap' && run && actData && (

--- a/web/src/components/FeedbackAdminScreen.tsx
+++ b/web/src/components/FeedbackAdminScreen.tsx
@@ -1,0 +1,72 @@
+import React, { useState, useEffect } from 'react'
+import { OverlayScreen } from './OverlayScreen'
+import { Section } from './Section'
+import { FeedbackItem, getAllFeedback, deleteFeedback } from '../game/feedback'
+
+interface Props {
+  onBack: () => void
+}
+
+const TYPE_LABELS: Record<string, string> = {
+  bug: '🐛 BUG',
+  suggestion: '💡 SUGGESTION',
+  other: '💬 OTHER',
+}
+
+export function FeedbackAdminScreen({ onBack }: Props) {
+  const [items, setItems]     = useState<FeedbackItem[]>([])
+  const [loading, setLoading] = useState(true)
+  const [status, setStatus]   = useState<string | null>(null)
+
+  function refresh() {
+    setLoading(true)
+    getAllFeedback().then(all => { setItems(all); setLoading(false) })
+  }
+
+  useEffect(() => { refresh() }, [])
+
+  async function handleDelete(id: string) {
+    if (!confirm('Delete this feedback item?')) return
+    try {
+      await deleteFeedback(id)
+      setStatus(`Deleted ${id}`)
+      refresh()
+    } catch (e) {
+      setStatus(`Error: ${String(e)}`)
+    }
+  }
+
+  return (
+    <OverlayScreen title="FEEDBACK ADMIN" onBack={onBack}>
+      <Section title={`Submissions (${items.length})`}>
+        {loading && <div className="news-loading">Loading…</div>}
+        {!loading && items.length === 0 && <div className="news-empty">No feedback yet.</div>}
+        {!loading && items.map(item => (
+          <div key={item.id} className="news-item">
+            <div className="news-item__meta">
+              <span className="news-item__tag">{TYPE_LABELS[item.type] ?? item.type}</span>
+              <span className="news-item__date">{item.submittedAt.slice(0, 16).replace('T', ' ')}</span>
+              {item.userId && (
+                <span className="news-item__date" style={{ opacity: 0.5, fontSize: '11px' }}>{item.userId.slice(0, 10)}…</span>
+              )}
+              <button
+                className="action-btn action-btn--danger"
+                style={{ marginLeft: 'auto', padding: '2px 10px', fontSize: '11px' }}
+                onClick={() => handleDelete(item.id)}
+              >
+                DELETE
+              </button>
+            </div>
+            <div className="news-item__title">{item.subject}</div>
+            <div className="news-item__body" style={{ whiteSpace: 'pre-wrap' }}>{item.body}</div>
+          </div>
+        ))}
+        {status && (
+          <div className="settings-label" style={{ color: status.startsWith('Error') ? '#ff4444' : '#33ff33', marginTop: '8px' }}>
+            {status}
+          </div>
+        )}
+      </Section>
+    </OverlayScreen>
+  )
+}

--- a/web/src/components/FeedbackModal.tsx
+++ b/web/src/components/FeedbackModal.tsx
@@ -1,0 +1,109 @@
+import React, { useState } from 'react'
+import { type User } from 'firebase/auth'
+import { ModalBackdrop } from './ModalBackdrop'
+import { submitFeedback, FeedbackType } from '../game/feedback'
+import { logError } from '../logger'
+
+interface Props {
+  user: User | null
+  onClose: () => void
+}
+
+const TYPE_LABELS: Record<FeedbackType, string> = {
+  bug: '🐛 Bug Report',
+  suggestion: '💡 Suggestion',
+  other: '💬 Other',
+}
+
+export function FeedbackModal({ user, onClose }: Props) {
+  const [type, setType]       = useState<FeedbackType>('bug')
+  const [subject, setSubject] = useState('')
+  const [body, setBody]       = useState('')
+  const [status, setStatus]   = useState<'idle' | 'sending' | 'done' | 'error'>('idle')
+  const [errorMsg, setErrorMsg] = useState<string | null>(null)
+
+  async function handleSubmit() {
+    if (!subject.trim() || !body.trim()) return
+    setStatus('sending')
+    setErrorMsg(null)
+    try {
+      await submitFeedback({ type, subject: subject.trim(), body: body.trim() }, user?.uid)
+      setStatus('done')
+      setTimeout(onClose, 1800)
+    } catch (e) {
+      logError('FeedbackModal: submit failed', { error: String(e) })
+      setErrorMsg('Failed to send — please try again.')
+      setStatus('error')
+    }
+  }
+
+  return (
+    <ModalBackdrop onClose={status === 'sending' ? () => {} : onClose}>
+      <div className="confirm-modal" style={{ maxWidth: 400, textAlign: 'left' }}>
+        <div className="confirm-modal-title">SEND FEEDBACK</div>
+
+        {status === 'done' ? (
+          <div style={{ textAlign: 'center', padding: '16px 0', color: 'var(--game-accent, #f0c040)' }}>
+            ✓ Thanks for your feedback!
+          </div>
+        ) : (
+          <>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
+              <div>
+                <div className="settings-label">Type</div>
+                <div style={{ display: 'flex', gap: '6px', flexWrap: 'wrap' }}>
+                  {(Object.keys(TYPE_LABELS) as FeedbackType[]).map(t => (
+                    <button
+                      key={t}
+                      className={`filter-btn${type === t ? ' filter-btn--active' : ''}`}
+                      onClick={() => setType(t)}
+                    >
+                      {TYPE_LABELS[t]}
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              <div>
+                <div className="settings-label">Subject</div>
+                <input
+                  className="settings-text-input"
+                  style={{ width: '100%' }}
+                  maxLength={120}
+                  placeholder="Brief summary…"
+                  value={subject}
+                  onChange={e => setSubject(e.target.value)}
+                />
+              </div>
+
+              <div>
+                <div className="settings-label">Details</div>
+                <textarea
+                  className="settings-text-input"
+                  style={{ width: '100%', minHeight: '90px', resize: 'vertical', fontFamily: 'inherit', fontSize: 'inherit' }}
+                  maxLength={2000}
+                  placeholder="Describe the bug or idea…"
+                  value={body}
+                  onChange={e => setBody(e.target.value)}
+                />
+              </div>
+
+              {errorMsg && (
+                <div className="settings-label" style={{ color: '#ff4444' }}>{errorMsg}</div>
+              )}
+            </div>
+
+            <div className="confirm-modal-actions" style={{ marginTop: '14px' }}>
+              <button className="action-btn" onClick={handleSubmit} disabled={status === 'sending' || !subject.trim() || !body.trim()}>
+                {status === 'sending' ? 'SENDING…' : 'SEND'}
+              </button>
+              <button className="action-btn action-btn--danger" onClick={onClose} disabled={status === 'sending'}>
+                CANCEL
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </ModalBackdrop>
+  )
+}

--- a/web/src/components/SettingsScreen.tsx
+++ b/web/src/components/SettingsScreen.tsx
@@ -24,6 +24,7 @@ interface Props {
   onGiftAdmin?: () => void
   onNewsAdmin?: () => void
   onCampaignAdmin?: () => void
+  onFeedbackAdmin?: () => void
 }
 
 const TEXT_SIZE_KEY      = 'jarv_text_size'
@@ -132,7 +133,7 @@ function exportLocalStorage(): void {
   URL.revokeObjectURL(url)
 }
 
-export function SettingsScreen({ onBack, onResetGame, user, authLoading, onDevCrystalsChanged, onDevHandicapChanged, onGiftAdmin, onNewsAdmin, onCampaignAdmin }: Props) {
+export function SettingsScreen({ onBack, onResetGame, user, authLoading, onDevCrystalsChanged, onDevHandicapChanged, onGiftAdmin, onNewsAdmin, onCampaignAdmin, onFeedbackAdmin }: Props) {
   const [soundOn,       setSoundOn]       = useState(isSoundEnabled)
   const [textSize,      setTextSize]      = useState(loadTextSize)
   const [textColor,     setTextColor]     = useState(loadTextColor)
@@ -458,7 +459,7 @@ export function SettingsScreen({ onBack, onResetGame, user, authLoading, onDevCr
     <></>
         )}
 
-        {user?.uid === GIFT_OWNER_UID && (onGiftAdmin || onNewsAdmin) && (
+        {user?.uid === GIFT_OWNER_UID && (onGiftAdmin || onNewsAdmin || onFeedbackAdmin) && (
 <>
       <Section bordered title="DEBUG">
             <div className="settings-row">
@@ -531,6 +532,15 @@ export function SettingsScreen({ onBack, onResetGame, user, authLoading, onDevCr
                   <div className="settings-sublabel">Edit act nodes, enemy decks, and environments</div>
                 </div>
                 <button className="action-btn action-btn--gold" onClick={onCampaignAdmin}>OPEN</button>
+              </div>
+            )}
+            {onFeedbackAdmin && (
+              <div className="settings-row">
+                <div>
+                  <div className="settings-label">Feedback inbox</div>
+                  <div className="settings-sublabel">View and delete player-submitted feedback</div>
+                </div>
+                <button className="action-btn action-btn--gold" onClick={onFeedbackAdmin}>OPEN</button>
               </div>
             )}
           </Section>

--- a/web/src/components/TitleScreen.tsx
+++ b/web/src/components/TitleScreen.tsx
@@ -47,9 +47,10 @@ interface Props {
   user: User | null
   onSignOut: () => void
   onSignIn: () => void
+  onFeedback: () => void
 }
 
-export function TitleScreen({ crystals, onPlay, onEndless, onCampaign, onCollection, onShop, onDeckBuilder, onSettings, onInventory, onAchievements, onHeroCards, onCharacter, on8bitUnlocked, onDailyChallenge, onEndlessLeaderboard, onCommander, commanderName, onTraining, onNews, hasUnreadNews, onMiniGames, onPlayerStats, user, onSignOut, onSignIn }: Props) {
+export function TitleScreen({ crystals, onPlay, onEndless, onCampaign, onCollection, onShop, onDeckBuilder, onSettings, onInventory, onAchievements, onHeroCards, onCharacter, on8bitUnlocked, onDailyChallenge, onEndlessLeaderboard, onCommander, commanderName, onTraining, onNews, hasUnreadNews, onMiniGames, onPlayerStats, user, onSignOut, onSignIn, onFeedback }: Props) {
   const deck             = loadDeck()
   const count            = deckTotalCards(deck)
   const valid            = isDeckValid(deck)
@@ -270,6 +271,12 @@ export function TitleScreen({ crystals, onPlay, onEndless, onCampaign, onCollect
           ) : (
             <button className="title-auth-btn" onClick={onSignIn}>SIGN IN</button>
           )}
+          <button
+            className="filter-btn"
+            onClick={onFeedback}
+            title="Send feedback or report a bug"
+            style={{ marginLeft: '6px', fontSize: '13px', padding: '2px 7px' }}
+          >?</button>
         </div>
       </div>
     </div>

--- a/web/src/game/feedback.ts
+++ b/web/src/game/feedback.ts
@@ -1,0 +1,53 @@
+// ─── Feedback / Bug Submission System ─────────────────────────────────────────
+// Player-submitted feedback stored in Firestore `feedback/` collection.
+//
+// Firestore rules required (add to firestore.rules):
+//   match /feedback/{feedbackId} {
+//     allow read, delete: if request.auth.uid == "pAB2tLH049PCOI73cQpFlisKpDw1";
+//     allow create: if true;
+//   }
+
+import { collection, getDocs, doc, setDoc, deleteDoc } from 'firebase/firestore'
+import { db } from '../firebase'
+import { logError } from '../logger'
+
+export type FeedbackType = 'bug' | 'suggestion' | 'other'
+
+export interface FeedbackItem {
+  id: string
+  type: FeedbackType
+  subject: string
+  body: string
+  submittedAt: string
+  userId?: string
+}
+
+export async function submitFeedback(
+  item: Omit<FeedbackItem, 'id' | 'submittedAt'>,
+  userId?: string,
+): Promise<void> {
+  const id = `${Date.now()}_${Math.random().toString(36).slice(2, 7)}`
+  const doc_ = {
+    type: item.type,
+    subject: item.subject,
+    body: item.body,
+    submittedAt: new Date().toISOString(),
+    ...(userId ? { userId } : {}),
+  }
+  await setDoc(doc(db, 'feedback', id), doc_)
+}
+
+export async function getAllFeedback(): Promise<FeedbackItem[]> {
+  try {
+    const snap = await getDocs(collection(db, 'feedback'))
+    const items = snap.docs.map(d => ({ id: d.id, ...d.data() } as FeedbackItem))
+    return items.sort((a, b) => b.submittedAt.localeCompare(a.submittedAt))
+  } catch (e) {
+    logError('getAllFeedback failed', { error: String(e) })
+    return []
+  }
+}
+
+export async function deleteFeedback(id: string): Promise<void> {
+  await deleteDoc(doc(db, 'feedback', id))
+}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds a small `?` button in the title screen footer that opens a feedback/bug submission modal
- Players can submit a type (Bug / Suggestion / Other), subject, and body — stored in Firestore `feedback/` collection
- Admin (Jarvichi) can view and delete submissions via a new **Feedback inbox** screen in Settings → Debug

## Changes

| File | Change |
|---|---|
| `web/src/game/feedback.ts` | New — Firestore CRUD (`submitFeedback`, `getAllFeedback`, `deleteFeedback`) |
| `web/src/components/FeedbackModal.tsx` | New — overlay form with type selector, subject, body; auto-closes on success |
| `web/src/components/FeedbackAdminScreen.tsx` | New — admin list view, newest-first, with delete |
| `web/src/components/TitleScreen.tsx` | Add `onFeedback` prop; `?` button in footer auth bar |
| `web/src/components/SettingsScreen.tsx` | Add `onFeedbackAdmin` prop; Feedback inbox button in admin section |
| `web/src/App.tsx` | Wire `feedbackOpen` state, `FeedbackModal`, `feedbackAdmin` screen |

## Firestore rules needed

Add to `firestore.rules`:
```
match /feedback/{feedbackId} {
  allow read, delete: if request.auth.uid == "pAB2tLH049PCOI73cQpFlisKpDw1";
  allow create: if true;
}
```

## Test plan

- [ ] Click `?` in title screen footer — modal opens
- [ ] Submit a bug report — succeeds, modal shows confirmation and closes
- [ ] Submit without subject or body — Send button stays disabled
- [ ] Sign in as admin, go to Settings → Feedback inbox — submissions appear
- [ ] Delete a submission from admin screen
- [ ] Build passes clean (`npm run build`)

https://claude.ai/code/session_01QeEYdpJBwW7Y3nm1QUnxqc
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QeEYdpJBwW7Y3nm1QUnxqc)_