### PR TITLE
Add missing card SVGs — Batches 6/17 & 9/17 (Units F + Buildings C)

### DIFF
--- a/web/public/sprites/gear-assembly.svg
+++ b/web/public/sprites/gear-assembly.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground -->
+  <ellipse cx="16" cy="30" rx="13" ry="2" fill="#2a2a1a"/>
+  <!-- Factory body -->
+  <rect x="4" y="16" width="24" height="14" rx="1" fill="#5a5244"/>
+  <rect x="4" y="16" width="24" height="3" fill="#6a6254"/>
+  <!-- Roof / flat top -->
+  <rect x="6" y="13" width="20" height="4" fill="#4a4438"/>
+  <!-- Chimney stacks -->
+  <rect x="7" y="6" width="4" height="9" rx="1" fill="#3a3830"/>
+  <rect x="21" y="8" width="4" height="7" rx="1" fill="#3a3830"/>
+  <!-- Steam puffs -->
+  <circle cx="9" cy="5" r="2" fill="#aaaaaa" opacity="0.5"/>
+  <circle cx="11" cy="3" r="1.5" fill="#cccccc" opacity="0.35"/>
+  <circle cx="23" cy="7" r="1.8" fill="#aaaaaa" opacity="0.45"/>
+  <!-- Large central gear -->
+  <circle cx="16" cy="21" r="5" fill="#888" stroke="#555" stroke-width="1"/>
+  <circle cx="16" cy="21" r="3" fill="#5a5244"/>
+  <circle cx="16" cy="21" r="1.5" fill="#333"/>
+  <!-- Gear teeth -->
+  <rect x="14.5" y="15.5" width="3" height="2" fill="#888"/>
+  <rect x="14.5" y="24.5" width="3" height="2" fill="#888"/>
+  <rect x="10.5" y="19.5" width="2" height="3" fill="#888"/>
+  <rect x="19.5" y="19.5" width="2" height="3" fill="#888"/>
+  <!-- Small side gear -->
+  <circle cx="27" cy="18" r="3" fill="#777" stroke="#444" stroke-width="0.8"/>
+  <circle cx="27" cy="18" r="1.5" fill="#4a4438"/>
+  <rect x="25.8" y="14.5" width="2.4" height="1.5" fill="#777"/>
+  <rect x="25.8" y="20" width="2.4" height="1.5" fill="#777"/>
+  <rect x="23.5" y="16.8" width="1.5" height="2.4" fill="#777"/>
+</svg>

--- a/web/public/sprites/gear-wall.svg
+++ b/web/public/sprites/gear-wall.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Wall body -->
+  <rect x="0" y="8" width="32" height="20" fill="#5a5244"/>
+  <!-- Battlements -->
+  <rect x="0" y="2" width="6" height="7" fill="#5a5244"/>
+  <rect x="8" y="2" width="6" height="7" fill="#5a5244"/>
+  <rect x="18" y="2" width="6" height="7" fill="#5a5244"/>
+  <rect x="26" y="2" width="6" height="7" fill="#5a5244"/>
+  <!-- Horizontal band -->
+  <rect x="0" y="10" width="32" height="2" fill="#4a4438"/>
+  <rect x="0" y="20" width="32" height="2" fill="#4a4438"/>
+  <!-- Central gear mechanism -->
+  <circle cx="16" cy="19" r="6" fill="#777" stroke="#444" stroke-width="1"/>
+  <circle cx="16" cy="19" r="4" fill="#5a5244"/>
+  <circle cx="16" cy="19" r="2" fill="#333"/>
+  <!-- Gear teeth -->
+  <rect x="14.5" y="12.5" width="3" height="2" fill="#777"/>
+  <rect x="14.5" y="24.5" width="3" height="2" fill="#777"/>
+  <rect x="9.5" y="17.5" width="2" height="3" fill="#777"/>
+  <rect x="20.5" y="17.5" width="2" height="3" fill="#777"/>
+  <rect x="10.8" y="13.8" width="2" height="2" fill="#777" transform="rotate(45,11.8,14.8)"/>
+  <rect x="19.2" y="13.8" width="2" height="2" fill="#777" transform="rotate(-45,20.2,14.8)"/>
+  <rect x="10.8" y="21.2" width="2" height="2" fill="#777" transform="rotate(-45,11.8,22.2)"/>
+  <rect x="19.2" y="21.2" width="2" height="2" fill="#777" transform="rotate(45,20.2,22.2)"/>
+  <!-- Rivets -->
+  <circle cx="3" cy="15" r="1" fill="#888"/>
+  <circle cx="29" cy="15" r="1" fill="#888"/>
+  <circle cx="3" cy="24" r="1" fill="#888"/>
+  <circle cx="29" cy="24" r="1" fill="#888"/>
+</svg>

--- a/web/public/sprites/gust-wall.svg
+++ b/web/public/sprites/gust-wall.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Wall body -->
+  <rect x="0" y="10" width="32" height="18" fill="#8ab4cc"/>
+  <!-- Battlements -->
+  <rect x="0" y="4" width="6" height="7" fill="#8ab4cc"/>
+  <rect x="8" y="4" width="6" height="7" fill="#8ab4cc"/>
+  <rect x="18" y="4" width="6" height="7" fill="#8ab4cc"/>
+  <rect x="26" y="4" width="6" height="7" fill="#8ab4cc"/>
+  <!-- Highlight band -->
+  <rect x="0" y="12" width="32" height="2" fill="#aaccdd" opacity="0.6"/>
+  <!-- Wind vent slits -->
+  <rect x="3" y="16" width="6" height="3" rx="1.5" fill="#334455" opacity="0.6"/>
+  <rect x="13" y="16" width="6" height="3" rx="1.5" fill="#334455" opacity="0.6"/>
+  <rect x="23" y="16" width="6" height="3" rx="1.5" fill="#334455" opacity="0.6"/>
+  <!-- Wind swirl emanating from vents -->
+  <path d="M6,14 Q9,12 10,14 Q8,16 6,14" fill="none" stroke="#eef8ff" stroke-width="1" opacity="0.8"/>
+  <path d="M16,14 Q19,12 20,14 Q18,16 16,14" fill="none" stroke="#eef8ff" stroke-width="1" opacity="0.8"/>
+  <path d="M26,14 Q29,12 30,14 Q28,16 26,14" fill="none" stroke="#eef8ff" stroke-width="1" opacity="0.8"/>
+  <!-- Wind streaks above wall -->
+  <path d="M2,8 Q8,6 12,8" stroke="#c8e8ff" stroke-width="1" fill="none" opacity="0.7"/>
+  <path d="M14,6 Q20,4 26,6" stroke="#c8e8ff" stroke-width="1" fill="none" opacity="0.6"/>
+  <path d="M4,3 Q10,1 16,3" stroke="#c8e8ff" stroke-width="0.8" fill="none" opacity="0.5"/>
+  <!-- Base shadow -->
+  <rect x="0" y="26" width="32" height="2" fill="#668899" opacity="0.4"/>
+</svg>

--- a/web/public/sprites/healer-s-hut.svg
+++ b/web/public/sprites/healer-s-hut.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground -->
+  <ellipse cx="16" cy="30" rx="12" ry="2" fill="#3a2a1a"/>
+  <!-- Hut walls -->
+  <rect x="5" y="18" width="22" height="12" rx="1" fill="#8a6a3a"/>
+  <rect x="5" y="18" width="22" height="3" fill="#9a7a4a"/>
+  <!-- Thatched roof -->
+  <polygon points="3,19 16,6 29,19" fill="#6a5a20"/>
+  <polygon points="5,19 16,8 27,19" fill="#8a7230"/>
+  <polygon points="7,19 16,10 25,19" fill="#9a8040"/>
+  <!-- Door -->
+  <rect x="13" y="23" width="6" height="7" rx="1" fill="#5a3a1a"/>
+  <rect x="13.5" y="23.5" width="5" height="6" fill="#6a4a2a"/>
+  <!-- Windows with green cross (healer symbol) -->
+  <rect x="7" y="20" width="5" height="5" rx="0.5" fill="#c8e8c0"/>
+  <rect x="9" y="19.5" width="1" height="6" fill="#22aa44"/>
+  <rect x="7" y="22" width="5" height="1" fill="#22aa44"/>
+  <rect x="20" y="20" width="5" height="5" rx="0.5" fill="#c8e8c0"/>
+  <rect x="22" y="19.5" width="1" height="6" fill="#22aa44"/>
+  <rect x="20" y="22" width="5" height="1" fill="#22aa44"/>
+  <!-- Healing aura particles -->
+  <circle cx="8" cy="14" r="1" fill="#44ee66" opacity="0.7"/>
+  <circle cx="24" cy="12" r="0.8" fill="#66ff88" opacity="0.6"/>
+  <circle cx="16" cy="3" r="1.2" fill="#22cc44" opacity="0.5"/>
+  <circle cx="11" cy="5" r="0.7" fill="#44ee66" opacity="0.4"/>
+  <circle cx="21" cy="7" r="0.8" fill="#66ff88" opacity="0.4"/>
+</svg>

--- a/web/public/sprites/living-thornwall.svg
+++ b/web/public/sprites/living-thornwall.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Wall core — tangled dark wood -->
+  <rect x="0" y="12" width="32" height="16" fill="#2d4a1a"/>
+  <!-- Bark texture bands -->
+  <rect x="0" y="14" width="32" height="2" fill="#1a2f0a" opacity="0.6"/>
+  <rect x="0" y="20" width="32" height="2" fill="#1a2f0a" opacity="0.6"/>
+  <!-- Top vine mass -->
+  <path d="M0,12 Q5,6 10,12 Q15,6 20,12 Q25,6 32,12" fill="#2d4a1a" stroke="#1a3010" stroke-width="1"/>
+  <!-- Thorns on top -->
+  <polygon points="4,11 6,4 8,11" fill="#1a2f0a"/>
+  <polygon points="10,10 12,3 14,10" fill="#1a2f0a"/>
+  <polygon points="18,11 20,4 22,11" fill="#1a2f0a"/>
+  <polygon points="25,10 27,3 29,10" fill="#1a2f0a"/>
+  <!-- Side thorns -->
+  <polygon points="0,16 -2,13 0,20" fill="#1a2f0a"/>
+  <polygon points="32,16 34,13 32,20" fill="#1a2f0a"/>
+  <!-- Green leaves -->
+  <ellipse cx="7" cy="8" rx="3" ry="2" fill="#4aaa22" transform="rotate(-20,7,8)"/>
+  <ellipse cx="16" cy="7" rx="3" ry="2" fill="#4aaa22" transform="rotate(10,16,7)"/>
+  <ellipse cx="25" cy="9" rx="3" ry="2" fill="#4aaa22" transform="rotate(-15,25,9)"/>
+  <!-- Glowing sap nodes -->
+  <circle cx="10" cy="18" r="1.2" fill="#88ff44" opacity="0.6"/>
+  <circle cx="22" cy="20" r="1" fill="#aaff66" opacity="0.5"/>
+  <!-- Ground roots -->
+  <path d="M5,28 Q3,32 6,32" stroke="#2d4a1a" stroke-width="2" fill="none"/>
+  <path d="M16,28 Q14,32 18,32" stroke="#2d4a1a" stroke-width="2" fill="none"/>
+  <path d="M27,28 Q29,32 26,32" stroke="#2d4a1a" stroke-width="2" fill="none"/>
+</svg>

--- a/web/public/sprites/pressure-valve.svg
+++ b/web/public/sprites/pressure-valve.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground -->
+  <ellipse cx="16" cy="30" rx="12" ry="2" fill="#2a2a1a"/>
+  <!-- Main boiler tank -->
+  <ellipse cx="16" cy="22" rx="11" ry="7" fill="#7a6a44"/>
+  <ellipse cx="16" cy="20" rx="9" ry="5" fill="#8a7a54" opacity="0.5"/>
+  <!-- Rivets around tank -->
+  <circle cx="5" cy="22" r="0.8" fill="#999"/>
+  <circle cx="27" cy="22" r="0.8" fill="#999"/>
+  <circle cx="10" cy="16" r="0.8" fill="#999"/>
+  <circle cx="22" cy="16" r="0.8" fill="#999"/>
+  <circle cx="10" cy="28" r="0.8" fill="#999"/>
+  <circle cx="22" cy="28" r="0.8" fill="#999"/>
+  <!-- Central pressure gauge -->
+  <circle cx="16" cy="22" r="4" fill="#444" stroke="#888" stroke-width="0.8"/>
+  <circle cx="16" cy="22" r="3" fill="#222"/>
+  <line x1="16" y1="22" x2="18" y2="20" stroke="#ff4444" stroke-width="1"/>
+  <!-- Pipe up -->
+  <rect x="14" y="6" width="4" height="11" fill="#666"/>
+  <rect x="13" y="4" width="6" height="4" rx="1" fill="#555"/>
+  <!-- Valve wheel -->
+  <circle cx="16" cy="8" r="4" fill="none" stroke="#888" stroke-width="1.5"/>
+  <line x1="12" y1="8" x2="20" y2="8" stroke="#888" stroke-width="1.5"/>
+  <line x1="16" y1="4" x2="16" y2="12" stroke="#888" stroke-width="1.5"/>
+  <circle cx="16" cy="8" r="1.5" fill="#666"/>
+  <!-- Steam jet -->
+  <path d="M13,4 Q10,2 12,0" stroke="#dddddd" stroke-width="1.5" fill="none" opacity="0.7"/>
+  <path d="M16,3 Q15,1 17,0" stroke="#cccccc" stroke-width="1.2" fill="none" opacity="0.5"/>
+  <!-- Side pipe -->
+  <rect x="27" y="20" width="5" height="3" rx="1" fill="#666"/>
+  <circle cx="29" cy="21.5" r="1.2" fill="#888" opacity="0.6"/>
+</svg>

