### PR TITLE
Act 9 cutscene graphics — The Frozen Expanse

### DIFF
--- a/web/public/cutscenes/act9-intro-1.svg
+++ b/web/public/cutscenes/act9-intro-1.svg
@@ -1,0 +1,91 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#030810"/>
+
+  <linearGradient id="ice-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#040c18"/>
+    <stop offset="50%" stop-color="#081424"/>
+    <stop offset="100%" stop-color="#0c1c30"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#ice-sky)"/>
+
+  <!-- Cold atmospheric haze — pale blue -->
+  <radialGradient id="cold-haze" cx="50%" cy="40%" r="60%">
+    <stop offset="0%" stop-color="#102840" stop-opacity="0.3"/>
+    <stop offset="100%" stop-color="#102840" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#cold-haze)"/>
+
+  <!-- Distant frozen horizon — flat, vast -->
+  <rect x="0" y="155" width="400" height="85" fill="#060e18"/>
+  <line x1="0" y1="155" x2="400" y2="155" stroke="#10243a" stroke-width="1.5"/>
+
+  <!-- Ice surface texture — flat, cracked -->
+  <g stroke="#0e2030" stroke-width="0.6" fill="none" opacity="0.5">
+    <path d="M0,165 Q60,162 120,165 Q180,168 240,165 Q300,162 360,165 Q380,167 400,165"/>
+    <path d="M0,178 Q80,174 160,178 Q240,182 320,178 Q370,180 400,178"/>
+    <path d="M0,192 Q100,188 200,192 Q300,196 400,192"/>
+    <!-- Cracks in ice -->
+    <path d="M50,160 Q55,170 58,185 Q60,195 62,210"/>
+    <path d="M150,158 Q148,168 153,180 Q156,193 154,208"/>
+    <path d="M280,160 Q285,172 282,186 Q280,198 283,215"/>
+    <path d="M370,162 Q368,175 372,188 Q374,200 370,215"/>
+  </g>
+
+  <!-- THE LEY LINES — bright orange running straight through the ice -->
+  <!-- Main horizontal ley line — most prominent -->
+  <linearGradient id="ley-h" x1="0" y1="0" x2="1" y2="0">
+    <stop offset="0%" stop-color="#c04000" stop-opacity="0.3"/>
+    <stop offset="20%" stop-color="#ff6020" stop-opacity="0.9"/>
+    <stop offset="50%" stop-color="#ff8030" stop-opacity="1"/>
+    <stop offset="80%" stop-color="#ff6020" stop-opacity="0.9"/>
+    <stop offset="100%" stop-color="#c04000" stop-opacity="0.3"/>
+  </linearGradient>
+  <rect x="0" y="166" width="400" height="5" fill="url(#ley-h)"/>
+  <rect x="0" y="167" width="400" height="3" fill="#ffb060" opacity="0.5"/>
+
+  <!-- Secondary ley line — slightly angled, deeper in the ice -->
+  <line x1="0" y1="178" x2="400" y2="172" stroke="#e05010" stroke-width="3" opacity="0.6"/>
+  <line x1="0" y1="178" x2="400" y2="172" stroke="#ff7020" stroke-width="1" opacity="0.5"/>
+
+  <!-- Ley glow through ice above the lines — they're below but glow upward -->
+  <radialGradient id="ley-ice-glow" cx="50%" cy="100%" r="50%">
+    <stop offset="0%" stop-color="#c04000" stop-opacity="0.3"/>
+    <stop offset="100%" stop-color="#c04000" stop-opacity="0"/>
+  </radialGradient>
+  <rect x="0" y="130" width="400" height="40" fill="url(#ley-ice-glow)"/>
+
+  <!-- Ice formations — frozen pillars/ridges on horizon -->
+  <g fill="#060e1c" stroke="#0e1e2e" stroke-width="1">
+    <!-- Left ridge -->
+    <polygon points="0,155 30,118 60,130 80,108 110,125 130,155"/>
+    <!-- Right ridge -->
+    <polygon points="270,155 295,112 320,128 345,105 370,120 400,140 400,155"/>
+  </g>
+  <!-- Ice sheen on ridges -->
+  <g fill="#102030" opacity="0.5">
+    <polygon points="30,118 45,120 60,130 50,125"/>
+    <polygon points="80,108 95,115 110,125 95,118"/>
+    <polygon points="295,112 310,118 320,128 308,120"/>
+    <polygon points="345,105 358,112 370,120 355,110"/>
+  </g>
+
+  <!-- Stars — cold, blue-white -->
+  <g fill="#a0c0e0" opacity="0.4">
+    <circle cx="40"  cy="20" r="1.2"/>
+    <circle cx="100" cy="12" r="1"/>
+    <circle cx="180" cy="18" r="1.5"/>
+    <circle cx="250" cy="8"  r="1"/>
+    <circle cx="340" cy="22" r="1.2"/>
+    <circle cx="380" cy="14" r="1"/>
+  </g>
+  <!-- Faint aurora — blue-green wash at horizon -->
+  <linearGradient id="aurora" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#102838" stop-opacity="0"/>
+    <stop offset="70%" stop-color="#082838" stop-opacity="0.2"/>
+    <stop offset="100%" stop-color="#062028" stop-opacity="0.3"/>
+  </linearGradient>
+  <rect x="0" y="60" width="400" height="95" fill="url(#aurora)"/>
+
+  <!-- Label -->
+  <text x="200" y="232" font-family="monospace" font-size="9" fill="#1a3050" text-anchor="middle" letter-spacing="3">THE FROZEN EXPANSE</text>
+</svg>

