### PR TITLE
Fix invalid SVG in act6-intro-3.svg

### DIFF
--- a/web/public/cutscenes/act1-intro-1.svg
+++ b/web/public/cutscenes/act1-intro-1.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#0a0a0a"/>
 
   <!-- Background glow at centre of fracture -->

--- a/web/public/cutscenes/act1-intro-2.svg
+++ b/web/public/cutscenes/act1-intro-2.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#0a0a0a"/>
 
   <!-- Horizon ground line -->

--- a/web/public/cutscenes/act1-intro-3.svg
+++ b/web/public/cutscenes/act1-intro-3.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#0a0a0a"/>
 
   <!-- Deep forest ambient gradient -->

--- a/web/public/cutscenes/act1-intro-4.svg
+++ b/web/public/cutscenes/act1-intro-4.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#0a0a0a"/>
 
   <!-- Forest path perspective — converging to a light at horizon -->

--- a/web/public/cutscenes/act1-outro-1.svg
+++ b/web/public/cutscenes/act1-outro-1.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#0a0a0a"/>
 
   <!-- Ambient light from fracturing roots -->

--- a/web/public/cutscenes/act1-outro-2.svg
+++ b/web/public/cutscenes/act1-outro-2.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#0a0a0a"/>
 
   <!-- Leaf litter on ground -->

--- a/web/public/cutscenes/act1-outro-3.svg
+++ b/web/public/cutscenes/act1-outro-3.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#0a0a0a"/>
 
   <!-- Open sky glow — path leads to light -->

--- a/web/public/cutscenes/act10-intro-1.svg
+++ b/web/public/cutscenes/act10-intro-1.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#0e0804"/>
 
   <linearGradient id="desert-sky" x1="0" y1="0" x2="0" y2="1">

--- a/web/public/cutscenes/act10-intro-2.svg
+++ b/web/public/cutscenes/act10-intro-2.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#0e0804"/>
 
   <linearGradient id="baron-sky" x1="0" y1="0" x2="0" y2="1">

--- a/web/public/cutscenes/act10-intro-3.svg
+++ b/web/public/cutscenes/act10-intro-3.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#0e0804"/>
   <linearGradient id="market-sky" x1="0" y1="0" x2="0" y2="1">
     <stop offset="0%" stop-color="#100e06"/>

--- a/web/public/cutscenes/act10-outro-1.svg
+++ b/web/public/cutscenes/act10-outro-1.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#0e0804"/>
   <linearGradient id="settle-sky" x1="0" y1="0" x2="0" y2="1">
     <stop offset="0%" stop-color="#100e06"/>

--- a/web/public/cutscenes/act10-outro-2.svg
+++ b/web/public/cutscenes/act10-outro-2.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#0e0804"/>
   <linearGradient id="deal-sky" x1="0" y1="0" x2="0" y2="1">
     <stop offset="0%" stop-color="#100e06"/>

--- a/web/public/cutscenes/act10-outro-3.svg
+++ b/web/public/cutscenes/act10-outro-3.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#0e0804"/>
   <linearGradient id="comp-sky" x1="0" y1="0" x2="0" y2="1">
     <stop offset="0%" stop-color="#100e06"/>

--- a/web/public/cutscenes/act11-intro-1.svg
+++ b/web/public/cutscenes/act11-intro-1.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#030802"/>
 
   <linearGradient id="canopy-sky" x1="0" y1="0" x2="0" y2="1">

--- a/web/public/cutscenes/act11-intro-2.svg
+++ b/web/public/cutscenes/act11-intro-2.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#030802"/>
   <linearGradient id="warden-sky" x1="0" y1="0" x2="0" y2="1">
     <stop offset="0%" stop-color="#040a02"/>

--- a/web/public/cutscenes/act11-intro-3.svg
+++ b/web/public/cutscenes/act11-intro-3.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#030802"/>
   <linearGradient id="path-sky" x1="0" y1="0" x2="0" y2="1">
     <stop offset="0%" stop-color="#040a02"/>

--- a/web/public/cutscenes/act11-outro-1.svg
+++ b/web/public/cutscenes/act11-outro-1.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#030802"/>
   <linearGradient id="yield-sky" x1="0" y1="0" x2="0" y2="1">
     <stop offset="0%" stop-color="#040a02"/>

--- a/web/public/cutscenes/act11-outro-2.svg
+++ b/web/public/cutscenes/act11-outro-2.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#030802"/>
   <linearGradient id="bark-sky" x1="0" y1="0" x2="0" y2="1">
     <stop offset="0%" stop-color="#040a02"/>

