### PR TITLE
City builder: add Lumber Camp (wood), gold/min in picker, fix speech bubbles

### DIFF
--- a/web/src/components/minigames/CityBuilder.tsx
+++ b/web/src/components/minigames/CityBuilder.tsx
@@ -19,6 +19,7 @@ import {
   getCardLevel, levelUpCost, levelUpCard,
   LEVEL_UP_COSTS, MAX_CARD_LEVEL, LEVEL_ATK_BONUS, LEVEL_MAX_HP_BONUS,
   getBuildingProduces,
+  INCOME_SPAWN, INCOME_UTILITY, INCOME_WALL,
 } from '../../game/cityBuilder'
 import { SpriteImg, AnimatedSpriteImg } from '../SpriteImg'
 import { Card } from '../../game/types'
@@ -242,6 +243,10 @@ export function CityBuilder({ onBack }: Props) {
               const cost        = isSpawner ? SPAWNER_PLACE_COST[card.rarity] : null
               const produces    = !isSpawner ? getBuildingProduces(card.name) : null
               const producesEntries = produces ? Object.entries(produces).filter(([, v]) => (v ?? 0) > 0) : []
+              const isWall      = !isSpawner && producesEntries.length === 0
+              const incomeRate  = isSpawner
+                ? INCOME_SPAWN[card.rarity]
+                : isWall ? INCOME_WALL[card.rarity] : INCOME_UTILITY[card.rarity]
 
               return (
                 <button
@@ -271,6 +276,9 @@ export function CityBuilder({ onBack }: Props) {
                         `+${amt} ${RESOURCE_ICONS[r as ResourceType]}/min`
                       ).join(' ')}
                     </div>
+                  )}
+                  {incomeRate > 0 && (
+                    <div className="city-picker-income">+{incomeRate} 💰/min</div>
                   )}
                 </button>
               )

--- a/web/src/data/cards.json
+++ b/web/src/data/cards.json
@@ -10270,6 +10270,29 @@
       "lore": "The first answer to every problem. Usually the second answer too."
     },
     {
+      "name": "Lumber Camp",
+      "rarity": "common",
+      "cost": 2,
+      "cardType": "structure",
+      "unit": {
+        "name": "Lumber Camp",
+        "attack": 0,
+        "maxHp": 15,
+        "isWall": false,
+        "bypassWall": false,
+        "moveSpeed": 0,
+        "attackRange": 0,
+        "attackCooldownMs": 0,
+        "structureEffect": {
+          "type": "attackAura",
+          "amount": 1
+        }
+      },
+      "description": "All friendly units deal +1 damage. Upgrade: +1 more.",
+      "deckCount": 2,
+      "lore": "Axes for trees, edges for everything else."
+    },
+    {
       "name": "Farm",
       "rarity": "uncommon",
       "cost": 3,

--- a/web/src/game/cityBuilder.ts
+++ b/web/src/game/cityBuilder.ts
@@ -19,11 +19,11 @@ export const CELL_PX = 72
 const MAX_OFFLINE_MINUTES = 480
 
 /** Income per minute for spawn buildings. */
-const INCOME_SPAWN: Record<CardRarity, number> = { common: 2, uncommon: 4, rare: 6, epic: 8, legendary: 10 }
+export const INCOME_SPAWN: Record<CardRarity, number> = { common: 2, uncommon: 4, rare: 6, epic: 8, legendary: 10 }
 /** Income per minute for utility buildings. */
-const INCOME_UTILITY: Record<CardRarity, number> = { common: 1, uncommon: 3, rare: 5, epic: 7, legendary: 8 }
+export const INCOME_UTILITY: Record<CardRarity, number> = { common: 1, uncommon: 3, rare: 5, epic: 7, legendary: 8 }
 /** Income per minute for wall / no-effect structures. */
-const INCOME_WALL: Record<CardRarity, number> = { common: 0, uncommon: 1, rare: 1, epic: 2, legendary: 2 }
+export const INCOME_WALL: Record<CardRarity, number> = { common: 0, uncommon: 1, rare: 1, epic: 2, legendary: 2 }
 
 /** Happiness regeneration per minute toward the target value. */
 const HAPPINESS_REGEN = 15
@@ -81,6 +81,7 @@ const BUILDING_RESOURCE_CONFIG: Record<string, Partial<ResourceStock>> = {
   'Pixie Garden':    { wheat: 3 },
   'Oasis Well':      { wheat: 2 },
   'Ancient Spring':  { wheat: 1 },
+  'Lumber Camp':     { wood: 3 },
   'Blacksmith':      { metal: 1 },
   'Stone Mason':     { planks: 2 },
   'Cryo Forge':      { metal: 1 },

--- a/web/src/game/collection.ts
+++ b/web/src/game/collection.ts
@@ -98,6 +98,7 @@ export const STARTER_COLLECTION: CollectionEntry[] = [
   { cardName: 'Knight',         count: 3 },
   { cardName: 'Wizard',         count: 1 },
   { cardName: 'Stone Wall',     count: 4 },
+  { cardName: 'Lumber Camp', count: 2 },
   { cardName: 'Farm',     count: 2 },
   { cardName: 'Barracks',       count: 1 },
   { cardName: 'Sharpen Blades', count: 2 },

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -8951,7 +8951,7 @@ html.light-mode .action-btn {
   position: absolute;
   inset: 0;
   pointer-events: none;
-  overflow: hidden;
+  overflow: visible;
 }
 
 .city-walker {
@@ -9240,6 +9240,13 @@ html.light-mode .action-btn {
 .city-picker-produces {
   font-size: 9px;
   color: #4a9a4a;
+  margin-top: 2px;
+  letter-spacing: 0.5px;
+}
+
+.city-picker-income {
+  font-size: 9px;
+  color: #d0a030;
   margin-top: 2px;
   letter-spacing: 0.5px;
 }


### PR DESCRIPTION
## Summary

- **Wood resource**: Adds a **Lumber Camp** (common structure) that produces +3 🪵/min in the city builder. It also grants +1 attack aura in battle. 2 copies added to the starter collection so the resource is available from the start. Previously wood had no production source but was consumed by placing uncommon+ spawner buildings.
- **Gold income clarity**: Each building card in the picker now shows its gold income rate (e.g. `+2 💰/min`) in gold text, directly visible on mobile without tooltips.
- **Speech bubbles**: Fixed affinity speech bubbles being invisible — `.city-unit-overlay` had `overflow: hidden` which clipped the bubble (positioned above the walker sprite). Changed to `overflow: visible`.

## Files changed

- `web/src/data/cards.json` — new Lumber Camp card
- `web/src/game/cityBuilder.ts` — Lumber Camp in resource config; export income rate constants
- `web/src/game/collection.ts` — 2× Lumber Camp in starter collection
- `web/src/components/minigames/CityBuilder.tsx` — import income constants; render `+N 💰/min` in picker
- `web/src/styles.css` — `.city-picker-income` style; `.city-unit-overlay` overflow fix

## Test plan

- [ ] Open city builder → place building picker shows `+N 💰/min` on every building
- [ ] Lumber Camp appears in picker for new players; placing it shows `+3 🪵/min` in city stats
- [ ] Wood resource accumulates over time with Lumber Camp placed
- [ ] Place a spawner whose affinity partner is absent — speech bubble appears above the walker

https://claude.ai/code/session_018Pv3Ch2UpfHLoUMYPqLJJo

---
_Generated by [Claude Code](https://claude.ai/code/session_018Pv3Ch2UpfHLoUMYPqLJJo)_