### PR TITLE
fix(city-builder): upgrades grant mastery XP instead of separate ATK/HP bonuses

### DIFF
--- a/web/src/components/CardDetailModal.tsx
+++ b/web/src/components/CardDetailModal.tsx
@@ -12,7 +12,6 @@ import { CardTile } from './CardTile'
 import { ModalBackdrop } from './ModalBackdrop'
 import { MasteryBar } from './MasteryBar'
 import { StatRow } from './StatRow'
-import { loadCityState, getCardLevel, LEVEL_ATK_BONUS, LEVEL_MAX_HP_BONUS } from '../game/cityBuilder'
 
 interface Props {
   card: Card
@@ -69,10 +68,6 @@ export function CardDetailModal({ card, collection, deckEntries, onClose, extras
       : Math.round(u.maxHp * (1 + 0.1 * masteryLvl)) - u.maxHp
     : 0
 
-  const cityLevel   = getCardLevel(loadCityState(), card.name)
-  const cityAtkBonus  = cityLevel * LEVEL_ATK_BONUS
-  const cityHpBonus   = cityLevel * LEVEL_MAX_HP_BONUS
-
   // Build trait tags
   const traits: string[] = []
   if (u) {
@@ -106,12 +101,6 @@ export function CardDetailModal({ card, collection, deckEntries, onClose, extras
           <div className="cdm-card-col">
             <CardTile card={card} canAfford={true} />
             <div className="cdm-owned">×{owned} owned{inDeck > 0 ? ` · ×${inDeck} in deck` : ''}</div>
-            {cityLevel > 0 && (
-              <div className="cdm-city-level">
-                {'★'.repeat(cityLevel)} LVL {cityLevel}
-                {' '}(+{cityAtkBonus} ATK / +{cityHpBonus} HP)
-              </div>
-            )}
           </div>
 
           {/* Right: stats */}

--- a/web/src/components/minigames/CityBuilder.tsx
+++ b/web/src/components/minigames/CityBuilder.tsx
@@ -5,7 +5,10 @@
 
 import React, { useState, useEffect, useCallback, useRef } from 'react'
 import { getCardCatalog } from '../../game/cards'
-import { loadCollection, getOwnedCount } from '../../game/collection'
+import {
+  loadCollection, saveCollection, getOwnedCount,
+  getMasteryXp, masteryLevel, masteryXpForLevel, masteryProgress,
+} from '../../game/collection'
 import {
   CITY_COLS, CITY_ROWS, CITY_CELLS, CELL_PX,
   CityCell, CityState, ResourceType, ResourceStock,
@@ -17,10 +20,11 @@ import {
   canAffordPlacement,
   resourceProductionRate, resourceConsumptionRate,
   getCardLevel, levelUpCost, levelUpCard,
-  LEVEL_UP_COSTS, MAX_CARD_LEVEL, LEVEL_ATK_BONUS, LEVEL_MAX_HP_BONUS,
+  LEVEL_UP_COSTS,
   getBuildingProduces,
   INCOME_SPAWN, INCOME_UTILITY, INCOME_WALL,
 } from '../../game/cityBuilder'
+import { MasteryBar } from '../MasteryBar'
 import { SpriteImg, AnimatedSpriteImg } from '../SpriteImg'
 import { Card } from '../../game/types'
 
@@ -182,7 +186,24 @@ export function CityBuilder({ onBack }: Props) {
     const next = levelUpCard(city, cardName)
     if (!next) { showToast('Not enough gold!'); return }
     save(next)
-    showToast(`${cardName} levelled up to ★${next.cardLevels[cardName]}!`)
+
+    // Grant enough mastery XP to advance the card by exactly one mastery level.
+    const col = loadCollection()
+    const currentXp = getMasteryXp(col, cardName)
+    const currentLvl = masteryLevel(currentXp)
+    const xpToGrant = masteryXpForLevel(currentLvl + 1) - currentXp
+    const updatedCol = col.map(e =>
+      e.cardName === cardName
+        ? { ...e, masteryXp: (e.masteryXp ?? 0) + xpToGrant }
+        : e
+    )
+    // If the card has no collection entry yet, add one.
+    if (!updatedCol.find(e => e.cardName === cardName)) {
+      updatedCol.push({ cardName, count: 0, masteryXp: xpToGrant })
+    }
+    saveCollection(updatedCol)
+
+    showToast(`${cardName} levelled up! Mastery ★${currentLvl + 1}`)
   }
 
   // ── Derived data ──────────────────────────────────────────────────────────────
@@ -308,7 +329,9 @@ export function CityBuilder({ onBack }: Props) {
           {levellable.map(card => {
             const level     = getCardLevel(city, card.name)
             const cost      = levelUpCost(level)
-            const canAfford = cost !== null && city.gold >= cost
+            const canAfford = city.gold >= cost
+            const xp        = getMasteryXp(loadCollection(), card.name)
+            const mLvl      = masteryLevel(xp)
             return (
               <button
                 key={card.name}
@@ -317,18 +340,10 @@ export function CityBuilder({ onBack }: Props) {
               >
                 <SpriteImg name={card.name} className="city-level-card-sprite" />
                 <div className="city-level-card-name">{card.name}</div>
-                <div className="city-level-card-stars">
-                  {Array.from({ length: MAX_CARD_LEVEL }, (_, i) => (
-                    <span key={i} className={`city-star-sm${i < level ? ' city-star-sm--filled' : ''}`}>★</span>
-                  ))}
+                <div className="city-level-card-stars">★{mLvl} mastery</div>
+                <div className={`city-level-card-cost${canAfford ? ' city-level-card-cost--ready' : ''}`}>
+                  ⚙ {cost.toLocaleString()}
                 </div>
-                {level < MAX_CARD_LEVEL ? (
-                  <div className={`city-level-card-cost${canAfford ? ' city-level-card-cost--ready' : ''}`}>
-                    ⚙ {cost}
-                  </div>
-                ) : (
-                  <div className="city-level-card-maxed">MAX</div>
-                )}
               </button>
             )
           })}
@@ -340,9 +355,11 @@ export function CityBuilder({ onBack }: Props) {
   // ── Level-up detail sub-screen ────────────────────────────────────────────────
 
   if (screen === 'levelup' && levelCard !== null) {
-    const card  = catalog.find(c => c.name === levelCard)
-    const level = getCardLevel(city, levelCard)
-    const cost  = levelUpCost(level)
+    const card     = catalog.find(c => c.name === levelCard)
+    const level    = getCardLevel(city, levelCard)
+    const cost     = levelUpCost(level)
+    const xp       = getMasteryXp(loadCollection(), levelCard)
+    const { level: mLvl } = masteryProgress(xp)
     return (
       <div className="city-screen">
         <div className="city-picker-header">
@@ -352,40 +369,33 @@ export function CityBuilder({ onBack }: Props) {
         <div className="city-level-detail">
           {card && <SpriteImg name={card.name} className="city-level-sprite" />}
           <div className="city-level-name">{levelCard}</div>
-          <div className="city-level-stars">
-            {Array.from({ length: MAX_CARD_LEVEL }, (_, i) => (
-              <span key={i} className={`city-star${i < level ? ' city-star--filled' : ''}`}>★</span>
-            ))}
-          </div>
           <div className="city-level-stats">
-            <div>+{level * LEVEL_ATK_BONUS} ATK bonus</div>
-            <div>+{level * LEVEL_MAX_HP_BONUS} max HP bonus</div>
+            <div style={{ marginBottom: 4 }}>Mastery</div>
+            <MasteryBar xp={xp} />
           </div>
-          {level < MAX_CARD_LEVEL ? (
-            <>
-              <div className="city-level-cost">
-                Next level costs <span className="city-gold">⚙ {cost}</span>
+          <div className="city-level-cost">
+            Next upgrade costs <span className="city-gold">⚙ {cost.toLocaleString()}</span>
+            {' '}and grants mastery ★{mLvl + 1}
+          </div>
+          <div className="city-level-costs-table">
+            {LEVEL_UP_COSTS.map((c, i) => (
+              <div key={i} className={`city-cost-row${i < level ? ' city-cost-row--done' : ''}`}>
+                <span>Upgrade {i + 1}</span>
+                <span>⚙ {c.toLocaleString()}</span>
               </div>
-              <div className="city-level-costs-table">
-                {LEVEL_UP_COSTS.map((c, i) => (
-                  <div key={i} className={`city-cost-row${i < level ? ' city-cost-row--done' : ''}`}>
-                    <span>★{i + 1}</span>
-                    <span>⚙ {c}</span>
-                    <span>+{(i + 1) * LEVEL_ATK_BONUS} ATK / +{(i + 1) * LEVEL_MAX_HP_BONUS} HP</span>
-                  </div>
-                ))}
-              </div>
-              <button
-                className={`action-btn${city.gold >= (cost ?? 0) ? ' action-btn--gold' : ''}`}
-                onClick={() => handleLevelUp(levelCard)}
-                disabled={city.gold < (cost ?? 0)}
-              >
-                {city.gold >= (cost ?? 0) ? `LEVEL UP (⚙ ${cost})` : `NEED ⚙ ${cost}`}
-              </button>
-            </>
-          ) : (
-            <div className="city-level-maxed">MAX LEVEL REACHED!</div>
-          )}
+            ))}
+            <div className={`city-cost-row${level >= LEVEL_UP_COSTS.length ? ' city-cost-row--done' : ''}`}>
+              <span>Upgrade {LEVEL_UP_COSTS.length + 1}+</span>
+              <span>⚙ {LEVEL_UP_COSTS[LEVEL_UP_COSTS.length - 1].toLocaleString()}</span>
+            </div>
+          </div>
+          <button
+            className={`action-btn${city.gold >= cost ? ' action-btn--gold' : ''}`}
+            onClick={() => handleLevelUp(levelCard)}
+            disabled={city.gold < cost}
+          >
+            {city.gold >= cost ? `LEVEL UP (⚙ ${cost.toLocaleString()})` : `NEED ⚙ ${cost.toLocaleString()}`}
+          </button>
         </div>
       </div>
     )

--- a/web/src/game/cityBuilder.ts
+++ b/web/src/game/cityBuilder.ts
@@ -30,12 +30,8 @@ const HAPPINESS_REGEN = 15
 /** Happiness drain per minute away from target when conditions not met. */
 const HAPPINESS_DRAIN = 10
 
-/** Level-up costs: index = target level (1-based). */
-export const LEVEL_UP_COSTS = [50000, 100000, 250000, 500000, 100000]
-export const MAX_CARD_LEVEL  = LEVEL_UP_COSTS.length
-
-export const LEVEL_ATK_BONUS    = 1
-export const LEVEL_MAX_HP_BONUS = 2
+/** Level-up costs: index = target level (1-based). Beyond the table, the last entry repeats. */
+export const LEVEL_UP_COSTS = [50000, 100000, 250000, 500000, 1000000]
 
 // ── Resource constants ────────────────────────────────────────────────────────
 
@@ -377,36 +373,18 @@ export function getCardLevel(state: CityState, cardName: string): number {
   return state.cardLevels[cardName] ?? 0
 }
 
-export function levelUpCost(currentLevel: number): number | null {
-  if (currentLevel >= MAX_CARD_LEVEL) return null
-  return LEVEL_UP_COSTS[currentLevel]
+export function levelUpCost(currentLevel: number): number {
+  return LEVEL_UP_COSTS[Math.min(currentLevel, LEVEL_UP_COSTS.length - 1)]
 }
 
 export function levelUpCard(state: CityState, cardName: string): CityState | null {
   const current = getCardLevel(state, cardName)
   const cost    = levelUpCost(current)
-  if (cost === null || state.gold < cost) return null
+  if (state.gold < cost) return null
   return {
     ...state,
     gold:       state.gold - cost,
     cardLevels: { ...state.cardLevels, [cardName]: current + 1 },
-  }
-}
-
-// ── Battle stat bonus helpers ─────────────────────────────────────────────────
-
-export function getCardBonuses(cardName: string): { atk: number; maxHp: number } {
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY)
-    if (!raw) return { atk: 0, maxHp: 0 }
-    const state = JSON.parse(raw) as Partial<CityState>
-    const level = (state.cardLevels ?? {})[cardName] ?? 0
-    return {
-      atk:   level * LEVEL_ATK_BONUS,
-      maxHp: level * LEVEL_MAX_HP_BONUS,
-    }
-  } catch {
-    return { atk: 0, maxHp: 0 }
   }
 }
 

--- a/web/src/game/engine/cards.ts
+++ b/web/src/game/engine/cards.ts
@@ -3,7 +3,6 @@ import { GameState, UpgradeEffect, Unit, BuffTag, LANE_WIDTH } from '../types';
 import { spawnUnit } from './helpers';
 import { drawCard } from './helpers';
 import {  Card, UnitTemplate } from '../types';
-import { getCardBonuses } from '../cityBuilder';
 
 // ─── Deploy a card onto the field ────────────────────────
 export function deployCard(s: GameState, card: Card, owner: 'player' | 'opponent', log: string[]): void {
@@ -62,11 +61,6 @@ export function deployCard(s: GameState, card: Card, owner: 'player' | 'opponent
       }
     }
     const unit = spawnUnit(card.unit, owner);
-    if (owner === 'player') {
-      const bonus = getCardBonuses(card.name);
-      if (bonus.atk   > 0) unit.attack = unit.attack + bonus.atk;
-      if (bonus.maxHp > 0) { unit.maxHp += bonus.maxHp; unit.hp += bonus.maxHp; }
-    }
     if (owner === 'player' && s.onCardPlayedEffects?.length) {
       for (const e of s.onCardPlayedEffects) {
         if (e.attackBonus) unit.attack = Math.max(0, unit.attack + e.attackBonus)


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Fixes #892. City builder upgrades were applying a separate flat ATK/HP bonus system (`getCardBonuses`) that was unrelated to the mastery system, causing inconsistent stats when inspecting upgraded buildings.

- Each city upgrade now grants exactly enough mastery XP to advance the card by one mastery level, routing all battle bonuses through the existing mastery system
- The separate `getCardBonuses` / `LEVEL_ATK_BONUS` / `LEVEL_MAX_HP_BONUS` system is removed entirely
- The 5-upgrade cap (`MAX_CARD_LEVEL`) is lifted — upgrades continue indefinitely at the highest gold tier (1,000,000)
- The upgrade UI now shows the card's mastery bar and level instead of the old ATK/HP bonus table
- `CardDetailModal` no longer shows a separate city-level line (mastery is already displayed via `MasteryBar`)

## Test plan

- [ ] Open City Builder → Upgrades, upgrade a card — toast should say "Mastery ★N"
- [ ] Verify the upgrade detail screen shows the mastery bar and correct next-level cost
- [ ] Upgrade a card beyond 5 times — should not be blocked
- [ ] Open the card in Collection/DeckBuilder — mastery bar should reflect the upgrade
- [ ] Deploy an upgraded structure in battle — stats should match mastery bonuses (not old flat bonuses)
- [ ] Card detail modal no longer shows a separate "★ LVL N (+ATK/+HP)" line

https://claude.ai/code/session_01F99TKBFLYZtNmqosjhqH4T
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01F99TKBFLYZtNmqosjhqH4T)_