### PR TITLE
Act 7 & 8 cutscene graphics — Emberfall Peaks + Fungal Deep

### DIFF
--- a/web/public/cutscenes/act7-intro-1.svg
+++ b/web/public/cutscenes/act7-intro-1.svg
@@ -1,0 +1,92 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#080402"/>
+
+  <linearGradient id="ember-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#0a0604"/>
+    <stop offset="50%" stop-color="#160a04"/>
+    <stop offset="100%" stop-color="#200c04"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#ember-sky)"/>
+
+  <!-- Volcanic glow on horizon — the peaks are hot -->
+  <radialGradient id="horizon-heat" cx="50%" cy="100%" r="60%">
+    <stop offset="0%" stop-color="#802000" stop-opacity="0.5"/>
+    <stop offset="60%" stop-color="#401000" stop-opacity="0.2"/>
+    <stop offset="100%" stop-color="#401000" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#horizon-heat)"/>
+
+  <!-- Far mountains — dark silhouettes -->
+  <g fill="#0e0604" opacity="0.9">
+    <polygon points="0,140 40,90 80,130 120,80 160,110 200,70 240,100 280,60 320,95 360,75 400,100 400,160 0,160"/>
+  </g>
+
+  <!-- Mid mountains — slightly lighter, volcanic glow at bases -->
+  <g fill="#140806">
+    <polygon points="0,160 30,120 70,145 110,110 150,135 190,105 230,130 270,115 310,140 350,120 400,145 400,200 0,200"/>
+  </g>
+
+  <!-- Lava flows visible on mid mountains — veins of orange -->
+  <g stroke="#c04000" stroke-width="1.5" fill="none" opacity="0.6">
+    <path d="M70,145 Q65,155 60,170 Q58,178 55,190"/>
+    <path d="M190,105 Q185,118 182,132 Q180,145 178,160"/>
+    <path d="M310,140 Q308,152 305,165 Q302,178 300,195"/>
+  </g>
+  <g stroke="#e06010" stroke-width="0.8" fill="none" opacity="0.4">
+    <path d="M67,148 Q62,158 60,172"/>
+    <path d="M187,108 Q183,122 181,136"/>
+    <path d="M307,143 Q305,155 302,168"/>
+  </g>
+
+  <!-- Foreground peak — large, centre -->
+  <polygon points="100,200 200,100 300,200" fill="#0e0806" stroke="#180c06" stroke-width="1"/>
+  <!-- Caldera glow at peak top -->
+  <radialGradient id="caldera-glow" cx="50%" cy="0%" r="50%">
+    <stop offset="0%" stop-color="#ff4000" stop-opacity="0.4"/>
+    <stop offset="100%" stop-color="#ff4000" stop-opacity="0"/>
+  </radialGradient>
+  <ellipse cx="200" cy="100" rx="30" ry="15" fill="url(#caldera-glow)"/>
+  <!-- Smoke from peak -->
+  <g fill="#1a0e08" opacity="0.5">
+    <ellipse cx="195" cy="85"  rx="18" ry="8"/>
+    <ellipse cx="205" cy="72"  rx="14" ry="7"/>
+    <ellipse cx="198" cy="60"  rx="12" ry="6"/>
+    <ellipse cx="208" cy="48"  rx="10" ry="5"/>
+  </g>
+
+  <!-- Left peak -->
+  <polygon points="0,200 60,128 140,200" fill="#0c0604" stroke="#160a04" stroke-width="1"/>
+  <!-- Right peak -->
+  <polygon points="260,200 340,118 400,200" fill="#0c0604" stroke="#160a04" stroke-width="1"/>
+
+  <!-- LEY LINES — glowing orange-red, visible through the volcanic rock -->
+  <!-- Left ley line seam -->
+  <g stroke="#c83000" stroke-width="1.5" fill="none" opacity="0.5">
+    <path d="M50,200 Q55,175 60,155 Q65,135 62,115 Q60,100 65,80"/>
+  </g>
+  <g stroke="#ff6020" stroke-width="0.6" fill="none" opacity="0.3">
+    <path d="M52,200 Q57,175 62,155 Q67,135 64,115"/>
+  </g>
+  <!-- Right ley line seam -->
+  <g stroke="#c83000" stroke-width="1.5" fill="none" opacity="0.5">
+    <path d="M350,200 Q345,175 340,155 Q335,135 338,115 Q340,100 335,80"/>
+  </g>
+
+  <!-- Falling embers — atmosphere -->
+  <g fill="#e04010" opacity="0.6">
+    <circle cx="80"  cy="40"  r="1.2"/>
+    <circle cx="140" cy="25"  r="1"/>
+    <circle cx="260" cy="35"  r="1.2"/>
+    <circle cx="330" cy="20"  r="1"/>
+    <circle cx="180" cy="50"  r="0.8"/>
+    <circle cx="310" cy="55"  r="1"/>
+  </g>
+  <g fill="#ff6020" opacity="0.3">
+    <circle cx="90"  cy="55"  r="0.8"/>
+    <circle cx="220" cy="40"  r="0.8"/>
+    <circle cx="355" cy="45"  r="0.8"/>
+  </g>
+
+  <!-- Label -->
+  <text x="200" y="232" font-family="monospace" font-size="9" fill="#3a1408" text-anchor="middle" letter-spacing="3">THE EMBERFALL PEAKS</text>
+</svg>

--- a/web/public/cutscenes/act7-intro-2.svg
+++ b/web/public/cutscenes/act7-intro-2.svg
@@ -1,0 +1,124 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#080402"/>
+
+  <linearGradient id="cin-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#0a0604"/>
+    <stop offset="100%" stop-color="#1e0a04"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#cin-sky)"/>
+
+  <!-- Heat shimmer atmosphere -->
+  <radialGradient id="heat-atm" cx="50%" cy="60%" r="50%">
+    <stop offset="0%" stop-color="#601800" stop-opacity="0.3"/>
+    <stop offset="100%" stop-color="#601800" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#heat-atm)"/>
+
+  <!-- Volcanic platform he stands on -->
+  <polygon points="80,200 320,190 330,212 70,215" fill="#100806" stroke="#201008" stroke-width="1.5"/>
+  <polygon points="80,200 320,190 322,196 80,207" fill="#1a0e08" stroke="#280e06" stroke-width="1"/>
+  <!-- Lava cracks in platform -->
+  <g stroke="#c03000" stroke-width="1" fill="none" opacity="0.5">
+    <path d="M100,200 Q110,203 120,200 Q115,206 105,207"/>
+    <path d="M200,192 Q210,196 215,192 Q212,199 203,200"/>
+    <path d="M280,196 Q285,200 295,198 Q290,206 280,207"/>
+  </g>
+
+  <!-- Shadow -->
+  <ellipse cx="200" cy="208" rx="42" ry="8" fill="#050201" opacity="0.8"/>
+
+  <!-- THE CINDERWARLORD — massive armoured figure, built from welded scrap -->
+  <!-- Boots — heavy, iron-shod -->
+  <ellipse cx="188" cy="213" rx="9" ry="4" fill="#0c0806"/>
+  <ellipse cx="214" cy="212" rx="9" ry="4" fill="#0c0806"/>
+  <!-- Legs — thick armoured plates -->
+  <rect x="183" y="195" width="10" height="18" rx="2" fill="#141008" stroke="#201408" stroke-width="0.8"/>
+  <rect x="209" y="194" width="10" height="18" rx="2" fill="#141008" stroke="#201408" stroke-width="0.8"/>
+
+  <!-- Main body — barrel chest, welded plate armour -->
+  <polygon points="175,155 225,155 232,196 168,196" fill="#181008" stroke="#281408" stroke-width="1.5"/>
+  <!-- Armour plate bolts -->
+  <g fill="#302010" opacity="0.7">
+    <circle cx="182" cy="162" r="2"/>
+    <circle cx="218" cy="162" r="2"/>
+    <circle cx="182" cy="178" r="2"/>
+    <circle cx="218" cy="178" r="2"/>
+    <circle cx="200" cy="170" r="2.5"/>
+  </g>
+  <!-- Forge-fire rune on chest — glowing orange -->
+  <g stroke="#e04000" stroke-width="1.2" fill="none" opacity="0.6">
+    <path d="M193,165 L200,158 L207,165 L207,175 L200,182 L193,175 Z"/>
+  </g>
+  <circle cx="200" cy="170" r="3" fill="#c03000" opacity="0.5"/>
+
+  <!-- Pauldrons — massive, forge-blackened -->
+  <ellipse cx="173" cy="158" rx="14" ry="7" fill="#100c06" stroke="#201408" stroke-width="1"/>
+  <ellipse cx="227" cy="158" rx="14" ry="7" fill="#100c06" stroke="#201408" stroke-width="1"/>
+  <!-- Shoulder spikes -->
+  <polygon points="163,156 169,148 165,158" fill="#1a1008"/>
+  <polygon points="237,156 231,148 235,158" fill="#1a1008"/>
+
+  <!-- Head — enclosed helm, no face visible, visor slits glow -->
+  <ellipse cx="200" cy="142" rx="16" ry="15" fill="#100c06" stroke="#201408" stroke-width="1.5"/>
+  <!-- Helm ridge -->
+  <path d="M186,135 Q200,126 214,135" stroke="#201408" stroke-width="2" fill="none"/>
+  <!-- Visor slits — glowing orange-red -->
+  <line x1="190" y1="143" x2="198" y2="143" stroke="#e04000" stroke-width="2" opacity="0.8"/>
+  <line x1="202" y1="143" x2="210" y2="143" stroke="#e04000" stroke-width="2" opacity="0.8"/>
+  <!-- Glow through visor -->
+  <radialGradient id="visor-glow" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#c03000" stop-opacity="0.5"/>
+    <stop offset="100%" stop-color="#c03000" stop-opacity="0"/>
+  </radialGradient>
+  <ellipse cx="200" cy="143" rx="12" ry="5" fill="url(#visor-glow)"/>
+
+  <!-- Left arm — gauntleted fist, raised in command -->
+  <line x1="175" y1="165" x2="152" y2="148" stroke="#141008" stroke-width="6" stroke-linecap="round"/>
+  <!-- Gauntlet fist -->
+  <rect x="143" y="141" width="14" height="12" rx="2" fill="#120e06" stroke="#201408" stroke-width="0.8"/>
+  <g stroke="#301808" stroke-width="0.8">
+    <line x1="147" y1="141" x2="147" y2="153"/>
+    <line x1="151" y1="141" x2="151" y2="153"/>
+    <line x1="155" y1="141" x2="155" y2="153"/>
+  </g>
+
+  <!-- Right arm — holding a great slag-hammer -->
+  <line x1="225" y1="162" x2="252" y2="145" stroke="#141008" stroke-width="6" stroke-linecap="round"/>
+  <!-- Hammer haft -->
+  <line x1="252" y1="118" x2="252" y2="200" stroke="#1e1408" stroke-width="3"/>
+  <!-- Hammer head — massive, square -->
+  <rect x="240" y="108" width="28" height="20" rx="2" fill="#120e06" stroke="#281408" stroke-width="1.5"/>
+  <!-- Glowing forge cracks on hammer -->
+  <g stroke="#c83010" stroke-width="0.8" opacity="0.6">
+    <path d="M243,112 Q248,118 252,112"/>
+    <path d="M256,115 Q260,120 256,125"/>
+  </g>
+
+  <!-- Ember sparks rising from armour — he runs hot -->
+  <g fill="#e04000" opacity="0.5">
+    <circle cx="165" cy="145" r="1.2"/>
+    <circle cx="235" cy="140" r="1"/>
+    <circle cx="200" cy="128" r="1.2"/>
+    <circle cx="180" cy="130" r="0.8"/>
+    <circle cx="220" cy="132" r="0.8"/>
+  </g>
+
+  <!-- Background — distant peaks glowing -->
+  <g fill="#0c0604" opacity="0.7">
+    <polygon points="0,195 50,155 100,195"/>
+    <polygon points="300,195 350,148 400,195"/>
+  </g>
+  <g fill="#802000" opacity="0.15">
+    <circle cx="50"  cy="155" r="20"/>
+    <circle cx="350" cy="148" r="20"/>
+  </g>
+
+  <!-- Smoke wisps at top -->
+  <g fill="#140a04" opacity="0.4">
+    <ellipse cx="100" cy="50" rx="40" ry="12"/>
+    <ellipse cx="310" cy="45" rx="35" ry="10"/>
+  </g>
+
+  <!-- Label -->
+  <text x="200" y="232" font-family="monospace" font-size="9" fill="#3a1408" text-anchor="middle" letter-spacing="3">THE CINDERWARLORD</text>
+</svg>

