### PR TITLE
feat(cutscene): graphic novel image display mechanism + Act 1 graphics

### DIFF
--- a/web/public/cutscenes/act1-intro-1.svg
+++ b/web/public/cutscenes/act1-intro-1.svg
@@ -1,0 +1,56 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#0a0a0a"/>
+
+  <!-- Background glow at centre of fracture -->
+  <radialGradient id="glow1" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#6b3fa0" stop-opacity="0.6"/>
+    <stop offset="100%" stop-color="#0a0a0a" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#glow1)"/>
+
+  <!-- Realm shards — jagged polygons breaking apart -->
+  <!-- Upper-left shard -->
+  <polygon points="60,20 180,80 140,130 30,90 10,40" fill="#1a1a2e" stroke="#4a2080" stroke-width="1.5"/>
+  <!-- Upper-right shard -->
+  <polygon points="220,10 390,30 380,110 250,90 200,50" fill="#1a2a1a" stroke="#2a6040" stroke-width="1.5"/>
+  <!-- Lower-left shard -->
+  <polygon points="10,150 150,140 120,220 20,230" fill="#1e1a10" stroke="#604020" stroke-width="1.5"/>
+  <!-- Lower-right shard -->
+  <polygon points="260,160 390,130 390,230 230,235" fill="#1a1a1e" stroke="#203060" stroke-width="1.5"/>
+  <!-- Centre fragment — floating -->
+  <polygon points="170,95 230,85 250,140 220,160 160,150" fill="#150f20" stroke="#8040c0" stroke-width="2"/>
+
+  <!-- Fracture cracks radiating from centre -->
+  <g stroke="#c080ff" stroke-width="1.5" fill="none" opacity="0.8">
+    <line x1="200" y1="120" x2="60" y2="20"/>
+    <line x1="200" y1="120" x2="380" y2="15"/>
+    <line x1="200" y1="120" x2="390" y2="200"/>
+    <line x1="200" y1="120" x2="10" y2="220"/>
+    <line x1="200" y1="120" x2="200" y2="5"/>
+    <line x1="200" y1="120" x2="350" y2="120"/>
+    <line x1="200" y1="120" x2="50" y2="150"/>
+  </g>
+  <!-- Secondary cracks, dimmer -->
+  <g stroke="#8040c0" stroke-width="0.8" fill="none" opacity="0.5">
+    <line x1="200" y1="120" x2="120" y2="50"/>
+    <line x1="200" y1="120" x2="300" y2="60"/>
+    <line x1="200" y1="120" x2="340" y2="170"/>
+    <line x1="200" y1="120" x2="100" y2="200"/>
+  </g>
+
+  <!-- Bright detonation point -->
+  <circle cx="200" cy="120" r="14" fill="#c080ff" opacity="0.9"/>
+  <circle cx="200" cy="120" r="8" fill="#ffffff" opacity="0.95"/>
+  <circle cx="200" cy="120" r="3" fill="#c080ff"/>
+
+  <!-- Floating debris dots -->
+  <circle cx="155" cy="75"  r="2" fill="#8040c0" opacity="0.7"/>
+  <circle cx="245" cy="68"  r="1.5" fill="#6b3fa0" opacity="0.6"/>
+  <circle cx="130" cy="160" r="2" fill="#8040c0" opacity="0.5"/>
+  <circle cx="270" cy="155" r="2.5" fill="#6b3fa0" opacity="0.7"/>
+  <circle cx="310" cy="90"  r="1.5" fill="#8040c0" opacity="0.6"/>
+  <circle cx="80"  cy="130" r="2" fill="#6b3fa0" opacity="0.5"/>
+
+  <!-- Label -->
+  <text x="200" y="228" font-family="monospace" font-size="9" fill="#4a2080" text-anchor="middle" letter-spacing="3">THE FRACTURE EVENT</text>
+</svg>

