### PR TITLE
Add claim-all button and sort unclaimed achievements to top

### DIFF
--- a/web/src/components/AchievementsScreen.tsx
+++ b/web/src/components/AchievementsScreen.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback } from 'react'
 import {
   ACHIEVEMENT_DEFS, AchievementDef, AchievementCategory,
-  loadAchievementSave, claimAchievementReward,
+  loadAchievementSave, claimAchievementReward, claimAllAchievementRewards,
 } from '../game/achievements'
 import { OverlayScreen } from './OverlayScreen'
 import { addCardsToCollection, loadCrystals, saveCrystals } from '../game/collection'
@@ -86,7 +86,43 @@ export function AchievementsScreen({ onBack, onCrystalsChanged }: Props) {
     setTimeout(() => setJustClaimed(null), 2000)
   }, [onCrystalsChanged])
 
-  const defs = ACHIEVEMENT_DEFS.filter(d => d.category === activeCategory)
+  const handleClaimAll = useCallback(() => {
+    const results = claimAllAchievementRewards()
+    if (results.length === 0) return
+
+    let crystalDelta = 0
+    for (const { reward } of results) {
+      if (reward.type === 'crystals' && reward.crystals) crystalDelta += reward.crystals
+      if (reward.bonusCrystals)                          crystalDelta += reward.bonusCrystals
+      if (reward.type === 'cards' && reward.cardName && reward.count) {
+        addCardsToCollection([{ cardName: reward.cardName, count: reward.count }])
+      }
+      if (reward.bonusCards) {
+        addCardsToCollection(reward.bonusCards)
+      }
+      if (reward.type === 'item' && reward.item) {
+        const full = ALL_ITEMS.find(i => i.id === reward.item!.id) ?? { ...reward.item, lore: '', weight: 1 }
+        addToInventory(full)
+      }
+      if (reward.avatarSlug) {
+        addUnlockedAvatar(reward.avatarSlug)
+      }
+    }
+    if (crystalDelta > 0) {
+      const next = loadCrystals() + crystalDelta
+      saveCrystals(next)
+      onCrystalsChanged(next)
+    }
+    setSave(loadAchievementSave())
+  }, [onCrystalsChanged])
+
+  const defs = ACHIEVEMENT_DEFS
+    .filter(d => d.category === activeCategory)
+    .sort((a, b) => {
+      const aUnclaimed = save.unlocked[a.id] && !save.claimed[a.id] ? 0 : 1
+      const bUnclaimed = save.unlocked[b.id] && !save.claimed[b.id] ? 0 : 1
+      return aUnclaimed - bUnclaimed
+    })
 
   // Count claimable in each category for badge
   function claimableCount(cat: AchievementCategory) {
@@ -96,9 +132,10 @@ export function AchievementsScreen({ onBack, onCrystalsChanged }: Props) {
   }
 
   // Stats
-  const totalUnlocked = Object.values(save.unlocked).filter(Boolean).length
-  const totalClaimed  = Object.values(save.claimed).filter(Boolean).length
-  const total         = ACHIEVEMENT_DEFS.length
+  const totalUnlocked  = Object.values(save.unlocked).filter(Boolean).length
+  const totalClaimed   = Object.values(save.claimed).filter(Boolean).length
+  const total          = ACHIEVEMENT_DEFS.length
+  const totalClaimable = ACHIEVEMENT_DEFS.filter(d => save.unlocked[d.id] && !save.claimed[d.id]).length
 
   return (
     <OverlayScreen
@@ -124,7 +161,14 @@ export function AchievementsScreen({ onBack, onCrystalsChanged }: Props) {
         })}
       </div>
 
-      <div className="ach-category-label">{CATEGORY_LABELS[activeCategory]}</div>
+      <div className="ach-claim-all-bar">
+        <div className="ach-category-label">{CATEGORY_LABELS[activeCategory]}</div>
+        {totalClaimable > 0 && (
+          <button className="action-btn ach-claim-all-btn" onClick={handleClaimAll}>
+            CLAIM ALL ({totalClaimable})
+          </button>
+        )}
+      </div>
 
       <div className="ach-list">
         {defs.map(def => {

--- a/web/src/game/achievements.ts
+++ b/web/src/game/achievements.ts
@@ -139,6 +139,19 @@ export function claimAchievementReward(achievementId: string): AchievementReward
   return def.reward
 }
 
+/** Claim all unlocked-but-unclaimed achievements at once. Returns each claimed reward. */
+export function claimAllAchievementRewards(): { def: AchievementDef; reward: AchievementReward }[] {
+  const save = loadAchievementSave()
+  const results: { def: AchievementDef; reward: AchievementReward }[] = []
+  for (const def of ACHIEVEMENT_DEFS) {
+    if (!save.unlocked[def.id] || save.claimed[def.id]) continue
+    save.claimed[def.id] = true
+    results.push({ def, reward: def.reward })
+  }
+  if (results.length > 0) saveAchievementSave(save)
+  return results
+}
+
 // ─── Helper: build kill achievement pair ─────────────────
 
 function killPair(

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -6675,11 +6675,23 @@ body {
   justify-content: center;
 }
 
+.ach-claim-all-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid #222;
+}
+
 .ach-category-label {
   padding: 6px 12px 4px;
   font-size: 0.786rem;
   color: var(--game-text-color-muted);
-  border-bottom: 1px solid #222;
+}
+
+.ach-claim-all-btn {
+  margin: 2px 12px;
+  font-size: 0.714rem;
+  padding: 3px 10px;
 }
 
 .ach-list {


### PR DESCRIPTION
## Summary

- Adds a **CLAIM ALL (n)** button to the achievements page that appears whenever there are unclaimed rewards; clicking it processes all unlocked-but-unclaimed achievements across every category in a single operation
- Unclaimed achievements are now sorted to the top of each category list so they're immediately visible
- New `claimAllAchievementRewards()` helper in `achievements.ts` claims all eligible achievements in one localStorage write

## Test plan

- [ ] Open the achievements page with some unlocked-but-unclaimed achievements — confirm they appear at the top of the list
- [ ] Verify the **CLAIM ALL (n)** button appears showing the correct count
- [ ] Click CLAIM ALL and confirm all rewards (crystals, cards, items, avatars) are granted and the button disappears
- [ ] Confirm individual CLAIM buttons still work as before
- [ ] Confirm the button is hidden when there are no unclaimed achievements

Closes #818

https://claude.ai/code/session_01KYwKELJAp7RtQzz8EemH5h

---
_Generated by [Claude Code](https://claude.ai/code/session_01KYwKELJAp7RtQzz8EemH5h)_