### PR TITLE
Add missing card SVGs — Batch 5/17: Units E (Steam Walker → Thunder Drake)

### DIFF
--- a/web/public/sprites/steam-walker-1.svg
+++ b/web/public/sprites/steam-walker-1.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect x="5" y="1" width="3" height="7" rx="1" fill="#7B5E3C"/>
+  <rect x="24" y="1" width="3" height="7" rx="1" fill="#7B5E3C"/>
+  <circle cx="6" cy="1" r="2" fill="#E0E0E0" opacity="0.9"/>
+  <circle cx="25" cy="1" r="2" fill="#E0E0E0" opacity="0.9"/>
+  <rect x="9" y="5" width="14" height="9" rx="2" fill="#C9A24C"/>
+  <rect x="9" y="5" width="14" height="4" rx="2" fill="#DEB96A"/>
+  <circle cx="11" cy="7" r="0.8" fill="#7B5E3C"/>
+  <circle cx="21" cy="7" r="0.8" fill="#7B5E3C"/>
+  <circle cx="13" cy="11" r="2" fill="#FF6B35"/>
+  <circle cx="19" cy="11" r="2" fill="#FF6B35"/>
+  <circle cx="13" cy="11" r="1" fill="#CC3300"/>
+  <circle cx="19" cy="11" r="1" fill="#CC3300"/>
+  <rect x="7" y="14" width="18" height="11" rx="2" fill="#8B5E3C"/>
+  <circle cx="16" cy="19" r="3" fill="#C9A24C"/>
+  <circle cx="16" cy="19" r="2" fill="#F0E0A0"/>
+  <line x1="16" y1="17.5" x2="17" y2="20" stroke="#7B5E3C" stroke-width="1"/>
+  <!-- Left arm raised -->
+  <rect x="1" y="11" width="6" height="8" rx="1" fill="#8B5E3C"/>
+  <rect x="1" y="17" width="6" height="3" rx="1" fill="#C9A24C"/>
+  <!-- Right arm normal -->
+  <rect x="25" y="14" width="6" height="8" rx="1" fill="#8B5E3C"/>
+  <rect x="25" y="20" width="6" height="3" rx="1" fill="#C9A24C"/>
+  <!-- Legs stride A -->
+  <rect x="9" y="25" width="6" height="7" rx="1" fill="#8B5E3C" transform="rotate(-5 12 28.5)"/>
+  <rect x="17" y="25" width="6" height="7" rx="1" fill="#8B5E3C" transform="rotate(5 20 28.5)"/>
+  <rect x="8" y="29" width="8" height="3" rx="1" fill="#C9A24C" transform="rotate(-5 12 30.5)"/>
+  <rect x="16" y="29" width="8" height="3" rx="1" fill="#C9A24C" transform="rotate(5 20 30.5)"/>
+</svg>

--- a/web/public/sprites/steam-walker-2.svg
+++ b/web/public/sprites/steam-walker-2.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Pipes slightly longer (body bobbed down) -->
+  <rect x="5" y="1" width="3" height="8" rx="1" fill="#7B5E3C"/>
+  <rect x="24" y="1" width="3" height="8" rx="1" fill="#7B5E3C"/>
+  <circle cx="6" cy="1" r="2" fill="#E0E0E0" opacity="0.9"/>
+  <circle cx="25" cy="1" r="2" fill="#E0E0E0" opacity="0.9"/>
+  <rect x="9" y="6" width="14" height="9" rx="2" fill="#C9A24C"/>
+  <rect x="9" y="6" width="14" height="4" rx="2" fill="#DEB96A"/>
+  <circle cx="11" cy="8" r="0.8" fill="#7B5E3C"/>
+  <circle cx="21" cy="8" r="0.8" fill="#7B5E3C"/>
+  <circle cx="13" cy="12" r="2" fill="#FF6B35"/>
+  <circle cx="19" cy="12" r="2" fill="#FF6B35"/>
+  <circle cx="13" cy="12" r="1" fill="#CC3300"/>
+  <circle cx="19" cy="12" r="1" fill="#CC3300"/>
+  <rect x="7" y="15" width="18" height="11" rx="2" fill="#8B5E3C"/>
+  <circle cx="16" cy="20" r="3" fill="#C9A24C"/>
+  <circle cx="16" cy="20" r="2" fill="#F0E0A0"/>
+  <line x1="16" y1="18.5" x2="17" y2="21" stroke="#7B5E3C" stroke-width="1"/>
+  <rect x="1" y="15" width="6" height="8" rx="1" fill="#8B5E3C"/>
+  <rect x="25" y="15" width="6" height="8" rx="1" fill="#8B5E3C"/>
+  <rect x="1" y="21" width="6" height="3" rx="1" fill="#C9A24C"/>
+  <rect x="25" y="21" width="6" height="3" rx="1" fill="#C9A24C"/>
+  <rect x="9" y="26" width="6" height="6" rx="1" fill="#8B5E3C"/>
+  <rect x="17" y="26" width="6" height="6" rx="1" fill="#8B5E3C"/>
+  <rect x="8" y="29" width="8" height="3" rx="1" fill="#C9A24C"/>
+  <rect x="16" y="29" width="8" height="3" rx="1" fill="#C9A24C"/>
+</svg>

--- a/web/public/sprites/steam-walker-3.svg
+++ b/web/public/sprites/steam-walker-3.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect x="5" y="1" width="3" height="7" rx="1" fill="#7B5E3C"/>
+  <rect x="24" y="1" width="3" height="7" rx="1" fill="#7B5E3C"/>
+  <circle cx="6" cy="1" r="2" fill="#E0E0E0" opacity="0.9"/>
+  <circle cx="25" cy="1" r="2" fill="#E0E0E0" opacity="0.9"/>
+  <rect x="9" y="5" width="14" height="9" rx="2" fill="#C9A24C"/>
+  <rect x="9" y="5" width="14" height="4" rx="2" fill="#DEB96A"/>
+  <circle cx="11" cy="7" r="0.8" fill="#7B5E3C"/>
+  <circle cx="21" cy="7" r="0.8" fill="#7B5E3C"/>
+  <circle cx="13" cy="11" r="2" fill="#FF6B35"/>
+  <circle cx="19" cy="11" r="2" fill="#FF6B35"/>
+  <circle cx="13" cy="11" r="1" fill="#CC3300"/>
+  <circle cx="19" cy="11" r="1" fill="#CC3300"/>
+  <rect x="7" y="14" width="18" height="11" rx="2" fill="#8B5E3C"/>
+  <circle cx="16" cy="19" r="3" fill="#C9A24C"/>
+  <circle cx="16" cy="19" r="2" fill="#F0E0A0"/>
+  <line x1="16" y1="17.5" x2="17" y2="20" stroke="#7B5E3C" stroke-width="1"/>
+  <!-- Left arm normal -->
+  <rect x="1" y="14" width="6" height="8" rx="1" fill="#8B5E3C"/>
+  <rect x="1" y="20" width="6" height="3" rx="1" fill="#C9A24C"/>
+  <!-- Right arm raised -->
+  <rect x="25" y="11" width="6" height="8" rx="1" fill="#8B5E3C"/>
+  <rect x="25" y="17" width="6" height="3" rx="1" fill="#C9A24C"/>
+  <!-- Legs stride B (opposite) -->
+  <rect x="9" y="25" width="6" height="7" rx="1" fill="#8B5E3C" transform="rotate(5 12 28.5)"/>
+  <rect x="17" y="25" width="6" height="7" rx="1" fill="#8B5E3C" transform="rotate(-5 20 28.5)"/>
+  <rect x="8" y="29" width="8" height="3" rx="1" fill="#C9A24C" transform="rotate(5 12 30.5)"/>
+  <rect x="16" y="29" width="8" height="3" rx="1" fill="#C9A24C" transform="rotate(-5 20 30.5)"/>
+</svg>

--- a/web/public/sprites/steam-walker.svg
+++ b/web/public/sprites/steam-walker.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Exhaust pipes -->
+  <rect x="5" y="1" width="3" height="7" rx="1" fill="#7B5E3C"/>
+  <rect x="24" y="1" width="3" height="7" rx="1" fill="#7B5E3C"/>
+  <!-- Steam puffs -->
+  <circle cx="6" cy="1" r="2" fill="#E0E0E0" opacity="0.9"/>
+  <circle cx="25" cy="1" r="2" fill="#E0E0E0" opacity="0.9"/>
+  <!-- Boiler head -->
+  <rect x="9" y="5" width="14" height="9" rx="2" fill="#C9A24C"/>
+  <rect x="9" y="5" width="14" height="4" rx="2" fill="#DEB96A"/>
+  <!-- Rivets -->
+  <circle cx="11" cy="7" r="0.8" fill="#7B5E3C"/>
+  <circle cx="21" cy="7" r="0.8" fill="#7B5E3C"/>
+  <!-- Gauge eyes -->
+  <circle cx="13" cy="11" r="2" fill="#FF6B35"/>
+  <circle cx="19" cy="11" r="2" fill="#FF6B35"/>
+  <circle cx="13" cy="11" r="1" fill="#CC3300"/>
+  <circle cx="19" cy="11" r="1" fill="#CC3300"/>
+  <!-- Boiler body -->
+  <rect x="7" y="14" width="18" height="11" rx="2" fill="#8B5E3C"/>
+  <!-- Chest pressure gauge -->
+  <circle cx="16" cy="19" r="3" fill="#C9A24C"/>
+  <circle cx="16" cy="19" r="2" fill="#F0E0A0"/>
+  <line x1="16" y1="17.5" x2="17" y2="20" stroke="#7B5E3C" stroke-width="1"/>
+  <!-- Piston arms -->
+  <rect x="1" y="14" width="6" height="8" rx="1" fill="#8B5E3C"/>
+  <rect x="25" y="14" width="6" height="8" rx="1" fill="#8B5E3C"/>
+  <rect x="1" y="20" width="6" height="3" rx="1" fill="#C9A24C"/>
+  <rect x="25" y="20" width="6" height="3" rx="1" fill="#C9A24C"/>
+  <!-- Piston legs -->
+  <rect x="9" y="25" width="6" height="7" rx="1" fill="#8B5E3C"/>
+  <rect x="17" y="25" width="6" height="7" rx="1" fill="#8B5E3C"/>
+  <!-- Foot plates -->
+  <rect x="8" y="29" width="8" height="3" rx="1" fill="#C9A24C"/>
+  <rect x="16" y="29" width="8" height="3" rx="1" fill="#C9A24C"/>
+</svg>

--- a/web/public/sprites/storm-hawk-1.svg
+++ b/web/public/sprites/storm-hawk-1.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Wings raised -->
+  <polygon points="16,15 3,4 1,14 9,14" fill="#1E3A5F"/>
+  <polygon points="16,15 29,4 31,14 23,14" fill="#1E3A5F"/>
+  <polygon points="8,14 1,14 3,18 10,16" fill="#2C5F8A"/>
+  <polygon points="24,14 31,14 29,18 22,16" fill="#2C5F8A"/>
+  <polygon points="3,8 6,6 5,10 7,8 5,12" fill="#F8B400" opacity="0.85"/>
+  <polygon points="29,8 26,6 27,10 25,8 27,12" fill="#F8B400" opacity="0.85"/>
+  <ellipse cx="16" cy="16" rx="5" ry="5" fill="#1A2B3F"/>
+  <circle cx="16" cy="11" r="3.5" fill="#1E3A5F"/>
+  <polygon points="14,8 15,5 16,8" fill="#2C5F8A"/>
+  <polygon points="16,7 17,4 18,7" fill="#3B7DBF"/>
+  <polygon points="19,10 24,11 19,12" fill="#F8B400"/>
+  <circle cx="18" cy="10.5" r="1.2" fill="#F8B400"/>
+  <circle cx="18.3" cy="10.2" r="0.5" fill="#1A2B3F"/>
+  <ellipse cx="16" cy="17" rx="3" ry="3" fill="#3B7DBF" opacity="0.6"/>
+  <ellipse cx="13" cy="22" rx="2" ry="3" fill="#1E3A5F"/>
+  <ellipse cx="19" cy="22" rx="2" ry="3" fill="#1E3A5F"/>
+  <polygon points="11,24 9,27 13,25" fill="#F8B400"/>
+  <polygon points="15,25 14,28 16,26" fill="#F8B400"/>
+  <polygon points="21,24 23,27 19,25" fill="#F8B400"/>
+</svg>