--- a/web/public/cutscenes/act7-intro-3.svg
+++ b/web/public/cutscenes/act7-intro-3.svg
@@ -1,0 +1,105 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#060301"/>
+
+  <linearGradient id="deep-rock" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#080402"/>
+    <stop offset="50%" stop-color="#0e0602"/>
+    <stop offset="100%" stop-color="#160802"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#deep-rock)"/>
+
+  <!-- Cave ceiling — jagged rock -->
+  <polygon points="0,0 400,0 400,55 370,45 340,60 300,38 260,58 220,35 180,52 140,32 100,55 60,38 20,52 0,40" fill="#0a0502"/>
+
+  <!-- Rock wall textures -->
+  <g fill="#0e0602" opacity="0.6">
+    <polygon points="0,0 0,120 15,100 10,80 20,60 8,40 15,20 0,10"/>
+    <polygon points="400,0 400,120 385,105 390,85 380,65 392,45 385,25 400,10"/>
+  </g>
+
+  <!-- THE LEY LINES — blazing orange-red seams through the rock -->
+  <!-- Primary central ley channel — horizontal, widest -->
+  <linearGradient id="ley-h-c" x1="0" y1="0" x2="1" y2="0">
+    <stop offset="0%" stop-color="#c03000" stop-opacity="0.4"/>
+    <stop offset="30%" stop-color="#ff5000" stop-opacity="0.9"/>
+    <stop offset="50%" stop-color="#ff8000" stop-opacity="1"/>
+    <stop offset="70%" stop-color="#ff5000" stop-opacity="0.9"/>
+    <stop offset="100%" stop-color="#c03000" stop-opacity="0.4"/>
+  </linearGradient>
+  <rect x="0" y="110" width="400" height="6" fill="url(#ley-h-c)"/>
+  <!-- Core glow -->
+  <rect x="0" y="111" width="400" height="4" fill="#ffb040" opacity="0.7"/>
+
+  <!-- Secondary ley channels — diagonal across rock -->
+  <line x1="0" y1="80"  x2="400" y2="155" stroke="#d04010" stroke-width="3" opacity="0.5"/>
+  <line x1="0" y1="80"  x2="400" y2="155" stroke="#ff7020" stroke-width="1" opacity="0.6"/>
+  <line x1="0" y1="165" x2="400" y2="90"  stroke="#c83010" stroke-width="2.5" opacity="0.4"/>
+  <line x1="0" y1="165" x2="400" y2="90"  stroke="#ff6018" stroke-width="0.8" opacity="0.5"/>
+
+  <!-- Vertical ley seams erupting up from below -->
+  <linearGradient id="ley-v1" x1="0" y1="1" x2="0" y2="0">
+    <stop offset="0%" stop-color="#ff5000" stop-opacity="0.8"/>
+    <stop offset="100%" stop-color="#ff5000" stop-opacity="0"/>
+  </linearGradient>
+  <rect x="98" y="60" width="4" height="180" fill="url(#ley-v1)"/>
+  <rect x="99" y="60" width="2" height="180" fill="#ffb040" opacity="0.5"/>
+
+  <rect x="198" y="40" width="4" height="200" fill="url(#ley-v1)"/>
+  <rect x="199" y="40" width="2" height="200" fill="#ffb040" opacity="0.6"/>
+
+  <rect x="298" y="60" width="4" height="180" fill="url(#ley-v1)"/>
+  <rect x="299" y="60" width="2" height="180" fill="#ffb040" opacity="0.5"/>
+
+  <!-- Ley glow halos -->
+  <radialGradient id="ley-halo-c" cx="50%" cy="50%" r="50%" gradientUnits="userSpaceOnUse" cx="200" cy="113" r="80">
+    <stop offset="0%" stop-color="#c03000" stop-opacity="0.4"/>
+    <stop offset="100%" stop-color="#c03000" stop-opacity="0"/>
+  </radialGradient>
+  <rect x="0" y="70" width="400" height="90" fill="url(#ley-halo-c)"/>
+
+  <!-- Magma pools at bottom — visible through floor cracks -->
+  <g fill="#180602" opacity="0.9">
+    <rect x="0" y="195" width="400" height="45"/>
+  </g>
+  <!-- Floor cracks revealing magma -->
+  <g stroke="#e04000" stroke-width="2" fill="none" opacity="0.7">
+    <path d="M40,195 Q50,205 55,195"/>
+    <path d="M120,198 Q130,210 140,198 Q150,205 160,198"/>
+    <path d="M230,196 Q240,208 248,196"/>
+    <path d="M310,197 Q320,207 330,197"/>
+  </g>
+  <!-- Magma glow through cracks -->
+  <g fill="#c03000" opacity="0.4">
+    <ellipse cx="48"  cy="200" rx="8"  ry="3"/>
+    <ellipse cx="135" cy="202" rx="12" ry="4"/>
+    <ellipse cx="239" cy="201" rx="9"  ry="3"/>
+    <ellipse cx="320" cy="202" rx="10" ry="3"/>
+  </g>
+
+  <!-- Heat rising — wavering upward distortion indicated by light lines -->
+  <g stroke="#ff4000" stroke-width="0.6" fill="none" opacity="0.2">
+    <path d="M100,195 Q98,180 101,165 Q103,150 100,135"/>
+    <path d="M200,195 Q198,175 201,160 Q203,145 200,130"/>
+    <path d="M300,195 Q298,180 301,165 Q303,148 300,133"/>
+  </g>
+
+  <!-- Rock stalactites at top lit from below -->
+  <g fill="#120804" stroke="#1c0c04" stroke-width="0.5">
+    <polygon points="30,55  38,55  34,75"/>
+    <polygon points="80,45  90,45  85,68"/>
+    <polygon points="150,38 162,38 156,64"/>
+    <polygon points="238,35 248,35 243,62"/>
+    <polygon points="310,42 320,42 315,66"/>
+    <polygon points="368,48 378,48 373,70"/>
+  </g>
+  <!-- Stalactites lit orange from ley glow below -->
+  <g fill="#6a1800" opacity="0.3">
+    <polygon points="30,55  38,55  34,75"/>
+    <polygon points="80,45  90,45  85,68"/>
+    <polygon points="150,38 162,38 156,64"/>
+    <polygon points="238,35 248,35 243,62"/>
+  </g>
+
+  <!-- Label -->
+  <text x="200" y="232" font-family="monospace" font-size="9" fill="#4a1a04" text-anchor="middle" letter-spacing="3">HEAT AND PRESSURE</text>
+</svg>

--- a/web/public/cutscenes/act7-outro-1.svg
+++ b/web/public/cutscenes/act7-outro-1.svg
@@ -1,0 +1,98 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#060301"/>
+
+  <linearGradient id="caldera-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#080402"/>
+    <stop offset="100%" stop-color="#1e0802"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#caldera-sky)"/>
+
+  <!-- Caldera interior — the confrontation site -->
+  <!-- Glowing magma below — the caldera floor is cracking -->
+  <radialGradient id="caldera-heat" cx="50%" cy="100%" r="60%">
+    <stop offset="0%" stop-color="#c02800" stop-opacity="0.7"/>
+    <stop offset="50%" stop-color="#801400" stop-opacity="0.4"/>
+    <stop offset="100%" stop-color="#400800" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#caldera-heat)"/>
+
+  <!-- Caldera walls — encircling rock -->
+  <g fill="#0a0602" stroke="#140804" stroke-width="1">
+    <polygon points="0,200 0,100 60,80 80,120 0,200"/>
+    <polygon points="400,200 400,95 340,78 320,118 400,200"/>
+  </g>
+  <!-- Rock ledge — the floor, now cracking -->
+  <polygon points="60,205 340,198 355,220 45,222" fill="#100602" stroke="#1c0802" stroke-width="1.5"/>
+
+  <!-- CRACKING FLOOR — lava seeping through fissures -->
+  <g stroke="#d04000" stroke-width="2" fill="none" opacity="0.8">
+    <path d="M80,205 Q100,210 110,205 Q105,215 90,218"/>
+    <path d="M150,200 Q165,206 175,200 Q185,208 190,200"/>
+    <path d="M220,202 Q235,210 248,202 Q240,212 228,215"/>
+    <path d="M290,205 Q300,212 315,205 Q308,216 295,218"/>
+  </g>
+  <g fill="#b82800" opacity="0.5">
+    <ellipse cx="95"  cy="212" rx="10" ry="4"/>
+    <ellipse cx="170" cy="206" rx="12" ry="4"/>
+    <ellipse cx="234" cy="210" rx="11" ry="4"/>
+    <ellipse cx="302" cy="212" rx="10" ry="4"/>
+  </g>
+
+  <!-- THE CINDERWARLORD — collapsed, armour cracked, visor dark -->
+  <ellipse cx="190" cy="212" rx="40" ry="7" fill="#040200" opacity="0.8"/>
+  <!-- Collapsed body — lying at angle, massive bulk now still -->
+  <polygon points="140,200 240,195 248,210 145,215" fill="#100806" stroke="#1c0c06" stroke-width="1"/>
+  <!-- Cracked chest plate -->
+  <polygon points="155,200 230,196 235,208 152,211" fill="#140c06" stroke="#200e06" stroke-width="0.8"/>
+  <g stroke="#d04010" stroke-width="1" fill="none" opacity="0.6">
+    <path d="M170,202 Q185,207 195,202 Q188,210 174,212"/>
+    <path d="M210,200 Q218,205 225,201"/>
+  </g>
+  <!-- Visor — dark, no longer glowing -->
+  <ellipse cx="190" cy="199" rx="15" ry="10" fill="#0c0804" stroke="#180c04" stroke-width="1"/>
+  <line x1="181" y1="200" x2="188" y2="200" stroke="#1a0c04" stroke-width="1.5" opacity="0.5"/>
+  <line x1="192" y1="200" x2="199" y2="200" stroke="#1a0c04" stroke-width="1.5" opacity="0.5"/>
+  <!-- Hammer fallen beside him -->
+  <line x1="240" y1="195" x2="310" y2="210" stroke="#1a1206" stroke-width="3"/>
+  <rect x="308" y="202" width="22" height="14" rx="2" fill="#0e0c04" stroke="#181008" stroke-width="1"/>
+
+  <!-- Smoke rising from cracked armour — heat dissipating -->
+  <g fill="#1a0a04" opacity="0.4">
+    <ellipse cx="190" cy="188" rx="20" ry="7"/>
+    <ellipse cx="195" cy="176" rx="15" ry="6"/>
+    <ellipse cx="188" cy="164" rx="12" ry="5"/>
+  </g>
+
+  <!-- Lava erupting into air — the defeat breaks the caldera loose -->
+  <!-- Left eruption -->
+  <g stroke="#e04000" stroke-width="1.5" fill="none" opacity="0.6">
+    <path d="M70,200 Q65,180 60,155 Q58,135 62,115"/>
+    <path d="M75,200 Q70,182 72,162"/>
+  </g>
+  <!-- Right eruption -->
+  <g stroke="#e04000" stroke-width="1.5" fill="none" opacity="0.6">
+    <path d="M330,200 Q335,180 340,155 Q342,130 338,110"/>
+    <path d="M325,200 Q330,182 328,162"/>
+  </g>
+  <!-- Ejected lava droplets -->
+  <g fill="#e04000" opacity="0.5">
+    <circle cx="58"  cy="120" r="2"/>
+    <circle cx="72"  cy="140" r="1.5"/>
+    <circle cx="340" cy="115" r="2"/>
+    <circle cx="327" cy="138" r="1.5"/>
+    <circle cx="65"  cy="100" r="1"/>
+    <circle cx="335" cy="105" r="1"/>
+  </g>
+
+  <!-- Falling ash in the air -->
+  <g fill="#2a1006" opacity="0.5">
+    <circle cx="100" cy="80"  r="1.2"/>
+    <circle cx="160" cy="60"  r="1"/>
+    <circle cx="230" cy="70"  r="1.2"/>
+    <circle cx="290" cy="55"  r="1"/>
+    <circle cx="350" cy="80"  r="1"/>
+  </g>
+
+  <!-- Label -->
+  <text x="200" y="232" font-family="monospace" font-size="9" fill="#3a1408" text-anchor="middle" letter-spacing="3">THE CINDERWARLORD FALLS</text>
+</svg>

