### PR TITLE
Add 5 missing hero cards (closes #905)

### DIFF
--- a/web/public/sprites/blast-maiden-1.svg
+++ b/web/public/sprites/blast-maiden-1.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Blast Maiden — stride A (left foot forward) -->
+  <rect x="9" y="13" width="14" height="10" rx="2" fill="#c45c00"/>
+  <rect x="10" y="14" width="12" height="8" rx="1" fill="#e07020"/>
+  <!-- Legs — left forward -->
+  <rect x="9" y="23" width="5" height="7" rx="1" fill="#8b3a00" transform="rotate(-8,11,23)"/>
+  <rect x="18" y="23" width="5" height="7" rx="1" fill="#8b3a00" transform="rotate(6,20,23)"/>
+  <rect x="8" y="28" width="6" height="3" rx="1" fill="#4a2000"/>
+  <rect x="18" y="28" width="6" height="3" rx="1" fill="#4a2000"/>
+  <circle cx="16" cy="10" r="6" fill="#f4c08a"/>
+  <path d="M10,10 Q10,4 16,3 Q22,4 22,10" fill="#c45c00"/>
+  <rect x="10" y="9" width="12" height="3" fill="#c45c00" rx="1"/>
+  <line x1="13" y1="10" x2="15" y2="10" stroke="#333" stroke-width="1.2"/>
+  <line x1="17" y1="10" x2="19" y2="10" stroke="#333" stroke-width="1.2"/>
+  <circle cx="25" cy="17" r="4.5" fill="#333"/>
+  <path d="M25,12 Q28,10 27,8" fill="none" stroke="#ff8c00" stroke-width="1.5"/>
+  <circle cx="27" cy="8" r="1" fill="#ff4400"/>
+  <rect x="22" y="14" width="4" height="3" rx="1" fill="#c45c00"/>
+  <rect x="5" y="16" width="5" height="3" rx="1" fill="#c45c00" transform="rotate(10,7,18)"/>
+</svg>

--- a/web/public/sprites/blast-maiden-2.svg
+++ b/web/public/sprites/blast-maiden-2.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Blast Maiden — neutral/mid stride -->
+  <rect x="9" y="12" width="14" height="11" rx="2" fill="#c45c00"/>
+  <rect x="10" y="13" width="12" height="9" rx="1" fill="#e07020"/>
+  <rect x="10" y="23" width="5" height="7" rx="1" fill="#8b3a00"/>
+  <rect x="17" y="23" width="5" height="7" rx="1" fill="#8b3a00"/>
+  <rect x="9" y="28" width="6" height="3" rx="1" fill="#4a2000"/>
+  <rect x="17" y="28" width="6" height="3" rx="1" fill="#4a2000"/>
+  <circle cx="16" cy="9" r="6" fill="#f4c08a"/>
+  <path d="M10,9 Q10,3 16,2 Q22,3 22,9" fill="#c45c00"/>
+  <rect x="10" y="8" width="12" height="3" fill="#c45c00" rx="1"/>
+  <line x1="13" y1="9" x2="15" y2="9" stroke="#333" stroke-width="1.2"/>
+  <line x1="17" y1="9" x2="19" y2="9" stroke="#333" stroke-width="1.2"/>
+  <circle cx="25" cy="16" r="4.5" fill="#333"/>
+  <path d="M25,11 Q29,9 28,7" fill="none" stroke="#ff8c00" stroke-width="1.5"/>
+  <circle cx="28" cy="7" r="1.2" fill="#ff4400"/>
+  <rect x="22" y="13" width="4" height="3" rx="1" fill="#c45c00"/>
+  <rect x="5" y="14" width="5" height="3" rx="1" fill="#c45c00"/>
+</svg>

--- a/web/public/sprites/blast-maiden-3.svg
+++ b/web/public/sprites/blast-maiden-3.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Blast Maiden — stride B (right foot forward) -->
+  <rect x="9" y="13" width="14" height="10" rx="2" fill="#c45c00"/>
+  <rect x="10" y="14" width="12" height="8" rx="1" fill="#e07020"/>
+  <!-- Legs — right forward -->
+  <rect x="9" y="23" width="5" height="7" rx="1" fill="#8b3a00" transform="rotate(6,11,23)"/>
+  <rect x="18" y="23" width="5" height="7" rx="1" fill="#8b3a00" transform="rotate(-8,20,23)"/>
+  <rect x="9" y="28" width="6" height="3" rx="1" fill="#4a2000"/>
+  <rect x="17" y="28" width="6" height="3" rx="1" fill="#4a2000"/>
+  <circle cx="16" cy="10" r="6" fill="#f4c08a"/>
+  <path d="M10,10 Q10,4 16,3 Q22,4 22,10" fill="#c45c00"/>
+  <rect x="10" y="9" width="12" height="3" fill="#c45c00" rx="1"/>
+  <line x1="13" y1="10" x2="15" y2="10" stroke="#333" stroke-width="1.2"/>
+  <line x1="17" y1="10" x2="19" y2="10" stroke="#333" stroke-width="1.2"/>
+  <circle cx="25" cy="18" r="4.5" fill="#333"/>
+  <path d="M25,13 Q27,11 28,9" fill="none" stroke="#ff8c00" stroke-width="1.5"/>
+  <circle cx="28" cy="9" r="1" fill="#ff4400"/>
+  <rect x="22" y="15" width="4" height="3" rx="1" fill="#c45c00" transform="rotate(-10,24,17)"/>
+  <rect x="5" y="15" width="5" height="3" rx="1" fill="#c45c00"/>
+</svg>

--- a/web/public/sprites/blast-maiden.svg
+++ b/web/public/sprites/blast-maiden.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Blast Maiden — neutral stance -->
+  <!-- Armored body -->
+  <rect x="9" y="13" width="14" height="10" rx="2" fill="#c45c00"/>
+  <rect x="10" y="14" width="12" height="8" rx="1" fill="#e07020"/>
+  <!-- Legs -->
+  <rect x="10" y="23" width="5" height="7" rx="1" fill="#8b3a00"/>
+  <rect x="17" y="23" width="5" height="7" rx="1" fill="#8b3a00"/>
+  <!-- Boots -->
+  <rect x="9" y="28" width="6" height="3" rx="1" fill="#4a2000"/>
+  <rect x="17" y="28" width="6" height="3" rx="1" fill="#4a2000"/>
+  <!-- Head -->
+  <circle cx="16" cy="10" r="6" fill="#f4c08a"/>
+  <!-- Helmet -->
+  <path d="M10,10 Q10,4 16,3 Q22,4 22,10" fill="#c45c00"/>
+  <rect x="10" y="9" width="12" height="3" fill="#c45c00" rx="1"/>
+  <!-- Eyes — determined look -->
+  <line x1="13" y1="10" x2="15" y2="10" stroke="#333" stroke-width="1.2"/>
+  <line x1="17" y1="10" x2="19" y2="10" stroke="#333" stroke-width="1.2"/>
+  <!-- Bomb (carried) -->
+  <circle cx="25" cy="18" r="4.5" fill="#333"/>
+  <circle cx="25" cy="18" r="4.5" fill="none" stroke="#888" stroke-width="0.5"/>
+  <!-- Fuse -->
+  <path d="M25,13 Q28,11 27,9" fill="none" stroke="#ff8c00" stroke-width="1.5"/>
+  <circle cx="27" cy="9" r="1" fill="#ff4400"/>
+  <!-- Arm holding bomb -->
+  <rect x="22" y="15" width="4" height="3" rx="1" fill="#c45c00"/>
+  <!-- Other arm -->
+  <rect x="5" y="15" width="5" height="3" rx="1" fill="#c45c00"/>
+</svg>

--- a/web/public/sprites/blood-summoner-1.svg
+++ b/web/public/sprites/blood-summoner-1.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Blood Summoner — frame 1 (stride A, summoning gesture) -->
+  <path d="M8,31 Q7,20 9,15 L23,15 Q25,20 23,31 Q19,28 16,31 Q13,28 8,31" fill="#5a0000"/>
+  <path d="M9,29 Q8,20 10,15 L22,15 Q24,20 22,29 Q19,26 16,29 Q13,26 9,29" fill="#7a0a0a"/>
+  <rect x="10" y="9" width="12" height="7" rx="2" fill="#6a0808"/>
+  <rect x="10" y="14" width="12" height="2" fill="#cc1111"/>
+  <circle cx="16" cy="7" r="5.5" fill="#e8c090"/>
+  <path d="M9,8 Q9,2 16,1 Q23,2 23,8 Q20,6 16,7 Q12,6 9,8" fill="#2a0000"/>
+  <circle cx="14" cy="7" r="1.8" fill="#ff2222" opacity="0.9"/>
+  <circle cx="18" cy="7" r="1.8" fill="#ff2222" opacity="0.9"/>
+  <rect x="25" y="2" width="2" height="22" rx="1" fill="#5a3a1a"/>
+  <circle cx="26" cy="3" r="3" fill="#e8e0d0"/>
+  <circle cx="24.5" cy="3.5" r="0.8" fill="#333"/>
+  <circle cx="27.5" cy="3.5" r="0.8" fill="#333"/>
+  <path d="M24.5,5 Q26,6 27.5,5" fill="none" stroke="#333" stroke-width="0.7"/>
+  <!-- Arm raised high — summoning -->
+  <rect x="3" y="8" width="8" height="2.5" rx="1" fill="#6a0808" transform="rotate(-45,7,9)"/>
+  <!-- Blood pool glow beneath -->
+  <ellipse cx="10" cy="31" rx="5" ry="1.5" fill="#cc0000" opacity="0.5"/>
+  <circle cx="26" cy="23" r="1.2" fill="#cc0000" opacity="0.9"/>
+  <circle cx="26" cy="26" r="0.8" fill="#cc0000" opacity="0.7"/>
+</svg>

--- a/web/public/sprites/blood-summoner-2.svg
+++ b/web/public/sprites/blood-summoner-2.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Blood Summoner — frame 2 (upright, staff glowing) -->
+  <path d="M8,30 Q7,20 9,15 L23,15 Q25,20 24,30 Q20,27 16,30 Q12,27 8,30" fill="#5a0000"/>
+  <path d="M9,28 Q8,20 10,15 L22,15 Q24,20 23,28 Q20,25 16,28 Q12,25 9,28" fill="#7a0a0a"/>
+  <rect x="10" y="9" width="12" height="7" rx="2" fill="#6a0808"/>
+  <rect x="10" y="14" width="12" height="2" fill="#dd2222"/>
+  <circle cx="16" cy="7" r="5.5" fill="#e8c090"/>
+  <path d="M9,8 Q9,2 16,1 Q23,2 23,8 Q20,6 16,7 Q12,6 9,8" fill="#2a0000"/>
+  <circle cx="14" cy="7" r="1.8" fill="#ff4444" opacity="0.95"/>
+  <circle cx="18" cy="7" r="1.8" fill="#ff4444" opacity="0.95"/>
+  <rect x="25" y="3" width="2" height="22" rx="1" fill="#5a3a1a"/>
+  <!-- Glowing skull — active summoning -->
+  <circle cx="26" cy="4" r="3.2" fill="#e8e0d0"/>
+  <circle cx="26" cy="4" r="3.5" fill="none" stroke="#ff2222" stroke-width="0.8" opacity="0.7"/>
+  <circle cx="24.5" cy="4.5" r="0.8" fill="#ff0000"/>
+  <circle cx="27.5" cy="4.5" r="0.8" fill="#ff0000"/>
+  <path d="M24.5,6 Q26,7 27.5,6" fill="none" stroke="#333" stroke-width="0.7"/>
+  <rect x="4" y="10" width="7" height="2.5" rx="1" fill="#6a0808" transform="rotate(-30,7,11)"/>
+  <circle cx="26" cy="24" r="1.5" fill="#cc0000" opacity="0.9"/>
+  <circle cx="26" cy="27" r="1" fill="#cc0000" opacity="0.7"/>
+  <circle cx="25" cy="30" r="0.7" fill="#cc0000" opacity="0.5"/>
+</svg>

--- a/web/public/sprites/blood-summoner-3.svg
+++ b/web/public/sprites/blood-summoner-3.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Blood Summoner — frame 3 (stride B, staff trailing) -->
+  <path d="M9,30 Q8,20 10,15 L23,15 Q26,20 24,30 Q20,27 16,30 Q12,27 9,30" fill="#5a0000"/>
+  <path d="M10,28 Q9,20 11,15 L22,15 Q25,20 23,28 Q20,25 16,28 Q13,25 10,28" fill="#7a0a0a"/>
+  <rect x="10" y="9" width="12" height="7" rx="2" fill="#6a0808"/>
+  <rect x="10" y="14" width="12" height="2" fill="#cc1111"/>
+  <circle cx="16" cy="7" r="5.5" fill="#e8c090"/>
+  <path d="M9,8 Q9,2 16,1 Q23,2 23,8 Q20,6 16,7 Q12,6 9,8" fill="#2a0000"/>
+  <circle cx="14" cy="7" r="1.8" fill="#ff2222" opacity="0.9"/>
+  <circle cx="18" cy="7" r="1.8" fill="#ff2222" opacity="0.9"/>
+  <!-- Staff slightly angled back -->
+  <rect x="24" y="4" width="2" height="22" rx="1" fill="#5a3a1a" transform="rotate(8,25,15)"/>
+  <circle cx="25" cy="4" r="3" fill="#e8e0d0"/>
+  <circle cx="23.5" cy="4.5" r="0.8" fill="#333"/>
+  <circle cx="26.5" cy="4.5" r="0.8" fill="#333"/>
+  <path d="M23.5,6 Q25,7 26.5,6" fill="none" stroke="#333" stroke-width="0.7"/>
+  <rect x="4" y="11" width="7" height="2.5" rx="1" fill="#6a0808" transform="rotate(-20,7,12)"/>
+  <circle cx="25" cy="24" r="1.2" fill="#cc0000" opacity="0.8"/>
+  <circle cx="25" cy="27" r="0.8" fill="#cc0000" opacity="0.5"/>
+</svg>

--- a/web/public/sprites/blood-summoner.svg
+++ b/web/public/sprites/blood-summoner.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Blood Summoner — dark necromancer with skull staff, crimson robes -->
+  <!-- Robe — wide dark red -->
+  <path d="M8,30 Q7,20 9,15 L23,15 Q25,20 24,30 Q20,27 16,30 Q12,27 8,30" fill="#5a0000"/>
+  <path d="M9,28 Q8,20 10,15 L22,15 Q24,20 23,28 Q20,25 16,28 Q12,25 9,28" fill="#7a0a0a"/>
+  <!-- Body -->
+  <rect x="10" y="9" width="12" height="7" rx="2" fill="#6a0808"/>
+  <!-- Crimson trim -->
+  <rect x="10" y="14" width="12" height="2" fill="#cc1111"/>
+  <!-- Head -->
+  <circle cx="16" cy="7" r="5.5" fill="#e8c090"/>
+  <!-- Dark hood -->
+  <path d="M9,8 Q9,2 16,1 Q23,2 23,8 Q20,6 16,7 Q12,6 9,8" fill="#2a0000"/>
+  <!-- Hollow eyes (shadow lord look) -->
+  <circle cx="14" cy="7" r="1.8" fill="#ff2222" opacity="0.9"/>
+  <circle cx="18" cy="7" r="1.8" fill="#ff2222" opacity="0.9"/>
+  <!-- Skull staff (right hand) -->
+  <rect x="25" y="3" width="2" height="22" rx="1" fill="#5a3a1a"/>
+  <!-- Skull top -->
+  <circle cx="26" cy="4" r="3" fill="#e8e0d0"/>
+  <circle cx="24.5" cy="4.5" r="0.8" fill="#333"/>
+  <circle cx="27.5" cy="4.5" r="0.8" fill="#333"/>
+  <path d="M24.5,6 Q26,7 27.5,6" fill="none" stroke="#333" stroke-width="0.7"/>
+  <!-- Left arm raised (summoning gesture) -->
+  <rect x="4" y="10" width="7" height="2.5" rx="1" fill="#6a0808" transform="rotate(-30,7,11)"/>
+  <!-- Blood drip effect from staff -->
+  <circle cx="26" cy="24" r="1.2" fill="#cc0000" opacity="0.8"/>
+  <circle cx="26" cy="27" r="0.8" fill="#cc0000" opacity="0.6"/>
+</svg>

--- a/web/public/sprites/blood-wraith-1.svg
+++ b/web/public/sprites/blood-wraith-1.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Blood Wraith — frame 1 (float low) -->
+  <path d="M10,31 Q8,23 9,17 L23,17 Q24,23 22,31 Q19,28 16,31 Q13,28 10,31" fill="#4a0000" opacity="0.85"/>
+  <path d="M9,31 Q11,27 9,25" fill="none" stroke="#cc2222" stroke-width="1" opacity="0.7"/>
+  <path d="M23,31 Q21,27 23,25" fill="none" stroke="#cc2222" stroke-width="1" opacity="0.7"/>
+  <ellipse cx="16" cy="13" rx="7" ry="5" fill="#660000"/>
+  <ellipse cx="16" cy="12" rx="6" ry="4" fill="#881111"/>
+  <circle cx="16" cy="8" r="6" fill="#d0c0b0"/>
+  <ellipse cx="13" cy="7.5" rx="2" ry="2.2" fill="#110000"/>
+  <ellipse cx="19" cy="7.5" rx="2" ry="2.2" fill="#110000"/>
+  <ellipse cx="13" cy="7.5" rx="1.2" ry="1.3" fill="#cc0000" opacity="0.7"/>
+  <ellipse cx="19" cy="7.5" rx="1.2" ry="1.3" fill="#cc0000" opacity="0.7"/>
+  <path d="M11,11 Q16,13 21,11" fill="none" stroke="#888" stroke-width="0.8"/>
+  <line x1="14" y1="11" x2="14" y2="12.5" stroke="#888" stroke-width="0.7"/>
+  <line x1="16" y1="11.5" x2="16" y2="13" stroke="#888" stroke-width="0.7"/>
+  <line x1="18" y1="11" x2="18" y2="12.5" stroke="#888" stroke-width="0.7"/>
+  <path d="M9,13 Q5,11 4,8" fill="none" stroke="#660000" stroke-width="2"/>
+  <line x1="4" y1="8" x2="2" y2="6" stroke="#880000" stroke-width="1"/>
+  <line x1="4" y1="8" x2="3" y2="5" stroke="#880000" stroke-width="1"/>
+  <path d="M23,13 Q27,11 28,8" fill="none" stroke="#660000" stroke-width="2"/>
+  <line x1="28" y1="8" x2="30" y2="6" stroke="#880000" stroke-width="1"/>
+  <line x1="28" y1="8" x2="29" y2="5" stroke="#880000" stroke-width="1"/>
+</svg>

--- a/web/public/sprites/blood-wraith-2.svg
+++ b/web/public/sprites/blood-wraith-2.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Blood Wraith — frame 2 (float high, arms spread) -->
+  <path d="M10,32 Q8,25 9,19 L23,19 Q24,25 22,32 Q19,29 16,32 Q13,29 10,32" fill="#4a0000" opacity="0.85"/>
+  <path d="M10,32 Q12,29 10,27" fill="none" stroke="#cc2222" stroke-width="1.2" opacity="0.8"/>
+  <path d="M22,32 Q20,29 22,27" fill="none" stroke="#cc2222" stroke-width="1.2" opacity="0.8"/>
+  <ellipse cx="16" cy="15" rx="7" ry="5" fill="#660000"/>
+  <ellipse cx="16" cy="14" rx="6" ry="4" fill="#881111"/>
+  <circle cx="16" cy="10" r="6" fill="#d0c0b0"/>
+  <ellipse cx="13" cy="9.5" rx="2" ry="2.2" fill="#110000"/>
+  <ellipse cx="19" cy="9.5" rx="2" ry="2.2" fill="#110000"/>
+  <ellipse cx="13" cy="9.5" rx="1.4" ry="1.5" fill="#ff0000" opacity="0.8"/>
+  <ellipse cx="19" cy="9.5" rx="1.4" ry="1.5" fill="#ff0000" opacity="0.8"/>
+  <path d="M11,13 Q16,15 21,13" fill="none" stroke="#888" stroke-width="0.8"/>
+  <line x1="14" y1="13" x2="14" y2="14.5" stroke="#888" stroke-width="0.7"/>
+  <line x1="16" y1="13.5" x2="16" y2="15" stroke="#888" stroke-width="0.7"/>
+  <line x1="18" y1="13" x2="18" y2="14.5" stroke="#888" stroke-width="0.7"/>
+  <!-- Arms spread wide -->
+  <path d="M9,15 Q4,13 2,11" fill="none" stroke="#660000" stroke-width="2.5"/>
+  <line x1="2" y1="11" x2="0" y2="9" stroke="#880000" stroke-width="1.2"/>
+  <line x1="2" y1="11" x2="1" y2="8" stroke="#880000" stroke-width="1.2"/>
+  <path d="M23,15 Q28,13 30,11" fill="none" stroke="#660000" stroke-width="2.5"/>
+  <line x1="30" y1="11" x2="32" y2="9" stroke="#880000" stroke-width="1.2"/>
+  <line x1="30" y1="11" x2="31" y2="8" stroke="#880000" stroke-width="1.2"/>
+</svg>

--- a/web/public/sprites/blood-wraith-3.svg
+++ b/web/public/sprites/blood-wraith-3.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Blood Wraith — frame 3 (drift, arms lower) -->
+  <path d="M11,32 Q8,24 10,18 L22,18 Q25,24 22,32 Q19,29 16,32 Q13,29 11,32" fill="#4a0000" opacity="0.85"/>
+  <path d="M11,32 Q12,27 10,25" fill="none" stroke="#cc2222" stroke-width="1" opacity="0.6"/>
+  <path d="M21,32 Q20,27 22,25" fill="none" stroke="#cc2222" stroke-width="1" opacity="0.6"/>
+  <ellipse cx="16" cy="14" rx="7" ry="5" fill="#660000"/>
+  <ellipse cx="16" cy="13" rx="6" ry="4" fill="#881111"/>
+  <circle cx="16" cy="9" r="6" fill="#d0c0b0"/>
+  <ellipse cx="13" cy="8.5" rx="2" ry="2.2" fill="#110000"/>
+  <ellipse cx="19" cy="8.5" rx="2" ry="2.2" fill="#110000"/>
+  <ellipse cx="13" cy="8.5" rx="1.2" ry="1.3" fill="#cc0000" opacity="0.7"/>
+  <ellipse cx="19" cy="8.5" rx="1.2" ry="1.3" fill="#cc0000" opacity="0.7"/>
+  <path d="M11,12 Q16,14 21,12" fill="none" stroke="#888" stroke-width="0.8"/>
+  <line x1="14" y1="12" x2="14" y2="13.5" stroke="#888" stroke-width="0.7"/>
+  <line x1="16" y1="12.5" x2="16" y2="14" stroke="#888" stroke-width="0.7"/>
+  <line x1="18" y1="12" x2="18" y2="13.5" stroke="#888" stroke-width="0.7"/>
+  <!-- Arms angled down -->
+  <path d="M9,14 Q5,15 3,14" fill="none" stroke="#660000" stroke-width="2"/>
+  <line x1="3" y1="14" x2="1" y2="13" stroke="#880000" stroke-width="1"/>
+  <line x1="3" y1="14" x2="2" y2="12" stroke="#880000" stroke-width="1"/>
+  <path d="M23,14 Q27,15 29,14" fill="none" stroke="#660000" stroke-width="2"/>
+  <line x1="29" y1="14" x2="31" y2="13" stroke="#880000" stroke-width="1"/>
+  <line x1="29" y1="14" x2="30" y2="12" stroke="#880000" stroke-width="1"/>
+</svg>

--- a/web/public/sprites/blood-wraith.svg
+++ b/web/public/sprites/blood-wraith.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Blood Wraith — ethereal undead, crimson and shadow -->
+  <!-- Ghostly lower form -->
+  <path d="M10,32 Q8,24 9,18 L23,18 Q24,24 22,32 Q19,29 16,32 Q13,29 10,32" fill="#4a0000" opacity="0.85"/>
+  <!-- Wisps at bottom -->
+  <path d="M10,32 Q12,28 10,26" fill="none" stroke="#cc2222" stroke-width="1" opacity="0.7"/>
+  <path d="M22,32 Q20,28 22,26" fill="none" stroke="#cc2222" stroke-width="1" opacity="0.7"/>
+  <!-- Body -->
+  <ellipse cx="16" cy="14" rx="7" ry="5" fill="#660000"/>
+  <ellipse cx="16" cy="13" rx="6" ry="4" fill="#881111"/>
+  <!-- Skull-like head -->
+  <circle cx="16" cy="9" r="6" fill="#d0c0b0"/>
+  <!-- Empty eye sockets -->
+  <ellipse cx="13" cy="8.5" rx="2" ry="2.2" fill="#110000"/>
+  <ellipse cx="19" cy="8.5" rx="2" ry="2.2" fill="#110000"/>
+  <!-- Red glow in sockets -->
+  <ellipse cx="13" cy="8.5" rx="1.2" ry="1.3" fill="#cc0000" opacity="0.7"/>
+  <ellipse cx="19" cy="8.5" rx="1.2" ry="1.3" fill="#cc0000" opacity="0.7"/>
+  <!-- Jaw -->
+  <path d="M11,12 Q16,14 21,12" fill="none" stroke="#888" stroke-width="0.8"/>
+  <line x1="14" y1="12" x2="14" y2="13.5" stroke="#888" stroke-width="0.7"/>
+  <line x1="16" y1="12.5" x2="16" y2="14" stroke="#888" stroke-width="0.7"/>
+  <line x1="18" y1="12" x2="18" y2="13.5" stroke="#888" stroke-width="0.7"/>
+  <!-- Clawed arms -->
+  <path d="M9,14 Q5,12 4,9" fill="none" stroke="#660000" stroke-width="2"/>
+  <line x1="4" y1="9" x2="2" y2="7" stroke="#880000" stroke-width="1"/>
+  <line x1="4" y1="9" x2="3" y2="6" stroke="#880000" stroke-width="1"/>
+  <path d="M23,14 Q27,12 28,9" fill="none" stroke="#660000" stroke-width="2"/>
+  <line x1="28" y1="9" x2="30" y2="7" stroke="#880000" stroke-width="1"/>
+  <line x1="28" y1="9" x2="29" y2="6" stroke="#880000" stroke-width="1"/>
+</svg>

--- a/web/public/sprites/builder-1.svg
+++ b/web/public/sprites/builder-1.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Builder — frame 1 (stride A, hammer raised) -->
+  <rect x="9" y="13" width="14" height="11" rx="2" fill="#8b6530"/>
+  <rect x="10" y="14" width="12" height="9" rx="1" fill="#a87840"/>
+  <rect x="12" y="14" width="8" height="1.5" fill="#5a3a10"/>
+  <!-- Left foot forward -->
+  <rect x="9" y="24" width="5" height="7" rx="1" fill="#7a5528" transform="rotate(-8,11,24)"/>
+  <rect x="18" y="24" width="5" height="7" rx="1" fill="#7a5528" transform="rotate(6,20,24)"/>
+  <rect x="8" y="29" width="6" height="3" rx="1" fill="#3a2010"/>
+  <rect x="18" y="29" width="6" height="3" rx="1" fill="#3a2010"/>
+  <circle cx="16" cy="10" r="5.5" fill="#f0c888"/>
+  <rect x="10" y="7" width="12" height="4" rx="2" fill="#e8c000"/>
+  <rect x="8" y="9" width="16" height="2" rx="1" fill="#cc9900"/>
+  <circle cx="14" cy="11" r="1.2" fill="#333"/>
+  <circle cx="18" cy="11" r="1.2" fill="#333"/>
+  <path d="M13,13 Q16,15 19,13" fill="#7a5528" stroke="#5a3a10" stroke-width="0.5"/>
+  <!-- Hammer raised -->
+  <rect x="24" y="8" width="2.5" height="14" rx="1" fill="#5a3a1a" transform="rotate(-30,25,15)"/>
+  <rect x="22" y="5" width="7" height="5" rx="1.5" fill="#888" transform="rotate(-30,25,7)"/>
+  <rect x="22" y="6" width="7" height="2" rx="0.5" fill="#aaaaaa" transform="rotate(-30,25,7)"/>
+  <rect x="4" y="15" width="6" height="2.5" rx="1" fill="#8b6530" transform="rotate(15,7,16)"/>
+  <rect x="9" y="23" width="14" height="2" rx="1" fill="#5a3a10"/>
+  <circle cx="16" cy="24" r="1" fill="#cc9900"/>
+</svg>

--- a/web/public/sprites/builder-2.svg
+++ b/web/public/sprites/builder-2.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Builder — frame 2 (hammer swinging down) -->
+  <rect x="9" y="12" width="14" height="12" rx="2" fill="#8b6530"/>
+  <rect x="10" y="13" width="12" height="10" rx="1" fill="#a87840"/>
+  <rect x="12" y="13" width="8" height="1.5" fill="#5a3a10"/>
+  <rect x="10" y="24" width="5" height="7" rx="1" fill="#7a5528"/>
+  <rect x="17" y="24" width="5" height="7" rx="1" fill="#7a5528"/>
+  <rect x="9" y="29" width="6" height="3" rx="1" fill="#3a2010"/>
+  <rect x="17" y="29" width="6" height="3" rx="1" fill="#3a2010"/>
+  <circle cx="16" cy="9" r="5.5" fill="#f0c888"/>
+  <rect x="10" y="6" width="12" height="4" rx="2" fill="#e8c000"/>
+  <rect x="8" y="8" width="16" height="2" rx="1" fill="#cc9900"/>
+  <circle cx="14" cy="10" r="1.2" fill="#333"/>
+  <circle cx="18" cy="10" r="1.2" fill="#333"/>
+  <path d="M13,12 Q16,14 19,12" fill="#7a5528" stroke="#5a3a10" stroke-width="0.5"/>
+  <!-- Hammer striking down -->
+  <rect x="24" y="14" width="2.5" height="12" rx="1" fill="#5a3a1a"/>
+  <rect x="21" y="12" width="7" height="5" rx="1.5" fill="#888"/>
+  <rect x="21" y="13" width="7" height="2" rx="0.5" fill="#aaaaaa"/>
+  <!-- Impact marks -->
+  <line x1="22" y1="26" x2="20" y2="27" stroke="#888" stroke-width="0.8" opacity="0.7"/>
+  <line x1="26" y1="26" x2="28" y2="27" stroke="#888" stroke-width="0.8" opacity="0.7"/>
+  <rect x="4" y="13" width="6" height="2.5" rx="1" fill="#8b6530"/>
+  <rect x="9" y="23" width="14" height="2" rx="1" fill="#5a3a10"/>
+  <circle cx="16" cy="24" r="1" fill="#cc9900"/>
+</svg>

--- a/web/public/sprites/builder-3.svg
+++ b/web/public/sprites/builder-3.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Builder — frame 3 (stride B, hammer at side) -->
+  <rect x="9" y="13" width="14" height="11" rx="2" fill="#8b6530"/>
+  <rect x="10" y="14" width="12" height="9" rx="1" fill="#a87840"/>
+  <rect x="12" y="14" width="8" height="1.5" fill="#5a3a10"/>
+  <!-- Right foot forward -->
+  <rect x="9" y="24" width="5" height="7" rx="1" fill="#7a5528" transform="rotate(6,11,24)"/>
+  <rect x="18" y="24" width="5" height="7" rx="1" fill="#7a5528" transform="rotate(-8,20,24)"/>
+  <rect x="8" y="29" width="6" height="3" rx="1" fill="#3a2010"/>
+  <rect x="18" y="29" width="6" height="3" rx="1" fill="#3a2010"/>
+  <circle cx="16" cy="10" r="5.5" fill="#f0c888"/>
+  <rect x="10" y="7" width="12" height="4" rx="2" fill="#e8c000"/>
+  <rect x="8" y="9" width="16" height="2" rx="1" fill="#cc9900"/>
+  <circle cx="14" cy="11" r="1.2" fill="#333"/>
+  <circle cx="18" cy="11" r="1.2" fill="#333"/>
+  <path d="M13,13 Q16,15 19,13" fill="#7a5528" stroke="#5a3a10" stroke-width="0.5"/>
+  <rect x="23" y="14" width="2.5" height="14" rx="1" fill="#5a3a1a"/>
+  <rect x="21" y="12" width="7" height="5" rx="1.5" fill="#888"/>
+  <rect x="21" y="13" width="7" height="2" rx="0.5" fill="#aaaaaa"/>
+  <rect x="4" y="14" width="6" height="2.5" rx="1" fill="#8b6530" transform="rotate(-15,7,15)"/>
+  <rect x="9" y="23" width="14" height="2" rx="1" fill="#5a3a10"/>
+  <circle cx="16" cy="24" r="1" fill="#cc9900"/>
+</svg>

--- a/web/public/sprites/builder.svg
+++ b/web/public/sprites/builder.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Builder — stocky worker with hammer, brown/tan work clothes -->
+  <!-- Sturdy body -->
+  <rect x="9" y="13" width="14" height="11" rx="2" fill="#8b6530"/>
+  <rect x="10" y="14" width="12" height="9" rx="1" fill="#a87840"/>
+  <!-- Overalls strap -->
+  <rect x="12" y="14" width="8" height="1.5" fill="#5a3a10"/>
+  <!-- Legs -->
+  <rect x="10" y="24" width="5" height="7" rx="1" fill="#7a5528"/>
+  <rect x="17" y="24" width="5" height="7" rx="1" fill="#7a5528"/>
+  <!-- Boots -->
+  <rect x="9" y="29" width="6" height="3" rx="1" fill="#3a2010"/>
+  <rect x="17" y="29" width="6" height="3" rx="1" fill="#3a2010"/>
+  <!-- Head -->
+  <circle cx="16" cy="10" r="5.5" fill="#f0c888"/>
+  <!-- Hard hat -->
+  <rect x="10" y="7" width="12" height="4" rx="2" fill="#e8c000"/>
+  <rect x="8" y="9" width="16" height="2" rx="1" fill="#cc9900"/>
+  <!-- Eyes — focused -->
+  <circle cx="14" cy="11" r="1.2" fill="#333"/>
+  <circle cx="18" cy="11" r="1.2" fill="#333"/>
+  <!-- Bushy moustache -->
+  <path d="M13,13 Q16,15 19,13" fill="#7a5528" stroke="#5a3a10" stroke-width="0.5"/>
+  <!-- Hammer (right hand) -->
+  <rect x="23" y="12" width="2.5" height="14" rx="1" fill="#5a3a1a"/>
+  <!-- Hammer head -->
+  <rect x="21" y="10" width="7" height="5" rx="1.5" fill="#888"/>
+  <rect x="21" y="11" width="7" height="2" rx="0.5" fill="#aaaaaa"/>
+  <!-- Left arm -->
+  <rect x="4" y="14" width="6" height="2.5" rx="1" fill="#8b6530"/>
+  <!-- Tool belt -->
+  <rect x="9" y="23" width="14" height="2" rx="1" fill="#5a3a10"/>
+  <circle cx="16" cy="24" r="1" fill="#cc9900"/>
+</svg>

--- a/web/public/sprites/phantom-1.svg
+++ b/web/public/sprites/phantom-1.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Phantom — frame 1 (robe sway left) -->
+  <ellipse cx="16" cy="16" rx="13" ry="14" fill="none" stroke="#6699ff" stroke-width="0.6" opacity="0.5"/>
+  <path d="M11,31 Q8,23 10,18 L22,18 Q24,22 21,31 Q18,28 16,31 Q13,28 11,31" fill="#3a2a7a" opacity="0.85"/>
+  <rect x="10" y="11" width="12" height="8" rx="3" fill="#4a35a0"/>
+  <path d="M8,12 Q8,4 16,3 Q24,4 24,12 Q21,10 16,11 Q11,10 8,12" fill="#2a1a5a"/>
+  <ellipse cx="16" cy="11" rx="4" ry="3.5" fill="#c8b4ff" opacity="0.6"/>
+  <circle cx="14" cy="11" r="1.5" fill="#99ccff"/>
+  <circle cx="18" cy="11" r="1.5" fill="#99ccff"/>
+  <rect x="4" y="13" width="6" height="2.5" rx="1" fill="#4a35a0" transform="rotate(-25,7,14)"/>
+  <rect x="22" y="11" width="6" height="2.5" rx="1" fill="#4a35a0" transform="rotate(15,25,12)"/>
+  <line x1="26" y1="8" x2="26" y2="19" stroke="#8844cc" stroke-width="1.5"/>
+  <path d="M24,11 Q26,13.5 28,11" fill="none" stroke="#aaaaff" stroke-width="0.8"/>
+  <line x1="22" y1="13" x2="26" y2="13" stroke="#ccaaff" stroke-width="1"/>
+  <circle cx="22" cy="13" r="1" fill="#ccaaff"/>
+  <circle cx="5" cy="5" r="1.2" fill="#99ccff" opacity="0.8"/>
+  <circle cx="27" cy="28" r="0.6" fill="#99ccff" opacity="0.4"/>
+  <circle cx="3" cy="22" r="0.9" fill="#ccaaff" opacity="0.7"/>
+</svg>

--- a/web/public/sprites/phantom-2.svg
+++ b/web/public/sprites/phantom-2.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Phantom — frame 2 (drawing bow) -->
+  <ellipse cx="16" cy="15" rx="13" ry="13" fill="none" stroke="#6699ff" stroke-width="0.6" opacity="0.6"/>
+  <path d="M10,30 Q8,22 10,17 L22,17 Q24,21 22,30 Q19,27 16,30 Q13,27 10,30" fill="#3a2a7a" opacity="0.85"/>
+  <rect x="10" y="10" width="12" height="8" rx="3" fill="#4a35a0"/>
+  <path d="M8,11 Q8,3 16,2 Q24,3 24,11 Q21,9 16,10 Q11,9 8,11" fill="#2a1a5a"/>
+  <ellipse cx="16" cy="10" rx="4" ry="3.5" fill="#c8b4ff" opacity="0.6"/>
+  <circle cx="14" cy="10" r="1.5" fill="#99ccff"/>
+  <circle cx="18" cy="10" r="1.5" fill="#99ccff"/>
+  <!-- Arms pulling bow string -->
+  <rect x="4" y="11" width="7" height="2.5" rx="1" fill="#4a35a0" transform="rotate(-10,7,12)"/>
+  <rect x="21" y="11" width="7" height="2.5" rx="1" fill="#4a35a0" transform="rotate(10,24,12)"/>
+  <!-- Bow fully drawn -->
+  <path d="M27,7 Q30,12.5 27,18" fill="none" stroke="#8844cc" stroke-width="2"/>
+  <line x1="27" y1="7" x2="27" y2="18" stroke="#ccaaff" stroke-width="0.8" stroke-dasharray="1,1"/>
+  <line x1="21" y1="12" x2="27" y2="12" stroke="#ccaaff" stroke-width="1.2"/>
+  <circle cx="21" cy="12" r="1.2" fill="#ccaaff"/>
+  <!-- Glowing arrow tip -->
+  <line x1="19" y1="12" x2="21" y2="12" stroke="#ffffff" stroke-width="1.5"/>
+  <circle cx="5" cy="7" r="0.8" fill="#99ccff" opacity="0.9"/>
+  <circle cx="29" cy="25" r="0.7" fill="#99ccff" opacity="0.5"/>
+</svg>

--- a/web/public/sprites/phantom-3.svg
+++ b/web/public/sprites/phantom-3.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Phantom — frame 3 (robe sway right / post-teleport shimmer) -->
+  <ellipse cx="16" cy="16" rx="14" ry="14" fill="none" stroke="#99bbff" stroke-width="0.8" opacity="0.6"/>
+  <path d="M9,30 Q8,22 11,18 L22,18 Q25,23 23,30 Q20,27 16,30 Q13,27 9,30" fill="#3a2a7a" opacity="0.85"/>
+  <rect x="10" y="11" width="12" height="8" rx="3" fill="#4a35a0"/>
+  <path d="M8,12 Q8,4 16,3 Q24,4 24,12 Q21,10 16,11 Q11,10 8,12" fill="#2a1a5a"/>
+  <ellipse cx="16" cy="11" rx="4" ry="3.5" fill="#c8b4ff" opacity="0.7"/>
+  <circle cx="14" cy="11" r="1.5" fill="#aaddff"/>
+  <circle cx="18" cy="11" r="1.5" fill="#aaddff"/>
+  <rect x="5" y="13" width="6" height="2.5" rx="1" fill="#4a35a0" transform="rotate(15,8,14)"/>
+  <rect x="21" y="12" width="6" height="2.5" rx="1" fill="#4a35a0" transform="rotate(-15,24,13)"/>
+  <line x1="26" y1="9" x2="26" y2="20" stroke="#8844cc" stroke-width="1.5"/>
+  <path d="M24,12 Q26,14.5 28,12" fill="none" stroke="#aaaaff" stroke-width="0.8"/>
+  <line x1="22" y1="14" x2="26" y2="14" stroke="#ccaaff" stroke-width="1"/>
+  <circle cx="22" cy="14" r="1" fill="#ccaaff"/>
+  <!-- Extra sparkles for teleport shimmer -->
+  <circle cx="4" cy="8" r="1.3" fill="#aaddff" opacity="0.9"/>
+  <circle cx="28" cy="4" r="0.9" fill="#ccaaff" opacity="0.7"/>
+  <circle cx="3" cy="26" r="0.8" fill="#99ccff" opacity="0.8"/>
+  <circle cx="29" cy="20" r="1" fill="#aaddff" opacity="0.6"/>
+</svg>

--- a/web/public/sprites/phantom.svg
+++ b/web/public/sprites/phantom.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Phantom (Teleporter) — spectral hooded archer, blue/purple -->
+  <!-- Ethereal glow aura -->
+  <ellipse cx="16" cy="16" rx="13" ry="14" fill="none" stroke="#6699ff" stroke-width="0.6" opacity="0.5"/>
+  <!-- Flowing robe / ghostly lower body -->
+  <path d="M10,30 Q8,22 10,18 L22,18 Q24,22 22,30 Q19,27 16,30 Q13,27 10,30" fill="#3a2a7a" opacity="0.85"/>
+  <!-- Body -->
+  <rect x="10" y="11" width="12" height="8" rx="3" fill="#4a35a0"/>
+  <!-- Hood -->
+  <path d="M8,12 Q8,4 16,3 Q24,4 24,12 Q21,10 16,11 Q11,10 8,12" fill="#2a1a5a"/>
+  <!-- Glowing face area (barely visible under hood) -->
+  <ellipse cx="16" cy="11" rx="4" ry="3.5" fill="#c8b4ff" opacity="0.6"/>
+  <!-- Glowing eyes -->
+  <circle cx="14" cy="11" r="1.5" fill="#99ccff"/>
+  <circle cx="18" cy="11" r="1.5" fill="#99ccff"/>
+  <!-- Arms -->
+  <rect x="5" y="12" width="6" height="2.5" rx="1" fill="#4a35a0" transform="rotate(-20,8,13)"/>
+  <rect x="21" y="12" width="6" height="2.5" rx="1" fill="#4a35a0" transform="rotate(20,24,13)"/>
+  <!-- Glowing arrow/bow -->
+  <line x1="26" y1="9" x2="26" y2="20" stroke="#8844cc" stroke-width="1.5"/>
+  <path d="M24,12 Q26,14.5 28,12" fill="none" stroke="#aaaaff" stroke-width="0.8"/>
+  <line x1="22" y1="14" x2="26" y2="14" stroke="#ccaaff" stroke-width="1"/>
+  <circle cx="22" cy="14" r="1" fill="#ccaaff"/>
+  <!-- Teleport sparkles -->
+  <circle cx="6" cy="6" r="1" fill="#99ccff" opacity="0.7"/>
+  <circle cx="28" cy="26" r="0.8" fill="#99ccff" opacity="0.5"/>
+  <circle cx="4" cy="24" r="0.7" fill="#ccaaff" opacity="0.6"/>
+</svg>

--- a/web/src/components/Battlefield.tsx
+++ b/web/src/components/Battlefield.tsx
@@ -254,6 +254,7 @@ function LaneUnit({ unit, stackIndex = 0, wallStack, onInspect, showName, celebr
         unit.climbing ? 'lane-unit--climbing' : '',
         unit.size ? `lane-unit--size-${unit.size}` : '',
         isCelebrating ? 'lane-unit--celebrating' : '',
+        unit.invisTimer != null && unit.invisTimer > 0 ? 'lane-unit--invisible' : '',
       ].filter(Boolean).join(' ')}
       style={isCelebrating ? { ...style, animationDelay: `${(unit.id.charCodeAt(0) % 7) * 0.1}s` } : style}
       title={`${unit.name} — ${unit.hp}/${unit.maxHp} HP, ${unit.attack} ATK`}

--- a/web/src/data/cards.json
+++ b/web/src/data/cards.json
@@ -19553,6 +19553,151 @@
       },
       "description": "HERO: Deploys Rob — a reckless wizard who explodes on death, blasting all nearby enemies! Also grants all units +3 attack.",
       "lore": "Big smile. Bigger explosions. The glasses are purely decorative."