--- a/web/public/cutscenes/act1-intro-2.svg
+++ b/web/public/cutscenes/act1-intro-2.svg
@@ -1,0 +1,74 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#0a0a0a"/>
+
+  <!-- Horizon ground line -->
+  <rect x="0" y="185" width="400" height="55" fill="#0e0e0e"/>
+  <line x1="0" y1="185" x2="400" y2="185" stroke="#1a1a1a" stroke-width="1"/>
+
+  <!-- Distant shard walls on horizon — broken silhouettes -->
+  <rect x="30"  y="140" width="18" height="45" fill="#111" opacity="0.7"/>
+  <rect x="55"  y="125" width="12" height="60" fill="#111" opacity="0.6"/>
+  <rect x="320" y="135" width="20" height="50" fill="#111" opacity="0.7"/>
+  <rect x="350" y="118" width="14" height="67" fill="#111" opacity="0.6"/>
+  <!-- Jagged tops -->
+  <polygon points="30,140 38,130 46,140" fill="#0a0a0a"/>
+  <polygon points="55,125 61,112 67,125" fill="#0a0a0a"/>
+  <polygon points="320,135 330,122 340,135" fill="#0a0a0a"/>
+  <polygon points="350,118 357,105 364,118" fill="#0a0a0a"/>
+
+  <!-- Faint shard walls far right -->
+  <rect x="380" y="150" width="10" height="35" fill="#111" opacity="0.4"/>
+
+  <!-- Ground details — cracked earth lines -->
+  <g stroke="#161616" stroke-width="1" fill="none">
+    <line x1="0"   y1="195" x2="160" y2="195"/>
+    <line x1="220" y1="198" x2="400" y2="198"/>
+    <line x1="50"  y1="210" x2="180" y2="210"/>
+    <line x1="240" y1="208" x2="370" y2="208"/>
+  </g>
+
+  <!-- Jarv figure — lone standing silhouette -->
+  <!-- Legs -->
+  <line x1="197" y1="175" x2="193" y2="185" stroke="#3a8a4a" stroke-width="2.5"/>
+  <line x1="203" y1="175" x2="207" y2="185" stroke="#3a8a4a" stroke-width="2.5"/>
+  <!-- Body -->
+  <line x1="200" y1="155" x2="200" y2="175" stroke="#3a8a4a" stroke-width="3"/>
+  <!-- Arms -->
+  <line x1="200" y1="162" x2="188" y2="170" stroke="#3a8a4a" stroke-width="2.5"/>
+  <line x1="200" y1="162" x2="212" y2="168" stroke="#3a8a4a" stroke-width="2.5"/>
+  <!-- Head -->
+  <circle cx="200" cy="149" r="6" fill="#3a8a4a"/>
+  <!-- Cloak outline -->
+  <polygon points="188,175 200,158 212,175 206,185 194,185" fill="none" stroke="#2a6a3a" stroke-width="1" opacity="0.6"/>
+
+  <!-- Cards held in right hand — small glowing rectangles -->
+  <g transform="translate(212,168) rotate(-20)">
+    <rect x="-1" y="-7" width="7" height="10" rx="1" fill="#1a3a2a" stroke="#40a060" stroke-width="0.8"/>
+    <rect x="3"  y="-8" width="7" height="10" rx="1" fill="#1a2a3a" stroke="#4060a0" stroke-width="0.8"/>
+    <rect x="7"  y="-7" width="7" height="10" rx="1" fill="#2a1a1a" stroke="#a04040" stroke-width="0.8"/>
+  </g>
+
+  <!-- Subtle ambient glow around figure -->
+  <radialGradient id="jarv-glow" cx="50%" cy="80%" r="30%">
+    <stop offset="0%" stop-color="#2a6a3a" stop-opacity="0.15"/>
+    <stop offset="100%" stop-color="#0a0a0a" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#jarv-glow)"/>
+
+  <!-- Stars in sky -->
+  <g fill="#ffffff" opacity="0.5">
+    <circle cx="40"  cy="30"  r="1"/>
+    <circle cx="90"  cy="55"  r="0.8"/>
+    <circle cx="150" cy="20"  r="1"/>
+    <circle cx="180" cy="70"  r="0.8"/>
+    <circle cx="260" cy="35"  r="1"/>
+    <circle cx="310" cy="18"  r="0.8"/>
+    <circle cx="360" cy="55"  r="1"/>
+    <circle cx="380" cy="30"  r="0.8"/>
+    <circle cx="70"  cy="85"  r="0.6"/>
+    <circle cx="330" cy="80"  r="0.6"/>
+  </g>
+
+  <!-- Label -->
+  <text x="200" y="228" font-family="monospace" font-size="9" fill="#2a6a3a" text-anchor="middle" letter-spacing="3">THE WANDERER</text>
+</svg>