--- a/web/public/sprites/salvage-dock.svg
+++ b/web/public/sprites/salvage-dock.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Water -->
+  <rect x="0" y="24" width="32" height="8" fill="#1a5577"/>
+  <path d="M0,25 Q4,23 8,25 Q12,27 16,25 Q20,23 24,25 Q28,27 32,25" fill="none" stroke="#44aacc" stroke-width="1" opacity="0.7"/>
+  <!-- Dock platform -->
+  <rect x="2" y="18" width="28" height="7" fill="#7a5a2a"/>
+  <!-- Plank lines -->
+  <line x1="8" y1="18" x2="8" y2="25" stroke="#5a3a1a" stroke-width="0.8"/>
+  <line x1="14" y1="18" x2="14" y2="25" stroke="#5a3a1a" stroke-width="0.8"/>
+  <line x1="20" y1="18" x2="20" y2="25" stroke="#5a3a1a" stroke-width="0.8"/>
+  <line x1="26" y1="18" x2="26" y2="25" stroke="#5a3a1a" stroke-width="0.8"/>
+  <!-- Support posts in water -->
+  <rect x="4" y="22" width="2" height="8" fill="#6a4a1a"/>
+  <rect x="14" y="22" width="2" height="8" fill="#6a4a1a"/>
+  <rect x="26" y="22" width="2" height="8" fill="#6a4a1a"/>
+  <!-- Warehouse/shed on dock -->
+  <rect x="6" y="8" width="20" height="11" rx="1" fill="#8a6a3a"/>
+  <polygon points="4,9 16,2 28,9" fill="#6a4a1a"/>
+  <!-- Window -->
+  <rect x="10" y="11" width="5" height="5" rx="0.5" fill="#aaddee"/>
+  <line x1="12.5" y1="11" x2="12.5" y2="16" stroke="#334455" stroke-width="0.8"/>
+  <line x1="10" y1="13.5" x2="15" y2="13.5" stroke="#334455" stroke-width="0.8"/>
+  <!-- Door -->
+  <rect x="17" y="13" width="5" height="6" rx="0.5" fill="#5a3a1a"/>
+  <!-- Salvage crate on dock -->
+  <rect x="22" y="14" width="4" height="4" fill="#aa8855" stroke="#775533" stroke-width="0.7"/>
+  <line x1="22" y1="16" x2="26" y2="16" stroke="#775533" stroke-width="0.6"/>
+  <line x1="24" y1="14" x2="24" y2="18" stroke="#775533" stroke-width="0.6"/>
+  <!-- Mooring post -->
+  <rect x="0" y="16" width="2" height="6" rx="0.5" fill="#5a3a1a"/>
+  <circle cx="1" cy="16" r="1.2" fill="#7a5a2a"/>
+</svg>

--- a/web/public/sprites/shadow-academy.svg
+++ b/web/public/sprites/shadow-academy.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground -->
+  <ellipse cx="16" cy="30" rx="14" ry="2.5" fill="#2a1a3a"/>
+  <!-- Main dark building -->
+  <rect x="5" y="14" width="22" height="18" rx="1" fill="#1a1130"/>
+  <rect x="5" y="14" width="22" height="3" fill="#22193a"/>
+  <!-- Elegant pointed roof -->
+  <polygon points="4,14 16,2 28,14" fill="#110d22"/>
+  <polygon points="6,14 16,4 26,14" fill="#191530"/>
+  <!-- Side spires -->
+  <polygon points="4,16 6,10 8,16" fill="#110d22"/>
+  <polygon points="24,16 26,10 28,16" fill="#110d22"/>
+  <!-- Crescent moon at peak -->
+  <path d="M18,4 Q13,4 13,8 Q13,10 16,10 Q12,10 12,6 Q12,2 16,2 Q17,2 18,4Z" fill="#9933cc" opacity="0.9"/>
+  <!-- Tall narrow windows with purple glow -->
+  <rect x="9" y="17" width="4" height="9" rx="2" fill="#110d22"/>
+  <rect x="9.5" y="17" width="3" height="8" rx="1.5" fill="#6611aa" opacity="0.7"/>
+  <rect x="19" y="17" width="4" height="9" rx="2" fill="#110d22"/>
+  <rect x="19.5" y="17" width="3" height="8" rx="1.5" fill="#6611aa" opacity="0.7"/>
+  <!-- Rune inscriptions -->
+  <line x1="14" y1="28" x2="18" y2="28" stroke="#9933cc" stroke-width="0.8" opacity="0.8"/>
+  <line x1="16" y1="26" x2="16" y2="30" stroke="#9933cc" stroke-width="0.8" opacity="0.8"/>
+  <circle cx="16" cy="28" r="1" fill="none" stroke="#9933cc" stroke-width="0.8" opacity="0.8"/>
+  <!-- Door -->
+  <rect x="13" y="26" width="6" height="6" rx="1" fill="#0a0818"/>
+  <rect x="14" y="26.5" width="4" height="5" rx="0.8" fill="#110d22"/>
+  <!-- Stars/magic particles -->
+  <circle cx="3" cy="10" r="0.8" fill="#9933cc" opacity="0.7"/>
+  <circle cx="29" cy="8" r="0.8" fill="#bb44ee" opacity="0.7"/>
+  <circle cx="6" cy="22" r="0.6" fill="#9933cc" opacity="0.5"/>
+  <circle cx="26" cy="19" r="0.6" fill="#bb44ee" opacity="0.5"/>
+</svg>

--- a/web/public/sprites/sky-beacon.svg
+++ b/web/public/sprites/sky-beacon.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground base -->
+  <ellipse cx="16" cy="30" rx="10" ry="2" fill="#4a4a5a"/>
+  <!-- Tower base -->
+  <polygon points="8,30 10,10 22,10 24,30" fill="#6a7a8a"/>
+  <!-- Tower highlight -->
+  <polygon points="10,30 11,10 14,10 13,30" fill="#8a9aaa" opacity="0.4"/>
+  <!-- Battlement top -->
+  <rect x="8" y="7" width="4" height="4" fill="#6a7a8a"/>
+  <rect x="14" y="5" width="4" height="6" fill="#6a7a8a"/>
+  <rect x="20" y="7" width="4" height="4" fill="#6a7a8a"/>
+  <rect x="9" y="9" width="14" height="2" fill="#5a6a7a"/>
+  <!-- Beacon light housing -->
+  <circle cx="16" cy="7" r="5" fill="#334455" stroke="#556677" stroke-width="0.8"/>
+  <!-- Beacon light — bright glow -->
+  <circle cx="16" cy="7" r="3.5" fill="#ffdd44" opacity="0.9"/>
+  <circle cx="16" cy="7" r="2" fill="#ffffff"/>
+  <!-- Light rays -->
+  <line x1="16" y1="7" x2="2" y2="1" stroke="#ffdd44" stroke-width="1" opacity="0.5"/>
+  <line x1="16" y1="7" x2="0" y2="10" stroke="#ffee88" stroke-width="0.8" opacity="0.4"/>
+  <line x1="16" y1="7" x2="30" y2="1" stroke="#ffdd44" stroke-width="1" opacity="0.5"/>
+  <line x1="16" y1="7" x2="32" y2="10" stroke="#ffee88" stroke-width="0.8" opacity="0.4"/>
+  <line x1="16" y1="7" x2="16" y2="0" stroke="#ffdd44" stroke-width="1" opacity="0.4"/>
+  <!-- Tower windows -->
+  <rect x="14" y="16" width="4" height="5" rx="2" fill="#aabbcc" opacity="0.6"/>
+  <rect x="14" y="23" width="4" height="4" rx="1" fill="#334455"/>
+  <!-- Stone texture -->
+  <line x1="8" y1="20" x2="24" y2="20" stroke="#556677" stroke-width="0.5" opacity="0.4"/>
+  <line x1="9" y1="25" x2="23" y2="25" stroke="#556677" stroke-width="0.5" opacity="0.4"/>
+</svg>

--- a/web/public/sprites/stone-wall.svg
+++ b/web/public/sprites/stone-wall.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Stone wall — heavy grey stonework with battlements -->
+  <!-- Battlements -->
+  <rect x="0" y="0" width="6" height="10" rx="0.5" fill="#7a7a7a" stroke="#555" stroke-width="0.6"/>
+  <rect x="8" y="0" width="6" height="10" rx="0.5" fill="#7a7a7a" stroke="#555" stroke-width="0.6"/>
+  <rect x="16" y="0" width="6" height="10" rx="0.5" fill="#7a7a7a" stroke="#555" stroke-width="0.6"/>
+  <rect x="24" y="0" width="8" height="10" rx="0.5" fill="#7a7a7a" stroke="#555" stroke-width="0.6"/>
+  <!-- Main wall body -->
+  <rect x="0" y="9" width="32" height="23" fill="#888"/>
+  <!-- Row 1 stones -->
+  <rect x="0" y="10" width="13" height="6" rx="0.5" fill="#8a8a8a" stroke="#666" stroke-width="0.5"/>
+  <rect x="15" y="10" width="17" height="6" rx="0.5" fill="#888" stroke="#666" stroke-width="0.5"/>
+  <!-- Row 2 stones (offset) -->
+  <rect x="0" y="18" width="8" height="6" rx="0.5" fill="#999" stroke="#666" stroke-width="0.5"/>
+  <rect x="10" y="18" width="12" height="6" rx="0.5" fill="#878787" stroke="#666" stroke-width="0.5"/>
+  <rect x="24" y="18" width="8" height="6" rx="0.5" fill="#999" stroke="#666" stroke-width="0.5"/>
+  <!-- Row 3 stones -->
+  <rect x="0" y="26" width="15" height="6" rx="0.5" fill="#8a8a8a" stroke="#666" stroke-width="0.5"/>
+  <rect x="17" y="26" width="15" height="6" rx="0.5" fill="#888" stroke="#666" stroke-width="0.5"/>
+  <!-- Mortar lines -->
+  <line x1="0" y1="9" x2="32" y2="9" stroke="#555" stroke-width="1.2"/>
+  <line x1="0" y1="17" x2="32" y2="17" stroke="#555" stroke-width="1.2"/>
+  <line x1="0" y1="25" x2="32" y2="25" stroke="#555" stroke-width="1.2"/>
+  <line x1="14" y1="9" x2="14" y2="17" stroke="#555" stroke-width="1.2"/>
+  <line x1="9" y1="17" x2="9" y2="25" stroke="#555" stroke-width="1.2"/>
+  <line x1="23" y1="17" x2="23" y2="25" stroke="#555" stroke-width="1.2"/>
+  <line x1="16" y1="25" x2="16" y2="32" stroke="#555" stroke-width="1.2"/>
+</svg>

--- a/web/public/sprites/tidal-sovereign-1.svg
+++ b/web/public/sprites/tidal-sovereign-1.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Tidal Sovereign — frame 1 (hover tilt left, body 1px lower) -->
+  <!-- Robe body shifted down 1px -->
+  <polygon points="10,29 22,29 20,15 12,15" fill="#1a4a8a"/>
+  <polygon points="11,29 21,29 19,17 13,17" fill="#3366bb" opacity="0.5"/>
+  <path d="M12,15 Q8,21 9,29" fill="#1a4a8a" stroke="#3366bb" stroke-width="0.5"/>
+  <rect x="13" y="11" width="6" height="5" rx="1" fill="#1a4a8a"/>
+  <!-- Head slightly lower -->
+  <ellipse cx="16" cy="9" rx="4" ry="4" fill="#ffccaa"/>
+  <polygon points="12,6 13,3 15,5 16,2 17,5 19,3 20,6 12,6" fill="#ddaa22"/>
+  <rect x="12" y="6" width="8" height="1.5" fill="#ddaa22"/>
+  <circle cx="14.5" cy="9" r="0.7" fill="#002244"/>
+  <circle cx="17.5" cy="9" r="0.7" fill="#002244"/>
+  <!-- Trident tilted left slightly -->
+  <line x1="21" y1="7" x2="20" y2="27" stroke="#44aadd" stroke-width="1.2"/>
+  <path d="M19,7 L21,5 L23,7" fill="none" stroke="#44aadd" stroke-width="1"/>
+  <line x1="21" y1="5" x2="21" y2="8" stroke="#44aadd" stroke-width="1"/>
+  <line x1="10" y1="29" x2="22" y2="29" stroke="#ddaa22" stroke-width="1"/>
+  <line x1="13" y1="15" x2="19" y2="15" stroke="#ddaa22" stroke-width="0.8"/>
+  <ellipse cx="13" cy="29" rx="2" ry="1" fill="#1a3a6a"/>
+  <ellipse cx="19" cy="29" rx="2" ry="1" fill="#1a3a6a"/>
+</svg>

--- a/web/public/sprites/tidal-sovereign-2.svg
+++ b/web/public/sprites/tidal-sovereign-2.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Tidal Sovereign — frame 2 (hover mid, normal height) -->
+  <!-- Robe body at normal height -->
+  <polygon points="10,28 22,28 20,14 12,14" fill="#1a4a8a"/>
+  <polygon points="11,28 21,28 19,16 13,16" fill="#3366bb" opacity="0.5"/>
+  <path d="M12,14 Q8,20 9,28" fill="#1a4a8a" stroke="#3366bb" stroke-width="0.5"/>
+  <rect x="13" y="10" width="6" height="5" rx="1" fill="#1a4a8a"/>
+  <ellipse cx="16" cy="8" rx="4" ry="4" fill="#ffccaa"/>
+  <polygon points="12,5 13,2 15,4 16,1 17,4 19,2 20,5 12,5" fill="#ddaa22"/>
+  <rect x="12" y="5" width="8" height="1.5" fill="#ddaa22"/>
+  <circle cx="14.5" cy="8" r="0.7" fill="#002244"/>
+  <circle cx="17.5" cy="8" r="0.7" fill="#002244"/>
+  <!-- Trident straight -->
+  <line x1="21" y1="6" x2="21" y2="26" stroke="#44aadd" stroke-width="1.2"/>
+  <path d="M19,6 L21,4 L23,6" fill="none" stroke="#44aadd" stroke-width="1"/>
+  <line x1="21" y1="4" x2="21" y2="7" stroke="#44aadd" stroke-width="1"/>
+  <line x1="10" y1="28" x2="22" y2="28" stroke="#ddaa22" stroke-width="1"/>
+  <line x1="13" y1="14" x2="19" y2="14" stroke="#ddaa22" stroke-width="0.8"/>
+  <!-- Feet centered (mid-hover) -->
+  <ellipse cx="14" cy="28" rx="2" ry="1" fill="#1a3a6a"/>
+  <ellipse cx="18" cy="28" rx="2" ry="1" fill="#1a3a6a"/>
+</svg>

