### PR TITLE
feat(mastery): meaningful bonuses for all building card types (#719)

### DIFF
--- a/web/src/components/CardDetailModal.tsx
+++ b/web/src/components/CardDetailModal.tsx
@@ -62,7 +62,11 @@ export function CardDetailModal({ card, collection, deckEntries, onClose, extras
 
   // Mastery stat bonuses (mirroring applyMasteryBonus in collection.ts)
   const atkBonus = (u && u.moveSpeed > 0) ? masteryLvl : 0
-  const hpBonus  = u ? (u.moveSpeed > 0 ? masteryLvl * 2 : masteryLvl * 10) : 0
+  const hpBonus  = u
+    ? u.moveSpeed > 0
+      ? masteryLvl * 2
+      : Math.round(u.maxHp * (1 + 0.1 * masteryLvl)) - u.maxHp
+    : 0
 
   const cityLevel   = getCardLevel(loadCityState(), card.name)
   const cityAtkBonus  = cityLevel * LEVEL_ATK_BONUS
@@ -221,7 +225,7 @@ export function CardDetailModal({ card, collection, deckEntries, onClose, extras
                 {masteryLvl < 5 && <span className="cdm-mastery-xp">{xpCur}/{xpNeeded} to Lv{masteryLvl + 1}</span>}
               </div>
               <MasteryBar xp={xp} />
-              {u && (
+              {u && u.moveSpeed > 0 && (
                 <div className="cdm-mastery-milestones">
                   <div className={`cdm-milestone${masteryLvl >= 1 ? ' cdm-milestone--unlocked' : ''}`}>
                     Lv1 — Affinity activates
@@ -231,6 +235,38 @@ export function CardDetailModal({ card, collection, deckEntries, onClose, extras
                   </div>
                 </div>
               )}
+              {u && u.moveSpeed === 0 && (() => {
+                const se = u.structureEffect as { type: string } | undefined
+                const milestones: { lvl: number; text: string }[] = [
+                  { lvl: 1, text: '+10% max HP per level' },
+                ]
+                if (u.isWall) {
+                  milestones.push({ lvl: 5, text: 'Elite: self-repairs 2 HP every 6s' })
+                } else if (se?.type === 'spawn') {
+                  milestones.push({ lvl: 1, text: '−5% spawn interval per level' })
+                } else if (se?.type === 'mana') {
+                  milestones.push({ lvl: 5, text: 'Elite: +1 mana produced per turn' })
+                } else if (se?.type === 'healAura') {
+                  milestones.push({ lvl: 1, text: '+1 heal per level' })
+                  milestones.push({ lvl: 5, text: 'Elite: 25% faster heal pulses' })
+                } else if (se?.type === 'repairAura') {
+                  milestones.push({ lvl: 1, text: '+1 repair per level' })
+                  milestones.push({ lvl: 5, text: 'Elite: 25% faster repair pulses' })
+                } else if (se?.type === 'attackAura') {
+                  milestones.push({ lvl: 1, text: '+1 ATK aura per 2 levels' })
+                } else if (se?.type === 'manaSpeed') {
+                  milestones.push({ lvl: 1, text: '4% faster mana regen per level' })
+                }
+                return (
+                  <div className="cdm-mastery-milestones">
+                    {milestones.map(m => (
+                      <div key={m.text} className={`cdm-milestone${masteryLvl >= m.lvl ? ' cdm-milestone--unlocked' : ''}`}>
+                        Lv{m.lvl} — {m.text}
+                      </div>
+                    ))}
+                  </div>
+                )
+              })()}
             </div>
 
             {/* Battle stats */}

--- a/web/src/game/collection.ts
+++ b/web/src/game/collection.ts
@@ -333,24 +333,36 @@ function applyMasteryBonus(card: Card, lvl: number): Card {
     u.attack = u.attack + lvl
     u.maxHp  = u.maxHp  + lvl * 2
   } else {
-    // Structures: +10% HP per mastery level
+    // Structures: +10% HP per mastery level (all types)
     u.maxHp = Math.round(u.maxHp * (1 + 0.1 * lvl))
-    // Mastery 5 unlocks a type-specific bonus
-    if (lvl >= 5) {
-      if (u.isWall) {
-        // Walls gain a self-repair aura (2 HP every 6 s)
-        u.structureEffect = { type: 'repairAura', amount: 2, intervalMs: 6000 }
-      } else if (u.structureEffect?.type === 'spawn') {
-        // Spawners get 25% faster spawn rate
-        const e = { ...(u.structureEffect as { type: 'spawn'; unitTemplate: import('./types').UnitTemplate; intervalMs: number }) }
-        e.intervalMs = Math.round(e.intervalMs * 0.75)
-        u.structureEffect = e
-      } else if (u.structureEffect?.type === 'mana') {
-        // Farms produce 1 extra mana
-        const e = { ...(u.structureEffect as { type: 'mana'; amount: number }) }
-        e.amount = e.amount + 1
-        u.structureEffect = e
+    if (u.isWall) {
+      // Lv5: walls gain a self-repair aura (2 HP every 6 s)
+      if (lvl >= 5) u.structureEffect = { type: 'repairAura', amount: 2, intervalMs: 6000 }
+    } else if (u.structureEffect) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const e = { ...u.structureEffect } as any
+      if (e.type === 'spawn') {
+        // −5% spawn interval per mastery level (cumulative)
+        e.intervalMs = Math.round(e.intervalMs * Math.pow(0.95, lvl))
+      } else if (e.type === 'mana') {
+        // Lv5: produce 1 extra mana per turn
+        if (lvl >= 5) e.amount = e.amount + 1
+      } else if (e.type === 'healAura') {
+        // +1 heal per mastery level; Lv5: 25% faster pulse
+        e.amount = e.amount + lvl
+        if (lvl >= 5) e.intervalMs = Math.round(e.intervalMs * 0.75)
+      } else if (e.type === 'repairAura') {
+        // +1 repair per mastery level; Lv5: 25% faster pulse
+        e.amount = e.amount + lvl
+        if (lvl >= 5) e.intervalMs = Math.round(e.intervalMs * 0.75)
+      } else if (e.type === 'attackAura') {
+        // +1 ATK aura per 2 mastery levels
+        e.amount = e.amount + Math.floor(lvl / 2)
+      } else if (e.type === 'manaSpeed') {
+        // 4% faster mana regen per mastery level (speedMult floored at 0.1)
+        e.speedMult = Math.max(0.1, +(e.speedMult - lvl * 0.04).toFixed(2))
       }
+      u.structureEffect = e
     }
   }
   return { ...card, unit: u }


### PR DESCRIPTION
## Summary

Fixes #719 — building card mastery previously had almost no gameplay effect and the card inspector showed wrong milestone text (unit-only milestones like "Affinity activates" and "+10% damage dealt").

- **`collection.ts`** — `applyMasteryBonus` now scales all structure effect types per mastery level:
  - `spawn` — −5% spawn interval per level (replaces the flat Lv5 −25%)
  - `healAura` — +1 heal amount per level; Lv5: 25% faster heal pulses
  - `repairAura` — +1 repair amount per level; Lv5: 25% faster repair pulses
  - `attackAura` — +1 ATK aura per 2 levels
  - `manaSpeed` — −4% speedMult per level (faster mana regen)
  - `wall` + `mana` (Farm) Lv5 unlocks unchanged
- **`CardDetailModal.tsx`** — mastery milestones section now shows building-specific text derived from the structure effect type, instead of unit-only milestones that don't apply to buildings. Also fixes a display bug where the HP bonus preview used a flat ×10 formula instead of the correct percentage.

## Test plan

- [ ] `npm run build` passes with no TypeScript errors ✅
- [ ] Open Card Detail for a **wall** — milestones show "+10% max HP per level" and "Lv5 — Elite: self-repairs 2 HP every 6s"
- [ ] Open Card Detail for a **spawner** (e.g. Barracks) — shows "−5% spawn interval per level"
- [ ] Open Card Detail for a **Farm** — shows "Lv5 — Elite: +1 mana produced per turn"
- [ ] Open Card Detail for a **Healer's Hut** — shows "+1 heal per level" and "Lv5 — 25% faster heal pulses"
- [ ] Open Card Detail for a **Blacksmith** — shows "+1 ATK aura per 2 levels"
- [ ] HP stat in the modal shows a correct percentage-based bonus (not a flat +10 per level)
- [ ] Unit cards (e.g. Goblin) still show the old "Affinity activates" / "+10% damage" milestones

https://claude.ai/code/session_01CayVUWdNYirJAStpaayfs8

---
_Generated by [Claude Code](https://claude.ai/code/session_01CayVUWdNYirJAStpaayfs8)_