### PR TITLE
Add missing sprites — Batch 13/17: Upgrades D (Fortify → Iron Skin)

### DIFF
--- a/web/public/sprites/fortify.svg
+++ b/web/public/sprites/fortify.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Stone wall glow -->
+  <rect x="4" y="10" width="24" height="18" rx="1" fill="#6b7a5a" opacity="0.3"/>
+  <!-- Stone blocks row 1 -->
+  <rect x="4" y="16" width="11" height="6" rx="0.5" fill="#8a9070" stroke="#4a5040" stroke-width="0.5"/>
+  <rect x="16" y="16" width="12" height="6" rx="0.5" fill="#8a9070" stroke="#4a5040" stroke-width="0.5"/>
+  <!-- Stone blocks row 2 -->
+  <rect x="4" y="22" width="7" height="6" rx="0.5" fill="#7a8060" stroke="#4a5040" stroke-width="0.5"/>
+  <rect x="12" y="22" width="9" height="6" rx="0.5" fill="#7a8060" stroke="#4a5040" stroke-width="0.5"/>
+  <rect x="22" y="22" width="6" height="6" rx="0.5" fill="#7a8060" stroke="#4a5040" stroke-width="0.5"/>
+  <!-- Battlements (top) -->
+  <rect x="4" y="10" width="5" height="7" rx="0.5" fill="#8a9070" stroke="#4a5040" stroke-width="0.5"/>
+  <rect x="11" y="10" width="5" height="7" rx="0.5" fill="#8a9070" stroke="#4a5040" stroke-width="0.5"/>
+  <rect x="18" y="10" width="5" height="7" rx="0.5" fill="#8a9070" stroke="#4a5040" stroke-width="0.5"/>
+  <rect x="25" y="10" width="3" height="7" rx="0.5" fill="#8a9070" stroke="#4a5040" stroke-width="0.5"/>
+  <!-- Fortify glow aura -->
+  <ellipse cx="16" cy="19" rx="14" ry="10" fill="#aaffaa" opacity="0.1"/>
+  <!-- Gold fortify rune -->
+  <circle cx="16" cy="19" r="3.5" fill="#ffdd44" opacity="0.25"/>
+  <text x="16" y="21.5" font-size="6" text-anchor="middle" fill="#ffdd44" font-family="monospace" opacity="0.9">✦</text>
+</svg>

--- a/web/public/sprites/frost-surge.svg
+++ b/web/public/sprites/frost-surge.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Cold mist backdrop -->
+  <ellipse cx="16" cy="24" rx="13" ry="6" fill="#aaddff" opacity="0.2"/>
+  <!-- Ice crystals -->
+  <polygon points="16,4 18,10 16,8 14,10" fill="#cceeff" stroke="#66aadd" stroke-width="0.5"/>
+  <polygon points="16,4 13,9 16,7 19,9" fill="#aaddff" stroke="#66aadd" stroke-width="0.5"/>
+  <!-- Left crystal -->
+  <polygon points="7,10 9,16 7,14 5,16" fill="#cceeff" stroke="#66aadd" stroke-width="0.5"/>
+  <polygon points="7,10 4,15 7,13 10,15" fill="#aaddff" stroke="#66aadd" stroke-width="0.5"/>
+  <!-- Right crystal -->
+  <polygon points="25,10 27,16 25,14 23,16" fill="#cceeff" stroke="#66aadd" stroke-width="0.5"/>
+  <polygon points="25,10 22,15 25,13 28,15" fill="#aaddff" stroke="#66aadd" stroke-width="0.5"/>
+  <!-- Frost wave -->
+  <path d="M3 22 Q8 18 13 22 Q18 26 23 22 Q27 18 30 22" stroke="#88ccff" stroke-width="1.5" fill="none" stroke-linecap="round"/>
+  <path d="M3 25 Q8 21 13 25 Q18 29 23 25 Q27 21 30 25" stroke="#aaddff" stroke-width="1" fill="none" stroke-linecap="round" opacity="0.6"/>
+  <!-- Snowflake sparkles -->
+  <circle cx="10" cy="20" r="1" fill="#ffffff" opacity="0.8"/>
+  <circle cx="16" cy="17" r="1.2" fill="#ffffff" opacity="0.9"/>
+  <circle cx="22" cy="20" r="1" fill="#ffffff" opacity="0.8"/>
+  <circle cx="6" cy="18" r="0.7" fill="#cceeff" opacity="0.7"/>
+  <circle cx="26" cy="18" r="0.7" fill="#cceeff" opacity="0.7"/>
+</svg>

