### PR TITLE
fix(battlefield): add missing themed environments for acts 8–13

### DIFF
--- a/web/public/sprites/battlefield/coast-left.svg
+++ b/web/public/sprites/battlefield/coast-left.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 220" preserveAspectRatio="none">
+  <!-- Coastal water strip left -->
+  <rect x="0" y="0" width="24" height="220" fill="#2060a0"/>
+  <!-- Wave lines -->
+  <path d="M0,40  C6,36  12,44 18,40  C20,38 22,40 24,40"  stroke="#80c0f0" stroke-width="1.2" fill="none" opacity="0.6"/>
+  <path d="M0,120 C8,116 14,124 20,120 C22,118 23,120 24,120" stroke="#80c0f0" stroke-width="1"   fill="none" opacity="0.55"/>
+  <path d="M0,195 C6,191 12,199 18,195 C21,193 23,195 24,195" stroke="#70b0e0" stroke-width="1.2" fill="none" opacity="0.6"/>
+  <!-- Sea foam dots -->
+  <circle cx="6"  cy="62"  r="2"   fill="#c0e8ff" opacity="0.4"/>
+  <circle cx="16" cy="78"  r="1.5" fill="#c0e8ff" opacity="0.35"/>
+  <circle cx="10" cy="148" r="2"   fill="#c0e8ff" opacity="0.4"/>
+  <!-- Coastal rock -->
+  <ellipse cx="10" cy="165" rx="8" ry="4" fill="#506080" opacity="0.6"/>
+  <line x1="24" y1="0" x2="24" y2="220" stroke="#104880" stroke-width="0.5" opacity="0.5"/>
+</svg>

--- a/web/public/sprites/battlefield/coast-right.svg
+++ b/web/public/sprites/battlefield/coast-right.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 220" preserveAspectRatio="none">
+  <!-- Coastal water strip right -->
+  <rect x="76" y="0" width="24" height="220" fill="#2060a0"/>
+  <!-- Wave lines -->
+  <path d="M76,55  C82,51  88,59 94,55  C96,53 98,55 100,55"  stroke="#80c0f0" stroke-width="1.2" fill="none" opacity="0.6"/>
+  <path d="M76,135 C84,131 90,139 96,135 C98,133 99,135 100,135" stroke="#80c0f0" stroke-width="1"   fill="none" opacity="0.55"/>
+  <path d="M76,205 C82,201 88,209 94,205 C97,203 99,205 100,205" stroke="#70b0e0" stroke-width="1.2" fill="none" opacity="0.6"/>
+  <!-- Sea foam dots -->
+  <circle cx="82" cy="78"  r="2"   fill="#c0e8ff" opacity="0.4"/>
+  <circle cx="94" cy="92"  r="1.5" fill="#c0e8ff" opacity="0.35"/>
+  <circle cx="88" cy="162" r="2"   fill="#c0e8ff" opacity="0.4"/>
+  <!-- Coastal rock -->
+  <ellipse cx="90" cy="112" rx="8" ry="4" fill="#506080" opacity="0.6"/>
+  <line x1="76" y1="0" x2="76" y2="220" stroke="#104880" stroke-width="0.5" opacity="0.5"/>
+</svg>

--- a/web/public/sprites/battlefield/dune-left.svg
+++ b/web/public/sprites/battlefield/dune-left.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 220" preserveAspectRatio="none">
+  <!-- Desert dune strip left -->
+  <rect x="0" y="0" width="24" height="220" fill="#a87838"/>
+  <!-- Dune ridges -->
+  <ellipse cx="12" cy="50"  rx="14" ry="4"   fill="#c09048" opacity="0.6"/>
+  <ellipse cx="12" cy="130" rx="14" ry="4"   fill="#c09048" opacity="0.55"/>
+  <ellipse cx="12" cy="200" rx="13" ry="3.5" fill="#c09048" opacity="0.5"/>
+  <!-- Wind-blown sand lines -->
+  <line x1="2"  y1="80"  x2="20" y2="78"  stroke="#d4a060" stroke-width="0.5" opacity="0.5"/>
+  <line x1="4"  y1="160" x2="22" y2="158" stroke="#d4a060" stroke-width="0.5" opacity="0.45"/>
+  <!-- Desert rock -->
+  <ellipse cx="10" cy="105" rx="6" ry="3.5" fill="#8a6030" opacity="0.55"/>
+  <line x1="24" y1="0" x2="24" y2="220" stroke="#886030" stroke-width="0.5" opacity="0.5"/>
+</svg>

--- a/web/public/sprites/battlefield/dune-right.svg
+++ b/web/public/sprites/battlefield/dune-right.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 220" preserveAspectRatio="none">
+  <!-- Desert dune strip right -->
+  <rect x="76" y="0" width="24" height="220" fill="#a87838"/>
+  <!-- Dune ridges -->
+  <ellipse cx="88" cy="65"  rx="14" ry="4"   fill="#c09048" opacity="0.6"/>
+  <ellipse cx="88" cy="145" rx="14" ry="4"   fill="#c09048" opacity="0.55"/>
+  <ellipse cx="88" cy="210" rx="13" ry="3.5" fill="#c09048" opacity="0.5"/>
+  <!-- Wind-blown sand lines -->
+  <line x1="78" y1="95"  x2="96" y2="93"  stroke="#d4a060" stroke-width="0.5" opacity="0.5"/>
+  <line x1="80" y1="175" x2="98" y2="173" stroke="#d4a060" stroke-width="0.5" opacity="0.45"/>
+  <!-- Desert rock -->
+  <ellipse cx="90" cy="118" rx="6" ry="3.5" fill="#8a6030" opacity="0.55"/>
+  <line x1="76" y1="0" x2="76" y2="220" stroke="#886030" stroke-width="0.5" opacity="0.5"/>
+</svg>