--- a/web/public/cutscenes/act1-intro-3.svg
+++ b/web/public/cutscenes/act1-intro-3.svg
@@ -1,0 +1,87 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#0a0a0a"/>
+
+  <!-- Deep forest ambient gradient -->
+  <radialGradient id="forest-glow" cx="50%" cy="60%" r="55%">
+    <stop offset="0%" stop-color="#0a2010" stop-opacity="1"/>
+    <stop offset="100%" stop-color="#0a0a0a" stop-opacity="1"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#forest-glow)"/>
+
+  <!-- Ground -->
+  <rect x="0" y="195" width="400" height="45" fill="#060e06"/>
+  <line x1="0" y1="195" x2="400" y2="195" stroke="#0f1a0f" stroke-width="1"/>
+
+  <!-- Background trees (far) -->
+  <g fill="#0c180c" opacity="0.8">
+    <!-- Trunks -->
+    <rect x="60"  y="120" width="8"  height="75"/>
+    <rect x="105" y="110" width="10" height="85"/>
+    <rect x="290" y="115" width="9"  height="80"/>
+    <rect x="330" y="108" width="11" height="87"/>
+    <!-- Canopies -->
+    <ellipse cx="64"  cy="105" rx="28" ry="30"/>
+    <ellipse cx="110" cy="88"  rx="35" ry="38"/>
+    <ellipse cx="295" cy="100" rx="30" ry="32"/>
+    <ellipse cx="336" cy="85"  rx="38" ry="42"/>
+  </g>
+
+  <!-- Mid trees -->
+  <g fill="#0f2210" opacity="0.9">
+    <rect x="20"  y="130" width="12" height="65"/>
+    <rect x="155" y="105" width="14" height="90"/>
+    <rect x="230" y="112" width="13" height="83"/>
+    <rect x="375" y="125" width="11" height="70"/>
+    <ellipse cx="26"  cy="110" rx="38" ry="44"/>
+    <ellipse cx="162" cy="80"  rx="45" ry="48"/>
+    <ellipse cx="237" cy="88"  rx="42" ry="46"/>
+    <ellipse cx="380" cy="104" rx="36" ry="40"/>
+  </g>
+
+  <!-- Foreground trees (close, dark) -->
+  <g fill="#061006">
+    <rect x="0"   y="80"  width="16" height="160"/>
+    <rect x="185" y="60"  width="20" height="180"/>
+    <rect x="385" y="90"  width="15" height="150"/>
+    <ellipse cx="8"   cy="55"  rx="50" ry="60"/>
+    <ellipse cx="195" cy="28"  rx="60" ry="65"/>
+    <ellipse cx="392" cy="62"  rx="48" ry="55"/>
+  </g>
+
+  <!-- Sealed gate at centre -->
+  <!-- Gate pillars -->
+  <rect x="158" y="130" width="12" height="65" fill="#1a3020" stroke="#2a5030" stroke-width="1"/>
+  <rect x="230" y="130" width="12" height="65" fill="#1a3020" stroke="#2a5030" stroke-width="1"/>
+  <!-- Gate arch -->
+  <path d="M158,130 Q200,95 242,130" fill="none" stroke="#2a5030" stroke-width="2"/>
+  <!-- Gate barrier — sealed glowing runes -->
+  <rect x="170" y="130" width="60" height="65" fill="#0a1a0a" stroke="#1a3020" stroke-width="0.5" opacity="0.8"/>
+  <!-- Rune lines on gate -->
+  <g stroke="#3a8050" stroke-width="0.8" opacity="0.6">
+    <line x1="175" y1="145" x2="225" y2="145"/>
+    <line x1="175" y1="158" x2="225" y2="158"/>
+    <line x1="175" y1="171" x2="225" y2="171"/>
+    <line x1="200" y1="133" x2="200" y2="192"/>
+  </g>
+  <!-- Seal glow -->
+  <radialGradient id="seal-glow" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#40a060" stop-opacity="0.3"/>
+    <stop offset="100%" stop-color="#0a0a0a" stop-opacity="0"/>
+  </radialGradient>
+  <rect x="155" y="90" width="90" height="110" fill="url(#seal-glow)"/>
+  <!-- Glowing rune symbol -->
+  <circle cx="200" cy="160" r="10" fill="none" stroke="#40a060" stroke-width="1" opacity="0.5"/>
+  <text x="200" y="164" font-family="monospace" font-size="8" fill="#40a060" text-anchor="middle" opacity="0.7">✦</text>
+
+  <!-- Roots on ground -->
+  <g stroke="#1a2a1a" stroke-width="2" fill="none" opacity="0.7">
+    <path d="M0,215 Q40,200 80,210 Q100,215 130,205"/>
+    <path d="M270,208 Q310,195 350,210 Q380,220 400,208"/>
+  </g>
+
+  <!-- Misty atmosphere -->
+  <rect x="0" y="170" width="400" height="30" fill="#0a150a" opacity="0.4"/>
+
+  <!-- Label -->
+  <text x="200" y="228" font-family="monospace" font-size="9" fill="#2a6030" text-anchor="middle" letter-spacing="3">THE VERDANT SHARD</text>
+</svg>