--- a/web/public/cutscenes/act9-intro-2.svg
+++ b/web/public/cutscenes/act9-intro-2.svg
@@ -1,0 +1,129 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#030810"/>
+
+  <linearGradient id="eng-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#040c18"/>
+    <stop offset="100%" stop-color="#0a1828"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#eng-sky)"/>
+
+  <!-- Cold pale atmospheric glow — the Engine emits its own faint light -->
+  <radialGradient id="engine-atm" cx="50%" cy="45%" r="50%">
+    <stop offset="0%" stop-color="#203850" stop-opacity="0.3"/>
+    <stop offset="100%" stop-color="#203850" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#engine-atm)"/>
+
+  <!-- Ice floor -->
+  <rect x="0" y="195" width="400" height="45" fill="#060e18"/>
+  <line x1="0" y1="195" x2="400" y2="195" stroke="#0e2030" stroke-width="1"/>
+  <!-- Ley lines through floor — orange under ice -->
+  <rect x="0" y="198" width="400" height="3" fill="#e05010" opacity="0.4"/>
+  <rect x="0" y="199" width="400" height="1" fill="#ff8030" opacity="0.3"/>
+
+  <!-- Shadow -->
+  <ellipse cx="200" cy="205" rx="55" ry="9" fill="#030608" opacity="0.8"/>
+
+  <!-- THE PALE ENGINE — a towering ancient machine, geometric, not humanoid -->
+  <!-- Base — wide, heavy plinth of cold grey metal -->
+  <rect x="145" y="180" width="110" height="20" rx="2" fill="#0e1a28" stroke="#182838" stroke-width="1.5"/>
+  <!-- Plinth detail — corroded rivets -->
+  <g fill="#182838" opacity="0.7">
+    <circle cx="155" cy="190" r="2"/>
+    <circle cx="245" cy="190" r="2"/>
+    <circle cx="165" cy="190" r="2"/>
+    <circle cx="235" cy="190" r="2"/>
+    <circle cx="200" cy="190" r="2"/>
+  </g>
+
+  <!-- Main body — tall column, multi-segmented -->
+  <rect x="163" y="120" width="74" height="62" fill="#0c1824" stroke="#182838" stroke-width="1.5"/>
+  <!-- Body segment dividers -->
+  <line x1="163" y1="140" x2="237" y2="140" stroke="#182838" stroke-width="1"/>
+  <line x1="163" y1="158" x2="237" y2="158" stroke="#182838" stroke-width="1"/>
+  <!-- Body detail — intake vents -->
+  <g fill="#080e18" stroke="#101820" stroke-width="0.5">
+    <rect x="170" y="125" width="18" height="10" rx="1"/>
+    <rect x="212" y="125" width="18" height="10" rx="1"/>
+    <rect x="170" y="143" width="18" height="10" rx="1"/>
+    <rect x="212" y="143" width="18" height="10" rx="1"/>
+  </g>
+  <!-- Pale blue glow from vents — still running, still processing -->
+  <g fill="#2060a0" opacity="0.3">
+    <rect x="170" y="125" width="18" height="10" rx="1"/>
+    <rect x="212" y="125" width="18" height="10" rx="1"/>
+    <rect x="170" y="143" width="18" height="10" rx="1"/>
+    <rect x="212" y="143" width="18" height="10" rx="1"/>
+  </g>
+
+  <!-- Upper section — narrowing, more mechanical complexity -->
+  <rect x="172" y="80" width="56" height="42" fill="#0e1c2c" stroke="#182838" stroke-width="1.5"/>
+  <!-- Processing unit — geometric face-like array -->
+  <rect x="178" y="86" width="16" height="12" rx="1" fill="#081420" stroke="#182838" stroke-width="0.8"/>
+  <rect x="206" y="86" width="16" height="12" rx="1" fill="#081420" stroke="#182838" stroke-width="0.8"/>
+  <!-- Eyes — rectangular, pale blue scanning lights -->
+  <rect x="179" y="87" width="14" height="10" rx="1" fill="#1040a0" opacity="0.7"/>
+  <rect x="207" y="87" width="14" height="10" rx="1" fill="#1040a0" opacity="0.7"/>
+  <!-- Scanning beam line — active processing -->
+  <line x1="186" y1="92" x2="214" y2="92" stroke="#4080e0" stroke-width="0.8" opacity="0.5"/>
+  <!-- Lower face grid — data processing mesh -->
+  <g stroke="#182838" stroke-width="0.6" fill="none" opacity="0.5">
+    <line x1="178" y1="102" x2="222" y2="102"/>
+    <line x1="178" y1="107" x2="222" y2="107"/>
+    <line x1="186" y1="100" x2="186" y2="110"/>
+    <line x1="194" y1="100" x2="194" y2="110"/>
+    <line x1="202" y1="100" x2="202" y2="110"/>
+    <line x1="210" y1="100" x2="210" y2="110"/>
+    <line x1="218" y1="100" x2="218" y2="110"/>
+  </g>
+
+  <!-- Crown — antenna array, precise geometric spines -->
+  <g fill="#0e1a28" stroke="#182030" stroke-width="1">
+    <line x1="185" y1="80" x2="182" y2="55" stroke="#182030" stroke-width="2"/>
+    <line x1="195" y1="80" x2="193" y2="48" stroke="#182030" stroke-width="2.5"/>
+    <line x1="205" y1="80" x2="207" y2="48" stroke="#182030" stroke-width="2.5"/>
+    <line x1="215" y1="80" x2="218" y2="55" stroke="#182030" stroke-width="2"/>
+    <!-- Antenna tips glow — transmitting -->
+    <circle cx="182" cy="54" r="2.5" fill="#3060c0" opacity="0.6"/>
+    <circle cx="193" cy="47" r="3" fill="#4070d0" opacity="0.7"/>
+    <circle cx="207" cy="47" r="3" fill="#4070d0" opacity="0.7"/>
+    <circle cx="218" cy="54" r="2.5" fill="#3060c0" opacity="0.6"/>
+  </g>
+
+  <!-- Side arms — extending machinery, articulated -->
+  <!-- Left arm -->
+  <line x1="163" y1="135" x2="130" y2="145" stroke="#0e1824" stroke-width="6" stroke-linecap="round"/>
+  <line x1="130" y1="145" x2="108" y2="160" stroke="#0e1824" stroke-width="4" stroke-linecap="round"/>
+  <rect x="96" y="152" width="20" height="14" rx="2" fill="#0c1620" stroke="#182030" stroke-width="0.8"/>
+  <!-- Right arm -->
+  <line x1="237" y1="135" x2="270" y2="145" stroke="#0e1824" stroke-width="6" stroke-linecap="round"/>
+  <line x1="270" y1="145" x2="292" y2="160" stroke="#0e1824" stroke-width="4" stroke-linecap="round"/>
+  <rect x="284" y="152" width="20" height="14" rx="2" fill="#0c1620" stroke="#182030" stroke-width="0.8"/>
+
+  <!-- Ley line feed — the Engine is drawing from the ley lines -->
+  <g stroke="#e05010" stroke-width="1.5" fill="none" opacity="0.5">
+    <path d="M0,198 Q80,192 145,188 Q165,185 200,182"/>
+    <path d="M400,198 Q320,192 255,188 Q235,185 200,182"/>
+  </g>
+  <!-- Ley energy entering base -->
+  <rect x="190" y="182" width="20" height="2" fill="#ff7020" opacity="0.6"/>
+
+  <!-- Ice crystals around base -->
+  <g fill="#0a1828" stroke="#142238" stroke-width="0.8" opacity="0.7">
+    <polygon points="148,193 152,180 156,193"/>
+    <polygon points="244,193 248,180 252,193"/>
+    <polygon points="138,200 142,188 146,200"/>
+    <polygon points="254,200 258,188 262,200"/>
+  </g>
+
+  <!-- Stars -->
+  <g fill="#a0c0e0" opacity="0.35">
+    <circle cx="40"  cy="22" r="1"/>
+    <circle cx="120" cy="15" r="1.2"/>
+    <circle cx="290" cy="18" r="1"/>
+    <circle cx="360" cy="25" r="1.2"/>
+  </g>
+
+  <!-- Label -->
+  <text x="200" y="232" font-family="monospace" font-size="9" fill="#1a3050" text-anchor="middle" letter-spacing="3">THE PALE ENGINE</text>
+</svg>

