### PR TITLE
Add Act 8 boss intro cutscene (The Root Queen)

### DIFF
--- a/web/public/cutscenes/act8-boss-1.svg
+++ b/web/public/cutscenes/act8-boss-1.svg
@@ -1,0 +1,127 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
+  <rect width="400" height="240" fill="#030206"/>
+  <linearGradient id="boss-deep" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#050108"/>
+    <stop offset="50%" stop-color="#06020a"/>
+    <stop offset="100%" stop-color="#08040c"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#boss-deep)"/>
+
+  <!-- Bioluminescent teal atmosphere — deep at the root queen's threshold -->
+  <radialGradient id="bq-threshold" cx="50%" cy="55%" r="55%">
+    <stop offset="0%" stop-color="#004040" stop-opacity="0.35"/>
+    <stop offset="60%" stop-color="#002828" stop-opacity="0.12"/>
+    <stop offset="100%" stop-color="#002828" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#bq-threshold)"/>
+
+  <!-- CEILING — dense mycelium canopy, roots hanging down -->
+  <rect x="0" y="0" width="400" height="45" fill="#050108"/>
+  <!-- Ceiling root mass -->
+  <g fill="#120620" opacity="0.9">
+    <ellipse cx="80"  cy="0" rx="55" ry="30"/>
+    <ellipse cx="200" cy="0" rx="70" ry="35"/>
+    <ellipse cx="320" cy="0" rx="55" ry="28"/>
+  </g>
+  <!-- Hanging root tendrils from ceiling -->
+  <g stroke="#1a0830" stroke-width="2.5" fill="none" opacity="0.8">
+    <path d="M55,0  Q52,20 58,42 Q62,55 55,70"/>
+    <path d="M80,0  Q78,25 85,48 Q88,62 80,78"/>
+    <path d="M120,0 Q118,18 125,38 Q128,52 122,66"/>
+    <path d="M175,0 Q172,22 180,45 Q183,60 175,78"/>
+    <path d="M200,0 Q197,28 205,52 Q208,68 200,88"/>
+    <path d="M225,0 Q228,22 220,45 Q217,60 225,78"/>
+    <path d="M280,0 Q282,18 275,38 Q272,52 278,66"/>
+    <path d="M320,0 Q322,25 315,48 Q312,62 320,78"/>
+    <path d="M345,0 Q348,20 342,42 Q338,55 345,70"/>
+  </g>
+  <!-- Bioluminescent nodes on ceiling tendrils -->
+  <g fill="#00c090" opacity="0.5">
+    <circle cx="55"  cy="70" r="2.5"/>
+    <circle cx="80"  cy="78" r="3"/>
+    <circle cx="122" cy="66" r="2"/>
+    <circle cx="175" cy="78" r="2.5"/>
+    <circle cx="200" cy="88" r="3.5"/>
+    <circle cx="225" cy="78" r="2.5"/>
+    <circle cx="278" cy="66" r="2"/>
+    <circle cx="320" cy="78" r="3"/>
+    <circle cx="345" cy="70" r="2.5"/>
+  </g>
+
+  <!-- FLOOR — mycelium mat, root veins spreading -->
+  <rect x="0" y="188" width="400" height="52" fill="#060108"/>
+  <!-- Floor root veins — converging toward centre -->
+  <g stroke="#1a0830" stroke-width="2" fill="none" opacity="0.7">
+    <path d="M0,220   Q80,210  140,200 Q170,196 200,194"/>
+    <path d="M400,220 Q320,210 260,200 Q230,196 200,194"/>
+    <path d="M0,235   Q100,225 160,210 Q180,204 200,200"/>
+    <path d="M400,235 Q300,225 240,210 Q220,204 200,200"/>
+    <path d="M50,240  Q120,228 170,215 Q185,210 200,206"/>
+    <path d="M350,240 Q280,228 230,215 Q215,210 200,206"/>
+  </g>
+  <!-- Floor glow nodes along veins -->
+  <g fill="#008060" opacity="0.4">
+    <circle cx="110" cy="210" r="2"/>
+    <circle cx="155" cy="202" r="2.5"/>
+    <circle cx="290" cy="210" r="2"/>
+    <circle cx="245" cy="202" r="2.5"/>
+    <circle cx="200" cy="196" r="3"/>
+  </g>
+
+  <!-- WALLS — left and right root columns -->
+  <!-- Left wall roots -->
+  <g stroke="#180628" stroke-width="3" fill="none" opacity="0.6">
+    <path d="M0,60  Q25,80  18,120 Q12,155 25,188"/>
+    <path d="M0,80  Q30,105 22,145 Q16,170 30,188"/>
+    <path d="M0,100 Q20,130 15,165 Q10,180 20,188"/>
+  </g>
+  <!-- Right wall roots -->
+  <g stroke="#180628" stroke-width="3" fill="none" opacity="0.6">
+    <path d="M400,60  Q375,80  382,120 Q388,155 375,188"/>
+    <path d="M400,80  Q370,105 378,145 Q384,170 370,188"/>
+    <path d="M400,100 Q380,130 385,165 Q390,180 380,188"/>
+  </g>
+
+  <!-- CONVERGING ROOT CORRIDOR — tunnelling toward the void at centre-back -->
+  <!-- Left side rails of the corridor -->
+  <path d="M0,188 Q80,175 130,160 Q165,150 200,140" stroke="#200840" stroke-width="2" fill="none" opacity="0.7"/>
+  <path d="M0,108 Q80,118 130,128 Q165,134 200,140"  stroke="#200840" stroke-width="2" fill="none" opacity="0.7"/>
+  <!-- Right side rails -->
+  <path d="M400,188 Q320,175 270,160 Q235,150 200,140" stroke="#200840" stroke-width="2" fill="none" opacity="0.7"/>
+  <path d="M400,108 Q320,118 270,128 Q235,134 200,140" stroke="#200840" stroke-width="2" fill="none" opacity="0.7"/>
+
+  <!-- THE VOID AHEAD — the Root Queen's chamber entrance -->
+  <radialGradient id="bq-void" cx="50%" cy="58%" r="22%">
+    <stop offset="0%" stop-color="#000808" stop-opacity="1"/>
+    <stop offset="50%" stop-color="#001818" stop-opacity="0.9"/>
+    <stop offset="100%" stop-color="#001818" stop-opacity="0"/>
+  </radialGradient>
+  <ellipse cx="200" cy="140" rx="65" ry="50" fill="url(#bq-void)"/>
+  <!-- Void border glow — teal pulse emanating from within -->
+  <ellipse cx="200" cy="140" rx="65" ry="50" fill="none" stroke="#00c090" stroke-width="1.5" opacity="0.35"/>
+  <ellipse cx="200" cy="140" rx="52" ry="40" fill="none" stroke="#00a070" stroke-width="0.8" opacity="0.25"/>
+  <!-- Inner tendrils reaching from the void outward -->
+  <g stroke="#00c090" stroke-width="0.8" fill="none" opacity="0.3">
+    <path d="M200,90  Q196,110 200,130"/>
+    <path d="M200,90  Q204,110 200,130"/>
+    <path d="M155,120 Q170,128 185,135"/>
+    <path d="M245,120 Q230,128 215,135"/>
+  </g>
+
+  <!-- Floating spore particles -->
+  <g fill="#00c090" opacity="0.3">
+    <circle cx="95"  cy="95"  r="1.2"/>
+    <circle cx="148" cy="78"  r="1"/>
+    <circle cx="72"  cy="140" r="1.2"/>
+    <circle cx="135" cy="160" r="0.8"/>
+    <circle cx="258" cy="82"  r="1.2"/>
+    <circle cx="305" cy="95"  r="1"/>
+    <circle cx="328" cy="140" r="1.2"/>
+    <circle cx="265" cy="158" r="0.8"/>
+    <circle cx="180" cy="105" r="1"/>
+    <circle cx="220" cy="108" r="1"/>
+  </g>
+
+  <!-- Label -->
+  <text x="200" y="232" font-family="monospace" font-size="9" fill="#006040" text-anchor="middle" letter-spacing="3">THE DEEP REMEMBERS</text>
+</svg>

