### PR TITLE
Add cutscene graphics for acts 10–13 and the finale

### DIFF
--- a/web/public/cutscenes/act10-intro-1.svg
+++ b/web/public/cutscenes/act10-intro-1.svg
@@ -1,0 +1,102 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#0e0804"/>
+
+  <linearGradient id="desert-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#100e08"/>
+    <stop offset="50%" stop-color="#181206"/>
+    <stop offset="100%" stop-color="#201808"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#desert-sky)"/>
+
+  <!-- Desert heat shimmer — warm amber atmosphere -->
+  <radialGradient id="heat-amb" cx="50%" cy="55%" r="55%">
+    <stop offset="0%" stop-color="#604010" stop-opacity="0.3"/>
+    <stop offset="100%" stop-color="#604010" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#heat-amb)"/>
+
+  <!-- Dune horizon — rolling sand forms -->
+  <!-- Far dunes -->
+  <g fill="#120c04" opacity="0.8">
+    <polygon points="0,155 60,125 120,148 180,120 240,142 300,115 360,138 400,120 400,160 0,160"/>
+  </g>
+  <!-- Mid dunes -->
+  <g fill="#180e06">
+    <polygon points="0,175 50,148 100,162 160,138 220,155 280,132 340,150 400,135 400,200 0,200"/>
+  </g>
+  <!-- Foreground dune curve -->
+  <g fill="#1c1006">
+    <polygon points="0,200 80,175 160,185 240,170 320,182 400,168 400,240 0,240"/>
+  </g>
+  <!-- Sand highlights on dune crests -->
+  <g stroke="#382010" stroke-width="1" fill="none" opacity="0.5">
+    <path d="M0,148 Q60,125 120,148"/>
+    <path d="M180,120 Q240,142 300,115"/>
+    <path d="M160,138 Q220,155 280,132"/>
+  </g>
+
+  <!-- THE LEY LINES — straight through the desert sand, glowing warm gold/orange -->
+  <!-- The Sand Market has made them into trade routes -->
+  <linearGradient id="sand-ley" x1="0" y1="0" x2="1" y2="0">
+    <stop offset="0%" stop-color="#c08020" stop-opacity="0.2"/>
+    <stop offset="30%" stop-color="#e0a030" stop-opacity="0.8"/>
+    <stop offset="50%" stop-color="#f0b840" stop-opacity="1"/>
+    <stop offset="70%" stop-color="#e0a030" stop-opacity="0.8"/>
+    <stop offset="100%" stop-color="#c08020" stop-opacity="0.2"/>
+  </linearGradient>
+  <rect x="0" y="168" width="400" height="4" fill="url(#sand-ley)"/>
+  <rect x="0" y="169" width="400" height="2" fill="#ffd060" opacity="0.4"/>
+  <!-- Second ley path — angled slightly -->
+  <line x1="0" y1="183" x2="400" y2="175" stroke="#c08828" stroke-width="2.5" opacity="0.5"/>
+  <line x1="0" y1="183" x2="400" y2="175" stroke="#e0b040" stroke-width="0.8" opacity="0.4"/>
+
+  <!-- Market spire on the horizon — catching moonlight -->
+  <line x1="200" y1="155" x2="200" y2="95" stroke="#201408" stroke-width="4"/>
+  <!-- Spire top — pointed -->
+  <polygon points="196,95 204,95 200,78" fill="#201808" stroke="#302010" stroke-width="1"/>
+  <!-- Spire windows glowing warm inside -->
+  <g fill="#b06020" opacity="0.5">
+    <rect x="197" y="108" width="6" height="5" rx="1"/>
+    <rect x="197" y="120" width="6" height="5" rx="1"/>
+    <rect x="197" y="132" width="6" height="5" rx="1"/>
+  </g>
+  <!-- Spire glow halo — it's lit from ley energy below -->
+  <radialGradient id="spire-glow" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#c08020" stop-opacity="0.25"/>
+    <stop offset="100%" stop-color="#c08020" stop-opacity="0"/>
+  </radialGradient>
+  <ellipse cx="200" cy="125" rx="35" ry="45" fill="url(#spire-glow)"/>
+
+  <!-- Market stalls/structures silhouetted around the spire -->
+  <g fill="#140e04" stroke="#201408" stroke-width="0.8">
+    <rect x="155" y="148" width="20" height="12"/>
+    <rect x="225" y="150" width="18" height="10"/>
+    <polygon points="155,148 165,138 175,148"/>
+    <polygon points="225,150 234,141 243,150"/>
+    <!-- Awning shapes -->
+    <path d="M150,152 Q165,148 180,152" stroke="#281808" fill="none" stroke-width="1.5"/>
+    <path d="M220,154 Q234,150 248,154" stroke="#281808" fill="none" stroke-width="1.5"/>
+  </g>
+  <!-- Market lights — warm dots around stalls -->
+  <g fill="#c08030" opacity="0.6">
+    <circle cx="155" cy="148" r="2"/>
+    <circle cx="175" cy="148" r="2"/>
+    <circle cx="225" cy="150" r="2"/>
+    <circle cx="243" cy="150" r="2"/>
+    <circle cx="185" cy="153" r="1.5"/>
+    <circle cx="215" cy="153" r="1.5"/>
+  </g>
+
+  <!-- Stars — warm, desert night sky -->
+  <g fill="#d0a040" opacity="0.35">
+    <circle cx="40"  cy="20" r="1.2"/>
+    <circle cx="110" cy="12" r="1"/>
+    <circle cx="180" cy="22" r="1.5"/>
+    <circle cx="260" cy="10" r="1"/>
+    <circle cx="340" cy="18" r="1.2"/>
+    <circle cx="380" cy="30" r="1"/>
+  </g>
+
+  <!-- Label -->
+  <text x="200" y="232" font-family="monospace" font-size="9" fill="#3a2008" text-anchor="middle" letter-spacing="3">THE SAND MARKET</text>
+</svg>

--- a/web/public/cutscenes/act10-intro-2.svg
+++ b/web/public/cutscenes/act10-intro-2.svg
@@ -1,0 +1,100 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#0e0804"/>
+
+  <linearGradient id="baron-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#100e06"/>
+    <stop offset="100%" stop-color="#1e1408"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#baron-sky)"/>
+
+  <!-- Warm desert atmosphere -->
+  <radialGradient id="baron-warm" cx="50%" cy="40%" r="50%">
+    <stop offset="0%" stop-color="#583010" stop-opacity="0.25"/>
+    <stop offset="100%" stop-color="#583010" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#baron-warm)"/>
+
+  <!-- Market floor — tiled, desert stone -->
+  <polygon points="80,195 320,188 330,210 70,212" fill="#120c04" stroke="#1c1206" stroke-width="1.5"/>
+  <polygon points="80,195 320,188 322,193 80,202" fill="#181006" stroke="#221408" stroke-width="1"/>
+  <!-- Tile cracks — old stone -->
+  <g stroke="#1c1006" stroke-width="0.6" fill="none" opacity="0.4">
+    <line x1="100" y1="195" x2="100" y2="210"/>
+    <line x1="150" y1="193" x2="152" y2="208"/>
+    <line x1="250" y1="192" x2="248" y2="207"/>
+    <line x1="300" y1="195" x2="300" y2="210"/>
+  </g>
+
+  <!-- Shadow -->
+  <ellipse cx="200" cy="206" rx="45" ry="8" fill="#080402" opacity="0.8"/>
+
+  <!-- THE DUNE BARON — well-dressed, merchant/magnate, hat, walking cane, elaborate coat -->
+  <!-- Boots — polished, ornate -->
+  <ellipse cx="189" cy="210" rx="8" ry="3.5" fill="#100c04"/>
+  <ellipse cx="213" cy="209" rx="8" ry="3.5" fill="#100c04"/>
+  <!-- Legs — tailored trousers -->
+  <line x1="191" y1="196" x2="189" y2="210" stroke="#141008" stroke-width="4" stroke-linecap="round"/>
+  <line x1="207" y1="195" x2="213" y2="209" stroke="#141008" stroke-width="4" stroke-linecap="round"/>
+  <!-- Long merchant coat — ornate, gold trim -->
+  <polygon points="177,155 223,155 230,196 170,196" fill="#181208" stroke="#281808" stroke-width="1"/>
+  <!-- Gold trim on coat -->
+  <g stroke="#a07020" stroke-width="1.5" opacity="0.6">
+    <path d="M178,162 Q200,166 222,162"/>
+    <path d="M177,172 Q200,176 223,172"/>
+    <path d="M176,182 Q200,186 224,182"/>
+  </g>
+  <!-- Coat buttons — gold -->
+  <g fill="#c08828" opacity="0.7">
+    <circle cx="200" cy="163" r="2"/>
+    <circle cx="200" cy="170" r="2"/>
+    <circle cx="200" cy="177" r="2"/>
+    <circle cx="200" cy="184" r="2"/>
+  </g>
+  <!-- Wide-brimmed merchant hat -->
+  <ellipse cx="200" cy="140" rx="20" ry="4" fill="#0e0c04" stroke="#181208" stroke-width="1"/>
+  <ellipse cx="200" cy="137" rx="13" ry="10" fill="#121006" stroke="#181408" stroke-width="0.8"/>
+  <!-- Hat band — gold -->
+  <ellipse cx="200" cy="140" rx="14" ry="3" fill="none" stroke="#a07020" stroke-width="1.5" opacity="0.6"/>
+  <!-- Face — composed, calculating -->
+  <ellipse cx="200" cy="147" rx="11" ry="10" fill="#141008" stroke="#201408" stroke-width="1"/>
+  <!-- Eyes — sharp, assessing value -->
+  <line x1="193" y1="147" x2="198" y2="146" stroke="#806040" stroke-width="1.5" opacity="0.7"/>
+  <line x1="202" y1="146" x2="207" y2="147" stroke="#806040" stroke-width="1.5" opacity="0.7"/>
+  <!-- Slight smirk -->
+  <path d="M194,153 Q200,156 206,153" stroke="#201808" stroke-width="1" fill="none"/>
+  <!-- Thin moustache -->
+  <path d="M195,151 Q200,152 205,151" stroke="#402808" stroke-width="1.2" fill="none"/>
+
+  <!-- Left arm — gesture of presentation, open palm -->
+  <line x1="177" y1="168" x2="155" y2="178" stroke="#141008" stroke-width="4" stroke-linecap="round"/>
+  <polygon points="148,174 158,172 160,184 150,186" fill="#161008" stroke="#221408" stroke-width="0.8"/>
+
+  <!-- Right arm — leaning on ornate walking cane -->
+  <line x1="223" y1="165" x2="240" y2="178" stroke="#141008" stroke-width="4" stroke-linecap="round"/>
+  <!-- Cane shaft -->
+  <line x1="240" y1="178" x2="245" y2="210" stroke="#281808" stroke-width="2.5"/>
+  <!-- Cane handle — ornate gold knob -->
+  <circle cx="238" cy="175" r="7" fill="#100c04" stroke="#907020" stroke-width="1.5"/>
+  <circle cx="238" cy="175" r="3" fill="#a07828" opacity="0.7"/>
+
+  <!-- Market goods/wares in background — amphora, crates silhouettes -->
+  <g fill="#100c04" stroke="#1c1208" stroke-width="0.8" opacity="0.7">
+    <ellipse cx="120" cy="198" rx="14" ry="8"/>
+    <rect x="112" y="190" width="16" height="10" rx="1"/>
+    <ellipse cx="280" cy="197" rx="12" ry="7"/>
+    <rect x="272" y="189" width="14" height="10" rx="1"/>
+    <rect x="145" y="190" width="20" height="12" rx="1"/>
+    <rect x="235" y="191" width="18" height="11" rx="1"/>
+  </g>
+
+  <!-- Desert stars above the market roof -->
+  <g fill="#d0a040" opacity="0.3">
+    <circle cx="50"  cy="22" r="1"/>
+    <circle cx="130" cy="15" r="1.2"/>
+    <circle cx="300" cy="18" r="1"/>
+    <circle cx="370" cy="25" r="1.2"/>
+  </g>
+
+  <!-- Label -->
+  <text x="200" y="232" font-family="monospace" font-size="9" fill="#3a2008" text-anchor="middle" letter-spacing="3">THE DUNE BARON</text>
+</svg>

--- a/web/public/cutscenes/act10-intro-3.svg
+++ b/web/public/cutscenes/act10-intro-3.svg
@@ -1,0 +1,112 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#0e0804"/>
+  <linearGradient id="market-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#100e06"/>
+    <stop offset="100%" stop-color="#1c1608"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#market-sky)"/>
+
+  <!-- Warm market glow from central spire below -->
+  <radialGradient id="spire-amb" cx="50%" cy="80%" r="55%">
+    <stop offset="0%" stop-color="#904820" stop-opacity="0.4"/>
+    <stop offset="100%" stop-color="#904820" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#spire-amb)"/>
+
+  <!-- Market floor perspective — looking down the route to the spire -->
+  <polygon points="0,240 400,240 400,190 0,200" fill="#120e04"/>
+  <line x1="0" y1="195" x2="400" y2="190" stroke="#1c1408" stroke-width="1"/>
+  <!-- Stone tiles -->
+  <g stroke="#181008" stroke-width="0.6" fill="none" opacity="0.4">
+    <line x1="0"   y1="200" x2="400" y2="193"/>
+    <line x1="0"   y1="210" x2="400" y2="203"/>
+    <line x1="80"  y1="195" x2="80"  y2="240"/>
+    <line x1="160" y1="193" x2="165" y2="240"/>
+    <line x1="240" y1="192" x2="235" y2="240"/>
+    <line x1="320" y1="194" x2="320" y2="240"/>
+  </g>
+
+  <!-- LEY CONVERGENCE — multiple ley lines meeting at the spire base -->
+  <!-- Left ley -->
+  <line x1="0" y1="200" x2="200" y2="185" stroke="#d09020" stroke-width="2.5" opacity="0.6"/>
+  <line x1="0" y1="200" x2="200" y2="185" stroke="#f0c040" stroke-width="0.8" opacity="0.5"/>
+  <!-- Right ley -->
+  <line x1="400" y1="196" x2="200" y2="185" stroke="#d09020" stroke-width="2.5" opacity="0.6"/>
+  <line x1="400" y1="196" x2="200" y2="185" stroke="#f0c040" stroke-width="0.8" opacity="0.5"/>
+  <!-- Third ley from lower-left -->
+  <line x1="0" y1="215" x2="200" y2="185" stroke="#c07810" stroke-width="1.5" opacity="0.4"/>
+  <!-- Fourth from lower-right -->
+  <line x1="400" y1="210" x2="200" y2="185" stroke="#c07810" stroke-width="1.5" opacity="0.4"/>
+  <!-- Convergence glow at base of spire -->
+  <radialGradient id="conv-glow" cx="50%" cy="77%" r="20%">
+    <stop offset="0%" stop-color="#d09020" stop-opacity="0.6"/>
+    <stop offset="100%" stop-color="#d09020" stop-opacity="0"/>
+  </radialGradient>
+  <ellipse cx="200" cy="185" rx="25" ry="15" fill="url(#conv-glow)"/>
+
+  <!-- CENTRAL SPIRE — towering, the Baron's power centre -->
+  <!-- Base -- wide platform -->
+  <rect x="178" y="175" width="44" height="15" rx="2" fill="#140e04" stroke="#201408" stroke-width="1"/>
+  <!-- Shaft -->
+  <rect x="186" y="90" width="28" height="87" fill="#120e04" stroke="#1c1408" stroke-width="1"/>
+  <!-- Shaft windows — lit warm orange -->
+  <g fill="#d06820" opacity="0.5">
+    <rect x="192" y="98"  width="6" height="8" rx="1"/>
+    <rect x="202" y="98"  width="6" height="8" rx="1"/>
+    <rect x="192" y="115" width="6" height="8" rx="1"/>
+    <rect x="202" y="115" width="6" height="8" rx="1"/>
+    <rect x="192" y="132" width="6" height="8" rx="1"/>
+    <rect x="202" y="132" width="6" height="8" rx="1"/>
+    <rect x="192" y="149" width="6" height="8" rx="1"/>
+    <rect x="202" y="149" width="6" height="8" rx="1"/>
+  </g>
+  <!-- Upper narrowing -->
+  <polygon points="182,90 218,90 214,62 186,62" fill="#120e04" stroke="#1c1408" stroke-width="1"/>
+  <!-- Spire tip -->
+  <polygon points="194,62 206,62 200,38" fill="#160e04" stroke="#201408" stroke-width="1"/>
+  <!-- Spire tip glow — ley energy bleeding out at top -->
+  <radialGradient id="tip-glow" cx="50%" cy="100%" r="60%">
+    <stop offset="0%" stop-color="#e0a030" stop-opacity="0.5"/>
+    <stop offset="100%" stop-color="#e0a030" stop-opacity="0"/>
+  </radialGradient>
+  <ellipse cx="200" cy="38" rx="15" ry="12" fill="url(#tip-glow)"/>
+
+  <!-- Market structures flanking the route -->
+  <g fill="#100c04" stroke="#181008" stroke-width="0.8" opacity="0.8">
+    <!-- Left stalls -->
+    <rect x="20"  y="170" width="50" height="30"/>
+    <rect x="80"  y="165" width="40" height="35"/>
+    <!-- Awning triangles -->
+    <polygon points="20,170  45,158 70,170"/>
+    <polygon points="80,165 100,155 120,165"/>
+    <!-- Right stalls -->
+    <rect x="330" y="170" width="50" height="30"/>
+    <rect x="280" y="165" width="40" height="35"/>
+    <polygon points="330,170 355,158 380,170"/>
+    <polygon points="280,165 300,155 320,165"/>
+  </g>
+  <!-- Market lanterns strung between stalls -->
+  <g fill="#c07828" opacity="0.5">
+    <circle cx="40"  cy="162" r="3"/>
+    <circle cx="65"  cy="158" r="3"/>
+    <circle cx="90"  cy="155" r="3"/>
+    <circle cx="310" cy="155" r="3"/>
+    <circle cx="335" cy="158" r="3"/>
+    <circle cx="360" cy="162" r="3"/>
+  </g>
+  <g stroke="#c07828" stroke-width="0.6" fill="none" opacity="0.3">
+    <path d="M40,162 Q65,158 90,155"/>
+    <path d="M310,155 Q335,158 360,162"/>
+  </g>
+
+  <!-- Stars -->
+  <g fill="#d0a040" opacity="0.3">
+    <circle cx="50"  cy="18" r="1"/>
+    <circle cx="150" cy="10" r="1.2"/>
+    <circle cx="260" cy="14" r="1"/>
+    <circle cx="370" cy="20" r="1.2"/>
+  </g>
+
+  <!-- Label -->
+  <text x="200" y="232" font-family="monospace" font-size="9" fill="#3a2008" text-anchor="middle" letter-spacing="3">THE MARKET ROUTE</text>
+</svg>

--- a/web/public/cutscenes/act10-outro-1.svg
+++ b/web/public/cutscenes/act10-outro-1.svg
@@ -1,0 +1,80 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#0e0804"/>
+  <linearGradient id="settle-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#100e06"/>
+    <stop offset="100%" stop-color="#1a1208"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#settle-sky)"/>
+
+  <!-- Dimmer market atmosphere — the Baron has accepted the loss -->
+  <radialGradient id="settle-warm" cx="50%" cy="55%" r="45%">
+    <stop offset="0%" stop-color="#402808" stop-opacity="0.2"/>
+    <stop offset="100%" stop-color="#402808" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#settle-warm)"/>
+
+  <!-- Market floor — same setting -->
+  <polygon points="80,195 320,188 330,210 70,212" fill="#120c04" stroke="#1c1206" stroke-width="1.5"/>
+  <polygon points="80,195 320,188 322,193 80,202" fill="#181006" stroke="#221408" stroke-width="1"/>
+
+  <!-- THE DUNE BARON — standing, composed, no longer threatening — calculating -->
+  <ellipse cx="200" cy="207" rx="38" ry="7" fill="#080402" opacity="0.7"/>
+  <!-- Boots -->
+  <ellipse cx="191" cy="211" rx="7" ry="3" fill="#100c04"/>
+  <ellipse cx="211" cy="210" rx="7" ry="3" fill="#100c04"/>
+  <!-- Legs -->
+  <line x1="193" y1="198" x2="191" y2="211" stroke="#141008" stroke-width="4" stroke-linecap="round"/>
+  <line x1="207" y1="197" x2="211" y2="210" stroke="#141008" stroke-width="4" stroke-linecap="round"/>
+  <!-- Coat — still elegant, perhaps a slight wrinkle now -->
+  <polygon points="178,157 222,157 228,198 172,198" fill="#181208" stroke="#281808" stroke-width="1"/>
+  <!-- Gold trim — intact, he maintains dignity -->
+  <g stroke="#907020" stroke-width="1.2" opacity="0.5">
+    <path d="M179,164 Q200,168 221,164"/>
+    <path d="M178,174 Q200,178 222,174"/>
+  </g>
+  <!-- Hat — still on, still composed -->
+  <ellipse cx="200" cy="142" rx="20" ry="4" fill="#0e0c04" stroke="#181208" stroke-width="1"/>
+  <ellipse cx="200" cy="139" rx="13" ry="10" fill="#121006" stroke="#181408" stroke-width="0.8"/>
+  <ellipse cx="200" cy="142" rx="14" ry="3" fill="none" stroke="#807018" stroke-width="1.2" opacity="0.5"/>
+  <!-- Face — composed, recalculating -->
+  <ellipse cx="200" cy="149" rx="11" ry="10" fill="#141008" stroke="#201408" stroke-width="1"/>
+  <!-- Eyes — neutral, calculating -->
+  <line x1="193" y1="149" x2="198" y2="148" stroke="#705030" stroke-width="1.5" opacity="0.6"/>
+  <line x1="202" y1="148" x2="207" y2="149" stroke="#705030" stroke-width="1.5" opacity="0.6"/>
+  <!-- Slight thinning of mouth — accepting -->
+  <line x1="194" y1="155" x2="206" y2="155" stroke="#201808" stroke-width="1"/>
+  <!-- Moustache -->
+  <path d="M195,153 Q200,154 205,153" stroke="#402808" stroke-width="1.2" fill="none"/>
+  <!-- Arms — both at sides, cane still in right hand but at rest -->
+  <line x1="178" y1="170" x2="162" y2="184" stroke="#141008" stroke-width="4" stroke-linecap="round"/>
+  <polygon points="155,180 165,178 167,190 157,192" fill="#161008" stroke="#221408" stroke-width="0.8"/>
+  <line x1="222" y1="168" x2="240" y2="182" stroke="#141008" stroke-width="4" stroke-linecap="round"/>
+  <line x1="240" y1="182" x2="244" y2="210" stroke="#281808" stroke-width="2.5"/>
+  <circle cx="238" cy="179" r="6" fill="#100c04" stroke="#907020" stroke-width="1.2" opacity="0.6"/>
+
+  <!-- Market stall silhouettes dimmed — night falling -->
+  <g fill="#0e0a04" opacity="0.8">
+    <rect x="60"  y="172" width="50" height="28"/>
+    <rect x="290" y="172" width="50" height="28"/>
+  </g>
+
+  <!-- Distant spire — still lit but lower glow -->
+  <line x1="340" y1="190" x2="340" y2="142" stroke="#181008" stroke-width="3" opacity="0.6"/>
+  <g fill="#905818" opacity="0.3">
+    <rect x="336" y="150" width="5" height="5" rx="0.5"/>
+    <rect x="336" y="162" width="5" height="5" rx="0.5"/>
+    <rect x="336" y="174" width="5" height="5" rx="0.5"/>
+  </g>
+
+  <!-- Stars — desert night -->
+  <g fill="#d0a040" opacity="0.35">
+    <circle cx="50"  cy="20" r="1"/>
+    <circle cx="130" cy="12" r="1.2"/>
+    <circle cx="250" cy="16" r="1"/>
+    <circle cx="370" cy="22" r="1.2"/>
+    <circle cx="200" cy="8"  r="1"/>
+  </g>
+
+  <!-- Label -->
+  <text x="200" y="232" font-family="monospace" font-size="9" fill="#3a2008" text-anchor="middle" letter-spacing="3">THE DUNE BARON SETTLES</text>
+</svg>

--- a/web/public/cutscenes/act10-outro-2.svg
+++ b/web/public/cutscenes/act10-outro-2.svg
@@ -1,0 +1,92 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#0e0804"/>
+  <linearGradient id="deal-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#100e06"/>
+    <stop offset="100%" stop-color="#1c1608"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#deal-sky)"/>
+
+  <radialGradient id="deal-warm" cx="40%" cy="55%" r="40%">
+    <stop offset="0%" stop-color="#503010" stop-opacity="0.25"/>
+    <stop offset="100%" stop-color="#503010" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#deal-warm)"/>
+
+  <!-- Market floor -->
+  <polygon points="60,198 340,190 350,215 50,217" fill="#120c04" stroke="#1c1206" stroke-width="1.5"/>
+  <polygon points="60,198 340,190 342,196 60,204" fill="#181006" stroke="#221408" stroke-width="1"/>
+
+  <!-- THE DUNE BARON — left side, cane planted, gesturing with one hand as he speaks -->
+  <ellipse cx="125" cy="208" rx="30" ry="6" fill="#080402" opacity="0.7"/>
+  <ellipse cx="119" cy="212" rx="7" ry="3" fill="#100c04"/>
+  <ellipse cx="133" cy="211" rx="7" ry="3" fill="#100c04"/>
+  <line x1="121" y1="199" x2="119" y2="212" stroke="#141008" stroke-width="4" stroke-linecap="round"/>
+  <line x1="130" y1="198" x2="133" y2="211" stroke="#141008" stroke-width="4" stroke-linecap="round"/>
+  <!-- Coat -->
+  <polygon points="106,160 146,160 151,199 101,199" fill="#181208" stroke="#281808" stroke-width="1"/>
+  <g stroke="#907020" stroke-width="1.2" opacity="0.5">
+    <path d="M107,167 Q126,171 145,167"/>
+  </g>
+  <!-- Hat -->
+  <ellipse cx="126" cy="145" rx="19" ry="4" fill="#0e0c04" stroke="#181208" stroke-width="1"/>
+  <ellipse cx="126" cy="142" rx="12" ry="9" fill="#121006" stroke="#181408" stroke-width="0.8"/>
+  <ellipse cx="126" cy="145" rx="13" ry="3" fill="none" stroke="#807018" stroke-width="1.2" opacity="0.5"/>
+  <!-- Face — speaking, slight sardonic amusement -->
+  <ellipse cx="126" cy="152" rx="10" ry="9" fill="#141008" stroke="#201408" stroke-width="1"/>
+  <line x1="120" y1="152" x2="124" y2="151" stroke="#705030" stroke-width="1.5" opacity="0.6"/>
+  <line x1="128" y1="151" x2="132" y2="152" stroke="#705030" stroke-width="1.5" opacity="0.6"/>
+  <path d="M119,157 Q126,160 133,157" stroke="#201808" stroke-width="1" fill="none"/>
+  <path d="M119,155 Q126,156 133,155" stroke="#402808" stroke-width="1.2" fill="none"/>
+  <!-- Left arm — gesturing, open, speaking -->
+  <line x1="106" y1="172" x2="88" y2="162" stroke="#141008" stroke-width="4" stroke-linecap="round"/>
+  <polygon points="82,158 92,156 94,167 84,169" fill="#161008" stroke="#221408" stroke-width="0.8"/>
+  <!-- Right arm — cane -->
+  <line x1="146" y1="170" x2="158" y2="182" stroke="#141008" stroke-width="4" stroke-linecap="round"/>
+  <line x1="158" y1="182" x2="162" y2="210" stroke="#281808" stroke-width="2.5"/>
+  <circle cx="156" cy="179" r="6" fill="#100c04" stroke="#907020" stroke-width="1.2" opacity="0.5"/>
+
+  <!-- Speech direction dots -->
+  <g fill="#604020" opacity="0.5">
+    <circle cx="172" cy="158" r="1.5"/>
+    <circle cx="180" cy="154" r="1.2"/>
+    <circle cx="188" cy="152" r="1"/>
+  </g>
+
+  <!-- JARV — right side, standing, listening -->
+  <ellipse cx="285" cy="210" rx="24" ry="5" fill="#040201" opacity="0.7"/>
+  <ellipse cx="278" cy="213" rx="5.5" ry="2.5" fill="#08090e"/>
+  <ellipse cx="291" cy="213" rx="5.5" ry="2.5" fill="#08090e"/>
+  <line x1="280" y1="203" x2="278" y2="213" stroke="#0c0c18" stroke-width="4" stroke-linecap="round"/>
+  <line x1="289" y1="202" x2="291" y2="213" stroke="#0c0c18" stroke-width="4" stroke-linecap="round"/>
+  <!-- Coral Mantle -->
+  <polygon points="268,178 302,178 306,203 264,203" fill="#0a1e20" stroke="#1a4040" stroke-width="1.5"/>
+  <g fill="#00c090" opacity="0.45">
+    <circle cx="264" cy="178" r="1.5"/>
+    <circle cx="306" cy="178" r="1.5"/>
+  </g>
+  <!-- Stormcaller Badge -->
+  <polygon points="285,186 289,189 289,195 285,198 281,195 281,189" fill="#080e20" stroke="#2848a0" stroke-width="0.6"/>
+  <!-- Head — turned toward Baron -->
+  <ellipse cx="283" cy="169" rx="10" ry="9" fill="#0c0c1a" stroke="#181830" stroke-width="1"/>
+  <ellipse cx="281" cy="172" rx="5.5" ry="3.5" fill="#080810"/>
+  <!-- Iron Standard -->
+  <line x1="310" y1="178" x2="328" y2="215" stroke="#2a3040" stroke-width="2.5"/>
+  <polygon points="308,178 312,178 310,169" fill="#404860" opacity="0.7"/>
+
+  <!-- Desert night -- lanterns lit in the market around them -->
+  <g fill="#c07828" opacity="0.4">
+    <circle cx="60"  cy="175" r="3"/>
+    <circle cx="340" cy="175" r="3"/>
+    <circle cx="200" cy="170" r="2.5"/>
+  </g>
+
+  <!-- Stars -->
+  <g fill="#d0a040" opacity="0.35">
+    <circle cx="60"  cy="20" r="1.2"/>
+    <circle cx="200" cy="12" r="1"/>
+    <circle cx="340" cy="22" r="1.2"/>
+  </g>
+
+  <!-- Label -->
+  <text x="200" y="232" font-family="monospace" font-size="9" fill="#3a2008" text-anchor="middle" letter-spacing="3">WHAT HE SAID</text>
+</svg>