--- a/web/public/sprites/storm-hawk-2.svg
+++ b/web/public/sprites/storm-hawk-2.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Wings level/horizontal -->
+  <polygon points="16,16 0,13 0,19 8,17" fill="#1E3A5F"/>
+  <polygon points="16,16 32,13 32,19 24,17" fill="#1E3A5F"/>
+  <polygon points="7,17 0,19 2,23 10,20" fill="#2C5F8A"/>
+  <polygon points="25,17 32,19 30,23 22,20" fill="#2C5F8A"/>
+  <polygon points="2,14 5,12 4,16 6,14 4,18" fill="#F8B400" opacity="0.85"/>
+  <polygon points="30,14 27,12 28,16 26,14 28,18" fill="#F8B400" opacity="0.85"/>
+  <ellipse cx="16" cy="16" rx="5" ry="5" fill="#1A2B3F"/>
+  <circle cx="16" cy="11" r="3.5" fill="#1E3A5F"/>
+  <polygon points="14,8 15,5 16,8" fill="#2C5F8A"/>
+  <polygon points="16,7 17,4 18,7" fill="#3B7DBF"/>
+  <polygon points="19,10 24,11 19,12" fill="#F8B400"/>
+  <circle cx="18" cy="10.5" r="1.2" fill="#F8B400"/>
+  <circle cx="18.3" cy="10.2" r="0.5" fill="#1A2B3F"/>
+  <ellipse cx="16" cy="17" rx="3" ry="3" fill="#3B7DBF" opacity="0.6"/>
+  <ellipse cx="13" cy="22" rx="2" ry="3.5" fill="#1E3A5F"/>
+  <ellipse cx="19" cy="22" rx="2" ry="3.5" fill="#1E3A5F"/>
+  <polygon points="11,24 9,27 13,25" fill="#F8B400"/>
+  <polygon points="15,25 14,28 16,26" fill="#F8B400"/>
+  <polygon points="21,24 23,27 19,25" fill="#F8B400"/>
+</svg>

--- a/web/public/sprites/storm-hawk-3.svg
+++ b/web/public/sprites/storm-hawk-3.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Wings down/diving -->
+  <polygon points="16,13 2,18 1,25 9,18" fill="#1E3A5F"/>
+  <polygon points="16,13 30,18 31,25 23,18" fill="#1E3A5F"/>
+  <polygon points="8,18 1,24 3,28 10,21" fill="#2C5F8A"/>
+  <polygon points="24,18 31,24 29,28 22,21" fill="#2C5F8A"/>
+  <polygon points="2,19 5,17 4,21 6,19 4,23" fill="#F8B400" opacity="0.85"/>
+  <polygon points="30,19 27,17 28,21 26,19 28,23" fill="#F8B400" opacity="0.85"/>
+  <ellipse cx="16" cy="13" rx="5" ry="5" fill="#1A2B3F"/>
+  <circle cx="16" cy="8" r="3.5" fill="#1E3A5F"/>
+  <polygon points="14,5 15,2 16,5" fill="#2C5F8A"/>
+  <polygon points="16,4 17,1 18,4" fill="#3B7DBF"/>
+  <polygon points="19,7 24,8 19,9" fill="#F8B400"/>
+  <circle cx="18" cy="7.5" r="1.2" fill="#F8B400"/>
+  <circle cx="18.3" cy="7.2" r="0.5" fill="#1A2B3F"/>
+  <ellipse cx="16" cy="14" rx="3" ry="3" fill="#3B7DBF" opacity="0.6"/>
+  <ellipse cx="13" cy="19" rx="2" ry="3" fill="#1E3A5F"/>
+  <ellipse cx="19" cy="19" rx="2" ry="3" fill="#1E3A5F"/>
+  <polygon points="11,21 9,24 13,22" fill="#F8B400"/>
+  <polygon points="15,22 14,25 16,23" fill="#F8B400"/>
+  <polygon points="21,21 23,24 19,22" fill="#F8B400"/>
+</svg>

--- a/web/public/sprites/storm-hawk.svg
+++ b/web/public/sprites/storm-hawk.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Wings spread -->
+  <polygon points="16,14 2,7 0,17 8,15" fill="#1E3A5F"/>
+  <polygon points="16,14 30,7 32,17 24,15" fill="#1E3A5F"/>
+  <!-- Wing secondary feathers -->
+  <polygon points="7,15 0,17 2,21 9,18" fill="#2C5F8A"/>
+  <polygon points="25,15 32,17 30,21 23,18" fill="#2C5F8A"/>
+  <!-- Lightning markings on wings -->
+  <polygon points="3,10 6,8 5,12 7,10 5,14" fill="#F8B400" opacity="0.85"/>
+  <polygon points="29,10 26,8 27,12 25,10 27,14" fill="#F8B400" opacity="0.85"/>
+  <!-- Body -->
+  <ellipse cx="16" cy="15" rx="5" ry="5" fill="#1A2B3F"/>
+  <!-- Head -->
+  <circle cx="16" cy="10" r="3.5" fill="#1E3A5F"/>
+  <!-- Crest feathers -->
+  <polygon points="14,7 15,4 16,7" fill="#2C5F8A"/>
+  <polygon points="16,6 17,3 18,6" fill="#3B7DBF"/>
+  <!-- Beak -->
+  <polygon points="19,9 24,10 19,11" fill="#F8B400"/>
+  <!-- Eye -->
+  <circle cx="18" cy="9.5" r="1.2" fill="#F8B400"/>
+  <circle cx="18.3" cy="9.2" r="0.5" fill="#1A2B3F"/>
+  <!-- Storm blue chest patch -->
+  <ellipse cx="16" cy="16" rx="3" ry="3" fill="#3B7DBF" opacity="0.6"/>
+  <!-- Talons -->
+  <ellipse cx="13" cy="21" rx="2" ry="3" fill="#1E3A5F"/>
+  <ellipse cx="19" cy="21" rx="2" ry="3" fill="#1E3A5F"/>
+  <polygon points="11,23 9,26 13,24" fill="#F8B400"/>
+  <polygon points="15,24 14,27 16,25" fill="#F8B400"/>
+  <polygon points="21,23 23,26 19,24" fill="#F8B400"/>
+</svg>

--- a/web/public/sprites/stormcaller-1.svg
+++ b/web/public/sprites/stormcaller-1.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <ellipse cx="16" cy="2" rx="6" ry="2" fill="#5D6D7E" opacity="0.7"/>
+  <!-- Lightning spark near raised staff -->
+  <polygon points="3,6 6,4 4,8" fill="#FFD166" opacity="0.9"/>
+  <circle cx="16" cy="7" r="4" fill="#C9A87C"/>
+  <rect x="12" y="3" width="8" height="3" rx="1" fill="#2C1654"/>
+  <polygon points="12,4 9,1 13,3" fill="#2C1654"/>
+  <polygon points="20,4 23,1 19,3" fill="#2C1654"/>
+  <circle cx="14.5" cy="7" r="1.2" fill="#74B9FF"/>
+  <circle cx="17.5" cy="7" r="1.2" fill="#74B9FF"/>
+  <circle cx="14.5" cy="7" r="0.6" fill="#0984E3"/>
+  <circle cx="17.5" cy="7" r="0.6" fill="#0984E3"/>
+  <rect x="10" y="11" width="12" height="12" rx="2" fill="#2C1654"/>
+  <rect x="10" y="11" width="12" height="4" rx="2" fill="#4A2080"/>
+  <polygon points="14,14 16,12 16,16 18,14 16,18 16,14" fill="#FFD166"/>
+  <!-- Staff raised higher -->
+  <rect x="4" y="0" width="2" height="20" rx="1" fill="#8B5E3C"/>
+  <circle cx="5" cy="0" r="3" fill="#5D6D7E" opacity="0.5"/>
+  <circle cx="5" cy="0" r="2" fill="#74B9FF"/>
+  <circle cx="5" cy="0" r="1" fill="#A8E6FF"/>
+  <!-- Left arm raised -->
+  <rect x="5" y="8" width="5" height="9" rx="1" fill="#2C1654"/>
+  <rect x="17" y="11" width="5" height="9" rx="1" fill="#2C1654"/>
+  <!-- Legs stride A -->
+  <rect x="11" y="23" width="4" height="8" rx="1" fill="#2C1654" transform="rotate(-4 13 27)"/>
+  <rect x="17" y="23" width="4" height="8" rx="1" fill="#2C1654" transform="rotate(4 19 27)"/>
+</svg>

--- a/web/public/sprites/stormcaller-2.svg
+++ b/web/public/sprites/stormcaller-2.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <ellipse cx="16" cy="2" rx="6" ry="2" fill="#5D6D7E" opacity="0.7"/>
+  <circle cx="16" cy="8" r="4" fill="#C9A87C"/>
+  <rect x="12" y="4" width="8" height="3" rx="1" fill="#2C1654"/>
+  <polygon points="12,5 9,2 13,4" fill="#2C1654"/>
+  <polygon points="20,5 23,2 19,4" fill="#2C1654"/>
+  <circle cx="14.5" cy="8" r="1.2" fill="#74B9FF"/>
+  <circle cx="17.5" cy="8" r="1.2" fill="#74B9FF"/>
+  <circle cx="14.5" cy="8" r="0.6" fill="#0984E3"/>
+  <circle cx="17.5" cy="8" r="0.6" fill="#0984E3"/>
+  <rect x="10" y="12" width="12" height="12" rx="2" fill="#2C1654"/>
+  <rect x="10" y="12" width="12" height="4" rx="2" fill="#4A2080"/>
+  <polygon points="14,15 16,13 16,17 18,15 16,19 16,15" fill="#FFD166"/>
+  <rect x="4" y="3" width="2" height="20" rx="1" fill="#8B5E3C"/>
+  <circle cx="5" cy="3" r="3" fill="#5D6D7E" opacity="0.5"/>
+  <circle cx="5" cy="3" r="2" fill="#74B9FF"/>
+  <circle cx="5" cy="3" r="1" fill="#A8E6FF"/>
+  <rect x="5" y="12" width="5" height="9" rx="1" fill="#2C1654"/>
+  <rect x="17" y="12" width="5" height="9" rx="1" fill="#2C1654"/>
+  <!-- Legs bob down -->
+  <rect x="11" y="24" width="4" height="7" rx="1" fill="#2C1654"/>
+  <rect x="17" y="24" width="4" height="7" rx="1" fill="#2C1654"/>
+</svg>

--- a/web/public/sprites/stormcaller-3.svg
+++ b/web/public/sprites/stormcaller-3.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <ellipse cx="16" cy="2" rx="6" ry="2" fill="#5D6D7E" opacity="0.7"/>
+  <!-- Lightning cast from right hand -->
+  <polygon points="23,9 28,7 25,12 30,10 26,16" fill="#FFD166"/>
+  <circle cx="16" cy="7" r="4" fill="#C9A87C"/>
+  <rect x="12" y="3" width="8" height="3" rx="1" fill="#2C1654"/>
+  <polygon points="12,4 9,1 13,3" fill="#2C1654"/>
+  <polygon points="20,4 23,1 19,3" fill="#2C1654"/>
+  <circle cx="14.5" cy="7" r="1.2" fill="#74B9FF"/>
+  <circle cx="17.5" cy="7" r="1.2" fill="#74B9FF"/>
+  <circle cx="14.5" cy="7" r="0.6" fill="#0984E3"/>
+  <circle cx="17.5" cy="7" r="0.6" fill="#0984E3"/>
+  <rect x="10" y="11" width="12" height="12" rx="2" fill="#2C1654"/>
+  <rect x="10" y="11" width="12" height="4" rx="2" fill="#4A2080"/>
+  <polygon points="14,14 16,12 16,16 18,14 16,18 16,14" fill="#FFD166"/>
+  <rect x="4" y="2" width="2" height="20" rx="1" fill="#8B5E3C"/>
+  <circle cx="5" cy="2" r="3" fill="#5D6D7E" opacity="0.5"/>
+  <circle cx="5" cy="2" r="2" fill="#74B9FF"/>
+  <circle cx="5" cy="2" r="1" fill="#A8E6FF"/>
+  <rect x="5" y="11" width="5" height="9" rx="1" fill="#2C1654"/>
+  <!-- Right arm raised casting -->
+  <rect x="17" y="8" width="5" height="9" rx="1" fill="#2C1654"/>
+  <!-- Legs stride B -->
+  <rect x="11" y="23" width="4" height="8" rx="1" fill="#2C1654" transform="rotate(4 13 27)"/>
+  <rect x="17" y="23" width="4" height="8" rx="1" fill="#2C1654" transform="rotate(-4 19 27)"/>
+</svg>