--- a/web/public/cutscenes/act7-outro-2.svg
+++ b/web/public/cutscenes/act7-outro-2.svg
@@ -1,0 +1,97 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#060301"/>
+
+  <linearGradient id="still-caldera" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#080402"/>
+    <stop offset="100%" stop-color="#180802"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#still-caldera)"/>
+
+  <!-- Subdued heat glow — battle over, caldera cooling -->
+  <radialGradient id="cool-glow" cx="50%" cy="85%" r="50%">
+    <stop offset="0%" stop-color="#802000" stop-opacity="0.35"/>
+    <stop offset="100%" stop-color="#802000" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#cool-glow)"/>
+
+  <!-- Rock ledge — caldera floor, cracked but stable -->
+  <polygon points="50,200 350,192 360,215 40,218" fill="#100602" stroke="#1c0802" stroke-width="1.5"/>
+  <polygon points="50,200 350,192 352,198 50,206" fill="#160a04" stroke="#200a04" stroke-width="1"/>
+  <!-- Cooling lava cracks — dimmer now -->
+  <g stroke="#802000" stroke-width="1" fill="none" opacity="0.4">
+    <path d="M100,202 Q112,207 118,202"/>
+    <path d="M220,196 Q230,202 240,196"/>
+    <path d="M300,200 Q310,205 320,200"/>
+  </g>
+
+  <!-- THE CINDERWARLORD — sitting, slumped against caldera wall left, visor cracked -->
+  <ellipse cx="120" cy="210" rx="30" ry="6" fill="#040200" opacity="0.7"/>
+  <!-- Slumped body — back against wall -->
+  <polygon points="95,175 155,175 160,210 90,210" fill="#141008" stroke="#201408" stroke-width="1"/>
+  <!-- Cracked chest armour -->
+  <g stroke="#501800" stroke-width="1" fill="none" opacity="0.5">
+    <path d="M110,182 Q120,188 130,182 Q125,192 113,194"/>
+  </g>
+  <!-- Arms — slack at sides, hammer gone -->
+  <line x1="95"  y1="182" x2="78" y2="200" stroke="#100c06" stroke-width="5" stroke-linecap="round"/>
+  <line x1="155" y1="182" x2="162" y2="200" stroke="#100c06" stroke-width="5" stroke-linecap="round"/>
+  <!-- Head — helm, visor cracked, dull glow behind crack -->
+  <ellipse cx="120" cy="162" rx="16" ry="14" fill="#0e0c06" stroke="#1c1008" stroke-width="1.5"/>
+  <path d="M106,155 Q120,146 134,155" stroke="#1c1008" stroke-width="2" fill="none"/>
+  <!-- Visor — cracked, faint residual glow -->
+  <line x1="111" y1="163" x2="118" y2="163" stroke="#600e00" stroke-width="1.5" opacity="0.4"/>
+  <line x1="122" y1="163" x2="129" y2="163" stroke="#600e00" stroke-width="1.5" opacity="0.4"/>
+  <!-- Crack across visor -->
+  <path d="M118,156 Q120,163 122,170" stroke="#802000" stroke-width="0.8" fill="none" opacity="0.6"/>
+  <!-- Mouth — open, speaking -->
+  <path d="M113,172 Q120,176 127,172" stroke="#1a0e06" stroke-width="1" fill="none"/>
+
+  <!-- JARV — right side, standing, listening, Coral Mantle and Stormcaller's Badge visible -->
+  <ellipse cx="278" cy="210" rx="26" ry="5" fill="#040201" opacity="0.7"/>
+  <!-- Boots -->
+  <ellipse cx="271" cy="213" rx="6" ry="2.5" fill="#08090e"/>
+  <ellipse cx="285" cy="213" rx="6" ry="2.5" fill="#08090e"/>
+  <!-- Legs -->
+  <line x1="273" y1="203" x2="271" y2="213" stroke="#0c0c18" stroke-width="4" stroke-linecap="round"/>
+  <line x1="282" y1="202" x2="285" y2="213" stroke="#0c0c18" stroke-width="4" stroke-linecap="round"/>
+  <!-- Coral Mantle — teal at edges -->
+  <polygon points="257,176 299,176 304,203 252,203" fill="#0a1e20" stroke="#1a4040" stroke-width="1.5"/>
+  <g fill="#00c090" opacity="0.5">
+    <circle cx="252" cy="176" r="1.5"/>
+    <circle cx="250" cy="184" r="1.2"/>
+    <circle cx="304" cy="176" r="1.5"/>
+    <circle cx="306" cy="184" r="1.2"/>
+  </g>
+  <!-- Stormcaller's Badge — on chest, small hex badge glowing faintly -->
+  <polygon points="278,184 282,187 282,193 278,196 274,193 274,187" fill="#080e20" stroke="#2848a0" stroke-width="0.8"/>
+  <line x1="278" y1="186" x2="278" y2="194" stroke="#4060c0" stroke-width="0.8" opacity="0.6"/>
+  <!-- Head — turned toward Cinderwarlord -->
+  <ellipse cx="276" cy="167" rx="11" ry="9" fill="#0c0c1a" stroke="#181830" stroke-width="1"/>
+  <ellipse cx="274" cy="170" rx="6" ry="4" fill="#080810"/>
+  <!-- Iron Standard resting against rock -->
+  <line x1="310" y1="175" x2="330" y2="218" stroke="#2a3040" stroke-width="2.5"/>
+  <polygon points="308,175 312,175 310,166" fill="#404860" opacity="0.8"/>
+
+  <!-- Speech bubbles / dots — the Cinderwarlord speaks -->
+  <g fill="#2a0e04" opacity="0.6">
+    <circle cx="148" cy="158" r="1.5"/>
+    <circle cx="156" cy="154" r="1.2"/>
+    <circle cx="163" cy="152" r="1"/>
+  </g>
+
+  <!-- Smoke and cooling atmosphere -->
+  <g fill="#140804" opacity="0.35">
+    <ellipse cx="80"  cy="70" rx="55" ry="18"/>
+    <ellipse cx="320" cy="65" rx="50" ry="16"/>
+  </g>
+
+  <!-- Dim ember sparks settling -->
+  <g fill="#c03000" opacity="0.3">
+    <circle cx="180" cy="55" r="1"/>
+    <circle cx="240" cy="45" r="0.8"/>
+    <circle cx="300" cy="60" r="1"/>
+  </g>
+
+  <!-- Label -->
+  <text x="200" y="232" font-family="monospace" font-size="9" fill="#3a1408" text-anchor="middle" letter-spacing="3">WHAT HE SAID</text>
+</svg>

--- a/web/public/cutscenes/act7-outro-3.svg
+++ b/web/public/cutscenes/act7-outro-3.svg
@@ -1,0 +1,115 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#060301"/>
+
+  <linearGradient id="magma-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#080402"/>
+    <stop offset="50%" stop-color="#120602"/>
+    <stop offset="100%" stop-color="#1e0802"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#magma-sky)"/>
+
+  <!-- Heat glow rising from below -->
+  <radialGradient id="core-heat" cx="50%" cy="80%" r="50%">
+    <stop offset="0%" stop-color="#c02800" stop-opacity="0.5"/>
+    <stop offset="60%" stop-color="#801400" stop-opacity="0.2"/>
+    <stop offset="100%" stop-color="#801400" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#core-heat)"/>
+
+  <!-- THE MAGMA CORE — centre frame, floating, radiating intense heat -->
+  <!-- Outer heat corona -->
+  <radialGradient id="core-corona" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#d03000" stop-opacity="0.4"/>
+    <stop offset="50%" stop-color="#a02000" stop-opacity="0.15"/>
+    <stop offset="100%" stop-color="#a02000" stop-opacity="0"/>
+  </radialGradient>
+  <ellipse cx="200" cy="95" rx="65" ry="55" fill="url(#core-corona)"/>
+  <!-- Outer irregular rock shell — volcanic glass exterior -->
+  <polygon points="200,44 232,58 248,88 240,120 216,138 184,138 160,120 152,88 168,58" fill="#0e0602" stroke="#301006" stroke-width="2"/>
+  <!-- Inner lava glow — visible through cracks -->
+  <radialGradient id="magma-inner" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#ff5000" stop-opacity="0.8"/>
+    <stop offset="50%" stop-color="#c03000" stop-opacity="0.5"/>
+    <stop offset="100%" stop-color="#800000" stop-opacity="0"/>
+  </radialGradient>
+  <polygon points="200,44 232,58 248,88 240,120 216,138 184,138 160,120 152,88 168,58" fill="url(#magma-inner)" opacity="0.6"/>
+  <!-- Volcanic glass surface texture — dark facets -->
+  <g fill="#100804" stroke="#200e04" stroke-width="0.8" opacity="0.8">
+    <polygon points="200,52 218,62 220,80 200,88 180,80 182,62"/>
+    <polygon points="200,88 220,92 232,108 220,122 200,128 180,122 168,108 180,92"/>
+  </g>
+  <!-- Lava seeping through cracks in glass -->
+  <g stroke="#ff5010" stroke-width="1.5" fill="none" opacity="0.7">
+    <path d="M180,62 Q190,72 180,80"/>
+    <path d="M220,62 Q210,72 220,80"/>
+    <path d="M168,108 Q178,115 168,122"/>
+    <path d="M232,108 Q222,115 232,122"/>
+    <path d="M200,52 Q204,62 200,70"/>
+  </g>
+  <!-- Molten core visible at centre -->
+  <circle cx="200" cy="91" r="22" fill="#200802" stroke="#c03000" stroke-width="1" opacity="0.8"/>
+  <circle cx="200" cy="91" r="14" fill="#ff4000" opacity="0.5"/>
+  <circle cx="200" cy="91" r="7"  fill="#ff8020" opacity="0.7"/>
+  <!-- Pulsing inner fire -->
+  <circle cx="200" cy="91" r="4"  fill="#ffb040" opacity="0.9"/>
+  <!-- Heat distortion rays — radiating outward -->
+  <g stroke="#c03000" stroke-width="0.8" fill="none" opacity="0.3">
+    <line x1="200" y1="44" x2="200" y2="22"/>
+    <line x1="248" y1="88" x2="272" y2="88"/>
+    <line x1="232" y1="58" x2="250" y2="40"/>
+    <line x1="152" y1="88" x2="128" y2="88"/>
+    <line x1="168" y1="58" x2="150" y2="40"/>
+    <line x1="200" y1="138" x2="200" y2="160"/>
+    <line x1="216" y1="138" x2="230" y2="154"/>
+    <line x1="184" y1="138" x2="170" y2="154"/>
+  </g>
+
+  <!-- JARV below — small, arms raised receiving the core -->
+  <ellipse cx="200" cy="220" rx="22" ry="4" fill="#030100" opacity="0.7"/>
+  <!-- Boots -->
+  <ellipse cx="194" cy="223" rx="5" ry="2" fill="#08090e"/>
+  <ellipse cx="207" cy="223" rx="5" ry="2" fill="#08090e"/>
+  <!-- Legs -->
+  <line x1="196" y1="214" x2="194" y2="223" stroke="#0c0c18" stroke-width="4" stroke-linecap="round"/>
+  <line x1="204" y1="213" x2="207" y2="223" stroke="#0c0c18" stroke-width="4" stroke-linecap="round"/>
+  <!-- Coral Mantle -->
+  <polygon points="184,183 216,183 220,213 180,213" fill="#0a1e20" stroke="#1a4040" stroke-width="1.5"/>
+  <g fill="#00c090" opacity="0.4">
+    <circle cx="180" cy="183" r="1.5"/>
+    <circle cx="220" cy="183" r="1.5"/>
+  </g>
+  <!-- Arms raised — reaching up, palms open to receive the core -->
+  <line x1="184" y1="190" x2="166" y2="168" stroke="#0c0c18" stroke-width="4" stroke-linecap="round"/>
+  <line x1="216" y1="190" x2="234" y2="168" stroke="#0c0c18" stroke-width="4" stroke-linecap="round"/>
+  <polygon points="160,163 170,162 172,173 162,174" fill="#0d0e1a" stroke="#181830" stroke-width="0.8"/>
+  <polygon points="230,163 240,162 242,173 232,174" fill="#0d0e1a" stroke="#181830" stroke-width="0.8"/>
+  <!-- Head tilted up -->
+  <ellipse cx="200" cy="174" rx="10" ry="9" fill="#0c0c1a" stroke="#181830" stroke-width="1"/>
+  <ellipse cx="200" cy="177" rx="5" ry="3.5" fill="#080810"/>
+
+  <!-- Energy transfer from core to hands -->
+  <g stroke="#c83000" stroke-width="1" fill="none" opacity="0.4">
+    <path d="M168,108 Q165,138 164,168"/>
+    <path d="M232,108 Q235,138 236,168"/>
+  </g>
+
+  <!-- Rocky floor below -->
+  <g fill="#0c0602" opacity="0.9">
+    <rect x="0" y="225" width="400" height="15"/>
+  </g>
+
+  <!-- Falling ash and embers in background -->
+  <g fill="#e04000" opacity="0.4">
+    <circle cx="50"  cy="40"  r="1.2"/>
+    <circle cx="120" cy="30"  r="1"/>
+    <circle cx="280" cy="28"  r="1.2"/>
+    <circle cx="350" cy="42"  r="1"/>
+  </g>
+  <g fill="#1e0a02" opacity="0.5">
+    <ellipse cx="80"  cy="55" rx="35" ry="10"/>
+    <ellipse cx="320" cy="50" rx="30" ry="9"/>
+  </g>
+
+  <!-- Label -->
+  <text x="200" y="238" font-family="monospace" font-size="9" fill="#4a1a04" text-anchor="middle" letter-spacing="3">DEEPER IN</text>
+</svg>