+    },
+    {
+      "id": "hero-blast-maiden",
+      "name": "Blast Maiden",
+      "rarity": "legendary",
+      "cost": 5,
+      "cardType": "unit",
+      "isHero": true,
+      "unit": {
+        "name": "Blast Maiden",
+        "attack": 11,
+        "maxHp": 65,
+        "isWall": false,
+        "bypassWall": false,
+        "moveSpeed": 13,
+        "attackRange": 5,
+        "attackCooldownMs": 1900,
+        "onDeathEffect": { "damage": 35, "range": 120 },
+        "tags": ["melee", "large"]
+      },
+      "heroEffect": {
+        "type": "buffMaxHp",
+        "amount": 15
+      },
+      "description": "HERO: Deploys the Blast Maiden — a fearless warrior carrying explosives. On death she detonates for massive AoE damage! All units also gain +15 max HP.",
+      "lore": "She doesn't fear death. Death fears the radius."
+    },
+    {
+      "id": "hero-phantom-dasher",
+      "name": "Phantom Dasher",
+      "rarity": "legendary",
+      "cost": 5,
+      "cardType": "unit",
+      "isHero": true,
+      "unit": {
+        "name": "Phantom",
+        "attack": 13,
+        "maxHp": 32,
+        "isWall": false,
+        "bypassWall": true,
+        "moveSpeed": 18,
+        "attackRange": 45,
+        "attackCooldownMs": 2000,
+        "teleportAbility": { "cooldownMs": 5500, "distancePx": 130 },
+        "tags": ["ranged", "magic"]
+      },
+      "heroEffect": {
+        "type": "buffSpeed",
+        "amount": 12
+      },
+      "description": "HERO: Deploys the Phantom — a spectral archer who teleports forward every 5.5s, bypassing obstacles! All units gain +12 speed.",
+      "lore": "Location is a state of mind. Mind is overrated."
+    },
+    {
+      "id": "hero-shadow",
+      "name": "Shadow",
+      "rarity": "legendary",
+      "cost": 5,
+      "cardType": "unit",
+      "isHero": true,
+      "unit": {
+        "name": "Shadow Stalker",
+        "attack": 16,
+        "maxHp": 32,
+        "isWall": false,
+        "bypassWall": false,
+        "climber": true,
+        "moveSpeed": 52,
+        "attackRange": 5,
+        "attackCooldownMs": 1300,
+        "invisibilityAbility": { "activeMs": 4000, "cooldownMs": 7000 },
+        "tags": ["melee", "fast"]
+      },
+      "heroEffect": {
+        "type": "buffAttackCooldown",
+        "amount": -400
+      },
+      "description": "HERO: Deploys the Shadow Stalker — a fast melee assassin who vanishes into invisibility periodically, becoming untargetable! All units also gain -400ms attack cooldown.",
+      "lore": "Always watching. Never seen."
+    },
+    {
+      "id": "hero-blood-summoner",
+      "name": "Blood Summoner",
+      "rarity": "legendary",
+      "cost": 5,
+      "cardType": "unit",
+      "isHero": true,
+      "unit": {
+        "name": "Blood Summoner",
+        "attack": 7,
+        "maxHp": 45,
+        "isWall": false,
+        "bypassWall": true,
+        "moveSpeed": 14,
+        "attackRange": 40,
+        "attackCooldownMs": 2500,
+        "bloodSummonAbility": {
+          "cooldownMs": 5000,
+          "range": 150,
+          "minionTemplate": {
+            "name": "Blood Wraith",
+            "attack": 9,
+            "maxHp": 20,
+            "isWall": false,
+            "bypassWall": false,
+            "moveSpeed": 34,
+            "attackRange": 5,
+            "attackCooldownMs": 1600,
+            "tags": ["undead", "fast"]
+          }
+        },
+        "tags": ["magic", "ranged"]
+      },
+      "heroEffect": {
+        "type": "healUnits",
+        "amount": 10
+      },
+      "description": "HERO: Deploys the Blood Summoner — a dark mage who raises Blood Wraiths from fallen enemies' blood pools every 5s! All units are also healed for 10 HP.",
+      "lore": "Blood doesn't lie. It just... gets around."
+    },
+    {
+      "id": "hero-the-builder",
+      "name": "The Builder",
+      "rarity": "legendary",
+      "cost": 5,
+      "cardType": "unit",
+      "isHero": true,
+      "unit": {
+        "name": "Builder",
+        "attack": 5,
+        "maxHp": 58,
+        "isWall": false,
+        "bypassWall": false,
+        "moveSpeed": 10,
+        "attackRange": 5,
+        "attackCooldownMs": 2200,
+        "unitTrait": { "builderMode": true, "buildIntervalMs": 3000, "buildRepairAmount": 8 },
+        "tags": ["melee", "slow"]
+      },
+      "heroEffect": {
+        "type": "buffMaxHp",
+        "amount": 18
+      },
+      "description": "HERO: Deploys the Builder — a tireless worker who repairs nearby buildings every 3s and upgrades them once they're at full health! All units gain +18 max HP.",
+      "lore": "Can fix anything. Given enough time. And lumber."
     }
   ]
 }

