### PR TITLE
feat(cutscene): add Act 4 graphic novel cutscene images

### DIFF
--- a/web/public/cutscenes/act4-intro-1.svg
+++ b/web/public/cutscenes/act4-intro-1.svg
@@ -1,0 +1,127 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#06040e"/>
+
+  <!-- Deep arcane sky -->
+  <linearGradient id="arcane-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#08061a"/>
+    <stop offset="60%" stop-color="#100c28"/>
+    <stop offset="100%" stop-color="#180f30"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#arcane-sky)"/>
+
+  <!-- Ground / base platform -->
+  <rect x="0" y="195" width="400" height="45" fill="#080614"/>
+  <rect x="0" y="193" width="400" height="4" fill="#12103a"/>
+
+  <!-- Crystal ground surface — faint refraction -->
+  <g stroke="#1e1860" stroke-width="0.6" opacity="0.5">
+    <line x1="0"   y1="205" x2="400" y2="205"/>
+    <line x1="0"   y1="218" x2="400" y2="218"/>
+    <line x1="60"  y1="195" x2="60"  y2="240"/>
+    <line x1="140" y1="195" x2="140" y2="240"/>
+    <line x1="200" y1="195" x2="200" y2="240"/>
+    <line x1="260" y1="195" x2="260" y2="240"/>
+    <line x1="340" y1="195" x2="340" y2="240"/>
+  </g>
+
+  <!-- Distant crystal formations — flanking -->
+  <!-- Left cluster -->
+  <g fill="#0e0c28" stroke="#1e1860" stroke-width="0.8">
+    <polygon points="20,195 30,140 40,195"/>
+    <polygon points="35,195 48,120 60,195"/>
+    <polygon points="52,195 62,155 72,195"/>
+  </g>
+  <!-- Left crystal faces (lighter) -->
+  <g fill="#14104a" opacity="0.6">
+    <polygon points="30,140 37,155 40,195 35,195 20,195 28,170"/>
+    <polygon points="48,120 56,140 60,195 52,195 35,195 44,145"/>
+  </g>
+
+  <!-- Right cluster -->
+  <g fill="#0e0c28" stroke="#1e1860" stroke-width="0.8">
+    <polygon points="328,195 340,155 352,195"/>
+    <polygon points="340,195 352,120 365,195"/>
+    <polygon points="358,195 370,145 382,195"/>
+  </g>
+  <g fill="#14104a" opacity="0.6">
+    <polygon points="340,155 348,172 352,195 340,195"/>
+    <polygon points="352,120 360,145 365,195 352,195 340,195 347,135"/>
+  </g>
+
+  <!-- MAIN SPIRE — centre, soaring upward -->
+  <!-- Base plinth -->
+  <rect x="165" y="180" width="70" height="15" fill="#12103a" stroke="#2a2870" stroke-width="1"/>
+  <rect x="155" y="185" width="90" height="10" fill="#0e0c2e" stroke="#1e1860" stroke-width="1"/>
+
+  <!-- Spire body — four-sided crystal tower -->
+  <!-- Front face (lightest) -->
+  <polygon points="200,10 240,180 160,180" fill="#14105a"/>
+  <!-- Left face (mid) -->
+  <polygon points="200,10 160,180 148,160 188,15" fill="#0e0c40"/>
+  <!-- Right face (mid-light) -->
+  <polygon points="200,10 240,180 252,160 212,15" fill="#181460"/>
+  <!-- Highlight strip down the centre front -->
+  <polygon points="200,10 206,30 203,180 197,180 194,30" fill="#2a2488" opacity="0.6"/>
+
+  <!-- Facet lines on spire face -->
+  <g stroke="#2a2480" stroke-width="0.8" opacity="0.5">
+    <line x1="200" y1="10"  x2="178" y2="100"/>
+    <line x1="200" y1="10"  x2="222" y2="100"/>
+    <line x1="178" y1="100" x2="222" y2="100"/>
+    <line x1="200" y1="10"  x2="170" y2="145"/>
+    <line x1="200" y1="10"  x2="230" y2="145"/>
+    <line x1="170" y1="145" x2="230" y2="145"/>
+  </g>
+
+  <!-- Spire apex glow -->
+  <radialGradient id="apex-glow" cx="50%" cy="4%" r="15%">
+    <stop offset="0%" stop-color="#80c0ff" stop-opacity="0.9"/>
+    <stop offset="100%" stop-color="#80c0ff" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#apex-glow)"/>
+  <circle cx="200" cy="12" r="4" fill="#a0d0ff" opacity="0.9"/>
+  <circle cx="200" cy="12" r="2" fill="#ffffff" opacity="0.95"/>
+
+  <!-- Sub-spires — left and right of main -->
+  <!-- Left sub-spire -->
+  <polygon points="158,25 178,175 138,175" fill="#12104a" stroke="#1e1860" stroke-width="0.8"/>
+  <polygon points="158,25 166,60 162,175 155,175 148,150 152,30" fill="#0e0c38" opacity="0.7"/>
+  <circle cx="158" cy="26" r="2.5" fill="#6090e0" opacity="0.7"/>
+
+  <!-- Right sub-spire -->
+  <polygon points="242,30 262,175 222,175" fill="#12104a" stroke="#1e1860" stroke-width="0.8"/>
+  <polygon points="242,30 250,65 247,175 240,175 233,160 238,35" fill="#181460" opacity="0.7"/>
+  <circle cx="242" cy="31" r="2.5" fill="#6090e0" opacity="0.7"/>
+
+  <!-- Arcane energy bands around spire — horizontal rings -->
+  <g stroke="#4060c0" stroke-width="1" fill="none" opacity="0.4">
+    <ellipse cx="200" cy="80"  rx="22" ry="5"/>
+    <ellipse cx="200" cy="120" rx="32" ry="6"/>
+    <ellipse cx="200" cy="155" rx="40" ry="7"/>
+  </g>
+
+  <!-- Floating crystal shards orbiting the spire -->
+  <g fill="#2a2480" stroke="#4060b0" stroke-width="0.5" opacity="0.7">
+    <polygon points="120,90  126,82  130,94  124,100"/>
+    <polygon points="280,85  287,78  290,91  283,96"/>
+    <polygon points="105,130 111,122 115,134 108,140"/>
+    <polygon points="294,125 300,117 304,130 297,135"/>
+    <polygon points="135,165 140,158 144,168 138,173"/>
+    <polygon points="265,160 271,153 275,164 268,170"/>
+  </g>
+
+  <!-- Stars / magical particles in sky -->
+  <g fill="#3050a0" opacity="0.5">
+    <circle cx="30"  cy="25"  r="1"/>
+    <circle cx="70"  cy="15"  r="1.5"/>
+    <circle cx="110" cy="40"  r="1"/>
+    <circle cx="300" cy="20"  r="1"/>
+    <circle cx="340" cy="40"  r="1.5"/>
+    <circle cx="380" cy="15"  r="1"/>
+    <circle cx="50"  cy="65"  r="1"/>
+    <circle cx="350" cy="70"  r="1"/>
+  </g>
+
+  <!-- Label -->
+  <text x="200" y="228" font-family="monospace" font-size="9" fill="#2a2480" text-anchor="middle" letter-spacing="3">THE CRYSTAL SPIRE</text>
+</svg>