--- a/web/public/cutscenes/act9-intro-3.svg
+++ b/web/public/cutscenes/act9-intro-3.svg
@@ -1,0 +1,112 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#050c18"/>
+
+  <linearGradient id="white-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#060e1e"/>
+    <stop offset="50%" stop-color="#0c1a2e"/>
+    <stop offset="100%" stop-color="#101e34"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#white-sky)"/>
+
+  <!-- WHITEOUT — the cold is structural, pressing in from all sides -->
+  <!-- Pale diffuse light everywhere — no clear source -->
+  <radialGradient id="white-press" cx="50%" cy="50%" r="60%">
+    <stop offset="0%" stop-color="#1c3048" stop-opacity="0.5"/>
+    <stop offset="80%" stop-color="#0e2038" stop-opacity="0.2"/>
+    <stop offset="100%" stop-color="#0e2038" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#white-press)"/>
+
+  <!-- Ice wall perspective — corridor of ice, closing in -->
+  <!-- Left wall panels -->
+  <g fill="#060e1c" stroke="#0e1e2e" stroke-width="1">
+    <polygon points="0,0 0,240 65,200 55,160 65,120 52,80 65,40 50,0"/>
+  </g>
+  <!-- Right wall panels -->
+  <g fill="#060e1c" stroke="#0e1e2e" stroke-width="1">
+    <polygon points="400,0 400,240 335,200 345,160 335,120 348,80 335,40 350,0"/>
+  </g>
+  <!-- Ice wall surface sheen — light refracting through blue-white ice -->
+  <g fill="#0e2038" opacity="0.4">
+    <polygon points="0,0  50,0  65,40  52,80  65,120 55,160 65,200 0,240 0,200 55,175 45,140 58,105 45,68 58,30 0,0"/>
+    <polygon points="400,0 350,0 335,40 348,80 335,120 345,160 335,200 400,240 400,200 345,175 355,140 342,105 355,68 342,30 400,0"/>
+  </g>
+
+  <!-- Ground — flat ice, structural, oppressive -->
+  <rect x="0" y="200" width="400" height="40" fill="#060e18"/>
+  <line x1="0" y1="200" x2="400" y2="200" stroke="#0e2030" stroke-width="1.5"/>
+  <!-- Ice surface micro-cracks -->
+  <g stroke="#0e1e2e" stroke-width="0.5" fill="none" opacity="0.4">
+    <path d="M30,205  Q45,210  55,205"/>
+    <path d="M100,208 Q115,215 125,208"/>
+    <path d="M190,204 Q205,210 218,204"/>
+    <path d="M275,207 Q290,214 302,207"/>
+    <path d="M355,205 Q368,211 378,205"/>
+  </g>
+
+  <!-- Ceiling of ice above -->
+  <polygon points="0,0 400,0 400,45 350,38 300,50 250,32 200,46 150,30 100,48 50,34 0,46" fill="#060e1c"/>
+  <!-- Ice ceiling underside — cold blue-white gleam -->
+  <g fill="#0c1e30" opacity="0.5">
+    <polygon points="0,46  50,34 40,46"/>
+    <polygon points="100,48 150,30 138,50"/>
+    <polygon points="200,46 250,32 235,48"/>
+    <polygon points="300,50 350,38 338,52"/>
+  </g>
+
+  <!-- Ley lines — visible through floor and walls, orange contrast against blue-white -->
+  <!-- Floor ley -->
+  <linearGradient id="floor-ley" x1="0" y1="0" x2="1" y2="0">
+    <stop offset="0%" stop-color="#c04000" stop-opacity="0.2"/>
+    <stop offset="25%" stop-color="#ff6020" stop-opacity="0.8"/>
+    <stop offset="50%" stop-color="#ff8030" stop-opacity="1"/>
+    <stop offset="75%" stop-color="#ff6020" stop-opacity="0.8"/>
+    <stop offset="100%" stop-color="#c04000" stop-opacity="0.2"/>
+  </linearGradient>
+  <rect x="0" y="203" width="400" height="4" fill="url(#floor-ley)"/>
+  <rect x="0" y="204" width="400" height="2" fill="#ffb060" opacity="0.4"/>
+  <!-- Wall ley seams — orange lines in blue ice walls -->
+  <line x1="52" y1="0"   x2="52" y2="200" stroke="#d05010" stroke-width="1.5" opacity="0.4"/>
+  <line x1="348" y1="0"  x2="348" y2="200" stroke="#d05010" stroke-width="1.5" opacity="0.4"/>
+  <line x1="53" y1="0"   x2="53" y2="200" stroke="#ff7020" stroke-width="0.6" opacity="0.3"/>
+  <line x1="347" y1="0"  x2="347" y2="200" stroke="#ff7020" stroke-width="0.6" opacity="0.3"/>
+
+  <!-- JARV — centre, small against the vast cold, walking into depth -->
+  <!-- Distant small figure — showing scale of the expanse -->
+  <ellipse cx="200" cy="202" rx="12" ry="3" fill="#030608" opacity="0.7"/>
+  <!-- Legs -->
+  <line x1="197" y1="196" x2="195" y2="202" stroke="#0c0c18" stroke-width="3" stroke-linecap="round"/>
+  <line x1="202" y1="196" x2="204" y2="202" stroke="#0c0c18" stroke-width="3" stroke-linecap="round"/>
+  <!-- Body — mantle tiny but teal visible -->
+  <polygon points="193,182 207,182 210,196 190,196" fill="#0a1e20" stroke="#1a4040" stroke-width="1"/>
+  <g fill="#00c090" opacity="0.5">
+    <circle cx="190" cy="182" r="1.2"/>
+    <circle cx="210" cy="182" r="1.2"/>
+  </g>
+  <!-- Head -->
+  <ellipse cx="200" cy="176" rx="6" ry="5" fill="#0c0c1a" stroke="#181830" stroke-width="0.8"/>
+  <!-- Iron Standard — tiny spear beside -->
+  <line x1="210" y1="182" x2="218" y2="202" stroke="#2a3040" stroke-width="1.5"/>
+
+  <!-- Cold mist / blizzard particles -->
+  <g fill="#a0c0d8" opacity="0.15">
+    <circle cx="80"  cy="90"  r="1.5"/>
+    <circle cx="140" cy="70"  r="1.2"/>
+    <circle cx="260" cy="80"  r="1.5"/>
+    <circle cx="320" cy="65"  r="1.2"/>
+    <circle cx="100" cy="150" r="1"/>
+    <circle cx="300" cy="145" r="1"/>
+    <circle cx="180" cy="110" r="1.2"/>
+    <circle cx="220" cy="120" r="1"/>
+  </g>
+  <!-- Snow streaks -->
+  <g stroke="#8090a8" stroke-width="0.5" fill="none" opacity="0.12">
+    <line x1="60"  y1="40"  x2="68"  y2="55"/>
+    <line x1="150" y1="30"  x2="155" y2="48"/>
+    <line x1="240" y1="25"  x2="244" y2="42"/>
+    <line x1="340" y1="38"  x2="346" y2="55"/>
+  </g>
+
+  <!-- Label -->
+  <text x="200" y="232" font-family="monospace" font-size="9" fill="#1a3050" text-anchor="middle" letter-spacing="3">INTO THE WHITE</text>
+</svg>