--- a/web/public/sprites/stormcaller.svg
+++ b/web/public/sprites/stormcaller.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Storm cloud above head -->
+  <ellipse cx="16" cy="2" rx="6" ry="2" fill="#5D6D7E" opacity="0.7"/>
+  <!-- Head -->
+  <circle cx="16" cy="7" r="4" fill="#C9A87C"/>
+  <!-- Wild stormy hair -->
+  <rect x="12" y="3" width="8" height="3" rx="1" fill="#2C1654"/>
+  <polygon points="12,4 9,1 13,3" fill="#2C1654"/>
+  <polygon points="20,4 23,1 19,3" fill="#2C1654"/>
+  <!-- Eyes (storm blue glow) -->
+  <circle cx="14.5" cy="7" r="1.2" fill="#74B9FF"/>
+  <circle cx="17.5" cy="7" r="1.2" fill="#74B9FF"/>
+  <circle cx="14.5" cy="7" r="0.6" fill="#0984E3"/>
+  <circle cx="17.5" cy="7" r="0.6" fill="#0984E3"/>
+  <!-- Robe body -->
+  <rect x="10" y="11" width="12" height="12" rx="2" fill="#2C1654"/>
+  <rect x="10" y="11" width="12" height="4" rx="2" fill="#4A2080"/>
+  <!-- Lightning bolt on chest -->
+  <polygon points="14,14 16,12 16,16 18,14 16,18 16,14" fill="#FFD166"/>
+  <!-- Staff (left side) -->
+  <rect x="4" y="2" width="2" height="20" rx="1" fill="#8B5E3C"/>
+  <!-- Storm orb on staff -->
+  <circle cx="5" cy="2" r="3" fill="#5D6D7E" opacity="0.5"/>
+  <circle cx="5" cy="2" r="2" fill="#74B9FF"/>
+  <circle cx="5" cy="2" r="1" fill="#A8E6FF"/>
+  <!-- Left arm (holding staff) -->
+  <rect x="5" y="11" width="5" height="9" rx="1" fill="#2C1654"/>
+  <!-- Right arm -->
+  <rect x="17" y="11" width="5" height="9" rx="1" fill="#2C1654"/>
+  <!-- Robe hem/legs -->
+  <rect x="11" y="23" width="4" height="8" rx="1" fill="#2C1654"/>
+  <rect x="17" y="23" width="4" height="8" rx="1" fill="#2C1654"/>
+</svg>

--- a/web/public/sprites/tempest-rider-1.svg
+++ b/web/public/sprites/tempest-rider-1.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <path d="M5,17 Q8,13 12,17 Q16,21 20,17" fill="none" stroke="#48CAE4" stroke-width="1.5" opacity="0.7"/>
+  <path d="M10,23 Q14,19 18,23 Q22,27 26,23" fill="none" stroke="#48CAE4" stroke-width="1" opacity="0.5"/>
+  <circle cx="16" cy="6" r="4" fill="#E8C87A"/>
+  <path d="M12,4 Q9,2 7,3" fill="none" stroke="#006994" stroke-width="1.5" stroke-linecap="round"/>
+  <path d="M13,3 Q10,1 8,2" fill="none" stroke="#006994" stroke-width="1" stroke-linecap="round"/>
+  <circle cx="14.5" cy="6" r="1" fill="#0077B6"/>
+  <circle cx="17.5" cy="6" r="1" fill="#0077B6"/>
+  <rect x="11" y="10" width="10" height="11" rx="2" fill="#0096C7"/>
+  <polygon points="11,10 3,11 4,21 11,21" fill="#0077B6" opacity="0.85"/>
+  <rect x="11" y="10" width="10" height="2" rx="1" fill="#FDCB6E"/>
+  <!-- Right arm raised with stronger gust -->
+  <rect x="21" y="7" width="5" height="8" rx="1" fill="#0096C7"/>
+  <circle cx="27" cy="11" r="2.5" fill="#48CAE4" opacity="0.8"/>
+  <path d="M28,8 Q31,6 31,9" fill="none" stroke="#48CAE4" stroke-width="1.2" opacity="0.7"/>
+  <rect x="12" y="21" width="4" height="9" rx="1" fill="#0077B6" transform="rotate(-4 14 25.5)"/>
+  <rect x="17" y="21" width="4" height="9" rx="1" fill="#0077B6" transform="rotate(4 19 25.5)"/>
+  <rect x="12" y="27" width="4" height="3" rx="1" fill="#FDCB6E" transform="rotate(-4 14 28.5)"/>
+  <rect x="17" y="27" width="4" height="3" rx="1" fill="#FDCB6E" transform="rotate(4 19 28.5)"/>
+</svg>

--- a/web/public/sprites/tempest-rider-2.svg
+++ b/web/public/sprites/tempest-rider-2.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <path d="M5,19 Q8,15 12,19 Q16,23 20,19" fill="none" stroke="#48CAE4" stroke-width="1.5" opacity="0.7"/>
+  <path d="M10,25 Q14,21 18,25 Q22,29 26,25" fill="none" stroke="#48CAE4" stroke-width="1" opacity="0.5"/>
+  <circle cx="16" cy="7" r="4" fill="#E8C87A"/>
+  <path d="M12,5 Q9,3 7,4" fill="none" stroke="#006994" stroke-width="1.5" stroke-linecap="round"/>
+  <path d="M13,4 Q10,2 8,3" fill="none" stroke="#006994" stroke-width="1" stroke-linecap="round"/>
+  <circle cx="14.5" cy="7" r="1" fill="#0077B6"/>
+  <circle cx="17.5" cy="7" r="1" fill="#0077B6"/>
+  <rect x="11" y="11" width="10" height="11" rx="2" fill="#0096C7"/>
+  <polygon points="11,11 4,14 5,23 11,22" fill="#0077B6" opacity="0.85"/>
+  <rect x="11" y="11" width="10" height="2" rx="1" fill="#FDCB6E"/>
+  <rect x="21" y="11" width="5" height="8" rx="1" fill="#0096C7"/>
+  <circle cx="27" cy="15" r="2" fill="#48CAE4" opacity="0.8"/>
+  <rect x="12" y="22" width="4" height="8" rx="1" fill="#0077B6"/>
+  <rect x="17" y="22" width="4" height="8" rx="1" fill="#0077B6"/>
+  <rect x="12" y="27" width="4" height="3" rx="1" fill="#FDCB6E"/>
+  <rect x="17" y="27" width="4" height="3" rx="1" fill="#FDCB6E"/>
+</svg>

--- a/web/public/sprites/tempest-rider-3.svg
+++ b/web/public/sprites/tempest-rider-3.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <path d="M5,18 Q8,14 12,18 Q16,22 20,18" fill="none" stroke="#48CAE4" stroke-width="1.5" opacity="0.7"/>
+  <path d="M10,24 Q14,20 18,24 Q22,28 26,24" fill="none" stroke="#48CAE4" stroke-width="1" opacity="0.5"/>
+  <circle cx="16" cy="6" r="4" fill="#E8C87A"/>
+  <!-- Hair blowing other way -->
+  <path d="M20,4 Q23,2 25,3" fill="none" stroke="#006994" stroke-width="1.5" stroke-linecap="round"/>
+  <path d="M19,3 Q22,1 24,2" fill="none" stroke="#006994" stroke-width="1" stroke-linecap="round"/>
+  <circle cx="14.5" cy="6" r="1" fill="#0077B6"/>
+  <circle cx="17.5" cy="6" r="1" fill="#0077B6"/>
+  <rect x="11" y="10" width="10" height="11" rx="2" fill="#0096C7"/>
+  <!-- Cloak billowing right this time -->
+  <polygon points="21,10 28,13 27,22 21,21" fill="#0077B6" opacity="0.85"/>
+  <rect x="11" y="10" width="10" height="2" rx="1" fill="#FDCB6E"/>
+  <!-- Left arm raised -->
+  <rect x="6" y="7" width="5" height="8" rx="1" fill="#0096C7"/>
+  <circle cx="5" cy="11" r="2.5" fill="#48CAE4" opacity="0.8"/>
+  <path d="M4,8 Q1,6 1,9" fill="none" stroke="#48CAE4" stroke-width="1.2" opacity="0.7"/>
+  <!-- Stride B -->
+  <rect x="12" y="21" width="4" height="9" rx="1" fill="#0077B6" transform="rotate(4 14 25.5)"/>
+  <rect x="17" y="21" width="4" height="9" rx="1" fill="#0077B6" transform="rotate(-4 19 25.5)"/>
+  <rect x="12" y="27" width="4" height="3" rx="1" fill="#FDCB6E" transform="rotate(4 14 28.5)"/>
+  <rect x="17" y="27" width="4" height="3" rx="1" fill="#FDCB6E" transform="rotate(-4 19 28.5)"/>
+</svg>

--- a/web/public/sprites/tempest-rider.svg
+++ b/web/public/sprites/tempest-rider.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Wind swirls -->
+  <path d="M5,18 Q8,14 12,18 Q16,22 20,18" fill="none" stroke="#48CAE4" stroke-width="1.5" opacity="0.7"/>
+  <path d="M10,24 Q14,20 18,24 Q22,28 26,24" fill="none" stroke="#48CAE4" stroke-width="1" opacity="0.5"/>
+  <!-- Head -->
+  <circle cx="16" cy="6" r="4" fill="#E8C87A"/>
+  <!-- Wind-blown hair -->
+  <path d="M12,4 Q9,2 7,3" fill="none" stroke="#006994" stroke-width="1.5" stroke-linecap="round"/>
+  <path d="M13,3 Q10,1 8,2" fill="none" stroke="#006994" stroke-width="1" stroke-linecap="round"/>
+  <!-- Eyes -->
+  <circle cx="14.5" cy="6" r="1" fill="#0077B6"/>
+  <circle cx="17.5" cy="6" r="1" fill="#0077B6"/>
+  <!-- Cloak body -->
+  <rect x="11" y="10" width="10" height="11" rx="2" fill="#0096C7"/>
+  <!-- Billowing cloak left -->
+  <polygon points="11,10 4,13 5,22 11,21" fill="#0077B6" opacity="0.85"/>
+  <!-- Gold collar trim -->
+  <rect x="11" y="10" width="10" height="2" rx="1" fill="#FDCB6E"/>
+  <!-- Right arm extended with gust -->
+  <rect x="21" y="10" width="5" height="8" rx="1" fill="#0096C7"/>
+  <circle cx="27" cy="14" r="2" fill="#48CAE4" opacity="0.8"/>
+  <!-- Legs -->
+  <rect x="12" y="21" width="4" height="9" rx="1" fill="#0077B6"/>
+  <rect x="17" y="21" width="4" height="9" rx="1" fill="#0077B6"/>
+  <!-- Boot trim -->
+  <rect x="12" y="27" width="4" height="3" rx="1" fill="#FDCB6E"/>
+  <rect x="17" y="27" width="4" height="3" rx="1" fill="#FDCB6E"/>
+</svg>

--- a/web/public/sprites/the-archivist-1.svg
+++ b/web/public/sprites/the-archivist-1.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="6" r="4" fill="#D4AC68"/>
+  <circle cx="14" cy="6" r="1.5" fill="none" stroke="#8B6B3D" stroke-width="0.7"/>
+  <circle cx="18" cy="6" r="1.5" fill="none" stroke="#8B6B3D" stroke-width="0.7"/>
+  <line x1="15.5" y1="6" x2="16.5" y2="6" stroke="#8B6B3D" stroke-width="0.7"/>
+  <line x1="12.5" y1="6" x2="12" y2="5.5" stroke="#8B6B3D" stroke-width="0.7"/>
+  <line x1="19.5" y1="6" x2="20" y2="5.5" stroke="#8B6B3D" stroke-width="0.7"/>
+  <circle cx="14" cy="6" r="0.7" fill="#4A2C17"/>
+  <circle cx="18" cy="6" r="0.7" fill="#4A2C17"/>
+  <ellipse cx="16" cy="3" rx="4" ry="2" fill="#4A2C17"/>
+  <rect x="10" y="10" width="12" height="13" rx="2" fill="#5C3A1E"/>
+  <rect x="10" y="10" width="12" height="3" rx="2" fill="#7A4E28"/>
+  <!-- Scroll raised up -->
+  <rect x="3" y="7" width="5" height="8" rx="1" fill="#D4AC68"/>
+  <line x1="4" y1="9" x2="7" y2="9" stroke="#8B6B3D" stroke-width="0.6"/>
+  <line x1="4" y1="11" x2="7" y2="11" stroke="#8B6B3D" stroke-width="0.6"/>
+  <line x1="4" y1="13" x2="7" y2="13" stroke="#8B6B3D" stroke-width="0.6"/>
+  <!-- Left arm raised -->
+  <rect x="5" y="7" width="5" height="9" rx="1" fill="#5C3A1E"/>
+  <!-- Right arm (quill) normal -->
+  <rect x="22" y="10" width="5" height="9" rx="1" fill="#5C3A1E"/>
+  <polygon points="25,4 27,1 27,8 25,8" fill="#F9CA24"/>
+  <rect x="25.5" y="8" width="1" height="5" fill="#4A2C17"/>
+  <!-- Legs stride A -->
+  <rect x="11" y="23" width="4" height="8" rx="1" fill="#5C3A1E" transform="rotate(-4 13 27)"/>
+  <rect x="17" y="23" width="4" height="8" rx="1" fill="#5C3A1E" transform="rotate(4 19 27)"/>
+</svg>

