### PR TITLE
fix(fruit-machine): hide ladder slots to the left of position 0 at rock bottom

### DIFF
--- a/web/src/components/minigames/FruitMachine.tsx
+++ b/web/src/components/minigames/FruitMachine.tsx
@@ -659,10 +659,13 @@ function regressBoardBy(steps: number) {
   const canBuy = phase === 'idle' && credits > 0 && credits < MAX_CREDITS && availCrystals >= BUY_COST
   const totalWin = lastWin ?? 0
 
-  // Board display window: 5 nodes centred on current position
-  const boardWindow = [-2, -1, 0, 1, 2].map(offset => {
-    const idx = ((boardPos + offset) % BOARD_SIZE + BOARD_SIZE) % BOARD_SIZE
-    return { idx, node: BOARD_NODES[idx], isCurrent: offset === 0 }
+  // Board display window: up to 5 nodes centred on current position.
+  // Offsets that would go below position 0 are omitted (no wrap-around at rock bottom).
+  const boardWindow = [-2, -1, 0, 1, 2].flatMap(offset => {
+    const absPos = boardPos + offset
+    if (absPos < 0) return []
+    const idx = absPos % BOARD_SIZE
+    return [{ idx, node: BOARD_NODES[idx], isCurrent: offset === 0 }]
   })
 
   return (


### PR DESCRIPTION
## Summary

- At board position 0 ("rock bottom"), the previous modulo wrap-around caused offsets -1 and -2 to resolve to the last two nodes of the board, showing them as if they were "behind" position 0.
- Fixed by switching from `.map()` with double-modulo to `.flatMap()` that simply drops any offset producing a negative absolute position — so no slots appear to the left when at the start of the ladder.
- At all other positions the behaviour is unchanged (still shows up to 2 nodes on each side of the current position).

## Test plan

- [ ] Start a new game / reset board to position 0 — confirm only the current node and the two to its right are shown (3 slots total, current on the left edge)
- [ ] Advance to position 1 — confirm one node appears to the left and two to the right (4 slots)
- [ ] Advance to position 2+ — confirm the normal 5-slot window is restored
- [ ] Verify no wraparound artifacts appear at any position

https://claude.ai/code/session_01Q1qxg2RsgDu3nEJc8WssS9

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q1qxg2RsgDu3nEJc8WssS9)_