### PR TITLE
feat(shop): badge on title-screen Shop button + dim unowned sell slots (#817)

### DIFF
--- a/web/src/components/ShopScreen.tsx
+++ b/web/src/components/ShopScreen.tsx
@@ -326,7 +326,7 @@ export function ShopScreen({ crystals, onBuyCrystalPack, onCrystalsChange, onBac
                   </div>
                 )}
                 <button
-                  className="action-btn"
+                  className={`action-btn${!hasItem ? ' action-btn--dim' : ''}`}
                   onClick={() => handleSellClick(slotId, hasItem)}
                   disabled={!hasItem || alreadySold}
                 >

--- a/web/src/components/TitleScreen.tsx
+++ b/web/src/components/TitleScreen.tsx
@@ -4,6 +4,8 @@ import { loadDeck, loadCollection, deckTotalCards, isDeckValid, COPIES_MAX, load
 import { loadRun } from '../game/questline'
 import { getCardCatalog } from '../game/cards'
 import { hasUnclaimedAchievements } from '../game/achievements'
+import { getDailyShopSellSlots } from '../game/shopSchedule'
+import { loadInventory } from '../game/dailyLogin'
 import { TitleButton } from './TitleButton'
 import { SpriteImg } from './SpriteImg'
 import { TitleIdleAnimation } from './TitleIdleAnimation'
@@ -63,6 +65,7 @@ export function TitleScreen({ crystals, onPlay, onEndless, onCampaign, onCollect
   const catalogTotal        = catalog.length
   const achievementAlert    = hasUnclaimedAchievements()
   const collectionAlert     = collection.some(e => e.count > COPIES_MAX)
+  const shopAlert           = (() => { const inv = loadInventory(); return getDailyShopSellSlots().some(s => inv.some(i => i.id === s.id)) })()
   const winStreak           = loadWinStreak()
   const bestStreak          = loadBestStreak()
   const dailyChallenge      = getDailyChallengeState()
@@ -237,7 +240,7 @@ export function TitleScreen({ crystals, onPlay, onEndless, onCampaign, onCollect
         <div className="title-nav-grid">
           <TitleButton onClick={onDeckBuilder}>DECK BUILDER</TitleButton>
           <TitleButton onClick={onCollection} badge={collectionAlert}>COLLECTION</TitleButton>
-          <TitleButton onClick={onShop}>🛒 SHOP</TitleButton>
+          <TitleButton onClick={onShop} badge={shopAlert}>🛒 SHOP</TitleButton>
           <TitleButton onClick={onHeroCards}>🦸 HEROES</TitleButton>
           <TitleButton onClick={onInventory}>🎒 INVENTORY</TitleButton>
           <TitleButton onClick={onAchievements} badge={achievementAlert}>🏆 ACHIEVEMENTS</TitleButton>


### PR DESCRIPTION
## Summary

- **Shop badge on title screen:** the `🛒 SHOP` button now shows the `!` badge whenever the player owns at least one item that the shop is buying today (`getDailyShopSellSlots` matched against `loadInventory`).
- **Dim unowned sell buttons:** in `ShopScreen`, sell buttons for items the player doesn't own now receive `action-btn--dim` (in addition to being `disabled`), giving a clear visual signal that the slot isn't actionable.

## Test plan

- [ ] Have an item in inventory that matches a daily sell slot → open title screen → Shop button shows `!` badge
- [ ] Have no matching sell-slot items → Shop button shows no badge
- [ ] Open shop → sell slots for items you own show normal green button; slots for items you don't own show dimmed (faded border + text) button
- [ ] Dimmed sell buttons are non-interactive (disabled)
- [ ] Build passes (`npm run build`) — confirmed clean ✓

Closes #817

https://claude.ai/code/session_01S87ZMvjtAhbqoGQunNLWXx

---
_Generated by [Claude Code](https://claude.ai/code/session_01S87ZMvjtAhbqoGQunNLWXx)_