--- a/web/public/cutscenes/act1-intro-4.svg
+++ b/web/public/cutscenes/act1-intro-4.svg
@@ -1,0 +1,87 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#0a0a0a"/>
+
+  <!-- Forest path perspective — converging to a light at horizon -->
+  <!-- Ground -->
+  <polygon points="0,240 400,240 260,140 140,140" fill="#060e06"/>
+  <!-- Path -->
+  <polygon points="175,240 225,240 215,140 185,140" fill="#0c160c"/>
+  <!-- Path edge lines -->
+  <line x1="175" y1="240" x2="185" y2="140" stroke="#122012" stroke-width="1"/>
+  <line x1="225" y1="240" x2="215" y2="140" stroke="#122012" stroke-width="1"/>
+
+  <!-- Tree trunks perspective — left side -->
+  <g fill="#061006">
+    <rect x="0"   y="60"  width="60"  height="180"/>
+    <rect x="55"  y="100" width="38"  height="140"/>
+    <rect x="90"  y="125" width="24"  height="115"/>
+    <rect x="112" y="140" width="16"  height="100"/>
+    <rect x="128" y="148" width="10"  height="92"/>
+    <rect x="138" y="153" width="8"   height="87"/>
+  </g>
+  <!-- Canopies left -->
+  <g fill="#0a1a0a" opacity="0.9">
+    <ellipse cx="30"  cy="40"  rx="70" ry="65"/>
+    <ellipse cx="74"  cy="78"  rx="50" ry="48"/>
+    <ellipse cx="102" cy="105" rx="36" ry="34"/>
+    <ellipse cx="120" cy="122" rx="24" ry="22"/>
+    <ellipse cx="133" cy="133" rx="16" ry="14"/>
+    <ellipse cx="142" cy="138" rx="12" ry="10"/>
+  </g>
+
+  <!-- Tree trunks — right side -->
+  <g fill="#061006">
+    <rect x="340" y="60"  width="60"  height="180"/>
+    <rect x="307" y="100" width="38"  height="140"/>
+    <rect x="276" y="125" width="24"  height="115"/>
+    <rect x="252" y="140" width="16"  height="100"/>
+    <rect x="234" y="148" width="10"  height="92"/>
+    <rect x="224" y="153" width="8"   height="87"/>
+  </g>
+  <!-- Canopies right -->
+  <g fill="#0a1a0a" opacity="0.9">
+    <ellipse cx="370" cy="40"  rx="70" ry="65"/>
+    <ellipse cx="326" cy="78"  rx="50" ry="48"/>
+    <ellipse cx="298" cy="105" rx="36" ry="34"/>
+    <ellipse cx="280" cy="122" rx="24" ry="22"/>
+    <ellipse cx="267" cy="133" rx="16" ry="14"/>
+    <ellipse cx="258" cy="138" rx="12" ry="10"/>
+  </g>
+
+  <!-- Ley line glow at vanishing point -->
+  <radialGradient id="ley-glow" cx="50%" cy="58%" r="20%">
+    <stop offset="0%" stop-color="#40c060" stop-opacity="0.7"/>
+    <stop offset="60%" stop-color="#206030" stop-opacity="0.2"/>
+    <stop offset="100%" stop-color="#0a0a0a" stop-opacity="0"/>
+  </radialGradient>
+  <rect x="140" y="100" width="120" height="80" fill="url(#ley-glow)"/>
+
+  <!-- Ley line tendrils along path -->
+  <g stroke="#30a050" stroke-width="0.8" fill="none" opacity="0.6">
+    <path d="M200,240 Q198,200 200,140"/>
+    <path d="M200,240 Q193,200 188,140" opacity="0.4"/>
+    <path d="M200,240 Q207,200 212,140" opacity="0.4"/>
+  </g>
+
+  <!-- Compass in foreground — bottom centre -->
+  <g transform="translate(200,210)">
+    <circle r="18" fill="#0e1a0e" stroke="#2a5030" stroke-width="1.5"/>
+    <!-- Compass ring marks -->
+    <g stroke="#2a5030" stroke-width="0.8">
+      <line x1="0" y1="-15" x2="0" y2="-12"/>
+      <line x1="0" y1="12"  x2="0" y2="15"/>
+      <line x1="-15" y1="0" x2="-12" y2="0"/>
+      <line x1="12"  y1="0" x2="15" y2="0"/>
+    </g>
+    <!-- Compass needle pointing up (north = into forest) -->
+    <polygon points="0,-12 2,0 0,3 -2,0" fill="#40c060"/>
+    <polygon points="0,3 2,0 0,12 -2,0" fill="#333"/>
+    <!-- Centre pivot -->
+    <circle r="2" fill="#60e080"/>
+    <!-- N label -->
+    <text x="0" y="-6" font-family="monospace" font-size="4" fill="#40c060" text-anchor="middle">N</text>
+  </g>
+
+  <!-- Label -->
+  <text x="200" y="15" font-family="monospace" font-size="9" fill="#2a6030" text-anchor="middle" letter-spacing="3">YOUR MISSION</text>
+</svg>