--- a/web/public/sprites/tidal-sovereign-3.svg
+++ b/web/public/sprites/tidal-sovereign-3.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Tidal Sovereign — frame 3 (hover tilt right, body 1px lower, mirror of frame 1) -->
+  <!-- Robe body shifted down 1px -->
+  <polygon points="10,29 22,29 20,15 12,15" fill="#1a4a8a"/>
+  <polygon points="11,29 21,29 19,17 13,17" fill="#3366bb" opacity="0.5"/>
+  <path d="M20,15 Q24,21 23,29" fill="#1a4a8a" stroke="#3366bb" stroke-width="0.5"/>
+  <rect x="13" y="11" width="6" height="5" rx="1" fill="#1a4a8a"/>
+  <!-- Head slightly lower -->
+  <ellipse cx="16" cy="9" rx="4" ry="4" fill="#ffccaa"/>
+  <polygon points="12,6 13,3 15,5 16,2 17,5 19,3 20,6 12,6" fill="#ddaa22"/>
+  <rect x="12" y="6" width="8" height="1.5" fill="#ddaa22"/>
+  <circle cx="14.5" cy="9" r="0.7" fill="#002244"/>
+  <circle cx="17.5" cy="9" r="0.7" fill="#002244"/>
+  <!-- Trident tilted right slightly -->
+  <line x1="21" y1="7" x2="22" y2="27" stroke="#44aadd" stroke-width="1.2"/>
+  <path d="M19,7 L21,5 L23,7" fill="none" stroke="#44aadd" stroke-width="1"/>
+  <line x1="21" y1="5" x2="21" y2="8" stroke="#44aadd" stroke-width="1"/>
+  <line x1="10" y1="29" x2="22" y2="29" stroke="#ddaa22" stroke-width="1"/>
+  <line x1="13" y1="15" x2="19" y2="15" stroke="#ddaa22" stroke-width="0.8"/>
+  <ellipse cx="13" cy="29" rx="2" ry="1" fill="#1a3a6a"/>
+  <ellipse cx="19" cy="29" rx="2" ry="1" fill="#1a3a6a"/>
+</svg>

--- a/web/public/sprites/tidal-sovereign.svg
+++ b/web/public/sprites/tidal-sovereign.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Tidal Sovereign — idle (regal water ruler) -->
+  <!-- Robe body -->
+  <polygon points="10,28 22,28 20,14 12,14" fill="#1a4a8a"/>
+  <polygon points="11,28 21,28 19,16 13,16" fill="#3366bb" opacity="0.5"/>
+  <!-- Cape -->
+  <path d="M12,14 Q8,20 9,28" fill="#1a4a8a" stroke="#3366bb" stroke-width="0.5"/>
+  <!-- Torso/neck -->
+  <rect x="13" y="10" width="6" height="5" rx="1" fill="#1a4a8a"/>
+  <!-- Head -->
+  <ellipse cx="16" cy="8" rx="4" ry="4" fill="#ffccaa"/>
+  <!-- Crown -->
+  <polygon points="12,5 13,2 15,4 16,1 17,4 19,2 20,5 12,5" fill="#ddaa22"/>
+  <rect x="12" y="5" width="8" height="1.5" fill="#ddaa22"/>
+  <!-- Eyes -->
+  <circle cx="14.5" cy="8" r="0.7" fill="#002244"/>
+  <circle cx="17.5" cy="8" r="0.7" fill="#002244"/>
+  <!-- Trident (right hand) -->
+  <line x1="21" y1="6" x2="21" y2="26" stroke="#44aadd" stroke-width="1.2"/>
+  <path d="M19,6 L21,4 L23,6" fill="none" stroke="#44aadd" stroke-width="1"/>
+  <line x1="21" y1="4" x2="21" y2="7" stroke="#44aadd" stroke-width="1"/>
+  <!-- Gold trim on robe -->
+  <line x1="10" y1="28" x2="22" y2="28" stroke="#ddaa22" stroke-width="1"/>
+  <line x1="13" y1="14" x2="19" y2="14" stroke="#ddaa22" stroke-width="0.8"/>
+  <!-- Feet -->
+  <ellipse cx="13" cy="28" rx="2" ry="1" fill="#1a3a6a"/>
+  <ellipse cx="19" cy="28" rx="2" ry="1" fill="#1a3a6a"/>
+</svg>

--- a/web/public/sprites/tide-runner-1.svg
+++ b/web/public/sprites/tide-runner-1.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Tide Runner — frame 1 (stride A: body down 1, left leg forward, right leg back) -->
+  <!-- Torso shifted down 1px -->
+  <rect x="12" y="12" width="8" height="9" rx="2" fill="#00aacc"/>
+  <!-- Head down 1px -->
+  <ellipse cx="16" cy="9" rx="4" ry="4" fill="#00aacc"/>
+  <circle cx="14.5" cy="8.5" r="1" fill="#002244"/>
+  <circle cx="17.5" cy="8.5" r="1" fill="#002244"/>
+  <circle cx="14.8" cy="8.2" r="0.4" fill="#44ccee"/>
+  <path d="M20,13 Q24,10 22,16" fill="#006688"/>
+  <ellipse cx="16" cy="16" rx="3" ry="2" fill="#44ccee" opacity="0.35"/>
+  <!-- Left leg forward (2px forward = shifted left) -->
+  <rect x="10" y="21" width="3" height="6" rx="1" fill="#006688"/>
+  <!-- Right leg back (shifted right) -->
+  <rect x="18" y="21" width="3" height="5" rx="1" fill="#006688"/>
+  <!-- Webbed feet -->
+  <ellipse cx="11.5" cy="27" rx="2.5" ry="1.2" fill="#006688"/>
+  <ellipse cx="19.5" cy="26" rx="2.5" ry="1.2" fill="#006688"/>
+  <!-- Arms swinging -->
+  <line x1="12" y1="14" x2="7" y2="16" stroke="#00aacc" stroke-width="2.5" stroke-linecap="round"/>
+  <line x1="20" y1="14" x2="25" y2="18" stroke="#00aacc" stroke-width="2.5" stroke-linecap="round"/>
+</svg>

--- a/web/public/sprites/tide-runner-2.svg
+++ b/web/public/sprites/tide-runner-2.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Tide Runner — frame 2 (mid-stride: normal height, legs together) -->
+  <!-- Torso at normal height -->
+  <rect x="12" y="11" width="8" height="9" rx="2" fill="#00aacc"/>
+  <ellipse cx="16" cy="8" rx="4" ry="4" fill="#00aacc"/>
+  <circle cx="14.5" cy="7.5" r="1" fill="#002244"/>
+  <circle cx="17.5" cy="7.5" r="1" fill="#002244"/>
+  <circle cx="14.8" cy="7.2" r="0.4" fill="#44ccee"/>
+  <path d="M20,12 Q24,9 22,15" fill="#006688"/>
+  <ellipse cx="16" cy="15" rx="3" ry="2" fill="#44ccee" opacity="0.35"/>
+  <!-- Both legs centered / near together -->
+  <rect x="13" y="20" width="3" height="7" rx="1" fill="#006688"/>
+  <rect x="16" y="20" width="3" height="7" rx="1" fill="#006688"/>
+  <ellipse cx="14.5" cy="27" rx="2" ry="1.2" fill="#006688"/>
+  <ellipse cx="17.5" cy="27" rx="2" ry="1.2" fill="#006688"/>
+  <!-- Arms mid-swing -->
+  <line x1="12" y1="13" x2="8" y2="15" stroke="#00aacc" stroke-width="2.5" stroke-linecap="round"/>
+  <line x1="20" y1="13" x2="24" y2="15" stroke="#00aacc" stroke-width="2.5" stroke-linecap="round"/>
+</svg>

--- a/web/public/sprites/tide-runner-3.svg
+++ b/web/public/sprites/tide-runner-3.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Tide Runner — frame 3 (stride B: mirror of frame 1, right leg forward) -->
+  <!-- Torso shifted down 1px -->
+  <rect x="12" y="12" width="8" height="9" rx="2" fill="#00aacc"/>
+  <ellipse cx="16" cy="9" rx="4" ry="4" fill="#00aacc"/>
+  <circle cx="14.5" cy="8.5" r="1" fill="#002244"/>
+  <circle cx="17.5" cy="8.5" r="1" fill="#002244"/>
+  <circle cx="14.8" cy="8.2" r="0.4" fill="#44ccee"/>
+  <path d="M20,13 Q24,10 22,16" fill="#006688"/>
+  <ellipse cx="16" cy="16" rx="3" ry="2" fill="#44ccee" opacity="0.35"/>
+  <!-- Right leg forward, left leg back (mirror of frame 1) -->
+  <rect x="14" y="21" width="3" height="5" rx="1" fill="#006688"/>
+  <rect x="19" y="21" width="3" height="6" rx="1" fill="#006688"/>
+  <ellipse cx="15.5" cy="26" rx="2.5" ry="1.2" fill="#006688"/>
+  <ellipse cx="20.5" cy="27" rx="2.5" ry="1.2" fill="#006688"/>
+  <!-- Arms swinging (mirrored) -->
+  <line x1="12" y1="14" x2="7" y2="18" stroke="#00aacc" stroke-width="2.5" stroke-linecap="round"/>
+  <line x1="20" y1="14" x2="25" y2="16" stroke="#00aacc" stroke-width="2.5" stroke-linecap="round"/>
+</svg>

--- a/web/public/sprites/tide-runner.svg
+++ b/web/public/sprites/tide-runner.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Tide Runner — idle (swift fish-person) -->
+  <!-- Torso -->
+  <rect x="12" y="11" width="8" height="9" rx="2" fill="#00aacc"/>
+  <!-- Head -->
+  <ellipse cx="16" cy="8" rx="4" ry="4" fill="#00aacc"/>
+  <!-- Eyes -->
+  <circle cx="14.5" cy="7.5" r="1" fill="#002244"/>
+  <circle cx="17.5" cy="7.5" r="1" fill="#002244"/>
+  <circle cx="14.8" cy="7.2" r="0.4" fill="#44ccee"/>
+  <!-- Dorsal fin on back -->
+  <path d="M20,12 Q24,9 22,15" fill="#006688"/>
+  <!-- Scale shimmer on torso -->
+  <ellipse cx="16" cy="15" rx="3" ry="2" fill="#44ccee" opacity="0.35"/>
+  <!-- Left leg -->
+  <rect x="12" y="20" width="3" height="7" rx="1" fill="#006688"/>
+  <!-- Right leg -->
+  <rect x="17" y="20" width="3" height="7" rx="1" fill="#006688"/>
+  <!-- Webbed feet -->
+  <ellipse cx="13.5" cy="27" rx="2.5" ry="1.2" fill="#006688"/>
+  <ellipse cx="18.5" cy="27" rx="2.5" ry="1.2" fill="#006688"/>
+  <!-- Arms -->
+  <line x1="12" y1="13" x2="8" y2="17" stroke="#00aacc" stroke-width="2.5" stroke-linecap="round"/>
+  <line x1="20" y1="13" x2="24" y2="17" stroke="#00aacc" stroke-width="2.5" stroke-linecap="round"/>
+</svg>

--- a/web/public/sprites/tide-stalker-1.svg
+++ b/web/public/sprites/tide-stalker-1.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Tide Stalker — frame 1 (stride A: body down 1, left leg forward, right back) -->
+  <!-- Body shifted down 1px -->
+  <ellipse cx="16" cy="19" rx="7" ry="6" fill="#112244"/>
+  <ellipse cx="16" cy="14" rx="5" ry="3.5" fill="#1a4455"/>
+  <ellipse cx="16" cy="12" rx="4" ry="3.5" fill="#112244"/>
+  <circle cx="14" cy="11" r="1.5" fill="#00ffcc"/>
+  <circle cx="18" cy="11" r="1.5" fill="#00ffcc"/>
+  <circle cx="14" cy="11" r="0.6" fill="#aaffee"/>
+  <circle cx="18" cy="11" r="0.6" fill="#aaffee"/>
+  <!-- Arms -->
+  <path d="M9,17 Q5,21 6,26" stroke="#334466" stroke-width="3" stroke-linecap="round" fill="none"/>
+  <path d="M6,26 L4,28 M6,26 L7,29 M6,26 L8,27" stroke="#334466" stroke-width="1.2"/>
+  <path d="M23,17 Q27,21 26,26" stroke="#334466" stroke-width="3" stroke-linecap="round" fill="none"/>
+  <path d="M26,26 L24,28 M26,26 L27,29 M26,26 L28,27" stroke="#334466" stroke-width="1.2"/>
+  <!-- Left leg forward -->
+  <rect x="10" y="24" width="3" height="5" rx="1" fill="#112244"/>
+  <!-- Right leg back -->
+  <rect x="18" y="24" width="3" height="4" rx="1" fill="#112244"/>
+  <circle cx="13" cy="18" r="0.8" fill="#00ffcc" opacity="0.5"/>
+  <circle cx="18" cy="20" r="0.8" fill="#00ffcc" opacity="0.5"/>
+</svg>

--- a/web/public/sprites/tide-stalker-2.svg
+++ b/web/public/sprites/tide-stalker-2.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Tide Stalker — frame 2 (mid-stride: normal height, legs centered) -->
+  <ellipse cx="16" cy="18" rx="7" ry="6" fill="#112244"/>
+  <ellipse cx="16" cy="13" rx="5" ry="3.5" fill="#1a4455"/>
+  <ellipse cx="16" cy="11" rx="4" ry="3.5" fill="#112244"/>
+  <circle cx="14" cy="10" r="1.5" fill="#00ffcc"/>
+  <circle cx="18" cy="10" r="1.5" fill="#00ffcc"/>
+  <circle cx="14" cy="10" r="0.6" fill="#aaffee"/>
+  <circle cx="18" cy="10" r="0.6" fill="#aaffee"/>
+  <path d="M9,16 Q5,20 6,25" stroke="#334466" stroke-width="3" stroke-linecap="round" fill="none"/>
+  <path d="M6,25 L4,27 M6,25 L7,28 M6,25 L8,26" stroke="#334466" stroke-width="1.2"/>
+  <path d="M23,16 Q27,20 26,25" stroke="#334466" stroke-width="3" stroke-linecap="round" fill="none"/>
+  <path d="M26,25 L24,27 M26,25 L27,28 M26,25 L28,26" stroke="#334466" stroke-width="1.2"/>
+  <!-- Both legs near center -->
+  <rect x="13" y="23" width="3" height="6" rx="1" fill="#112244"/>
+  <rect x="16" y="23" width="3" height="6" rx="1" fill="#112244"/>
+  <circle cx="14" cy="17" r="0.8" fill="#00ffcc" opacity="0.5"/>
+  <circle cx="18" cy="19" r="0.8" fill="#00ffcc" opacity="0.5"/>
+</svg>

