### PR TITLE
fix(pwa): make SW update check more reliable

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -295,6 +295,9 @@ export default function App() {
         setInterval(() => r.update().catch(() => {}), 60 * 60 * 1000)
       }
     },
+    onNeedRefresh() {
+      updateServiceWorker(true)
+    },
   })
   useEffect(() => {
     if (needRefresh) updateServiceWorker(true)

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
   plugins: [react(), VitePWA({
     registerType: 'autoUpdate',
     workbox: {
+      skipWaiting: true,
       clientsClaim: true,
       // Cache all static assets with cache-first strategy
       globPatterns: ['**/*.{js,css,html,ico,png,svg,woff,woff2}'],


### PR DESCRIPTION
## Summary

- **`vite.config.ts`**: Add explicit `skipWaiting: true` to the workbox block. `registerType: 'autoUpdate'` injects this implicitly, but being explicit makes it consistent with the existing explicit `clientsClaim: true` and ensures the new SW activates immediately rather than waiting for all clients to close.
- **`App.tsx`**: Add `onNeedRefresh` callback to `useRegisterSW` so that if a waiting SW is detected the update is applied and the page reloads immediately via `updateServiceWorker(true)`, rather than relying solely on the `useEffect` path which fires one render later.

## Test plan

- [ ] Deploy a new build and verify the page reloads to pick up the new SW in a normal browser tab
- [ ] Install the app to the home screen (standalone mode) and verify a new deploy is picked up on next launch
- [ ] Verify no infinite reload loop on first install

https://claude.ai/code/session_01EZXeEbXWQj3i48at4GK3M9

---
_Generated by [Claude Code](https://claude.ai/code/session_01EZXeEbXWQj3i48at4GK3M9)_