### PR TITLE
Hero Builder: 3 charges then saboteur run (#914)

### DIFF
--- a/web/src/data/cards.json
+++ b/web/src/data/cards.json
@@ -19693,14 +19693,14 @@
         "moveSpeed": 10,
         "attackRange": 5,
         "attackCooldownMs": 2200,
-        "unitTrait": { "builderMode": true, "buildIntervalMs": 3000, "buildRepairAmount": 8 },
+        "unitTrait": { "builderMode": true, "buildIntervalMs": 3000, "buildRepairAmount": 8, "buildCharges": 3 },
         "tags": ["melee", "slow"]
       },
       "heroEffect": {
         "type": "buffMaxHp",
         "amount": 18
       },
-      "description": "HERO: Deploys the Builder — a tireless worker who repairs nearby buildings every 3s and upgrades them once they're at full health! All units gain +18 max HP.",
+      "description": "HERO: Deploys the Builder — repairs or upgrades a building every 3s (3 charges). After all charges are spent, he sprints to the enemy base avoiding enemies and detonates on the first enemy building he reaches! All units gain +18 max HP.",
       "lore": "Can fix anything. Given enough time. And lumber."
     }
   ]

--- a/web/src/game/engine.ts
+++ b/web/src/game/engine.ts
@@ -577,52 +577,83 @@ function performUnitMaintenance(s: GameState, deltaMs: number, log: string[]) {
       }
     }
 
