### PR TITLE
City builder: restrict level-up section to structures only

### DIFF
--- a/web/src/components/minigames/CityBuilder.tsx
+++ b/web/src/components/minigames/CityBuilder.tsx
@@ -188,7 +188,7 @@ export function CityBuilder({ onBack }: Props) {
     (placedCounts[c.name] ?? 0) < getOwnedCount(collection, c.name)
   )
 
-  const levellable = catalog.filter(c => getOwnedCount(collection, c.name) > 0)
+  const levellable = catalog.filter(c => c.cardType === 'structure' && getOwnedCount(collection, c.name) > 0)
 
   const incomeRate = Math.round(goldIncomeRate(city))
   const wageRate   = Math.round(goldWageRate(city))
@@ -374,8 +374,8 @@ export function CityBuilder({ onBack }: Props) {
       </div>
 
       {/* Level up section */}
-      <div className="city-section-title">LEVEL UP CARDS</div>
-      <div className="city-hint">Spend gold to permanently boost cards in battle.</div>
+      <div className="city-section-title">LEVEL UP BUILDINGS</div>
+      <div className="city-hint">Spend gold to permanently boost your structures in battle.</div>
       <div className="city-level-grid">
         {levellable.map(card => {
           const level     = getCardLevel(city, card.name)


### PR DESCRIPTION
## Summary
- The "LEVEL UP" section in the City Builder now only lists structure cards (previously showed all owned cards including units and spells)
- Section title updated to "LEVEL UP BUILDINGS" and hint text updated accordingly

## Test plan
- [ ] Open City Builder → LEVEL UP BUILDINGS section shows only structure cards (e.g. Barracks, Farm), not unit or spell cards
- [ ] Levelling up a structure still works and costs gold correctly
- [ ] Unit cards (e.g. Goblin) do not appear in the level-up list

https://claude.ai/code/session_01A1iZfbm7oN6wq27pRVwSzg

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1iZfbm7oN6wq27pRVwSzg)_