### PR TITLE
feat(cutscene): add Act 5 graphic novel cutscene images

### DIFF
--- a/web/public/cutscenes/act5-intro-1.svg
+++ b/web/public/cutscenes/act5-intro-1.svg
@@ -1,0 +1,139 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#04080e"/>
+
+  <!-- Deep ocean gradient — dark above, slightly lighter at depth -->
+  <linearGradient id="ocean-depth" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#060c18"/>
+    <stop offset="50%" stop-color="#081420"/>
+    <stop offset="100%" stop-color="#0a1c2a"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#ocean-depth)"/>
+
+  <!-- Bioluminescent ambient glow -->
+  <radialGradient id="bio-glow" cx="50%" cy="60%" r="45%">
+    <stop offset="0%" stop-color="#00a8a8" stop-opacity="0.15"/>
+    <stop offset="100%" stop-color="#00a8a8" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#bio-glow)"/>
+
+  <!-- Seabed / reef floor -->
+  <rect x="0" y="188" width="400" height="52" fill="#060e10"/>
+  <rect x="0" y="185" width="400" height="5"  fill="#0a1618"/>
+
+  <!-- Seabed texture — sand ripples -->
+  <g stroke="#0e1e20" stroke-width="0.7" opacity="0.5">
+    <path d="M0,200 Q50,196 100,200 Q150,204 200,200 Q250,196 300,200 Q350,204 400,200"/>
+    <path d="M0,215 Q60,211 120,215 Q180,219 240,215 Q300,211 360,215 Q390,217 400,215"/>
+  </g>
+
+  <!-- Coral formations — left cluster -->
+  <g fill="#1e0c08" stroke="#3a1810" stroke-width="0.8">
+    <!-- Brain coral -->
+    <ellipse cx="45" cy="188" rx="22" ry="14"/>
+    <!-- Maze grooves on brain coral -->
+    <g stroke="#2a0e08" stroke-width="1" fill="none">
+      <path d="M28,186 Q35,180 45,186 Q55,192 62,186"/>
+      <path d="M30,190 Q38,184 48,190 Q58,196 64,190"/>
+    </g>
+  </g>
+  <!-- Branching coral — left -->
+  <g stroke="#4a1808" stroke-width="2.5" fill="none">
+    <path d="M80,188 Q78,170 75,155"/>
+    <path d="M75,155 Q70,140 65,128"/>
+    <path d="M75,155 Q80,140 85,130"/>
+    <path d="M65,128 Q58,115 55,105"/>
+    <path d="M65,128 Q68,113 72,105"/>
+    <path d="M85,130 Q88,115 92,105"/>
+  </g>
+  <!-- Coral polyps glow -->
+  <g fill="#00c0a0" opacity="0.5">
+    <circle cx="55"  cy="105" r="2"/>
+    <circle cx="72"  cy="105" r="2"/>
+    <circle cx="92"  cy="105" r="2"/>
+    <circle cx="65"  cy="128" r="1.5"/>
+    <circle cx="85"  cy="130" r="1.5"/>
+  </g>
+
+  <!-- Coral formations — right cluster -->
+  <g stroke="#3a1808" stroke-width="2.5" fill="none">
+    <path d="M320,188 Q318,168 315,150"/>
+    <path d="M315,150 Q308,133 304,118"/>
+    <path d="M315,150 Q322,134 328,120"/>
+    <path d="M304,118 Q298,103 295,90"/>
+    <path d="M304,118 Q307,102 312,90"/>
+    <path d="M328,120 Q332,104 337,90"/>
+  </g>
+  <g fill="#00c0a0" opacity="0.5">
+    <circle cx="295" cy="90"  r="2"/>
+    <circle cx="312" cy="90"  r="2"/>
+    <circle cx="337" cy="90"  r="2"/>
+    <circle cx="304" cy="118" r="1.5"/>
+    <circle cx="328" cy="120" r="1.5"/>
+  </g>
+
+  <!-- Brain coral right -->
+  <g fill="#1e0c08" stroke="#3a1810" stroke-width="0.8">
+    <ellipse cx="355" cy="188" rx="24" ry="12"/>
+    <g stroke="#2a0e08" stroke-width="1" fill="none">
+      <path d="M336,186 Q344,180 355,186 Q366,192 374,186"/>
+    </g>
+  </g>
+
+  <!-- SUNKEN SHIP — centre/right, tilted, encrusted -->
+  <!-- Hull -->
+  <polygon points="140,145 280,130 290,170 130,178" fill="#0c1820" stroke="#182838" stroke-width="1.5"/>
+  <!-- Hull planks -->
+  <g stroke="#141e2a" stroke-width="0.6" opacity="0.4">
+    <line x1="140" y1="155" x2="288" y2="140"/>
+    <line x1="138" y1="163" x2="290" y2="152"/>
+    <line x1="136" y1="171" x2="290" y2="162"/>
+  </g>
+  <!-- Mast — broken, listing -->
+  <line x1="200" y1="130" x2="196" y2="50" stroke="#162030" stroke-width="4" transform="rotate(-8,200,130)"/>
+  <line x1="196" y1="75"  x2="230" y2="95" stroke="#162030" stroke-width="2.5" transform="rotate(-8,200,130)"/>
+  <!-- Torn sail remnant -->
+  <polygon points="196,55 225,72 210,90 196,80" fill="#0e1828" stroke="#182838" stroke-width="0.8" opacity="0.7" transform="rotate(-8,200,130)"/>
+  <!-- Coral growth on ship -->
+  <g fill="#3a1808" stroke="#5a2810" stroke-width="0.5">
+    <ellipse cx="155" cy="175" rx="8" ry="5"/>
+    <ellipse cx="260" cy="168" rx="7" ry="4"/>
+    <ellipse cx="210" cy="170" rx="9" ry="5"/>
+  </g>
+
+  <!-- Half-submerged section — water surface line (the shard is half above) -->
+  <rect x="0" y="0" width="400" height="50" fill="#060e14" opacity="0.7"/>
+  <!-- Water surface shimmer -->
+  <g stroke="#1a3040" stroke-width="1" opacity="0.6">
+    <path d="M0,48 Q30,44 60,48 Q90,52 120,48 Q150,44 180,48 Q210,52 240,48 Q270,44 300,48 Q330,52 360,48 Q390,44 400,48"/>
+  </g>
+  <!-- Surface light ripples -->
+  <g stroke="#2a4860" stroke-width="0.5" opacity="0.3">
+    <path d="M0,42 Q40,38 80,42 Q120,46 160,42 Q200,38 240,42 Q280,46 320,42 Q360,38 400,42"/>
+    <path d="M0,54 Q50,50 100,54 Q150,58 200,54 Q250,50 300,54 Q350,58 400,54"/>
+  </g>
+
+  <!-- Bioluminescent particles drifting in water -->
+  <g fill="#00d0b0" opacity="0.4">
+    <circle cx="50"  cy="80"  r="1.5"/>
+    <circle cx="100" cy="65"  r="1"/>
+    <circle cx="160" cy="95"  r="1.5"/>
+    <circle cx="240" cy="70"  r="1"/>
+    <circle cx="300" cy="85"  r="1.5"/>
+    <circle cx="360" cy="60"  r="1"/>
+    <circle cx="30"  cy="120" r="1.5"/>
+    <circle cx="130" cy="110" r="1"/>
+    <circle cx="270" cy="115" r="1.5"/>
+    <circle cx="380" cy="100" r="1"/>
+    <circle cx="70"  cy="145" r="1"/>
+    <circle cx="340" cy="140" r="1.5"/>
+  </g>
+
+  <!-- Ley line threads — faintly visible in the water -->
+  <g stroke="#00a8a8" stroke-width="0.8" fill="none" opacity="0.2">
+    <path d="M0,120 Q100,108 200,115 Q300,122 400,110"/>
+    <path d="M0,150 Q80,138 160,145 Q240,152 400,140"/>
+  </g>
+
+  <!-- Label -->
+  <text x="200" y="228" font-family="monospace" font-size="9" fill="#1a4040" text-anchor="middle" letter-spacing="3">THE SUNKEN REEF</text>
+</svg>