--- a/web/public/cutscenes/act4-intro-2.svg
+++ b/web/public/cutscenes/act4-intro-2.svg
@@ -1,0 +1,114 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#06040e"/>
+
+  <!-- Deep arcane sky -->
+  <linearGradient id="sky-wand4" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#08061a"/>
+    <stop offset="100%" stop-color="#140e30"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#sky-wand4)"/>
+
+  <!-- Distant Crystal Spire on horizon — rightward -->
+  <g opacity="0.7">
+    <polygon points="295,170 310,60  325,170" fill="#0e0c28" stroke="#1e1860" stroke-width="0.8"/>
+    <polygon points="310,60 317,90 314,170 308,170 304,130 308,65" fill="#141050" opacity="0.7"/>
+    <circle cx="310" cy="62" r="2" fill="#6090e0" opacity="0.8"/>
+    <polygon points="278,170 290,90  302,170" fill="#0c0a22" stroke="#181850" stroke-width="0.6"/>
+    <circle cx="290" cy="91" r="1.5" fill="#4070c0" opacity="0.6"/>
+    <polygon points="318,170 330,95  342,170" fill="#0c0a22" stroke="#181850" stroke-width="0.6"/>
+    <circle cx="330" cy="96" r="1.5" fill="#4070c0" opacity="0.6"/>
+  </g>
+
+  <!-- Arcane glow from the Spire ahead -->
+  <radialGradient id="spire-distant" cx="77%" cy="65%" r="28%">
+    <stop offset="0%" stop-color="#4060c0" stop-opacity="0.25"/>
+    <stop offset="100%" stop-color="#4060c0" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#spire-distant)"/>
+
+  <!-- Crystal ground — faint facets -->
+  <rect x="0" y="196" width="400" height="44" fill="#08060e"/>
+  <rect x="0" y="193" width="400" height="5" fill="#100c30"/>
+  <g stroke="#1e1850" stroke-width="0.5" opacity="0.4">
+    <path d="M0,205 Q80,200 160,205 Q240,210 320,204 Q370,200 400,206"/>
+    <path d="M0,218 Q60,214 130,219 Q200,224 280,218 Q350,214 400,220"/>
+  </g>
+
+  <!-- Small crystal formations on the ground path -->
+  <g fill="#0e0c28" stroke="#1e1860" stroke-width="0.5" opacity="0.7">
+    <polygon points="60,196  65,183  70,196"/>
+    <polygon points="73,196  80,178  87,196"/>
+    <polygon points="310,196 316,186 322,196"/>
+    <polygon points="325,196 332,180 339,196"/>
+  </g>
+
+  <!-- JARV — wanderer figure, left of centre, facing right -->
+  <ellipse cx="150" cy="205" rx="22" ry="6" fill="#050408" opacity="0.7"/>
+
+  <!-- Boots -->
+  <ellipse cx="140" cy="208" rx="6" ry="3" fill="#0a0818"/>
+  <ellipse cx="158" cy="207" rx="6" ry="3" fill="#0a0818"/>
+
+  <!-- Legs -->
+  <line x1="144" y1="196" x2="140" y2="208" stroke="#10081e" stroke-width="4" stroke-linecap="round"/>
+  <line x1="154" y1="196" x2="158" y2="207" stroke="#10081e" stroke-width="4" stroke-linecap="round"/>
+
+  <!-- Cloak -->
+  <polygon points="133,178 168,178 172,198 129,198" fill="#181430" stroke="#241e48" stroke-width="1"/>
+  <!-- Hood -->
+  <ellipse cx="150" cy="172" rx="11" ry="9" fill="#14102a" stroke="#201a40" stroke-width="1"/>
+  <ellipse cx="151" cy="175" rx="7"  ry="5" fill="#0c0818"/>
+
+  <!-- Left arm — holding Soulstone -->
+  <line x1="134" y1="183" x2="120" y2="190" stroke="#181430" stroke-width="3" stroke-linecap="round"/>
+  <!-- Soulstone in left hand — warm dark glow -->
+  <circle cx="117" cy="192" r="5" fill="#1e140c" stroke="#3a2010" stroke-width="1"/>
+  <radialGradient id="soul-wand" cx="40%" cy="40%" r="60%">
+    <stop offset="0%" stop-color="#8c3808" stop-opacity="0.6"/>
+    <stop offset="100%" stop-color="#8c3808" stop-opacity="0"/>
+  </radialGradient>
+  <circle cx="117" cy="192" r="5" fill="url(#soul-wand)"/>
+  <circle cx="115" cy="190" r="2" fill="#3a2018" opacity="0.6"/>
+
+  <!-- Right arm — holding Iron Standard upright -->
+  <line x1="166" y1="183" x2="185" y2="168" stroke="#181430" stroke-width="3" stroke-linecap="round"/>
+  <!-- Standard pole -->
+  <line x1="185" y1="135" x2="185" y2="210" stroke="#2a3040" stroke-width="2.5"/>
+  <polygon points="183,135 187,135 185,126" fill="#404860"/>
+  <!-- Banner — wind-blown right (Jarv moving right, wind from left) -->
+  <polygon points="185,138 185,155 218,150 220,136" fill="#1e2438" stroke="#303548" stroke-width="1"/>
+  <g stroke="#3a4060" stroke-width="1.2">
+    <line x1="200" y1="140" x2="200" y2="152"/>
+    <line x1="193" y1="146" x2="208" y2="146"/>
+  </g>
+
+  <!-- Footprints behind Jarv -->
+  <g fill="#0c0a1e" opacity="0.5">
+    <ellipse cx="124" cy="202" rx="4" ry="2" transform="rotate(-12,124,202)"/>
+    <ellipse cx="110" cy="203" rx="4" ry="2" transform="rotate(10,110,203)"/>
+    <ellipse cx="95"  cy="202" rx="3.5" ry="2" transform="rotate(-12,95,202)"/>
+  </g>
+
+  <!-- Floating crystal shards drifting in the air -->
+  <g fill="#1e1c50" stroke="#3040a0" stroke-width="0.5" opacity="0.6">
+    <polygon points="55,80  60,72  63,83  57,88"/>
+    <polygon points="220,55 225,47 228,58 222,63"/>
+    <polygon points="40,130 44,122 48,133 42,138"/>
+    <polygon points="245,95 250,87 254,98 248,103"/>
+    <polygon points="370,60 375,52 378,63 372,68"/>
+  </g>
+
+  <!-- Stars -->
+  <g fill="#3050a0" opacity="0.4">
+    <circle cx="30"  cy="20" r="1"/>
+    <circle cx="80"  cy="10" r="1.5"/>
+    <circle cx="175" cy="30" r="1"/>
+    <circle cx="270" cy="15" r="1.5"/>
+    <circle cx="380" cy="25" r="1"/>
+    <circle cx="25"  cy="60" r="1"/>
+    <circle cx="390" cy="55" r="1"/>
+  </g>
+
+  <!-- Label -->
+  <text x="200" y="228" font-family="monospace" font-size="9" fill="#2a2480" text-anchor="middle" letter-spacing="3">THE WANDERER</text>
+</svg>