--- a/web/public/cutscenes/act11-outro-3.svg
+++ b/web/public/cutscenes/act11-outro-3.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#030802"/>
   <linearGradient id="road11-sky" x1="0" y1="0" x2="0" y2="1">
     <stop offset="0%" stop-color="#040a02"/>

--- a/web/public/cutscenes/act12-intro-1.svg
+++ b/web/public/cutscenes/act12-intro-1.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#040810"/>
 
   <linearGradient id="coast-sky" x1="0" y1="0" x2="0" y2="1">

--- a/web/public/cutscenes/act12-intro-2.svg
+++ b/web/public/cutscenes/act12-intro-2.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#040810"/>
   <linearGradient id="hm-sky" x1="0" y1="0" x2="0" y2="1">
     <stop offset="0%" stop-color="#060a14"/>

--- a/web/public/cutscenes/act12-intro-3.svg
+++ b/web/public/cutscenes/act12-intro-3.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#040810"/>
   <linearGradient id="permit-sky" x1="0" y1="0" x2="0" y2="1">
     <stop offset="0%" stop-color="#060a14"/>

--- a/web/public/cutscenes/act12-outro-1.svg
+++ b/web/public/cutscenes/act12-outro-1.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#040810"/>
   <linearGradient id="break-sky" x1="0" y1="0" x2="0" y2="1">
     <stop offset="0%" stop-color="#060a14"/>

--- a/web/public/cutscenes/act12-outro-2.svg
+++ b/web/public/cutscenes/act12-outro-2.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#040810"/>
   <linearGradient id="hook-sky" x1="0" y1="0" x2="0" y2="1">
     <stop offset="0%" stop-color="#060a14"/>

--- a/web/public/cutscenes/act12-outro-3.svg
+++ b/web/public/cutscenes/act12-outro-3.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#040810"/>
   <linearGradient id="horizon-sky" x1="0" y1="0" x2="0" y2="1">
     <stop offset="0%" stop-color="#060a14"/>

--- a/web/public/cutscenes/act13-intro-1.svg
+++ b/web/public/cutscenes/act13-intro-1.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#070502"/>
 
   <linearGradient id="vault-sky" x1="0" y1="0" x2="0" y2="1">

--- a/web/public/cutscenes/act13-intro-2.svg
+++ b/web/public/cutscenes/act13-intro-2.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#070502"/>
   <linearGradient id="auto-sky" x1="0" y1="0" x2="0" y2="1">
     <stop offset="0%" stop-color="#080602"/>

--- a/web/public/cutscenes/act13-intro-3.svg
+++ b/web/public/cutscenes/act13-intro-3.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#070502"/>
   <linearGradient id="within-sky" x1="0" y1="0" x2="0" y2="1">
     <stop offset="0%" stop-color="#080602"/>

--- a/web/public/cutscenes/act13-outro-1.svg
+++ b/web/public/cutscenes/act13-outro-1.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#070502"/>
   <linearGradient id="offline-sky" x1="0" y1="0" x2="0" y2="1">
     <stop offset="0%" stop-color="#080602"/>

--- a/web/public/cutscenes/act13-outro-2.svg
+++ b/web/public/cutscenes/act13-outro-2.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#070502"/>
   <linearGradient id="gear-sky" x1="0" y1="0" x2="0" y2="1">
     <stop offset="0%" stop-color="#080602"/>

--- a/web/public/cutscenes/act13-outro-3.svg
+++ b/web/public/cutscenes/act13-outro-3.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#070502"/>
   <linearGradient id="ascend-sky" x1="0" y1="0" x2="0" y2="1">
     <stop offset="0%" stop-color="#0a0806"/>

--- a/web/public/cutscenes/act2-intro-1.svg
+++ b/web/public/cutscenes/act2-intro-1.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#08090c"/>
 
   <!-- Dark sky gradient -->

--- a/web/public/cutscenes/act2-intro-2.svg
+++ b/web/public/cutscenes/act2-intro-2.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#08090c"/>
 
   <!-- Dark overcast sky -->

--- a/web/public/cutscenes/act2-intro-3.svg
+++ b/web/public/cutscenes/act2-intro-3.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#08090c"/>
 
   <!-- Canyon atmosphere — hazy sky -->

--- a/web/public/cutscenes/act2-intro-4.svg
+++ b/web/public/cutscenes/act2-intro-4.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#08090c"/>
 
   <!-- Dark background -->