--- a/web/public/cutscenes/act5-intro-2.svg
+++ b/web/public/cutscenes/act5-intro-2.svg
@@ -1,0 +1,128 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#04080e"/>
+
+  <linearGradient id="sov-bg" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#060c18"/>
+    <stop offset="100%" stop-color="#0a1c2a"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#sov-bg)"/>
+
+  <!-- Sovereign's presence — cold deep-water glow -->
+  <radialGradient id="sov-glow" cx="50%" cy="45%" r="45%">
+    <stop offset="0%" stop-color="#0080a0" stop-opacity="0.3"/>
+    <stop offset="60%" stop-color="#004060" stop-opacity="0.15"/>
+    <stop offset="100%" stop-color="#04080e" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#sov-glow)"/>
+
+  <!-- Seabed -->
+  <rect x="0" y="195" width="400" height="45" fill="#060e10"/>
+  <rect x="0" y="192" width="400" height="5"  fill="#0a1618"/>
+
+  <!-- THE TIDAL SOVEREIGN — massive, looming figure made of water, coral, memory -->
+  <!-- Lower body — wave base, crashing water form -->
+  <g fill="#0a2030" opacity="0.9">
+    <ellipse cx="200" cy="192" rx="80" ry="18"/>
+    <ellipse cx="200" cy="182" rx="65" ry="20"/>
+  </g>
+  <!-- Wave foam at base -->
+  <g fill="#1a3848" opacity="0.5">
+    <ellipse cx="140" cy="188" rx="20" ry="6"/>
+    <ellipse cx="200" cy="190" rx="30" ry="7"/>
+    <ellipse cx="260" cy="188" rx="20" ry="6"/>
+  </g>
+
+  <!-- Body trunk — compressed water column -->
+  <g fill="#0c2838" opacity="0.85">
+    <polygon points="165,80 235,80 245,182 155,182"/>
+  </g>
+  <!-- Body striations — layers of compressed sea memory -->
+  <g stroke="#1a4050" stroke-width="1" opacity="0.5">
+    <line x1="162" y1="100" x2="238" y2="100"/>
+    <line x1="160" y1="120" x2="240" y2="120"/>
+    <line x1="158" y1="140" x2="242" y2="140"/>
+    <line x1="156" y1="160" x2="244" y2="160"/>
+  </g>
+  <!-- Body outer edge glow -->
+  <polygon points="165,80 235,80 245,182 155,182" fill="none" stroke="#00a0b8" stroke-width="1.5" opacity="0.4"/>
+
+  <!-- Arms — massive sweeping water tendrils -->
+  <!-- Left arm — reaching out -->
+  <g fill="#0a2030" opacity="0.8">
+    <path d="M165,120 Q130,110 95,90 Q65,72 40,58"/>
+    <path d="M165,130 Q132,122 100,104 Q72,88 48,76"/>
+  </g>
+  <path d="M165,125 Q130,116 95,97 Q65,80 40,67" stroke="#1a4050" stroke-width="3" fill="none"/>
+  <!-- Tendril tip glow -->
+  <radialGradient id="tendril-l" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#00c0d0" stop-opacity="0.6"/>
+    <stop offset="100%" stop-color="#00c0d0" stop-opacity="0"/>
+  </radialGradient>
+  <ellipse cx="40" cy="67" rx="12" ry="8" fill="url(#tendril-l)"/>
+
+  <!-- Right arm — raised, threatening -->
+  <g fill="#0a2030" opacity="0.8">
+    <path d="M235,115 Q270,100 305,78 Q332,60 355,45"/>
+    <path d="M235,125 Q268,112 302,92 Q330,76 352,62"/>
+  </g>
+  <path d="M235,120 Q268,106 303,85 Q331,68 354,53" stroke="#1a4050" stroke-width="3" fill="none"/>
+  <radialGradient id="tendril-r" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#00c0d0" stop-opacity="0.6"/>
+    <stop offset="100%" stop-color="#00c0d0" stop-opacity="0"/>
+  </radialGradient>
+  <ellipse cx="354" cy="53" rx="12" ry="8" fill="url(#tendril-r)"/>
+
+  <!-- Head — a compressed mass of coral and water, ancient face -->
+  <ellipse cx="200" cy="62" rx="36" ry="28" fill="#0e2838" stroke="#1a4050" stroke-width="1.5"/>
+  <!-- Coral growths on head -->
+  <g stroke="#4a1808" stroke-width="2" fill="none" opacity="0.7">
+    <path d="M182,40 Q178,30 175,22"/>
+    <path d="M175,22 Q168,14 165,8"/>
+    <path d="M175,22 Q180,14 183,8"/>
+    <path d="M200,38 Q198,28 198,18"/>
+    <path d="M218,40 Q222,30 225,22"/>
+    <path d="M225,22 Q220,14 218,8"/>
+    <path d="M225,22 Q232,14 235,8"/>
+  </g>
+  <!-- Coral polyp glows on head -->
+  <g fill="#00c090" opacity="0.6">
+    <circle cx="165" cy="8"  r="2"/>
+    <circle cx="183" cy="8"  r="2"/>
+    <circle cx="198" cy="18" r="2"/>
+    <circle cx="218" cy="8"  r="2"/>
+    <circle cx="235" cy="8"  r="2"/>
+  </g>
+
+  <!-- Eyes — two cold, deep-ocean lights -->
+  <circle cx="188" cy="60" r="7" fill="#04101a"/>
+  <circle cx="212" cy="60" r="7" fill="#04101a"/>
+  <circle cx="188" cy="60" r="4" fill="#0090b0" opacity="0.8"/>
+  <circle cx="212" cy="60" r="4" fill="#0090b0" opacity="0.8"/>
+  <circle cx="188" cy="60" r="2" fill="#00d0e8" opacity="0.9"/>
+  <circle cx="212" cy="60" r="2" fill="#00d0e8" opacity="0.9"/>
+
+  <!-- "Mouth" — a slow grinding current -->
+  <path d="M183,74 Q200,80 217,74" stroke="#1a4050" stroke-width="2" fill="none" opacity="0.6"/>
+
+  <!-- Water particles swirling around the Sovereign -->
+  <g fill="#00c0c8" opacity="0.3">
+    <circle cx="100" cy="105" r="2"/>
+    <circle cx="80"  cy="140" r="1.5"/>
+    <circle cx="60"  cy="170" r="2"/>
+    <circle cx="310" cy="100" r="2"/>
+    <circle cx="330" cy="135" r="1.5"/>
+    <circle cx="350" cy="165" r="2"/>
+    <circle cx="130" cy="60"  r="1.5"/>
+    <circle cx="270" cy="55"  r="1.5"/>
+  </g>
+  <!-- Orbiting water droplets -->
+  <g fill="#1a4060" opacity="0.5">
+    <circle cx="150" cy="95" r="3"/>
+    <circle cx="255" cy="92" r="3"/>
+    <circle cx="125" cy="145" r="2.5"/>
+    <circle cx="278" cy="140" r="2.5"/>
+  </g>
+
+  <!-- Label -->
+  <text x="200" y="228" font-family="monospace" font-size="9" fill="#1a4040" text-anchor="middle" letter-spacing="3">THE TIDAL SOVEREIGN</text>
+</svg>