--- a/web/public/cutscenes/act9-outro-1.svg
+++ b/web/public/cutscenes/act9-outro-1.svg
@@ -1,0 +1,103 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#030810"/>
+
+  <linearGradient id="halt-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#040c18"/>
+    <stop offset="100%" stop-color="#0a1828"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#halt-sky)"/>
+
+  <!-- Cold quiet atmosphere — nothing emitting now -->
+  <radialGradient id="halt-quiet" cx="50%" cy="45%" r="45%">
+    <stop offset="0%" stop-color="#102030" stop-opacity="0.2"/>
+    <stop offset="100%" stop-color="#102030" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#halt-quiet)"/>
+
+  <!-- Ice floor -->
+  <rect x="0" y="195" width="400" height="45" fill="#060e18"/>
+  <line x1="0" y1="195" x2="400" y2="195" stroke="#0e2030" stroke-width="1"/>
+  <!-- Ley lines through floor — still present, unchanged by the Engine's halt -->
+  <rect x="0" y="198" width="400" height="3" fill="#e05010" opacity="0.35"/>
+  <rect x="0" y="199" width="400" height="1" fill="#ff8030" opacity="0.25"/>
+
+  <!-- THE PALE ENGINE — stopped, but not fallen. Precisely still. -->
+  <!-- Base — unchanged, intact -->
+  <rect x="145" y="178" width="110" height="20" rx="2" fill="#0e1a28" stroke="#182838" stroke-width="1.5"/>
+  <!-- Body -->
+  <rect x="163" y="118" width="74" height="62" fill="#0c1824" stroke="#182838" stroke-width="1.5"/>
+  <!-- Segment lines -->
+  <line x1="163" y1="138" x2="237" y2="138" stroke="#182838" stroke-width="1"/>
+  <line x1="163" y1="156" x2="237" y2="156" stroke="#182838" stroke-width="1"/>
+  <!-- Vents — DARK now, no output -->
+  <g fill="#060e18" stroke="#101820" stroke-width="0.5">
+    <rect x="170" y="123" width="18" height="10" rx="1"/>
+    <rect x="212" y="123" width="18" height="10" rx="1"/>
+    <rect x="170" y="141" width="18" height="10" rx="1"/>
+    <rect x="212" y="141" width="18" height="10" rx="1"/>
+  </g>
+  <!-- Upper section -->
+  <rect x="172" y="78" width="56" height="42" fill="#0e1c2c" stroke="#182838" stroke-width="1.5"/>
+  <!-- Eyes — OFF. Dark rectangles. -->
+  <rect x="179" y="85" width="14" height="10" rx="1" fill="#060e18" stroke="#101820" stroke-width="0.5"/>
+  <rect x="207" y="85" width="14" height="10" rx="1" fill="#060e18" stroke="#101820" stroke-width="0.5"/>
+  <!-- Just the tiniest residual blue in one eye — one last flicker before true halt -->
+  <rect x="180" y="86" width="5" height="3" rx="0.5" fill="#0c2060" opacity="0.4"/>
+  <!-- Processing mesh — still -->
+  <g stroke="#0e1828" stroke-width="0.6" fill="none" opacity="0.4">
+    <line x1="178" y1="100" x2="222" y2="100"/>
+    <line x1="178" y1="105" x2="222" y2="105"/>
+    <line x1="186" y1="98"  x2="186" y2="108"/>
+    <line x1="200" y1="98"  x2="200" y2="108"/>
+    <line x1="214" y1="98"  x2="214" y2="108"/>
+  </g>
+  <!-- Antennas — power down, tips dark -->
+  <line x1="185" y1="78" x2="182" y2="53" stroke="#182030" stroke-width="2"/>
+  <line x1="195" y1="78" x2="193" y2="46" stroke="#182030" stroke-width="2.5"/>
+  <line x1="205" y1="78" x2="207" y2="46" stroke="#182030" stroke-width="2.5"/>
+  <line x1="215" y1="78" x2="218" y2="53" stroke="#182030" stroke-width="2"/>
+  <!-- Antenna tips — dark -->
+  <circle cx="182" cy="52" r="2.5" fill="#0a1428" opacity="0.8"/>
+  <circle cx="193" cy="45" r="3"   fill="#0a1428" opacity="0.8"/>
+  <circle cx="207" cy="45" r="3"   fill="#0a1428" opacity="0.8"/>
+  <circle cx="218" cy="52" r="2.5" fill="#0a1428" opacity="0.8"/>
+  <!-- Arms — lowered, resting at sides precisely -->
+  <line x1="163" y1="133" x2="138" y2="148" stroke="#0e1824" stroke-width="6" stroke-linecap="round"/>
+  <line x1="138" y1="148" x2="130" y2="168" stroke="#0e1824" stroke-width="4" stroke-linecap="round"/>
+  <rect x="118" y="162" width="20" height="14" rx="2" fill="#0c1620" stroke="#182030" stroke-width="0.8"/>
+  <line x1="237" y1="133" x2="262" y2="148" stroke="#0e1824" stroke-width="6" stroke-linecap="round"/>
+  <line x1="262" y1="148" x2="270" y2="168" stroke="#0e1824" stroke-width="4" stroke-linecap="round"/>
+  <rect x="262" y="162" width="20" height="14" rx="2" fill="#0c1620" stroke="#182030" stroke-width="0.8"/>
+
+  <!-- Subtle frost forming on the Engine — it's getting colder now it's stopped -->
+  <g stroke="#8090a8" stroke-width="0.5" fill="none" opacity="0.2">
+    <path d="M172,178 Q175,172 172,166"/>
+    <path d="M237,168 Q240,162 237,155"/>
+    <path d="M200,78 Q203,72 200,66"/>
+  </g>
+
+  <!-- Ley lines — unchanged, running under everything -->
+  <rect x="0" y="198" width="400" height="3" fill="#e05010" opacity="0.35"/>
+
+  <!-- Ice crystals at base — growing now the warmth is gone -->
+  <g fill="#0a1828" stroke="#142238" stroke-width="0.8" opacity="0.8">
+    <polygon points="148,192 152,178 156,192"/>
+    <polygon points="244,192 248,178 252,192"/>
+    <polygon points="136,198 140,184 144,198"/>
+    <polygon points="256,198 260,184 264,198"/>
+    <polygon points="160,196 163,185 166,196"/>
+    <polygon points="234,196 237,185 240,196"/>
+  </g>
+
+  <!-- Stars -->
+  <g fill="#a0c0e0" opacity="0.4">
+    <circle cx="50"  cy="20" r="1.2"/>
+    <circle cx="130" cy="12" r="1"/>
+    <circle cx="270" cy="16" r="1.2"/>
+    <circle cx="370" cy="22" r="1"/>
+    <circle cx="200" cy="8"  r="1"/>
+  </g>
+
+  <!-- Label -->
+  <text x="200" y="232" font-family="monospace" font-size="9" fill="#1a3050" text-anchor="middle" letter-spacing="3">THE PALE ENGINE HALTS</text>
+</svg>

