### PR TITLE
feat(cutscene): add Act 1 & Act 2 graphic novel cutscene images

### DIFF
--- a/web/public/cutscenes/act2-intro-1.svg
+++ b/web/public/cutscenes/act2-intro-1.svg
@@ -1,0 +1,125 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#08090c"/>
+
+  <!-- Dark sky gradient -->
+  <linearGradient id="sky2" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#0d1220" stop-opacity="1"/>
+    <stop offset="100%" stop-color="#1a1e2a" stop-opacity="1"/>
+  </linearGradient>
+  <rect width="400" height="180" fill="url(#sky2)"/>
+
+  <!-- Ground / rubble base -->
+  <rect x="0" y="185" width="400" height="55" fill="#0a0b0e"/>
+  <line x1="0" y1="185" x2="400" y2="185" stroke="#151820" stroke-width="1"/>
+
+  <!-- Distant canyon walls — left -->
+  <polygon points="0,185 0,90 60,100 80,120 70,185" fill="#0f1118"/>
+  <!-- Distant canyon walls — right -->
+  <polygon points="400,185 400,80 340,95 320,125 330,185" fill="#0f1118"/>
+
+  <!-- Main citadel wall — centre mass -->
+  <rect x="100" y="60" width="200" height="125" fill="#141720" stroke="#252a38" stroke-width="1.5"/>
+
+  <!-- Wall texture — horizontal courses -->
+  <g stroke="#1c2030" stroke-width="0.8" opacity="0.6">
+    <line x1="100" y1="85"  x2="300" y2="85"/>
+    <line x1="100" y1="110" x2="300" y2="110"/>
+    <line x1="100" y1="135" x2="300" y2="135"/>
+    <line x1="100" y1="160" x2="300" y2="160"/>
+  </g>
+  <!-- Vertical joints staggered -->
+  <g stroke="#1c2030" stroke-width="0.6" opacity="0.5">
+    <line x1="140" y1="60"  x2="140" y2="85"/>
+    <line x1="180" y1="60"  x2="180" y2="85"/>
+    <line x1="220" y1="60"  x2="220" y2="85"/>
+    <line x1="260" y1="60"  x2="260" y2="85"/>
+    <line x1="120" y1="85"  x2="120" y2="110"/>
+    <line x1="160" y1="85"  x2="160" y2="110"/>
+    <line x1="200" y1="85"  x2="200" y2="110"/>
+    <line x1="240" y1="85"  x2="240" y2="110"/>
+    <line x1="280" y1="85"  x2="280" y2="110"/>
+    <line x1="140" y1="110" x2="140" y2="135"/>
+    <line x1="180" y1="110" x2="180" y2="135"/>
+    <line x1="220" y1="110" x2="220" y2="135"/>
+    <line x1="260" y1="110" x2="260" y2="135"/>
+  </g>
+
+  <!-- Battlements (merlons) across the top -->
+  <g fill="#1a1e2d" stroke="#252a38" stroke-width="1">
+    <rect x="100" y="42" width="18" height="20"/>
+    <rect x="124" y="42" width="18" height="20"/>
+    <rect x="148" y="42" width="18" height="20"/>
+    <rect x="172" y="42" width="18" height="20"/>
+    <rect x="196" y="42" width="18" height="20"/>
+    <rect x="220" y="42" width="18" height="20"/>
+    <rect x="244" y="42" width="18" height="20"/>
+    <rect x="268" y="42" width="18" height="20"/>
+  </g>
+
+  <!-- Left flanking tower -->
+  <rect x="78" y="75" width="30" height="110" fill="#161a26" stroke="#252a38" stroke-width="1"/>
+  <g fill="#1c2030" stroke="#252a38" stroke-width="0.8">
+    <rect x="78" y="60" width="10" height="16"/>
+    <rect x="90" y="60" width="10" height="16"/>
+    <rect x="100" y="60" width="9"  height="16"/>
+  </g>
+
+  <!-- Right flanking tower -->
+  <rect x="292" y="75" width="30" height="110" fill="#161a26" stroke="#252a38" stroke-width="1"/>
+  <g fill="#1c2030" stroke="#252a38" stroke-width="0.8">
+    <rect x="292" y="60" width="10" height="16"/>
+    <rect x="304" y="60" width="10" height="16"/>
+    <rect x="316" y="60" width="6"  height="16"/>
+  </g>
+
+  <!-- Gate — sealed, iron-banded -->
+  <rect x="168" y="140" width="64" height="45" fill="#0c0e14" stroke="#303548" stroke-width="2"/>
+  <!-- Gate planks -->
+  <g stroke="#181d28" stroke-width="3" fill="none">
+    <line x1="168" y1="155" x2="232" y2="155"/>
+    <line x1="168" y1="168" x2="232" y2="168"/>
+    <line x1="168" y1="181" x2="232" y2="181"/>
+  </g>
+  <!-- Iron banding on gate -->
+  <g stroke="#303548" stroke-width="4" opacity="0.7">
+    <line x1="168" y1="148" x2="232" y2="148"/>
+    <line x1="168" y1="162" x2="232" y2="162"/>
+    <line x1="168" y1="176" x2="232" y2="176"/>
+  </g>
+  <!-- Gate arch shadow -->
+  <ellipse cx="200" cy="140" rx="32" ry="6" fill="#0a0c10" opacity="0.8"/>
+
+  <!-- Warlord banner atop centre -->
+  <line x1="197" y1="10" x2="197" y2="44" stroke="#303548" stroke-width="2"/>
+  <polygon points="197,10 230,20 197,30" fill="#1e2438" stroke="#303548" stroke-width="1"/>
+  <!-- Iron cross on banner -->
+  <g stroke="#404860" stroke-width="1.5">
+    <line x1="206" y1="18" x2="206" y2="28"/>
+    <line x1="201" y1="23" x2="212" y2="23"/>
+  </g>
+
+  <!-- Distant torches on battlements — tiny warm glows -->
+  <circle cx="118" cy="59" r="2.5" fill="#c07020" opacity="0.7"/>
+  <circle cx="156" cy="59" r="2"   fill="#c07020" opacity="0.6"/>
+  <circle cx="244" cy="59" r="2"   fill="#c07020" opacity="0.6"/>
+  <circle cx="280" cy="59" r="2.5" fill="#c07020" opacity="0.7"/>
+
+  <!-- Arrow slit windows — dim glow -->
+  <g fill="#c07020" opacity="0.3">
+    <rect x="126" y="100" width="4" height="10" rx="2"/>
+    <rect x="150" y="100" width="4" height="10" rx="2"/>
+    <rect x="246" y="100" width="4" height="10" rx="2"/>
+    <rect x="270" y="100" width="4" height="10" rx="2"/>
+  </g>
+
+  <!-- Rubble at base -->
+  <g fill="#0f1118" stroke="#151820" stroke-width="0.5" opacity="0.8">
+    <polygon points="85,185  95,175  110,185"/>
+    <polygon points="290,185 302,172 315,185"/>
+    <polygon points="145,185 155,180 165,185"/>
+    <polygon points="235,185 248,178 260,185"/>
+  </g>
+
+  <!-- Label -->
+  <text x="200" y="230" font-family="monospace" font-size="9" fill="#303548" text-anchor="middle" letter-spacing="3">THE IRON CITADEL</text>
+</svg>

