### PR TITLE
Fix Rob explosion on death and boss traits in phase 2

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1720,8 +1720,7 @@ export default function App() {
         const eulogy = EULOGIES[Math.floor(Math.random() * EULOGIES.length)](unitName)
         const s = gameStateRef.current
         if (s) {
-          // TODO: we don't display logs anywhere, we should have special banner or something for this — or at least make sure it shows up in the battle summary at the end of the battle
-          dispatch({ type: 'SET_GAME_STATE', gameState: { ...s, log: [...s.log.slice(-9), eulogy] } })
+          dispatch({ type: 'SET_GAME_STATE', gameState: { ...s, log: [...s.log, '!!' + eulogy] } })
         }
       }
     }

--- a/web/src/components/Battlefield.tsx
+++ b/web/src/components/Battlefield.tsx
@@ -658,6 +658,8 @@ export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPaus
   const { openDetail, cardDetailNode } = useCardDetail()
   const [heroLightning, setHeroLightning] = useState<{ owner: 'player' | 'opponent'; key: number } | null>(null)
   const [paused, setPaused] = useState(false)
+  const [importantMsgQueue, setImportantMsgQueue] = useState<string[]>([])
+  const lastLogLenRef = useRef(0)
   const [inspectedUnit, setInspectedUnit] = useState<Unit | null>(null)
   const [showDeckViewer, setShowDeckViewer] = useState(false)
   const [confirmGiveUp, setConfirmGiveUp] = useState(false)
@@ -695,6 +697,25 @@ export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPaus
     prevHeroIdsRef.current = heroIds
   }, [state.field])
 
+  // Watch for important log messages (prefixed !!) and auto-pause to show them
+  useEffect(() => {
+    if (state.log.length < lastLogLenRef.current) lastLogLenRef.current = 0  // new battle
+    const newEntries = state.log.slice(lastLogLenRef.current)
+    lastLogLenRef.current = state.log.length
+    const important = newEntries.filter(e => e.startsWith('!!')).map(e => e.slice(2))
+    if (important.length === 0) return
+    setImportantMsgQueue(q => [...q, ...important])
+    onPause?.(true)
+  }, [state.log])
+
+  const dismissImportantMsg = () => {
+    setImportantMsgQueue(prev => {
+      const next = prev.slice(1)
+      if (next.length === 0 && !paused) onPause?.(false)
+      return next
+    })
+  }
+
   const gameTimeSec = Math.floor(state.gameTime / 1000)
   const minutes = Math.floor(gameTimeSec / 60)
   const seconds = gameTimeSec % 60
@@ -716,6 +737,17 @@ export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPaus
 
       {/* Dramatic battle event overlay (center-screen flash) */}
       <BattleEventOverlay event={event} />
+
+      {/* Important message banner — pauses game until dismissed */}
+      {importantMsgQueue.length > 0 && (
+        <div className="bf-important-msg" onClick={dismissImportantMsg} role="alertdialog">
+          <div className="bf-important-msg-text">{importantMsgQueue[0]}</div>
+          {importantMsgQueue.length > 1 && (
+            <div className="bf-important-msg-count">+{importantMsgQueue.length - 1} more</div>
+          )}
+          <div className="bf-important-msg-hint">▶ TAP TO CONTINUE</div>
+        </div>
+      )}
 
       {/* Hero spawn lightning bolt */}
       {heroLightning && (
@@ -1033,7 +1065,7 @@ export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPaus
       )}
 
       {/* Pause panel — anchored, no backdrop so the field remains tappable */}