--- a/web/public/cutscenes/act8-boss-2.svg
+++ b/web/public/cutscenes/act8-boss-2.svg
@@ -1,0 +1,134 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
+  <rect width="400" height="240" fill="#030206"/>
+  <linearGradient id="rq-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#04010a"/>
+    <stop offset="50%" stop-color="#060208"/>
+    <stop offset="100%" stop-color="#0a040e"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#rq-sky)"/>
+
+  <!-- Root Queen chamber atmosphere -->
+  <radialGradient id="rq-glow" cx="50%" cy="45%" r="50%">
+    <stop offset="0%" stop-color="#004840" stop-opacity="0.5"/>
+    <stop offset="50%" stop-color="#003028" stop-opacity="0.2"/>
+    <stop offset="100%" stop-color="#003028" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#rq-glow)"/>
+
+  <!-- THE ROOT QUEEN — vast, non-humanoid, ancient -->
+  <!-- Outer root mass — spreading across the whole frame -->
+  <!-- Primary trunk — centre, massive -->
+  <path d="M200,240 Q195,210 198,185 Q200,160 200,140 Q200,120 200,105" stroke="#1a0830" stroke-width="22" stroke-linecap="round" fill="none"/>
+  <path d="M200,240 Q195,210 198,185 Q200,160 200,140 Q200,120 200,105" stroke="#250c3e" stroke-width="14" stroke-linecap="round" fill="none" opacity="0.6"/>
+
+  <!-- Major branches — radiating outward from trunk -->
+  <!-- Upper left major branch -->
+  <path d="M200,140 Q175,128 148,112 Q122,98  92,88" stroke="#1a0830" stroke-width="12" stroke-linecap="round" fill="none"/>
+  <path d="M200,140 Q175,128 148,112 Q122,98  92,88" stroke="#250c3e" stroke-width="7" stroke-linecap="round" fill="none" opacity="0.5"/>
+  <!-- Upper right major branch -->
+  <path d="M200,140 Q225,128 252,112 Q278,98  308,88" stroke="#1a0830" stroke-width="12" stroke-linecap="round" fill="none"/>
+  <path d="M200,140 Q225,128 252,112 Q278,98  308,88" stroke="#250c3e" stroke-width="7" stroke-linecap="round" fill="none" opacity="0.5"/>
+  <!-- Mid-left branch -->
+  <path d="M200,165 Q165,158 130,148 Q100,140 68,142" stroke="#180628" stroke-width="9" stroke-linecap="round" fill="none"/>
+  <!-- Mid-right branch -->
+  <path d="M200,165 Q235,158 270,148 Q300,140 332,142" stroke="#180628" stroke-width="9" stroke-linecap="round" fill="none"/>
+  <!-- Lower left spreading root -->
+  <path d="M200,200 Q158,195 115,188 Q75,182 35,185" stroke="#140520" stroke-width="7" stroke-linecap="round" fill="none"/>
+  <!-- Lower right spreading root -->
+  <path d="M200,200 Q242,195 285,188 Q325,182 365,185" stroke="#140520" stroke-width="7" stroke-linecap="round" fill="none"/>
+
+  <!-- Secondary branch system — sub-branches off majors -->
+  <g stroke="#160628" stroke-width="5" stroke-linecap="round" fill="none" opacity="0.8">
+    <path d="M148,112 Q130,100 108,95 Q88,92 70,98"/>
+    <path d="M92,88  Q72,82  52,84"/>
+    <path d="M148,112 Q138,96 132,78 Q128,65 135,52"/>
+    <path d="M252,112 Q272,100 292,95 Q310,92 330,98"/>
+    <path d="M308,88  Q328,82  348,84"/>
+    <path d="M252,112 Q262,96 268,78 Q272,65 265,52"/>
+  </g>
+
+  <!-- Tertiary rootlets — fine network -->
+  <g stroke="#200838" stroke-width="2" stroke-linecap="round" fill="none" opacity="0.6">
+    <path d="M108,95 Q95,88 80,90 Q65,92 55,100"/>
+    <path d="M135,52 Q128,38 132,24 Q136,12 142,5"/>
+    <path d="M135,52 Q120,45 108,48"/>
+    <path d="M265,52 Q272,38 268,24 Q264,12 258,5"/>
+    <path d="M265,52 Q280,45 292,48"/>
+    <path d="M292,95 Q305,88 320,90 Q335,92 345,100"/>
+    <path d="M68,142 Q45,138 22,140"/>
+    <path d="M332,142 Q355,138 378,140"/>
+    <path d="M35,185 Q18,182 5,188"/>
+    <path d="M365,185 Q382,182 395,188"/>
+  </g>
+
+  <!-- THE NODE-EYES — multiple, distributed across the root mass -->
+  <!-- Primary eye cluster — at the trunk convergence point -->
+  <circle cx="200" cy="115" r="14" fill="#060210" stroke="#00c090" stroke-width="1.5"/>
+  <circle cx="200" cy="115" r="9"  fill="#030108" stroke="#00e0b0" stroke-width="1"/>
+  <circle cx="200" cy="115" r="4"  fill="#00c090" opacity="0.7"/>
+  <circle cx="200" cy="115" r="2"  fill="#00f0d0" opacity="0.9"/>
+
+  <!-- Secondary eyes — on major branches -->
+  <circle cx="138" cy="110" r="8"  fill="#050110" stroke="#00c090" stroke-width="1.2"/>
+  <circle cx="138" cy="110" r="5"  fill="#020108" stroke="#00a070" stroke-width="0.8"/>
+  <circle cx="138" cy="110" r="2.5" fill="#00c090" opacity="0.8"/>
+
+  <circle cx="262" cy="110" r="8"  fill="#050110" stroke="#00c090" stroke-width="1.2"/>
+  <circle cx="262" cy="110" r="5"  fill="#020108" stroke="#00a070" stroke-width="0.8"/>
+  <circle cx="262" cy="110" r="2.5" fill="#00c090" opacity="0.8"/>
+
+  <!-- Smaller eye nodes scattered across branches -->
+  <g fill="#00c090" opacity="0.6">
+    <circle cx="80"  cy="92"  r="4"/>
+    <circle cx="320" cy="92"  r="4"/>
+    <circle cx="108" cy="142" r="3"/>
+    <circle cx="292" cy="142" r="3"/>
+    <circle cx="48"  cy="184" r="3"/>
+    <circle cx="352" cy="184" r="3"/>
+    <circle cx="140" cy="58"  r="2.5"/>
+    <circle cx="260" cy="58"  r="2.5"/>
+  </g>
+  <!-- Eye gleam highlights -->
+  <g fill="#00f0d0" opacity="0.7">
+    <circle cx="79"  cy="91"  r="1.5"/>
+    <circle cx="319" cy="91"  r="1.5"/>
+    <circle cx="107" cy="141" r="1.2"/>
+    <circle cx="291" cy="141" r="1.2"/>
+  </g>
+
+  <!-- Bioluminescent teal pulse veins — running along major branches -->
+  <g stroke="#00a070" stroke-width="0.8" fill="none" opacity="0.35">
+    <path d="M200,115 Q188,118 148,112"/>
+    <path d="M200,115 Q212,118 252,112"/>
+    <path d="M200,115 Q200,130 200,165"/>
+    <path d="M148,112 Q120,100 80,92"/>
+    <path d="M252,112 Q280,100 320,92"/>
+  </g>
+
+  <!-- Spore cloud — emanating from the Queen -->
+  <g fill="#00c090" opacity="0.2">
+    <circle cx="165" cy="90"  r="1.5"/>
+    <circle cx="172" cy="78"  r="1.2"/>
+    <circle cx="185" cy="68"  r="1"/>
+    <circle cx="215" cy="90"  r="1.5"/>
+    <circle cx="228" cy="78"  r="1.2"/>
+    <circle cx="218" cy="65"  r="1"/>
+    <circle cx="200" cy="72"  r="1.2"/>
+    <circle cx="155" cy="82"  r="1"/>
+    <circle cx="245" cy="80"  r="1"/>
+    <circle cx="118" cy="80"  r="1.2"/>
+    <circle cx="282" cy="78"  r="1.2"/>
+  </g>
+
+  <!-- Floor — root-covered stone -->
+  <rect x="0" y="205" width="400" height="35" fill="#060108"/>
+  <g stroke="#180628" stroke-width="0.8" fill="none" opacity="0.4">
+    <line x1="0" y1="205" x2="400" y2="205"/>
+    <path d="M200,205 Q195,215 198,235"/>
+    <path d="M150,205 Q145,218 148,235"/>
+    <path d="M250,205 Q255,218 252,235"/>
+  </g>
+
+  <!-- Label -->
+  <text x="200" y="232" font-family="monospace" font-size="9" fill="#006040" text-anchor="middle" letter-spacing="3">THE ROOT QUEEN</text>
+</svg>

