### PR TITLE
feat(minigame): fishing (#704)

### DIFF
--- a/todo.md
+++ b/todo.md
@@ -47,7 +47,7 @@ Issues sourced from GitHub. Last synced: 2026-04-22 (session 42).
   - [x] **#712** Core game loop: place units/buildings, collect resources over time
   - [x] **#713** Card leveling: spend city resources to level up cards (max ★5, +1 ATK / +2 HP per level)
   - [x] **#714** UI screen, grid layout (6×4), persistent save state (jarv_city_builder)
-- [ ] **#704** Minigame: fishing — Feature Request | Priority: Low — Add a fishing minigame (accessible from minigames hub). No duplicates.
+- [x] **#704** Minigame: fishing — Feature Request | Priority: Low — Add a fishing minigame (accessible from minigames hub). No duplicates.
 
 ## 🔵 Improvements — New (from GitHub, session 40 sync)
 

--- a/web/src/components/MiniGamesMenu.tsx
+++ b/web/src/components/MiniGamesMenu.tsx
@@ -23,6 +23,7 @@ import { HigherOrLower }  from './minigames/HigherOrLower'
 import { FruitMachine }   from './minigames/FruitMachine'
 import { VideoPoker }     from './minigames/VideoPoker'
 import { CityBuilder }    from './minigames/CityBuilder'
+import { Fishing }        from './minigames/Fishing'
 
 interface Props {
   crystals:          number
@@ -32,7 +33,7 @@ interface Props {
   onBack:            () => void
 }
 
-type SubScreen = 'menu' | MiniGameId | 'prizes' | 'leaderboard' | 'citybuilder'
+type SubScreen = 'menu' | MiniGameId | 'prizes' | 'leaderboard' | 'citybuilder' | 'fishing'
 
 // Pick N random cards from catalog, optionally filtered by rarity
 function pickRandomCards(count: number, rarity?: 'uncommon' | 'rare' | 'legendary'): string[] {
@@ -82,7 +83,7 @@ export function MiniGamesMenu({ crystals, onCrystalsChange, user, characterName,
 
   // ── Game completion handler ───────────────────────────────────────────────────
 
-  const handleGameDone = useCallback((gameId: MiniGameId, ticketsEarned: number, opts?: { perfect?: boolean; jackpot?: boolean }) => {
+  const handleGameDone = useCallback((gameId: MiniGameId, ticketsEarned: number, opts?: { perfect?: boolean; jackpot?: boolean; score?: number }) => {
     if (ticketsEarned > 0) {
       addTickets(ticketsEarned)
       refreshTickets()
@@ -115,6 +116,9 @@ export function MiniGamesMenu({ crystals, onCrystalsChange, user, characterName,
       setAchievementProgress('miniGame:fruitMachine:bestScore', newBest)
     } else if (gameId === 'videoPoker') {
       setAchievementProgress('miniGame:videoPoker:bestScore', newBest)
+    } else if (gameId === 'fishing') {
+      setAchievementProgress('miniGame:fishing:bestScore', newBest)
+      if (opts?.score) setAchievementProgress('miniGame:fishing:bestWeightG', opts.score)
     }
 
     // Publish to leaderboard if signed in
@@ -123,7 +127,7 @@ export function MiniGamesMenu({ crystals, onCrystalsChange, user, characterName,
         uid: user.uid,
         characterName,
         gameId,
-        score: ticketsEarned,
+        score: opts?.score ?? ticketsEarned,
       }).catch(() => { /* offline — ignore */ })
     }
 
@@ -219,6 +223,13 @@ export function MiniGamesMenu({ crystals, onCrystalsChange, user, characterName,
   if (subScreen === 'videoPoker') {
     return <VideoPoker onDone={(t) => handleGameDone('videoPoker', t)} />
   }
+  if (subScreen === 'fishing') {
+    return (
+      <Fishing
+        onDone={(tickets, weightG) => handleGameDone('fishing', tickets, { score: weightG })}
+      />
+    )
+  }
   if (subScreen === 'citybuilder') {
     return <CityBuilder onBack={() => setSubScreen('menu')} />
   }
@@ -241,7 +252,7 @@ export function MiniGamesMenu({ crystals, onCrystalsChange, user, characterName,
         <>
           {/* Game grid */}
           <div className="minigame-grid">
-            {(['marble', 'tileflip', 'crystalcatch', 'spinner', 'marblerace', 'higherOrLower', 'fruitMachine', 'videoPoker'] as MiniGameId[]).map(id => {
+            {(['marble', 'tileflip', 'crystalcatch', 'spinner', 'marblerace', 'higherOrLower', 'fruitMachine', 'videoPoker', 'fishing'] as MiniGameId[]).map(id => {
               const cost    = MINI_GAME_COSTS[id]
               const locked  = currentCrystals < cost
               const best    = loadLocalHighScore(id)
@@ -337,7 +348,7 @@ export function MiniGamesMenu({ crystals, onCrystalsChange, user, characterName,
 
           <div className="lb-controls">
             <div className="lb-game-tabs">
-              {(['marble', 'tileflip', 'crystalcatch', 'spinner', 'marblerace', 'higherOrLower', 'fruitMachine', 'videoPoker'] as MiniGameId[]).map(id => (
+              {(['marble', 'tileflip', 'crystalcatch', 'spinner', 'marblerace', 'higherOrLower', 'fruitMachine', 'videoPoker', 'fishing'] as MiniGameId[]).map(id => (
                 <button
                   key={id}
                   className={`filter-btn${lbGame === id ? ' filter-btn--active' : ''}`}

--- a/web/src/components/minigames/Fishing.tsx
+++ b/web/src/components/minigames/Fishing.tsx
@@ -1,0 +1,350 @@
+// ─── Fishing Minigame ─────────────────────────────────────────────────────────
+// Cast, wait for a bite, reel in. Score = fish weight (grams) published to
+// the leaderboard. 5% chance to snag an item or card instead of a fish.
+
+import React, { useState, useEffect, useRef, useCallback } from 'react'
+import { addCollectible } from '../../game/itemStore'
+import { addCardsToCollection } from '../../game/collection'
+import { getCardCatalog } from '../../game/cards'
+import ITEMS_DATA from '../../data/items.json'
+import { logError } from '../../logger'
+
+const BITE_WINDOW_MS = 1500
+
+// ── Fish data ─────────────────────────────────────────────────────────────────
+
+interface FishTier {
+  tier: string
+  icon: string
+  names: string[]
+  minG: number; maxG: number
+  minCm: number; maxCm: number
+  minT: number; maxT: number
+  chance: number
+}
+
+const FISH_TIERS: FishTier[] = [
+  {
+    tier: 'Tiddler', icon: '🐟',
+    names: ['Minnow', 'Dace', 'Gudgeon', 'Bleak', 'Stickleback'],
+    minG: 100,   maxG: 500,   minCm: 8,   maxCm: 25,  minT: 2,   maxT: 6,   chance: 40,
+  },
+  {
+    tier: 'Small', icon: '🐠',
+    names: ['Roach', 'Rudd', 'Perch', 'Bream', 'Chub'],
+    minG: 500,   maxG: 2000,  minCm: 25,  maxCm: 45,  minT: 8,   maxT: 18,  chance: 30,
+  },
+  {
+    tier: 'Medium', icon: '🐡',
+    names: ['Carp', 'Tench', 'Barbel', 'Zander', 'Catfish'],
+    minG: 2000,  maxG: 5000,  minCm: 45,  maxCm: 70,  minT: 22,  maxT: 40,  chance: 15,
+  },
+  {
+    tier: 'Large', icon: '🦈',
+    names: ['Pike', 'Salmon', 'Sea Bass', 'Wels Catfish', 'Sturgeon'],
+    minG: 5000,  maxG: 12000, minCm: 70,  maxCm: 110, minT: 42,  maxT: 75,  chance: 9,
+  },
+  {
+    tier: 'Trophy', icon: '🏆',
+    names: ['Giant Carp', 'Monster Pike', 'River Titan', 'Trophy Salmon', 'Great Barbel'],
+    minG: 12000, maxG: 25000, minCm: 110, maxCm: 150, minT: 80,  maxT: 130, chance: 5,
+  },
+  {
+    tier: 'Legendary', icon: '✨',
+    names: ['Ancient Sturgeon', 'Dragon Carp', 'Leviathan Eel', 'World Record Bass', 'Fracture Fish'],
+    minG: 25000, maxG: 50000, minCm: 150, maxCm: 200, minT: 150, maxT: 250, chance: 1,
+  },
+]
+
+// ── Catch types ───────────────────────────────────────────────────────────────
+
+interface FishCatch {
+  kind: 'fish'
+  tier: string
+  tierIcon: string
+  name: string
+  weightGrams: number
+  lengthCm: number
+  tickets: number
+}
+
+interface ItemCatch {
+  kind: 'item'
+  id: string
+  name: string
+  icon: string
+  desc: string
+}
+
+interface CardCatch {
+  kind: 'card'
+  name: string
+  rarity: string
+}
+
+type Catch = FishCatch | ItemCatch | CardCatch
+
+type Phase = 'idle' | 'waiting' | 'bite' | 'missed' | 'caught'
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function rand(min: number, max: number) {
+  return Math.floor(min + Math.random() * (max - min))
+}
+
+function rollFish(): FishCatch {
+  const roll = Math.random() * 100
+  let cum = 0
+  let tier = FISH_TIERS[0]
+  for (const t of FISH_TIERS) {
+    cum += t.chance
+    if (roll < cum) { tier = t; break }
+  }
+  return {
+    kind: 'fish',
+    tier: tier.tier,
+    tierIcon: tier.icon,
+    name: tier.names[rand(0, tier.names.length)],
+    weightGrams: rand(tier.minG, tier.maxG),
+    lengthCm: rand(tier.minCm, tier.maxCm),
+    tickets: rand(tier.minT, tier.maxT),
+  }
+}
+
+function formatWeight(g: number): string {
+  return g < 1000 ? `${g}g` : `${(g / 1000).toFixed(1)}kg`
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+interface Props {
+  onDone: (ticketsEarned: number, fishWeightGrams: number) => void
+}
+
+export function Fishing({ onDone }: Props) {
+  const [phase, setPhase]   = useState<Phase>('idle')
+  const [result, setResult] = useState<Catch | null>(null)
+  const [biteMs, setBiteMs] = useState(BITE_WINDOW_MS)
+
+  const waitRef     = useRef<ReturnType<typeof setTimeout>  | null>(null)
+  const biteRef     = useRef<ReturnType<typeof setTimeout>  | null>(null)
+  const countRef    = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  const clearTimers = useCallback(() => {
+    if (waitRef.current)  clearTimeout(waitRef.current)
+    if (biteRef.current)  clearTimeout(biteRef.current)
+    if (countRef.current) clearInterval(countRef.current)
+  }, [])
+
+  useEffect(() => clearTimers, [clearTimers])
+
+  function startCast() {
+    clearTimers()
+    setPhase('waiting')
+    const delay = 2000 + Math.random() * 4000
+    waitRef.current = setTimeout(triggerBite, delay)
+  }
+
+  function triggerBite() {
+    setPhase('bite')
+    setBiteMs(BITE_WINDOW_MS)
+    const start = Date.now()
+    countRef.current = setInterval(() => {
+      setBiteMs(Math.max(0, BITE_WINDOW_MS - (Date.now() - start)))
+    }, 50)
+    biteRef.current = setTimeout(() => {
+      clearTimers()
+      setPhase('missed')
+    }, BITE_WINDOW_MS)
+  }
+
+  function reelIn() {
+    if (phase !== 'bite') return
+    clearTimers()
+    const catch_ = buildCatch()
+    applyReward(catch_)
+    setResult(catch_)
+    setPhase('caught')
+  }
+
+  function buildCatch(): Catch {
+    if (Math.random() >= 0.05) return rollFish()
+    // 5% special
+    if (Math.random() < 0.5) {
+      const item = ITEMS_DATA[rand(0, ITEMS_DATA.length)]
+      return { kind: 'item', id: item.id, name: item.name, icon: item.icon, desc: item.desc }
+    }
+    const catalog = getCardCatalog()
+    if (catalog.length === 0) {
+      const item = ITEMS_DATA[rand(0, ITEMS_DATA.length)]
+      return { kind: 'item', id: item.id, name: item.name, icon: item.icon, desc: item.desc }
+    }
+    const card = catalog[rand(0, catalog.length)]
+    return { kind: 'card', name: card.name, rarity: card.rarity }
+  }
+
+  function applyReward(c: Catch) {
+    if (c.kind === 'item') {
+      try { addCollectible(c.id) }
+      catch (e) { logError('Fishing: addCollectible failed', { error: String(e) }) }
+    } else if (c.kind === 'card') {
+      addCardsToCollection([{ cardName: c.name, count: 1 }])
+    }
+  }
+
+  function catchTickets(): number {
+    if (!result) return 0
+    if (result.kind === 'fish')  return result.tickets
+    if (result.kind === 'card')  return 10
+    return 5
+  }
+
+  function catchWeightG(): number {
+    if (result?.kind === 'fish') return result.weightGrams
+    return 0
+  }
+
+  function done() { onDone(catchTickets(), catchWeightG()) }
+
+  const biteBarPct = Math.round((biteMs / BITE_WINDOW_MS) * 100)
+
+  return (
+    <div className="fishing-screen">
+      <div className="fishing-header">
+        <div className="fishing-title">🎣 FISHING</div>
+      </div>
+
+      {/* Scene */}
+      <div className="fishing-scene">
+        {phase === 'idle' && (
+          <div className="fishing-art">
+            <div>🎣</div>
+            <div className="fishing-water-idle">≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈</div>
+          </div>
+        )}
+
+        {phase === 'waiting' && (
+          <div className="fishing-art">
+            <div className="fishing-rod-line">🎣</div>
+            <div className="fishing-line">│</div>
+            <div className="fishing-line">│</div>
+            <div className="fishing-bobber-wrap">
+              <span className="fishing-bobber">●</span>
+            </div>
+            <div className="fishing-water">≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈</div>
+          </div>
+        )}
+
+        {phase === 'bite' && (
+          <div className="fishing-art">
+            <div className="fishing-rod-line">🎣</div>
+            <div className="fishing-line fishing-line--taut">╲</div>
+            <div className="fishing-line fishing-line--taut">╲</div>
+            <div className="fishing-bobber-wrap">
+              <span className="fishing-bobber fishing-bobber--bite">◉</span>
+            </div>
+            <div className="fishing-water">≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈</div>
+          </div>
+        )}
+
+        {phase === 'missed' && (
+          <div className="fishing-art fishing-art--missed">
+            <div>🎣 💦</div>
+            <div className="fishing-water-idle">≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈</div>
+          </div>
+        )}
+
+        {phase === 'caught' && result && (
+          <div className="fishing-art fishing-art--caught">
+            <div className="fishing-catch-icon">
+              {result.kind === 'fish' ? result.tierIcon : result.kind === 'item' ? result.icon : '🃏'}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Status */}
+      <div className="fishing-status">
+        {phase === 'idle'    && <p className="fishing-prompt">Cast your line and wait for a bite.</p>}
+        {phase === 'waiting' && <p className="fishing-prompt fishing-prompt--waiting">Waiting for a bite…</p>}
+
+        {phase === 'bite' && (
+          <>
+            <p className="fishing-prompt fishing-prompt--bite">🔴 BITE! REEL IN! 🔴</p>
+            <div className="fishing-bite-bar-wrap">
+              <div className="fishing-bite-bar" style={{ width: `${biteBarPct}%` }} />
+            </div>
+          </>
+        )}
+
+        {phase === 'missed' && (
+          <p className="fishing-prompt fishing-prompt--missed">The fish got away… too slow!</p>
+        )}
+
+        {phase === 'caught' && result?.kind === 'fish' && (
+          <div className="fishing-result">
+            <div className="fishing-result-tier">✦ {result.tier} ✦</div>
+            <div className="fishing-result-name">{result.tierIcon} {result.name}</div>
+            <div className="fishing-result-stats">
+              <span>{formatWeight(result.weightGrams)}</span>
+              <span className="fishing-result-sep">·</span>
+              <span>{result.lengthCm}cm</span>
+            </div>
+            <div className="fishing-result-tickets">+{result.tickets} 🎫</div>
+          </div>
+        )}
+
+        {phase === 'caught' && result?.kind === 'item' && (
+          <div className="fishing-result fishing-result--special">
+            <div className="fishing-result-tier">✦ SPECIAL FIND ✦</div>
+            <div className="fishing-result-name">{result.icon} {result.name}</div>
+            <div className="fishing-result-desc">{result.desc}</div>
+            <div className="fishing-result-tickets">+5 🎫  ·  Added to inventory!</div>
+          </div>
+        )}
+
+        {phase === 'caught' && result?.kind === 'card' && (
+          <div className="fishing-result fishing-result--special">
+            <div className="fishing-result-tier">✦ RARE CARD FOUND ✦</div>
+            <div className="fishing-result-name">🃏 {result.name}</div>
+            <div className="fishing-result-desc">{result.rarity}</div>
+            <div className="fishing-result-tickets">+10 🎫  ·  Added to collection!</div>
+          </div>
+        )}
+      </div>
+
+      {/* Controls */}
+      <div className="fishing-controls">
+        {phase === 'idle' && (
+          <button className="action-btn action-btn--gold" onClick={startCast}>
+            🎣 CAST!
+          </button>
+        )}
+
+        {phase === 'waiting' && (
+          <button className="action-btn" disabled>Waiting…</button>
+        )}
+
+        {phase === 'bite' && (
+          <button className="action-btn action-btn--large fishing-reel-btn" onClick={reelIn}>
+            🐟 REEL IN!
+          </button>
+        )}
+
+        {phase === 'missed' && (
+          <div className="fishing-btn-row">
+            <button className="action-btn action-btn--gold" onClick={startCast}>TRY AGAIN</button>
+            <button className="action-btn action-btn--danger" onClick={() => onDone(0, 0)}>GIVE UP</button>
+          </div>
+        )}
+
+        {phase === 'caught' && (
+          <div className="fishing-btn-row">
+            <button className="action-btn action-btn--gold" onClick={startCast}>FISH AGAIN</button>
+            <button className="action-btn" onClick={done}>DONE</button>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/web/src/data/economy.json
+++ b/web/src/data/economy.json
@@ -27,7 +27,8 @@
     "marblerace":     25,
     "higherOrLower":  5,
     "fruitMachine":   50,
-    "videoPoker":     0
+    "videoPoker":     0,
+    "fishing":       15
   },
 
   "ticketPrizes": [

--- a/web/src/game/miniGames.ts
+++ b/web/src/game/miniGames.ts
@@ -20,7 +20,7 @@ export { getTickets as loadTickets, addTickets, spendTickets }
 
 // ── Game Costs ────────────────────────────────────────────────────────────────
 
-export type MiniGameId = 'marble' | 'tileflip' | 'crystalcatch' | 'spinner' | 'marblerace' | 'higherOrLower' | 'fruitMachine' | 'videoPoker'
+export type MiniGameId = 'marble' | 'tileflip' | 'crystalcatch' | 'spinner' | 'marblerace' | 'higherOrLower' | 'fruitMachine' | 'videoPoker' | 'fishing'
 
 export const MINI_GAME_COSTS = _MINI_GAME_COSTS as Record<MiniGameId, number>
 
@@ -33,6 +33,7 @@ export const MINI_GAME_LABELS: Record<MiniGameId, string> = {
   higherOrLower:  'Higher or Lower',
   fruitMachine:   'Fruit Machine',
   videoPoker:     'Video Poker',
+  fishing:        'Fishing',
 }
 
 export const MINI_GAME_DESCRIPTIONS: Record<MiniGameId, string> = {
@@ -44,6 +45,7 @@ export const MINI_GAME_DESCRIPTIONS: Record<MiniGameId, string> = {
   higherOrLower:  'Guess whether each card is higher or lower. Get all 4 right for the jackpot!',
   fruitMachine:   'Spin the reels, hold your lucky symbols, and cash out your winnings!',
   videoPoker:     'Jacks or Better. Hold your best cards, draw, and win big!',
+  fishing:        'Cast your line and reel in a catch. Rare fish earn big tickets — and sometimes treasure!',
 }
 
 export const MINI_GAME_ICONS: Record<MiniGameId, string> = {
@@ -55,6 +57,7 @@ export const MINI_GAME_ICONS: Record<MiniGameId, string> = {
   higherOrLower:  '🎴',
   fruitMachine:   '🎰',
   videoPoker:     '♠',
+  fishing:        '🎣',
 }
 
 // ── Ticket Prizes ─────────────────────────────────────────────────────────────

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -10872,3 +10872,271 @@ html.light-mode .action-btn {
 .reward-summary-row span:last-child {
   color: #aaa;
 }
+
+/* ── Fishing minigame ── */
+
+.fishing-screen {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  padding: 16px 12px;
+  min-height: 100vh;
+  background: #0a0a0a;
+  font-family: monospace;
+  color: #ccc;
+}
+
+.fishing-header {
+  width: 100%;
+  text-align: center;
+}
+
+.fishing-title {
+  font-size: 1.3rem;
+  font-weight: bold;
+  letter-spacing: 3px;
+  color: #7ef;
+  text-transform: uppercase;
+}
+
+.fishing-scene {
+  width: 100%;
+  max-width: 320px;
+  background: #111;
+  border: 1px solid #333;
+  border-radius: 4px;
+  padding: 20px 12px;
+  text-align: center;
+  min-height: 130px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.fishing-art {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  font-size: 1.1rem;
+  line-height: 1.4;
+  color: #aaa;
+}
+
+.fishing-art--missed {
+  color: #888;
+  opacity: 0.7;
+}
+
+.fishing-art--caught {
+  gap: 0;
+}
+
+.fishing-rod-line {
+  font-size: 1.5rem;
+}
+
+.fishing-line {
+  color: #666;
+  font-size: 1rem;
+  line-height: 1;
+}
+
+.fishing-line--taut {
+  color: #aaa;
+  animation: fishing-taut 0.15s ease-in-out infinite alternate;
+}
+
+@keyframes fishing-taut {
+  from { transform: translateX(-1px); }
+  to   { transform: translateX(1px); }
+}
+
+.fishing-bobber-wrap {
+  margin: 2px 0;
+}
+
+.fishing-bobber {
+  font-size: 1rem;
+  color: #e44;
+  display: inline-block;
+  animation: fishing-bob 1.2s ease-in-out infinite;
+}
+
+@keyframes fishing-bob {
+  0%, 100% { transform: translateY(0); }
+  50%       { transform: translateY(4px); }
+}
+
+.fishing-bobber--bite {
+  color: #ff4;
+  animation: fishing-bite-flash 0.25s step-end infinite;
+}
+
+@keyframes fishing-bite-flash {
+  0%, 50% { opacity: 1; }
+  51%, 100% { opacity: 0; }
+}
+
+.fishing-water {
+  color: #46a;
+  font-size: 0.9rem;
+  letter-spacing: 1px;
+  animation: fishing-wave 2s linear infinite;
+}
+
+.fishing-water-idle {
+  color: #46a;
+  font-size: 0.9rem;
+  letter-spacing: 1px;
+}
+
+@keyframes fishing-wave {
+  0%   { letter-spacing: 1px; }
+  50%  { letter-spacing: 2px; }
+  100% { letter-spacing: 1px; }
+}
+
+.fishing-catch-icon {
+  font-size: 3rem;
+  animation: fishing-pop 0.3s ease-out;
+}
+
+@keyframes fishing-pop {
+  0%   { transform: scale(0.3); opacity: 0; }
+  70%  { transform: scale(1.2); }
+  100% { transform: scale(1);   opacity: 1; }
+}
+
+.fishing-status {
+  width: 100%;
+  max-width: 320px;
+  text-align: center;
+  min-height: 80px;
+}
+
+.fishing-prompt {
+  font-size: 0.9rem;
+  color: #888;
+  margin: 0;
+  letter-spacing: 1px;
+}
+
+.fishing-prompt--waiting {
+  color: #57a;
+  animation: fishing-ellipsis 1.5s steps(4, end) infinite;
+}
+
+@keyframes fishing-ellipsis {
+  0%   { opacity: 0.4; }
+  50%  { opacity: 1;   }
+  100% { opacity: 0.4; }
+}
+
+.fishing-prompt--bite {
+  color: #f55;
+  font-size: 1.1rem;
+  font-weight: bold;
+  letter-spacing: 2px;
+  animation: fishing-bite-pulse 0.4s ease-in-out infinite alternate;
+}
+
+@keyframes fishing-bite-pulse {
+  from { color: #f55; }
+  to   { color: #ff0; }
+}
+
+.fishing-prompt--missed {
+  color: #666;
+  font-style: italic;
+}
+
+.fishing-bite-bar-wrap {
+  margin: 8px auto 0;
+  width: 200px;
+  height: 8px;
+  background: #222;
+  border: 1px solid #444;
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.fishing-bite-bar {
+  height: 100%;
+  background: linear-gradient(90deg, #f55, #ff0);
+  transition: width 0.05s linear;
+}
+
+.fishing-result {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+}
+
+.fishing-result--special {
+  color: #fd7;
+}
+
+.fishing-result-tier {
+  font-size: 0.75rem;
+  letter-spacing: 3px;
+  color: #888;
+  text-transform: uppercase;
+}
+
+.fishing-result-name {
+  font-size: 1.3rem;
+  font-weight: bold;
+  color: #eee;
+}
+
+.fishing-result-stats {
+  font-size: 0.85rem;
+  color: #7ef;
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.fishing-result-sep {
+  color: #444;
+}
+
+.fishing-result-desc {
+  font-size: 0.8rem;
+  color: #888;
+  max-width: 260px;
+}
+
+.fishing-result-tickets {
+  font-size: 1rem;
+  color: #7f7;
+  font-weight: bold;
+  margin-top: 4px;
+}
+
+.fishing-controls {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  max-width: 320px;
+}
+
+.fishing-reel-btn {
+  animation: fishing-reel-pulse 0.3s ease-in-out infinite alternate;
+}
+
+@keyframes fishing-reel-pulse {
+  from { transform: scale(1);    box-shadow: 0 0 8px #4f4; }
+  to   { transform: scale(1.04); box-shadow: 0 0 20px #4f4; }
+}
+
+.fishing-btn-row {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+}


### PR DESCRIPTION
## Summary

- Adds a **Fishing** minigame to the Arcade hub (costs 15 💎 per session)
- Cast your line → wait for a random bite (2–6s) → click **REEL IN!** within 1.5s
- 6 fish tiers from Tiddler (100g) to Legendary (50kg), each with random weight, length, and ticket payout
- **5% rare catch** chance: awards a random inventory item or card from the catalog
- Fish weight (grams) is published as the leaderboard score → "best catch of the day" online scoreboard
- Player can fish again for free within the same session; clicking **DONE** submits the current catch

## Test plan

- [ ] Fishing card appears in the Arcade grid with 🎣 icon and 15 💎 cost
- [ ] Costs 15 crystals on start; locked when below that
- [ ] Idle → cast → bobber bobs → bite alert fires → reel-in button works
- [ ] Bite countdown bar depletes; missing the window shows "got away" + TRY AGAIN
- [ ] Caught fish shows correct tier name, weight, length, ticket reward
- [ ] Rare catch (5%) adds item to inventory or card to collection
- [ ] FISH AGAIN resets to waiting state; DONE calls onDone and returns to menu
- [ ] Fishing appears in the Leaderboards tab; score shows fish weight in grams

https://claude.ai/code/session_016cctwZVQTtCkVoJc1Fco1u

---
_Generated by [Claude Code](https://claude.ai/code/session_016cctwZVQTtCkVoJc1Fco1u)_