### PR TITLE
fix(daily-challenge): set max mana floor to deck's highest card cost

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1000,11 +1000,12 @@ export default function App() {
     const opponentCards = getDailyOpponentDeck()
     battleAllLegendaryRef.current = playerCards.length > 0 && playerCards.every(c => c.rarity === 'legendary')
     // Debatable as to whether the reducer state here should be called "START_DAILY_CHALLENGE" instead of "START"
-    dispatch({ type: 'START', gameState: newGame({ 
+    dispatch({ type: 'START', gameState: newGame({
       prebuiltPlayerDeck:   playerCards,
       prebuiltOpponentDeck: opponentCards,
       opponentHandicap: 0,
       quickStart: true,
+      isDailyChallenge: true,
     }) })
     setScreen('playing') // TODO — move this into the reducer so the transition is atomic and can't be interrupted by a re-render
     rollRareEvent()
@@ -1028,6 +1029,7 @@ export default function App() {
       prebuiltOpponentDeck: opponentCards,
       opponentHandicap: 0,
       quickStart: true,
+      isDailyChallenge: true,
     }) })
     setScreen('playing')
     rollRareEvent()

--- a/web/src/game/engine.ts
+++ b/web/src/game/engine.ts
@@ -130,6 +130,8 @@ export interface NewGameOptions {
   opponentCardPool?: Card[]
   /** Allow the player to have unlimited maximum mana. */
   forgiveManaLimit?: boolean
+  /** Daily challenge mode: sets max mana floor to the highest card cost in the player's deck. */
+  isDailyChallenge?: boolean
 }
 
 export function newGame(
@@ -168,6 +170,7 @@ export function newGame(
     bossSpawnKillPct,
     opponentCardPool,
     forgiveManaLimit,
+    isDailyChallenge,
   } = opts
 
   // Pre-built decks are already in seeded order — don't re-shuffle with Math.random()
@@ -233,7 +236,10 @@ export function newGame(
         `Enemy strategy: ${STRATEGY_LABELS[strategy]}`,
       ]
 
-  const maxMana = forgiveManaLimit ? 9 : Math.max(BASE_MAX_MANA, loadPlayerStats().maxMana)
+  const deckMaxMana = isDailyChallenge && playerDeck.length > 0
+    ? playerDeck.reduce((m, c) => Math.max(m, c.cost), 0)
+    : undefined
+  const maxMana = forgiveManaLimit ? 9 : Math.max(BASE_MAX_MANA, deckMaxMana ?? 0, loadPlayerStats().maxMana)
 
   return {
     playerBase: { hp: 50, maxHp: 50 },
@@ -283,6 +289,7 @@ export function newGame(
     endlessOpponentDeckTemplate: endlessMode ? [...opponentDeck] : undefined,
     bossSpawnKillPct: bossSpawnKillPct ?? 0.5,
     forgiveManaLimit: forgiveManaLimit ?? false,
+    deckMaxMana,
   }
 }
 
@@ -557,7 +564,8 @@ function applyRelicBuffs(s: GameState, deltaMs: number) {
 
 function regenerateMana(s: GameState, deltaMs: number) {
   const manaBonus = getManaBonus(s.field, 'player')
-  s.maxMana = s.forgiveManaLimit ? 9 : Math.min(10, BASE_MAX_MANA + manaBonus + (s.relicManaBonus ?? 0))
+  const effectiveBase = Math.max(BASE_MAX_MANA, s.deckMaxMana ?? 0)
+  s.maxMana = s.forgiveManaLimit ? 9 : Math.min(10, effectiveBase + manaBonus + (s.relicManaBonus ?? 0))
 
   if (s.mana < s.maxMana) {
     const speedMult = 1 + getManaSpeedMult(s.field, 'player')

--- a/web/src/game/types.ts
+++ b/web/src/game/types.ts
@@ -289,4 +289,6 @@ export interface GameState {
   endlessOpponentManaMult?: number
   /** Allow the player to have unlimited maximum mana. */
   forgiveManaLimit?: boolean
+  /** Daily challenge: floor for maxMana equal to the highest card cost in the player's deck. */
+  deckMaxMana?: number
 }


### PR DESCRIPTION
## Summary

- In daily challenge mode, the engine now computes the highest card cost in the player's seeded deck and stores it as `deckMaxMana` on the game state
- Both `newGame()` (initial mana cap) and `regenerateMana()` (per-tick cap) use `Math.max(BASE_MAX_MANA, deckMaxMana)` as the effective base, so players can always afford their highest-cost card without needing a Farm
- Campaign and quick play are unaffected — `deckMaxMana` is only set when `isDailyChallenge: true` is passed to `newGame()`

## Test plan

- [ ] Start a daily challenge and verify the mana cap shown equals the highest card cost in the dealt hand/deck
- [ ] Confirm Farms still increase mana beyond that floor (additive bonus still applies)
- [ ] Play a campaign battle and confirm max mana behaviour is unchanged (starts at 5, grows only with Farms/relics)
- [ ] Play quick battle and confirm max mana behaviour is unchanged

https://claude.ai/code/session_01XxiLRABUcGa8XTJ2EmHRmy

---
_Generated by [Claude Code](https://claude.ai/code/session_01XxiLRABUcGa8XTJ2EmHRmy)_