--- a/web/public/sprites/the-archivist-2.svg
+++ b/web/public/sprites/the-archivist-2.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="7" r="4" fill="#D4AC68"/>
+  <circle cx="14" cy="7" r="1.5" fill="none" stroke="#8B6B3D" stroke-width="0.7"/>
+  <circle cx="18" cy="7" r="1.5" fill="none" stroke="#8B6B3D" stroke-width="0.7"/>
+  <line x1="15.5" y1="7" x2="16.5" y2="7" stroke="#8B6B3D" stroke-width="0.7"/>
+  <line x1="12.5" y1="7" x2="12" y2="6.5" stroke="#8B6B3D" stroke-width="0.7"/>
+  <line x1="19.5" y1="7" x2="20" y2="6.5" stroke="#8B6B3D" stroke-width="0.7"/>
+  <circle cx="14" cy="7" r="0.7" fill="#4A2C17"/>
+  <circle cx="18" cy="7" r="0.7" fill="#4A2C17"/>
+  <ellipse cx="16" cy="4" rx="4" ry="2" fill="#4A2C17"/>
+  <rect x="10" y="11" width="12" height="13" rx="2" fill="#5C3A1E"/>
+  <rect x="10" y="11" width="12" height="3" rx="2" fill="#7A4E28"/>
+  <rect x="3" y="12" width="5" height="8" rx="1" fill="#D4AC68"/>
+  <line x1="4" y1="14" x2="7" y2="14" stroke="#8B6B3D" stroke-width="0.6"/>
+  <line x1="4" y1="16" x2="7" y2="16" stroke="#8B6B3D" stroke-width="0.6"/>
+  <line x1="4" y1="18" x2="7" y2="18" stroke="#8B6B3D" stroke-width="0.6"/>
+  <rect x="5" y="11" width="5" height="9" rx="1" fill="#5C3A1E"/>
+  <rect x="22" y="11" width="5" height="9" rx="1" fill="#5C3A1E"/>
+  <polygon points="25,5 27,2 27,9 25,9" fill="#F9CA24"/>
+  <rect x="25.5" y="9" width="1" height="5" fill="#4A2C17"/>
+  <!-- Legs bob down -->
+  <rect x="11" y="24" width="4" height="7" rx="1" fill="#5C3A1E"/>
+  <rect x="17" y="24" width="4" height="7" rx="1" fill="#5C3A1E"/>
+</svg>

--- a/web/public/sprites/the-archivist-3.svg
+++ b/web/public/sprites/the-archivist-3.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="6" r="4" fill="#D4AC68"/>
+  <circle cx="14" cy="6" r="1.5" fill="none" stroke="#8B6B3D" stroke-width="0.7"/>
+  <circle cx="18" cy="6" r="1.5" fill="none" stroke="#8B6B3D" stroke-width="0.7"/>
+  <line x1="15.5" y1="6" x2="16.5" y2="6" stroke="#8B6B3D" stroke-width="0.7"/>
+  <line x1="12.5" y1="6" x2="12" y2="5.5" stroke="#8B6B3D" stroke-width="0.7"/>
+  <line x1="19.5" y1="6" x2="20" y2="5.5" stroke="#8B6B3D" stroke-width="0.7"/>
+  <circle cx="14" cy="6" r="0.7" fill="#4A2C17"/>
+  <circle cx="18" cy="6" r="0.7" fill="#4A2C17"/>
+  <ellipse cx="16" cy="3" rx="4" ry="2" fill="#4A2C17"/>
+  <rect x="10" y="10" width="12" height="13" rx="2" fill="#5C3A1E"/>
+  <rect x="10" y="10" width="12" height="3" rx="2" fill="#7A4E28"/>
+  <!-- Scroll normal -->
+  <rect x="3" y="11" width="5" height="8" rx="1" fill="#D4AC68"/>
+  <line x1="4" y1="13" x2="7" y2="13" stroke="#8B6B3D" stroke-width="0.6"/>
+  <line x1="4" y1="15" x2="7" y2="15" stroke="#8B6B3D" stroke-width="0.6"/>
+  <line x1="4" y1="17" x2="7" y2="17" stroke="#8B6B3D" stroke-width="0.6"/>
+  <rect x="5" y="10" width="5" height="9" rx="1" fill="#5C3A1E"/>
+  <!-- Right arm (quill) raised -->
+  <rect x="22" y="7" width="5" height="9" rx="1" fill="#5C3A1E"/>
+  <polygon points="25,1 27,0" fill="none"/>
+  <polygon points="25,1 27,0 27,5 25,5" fill="#F9CA24"/>
+  <rect x="25.5" y="5" width="1" height="5" fill="#4A2C17"/>
+  <!-- Legs stride B -->
+  <rect x="11" y="23" width="4" height="8" rx="1" fill="#5C3A1E" transform="rotate(4 13 27)"/>
+  <rect x="17" y="23" width="4" height="8" rx="1" fill="#5C3A1E" transform="rotate(-4 19 27)"/>
+</svg>

--- a/web/public/sprites/the-archivist.svg
+++ b/web/public/sprites/the-archivist.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Head -->
+  <circle cx="16" cy="6" r="4" fill="#D4AC68"/>
+  <!-- Spectacles -->
+  <circle cx="14" cy="6" r="1.5" fill="none" stroke="#8B6B3D" stroke-width="0.7"/>
+  <circle cx="18" cy="6" r="1.5" fill="none" stroke="#8B6B3D" stroke-width="0.7"/>
+  <line x1="15.5" y1="6" x2="16.5" y2="6" stroke="#8B6B3D" stroke-width="0.7"/>
+  <line x1="12.5" y1="6" x2="12" y2="5.5" stroke="#8B6B3D" stroke-width="0.7"/>
+  <line x1="19.5" y1="6" x2="20" y2="5.5" stroke="#8B6B3D" stroke-width="0.7"/>
+  <!-- Eyes through spectacles -->
+  <circle cx="14" cy="6" r="0.7" fill="#4A2C17"/>
+  <circle cx="18" cy="6" r="0.7" fill="#4A2C17"/>
+  <!-- Hair -->
+  <ellipse cx="16" cy="3" rx="4" ry="2" fill="#4A2C17"/>
+  <!-- Brown robe -->
+  <rect x="10" y="10" width="12" height="13" rx="2" fill="#5C3A1E"/>
+  <rect x="10" y="10" width="12" height="3" rx="2" fill="#7A4E28"/>
+  <!-- Scroll held in left hand -->
+  <rect x="3" y="11" width="5" height="8" rx="1" fill="#D4AC68"/>
+  <line x1="4" y1="13" x2="7" y2="13" stroke="#8B6B3D" stroke-width="0.6"/>
+  <line x1="4" y1="15" x2="7" y2="15" stroke="#8B6B3D" stroke-width="0.6"/>
+  <line x1="4" y1="17" x2="7" y2="17" stroke="#8B6B3D" stroke-width="0.6"/>
+  <!-- Left arm holding scroll -->
+  <rect x="5" y="10" width="5" height="9" rx="1" fill="#5C3A1E"/>
+  <!-- Quill in right hand -->
+  <rect x="22" y="10" width="5" height="9" rx="1" fill="#5C3A1E"/>
+  <polygon points="25,4 27,1 27,8 25,8" fill="#F9CA24"/>
+  <rect x="25.5" y="8" width="1" height="5" fill="#4A2C17"/>
+  <!-- Legs -->
+  <rect x="11" y="23" width="4" height="8" rx="1" fill="#5C3A1E"/>
+  <rect x="17" y="23" width="4" height="8" rx="1" fill="#5C3A1E"/>
+</svg>

--- a/web/public/sprites/the-ashwalker-1.svg
+++ b/web/public/sprites/the-ashwalker-1.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ash trails from raised arm -->
+  <circle cx="5" cy="5" r="1" fill="#636E72" opacity="0.6"/>
+  <circle cx="3" cy="8" r="0.8" fill="#636E72" opacity="0.6"/>
+  <circle cx="4" cy="11" r="0.7" fill="#636E72" opacity="0.5"/>
+  <circle cx="24" cy="8" r="0.8" fill="#636E72" opacity="0.4"/>
+  <circle cx="26" cy="12" r="0.7" fill="#636E72" opacity="0.4"/>
+  <circle cx="16" cy="6" r="4" fill="#4A4A4A"/>
+  <ellipse cx="14" cy="5.5" rx="1.5" ry="1.2" fill="#E17055"/>
+  <ellipse cx="18" cy="5.5" rx="1.5" ry="1.2" fill="#E17055"/>
+  <ellipse cx="14" cy="5.5" rx="0.8" ry="0.6" fill="#FDCB6E"/>
+  <ellipse cx="18" cy="5.5" rx="0.8" ry="0.6" fill="#FDCB6E"/>
+  <line x1="15" y1="3" x2="14" y2="7" stroke="#2D3436" stroke-width="0.8"/>
+  <line x1="18" y1="4" x2="17" y2="8" stroke="#2D3436" stroke-width="0.8"/>
+  <rect x="10" y="10" width="12" height="13" rx="2" fill="#3D3D3D"/>
+  <line x1="13" y1="11" x2="12" y2="16" stroke="#636E72" stroke-width="0.8"/>
+  <line x1="18" y1="12" x2="19" y2="17" stroke="#636E72" stroke-width="0.8"/>
+  <circle cx="16" cy="16" r="1.5" fill="#E17055" opacity="0.7"/>
+  <circle cx="16" cy="16" r="0.8" fill="#FDCB6E" opacity="0.8"/>
+  <polygon points="10,23 7,28 11,24" fill="#3D3D3D"/>
+  <polygon points="22,23 25,28 21,24" fill="#3D3D3D"/>
+  <!-- Left arm raised with ember glow -->
+  <rect x="4" y="7" width="6" height="9" rx="1" fill="#3D3D3D"/>
+  <line x1="6" y1="8" x2="5" y2="12" stroke="#636E72" stroke-width="0.7"/>
+  <circle cx="4" cy="7" r="1.5" fill="#E17055" opacity="0.8"/>
+  <circle cx="4" cy="7" r="0.7" fill="#FDCB6E"/>
+  <rect x="22" y="10" width="6" height="9" rx="1" fill="#3D3D3D"/>
+  <line x1="25" y1="12" x2="26" y2="16" stroke="#636E72" stroke-width="0.7"/>
+  <!-- Stride A -->
+  <rect x="11" y="23" width="4" height="8" rx="1" fill="#3D3D3D" transform="rotate(-4 13 27)"/>
+  <rect x="17" y="23" width="4" height="8" rx="1" fill="#3D3D3D" transform="rotate(4 19 27)"/>
+</svg>

--- a/web/public/sprites/the-ashwalker-2.svg
+++ b/web/public/sprites/the-ashwalker-2.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="8" cy="6" r="1" fill="#636E72" opacity="0.6"/>
+  <circle cx="24" cy="9" r="0.8" fill="#636E72" opacity="0.5"/>
+  <circle cx="6" cy="15" r="0.7" fill="#636E72" opacity="0.4"/>
+  <circle cx="26" cy="13" r="0.7" fill="#636E72" opacity="0.4"/>
+  <circle cx="16" cy="7" r="4" fill="#4A4A4A"/>
+  <ellipse cx="14" cy="6.5" rx="1.5" ry="1.2" fill="#E17055"/>
+  <ellipse cx="18" cy="6.5" rx="1.5" ry="1.2" fill="#E17055"/>
+  <ellipse cx="14" cy="6.5" rx="0.8" ry="0.6" fill="#FDCB6E"/>
+  <ellipse cx="18" cy="6.5" rx="0.8" ry="0.6" fill="#FDCB6E"/>
+  <line x1="15" y1="4" x2="14" y2="8" stroke="#2D3436" stroke-width="0.8"/>
+  <line x1="18" y1="5" x2="17" y2="9" stroke="#2D3436" stroke-width="0.8"/>
+  <rect x="10" y="11" width="12" height="13" rx="2" fill="#3D3D3D"/>
+  <line x1="13" y1="12" x2="12" y2="17" stroke="#636E72" stroke-width="0.8"/>
+  <line x1="18" y1="13" x2="19" y2="18" stroke="#636E72" stroke-width="0.8"/>
+  <circle cx="16" cy="17" r="1.5" fill="#E17055" opacity="0.7"/>
+  <circle cx="16" cy="17" r="0.8" fill="#FDCB6E" opacity="0.8"/>
+  <polygon points="10,24 7,29 11,25" fill="#3D3D3D"/>
+  <polygon points="22,24 25,29 21,25" fill="#3D3D3D"/>
+  <rect x="4" y="11" width="6" height="9" rx="1" fill="#3D3D3D"/>
+  <rect x="22" y="11" width="6" height="9" rx="1" fill="#3D3D3D"/>
+  <line x1="6" y1="12" x2="5" y2="16" stroke="#636E72" stroke-width="0.7"/>
+  <line x1="25" y1="13" x2="26" y2="17" stroke="#636E72" stroke-width="0.7"/>
+  <!-- Legs bob down -->
+  <rect x="11" y="24" width="4" height="7" rx="1" fill="#3D3D3D"/>
+  <rect x="17" y="24" width="4" height="7" rx="1" fill="#3D3D3D"/>
+</svg>