--- a/web/public/cutscenes/act8-intro-1.svg
+++ b/web/public/cutscenes/act8-intro-1.svg
@@ -1,0 +1,114 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#030206"/>
+
+  <linearGradient id="deep-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#040208"/>
+    <stop offset="50%" stop-color="#06030e"/>
+    <stop offset="100%" stop-color="#080414"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#deep-sky)"/>
+
+  <!-- Bioluminescent spore atmosphere — faint purple glow -->
+  <radialGradient id="spore-atm" cx="50%" cy="60%" r="55%">
+    <stop offset="0%" stop-color="#400880" stop-opacity="0.25"/>
+    <stop offset="100%" stop-color="#400880" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#spore-atm)"/>
+
+  <!-- Cave ceiling — jagged, dripping stalactites -->
+  <polygon points="0,0 400,0 400,50 375,38 350,55 315,35 280,52 245,30 210,48 175,28 140,50 105,33 70,52 35,34 0,48" fill="#050208"/>
+  <!-- Stalactites more detailed -->
+  <g fill="#060309" stroke="#0a0412" stroke-width="0.5">
+    <polygon points="28,48  36,48  32,72"/>
+    <polygon points="72,52  82,52  77,78"/>
+    <polygon points="138,50 150,50 144,80"/>
+    <polygon points="213,48 223,48 218,76"/>
+    <polygon points="283,52 293,52 288,78"/>
+    <polygon points="352,55 362,55 357,82"/>
+  </g>
+  <!-- Mycelium hanging from ceiling — thread-like filaments -->
+  <g stroke="#301848" stroke-width="0.6" fill="none" opacity="0.5">
+    <path d="M32,72 Q30,85 28,100 Q31,112 29,125"/>
+    <path d="M77,78 Q75,92 78,108 Q76,118 74,130"/>
+    <path d="M144,80 Q142,95 145,112 Q143,125 141,138"/>
+    <path d="M288,78 Q290,93 287,110 Q289,124 291,140"/>
+    <path d="M357,82 Q359,96 356,110 Q358,125 360,140"/>
+  </g>
+
+  <!-- Cave floor — rock with mycelium mats -->
+  <polygon points="0,200 400,200 400,240 0,240" fill="#050208"/>
+  <polygon points="0,195 400,188 400,205 0,210" fill="#07030c" stroke="#0e0618" stroke-width="1"/>
+  <!-- Mycelium mat on floor — pale web texture -->
+  <g stroke="#281240" stroke-width="0.8" fill="none" opacity="0.4">
+    <path d="M0,200 Q50,195 100,200 Q150,205 200,200 Q250,195 300,200 Q350,205 400,200"/>
+    <path d="M20,202 Q70,197 120,202 Q170,207 220,202"/>
+    <path d="M200,200 Q240,195 280,200 Q320,205 380,200"/>
+  </g>
+
+  <!-- MUSHROOMS — large glowing clusters -->
+  <!-- Left large cluster -->
+  <g>
+    <!-- Stems -->
+    <line x1="60" y1="200" x2="58" y2="165" stroke="#1a0c28" stroke-width="4" stroke-linecap="round"/>
+    <line x1="80" y1="200" x2="82" y2="158" stroke="#1a0c28" stroke-width="5" stroke-linecap="round"/>
+    <line x1="45" y1="200" x2="42" y2="172" stroke="#1a0c28" stroke-width="3" stroke-linecap="round"/>
+    <!-- Caps -->
+    <ellipse cx="58" cy="163" rx="20" ry="9" fill="#1a0830" stroke="#301050" stroke-width="1"/>
+    <ellipse cx="82" cy="155" rx="26" ry="11" fill="#200a38" stroke="#381260" stroke-width="1"/>
+    <ellipse cx="42" cy="170" rx="16" ry="7" fill="#18082c" stroke="#280e48" stroke-width="1"/>
+    <!-- Bioluminescent glow under caps -->
+    <radialGradient id="mush-l-glow" cx="50%" cy="100%" r="70%">
+      <stop offset="0%" stop-color="#8020e0" stop-opacity="0.4"/>
+      <stop offset="100%" stop-color="#8020e0" stop-opacity="0"/>
+    </radialGradient>
+    <ellipse cx="82" cy="155" rx="26" ry="11" fill="url(#mush-l-glow)"/>
+    <ellipse cx="58" cy="163" rx="20" ry="9" fill="url(#mush-l-glow)" opacity="0.6"/>
+  </g>
+
+  <!-- Right large cluster -->
+  <g>
+    <line x1="330" y1="200" x2="328" y2="160" stroke="#1a0c28" stroke-width="5" stroke-linecap="round"/>
+    <line x1="350" y1="200" x2="355" y2="168" stroke="#1a0c28" stroke-width="4" stroke-linecap="round"/>
+    <line x1="315" y1="200" x2="310" y2="172" stroke="#1a0c28" stroke-width="3" stroke-linecap="round"/>
+    <ellipse cx="328" cy="157" rx="25" ry="10" fill="#200a38" stroke="#381260" stroke-width="1"/>
+    <ellipse cx="355" cy="165" rx="20" ry="8" fill="#1a0830" stroke="#301050" stroke-width="1"/>
+    <ellipse cx="310" cy="169" rx="16" ry="7" fill="#18082c" stroke="#280e48" stroke-width="1"/>
+    <ellipse cx="328" cy="157" rx="25" ry="10" fill="url(#mush-l-glow)"/>
+  </g>
+
+  <!-- Centre — ley line descending, visible going DOWN into the floor -->
+  <linearGradient id="ley-down" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#8040e0" stop-opacity="0.1"/>
+    <stop offset="60%" stop-color="#6030c0" stop-opacity="0.6"/>
+    <stop offset="100%" stop-color="#4020a0" stop-opacity="0.9"/>
+  </linearGradient>
+  <rect x="196" y="0" width="8" height="200" fill="url(#ley-down)"/>
+  <rect x="198" y="0" width="4" height="200" fill="#c080ff" opacity="0.3"/>
+  <!-- Ley line vanishing into floor crack -->
+  <g stroke="#8040e0" stroke-width="1" fill="none" opacity="0.5">
+    <path d="M196,200 Q198,205 200,210"/>
+    <path d="M204,200 Q202,205 200,210"/>
+  </g>
+
+  <!-- Floating spores — bioluminescent dots -->
+  <g fill="#a040f0" opacity="0.5">
+    <circle cx="120" cy="120" r="1.5"/>
+    <circle cx="160" cy="95"  r="1"/>
+    <circle cx="240" cy="110" r="1.5"/>
+    <circle cx="280" cy="85"  r="1"/>
+    <circle cx="140" cy="140" r="1"/>
+    <circle cx="260" cy="130" r="1"/>
+    <circle cx="180" cy="75"  r="0.8"/>
+    <circle cx="320" cy="105" r="1"/>
+    <circle cx="90"  cy="100" r="0.8"/>
+  </g>
+  <g fill="#40c0a0" opacity="0.35">
+    <circle cx="150" cy="60"  r="1"/>
+    <circle cx="250" cy="70"  r="1"/>
+    <circle cx="350" cy="90"  r="0.8"/>
+    <circle cx="50"  cy="80"  r="0.8"/>
+  </g>
+
+  <!-- Label -->
+  <text x="200" y="232" font-family="monospace" font-size="9" fill="#2a1040" text-anchor="middle" letter-spacing="3">THE FUNGAL DEEP</text>
+</svg>