--- a/web/public/cutscenes/act10-outro-3.svg
+++ b/web/public/cutscenes/act10-outro-3.svg
@@ -1,0 +1,112 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#0e0804"/>
+  <linearGradient id="comp-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#100e06"/>
+    <stop offset="50%" stop-color="#161006"/>
+    <stop offset="100%" stop-color="#1c1408"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#comp-sky)"/>
+
+  <!-- Golden glow — the Compass radiates warm light -->
+  <radialGradient id="comp-glow" cx="50%" cy="40%" r="45%">
+    <stop offset="0%" stop-color="#a07020" stop-opacity="0.5"/>
+    <stop offset="60%" stop-color="#806010" stop-opacity="0.2"/>
+    <stop offset="100%" stop-color="#806010" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#comp-glow)"/>
+
+  <!-- THE GOLDEN COMPASS — the Baron's personal navigation relic -->
+  <!-- Outer case glow ring -->
+  <circle cx="200" cy="92" r="50" fill="none" stroke="#a07020" stroke-width="0.8" opacity="0.3"/>
+  <circle cx="200" cy="92" r="46" fill="none" stroke="#c09030" stroke-width="0.5" opacity="0.4"/>
+
+  <!-- Compass outer ring — ornate gold casing -->
+  <circle cx="200" cy="92" r="40" fill="#0e0c04" stroke="#907020" stroke-width="2"/>
+  <!-- Compass bezel markings — cardinal points -->
+  <g fill="#c09030" opacity="0.7">
+    <!-- N -->
+    <polygon points="200,56 203,64 200,62 197,64"/>
+    <!-- S -->
+    <polygon points="200,128 203,120 200,122 197,120"/>
+    <!-- E -->
+    <polygon points="236,92 228,89 230,92 228,95"/>
+    <!-- W -->
+    <polygon points="164,92 172,89 170,92 172,95"/>
+  </g>
+  <!-- Bezel tick marks -->
+  <g stroke="#806018" stroke-width="0.8" opacity="0.5">
+    <line x1="200" y1="54" x2="200" y2="59"/>
+    <line x1="228" y1="64" x2="225" y2="68"/>
+    <line x1="238" y1="92" x2="233" y2="92"/>
+    <line x1="228" y1="120" x2="225" y2="116"/>
+    <line x1="200" y1="130" x2="200" y2="125"/>
+    <line x1="172" y1="120" x2="175" y2="116"/>
+    <line x1="162" y1="92" x2="167" y2="92"/>
+    <line x1="172" y1="64" x2="175" y2="68"/>
+  </g>
+
+  <!-- Compass rose — inner mechanism -->
+  <circle cx="200" cy="92" r="30" fill="#0c0a02" stroke="#706010" stroke-width="1"/>
+  <!-- Rose radial lines -->
+  <g stroke="#504010" stroke-width="0.8" fill="none" opacity="0.6">
+    <line x1="200" y1="62" x2="200" y2="122"/>
+    <line x1="170" y1="92" x2="230" y2="92"/>
+    <line x1="179" y1="71" x2="221" y2="113"/>
+    <line x1="221" y1="71" x2="179" y2="113"/>
+  </g>
+  <!-- Inner compass disc — gold gradient -->
+  <radialGradient id="comp-inner" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#c09030" stop-opacity="0.4"/>
+    <stop offset="60%" stop-color="#907020" stop-opacity="0.15"/>
+    <stop offset="100%" stop-color="#907020" stop-opacity="0"/>
+  </radialGradient>
+  <circle cx="200" cy="92" r="28" fill="url(#comp-inner)"/>
+  <!-- Compass needle — gold, pointing to ley convergence -->
+  <polygon points="200,66 203,92 200,118 197,92" fill="#c09030" opacity="0.8"/>
+  <polygon points="200,66 203,92 200,78 197,92" fill="#e0b040" opacity="0.9"/>
+  <!-- Needle pivot -->
+  <circle cx="200" cy="92" r="4" fill="#0e0c04" stroke="#c09030" stroke-width="1.5"/>
+  <circle cx="200" cy="92" r="2" fill="#e0b040" opacity="0.7"/>
+
+  <!-- Engraving on outer ring — Baron's mark -->
+  <circle cx="200" cy="92" r="36" fill="none" stroke="#706010" stroke-width="0.6" stroke-dasharray="3,4" opacity="0.4"/>
+
+  <!-- Jarv below — small, holding compass in outstretched palm -->
+  <ellipse cx="200" cy="222" rx="20" ry="4" fill="#030201" opacity="0.7"/>
+  <ellipse cx="194" cy="224" rx="4.5" ry="2" fill="#08090e"/>
+  <ellipse cx="206" cy="224" rx="4.5" ry="2" fill="#08090e"/>
+  <line x1="196" y1="215" x2="194" y2="224" stroke="#0c0c18" stroke-width="3.5" stroke-linecap="round"/>
+  <line x1="204" y1="215" x2="206" y2="224" stroke="#0c0c18" stroke-width="3.5" stroke-linecap="round"/>
+  <!-- Coral Mantle -->
+  <polygon points="184,184 216,184 220,214 180,214" fill="#0a1e20" stroke="#1a4040" stroke-width="1.5"/>
+  <g fill="#00c090" opacity="0.4">
+    <circle cx="180" cy="184" r="1.5"/>
+    <circle cx="220" cy="184" r="1.5"/>
+  </g>
+  <!-- One arm extended upward, palm open holding compass -->
+  <line x1="184" y1="191" x2="168" y2="172" stroke="#0c0c18" stroke-width="3.5" stroke-linecap="round"/>
+  <line x1="216" y1="191" x2="232" y2="172" stroke="#0c0c18" stroke-width="3.5" stroke-linecap="round"/>
+  <polygon points="162,167 172,166 174,177 164,178" fill="#0d0e1a" stroke="#181830" stroke-width="0.8"/>
+  <polygon points="228,167 238,166 240,177 230,178" fill="#0d0e1a" stroke="#181830" stroke-width="0.8"/>
+  <!-- Head -->
+  <ellipse cx="200" cy="175" rx="9" ry="8" fill="#0c0c1a" stroke="#181830" stroke-width="1"/>
+  <ellipse cx="200" cy="178" rx="5" ry="3" fill="#080810"/>
+
+  <!-- Golden light on Jarv's hands from the Compass -->
+  <g fill="#c08820" opacity="0.2">
+    <ellipse cx="165" cy="174" rx="8" ry="5"/>
+    <ellipse cx="235" cy="174" rx="8" ry="5"/>
+  </g>
+
+  <!-- Desert sand and stars -->
+  <rect x="0" y="228" width="400" height="12" fill="#120e04"/>
+  <g fill="#d0a040" opacity="0.3">
+    <circle cx="50"  cy="18" r="1"/>
+    <circle cx="150" cy="10" r="1.2"/>
+    <circle cx="260" cy="15" r="1"/>
+    <circle cx="360" cy="22" r="1.2"/>
+  </g>
+
+  <!-- Label -->
+  <text x="200" y="238" font-family="monospace" font-size="9" fill="#3a2008" text-anchor="middle" letter-spacing="3">THE GOLDEN COMPASS</text>
+</svg>

--- a/web/public/cutscenes/act11-intro-1.svg
+++ b/web/public/cutscenes/act11-intro-1.svg
@@ -1,0 +1,99 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#030802"/>
+
+  <linearGradient id="canopy-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#040a02"/>
+    <stop offset="50%" stop-color="#060e04"/>
+    <stop offset="100%" stop-color="#081206"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#canopy-sky)"/>
+
+  <!-- Forest bioluminescent ambient -->
+  <radialGradient id="canopy-glow" cx="50%" cy="30%" r="55%">
+    <stop offset="0%" stop-color="#102808" stop-opacity="0.4"/>
+    <stop offset="100%" stop-color="#102808" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#canopy-glow)"/>
+
+  <!-- HIGH CANOPY — dense interlocked branches filling the upper frame -->
+  <g fill="#050c02" stroke="#081202" stroke-width="0.5">
+    <polygon points="0,0 400,0 400,70 360,60 320,75 280,55 240,72 200,48 160,70 120,52 80,68 40,50 0,65"/>
+  </g>
+  <!-- Canopy layer 2 — more branch silhouettes -->
+  <g fill="#060e03" opacity="0.8">
+    <polygon points="0,65 0,0 35,0 30,50"/>
+    <polygon points="400,65 400,0 365,0 368,52"/>
+    <ellipse cx="80"  cy="40" rx="55" ry="22"/>
+    <ellipse cx="200" cy="32" rx="65" ry="25"/>
+    <ellipse cx="320" cy="38" rx="55" ry="22"/>
+  </g>
+  <!-- Ley lines threading through roots — bright green-gold seams -->
+  <g stroke="#20a040" stroke-width="1.2" fill="none" opacity="0.5">
+    <path d="M0,68 Q50,60 100,68 Q150,76 200,65 Q250,54 300,65 Q350,76 400,68"/>
+    <path d="M0,78 Q80,70 160,80 Q240,90 320,78 Q360,72 400,78"/>
+  </g>
+
+  <!-- TREE TRUNKS — massive, ancient, ley veins glowing -->
+  <!-- Left trunk -->
+  <rect x="30" y="65" width="45" height="180" fill="#050c02" stroke="#0a1604" stroke-width="1"/>
+  <!-- Left trunk ley seam -->
+  <line x1="52" y1="65"  x2="50" y2="245" stroke="#18a030" stroke-width="1.5" opacity="0.4"/>
+  <line x1="53" y1="65"  x2="51" y2="245" stroke="#40e060" stroke-width="0.5" opacity="0.3"/>
+  <!-- Root buttresses left -->
+  <g fill="#040a02" stroke="#081404" stroke-width="0.8">
+    <polygon points="30,200 15,240 30,240"/>
+    <polygon points="75,200 90,240 75,240"/>
+    <polygon points="52,195 42,240 62,240"/>
+  </g>
+
+  <!-- Centre trunk — massive -->
+  <rect x="172" y="48" width="56" height="197" fill="#050c02" stroke="#0a1604" stroke-width="1"/>
+  <!-- Centre ley seam — brightest -->
+  <line x1="199" y1="48"  x2="199" y2="245" stroke="#20c040" stroke-width="2" opacity="0.5"/>
+  <line x1="200" y1="48"  x2="200" y2="245" stroke="#60ff80" stroke-width="0.8" opacity="0.4"/>
+  <!-- Root buttresses centre -->
+  <g fill="#040a02" stroke="#081404" stroke-width="0.8">
+    <polygon points="172,195 155,240 172,240"/>
+    <polygon points="228,195 245,240 228,240"/>
+    <polygon points="200,192 185,240 215,240"/>
+  </g>
+
+  <!-- Right trunk -->
+  <rect x="325" y="60" width="45" height="185" fill="#050c02" stroke="#0a1604" stroke-width="1"/>
+  <line x1="347" y1="60"  x2="347" y2="245" stroke="#18a030" stroke-width="1.5" opacity="0.4"/>
+  <g fill="#040a02" stroke="#081404" stroke-width="0.8">
+    <polygon points="325,200 310,240 325,240"/>
+    <polygon points="370,200 385,240 370,240"/>
+  </g>
+
+  <!-- Forest floor — deep leaf litter and roots -->
+  <rect x="0" y="210" width="400" height="30" fill="#040802"/>
+  <!-- Root networks on floor -->
+  <g stroke="#0a1604" stroke-width="1.5" fill="none" opacity="0.5">
+    <path d="M52,245 Q80,230 110,240 Q140,250 160,235"/>
+    <path d="M200,245 Q230,228 260,238 Q290,248 320,232"/>
+  </g>
+
+  <!-- Bioluminescent moss/spores on trunks -->
+  <g fill="#20c040" opacity="0.2">
+    <circle cx="45"  cy="130" r="3"/>
+    <circle cx="65"  cy="155" r="2.5"/>
+    <circle cx="185" cy="120" r="3"/>
+    <circle cx="215" cy="145" r="2.5"/>
+    <circle cx="335" cy="135" r="3"/>
+    <circle cx="350" cy="160" r="2"/>
+  </g>
+
+  <!-- Floating spores — canopy life -->
+  <g fill="#40c060" opacity="0.3">
+    <circle cx="100" cy="110" r="1.2"/>
+    <circle cx="150" cy="90"  r="1"/>
+    <circle cx="250" cy="95"  r="1.2"/>
+    <circle cx="310" cy="112" r="1"/>
+    <circle cx="130" cy="140" r="0.8"/>
+    <circle cx="280" cy="135" r="0.8"/>
+  </g>
+
+  <!-- Label -->
+  <text x="200" y="232" font-family="monospace" font-size="9" fill="#183010" text-anchor="middle" letter-spacing="3">THE VERDANT CANOPY</text>
+</svg>

--- a/web/public/cutscenes/act11-intro-2.svg
+++ b/web/public/cutscenes/act11-intro-2.svg
@@ -1,0 +1,95 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#030802"/>
+  <linearGradient id="warden-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#040a02"/>
+    <stop offset="100%" stop-color="#081206"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#warden-sky)"/>
+
+  <!-- Green canopy glow — the Warden IS the canopy -->
+  <radialGradient id="warden-glow" cx="50%" cy="40%" r="55%">
+    <stop offset="0%" stop-color="#184010" stop-opacity="0.45"/>
+    <stop offset="100%" stop-color="#184010" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#warden-glow)"/>
+
+  <!-- Forest floor -->
+  <rect x="0" y="200" width="400" height="40" fill="#040802"/>
+  <line x1="0" y1="200" x2="400" y2="200" stroke="#0a1604" stroke-width="1"/>
+  <!-- Root mats -->
+  <g stroke="#0a1406" stroke-width="1" fill="none" opacity="0.4">
+    <path d="M0,205 Q80,200 160,205 Q240,210 320,205 Q370,202 400,205"/>
+  </g>
+
+  <!-- THE ELDER WARDEN — the canopy made sovereign -->
+  <!-- Not humanoid — a vast aggregated form of interlocked branches and living wood -->
+  <!-- Main "body" mass — converging branches forming a presence -->
+  <!-- Root pillar base -->
+  <g fill="#060e04" stroke="#0e1808" stroke-width="1">
+    <polygon points="170,200 230,200 240,240 160,240" fill="#050c02"/>
+    <!-- Spreading root tendrils at base -->
+    <path d="M170,200 Q155,210 140,220 Q125,228 110,235" stroke="#0a1408" stroke-width="3" fill="none"/>
+    <path d="M230,200 Q245,210 260,220 Q275,228 290,235" stroke="#0a1408" stroke-width="3" fill="none"/>
+    <path d="M185,200 Q178,215 172,230" stroke="#0a1408" stroke-width="2" fill="none"/>
+    <path d="M215,200 Q222,215 228,230" stroke="#0a1408" stroke-width="2" fill="none"/>
+  </g>
+  <!-- Central mass — coiling branches -->
+  <g fill="#060e03" stroke="#0e1806" stroke-width="1.5">
+    <ellipse cx="200" cy="155" rx="55" ry="50"/>
+  </g>
+  <!-- Branch arms radiating outward — the Warden's reach -->
+  <g stroke="#081404" stroke-width="4" fill="none" stroke-linecap="round">
+    <path d="M155,140 Q120,125 85,108 Q60,96 35,88"/>
+    <path d="M245,140 Q280,125 315,108 Q340,96 365,88"/>
+    <path d="M165,120 Q140,100 118,82 Q100,68 82,55"/>
+    <path d="M235,120 Q260,100 282,82 Q300,68 318,55"/>
+    <path d="M200,105 Q195,80 190,58 Q186,42 183,28"/>
+    <path d="M200,105 Q205,80 210,58 Q214,42 217,28"/>
+  </g>
+  <!-- Secondary branch tendrils -->
+  <g stroke="#0a1804" stroke-width="2" fill="none" stroke-linecap="round" opacity="0.7">
+    <path d="M85,108 Q70,102 55,95"/>
+    <path d="M315,108 Q330,102 345,95"/>
+    <path d="M118,82 Q108,75 98,65"/>
+    <path d="M282,82 Q292,75 302,65"/>
+  </g>
+  <!-- Branch tips lit with ley energy — green nodes -->
+  <g fill="#20c040" opacity="0.5">
+    <circle cx="35"  cy="88"  r="4"/>
+    <circle cx="365" cy="88"  r="4"/>
+    <circle cx="82"  cy="55"  r="3.5"/>
+    <circle cx="318" cy="55"  r="3.5"/>
+    <circle cx="183" cy="28"  r="3"/>
+    <circle cx="217" cy="28"  r="3"/>
+  </g>
+  <!-- Face of the Warden — two glowing nodes where "eyes" would be -->
+  <circle cx="185" cy="148" r="6" fill="#060e04" stroke="#20a030" stroke-width="1.5" opacity="0.7"/>
+  <circle cx="215" cy="148" r="6" fill="#060e04" stroke="#20a030" stroke-width="1.5" opacity="0.7"/>
+  <circle cx="185" cy="148" r="3" fill="#30c050" opacity="0.6"/>
+  <circle cx="215" cy="148" r="3" fill="#30c050" opacity="0.6"/>
+  <!-- Mouth — a wide seam like bark splitting -->
+  <path d="M180,163 Q200,170 220,163" stroke="#0e1a06" stroke-width="2.5" fill="none" opacity="0.7"/>
+  <!-- Inner canopy texture on body mass -->
+  <g fill="#0a1604" opacity="0.6">
+    <ellipse cx="200" cy="145" rx="35" ry="30"/>
+    <ellipse cx="195" cy="135" rx="18" ry="14"/>
+    <ellipse cx="210" cy="140" rx="14" ry="12"/>
+  </g>
+  <!-- Bioluminescent ley veins on trunk body -->
+  <g stroke="#20c040" stroke-width="0.8" fill="none" opacity="0.4">
+    <path d="M185,200 Q190,185 188,165 Q186,150 188,135"/>
+    <path d="M215,200 Q210,185 212,165 Q214,150 212,135"/>
+    <path d="M200,200 Q200,180 200,155"/>
+  </g>
+
+  <!-- Falling leaves — the canopy breathing -->
+  <g fill="#184010" opacity="0.4">
+    <ellipse cx="80"  cy="180" rx="4" ry="2" transform="rotate(-30 80 180)"/>
+    <ellipse cx="140" cy="165" rx="3" ry="1.5" transform="rotate(20 140 165)"/>
+    <ellipse cx="260" cy="170" rx="4" ry="2" transform="rotate(15 260 170)"/>
+    <ellipse cx="320" cy="185" rx="3" ry="1.5" transform="rotate(-20 320 185)"/>
+  </g>
+
+  <!-- Label -->
+  <text x="200" y="232" font-family="monospace" font-size="9" fill="#183010" text-anchor="middle" letter-spacing="3">THE ELDER WARDEN</text>
+</svg>

--- a/web/public/cutscenes/act11-intro-3.svg
+++ b/web/public/cutscenes/act11-intro-3.svg
@@ -1,0 +1,112 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#030802"/>
+  <linearGradient id="path-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#040a02"/>
+    <stop offset="100%" stop-color="#081006"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#path-sky)"/>
+
+  <!-- Ancient forest warmth — enclosed, breathing -->
+  <radialGradient id="path-glow" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#142a08" stop-opacity="0.4"/>
+    <stop offset="100%" stop-color="#142a08" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#path-glow)"/>
+
+  <!-- Dense tree walls — left and right -->
+  <g fill="#050c02" stroke="#0a1404" stroke-width="1">
+    <rect x="0"   y="0" width="75" height="240"/>
+    <rect x="325" y="0" width="75" height="240"/>
+  </g>
+  <!-- Tree wall texture — bark lines -->
+  <g stroke="#081204" stroke-width="0.6" fill="none" opacity="0.4">
+    <line x1="20" y1="0" x2="18" y2="240"/>
+    <line x1="40" y1="0" x2="42" y2="240"/>
+    <line x1="60" y1="0" x2="58" y2="240"/>
+    <line x1="340" y1="0" x2="342" y2="240"/>
+    <line x1="360" y1="0" x2="358" y2="240"/>
+    <line x1="380" y1="0" x2="382" y2="240"/>
+  </g>
+  <!-- Bioluminescent moss patches on walls -->
+  <g fill="#20c040" opacity="0.18">
+    <ellipse cx="30"  cy="80"  rx="15" ry="6"/>
+    <ellipse cx="50"  cy="140" rx="12" ry="5"/>
+    <ellipse cx="25"  cy="190" rx="14" ry="5"/>
+    <ellipse cx="370" cy="90"  rx="15" ry="6"/>
+    <ellipse cx="350" cy="145" rx="12" ry="5"/>
+    <ellipse cx="375" cy="195" rx="14" ry="5"/>
+  </g>
+
+  <!-- Canopy ceiling — thick interlocked branches -->
+  <polygon points="0,0 400,0 400,62 370,50 335,65 300,48 265,62 230,44 200,58 170,42 135,60 100,46 65,62 30,48 0,58" fill="#050c02"/>
+  <!-- Canopy layer -->
+  <g fill="#060e03" opacity="0.7">
+    <ellipse cx="80"  cy="38" rx="50" ry="20"/>
+    <ellipse cx="200" cy="30" rx="60" ry="22"/>
+    <ellipse cx="320" cy="36" rx="50" ry="20"/>
+  </g>
+
+  <!-- THE PATH — narrow corridor through ancient heartwood -->
+  <!-- Path floor — mossy, root-crossed -->
+  <polygon points="75,200 325,200 325,240 75,240" fill="#050a02"/>
+  <polygon points="75,200 325,200 320,240 80,240" fill="#060c03" opacity="0.5"/>
+  <!-- Root ridges crossing the path -->
+  <g stroke="#0a1404" stroke-width="2" fill="none" opacity="0.5">
+    <path d="M75,215 Q130,210 200,215 Q270,220 325,215"/>
+    <path d="M75,228 Q140,224 200,228 Q260,232 325,228"/>
+    <path d="M90,210 Q100,220 95,230"/>
+    <path d="M200,205 Q205,215 200,225"/>
+    <path d="M310,210 Q300,220 305,230"/>
+  </g>
+
+  <!-- LEY CONVERGENCE — the heartwood ahead glows bright green-gold -->
+  <!-- Ley lines running along the path floor -->
+  <linearGradient id="path-ley" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#20b040" stop-opacity="0"/>
+    <stop offset="60%" stop-color="#40d060" stop-opacity="0.7"/>
+    <stop offset="100%" stop-color="#20b040" stop-opacity="0.9"/>
+  </linearGradient>
+  <rect x="188" y="80" width="24" height="160" fill="url(#path-ley)" opacity="0.4"/>
+  <rect x="196" y="80" width="8"  height="160" fill="#60ff80" opacity="0.2"/>
+
+  <!-- Heartwood ahead — the convergence point glowing in the distance -->
+  <radialGradient id="heart-glow" cx="50%" cy="60%" r="40%">
+    <stop offset="0%" stop-color="#30c050" stop-opacity="0.6"/>
+    <stop offset="50%" stop-color="#18a030" stop-opacity="0.25"/>
+    <stop offset="100%" stop-color="#18a030" stop-opacity="0"/>
+  </radialGradient>
+  <rect x="75" y="80" width="250" height="160" fill="url(#heart-glow)"/>
+  <!-- Ancient heartwood silhouette — massive trunk in the middle-distance -->
+  <rect x="178" y="125" width="44" height="120" fill="#040902" stroke="#081204" stroke-width="1"/>
+  <!-- Ley veins on heartwood -->
+  <line x1="199" y1="125" x2="198" y2="245" stroke="#30d050" stroke-width="1.5" opacity="0.5"/>
+  <line x1="201" y1="125" x2="202" y2="245" stroke="#60ff80" stroke-width="0.6" opacity="0.35"/>
+  <!-- Heartwood glow -->
+  <radialGradient id="hw-glow" cx="50%" cy="40%" r="50%">
+    <stop offset="0%" stop-color="#40e060" stop-opacity="0.4"/>
+    <stop offset="100%" stop-color="#40e060" stop-opacity="0"/>
+  </radialGradient>
+  <rect x="168" y="125" width="64" height="60" fill="url(#hw-glow)"/>
+
+  <!-- JARV — small, at mid-ground, walking toward the heartwood -->
+  <!-- Tiny silhouette to show scale of the ancient trees -->
+  <ellipse cx="200" cy="200" rx="10" ry="2.5" fill="#020401" opacity="0.7"/>
+  <line x1="197" y1="193" x2="196" y2="200" stroke="#0c0c18" stroke-width="2.5" stroke-linecap="round"/>
+  <line x1="202" y1="193" x2="203" y2="200" stroke="#0c0c18" stroke-width="2.5" stroke-linecap="round"/>
+  <polygon points="193,181 207,181 210,193 190,193" fill="#0a1e20" stroke="#1a4040" stroke-width="0.8"/>
+  <ellipse cx="200" cy="175" rx="7" ry="6" fill="#0c0c1a" stroke="#181830" stroke-width="0.8"/>
+  <line x1="207" y1="183" x2="214" y2="196" stroke="#2a3040" stroke-width="1.5"/>
+
+  <!-- Floating spores drifting down path -->
+  <g fill="#40c060" opacity="0.35">
+    <circle cx="110" cy="120" r="1.2"/>
+    <circle cx="150" cy="100" r="1"/>
+    <circle cx="250" cy="108" r="1.2"/>
+    <circle cx="290" cy="122" r="1"/>
+    <circle cx="130" cy="155" r="0.8"/>
+    <circle cx="270" cy="148" r="0.8"/>
+  </g>
+
+  <!-- Label -->
+  <text x="200" y="232" font-family="monospace" font-size="9" fill="#183010" text-anchor="middle" letter-spacing="3">THE PATH THROUGH</text>
+</svg>