--- a/web/public/sprites/tide-stalker-3.svg
+++ b/web/public/sprites/tide-stalker-3.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Tide Stalker — frame 3 (stride B: body down 1, right leg forward, mirror of frame 1) -->
+  <ellipse cx="16" cy="19" rx="7" ry="6" fill="#112244"/>
+  <ellipse cx="16" cy="14" rx="5" ry="3.5" fill="#1a4455"/>
+  <ellipse cx="16" cy="12" rx="4" ry="3.5" fill="#112244"/>
+  <circle cx="14" cy="11" r="1.5" fill="#00ffcc"/>
+  <circle cx="18" cy="11" r="1.5" fill="#00ffcc"/>
+  <circle cx="14" cy="11" r="0.6" fill="#aaffee"/>
+  <circle cx="18" cy="11" r="0.6" fill="#aaffee"/>
+  <path d="M9,17 Q5,21 6,26" stroke="#334466" stroke-width="3" stroke-linecap="round" fill="none"/>
+  <path d="M6,26 L4,28 M6,26 L7,29 M6,26 L8,27" stroke="#334466" stroke-width="1.2"/>
+  <path d="M23,17 Q27,21 26,26" stroke="#334466" stroke-width="3" stroke-linecap="round" fill="none"/>
+  <path d="M26,26 L24,28 M26,26 L27,29 M26,26 L28,27" stroke="#334466" stroke-width="1.2"/>
+  <!-- Right leg forward, left leg back (mirror of frame 1) -->
+  <rect x="14" y="24" width="3" height="4" rx="1" fill="#112244"/>
+  <rect x="19" y="24" width="3" height="5" rx="1" fill="#112244"/>
+  <circle cx="14" cy="18" r="0.8" fill="#00ffcc" opacity="0.5"/>
+  <circle cx="19" cy="20" r="0.8" fill="#00ffcc" opacity="0.5"/>
+</svg>

--- a/web/public/sprites/tide-stalker.svg
+++ b/web/public/sprites/tide-stalker.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Tide Stalker — idle (hunched aquatic predator) -->
+  <!-- Hunched body -->
+  <ellipse cx="16" cy="18" rx="7" ry="6" fill="#112244"/>
+  <!-- Back hump/hunch -->
+  <ellipse cx="16" cy="13" rx="5" ry="3.5" fill="#1a4455"/>
+  <!-- Head (low, forward) -->
+  <ellipse cx="16" cy="11" rx="4" ry="3.5" fill="#112244"/>
+  <!-- Bioluminescent eyes -->
+  <circle cx="14" cy="10" r="1.5" fill="#00ffcc"/>
+  <circle cx="18" cy="10" r="1.5" fill="#00ffcc"/>
+  <circle cx="14" cy="10" r="0.6" fill="#aaffee"/>
+  <circle cx="18" cy="10" r="0.6" fill="#aaffee"/>
+  <!-- Left elongated arm/claw -->
+  <path d="M9,16 Q5,20 6,25" stroke="#334466" stroke-width="3" stroke-linecap="round" fill="none"/>
+  <path d="M6,25 L4,27 M6,25 L7,28 M6,25 L8,26" stroke="#334466" stroke-width="1.2"/>
+  <!-- Right elongated arm/claw -->
+  <path d="M23,16 Q27,20 26,25" stroke="#334466" stroke-width="3" stroke-linecap="round" fill="none"/>
+  <path d="M26,25 L24,27 M26,25 L27,28 M26,25 L28,26" stroke="#334466" stroke-width="1.2"/>
+  <!-- Legs -->
+  <rect x="12" y="23" width="3" height="6" rx="1" fill="#112244"/>
+  <rect x="17" y="23" width="3" height="6" rx="1" fill="#112244"/>
+  <!-- Bioluminescent patches on body -->
+  <circle cx="14" cy="17" r="0.8" fill="#00ffcc" opacity="0.5"/>
+  <circle cx="18" cy="19" r="0.8" fill="#00ffcc" opacity="0.5"/>
+</svg>

--- a/web/public/sprites/vault-drone-1.svg
+++ b/web/public/sprites/vault-drone-1.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Vault Drone — frame 1 (body 1px lower, slight left tilt) -->
+  <!-- Rotor blades (angled) -->
+  <ellipse cx="16" cy="9" rx="9" ry="1.5" fill="#aabbcc" opacity="0.7" transform="rotate(-4,16,9)"/>
+  <line x1="7" y1="9" x2="25" y2="9" stroke="#778899" stroke-width="1" transform="rotate(-4,16,9)"/>
+  <!-- Disc body shifted 1px down, slight tilt -->
+  <ellipse cx="16" cy="17" rx="8" ry="5" fill="#778899" stroke="#334455" stroke-width="1" transform="rotate(-3,16,17)"/>
+  <ellipse cx="16" cy="16" rx="5" ry="3" fill="#aabbcc" opacity="0.5" transform="rotate(-3,16,16)"/>
+  <!-- Sensor eye -->
+  <circle cx="15.5" cy="17" r="2.5" fill="#334455"/>
+  <circle cx="15.5" cy="17" r="1.5" fill="#ffdd44"/>
+  <circle cx="16" cy="16.5" r="0.5" fill="#ffffff" opacity="0.8"/>
+  <!-- Rivets -->
+  <circle cx="10.5" cy="16" r="0.7" fill="#aabbcc"/>
+  <circle cx="20.5" cy="16" r="0.7" fill="#aabbcc"/>
+  <circle cx="12.5" cy="20" r="0.7" fill="#aabbcc"/>
+  <circle cx="18.5" cy="20" r="0.7" fill="#aabbcc"/>
+  <!-- Thruster nozzles -->
+  <rect x="12" y="21" width="3" height="3" rx="1" fill="#334455"/>
+  <rect x="17" y="21" width="3" height="3" rx="1" fill="#334455"/>
+  <ellipse cx="13.5" cy="24" rx="1.5" ry="0.7" fill="#ffdd44" opacity="0.8"/>
+  <ellipse cx="18.5" cy="24" rx="1.5" ry="0.7" fill="#ffdd44" opacity="0.8"/>
+</svg>

--- a/web/public/sprites/vault-drone-2.svg
+++ b/web/public/sprites/vault-drone-2.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Vault Drone — frame 2 (mid-hover, body at normal height) -->
+  <!-- Rotor blades fast spin -->
+  <ellipse cx="16" cy="9" rx="10" ry="1.2" fill="#aabbcc" opacity="0.8"/>
+  <line x1="6" y1="9" x2="26" y2="9" stroke="#778899" stroke-width="1"/>
+  <!-- Disc body -->
+  <ellipse cx="16" cy="16" rx="8" ry="5" fill="#778899" stroke="#334455" stroke-width="1"/>
+  <ellipse cx="16" cy="15" rx="5" ry="3" fill="#aabbcc" opacity="0.5"/>
+  <!-- Sensor eye -->
+  <circle cx="16" cy="16" r="2.5" fill="#334455"/>
+  <circle cx="16" cy="16" r="1.5" fill="#ffdd44"/>
+  <circle cx="16.5" cy="15.5" r="0.5" fill="#ffffff" opacity="0.8"/>
+  <!-- Rivets -->
+  <circle cx="11" cy="15" r="0.7" fill="#aabbcc"/>
+  <circle cx="21" cy="15" r="0.7" fill="#aabbcc"/>
+  <circle cx="13" cy="19" r="0.7" fill="#aabbcc"/>
+  <circle cx="19" cy="19" r="0.7" fill="#aabbcc"/>
+  <!-- Thruster nozzles -->
+  <rect x="12" y="20" width="3" height="3" rx="1" fill="#334455"/>
+  <rect x="17" y="20" width="3" height="3" rx="1" fill="#334455"/>
+  <ellipse cx="13.5" cy="23" rx="1.5" ry="0.7" fill="#ffdd44" opacity="0.9"/>
+  <ellipse cx="18.5" cy="23" rx="1.5" ry="0.7" fill="#ffdd44" opacity="0.9"/>
+</svg>

--- a/web/public/sprites/vault-drone-3.svg
+++ b/web/public/sprites/vault-drone-3.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Vault Drone — frame 3 (body 1px lower, tilt opposite/right) -->
+  <!-- Rotor blades (angled opposite) -->
+  <ellipse cx="16" cy="9" rx="9" ry="1.5" fill="#aabbcc" opacity="0.7" transform="rotate(4,16,9)"/>
+  <line x1="7" y1="9" x2="25" y2="9" stroke="#778899" stroke-width="1" transform="rotate(4,16,9)"/>
+  <!-- Disc body shifted 1px down, tilt right -->
+  <ellipse cx="16" cy="17" rx="8" ry="5" fill="#778899" stroke="#334455" stroke-width="1" transform="rotate(3,16,17)"/>
+  <ellipse cx="16" cy="16" rx="5" ry="3" fill="#aabbcc" opacity="0.5" transform="rotate(3,16,16)"/>
+  <!-- Sensor eye -->
+  <circle cx="16.5" cy="17" r="2.5" fill="#334455"/>
+  <circle cx="16.5" cy="17" r="1.5" fill="#ffdd44"/>
+  <circle cx="17" cy="16.5" r="0.5" fill="#ffffff" opacity="0.8"/>
+  <!-- Rivets -->
+  <circle cx="11.5" cy="16" r="0.7" fill="#aabbcc"/>
+  <circle cx="21.5" cy="16" r="0.7" fill="#aabbcc"/>
+  <circle cx="13.5" cy="20" r="0.7" fill="#aabbcc"/>
+  <circle cx="19.5" cy="20" r="0.7" fill="#aabbcc"/>
+  <!-- Thruster nozzles -->
+  <rect x="12" y="21" width="3" height="3" rx="1" fill="#334455"/>
+  <rect x="17" y="21" width="3" height="3" rx="1" fill="#334455"/>
+  <ellipse cx="13.5" cy="24" rx="1.5" ry="0.7" fill="#ffdd44" opacity="0.8"/>
+  <ellipse cx="18.5" cy="24" rx="1.5" ry="0.7" fill="#ffdd44" opacity="0.8"/>
+</svg>

--- a/web/public/sprites/vault-drone.svg
+++ b/web/public/sprites/vault-drone.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Vault Drone — idle (small flying mechanical drone) -->
+  <!-- Rotor blades -->
+  <ellipse cx="16" cy="9" rx="9" ry="1.5" fill="#aabbcc" opacity="0.7"/>
+  <line x1="7" y1="9" x2="25" y2="9" stroke="#778899" stroke-width="1"/>
+  <!-- Disc body -->
+  <ellipse cx="16" cy="16" rx="8" ry="5" fill="#778899" stroke="#334455" stroke-width="1"/>
+  <ellipse cx="16" cy="15" rx="5" ry="3" fill="#aabbcc" opacity="0.5"/>
+  <!-- Sensor eye -->
+  <circle cx="16" cy="16" r="2.5" fill="#334455"/>
+  <circle cx="16" cy="16" r="1.5" fill="#ffdd44"/>
+  <circle cx="16.5" cy="15.5" r="0.5" fill="#ffffff" opacity="0.8"/>
+  <!-- Rivets on body -->
+  <circle cx="11" cy="15" r="0.7" fill="#aabbcc"/>
+  <circle cx="21" cy="15" r="0.7" fill="#aabbcc"/>
+  <circle cx="13" cy="19" r="0.7" fill="#aabbcc"/>
+  <circle cx="19" cy="19" r="0.7" fill="#aabbcc"/>
+  <!-- Thruster nozzles bottom -->
+  <rect x="12" y="20" width="3" height="3" rx="1" fill="#334455"/>
+  <rect x="17" y="20" width="3" height="3" rx="1" fill="#334455"/>
+  <ellipse cx="13.5" cy="23" rx="1.5" ry="0.7" fill="#ffdd44" opacity="0.6"/>
+  <ellipse cx="18.5" cy="23" rx="1.5" ry="0.7" fill="#ffdd44" opacity="0.6"/>
+</svg>

--- a/web/public/sprites/vault-guardian-1.svg
+++ b/web/public/sprites/vault-guardian-1.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Vault Guardian — frame 1 (body 1px down, left leg fwd, right leg back) -->
+  <!-- Left shoulder pauldron -->
+  <rect x="4" y="11" width="6" height="5" rx="1" fill="#445566"/>
+  <!-- Right shoulder pauldron -->
+  <rect x="22" y="11" width="6" height="5" rx="1" fill="#445566"/>
+  <!-- Wide boxy torso shifted 1px down -->
+  <rect x="9" y="13" width="14" height="11" rx="1" fill="#445566" stroke="#334455" stroke-width="1"/>
+  <rect x="11" y="15" width="10" height="7" rx="1" fill="#778899" opacity="0.4"/>
+  <!-- Rivets -->
+  <circle cx="11" cy="14" r="0.8" fill="#aabbcc"/>
+  <circle cx="21" cy="14" r="0.8" fill="#aabbcc"/>
+  <circle cx="11" cy="23" r="0.8" fill="#aabbcc"/>
+  <circle cx="21" cy="23" r="0.8" fill="#aabbcc"/>
+  <!-- Helmet -->
+  <rect x="11" y="5" width="10" height="9" rx="2" fill="#445566" stroke="#334455" stroke-width="1"/>
+  <!-- Visor -->
+  <rect x="12" y="8" width="8" height="3" rx="1" fill="#44aaff"/>
+  <rect x="13" y="8.5" width="6" height="2" rx="0.5" fill="#88ccff" opacity="0.7"/>
+  <!-- Left leg 2px forward (low) -->
+  <rect x="11" y="24" width="4" height="7" rx="1" fill="#445566" stroke="#334455" stroke-width="0.8" transform="translate(-2,0) rotate(8,13,27)"/>
+  <!-- Right leg 1px back -->
+  <rect x="17" y="24" width="4" height="7" rx="1" fill="#445566" stroke="#334455" stroke-width="0.8" transform="translate(1,0) rotate(-5,19,27)"/>
+  <!-- Feet -->
+  <rect x="8" y="29" width="6" height="2" rx="1" fill="#334455"/>
+  <rect x="17" y="29" width="6" height="2" rx="1" fill="#334455"/>
+  <!-- Arms -->
+  <rect x="5" y="16" width="4" height="8" rx="1" fill="#445566"/>
+  <rect x="23" y="16" width="4" height="8" rx="1" fill="#445566"/>
+</svg>