--- a/web/public/cutscenes/act2-outro-1.svg
+++ b/web/public/cutscenes/act2-outro-1.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#08090c"/>
 
   <!-- Light flooding through the open gate — the key element -->

--- a/web/public/cutscenes/act2-outro-2.svg
+++ b/web/public/cutscenes/act2-outro-2.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#08090c"/>
 
   <!-- Armoury interior — dark stone walls -->

--- a/web/public/cutscenes/act3-intro-1.svg
+++ b/web/public/cutscenes/act3-intro-1.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#090908"/>
 
   <!-- Ashen sky — hazy smoke gradient -->

--- a/web/public/cutscenes/act3-intro-2.svg
+++ b/web/public/cutscenes/act3-intro-2.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#090908"/>
 
   <!-- Smoky ashen sky -->

--- a/web/public/cutscenes/act3-intro-3.svg
+++ b/web/public/cutscenes/act3-intro-3.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#090908"/>
 
   <!-- Smoky overcast sky — almost no distinction between sky and land -->

--- a/web/public/cutscenes/act3-intro-4.svg
+++ b/web/public/cutscenes/act3-intro-4.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#090908"/>
 
   <!-- Dark background with ember glow at centre -->

--- a/web/public/cutscenes/act3-outro-1.svg
+++ b/web/public/cutscenes/act3-outro-1.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#090908"/>
 
   <!-- Fading ember glow at centre — the collapse point -->

--- a/web/public/cutscenes/act3-outro-2.svg
+++ b/web/public/cutscenes/act3-outro-2.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#090908"/>
 
   <!-- Background — the still aftermath, ash ground, dying embers -->

--- a/web/public/cutscenes/act4-intro-1.svg
+++ b/web/public/cutscenes/act4-intro-1.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#06040e"/>
 
   <!-- Deep arcane sky -->

--- a/web/public/cutscenes/act4-intro-2.svg
+++ b/web/public/cutscenes/act4-intro-2.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#06040e"/>
 
   <!-- Deep arcane sky -->

--- a/web/public/cutscenes/act4-intro-3.svg
+++ b/web/public/cutscenes/act4-intro-3.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#06040e"/>
 
   <!-- Interior — deep arcane chamber glow -->

--- a/web/public/cutscenes/act4-intro-4.svg
+++ b/web/public/cutscenes/act4-intro-4.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#06040e"/>
 
   <!-- Arcane background glow -->

--- a/web/public/cutscenes/act4-outro-1.svg
+++ b/web/public/cutscenes/act4-outro-1.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#06040e"/>
 
   <!-- Fading arcane glow — dying down from centre -->

--- a/web/public/cutscenes/act4-outro-2.svg
+++ b/web/public/cutscenes/act4-outro-2.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#06040e"/>
 
   <!-- Archive interior — dim, orderly -->

--- a/web/public/cutscenes/act5-intro-1.svg
+++ b/web/public/cutscenes/act5-intro-1.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#04080e"/>
 
   <!-- Deep ocean gradient — dark above, slightly lighter at depth -->

--- a/web/public/cutscenes/act5-intro-2.svg
+++ b/web/public/cutscenes/act5-intro-2.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#04080e"/>
 
   <linearGradient id="sov-bg" x1="0" y1="0" x2="0" y2="1">

--- a/web/public/cutscenes/act5-intro-3.svg
+++ b/web/public/cutscenes/act5-intro-3.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#04080e"/>
 
   <linearGradient id="ley-bg" x1="0" y1="0" x2="0" y2="1">

--- a/web/public/cutscenes/act5-outro-1.svg
+++ b/web/public/cutscenes/act5-outro-1.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#04080e"/>
 
   <linearGradient id="recede-bg" x1="0" y1="0" x2="0" y2="1">

--- a/web/public/cutscenes/act5-outro-2.svg
+++ b/web/public/cutscenes/act5-outro-2.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#04080e"/>
 
   <radialGradient id="mem-glow" cx="50%" cy="45%" r="50%">

--- a/web/public/cutscenes/act5-outro-3.svg
+++ b/web/public/cutscenes/act5-outro-3.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#04080e"/>
 
   <linearGradient id="onward-sky" x1="0" y1="0" x2="0" y2="1">

--- a/web/public/cutscenes/act6-intro-1.svg
+++ b/web/public/cutscenes/act6-intro-1.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#06091a"/>
 
   <!-- Sky gradient — high altitude blues -->

