### PR TITLE
Act 6 cutscene graphics — The Sky Dominion

### DIFF
--- a/web/public/cutscenes/act5-intro-1.svg
+++ b/web/public/cutscenes/act5-intro-1.svg
@@ -1,0 +1,139 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#04080e"/>
+
+  <!-- Deep ocean gradient — dark above, slightly lighter at depth -->
+  <linearGradient id="ocean-depth" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#060c18"/>
+    <stop offset="50%" stop-color="#081420"/>
+    <stop offset="100%" stop-color="#0a1c2a"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#ocean-depth)"/>
+
+  <!-- Bioluminescent ambient glow -->
+  <radialGradient id="bio-glow" cx="50%" cy="60%" r="45%">
+    <stop offset="0%" stop-color="#00a8a8" stop-opacity="0.15"/>
+    <stop offset="100%" stop-color="#00a8a8" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#bio-glow)"/>
+
+  <!-- Seabed / reef floor -->
+  <rect x="0" y="188" width="400" height="52" fill="#060e10"/>
+  <rect x="0" y="185" width="400" height="5"  fill="#0a1618"/>
+
+  <!-- Seabed texture — sand ripples -->
+  <g stroke="#0e1e20" stroke-width="0.7" opacity="0.5">
+    <path d="M0,200 Q50,196 100,200 Q150,204 200,200 Q250,196 300,200 Q350,204 400,200"/>
+    <path d="M0,215 Q60,211 120,215 Q180,219 240,215 Q300,211 360,215 Q390,217 400,215"/>
+  </g>
+
+  <!-- Coral formations — left cluster -->
+  <g fill="#1e0c08" stroke="#3a1810" stroke-width="0.8">
+    <!-- Brain coral -->
+    <ellipse cx="45" cy="188" rx="22" ry="14"/>
+    <!-- Maze grooves on brain coral -->
+    <g stroke="#2a0e08" stroke-width="1" fill="none">
+      <path d="M28,186 Q35,180 45,186 Q55,192 62,186"/>
+      <path d="M30,190 Q38,184 48,190 Q58,196 64,190"/>
+    </g>
+  </g>
+  <!-- Branching coral — left -->
+  <g stroke="#4a1808" stroke-width="2.5" fill="none">
+    <path d="M80,188 Q78,170 75,155"/>
+    <path d="M75,155 Q70,140 65,128"/>
+    <path d="M75,155 Q80,140 85,130"/>
+    <path d="M65,128 Q58,115 55,105"/>
+    <path d="M65,128 Q68,113 72,105"/>
+    <path d="M85,130 Q88,115 92,105"/>
+  </g>
+  <!-- Coral polyps glow -->
+  <g fill="#00c0a0" opacity="0.5">
+    <circle cx="55"  cy="105" r="2"/>
+    <circle cx="72"  cy="105" r="2"/>
+    <circle cx="92"  cy="105" r="2"/>
+    <circle cx="65"  cy="128" r="1.5"/>
+    <circle cx="85"  cy="130" r="1.5"/>
+  </g>
+
+  <!-- Coral formations — right cluster -->
+  <g stroke="#3a1808" stroke-width="2.5" fill="none">
+    <path d="M320,188 Q318,168 315,150"/>
+    <path d="M315,150 Q308,133 304,118"/>
+    <path d="M315,150 Q322,134 328,120"/>
+    <path d="M304,118 Q298,103 295,90"/>
+    <path d="M304,118 Q307,102 312,90"/>
+    <path d="M328,120 Q332,104 337,90"/>
+  </g>
+  <g fill="#00c0a0" opacity="0.5">
+    <circle cx="295" cy="90"  r="2"/>
+    <circle cx="312" cy="90"  r="2"/>
+    <circle cx="337" cy="90"  r="2"/>
+    <circle cx="304" cy="118" r="1.5"/>
+    <circle cx="328" cy="120" r="1.5"/>
+  </g>
+
+  <!-- Brain coral right -->
+  <g fill="#1e0c08" stroke="#3a1810" stroke-width="0.8">
+    <ellipse cx="355" cy="188" rx="24" ry="12"/>
+    <g stroke="#2a0e08" stroke-width="1" fill="none">
+      <path d="M336,186 Q344,180 355,186 Q366,192 374,186"/>
+    </g>
+  </g>
+
+  <!-- SUNKEN SHIP — centre/right, tilted, encrusted -->
+  <!-- Hull -->
+  <polygon points="140,145 280,130 290,170 130,178" fill="#0c1820" stroke="#182838" stroke-width="1.5"/>
+  <!-- Hull planks -->
+  <g stroke="#141e2a" stroke-width="0.6" opacity="0.4">
+    <line x1="140" y1="155" x2="288" y2="140"/>
+    <line x1="138" y1="163" x2="290" y2="152"/>
+    <line x1="136" y1="171" x2="290" y2="162"/>
+  </g>
+  <!-- Mast — broken, listing -->
+  <line x1="200" y1="130" x2="196" y2="50" stroke="#162030" stroke-width="4" transform="rotate(-8,200,130)"/>
+  <line x1="196" y1="75"  x2="230" y2="95" stroke="#162030" stroke-width="2.5" transform="rotate(-8,200,130)"/>
+  <!-- Torn sail remnant -->
+  <polygon points="196,55 225,72 210,90 196,80" fill="#0e1828" stroke="#182838" stroke-width="0.8" opacity="0.7" transform="rotate(-8,200,130)"/>
+  <!-- Coral growth on ship -->
+  <g fill="#3a1808" stroke="#5a2810" stroke-width="0.5">
+    <ellipse cx="155" cy="175" rx="8" ry="5"/>
+    <ellipse cx="260" cy="168" rx="7" ry="4"/>
+    <ellipse cx="210" cy="170" rx="9" ry="5"/>
+  </g>
+
+  <!-- Half-submerged section — water surface line (the shard is half above) -->
+  <rect x="0" y="0" width="400" height="50" fill="#060e14" opacity="0.7"/>
+  <!-- Water surface shimmer -->
+  <g stroke="#1a3040" stroke-width="1" opacity="0.6">
+    <path d="M0,48 Q30,44 60,48 Q90,52 120,48 Q150,44 180,48 Q210,52 240,48 Q270,44 300,48 Q330,52 360,48 Q390,44 400,48"/>
+  </g>
+  <!-- Surface light ripples -->
+  <g stroke="#2a4860" stroke-width="0.5" opacity="0.3">
+    <path d="M0,42 Q40,38 80,42 Q120,46 160,42 Q200,38 240,42 Q280,46 320,42 Q360,38 400,42"/>
+    <path d="M0,54 Q50,50 100,54 Q150,58 200,54 Q250,50 300,54 Q350,58 400,54"/>
+  </g>
+
+  <!-- Bioluminescent particles drifting in water -->
+  <g fill="#00d0b0" opacity="0.4">
+    <circle cx="50"  cy="80"  r="1.5"/>
+    <circle cx="100" cy="65"  r="1"/>
+    <circle cx="160" cy="95"  r="1.5"/>
+    <circle cx="240" cy="70"  r="1"/>
+    <circle cx="300" cy="85"  r="1.5"/>
+    <circle cx="360" cy="60"  r="1"/>
+    <circle cx="30"  cy="120" r="1.5"/>
+    <circle cx="130" cy="110" r="1"/>
+    <circle cx="270" cy="115" r="1.5"/>
+    <circle cx="380" cy="100" r="1"/>
+    <circle cx="70"  cy="145" r="1"/>
+    <circle cx="340" cy="140" r="1.5"/>
+  </g>
+
+  <!-- Ley line threads — faintly visible in the water -->
+  <g stroke="#00a8a8" stroke-width="0.8" fill="none" opacity="0.2">
+    <path d="M0,120 Q100,108 200,115 Q300,122 400,110"/>
+    <path d="M0,150 Q80,138 160,145 Q240,152 400,140"/>
+  </g>
+
+  <!-- Label -->
+  <text x="200" y="228" font-family="monospace" font-size="9" fill="#1a4040" text-anchor="middle" letter-spacing="3">THE SUNKEN REEF</text>
+</svg>

--- a/web/public/cutscenes/act5-intro-2.svg
+++ b/web/public/cutscenes/act5-intro-2.svg
@@ -1,0 +1,128 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#04080e"/>
+
+  <linearGradient id="sov-bg" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#060c18"/>
+    <stop offset="100%" stop-color="#0a1c2a"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#sov-bg)"/>
+
+  <!-- Sovereign's presence — cold deep-water glow -->
+  <radialGradient id="sov-glow" cx="50%" cy="45%" r="45%">
+    <stop offset="0%" stop-color="#0080a0" stop-opacity="0.3"/>
+    <stop offset="60%" stop-color="#004060" stop-opacity="0.15"/>
+    <stop offset="100%" stop-color="#04080e" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#sov-glow)"/>
+
+  <!-- Seabed -->
+  <rect x="0" y="195" width="400" height="45" fill="#060e10"/>
+  <rect x="0" y="192" width="400" height="5"  fill="#0a1618"/>
+
+  <!-- THE TIDAL SOVEREIGN — massive, looming figure made of water, coral, memory -->
+  <!-- Lower body — wave base, crashing water form -->
+  <g fill="#0a2030" opacity="0.9">
+    <ellipse cx="200" cy="192" rx="80" ry="18"/>
+    <ellipse cx="200" cy="182" rx="65" ry="20"/>
+  </g>
+  <!-- Wave foam at base -->
+  <g fill="#1a3848" opacity="0.5">
+    <ellipse cx="140" cy="188" rx="20" ry="6"/>
+    <ellipse cx="200" cy="190" rx="30" ry="7"/>
+    <ellipse cx="260" cy="188" rx="20" ry="6"/>
+  </g>
+
+  <!-- Body trunk — compressed water column -->
+  <g fill="#0c2838" opacity="0.85">
+    <polygon points="165,80 235,80 245,182 155,182"/>
+  </g>
+  <!-- Body striations — layers of compressed sea memory -->
+  <g stroke="#1a4050" stroke-width="1" opacity="0.5">
+    <line x1="162" y1="100" x2="238" y2="100"/>
+    <line x1="160" y1="120" x2="240" y2="120"/>
+    <line x1="158" y1="140" x2="242" y2="140"/>
+    <line x1="156" y1="160" x2="244" y2="160"/>
+  </g>
+  <!-- Body outer edge glow -->
+  <polygon points="165,80 235,80 245,182 155,182" fill="none" stroke="#00a0b8" stroke-width="1.5" opacity="0.4"/>
+
+  <!-- Arms — massive sweeping water tendrils -->
+  <!-- Left arm — reaching out -->
+  <g fill="#0a2030" opacity="0.8">
+    <path d="M165,120 Q130,110 95,90 Q65,72 40,58"/>
+    <path d="M165,130 Q132,122 100,104 Q72,88 48,76"/>
+  </g>
+  <path d="M165,125 Q130,116 95,97 Q65,80 40,67" stroke="#1a4050" stroke-width="3" fill="none"/>
+  <!-- Tendril tip glow -->
+  <radialGradient id="tendril-l" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#00c0d0" stop-opacity="0.6"/>
+    <stop offset="100%" stop-color="#00c0d0" stop-opacity="0"/>
+  </radialGradient>
+  <ellipse cx="40" cy="67" rx="12" ry="8" fill="url(#tendril-l)"/>
+
+  <!-- Right arm — raised, threatening -->
+  <g fill="#0a2030" opacity="0.8">
+    <path d="M235,115 Q270,100 305,78 Q332,60 355,45"/>
+    <path d="M235,125 Q268,112 302,92 Q330,76 352,62"/>
+  </g>
+  <path d="M235,120 Q268,106 303,85 Q331,68 354,53" stroke="#1a4050" stroke-width="3" fill="none"/>
+  <radialGradient id="tendril-r" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#00c0d0" stop-opacity="0.6"/>
+    <stop offset="100%" stop-color="#00c0d0" stop-opacity="0"/>
+  </radialGradient>
+  <ellipse cx="354" cy="53" rx="12" ry="8" fill="url(#tendril-r)"/>
+
+  <!-- Head — a compressed mass of coral and water, ancient face -->
+  <ellipse cx="200" cy="62" rx="36" ry="28" fill="#0e2838" stroke="#1a4050" stroke-width="1.5"/>
+  <!-- Coral growths on head -->
+  <g stroke="#4a1808" stroke-width="2" fill="none" opacity="0.7">
+    <path d="M182,40 Q178,30 175,22"/>
+    <path d="M175,22 Q168,14 165,8"/>
+    <path d="M175,22 Q180,14 183,8"/>
+    <path d="M200,38 Q198,28 198,18"/>
+    <path d="M218,40 Q222,30 225,22"/>
+    <path d="M225,22 Q220,14 218,8"/>
+    <path d="M225,22 Q232,14 235,8"/>
+  </g>
+  <!-- Coral polyp glows on head -->
+  <g fill="#00c090" opacity="0.6">
+    <circle cx="165" cy="8"  r="2"/>
+    <circle cx="183" cy="8"  r="2"/>
+    <circle cx="198" cy="18" r="2"/>
+    <circle cx="218" cy="8"  r="2"/>
+    <circle cx="235" cy="8"  r="2"/>
+  </g>
+
+  <!-- Eyes — two cold, deep-ocean lights -->
+  <circle cx="188" cy="60" r="7" fill="#04101a"/>
+  <circle cx="212" cy="60" r="7" fill="#04101a"/>
+  <circle cx="188" cy="60" r="4" fill="#0090b0" opacity="0.8"/>
+  <circle cx="212" cy="60" r="4" fill="#0090b0" opacity="0.8"/>
+  <circle cx="188" cy="60" r="2" fill="#00d0e8" opacity="0.9"/>
+  <circle cx="212" cy="60" r="2" fill="#00d0e8" opacity="0.9"/>
+
+  <!-- "Mouth" — a slow grinding current -->
+  <path d="M183,74 Q200,80 217,74" stroke="#1a4050" stroke-width="2" fill="none" opacity="0.6"/>
+
+  <!-- Water particles swirling around the Sovereign -->
+  <g fill="#00c0c8" opacity="0.3">
+    <circle cx="100" cy="105" r="2"/>
+    <circle cx="80"  cy="140" r="1.5"/>
+    <circle cx="60"  cy="170" r="2"/>
+    <circle cx="310" cy="100" r="2"/>
+    <circle cx="330" cy="135" r="1.5"/>
+    <circle cx="350" cy="165" r="2"/>
+    <circle cx="130" cy="60"  r="1.5"/>
+    <circle cx="270" cy="55"  r="1.5"/>
+  </g>
+  <!-- Orbiting water droplets -->
+  <g fill="#1a4060" opacity="0.5">
+    <circle cx="150" cy="95" r="3"/>
+    <circle cx="255" cy="92" r="3"/>
+    <circle cx="125" cy="145" r="2.5"/>
+    <circle cx="278" cy="140" r="2.5"/>
+  </g>
+
+  <!-- Label -->
+  <text x="200" y="228" font-family="monospace" font-size="9" fill="#1a4040" text-anchor="middle" letter-spacing="3">THE TIDAL SOVEREIGN</text>
+</svg>