--- a/web/src/game/cards.ts
+++ b/web/src/game/cards.ts
@@ -55,6 +55,9 @@ interface RawUnitDef {
   climber?: boolean
   structureEffect?: RawStructureEffect
   onDeathEffect?: { damage: number; range: number }
+  teleportAbility?: { cooldownMs: number; distancePx: number }
+  invisibilityAbility?: { activeMs: number; cooldownMs: number }
+  bloodSummonAbility?: { cooldownMs: number; minionTemplate: RawUnitDef; range: number }
 }
 
 interface RawCardDef {

--- a/web/src/game/engine.ts
+++ b/web/src/game/engine.ts
@@ -1,14 +1,16 @@
-import { GameState, Card, UnitTemplate, CardRarity } from './types'
+import { GameState, Card, UnitTemplate, CardRarity, LANE_WIDTH } from './types'
 import { makeDeck, makeNodeDeck, HERO_CARDS, getCardUnit, getCardCatalog, flushCardValidationErrors } from './cards'
 import { loadPlayerStats } from './playerStats'
 
 import { moveUnits, processAffinities } from './engine/units'
 import { processAttacks } from './engine/combat'
-import { BASE_MAX_MANA, BLOOD_POOL_FADE_MS, MANA_REGEN_MS, OPPONENT_INTERVAL_MS, PLAYER_SPAWN_X, SPAWN_GROW_MS } from './engine/constants'
+import { BASE_MAX_MANA, BLOOD_POOL_FADE_MS, BASE_STOP_MARGIN, MANA_REGEN_MS, OPPONENT_INTERVAL_MS, PLAYER_SPAWN_X, SPAWN_GROW_MS } from './engine/constants'
 import { genericBossAI, getBossAIDef } from './engine/boss'
 import { tickBossTrait } from './engine/bossTraits'
 import { getManaBonus, getManaSpeedMult } from './engine/bonusEffects'
 import { uid, shuffle, spawnUnit } from './engine/helpers'
+import { MAX_UPGRADE_LEVEL } from './engine/cards'
+import { unitDist } from './engine/targeting'
 import { opponentAI } from './engine/opponentAI'
 import { triggerBattleEvent, BATTLE_EVENT_BASE_MS } from './engine/battleEvents'
 import { generateTerrain } from './engine/terrain'
@@ -549,6 +551,115 @@ function performUnitMaintenance(s: GameState, deltaMs: number, log: string[]) {
           log.push(`${who} ${unit.name} repaired ${targets.length} structure(s) for ${amount} HP.`)
         }
         unit.spawnTimer = intervalMs
+      }
+    }
+
+    // Teleport ability: blink forward every cooldownMs
+    if (unit.teleportAbility && unit.moveSpeed > 0 && unit.hp > 0) {
+      if (unit.teleportTimer == null) unit.teleportTimer = unit.teleportAbility.cooldownMs
+      unit.teleportTimer -= deltaMs
+      if (unit.teleportTimer <= 0) {
+        const dist = unit.teleportAbility.distancePx
+        if (unit.owner === 'player') {
+          unit.x = Math.min(LANE_WIDTH - BASE_STOP_MARGIN, unit.x + dist)
+        } else {
+          unit.x = Math.max(BASE_STOP_MARGIN, unit.x - dist)
+        }
+        unit.damageFlashTimer = 150
+        unit.teleportTimer = unit.teleportAbility.cooldownMs
+        log.push(`${unit.name} blinks forward!`)
+      }
+    }
+
+    // Invisibility ability: cycle between active (invisible) and cooldown phases
+    if (unit.invisibilityAbility && unit.moveSpeed > 0 && unit.hp > 0) {
+      if (unit.invisTimer == null && unit.invisCooldownTimer == null) {
+        // First tick — begin invisible immediately
+        unit.invisTimer = unit.invisibilityAbility.activeMs
+        log.push(`!!${unit.name} vanishes into shadow!`)
+      } else if (unit.invisTimer != null && unit.invisTimer > 0) {
+        unit.invisTimer = Math.max(0, unit.invisTimer - deltaMs)
+        if (unit.invisTimer === 0) {
+          unit.invisCooldownTimer = unit.invisibilityAbility.cooldownMs
+        }
+      } else if (unit.invisCooldownTimer != null && unit.invisCooldownTimer > 0) {
+        unit.invisCooldownTimer = Math.max(0, unit.invisCooldownTimer - deltaMs)
+        if (unit.invisCooldownTimer === 0) {
+          unit.invisTimer = unit.invisibilityAbility.activeMs
+          log.push(`!!${unit.name} vanishes again!`)
+        }
+      }
+    }
+
+    // Blood summon ability: consume a nearby blood pool to raise a minion
+    if (unit.bloodSummonAbility && unit.moveSpeed > 0 && unit.hp > 0) {
+      if (unit.bloodSummonTimer == null) unit.bloodSummonTimer = unit.bloodSummonAbility.cooldownMs
+      unit.bloodSummonTimer -= deltaMs
+      if (unit.bloodSummonTimer <= 0) {
+        const pool = s.bloodPools.find(
+          p => p.fadingAt === undefined &&
+               Math.hypot(p.x - unit.x, p.y - unit.y) <= unit.bloodSummonAbility!.range
+        )
+        if (pool) {
+          pool.fadingAt = s.gameTime
+          const minion = spawnUnit(unit.bloodSummonAbility.minionTemplate, unit.owner)
+          minion.x = pool.x
+          minion.y = pool.y
+          minion.spawnGrowTimer = SPAWN_GROW_MS
+          s.field.push(minion)
+          const who = unit.owner === 'player' ? 'Your' : 'Enemy'
+          log.push(`!!${who} ${unit.name} raises a ${minion.name} from the fallen!`)
+        }
+        unit.bloodSummonTimer = unit.bloodSummonAbility.cooldownMs
+      }
+    }
+
+    // Builder ability: repair damaged buildings or upgrade fully-healed ones
+    if (unit.unitTrait?.builderMode && unit.moveSpeed > 0 && unit.hp > 0) {
+      const buildInterval = unit.unitTrait.buildIntervalMs ?? 3000
+      const repairAmt = unit.unitTrait.buildRepairAmount ?? 8
+      if (unit.buildTimer == null) unit.buildTimer = buildInterval
+      unit.buildTimer -= deltaMs
+      if (unit.buildTimer <= 0) {
+        const nearBuilding = s.field.find(
+          b => b.owner === unit.owner && b.moveSpeed === 0 && !b.isWall && b.hp > 0 &&
+               unitDist(unit, b) <= 60
+        )
+        if (nearBuilding) {
+          if (nearBuilding.hp < nearBuilding.maxHp) {
+            nearBuilding.hp = Math.min(nearBuilding.maxHp, nearBuilding.hp + repairAmt)
+            const who = unit.owner === 'player' ? 'Your' : 'Enemy'
+            log.push(`${who} ${unit.name} repaired ${nearBuilding.name} for ${repairAmt} HP.`)
+          } else if ((nearBuilding.upgradeLevel ?? 1) < MAX_UPGRADE_LEVEL) {
+            nearBuilding.maxHp *= 2
+            nearBuilding.hp = nearBuilding.maxHp
+            nearBuilding.upgradeLevel = (nearBuilding.upgradeLevel ?? 1) + 1
+            let note = 'HP×2'
+            if (nearBuilding.structureEffect?.type === 'spawn') {
+              const eff = nearBuilding.structureEffect as { type: 'spawn'; unitTemplate: UnitTemplate; intervalMs: number }
+              eff.intervalMs = Math.max(1500, Math.floor(eff.intervalMs / 2))
+              if (nearBuilding.spawnTimer != null) nearBuilding.spawnTimer = Math.min(nearBuilding.spawnTimer, eff.intervalMs)
+              note += ', spawn×2'
+            }
+            if (nearBuilding.structureEffect?.type === 'mana') {
+              (nearBuilding.structureEffect as { type: 'mana'; amount: number }).amount += 1
+              note += ', mana+1'
+            }
+            if (nearBuilding.structureEffect?.type === 'healAura') {
+              const eff = nearBuilding.structureEffect as { type: 'healAura'; amount: number; intervalMs: number }
+              eff.intervalMs = Math.max(2000, Math.floor(eff.intervalMs / 2))
+              note += ', heal×2'
+            }
+            if (nearBuilding.structureEffect?.type === 'repairAura') {
+              const eff = nearBuilding.structureEffect as { type: 'repairAura'; amount: number; intervalMs: number }
+              eff.intervalMs = Math.max(2000, Math.floor(eff.intervalMs / 2))
+              note += ', repair×2'
+            }
+            const who = unit.owner === 'player' ? 'Your' : 'Enemy'
+            log.push(`!!${who} ${unit.name} upgraded ${nearBuilding.name}! (${note})`)
+          }
+        }
+        unit.buildTimer = buildInterval
       }
     }
   }