--- a/web/public/cutscenes/act6-intro-2.svg
+++ b/web/public/cutscenes/act6-intro-2.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#06091a"/>
 
   <linearGradient id="cm-sky" x1="0" y1="0" x2="0" y2="1">

--- a/web/public/cutscenes/act6-intro-3.svg
+++ b/web/public/cutscenes/act6-intro-3.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#06091a"/>
 
   <linearGradient id="ley6-sky" x1="0" y1="0" x2="0" y2="1">

--- a/web/public/cutscenes/act6-intro-3.svg
+++ b/web/public/cutscenes/act6-intro-3.svg
@@ -50,7 +50,7 @@
       <path d="M96,145 L90,157 L98,157 L92,169"/>
     </g>
     <!-- Outer glow -->
-    <radialGradient id="ley-glow-l" cx="50%" cy="50%" r="50%" gradientUnits="userSpaceOnUse" cx="100" cy="120" r="30">
+    <radialGradient id="ley-glow-l" gradientUnits="userSpaceOnUse" cx="100" cy="120" r="30">
       <stop offset="0%" stop-color="#2060c0" stop-opacity="0.3"/>
       <stop offset="100%" stop-color="#2060c0" stop-opacity="0"/>
     </radialGradient>
@@ -111,7 +111,7 @@
 
   <!-- Centre island top anchor -->
   <rect x="178" y="38" width="44" height="10" rx="2" fill="#0e1828" stroke="#1a2838" stroke-width="1"/>
-  <rect x="178" y="38" width="44" height="10" rx="2" fill="url(#anchor-l)" opacity="1.2"/>
+  <rect x="178" y="38" width="44" height="10" rx="2" fill="url(#anchor-l)"/>
 
   <!-- Right island top anchor -->
   <rect x="278" y="46" width="44" height="10" rx="2" fill="#0e1828" stroke="#1a2838" stroke-width="1"/>

--- a/web/public/cutscenes/act6-outro-1.svg
+++ b/web/public/cutscenes/act6-outro-1.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#06091a"/>
 
   <linearGradient id="calm-sky" x1="0" y1="0" x2="0" y2="1">

--- a/web/public/cutscenes/act6-outro-2.svg
+++ b/web/public/cutscenes/act6-outro-2.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#06091a"/>
 
   <linearGradient id="still-sky" x1="0" y1="0" x2="0" y2="1">

--- a/web/public/cutscenes/act6-outro-3.svg
+++ b/web/public/cutscenes/act6-outro-3.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#05081a"/>
 
   <linearGradient id="ascent-sky" x1="0" y1="0" x2="0" y2="1">

--- a/web/public/cutscenes/act7-intro-1.svg
+++ b/web/public/cutscenes/act7-intro-1.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#080402"/>
 
   <linearGradient id="ember-sky" x1="0" y1="0" x2="0" y2="1">

--- a/web/public/cutscenes/act7-intro-2.svg
+++ b/web/public/cutscenes/act7-intro-2.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#080402"/>
 
   <linearGradient id="cin-sky" x1="0" y1="0" x2="0" y2="1">

--- a/web/public/cutscenes/act7-intro-3.svg
+++ b/web/public/cutscenes/act7-intro-3.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#060301"/>
 
   <linearGradient id="deep-rock" x1="0" y1="0" x2="0" y2="1">

--- a/web/public/cutscenes/act7-outro-1.svg
+++ b/web/public/cutscenes/act7-outro-1.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#060301"/>
 
   <linearGradient id="caldera-sky" x1="0" y1="0" x2="0" y2="1">

--- a/web/public/cutscenes/act7-outro-2.svg
+++ b/web/public/cutscenes/act7-outro-2.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#060301"/>
 
   <linearGradient id="still-caldera" x1="0" y1="0" x2="0" y2="1">

--- a/web/public/cutscenes/act7-outro-3.svg
+++ b/web/public/cutscenes/act7-outro-3.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#060301"/>
 
   <linearGradient id="magma-sky" x1="0" y1="0" x2="0" y2="1">

--- a/web/public/cutscenes/act8-intro-1.svg
+++ b/web/public/cutscenes/act8-intro-1.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#030206"/>
 
   <linearGradient id="deep-sky" x1="0" y1="0" x2="0" y2="1">

--- a/web/public/cutscenes/act8-intro-2.svg
+++ b/web/public/cutscenes/act8-intro-2.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#030206"/>
 
   <linearGradient id="rq-sky" x1="0" y1="0" x2="0" y2="1">