--- a/web/public/cutscenes/act5-intro-3.svg
+++ b/web/public/cutscenes/act5-intro-3.svg
@@ -1,0 +1,107 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#04080e"/>
+
+  <linearGradient id="ley-bg" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#060c18"/>
+    <stop offset="100%" stop-color="#081620"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#ley-bg)"/>
+
+  <!-- Ley line central glow -->
+  <radialGradient id="ley-glow" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#00a8c0" stop-opacity="0.25"/>
+    <stop offset="100%" stop-color="#00a8c0" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#ley-glow)"/>
+
+  <!-- Seabed -->
+  <rect x="0" y="192" width="400" height="48" fill="#060e10"/>
+  <g stroke="#0e1e20" stroke-width="0.6" opacity="0.4">
+    <path d="M0,205 Q80,201 160,205 Q240,209 320,204 Q370,201 400,206"/>
+  </g>
+
+  <!-- Coral arch / gate structure — ancient, pre-Fracture -->
+  <!-- Left pillar -->
+  <rect x="80"  y="80" width="20" height="115" fill="#0e1e18" stroke="#182e28" stroke-width="1"/>
+  <!-- Right pillar -->
+  <rect x="300" y="80" width="20" height="115" fill="#0e1e18" stroke="#182e28" stroke-width="1"/>
+  <!-- Arch spanning pillars — carved stone, coral-encrusted -->
+  <path d="M80,80 Q200,20 320,80" stroke="#182e28" stroke-width="12" fill="none"/>
+  <path d="M80,80 Q200,20 320,80" stroke="#0e1e18" stroke-width="8"  fill="none"/>
+  <!-- Coral on arch -->
+  <g stroke="#3a1808" stroke-width="1.5" fill="none" opacity="0.6">
+    <path d="M120,62 Q118,52 116,44"/>
+    <path d="M160,42 Q158,32 156,24"/>
+    <path d="M200,30 Q200,20 200,12"/>
+    <path d="M240,42 Q242,32 244,24"/>
+    <path d="M280,62 Q282,52 284,44"/>
+  </g>
+  <g fill="#00c090" opacity="0.5">
+    <circle cx="116" cy="44" r="2"/>
+    <circle cx="156" cy="24" r="2"/>
+    <circle cx="200" cy="12" r="2.5"/>
+    <circle cx="244" cy="24" r="2"/>
+    <circle cx="284" cy="44" r="2"/>
+  </g>
+  <!-- Arch keystone -->
+  <polygon points="190,28 210,28 214,42 186,42" fill="#0e1e18" stroke="#182e28" stroke-width="1"/>
+  <!-- Glowing rune on keystone -->
+  <text x="200" y="39" font-family="monospace" font-size="8" fill="#00a8c0" text-anchor="middle" opacity="0.7">◈</text>
+
+  <!-- LEY LINES — glowing threads running through the arch -->
+  <!-- Primary ley line — strong, central -->
+  <path d="M0,118 Q100,110 200,115 Q300,120 400,112" stroke="#00c0d0" stroke-width="2" fill="none" opacity="0.7"/>
+  <!-- Glow around primary ley line -->
+  <path d="M0,118 Q100,110 200,115 Q300,120 400,112" stroke="#00c0d0" stroke-width="8" fill="none" opacity="0.1"/>
+  <!-- Secondary ley lines — fainter, weaving -->
+  <path d="M0,100 Q80,92 160,98 Q240,104 320,96 Q370,92 400,98"  stroke="#0090a8" stroke-width="1" fill="none" opacity="0.4"/>
+  <path d="M0,132 Q90,125 180,130 Q270,135 360,128 Q390,126 400,128" stroke="#0090a8" stroke-width="1" fill="none" opacity="0.4"/>
+  <path d="M0,88  Q120,78 200,84  Q280,90 400,82"  stroke="#006880" stroke-width="0.8" fill="none" opacity="0.25"/>
+  <path d="M0,148 Q100,140 200,144 Q300,148 400,142" stroke="#006880" stroke-width="0.8" fill="none" opacity="0.25"/>
+
+  <!-- Ley node — intersection point at centre of arch -->
+  <circle cx="200" cy="115" r="12" fill="#041018" stroke="#00c0d0" stroke-width="1.5" opacity="0.8"/>
+  <circle cx="200" cy="115" r="7"  fill="#061420" stroke="#00a8c0" stroke-width="1"/>
+  <circle cx="200" cy="115" r="3"  fill="#00d0e0" opacity="0.9"/>
+  <!-- Node spokes -->
+  <g stroke="#00a0b8" stroke-width="0.8" opacity="0.5">
+    <line x1="200" y1="103" x2="200" y2="115"/>
+    <line x1="200" y1="115" x2="200" y2="127"/>
+    <line x1="188" y1="115" x2="212" y2="115"/>
+    <line x1="192" y1="107" x2="208" y2="123"/>
+    <line x1="208" y1="107" x2="192" y2="123"/>
+  </g>
+
+  <!-- Ancient marker stones flanking the passage — engraved with ley symbols -->
+  <!-- Left markers -->
+  <rect x="55"  y="158" width="16" height="35" fill="#0a1818" stroke="#162828" stroke-width="1"/>
+  <text x="63"  y="175" font-family="monospace" font-size="7" fill="#1a4040" text-anchor="middle" opacity="0.6">◇</text>
+  <text x="63"  y="186" font-family="monospace" font-size="7" fill="#1a4040" text-anchor="middle" opacity="0.6">◆</text>
+  <!-- Right markers -->
+  <rect x="329" y="158" width="16" height="35" fill="#0a1818" stroke="#162828" stroke-width="1"/>
+  <text x="337" y="175" font-family="monospace" font-size="7" fill="#1a4040" text-anchor="middle" opacity="0.6">◇</text>
+  <text x="337" y="186" font-family="monospace" font-size="7" fill="#1a4040" text-anchor="middle" opacity="0.6">◆</text>
+
+  <!-- Beyond the arch — the passage tunnel, dim but beckoning -->
+  <ellipse cx="200" cy="155" rx="35" ry="30" fill="#030810" stroke="#0a1820" stroke-width="1" opacity="0.8"/>
+  <radialGradient id="tunnel-light" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#00a0b0" stop-opacity="0.2"/>
+    <stop offset="100%" stop-color="#00a0b0" stop-opacity="0"/>
+  </radialGradient>
+  <ellipse cx="200" cy="155" rx="35" ry="30" fill="url(#tunnel-light)"/>
+
+  <!-- Bioluminescent particles drifting through the arch -->
+  <g fill="#00d0b0" opacity="0.35">
+    <circle cx="150" cy="95"  r="1.5"/>
+    <circle cx="175" cy="108" r="1"/>
+    <circle cx="225" cy="105" r="1.5"/>
+    <circle cx="250" cy="92"  r="1"/>
+    <circle cx="130" cy="130" r="1"/>
+    <circle cx="270" cy="128" r="1"/>
+    <circle cx="185" cy="145" r="1.5"/>
+    <circle cx="215" cy="142" r="1.5"/>
+  </g>
+
+  <!-- Label -->
+  <text x="200" y="228" font-family="monospace" font-size="9" fill="#1a4040" text-anchor="middle" letter-spacing="3">THE PASSAGE</text>
+</svg>