--- a/web/public/cutscenes/act5-intro-3.svg
+++ b/web/public/cutscenes/act5-intro-3.svg
@@ -1,0 +1,107 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#04080e"/>
+
+  <linearGradient id="ley-bg" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#060c18"/>
+    <stop offset="100%" stop-color="#081620"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#ley-bg)"/>
+
+  <!-- Ley line central glow -->
+  <radialGradient id="ley-glow" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#00a8c0" stop-opacity="0.25"/>
+    <stop offset="100%" stop-color="#00a8c0" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#ley-glow)"/>
+
+  <!-- Seabed -->
+  <rect x="0" y="192" width="400" height="48" fill="#060e10"/>
+  <g stroke="#0e1e20" stroke-width="0.6" opacity="0.4">
+    <path d="M0,205 Q80,201 160,205 Q240,209 320,204 Q370,201 400,206"/>
+  </g>
+
+  <!-- Coral arch / gate structure — ancient, pre-Fracture -->
+  <!-- Left pillar -->
+  <rect x="80"  y="80" width="20" height="115" fill="#0e1e18" stroke="#182e28" stroke-width="1"/>
+  <!-- Right pillar -->
+  <rect x="300" y="80" width="20" height="115" fill="#0e1e18" stroke="#182e28" stroke-width="1"/>
+  <!-- Arch spanning pillars — carved stone, coral-encrusted -->
+  <path d="M80,80 Q200,20 320,80" stroke="#182e28" stroke-width="12" fill="none"/>
+  <path d="M80,80 Q200,20 320,80" stroke="#0e1e18" stroke-width="8"  fill="none"/>
+  <!-- Coral on arch -->
+  <g stroke="#3a1808" stroke-width="1.5" fill="none" opacity="0.6">
+    <path d="M120,62 Q118,52 116,44"/>
+    <path d="M160,42 Q158,32 156,24"/>
+    <path d="M200,30 Q200,20 200,12"/>
+    <path d="M240,42 Q242,32 244,24"/>
+    <path d="M280,62 Q282,52 284,44"/>
+  </g>
+  <g fill="#00c090" opacity="0.5">
+    <circle cx="116" cy="44" r="2"/>
+    <circle cx="156" cy="24" r="2"/>
+    <circle cx="200" cy="12" r="2.5"/>
+    <circle cx="244" cy="24" r="2"/>
+    <circle cx="284" cy="44" r="2"/>
+  </g>
+  <!-- Arch keystone -->
+  <polygon points="190,28 210,28 214,42 186,42" fill="#0e1e18" stroke="#182e28" stroke-width="1"/>
+  <!-- Glowing rune on keystone -->
+  <text x="200" y="39" font-family="monospace" font-size="8" fill="#00a8c0" text-anchor="middle" opacity="0.7">◈</text>
+
+  <!-- LEY LINES — glowing threads running through the arch -->
+  <!-- Primary ley line — strong, central -->
+  <path d="M0,118 Q100,110 200,115 Q300,120 400,112" stroke="#00c0d0" stroke-width="2" fill="none" opacity="0.7"/>
+  <!-- Glow around primary ley line -->
+  <path d="M0,118 Q100,110 200,115 Q300,120 400,112" stroke="#00c0d0" stroke-width="8" fill="none" opacity="0.1"/>
+  <!-- Secondary ley lines — fainter, weaving -->
+  <path d="M0,100 Q80,92 160,98 Q240,104 320,96 Q370,92 400,98"  stroke="#0090a8" stroke-width="1" fill="none" opacity="0.4"/>
+  <path d="M0,132 Q90,125 180,130 Q270,135 360,128 Q390,126 400,128" stroke="#0090a8" stroke-width="1" fill="none" opacity="0.4"/>
+  <path d="M0,88  Q120,78 200,84  Q280,90 400,82"  stroke="#006880" stroke-width="0.8" fill="none" opacity="0.25"/>
+  <path d="M0,148 Q100,140 200,144 Q300,148 400,142" stroke="#006880" stroke-width="0.8" fill="none" opacity="0.25"/>
+
+  <!-- Ley node — intersection point at centre of arch -->
+  <circle cx="200" cy="115" r="12" fill="#041018" stroke="#00c0d0" stroke-width="1.5" opacity="0.8"/>
+  <circle cx="200" cy="115" r="7"  fill="#061420" stroke="#00a8c0" stroke-width="1"/>
+  <circle cx="200" cy="115" r="3"  fill="#00d0e0" opacity="0.9"/>
+  <!-- Node spokes -->
+  <g stroke="#00a0b8" stroke-width="0.8" opacity="0.5">
+    <line x1="200" y1="103" x2="200" y2="115"/>
+    <line x1="200" y1="115" x2="200" y2="127"/>
+    <line x1="188" y1="115" x2="212" y2="115"/>
+    <line x1="192" y1="107" x2="208" y2="123"/>
+    <line x1="208" y1="107" x2="192" y2="123"/>
+  </g>
+
+  <!-- Ancient marker stones flanking the passage — engraved with ley symbols -->
+  <!-- Left markers -->
+  <rect x="55"  y="158" width="16" height="35" fill="#0a1818" stroke="#162828" stroke-width="1"/>
+  <text x="63"  y="175" font-family="monospace" font-size="7" fill="#1a4040" text-anchor="middle" opacity="0.6">◇</text>
+  <text x="63"  y="186" font-family="monospace" font-size="7" fill="#1a4040" text-anchor="middle" opacity="0.6">◆</text>
+  <!-- Right markers -->
+  <rect x="329" y="158" width="16" height="35" fill="#0a1818" stroke="#162828" stroke-width="1"/>
+  <text x="337" y="175" font-family="monospace" font-size="7" fill="#1a4040" text-anchor="middle" opacity="0.6">◇</text>
+  <text x="337" y="186" font-family="monospace" font-size="7" fill="#1a4040" text-anchor="middle" opacity="0.6">◆</text>
+
+  <!-- Beyond the arch — the passage tunnel, dim but beckoning -->
+  <ellipse cx="200" cy="155" rx="35" ry="30" fill="#030810" stroke="#0a1820" stroke-width="1" opacity="0.8"/>
+  <radialGradient id="tunnel-light" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#00a0b0" stop-opacity="0.2"/>
+    <stop offset="100%" stop-color="#00a0b0" stop-opacity="0"/>
+  </radialGradient>
+  <ellipse cx="200" cy="155" rx="35" ry="30" fill="url(#tunnel-light)"/>
+
+  <!-- Bioluminescent particles drifting through the arch -->
+  <g fill="#00d0b0" opacity="0.35">
+    <circle cx="150" cy="95"  r="1.5"/>
+    <circle cx="175" cy="108" r="1"/>
+    <circle cx="225" cy="105" r="1.5"/>
+    <circle cx="250" cy="92"  r="1"/>
+    <circle cx="130" cy="130" r="1"/>
+    <circle cx="270" cy="128" r="1"/>
+    <circle cx="185" cy="145" r="1.5"/>
+    <circle cx="215" cy="142" r="1.5"/>
+  </g>
+
+  <!-- Label -->
+  <text x="200" y="228" font-family="monospace" font-size="9" fill="#1a4040" text-anchor="middle" letter-spacing="3">THE PASSAGE</text>
+</svg>