--- a/web/public/sprites/vault-guardian-2.svg
+++ b/web/public/sprites/vault-guardian-2.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Vault Guardian — frame 2 (mid-stride, body normal height) -->
+  <!-- Left shoulder pauldron -->
+  <rect x="4" y="10" width="6" height="5" rx="1" fill="#445566"/>
+  <!-- Right shoulder pauldron -->
+  <rect x="22" y="10" width="6" height="5" rx="1" fill="#445566"/>
+  <!-- Wide boxy torso -->
+  <rect x="9" y="12" width="14" height="11" rx="1" fill="#445566" stroke="#334455" stroke-width="1"/>
+  <rect x="11" y="14" width="10" height="7" rx="1" fill="#778899" opacity="0.4"/>
+  <!-- Rivets -->
+  <circle cx="11" cy="13" r="0.8" fill="#aabbcc"/>
+  <circle cx="21" cy="13" r="0.8" fill="#aabbcc"/>
+  <circle cx="11" cy="22" r="0.8" fill="#aabbcc"/>
+  <circle cx="21" cy="22" r="0.8" fill="#aabbcc"/>
+  <!-- Helmet -->
+  <rect x="11" y="4" width="10" height="9" rx="2" fill="#445566" stroke="#334455" stroke-width="1"/>
+  <!-- Visor -->
+  <rect x="12" y="7" width="8" height="3" rx="1" fill="#44aaff"/>
+  <rect x="13" y="7.5" width="6" height="2" rx="0.5" fill="#88ccff" opacity="0.7"/>
+  <!-- Both legs near center (mid-stride) -->
+  <rect x="12" y="23" width="4" height="7" rx="1" fill="#445566" stroke="#334455" stroke-width="0.8"/>
+  <rect x="16" y="23" width="4" height="7" rx="1" fill="#445566" stroke="#334455" stroke-width="0.8"/>
+  <!-- Feet -->
+  <rect x="11" y="29" width="5" height="2" rx="1" fill="#334455"/>
+  <rect x="16" y="29" width="5" height="2" rx="1" fill="#334455"/>
+  <!-- Arms -->
+  <rect x="5" y="15" width="4" height="8" rx="1" fill="#445566"/>
+  <rect x="23" y="15" width="4" height="8" rx="1" fill="#445566"/>
+</svg>

--- a/web/public/sprites/vault-guardian-3.svg
+++ b/web/public/sprites/vault-guardian-3.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Vault Guardian — frame 3 (body 1px down, right leg fwd, left leg back — mirror of 1) -->
+  <!-- Left shoulder pauldron -->
+  <rect x="4" y="11" width="6" height="5" rx="1" fill="#445566"/>
+  <!-- Right shoulder pauldron -->
+  <rect x="22" y="11" width="6" height="5" rx="1" fill="#445566"/>
+  <!-- Wide boxy torso shifted 1px down -->
+  <rect x="9" y="13" width="14" height="11" rx="1" fill="#445566" stroke="#334455" stroke-width="1"/>
+  <rect x="11" y="15" width="10" height="7" rx="1" fill="#778899" opacity="0.4"/>
+  <!-- Rivets -->
+  <circle cx="11" cy="14" r="0.8" fill="#aabbcc"/>
+  <circle cx="21" cy="14" r="0.8" fill="#aabbcc"/>
+  <circle cx="11" cy="23" r="0.8" fill="#aabbcc"/>
+  <circle cx="21" cy="23" r="0.8" fill="#aabbcc"/>
+  <!-- Helmet -->
+  <rect x="11" y="5" width="10" height="9" rx="2" fill="#445566" stroke="#334455" stroke-width="1"/>
+  <!-- Visor -->
+  <rect x="12" y="8" width="8" height="3" rx="1" fill="#44aaff"/>
+  <rect x="13" y="8.5" width="6" height="2" rx="0.5" fill="#88ccff" opacity="0.7"/>
+  <!-- Right leg 2px forward (low) -->
+  <rect x="17" y="24" width="4" height="7" rx="1" fill="#445566" stroke="#334455" stroke-width="0.8" transform="translate(2,0) rotate(-8,19,27)"/>
+  <!-- Left leg 1px back -->
+  <rect x="11" y="24" width="4" height="7" rx="1" fill="#445566" stroke="#334455" stroke-width="0.8" transform="translate(-1,0) rotate(5,13,27)"/>
+  <!-- Feet -->
+  <rect x="9" y="29" width="6" height="2" rx="1" fill="#334455"/>
+  <rect x="17" y="29" width="6" height="2" rx="1" fill="#334455"/>
+  <!-- Arms -->
+  <rect x="5" y="16" width="4" height="8" rx="1" fill="#445566"/>
+  <rect x="23" y="16" width="4" height="8" rx="1" fill="#445566"/>
+</svg>

--- a/web/public/sprites/vault-guardian.svg
+++ b/web/public/sprites/vault-guardian.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Vault Guardian — idle (heavy armored robot) -->
+  <!-- Left shoulder pauldron -->
+  <rect x="4" y="10" width="6" height="5" rx="1" fill="#445566"/>
+  <!-- Right shoulder pauldron -->
+  <rect x="22" y="10" width="6" height="5" rx="1" fill="#445566"/>
+  <!-- Wide boxy torso -->
+  <rect x="9" y="12" width="14" height="11" rx="1" fill="#445566" stroke="#334455" stroke-width="1"/>
+  <rect x="11" y="14" width="10" height="7" rx="1" fill="#778899" opacity="0.4"/>
+  <!-- Rivets on torso -->
+  <circle cx="11" cy="13" r="0.8" fill="#aabbcc"/>
+  <circle cx="21" cy="13" r="0.8" fill="#aabbcc"/>
+  <circle cx="11" cy="22" r="0.8" fill="#aabbcc"/>
+  <circle cx="21" cy="22" r="0.8" fill="#aabbcc"/>
+  <!-- Helmet -->
+  <rect x="11" y="4" width="10" height="9" rx="2" fill="#445566" stroke="#334455" stroke-width="1"/>
+  <!-- Visor glowing -->
+  <rect x="12" y="7" width="8" height="3" rx="1" fill="#44aaff"/>
+  <rect x="13" y="7.5" width="6" height="2" rx="0.5" fill="#88ccff" opacity="0.7"/>
+  <!-- Cylindrical legs -->
+  <rect x="11" y="23" width="4" height="7" rx="1" fill="#445566" stroke="#334455" stroke-width="0.8"/>
+  <rect x="17" y="23" width="4" height="7" rx="1" fill="#445566" stroke="#334455" stroke-width="0.8"/>
+  <!-- Feet -->
+  <rect x="10" y="29" width="6" height="2" rx="1" fill="#334455"/>
+  <rect x="16" y="29" width="6" height="2" rx="1" fill="#334455"/>
+  <!-- Arms -->
+  <rect x="5" y="15" width="4" height="8" rx="1" fill="#445566"/>
+  <rect x="23" y="15" width="4" height="8" rx="1" fill="#445566"/>
+</svg>

--- a/web/public/sprites/vine-colossus-1.svg
+++ b/web/public/sprites/vine-colossus-1.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Vine Colossus — frame 1 (body 1px down, left leg fwd, right leg back) -->
+  <!-- Left leg forward 2px -->
+  <rect x="7" y="23" width="5" height="9" rx="2" fill="#4a2a0a"/>
+  <!-- Right leg back 1px -->
+  <rect x="20" y="23" width="5" height="9" rx="2" fill="#4a2a0a"/>
+  <!-- Vine wrap on legs -->
+  <path d="M7,26 Q10,25 12,27 Q10,29 7,28" fill="#1a3a0a" opacity="0.7"/>
+  <path d="M20,26 Q23,25 25,27 Q23,29 20,28" fill="#1a3a0a" opacity="0.7"/>
+  <!-- Massive body shifted 1px down -->
+  <rect x="7" y="12" width="18" height="13" rx="3" fill="#1a3a0a" stroke="#4a2a0a" stroke-width="1.5"/>
+  <!-- Vine-wrapped arms -->
+  <path d="M7,15 Q1,17 2,25" stroke="#4a2a0a" stroke-width="5" stroke-linecap="round" fill="none"/>
+  <path d="M2,25 L0,28 M2,25 L3,29" stroke="#1a3a0a" stroke-width="2"/>
+  <path d="M25,15 Q31,17 30,25" stroke="#4a2a0a" stroke-width="5" stroke-linecap="round" fill="none"/>
+  <path d="M30,25 L32,28 M30,25 L29,29" stroke="#1a3a0a" stroke-width="2"/>
+  <!-- Moss patches -->
+  <ellipse cx="12" cy="16" rx="3" ry="2" fill="#4aaa22" opacity="0.7"/>
+  <ellipse cx="20" cy="19" rx="3" ry="2" fill="#4aaa22" opacity="0.7"/>
+  <!-- Leafy head -->
+  <ellipse cx="16" cy="10" rx="7" ry="6" fill="#1a3a0a" stroke="#4a2a0a" stroke-width="1"/>
+  <!-- Leaf crown -->
+  <path d="M10,8 Q12,3 14,7" fill="#4aaa22"/>
+  <path d="M14,6 Q16,2 18,6" fill="#4aaa22"/>
+  <path d="M18,8 Q20,3 22,8" fill="#4aaa22"/>
+  <!-- Glowing eyes -->
+  <circle cx="13" cy="10" r="2" fill="#aaff44"/>
+  <circle cx="19" cy="10" r="2" fill="#aaff44"/>
+  <circle cx="13" cy="10" r="0.8" fill="#ffffff" opacity="0.8"/>
+  <circle cx="19" cy="10" r="0.8" fill="#ffffff" opacity="0.8"/>
+</svg>

--- a/web/public/sprites/vine-colossus-2.svg
+++ b/web/public/sprites/vine-colossus-2.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Vine Colossus — frame 2 (mid-stride, both legs near center) -->
+  <!-- Legs centered -->
+  <rect x="10" y="22" width="5" height="9" rx="2" fill="#4a2a0a"/>
+  <rect x="17" y="22" width="5" height="#9" rx="2" fill="#4a2a0a"/>
+  <!-- Vine wrap on legs -->
+  <path d="M10,25 Q13,24 15,26" fill="#1a3a0a" opacity="0.7"/>
+  <path d="M17,25 Q20,24 22,26" fill="#1a3a0a" opacity="0.7"/>
+  <!-- Massive body normal height -->
+  <rect x="7" y="11" width="18" height="13" rx="3" fill="#1a3a0a" stroke="#4a2a0a" stroke-width="1.5"/>
+  <!-- Vine-wrapped arms -->
+  <path d="M7,14 Q1,16 2,24" stroke="#4a2a0a" stroke-width="5" stroke-linecap="round" fill="none"/>
+  <path d="M2,24 L0,27 M2,24 L3,28" stroke="#1a3a0a" stroke-width="2"/>
+  <path d="M25,14 Q31,16 30,24" stroke="#4a2a0a" stroke-width="5" stroke-linecap="round" fill="none"/>
+  <path d="M30,24 L32,27 M30,24 L29,28" stroke="#1a3a0a" stroke-width="2"/>
+  <!-- Moss patches -->
+  <ellipse cx="12" cy="15" rx="3" ry="2" fill="#4aaa22" opacity="0.7"/>
+  <ellipse cx="20" cy="18" rx="3" ry="2" fill="#4aaa22" opacity="0.7"/>
+  <!-- Leafy head -->
+  <ellipse cx="16" cy="9" rx="7" ry="6" fill="#1a3a0a" stroke="#4a2a0a" stroke-width="1"/>
+  <!-- Leaf crown -->
+  <path d="M10,7 Q12,2 14,6" fill="#4aaa22"/>
+  <path d="M14,5 Q16,1 18,5" fill="#4aaa22"/>
+  <path d="M18,7 Q20,2 22,7" fill="#4aaa22"/>
+  <!-- Glowing eyes -->
+  <circle cx="13" cy="9" r="2" fill="#aaff44"/>
+  <circle cx="19" cy="9" r="2" fill="#aaff44"/>
+  <circle cx="13" cy="9" r="0.8" fill="#ffffff" opacity="0.8"/>
+  <circle cx="19" cy="9" r="0.8" fill="#ffffff" opacity="0.8"/>
+</svg>

--- a/web/public/sprites/vine-colossus-3.svg
+++ b/web/public/sprites/vine-colossus-3.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Vine Colossus — frame 3 (body 1px down, right leg fwd, left leg back — mirror of 1) -->
+  <!-- Left leg back 1px -->
+  <rect x="9" y="23" width="5" height="9" rx="2" fill="#4a2a0a"/>
+  <!-- Right leg forward 2px -->
+  <rect x="18" y="23" width="5" height="9" rx="2" fill="#4a2a0a"/>
+  <!-- Vine wrap on legs -->
+  <path d="M9,26 Q12,25 14,27 Q12,29 9,28" fill="#1a3a0a" opacity="0.7"/>
+  <path d="M18,26 Q21,25 23,27 Q21,29 18,28" fill="#1a3a0a" opacity="0.7"/>
+  <!-- Massive body shifted 1px down -->
+  <rect x="7" y="12" width="18" height="13" rx="3" fill="#1a3a0a" stroke="#4a2a0a" stroke-width="1.5"/>
+  <!-- Vine-wrapped arms -->
+  <path d="M7,15 Q1,17 2,25" stroke="#4a2a0a" stroke-width="5" stroke-linecap="round" fill="none"/>
+  <path d="M2,25 L0,28 M2,25 L3,29" stroke="#1a3a0a" stroke-width="2"/>
+  <path d="M25,15 Q31,17 30,25" stroke="#4a2a0a" stroke-width="5" stroke-linecap="round" fill="none"/>
+  <path d="M30,25 L32,28 M30,25 L29,29" stroke="#1a3a0a" stroke-width="2"/>
+  <!-- Moss patches -->
+  <ellipse cx="12" cy="16" rx="3" ry="2" fill="#4aaa22" opacity="0.7"/>
+  <ellipse cx="20" cy="19" rx="3" ry="2" fill="#4aaa22" opacity="0.7"/>
+  <!-- Leafy head -->
+  <ellipse cx="16" cy="10" rx="7" ry="6" fill="#1a3a0a" stroke="#4a2a0a" stroke-width="1"/>
+  <!-- Leaf crown -->
+  <path d="M10,8 Q12,3 14,7" fill="#4aaa22"/>
+  <path d="M14,6 Q16,2 18,6" fill="#4aaa22"/>
+  <path d="M18,8 Q20,3 22,8" fill="#4aaa22"/>
+  <!-- Glowing eyes -->
+  <circle cx="13" cy="10" r="2" fill="#aaff44"/>
+  <circle cx="19" cy="10" r="2" fill="#aaff44"/>
+  <circle cx="13" cy="10" r="0.8" fill="#ffffff" opacity="0.8"/>
+  <circle cx="19" cy="10" r="0.8" fill="#ffffff" opacity="0.8"/>
+</svg>

