### PR TITLE
fix: add epic rarity to CardRarity type and all lookup tables

### DIFF
--- a/web/src/data/economy.json
+++ b/web/src/data/economy.json
@@ -7,6 +7,7 @@
     "common":    5,
     "uncommon": 15,
     "rare":     40,
+    "epic":     65,
     "legendary": 100
   },
 
@@ -14,6 +15,7 @@
     "common":    40,
     "uncommon":  90,
     "rare":     200,
+    "epic":     280,
     "legendary": 400
   },
 

--- a/web/src/game/cards.ts
+++ b/web/src/game/cards.ts
@@ -247,5 +247,5 @@ export function getCardUnit(cardName: string): UnitTemplate | undefined {
 }
 
 export function rarityStars(r: CardRarity): string {
-  return '\u2605'.repeat({ common: 1, uncommon: 2, rare: 3, legendary: 4 }[r])
+  return '\u2605'.repeat({ common: 1, uncommon: 2, rare: 3, epic: 4, legendary: 5 }[r])
 }

--- a/web/src/game/cityBuilder.ts
+++ b/web/src/game/cityBuilder.ts
@@ -19,11 +19,11 @@ export const CELL_PX = 72
 const MAX_OFFLINE_MINUTES = 480
 
 /** Income per minute for spawn buildings. */
-const INCOME_SPAWN: Record<CardRarity, number> = { common: 2, uncommon: 4, rare: 6, legendary: 10 }
+const INCOME_SPAWN: Record<CardRarity, number> = { common: 2, uncommon: 4, rare: 6, epic: 8, legendary: 10 }
 /** Income per minute for utility buildings. */
-const INCOME_UTILITY: Record<CardRarity, number> = { common: 1, uncommon: 3, rare: 5, legendary: 8 }
+const INCOME_UTILITY: Record<CardRarity, number> = { common: 1, uncommon: 3, rare: 5, epic: 7, legendary: 8 }
 /** Income per minute for wall / no-effect structures. */
-const INCOME_WALL: Record<CardRarity, number> = { common: 0, uncommon: 1, rare: 1, legendary: 2 }
+const INCOME_WALL: Record<CardRarity, number> = { common: 0, uncommon: 1, rare: 1, epic: 2, legendary: 2 }
 
 /** Happiness regeneration per minute toward the target value. */
 const HAPPINESS_REGEN = 15
@@ -40,18 +40,19 @@ export const LEVEL_MAX_HP_BONUS = 2
 // ── Resource constants ────────────────────────────────────────────────────────
 
 /** Defence value contributed by walls (per rarity). */
-const WALL_DEFENSE: Record<CardRarity, number> = { common: 5, uncommon: 10, rare: 20, legendary: 40 }
+const WALL_DEFENSE: Record<CardRarity, number> = { common: 5, uncommon: 10, rare: 20, epic: 30, legendary: 40 }
 /** Defence value contributed by spawn buildings (per rarity). */
-const SPAWN_DEFENSE: Record<CardRarity, number> = { common: 3, uncommon: 6, rare: 12, legendary: 25 }
+const SPAWN_DEFENSE: Record<CardRarity, number> = { common: 3, uncommon: 6, rare: 12, epic: 18, legendary: 25 }
 
 /** Wheat consumed per minute by a spawn building (units need feeding). */
-const FOOD_CONSUME_RATE: Record<CardRarity, number> = { common: 1, uncommon: 2, rare: 3, legendary: 5 }
+const FOOD_CONSUME_RATE: Record<CardRarity, number> = { common: 1, uncommon: 2, rare: 3, epic: 4, legendary: 5 }
 
 /** Resource cost to place a spawner of a given rarity. */
 export const SPAWNER_PLACE_COST: Record<CardRarity, Partial<ResourceStock>> = {
   common:    { wheat: 20 },
   uncommon:  { wheat: 30, wood: 10 },
   rare:      { wheat: 50, wood: 20, ore: 10 },
+  epic:      { wheat: 65, wood: 30, ore: 15 },
   legendary: { wheat: 80, wood: 40, ore: 20 },
 }
 

--- a/web/src/game/engine.ts
+++ b/web/src/game/engine.ts
@@ -38,7 +38,7 @@ export const MAX_HANDICAP = 20
 // Thresholds also apply to campaign nodes: a node with handicap 8 puts the
 // opponent on uncommon-max, making early acts beatable with a starter deck.
 
-const RARITY_RANK: Record<CardRarity, number> = { common: 0, uncommon: 1, rare: 2, legendary: 3 }
+const RARITY_RANK: Record<CardRarity, number> = { common: 0, uncommon: 1, rare: 2, epic: 3, legendary: 4 }
 
 const QUICKPLAY_DECK_SIZE    = 20
 const QUICKPLAY_MIN_UNITS    = 3

--- a/web/src/game/shopSchedule.ts
+++ b/web/src/game/shopSchedule.ts
@@ -166,6 +166,7 @@ export const SHOP_CARD_PRICES: Record<CardRarity, number> = {
   common:    30,
   uncommon:  75,
   rare:      180,
+  epic:      250,
   legendary: 350,
 }
 

--- a/web/src/game/types.ts
+++ b/web/src/game/types.ts
@@ -22,7 +22,7 @@ export type UpgradeEffect =
 
 // ─── Cards ───────────────────────────────────────────────
 
-export type CardRarity = 'common' | 'uncommon' | 'rare' | 'legendary'
+export type CardRarity = 'common' | 'uncommon' | 'rare' | 'epic' | 'legendary'
 export type CardType = 'unit' | 'structure' | 'upgrade'
 
 export interface UnitTemplate {


### PR DESCRIPTION
## Summary

- `cards.json` contains epic-rarity cards (e.g. Archer's Keep, a spawner structure) but `'epic'` was missing from the `CardRarity` TypeScript type and every `Record<CardRarity, ...>` lookup table
- When the city builder picker screen rendered, `canAffordPlacement` called `Object.entries(SPAWNER_PLACE_COST['epic'])` where the value was `undefined`, throwing a `TypeError` that crashed React and showed a blank black screen
- Added `'epic'` to `CardRarity` and interpolated values between `rare` and `legendary` across all 7 tables in `cityBuilder.ts`, plus `engine.ts`, `shopSchedule.ts`, `economy.json`, and the `rarityStars` helper in `cards.ts`

## Test plan

- [ ] Open city builder with an Archer's Keep (epic structure) in your collection
- [ ] Tap an empty grid cell — picker screen should render without crashing
- [ ] Archer's Keep should appear with its resource cost displayed
- [ ] Placing it should deduct the correct resources (65 wheat, 30 wood, 15 ore)
- [ ] Verify no TypeScript errors in changed files

https://claude.ai/code/session_01EGm3AaeXZQwxQxwezSe5KM

---
_Generated by [Claude Code](https://claude.ai/code/session_01EGm3AaeXZQwxQxwezSe5KM)_