--- a/web/public/cutscenes/act9-outro-2.svg
+++ b/web/public/cutscenes/act9-outro-2.svg
@@ -1,0 +1,114 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#030810"/>
+
+  <linearGradient id="proc-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#040c18"/>
+    <stop offset="100%" stop-color="#081420"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#proc-sky)"/>
+
+  <!-- Minimal glow — the Engine's last output, a data transmission -->
+  <radialGradient id="data-glow" cx="40%" cy="50%" r="40%">
+    <stop offset="0%" stop-color="#102848" stop-opacity="0.35"/>
+    <stop offset="100%" stop-color="#102848" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#data-glow)"/>
+
+  <!-- Ice floor -->
+  <rect x="0" y="198" width="400" height="42" fill="#060e18"/>
+  <line x1="0" y1="198" x2="400" y2="198" stroke="#0e2030" stroke-width="1"/>
+  <rect x="0" y="201" width="400" height="2" fill="#e05010" opacity="0.3"/>
+
+  <!-- THE PALE ENGINE — left side, standing still, one antenna pulsing faintly -->
+  <!-- Smaller rendering — more space for Jarv -->
+  <rect x="58" y="182" width="84" height="16" rx="2" fill="#0e1a28" stroke="#182838" stroke-width="1"/>
+  <rect x="70" y="132" width="60" height="52" fill="#0c1824" stroke="#182838" stroke-width="1.5"/>
+  <line x1="70"  y1="152" x2="130" y2="152" stroke="#182838" stroke-width="0.8"/>
+  <line x1="70"  y1="168" x2="130" y2="168" stroke="#182838" stroke-width="0.8"/>
+  <!-- Vents dark -->
+  <g fill="#060e18" stroke="#101820" stroke-width="0.5">
+    <rect x="76"  y="137" width="14" height="8" rx="1"/>
+    <rect x="110" y="137" width="14" height="8" rx="1"/>
+    <rect x="76"  y="157" width="14" height="8" rx="1"/>
+    <rect x="110" y="157" width="14" height="8" rx="1"/>
+  </g>
+  <rect x="75" y="94" width="50" height="40" fill="#0e1c2c" stroke="#182838" stroke-width="1"/>
+  <!-- Eyes — both dark, halted -->
+  <rect x="80"  y="99" width="12" height="9" rx="1" fill="#060e18" stroke="#101820" stroke-width="0.5"/>
+  <rect x="108" y="99" width="12" height="9" rx="1" fill="#060e18" stroke="#101820" stroke-width="0.5"/>
+  <!-- Antennae — one with a last pulse of blue data light -->
+  <line x1="88"  y1="94" x2="86"  y2="70" stroke="#182030" stroke-width="1.5"/>
+  <line x1="95"  y1="94" x2="95"  y2="64" stroke="#182030" stroke-width="2"/>
+  <line x1="105" y1="94" x2="105" y2="64" stroke="#182030" stroke-width="2"/>
+  <line x1="112" y1="94" x2="114" y2="70" stroke="#182030" stroke-width="1.5"/>
+  <circle cx="95"  cy="63" r="2" fill="#2050a0" opacity="0.5"/>
+  <circle cx="105" cy="63" r="2" fill="#2050a0" opacity="0.3"/>
+  <!-- Data stream — packets flowing out of the transmitting antenna -->
+  <g fill="#3060c0" opacity="0.4">
+    <circle cx="95" cy="55" r="1.5"/>
+    <circle cx="95" cy="48" r="1.2"/>
+    <circle cx="95" cy="41" r="1"/>
+    <circle cx="95" cy="35" r="0.8"/>
+  </g>
+  <!-- Arms hanging still -->
+  <line x1="70"  y1="148" x2="50"  y2="162" stroke="#0e1824" stroke-width="5" stroke-linecap="round"/>
+  <line x1="130" y1="148" x2="150" y2="162" stroke="#0e1824" stroke-width="5" stroke-linecap="round"/>
+
+  <!-- DATA TRANSMISSION — geometric patterns floating in air, its "last words" -->
+  <!-- Binary-like pattern drifting from the Engine toward centre -->
+  <g fill="#2050a0" opacity="0.3">
+    <rect x="155" y="85"  width="4" height="4" rx="0.5"/>
+    <rect x="163" y="85"  width="4" height="4" rx="0.5"/>
+    <rect x="155" y="93"  width="4" height="4" rx="0.5"/>
+    <rect x="171" y="93"  width="4" height="4" rx="0.5"/>
+    <rect x="163" y="101" width="4" height="4" rx="0.5"/>
+    <rect x="171" y="85"  width="4" height="4" rx="0.5"/>
+  </g>
+  <g fill="#1840a0" opacity="0.2">
+    <rect x="182" y="80"  width="3" height="3" rx="0.5"/>
+    <rect x="188" y="86"  width="3" height="3" rx="0.5"/>
+    <rect x="182" y="92"  width="3" height="3" rx="0.5"/>
+    <rect x="194" y="80"  width="3" height="3" rx="0.5"/>
+    <rect x="194" y="92"  width="3" height="3" rx="0.5"/>
+  </g>
+
+  <!-- JARV — right side, standing, facing the Engine -->
+  <ellipse cx="290" cy="206" rx="22" ry="4" fill="#030608" opacity="0.7"/>
+  <ellipse cx="283" cy="208" rx="5" ry="2" fill="#08090e"/>
+  <ellipse cx="296" cy="208" rx="5" ry="2" fill="#08090e"/>
+  <line x1="285" y1="200" x2="283" y2="208" stroke="#0c0c18" stroke-width="4" stroke-linecap="round"/>
+  <line x1="293" y1="199" x2="296" y2="208" stroke="#0c0c18" stroke-width="4" stroke-linecap="round"/>
+  <!-- Coral Mantle -->
+  <polygon points="272,175 308,175 312,200 268,200" fill="#0a1e20" stroke="#1a4040" stroke-width="1.5"/>
+  <g fill="#00c090" opacity="0.45">
+    <circle cx="268" cy="175" r="1.5"/>
+    <circle cx="312" cy="175" r="1.5"/>
+  </g>
+  <!-- Stormcaller Badge on chest — small hex -->
+  <polygon points="290,183 294,186 294,192 290,195 286,192 286,186" fill="#080e20" stroke="#2848a0" stroke-width="0.6"/>
+  <line x1="290" y1="185" x2="290" y2="193" stroke="#4060c0" stroke-width="0.6" opacity="0.5"/>
+  <!-- Head — tilted toward the Engine's data stream -->
+  <ellipse cx="288" cy="166" rx="10" ry="9" fill="#0c0c1a" stroke="#181830" stroke-width="1"/>
+  <ellipse cx="286" cy="169" rx="5.5" ry="3.5" fill="#080810"/>
+  <!-- Iron Standard — planted beside -->
+  <line x1="314" y1="175" x2="332" y2="212" stroke="#2a3040" stroke-width="2.5"/>
+  <polygon points="312,175 316,175 314,166" fill="#404860" opacity="0.7"/>
+
+  <!-- Ice crystals — growing in the cold quiet -->
+  <g fill="#0a1828" stroke="#142238" stroke-width="0.7" opacity="0.7">
+    <polygon points="50,196  54,182  58,196"/>
+    <polygon points="340,196 344,183 348,196"/>
+    <polygon points="38,200  42,188  46,200"/>
+    <polygon points="352,200 356,188 360,200"/>
+  </g>
+
+  <!-- Stars -->
+  <g fill="#a0c0e0" opacity="0.35">
+    <circle cx="60"  cy="18" r="1"/>
+    <circle cx="200" cy="12" r="1.2"/>
+    <circle cx="350" cy="20" r="1"/>
+  </g>
+
+  <!-- Label -->
+  <text x="200" y="232" font-family="monospace" font-size="9" fill="#1a3050" text-anchor="middle" letter-spacing="3">WHAT IT PROCESSED</text>
+</svg>