--- a/web/public/sprites/battlefield/floor-coast.svg
+++ b/web/public/sprites/battlefield/floor-coast.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 220" preserveAspectRatio="none">
+  <rect width="100" height="220" fill="#b89858"/>
+  <!-- Wet sand shimmer patches -->
+  <ellipse cx="50" cy="50"  rx="22" ry="7"  fill="#c8b888" opacity="0.4"/>
+  <ellipse cx="50" cy="130" rx="24" ry="8"  fill="#c8b888" opacity="0.35"/>
+  <ellipse cx="50" cy="195" rx="18" ry="6"  fill="#c8b888" opacity="0.4"/>
+  <!-- Shell and pebble dots -->
+  <circle cx="28" cy="88"  r="1.2" fill="#e0d0a0" opacity="0.35"/>
+  <circle cx="68" cy="150" r="1"   fill="#e0d0a0" opacity="0.3"/>
+  <circle cx="40" cy="175" r="1.2" fill="#d8c890" opacity="0.3"/>
+</svg>

--- a/web/public/sprites/battlefield/floor-desert.svg
+++ b/web/public/sprites/battlefield/floor-desert.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 220" preserveAspectRatio="none">
+  <rect width="100" height="220" fill="#c8a050"/>
+  <!-- Dune shadow ripples -->
+  <ellipse cx="50" cy="55"  rx="25" ry="8"  fill="#b08840" opacity="0.35"/>
+  <ellipse cx="50" cy="130" rx="28" ry="9"  fill="#b08840" opacity="0.3"/>
+  <ellipse cx="50" cy="200" rx="22" ry="7"  fill="#b08840" opacity="0.35"/>
+  <!-- Sand texture dots -->
+  <circle cx="30" cy="85"  r="1" fill="#d8b870" opacity="0.3"/>
+  <circle cx="70" cy="155" r="1" fill="#d8b870" opacity="0.25"/>
+  <circle cx="45" cy="185" r="1" fill="#e0c080" opacity="0.25"/>
+</svg>

--- a/web/public/sprites/battlefield/floor-frost.svg
+++ b/web/public/sprites/battlefield/floor-frost.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 220" preserveAspectRatio="none">
+  <rect width="100" height="220" fill="#c8dff0"/>
+  <!-- Ice crack lines -->
+  <line x1="20" y1="30"  x2="45" y2="55"  stroke="#a0c8e8" stroke-width="0.6" opacity="0.5"/>
+  <line x1="55" y1="90"  x2="78" y2="110" stroke="#a0c8e8" stroke-width="0.5" opacity="0.45"/>
+  <line x1="15" y1="150" x2="40" y2="168" stroke="#90b8d8" stroke-width="0.6" opacity="0.5"/>
+  <line x1="60" y1="178" x2="82" y2="198" stroke="#a0c8e8" stroke-width="0.5" opacity="0.45"/>
+  <!-- Snow patches -->
+  <ellipse cx="50" cy="60"  rx="20" ry="7" fill="#e8f4ff" opacity="0.4"/>
+  <ellipse cx="50" cy="145" rx="22" ry="8" fill="#e8f4ff" opacity="0.35"/>
+  <ellipse cx="50" cy="205" rx="17" ry="5" fill="#e8f4ff" opacity="0.4"/>
+</svg>

--- a/web/public/sprites/battlefield/floor-fungal.svg
+++ b/web/public/sprites/battlefield/floor-fungal.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 220" preserveAspectRatio="none">
+  <rect width="100" height="220" fill="#261a2c"/>
+  <!-- Spore shadow clusters -->
+  <ellipse cx="50" cy="55"  rx="18" ry="7"  fill="#1e1226" opacity="0.5"/>
+  <ellipse cx="50" cy="135" rx="20" ry="8"  fill="#1e1226" opacity="0.45"/>
+  <ellipse cx="50" cy="200" rx="16" ry="6"  fill="#1e1226" opacity="0.5"/>
+  <!-- Spore dots -->
+  <circle cx="25" cy="80"  r="1.2" fill="#b060c0" opacity="0.35"/>
+  <circle cx="72" cy="110" r="1"   fill="#b060c0" opacity="0.3"/>
+  <circle cx="35" cy="165" r="1.2" fill="#c070d0" opacity="0.35"/>
+  <circle cx="68" cy="195" r="1"   fill="#b060c0" opacity="0.3"/>
+</svg>

--- a/web/public/sprites/battlefield/floor-vault.svg
+++ b/web/public/sprites/battlefield/floor-vault.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 220" preserveAspectRatio="none">
+  <rect width="100" height="220" fill="#1c1820"/>
+  <!-- Stone block seam lines -->
+  <line x1="0" y1="44"  x2="100" y2="44"  stroke="#16141a" stroke-width="0.5" opacity="0.6"/>
+  <line x1="0" y1="88"  x2="100" y2="88"  stroke="#16141a" stroke-width="0.5" opacity="0.6"/>
+  <line x1="0" y1="132" x2="100" y2="132" stroke="#16141a" stroke-width="0.5" opacity="0.6"/>
+  <line x1="0" y1="176" x2="100" y2="176" stroke="#16141a" stroke-width="0.5" opacity="0.6"/>
+  <!-- Faint rune glows -->
+  <circle cx="30" cy="66"  r="2" fill="#4040c0" opacity="0.2"/>
+  <circle cx="70" cy="110" r="2" fill="#4040c0" opacity="0.18"/>
+  <circle cx="35" cy="154" r="2" fill="#4040c0" opacity="0.2"/>
+  <circle cx="65" cy="198" r="2" fill="#5050d0" opacity="0.18"/>
+</svg>