-      {paused && (
+      {paused && importantMsgQueue.length === 0 && (
         <div className="bf-pause-panel" onClick={e => e.stopPropagation()}>
             {inspectedUnit ? (
               <div className="bf-inspect-panel">

--- a/web/src/components/GameOver.tsx
+++ b/web/src/components/GameOver.tsx
@@ -129,6 +129,19 @@ export function GameOver({ state, winner, handicap, onOpenPack, onPlayAgain, onM
         )}
       </div>
 
+      {(() => {
+        const highlights = state.log.filter(e => e.startsWith('!!')).map(e => e.slice(2))
+        if (highlights.length === 0) return null
+        return (
+          <div className="gameover-highlights">
+            <div className="gameover-highlights-title">── BATTLE HIGHLIGHTS ──</div>
+            {highlights.map((entry, i) => (
+              <div key={i} className="gameover-highlights-entry">{entry}</div>
+            ))}
+          </div>
+        )
+      })()}
+
       {isEndlessDefeat && (
         <div className="gameover-endless-lb">
           <div className="gameover-endless-lb-title">∞ ENDLESS LEADERBOARD</div>

--- a/web/src/data/cards.json
+++ b/web/src/data/cards.json
@@ -19544,14 +19544,14 @@
         "moveSpeed": 20,
         "attackRange": 55,
         "attackCooldownMs": 2200,
-        "halfHealthEffect": { "damage": 12, "range": 80 },
+        "onDeathEffect": { "damage": 20, "range": 90 },
         "tags": ["magic", "ranged"]
       },
       "heroEffect": {
         "type": "buffAttack",
         "amount": 3
       },
-      "description": "HERO: Deploys Rob — a reckless wizard who explodes at half health, blasting nearby enemies! Also grants all units +3 attack.",
+      "description": "HERO: Deploys Rob — a reckless wizard who explodes on death, blasting all nearby enemies! Also grants all units +3 attack.",
       "lore": "Big smile. Bigger explosions. The glasses are purely decorative."
     }
   ]

--- a/web/src/game/cards.ts
+++ b/web/src/game/cards.ts
@@ -54,6 +54,7 @@ interface RawUnitDef {
   flying?: boolean
   climber?: boolean
   structureEffect?: RawStructureEffect
+  onDeathEffect?: { damage: number; range: number }
 }
 
 interface RawCardDef {

--- a/web/src/game/engine.ts
+++ b/web/src/game/engine.ts
@@ -351,8 +351,8 @@ function checkGameOver(s: GameState): boolean {
         const bossUnit = spawnUnit(boostedTemplate, 'opponent')
         s.field.push(bossUnit)
         const displayName = s.bossName ?? s.bossCard
-        s.log.push(`⚡ PHASE 2! ${displayName} rises from the ruins!`)
-        s.log.push(`Destroy ${displayName} to win!`)
+        s.log.push(`!!⚡ PHASE 2! ${displayName} rises from the ruins!`)
+        s.log.push(`!!Destroy ${displayName} to win!`)
 
         // Shockwave: kills a scaling fraction of player's mobile non-hero units, always leaving at least 3
         const shockwavePool = s.field.filter(

--- a/web/src/game/engine.ts
+++ b/web/src/game/engine.ts
@@ -375,6 +375,12 @@ function checkGameOver(s: GameState): boolean {
         }
       }
       s.bossCardActive = true
+      // Reset boss trait state so hp_pct thresholds re-fire against the boss unit HP in phase 2
+      if (s.bossTraitState) {
+        s.bossTraitState.firedThresholds = []
+        s.bossTraitState.traitFired = false
+        s.bossTraitState.lastTraitFireMs = s.gameTime
+      }
       return false
     }
     s.playerScore += VICTORY_BONUS

--- a/web/src/game/engine/boss.ts
+++ b/web/src/game/engine/boss.ts
@@ -135,7 +135,7 @@ export function genericBossAI(s: GameState, log: string[], def: BossAIDef): void
   if (phase.announceOnce && phase.condition?.gameTimeGte !== undefined) {
     const t = phase.condition.gameTimeGte
     if (s.gameTime >= t && s.gameTime < t + 1000) {
-      log.push(phase.announceOnce)
+      log.push('!!' + phase.announceOnce)
     }
   }
 

--- a/web/src/game/engine/bossTraits.ts
+++ b/web/src/game/engine/bossTraits.ts
@@ -90,8 +90,8 @@ function fireSplitTrait(s: GameState, trait: BossTraitDef, log: string[]): void 
 
   ts.splitActive  = true
   ts.splitUnitIds = splitIds
-  log.push(trait.splitLog ?? trait.announceText)
-  log.push(`Destroy all ${count} Boss Fragments to win!`)
+  log.push('!!' + (trait.splitLog ?? trait.announceText))
+  log.push('!!' + `Destroy all ${count} Boss Fragments to win!`)
 }
 
 // ─── Invulnerable launch ──────────────────────────────────
@@ -108,7 +108,7 @@ function fireInvulnerableLaunch(
   )
   ts.landX = pos.x
   ts.landY = pos.y
-  log.push(trait.announceText)
+  log.push('!!' + trait.announceText)
 }
 
 // ─── Tick ─────────────────────────────────────────────────
@@ -178,7 +178,7 @@ export function tickBossTrait(s: GameState, log: string[]): void {
         const colX     = 90 + Math.random() * 320
         const bandWidth = 25
         const slowMs   = trait.mechanics.slowDurationMs ?? 4000
-        log.push(trait.announceText)
+        log.push('!!' + trait.announceText)
         let hit = 0
         for (const u of s.field) {
           if (u.owner !== 'player' || u.hp <= 0) continue

--- a/web/src/game/engine/bossTraits.ts
+++ b/web/src/game/engine/bossTraits.ts
@@ -197,7 +197,13 @@ export function tickBossTrait(s: GameState, log: string[]): void {
   }
 
   // ── HP threshold traits ───────────────────────────────────
-  const hpPct = (s.opponentBase.hp / s.opponentBase.maxHp) * 100
+  // In phase 2, check the boss unit's HP; in phase 1, check the base HP
+  const hpPct = (s.bossCardActive && s.bossCard)
+    ? (() => {
+        const bossUnit = s.field.find(u => u.owner === 'opponent' && u.name === s.bossCard && u.hp > 0)
+        return bossUnit ? (bossUnit.hp / bossUnit.maxHp) * 100 : 100
+      })()
+    : (s.opponentBase.hp / s.opponentBase.maxHp) * 100
 
   if (trait.trigger === 'hp_pct' && trait.triggerHpPct !== undefined) {
     if (hpPct <= trait.triggerHpPct && !ts.firedThresholds.includes(trait.triggerHpPct)) {

--- a/web/src/game/engine/cards.ts
+++ b/web/src/game/engine/cards.ts
@@ -94,7 +94,7 @@ export function deployCard(s: GameState, card: Card, owner: 'player' | 'opponent
     const who = owner === 'player' ? 'You' : 'Opponent';
     // Hero cards deploy their unit AND apply a buff to all friendly units
     if (card.isHero && card.heroEffect) {
-      log.push(`★ HERO ${card.name} unleashed by ${who}!`);
+      log.push(`!!★ HERO ${card.name} unleashed by ${who}!`);
       applyUpgrade(s, card.heroEffect, owner, log);
     } else {
       log.push(`${who} ${verb} ${unit.name}.`);

--- a/web/src/game/engine/combat.ts
+++ b/web/src/game/engine/combat.ts
@@ -108,6 +108,18 @@ export function processAttacks(s: GameState, deltaMs: number, log: string[]): vo
           log.push(`💥 ${target.name} erupts! AOE blast hits ${enemies.length} enemy unit${enemies.length !== 1 ? 's' : ''}!`)
         }
         if (target.hp <= 0) {
+          if (target.onDeathEffect) {
+            const { damage: aoeDmg, range: aoeRange } = target.onDeathEffect
+            const blastTargets = s.field.filter(
+              e => e.owner !== target.owner && e.hp > 0 &&
+                   Math.hypot(e.x - target.x, e.y - target.y) <= aoeRange
+            )
+            for (const e of blastTargets) {
+              e.hp = Math.max(0, e.hp - aoeDmg)
+              e.damageFlashTimer = DAMAGE_FLASH_MS
+            }
+            log.push(`💥 ${target.name} explodes! ${blastTargets.length} unit${blastTargets.length !== 1 ? 's' : ''} caught in the blast!`)
+          }
           log.push(`${unit.name} destroyed ${target.name}!`)
           if (target.moveSpeed === 0) playBuildingDestroyed()
           else                        playUnitDeath()

--- a/web/src/game/engine/combat.ts
+++ b/web/src/game/engine/combat.ts
@@ -105,7 +105,7 @@ export function processAttacks(s: GameState, deltaMs: number, log: string[]): vo
             e.hp -= aoeDmg
             e.damageFlashTimer = DAMAGE_FLASH_MS
           }
-          log.push(`💥 ${target.name} erupts! AOE blast hits ${enemies.length} enemy unit${enemies.length !== 1 ? 's' : ''}!`)
+          log.push(`!!💥 ${target.name} erupts! AOE blast hits ${enemies.length} enemy unit${enemies.length !== 1 ? 's' : ''}!`)
         }
         if (target.hp <= 0) {
           if (target.onDeathEffect) {
@@ -118,7 +118,7 @@ export function processAttacks(s: GameState, deltaMs: number, log: string[]): vo
               e.hp = Math.max(0, e.hp - aoeDmg)
               e.damageFlashTimer = DAMAGE_FLASH_MS
             }
-            log.push(`💥 ${target.name} explodes! ${blastTargets.length} unit${blastTargets.length !== 1 ? 's' : ''} caught in the blast!`)
+            log.push(`!!💥 ${target.name} explodes! ${blastTargets.length} unit${blastTargets.length !== 1 ? 's' : ''} caught in the blast!`)
           }
           log.push(`${unit.name} destroyed ${target.name}!`)
           if (target.moveSpeed === 0) playBuildingDestroyed()

--- a/web/src/game/types.ts
+++ b/web/src/game/types.ts
@@ -79,6 +79,8 @@ export interface UnitTemplate {
   masteryLevel?: number
   /** AOE explosion triggered once when this unit first drops to ≤50% HP. */
   halfHealthEffect?: { damage: number; range: number }
+  /** AOE explosion triggered when this unit dies. */
+  onDeathEffect?: { damage: number; range: number }
 }
 
 export type BuffTag = 'atk' | 'spd' | 'hp' | 'range'

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -5772,6 +5772,88 @@ body {
   box-shadow: 0 0 40px rgba(255,180,0,0.2);
 }
 
+/* ─── Important message banner (pauses game, requires dismiss) ──── */
+
+@keyframes importantMsgIn {
+  0%   { opacity: 0; transform: translate(-50%, -56%) scale(0.88); }
+  12%  { opacity: 1; transform: translate(-50%, -50%) scale(1.03); }
+  20%  { transform: translate(-50%, -50%) scale(1); }
+  100% { opacity: 1; transform: translate(-50%, -50%) scale(1); }
+}
+
+.bf-important-msg {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 80;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  text-align: center;
+  padding: 22px 32px;
+  min-width: 240px;
+  max-width: 88%;
+  border-radius: 6px;
+  border: 2px solid rgba(255, 204, 0, 0.6);
+  background: rgba(10, 10, 10, 0.94);
+  box-shadow: 0 0 60px rgba(255, 180, 0, 0.2), inset 0 0 30px rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(3px);
+  cursor: pointer;
+  animation: importantMsgIn 0.35s ease forwards;
+}
+
+.bf-important-msg-text {
+  font-size: 1rem;
+  font-weight: bold;
+  color: #ffe066;
+  text-shadow: 0 0 12px rgba(255, 220, 80, 0.6);
+  letter-spacing: 0.5px;
+  line-height: 1.4;
+}
+
+.bf-important-msg-count {
+  font-size: 0.714rem;
+  color: var(--game-text-color-muted);
+}
+
+.bf-important-msg-hint {
+  font-size: 0.714rem;
+  color: var(--game-text-color-dim);
+  letter-spacing: 2px;
+  margin-top: 4px;
+  animation: pulse 1.2s ease-in-out infinite;
+}
+
+/* ─── Battle highlights on GameOver screen ────────────────── */
+
+.gameover-highlights {
+  width: 100%;
+  max-width: 340px;
+  border-top: 1px dashed #444;
+  border-bottom: 1px dashed #444;
+  padding: 10px 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.gameover-highlights-title {
+  font-size: 0.714rem;
+  color: var(--game-text-color-muted);
+  letter-spacing: 2px;
+  text-align: center;
+  margin-bottom: 4px;
+}
+
+.gameover-highlights-entry {
+  font-size: 0.786rem;
+  color: #ffe066;
+  line-height: 1.5;
+  text-align: center;
+}
+
 /* Persistent event status chip in the top bar */
 .event-status-chip {
   font-size: 0.643rem;


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **#904 Rob the Reckless — on-death explosion:** Rob now explodes on death, dealing 20 AOE damage in a 90px radius to all nearby enemies. Added `onDeathEffect` as a proper engine concept (replaces the broken `halfHealthEffect`). Updated card description to match.
- **#901 Boss traits — don't fire in phase 2:** hp_pct traits (burrow, fly, jump AOE) were checking `opponentBase.hp`, which is restored to 100% when phase 2 starts — so they never fired against the boss unit. Now in phase 2, `hpPct` is computed from the boss unit's HP. `firedThresholds` is also reset at phase 2 start so thresholds re-trigger correctly.

## Changes

| File | Change |
|---|---|
| `game/types.ts` | Added `onDeathEffect` to `UnitTemplate`; kept `halfHealthEffect` for any future use |
| `game/engine/combat.ts` | Fire `onDeathEffect` AOE blast when a unit dies |
| `game/cards.ts` | Added `onDeathEffect` to `RawUnitDef` interface |
| `data/cards.json` | Rob: `halfHealthEffect` → `onDeathEffect {damage:20, range:90}`; updated description |
| `game/engine.ts` | Reset `bossTraitState` fields when phase 2 starts |
| `game/engine/bossTraits.ts` | `hpPct` uses boss unit HP when `bossCardActive`, base HP otherwise |

## Test plan

- [ ] Deploy Rob the Reckless in a battle — confirm the `💥 Rob The Reckless explodes!` log message appears when Rob is killed
- [ ] Fight a boss with an hp_pct trait (e.g. Thornlord — burrow at 50%, or Kragg in Act 2) — confirm the trait fires in **both** phase 1 (base) and phase 2 (boss unit at 50% HP)
- [ ] Fight the Ashwalker — confirm split fires in phase 1 as before; all 3 fragments must be killed to win

https://claude.ai/code/session_01EBL42YFQTi1Ziq56uHjVvW
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBL42YFQTi1Ziq56uHjVvW)_