--- a/web/public/cutscenes/act8-intro-2.svg
+++ b/web/public/cutscenes/act8-intro-2.svg
@@ -1,0 +1,109 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#030206"/>
+
+  <linearGradient id="rq-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#040208"/>
+    <stop offset="100%" stop-color="#09041a"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#rq-sky)"/>
+
+  <!-- Mycelial network glow — the Root Queen IS the network -->
+  <radialGradient id="network-glow" cx="50%" cy="50%" r="55%">
+    <stop offset="0%" stop-color="#500a90" stop-opacity="0.4"/>
+    <stop offset="60%" stop-color="#300860" stop-opacity="0.15"/>
+    <stop offset="100%" stop-color="#300860" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#network-glow)"/>
+
+  <!-- Mycelium strands — the network radiating from the centre -->
+  <!-- Primary strands -->
+  <g stroke="#401070" stroke-width="1.5" fill="none" opacity="0.5">
+    <path d="M200,120 Q170,100 140,80 Q110,60 80,45"/>
+    <path d="M200,120 Q185,90 175,60 Q168,40 165,20"/>
+    <path d="M200,120 Q215,90 225,60 Q232,40 235,20"/>
+    <path d="M200,120 Q230,100 260,80 Q290,60 320,45"/>
+    <path d="M200,120 Q160,115 120,110 Q80,105 40,100"/>
+    <path d="M200,120 Q240,115 280,110 Q320,105 360,100"/>
+    <path d="M200,120 Q175,140 150,165 Q130,182 110,200"/>
+    <path d="M200,120 Q225,140 250,165 Q270,182 290,200"/>
+    <path d="M200,120 Q200,145 200,175 Q200,195 200,215"/>
+  </g>
+  <!-- Secondary branching strands -->
+  <g stroke="#300c58" stroke-width="0.8" fill="none" opacity="0.35">
+    <path d="M140,80 Q120,70 95,62"/>
+    <path d="M260,80 Q280,70 305,62"/>
+    <path d="M175,60 Q160,50 148,38"/>
+    <path d="M225,60 Q240,50 252,38"/>
+    <path d="M120,110 Q100,118 75,125"/>
+    <path d="M280,110 Q300,118 325,125"/>
+    <path d="M150,165 Q135,175 118,185"/>
+    <path d="M250,165 Q265,175 282,185"/>
+  </g>
+  <!-- Node pulses — the network nodes glowing -->
+  <g fill="#8030d0" opacity="0.6">
+    <circle cx="200" cy="120" r="6"/>
+    <circle cx="140" cy="80"  r="3.5"/>
+    <circle cx="260" cy="80"  r="3.5"/>
+    <circle cx="175" cy="60"  r="3"/>
+    <circle cx="225" cy="60"  r="3"/>
+    <circle cx="120" cy="110" r="3"/>
+    <circle cx="280" cy="110" r="3"/>
+    <circle cx="150" cy="165" r="3"/>
+    <circle cx="250" cy="165" r="3"/>
+    <circle cx="80"  cy="45"  r="2.5"/>
+    <circle cx="320" cy="45"  r="2.5"/>
+  </g>
+  <!-- Central core — brightest node -->
+  <circle cx="200" cy="120" r="12" fill="#200840" stroke="#7020c0" stroke-width="1.5" opacity="0.8"/>
+  <circle cx="200" cy="120" r="7"  fill="#6018b0" opacity="0.7"/>
+  <circle cx="200" cy="120" r="3"  fill="#c040ff" opacity="0.9"/>
+
+  <!-- THE ROOT QUEEN — an emergent form rising from the mycelium at centre -->
+  <!-- Not humanoid — a tall, branching pillar of mycelium that suggests a face/presence -->
+  <!-- Main trunk -->
+  <line x1="200" y1="200" x2="200" y2="120" stroke="#2a1040" stroke-width="8" stroke-linecap="round"/>
+  <line x1="200" y1="200" x2="200" y2="120" stroke="#501080" stroke-width="4" stroke-linecap="round" opacity="0.5"/>
+  <!-- Branching arms -->
+  <line x1="200" y1="155" x2="170" y2="135" stroke="#200c38" stroke-width="5" stroke-linecap="round"/>
+  <line x1="200" y1="155" x2="230" y2="135" stroke="#200c38" stroke-width="5" stroke-linecap="round"/>
+  <line x1="170" y1="135" x2="155" y2="118" stroke="#180a2c" stroke-width="3" stroke-linecap="round"/>
+  <line x1="230" y1="135" x2="245" y2="118" stroke="#180a2c" stroke-width="3" stroke-linecap="round"/>
+  <!-- Upper filaments — crown-like -->
+  <g stroke="#401870" stroke-width="1.5" fill="none" opacity="0.7">
+    <path d="M200,120 Q192,108 188,96 Q186,86 190,78"/>
+    <path d="M200,120 Q208,108 212,96 Q214,86 210,78"/>
+    <path d="M200,120 Q196,105 194,92"/>
+    <path d="M200,120 Q204,105 206,92"/>
+  </g>
+  <!-- "Face" — suggestion of eyes — two glowing nodes at top of trunk -->
+  <circle cx="194" cy="118" r="3" fill="#8030d0" opacity="0.7"/>
+  <circle cx="206" cy="118" r="3" fill="#8030d0" opacity="0.7"/>
+  <!-- Root base spreading -->
+  <g stroke="#180a28" stroke-width="2" fill="none" opacity="0.6">
+    <path d="M196,200 Q185,205 175,210"/>
+    <path d="M200,200 Q200,208 200,215"/>
+    <path d="M204,200 Q215,205 225,210"/>
+    <path d="M190,200 Q178,208 165,215"/>
+    <path d="M210,200 Q222,208 235,215"/>
+  </g>
+
+  <!-- Spore cloud at top -->
+  <g fill="#6018a0" opacity="0.25">
+    <ellipse cx="200" cy="40" rx="80" ry="22"/>
+    <ellipse cx="160" cy="28" rx="50" ry="14"/>
+    <ellipse cx="240" cy="30" rx="45" ry="12"/>
+  </g>
+
+  <!-- Floating spores -->
+  <g fill="#9030e0" opacity="0.45">
+    <circle cx="80"  cy="50"  r="1.2"/>
+    <circle cx="130" cy="30"  r="1"/>
+    <circle cx="270" cy="35"  r="1.2"/>
+    <circle cx="330" cy="55"  r="1"/>
+    <circle cx="50"  cy="140" r="1"/>
+    <circle cx="350" cy="135" r="1"/>
+  </g>
+
+  <!-- Label -->
+  <text x="200" y="232" font-family="monospace" font-size="9" fill="#2a1040" text-anchor="middle" letter-spacing="3">THE ROOT QUEEN</text>
+</svg>

--- a/web/public/cutscenes/act8-intro-3.svg
+++ b/web/public/cutscenes/act8-intro-3.svg
@@ -1,0 +1,113 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#030206"/>
+
+  <linearGradient id="under-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#040208"/>
+    <stop offset="100%" stop-color="#0a0418"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#under-sky)"/>
+
+  <!-- Enclosed warmth — soft purple-green ambient glow -->
+  <radialGradient id="warm-cave" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#380870" stop-opacity="0.3"/>
+    <stop offset="100%" stop-color="#380870" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#warm-cave)"/>
+
+  <!-- Cave walls — closing in -->
+  <!-- Left wall -->
+  <polygon points="0,0 0,240 70,240 55,200 50,160 60,120 45,80 55,40 40,0" fill="#060309"/>
+  <!-- Right wall -->
+  <polygon points="400,0 400,240 330,240 345,200 350,160 340,120 355,80 345,40 360,0" fill="#060309"/>
+  <!-- Wall texture — mycelium veins -->
+  <g stroke="#1a0830" stroke-width="0.8" fill="none" opacity="0.5">
+    <path d="M50,40 Q40,60 45,80 Q55,100 48,120 Q40,140 50,160"/>
+    <path d="M55,60 Q48,80 52,100"/>
+    <path d="M350,40 Q360,60 355,80 Q345,100 352,120 Q360,140 350,160"/>
+    <path d="M345,60 Q352,80 348,100"/>
+  </g>
+  <!-- Bioluminescent patches on wall -->
+  <g fill="#6020a0" opacity="0.3">
+    <ellipse cx="40"  cy="80"  rx="12" ry="6"/>
+    <ellipse cx="52"  cy="140" rx="10" ry="5"/>
+    <ellipse cx="360" cy="90"  rx="12" ry="6"/>
+    <ellipse cx="348" cy="145" rx="10" ry="5"/>
+  </g>
+
+  <!-- TUNNEL PERSPECTIVE — corridor stretching ahead, getting smaller -->
+  <!-- Tunnel rings — suggesting depth -->
+  <g stroke="#180630" stroke-width="1" fill="none" opacity="0.6">
+    <ellipse cx="200" cy="120" rx="130" ry="90"/>
+    <ellipse cx="200" cy="120" rx="105" ry="72"/>
+    <ellipse cx="200" cy="120" rx="80"  ry="55"/>
+    <ellipse cx="200" cy="120" rx="55"  ry="38"/>
+    <ellipse cx="200" cy="120" rx="32"  ry="22"/>
+    <ellipse cx="200" cy="120" rx="14"  ry="10"/>
+  </g>
+  <!-- Tunnel glow getting brighter at depth — something glowing ahead -->
+  <radialGradient id="depth-glow" cx="50%" cy="50%" r="40%">
+    <stop offset="0%" stop-color="#8030d0" stop-opacity="0.5"/>
+    <stop offset="60%" stop-color="#5020a0" stop-opacity="0.15"/>
+    <stop offset="100%" stop-color="#5020a0" stop-opacity="0"/>
+  </radialGradient>
+  <ellipse cx="200" cy="120" rx="130" ry="90" fill="url(#depth-glow)"/>
+
+  <!-- Mycelium covering tunnel walls — growing denser deeper in -->
+  <g stroke="#280c48" stroke-width="0.8" fill="none" opacity="0.4">
+    <!-- Outer ring mycelium -->
+    <path d="M70,120 Q90,110 100,90 Q110,70 130,65"/>
+    <path d="M70,120 Q85,130 95,150 Q105,165 125,170"/>
+    <path d="M330,120 Q310,110 300,90 Q290,70 270,65"/>
+    <path d="M330,120 Q315,130 305,150 Q295,165 275,170"/>
+    <!-- Stalactite-like growths at top -->
+    <path d="M140,30 Q145,50 142,70"/>
+    <path d="M200,30 Q200,55 200,75"/>
+    <path d="M260,30 Q255,50 258,70"/>
+  </g>
+
+  <!-- Mushroom silhouettes in mid-ground -->
+  <g fill="#100828" opacity="0.7">
+    <!-- Left set -->
+    <ellipse cx="95"  cy="175" rx="18" ry="7"/>
+    <line x1="95"  y1="182" x2="95"  y2="200" stroke="#100828" stroke-width="4"/>
+    <ellipse cx="115" cy="180" rx="14" ry="6"/>
+    <line x1="115" y1="186" x2="115" y2="200" stroke="#100828" stroke-width="3"/>
+    <!-- Right set -->
+    <ellipse cx="305" cy="175" rx="18" ry="7"/>
+    <line x1="305" y1="182" x2="305" y2="200" stroke="#100828" stroke-width="4"/>
+    <ellipse cx="285" cy="180" rx="14" ry="6"/>
+    <line x1="285" y1="186" x2="285" y2="200" stroke="#100828" stroke-width="3"/>
+  </g>
+  <!-- Glow under mushroom caps -->
+  <g fill="#6018a0" opacity="0.25">
+    <ellipse cx="95"  cy="178" rx="18" ry="5"/>
+    <ellipse cx="305" cy="178" rx="18" ry="5"/>
+  </g>
+
+  <!-- Floating spores — many, this is their home -->
+  <g fill="#9030e0" opacity="0.5">
+    <circle cx="90"  cy="60"  r="1.2"/>
+    <circle cx="130" cy="45"  r="1"/>
+    <circle cx="170" cy="35"  r="1.2"/>
+    <circle cx="230" cy="40"  r="1"/>
+    <circle cx="270" cy="50"  r="1.2"/>
+    <circle cx="310" cy="38"  r="1"/>
+    <circle cx="110" cy="90"  r="0.8"/>
+    <circle cx="290" cy="88"  r="0.8"/>
+    <circle cx="150" cy="80"  r="1"/>
+    <circle cx="250" cy="75"  r="1"/>
+  </g>
+  <g fill="#30c0a0" opacity="0.3">
+    <circle cx="160" cy="55"  r="0.8"/>
+    <circle cx="240" cy="60"  r="0.8"/>
+    <circle cx="80"  cy="110" r="0.8"/>
+    <circle cx="320" cy="108" r="0.8"/>
+  </g>
+
+  <!-- Something watching — two faint eyes in the deep -->
+  <circle cx="194" cy="120" r="2.5" fill="#c050ff" opacity="0.4"/>
+  <circle cx="206" cy="120" r="2.5" fill="#c050ff" opacity="0.4"/>
+
+  <!-- Label -->
+  <text x="200" y="232" font-family="monospace" font-size="9" fill="#2a1040" text-anchor="middle" letter-spacing="3">GOING UNDER</text>
+</svg>