--- a/web/public/sprites/battlefield/frost-left.svg
+++ b/web/public/sprites/battlefield/frost-left.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 220" preserveAspectRatio="none">
+  <!-- Frost strip left -->
+  <rect x="0" y="0" width="24" height="220" fill="#a8c8e0"/>
+  <!-- Ice crystal 1 -->
+  <polygon points="10,25 6,45 14,45"  fill="#d8eeff" opacity="0.8"/>
+  <polygon points="10,25 4,40 16,40"  fill="#c0e0f8" opacity="0.6"/>
+  <!-- Ice crystal 2 -->
+  <polygon points="14,118 10,140 18,140" fill="#d0e8f8" opacity="0.75"/>
+  <!-- Frost branch 1 -->
+  <line x1="8"  y1="75" x2="18" y2="65" stroke="#e0f0ff" stroke-width="1"   opacity="0.6"/>
+  <line x1="8"  y1="75" x2="18" y2="85" stroke="#e0f0ff" stroke-width="1"   opacity="0.6"/>
+  <line x1="8"  y1="75" x2="2"  y2="75" stroke="#e0f0ff" stroke-width="1"   opacity="0.5"/>
+  <!-- Frost branch 2 -->
+  <line x1="12" y1="175" x2="20" y2="165" stroke="#d8ecff" stroke-width="0.8" opacity="0.55"/>
+  <line x1="12" y1="175" x2="20" y2="185" stroke="#d8ecff" stroke-width="0.8" opacity="0.55"/>
+  <line x1="24" y1="0" x2="24" y2="220" stroke="#88a8c0" stroke-width="0.5" opacity="0.5"/>
+</svg>

--- a/web/public/sprites/battlefield/frost-right.svg
+++ b/web/public/sprites/battlefield/frost-right.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 220" preserveAspectRatio="none">
+  <!-- Frost strip right -->
+  <rect x="76" y="0" width="24" height="220" fill="#a8c8e0"/>
+  <!-- Ice crystal 1 -->
+  <polygon points="90,35 86,55 94,55"  fill="#d8eeff" opacity="0.8"/>
+  <polygon points="90,35 84,50 96,50"  fill="#c0e0f8" opacity="0.6"/>
+  <!-- Ice crystal 2 -->
+  <polygon points="86,128 82,150 90,150" fill="#d0e8f8" opacity="0.75"/>
+  <!-- Frost branch 1 -->
+  <line x1="92" y1="90" x2="82" y2="80"  stroke="#e0f0ff" stroke-width="1"   opacity="0.6"/>
+  <line x1="92" y1="90" x2="82" y2="100" stroke="#e0f0ff" stroke-width="1"   opacity="0.6"/>
+  <line x1="92" y1="90" x2="98" y2="90"  stroke="#e0f0ff" stroke-width="1"   opacity="0.5"/>
+  <!-- Frost branch 2 -->
+  <line x1="88" y1="185" x2="80" y2="175" stroke="#d8ecff" stroke-width="0.8" opacity="0.55"/>
+  <line x1="88" y1="185" x2="80" y2="195" stroke="#d8ecff" stroke-width="0.8" opacity="0.55"/>
+  <line x1="76" y1="0" x2="76" y2="220" stroke="#88a8c0" stroke-width="0.5" opacity="0.5"/>
+</svg>

--- a/web/public/sprites/battlefield/fungal-left.svg
+++ b/web/public/sprites/battlefield/fungal-left.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 220" preserveAspectRatio="none">
+  <!-- Fungal strip left -->
+  <rect x="0" y="0" width="24" height="220" fill="#1e1226"/>
+  <!-- Mushroom cap 1 -->
+  <ellipse cx="12" cy="45" rx="10" ry="6" fill="#8a3070" opacity="0.85"/>
+  <rect x="10" y="45" width="4" height="12" fill="#5a2040" rx="1"/>
+  <!-- Mushroom cap 2 -->
+  <ellipse cx="10" cy="140" rx="9" ry="5" fill="#6a2860" opacity="0.8"/>
+  <rect x="8"  y="140" width="4" height="10" fill="#4a1830" rx="1"/>
+  <!-- Spore tendrils -->
+  <path d="M14,70 C10,80 16,88 12,96"  stroke="#c080d0" stroke-width="0.8" fill="none" opacity="0.5"/>
+  <path d="M8,165 C12,175 8,182 11,190" stroke="#b070c0" stroke-width="0.8" fill="none" opacity="0.45"/>
+  <!-- Spore glow dots -->
+  <circle cx="16" cy="78"  r="1" fill="#d090e0" opacity="0.55"/>
+  <circle cx="9"  cy="175" r="1" fill="#c080d0" opacity="0.5"/>
+  <line x1="24" y1="0" x2="24" y2="220" stroke="#180c20" stroke-width="0.5" opacity="0.5"/>
+</svg>

--- a/web/public/sprites/battlefield/fungal-right.svg
+++ b/web/public/sprites/battlefield/fungal-right.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 220" preserveAspectRatio="none">
+  <!-- Fungal strip right -->
+  <rect x="76" y="0" width="24" height="220" fill="#1e1226"/>
+  <!-- Mushroom cap 1 -->
+  <ellipse cx="88" cy="60"  rx="10" ry="6" fill="#8a3070" opacity="0.85"/>
+  <rect x="86" y="60" width="4" height="12" fill="#5a2040" rx="1"/>
+  <!-- Mushroom cap 2 -->
+  <ellipse cx="90" cy="155" rx="9" ry="5" fill="#6a2860" opacity="0.8"/>
+  <rect x="88" y="155" width="4" height="10" fill="#4a1830" rx="1"/>
+  <!-- Spore tendrils -->
+  <path d="M86,85  C90,95  84,103 88,111" stroke="#c080d0" stroke-width="0.8" fill="none" opacity="0.5"/>
+  <path d="M92,180 C88,190 92,197 89,205" stroke="#b070c0" stroke-width="0.8" fill="none" opacity="0.45"/>
+  <!-- Spore glow dots -->
+  <circle cx="84" cy="92"  r="1" fill="#d090e0" opacity="0.55"/>
+  <circle cx="91" cy="192" r="1" fill="#c080d0" opacity="0.5"/>
+  <line x1="76" y1="0" x2="76" y2="220" stroke="#180c20" stroke-width="0.5" opacity="0.5"/>
+</svg>