--- a/web/public/cutscenes/act5-outro-1.svg
+++ b/web/public/cutscenes/act5-outro-1.svg
@@ -1,0 +1,128 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#04080e"/>
+
+  <linearGradient id="recede-bg" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#060c18"/>
+    <stop offset="100%" stop-color="#0a1c2a"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#recede-bg)"/>
+
+  <!-- Fading glow — the Sovereign's power diminishing -->
+  <radialGradient id="recede-glow" cx="50%" cy="55%" r="45%">
+    <stop offset="0%" stop-color="#006080" stop-opacity="0.2"/>
+    <stop offset="100%" stop-color="#006080" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#recede-glow)"/>
+
+  <!-- Seabed — the shore, now exposed as the wave pulls back -->
+  <rect x="0" y="185" width="400" height="55" fill="#060e10"/>
+  <!-- Wet sand / exposed reef floor -->
+  <g stroke="#0e2020" stroke-width="0.8" opacity="0.5">
+    <path d="M0,198 Q60,193 120,198 Q180,203 240,198 Q300,193 360,198 Q390,200 400,198"/>
+    <path d="M0,212 Q50,207 110,212 Q170,217 240,212 Q310,207 380,212"/>
+  </g>
+  <!-- Tide pools left behind -->
+  <g fill="#081820" stroke="#102828" stroke-width="0.5">
+    <ellipse cx="60"  cy="196" rx="25" ry="6"/>
+    <ellipse cx="180" cy="198" rx="18" ry="5"/>
+    <ellipse cx="320" cy="196" rx="22" ry="6"/>
+  </g>
+  <!-- Water in tide pools — faint bioluminescent -->
+  <g fill="#006880" opacity="0.2">
+    <ellipse cx="60"  cy="196" rx="22" ry="5"/>
+    <ellipse cx="180" cy="198" rx="15" ry="4"/>
+    <ellipse cx="320" cy="196" rx="19" ry="5"/>
+  </g>
+
+  <!-- THE SOVEREIGN RECEDING — dissolving wave pulling back toward the horizon -->
+  <!-- The mass is moving backward (right to horizon, or sinking down) -->
+  <!-- Bottom mass — already thinning, spreading out -->
+  <g fill="#0a2030" opacity="0.6">
+    <ellipse cx="200" cy="183" rx="110" ry="12"/>
+    <ellipse cx="200" cy="175" rx="85"  ry="12"/>
+  </g>
+  <!-- Mid body — fragments breaking apart -->
+  <g fill="#0c2838" opacity="0.65">
+    <polygon points="168,110 232,110 240,175 160,175"/>
+  </g>
+  <!-- Body striations fading -->
+  <g stroke="#1a4050" stroke-width="0.8" opacity="0.25">
+    <line x1="166" y1="128" x2="234" y2="128"/>
+    <line x1="164" y1="148" x2="236" y2="148"/>
+    <line x1="162" y1="168" x2="238" y2="168"/>
+  </g>
+
+  <!-- Arms — pulling back, becoming foam -->
+  <g fill="#0a2030" opacity="0.4">
+    <!-- Left arm receding -->
+    <path d="M168,130 Q130,118 90,100 Q60,86 30,72"/>
+    <path d="M168,140 Q132,130 94,114 Q64,100 36,88"/>
+  </g>
+  <path d="M168,135 Q131,124 92,107 Q62,93 33,80" stroke="#104050" stroke-width="2" fill="none" opacity="0.4"/>
+  <!-- Left arm dissolving into droplets -->
+  <g fill="#00a0b0" opacity="0.25">
+    <circle cx="30"  cy="72"  r="5"/>
+    <circle cx="18"  cy="68"  r="3"/>
+    <circle cx="8"   cy="65"  r="2"/>
+  </g>
+
+  <!-- Right arm receding -->
+  <g fill="#0a2030" opacity="0.4">
+    <path d="M232,125 Q272,110 312,92 Q342,78 368,65"/>
+    <path d="M232,136 Q270,124 308,108 Q338,95 362,82"/>
+  </g>
+  <path d="M232,130 Q271,117 310,100 Q340,86 365,73" stroke="#104050" stroke-width="2" fill="none" opacity="0.4"/>
+  <g fill="#00a0b0" opacity="0.25">
+    <circle cx="368" cy="65" r="5"/>
+    <circle cx="380" cy="61" r="3"/>
+    <circle cx="390" cy="58" r="2"/>
+  </g>
+
+  <!-- Head — dissolving, eyes going dark -->
+  <ellipse cx="200" cy="88" rx="32" ry="25" fill="#0c2030" stroke="#1a4050" stroke-width="1" opacity="0.7"/>
+  <!-- Coral falling away -->
+  <g stroke="#3a1808" stroke-width="1.5" fill="none" opacity="0.3">
+    <path d="M186,66 Q183,56 181,48"/>
+    <path d="M200,62 Q200,52 200,44"/>
+    <path d="M214,66 Q217,56 219,48"/>
+  </g>
+
+  <!-- Eyes — dark, the light going out -->
+  <circle cx="188" cy="86" r="6" fill="#060e18"/>
+  <circle cx="212" cy="86" r="6" fill="#060e18"/>
+  <circle cx="188" cy="86" r="3" fill="#003848" opacity="0.5"/>
+  <circle cx="212" cy="86" r="3" fill="#003848" opacity="0.5"/>
+  <!-- Last flicker -->
+  <circle cx="188" cy="86" r="1.5" fill="#0090a8" opacity="0.3"/>
+  <circle cx="212" cy="86" r="1.5" fill="#0090a8" opacity="0.3"/>
+
+  <!-- The recession — water streaming away in all directions from the collapsed form -->
+  <g stroke="#0a2838" stroke-width="1.5" fill="none" opacity="0.5">
+    <path d="M160,180 Q90,186 20,182"/>
+    <path d="M240,180 Q310,186 380,182"/>
+    <path d="M155,178 Q100,184 40,188"/>
+    <path d="M245,178 Q300,184 360,188"/>
+  </g>
+
+  <!-- Foam and seafoam bubbles left behind -->
+  <g fill="#0a2838" opacity="0.4">
+    <ellipse cx="100" cy="184" rx="15" ry="4"/>
+    <ellipse cx="295" cy="182" rx="12" ry="4"/>
+    <ellipse cx="200" cy="183" rx="20" ry="5"/>
+  </g>
+
+  <!-- Bioluminescent particles settling — the reef calming -->
+  <g fill="#00a0a8" opacity="0.2">
+    <circle cx="80"  cy="90"  r="1.5"/>
+    <circle cx="140" cy="70"  r="1"/>
+    <circle cx="260" cy="68"  r="1.5"/>
+    <circle cx="320" cy="85"  r="1"/>
+    <circle cx="60"  cy="140" r="1.5"/>
+    <circle cx="345" cy="135" r="1"/>
+    <circle cx="120" cy="155" r="1"/>
+    <circle cx="280" cy="150" r="1.5"/>
+  </g>
+
+  <!-- Label -->
+  <text x="200" y="228" font-family="monospace" font-size="9" fill="#1a4040" text-anchor="middle" letter-spacing="3">THE SOVEREIGN FALLS</text>
+</svg>