--- a/web/public/cutscenes/act1-outro-1.svg
+++ b/web/public/cutscenes/act1-outro-1.svg
@@ -1,0 +1,83 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#0a0a0a"/>
+
+  <!-- Ambient light from fracturing roots -->
+  <radialGradient id="collapse-glow" cx="50%" cy="45%" r="45%">
+    <stop offset="0%" stop-color="#3a7020" stop-opacity="0.5"/>
+    <stop offset="100%" stop-color="#0a0a0a" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#collapse-glow)"/>
+
+  <!-- Ground -->
+  <rect x="0" y="200" width="400" height="40" fill="#060e06"/>
+  <line x1="0" y1="200" x2="400" y2="200" stroke="#0f1a0f" stroke-width="1"/>
+
+  <!-- Thornlord crumbling figure — made of geometric root shapes -->
+  <!-- Central body mass disintegrating -->
+  <g opacity="0.9">
+    <!-- Body chunks separating -->
+    <polygon points="175,100 210,95 215,145 170,150" fill="#1a2e10" stroke="#2a4a18" stroke-width="1"/>
+    <polygon points="210,95 235,105 230,140 215,145" fill="#162808" stroke="#243a10" stroke-width="1" transform="rotate(8,222,120)"/>
+    <polygon points="168,105 178,100 170,150 158,140" fill="#162808" stroke="#243a10" stroke-width="1" transform="rotate(-10,165,125)"/>
+  </g>
+
+  <!-- Root arms — one reaching up (left), one collapsing (right) -->
+  <!-- Left arm — reaching skyward, splitting -->
+  <g stroke="#2a4a18" stroke-width="3" fill="none">
+    <path d="M175,110 Q150,80 130,50"/>
+    <path d="M130,50 Q115,30 100,15"/>
+    <path d="M130,50 Q140,25 155,10"/>
+  </g>
+  <!-- Bark splits on left arm -->
+  <g stroke="#40a030" stroke-width="0.8" opacity="0.5">
+    <line x1="155" y1="75" x2="160" y2="65"/>
+    <line x1="140" y1="60" x2="135" y2="50"/>
+    <line x1="120" y1="35" x2="112" y2="28"/>
+  </g>
+
+  <!-- Right arm — dropping, falling apart -->
+  <g stroke="#2a4a18" stroke-width="3" fill="none" opacity="0.7">
+    <path d="M215,115 Q255,100 285,120"/>
+    <path d="M285,120 Q310,135 330,150"/>
+  </g>
+
+  <!-- Legs/roots going into ground -->
+  <g stroke="#1e380e" stroke-width="4" fill="none">
+    <path d="M185,148 Q180,175 170,200"/>
+    <path d="M200,150 Q200,180 200,205"/>
+    <path d="M215,145 Q220,175 235,200"/>
+  </g>
+
+  <!-- Bark fragments flying off -->
+  <g fill="#2a4a18" opacity="0.8">
+    <polygon points="130,80  136,75  133,85"/>
+    <polygon points="260,90  267,85  263,96"/>
+    <polygon points="155,45  160,38  163,47"/>
+    <polygon points="105,20  110,14  112,23"/>
+    <polygon points="290,135 296,130 293,140"/>
+  </g>
+  <!-- Lighter bark shards -->
+  <g fill="#3a6828" opacity="0.5">
+    <polygon points="145,65 150,60 148,69"/>
+    <polygon points="240,108 246,103 243,112"/>
+    <polygon points="170,30 174,25 176,33"/>
+    <polygon points="320,148 325,143 322,152"/>
+  </g>
+
+  <!-- Glowing pathway cracks opening in ground -->
+  <g stroke="#50c030" stroke-width="1.5" fill="none" opacity="0.7">
+    <path d="M100,200 Q150,190 200,195 Q250,200 300,190"/>
+    <path d="M60,210  Q120,202 180,207 Q240,212 320,203 Q360,198 390,205"/>
+  </g>
+  <!-- Glow dots along paths -->
+  <g fill="#50c030" opacity="0.5">
+    <circle cx="150" cy="193" r="2"/>
+    <circle cx="200" cy="196" r="2.5"/>
+    <circle cx="250" cy="192" r="2"/>
+    <circle cx="130" cy="205" r="1.5"/>
+    <circle cx="300" cy="204" r="1.5"/>
+  </g>
+
+  <!-- Label -->
+  <text x="200" y="228" font-family="monospace" font-size="9" fill="#2a6020" text-anchor="middle" letter-spacing="3">THE THORNLORD FALLS</text>
+</svg>