--- a/web/public/sprites/battlefield/path-dust-center.svg
+++ b/web/public/sprites/battlefield/path-dust-center.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 220" preserveAspectRatio="none">
+  <!-- Dusty desert track center -->
+  <path d="M34,0 C33,50 36,105 34,148 C32,182 35,202 34,220 L66,220 C65,202 68,182 66,148 C64,105 67,50 66,0 Z" fill="#8a6028" opacity="0.9"/>
+  <path d="M36,0 C35,48 38,103 36,146 C34,180 37,201 36,220 L64,220 C63,201 66,180 64,146 C62,103 65,48 64,0 Z" fill="#a07838"/>
+  <!-- Dust marks -->
+  <ellipse cx="50" cy="60"  rx="6" ry="2"   fill="#c09858" opacity="0.35"/>
+  <ellipse cx="50" cy="130" rx="7" ry="2"   fill="#c09858" opacity="0.3"/>
+  <ellipse cx="50" cy="190" rx="5" ry="1.5" fill="#b08848" opacity="0.35"/>
+</svg>

--- a/web/public/sprites/battlefield/path-ice-center.svg
+++ b/web/public/sprites/battlefield/path-ice-center.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 220" preserveAspectRatio="none">
+  <!-- Frozen ice path center -->
+  <path d="M34,0 C33,50 36,105 34,148 C32,182 35,202 34,220 L66,220 C65,202 68,182 66,148 C64,105 67,50 66,0 Z" fill="#88b8d8" opacity="0.7"/>
+  <path d="M36,0 C35,48 38,103 36,146 C34,180 37,201 36,220 L64,220 C63,201 66,180 64,146 C62,103 65,48 64,0 Z" fill="#a0c8e8" opacity="0.85"/>
+  <!-- Ice crack details -->
+  <line x1="42" y1="50"  x2="58" y2="62"  stroke="#c8e8ff" stroke-width="0.7" opacity="0.55"/>
+  <line x1="44" y1="110" x2="56" y2="122" stroke="#c8e8ff" stroke-width="0.6" opacity="0.5"/>
+  <line x1="42" y1="165" x2="58" y2="178" stroke="#b8d8f8" stroke-width="0.7" opacity="0.55"/>
+</svg>

--- a/web/public/sprites/battlefield/path-shore-center.svg
+++ b/web/public/sprites/battlefield/path-shore-center.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 220" preserveAspectRatio="none">
+  <!-- Wet-packed shore path center -->
+  <path d="M34,0 C33,50 36,105 34,148 C32,182 35,202 34,220 L66,220 C65,202 68,182 66,148 C64,105 67,50 66,0 Z" fill="#806838" opacity="0.9"/>
+  <path d="M36,0 C35,48 38,103 36,146 C34,180 37,201 36,220 L64,220 C63,201 66,180 64,146 C62,103 65,48 64,0 Z" fill="#9a7848"/>
+  <!-- Shell marks -->
+  <circle cx="50" cy="58"  r="1.2" fill="#c0a870" opacity="0.45"/>
+  <circle cx="48" cy="120" r="1"   fill="#c0a870" opacity="0.4"/>
+  <circle cx="52" cy="175" r="1.2" fill="#b89860" opacity="0.45"/>
+</svg>

--- a/web/public/sprites/battlefield/path-spore-center.svg
+++ b/web/public/sprites/battlefield/path-spore-center.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 220" preserveAspectRatio="none">
+  <!-- Spore-dusted soil path center -->
+  <path d="M34,0 C33,50 36,105 34,148 C32,182 35,202 34,220 L66,220 C65,202 68,182 66,148 C64,105 67,50 66,0 Z" fill="#1a0e22" opacity="0.9"/>
+  <path d="M36,0 C35,48 38,103 36,146 C34,180 37,201 36,220 L64,220 C63,201 66,180 64,146 C62,103 65,48 64,0 Z" fill="#22102a"/>
+  <!-- Spore clusters along path -->
+  <circle cx="50" cy="55"  r="1.5" fill="#c080d0" opacity="0.5"/>
+  <circle cx="48" cy="110" r="1.2" fill="#b070c0" opacity="0.45"/>
+  <circle cx="52" cy="168" r="1.5" fill="#c080d0" opacity="0.5"/>
+  <circle cx="50" cy="210" r="1"   fill="#a060b0" opacity="0.4"/>
+</svg>

--- a/web/public/sprites/battlefield/path-vault-center.svg
+++ b/web/public/sprites/battlefield/path-vault-center.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 220" preserveAspectRatio="none">
+  <!-- Worn vault corridor path center -->
+  <path d="M34,0 C33,50 36,105 34,148 C32,182 35,202 34,220 L66,220 C65,202 68,182 66,148 C64,105 67,50 66,0 Z" fill="#100e14" opacity="0.9"/>
+  <path d="M36,0 C35,48 38,103 36,146 C34,180 37,201 36,220 L64,220 C63,201 66,180 64,146 C62,103 65,48 64,0 Z" fill="#18141e"/>
+  <!-- Faint rune glow on floor stones -->
+  <circle cx="50" cy="55"  r="1.5" fill="#6060d0" opacity="0.3"/>
+  <circle cx="50" cy="110" r="2"   fill="#5050c0" opacity="0.25"/>
+  <circle cx="50" cy="168" r="1.5" fill="#6060d0" opacity="0.3"/>
+  <circle cx="50" cy="210" r="1"   fill="#4040b0" opacity="0.2"/>
+</svg>

