### PR TITLE
Fix missing title in act8 rootqueen bossIntro panels

### DIFF
--- a/web/src/data/acts/act8.json
+++ b/web/src/data/acts/act8.json
@@ -591,10 +591,12 @@
       ],
       "bossIntro": [
         {
+          "title": "THE DEEP REMEMBERS",
           "image": "cutscenes/act8-boss-1.svg",
           "text": "The network thickens. Every surface here breathes — wall, floor, ceiling interwoven with roots that pulse with slow, cold light. This is the oldest part of the Fungal Deep. Nothing here has ever been separate.\n\nSomething knows you are here."
         },
         {
+          "title": "THE ROOT QUEEN",
           "image": "cutscenes/act8-boss-2.svg",
           "text": "She does not rise to meet you. She was already here — has always been here, rooted at the centre of everything, extending through every tendril you have ever seen in this place.\n\nThe Root Queen opens her eyes. All of them."
         }


### PR DESCRIPTION
## Summary

`CutscenePanel` requires a `title` field, which was missing from the two `bossIntro` panels added to the `rootqueen` node in `act8.json`. This caused a TypeScript build failure after #876 merged.

Adds:
- `"title": "THE DEEP REMEMBERS"` to panel 1
- `"title": "THE ROOT QUEEN"` to panel 2

## Test plan

- [ ] `npm run build` passes

https://claude.ai/code/session_01GXML372usPatkqhfiuvdWX

---
_Generated by [Claude Code](https://claude.ai/code/session_01GXML372usPatkqhfiuvdWX)_