### PR TITLE
fix(#879): suppress Firebase 'Load failed' unhandled rejection on iOS Safari

### DIFF
--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -10,14 +10,21 @@ setErrorLogger((msg, ctx) => rollbar.error(msg, ctx as object))
 // achievement was added (e.g. after a game update adds new achievements).
 import('./game/achievements').then(({ backfillAchievements }) => backfillAchievements())
 
-// Firebase uses IndexedDB internally for Firestore caching. If the browser
-// drops that connection (common in Safari / backgrounded tabs), Firebase throws
-// an UnknownError that would otherwise surface as an unhandled rejection in
-// Rollbar. We catch it here and swallow it — Firestore recovers automatically
-// on the next operation, so no user action is needed.
+// Firebase throws unhandled rejections internally that are not actionable.
+// Suppress them here so Rollbar doesn't log noise:
+//
+// - "Connection to Indexed Database server lost" — Firestore/IndexedDB
+//   disconnect in Safari / backgrounded tabs; Firestore recovers automatically.
+//
+// - "Load failed" — iOS Safari network error thrown by the Firebase SDK's
+//   internal fetch() calls (auth + Firestore long-poll) when the ServiceWorker
+//   updates and the page reloads mid-session. Firebase reconnects on its own.
 window.addEventListener('unhandledrejection', (event) => {
   const msg = String(event.reason?.message ?? event.reason ?? '')
-  if (msg.includes('Connection to Indexed Database server lost')) {
+  if (
+    msg.includes('Connection to Indexed Database server lost') ||
+    msg === 'Load failed'
+  ) {
     event.preventDefault()
   }
 })


### PR DESCRIPTION
## Summary

Fixes #879.

The Rollbar telemetry shows the error fires ~6s into an iOS Safari session when the ServiceWorker update triggers a page reload. At that moment, the Firebase SDK's internal `fetch()` calls (auth token refresh + Firestore long-poll) are interrupted, throwing an uncaught `TypeError: Load failed` with no stack frames.

Firebase reconnects automatically — no user action is needed, and the error is not actionable.

**Fix:** extend the existing `unhandledrejection` handler in `main.tsx` to suppress this error message, matching the same pattern already used for the `UnknownError: Connection to Indexed Database server lost` (#416).

## Test plan
- [ ] Build passes clean
- [ ] On iOS Safari, load the game and wait for SW update — no new Rollbar items for "Load failed"

https://claude.ai/code/session_011dhVDvaLHqvM3HnUbSNGND

---
_Generated by [Claude Code](https://claude.ai/code/session_011dhVDvaLHqvM3HnUbSNGND)_