--- a/web/public/cutscenes/act11-outro-1.svg
+++ b/web/public/cutscenes/act11-outro-1.svg
@@ -1,0 +1,82 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#030802"/>
+  <linearGradient id="yield-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#040a02"/>
+    <stop offset="100%" stop-color="#060e04"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#yield-sky)"/>
+
+  <!-- Dimming forest — the Warden withdrawing, light fading -->
+  <radialGradient id="yield-dim" cx="50%" cy="40%" r="55%">
+    <stop offset="0%" stop-color="#0c2008" stop-opacity="0.25"/>
+    <stop offset="100%" stop-color="#0c2008" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#yield-dim)"/>
+
+  <!-- Forest floor -->
+  <rect x="0" y="200" width="400" height="40" fill="#040802"/>
+  <line x1="0" y1="200" x2="400" y2="200" stroke="#081204" stroke-width="1"/>
+
+  <!-- Tree trunks — still standing, Warden withdrawing back into them -->
+  <rect x="35"  y="60"  width="42" height="145" fill="#050c02" stroke="#0a1404" stroke-width="1" opacity="0.8"/>
+  <rect x="175" y="45"  width="50" height="160" fill="#050c02" stroke="#0a1404" stroke-width="1" opacity="0.8"/>
+  <rect x="323" y="58"  width="42" height="148" fill="#050c02" stroke="#0a1404" stroke-width="1" opacity="0.8"/>
+  <!-- Root buttresses -->
+  <g fill="#040a02" stroke="#081404" stroke-width="0.8" opacity="0.7">
+    <polygon points="35,195 20,240 35,240"/>
+    <polygon points="77,195 92,240 77,240"/>
+    <polygon points="175,192 158,240 175,240"/>
+    <polygon points="225,192 242,240 225,240"/>
+    <polygon points="323,195 308,240 323,240"/>
+    <polygon points="365,195 380,240 365,240"/>
+  </g>
+
+  <!-- THE WARDEN FORM — dissolving, branching arms retreating back into canopy -->
+  <!-- Central mass — shrinking, losing cohesion -->
+  <ellipse cx="200" cy="140" rx="40" ry="35" fill="#060e04" stroke="#0e1806" stroke-width="1" opacity="0.5"/>
+  <ellipse cx="200" cy="138" rx="25" ry="22" fill="#050c02" opacity="0.7"/>
+  <!-- Arms withdrawing — upward, back into canopy -->
+  <g stroke="#081404" stroke-width="3" fill="none" stroke-linecap="round" opacity="0.5">
+    <path d="M165,128 Q130,108 100,88 Q72,72 50,60"/>
+    <path d="M235,128 Q270,108 300,88 Q328,72 350,60"/>
+    <path d="M185,112 Q165,90 148,70 Q134,54 122,40"/>
+    <path d="M215,112 Q235,90 252,70 Q266,54 278,40"/>
+  </g>
+  <!-- Eyes — fading, closing -->
+  <circle cx="186" cy="138" r="4" fill="#060e04" stroke="#18a030" stroke-width="1" opacity="0.25"/>
+  <circle cx="214" cy="138" r="4" fill="#060e04" stroke="#18a030" stroke-width="1" opacity="0.25"/>
+  <circle cx="186" cy="138" r="2" fill="#20c040" opacity="0.2"/>
+  <circle cx="214" cy="138" r="2" fill="#20c040" opacity="0.2"/>
+  <!-- Branch tips going dark — nodes off -->
+  <g fill="#183010" opacity="0.2">
+    <circle cx="50"  cy="60" r="3"/>
+    <circle cx="350" cy="60" r="3"/>
+    <circle cx="122" cy="40" r="2.5"/>
+    <circle cx="278" cy="40" r="2.5"/>
+  </g>
+
+  <!-- Ley lines — still active, unaffected by withdrawal -->
+  <line x1="199" y1="45" x2="199" y2="200" stroke="#18a030" stroke-width="1.2" opacity="0.3"/>
+  <line x1="201" y1="45" x2="201" y2="200" stroke="#40e060" stroke-width="0.5" opacity="0.2"/>
+
+  <!-- Falling leaves — the Warden shedding as it withdraws -->
+  <g fill="#183010" opacity="0.5">
+    <ellipse cx="80"  cy="170" rx="5" ry="2" transform="rotate(-25 80 170)"/>
+    <ellipse cx="130" cy="155" rx="4" ry="2" transform="rotate(15 130 155)"/>
+    <ellipse cx="270" cy="160" rx="5" ry="2" transform="rotate(20 270 160)"/>
+    <ellipse cx="320" cy="175" rx="4" ry="2" transform="rotate(-15 320 175)"/>
+    <ellipse cx="160" cy="185" rx="3" ry="1.5" transform="rotate(10 160 185)"/>
+    <ellipse cx="240" cy="180" rx="3" ry="1.5" transform="rotate(-10 240 180)"/>
+  </g>
+
+  <!-- Canopy above — denser as the Warden returns to it -->
+  <polygon points="0,0 400,0 400,60 370,48 335,62 295,44 255,60 215,42 185,58 155,40 115,60 75,44 35,60 0,48" fill="#050c02"/>
+  <g fill="#060e03" opacity="0.7">
+    <ellipse cx="100" cy="35" rx="60" ry="22"/>
+    <ellipse cx="200" cy="28" rx="70" ry="24"/>
+    <ellipse cx="300" cy="33" rx="60" ry="22"/>
+  </g>
+
+  <!-- Label -->
+  <text x="200" y="232" font-family="monospace" font-size="9" fill="#183010" text-anchor="middle" letter-spacing="3">THE CANOPY YIELDS</text>
+</svg>

--- a/web/public/cutscenes/act11-outro-2.svg
+++ b/web/public/cutscenes/act11-outro-2.svg
@@ -1,0 +1,99 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#030802"/>
+  <linearGradient id="bark-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#040a02"/>
+    <stop offset="100%" stop-color="#081006"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#bark-sky)"/>
+
+  <!-- Soft forest warmth — quiet after the Warden's withdrawal -->
+  <radialGradient id="bark-glow" cx="50%" cy="45%" r="45%">
+    <stop offset="0%" stop-color="#183810" stop-opacity="0.4"/>
+    <stop offset="60%" stop-color="#102808" stop-opacity="0.15"/>
+    <stop offset="100%" stop-color="#102808" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#bark-glow)"/>
+
+  <!-- LIVING BARK — the relic, centre frame -->
+  <!-- Outer glow ring — alive, warm -->
+  <radialGradient id="bark-aura" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#28a040" stop-opacity="0.4"/>
+    <stop offset="50%" stop-color="#18802a" stop-opacity="0.15"/>
+    <stop offset="100%" stop-color="#18802a" stop-opacity="0"/>
+  </radialGradient>
+  <ellipse cx="200" cy="95" rx="60" ry="55" fill="url(#bark-aura)"/>
+
+  <!-- Bark shape — irregular, organic strip of living heartwood -->
+  <!-- Main bark body — curved, like a section of ancient trunk -->
+  <path d="M172,55 Q188,48 212,52 Q228,56 232,78 Q235,100 228,122 Q222,140 208,148 Q194,155 180,148 Q166,140 162,118 Q158,96 162,74 Q165,62 172,55 Z" fill="#0a1606" stroke="#183010" stroke-width="2"/>
+  <!-- Bark surface texture — fissures and grain -->
+  <g stroke="#142808" stroke-width="0.8" fill="none" opacity="0.6">
+    <path d="M176,62 Q182,80 178,100 Q175,118 178,136"/>
+    <path d="M190,56 Q194,75 191,96 Q188,114 191,132"/>
+    <path d="M204,58 Q208,78 205,98 Q202,116 205,134"/>
+    <path d="M218,68 Q222,86 219,105 Q216,122 219,138"/>
+  </g>
+  <!-- Horizontal ring marks — age rings visible in cross-section -->
+  <g stroke="#1a3010" stroke-width="0.6" fill="none" opacity="0.4">
+    <path d="M165,80  Q200,76 232,82"/>
+    <path d="M163,100 Q200,96 234,102"/>
+    <path d="M165,120 Q200,116 232,122"/>
+  </g>
+  <!-- Bioluminescent ley veins running through the bark — it's alive -->
+  <g stroke="#30c050" stroke-width="1" fill="none" opacity="0.5">
+    <path d="M182,60 Q186,80 183,100 Q180,118 183,136"/>
+    <path d="M200,55 Q200,76 200,98 Q200,116 200,135"/>
+    <path d="M218,68 Q214,86 216,106 Q218,122 215,138"/>
+  </g>
+  <!-- Living surface glow — ley energy just under the bark -->
+  <radialGradient id="bark-inner" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#28c048" stop-opacity="0.3"/>
+    <stop offset="100%" stop-color="#28c048" stop-opacity="0"/>
+  </radialGradient>
+  <path d="M172,55 Q188,48 212,52 Q228,56 232,78 Q235,100 228,122 Q222,140 208,148 Q194,155 180,148 Q166,140 162,118 Q158,96 162,74 Q165,62 172,55 Z" fill="url(#bark-inner)"/>
+  <!-- Small bud — inexplicably growing from the top edge of the bark -->
+  <g fill="#20a030" opacity="0.7">
+    <ellipse cx="200" cy="52" rx="5" ry="3" transform="rotate(-10 200 52)"/>
+    <ellipse cx="210" cy="55" rx="4" ry="2.5" transform="rotate(15 210 55)"/>
+  </g>
+  <line x1="200" y1="55" x2="200" y2="48" stroke="#18a028" stroke-width="1" opacity="0.6"/>
+  <line x1="210" y1="58" x2="213" y2="50" stroke="#18a028" stroke-width="1" opacity="0.5"/>
+
+  <!-- JARV — below, arms raised receiving the bark -->
+  <ellipse cx="200" cy="222" rx="20" ry="4" fill="#020401" opacity="0.7"/>
+  <ellipse cx="194" cy="224" rx="4.5" ry="2" fill="#08090e"/>
+  <ellipse cx="206" cy="224" rx="4.5" ry="2" fill="#08090e"/>
+  <line x1="196" y1="215" x2="194" y2="224" stroke="#0c0c18" stroke-width="3.5" stroke-linecap="round"/>
+  <line x1="204" y1="214" x2="206" y2="224" stroke="#0c0c18" stroke-width="3.5" stroke-linecap="round"/>
+  <polygon points="184,183 216,183 220,213 180,213" fill="#0a1e20" stroke="#1a4040" stroke-width="1.5"/>
+  <g fill="#00c090" opacity="0.4">
+    <circle cx="180" cy="183" r="1.5"/>
+    <circle cx="220" cy="183" r="1.5"/>
+  </g>
+  <line x1="184" y1="190" x2="166" y2="168" stroke="#0c0c18" stroke-width="3.5" stroke-linecap="round"/>
+  <line x1="216" y1="190" x2="234" y2="168" stroke="#0c0c18" stroke-width="3.5" stroke-linecap="round"/>
+  <polygon points="160,163 170,162 172,173 162,174" fill="#0d0e1a" stroke="#181830" stroke-width="0.8"/>
+  <polygon points="230,163 240,162 242,173 232,174" fill="#0d0e1a" stroke="#181830" stroke-width="0.8"/>
+  <ellipse cx="200" cy="174" rx="9" ry="8" fill="#0c0c1a" stroke="#181830" stroke-width="1"/>
+  <ellipse cx="200" cy="177" rx="5" ry="3" fill="#080810"/>
+
+  <!-- Forest floor -->
+  <rect x="0" y="226" width="400" height="14" fill="#040802"/>
+  <g stroke="#0a1404" stroke-width="1" fill="none" opacity="0.3">
+    <path d="M0,228 Q100,225 200,228 Q300,231 400,228"/>
+  </g>
+
+  <!-- Drifting canopy leaves — quietly settling -->
+  <g fill="#183010" opacity="0.4">
+    <ellipse cx="70"  cy="120" rx="4" ry="2" transform="rotate(-20 70 120)"/>
+    <ellipse cx="140" cy="100" rx="3" ry="1.5" transform="rotate(10 140 100)"/>
+    <ellipse cx="260" cy="105" rx="4" ry="2" transform="rotate(18 260 105)"/>
+    <ellipse cx="330" cy="118" rx="3" ry="1.5" transform="rotate(-12 330 118)"/>
+  </g>
+
+  <!-- Canopy framing -->
+  <polygon points="0,0 400,0 400,48 365,36 325,50 285,34 245,50 205,32 175,48 135,32 95,50 55,34 15,50 0,38" fill="#050c02"/>
+
+  <!-- Label -->
+  <text x="200" y="238" font-family="monospace" font-size="9" fill="#183010" text-anchor="middle" letter-spacing="3">LIVING BARK</text>
+</svg>

--- a/web/public/cutscenes/act11-outro-3.svg
+++ b/web/public/cutscenes/act11-outro-3.svg
@@ -1,0 +1,94 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#030802"/>
+  <linearGradient id="road11-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#040a02"/>
+    <stop offset="50%" stop-color="#060e04"/>
+    <stop offset="100%" stop-color="#0a1408"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#road11-sky)"/>
+
+  <!-- Forest edge opening up — light ahead -->
+  <radialGradient id="exit-glow" cx="50%" cy="50%" r="45%">
+    <stop offset="0%" stop-color="#203818" stop-opacity="0.4"/>
+    <stop offset="100%" stop-color="#203818" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#exit-glow)"/>
+
+  <!-- Receding canopy — trees thinning toward right (the way out) -->
+  <!-- Dense canopy left side, thinning to right -->
+  <g fill="#050c02" opacity="0.9">
+    <polygon points="0,0 200,0 200,65 170,52 140,68 110,50 80,66 50,50 20,64 0,54"/>
+  </g>
+  <g fill="#060e03" opacity="0.6">
+    <ellipse cx="50"  cy="42" rx="55" ry="20"/>
+    <ellipse cx="140" cy="35" rx="60" ry="22"/>
+  </g>
+  <!-- Sparse canopy right side — thinning out -->
+  <g fill="#050c02" opacity="0.5">
+    <polygon points="200,0 400,0 400,50 370,38 330,52 290,36 250,50 220,36 200,46"/>
+  </g>
+
+  <!-- Tree silhouettes left — dense -->
+  <g fill="#050c02" stroke="#0a1404" stroke-width="1">
+    <rect x="0"   y="52" width="38" height="193"/>
+    <rect x="50"  y="60" width="34" height="185"/>
+    <rect x="105" y="55" width="38" height="190"/>
+  </g>
+  <!-- Tree silhouettes right — fewer, more spaced -->
+  <g fill="#060e04" stroke="#0c1606" stroke-width="1" opacity="0.7">
+    <rect x="280" y="72" width="28" height="173"/>
+    <rect x="345" y="80" width="24" height="165"/>
+  </g>
+
+  <!-- Ground — forest floor transitioning to open path -->
+  <polygon points="0,215 400,205 400,240 0,240" fill="#040a02"/>
+  <line x1="0" y1="215" x2="400" y2="205" stroke="#0a1404" stroke-width="1"/>
+  <!-- Root mats thinning toward right -->
+  <g stroke="#0a1404" stroke-width="1" fill="none" opacity="0.4">
+    <path d="M0,222 Q50,218 100,222 Q150,226 200,222"/>
+    <path d="M50,228 Q100,224 150,228 Q200,232 250,228"/>
+  </g>
+
+  <!-- JARV — centre-right, walking toward the light, back to viewer -->
+  <ellipse cx="260" cy="215" rx="18" ry="4" fill="#020401" opacity="0.7"/>
+  <line x1="255" y1="207" x2="254" y2="215" stroke="#0c0c18" stroke-width="3" stroke-linecap="round"/>
+  <line x1="263" y1="207" x2="265" y2="215" stroke="#0c0c18" stroke-width="3" stroke-linecap="round"/>
+  <!-- Coral Mantle — small, walking away -->
+  <polygon points="249,194 271,194 274,207 246,207" fill="#0a1e20" stroke="#1a4040" stroke-width="1"/>
+  <g fill="#00c090" opacity="0.4">
+    <circle cx="246" cy="194" r="1.2"/>
+    <circle cx="274" cy="194" r="1.2"/>
+  </g>
+  <ellipse cx="259" cy="188" rx="7" ry="6" fill="#0c0c1a" stroke="#181830" stroke-width="0.8"/>
+  <!-- Iron Standard over shoulder -->
+  <line x1="270" y1="195" x2="285" y2="208" stroke="#2a3040" stroke-width="2"/>
+  <polygon points="268,195 272,195 270,186" fill="#404860" opacity="0.6"/>
+
+  <!-- The canopy resumes above behind — sound of life returning -->
+  <!-- Ley line faint on the path — still present even outside the forest -->
+  <line x1="230" y1="215" x2="400" y2="210" stroke="#20a030" stroke-width="1" opacity="0.25"/>
+
+  <!-- Forest sounds — abstract leaves drifting up from behind -->
+  <g fill="#183010" opacity="0.4">
+    <ellipse cx="140" cy="155" rx="4" ry="2" transform="rotate(-15 140 155)"/>
+    <ellipse cx="175" cy="130" rx="3" ry="1.5" transform="rotate(10 175 130)"/>
+    <ellipse cx="200" cy="145" rx="4" ry="2" transform="rotate(20 200 145)"/>
+  </g>
+
+  <!-- Open sky ahead — slightly lighter at right -->
+  <radialGradient id="ahead-light" cx="80%" cy="40%" r="35%">
+    <stop offset="0%" stop-color="#182010" stop-opacity="0.2"/>
+    <stop offset="100%" stop-color="#182010" stop-opacity="0"/>
+  </radialGradient>
+  <rect x="200" y="0" width="200" height="210" fill="url(#ahead-light)"/>
+
+  <!-- Stars where canopy has opened -->
+  <g fill="#60a040" opacity="0.3">
+    <circle cx="310" cy="28" r="1"/>
+    <circle cx="355" cy="18" r="1.2"/>
+    <circle cx="385" cy="35" r="1"/>
+  </g>
+
+  <!-- Label -->
+  <text x="200" y="232" font-family="monospace" font-size="9" fill="#183010" text-anchor="middle" letter-spacing="3">THE ROAD AHEAD</text>
+</svg>

--- a/web/public/cutscenes/act12-intro-1.svg
+++ b/web/public/cutscenes/act12-intro-1.svg
@@ -1,0 +1,97 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#040810"/>
+
+  <linearGradient id="coast-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#060a14"/>
+    <stop offset="50%" stop-color="#0a1020"/>
+    <stop offset="100%" stop-color="#0e1828"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#coast-sky)"/>
+
+  <!-- Overcast grey atmosphere — the Fracture broke more than just land -->
+  <radialGradient id="fracture-atm" cx="50%" cy="40%" r="60%">
+    <stop offset="0%" stop-color="#182030" stop-opacity="0.3"/>
+    <stop offset="100%" stop-color="#182030" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#fracture-atm)"/>
+
+  <!-- SEA — grey, heavy, churning -->
+  <rect x="0" y="155" width="400" height="85" fill="#060c14"/>
+  <!-- Wave lines -->
+  <g stroke="#0e1c2c" stroke-width="1" fill="none" opacity="0.7">
+    <path d="M0,168 Q40,163 80,168 Q120,173 160,168 Q200,163 240,168 Q280,173 320,168 Q360,163 400,168"/>
+    <path d="M0,182 Q50,177 100,182 Q150,187 200,182 Q250,177 300,182 Q350,187 400,182"/>
+    <path d="M0,198 Q60,193 120,198 Q180,203 240,198 Q300,193 360,198 Q380,200 400,198"/>
+  </g>
+  <!-- Whitecaps -->
+  <g fill="#0e1e30" opacity="0.4">
+    <ellipse cx="60"  cy="166" rx="15" ry="3"/>
+    <ellipse cx="180" cy="170" rx="12" ry="2.5"/>
+    <ellipse cx="300" cy="165" rx="14" ry="3"/>
+    <ellipse cx="380" cy="172" rx="10" ry="2.5"/>
+  </g>
+
+  <!-- THE SHATTERED COAST — city split across several sea-separated fragments -->
+  <!-- Left land fragment -->
+  <polygon points="0,155 100,148 110,170 80,178 0,175" fill="#080c14" stroke="#101824" stroke-width="1.5"/>
+  <polygon points="0,148 100,148 98,154 0,158" fill="#0c1420" stroke="#182030" stroke-width="0.8"/>
+  <!-- Ruins on left fragment -->
+  <g fill="#070a12" stroke="#0e1420" stroke-width="0.8">
+    <rect x="15"  y="130" width="12" height="20"/>
+    <rect x="35"  y="125" width="10" height="25"/>
+    <rect x="55"  y="132" width="14" height="18"/>
+    <rect x="75"  y="128" width="10" height="22"/>
+  </g>
+  <!-- Broken wall on left -->
+  <path d="M10,148 Q30,142 50,148 Q45,138 42,130" stroke="#0e1420" stroke-width="2" fill="none"/>
+
+  <!-- Centre fragment — the main harbour ruins, largest piece -->
+  <polygon points="140,152 265,145 270,165 255,172 140,170" fill="#08101a" stroke="#10182a" stroke-width="1.5"/>
+  <polygon points="140,152 265,145 263,150 140,158" fill="#0c1622" stroke="#182030" stroke-width="0.8"/>
+  <!-- Port ruins — harbour wall, crane, towers -->
+  <g fill="#060a12" stroke="#0c1420" stroke-width="0.8">
+    <rect x="148" y="126" width="16" height="28"/>
+    <rect x="172" y="118" width="12" height="36"/>
+    <rect x="192" y="128" width="20" height="26"/>
+    <rect x="220" y="122" width="14" height="32"/>
+    <rect x="242" y="130" width="16" height="24"/>
+  </g>
+  <!-- Crane arm sticking out over water — collapsed -->
+  <line x1="172" y1="118" x2="155" y2="102" stroke="#0e1828" stroke-width="2.5"/>
+  <line x1="155" y1="102" x2="138" y2="110" stroke="#0e1828" stroke-width="1.5"/>
+  <!-- Broken dock jutting into water -->
+  <rect x="195" y="163" width="30" height="6" fill="#08101a" stroke="#101828" stroke-width="0.8"/>
+
+  <!-- Right fragment -->
+  <polygon points="300,150 400,143 400,165 380,172 300,168" fill="#070c16" stroke="#0f1826" stroke-width="1.5"/>
+  <polygon points="300,150 400,143 400,148 300,156" fill="#0b1420" stroke="#18202e" stroke-width="0.8"/>
+  <!-- Ruins on right -->
+  <g fill="#060a12" stroke="#0c1420" stroke-width="0.8">
+    <rect x="310" y="128" width="12" height="24"/>
+    <rect x="330" y="122" width="14" height="30"/>
+    <rect x="355" y="130" width="10" height="22"/>
+    <rect x="375" y="126" width="14" height="26"/>
+  </g>
+
+  <!-- Fracture lines visible in land fragments — the Fracture event -->
+  <g stroke="#182030" stroke-width="1" fill="none" opacity="0.5">
+    <path d="M50,148 Q55,160 52,172"/>
+    <path d="M195,145 Q200,155 198,168"/>
+    <path d="M340,150 Q338,162 342,172"/>
+  </g>
+
+  <!-- Storm clouds — heavy, pressing down -->
+  <g fill="#0a1018" opacity="0.7">
+    <ellipse cx="80"  cy="80" rx="80" ry="28"/>
+    <ellipse cx="200" cy="70" rx="90" ry="30"/>
+    <ellipse cx="330" cy="78" rx="75" ry="26"/>
+  </g>
+  <g fill="#0c1220" opacity="0.5">
+    <ellipse cx="60"  cy="65" rx="55" ry="18"/>
+    <ellipse cx="200" cy="55" rx="70" ry="22"/>
+    <ellipse cx="350" cy="62" rx="50" ry="18"/>
+  </g>
+
+  <!-- Label -->
+  <text x="200" y="232" font-family="monospace" font-size="9" fill="#182030" text-anchor="middle" letter-spacing="3">THE SHATTERED COAST</text>
+</svg>

--- a/web/public/cutscenes/act12-intro-2.svg
+++ b/web/public/cutscenes/act12-intro-2.svg
@@ -1,0 +1,109 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#040810"/>
+  <linearGradient id="hm-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#060a14"/>
+    <stop offset="100%" stop-color="#0c1828"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#hm-sky)"/>
+
+  <radialGradient id="hm-atm" cx="50%" cy="40%" r="50%">
+    <stop offset="0%" stop-color="#162028" stop-opacity="0.25"/>
+    <stop offset="100%" stop-color="#162028" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#hm-atm)"/>
+
+  <!-- Harbour dock — he stands on the remaining pier -->
+  <polygon points="80,195 320,188 328,208 72,210" fill="#080c14" stroke="#10182a" stroke-width="1.5"/>
+  <polygon points="80,195 320,188 321,193 80,202" fill="#0c1420" stroke="#182030" stroke-width="1"/>
+  <!-- Dock planks -->
+  <g stroke="#0e1828" stroke-width="0.6" fill="none" opacity="0.4">
+    <line x1="100" y1="195" x2="102" y2="210"/>
+    <line x1="130" y1="194" x2="130" y2="209"/>
+    <line x1="170" y1="193" x2="170" y2="208"/>
+    <line x1="230" y1="192" x2="230" y2="207"/>
+    <line x1="270" y1="193" x2="270" y2="208"/>
+    <line x1="300" y1="194" x2="300" y2="209"/>
+  </g>
+  <!-- Sea around dock -->
+  <g stroke="#0e1c2c" stroke-width="0.8" fill="none" opacity="0.5">
+    <path d="M0,200 Q40,196 80,200"/>
+    <path d="M320,196 Q360,192 400,196"/>
+  </g>
+
+  <!-- Shadow -->
+  <ellipse cx="200" cy="204" rx="42" ry="7" fill="#030608" opacity="0.8"/>
+
+  <!-- THE HARBORMASTER — once a port inspector, now something else -->
+  <!-- Boots — worn, practical -->
+  <ellipse cx="191" cy="208" rx="8" ry="3.5" fill="#08090e"/>
+  <ellipse cx="211" cy="207" rx="8" ry="3.5" fill="#08090e"/>
+  <line x1="193" y1="195" x2="191" y2="208" stroke="#0c1020" stroke-width="4" stroke-linecap="round"/>
+  <line x1="207" y1="194" x2="211" y2="207" stroke="#0c1020" stroke-width="4" stroke-linecap="round"/>
+  <!-- Heavy coat — waterproofed, iron-grey -->
+  <polygon points="178,155 222,155 228,195 172,195" fill="#101828" stroke="#182030" stroke-width="1"/>
+  <!-- Coat buckles -->
+  <g fill="#283848" opacity="0.6">
+    <rect x="185" y="162" width="8" height="5" rx="1"/>
+    <rect x="207" y="162" width="8" height="5" rx="1"/>
+    <rect x="196" y="175" width="8" height="5" rx="1"/>
+  </g>
+  <!-- Shoulder board — HARBORMASTER insignia, iron -->
+  <ellipse cx="180" cy="157" rx="10" ry="5" fill="#142030" opacity="0.8"/>
+  <ellipse cx="220" cy="157" rx="10" ry="5" fill="#142030" opacity="0.8"/>
+  <!-- Anchor emblem on shoulder -->
+  <g fill="#283848" opacity="0.5">
+    <circle cx="180" cy="157" r="3"/>
+    <circle cx="220" cy="157" r="3"/>
+  </g>
+  <!-- Head — weathered, set jaw, peaked cap -->
+  <ellipse cx="200" cy="143" rx="13" ry="12" fill="#0e1828" stroke="#182030" stroke-width="1"/>
+  <rect x="186" y="131" width="28" height="9" rx="2" fill="#0a1018" stroke="#162028" stroke-width="1"/>
+  <rect x="182" y="138" width="36" height="4" rx="1" fill="#080e16" stroke="#142024" stroke-width="0.8"/>
+  <!-- Cap badge — anchor, tarnished -->
+  <g fill="#283040" opacity="0.6">
+    <circle cx="200" cy="134" r="3"/>
+    <line x1="200" y1="131" x2="200" y2="137" stroke="#283040" stroke-width="1"/>
+    <line x1="197" y1="137" x2="203" y2="137" stroke="#283040" stroke-width="1"/>
+  </g>
+  <!-- Eyes — flat, bureaucratic iron -->
+  <line x1="192" y1="145" x2="197" y2="144" stroke="#405060" stroke-width="1.5" opacity="0.8"/>
+  <line x1="203" y1="144" x2="208" y2="145" stroke="#405060" stroke-width="1.5" opacity="0.8"/>
+  <!-- Tight mouth — no warmth -->
+  <line x1="193" y1="150" x2="207" y2="150" stroke="#182028" stroke-width="1.2"/>
+
+  <!-- Left arm — holding a ledger/clipboard — permit authority -->
+  <line x1="178" y1="168" x2="158" y2="178" stroke="#0c1020" stroke-width="4" stroke-linecap="round"/>
+  <rect x="148" y="172" width="18" height="22" rx="1" fill="#0a1018" stroke="#182030" stroke-width="0.8"/>
+  <!-- Pages in ledger -->
+  <g stroke="#182030" stroke-width="0.5" opacity="0.5">
+    <line x1="151" y1="177" x2="163" y2="177"/>
+    <line x1="151" y1="181" x2="163" y2="181"/>
+    <line x1="151" y1="185" x2="163" y2="185"/>
+  </g>
+
+  <!-- Right arm — pointing — ACCESS DENIED gesture -->
+  <line x1="222" y1="165" x2="248" y2="155" stroke="#0c1020" stroke-width="4" stroke-linecap="round"/>
+  <polygon points="243,148 253,150 250,162 240,160" fill="#0e1428" stroke="#182030" stroke-width="0.8"/>
+
+  <!-- Flagship in background — large iron hull moored at dock -->
+  <g fill="#060a14" stroke="#0e182a" stroke-width="1" opacity="0.7">
+    <polygon points="30,195 80,185 90,198 35,202"/>
+    <rect x="35" y="170" width="50" height="18"/>
+    <line x1="60" y1="170" x2="60" y2="145" stroke="#0e182a" stroke-width="2"/>
+    <polygon points="60,145 80,155 60,162" fill="#0c1628" opacity="0.5"/>
+  </g>
+  <g fill="#060a14" stroke="#0e182a" stroke-width="1" opacity="0.7">
+    <polygon points="310,193 365,184 370,197 315,200"/>
+    <rect x="315" y="168" width="50" height="18"/>
+    <line x1="340" y1="168" x2="340" y2="143" stroke="#0e182a" stroke-width="2"/>
+  </g>
+
+  <!-- Storm sky -->
+  <g fill="#0a1018" opacity="0.6">
+    <ellipse cx="100" cy="75" rx="70" ry="25"/>
+    <ellipse cx="300" cy="70" rx="65" ry="24"/>
+  </g>
+
+  <!-- Label -->
+  <text x="200" y="232" font-family="monospace" font-size="9" fill="#182030" text-anchor="middle" letter-spacing="3">THE HARBORMASTER</text>
+</svg>