--- a/web/public/cutscenes/act2-intro-2.svg
+++ b/web/public/cutscenes/act2-intro-2.svg
@@ -1,0 +1,107 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#08090c"/>
+
+  <!-- Dark overcast sky -->
+  <linearGradient id="sky-wand" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#0c1018"/>
+    <stop offset="100%" stop-color="#181c28"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#sky-wand)"/>
+
+  <!-- Distant citadel silhouette on horizon -->
+  <g fill="#0f1220" opacity="0.9">
+    <!-- Wall mass -->
+    <rect x="220" y="110" width="180" height="90"/>
+    <!-- Battlements -->
+    <rect x="220" y="100" width="12" height="12"/>
+    <rect x="236" y="100" width="12" height="12"/>
+    <rect x="252" y="100" width="12" height="12"/>
+    <rect x="268" y="100" width="12" height="12"/>
+    <rect x="284" y="100" width="12" height="12"/>
+    <rect x="300" y="100" width="12" height="12"/>
+    <rect x="316" y="100" width="12" height="12"/>
+    <rect x="332" y="100" width="12" height="12"/>
+    <rect x="348" y="100" width="12" height="12"/>
+    <rect x="364" y="100" width="12" height="12"/>
+    <rect x="380" y="100" width="20" height="12"/>
+    <!-- Left tower -->
+    <rect x="206" y="90"  width="22" height="110"/>
+    <!-- Tower merlons -->
+    <rect x="206" y="80" width="8" height="12"/>
+    <rect x="218" y="80" width="8" height="12"/>
+  </g>
+
+  <!-- Dim torch glow from distant citadel -->
+  <radialGradient id="citadel-glow" cx="75%" cy="52%" r="20%">
+    <stop offset="0%" stop-color="#c06818" stop-opacity="0.15"/>
+    <stop offset="100%" stop-color="#c06818" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#citadel-glow)"/>
+
+  <!-- Rocky road / broken ground -->
+  <rect x="0" y="200" width="400" height="40" fill="#0a0b0e"/>
+  <rect x="0" y="185" width="400" height="16" fill="#0d0f14"/>
+  <!-- Path line -->
+  <path d="M0,195 Q100,190 200,193 Q300,196 400,192" stroke="#151820" stroke-width="2" fill="none"/>
+
+  <!-- Canyon walls flanking the road -->
+  <polygon points="0,240 0,130 70,150 60,185 50,240" fill="#0b0d12"/>
+  <polygon points="0,240 0,160 50,170 45,200 30,240" fill="#0d1018"/>
+
+  <!-- Wanderer figure — Jarv — mid-left, walking right toward citadel -->
+  <!-- Shadow on ground -->
+  <ellipse cx="140" cy="198" rx="18" ry="5" fill="#060709" opacity="0.8"/>
+
+  <!-- Cloak / body -->
+  <polygon points="128,180 152,180 156,200 124,200" fill="#1a1c28" stroke="#252838" stroke-width="1"/>
+  <!-- Hood -->
+  <ellipse cx="140" cy="175" rx="10" ry="8" fill="#161820" stroke="#222432" stroke-width="1"/>
+  <!-- Face shadow under hood -->
+  <ellipse cx="141" cy="178" rx="6" ry="4" fill="#0e1018"/>
+
+  <!-- Arm outstretched toward citadel — holding card -->
+  <line x1="152" y1="183" x2="167" y2="176" stroke="#1a1c28" stroke-width="3" stroke-linecap="round"/>
+  <!-- Card in hand (small rectangle) -->
+  <rect x="164" y="171" width="10" height="14" rx="1" fill="#1e2438" stroke="#404860" stroke-width="1"/>
+  <!-- Card glow hint -->
+  <rect x="165" y="172" width="8" height="12" rx="1" fill="#303860" opacity="0.4"/>
+
+  <!-- Other arm — at side -->
+  <line x1="128" y1="183" x2="118" y2="192" stroke="#1a1c28" stroke-width="3" stroke-linecap="round"/>
+
+  <!-- Legs -->
+  <line x1="136" y1="200" x2="132" y2="215" stroke="#151720" stroke-width="3" stroke-linecap="round"/>
+  <line x1="144" y1="200" x2="148" y2="214" stroke="#151720" stroke-width="3" stroke-linecap="round"/>
+
+  <!-- Boot detail -->
+  <ellipse cx="131" cy="215" rx="5" ry="3" fill="#111318"/>
+  <ellipse cx="149" cy="214" rx="5" ry="3" fill="#111318"/>
+
+  <!-- Footprints in dust behind wanderer -->
+  <g fill="#101218" opacity="0.5">
+    <ellipse cx="110" cy="197" rx="4" ry="2" transform="rotate(-10,110,197)"/>
+    <ellipse cx="98"  cy="198" rx="4" ry="2" transform="rotate(8,98,198)"/>
+    <ellipse cx="84"  cy="197" rx="4" ry="2" transform="rotate(-10,84,197)"/>
+  </g>
+
+  <!-- Dust motes in foreground -->
+  <g fill="#1a1e2a" opacity="0.4">
+    <circle cx="65"  cy="190" r="2"/>
+    <circle cx="55"  cy="196" r="1.5"/>
+    <circle cx="170" cy="205" r="1.5"/>
+    <circle cx="185" cy="200" r="1"/>
+  </g>
+
+  <!-- Stars / debris in sky -->
+  <g fill="#252a38" opacity="0.3">
+    <circle cx="40"  cy="30"  r="1"/>
+    <circle cx="90"  cy="20"  r="0.8"/>
+    <circle cx="150" cy="40"  r="1"/>
+    <circle cx="110" cy="55"  r="0.8"/>
+    <circle cx="30"  cy="65"  r="1"/>
+    <circle cx="180" cy="25"  r="0.8"/>
+  </g>
+
+  <!-- Label -->
+  <text x="200" y="230" font-family="monospace" font-size="9" fill="#303548" text-anchor="middle" letter-spacing="3">THE WANDERER</text>
+</svg>

