### PR TITLE
Improve Cloudinary upload error detail

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,6 +41,8 @@ jobs:
           VITE_FIREBASE_STORAGE_BUCKET: ${{ secrets.VITE_FIREBASE_STORAGE_BUCKET }}
           VITE_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.VITE_FIREBASE_MESSAGING_SENDER_ID }}
           VITE_FIREBASE_APP_ID: ${{ secrets.VITE_FIREBASE_APP_ID }}
+          VITE_CLOUDINARY_CLOUD_NAME: ${{ secrets.VITE_CLOUDINARY_CLOUD_NAME }}
+          VITE_CLOUDINARY_UPLOAD_PRESET: ${{ secrets.VITE_CLOUDINARY_UPLOAD_PRESET }}
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/web/src/game/news.ts
+++ b/web/src/game/news.ts
@@ -145,7 +145,11 @@ export async function uploadNewsImage(file: File): Promise<string> {
     method: 'POST',
     body: form,
   })
-  if (!res.ok) throw new Error(`Cloudinary upload failed: ${res.statusText}`)
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({})) as { error?: { message?: string } }
+    const detail = body?.error?.message ?? res.statusText
+    throw new Error(`Cloudinary upload failed: ${detail}`)
+  }
   const data = await res.json() as { secure_url: string }
   return data.secure_url
 }


### PR DESCRIPTION
## Summary

- Parses the Cloudinary JSON error response so the logged message includes the actual reason (e.g. "Upload preset must be whitelisted for unsigned uploads") rather than just "Unauthorized"

The most common cause of the 401 is the upload preset not being set to **Unsigned** in the Cloudinary dashboard (Settings → Upload → Upload presets).

https://claude.ai/code/session_01XgHFiaP7kwQ1UAgSVx4btX

---
_Generated by [Claude Code](https://claude.ai/code/session_01XgHFiaP7kwQ1UAgSVx4btX)_