--- a/web/public/cutscenes/act12-intro-3.svg
+++ b/web/public/cutscenes/act12-intro-3.svg
@@ -1,0 +1,97 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#040810"/>
+  <linearGradient id="permit-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#060a14"/>
+    <stop offset="100%" stop-color="#0e1828"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#permit-sky)"/>
+
+  <radialGradient id="permit-atm" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#142028" stop-opacity="0.3"/>
+    <stop offset="100%" stop-color="#142028" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#permit-atm)"/>
+
+  <!-- THE SEA ROUTE — narrow passage between two shattered land fragments -->
+  <!-- Left fragment wall -->
+  <polygon points="0,0 0,240 75,240 68,200 72,160 62,120 70,80 58,40 68,0" fill="#060a12"/>
+  <!-- Right fragment wall -->
+  <polygon points="400,0 400,240 325,240 332,200 328,160 338,120 330,80 342,40 332,0" fill="#060a12"/>
+  <!-- Cliff face detail — rough shattered stone -->
+  <g stroke="#0c1420" stroke-width="1" fill="none" opacity="0.4">
+    <path d="M65,40 Q58,60 62,80 Q70,100 62,120 Q54,140 65,160 Q74,178 68,200"/>
+    <path d="M335,40 Q342,60 338,80 Q330,100 338,120 Q346,140 335,160 Q326,178 332,200"/>
+  </g>
+  <!-- Fracture lines in cliff faces -->
+  <g stroke="#182030" stroke-width="1.5" fill="none" opacity="0.5">
+    <path d="M30,60 Q38,80 32,100"/>
+    <path d="M370,65 Q362,85 368,105"/>
+  </g>
+
+  <!-- THE SEA — filling the passage -->
+  <rect x="75" y="175" width="250" height="65" fill="#060c14"/>
+  <g stroke="#0e1c2c" stroke-width="0.8" fill="none" opacity="0.6">
+    <path d="M75,188 Q125,184 175,188 Q225,192 275,188 Q305,185 325,188"/>
+    <path d="M75,202 Q140,198 200,202 Q260,206 325,202"/>
+    <path d="M75,215 Q150,211 200,215 Q250,219 325,215"/>
+  </g>
+
+  <!-- PERMIT SIGN — big iron notice board, bolted to left cliff -->
+  <rect x="20" y="95" width="52" height="65" rx="2" fill="#080e18" stroke="#182030" stroke-width="2"/>
+  <!-- Sign text lines — bureaucratic officialdom -->
+  <g stroke="#182838" stroke-width="1" fill="none" opacity="0.6">
+    <line x1="26" y1="105" x2="66" y2="105"/>
+    <line x1="26" y1="112" x2="66" y2="112"/>
+    <line x1="26" y1="119" x2="55" y2="119"/>
+    <line x1="26" y1="126" x2="66" y2="126"/>
+    <line x1="26" y1="133" x2="60" y2="133"/>
+    <line x1="26" y1="140" x2="66" y2="140"/>
+    <line x1="26" y1="147" x2="50" y2="147"/>
+  </g>
+  <!-- Anchor stamp at bottom — the Harbormaster's seal -->
+  <circle cx="46" cy="154" r="5" fill="none" stroke="#283848" stroke-width="1" opacity="0.5"/>
+  <circle cx="46" cy="154" r="2" fill="#283848" opacity="0.4"/>
+  <!-- Sign bracket -->
+  <line x1="46" y1="95" x2="46" y2="88" stroke="#182030" stroke-width="2.5"/>
+  <line x1="38" y1="88" x2="54" y2="88" stroke="#182030" stroke-width="1.5"/>
+
+  <!-- Mirror sign on right cliff -->
+  <rect x="328" y="98" width="52" height="65" rx="2" fill="#080e18" stroke="#182030" stroke-width="2"/>
+  <g stroke="#182838" stroke-width="1" fill="none" opacity="0.6">
+    <line x1="334" y1="108" x2="374" y2="108"/>
+    <line x1="334" y1="115" x2="374" y2="115"/>
+    <line x1="334" y1="122" x2="365" y2="122"/>
+    <line x1="334" y1="129" x2="374" y2="129"/>
+    <line x1="334" y1="136" x2="368" y2="136"/>
+    <line x1="334" y1="143" x2="374" y2="143"/>
+  </g>
+  <circle cx="354" cy="157" r="5" fill="none" stroke="#283848" stroke-width="1" opacity="0.5"/>
+  <circle cx="354" cy="157" r="2" fill="#283848" opacity="0.4"/>
+  <line x1="354" y1="98" x2="354" y2="91" stroke="#182030" stroke-width="2.5"/>
+  <line x1="346" y1="91" x2="362" y2="91" stroke="#182030" stroke-width="1.5"/>
+
+  <!-- JARV — centre of the passage, small boat silhouette approaching from left -->
+  <!-- Small boat hull -->
+  <polygon points="148,185 230,185 235,195 143,195" fill="#08101a" stroke="#101828" stroke-width="1"/>
+  <!-- Mast -->
+  <line x1="185" y1="185" x2="185" y2="152" stroke="#0c1420" stroke-width="2"/>
+  <!-- Sail — small, furled -->
+  <polygon points="185,155 210,165 185,175" fill="#0e1828" stroke="#182030" stroke-width="0.8" opacity="0.7"/>
+  <!-- Jarv at bow, Iron Standard as mast-head -->
+  <line x1="185" y1="152" x2="185" y2="138" stroke="#2a3040" stroke-width="1.5"/>
+  <polygon points="183,138 187,138 185,129" fill="#404860" opacity="0.7"/>
+
+  <!-- Looming storm above the passage -->
+  <g fill="#0a1018" opacity="0.7">
+    <ellipse cx="200" cy="60" rx="100" ry="35"/>
+    <ellipse cx="140" cy="45" rx="60" ry="22"/>
+    <ellipse cx="270" cy="48" rx="55" ry="20"/>
+  </g>
+  <!-- Lightning potential — tension -->
+  <g stroke="#304050" stroke-width="0.8" fill="none" opacity="0.2">
+    <path d="M190,90 L187,100 L193,100 L190,110"/>
+  </g>
+
+  <!-- Label -->
+  <text x="200" y="232" font-family="monospace" font-size="9" fill="#182030" text-anchor="middle" letter-spacing="3">NO PERMIT</text>
+</svg>

--- a/web/public/cutscenes/act12-outro-1.svg
+++ b/web/public/cutscenes/act12-outro-1.svg
@@ -1,0 +1,84 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#040810"/>
+  <linearGradient id="break-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#060a14"/>
+    <stop offset="100%" stop-color="#0c1624"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#break-sky)"/>
+
+  <!-- Sea at dusk — battle aftermath, water turbulent -->
+  <rect x="0" y="160" width="400" height="80" fill="#050c14"/>
+  <g stroke="#0c1a28" stroke-width="1" fill="none" opacity="0.6">
+    <path d="M0,172 Q50,168 100,172 Q150,176 200,172 Q250,168 300,172 Q350,176 400,172"/>
+    <path d="M0,185 Q60,181 120,185 Q180,189 240,185 Q300,181 360,185 Q380,187 400,185"/>
+    <path d="M0,200 Q80,196 160,200 Q240,204 320,200 Q370,198 400,200"/>
+  </g>
+
+  <!-- THE FLAGSHIP LISTING — taking on water, hull breached, deck tilting -->
+  <!-- Hull — tilted rightward -->
+  <g transform="translate(200,178) rotate(12) translate(-200,-178)">
+    <polygon points="100,165 300,160 315,185 295,200 105,205 85,185" fill="#070c14" stroke="#0f1a28" stroke-width="1.5"/>
+    <polygon points="100,165 300,160 298,168 100,172" fill="#0a1220" stroke="#152030" stroke-width="1"/>
+    <!-- Deck details -->
+    <line x1="200" y1="162" x2="200" y2="140" stroke="#0e1828" stroke-width="2.5"/>
+    <polygon points="200,140 220,152 200,160" fill="#0c1628" opacity="0.6"/>
+    <!-- Hull breach — water entering -->
+    <g stroke="#0e2030" stroke-width="1" fill="none" opacity="0.5">
+      <path d="M240,190 Q250,195 255,190 Q248,200 240,202"/>
+      <path d="M265,188 Q272,195 275,188"/>
+    </g>
+  </g>
+
+  <!-- Water rushing in around the breached hull -->
+  <g fill="#060e1a" opacity="0.5">
+    <ellipse cx="270" cy="195" rx="30" ry="8"/>
+  </g>
+  <g stroke="#0e2030" stroke-width="1.5" fill="none" opacity="0.4">
+    <path d="M240,195 Q255,190 270,195 Q285,200 300,195"/>
+  </g>
+
+  <!-- Debris floating — wreckage in water -->
+  <g fill="#070c14" stroke="#0e182a" stroke-width="0.8" opacity="0.7">
+    <rect x="50"  y="180" width="25" height="8" rx="1" transform="rotate(-5 62 184)"/>
+    <rect x="340" y="182" width="20" height="6" rx="1" transform="rotate(8 350 185)"/>
+    <rect x="115" y="190" width="18" height="5" rx="1" transform="rotate(-3 124 192)"/>
+    <rect x="360" y="192" width="15" height="5" rx="1" transform="rotate(4 367 194)"/>
+  </g>
+
+  <!-- THE HARBORMASTER — standing on stern as it lists, refusing to flee -->
+  <!-- Small figure on tilted deck, right side -->
+  <ellipse cx="275" cy="172" rx="14" ry="4" fill="#030608" opacity="0.7" transform="rotate(12 275 172)"/>
+  <line x1="272" y1="162" x2="271" y2="172" stroke="#0c1020" stroke-width="3" stroke-linecap="round" transform="rotate(12 272 167)"/>
+  <line x1="278" y1="161" x2="280" y2="171" stroke="#0c1020" stroke-width="3" stroke-linecap="round" transform="rotate(12 279 166)"/>
+  <polygon points="267,152 285,152 288,162 264,162" fill="#101828" stroke="#182030" stroke-width="0.8" transform="rotate(12 276 157)"/>
+  <ellipse cx="276" cy="146" rx="8" ry="7" fill="#0e1828" stroke="#182030" stroke-width="0.8" transform="rotate(12 276 146)"/>
+  <!-- Peaked cap stays on -->
+  <rect x="269" y="140" width="18" height="6" rx="1" fill="#0a1018" stroke="#162028" stroke-width="0.8" transform="rotate(12 278 143)"/>
+
+  <!-- JARV'S BOAT — centre, approaching — intact, iron standard flying -->
+  <polygon points="155,182 245,182 250,194 150,194" fill="#081018" stroke="#101828" stroke-width="1"/>
+  <line x1="195" y1="182" x2="195" y2="148" stroke="#0c1420" stroke-width="2"/>
+  <polygon points="195,150 218,162 195,172" fill="#0e1828" stroke="#182030" stroke-width="0.8" opacity="0.7"/>
+  <line x1="195" y1="148" x2="195" y2="135" stroke="#2a3040" stroke-width="1.5"/>
+  <polygon points="193,135 197,135 195,126" fill="#404860" opacity="0.7"/>
+  <!-- Small Coral Mantle visible at bow -->
+  <g fill="#006040" opacity="0.4">
+    <circle cx="240" cy="183" r="2"/>
+    <circle cx="244" cy="182" r="1.5"/>
+  </g>
+
+  <!-- Storm clouds breaking slightly — the iron tide has broken -->
+  <g fill="#0a1018" opacity="0.6">
+    <ellipse cx="80"  cy="65" rx="65" ry="22"/>
+    <ellipse cx="320" cy="60" rx="60" ry="20"/>
+  </g>
+  <!-- Small break in clouds centre — the passage is open now -->
+  <radialGradient id="break-light" cx="50%" cy="30%" r="25%">
+    <stop offset="0%" stop-color="#182030" stop-opacity="0.2"/>
+    <stop offset="100%" stop-color="#182030" stop-opacity="0"/>
+  </radialGradient>
+  <rect x="140" y="0" width="120" height="100" fill="url(#break-light)"/>
+
+  <!-- Label -->
+  <text x="200" y="232" font-family="monospace" font-size="9" fill="#182030" text-anchor="middle" letter-spacing="3">THE IRON TIDE BREAKS</text>
+</svg>

--- a/web/public/cutscenes/act12-outro-2.svg
+++ b/web/public/cutscenes/act12-outro-2.svg
@@ -1,0 +1,91 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#040810"/>
+  <linearGradient id="hook-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#060a14"/>
+    <stop offset="50%" stop-color="#0a1420"/>
+    <stop offset="100%" stop-color="#0e1c2c"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#hook-sky)"/>
+
+  <!-- Pale dawn breaking over the water — the tide has pulled back -->
+  <radialGradient id="dawn-coast" cx="50%" cy="70%" r="55%">
+    <stop offset="0%" stop-color="#182840" stop-opacity="0.4"/>
+    <stop offset="100%" stop-color="#182840" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#dawn-coast)"/>
+
+  <!-- Beach / sand flat — the tide has pulled back, revealing the relic -->
+  <polygon points="0,190 400,182 400,240 0,240" fill="#07090e"/>
+  <line x1="0" y1="190" x2="400" y2="182" stroke="#0e1828" stroke-width="1.5"/>
+  <!-- Sand texture — wet, with tide-line -->
+  <g stroke="#0a1018" stroke-width="0.6" fill="none" opacity="0.4">
+    <path d="M0,195 Q80,191 160,195 Q240,199 320,195 Q370,192 400,195"/>
+    <path d="M0,205 Q100,201 200,205 Q300,209 400,205"/>
+    <path d="M0,218 Q120,214 240,218 Q340,222 400,218"/>
+  </g>
+  <!-- Sea edge — water receding left -->
+  <g stroke="#0e2030" stroke-width="1" fill="none" opacity="0.5">
+    <path d="M0,188 Q40,184 80,188"/>
+  </g>
+  <rect x="0" y="182" width="85" height="58" fill="#060c14" opacity="0.5"/>
+
+  <!-- THE SALVAGE HOOK — half-buried in sand, massive, iron -->
+  <!-- Hook body — curved, nautical -->
+  <!-- Main hook arc -->
+  <path d="M185,155 Q168,155 162,168 Q156,182 165,192 Q175,202 190,200 Q205,198 210,188" stroke="#1e2838" stroke-width="8" fill="none" stroke-linecap="round"/>
+  <!-- Hook tip -->
+  <path d="M210,188 Q222,178 218,168 Q214,158 205,155" stroke="#1e2838" stroke-width="6" fill="none" stroke-linecap="round"/>
+  <!-- Hook point -->
+  <polygon points="202,152 208,152 205,144" fill="#182030" stroke="#2a3848" stroke-width="0.8"/>
+  <!-- Shank — extending up out of sand -->
+  <line x1="185" y1="155" x2="190" y2="120" stroke="#182030" stroke-width="7" stroke-linecap="round"/>
+  <!-- Ring at top of shank -->
+  <circle cx="190" cy="118" r="9" fill="none" stroke="#1e2838" stroke-width="4"/>
+  <!-- Iron surface — corroded, old -->
+  <path d="M185,155 Q168,155 162,168 Q156,182 165,192 Q175,202 190,200 Q205,198 210,188" stroke="#283848" stroke-width="4" fill="none" stroke-linecap="round" opacity="0.4"/>
+  <!-- Rust/barnacle detail -->
+  <g fill="#1e2838" opacity="0.5">
+    <circle cx="170" cy="175" r="3"/>
+    <circle cx="182" cy="195" r="2.5"/>
+    <circle cx="200" cy="192" r="2"/>
+    <circle cx="190" cy="135" r="2"/>
+  </g>
+  <!-- Glow — the hook has ley-energy imbued, symbol of passage -->
+  <radialGradient id="hook-glow" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#1840a0" stop-opacity="0.25"/>
+    <stop offset="100%" stop-color="#1840a0" stop-opacity="0"/>
+  </radialGradient>
+  <ellipse cx="190" cy="165" rx="45" ry="40" fill="url(#hook-glow)"/>
+  <!-- Half-buried in sand — lower portion disappearing into ground -->
+  <rect x="155" y="190" width="70" height="20" fill="#07090e" opacity="0.7"/>
+
+  <!-- Jarv kneeling beside the hook, reaching for it -->
+  <ellipse cx="255" cy="205" rx="20" ry="4" fill="#020401" opacity="0.6"/>
+  <line x1="251" y1="198" x2="250" y2="205" stroke="#0c0c18" stroke-width="3.5" stroke-linecap="round"/>
+  <line x1="258" y1="198" x2="260" y2="205" stroke="#0c0c18" stroke-width="3.5" stroke-linecap="round"/>
+  <polygon points="244,183 268,183 271,198 241,198" fill="#0a1e20" stroke="#1a4040" stroke-width="1.5"/>
+  <g fill="#00c090" opacity="0.4">
+    <circle cx="241" cy="183" r="1.5"/>
+    <circle cx="271" cy="183" r="1.5"/>
+  </g>
+  <ellipse cx="254" cy="174" rx="9" ry="8" fill="#0c0c1a" stroke="#181830" stroke-width="1"/>
+  <!-- Arm reaching toward hook -->
+  <line x1="244" y1="190" x2="228" y2="178" stroke="#0c0c18" stroke-width="3.5" stroke-linecap="round"/>
+  <polygon points="222,174 232,173 234,184 224,185" fill="#0d0e1a" stroke="#181830" stroke-width="0.8"/>
+
+  <!-- Distant sea and clearing sky -->
+  <rect x="0" y="150" width="160" height="40" fill="#060c14" opacity="0.7"/>
+  <g stroke="#0e1c2c" stroke-width="0.8" fill="none" opacity="0.4">
+    <path d="M0,160 Q40,156 80,160"/>
+    <path d="M0,172 Q50,168 100,172"/>
+  </g>
+
+  <!-- Storm clouds thinning -->
+  <g fill="#0a1018" opacity="0.45">
+    <ellipse cx="70"  cy="68" rx="60" ry="20"/>
+    <ellipse cx="330" cy="62" rx="55" ry="18"/>
+  </g>
+
+  <!-- Label -->
+  <text x="200" y="232" font-family="monospace" font-size="9" fill="#182030" text-anchor="middle" letter-spacing="3">SALVAGE HOOK</text>
+</svg>

--- a/web/public/cutscenes/act12-outro-3.svg
+++ b/web/public/cutscenes/act12-outro-3.svg
@@ -1,0 +1,98 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#040810"/>
+  <linearGradient id="horizon-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#060a14"/>
+    <stop offset="40%" stop-color="#0a1420"/>
+    <stop offset="100%" stop-color="#0e1c2e"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#horizon-sky)"/>
+
+  <!-- Dawn breaking on the horizon — open sea ahead -->
+  <radialGradient id="dawn-horizon" cx="85%" cy="55%" r="40%">
+    <stop offset="0%" stop-color="#1a3048" stop-opacity="0.5"/>
+    <stop offset="60%" stop-color="#102030" stop-opacity="0.2"/>
+    <stop offset="100%" stop-color="#102030" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#dawn-horizon)"/>
+
+  <!-- Open sea — vast, grey-blue, the horizon ahead -->
+  <rect x="0" y="145" width="400" height="95" fill="#060c14"/>
+  <line x1="0" y1="145" x2="400" y2="145" stroke="#0e2030" stroke-width="1.5"/>
+  <g stroke="#0e1c2c" stroke-width="0.8" fill="none" opacity="0.5">
+    <path d="M0,158 Q60,154 120,158 Q180,162 240,158 Q300,154 360,158 Q380,160 400,158"/>
+    <path d="M0,172 Q80,168 160,172 Q240,176 320,172 Q370,170 400,172"/>
+    <path d="M0,188 Q100,184 200,188 Q300,192 400,188"/>
+    <path d="M0,206 Q120,202 240,206 Q340,210 400,206"/>
+  </g>
+  <!-- Far horizon shimmer -->
+  <linearGradient id="sea-horizon" x1="0" y1="0" x2="1" y2="0">
+    <stop offset="0%" stop-color="#0e2030" stop-opacity="0"/>
+    <stop offset="70%" stop-color="#1a3048" stop-opacity="0.3"/>
+    <stop offset="100%" stop-color="#2a4060" stop-opacity="0.5"/>
+  </linearGradient>
+  <rect x="0" y="138" width="400" height="15" fill="url(#sea-horizon)"/>
+
+  <!-- NEXT SHARD silhouette on horizon — distant, mysterious -->
+  <g fill="#060a10" opacity="0.6">
+    <polygon points="300,145 318,118 336,145"/>
+    <polygon points="328,145 348,105 368,145"/>
+    <polygon points="355,145 368,122 380,145"/>
+  </g>
+  <!-- Faint glow behind next shard -->
+  <radialGradient id="shard-glow" cx="88%" cy="60%" r="20%">
+    <stop offset="0%" stop-color="#2040a0" stop-opacity="0.2"/>
+    <stop offset="100%" stop-color="#2040a0" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#shard-glow)"/>
+
+  <!-- Shattered coast fragments receding left and behind -->
+  <!-- Left fragment, receding -->
+  <polygon points="0,145 55,138 60,158 50,165 0,162" fill="#07091a" opacity="0.7"/>
+  <g fill="#060a14" opacity="0.6">
+    <rect x="10"  y="120" width="10" height="20"/>
+    <rect x="28"  y="115" width="8"  height="25"/>
+    <rect x="42"  y="122" width="10" height="18"/>
+  </g>
+
+  <!-- JARV'S BOAT — centre, sailing forward, Iron Standard at mast -->
+  <!-- Hull -->
+  <polygon points="148,178 262,178 268,192 142,192" fill="#081018" stroke="#101828" stroke-width="1.2"/>
+  <!-- Mast -->
+  <line x1="200" y1="178" x2="200" y2="138" stroke="#0c1420" stroke-width="2.5"/>
+  <!-- Sail — billowing, moving forward -->
+  <polygon points="200,142 240,158 200,172" fill="#0e1828" stroke="#182030" stroke-width="1" opacity="0.8"/>
+  <!-- Iron Standard at masthead -->
+  <line x1="200" y1="138" x2="200" y2="122" stroke="#2a3040" stroke-width="2"/>
+  <polygon points="198,122 202,122 200,113" fill="#404860" opacity="0.8"/>
+  <!-- Flag banner on standard -->
+  <polygon points="200,125 222,132 200,138" fill="#1e2438" stroke="#303548" stroke-width="0.8" opacity="0.7"/>
+  <!-- Coral Mantle visible on Jarv at the bow -->
+  <ellipse cx="256" cy="179" rx="8" ry="3" fill="#0a1e20" opacity="0.6"/>
+  <g fill="#00c090" opacity="0.4">
+    <circle cx="250" cy="179" r="1.5"/>
+    <circle cx="262" cy="179" r="1.5"/>
+  </g>
+  <!-- Jarv figure at helm -->
+  <ellipse cx="256" cy="175" rx="5" ry="4" fill="#0c0c1a" stroke="#181830" stroke-width="0.8"/>
+
+  <!-- Wake behind boat -->
+  <g stroke="#0e2030" stroke-width="1" fill="none" opacity="0.4">
+    <path d="M148,185 Q120,190 90,188 Q60,186 30,190"/>
+    <path d="M148,188 Q110,194 70,192 Q40,190 10,194"/>
+  </g>
+
+  <!-- Clearing sky — patches of open dark between clouds -->
+  <g fill="#0a1018" opacity="0.5">
+    <ellipse cx="80"  cy="70" rx="70" ry="22"/>
+    <ellipse cx="240" cy="62" rx="55" ry="18"/>
+  </g>
+  <!-- Stars visible in clearing -->
+  <g fill="#8090b0" opacity="0.3">
+    <circle cx="160" cy="30" r="1.2"/>
+    <circle cx="220" cy="20" r="1"/>
+    <circle cx="270" cy="35" r="1"/>
+  </g>
+
+  <!-- Label -->
+  <text x="200" y="232" font-family="monospace" font-size="9" fill="#182030" text-anchor="middle" letter-spacing="3">THE HORIZON</text>
+</svg>