--- a/web/public/cutscenes/act2-intro-3.svg
+++ b/web/public/cutscenes/act2-intro-3.svg
@@ -1,0 +1,148 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#08090c"/>
+
+  <!-- Canyon atmosphere — hazy sky -->
+  <linearGradient id="canyon-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#0c1018"/>
+    <stop offset="70%" stop-color="#141820"/>
+    <stop offset="100%" stop-color="#1a1c22"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#canyon-sky)"/>
+
+  <!-- Canyon floor — deep dark chasm -->
+  <rect x="80" y="148" width="240" height="92" fill="#050608"/>
+  <!-- Canyon floor glow — sickly pale -->
+  <radialGradient id="chasm-glow" cx="50%" cy="90%" r="40%">
+    <stop offset="0%" stop-color="#202840" stop-opacity="0.4"/>
+    <stop offset="100%" stop-color="#202840" stop-opacity="0"/>
+  </radialGradient>
+  <rect x="80" y="148" width="240" height="92" fill="url(#chasm-glow)"/>
+
+  <!-- Left canyon wall -->
+  <polygon points="0,240 0,60 80,80 80,240" fill="#0d1018"/>
+  <polygon points="0,240 0,100 60,115 60,240" fill="#0b0d12"/>
+
+  <!-- Right canyon wall -->
+  <polygon points="400,240 400,55 320,75 320,240" fill="#0d1018"/>
+  <polygon points="400,240 400,95 340,110 340,240" fill="#0b0d12"/>
+
+  <!-- Canyon wall texture lines -->
+  <g stroke="#111420" stroke-width="0.5" opacity="0.5">
+    <line x1="15" y1="100" x2="70" y2="110"/>
+    <line x1="10" y1="130" x2="65" y2="140"/>
+    <line x1="20" y1="160" x2="68" y2="165"/>
+    <line x1="330" y1="100" x2="390" y2="90"/>
+    <line x1="335" y1="130" x2="395" y2="120"/>
+    <line x1="332" y1="160" x2="392" y2="152"/>
+  </g>
+
+  <!-- Garrison point A — left wall ledge -->
+  <rect x="5" y="105" width="68" height="40" fill="#131620" stroke="#1e2230" stroke-width="1"/>
+  <!-- Battlements A -->
+  <g fill="#1a1e2c" stroke="#1e2230" stroke-width="0.8">
+    <rect x="5"  y="96" width="10" height="11"/>
+    <rect x="18" y="96" width="10" height="11"/>
+    <rect x="31" y="96" width="10" height="11"/>
+    <rect x="44" y="96" width="10" height="11"/>
+    <rect x="57" y="96" width="10" height="11"/>
+  </g>
+  <!-- Torch A -->
+  <circle cx="36" cy="102" r="2" fill="#b06010" opacity="0.7"/>
+
+  <!-- Garrison point B — right wall ledge -->
+  <rect x="327" y="100" width="68" height="40" fill="#131620" stroke="#1e2230" stroke-width="1"/>
+  <!-- Battlements B -->
+  <g fill="#1a1e2c" stroke="#1e2230" stroke-width="0.8">
+    <rect x="327" y="91" width="10" height="11"/>
+    <rect x="340" y="91" width="10" height="11"/>
+    <rect x="353" y="91" width="10" height="11"/>
+    <rect x="366" y="91" width="10" height="11"/>
+    <rect x="379" y="91" width="16" height="11"/>
+  </g>
+  <!-- Torch B -->
+  <circle cx="360" cy="97" r="2" fill="#b06010" opacity="0.7"/>
+
+  <!-- Garrison point C — hanging chain bridge platform centre-left -->
+  <rect x="100" y="130" width="60" height="30" fill="#131620" stroke="#1e2230" stroke-width="1"/>
+  <g fill="#1a1e2c" stroke="#1e2230" stroke-width="0.8">
+    <rect x="100" y="121" width="9"  height="11"/>
+    <rect x="112" y="121" width="9"  height="11"/>
+    <rect x="124" y="121" width="9"  height="11"/>
+    <rect x="136" y="121" width="9"  height="11"/>
+    <rect x="148" y="121" width="12" height="11"/>
+  </g>
+  <!-- Chain to left wall -->
+  <path d="M73,120 Q87,128 100,130" stroke="#252a38" stroke-width="1.5" fill="none" stroke-dasharray="4,3"/>
+  <!-- Chain to right (toward D) -->
+  <path d="M160,140 Q195,145 240,140" stroke="#252a38" stroke-width="1.5" fill="none" stroke-dasharray="4,3"/>
+
+  <!-- Garrison point D — centre-right platform -->
+  <rect x="240" y="128" width="60" height="32" fill="#131620" stroke="#1e2230" stroke-width="1"/>
+  <g fill="#1a1e2c" stroke="#1e2230" stroke-width="0.8">
+    <rect x="240" y="119" width="9"  height="11"/>
+    <rect x="252" y="119" width="9"  height="11"/>
+    <rect x="264" y="119" width="9"  height="11"/>
+    <rect x="276" y="119" width="9"  height="11"/>
+    <rect x="288" y="119" width="12" height="11"/>
+  </g>
+  <!-- Chain to right wall -->
+  <path d="M300,138 Q311,132 327,125" stroke="#252a38" stroke-width="1.5" fill="none" stroke-dasharray="4,3"/>
+
+  <!-- Chains dropping into chasm -->
+  <g stroke="#252a38" stroke-width="1" fill="none" opacity="0.4" stroke-dasharray="3,4">
+    <line x1="115" y1="160" x2="110" y2="200"/>
+    <line x1="145" y1="160" x2="148" y2="200"/>
+    <line x1="255" y1="160" x2="252" y2="200"/>
+    <line x1="285" y1="160" x2="288" y2="200"/>
+  </g>
+
+  <!-- INNER WALL — Kragg's sanctum — back of canyon, elevated -->
+  <rect x="130" y="45" width="140" height="75" fill="#161924" stroke="#2a3040" stroke-width="2"/>
+  <!-- Inner wall stone courses -->
+  <g stroke="#1e2230" stroke-width="0.8" opacity="0.5">
+    <line x1="130" y1="65"  x2="270" y2="65"/>
+    <line x1="130" y1="85"  x2="270" y2="85"/>
+    <line x1="130" y1="105" x2="270" y2="105"/>
+  </g>
+  <!-- Inner wall battlements -->
+  <g fill="#1e2232" stroke="#2a3040" stroke-width="1">
+    <rect x="130" y="33" width="14" height="14"/>
+    <rect x="148" y="33" width="14" height="14"/>
+    <rect x="166" y="33" width="14" height="14"/>
+    <rect x="184" y="33" width="14" height="14"/>
+    <rect x="202" y="33" width="14" height="14"/>
+    <rect x="220" y="33" width="14" height="14"/>
+    <rect x="238" y="33" width="14" height="14"/>
+    <rect x="256" y="33" width="14" height="14"/>
+  </g>
+  <!-- Kragg's banner flying above inner wall -->
+  <line x1="197" y1="5"  x2="197" y2="34" stroke="#2a3040" stroke-width="2"/>
+  <polygon points="197,6 236,14 197,24" fill="#1e2438" stroke="#3a4060" stroke-width="1"/>
+  <g stroke="#4a5880" stroke-width="1.5">
+    <line x1="208" y1="12" x2="208" y2="20"/>
+    <line x1="202" y1="16" x2="215" y2="16"/>
+  </g>
+  <!-- Inner wall torches — slightly warmer than outer -->
+  <circle cx="148" cy="40" r="2.5" fill="#c07020" opacity="0.8"/>
+  <circle cx="200" cy="40" r="2.5" fill="#c07020" opacity="0.8"/>
+  <circle cx="252" cy="40" r="2.5" fill="#c07020" opacity="0.8"/>
+
+  <!-- Inner wall gate — sealed -->
+  <rect x="178" y="90" width="44" height="30" fill="#0c0e14" stroke="#2a3040" stroke-width="1.5"/>
+  <g stroke="#1e2438" stroke-width="2">
+    <line x1="178" y1="100" x2="222" y2="100"/>
+    <line x1="178" y1="108" x2="222" y2="108"/>
+    <line x1="178" y1="116" x2="222" y2="116"/>
+  </g>
+  <g stroke="#2a3040" stroke-width="3" opacity="0.6">
+    <line x1="178" y1="95"  x2="222" y2="95"/>
+    <line x1="178" y1="105" x2="222" y2="105"/>
+    <line x1="178" y1="115" x2="222" y2="115"/>
+  </g>
+
+  <!-- Bridge from platform C up to inner wall -->
+  <path d="M130,145 Q145,115 155,120" stroke="#1e2230" stroke-width="2" fill="none"/>
+
+  <!-- Label -->
+  <text x="200" y="232" font-family="monospace" font-size="9" fill="#2a3040" text-anchor="middle" letter-spacing="3">THE GARRISON NETWORK</text>
+</svg>