--- a/web/public/sprites/the-ashwalker-3.svg
+++ b/web/public/sprites/the-ashwalker-3.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ash trails from right raised arm -->
+  <circle cx="27" cy="5" r="1" fill="#636E72" opacity="0.6"/>
+  <circle cx="29" cy="8" r="0.8" fill="#636E72" opacity="0.6"/>
+  <circle cx="28" cy="11" r="0.7" fill="#636E72" opacity="0.5"/>
+  <circle cx="8" cy="8" r="0.8" fill="#636E72" opacity="0.4"/>
+  <circle cx="6" cy="12" r="0.7" fill="#636E72" opacity="0.4"/>
+  <circle cx="16" cy="6" r="4" fill="#4A4A4A"/>
+  <ellipse cx="14" cy="5.5" rx="1.5" ry="1.2" fill="#E17055"/>
+  <ellipse cx="18" cy="5.5" rx="1.5" ry="1.2" fill="#E17055"/>
+  <ellipse cx="14" cy="5.5" rx="0.8" ry="0.6" fill="#FDCB6E"/>
+  <ellipse cx="18" cy="5.5" rx="0.8" ry="0.6" fill="#FDCB6E"/>
+  <line x1="15" y1="3" x2="14" y2="7" stroke="#2D3436" stroke-width="0.8"/>
+  <line x1="18" y1="4" x2="17" y2="8" stroke="#2D3436" stroke-width="0.8"/>
+  <rect x="10" y="10" width="12" height="13" rx="2" fill="#3D3D3D"/>
+  <line x1="13" y1="11" x2="12" y2="16" stroke="#636E72" stroke-width="0.8"/>
+  <line x1="18" y1="12" x2="19" y2="17" stroke="#636E72" stroke-width="0.8"/>
+  <circle cx="16" cy="16" r="1.5" fill="#E17055" opacity="0.7"/>
+  <circle cx="16" cy="16" r="0.8" fill="#FDCB6E" opacity="0.8"/>
+  <polygon points="10,23 7,28 11,24" fill="#3D3D3D"/>
+  <polygon points="22,23 25,28 21,24" fill="#3D3D3D"/>
+  <!-- Left arm normal -->
+  <rect x="4" y="10" width="6" height="9" rx="1" fill="#3D3D3D"/>
+  <line x1="6" y1="11" x2="5" y2="15" stroke="#636E72" stroke-width="0.7"/>
+  <!-- Right arm raised with ember glow -->
+  <rect x="22" y="7" width="6" height="9" rx="1" fill="#3D3D3D"/>
+  <line x1="25" y1="8" x2="26" y2="12" stroke="#636E72" stroke-width="0.7"/>
+  <circle cx="28" cy="7" r="1.5" fill="#E17055" opacity="0.8"/>
+  <circle cx="28" cy="7" r="0.7" fill="#FDCB6E"/>
+  <!-- Stride B -->
+  <rect x="11" y="23" width="4" height="8" rx="1" fill="#3D3D3D" transform="rotate(4 13 27)"/>
+  <rect x="17" y="23" width="4" height="8" rx="1" fill="#3D3D3D" transform="rotate(-4 19 27)"/>
+</svg>

--- a/web/public/sprites/the-ashwalker.svg
+++ b/web/public/sprites/the-ashwalker.svg
@@ -1,0 +1,37 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ash particles floating -->
+  <circle cx="8" cy="5" r="1" fill="#636E72" opacity="0.6"/>
+  <circle cx="24" cy="8" r="0.8" fill="#636E72" opacity="0.5"/>
+  <circle cx="6" cy="14" r="0.7" fill="#636E72" opacity="0.4"/>
+  <circle cx="26" cy="12" r="0.7" fill="#636E72" opacity="0.4"/>
+  <!-- Head -->
+  <circle cx="16" cy="6" r="4" fill="#4A4A4A"/>
+  <!-- Hollow ember eyes -->
+  <ellipse cx="14" cy="5.5" rx="1.5" ry="1.2" fill="#E17055"/>
+  <ellipse cx="18" cy="5.5" rx="1.5" ry="1.2" fill="#E17055"/>
+  <ellipse cx="14" cy="5.5" rx="0.8" ry="0.6" fill="#FDCB6E"/>
+  <ellipse cx="18" cy="5.5" rx="0.8" ry="0.6" fill="#FDCB6E"/>
+  <!-- Cracks on head -->
+  <line x1="15" y1="3" x2="14" y2="7" stroke="#2D3436" stroke-width="0.8"/>
+  <line x1="18" y1="4" x2="17" y2="8" stroke="#2D3436" stroke-width="0.8"/>
+  <!-- Tattered cloak body -->
+  <rect x="10" y="10" width="12" height="13" rx="2" fill="#3D3D3D"/>
+  <!-- Crack marks on body -->
+  <line x1="13" y1="11" x2="12" y2="16" stroke="#636E72" stroke-width="0.8"/>
+  <line x1="18" y1="12" x2="19" y2="17" stroke="#636E72" stroke-width="0.8"/>
+  <!-- Ember on chest -->
+  <circle cx="16" cy="16" r="1.5" fill="#E17055" opacity="0.7"/>
+  <circle cx="16" cy="16" r="0.8" fill="#FDCB6E" opacity="0.8"/>
+  <!-- Tattered cloak edges -->
+  <polygon points="10,23 7,28 11,24" fill="#3D3D3D"/>
+  <polygon points="22,23 25,28 21,24" fill="#3D3D3D"/>
+  <!-- Arms -->
+  <rect x="4" y="10" width="6" height="9" rx="1" fill="#3D3D3D"/>
+  <rect x="22" y="10" width="6" height="9" rx="1" fill="#3D3D3D"/>
+  <!-- Cracks on arms -->
+  <line x1="6" y1="11" x2="5" y2="15" stroke="#636E72" stroke-width="0.7"/>
+  <line x1="25" y1="12" x2="26" y2="16" stroke="#636E72" stroke-width="0.7"/>
+  <!-- Legs -->
+  <rect x="11" y="23" width="4" height="8" rx="1" fill="#3D3D3D"/>
+  <rect x="17" y="23" width="4" height="8" rx="1" fill="#3D3D3D"/>
+</svg>

--- a/web/public/sprites/the-elder-warden-1.svg
+++ b/web/public/sprites/the-elder-warden-1.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Staff raised - larger glow -->
+  <circle cx="5" cy="1" r="4" fill="#F9CA24" opacity="0.3"/>
+  <rect x="4" y="1" width="2" height="22" rx="1" fill="#8B5E3C"/>
+  <circle cx="5" cy="1" r="2.5" fill="#F9CA24"/>
+  <circle cx="5" cy="1" r="1.2" fill="#FFF9C4"/>
+  <circle cx="16" cy="6" r="4" fill="#C9A87C"/>
+  <ellipse cx="16" cy="11" rx="4" ry="4" fill="#E8E8E8"/>
+  <polygon points="13,14 16,20 19,14" fill="#E8E8E8"/>
+  <line x1="13.5" y1="6" x2="15.5" y2="6" stroke="#4A2C17" stroke-width="1.2"/>
+  <line x1="16.5" y1="6" x2="18.5" y2="6" stroke="#4A2C17" stroke-width="1.2"/>
+  <line x1="13" y1="5" x2="15.5" y2="5" stroke="#8B6B3D" stroke-width="0.8"/>
+  <line x1="16.5" y1="5" x2="19" y2="5" stroke="#8B6B3D" stroke-width="0.8"/>
+  <rect x="10" y="10" width="12" height="14" rx="2" fill="#1D4D35"/>
+  <rect x="10" y="10" width="12" height="4" rx="2" fill="#2D6A4F"/>
+  <polygon points="10,14 7,16 10,18" fill="#52B788"/>
+  <polygon points="22,14 25,16 22,18" fill="#52B788"/>
+  <rect x="10" y="20" width="12" height="2" rx="1" fill="#F9CA24"/>
+  <!-- Staff arm raised -->
+  <rect x="5" y="7" width="5" height="9" rx="1" fill="#1D4D35"/>
+  <rect x="17" y="10" width="5" height="9" rx="1" fill="#1D4D35"/>
+  <!-- Stride A -->
+  <rect x="11" y="24" width="4" height="7" rx="1" fill="#1D4D35" transform="rotate(-4 13 27.5)"/>
+  <rect x="17" y="24" width="4" height="7" rx="1" fill="#1D4D35" transform="rotate(4 19 27.5)"/>
+</svg>

--- a/web/public/sprites/the-elder-warden-2.svg
+++ b/web/public/sprites/the-elder-warden-2.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="5" cy="4" r="3.5" fill="#F9CA24" opacity="0.3"/>
+  <rect x="4" y="4" width="2" height="22" rx="1" fill="#8B5E3C"/>
+  <circle cx="5" cy="4" r="2.5" fill="#F9CA24"/>
+  <circle cx="5" cy="4" r="1.2" fill="#FFF9C4"/>
+  <circle cx="16" cy="7" r="4" fill="#C9A87C"/>
+  <ellipse cx="16" cy="12" rx="4" ry="4" fill="#E8E8E8"/>
+  <polygon points="13,15 16,21 19,15" fill="#E8E8E8"/>
+  <line x1="13.5" y1="7" x2="15.5" y2="7" stroke="#4A2C17" stroke-width="1.2"/>
+  <line x1="16.5" y1="7" x2="18.5" y2="7" stroke="#4A2C17" stroke-width="1.2"/>
+  <line x1="13" y1="6" x2="15.5" y2="6" stroke="#8B6B3D" stroke-width="0.8"/>
+  <line x1="16.5" y1="6" x2="19" y2="6" stroke="#8B6B3D" stroke-width="0.8"/>
+  <rect x="10" y="11" width="12" height="14" rx="2" fill="#1D4D35"/>
+  <rect x="10" y="11" width="12" height="4" rx="2" fill="#2D6A4F"/>
+  <polygon points="10,15 7,17 10,19" fill="#52B788"/>
+  <polygon points="22,15 25,17 22,19" fill="#52B788"/>
+  <rect x="10" y="21" width="12" height="2" rx="1" fill="#F9CA24"/>
+  <rect x="5" y="11" width="5" height="9" rx="1" fill="#1D4D35"/>
+  <rect x="17" y="11" width="5" height="9" rx="1" fill="#1D4D35"/>
+  <!-- Legs bob down -->
+  <rect x="11" y="25" width="4" height="6" rx="1" fill="#1D4D35"/>
+  <rect x="17" y="25" width="4" height="6" rx="1" fill="#1D4D35"/>
+</svg>