--- a/web/public/cutscenes/act13-intro-1.svg
+++ b/web/public/cutscenes/act13-intro-1.svg
@@ -1,0 +1,136 @@
+<svg xmlns="http://www.w3.org/2020/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#070502"/>
+
+  <linearGradient id="vault-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#080602"/>
+    <stop offset="50%" stop-color="#100a04"/>
+    <stop offset="100%" stop-color="#180e06"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#vault-sky)"/>
+
+  <!-- Warm brass glow from the machinery below -->
+  <radialGradient id="vault-glow" cx="50%" cy="70%" r="55%">
+    <stop offset="0%" stop-color="#583010" stop-opacity="0.4"/>
+    <stop offset="100%" stop-color="#583010" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#vault-glow)"/>
+
+  <!-- STONE CEILING of the vault — carved, ancient -->
+  <polygon points="0,0 400,0 400,50 370,38 335,52 300,36 265,52 230,34 200,50 170,34 135,50 100,36 65,52 30,38 0,50" fill="#0a0806"/>
+  <g fill="#0e0c08" opacity="0.5">
+    <polygon points="0,50 30,38 25,55"/>
+    <polygon points="65,52 100,36 90,55"/>
+    <polygon points="135,50 170,34 160,55"/>
+    <polygon points="230,34 265,52 255,55"/>
+    <polygon points="300,36 335,52 330,56"/>
+    <polygon points="370,38 400,50 400,55"/>
+  </g>
+
+  <!-- VAULT WALLS — massive stone, with gear-channel cut-outs -->
+  <g fill="#0a0806" stroke="#141008" stroke-width="1">
+    <rect x="0"   y="50" width="65"  height="190"/>
+    <rect x="335" y="50" width="65"  height="190"/>
+  </g>
+  <!-- Gear cutouts in walls — mechanical channels -->
+  <g fill="#060402" stroke="#0e0a06" stroke-width="0.8">
+    <circle cx="32"  cy="95"  r="18"/>
+    <circle cx="32"  cy="145" r="18"/>
+    <circle cx="32"  cy="195" r="18"/>
+    <circle cx="368" cy="95"  r="18"/>
+    <circle cx="368" cy="145" r="18"/>
+    <circle cx="368" cy="195" r="18"/>
+  </g>
+  <!-- Gear teeth -->
+  <g fill="#0e0a04" opacity="0.7">
+    <circle cx="32"  cy="75"  r="3"/>
+    <circle cx="50"  cy="79"  r="3"/>
+    <circle cx="14"  cy="79"  r="3"/>
+    <circle cx="32"  cy="115" r="3"/>
+    <circle cx="50"  cy="111" r="3"/>
+    <circle cx="14"  cy="111" r="3"/>
+    <circle cx="368" cy="75"  r="3"/>
+    <circle cx="386" cy="79"  r="3"/>
+    <circle cx="350" cy="79"  r="3"/>
+    <circle cx="368" cy="115" r="3"/>
+    <circle cx="386" cy="111" r="3"/>
+    <circle cx="350" cy="111" r="3"/>
+  </g>
+  <!-- Gear hub glows — brass, active -->
+  <g fill="#804010" opacity="0.4">
+    <circle cx="32"  cy="95"  r="6"/>
+    <circle cx="32"  cy="145" r="6"/>
+    <circle cx="368" cy="95"  r="6"/>
+    <circle cx="368" cy="145" r="6"/>
+  </g>
+
+  <!-- GREAT GEAR COLUMNS — massive gear-trains running floor to ceiling -->
+  <!-- Left gear column -->
+  <g fill="#0c0a04" stroke="#181008" stroke-width="1.5">
+    <circle cx="110" cy="90"  r="35"/>
+    <circle cx="110" cy="175" r="40"/>
+  </g>
+  <g fill="#181008" opacity="0.5">
+    <circle cx="110" cy="90"  r="22"/>
+    <circle cx="110" cy="175" r="26"/>
+  </g>
+  <!-- Gear teeth outer rings -->
+  <g fill="#160e04" stroke="#201408" stroke-width="0.8" opacity="0.7">
+    <circle cx="110" cy="55"  r="4"/>
+    <circle cx="130" cy="60"  r="4"/>
+    <circle cx="143" cy="72"  r="4"/>
+    <circle cx="145" cy="90"  r="4"/>
+    <circle cx="143" cy="108" r="4"/>
+    <circle cx="130" cy="120" r="4"/>
+    <circle cx="110" cy="125" r="4"/>
+    <circle cx="90"  cy="120" r="4"/>
+    <circle cx="77"  cy="108" r="4"/>
+    <circle cx="75"  cy="90"  r="4"/>
+    <circle cx="77"  cy="72"  r="4"/>
+    <circle cx="90"  cy="60"  r="4"/>
+  </g>
+  <!-- Hub -->
+  <circle cx="110" cy="90" r="8" fill="#804010" opacity="0.4"/>
+  <circle cx="110" cy="175" r="9" fill="#804010" opacity="0.4"/>
+
+  <!-- Right gear column -->
+  <g fill="#0c0a04" stroke="#181008" stroke-width="1.5">
+    <circle cx="290" cy="88"  r="35"/>
+    <circle cx="290" cy="175" r="40"/>
+  </g>
+  <g fill="#181008" opacity="0.5">
+    <circle cx="290" cy="88"  r="22"/>
+    <circle cx="290" cy="175" r="26"/>
+  </g>
+  <!-- Hub -->
+  <circle cx="290" cy="88"  r="8" fill="#804010" opacity="0.4"/>
+  <circle cx="290" cy="175" r="9" fill="#804010" opacity="0.4"/>
+
+  <!-- Centre — connecting shaft with ley energy coiled around it -->
+  <line x1="200" y1="50" x2="200" y2="240" stroke="#241408" stroke-width="6"/>
+  <!-- Ley energy coil — spiralling around the shaft -->
+  <g stroke="#e08020" stroke-width="1" fill="none" opacity="0.4">
+    <path d="M196,55 Q190,65 196,75 Q202,85 196,95 Q190,105 196,115 Q202,125 196,135 Q190,145 196,155 Q202,165 196,175 Q190,185 196,195 Q202,205 196,215"/>
+    <path d="M204,60 Q210,70 204,80 Q198,90 204,100 Q210,110 204,120 Q198,130 204,140 Q210,150 204,160 Q198,170 204,180 Q210,190 204,200"/>
+  </g>
+  <!-- Shaft hub glow -->
+  <circle cx="200" cy="145" r="12" fill="#804010" opacity="0.3"/>
+  <circle cx="200" cy="145" r="6"  fill="#c06018" opacity="0.3"/>
+
+  <!-- Floor — iron grating with glow beneath -->
+  <rect x="65" y="220" width="270" height="20" fill="#0c0a04" opacity="0.8"/>
+  <g stroke="#1a1006" stroke-width="1" fill="none" opacity="0.4">
+    <line x1="65"  y1="220" x2="335" y2="220"/>
+    <line x1="65"  y1="228" x2="335" y2="228"/>
+    <line x1="100" y1="220" x2="100" y2="240"/>
+    <line x1="140" y1="220" x2="140" y2="240"/>
+    <line x1="180" y1="220" x2="180" y2="240"/>
+    <line x1="220" y1="220" x2="220" y2="240"/>
+    <line x1="260" y1="220" x2="260" y2="240"/>
+    <line x1="300" y1="220" x2="300" y2="240"/>
+  </g>
+  <!-- Glow through grating -->
+  <rect x="65" y="224" width="270" height="6" fill="#804010" opacity="0.2"/>
+
+  <!-- Label -->
+  <text x="200" y="232" font-family="monospace" font-size="9" fill="#3a1a08" text-anchor="middle" letter-spacing="3">THE CLOCKWORK VAULTS</text>
+</svg>

--- a/web/public/cutscenes/act13-intro-1.svg
+++ b/web/public/cutscenes/act13-intro-1.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2020/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
   <rect width="400" height="240" fill="#070502"/>
 
   <linearGradient id="vault-sky" x1="0" y1="0" x2="0" y2="1">

--- a/web/public/cutscenes/act13-intro-2.svg
+++ b/web/public/cutscenes/act13-intro-2.svg
@@ -1,0 +1,141 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#070502"/>
+  <linearGradient id="auto-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#080602"/>
+    <stop offset="100%" stop-color="#160c04"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#auto-sky)"/>
+
+  <!-- Brass machinery atmosphere -->
+  <radialGradient id="auto-glow" cx="50%" cy="45%" r="50%">
+    <stop offset="0%" stop-color="#503010" stop-opacity="0.35"/>
+    <stop offset="100%" stop-color="#503010" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#auto-glow)"/>
+
+  <!-- Vault floor — iron grating -->
+  <rect x="0" y="200" width="400" height="40" fill="#0a0804"/>
+  <g stroke="#161008" stroke-width="0.8" fill="none" opacity="0.4">
+    <line x1="0"   y1="200" x2="400" y2="200"/>
+    <line x1="0"   y1="210" x2="400" y2="210"/>
+    <line x1="0"   y1="220" x2="400" y2="220"/>
+    <line x1="50"  y1="200" x2="50"  y2="240"/>
+    <line x1="100" y1="200" x2="100" y2="240"/>
+    <line x1="150" y1="200" x2="150" y2="240"/>
+    <line x1="200" y1="200" x2="200" y2="240"/>
+    <line x1="250" y1="200" x2="250" y2="240"/>
+    <line x1="300" y1="200" x2="300" y2="240"/>
+    <line x1="350" y1="200" x2="350" y2="240"/>
+  </g>
+  <rect x="0" y="204" width="400" height="4" fill="#804010" opacity="0.15"/>
+
+  <!-- Shadow -->
+  <ellipse cx="200" cy="210" rx="65" ry="12" fill="#030201" opacity="0.9"/>
+
+  <!-- THE GRAND AUTOMATON — massive, multi-armed, calculating machine entity -->
+  <!-- Base plinth — wide, heavy -->
+  <rect x="140" y="185" width="120" height="20" rx="3" fill="#0e0c04" stroke="#201408" stroke-width="2"/>
+  <!-- Plinth rivets -->
+  <g fill="#201408" opacity="0.7">
+    <circle cx="152" cy="195" r="2.5"/>
+    <circle cx="248" cy="195" r="2.5"/>
+    <circle cx="165" cy="195" r="2"/>
+    <circle cx="235" cy="195" r="2"/>
+    <circle cx="200" cy="195" r="2.5"/>
+  </g>
+
+  <!-- Lower body — barrel-like torso -->
+  <rect x="158" y="130" width="84" height="57" rx="4" fill="#0c0a04" stroke="#1e1408" stroke-width="2"/>
+  <!-- Torso panel divisions -->
+  <line x1="158" y1="152" x2="242" y2="152" stroke="#181208" stroke-width="1"/>
+  <line x1="158" y1="168" x2="242" y2="168" stroke="#181208" stroke-width="1"/>
+  <!-- Pressure gauges on torso -->
+  <g fill="#080602" stroke="#1a1006" stroke-width="0.8">
+    <circle cx="175" cy="142" r="7"/>
+    <circle cx="200" cy="142" r="7"/>
+    <circle cx="225" cy="142" r="7"/>
+  </g>
+  <!-- Gauge needles — all reading different values, calculating -->
+  <line x1="175" y1="142" x2="178" y2="136" stroke="#c06818" stroke-width="1" opacity="0.6"/>
+  <line x1="200" y1="142" x2="204" y2="138" stroke="#c06818" stroke-width="1" opacity="0.6"/>
+  <line x1="225" y1="142" x2="221" y2="137" stroke="#c06818" stroke-width="1" opacity="0.6"/>
+  <!-- Mechanical pipes connecting sections -->
+  <g stroke="#1a1006" stroke-width="2.5" fill="none">
+    <path d="M158,165 Q148,165 145,175 Q142,185 150,188"/>
+    <path d="M242,165 Q252,165 255,175 Q258,185 250,188"/>
+  </g>
+
+  <!-- Upper body — processor core, multi-faceted -->
+  <polygon points="165,100 235,100 245,130 155,130" fill="#0e0c04" stroke="#201408" stroke-width="1.5"/>
+  <!-- Processing vanes -->
+  <g fill="#0a0802" stroke="#181006" stroke-width="0.8" opacity="0.8">
+    <rect x="172" y="106" width="14" height="10" rx="1"/>
+    <rect x="192" y="104" width="16" height="12" rx="1"/>
+    <rect x="214" y="106" width="14" height="10" rx="1"/>
+  </g>
+  <!-- Calculation lights — amber, active -->
+  <g fill="#c06010" opacity="0.5">
+    <rect x="172" y="106" width="14" height="10" rx="1"/>
+    <rect x="214" y="106" width="14" height="10" rx="1"/>
+  </g>
+  <g fill="#e08020" opacity="0.3">
+    <rect x="192" y="104" width="16" height="12" rx="1"/>
+  </g>
+
+  <!-- HEAD — central sensor dome -->
+  <ellipse cx="200" cy="92" rx="28" ry="24" fill="#0c0a04" stroke="#1e1408" stroke-width="2"/>
+  <!-- Sensor ring around dome -->
+  <circle cx="200" cy="92" r="28" fill="none" stroke="#281a08" stroke-width="0.8"/>
+  <!-- Primary sensor — single large optic, cold and calculating -->
+  <circle cx="200" cy="92" r="14" fill="#080602" stroke="#301808" stroke-width="1.5"/>
+  <circle cx="200" cy="92" r="9"  fill="#120c02" stroke="#401e08" stroke-width="1"/>
+  <circle cx="200" cy="92" r="5"  fill="#c06010" opacity="0.6"/>
+  <circle cx="200" cy="92" r="2"  fill="#f08820" opacity="0.8"/>
+  <!-- Secondary sensors — smaller ring -->
+  <g fill="#c06010" opacity="0.35">
+    <circle cx="182" cy="82" r="3"/>
+    <circle cx="218" cy="82" r="3"/>
+    <circle cx="176" cy="96" r="3"/>
+    <circle cx="224" cy="96" r="3"/>
+    <circle cx="184" cy="108" r="3"/>
+    <circle cx="216" cy="108" r="3"/>
+  </g>
+
+  <!-- FOUR ARMS — the Automaton reaches in multiple directions simultaneously -->
+  <!-- Upper left arm -->
+  <line x1="163" y1="115" x2="128" y2="95" stroke="#0e0c04" stroke-width="7" stroke-linecap="round"/>
+  <line x1="128" y1="95" x2="100" y2="78" stroke="#0e0c04" stroke-width="5" stroke-linecap="round"/>
+  <rect x="88" y="70" width="22" height="16" rx="2" fill="#0c0a04" stroke="#1e1408" stroke-width="1"/>
+  <!-- Lower left arm -->
+  <line x1="160" y1="150" x2="122" y2="155" stroke="#0e0c04" stroke-width="6" stroke-linecap="round"/>
+  <line x1="122" y1="155" x2="92"  y2="165" stroke="#0e0c04" stroke-width="4" stroke-linecap="round"/>
+  <rect x="80" y="158" width="20" height="14" rx="2" fill="#0c0a04" stroke="#1e1408" stroke-width="1"/>
+  <!-- Upper right arm -->
+  <line x1="237" y1="115" x2="272" y2="95" stroke="#0e0c04" stroke-width="7" stroke-linecap="round"/>
+  <line x1="272" y1="95" x2="300" y2="78" stroke="#0e0c04" stroke-width="5" stroke-linecap="round"/>
+  <rect x="290" y="70" width="22" height="16" rx="2" fill="#0c0a04" stroke="#1e1408" stroke-width="1"/>
+  <!-- Lower right arm -->
+  <line x1="240" y1="150" x2="278" y2="155" stroke="#0e0c04" stroke-width="6" stroke-linecap="round"/>
+  <line x1="278" y1="155" x2="308" y2="165" stroke="#0e0c04" stroke-width="4" stroke-linecap="round"/>
+  <rect x="300" y="158" width="20" height="14" rx="2" fill="#0c0a04" stroke="#1e1408" stroke-width="1"/>
+
+  <!-- Gear elements on arms — it is literally made of clock parts -->
+  <g fill="#1a1006" stroke="#281408" stroke-width="0.8" opacity="0.6">
+    <circle cx="115" cy="86"  r="5"/>
+    <circle cx="110" cy="160" r="5"/>
+    <circle cx="285" cy="86"  r="5"/>
+    <circle cx="290" cy="160" r="5"/>
+  </g>
+
+  <!-- Stars of spark — active processing venting heat -->
+  <g fill="#c06010" opacity="0.4">
+    <circle cx="168" cy="85" r="1.2"/>
+    <circle cx="232" cy="83" r="1.2"/>
+    <circle cx="200" cy="68" r="1"/>
+    <circle cx="175" cy="72" r="0.8"/>
+    <circle cx="225" cy="74" r="0.8"/>
+  </g>
+
+  <!-- Label -->
+  <text x="200" y="232" font-family="monospace" font-size="9" fill="#3a1a08" text-anchor="middle" letter-spacing="3">THE GRAND AUTOMATON</text>
+</svg>

--- a/web/public/cutscenes/act13-intro-3.svg
+++ b/web/public/cutscenes/act13-intro-3.svg
@@ -1,0 +1,123 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#070502"/>
+  <linearGradient id="within-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#080602"/>
+    <stop offset="100%" stop-color="#160c04"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#within-sky)"/>
+
+  <!-- Brass and ley glow — mixed warm amber and cool ley blue-green -->
+  <radialGradient id="within-glow" cx="50%" cy="60%" r="50%">
+    <stop offset="0%" stop-color="#604020" stop-opacity="0.4"/>
+    <stop offset="100%" stop-color="#604020" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#within-glow)"/>
+
+  <!-- Vault chamber walls — massive gear-lined -->
+  <g fill="#09070a" stroke="#131008" stroke-width="1">
+    <rect x="0"   y="0"  width="80"  height="240"/>
+    <rect x="320" y="0"  width="80"  height="240"/>
+  </g>
+  <!-- Gear rows on walls -->
+  <g fill="#0d0b05" stroke="#1c1208" stroke-width="0.8" opacity="0.8">
+    <circle cx="40"  cy="50"  r="28"/>
+    <circle cx="40"  cy="130" r="28"/>
+    <circle cx="40"  cy="210" r="28"/>
+    <circle cx="360" cy="50"  r="28"/>
+    <circle cx="360" cy="130" r="28"/>
+    <circle cx="360" cy="210" r="28"/>
+  </g>
+  <g fill="#181006" opacity="0.5">
+    <circle cx="40"  cy="50"  r="16"/>
+    <circle cx="40"  cy="130" r="16"/>
+    <circle cx="360" cy="50"  r="16"/>
+    <circle cx="360" cy="130" r="16"/>
+  </g>
+  <g fill="#804010" opacity="0.3">
+    <circle cx="40"  cy="50"  r="6"/>
+    <circle cx="40"  cy="130" r="6"/>
+    <circle cx="360" cy="50"  r="6"/>
+    <circle cx="360" cy="130" r="6"/>
+  </g>
+
+  <!-- Vault ceiling with hanging mechanism -->
+  <rect x="0" y="0" width="400" height="38" fill="#090704"/>
+  <g stroke="#141008" stroke-width="1" fill="none" opacity="0.4">
+    <line x1="80"  y1="38" x2="80"  y2="0"/>
+    <line x1="160" y1="38" x2="160" y2="0"/>
+    <line x1="240" y1="38" x2="240" y2="0"/>
+    <line x1="320" y1="38" x2="320" y2="0"/>
+  </g>
+  <!-- Hanging chains / mechanisms -->
+  <g stroke="#181008" stroke-width="2" opacity="0.5">
+    <line x1="120" y1="38" x2="120" y2="70"/>
+    <line x1="200" y1="38" x2="200" y2="75"/>
+    <line x1="280" y1="38" x2="280" y2="70"/>
+  </g>
+  <g fill="#1a1006" opacity="0.5">
+    <circle cx="120" cy="72" r="5"/>
+    <circle cx="200" cy="77" r="6"/>
+    <circle cx="280" cy="72" r="5"/>
+  </g>
+
+  <!-- THE AUTOMATON — small distant form at chamber centre, surrounded by ley coil -->
+  <!-- Ley convergence at chamber centre — the ley lines coiled around it -->
+  <radialGradient id="conv-ley" cx="50%" cy="55%" r="35%">
+    <stop offset="0%" stop-color="#c06010" stop-opacity="0.35"/>
+    <stop offset="40%" stop-color="#903808" stop-opacity="0.15"/>
+    <stop offset="100%" stop-color="#903808" stop-opacity="0"/>
+  </radialGradient>
+  <ellipse cx="200" cy="140" rx="80" ry="65" fill="url(#conv-ley)"/>
+  <!-- Ley lines coiling around the Automaton position -->
+  <g stroke="#c06810" stroke-width="1.5" fill="none" opacity="0.4">
+    <path d="M200,75 Q230,95 240,120 Q250,145 235,165 Q220,185 200,192"/>
+    <path d="M200,75 Q170,95 160,120 Q150,145 165,165 Q180,185 200,192"/>
+  </g>
+  <g stroke="#e08820" stroke-width="0.6" fill="none" opacity="0.3">
+    <path d="M200,80 Q225,100 235,125 Q245,150 228,168"/>
+    <path d="M200,80 Q175,100 165,125 Q155,150 172,168"/>
+  </g>
+  <!-- Ley node at centre -->
+  <circle cx="200" cy="135" r="18" fill="#120902" stroke="#c06810" stroke-width="1.5" opacity="0.6"/>
+  <circle cx="200" cy="135" r="10" fill="#1e0e04" opacity="0.8"/>
+  <circle cx="200" cy="135" r="5"  fill="#c06010" opacity="0.4"/>
+
+  <!-- Grand Automaton silhouette at centre — smaller scale, deep in chamber -->
+  <rect x="190" y="118" width="20" height="22" fill="#0a0802" stroke="#181006" stroke-width="0.8"/>
+  <ellipse cx="200" cy="116" rx="10" ry="9" fill="#0a0802" stroke="#181006" stroke-width="0.8"/>
+  <!-- Automaton sensor glow — visible at distance -->
+  <circle cx="200" cy="116" r="4" fill="#c06010" opacity="0.5"/>
+  <!-- Arms reaching into ley coil -->
+  <line x1="190" y1="125" x2="172" y2="118" stroke="#0a0802" stroke-width="3" stroke-linecap="round"/>
+  <line x1="210" y1="125" x2="228" y2="118" stroke="#0a0802" stroke-width="3" stroke-linecap="round"/>
+
+  <!-- Ground level perspective — iron grating -->
+  <rect x="80" y="205" width="240" height="35" fill="#0a0804" opacity="0.8"/>
+  <g stroke="#181006" stroke-width="0.6" fill="none" opacity="0.3">
+    <line x1="80"  y1="205" x2="320" y2="205"/>
+    <line x1="80"  y1="215" x2="320" y2="215"/>
+    <line x1="80"  y1="225" x2="320" y2="225"/>
+    <line x1="120" y1="205" x2="120" y2="240"/>
+    <line x1="160" y1="205" x2="160" y2="240"/>
+    <line x1="200" y1="205" x2="200" y2="240"/>
+    <line x1="240" y1="205" x2="240" y2="240"/>
+    <line x1="280" y1="205" x2="280" y2="240"/>
+  </g>
+
+  <!-- Ley line horizontal channels in floor -->
+  <line x1="80" y1="207" x2="320" y2="207" stroke="#c06010" stroke-width="1.5" opacity="0.3"/>
+  <line x1="80" y1="208" x2="320" y2="208" stroke="#e08820" stroke-width="0.5" opacity="0.2"/>
+
+  <!-- Floating gear bits — dust of ancient machinery -->
+  <g fill="#c06010" opacity="0.25">
+    <circle cx="110" cy="90"  r="1.2"/>
+    <circle cx="145" cy="70"  r="1"/>
+    <circle cx="255" cy="75"  r="1.2"/>
+    <circle cx="290" cy="92"  r="1"/>
+    <circle cx="130" cy="160" r="0.8"/>
+    <circle cx="270" cy="155" r="0.8"/>
+  </g>
+
+  <!-- Label -->
+  <text x="200" y="232" font-family="monospace" font-size="9" fill="#3a1a08" text-anchor="middle" letter-spacing="3">WHAT LIES WITHIN</text>
+</svg>

--- a/web/public/cutscenes/act13-outro-1.svg
+++ b/web/public/cutscenes/act13-outro-1.svg
@@ -1,0 +1,99 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#070502"/>
+  <linearGradient id="offline-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#080602"/>
+    <stop offset="100%" stop-color="#120a04"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#offline-sky)"/>
+
+  <!-- Dim — the drives winding down, warmth fading -->
+  <radialGradient id="offline-dim" cx="50%" cy="45%" r="50%">
+    <stop offset="0%" stop-color="#301808" stop-opacity="0.2"/>
+    <stop offset="100%" stop-color="#301808" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#offline-dim)"/>
+
+  <!-- Vault floor shudder detail — a crack appearing -->
+  <rect x="0" y="200" width="400" height="40" fill="#0a0804"/>
+  <g stroke="#161008" stroke-width="0.8" fill="none" opacity="0.3">
+    <line x1="0"   y1="200" x2="400" y2="200"/>
+    <line x1="0"   y1="212" x2="400" y2="212"/>
+    <line x1="80"  y1="200" x2="80"  y2="240"/>
+    <line x1="160" y1="200" x2="160" y2="240"/>
+    <line x1="240" y1="200" x2="240" y2="240"/>
+    <line x1="320" y1="200" x2="320" y2="240"/>
+  </g>
+  <!-- Vault shudder crack in floor -->
+  <path d="M140,200 Q155,210 160,220 Q168,230 165,240" stroke="#281408" stroke-width="1.5" fill="none" opacity="0.5"/>
+
+  <!-- THE GRAND AUTOMATON — systems offline, arms lowered, drives winding down -->
+  <!-- Base plinth -->
+  <rect x="148" y="182" width="104" height="18" rx="3" fill="#0e0c04" stroke="#1e1408" stroke-width="1.5"/>
+  <!-- Lower body -->
+  <rect x="163" y="128" width="74" height="56" rx="4" fill="#0c0a04" stroke="#181208" stroke-width="1.5"/>
+  <!-- Gauges — needles dropped to zero -->
+  <g fill="#080602" stroke="#141006" stroke-width="0.6">
+    <circle cx="180" cy="140" r="6"/>
+    <circle cx="200" cy="140" r="6"/>
+    <circle cx="220" cy="140" r="6"/>
+  </g>
+  <!-- All needles pointing straight down — zero -->
+  <line x1="180" y1="140" x2="180" y2="146" stroke="#281408" stroke-width="1" opacity="0.5"/>
+  <line x1="200" y1="140" x2="200" y2="146" stroke="#281408" stroke-width="1" opacity="0.5"/>
+  <line x1="220" y1="140" x2="220" y2="146" stroke="#281408" stroke-width="1" opacity="0.5"/>
+  <!-- Upper body -->
+  <polygon points="170,98 230,98 240,128 160,128" fill="#0e0c04" stroke="#1e1408" stroke-width="1.5"/>
+  <!-- Processing vanes — all dark now -->
+  <g fill="#060402" stroke="#0e0a06" stroke-width="0.5">
+    <rect x="175" y="104" width="14" height="10" rx="1"/>
+    <rect x="194" y="102" width="16" height="12" rx="1"/>
+    <rect x="213" y="104" width="14" height="10" rx="1"/>
+  </g>
+  <!-- Head dome -->
+  <ellipse cx="200" cy="88" rx="26" ry="22" fill="#0c0a04" stroke="#1c1408" stroke-width="1.5"/>
+  <!-- Primary sensor — OFF, dark -->
+  <circle cx="200" cy="88" r="13" fill="#070502" stroke="#201008" stroke-width="1"/>
+  <circle cx="200" cy="88" r="8"  fill="#050402" stroke="#181006" stroke-width="0.8"/>
+  <circle cx="200" cy="88" r="3"  fill="#0a0604" opacity="0.8"/>
+  <!-- Secondary sensors — off -->
+  <g fill="#0a0804" opacity="0.4">
+    <circle cx="183" cy="79" r="2.5"/>
+    <circle cx="217" cy="79" r="2.5"/>
+    <circle cx="178" cy="92" r="2.5"/>
+    <circle cx="222" cy="92" r="2.5"/>
+  </g>
+
+  <!-- Arms — all LOWERED, hanging at sides — precise cessation -->
+  <!-- Upper left -->
+  <line x1="165" y1="113" x2="138" y2="128" stroke="#0e0c04" stroke-width="6" stroke-linecap="round"/>
+  <line x1="138" y1="128" x2="120" y2="148" stroke="#0e0c04" stroke-width="4" stroke-linecap="round"/>
+  <rect x="108" y="143" width="20" height="13" rx="2" fill="#0c0a04" stroke="#181208" stroke-width="0.8"/>
+  <!-- Lower left — hanging -->
+  <line x1="163" y1="148" x2="138" y2="158" stroke="#0e0c04" stroke-width="5" stroke-linecap="round"/>
+  <line x1="138" y1="158" x2="118" y2="175" stroke="#0e0c04" stroke-width="3.5" stroke-linecap="round"/>
+  <rect x="106" y="170" width="18" height="12" rx="2" fill="#0c0a04" stroke="#181208" stroke-width="0.8"/>
+  <!-- Upper right -->
+  <line x1="235" y1="113" x2="262" y2="128" stroke="#0e0c04" stroke-width="6" stroke-linecap="round"/>
+  <line x1="262" y1="128" x2="280" y2="148" stroke="#0e0c04" stroke-width="4" stroke-linecap="round"/>
+  <rect x="272" y="143" width="20" height="13" rx="2" fill="#0c0a04" stroke="#181208" stroke-width="0.8"/>
+  <!-- Lower right -->
+  <line x1="237" y1="148" x2="262" y2="158" stroke="#0e0c04" stroke-width="5" stroke-linecap="round"/>
+  <line x1="262" y1="158" x2="282" y2="175" stroke="#0e0c04" stroke-width="3.5" stroke-linecap="round"/>
+  <rect x="276" y="170" width="18" height="12" rx="2" fill="#0c0a04" stroke="#181208" stroke-width="0.8"/>
+
+  <!-- Steam venting from joints — the last exhale -->
+  <g fill="#201408" opacity="0.3">
+    <ellipse cx="168" cy="110" rx="10" ry="5"/>
+    <ellipse cx="232" cy="110" rx="10" ry="5"/>
+    <ellipse cx="200" cy="65"  rx="12" ry="5"/>
+  </g>
+
+  <!-- Ley coil still present — unchanged by Automaton's halt -->
+  <g stroke="#804010" stroke-width="1" fill="none" opacity="0.25">
+    <path d="M200,60 Q228,80 235,110 Q240,140 225,162 Q210,182 200,190"/>
+    <path d="M200,60 Q172,80 165,110 Q160,140 175,162 Q190,182 200,190"/>
+  </g>
+
+  <!-- Label -->
+  <text x="200" y="232" font-family="monospace" font-size="9" fill="#3a1a08" text-anchor="middle" letter-spacing="3">SYSTEMS OFFLINE</text>
+</svg>