--- a/web/public/cutscenes/act2-intro-4.svg
+++ b/web/public/cutscenes/act2-intro-4.svg
@@ -1,0 +1,115 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#08090c"/>
+
+  <!-- Dark background -->
+  <radialGradient id="mission-glow" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#1a1e30" stop-opacity="0.6"/>
+    <stop offset="100%" stop-color="#08090c" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#mission-glow)"/>
+
+  <!-- Tactical map grid lines — faint -->
+  <g stroke="#141820" stroke-width="0.5" opacity="0.6">
+    <line x1="0"   y1="40"  x2="400" y2="40"/>
+    <line x1="0"   y1="80"  x2="400" y2="80"/>
+    <line x1="0"   y1="120" x2="400" y2="120"/>
+    <line x1="0"   y1="160" x2="400" y2="160"/>
+    <line x1="0"   y1="200" x2="400" y2="200"/>
+    <line x1="50"  y1="0"   x2="50"  y2="240"/>
+    <line x1="100" y1="0"   x2="100" y2="240"/>
+    <line x1="150" y1="0"   x2="150" y2="240"/>
+    <line x1="200" y1="0"   x2="200" y2="240"/>
+    <line x1="250" y1="0"   x2="250" y2="240"/>
+    <line x1="300" y1="0"   x2="300" y2="240"/>
+    <line x1="350" y1="0"   x2="350" y2="240"/>
+  </g>
+
+  <!-- Left side: player position marker -->
+  <!-- Small shield / base icon at left -->
+  <polygon points="30,120 48,110 66,120 66,140 48,150 30,140" fill="#0f1820" stroke="#204060" stroke-width="1.5"/>
+  <!-- Player star -->
+  <polygon points="48,118 51,126 59,126 53,131 55,139 48,134 41,139 43,131 37,126 45,126" fill="#204060" opacity="0.8"/>
+
+  <!-- Garrison points along the path — enemy positions (left to right) -->
+  <!-- Garrison 1 -->
+  <rect x="108" y="104" width="24" height="32" fill="#141820" stroke="#2a3040" stroke-width="1.5"/>
+  <g fill="#2a3040">
+    <rect x="108" y="97" width="7" height="9"/>
+    <rect x="118" y="97" width="7" height="9"/>
+    <rect x="128" y="97" width="4" height="9"/>
+  </g>
+  <!-- Garrison 1 torch -->
+  <circle cx="120" cy="103" r="2" fill="#b05820" opacity="0.6"/>
+
+  <!-- Garrison 2 -->
+  <rect x="188" y="96" width="24" height="34" fill="#141820" stroke="#2a3040" stroke-width="1.5"/>
+  <g fill="#2a3040">
+    <rect x="188" y="88" width="7" height="10"/>
+    <rect x="198" y="88" width="7" height="10"/>
+    <rect x="208" y="88" width="4" height="10"/>
+  </g>
+  <circle cx="200" cy="95" r="2" fill="#b05820" opacity="0.6"/>
+
+  <!-- Garrison 3 — final before boss -->
+  <rect x="268" y="100" width="24" height="30" fill="#141820" stroke="#2a3040" stroke-width="1.5"/>
+  <g fill="#2a3040">
+    <rect x="268" y="92" width="7" height="10"/>
+    <rect x="278" y="92" width="7" height="10"/>
+    <rect x="288" y="92" width="4" height="10"/>
+  </g>
+  <circle cx="280" cy="98" r="2" fill="#b05820" opacity="0.6"/>
+
+  <!-- BOSS marker — Warlord Kragg — far right, fortress icon -->
+  <rect x="342" y="80" width="48" height="60" fill="#161c28" stroke="#3a4060" stroke-width="2"/>
+  <g fill="#202838" stroke="#3a4060" stroke-width="1">
+    <rect x="342" y="70" width="13" height="12"/>
+    <rect x="358" y="70" width="13" height="12"/>
+    <rect x="374" y="70" width="16" height="12"/>
+  </g>
+  <!-- Boss skull icon -->
+  <circle cx="366" cy="104" r="10" fill="#0e1220" stroke="#3a4060" stroke-width="1"/>
+  <circle cx="362" cy="101" r="2.5" fill="#3a4060"/>
+  <circle cx="370" cy="101" r="2.5" fill="#3a4060"/>
+  <path d="M360,108 Q366,112 372,108" stroke="#3a4060" stroke-width="1" fill="none"/>
+  <line x1="362" y1="110" x2="362" y2="113" stroke="#3a4060" stroke-width="1"/>
+  <line x1="366" y1="111" x2="366" y2="113" stroke="#3a4060" stroke-width="1"/>
+  <line x1="370" y1="110" x2="370" y2="113" stroke="#3a4060" stroke-width="1"/>
+  <!-- Boss name text -->
+  <text x="366" y="130" font-family="monospace" font-size="7" fill="#3a4060" text-anchor="middle">KRAGG</text>
+
+  <!-- Path / route arrows from player to garrison 1 -->
+  <path d="M66,120 Q87,120 108,120" stroke="#204060" stroke-width="1.5" fill="none" stroke-dasharray="5,3" marker-end="url(#arr)"/>
+  <!-- Path from garrison 1 to 2 -->
+  <path d="M132,120 Q160,112 188,113" stroke="#204060" stroke-width="1.5" fill="none" stroke-dasharray="5,3"/>
+  <!-- Arrow head manually -->
+  <polygon points="185,110 192,113 185,116" fill="#204060"/>
+  <!-- Path from garrison 2 to 3 -->
+  <path d="M212,113 Q240,106 268,110" stroke="#204060" stroke-width="1.5" fill="none" stroke-dasharray="5,3"/>
+  <polygon points="265,107 272,110 265,113" fill="#204060"/>
+  <!-- Path from garrison 3 to boss -->
+  <path d="M292,115 Q317,110 342,110" stroke="#3a4060" stroke-width="2" fill="none" stroke-dasharray="5,3"/>
+  <polygon points="339,107 346,110 339,113" fill="#3a4060"/>
+
+  <!-- X markers on garrison positions — "must clear" -->
+  <g stroke="#3a4060" stroke-width="1.5" opacity="0.6">
+    <line x1="112" y1="115" x2="128" y2="130"/>
+    <line x1="128" y1="115" x2="112" y2="130"/>
+    <line x1="192" y1="107" x2="208" y2="122"/>
+    <line x1="208" y1="107" x2="192" y2="122"/>
+    <line x1="272" y1="111" x2="288" y2="124"/>
+    <line x1="288" y1="111" x2="272" y2="124"/>
+  </g>
+
+  <!-- Canyon border lines on map -->
+  <path d="M80,60 Q90,100 80,150" stroke="#1a1e2a" stroke-width="3" fill="none"/>
+  <path d="M80,150 Q90,180 85,220" stroke="#1a1e2a" stroke-width="3" fill="none"/>
+  <path d="M330,55 Q320,95 330,145" stroke="#1a1e2a" stroke-width="3" fill="none"/>
+  <path d="M330,145 Q320,175 325,218" stroke="#1a1e2a" stroke-width="3" fill="none"/>
+
+  <!-- Objective text at top -->
+  <text x="200" y="22" font-family="monospace" font-size="8" fill="#204060" text-anchor="middle" letter-spacing="2">OBJECTIVE: BREACH THE INNER WALL</text>
+  <line x1="60" y1="27" x2="340" y2="27" stroke="#1a2030" stroke-width="0.8"/>
+
+  <!-- Label -->
+  <text x="200" y="232" font-family="monospace" font-size="9" fill="#2a3040" text-anchor="middle" letter-spacing="3">YOUR MISSION</text>
+</svg>