--- a/web/src/data/acts/act8.json
+++ b/web/src/data/acts/act8.json
@@ -588,6 +588,16 @@
         "Spore Surge",
         "Mycelium Surge",
         "Deep Growth"
+      ],
+      "bossIntro": [
+        {
+          "image": "cutscenes/act8-boss-1.svg",
+          "text": "The network thickens. Every surface here breathes — wall, floor, ceiling interwoven with roots that pulse with slow, cold light. This is the oldest part of the Fungal Deep. Nothing here has ever been separate.\n\nSomething knows you are here."
+        },
+        {
+          "image": "cutscenes/act8-boss-2.svg",
+          "text": "She does not rise to meet you. She was already here — has always been here, rooted at the centre of everything, extending through every tendril you have ever seen in this place.\n\nThe Root Queen opens her eyes. All of them."
+        }
       ]
     },
     "node-1776871962308": {


### PR DESCRIPTION
## Summary

- Adds `act8-boss-1.svg` — atmospheric deep forest/mycelium corridor, bioluminescent teal glow, converging roots leading into the Root Queen's chamber
- Adds `act8-boss-2.svg` — the Root Queen revealed: vast non-humanoid branching mycelial form with distributed node-eyes across the root mass
- Wires `bossIntro` array into the `rootqueen` boss node in `act8.json`
- Both SVGs include `style="filter: brightness(1.4)"` per spec

## Test plan

- [ ] Boss intro cutscene displays when selecting the Root Queen node in Act 8
- [ ] Boss dialogue still plays after the cutscene
- [ ] Build passes

Closes #864

https://claude.ai/code/session_01GXML372usPatkqhfiuvdWX

---
_Generated by [Claude Code](https://claude.ai/code/session_01GXML372usPatkqhfiuvdWX)_