--- a/web/public/cutscenes/act8-outro-1.svg
+++ b/web/public/cutscenes/act8-outro-1.svg
@@ -1,0 +1,87 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#030206"/>
+
+  <linearGradient id="still-deep" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#040208"/>
+    <stop offset="100%" stop-color="#070310"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#still-deep)"/>
+
+  <!-- Dimming glow — the network quieting like a dying fire -->
+  <radialGradient id="dim-glow" cx="50%" cy="50%" r="55%">
+    <stop offset="0%" stop-color="#300860" stop-opacity="0.2"/>
+    <stop offset="100%" stop-color="#300860" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#dim-glow)"/>
+
+  <!-- Mycelium strands — fading, losing brightness -->
+  <g stroke="#200840" stroke-width="1.2" fill="none" opacity="0.35">
+    <path d="M200,130 Q170,110 140,90 Q110,70 80,55"/>
+    <path d="M200,130 Q215,100 225,70 Q232,50 235,30"/>
+    <path d="M200,130 Q185,100 175,70 Q168,50 165,30"/>
+    <path d="M200,130 Q230,110 260,90 Q290,70 320,55"/>
+    <path d="M200,130 Q155,125 110,120 Q70,115 35,110"/>
+    <path d="M200,130 Q245,125 290,120 Q330,115 365,110"/>
+    <path d="M200,130 Q200,155 200,185 Q200,205 200,220"/>
+  </g>
+  <!-- Network nodes — most dark, a few still faintly lit -->
+  <g fill="#401060" opacity="0.4">
+    <circle cx="140" cy="90"  r="2.5"/>
+    <circle cx="260" cy="90"  r="2.5"/>
+    <circle cx="175" cy="70"  r="2"/>
+    <circle cx="225" cy="70"  r="2"/>
+  </g>
+  <!-- Central node — dimming out -->
+  <circle cx="200" cy="130" r="10" fill="#180630" stroke="#401068" stroke-width="1" opacity="0.6"/>
+  <circle cx="200" cy="130" r="5"  fill="#300c58" opacity="0.5"/>
+  <circle cx="200" cy="130" r="2"  fill="#6018a0" opacity="0.4"/>
+
+  <!-- THE ROOT QUEEN FORM — dispersing, dissolving back into the network -->
+  <!-- Main trunk — fragmenting -->
+  <line x1="200" y1="210" x2="200" y2="130" stroke="#180828" stroke-width="6" stroke-linecap="round" opacity="0.6"/>
+  <!-- Fragmenting branches — some breaking away -->
+  <line x1="200" y1="165" x2="172" y2="148" stroke="#140620" stroke-width="4" stroke-linecap="round" opacity="0.5"/>
+  <line x1="200" y1="165" x2="228" y2="148" stroke="#140620" stroke-width="4" stroke-linecap="round" opacity="0.5"/>
+  <!-- Upper filaments — going dark, drooping -->
+  <g stroke="#280a40" stroke-width="1.2" fill="none" opacity="0.4">
+    <path d="M200,130 Q193,118 189,108 Q188,100 192,93"/>
+    <path d="M200,130 Q207,118 211,108 Q212,100 208,93"/>
+  </g>
+  <!-- Eyes — closing, fading -->
+  <circle cx="194" cy="128" r="2" fill="#400a70" opacity="0.3"/>
+  <circle cx="206" cy="128" r="2" fill="#400a70" opacity="0.3"/>
+  <!-- Disconnecting root tendrils — floating free, dissipating -->
+  <g stroke="#180630" stroke-width="0.8" fill="none" opacity="0.3">
+    <path d="M190,210 Q182,215 175,220"/>
+    <path d="M200,210 Q200,218 200,225"/>
+    <path d="M210,210 Q218,215 225,220"/>
+    <path d="M180,205 Q168,212 155,218"/>
+    <path d="M220,205 Q232,212 245,218"/>
+  </g>
+
+  <!-- Spores — falling now instead of floating up — settling -->
+  <g fill="#601890" opacity="0.35">
+    <circle cx="80"  cy="80"  r="1.2"/>
+    <circle cx="130" cy="65"  r="1"/>
+    <circle cx="180" cy="50"  r="1.2"/>
+    <circle cx="220" cy="55"  r="1"/>
+    <circle cx="270" cy="62"  r="1.2"/>
+    <circle cx="320" cy="75"  r="1"/>
+    <circle cx="100" cy="110" r="0.8"/>
+    <circle cx="300" cy="108" r="0.8"/>
+  </g>
+  <!-- Floor mushrooms — caps drooping slightly -->
+  <g opacity="0.5">
+    <!-- Left mushrooms dim -->
+    <line x1="70" y1="200" x2="68" y2="172" stroke="#100828" stroke-width="4" stroke-linecap="round"/>
+    <ellipse cx="68" cy="170" rx="18" ry="7" fill="#14082a" stroke="#200a3c" stroke-width="0.8"/>
+    <line x1="340" y1="200" x2="342" y2="172" stroke="#100828" stroke-width="4" stroke-linecap="round"/>
+    <ellipse cx="342" cy="170" rx="18" ry="7" fill="#14082a" stroke="#200a3c" stroke-width="0.8"/>
+  </g>
+
+  <!-- Cave ceiling -->
+  <polygon points="0,0 400,0 400,40 370,30 340,45 300,28 260,44 220,26 180,42 140,25 100,42 60,28 20,44 0,32" fill="#050208"/>
+
+  <!-- Label -->
+  <text x="200" y="232" font-family="monospace" font-size="9" fill="#2a1040" text-anchor="middle" letter-spacing="3">THE ROOT QUEEN STILLS</text>
+</svg>

--- a/web/public/cutscenes/act8-outro-2.svg
+++ b/web/public/cutscenes/act8-outro-2.svg
@@ -1,0 +1,102 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#030206"/>
+
+  <linearGradient id="quiet-deep" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#040208"/>
+    <stop offset="100%" stop-color="#080312"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#quiet-deep)"/>
+
+  <!-- Soft bioluminescent ambient — the network is still, but not dead -->
+  <radialGradient id="soft-bio" cx="35%" cy="55%" r="45%">
+    <stop offset="0%" stop-color="#380870" stop-opacity="0.2"/>
+    <stop offset="100%" stop-color="#380870" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#soft-bio)"/>
+
+  <!-- Cave floor and walls -->
+  <polygon points="0,200 400,193 400,240 0,240" fill="#060309"/>
+  <polygon points="0,195 400,188 402,196 0,202" fill="#0a0412" stroke="#120618" stroke-width="1"/>
+  <!-- Mycelium mat — still, silver-purple -->
+  <g stroke="#1a0830" stroke-width="0.8" fill="none" opacity="0.3">
+    <path d="M0,200 Q80,196 160,200 Q240,204 320,200 Q360,198 400,200"/>
+  </g>
+
+  <!-- THE ROOT QUEEN — left, now just a low mound, mostly dissolved back into the floor -->
+  <!-- Residual form — truncated pillar, much smaller -->
+  <line x1="110" y1="200" x2="110" y2="170" stroke="#180828" stroke-width="5" stroke-linecap="round" opacity="0.5"/>
+  <!-- Spreading roots / mound -->
+  <ellipse cx="110" cy="200" rx="30" ry="6" fill="#0a0418" opacity="0.7"/>
+  <g stroke="#1a0830" stroke-width="1" fill="none" opacity="0.35">
+    <path d="M100,200 Q88,203 78,206"/>
+    <path d="M110,200 Q110,206 110,212"/>
+    <path d="M120,200 Q132,203 142,206"/>
+  </g>
+  <!-- Faint network glow around the mound -->
+  <radialGradient id="mound-glow" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#500a90" stop-opacity="0.25"/>
+    <stop offset="100%" stop-color="#500a90" stop-opacity="0"/>
+  </radialGradient>
+  <ellipse cx="110" cy="190" rx="40" ry="25" fill="url(#mound-glow)"/>
+  <!-- Residual eyes — very dim, level with Jarv, acknowledging -->
+  <circle cx="103" cy="173" r="2" fill="#601898" opacity="0.3"/>
+  <circle cx="117" cy="173" r="2" fill="#601898" opacity="0.3"/>
+
+  <!-- Mycelium tendrils reaching toward Jarv — non-threatening, communicating -->
+  <g stroke="#281048" stroke-width="0.8" fill="none" opacity="0.4">
+    <path d="M140,190 Q175,183 200,183 Q225,183 255,188"/>
+    <path d="M142,196 Q180,192 210,192 Q240,192 258,196"/>
+  </g>
+  <!-- Glow along the reaching strand -->
+  <circle cx="165" cy="185" r="1.5" fill="#7020c0" opacity="0.4"/>
+  <circle cx="200" cy="183" r="1.5" fill="#7020c0" opacity="0.3"/>
+  <circle cx="235" cy="185" r="1.5" fill="#7020c0" opacity="0.4"/>
+
+  <!-- JARV — right side, kneeling / crouching, at eye level with the mound -->
+  <ellipse cx="290" cy="208" rx="24" ry="5" fill="#030102" opacity="0.7"/>
+  <!-- Crouched — knees bent, sitting back on heels -->
+  <ellipse cx="283" cy="210" rx="6" ry="3" fill="#08090e"/>
+  <ellipse cx="297" cy="210" rx="6" ry="3" fill="#08090e"/>
+  <line x1="285" y1="203" x2="283" y2="210" stroke="#0c0c18" stroke-width="4" stroke-linecap="round"/>
+  <line x1="295" y1="202" x2="297" y2="210" stroke="#0c0c18" stroke-width="4" stroke-linecap="round"/>
+  <!-- Coral mantle draped on floor -->
+  <polygon points="272,180 308,180 312,203 268,203" fill="#0a1e20" stroke="#1a4040" stroke-width="1.5"/>
+  <g fill="#00c090" opacity="0.4">
+    <circle cx="268" cy="180" r="1.5"/>
+    <circle cx="312" cy="180" r="1.5"/>
+  </g>
+  <!-- Head tilted toward the Root Queen mound -->
+  <ellipse cx="288" cy="171" rx="10" ry="9" fill="#0c0c1a" stroke="#181830" stroke-width="1"/>
+  <ellipse cx="286" cy="174" rx="5.5" ry="3.5" fill="#080810"/>
+  <!-- Iron Standard — planted beside, leaning -->
+  <line x1="315" y1="178" x2="332" y2="215" stroke="#2a3040" stroke-width="2.5"/>
+  <polygon points="313,178 317,178 315,169" fill="#404860" opacity="0.7"/>
+
+  <!-- Spores drifting gently -->
+  <g fill="#7020b0" opacity="0.35">
+    <circle cx="70"  cy="80"  r="1"/>
+    <circle cx="130" cy="60"  r="1.2"/>
+    <circle cx="200" cy="50"  r="1"/>
+    <circle cx="260" cy="65"  r="1.2"/>
+    <circle cx="340" cy="75"  r="1"/>
+    <circle cx="160" cy="130" r="0.8"/>
+    <circle cx="250" cy="120" r="0.8"/>
+  </g>
+
+  <!-- Small mushrooms nearby — still softly lit -->
+  <g opacity="0.55">
+    <line x1="360" y1="200" x2="360" y2="180" stroke="#10082a" stroke-width="3" stroke-linecap="round"/>
+    <ellipse cx="360" cy="179" rx="14" ry="6" fill="#18083c" stroke="#280c58" stroke-width="0.8"/>
+    <radialGradient id="sm-glow" cx="50%" cy="100%" r="70%">
+      <stop offset="0%" stop-color="#7020c0" stop-opacity="0.3"/>
+      <stop offset="100%" stop-color="#7020c0" stop-opacity="0"/>
+    </radialGradient>
+    <ellipse cx="360" cy="179" rx="14" ry="6" fill="url(#sm-glow)"/>
+  </g>
+
+  <!-- Cave ceiling -->
+  <polygon points="0,0 400,0 400,42 372,32 345,48 308,30 265,46 225,28 185,44 145,28 108,46 65,30 25,46 0,34" fill="#050208"/>
+
+  <!-- Label -->
+  <text x="200" y="232" font-family="monospace" font-size="9" fill="#2a1040" text-anchor="middle" letter-spacing="3">WHAT SHE UNDERSTOOD</text>
+</svg>

