### PR TITLE
fix(act12): fix harbormaster boss AI playing no cards

### DIFF
--- a/web/src/data/bossAIs.json
+++ b/web/src/data/bossAIs.json
@@ -834,17 +834,15 @@
         },
         "priorities": [
           {
-            "type": "structure",
-            "subType": "spawn",
-            "order": "first"
+            "cardType": "structure",
+            "structureEffect": "spawn"
           },
           {
-            "type": "unit",
-            "order": "cost_desc"
+            "cardType": "unit",
+            "sortBy": "cost_desc"
           },
           {
-            "type": "upgrade",
-            "order": "first"
+            "cardType": "upgrade"
           }
         ]
       },
@@ -855,23 +853,20 @@
         },
         "priorities": [
           {
-            "type": "unit",
-            "tag": "ranged",
-            "order": "cost_desc"
+            "cardType": "unit",
+            "flying": true,
+            "sortBy": "cost_desc"
           },
           {
-            "type": "unit",
-            "tag": "flying",
-            "order": "cost_desc"
+            "cardType": "structure",
+            "structureEffect": "spawn"
           },
           {
-            "type": "structure",
-            "subType": "spawn",
-            "order": "first"
+            "cardType": "unit",
+            "sortBy": "cost_desc"
           },
           {
-            "type": "upgrade",
-            "order": "first"
+            "cardType": "upgrade"
           }
         ],
         "announceOnce": "The Harbormaster signals his fleet!"
@@ -883,17 +878,15 @@
         "announceOnce": "The iron tide rises! No mercy!",
         "priorities": [
           {
-            "type": "unit",
-            "order": "cost_desc"
+            "cardType": "unit",
+            "sortBy": "cost_desc"
           },
           {
-            "type": "structure",
-            "subType": "spawn",
-            "order": "first"
+            "cardType": "structure",
+            "structureEffect": "spawn"
           },
           {
-            "type": "upgrade",
-            "order": "first"
+            "cardType": "upgrade"
           }
         ]
       }


### PR DESCRIPTION
## Summary

- The harbormaster boss AI in `bossAIs.json` used wrong field names in its priority objects (`type`/`subType`/`order`/`tag`) instead of the engine-expected names (`cardType`/`structureEffect`/`sortBy`)
- Because `p.cardType` was `undefined` on every priority, `matchesPriority` in `engine/boss.ts` never matched any card, so the boss played nothing each turn
- Fixed by renaming fields to match the `BossAIPriority` interface; also dropped the unsupported `tag` filter (replaced with `flying: true` for the flying-unit priority in phase 2)

## Test plan

- [ ] Play Act 12 — the Harbormaster should now actively play cards each turn
- [ ] Verify phase 1 (0–30s): spawn structures then units by cost
- [ ] Verify phase 2 (30–70s): prioritises flying units, then spawn structures, then other units
- [ ] Verify phase 3 (70s+): higher mana (8) and plays up to 4 cards per turn

Closes #918

https://claude.ai/code/session_01Hc2bstvPJ8uBdL4BZwrjPZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hc2bstvPJ8uBdL4BZwrjPZ)_