--- a/web/public/sprites/vine-colossus.svg
+++ b/web/public/sprites/vine-colossus.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Vine Colossus — idle (massive vine giant) -->
+  <!-- Tree-trunk legs -->
+  <rect x="9" y="22" width="5" height="9" rx="2" fill="#4a2a0a"/>
+  <rect x="18" y="22" width="5" height="9" rx="2" fill="#4a2a0a"/>
+  <!-- Vine wrap on legs -->
+  <path d="M9,25 Q12,24 14,26 Q12,28 9,27" fill="#1a3a0a" opacity="0.7"/>
+  <path d="M18,25 Q21,24 23,26 Q21,28 18,27" fill="#1a3a0a" opacity="0.7"/>
+  <!-- Massive bulky body -->
+  <rect x="7" y="11" width="18" height="13" rx="3" fill="#1a3a0a" stroke="#4a2a0a" stroke-width="1.5"/>
+  <!-- Vine-wrapped arms — left huge -->
+  <path d="M7,14 Q1,16 2,24" stroke="#4a2a0a" stroke-width="5" stroke-linecap="round" fill="none"/>
+  <path d="M2,24 L0,27 M2,24 L3,28" stroke="#1a3a0a" stroke-width="2"/>
+  <!-- Vine-wrapped arms — right huge -->
+  <path d="M25,14 Q31,16 30,24" stroke="#4a2a0a" stroke-width="5" stroke-linecap="round" fill="none"/>
+  <path d="M30,24 L32,27 M30,24 L29,28" stroke="#1a3a0a" stroke-width="2"/>
+  <!-- Moss patches on body -->
+  <ellipse cx="12" cy="15" rx="3" ry="2" fill="#4aaa22" opacity="0.7"/>
+  <ellipse cx="20" cy="18" rx="3" ry="2" fill="#4aaa22" opacity="0.7"/>
+  <!-- Leafy head -->
+  <ellipse cx="16" cy="9" rx="7" ry="6" fill="#1a3a0a" stroke="#4a2a0a" stroke-width="1"/>
+  <!-- Leaf crown -->
+  <path d="M10,7 Q12,2 14,6" fill="#4aaa22"/>
+  <path d="M14,5 Q16,1 18,5" fill="#4aaa22"/>
+  <path d="M18,7 Q20,2 22,7" fill="#4aaa22"/>
+  <!-- Glowing eyes -->
+  <circle cx="13" cy="9" r="2" fill="#aaff44"/>
+  <circle cx="19" cy="9" r="2" fill="#aaff44"/>
+  <circle cx="13" cy="9" r="0.8" fill="#ffffff" opacity="0.8"/>
+  <circle cx="19" cy="9" r="0.8" fill="#ffffff" opacity="0.8"/>
+</svg>

--- a/web/public/sprites/vine-runner-1.svg
+++ b/web/public/sprites/vine-runner-1.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Vine Runner — frame 1 (body 1px down, left leg fwd, right leg back) -->
+  <!-- Vine tendrils trailing -->
+  <path d="M12,19 Q6,23 4,29" stroke="#3a7a20" stroke-width="1.5" fill="none" opacity="0.8"/>
+  <path d="M13,21 Q7,27 5,32" stroke="#55aa33" stroke-width="1" fill="none" opacity="0.6"/>
+  <!-- Slim body 1px down -->
+  <rect x="12" y="14" width="8" height="10" rx="2" fill="#3a7a20"/>
+  <polygon points="15,14 17,14 19,12 13,12" fill="#55aa33" opacity="0.6"/>
+  <!-- Head -->
+  <ellipse cx="16" cy="10" rx="4" ry="4" fill="#3a7a20" stroke="#553311" stroke-width="0.8"/>
+  <!-- Leaf crest -->
+  <path d="M14,7 Q16,3 18,7 Q16,6 14,7 Z" fill="#88dd44"/>
+  <path d="M13,8 Q15,4 17,8 Q15,7 13,8 Z" fill="#55aa33"/>
+  <!-- Eyes -->
+  <circle cx="14.5" cy="10" r="0.8" fill="#88dd44"/>
+  <circle cx="17.5" cy="10" r="0.8" fill="#88dd44"/>
+  <!-- Arms -->
+  <path d="M12,16 Q8,15 7,19" stroke="#553311" stroke-width="2" stroke-linecap="round" fill="none"/>
+  <path d="M20,16 Q24,15 25,19" stroke="#553311" stroke-width="2" stroke-linecap="round" fill="none"/>
+  <!-- Left leg forward 2px, right leg back 1px -->
+  <rect x="11" y="24" width="3" height="7" rx="1" fill="#553311" transform="rotate(12,12.5,27)"/>
+  <rect x="17" y="24" width="3" height="7" rx="1" fill="#553311" transform="rotate(-8,18.5,27)"/>
+  <!-- Feet -->
+  <ellipse cx="11" cy="30" rx="2" ry="1" fill="#3a7a20"/>
+  <ellipse cx="19" cy="30" rx="2" ry="1" fill="#3a7a20"/>
+</svg>

--- a/web/public/sprites/vine-runner-2.svg
+++ b/web/public/sprites/vine-runner-2.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Vine Runner — frame 2 (mid-stride, both legs near center) -->
+  <!-- Vine tendrils trailing -->
+  <path d="M12,18 Q6,22 4,28" stroke="#3a7a20" stroke-width="1.5" fill="none" opacity="0.8"/>
+  <path d="M13,20 Q7,26 5,31" stroke="#55aa33" stroke-width="1" fill="none" opacity="0.6"/>
+  <!-- Slim body normal height -->
+  <rect x="12" y="13" width="8" height="10" rx="2" fill="#3a7a20"/>
+  <polygon points="15,13 17,13 19,11 13,11" fill="#55aa33" opacity="0.6"/>
+  <!-- Head -->
+  <ellipse cx="16" cy="9" rx="4" ry="4" fill="#3a7a20" stroke="#553311" stroke-width="0.8"/>
+  <!-- Leaf crest -->
+  <path d="M14,6 Q16,2 18,6 Q16,5 14,6 Z" fill="#88dd44"/>
+  <path d="M13,7 Q15,3 17,7 Q15,6 13,7 Z" fill="#55aa33"/>
+  <!-- Eyes -->
+  <circle cx="14.5" cy="9" r="0.8" fill="#88dd44"/>
+  <circle cx="17.5" cy="9" r="0.8" fill="#88dd44"/>
+  <!-- Arms -->
+  <path d="M12,15 Q8,14 7,18" stroke="#553311" stroke-width="2" stroke-linecap="round" fill="none"/>
+  <path d="M20,15 Q24,14 25,18" stroke="#553311" stroke-width="2" stroke-linecap="round" fill="none"/>
+  <!-- Both legs near center -->
+  <rect x="13" y="23" width="3" height="7" rx="1" fill="#553311"/>
+  <rect x="16" y="23" width="3" height="7" rx="1" fill="#553311"/>
+  <!-- Feet -->
+  <ellipse cx="14.5" cy="30" rx="2" ry="1" fill="#3a7a20"/>
+  <ellipse cx="17.5" cy="30" rx="2" ry="1" fill="#3a7a20"/>
+</svg>

--- a/web/public/sprites/vine-runner-3.svg
+++ b/web/public/sprites/vine-runner-3.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Vine Runner — frame 3 (body 1px down, right leg fwd, left leg back — mirror of 1) -->
+  <!-- Vine tendrils trailing -->
+  <path d="M12,19 Q6,23 4,29" stroke="#3a7a20" stroke-width="1.5" fill="none" opacity="0.8"/>
+  <path d="M13,21 Q7,27 5,32" stroke="#55aa33" stroke-width="1" fill="none" opacity="0.6"/>
+  <!-- Slim body 1px down -->
+  <rect x="12" y="14" width="8" height="10" rx="2" fill="#3a7a20"/>
+  <polygon points="15,14 17,14 19,12 13,12" fill="#55aa33" opacity="0.6"/>
+  <!-- Head -->
+  <ellipse cx="16" cy="10" rx="4" ry="4" fill="#3a7a20" stroke="#553311" stroke-width="0.8"/>
+  <!-- Leaf crest -->
+  <path d="M14,7 Q16,3 18,7 Q16,6 14,7 Z" fill="#88dd44"/>
+  <path d="M13,8 Q15,4 17,8 Q15,7 13,8 Z" fill="#55aa33"/>
+  <!-- Eyes -->
+  <circle cx="14.5" cy="10" r="0.8" fill="#88dd44"/>
+  <circle cx="17.5" cy="10" r="0.8" fill="#88dd44"/>
+  <!-- Arms -->
+  <path d="M12,16 Q8,15 7,19" stroke="#553311" stroke-width="2" stroke-linecap="round" fill="none"/>
+  <path d="M20,16 Q24,15 25,19" stroke="#553311" stroke-width="2" stroke-linecap="round" fill="none"/>
+  <!-- Right leg forward 2px, left leg back 1px -->
+  <rect x="17" y="24" width="3" height="7" rx="1" fill="#553311" transform="rotate(-12,18.5,27)"/>
+  <rect x="12" y="24" width="3" height="7" rx="1" fill="#553311" transform="rotate(8,13.5,27)"/>
+  <!-- Feet -->
+  <ellipse cx="21" cy="30" rx="2" ry="1" fill="#3a7a20"/>
+  <ellipse cx="13" cy="30" rx="2" ry="1" fill="#3a7a20"/>
+</svg>

--- a/web/public/sprites/vine-runner.svg
+++ b/web/public/sprites/vine-runner.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Vine Runner — idle (fast agile vine creature) -->
+  <!-- Vine tendrils trailing (back) -->
+  <path d="M12,18 Q6,22 4,28" stroke="#3a7a20" stroke-width="1.5" fill="none" opacity="0.8"/>
+  <path d="M13,20 Q7,26 5,31" stroke="#55aa33" stroke-width="1" fill="none" opacity="0.6"/>
+  <!-- Slim body -->
+  <rect x="12" y="13" width="8" height="10" rx="2" fill="#3a7a20"/>
+  <!-- Forward lean -->
+  <polygon points="15,13 17,13 19,11 13,11" fill="#55aa33" opacity="0.6"/>
+  <!-- Head -->
+  <ellipse cx="16" cy="9" rx="4" ry="4" fill="#3a7a20" stroke="#553311" stroke-width="0.8"/>
+  <!-- Leaf crest -->
+  <path d="M14,6 Q16,2 18,6 Q16,5 14,6 Z" fill="#88dd44"/>
+  <path d="M13,7 Q15,3 17,7 Q15,6 13,7 Z" fill="#55aa33"/>
+  <!-- Eyes -->
+  <circle cx="14.5" cy="9" r="0.8" fill="#88dd44"/>
+  <circle cx="17.5" cy="9" r="0.8" fill="#88dd44"/>
+  <!-- Bark texture arms -->
+  <path d="M12,15 Q8,14 7,18" stroke="#553311" stroke-width="2" stroke-linecap="round" fill="none"/>
+  <path d="M20,15 Q24,14 25,18" stroke="#553311" stroke-width="2" stroke-linecap="round" fill="none"/>
+  <!-- Slim sprinting legs -->
+  <rect x="13" y="23" width="3" height="7" rx="1" fill="#553311"/>
+  <rect x="16" y="23" width="3" height="7" rx="1" fill="#553311"/>
+  <!-- Feet -->
+  <ellipse cx="14.5" cy="30" rx="2" ry="1" fill="#3a7a20"/>
+  <ellipse cx="17.5" cy="30" rx="2" ry="1" fill="#3a7a20"/>
+</svg>

--- a/web/public/sprites/warlord-kragg-1.svg
+++ b/web/public/sprites/warlord-kragg-1.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Warlord Kragg — frame 1 (body 1px down, left leg fwd, right leg back) -->
+  <!-- Left leg forward 2px -->
+  <rect x="9" y="23" width="4" height="8" rx="1" fill="#333344" transform="rotate(10,11,27)"/>
+  <!-- Right leg back -->
+  <rect x="19" y="23" width="4" height="8" rx="1" fill="#333344" transform="rotate(-6,21,27)"/>
+  <!-- Spiked shoulder pads shifted 1px down -->
+  <rect x="4" y="12" width="7" height="5" rx="1" fill="#333344" stroke="#222233" stroke-width="0.8"/>
+  <polygon points="4,12 5,9 6,12" fill="#ddcc88"/>
+  <polygon points="8,12 9,9 10,12" fill="#ddcc88"/>
+  <rect x="21" y="12" width="7" height="5" rx="1" fill="#333344" stroke="#222233" stroke-width="0.8"/>
+  <polygon points="22,12 23,9 24,12" fill="#ddcc88"/>
+  <polygon points="26,12 27,9 28,12" fill="#ddcc88"/>
+  <!-- Broad armored torso shifted 1px down -->
+  <rect x="9" y="13" width="14" height="11" rx="1" fill="#333344" stroke="#222233" stroke-width="1"/>
+  <rect x="9" y="17" width="14" height="2" fill="#aa2222" opacity="0.7"/>
+  <!-- Horned helmet -->
+  <rect x="11" y="5" width="10" height="9" rx="2" fill="#333344" stroke="#222233" stroke-width="1"/>
+  <polygon points="11,7 9,3 12,6" fill="#ddcc88"/>
+  <polygon points="21,7 23,3 20,6" fill="#ddcc88"/>
+  <!-- Orc face -->
+  <ellipse cx="16" cy="9" rx="4" ry="4" fill="#668833"/>
+  <circle cx="14.5" cy="8.5" r="0.8" fill="#aa2222"/>
+  <circle cx="17.5" cy="8.5" r="0.8" fill="#aa2222"/>
+  <rect x="14" y="12" width="1.5" height="2" rx="0.5" fill="#ddcc88"/>
+  <rect x="16.5" y="12" width="1.5" height="2" rx="0.5" fill="#ddcc88"/>
+  <!-- Axe -->
+  <line x1="23" y1="8" x2="25" y2="28" stroke="#222233" stroke-width="1.5"/>
+  <path d="M20,9 Q23,6 26,9 Q24,13 23,13 Z" fill="#333344" stroke="#222233" stroke-width="1"/>
+  <line x1="22" y1="9" x2="25" y2="10" stroke="#aabbcc" stroke-width="0.8"/>
+</svg>