--- a/web/public/cutscenes/act5-outro-2.svg
+++ b/web/public/cutscenes/act5-outro-2.svg
@@ -1,0 +1,102 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#04080e"/>
+
+  <radialGradient id="mem-glow" cx="50%" cy="45%" r="50%">
+    <stop offset="0%" stop-color="#1a1040" stop-opacity="0.6"/>
+    <stop offset="100%" stop-color="#04080e" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#mem-glow)"/>
+
+  <!-- The memory — fractured world-map style, showing the Fracture Event being caused deliberately -->
+  <!-- Background: the pre-Fracture world, intact -->
+  <!-- Continent-like shape — the Dominion, whole -->
+  <g fill="#0c0c20" stroke="#1a1840" stroke-width="1" opacity="0.7">
+    <polygon points="80,50 180,30 280,40 340,80 320,140 260,170 180,175 100,160 60,120 50,80"/>
+  </g>
+  <!-- Dominion regions -->
+  <g stroke="#141430" stroke-width="0.5" opacity="0.4">
+    <line x1="160" y1="30"  x2="155" y2="175"/>
+    <line x1="240" y1="38"  x2="245" y2="172"/>
+    <line x1="50"  y1="105" x2="340" y2="105"/>
+  </g>
+
+  <!-- Region labels — faint -->
+  <g fill="#1e1850" opacity="0.45" font-family="monospace" font-size="6">
+    <text x="100" y="80">VERDANT</text>
+    <text x="175" y="72">IRON</text>
+    <text x="255" y="78">CRYSTAL</text>
+    <text x="100" y="135">ASHEN</text>
+    <text x="190" y="145">REEF</text>
+    <text x="270" y="140">SKY</text>
+  </g>
+
+  <!-- The FRACTURE EVENT being caused — a single deliberate strike point -->
+  <!-- Strike point — not at a natural fault, but at the Dominion's heart -->
+  <circle cx="200" cy="102" r="8" fill="#200818" stroke="#601020" stroke-width="1.5"/>
+  <circle cx="200" cy="102" r="4" fill="#400c10" stroke="#801828" stroke-width="1"/>
+  <circle cx="200" cy="102" r="2" fill="#c02030" opacity="0.9"/>
+
+  <!-- The fracture lines radiating OUT from the strike — deliberate, not natural -->
+  <g stroke="#6010a0" stroke-width="1.5" fill="none" opacity="0.7">
+    <line x1="200" y1="102" x2="80"  y2="30"/>
+    <line x1="200" y1="102" x2="340" y2="40"/>
+    <line x1="200" y1="102" x2="340" y2="145"/>
+    <line x1="200" y1="102" x2="60"  y2="130"/>
+    <line x1="200" y1="102" x2="180" y2="175"/>
+    <line x1="200" y1="102" x2="240" y2="172"/>
+    <line x1="200" y1="102" x2="200" y2="15"/>
+    <line x1="200" y1="102" x2="350" y2="95"/>
+    <line x1="200" y1="102" x2="50"  y2="90"/>
+  </g>
+  <!-- Secondary fracture lines -->
+  <g stroke="#40086a" stroke-width="0.8" fill="none" opacity="0.4">
+    <line x1="200" y1="102" x2="130" y2="45"/>
+    <line x1="200" y1="102" x2="270" y2="48"/>
+    <line x1="200" y1="102" x2="310" y2="125"/>
+    <line x1="200" y1="102" x2="100" y2="150"/>
+  </g>
+
+  <!-- The world shattering into shards -->
+  <g fill="#0a0818" stroke="#1a1040" stroke-width="1" opacity="0.5">
+    <polygon points="80,50  160,30 155,100 60,90"   transform="translate(-5,-8)"/>
+    <polygon points="160,30 280,40 248,100 155,100"  transform="translate(2,-6)"/>
+    <polygon points="248,100 320,80 340,145 260,155" transform="translate(8,4)"/>
+    <polygon points="60,90  155,100 160,160 60,140"  transform="translate(-8,5)"/>
+    <polygon points="155,100 248,100 245,172 160,175" transform="translate(-2,8)"/>
+  </g>
+
+  <!-- A HAND — the figure who caused it (silhouette only, anonymous) -->
+  <!-- Reaching down from top, finger touching the strike point -->
+  <!-- Arm from top-right -->
+  <g fill="#0c0a18" stroke="#181430" stroke-width="1.5" opacity="0.8">
+    <!-- Forearm shape -->
+    <polygon points="340,0 370,0 360,60 330,70"/>
+    <!-- Hand -->
+    <polygon points="320,68 340,60 360,60 355,85 340,88 325,82 318,76"/>
+    <!-- Pointing finger toward strike point -->
+    <path d="M325,80 Q270,92 210,100" stroke="#0c0a18" stroke-width="6" fill="none" stroke-linecap="round"/>
+    <circle cx="210" cy="100" r="5" fill="#0c0a18"/>
+  </g>
+  <!-- Finger glow — the deliberate act -->
+  <radialGradient id="finger-glow" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#c02030" stop-opacity="0.4"/>
+    <stop offset="100%" stop-color="#c02030" stop-opacity="0"/>
+  </radialGradient>
+  <circle cx="205" cy="101" r="15" fill="url(#finger-glow)"/>
+
+  <!-- Memory fragments — the Sovereign's recollection, watery -->
+  <g fill="#006880" opacity="0.15">
+    <circle cx="60"  cy="20"  r="8"/>
+    <circle cx="30"  cy="55"  r="6"/>
+    <circle cx="15"  cy="90"  r="5"/>
+    <circle cx="25"  cy="130" r="7"/>
+    <circle cx="50"  cy="170" r="5"/>
+  </g>
+
+  <!-- Warning text — the revelation -->
+  <text x="200" y="208" font-family="monospace" font-size="7" fill="#3a1040" text-anchor="middle" letter-spacing="1">THE FRACTURE WAS NO ACCIDENT</text>
+  <line x1="70" y1="212" x2="330" y2="212" stroke="#1a0820" stroke-width="0.8"/>
+
+  <!-- Label -->
+  <text x="200" y="228" font-family="monospace" font-size="9" fill="#1a4040" text-anchor="middle" letter-spacing="3">WHAT YOU LEARNED</text>
+</svg>

