### PR TITLE
feat(city-builder): resource system, city stats, affinity bubbles, upgrade screen (#800)

### DIFF
--- a/web/src/components/minigames/CityBuilder.tsx
+++ b/web/src/components/minigames/CityBuilder.tsx
@@ -1,17 +1,21 @@
 // ─── City Builder ─────────────────────────────────────────────────────────────
 // Idle city: place owned structure cards on a grid. Spawn buildings show their
-// unit walking around the city. Units need wages; if unpaid, happiness drops
-// and the building earns at half rate.
+// unit walking around the city. Resources are produced and consumed over time.
+// Happiness is driven by food and defence.
 
 import React, { useState, useEffect, useCallback, useRef } from 'react'
 import { getCardCatalog } from '../../game/cards'
 import { loadCollection, getOwnedCount } from '../../game/collection'
 import {
   CITY_COLS, CITY_ROWS, CITY_CELLS, CELL_PX,
-  CityCell, CityState,
+  CityCell, CityState, ResourceType, ResourceStock,
+  RESOURCE_ICONS, SPAWNER_PLACE_COST,
   loadCityState, saveCityState, tickCity,
   placeCard, removeCard,
-  goldIncomeRate, goldWageRate, goldNetRate,
+  goldIncomeRate, goldNetRate,
+  cityDefense, cityPopulation,
+  canAffordPlacement,
+  resourceProductionRate, resourceConsumptionRate,
   getCardLevel, levelUpCost, levelUpCard,
   LEVEL_UP_COSTS, MAX_CARD_LEVEL, LEVEL_ATK_BONUS, LEVEL_MAX_HP_BONUS,
 } from '../../game/cityBuilder'
@@ -28,6 +32,7 @@ const SPEED     = 0.8 // px per 100 ms tick
 interface Walker {
   cellIndex: number
   unitName:  string
+  affinityWith?: string
   x:   number
   y:   number
   vx:  number
@@ -35,11 +40,12 @@ interface Walker {
   turnTimer: number
 }
 
-function makeWalker(cellIndex: number, unitName: string): Walker {
+function makeWalker(cellIndex: number, unitName: string, affinityWith?: string): Walker {
   const angle = Math.random() * Math.PI * 2
   return {
     cellIndex,
     unitName,
+    affinityWith,
     x: Math.random() * (OVERLAY_W - UNIT_SIZE),
     y: Math.random() * (OVERLAY_H - UNIT_SIZE),
     vx: Math.cos(angle) * SPEED,
@@ -54,7 +60,7 @@ interface Props {
   onBack: () => void
 }
 
-type SubScreen = 'city' | 'picker' | 'levelup'
+type SubScreen = 'city' | 'picker' | 'upgrade' | 'levelup'
 
 export function CityBuilder({ onBack }: Props) {
   const [city, setCity]       = useState<CityState>(() => tickCity(loadCityState()))
@@ -83,7 +89,7 @@ export function CityBuilder({ onBack }: Props) {
         const cell = city.grid[i]
         if (!cell?.spawnedUnitName) continue
         const existing = prev.find(w => w.cellIndex === i && w.unitName === cell.spawnedUnitName)
-        next.push(existing ?? makeWalker(i, cell.spawnedUnitName))
+        next.push(existing ?? makeWalker(i, cell.spawnedUnitName, cell.affinityWith))
       }
       return next
     })
@@ -92,18 +98,15 @@ export function CityBuilder({ onBack }: Props) {
 
   // ── Animation loop ────────────────────────────────────────────────────────────
 
-  const walkersRef = useRef(walkers)
-  walkersRef.current = walkers
-
   useEffect(() => {
     const id = setInterval(() => {
       setWalkers(prev => prev.map(w => {
         let { x, y, vx, vy, turnTimer } = w
         x += vx
         y += vy
-        if (x < 0)                 { x = 0;                  vx = Math.abs(vx) }
+        if (x < 0)                     { x = 0;                    vx = Math.abs(vx) }
         if (x > OVERLAY_W - UNIT_SIZE) { x = OVERLAY_W - UNIT_SIZE; vx = -Math.abs(vx) }
-        if (y < 0)                 { y = 0;                  vy = Math.abs(vy) }
+        if (y < 0)                     { y = 0;                    vy = Math.abs(vy) }
         if (y > OVERLAY_H - UNIT_SIZE) { y = OVERLAY_H - UNIT_SIZE; vy = -Math.abs(vy) }
         turnTimer--
         if (turnTimer <= 0) {
@@ -116,9 +119,9 @@ export function CityBuilder({ onBack }: Props) {
       }))
     }, 100)
     return () => clearInterval(id)
-  }, []) // stable — no deps
+  }, [])
 
-  // ── Gold tick (every 10 s while screen is open) ───────────────────────────────
+  // ── Gold + resource tick (every 10 s while screen is open) ───────────────────
 
   useEffect(() => {
     const id = setInterval(() => {
@@ -148,13 +151,23 @@ export function CityBuilder({ onBack }: Props) {
 
   const handlePickCard = useCallback((card: Card) => {
     const spawnEffect = card.unit?.structureEffect
-    const spawnedUnitName = spawnEffect?.type === 'spawn'
+    const isSpawner   = spawnEffect?.type === 'spawn'
+    const spawnedUnitName = isSpawner
       ? (spawnEffect as { type: 'spawn'; unitTemplate: { name: string }; intervalMs: number }).unitTemplate.name
       : undefined
+
+    if (isSpawner && !canAffordPlacement(city, card.rarity)) {
+      showToast('Not enough resources!')
+      return
+    }
+
+    const affinityWith = card.unit?.affinity?.withName
+
     const cell: CityCell = {
-      cardName:        card.name,
-      rarity:          card.rarity,
+      cardName: card.name,
+      rarity:   card.rarity,
       spawnedUnitName,
+      affinityWith,
     }
     save(placeCard(city, pickerIndex, cell))
     setScreen('city')
@@ -188,11 +201,22 @@ export function CityBuilder({ onBack }: Props) {
     (placedCounts[c.name] ?? 0) < getOwnedCount(collection, c.name)
   )
 
-  const levellable = catalog.filter(c => c.cardType === 'structure' && getOwnedCount(collection, c.name) > 0)
+  const levellable = catalog.filter(c =>
+    c.cardType === 'structure' && getOwnedCount(collection, c.name) > 0
+  )
 
   const incomeRate = Math.round(goldIncomeRate(city))
-  const wageRate   = Math.round(goldWageRate(city))
   const netRate    = Math.round(goldNetRate(city))
+  const defense    = cityDefense(city)
+  const population = cityPopulation(city)
+
+  const prodRates = resourceProductionRate(city)
+  const consRates = resourceConsumptionRate(city)
+
+  // Which unit names are currently present in the city as walkers
+  const presentUnitNames = new Set(
+    city.grid.filter(Boolean).map(c => c!.spawnedUnitName).filter(Boolean) as string[]
+  )
 
   // ── Card picker sub-screen ────────────────────────────────────────────────────
 
@@ -209,17 +233,33 @@ export function CityBuilder({ onBack }: Props) {
           <div className="city-picker-grid">
             {availableForPlace.map(card => {
               const spawnEffect = card.unit?.structureEffect
-              const spawnName = spawnEffect?.type === 'spawn'
+              const isSpawner   = spawnEffect?.type === 'spawn'
+              const spawnName   = isSpawner
                 ? (spawnEffect as { type: 'spawn'; unitTemplate: { name: string }; intervalMs: number }).unitTemplate.name
                 : null
+              const affordable  = !isSpawner || canAffordPlacement(city, card.rarity)
+              const cost        = isSpawner ? SPAWNER_PLACE_COST[card.rarity] : null
+
               return (
-                <button key={card.name} className="city-picker-card" onClick={() => handlePickCard(card)}>
+                <button
+                  key={card.name}
+                  className={`city-picker-card${!affordable ? ' city-picker-card--unaffordable' : ''}`}
+                  onClick={() => handlePickCard(card)}
+                  disabled={!affordable}
+                >
                   <SpriteImg name={card.name} className="city-picker-sprite" />
                   <div className="city-picker-name">{card.name}</div>
                   <div className={`city-picker-rarity city-picker-rarity--${card.rarity}`}>{card.rarity}</div>
                   {spawnName && (
                     <div className="city-picker-spawns">
                       spawns <SpriteImg name={spawnName} className="city-picker-spawn-icon" />
+                    </div>
+                  )}
+                  {cost && (
+                    <div className="city-picker-cost">
+                      {Object.entries(cost).map(([r, amt]) =>
+                        `${RESOURCE_ICONS[r as ResourceType]}${amt}`
+                      ).join(' ')}
                     </div>
                   )}
                 </button>
@@ -231,7 +271,55 @@ export function CityBuilder({ onBack }: Props) {
     )
   }
 
-  // ── Level-up sub-screen ───────────────────────────────────────────────────────
+  // ── Upgrade sub-screen (card level-up grid) ───────────────────────────────────
+
+  if (screen === 'upgrade') {
+    return (
+      <div className="city-screen">
+        <div className="city-picker-header">
+          <button className="action-btn" onClick={() => setScreen('city')}>← BACK</button>
+          <div className="city-picker-title">UPGRADE BUILDINGS</div>
+        </div>
+        <div className="city-gold-display" style={{ textAlign: 'center', padding: '4px' }}>
+          ⚙ {city.gold.toLocaleString()} gold
+        </div>
+        <div className="city-hint" style={{ textAlign: 'center', marginBottom: 6 }}>
+          Spend gold to permanently boost structures in battle.
+        </div>
+        <div className="city-level-grid">
+          {levellable.map(card => {
+            const level     = getCardLevel(city, card.name)
+            const cost      = levelUpCost(level)
+            const canAfford = cost !== null && city.gold >= cost
+            return (
+              <button
+                key={card.name}
+                className={`city-level-card${level > 0 ? ' city-level-card--levelled' : ''}`}
+                onClick={() => { setLevelCard(card.name); setScreen('levelup') }}
+              >
+                <SpriteImg name={card.name} className="city-level-card-sprite" />
+                <div className="city-level-card-name">{card.name}</div>
+                <div className="city-level-card-stars">
+                  {Array.from({ length: MAX_CARD_LEVEL }, (_, i) => (
+                    <span key={i} className={`city-star-sm${i < level ? ' city-star-sm--filled' : ''}`}>★</span>
+                  ))}
+                </div>
+                {level < MAX_CARD_LEVEL ? (
+                  <div className={`city-level-card-cost${canAfford ? ' city-level-card-cost--ready' : ''}`}>
+                    ⚙ {cost}
+                  </div>
+                ) : (
+                  <div className="city-level-card-maxed">MAX</div>
+                )}
+              </button>
+            )
+          })}
+        </div>
+      </div>
+    )
+  }
+
+  // ── Level-up detail sub-screen ────────────────────────────────────────────────
 
   if (screen === 'levelup' && levelCard !== null) {
     const card  = catalog.find(c => c.name === levelCard)
@@ -240,7 +328,7 @@ export function CityBuilder({ onBack }: Props) {
     return (
       <div className="city-screen">
         <div className="city-picker-header">
-          <button className="action-btn" onClick={() => setScreen('city')}>← BACK</button>
+          <button className="action-btn" onClick={() => setScreen('upgrade')}>← BACK</button>
           <div className="city-picker-title">LEVEL UP CARD</div>
         </div>
         <div className="city-level-detail">
@@ -295,16 +383,45 @@ export function CityBuilder({ onBack }: Props) {
       <div className="city-header">
         <button className="action-btn" onClick={onBack}>← BACK</button>
         <div className="city-title">🏙 CITY</div>
-        <div className="city-gold-display">⚙ {city.gold.toLocaleString()}</div>
+        <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+          <div className="city-gold-display">⚙ {city.gold.toLocaleString()}</div>
+          <button className="filter-btn" onClick={() => setScreen('upgrade')}>★ UPGRADES</button>
+        </div>
       </div>
 
-      {/* Income breakdown */}
+      {/* Income summary */}
       <div className="city-income-row">
-        <span className="city-income-in">+{incomeRate} income</span>
-        {wageRate > 0 && <span className="city-income-wage"> − {wageRate} wages</span>}
+        <span className="city-income-in">+{incomeRate} gold</span>
         <span className={`city-income-net${netRate >= 0 ? ' city-income-net--pos' : ' city-income-net--neg'}`}>
-          {netRate >= 0 ? `= +${netRate}` : `= ${netRate}`}/min
+          {netRate >= 0 ? `+${netRate}` : `${netRate}`}/min
         </span>
+      </div>
+
+      {/* City stats */}
+      <div className="city-stats-row">
+        <div className="city-stat city-stat--defense" title="City Defence">
+          🛡 {defense}
+        </div>
+        <div className="city-stat city-stat--population" title="Population (active units)">
+          👥 {population}
+        </div>
+        {(['wheat', 'wood', 'ore', 'bread', 'planks', 'metal'] as ResourceType[]).map(res => {
+          const stock   = Math.floor(city.resources[res])
+          const prod    = prodRates[res] ?? 0
+          const cons    = consRates[res] ?? 0
+          const net     = prod - cons
+          if (stock === 0 && prod === 0) return null
+          return (
+            <div key={res} className="city-stat" title={`${res}: ${stock} stock, ${net >= 0 ? '+' : ''}${net}/min`}>
+              {RESOURCE_ICONS[res]} {stock}
+              {net !== 0 && (
+                <span className={net > 0 ? 'city-res-pos' : 'city-res-neg'}>
+                  {net > 0 ? `+${net}` : net}/m
+                </span>
+              )}
+            </div>
+          )
+        })}
       </div>
 
       {/* City world: grid + walker overlay */}
@@ -353,13 +470,19 @@ export function CityBuilder({ onBack }: Props) {
         {/* Walking units overlay */}
         <div className="city-unit-overlay" aria-hidden="true">
           {walkers.map(w => {
-            const happiness = city.happiness[w.cellIndex] ?? 100
+            const happiness    = city.happiness[w.cellIndex] ?? 100
+            const wantsFriend  = w.affinityWith && !presentUnitNames.has(w.affinityWith)
             return (
               <div
                 key={w.cellIndex}
                 className={`city-walker${happiness === 0 ? ' city-walker--unhappy' : ''}`}
                 style={{ left: Math.round(w.x), top: Math.round(w.y) }}
               >
+                {wantsFriend && (
+                  <div className="city-speech-bubble" title={`Wants a ${w.affinityWith}!`}>
+                    <SpriteImg name={w.affinityWith!} className="city-speech-icon" />
+                  </div>
+                )}
                 <AnimatedSpriteImg
                   name={w.unitName}
                   frameCount={3}
@@ -371,39 +494,6 @@ export function CityBuilder({ onBack }: Props) {
             )
           })}
         </div>
-      </div>
-
-      {/* Level up section */}
-      <div className="city-section-title">LEVEL UP BUILDINGS</div>
-      <div className="city-hint">Spend gold to permanently boost your structures in battle.</div>
-      <div className="city-level-grid">
-        {levellable.map(card => {
-          const level     = getCardLevel(city, card.name)
-          const cost      = levelUpCost(level)
-          const canAfford = cost !== null && city.gold >= cost
-          return (
-            <button
-              key={card.name}
-              className={`city-level-card${level > 0 ? ' city-level-card--levelled' : ''}`}
-              onClick={() => { setLevelCard(card.name); setScreen('levelup') }}
-            >
-              <SpriteImg name={card.name} className="city-level-card-sprite" />
-              <div className="city-level-card-name">{card.name}</div>
-              <div className="city-level-card-stars">
-                {Array.from({ length: MAX_CARD_LEVEL }, (_, i) => (
-                  <span key={i} className={`city-star-sm${i < level ? ' city-star-sm--filled' : ''}`}>★</span>
-                ))}
-              </div>
-              {level < MAX_CARD_LEVEL ? (
-                <div className={`city-level-card-cost${canAfford ? ' city-level-card-cost--ready' : ''}`}>
-                  ⚙ {cost}
-                </div>
-              ) : (
-                <div className="city-level-card-maxed">MAX</div>
-              )}
-            </button>
-          )
-        })}
       </div>
     </div>
   )

--- a/web/src/game/cityBuilder.ts
+++ b/web/src/game/cityBuilder.ts
@@ -1,7 +1,7 @@
 // ─── City Builder ─────────────────────────────────────────────────────────────
 // Persistent idle city: place owned structures on a grid. Spawn buildings show
-// their unit walking around the city view. Units need wages (gold); if unaffordable
-// their happiness drops and their building earns at half rate.
+// their unit walking around the city view. Resources are produced and consumed
+// each tick. Happiness is driven by food availability and city defence.
 
 import { logError } from '../logger'
 import { CardRarity } from './types'
@@ -18,41 +18,111 @@ export const CELL_PX = 72
 /** Max minutes of offline accumulation counted (8 hours). */
 const MAX_OFFLINE_MINUTES = 480
 
-/** Income per minute for spawn buildings (offset by wage). */
+/** Income per minute for spawn buildings. */
 const INCOME_SPAWN: Record<CardRarity, number> = { common: 2, uncommon: 4, rare: 6, legendary: 10 }
-/** Income per minute for utility buildings (mana / heal / attack auras / etc.). */
+/** Income per minute for utility buildings. */
 const INCOME_UTILITY: Record<CardRarity, number> = { common: 1, uncommon: 3, rare: 5, legendary: 8 }
 /** Income per minute for wall / no-effect structures. */
 const INCOME_WALL: Record<CardRarity, number> = { common: 0, uncommon: 1, rare: 1, legendary: 2 }
-/** Wage drained per minute per spawned unit. */
-const WAGE_SPAWN: Record<CardRarity, number> = { common: 1, uncommon: 2, rare: 3, legendary: 5 }
 
-/** Happiness regeneration per minute when wages are affordable. */
+/** Happiness regeneration per minute toward the target value. */
 const HAPPINESS_REGEN = 15
-/** Happiness drain per minute when wages cannot be paid. */
-const HAPPINESS_DRAIN = 20
+/** Happiness drain per minute away from target when conditions not met. */
+const HAPPINESS_DRAIN = 10
 
-/** Level-up costs: index = target level (1-based). cost[0] = cost to reach lvl 1, etc. */
+/** Level-up costs: index = target level (1-based). */
 export const LEVEL_UP_COSTS = [50000, 100000, 250000, 500000, 100000]
 export const MAX_CARD_LEVEL  = LEVEL_UP_COSTS.length
 
 export const LEVEL_ATK_BONUS    = 1
 export const LEVEL_MAX_HP_BONUS = 2
 
+// ── Resource constants ────────────────────────────────────────────────────────
+
+/** Defence value contributed by walls (per rarity). */
+const WALL_DEFENSE: Record<CardRarity, number> = { common: 5, uncommon: 10, rare: 20, legendary: 40 }
+/** Defence value contributed by spawn buildings (per rarity). */
+const SPAWN_DEFENSE: Record<CardRarity, number> = { common: 3, uncommon: 6, rare: 12, legendary: 25 }
+
+/** Wheat consumed per minute by a spawn building (units need feeding). */
+const FOOD_CONSUME_RATE: Record<CardRarity, number> = { common: 1, uncommon: 2, rare: 3, legendary: 5 }
+
+/** Resource cost to place a spawner of a given rarity. */
+export const SPAWNER_PLACE_COST: Record<CardRarity, Partial<ResourceStock>> = {
+  common:    { wheat: 20 },
+  uncommon:  { wheat: 30, wood: 10 },
+  rare:      { wheat: 50, wood: 20, ore: 10 },
+  legendary: { wheat: 80, wood: 40, ore: 20 },
+}
+
+/** Icons for each resource type (used in UI). */
+export const RESOURCE_ICONS: Record<ResourceType, string> = {
+  wheat:  '🌾',
+  wood:   '🪵',
+  ore:    '⛏',
+  bread:  '🍞',
+  planks: '🪚',
+  metal:  '⚔',
+}
+
+// ── Resource building config ──────────────────────────────────────────────────
+
+/**
+ * Map of building name → resource production per minute.
+ * Buildings not listed here fall back to keyword matching in getBuildingResourceConfig.
+ */
+const BUILDING_RESOURCE_CONFIG: Record<string, Partial<ResourceStock>> = {
+  'Farm':         { wheat: 3 },
+  'Canopy Farm':  { wheat: 4 },
+  'Blacksmith':   { metal: 1 },
+  'Stone Mason':  { planks: 2 },
+  'Cryo Forge':   { metal: 1 },
+  'Clockwork Forge': { metal: 2 },
+  'Titan Forge':  { metal: 2 },
+  'Glacial Forge':{ metal: 1 },
+  'Golem Forge':  { metal: 2 },
+  'Arcane Forge': { metal: 1 },
+  'Automaton Forge': { metal: 2 },
+}
+
+/** Keyword patterns for resource production fallback (checked in order). */
+const KEYWORD_RESOURCE: Array<{ pattern: RegExp; produces: Partial<ResourceStock> }> = [
+  { pattern: /farm/i,       produces: { wheat: 2 } },
+  { pattern: /forge|smith/i, produces: { metal: 1 } },
+  { pattern: /mason|quarry|stone/i, produces: { planks: 1, ore: 1 } },
+  { pattern: /lumber|sawmill|timber/i, produces: { wood: 3 } },
+  { pattern: /mill|bakery/i, produces: { bread: 1 } },
+  { pattern: /mine|iron hall/i, produces: { ore: 2 } },
+]
+
+function getBuildingProduces(name: string): Partial<ResourceStock> {
+  if (BUILDING_RESOURCE_CONFIG[name]) return BUILDING_RESOURCE_CONFIG[name]
+  for (const { pattern, produces } of KEYWORD_RESOURCE) {
+    if (pattern.test(name)) return produces
+  }
+  return {}
+}
+
 // ── Types ─────────────────────────────────────────────────────────────────────
+
+export type ResourceType = 'wheat' | 'wood' | 'ore' | 'bread' | 'planks' | 'metal'
+export type ResourceStock = Record<ResourceType, number>
 
 export type StructureKind = 'spawn' | 'utility' | 'wall'
 
 export interface CityCell {
   cardName:          string
   rarity:            CardRarity
-  /** Name of the unit that this building spawns (from structureEffect.spawn), if any. */
+  /** Name of the unit this building spawns (from structureEffect.spawn), if any. */
   spawnedUnitName?:  string
+  /** Unit name this walker wants as an affinity friend (stored at placement). */
+  affinityWith?:     string
 }
 
 export interface CityState {
   grid:       (CityCell | undefined)[]
   gold:       number
+  resources:  ResourceStock
   lastTick:   number
   cardLevels: Record<string, number>
   /** cellIndex → happiness 0–100 (only meaningful for spawn buildings). */
@@ -63,10 +133,15 @@ export interface CityState {
 
 const STORAGE_KEY = 'jarv_city_builder'
 
+function emptyResources(): ResourceStock {
+  return { wheat: 0, wood: 0, ore: 0, bread: 0, planks: 0, metal: 0 }
+}
+
 function defaultState(): CityState {
   return {
     grid:       Array(CITY_CELLS).fill(undefined),
-    gold:       0,
+    gold:       500,
+    resources:  { wheat: 300, wood: 300, ore: 150, bread: 0, planks: 0, metal: 0 },
     lastTick:   Date.now(),
     cardLevels: {},
     happiness:  {},
@@ -78,9 +153,18 @@ export function loadCityState(): CityState {
     const raw = localStorage.getItem(STORAGE_KEY)
     if (!raw) return defaultState()
     const parsed = JSON.parse(raw) as Partial<CityState>
+    const savedResources = (parsed.resources ?? {}) as Partial<ResourceStock>
     return {
       grid:       parsed.grid       ?? Array(CITY_CELLS).fill(undefined),
       gold:       parsed.gold       ?? 0,
+      resources:  {
+        wheat:  savedResources.wheat  ?? 0,
+        wood:   savedResources.wood   ?? 0,
+        ore:    savedResources.ore    ?? 0,
+        bread:  savedResources.bread  ?? 0,
+        planks: savedResources.planks ?? 0,
+        metal:  savedResources.metal  ?? 0,
+      },
       lastTick:   parsed.lastTick   ?? Date.now(),
       cardLevels: parsed.cardLevels ?? {},
       happiness:  parsed.happiness  ?? {},
@@ -110,11 +194,49 @@ function cellIncomeRate(cell: CityCell, happy: boolean): number {
   const kind = getStructureKind(cell)
   const base = kind === 'spawn'
     ? INCOME_SPAWN[cell.rarity]
-    : kind === 'wall'
-    ? INCOME_WALL[cell.rarity]
     : INCOME_UTILITY[cell.rarity]
   if (kind === 'spawn' && !happy) return base * 0.5
   return base
+}
+
+/** Defence value a wall contributes (full if city has any spawners, half otherwise). */
+function wallDefense(cell: CityCell, cityHasSpawners: boolean): number {
+  const base = WALL_DEFENSE[cell.rarity]
+  return cityHasSpawners ? Math.round(base * 1.5) : base
+}
+
+// ── City aggregate stats ──────────────────────────────────────────────────────
+
+export function cityDefense(state: CityState): number {
+  const hasSpawners = state.grid.some(c => c?.spawnedUnitName)
+  let total = 0
+  for (const cell of state.grid) {
+    if (!cell) continue
+    if (cell.spawnedUnitName) {
+      total += SPAWN_DEFENSE[cell.rarity]
+    } else if (!cell.spawnedUnitName && WALL_DEFENSE[cell.rarity] !== undefined) {
+      // Determine if it's actually a wall by checking income table (walls earn 0 base)
+      const incomeIfWall = INCOME_WALL[cell.rarity]
+      const incomeIfUtil = INCOME_UTILITY[cell.rarity]
+      // A cell is wall-like if its income would be 0 for common rarity and hasn't a spawn
+      // We detect walls by checking if the cell has no produced resource and no spawner
+      const produces = getBuildingProduces(cell.cardName)
+      const isResourceProducer = Object.values(produces).some(v => (v ?? 0) > 0)
+      if (!isResourceProducer && incomeIfWall < incomeIfUtil) {
+        total += wallDefense(cell, hasSpawners)
+      }
+    }
+  }
+  return total
+}
+
+export function cityPopulation(state: CityState): number {
+  let count = 0
+  for (let i = 0; i < state.grid.length; i++) {
+    const cell = state.grid[i]
+    if (cell?.spawnedUnitName && (state.happiness[i] ?? 100) > 0) count++
+  }
+  return count
 }
 
 // ── Offline tick ──────────────────────────────────────────────────────────────
@@ -124,40 +246,62 @@ export function tickCity(state: CityState): CityState {
   const elapsed = now - state.lastTick
   const minutes = Math.min(elapsed / 60_000, MAX_OFFLINE_MINUTES)
 
-  let goldEarned  = 0
-  let wagesOwed   = 0
-  const newHappy  = { ...state.happiness }
+  const newResources = { ...state.resources }
+  let goldEarned = 0
+  const newHappy = { ...state.happiness }
 
-  // Calculate totals
+  const defense   = cityDefense(state)
+  const population = Math.max(cityPopulation(state), 1)
+
   for (let i = 0; i < state.grid.length; i++) {
     const cell = state.grid[i]
     if (!cell) continue
+
     const happy = (newHappy[i] ?? 100) > 0
+
+    // Gold income
     goldEarned += cellIncomeRate(cell, happy) * minutes
+
+    // Resource production (utility/non-spawner buildings that produce resources)
+    if (!cell.spawnedUnitName) {
+      const produces = getBuildingProduces(cell.cardName)
+      for (const [res, rate] of Object.entries(produces) as [ResourceType, number][]) {
+        if (rate > 0) newResources[res] = (newResources[res] ?? 0) + rate * minutes
+      }
+    }
+
+    // Spawners consume food (wheat)
     if (cell.spawnedUnitName && happy) {
-      wagesOwed += WAGE_SPAWN[cell.rarity] * minutes
+      const consume = FOOD_CONSUME_RATE[cell.rarity] * minutes
+      newResources.wheat = Math.max(0, (newResources.wheat ?? 0) - consume)
     }
   }
 
-  const canPayWages = state.gold + Math.floor(goldEarned) >= Math.floor(wagesOwed)
+  // Update happiness toward target based on food and defence
+  const foodScore    = Math.min(100, (newResources.wheat / population) * 5)
+  const defenseScore = Math.min(100, (defense / population) * 8)
+  const happyTarget  = Math.round(foodScore * 0.6 + defenseScore * 0.4)
 
-  // Update happiness
   for (let i = 0; i < state.grid.length; i++) {
     const cell = state.grid[i]
     if (!cell?.spawnedUnitName) continue
     const current = newHappy[i] ?? 100
-    if (canPayWages) {
-      newHappy[i] = Math.min(100, current + HAPPINESS_REGEN * minutes)
-    } else {
-      newHappy[i] = Math.max(0, current - HAPPINESS_DRAIN * minutes)
+    if (current < happyTarget) {
+      newHappy[i] = Math.min(happyTarget, current + HAPPINESS_REGEN * minutes)
+    } else if (current > happyTarget) {
+      newHappy[i] = Math.max(happyTarget, current - HAPPINESS_DRAIN * minutes)
     }
   }
 
-  const goldDelta = Math.floor(goldEarned) - (canPayWages ? Math.floor(wagesOwed) : 0)
+  // Clamp resources
+  for (const key of Object.keys(newResources) as ResourceType[]) {
+    newResources[key] = Math.max(0, newResources[key])
+  }
 
   return {
     ...state,
-    gold:      Math.max(0, state.gold + goldDelta),
+    gold:      Math.max(0, state.gold + Math.floor(goldEarned)),
+    resources: newResources,
     lastTick:  now,
     happiness: newHappy,
   }
@@ -170,7 +314,17 @@ export function placeCard(state: CityState, index: number, cell: CityCell): City
   grid[index] = cell
   const happiness = { ...state.happiness }
   if (cell.spawnedUnitName) happiness[index] = 100
-  return { ...state, grid, happiness }
+
+  // Deduct placement cost for spawners
+  let resources = { ...state.resources }
+  if (cell.spawnedUnitName) {
+    const cost = SPAWNER_PLACE_COST[cell.rarity]
+    for (const [res, amount] of Object.entries(cost) as [ResourceType, number][]) {
+      resources[res] = Math.max(0, (resources[res] ?? 0) - amount)
+    }
+  }
+
+  return { ...state, grid, happiness, resources }
 }
 
 export function removeCard(state: CityState, index: number): CityState {
@@ -179,6 +333,16 @@ export function removeCard(state: CityState, index: number): CityState {
   const happiness = { ...state.happiness }
   delete happiness[index]
   return { ...state, grid, happiness }
+}
+
+// ── Affordability ─────────────────────────────────────────────────────────────
+
+export function canAffordPlacement(state: CityState, rarity: CardRarity): boolean {
+  const cost = SPAWNER_PLACE_COST[rarity]
+  for (const [res, amount] of Object.entries(cost) as [ResourceType, number][]) {
+    if ((state.resources[res] ?? 0) < amount) return false
+  }
+  return true
 }
 
 // ── Rate helpers ──────────────────────────────────────────────────────────────
@@ -194,18 +358,8 @@ export function goldIncomeRate(state: CityState): number {
   return total
 }
 
-export function goldWageRate(state: CityState): number {
-  let total = 0
-  for (let i = 0; i < state.grid.length; i++) {
-    const cell = state.grid[i]
-    if (!cell?.spawnedUnitName) continue
-    total += WAGE_SPAWN[cell.rarity]
-  }
-  return total
-}
-
 export function goldNetRate(state: CityState): number {
-  return goldIncomeRate(state) - goldWageRate(state)
+  return goldIncomeRate(state)
 }
 
 // ── Card levelling ────────────────────────────────────────────────────────────
@@ -245,4 +399,30 @@ export function getCardBonuses(cardName: string): { atk: number; maxHp: number }
   } catch {
     return { atk: 0, maxHp: 0 }
   }
+}
+
+// ── Resource helpers ──────────────────────────────────────────────────────────
+
+export function resourceProductionRate(state: CityState): Partial<ResourceStock> {
+  const rates: Partial<ResourceStock> = {}
+  for (const cell of state.grid) {
+    if (!cell || cell.spawnedUnitName) continue
+    const produces = getBuildingProduces(cell.cardName)
+    for (const [res, rate] of Object.entries(produces) as [ResourceType, number][]) {
+      rates[res] = (rates[res] ?? 0) + rate
+    }
+  }
+  return rates
+}
+
+export function resourceConsumptionRate(state: CityState): Partial<ResourceStock> {
+  const rates: Partial<ResourceStock> = {}
+  for (let i = 0; i < state.grid.length; i++) {
+    const cell = state.grid[i]
+    if (!cell?.spawnedUnitName) continue
+    const happy = (state.happiness[i] ?? 100) > 0
+    if (!happy) continue
+    rates.wheat = (rates.wheat ?? 0) + FOOD_CONSUME_RATE[cell.rarity]
+  }
+  return rates
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -9161,6 +9161,79 @@ html.light-mode .action-btn {
 .city-cost-row--done { color: #3a5a3a; text-decoration: line-through; }
 .city-level-maxed    { font-size: 14px; color: #d0a030; letter-spacing: 2px; margin-top: 8px; }
 
+/* ── City Stats Row ───────────────────────────────────────────────────────── */
+
+.city-stats-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  padding: 4px 8px 6px;
+}
+
+.city-stat {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  font-size: 10px;
+  background: #0a150a;
+  border: 1px solid #1a3a1a;
+  border-radius: 3px;
+  padding: 2px 6px;
+  color: #90c090;
+}
+
+.city-stat--defense    { border-color: #2a4a8a; color: #80a0d0; }
+.city-stat--population { border-color: #5a3a8a; color: #b090d0; }
+.city-res-pos { color: #60d060; font-size: 9px; margin-left: 2px; }
+.city-res-neg { color: #d06060; font-size: 9px; margin-left: 2px; }
+
+/* ── Speech Bubble ────────────────────────────────────────────────────────── */
+
+.city-speech-bubble {
+  position: absolute;
+  bottom: 22px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #111;
+  border: 1px solid #40a040;
+  border-radius: 4px;
+  padding: 2px 3px;
+  pointer-events: none;
+  white-space: nowrap;
+  animation: city-bubble-pulse 2s ease-in-out infinite;
+}
+
+.city-speech-bubble::after {
+  content: '';
+  position: absolute;
+  bottom: -5px;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 4px solid transparent;
+  border-top-color: #40a040;
+}
+
+.city-speech-icon { width: 12px; height: 12px; image-rendering: pixelated; display: block; }
+
+@keyframes city-bubble-pulse {
+  0%, 100% { opacity: 1; transform: translateX(-50%) translateY(0); }
+  50%       { opacity: 0.7; transform: translateX(-50%) translateY(-2px); }
+}
+
+/* ── Picker resource cost ─────────────────────────────────────────────────── */
+
+.city-picker-cost {
+  font-size: 9px;
+  color: #a07030;
+  margin-top: 2px;
+  letter-spacing: 0.5px;
+}
+
+.city-picker-card--unaffordable {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
 /* ── Card tile level badge ────────────────────────────────────────────────── */
 
 .card-city-level {


### PR DESCRIPTION
## Summary

- **Resource system**: 6 resource types (wheat, wood, ore, bread, planks, metal) tracked in `CityState`. Buildings produce resources based on name matching (e.g. Farm → wheat, Forge buildings → metal, Stone Mason → planks). Spawner buildings consume wheat each minute per active unit.
- **City stats bar**: Main city view now shows 🛡 Defence, 👥 Population, and each resource stock with net production rate.
- **Spawner placement costs**: Placing a spawner deducts resources (scales with rarity: common = 20 wheat, up to legendary = 80 wheat + 40 wood + 20 ore). Cards you can't afford are greyed out in the picker.
- **Happiness revamp**: Happiness is now driven by food-per-capita (60%) and defence-per-capita (40%), replacing the old wage-only system. New cities start with 300 wheat, 300 wood, 150 ore to get going.
- **UPGRADES sub-screen**: The card level-up grid has been moved off the main city view to a dedicated "UPGRADES" screen, accessible via a new button in the header. This frees up the main view for the city world.
- **Affinity speech bubbles**: Walkers whose unit has an affinity partner absent from the city now show a pulsing speech bubble with the partner's sprite icon above them.

## Test plan

- [ ] Open City Builder — confirm stats bar (🛡, 👥, 🌾, 🪵, ⛏) is visible with starting resources
- [ ] Tap UPGRADES button — confirm level-up grid opens on its own screen with ← BACK
- [ ] Tap an empty cell — confirm picker shows resource costs under spawner cards; legend cards should be greyed out early when resources are low
- [ ] Place a spawner — confirm resource stock decreases by the correct cost
- [ ] Place a unit that has an affinity (e.g. Dragon wants Catapult) — confirm speech bubble appears above its walker when the Catapult spawner is absent
- [ ] Let the city run for 10 s — confirm wheat decreases as spawners eat, gold still accumulates
- [ ] `npm run build` passes clean

https://claude.ai/code/session_012kkmgaG282XnSt79C3CusZ

---
_Generated by [Claude Code](https://claude.ai/code/session_012kkmgaG282XnSt79C3CusZ)_