--- a/web/public/cutscenes/act5-outro-1.svg
+++ b/web/public/cutscenes/act5-outro-1.svg
@@ -1,0 +1,128 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#04080e"/>
+
+  <linearGradient id="recede-bg" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#060c18"/>
+    <stop offset="100%" stop-color="#0a1c2a"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#recede-bg)"/>
+
+  <!-- Fading glow — the Sovereign's power diminishing -->
+  <radialGradient id="recede-glow" cx="50%" cy="55%" r="45%">
+    <stop offset="0%" stop-color="#006080" stop-opacity="0.2"/>
+    <stop offset="100%" stop-color="#006080" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#recede-glow)"/>
+
+  <!-- Seabed — the shore, now exposed as the wave pulls back -->
+  <rect x="0" y="185" width="400" height="55" fill="#060e10"/>
+  <!-- Wet sand / exposed reef floor -->
+  <g stroke="#0e2020" stroke-width="0.8" opacity="0.5">
+    <path d="M0,198 Q60,193 120,198 Q180,203 240,198 Q300,193 360,198 Q390,200 400,198"/>
+    <path d="M0,212 Q50,207 110,212 Q170,217 240,212 Q310,207 380,212"/>
+  </g>
+  <!-- Tide pools left behind -->
+  <g fill="#081820" stroke="#102828" stroke-width="0.5">
+    <ellipse cx="60"  cy="196" rx="25" ry="6"/>
+    <ellipse cx="180" cy="198" rx="18" ry="5"/>
+    <ellipse cx="320" cy="196" rx="22" ry="6"/>
+  </g>
+  <!-- Water in tide pools — faint bioluminescent -->
+  <g fill="#006880" opacity="0.2">
+    <ellipse cx="60"  cy="196" rx="22" ry="5"/>
+    <ellipse cx="180" cy="198" rx="15" ry="4"/>
+    <ellipse cx="320" cy="196" rx="19" ry="5"/>
+  </g>
+
+  <!-- THE SOVEREIGN RECEDING — dissolving wave pulling back toward the horizon -->
+  <!-- The mass is moving backward (right to horizon, or sinking down) -->
+  <!-- Bottom mass — already thinning, spreading out -->
+  <g fill="#0a2030" opacity="0.6">
+    <ellipse cx="200" cy="183" rx="110" ry="12"/>
+    <ellipse cx="200" cy="175" rx="85"  ry="12"/>
+  </g>
+  <!-- Mid body — fragments breaking apart -->
+  <g fill="#0c2838" opacity="0.65">
+    <polygon points="168,110 232,110 240,175 160,175"/>
+  </g>
+  <!-- Body striations fading -->
+  <g stroke="#1a4050" stroke-width="0.8" opacity="0.25">
+    <line x1="166" y1="128" x2="234" y2="128"/>
+    <line x1="164" y1="148" x2="236" y2="148"/>
+    <line x1="162" y1="168" x2="238" y2="168"/>
+  </g>
+
+  <!-- Arms — pulling back, becoming foam -->
+  <g fill="#0a2030" opacity="0.4">
+    <!-- Left arm receding -->
+    <path d="M168,130 Q130,118 90,100 Q60,86 30,72"/>
+    <path d="M168,140 Q132,130 94,114 Q64,100 36,88"/>
+  </g>
+  <path d="M168,135 Q131,124 92,107 Q62,93 33,80" stroke="#104050" stroke-width="2" fill="none" opacity="0.4"/>
+  <!-- Left arm dissolving into droplets -->
+  <g fill="#00a0b0" opacity="0.25">
+    <circle cx="30"  cy="72"  r="5"/>
+    <circle cx="18"  cy="68"  r="3"/>
+    <circle cx="8"   cy="65"  r="2"/>
+  </g>
+
+  <!-- Right arm receding -->
+  <g fill="#0a2030" opacity="0.4">
+    <path d="M232,125 Q272,110 312,92 Q342,78 368,65"/>
+    <path d="M232,136 Q270,124 308,108 Q338,95 362,82"/>
+  </g>
+  <path d="M232,130 Q271,117 310,100 Q340,86 365,73" stroke="#104050" stroke-width="2" fill="none" opacity="0.4"/>
+  <g fill="#00a0b0" opacity="0.25">
+    <circle cx="368" cy="65" r="5"/>
+    <circle cx="380" cy="61" r="3"/>
+    <circle cx="390" cy="58" r="2"/>
+  </g>
+
+  <!-- Head — dissolving, eyes going dark -->
+  <ellipse cx="200" cy="88" rx="32" ry="25" fill="#0c2030" stroke="#1a4050" stroke-width="1" opacity="0.7"/>
+  <!-- Coral falling away -->
+  <g stroke="#3a1808" stroke-width="1.5" fill="none" opacity="0.3">
+    <path d="M186,66 Q183,56 181,48"/>
+    <path d="M200,62 Q200,52 200,44"/>
+    <path d="M214,66 Q217,56 219,48"/>
+  </g>
+
+  <!-- Eyes — dark, the light going out -->
+  <circle cx="188" cy="86" r="6" fill="#060e18"/>
+  <circle cx="212" cy="86" r="6" fill="#060e18"/>
+  <circle cx="188" cy="86" r="3" fill="#003848" opacity="0.5"/>
+  <circle cx="212" cy="86" r="3" fill="#003848" opacity="0.5"/>
+  <!-- Last flicker -->
+  <circle cx="188" cy="86" r="1.5" fill="#0090a8" opacity="0.3"/>
+  <circle cx="212" cy="86" r="1.5" fill="#0090a8" opacity="0.3"/>
+
+  <!-- The recession — water streaming away in all directions from the collapsed form -->
+  <g stroke="#0a2838" stroke-width="1.5" fill="none" opacity="0.5">
+    <path d="M160,180 Q90,186 20,182"/>
+    <path d="M240,180 Q310,186 380,182"/>
+    <path d="M155,178 Q100,184 40,188"/>
+    <path d="M245,178 Q300,184 360,188"/>
+  </g>
+
+  <!-- Foam and seafoam bubbles left behind -->
+  <g fill="#0a2838" opacity="0.4">
+    <ellipse cx="100" cy="184" rx="15" ry="4"/>
+    <ellipse cx="295" cy="182" rx="12" ry="4"/>
+    <ellipse cx="200" cy="183" rx="20" ry="5"/>
+  </g>
+
+  <!-- Bioluminescent particles settling — the reef calming -->
+  <g fill="#00a0a8" opacity="0.2">
+    <circle cx="80"  cy="90"  r="1.5"/>
+    <circle cx="140" cy="70"  r="1"/>
+    <circle cx="260" cy="68"  r="1.5"/>
+    <circle cx="320" cy="85"  r="1"/>
+    <circle cx="60"  cy="140" r="1.5"/>
+    <circle cx="345" cy="135" r="1"/>
+    <circle cx="120" cy="155" r="1"/>
+    <circle cx="280" cy="150" r="1.5"/>
+  </g>
+
+  <!-- Label -->
+  <text x="200" y="228" font-family="monospace" font-size="9" fill="#1a4040" text-anchor="middle" letter-spacing="3">THE SOVEREIGN FALLS</text>
+</svg>

--- a/web/public/cutscenes/act5-outro-2.svg
+++ b/web/public/cutscenes/act5-outro-2.svg
@@ -1,0 +1,102 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#04080e"/>
+
+  <radialGradient id="mem-glow" cx="50%" cy="45%" r="50%">
+    <stop offset="0%" stop-color="#1a1040" stop-opacity="0.6"/>
+    <stop offset="100%" stop-color="#04080e" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#mem-glow)"/>
+
+  <!-- The memory — fractured world-map style, showing the Fracture Event being caused deliberately -->
+  <!-- Background: the pre-Fracture world, intact -->
+  <!-- Continent-like shape — the Dominion, whole -->
+  <g fill="#0c0c20" stroke="#1a1840" stroke-width="1" opacity="0.7">
+    <polygon points="80,50 180,30 280,40 340,80 320,140 260,170 180,175 100,160 60,120 50,80"/>
+  </g>
+  <!-- Dominion regions -->
+  <g stroke="#141430" stroke-width="0.5" opacity="0.4">
+    <line x1="160" y1="30"  x2="155" y2="175"/>
+    <line x1="240" y1="38"  x2="245" y2="172"/>
+    <line x1="50"  y1="105" x2="340" y2="105"/>
+  </g>
+
+  <!-- Region labels — faint -->
+  <g fill="#1e1850" opacity="0.45" font-family="monospace" font-size="6">
+    <text x="100" y="80">VERDANT</text>
+    <text x="175" y="72">IRON</text>
+    <text x="255" y="78">CRYSTAL</text>
+    <text x="100" y="135">ASHEN</text>
+    <text x="190" y="145">REEF</text>
+    <text x="270" y="140">SKY</text>
+  </g>
+
+  <!-- The FRACTURE EVENT being caused — a single deliberate strike point -->
+  <!-- Strike point — not at a natural fault, but at the Dominion's heart -->
+  <circle cx="200" cy="102" r="8" fill="#200818" stroke="#601020" stroke-width="1.5"/>
+  <circle cx="200" cy="102" r="4" fill="#400c10" stroke="#801828" stroke-width="1"/>
+  <circle cx="200" cy="102" r="2" fill="#c02030" opacity="0.9"/>
+
+  <!-- The fracture lines radiating OUT from the strike — deliberate, not natural -->
+  <g stroke="#6010a0" stroke-width="1.5" fill="none" opacity="0.7">
+    <line x1="200" y1="102" x2="80"  y2="30"/>
+    <line x1="200" y1="102" x2="340" y2="40"/>
+    <line x1="200" y1="102" x2="340" y2="145"/>
+    <line x1="200" y1="102" x2="60"  y2="130"/>
+    <line x1="200" y1="102" x2="180" y2="175"/>
+    <line x1="200" y1="102" x2="240" y2="172"/>
+    <line x1="200" y1="102" x2="200" y2="15"/>
+    <line x1="200" y1="102" x2="350" y2="95"/>
+    <line x1="200" y1="102" x2="50"  y2="90"/>
+  </g>
+  <!-- Secondary fracture lines -->
+  <g stroke="#40086a" stroke-width="0.8" fill="none" opacity="0.4">
+    <line x1="200" y1="102" x2="130" y2="45"/>
+    <line x1="200" y1="102" x2="270" y2="48"/>
+    <line x1="200" y1="102" x2="310" y2="125"/>
+    <line x1="200" y1="102" x2="100" y2="150"/>
+  </g>
+
+  <!-- The world shattering into shards -->
+  <g fill="#0a0818" stroke="#1a1040" stroke-width="1" opacity="0.5">
+    <polygon points="80,50  160,30 155,100 60,90"   transform="translate(-5,-8)"/>
+    <polygon points="160,30 280,40 248,100 155,100"  transform="translate(2,-6)"/>
+    <polygon points="248,100 320,80 340,145 260,155" transform="translate(8,4)"/>
+    <polygon points="60,90  155,100 160,160 60,140"  transform="translate(-8,5)"/>
+    <polygon points="155,100 248,100 245,172 160,175" transform="translate(-2,8)"/>
+  </g>
+
+  <!-- A HAND — the figure who caused it (silhouette only, anonymous) -->
+  <!-- Reaching down from top, finger touching the strike point -->
+  <!-- Arm from top-right -->
+  <g fill="#0c0a18" stroke="#181430" stroke-width="1.5" opacity="0.8">
+    <!-- Forearm shape -->
+    <polygon points="340,0 370,0 360,60 330,70"/>
+    <!-- Hand -->
+    <polygon points="320,68 340,60 360,60 355,85 340,88 325,82 318,76"/>
+    <!-- Pointing finger toward strike point -->
+    <path d="M325,80 Q270,92 210,100" stroke="#0c0a18" stroke-width="6" fill="none" stroke-linecap="round"/>
+    <circle cx="210" cy="100" r="5" fill="#0c0a18"/>
+  </g>
+  <!-- Finger glow — the deliberate act -->
+  <radialGradient id="finger-glow" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#c02030" stop-opacity="0.4"/>
+    <stop offset="100%" stop-color="#c02030" stop-opacity="0"/>
+  </radialGradient>
+  <circle cx="205" cy="101" r="15" fill="url(#finger-glow)"/>
+
+  <!-- Memory fragments — the Sovereign's recollection, watery -->
+  <g fill="#006880" opacity="0.15">
+    <circle cx="60"  cy="20"  r="8"/>
+    <circle cx="30"  cy="55"  r="6"/>
+    <circle cx="15"  cy="90"  r="5"/>
+    <circle cx="25"  cy="130" r="7"/>
+    <circle cx="50"  cy="170" r="5"/>
+  </g>
+
+  <!-- Warning text — the revelation -->
+  <text x="200" y="208" font-family="monospace" font-size="7" fill="#3a1040" text-anchor="middle" letter-spacing="1">THE FRACTURE WAS NO ACCIDENT</text>
+  <line x1="70" y1="212" x2="330" y2="212" stroke="#1a0820" stroke-width="0.8"/>
+
+  <!-- Label -->
+  <text x="200" y="228" font-family="monospace" font-size="9" fill="#1a4040" text-anchor="middle" letter-spacing="3">WHAT YOU LEARNED</text>
+</svg>