--- a/web/public/sprites/warlord-kragg-2.svg
+++ b/web/public/sprites/warlord-kragg-2.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Warlord Kragg — frame 2 (mid-stride, both legs near center) -->
+  <!-- Both legs centered -->
+  <rect x="12" y="22" width="4" height="8" rx="1" fill="#333344"/>
+  <rect x="16" y="22" width="4" height="8" rx="1" fill="#333344"/>
+  <!-- Spiked shoulder pads -->
+  <rect x="4" y="11" width="7" height="5" rx="1" fill="#333344" stroke="#222233" stroke-width="0.8"/>
+  <polygon points="4,11 5,8 6,11" fill="#ddcc88"/>
+  <polygon points="8,11 9,8 10,11" fill="#ddcc88"/>
+  <rect x="21" y="11" width="7" height="5" rx="1" fill="#333344" stroke="#222233" stroke-width="0.8"/>
+  <polygon points="22,11 23,8 24,11" fill="#ddcc88"/>
+  <polygon points="26,11 27,8 28,11" fill="#ddcc88"/>
+  <!-- Broad armored torso -->
+  <rect x="9" y="12" width="14" height="11" rx="1" fill="#333344" stroke="#222233" stroke-width="1"/>
+  <rect x="9" y="16" width="14" height="2" fill="#aa2222" opacity="0.7"/>
+  <!-- Horned helmet -->
+  <rect x="11" y="4" width="10" height="9" rx="2" fill="#333344" stroke="#222233" stroke-width="1"/>
+  <polygon points="11,6 9,2 12,5" fill="#ddcc88"/>
+  <polygon points="21,6 23,2 20,5" fill="#ddcc88"/>
+  <!-- Orc face -->
+  <ellipse cx="16" cy="8" rx="4" ry="4" fill="#668833"/>
+  <circle cx="14.5" cy="7.5" r="0.8" fill="#aa2222"/>
+  <circle cx="17.5" cy="7.5" r="0.8" fill="#aa2222"/>
+  <rect x="14" y="11" width="1.5" height="2" rx="0.5" fill="#ddcc88"/>
+  <rect x="16.5" y="11" width="1.5" height="2" rx="0.5" fill="#ddcc88"/>
+  <!-- Axe -->
+  <line x1="23" y1="7" x2="25" y2="27" stroke="#222233" stroke-width="1.5"/>
+  <path d="M20,8 Q23,5 26,8 Q24,12 23,12 Z" fill="#333344" stroke="#222233" stroke-width="1"/>
+  <line x1="22" y1="8" x2="25" y2="9" stroke="#aabbcc" stroke-width="0.8"/>
+</svg>

--- a/web/public/sprites/warlord-kragg-3.svg
+++ b/web/public/sprites/warlord-kragg-3.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Warlord Kragg — frame 3 (body 1px down, right leg fwd, left leg back — mirror of 1) -->
+  <!-- Right leg forward 2px -->
+  <rect x="19" y="23" width="4" height="8" rx="1" fill="#333344" transform="rotate(-10,21,27)"/>
+  <!-- Left leg back -->
+  <rect x="9" y="23" width="4" height="8" rx="1" fill="#333344" transform="rotate(6,11,27)"/>
+  <!-- Spiked shoulder pads shifted 1px down -->
+  <rect x="4" y="12" width="7" height="5" rx="1" fill="#333344" stroke="#222233" stroke-width="0.8"/>
+  <polygon points="4,12 5,9 6,12" fill="#ddcc88"/>
+  <polygon points="8,12 9,9 10,12" fill="#ddcc88"/>
+  <rect x="21" y="12" width="7" height="5" rx="1" fill="#333344" stroke="#222233" stroke-width="0.8"/>
+  <polygon points="22,12 23,9 24,12" fill="#ddcc88"/>
+  <polygon points="26,12 27,9 28,12" fill="#ddcc88"/>
+  <!-- Broad armored torso shifted 1px down -->
+  <rect x="9" y="13" width="14" height="11" rx="1" fill="#333344" stroke="#222233" stroke-width="1"/>
+  <rect x="9" y="17" width="14" height="2" fill="#aa2222" opacity="0.7"/>
+  <!-- Horned helmet -->
+  <rect x="11" y="5" width="10" height="9" rx="2" fill="#333344" stroke="#222233" stroke-width="1"/>
+  <polygon points="11,7 9,3 12,6" fill="#ddcc88"/>
+  <polygon points="21,7 23,3 20,6" fill="#ddcc88"/>
+  <!-- Orc face -->
+  <ellipse cx="16" cy="9" rx="4" ry="4" fill="#668833"/>
+  <circle cx="14.5" cy="8.5" r="0.8" fill="#aa2222"/>
+  <circle cx="17.5" cy="8.5" r="0.8" fill="#aa2222"/>
+  <rect x="14" y="12" width="1.5" height="2" rx="0.5" fill="#ddcc88"/>
+  <rect x="16.5" y="12" width="1.5" height="2" rx="0.5" fill="#ddcc88"/>
+  <!-- Axe -->
+  <line x1="23" y1="8" x2="25" y2="28" stroke="#222233" stroke-width="1.5"/>
+  <path d="M20,9 Q23,6 26,9 Q24,13 23,13 Z" fill="#333344" stroke="#222233" stroke-width="1"/>
+  <line x1="22" y1="9" x2="25" y2="10" stroke="#aabbcc" stroke-width="0.8"/>
+</svg>

--- a/web/public/sprites/warlord-kragg.svg
+++ b/web/public/sprites/warlord-kragg.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Warlord Kragg — idle (battle-hardened orc warlord) -->
+  <!-- Legs -->
+  <rect x="11" y="22" width="4" height="8" rx="1" fill="#333344"/>
+  <rect x="17" y="22" width="4" height="8" rx="1" fill="#333344"/>
+  <!-- Spiked shoulder pads -->
+  <rect x="4" y="11" width="7" height="5" rx="1" fill="#333344" stroke="#222233" stroke-width="0.8"/>
+  <polygon points="4,11 5,8 6,11" fill="#ddcc88"/>
+  <polygon points="8,11 9,8 10,11" fill="#ddcc88"/>
+  <rect x="21" y="11" width="7" height="5" rx="1" fill="#333344" stroke="#222233" stroke-width="0.8"/>
+  <polygon points="22,11 23,8 24,11" fill="#ddcc88"/>
+  <polygon points="26,11 27,8 28,11" fill="#ddcc88"/>
+  <!-- Broad armored torso -->
+  <rect x="9" y="12" width="14" height="11" rx="1" fill="#333344" stroke="#222233" stroke-width="1"/>
+  <!-- Red accent stripe -->
+  <rect x="9" y="16" width="14" height="2" fill="#aa2222" opacity="0.7"/>
+  <!-- Horned helmet -->
+  <rect x="11" y="4" width="10" height="9" rx="2" fill="#333344" stroke="#222233" stroke-width="1"/>
+  <polygon points="11,6 9,2 12,5" fill="#ddcc88"/>
+  <polygon points="21,6 23,2 20,5" fill="#ddcc88"/>
+  <!-- Orc face (green skin) -->
+  <ellipse cx="16" cy="8" rx="4" ry="4" fill="#668833"/>
+  <!-- Eyes — fierce -->
+  <circle cx="14.5" cy="7.5" r="0.8" fill="#aa2222"/>
+  <circle cx="17.5" cy="7.5" r="0.8" fill="#aa2222"/>
+  <!-- Tusks -->
+  <rect x="14" y="11" width="1.5" height="2" rx="0.5" fill="#ddcc88"/>
+  <rect x="16.5" y="11" width="1.5" height="2" rx="0.5" fill="#ddcc88"/>
+  <!-- Large axe (right hand) -->
+  <line x1="23" y1="7" x2="25" y2="27" stroke="#222233" stroke-width="1.5"/>
+  <path d="M20,8 Q23,5 26,8 Q24,12 23,12 Z" fill="#333344" stroke="#222233" stroke-width="1"/>
+  <line x1="22" y1="8" x2="25" y2="9" stroke="#aabbcc" stroke-width="0.8"/>
+</svg>

--- a/web/public/sprites/wave-brawler-1.svg
+++ b/web/public/sprites/wave-brawler-1.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Wave Brawler — frame 1 (body 1px down, left leg fwd, right leg back) -->
+  <!-- Left leg forward 2px -->
+  <rect x="9" y="23" width="4" height="8" rx="1" fill="#2266aa" transform="rotate(10,11,27)"/>
+  <!-- Right leg back -->
+  <rect x="19" y="23" width="4" height="8" rx="1" fill="#2266aa" transform="rotate(-7,21,27)"/>
+  <!-- Feet -->
+  <ellipse cx="10" cy="30" rx="2.5" ry="1.2" fill="#1a4a88"/>
+  <ellipse cx="21" cy="30" rx="2.5" ry="1.2" fill="#1a4a88"/>
+  <!-- Muscular chest shifted 1px down -->
+  <rect x="9" y="13" width="14" height="11" rx="2" fill="#2266aa" stroke="#1a4a88" stroke-width="1"/>
+  <!-- Wave pattern -->
+  <path d="M9,19 Q12,17 15,19 Q18,21 21,19 Q22,18 23,19" fill="none" stroke="#aaddee" stroke-width="1.2" opacity="0.7"/>
+  <path d="M9,22 Q12,20 15,22 Q18,24 21,22 Q22,21 23,22" fill="none" stroke="#44aacc" stroke-width="0.8" opacity="0.5"/>
+  <!-- Head -->
+  <ellipse cx="16" cy="10" rx="4.5" ry="4.5" fill="#228899"/>
+  <circle cx="14.5" cy="9.5" r="0.8" fill="#002244"/>
+  <circle cx="17.5" cy="9.5" r="0.8" fill="#002244"/>
+  <!-- Arms / fists — left raised, right back -->
+  <rect x="5" y="15" width="4" height="7" rx="1" fill="#2266aa"/>
+  <path d="M5,16 Q3,13 5,15" fill="#228899"/>
+  <rect x="23" y="15" width="4" height="7" rx="1" fill="#2266aa"/>
+  <path d="M27,16 Q29,13 27,15" fill="#228899"/>
+  <!-- Raised fists -->
+  <rect x="5" y="12" width="4" height="3" rx="1" fill="#44aacc"/>
+  <rect x="23" y="15" width="4" height="3" rx="1" fill="#44aacc"/>
+  <ellipse cx="16" cy="15" rx="4" ry="2" fill="#aaddee" opacity="0.3"/>
+</svg>

--- a/web/public/sprites/wave-brawler-2.svg
+++ b/web/public/sprites/wave-brawler-2.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Wave Brawler — frame 2 (mid-stride, both legs near center) -->
+  <!-- Both legs centered -->
+  <rect x="12" y="22" width="4" height="8" rx="1" fill="#2266aa"/>
+  <rect x="16" y="22" width="4" height="8" rx="1" fill="#2266aa"/>
+  <!-- Feet -->
+  <ellipse cx="14" cy="30" rx="2.5" ry="1.2" fill="#1a4a88"/>
+  <ellipse cx="18" cy="30" rx="2.5" ry="1.2" fill="#1a4a88"/>
+  <!-- Muscular chest normal height -->
+  <rect x="9" y="12" width="14" height="11" rx="2" fill="#2266aa" stroke="#1a4a88" stroke-width="1"/>
+  <!-- Wave pattern -->
+  <path d="M9,18 Q12,16 15,18 Q18,20 21,18 Q22,17 23,18" fill="none" stroke="#aaddee" stroke-width="1.2" opacity="0.7"/>
+  <path d="M9,21 Q12,19 15,21 Q18,23 21,21 Q22,20 23,21" fill="none" stroke="#44aacc" stroke-width="0.8" opacity="0.5"/>
+  <!-- Head -->
+  <ellipse cx="16" cy="9" rx="4.5" ry="4.5" fill="#228899"/>
+  <circle cx="14.5" cy="8.5" r="0.8" fill="#002244"/>
+  <circle cx="17.5" cy="8.5" r="0.8" fill="#002244"/>
+  <!-- Arms / fists both at mid -->
+  <rect x="5" y="14" width="4" height="7" rx="1" fill="#2266aa"/>
+  <path d="M5,15 Q3,12 5,14" fill="#228899"/>
+  <rect x="23" y="14" width="4" height="7" rx="1" fill="#2266aa"/>
+  <path d="M27,15 Q29,12 27,14" fill="#228899"/>
+  <rect x="5" y="13" width="4" height="3" rx="1" fill="#44aacc"/>
+  <rect x="23" y="13" width="4" height="3" rx="1" fill="#44aacc"/>
+  <ellipse cx="16" cy="14" rx="4" ry="2" fill="#aaddee" opacity="0.3"/>
+</svg>

--- a/web/public/sprites/wave-brawler-3.svg
+++ b/web/public/sprites/wave-brawler-3.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Wave Brawler — frame 3 (body 1px down, right leg fwd, left leg back — mirror of 1) -->
+  <!-- Right leg forward 2px -->
+  <rect x="19" y="23" width="4" height="8" rx="1" fill="#2266aa" transform="rotate(-10,21,27)"/>
+  <!-- Left leg back -->
+  <rect x="9" y="23" width="4" height="8" rx="1" fill="#2266aa" transform="rotate(7,11,27)"/>
+  <!-- Feet -->
+  <ellipse cx="22" cy="30" rx="2.5" ry="1.2" fill="#1a4a88"/>
+  <ellipse cx="11" cy="30" rx="2.5" ry="1.2" fill="#1a4a88"/>
+  <!-- Muscular chest shifted 1px down -->
+  <rect x="9" y="13" width="14" height="11" rx="2" fill="#2266aa" stroke="#1a4a88" stroke-width="1"/>
+  <!-- Wave pattern -->
+  <path d="M9,19 Q12,17 15,19 Q18,21 21,19 Q22,18 23,19" fill="none" stroke="#aaddee" stroke-width="1.2" opacity="0.7"/>
+  <path d="M9,22 Q12,20 15,22 Q18,24 21,22 Q22,21 23,22" fill="none" stroke="#44aacc" stroke-width="0.8" opacity="0.5"/>
+  <!-- Head -->
+  <ellipse cx="16" cy="10" rx="4.5" ry="4.5" fill="#228899"/>
+  <circle cx="14.5" cy="9.5" r="0.8" fill="#002244"/>
+  <circle cx="17.5" cy="9.5" r="0.8" fill="#002244"/>
+  <!-- Arms / fists — right raised, left back -->
+  <rect x="5" y="15" width="4" height="7" rx="1" fill="#2266aa"/>
+  <path d="M5,16 Q3,13 5,15" fill="#228899"/>
+  <rect x="23" y="15" width="4" height="7" rx="1" fill="#2266aa"/>
+  <path d="M27,16 Q29,13 27,15" fill="#228899"/>
+  <!-- Raised fists -->
+  <rect x="5" y="15" width="4" height="3" rx="1" fill="#44aacc"/>
+  <rect x="23" y="12" width="4" height="3" rx="1" fill="#44aacc"/>
+  <ellipse cx="16" cy="15" rx="4" ry="2" fill="#aaddee" opacity="0.3"/>
+</svg>