--- a/web/public/cutscenes/act5-outro-3.svg
+++ b/web/public/cutscenes/act5-outro-3.svg
@@ -1,0 +1,126 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#04080e"/>
+
+  <linearGradient id="onward-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#060c18"/>
+    <stop offset="60%" stop-color="#0a1620"/>
+    <stop offset="100%" stop-color="#0c1c28"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#onward-sky)"/>
+
+  <!-- Shore / beach — leaving the reef, stepping onto dry land ahead -->
+  <!-- Ocean behind (right half) -->
+  <rect x="200" y="160" width="200" height="80" fill="#060e14"/>
+  <g stroke="#0e2030" stroke-width="0.7" opacity="0.5">
+    <path d="M200,172 Q240,168 280,172 Q320,176 360,172 Q390,170 400,172"/>
+    <path d="M200,185 Q250,181 300,185 Q350,189 400,185"/>
+    <path d="M200,200 Q260,196 320,200 Q370,204 400,200"/>
+  </g>
+
+  <!-- Dry land ahead (left half) — leading into the distance -->
+  <rect x="0" y="168" width="205" height="72" fill="#0a0c10"/>
+  <g stroke="#141818" stroke-width="0.6" opacity="0.4">
+    <path d="M0,185 Q50,181 100,185 Q150,189 200,185"/>
+    <path d="M0,200 Q60,196 120,200 Q170,204 200,200"/>
+  </g>
+
+  <!-- Shoreline transition -->
+  <path d="M200,168 Q205,172 210,185 Q215,200 210,240" stroke="#0e2030" stroke-width="2" fill="none"/>
+
+  <!-- Horizon line -->
+  <line x1="0" y1="168" x2="400" y2="168" stroke="#141c24" stroke-width="1"/>
+
+  <!-- JARV — centre-left, standing, looking forward (silhouette with relic) -->
+  <ellipse cx="140" cy="208" rx="20" ry="5" fill="#050608" opacity="0.7"/>
+
+  <!-- Boots -->
+  <ellipse cx="132" cy="210" rx="6" ry="3" fill="#08090e"/>
+  <ellipse cx="150" cy="210" rx="6" ry="3" fill="#08090e"/>
+  <!-- Legs -->
+  <line x1="136" y1="198" x2="132" y2="210" stroke="#0c0c18" stroke-width="4" stroke-linecap="round"/>
+  <line x1="145" y1="198" x2="150" y2="210" stroke="#0c0c18" stroke-width="4" stroke-linecap="round"/>
+
+  <!-- THE CORAL MANTLE — draped around Jarv's shoulders, it glows faintly teal -->
+  <!-- Mantle body — flowing, coral-like at edges -->
+  <polygon points="112,175 168,175 174,200 106,200" fill="#0a1e20" stroke="#1a4040" stroke-width="1.5"/>
+  <!-- Mantle coral edge detail -->
+  <g stroke="#2a6040" stroke-width="1.5" fill="none" opacity="0.7">
+    <!-- Left edge coral nubs -->
+    <path d="M112,185 Q108,178 106,172"/>
+    <path d="M112,195 Q106,188 103,182"/>
+    <!-- Right edge coral nubs -->
+    <path d="M168,185 Q172,178 174,172"/>
+    <path d="M168,195 Q174,188 177,182"/>
+  </g>
+  <!-- Coral polyp glow on mantle edges -->
+  <g fill="#00c090" opacity="0.6">
+    <circle cx="106" cy="172" r="2"/>
+    <circle cx="103" cy="182" r="1.5"/>
+    <circle cx="174" cy="172" r="2"/>
+    <circle cx="177" cy="182" r="1.5"/>
+  </g>
+  <!-- Mantle inner glow — bioluminescent teal seeping through -->
+  <radialGradient id="mantle-glow" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#008060" stop-opacity="0.25"/>
+    <stop offset="100%" stop-color="#008060" stop-opacity="0"/>
+  </radialGradient>
+  <polygon points="112,175 168,175 174,200 106,200" fill="url(#mantle-glow)"/>
+
+  <!-- Hood / head -->
+  <ellipse cx="140" cy="168" rx="12" ry="10" fill="#0c0c1a" stroke="#181830" stroke-width="1"/>
+  <ellipse cx="141" cy="171" rx="7"  ry="5"  fill="#080810"/>
+
+  <!-- Iron Standard in right hand -->
+  <line x1="162" y1="178" x2="185" y2="160" stroke="#181830" stroke-width="3" stroke-linecap="round"/>
+  <line x1="185" y1="130" x2="185" y2="212" stroke="#2a3040" stroke-width="2.5"/>
+  <polygon points="183,130 187,130 185,121" fill="#404860"/>
+  <polygon points="185,132 215,140 213,155 185,148" fill="#1e2438" stroke="#303548" stroke-width="1"/>
+  <g stroke="#3a4060" stroke-width="1.2">
+    <line x1="197" y1="136" x2="197" y2="148"/>
+    <line x1="191" y1="142" x2="204" y2="142"/>
+  </g>
+
+  <!-- THE ROAD AHEAD — path stretching forward from Jarv's position into the distant land -->
+  <path d="M140,210 Q160,205 200,202 Q260,198 340,196 Q380,195 400,195" stroke="#141c20" stroke-width="2" fill="none"/>
+  <path d="M140,215 Q160,210 200,207 Q260,203 340,201 Q380,200 400,200" stroke="#101618" stroke-width="1.5" fill="none" opacity="0.5"/>
+
+  <!-- Distant shard silhouettes on the horizon — the acts yet to come -->
+  <g fill="#0a0c14" opacity="0.6">
+    <!-- Shard 1 -->
+    <polygon points="240,168 248,148 256,168"/>
+    <!-- Shard 2 -->
+    <polygon points="268,168 278,138 288,168"/>
+    <!-- Shard 3 -->
+    <polygon points="300,168 312,152 324,168"/>
+    <!-- Shard 4 -->
+    <polygon points="340,168 350,142 362,168"/>
+  </g>
+  <!-- Faint glow behind distant shards — mysterious, beckoning -->
+  <radialGradient id="horizon-mystery" cx="80%" cy="68%" r="25%">
+    <stop offset="0%" stop-color="#401060" stop-opacity="0.2"/>
+    <stop offset="100%" stop-color="#401060" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#horizon-mystery)"/>
+
+  <!-- Stars -->
+  <g fill="#2a3050" opacity="0.4">
+    <circle cx="30"  cy="20" r="1"/>
+    <circle cx="80"  cy="12" r="1.5"/>
+    <circle cx="150" cy="30" r="1"/>
+    <circle cx="210" cy="15" r="1.5"/>
+    <circle cx="290" cy="25" r="1"/>
+    <circle cx="350" cy="10" r="1.5"/>
+    <circle cx="390" cy="35" r="1"/>
+  </g>
+
+  <!-- Bioluminescent sea behind, fading -->
+  <g fill="#004858" opacity="0.2">
+    <circle cx="240" cy="175" r="2"/>
+    <circle cx="280" cy="180" r="1.5"/>
+    <circle cx="320" cy="175" r="2"/>
+    <circle cx="360" cy="180" r="1.5"/>
+  </g>
+
+  <!-- Label -->
+  <text x="200" y="232" font-family="monospace" font-size="9" fill="#1a4040" text-anchor="middle" letter-spacing="3">ONWARD</text>
+</svg>

