### PR TITLE
feat(shop): buy multiple card packs in one go (#893)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -312,7 +312,7 @@ export default function App() {
     [],
   )
 
-  const [pack, setPack]           = useState<string[]>([])
+  const [packs, setPacks]         = useState<string[][]>([])
   const [handicap, setHandicap]   = useState<number>(loadHandicap)
   const [crystals, setCrystals]   = useState<number>(loadCrystals)
 
@@ -1914,18 +1914,19 @@ export default function App() {
         break
     }
 
-    setPack( pack)
+    setPacks([pack])
     setScreen('pack')
   }, [])
 
-  const handleBuyCrystalPack = useCallback(() => {
+  const handleBuyCrystalPack = useCallback((qty: number = 1) => {
     const current = loadCrystals()
-    if (current < CRYSTAL_PACK_COST) return
-    const next = current - CRYSTAL_PACK_COST
+    const totalCost = CRYSTAL_PACK_COST * qty
+    if (current < totalCost) return
+    const next = current - totalCost
     saveCrystals(next)
     setCrystals(next)
     packBackScreenRef.current = 'shop'
-    setPack(generatePack())
+    setPacks(Array.from({ length: qty }, () => generatePack()))
     setScreen('pack')
   }, [])
 
@@ -2390,7 +2391,7 @@ export default function App() {
       )}
 
       {screen === 'pack' && (
-        <PackOpening pack={pack} onDone={handlePackDone} />
+        <PackOpening packs={packs} onDone={handlePackDone} />
       )}
 
       {screen === 'inventory' && (

--- a/web/src/components/PackOpening.tsx
+++ b/web/src/components/PackOpening.tsx
@@ -6,22 +6,29 @@ import { CardTile } from './CardTile'
 import { useCardDetail } from './useCardDetail'
 
 interface Props {
-  /** Array of 5 card names in reveal order */
-  pack: string[]
+  /** One or more packs; each pack is an array of card names in reveal order */
+  packs: string[][]
   onDone: () => void
 }
 
 const TAP_REQUIRED: Partial<Record<string, number>> = { rare: 3, legendary: 5 }
 
-export function PackOpening({ pack, onDone }: Props) {
+export function PackOpening({ packs, onDone }: Props) {
   const catalog = getCardCatalog()
+
+  // Which pack we're currently opening
+  const [packIdx, setPackIdx] = useState(0)
+  const packIdxRef = useRef(0)
+
+  const pack = packs[packIdx] ?? []
+
   const [revealed, setRevealed] = useState(0)
   const [flippingOut, setFlippingOut] = useState<Set<number>>(new Set())
   const [tapCounts, setTapCounts] = useState<Record<number, number>>({})
   const tapCountsRef = useRef<Record<number, number>>({})
   const decayTimers = useRef<Record<number, ReturnType<typeof setTimeout>>>({})
   const [wobbleKeys, setWobbleKeys] = useState<Record<number, number>>({})
-  const [done, setDone] = useState(false)
+  const [allDone, setAllDone] = useState(false)
   const [spotlightCard, setSpotlightCard] = useState<number | null>(null)
   const [spotlightExiting, setSpotlightExiting] = useState(false)
 
@@ -30,6 +37,21 @@ export function PackOpening({ pack, onDone }: Props) {
   const { openDetail, cardDetailNode } = useCardDetail()
 
   const cards = pack.map(name => catalog.find(c => c.name === name) ?? null)
+
+  function advanceToNextPack() {
+    const nextIdx = packIdxRef.current + 1
+    packIdxRef.current = nextIdx
+    setPackIdx(nextIdx)
+    setRevealed(0)
+    setFlippingOut(new Set())
+    setTapCounts({})
+    tapCountsRef.current = {}
+    Object.values(decayTimers.current).forEach(clearTimeout)
+    decayTimers.current = {}
+    setWobbleKeys({})
+    setSpotlightCard(null)
+    setSpotlightExiting(false)
+  }
 
   function revealCard(i: number) {
     setFlippingOut(prev => new Set([...prev, i]))
@@ -51,10 +73,16 @@ export function PackOpening({ pack, onDone }: Props) {
   }, [revealed])
 
   // Auto-advance for common/uncommon; pause for rare/legendary until tapped
+  // When all cards in the current pack are revealed, advance to next pack or finish
   useEffect(() => {
-    if (revealed >= pack.length) {
+    if (revealed >= pack.length && pack.length > 0) {
       addCardsToCollection(pack.map(name => ({ cardName: name, count: 1 })))
-      setDone(true)
+      if (packIdxRef.current < packs.length - 1) {
+        const t = setTimeout(advanceToNextPack, 1000)
+        return () => clearTimeout(t)
+      } else {
+        setAllDone(true)
+      }
       return
     }
     const card = cards[revealed]
@@ -78,7 +106,7 @@ export function PackOpening({ pack, onDone }: Props) {
       if (cur <= 0) return
       const next = cur - 1
       setCount(i, next)
-      if (next > 0) scheduleDecay(i) // cascade: keep decaying until 0
+      if (next > 0) scheduleDecay(i)
     }, 500)
   }
 
@@ -93,7 +121,6 @@ export function PackOpening({ pack, onDone }: Props) {
     const newCount = current + 1
     setCount(i, newCount)
     if (newCount >= tapsNeeded) {
-      // Exit the spotlight with animation, then reveal
       setSpotlightExiting(true)
       setTimeout(() => {
         setSpotlightCard(null)
@@ -132,7 +159,6 @@ export function PackOpening({ pack, onDone }: Props) {
       >
         <div className="pack-card-flip">
           <div className="pack-card-back">
-            {/* remount on each tap to retrigger wobble animation */}
             <div
               key={`w-${wobbleKeys[i] ?? 0}`}
               className={`pack-card-hidden${(wobbleKeys[i] ?? 0) > 0 ? ' pack-wobble' : ''}`}
@@ -153,7 +179,7 @@ export function PackOpening({ pack, onDone }: Props) {
           <div className="pack-card-front">
             {card ? (
               <div className="pack-card-reveal">
-                <CardTile card={card} canAfford={true} onClick={done ? () => openDetail(card) : undefined} />
+                <CardTile card={card} canAfford={true} onClick={allDone ? () => openDetail(card) : undefined} />
                 <div className={`pack-card-rarity pack-card-rarity--${card.rarity}`}>
                   {rarityStars(card.rarity)}
                 </div>
@@ -170,24 +196,32 @@ export function PackOpening({ pack, onDone }: Props) {
 
   const waitingForTap = revealed < pack.length && (TAP_REQUIRED[cards[revealed]?.rarity ?? 'common'] ?? 0) > 0
 
+  const isMultiPack = packs.length > 1
+
   return (
     <div className="pack-screen">
       <div className="pack-title">✦ PACK OPENED ✦</div>
-      <div className="pack-subtitle">You earned a reward for winning!</div>
+      {isMultiPack ? (
+        <div className="pack-subtitle">Pack {packIdx + 1} of {packs.length}</div>
+      ) : (
+        <div className="pack-subtitle">You earned a reward for winning!</div>
+      )}
 
-      <div className="pack-rows">
+      <div className="pack-rows" key={packIdx}>
         <div className="pack-cards">{row1.map((card, i) => renderCard(card, i))}</div>
         {row2.length > 0 && (
           <div className="pack-cards">{row2.map((card, i) => renderCard(card, i + 3))}</div>
         )}
       </div>
 
-      {done ? (
+      {allDone ? (
         <button className="action-btn action-btn--large" onClick={onDone}>
           CONTINUE →
         </button>
       ) : (
-        <div className="pack-wait">{waitingForTap ? 'Tap the card to reveal it!' : 'Revealing…'}</div>
+        <div className="pack-wait">
+          {waitingForTap ? 'Tap the card to reveal it!' : 'Revealing…'}
+        </div>
       )}
 
       {cardDetailNode}

--- a/web/src/components/ShopScreen.stories.tsx
+++ b/web/src/components/ShopScreen.stories.tsx
@@ -15,7 +15,7 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     crystals: 250,
-    onBuyCrystalPack: fn(),
+    onBuyCrystalPack: fn<(qty: number) => void>(),
     onBack: fn(),
     onCrystalsChange: fn(),
   },

--- a/web/src/components/ShopScreen.tsx
+++ b/web/src/components/ShopScreen.tsx
@@ -74,13 +74,16 @@ function formatShiftTimeNatural(seconds: number): string {
 
 interface Props {
   crystals: number
-  onBuyCrystalPack: () => void
+  onBuyCrystalPack: (qty: number) => void
   onCrystalsChange: (newAmount: number) => void
   onBack: () => void
 }
 
+const PACK_QUANTITIES = [1, 3, 5, 10]
+
 export function ShopScreen({ crystals, onBuyCrystalPack, onCrystalsChange, onBack }: Props) {
-  const canBuyPack = crystals >= CRYSTAL_PACK_COST
+  const [packQty, setPackQty] = useState(1)
+  const canBuyPack = crystals >= CRYSTAL_PACK_COST * packQty
 
   const [npc, setNpc] = useState(() => getDailyShopNPC())
   const [dailyCards, setDailyCards] = useState(() => getDailyShopCards())
@@ -153,7 +156,7 @@ export function ShopScreen({ crystals, onBuyCrystalPack, onCrystalsChange, onBac
 
   function handleBuyPackClick() {
     if (canBuyPack) {
-      onBuyCrystalPack()
+      onBuyCrystalPack(packQty)
     } else {
       incrementAchievementProgress('misc:shop_broke_click')
     }
@@ -283,12 +286,25 @@ export function ShopScreen({ crystals, onBuyCrystalPack, onCrystalsChange, onBac
           <div className="shop-item-desc">
             5 cards · 2 Common · 1 Uncommon · 1 Rare · 1 Bonus
           </div>
+          <div className="shop-pack-qty-row">
+            {PACK_QUANTITIES.map(q => (
+              <button
+                key={q}
+                className={`filter-btn${packQty === q ? ' filter-btn--active' : ''}`}
+                onClick={() => setPackQty(q)}
+              >
+                ×{q}
+              </button>
+            ))}
+          </div>
           <button
             className="action-btn action-btn--gold"
             onClick={handleBuyPackClick}
             disabled={false}
           >
-            {canBuyPack ? `Buy — ${CRYSTAL_PACK_COST} 💎` : `Need ${CRYSTAL_PACK_COST - crystals} more 💎`}
+            {canBuyPack
+              ? `Buy ${packQty > 1 ? `${packQty}× ` : ''}— ${CRYSTAL_PACK_COST * packQty} 💎`
+              : `Need ${CRYSTAL_PACK_COST * packQty - crystals} more 💎`}
           </button>
         </div>
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1731,6 +1731,13 @@ body {
   opacity: 0.55;
 }
 
+.shop-pack-qty-row {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
 /* Shop consumables */
 .shop-consumables {
   display: flex;


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **ShopScreen**: Adds a ×1 / ×3 / ×5 / ×10 quantity selector below the Card Pack item. The buy button deducts the full batch cost and label updates to show total (e.g. "Buy 5× — 500 💎").
- **App.tsx**: `pack: string[]` → `packs: string[][]`; `handleBuyCrystalPack(qty)` generates `qty` packs in a single call.
- **PackOpening**: Now accepts `packs: string[][]`. Opens each pack in sequence with a 1-second auto-advance between them, shows "Pack X of N" counter for multi-pack runs, and only shows the "CONTINUE →" button after the final pack is fully revealed. Cards are added to the collection as each pack completes.

## Test plan

- [ ] Buy a single pack from the shop — existing flow unchanged, "Pack 1 of 1" not shown (subtitle stays "You earned a reward for winning!")
- [ ] Select ×3, buy — see "Pack 1 of 3" → auto-advances → "Pack 2 of 3" → "Pack 3 of 3" → CONTINUE button
- [ ] Rare/legendary cards still require taps within multi-pack flow
- [ ] Crystal balance deducted correctly for the full batch quantity
- [ ] Winning a battle still opens a single pack normally

https://claude.ai/code/session_019FHnDurTUaU2dGMtL2WtMd
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_019FHnDurTUaU2dGMtL2WtMd)_