--- a/web/public/cutscenes/act9-outro-3.svg
+++ b/web/public/cutscenes/act9-outro-3.svg
@@ -1,0 +1,124 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#030810"/>
+
+  <linearGradient id="frost-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#040c18"/>
+    <stop offset="50%" stop-color="#081420"/>
+    <stop offset="100%" stop-color="#0c1c2c"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#frost-sky)"/>
+
+  <!-- Cold pale glow — the Frost Mantle radiates a chill light -->
+  <radialGradient id="frost-glow" cx="50%" cy="40%" r="45%">
+    <stop offset="0%" stop-color="#1c3858" stop-opacity="0.5"/>
+    <stop offset="60%" stop-color="#102438" stop-opacity="0.2"/>
+    <stop offset="100%" stop-color="#102438" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#frost-glow)"/>
+
+  <!-- THE FROST MANTLE — the Engine's outer casing, now a relic -->
+  <!-- Dense, cold, angular — machine-origin but with its own presence -->
+  <!-- Outer glow ring — extreme cold radiating outward -->
+  <radialGradient id="mantle-cold" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#1840a0" stop-opacity="0.35"/>
+    <stop offset="50%" stop-color="#1030a0" stop-opacity="0.1"/>
+    <stop offset="100%" stop-color="#1030a0" stop-opacity="0"/>
+  </radialGradient>
+  <ellipse cx="200" cy="95" rx="70" ry="58" fill="url(#mantle-cold)"/>
+
+  <!-- Ice crystal halo forming around the Mantle -->
+  <g fill="none" stroke="#1840a0" stroke-width="0.8" opacity="0.35">
+    <line x1="200" y1="42" x2="200" y2="28"/>
+    <line x1="200" y1="42" x2="192" y2="32"/>
+    <line x1="200" y1="42" x2="208" y2="32"/>
+    <line x1="248" y1="68" x2="260" y2="60"/>
+    <line x1="248" y1="68" x2="256" y2="75"/>
+    <line x1="248" y1="68" x2="242" y2="60"/>
+    <line x1="152" y1="68" x2="140" y2="60"/>
+    <line x1="152" y1="68" x2="144" y2="75"/>
+    <line x1="152" y1="68" x2="158" y2="60"/>
+    <line x1="248" y1="122" x2="260" y2="130"/>
+    <line x1="152" y1="122" x2="140" y2="130"/>
+    <line x1="200" y1="148" x2="200" y2="162"/>
+    <line x1="200" y1="148" x2="192" y2="158"/>
+    <line x1="200" y1="148" x2="208" y2="158"/>
+  </g>
+
+  <!-- Frost Mantle body — hexagonal plate from the Engine's casing -->
+  <polygon points="200,45 236,65 236,125 200,145 164,125 164,65" fill="#0a1428" stroke="#203858" stroke-width="2"/>
+  <!-- Machine surface texture — grid of cold metal panels -->
+  <g stroke="#142030" stroke-width="0.8" fill="none" opacity="0.7">
+    <line x1="164" y1="75"  x2="236" y2="75"/>
+    <line x1="164" y1="95"  x2="236" y2="95"/>
+    <line x1="164" y1="115" x2="236" y2="115"/>
+    <line x1="177" y1="65"  x2="177" y2="135"/>
+    <line x1="191" y1="52"  x2="191" y2="143"/>
+    <line x1="200" y1="45"  x2="200" y2="145"/>
+    <line x1="209" y1="52"  x2="209" y2="143"/>
+    <line x1="223" y1="65"  x2="223" y2="135"/>
+  </g>
+  <!-- Vent openings — holes in the casing, no longer active -->
+  <g fill="#06101e" stroke="#102030" stroke-width="0.5">
+    <rect x="178" y="68"  width="12" height="8"  rx="1"/>
+    <rect x="210" y="68"  width="12" height="8"  rx="1"/>
+    <rect x="178" y="98"  width="12" height="8"  rx="1"/>
+    <rect x="210" y="98"  width="12" height="8"  rx="1"/>
+    <rect x="178" y="118" width="12" height="8"  rx="1"/>
+    <rect x="210" y="118" width="12" height="8"  rx="1"/>
+  </g>
+  <!-- Frost crystallising in the vents — it's already freezing over -->
+  <g fill="#1840a0" opacity="0.2">
+    <rect x="178" y="68"  width="12" height="8"  rx="1"/>
+    <rect x="210" y="98"  width="12" height="8"  rx="1"/>
+    <rect x="178" y="118" width="12" height="8"  rx="1"/>
+  </g>
+  <!-- Central status indicator — last blue pulse, almost gone -->
+  <circle cx="200" cy="95" r="10" fill="#080e20" stroke="#1840a0" stroke-width="1" opacity="0.7"/>
+  <circle cx="200" cy="95" r="5"  fill="#1030a0" opacity="0.4"/>
+  <circle cx="200" cy="95" r="2"  fill="#4070e0" opacity="0.3"/>
+
+  <!-- JARV — below, small, standard set aside, both arms cradling the Mantle -->
+  <ellipse cx="200" cy="220" rx="22" ry="4" fill="#030608" opacity="0.6"/>
+  <ellipse cx="193" cy="222" rx="5"  ry="2" fill="#08090e"/>
+  <ellipse cx="207" cy="222" rx="5"  ry="2" fill="#08090e"/>
+  <line x1="195" y1="213" x2="193" y2="222" stroke="#0c0c18" stroke-width="4" stroke-linecap="round"/>
+  <line x1="205" y1="213" x2="207" y2="222" stroke="#0c0c18" stroke-width="4" stroke-linecap="round"/>
+  <!-- Coral Mantle -->
+  <polygon points="183,182 217,182 221,212 179,212" fill="#0a1e20" stroke="#1a4040" stroke-width="1.5"/>
+  <g fill="#00c090" opacity="0.4">
+    <circle cx="179" cy="182" r="1.5"/>
+    <circle cx="221" cy="182" r="1.5"/>
+  </g>
+  <!-- Arms raised — receiving -->
+  <line x1="183" y1="190" x2="165" y2="168" stroke="#0c0c18" stroke-width="4" stroke-linecap="round"/>
+  <line x1="217" y1="190" x2="235" y2="168" stroke="#0c0c18" stroke-width="4" stroke-linecap="round"/>
+  <polygon points="159,163 169,162 171,173 161,174" fill="#0d0e1a" stroke="#181830" stroke-width="0.8"/>
+  <polygon points="231,163 241,162 243,173 233,174" fill="#0d0e1a" stroke="#181830" stroke-width="0.8"/>
+  <!-- Head -->
+  <ellipse cx="200" cy="173" rx="10" ry="9" fill="#0c0c1a" stroke="#181830" stroke-width="1"/>
+  <ellipse cx="200" cy="176" rx="5" ry="3.5" fill="#080810"/>
+
+  <!-- Transfer — cold radiating downward to hands -->
+  <g stroke="#1838a0" stroke-width="0.8" fill="none" opacity="0.3">
+    <path d="M164,125 Q162,145 162,168"/>
+    <path d="M236,125 Q238,145 238,168"/>
+  </g>
+
+  <!-- Ice floor -->
+  <rect x="0" y="225" width="400" height="15" fill="#060e18"/>
+  <!-- Ley line through floor — orange -->
+  <rect x="0" y="227" width="400" height="2" fill="#e05010" opacity="0.3"/>
+
+  <!-- Stars — cold and clear -->
+  <g fill="#a0c0e0" opacity="0.45">
+    <circle cx="40"  cy="18" r="1.5"/>
+    <circle cx="110" cy="10" r="1"/>
+    <circle cx="290" cy="12" r="1.5"/>
+    <circle cx="365" cy="20" r="1"/>
+    <circle cx="170" cy="30" r="1"/>
+    <circle cx="340" cy="35" r="1"/>
+  </g>
+
+  <!-- Label -->
+  <text x="200" y="238" font-family="monospace" font-size="9" fill="#1a3050" text-anchor="middle" letter-spacing="3">THE FROST MANTLE</text>
+</svg>