--- a/web/public/cutscenes/act13-outro-2.svg
+++ b/web/public/cutscenes/act13-outro-2.svg
@@ -1,0 +1,110 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#070502"/>
+  <linearGradient id="gear-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#080602"/>
+    <stop offset="50%" stop-color="#0e0a04"/>
+    <stop offset="100%" stop-color="#160e06"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#gear-sky)"/>
+
+  <!-- Warm amber relic glow -->
+  <radialGradient id="gear-glow" cx="50%" cy="38%" r="45%">
+    <stop offset="0%" stop-color="#804820" stop-opacity="0.5"/>
+    <stop offset="60%" stop-color="#603010" stop-opacity="0.2"/>
+    <stop offset="100%" stop-color="#603010" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#gear-glow)"/>
+
+  <!-- THE GEAR HEART — small, intricate, beautiful -->
+  <!-- Outer aura — amber light -->
+  <radialGradient id="gh-aura" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#c06818" stop-opacity="0.45"/>
+    <stop offset="50%" stop-color="#904010" stop-opacity="0.15"/>
+    <stop offset="100%" stop-color="#904010" stop-opacity="0"/>
+  </radialGradient>
+  <circle cx="200" cy="90" r="55" fill="url(#gh-aura)"/>
+
+  <!-- Outer gear ring -->
+  <circle cx="200" cy="90" r="42" fill="#080602" stroke="#904010" stroke-width="2"/>
+  <!-- Gear teeth outer ring -->
+  <g fill="#c06010" opacity="0.6">
+    <polygon points="200,48 204,56 196,56"/>
+    <polygon points="223,52 225,61 217,59"/>
+    <polygon points="242,66 241,75 233,72"/>
+    <polygon points="250,88 242,92 242,84"/>
+    <polygon points="243,110 235,110 237,103"/>
+    <polygon points="225,126 219,119 226,116"/>
+    <polygon points="200,132 196,124 204,124"/>
+    <polygon points="175,126 174,118 181,120"/>
+    <polygon points="157,110 163,104 165,111"/>
+    <polygon points="150,88 158,84 158,92"/>
+    <polygon points="158,66 164,72 157,75"/>
+    <polygon points="177,52 175,61 183,59"/>
+  </g>
+
+  <!-- Middle gear ring — second layer, offset rotation -->
+  <circle cx="200" cy="90" r="30" fill="#0c0904" stroke="#703010" stroke-width="1.5"/>
+  <g fill="#a05010" opacity="0.5">
+    <polygon points="200,60 203,67 197,67"/>
+    <polygon points="218,65 218,72 212,70"/>
+    <polygon points="228,82 222,85 222,79"/>
+    <polygon points="225,98 219,96 221,102"/>
+    <polygon points="212,113 209,106 215,105"/>
+    <polygon points="200,118 197,111 203,111"/>
+    <polygon points="188,113 185,106 191,105"/>
+    <polygon points="175,98 179,96 179,102"/>
+    <polygon points="172,82 178,79 178,85"/>
+    <polygon points="182,65 182,72 188,70"/>
+  </g>
+
+  <!-- Inner crystal structure — the drive core -->
+  <circle cx="200" cy="90" r="18" fill="#0e0a02" stroke="#c06818" stroke-width="1.5"/>
+  <!-- Crystal facets -->
+  <g fill="#120c02" stroke="#904010" stroke-width="0.8" opacity="0.8">
+    <polygon points="200,74 210,84 205,98 195,98 190,84"/>
+    <polygon points="200,74 210,84 205,98 200,106 195,98 190,84"/>
+  </g>
+  <!-- Crystal core glow — amber, pulsing -->
+  <circle cx="200" cy="90" r="10" fill="#c06010" opacity="0.4"/>
+  <circle cx="200" cy="90" r="5"  fill="#e08020" opacity="0.6"/>
+  <circle cx="200" cy="90" r="2"  fill="#f0a030" opacity="0.9"/>
+  <!-- Radial lines in crystal — drive pathways -->
+  <g stroke="#c06818" stroke-width="0.6" fill="none" opacity="0.5">
+    <line x1="200" y1="74" x2="200" y2="90"/>
+    <line x1="210" y1="84" x2="200" y2="90"/>
+    <line x1="205" y1="98" x2="200" y2="90"/>
+    <line x1="195" y1="98" x2="200" y2="90"/>
+    <line x1="190" y1="84" x2="200" y2="90"/>
+  </g>
+
+  <!-- JARV — below, arms raised receiving the relic -->
+  <ellipse cx="200" cy="222" rx="20" ry="4" fill="#030201" opacity="0.7"/>
+  <ellipse cx="194" cy="224" rx="4.5" ry="2" fill="#08090e"/>
+  <ellipse cx="206" cy="224" rx="4.5" ry="2" fill="#08090e"/>
+  <line x1="196" y1="215" x2="194" y2="224" stroke="#0c0c18" stroke-width="3.5" stroke-linecap="round"/>
+  <line x1="204" y1="215" x2="206" y2="224" stroke="#0c0c18" stroke-width="3.5" stroke-linecap="round"/>
+  <polygon points="184,184 216,184 220,214 180,214" fill="#0a1e20" stroke="#1a4040" stroke-width="1.5"/>
+  <g fill="#00c090" opacity="0.4">
+    <circle cx="180" cy="184" r="1.5"/>
+    <circle cx="220" cy="184" r="1.5"/>
+  </g>
+  <line x1="184" y1="191" x2="166" y2="169" stroke="#0c0c18" stroke-width="3.5" stroke-linecap="round"/>
+  <line x1="216" y1="191" x2="234" y2="169" stroke="#0c0c18" stroke-width="3.5" stroke-linecap="round"/>
+  <polygon points="160,164 170,163 172,174 162,175" fill="#0d0e1a" stroke="#181830" stroke-width="0.8"/>
+  <polygon points="230,164 240,163 242,174 232,175" fill="#0d0e1a" stroke="#181830" stroke-width="0.8"/>
+  <ellipse cx="200" cy="175" rx="9" ry="8" fill="#0c0c1a" stroke="#181830" stroke-width="1"/>
+  <ellipse cx="200" cy="178" rx="5" ry="3" fill="#080810"/>
+
+  <!-- Transfer beam — amber warmth descending to hands -->
+  <g stroke="#904010" stroke-width="0.8" fill="none" opacity="0.3">
+    <path d="M175,118 Q168,140 163,168"/>
+    <path d="M225,118 Q232,140 237,168"/>
+  </g>
+
+  <!-- Vault floor -->
+  <rect x="0" y="228" width="400" height="12" fill="#0a0804"/>
+  <rect x="0" y="230" width="400" height="2" fill="#804010" opacity="0.2"/>
+
+  <!-- Label -->
+  <text x="200" y="238" font-family="monospace" font-size="9" fill="#3a1a08" text-anchor="middle" letter-spacing="3">GEAR HEART</text>
+</svg>

--- a/web/public/cutscenes/act13-outro-3.svg
+++ b/web/public/cutscenes/act13-outro-3.svg
@@ -1,0 +1,124 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#070502"/>
+  <linearGradient id="ascend-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#0a0806"/>
+    <stop offset="50%" stop-color="#120e08"/>
+    <stop offset="100%" stop-color="#1c160c"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#ascend-sky)"/>
+
+  <!-- Vault machinery continues — built to run forever -->
+  <radialGradient id="tick-glow" cx="20%" cy="55%" r="30%">
+    <stop offset="0%" stop-color="#503010" stop-opacity="0.3"/>
+    <stop offset="100%" stop-color="#503010" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#tick-glow)"/>
+
+  <!-- VAULT DESCENDING BEHIND — Jarv climbing stairs/ladder upward -->
+  <!-- Left wall — gear mechanisms, still turning -->
+  <g fill="#09070a" stroke="#131008" stroke-width="1">
+    <rect x="0"   y="0"  width="72" height="240"/>
+    <rect x="328" y="0"  width="72" height="240"/>
+  </g>
+  <g fill="#0e0c06" stroke="#1c1408" stroke-width="0.8" opacity="0.7">
+    <circle cx="36"  cy="80"  r="26"/>
+    <circle cx="36"  cy="170" r="26"/>
+    <circle cx="364" cy="80"  r="26"/>
+    <circle cx="364" cy="170" r="26"/>
+  </g>
+  <g fill="#181006" opacity="0.5">
+    <circle cx="36"  cy="80"  r="14"/>
+    <circle cx="36"  cy="170" r="14"/>
+    <circle cx="364" cy="80"  r="14"/>
+    <circle cx="364" cy="170" r="14"/>
+  </g>
+  <!-- Gears still turning — ticking marks -->
+  <g fill="#904010" opacity="0.3">
+    <circle cx="36"  cy="56"  r="3"/>
+    <circle cx="54"  cy="62"  r="3"/>
+    <circle cx="60"  cy="80"  r="3"/>
+    <circle cx="364" cy="56"  r="3"/>
+    <circle cx="346" cy="62"  r="3"/>
+    <circle cx="340" cy="80"  r="3"/>
+  </g>
+
+  <!-- Staircase — ascending from lower vault to surface opening above -->
+  <!-- Stair side rails -->
+  <line x1="155" y1="240" x2="165" y2="50" stroke="#181208" stroke-width="2.5"/>
+  <line x1="245" y1="240" x2="235" y2="50" stroke="#181208" stroke-width="2.5"/>
+  <!-- Stair treads — perspective receding upward -->
+  <g stroke="#181208" stroke-width="1" fill="#0e0c04" opacity="0.7">
+    <rect x="156" y="220" width="88" height="7"  rx="0.5"/>
+    <rect x="158" y="205" width="84" height="6.5" rx="0.5"/>
+    <rect x="160" y="190" width="80" height="6"  rx="0.5"/>
+    <rect x="163" y="176" width="74" height="5.5" rx="0.5"/>
+    <rect x="165" y="163" width="70" height="5"  rx="0.5"/>
+    <rect x="167" y="151" width="66" height="4.5" rx="0.5"/>
+    <rect x="169" y="140" width="62" height="4"  rx="0.5"/>
+    <rect x="171" y="130" width="58" height="3.5" rx="0.5"/>
+    <rect x="173" y="121" width="54" height="3"  rx="0.5"/>
+    <rect x="175" y="113" width="50" height="2.5" rx="0.5"/>
+    <rect x="177" y="106" width="46" height="2.5" rx="0.5"/>
+    <rect x="179" y="100" width="42" height="2"  rx="0.5"/>
+  </g>
+  <!-- Stair glow from below — ley light coming up through the vault grating -->
+  <radialGradient id="stair-glow" cx="50%" cy="100%" r="60%">
+    <stop offset="0%" stop-color="#904010" stop-opacity="0.3"/>
+    <stop offset="100%" stop-color="#904010" stop-opacity="0"/>
+  </radialGradient>
+  <rect x="155" y="80" width="90" height="160" fill="url(#stair-glow)"/>
+
+  <!-- Light above — the surface opening -->
+  <radialGradient id="surface-light" cx="50%" cy="0%" r="50%">
+    <stop offset="0%" stop-color="#282010" stop-opacity="0.6"/>
+    <stop offset="60%" stop-color="#181008" stop-opacity="0.2"/>
+    <stop offset="100%" stop-color="#181008" stop-opacity="0"/>
+  </radialGradient>
+  <rect x="155" y="0" width="90" height="100" fill="url(#surface-light)"/>
+  <!-- Opening frame at top -->
+  <rect x="155" y="45" width="90" height="8" rx="2" fill="#181008" stroke="#281808" stroke-width="1"/>
+  <!-- Light spilling through opening -->
+  <g stroke="#382010" stroke-width="0.8" fill="none" opacity="0.2">
+    <line x1="200" y1="53" x2="175" y2="80"/>
+    <line x1="200" y1="53" x2="200" y2="85"/>
+    <line x1="200" y1="53" x2="225" y2="80"/>
+  </g>
+
+  <!-- JARV — on stairs, ascending, back to viewer, nearly at the top -->
+  <!-- Mid-stair position -->
+  <ellipse cx="200" cy="113" rx="12" ry="3" fill="#020301" opacity="0.5"/>
+  <line x1="197" y1="106" x2="196" y2="113" stroke="#0c0c18" stroke-width="3" stroke-linecap="round"/>
+  <line x1="202" y1="106" x2="203" y2="113" stroke="#0c0c18" stroke-width="3" stroke-linecap="round"/>
+  <polygon points="192,95 208,95 211,106 189,106" fill="#0a1e20" stroke="#1a4040" stroke-width="1"/>
+  <g fill="#00c090" opacity="0.4">
+    <circle cx="189" cy="95" r="1.2"/>
+    <circle cx="211" cy="95" r="1.2"/>
+  </g>
+  <ellipse cx="200" cy="89" rx="7" ry="6" fill="#0c0c1a" stroke="#181830" stroke-width="0.8"/>
+  <!-- Iron Standard over shoulder -->
+  <line x1="208" y1="96" x2="220" y2="108" stroke="#2a3040" stroke-width="2"/>
+  <polygon points="206,96 210,96 208,87" fill="#404860" opacity="0.7"/>
+
+  <!-- Machinery background details still ticking -->
+  <!-- Left side mechanism dials -->
+  <g fill="#150f05" stroke="#201208" stroke-width="0.8" opacity="0.5">
+    <rect x="82"  y="110" width="30" height="20" rx="1"/>
+    <rect x="82"  y="145" width="30" height="20" rx="1"/>
+    <rect x="288" y="110" width="30" height="20" rx="1"/>
+    <rect x="288" y="145" width="30" height="20" rx="1"/>
+  </g>
+  <!-- Indicator lights — still on -->
+  <g fill="#904010" opacity="0.35">
+    <circle cx="90"  cy="118" r="2"/>
+    <circle cx="90"  cy="152" r="2"/>
+    <circle cx="310" cy="118" r="2"/>
+    <circle cx="310" cy="152" r="2"/>
+  </g>
+
+  <!-- Ceiling of the vault above the opening -->
+  <rect x="0" y="0" width="155" height="52" fill="#090704"/>
+  <rect x="245" y="0" width="155" height="52" fill="#090704"/>
+
+  <!-- Label -->
+  <text x="200" y="232" font-family="monospace" font-size="9" fill="#3a1a08" text-anchor="middle" letter-spacing="3">ONWARD</text>
+</svg>

--- a/web/public/cutscenes/actfinale-intro-1.svg
+++ b/web/public/cutscenes/actfinale-intro-1.svg
@@ -1,0 +1,96 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#060408"/>
+  <linearGradient id="void-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#0c0618"/>
+    <stop offset="50%" stop-color="#080412"/>
+    <stop offset="100%" stop-color="#0a060e"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#void-sky)"/>
+
+  <!-- Fracture wound glow in sky -->
+  <radialGradient id="fracture-core-glow" cx="50%" cy="28%" r="38%">
+    <stop offset="0%" stop-color="#7010c0" stop-opacity="0.55"/>
+    <stop offset="45%" stop-color="#4008a0" stop-opacity="0.25"/>
+    <stop offset="100%" stop-color="#400880" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#fracture-core-glow)"/>
+
+  <!-- Primary fracture tear — vertical, jagged void rift -->
+  <path d="M200,0 L196,28 L213,44 L186,68 L208,88 L191,112 L207,132 L195,158" stroke="#b040e8" stroke-width="2.5" fill="none" opacity="0.85"/>
+  <path d="M200,0 L196,28 L213,44 L186,68 L208,88 L191,112 L207,132 L195,158" stroke="#d878ff" stroke-width="0.8" fill="none" opacity="0.35"/>
+
+  <!-- Secondary fracture branches left -->
+  <path d="M186,68 L158,58 L132,52" stroke="#9020d0" stroke-width="1.4" fill="none" opacity="0.65"/>
+  <path d="M208,88 L175,82 L148,86" stroke="#9020d0" stroke-width="1.2" fill="none" opacity="0.55"/>
+  <path d="M158,58 L138,48 L108,54" stroke="#701090" stroke-width="0.9" fill="none" opacity="0.4"/>
+
+  <!-- Secondary fracture branches right -->
+  <path d="M213,44 L248,36 L275,30" stroke="#9020d0" stroke-width="1.4" fill="none" opacity="0.65"/>
+  <path d="M208,88 L244,80 L272,84" stroke="#9020d0" stroke-width="1.2" fill="none" opacity="0.55"/>
+  <path d="M244,80 L276,90 L300,82" stroke="#701090" stroke-width="0.9" fill="none" opacity="0.4"/>
+
+  <!-- Void mass at fracture heart -->
+  <ellipse cx="200" cy="75" rx="32" ry="26" fill="#12042a" opacity="0.75"/>
+  <ellipse cx="200" cy="75" rx="18" ry="14" fill="#0a0218" opacity="0.9"/>
+  <ellipse cx="200" cy="75" rx="8"  ry="6"  fill="#1e0840" opacity="0.7"/>
+
+  <!-- Floating shards of broken reality -->
+  <g fill="#501080" stroke="#8020c0" stroke-width="0.5" opacity="0.6">
+    <polygon points="142,38 150,33 153,42 145,46"/>
+    <polygon points="254,30 264,26 266,36 257,39"/>
+    <polygon points="112,70 121,65 124,74 116,78"/>
+    <polygon points="282,76 293,71 295,81 285,84"/>
+    <polygon points="128,100 137,96 139,104 131,108"/>
+    <polygon points="268,94 278,90 280,99 271,102"/>
+  </g>
+  <g fill="#301060" opacity="0.35">
+    <polygon points="95,54 102,50 103,58"/>
+    <polygon points="303,48 312,44 313,52"/>
+    <polygon points="168,22 175,18 176,26"/>
+    <polygon points="222,18 230,14 231,22"/>
+  </g>
+
+  <!-- Ruined ground — broken stone approach -->
+  <rect x="0" y="178" width="400" height="62" fill="#0a0810"/>
+
+  <!-- Stone floor cracks from fracture energy -->
+  <g stroke="#2a1050" stroke-width="0.8" fill="none" opacity="0.4">
+    <line x1="0" y1="178" x2="400" y2="178"/>
+    <path d="M165,178 Q175,200 172,240"/>
+    <path d="M235,178 Q225,200 228,240"/>
+    <path d="M110,178 Q105,208 100,240"/>
+    <path d="M290,178 Q295,208 300,240"/>
+  </g>
+
+  <!-- Broken left arch -->
+  <path d="M55,178 L55,142 Q55,122 76,122 Q97,122 97,142 L97,178" fill="#0e0c16" stroke="#1c1428" stroke-width="1.5"/>
+  <rect x="50" y="174" width="52" height="7" rx="1" fill="#100e18" stroke="#1e1632" stroke-width="0.8"/>
+
+  <!-- Broken right arch — sheared mid-span -->
+  <line x1="303" y1="178" x2="303" y2="144" stroke="#1c1428" stroke-width="3"/>
+  <path d="M303,144 Q304,128 322,126" stroke="#1c1428" stroke-width="2" fill="none"/>
+  <rect x="298" y="174" width="45" height="7" rx="1" fill="#100e18" stroke="#1e1632" stroke-width="0.8"/>
+
+  <!-- Rubble -->
+  <g fill="#100e18" stroke="#1a1428" stroke-width="0.5" opacity="0.8">
+    <polygon points="120,178 136,162 150,178"/>
+    <polygon points="248,178 264,166 278,178"/>
+    <polygon points="44,178 58,172 64,178"/>
+    <polygon points="336,178 352,170 365,178"/>
+  </g>
+
+  <!-- Ley energy seeping upward through ground cracks — disrupted -->
+  <g stroke="#8020c0" stroke-width="0.8" fill="none" opacity="0.18">
+    <path d="M165,178 Q180,162 200,158"/>
+    <path d="M235,178 Q220,162 200,158"/>
+  </g>
+
+  <!-- Distant collapsed spires -->
+  <g fill="#0c0a14" stroke="#161228" stroke-width="0.8" opacity="0.6">
+    <polygon points="168,178 172,150 176,178"/>
+    <polygon points="224,178 228,155 232,178"/>
+  </g>
+
+  <!-- Label -->
+  <text x="200" y="232" font-family="monospace" font-size="9" fill="#4a1878" text-anchor="middle" letter-spacing="3">THE FRACTURED CORE</text>
+</svg>

--- a/web/public/cutscenes/actfinale-intro-2.svg
+++ b/web/public/cutscenes/actfinale-intro-2.svg
@@ -1,0 +1,98 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#040208"/>
+
+  <!-- Deep void atmosphere — radial darkness -->
+  <radialGradient id="entity-dark" cx="50%" cy="45%" r="55%">
+    <stop offset="0%" stop-color="#0e0420"/>
+    <stop offset="60%" stop-color="#070214"/>
+    <stop offset="100%" stop-color="#040208"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#entity-dark)"/>
+
+  <!-- Outer fracture aura -->
+  <radialGradient id="entity-aura" cx="50%" cy="45%" r="48%">
+    <stop offset="0%" stop-color="#8020c0" stop-opacity="0.3"/>
+    <stop offset="50%" stop-color="#5008a0" stop-opacity="0.12"/>
+    <stop offset="100%" stop-color="#5008a0" stop-opacity="0"/>
+  </radialGradient>
+  <ellipse cx="200" cy="108" rx="120" ry="100" fill="url(#entity-aura)"/>
+
+  <!-- THE FRACTURE ENTITY — an absence given form -->
+  <!-- Outer crackling boundary lines -->
+  <g stroke="#a030e0" stroke-width="1.5" fill="none" opacity="0.75">
+    <path d="M200,28 L197,52 L212,66 L194,86"/>
+    <path d="M200,28 L203,52 L188,66 L206,86"/>
+    <path d="M278,58 L252,74 L238,92 L218,104"/>
+    <path d="M122,58 L148,74 L162,92 L182,104"/>
+    <path d="M298,110 L270,110 L250,115 L232,110"/>
+    <path d="M102,110 L130,110 L150,115 L168,110"/>
+    <path d="M268,172 L246,152 L228,136 L212,120"/>
+    <path d="M132,172 L154,152 L172,136 L188,120"/>
+  </g>
+  <g stroke="#c860f8" stroke-width="0.6" fill="none" opacity="0.35">
+    <path d="M200,18 L196,46 L214,62 L192,82"/>
+    <path d="M290,52 L262,70 L245,90 L220,102"/>
+    <path d="M110,52 L138,70 L155,90 L180,102"/>
+    <path d="M306,118 L278,118 L255,122"/>
+    <path d="M94,118 L122,118 L145,122"/>
+  </g>
+
+  <!-- Void body — the absence itself -->
+  <circle cx="200" cy="108" r="62" fill="#060118" stroke="#7010b0" stroke-width="1.2" opacity="0.85"/>
+  <circle cx="200" cy="108" r="46" fill="#040010" stroke="#5008a0" stroke-width="0.8" opacity="0.8"/>
+
+  <!-- Internal fracture geometry — broken reality lattice -->
+  <g fill="none" stroke="#6010a0" stroke-width="0.7" opacity="0.5">
+    <polygon points="200,72 228,94 222,128 200,142 178,128 172,94"/>
+    <polygon points="200,80 220,98 215,126 200,136 185,126 180,98"/>
+  </g>
+  <g stroke="#8020c0" stroke-width="0.5" fill="none" opacity="0.3">
+    <line x1="200" y1="72" x2="200" y2="108"/>
+    <line x1="228" y1="94" x2="200" y2="108"/>
+    <line x1="222" y1="128" x2="200" y2="108"/>
+    <line x1="178" y1="128" x2="200" y2="108"/>
+    <line x1="172" y1="94" x2="200" y2="108"/>
+  </g>
+
+  <!-- The eyes — two voids within the void -->
+  <ellipse cx="186" cy="100" rx="10" ry="7" fill="#0c0220" stroke="#9020d0" stroke-width="0.8"/>
+  <ellipse cx="214" cy="100" rx="10" ry="7" fill="#0c0220" stroke="#9020d0" stroke-width="0.8"/>
+  <!-- Iris — fracture-light glow -->
+  <ellipse cx="186" cy="100" rx="5" ry="3.5" fill="#501090" opacity="0.7"/>
+  <ellipse cx="214" cy="100" rx="5" ry="3.5" fill="#501090" opacity="0.7"/>
+  <!-- Pupil gleam -->
+  <circle cx="185" cy="99" r="1.8" fill="#d060ff" opacity="0.9"/>
+  <circle cx="213" cy="99" r="1.8" fill="#d060ff" opacity="0.9"/>
+  <!-- Secondary gleam -->
+  <circle cx="187" cy="102" r="0.8" fill="#e090ff" opacity="0.5"/>
+  <circle cx="215" cy="102" r="0.8" fill="#e090ff" opacity="0.5"/>
+
+  <!-- The fracture-mouth — a crack, not a face -->
+  <path d="M182,120 Q191,128 200,126 Q209,128 218,120" stroke="#9020d0" stroke-width="1.2" fill="none" opacity="0.6"/>
+  <path d="M185,122 Q192,126 200,124 Q208,126 215,122" stroke="#c060f0" stroke-width="0.5" fill="none" opacity="0.3"/>
+
+  <!-- Floating crystal shard fragments -->
+  <g fill="#401068" stroke="#6810a0" stroke-width="0.5" opacity="0.65">
+    <polygon points="144,60 153,55 156,64 148,68"/>
+    <polygon points="244,57 254,52 257,62 248,65"/>
+    <polygon points="130,132 140,127 143,136 134,140"/>
+    <polygon points="258,130 268,125 271,134 262,138"/>
+    <polygon points="160,174 169,169 172,178 163,181"/>
+    <polygon points="228,172 238,167 241,176 232,179"/>
+    <polygon points="96,95 104,90 106,99 99,102"/>
+    <polygon points="296,92 305,87 307,96 299,100"/>
+  </g>
+
+  <!-- Void floor — cracked stone, reality fragmenting -->
+  <rect x="0" y="202" width="400" height="38" fill="#060410"/>
+  <g stroke="#2a1050" stroke-width="0.6" fill="none" opacity="0.35">
+    <line x1="0" y1="202" x2="400" y2="202"/>
+    <path d="M155,202 Q168,218 165,240"/>
+    <path d="M245,202 Q232,218 235,240"/>
+    <path d="M80,202 Q75,220 72,240"/>
+    <path d="M320,202 Q325,220 328,240"/>
+  </g>
+
+  <!-- Label -->
+  <text x="200" y="234" font-family="monospace" font-size="9" fill="#4a1878" text-anchor="middle" letter-spacing="3">THE FORCE WITHIN</text>
+</svg>