--- a/web/public/cutscenes/act8-outro-3.svg
+++ b/web/public/cutscenes/act8-outro-3.svg
@@ -1,0 +1,126 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#030206"/>
+
+  <linearGradient id="spore-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#040208"/>
+    <stop offset="50%" stop-color="#07030f"/>
+    <stop offset="100%" stop-color="#0a0418"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#spore-sky)"/>
+
+  <!-- Bioluminescent bloom — warm and alive -->
+  <radialGradient id="bloom-glow" cx="50%" cy="40%" r="45%">
+    <stop offset="0%" stop-color="#601898" stop-opacity="0.45"/>
+    <stop offset="50%" stop-color="#401068" stop-opacity="0.2"/>
+    <stop offset="100%" stop-color="#401068" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#bloom-glow)"/>
+
+  <!-- THE SPORE BLOOM — centre frame, dense warm cluster, technically a seed -->
+  <!-- Outer spore halo — many tiny spores orbiting -->
+  <g fill="#a030e0" opacity="0.4">
+    <circle cx="200" cy="95"  r="1.5"/>
+    <circle cx="230" cy="85"  r="1.2"/>
+    <circle cx="245" cy="100" r="1"/>
+    <circle cx="240" cy="115" r="1.5"/>
+    <circle cx="225" cy="128" r="1.2"/>
+    <circle cx="205" cy="132" r="1"/>
+    <circle cx="185" cy="130" r="1.5"/>
+    <circle cx="170" cy="118" r="1.2"/>
+    <circle cx="162" cy="102" r="1"/>
+    <circle cx="168" cy="86"  r="1.5"/>
+    <circle cx="182" cy="76"  r="1.2"/>
+    <circle cx="200" cy="72"  r="1"/>
+    <circle cx="216" cy="75"  r="1.5"/>
+  </g>
+  <!-- Outer ring glow -->
+  <radialGradient id="bloom-outer" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#8020c0" stop-opacity="0.35"/>
+    <stop offset="60%" stop-color="#6010a0" stop-opacity="0.1"/>
+    <stop offset="100%" stop-color="#6010a0" stop-opacity="0"/>
+  </radialGradient>
+  <circle cx="200" cy="103" r="50" fill="url(#bloom-outer)"/>
+
+  <!-- Spore Bloom body — irregular, organic cluster -->
+  <!-- Main cluster mass -->
+  <circle cx="200" cy="103" r="28" fill="#0e0520" stroke="#3a0c68" stroke-width="1.5"/>
+  <!-- Inner organic texture — bumpy, seed-like -->
+  <g fill="#160830" stroke="#280a50" stroke-width="0.8" opacity="0.9">
+    <circle cx="200" cy="103" r="20"/>
+    <circle cx="192" cy="96"  r="8"/>
+    <circle cx="210" cy="98"  r="9"/>
+    <circle cx="204" cy="112" r="8"/>
+    <circle cx="193" cy="110" r="7"/>
+  </g>
+  <!-- Bioluminescent veins running through it -->
+  <g stroke="#c040ff" stroke-width="0.8" fill="none" opacity="0.6">
+    <path d="M192,88 Q196,96 192,104 Q196,112 192,118"/>
+    <path d="M208,88 Q204,96 208,104 Q204,112 208,118"/>
+    <path d="M180,103 Q190,99 200,103 Q210,99 220,103"/>
+  </g>
+  <!-- Central bright node — the seed's core -->
+  <circle cx="200" cy="103" r="8"  fill="#200840" stroke="#7018c0" stroke-width="1"/>
+  <circle cx="200" cy="103" r="4"  fill="#8020d0" opacity="0.7"/>
+  <circle cx="200" cy="103" r="2"  fill="#d060ff" opacity="0.9"/>
+  <!-- Warm teal glow — it is technically alive -->
+  <radialGradient id="life-glow" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#20b080" stop-opacity="0.3"/>
+    <stop offset="100%" stop-color="#20b080" stop-opacity="0"/>
+  </radialGradient>
+  <circle cx="200" cy="103" r="28" fill="url(#life-glow)"/>
+
+  <!-- JARV below — arms raised, receiving the relic -->
+  <ellipse cx="200" cy="222" rx="22" ry="4" fill="#030102" opacity="0.7"/>
+  <!-- Boots -->
+  <ellipse cx="194" cy="225" rx="5" ry="2" fill="#08090e"/>
+  <ellipse cx="207" cy="225" rx="5" ry="2" fill="#08090e"/>
+  <!-- Legs -->
+  <line x1="196" y1="215" x2="194" y2="225" stroke="#0c0c18" stroke-width="4" stroke-linecap="round"/>
+  <line x1="205" y1="215" x2="207" y2="225" stroke="#0c0c18" stroke-width="4" stroke-linecap="round"/>
+  <!-- Coral Mantle -->
+  <polygon points="183,184 217,184 222,214 178,214" fill="#0a1e20" stroke="#1a4040" stroke-width="1.5"/>
+  <g fill="#00c090" opacity="0.4">
+    <circle cx="178" cy="184" r="1.5"/>
+    <circle cx="222" cy="184" r="1.5"/>
+  </g>
+  <!-- Arms reaching up -->
+  <line x1="183" y1="191" x2="164" y2="168" stroke="#0c0c18" stroke-width="4" stroke-linecap="round"/>
+  <line x1="217" y1="191" x2="236" y2="168" stroke="#0c0c18" stroke-width="4" stroke-linecap="round"/>
+  <polygon points="158,163 168,162 170,173 160,174" fill="#0d0e1a" stroke="#181830" stroke-width="0.8"/>
+  <polygon points="232,163 242,162 244,173 234,174" fill="#0d0e1a" stroke="#181830" stroke-width="0.8"/>
+  <!-- Head -->
+  <ellipse cx="200" cy="175" rx="10" ry="9" fill="#0c0c1a" stroke="#181830" stroke-width="1"/>
+  <ellipse cx="200" cy="178" rx="5" ry="3.5" fill="#080810"/>
+
+  <!-- Transfer glow from bloom to hands -->
+  <g stroke="#6018a0" stroke-width="0.8" fill="none" opacity="0.35">
+    <path d="M176,118 Q170,142 163,166"/>
+    <path d="M224,118 Q230,142 237,166"/>
+  </g>
+
+  <!-- Scattered spores — the bloom releasing as it's touched -->
+  <g fill="#9030d0" opacity="0.5">
+    <circle cx="140" cy="90"  r="1.2"/>
+    <circle cx="260" cy="88"  r="1.2"/>
+    <circle cx="120" cy="115" r="1"/>
+    <circle cx="280" cy="112" r="1"/>
+    <circle cx="160" cy="65"  r="1.5"/>
+    <circle cx="240" cy="62"  r="1.5"/>
+    <circle cx="100" cy="50"  r="1"/>
+    <circle cx="300" cy="48"  r="1"/>
+  </g>
+
+  <!-- Mushroom silhouettes at bottom corners -->
+  <g opacity="0.45">
+    <line x1="45" y1="225" x2="43" y2="198" stroke="#0e0628" stroke-width="4" stroke-linecap="round"/>
+    <ellipse cx="43" cy="196" rx="20" ry="8" fill="#160838" stroke="#24085a" stroke-width="0.8"/>
+    <line x1="355" y1="225" x2="357" y2="198" stroke="#0e0628" stroke-width="4" stroke-linecap="round"/>
+    <ellipse cx="357" cy="196" rx="20" ry="8" fill="#160838" stroke="#24085a" stroke-width="0.8"/>
+  </g>
+
+  <!-- Cave ceiling framing -->
+  <polygon points="0,0 400,0 400,35 370,25 335,40 295,22 255,38 215,20 185,36 155,20 115,38 75,22 35,40 0,26" fill="#050208"/>
+
+  <!-- Label -->
+  <text x="200" y="238" font-family="monospace" font-size="9" fill="#2a1040" text-anchor="middle" letter-spacing="3">THE SPORE BLOOM</text>
+</svg>