--- a/web/public/cutscenes/act5-outro-3.svg
+++ b/web/public/cutscenes/act5-outro-3.svg
@@ -1,0 +1,126 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#04080e"/>
+
+  <linearGradient id="onward-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#060c18"/>
+    <stop offset="60%" stop-color="#0a1620"/>
+    <stop offset="100%" stop-color="#0c1c28"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#onward-sky)"/>
+
+  <!-- Shore / beach — leaving the reef, stepping onto dry land ahead -->
+  <!-- Ocean behind (right half) -->
+  <rect x="200" y="160" width="200" height="80" fill="#060e14"/>
+  <g stroke="#0e2030" stroke-width="0.7" opacity="0.5">
+    <path d="M200,172 Q240,168 280,172 Q320,176 360,172 Q390,170 400,172"/>
+    <path d="M200,185 Q250,181 300,185 Q350,189 400,185"/>
+    <path d="M200,200 Q260,196 320,200 Q370,204 400,200"/>
+  </g>
+
+  <!-- Dry land ahead (left half) — leading into the distance -->
+  <rect x="0" y="168" width="205" height="72" fill="#0a0c10"/>
+  <g stroke="#141818" stroke-width="0.6" opacity="0.4">
+    <path d="M0,185 Q50,181 100,185 Q150,189 200,185"/>
+    <path d="M0,200 Q60,196 120,200 Q170,204 200,200"/>
+  </g>
+
+  <!-- Shoreline transition -->
+  <path d="M200,168 Q205,172 210,185 Q215,200 210,240" stroke="#0e2030" stroke-width="2" fill="none"/>
+
+  <!-- Horizon line -->
+  <line x1="0" y1="168" x2="400" y2="168" stroke="#141c24" stroke-width="1"/>
+
+  <!-- JARV — centre-left, standing, looking forward (silhouette with relic) -->
+  <ellipse cx="140" cy="208" rx="20" ry="5" fill="#050608" opacity="0.7"/>
+
+  <!-- Boots -->
+  <ellipse cx="132" cy="210" rx="6" ry="3" fill="#08090e"/>
+  <ellipse cx="150" cy="210" rx="6" ry="3" fill="#08090e"/>
+  <!-- Legs -->
+  <line x1="136" y1="198" x2="132" y2="210" stroke="#0c0c18" stroke-width="4" stroke-linecap="round"/>
+  <line x1="145" y1="198" x2="150" y2="210" stroke="#0c0c18" stroke-width="4" stroke-linecap="round"/>
+
+  <!-- THE CORAL MANTLE — draped around Jarv's shoulders, it glows faintly teal -->
+  <!-- Mantle body — flowing, coral-like at edges -->
+  <polygon points="112,175 168,175 174,200 106,200" fill="#0a1e20" stroke="#1a4040" stroke-width="1.5"/>
+  <!-- Mantle coral edge detail -->
+  <g stroke="#2a6040" stroke-width="1.5" fill="none" opacity="0.7">
+    <!-- Left edge coral nubs -->
+    <path d="M112,185 Q108,178 106,172"/>
+    <path d="M112,195 Q106,188 103,182"/>
+    <!-- Right edge coral nubs -->
+    <path d="M168,185 Q172,178 174,172"/>
+    <path d="M168,195 Q174,188 177,182"/>
+  </g>
+  <!-- Coral polyp glow on mantle edges -->
+  <g fill="#00c090" opacity="0.6">
+    <circle cx="106" cy="172" r="2"/>
+    <circle cx="103" cy="182" r="1.5"/>
+    <circle cx="174" cy="172" r="2"/>
+    <circle cx="177" cy="182" r="1.5"/>
+  </g>
+  <!-- Mantle inner glow — bioluminescent teal seeping through -->
+  <radialGradient id="mantle-glow" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#008060" stop-opacity="0.25"/>
+    <stop offset="100%" stop-color="#008060" stop-opacity="0"/>
+  </radialGradient>
+  <polygon points="112,175 168,175 174,200 106,200" fill="url(#mantle-glow)"/>
+
+  <!-- Hood / head -->
+  <ellipse cx="140" cy="168" rx="12" ry="10" fill="#0c0c1a" stroke="#181830" stroke-width="1"/>
+  <ellipse cx="141" cy="171" rx="7"  ry="5"  fill="#080810"/>
+
+  <!-- Iron Standard in right hand -->
+  <line x1="162" y1="178" x2="185" y2="160" stroke="#181830" stroke-width="3" stroke-linecap="round"/>
+  <line x1="185" y1="130" x2="185" y2="212" stroke="#2a3040" stroke-width="2.5"/>
+  <polygon points="183,130 187,130 185,121" fill="#404860"/>
+  <polygon points="185,132 215,140 213,155 185,148" fill="#1e2438" stroke="#303548" stroke-width="1"/>
+  <g stroke="#3a4060" stroke-width="1.2">
+    <line x1="197" y1="136" x2="197" y2="148"/>
+    <line x1="191" y1="142" x2="204" y2="142"/>
+  </g>
+
+  <!-- THE ROAD AHEAD — path stretching forward from Jarv's position into the distant land -->
+  <path d="M140,210 Q160,205 200,202 Q260,198 340,196 Q380,195 400,195" stroke="#141c20" stroke-width="2" fill="none"/>
+  <path d="M140,215 Q160,210 200,207 Q260,203 340,201 Q380,200 400,200" stroke="#101618" stroke-width="1.5" fill="none" opacity="0.5"/>
+
+  <!-- Distant shard silhouettes on the horizon — the acts yet to come -->
+  <g fill="#0a0c14" opacity="0.6">
+    <!-- Shard 1 -->
+    <polygon points="240,168 248,148 256,168"/>
+    <!-- Shard 2 -->
+    <polygon points="268,168 278,138 288,168"/>
+    <!-- Shard 3 -->
+    <polygon points="300,168 312,152 324,168"/>
+    <!-- Shard 4 -->
+    <polygon points="340,168 350,142 362,168"/>
+  </g>
+  <!-- Faint glow behind distant shards — mysterious, beckoning -->
+  <radialGradient id="horizon-mystery" cx="80%" cy="68%" r="25%">
+    <stop offset="0%" stop-color="#401060" stop-opacity="0.2"/>
+    <stop offset="100%" stop-color="#401060" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#horizon-mystery)"/>
+
+  <!-- Stars -->
+  <g fill="#2a3050" opacity="0.4">
+    <circle cx="30"  cy="20" r="1"/>
+    <circle cx="80"  cy="12" r="1.5"/>
+    <circle cx="150" cy="30" r="1"/>
+    <circle cx="210" cy="15" r="1.5"/>
+    <circle cx="290" cy="25" r="1"/>
+    <circle cx="350" cy="10" r="1.5"/>
+    <circle cx="390" cy="35" r="1"/>
+  </g>
+
+  <!-- Bioluminescent sea behind, fading -->
+  <g fill="#004858" opacity="0.2">
+    <circle cx="240" cy="175" r="2"/>
+    <circle cx="280" cy="180" r="1.5"/>
+    <circle cx="320" cy="175" r="2"/>
+    <circle cx="360" cy="180" r="1.5"/>
+  </g>
+
+  <!-- Label -->
+  <text x="200" y="232" font-family="monospace" font-size="9" fill="#1a4040" text-anchor="middle" letter-spacing="3">ONWARD</text>
+</svg>

--- a/web/public/cutscenes/act6-intro-1.svg
+++ b/web/public/cutscenes/act6-intro-1.svg
@@ -1,0 +1,130 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#06091a"/>
+
+  <!-- Sky gradient — high altitude blues -->
+  <linearGradient id="sky6" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#08102a"/>
+    <stop offset="50%" stop-color="#0c1c3a"/>
+    <stop offset="100%" stop-color="#102040"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#sky6)"/>
+
+  <!-- Cloud layer — below the islands -->
+  <g fill="#141e30" opacity="0.7">
+    <ellipse cx="60"  cy="220" rx="70" ry="22"/>
+    <ellipse cx="200" cy="225" rx="90" ry="20"/>
+    <ellipse cx="340" cy="218" rx="75" ry="24"/>
+    <ellipse cx="130" cy="215" rx="55" ry="18"/>
+    <ellipse cx="270" cy="220" rx="60" ry="20"/>
+  </g>
+  <!-- Cloud highlights -->
+  <g fill="#1e2c48" opacity="0.4">
+    <ellipse cx="60"  cy="214" rx="55" ry="12"/>
+    <ellipse cx="200" cy="218" rx="70" ry="12"/>
+    <ellipse cx="340" cy="212" rx="60" ry="14"/>
+  </g>
+
+  <!-- FLOATING ISLANDS -->
+  <!-- Island 1 — large, centre, main platform -->
+  <g>
+    <!-- Underside — rocky, jagged -->
+    <polygon points="120,140 280,130 300,155 240,165 200,170 160,168 100,160" fill="#0a1020" stroke="#162030" stroke-width="1"/>
+    <!-- Dirt/rock underside detail -->
+    <g fill="#0e1828" stroke="#182838" stroke-width="0.5">
+      <polygon points="140,145 160,138 165,155 145,158"/>
+      <polygon points="200,135 220,130 225,150 205,155"/>
+      <polygon points="255,138 275,132 278,155 258,160"/>
+    </g>
+    <!-- Top surface — grass/rock -->
+    <polygon points="120,140 280,130 290,135 280,142 120,150 110,145" fill="#101e18" stroke="#1a2e22" stroke-width="1"/>
+    <!-- Grass tufts -->
+    <g stroke="#1e3828" stroke-width="1.5" fill="none">
+      <path d="M140,140 Q138,133 136,127"/>
+      <path d="M160,138 Q158,131 156,125"/>
+      <path d="M200,133 Q198,126 196,120"/>
+      <path d="M240,132 Q238,125 236,119"/>
+      <path d="M260,134 Q258,127 256,121"/>
+    </g>
+    <!-- Buildings on main island — military towers -->
+    <rect x="175" y="115" width="10" height="25" fill="#0e1828" stroke="#182838" stroke-width="1"/>
+    <rect x="210" y="118" width="10" height="22" fill="#0e1828" stroke="#182838" stroke-width="1"/>
+    <!-- Tower battlements -->
+    <g fill="#141e2c" stroke="#182838" stroke-width="0.5">
+      <rect x="175" y="110" width="4" height="7"/>
+      <rect x="181" y="110" width="4" height="7"/>
+      <rect x="210" y="113" width="4" height="7"/>
+      <rect x="216" y="113" width="4" height="7"/>
+    </g>
+    <!-- Banner on main tower -->
+    <line x1="180" y1="110" x2="180" y2="90" stroke="#1e2838" stroke-width="1.5"/>
+    <polygon points="180,90 205,97 180,104" fill="#182038" stroke="#283050" stroke-width="0.8"/>
+    <!-- Wind symbol on banner -->
+    <path d="M186,95 Q193,98 186,101" stroke="#3040a0" stroke-width="1" fill="none" opacity="0.7"/>
+  </g>
+
+  <!-- Island 2 — smaller, upper left, connected by rope bridge -->
+  <g>
+    <polygon points="20,85 105,78 115,95 80,102 20,100" fill="#0a1020" stroke="#162030" stroke-width="1"/>
+    <polygon points="20,85 105,78 108,82 20,90" fill="#101e18" stroke="#1a2e22" stroke-width="1"/>
+    <!-- Small watchtower -->
+    <rect x="55" y="72" width="8" height="16" fill="#0e1828" stroke="#182838" stroke-width="0.8"/>
+    <rect x="54" y="69" width="4" height="5" fill="#141e2c"/>
+    <rect x="59" y="69" width="4" height="5" fill="#141e2c"/>
+  </g>
+
+  <!-- Island 3 — right, medium -->
+  <g>
+    <polygon points="295,100 380,93 390,115 350,120 295,118" fill="#0a1020" stroke="#162030" stroke-width="1"/>
+    <polygon points="295,100 380,93 382,98 295,108" fill="#101e18" stroke="#1a2e22" stroke-width="1"/>
+    <!-- Landing platform -->
+    <rect x="330" y="88" width="35" height="6" fill="#141e28" stroke="#1e2e38" stroke-width="0.8"/>
+  </g>
+
+  <!-- Rope bridges connecting islands -->
+  <!-- Bridge from island 2 to island 1 -->
+  <g stroke="#1e2838" stroke-width="1" fill="none" opacity="0.7">
+    <path d="M105,90 Q112,105 120,140"/>
+    <path d="M108,90 Q116,106 124,140"/>
+    <!-- Rope rungs -->
+    <line x1="107" y1="100" x2="113" y2="101"/>
+    <line x1="109" y1="112" x2="116" y2="114"/>
+    <line x1="112" y1="124" x2="120" y2="127"/>
+  </g>
+  <!-- Bridge from island 1 to island 3 -->
+  <g stroke="#1e2838" stroke-width="1" fill="none" opacity="0.7">
+    <path d="M280,132 Q287,118 295,108"/>
+    <path d="M283,132 Q290,118 298,108"/>
+    <line x1="282" y1="124" x2="289" y2="120"/>
+    <line x1="284" y1="116" x2="291" y2="112"/>
+  </g>
+
+  <!-- Storm clouds in the distance — gathering -->
+  <g fill="#0e1628" opacity="0.5">
+    <ellipse cx="320" cy="55" rx="50" ry="22"/>
+    <ellipse cx="350" cy="45" rx="40" ry="18"/>
+    <ellipse cx="295" cy="50" rx="35" ry="16"/>
+  </g>
+  <!-- Lightning bolt in storm cloud -->
+  <g stroke="#c0c020" stroke-width="1.5" fill="none" opacity="0.6">
+    <path d="M330,48 L325,60 L332,60 L327,72"/>
+  </g>
+
+  <!-- Sky birds / flying units silhouettes -->
+  <g fill="#1a2840" opacity="0.5">
+    <path d="M150,55 Q155,50 160,55 Q155,52 150,55"/>
+    <path d="M230,40 Q236,35 242,40 Q236,37 230,40"/>
+    <path d="M80,40  Q85,35 90,40 Q85,37 80,40"/>
+  </g>
+
+  <!-- Stars -->
+  <g fill="#2a3860" opacity="0.4">
+    <circle cx="40"  cy="20" r="1"/>
+    <circle cx="110" cy="12" r="1.5"/>
+    <circle cx="180" cy="25" r="1"/>
+    <circle cx="270" cy="15" r="1.5"/>
+    <circle cx="380" cy="20" r="1"/>
+  </g>
+
+  <!-- Label -->
+  <text x="200" y="232" font-family="monospace" font-size="9" fill="#1e2e50" text-anchor="middle" letter-spacing="3">THE SKY DOMINION</text>
+</svg>