--- a/web/public/sprites/battlefield/vault-left.svg
+++ b/web/public/sprites/battlefield/vault-left.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 220" preserveAspectRatio="none">
+  <!-- Vault wall strip left -->
+  <rect x="0" y="0" width="24" height="220" fill="#141018"/>
+  <!-- Stone pillar blocks -->
+  <rect x="2" y="0"   width="8" height="50" fill="#1e1a24" rx="1"/>
+  <rect x="2" y="52"  width="8" height="50" fill="#1c1822" rx="1"/>
+  <rect x="2" y="104" width="8" height="50" fill="#1e1a24" rx="1"/>
+  <rect x="2" y="156" width="8" height="64" fill="#1c1822" rx="1"/>
+  <!-- Rune marks -->
+  <line x1="5" y1="25"  x2="9"  y2="25"  stroke="#5050c0" stroke-width="0.8" opacity="0.4"/>
+  <line x1="7" y1="22"  x2="7"  y2="28"  stroke="#5050c0" stroke-width="0.8" opacity="0.4"/>
+  <line x1="5" y1="128" x2="9"  y2="128" stroke="#4040b0" stroke-width="0.8" opacity="0.35"/>
+  <!-- Iron ring details -->
+  <circle cx="18" cy="55"  r="2.5" fill="#2a2830" stroke="#403c4a" stroke-width="0.5"/>
+  <circle cx="18" cy="110" r="2.5" fill="#2a2830" stroke="#403c4a" stroke-width="0.5"/>
+  <circle cx="18" cy="165" r="2.5" fill="#2a2830" stroke="#403c4a" stroke-width="0.5"/>
+  <line x1="24" y1="0" x2="24" y2="220" stroke="#0c0a10" stroke-width="0.5" opacity="0.6"/>
+</svg>

--- a/web/public/sprites/battlefield/vault-right.svg
+++ b/web/public/sprites/battlefield/vault-right.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 220" preserveAspectRatio="none">
+  <!-- Vault wall strip right -->
+  <rect x="76" y="0" width="24" height="220" fill="#141018"/>
+  <!-- Stone pillar blocks -->
+  <rect x="90" y="0"   width="8" height="50" fill="#1e1a24" rx="1"/>
+  <rect x="90" y="52"  width="8" height="50" fill="#1c1822" rx="1"/>
+  <rect x="90" y="104" width="8" height="50" fill="#1e1a24" rx="1"/>
+  <rect x="90" y="156" width="8" height="64" fill="#1c1822" rx="1"/>
+  <!-- Rune marks -->
+  <line x1="93" y1="78"  x2="97" y2="78"  stroke="#5050c0" stroke-width="0.8" opacity="0.4"/>
+  <line x1="95" y1="75"  x2="95" y2="81"  stroke="#5050c0" stroke-width="0.8" opacity="0.4"/>
+  <line x1="93" y1="178" x2="97" y2="178" stroke="#4040b0" stroke-width="0.8" opacity="0.35"/>
+  <!-- Iron ring details -->
+  <circle cx="82" cy="70"  r="2.5" fill="#2a2830" stroke="#403c4a" stroke-width="0.5"/>
+  <circle cx="82" cy="125" r="2.5" fill="#2a2830" stroke="#403c4a" stroke-width="0.5"/>
+  <circle cx="82" cy="180" r="2.5" fill="#2a2830" stroke="#403c4a" stroke-width="0.5"/>
+  <line x1="76" y1="0" x2="76" y2="220" stroke="#0c0a10" stroke-width="0.5" opacity="0.6"/>
+</svg>