--- a/web/public/cutscenes/act2-outro-1.svg
+++ b/web/public/cutscenes/act2-outro-1.svg
@@ -1,0 +1,129 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#08090c"/>
+
+  <!-- Light flooding through the open gate — the key element -->
+  <radialGradient id="gate-light" cx="50%" cy="65%" r="45%">
+    <stop offset="0%" stop-color="#d09040" stop-opacity="0.9"/>
+    <stop offset="30%" stop-color="#a06820" stop-opacity="0.5"/>
+    <stop offset="100%" stop-color="#08090c" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#gate-light)"/>
+
+  <!-- Ground -->
+  <rect x="0" y="200" width="400" height="40" fill="#0a0c10"/>
+  <line x1="0" y1="200" x2="400" y2="200" stroke="#141820" stroke-width="1"/>
+
+  <!-- Main wall — cracked, damaged -->
+  <rect x="80" y="50" width="240" height="150" fill="#141720" stroke="#1e2230" stroke-width="1.5"/>
+
+  <!-- Wall cracks from the battle -->
+  <g stroke="#252a38" stroke-width="1" fill="none" opacity="0.7">
+    <path d="M140,80 Q148,95 143,115 Q138,130 145,150"/>
+    <path d="M260,85 Q253,102 258,120 Q263,135 257,155"/>
+    <path d="M180,50 Q185,68 182,85"/>
+    <path d="M230,50 Q226,70 229,88"/>
+  </g>
+  <!-- Heavier cracks near gate -->
+  <g stroke="#303548" stroke-width="1.5" fill="none" opacity="0.5">
+    <path d="M165,150 Q172,165 168,180"/>
+    <path d="M235,150 Q228,168 232,182"/>
+    <path d="M155,130 Q148,140 140,148"/>
+    <path d="M245,128 Q252,138 260,148"/>
+  </g>
+
+  <!-- Wall texture -->
+  <g stroke="#1a1e2c" stroke-width="0.7" opacity="0.4">
+    <line x1="80"  y1="80"  x2="320" y2="80"/>
+    <line x1="80"  y1="110" x2="320" y2="110"/>
+    <line x1="80"  y1="140" x2="320" y2="140"/>
+    <line x1="80"  y1="170" x2="320" y2="170"/>
+  </g>
+
+  <!-- Battlements — some knocked off -->
+  <g fill="#1a1e2c" stroke="#252a38" stroke-width="0.8">
+    <rect x="80"  y="35" width="14" height="17"/>
+    <rect x="98"  y="35" width="14" height="17"/>
+    <rect x="116" y="35" width="14" height="17"/>
+    <!-- gap: 134 — merlon knocked off -->
+    <rect x="152" y="35" width="14" height="17"/>
+    <rect x="170" y="35" width="14" height="17"/>
+    <!-- gap: 188 -->
+    <rect x="206" y="35" width="14" height="17"/>
+    <!-- gap: 224 -->
+    <rect x="242" y="35" width="14" height="17"/>
+    <rect x="260" y="35" width="14" height="17"/>
+    <rect x="278" y="35" width="14" height="17"/>
+    <rect x="296" y="35" width="24" height="17"/>
+  </g>
+
+  <!-- Fallen merlon chunks on ground -->
+  <g fill="#141720" stroke="#1e2230" stroke-width="0.5">
+    <rect x="125" y="196" width="12" height="7" transform="rotate(-15,131,200)"/>
+    <rect x="185" y="198" width="10" height="6" transform="rotate(10,190,201)"/>
+    <rect x="228" y="195" width="13" height="8" transform="rotate(-8,234,199)"/>
+  </g>
+
+  <!-- THE GATE — open, blazing with light from beyond -->
+  <!-- Gate frame -->
+  <rect x="162" y="130" width="76" height="70" fill="#0c0e14" stroke="#303548" stroke-width="2"/>
+  <!-- Inner light from open gate -->
+  <rect x="164" y="132" width="72" height="68" fill="#d09040" opacity="0.85"/>
+  <!-- Light rays emanating from gate -->
+  <g stroke="#e0a848" stroke-width="1" fill="none" opacity="0.5">
+    <line x1="200" y1="165" x2="90"  y2="80"/>
+    <line x1="200" y1="165" x2="310" y2="80"/>
+    <line x1="200" y1="165" x2="60"  y2="165"/>
+    <line x1="200" y1="165" x2="340" y2="165"/>
+    <line x1="200" y1="165" x2="120" y2="240"/>
+    <line x1="200" y1="165" x2="280" y2="240"/>
+    <line x1="200" y1="165" x2="200" y2="240"/>
+  </g>
+  <!-- Gate interior glow — silhouette of open space beyond -->
+  <radialGradient id="gate-interior" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#f0c060" stop-opacity="1"/>
+    <stop offset="60%" stop-color="#d09040" stop-opacity="0.8"/>
+    <stop offset="100%" stop-color="#a06830" stop-opacity="0.6"/>
+  </radialGradient>
+  <rect x="164" y="132" width="72" height="68" fill="url(#gate-interior)"/>
+
+  <!-- Silhouette of figure stepping through the gate (soldier moving toward freedom) -->
+  <g fill="#0c0e14" opacity="0.6">
+    <!-- Body -->
+    <rect x="193" y="155" width="14" height="24"/>
+    <!-- Head -->
+    <circle cx="200" cy="151" r="7"/>
+    <!-- Arm outstretched -->
+    <line x1="207" y1="162" x2="218" y2="168" stroke="#0c0e14" stroke-width="4" stroke-linecap="round"/>
+  </g>
+
+  <!-- Kragg's banner — falling, torn -->
+  <line x1="197" y1="10" x2="197" y2="37" stroke="#303548" stroke-width="2"/>
+  <!-- Banner torn, hanging sideways -->
+  <polygon points="197,10 232,18 230,30 200,25" fill="#1e2438" stroke="#3a4060" stroke-width="1" transform="rotate(20,197,18)"/>
+  <!-- Iron cross — now broken / crossed out -->
+  <g stroke="#404860" stroke-width="1.2" opacity="0.5" transform="rotate(20,197,18)">
+    <line x1="208" y1="14" x2="208" y2="24"/>
+    <line x1="202" y1="19" x2="215" y2="19"/>
+  </g>
+  <!-- Falling banner pieces -->
+  <g fill="#1e2438" opacity="0.4">
+    <polygon points="155,25 165,20 162,32" transform="rotate(-30,160,26)"/>
+    <polygon points="240,30 250,22 248,35" transform="rotate(15,245,29)"/>
+  </g>
+
+  <!-- Soldiers moving toward gate — tiny silhouettes at ground level -->
+  <g fill="#0c0e14" opacity="0.7">
+    <!-- Figure 1 -->
+    <circle cx="112" cy="196" r="4"/>
+    <rect x="109" y="200" width="6" height="8"/>
+    <!-- Figure 2 -->
+    <circle cx="130" cy="197" r="3.5"/>
+    <rect x="127" y="201" width="6" height="7"/>
+    <!-- Figure 3 on the other side -->
+    <circle cx="272" cy="197" r="4"/>
+    <rect x="269" y="201" width="6" height="8"/>
+  </g>
+
+  <!-- Label -->
+  <text x="200" y="232" font-family="monospace" font-size="9" fill="#604020" text-anchor="middle" letter-spacing="3">THE WALL FALLS</text>
+</svg>