-    // Builder ability: repair damaged buildings or upgrade fully-healed ones
+    // Builder ability: repair/upgrade buildings (3 charges), then run to enemy base and detonate
     if (unit.unitTrait?.builderMode && unit.moveSpeed > 0 && unit.hp > 0) {
-      const buildInterval = unit.unitTrait.buildIntervalMs ?? 3000
-      const repairAmt = unit.unitTrait.buildRepairAmount ?? 8
-      if (unit.buildTimer == null) unit.buildTimer = buildInterval
-      unit.buildTimer -= deltaMs
-      if (unit.buildTimer <= 0) {
-        const nearBuilding = s.field.find(
-          b => b.owner === unit.owner && b.moveSpeed === 0 && !b.isWall && b.hp > 0 &&
-               unitDist(unit, b) <= 60
+      if (unit.builderChargesLeft == null) {
+        unit.builderChargesLeft = unit.unitTrait.buildCharges ?? 3
+      }
+
+      if (unit.builderSaboteurMode) {
+        // Detonate on contact with any enemy building
+        const enemyBuilding = s.field.find(
+          b => b.owner !== unit.owner && b.moveSpeed === 0 && !b.isWall && b.hp > 0 &&
+               unitDist(unit, b) <= 40
         )
-        if (nearBuilding) {
-          if (nearBuilding.hp < nearBuilding.maxHp) {
-            nearBuilding.hp = Math.min(nearBuilding.maxHp, nearBuilding.hp + repairAmt)
-            const who = unit.owner === 'player' ? 'Your' : 'Enemy'
-            log.push(`${who} ${unit.name} repaired ${nearBuilding.name} for ${repairAmt} HP.`)
-          } else if ((nearBuilding.upgradeLevel ?? 1) < MAX_UPGRADE_LEVEL) {
-            nearBuilding.maxHp *= 2
-            nearBuilding.hp = nearBuilding.maxHp
-            nearBuilding.upgradeLevel = (nearBuilding.upgradeLevel ?? 1) + 1
-            let note = 'HP×2'
-            if (nearBuilding.structureEffect?.type === 'spawn') {
-              const eff = nearBuilding.structureEffect as { type: 'spawn'; unitTemplate: UnitTemplate; intervalMs: number }
-              eff.intervalMs = Math.max(1500, Math.floor(eff.intervalMs / 2))
-              if (nearBuilding.spawnTimer != null) nearBuilding.spawnTimer = Math.min(nearBuilding.spawnTimer, eff.intervalMs)
-              note += ', spawn×2'
-            }
-            if (nearBuilding.structureEffect?.type === 'mana') {
-              (nearBuilding.structureEffect as { type: 'mana'; amount: number }).amount += 1
-              note += ', mana+1'
-            }
-            if (nearBuilding.structureEffect?.type === 'healAura') {
-              const eff = nearBuilding.structureEffect as { type: 'healAura'; amount: number; intervalMs: number }
-              eff.intervalMs = Math.max(2000, Math.floor(eff.intervalMs / 2))
-              note += ', heal×2'
-            }
-            if (nearBuilding.structureEffect?.type === 'repairAura') {
-              const eff = nearBuilding.structureEffect as { type: 'repairAura'; amount: number; intervalMs: number }
-              eff.intervalMs = Math.max(2000, Math.floor(eff.intervalMs / 2))
-              note += ', repair×2'
-            }
-            const who = unit.owner === 'player' ? 'Your' : 'Enemy'
-            log.push(`!!${who} ${unit.name} upgraded ${nearBuilding.name}! (${note})`)
-          }
+        if (enemyBuilding) {
+          const who = unit.owner === 'player' ? 'Your' : 'Enemy'
+          log.push(`!!${who} ${unit.name} detonates at ${enemyBuilding.name}, destroying it!`)
+          enemyBuilding.hp = 0
+          unit.hp = 0
         }
-        unit.buildTimer = buildInterval
+      } else {
+        const buildInterval = unit.unitTrait.buildIntervalMs ?? 3000
+        const repairAmt = unit.unitTrait.buildRepairAmount ?? 8
+        if (unit.buildTimer == null) unit.buildTimer = buildInterval
+        unit.buildTimer -= deltaMs
+        if (unit.buildTimer <= 0) {
+          const nearBuilding = s.field.find(
+            b => b.owner === unit.owner && b.moveSpeed === 0 && !b.isWall && b.hp > 0 &&
+                 unitDist(unit, b) <= 60
+          )
+          if (nearBuilding) {
+            let actionTaken = false
+            if (nearBuilding.hp < nearBuilding.maxHp) {
+              nearBuilding.hp = Math.min(nearBuilding.maxHp, nearBuilding.hp + repairAmt)
+              const who = unit.owner === 'player' ? 'Your' : 'Enemy'
+              log.push(`${who} ${unit.name} repaired ${nearBuilding.name} for ${repairAmt} HP.`)
+              actionTaken = true
+            } else if ((nearBuilding.upgradeLevel ?? 1) < MAX_UPGRADE_LEVEL) {
+              nearBuilding.maxHp *= 2
+              nearBuilding.hp = nearBuilding.maxHp
+              nearBuilding.upgradeLevel = (nearBuilding.upgradeLevel ?? 1) + 1
+              let note = 'HP×2'
+              if (nearBuilding.structureEffect?.type === 'spawn') {
+                const eff = nearBuilding.structureEffect as { type: 'spawn'; unitTemplate: UnitTemplate; intervalMs: number }
+                eff.intervalMs = Math.max(1500, Math.floor(eff.intervalMs / 2))
+                if (nearBuilding.spawnTimer != null) nearBuilding.spawnTimer = Math.min(nearBuilding.spawnTimer, eff.intervalMs)
+                note += ', spawn×2'
+              }
+              if (nearBuilding.structureEffect?.type === 'mana') {
+                (nearBuilding.structureEffect as { type: 'mana'; amount: number }).amount += 1
+                note += ', mana+1'
+              }
+              if (nearBuilding.structureEffect?.type === 'healAura') {
+                const eff = nearBuilding.structureEffect as { type: 'healAura'; amount: number; intervalMs: number }
+                eff.intervalMs = Math.max(2000, Math.floor(eff.intervalMs / 2))
+                note += ', heal×2'
+              }
+              if (nearBuilding.structureEffect?.type === 'repairAura') {
+                const eff = nearBuilding.structureEffect as { type: 'repairAura'; amount: number; intervalMs: number }
+                eff.intervalMs = Math.max(2000, Math.floor(eff.intervalMs / 2))
+                note += ', repair×2'
+              }
+              const who = unit.owner === 'player' ? 'Your' : 'Enemy'
+              log.push(`!!${who} ${unit.name} upgraded ${nearBuilding.name}! (${note})`)
+              actionTaken = true
+            }
+
+            if (actionTaken) {
+              unit.builderChargesLeft! -= 1
+              unit.builderLastBuildingId = nearBuilding.id
+              if (unit.builderChargesLeft! <= 0) {
+                unit.builderSaboteurMode = true
+                const who = unit.owner === 'player' ? 'Your' : 'Enemy'
+                log.push(`!!${who} ${unit.name} has used all charges — running to the enemy base!`)
+              }
+            }
+          }
+          unit.buildTimer = buildInterval
+        }
       }
     }
 

--- a/web/src/game/engine/units.ts
+++ b/web/src/game/engine/units.ts
@@ -116,21 +116,51 @@ export function moveUnits(s: GameState, deltaMs: number): void {
       }
     }
 
-    // Builder trait: seek nearest friendly building rather than advancing toward enemy
+    // Builder trait: seek nearest friendly building; once charges exhausted, run to enemy base
     if (unit.unitTrait?.builderMode) {
-      const buildings = s.field.filter(b => b.owner === unit.owner && b.moveSpeed === 0 && !b.isWall && b.hp > 0)
-      if (buildings.length > 0) {
-        const nearest = buildings.reduce((a, b) => unitDist(unit, a) < unitDist(unit, b) ? a : b)
-        const dist = unitDist(unit, nearest)
-        if (dist <= 30) {
-          // Already adjacent to a building — hold position
-          tx = unit.x
-          ty = unit.y
+      if (unit.builderSaboteurMode) {
+        // Sprint to enemy base, steering away from nearby enemies
+        const enemyBaseX = unit.owner === 'player' ? LANE_WIDTH : 0
+        const fleeRange = 80
+        let fvx = 0, fvy = 0, fleeCount = 0
+        for (const other of s.field) {
+          if (other.owner === unit.owner || other.hp <= 0) continue
+          const dist = unitDist(unit, other)
+          if (dist > fleeRange || dist === 0) continue
+          fvx += unit.x - other.x
+          fvy += unit.y - other.y
+          fleeCount++
+        }
+        if (fleeCount > 0) {
+          const len = Math.sqrt(fvx * fvx + fvy * fvy) || 1
+          tx = enemyBaseX + (fvx / len) * 80
+          ty = unit.y + (fvy / len) * 40
         } else {
-          tx = nearest.x
-          ty = nearest.y
+          tx = enemyBaseX
+          ty = 0
         }
         hasTarget = true
+      } else {
+        // Normal mode: seek nearest friendly building, skipping the one last serviced
+        let buildings = s.field.filter(
+          b => b.owner === unit.owner && b.moveSpeed === 0 && !b.isWall && b.hp > 0 &&
+               b.id !== unit.builderLastBuildingId
+        )
+        if (buildings.length === 0) {
+          buildings = s.field.filter(b => b.owner === unit.owner && b.moveSpeed === 0 && !b.isWall && b.hp > 0)
+        }
+        if (buildings.length > 0) {
+          const nearest = buildings.reduce((a, b) => unitDist(unit, a) < unitDist(unit, b) ? a : b)
+          const dist = unitDist(unit, nearest)
+          if (dist <= 30) {
+            tx = unit.x
+            ty = unit.y
+          } else {
+            tx = nearest.x
+            ty = nearest.y
+          }
+          hasTarget = true
+        }
       }
     }
 

--- a/web/src/game/types.ts
+++ b/web/src/game/types.ts
@@ -119,6 +119,8 @@ export interface UnitTrait {
   buildIntervalMs?: number
   /** HP healed to a damaged building per builder tick (default 8). */
   buildRepairAmount?: number
+  /** Total number of repair/upgrade charges before entering saboteur mode (default 3). */
+  buildCharges?: number
 }
 
 export interface Unit extends UnitTemplate {
@@ -163,6 +165,12 @@ export interface Unit extends UnitTemplate {
   bloodSummonTimer?: number
   /** ms until next builder repair/upgrade tick. */
   buildTimer?: number
+  /** Remaining charges before the builder enters saboteur mode. */
+  builderChargesLeft?: number
+  /** True once all charges are spent — builder runs to enemy base to self-destruct. */
+  builderSaboteurMode?: boolean
+  /** ID of the last building the builder serviced — excluded when picking next target. */
+  builderLastBuildingId?: string
 }
 
 // ─── Animation Events ─────────────────────────────────────


### PR DESCRIPTION
## Summary

- The Builder hero was too powerful with unlimited repair/upgrade cycles
- He now has **3 charges** — each charge repairs or upgrades one building, then he moves to the next
- After spending all 3 charges he enters **saboteur mode**: sprints toward the enemy base while dodging nearby enemies
- On contact with the first enemy building he reaches, he **detonates** — destroying it and dying

## Changes

- `types.ts`: added `buildCharges` to `UnitTrait`; added `builderChargesLeft`, `builderSaboteurMode`, `builderLastBuildingId` to `Unit`
- `engine/units.ts`: saboteur path steers away from nearby enemies while targeting enemy base; normal path excludes the last-serviced building when picking next target
- `engine.ts`: initialises charges on first tick; consumes one per repair/upgrade; switches to saboteur mode at 0; detonates on enemy building contact
- `cards.json`: `buildCharges: 3` added to unitTrait; description updated to reflect new behaviour

## Test plan

- [ ] Deploy Builder — confirm he repairs/upgrades up to 3 buildings then stops doing builder work
- [ ] After 3rd action, confirm log shows "running to the enemy base" message and he starts heading forward
- [ ] Confirm he steers around (not through) enemy units rather than fighting
- [ ] Confirm he destroys the first enemy building he contacts and then dies
- [ ] Confirm enemy Builder behaves identically (charges then runs at player buildings)

Closes #914

---
_Generated by [Claude Code](https://claude.ai/code/session_01ACPCzVAZ7W4Eyp5suBibSz)_