--- a/web/src/data/acts/act9.json
+++ b/web/src/data/acts/act9.json
@@ -43,29 +43,35 @@
   "intro": [
     {
       "title": "THE FROZEN EXPANSE",
-      "text": "The ley lines don't slow down in the cold. They run straight through the ice, bright orange against the white, like cracks in a frozen river that's trying to remember it used to flow.\n\nThe Frozen Expanse has been like this since before the Fracture. The Fracture just made it larger. Colder. More hostile to visitors.\n\nThe Pale Engine is in there. It has been there for a long time. It is not pleased to have directions."
+      "text": "The ley lines don't slow down in the cold. They run straight through the ice, bright orange against the white, like cracks in a frozen river that's trying to remember it used to flow.\n\nThe Frozen Expanse has been like this since before the Fracture. The Fracture just made it larger. Colder. More hostile to visitors.\n\nThe Pale Engine is in there. It has been there for a long time. It is not pleased to have directions.",
+      "image": "cutscenes/act9-intro-1.svg"
     },
     {
       "title": "THE PALE ENGINE",
-      "text": "Nobody built the Pale Engine — or if they did, they did it so long ago that the Engine has stopped caring about the distinction. It runs on cold and purpose. Its purpose is to hold the Expanse against everything that isn't ice.\n\nIt doesn't sleep. It doesn't negotiate. It processes.\n\nYou represent an input it hasn't encountered before. It is in the process of developing a protocol."
+      "text": "Nobody built the Pale Engine — or if they did, they did it so long ago that the Engine has stopped caring about the distinction. It runs on cold and purpose. Its purpose is to hold the Expanse against everything that isn't ice.\n\nIt doesn't sleep. It doesn't negotiate. It processes.\n\nYou represent an input it hasn't encountered before. It is in the process of developing a protocol.",
+      "image": "cutscenes/act9-intro-2.svg"
     },
     {
       "title": "INTO THE WHITE",
-      "text": "The cold here isn't just weather. It's structural. It holds the landscape together in a way that makes you understand why the Pale Engine defends it — remove the cold and the whole Expanse would need to rethink what it is.\n\nYou aren't here to take the cold. You're here to pass through it.\n\nThe Pale Engine will need to understand that distinction. You will need to explain it forcefully."
+      "text": "The cold here isn't just weather. It's structural. It holds the landscape together in a way that makes you understand why the Pale Engine defends it — remove the cold and the whole Expanse would need to rethink what it is.\n\nYou aren't here to take the cold. You're here to pass through it.\n\nThe Pale Engine will need to understand that distinction. You will need to explain it forcefully.",
+      "image": "cutscenes/act9-intro-3.svg"
     }
   ],
   "outro": [
     {
       "title": "THE PALE ENGINE HALTS",
-      "text": "The Pale Engine doesn't fall. It stops — a precise, deliberate cessation, like a machine completing a cycle rather than failing. The cold continues around it. The Expanse doesn't care who won.\n\nThe ley lines pulse through the ice and keep going. They were never going to stop for this."
+      "text": "The Pale Engine doesn't fall. It stops — a precise, deliberate cessation, like a machine completing a cycle rather than failing. The cold continues around it. The Expanse doesn't care who won.\n\nThe ley lines pulse through the ice and keep going. They were never going to stop for this.",
+      "image": "cutscenes/act9-outro-1.svg"
     },
     {
       "title": "WHAT IT PROCESSED",
-      "text": "At some point during the battle, the Engine processed the situation correctly: you were not there to hold the Expanse, you were there to cross it.\n\nIt had not previously computed that as an option worth defending against.\n\nThis is, apparently, an update to its protocol."
+      "text": "At some point during the battle, the Engine processed the situation correctly: you were not there to hold the Expanse, you were there to cross it.\n\nIt had not previously computed that as an option worth defending against.\n\nThis is, apparently, an update to its protocol.",
+      "image": "cutscenes/act9-outro-2.svg"
     },
     {
       "title": "THE FROST MANTLE",
-      "text": "The Frost Mantle is a layer of something that was once the Engine's outer casing — dense, cold, and almost ornamental in the way it's settled into a shape that fits across your shoulders.\n\nThe cold doesn't bother you as much as it did. That's the point.\n\nThe ley lines run on. The Expanse recedes behind you."
+      "text": "The Frost Mantle is a layer of something that was once the Engine's outer casing — dense, cold, and almost ornamental in the way it's settled into a shape that fits across your shoulders.\n\nThe cold doesn't bother you as much as it did. That's the point.\n\nThe ley lines run on. The Expanse recedes behind you.",
+      "image": "cutscenes/act9-outro-3.svg"
     }
   ],
   "nodes": {


### PR DESCRIPTION
## Summary

- Adds 6 SVG cutscene panels for Act 9 (The Frozen Expanse): 3 intro + 3 outro
- Wires `image` fields into `act9.json`
- Ice-blue/white palette with high-contrast orange ley lines

## Panels

| File | Title |
|------|-------|
| `act9-intro-1.svg` | THE FROZEN EXPANSE — vast flat ice landscape, orange ley lines visible through the surface, frozen ridges, aurora |
| `act9-intro-2.svg` | THE PALE ENGINE — geometric ancient machine with scanning eye-panels, transmitting antennae, drawing from ley lines through base |
| `act9-intro-3.svg` | INTO THE WHITE — ice corridor pressing in from all sides, Jarv small at centre, ley lines in walls and floor |
| `act9-outro-1.svg` | THE PALE ENGINE HALTS — machine stopped precisely: antennae dark, vents cold, frost crystallising on casing |
| `act9-outro-2.svg` | WHAT IT PROCESSED — Engine's last data transmission as floating geometric packets; Jarv observing |
| `act9-outro-3.svg` | THE FROST MANTLE — hexagonal machine-casing relic with grid panels and dying status core, Jarv receiving it |

Closes #835 (partially — acts 7–9 complete; 10–13 still in progress).

## Test plan

- [ ] `npm run build` passes
- [ ] Act 9 intro and outro cutscenes display all panels correctly
- [ ] Art style consistent with Acts 1–8

https://claude.ai/code/session_01GXML372usPatkqhfiuvdWX

---
_Generated by [Claude Code](https://claude.ai/code/session_01GXML372usPatkqhfiuvdWX)_