--- a/web/public/sprites/fungal-bloom.svg
+++ b/web/public/sprites/fungal-bloom.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground -->
+  <ellipse cx="16" cy="28" rx="12" ry="3" fill="#5a3a1a" opacity="0.4"/>
+  <!-- Large mushroom stem -->
+  <rect x="13" y="17" width="6" height="10" rx="1" fill="#e8d5b0" stroke="#a08050" stroke-width="0.5"/>
+  <!-- Large mushroom cap -->
+  <ellipse cx="16" cy="17" rx="10" ry="6" fill="#8b3a8b" stroke="#5a1a5a" stroke-width="0.5"/>
+  <ellipse cx="16" cy="17" rx="7" ry="4" fill="#a04aaa" opacity="0.7"/>
+  <!-- Cap spots -->
+  <circle cx="12" cy="15" r="1.5" fill="#ffffff" opacity="0.6"/>
+  <circle cx="18" cy="14" r="1.2" fill="#ffffff" opacity="0.6"/>
+  <circle cx="22" cy="16" r="1" fill="#ffffff" opacity="0.5"/>
+  <!-- Small mushroom left -->
+  <rect x="5" y="22" width="3" height="5" rx="0.5" fill="#e8d5b0" stroke="#a08050" stroke-width="0.4"/>
+  <ellipse cx="6.5" cy="22" rx="4" ry="2.5" fill="#cc66aa" stroke="#882255" stroke-width="0.4"/>
+  <!-- Small mushroom right -->
+  <rect x="24" y="23" width="3" height="4" rx="0.5" fill="#e8d5b0" stroke="#a08050" stroke-width="0.4"/>
+  <ellipse cx="25.5" cy="23" rx="3.5" ry="2" fill="#cc66aa" stroke="#882255" stroke-width="0.4"/>
+  <!-- Spore particles -->
+  <circle cx="9" cy="12" r="0.8" fill="#dd88ff" opacity="0.7"/>
+  <circle cx="14" cy="9" r="0.6" fill="#dd88ff" opacity="0.7"/>
+  <circle cx="21" cy="10" r="0.7" fill="#dd88ff" opacity="0.6"/>
+  <circle cx="25" cy="13" r="0.5" fill="#dd88ff" opacity="0.6"/>
+  <circle cx="7" cy="17" r="0.6" fill="#cc66ff" opacity="0.5"/>
+</svg>

--- a/web/public/sprites/gear-sprint.svg
+++ b/web/public/sprites/gear-sprint.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Speed trail lines -->
+  <line x1="2" y1="13" x2="12" y2="13" stroke="#aaaaaa" stroke-width="1" stroke-linecap="round" opacity="0.5"/>
+  <line x1="2" y1="16" x2="10" y2="16" stroke="#aaaaaa" stroke-width="1.5" stroke-linecap="round" opacity="0.6"/>
+  <line x1="2" y1="19" x2="12" y2="19" stroke="#aaaaaa" stroke-width="1" stroke-linecap="round" opacity="0.5"/>
+  <!-- Gear body -->
+  <circle cx="20" cy="16" r="8" fill="#888888" stroke="#555555" stroke-width="0.8"/>
+  <circle cx="20" cy="16" r="5.5" fill="#aaaaaa" stroke="#666666" stroke-width="0.6"/>
+  <circle cx="20" cy="16" r="2" fill="#444444"/>
+  <!-- Gear teeth -->
+  <rect x="18.5" y="7" width="3" height="2.5" rx="0.5" fill="#888888" stroke="#555555" stroke-width="0.5"/>
+  <rect x="18.5" y="22.5" width="3" height="2.5" rx="0.5" fill="#888888" stroke="#555555" stroke-width="0.5"/>
+  <rect x="11" y="14.5" width="2.5" height="3" rx="0.5" fill="#888888" stroke="#555555" stroke-width="0.5"/>
+  <rect x="26.5" y="14.5" width="2.5" height="3" rx="0.5" fill="#888888" stroke="#555555" stroke-width="0.5"/>
+  <rect x="12.5" y="9.5" width="2.5" height="2.5" rx="0.5" fill="#888888" stroke="#555555" stroke-width="0.5" transform="rotate(-45 13.75 10.75)"/>
+  <rect x="24.5" y="9.5" width="2.5" height="2.5" rx="0.5" fill="#888888" stroke="#555555" stroke-width="0.5" transform="rotate(45 25.75 10.75)"/>
+  <rect x="12.5" y="19.5" width="2.5" height="2.5" rx="0.5" fill="#888888" stroke="#555555" stroke-width="0.5" transform="rotate(45 13.75 20.75)"/>
+  <rect x="24.5" y="19.5" width="2.5" height="2.5" rx="0.5" fill="#888888" stroke="#555555" stroke-width="0.5" transform="rotate(-45 25.75 20.75)"/>
+  <!-- Speed glow -->
+  <ellipse cx="20" cy="16" rx="9" ry="9" fill="#ffaa00" opacity="0.1"/>
+</svg>