--- a/web/public/sprites/wave-brawler.svg
+++ b/web/public/sprites/wave-brawler.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Wave Brawler — idle (muscular water fighter, bare-chested) -->
+  <!-- Legs -->
+  <rect x="11" y="22" width="4" height="8" rx="1" fill="#2266aa"/>
+  <rect x="17" y="22" width="4" height="8" rx="1" fill="#2266aa"/>
+  <!-- Feet -->
+  <ellipse cx="13" cy="30" rx="2.5" ry="1.2" fill="#1a4a88"/>
+  <ellipse cx="19" cy="30" rx="2.5" ry="1.2" fill="#1a4a88"/>
+  <!-- Muscular bare chest (wide) -->
+  <rect x="9" y="12" width="14" height="11" rx="2" fill="#2266aa" stroke="#1a4a88" stroke-width="1"/>
+  <!-- Wave pattern on body -->
+  <path d="M9,18 Q12,16 15,18 Q18,20 21,18 Q22,17 23,18" fill="none" stroke="#aaddee" stroke-width="1.2" opacity="0.7"/>
+  <path d="M9,21 Q12,19 15,21 Q18,23 21,21 Q22,20 23,21" fill="none" stroke="#44aacc" stroke-width="0.8" opacity="0.5"/>
+  <!-- Head -->
+  <ellipse cx="16" cy="9" rx="4.5" ry="4.5" fill="#228899"/>
+  <!-- Eyes -->
+  <circle cx="14.5" cy="8.5" r="0.8" fill="#002244"/>
+  <circle cx="17.5" cy="8.5" r="0.8" fill="#002244"/>
+  <!-- Fins on forearms (raised fists) -->
+  <rect x="5" y="14" width="4" height="7" rx="1" fill="#2266aa"/>
+  <path d="M5,15 Q3,12 5,14" fill="#228899"/>
+  <rect x="23" y="14" width="4" height="7" rx="1" fill="#2266aa"/>
+  <path d="M27,15 Q29,12 27,14" fill="#228899"/>
+  <!-- Raised fists -->
+  <rect x="5" y="13" width="4" height="3" rx="1" fill="#44aacc"/>
+  <rect x="23" y="13" width="4" height="3" rx="1" fill="#44aacc"/>
+  <!-- Foam white highlight on chest -->
+  <ellipse cx="16" cy="14" rx="4" ry="2" fill="#aaddee" opacity="0.3"/>
+</svg>

--- a/web/public/sprites/wind-sprite-1.svg
+++ b/web/public/sprites/wind-sprite-1.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Wind Sprite — frame 1 (body 1px lower, slight left tilt) -->
+  <!-- Swirling wisps trailing (shifted) -->
+  <path d="M16,19 Q8,23 6,29" stroke="#87ceeb" stroke-width="1.5" fill="none" opacity="0.6"/>
+  <path d="M16,19 Q24,23 26,29" stroke="#c8e8ff" stroke-width="1.5" fill="none" opacity="0.6"/>
+  <path d="M14,18 Q5,21 3,27" stroke="#aaaaff" stroke-width="1" fill="none" opacity="0.4"/>
+  <path d="M18,18 Q27,21 29,27" stroke="#aaaaff" stroke-width="1" fill="none" opacity="0.4"/>
+  <!-- Leaf-like wings (tilted left) -->
+  <path d="M15,14 Q7,10 6,15 Q9,17 15,15 Z" fill="#87ceeb" opacity="0.7"/>
+  <path d="M15,14 Q23,10 24,15 Q21,17 15,15 Z" fill="#c8e8ff" opacity="0.7"/>
+  <!-- Small round body 1px lower, left tilt -->
+  <circle cx="15.5" cy="18" r="6" fill="#87ceeb" stroke="#c8e8ff" stroke-width="0.8"/>
+  <circle cx="15.5" cy="17" r="4" fill="#c8e8ff" opacity="0.5"/>
+  <!-- Tiny face -->
+  <circle cx="14" cy="17.5" r="0.7" fill="#aaaaff"/>
+  <circle cx="17" cy="17.5" r="0.7" fill="#aaaaff"/>
+  <path d="M14,19 Q15.5,20.5 17,19" fill="none" stroke="#aaaaff" stroke-width="0.7"/>
+  <!-- White wisp swirl -->
+  <path d="M11,14 Q13,12 15,14" fill="none" stroke="#ffffff" stroke-width="0.8" opacity="0.8"/>
+  <path d="M19,14 Q17,12 15,14" fill="none" stroke="#ffffff" stroke-width="0.8" opacity="0.8"/>
+</svg>

--- a/web/public/sprites/wind-sprite-2.svg
+++ b/web/public/sprites/wind-sprite-2.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Wind Sprite — frame 2 (mid-hover, body at normal height) -->
+  <!-- Swirling wisps -->
+  <path d="M16,18 Q8,22 6,28" stroke="#87ceeb" stroke-width="1.5" fill="none" opacity="0.6"/>
+  <path d="M16,18 Q24,22 26,28" stroke="#c8e8ff" stroke-width="1.5" fill="none" opacity="0.6"/>
+  <path d="M14,17 Q5,20 3,26" stroke="#aaaaff" stroke-width="1" fill="none" opacity="0.4"/>
+  <path d="M18,17 Q27,20 29,26" stroke="#aaaaff" stroke-width="1" fill="none" opacity="0.4"/>
+  <!-- Wings (wider mid-hover) -->
+  <path d="M16,13 Q7,8 6,13 Q10,16 16,14 Z" fill="#87ceeb" opacity="0.8"/>
+  <path d="M16,13 Q25,8 26,13 Q22,16 16,14 Z" fill="#c8e8ff" opacity="0.8"/>
+  <!-- Small round body -->
+  <circle cx="16" cy="17" r="6" fill="#87ceeb" stroke="#c8e8ff" stroke-width="0.8"/>
+  <circle cx="16" cy="16" r="4" fill="#c8e8ff" opacity="0.5"/>
+  <!-- Tiny face -->
+  <circle cx="14.5" cy="16.5" r="0.7" fill="#aaaaff"/>
+  <circle cx="17.5" cy="16.5" r="0.7" fill="#aaaaff"/>
+  <path d="M14.5,18 Q16,19.5 17.5,18" fill="none" stroke="#aaaaff" stroke-width="0.7"/>
+  <!-- White wisp swirl -->
+  <path d="M12,13 Q14,11 16,13" fill="none" stroke="#ffffff" stroke-width="0.8" opacity="0.8"/>
+  <path d="M20,13 Q18,11 16,13" fill="none" stroke="#ffffff" stroke-width="0.8" opacity="0.8"/>
+</svg>

--- a/web/public/sprites/wind-sprite-3.svg
+++ b/web/public/sprites/wind-sprite-3.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Wind Sprite — frame 3 (body 1px lower, tilt opposite/right — mirror of 1) -->
+  <!-- Swirling wisps trailing -->
+  <path d="M16,19 Q8,23 6,29" stroke="#87ceeb" stroke-width="1.5" fill="none" opacity="0.6"/>
+  <path d="M16,19 Q24,23 26,29" stroke="#c8e8ff" stroke-width="1.5" fill="none" opacity="0.6"/>
+  <path d="M14,18 Q5,21 3,27" stroke="#aaaaff" stroke-width="1" fill="none" opacity="0.4"/>
+  <path d="M18,18 Q27,21 29,27" stroke="#aaaaff" stroke-width="1" fill="none" opacity="0.4"/>
+  <!-- Leaf-like wings (tilted right) -->
+  <path d="M17,14 Q9,10 8,15 Q11,17 17,15 Z" fill="#87ceeb" opacity="0.7"/>
+  <path d="M17,14 Q25,10 26,15 Q23,17 17,15 Z" fill="#c8e8ff" opacity="0.7"/>
+  <!-- Small round body 1px lower, right tilt -->
+  <circle cx="16.5" cy="18" r="6" fill="#87ceeb" stroke="#c8e8ff" stroke-width="0.8"/>
+  <circle cx="16.5" cy="17" r="4" fill="#c8e8ff" opacity="0.5"/>
+  <!-- Tiny face -->
+  <circle cx="15" cy="17.5" r="0.7" fill="#aaaaff"/>
+  <circle cx="18" cy="17.5" r="0.7" fill="#aaaaff"/>
+  <path d="M15,19 Q16.5,20.5 18,19" fill="none" stroke="#aaaaff" stroke-width="0.7"/>
+  <!-- White wisp swirl -->
+  <path d="M13,14 Q15,12 17,14" fill="none" stroke="#ffffff" stroke-width="0.8" opacity="0.8"/>
+  <path d="M21,14 Q19,12 17,14" fill="none" stroke="#ffffff" stroke-width="0.8" opacity="0.8"/>
+</svg>

--- a/web/public/sprites/wind-sprite.svg
+++ b/web/public/sprites/wind-sprite.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Wind Sprite — idle (small wind elemental, wispy and magical) -->
+  <!-- Swirling wind wisps trailing -->
+  <path d="M16,18 Q8,22 6,28" stroke="#87ceeb" stroke-width="1.5" fill="none" opacity="0.6"/>
+  <path d="M16,18 Q24,22 26,28" stroke="#c8e8ff" stroke-width="1.5" fill="none" opacity="0.6"/>
+  <path d="M14,17 Q5,20 3,26" stroke="#aaaaff" stroke-width="1" fill="none" opacity="0.4"/>
+  <path d="M18,17 Q27,20 29,26" stroke="#aaaaff" stroke-width="1" fill="none" opacity="0.4"/>
+  <!-- Leaf-like wings -->
+  <path d="M16,13 Q8,9 7,14 Q10,16 16,14 Z" fill="#87ceeb" opacity="0.7"/>
+  <path d="M16,13 Q24,9 25,14 Q22,16 16,14 Z" fill="#c8e8ff" opacity="0.7"/>
+  <!-- Small round body -->
+  <circle cx="16" cy="17" r="6" fill="#87ceeb" stroke="#c8e8ff" stroke-width="0.8"/>
+  <circle cx="16" cy="16" r="4" fill="#c8e8ff" opacity="0.5"/>
+  <!-- Tiny face -->
+  <circle cx="14.5" cy="16.5" r="0.7" fill="#aaaaff"/>
+  <circle cx="17.5" cy="16.5" r="0.7" fill="#aaaaff"/>
+  <!-- Smile -->
+  <path d="M14.5,18 Q16,19.5 17.5,18" fill="none" stroke="#aaaaff" stroke-width="0.7"/>
+  <!-- White wisp swirl details -->
+  <path d="M12,13 Q14,11 16,13" fill="none" stroke="#ffffff" stroke-width="0.8" opacity="0.8"/>
+  <path d="M20,13 Q18,11 16,13" fill="none" stroke="#ffffff" stroke-width="0.8" opacity="0.8"/>
+</svg>


### PR DESCRIPTION
Closes #606
Closes #609

## Summary

- Adds 32×32 viewBox SVGs for 10 missing unit cards (batch 6/17) and 10 missing building cards (batch 9/17)
- Unit cards get 4 files each: idle base + 3 walk animation frames (`-1`, `-2`, `-3`)
- Building cards get 1 file each
- 50 files total in `web/public/sprites/`
- `healer-s-hut.svg` and `shadow-academy.svg` reuse content from existing orphan files `healer-hut.svg` and `shadow-acad.svg`

## Units (batch 6/17)

| Unit | Files |
|---|---|
| Tidal Sovereign | `tidal-sovereign.svg` + walk frames ✅ |
| Tide Runner | `tide-runner.svg` + walk frames ✅ |
| Tide Stalker | `tide-stalker.svg` + walk frames ✅ |
| Vault Drone | `vault-drone.svg` + walk frames (in progress) |
| Vault Guardian | `vault-guardian.svg` + walk frames (in progress) |
| Vine Colossus | `vine-colossus.svg` + walk frames (in progress) |
| Vine Runner | `vine-runner.svg` + walk frames (in progress) |
| Warlord Kragg | `warlord-kragg.svg` + walk frames (in progress) |
| Wave Brawler | `wave-brawler.svg` + walk frames (in progress) |
| Wind Sprite | `wind-sprite.svg` + walk frames (in progress) |

## Buildings (batch 9/17)

| Building | File |
|---|---|
| Gear Assembly | `gear-assembly.svg` ✅ |
| Gear Wall | `gear-wall.svg` ✅ |
| Gust Wall | `gust-wall.svg` ✅ |
| Healer's Hut | `healer-s-hut.svg` ✅ |
| Living Thornwall | `living-thornwall.svg` ✅ |
| Pressure Valve | `pressure-valve.svg` ✅ |
| Salvage Dock | `salvage-dock.svg` ✅ |
| Shadow Academy | `shadow-academy.svg` ✅ |
| Sky Beacon | `sky-beacon.svg` ✅ |
| Stone Wall | `stone-wall.svg` ✅ |

## Test plan

- [ ] Verify all SVG files render correctly at 32×32 in browser
- [ ] Confirm unit walk frame animation plays in-lane (frames -1/-2/-3 cycle)
- [ ] Check card display at 64×40 px — no clipping
- [ ] Confirm building sprites display on card and in-lane

https://claude.ai/code/session_01NKY7mThgFaX39Re3RBapuE