### PR TITLE
Buff weak late-game relics (Acts 10–Finale)

### DIFF
--- a/web/src/data/acts/act10.json
+++ b/web/src/data/acts/act10.json
@@ -4,7 +4,7 @@
   "title": "ACT X",
   "subtitle": "The Sand Market",
   "rewardRelic": "Golden Compass",
-  "rewardRelicDesc": "You start each battle with +1 mana.",
+  "rewardRelicDesc": "You start each battle with full mana.",
   "environment": "sand",
   "rewardTags": [
     "sand",
@@ -43,7 +43,7 @@
   "intro": [
     {
       "title": "THE SAND MARKET",
-      "text": "The ley lines run straight through the desert, which the Sand Market has spent decades making commercially relevant. The market grew up around the ley convergence — vendors first, then traders, then mercenaries, then the Dune Baron, who saw the strategic value and started charging for it.\n\nEverything here has a price. Including passage through it.",
+      "text": "The ley lines run straight through the desert, which the Sand Market has spent decades making commercially relevant. The market grew up around the ley convergence \u2014 vendors first, then traders, then mercenaries, then the Dune Baron, who saw the strategic value and started charging for it.\n\nEverything here has a price. Including passage through it.",
       "image": "cutscenes/act10-intro-1.svg"
     },
     {
@@ -53,14 +53,14 @@
     },
     {
       "title": "THE MARKET ROUTE",
-      "text": "The ley lines converge beneath the market's central spire — the Dune Baron uses the energy surplus to power the lights, the forges, and the contract-binding seals that make his mercenary arrangements legally enforceable.\n\nYou need the convergence point. He isn't selling it.\n\nYou're going to take it. He'll probably factor this into his pricing for the next traveller.",
+      "text": "The ley lines converge beneath the market's central spire \u2014 the Dune Baron uses the energy surplus to power the lights, the forges, and the contract-binding seals that make his mercenary arrangements legally enforceable.\n\nYou need the convergence point. He isn't selling it.\n\nYou're going to take it. He'll probably factor this into his pricing for the next traveller.",
       "image": "cutscenes/act10-intro-3.svg"
     }
   ],
   "outro": [
     {
       "title": "THE DUNE BARON SETTLES",
-      "text": "The Dune Baron doesn't lose gracefully. He loses expensively — which means he calculates the cost of the outcome, determines it was within acceptable parameters, and files the result under 'resolved.'\n\nThe ley lines pulse through the market floor. The convergence point opens.\n\nHe's already thinking about what to charge the next person who shows up.",
+      "text": "The Dune Baron doesn't lose gracefully. He loses expensively \u2014 which means he calculates the cost of the outcome, determines it was within acceptable parameters, and files the result under 'resolved.'\n\nThe ley lines pulse through the market floor. The convergence point opens.\n\nHe's already thinking about what to charge the next person who shows up.",
       "image": "cutscenes/act10-outro-1.svg"
     },
     {
@@ -70,7 +70,7 @@
     },
     {
       "title": "THE GOLDEN COMPASS",
-      "text": "The Golden Compass sits warm in your palm — the Baron's personal navigation tool, used to track ley line convergences across the desert. It still points to them.\n\nIt also, apparently, makes you faster off the mark. The Baron claims he hadn't noticed that. You don't believe him.\n\nThe ley lines point on. The market recedes. The desert is, for once, quiet.",
+      "text": "The Golden Compass sits warm in your palm \u2014 the Baron's personal navigation tool, used to track ley line convergences across the desert. It still points to them.\n\nIt also, apparently, makes you faster off the mark. The Baron claims he hadn't noticed that. You don't believe him.\n\nThe ley lines point on. The market recedes. The desert is, for once, quiet.",
       "image": "cutscenes/act10-outro-3.svg"
     }
   ],
@@ -128,7 +128,7 @@
           [
             {
               "label": "Drink from the spring",
-              "consequence": "The water restores — healed 14 HP",
+              "consequence": "The water restores \u2014 healed 14 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 14
@@ -136,7 +136,7 @@
             },
             {
               "label": "Drink from the spring",
-              "consequence": "Something in it stings — lose 6 HP",
+              "consequence": "Something in it stings \u2014 lose 6 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 6
@@ -162,7 +162,7 @@
           [
             {
               "label": "Search the offering-stones",
-              "consequence": "Something useful left behind — uncommon card",
+              "consequence": "Something useful left behind \u2014 uncommon card",
               "effect": {
                 "type": "gainCard",
                 "rarity": "uncommon"
@@ -170,7 +170,7 @@
             },
             {
               "label": "Search the offering-stones",
-              "consequence": "Coins left as offerings — +22 crystals",
+              "consequence": "Coins left as offerings \u2014 +22 crystals",
               "effect": {
                 "type": "gainCrystals",
                 "amount": 22
@@ -187,7 +187,7 @@
           [
             {
               "label": "Fill your reserves",
-              "consequence": "The water heals on the road — healed 8 HP",
+              "consequence": "The water heals on the road \u2014 healed 8 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 8
@@ -473,12 +473,12 @@
       "environment": "sand",
       "eventConfig": {
         "title": "The Mirage Cache",
-        "description": "A concealed depot in the dune face — the Baron's forces maintain several, and not all of them are decoys. This one is real. The lock is good but not insurmountable.",
+        "description": "A concealed depot in the dune face \u2014 the Baron's forces maintain several, and not all of them are decoys. This one is real. The lock is good but not insurmountable.",
         "pools": [
           [
             {
               "label": "Open the cache",
-              "consequence": "Weapons inside — rare card",
+              "consequence": "Weapons inside \u2014 rare card",
               "effect": {
                 "type": "gainCard",
                 "rarity": "rare"
@@ -486,7 +486,7 @@
             },
             {
               "label": "Open the cache",
-              "consequence": "Supplies — healed 15 HP",
+              "consequence": "Supplies \u2014 healed 15 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 15
@@ -494,7 +494,7 @@
             },
             {
               "label": "Open the cache",
-              "consequence": "It was a decoy — lose 12 HP",
+              "consequence": "It was a decoy \u2014 lose 12 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 12
@@ -520,7 +520,7 @@
             },
             {
               "label": "Sell the contents",
-              "consequence": "One item worth keeping — uncommon card",
+              "consequence": "One item worth keeping \u2014 uncommon card",
               "effect": {
                 "type": "gainCard",
                 "rarity": "uncommon"
@@ -617,12 +617,12 @@
       "environment": "sand",
       "eventConfig": {
         "title": "The Baron's Ledger",
-        "description": "The Dune Baron's transaction records — every contract, every sale, every mercenary hired and dismissed since the market was established. His notes on the Fracture are in here. He logged it as a business disruption.",
+        "description": "The Dune Baron's transaction records \u2014 every contract, every sale, every mercenary hired and dismissed since the market was established. His notes on the Fracture are in here. He logged it as a business disruption.",
         "pools": [
           [
             {
               "label": "Study the contracts",
-              "consequence": "Exploitable intel — rare card",
+              "consequence": "Exploitable intel \u2014 rare card",
               "effect": {
                 "type": "gainCard",
                 "rarity": "rare"
@@ -630,7 +630,7 @@
             },
             {
               "label": "Study the contracts",
-              "consequence": "Supply chain map — +28 crystals",
+              "consequence": "Supply chain map \u2014 +28 crystals",
               "effect": {
                 "type": "gainCrystals",
                 "amount": 28
@@ -640,7 +640,7 @@
           [
             {
               "label": "Rest in the records room",
-              "consequence": "Quiet and warm — healed 15 HP",
+              "consequence": "Quiet and warm \u2014 healed 15 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 15

--- a/web/src/data/acts/act11.json
+++ b/web/src/data/acts/act11.json
@@ -4,7 +4,7 @@
   "title": "ACT XI",
   "subtitle": "The Verdant Canopy",
   "rewardRelic": "Living Bark",
-  "rewardRelicDesc": "Your base gains +15 maximum HP.",
+  "rewardRelicDesc": "Your base gains +25 max HP and all your units gain +4 max HP at the start of every battle.",
   "environment": "forest",
   "rewardTags": [
     "canopy",
@@ -43,34 +43,34 @@
   "intro": [
     {
       "title": "THE VERDANT CANOPY",
-      "text": "The ley lines rise into the high canopy here, threading through root systems older than memory. The forest above the treeline moves differently. It doesn't react to you — it notices you.\n\nThe Elder Warden has kept this canopy since before the Fracture. It has watched dozens of expeditions attempt passage. None returned changed for the better.",
+      "text": "The ley lines rise into the high canopy here, threading through root systems older than memory. The forest above the treeline moves differently. It doesn't react to you \u2014 it notices you.\n\nThe Elder Warden has kept this canopy since before the Fracture. It has watched dozens of expeditions attempt passage. None returned changed for the better.",
       "image": "cutscenes/act11-intro-1.svg"
     },
     {
       "title": "THE ELDER WARDEN",
-      "text": "It is not a creature in any familiar sense. The Warden is the canopy made sovereign — a convergence of root and memory and something older that has no name in any language you speak.\n\nIt does not hate you. Hatred requires noticing something as a peer. The Warden sees you as disruption. Disruptions are removed.",
+      "text": "It is not a creature in any familiar sense. The Warden is the canopy made sovereign \u2014 a convergence of root and memory and something older that has no name in any language you speak.\n\nIt does not hate you. Hatred requires noticing something as a peer. The Warden sees you as disruption. Disruptions are removed.",
       "image": "cutscenes/act11-intro-2.svg"
     },
     {
       "title": "THE PATH THROUGH",
-      "text": "The ley convergence runs through the ancient heartwood at the canopy's centre. Scholars have theorised about it for decades. None have gotten close enough to verify.\n\nYou will need to fight through layers of living defence — root walls, grove-spawned treants, flying watchers — before the Warden descends. And then you will need to convince it, by force, that disruption can be useful.",
+      "text": "The ley convergence runs through the ancient heartwood at the canopy's centre. Scholars have theorised about it for decades. None have gotten close enough to verify.\n\nYou will need to fight through layers of living defence \u2014 root walls, grove-spawned treants, flying watchers \u2014 before the Warden descends. And then you will need to convince it, by force, that disruption can be useful.",
       "image": "cutscenes/act11-intro-3.svg"
     }
   ],
   "outro": [
     {
       "title": "THE CANOPY YIELDS",
-      "text": "The Elder Warden does not fall. It withdraws — slowly, deliberately, as though choosing to end the engagement rather than being forced to. The distinction matters to it.\n\nThe ley convergence is exposed. The heartwood pulses with calm energy, older than anything you've touched before.",
+      "text": "The Elder Warden does not fall. It withdraws \u2014 slowly, deliberately, as though choosing to end the engagement rather than being forced to. The distinction matters to it.\n\nThe ley convergence is exposed. The heartwood pulses with calm energy, older than anything you've touched before.",
       "image": "cutscenes/act11-outro-1.svg"
     },
     {
       "title": "LIVING BARK",
-      "text": "Where the Warden stood, a strip of bark remains — thick, warm to the touch, and inexplicably alive. It hardens in your hands into something like armour, or maybe a shield, or maybe just the canopy saying: you've earned a layer of protection.\n\nYou don't question it. The canopy rewards results.",
+      "text": "Where the Warden stood, a strip of bark remains \u2014 thick, warm to the touch, and inexplicably alive. It hardens in your hands into something like armour, or maybe a shield, or maybe just the canopy saying: you've earned a layer of protection.\n\nYou don't question it. The canopy rewards results.",
       "image": "cutscenes/act11-outro-2.svg"
     },
     {
       "title": "THE ROAD AHEAD",
-      "text": "The Verdant Canopy recedes behind you as you descend. Above, you hear the canopy resume its ordinary rhythms — something enormous moving between branches, watchers returning to their posts.\n\nThe Warden is already repairing the damage. It won't hold a grudge. It's too old for that. It will simply be ready when you return.",
+      "text": "The Verdant Canopy recedes behind you as you descend. Above, you hear the canopy resume its ordinary rhythms \u2014 something enormous moving between branches, watchers returning to their posts.\n\nThe Warden is already repairing the damage. It won't hold a grudge. It's too old for that. It will simply be ready when you return.",
       "image": "cutscenes/act11-outro-3.svg"
     }
   ],
@@ -120,7 +120,7 @@
       ],
       "eventConfig": {
         "title": "The Root Shrine",
-        "description": "A gnarled shrine wrapped in glowing roots. You can feel something ancient in it. The options it presents are simple — give something, take something, or leave it alone.",
+        "description": "A gnarled shrine wrapped in glowing roots. You can feel something ancient in it. The options it presents are simple \u2014 give something, take something, or leave it alone.",
         "pools": [
           [
             {
@@ -277,7 +277,7 @@
       ],
       "eventConfig": {
         "title": "The Canopy Rift",
-        "description": "A gap in the ancient canopy shows the raw ley lines beneath — shimmering, strange, and old. You can attempt to draw on them, or simply study them from a safe distance.",
+        "description": "A gap in the ancient canopy shows the raw ley lines beneath \u2014 shimmering, strange, and old. You can attempt to draw on them, or simply study them from a safe distance.",
         "pools": [
           [
             {
@@ -410,7 +410,7 @@
       ],
       "eventConfig": {
         "title": "The Warden's Gaze",
-        "description": "You feel it before you see it — a presence older than stone watching from the high branches. It hasn't moved. It's waiting to see what you do. Your choice here will define what follows.",
+        "description": "You feel it before you see it \u2014 a presence older than stone watching from the high branches. It hasn't moved. It's waiting to see what you do. Your choice here will define what follows.",
         "pools": [
           [
             {

--- a/web/src/data/acts/act12.json
+++ b/web/src/data/acts/act12.json
@@ -4,7 +4,7 @@
   "title": "ACT XII",
   "subtitle": "The Shattered Coast",
   "rewardRelic": "Salvage Hook",
-  "rewardRelicDesc": "Once per battle, one of your destroyed units is revived at 1 HP.",
+  "rewardRelicDesc": "Once per battle, one of your destroyed units is revived at full HP.",
   "environment": "coast",
   "rewardTags": [
     "wreck",
@@ -43,17 +43,17 @@
   "intro": [
     {
       "title": "THE SHATTERED COAST",
-      "text": "The Shattered Coast was once a thriving port city — before the Fracture split it across seven separate shards.\n\nNow the channels between shards are controlled by a single authority: the Harbormaster. Nothing moves without his iron seal. No cargo. No people. No information.",
+      "text": "The Shattered Coast was once a thriving port city \u2014 before the Fracture split it across seven separate shards.\n\nNow the channels between shards are controlled by a single authority: the Harbormaster. Nothing moves without his iron seal. No cargo. No people. No information.",
       "image": "cutscenes/act12-intro-1.svg"
     },
     {
       "title": "THE HARBORMASTER",
-      "text": "He was a port inspector once, before the Fracture. Now he is something else — a man who discovered that chaos could be administered, and administration could be power.\n\nHis fleet patrols the shattered channels. His flags are the only law. The wreck divers answer to him. The storm hawks circle his flagship.",
+      "text": "He was a port inspector once, before the Fracture. Now he is something else \u2014 a man who discovered that chaos could be administered, and administration could be power.\n\nHis fleet patrols the shattered channels. His flags are the only law. The wreck divers answer to him. The storm hawks circle his flagship.",
       "image": "cutscenes/act12-intro-2.svg"
     },
     {
       "title": "NO PERMIT",
-      "text": "You don't have his permit. You don't intend to get one.\n\nThe coast is the only route forward, and the Harbormaster blocks it. Fight through his patrols, his reef wardens, his iron anchorage — and put an end to the toll.",
+      "text": "You don't have his permit. You don't intend to get one.\n\nThe coast is the only route forward, and the Harbormaster blocks it. Fight through his patrols, his reef wardens, his iron anchorage \u2014 and put an end to the toll.",
       "image": "cutscenes/act12-intro-3.svg"
     }
   ],
@@ -65,7 +65,7 @@
     },
     {
       "title": "SALVAGE HOOK",
-      "text": "Among the wreckage, half-buried in sand, you find a salvage hook — the symbol of passage along this coast. It's old. Pre-Fracture. It means something.\n\nYou pocket it. The channels open around you.",
+      "text": "Among the wreckage, half-buried in sand, you find a salvage hook \u2014 the symbol of passage along this coast. It's old. Pre-Fracture. It means something.\n\nYou pocket it. The channels open around you.",
       "image": "cutscenes/act12-outro-2.svg"
     },
     {
@@ -437,7 +437,7 @@
       "id": "iron-anchorage",
       "type": "elite",
       "label": "Iron Anchorage",
-      "description": "The Harbormaster's advance guard — iron-hulled and merciless.",
+      "description": "The Harbormaster's advance guard \u2014 iron-hulled and merciless.",
       "row": 4,
       "col": 3,
       "rowCols": 4,

--- a/web/src/data/acts/act13.json
+++ b/web/src/data/acts/act13.json
@@ -4,7 +4,7 @@
   "title": "ACT XIII",
   "subtitle": "The Clockwork Vaults",
   "rewardRelic": "Gear Heart",
-  "rewardRelicDesc": "All your units gain +1 ATK when played, and your base gains +1 max HP each battle.",
+  "rewardRelicDesc": "All your units gain +3 ATK and +3 max HP at battle start, and gain an additional +2 ATK whenever any card is played.",
   "environment": "vault",
   "rewardTags": [
     "clockwork",
@@ -43,12 +43,12 @@
   "intro": [
     {
       "title": "THE CLOCKWORK VAULTS",
-      "text": "Deep beneath the shattered earth, the Clockwork Vaults hum with ancient machinery — built before the Fracture by an artificer order that no longer exists.\n\nThe Grand Automaton maintains it all. Has maintained it for two hundred years. No one knows if it was told to stop.",
+      "text": "Deep beneath the shattered earth, the Clockwork Vaults hum with ancient machinery \u2014 built before the Fracture by an artificer order that no longer exists.\n\nThe Grand Automaton maintains it all. Has maintained it for two hundred years. No one knows if it was told to stop.",
       "image": "cutscenes/act13-intro-1.svg"
     },
     {
       "title": "THE GRAND AUTOMATON",
-      "text": "It is not hostile. Hostility implies intent. The Automaton simply optimises — calculating minimum-force resolutions for all threats to vault integrity.\n\nYou are a threat to vault integrity.",
+      "text": "It is not hostile. Hostility implies intent. The Automaton simply optimises \u2014 calculating minimum-force resolutions for all threats to vault integrity.\n\nYou are a threat to vault integrity.",
       "image": "cutscenes/act13-intro-2.svg"
     },
     {
@@ -65,7 +65,7 @@
     },
     {
       "title": "GEAR HEART",
-      "text": "Amid the cooling machinery, you find a small gear-shaped crystal — the Automaton's drive core, still faintly warm.\n\nA fitting trophy. It pulses with each heartbeat.",
+      "text": "Amid the cooling machinery, you find a small gear-shaped crystal \u2014 the Automaton's drive core, still faintly warm.\n\nA fitting trophy. It pulses with each heartbeat.",
       "image": "cutscenes/act13-outro-2.svg"
     },
     {
@@ -357,7 +357,7 @@
       "id": "repair-bay",
       "type": "rest",
       "label": "Salvaged Repair Bay",
-      "description": "Abandoned repair alcove — still functional.",
+      "description": "Abandoned repair alcove \u2014 still functional.",
       "row": 3,
       "col": 3,
       "rowCols": 4,

--- a/web/src/data/acts/actfinale.json
+++ b/web/src/data/acts/actfinale.json
@@ -3,7 +3,7 @@
   "title": "FINALE",
   "subtitle": "The Fractured Core",
   "rewardRelic": "Worldmender's Crest",
-  "rewardRelicDesc": "A mark of the one who healed the world. Worn by no one before.",
+  "rewardRelicDesc": "The mark of the Worldmender. Your base gains +30 max HP, all units gain +6 ATK and +8 max HP, and your maximum mana is increased by 2.",
   "environment": "ruins",
   "rewardTags": [],
   "replayModifiers": [
@@ -39,12 +39,12 @@
   "intro": [
     {
       "title": "THE FRACTURED CORE",
-      "text": "You have crossed thirteen shards, faced their champions, and collected their secrets. The path has always led here — to the wound at the world's heart.\n\nThe Fracture Event tore reality apart and scattered the Dominion into pieces. Something caused it. Something remains at the centre.",
+      "text": "You have crossed thirteen shards, faced their champions, and collected their secrets. The path has always led here \u2014 to the wound at the world's heart.\n\nThe Fracture Event tore reality apart and scattered the Dominion into pieces. Something caused it. Something remains at the centre.",
       "image": "cutscenes/actfinale-intro-1.svg"
     },
     {
       "title": "THE FORCE WITHIN",
-      "text": "The Fractured Core does not feel like a place. It feels like the absence of one — a scar where the world used to be whole.\n\nThe entity within has no name. No origin. It simply is the fracture, given will and hunger.",
+      "text": "The Fractured Core does not feel like a place. It feels like the absence of one \u2014 a scar where the world used to be whole.\n\nThe entity within has no name. No origin. It simply is the fracture, given will and hunger.",
       "image": "cutscenes/actfinale-intro-2.svg"
     },
     {
@@ -56,7 +56,7 @@
   "outro": [
     {
       "title": "THE FRACTURE CLOSES",
-      "text": "The entity shudders. Writhes. And then — for the first time since the cataclysm — something at the heart of the world goes quiet.\n\nThe wound begins to close.",
+      "text": "The entity shudders. Writhes. And then \u2014 for the first time since the cataclysm \u2014 something at the heart of the world goes quiet.\n\nThe wound begins to close.",
       "image": "cutscenes/actfinale-outro-1.svg"
     },
     {
@@ -144,7 +144,7 @@
       "id": "fractures-herald",
       "type": "elite",
       "label": "The Fracture's Herald",
-      "description": "A projection of the Fracture itself — testing your limits before the end.",
+      "description": "A projection of the Fracture itself \u2014 testing your limits before the end.",
       "row": 3,
       "col": 0,
       "rowCols": 1,
@@ -168,7 +168,7 @@
       "id": "the-fracture-node",
       "type": "boss",
       "label": "The Fracture",
-      "description": "The source of the cataclysm. The end of the world — or yours.",
+      "description": "The source of the cataclysm. The end of the world \u2014 or yours.",
       "row": 4,
       "col": 0,
       "rowCols": 1,

--- a/web/src/data/relics.json
+++ b/web/src/data/relics.json
@@ -47,8 +47,8 @@
   {
     "name": "Golden Compass",
     "icon": "🧭",
-    "desc": "You start each battle with +1 mana.",
-    "effects": [{ "type": "startMana", "amount": 1 }]
+    "desc": "You start each battle with full mana.",
+    "effects": [{ "type": "startMana", "amount": 99 }]
   },
   {
     "name": "Spore Bloom",
@@ -65,28 +65,37 @@
   {
     "name": "Living Bark",
     "icon": "🌿",
-    "desc": "Your base gains +15 max HP at the start of every battle.",
-    "effects": [{ "type": "baseHp", "amount": 15 }]
+    "desc": "Your base gains +25 max HP and all your units gain +4 max HP at the start of every battle.",
+    "effects": [
+      { "type": "baseHp", "amount": 25 },
+      { "type": "unitHp", "amount": 4 }
+    ]
   },
   {
     "name": "Salvage Hook",
     "icon": "🪝",
-    "desc": "Once per battle, one of your destroyed units is revived at 1 HP.",
-    "effects": [{ "type": "unitRevive", "hp": 1 }]
+    "desc": "Once per battle, one of your destroyed units is revived at full HP.",
+    "effects": [{ "type": "unitRevive", "hp": "full" }]
   },
   {
     "name": "Gear Heart",
     "icon": "⚙️",
-    "desc": "All your units gain +1 ATK when played, and your base gains +1 max HP at battle start.",
+    "desc": "All your units gain +3 ATK and +3 max HP at battle start, and gain an additional +2 ATK whenever any card is played.",
     "effects": [
-      { "type": "onPlayAtk", "amount": 1 },
-      { "type": "baseHp", "amount": 1 }
+      { "type": "unitAtk", "amount": 3 },
+      { "type": "unitHp", "amount": 3 },
+      { "type": "onPlayAtk", "amount": 2 }
     ]
   },
   {
     "name": "Worldmender's Crest",
     "icon": "🌐",
-    "desc": "Your base gains +5 max HP at the start of every battle.",
-    "effects": [{ "type": "baseHp", "amount": 5 }]
+    "desc": "The mark of the Worldmender. Your base gains +30 max HP, all units gain +6 ATK and +8 max HP, and your maximum mana is increased by 2.",
+    "effects": [
+      { "type": "baseHp", "amount": 30 },
+      { "type": "unitAtk", "amount": 6 },
+      { "type": "unitHp", "amount": 8 },
+      { "type": "maxMana", "amount": 2 }
+    ]
   }
 ]

--- a/web/src/game/engine/combat.ts
+++ b/web/src/game/engine/combat.ts
@@ -182,7 +182,7 @@ export function processAttacks(s: GameState, deltaMs: number, log: string[]): vo
   if (s.unitReviveHp !== undefined) {
     const dead = s.field.find(u => u.owner === 'player' && u.hp <= 0 && u.moveSpeed > 0)
     if (dead) {
-      dead.hp = s.unitReviveHp === 'half' ? Math.ceil(dead.maxHp / 2) : s.unitReviveHp
+      dead.hp = s.unitReviveHp === 'half' ? Math.ceil(dead.maxHp / 2) : s.unitReviveHp === 'full' ? dead.maxHp : s.unitReviveHp
       s.unitReviveHp = undefined
       log.push(`${dead.name} rises from the dead!`)
     }

--- a/web/src/game/relics.ts
+++ b/web/src/game/relics.ts
@@ -15,7 +15,7 @@ export type RelicEffect =
   | { type: 'unitHp';     amount: number }
   | { type: 'maxMana';    amount: number }
   | { type: 'startMana';  amount: number }
-  | { type: 'unitRevive'; hp: 'half' | number }
+  | { type: 'unitRevive'; hp: 'half' | 'full' | number }
   | { type: 'tickHeal';   amount: number; intervalMs: number }
   | { type: 'onPlayAtk';  amount: number }
 

--- a/web/src/game/types.ts
+++ b/web/src/game/types.ts
@@ -308,7 +308,7 @@ export interface GameState {
   bossTraitState?: BossTraitState
   terrain: TerrainObstacle[]
   environment?: string       // battlefield background theme ('forest' | 'ruins' | 'camp' | 'citadel' | 'ashen')
-  unitReviveHp?: 'half' | number      // pending one-time unit revive at this HP value (set by Soulstone/Salvage Hook relics)
+  unitReviveHp?: 'half' | 'full' | number      // pending one-time unit revive at this HP value (set by Soulstone/Salvage Hook relics)
   relicManaBonus?: number             // passive +N to maxMana cap (set by Prism Lens relic)
   playerManaRegenMs?: number          // player's upgraded mana regen interval (default 3000 ms)
   tickEffects?: TickEffect[]          // periodic effects applied each engine tick


### PR DESCRIPTION
## Summary

Closes #919

The five relics awarded from Act 10 onwards were underpowered compared to early-game relics. This PR keeps all relic names intact (to preserve existing player inventories) and upgrades their effects:

| Relic | Before | After |
|-------|--------|-------|
| **Golden Compass** (Act 10) | +1 start mana | Start every battle with **full mana** |
| **Living Bark** (Act 11) | +15 base HP | +25 base HP **+ all units +4 max HP** |
| **Salvage Hook** (Act 12) | Revive at 1 HP | Revive at **full HP** (now strictly stronger than Soulstone) |
| **Gear Heart** (Act 13) | +1 ATK on play + 1 base HP | +3 ATK +3 HP at start + **+2 ATK per card played** |
| **Worldmender's Crest** (Finale) | +5 base HP | +30 base HP, **+6 ATK +8 HP all units, +2 max mana** |

Also adds `'full'` as a valid `unitRevive` option in `types.ts`, `relics.ts`, and `combat.ts`.

## Test plan
- [ ] Complete Act 10–Finale and confirm each relic is awarded correctly
- [ ] Verify Golden Compass starts battles at full mana
- [ ] Verify Living Bark grants +25 base HP and +4 unit HP
- [ ] Verify Salvage Hook revives a unit at full HP (not 1 HP)
- [ ] Verify Gear Heart grants +3 ATK/HP at start and +2 ATK per card played
- [ ] Verify Worldmender's Crest grants all stated bonuses
- [ ] Confirm existing players with these relics in their inventory still work correctly

https://claude.ai/code/session_01CN6iK62ynuKmb3i5ZbxHcc

---
_Generated by [Claude Code](https://claude.ai/code/session_01CN6iK62ynuKmb3i5ZbxHcc)_