--- a/web/public/sprites/glacier-hide.svg
+++ b/web/public/sprites/glacier-hide.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ice armor silhouette -->
+  <ellipse cx="16" cy="10" rx="6" ry="5" fill="#cceeff" stroke="#66aacc" stroke-width="0.6" opacity="0.9"/>
+  <!-- Body shield -->
+  <rect x="10" y="14" width="12" height="12" rx="2" fill="#aaddee" stroke="#66aacc" stroke-width="0.6" opacity="0.9"/>
+  <!-- Ice plate facets on shield -->
+  <polygon points="10,14 16,10 22,14 22,20 16,24 10,20" fill="none" stroke="#88ccee" stroke-width="0.8" opacity="0.7"/>
+  <line x1="16" y1="10" x2="16" y2="24" stroke="#88ccee" stroke-width="0.5" opacity="0.5"/>
+  <line x1="10" y1="17" x2="22" y2="17" stroke="#88ccee" stroke-width="0.5" opacity="0.5"/>
+  <!-- Ice shards protruding -->
+  <polygon points="6,12 8,16 5,18" fill="#cceeff" stroke="#66aacc" stroke-width="0.4"/>
+  <polygon points="26,12 24,16 27,18" fill="#cceeff" stroke="#66aacc" stroke-width="0.4"/>
+  <polygon points="14,3 16,7 12,6" fill="#ddeeff" stroke="#66aacc" stroke-width="0.4"/>
+  <polygon points="18,3 16,7 20,6" fill="#ddeeff" stroke="#66aacc" stroke-width="0.4"/>
+  <!-- Frost shimmer highlights -->
+  <ellipse cx="14" cy="15" rx="2" ry="1.5" fill="#ffffff" opacity="0.4"/>
+  <ellipse cx="19" cy="19" rx="1.5" ry="1" fill="#ffffff" opacity="0.3"/>
+  <!-- Camouflage dots -->
+  <circle cx="13" cy="20" r="0.8" fill="#88bbcc" opacity="0.5"/>
+  <circle cx="19" cy="22" r="0.6" fill="#88bbcc" opacity="0.5"/>
+  <circle cx="16" cy="18" r="0.7" fill="#88bbcc" opacity="0.4"/>
+  <!-- Base glow -->
+  <ellipse cx="16" cy="27" rx="9" ry="2.5" fill="#aaddff" opacity="0.2"/>
+</svg>

--- a/web/public/sprites/gold-standard.svg
+++ b/web/public/sprites/gold-standard.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Banner pole -->
+  <rect x="15" y="3" width="2" height="26" rx="0.5" fill="#8a6622" stroke="#5a3a00" stroke-width="0.4"/>
+  <!-- Banner flag -->
+  <polygon points="17,4 28,9 17,14" fill="#ffcc00" stroke="#cc9900" stroke-width="0.5"/>
+  <!-- Banner emblem -->
+  <circle cx="22" cy="9" r="2.5" fill="#ffaa00" opacity="0.8"/>
+  <text x="22" y="11" font-size="5" text-anchor="middle" fill="#5a3a00" font-family="monospace" opacity="0.9">★</text>
+  <!-- Gold coins stacked at base -->
+  <ellipse cx="16" cy="28" rx="6" ry="2" fill="#ffdd44" stroke="#cc9900" stroke-width="0.5"/>
+  <ellipse cx="16" cy="26.5" rx="6" ry="2" fill="#ffcc00" stroke="#cc9900" stroke-width="0.5"/>
+  <ellipse cx="16" cy="25" rx="6" ry="2" fill="#ffdd44" stroke="#cc9900" stroke-width="0.5"/>
+  <!-- Shine lines on coins -->
+  <line x1="12" y1="25" x2="20" y2="25" stroke="#ffffff" stroke-width="0.4" opacity="0.4"/>
+  <!-- Gold glow aura -->
+  <ellipse cx="16" cy="16" rx="14" ry="14" fill="#ffcc00" opacity="0.06"/>
+</svg>