--- a/web/public/cutscenes/act4-intro-3.svg
+++ b/web/public/cutscenes/act4-intro-3.svg
@@ -1,0 +1,155 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#06040e"/>
+
+  <!-- Interior — deep arcane chamber glow -->
+  <radialGradient id="chamber-glow" cx="50%" cy="45%" r="50%">
+    <stop offset="0%" stop-color="#2030a0" stop-opacity="0.4"/>
+    <stop offset="60%" stop-color="#101860" stop-opacity="0.2"/>
+    <stop offset="100%" stop-color="#06040e" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#chamber-glow)"/>
+
+  <!-- Floor — crystal flagstone pattern -->
+  <rect x="0" y="188" width="400" height="52" fill="#080618"/>
+  <!-- Floor crystal lines — perspective grid -->
+  <g stroke="#1a1860" stroke-width="0.8" opacity="0.6">
+    <!-- Horizontal -->
+    <line x1="0"   y1="200" x2="400" y2="200"/>
+    <line x1="0"   y1="215" x2="400" y2="215"/>
+    <line x1="0"   y1="230" x2="400" y2="230"/>
+    <!-- Perspective lines converging to vanishing point (200, 188) -->
+    <line x1="200" y1="188" x2="0"   y2="240"/>
+    <line x1="200" y1="188" x2="50"  y2="240"/>
+    <line x1="200" y1="188" x2="100" y2="240"/>
+    <line x1="200" y1="188" x2="150" y2="240"/>
+    <line x1="200" y1="188" x2="200" y2="240"/>
+    <line x1="200" y1="188" x2="250" y2="240"/>
+    <line x1="200" y1="188" x2="300" y2="240"/>
+    <line x1="200" y1="188" x2="350" y2="240"/>
+    <line x1="200" y1="188" x2="400" y2="240"/>
+  </g>
+  <!-- Floor glow pools from crystals above -->
+  <radialGradient id="floor-reflect" cx="50%" cy="100%" r="40%">
+    <stop offset="0%" stop-color="#2040a0" stop-opacity="0.25"/>
+    <stop offset="100%" stop-color="#2040a0" stop-opacity="0"/>
+  </radialGradient>
+  <rect x="0" y="188" width="400" height="52" fill="url(#floor-reflect)"/>
+
+  <!-- Walls — crystalline, angular -->
+  <!-- Left wall face -->
+  <polygon points="0,0 80,0 80,188 0,188" fill="#0a0820"/>
+  <!-- Left wall crystal vein lines -->
+  <g stroke="#1e2070" stroke-width="0.8" opacity="0.5">
+    <line x1="15"  y1="0"   x2="15"  y2="188"/>
+    <line x1="35"  y1="0"   x2="35"  y2="188"/>
+    <line x1="55"  y1="0"   x2="55"  y2="188"/>
+    <line x1="0"   y1="50"  x2="80"  y2="50"/>
+    <line x1="0"   y1="100" x2="80"  y2="100"/>
+    <line x1="0"   y1="150" x2="80"  y2="150"/>
+  </g>
+  <!-- Left wall crystal sconce -->
+  <polygon points="58,85 68,80 74,100 64,105" fill="#141260" stroke="#2a2a90" stroke-width="0.8"/>
+  <radialGradient id="sconce-l" cx="50%" cy="50%" r="60%">
+    <stop offset="0%" stop-color="#6080e0" stop-opacity="0.7"/>
+    <stop offset="100%" stop-color="#6080e0" stop-opacity="0"/>
+  </radialGradient>
+  <ellipse cx="66" cy="92" rx="20" ry="16" fill="url(#sconce-l)"/>
+
+  <!-- Right wall face -->
+  <polygon points="320,0 400,0 400,188 320,188" fill="#0a0820"/>
+  <g stroke="#1e2070" stroke-width="0.8" opacity="0.5">
+    <line x1="335" y1="0"   x2="335" y2="188"/>
+    <line x1="355" y1="0"   x2="355" y2="188"/>
+    <line x1="375" y1="0"   x2="375" y2="188"/>
+    <line x1="320" y1="50"  x2="400" y2="50"/>
+    <line x1="320" y1="100" x2="400" y2="100"/>
+    <line x1="320" y1="150" x2="400" y2="150"/>
+  </g>
+  <!-- Right wall crystal sconce -->
+  <polygon points="326,85 336,80 342,100 332,105" fill="#141260" stroke="#2a2a90" stroke-width="0.8"/>
+  <radialGradient id="sconce-r" cx="50%" cy="50%" r="60%">
+    <stop offset="0%" stop-color="#6080e0" stop-opacity="0.7"/>
+    <stop offset="100%" stop-color="#6080e0" stop-opacity="0"/>
+  </radialGradient>
+  <ellipse cx="334" cy="92" rx="20" ry="16" fill="url(#sconce-r)"/>
+
+  <!-- Ceiling — vaulted crystal lattice -->
+  <rect x="80" y="0" width="240" height="35" fill="#0c0a24"/>
+  <!-- Lattice pattern on ceiling -->
+  <g stroke="#2030a0" stroke-width="0.8" opacity="0.5">
+    <line x1="80"  y1="35" x2="200" y2="0"/>
+    <line x1="320" y1="35" x2="200" y2="0"/>
+    <line x1="140" y1="35" x2="200" y2="0"/>
+    <line x1="260" y1="35" x2="200" y2="0"/>
+    <line x1="80"  y1="0"  x2="80"  y2="35"/>
+    <line x1="320" y1="0"  x2="320" y2="35"/>
+    <!-- Horizontal beams -->
+    <line x1="80"  y1="10" x2="320" y2="10"/>
+    <line x1="80"  y1="22" x2="320" y2="22"/>
+  </g>
+  <!-- Central hanging crystal chandelier -->
+  <line x1="200" y1="0" x2="200" y2="40" stroke="#3040a0" stroke-width="1.5"/>
+  <polygon points="188,40 212,40 218,58 182,58" fill="#141260" stroke="#2a2a90" stroke-width="1"/>
+  <!-- Chandelier crystal drops -->
+  <g fill="#1e1c70" stroke="#3a3ab0" stroke-width="0.5">
+    <polygon points="188,58 192,66 186,66"/>
+    <polygon points="196,58 200,68 194,68"/>
+    <polygon points="204,58 208,68 202,68"/>
+    <polygon points="212,58 216,66 210,66"/>
+  </g>
+  <!-- Chandelier glow -->
+  <radialGradient id="chandelier-glow" cx="50%" cy="70%" r="50%">
+    <stop offset="0%" stop-color="#4060d0" stop-opacity="0.5"/>
+    <stop offset="100%" stop-color="#4060d0" stop-opacity="0"/>
+  </radialGradient>
+  <ellipse cx="200" cy="62" rx="40" ry="20" fill="url(#chandelier-glow)"/>
+
+  <!-- ARCANE CONSTRUCT — centre hallway, looming -->
+  <!-- Body — angular crystalline golem shape -->
+  <g fill="#141260" stroke="#2a2a80" stroke-width="1">
+    <!-- Torso -->
+    <polygon points="185,120 215,120 220,165 180,165"/>
+    <!-- Head — angular crystal -->
+    <polygon points="192,100 208,100 214,120 186,120"/>
+    <!-- Crystal crown/antenna on head -->
+    <polygon points="198,90 202,90 205,100 195,100"/>
+    <polygon points="196,82 200,76 204,82 202,90 198,90"/>
+  </g>
+  <!-- Construct eye glow -->
+  <circle cx="196" cy="110" r="3" fill="#4060d0" opacity="0.8"/>
+  <circle cx="204" cy="110" r="3" fill="#4060d0" opacity="0.8"/>
+  <circle cx="196" cy="110" r="1.5" fill="#80a0ff" opacity="0.9"/>
+  <circle cx="204" cy="110" r="1.5" fill="#80a0ff" opacity="0.9"/>
+  <!-- Construct arms -->
+  <line x1="180" y1="130" x2="160" y2="148" stroke="#1e1c60" stroke-width="5" stroke-linecap="round"/>
+  <line x1="220" y1="130" x2="240" y2="148" stroke="#1e1c60" stroke-width="5" stroke-linecap="round"/>
+  <!-- Arm crystal gauntlets -->
+  <polygon points="155,142 165,140 168,154 158,156" fill="#141260" stroke="#2a2a80" stroke-width="0.8"/>
+  <polygon points="235,142 245,140 248,154 238,156" fill="#141260" stroke="#2a2a80" stroke-width="0.8"/>
+  <!-- Construct legs -->
+  <line x1="190" y1="165" x2="185" y2="188" stroke="#141260" stroke-width="5" stroke-linecap="round"/>
+  <line x1="210" y1="165" x2="215" y2="188" stroke="#141260" stroke-width="5" stroke-linecap="round"/>
+  <!-- Leg crystal feet -->
+  <polygon points="180,184 192,182 192,192 178,192" fill="#141260" stroke="#2a2a80" stroke-width="0.5"/>
+  <polygon points="208,182 220,184 222,192 208,192" fill="#141260" stroke="#2a2a80" stroke-width="0.5"/>
+
+  <!-- Construct energy aura -->
+  <radialGradient id="construct-aura" cx="50%" cy="50%" r="40%">
+    <stop offset="0%" stop-color="#3050c0" stop-opacity="0.3"/>
+    <stop offset="100%" stop-color="#3050c0" stop-opacity="0"/>
+  </radialGradient>
+  <ellipse cx="200" cy="140" rx="50" ry="45" fill="url(#construct-aura)"/>
+
+  <!-- Floating arcane runes on walls -->
+  <g fill="#2a2890" opacity="0.5" font-family="monospace" font-size="12">
+    <text x="25"  y="70">◈</text>
+    <text x="25"  y="120">◇</text>
+    <text x="25"  y="170">◆</text>
+    <text x="355" y="70">◈</text>
+    <text x="355" y="120">◇</text>
+    <text x="355" y="170">◆</text>
+  </g>
+
+  <!-- Label -->
+  <text x="200" y="232" font-family="monospace" font-size="9" fill="#2a2480" text-anchor="middle" letter-spacing="3">THE ARCANE SANCTUM</text>
+</svg>

