### PR TITLE
fix(cutscene): images not showing on run 2+

### DIFF
--- a/web/src/components/CutsceneScreen.tsx
+++ b/web/src/components/CutsceneScreen.tsx
@@ -45,7 +45,7 @@ export function CutsceneScreen({ panels, onDone }: Props) {
       <div className={`cutscene-content${visible ? ' cutscene-content--visible' : ''}`}>
         <div className="cutscene-act-label">// {panel.title}</div>
         {panel.image && (
-          <img src={panel.image} alt="" className="cutscene-image" />
+          <img src={`${import.meta.env.BASE_URL}${panel.image}`} alt="" className="cutscene-image" />
         )}
         <div className="cutscene-body">
           {paragraphs.map((p, i) => (

--- a/web/src/game/questline.ts
+++ b/web/src/game/questline.ts
@@ -449,9 +449,10 @@ export function resolveActIntro(act: Act, n: number): CutscenePanel[] {
   if (n <= 1 || !act.introRules?.length) return act.intro ?? []
   const rule = act.introRules.find(r => matchesCondition(r.condition, n))
   if (!rule) return act.intro ?? []
-  return rule.panels.map(p => ({
+  return rule.panels.map((p, i) => ({
     title: resolvePlaceholders(p.title, n, act),
     text:  resolvePlaceholders(p.text,  n, act),
+    image: p.image ?? act.intro?.[i]?.image,
   }))
 }
 


### PR DESCRIPTION
## Problem

Two bugs meant cutscene images weren't visible:

1. **`resolveActIntro` stripped `image` on run 2+** — when `introRules` fire (any run ≥ 2), panels were mapped as `{ title, text }` only, discarding the `image` field. Fix: positional fallback to `act.intro[i].image` so images are inherited from the static intro at the same panel slot.

2. **Relative `src` path** — `src="cutscenes/act1-intro-1.svg"` is a relative URL that can resolve incorrectly depending on host path. Fix: prefix with `import.meta.env.BASE_URL` (which is `/` with current Vite config, giving a reliable absolute path).

## Changes

- `questline.ts`: `resolveActIntro` now includes `image: p.image ?? act.intro?.[i]?.image` when mapping rule panels
- `CutsceneScreen.tsx`: `src` uses `\`${import.meta.env.BASE_URL}${panel.image}\``

https://claude.ai/code/session_018Fc28vkpbGujaearhCb92N

---
_Generated by [Claude Code](https://claude.ai/code/session_018Fc28vkpbGujaearhCb92N)_