--- a/web/src/data/acts/act5.json
+++ b/web/src/data/acts/act5.json
@@ -42,29 +42,35 @@
   "intro": [
     {
       "title": "THE SUNKEN REEF",
-      "text": "The shard hangs half-submerged — a lattice of coral, sunken ships, and old magic squeezed between two impossible tides.\n\nSomething large lives at its centre. Something old. The traders who escaped this shard don't talk about what they saw, but they all flinch at the same sounds: deep water, and bells."
+      "text": "The shard hangs half-submerged — a lattice of coral, sunken ships, and old magic squeezed between two impossible tides.\n\nSomething large lives at its centre. Something old. The traders who escaped this shard don't talk about what they saw, but they all flinch at the same sounds: deep water, and bells.",
+      "image": "cutscenes/act5-intro-1.svg"
     },
     {
       "title": "THE TIDAL SOVEREIGN",
-      "text": "The Reef's guardian calls itself the Tidal Sovereign — a being of compressed sea-memory and slow, grinding patience.\n\nIt does not distinguish between invaders and travellers. The ocean, it once said, does not distinguish between ships it sinks and ships it simply forgets about.\n\nYou have decided not to be forgotten."
+      "text": "The Reef's guardian calls itself the Tidal Sovereign — a being of compressed sea-memory and slow, grinding patience.\n\nIt does not distinguish between invaders and travellers. The ocean, it once said, does not distinguish between ships it sinks and ships it simply forgets about.\n\nYou have decided not to be forgotten.",
+      "image": "cutscenes/act5-intro-2.svg"
     },
     {
       "title": "THE PASSAGE",
-      "text": "The ley lines that thread through the Sunken Reef are old — older than the Fracture, older than the Dominion. They connect, somewhere in the deep, to the Fractured Core.\n\nIf you can break through the Sovereign's grip on the pathways, you might finally understand what the Fracture Event actually was.\n\nIf. The word is doing significant structural work in that sentence."
+      "text": "The ley lines that thread through the Sunken Reef are old — older than the Fracture, older than the Dominion. They connect, somewhere in the deep, to the Fractured Core.\n\nIf you can break through the Sovereign's grip on the pathways, you might finally understand what the Fracture Event actually was.\n\nIf. The word is doing significant structural work in that sentence.",
+      "image": "cutscenes/act5-intro-3.svg"
     }
   ],
   "outro": [
     {
       "title": "THE SOVEREIGN FALLS",
-      "text": "The Tidal Sovereign does not collapse. It recedes — like a wave pulling back from shore, leaving behind silence and the smell of deep ocean.\n\nThe coral pathways glow. Sealed ley lines crack open. The Reef's memory of the Fracture is vivid and specific and terrifying, and you carry it with you as you leave."
+      "text": "The Tidal Sovereign does not collapse. It recedes — like a wave pulling back from shore, leaving behind silence and the smell of deep ocean.\n\nThe coral pathways glow. Sealed ley lines crack open. The Reef's memory of the Fracture is vivid and specific and terrifying, and you carry it with you as you leave.",
+      "image": "cutscenes/act5-outro-1.svg"
     },
     {
       "title": "WHAT YOU LEARNED",
-      "text": "The Fracture Event wasn't an accident.\n\nSomeone caused it deliberately. The Sovereign remembered the moment, the direction, the specific signature of the magic. A weapon that destroyed an empire by tearing the world apart at its seams.\n\nYou don't have a name yet. You have a direction."
+      "text": "The Fracture Event wasn't an accident.\n\nSomeone caused it deliberately. The Sovereign remembered the moment, the direction, the specific signature of the magic. A weapon that destroyed an empire by tearing the world apart at its seams.\n\nYou don't have a name yet. You have a direction.",
+      "image": "cutscenes/act5-outro-2.svg"
     },
     {
       "title": "ONWARD",
-      "text": "The Coral Mantle settles around you — a gift from the Reef, or a remnant of the Sovereign's dissolved form. Either way it fits.\n\nAhead: the Sky Dominion, where the aerial shards drift above clouds no map has ever charted. The ley lines point upward.\n\nYou have always been bad at taking hints."
+      "text": "The Coral Mantle settles around you — a gift from the Reef, or a remnant of the Sovereign's dissolved form. Either way it fits.\n\nAhead: the Sky Dominion, where the aerial shards drift above clouds no map has ever charted. The ley lines point upward.\n\nYou have always been bad at taking hints.",
+      "image": "cutscenes/act5-outro-3.svg"
     }
   ],
   "nodes": {


### PR DESCRIPTION
Continues #816 — Act 5 complete (Acts 6–13 + Finale to follow)

## Summary

- Creates 6 SVG cutscene panels for Act 5 — The Sunken Reef (3 intro + 3 outro)
- Wires `image` paths into `act5.json` intro/outro panels

## Act 5 panels (The Sunken Reef)
- `act5-intro-1.svg` — The Sunken Reef (half-submerged lattice of coral, a tilted sunken ship with coral growth, bioluminescent particles, ley line threads)
- `act5-intro-2.svg` — The Tidal Sovereign (looming water-column figure: compressed sea memory, coral crown, cold glowing eyes, sweeping tendril arms)
- `act5-intro-3.svg` — The Passage (ancient coral arch gate, glowing ley lines threading through and converging at a central node, tunnel beyond)
- `act5-outro-1.svg` — The Sovereign Falls (the body receding like a wave: arms dissolving to foam, eyes going dark, water streaming back along the exposed seabed)
- `act5-outro-2.svg` — What You Learned (map of the pre-Fracture Dominion with a deliberate strike point and radiating fracture lines — a silhouetted hand pointing at the origin)
- `act5-outro-3.svg` — Onward (Jarv on the shore, wearing the Coral Mantle relic, looking toward distant shards on the horizon with the road ahead)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GXML372usPatkqhfiuvdWX)_