--- a/web/public/sprites/haste.svg
+++ b/web/public/sprites/haste.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Speed lines (trailing) -->
+  <line x1="2" y1="10" x2="18" y2="10" stroke="#ffcc00" stroke-width="1.2" stroke-linecap="round" opacity="0.5"/>
+  <line x1="2" y1="13" x2="14" y2="13" stroke="#ffcc00" stroke-width="0.8" stroke-linecap="round" opacity="0.4"/>
+  <line x1="2" y1="16" x2="20" y2="16" stroke="#ffaa00" stroke-width="2" stroke-linecap="round" opacity="0.6"/>
+  <line x1="2" y1="19" x2="14" y2="19" stroke="#ffcc00" stroke-width="0.8" stroke-linecap="round" opacity="0.4"/>
+  <line x1="2" y1="22" x2="18" y2="22" stroke="#ffcc00" stroke-width="1.2" stroke-linecap="round" opacity="0.5"/>
+  <!-- Lightning bolt -->
+  <polygon points="22,4 16,17 20,17 14,29 26,14 21,14" fill="#ffee00" stroke="#cc8800" stroke-width="0.6"/>
+  <!-- Inner bolt highlight -->
+  <polygon points="22,7 17,17 20,17 15,26 24,15 21,15" fill="#ffffff" opacity="0.3"/>
+  <!-- Glow -->
+  <ellipse cx="20" cy="16" rx="10" ry="12" fill="#ffcc00" opacity="0.08"/>
+</svg>

--- a/web/public/sprites/inferno-surge.svg
+++ b/web/public/sprites/inferno-surge.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Heat haze base -->
+  <ellipse cx="16" cy="28" rx="12" ry="3" fill="#ff4400" opacity="0.25"/>
+  <!-- Outer flame left -->
+  <path d="M6 28 Q4 22 7 18 Q5 15 8 12 Q10 17 9 20 Q12 15 11 10 Q15 16 13 22 Q16 17 15 13 Q19 19 17 24 Q20 19 19 15 Q22 20 21 24 Q23 18 24 14 Q26 19 24 23 Q27 18 27 22 Q29 26 26 28 Z" fill="#ff6600" opacity="0.9"/>
+  <!-- Inner flame -->
+  <path d="M9 28 Q8 23 10 20 Q12 23 11 26 Q14 21 13 17 Q17 22 16 25 Q18 21 18 17 Q21 22 20 26 Q22 22 23 19 Q25 23 23 28 Z" fill="#ff9900"/>
+  <!-- Core flame -->
+  <path d="M12 28 Q11 24 13 21 Q15 24 14 27 Q16 22 16 19 Q18 23 18 26 Q19 22 20 20 Q22 24 20 28 Z" fill="#ffcc00"/>
+  <!-- Ember sparks -->
+  <circle cx="10" cy="14" r="1" fill="#ff6600" opacity="0.8"/>
+  <circle cx="16" cy="10" r="1.2" fill="#ffaa00" opacity="0.9"/>
+  <circle cx="22" cy="12" r="0.8" fill="#ff6600" opacity="0.7"/>
+  <circle cx="13" cy="8" r="0.6" fill="#ffdd44" opacity="0.8"/>
+  <circle cx="20" cy="7" r="0.7" fill="#ffdd44" opacity="0.7"/>
+  <circle cx="8" cy="10" r="0.5" fill="#ff4400" opacity="0.6"/>
+</svg>