--- a/web/public/cutscenes/actfinale-intro-3.svg
+++ b/web/public/cutscenes/actfinale-intro-3.svg
@@ -1,0 +1,105 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#060408"/>
+  <linearGradient id="road-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#0e0620"/>
+    <stop offset="40%" stop-color="#0a0418"/>
+    <stop offset="100%" stop-color="#0c060e"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#road-sky)"/>
+
+  <!-- The Fracture ahead — vast void tear filling upper half -->
+  <radialGradient id="ahead-fracture" cx="50%" cy="20%" r="50%">
+    <stop offset="0%" stop-color="#8018c8" stop-opacity="0.6"/>
+    <stop offset="40%" stop-color="#5010a0" stop-opacity="0.3"/>
+    <stop offset="100%" stop-color="#400880" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#ahead-fracture)"/>
+
+  <!-- Main void mass -->
+  <ellipse cx="200" cy="80" rx="130" ry="90" fill="#0c0420" opacity="0.7"/>
+  <ellipse cx="200" cy="70" rx="90"  ry="65" fill="#08021a" opacity="0.8"/>
+
+  <!-- Fracture rift lines — radiating from the void -->
+  <g stroke="#a030e0" stroke-width="1.8" fill="none" opacity="0.8">
+    <path d="M200,0 L197,35 L215,52 L188,75"/>
+    <path d="M200,0 L203,35 L185,52 L212,75"/>
+  </g>
+  <g stroke="#8020c0" stroke-width="1.2" fill="none" opacity="0.6">
+    <path d="M215,52 L255,40 L290,32"/>
+    <path d="M185,52 L145,40 L110,32"/>
+    <path d="M188,75 L148,72 L112,78"/>
+    <path d="M212,75 L252,72 L288,78"/>
+    <path d="M188,75 L165,95 L138,108"/>
+    <path d="M212,75 L235,95 L262,108"/>
+  </g>
+  <g stroke="#601090" stroke-width="0.7" fill="none" opacity="0.35">
+    <path d="M110,32 L75,28 L50,35"/>
+    <path d="M290,32 L325,28 L350,35"/>
+    <path d="M112,78 L80,85 L55,80"/>
+    <path d="M288,78 L320,85 L345,80"/>
+  </g>
+
+  <!-- Floating shards -->
+  <g fill="#401068" stroke="#6810a0" stroke-width="0.5" opacity="0.55">
+    <polygon points="148,30 157,25 160,34 152,38"/>
+    <polygon points="240,26 250,21 252,31 244,34"/>
+    <polygon points="95,50 104,45 107,54 99,57"/>
+    <polygon points="292,46 302,41 304,50 296,54"/>
+    <polygon points="118,95 127,90 130,99 122,102"/>
+    <polygon points="270,92 280,87 282,96 274,100"/>
+  </g>
+
+  <!-- Road / ground — stone path ending at the fracture -->
+  <rect x="0" y="175" width="400" height="65" fill="#0a080e"/>
+
+  <!-- Road in perspective — converging toward fracture -->
+  <path d="M0,220 L150,175 L250,175 L400,220" fill="#0e0c14" stroke="#181228" stroke-width="1"/>
+  <!-- Road edge lines -->
+  <line x1="150" y1="175" x2="0" y2="230" stroke="#1e1630" stroke-width="1" opacity="0.5"/>
+  <line x1="250" y1="175" x2="400" y2="230" stroke="#1e1630" stroke-width="1" opacity="0.5"/>
+  <!-- Pavement cracks — void energy splitting the road -->
+  <g stroke="#401080" stroke-width="0.8" fill="none" opacity="0.3">
+    <path d="M185,175 Q190,195 188,220"/>
+    <path d="M215,175 Q210,195 212,220"/>
+    <path d="M145,185 Q160,200 158,225"/>
+    <path d="M255,185 Q240,200 242,225"/>
+  </g>
+
+  <!-- Broken stone pillars flanking the road end -->
+  <rect x="130" y="155" width="14" height="22" rx="1" fill="#100e18" stroke="#1e1830" stroke-width="0.8"/>
+  <rect x="256" y="155" width="14" height="22" rx="1" fill="#100e18" stroke="#1e1830" stroke-width="0.8"/>
+  <!-- Pillar tops — sheared off by fracture energy -->
+  <polygon points="130,155 144,155 142,148 132,148" fill="#140e1e" stroke="#1c1630" stroke-width="0.6"/>
+  <polygon points="256,155 270,155 268,148 258,148" fill="#140e1e" stroke="#1c1630" stroke-width="0.6"/>
+
+  <!-- JARV — small silhouette, facing the fracture, laden with relics -->
+  <!-- Shadow -->
+  <ellipse cx="200" cy="183" rx="16" ry="3.5" fill="#020101" opacity="0.6"/>
+  <!-- Legs -->
+  <line x1="197" y1="177" x2="196" y2="183" stroke="#0c0c18" stroke-width="3" stroke-linecap="round"/>
+  <line x1="202" y1="177" x2="203" y2="183" stroke="#0c0c18" stroke-width="3" stroke-linecap="round"/>
+  <!-- Torso + Coral Mantle -->
+  <polygon points="191,163 209,163 212,177 188,177" fill="#0a1e20" stroke="#1a4040" stroke-width="1"/>
+  <!-- Mantle shoulder detail -->
+  <path d="M191,163 Q185,160 184,166" stroke="#1a5048" stroke-width="1.5" fill="none"/>
+  <path d="M209,163 Q215,160 216,166" stroke="#1a5048" stroke-width="1.5" fill="none"/>
+  <!-- Stormcaller's Badge on chest -->
+  <polygon points="197,167 200,164 203,167 201,170 199,170" fill="#304060" opacity="0.8"/>
+  <!-- Soulstone glow at collar -->
+  <circle cx="200" cy="163" r="1.5" fill="#4060c0" opacity="0.7"/>
+  <!-- Head -->
+  <ellipse cx="200" cy="158" rx="6" ry="5.5" fill="#0c0c1a" stroke="#181830" stroke-width="0.8"/>
+  <!-- Iron Standard over shoulder -->
+  <line x1="209" y1="165" x2="220" y2="152" stroke="#2a3040" stroke-width="1.8"/>
+  <polygon points="207,165 211,165 209,157" fill="#404860" opacity="0.7"/>
+  <!-- Golden Compass at hip -->
+  <circle cx="212" cy="174" r="2" fill="#c09020" opacity="0.6"/>
+  <circle cx="212" cy="174" r="1" fill="#e0b030" opacity="0.5"/>
+  <!-- Gear Heart glow on chest -->
+  <circle cx="200" cy="170" r="1.5" fill="#a04010" opacity="0.5"/>
+  <!-- Salvage Hook at belt -->
+  <path d="M188,174 Q185,172 186,169" stroke="#506070" stroke-width="1.2" fill="none"/>
+
+  <!-- Label -->
+  <text x="200" y="234" font-family="monospace" font-size="9" fill="#4a1878" text-anchor="middle" letter-spacing="3">THE END OF THE ROAD</text>
+</svg>

--- a/web/public/cutscenes/actfinale-outro-1.svg
+++ b/web/public/cutscenes/actfinale-outro-1.svg
@@ -1,0 +1,95 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#060408"/>
+  <linearGradient id="closing-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#0e0620"/>
+    <stop offset="50%" stop-color="#0c0616"/>
+    <stop offset="100%" stop-color="#100a0c"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#closing-sky)"/>
+
+  <!-- The fracture retracting — warmth beginning to bleed through -->
+  <radialGradient id="closing-warmth" cx="50%" cy="40%" r="45%">
+    <stop offset="0%" stop-color="#c06010" stop-opacity="0.25"/>
+    <stop offset="40%" stop-color="#8020c0" stop-opacity="0.15"/>
+    <stop offset="100%" stop-color="#400880" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#closing-warmth)"/>
+
+  <!-- Fracture entity SHATTERING — fragments flying outward -->
+  <!-- Central void dissolving, edges fragmenting -->
+  <circle cx="200" cy="100" r="55" fill="#0a021a" stroke="#7010a0" stroke-width="1" opacity="0.5"/>
+  <circle cx="200" cy="100" r="38" fill="#06010e" stroke="#5008a0" stroke-width="0.8" opacity="0.6"/>
+
+  <!-- Fracture lines — RETRACTING inward, collapsing -->
+  <g stroke="#8020c0" stroke-width="1.5" fill="none" opacity="0.55">
+    <path d="M200,40 L197,62 L210,75 L194,92"/>
+    <path d="M200,40 L203,62 L190,75 L206,92"/>
+    <path d="M262,58 L244,72 L232,88 L215,100"/>
+    <path d="M138,58 L156,72 L168,88 L185,100"/>
+  </g>
+  <!-- Fading/dissolving fracture arms -->
+  <g stroke="#601090" stroke-width="0.8" fill="none" opacity="0.3">
+    <path d="M262,58 L290,52 L315,46"/>
+    <path d="M138,58 L110,52 L85,46"/>
+    <path d="M232,88 L260,85 L285,88"/>
+    <path d="M168,88 L140,85 L115,88"/>
+  </g>
+
+  <!-- SHATTER FRAGMENTS — entity breaking apart -->
+  <!-- Large fragments flying outward -->
+  <g fill="#300850" stroke="#6010a0" stroke-width="0.6" opacity="0.8">
+    <polygon points="148,52 160,45 164,56 153,62"/>
+    <polygon points="238,48 252,42 255,54 243,59"/>
+    <polygon points="120,88 134,82 138,94 125,99"/>
+    <polygon points="262,85 277,79 280,91 267,96"/>
+    <polygon points="155,130 168,124 172,136 160,141"/>
+    <polygon points="228,128 242,122 246,134 233,139"/>
+    <polygon points="95,110 108,104 112,116 100,120"/>
+    <polygon points="290,108 303,102 307,114 294,118"/>
+  </g>
+  <!-- Smaller sparks -->
+  <g fill="#8020c0" opacity="0.5">
+    <circle cx="172" cy="38" r="2"/>
+    <circle cx="230" cy="35" r="1.5"/>
+    <circle cx="108" cy="72" r="1.5"/>
+    <circle cx="292" cy="68" r="2"/>
+    <circle cx="140" cy="148" r="1.5"/>
+    <circle cx="260" cy="145" r="1.5"/>
+    <circle cx="85" cy="128" r="1.2"/>
+    <circle cx="315" cy="125" r="1.2"/>
+  </g>
+
+  <!-- WARM LIGHT piercing through — amber dawn bleeding into the void -->
+  <radialGradient id="dawn-pierce" cx="50%" cy="100%" r="60%">
+    <stop offset="0%" stop-color="#c04808" stop-opacity="0.35"/>
+    <stop offset="50%" stop-color="#802808" stop-opacity="0.12"/>
+    <stop offset="100%" stop-color="#802808" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#dawn-pierce)"/>
+
+  <!-- Warm light rays through cracks in the fracture -->
+  <g stroke="#c06018" stroke-width="1" fill="none" opacity="0.3">
+    <path d="M185,140 L165,180 L148,220"/>
+    <path d="M200,145 L200,185 L200,230"/>
+    <path d="M215,140 L235,180 L252,220"/>
+  </g>
+
+  <!-- The fracture closing — center wound contracting -->
+  <ellipse cx="200" cy="100" rx="20" ry="16" fill="#100430" stroke="#9020d0" stroke-width="1.5" opacity="0.7"/>
+  <!-- Closing seam — warm light visible at edges -->
+  <path d="M185,100 Q192,96 200,98 Q208,96 215,100" stroke="#c06018" stroke-width="1" fill="none" opacity="0.4"/>
+  <path d="M185,100 Q192,104 200,102 Q208,104 215,100" stroke="#c06018" stroke-width="1" fill="none" opacity="0.4"/>
+
+  <!-- Ground — cracks beginning to close -->
+  <rect x="0" y="192" width="400" height="48" fill="#0c0a0e"/>
+  <g stroke="#200840" stroke-width="0.8" fill="none" opacity="0.3">
+    <line x1="0" y1="192" x2="400" y2="192"/>
+    <path d="M175,192 Q178,210 176,240" stroke-width="1.5"/>
+    <path d="M225,192 Q222,210 224,240" stroke-width="1.5"/>
+  </g>
+  <!-- Warm seam at ground — healing beginning -->
+  <line x1="0" y1="194" x2="400" y2="194" stroke="#802808" stroke-width="0.8" opacity="0.2"/>
+
+  <!-- Label -->
+  <text x="200" y="234" font-family="monospace" font-size="9" fill="#4a1878" text-anchor="middle" letter-spacing="3">THE FRACTURE CLOSES</text>
+</svg>

--- a/web/public/cutscenes/actfinale-outro-2.svg
+++ b/web/public/cutscenes/actfinale-outro-2.svg
@@ -1,0 +1,153 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#080608"/>
+  <linearGradient id="healing-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#0c0a14"/>
+    <stop offset="50%" stop-color="#0e0c0a"/>
+    <stop offset="100%" stop-color="#120e08"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#healing-sky)"/>
+
+  <!-- Healing warmth spreading from center -->
+  <radialGradient id="world-warmth" cx="50%" cy="50%" r="55%">
+    <stop offset="0%" stop-color="#c06010" stop-opacity="0.3"/>
+    <stop offset="50%" stop-color="#806020" stop-opacity="0.12"/>
+    <stop offset="100%" stop-color="#604010" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#world-warmth)"/>
+
+  <!-- HEALING PANORAMIC — three vignettes of shards healing -->
+  <!-- Dividing lines between vignettes -->
+  <line x1="134" y1="20" x2="134" y2="200" stroke="#181208" stroke-width="1" opacity="0.6"/>
+  <line x1="266" y1="20" x2="266" y2="200" stroke="#181208" stroke-width="1" opacity="0.6"/>
+
+  <!-- === LEFT VIGNETTE — THE VERDANT SHARD HEALING === -->
+  <!-- Background -->
+  <rect x="0" y="20" width="134" height="180" fill="#080a06"/>
+  <radialGradient id="verdant-heal" cx="50%" cy="60%" r="50%">
+    <stop offset="0%" stop-color="#183010" stop-opacity="0.6"/>
+    <stop offset="100%" stop-color="#183010" stop-opacity="0"/>
+  </radialGradient>
+  <rect x="0" y="20" width="134" height="180" fill="url(#verdant-heal)"/>
+  <!-- Cracked stone floor spreading green -->
+  <rect x="0" y="160" width="134" height="40" fill="#0c100a"/>
+  <g stroke="#102008" stroke-width="0.6" fill="none" opacity="0.4">
+    <path d="M30,160 Q40,170 38,200"/>
+    <path d="M90,160 Q80,172 82,200"/>
+  </g>
+  <!-- Roots spreading into cracks — healing -->
+  <g stroke="#1a4010" stroke-width="1.2" fill="none" opacity="0.7">
+    <path d="M67,160 Q60,148 55,138 Q48,126 50,115"/>
+    <path d="M67,160 Q75,148 80,138 Q85,126 82,115"/>
+    <path d="M55,138 Q42,130 35,120"/>
+    <path d="M80,138 Q93,130 100,120"/>
+  </g>
+  <!-- New growth buds at root tips -->
+  <g fill="#204018" opacity="0.8">
+    <ellipse cx="50" cy="114" rx="5" ry="3"/>
+    <ellipse cx="82" cy="114" rx="5" ry="3"/>
+    <ellipse cx="35" cy="119" rx="4" ry="2.5"/>
+    <ellipse cx="100" cy="119" rx="4" ry="2.5"/>
+  </g>
+  <!-- Bioluminescent green nodes -->
+  <g fill="#00c060" opacity="0.35">
+    <circle cx="50"  cy="113" r="2"/>
+    <circle cx="82"  cy="113" r="2"/>
+    <circle cx="35"  cy="118" r="1.5"/>
+    <circle cx="100" cy="118" r="1.5"/>
+  </g>
+  <!-- Ancient tree silhouette — returning -->
+  <line x1="67" y1="80" x2="67" y2="160" stroke="#122008" stroke-width="5"/>
+  <g stroke="#182808" stroke-width="2" fill="none" opacity="0.7">
+    <path d="M67,100 Q48,90 40,78"/>
+    <path d="M67,110 Q85,98 95,85"/>
+    <path d="M67,90 Q55,76 50,64"/>
+  </g>
+  <!-- Vignette label -->
+  <text x="67" y="210" font-family="monospace" font-size="7" fill="#204018" text-anchor="middle" letter-spacing="1">VERDANT</text>
+
+  <!-- === CENTRE VIGNETTE — THE FRACTURED CORE SEALING === -->
+  <rect x="134" y="20" width="132" height="180" fill="#0a0812"/>
+  <radialGradient id="core-seal" cx="50%" cy="45%" r="50%">
+    <stop offset="0%" stop-color="#c06010" stop-opacity="0.35"/>
+    <stop offset="50%" stop-color="#804010" stop-opacity="0.15"/>
+    <stop offset="100%" stop-color="#804010" stop-opacity="0"/>
+  </radialGradient>
+  <rect x="134" y="20" width="132" height="180" fill="url(#core-seal)"/>
+  <!-- The wound sealing — amber warmth flooding in -->
+  <radialGradient id="seal-glow" cx="50%" cy="45%" r="40%">
+    <stop offset="0%" stop-color="#e08020" stop-opacity="0.5"/>
+    <stop offset="40%" stop-color="#c06010" stop-opacity="0.2"/>
+    <stop offset="100%" stop-color="#c06010" stop-opacity="0"/>
+  </radialGradient>
+  <ellipse cx="200" cy="105" rx="55" ry="48" fill="url(#seal-glow)"/>
+  <!-- The sealed fracture — now just a scar -->
+  <path d="M200,58 L198,80 L208,92 L192,110 L204,128 L198,148" stroke="#4a0878" stroke-width="1.5" fill="none" opacity="0.4"/>
+  <!-- Amber light flooding the scar -->
+  <path d="M200,58 L198,80 L208,92 L192,110 L204,128 L198,148" stroke="#c06010" stroke-width="0.6" fill="none" opacity="0.5"/>
+  <!-- Light rays spreading outward from sealed wound -->
+  <g stroke="#d07020" stroke-width="0.8" fill="none" opacity="0.25">
+    <line x1="200" y1="100" x2="155" y2="75"/>
+    <line x1="200" y1="100" x2="155" y2="115"/>
+    <line x1="200" y1="100" x2="162" y2="148"/>
+    <line x1="200" y1="100" x2="245" y2="75"/>
+    <line x1="200" y1="100" x2="245" y2="115"/>
+    <line x1="200" y1="100" x2="238" y2="148"/>
+  </g>
+  <!-- World pieces drifting back — symbolic circles -->
+  <g fill="none" stroke="#c06010" stroke-width="0.8" opacity="0.4">
+    <circle cx="200" cy="100" r="30"/>
+    <circle cx="200" cy="100" r="42"/>
+  </g>
+  <!-- Ground healing -->
+  <rect x="134" y="168" width="132" height="32" fill="#0e0c0a"/>
+  <line x1="134" y1="170" x2="266" y2="170" stroke="#c06010" stroke-width="0.8" opacity="0.2"/>
+  <!-- Vignette label -->
+  <text x="200" y="210" font-family="monospace" font-size="7" fill="#603010" text-anchor="middle" letter-spacing="1">CORE SEALED</text>
+
+  <!-- === RIGHT VIGNETTE — THE ASHEN WASTES COOLING === -->
+  <rect x="266" y="20" width="134" height="180" fill="#0a0806"/>
+  <radialGradient id="ash-cool" cx="50%" cy="55%" r="50%">
+    <stop offset="0%" stop-color="#302010" stop-opacity="0.5"/>
+    <stop offset="100%" stop-color="#302010" stop-opacity="0"/>
+  </radialGradient>
+  <rect x="266" y="20" width="134" height="180" fill="url(#ash-cool)"/>
+  <!-- Dying fires — embers cooling to grey -->
+  <g fill="#281008" opacity="0.8">
+    <ellipse cx="305" cy="155" rx="18" ry="8"/>
+    <ellipse cx="340" cy="158" rx="14" ry="7"/>
+    <ellipse cx="370" cy="153" rx="12" ry="6"/>
+  </g>
+  <!-- Cooling fire glow — fading amber to ash grey -->
+  <g fill="#401808" opacity="0.5">
+    <ellipse cx="305" cy="150" rx="10" ry="6"/>
+    <ellipse cx="340" cy="153" rx="8"  ry="5"/>
+  </g>
+  <!-- Last wisps of smoke -->
+  <g stroke="#302018" stroke-width="1" fill="none" opacity="0.35">
+    <path d="M305,148 Q300,138 302,126 Q305,114 300,105"/>
+    <path d="M340,151 Q337,140 340,128 Q343,116 338,106"/>
+  </g>
+  <!-- Ash grey spreading from cooling fires -->
+  <g fill="#181410" opacity="0.6">
+    <ellipse cx="310" cy="162" rx="22" ry="5"/>
+    <ellipse cx="348" cy="164" rx="18" ry="4"/>
+  </g>
+  <!-- Distant horizon lightening — dawn returning -->
+  <rect x="266" y="80" width="134" height="4" fill="#302010" opacity="0.3"/>
+  <rect x="266" y="82" width="134" height="2" fill="#604020" opacity="0.2"/>
+  <!-- Cooling rubble silhouettes -->
+  <g fill="#160e08" stroke="#201208" stroke-width="0.6" opacity="0.7">
+    <polygon points="280,168 292,148 304,168"/>
+    <polygon points="355,168 368,152 380,168"/>
+  </g>
+  <!-- Vignette label -->
+  <text x="333" y="210" font-family="monospace" font-size="7" fill="#301808" text-anchor="middle" letter-spacing="1">ASHEN WASTES</text>
+
+  <!-- Top bar -->
+  <rect x="0" y="0" width="400" height="22" fill="#0a0810"/>
+  <text x="200" y="15" font-family="monospace" font-size="8" fill="#502080" text-anchor="middle" letter-spacing="2" opacity="0.8">ACROSS THE SHARDS</text>
+
+  <!-- Bottom label -->
+  <rect x="0" y="200" width="400" height="40" fill="#0a0810"/>
+  <text x="200" y="225" font-family="monospace" font-size="9" fill="#5a2808" text-anchor="middle" letter-spacing="3">HEALING</text>
+</svg>

--- a/web/public/cutscenes/actfinale-outro-3.svg
+++ b/web/public/cutscenes/actfinale-outro-3.svg
@@ -1,0 +1,115 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#080608"/>
+  <linearGradient id="dawn-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#100c18"/>
+    <stop offset="30%" stop-color="#180e0c"/>
+    <stop offset="70%" stop-color="#201408"/>
+    <stop offset="100%" stop-color="#281806"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#dawn-sky)"/>
+
+  <!-- Dawn warmth — the world's first light since the fracture -->
+  <radialGradient id="dawn-warmth" cx="50%" cy="65%" r="60%">
+    <stop offset="0%" stop-color="#e08020" stop-opacity="0.45"/>
+    <stop offset="40%" stop-color="#c06010" stop-opacity="0.2"/>
+    <stop offset="100%" stop-color="#904010" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#dawn-warmth)"/>
+
+  <!-- Sealed fracture scar — now healed, glowing faint gold -->
+  <radialGradient id="scar-glow" cx="50%" cy="35%" r="30%">
+    <stop offset="0%" stop-color="#e0a030" stop-opacity="0.4"/>
+    <stop offset="60%" stop-color="#c07018" stop-opacity="0.15"/>
+    <stop offset="100%" stop-color="#c07018" stop-opacity="0"/>
+  </radialGradient>
+  <ellipse cx="200" cy="80" rx="70" ry="55" fill="url(#scar-glow)"/>
+
+  <!-- The healed wound — sealed scar, warm gold seam -->
+  <path d="M200,30 L198,52 L210,65 L193,82 L206,100 L198,118" stroke="#301828" stroke-width="1.5" fill="none" opacity="0.3"/>
+  <!-- Gold seam over the scar — mended -->
+  <path d="M200,30 L198,52 L210,65 L193,82 L206,100 L198,118" stroke="#e0a030" stroke-width="0.8" fill="none" opacity="0.6"/>
+  <!-- Mending light rays from the sealed scar -->
+  <g stroke="#e08020" stroke-width="0.8" fill="none" opacity="0.2">
+    <line x1="200" y1="75" x2="145" y2="50"/>
+    <line x1="200" y1="75" x2="140" y2="80"/>
+    <line x1="200" y1="75" x2="155" y2="115"/>
+    <line x1="200" y1="75" x2="255" y2="50"/>
+    <line x1="200" y1="75" x2="260" y2="80"/>
+    <line x1="200" y1="75" x2="245" y2="115"/>
+    <line x1="200" y1="75" x2="200" y2="35"/>
+  </g>
+
+  <!-- THE WORLDMENDER'S CREST — the relic, floating above Jarv -->
+  <!-- Outer crest ring — ornate, golden -->
+  <circle cx="200" cy="75" r="28" fill="#100a04" stroke="#d08820" stroke-width="1.8" opacity="0.9"/>
+  <!-- Crest wing elements — left -->
+  <path d="M172,75 Q165,65 168,55 Q174,48 182,52" fill="#140c04" stroke="#c07818" stroke-width="1" opacity="0.8"/>
+  <path d="M172,75 Q162,78 163,88 Q168,96 178,94" fill="#140c04" stroke="#c07818" stroke-width="1" opacity="0.8"/>
+  <!-- Crest wing elements — right -->
+  <path d="M228,75 Q235,65 232,55 Q226,48 218,52" fill="#140c04" stroke="#c07818" stroke-width="1" opacity="0.8"/>
+  <path d="M228,75 Q238,78 237,88 Q232,96 222,94" fill="#140c04" stroke="#c07818" stroke-width="1" opacity="0.8"/>
+  <!-- Inner crest field — the sealed world -->
+  <circle cx="200" cy="75" r="19" fill="#0e0804" stroke="#e09828" stroke-width="1.2" opacity="0.9"/>
+  <!-- World-map inside — simplified fracture-healed shard pattern -->
+  <g fill="none" stroke="#c07018" stroke-width="0.6" opacity="0.5">
+    <circle cx="200" cy="75" r="12"/>
+    <line x1="200" y1="63" x2="200" y2="87"/>
+    <line x1="188" y1="75" x2="212" y2="75"/>
+  </g>
+  <!-- Healed fracture line across the world -->
+  <path d="M195,65 Q199,72 200,75 Q201,78 205,85" stroke="#e0a030" stroke-width="1" fill="none" opacity="0.8"/>
+  <!-- Core light — gold pulse -->
+  <circle cx="200" cy="75" r="7" fill="#e08018" opacity="0.45"/>
+  <circle cx="200" cy="75" r="4" fill="#f0a030" opacity="0.6"/>
+  <circle cx="200" cy="75" r="2" fill="#f8c050" opacity="0.9"/>
+  <!-- Crest rivets / ornamental points -->
+  <g fill="#e09828" opacity="0.7">
+    <circle cx="200" cy="47" r="2"/>
+    <circle cx="200" cy="103" r="2"/>
+    <circle cx="172" cy="75" r="2"/>
+    <circle cx="228" cy="75" r="2"/>
+    <circle cx="180" cy="54" r="1.5"/>
+    <circle cx="220" cy="54" r="1.5"/>
+    <circle cx="180" cy="96" r="1.5"/>
+    <circle cx="220" cy="96" r="1.5"/>
+  </g>
+
+  <!-- JARV — standing at the healed core, facing us for the first time -->
+  <!-- Shadow -->
+  <ellipse cx="200" cy="210" rx="22" ry="5" fill="#030201" opacity="0.6"/>
+  <!-- Legs -->
+  <line x1="196" y1="200" x2="195" y2="210" stroke="#0c0c18" stroke-width="3.5" stroke-linecap="round"/>
+  <line x1="203" y1="200" x2="204" y2="210" stroke="#0c0c18" stroke-width="3.5" stroke-linecap="round"/>
+  <!-- Torso + Coral Mantle (now catching dawn light) -->
+  <polygon points="189,180 211,180 214,200 186,200" fill="#0a1e20" stroke="#1a5048" stroke-width="1.2"/>
+  <!-- Mantle shoulder warmth -->
+  <path d="M189,180 Q182,176 180,183" stroke="#1a6050" stroke-width="1.8" fill="none"/>
+  <path d="M211,180 Q218,176 220,183" stroke="#1a6050" stroke-width="1.8" fill="none"/>
+  <!-- Stormcaller's Badge — glinting in dawn -->
+  <polygon points="197,184 200,181 203,184 201,188 199,188" fill="#506080" opacity="0.9"/>
+  <!-- Soulstone — softly lit -->
+  <circle cx="200" cy="180" r="2" fill="#6080d0" opacity="0.7"/>
+  <!-- Golden Compass at hip — catching dawn -->
+  <circle cx="213" cy="196" r="2.5" fill="#c09020" opacity="0.75"/>
+  <circle cx="213" cy="196" r="1.2" fill="#e0b030" opacity="0.6"/>
+  <!-- Gear Heart on chest — warm amber -->
+  <circle cx="200" cy="190" r="1.8" fill="#a04010" opacity="0.65"/>
+  <!-- Salvage Hook -->
+  <path d="M187,197 Q184,194 185,191" stroke="#506070" stroke-width="1.2" fill="none"/>
+  <!-- Iron Standard — held upright now, not over shoulder -->
+  <line x1="215" y1="200" x2="215" y2="168" stroke="#2a3040" stroke-width="2.2"/>
+  <polygon points="212,168 218,168 215,158" fill="#606880" opacity="0.8"/>
+  <!-- Head -->
+  <ellipse cx="200" cy="172" rx="7.5" ry="7" fill="#0c0c1a" stroke="#181830" stroke-width="0.8"/>
+  <!-- Eyes — visible, facing viewer -->
+  <ellipse cx="197" cy="171" rx="1.8" ry="1.4" fill="#c0c0e0" opacity="0.6"/>
+  <ellipse cx="203" cy="171" rx="1.8" ry="1.4" fill="#c0c0e0" opacity="0.6"/>
+
+  <!-- Dawn horizon line -->
+  <rect x="0" y="218" width="400" height="22" fill="#120e08"/>
+  <line x1="0" y1="218" x2="400" y2="218" stroke="#c07018" stroke-width="1.2" opacity="0.4"/>
+  <line x1="0" y1="220" x2="400" y2="220" stroke="#e09030" stroke-width="0.5" opacity="0.25"/>
+
+  <!-- Label -->
+  <text x="200" y="235" font-family="monospace" font-size="9" fill="#7a4010" text-anchor="middle" letter-spacing="3">WORLDMENDER</text>
+</svg>

