### PR TITLE
Add missing card SVGs — Batches 7 & 8 (issues #607 & #608)

### DIFF
--- a/web/public/sprites/aerie-roost.svg
+++ b/web/public/sprites/aerie-roost.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Tall wooden post -->
+  <rect x="14" y="10" width="4" height="20" rx="1" fill="#7a5a2a"/>
+  <line x1="15" y1="10" x2="15" y2="30" stroke="#5a3a0a" stroke-width="0.6"/>
+  <!-- Cross-beam support -->
+  <rect x="6" y="22" width="20" height="3" rx="1" fill="#8a6a3a"/>
+  <rect x="6" y="22" width="20" height="1" fill="#6a4a1a"/>
+  <!-- Diagonal braces -->
+  <line x1="16" y1="10" x2="7" y2="22" stroke="#6a4a1a" stroke-width="1.5"/>
+  <line x1="16" y1="10" x2="25" y2="22" stroke="#6a4a1a" stroke-width="1.5"/>
+  <!-- Platform/nest at top -->
+  <ellipse cx="16" cy="10" rx="8" ry="3" fill="#6a4a1a"/>
+  <ellipse cx="16" cy="9" rx="7" ry="2.5" fill="#8a6a3a"/>
+  <!-- Nest material (twigs) -->
+  <line x1="10" y1="9" x2="22" y2="8" stroke="#5a3a0a" stroke-width="0.8"/>
+  <line x1="11" y1="11" x2="21" y2="9" stroke="#5a3a0a" stroke-width="0.8"/>
+  <line x1="9" y1="10" x2="14" y2="7" stroke="#5a3a0a" stroke-width="0.7"/>
+  <line x1="18" y1="7" x2="23" y2="10" stroke="#5a3a0a" stroke-width="0.7"/>
+  <!-- Bird perched on nest -->
+  <ellipse cx="16" cy="7" rx="3" ry="2" fill="#ccaa44"/>
+  <ellipse cx="18" cy="6.5" rx="1.5" ry="1.2" fill="#ddbb55"/>
+  <!-- Bird wing -->
+  <path d="M14,7 Q11,5 12,8" fill="#ccaa44"/>
+  <!-- Bird eye -->
+  <circle cx="18.5" cy="6.2" r="0.5" fill="#222"/>
+  <!-- Bird beak -->
+  <polygon points="19.5,6.5 21,6.2 19.5,7" fill="#e87a22"/>
+  <!-- Small perch birds on beam -->
+  <ellipse cx="9" cy="21" rx="1.5" ry="1" fill="#aaaaaa"/>
+  <ellipse cx="23" cy="21" rx="1.5" ry="1" fill="#aaaaaa"/>
+  <!-- Ground base -->
+  <rect x="11" y="28" width="10" height="3" rx="1" fill="#5a3a0a"/>
+</svg>

--- a/web/public/sprites/ancient-altar.svg
+++ b/web/public/sprites/ancient-altar.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground -->
+  <ellipse cx="16" cy="30" rx="14" ry="2.5" fill="#4a3a2a"/>
+  <!-- Standing stone monoliths -->
+  <rect x="3" y="10" width="5" height="20" rx="1" fill="#6a6a6a"/>
+  <rect x="3.5" y="10" width="4" height="5" fill="#7a7a7a"/>
+  <rect x="24" y="10" width="5" height="20" rx="1" fill="#6a6a6a"/>
+  <rect x="24.5" y="10" width="4" height="5" fill="#7a7a7a"/>
+  <!-- Capstone across top -->
+  <rect x="1" y="8" width="30" height="4" rx="1" fill="#5a5a5a"/>
+  <rect x="1" y="8" width="30" height="2" fill="#6a6a6a"/>
+  <!-- Central altar stone -->
+  <rect x="9" y="18" width="14" height="10" rx="1" fill="#5a5050"/>
+  <rect x="9" y="18" width="14" height="3" fill="#6a6060"/>
+  <!-- Sacrificial bowl on altar -->
+  <ellipse cx="16" cy="19" rx="4" ry="2" fill="#3a2a1a"/>
+  <ellipse cx="16" cy="18.5" rx="3" ry="1.5" fill="#1a1010"/>
+  <!-- Glowing energy in bowl -->
+  <ellipse cx="16" cy="18" rx="2" ry="1" fill="#aa44ff" opacity="0.8"/>
+  <ellipse cx="16" cy="17.5" rx="1.2" ry="0.8" fill="#dd88ff" opacity="0.7"/>
+  <!-- Energy beam rising -->
+  <line x1="16" y1="6" x2="16" y2="17" stroke="#9922cc" stroke-width="2" opacity="0.6"/>
+  <ellipse cx="16" cy="5" rx="3" ry="2" fill="#9922cc" opacity="0.5"/>
+  <ellipse cx="16" cy="5" rx="1.5" ry="1" fill="#cc66ff" opacity="0.7"/>
+  <!-- Runes on monoliths -->
+  <line x1="5" y1="14" x2="7" y2="16" stroke="#9922cc" stroke-width="0.8" opacity="0.8"/>
+  <line x1="7" y1="14" x2="5" y2="16" stroke="#9922cc" stroke-width="0.8" opacity="0.8"/>
+  <line x1="25" y1="14" x2="27" y2="16" stroke="#9922cc" stroke-width="0.8" opacity="0.8"/>
+  <line x1="27" y1="14" x2="25" y2="16" stroke="#9922cc" stroke-width="0.8" opacity="0.8"/>
+  <!-- Runes on altar face -->
+  <line x1="11" y1="22" x2="15" y2="22" stroke="#7711aa" stroke-width="0.8" opacity="0.7"/>
+  <line x1="13" y1="20.5" x2="13" y2="23.5" stroke="#7711aa" stroke-width="0.8" opacity="0.7"/>
+  <line x1="17" y1="22" x2="21" y2="22" stroke="#7711aa" stroke-width="0.8" opacity="0.7"/>
+  <line x1="19" y1="20.5" x2="19" y2="23.5" stroke="#7711aa" stroke-width="0.8" opacity="0.7"/>
+  <!-- Magic sparks around -->
+  <circle cx="4" cy="20" r="0.8" fill="#aa44ff" opacity="0.7"/>
+  <circle cx="28" cy="18" r="0.8" fill="#cc66ff" opacity="0.7"/>
+  <circle cx="6" cy="26" r="0.6" fill="#9922cc" opacity="0.5"/>
+  <circle cx="26" cy="24" r="0.6" fill="#aa44ff" opacity="0.5"/>
+</svg>

--- a/web/public/sprites/ancient-barracks.svg
+++ b/web/public/sprites/ancient-barracks.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#3a2a1a" opacity="0.5"/>
+  <!-- Main stone wall -->
+  <rect x="2" y="14" width="28" height="16" rx="1" fill="#7a6a4a"/>
+  <rect x="2" y="14" width="28" height="3" fill="#6a5a3a"/>
+  <!-- Stone block lines -->
+  <line x1="2" y1="18" x2="30" y2="18" stroke="#5a4a2a" stroke-width="0.6"/>
+  <line x1="2" y1="22" x2="30" y2="22" stroke="#5a4a2a" stroke-width="0.6"/>
+  <line x1="2" y1="26" x2="30" y2="26" stroke="#5a4a2a" stroke-width="0.6"/>
+  <line x1="9" y1="18" x2="9" y2="30" stroke="#5a4a2a" stroke-width="0.6"/>
+  <line x1="16" y1="14" x2="16" y2="30" stroke="#5a4a2a" stroke-width="0.6"/>
+  <line x1="23" y1="18" x2="23" y2="30" stroke="#5a4a2a" stroke-width="0.6"/>
+  <!-- Roof (ancient pitched stone) -->
+  <polygon points="0,14 16,4 32,14" fill="#5a4a2a"/>
+  <polygon points="2,14 16,6 30,14" fill="#6a5a3a"/>
+  <!-- Roof ridge -->
+  <line x1="16" y1="4" x2="16" y2="14" stroke="#4a3a1a" stroke-width="1"/>
+  <!-- Battlements -->
+  <rect x="3" y="11" width="4" height="4" rx="0.5" fill="#6a5a3a"/>
+  <rect x="10" y="11" width="4" height="4" rx="0.5" fill="#6a5a3a"/>
+  <rect x="18" y="11" width="4" height="4" rx="0.5" fill="#6a5a3a"/>
+  <rect x="25" y="11" width="4" height="4" rx="0.5" fill="#6a5a3a"/>
+  <!-- Door arch -->
+  <path d="M12,30 L12,22 Q16,18 20,22 L20,30 Z" fill="#2a1a0a"/>
+  <!-- Ivy/moss on wall -->
+  <path d="M2,16 Q4,14 5,17 Q3,19 2,18 Z" fill="#3a6a1a" opacity="0.7"/>
+  <path d="M27,17 Q29,14 30,16 Q29,20 27,19 Z" fill="#3a6a1a" opacity="0.7"/>
+  <path d="M7,22 Q9,20 10,23 Q8,25 7,24 Z" fill="#3a6a1a" opacity="0.6"/>
+  <!-- Banner -->
+  <line x1="16" y1="4" x2="16" y2="1" stroke="#4a3a1a" stroke-width="1"/>
+  <polygon points="16,1 22,2.5 16,4" fill="#8b2222"/>
+</svg>

--- a/web/public/sprites/ancient-grove.svg
+++ b/web/public/sprites/ancient-grove.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Central ancient tree trunk -->
+  <rect x="13" y="18" width="6" height="13" rx="2" fill="#6b4226"/>
+  <line x1="15" y1="18" x2="15" y2="31" stroke="#4a2a10" stroke-width="0.8"/>
+  <line x1="18" y1="18" x2="18" y2="31" stroke="#4a2a10" stroke-width="0.8"/>
+  <!-- Main canopy -->
+  <circle cx="16" cy="12" r="9" fill="#2d7a1b"/>
+  <circle cx="16" cy="10" r="7" fill="#3a9a20"/>
+  <!-- Side trees (smaller) -->
+  <rect x="4" y="22" width="4" height="8" rx="1" fill="#5a3518"/>
+  <circle cx="6" cy="18" r="5" fill="#2d7a1b"/>
+  <rect x="24" y="22" width="4" height="8" rx="1" fill="#5a3518"/>
+  <circle cx="26" cy="18" r="5" fill="#2d7a1b"/>
+  <!-- Roots -->
+  <ellipse cx="11" cy="31" rx="4" ry="1.5" fill="#4a2a10" transform="rotate(-15,11,31)"/>
+  <ellipse cx="21" cy="31" rx="4" ry="1.5" fill="#4a2a10" transform="rotate(15,21,31)"/>
+  <!-- Glowing center -->
+  <circle cx="16" cy="12" r="3" fill="#88dd44" opacity="0.5"/>
+  <!-- Ancient rune on trunk -->
+  <text x="16" y="26" font-size="6" text-anchor="middle" fill="#88cc44" font-family="monospace">ᚱ</text>
+</svg>

--- a/web/public/sprites/ballista-tower.svg
+++ b/web/public/sprites/ballista-tower.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Tower base -->
+  <rect x="8" y="16" width="16" height="14" rx="1" fill="#7a6a5a"/>
+  <rect x="8" y="16" width="16" height="2" fill="#6a5a4a"/>
+  <!-- Stone lines -->
+  <line x1="8" y1="20" x2="24" y2="20" stroke="#5a4a3a" stroke-width="0.6"/>
+  <line x1="8" y1="24" x2="24" y2="24" stroke="#5a4a3a" stroke-width="0.6"/>
+  <line x1="8" y1="28" x2="24" y2="28" stroke="#5a4a3a" stroke-width="0.6"/>
+  <line x1="14" y1="20" x2="14" y2="30" stroke="#5a4a3a" stroke-width="0.6"/>
+  <line x1="20" y1="16" x2="20" y2="30" stroke="#5a4a3a" stroke-width="0.6"/>
+  <!-- Tower top platform -->
+  <rect x="6" y="12" width="20" height="5" rx="1" fill="#8a7a5a"/>
+  <rect x="6" y="12" width="20" height="1.5" fill="#6a5a3a"/>
+  <!-- Battlements -->
+  <rect x="7" y="8" width="3" height="5" rx="0.5" fill="#7a6a4a"/>
+  <rect x="13" y="8" width="3" height="5" rx="0.5" fill="#7a6a4a"/>
+  <rect x="19" y="8" width="3" height="5" rx="0.5" fill="#7a6a4a"/>
+  <rect x="25" y="8" width="1.5" height="5" rx="0.5" fill="#7a6a4a"/>
+  <rect x="5.5" y="8" width="1.5" height="5" rx="0.5" fill="#7a6a4a"/>
+  <!-- Ballista frame (mounted on platform) -->
+  <rect x="13" y="9" width="6" height="3" rx="0.5" fill="#5a3a0a"/>
+  <!-- Ballista bow arms -->
+  <path d="M13,10 Q10,8 11,12" stroke="#7a5a1a" stroke-width="1.5" fill="none"/>
+  <path d="M19,10 Q22,8 21,12" stroke="#7a5a1a" stroke-width="1.5" fill="none"/>
+  <!-- Bowstring -->
+  <line x1="11" y1="10" x2="21" y2="10" stroke="#cccc88" stroke-width="0.7"/>
+  <!-- Bolt loaded -->
+  <line x1="14" y1="10" x2="8" y2="10" stroke="#8a5a1a" stroke-width="1.5"/>
+  <polygon points="8,10 10,9 10,11" fill="#aaaaaa"/>
+  <!-- Arrow slit window -->
+  <rect x="14" y="21" width="4" height="5" rx="0.3" fill="#2a1a0a"/>
+  <polygon points="14,21 16,19 18,21" fill="#2a1a0a"/>
+</svg>

--- a/web/public/sprites/breakwater-wall.svg
+++ b/web/public/sprites/breakwater-wall.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Water base -->
+  <rect x="0" y="26" width="32" height="6" rx="0" fill="#2255aa" opacity="0.5"/>
+  <path d="M0,26 Q4,24 8,26 Q12,28 16,26 Q20,24 24,26 Q28,28 32,26 L32,32 L0,32 Z" fill="#3377cc" opacity="0.4"/>
+  <!-- Main wall body -->
+  <rect x="2" y="12" width="28" height="16" rx="1" fill="#8a7a6a"/>
+  <rect x="2" y="12" width="28" height="2" fill="#6a5a4a"/>
+  <!-- Stone block lines horizontal -->
+  <line x1="2" y1="16" x2="30" y2="16" stroke="#6a5a4a" stroke-width="0.7"/>
+  <line x1="2" y1="20" x2="30" y2="20" stroke="#6a5a4a" stroke-width="0.7"/>
+  <line x1="2" y1="24" x2="30" y2="24" stroke="#6a5a4a" stroke-width="0.7"/>
+  <!-- Stone block lines vertical (staggered) -->
+  <line x1="10" y1="12" x2="10" y2="16" stroke="#6a5a4a" stroke-width="0.7"/>
+  <line x1="20" y1="12" x2="20" y2="16" stroke="#6a5a4a" stroke-width="0.7"/>
+  <line x1="6" y1="16" x2="6" y2="20" stroke="#6a5a4a" stroke-width="0.7"/>
+  <line x1="15" y1="16" x2="15" y2="20" stroke="#6a5a4a" stroke-width="0.7"/>
+  <line x1="24" y1="16" x2="24" y2="20" stroke="#6a5a4a" stroke-width="0.7"/>
+  <line x1="10" y1="20" x2="10" y2="24" stroke="#6a5a4a" stroke-width="0.7"/>
+  <line x1="20" y1="20" x2="20" y2="24" stroke="#6a5a4a" stroke-width="0.7"/>
+  <line x1="6" y1="24" x2="6" y2="28" stroke="#6a5a4a" stroke-width="0.7"/>
+  <line x1="15" y1="24" x2="15" y2="28" stroke="#6a5a4a" stroke-width="0.7"/>
+  <line x1="24" y1="24" x2="24" y2="28" stroke="#6a5a4a" stroke-width="0.7"/>
+  <!-- Top crenellations -->
+  <rect x="2" y="8" width="5" height="5" rx="0.5" fill="#7a6a5a"/>
+  <rect x="10" y="8" width="5" height="5" rx="0.5" fill="#7a6a5a"/>
+  <rect x="18" y="8" width="5" height="5" rx="0.5" fill="#7a6a5a"/>
+  <rect x="26" y="8" width="4" height="5" rx="0.5" fill="#7a6a5a"/>
+  <!-- Barnacle/seaweed patches -->
+  <circle cx="5" cy="22" r="1.2" fill="#3a7a3a" opacity="0.7"/>
+  <circle cx="4" cy="24" r="0.8" fill="#2a6a2a" opacity="0.6"/>
+  <circle cx="27" cy="20" r="1" fill="#3a7a3a" opacity="0.7"/>
+  <!-- Water splash at base -->
+  <path d="M0,26 Q3,23 5,26" fill="none" stroke="#88ccff" stroke-width="0.8" opacity="0.7"/>
+  <path d="M26,26 Q29,23 32,26" fill="none" stroke="#88ccff" stroke-width="0.8" opacity="0.7"/>
+</svg>

--- a/web/public/sprites/canopy-farm.svg
+++ b/web/public/sprites/canopy-farm.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Tree trunks supporting platform -->
+  <rect x="5" y="20" width="3" height="11" rx="1" fill="#6b4226"/>
+  <rect x="24" y="20" width="3" height="11" rx="1" fill="#6b4226"/>
+  <!-- Platform -->
+  <rect x="3" y="17" width="26" height="4" rx="1" fill="#8a6a3a"/>
+  <rect x="3" y="17" width="26" height="1.5" fill="#6a4a1a"/>
+  <!-- Crop rows on platform -->
+  <rect x="5" y="14" width="6" height="4" rx="0.5" fill="#3a7a1a"/>
+  <rect x="13" y="14" width="6" height="4" rx="0.5" fill="#5a9a2a"/>
+  <rect x="21" y="14" width="6" height="4" rx="0.5" fill="#3a7a1a"/>
+  <!-- Crop sprouts -->
+  <line x1="7" y1="14" x2="7" y2="11" stroke="#44aa22" stroke-width="0.8"/>
+  <line x1="9" y1="14" x2="9" y2="12" stroke="#44aa22" stroke-width="0.8"/>
+  <line x1="15" y1="14" x2="15" y2="11" stroke="#66cc33" stroke-width="0.8"/>
+  <line x1="17" y1="14" x2="17" y2="12" stroke="#66cc33" stroke-width="0.8"/>
+  <line x1="23" y1="14" x2="23" y2="11" stroke="#44aa22" stroke-width="0.8"/>
+  <line x1="25" y1="14" x2="25" y2="12" stroke="#44aa22" stroke-width="0.8"/>
+  <!-- Leaf clusters over crops -->
+  <circle cx="7" cy="10" r="2.5" fill="#2d7a1b"/>
+  <circle cx="9" cy="11" r="2" fill="#3a9a20"/>
+  <circle cx="15" cy="10" r="2.5" fill="#2d7a1b"/>
+  <circle cx="17" cy="11" r="2" fill="#3a9a20"/>
+  <circle cx="23" cy="10" r="2.5" fill="#2d7a1b"/>
+  <circle cx="25" cy="11" r="2" fill="#3a9a20"/>
+  <!-- Canopy overhead -->
+  <ellipse cx="16" cy="5" rx="14" ry="5" fill="#2d7a1b" opacity="0.7"/>
+  <ellipse cx="16" cy="4" rx="11" ry="4" fill="#3a9a20" opacity="0.6"/>
+  <!-- Rope ladder -->
+  <line x1="16" y1="21" x2="16" y2="30" stroke="#8a6a3a" stroke-width="0.8"/>
+  <line x1="14" y1="21" x2="14" y2="30" stroke="#8a6a3a" stroke-width="0.8"/>
+  <line x1="14" y1="23" x2="16" y2="23" stroke="#8a6a3a" stroke-width="0.8"/>
+  <line x1="14" y1="25" x2="16" y2="25" stroke="#8a6a3a" stroke-width="0.8"/>
+  <line x1="14" y1="27" x2="16" y2="27" stroke="#8a6a3a" stroke-width="0.8"/>
+  <line x1="14" y1="29" x2="16" y2="29" stroke="#8a6a3a" stroke-width="0.8"/>
+</svg>

--- a/web/public/sprites/canopy-watchtower.svg
+++ b/web/public/sprites/canopy-watchtower.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Tree trunk base -->
+  <rect x="13" y="16" width="6" height="15" rx="2" fill="#6b4226"/>
+  <line x1="15" y1="16" x2="15" y2="31" stroke="#4a2a10" stroke-width="0.8"/>
+  <!-- Root buttresses -->
+  <ellipse cx="10" cy="31" rx="5" ry="1.5" fill="#4a2a10" transform="rotate(-20,10,31)"/>
+  <ellipse cx="22" cy="31" rx="5" ry="1.5" fill="#4a2a10" transform="rotate(20,22,31)"/>
+  <!-- Mid-trunk foliage -->
+  <circle cx="16" cy="18" r="6" fill="#2d7a1b" opacity="0.6"/>
+  <!-- Tower platform -->
+  <rect x="6" y="11" width="20" height="5" rx="1" fill="#7a5a2a"/>
+  <rect x="6" y="11" width="20" height="1.5" fill="#5a3a0a"/>
+  <!-- Watchtower cab -->
+  <rect x="9" y="5" width="14" height="7" rx="1" fill="#8a6a3a"/>
+  <rect x="9" y="5" width="14" height="2" fill="#6a4a1a"/>
+  <!-- Crenellations -->
+  <rect x="10" y="2" width="3" height="4" rx="0.5" fill="#7a5a2a"/>
+  <rect x="15" y="2" width="3" height="4" rx="0.5" fill="#7a5a2a"/>
+  <rect x="20" y="2" width="3" height="4" rx="0.5" fill="#7a5a2a"/>
+  <!-- Arrow slits -->
+  <rect x="12" y="7" width="2" height="3" rx="0.3" fill="#2a1a0a"/>
+  <rect x="18" y="7" width="2" height="3" rx="0.3" fill="#2a1a0a"/>
+  <!-- Canopy camouflage around cab -->
+  <circle cx="10" cy="5" r="3" fill="#2d7a1b" opacity="0.8"/>
+  <circle cx="22" cy="5" r="3" fill="#2d7a1b" opacity="0.8"/>
+  <circle cx="16" cy="3" r="3.5" fill="#3a9a20" opacity="0.6"/>
+  <!-- Vine wrapping trunk -->
+  <path d="M13,28 Q11,25 13,22 Q15,19 13,16" stroke="#3a7a1a" stroke-width="1" fill="none" opacity="0.7"/>
+</svg>

--- a/web/public/sprites/centaur-stable.svg
+++ b/web/public/sprites/centaur-stable.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground -->
+  <rect x="2" y="26" width="28" height="4" rx="1" fill="#8a7a3a"/>
+  <!-- Stable walls -->
+  <rect x="3" y="14" width="26" height="14" rx="1" fill="#9a6a2a"/>
+  <rect x="3" y="14" width="26" height="3" fill="#7a4a1a"/>
+  <!-- Roof -->
+  <polygon points="1,14 16,3 31,14" fill="#5a3a0a"/>
+  <polygon points="3,14 16,5 29,14" fill="#6a4a1a"/>
+  <!-- Roof ridge -->
+  <line x1="16" y1="3" x2="16" y2="14" stroke="#4a2a0a" stroke-width="1"/>
+  <!-- Stall dividers -->
+  <rect x="13" y="17" width="1.5" height="11" rx="0.5" fill="#6a3a0a"/>
+  <rect x="20" y="17" width="1.5" height="11" rx="0.5" fill="#6a3a0a"/>
+  <!-- Hay bales -->
+  <rect x="5" y="22" width="6" height="4" rx="1" fill="#ccaa22"/>
+  <line x1="5" y1="24" x2="11" y2="24" stroke="#aa8811" stroke-width="0.8"/>
+  <line x1="5" y1="23" x2="11" y2="23" stroke="#aa8811" stroke-width="0.5"/>
+  <!-- Spear rack in middle stall -->
+  <rect x="15.5" y="18" width="1" height="8" rx="0.3" fill="#7a5a2a"/>
+  <line x1="14" y1="20" x2="18" y2="20" stroke="#7a5a2a" stroke-width="0.8"/>
+  <line x1="14" y1="22" x2="18" y2="22" stroke="#7a5a2a" stroke-width="0.8"/>
+  <polygon points="16,17 15.3,19 16.7,19" fill="#aaaaaa"/>
+  <!-- Horseshoe on wall -->
+  <path d="M23,20 Q21,17 23,15 Q25,13 27,15 Q29,17 27,20" stroke="#888888" stroke-width="1.5" fill="none"/>
+  <!-- Water trough -->
+  <rect x="22" y="22" width="7" height="3" rx="0.5" fill="#6a3a0a"/>
+  <rect x="22.5" y="22.5" width="6" height="2" rx="0.3" fill="#3388aa"/>
+</svg>

--- a/web/public/sprites/clockwork-forge.svg
+++ b/web/public/sprites/clockwork-forge.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Forge body -->
+  <rect x="4" y="14" width="24" height="16" rx="2" fill="#5a4a3a"/>
+  <rect x="4" y="14" width="24" height="3" fill="#4a3a2a"/>
+  <!-- Forge door (hot interior) -->
+  <rect x="11" y="18" width="10" height="9" rx="1" fill="#1a1a1a"/>
+  <rect x="12" y="19" width="8" height="7" rx="0.5" fill="#cc4400"/>
+  <rect x="13" y="20" width="6" height="5" rx="0.5" fill="#ff8800" opacity="0.9"/>
+  <ellipse cx="16" cy="23" rx="3" ry="2.5" fill="#ffcc00" opacity="0.8"/>
+  <!-- Chimney/stack -->
+  <rect x="20" y="6" width="5" height="10" rx="1" fill="#4a3a2a"/>
+  <rect x="19" y="5" width="7" height="3" rx="1" fill="#3a2a1a"/>
+  <!-- Smoke -->
+  <ellipse cx="22" cy="4" rx="2" ry="1.5" fill="#888888" opacity="0.5"/>
+  <ellipse cx="23" cy="2" rx="1.5" ry="1" fill="#aaaaaa" opacity="0.4"/>
+  <!-- Large gear (left side) -->
+  <circle cx="8" cy="12" r="5" fill="#6a6a5a" stroke="#4a4a3a" stroke-width="0.8"/>
+  <circle cx="8" cy="12" r="3" fill="#4a4a3a"/>
+  <circle cx="8" cy="12" r="1.5" fill="#8a8a6a"/>
+  <!-- Gear teeth -->
+  <rect x="5.5" y="6" width="5" height="2" rx="0.5" fill="#6a6a5a"/>
+  <rect x="5.5" y="16" width="5" height="2" rx="0.5" fill="#6a6a5a"/>
+  <rect x="2" y="9.5" width="2" height="5" rx="0.5" fill="#6a6a5a"/>
+  <rect x="12" y="9.5" width="2" height="5" rx="0.5" fill="#6a6a5a"/>
+  <!-- Small gear (top right) -->
+  <circle cx="25" cy="12" r="3" fill="#6a6a5a" stroke="#4a4a3a" stroke-width="0.6"/>
+  <circle cx="25" cy="12" r="1.5" fill="#4a4a3a"/>
+  <rect x="23.5" y="8.5" width="3" height="1.5" rx="0.3" fill="#6a6a5a"/>
+  <rect x="23.5" y="14" width="3" height="1.5" rx="0.3" fill="#6a6a5a"/>
+  <rect x="21" y="10.5" width="1.5" height="3" rx="0.3" fill="#6a6a5a"/>
+  <rect x="27.5" y="10.5" width="1.5" height="3" rx="0.3" fill="#6a6a5a"/>
+  <!-- Connecting pipe -->
+  <rect x="10" y="11" width="13" height="2" rx="1" fill="#7a5a2a"/>
+  <!-- Rivets on body -->
+  <circle cx="6" cy="16" r="0.8" fill="#8a7a5a"/>
+  <circle cx="26" cy="16" r="0.8" fill="#8a7a5a"/>
+  <circle cx="6" cy="26" r="0.8" fill="#8a7a5a"/>
+  <circle cx="26" cy="26" r="0.8" fill="#8a7a5a"/>
+</svg>

--- a/web/public/sprites/cloudfort.svg
+++ b/web/public/sprites/cloudfort.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Cloud base -->
+  <ellipse cx="16" cy="28" rx="14" ry="4" fill="#ccddee"/>
+  <ellipse cx="10" cy="26" rx="7" ry="4" fill="#ddeeff"/>
+  <ellipse cx="22" cy="26" rx="7" ry="4" fill="#ddeeff"/>
+  <ellipse cx="16" cy="25" rx="10" ry="4" fill="#eef5ff"/>
+  <!-- Fort walls (on cloud) -->
+  <rect x="7" y="14" width="18" height="12" rx="1" fill="#cce0f0"/>
+  <rect x="7" y="14" width="18" height="2.5" fill="#aaccdd"/>
+  <!-- Stone texture lines -->
+  <line x1="7" y1="18" x2="25" y2="18" stroke="#99bbcc" stroke-width="0.5"/>
+  <line x1="7" y1="22" x2="25" y2="22" stroke="#99bbcc" stroke-width="0.5"/>
+  <line x1="13" y1="14" x2="13" y2="26" stroke="#99bbcc" stroke-width="0.5"/>
+  <line x1="19" y1="14" x2="19" y2="26" stroke="#99bbcc" stroke-width="0.5"/>
+  <!-- Gate -->
+  <path d="M13,26 L13,20 Q16,17 19,20 L19,26 Z" fill="#3a5a7a"/>
+  <!-- Towers -->
+  <rect x="5" y="10" width="6" height="14" rx="1" fill="#bbcedd"/>
+  <rect x="21" y="10" width="6" height="14" rx="1" fill="#bbcedd"/>
+  <!-- Tower crenellations -->
+  <rect x="5" y="7" width="2" height="4" rx="0.3" fill="#aabbcc"/>
+  <rect x="8.5" y="7" width="2" height="4" rx="0.3" fill="#aabbcc"/>
+  <rect x="21" y="7" width="2" height="4" rx="0.3" fill="#aabbcc"/>
+  <rect x="24.5" y="7" width="2" height="4" rx="0.3" fill="#aabbcc"/>
+  <!-- Lightning energy on towers -->
+  <path d="M8,12 L7,14 L9,13 L8,16" stroke="#88aaff" stroke-width="1" fill="none" opacity="0.8"/>
+  <path d="M24,12 L23,14 L25,13 L24,16" stroke="#88aaff" stroke-width="1" fill="none" opacity="0.8"/>
+  <!-- Flag -->
+  <line x1="16" y1="14" x2="16" y2="10" stroke="#6a8aaa" stroke-width="1"/>
+  <polygon points="16,10 22,11.5 16,13" fill="#5577cc"/>
+  <!-- Cloud wisps -->
+  <ellipse cx="4" cy="27" rx="3" ry="1.5" fill="#ddeeff" opacity="0.7"/>
+  <ellipse cx="28" cy="27" rx="3" ry="1.5" fill="#ddeeff" opacity="0.7"/>
+</svg>

--- a/web/public/sprites/command-tent.svg
+++ b/web/public/sprites/command-tent.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Tent main canvas -->
+  <polygon points="16,4 2,24 30,24" fill="#8b7a4a"/>
+  <!-- Tent shadow/fold lines -->
+  <line x1="16" y1="4" x2="10" y2="24" stroke="#6b5a2a" stroke-width="0.8"/>
+  <line x1="16" y1="4" x2="22" y2="24" stroke="#6b5a2a" stroke-width="0.8"/>
+  <!-- Tent flap/opening -->
+  <polygon points="16,8 12,24 16,20 20,24" fill="#6b5a2a"/>
+  <!-- Ground skirt -->
+  <rect x="2" y="23" width="28" height="4" rx="0.5" fill="#7a6a3a"/>
+  <line x1="2" y1="24" x2="30" y2="24" stroke="#5a4a1a" stroke-width="0.8"/>
+  <!-- Flag on peak -->
+  <line x1="16" y1="4" x2="16" y2="0" stroke="#5a4a1a" stroke-width="1.2"/>
+  <polygon points="16,0 22,2 16,4" fill="#cc3333"/>
+  <!-- Ropes/pegs -->
+  <line x1="16" y1="4" x2="5" y2="20" stroke="#9a8a4a" stroke-width="0.6"/>
+  <line x1="16" y1="4" x2="27" y2="20" stroke="#9a8a4a" stroke-width="0.6"/>
+  <!-- Map/table silhouette through canvas -->
+  <rect x="12" y="16" width="8" height="5" rx="0.5" fill="#9a8a4a" opacity="0.5"/>
+</svg>

--- a/web/public/sprites/drift-net.svg
+++ b/web/public/sprites/drift-net.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Water surface -->
+  <path d="M0,26 Q4,24 8,26 Q12,28 16,26 Q20,24 24,26 Q28,28 32,26 L32,32 L0,32 Z" fill="#2266aa" opacity="0.5"/>
+  <!-- Net posts -->
+  <rect x="3" y="8" width="3" height="20" rx="1" fill="#7a5a2a"/>
+  <rect x="26" y="8" width="3" height="20" rx="1" fill="#7a5a2a"/>
+  <!-- Post tops -->
+  <ellipse cx="4.5" cy="8" rx="2" ry="1" fill="#8a6a3a"/>
+  <ellipse cx="27.5" cy="8" rx="2" ry="1" fill="#8a6a3a"/>
+  <!-- Net top rope -->
+  <path d="M4.5,9 Q16,6 27.5,9" stroke="#ccaa55" stroke-width="1.2" fill="none"/>
+  <!-- Net mesh (vertical cords) -->
+  <line x1="9" y1="10" x2="7" y2="24" stroke="#aaaa77" stroke-width="0.7"/>
+  <line x1="13" y1="9" x2="11" y2="24" stroke="#aaaa77" stroke-width="0.7"/>
+  <line x1="17" y1="8" x2="15" y2="24" stroke="#aaaa77" stroke-width="0.7"/>
+  <line x1="21" y1="9" x2="19" y2="24" stroke="#aaaa77" stroke-width="0.7"/>
+  <line x1="25" y1="10" x2="23" y2="24" stroke="#aaaa77" stroke-width="0.7"/>
+  <!-- Net mesh (horizontal cords) -->
+  <path d="M5,12 Q16,10 28,12" stroke="#aaaa77" stroke-width="0.7" fill="none"/>
+  <path d="M5,16 Q16,14 28,16" stroke="#aaaa77" stroke-width="0.7" fill="none"/>
+  <path d="M5,20 Q16,18 28,20" stroke="#aaaa77" stroke-width="0.7" fill="none"/>
+  <path d="M5,24 Q16,22 28,24" stroke="#aaaa77" stroke-width="0.7" fill="none"/>
+  <!-- Floats on top rope -->
+  <ellipse cx="10" cy="9" rx="1.5" ry="1" fill="#dd4422"/>
+  <ellipse cx="16" cy="8" rx="1.5" ry="1" fill="#dd4422"/>
+  <ellipse cx="22" cy="9" rx="1.5" ry="1" fill="#dd4422"/>
+  <!-- Caught fish silhouette in net -->
+  <ellipse cx="14" cy="17" rx="3" ry="1.5" fill="#4488aa" opacity="0.6"/>
+  <polygon points="11,17 9,15 9,19" fill="#4488aa" opacity="0.6"/>
+  <!-- Wave ripples -->
+  <path d="M2,27 Q6,25 10,27" fill="none" stroke="#88bbdd" stroke-width="0.7" opacity="0.6"/>
+  <path d="M20,27 Q24,25 28,27" fill="none" stroke="#88bbdd" stroke-width="0.7" opacity="0.6"/>
+</svg>

--- a/web/public/sprites/drone-array.svg
+++ b/web/public/sprites/drone-array.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Base platform -->
+  <rect x="8" y="24" width="16" height="6" rx="2" fill="#3a3a4a"/>
+  <rect x="8" y="24" width="16" height="2" fill="#2a2a3a"/>
+  <!-- Vertical struts -->
+  <rect x="12" y="16" width="2" height="9" rx="0.5" fill="#4a4a5a"/>
+  <rect x="18" y="16" width="2" height="9" rx="0.5" fill="#4a4a5a"/>
+  <!-- Central emitter/antenna -->
+  <rect x="15" y="8" width="2" height="16" rx="0.5" fill="#5a5a6a"/>
+  <ellipse cx="16" cy="8" rx="3" ry="2" fill="#4a4a5a"/>
+  <ellipse cx="16" cy="7" rx="2" ry="1.5" fill="#6a6a7a"/>
+  <!-- Core energy orb -->
+  <circle cx="16" cy="15" r="3" fill="#1a1a2a"/>
+  <circle cx="16" cy="15" r="2" fill="#3344cc" opacity="0.9"/>
+  <circle cx="16" cy="15" r="1" fill="#aabbff" opacity="0.8"/>
+  <!-- Orbital ring -->
+  <ellipse cx="16" cy="15" rx="7" ry="3" fill="none" stroke="#4466dd" stroke-width="0.7" opacity="0.6"/>
+  <!-- Drone 1 (top orbit) -->
+  <rect x="20" y="11" width="4" height="2.5" rx="1" fill="#5566aa"/>
+  <line x1="20" y1="11.5" x2="18" y2="13" stroke="#4455aa" stroke-width="0.6"/>
+  <line x1="24" y1="11.5" x2="22" y2="13" stroke="#4455aa" stroke-width="0.6"/>
+  <circle cx="22" cy="12" r="0.8" fill="#88aaff" opacity="0.8"/>
+  <!-- Drone 2 (bottom orbit) -->
+  <rect x="8" y="17" width="4" height="2.5" rx="1" fill="#5566aa"/>
+  <line x1="8" y1="17.5" x2="10" y2="16" stroke="#4455aa" stroke-width="0.6"/>
+  <line x1="12" y1="17.5" x2="14" y2="16" stroke="#4455aa" stroke-width="0.6"/>
+  <circle cx="10" cy="18" r="0.8" fill="#88aaff" opacity="0.8"/>
+  <!-- Energy pulses -->
+  <line x1="16" y1="8" x2="22" y2="11" stroke="#4466dd" stroke-width="0.5" opacity="0.5"/>
+  <line x1="16" y1="8" x2="10" y2="17" stroke="#4466dd" stroke-width="0.5" opacity="0.5"/>
+  <!-- Panel details on base -->
+  <line x1="10" y1="26" x2="22" y2="26" stroke="#5a5a6a" stroke-width="0.6"/>
+  <circle cx="13" cy="27" r="0.8" fill="#6677cc" opacity="0.8"/>
+  <circle cx="16" cy="27" r="0.8" fill="#6677cc" opacity="0.8"/>
+  <circle cx="19" cy="27" r="0.8" fill="#6677cc" opacity="0.8"/>
+</svg>

--- a/web/public/sprites/elder-grove.svg
+++ b/web/public/sprites/elder-grove.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Central elder tree trunk (thick, gnarled) -->
+  <rect x="12" y="19" width="8" height="12" rx="3" fill="#5a3010"/>
+  <line x1="14" y1="19" x2="13" y2="31" stroke="#3a1a00" stroke-width="1"/>
+  <line x1="18" y1="19" x2="19" y2="31" stroke="#3a1a00" stroke-width="1"/>
+  <!-- Main canopy (large, dark ancient) -->
+  <circle cx="16" cy="12" r="11" fill="#1a5010"/>
+  <circle cx="16" cy="10" r="9" fill="#2a6a18"/>
+  <circle cx="14" cy="11" r="7" fill="#1a5010" opacity="0.5"/>
+  <!-- Flanking elder trees -->
+  <rect x="3" y="22" width="4" height="9" rx="1.5" fill="#4a2a08"/>
+  <circle cx="5" cy="17" r="6" fill="#1a5010"/>
+  <circle cx="5" cy="15" r="4.5" fill="#2a6a18"/>
+  <rect x="25" y="22" width="4" height="9" rx="1.5" fill="#4a2a08"/>
+  <circle cx="27" cy="17" r="6" fill="#1a5010"/>
+  <circle cx="27" cy="15" r="4.5" fill="#2a6a18"/>
+  <!-- Ancient roots spreading -->
+  <ellipse cx="10" cy="31" rx="5" ry="1.5" fill="#3a1a00" transform="rotate(-20,10,31)"/>
+  <ellipse cx="22" cy="31" rx="5" ry="1.5" fill="#3a1a00" transform="rotate(20,22,31)"/>
+  <!-- Golden glow/light through canopy -->
+  <circle cx="16" cy="12" r="4" fill="#88dd44" opacity="0.25"/>
+  <circle cx="16" cy="11" r="2" fill="#aaff55" opacity="0.2"/>
+  <!-- Wisps of ancient magic -->
+  <circle cx="10" cy="10" r="1" fill="#44ff88" opacity="0.5"/>
+  <circle cx="22" cy="9" r="0.8" fill="#44ff88" opacity="0.4"/>
+  <circle cx="8" cy="16" r="0.7" fill="#88ffaa" opacity="0.5"/>
+  <circle cx="24" cy="15" r="0.7" fill="#88ffaa" opacity="0.4"/>
+  <!-- Ancient rune on trunk -->
+  <text x="16" y="27" font-size="6" text-anchor="middle" fill="#88cc44" font-family="monospace">ᚠ</text>
+  <!-- Star/flower at crown -->
+  <circle cx="16" cy="4" r="2" fill="#aaff44" opacity="0.6"/>
+  <circle cx="16" cy="4" r="1" fill="#ccff88" opacity="0.7"/>
+</svg>

--- a/web/public/sprites/elder-shrine.svg
+++ b/web/public/sprites/elder-shrine.svg
@@ -1,0 +1,41 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground -->
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#3a2a1a" opacity="0.5"/>
+  <!-- Stone base/dais -->
+  <rect x="4" y="26" width="24" height="4" rx="1" fill="#6a6050"/>
+  <rect x="4" y="26" width="24" height="1.5" fill="#7a7060"/>
+  <!-- Stone step -->
+  <rect x="6" y="24" width="20" height="3" rx="1" fill="#7a7060"/>
+  <!-- Shrine chamber walls -->
+  <rect x="9" y="12" width="14" height="14" rx="1" fill="#6a5a4a"/>
+  <rect x="9" y="12" width="14" height="3" fill="#5a4a3a"/>
+  <!-- Stone block lines -->
+  <line x1="9" y1="17" x2="23" y2="17" stroke="#4a3a2a" stroke-width="0.5"/>
+  <line x1="9" y1="21" x2="23" y2="21" stroke="#4a3a2a" stroke-width="0.5"/>
+  <line x1="14" y1="12" x2="14" y2="26" stroke="#4a3a2a" stroke-width="0.5"/>
+  <line x1="19" y1="12" x2="19" y2="26" stroke="#4a3a2a" stroke-width="0.5"/>
+  <!-- Arched doorway -->
+  <path d="M12,26 L12,19 Q16,15 20,19 L20,26 Z" fill="#2a1a0a"/>
+  <!-- Interior glow -->
+  <ellipse cx="16" cy="21" rx="3" ry="2" fill="#ffaa22" opacity="0.6"/>
+  <!-- Roof/pediment -->
+  <polygon points="7,12 16,4 25,12" fill="#5a4a3a"/>
+  <polygon points="9,12 16,6 23,12" fill="#6a5a4a"/>
+  <!-- Roof ridge ornament -->
+  <ellipse cx="16" cy="5" rx="2" ry="2.5" fill="#8a7060"/>
+  <ellipse cx="16" cy="4" rx="1.2" ry="1.5" fill="#aa9a70"/>
+  <!-- Offering flame on ridge -->
+  <ellipse cx="16" cy="3" rx="1.5" ry="1" fill="#ff8822" opacity="0.9"/>
+  <ellipse cx="16" cy="2" rx="1" ry="1" fill="#ffcc44" opacity="0.8"/>
+  <ellipse cx="16" cy="1.5" rx="0.6" ry="0.8" fill="#ffffff" opacity="0.6"/>
+  <!-- Side pillars -->
+  <rect x="7" y="12" width="3" height="12" rx="0.5" fill="#7a6a5a"/>
+  <rect x="22" y="12" width="3" height="12" rx="0.5" fill="#7a6a5a"/>
+  <!-- Elder runes on pillars -->
+  <text x="8.5" y="22" font-size="5" text-anchor="middle" fill="#aa8844" font-family="monospace">ᚢ</text>
+  <text x="23.5" y="22" font-size="5" text-anchor="middle" fill="#aa8844" font-family="monospace">ᚦ</text>
+  <!-- Magic sparks -->
+  <circle cx="6" cy="16" r="0.8" fill="#ffaa22" opacity="0.6"/>
+  <circle cx="26" cy="14" r="0.7" fill="#ffcc44" opacity="0.5"/>
+  <circle cx="10" cy="10" r="0.6" fill="#ffaa22" opacity="0.4"/>
+</svg>

--- a/web/public/sprites/thornlord-1.svg
+++ b/web/public/sprites/thornlord-1.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Thornlord — frame 1 (stride A: left root-leg forward) -->
+  <!-- trunk -->
+  <rect x="12" y="18" width="8" height="10" rx="2" fill="#5a3010"/>
+  <rect x="13" y="20" width="6" height="8" fill="#7a4820" opacity="0.5"/>
+  <!-- body/crown -->
+  <ellipse cx="16" cy="14" rx="9" ry="10" fill="#2d5a1b"/>
+  <ellipse cx="16" cy="13" rx="7" ry="8" fill="#3a7222" opacity="0.7"/>
+  <!-- left branch-arm (raised) -->
+  <line x1="7" y1="12" x2="1" y2="7" stroke="#5a3010" stroke-width="2.5" stroke-linecap="round"/>
+  <line x1="1" y1="7" x2="0" y2="4" stroke="#5a3010" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="1" y1="7" x2="0" y2="10" stroke="#5a3010" stroke-width="1.5" stroke-linecap="round"/>
+  <!-- right branch-arm -->
+  <line x1="25" y1="13" x2="30" y2="9" stroke="#5a3010" stroke-width="2.5" stroke-linecap="round"/>
+  <line x1="30" y1="9" x2="32" y2="6" stroke="#5a3010" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="30" y1="9" x2="31" y2="12" stroke="#5a3010" stroke-width="1.5" stroke-linecap="round"/>
+  <!-- thorns -->
+  <polygon points="10,6 9,2 12,5" fill="#1a4010"/>
+  <polygon points="16,4 15,0 17,0 18,4" fill="#1a4010"/>
+  <polygon points="22,6 23,2 20,5" fill="#1a4010"/>
+  <polygon points="8,12 5,10 9,10" fill="#1a4010"/>
+  <polygon points="24,12 27,10 23,10" fill="#1a4010"/>
+  <!-- glowing eyes -->
+  <ellipse cx="12" cy="14" rx="2.5" ry="2" fill="#00ff44"/>
+  <ellipse cx="20" cy="14" rx="2.5" ry="2" fill="#00ff44"/>
+  <ellipse cx="12" cy="14" rx="1" ry="1" fill="#ccffcc"/>
+  <ellipse cx="20" cy="14" rx="1" ry="1" fill="#ccffcc"/>
+  <ellipse cx="12" cy="14" rx="3" ry="2.5" fill="#00ff44" opacity="0.2"/>
+  <ellipse cx="20" cy="14" rx="3" ry="2.5" fill="#00ff44" opacity="0.2"/>
+  <!-- Roots: left forward, right back -->
+  <ellipse cx="11" cy="31" rx="5" ry="1.5" fill="#4a2a10" transform="rotate(-10,11,31)"/>
+  <ellipse cx="21" cy="29" rx="4" ry="1.5" fill="#4a2a10" transform="rotate(15,21,29)"/>
+</svg>

--- a/web/public/sprites/thornlord-2.svg
+++ b/web/public/sprites/thornlord-2.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Thornlord — frame 2 (mid-stride, body 1px higher) -->
+  <!-- trunk -->
+  <rect x="12" y="17" width="8" height="10" rx="2" fill="#5a3010"/>
+  <rect x="13" y="19" width="6" height="8" fill="#7a4820" opacity="0.5"/>
+  <!-- body/crown (1px higher) -->
+  <ellipse cx="16" cy="13" rx="9" ry="10" fill="#2d5a1b"/>
+  <ellipse cx="16" cy="12" rx="7" ry="8" fill="#3a7222" opacity="0.7"/>
+  <!-- left branch-arm -->
+  <line x1="7" y1="12" x2="2" y2="8" stroke="#5a3010" stroke-width="2.5" stroke-linecap="round"/>
+  <line x1="2" y1="8" x2="0" y2="5" stroke="#5a3010" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="2" y1="8" x2="1" y2="11" stroke="#5a3010" stroke-width="1.5" stroke-linecap="round"/>
+  <!-- right branch-arm -->
+  <line x1="25" y1="12" x2="30" y2="8" stroke="#5a3010" stroke-width="2.5" stroke-linecap="round"/>
+  <line x1="30" y1="8" x2="32" y2="5" stroke="#5a3010" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="30" y1="8" x2="31" y2="11" stroke="#5a3010" stroke-width="1.5" stroke-linecap="round"/>
+  <!-- thorns -->
+  <polygon points="10,5 9,1 12,4" fill="#1a4010"/>
+  <polygon points="16,3 15,0 17,0 18,3" fill="#1a4010"/>
+  <polygon points="22,5 23,1 20,4" fill="#1a4010"/>
+  <polygon points="8,11 5,9 9,9" fill="#1a4010"/>
+  <polygon points="24,11 27,9 23,9" fill="#1a4010"/>
+  <!-- glowing eyes -->
+  <ellipse cx="12" cy="13" rx="2.5" ry="2" fill="#00ff44"/>
+  <ellipse cx="20" cy="13" rx="2.5" ry="2" fill="#00ff44"/>
+  <ellipse cx="12" cy="13" rx="1" ry="1" fill="#ccffcc"/>
+  <ellipse cx="20" cy="13" rx="1" ry="1" fill="#ccffcc"/>
+  <ellipse cx="12" cy="13" rx="3" ry="2.5" fill="#00ff44" opacity="0.2"/>
+  <ellipse cx="20" cy="13" rx="3" ry="2.5" fill="#00ff44" opacity="0.2"/>
+  <!-- Roots mid-stride (both level) -->
+  <ellipse cx="11" cy="30" rx="5" ry="1.5" fill="#4a2a10" transform="rotate(-15,11,30)"/>
+  <ellipse cx="21" cy="30" rx="4" ry="1.5" fill="#4a2a10" transform="rotate(15,21,30)"/>
+</svg>

--- a/web/public/sprites/thornlord-3.svg
+++ b/web/public/sprites/thornlord-3.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Thornlord — frame 3 (stride B: right root-leg forward, left back) -->
+  <!-- trunk -->
+  <rect x="12" y="18" width="8" height="10" rx="2" fill="#5a3010"/>
+  <rect x="13" y="20" width="6" height="8" fill="#7a4820" opacity="0.5"/>
+  <!-- body/crown -->
+  <ellipse cx="16" cy="14" rx="9" ry="10" fill="#2d5a1b"/>
+  <ellipse cx="16" cy="13" rx="7" ry="8" fill="#3a7222" opacity="0.7"/>
+  <!-- left branch-arm -->
+  <line x1="7" y1="13" x2="2" y2="9" stroke="#5a3010" stroke-width="2.5" stroke-linecap="round"/>
+  <line x1="2" y1="9" x2="0" y2="6" stroke="#5a3010" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="2" y1="9" x2="1" y2="12" stroke="#5a3010" stroke-width="1.5" stroke-linecap="round"/>
+  <!-- right branch-arm (raised) -->
+  <line x1="25" y1="12" x2="31" y2="7" stroke="#5a3010" stroke-width="2.5" stroke-linecap="round"/>
+  <line x1="31" y1="7" x2="32" y2="4" stroke="#5a3010" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="31" y1="7" x2="32" y2="10" stroke="#5a3010" stroke-width="1.5" stroke-linecap="round"/>
+  <!-- thorns -->
+  <polygon points="10,6 9,2 12,5" fill="#1a4010"/>
+  <polygon points="16,4 15,0 17,0 18,4" fill="#1a4010"/>
+  <polygon points="22,6 23,2 20,5" fill="#1a4010"/>
+  <polygon points="8,12 5,10 9,10" fill="#1a4010"/>
+  <polygon points="24,12 27,10 23,10" fill="#1a4010"/>
+  <!-- glowing eyes -->
+  <ellipse cx="12" cy="14" rx="2.5" ry="2" fill="#00ff44"/>
+  <ellipse cx="20" cy="14" rx="2.5" ry="2" fill="#00ff44"/>
+  <ellipse cx="12" cy="14" rx="1" ry="1" fill="#ccffcc"/>
+  <ellipse cx="20" cy="14" rx="1" ry="1" fill="#ccffcc"/>
+  <ellipse cx="12" cy="14" rx="3" ry="2.5" fill="#00ff44" opacity="0.2"/>
+  <ellipse cx="20" cy="14" rx="3" ry="2.5" fill="#00ff44" opacity="0.2"/>
+  <!-- Roots: right forward, left back (opposite of frame 1) -->
+  <ellipse cx="11" cy="29" rx="4" ry="1.5" fill="#4a2a10" transform="rotate(-15,11,29)"/>
+  <ellipse cx="21" cy="31" rx="5" ry="1.5" fill="#4a2a10" transform="rotate(10,21,31)"/>
+</svg>

--- a/web/public/sprites/wreck-diver-1.svg
+++ b/web/public/sprites/wreck-diver-1.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Wreck Diver — frame 1 (stride A: left leg forward, right back) -->
+  <!-- Diving helmet -->
+  <ellipse cx="16" cy="7" rx="5" ry="5.5" fill="#4a7a8a"/>
+  <ellipse cx="16" cy="7" rx="3.5" ry="3" fill="#88ccdd" opacity="0.6"/>
+  <ellipse cx="15" cy="6.5" rx="1.5" ry="1.2" fill="#aaddee" opacity="0.7"/>
+  <ellipse cx="16" cy="11" rx="5.5" ry="1.5" fill="#3a5a6a"/>
+  <!-- Air hose -->
+  <path d="M21,7 Q26,5 27,10 Q28,15 24,16" stroke="#88aa44" stroke-width="1.5" fill="none"/>
+  <!-- Body -->
+  <rect x="11" y="11" width="10" height="11" rx="2" fill="#1a3a4a"/>
+  <rect x="12" y="11" width="8" height="2" fill="#2a4a5a"/>
+  <!-- Belt -->
+  <rect x="11" y="18" width="10" height="2" fill="#6a5a2a"/>
+  <circle cx="16" cy="19" r="1" fill="#ccaa22"/>
+  <!-- Arms -->
+  <rect x="7" y="12" width="4" height="8" rx="2" fill="#1a3a4a"/>
+  <rect x="21" y="12" width="4" height="8" rx="2" fill="#1a3a4a"/>
+  <ellipse cx="9" cy="21" rx="2.5" ry="1.5" fill="#2a5a3a"/>
+  <ellipse cx="23" cy="21" rx="2.5" ry="1.5" fill="#2a5a3a"/>
+  <!-- Legs: left forward, right back -->
+  <rect x="11" y="22" width="4" height="9" rx="1" fill="#1a3a4a"/>
+  <rect x="17" y="22" width="4" height="7" rx="1" fill="#1a3a4a"/>
+  <!-- Fins -->
+  <ellipse cx="12" cy="32" rx="4" ry="1.5" fill="#2a5a3a"/>
+  <ellipse cx="20" cy="30" rx="4" ry="1.5" fill="#2a5a3a"/>
+</svg>

--- a/web/public/sprites/wreck-diver-2.svg
+++ b/web/public/sprites/wreck-diver-2.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Wreck Diver — frame 2 (mid-stride, body 1px higher) -->
+  <!-- Diving helmet -->
+  <ellipse cx="16" cy="6" rx="5" ry="5.5" fill="#4a7a8a"/>
+  <ellipse cx="16" cy="6" rx="3.5" ry="3" fill="#88ccdd" opacity="0.6"/>
+  <ellipse cx="15" cy="5.5" rx="1.5" ry="1.2" fill="#aaddee" opacity="0.7"/>
+  <ellipse cx="16" cy="10" rx="5.5" ry="1.5" fill="#3a5a6a"/>
+  <!-- Air hose -->
+  <path d="M21,6 Q26,4 27,9 Q28,14 24,15" stroke="#88aa44" stroke-width="1.5" fill="none"/>
+  <!-- Body -->
+  <rect x="11" y="10" width="10" height="11" rx="2" fill="#1a3a4a"/>
+  <rect x="12" y="10" width="8" height="2" fill="#2a4a5a"/>
+  <!-- Belt -->
+  <rect x="11" y="17" width="10" height="2" fill="#6a5a2a"/>
+  <circle cx="16" cy="18" r="1" fill="#ccaa22"/>
+  <!-- Arms -->
+  <rect x="7" y="11" width="4" height="8" rx="2" fill="#1a3a4a"/>
+  <rect x="21" y="11" width="4" height="8" rx="2" fill="#1a3a4a"/>
+  <ellipse cx="9" cy="20" rx="2.5" ry="1.5" fill="#2a5a3a"/>
+  <ellipse cx="23" cy="20" rx="2.5" ry="1.5" fill="#2a5a3a"/>
+  <!-- Legs (mid stride, both roughly even) -->
+  <rect x="11" y="21" width="4" height="9" rx="1" fill="#1a3a4a"/>
+  <rect x="17" y="21" width="4" height="9" rx="1" fill="#1a3a4a"/>
+  <!-- Fins -->
+  <ellipse cx="13" cy="31" rx="4" ry="1.5" fill="#2a5a3a"/>
+  <ellipse cx="20" cy="31" rx="4" ry="1.5" fill="#2a5a3a"/>
+</svg>

--- a/web/public/sprites/wreck-diver-3.svg
+++ b/web/public/sprites/wreck-diver-3.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Wreck Diver — frame 3 (stride B: right leg forward, left back — opposite of frame 1) -->
+  <!-- Diving helmet -->
+  <ellipse cx="16" cy="7" rx="5" ry="5.5" fill="#4a7a8a"/>
+  <ellipse cx="16" cy="7" rx="3.5" ry="3" fill="#88ccdd" opacity="0.6"/>
+  <ellipse cx="15" cy="6.5" rx="1.5" ry="1.2" fill="#aaddee" opacity="0.7"/>
+  <ellipse cx="16" cy="11" rx="5.5" ry="1.5" fill="#3a5a6a"/>
+  <!-- Air hose -->
+  <path d="M21,7 Q26,5 27,10 Q28,15 24,16" stroke="#88aa44" stroke-width="1.5" fill="none"/>
+  <!-- Body -->
+  <rect x="11" y="11" width="10" height="11" rx="2" fill="#1a3a4a"/>
+  <rect x="12" y="11" width="8" height="2" fill="#2a4a5a"/>
+  <!-- Belt -->
+  <rect x="11" y="18" width="10" height="2" fill="#6a5a2a"/>
+  <circle cx="16" cy="19" r="1" fill="#ccaa22"/>
+  <!-- Arms -->
+  <rect x="7" y="12" width="4" height="8" rx="2" fill="#1a3a4a"/>
+  <rect x="21" y="12" width="4" height="8" rx="2" fill="#1a3a4a"/>
+  <ellipse cx="9" cy="21" rx="2.5" ry="1.5" fill="#2a5a3a"/>
+  <ellipse cx="23" cy="21" rx="2.5" ry="1.5" fill="#2a5a3a"/>
+  <!-- Legs: right forward, left back (opposite of frame 1) -->
+  <rect x="11" y="22" width="4" height="7" rx="1" fill="#1a3a4a"/>
+  <rect x="17" y="22" width="4" height="9" rx="1" fill="#1a3a4a"/>
+  <!-- Fins -->
+  <ellipse cx="12" cy="30" rx="4" ry="1.5" fill="#2a5a3a"/>
+  <ellipse cx="20" cy="32" rx="4" ry="1.5" fill="#2a5a3a"/>
+</svg>

--- a/web/public/sprites/wreck-diver.svg
+++ b/web/public/sprites/wreck-diver.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Wreck Diver — static/frame 2 -->
+  <!-- Diving helmet -->
+  <ellipse cx="16" cy="7" rx="5" ry="5.5" fill="#4a7a8a"/>
+  <ellipse cx="16" cy="7" rx="3.5" ry="3" fill="#88ccdd" opacity="0.6"/>
+  <ellipse cx="15" cy="6.5" rx="1.5" ry="1.2" fill="#aaddee" opacity="0.7"/>
+  <!-- Helmet rim -->
+  <ellipse cx="16" cy="11" rx="5.5" ry="1.5" fill="#3a5a6a"/>
+  <!-- Air hose -->
+  <path d="M21,7 Q26,5 27,10 Q28,15 24,16" stroke="#88aa44" stroke-width="1.5" fill="none"/>
+  <!-- Body (wetsuit) -->
+  <rect x="11" y="11" width="10" height="11" rx="2" fill="#1a3a4a"/>
+  <rect x="12" y="11" width="8" height="2" fill="#2a4a5a"/>
+  <!-- Belt with equipment -->
+  <rect x="11" y="18" width="10" height="2" fill="#6a5a2a"/>
+  <circle cx="16" cy="19" r="1" fill="#ccaa22"/>
+  <!-- Arms -->
+  <rect x="7" y="12" width="4" height="8" rx="2" fill="#1a3a4a"/>
+  <rect x="21" y="12" width="4" height="8" rx="2" fill="#1a3a4a"/>
+  <!-- Hands/flippers -->
+  <ellipse cx="9" cy="21" rx="2.5" ry="1.5" fill="#2a5a3a"/>
+  <ellipse cx="23" cy="21" rx="2.5" ry="1.5" fill="#2a5a3a"/>
+  <!-- Legs -->
+  <rect x="12" y="22" width="4" height="8" rx="1" fill="#1a3a4a"/>
+  <rect x="17" y="22" width="4" height="8" rx="1" fill="#1a3a4a"/>
+  <!-- Fins -->
+  <ellipse cx="13" cy="31" rx="4" ry="1.5" fill="#2a5a3a"/>
+  <ellipse cx="20" cy="31" rx="4" ry="1.5" fill="#2a5a3a"/>
+</svg>

--- a/web/public/sprites/wreck-golem-1.svg
+++ b/web/public/sprites/wreck-golem-1.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Wreck Golem — frame 1 (stride A: left leg forward, right back) -->
+  <rect x="11" y="2" width="10" height="9" rx="2" fill="#5a5a4a"/>
+  <rect x="11" y="2" width="10" height="2" fill="#6a6a5a"/>
+  <circle cx="14" cy="7" r="2" fill="#3a3a2a"/>
+  <circle cx="14" cy="7" r="1.2" fill="#dd8822" opacity="0.9"/>
+  <circle cx="19" cy="7" r="2" fill="#3a3a2a"/>
+  <circle cx="19" cy="7" r="1.2" fill="#dd8822" opacity="0.9"/>
+  <line x1="13" y1="4" x2="12" y2="9" stroke="#8a4a1a" stroke-width="0.7" opacity="0.6"/>
+  <line x1="20" y1="4" x2="21" y2="9" stroke="#8a4a1a" stroke-width="0.7" opacity="0.6"/>
+  <rect x="14" y="10" width="4" height="2" rx="0.5" fill="#4a4a3a"/>
+  <circle cx="15" cy="11" r="1" fill="#6a6a5a"/>
+  <circle cx="18" cy="11" r="1" fill="#6a6a5a"/>
+  <rect x="8" y="12" width="16" height="12" rx="2" fill="#5a5a4a"/>
+  <rect x="8" y="12" width="16" height="3" fill="#4a4a3a"/>
+  <circle cx="10" cy="14" r="0.8" fill="#7a7a6a"/>
+  <circle cx="22" cy="14" r="0.8" fill="#7a7a6a"/>
+  <circle cx="10" cy="20" r="0.8" fill="#7a7a6a"/>
+  <circle cx="22" cy="20" r="0.8" fill="#7a7a6a"/>
+  <line x1="16" y1="15" x2="16" y2="22" stroke="#3a3a2a" stroke-width="1.5"/>
+  <line x1="13" y1="17" x2="19" y2="17" stroke="#3a3a2a" stroke-width="1.5"/>
+  <ellipse cx="16" cy="22" rx="2" ry="1" fill="none" stroke="#3a3a2a" stroke-width="1"/>
+  <rect x="2" y="12" width="6" height="10" rx="2" fill="#6a5a3a"/>
+  <rect x="24" y="12" width="6" height="10" rx="2" fill="#6a5a3a"/>
+  <line x1="3" y1="15" x2="7" y2="15" stroke="#4a3a1a" stroke-width="0.8"/>
+  <line x1="3" y1="18" x2="7" y2="18" stroke="#4a3a1a" stroke-width="0.8"/>
+  <line x1="25" y1="15" x2="29" y2="15" stroke="#4a3a1a" stroke-width="0.8"/>
+  <line x1="25" y1="18" x2="29" y2="18" stroke="#4a3a1a" stroke-width="0.8"/>
+  <rect x="1" y="21" width="7" height="5" rx="2" fill="#5a4a2a"/>
+  <rect x="24" y="21" width="7" height="5" rx="2" fill="#5a4a2a"/>
+  <!-- Legs: left forward, right back -->
+  <rect x="9" y="24" width="5" height="9" rx="1" fill="#5a5a4a"/>
+  <rect x="17" y="24" width="5" height="7" rx="1" fill="#5a5a4a"/>
+  <ellipse cx="11" cy="33" rx="4" ry="1.2" fill="#3a4a2a"/>
+  <ellipse cx="20" cy="31" rx="4" ry="1.2" fill="#3a4a2a"/>
+</svg>

--- a/web/public/sprites/wreck-golem-2.svg
+++ b/web/public/sprites/wreck-golem-2.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Wreck Golem — frame 2 (mid-stride, body 1px higher) -->
+  <rect x="11" y="1" width="10" height="9" rx="2" fill="#5a5a4a"/>
+  <rect x="11" y="1" width="10" height="2" fill="#6a6a5a"/>
+  <circle cx="14" cy="6" r="2" fill="#3a3a2a"/>
+  <circle cx="14" cy="6" r="1.2" fill="#dd8822" opacity="0.9"/>
+  <circle cx="19" cy="6" r="2" fill="#3a3a2a"/>
+  <circle cx="19" cy="6" r="1.2" fill="#dd8822" opacity="0.9"/>
+  <line x1="13" y1="3" x2="12" y2="8" stroke="#8a4a1a" stroke-width="0.7" opacity="0.6"/>
+  <line x1="20" y1="3" x2="21" y2="8" stroke="#8a4a1a" stroke-width="0.7" opacity="0.6"/>
+  <rect x="14" y="9" width="4" height="2" rx="0.5" fill="#4a4a3a"/>
+  <circle cx="15" cy="10" r="1" fill="#6a6a5a"/>
+  <circle cx="18" cy="10" r="1" fill="#6a6a5a"/>
+  <rect x="8" y="11" width="16" height="12" rx="2" fill="#5a5a4a"/>
+  <rect x="8" y="11" width="16" height="3" fill="#4a4a3a"/>
+  <circle cx="10" cy="13" r="0.8" fill="#7a7a6a"/>
+  <circle cx="22" cy="13" r="0.8" fill="#7a7a6a"/>
+  <circle cx="10" cy="19" r="0.8" fill="#7a7a6a"/>
+  <circle cx="22" cy="19" r="0.8" fill="#7a7a6a"/>
+  <line x1="16" y1="14" x2="16" y2="21" stroke="#3a3a2a" stroke-width="1.5"/>
+  <line x1="13" y1="16" x2="19" y2="16" stroke="#3a3a2a" stroke-width="1.5"/>
+  <ellipse cx="16" cy="21" rx="2" ry="1" fill="none" stroke="#3a3a2a" stroke-width="1"/>
+  <rect x="2" y="11" width="6" height="10" rx="2" fill="#6a5a3a"/>
+  <rect x="24" y="11" width="6" height="10" rx="2" fill="#6a5a3a"/>
+  <line x1="3" y1="14" x2="7" y2="14" stroke="#4a3a1a" stroke-width="0.8"/>
+  <line x1="3" y1="17" x2="7" y2="17" stroke="#4a3a1a" stroke-width="0.8"/>
+  <line x1="25" y1="14" x2="29" y2="14" stroke="#4a3a1a" stroke-width="0.8"/>
+  <line x1="25" y1="17" x2="29" y2="17" stroke="#4a3a1a" stroke-width="0.8"/>
+  <rect x="1" y="20" width="7" height="5" rx="2" fill="#5a4a2a"/>
+  <rect x="24" y="20" width="7" height="5" rx="2" fill="#5a4a2a"/>
+  <!-- Legs mid-stride (both even) -->
+  <rect x="10" y="23" width="5" height="8" rx="1" fill="#5a5a4a"/>
+  <rect x="17" y="23" width="5" height="8" rx="1" fill="#5a5a4a"/>
+  <ellipse cx="12" cy="32" rx="4" ry="1.2" fill="#3a4a2a"/>
+  <ellipse cx="20" cy="32" rx="4" ry="1.2" fill="#3a4a2a"/>
+</svg>

--- a/web/public/sprites/wreck-golem-3.svg
+++ b/web/public/sprites/wreck-golem-3.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Wreck Golem — frame 3 (stride B: right leg forward, left back) -->
+  <rect x="11" y="2" width="10" height="9" rx="2" fill="#5a5a4a"/>
+  <rect x="11" y="2" width="10" height="2" fill="#6a6a5a"/>
+  <circle cx="14" cy="7" r="2" fill="#3a3a2a"/>
+  <circle cx="14" cy="7" r="1.2" fill="#dd8822" opacity="0.9"/>
+  <circle cx="19" cy="7" r="2" fill="#3a3a2a"/>
+  <circle cx="19" cy="7" r="1.2" fill="#dd8822" opacity="0.9"/>
+  <line x1="13" y1="4" x2="12" y2="9" stroke="#8a4a1a" stroke-width="0.7" opacity="0.6"/>
+  <line x1="20" y1="4" x2="21" y2="9" stroke="#8a4a1a" stroke-width="0.7" opacity="0.6"/>
+  <rect x="14" y="10" width="4" height="2" rx="0.5" fill="#4a4a3a"/>
+  <circle cx="15" cy="11" r="1" fill="#6a6a5a"/>
+  <circle cx="18" cy="11" r="1" fill="#6a6a5a"/>
+  <rect x="8" y="12" width="16" height="12" rx="2" fill="#5a5a4a"/>
+  <rect x="8" y="12" width="16" height="3" fill="#4a4a3a"/>
+  <circle cx="10" cy="14" r="0.8" fill="#7a7a6a"/>
+  <circle cx="22" cy="14" r="0.8" fill="#7a7a6a"/>
+  <circle cx="10" cy="20" r="0.8" fill="#7a7a6a"/>
+  <circle cx="22" cy="20" r="0.8" fill="#7a7a6a"/>
+  <line x1="16" y1="15" x2="16" y2="22" stroke="#3a3a2a" stroke-width="1.5"/>
+  <line x1="13" y1="17" x2="19" y2="17" stroke="#3a3a2a" stroke-width="1.5"/>
+  <ellipse cx="16" cy="22" rx="2" ry="1" fill="none" stroke="#3a3a2a" stroke-width="1"/>
+  <rect x="2" y="12" width="6" height="10" rx="2" fill="#6a5a3a"/>
+  <rect x="24" y="12" width="6" height="10" rx="2" fill="#6a5a3a"/>
+  <line x1="3" y1="15" x2="7" y2="15" stroke="#4a3a1a" stroke-width="0.8"/>
+  <line x1="3" y1="18" x2="7" y2="18" stroke="#4a3a1a" stroke-width="0.8"/>
+  <line x1="25" y1="15" x2="29" y2="15" stroke="#4a3a1a" stroke-width="0.8"/>
+  <line x1="25" y1="18" x2="29" y2="18" stroke="#4a3a1a" stroke-width="0.8"/>
+  <rect x="1" y="21" width="7" height="5" rx="2" fill="#5a4a2a"/>
+  <rect x="24" y="21" width="7" height="5" rx="2" fill="#5a4a2a"/>
+  <!-- Legs: right forward, left back (opposite of frame 1) -->
+  <rect x="9" y="24" width="5" height="7" rx="1" fill="#5a5a4a"/>
+  <rect x="17" y="24" width="5" height="9" rx="1" fill="#5a5a4a"/>
+  <ellipse cx="11" cy="31" rx="4" ry="1.2" fill="#3a4a2a"/>
+  <ellipse cx="20" cy="33" rx="4" ry="1.2" fill="#3a4a2a"/>
+</svg>

--- a/web/public/sprites/wreck-golem.svg
+++ b/web/public/sprites/wreck-golem.svg
@@ -1,0 +1,47 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Wreck Golem — static/frame 2 -->
+  <!-- Head (barnacled iron) -->
+  <rect x="11" y="2" width="10" height="9" rx="2" fill="#5a5a4a"/>
+  <rect x="11" y="2" width="10" height="2" fill="#6a6a5a"/>
+  <!-- Porthole eyes -->
+  <circle cx="14" cy="7" r="2" fill="#3a3a2a"/>
+  <circle cx="14" cy="7" r="1.2" fill="#dd8822" opacity="0.9"/>
+  <circle cx="19" cy="7" r="2" fill="#3a3a2a"/>
+  <circle cx="19" cy="7" r="1.2" fill="#dd8822" opacity="0.9"/>
+  <!-- Rust streaks on head -->
+  <line x1="13" y1="4" x2="12" y2="9" stroke="#8a4a1a" stroke-width="0.7" opacity="0.6"/>
+  <line x1="20" y1="4" x2="21" y2="9" stroke="#8a4a1a" stroke-width="0.7" opacity="0.6"/>
+  <!-- Neck bolts -->
+  <rect x="14" y="10" width="4" height="2" rx="0.5" fill="#4a4a3a"/>
+  <circle cx="15" cy="11" r="1" fill="#6a6a5a"/>
+  <circle cx="18" cy="11" r="1" fill="#6a6a5a"/>
+  <!-- Torso (ship-hull plates) -->
+  <rect x="8" y="12" width="16" height="12" rx="2" fill="#5a5a4a"/>
+  <rect x="8" y="12" width="16" height="3" fill="#4a4a3a"/>
+  <!-- Plate rivets -->
+  <circle cx="10" cy="14" r="0.8" fill="#7a7a6a"/>
+  <circle cx="22" cy="14" r="0.8" fill="#7a7a6a"/>
+  <circle cx="10" cy="20" r="0.8" fill="#7a7a6a"/>
+  <circle cx="22" cy="20" r="0.8" fill="#7a7a6a"/>
+  <!-- Chest anchor emblem -->
+  <line x1="16" y1="15" x2="16" y2="22" stroke="#3a3a2a" stroke-width="1.5"/>
+  <line x1="13" y1="17" x2="19" y2="17" stroke="#3a3a2a" stroke-width="1.5"/>
+  <ellipse cx="16" cy="22" rx="2" ry="1" fill="none" stroke="#3a3a2a" stroke-width="1"/>
+  <!-- Arms (planks + chains) -->
+  <rect x="2" y="12" width="6" height="10" rx="2" fill="#6a5a3a"/>
+  <rect x="24" y="12" width="6" height="10" rx="2" fill="#6a5a3a"/>
+  <!-- Chain details on arms -->
+  <line x1="3" y1="15" x2="7" y2="15" stroke="#4a3a1a" stroke-width="0.8"/>
+  <line x1="3" y1="18" x2="7" y2="18" stroke="#4a3a1a" stroke-width="0.8"/>
+  <line x1="25" y1="15" x2="29" y2="15" stroke="#4a3a1a" stroke-width="0.8"/>
+  <line x1="25" y1="18" x2="29" y2="18" stroke="#4a3a1a" stroke-width="0.8"/>
+  <!-- Fists -->
+  <rect x="1" y="21" width="7" height="5" rx="2" fill="#5a4a2a"/>
+  <rect x="24" y="21" width="7" height="5" rx="2" fill="#5a4a2a"/>
+  <!-- Legs (iron pillars) -->
+  <rect x="10" y="24" width="5" height="8" rx="1" fill="#5a5a4a"/>
+  <rect x="17" y="24" width="5" height="8" rx="1" fill="#5a5a4a"/>
+  <!-- Barnacles on feet -->
+  <ellipse cx="12" cy="32" rx="4" ry="1.2" fill="#3a4a2a"/>
+  <ellipse cx="20" cy="32" rx="4" ry="1.2" fill="#3a4a2a"/>
+</svg>

--- a/web/public/sprites/zephyr-scout-1.svg
+++ b/web/public/sprites/zephyr-scout-1.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Zephyr Scout — frame 1 (stride A: left leg forward, right back) -->
+  <path d="M11,6 Q13,1 16,3 Q19,1 21,6" fill="#ccaa44"/>
+  <path d="M21,6 Q26,3 25,7" fill="#ccaa44" opacity="0.7"/>
+  <ellipse cx="16" cy="8" rx="5" ry="5" fill="#f0c898"/>
+  <ellipse cx="14" cy="7.5" rx="1.2" ry="1" fill="#1a4a1a"/>
+  <ellipse cx="18" cy="7.5" rx="1.2" ry="1" fill="#1a4a1a"/>
+  <circle cx="14.3" cy="7.3" r="0.4" fill="#ffffff"/>
+  <circle cx="18.3" cy="7.3" r="0.4" fill="#ffffff"/>
+  <path d="M11,11 Q16,14 21,11" stroke="#88ccaa" stroke-width="2" fill="none"/>
+  <path d="M21,11 Q25,9 27,12" stroke="#88ccaa" stroke-width="1.5" fill="none" opacity="0.7"/>
+  <rect x="12" y="12" width="8" height="10" rx="2" fill="#7a6a2a"/>
+  <rect x="12" y="12" width="8" height="2.5" fill="#6a5a1a"/>
+  <rect x="12" y="19" width="8" height="1.5" fill="#4a3a0a"/>
+  <rect x="8" y="13" width="4" height="7" rx="2" fill="#7a6a2a"/>
+  <rect x="20" y="13" width="4" height="7" rx="2" fill="#7a6a2a"/>
+  <path d="M12,13 Q5,18 4,24 Q8,22 12,22 Z" fill="#99bb55" opacity="0.8"/>
+  <path d="M20,13 Q27,18 28,24 Q24,22 20,22 Z" fill="#99bb55" opacity="0.8"/>
+  <line x1="8" y1="16" x2="5" y2="20" stroke="#7a9a33" stroke-width="0.7"/>
+  <line x1="10" y1="18" x2="6" y2="22" stroke="#7a9a33" stroke-width="0.7"/>
+  <line x1="24" y1="16" x2="27" y2="20" stroke="#7a9a33" stroke-width="0.7"/>
+  <line x1="22" y1="18" x2="26" y2="22" stroke="#7a9a33" stroke-width="0.7"/>
+  <!-- Legs: left forward, right back -->
+  <rect x="12" y="22" width="3" height="9" rx="1" fill="#5a4a1a"/>
+  <rect x="17" y="22" width="3" height="7" rx="1" fill="#5a4a1a"/>
+  <rect x="11" y="29" width="5" height="3" rx="1" fill="#3a2a0a"/>
+  <rect x="16" y="27" width="5" height="3" rx="1" fill="#3a2a0a"/>
+</svg>

--- a/web/public/sprites/zephyr-scout-2.svg
+++ b/web/public/sprites/zephyr-scout-2.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Zephyr Scout — frame 2 (mid-stride, body 1px higher) -->
+  <path d="M11,5 Q13,0 16,2 Q19,0 21,5" fill="#ccaa44"/>
+  <path d="M21,5 Q26,2 25,6" fill="#ccaa44" opacity="0.7"/>
+  <ellipse cx="16" cy="7" rx="5" ry="5" fill="#f0c898"/>
+  <ellipse cx="14" cy="6.5" rx="1.2" ry="1" fill="#1a4a1a"/>
+  <ellipse cx="18" cy="6.5" rx="1.2" ry="1" fill="#1a4a1a"/>
+  <circle cx="14.3" cy="6.3" r="0.4" fill="#ffffff"/>
+  <circle cx="18.3" cy="6.3" r="0.4" fill="#ffffff"/>
+  <path d="M11,10 Q16,13 21,10" stroke="#88ccaa" stroke-width="2" fill="none"/>
+  <path d="M21,10 Q25,8 27,11" stroke="#88ccaa" stroke-width="1.5" fill="none" opacity="0.7"/>
+  <rect x="12" y="11" width="8" height="10" rx="2" fill="#7a6a2a"/>
+  <rect x="12" y="11" width="8" height="2.5" fill="#6a5a1a"/>
+  <rect x="12" y="18" width="8" height="1.5" fill="#4a3a0a"/>
+  <rect x="8" y="12" width="4" height="7" rx="2" fill="#7a6a2a"/>
+  <rect x="20" y="12" width="4" height="7" rx="2" fill="#7a6a2a"/>
+  <path d="M12,12 Q5,17 4,23 Q8,21 12,21 Z" fill="#99bb55" opacity="0.8"/>
+  <path d="M20,12 Q27,17 28,23 Q24,21 20,21 Z" fill="#99bb55" opacity="0.8"/>
+  <line x1="8" y1="15" x2="5" y2="19" stroke="#7a9a33" stroke-width="0.7"/>
+  <line x1="10" y1="17" x2="6" y2="21" stroke="#7a9a33" stroke-width="0.7"/>
+  <line x1="24" y1="15" x2="27" y2="19" stroke="#7a9a33" stroke-width="0.7"/>
+  <line x1="22" y1="17" x2="26" y2="21" stroke="#7a9a33" stroke-width="0.7"/>
+  <!-- Legs mid-stride (both even) -->
+  <rect x="13" y="21" width="3" height="8" rx="1" fill="#5a4a1a"/>
+  <rect x="17" y="21" width="3" height="8" rx="1" fill="#5a4a1a"/>
+  <rect x="12" y="27" width="5" height="3" rx="1" fill="#3a2a0a"/>
+  <rect x="16" y="27" width="5" height="3" rx="1" fill="#3a2a0a"/>
+</svg>

--- a/web/public/sprites/zephyr-scout-3.svg
+++ b/web/public/sprites/zephyr-scout-3.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Zephyr Scout — frame 3 (stride B: right leg forward, left back) -->
+  <path d="M11,6 Q13,1 16,3 Q19,1 21,6" fill="#ccaa44"/>
+  <path d="M21,6 Q26,3 25,7" fill="#ccaa44" opacity="0.7"/>
+  <ellipse cx="16" cy="8" rx="5" ry="5" fill="#f0c898"/>
+  <ellipse cx="14" cy="7.5" rx="1.2" ry="1" fill="#1a4a1a"/>
+  <ellipse cx="18" cy="7.5" rx="1.2" ry="1" fill="#1a4a1a"/>
+  <circle cx="14.3" cy="7.3" r="0.4" fill="#ffffff"/>
+  <circle cx="18.3" cy="7.3" r="0.4" fill="#ffffff"/>
+  <path d="M11,11 Q16,14 21,11" stroke="#88ccaa" stroke-width="2" fill="none"/>
+  <path d="M21,11 Q25,9 27,12" stroke="#88ccaa" stroke-width="1.5" fill="none" opacity="0.7"/>
+  <rect x="12" y="12" width="8" height="10" rx="2" fill="#7a6a2a"/>
+  <rect x="12" y="12" width="8" height="2.5" fill="#6a5a1a"/>
+  <rect x="12" y="19" width="8" height="1.5" fill="#4a3a0a"/>
+  <rect x="8" y="13" width="4" height="7" rx="2" fill="#7a6a2a"/>
+  <rect x="20" y="13" width="4" height="7" rx="2" fill="#7a6a2a"/>
+  <path d="M12,13 Q5,18 4,24 Q8,22 12,22 Z" fill="#99bb55" opacity="0.8"/>
+  <path d="M20,13 Q27,18 28,24 Q24,22 20,22 Z" fill="#99bb55" opacity="0.8"/>
+  <line x1="8" y1="16" x2="5" y2="20" stroke="#7a9a33" stroke-width="0.7"/>
+  <line x1="10" y1="18" x2="6" y2="22" stroke="#7a9a33" stroke-width="0.7"/>
+  <line x1="24" y1="16" x2="27" y2="20" stroke="#7a9a33" stroke-width="0.7"/>
+  <line x1="22" y1="18" x2="26" y2="22" stroke="#7a9a33" stroke-width="0.7"/>
+  <!-- Legs: right forward, left back (opposite of frame 1) -->
+  <rect x="12" y="22" width="3" height="7" rx="1" fill="#5a4a1a"/>
+  <rect x="17" y="22" width="3" height="9" rx="1" fill="#5a4a1a"/>
+  <rect x="11" y="27" width="5" height="3" rx="1" fill="#3a2a0a"/>
+  <rect x="16" y="29" width="5" height="3" rx="1" fill="#3a2a0a"/>
+</svg>

--- a/web/public/sprites/zephyr-scout.svg
+++ b/web/public/sprites/zephyr-scout.svg
@@ -1,0 +1,38 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Zephyr Scout — static/frame 2 -->
+  <!-- Hair/hood (wind-swept) -->
+  <path d="M11,6 Q13,1 16,3 Q19,1 21,6" fill="#ccaa44"/>
+  <path d="M21,6 Q26,3 25,7" fill="#ccaa44" opacity="0.7"/>
+  <!-- Head -->
+  <ellipse cx="16" cy="8" rx="5" ry="5" fill="#f0c898"/>
+  <!-- Eyes (alert, keen) -->
+  <ellipse cx="14" cy="7.5" rx="1.2" ry="1" fill="#1a4a1a"/>
+  <ellipse cx="18" cy="7.5" rx="1.2" ry="1" fill="#1a4a1a"/>
+  <circle cx="14.3" cy="7.3" r="0.4" fill="#ffffff"/>
+  <circle cx="18.3" cy="7.3" r="0.4" fill="#ffffff"/>
+  <!-- Light scarf -->
+  <path d="M11,11 Q16,14 21,11" stroke="#88ccaa" stroke-width="2" fill="none"/>
+  <path d="M21,11 Q25,9 27,12" stroke="#88ccaa" stroke-width="1.5" fill="none" opacity="0.7"/>
+  <!-- Body (light leather vest) -->
+  <rect x="12" y="12" width="8" height="10" rx="2" fill="#7a6a2a"/>
+  <rect x="12" y="12" width="8" height="2.5" fill="#6a5a1a"/>
+  <!-- Belt -->
+  <rect x="12" y="19" width="8" height="1.5" fill="#4a3a0a"/>
+  <!-- Arms (slender) -->
+  <rect x="8" y="13" width="4" height="7" rx="2" fill="#7a6a2a"/>
+  <rect x="20" y="13" width="4" height="7" rx="2" fill="#7a6a2a"/>
+  <!-- Wing cloak (feathered) -->
+  <path d="M12,13 Q5,18 4,24 Q8,22 12,22 Z" fill="#99bb55" opacity="0.8"/>
+  <path d="M20,13 Q27,18 28,24 Q24,22 20,22 Z" fill="#99bb55" opacity="0.8"/>
+  <!-- Feather details -->
+  <line x1="8" y1="16" x2="5" y2="20" stroke="#7a9a33" stroke-width="0.7"/>
+  <line x1="10" y1="18" x2="6" y2="22" stroke="#7a9a33" stroke-width="0.7"/>
+  <line x1="24" y1="16" x2="27" y2="20" stroke="#7a9a33" stroke-width="0.7"/>
+  <line x1="22" y1="18" x2="26" y2="22" stroke="#7a9a33" stroke-width="0.7"/>
+  <!-- Legs -->
+  <rect x="13" y="22" width="3" height="8" rx="1" fill="#5a4a1a"/>
+  <rect x="17" y="22" width="3" height="8" rx="1" fill="#5a4a1a"/>
+  <!-- Boots -->
+  <rect x="12" y="28" width="5" height="3" rx="1" fill="#3a2a0a"/>
+  <rect x="16" y="28" width="5" height="3" rx="1" fill="#3a2a0a"/>
+</svg>


### PR DESCRIPTION
Closes #607, closes #608

## Summary

- **Units (Issue #607):** Wreck Diver, Wreck Golem, Zephyr Scout — each with static + 3 walk frames. Thornlord walk frames only (base already existed).
- **Buildings (Issue #607):** Ancient Altar, Ancient Grove (reused orphan `anc-altar.svg` / `anc-grove.svg`), Ancient Barracks, Aerie Roost, Ballista Tower, Breakwater Wall.
- **Buildings (Issue #608):** Command Tent, Centaur Stable (reused orphan `cmd-tent.svg` / `cntaur-stbl.svg`), Canopy Farm, Canopy Watchtower, Clockwork Forge, Cloudfort, Drift Net, Drone Array, Elder Grove, Elder Shrine.

## File count
- 27 new SVG files added across both issues.

## Notes
- Orphan files (`anc-altar.svg`, `anc-grove.svg`, `cmd-tent.svg`, `cntaur-stbl.svg`) were reused by copying content to the correctly-named files.
- Walk frames follow the standard convention: frame 2 = body 1px higher, frames 1 & 3 = opposite strides.

https://claude.ai/code/session_01N8PP3AYB5cnjTMKW144oED

---
_Generated by [Claude Code](https://claude.ai/code/session_01N8PP3AYB5cnjTMKW144oED)_