### PR TITLE
feat(#705): city builder v2 — structures only, walking units, wages

### DIFF
--- a/web/src/components/minigames/CityBuilder.tsx
+++ b/web/src/components/minigames/CityBuilder.tsx
@@ -1,31 +1,68 @@
 // ─── City Builder ─────────────────────────────────────────────────────────────
-// Idle city minigame: place owned cards on a grid, collect gold, level up cards.
+// Idle city: place owned structure cards on a grid. Spawn buildings show their
+// unit walking around the city. Units need wages; if unpaid, happiness drops
+// and the building earns at half rate.
 
-import React, { useState, useCallback } from 'react'
+import React, { useState, useEffect, useCallback, useRef } from 'react'
 import { getCardCatalog } from '../../game/cards'
 import { loadCollection, getOwnedCount } from '../../game/collection'
 import {
-  CITY_COLS, CITY_ROWS, CITY_CELLS,
+  CITY_COLS, CITY_ROWS, CITY_CELLS, CELL_PX,
   CityCell, CityState,
   loadCityState, saveCityState, tickCity,
   placeCard, removeCard,
-  goldPerMinute, getCardLevel, levelUpCost, levelUpCard,
+  goldIncomeRate, goldWageRate, goldNetRate,
+  getCardLevel, levelUpCost, levelUpCard,
   LEVEL_UP_COSTS, MAX_CARD_LEVEL, LEVEL_ATK_BONUS, LEVEL_MAX_HP_BONUS,
 } from '../../game/cityBuilder'
-import { SpriteImg } from '../SpriteImg'
+import { SpriteImg, AnimatedSpriteImg } from '../SpriteImg'
 import { Card } from '../../game/types'
+
+// ── Walking unit state ────────────────────────────────────────────────────────
+
+const OVERLAY_W = CITY_COLS * CELL_PX
+const OVERLAY_H = CITY_ROWS * CELL_PX
+const UNIT_SIZE = 20
+const SPEED     = 0.8 // px per 100 ms tick
+
+interface Walker {
+  cellIndex: number
+  unitName:  string
+  x:   number
+  y:   number
+  vx:  number
+  vy:  number
+  turnTimer: number
+}
+
+function makeWalker(cellIndex: number, unitName: string): Walker {
+  const angle = Math.random() * Math.PI * 2
+  return {
+    cellIndex,
+    unitName,
+    x: Math.random() * (OVERLAY_W - UNIT_SIZE),
+    y: Math.random() * (OVERLAY_H - UNIT_SIZE),
+    vx: Math.cos(angle) * SPEED,
+    vy: Math.sin(angle) * SPEED,
+    turnTimer: 20 + Math.floor(Math.random() * 30),
+  }
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
 
 interface Props {
   onBack: () => void
 }
 
-type PickerMode = { type: 'place'; index: number } | null
+type SubScreen = 'city' | 'picker' | 'levelup'
 
 export function CityBuilder({ onBack }: Props) {
   const [city, setCity]       = useState<CityState>(() => tickCity(loadCityState()))
-  const [picker, setPicker]   = useState<PickerMode>(null)
-  const [levelCard, setLevelCard] = useState<string | null>(null)
+  const [screen, setScreen]   = useState<SubScreen>('city')
+  const [pickerIndex, setPickerIndex] = useState<number>(0)
+  const [levelCard, setLevelCard]     = useState<string | null>(null)
   const [toast, setToast]     = useState<string | null>(null)
+  const [walkers, setWalkers] = useState<Walker[]>([])
 
   function showToast(msg: string) {
     setToast(msg)
@@ -37,111 +74,173 @@ export function CityBuilder({ onBack }: Props) {
     saveCityState(next)
   }
 
-  // ── Cell tap ─────────────────────────────────────────────────────────────────
+  // ── Sync walkers when grid changes ───────────────────────────────────────────
+
+  useEffect(() => {
+    setWalkers(prev => {
+      const next: Walker[] = []
+      for (let i = 0; i < city.grid.length; i++) {
+        const cell = city.grid[i]
+        if (!cell?.spawnedUnitName) continue
+        const existing = prev.find(w => w.cellIndex === i && w.unitName === cell.spawnedUnitName)
+        next.push(existing ?? makeWalker(i, cell.spawnedUnitName))
+      }
+      return next
+    })
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [city.grid])
+
+  // ── Animation loop ────────────────────────────────────────────────────────────
+
+  const walkersRef = useRef(walkers)
+  walkersRef.current = walkers
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setWalkers(prev => prev.map(w => {
+        let { x, y, vx, vy, turnTimer } = w
+        x += vx
+        y += vy
+        if (x < 0)                 { x = 0;                  vx = Math.abs(vx) }
+        if (x > OVERLAY_W - UNIT_SIZE) { x = OVERLAY_W - UNIT_SIZE; vx = -Math.abs(vx) }
+        if (y < 0)                 { y = 0;                  vy = Math.abs(vy) }
+        if (y > OVERLAY_H - UNIT_SIZE) { y = OVERLAY_H - UNIT_SIZE; vy = -Math.abs(vy) }
+        turnTimer--
+        if (turnTimer <= 0) {
+          const angle = Math.random() * Math.PI * 2
+          vx = Math.cos(angle) * SPEED
+          vy = Math.sin(angle) * SPEED
+          turnTimer = 20 + Math.floor(Math.random() * 30)
+        }
+        return { ...w, x, y, vx, vy, turnTimer }
+      }))
+    }, 100)
+    return () => clearInterval(id)
+  }, []) // stable — no deps
+
+  // ── Gold tick (every 10 s while screen is open) ───────────────────────────────
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setCity(prev => {
+        const next = tickCity(prev)
+        saveCityState(next)
+        return next
+      })
+    }, 10_000)
+    return () => clearInterval(id)
+  }, [])
+
+  // ── Cell interaction ──────────────────────────────────────────────────────────
 
   function handleCellTap(index: number) {
-    const cell = city.grid[index]
-    if (cell) {
-      // Remove existing card
+    if (city.grid[index]) {
+      const cell = city.grid[index]!
       save(removeCard(city, index))
       showToast(`${cell.cardName} removed.`)
     } else {
-      setPicker({ type: 'place', index })
+      setPickerIndex(index)
+      setScreen('picker')
     }
   }
 
   // ── Place a card ──────────────────────────────────────────────────────────────
 
   const handlePickCard = useCallback((card: Card) => {
-    if (!picker) return
+    const spawnEffect = card.unit?.structureEffect
+    const spawnedUnitName = spawnEffect?.type === 'spawn'
+      ? (spawnEffect as { type: 'spawn'; unitTemplate: { name: string }; intervalMs: number }).unitTemplate.name
+      : undefined
     const cell: CityCell = {
-      cardName: card.name,
-      cardType: card.cardType as 'unit' | 'structure',
-      rarity:   card.rarity,
+      cardName:        card.name,
+      rarity:          card.rarity,
+      spawnedUnitName,
     }
-    save(placeCard(city, picker.index, cell))
-    setPicker(null)
+    save(placeCard(city, pickerIndex, cell))
+    setScreen('city')
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [picker, city])
+  }, [pickerIndex, city])
 
   // ── Level up ──────────────────────────────────────────────────────────────────
 
   function handleLevelUp(cardName: string) {
     const next = levelUpCard(city, cardName)
-    if (!next) {
-      showToast('Not enough gold!')
-      return
-    }
+    if (!next) { showToast('Not enough gold!'); return }
     save(next)
-    const newLevel = next.cardLevels[cardName] ?? 0
-    showToast(`${cardName} levelled up to ★${newLevel}!`)
+    showToast(`${cardName} levelled up to ★${next.cardLevels[cardName]}!`)
   }
 