--- a/web/public/cutscenes/act6-intro-2.svg
+++ b/web/public/cutscenes/act6-intro-2.svg
@@ -1,0 +1,129 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#06091a"/>
+
+  <linearGradient id="cm-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#080f20"/>
+    <stop offset="100%" stop-color="#101828"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#cm-sky)"/>
+
+  <!-- Storm atmosphere — her domain -->
+  <radialGradient id="storm-glow" cx="50%" cy="40%" r="50%">
+    <stop offset="0%" stop-color="#203060" stop-opacity="0.35"/>
+    <stop offset="100%" stop-color="#203060" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#storm-glow)"/>
+
+  <!-- Ground — floating island platform she stands on -->
+  <polygon points="100,195 300,185 310,205 90,210" fill="#0a1020" stroke="#162030" stroke-width="1.5"/>
+  <polygon points="100,195 300,185 302,190 100,202" fill="#101e18" stroke="#1a2e22" stroke-width="1"/>
+  <!-- Platform edge glow — electricity in the stone -->
+  <path d="M100,195 Q200,185 300,185" stroke="#3040a0" stroke-width="0.8" fill="none" opacity="0.4"/>
+
+  <!-- Shadow -->
+  <ellipse cx="200" cy="202" rx="40" ry="8" fill="#050810" opacity="0.7"/>
+
+  <!-- THE CLOUDMARSHAL — commanding figure, robed in storm-grey, holding a staff -->
+  <!-- Boots -->
+  <ellipse cx="190" cy="207" rx="7" ry="3" fill="#0a0c18"/>
+  <ellipse cx="212" cy="205" rx="7" ry="3" fill="#0a0c18"/>
+  <!-- Legs -->
+  <line x1="192" y1="194" x2="190" y2="207" stroke="#101828" stroke-width="4" stroke-linecap="round"/>
+  <line x1="206" y1="192" x2="212" y2="205" stroke="#101828" stroke-width="4" stroke-linecap="round"/>
+
+  <!-- Uniform / coat — military, storm-grey -->
+  <polygon points="178,155 222,155 228,194 172,194" fill="#181c28" stroke="#242c40" stroke-width="1"/>
+  <!-- Coat epaulettes -->
+  <ellipse cx="180" cy="157" rx="10" ry="5" fill="#2030a0" opacity="0.7"/>
+  <ellipse cx="220" cy="157" rx="10" ry="5" fill="#2030a0" opacity="0.7"/>
+  <!-- Gold braiding on uniform -->
+  <g stroke="#806020" stroke-width="1.5" opacity="0.6">
+    <path d="M183,162 Q200,165 217,162"/>
+    <path d="M182,170 Q200,173 218,170"/>
+    <path d="M181,178 Q200,181 219,178"/>
+  </g>
+  <!-- Medals on chest -->
+  <g fill="#806020" opacity="0.7">
+    <circle cx="190" cy="168" r="3"/>
+    <circle cx="196" cy="165" r="2.5"/>
+    <circle cx="202" cy="163" r="2.5"/>
+    <circle cx="208" cy="165" r="2.5"/>
+    <circle cx="214" cy="168" r="3"/>
+  </g>
+
+  <!-- Head — stern face, commanding -->
+  <ellipse cx="200" cy="143" rx="14" ry="13" fill="#141c28" stroke="#202838" stroke-width="1"/>
+  <!-- Hair / military cap -->
+  <rect x="186" y="130" width="28" height="10" rx="2" fill="#0e1420" stroke="#1a2030" stroke-width="1"/>
+  <!-- Cap brim -->
+  <rect x="182" y="138" width="36" height="4" rx="1" fill="#0c1018" stroke="#182028" stroke-width="0.8"/>
+  <!-- Cap badge — lightning bolt -->
+  <g fill="#c0c020" opacity="0.7">
+    <polygon points="198,133 202,133 200,137 204,137 198,142 200,138 196,138"/>
+  </g>
+  <!-- Face -->
+  <line x1="192" y1="148" x2="198" y2="147" stroke="#283848" stroke-width="1.5"/>
+  <line x1="202" y1="147" x2="208" y2="148" stroke="#283848" stroke-width="1.5"/>
+  <!-- Eyes — sharp, assessing -->
+  <line x1="192" y1="143" x2="197" y2="143" stroke="#8090c0" stroke-width="1.5" opacity="0.8"/>
+  <line x1="203" y1="143" x2="208" y2="143" stroke="#8090c0" stroke-width="1.5" opacity="0.8"/>
+
+  <!-- Left arm — gauntleted, pointing to the side -->
+  <line x1="178" y1="165" x2="155" y2="172" stroke="#181c28" stroke-width="4" stroke-linecap="round"/>
+  <polygon points="148,168 160,166 162,178 150,180" fill="#1a2030" stroke="#242c40" stroke-width="0.8"/>
+
+  <!-- Right arm — holding Weather Staff -->
+  <line x1="222" y1="162" x2="245" y2="150" stroke="#181c28" stroke-width="4" stroke-linecap="round"/>
+  <!-- Staff -->
+  <line x1="245" y1="120" x2="245" y2="200" stroke="#202838" stroke-width="2.5"/>
+  <!-- Staff head — storm orb -->
+  <circle cx="245" cy="118" r="10" fill="#0e1428" stroke="#3040a0" stroke-width="1.5"/>
+  <!-- Storm orb glow -->
+  <radialGradient id="orb-glow" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#4060e0" stop-opacity="0.7"/>
+    <stop offset="100%" stop-color="#4060e0" stop-opacity="0"/>
+  </radialGradient>
+  <circle cx="245" cy="118" r="10" fill="url(#orb-glow)"/>
+  <circle cx="245" cy="118" r="4" fill="#2040c0" opacity="0.8"/>
+  <!-- Miniature lightning inside orb -->
+  <g stroke="#e0e060" stroke-width="0.8" opacity="0.6">
+    <path d="M243,112 L241,118 L245,118 L242,124"/>
+  </g>
+
+  <!-- Storm clouds swirling around her — she commands them -->
+  <!-- Left cloud -->
+  <g fill="#0e1828" opacity="0.6">
+    <ellipse cx="80"  cy="140" rx="45" ry="18"/>
+    <ellipse cx="55"  cy="130" rx="30" ry="14"/>
+    <ellipse cx="105" cy="132" rx="35" ry="16"/>
+  </g>
+  <!-- Right cloud -->
+  <g fill="#0e1828" opacity="0.6">
+    <ellipse cx="330" cy="135" rx="50" ry="20"/>
+    <ellipse cx="360" cy="125" rx="30" ry="14"/>
+    <ellipse cx="310" cy="128" rx="35" ry="16"/>
+  </g>
+
+  <!-- Lightning arcing from her staff to the clouds -->
+  <g stroke="#c0c820" stroke-width="1" fill="none" opacity="0.5">
+    <path d="M245,118 Q190,110 110,138"/>
+    <path d="M245,118 Q300,110 340,130"/>
+  </g>
+  <!-- Lightning sparks -->
+  <g stroke="#e0e060" stroke-width="0.8" opacity="0.4">
+    <path d="M108,135 L104,145 L110,145 L106,155"/>
+    <path d="M338,127 L334,137 L340,137 L336,147"/>
+  </g>
+
+  <!-- Stars in sky above -->
+  <g fill="#2a3860" opacity="0.4">
+    <circle cx="30"  cy="20" r="1"/>
+    <circle cx="100" cy="15" r="1.5"/>
+    <circle cx="300" cy="10" r="1.5"/>
+    <circle cx="370" cy="22" r="1"/>
+    <circle cx="180" cy="8"  r="1"/>
+  </g>
+
+  <!-- Label -->
+  <text x="200" y="232" font-family="monospace" font-size="9" fill="#1e2e50" text-anchor="middle" letter-spacing="3">THE CLOUDMARSHAL</text>
+</svg>