--- a/web/public/cutscenes/act4-intro-4.svg
+++ b/web/public/cutscenes/act4-intro-4.svg
@@ -1,0 +1,108 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#06040e"/>
+
+  <!-- Arcane background glow -->
+  <radialGradient id="mission4-bg" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#141060" stop-opacity="0.5"/>
+    <stop offset="100%" stop-color="#06040e" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#mission4-bg)"/>
+
+  <!-- Arcane map grid — hexagonal feel via diamond pattern -->
+  <g stroke="#120e40" stroke-width="0.5" opacity="0.6">
+    <line x1="0"   y1="40"  x2="400" y2="40"/>
+    <line x1="0"   y1="80"  x2="400" y2="80"/>
+    <line x1="0"   y1="120" x2="400" y2="120"/>
+    <line x1="0"   y1="160" x2="400" y2="160"/>
+    <line x1="0"   y1="200" x2="400" y2="200"/>
+    <line x1="50"  y1="0"   x2="50"  y2="240"/>
+    <line x1="100" y1="0"   x2="100" y2="240"/>
+    <line x1="150" y1="0"   x2="150" y2="240"/>
+    <line x1="200" y1="0"   x2="200" y2="240"/>
+    <line x1="250" y1="0"   x2="250" y2="240"/>
+    <line x1="300" y1="0"   x2="300" y2="240"/>
+    <line x1="350" y1="0"   x2="350" y2="240"/>
+  </g>
+
+  <!-- Player — left side -->
+  <polygon points="30,120 48,110 66,120 66,140 48,150 30,140" fill="#0c0a28" stroke="#203060" stroke-width="1.5"/>
+  <polygon points="48,118 51,126 59,126 53,131 55,139 48,134 41,139 43,131 37,126 45,126" fill="#203060" opacity="0.8"/>
+
+  <!-- OUTER LATTICE — crystal barrier zone -->
+  <ellipse cx="130" cy="120" rx="25" ry="20" fill="#0e0c30" stroke="#3040a0" stroke-width="1" stroke-dasharray="4,2"/>
+  <!-- Lattice crystal nodes -->
+  <g fill="#1e1c60" stroke="#3040a0" stroke-width="0.8">
+    <polygon points="118,108 124,102 130,108 124,114"/>
+    <polygon points="130,108 136,102 142,108 136,114"/>
+    <polygon points="124,114 130,108 136,114 130,120"/>
+    <polygon points="118,120 124,114 130,120 124,126"/>
+    <polygon points="130,120 136,114 142,120 136,126"/>
+    <polygon points="124,126 130,120 136,126 130,132"/>
+  </g>
+  <text x="130" y="145" font-family="monospace" font-size="6" fill="#3040a0" text-anchor="middle">LATTICE</text>
+
+  <!-- ARCANE SANCTUM — crystal maze -->
+  <ellipse cx="215" cy="112" rx="28" ry="22" fill="#0e0c30" stroke="#3040a0" stroke-width="1" stroke-dasharray="4,2"/>
+  <!-- Maze interior lines -->
+  <g stroke="#2030a0" stroke-width="1" opacity="0.6">
+    <line x1="200" y1="100" x2="200" y2="124"/>
+    <line x1="200" y1="100" x2="230" y2="100"/>
+    <line x1="230" y1="100" x2="230" y2="112"/>
+    <line x1="210" y1="112" x2="230" y2="112"/>
+    <line x1="210" y1="112" x2="210" y2="124"/>
+    <line x1="200" y1="124" x2="220" y2="124"/>
+  </g>
+  <!-- Construct icon in sanctum -->
+  <g fill="#1e1c60" opacity="0.8">
+    <rect x="215" y="103" width="6" height="8"/>
+    <polygon points="213,103 221,103 219,99 215,99"/>
+    <circle cx="217" cy="107" r="1.5" fill="#4060d0"/>
+    <circle cx="220" cy="107" r="1.5" fill="#4060d0"/>
+  </g>
+  <text x="215" y="148" font-family="monospace" font-size="6" fill="#3040a0" text-anchor="middle">SANCTUM</text>
+
+  <!-- THE ARCHIVIST boss marker -->
+  <rect x="338" y="72" width="52" height="68" fill="#0c0a26" stroke="#3a3aa0" stroke-width="2"/>
+  <!-- Archivist silhouette — robed figure with crystal staff -->
+  <g fill="#161460" opacity="0.9">
+    <circle cx="364" cy="86"  r="8"/>
+    <polygon points="355,94 373,94 376,128 352,128"/>
+    <!-- Hood / cowl -->
+    <polygon points="356,86 372,86 368,94 360,94"/>
+  </g>
+  <!-- Eye glow from Archivist -->
+  <circle cx="362" cy="85" r="2" fill="#6080e0" opacity="0.9"/>
+  <circle cx="367" cy="85" r="2" fill="#6080e0" opacity="0.9"/>
+  <!-- Staff -->
+  <line x1="376" y1="94" x2="390" y2="130" stroke="#2a2a80" stroke-width="2"/>
+  <polygon points="384,122 392,118 396,130 388,134" fill="#1e1c60" stroke="#3a3aa0" stroke-width="0.8"/>
+  <!-- Staff crystal -->
+  <circle cx="390" cy="120" r="4" fill="#4060d0" opacity="0.8"/>
+  <!-- Archivist name -->
+  <text x="364" y="148" font-family="monospace" font-size="6" fill="#3a3aa0" text-anchor="middle">ARCHIVIST</text>
+
+  <!-- Route arrows -->
+  <path d="M66,120 Q90,120 105,120" stroke="#203060" stroke-width="1.5" fill="none" stroke-dasharray="5,3"/>
+  <polygon points="102,117 109,120 102,123" fill="#203060"/>
+  <!-- Through lattice -->
+  <path d="M155,118 Q180,115 187,114" stroke="#3040a0" stroke-width="1.5" fill="none" stroke-dasharray="5,3"/>
+  <polygon points="184,111 191,114 184,117" fill="#3040a0"/>
+  <!-- Through sanctum -->
+  <path d="M243,110 Q280,105 338,98" stroke="#3a3aa0" stroke-width="2" fill="none" stroke-dasharray="5,3"/>
+  <polygon points="335,95 342,98 335,101" fill="#3a3aa0"/>
+
+  <!-- Crystal hazard markers -->
+  <g stroke="#3040a0" stroke-width="1" opacity="0.5">
+    <line x1="113" y1="103" x2="147" y2="137"/>
+    <line x1="147" y1="103" x2="113" y2="137"/>
+    <line x1="190" y1="94"  x2="240" y2="130"/>
+    <line x1="240" y1="94"  x2="190" y2="130"/>
+  </g>
+
+  <!-- Objective text -->
+  <text x="200" y="22" font-family="monospace" font-size="8" fill="#2a2480" text-anchor="middle" letter-spacing="2">OBJECTIVE: REACH THE ARCHIVIST</text>
+  <line x1="60" y1="27" x2="340" y2="27" stroke="#181860" stroke-width="0.8"/>
+
+  <!-- Label -->
+  <text x="200" y="232" font-family="monospace" font-size="9" fill="#2a2480" text-anchor="middle" letter-spacing="3">YOUR MISSION</text>
+</svg>