-  // ── Picker contents ───────────────────────────────────────────────────────────
+  // ── Derived data ──────────────────────────────────────────────────────────────
 
-  const catalog     = getCardCatalog()
-  const collection  = loadCollection()
-  const ownedCards  = catalog.filter(c =>
-    (c.cardType === 'unit' || c.cardType === 'structure') &&
-    getOwnedCount(collection, c.name) > 0
+  const catalog    = getCardCatalog()
+  const collection = loadCollection()
+
+  const ownedStructures = catalog.filter(c =>
+    c.cardType === 'structure' && getOwnedCount(collection, c.name) > 0
   )
 
-  // Cards already placed on the grid (by name, to allow duplicates only if owned count covers it)
   const placedCounts: Record<string, number> = {}
   for (const cell of city.grid) {
     if (cell) placedCounts[cell.cardName] = (placedCounts[cell.cardName] ?? 0) + 1
   }
 
-  const availableForPlace = ownedCards.filter(c =>
+  const availableForPlace = ownedStructures.filter(c =>
     (placedCounts[c.name] ?? 0) < getOwnedCount(collection, c.name)
   )
 
-  // ── Levellable cards (cards player owns) ──────────────────────────────────────
-
   const levellable = catalog.filter(c => getOwnedCount(collection, c.name) > 0)
 
-  const gpm = goldPerMinute(city)
+  const incomeRate = Math.round(goldIncomeRate(city))
+  const wageRate   = Math.round(goldWageRate(city))
+  const netRate    = Math.round(goldNetRate(city))
 
-  // ─── Render ───────────────────────────────────────────────────────────────────
+  // ── Card picker sub-screen ────────────────────────────────────────────────────
 
-  if (picker) {
+  if (screen === 'picker') {
     return (
       <div className="city-screen">
         <div className="city-picker-header">
-          <button className="action-btn" onClick={() => setPicker(null)}>← BACK</button>
-          <div className="city-picker-title">PLACE A CARD</div>
+          <button className="action-btn" onClick={() => setScreen('city')}>← BACK</button>
+          <div className="city-picker-title">PLACE A BUILDING</div>
         </div>
         {availableForPlace.length === 0 ? (
-          <div className="city-picker-empty">No cards available. Earn more from battles!</div>
+          <div className="city-picker-empty">No buildings available. Earn more from battles!</div>
         ) : (
           <div className="city-picker-grid">
-            {availableForPlace.map(card => (
-              <button
-                key={card.name}
-                className="city-picker-card"
-                onClick={() => handlePickCard(card)}
-              >
-                <SpriteImg name={card.name} className="city-picker-sprite" />
-                <div className="city-picker-name">{card.name}</div>
-                <div className={`city-picker-rarity city-picker-rarity--${card.rarity}`}>
-                  {card.rarity}
-                </div>
-              </button>
-            ))}
+            {availableForPlace.map(card => {
+              const spawnEffect = card.unit?.structureEffect
+              const spawnName = spawnEffect?.type === 'spawn'
+                ? (spawnEffect as { type: 'spawn'; unitTemplate: { name: string }; intervalMs: number }).unitTemplate.name
+                : null
+              return (
+                <button key={card.name} className="city-picker-card" onClick={() => handlePickCard(card)}>
+                  <SpriteImg name={card.name} className="city-picker-sprite" />
+                  <div className="city-picker-name">{card.name}</div>
+                  <div className={`city-picker-rarity city-picker-rarity--${card.rarity}`}>{card.rarity}</div>
+                  {spawnName && (
+                    <div className="city-picker-spawns">
+                      spawns <SpriteImg name={spawnName} className="city-picker-spawn-icon" />
+                    </div>
+                  )}
+                </button>
+              )
+            })}
           </div>
         )}
       </div>
     )
   }
 
-  if (levelCard !== null) {
+  // ── Level-up sub-screen ───────────────────────────────────────────────────────
+
+  if (screen === 'levelup' && levelCard !== null) {
     const card  = catalog.find(c => c.name === levelCard)
     const level = getCardLevel(city, levelCard)
     const cost  = levelUpCost(level)
     return (
       <div className="city-screen">
         <div className="city-picker-header">
-          <button className="action-btn" onClick={() => setLevelCard(null)}>← BACK</button>
+          <button className="action-btn" onClick={() => setScreen('city')}>← BACK</button>
           <div className="city-picker-title">LEVEL UP CARD</div>
         </div>
         <div className="city-level-detail">
@@ -186,6 +285,8 @@ export function CityBuilder({ onBack }: Props) {
     )
   }
 
+  // ── Main city view ────────────────────────────────────────────────────────────
+
   return (
     <div className="city-screen">
       {toast && <div className="city-toast" role="alert">{toast}</div>}
@@ -196,40 +297,80 @@ export function CityBuilder({ onBack }: Props) {
         <div className="city-title">🏙 CITY</div>
         <div className="city-gold-display">⚙ {city.gold.toLocaleString()}</div>
       </div>
-      <div className="city-subheader">
-        {gpm > 0
-          ? `+${gpm} gold/min — place buildings to earn more`
-          : 'Place units and buildings to generate gold'}
+
+      {/* Income breakdown */}
+      <div className="city-income-row">
+        <span className="city-income-in">+{incomeRate} income</span>
+        {wageRate > 0 && <span className="city-income-wage"> − {wageRate} wages</span>}
+        <span className={`city-income-net${netRate >= 0 ? ' city-income-net--pos' : ' city-income-net--neg'}`}>
+          {netRate >= 0 ? `= +${netRate}` : `= ${netRate}`}/min
+        </span>
       </div>
 
-      {/* Grid */}
-      <div
-        className="city-grid"
-        style={{ gridTemplateColumns: `repeat(${CITY_COLS}, 1fr)` }}
-      >
-        {Array.from({ length: CITY_CELLS }, (_, i) => {
-          const cell = city.grid[i]
-          return (
-            <button
-              key={i}
-              className={`city-cell${cell ? ' city-cell--occupied' : ''}`}
-              onClick={() => handleCellTap(i)}
-              title={cell ? `${cell.cardName} — tap to remove` : 'Empty — tap to place'}
-            >
-              {cell ? (
-                <>
-                  <SpriteImg name={cell.cardName} className="city-cell-sprite" />
-                  <div className="city-cell-name">{cell.cardName}</div>
-                  {getCardLevel(city, cell.cardName) > 0 && (
-                    <div className="city-cell-level">★{getCardLevel(city, cell.cardName)}</div>
-                  )}
-                </>
-              ) : (
-                <span className="city-cell-empty">+</span>
-              )}
-            </button>
-          )
-        })}
+      {/* City world: grid + walker overlay */}
+      <div className="city-world">
+        <div
+          className="city-grid"
+          style={{ gridTemplateColumns: `repeat(${CITY_COLS}, 1fr)` }}
+        >
+          {Array.from({ length: CITY_CELLS }, (_, i) => {
+            const cell      = city.grid[i]
+            const happiness = cell?.spawnedUnitName ? (city.happiness[i] ?? 100) : 100
+            const unhappy   = happiness === 0
+            return (
+              <button
+                key={i}
+                className={`city-cell${cell ? ' city-cell--occupied' : ''}`}
+                onClick={() => handleCellTap(i)}
+                title={cell ? `${cell.cardName} — tap to remove` : 'Empty — tap to place'}
+              >
+                {cell ? (
+                  <>
+                    <SpriteImg name={cell.cardName} className="city-cell-sprite" />
+                    <div className="city-cell-name">{cell.cardName}</div>
+                    {getCardLevel(city, cell.cardName) > 0 && (
+                      <div className="city-cell-level">★{getCardLevel(city, cell.cardName)}</div>
+                    )}
+                    {cell.spawnedUnitName && (
+                      <div
+                        className="city-cell-happiness"
+                        style={{
+                          width: `${happiness}%`,
+                          background: happiness > 60 ? '#40a040' : happiness > 30 ? '#a0a020' : '#a03020',
+                        }}
+                      />
+                    )}
+                    {unhappy && <span className="city-cell-unhappy-icon">⚠</span>}
+                  </>
+                ) : (
+                  <span className="city-cell-empty">+</span>
+                )}
+              </button>
+            )
+          })}
+        </div>
+
+        {/* Walking units overlay */}
+        <div className="city-unit-overlay" aria-hidden="true">
+          {walkers.map(w => {
+            const happiness = city.happiness[w.cellIndex] ?? 100
+            return (
+              <div
+                key={w.cellIndex}
+                className={`city-walker${happiness === 0 ? ' city-walker--unhappy' : ''}`}
+                style={{ left: Math.round(w.x), top: Math.round(w.y) }}
+              >
+                <AnimatedSpriteImg
+                  name={w.unitName}
+                  frameCount={3}
+                  fps={6}
+                  className="city-walker-sprite"
+                />
+                {happiness < 30 && <span className="city-walker-need">!</span>}
+              </div>
+            )
+          })}
+        </div>
       </div>
 
       {/* Level up section */}
@@ -237,14 +378,14 @@ export function CityBuilder({ onBack }: Props) {
       <div className="city-hint">Spend gold to permanently boost cards in battle.</div>
       <div className="city-level-grid">
         {levellable.map(card => {
-          const level = getCardLevel(city, card.name)
-          const cost  = levelUpCost(level)
+          const level     = getCardLevel(city, card.name)
+          const cost      = levelUpCost(level)
           const canAfford = cost !== null && city.gold >= cost
           return (
             <button
               key={card.name}
               className={`city-level-card${level > 0 ? ' city-level-card--levelled' : ''}`}
-              onClick={() => setLevelCard(card.name)}
+              onClick={() => { setLevelCard(card.name); setScreen('levelup') }}
             >
               <SpriteImg name={card.name} className="city-level-card-sprite" />
               <div className="city-level-card-name">{card.name}</div>

--- a/web/src/game/cityBuilder.ts
+++ b/web/src/game/cityBuilder.ts
@@ -1,57 +1,62 @@
 // ─── City Builder ─────────────────────────────────────────────────────────────
-// Persistent idle city: place owned units/buildings on a grid, collect gold
-// over time, spend gold to permanently level up cards.
+// Persistent idle city: place owned structures on a grid. Spawn buildings show
+// their unit walking around the city view. Units need wages (gold); if unaffordable
+// their happiness drops and their building earns at half rate.
 
 import { logError } from '../logger'
 import { CardRarity } from './types'
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
-export const CITY_COLS = 6
-export const CITY_ROWS = 4
+export const CITY_COLS  = 6
+export const CITY_ROWS  = 4
 export const CITY_CELLS = CITY_COLS * CITY_ROWS
+
+/** Each grid cell is this many pixels wide/tall in the overlay. */
+export const CELL_PX = 72
 
 /** Max minutes of offline accumulation counted (8 hours). */
 const MAX_OFFLINE_MINUTES = 480
 
-/** Gold generated per minute per cell, keyed by rarity. */
-const GOLD_PER_MIN_UNIT: Record<CardRarity, number> = {
-  common: 1,
-  uncommon: 2,
-  rare: 3,
-  legendary: 5,
-}
-const GOLD_PER_MIN_STRUCTURE: Record<CardRarity, number> = {
-  common: 3,
-  uncommon: 5,
-  rare: 7,
-  legendary: 12,
-}
+/** Income per minute for spawn buildings (offset by wage). */
+const INCOME_SPAWN: Record<CardRarity, number> = { common: 2, uncommon: 4, rare: 6, legendary: 10 }
+/** Income per minute for utility buildings (mana / heal / attack auras / etc.). */
+const INCOME_UTILITY: Record<CardRarity, number> = { common: 1, uncommon: 3, rare: 5, legendary: 8 }
+/** Income per minute for wall / no-effect structures. */
+const INCOME_WALL: Record<CardRarity, number> = { common: 0, uncommon: 1, rare: 1, legendary: 2 }
+/** Wage drained per minute per spawned unit. */
+const WAGE_SPAWN: Record<CardRarity, number> = { common: 1, uncommon: 2, rare: 3, legendary: 5 }
+
+/** Happiness regeneration per minute when wages are affordable. */
+const HAPPINESS_REGEN = 15
+/** Happiness drain per minute when wages cannot be paid. */
+const HAPPINESS_DRAIN = 20
 
 /** Level-up costs: index = target level (1-based). cost[0] = cost to reach lvl 1, etc. */
-export const LEVEL_UP_COSTS = [50000, 100000, 250000, 500000, 100000] // 
+export const LEVEL_UP_COSTS = [50000, 100000, 250000, 500000, 100000]
 export const MAX_CARD_LEVEL  = LEVEL_UP_COSTS.length
 
-/** Stat bonuses applied per level (cumulative). */
-export const LEVEL_ATK_BONUS    = 1   // per level
-export const LEVEL_MAX_HP_BONUS = 2   // per level
+export const LEVEL_ATK_BONUS    = 1
+export const LEVEL_MAX_HP_BONUS = 2
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
+export type StructureKind = 'spawn' | 'utility' | 'wall'
+
 export interface CityCell {
-  cardName:  string
-  cardType:  'unit' | 'structure'
-  rarity:    CardRarity
+  cardName:          string
+  rarity:            CardRarity
+  /** Name of the unit that this building spawns (from structureEffect.spawn), if any. */
+  spawnedUnitName?:  string
 }
 
 export interface CityState {
-  /** Sparse map: cellIndex → CityCell (undefined = empty). */
-  grid:    (CityCell | undefined)[]
-  gold:    number
-  /** timestamp (ms) of last tick calculation. */
-  lastTick: number
-  /** cardName → level (1-based; absent = level 0). */
+  grid:       (CityCell | undefined)[]
+  gold:       number
+  lastTick:   number
   cardLevels: Record<string, number>
+  /** cellIndex → happiness 0–100 (only meaningful for spawn buildings). */
+  happiness:  Record<number, number>
 }
 
 // ── Storage ───────────────────────────────────────────────────────────────────
@@ -64,6 +69,7 @@ function defaultState(): CityState {
     gold:       0,
     lastTick:   Date.now(),
     cardLevels: {},
+    happiness:  {},
   }
 }
 
@@ -77,6 +83,7 @@ export function loadCityState(): CityState {
       gold:       parsed.gold       ?? 0,
       lastTick:   parsed.lastTick   ?? Date.now(),
       cardLevels: parsed.cardLevels ?? {},
+      happiness:  parsed.happiness  ?? {},
     }
   } catch (err) {
     logError('loadCityState failed', err as Record<string, unknown>)
@@ -92,58 +99,113 @@ export function saveCityState(state: CityState): void {
   }
 }
 
+// ── Structure classification ──────────────────────────────────────────────────
+
+export function getStructureKind(cell: CityCell): StructureKind {
+  if (cell.spawnedUnitName) return 'spawn'
+  return 'utility'
+}
+
+function cellIncomeRate(cell: CityCell, happy: boolean): number {
+  const kind = getStructureKind(cell)
+  const base = kind === 'spawn'
+    ? INCOME_SPAWN[cell.rarity]
+    : kind === 'wall'
+    ? INCOME_WALL[cell.rarity]
+    : INCOME_UTILITY[cell.rarity]
+  if (kind === 'spawn' && !happy) return base * 0.5
+  return base
+}
+
 // ── Offline tick ──────────────────────────────────────────────────────────────
 
-/** Calculate gold earned since lastTick, cap at MAX_OFFLINE_MINUTES, return updated state. */
 export function tickCity(state: CityState): CityState {
   const now     = Date.now()
   const elapsed = now - state.lastTick
   const minutes = Math.min(elapsed / 60_000, MAX_OFFLINE_MINUTES)
 
-  let earned = 0
-  for (const cell of state.grid) {
+  let goldEarned  = 0
+  let wagesOwed   = 0
+  const newHappy  = { ...state.happiness }
+
+  // Calculate totals
+  for (let i = 0; i < state.grid.length; i++) {
+    const cell = state.grid[i]
     if (!cell) continue
-    const rate = cell.cardType === 'structure'
-      ? GOLD_PER_MIN_STRUCTURE[cell.rarity]
-      : GOLD_PER_MIN_UNIT[cell.rarity]
-    earned += rate * minutes
+    const happy = (newHappy[i] ?? 100) > 0
+    goldEarned += cellIncomeRate(cell, happy) * minutes
+    if (cell.spawnedUnitName && happy) {
+      wagesOwed += WAGE_SPAWN[cell.rarity] * minutes
+    }
   }
+
+  const canPayWages = state.gold + Math.floor(goldEarned) >= Math.floor(wagesOwed)
+
+  // Update happiness
+  for (let i = 0; i < state.grid.length; i++) {
+    const cell = state.grid[i]
+    if (!cell?.spawnedUnitName) continue
+    const current = newHappy[i] ?? 100
+    if (canPayWages) {
+      newHappy[i] = Math.min(100, current + HAPPINESS_REGEN * minutes)
+    } else {
+      newHappy[i] = Math.max(0, current - HAPPINESS_DRAIN * minutes)
+    }
+  }
+
+  const goldDelta = Math.floor(goldEarned) - (canPayWages ? Math.floor(wagesOwed) : 0)
 
   return {
     ...state,
-    gold:     state.gold + Math.floor(earned),
-    lastTick: now,
+    gold:      Math.max(0, state.gold + goldDelta),
+    lastTick:  now,
+    happiness: newHappy,
   }
 }
 
 // ── Grid helpers ──────────────────────────────────────────────────────────────
 
-export function placeCard(
-  state: CityState,
-  index: number,
-  cell: CityCell,
-): CityState {
+export function placeCard(state: CityState, index: number, cell: CityCell): CityState {
   const grid = [...state.grid]
   grid[index] = cell
-  return { ...state, grid }
+  const happiness = { ...state.happiness }
+  if (cell.spawnedUnitName) happiness[index] = 100
+  return { ...state, grid, happiness }
 }
 
 export function removeCard(state: CityState, index: number): CityState {
   const grid = [...state.grid]
   grid[index] = undefined
-  return { ...state, grid }
+  const happiness = { ...state.happiness }
+  delete happiness[index]
+  return { ...state, grid, happiness }
 }
 
-/** Gold generated per minute for the current city layout. */
-export function goldPerMinute(state: CityState): number {
+// ── Rate helpers ──────────────────────────────────────────────────────────────
+
+export function goldIncomeRate(state: CityState): number {
   let total = 0
-  for (const cell of state.grid) {
+  for (let i = 0; i < state.grid.length; i++) {
+    const cell = state.grid[i]
     if (!cell) continue
-    total += cell.cardType === 'structure'
-      ? GOLD_PER_MIN_STRUCTURE[cell.rarity]
-      : GOLD_PER_MIN_UNIT[cell.rarity]
+    const happy = (state.happiness[i] ?? 100) > 0
+    total += cellIncomeRate(cell, happy)
   }
   return total
+}
+
+export function goldWageRate(state: CityState): number {
+  let total = 0
+  for (let i = 0; i < state.grid.length; i++) {
+    const cell = state.grid[i]
+    if (!cell?.spawnedUnitName) continue
+    total += WAGE_SPAWN[cell.rarity]
+  }
+  return total
+}
+
+export function goldNetRate(state: CityState): number {
+  return goldIncomeRate(state) - goldWageRate(state)
 }
 
 // ── Card levelling ────────────────────────────────────────────────────────────
@@ -168,7 +230,7 @@ export function levelUpCard(state: CityState, cardName: string): CityState | nul
   }
 }
 
-// ── Stat bonus helpers ────────────────────────────────────────────────────────
+// ── Battle stat bonus helpers ─────────────────────────────────────────────────
 
 export function getCardBonuses(cardName: string): { atk: number; maxHp: number } {
   try {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -8809,28 +8809,10 @@ html.light-mode .action-btn {
   margin: 8px 0 16px;
 }
 
-.city-builder-hub-icon {
-  font-size: 28px;
-  flex-shrink: 0;
-}
-
-.city-builder-hub-info {
-  flex: 1;
-  min-width: 0;
-}
-
-.city-builder-hub-name {
-  font-size: 13px;
-  font-weight: bold;
-  color: #60d060;
-  letter-spacing: 1px;
-  margin-bottom: 4px;
-}
-
-.city-builder-hub-desc {
-  font-size: 11px;
-  color: #669966;
-}
+.city-builder-hub-icon { font-size: 28px; flex-shrink: 0; }
+.city-builder-hub-info { flex: 1; min-width: 0; }
+.city-builder-hub-name { font-size: 13px; font-weight: bold; color: #60d060; letter-spacing: 1px; margin-bottom: 4px; }
+.city-builder-hub-desc { font-size: 11px; color: #669966; }
 
 /* ── City Builder Screen ──────────────────────────────────────────────────── */
 
@@ -8865,61 +8847,60 @@ html.light-mode .action-btn {
   font-weight: bold;
 }
 
-.city-subheader {
+/* Income / wage row */
+.city-income-row {
   font-size: 11px;
-  color: #669966;
   text-align: center;
-  letter-spacing: 1px;
+  display: flex;
+  justify-content: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+.city-income-in   { color: #60a060; }
+.city-income-wage { color: #a06060; }
+.city-income-net--pos { color: #60d060; font-weight: bold; }
+.city-income-net--neg { color: #d06060; font-weight: bold; }
+
+/* ── City world: grid + walker overlay ───────────────────────────────────── */
+
+.city-world {
+  position: relative;
+  width: 100%;
+  /* height is determined by grid content */
 }
 
 .city-grid {
   display: grid;
-  gap: 6px;
-  margin: 4px 0;
+  gap: 3px;
+  width: 100%;
 }
 
 .city-cell {
   background: #050a05;
   border: 1px dashed #1a3a1a;
   border-radius: 3px;
-  min-height: 64px;
+  min-height: 72px;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  padding: 4px;
+  padding: 4px 2px 8px;
   position: relative;
   transition: border-color 0.15s;
+  overflow: hidden;
 }
 
-.city-cell:hover {
-  border-color: #3a7a3a;
-  background: #080f08;
-}
+.city-cell:hover             { border-color: #3a7a3a; background: #080f08; }
+.city-cell--occupied         { border-style: solid; border-color: #207020; background: #061006; }
+.city-cell--occupied:hover   { border-color: #aa3030; background: #120606; }
 
-.city-cell--occupied {
-  border-style: solid;
-  border-color: #207020;
-  background: #061006;
-}
-
-.city-cell--occupied:hover {
-  border-color: #aa3030;
-  background: #120606;
-}
-
-.city-cell-sprite {
-  width: 32px;
-  height: 32px;
-  image-rendering: pixelated;
-}
+.city-cell-sprite  { width: 32px; height: 32px; image-rendering: pixelated; }
 
 .city-cell-name {
-  font-size: 8px;
+  font-size: 7px;
   color: #669966;
   text-align: center;
-  letter-spacing: 0.5px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -8935,10 +8916,65 @@ html.light-mode .action-btn {
   font-weight: bold;
 }
 
-.city-cell-empty {
-  font-size: 20px;
-  color: #1a3a1a;
+.city-cell-empty { font-size: 20px; color: #1a3a1a; }
+
+/* Happiness bar — thin strip at very bottom of cell */
+.city-cell-happiness {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  height: 4px;
+  border-radius: 0 0 2px 2px;
+  transition: width 1s linear, background 1s linear;
 }
+
+.city-cell-unhappy-icon {
+  position: absolute;
+  top: 1px;
+  left: 3px;
+  font-size: 9px;
+  color: #d06020;
+  line-height: 1;
+}
+
+/* ── Walker overlay ──────────────────────────────────────────────────────── */
+
+.city-unit-overlay {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  overflow: hidden;
+}
+
+.city-walker {
+  position: absolute;
+  width: 20px;
+  height: 20px;
+}
+
+.city-walker-sprite {
+  width: 20px;
+  height: 20px;
+  image-rendering: pixelated;
+}
+
+.city-walker--unhappy .city-walker-sprite {
+  opacity: 0.45;
+  filter: grayscale(1);
+}
+
+.city-walker-need {
+  position: absolute;
+  top: -6px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 9px;
+  color: #d04020;
+  font-weight: bold;
+  line-height: 1;
+}
+
+/* ── Misc city UI ─────────────────────────────────────────────────────────── */
 
 .city-section-title {
   font-size: 12px;
@@ -8949,10 +8985,7 @@ html.light-mode .action-btn {
   padding-bottom: 4px;
 }
 
-.city-hint {
-  font-size: 10px;
-  color: #4a7a4a;
-}
+.city-hint { font-size: 10px; color: #4a7a4a; }
 
 .city-toast {
   position: fixed;
@@ -8969,10 +9002,7 @@ html.light-mode .action-btn {
   pointer-events: none;
 }
 
-.city-gold {
-  color: #d0a030;
-  font-weight: bold;
-}
+.city-gold { color: #d0a030; font-weight: bold; }
 
 /* ── Card Picker ──────────────────────────────────────────────────────────── */
 
@@ -8991,12 +9021,7 @@ html.light-mode .action-btn {
   text-align: center;
 }
 
-.city-picker-empty {
-  text-align: center;
-  color: #4a7a4a;
-  font-size: 12px;
-  margin-top: 40px;
-}
+.city-picker-empty { text-align: center; color: #4a7a4a; font-size: 12px; margin-top: 40px; }
 
 .city-picker-grid {
   display: grid;
@@ -9021,16 +9046,9 @@ html.light-mode .action-btn {
   transition: border-color 0.15s, background 0.15s;
 }
 
-.city-picker-card:hover {
-  border-color: #40a040;
-  background: #091509;
-}
+.city-picker-card:hover { border-color: #40a040; background: #091509; }
 
-.city-picker-sprite {
-  width: 32px;
-  height: 32px;
-  image-rendering: pixelated;
-}
+.city-picker-sprite { width: 32px; height: 32px; image-rendering: pixelated; }
 
 .city-picker-name {
   font-size: 9px;
@@ -9042,14 +9060,21 @@ html.light-mode .action-btn {
   max-width: 100%;
 }
 
-.city-picker-rarity {
+.city-picker-rarity           { font-size: 8px; letter-spacing: 0.5px; }
+.city-picker-rarity--common   { color: #888; }
+.city-picker-rarity--uncommon { color: #4a9a4a; }
+.city-picker-rarity--rare     { color: #4a6aba; }
+.city-picker-rarity--legendary{ color: #c08020; }
+
+.city-picker-spawns {
+  display: flex;
+  align-items: center;
+  gap: 3px;
   font-size: 8px;
-  letter-spacing: 0.5px;
+  color: #4a8a4a;
 }
-.city-picker-rarity--common    { color: #888; }
-.city-picker-rarity--uncommon  { color: #4a9a4a; }
-.city-picker-rarity--rare      { color: #4a6aba; }
-.city-picker-rarity--legendary { color: #c08020; }
+
+.city-picker-spawn-icon { width: 14px; height: 14px; image-rendering: pixelated; }
 
 /* ── Level Up Panel ───────────────────────────────────────────────────────── */
 
@@ -9076,19 +9101,9 @@ html.light-mode .action-btn {
   transition: border-color 0.15s;
 }
 
-.city-level-card:hover {
-  border-color: #40a040;
-}
-
-.city-level-card--levelled {
-  border-color: #806020;
-}
-
-.city-level-card-sprite {
-  width: 28px;
-  height: 28px;
-  image-rendering: pixelated;
-}
+.city-level-card:hover        { border-color: #40a040; }
+.city-level-card--levelled    { border-color: #806020; }
+.city-level-card-sprite       { width: 28px; height: 28px; image-rendering: pixelated; }
 
 .city-level-card-name {
   font-size: 8px;
@@ -9100,35 +9115,12 @@ html.light-mode .action-btn {
   max-width: 100%;
 }
 
-.city-level-card-stars {
-  display: flex;
-  gap: 1px;
-}
-
-.city-star-sm {
-  font-size: 8px;
-  color: #2a4a2a;
-}
-
-.city-star-sm--filled {
-  color: #d0a030;
-}
-
-.city-level-card-cost {
-  font-size: 9px;
-  color: #4a7a4a;
-}
-
-.city-level-card-cost--ready {
-  color: #d0a030;
-  font-weight: bold;
-}
-
-.city-level-card-maxed {
-  font-size: 8px;
-  color: #c08020;
-  letter-spacing: 1px;
-}
+.city-level-card-stars { display: flex; gap: 1px; }
+.city-star-sm          { font-size: 8px; color: #2a4a2a; }
+.city-star-sm--filled  { color: #d0a030; }
+.city-level-card-cost        { font-size: 9px; color: #4a7a4a; }
+.city-level-card-cost--ready { color: #d0a030; font-weight: bold; }
+.city-level-card-maxed       { font-size: 8px; color: #c08020; letter-spacing: 1px; }
 
 /* ── Level Detail Screen ──────────────────────────────────────────────────── */
 
@@ -9140,42 +9132,13 @@ html.light-mode .action-btn {
   padding: 16px 8px;
 }
 
-.city-level-sprite {
-  width: 64px;
-  height: 64px;
-  image-rendering: pixelated;
-}
-
-.city-level-name {
-  font-size: 15px;
-  color: #90e090;
-  letter-spacing: 1px;
-}
-
-.city-level-stars {
-  display: flex;
-  gap: 4px;
-}
-
-.city-star {
-  font-size: 18px;
-  color: #2a4a2a;
-}
-
-.city-star--filled {
-  color: #d0a030;
-}
-
-.city-level-stats {
-  font-size: 12px;
-  color: #60d060;
-  text-align: center;
-}
-
-.city-level-cost {
-  font-size: 12px;
-  color: #aaa;
-}
+.city-level-sprite  { width: 64px; height: 64px; image-rendering: pixelated; }
+.city-level-name    { font-size: 15px; color: #90e090; letter-spacing: 1px; }
+.city-level-stars   { display: flex; gap: 4px; }
+.city-star          { font-size: 18px; color: #2a4a2a; }
+.city-star--filled  { color: #d0a030; }
+.city-level-stats   { font-size: 12px; color: #60d060; text-align: center; }
+.city-level-cost    { font-size: 12px; color: #aaa; }
 
 .city-level-costs-table {
   width: 100%;
@@ -9195,17 +9158,8 @@ html.light-mode .action-btn {
   border-radius: 2px;
 }
 
-.city-cost-row--done {
-  color: #3a5a3a;
-  text-decoration: line-through;
-}
-
-.city-level-maxed {
-  font-size: 14px;
-  color: #d0a030;
-  letter-spacing: 2px;
-  margin-top: 8px;
-}
+.city-cost-row--done { color: #3a5a3a; text-decoration: line-through; }
+.city-level-maxed    { font-size: 14px; color: #d0a030; letter-spacing: 2px; margin-top: 8px; }
 
 /* ── Card tile level badge ────────────────────────────────────────────────── */
 


### PR DESCRIPTION
## Summary

- **Structures only** — card picker now filters to `cardType === 'structure'`; unit and upgrade cards are excluded
- **Walking units** — spawn buildings (Barracks, Dragon Lair, etc.) show their spawned unit as an animated sprite walking freely around the city grid area via an absolutely-positioned overlay
- **Wages / happiness mechanic** — each spawned unit has an upkeep cost (gold/min by rarity). If the city can afford wages, happiness regenerates; if not, happiness drains. Unhappy units show greyed out with a `!` badge and their building earns at half rate
- **Income breakdown** shown in header: `+income  − wages  = net/min`
- **Picker preview** — spawn buildings show the unit sprite they produce before you place them

## Rate table

| Building kind | Income/min (common→legendary) | Wage/min |
|---|---|---|
| Spawn (e.g. Barracks) | 2 / 4 / 6 / 10 | 1 / 2 / 3 / 5 |
| Utility (Farm, Mana Tower…) | 1 / 3 / 5 / 8 | — |
| Wall / no effect | 0 / 1 / 1 / 2 | — |

## Test plan
- [ ] Picker shows only structure cards (no Goblin, Archer, upgrades)
- [ ] Placing a Barracks → Goblin walks around the city area with animated sprite
- [ ] Placing a Farm → no walker, just building with steady gold income
- [ ] Income/wage/net row updates as buildings are added/removed
- [ ] Fill grid with expensive spawn buildings → wages exceed income → happiness bar turns red → walkers grey out with `!`
- [ ] Remove buildings → net rate recovers, happiness regenerates, walkers return to normal
- [ ] Navigate away and back → walkers re-initialise at random positions; gold and happiness persist

https://claude.ai/code/session_01A1iZfbm7oN6wq27pRVwSzg

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1iZfbm7oN6wq27pRVwSzg)_