--- a/web/public/cutscenes/act6-intro-3.svg
+++ b/web/public/cutscenes/act6-intro-3.svg
@@ -1,0 +1,140 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#06091a"/>
+
+  <linearGradient id="ley6-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#080f20"/>
+    <stop offset="100%" stop-color="#0e1a30"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#ley6-sky)"/>
+
+  <!-- Thick cloud layer — the ley lines punch through it -->
+  <!-- Lower cloud bank -->
+  <g fill="#0c1520" opacity="0.8">
+    <ellipse cx="0"   cy="190" rx="80"  ry="30"/>
+    <ellipse cx="80"  cy="185" rx="70"  ry="28"/>
+    <ellipse cx="160" cy="188" rx="75"  ry="32"/>
+    <ellipse cx="240" cy="184" rx="70"  ry="28"/>
+    <ellipse cx="320" cy="188" rx="75"  ry="32"/>
+    <ellipse cx="400" cy="185" rx="80"  ry="30"/>
+  </g>
+  <g fill="#101c2c" opacity="0.5">
+    <ellipse cx="40"  cy="178" rx="60"  ry="20"/>
+    <ellipse cx="140" cy="175" rx="65"  ry="22"/>
+    <ellipse cx="260" cy="176" rx="65"  ry="22"/>
+    <ellipse cx="380" cy="178" rx="55"  ry="20"/>
+  </g>
+
+  <!-- Upper cloud wisps — just below the top islands -->
+  <g fill="#0c1520" opacity="0.4">
+    <ellipse cx="60"  cy="60" rx="50" ry="15"/>
+    <ellipse cx="340" cy="55" rx="55" ry="16"/>
+    <ellipse cx="200" cy="50" rx="45" ry="12"/>
+  </g>
+
+  <!-- THE LEY LINE COLUMNS — crackling vertical energy rising up through the clouds -->
+  <!-- Left ley column -->
+  <g opacity="0.8">
+    <!-- Column body — thick, crackling -->
+    <rect x="88" y="0" width="24" height="240" fill="#080c20" opacity="0.6"/>
+    <!-- Inner core glow -->
+    <linearGradient id="ley-col-l" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#40a0e0" stop-opacity="0.8"/>
+      <stop offset="50%" stop-color="#2060c0" stop-opacity="0.6"/>
+      <stop offset="100%" stop-color="#40a0e0" stop-opacity="0.8"/>
+    </linearGradient>
+    <rect x="96" y="0" width="8" height="240" fill="url(#ley-col-l)"/>
+    <!-- Crackling discharge sparks on left column -->
+    <g stroke="#80c0ff" stroke-width="0.8" fill="none" opacity="0.6">
+      <path d="M96,40  L90,52  L98,52  L92,64"/>
+      <path d="M104,90  L110,102 L102,102 L108,114"/>
+      <path d="M96,145 L90,157 L98,157 L92,169"/>
+    </g>
+    <!-- Outer glow -->
+    <radialGradient id="ley-glow-l" cx="50%" cy="50%" r="50%" gradientUnits="userSpaceOnUse" cx="100" cy="120" r="30">
+      <stop offset="0%" stop-color="#2060c0" stop-opacity="0.3"/>
+      <stop offset="100%" stop-color="#2060c0" stop-opacity="0"/>
+    </radialGradient>
+    <rect x="70" y="0" width="60" height="240" fill="url(#ley-glow-l)" opacity="0.4"/>
+  </g>
+
+  <!-- Centre ley column — strongest -->
+  <g opacity="0.9">
+    <rect x="188" y="0" width="24" height="240" fill="#080c20" opacity="0.6"/>
+    <linearGradient id="ley-col-c" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#60c0ff" stop-opacity="0.9"/>
+      <stop offset="40%" stop-color="#3080e0" stop-opacity="0.7"/>
+      <stop offset="100%" stop-color="#60c0ff" stop-opacity="0.9"/>
+    </linearGradient>
+    <rect x="196" y="0" width="8" height="240" fill="url(#ley-col-c)"/>
+    <g stroke="#a0d8ff" stroke-width="1" fill="none" opacity="0.7">
+      <path d="M196,30  L190,44  L198,44  L192,58"/>
+      <path d="M204,75  L210,89  L202,89  L208,103"/>
+      <path d="M196,130 L190,144 L198,144 L192,158"/>
+      <path d="M204,175 L210,189 L202,189 L208,203"/>
+    </g>
+    <radialGradient id="ley-glow-c" gradientUnits="userSpaceOnUse" cx="200" cy="120" r="40">
+      <stop offset="0%" stop-color="#3080e0" stop-opacity="0.35"/>
+      <stop offset="100%" stop-color="#3080e0" stop-opacity="0"/>
+    </radialGradient>
+    <rect x="160" y="0" width="80" height="240" fill="url(#ley-glow-c)" opacity="0.4"/>
+  </g>
+
+  <!-- Right ley column -->
+  <g opacity="0.8">
+    <rect x="288" y="0" width="24" height="240" fill="#080c20" opacity="0.6"/>
+    <linearGradient id="ley-col-r" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#40a0e0" stop-opacity="0.8"/>
+      <stop offset="50%" stop-color="#2060c0" stop-opacity="0.6"/>
+      <stop offset="100%" stop-color="#40a0e0" stop-opacity="0.8"/>
+    </linearGradient>
+    <rect x="296" y="0" width="8" height="240" fill="url(#ley-col-r)"/>
+    <g stroke="#80c0ff" stroke-width="0.8" fill="none" opacity="0.6">
+      <path d="M296,55  L290,67  L298,67  L292,79"/>
+      <path d="M304,110 L310,122 L302,122 L308,134"/>
+      <path d="M296,165 L290,177 L298,177 L292,189"/>
+    </g>
+    <radialGradient id="ley-glow-r" gradientUnits="userSpaceOnUse" cx="300" cy="120" r="30">
+      <stop offset="0%" stop-color="#2060c0" stop-opacity="0.3"/>
+      <stop offset="100%" stop-color="#2060c0" stop-opacity="0"/>
+    </radialGradient>
+    <rect x="270" y="0" width="60" height="240" fill="url(#ley-glow-r)" opacity="0.4"/>
+  </g>
+
+  <!-- Island platforms where ley lines connect — top anchors -->
+  <!-- Left island top anchor -->
+  <rect x="78" y="50" width="44" height="10" rx="2" fill="#0e1828" stroke="#1a2838" stroke-width="1"/>
+  <radialGradient id="anchor-l" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#3080e0" stop-opacity="0.5"/>
+    <stop offset="100%" stop-color="#3080e0" stop-opacity="0"/>
+  </radialGradient>
+  <rect x="78" y="50" width="44" height="10" rx="2" fill="url(#anchor-l)"/>
+
+  <!-- Centre island top anchor -->
+  <rect x="178" y="38" width="44" height="10" rx="2" fill="#0e1828" stroke="#1a2838" stroke-width="1"/>
+  <rect x="178" y="38" width="44" height="10" rx="2" fill="url(#anchor-l)" opacity="1.2"/>
+
+  <!-- Right island top anchor -->
+  <rect x="278" y="46" width="44" height="10" rx="2" fill="#0e1828" stroke="#1a2838" stroke-width="1"/>
+  <rect x="278" y="46" width="44" height="10" rx="2" fill="url(#anchor-l)"/>
+
+  <!-- Horizontal ley bridge connecting the columns — the bridge Jarv must cross -->
+  <!-- Bridge platform floating on ley energy -->
+  <rect x="100" y="115" width="100" height="8" fill="#0c1428" stroke="#1a2848" stroke-width="1"/>
+  <rect x="200" y="112" width="100" height="8" fill="#0c1428" stroke="#1a2848" stroke-width="1"/>
+  <!-- Bridge glow -->
+  <rect x="100" y="115" width="100" height="8" fill="url(#ley-glow-c)" opacity="0.6"/>
+  <rect x="200" y="112" width="100" height="8" fill="url(#ley-glow-c)" opacity="0.6"/>
+
+  <!-- Stars -->
+  <g fill="#1a2848" opacity="0.4">
+    <circle cx="30"  cy="20" r="1"/>
+    <circle cx="150" cy="15" r="1"/>
+    <circle cx="250" cy="22" r="1.5"/>
+    <circle cx="370" cy="18" r="1"/>
+    <circle cx="50"  cy="38" r="1"/>
+    <circle cx="355" cy="35" r="1"/>
+  </g>
+
+  <!-- Label -->
+  <text x="200" y="232" font-family="monospace" font-size="9" fill="#1e2e50" text-anchor="middle" letter-spacing="3">THE LEY BRIDGE</text>
+</svg>

--- a/web/public/cutscenes/act6-outro-1.svg
+++ b/web/public/cutscenes/act6-outro-1.svg
@@ -1,0 +1,100 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#06091a"/>
+
+  <linearGradient id="calm-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#080e1e"/>
+    <stop offset="100%" stop-color="#0e1828"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#calm-sky)"/>
+
+  <!-- Fading storm — the energy dissipating -->
+  <radialGradient id="calm-glow" cx="50%" cy="40%" r="50%">
+    <stop offset="0%" stop-color="#101830" stop-opacity="0.3"/>
+    <stop offset="100%" stop-color="#101830" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#calm-glow)"/>
+
+  <!-- Island platform — the confrontation site -->
+  <polygon points="80,195 320,185 330,205 70,210" fill="#0a1020" stroke="#162030" stroke-width="1.5"/>
+  <polygon points="80,195 320,185 322,190 80,202" fill="#101e18" stroke="#1a2e22" stroke-width="1"/>
+
+  <!-- THE CLOUDMARSHAL — standing, staff lowered, head bowed slightly — conceding -->
+  <ellipse cx="200" cy="204" rx="35" ry="7" fill="#050810" opacity="0.7"/>
+
+  <!-- Boots -->
+  <ellipse cx="191" cy="208" rx="7" ry="3" fill="#0a0c18"/>
+  <ellipse cx="211" cy="207" rx="7" ry="3" fill="#0a0c18"/>
+  <!-- Legs -->
+  <line x1="193" y1="195" x2="191" y2="208" stroke="#101828" stroke-width="4" stroke-linecap="round"/>
+  <line x1="207" y1="194" x2="211" y2="207" stroke="#101828" stroke-width="4" stroke-linecap="round"/>
+
+  <!-- Uniform — slightly ragged, battle-worn -->
+  <polygon points="181,158 219,158 224,195 176,195" fill="#181c28" stroke="#242c40" stroke-width="1"/>
+  <!-- Epaulettes — dimmer now -->
+  <ellipse cx="183" cy="160" rx="9" ry="4" fill="#182080" opacity="0.5"/>
+  <ellipse cx="217" cy="160" rx="9" ry="4" fill="#182080" opacity="0.5"/>
+
+  <!-- Head — bowed forward slightly, hat still on -->
+  <ellipse cx="200" cy="146" rx="13" ry="12" fill="#141c28" stroke="#202838" stroke-width="1"/>
+  <rect x="187" y="134" width="26" height="9"  rx="2" fill="#0e1420" stroke="#1a2030" stroke-width="1"/>
+  <rect x="183" y="141" width="34" height="4"  rx="1" fill="#0c1018" stroke="#182028" stroke-width="0.8"/>
+  <!-- Cap badge — lightning bolt, but dimmed -->
+  <g fill="#604010" opacity="0.5">
+    <polygon points="198,136 202,136 200,140 204,140 198,145 200,141 196,141"/>
+  </g>
+  <!-- Face — eyes down, stern but accepting -->
+  <line x1="192" y1="151" x2="197" y2="150" stroke="#283848" stroke-width="1.5"/>
+  <line x1="203" y1="150" x2="208" y2="151" stroke="#283848" stroke-width="1.5"/>
+
+  <!-- Left arm — at side, fist clenched (the concession is not easy) -->
+  <line x1="181" y1="167" x2="170" y2="180" stroke="#181c28" stroke-width="4" stroke-linecap="round"/>
+  <polygon points="163,176 173,174 175,186 165,188" fill="#1a2030" stroke="#242c40" stroke-width="0.8"/>
+
+  <!-- Right arm — staff planted in ground, lowered -->
+  <line x1="219" y1="165" x2="235" y2="178" stroke="#181c28" stroke-width="4" stroke-linecap="round"/>
+  <!-- Staff — tip touching the ground, no longer raised in command -->
+  <line x1="235" y1="178" x2="235" y2="205" stroke="#202838" stroke-width="2.5"/>
+  <!-- Staff orb — dark, energy spent -->
+  <circle cx="235" cy="173" r="9" fill="#0a1020" stroke="#1a2838" stroke-width="1.5"/>
+  <circle cx="235" cy="173" r="4" fill="#0e1428" opacity="0.7"/>
+  <!-- Just a dying flicker in the orb -->
+  <circle cx="235" cy="173" r="2" fill="#2040a0" opacity="0.3"/>
+
+  <!-- Storm clouds — breaking apart, calming -->
+  <g fill="#0c1420" opacity="0.4">
+    <ellipse cx="70"  cy="100" rx="55" ry="22"/>
+    <ellipse cx="50"  cy="88"  rx="35" ry="16"/>
+    <ellipse cx="100" cy="92"  rx="40" ry="18"/>
+  </g>
+  <g fill="#0c1420" opacity="0.35">
+    <ellipse cx="330" cy="95" rx="55" ry="22"/>
+    <ellipse cx="355" cy="83" rx="35" ry="15"/>
+    <ellipse cx="310" cy="88" rx="38" ry="18"/>
+  </g>
+  <!-- Storm lightning — last discharge, fading -->
+  <g stroke="#8090a0" stroke-width="0.8" opacity="0.2">
+    <path d="M60,88  L56,100 L62,100 L58,112"/>
+    <path d="M340,82 L336,94 L342,94 L338,106"/>
+  </g>
+
+  <!-- Calm rays through breaking clouds — light returning -->
+  <g stroke="#1a2840" stroke-width="2" opacity="0.2">
+    <line x1="200" y1="0"   x2="80"  y2="185"/>
+    <line x1="200" y1="0"   x2="200" y2="185"/>
+    <line x1="200" y1="0"   x2="320" y2="185"/>
+    <line x1="200" y1="0"   x2="130" y2="185"/>
+    <line x1="200" y1="0"   x2="270" y2="185"/>
+  </g>
+
+  <!-- Stars returning as storm clears -->
+  <g fill="#2a3860" opacity="0.5">
+    <circle cx="40"  cy="18" r="1.5"/>
+    <circle cx="120" cy="10" r="1"/>
+    <circle cx="280" cy="12" r="1.5"/>
+    <circle cx="360" cy="20" r="1"/>
+    <circle cx="180" cy="6"  r="1"/>
+  </g>
+
+  <!-- Label -->
+  <text x="200" y="232" font-family="monospace" font-size="9" fill="#1e2e50" text-anchor="middle" letter-spacing="3">THE CLOUDMARSHAL FALLS</text>
+</svg>

