### PR TITLE
Upload news images to Firebase Storage

### DIFF
--- a/storage.rules
+++ b/storage.rules
@@ -1,0 +1,12 @@
+rules_version = '2';
+service firebase.storage {
+  match /b/{bucket}/o {
+
+    // News post images — public read, admin-only write
+    match /news-images/{filename} {
+      allow read: if true;
+      allow write: if request.auth.uid == "pAB2tLH049PCOI73cQpFlisKpDw1";
+    }
+
+  }
+}

--- a/web/src/components/CardDetailModal.tsx
+++ b/web/src/components/CardDetailModal.tsx
@@ -32,6 +32,7 @@ const RARITY_COLOUR: Record<string, string> = {
   common:    '#55cc55',
   uncommon:  '#4499ff',
   rare:      '#bb66ff',
+  epic:      '#ff8800',
   legendary: '#ffcc00',
 }
 
@@ -94,7 +95,7 @@ export function CardDetailModal({ card, collection, deckEntries, onClose, extras
         <div className="cdm-header">
           <span className="cdm-name" style={{ color: rarityCol }}>{card.name}</span>
           <span className="cdm-rarity" style={{ color: rarityCol }}>
-            {'★'.repeat({ common: 1, uncommon: 2, rare: 3, legendary: 4 }[card.rarity])}
+            {'★'.repeat({ common: 1, uncommon: 2, rare: 3, epic: 4, legendary: 5 }[card.rarity])}
             {' '}{card.rarity.toUpperCase()}
           </span>
           <button className="cdm-close" onClick={onClose}>✕</button>

--- a/web/src/components/CollectionScreen.tsx
+++ b/web/src/components/CollectionScreen.tsx
@@ -138,7 +138,7 @@ export function CollectionScreen({ crystals, onCrystalsChanged, onBack, commande
     return true
   })
 
-  const RARITY_ORDER: Record<CardRarity, number> = { common: 0, uncommon: 1, rare: 2, legendary: 3 }
+  const RARITY_ORDER: Record<CardRarity, number> = { common: 0, uncommon: 1, rare: 2, epic: 3, legendary: 4 }
   const TYPE_ORDER: Record<CardType, number>     = { unit: 0, structure: 1, upgrade: 2 }
 
   // Default sort: spawn buildings appear immediately after the unit they spawn.

--- a/web/src/components/DeckBuilder.tsx
+++ b/web/src/components/DeckBuilder.tsx
@@ -250,7 +250,7 @@ export function DeckBuilder({ onBack, fatiguedCards = [] }: Props) {
     return map
   }, [catalog])
 
-  const RARITY_ORDER: Record<CardRarity, number> = { common: 0, uncommon: 1, rare: 2, legendary: 3 }
+  const RARITY_ORDER: Record<CardRarity, number> = { common: 0, uncommon: 1, rare: 2, epic: 3, legendary: 4 }
   const TYPE_ORDER: Record<CardType, number>     = { unit: 0, structure: 1, upgrade: 2 }
 
   const catalogPos = useMemo(() => new Map<string, number>(catalog.map((c, i) => [c.name, i])), [catalog])

--- a/web/src/components/NewsAdminScreen.tsx
+++ b/web/src/components/NewsAdminScreen.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react'
 import { OverlayScreen } from './OverlayScreen'
 import { Section } from './Section'
-import { NewsItem, NEWS_TAGS, getAllNews, saveNewsToFirestore, deleteNewsFromFirestore } from '../game/news'
+import { NewsItem, NEWS_TAGS, getAllNews, saveNewsToFirestore, deleteNewsFromFirestore, uploadNewsImage } from '../game/news'
 
 interface Props {
   onBack: () => void
@@ -26,6 +26,7 @@ export function NewsAdminScreen({ onBack }: Props) {
   const [loading, setLoading] = useState(true)
   const [draft, setDraft] = useState(blankItem())
   const [saving, setSaving] = useState(false)
+  const [uploading, setUploading] = useState(false)
   const [status, setStatus] = useState<string | null>(null)
 
   function refresh() {
@@ -59,6 +60,24 @@ export function NewsAdminScreen({ onBack }: Props) {
       setStatus(`Error: ${String(e)}`)
     } finally {
       setSaving(false)
+    }
+  }
+
+  async function handleImageFile(file: File) {
+    if (!draft.id) {
+      setStatus('Set an ID before uploading an image.')
+      return
+    }
+    setUploading(true)
+    setStatus(null)
+    try {
+      const url = await uploadNewsImage(file, draft.id)
+      setDraft(d => ({ ...d, imageUrl: url }))
+      setStatus('Image uploaded.')
+    } catch (e) {
+      setStatus(`Upload error: ${String(e)}`)
+    } finally {
+      setUploading(false)
     }
   }
 
@@ -133,17 +152,29 @@ export function NewsAdminScreen({ onBack }: Props) {
           </div>
 
           <div>
-            <div className="settings-label">Image URL (optional)</div>
+            <div className="settings-label">Image (optional)</div>
             <input
+              type="file"
+              accept="image/*"
               className="settings-text-input"
-              style={{ width: '100%' }}
-              value={draft.imageUrl ?? ''}
-              onChange={e => setDraft(d => ({ ...d, imageUrl: e.target.value || undefined }))}
-              placeholder="https://…"
+              style={{ cursor: 'pointer' }}
+              disabled={uploading}
+              onChange={e => { const f = e.target.files?.[0]; if (f) handleImageFile(f) }}
             />
+            {uploading && <div className="settings-label" style={{ marginTop: '4px' }}>Uploading…</div>}
+            {draft.imageUrl && !uploading && (
+              <div style={{ marginTop: '6px', display: 'flex', alignItems: 'center', gap: '8px' }}>
+                <img src={draft.imageUrl} alt="preview" style={{ maxHeight: '80px', maxWidth: '160px', objectFit: 'cover', borderRadius: '3px', border: '1px solid var(--game-border)' }} />
+                <button
+                  className="action-btn action-btn--danger"
+                  style={{ padding: '2px 8px', fontSize: '11px' }}
+                  onClick={() => setDraft(d => ({ ...d, imageUrl: undefined }))}
+                >REMOVE</button>
+              </div>
+            )}
           </div>
 
-          <button className="action-btn" onClick={handleCreate} disabled={saving}>
+          <button className="action-btn" onClick={handleCreate} disabled={saving || uploading}>
             {saving ? 'SAVING…' : 'CREATE POST'}
           </button>
           {status && <div className="settings-label" style={{ color: status.startsWith('Error') ? '#ff4444' : '#33ff33' }}>{status}</div>}

--- a/web/src/firebase.ts
+++ b/web/src/firebase.ts
@@ -1,6 +1,7 @@
 import { initializeApp } from 'firebase/app'
 import { getAuth } from 'firebase/auth'
 import { getFirestore } from 'firebase/firestore'
+import { getStorage } from 'firebase/storage'
 
 const firebaseConfig = {
   apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
@@ -14,3 +15,4 @@ const firebaseConfig = {
 const app = initializeApp(firebaseConfig)
 export const auth = getAuth(app)
 export const db = getFirestore(app)
+export const storage = getStorage(app)

--- a/web/src/game/news.ts
+++ b/web/src/game/news.ts
@@ -16,7 +16,8 @@
 //   imageUrl: string  (optional, URL of an image to display in the post)
 
 import { collection, getDocs, doc, setDoc, deleteDoc } from 'firebase/firestore'
-import { db } from '../firebase'
+import { ref, uploadBytes, getDownloadURL } from 'firebase/storage'
+import { db, storage } from '../firebase'
 import { logError } from '../logger'
 import newsData from '../data/news.json'
 
@@ -120,4 +121,21 @@ export async function saveNewsToFirestore(item: NewsItem): Promise<void> {
 /** Delete a news document from Firestore. */
 export async function deleteNewsFromFirestore(id: string): Promise<void> {
   await deleteDoc(doc(db, 'news', id))
+}
+
+/**
+ * Upload an image file to Firebase Storage under news-images/.
+ * Returns the public download URL.
+ *
+ * Storage rules required (deploy via Firebase Console or CLI):
+ *   match /news-images/{filename} {
+ *     allow read: if true;
+ *     allow write: if request.auth.uid == "pAB2tLH049PCOI73cQpFlisKpDw1";
+ *   }
+ */
+export async function uploadNewsImage(file: File, newsId: string): Promise<string> {
+  const ext = file.name.split('.').pop() ?? 'jpg'
+  const storageRef = ref(storage, `news-images/${newsId}_${Date.now()}.${ext}`)
+  await uploadBytes(storageRef, file)
+  return getDownloadURL(storageRef)
 }


### PR DESCRIPTION
## Summary

- Exports `storage` from `firebase.ts` (Firebase Storage instance)
- Adds `uploadNewsImage(file, newsId)` to `news.ts` — uploads to `news-images/` and returns the public download URL
- Replaces the manual URL text field in `NewsAdminScreen` with a file picker; uploads on selection, shows a thumbnail preview with a REMOVE button, and disables CREATE POST while uploading
- Adds `storage.rules` granting public read and admin-only write on `news-images/**`

## Test plan

- [ ] Open News Admin, enter a title (to generate an ID), then pick an image — verify thumbnail appears and status shows "Image uploaded."
- [ ] Submit the post and open the News screen — verify the image renders between title and body
- [ ] Create a post without an image — verify no broken image element appears
- [ ] Deploy `storage.rules` via `firebase deploy --only storage` (required for uploads to work in production)

https://claude.ai/code/session_01XgHFiaP7kwQ1UAgSVx4btX

---
_Generated by [Claude Code](https://claude.ai/code/session_01XgHFiaP7kwQ1UAgSVx4btX)_