--- a/web/public/sprites/the-elder-warden-3.svg
+++ b/web/public/sprites/the-elder-warden-3.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="5" cy="3" r="3.5" fill="#F9CA24" opacity="0.3"/>
+  <rect x="4" y="3" width="2" height="22" rx="1" fill="#8B5E3C"/>
+  <circle cx="5" cy="3" r="2.5" fill="#F9CA24"/>
+  <circle cx="5" cy="3" r="1.2" fill="#FFF9C4"/>
+  <circle cx="16" cy="6" r="4" fill="#C9A87C"/>
+  <ellipse cx="16" cy="11" rx="4" ry="4" fill="#E8E8E8"/>
+  <polygon points="13,14 16,20 19,14" fill="#E8E8E8"/>
+  <line x1="13.5" y1="6" x2="15.5" y2="6" stroke="#4A2C17" stroke-width="1.2"/>
+  <line x1="16.5" y1="6" x2="18.5" y2="6" stroke="#4A2C17" stroke-width="1.2"/>
+  <line x1="13" y1="5" x2="15.5" y2="5" stroke="#8B6B3D" stroke-width="0.8"/>
+  <line x1="16.5" y1="5" x2="19" y2="5" stroke="#8B6B3D" stroke-width="0.8"/>
+  <rect x="10" y="10" width="12" height="14" rx="2" fill="#1D4D35"/>
+  <rect x="10" y="10" width="12" height="4" rx="2" fill="#2D6A4F"/>
+  <polygon points="10,14 7,16 10,18" fill="#52B788"/>
+  <polygon points="22,14 25,16 22,18" fill="#52B788"/>
+  <rect x="10" y="20" width="12" height="2" rx="1" fill="#F9CA24"/>
+  <!-- Staff arm normal -->
+  <rect x="5" y="10" width="5" height="9" rx="1" fill="#1D4D35"/>
+  <!-- Right arm raised in blessing -->
+  <rect x="17" y="7" width="5" height="9" rx="1" fill="#1D4D35"/>
+  <!-- Gold sparkle from raised hand -->
+  <circle cx="23" cy="7" r="2" fill="#F9CA24" opacity="0.6"/>
+  <circle cx="23" cy="7" r="1" fill="#FFF9C4" opacity="0.8"/>
+  <!-- Stride B -->
+  <rect x="11" y="24" width="4" height="7" rx="1" fill="#1D4D35" transform="rotate(4 13 27.5)"/>
+  <rect x="17" y="24" width="4" height="7" rx="1" fill="#1D4D35" transform="rotate(-4 19 27.5)"/>
+</svg>

--- a/web/public/sprites/the-elder-warden.svg
+++ b/web/public/sprites/the-elder-warden.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Staff glow halo -->
+  <circle cx="5" cy="3" r="3.5" fill="#F9CA24" opacity="0.3"/>
+  <!-- Staff -->
+  <rect x="4" y="3" width="2" height="22" rx="1" fill="#8B5E3C"/>
+  <!-- Gold orb on staff -->
+  <circle cx="5" cy="3" r="2.5" fill="#F9CA24"/>
+  <circle cx="5" cy="3" r="1.2" fill="#FFF9C4"/>
+  <!-- Head -->
+  <circle cx="16" cy="6" r="4" fill="#C9A87C"/>
+  <!-- Long white beard -->
+  <ellipse cx="16" cy="11" rx="4" ry="4" fill="#E8E8E8"/>
+  <polygon points="13,14 16,20 19,14" fill="#E8E8E8"/>
+  <!-- Wise half-closed eyes -->
+  <line x1="13.5" y1="6" x2="15.5" y2="6" stroke="#4A2C17" stroke-width="1.2"/>
+  <line x1="16.5" y1="6" x2="18.5" y2="6" stroke="#4A2C17" stroke-width="1.2"/>
+  <!-- Eyebrows -->
+  <line x1="13" y1="5" x2="15.5" y2="5" stroke="#8B6B3D" stroke-width="0.8"/>
+  <line x1="16.5" y1="5" x2="19" y2="5" stroke="#8B6B3D" stroke-width="0.8"/>
+  <!-- Forest green robe -->
+  <rect x="10" y="10" width="12" height="14" rx="2" fill="#1D4D35"/>
+  <rect x="10" y="10" width="12" height="4" rx="2" fill="#2D6A4F"/>
+  <!-- Leaf trim -->
+  <polygon points="10,14 7,16 10,18" fill="#52B788"/>
+  <polygon points="22,14 25,16 22,18" fill="#52B788"/>
+  <!-- Gold belt -->
+  <rect x="10" y="20" width="12" height="2" rx="1" fill="#F9CA24"/>
+  <!-- Staff arm (left) -->
+  <rect x="5" y="10" width="5" height="9" rx="1" fill="#1D4D35"/>
+  <!-- Right arm -->
+  <rect x="17" y="10" width="5" height="9" rx="1" fill="#1D4D35"/>
+  <!-- Legs -->
+  <rect x="11" y="24" width="4" height="7" rx="1" fill="#1D4D35"/>
+  <rect x="17" y="24" width="4" height="7" rx="1" fill="#1D4D35"/>
+</svg>

--- a/web/public/sprites/the-grand-automaton-1.svg
+++ b/web/public/sprites/the-grand-automaton-1.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect x="7" y="1" width="18" height="13" rx="2" fill="#B8860B"/>
+  <rect x="7" y="1" width="18" height="6" rx="2" fill="#D4AF37"/>
+  <circle cx="9" cy="3" r="0.8" fill="#7D5A00"/>
+  <circle cx="23" cy="3" r="0.8" fill="#7D5A00"/>
+  <circle cx="9" cy="12" r="0.8" fill="#7D5A00"/>
+  <circle cx="23" cy="12" r="0.8" fill="#7D5A00"/>
+  <rect x="10" y="5" width="5" height="4" rx="1" fill="#00CEC9"/>
+  <rect x="17" y="5" width="5" height="4" rx="1" fill="#00CEC9"/>
+  <rect x="11" y="5.5" width="3" height="3" rx="0.5" fill="#81ECEC"/>
+  <rect x="18" y="5.5" width="3" height="3" rx="0.5" fill="#81ECEC"/>
+  <rect x="11" y="10" width="10" height="3" rx="1" fill="#7D5A00"/>
+  <line x1="14" y1="10" x2="14" y2="13" stroke="#B8860B" stroke-width="0.6"/>
+  <line x1="18" y1="10" x2="18" y2="13" stroke="#B8860B" stroke-width="0.6"/>
+  <rect x="5" y="14" width="22" height="13" rx="2" fill="#9A7000"/>
+  <rect x="12" y="17" width="8" height="6" rx="1" fill="#B8860B"/>
+  <circle cx="16" cy="20" r="3" fill="#00CEC9" opacity="0.9"/>
+  <circle cx="16" cy="20" r="1.5" fill="#81ECEC"/>
+  <!-- Left arm raised -->
+  <rect x="0" y="11" width="5" height="11" rx="1" fill="#9A7000"/>
+  <circle cx="2.5" cy="11" r="2" fill="#B8860B"/>
+  <rect x="0" y="20" width="6" height="5" rx="1" fill="#7D5A00"/>
+  <!-- Right arm normal -->
+  <rect x="27" y="14" width="5" height="11" rx="1" fill="#9A7000"/>
+  <circle cx="29.5" cy="14" r="2" fill="#B8860B"/>
+  <rect x="26" y="23" width="6" height="5" rx="1" fill="#7D5A00"/>
+  <!-- Legs stride A -->
+  <rect x="7" y="27" width="7" height="5" rx="1" fill="#9A7000" transform="rotate(-4 10.5 29.5)"/>
+  <rect x="18" y="27" width="7" height="5" rx="1" fill="#9A7000" transform="rotate(4 21.5 29.5)"/>
+</svg>

--- a/web/public/sprites/the-grand-automaton-2.svg
+++ b/web/public/sprites/the-grand-automaton-2.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect x="7" y="2" width="18" height="13" rx="2" fill="#B8860B"/>
+  <rect x="7" y="2" width="18" height="6" rx="2" fill="#D4AF37"/>
+  <circle cx="9" cy="4" r="0.8" fill="#7D5A00"/>
+  <circle cx="23" cy="4" r="0.8" fill="#7D5A00"/>
+  <circle cx="9" cy="13" r="0.8" fill="#7D5A00"/>
+  <circle cx="23" cy="13" r="0.8" fill="#7D5A00"/>
+  <rect x="10" y="6" width="5" height="4" rx="1" fill="#00CEC9"/>
+  <rect x="17" y="6" width="5" height="4" rx="1" fill="#00CEC9"/>
+  <rect x="11" y="6.5" width="3" height="3" rx="0.5" fill="#81ECEC"/>
+  <rect x="18" y="6.5" width="3" height="3" rx="0.5" fill="#81ECEC"/>
+  <rect x="11" y="11" width="10" height="3" rx="1" fill="#7D5A00"/>
+  <line x1="14" y1="11" x2="14" y2="14" stroke="#B8860B" stroke-width="0.6"/>
+  <line x1="18" y1="11" x2="18" y2="14" stroke="#B8860B" stroke-width="0.6"/>
+  <rect x="5" y="15" width="22" height="13" rx="2" fill="#9A7000"/>
+  <rect x="12" y="18" width="8" height="6" rx="1" fill="#B8860B"/>
+  <circle cx="16" cy="21" r="3" fill="#00CEC9" opacity="0.9"/>
+  <circle cx="16" cy="21" r="1.5" fill="#81ECEC"/>
+  <rect x="0" y="15" width="5" height="11" rx="1" fill="#9A7000"/>
+  <circle cx="2.5" cy="15" r="2" fill="#B8860B"/>
+  <rect x="0" y="24" width="6" height="5" rx="1" fill="#7D5A00"/>
+  <rect x="27" y="15" width="5" height="11" rx="1" fill="#9A7000"/>
+  <circle cx="29.5" cy="15" r="2" fill="#B8860B"/>
+  <rect x="26" y="24" width="6" height="5" rx="1" fill="#7D5A00"/>
+  <!-- Legs bob down -->
+  <rect x="7" y="28" width="7" height="4" rx="1" fill="#9A7000"/>
+  <rect x="18" y="28" width="7" height="4" rx="1" fill="#9A7000"/>
+</svg>

--- a/web/public/sprites/the-grand-automaton-3.svg
+++ b/web/public/sprites/the-grand-automaton-3.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect x="7" y="1" width="18" height="13" rx="2" fill="#B8860B"/>
+  <rect x="7" y="1" width="18" height="6" rx="2" fill="#D4AF37"/>
+  <circle cx="9" cy="3" r="0.8" fill="#7D5A00"/>
+  <circle cx="23" cy="3" r="0.8" fill="#7D5A00"/>
+  <circle cx="9" cy="12" r="0.8" fill="#7D5A00"/>
+  <circle cx="23" cy="12" r="0.8" fill="#7D5A00"/>
+  <rect x="10" y="5" width="5" height="4" rx="1" fill="#00CEC9"/>
+  <rect x="17" y="5" width="5" height="4" rx="1" fill="#00CEC9"/>
+  <rect x="11" y="5.5" width="3" height="3" rx="0.5" fill="#81ECEC"/>
+  <rect x="18" y="5.5" width="3" height="3" rx="0.5" fill="#81ECEC"/>
+  <rect x="11" y="10" width="10" height="3" rx="1" fill="#7D5A00"/>
+  <line x1="14" y1="10" x2="14" y2="13" stroke="#B8860B" stroke-width="0.6"/>
+  <line x1="18" y1="10" x2="18" y2="13" stroke="#B8860B" stroke-width="0.6"/>
+  <rect x="5" y="14" width="22" height="13" rx="2" fill="#9A7000"/>
+  <rect x="12" y="17" width="8" height="6" rx="1" fill="#B8860B"/>
+  <circle cx="16" cy="20" r="3" fill="#00CEC9" opacity="0.9"/>
+  <circle cx="16" cy="20" r="1.5" fill="#81ECEC"/>
+  <!-- Left arm normal -->
+  <rect x="0" y="14" width="5" height="11" rx="1" fill="#9A7000"/>
+  <circle cx="2.5" cy="14" r="2" fill="#B8860B"/>
+  <rect x="0" y="23" width="6" height="5" rx="1" fill="#7D5A00"/>
+  <!-- Right arm raised -->
+  <rect x="27" y="11" width="5" height="11" rx="1" fill="#9A7000"/>
+  <circle cx="29.5" cy="11" r="2" fill="#B8860B"/>
+  <rect x="26" y="20" width="6" height="5" rx="1" fill="#7D5A00"/>
+  <!-- Legs stride B -->
+  <rect x="7" y="27" width="7" height="5" rx="1" fill="#9A7000" transform="rotate(4 10.5 29.5)"/>
+  <rect x="18" y="27" width="7" height="5" rx="1" fill="#9A7000" transform="rotate(-4 21.5 29.5)"/>
+</svg>