--- a/web/public/cutscenes/act8-intro-3.svg
+++ b/web/public/cutscenes/act8-intro-3.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#030206"/>
 
   <linearGradient id="under-sky" x1="0" y1="0" x2="0" y2="1">

--- a/web/public/cutscenes/act8-outro-1.svg
+++ b/web/public/cutscenes/act8-outro-1.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#030206"/>
 
   <linearGradient id="still-deep" x1="0" y1="0" x2="0" y2="1">

--- a/web/public/cutscenes/act8-outro-2.svg
+++ b/web/public/cutscenes/act8-outro-2.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#030206"/>
 
   <linearGradient id="quiet-deep" x1="0" y1="0" x2="0" y2="1">

--- a/web/public/cutscenes/act8-outro-3.svg
+++ b/web/public/cutscenes/act8-outro-3.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#030206"/>
 
   <linearGradient id="spore-sky" x1="0" y1="0" x2="0" y2="1">

--- a/web/public/cutscenes/act9-intro-1.svg
+++ b/web/public/cutscenes/act9-intro-1.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#030810"/>
 
   <linearGradient id="ice-sky" x1="0" y1="0" x2="0" y2="1">

--- a/web/public/cutscenes/act9-intro-2.svg
+++ b/web/public/cutscenes/act9-intro-2.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#030810"/>
 
   <linearGradient id="eng-sky" x1="0" y1="0" x2="0" y2="1">

--- a/web/public/cutscenes/act9-intro-3.svg
+++ b/web/public/cutscenes/act9-intro-3.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#050c18"/>
 
   <linearGradient id="white-sky" x1="0" y1="0" x2="0" y2="1">

--- a/web/public/cutscenes/act9-outro-1.svg
+++ b/web/public/cutscenes/act9-outro-1.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#030810"/>
 
   <linearGradient id="halt-sky" x1="0" y1="0" x2="0" y2="1">

--- a/web/public/cutscenes/act9-outro-2.svg
+++ b/web/public/cutscenes/act9-outro-2.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#030810"/>
 
   <linearGradient id="proc-sky" x1="0" y1="0" x2="0" y2="1">

--- a/web/public/cutscenes/act9-outro-3.svg
+++ b/web/public/cutscenes/act9-outro-3.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#030810"/>
 
   <linearGradient id="frost-sky" x1="0" y1="0" x2="0" y2="1">

--- a/web/public/cutscenes/actfinale-intro-1.svg
+++ b/web/public/cutscenes/actfinale-intro-1.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#060408"/>
   <linearGradient id="void-sky" x1="0" y1="0" x2="0" y2="1">
     <stop offset="0%" stop-color="#0c0618"/>

--- a/web/public/cutscenes/actfinale-intro-2.svg
+++ b/web/public/cutscenes/actfinale-intro-2.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#040208"/>
 
   <!-- Deep void atmosphere — radial darkness -->

--- a/web/public/cutscenes/actfinale-intro-3.svg
+++ b/web/public/cutscenes/actfinale-intro-3.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#060408"/>
   <linearGradient id="road-sky" x1="0" y1="0" x2="0" y2="1">
     <stop offset="0%" stop-color="#0e0620"/>

--- a/web/public/cutscenes/actfinale-outro-1.svg
+++ b/web/public/cutscenes/actfinale-outro-1.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#060408"/>
   <linearGradient id="closing-sky" x1="0" y1="0" x2="0" y2="1">
     <stop offset="0%" stop-color="#0e0620"/>

--- a/web/public/cutscenes/actfinale-outro-2.svg
+++ b/web/public/cutscenes/actfinale-outro-2.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#080608"/>
   <linearGradient id="healing-sky" x1="0" y1="0" x2="0" y2="1">
     <stop offset="0%" stop-color="#0c0a14"/>

--- a/web/public/cutscenes/actfinale-outro-3.svg
+++ b/web/public/cutscenes/actfinale-outro-3.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#080608"/>
   <linearGradient id="dawn-sky" x1="0" y1="0" x2="0" y2="1">
     <stop offset="0%" stop-color="#100c18"/>


### PR DESCRIPTION
## Summary

- Remove duplicate `cx`/`cy`/`r` attributes on `radialGradient#ley-glow-l` — duplicate attributes are invalid XML and cause SVG parsers to reject the file
- Remove `opacity="1.2"` on the centre anchor rect — opacity must be in the range 0–1

https://claude.ai/code/session_017jxQ6HEs6k4FaX5mjkKdvC

---
_Generated by [Claude Code](https://claude.ai/code/session_017jxQ6HEs6k4FaX5mjkKdvC)_