--- a/web/public/cutscenes/act6-outro-2.svg
+++ b/web/public/cutscenes/act6-outro-2.svg
@@ -1,0 +1,112 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#06091a"/>
+
+  <linearGradient id="still-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#070c1c"/>
+    <stop offset="100%" stop-color="#0e1828"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#still-sky)"/>
+
+  <!-- Quiet clearing in the storm — stars visible, atmosphere calmed -->
+  <radialGradient id="still-glow" cx="50%" cy="30%" r="45%">
+    <stop offset="0%" stop-color="#0c1a38" stop-opacity="0.4"/>
+    <stop offset="100%" stop-color="#0c1a38" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#still-glow)"/>
+
+  <!-- Island platform — same site, now quiet -->
+  <polygon points="60,196 340,186 350,206 50,212" fill="#0a1020" stroke="#162030" stroke-width="1.5"/>
+  <polygon points="60,196 340,186 342,191 60,203" fill="#101e18" stroke="#1a2e22" stroke-width="1"/>
+
+  <!-- THE CLOUDMARSHAL — left side, turned slightly toward Jarv, staff still planted -->
+  <ellipse cx="135" cy="204" rx="28" ry="6" fill="#050810" opacity="0.6"/>
+  <!-- Boots -->
+  <ellipse cx="128" cy="208" rx="6" ry="2.5" fill="#0a0c18"/>
+  <ellipse cx="144" cy="207" rx="6" ry="2.5" fill="#0a0c18"/>
+  <!-- Legs -->
+  <line x1="130" y1="196" x2="128" y2="208" stroke="#101828" stroke-width="4" stroke-linecap="round"/>
+  <line x1="140" y1="195" x2="144" y2="207" stroke="#101828" stroke-width="4" stroke-linecap="round"/>
+  <!-- Uniform -->
+  <polygon points="120,162 150,162 155,196 115,196" fill="#181c28" stroke="#242c40" stroke-width="1"/>
+  <!-- Epaulettes — dimmed -->
+  <ellipse cx="122" cy="164" rx="8" ry="3.5" fill="#182080" opacity="0.4"/>
+  <ellipse cx="148" cy="164" rx="8" ry="3.5" fill="#182080" opacity="0.4"/>
+  <!-- Head — turned right, toward Jarv -->
+  <ellipse cx="137" cy="150" rx="11" ry="10" fill="#141c28" stroke="#202838" stroke-width="1"/>
+  <rect x="126" y="139" width="22" height="8" rx="2" fill="#0e1420" stroke="#1a2030" stroke-width="1"/>
+  <rect x="122" y="145" width="30" height="4" rx="1" fill="#0c1018" stroke="#182028" stroke-width="0.8"/>
+  <!-- Badge dimmed -->
+  <g fill="#504010" opacity="0.4">
+    <polygon points="135,141 139,141 137,145 141,145 135,149 137,145 133,145"/>
+  </g>
+  <!-- Eyes — open, level gaze at Jarv -->
+  <line x1="130" y1="153" x2="135" y2="152" stroke="#506080" stroke-width="1.5" opacity="0.8"/>
+  <line x1="139" y1="152" x2="144" y2="153" stroke="#506080" stroke-width="1.5" opacity="0.8"/>
+  <!-- Mouth — open slightly, speaking -->
+  <path d="M131,157 Q137,160 143,157" stroke="#283848" stroke-width="1" fill="none"/>
+  <!-- Left arm — at side -->
+  <line x1="120" y1="170" x2="110" y2="182" stroke="#181c28" stroke-width="4" stroke-linecap="round"/>
+  <polygon points="104,178 114,177 115,188 105,189" fill="#1a2030" stroke="#242c40" stroke-width="0.8"/>
+  <!-- Right arm — gesturing toward Jarv, speaking -->
+  <line x1="150" y1="168" x2="163" y2="175" stroke="#181c28" stroke-width="4" stroke-linecap="round"/>
+  <polygon points="158,171 168,169 170,180 160,182" fill="#1a2030" stroke="#242c40" stroke-width="0.8"/>
+  <!-- Staff — planted, leaning slightly away -->
+  <line x1="117" y1="178" x2="113" y2="205" stroke="#202838" stroke-width="2.5"/>
+  <!-- Staff orb — dark, spent -->
+  <circle cx="113" cy="173" r="7" fill="#0a1020" stroke="#1a2838" stroke-width="1.5"/>
+  <circle cx="113" cy="173" r="3" fill="#0e1428" opacity="0.5"/>
+
+  <!-- JARV — right side, facing the Cloudmarshal, listening -->
+  <ellipse cx="270" cy="205" rx="25" ry="5" fill="#050810" opacity="0.6"/>
+  <!-- Boots -->
+  <ellipse cx="263" cy="209" rx="6" ry="2.5" fill="#08090e"/>
+  <ellipse cx="278" cy="208" rx="6" ry="2.5" fill="#08090e"/>
+  <!-- Legs -->
+  <line x1="265" y1="198" x2="263" y2="209" stroke="#0c0c18" stroke-width="4" stroke-linecap="round"/>
+  <line x1="274" y1="197" x2="278" y2="208" stroke="#0c0c18" stroke-width="4" stroke-linecap="round"/>
+  <!-- Coral mantle — draped, teal edge glow -->
+  <polygon points="250,173 290,173 295,198 245,198" fill="#0a1e20" stroke="#1a4040" stroke-width="1.5"/>
+  <g fill="#00c090" opacity="0.5">
+    <circle cx="245" cy="173" r="1.5"/>
+    <circle cx="243" cy="182" r="1.2"/>
+    <circle cx="295" cy="173" r="1.5"/>
+    <circle cx="297" cy="182" r="1.2"/>
+  </g>
+  <!-- Hood / head — turned left toward Cloudmarshal -->
+  <ellipse cx="268" cy="164" rx="11" ry="9" fill="#0c0c1a" stroke="#181830" stroke-width="1"/>
+  <ellipse cx="266" cy="167" rx="6" ry="4" fill="#080810"/>
+  <!-- Iron Standard — resting, held loosely at side -->
+  <line x1="288" y1="180" x2="308" y2="165" stroke="#181830" stroke-width="3" stroke-linecap="round"/>
+  <line x1="308" y1="140" x2="308" y2="210" stroke="#2a3040" stroke-width="2.5"/>
+  <polygon points="306,140 310,140 308,131" fill="#404860"/>
+
+  <!-- Speech indicator — subtle arc above Cloudmarshal, implying speech -->
+  <g stroke="#2a3850" stroke-width="0.8" fill="none" opacity="0.6">
+    <path d="M145,142 Q165,128 175,135 Q165,138 160,145 Z"/>
+  </g>
+  <g fill="#1e3050" opacity="0.7">
+    <circle cx="158" cy="135" r="1.5"/>
+    <circle cx="165" cy="131" r="1.2"/>
+    <circle cx="172" cy="133" r="1"/>
+  </g>
+
+  <!-- Remaining storm wisps — high above, dissipating -->
+  <g fill="#0c1420" opacity="0.25">
+    <ellipse cx="80"  cy="60" rx="60" ry="18"/>
+    <ellipse cx="320" cy="55" rx="55" ry="16"/>
+  </g>
+
+  <!-- Stars — clear sky returning -->
+  <g fill="#2a3860" opacity="0.55">
+    <circle cx="40"  cy="18" r="1.5"/>
+    <circle cx="110" cy="10" r="1"/>
+    <circle cx="200" cy="14" r="1.5"/>
+    <circle cx="290" cy="8"  r="1"/>
+    <circle cx="365" cy="20" r="1.5"/>
+    <circle cx="170" cy="30" r="1"/>
+    <circle cx="340" cy="35" r="1"/>
+  </g>
+
+  <!-- Label -->
+  <text x="200" y="232" font-family="monospace" font-size="9" fill="#1e2e50" text-anchor="middle" letter-spacing="3">WHAT SHE SAID</text>
+</svg>

--- a/web/public/cutscenes/act6-outro-3.svg
+++ b/web/public/cutscenes/act6-outro-3.svg
@@ -1,0 +1,115 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#05081a"/>
+
+  <linearGradient id="ascent-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#06091e"/>
+    <stop offset="50%" stop-color="#0a1428"/>
+    <stop offset="100%" stop-color="#0c1830"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#ascent-sky)"/>
+
+  <!-- Rising light — breakthrough above clouds -->
+  <radialGradient id="ascent-light" cx="50%" cy="15%" r="40%">
+    <stop offset="0%" stop-color="#2050c0" stop-opacity="0.3"/>
+    <stop offset="60%" stop-color="#1030a0" stop-opacity="0.1"/>
+    <stop offset="100%" stop-color="#1030a0" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#ascent-light)"/>
+
+  <!-- THE STORMCALLER'S BADGE — floating, radiating energy, centre-frame -->
+  <!-- Badge outer ring — electrified -->
+  <circle cx="200" cy="90" r="38" fill="none" stroke="#2040a0" stroke-width="1" opacity="0.4"/>
+  <circle cx="200" cy="90" r="34" fill="none" stroke="#3060d0" stroke-width="0.8" opacity="0.6"/>
+  <!-- Badge body — hexagonal storm motif -->
+  <polygon points="200,56 228,73 228,107 200,124 172,107 172,73" fill="#080e20" stroke="#2848a0" stroke-width="1.5"/>
+  <!-- Badge inner glow -->
+  <radialGradient id="badge-glow" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#304090" stop-opacity="0.5"/>
+    <stop offset="60%" stop-color="#203080" stop-opacity="0.2"/>
+    <stop offset="100%" stop-color="#203080" stop-opacity="0"/>
+  </radialGradient>
+  <polygon points="200,56 228,73 228,107 200,124 172,107 172,73" fill="url(#badge-glow)"/>
+  <!-- Central lightning motif on badge -->
+  <g fill="#90a8e0" opacity="0.9">
+    <polygon points="200,66 206,66 200,84 210,84 196,114 200,92 190,92"/>
+  </g>
+  <!-- Badge ring dots — rank indicators -->
+  <g fill="#4060c0" opacity="0.7">
+    <circle cx="200" cy="59" r="2.5"/>
+    <circle cx="225" cy="74" r="2.5"/>
+    <circle cx="225" cy="106" r="2.5"/>
+    <circle cx="200" cy="121" r="2.5"/>
+    <circle cx="175" cy="106" r="2.5"/>
+    <circle cx="175" cy="74" r="2.5"/>
+  </g>
+  <!-- Electric arc discharge from badge -->
+  <g stroke="#80a8ff" stroke-width="0.8" fill="none" opacity="0.5">
+    <path d="M200,56 L196,44 L202,44 L198,36"/>
+    <path d="M228,73 L240,66 L238,72 L250,68"/>
+    <path d="M172,73 L160,66 L162,72 L150,68"/>
+  </g>
+
+  <!-- JARV — below the badge, arms raised receiving it — ascending pose -->
+  <ellipse cx="200" cy="215" rx="24" ry="5" fill="#050608" opacity="0.6"/>
+  <!-- Boots -->
+  <ellipse cx="193" cy="218" rx="5" ry="2" fill="#08090e"/>
+  <ellipse cx="207" cy="218" rx="5" ry="2" fill="#08090e"/>
+  <!-- Legs -->
+  <line x1="195" y1="207" x2="193" y2="218" stroke="#0c0c18" stroke-width="4" stroke-linecap="round"/>
+  <line x1="204" y1="207" x2="207" y2="218" stroke="#0c0c18" stroke-width="4" stroke-linecap="round"/>
+  <!-- Coral mantle — flowing upward at edges, arms raised push it back -->
+  <polygon points="181,178 219,178 224,207 176,207" fill="#0a1e20" stroke="#1a4040" stroke-width="1.5"/>
+  <g fill="#00c090" opacity="0.55">
+    <circle cx="176" cy="178" r="1.5"/>
+    <circle cx="174" cy="187" r="1.2"/>
+    <circle cx="224" cy="178" r="1.5"/>
+    <circle cx="226" cy="187" r="1.2"/>
+  </g>
+  <!-- Arms raised — reaching up toward badge -->
+  <line x1="181" y1="185" x2="162" y2="160" stroke="#0c0c18" stroke-width="4" stroke-linecap="round"/>
+  <line x1="219" y1="185" x2="238" y2="160" stroke="#0c0c18" stroke-width="4" stroke-linecap="round"/>
+  <!-- Hands open, reaching -->
+  <polygon points="156,155 166,153 168,165 158,167" fill="#0d0e1a" stroke="#181830" stroke-width="0.8"/>
+  <polygon points="234,155 244,153 246,165 236,167" fill="#0d0e1a" stroke="#181830" stroke-width="0.8"/>
+  <!-- Head — tilted up toward badge -->
+  <ellipse cx="200" cy="169" rx="11" ry="9" fill="#0c0c1a" stroke="#181830" stroke-width="1"/>
+  <ellipse cx="200" cy="172" rx="6" ry="4" fill="#080810"/>
+
+  <!-- Energy transfer beam — badge to Jarv's hands -->
+  <g stroke="#4060c0" stroke-width="1" fill="none" opacity="0.4">
+    <path d="M172,107 Q166,130 162,160"/>
+    <path d="M228,107 Q234,130 238,160"/>
+  </g>
+
+  <!-- Iron Standard — leaning against invisible wall, temporarily set down -->
+  <line x1="300" y1="170" x2="320" y2="220" stroke="#2a3040" stroke-width="2.5"/>
+  <polygon points="298,170 302,170 300,161" fill="#404860" opacity="0.8"/>
+
+  <!-- Cloud layer far below — they are above it now -->
+  <g fill="#0a1220" opacity="0.5">
+    <ellipse cx="0"   cy="230" rx="80"  ry="20"/>
+    <ellipse cx="100" cy="228" rx="80"  ry="18"/>
+    <ellipse cx="200" cy="232" rx="90"  ry="22"/>
+    <ellipse cx="300" cy="228" rx="80"  ry="18"/>
+    <ellipse cx="400" cy="230" rx="80"  ry="20"/>
+  </g>
+
+  <!-- Stars — vivid, above the storm now -->
+  <g fill="#3050a0" opacity="0.7">
+    <circle cx="30"  cy="15" r="1.5"/>
+    <circle cx="80"  cy="8"  r="1"/>
+    <circle cx="140" cy="20" r="1.5"/>
+    <circle cx="260" cy="18" r="1.5"/>
+    <circle cx="320" cy="10" r="1"/>
+    <circle cx="375" cy="22" r="1.5"/>
+  </g>
+  <g fill="#6080c0" opacity="0.4">
+    <circle cx="55"  cy="40" r="1"/>
+    <circle cx="165" cy="35" r="1"/>
+    <circle cx="240" cy="42" r="1"/>
+    <circle cx="350" cy="38" r="1"/>
+  </g>
+
+  <!-- Label -->
+  <text x="200" y="238" font-family="monospace" font-size="9" fill="#1e2e50" text-anchor="middle" letter-spacing="3">HIGHER STILL</text>
+</svg>