--- a/web/public/sprites/the-grand-automaton.svg
+++ b/web/public/sprites/the-grand-automaton.svg
@@ -1,0 +1,37 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Massive blocky head -->
+  <rect x="7" y="1" width="18" height="13" rx="2" fill="#B8860B"/>
+  <rect x="7" y="1" width="18" height="6" rx="2" fill="#D4AF37"/>
+  <!-- Rivets on corners -->
+  <circle cx="9" cy="3" r="0.8" fill="#7D5A00"/>
+  <circle cx="23" cy="3" r="0.8" fill="#7D5A00"/>
+  <circle cx="9" cy="12" r="0.8" fill="#7D5A00"/>
+  <circle cx="23" cy="12" r="0.8" fill="#7D5A00"/>
+  <!-- Glowing teal gem eyes -->
+  <rect x="10" y="5" width="5" height="4" rx="1" fill="#00CEC9"/>
+  <rect x="17" y="5" width="5" height="4" rx="1" fill="#00CEC9"/>
+  <rect x="11" y="5.5" width="3" height="3" rx="0.5" fill="#81ECEC"/>
+  <rect x="18" y="5.5" width="3" height="3" rx="0.5" fill="#81ECEC"/>
+  <!-- Jaw grate -->
+  <rect x="11" y="10" width="10" height="3" rx="1" fill="#7D5A00"/>
+  <line x1="14" y1="10" x2="14" y2="13" stroke="#B8860B" stroke-width="0.6"/>
+  <line x1="18" y1="10" x2="18" y2="13" stroke="#B8860B" stroke-width="0.6"/>
+  <!-- Massive body -->
+  <rect x="5" y="14" width="22" height="13" rx="2" fill="#9A7000"/>
+  <!-- Chest gem -->
+  <rect x="12" y="17" width="8" height="6" rx="1" fill="#B8860B"/>
+  <circle cx="16" cy="20" r="3" fill="#00CEC9" opacity="0.9"/>
+  <circle cx="16" cy="20" r="1.5" fill="#81ECEC"/>
+  <!-- Heavy arms -->
+  <rect x="0" y="14" width="5" height="11" rx="1" fill="#9A7000"/>
+  <rect x="27" y="14" width="5" height="11" rx="1" fill="#9A7000"/>
+  <!-- Arm shoulder joints -->
+  <circle cx="2.5" cy="14" r="2" fill="#B8860B"/>
+  <circle cx="29.5" cy="14" r="2" fill="#B8860B"/>
+  <!-- Fists -->
+  <rect x="0" y="23" width="6" height="5" rx="1" fill="#7D5A00"/>
+  <rect x="26" y="23" width="6" height="5" rx="1" fill="#7D5A00"/>
+  <!-- Heavy legs -->
+  <rect x="7" y="27" width="7" height="5" rx="1" fill="#9A7000"/>
+  <rect x="18" y="27" width="7" height="5" rx="1" fill="#9A7000"/>
+</svg>

--- a/web/public/sprites/the-harbormaster-1.svg
+++ b/web/public/sprites/the-harbormaster-1.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect x="9" y="3" width="14" height="2" rx="1" fill="#0D2137"/>
+  <rect x="11" y="1" width="10" height="4" rx="1" fill="#1B3A6B"/>
+  <rect x="14" y="1.5" width="4" height="2" rx="0.5" fill="#F39C12"/>
+  <circle cx="16" cy="8" r="4" fill="#D4AC68"/>
+  <ellipse cx="16" cy="10.5" rx="3" ry="1.2" fill="#4A3B2A"/>
+  <circle cx="14.5" cy="7.5" r="1" fill="#2C3E50"/>
+  <circle cx="17.5" cy="7.5" r="1" fill="#2C3E50"/>
+  <rect x="9" y="12" width="14" height="13" rx="2" fill="#1B3A6B"/>
+  <rect x="9" y="12" width="14" height="4" rx="2" fill="#2C5282"/>
+  <circle cx="16" cy="14" r="0.8" fill="#F39C12"/>
+  <circle cx="16" cy="17" r="0.8" fill="#F39C12"/>
+  <circle cx="16" cy="20" r="0.8" fill="#F39C12"/>
+  <rect x="7" y="12" width="4" height="2" rx="1" fill="#F39C12"/>
+  <rect x="21" y="12" width="4" height="2" rx="1" fill="#F39C12"/>
+  <!-- Left arm (telescope) raised to eye -->
+  <rect x="4" y="9" width="5" height="9" rx="1" fill="#1B3A6B"/>
+  <rect x="1" y="12" width="7" height="3" rx="1" fill="#8B6B3D"/>
+  <rect x="0" y="12.5" width="3" height="2" rx="0.5" fill="#C9A24C"/>
+  <rect x="23" y="12" width="5" height="9" rx="1" fill="#1B3A6B"/>
+  <!-- Stride A -->
+  <rect x="10" y="25" width="5" height="7" rx="1" fill="#0D2137" transform="rotate(-4 12.5 28.5)"/>
+  <rect x="17" y="25" width="5" height="7" rx="1" fill="#0D2137" transform="rotate(4 19.5 28.5)"/>
+</svg>

--- a/web/public/sprites/the-harbormaster-2.svg
+++ b/web/public/sprites/the-harbormaster-2.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect x="9" y="4" width="14" height="2" rx="1" fill="#0D2137"/>
+  <rect x="11" y="2" width="10" height="4" rx="1" fill="#1B3A6B"/>
+  <rect x="14" y="2.5" width="4" height="2" rx="0.5" fill="#F39C12"/>
+  <circle cx="16" cy="9" r="4" fill="#D4AC68"/>
+  <ellipse cx="16" cy="11.5" rx="3" ry="1.2" fill="#4A3B2A"/>
+  <circle cx="14.5" cy="8.5" r="1" fill="#2C3E50"/>
+  <circle cx="17.5" cy="8.5" r="1" fill="#2C3E50"/>
+  <rect x="9" y="13" width="14" height="13" rx="2" fill="#1B3A6B"/>
+  <rect x="9" y="13" width="14" height="4" rx="2" fill="#2C5282"/>
+  <circle cx="16" cy="15" r="0.8" fill="#F39C12"/>
+  <circle cx="16" cy="18" r="0.8" fill="#F39C12"/>
+  <circle cx="16" cy="21" r="0.8" fill="#F39C12"/>
+  <rect x="7" y="13" width="4" height="2" rx="1" fill="#F39C12"/>
+  <rect x="21" y="13" width="4" height="2" rx="1" fill="#F39C12"/>
+  <rect x="4" y="13" width="5" height="9" rx="1" fill="#1B3A6B"/>
+  <rect x="1" y="16" width="7" height="3" rx="1" fill="#8B6B3D"/>
+  <rect x="0" y="16.5" width="3" height="2" rx="0.5" fill="#C9A24C"/>
+  <rect x="23" y="13" width="5" height="9" rx="1" fill="#1B3A6B"/>
+  <!-- Legs bob down -->
+  <rect x="10" y="26" width="5" height="6" rx="1" fill="#0D2137"/>
+  <rect x="17" y="26" width="5" height="6" rx="1" fill="#0D2137"/>
+</svg>

--- a/web/public/sprites/the-harbormaster-3.svg
+++ b/web/public/sprites/the-harbormaster-3.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect x="9" y="3" width="14" height="2" rx="1" fill="#0D2137"/>
+  <rect x="11" y="1" width="10" height="4" rx="1" fill="#1B3A6B"/>
+  <rect x="14" y="1.5" width="4" height="2" rx="0.5" fill="#F39C12"/>
+  <circle cx="16" cy="8" r="4" fill="#D4AC68"/>
+  <ellipse cx="16" cy="10.5" rx="3" ry="1.2" fill="#4A3B2A"/>
+  <circle cx="14.5" cy="7.5" r="1" fill="#2C3E50"/>
+  <circle cx="17.5" cy="7.5" r="1" fill="#2C3E50"/>
+  <rect x="9" y="12" width="14" height="13" rx="2" fill="#1B3A6B"/>
+  <rect x="9" y="12" width="14" height="4" rx="2" fill="#2C5282"/>
+  <circle cx="16" cy="14" r="0.8" fill="#F39C12"/>
+  <circle cx="16" cy="17" r="0.8" fill="#F39C12"/>
+  <circle cx="16" cy="20" r="0.8" fill="#F39C12"/>
+  <rect x="7" y="12" width="4" height="2" rx="1" fill="#F39C12"/>
+  <rect x="21" y="12" width="4" height="2" rx="1" fill="#F39C12"/>
+  <!-- Left arm telescope normal -->
+  <rect x="4" y="12" width="5" height="9" rx="1" fill="#1B3A6B"/>
+  <rect x="1" y="15" width="7" height="3" rx="1" fill="#8B6B3D"/>
+  <rect x="0" y="15.5" width="3" height="2" rx="0.5" fill="#C9A24C"/>
+  <!-- Right arm raised in salute -->
+  <rect x="23" y="9" width="5" height="9" rx="1" fill="#1B3A6B"/>
+  <!-- Stride B -->
+  <rect x="10" y="25" width="5" height="7" rx="1" fill="#0D2137" transform="rotate(4 12.5 28.5)"/>
+  <rect x="17" y="25" width="5" height="7" rx="1" fill="#0D2137" transform="rotate(-4 19.5 28.5)"/>
+</svg>

--- a/web/public/sprites/the-harbormaster.svg
+++ b/web/public/sprites/the-harbormaster.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Captain's hat brim -->
+  <rect x="9" y="3" width="14" height="2" rx="1" fill="#0D2137"/>
+  <!-- Hat crown -->
+  <rect x="11" y="1" width="10" height="4" rx="1" fill="#1B3A6B"/>
+  <!-- Hat badge -->
+  <rect x="14" y="1.5" width="4" height="2" rx="0.5" fill="#F39C12"/>
+  <!-- Head -->
+  <circle cx="16" cy="8" r="4" fill="#D4AC68"/>
+  <!-- Mustache -->
+  <ellipse cx="16" cy="10.5" rx="3" ry="1.2" fill="#4A3B2A"/>
+  <!-- Eyes -->
+  <circle cx="14.5" cy="7.5" r="1" fill="#2C3E50"/>
+  <circle cx="17.5" cy="7.5" r="1" fill="#2C3E50"/>
+  <!-- Naval coat -->
+  <rect x="9" y="12" width="14" height="13" rx="2" fill="#1B3A6B"/>
+  <rect x="9" y="12" width="14" height="4" rx="2" fill="#2C5282"/>
+  <!-- Gold buttons -->
+  <circle cx="16" cy="14" r="0.8" fill="#F39C12"/>
+  <circle cx="16" cy="17" r="0.8" fill="#F39C12"/>
+  <circle cx="16" cy="20" r="0.8" fill="#F39C12"/>
+  <!-- Gold epaulettes -->
+  <rect x="7" y="12" width="4" height="2" rx="1" fill="#F39C12"/>
+  <rect x="21" y="12" width="4" height="2" rx="1" fill="#F39C12"/>
+  <!-- Left arm (telescope) -->
+  <rect x="4" y="12" width="5" height="9" rx="1" fill="#1B3A6B"/>
+  <!-- Telescope -->
+  <rect x="1" y="15" width="7" height="3" rx="1" fill="#8B6B3D"/>
+  <rect x="0" y="15.5" width="3" height="2" rx="0.5" fill="#C9A24C"/>
+  <!-- Right arm -->
+  <rect x="23" y="12" width="5" height="9" rx="1" fill="#1B3A6B"/>
+  <!-- Navy trousers -->
+  <rect x="10" y="25" width="5" height="7" rx="1" fill="#0D2137"/>
+  <rect x="17" y="25" width="5" height="7" rx="1" fill="#0D2137"/>
+</svg>