--- a/web/src/data/acts/act4.json
+++ b/web/src/data/acts/act4.json
@@ -50,7 +50,7 @@
   "intro": [
     {
       "title": "THE CRYSTAL SPIRE",
-      "text": "Before the Fracture, the Crystal Spire was the Dominion's arcane research division Ã¢ÂÂ a floating fortress of compressed ley-line energy, staffed by scholars who were very important and knew it.\n\nThe Fracture didn't destroy the Spire. It crystallised it. The entire shard froze mid-operation: experiments running, libraries mid-catalogue, staff mid-sentence. The crystal grew inward. The scholars who survived became part of the archive.\n\nThe Archivist survived better than most.",
+      "text": "Before the Fracture, the Crystal Spire was the Dominion's arcane research division — a floating fortress of compressed ley-line energy, staffed by scholars who were very important and knew it.\n\nThe Fracture didn't destroy the Spire. It crystallised it. The entire shard froze mid-operation: experiments running, libraries mid-catalogue, staff mid-sentence. The crystal grew inward. The scholars who survived became part of the archive.\n\nThe Archivist survived better than most.",
       "image": "cutscenes/act4-intro-1.svg"
     },
     {
@@ -60,7 +60,7 @@
     },
     {
       "title": "THE CRYSTAL SPIRE",
-      "text": "The Spire is a labyrinth of crystallised corridors, arcane constructs, and rooms that echo with the voices of people who stopped speaking three years ago.\n\nAt its heart, the Archivist Ã¢ÂÂ scholar, archivist, and now something considerably more and considerably less than either Ã¢ÂÂ catalogues everything that enters. He has been cataloguing you since you entered the shard.\n\nHe has extensive notes.",
+      "text": "The Spire is a labyrinth of crystallised corridors, arcane constructs, and rooms that echo with the voices of people who stopped speaking three years ago.\n\nAt its heart, the Archivist — scholar, archivist, and now something considerably more and considerably less than either — catalogues everything that enters. He has been cataloguing you since you entered the shard.\n\nHe has extensive notes.",
       "image": "cutscenes/act4-intro-3.svg"
     },
     {
@@ -72,12 +72,12 @@
   "outro": [
     {
       "title": "THE ARCHIVE FALLS SILENT",
-      "text": "The Archivist's crystal matrix collapses. Not violently Ã¢ÂÂ methodically. Each facet dims in order, as though even his defeat is being filed.\n\nThe Spire holds its breath. Then, for the first time in three years, a window opens somewhere deep in the structure. Not because it was unlocked. Because whoever had been locking it is no longer in a position to care.\n\nLight comes through. Ordinary, unremarkable light. In the Crystal Spire, it looks like a miracle.",
+      "text": "The Archivist's crystal matrix collapses. Not violently — methodically. Each facet dims in order, as though even his defeat is being filed.\n\nThe Spire holds its breath. Then, for the first time in three years, a window opens somewhere deep in the structure. Not because it was unlocked. Because whoever had been locking it is no longer in a position to care.\n\nLight comes through. Ordinary, unremarkable light. In the Crystal Spire, it looks like a miracle.",
       "image": "cutscenes/act4-outro-1.svg"
     },
     {
       "title": "PRISM LENS",
-      "text": "Among the Archivist's collection Ã¢ÂÂ catalogued, cross-referenced, annotated in a hand that had become increasingly less human Ã¢ÂÂ you find it.\n\nA lens ground from the Spire's heart crystal. It refracts mana the way a prism refracts light: input, multiplied, redirected.\n\nThe Archivist's note reads: *'Item 7,441: Prism Lens. Effect: mana amplification. Recommendation: do not give to wandering tactician.'\n\nYou take it.",
+      "text": "Among the Archivist's collection — catalogued, cross-referenced, annotated in a hand that had become increasingly less human — you find it.\n\nA lens ground from the Spire's heart crystal. It refracts mana the way a prism refracts light: input, multiplied, redirected.\n\nThe Archivist's note reads: *'Item 7,441: Prism Lens. Effect: mana amplification. Recommendation: do not give to wandering tactician.'\n\nYou take it.",
       "image": "cutscenes/act4-outro-2.svg"
     }
   ],
@@ -86,7 +86,7 @@
       "Currently, technically, trespassing in a building that has documented every trespasser since the Dominion era.",
       "Professionally speaking, now classified as a hostile anomaly in an active archive.",
       "In the scholarly sense, an unscheduled variable in someone else's extremely long experiment.",
-      "Now Ã¢ÂÂ by the Archivist's own notation Ã¢ÂÂ Specimen 7,441-B, Category: Recurring.",
+      "Now — by the Archivist's own notation — Specimen 7,441-B, Category: Recurring.",
       "Technically unenrolled, which puts you in a narrow category of people who have entered the Spire and stayed that way."
     ],
     "jarvIntros": [
@@ -98,15 +98,15 @@
     ],
     "spireDesc": [
       "The Crystal Spire floats above the shard floor on compressed ley lines, its corridors refracting light into colours that don't have names. The scholars called it the height of Dominion achievement. From the outside it looks like someone built a fortress out of a prism and forgot to add doors.",
-      "The Spire's outer lattice is a maze of crystallised arcane energy Ã¢ÂÂ walls that shift, corridors that echo with old spells still running, and constructs that patrol with the cheerful persistence of things that have never been told to stop.",
+      "The Spire's outer lattice is a maze of crystallised arcane energy — walls that shift, corridors that echo with old spells still running, and constructs that patrol with the cheerful persistence of things that have never been told to stop.",
       "Three years of isolation have given the Spire's internal systems time to optimise themselves. Every approach is monitored. Every intrusion is logged. The Archivist receives notification of your exact position in real time.",
       "The Crystal Spire hums. Constantly. A low, harmonic resonance that carries meaning if you listen long enough. You have been listening for forty minutes. The meaning is 'leave.'"
     ],
     "archivistDesc": [
-      "The Archivist was the Dominion's head of magical research before the Fracture Ã¢ÂÂ a precise, methodical scholar who believed that anything worth knowing was worth cataloguing and anything worth cataloguing was worth defending.\n\nThe Fracture gave him more to catalogue than he'd expected. He adapted.",
+      "The Archivist was the Dominion's head of magical research before the Fracture — a precise, methodical scholar who believed that anything worth knowing was worth cataloguing and anything worth cataloguing was worth defending.\n\nThe Fracture gave him more to catalogue than he'd expected. He adapted.",
       "No surviving record of the Archivist exists outside the Spire. This is because the Archivist controls all the surviving records.\n\nHe is, by his own notation, entry 1 in the archive. The entry runs to forty-seven pages and is still being updated.",
       "The Archivist doesn't fight. He categorises. He processes. He applies the appropriate countermeasures from the section labelled 'threats, external, category: persistent.'\n\nYou are in that section. You have been in that section since you crossed the shard boundary. You have a case number.",
-      "In the Spire's early catalogues, the Archivist noted that magic follows rules and rules can be mastered. His later entries Ã¢ÂÂ written after the Fracture, in a hand that grew steadily less human Ã¢ÂÂ simply note that mastery takes time.\n\nHe has had time."
+      "In the Spire's early catalogues, the Archivist noted that magic follows rules and rules can be mastered. His later entries — written after the Fracture, in a hand that grew steadily less human — simply note that mastery takes time.\n\nHe has had time."
     ],
     "priorRunSummaries": [
       "The outer lattice looked exactly as the recovered schematics described it. Which was suspicious, because the schematics were three years old and the lattice was known to rearrange itself.",
@@ -137,12 +137,12 @@
       "Fifty approaches. The crystal walls show you all your previous visits simultaneously. It looks like a gallery. The Archivist has curated it."
     ],
     "milestoneOpenings100": [
-      "The Archivist is at the entrance.\n\nNot in his chamber Ã¢ÂÂ at the entrance. Waiting.\n\n'One hundred visits,' he says. The crystal in his voice has grown, over the years, into something almost warm. 'Do you know what that means, in terms of the archive?'\n\nA pause. A soft chime, somewhere deep in the Spire.\n\n'You have generated more data than the Dominion's entire eastern campaign. I have seventeen volumes dedicated exclusively to your methodology. You are, empirically, the most significant external variable this archive has ever processed.'\n\nHe tilts his crystalline head.\n\n'I have decided to consider this a collaboration.'"
+      "The Archivist is at the entrance.\n\nNot in his chamber — at the entrance. Waiting.\n\n'One hundred visits,' he says. The crystal in his voice has grown, over the years, into something almost warm. 'Do you know what that means, in terms of the archive?'\n\nA pause. A soft chime, somewhere deep in the Spire.\n\n'You have generated more data than the Dominion's entire eastern campaign. I have seventeen volumes dedicated exclusively to your methodology. You are, empirically, the most significant external variable this archive has ever processed.'\n\nHe tilts his crystalline head.\n\n'I have decided to consider this a collaboration.'"
     ]
   },
   "midRunTemplates": [
     "The {ordinalLower} visit to the Crystal Spire. The archive has updated your file. It is now cross-referenced under seventeen categories.",
-    "Campaign {n}. The constructs recognise you on sight. The Archivist has stopped logging your entry time Ã¢ÂÂ he predicts it accurately enough to not bother.",
+    "Campaign {n}. The constructs recognise you on sight. The Archivist has stopped logging your entry time — he predicts it accurately enough to not bother.",
     "{n} campaigns through the lattice. The crystal corridors look the same. They always look the same. The Archivist prefers consistency.",
     "{n} times past the outer lattice. Your case number has gained a suffix: 'See also: the persistent one.'",
     "Run {n}. The Archivist's notes on you are now longer than his notes on the Fracture itself. He considers this an appropriate allocation of resources.",
@@ -347,7 +347,7 @@
         },
         {
           "title": "A NOTIFICATION",
-          "text": "And yet Ã¢ÂÂ {pool:priorRunOpenings:0}\n\nYou push the feeling aside. The Spire is waiting.\n\nIt has always been waiting. It files everything."
+          "text": "And yet — {pool:priorRunOpenings:0}\n\nYou push the feeling aside. The Spire is waiting.\n\nIt has always been waiting. It files everything."
         }
       ]
     }