--- a/web/public/cutscenes/act4-outro-1.svg
+++ b/web/public/cutscenes/act4-outro-1.svg
@@ -1,0 +1,108 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#06040e"/>
+
+  <!-- Fading arcane glow — dying down from centre -->
+  <radialGradient id="dying-arcane" cx="50%" cy="50%" r="45%">
+    <stop offset="0%" stop-color="#101880" stop-opacity="0.4"/>
+    <stop offset="50%" stop-color="#080c40" stop-opacity="0.2"/>
+    <stop offset="100%" stop-color="#06040e" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#dying-arcane)"/>
+
+  <!-- Floor — crystal ground, dimming -->
+  <rect x="0" y="188" width="400" height="52" fill="#07050f"/>
+  <g stroke="#12104a" stroke-width="0.6" opacity="0.3">
+    <line x1="200" y1="188" x2="0"   y2="240"/>
+    <line x1="200" y1="188" x2="100" y2="240"/>
+    <line x1="200" y1="188" x2="200" y2="240"/>
+    <line x1="200" y1="188" x2="300" y2="240"/>
+    <line x1="200" y1="188" x2="400" y2="240"/>
+    <line x1="0"   y1="210" x2="400" y2="210"/>
+  </g>
+
+  <!-- THE ARCHIVIST COLLAPSING — crystal matrix disintegrating -->
+
+  <!-- Outer crystal matrix rings — fragmenting -->
+  <g stroke="#1e2060" stroke-width="1" fill="none" opacity="0.4">
+    <polygon points="200,50 260,90 240,155 160,155 140,90"/>
+    <polygon points="200,65 245,98 229,148 171,148 155,98"/>
+  </g>
+  <!-- Matrix fragments separating and flying outward -->
+  <g fill="#141260" stroke="#2a2a80" stroke-width="0.5" opacity="0.6">
+    <!-- Top fragments -->
+    <polygon points="195,45 202,38 207,48 200,52"/>
+    <polygon points="210,42 218,35 222,46 214,49"/>
+    <polygon points="180,48 186,40 191,50 184,54"/>
+    <!-- Right side -->
+    <polygon points="258,86 266,78 270,90 262,95"/>
+    <polygon points="264,108 272,100 276,112 268,118"/>
+    <!-- Left side -->
+    <polygon points="134,86 140,78 143,90 136,94"/>
+    <polygon points="130,110 136,102 140,114 132,118"/>
+    <!-- Bottom -->
+    <polygon points="160,156 165,148 172,158 165,162"/>
+    <polygon points="235,154 241,146 247,157 240,162"/>
+  </g>
+  <!-- Lighter inner shards -->
+  <g fill="#1e1c70" opacity="0.4">
+    <polygon points="220,38 226,31 230,41"/>
+    <polygon points="170,42 175,34 178,44"/>
+    <polygon points="275,125 281,118 284,129"/>
+    <polygon points="118,122 124,115 127,126"/>
+  </g>
+
+  <!-- The Archivist — body collapsing inward, methodically -->
+  <!-- Outer robe disintegrating -->
+  <g fill="#0e0c2e" opacity="0.7">
+    <polygon points="178,100 222,100 228,165 172,165"/>
+  </g>
+  <!-- Robe facets falling away -->
+  <g fill="#141260" stroke="#2020a0" stroke-width="0.5" opacity="0.5">
+    <polygon points="172,130 178,120 175,145 170,140"/>
+    <polygon points="228,128 224,118 226,145 231,140"/>
+    <polygon points="185,165 190,155 195,168 188,170"/>
+    <polygon points="215,163 220,153 225,167 218,170"/>
+  </g>
+
+  <!-- Head / cowl — cracking apart -->
+  <circle cx="200" cy="90" r="16" fill="#0e0c2e" stroke="#1a1a70" stroke-width="1"/>
+  <!-- Crystal cracks across the head -->
+  <g stroke="#3a3aa0" stroke-width="1" fill="none" opacity="0.6">
+    <path d="M200,74 Q205,82 200,90"/>
+    <path d="M200,90 Q194,97 190,106"/>
+    <path d="M200,90 Q207,97 212,104"/>
+    <path d="M192,80 Q196,85 200,90"/>
+    <path d="M208,80 Q204,85 200,90"/>
+  </g>
+  <!-- Eyes — going dark, last flicker -->
+  <circle cx="195" cy="88" r="3" fill="#1e1c60"/>
+  <circle cx="205" cy="88" r="3" fill="#1e1c60"/>
+  <circle cx="195" cy="88" r="1.5" fill="#3040c0" opacity="0.4"/>
+  <circle cx="205" cy="88" r="1.5" fill="#3040c0" opacity="0.4"/>
+
+  <!-- Staff — falling, crystal at top going dark -->
+  <line x1="215" y1="100" x2="250" y2="185" stroke="#1e1c50" stroke-width="2" transform="rotate(20,215,100)"/>
+  <polygon points="245,178 255,174 260,188 250,192" fill="#0e0c2e" stroke="#1a1a60" stroke-width="0.8" transform="rotate(20,215,100)"/>
+  <circle cx="255" cy="170" r="5" fill="#1a1860" opacity="0.5" transform="rotate(20,215,100)"/>
+
+  <!-- Crystal facets from matrix going dark one by one -->
+  <!-- Facets still lit (faint) -->
+  <g fill="#161480" opacity="0.25">
+    <polygon points="155,100 162,92 167,103 160,108"/>
+    <polygon points="240,98 247,90 252,102 245,107"/>
+    <polygon points="200,55 207,47 212,58 205,62"/>
+  </g>
+
+  <!-- Silence / stillness — dust motes settling, not falling -->
+  <g fill="#1a1860" opacity="0.2">
+    <circle cx="80"  cy="60"  r="1.5"/>
+    <circle cx="310" cy="55"  r="1.5"/>
+    <circle cx="130" cy="140" r="1"/>
+    <circle cx="280" cy="135" r="1"/>
+    <circle cx="50"  cy="170" r="1.5"/>
+    <circle cx="355" cy="165" r="1.5"/>
+  </g>
+
+  <!-- Label -->
+  <text x="200" y="228" font-family="monospace" font-size="9" fill="#1e1a60" text-anchor="middle" letter-spacing="3">THE ARCHIVE FALLS SILENT</text>
+</svg>