--- a/web/public/sprites/thunder-drake-1.svg
+++ b/web/public/sprites/thunder-drake-1.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Wings raised -->
+  <polygon points="16,15 3,4 1,14 9,14" fill="#2C3E50"/>
+  <polygon points="16,15 29,4 31,14 23,14" fill="#2C3E50"/>
+  <polygon points="8,14 1,14 3,18 10,16" fill="#4A6FA5"/>
+  <polygon points="24,14 31,14 29,18 22,16" fill="#4A6FA5"/>
+  <polygon points="3,8 6,6 5,10 7,8 5,12" fill="#F1C40F" opacity="0.85"/>
+  <polygon points="29,8 26,6 27,10 25,8 27,12" fill="#F1C40F" opacity="0.85"/>
+  <ellipse cx="16" cy="16" rx="6" ry="6" fill="#1A2B3F"/>
+  <ellipse cx="14" cy="14" rx="2" ry="1.5" fill="#2C3E50"/>
+  <ellipse cx="18" cy="14" rx="2" ry="1.5" fill="#2C3E50"/>
+  <ellipse cx="16" cy="17" rx="2" ry="1.5" fill="#2C3E50"/>
+  <ellipse cx="16" cy="10" rx="4.5" ry="3.5" fill="#2C3E50"/>
+  <polygon points="13,8 11,3 14,7" fill="#8E44AD"/>
+  <polygon points="19,8 21,3 18,7" fill="#8E44AD"/>
+  <ellipse cx="16" cy="11" rx="3" ry="2" fill="#1A2B3F"/>
+  <circle cx="14.5" cy="11" r="0.8" fill="#F1C40F" opacity="0.8"/>
+  <circle cx="17.5" cy="11" r="0.8" fill="#F1C40F" opacity="0.8"/>
+  <circle cx="13.5" cy="9" r="1.3" fill="#F1C40F"/>
+  <circle cx="18.5" cy="9" r="1.3" fill="#F1C40F"/>
+  <circle cx="13.5" cy="9" r="0.6" fill="#1A2B3F"/>
+  <circle cx="18.5" cy="9" r="0.6" fill="#1A2B3F"/>
+  <path d="M22,18 Q28,21 30,26 Q28,29 25,27" fill="none" stroke="#2C3E50" stroke-width="3" stroke-linecap="round"/>
+  <ellipse cx="12" cy="23" rx="2.5" ry="3" fill="#2C3E50"/>
+  <ellipse cx="20" cy="23" rx="2.5" ry="3" fill="#2C3E50"/>
+  <polygon points="10,25 8,28 12,26" fill="#8E44AD"/>
+  <polygon points="14,25 13,29 15,26" fill="#8E44AD"/>
+  <polygon points="18,25 17,29 19,26" fill="#8E44AD"/>
+  <polygon points="22,25 24,28 20,26" fill="#8E44AD"/>
+</svg>

--- a/web/public/sprites/thunder-drake-2.svg
+++ b/web/public/sprites/thunder-drake-2.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Wings level/horizontal -->
+  <polygon points="16,16 0,13 0,19 8,17" fill="#2C3E50"/>
+  <polygon points="16,16 32,13 32,19 24,17" fill="#2C3E50"/>
+  <polygon points="7,17 0,19 2,23 10,20" fill="#4A6FA5"/>
+  <polygon points="25,17 32,19 30,23 22,20" fill="#4A6FA5"/>
+  <polygon points="2,14 5,12 4,16 6,14 4,18" fill="#F1C40F" opacity="0.85"/>
+  <polygon points="30,14 27,12 28,16 26,14 28,18" fill="#F1C40F" opacity="0.85"/>
+  <ellipse cx="16" cy="16" rx="6" ry="6" fill="#1A2B3F"/>
+  <ellipse cx="14" cy="14" rx="2" ry="1.5" fill="#2C3E50"/>
+  <ellipse cx="18" cy="14" rx="2" ry="1.5" fill="#2C3E50"/>
+  <ellipse cx="16" cy="17" rx="2" ry="1.5" fill="#2C3E50"/>
+  <ellipse cx="16" cy="10" rx="4.5" ry="3.5" fill="#2C3E50"/>
+  <polygon points="13,8 11,3 14,7" fill="#8E44AD"/>
+  <polygon points="19,8 21,3 18,7" fill="#8E44AD"/>
+  <ellipse cx="16" cy="11" rx="3" ry="2" fill="#1A2B3F"/>
+  <circle cx="14.5" cy="11" r="0.8" fill="#F1C40F" opacity="0.8"/>
+  <circle cx="17.5" cy="11" r="0.8" fill="#F1C40F" opacity="0.8"/>
+  <circle cx="13.5" cy="9" r="1.3" fill="#F1C40F"/>
+  <circle cx="18.5" cy="9" r="1.3" fill="#F1C40F"/>
+  <circle cx="13.5" cy="9" r="0.6" fill="#1A2B3F"/>
+  <circle cx="18.5" cy="9" r="0.6" fill="#1A2B3F"/>
+  <path d="M22,18 Q28,21 30,26 Q28,29 25,27" fill="none" stroke="#2C3E50" stroke-width="3" stroke-linecap="round"/>
+  <ellipse cx="12" cy="23" rx="2.5" ry="3.5" fill="#2C3E50"/>
+  <ellipse cx="20" cy="23" rx="2.5" ry="3.5" fill="#2C3E50"/>
+  <polygon points="10,25 8,28 12,26" fill="#8E44AD"/>
+  <polygon points="14,25 13,29 15,26" fill="#8E44AD"/>
+  <polygon points="18,25 17,29 19,26" fill="#8E44AD"/>
+  <polygon points="22,25 24,28 20,26" fill="#8E44AD"/>
+</svg>

--- a/web/public/sprites/thunder-drake-3.svg
+++ b/web/public/sprites/thunder-drake-3.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Wings down/striking -->
+  <polygon points="16,13 2,18 1,25 9,18" fill="#2C3E50"/>
+  <polygon points="16,13 30,18 31,25 23,18" fill="#2C3E50"/>
+  <polygon points="8,18 1,24 3,28 10,21" fill="#4A6FA5"/>
+  <polygon points="24,18 31,24 29,28 22,21" fill="#4A6FA5"/>
+  <!-- Lightning burst from body when striking -->
+  <polygon points="18,14 24,11 20,16 26,13 21,20" fill="#F1C40F"/>
+  <polygon points="14,14 8,11 12,16 6,13 11,20" fill="#F1C40F" opacity="0.5"/>
+  <polygon points="2,19 5,17 4,21 6,19 4,23" fill="#F1C40F" opacity="0.7"/>
+  <polygon points="30,19 27,17 28,21 26,19 28,23" fill="#F1C40F" opacity="0.7"/>
+  <ellipse cx="16" cy="13" rx="6" ry="6" fill="#1A2B3F"/>
+  <ellipse cx="14" cy="11" rx="2" ry="1.5" fill="#2C3E50"/>
+  <ellipse cx="18" cy="11" rx="2" ry="1.5" fill="#2C3E50"/>
+  <ellipse cx="16" cy="14" rx="2" ry="1.5" fill="#2C3E50"/>
+  <ellipse cx="16" cy="7" rx="4.5" ry="3.5" fill="#2C3E50"/>
+  <polygon points="13,5 11,0 14,4" fill="#8E44AD"/>
+  <polygon points="19,5 21,0 18,4" fill="#8E44AD"/>
+  <ellipse cx="16" cy="8" rx="3" ry="2" fill="#1A2B3F"/>
+  <circle cx="14.5" cy="8" r="0.8" fill="#F1C40F" opacity="0.8"/>
+  <circle cx="17.5" cy="8" r="0.8" fill="#F1C40F" opacity="0.8"/>
+  <circle cx="13.5" cy="6" r="1.3" fill="#F1C40F"/>
+  <circle cx="18.5" cy="6" r="1.3" fill="#F1C40F"/>
+  <circle cx="13.5" cy="6" r="0.6" fill="#1A2B3F"/>
+  <circle cx="18.5" cy="6" r="0.6" fill="#1A2B3F"/>
+  <path d="M22,15 Q28,18 30,23 Q28,26 25,24" fill="none" stroke="#2C3E50" stroke-width="3" stroke-linecap="round"/>
+  <ellipse cx="12" cy="20" rx="2.5" ry="3" fill="#2C3E50"/>
+  <ellipse cx="20" cy="20" rx="2.5" ry="3" fill="#2C3E50"/>
+  <polygon points="10,22 8,25 12,23" fill="#8E44AD"/>
+  <polygon points="14,22 13,26 15,23" fill="#8E44AD"/>
+  <polygon points="18,22 17,26 19,23" fill="#8E44AD"/>
+  <polygon points="22,22 24,25 20,23" fill="#8E44AD"/>
+</svg>

--- a/web/public/sprites/thunder-drake.svg
+++ b/web/public/sprites/thunder-drake.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Wings spread -->
+  <polygon points="16,14 1,5 0,16 8,14" fill="#2C3E50"/>
+  <polygon points="16,14 31,5 32,16 24,14" fill="#2C3E50"/>
+  <!-- Wing membrane -->
+  <polygon points="7,14 0,15 2,20 9,17" fill="#4A6FA5"/>
+  <polygon points="25,14 32,15 30,20 23,17" fill="#4A6FA5"/>
+  <!-- Lightning markings on wings -->
+  <polygon points="3,9 6,7 5,11 7,9 5,13" fill="#F1C40F" opacity="0.85"/>
+  <polygon points="29,9 26,7 27,11 25,9 27,13" fill="#F1C40F" opacity="0.85"/>
+  <!-- Body -->
+  <ellipse cx="16" cy="15" rx="6" ry="6" fill="#1A2B3F"/>
+  <!-- Scale pattern -->
+  <ellipse cx="14" cy="13" rx="2" ry="1.5" fill="#2C3E50"/>
+  <ellipse cx="18" cy="13" rx="2" ry="1.5" fill="#2C3E50"/>
+  <ellipse cx="16" cy="16" rx="2" ry="1.5" fill="#2C3E50"/>
+  <!-- Head -->
+  <ellipse cx="16" cy="9" rx="4.5" ry="3.5" fill="#2C3E50"/>
+  <!-- Horns -->
+  <polygon points="13,7 11,2 14,6" fill="#8E44AD"/>
+  <polygon points="19,7 21,2 18,6" fill="#8E44AD"/>
+  <!-- Snout -->
+  <ellipse cx="16" cy="10" rx="3" ry="2" fill="#1A2B3F"/>
+  <!-- Nostrils with electric glow -->
+  <circle cx="14.5" cy="10" r="0.8" fill="#F1C40F" opacity="0.8"/>
+  <circle cx="17.5" cy="10" r="0.8" fill="#F1C40F" opacity="0.8"/>
+  <!-- Eyes (electric yellow) -->
+  <circle cx="13.5" cy="8" r="1.3" fill="#F1C40F"/>
+  <circle cx="18.5" cy="8" r="1.3" fill="#F1C40F"/>
+  <circle cx="13.5" cy="8" r="0.6" fill="#1A2B3F"/>
+  <circle cx="18.5" cy="8" r="0.6" fill="#1A2B3F"/>
+  <!-- Tail -->
+  <path d="M22,17 Q28,20 30,25 Q28,28 25,26" fill="none" stroke="#2C3E50" stroke-width="3" stroke-linecap="round"/>
+  <!-- Legs/claws -->
+  <ellipse cx="12" cy="22" rx="2.5" ry="3" fill="#2C3E50"/>
+  <ellipse cx="20" cy="22" rx="2.5" ry="3" fill="#2C3E50"/>
+  <!-- Claws -->
+  <polygon points="10,24 8,27 12,25" fill="#8E44AD"/>
+  <polygon points="14,24 13,28 15,25" fill="#8E44AD"/>
+  <polygon points="18,24 17,28 19,25" fill="#8E44AD"/>
+  <polygon points="22,24 24,27 20,25" fill="#8E44AD"/>
+</svg>


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds 40 SVG sprite files (base + 3 walk frames each) for 10 unit cards from issue #605
- Each unit has a distinctive design with thematically appropriate colors and shapes
- Walk animation follows the standard 4-frame cycle: idle → stride A → bob → stride B

## Units added

| Unit | Design notes |
|---|---|
| Steam Walker | Steampunk mechanical biped; brass boiler head with gauge-eyes, exhaust pipes, piston arms/legs |
| Storm Hawk | Bird-of-prey creature; polygon wings with lightning markings, yellow talons, storm-blue plumage |
| Stormcaller | Humanoid mage; storm-cloud hair, staff with teal orb, lightning bolt chest motif, casts bolts in frame 3 |
| Tempest Rider | Wind rider; billowing cloak, glowing wind-gust hand, hair and cloak reverse direction each stride |
| The Archivist | Scholar; round spectacles, quill, held scroll with visible text lines |
| The Ashwalker | Ash spirit; cracked charcoal body, hollow ember eyes, floating ash particles, tattered cloak |
| The Elder Warden | Nature guardian; long beard, gold staff orb (glow pulses with stride), leaf trim, blessing gesture |
| The Grand Automaton | Massive construct; wide bronze/gold body, teal gem eyes, heavy arms with shoulder joints |
| The Harbormaster | Naval captain; peaked cap with badge, gold buttons and epaulettes, telescope raised to eye |
| Thunder Drake | Electric dragon; spread polygon wings with lightning bolts, purple horns/claws, electric-yellow eyes |

## Test plan

- [ ] Verify all 40 files render correctly in-browser (SVG namespace, viewBox, no broken paths)
- [ ] Confirm walk animation cycles correctly in-game (frames -1 / -2 / -3 loop visibly)
- [ ] Check sprites display at both lane size (32×28) and card size (64×40) without clipping

Closes #605

https://claude.ai/code/session_01Gv3yXRpeCqtKFEAJLkx2Xg
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gv3yXRpeCqtKFEAJLkx2Xg)_