### PR TITLE
Fix Rob explosion, boss phase 2 traits, and auto-dismiss battle banners

### DIFF
--- a/web/src/components/Battlefield.tsx
+++ b/web/src/components/Battlefield.tsx
@@ -716,6 +716,13 @@ export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPaus
     })
   }
 
+  // Auto-dismiss the current important message after 3.5 s (resets for each new message)
+  useEffect(() => {
+    if (importantMsgQueue.length === 0) return
+    const id = setTimeout(dismissImportantMsg, 3500)
+    return () => clearTimeout(id)
+  }, [importantMsgQueue[0]])
+
   const gameTimeSec = Math.floor(state.gameTime / 1000)
   const minutes = Math.floor(gameTimeSec / 60)
   const seconds = gameTimeSec % 60
@@ -740,12 +747,11 @@ export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPaus
 
       {/* Important message banner — pauses game until dismissed */}
       {importantMsgQueue.length > 0 && (
-        <div className="bf-important-msg" onClick={dismissImportantMsg} role="alertdialog">
+        <div key={importantMsgQueue[0]} className="bf-important-msg" onClick={dismissImportantMsg} role="alertdialog">
           <div className="bf-important-msg-text">{importantMsgQueue[0]}</div>
           {importantMsgQueue.length > 1 && (
             <div className="bf-important-msg-count">+{importantMsgQueue.length - 1} more</div>
           )}
-          <div className="bf-important-msg-hint">▶ TAP TO CONTINUE</div>
         </div>
       )}
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -5776,9 +5776,10 @@ body {
 
 @keyframes importantMsgIn {
   0%   { opacity: 0; transform: translate(-50%, -56%) scale(0.88); }
-  12%  { opacity: 1; transform: translate(-50%, -50%) scale(1.03); }
-  20%  { transform: translate(-50%, -50%) scale(1); }
-  100% { opacity: 1; transform: translate(-50%, -50%) scale(1); }
+  10%  { opacity: 1; transform: translate(-50%, -50%) scale(1.03); }
+  18%  { transform: translate(-50%, -50%) scale(1); }
+  78%  { opacity: 1; transform: translate(-50%, -50%) scale(1); }
+  100% { opacity: 0; transform: translate(-50%, -44%) scale(0.95); }
 }
 
 .bf-important-msg {
@@ -5801,7 +5802,8 @@ body {
   box-shadow: 0 0 60px rgba(255, 180, 0, 0.2), inset 0 0 30px rgba(0, 0, 0, 0.5);
   backdrop-filter: blur(3px);
   cursor: pointer;
-  animation: importantMsgIn 0.35s ease forwards;
+  animation: importantMsgIn 3.5s ease forwards;
+  pointer-events: auto;
 }
 
 .bf-important-msg-text {
@@ -5818,13 +5820,6 @@ body {
   color: var(--game-text-color-muted);
 }
 
-.bf-important-msg-hint {
-  font-size: 0.714rem;
-  color: var(--game-text-color-dim);
-  letter-spacing: 2px;
-  margin-top: 4px;
-  animation: pulse 1.2s ease-in-out infinite;
-}
 
 /* ─── Battle highlights on GameOver screen ────────────────── */
 


### PR DESCRIPTION
## Summary

- **#904 Rob the Reckless**: Replaced `halfHealthEffect` with `onDeathEffect` — Rob now reliably explodes on death dealing 20 damage in range 90 to all nearby enemies
- **#901 Boss phase 2 traits**: `hpPct` thresholds now track the boss unit's HP in phase 2 (was always reading `opponentBase.hp` which resets to 100% at phase 2 start); `firedThresholds` also reset when phase 2 begins
- **#753 Battle message display**: Added `!!`-prefixed log convention for important events; these appear as a centre-screen banner that auto-pauses the game, fades out after 3.5s (tap to skip early). Important events also appear in the post-game "Battle Highlights" section on the Game Over screen.

## Test plan

- [ ] Play Rob the Reckless — confirm explosion fires on death, not at half health
- [ ] Start a boss fight, reach phase 2 — confirm phase 2 trait thresholds fire as the boss unit loses HP
- [ ] Trigger a hero card, phase 2 transition, or supply drop — confirm banner appears centre-screen, game pauses, banner fades out after ~3.5s and game resumes automatically
- [ ] Tap banner early — confirm it dismisses immediately
- [ ] Check Game Over screen — confirm "Battle Highlights" section lists the important events

https://claude.ai/code/session_01EBL42YFQTi1Ziq56uHjVvW

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBL42YFQTi1Ziq56uHjVvW)_