### PR TITLE
Add missing card SVGs — Batches 10, 11 & 12 (issues #610, #611 & #612)

### DIFF
--- a/web/public/sprites/aerial-volley.svg
+++ b/web/public/sprites/aerial-volley.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Sky backdrop glow -->
+  <ellipse cx="16" cy="6" rx="12" ry="5" fill="#4488cc" opacity="0.3"/>
+  <!-- Arrow 1 (left, steep angle) -->
+  <line x1="7" y1="4" x2="5" y2="20" stroke="#8a5a1a" stroke-width="1.5" stroke-linecap="round"/>
+  <polygon points="5,20 3,17 7,18" fill="#ccbbaa"/>
+  <line x1="7" y1="4" x2="6" y2="6" stroke="#ffcc00" stroke-width="0.8"/>
+  <line x1="7" y1="4" x2="8" y2="6" stroke="#ffcc00" stroke-width="0.8"/>
+  <!-- Arrow 2 (centre, vertical) -->
+  <line x1="16" y1="2" x2="16" y2="20" stroke="#8a5a1a" stroke-width="1.5" stroke-linecap="round"/>
+  <polygon points="16,20 14,17 18,17" fill="#ccbbaa"/>
+  <line x1="16" y1="2" x2="15" y2="5" stroke="#ffcc00" stroke-width="0.8"/>
+  <line x1="16" y1="2" x2="17" y2="5" stroke="#ffcc00" stroke-width="0.8"/>
+  <!-- Arrow 3 (right, steep angle) -->
+  <line x1="25" y1="4" x2="27" y2="20" stroke="#8a5a1a" stroke-width="1.5" stroke-linecap="round"/>
+  <polygon points="27,20 25,17 29,18" fill="#ccbbaa"/>
+  <line x1="25" y1="4" x2="24" y2="6" stroke="#ffcc00" stroke-width="0.8"/>
+  <line x1="25" y1="4" x2="26" y2="6" stroke="#ffcc00" stroke-width="0.8"/>
+  <!-- Arrow 4 (mid-left) -->
+  <line x1="10" y1="3" x2="9" y2="15" stroke="#8a5a1a" stroke-width="1.2" stroke-linecap="round"/>
+  <polygon points="9,15 7.5,13 10.5,13" fill="#ccbbaa"/>
+  <!-- Arrow 5 (mid-right) -->
+  <line x1="22" y1="3" x2="23" y2="15" stroke="#8a5a1a" stroke-width="1.2" stroke-linecap="round"/>
+  <polygon points="23,15 21.5,13 24.5,13" fill="#ccbbaa"/>
+  <!-- Impact dust cloud at bottom -->
+  <ellipse cx="16" cy="27" rx="12" ry="4" fill="#aa8833" opacity="0.3"/>
+  <ellipse cx="7" cy="26" rx="4" ry="2.5" fill="#cc9944" opacity="0.25"/>
+  <ellipse cx="25" cy="26" rx="4" ry="2.5" fill="#cc9944" opacity="0.25"/>
+  <!-- Impact craters -->
+  <ellipse cx="5" cy="28" rx="2" ry="1" fill="#8a6622" opacity="0.5"/>
+  <ellipse cx="16" cy="28" rx="2.5" ry="1" fill="#8a6622" opacity="0.5"/>
+  <ellipse cx="27" cy="28" rx="2" ry="1" fill="#8a6622" opacity="0.5"/>
+</svg>

--- a/web/public/sprites/ancient-blessing.svg
+++ b/web/public/sprites/ancient-blessing.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Divine light rays from above -->
+  <line x1="16" y1="1" x2="10" y2="16" stroke="#ffdd44" stroke-width="2" opacity="0.4" stroke-linecap="round"/>
+  <line x1="16" y1="1" x2="16" y2="18" stroke="#ffdd44" stroke-width="2.5" opacity="0.5" stroke-linecap="round"/>
+  <line x1="16" y1="1" x2="22" y2="16" stroke="#ffdd44" stroke-width="2" opacity="0.4" stroke-linecap="round"/>
+  <line x1="16" y1="1" x2="7" y2="14" stroke="#ffee88" stroke-width="1.2" opacity="0.3" stroke-linecap="round"/>
+  <line x1="16" y1="1" x2="25" y2="14" stroke="#ffee88" stroke-width="1.2" opacity="0.3" stroke-linecap="round"/>
+  <!-- Source glow at top -->
+  <ellipse cx="16" cy="2" rx="5" ry="2.5" fill="#ffdd44" opacity="0.6"/>
+  <ellipse cx="16" cy="1.5" rx="3" ry="1.5" fill="#ffffff" opacity="0.5"/>
+  <!-- Central blessed circle -->
+  <circle cx="16" cy="19" r="7" fill="#ffdd44" opacity="0.2"/>
+  <circle cx="16" cy="19" r="5" fill="#ffdd44" opacity="0.3"/>
+  <circle cx="16" cy="19" r="3" fill="#ffcc00" opacity="0.7"/>
+  <circle cx="16" cy="19" r="1.5" fill="#ffffff" opacity="0.8"/>
+  <!-- Ancient rune in centre -->
+  <text x="16" y="21.5" font-size="7" text-anchor="middle" fill="#aa8800" font-family="monospace" opacity="0.9">ᚷ</text>
+  <!-- Radiant sparkles -->
+  <circle cx="9" cy="17" r="1" fill="#ffdd44" opacity="0.7"/>
+  <circle cx="23" cy="17" r="1" fill="#ffdd44" opacity="0.7"/>
+  <circle cx="12" cy="13" r="0.8" fill="#ffffff" opacity="0.6"/>
+  <circle cx="20" cy="13" r="0.8" fill="#ffffff" opacity="0.6"/>
+  <circle cx="16" cy="11" r="0.8" fill="#ffee88" opacity="0.7"/>
+  <!-- Ground glow -->
+  <ellipse cx="16" cy="28" rx="10" ry="3" fill="#ffdd44" opacity="0.15"/>
+</svg>

--- a/web/public/sprites/arcane-efficiency.svg
+++ b/web/public/sprites/arcane-efficiency.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Large gear (left) -->
+  <circle cx="11" cy="17" r="8" fill="#5a5a6a" stroke="#3a3a4a" stroke-width="0.8"/>
+  <circle cx="11" cy="17" r="5" fill="#3a3a4a"/>
+  <circle cx="11" cy="17" r="2.5" fill="#6a6a7a"/>
+  <!-- Gear teeth (large) -->
+  <rect x="8.5" y="8" width="5" height="2.5" rx="0.5" fill="#5a5a6a"/>
+  <rect x="8.5" y="24.5" width="5" height="2.5" rx="0.5" fill="#5a5a6a"/>
+  <rect x="2" y="14.5" width="2.5" height="5" rx="0.5" fill="#5a5a6a"/>
+  <rect x="17.5" y="14.5" width="2.5" height="5" rx="0.5" fill="#5a5a6a"/>
+  <rect x="4" y="10" width="2.5" height="4" rx="0.5" fill="#5a5a6a" transform="rotate(-45,5,12)"/>
+  <rect x="15" y="10" width="2.5" height="4" rx="0.5" fill="#5a5a6a" transform="rotate(45,16,12)"/>
+  <!-- Small gear (right, meshing) -->
+  <circle cx="23" cy="12" r="5" fill="#6a6a7a" stroke="#4a4a5a" stroke-width="0.7"/>
+  <circle cx="23" cy="12" r="3" fill="#4a4a5a"/>
+  <circle cx="23" cy="12" r="1.5" fill="#7a7a8a"/>
+  <rect x="21" y="6.5" width="4" height="2" rx="0.4" fill="#6a6a7a"/>
+  <rect x="21" y="15.5" width="4" height="2" rx="0.4" fill="#6a6a7a"/>
+  <rect x="17.5" y="10" width="2" height="4" rx="0.4" fill="#6a6a7a"/>
+  <rect x="27.5" y="10" width="2" height="4" rx="0.4" fill="#6a6a7a"/>
+  <!-- Arcane energy flowing through gears -->
+  <circle cx="11" cy="17" r="2.5" fill="#8844ff" opacity="0.6"/>
+  <circle cx="11" cy="17" r="1.2" fill="#cc88ff" opacity="0.7"/>
+  <circle cx="23" cy="12" r="1.5" fill="#8844ff" opacity="0.5"/>
+  <circle cx="23" cy="12" r="0.7" fill="#cc88ff" opacity="0.6"/>
+  <!-- Energy arc between gears -->
+  <path d="M16,14 Q19,11 20,12" stroke="#aa55ff" stroke-width="1" fill="none" opacity="0.7"/>
+  <!-- Efficiency arrow (upward) -->
+  <line x1="27" y1="28" x2="27" y2="20" stroke="#44ff88" stroke-width="1.5" stroke-linecap="round"/>
+  <polygon points="27,19 25,22 29,22" fill="#44ff88"/>
+</svg>

--- a/web/public/sprites/battle-cry.svg
+++ b/web/public/sprites/battle-cry.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Sound wave rings emanating outward -->
+  <ellipse cx="12" cy="16" rx="4" ry="6" fill="none" stroke="#ff6622" stroke-width="1.5" opacity="0.9"/>
+  <ellipse cx="12" cy="16" rx="8" ry="10" fill="none" stroke="#ff6622" stroke-width="1.2" opacity="0.6"/>
+  <ellipse cx="12" cy="16" rx="12" ry="14" fill="none" stroke="#ff8844" stroke-width="0.9" opacity="0.4"/>
+  <!-- Mouth/shout source -->
+  <ellipse cx="9" cy="16" rx="4" ry="5" fill="#cc3300"/>
+  <ellipse cx="9" cy="16" rx="3" ry="4" fill="#ff4400"/>
+  <ellipse cx="9" cy="17" rx="2" ry="2.5" fill="#1a0a00"/>
+  <!-- Force lines (directional) -->
+  <line x1="14" y1="11" x2="22" y2="8" stroke="#ff8844" stroke-width="1.5" stroke-linecap="round" opacity="0.8"/>
+  <line x1="15" y1="16" x2="30" y2="16" stroke="#ff6622" stroke-width="2" stroke-linecap="round" opacity="0.8"/>
+  <line x1="14" y1="21" x2="22" y2="24" stroke="#ff8844" stroke-width="1.5" stroke-linecap="round" opacity="0.8"/>
+  <!-- Arrow tips on force lines -->
+  <polygon points="22,8 19,7 20,10" fill="#ff8844" opacity="0.8"/>
+  <polygon points="30,16 27,14 27,18" fill="#ff6622" opacity="0.8"/>
+  <polygon points="22,24 19,22 20,26" fill="#ff8844" opacity="0.8"/>
+  <!-- Exclamation / energy burst at source -->
+  <circle cx="9" cy="8" r="2" fill="#ffcc00"/>
+  <rect x="8.2" y="3" width="1.6" height="3.5" rx="0.5" fill="#ffcc00"/>
+  <!-- Spark particles -->
+  <circle cx="20" cy="10" r="1" fill="#ffaa44" opacity="0.7"/>
+  <circle cx="25" cy="14" r="0.8" fill="#ff8822" opacity="0.6"/>
+  <circle cx="20" cy="22" r="1" fill="#ffaa44" opacity="0.7"/>
+</svg>

--- a/web/public/sprites/battle-hardened.svg
+++ b/web/public/sprites/battle-hardened.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Shield outer (iron) -->
+  <path d="M16,2 L28,7 L28,18 Q28,28 16,31 Q4,28 4,18 L4,7 Z" fill="#5a5a6a"/>
+  <!-- Shield inner plate -->
+  <path d="M16,5 L25,9 L25,18 Q25,26 16,28 Q7,26 7,18 L7,9 Z" fill="#6a6a7a"/>
+  <!-- Shield boss (centre rivet) -->
+  <circle cx="16" cy="17" r="5" fill="#4a4a5a"/>
+  <circle cx="16" cy="17" r="3.5" fill="#7a7a8a"/>
+  <circle cx="16" cy="17" r="1.5" fill="#9a9aaa"/>
+  <!-- Battle scars (diagonal gashes) -->
+  <line x1="10" y1="9" x2="14" y2="15" stroke="#3a3a4a" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="11" y1="9" x2="15" y2="15" stroke="#8a8a9a" stroke-width="0.7" stroke-linecap="round"/>
+  <line x1="20" y1="12" x2="24" y2="19" stroke="#3a3a4a" stroke-width="1.2" stroke-linecap="round"/>
+  <line x1="21" y1="12" x2="25" y2="19" stroke="#8a8a9a" stroke-width="0.6" stroke-linecap="round"/>
+  <line x1="9" y1="20" x2="14" y2="25" stroke="#3a3a4a" stroke-width="1" stroke-linecap="round"/>
+  <!-- Rivets at corners -->
+  <circle cx="10" cy="10" r="1.2" fill="#8a8a9a"/>
+  <circle cx="22" cy="10" r="1.2" fill="#8a8a9a"/>
+  <circle cx="9" cy="20" r="1.2" fill="#8a8a9a"/>
+  <circle cx="23" cy="20" r="1.2" fill="#8a8a9a"/>
+  <!-- Iron band across middle -->
+  <rect x="4" y="15" width="24" height="3" rx="0.5" fill="#5a5a6a" opacity="0.6"/>
+  <!-- Hardened glow (red tint — battle-worn) -->
+  <path d="M16,2 L28,7 L28,18 Q28,28 16,31 Q4,28 4,18 L4,7 Z" fill="#ff4400" opacity="0.06"/>
+  <!-- Crossed swords emblem on boss -->
+  <line x1="14" y1="15" x2="18" y2="19" stroke="#3a3a4a" stroke-width="1" stroke-linecap="round"/>
+  <line x1="18" y1="15" x2="14" y2="19" stroke="#3a3a4a" stroke-width="1" stroke-linecap="round"/>
+</svg>

--- a/web/public/sprites/blizzard-blast.svg
+++ b/web/public/sprites/blizzard-blast.svg
@@ -1,0 +1,37 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ice blast core -->
+  <circle cx="16" cy="16" r="6" fill="#aaddff" opacity="0.8"/>
+  <circle cx="16" cy="16" r="4" fill="#ddeeff" opacity="0.9"/>
+  <circle cx="16" cy="16" r="2" fill="#ffffff"/>
+  <!-- Ice shards radiating out -->
+  <!-- Top -->
+  <polygon points="16,10 14.5,5 17.5,5" fill="#88ccff"/>
+  <polygon points="16,10 15,7 17,7" fill="#aaddff" opacity="0.8"/>
+  <!-- Top-right -->
+  <polygon points="20,12 24,7 25,10" fill="#88ccff"/>
+  <!-- Right -->
+  <polygon points="22,16 27,14.5 27,17.5" fill="#88ccff"/>
+  <polygon points="22,16 25,15 25,17" fill="#aaddff" opacity="0.8"/>
+  <!-- Bottom-right -->
+  <polygon points="20,20 24,25 21,26" fill="#88ccff"/>
+  <!-- Bottom -->
+  <polygon points="16,22 14.5,27 17.5,27" fill="#88ccff"/>
+  <polygon points="16,22 15,25 17,25" fill="#aaddff" opacity="0.8"/>
+  <!-- Bottom-left -->
+  <polygon points="12,20 8,25 7,22" fill="#88ccff"/>
+  <!-- Left -->
+  <polygon points="10,16 5,14.5 5,17.5" fill="#88ccff"/>
+  <polygon points="10,16 7,15 7,17" fill="#aaddff" opacity="0.8"/>
+  <!-- Top-left -->
+  <polygon points="12,12 8,7 11,6" fill="#88ccff"/>
+  <!-- Snowflake cross in centre -->
+  <line x1="16" y1="13" x2="16" y2="19" stroke="#ffffff" stroke-width="1.5"/>
+  <line x1="13" y1="16" x2="19" y2="16" stroke="#ffffff" stroke-width="1.5"/>
+  <line x1="14" y1="14" x2="18" y2="18" stroke="#ffffff" stroke-width="1"/>
+  <line x1="18" y1="14" x2="14" y2="18" stroke="#ffffff" stroke-width="1"/>
+  <!-- Frost sparkles -->
+  <circle cx="8" cy="10" r="1" fill="#cceeff" opacity="0.8"/>
+  <circle cx="24" cy="10" r="1" fill="#cceeff" opacity="0.8"/>
+  <circle cx="6" cy="22" r="0.8" fill="#aaddff" opacity="0.7"/>
+  <circle cx="26" cy="22" r="0.8" fill="#aaddff" opacity="0.7"/>
+</svg>

--- a/web/public/sprites/bloodlust.svg
+++ b/web/public/sprites/bloodlust.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Dark aura outer ring -->
+  <circle cx="16" cy="15" r="13" fill="#440000" opacity="0.4"/>
+  <circle cx="16" cy="15" r="10" fill="#660000" opacity="0.5"/>
+  <!-- Blood drops raining -->
+  <!-- Drop 1 -->
+  <ellipse cx="8" cy="7" rx="1.5" ry="2" fill="#cc0000"/>
+  <polygon points="8,9 6.5,6 9.5,6" fill="#cc0000"/>
+  <!-- Drop 2 -->
+  <ellipse cx="16" cy="5" rx="2" ry="2.5" fill="#dd0000"/>
+  <polygon points="16,7.5 14,4.5 18,4.5" fill="#dd0000"/>
+  <!-- Drop 3 -->
+  <ellipse cx="24" cy="7" rx="1.5" ry="2" fill="#cc0000"/>
+  <polygon points="24,9 22.5,6 25.5,6" fill="#cc0000"/>
+  <!-- Drop 4 (falling) -->
+  <ellipse cx="5" cy="16" rx="1.2" ry="1.8" fill="#bb0000"/>
+  <ellipse cx="27" cy="14" rx="1.2" ry="1.8" fill="#bb0000"/>
+  <!-- Rage core (fist/claw) -->
+  <circle cx="16" cy="17" r="6" fill="#880000"/>
+  <circle cx="16" cy="17" r="4.5" fill="#aa0000"/>
+  <!-- Claw marks on core -->
+  <line x1="13" y1="14" x2="15" y2="20" stroke="#ff2200" stroke-width="1.2" stroke-linecap="round"/>
+  <line x1="16" y1="13" x2="16" y2="21" stroke="#ff2200" stroke-width="1.2" stroke-linecap="round"/>
+  <line x1="19" y1="14" x2="17" y2="20" stroke="#ff2200" stroke-width="1.2" stroke-linecap="round"/>
+  <!-- Glowing red eyes in core -->
+  <circle cx="13.5" cy="16" r="1.5" fill="#ff4400"/>
+  <circle cx="18.5" cy="16" r="1.5" fill="#ff4400"/>
+  <circle cx="13.5" cy="16" r="0.7" fill="#ffaa00"/>
+  <circle cx="18.5" cy="16" r="0.7" fill="#ffaa00"/>
+  <!-- Blood pool at base -->
+  <ellipse cx="16" cy="29" rx="9" ry="2.5" fill="#880000" opacity="0.5"/>
+  <ellipse cx="16" cy="29" rx="6" ry="1.5" fill="#aa0000" opacity="0.6"/>
+</svg>

--- a/web/public/sprites/burning-rush.svg
+++ b/web/public/sprites/burning-rush.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Speed lines trailing left -->
+  <line x1="1" y1="12" x2="14" y2="14" stroke="#ff6600" stroke-width="1.5" stroke-linecap="round" opacity="0.5"/>
+  <line x1="1" y1="16" x2="12" y2="16" stroke="#ff4400" stroke-width="2" stroke-linecap="round" opacity="0.6"/>
+  <line x1="1" y1="20" x2="14" y2="18" stroke="#ff6600" stroke-width="1.5" stroke-linecap="round" opacity="0.5"/>
+  <line x1="3" y1="9" x2="12" y2="12" stroke="#ffaa00" stroke-width="1" stroke-linecap="round" opacity="0.4"/>
+  <line x1="3" y1="23" x2="12" y2="20" stroke="#ffaa00" stroke-width="1" stroke-linecap="round" opacity="0.4"/>
+  <!-- Flame body (teardrop going right) -->
+  <path d="M10,16 Q12,8 20,10 Q26,12 27,16 Q26,20 20,22 Q12,24 10,16 Z" fill="#ff4400"/>
+  <path d="M12,16 Q14,10 20,12 Q24,14 25,16 Q24,18 20,20 Q14,22 12,16 Z" fill="#ff8800"/>
+  <path d="M14,16 Q16,12 20,13 Q23,14.5 23,16 Q23,17.5 20,19 Q16,20 14,16 Z" fill="#ffcc00"/>
+  <!-- Arrow tip pointing right -->
+  <polygon points="27,16 23,12 23,20" fill="#ffffff" opacity="0.9"/>
+  <polygon points="29,16 25,13 25,19" fill="#ffee44"/>
+  <!-- Flame inner core -->
+  <ellipse cx="19" cy="16" rx="3" ry="2.5" fill="#ffee44" opacity="0.8"/>
+  <ellipse cx="19" cy="16" rx="1.5" ry="1.2" fill="#ffffff" opacity="0.6"/>
+  <!-- Ember sparks -->
+  <circle cx="8" cy="10" r="1.2" fill="#ff8800" opacity="0.7"/>
+  <circle cx="6" cy="16" r="1" fill="#ff6600" opacity="0.6"/>
+  <circle cx="8" cy="22" r="1.2" fill="#ff8800" opacity="0.7"/>
+  <circle cx="14" cy="7" r="0.8" fill="#ffaa00" opacity="0.5"/>
+  <circle cx="14" cy="25" r="0.8" fill="#ffaa00" opacity="0.5"/>
+</svg>

--- a/web/public/sprites/canopy-growth.svg
+++ b/web/public/sprites/canopy-growth.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground sprout line -->
+  <ellipse cx="16" cy="30" rx="10" ry="2" fill="#4a3a1a" opacity="0.5"/>
+  <!-- Central vine (main stalk upward) -->
+  <path d="M16,30 Q14,24 16,18 Q18,12 16,6" stroke="#3a7a1a" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+  <!-- Left branch vine -->
+  <path d="M15,22 Q9,19 6,21" stroke="#3a7a1a" stroke-width="1.5" fill="none" stroke-linecap="round"/>
+  <path d="M14,16 Q8,13 5,15" stroke="#3a7a1a" stroke-width="1.5" fill="none" stroke-linecap="round"/>
+  <!-- Right branch vine -->
+  <path d="M17,20 Q23,17 26,19" stroke="#3a7a1a" stroke-width="1.5" fill="none" stroke-linecap="round"/>
+  <path d="M17,14 Q23,11 27,13" stroke="#3a7a1a" stroke-width="1.5" fill="none" stroke-linecap="round"/>
+  <!-- Leaves on branches -->
+  <!-- Left leaves -->
+  <ellipse cx="6" cy="20" rx="3.5" ry="2" fill="#3a9a20" transform="rotate(-20,6,20)"/>
+  <ellipse cx="5" cy="14" rx="3" ry="1.8" fill="#2d7a1b" transform="rotate(-30,5,14)"/>
+  <ellipse cx="10" cy="12" rx="2.5" ry="1.5" fill="#3a9a20" transform="rotate(-10,10,12)"/>
+  <!-- Right leaves -->
+  <ellipse cx="26" cy="18" rx="3.5" ry="2" fill="#3a9a20" transform="rotate(20,26,18)"/>
+  <ellipse cx="27" cy="12" rx="3" ry="1.8" fill="#2d7a1b" transform="rotate(30,27,12)"/>
+  <ellipse cx="22" cy="10" rx="2.5" ry="1.5" fill="#3a9a20" transform="rotate(10,22,10)"/>
+  <!-- Top canopy burst -->
+  <circle cx="16" cy="6" r="5" fill="#2d7a1b"/>
+  <circle cx="13" cy="5" r="3.5" fill="#3a9a20"/>
+  <circle cx="19" cy="5" r="3.5" fill="#3a9a20"/>
+  <circle cx="16" cy="4" r="3" fill="#44bb22"/>
+  <!-- Growth sparkles (upward motion) -->
+  <circle cx="16" cy="10" r="0.8" fill="#88ff44" opacity="0.8"/>
+  <circle cx="13" cy="14" r="0.7" fill="#66dd22" opacity="0.7"/>
+  <circle cx="19" cy="12" r="0.7" fill="#88ff44" opacity="0.7"/>
+  <!-- Up arrows (growth direction) -->
+  <polygon points="16,2 14,5 18,5" fill="#88ff44" opacity="0.9"/>
+</svg>

--- a/web/public/sprites/clockwork-tune.svg
+++ b/web/public/sprites/clockwork-tune.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Main gear -->
+  <circle cx="14" cy="18" r="9" fill="#6a6a5a" stroke="#4a4a3a" stroke-width="0.8"/>
+  <circle cx="14" cy="18" r="6" fill="#4a4a3a"/>
+  <circle cx="14" cy="18" r="3" fill="#7a7a6a"/>
+  <!-- Gear teeth -->
+  <rect x="11.5" y="8" width="5" height="2.5" rx="0.5" fill="#6a6a5a"/>
+  <rect x="11.5" y="25.5" width="5" height="2.5" rx="0.5" fill="#6a6a5a"/>
+  <rect x="4" y="15.5" width="2.5" height="5" rx="0.5" fill="#6a6a5a"/>
+  <rect x="21.5" y="15.5" width="2.5" height="5" rx="0.5" fill="#6a6a5a"/>
+  <rect x="6" y="10.5" width="3" height="4" rx="0.5" fill="#6a6a5a" transform="rotate(-45,7.5,12.5)"/>
+  <rect x="17" y="10.5" width="3" height="4" rx="0.5" fill="#6a6a5a" transform="rotate(45,18.5,12.5)"/>
+  <rect x="6" y="19.5" width="3" height="4" rx="0.5" fill="#6a6a5a" transform="rotate(45,7.5,21.5)"/>
+  <rect x="17" y="19.5" width="3" height="4" rx="0.5" fill="#6a6a5a" transform="rotate(-45,18.5,21.5)"/>
+  <!-- Wrench overlaid -->
+  <rect x="18" y="5" width="5" height="16" rx="2" fill="#8a7a4a" transform="rotate(35,20.5,13)"/>
+  <!-- Wrench head (open end) -->
+  <path d="M26,4 Q30,3 31,7 Q30,9 27,8" stroke="#8a7a4a" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+  <path d="M24,7 Q28,5 30,8 Q29,11 26,10" stroke="#8a7a4a" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+  <!-- Wrench handle grip lines -->
+  <line x1="19" y1="18" x2="22" y2="16" stroke="#6a5a2a" stroke-width="0.8"/>
+  <line x1="20" y1="20" x2="23" y2="18" stroke="#6a5a2a" stroke-width="0.8"/>
+  <!-- Tune-up sparkles -->
+  <circle cx="24" cy="5" r="1.2" fill="#ffcc00" opacity="0.9"/>
+  <circle cx="28" cy="9" r="1" fill="#ffdd44" opacity="0.7"/>
+  <circle cx="26" cy="3" r="0.7" fill="#ffffff" opacity="0.7"/>
+  <!-- Gear centre glow (tuned up) -->
+  <circle cx="14" cy="18" r="2" fill="#44aaff" opacity="0.5"/>
+  <circle cx="14" cy="18" r="1" fill="#88ccff" opacity="0.7"/>
+</svg>

--- a/web/public/sprites/cloud-cover.svg
+++ b/web/public/sprites/cloud-cover.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Shadow on ground -->
+  <ellipse cx="16" cy="30" rx="13" ry="2.5" fill="#3a3a4a" opacity="0.4"/>
+  <!-- Hidden unit silhouette beneath -->
+  <ellipse cx="16" cy="26" rx="6" ry="4" fill="#2a2a3a" opacity="0.3"/>
+  <!-- Cloud layer (main, billowing) -->
+  <ellipse cx="16" cy="16" rx="14" ry="7" fill="#ccddee"/>
+  <ellipse cx="10" cy="14" rx="8" ry="6" fill="#ddeeff"/>
+  <ellipse cx="22" cy="14" rx="8" ry="6" fill="#ddeeff"/>
+  <ellipse cx="16" cy="12" rx="10" ry="7" fill="#eef5ff"/>
+  <!-- Upper cloud puffs -->
+  <ellipse cx="9" cy="10" rx="6" ry="5" fill="#ddeeff"/>
+  <ellipse cx="16" cy="8" rx="7" ry="5" fill="#eef5ff"/>
+  <ellipse cx="23" cy="10" rx="6" ry="5" fill="#ddeeff"/>
+  <!-- Cloud highlights -->
+  <ellipse cx="12" cy="8" rx="4" ry="3" fill="#ffffff" opacity="0.6"/>
+  <ellipse cx="20" cy="9" rx="3" ry="2.5" fill="#ffffff" opacity="0.5"/>
+  <!-- Misty wisps drifting down -->
+  <ellipse cx="7" cy="20" rx="4" ry="2" fill="#ccdde8" opacity="0.6"/>
+  <ellipse cx="25" cy="21" rx="4" ry="2" fill="#ccdde8" opacity="0.5"/>
+  <ellipse cx="16" cy="22" rx="5" ry="2" fill="#bbccd8" opacity="0.5"/>
+  <!-- Eye/stealth symbol in cloud -->
+  <ellipse cx="16" cy="14" rx="5" ry="3" fill="#4a5a7a" opacity="0.4"/>
+  <ellipse cx="16" cy="14" rx="3" ry="1.8" fill="#6a7a9a" opacity="0.5"/>
+  <circle cx="16" cy="14" r="1.2" fill="#2a3a5a" opacity="0.6"/>
+</svg>

--- a/web/public/sprites/crystal-resonance.svg
+++ b/web/public/sprites/crystal-resonance.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Resonance rings (outermost to inner) -->
+  <ellipse cx="16" cy="18" rx="14" ry="6" fill="none" stroke="#aa66ff" stroke-width="0.8" opacity="0.3"/>
+  <ellipse cx="16" cy="18" rx="11" ry="5" fill="none" stroke="#bb77ff" stroke-width="0.9" opacity="0.45"/>
+  <ellipse cx="16" cy="18" rx="8" ry="4" fill="none" stroke="#cc88ff" stroke-width="1" opacity="0.6"/>
+  <ellipse cx="16" cy="18" rx="5" ry="2.5" fill="none" stroke="#dd99ff" stroke-width="1.2" opacity="0.75"/>
+  <!-- Crystal base facet -->
+  <polygon points="16,28 10,20 16,22 22,20" fill="#5522aa"/>
+  <polygon points="16,28 10,20 16,22" fill="#7733cc"/>
+  <!-- Crystal main body -->
+  <polygon points="16,4 10,14 10,20 16,22 22,20 22,14" fill="#8844dd"/>
+  <polygon points="16,4 10,14 16,16 22,14" fill="#aa66ff"/>
+  <!-- Crystal left face -->
+  <polygon points="10,14 10,20 16,22 16,16" fill="#6633bb"/>
+  <!-- Crystal right face -->
+  <polygon points="22,14 22,20 16,22 16,16" fill="#9955ee"/>
+  <!-- Crystal tip glow -->
+  <ellipse cx="16" cy="5" rx="3" ry="2" fill="#dd99ff" opacity="0.8"/>
+  <ellipse cx="16" cy="4" rx="1.8" ry="1.2" fill="#ffffff" opacity="0.7"/>
+  <!-- Inner light beam down crystal -->
+  <line x1="16" y1="4" x2="16" y2="22" stroke="#ffffff" stroke-width="0.8" opacity="0.4"/>
+  <!-- Harmonic sparkles at ring intersections -->
+  <circle cx="4" cy="18" r="1" fill="#cc88ff" opacity="0.7"/>
+  <circle cx="28" cy="18" r="1" fill="#cc88ff" opacity="0.7"/>
+  <circle cx="7" cy="16" r="0.8" fill="#bb77ff" opacity="0.6"/>
+  <circle cx="25" cy="16" r="0.8" fill="#bb77ff" opacity="0.6"/>
+  <circle cx="2" cy="19" r="0.6" fill="#aa66ff" opacity="0.5"/>
+  <circle cx="30" cy="19" r="0.6" fill="#aa66ff" opacity="0.5"/>
+</svg>

--- a/web/public/sprites/crystalline-shell.svg
+++ b/web/public/sprites/crystalline-shell.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Outer shell facets -->
+  <polygon points="16,2 28,9 28,23 16,30 4,23 4,9" fill="#5588cc" opacity="0.3"/>
+  <polygon points="16,2 28,9 28,23 16,30 4,23 4,9" fill="none" stroke="#88bbff" stroke-width="1.2"/>
+  <!-- Crystal facet lines -->
+  <line x1="16" y1="2" x2="16" y2="30" stroke="#aaccff" stroke-width="0.7" opacity="0.5"/>
+  <line x1="4" y1="9" x2="28" y2="23" stroke="#aaccff" stroke-width="0.7" opacity="0.5"/>
+  <line x1="28" y1="9" x2="4" y2="23" stroke="#aaccff" stroke-width="0.7" opacity="0.5"/>
+  <!-- Inner shell (smaller, brighter) -->
+  <polygon points="16,6 24,11 24,21 16,26 8,21 8,11" fill="#88bbff" opacity="0.25"/>
+  <polygon points="16,6 24,11 24,21 16,26 8,21 8,11" fill="none" stroke="#ccddff" stroke-width="0.9"/>
+  <!-- Core glow -->
+  <circle cx="16" cy="16" r="5" fill="#aaccff" opacity="0.4"/>
+  <circle cx="16" cy="16" r="3" fill="#ddeeff" opacity="0.6"/>
+  <circle cx="16" cy="16" r="1.5" fill="#ffffff" opacity="0.8"/>
+  <!-- Refraction sparkles at vertices -->
+  <circle cx="16" cy="2" r="1.2" fill="#ffffff" opacity="0.9"/>
+  <circle cx="28" cy="9" r="1" fill="#ccddff" opacity="0.8"/>
+  <circle cx="28" cy="23" r="1" fill="#ccddff" opacity="0.8"/>
+  <circle cx="16" cy="30" r="1.2" fill="#ffffff" opacity="0.9"/>
+  <circle cx="4" cy="23" r="1" fill="#ccddff" opacity="0.8"/>
+  <circle cx="4" cy="9" r="1" fill="#ccddff" opacity="0.8"/>
+</svg>

--- a/web/public/sprites/current-mastery.svg
+++ b/web/public/sprites/current-mastery.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Swirling current (two intertwined streams) -->
+  <!-- Blue water current -->
+  <path d="M4,16 Q8,8 16,10 Q24,12 28,6" stroke="#2288cc" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+  <path d="M4,20 Q8,12 16,14 Q24,16 28,10" stroke="#44aaee" stroke-width="1.5" fill="none" stroke-linecap="round" opacity="0.7"/>
+  <!-- Electric current -->
+  <path d="M4,22 Q10,28 16,22 Q22,16 28,22" stroke="#ffee22" stroke-width="2" fill="none" stroke-linecap="round"/>
+  <path d="M28,22 L26,20 L27,22 L25,21 L27,23" stroke="#ffee22" stroke-width="1" fill="none" stroke-linecap="round"/>
+  <!-- Mastery hand silhouette (open palm) -->
+  <ellipse cx="16" cy="17" rx="5" ry="6" fill="#c8a060" opacity="0.85"/>
+  <!-- Fingers -->
+  <rect x="11" y="10" width="2" height="6" rx="1" fill="#c8a060"/>
+  <rect x="13.5" y="9" width="2" height="7" rx="1" fill="#c8a060"/>
+  <rect x="16" y="9.5" width="2" height="6.5" rx="1" fill="#c8a060"/>
+  <rect x="18.5" y="10" width="2" height="6" rx="1" fill="#c8a060"/>
+  <!-- Thumb -->
+  <rect x="9" y="13" width="3" height="2" rx="1" fill="#c8a060" transform="rotate(-20,10.5,14)"/>
+  <!-- Energy orb in palm -->
+  <circle cx="16" cy="18" r="3" fill="#1166aa" opacity="0.7"/>
+  <circle cx="16" cy="18" r="1.8" fill="#44aaff" opacity="0.8"/>
+  <circle cx="16" cy="18" r="0.9" fill="#ffffff" opacity="0.7"/>
+  <!-- Lightning arc from orb -->
+  <path d="M16,15 L15,13 L17,14 L16,11" stroke="#ffee22" stroke-width="1" fill="none" stroke-linecap="round"/>
+</svg>

--- a/web/public/sprites/dark-ritual.svg
+++ b/web/public/sprites/dark-ritual.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ritual circle -->
+  <circle cx="16" cy="17" r="13" fill="none" stroke="#440066" stroke-width="1.2"/>
+  <circle cx="16" cy="17" r="11" fill="none" stroke="#660099" stroke-width="0.7" opacity="0.6"/>
+  <!-- Pentagram lines -->
+  <polygon points="16,4 26,22 6,11 26,11 6,22" fill="none" stroke="#9922cc" stroke-width="1"/>
+  <!-- Dark glow fill inside circle -->
+  <circle cx="16" cy="17" r="12" fill="#220033" opacity="0.5"/>
+  <!-- Candles at five points -->
+  <rect x="15" y="2" width="2" height="3" rx="0.5" fill="#ccaa44"/>
+  <ellipse cx="16" cy="2" rx="1" ry="0.7" fill="#ffdd44"/>
+  <rect x="25" y="20" width="2" height="3" rx="0.5" fill="#ccaa44"/>
+  <ellipse cx="26" cy="20" rx="1" ry="0.7" fill="#ffdd44"/>
+  <rect x="20" y="28" width="2" height="3" rx="0.5" fill="#ccaa44"/>
+  <ellipse cx="21" cy="28" rx="1" ry="0.7" fill="#ffdd44"/>
+  <rect x="9" y="28" width="2" height="3" rx="0.5" fill="#ccaa44"/>
+  <ellipse cx="10" cy="28" rx="1" ry="0.7" fill="#ffdd44"/>
+  <rect x="5" y="20" width="2" height="3" rx="0.5" fill="#ccaa44"/>
+  <ellipse cx="6" cy="20" rx="1" ry="0.7" fill="#ffdd44"/>
+  <!-- Dark energy core -->
+  <circle cx="16" cy="17" r="4" fill="#440066" opacity="0.9"/>
+  <circle cx="16" cy="17" r="2.5" fill="#8822cc" opacity="0.8"/>
+  <circle cx="16" cy="17" r="1.2" fill="#cc55ff" opacity="0.9"/>
+  <!-- Dark wisps rising -->
+  <path d="M16,13 Q14,10 16,8 Q18,10 16,13" fill="#660099" opacity="0.6"/>
+  <path d="M12,15 Q10,12 12,10" stroke="#880099" stroke-width="0.8" fill="none" opacity="0.5"/>
+  <path d="M20,15 Q22,12 20,10" stroke="#880099" stroke-width="0.8" fill="none" opacity="0.5"/>
+</svg>

--- a/web/public/sprites/deep-growth.svg
+++ b/web/public/sprites/deep-growth.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Deep ocean/dark ground layer -->
+  <rect x="0" y="24" width="32" height="8" rx="0" fill="#112233" opacity="0.7"/>
+  <path d="M0,24 Q4,22 8,24 Q12,26 16,24 Q20,22 24,24 Q28,26 32,24 L32,32 L0,32 Z" fill="#1a3344" opacity="0.6"/>
+  <!-- Deep roots anchoring below -->
+  <path d="M13,30 Q12,27 14,24" stroke="#2a5a2a" stroke-width="1.5" fill="none"/>
+  <path d="M19,30 Q20,27 18,24" stroke="#2a5a2a" stroke-width="1.5" fill="none"/>
+  <path d="M16,31 Q16,27 16,24" stroke="#3a6a1a" stroke-width="2" fill="none"/>
+  <!-- Main deep vine erupting upward -->
+  <path d="M16,24 Q14,18 16,12 Q18,6 16,1" stroke="#2a6a1a" stroke-width="3" fill="none" stroke-linecap="round"/>
+  <!-- Branch vines -->
+  <path d="M15,20 Q9,17 5,19" stroke="#2a6a1a" stroke-width="1.8" fill="none" stroke-linecap="round"/>
+  <path d="M17,15 Q23,12 27,14" stroke="#2a6a1a" stroke-width="1.8" fill="none" stroke-linecap="round"/>
+  <path d="M15,10 Q9,7 6,9" stroke="#3a7a1a" stroke-width="1.5" fill="none" stroke-linecap="round"/>
+  <!-- Bioluminescent leaves (deep-sea glow) -->
+  <ellipse cx="5" cy="18" rx="3.5" ry="2" fill="#22aa55" opacity="0.85" transform="rotate(-25,5,18)"/>
+  <ellipse cx="27" cy="13" rx="3.5" ry="2" fill="#22aa55" opacity="0.85" transform="rotate(25,27,13)"/>
+  <ellipse cx="6" cy="8" rx="3" ry="1.8" fill="#33bb66" opacity="0.8" transform="rotate(-15,6,8)"/>
+  <!-- Top bloom (dark, glowing deep-sea flower) -->
+  <circle cx="16" cy="2" r="4" fill="#116633"/>
+  <circle cx="16" cy="2" r="2.5" fill="#22aa55"/>
+  <circle cx="16" cy="2" r="1.2" fill="#55ffaa" opacity="0.9"/>
+  <!-- Glow halos on leaves -->
+  <ellipse cx="5" cy="18" rx="4.5" ry="3" fill="#22aa55" opacity="0.2" transform="rotate(-25,5,18)"/>
+  <ellipse cx="27" cy="13" rx="4.5" ry="3" fill="#22aa55" opacity="0.2" transform="rotate(25,27,13)"/>
+  <!-- Bubbles rising (deep sea) -->
+  <circle cx="10" cy="22" r="0.8" fill="#4499aa" opacity="0.6"/>
+  <circle cx="22" cy="21" r="0.7" fill="#4499aa" opacity="0.5"/>
+  <circle cx="7" cy="19" r="0.6" fill="#55aabb" opacity="0.4"/>
+</svg>

--- a/web/public/sprites/deep-resilience.svg
+++ b/web/public/sprites/deep-resilience.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Deep water background -->
+  <ellipse cx="16" cy="20" rx="14" ry="11" fill="#112244" opacity="0.5"/>
+  <!-- Coral/barnacle armour shield base -->
+  <path d="M16,3 L27,9 L27,21 Q27,30 16,31 Q5,30 5,21 L5,9 Z" fill="#336677"/>
+  <path d="M16,6 L24,11 L24,21 Q24,28 16,29 Q8,28 8,21 L8,11 Z" fill="#447788"/>
+  <!-- Coral growths on shield -->
+  <path d="M8,14 Q5,11 7,9 Q9,7 10,10" fill="#cc6644" opacity="0.8"/>
+  <path d="M24,14 Q27,11 25,9 Q23,7 22,10" fill="#cc6644" opacity="0.8"/>
+  <path d="M10,22 Q7,20 8,18 Q10,16 11,19" fill="#dd7755" opacity="0.7"/>
+  <path d="M22,22 Q25,20 24,18 Q22,16 21,19" fill="#dd7755" opacity="0.7"/>
+  <!-- Barnacle clusters -->
+  <circle cx="9" cy="17" r="1.5" fill="#558899"/>
+  <circle cx="9" cy="17" r="0.8" fill="#669999"/>
+  <circle cx="23" cy="17" r="1.5" fill="#558899"/>
+  <circle cx="23" cy="17" r="0.8" fill="#669999"/>
+  <!-- Shield boss — deep-sea emblem -->
+  <circle cx="16" cy="18" r="5" fill="#224455"/>
+  <circle cx="16" cy="18" r="3.5" fill="#335566"/>
+  <!-- Anchor symbol -->
+  <line x1="16" y1="14" x2="16" y2="22" stroke="#88bbcc" stroke-width="1.2"/>
+  <ellipse cx="16" cy="14" rx="2" ry="1" fill="none" stroke="#88bbcc" stroke-width="1"/>
+  <line x1="13" y1="22" x2="19" y2="22" stroke="#88bbcc" stroke-width="1"/>
+  <path d="M13,22 Q12,24 13.5,25" stroke="#88bbcc" stroke-width="0.8" fill="none"/>
+  <path d="M19,22 Q20,24 18.5,25" stroke="#88bbcc" stroke-width="0.8" fill="none"/>
+  <!-- Bioluminescent edge glow -->
+  <path d="M16,3 L27,9 L27,21 Q27,30 16,31 Q5,30 5,21 L5,9 Z" fill="none" stroke="#44aacc" stroke-width="0.8" opacity="0.6"/>
+  <!-- Water pressure ripple -->
+  <ellipse cx="16" cy="18" rx="8" ry="5" fill="none" stroke="#4488aa" stroke-width="0.6" opacity="0.4"/>
+</svg>

--- a/web/public/sprites/desert-rush.svg
+++ b/web/public/sprites/desert-rush.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Sand dune ground -->
+  <path d="M0,28 Q8,24 16,26 Q24,28 32,24 L32,32 L0,32 Z" fill="#cc9944" opacity="0.6"/>
+  <!-- Sandstorm trails (left to right) -->
+  <path d="M0,20 Q6,17 12,19 Q18,21 24,18 Q28,16 32,18" stroke="#ddbb66" stroke-width="2.5" fill="none" stroke-linecap="round" opacity="0.6"/>
+  <path d="M0,16 Q6,13 14,15 Q22,17 32,13" stroke="#cc9933" stroke-width="2" fill="none" stroke-linecap="round" opacity="0.5"/>
+  <path d="M0,12 Q8,9 16,11 Q24,13 32,9" stroke="#eebb77" stroke-width="1.5" fill="none" stroke-linecap="round" opacity="0.4"/>
+  <!-- Sand particles -->
+  <circle cx="4" cy="18" r="1.2" fill="#ddaa44" opacity="0.7"/>
+  <circle cx="10" cy="14" r="1" fill="#ccaa33" opacity="0.6"/>
+  <circle cx="18" cy="10" r="1.2" fill="#ddbb55" opacity="0.6"/>
+  <circle cx="26" cy="15" r="1" fill="#ccaa33" opacity="0.5"/>
+  <circle cx="30" cy="11" r="0.8" fill="#ddaa44" opacity="0.5"/>
+  <!-- Rushing figure silhouette -->
+  <!-- Head -->
+  <circle cx="22" cy="14" r="3" fill="#8a6a2a"/>
+  <!-- Keffiyeh/scarf streaming behind -->
+  <path d="M20,13 Q15,11 10,13 Q8,14 10,16 Q14,14 20,15" fill="#cc4422" opacity="0.85"/>
+  <!-- Body leaning forward -->
+  <ellipse cx="21" cy="19" rx="4" ry="5" fill="#8a6a2a" transform="rotate(-20,21,19)"/>
+  <!-- Legs running -->
+  <rect x="18" y="22" width="3" height="7" rx="1" fill="#6a4a1a" transform="rotate(-15,19.5,25.5)"/>
+  <rect x="22" y="21" width="3" height="6" rx="1" fill="#6a4a1a" transform="rotate(10,23.5,24)"/>
+  <!-- Speed lines from figure -->
+  <line x1="17" y1="14" x2="4" y2="14" stroke="#ffcc44" stroke-width="1.5" stroke-linecap="round" opacity="0.7"/>
+  <line x1="17" y1="17" x2="3" y2="18" stroke="#ffaa22" stroke-width="1.2" stroke-linecap="round" opacity="0.6"/>
+  <line x1="17" y1="20" x2="5" y2="21" stroke="#ffcc44" stroke-width="1" stroke-linecap="round" opacity="0.5"/>
+</svg>

--- a/web/public/sprites/eagle-eye.svg
+++ b/web/public/sprites/eagle-eye.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Eye outline (large, sharp) -->
+  <path d="M2,16 Q8,6 16,6 Q24,6 30,16 Q24,26 16,26 Q8,26 2,16 Z" fill="#1a1a2a"/>
+  <path d="M4,16 Q9,8 16,8 Q23,8 28,16 Q23,24 16,24 Q9,24 4,16 Z" fill="#2a3a5a"/>
+  <!-- Iris -->
+  <circle cx="16" cy="16" r="7" fill="#cc8822"/>
+  <circle cx="16" cy="16" r="5.5" fill="#ddaa33"/>
+  <!-- Iris detail lines -->
+  <line x1="16" y1="9" x2="16" y2="23" stroke="#aa6611" stroke-width="0.5" opacity="0.6"/>
+  <line x1="9" y1="16" x2="23" y2="16" stroke="#aa6611" stroke-width="0.5" opacity="0.6"/>
+  <line x1="11" y1="11" x2="21" y2="21" stroke="#aa6611" stroke-width="0.5" opacity="0.4"/>
+  <line x1="21" y1="11" x2="11" y2="21" stroke="#aa6611" stroke-width="0.5" opacity="0.4"/>
+  <!-- Pupil (vertical slit — eagle) -->
+  <ellipse cx="16" cy="16" rx="2" ry="4.5" fill="#0a0a0a"/>
+  <!-- Eye shine -->
+  <ellipse cx="14" cy="13" rx="1.5" ry="1" fill="#ffffff" opacity="0.7"/>
+  <!-- Targeting reticle overlaid -->
+  <circle cx="16" cy="16" r="11" fill="none" stroke="#ffcc00" stroke-width="0.8" opacity="0.6"/>
+  <line x1="16" y1="4" x2="16" y2="8" stroke="#ffcc00" stroke-width="1" opacity="0.7"/>
+  <line x1="16" y1="24" x2="16" y2="28" stroke="#ffcc00" stroke-width="1" opacity="0.7"/>
+  <line x1="4" y1="16" x2="8" y2="16" stroke="#ffcc00" stroke-width="1" opacity="0.7"/>
+  <line x1="24" y1="16" x2="28" y2="16" stroke="#ffcc00" stroke-width="1" opacity="0.7"/>
+  <!-- Sharp vision rays at corners -->
+  <line x1="5" y1="7" x2="10" y2="11" stroke="#ffdd44" stroke-width="0.8" opacity="0.5"/>
+  <line x1="27" y1="7" x2="22" y2="11" stroke="#ffdd44" stroke-width="0.8" opacity="0.5"/>
+  <line x1="5" y1="25" x2="10" y2="21" stroke="#ffdd44" stroke-width="0.8" opacity="0.5"/>
+  <line x1="27" y1="25" x2="22" y2="21" stroke="#ffdd44" stroke-width="0.8" opacity="0.5"/>
+</svg>

--- a/web/public/sprites/entropy-wave.svg
+++ b/web/public/sprites/entropy-wave.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Chaotic decay wave — distorted, fragmented arcs -->
+  <!-- Wave 1 (outer, breaking apart) -->
+  <path d="M1,16 Q4,10 7,13 Q9,15 10,12 Q12,8 14,11 Q15,13 16,10" stroke="#8844cc" stroke-width="1.5" fill="none" stroke-linecap="round" opacity="0.7"/>
+  <path d="M16,10 Q18,7 20,10 Q21,12 23,9 Q25,6 27,10 Q29,13 31,10" stroke="#aa55dd" stroke-width="1.5" fill="none" stroke-linecap="round" opacity="0.6"/>
+  <!-- Wave 2 (mid) -->
+  <path d="M1,20 Q3,14 6,17 Q8,19 10,16 Q12,13 15,17 Q16,19 17,16" stroke="#6633aa" stroke-width="2" fill="none" stroke-linecap="round" opacity="0.8"/>
+  <path d="M17,16 Q19,13 21,16 Q23,19 25,15 Q27,12 29,16 Q30,18 31,16" stroke="#7744bb" stroke-width="2" fill="none" stroke-linecap="round" opacity="0.7"/>
+  <!-- Wave 3 (inner, most chaotic) -->
+  <path d="M2,23 Q5,18 7,21 Q9,24 12,20 Q14,17 16,21 Q17,23 18,20 Q20,17 22,21 Q25,25 27,20 Q29,17 31,21" stroke="#9955ee" stroke-width="1.2" fill="none" stroke-linecap="round" opacity="0.6"/>
+  <!-- Entropy particles (fragmenting) -->
+  <circle cx="8" cy="12" r="1.2" fill="#aa55dd" opacity="0.8"/>
+  <circle cx="16" cy="8" r="1" fill="#cc66ff" opacity="0.7"/>
+  <circle cx="24" cy="11" r="1.2" fill="#aa55dd" opacity="0.7"/>
+  <circle cx="4" cy="20" r="0.9" fill="#8833bb" opacity="0.6"/>
+  <circle cx="28" cy="18" r="0.9" fill="#9944cc" opacity="0.6"/>
+  <!-- Decay fragments (squares dissolving) -->
+  <rect x="10" y="6" width="2" height="2" rx="0.3" fill="#7733aa" opacity="0.5"/>
+  <rect x="20" y="5" width="2" height="2" rx="0.3" fill="#8844bb" opacity="0.4"/>
+  <rect x="6" y="25" width="2" height="2" rx="0.3" fill="#6622aa" opacity="0.5"/>
+  <rect x="24" y="24" width="2" height="2" rx="0.3" fill="#7733bb" opacity="0.4"/>
+  <!-- Central entropy burst -->
+  <circle cx="16" cy="17" r="3" fill="#440066" opacity="0.7"/>
+  <circle cx="16" cy="17" r="1.5" fill="#9933cc" opacity="0.8"/>
+  <circle cx="16" cy="17" r="0.7" fill="#cc66ff" opacity="0.9"/>
+</svg>

--- a/web/public/sprites/feather-step.svg
+++ b/web/public/sprites/feather-step.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Large feather (central) -->
+  <path d="M16,2 Q22,8 20,16 Q18,22 16,28" stroke="#aabb88" stroke-width="1" fill="none"/>
+  <!-- Feather vane left -->
+  <path d="M16,4 Q11,7 10,12 Q12,10 16,8" fill="#ccdd99" opacity="0.85"/>
+  <path d="M16,8 Q10,12 9,17 Q12,14 16,12" fill="#bbcc88" opacity="0.8"/>
+  <path d="M16,12 Q10,16 9,21 Q12,18 16,16" fill="#aabb77" opacity="0.75"/>
+  <path d="M16,16 Q11,20 11,25 Q13,22 16,20" fill="#99aa66" opacity="0.7"/>
+  <!-- Feather vane right -->
+  <path d="M16,4 Q21,7 22,12 Q20,10 16,8" fill="#ccdd99" opacity="0.85"/>
+  <path d="M16,8 Q22,12 23,17 Q20,14 16,12" fill="#bbcc88" opacity="0.8"/>
+  <path d="M16,12 Q22,16 23,21 Q20,18 16,16" fill="#aabb77" opacity="0.75"/>
+  <path d="M16,16 Q21,20 21,25 Q19,22 16,20" fill="#99aa66" opacity="0.7"/>
+  <!-- Feather tip -->
+  <path d="M16,24 Q15,27 16,30 Q17,27 16,24" fill="#88aa55"/>
+  <!-- Light footprints below -->
+  <!-- Left foot -->
+  <ellipse cx="10" cy="27" rx="3" ry="1.5" fill="#aabb77" opacity="0.5" transform="rotate(-15,10,27)"/>
+  <ellipse cx="9" cy="25" rx="1" ry="0.6" fill="#aabb77" opacity="0.4" transform="rotate(-15,9,25)"/>
+  <ellipse cx="11" cy="25" rx="1" ry="0.6" fill="#aabb77" opacity="0.4" transform="rotate(-15,11,25)"/>
+  <!-- Right foot -->
+  <ellipse cx="22" cy="29" rx="3" ry="1.5" fill="#aabb77" opacity="0.4" transform="rotate(15,22,29)"/>
+  <ellipse cx="21" cy="27" rx="1" ry="0.6" fill="#aabb77" opacity="0.35" transform="rotate(15,21,27)"/>
+  <ellipse cx="23" cy="27" rx="1" ry="0.6" fill="#aabb77" opacity="0.35" transform="rotate(15,23,27)"/>
+  <!-- Nimble sparkles -->
+  <circle cx="6" cy="24" r="0.8" fill="#ddeebb" opacity="0.7"/>
+  <circle cx="26" cy="26" r="0.8" fill="#ddeebb" opacity="0.6"/>
+  <circle cx="8" cy="20" r="0.6" fill="#ccdd99" opacity="0.5"/>
+</svg>

--- a/web/public/sprites/field-medic.svg
+++ b/web/public/sprites/field-medic.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Medical bag -->
+  <rect x="8" y="16" width="16" height="13" rx="2" fill="#eeeeee"/>
+  <rect x="8" y="16" width="16" height="3" rx="1" fill="#dddddd"/>
+  <!-- Bag handle -->
+  <path d="M12,16 Q12,12 16,12 Q20,12 20,16" fill="none" stroke="#cccccc" stroke-width="2"/>
+  <!-- Red cross on bag -->
+  <rect x="14" y="19" width="4" height="7" rx="0.5" fill="#cc2222"/>
+  <rect x="11" y="21.5" width="10" height="4" rx="0.5" fill="#cc2222"/>
+  <!-- Healing glow emanating -->
+  <ellipse cx="16" cy="22" rx="10" ry="8" fill="#33cc66" opacity="0.15"/>
+  <ellipse cx="16" cy="22" rx="7" ry="5.5" fill="#44dd77" opacity="0.15"/>
+  <!-- Green healing cross above -->
+  <rect x="14.5" y="6" width="3" height="9" rx="1" fill="#33cc55" opacity="0.9"/>
+  <rect x="11" y="9" width="10" height="3" rx="1" fill="#33cc55" opacity="0.9"/>
+  <!-- Cross glow -->
+  <rect x="14.5" y="6" width="3" height="9" rx="1" fill="#88ffaa" opacity="0.3"/>
+  <rect x="11" y="9" width="10" height="3" rx="1" fill="#88ffaa" opacity="0.3"/>
+  <!-- Healing sparkles -->
+  <circle cx="7" cy="12" r="1.2" fill="#44ee77" opacity="0.8"/>
+  <circle cx="25" cy="10" r="1" fill="#55ff88" opacity="0.7"/>
+  <circle cx="5" cy="20" r="0.9" fill="#33cc55" opacity="0.6"/>
+  <circle cx="27" cy="18" r="0.9" fill="#44dd66" opacity="0.6"/>
+  <circle cx="10" cy="8" r="0.7" fill="#66ffaa" opacity="0.5"/>
+  <circle cx="22" cy="7" r="0.7" fill="#66ffaa" opacity="0.5"/>
+  <!-- Bandage roll detail on bag -->
+  <ellipse cx="20" cy="27" rx="2" ry="1" fill="#cccccc" opacity="0.7"/>
+  <line x1="18" y1="27" x2="22" y2="27" stroke="#aaaaaa" stroke-width="0.5"/>
+</svg>

--- a/web/public/sprites/storm-beacon.svg
+++ b/web/public/sprites/storm-beacon.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Base -->
+  <rect x="10" y="26" width="12" height="5" rx="1" fill="#5a5a6a"/>
+  <rect x="8" y="24" width="16" height="3" rx="1" fill="#6a6a7a"/>
+  <!-- Tower shaft -->
+  <rect x="13" y="10" width="6" height="15" rx="1" fill="#5a5a6a"/>
+  <line x1="15" y1="10" x2="15" y2="25" stroke="#4a4a5a" stroke-width="0.6"/>
+  <!-- Beacon housing -->
+  <ellipse cx="16" cy="10" rx="5" ry="3" fill="#4a4a5a"/>
+  <ellipse cx="16" cy="9" rx="4" ry="2.5" fill="#6a6a7a"/>
+  <!-- Storm orb inside beacon -->
+  <circle cx="16" cy="9" r="3" fill="#1a1a2a"/>
+  <circle cx="16" cy="9" r="2" fill="#4466ff" opacity="0.9"/>
+  <circle cx="16" cy="9" r="1" fill="#aabbff"/>
+  <!-- Lightning bolts emanating -->
+  <path d="M16,6 L14,3 L16,4 L15,1" stroke="#ffee44" stroke-width="1.2" fill="none" stroke-linecap="round"/>
+  <path d="M20,8 L23,6 L22,8 L25,7" stroke="#ffee44" stroke-width="1.2" fill="none" stroke-linecap="round"/>
+  <path d="M12,8 L9,6 L10,8 L7,7" stroke="#ffee44" stroke-width="1.2" fill="none" stroke-linecap="round"/>
+  <!-- Electric glow ring -->
+  <ellipse cx="16" cy="9" rx="6" ry="4" fill="none" stroke="#88aaff" stroke-width="0.7" opacity="0.5"/>
+  <!-- Tower bands -->
+  <rect x="13" y="15" width="6" height="1.5" rx="0.5" fill="#7a7a8a"/>
+  <rect x="13" y="20" width="6" height="1.5" rx="0.5" fill="#7a7a8a"/>
+  <!-- Small spark details -->
+  <circle cx="11" cy="12" r="0.7" fill="#ffee44" opacity="0.7"/>
+  <circle cx="21" cy="11" r="0.7" fill="#ffee44" opacity="0.6"/>
+  <circle cx="9" cy="10" r="0.5" fill="#aabbff" opacity="0.5"/>
+</svg>

--- a/web/public/sprites/storm-tower.svg
+++ b/web/public/sprites/storm-tower.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Tower base -->
+  <rect x="7" y="18" width="18" height="13" rx="1" fill="#5a5a6a"/>
+  <rect x="7" y="18" width="18" height="2.5" fill="#4a4a5a"/>
+  <!-- Stone lines -->
+  <line x1="7" y1="22" x2="25" y2="22" stroke="#4a4a5a" stroke-width="0.6"/>
+  <line x1="7" y1="26" x2="25" y2="26" stroke="#4a4a5a" stroke-width="0.6"/>
+  <line x1="13" y1="18" x2="13" y2="31" stroke="#4a4a5a" stroke-width="0.6"/>
+  <line x1="19" y1="18" x2="19" y2="31" stroke="#4a4a5a" stroke-width="0.6"/>
+  <!-- Tower upper section (narrower) -->
+  <rect x="9" y="8" width="14" height="11" rx="1" fill="#6a6a7a"/>
+  <rect x="9" y="8" width="14" height="2" fill="#5a5a6a"/>
+  <!-- Crenellations -->
+  <rect x="9" y="4" width="3" height="5" rx="0.5" fill="#5a5a6a"/>
+  <rect x="14" y="4" width="3" height="5" rx="0.5" fill="#5a5a6a"/>
+  <rect x="19" y="4" width="3" height="5" rx="0.5" fill="#5a5a6a"/>
+  <!-- Storm energy between crenellations -->
+  <path d="M10,5 L13,3 L15,5 L17,3 L19,5 L21,3" stroke="#ffee44" stroke-width="1" fill="none" stroke-linecap="round"/>
+  <!-- Arrow slits -->
+  <rect x="14" y="10" width="3" height="5" rx="0.3" fill="#2a2a3a"/>
+  <polygon points="14,10 15.5,8 17,10" fill="#2a2a3a"/>
+  <!-- Gate -->
+  <rect x="13" y="24" width="6" height="7" rx="0.3" fill="#2a2a3a"/>
+  <!-- Storm cloud above tower -->
+  <ellipse cx="16" cy="3" rx="7" ry="2.5" fill="#4a4a66" opacity="0.8"/>
+  <ellipse cx="12" cy="4" rx="4" ry="2" fill="#5a5a77" opacity="0.7"/>
+  <ellipse cx="20" cy="4" rx="4" ry="2" fill="#5a5a77" opacity="0.7"/>
+  <!-- Lightning strike from cloud -->
+  <path d="M16,5 L14,9 L16,8 L15,12" stroke="#ffee44" stroke-width="1.5" fill="none" stroke-linecap="round"/>
+  <!-- Sparks on battlements -->
+  <circle cx="11" cy="5" r="0.8" fill="#aabbff" opacity="0.8"/>
+  <circle cx="21" cy="5" r="0.8" fill="#aabbff" opacity="0.8"/>
+</svg>

--- a/web/public/sprites/stormgate.svg
+++ b/web/public/sprites/stormgate.svg
@@ -1,0 +1,41 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground -->
+  <rect x="1" y="29" width="30" height="3" rx="1" fill="#4a4a5a"/>
+  <!-- Left pillar -->
+  <rect x="2" y="8" width="7" height="22" rx="1" fill="#6a6a7a"/>
+  <rect x="2" y="8" width="7" height="3" fill="#5a5a6a"/>
+  <!-- Left pillar cap -->
+  <rect x="1" y="6" width="9" height="3" rx="0.5" fill="#7a7a8a"/>
+  <!-- Right pillar -->
+  <rect x="23" y="8" width="7" height="22" rx="1" fill="#6a6a7a"/>
+  <rect x="23" y="8" width="7" height="3" fill="#5a5a6a"/>
+  <!-- Right pillar cap -->
+  <rect x="22" y="6" width="9" height="3" rx="0.5" fill="#7a7a8a"/>
+  <!-- Storm orbs on pillar caps -->
+  <circle cx="5.5" cy="5" r="2.5" fill="#3344bb"/>
+  <circle cx="5.5" cy="5" r="1.5" fill="#6688ff" opacity="0.9"/>
+  <circle cx="26.5" cy="5" r="2.5" fill="#3344bb"/>
+  <circle cx="26.5" cy="5" r="1.5" fill="#6688ff" opacity="0.9"/>
+  <!-- Stone block lines on pillars -->
+  <line x1="2" y1="13" x2="9" y2="13" stroke="#5a5a6a" stroke-width="0.6"/>
+  <line x1="2" y1="18" x2="9" y2="18" stroke="#5a5a6a" stroke-width="0.6"/>
+  <line x1="2" y1="23" x2="9" y2="23" stroke="#5a5a6a" stroke-width="0.6"/>
+  <line x1="23" y1="13" x2="30" y2="13" stroke="#5a5a6a" stroke-width="0.6"/>
+  <line x1="23" y1="18" x2="30" y2="18" stroke="#5a5a6a" stroke-width="0.6"/>
+  <line x1="23" y1="23" x2="30" y2="23" stroke="#5a5a6a" stroke-width="0.6"/>
+  <!-- Storm energy arc between pillars -->
+  <path d="M9,10 Q16,4 23,10" stroke="#ffee44" stroke-width="1.5" fill="none" opacity="0.9"/>
+  <path d="M9,10 Q16,7 23,10" stroke="#aabbff" stroke-width="0.8" fill="none" opacity="0.7"/>
+  <!-- Secondary arcs -->
+  <path d="M9,14 Q16,10 23,14" stroke="#ffee44" stroke-width="0.8" fill="none" opacity="0.5"/>
+  <!-- Gate opening (dark interior) -->
+  <rect x="9" y="14" width="14" height="15" fill="#1a1a2a"/>
+  <path d="M9,14 Q16,8 23,14" fill="#1a1a2a"/>
+  <!-- Gate energy shimmer -->
+  <rect x="9" y="14" width="14" height="15" fill="#3355aa" opacity="0.2"/>
+  <!-- Rune glyphs on pillars -->
+  <line x1="4" y1="16" x2="7" y2="16" stroke="#aabbff" stroke-width="0.7" opacity="0.6"/>
+  <line x1="5.5" y1="15" x2="5.5" y2="17" stroke="#aabbff" stroke-width="0.7" opacity="0.6"/>
+  <line x1="25" y1="16" x2="28" y2="16" stroke="#aabbff" stroke-width="0.7" opacity="0.6"/>
+  <line x1="26.5" y1="15" x2="26.5" y2="17" stroke="#aabbff" stroke-width="0.7" opacity="0.6"/>
+</svg>

--- a/web/public/sprites/thunder-battery.svg
+++ b/web/public/sprites/thunder-battery.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Base platform -->
+  <rect x="2" y="26" width="28" height="5" rx="1" fill="#4a4a5a"/>
+  <rect x="2" y="26" width="28" height="1.5" fill="#3a3a4a"/>
+  <!-- Three capacitor coils -->
+  <!-- Left coil -->
+  <rect x="4" y="14" width="6" height="13" rx="1" fill="#3a3a5a"/>
+  <rect x="4" y="14" width="6" height="2" fill="#2a2a4a"/>
+  <line x1="4" y1="17" x2="10" y2="17" stroke="#5a5a7a" stroke-width="0.7"/>
+  <line x1="4" y1="20" x2="10" y2="20" stroke="#5a5a7a" stroke-width="0.7"/>
+  <line x1="4" y1="23" x2="10" y2="23" stroke="#5a5a7a" stroke-width="0.7"/>
+  <rect x="5" y="10" width="4" height="5" rx="0.5" fill="#4a4a6a"/>
+  <ellipse cx="7" cy="10" rx="2" ry="1" fill="#5a5a7a"/>
+  <!-- Center coil -->
+  <rect x="13" y="12" width="6" height="15" rx="1" fill="#3a3a5a"/>
+  <rect x="13" y="12" width="6" height="2" fill="#2a2a4a"/>
+  <line x1="13" y1="15" x2="19" y2="15" stroke="#5a5a7a" stroke-width="0.7"/>
+  <line x1="13" y1="18" x2="19" y2="18" stroke="#5a5a7a" stroke-width="0.7"/>
+  <line x1="13" y1="21" x2="19" y2="21" stroke="#5a5a7a" stroke-width="0.7"/>
+  <line x1="13" y1="24" x2="19" y2="24" stroke="#5a5a7a" stroke-width="0.7"/>
+  <rect x="14" y="8" width="4" height="5" rx="0.5" fill="#4a4a6a"/>
+  <ellipse cx="16" cy="8" rx="2" ry="1" fill="#5a5a7a"/>
+  <!-- Right coil -->
+  <rect x="22" y="14" width="6" height="13" rx="1" fill="#3a3a5a"/>
+  <rect x="22" y="14" width="6" height="2" fill="#2a2a4a"/>
+  <line x1="22" y1="17" x2="28" y2="17" stroke="#5a5a7a" stroke-width="0.7"/>
+  <line x1="22" y1="20" x2="28" y2="20" stroke="#5a5a7a" stroke-width="0.7"/>
+  <line x1="22" y1="23" x2="28" y2="23" stroke="#5a5a7a" stroke-width="0.7"/>
+  <rect x="23" y="10" width="4" height="5" rx="0.5" fill="#4a4a6a"/>
+  <ellipse cx="25" cy="10" rx="2" ry="1" fill="#5a5a7a"/>
+  <!-- Charge glow in each coil -->
+  <rect x="5" y="15" width="4" height="11" rx="0.5" fill="#3366ff" opacity="0.3"/>
+  <rect x="14" y="13" width="4" height="13" rx="0.5" fill="#3366ff" opacity="0.4"/>
+  <rect x="23" y="15" width="4" height="11" rx="0.5" fill="#3366ff" opacity="0.3"/>
+  <!-- Arc between coils -->
+  <path d="M10,11 Q12,9 13,11" stroke="#ffee44" stroke-width="1.2" fill="none" opacity="0.8"/>
+  <path d="M19,9 Q21,7 22,9" stroke="#ffee44" stroke-width="1.2" fill="none" opacity="0.8"/>
+  <!-- Top discharge sparks -->
+  <path d="M7,9 L6,7 L8,8 L7,5" stroke="#ffee44" stroke-width="1" fill="none" stroke-linecap="round"/>
+  <path d="M16,7 L15,5 L17,6 L16,3" stroke="#ffee44" stroke-width="1.2" fill="none" stroke-linecap="round"/>
+  <path d="M25,9 L24,7 L26,8 L25,5" stroke="#ffee44" stroke-width="1" fill="none" stroke-linecap="round"/>
+</svg>

--- a/web/public/sprites/tidal-fortress.svg
+++ b/web/public/sprites/tidal-fortress.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Sea base -->
+  <path d="M0,27 Q4,25 8,27 Q12,29 16,27 Q20,25 24,27 Q28,29 32,27 L32,32 L0,32 Z" fill="#2266aa" opacity="0.6"/>
+  <!-- Main fortress wall -->
+  <rect x="4" y="13" width="24" height="15" rx="1" fill="#6a6070"/>
+  <rect x="4" y="13" width="24" height="2.5" fill="#5a5060"/>
+  <!-- Stone lines -->
+  <line x1="4" y1="17" x2="28" y2="17" stroke="#5a5060" stroke-width="0.6"/>
+  <line x1="4" y1="21" x2="28" y2="21" stroke="#5a5060" stroke-width="0.6"/>
+  <line x1="4" y1="25" x2="28" y2="25" stroke="#5a5060" stroke-width="0.6"/>
+  <line x1="11" y1="13" x2="11" y2="28" stroke="#5a5060" stroke-width="0.6"/>
+  <line x1="19" y1="13" x2="19" y2="28" stroke="#5a5060" stroke-width="0.6"/>
+  <!-- Corner towers -->
+  <rect x="2" y="8" width="8" height="20" rx="1" fill="#7a7080"/>
+  <rect x="2" y="8" width="8" height="2.5" fill="#5a5060"/>
+  <rect x="22" y="8" width="8" height="20" rx="1" fill="#7a7080"/>
+  <rect x="22" y="8" width="8" height="2.5" fill="#5a5060"/>
+  <!-- Tower crenellations -->
+  <rect x="2" y="4" width="2.5" height="5" rx="0.3" fill="#6a6070"/>
+  <rect x="6" y="4" width="2.5" height="5" rx="0.3" fill="#6a6070"/>
+  <rect x="22" y="4" width="2.5" height="5" rx="0.3" fill="#6a6070"/>
+  <rect x="26" y="4" width="2.5" height="5" rx="0.3" fill="#6a6070"/>
+  <!-- Gate arch -->
+  <path d="M12,28 L12,20 Q16,16 20,20 L20,28 Z" fill="#2a1a2a"/>
+  <!-- Portcullis lines -->
+  <line x1="13" y1="20" x2="13" y2="28" stroke="#4a3a4a" stroke-width="0.7"/>
+  <line x1="16" y1="19" x2="16" y2="28" stroke="#4a3a4a" stroke-width="0.7"/>
+  <line x1="19" y1="20" x2="19" y2="28" stroke="#4a3a4a" stroke-width="0.7"/>
+  <line x1="12" y1="22" x2="20" y2="22" stroke="#4a3a4a" stroke-width="0.7"/>
+  <line x1="12" y1="25" x2="20" y2="25" stroke="#4a3a4a" stroke-width="0.7"/>
+  <!-- Tidal waves at base -->
+  <path d="M0,27 Q3,24 6,27" fill="none" stroke="#88ccff" stroke-width="1" opacity="0.8"/>
+  <path d="M24,27 Q27,24 30,27" fill="none" stroke="#88ccff" stroke-width="1" opacity="0.8"/>
+  <!-- Barnacles/seaweed on base -->
+  <circle cx="5" cy="24" r="1" fill="#3a7a3a" opacity="0.6"/>
+  <circle cx="27" cy="22" r="1" fill="#3a7a3a" opacity="0.6"/>
+  <!-- Flags on towers -->
+  <line x1="6" y1="4" x2="6" y2="1" stroke="#5a5060" stroke-width="0.8"/>
+  <polygon points="6,1 11,2 6,3.5" fill="#4466aa"/>
+  <line x1="26" y1="4" x2="26" y2="1" stroke="#5a5060" stroke-width="0.8"/>
+  <polygon points="26,1 31,2 26,3.5" fill="#4466aa"/>
+</svg>

--- a/web/public/sprites/titan-forge.svg
+++ b/web/public/sprites/titan-forge.svg
@@ -1,0 +1,38 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Massive forge body -->
+  <rect x="2" y="12" width="28" height="18" rx="2" fill="#5a3a2a"/>
+  <rect x="2" y="12" width="28" height="3" fill="#4a2a1a"/>
+  <!-- Stone banding -->
+  <rect x="2" y="18" width="28" height="2" fill="#4a2a1a"/>
+  <rect x="2" y="24" width="28" height="2" fill="#4a2a1a"/>
+  <!-- Forge mouth (large, glowing) -->
+  <rect x="9" y="16" width="14" height="11" rx="1" fill="#1a0a00"/>
+  <rect x="10" y="17" width="12" height="9" rx="0.5" fill="#dd3300"/>
+  <rect x="11" y="18" width="10" height="7" rx="0.5" fill="#ff6600" opacity="0.9"/>
+  <ellipse cx="16" cy="21" rx="5" ry="4" fill="#ffcc00" opacity="0.8"/>
+  <ellipse cx="16" cy="21" rx="2.5" ry="2" fill="#ffffff" opacity="0.4"/>
+  <!-- Twin chimneys -->
+  <rect x="5" y="4" width="5" height="10" rx="1" fill="#4a2a1a"/>
+  <rect x="4" y="3" width="7" height="3" rx="1" fill="#3a1a0a"/>
+  <rect x="22" y="4" width="5" height="10" rx="1" fill="#4a2a1a"/>
+  <rect x="21" y="3" width="7" height="3" rx="1" fill="#3a1a0a"/>
+  <!-- Smoke from chimneys -->
+  <ellipse cx="7.5" cy="2" rx="2.5" ry="1.5" fill="#666666" opacity="0.6"/>
+  <ellipse cx="8" cy="0" rx="2" ry="1" fill="#888888" opacity="0.4"/>
+  <ellipse cx="24.5" cy="2" rx="2.5" ry="1.5" fill="#666666" opacity="0.6"/>
+  <ellipse cx="25" cy="0" rx="2" ry="1" fill="#888888" opacity="0.4"/>
+  <!-- Massive gear on side -->
+  <circle cx="28" cy="16" r="4" fill="#7a5a2a" stroke="#5a3a0a" stroke-width="0.8"/>
+  <circle cx="28" cy="16" r="2.5" fill="#4a3a1a"/>
+  <circle cx="28" cy="16" r="1.2" fill="#8a6a3a"/>
+  <rect x="26" y="11" width="4" height="2" rx="0.5" fill="#7a5a2a"/>
+  <rect x="26" y="19" width="4" height="2" rx="0.5" fill="#7a5a2a"/>
+  <rect x="23" y="14" width="2" height="4" rx="0.5" fill="#7a5a2a"/>
+  <!-- Rivets on body -->
+  <circle cx="4" cy="14" r="0.8" fill="#8a6a4a"/>
+  <circle cx="4" cy="20" r="0.8" fill="#8a6a4a"/>
+  <circle cx="4" cy="26" r="0.8" fill="#8a6a4a"/>
+  <!-- Anvil at base -->
+  <rect x="13" y="28" width="8" height="2" rx="0.5" fill="#7a7a6a"/>
+  <rect x="14" y="30" width="6" height="2" rx="0.5" fill="#6a6a5a"/>
+</svg>

--- a/web/public/sprites/vault-repair-bay.svg
+++ b/web/public/sprites/vault-repair-bay.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Vault door / back wall -->
+  <rect x="2" y="8" width="28" height="22" rx="1" fill="#5a5a4a"/>
+  <rect x="2" y="8" width="28" height="2.5" fill="#4a4a3a"/>
+  <!-- Roof overhang -->
+  <rect x="1" y="6" width="30" height="4" rx="1" fill="#6a6a5a"/>
+  <rect x="1" y="6" width="30" height="1.5" fill="#5a5a4a"/>
+  <!-- Bay opening -->
+  <rect x="6" y="14" width="20" height="16" rx="0" fill="#2a2a1a"/>
+  <!-- Gantry frame above bay -->
+  <rect x="6" y="10" width="20" height="5" rx="0.5" fill="#7a7a5a"/>
+  <line x1="6" y1="12" x2="26" y2="12" stroke="#5a5a3a" stroke-width="0.7"/>
+  <!-- Gantry chain/hoist -->
+  <line x1="16" y1="12" x2="16" y2="18" stroke="#8a8a6a" stroke-width="0.8"/>
+  <rect x="13" y="18" width="6" height="3" rx="0.5" fill="#9a8a4a"/>
+  <line x1="14" y1="17" x2="14" y2="19" stroke="#8a7a3a" stroke-width="0.7"/>
+  <line x1="18" y1="17" x2="18" y2="19" stroke="#8a7a3a" stroke-width="0.7"/>
+  <!-- Unit on repair platform -->
+  <rect x="12" y="21" width="8" height="6" rx="1" fill="#4a4a3a" opacity="0.8"/>
+  <!-- Repair sparks -->
+  <path d="M15,21 L14,19 L16,20 L15,17" stroke="#ffcc00" stroke-width="0.9" fill="none" stroke-linecap="round"/>
+  <path d="M18,22 L19,20 L17,21" stroke="#ffcc00" stroke-width="0.8" fill="none" stroke-linecap="round"/>
+  <!-- Tool rack on left wall -->
+  <rect x="3" y="15" width="2" height="10" rx="0.3" fill="#6a5a3a"/>
+  <line x1="3" y1="17" x2="5" y2="17" stroke="#8a7a4a" stroke-width="0.8"/>
+  <line x1="3" y1="19" x2="5" y2="19" stroke="#8a7a4a" stroke-width="0.8"/>
+  <line x1="3" y1="21" x2="5" y2="21" stroke="#8a7a4a" stroke-width="0.8"/>
+  <!-- Wrench on rack -->
+  <ellipse cx="4" cy="16" rx="1" ry="0.7" fill="#aaaaaa"/>
+  <!-- Parts shelf on right -->
+  <rect x="27" y="15" width="2" height="8" rx="0.3" fill="#6a5a3a"/>
+  <circle cx="28" cy="17" r="1" fill="#888888"/>
+  <circle cx="28" cy="20" r="0.8" fill="#aa8833"/>
+  <!-- Warning stripe on floor -->
+  <line x1="7" y1="29" x2="25" y2="29" stroke="#ffcc00" stroke-width="1.5" stroke-dasharray="2,2"/>
+</svg>

--- a/web/public/sprites/wind-shrine.svg
+++ b/web/public/sprites/wind-shrine.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground base -->
+  <ellipse cx="16" cy="31" rx="12" ry="1.5" fill="#3a3a2a" opacity="0.5"/>
+  <!-- Stone dais -->
+  <rect x="5" y="27" width="22" height="4" rx="1" fill="#7a7a6a"/>
+  <rect x="7" y="25" width="18" height="3" rx="1" fill="#8a8a7a"/>
+  <!-- Central pole -->
+  <rect x="15" y="8" width="2" height="18" rx="0.5" fill="#7a6a3a"/>
+  <!-- Wind vane at top (4-bladed) -->
+  <rect x="11" y="6" width="10" height="2" rx="1" fill="#aaaaaa"/>
+  <rect x="15" y="3" width="2" height="9" rx="1" fill="#aaaaaa"/>
+  <!-- Vane tip decoration -->
+  <polygon points="16,3 14,5 18,5" fill="#cccc44"/>
+  <!-- Wind streamers (horizontal ribbons) -->
+  <path d="M17,10 Q22,9 26,11 Q22,12 17,11 Z" fill="#88ccff" opacity="0.8"/>
+  <path d="M17,14 Q23,12 28,14 Q23,16 17,15 Z" fill="#aaddff" opacity="0.7"/>
+  <path d="M15,18 Q9,17 5,19 Q9,21 15,19 Z" fill="#88ccff" opacity="0.7"/>
+  <!-- Offering bowl on dais -->
+  <ellipse cx="16" cy="25" rx="4" ry="1.5" fill="#5a5a4a"/>
+  <ellipse cx="16" cy="24.5" rx="3" ry="1" fill="#3a3a2a"/>
+  <!-- Wind energy wisps -->
+  <path d="M3,14 Q7,12 8,15 Q6,17 3,16" fill="none" stroke="#88ddff" stroke-width="0.8" opacity="0.7"/>
+  <path d="M29,10 Q27,13 25,12 Q26,9 29,10" fill="none" stroke="#88ddff" stroke-width="0.8" opacity="0.6"/>
+  <path d="M2,20 Q5,18 7,20 Q5,22 2,21" fill="none" stroke="#aaeeff" stroke-width="0.7" opacity="0.5"/>
+  <!-- Rune on pole -->
+  <text x="16" y="20" font-size="5" text-anchor="middle" fill="#aaccff" font-family="monospace" opacity="0.8">ᚹ</text>
+  <!-- Side stone markers -->
+  <rect x="5" y="17" width="2" height="9" rx="0.5" fill="#7a7a6a"/>
+  <rect x="25" y="17" width="2" height="9" rx="0.5" fill="#7a7a6a"/>
+</svg>


### PR DESCRIPTION
Closes #610, closes #611, closes #612

## Summary

**Issue #610 — Buildings D + Upgrades A (10 files):**
- Buildings: `storm-beacon.svg`, `storm-tower.svg`, `stormgate.svg`, `thunder-battery.svg`, `tidal-fortress.svg`, `titan-forge.svg`, `vault-repair-bay.svg`, `wind-shrine.svg`
- Upgrades: `aerial-volley.svg`, `ancient-blessing.svg`

**Issue #611 — Upgrades B (10 files):**
- `arcane-efficiency.svg`, `battle-cry.svg`, `battle-hardened.svg`, `blizzard-blast.svg`, `bloodlust.svg`, `burning-rush.svg`, `canopy-growth.svg`, `clockwork-tune.svg`, `cloud-cover.svg`, `crystal-resonance.svg`

**Issue #612 — Upgrades C (10 files):**
- `crystalline-shell.svg`, `current-mastery.svg`, `dark-ritual.svg`, `deep-growth.svg`, `deep-resilience.svg`, `desert-rush.svg`, `eagle-eye.svg`, `entropy-wave.svg`, `feather-step.svg`, `field-medic.svg`

https://claude.ai/code/session_01N8PP3AYB5cnjTMKW144oED