--- a/web/public/cutscenes/act1-outro-2.svg
+++ b/web/public/cutscenes/act1-outro-2.svg
@@ -1,0 +1,70 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#0a0a0a"/>
+
+  <!-- Leaf litter on ground -->
+  <radialGradient id="leaf-glow" cx="50%" cy="70%" r="40%">
+    <stop offset="0%" stop-color="#1a3010" stop-opacity="0.4"/>
+    <stop offset="100%" stop-color="#0a0a0a" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#leaf-glow)"/>
+
+  <!-- Fallen bark pieces on ground -->
+  <g fill="#162010" stroke="#202e14" stroke-width="0.8">
+    <ellipse cx="60"  cy="195" rx="35" ry="8" transform="rotate(-15,60,195)"/>
+    <ellipse cx="130" cy="210" rx="28" ry="6" transform="rotate(10,130,210)"/>
+    <ellipse cx="290" cy="198" rx="32" ry="7" transform="rotate(-8,290,198)"/>
+    <ellipse cx="360" cy="208" rx="25" ry="6" transform="rotate(20,360,208)"/>
+    <ellipse cx="200" cy="220" rx="40" ry="9" transform="rotate(-5,200,220)"/>
+  </g>
+  <!-- Small leaves scattered -->
+  <g fill="#1e3015" opacity="0.7">
+    <ellipse cx="80"  cy="188" rx="6"  ry="3" transform="rotate(30,80,188)"/>
+    <ellipse cx="160" cy="202" rx="5"  ry="2" transform="rotate(-20,160,202)"/>
+    <ellipse cx="240" cy="190" rx="7"  ry="3" transform="rotate(15,240,190)"/>
+    <ellipse cx="320" cy="215" rx="5"  ry="2" transform="rotate(-30,320,215)"/>
+    <ellipse cx="50"  cy="215" rx="4"  ry="2" transform="rotate(45,50,215)"/>
+    <ellipse cx="355" cy="185" rx="6"  ry="3" transform="rotate(-10,355,185)"/>
+  </g>
+
+  <!-- Bark Shield — centre-stage, propped up -->
+  <g transform="translate(200,130)">
+    <!-- Shield shadow -->
+    <ellipse cx="0" cy="62" rx="38" ry="8" fill="#000" opacity="0.4"/>
+    <!-- Shield body — rounded top, pointed bottom -->
+    <path d="M-32,-40 Q-32,-52 0,-58 Q32,-52 32,-40 L32,20 Q32,35 0,58 Q-32,35 -32,20 Z"
+          fill="#1e3415" stroke="#3a6020" stroke-width="2"/>
+    <!-- Shield wood grain lines -->
+    <g stroke="#2a4a18" stroke-width="0.8" fill="none" opacity="0.6">
+      <line x1="-20" y1="-30" x2="-20" y2="40"/>
+      <line x1="-8"  y1="-40" x2="-8"  y2="50"/>
+      <line x1="4"   y1="-42" x2="4"   y2="52"/>
+      <line x1="16"  y1="-40" x2="16"  y2="46"/>
+      <line x1="26"  y1="-30" x2="26"  y2="36"/>
+    </g>
+    <!-- Shield face — bark texture patches -->
+    <ellipse cx="-10" cy="-10" rx="8" ry="10" fill="#243a16" opacity="0.5"/>
+    <ellipse cx="14"  cy="15"  rx="7" ry="9"  fill="#1e3012" opacity="0.5"/>
+    <!-- Shield boss (centre emblem) — tree ring motif -->
+    <circle cx="0" cy="0" r="16" fill="none" stroke="#4a7828" stroke-width="1.5"/>
+    <circle cx="0" cy="0" r="10" fill="none" stroke="#3a6020" stroke-width="1"/>
+    <circle cx="0" cy="0" r="4"  fill="#3a6020"/>
+    <!-- Subtle glow around boss -->
+    <circle cx="0" cy="0" r="18" fill="none" stroke="#50a030" stroke-width="0.5" opacity="0.5"/>
+    <!-- Thornlord mark — small thorn cross -->
+    <line x1="0" y1="-18" x2="0" y2="-12" stroke="#50a030" stroke-width="1" opacity="0.6"/>
+    <line x1="-18" y1="0" x2="-12" y2="0" stroke="#50a030" stroke-width="1" opacity="0.6"/>
+    <line x1="12" y1="0"  x2="18" y2="0"  stroke="#50a030" stroke-width="1" opacity="0.6"/>
+    <line x1="0" y1="12"  x2="0" y2="18"  stroke="#50a030" stroke-width="1" opacity="0.6"/>
+  </g>
+
+  <!-- Faint forest silhouette in background -->
+  <g fill="#0c140c" opacity="0.5">
+    <rect x="0"   y="100" width="30"  height="100"/>
+    <rect x="370" y="110" width="30"  height="90"/>
+    <ellipse cx="15"  cy="80"  rx="40" ry="45"/>
+    <ellipse cx="385" cy="90"  rx="40" ry="45"/>
+  </g>
+
+  <!-- Label -->
+  <text x="200" y="228" font-family="monospace" font-size="9" fill="#2a6020" text-anchor="middle" letter-spacing="3">WHAT HE WAS</text>
+</svg>