--- a/web/public/cutscenes/act2-outro-2.svg
+++ b/web/public/cutscenes/act2-outro-2.svg
@@ -1,0 +1,144 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#08090c"/>
+
+  <!-- Armoury interior — dark stone walls -->
+  <linearGradient id="armory-wall" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#0d1018"/>
+    <stop offset="100%" stop-color="#0a0c12"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#armory-wall)"/>
+
+  <!-- Stone floor -->
+  <rect x="0" y="185" width="400" height="55" fill="#0a0b10"/>
+  <!-- Floor flagstones -->
+  <g stroke="#111420" stroke-width="0.8" opacity="0.5">
+    <line x1="0"   y1="200" x2="400" y2="200"/>
+    <line x1="0"   y1="215" x2="400" y2="215"/>
+    <line x1="50"  y1="185" x2="50"  y2="240"/>
+    <line x1="130" y1="185" x2="130" y2="240"/>
+    <line x1="200" y1="185" x2="200" y2="240"/>
+    <line x1="270" y1="185" x2="270" y2="240"/>
+    <line x1="350" y1="185" x2="350" y2="240"/>
+  </g>
+
+  <!-- Left wall weapon racks -->
+  <rect x="10" y="50" width="8" height="135" fill="#0f1218" stroke="#1a1e28" stroke-width="0.8"/>
+  <!-- Weapons hanging on rack -->
+  <g stroke="#252a38" stroke-width="2" fill="none">
+    <line x1="14" y1="60"  x2="14" y2="130"/>
+    <line x1="14" y1="65"  x2="30" y2="65"/>
+    <line x1="14" y1="90"  x2="32" y2="90"/>
+    <line x1="14" y1="115" x2="28" y2="115"/>
+  </g>
+  <!-- Sword shapes -->
+  <g fill="#1e2438" stroke="#303548" stroke-width="0.5">
+    <polygon points="30,58 34,62 30,130 26,62"/><!-- sword 1 -->
+    <polygon points="32,83 36,87 32,155 28,87"/><!-- sword 2 -->
+    <polygon points="28,108 32,112 28,170 24,112"/><!-- sword 3 -->
+  </g>
+
+  <!-- Right wall weapon racks -->
+  <rect x="382" y="50" width="8" height="135" fill="#0f1218" stroke="#1a1e28" stroke-width="0.8"/>
+  <g stroke="#252a38" stroke-width="2" fill="none">
+    <line x1="386" y1="60"  x2="386" y2="130"/>
+    <line x1="386" y1="65"  x2="370" y2="65"/>
+    <line x1="386" y1="90"  x2="368" y2="90"/>
+    <line x1="386" y1="115" x2="372" y2="115"/>
+  </g>
+  <g fill="#1e2438" stroke="#303548" stroke-width="0.5">
+    <polygon points="370,58 374,62 370,130 366,62"/>
+    <polygon points="368,83 372,87 368,155 364,87"/>
+    <polygon points="372,108 376,112 372,170 368,112"/>
+  </g>
+
+  <!-- Armoury torch sconces on side walls -->
+  <g>
+    <!-- Left torch -->
+    <rect x="55" y="80" width="6" height="14" fill="#1e2030" stroke="#303040" stroke-width="0.5"/>
+    <polygon points="52,80 64,80 60,70 56,70" fill="#1e2030" stroke="#303040" stroke-width="0.5"/>
+    <radialGradient id="torch-l" cx="50%" cy="0%" r="80%">
+      <stop offset="0%" stop-color="#c07020" stop-opacity="0.9"/>
+      <stop offset="100%" stop-color="#c07020" stop-opacity="0"/>
+    </radialGradient>
+    <ellipse cx="58" cy="72" rx="16" ry="12" fill="url(#torch-l)" opacity="0.7"/>
+    <!-- Right torch -->
+    <rect x="339" y="80" width="6" height="14" fill="#1e2030" stroke="#303040" stroke-width="0.5"/>
+    <polygon points="336,80 348,80 344,70 340,70" fill="#1e2030" stroke="#303040" stroke-width="0.5"/>
+    <radialGradient id="torch-r" cx="50%" cy="0%" r="80%">
+      <stop offset="0%" stop-color="#c07020" stop-opacity="0.9"/>
+      <stop offset="100%" stop-color="#c07020" stop-opacity="0"/>
+    </radialGradient>
+    <ellipse cx="342" cy="72" rx="16" ry="12" fill="url(#torch-r)" opacity="0.7"/>
+  </g>
+
+  <!-- THE IRON STANDARD — centrepiece -->
+  <!-- Stone pedestal / plinth -->
+  <rect x="170" y="160" width="60" height="25" fill="#111520" stroke="#1e2438" stroke-width="1.5"/>
+  <rect x="163" y="178" width="74" height="10" fill="#141820" stroke="#1e2438" stroke-width="1"/>
+  <!-- Inscription on plinth -->
+  <text x="200" y="173" font-family="monospace" font-size="5" fill="#252a38" text-anchor="middle" letter-spacing="1">IRON STANDARD</text>
+
+  <!-- Standard pole -->
+  <rect x="198" y="30" width="4" height="130" fill="#2a3040" stroke="#3a4060" stroke-width="0.8"/>
+  <!-- Pole finial — iron spike -->
+  <polygon points="197,30 203,30 200,20" fill="#404860" stroke="#505878" stroke-width="0.5"/>
+
+  <!-- The banner itself — weathered Dominion banner -->
+  <!-- Main banner cloth -->
+  <polygon points="202,32 268,40 264,90 202,85" fill="#1e2438" stroke="#3a4060" stroke-width="1.5"/>
+  <!-- Banner field — iron grey -->
+  <rect x="204" y="34" width="62" height="49" fill="#202840"/>
+
+  <!-- Iron cross motif on banner — the Dominion symbol -->
+  <g stroke="#505878" stroke-width="3" fill="none">
+    <line x1="235" y1="38" x2="235" y2="79"/>
+    <line x1="214" y1="58" x2="256" y2="58"/>
+  </g>
+  <!-- Cross embellishments -->
+  <g fill="#606888">
+    <rect x="230" y="36" width="10" height="4"/>
+    <rect x="230" y="77" width="10" height="4"/>
+    <rect x="212" y="54" width="4" height="8"/>
+    <rect x="254" y="54" width="4" height="8"/>
+  </g>
+
+  <!-- Worn / battle-damage on banner -->
+  <g stroke="#161c28" stroke-width="1" fill="none" opacity="0.5">
+    <path d="M246,38 Q250,50 248,60"/>
+    <path d="M258,55 Q262,65 260,75"/>
+  </g>
+  <!-- Fringe at bottom of banner -->
+  <g stroke="#303548" stroke-width="1">
+    <line x1="204" y1="83" x2="202" y2="91"/>
+    <line x1="210" y1="84" x2="208" y2="92"/>
+    <line x1="216" y1="84" x2="214" y2="93"/>
+    <line x1="222" y1="84" x2="220" y2="92"/>
+    <line x1="228" y1="84" x2="226" y2="92"/>
+    <line x1="234" y1="84" x2="232" y2="93"/>
+    <line x1="240" y1="84" x2="238" y2="92"/>
+    <line x1="246" y1="84" x2="244" y2="92"/>
+    <line x1="252" y1="84" x2="250" y2="93"/>
+    <line x1="258" y1="84" x2="256" y2="92"/>
+    <line x1="264" y1="84" x2="262" y2="92"/>
+  </g>
+
+  <!-- Atmospheric glow around the standard — iron remembers -->
+  <radialGradient id="standard-glow" cx="56%" cy="45%" r="30%">
+    <stop offset="0%" stop-color="#404860" stop-opacity="0.4"/>
+    <stop offset="100%" stop-color="#404860" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#standard-glow)"/>
+
+  <!-- Dust motes in armoury air -->
+  <g fill="#303548" opacity="0.3">
+    <circle cx="90"  cy="100" r="1"/>
+    <circle cx="310" cy="90"  r="1"/>
+    <circle cx="155" cy="140" r="0.8"/>
+    <circle cx="250" cy="130" r="0.8"/>
+    <circle cx="170" cy="60"  r="1"/>
+    <circle cx="280" cy="70"  r="0.8"/>
+  </g>
+
+  <!-- Label -->
+  <text x="200" y="232" font-family="monospace" font-size="9" fill="#303548" text-anchor="middle" letter-spacing="3">THE IRON STANDARD</text>
+</svg>