--- a/web/src/data/acts/act10.json
+++ b/web/src/data/acts/act10.json
@@ -43,29 +43,35 @@
   "intro": [
     {
       "title": "THE SAND MARKET",
-      "text": "The ley lines run straight through the desert, which the Sand Market has spent decades making commercially relevant. The market grew up around the ley convergence — vendors first, then traders, then mercenaries, then the Dune Baron, who saw the strategic value and started charging for it.\n\nEverything here has a price. Including passage through it."
+      "text": "The ley lines run straight through the desert, which the Sand Market has spent decades making commercially relevant. The market grew up around the ley convergence — vendors first, then traders, then mercenaries, then the Dune Baron, who saw the strategic value and started charging for it.\n\nEverything here has a price. Including passage through it.",
+      "image": "cutscenes/act10-intro-1.svg"
     },
     {
       "title": "THE DUNE BARON",
-      "text": "The Dune Baron is not a warlord in any conventional sense. He's a businessman who happens to employ an army. The distinction matters to him. He'll explain it at length if you have the time.\n\nYou don't have the time. He knows this. He's going to make you spend it anyway.\n\nHe respects efficiency, but only if you can afford it."
+      "text": "The Dune Baron is not a warlord in any conventional sense. He's a businessman who happens to employ an army. The distinction matters to him. He'll explain it at length if you have the time.\n\nYou don't have the time. He knows this. He's going to make you spend it anyway.\n\nHe respects efficiency, but only if you can afford it.",
+      "image": "cutscenes/act10-intro-2.svg"
     },
     {
       "title": "THE MARKET ROUTE",
-      "text": "The ley lines converge beneath the market's central spire — the Dune Baron uses the energy surplus to power the lights, the forges, and the contract-binding seals that make his mercenary arrangements legally enforceable.\n\nYou need the convergence point. He isn't selling it.\n\nYou're going to take it. He'll probably factor this into his pricing for the next traveller."
+      "text": "The ley lines converge beneath the market's central spire — the Dune Baron uses the energy surplus to power the lights, the forges, and the contract-binding seals that make his mercenary arrangements legally enforceable.\n\nYou need the convergence point. He isn't selling it.\n\nYou're going to take it. He'll probably factor this into his pricing for the next traveller.",
+      "image": "cutscenes/act10-intro-3.svg"
     }
   ],
   "outro": [
     {
       "title": "THE DUNE BARON SETTLES",
-      "text": "The Dune Baron doesn't lose gracefully. He loses expensively — which means he calculates the cost of the outcome, determines it was within acceptable parameters, and files the result under 'resolved.'\n\nThe ley lines pulse through the market floor. The convergence point opens.\n\nHe's already thinking about what to charge the next person who shows up."
+      "text": "The Dune Baron doesn't lose gracefully. He loses expensively — which means he calculates the cost of the outcome, determines it was within acceptable parameters, and files the result under 'resolved.'\n\nThe ley lines pulse through the market floor. The convergence point opens.\n\nHe's already thinking about what to charge the next person who shows up.",
+      "image": "cutscenes/act10-outro-1.svg"
     },
     {
       "title": "WHAT HE SAID",
-      "text": "'You fought well,' the Baron said. 'I'll give you that at no charge.'\n\nYou asked about the Golden Compass.\n\n'Consider it a finder's fee,' he said. 'For finding the limits of my hospitality.'"
+      "text": "'You fought well,' the Baron said. 'I'll give you that at no charge.'\n\nYou asked about the Golden Compass.\n\n'Consider it a finder's fee,' he said. 'For finding the limits of my hospitality.'",
+      "image": "cutscenes/act10-outro-2.svg"
     },
     {
       "title": "THE GOLDEN COMPASS",
-      "text": "The Golden Compass sits warm in your palm — the Baron's personal navigation tool, used to track ley line convergences across the desert. It still points to them.\n\nIt also, apparently, makes you faster off the mark. The Baron claims he hadn't noticed that. You don't believe him.\n\nThe ley lines point on. The market recedes. The desert is, for once, quiet."
+      "text": "The Golden Compass sits warm in your palm — the Baron's personal navigation tool, used to track ley line convergences across the desert. It still points to them.\n\nIt also, apparently, makes you faster off the mark. The Baron claims he hadn't noticed that. You don't believe him.\n\nThe ley lines point on. The market recedes. The desert is, for once, quiet.",
+      "image": "cutscenes/act10-outro-3.svg"
     }
   ],
   "nodes": {

--- a/web/src/data/acts/act11.json
+++ b/web/src/data/acts/act11.json
@@ -43,29 +43,35 @@
   "intro": [
     {
       "title": "THE VERDANT CANOPY",
-      "text": "The ley lines rise into the high canopy here, threading through root systems older than memory. The forest above the treeline moves differently. It doesn't react to you \u2014 it notices you.\n\nThe Elder Warden has kept this canopy since before the Fracture. It has watched dozens of expeditions attempt passage. None returned changed for the better."
+      "text": "The ley lines rise into the high canopy here, threading through root systems older than memory. The forest above the treeline moves differently. It doesn't react to you — it notices you.\n\nThe Elder Warden has kept this canopy since before the Fracture. It has watched dozens of expeditions attempt passage. None returned changed for the better.",
+      "image": "cutscenes/act11-intro-1.svg"
     },
     {
       "title": "THE ELDER WARDEN",
-      "text": "It is not a creature in any familiar sense. The Warden is the canopy made sovereign \u2014 a convergence of root and memory and something older that has no name in any language you speak.\n\nIt does not hate you. Hatred requires noticing something as a peer. The Warden sees you as disruption. Disruptions are removed."
+      "text": "It is not a creature in any familiar sense. The Warden is the canopy made sovereign — a convergence of root and memory and something older that has no name in any language you speak.\n\nIt does not hate you. Hatred requires noticing something as a peer. The Warden sees you as disruption. Disruptions are removed.",
+      "image": "cutscenes/act11-intro-2.svg"
     },
     {
       "title": "THE PATH THROUGH",
-      "text": "The ley convergence runs through the ancient heartwood at the canopy's centre. Scholars have theorised about it for decades. None have gotten close enough to verify.\n\nYou will need to fight through layers of living defence \u2014 root walls, grove-spawned treants, flying watchers \u2014 before the Warden descends. And then you will need to convince it, by force, that disruption can be useful."
+      "text": "The ley convergence runs through the ancient heartwood at the canopy's centre. Scholars have theorised about it for decades. None have gotten close enough to verify.\n\nYou will need to fight through layers of living defence — root walls, grove-spawned treants, flying watchers — before the Warden descends. And then you will need to convince it, by force, that disruption can be useful.",
+      "image": "cutscenes/act11-intro-3.svg"
     }
   ],
   "outro": [
     {
       "title": "THE CANOPY YIELDS",
-      "text": "The Elder Warden does not fall. It withdraws \u2014 slowly, deliberately, as though choosing to end the engagement rather than being forced to. The distinction matters to it.\n\nThe ley convergence is exposed. The heartwood pulses with calm energy, older than anything you've touched before."
+      "text": "The Elder Warden does not fall. It withdraws — slowly, deliberately, as though choosing to end the engagement rather than being forced to. The distinction matters to it.\n\nThe ley convergence is exposed. The heartwood pulses with calm energy, older than anything you've touched before.",
+      "image": "cutscenes/act11-outro-1.svg"
     },
     {
       "title": "LIVING BARK",
-      "text": "Where the Warden stood, a strip of bark remains \u2014 thick, warm to the touch, and inexplicably alive. It hardens in your hands into something like armour, or maybe a shield, or maybe just the canopy saying: you've earned a layer of protection.\n\nYou don't question it. The canopy rewards results."
+      "text": "Where the Warden stood, a strip of bark remains — thick, warm to the touch, and inexplicably alive. It hardens in your hands into something like armour, or maybe a shield, or maybe just the canopy saying: you've earned a layer of protection.\n\nYou don't question it. The canopy rewards results.",
+      "image": "cutscenes/act11-outro-2.svg"
     },
     {
       "title": "THE ROAD AHEAD",
-      "text": "The Verdant Canopy recedes behind you as you descend. Above, you hear the canopy resume its ordinary rhythms \u2014 something enormous moving between branches, watchers returning to their posts.\n\nThe Warden is already repairing the damage. It won't hold a grudge. It's too old for that. It will simply be ready when you return."
+      "text": "The Verdant Canopy recedes behind you as you descend. Above, you hear the canopy resume its ordinary rhythms — something enormous moving between branches, watchers returning to their posts.\n\nThe Warden is already repairing the damage. It won't hold a grudge. It's too old for that. It will simply be ready when you return.",
+      "image": "cutscenes/act11-outro-3.svg"
     }
   ],
   "nodes": {
@@ -114,7 +120,7 @@
       ],
       "eventConfig": {
         "title": "The Root Shrine",
-        "description": "A gnarled shrine wrapped in glowing roots. You can feel something ancient in it. The options it presents are simple \u2014 give something, take something, or leave it alone.",
+        "description": "A gnarled shrine wrapped in glowing roots. You can feel something ancient in it. The options it presents are simple — give something, take something, or leave it alone.",
         "pools": [
           [
             {
@@ -122,8 +128,14 @@
               "effect": {
                 "type": "compound",
                 "effects": [
-                  { "type": "damageHp", "amount": 8 },
-                  { "type": "gainCard", "rarity": "rare" }
+                  {
+                    "type": "damageHp",
+                    "amount": 8
+                  },
+                  {
+                    "type": "gainCard",
+                    "rarity": "rare"
+                  }
                 ]
               },
               "consequence": "You receive a rare card."
@@ -265,7 +277,7 @@
       ],
       "eventConfig": {
         "title": "The Canopy Rift",
-        "description": "A gap in the ancient canopy shows the raw ley lines beneath \u2014 shimmering, strange, and old. You can attempt to draw on them, or simply study them from a safe distance.",
+        "description": "A gap in the ancient canopy shows the raw ley lines beneath — shimmering, strange, and old. You can attempt to draw on them, or simply study them from a safe distance.",
         "pools": [
           [
             {
@@ -273,8 +285,14 @@
               "effect": {
                 "type": "compound",
                 "effects": [
-                  { "type": "damageHp", "amount": 5 },
-                  { "type": "gainCard", "rarity": "rare" }
+                  {
+                    "type": "damageHp",
+                    "amount": 5
+                  },
+                  {
+                    "type": "gainCard",
+                    "rarity": "rare"
+                  }
                 ]
               },
               "consequence": "You receive a rare card."
@@ -392,7 +410,7 @@
       ],
       "eventConfig": {
         "title": "The Warden's Gaze",
-        "description": "You feel it before you see it \u2014 a presence older than stone watching from the high branches. It hasn't moved. It's waiting to see what you do. Your choice here will define what follows.",
+        "description": "You feel it before you see it — a presence older than stone watching from the high branches. It hasn't moved. It's waiting to see what you do. Your choice here will define what follows.",
         "pools": [
           [
             {
@@ -410,8 +428,14 @@
               "effect": {
                 "type": "compound",
                 "effects": [
-                  { "type": "gainCrystals", "amount": 100 },
-                  { "type": "damageHp", "amount": 15 }
+                  {
+                    "type": "gainCrystals",
+                    "amount": 100
+                  },
+                  {
+                    "type": "damageHp",
+                    "amount": 15
+                  }
                 ]
               },
               "consequence": "You gain 100 crystals."

--- a/web/src/data/acts/act12.json
+++ b/web/src/data/acts/act12.json
@@ -43,29 +43,35 @@
   "intro": [
     {
       "title": "THE SHATTERED COAST",
-      "text": "The Shattered Coast was once a thriving port city \u2014 before the Fracture split it across seven separate shards.\n\nNow the channels between shards are controlled by a single authority: the Harbormaster. Nothing moves without his iron seal. No cargo. No people. No information."
+      "text": "The Shattered Coast was once a thriving port city — before the Fracture split it across seven separate shards.\n\nNow the channels between shards are controlled by a single authority: the Harbormaster. Nothing moves without his iron seal. No cargo. No people. No information.",
+      "image": "cutscenes/act12-intro-1.svg"
     },
     {
       "title": "THE HARBORMASTER",
-      "text": "He was a port inspector once, before the Fracture. Now he is something else \u2014 a man who discovered that chaos could be administered, and administration could be power.\n\nHis fleet patrols the shattered channels. His flags are the only law. The wreck divers answer to him. The storm hawks circle his flagship."
+      "text": "He was a port inspector once, before the Fracture. Now he is something else — a man who discovered that chaos could be administered, and administration could be power.\n\nHis fleet patrols the shattered channels. His flags are the only law. The wreck divers answer to him. The storm hawks circle his flagship.",
+      "image": "cutscenes/act12-intro-2.svg"
     },
     {
       "title": "NO PERMIT",
-      "text": "You don't have his permit. You don't intend to get one.\n\nThe coast is the only route forward, and the Harbormaster blocks it. Fight through his patrols, his reef wardens, his iron anchorage \u2014 and put an end to the toll."
+      "text": "You don't have his permit. You don't intend to get one.\n\nThe coast is the only route forward, and the Harbormaster blocks it. Fight through his patrols, his reef wardens, his iron anchorage — and put an end to the toll.",
+      "image": "cutscenes/act12-intro-3.svg"
     }
   ],
   "outro": [
     {
       "title": "THE IRON TIDE BREAKS",
-      "text": "The Harbormaster's flagship lists into the grey water, its iron hull taking on the sea. He didn't ask for terms. He didn't retreat. He fought until the storm itself abandoned him."
+      "text": "The Harbormaster's flagship lists into the grey water, its iron hull taking on the sea. He didn't ask for terms. He didn't retreat. He fought until the storm itself abandoned him.",
+      "image": "cutscenes/act12-outro-1.svg"
     },
     {
       "title": "SALVAGE HOOK",
-      "text": "Among the wreckage, half-buried in sand, you find a salvage hook \u2014 the symbol of passage along this coast. It's old. Pre-Fracture. It means something.\n\nYou pocket it. The channels open around you."
+      "text": "Among the wreckage, half-buried in sand, you find a salvage hook — the symbol of passage along this coast. It's old. Pre-Fracture. It means something.\n\nYou pocket it. The channels open around you.",
+      "image": "cutscenes/act12-outro-2.svg"
     },
     {
       "title": "THE HORIZON",
-      "text": "The tide pulls back. The next shard waits beyond the horizon.\n\nYou sail on."
+      "text": "The tide pulls back. The next shard waits beyond the horizon.\n\nYou sail on.",
+      "image": "cutscenes/act12-outro-3.svg"
     }
   ],
   "nodes": {
@@ -115,8 +121,14 @@
               "effect": {
                 "type": "compound",
                 "effects": [
-                  { "type": "damageHp", "amount": 8 },
-                  { "type": "gainCard", "rarity": "rare" }
+                  {
+                    "type": "damageHp",
+                    "amount": 8
+                  },
+                  {
+                    "type": "gainCard",
+                    "rarity": "rare"
+                  }
                 ]
               }
             }
@@ -248,8 +260,14 @@
               "effect": {
                 "type": "compound",
                 "effects": [
-                  { "type": "damageHp", "amount": 6 },
-                  { "type": "gainCard", "rarity": "rare" }
+                  {
+                    "type": "damageHp",
+                    "amount": 6
+                  },
+                  {
+                    "type": "gainCard",
+                    "rarity": "rare"
+                  }
                 ]
               }
             }
@@ -380,8 +398,14 @@
               "effect": {
                 "type": "compound",
                 "effects": [
-                  { "type": "gainCrystals", "amount": 100 },
-                  { "type": "damageHp", "amount": 15 }
+                  {
+                    "type": "gainCrystals",
+                    "amount": 100
+                  },
+                  {
+                    "type": "damageHp",
+                    "amount": 15
+                  }
                 ]
               }
             }
@@ -413,7 +437,7 @@
       "id": "iron-anchorage",
       "type": "elite",
       "label": "Iron Anchorage",
-      "description": "The Harbormaster's advance guard \u2014 iron-hulled and merciless.",
+      "description": "The Harbormaster's advance guard — iron-hulled and merciless.",
       "row": 4,
       "col": 3,
       "rowCols": 4,

--- a/web/src/data/acts/act13.json
+++ b/web/src/data/acts/act13.json
@@ -43,29 +43,35 @@
   "intro": [
     {
       "title": "THE CLOCKWORK VAULTS",
-      "text": "Deep beneath the shattered earth, the Clockwork Vaults hum with ancient machinery \u2014 built before the Fracture by an artificer order that no longer exists.\n\nThe Grand Automaton maintains it all. Has maintained it for two hundred years. No one knows if it was told to stop."
+      "text": "Deep beneath the shattered earth, the Clockwork Vaults hum with ancient machinery — built before the Fracture by an artificer order that no longer exists.\n\nThe Grand Automaton maintains it all. Has maintained it for two hundred years. No one knows if it was told to stop.",
+      "image": "cutscenes/act13-intro-1.svg"
     },
     {
       "title": "THE GRAND AUTOMATON",
-      "text": "It is not hostile. Hostility implies intent. The Automaton simply optimises \u2014 calculating minimum-force resolutions for all threats to vault integrity.\n\nYou are a threat to vault integrity."
+      "text": "It is not hostile. Hostility implies intent. The Automaton simply optimises — calculating minimum-force resolutions for all threats to vault integrity.\n\nYou are a threat to vault integrity.",
+      "image": "cutscenes/act13-intro-2.svg"
     },
     {
       "title": "WHAT LIES WITHIN",
-      "text": "The ley convergence threads through the Vault's central chamber, coiled around the Automaton's power core. It cannot be extracted without confronting the machine.\n\nThe machine cannot be reasoned with. But it can be defeated."
+      "text": "The ley convergence threads through the Vault's central chamber, coiled around the Automaton's power core. It cannot be extracted without confronting the machine.\n\nThe machine cannot be reasoned with. But it can be defeated.",
+      "image": "cutscenes/act13-intro-3.svg"
     }
   ],
   "outro": [
     {
       "title": "SYSTEMS OFFLINE",
-      "text": "The Grand Automaton's drives wind down with a sound like a long exhale. The vault shudders. Somewhere deep below, something enormous stops moving for the first time in centuries."
+      "text": "The Grand Automaton's drives wind down with a sound like a long exhale. The vault shudders. Somewhere deep below, something enormous stops moving for the first time in centuries.",
+      "image": "cutscenes/act13-outro-1.svg"
     },
     {
       "title": "GEAR HEART",
-      "text": "Amid the cooling machinery, you find a small gear-shaped crystal \u2014 the Automaton's drive core, still faintly warm.\n\nA fitting trophy. It pulses with each heartbeat."
+      "text": "Amid the cooling machinery, you find a small gear-shaped crystal — the Automaton's drive core, still faintly warm.\n\nA fitting trophy. It pulses with each heartbeat.",
+      "image": "cutscenes/act13-outro-2.svg"
     },
     {
       "title": "ONWARD",
-      "text": "The vault's mechanisms continue to tick behind you as you ascend. They were built to run forever.\n\nPerhaps they will."
+      "text": "The vault's mechanisms continue to tick behind you as you ascend. They were built to run forever.\n\nPerhaps they will.",
+      "image": "cutscenes/act13-outro-3.svg"
     }
   ],
   "nodes": {
@@ -115,8 +121,14 @@
               "effect": {
                 "type": "compound",
                 "effects": [
-                  { "type": "damageHp", "amount": 8 },
-                  { "type": "gainCard", "rarity": "rare" }
+                  {
+                    "type": "damageHp",
+                    "amount": 8
+                  },
+                  {
+                    "type": "gainCard",
+                    "rarity": "rare"
+                  }
                 ]
               }
             }
@@ -248,8 +260,14 @@
               "effect": {
                 "type": "compound",
                 "effects": [
-                  { "type": "damageHp", "amount": 5 },
-                  { "type": "gainCard", "rarity": "rare" }
+                  {
+                    "type": "damageHp",
+                    "amount": 5
+                  },
+                  {
+                    "type": "gainCard",
+                    "rarity": "rare"
+                  }
                 ]
               }
             }
@@ -339,7 +357,7 @@
       "id": "repair-bay",
       "type": "rest",
       "label": "Salvaged Repair Bay",
-      "description": "Abandoned repair alcove \u2014 still functional.",
+      "description": "Abandoned repair alcove — still functional.",
       "row": 3,
       "col": 3,
       "rowCols": 4,
@@ -380,8 +398,14 @@
               "effect": {
                 "type": "compound",
                 "effects": [
-                  { "type": "gainCrystals", "amount": 100 },
-                  { "type": "damageHp", "amount": 15 }
+                  {
+                    "type": "gainCrystals",
+                    "amount": 100
+                  },
+                  {
+                    "type": "damageHp",
+                    "amount": 15
+                  }
                 ]
               }
             }

--- a/web/src/data/acts/actfinale.json
+++ b/web/src/data/acts/actfinale.json
@@ -39,29 +39,35 @@
   "intro": [
     {
       "title": "THE FRACTURED CORE",
-      "text": "You have crossed thirteen shards, faced their champions, and collected their secrets. The path has always led here \u2014 to the wound at the world's heart.\n\nThe Fracture Event tore reality apart and scattered the Dominion into pieces. Something caused it. Something remains at the centre."
+      "text": "You have crossed thirteen shards, faced their champions, and collected their secrets. The path has always led here — to the wound at the world's heart.\n\nThe Fracture Event tore reality apart and scattered the Dominion into pieces. Something caused it. Something remains at the centre.",
+      "image": "cutscenes/actfinale-intro-1.svg"
     },
     {
       "title": "THE FORCE WITHIN",
-      "text": "The Fractured Core does not feel like a place. It feels like the absence of one \u2014 a scar where the world used to be whole.\n\nThe entity within has no name. No origin. It simply is the fracture, given will and hunger."
+      "text": "The Fractured Core does not feel like a place. It feels like the absence of one — a scar where the world used to be whole.\n\nThe entity within has no name. No origin. It simply is the fracture, given will and hunger.",
+      "image": "cutscenes/actfinale-intro-2.svg"
     },
     {
       "title": "THE END OF THE ROAD",
-      "text": "There is no one left to send. No other path to walk. You are Jarv, wandering tactician, and this is the last battlefield.\n\nIf the Core falls, the world begins to heal. If you fall, there is no one else."
+      "text": "There is no one left to send. No other path to walk. You are Jarv, wandering tactician, and this is the last battlefield.\n\nIf the Core falls, the world begins to heal. If you fall, there is no one else.",
+      "image": "cutscenes/actfinale-intro-3.svg"
     }
   ],
   "outro": [
     {
       "title": "THE FRACTURE CLOSES",
-      "text": "The entity shudders. Writhes. And then \u2014 for the first time since the cataclysm \u2014 something at the heart of the world goes quiet.\n\nThe wound begins to close."
+      "text": "The entity shudders. Writhes. And then — for the first time since the cataclysm — something at the heart of the world goes quiet.\n\nThe wound begins to close.",
+      "image": "cutscenes/actfinale-outro-1.svg"
     },
     {
       "title": "HEALING",
-      "text": "Across the shards, the tremors stop. The Verdant Shard's roots spread back into cracked stone. The Iron Citadel's fires die down. The Ashen Wastes, slowly, begin to grey.\n\nIt will take generations. But it has begun."
+      "text": "Across the shards, the tremors stop. The Verdant Shard's roots spread back into cracked stone. The Iron Citadel's fires die down. The Ashen Wastes, slowly, begin to grey.\n\nIt will take generations. But it has begun.",
+      "image": "cutscenes/actfinale-outro-2.svg"
     },
     {
       "title": "WORLDMENDER",
-      "text": "You stand at the heart of what was broken and watch the pieces, impossibly, start to drift back together.\n\nYou did this. You, and every unit you sent forward, every choice you made, every shard you crossed.\n\nWorldmender."
+      "text": "You stand at the heart of what was broken and watch the pieces, impossibly, start to drift back together.\n\nYou did this. You, and every unit you sent forward, every choice you made, every shard you crossed.\n\nWorldmender.",
+      "image": "cutscenes/actfinale-outro-3.svg"
     }
   ],
   "nodes": {
@@ -138,7 +144,7 @@
       "id": "fractures-herald",
       "type": "elite",
       "label": "The Fracture's Herald",
-      "description": "A projection of the Fracture itself \u2014 testing your limits before the end.",
+      "description": "A projection of the Fracture itself — testing your limits before the end.",
       "row": 3,
       "col": 0,
       "rowCols": 1,
@@ -162,7 +168,7 @@
       "id": "the-fracture-node",
       "type": "boss",
       "label": "The Fracture",
-      "description": "The source of the cataclysm. The end of the world \u2014 or yours.",
+      "description": "The source of the cataclysm. The end of the world — or yours.",
       "row": 4,
       "col": 0,
       "rowCols": 1,


### PR DESCRIPTION
## Summary

- Adds 6 SVG cutscene panels each for acts 10, 11, 12, 13, and the finale (30 panels total)
- Wires `image` fields into `act10.json`, `act11.json`, `act12.json`, `act13.json`, `actfinale.json`
- Fixes xmlns typo in `act13-intro-1.svg`

### Act 10 — The Sand Market
Warm desert amber/gold palette. Dune Baron merchant encounter, golden compass relic.

### Act 11 — The Verdant Canopy
Deep forest greens / bioluminescent palette. Elder Warden (branching aggregate form), Living Bark relic.

### Act 12 — The Shattered Coast
Stormy grey-blue / maritime iron palette. Harbormaster bureaucrat encounter, Salvage Hook relic.

### Act 13 — The Clockwork Vaults
Brass/copper amber / underground machinery palette. Grand Automaton (four-armed calculating machine), Gear Heart relic, Jarv ascending vault stairs onward.

### Finale — The Fractured Core
Void purple-black with fracture energy palette transitioning to dawn gold:
- Intro 1: The Fractured Core — ruined approach, vast void tear in sky
- Intro 2: The Force Within — fracture entity close-up, eyes within the void
- Intro 3: The End of the Road — Jarv small against the fracture, all relics visible
- Outro 1: The Fracture Closes — entity shattering, warm amber bleeding through
- Outro 2: Healing — panoramic triptych (Verdant, Core sealed, Ashen Wastes)
- Outro 3: Worldmender — dawn light, healed scar, Worldmender's Crest relic, Jarv facing us

## Test plan

- [ ] Build passes (`cd web && npm run build`)
- [ ] Cutscene panels display in-game for acts 10–13 and finale intros/outros
- [ ] All SVG files have correct `xmlns="http://www.w3.org/2000/svg"`

Closes #835
Closes #836

https://claude.ai/code/session_01GXML372usPatkqhfiuvdWX