--- a/web/public/cutscenes/act1-outro-3.svg
+++ b/web/public/cutscenes/act1-outro-3.svg
@@ -1,0 +1,97 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#0a0a0a"/>
+
+  <!-- Open sky glow — path leads to light -->
+  <radialGradient id="path-light" cx="50%" cy="55%" r="35%">
+    <stop offset="0%" stop-color="#204a30" stop-opacity="0.8"/>
+    <stop offset="70%" stop-color="#102015" stop-opacity="0.3"/>
+    <stop offset="100%" stop-color="#0a0a0a" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#path-light)"/>
+
+  <!-- Ground/floor of the path -->
+  <polygon points="0,240 400,240 280,155 120,155" fill="#080e08"/>
+  <!-- Path corridor -->
+  <polygon points="165,240 235,240 220,155 180,155" fill="#0c180c"/>
+  <!-- Path edges -->
+  <line x1="165" y1="240" x2="180" y2="155" stroke="#142014" stroke-width="1"/>
+  <line x1="235" y1="240" x2="220" y2="155" stroke="#142014" stroke-width="1"/>
+
+  <!-- Ancient tree trunks framing the path — left side -->
+  <g fill="#060e06">
+    <rect x="0"   y="50"  width="55"  height="190"/>
+    <rect x="50"  y="90"  width="38"  height="150"/>
+    <rect x="82"  y="115" width="26"  height="125"/>
+    <rect x="103" y="133" width="18"  height="107"/>
+    <rect x="118" y="145" width="12"  height="95"/>
+    <rect x="128" y="152" width="8"   height="88"/>
+    <rect x="135" y="156" width="6"   height="84"/>
+  </g>
+  <!-- Canopies left -->
+  <g fill="#091409">
+    <ellipse cx="28"  cy="28"  rx="65" ry="58"/>
+    <ellipse cx="69"  cy="68"  rx="50" ry="46"/>
+    <ellipse cx="95"  cy="95"  rx="36" ry="32"/>
+    <ellipse cx="112" cy="115" rx="25" ry="22"/>
+    <ellipse cx="124" cy="130" rx="16" ry="14"/>
+    <ellipse cx="132" cy="141" rx="10" ry="9"/>
+  </g>
+
+  <!-- Right side trees -->
+  <g fill="#060e06">
+    <rect x="345" y="50"  width="55"  height="190"/>
+    <rect x="312" y="90"  width="38"  height="150"/>
+    <rect x="286" y="115" width="26"  height="125"/>
+    <rect x="265" y="133" width="18"  height="107"/>
+    <rect x="250" y="145" width="12"  height="95"/>
+    <rect x="240" y="152" width="8"   height="88"/>
+    <rect x="233" y="156" width="6"   height="84"/>
+  </g>
+  <!-- Canopies right -->
+  <g fill="#091409">
+    <ellipse cx="372" cy="28"  rx="65" ry="58"/>
+    <ellipse cx="331" cy="68"  rx="50" ry="46"/>
+    <ellipse cx="305" cy="95"  rx="36" ry="32"/>
+    <ellipse cx="288" cy="115" rx="25" ry="22"/>
+    <ellipse cx="276" cy="130" rx="16" ry="14"/>
+    <ellipse cx="268" cy="141" rx="10" ry="9"/>
+  </g>
+
+  <!-- Ley lines pulsing along the path -->
+  <g stroke="#40c060" fill="none" opacity="0.7">
+    <path d="M200,240 Q198,210 200,155" stroke-width="1.5"/>
+    <path d="M200,240 Q192,210 186,155" stroke-width="0.8" opacity="0.5"/>
+    <path d="M200,240 Q208,210 214,155" stroke-width="0.8" opacity="0.5"/>
+  </g>
+  <!-- Ley nodes — glowing points along path -->
+  <g fill="#40c060">
+    <circle cx="200" cy="240" r="3" opacity="0.3"/>
+    <circle cx="199" cy="215" r="2.5" opacity="0.5"/>
+    <circle cx="199" cy="190" r="2" opacity="0.6"/>
+    <circle cx="200" cy="170" r="2" opacity="0.7"/>
+    <circle cx="200" cy="158" r="3" opacity="0.9"/>
+  </g>
+
+  <!-- Opening beyond trees — bright horizon glow -->
+  <radialGradient id="horizon-glow" cx="50%" cy="65%" r="15%">
+    <stop offset="0%" stop-color="#60e080" stop-opacity="0.6"/>
+    <stop offset="100%" stop-color="#0a0a0a" stop-opacity="0"/>
+  </radialGradient>
+  <rect x="170" y="120" width="60" height="60" fill="url(#horizon-glow)"/>
+
+  <!-- Stars visible through the opening -->
+  <g fill="#ffffff" opacity="0.4">
+    <circle cx="195" cy="135" r="0.8"/>
+    <circle cx="205" cy="128" r="0.6"/>
+    <circle cx="200" cy="140" r="0.5"/>
+  </g>
+
+  <!-- Roots on path edges -->
+  <g stroke="#102010" stroke-width="1.5" fill="none" opacity="0.6">
+    <path d="M0,220 Q50,210 90,218 Q120,225 150,215"/>
+    <path d="M250,215 Q280,222 320,212 Q360,203 400,215"/>
+  </g>
+
+  <!-- Label -->
+  <text x="200" y="228" font-family="monospace" font-size="9" fill="#2a6030" text-anchor="middle" letter-spacing="3">THE ROAD AHEAD</text>
+</svg>