--- a/web/public/cutscenes/act4-outro-2.svg
+++ b/web/public/cutscenes/act4-outro-2.svg
@@ -1,0 +1,148 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#06040e"/>
+
+  <!-- Archive interior — dim, orderly -->
+  <linearGradient id="archive-bg" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#0a0820"/>
+    <stop offset="100%" stop-color="#080614"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#archive-bg)"/>
+
+  <!-- Prism Lens warm-cool glow from centre -->
+  <radialGradient id="prism-glow" cx="50%" cy="52%" r="35%">
+    <stop offset="0%" stop-color="#80c0ff" stop-opacity="0.5"/>
+    <stop offset="30%" stop-color="#4080c0" stop-opacity="0.25"/>
+    <stop offset="100%" stop-color="#06040e" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#prism-glow)"/>
+
+  <!-- Archive shelves — left wall -->
+  <rect x="0" y="0" width="70" height="240" fill="#080616"/>
+  <g stroke="#12104a" stroke-width="0.8" opacity="0.5">
+    <line x1="0"  y1="40"  x2="70" y2="40"/>
+    <line x1="0"  y1="80"  x2="70" y2="80"/>
+    <line x1="0"  y1="120" x2="70" y2="120"/>
+    <line x1="0"  y1="160" x2="70" y2="160"/>
+    <line x1="0"  y1="200" x2="70" y2="200"/>
+  </g>
+  <!-- Crystal specimen jars on shelves -->
+  <g fill="#141260" stroke="#2030a0" stroke-width="0.5" opacity="0.6">
+    <ellipse cx="15" cy="35" rx="6" ry="8"/>
+    <ellipse cx="30" cy="35" rx="5" ry="7"/>
+    <ellipse cx="45" cy="35" rx="6" ry="9"/>
+    <ellipse cx="15" cy="75" rx="5" ry="7"/>
+    <ellipse cx="32" cy="75" rx="6" ry="8"/>
+    <ellipse cx="50" cy="75" rx="5" ry="7"/>
+    <ellipse cx="18" cy="115" rx="6" ry="8"/>
+    <ellipse cx="40" cy="115" rx="5" ry="7"/>
+  </g>
+  <!-- Faint labels on jars -->
+  <g fill="#1a1860" opacity="0.4" font-family="monospace" font-size="4">
+    <text x="8"  y="48">CR-7</text>
+    <text x="24" y="47">SP-2</text>
+    <text x="8"  y="88">AR-1</text>
+    <text x="28" y="87">CR-9</text>
+  </g>
+
+  <!-- Archive shelves — right wall -->
+  <rect x="330" y="0" width="70" height="240" fill="#080616"/>
+  <g stroke="#12104a" stroke-width="0.8" opacity="0.5">
+    <line x1="330" y1="40"  x2="400" y2="40"/>
+    <line x1="330" y1="80"  x2="400" y2="80"/>
+    <line x1="330" y1="120" x2="400" y2="120"/>
+    <line x1="330" y1="160" x2="400" y2="160"/>
+    <line x1="330" y1="200" x2="400" y2="200"/>
+  </g>
+  <g fill="#141260" stroke="#2030a0" stroke-width="0.5" opacity="0.6">
+    <ellipse cx="345" cy="35" rx="6" ry="8"/>
+    <ellipse cx="360" cy="35" rx="5" ry="7"/>
+    <ellipse cx="378" cy="35" rx="6" ry="9"/>
+    <ellipse cx="348" cy="75" rx="5" ry="7"/>
+    <ellipse cx="365" cy="75" rx="6" ry="8"/>
+    <ellipse cx="382" cy="75" rx="5" ry="7"/>
+    <ellipse cx="350" cy="115" rx="6" ry="8"/>
+    <ellipse cx="372" cy="115" rx="5" ry="7"/>
+  </g>
+
+  <!-- Floor -->
+  <rect x="0" y="185" width="400" height="55" fill="#07050e"/>
+  <g stroke="#12104a" stroke-width="0.7" opacity="0.4">
+    <line x1="0"   y1="200" x2="400" y2="200"/>
+    <line x1="0"   y1="218" x2="400" y2="218"/>
+    <line x1="200" y1="185" x2="70"  y2="240"/>
+    <line x1="200" y1="185" x2="330" y2="240"/>
+    <line x1="200" y1="185" x2="200" y2="240"/>
+  </g>
+
+  <!-- Display pedestal -->
+  <rect x="168" y="168" width="64" height="18" fill="#0e0c28" stroke="#2020a0" stroke-width="1.5"/>
+  <rect x="160" y="180" width="80" height="8"  fill="#0c0a22" stroke="#181860" stroke-width="1"/>
+  <text x="200" y="176" font-family="monospace" font-size="5" fill="#2020a0" text-anchor="middle" letter-spacing="1">PRISM LENS — CAT. #0047</text>
+
+  <!-- THE PRISM LENS — centrepiece on pedestal -->
+  <!-- Lens housing — circular frame -->
+  <circle cx="200" cy="118" r="38" fill="none" stroke="#2030a0" stroke-width="2"/>
+  <circle cx="200" cy="118" r="35" fill="none" stroke="#1a2070" stroke-width="1"/>
+  <!-- Frame details — arcane engravings -->
+  <g stroke="#2030a0" stroke-width="1" opacity="0.5">
+    <line x1="200" y1="80"  x2="200" y2="83"/>
+    <line x1="200" y1="153" x2="200" y2="156"/>
+    <line x1="162" y1="118" x2="165" y2="118"/>
+    <line x1="235" y1="118" x2="238" y2="118"/>
+    <!-- Diagonal marks -->
+    <line x1="174" y1="92"  x2="176" y2="95"/>
+    <line x1="224" y1="141" x2="226" y2="144"/>
+    <line x1="174" y1="144" x2="176" y2="141"/>
+    <line x1="224" y1="95"  x2="226" y2="92"/>
+  </g>
+
+  <!-- Lens glass — refracting light -->
+  <circle cx="200" cy="118" r="32" fill="#0c0c30" stroke="#1e2090" stroke-width="0.5"/>
+
+  <!-- Prism refraction — white light splitting into spectrum inside lens -->
+  <!-- Central white beam -->
+  <line x1="200" y1="86" x2="200" y2="150" stroke="#d0e8ff" stroke-width="1.5" opacity="0.6"/>
+  <!-- Refracted rays fanning out -->
+  <g opacity="0.5" stroke-width="1">
+    <line x1="200" y1="118" x2="168" y2="150" stroke="#ff8080"/><!-- red -->
+    <line x1="200" y1="118" x2="172" y2="150" stroke="#ffb060"/><!-- orange -->
+    <line x1="200" y1="118" x2="178" y2="150" stroke="#e0e060"/><!-- yellow -->
+    <line x1="200" y1="118" x2="185" y2="150" stroke="#80e080"/><!-- green -->
+    <line x1="200" y1="118" x2="193" y2="150" stroke="#60c0e0"/><!-- cyan -->
+    <line x1="200" y1="118" x2="207" y2="150" stroke="#6080e0"/><!-- blue -->
+    <line x1="200" y1="118" x2="215" y2="150" stroke="#9060e0"/><!-- violet -->
+    <line x1="200" y1="118" x2="222" y2="150" stroke="#c060c0"/><!-- purple -->
+    <line x1="200" y1="118" x2="228" y2="150" stroke="#e08080"/><!-- pink -->
+    <line x1="200" y1="118" x2="232" y2="150" stroke="#d0d0d0"/><!-- white-ish -->
+  </g>
+  <!-- Light entry point — top of lens -->
+  <circle cx="200" cy="88" r="3" fill="#a0c8ff" opacity="0.8"/>
+
+  <!-- Spectrum fan glow on floor below lens -->
+  <radialGradient id="spectrum-floor" cx="50%" cy="0%" r="80%">
+    <stop offset="0%" stop-color="#4060c0" stop-opacity="0.3"/>
+    <stop offset="100%" stop-color="#4060c0" stop-opacity="0"/>
+  </radialGradient>
+  <ellipse cx="200" cy="168" rx="45" ry="10" fill="url(#spectrum-floor)"/>
+
+  <!-- Arcane notation around lens — the Archivist's cataloguing -->
+  <g fill="#1a1860" opacity="0.5" font-family="monospace" font-size="5">
+    <text x="100" y="95">REFRACTION INDEX: ∞</text>
+    <text x="100" y="145">MANA AMPLIFICATION: +1/TURN</text>
+    <text x="220" y="95">ORIGIN: DOMINION ARCANE DIV.</text>
+    <text x="220" y="145">STATUS: ACTIVE — CLASS: RELIC</text>
+  </g>
+
+  <!-- Floating crystal dust from the lens -->
+  <g fill="#4060c0" opacity="0.3">
+    <circle cx="155" cy="90"  r="1.5"/>
+    <circle cx="248" cy="88"  r="1.5"/>
+    <circle cx="140" cy="118" r="1"/>
+    <circle cx="260" cy="118" r="1"/>
+    <circle cx="148" cy="148" r="1.5"/>
+    <circle cx="254" cy="148" r="1.5"/>
+  </g>
+
+  <!-- Label -->
+  <text x="200" y="228" font-family="monospace" font-size="9" fill="#2a2480" text-anchor="middle" letter-spacing="3">PRISM LENS</text>
+</svg>