--- a/web/src/game/engine/targeting.ts
+++ b/web/src/game/engine/targeting.ts
@@ -26,6 +26,7 @@ export function findNearestEnemy(field: Unit[], unit: Unit): Unit | null {
     if (other.isWall && (unit.flying || unit.climber)) continue
     if (unit.owner === 'player'   && other.x < unit.x) continue
     if (unit.owner === 'opponent' && other.x > unit.x) continue
+    if (other.invisTimer != null && other.invisTimer > 0) continue
     const d = unitDist(unit, other)
     if (d < nearestDist) { nearestDist = d; nearest = other }
   }
@@ -47,6 +48,7 @@ export function findNearestEnemyByPriority(field: Unit[], unit: Unit): Unit | nu
     if (other.isWall && (unit.flying || unit.climber)) continue
     const ahead = isPlayer ? other.x >= unit.x : other.x <= unit.x
     if (!ahead) continue
+    if (other.invisTimer != null && other.invisTimer > 0) continue
     const matches = (pri === 'walls' && other.isWall) ||
       (pri === 'buildings' && other.moveSpeed === 0 && !other.isWall) ||
       (pri === 'boss' && !!other.isHero) ||
@@ -67,6 +69,7 @@ export function findEnemyBehind(field: Unit[], unit: Unit): Unit | null {
     if (other.isWall && (unit.flying || unit.climber)) continue
     if (unit.owner === 'player'   && other.x >= unit.x) continue
     if (unit.owner === 'opponent' && other.x <= unit.x) continue
+    if (other.invisTimer != null && other.invisTimer > 0) continue
     const d = unitDist(unit, other)
     if (d < nearestDist) { nearestDist = d; nearest = other }
   }