--- a/web/src/components/CutsceneScreen.tsx
+++ b/web/src/components/CutsceneScreen.tsx
@@ -44,6 +44,9 @@ export function CutsceneScreen({ panels, onDone }: Props) {
     <div className="cutscene-screen" onClick={advance}>
       <div className={`cutscene-content${visible ? ' cutscene-content--visible' : ''}`}>
         <div className="cutscene-act-label">// {panel.title}</div>
+        {panel.image && (
+          <img src={panel.image} alt="" className="cutscene-image" />
+        )}
         <div className="cutscene-body">
           {paragraphs.map((p, i) => (
             <p key={i} className="cutscene-paragraph">{p}</p>

--- a/web/src/data/acts/act1.json
+++ b/web/src/data/acts/act1.json
@@ -42,32 +42,39 @@
   "intro": [
     {
       "title": "THE FRACTURE",
+      "image": "cutscenes/act1-intro-1.svg",
       "text": "Three years ago, the Grand Dominion shattered.\n\nNot in war. Not gradually. In a single catastrophic instant — a magical detonation the scholars call the Fracture Event. The realm split into isolated shards, each one sealed behind walls of warped space and collapsed ley lines.\n\nNobody knows who caused it. Nobody knows how to undo it."
     },
     {
       "title": "THE WANDERER",
+      "image": "cutscenes/act1-intro-2.svg",
       "text": "You are Jarv. Former tactician of the Dominion's western campaigns. Now, technically, unemployed.\n\nThe army you served no longer exists. The city you lived in is cut off behind a shard wall. The people you knew are either dead, stranded, or figuring out their own problems.\n\nYou have a deck of cards, a vague sense of mission, and the navigational instincts of someone who has been lost before and considers it acceptable."
     },
     {
       "title": "THE VERDANT SHARD",
+      "image": "cutscenes/act1-intro-3.svg",
       "text": "Your compass points to the nearest reachable shard — a dense, ancient forest realm that has grown wild and hostile since the Fracture closed its borders.\n\nThe shard's guardian, a being called the Thornlord, has sealed its internal pathways. Local traders say he was old before the Dominion was founded.\n\nLocal traders also say he hasn't spoken to anyone in forty years. You're choosing to interpret that as optimistically as possible."
     },
     {
       "title": "YOUR MISSION",
+      "image": "cutscenes/act1-intro-4.svg",
       "text": "Break through the shard. Reach the Thornlord. Defeat him. Earn passage.\n\nTake whatever cards and crystals you can carry out the other side — your collection grows with every run, your mastery deepens, and somewhere in the Fractured Core the answer to all of this is waiting.\n\nProbably."
     }
   ],
   "outro": [
     {
       "title": "THE THORNLORD FALLS",
+      "image": "cutscenes/act1-outro-1.svg",
       "text": "The ancient guardian crumples. Roots unravel. Bark splits along fracture lines older than the Dominion.\n\nFor a moment the whole forest holds its breath — then it exhales. The sealed pathways glow faintly and open like doors that have been waiting for exactly this."
     },
     {
       "title": "WHAT HE WAS",
+      "image": "cutscenes/act1-outro-2.svg",
       "text": "The Thornlord was not evil. He was old, and afraid, and doing what guardians do when the world stops making sense.\n\nYou take the Bark Shield he leaves behind. Not as a trophy. As a reminder that some things only break because nothing else would hold."
     },
     {
       "title": "THE ROAD AHEAD",
+      "image": "cutscenes/act1-outro-3.svg",
       "text": "One shard cleared. The ley lines pulse — faint, but connected.\n\nYour deck returns to its bones. Your collection carries forward. Somewhere beyond the Verdant Shard, the Iron Citadel waits — and whoever controls it will not be glad to see you.\n\nGood."
     }
   ],

--- a/web/src/game/questline.ts
+++ b/web/src/game/questline.ts
@@ -232,6 +232,7 @@ export function generateMerchantCards(): string[] {
 export interface CutscenePanel {
   title: string
   text: string
+  image?: string  // path relative to /public, e.g. "cutscenes/act1-intro-1.svg"
 }
 
 // ─── Intro rule system ────────────────────────────────────

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -5242,6 +5242,15 @@ body {
   margin-bottom: 28px;
 }
 
+.cutscene-image {
+  width: 100%;
+  aspect-ratio: 5 / 3;
+  object-fit: cover;
+  border: 1px solid #1a1a1a;
+  margin-bottom: 24px;
+  display: block;
+}
+
 .cutscene-body {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary

Closes #816 (Act 1 portion — one act at a time as specified).

- **Mechanism:** Add optional `image?` field to `CutscenePanel` interface; `CutsceneScreen.tsx` renders a full-width image above the text body when `panel.image` is present. Panels without images continue to render text-only (no regressions).
- **CSS:** New `.cutscene-image` class — full-width, 5:3 aspect ratio, dark border, fits the retro terminal aesthetic.
- **Act 1 graphics:** 7 SVG panels (4 intro + 3 outro) placed in `web/public/cutscenes/`. Each committed separately per sprite workflow.
- **act1.json:** `image` paths wired into every intro and outro panel.

### SVG panels created
| File | Panel |
|---|---|
| `act1-intro-1.svg` | THE FRACTURE — realm shattering with radiating cracks |
| `act1-intro-2.svg` | THE WANDERER — lone Jarv figure holding cards on a dark plain |
| `act1-intro-3.svg` | THE VERDANT SHARD — ancient forest with sealed gate and runes |
| `act1-intro-4.svg` | YOUR MISSION — forest path in perspective with compass |
| `act1-outro-1.svg` | THE THORNLORD FALLS — crumbling root figure, glowing pathways |
| `act1-outro-2.svg` | WHAT HE WAS — Bark Shield on fallen leaves |
| `act1-outro-3.svg` | THE ROAD AHEAD — open forest corridor with pulsing ley lines |

## Test plan

- [ ] Build passes: `cd web && npm run build`
- [ ] Play Act 1 intro — 4 panels each showing a graphic novel image above text
- [ ] Complete Act 1 and defeat the Thornlord — 3 outro panels with images
- [ ] Confirm panels from `introRules` (no `image` field) still render text-only without errors

https://claude.ai/code/session_018Fc28vkpbGujaearhCb92N

---
_Generated by [Claude Code](https://claude.ai/code/session_018Fc28vkpbGujaearhCb92N)_