--- a/web/src/data/acts/act4.json
+++ b/web/src/data/acts/act4.json
@@ -50,29 +50,35 @@
   "intro": [
     {
       "title": "THE CRYSTAL SPIRE",
-      "text": "Before the Fracture, the Crystal Spire was the Dominion's arcane research division Ã¢ÂÂ a floating fortress of compressed ley-line energy, staffed by scholars who were very important and knew it.\n\nThe Fracture didn't destroy the Spire. It crystallised it. The entire shard froze mid-operation: experiments running, libraries mid-catalogue, staff mid-sentence. The crystal grew inward. The scholars who survived became part of the archive.\n\nThe Archivist survived better than most."
+      "text": "Before the Fracture, the Crystal Spire was the Dominion's arcane research division Ã¢ÂÂ a floating fortress of compressed ley-line energy, staffed by scholars who were very important and knew it.\n\nThe Fracture didn't destroy the Spire. It crystallised it. The entire shard froze mid-operation: experiments running, libraries mid-catalogue, staff mid-sentence. The crystal grew inward. The scholars who survived became part of the archive.\n\nThe Archivist survived better than most.",
+      "image": "cutscenes/act4-intro-1.svg"
     },
     {
       "title": "THE WANDERER",
-      "text": "You are Jarv. Carrying an Iron Standard. Carrying a Soulstone. Carrying the particular exhaustion of someone who has crossed two impossible shards and is beginning to think the Fractured Core is going to be the easiest part of this.\n\nYou have a deck of cards, a route through the Spire's outer lattice, and the professional conviction that scholars who have had three years to perfect their defences have still, somewhere, made at least one mistake."
+      "text": "You are Jarv. Carrying an Iron Standard. Carrying a Soulstone. Carrying the particular exhaustion of someone who has crossed two impossible shards and is beginning to think the Fractured Core is going to be the easiest part of this.\n\nYou have a deck of cards, a route through the Spire's outer lattice, and the professional conviction that scholars who have had three years to perfect their defences have still, somewhere, made at least one mistake.",
+      "image": "cutscenes/act4-intro-2.svg"
     },
     {
       "title": "THE CRYSTAL SPIRE",
-      "text": "The Spire is a labyrinth of crystallised corridors, arcane constructs, and rooms that echo with the voices of people who stopped speaking three years ago.\n\nAt its heart, the Archivist Ã¢ÂÂ scholar, archivist, and now something considerably more and considerably less than either Ã¢ÂÂ catalogues everything that enters. He has been cataloguing you since you entered the shard.\n\nHe has extensive notes."
+      "text": "The Spire is a labyrinth of crystallised corridors, arcane constructs, and rooms that echo with the voices of people who stopped speaking three years ago.\n\nAt its heart, the Archivist Ã¢ÂÂ scholar, archivist, and now something considerably more and considerably less than either Ã¢ÂÂ catalogues everything that enters. He has been cataloguing you since you entered the shard.\n\nHe has extensive notes.",
+      "image": "cutscenes/act4-intro-3.svg"
     },
     {
       "title": "YOUR MISSION",
-      "text": "Breach the outer lattice. Navigate the arcane sanctum. Reach the Archivist.\n\nStop him cataloguing things.\n\nTry not to become a footnote."
+      "text": "Breach the outer lattice. Navigate the arcane sanctum. Reach the Archivist.\n\nStop him cataloguing things.\n\nTry not to become a footnote.",
+      "image": "cutscenes/act4-intro-4.svg"
     }
   ],
   "outro": [
     {
       "title": "THE ARCHIVE FALLS SILENT",
-      "text": "The Archivist's crystal matrix collapses. Not violently Ã¢ÂÂ methodically. Each facet dims in order, as though even his defeat is being filed.\n\nThe Spire holds its breath. Then, for the first time in three years, a window opens somewhere deep in the structure. Not because it was unlocked. Because whoever had been locking it is no longer in a position to care.\n\nLight comes through. Ordinary, unremarkable light. In the Crystal Spire, it looks like a miracle."
+      "text": "The Archivist's crystal matrix collapses. Not violently Ã¢ÂÂ methodically. Each facet dims in order, as though even his defeat is being filed.\n\nThe Spire holds its breath. Then, for the first time in three years, a window opens somewhere deep in the structure. Not because it was unlocked. Because whoever had been locking it is no longer in a position to care.\n\nLight comes through. Ordinary, unremarkable light. In the Crystal Spire, it looks like a miracle.",
+      "image": "cutscenes/act4-outro-1.svg"
     },
     {
       "title": "PRISM LENS",
-      "text": "Among the Archivist's collection Ã¢ÂÂ catalogued, cross-referenced, annotated in a hand that had become increasingly less human Ã¢ÂÂ you find it.\n\nA lens ground from the Spire's heart crystal. It refracts mana the way a prism refracts light: input, multiplied, redirected.\n\nThe Archivist's note reads: *'Item 7,441: Prism Lens. Effect: mana amplification. Recommendation: do not give to wandering tactician.'\n\nYou take it."
+      "text": "Among the Archivist's collection Ã¢ÂÂ catalogued, cross-referenced, annotated in a hand that had become increasingly less human Ã¢ÂÂ you find it.\n\nA lens ground from the Spire's heart crystal. It refracts mana the way a prism refracts light: input, multiplied, redirected.\n\nThe Archivist's note reads: *'Item 7,441: Prism Lens. Effect: mana amplification. Recommendation: do not give to wandering tactician.'\n\nYou take it.",
+      "image": "cutscenes/act4-outro-2.svg"
     }
   ],
   "variantPools": {


### PR DESCRIPTION
Continues #816 — Act 4 complete (Acts 5–13 + Finale to follow)

## Summary

- Creates 6 SVG cutscene panels for Act 4 — The Crystal Spire (4 intro + 2 outro)
- Wires `image` paths into `act4.json` intro/outro panels

## Act 4 panels (The Crystal Spire)
- `act4-intro-1.svg` — The Crystal Spire (towering four-sided crystal spire with sub-spires, arcane energy bands, glowing apex)
- `act4-intro-2.svg` — The Wanderer (Jarv carrying the Iron Standard and the Soulstone, approaching the Spire through crystal formations)
- `act4-intro-3.svg` — The Arcane Sanctum (crystalline corridor interior: perspective floor grid, chandelier, crystal sconces, arcane construct with glowing eyes)
- `act4-intro-4.svg` — Your Mission (tactical map: outer lattice zone, sanctum maze, Archivist boss marker with staff and glowing eyes)
- `act4-outro-1.svg` — The Archive Falls Silent (Archivist's crystal matrix fragmenting methodically: outer rings separating, eyes going dark, staff falling)
- `act4-outro-2.svg` — Prism Lens (the relic on an archive pedestal: circular lens housing, white light refracting into full spectrum, Archivist's catalogue notation)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GXML372usPatkqhfiuvdWX)_