### PR TITLE
Show utility building resource production in picker; add food buildings

### DIFF
--- a/web/src/components/minigames/CityBuilder.tsx
+++ b/web/src/components/minigames/CityBuilder.tsx
@@ -18,6 +18,7 @@ import {
   resourceProductionRate, resourceConsumptionRate,
   getCardLevel, levelUpCost, levelUpCard,
   LEVEL_UP_COSTS, MAX_CARD_LEVEL, LEVEL_ATK_BONUS, LEVEL_MAX_HP_BONUS,
+  getBuildingProduces,
 } from '../../game/cityBuilder'
 import { SpriteImg, AnimatedSpriteImg } from '../SpriteImg'
 import { Card } from '../../game/types'
@@ -239,6 +240,8 @@ export function CityBuilder({ onBack }: Props) {
                 : null
               const affordable  = !isSpawner || canAffordPlacement(city, card.rarity)
               const cost        = isSpawner ? SPAWNER_PLACE_COST[card.rarity] : null
+              const produces    = !isSpawner ? getBuildingProduces(card.name) : null
+              const producesEntries = produces ? Object.entries(produces).filter(([, v]) => (v ?? 0) > 0) : []
 
               return (
                 <button
@@ -259,6 +262,13 @@ export function CityBuilder({ onBack }: Props) {
                     <div className="city-picker-cost">
                       {Object.entries(cost).map(([r, amt]) =>
                         `${RESOURCE_ICONS[r as ResourceType]}${amt}`
+                      ).join(' ')}
+                    </div>
+                  )}
+                  {producesEntries.length > 0 && (
+                    <div className="city-picker-produces">
+                      {producesEntries.map(([r, amt]) =>
+                        `+${amt} ${RESOURCE_ICONS[r as ResourceType]}/min`
                       ).join(' ')}
                     </div>
                   )}

--- a/web/src/game/cityBuilder.ts
+++ b/web/src/game/cityBuilder.ts
@@ -73,22 +73,29 @@ export const RESOURCE_ICONS: Record<ResourceType, string> = {
  * Buildings not listed here fall back to keyword matching in getBuildingResourceConfig.
  */
 const BUILDING_RESOURCE_CONFIG: Record<string, Partial<ResourceStock>> = {
-  'Farm':         { wheat: 3 },
-  'Canopy Farm':  { wheat: 4 },
-  'Blacksmith':   { metal: 1 },
-  'Stone Mason':  { planks: 2 },
-  'Cryo Forge':   { metal: 1 },
+  'Farm':            { wheat: 3 },
+  'Canopy Farm':     { wheat: 4 },
+  'Bloom Garden':    { wheat: 2 },
+  'Scout Garden':    { wheat: 2 },
+  'Drift Garden':    { wheat: 2 },
+  'Pixie Garden':    { wheat: 3 },
+  'Oasis Well':      { wheat: 2 },
+  'Ancient Spring':  { wheat: 1 },
+  'Blacksmith':      { metal: 1 },
+  'Stone Mason':     { planks: 2 },
+  'Cryo Forge':      { metal: 1 },
   'Clockwork Forge': { metal: 2 },
-  'Titan Forge':  { metal: 2 },
-  'Glacial Forge':{ metal: 1 },
-  'Golem Forge':  { metal: 2 },
-  'Arcane Forge': { metal: 1 },
+  'Titan Forge':     { metal: 2 },
+  'Glacial Forge':   { metal: 1 },
+  'Golem Forge':     { metal: 2 },
+  'Arcane Forge':    { metal: 1 },
   'Automaton Forge': { metal: 2 },
 }
 
 /** Keyword patterns for resource production fallback (checked in order). */
 const KEYWORD_RESOURCE: Array<{ pattern: RegExp; produces: Partial<ResourceStock> }> = [
   { pattern: /farm/i,       produces: { wheat: 2 } },
+  { pattern: /garden|orchard/i, produces: { wheat: 2 } },
   { pattern: /forge|smith/i, produces: { metal: 1 } },
   { pattern: /mason|quarry|stone/i, produces: { planks: 1, ore: 1 } },
   { pattern: /lumber|sawmill|timber/i, produces: { wood: 3 } },
@@ -96,7 +103,7 @@ const KEYWORD_RESOURCE: Array<{ pattern: RegExp; produces: Partial<ResourceStock
   { pattern: /mine|iron hall/i, produces: { ore: 2 } },
 ]
 
-function getBuildingProduces(name: string): Partial<ResourceStock> {
+export function getBuildingProduces(name: string): Partial<ResourceStock> {
   if (BUILDING_RESOURCE_CONFIG[name]) return BUILDING_RESOURCE_CONFIG[name]
   for (const { pattern, produces } of KEYWORD_RESOURCE) {
     if (pattern.test(name)) return produces

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -9237,6 +9237,13 @@ html.light-mode .action-btn {
   letter-spacing: 0.5px;
 }
 
+.city-picker-produces {
+  font-size: 9px;
+  color: #4a9a4a;
+  margin-top: 2px;
+  letter-spacing: 0.5px;
+}
+
 .city-picker-card--unaffordable {
   opacity: 0.4;
   cursor: not-allowed;


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **UI fix**: The "Place a Building" picker now shows what resources utility buildings produce (e.g. `+3 🌾/min`) in green, so players can identify food sources before placing them
- **New food buildings**: Added 6 existing card structures as wheat producers in the city builder:
  - Bloom Garden (common) — +2 🌾/min
  - Scout Garden (common) — +2 🌾/min
  - Drift Garden (uncommon) — +2 🌾/min
  - Pixie Garden (rare) — +3 🌾/min
  - Oasis Well (uncommon) — +2 🌾/min
  - Ancient Spring (common) — +1 🌾/min
- **Keyword fallback**: Added `/garden|orchard/i` pattern so any other garden/orchard structures in the card catalog also produce wheat automatically

## Test plan

- [ ] Open city builder and click "Place a Building"
- [ ] Verify utility buildings with resource production (Farm, Canopy Farm, gardens) show a green `+N 🌾/min` line
- [ ] Verify spawner buildings still show their spawn unit icon and placement cost (no produces line)
- [ ] Verify utility buildings with no resource output (walls, aura buildings) show no produces line
- [ ] Place a garden building and confirm wheat ticks up in the city resource display

https://claude.ai/code/session_01MBGqCw9F59GrPQUwhsTXTw
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MBGqCw9F59GrPQUwhsTXTw)_