### PR TITLE
feat(minigame): cloud-sync Fruit Machine Grand jackpot (#819)

### DIFF
--- a/web/src/components/minigames/FruitMachine.tsx
+++ b/web/src/components/minigames/FruitMachine.tsx
@@ -18,6 +18,11 @@
 import React, { useState, useRef, useEffect } from 'react'
 import { loadCrystals, saveCrystals } from '../../game/collection'
 import { logError } from '../../logger'
+import {
+  fetchGrandJackpot,
+  incrementGrandJackpot,
+  claimAndResetGrandJackpot,
+} from '../../game/fruitMachineJackpot'
 
 interface Props {
   onDone: (ticketsEarned: number) => void
@@ -223,6 +228,21 @@ export function FruitMachine({ onDone }: Props) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
+  // Fetch live grand jackpot from Firestore on mount, then poll every 30 s
+  useEffect(() => {
+    let cancelled = false
+    function refresh() {
+      fetchGrandJackpot().then(val => {
+        if (cancelled) return
+        grandJackpotRef.current = val
+        setGrandJackpot(val)
+      })
+    }
+    refresh()
+    const timer = setInterval(refresh, 30_000)
+    return () => { cancelled = true; clearInterval(timer) }
+  }, [])
+
   // Auto cash-out when out of credits
   useEffect(() => {
     if (phase === 'idle' && credits <= 0) {
@@ -288,17 +308,18 @@ export function FruitMachine({ onDone }: Props) {
         setPhase('jackpot-win')
         break
       case 'jackpot-grand': {
-        const amount = grandJackpotRef.current
         const resetVal = JACKPOT_TIERS[3].base
-        grandJackpotRef.current = resetVal
-        setGrandJackpot(resetVal)
-        try { localStorage.setItem('fm_grand', String(resetVal)) } catch (e) { logError('fm_grand reset', { error: String(e) }) }
-        setCredits(c => c + amount)
-        setJackpotWon({ tier: 'Grand', amount })
-        boardPosRef.current = 0
-        setBoardPos(0)
-        try { localStorage.setItem('fm_board_pos', '0') } catch (e) { logError('fm_board_pos grand reset', { error: String(e) }) }
-        setPhase('jackpot-win')
+        // Claim via transaction so two simultaneous winners can't both get the full pot
+        claimAndResetGrandJackpot().then(amount => {
+          grandJackpotRef.current = resetVal
+          setGrandJackpot(resetVal)
+          setCredits(c => c + amount)
+          setJackpotWon({ tier: 'Grand', amount })
+          boardPosRef.current = 0
+          setBoardPos(0)
+          try { localStorage.setItem('fm_board_pos', '0') } catch (e) { logError('fm_board_pos grand reset', { error: String(e) }) }
+          setPhase('jackpot-win')
+        })
         break
       }
     }
@@ -409,11 +430,12 @@ function regressBoardBy(steps: number) {
     ladderSpinRef.current = true
     setRecentlyHeld([...held] as [boolean, boolean, boolean])
 
-    // Grand jackpot grows by 1 every spin
+    // Grand jackpot grows by 1 every spin — increment server-side and mirror locally
     const newGrand = grandJackpotRef.current + 1
     grandJackpotRef.current = newGrand
     setGrandJackpot(newGrand)
     try { localStorage.setItem('fm_grand', String(newGrand)) } catch (e) { logError('fm_grand save', { error: String(e) }) }
+    incrementGrandJackpot()
 
     setPhase('spinning')
     const spinCost = freeSpin ? 0 : 1

--- a/web/src/game/fruitMachineJackpot.ts
+++ b/web/src/game/fruitMachineJackpot.ts
@@ -1,0 +1,71 @@
+// Cloud sync for the Fruit Machine Grand jackpot.
+// A single shared Firestore document holds the live pot; every spin increments
+// it atomically and a transaction serialises wins to prevent two players
+// claiming the same pot simultaneously.
+
+import {
+  doc, getDoc, setDoc, runTransaction, increment, Timestamp,
+} from 'firebase/firestore'
+import { db } from '../firebase'
+import { logError } from '../logger'
+
+const JACKPOT_DOC = doc(db, 'globalState', 'fruitMachineJackpot')
+const GRAND_BASE = 500
+const LOCAL_KEY = 'fm_grand'
+
+// Required Firestore security rules:
+//   match /globalState/fruitMachineJackpot {
+//     allow read: if true;
+//     allow write: if request.auth != null;
+//   }
+
+/** Reads the live jackpot from Firestore; falls back to localStorage on error. */
+export async function fetchGrandJackpot(): Promise<number> {
+  try {
+    const snap = await getDoc(JACKPOT_DOC)
+    if (snap.exists()) {
+      const val = snap.data().value as number
+      try { localStorage.setItem(LOCAL_KEY, String(val)) } catch { /* ignore */ }
+      return val
+    }
+    // Doc doesn't exist yet — seed it with the local value.
+    const local = localJackpot()
+    await setDoc(JACKPOT_DOC, { value: local, updatedAt: Timestamp.now() })
+    return local
+  } catch {
+    return localJackpot()
+  }
+}
+
+/** Atomically increments the shared jackpot by 1 per spin (fire-and-forget). */
+export function incrementGrandJackpot(): void {
+  setDoc(JACKPOT_DOC, { value: increment(1), updatedAt: Timestamp.now() }, { merge: true })
+    .catch(e => logError('fm_grand increment', { error: String(e) }))
+}
+
+/**
+ * Transaction: reads the current pot, resets it to GRAND_BASE, returns the
+ * amount the winner receives. Safe against two simultaneous winners.
+ */
+export async function claimAndResetGrandJackpot(): Promise<number> {
+  try {
+    const won = await runTransaction(db, async tx => {
+      const snap = await tx.get(JACKPOT_DOC)
+      const current = snap.exists() ? (snap.data().value as number) : GRAND_BASE
+      tx.set(JACKPOT_DOC, { value: GRAND_BASE, updatedAt: Timestamp.now() })
+      return current
+    })
+    try { localStorage.setItem(LOCAL_KEY, String(GRAND_BASE)) } catch { /* ignore */ }
+    return won
+  } catch (e) {
+    logError('fm_grand claim', { error: String(e) })
+    // Fall back: award local value and reset locally.
+    const local = localJackpot()
+    try { localStorage.setItem(LOCAL_KEY, String(GRAND_BASE)) } catch { /* ignore */ }
+    return local
+  }
+}
+
+function localJackpot(): number {
+  try { return parseInt(localStorage.getItem(LOCAL_KEY) ?? String(GRAND_BASE), 10) } catch { return GRAND_BASE }
+}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **New file `web/src/game/fruitMachineJackpot.ts`** — three Firestore helpers:
  - `fetchGrandJackpot()` — reads `globalState/fruitMachineJackpot`, falls back to `localStorage` when offline
  - `incrementGrandJackpot()` — `FieldValue.increment(1)` per spin, fire-and-forget (atomic counter, no lock needed)
  - `claimAndResetGrandJackpot()` — Firestore transaction: reads current pot, resets to 500, returns winner's amount (prevents two simultaneous winners sharing the same pot)
- **`FruitMachine.tsx`**:
  - On mount: fetch live jackpot from Firestore; poll every 30 s so the display stays current across all players
  - Each spin: call `incrementGrandJackpot()` alongside the existing optimistic local `+1`
  - Grand jackpot win: use `claimAndResetGrandJackpot()` instead of a plain local reset

## Firestore security rules needed

Add to your Firestore rules before merging:

```
match /globalState/fruitMachineJackpot {
  allow read: if true;
  allow write: if request.auth != null;
}
```

## Test plan

- [ ] Open Fruit Machine in two separate browser tabs; verify the Grand jackpot display is the same in both and increments as you spin in either tab
- [ ] Simulate offline (DevTools → Network: Offline) — game should still function with local value
- [ ] In Firestore console, manually set `globalState/fruitMachineJackpot.value` to a high number; open the game and verify the display updates within 30 s

Closes #819

https://claude.ai/code/session_015mX2eeGJeNR7tPEnk6Guxc
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_015mX2eeGJeNR7tPEnk6Guxc)_