--- a/web/src/data/acts/act7.json
+++ b/web/src/data/acts/act7.json
@@ -43,29 +43,35 @@
   "intro": [
     {
       "title": "THE EMBERFALL PEAKS",
-      "text": "The ley lines cut through the mountains here — through layers of volcanic rock still warm from the last eruption. This is the Emberfall Peaks: a chain of active volcanoes that the Fracture cracked open and left to simmer.\n\nThings live here. Heat-adapted things. Things that were dangerous before the Fracture made them angrier.\n\nThe ley path goes through the caldera. There's no route around."
+      "text": "The ley lines cut through the mountains here — through layers of volcanic rock still warm from the last eruption. This is the Emberfall Peaks: a chain of active volcanoes that the Fracture cracked open and left to simmer.\n\nThings live here. Heat-adapted things. Things that were dangerous before the Fracture made them angrier.\n\nThe ley path goes through the caldera. There's no route around.",
+      "image": "cutscenes/act7-intro-1.svg"
     },
     {
       "title": "THE CINDERWARLORD",
-      "text": "The Peaks are held by the Cinderwarlord — a commander who built an army out of whatever the volcanoes threw up: crawlers, hounds, archers who fire molten shot, constructs assembled from cooled lava-flow.\n\nHe has not lost the mountains once. The mountains are on his side. Literally. He has an understanding with them.\n\nYou are going to walk through his territory regardless."
+      "text": "The Peaks are held by the Cinderwarlord — a commander who built an army out of whatever the volcanoes threw up: crawlers, hounds, archers who fire molten shot, constructs assembled from cooled lava-flow.\n\nHe has not lost the mountains once. The mountains are on his side. Literally. He has an understanding with them.\n\nYou are going to walk through his territory regardless.",
+      "image": "cutscenes/act7-intro-2.svg"
     },
     {
       "title": "HEAT AND PRESSURE",
-      "text": "The deeper you go, the hotter it gets. The ley lines are visible here — they glow faintly orange, like metal near a forge, and they point straight toward the caldera at the heart of the range.\n\nWhatever is at the Fracture Core, the ley lines think this is the way.\n\nYou have learned to trust the ley lines. You have also learned to bring extra water."
+      "text": "The deeper you go, the hotter it gets. The ley lines are visible here — they glow faintly orange, like metal near a forge, and they point straight toward the caldera at the heart of the range.\n\nWhatever is at the Fracture Core, the ley lines think this is the way.\n\nYou have learned to trust the ley lines. You have also learned to bring extra water.",
+      "image": "cutscenes/act7-intro-3.svg"
     }
   ],
   "outro": [
     {
       "title": "THE CINDERWARLORD FALLS",
-      "text": "The Cinderwarlord does not retreat. He stands in the caldera as the ground cracks around him, and he waits for the mountain to finish the job.\n\nThe mountain does not finish the job.\n\nHe concedes the terrain with the precision of someone who has done it once before and always swore he wouldn't do it again."
+      "text": "The Cinderwarlord does not retreat. He stands in the caldera as the ground cracks around him, and he waits for the mountain to finish the job.\n\nThe mountain does not finish the job.\n\nHe concedes the terrain with the precision of someone who has done it once before and always swore he wouldn't do it again.",
+      "image": "cutscenes/act7-outro-1.svg"
     },
     {
       "title": "WHAT HE SAID",
-      "text": "'You shouldn't be able to fight in this heat,' he said.\n\nYou told him you'd had practice.\n\n'That's not the point,' he said. He seemed genuinely bothered by the logistics of it."
+      "text": "'You shouldn't be able to fight in this heat,' he said.\n\nYou told him you'd had practice.\n\n'That's not the point,' he said. He seemed genuinely bothered by the logistics of it.",
+      "image": "cutscenes/act7-outro-2.svg"
     },
     {
       "title": "DEEPER IN",
-      "text": "The Magma Core sits in your hand — a solid chunk of volcanic glass with something still burning at the centre. The Cinderwarlord's mark of command.\n\nThe ley lines glow brighter past the caldera. Whatever the Fracture Core is, it's warmer on this side.\n\nYou move forward. The mountains stop objecting."
+      "text": "The Magma Core sits in your hand — a solid chunk of volcanic glass with something still burning at the centre. The Cinderwarlord's mark of command.\n\nThe ley lines glow brighter past the caldera. Whatever the Fracture Core is, it's warmer on this side.\n\nYou move forward. The mountains stop objecting.",
+      "image": "cutscenes/act7-outro-3.svg"
     }
   ],
   "nodes": {

--- a/web/src/data/acts/act8.json
+++ b/web/src/data/acts/act8.json
@@ -43,29 +43,35 @@
   "intro": [
     {
       "title": "THE FUNGAL DEEP",
-      "text": "The ley lines go down here.\n\nNot metaphorically. They descend through the rock, through collapsed caverns, through layers of earth that haven't seen light since the Fracture shattered the surface above them. The mycelium found the ley lines years ago and grew around them. It's been feeding ever since.\n\nYou will need to go down into it."
+      "text": "The ley lines go down here.\n\nNot metaphorically. They descend through the rock, through collapsed caverns, through layers of earth that haven't seen light since the Fracture shattered the surface above them. The mycelium found the ley lines years ago and grew around them. It's been feeding ever since.\n\nYou will need to go down into it.",
+      "image": "cutscenes/act8-intro-1.svg"
     },
     {
       "title": "THE ROOT QUEEN",
-      "text": "The Fungal Deep is not ruled. It is tended.\n\nThe Root Queen is not a person in any conventional sense — she's the oldest node in the mycelium network, the point everything connects back to. She doesn't give orders. She pulses. Things respond.\n\nShe has been aware of you since you entered the first cavern. She has been deciding what to do about you. She has decided."
+      "text": "The Fungal Deep is not ruled. It is tended.\n\nThe Root Queen is not a person in any conventional sense — she's the oldest node in the mycelium network, the point everything connects back to. She doesn't give orders. She pulses. Things respond.\n\nShe has been aware of you since you entered the first cavern. She has been deciding what to do about you. She has decided.",
+      "image": "cutscenes/act8-intro-2.svg"
     },
     {
       "title": "GOING UNDER",
-      "text": "You've fought in forests and on volcanoes and in the sky. This is different. This is enclosed, and wet, and alive in a way that makes you aware you are the only thing down here that breathes with lungs.\n\nThe mycelium doesn't sleep. It doesn't stop growing. It doesn't get tired.\n\nYou just need to reach the Root Queen before she finishes deciding."
+      "text": "You've fought in forests and on volcanoes and in the sky. This is different. This is enclosed, and wet, and alive in a way that makes you aware you are the only thing down here that breathes with lungs.\n\nThe mycelium doesn't sleep. It doesn't stop growing. It doesn't get tired.\n\nYou just need to reach the Root Queen before she finishes deciding.",
+      "image": "cutscenes/act8-intro-3.svg"
     }
   ],
   "outro": [
     {
       "title": "THE ROOT QUEEN STILLS",
-      "text": "The network doesn't die. That would be too simple.\n\nIt stills — a long, slow reduction, like a fire burning down rather than going out. The Root Queen doesn't speak exactly, but something that constitutes speech passes through the mycelium and reaches you: something that means 'enough.'\n\nThe ley lines pulse clear. The way opens downward."
+      "text": "The network doesn't die. That would be too simple.\n\nIt stills — a long, slow reduction, like a fire burning down rather than going out. The Root Queen doesn't speak exactly, but something that constitutes speech passes through the mycelium and reaches you: something that means 'enough.'\n\nThe ley lines pulse clear. The way opens downward.",
+      "image": "cutscenes/act8-outro-1.svg"
     },
     {
       "title": "WHAT SHE UNDERSTOOD",
-      "text": "She didn't fight because she was angry. She fought because the network told her something was moving through the deep that didn't belong to it, and the network is very old and has very clear feelings about that sort of thing.\n\nShe understood, eventually. You also don't entirely belong to the things that are trying to stop you.\n\nShe let the ley lines pass."
+      "text": "She didn't fight because she was angry. She fought because the network told her something was moving through the deep that didn't belong to it, and the network is very old and has very clear feelings about that sort of thing.\n\nShe understood, eventually. You also don't entirely belong to the things that are trying to stop you.\n\nShe let the ley lines pass.",
+      "image": "cutscenes/act8-outro-2.svg"
     },
     {
       "title": "THE SPORE BLOOM",
-      "text": "The Spore Bloom sits in your hand — a dense, warm cluster of something that is technically a seed but feels considerably more significant than that.\n\nThe mycelium connected to it as you left, briefly. You got the impression it was saying goodbye.\n\nThe ley lines run deeper. They always run deeper. That, at least, is consistent."
+      "text": "The Spore Bloom sits in your hand — a dense, warm cluster of something that is technically a seed but feels considerably more significant than that.\n\nThe mycelium connected to it as you left, briefly. You got the impression it was saying goodbye.\n\nThe ley lines run deeper. They always run deeper. That, at least, is consistent.",
+      "image": "cutscenes/act8-outro-3.svg"
     }
   ],
   "nodes": {
@@ -683,8 +689,8 @@
     "node-1776872005580": {
       "id": "node-1776872005580",
       "type": "elite",
-  "label": "Tendril Nexus",
-  "description": "A knotted mass of aggressive growths converges here, reacting violently to intrusion.",
+      "label": "Tendril Nexus",
+      "description": "A knotted mass of aggressive growths converges here, reacting violently to intrusion.",
       "row": 6,
       "col": 1,
       "rowCols": 2,
@@ -716,8 +722,8 @@
     "node-1776872007977": {
       "id": "node-1776872007977",
       "type": "elite",
-  "label": "Vanguard Cluster",
-  "description": "Fragments of the Root Queen’s will, acting in eerie synchrony.",
+      "label": "Vanguard Cluster",
+      "description": "Fragments of the Root Queen’s will, acting in eerie synchrony.",
       "row": 6,
       "col": 0,
       "rowCols": 2,
@@ -781,8 +787,8 @@
     "node-1776872044010": {
       "id": "node-1776872044010",
       "type": "battle",
-  "label": "Spinecap Expanse",
-  "description": "Tall fungal growths sway slightly, releasing spores that track your movement.",
+      "label": "Spinecap Expanse",
+      "description": "Tall fungal growths sway slightly, releasing spores that track your movement.",
       "row": 7,
       "col": 1,
       "rowCols": 4,
@@ -813,8 +819,8 @@
     "node-1776872044955": {
       "id": "node-1776872044955",
       "type": "battle",
-  "label": "Veil of Spores",
-  "description": "A hazy cloud obscures vision; something moves within it before you do.",
+      "label": "Veil of Spores",
+      "description": "A hazy cloud obscures vision; something moves within it before you do.",
       "row": 7,
       "col": 2,
       "rowCols": 4,
@@ -845,8 +851,8 @@
     "node-1776872045815": {
       "id": "node-1776872045815",
       "type": "battle",
-  "label": "Mycelial Threshold",
-  "description": "A boundary zone where the network thickens, as if resisting your advance.",
+      "label": "Mycelial Threshold",
+      "description": "A boundary zone where the network thickens, as if resisting your advance.",
       "row": 7,
       "col": 3,
       "rowCols": 4,
@@ -877,8 +883,8 @@
     "node-1776872052910": {
       "id": "node-1776872052910",
       "type": "battle",
-  "label": "Fungal Driftway",
-  "description": "Loose layers of fungal matter shift underfoot, carrying signals deeper into the network.",
+      "label": "Fungal Driftway",
+      "description": "Loose layers of fungal matter shift underfoot, carrying signals deeper into the network.",
       "row": 9,
       "col": 0,
       "rowCols": 3,
@@ -909,8 +915,8 @@
     "node-1776872059912": {
       "id": "node-1776872059912",
       "type": "battle",
-  "label": "Sporecurrent Path",
-  "description": "Air currents push spores in rhythmic waves, almost like breathing.",
+      "label": "Sporecurrent Path",
+      "description": "Air currents push spores in rhythmic waves, almost like breathing.",
       "row": 9,
       "col": 1,
       "rowCols": 3,
@@ -941,8 +947,8 @@
     "node-1776872067715": {
       "id": "node-1776872067715",
       "type": "rest",
-  "label": "Silent Reservoir",
-  "description": "A rare untouched pool. The absence of mycelium feels unnatural.",
+      "label": "Silent Reservoir",
+      "description": "A rare untouched pool. The absence of mycelium feels unnatural.",
       "row": 8,
       "col": 0,
       "rowCols": 4,
@@ -955,8 +961,8 @@
     "node-1776872069113": {
       "id": "node-1776872069113",
       "type": "merchant",
-  "label": "Subterranean Broker",
-  "description": "A quiet trader dealing in bioluminescent and questionably sourced goods.",
+      "label": "Subterranean Broker",
+      "description": "A quiet trader dealing in bioluminescent and questionably sourced goods.",
       "row": 8,
       "col": 1,
       "rowCols": 4,
@@ -968,8 +974,8 @@
     "node-1776872070361": {
       "id": "node-1776872070361",
       "type": "event",
-  "label": "Memory Lattice",
-  "description": "Crystalline strands store echoes of the past, faintly humming with old signals.",
+      "label": "Memory Lattice",
+      "description": "Crystalline strands store echoes of the past, faintly humming with old signals.",
       "row": 8,
       "col": 2,
       "rowCols": 4,
@@ -1023,8 +1029,8 @@
     "node-1776872071261": {
       "id": "node-1776872071261",
       "type": "event",
-  "label": "Spore Fissure",
-  "description": "A cracked vent releases bursts of spores carrying fragmented impressions.",
+      "label": "Spore Fissure",
+      "description": "A cracked vent releases bursts of spores carrying fragmented impressions.",
       "row": 8,
       "col": 3,
       "rowCols": 4,
@@ -1101,8 +1107,8 @@
     "node-1776872129768": {
       "id": "node-1776872129768",
       "type": "rest",
-  "label": "Clearwater Hollow",
-  "description": "A calm basin of water, strangely isolated from the surrounding growth.",
+      "label": "Clearwater Hollow",
+      "description": "A calm basin of water, strangely isolated from the surrounding growth.",
       "row": 11,
       "col": 0,
       "rowCols": 1,
@@ -1115,8 +1121,8 @@
     "node-1776872141075": {
       "id": "node-1776872141075",
       "type": "elite",
-  "label": "Heart-Tendrils",
-  "description": "These growths pulse in unison, striking with coordinated precision.",
+      "label": "Heart-Tendrils",
+      "description": "These growths pulse in unison, striking with coordinated precision.",
       "row": 10,
       "col": 0,
       "rowCols": 1,
@@ -1147,8 +1153,8 @@
     "node-1776872152088": {
       "id": "node-1776872152088",
       "type": "battle",
-  "label": "Deepgrowth Crossing",
-  "description": "Here the mycelium grows unchecked, thick enough to feel like muscle beneath you.",
+      "label": "Deepgrowth Crossing",
+      "description": "Here the mycelium grows unchecked, thick enough to feel like muscle beneath you.",
       "row": 9,
       "col": 2,
       "rowCols": 3,


### PR DESCRIPTION
## Summary

- Adds 6 SVG cutscene panels for Act 7 (The Emberfall Peaks): 3 intro + 3 outro
- Adds 6 SVG cutscene panels for Act 8 (The Fungal Deep): 3 intro + 3 outro
- Wires `image` fields into `act7.json` and `act8.json`

## Act 7 Panels — volcanic red/orange palette

| File | Title |
|------|-------|
| `act7-intro-1.svg` | THE EMBERFALL PEAKS — volcanic mountain range, lava flows, ley lines glowing through rock |
| `act7-intro-2.svg` | THE CINDERWARLORD — armoured commander, forge-fire helm with glowing visor slits, slag hammer |
| `act7-intro-3.svg` | HEAT AND PRESSURE — deep cave with blazing horizontal ley seams and magma pools through floor cracks |
| `act7-outro-1.svg` | THE CINDERWARLORD FALLS — collapsed armour in cracking caldera, lava erupting at walls |
| `act7-outro-2.svg` | WHAT HE SAID — post-battle in cooling caldera, Cinderwarlord slumped against wall |
| `act7-outro-3.svg` | DEEPER IN — Magma Core relic (volcanic glass with molten centre), Jarv receiving it arms raised |

## Act 8 Panels — bioluminescent purple/teal palette

| File | Title |
|------|-------|
| `act8-intro-1.svg` | THE FUNGAL DEEP — cave with glowing mushroom clusters, ley line descending into floor |
| `act8-intro-2.svg` | THE ROOT QUEEN — mycelial network entity, branching trunk radiating strands, node-eyes |
| `act8-intro-3.svg` | GOING UNDER — tunnel perspective with dense spore atmosphere and watching eyes in the dark |
| `act8-outro-1.svg` | THE ROOT QUEEN STILLS — network dimming, trunk dissolving, spores settling |
| `act8-outro-2.svg` | WHAT SHE UNDERSTOOD — Jarv crouched as residual mound sends tendrils toward him |
| `act8-outro-3.svg` | THE SPORE BLOOM — dense bioluminescent relic cluster, Jarv receiving it arms raised |

## Test plan

- [ ] Run `npm run build` — passes with no errors
- [ ] Play to Act 7, verify intro and outro cutscenes show all panels with graphics
- [ ] Play to Act 8, verify intro and outro cutscenes show all panels with graphics
- [ ] Art style matches Acts 1–6 (dark background, monospace label, 400×240 viewBox)

https://claude.ai/code/session_01GXML372usPatkqhfiuvdWX