@@ -453,12 +453,12 @@
       "environment": "citadel",
       "eventConfig": {
         "title": "The Arcane Court",
-        "description": "Crystalline towers rise around you. Hooded figures stand in a circle, studying a glowing object that floats at the centre. They donÃ¢ÂÂt seem hostile. Not yet.",
+        "description": "Crystalline towers rise around you. Hooded figures stand in a circle, studying a glowing object that floats at the centre. They don’t seem hostile. Not yet.",
         "pools": [
           [
             {
               "label": "Step into the circle",
-              "consequence": "The magic steadies you Ã¢ÂÂ restored 10 HP",
+              "consequence": "The magic steadies you — restored 10 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 10
@@ -466,7 +466,7 @@
             },
             {
               "label": "Step into the circle",
-              "consequence": "The ritual grants you a boon Ã¢ÂÂ +18 crystals",
+              "consequence": "The ritual grants you a boon — +18 crystals",
               "effect": {
                 "type": "gainCrystals",
                 "amount": 18
@@ -474,7 +474,7 @@
             },
             {
               "label": "Step into the circle",
-              "consequence": "The energy rejects you Ã¢ÂÂ lose 8 HP",
+              "consequence": "The energy rejects you — lose 8 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 8
@@ -490,7 +490,7 @@
             },
             {
               "label": "Step into the circle",
-              "consequence": "Something small falls from the air Ã¢ÂÂ added to inventory",
+              "consequence": "Something small falls from the air — added to inventory",
               "effect": {
                 "type": "gainItem"
               }
@@ -499,7 +499,7 @@
           [
             {
               "label": "Observe from the doorway",
-              "consequence": "You note weaknesses Ã¢ÂÂ +15 crystals",
+              "consequence": "You note weaknesses — +15 crystals",
               "effect": {
                 "type": "gainCrystals",
                 "amount": 15
@@ -507,21 +507,21 @@
             },
             {
               "label": "Observe from the doorway",
-              "consequence": "They donÃ¢ÂÂt notice you. Nothing happens.",
+              "consequence": "They don’t notice you. Nothing happens.",
               "effect": {
                 "type": "nothing"
               }
             },
             {
               "label": "Observe from the doorway",
-              "consequence": "One of them nods. You find something on the floor Ã¢ÂÂ added to inventory",
+              "consequence": "One of them nods. You find something on the floor — added to inventory",
               "effect": {
                 "type": "gainItem"
               }
             },
             {
               "label": "Observe from the doorway",
-              "consequence": "A fragment drifts toward you Ã¢ÂÂ restored 6 HP",
+              "consequence": "A fragment drifts toward you — restored 6 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 6
@@ -529,7 +529,7 @@
             },
             {
               "label": "Observe from the doorway",
-              "consequence": "A curious object rolls under your foot Ã¢ÂÂ added to inventory",
+              "consequence": "A curious object rolls under your foot — added to inventory",
               "effect": {
                 "type": "gainItem"
               }
@@ -546,7 +546,7 @@
             },
             {
               "label": "Disrupt the ritual",
-              "consequence": "The explosion throws you back Ã¢ÂÂ lose 15 HP",
+              "consequence": "The explosion throws you back — lose 15 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 15
@@ -569,7 +569,7 @@
             },
             {
               "label": "Disrupt the ritual",
-              "consequence": "Something breaks loose in the chaos Ã¢ÂÂ added to inventory",
+              "consequence": "Something breaks loose in the chaos — added to inventory",
               "effect": {
                 "type": "gainItem"
               }
@@ -805,7 +805,7 @@
           [
             {
               "label": "Study the crystals",
-              "consequence": "Absorbed energy restores you Ã¢ÂÂ restored 8 HP",
+              "consequence": "Absorbed energy restores you — restored 8 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 8
@@ -813,7 +813,7 @@
             },
             {
               "label": "Study the crystals",
-              "consequence": "You extract a pattern Ã¢ÂÂ gain a common card",
+              "consequence": "You extract a pattern — gain a common card",
               "effect": {
                 "type": "gainCard",
                 "rarity": "common"
@@ -821,7 +821,7 @@
             },
             {
               "label": "Study the crystals",
-              "consequence": "The knowledge costs you Ã¢ÂÂ lose 6 HP",
+              "consequence": "The knowledge costs you — lose 6 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 6
@@ -829,7 +829,7 @@
             },
             {
               "label": "Study the crystals",
-              "consequence": "You find a practical application Ã¢ÂÂ +12 crystals",
+              "consequence": "You find a practical application — +12 crystals",
               "effect": {
                 "type": "gainCrystals",
                 "amount": 12
@@ -837,7 +837,7 @@
             },
             {
               "label": "Study the crystals",
-              "consequence": "A small crystal detaches from the shelf Ã¢ÂÂ added to inventory",
+              "consequence": "A small crystal detaches from the shelf — added to inventory",
               "effect": {
                 "type": "gainItem"
               }
@@ -862,7 +862,7 @@
             },
             {
               "label": "Take a crystal shard",
-              "consequence": "It releases a feedback pulse Ã¢ÂÂ lose 10 HP",
+              "consequence": "It releases a feedback pulse — lose 10 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 10
@@ -870,7 +870,7 @@
             },
             {
               "label": "Take a crystal shard",
-              "consequence": "Something shifts inside it. You keep it Ã¢ÂÂ added to inventory",
+              "consequence": "Something shifts inside it. You keep it — added to inventory",
               "effect": {
                 "type": "gainItem"
               }
@@ -894,7 +894,7 @@
             },
             {
               "label": "Leave an offering of mana",
-              "consequence": "Something flows back in return Ã¢ÂÂ restored 15 HP",
+              "consequence": "Something flows back in return — restored 15 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 15
@@ -902,7 +902,7 @@
             },
             {
               "label": "Leave an offering of mana",
-              "consequence": "The archive takes more than you offered Ã¢ÂÂ lose 5 HP",
+              "consequence": "The archive takes more than you offered — lose 5 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 5
@@ -910,14 +910,14 @@
             },
             {
               "label": "Leave an offering of mana",
-              "consequence": "Something small materialises at your feet Ã¢ÂÂ added to inventory",
+              "consequence": "Something small materialises at your feet — added to inventory",
               "effect": {
                 "type": "gainItem"
               }
             },
             {
               "label": "Leave an offering of mana",
-              "consequence": "The archive blesses you with renewed vigour Ã¢ÂÂ +1 life",
+              "consequence": "The archive blesses you with renewed vigour — +1 life",
               "effect": {
                 "type": "gainLife",
                 "amount": 1

--- a/web/src/data/battlefield.json
+++ b/web/src/data/battlefield.json
@@ -10,7 +10,12 @@
     "arcane":      ["floor-crystal", "crystal-left", "crystal-right", "path-arcane-center"],
     "reef":        ["floor-sand", "reef-left", "reef-right", "path-coral-center"],
     "sky":         ["floor-cloud", "cloud-left", "cloud-right", "path-sky-center"],
-    "volcano":     ["floor-lava", "lava-left", "lava-right", "path-ember-center"]
+    "volcano":     ["floor-lava", "lava-left", "lava-right", "path-ember-center"],
+    "fungal":      ["floor-fungal", "fungal-left", "fungal-right", "path-spore-center"],
+    "frost":       ["floor-frost", "frost-left", "frost-right", "path-ice-center"],
+    "sand":        ["floor-desert", "dune-left", "dune-right", "path-dust-center"],
+    "coast":       ["floor-coast", "coast-left", "coast-right", "path-shore-center"],
+    "vault":       ["floor-vault", "vault-left", "vault-right", "path-vault-center"]
   },
   "seasonLayers": {
     "spring": ["season-spring-flowers"],


### PR DESCRIPTION
Fixes #913

## Root cause

`battlefield.json` was missing 5 environment entries. The `BattlefieldBackground` component falls back to `forest` when an env key isn't found, so acts 8–13 (except act 11 which already uses `forest`) all rendered the default green ground.

## What's added

5 new environments × 4 SVG layers each = 20 new sprite files:

| Act | Environment | Floor | Edges | Path |
|-----|-------------|-------|-------|------|
| 8 | `fungal` | Dark purple, spore shadows | Mushroom caps + spore tendrils | Dark soil with spore dots |
| 9 | `frost` | Pale blue-white, ice cracks | Ice crystals + frost branches | Icy blue with crack detail |
| 10 | `sand` | Warm sandy tan, dune ripples | Dune ridges + desert rocks | Dusty track |
| 12 | `coast` | Sandy beach, wet shimmer | Waves + sea foam + coastal rocks | Packed wet sand |
| 13 | `vault` | Dark stone, block seams + rune glows | Pillar blocks + rune marks + iron rings | Worn corridor + floor runes |

https://claude.ai/code/session_01VW7FYzZyG3XFkdWnuSVcnt

---
_Generated by [Claude Code](https://claude.ai/code/session_01VW7FYzZyG3XFkdWnuSVcnt)_