--- a/web/src/data/acts/act5.json
+++ b/web/src/data/acts/act5.json
@@ -42,29 +42,35 @@
   "intro": [
     {
       "title": "THE SUNKEN REEF",
-      "text": "The shard hangs half-submerged — a lattice of coral, sunken ships, and old magic squeezed between two impossible tides.\n\nSomething large lives at its centre. Something old. The traders who escaped this shard don't talk about what they saw, but they all flinch at the same sounds: deep water, and bells."
+      "text": "The shard hangs half-submerged — a lattice of coral, sunken ships, and old magic squeezed between two impossible tides.\n\nSomething large lives at its centre. Something old. The traders who escaped this shard don't talk about what they saw, but they all flinch at the same sounds: deep water, and bells.",
+      "image": "cutscenes/act5-intro-1.svg"
     },
     {
       "title": "THE TIDAL SOVEREIGN",
-      "text": "The Reef's guardian calls itself the Tidal Sovereign — a being of compressed sea-memory and slow, grinding patience.\n\nIt does not distinguish between invaders and travellers. The ocean, it once said, does not distinguish between ships it sinks and ships it simply forgets about.\n\nYou have decided not to be forgotten."
+      "text": "The Reef's guardian calls itself the Tidal Sovereign — a being of compressed sea-memory and slow, grinding patience.\n\nIt does not distinguish between invaders and travellers. The ocean, it once said, does not distinguish between ships it sinks and ships it simply forgets about.\n\nYou have decided not to be forgotten.",
+      "image": "cutscenes/act5-intro-2.svg"
     },
     {
       "title": "THE PASSAGE",
-      "text": "The ley lines that thread through the Sunken Reef are old — older than the Fracture, older than the Dominion. They connect, somewhere in the deep, to the Fractured Core.\n\nIf you can break through the Sovereign's grip on the pathways, you might finally understand what the Fracture Event actually was.\n\nIf. The word is doing significant structural work in that sentence."
+      "text": "The ley lines that thread through the Sunken Reef are old — older than the Fracture, older than the Dominion. They connect, somewhere in the deep, to the Fractured Core.\n\nIf you can break through the Sovereign's grip on the pathways, you might finally understand what the Fracture Event actually was.\n\nIf. The word is doing significant structural work in that sentence.",
+      "image": "cutscenes/act5-intro-3.svg"
     }
   ],
   "outro": [
     {
       "title": "THE SOVEREIGN FALLS",
-      "text": "The Tidal Sovereign does not collapse. It recedes — like a wave pulling back from shore, leaving behind silence and the smell of deep ocean.\n\nThe coral pathways glow. Sealed ley lines crack open. The Reef's memory of the Fracture is vivid and specific and terrifying, and you carry it with you as you leave."
+      "text": "The Tidal Sovereign does not collapse. It recedes — like a wave pulling back from shore, leaving behind silence and the smell of deep ocean.\n\nThe coral pathways glow. Sealed ley lines crack open. The Reef's memory of the Fracture is vivid and specific and terrifying, and you carry it with you as you leave.",
+      "image": "cutscenes/act5-outro-1.svg"
     },
     {
       "title": "WHAT YOU LEARNED",
-      "text": "The Fracture Event wasn't an accident.\n\nSomeone caused it deliberately. The Sovereign remembered the moment, the direction, the specific signature of the magic. A weapon that destroyed an empire by tearing the world apart at its seams.\n\nYou don't have a name yet. You have a direction."
+      "text": "The Fracture Event wasn't an accident.\n\nSomeone caused it deliberately. The Sovereign remembered the moment, the direction, the specific signature of the magic. A weapon that destroyed an empire by tearing the world apart at its seams.\n\nYou don't have a name yet. You have a direction.",
+      "image": "cutscenes/act5-outro-2.svg"
     },
     {
       "title": "ONWARD",
-      "text": "The Coral Mantle settles around you — a gift from the Reef, or a remnant of the Sovereign's dissolved form. Either way it fits.\n\nAhead: the Sky Dominion, where the aerial shards drift above clouds no map has ever charted. The ley lines point upward.\n\nYou have always been bad at taking hints."
+      "text": "The Coral Mantle settles around you — a gift from the Reef, or a remnant of the Sovereign's dissolved form. Either way it fits.\n\nAhead: the Sky Dominion, where the aerial shards drift above clouds no map has ever charted. The ley lines point upward.\n\nYou have always been bad at taking hints.",
+      "image": "cutscenes/act5-outro-3.svg"
     }
   ],
   "nodes": {

--- a/web/src/data/acts/act6.json
+++ b/web/src/data/acts/act6.json
@@ -42,29 +42,35 @@
   "intro": [
     {
       "title": "THE SKY DOMINION",
-      "text": "You've climbed out of the sea and into the air.\n\nThe Sky Dominion exists on drifting islands — chunks of terrain that broke loose during the Fracture and simply refused to come back down. They've been up here so long they've built cities on them. Militarised them. Connected them with rope-bridges and siege platforms and weapons specifically designed to hit things that are also in the air.\n\nThey do not like visitors."
+      "text": "You've climbed out of the sea and into the air.\n\nThe Sky Dominion exists on drifting islands — chunks of terrain that broke loose during the Fracture and simply refused to come back down. They've been up here so long they've built cities on them. Militarised them. Connected them with rope-bridges and siege platforms and weapons specifically designed to hit things that are also in the air.\n\nThey do not like visitors.",
+      "image": "cutscenes/act6-intro-1.svg"
     },
     {
       "title": "THE CLOUDMARSHAL",
-      "text": "Command of the Sky Dominion belongs to the Cloudmarshal — a general who has never lost a battle because, practically speaking, her armies have always had the high ground.\n\nShe does not consider a tactician without wings a credible threat. She's said this, publicly, several times.\n\nYou are going to prove her wrong. You always find this kind of statement motivating."
+      "text": "Command of the Sky Dominion belongs to the Cloudmarshal — a general who has never lost a battle because, practically speaking, her armies have always had the high ground.\n\nShe does not consider a tactician without wings a credible threat. She's said this, publicly, several times.\n\nYou are going to prove her wrong. You always find this kind of statement motivating.",
+      "image": "cutscenes/act6-intro-2.svg"
     },
     {
       "title": "THE LEY BRIDGE",
-      "text": "The ley lines rise here — thick, crackling columns of energy that punch up through the clouds and connect to something far above. If the Fractured Core exists anywhere, the ley lines suggest it's in a direction the Cloudmarshal considers her personal airspace.\n\nYou will need to break through her defences to reach it.\n\nAt least the view will be good."
+      "text": "The ley lines rise here — thick, crackling columns of energy that punch up through the clouds and connect to something far above. If the Fractured Core exists anywhere, the ley lines suggest it's in a direction the Cloudmarshal considers her personal airspace.\n\nYou will need to break through her defences to reach it.\n\nAt least the view will be good.",
+      "image": "cutscenes/act6-intro-3.svg"
     }
   ],
   "outro": [
     {
       "title": "THE CLOUDMARSHAL FALLS",
-      "text": "The Cloudmarshal does not surrender. She concedes the tactical situation, which is different, and she does it with the kind of grudging precision you only see in people who have never actually had to admit defeat before.\n\nThe ley bridge opens. The sky path clears.\n\nFrom up here, you can almost see where the Fracture scar runs through the upper atmosphere."
+      "text": "The Cloudmarshal does not surrender. She concedes the tactical situation, which is different, and she does it with the kind of grudging precision you only see in people who have never actually had to admit defeat before.\n\nThe ley bridge opens. The sky path clears.\n\nFrom up here, you can almost see where the Fracture scar runs through the upper atmosphere.",
+      "image": "cutscenes/act6-outro-1.svg"
     },
     {
       "title": "WHAT SHE SAID",
-      "text": "'You fight without flying,' she said, as you left. 'That shouldn't work.'\n\nYou told her you'd never found that to be a meaningful constraint.\n\nShe did not look convinced. She did, however, step aside."
+      "text": "'You fight without flying,' she said, as you left. 'That shouldn't work.'\n\nYou told her you'd never found that to be a meaningful constraint.\n\nShe did not look convinced. She did, however, step aside.",
+      "image": "cutscenes/act6-outro-2.svg"
     },
     {
       "title": "HIGHER STILL",
-      "text": "The Stormcaller's Badge sits in your hand — a Sky Dominion medal, given to the first enemy officer who ever reached the upper platforms.\n\nYou aren't an officer. Close enough.\n\nThe ley lines point upward. They always do. You've stopped being surprised by that."
+      "text": "The Stormcaller's Badge sits in your hand — a Sky Dominion medal, given to the first enemy officer who ever reached the upper platforms.\n\nYou aren't an officer. Close enough.\n\nThe ley lines point upward. They always do. You've stopped being surprised by that.",
+      "image": "cutscenes/act6-outro-3.svg"
     }
   ],
   "nodes": {


### PR DESCRIPTION
## Summary

- Adds 6 SVG cutscene panels for Act 6 (The Sky Dominion): 3 intro + 3 outro
- Wires `image` fields into `act6.json` for all intro and outro panels

## Panels

| File | Title |
|------|-------|
| `act6-intro-1.svg` | THE SKY DOMINION — floating island fortress, rope bridges, military towers, gathering storm |
| `act6-intro-2.svg` | THE CLOUDMARSHAL — commanding figure in military uniform, weather staff with storm orb, lightning arcing to clouds |
| `act6-intro-3.svg` | THE LEY BRIDGE — three crackling ley line columns punching through cloud layer, floating bridge platforms |
| `act6-outro-1.svg` | THE CLOUDMARSHAL FALLS — figure with staff lowered and planted, storm breaking apart, calm light returning |
| `act6-outro-2.svg` | WHAT SHE SAID — quiet post-battle exchange, Jarv (with Coral Mantle) listening to the Cloudmarshal speak |
| `act6-outro-3.svg` | HIGHER STILL — Jarv receiving the Stormcaller's Badge relic, arms raised above the cloud layer |

## Test plan

- [ ] Run `npm run build` — passes with no errors
- [ ] Launch game, play to Act 6, verify intro cutscene shows all 3 panels with graphics
- [ ] Complete Act 6, verify outro cutscene shows all 3 panels with graphics
- [ ] Check SVG art style matches Acts 1–5 (dark background, monospace label, 400×240 viewBox)

https://claude.ai/code/session_01GXML372usPatkqhfiuvdWX

---
_Generated by [Claude Code](https://claude.ai/code/session_01GXML372usPatkqhfiuvdWX)_