@@ -86,6 +89,7 @@ export function findAttackTarget(field: Unit[], unit: Unit): Unit | null {
     if (other.owner === unit.owner || other.hp <= 0) continue
     if (other.isMoat) continue
     if (other.isWall && (unit.bypassWall || unit.climber)) continue
+    if (other.invisTimer != null && other.invisTimer > 0) continue
     const d = unitDist(unit, other)
     if (d > unit.attackRange) continue
     if (unit.targetUnitType === 'flying'     && !other.flying)  continue

--- a/web/src/game/engine/units.ts
+++ b/web/src/game/engine/units.ts
@@ -116,6 +116,24 @@ export function moveUnits(s: GameState, deltaMs: number): void {
       }
     }
 
+    // Builder trait: seek nearest friendly building rather than advancing toward enemy
+    if (unit.unitTrait?.builderMode) {
+      const buildings = s.field.filter(b => b.owner === unit.owner && b.moveSpeed === 0 && !b.isWall && b.hp > 0)
+      if (buildings.length > 0) {
+        const nearest = buildings.reduce((a, b) => unitDist(unit, a) < unitDist(unit, b) ? a : b)
+        const dist = unitDist(unit, nearest)
+        if (dist <= 30) {
+          // Already adjacent to a building — hold position
+          tx = unit.x
+          ty = unit.y
+        } else {
+          tx = nearest.x
+          ty = nearest.y
+        }
+        hasTarget = true
+      }
+    }
+
     // Unit trait: guard base (active for first 2 minutes only)
     if (unit.unitTrait?.guardBase && s.gameTime < 120000) {
       const ownBaseX      = unit.owner === 'player' ? 0 : LANE_WIDTH

--- a/web/src/game/types.ts
+++ b/web/src/game/types.ts
@@ -81,6 +81,12 @@ export interface UnitTemplate {
   halfHealthEffect?: { damage: number; range: number }
   /** AOE explosion triggered when this unit dies. */
   onDeathEffect?: { damage: number; range: number }
+  /** Periodic forward blink — unit teleports ahead every cooldownMs ms. */
+  teleportAbility?: { cooldownMs: number; distancePx: number }
+  /** Periodic invisibility — unit becomes untargetable for activeMs, then enters cooldownMs cooldown. */
+  invisibilityAbility?: { activeMs: number; cooldownMs: number }
+  /** Blood pool consumption — unit raises a minion from a nearby blood pool every cooldownMs. */
+  bloodSummonAbility?: { cooldownMs: number; minionTemplate: UnitTemplate; range: number }
 }
 
 export type BuffTag = 'atk' | 'spd' | 'hp' | 'range'
@@ -107,6 +113,12 @@ export interface UnitTrait {
   baseGuardRange?: number
   /** Enemy proximity to own base that breaks the guard stance (default 180 px). */
   engageRange?: number
+  /** Builder mode — unit moves to nearest friendly building, repairing and upgrading it. */
+  builderMode?: boolean
+  /** ms between builder repair/upgrade ticks (default 3000). */
+  buildIntervalMs?: number
+  /** HP healed to a damaged building per builder tick (default 8). */
+  buildRepairAmount?: number
 }
 
 export interface Unit extends UnitTemplate {
@@ -141,6 +153,16 @@ export interface Unit extends UnitTemplate {
   lastAttackerId?: string
   /** True once the halfHealthEffect has fired — prevents re-triggering. */
   halfHealthFired?: boolean
+  /** ms until next teleport blink. */
+  teleportTimer?: number
+  /** ms remaining invisible (> 0 = invisible; enemies cannot target this unit). */
+  invisTimer?: number
+  /** ms remaining in invisibility cooldown before the next active phase. */
+  invisCooldownTimer?: number
+  /** ms until next blood pool summon attempt. */
+  bloodSummonTimer?: number
+  /** ms until next builder repair/upgrade tick. */
+  buildTimer?: number
 }
 
 // ─── Animation Events ─────────────────────────────────────

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -7828,6 +7828,12 @@ html.light-mode .action-btn {
   animation: climbing-anim 0.4s ease-in-out infinite;
 }
 
+/* Invisible units — player can see them faintly; enemies cannot target them */
+.lane-unit--invisible {
+  opacity: 0.28;
+  filter: blur(0.5px) saturate(0.4);
+}
+
 /* Persistent damage/blood augments — three tiers based on remaining HP */
 /* Mild (75–100% HP lost): slight red tint, visibly darker */
 .lane-unit-sprite--damaged {


### PR DESCRIPTION
Closes #905.

## New heroes

| Hero | Unit | Special mechanic | Hero effect |
|------|------|-----------------|-------------|
| **Blast Maiden** | Blast Maiden | Explodes on death — 35 dmg, 120px AoE | +15 max HP to all units |
| **Phantom Dasher** | Phantom | Teleports forward 130px every 5.5s | +12 speed to all units |
| **Shadow** | Shadow Stalker | Goes invisible 4s every 11s — enemies cannot target it | -400ms attack cooldown all units |
| **Blood Summoner** | Blood Summoner | Raises a Blood Wraith from a nearby blood pool every 5s | +10 HP heal all units |
| **The Builder** | Builder | Moves to friendly buildings, repairs 8 HP / 3s, upgrades at full HP | +18 max HP to all units |

## New engine mechanics

- **`teleportAbility`** (`cooldownMs`, `distancePx`) — unit blinks forward on a timer
- **`invisibilityAbility`** (`activeMs`, `cooldownMs`) — unit cycles between invisible and visible; all four targeting functions skip invisible units
- **`bloodSummonAbility`** (`cooldownMs`, `minionTemplate`, `range`) — consumes a nearby blood pool and spawns an inline-defined minion unit
- **`unitTrait.builderMode`** + `buildIntervalMs` + `buildRepairAmount` — unit seeks the nearest friendly building, stops adjacent, repairs / upgrades it on a tick

Invisible units render at 28% opacity with a desaturation filter so the player can still track them.

## New sprites (SVG, base + 3 animation frames each)
`blast-maiden`, `phantom`, `blood-summoner`, `builder`, `blood-wraith`
Shadow Stalker reuses the existing `shadow-stalker` sprite.

## Test plan
- [ ] Play Blast Maiden — confirm death explosion hits multiple nearby enemies
- [ ] Play Phantom Dasher — confirm unit blinks forward periodically, bypassing walls
- [ ] Play Shadow — confirm it becomes semi-transparent, enemies stop targeting it during the invisible phase; confirm it reappears and re-enters cooldown
- [ ] Play Blood Summoner — get some units killed to create blood pools; confirm Blood Wraiths rise from them
- [ ] Play The Builder near structures — confirm it walks to a building, repairs damaged ones, upgrades full-HP ones (★ counter increments)
- [ ] Check all five hero card descriptions and lore in the card UI

https://claude.ai/code/session_01EBL42YFQTi1Ziq56uHjVvW

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBL42YFQTi1Ziq56uHjVvW)_