--- a/web/src/data/acts/act2.json
+++ b/web/src/data/acts/act2.json
@@ -44,29 +44,35 @@
   "intro": [
     {
       "title": "THE IRON CITADEL",
-      "text": "The Fracture spared the Iron Citadel its chaos — or so the stories go. In truth, the Citadel's warlords sealed the shard themselves, the moment they realised sealing it kept everyone else out.\n\nFor three years they have ruled the rubble with a disciplined fist. Trade routes closed. Refugees turned back at the walls. The shard hoards its iron and feeds on order."
+      "text": "The Fracture spared the Iron Citadel its chaos — or so the stories go. In truth, the Citadel's warlords sealed the shard themselves, the moment they realised sealing it kept everyone else out.\n\nFor three years they have ruled the rubble with a disciplined fist. Trade routes closed. Refugees turned back at the walls. The shard hoards its iron and feeds on order.",
+      "image": "cutscenes/act2-intro-1.svg"
     },
     {
       "title": "THE WANDERER",
-      "text": "You are Jarv. Former tactician of the western campaigns, now nominally a free agent.\n\nYou have a deck of cards, a route through the Citadel's outer defences, and the stubborn conviction that warlords who fortify themselves this thoroughly are usually hiding something embarrassing."
+      "text": "You are Jarv. Former tactician of the western campaigns, now nominally a free agent.\n\nYou have a deck of cards, a route through the Citadel's outer defences, and the stubborn conviction that warlords who fortify themselves this thoroughly are usually hiding something embarrassing.",
+      "image": "cutscenes/act2-intro-2.svg"
     },
     {
       "title": "THE IRON CITADEL",
-      "text": "The Citadel is a network of fortified garrison points strung across a shattered canyon. Its defenders are disciplined, well-armed, and have had three years to practice waiting.\n\nAt the top, behind the inner wall, is Warlord Kragg. He was a general before the Fracture. He is considerably less reasonable now."
+      "text": "The Citadel is a network of fortified garrison points strung across a shattered canyon. Its defenders are disciplined, well-armed, and have had three years to practice waiting.\n\nAt the top, behind the inner wall, is Warlord Kragg. He was a general before the Fracture. He is considerably less reasonable now.",
+      "image": "cutscenes/act2-intro-3.svg"
     },
     {
       "title": "YOUR MISSION",
-      "text": "Fight through the garrison line. Reach Warlord Kragg.\n\nBreak the siege. Open the Citadel."
+      "text": "Fight through the garrison line. Reach Warlord Kragg.\n\nBreak the siege. Open the Citadel.",
+      "image": "cutscenes/act2-intro-4.svg"
     }
   ],
   "outro": [
     {
       "title": "THE WALL FALLS",
-      "text": "Kragg's banner comes down.\n\nFor a long moment, nothing happens. Then, from somewhere in the rubble, a single soldier begins to move — not toward you, but toward the sealed gate. Others follow.\n\nThe gate opens for the first time in three years. You watch from the rampart as light floods into the canyon."
+      "text": "Kragg's banner comes down.\n\nFor a long moment, nothing happens. Then, from somewhere in the rubble, a single soldier begins to move — not toward you, but toward the sealed gate. Others follow.\n\nThe gate opens for the first time in three years. You watch from the rampart as light floods into the canyon.",
+      "image": "cutscenes/act2-outro-1.svg"
     },
     {
       "title": "IRON STANDARD",
-      "text": "Among the Citadel's armoury, you find it — the Iron Standard. The banner carried at the front of every Dominion march before the Fracture.\n\nIt no longer represents anything. But the iron in it remembers.\n\nYou take it with you."
+      "text": "Among the Citadel's armoury, you find it — the Iron Standard. The banner carried at the front of every Dominion march before the Fracture.\n\nIt no longer represents anything. But the iron in it remembers.\n\nYou take it with you.",
+      "image": "cutscenes/act2-outro-2.svg"
     }
   ],
   "variantPools": {


### PR DESCRIPTION
Closes #816 (partial — Act 1 & Act 2 complete; Acts 3–13 + Finale to follow)

## Summary

- Adds the cutscene image display mechanism (image field on panels, graphic novel rendering)
- Creates 7 SVG cutscene panels for Act 1 (4 intro + 3 outro)
- Creates 6 SVG cutscene panels for Act 2 (4 intro + 2 outro)
- Wires `image` paths into `act1.json` and `act2.json` intro/outro panels
- Fixes cutscene images showing only on first run

## Act 1 panels (The Verdant Shard)
- `act1-intro-1.svg` — The Fracture Event (shards radiating purple cracks)
- `act1-intro-2.svg` — The Wanderer (Jarv approaching the forest)
- `act1-intro-3.svg` — The Verdant Shard (dense canopy, ancient trees)
- `act1-intro-4.svg` — Your Mission (tactical map)
- `act1-outro-1.svg` — The Thornlord Falls (crumbling root figure)
- `act1-outro-2.svg` — What He Was / Bark Shield (forest memory)
- `act1-outro-3.svg` — The Road Ahead

## Act 2 panels (The Iron Citadel)
- `act2-intro-1.svg` — The Iron Citadel (looming fortress wall with sealed gate)
- `act2-intro-2.svg` — The Wanderer (Jarv approaching with card in hand, citadel on horizon)
- `act2-intro-3.svg` — The Garrison Network (chain-bridge platforms across a shattered canyon)
- `act2-intro-4.svg` — Your Mission (tactical map with garrison waypoints and Kragg's inner wall)
- `act2-outro-1.svg` — The Wall Falls (gate blasted open, light flooding the canyon)
- `act2-outro-2.svg` — The Iron Standard (the relic banner on a stone pedestal in the armoury)

## Art style
All panels: 400×240 SVG, dark `#0a0a0a` background, geometric shapes, monospace label at bottom — consistent graphic novel aesthetic across both acts.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GXML372usPatkqhfiuvdWX)_