--- a/web/public/sprites/iron-discipline.svg
+++ b/web/public/sprites/iron-discipline.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Sword upright -->
+  <rect x="15" y="5" width="2" height="18" rx="0.5" fill="#cccccc" stroke="#888888" stroke-width="0.5"/>
+  <!-- Sword crossguard -->
+  <rect x="9" y="19" width="14" height="2.5" rx="0.5" fill="#999999" stroke="#555555" stroke-width="0.5"/>
+  <!-- Sword blade highlight -->
+  <line x1="16" y1="6" x2="16" y2="19" stroke="#ffffff" stroke-width="0.5" opacity="0.5"/>
+  <!-- Sword pommel -->
+  <circle cx="16" cy="23" r="3" fill="#888888" stroke="#555555" stroke-width="0.5"/>
+  <circle cx="16" cy="23" r="1.5" fill="#aaaaaa"/>
+  <!-- Discipline aura rings -->
+  <circle cx="16" cy="14" r="11" fill="none" stroke="#aaaaaa" stroke-width="0.5" opacity="0.3"/>
+  <circle cx="16" cy="14" r="8" fill="none" stroke="#aaaaaa" stroke-width="0.4" opacity="0.4"/>
+  <!-- Rank marks (3 pips = command) -->
+  <rect x="7" y="12" width="4" height="1.5" rx="0.3" fill="#ffcc00" opacity="0.9"/>
+  <rect x="7" y="14.5" width="4" height="1.5" rx="0.3" fill="#ffcc00" opacity="0.9"/>
+  <rect x="7" y="17" width="4" height="1.5" rx="0.3" fill="#ffcc00" opacity="0.9"/>
+  <rect x="21" y="12" width="4" height="1.5" rx="0.3" fill="#ffcc00" opacity="0.9"/>
+  <rect x="21" y="14.5" width="4" height="1.5" rx="0.3" fill="#ffcc00" opacity="0.9"/>
+  <rect x="21" y="17" width="4" height="1.5" rx="0.3" fill="#ffcc00" opacity="0.9"/>
+</svg>

--- a/web/public/sprites/iron-skin.svg
+++ b/web/public/sprites/iron-skin.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Body silhouette -->
+  <ellipse cx="16" cy="9" rx="5" ry="5" fill="#888888" stroke="#555555" stroke-width="0.5"/>
+  <rect x="10" y="13" width="12" height="14" rx="2" fill="#888888" stroke="#555555" stroke-width="0.5"/>
+  <!-- Iron plate seams on torso -->
+  <line x1="16" y1="13" x2="16" y2="27" stroke="#555555" stroke-width="0.5" opacity="0.7"/>
+  <line x1="10" y1="18" x2="22" y2="18" stroke="#555555" stroke-width="0.5" opacity="0.7"/>
+  <line x1="10" y1="22" x2="22" y2="22" stroke="#555555" stroke-width="0.5" opacity="0.7"/>
+  <!-- Rivets -->
+  <circle cx="11.5" cy="14.5" r="0.8" fill="#aaaaaa"/>
+  <circle cx="20.5" cy="14.5" r="0.8" fill="#aaaaaa"/>
+  <circle cx="11.5" cy="19.5" r="0.8" fill="#aaaaaa"/>
+  <circle cx="20.5" cy="19.5" r="0.8" fill="#aaaaaa"/>
+  <circle cx="11.5" cy="23.5" r="0.8" fill="#aaaaaa"/>
+  <circle cx="20.5" cy="23.5" r="0.8" fill="#aaaaaa"/>
+  <!-- Metallic highlights on plates -->
+  <rect x="10.5" y="13.5" width="5" height="4" rx="0.3" fill="#aaaaaa" opacity="0.3"/>
+  <rect x="16.5" y="18.5" width="5" height="3" rx="0.3" fill="#aaaaaa" opacity="0.3"/>
+  <!-- Head highlight -->
+  <ellipse cx="14" cy="7" rx="2" ry="2" fill="#bbbbbb" opacity="0.4"/>
+  <!-- Iron glow aura -->
+  <ellipse cx="16" cy="16" rx="13" ry="13" fill="#888888" opacity="0.07"/>
+</svg>


### PR DESCRIPTION
Closes #613

Adds 10 upgrade/spell SVG sprites to `web/public/sprites/`:

| Card | File |
|---|---|
| Fortify | `fortify.svg` — stone battlement wall with gold rune |
| Frost Surge | `frost-surge.svg` — ice crystals + frost wave |
| Fungal Bloom | `fungal-bloom.svg` — purple mushroom cap with spore particles |
| Gear Sprint | `gear-sprint.svg` — gear with speed trail lines |
| Glacier Hide | `glacier-hide.svg` — faceted ice-plate armour with protruding shards |
| Gold Standard | `gold-standard.svg` — gold banner with star emblem + coin stack |
| Haste | `haste.svg` — lightning bolt with speed trails |
| Inferno Surge | `inferno-surge.svg` — layered flame with ember sparks |
| Iron Discipline | `iron-discipline.svg` — upright sword with rank pips |
| Iron Skin | `iron-skin.svg` — riveted iron-plate armour silhouette |

All files are 32×32 viewBox SVGs using simple geometric shapes, consistent with the existing sprite style.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ACiLy6sFHe5aZvgwbwADFG)_