### PR TITLE
Add image support to news posts

### DIFF
--- a/web/src/components/NewsAdminScreen.tsx
+++ b/web/src/components/NewsAdminScreen.tsx
@@ -132,6 +132,17 @@ export function NewsAdminScreen({ onBack }: Props) {
             />
           </div>
 
+          <div>
+            <div className="settings-label">Image URL (optional)</div>
+            <input
+              className="settings-text-input"
+              style={{ width: '100%' }}
+              value={draft.imageUrl ?? ''}
+              onChange={e => setDraft(d => ({ ...d, imageUrl: e.target.value || undefined }))}
+              placeholder="https://…"
+            />
+          </div>
+
           <button className="action-btn" onClick={handleCreate} disabled={saving}>
             {saving ? 'SAVING…' : 'CREATE POST'}
           </button>
@@ -156,6 +167,13 @@ export function NewsAdminScreen({ onBack }: Props) {
               </button>
             </div>
             <div className="news-item__title">{item.title}</div>
+            {item.imageUrl && (
+              <img
+                className="news-item__image"
+                src={item.imageUrl}
+                alt={item.title}
+              />
+            )}
             <div className="news-item__body">{item.body}</div>
           </div>
         ))}

--- a/web/src/components/NewsScreen.tsx
+++ b/web/src/components/NewsScreen.tsx
@@ -47,6 +47,13 @@ export function NewsScreen({ onBack }: Props) {
               >✕</button>
             </div>
             <div className="news-item__title">{item.title}</div>
+            {item.imageUrl && (
+              <img
+                className="news-item__image"
+                src={item.imageUrl}
+                alt={item.title}
+              />
+            )}
             <div className="news-item__body">{item.body}</div>
           </div>
         ))}

--- a/web/src/game/news.ts
+++ b/web/src/game/news.ts
@@ -9,10 +9,11 @@
 //   }
 //
 // Document schema (matches NewsItem):
-//   title:  string
-//   body:   string
-//   date:   string  (ISO date, e.g. "2026-03-29")
-//   tag:    string  (optional, e.g. "NEW FEATURE", "BUG FIX", "UPDATE", "EVENT")
+//   title:    string
+//   body:     string
+//   date:     string  (ISO date, e.g. "2026-03-29")
+//   tag:      string  (optional, e.g. "NEW FEATURE", "BUG FIX", "UPDATE", "EVENT")
+//   imageUrl: string  (optional, URL of an image to display in the post)
 
 import { collection, getDocs, doc, setDoc, deleteDoc } from 'firebase/firestore'
 import { db } from '../firebase'
@@ -27,6 +28,7 @@ export interface NewsItem {
   body: string
   date: string
   tag?: string
+  imageUrl?: string
 }
 
 export const NEWS_TAGS = ['NEW FEATURE', 'UPDATE', 'BUG FIX', 'EVENT'] as const

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -8653,6 +8653,14 @@ html.light-mode .action-btn {
   color: var(--game-text-color);
 }
 
+.news-item__image {
+  width: 100%;
+  max-height: 320px;
+  object-fit: cover;
+  border-radius: 4px;
+  border: 1px solid var(--game-border);
+}
+
 .news-item__body {
   font-size: 0.857rem;
   color: #aaa;


### PR DESCRIPTION
## Summary

- Adds optional `imageUrl` field to the `NewsItem` type in `news.ts`
- Admin can enter an image URL in the Create Post form in `NewsAdminScreen`; the image previews in the active posts list too
- `NewsScreen` renders the image between the title and body when present
- Adds `.news-item__image` CSS: full-width, capped at 320px height, `object-fit: cover`, with border-radius and border to match the game's style

## Test plan

- [ ] Open News Admin, create a post with an image URL — verify image appears in the active posts list
- [ ] Open News (What's New) screen — verify image renders between title and body
- [ ] Create a post without an image URL — verify no broken image element appears
- [ ] Confirm existing posts without `imageUrl` are unaffected

https://claude.ai/code/session_01XgHFiaP7kwQ1UAgSVx4btX

---
_Generated by [Claude Code](https://claude.ai/code/session_01XgHFiaP7kwQ1UAgSVx4btX)_