### PR TITLE
fix(city-builder): base upgrade cost on current mastery level

### DIFF
--- a/web/src/components/minigames/CityBuilder.tsx
+++ b/web/src/components/minigames/CityBuilder.tsx
@@ -183,14 +183,15 @@ export function CityBuilder({ onBack }: Props) {
   // ── Level up ──────────────────────────────────────────────────────────────────
 
   function handleLevelUp(cardName: string) {
-    const next = levelUpCard(city, cardName)
+    const col = loadCollection()
+    const currentXp = getMasteryXp(col, cardName)
+    const currentLvl = masteryLevel(currentXp)
+
+    const next = levelUpCard(city, cardName, currentLvl)
     if (!next) { showToast('Not enough gold!'); return }
     save(next)
 
     // Grant enough mastery XP to advance the card by exactly one mastery level.
-    const col = loadCollection()
-    const currentXp = getMasteryXp(col, cardName)
-    const currentLvl = masteryLevel(currentXp)
     const xpToGrant = masteryXpForLevel(currentLvl + 1) - currentXp
     const updatedCol = col.map(e =>
       e.cardName === cardName
@@ -327,11 +328,11 @@ export function CityBuilder({ onBack }: Props) {
         </div>
         <div className="city-level-grid">
           {levellable.map(card => {
-            const level     = getCardLevel(city, card.name)
-            const cost      = levelUpCost(level)
-            const canAfford = city.gold >= cost
             const xp        = getMasteryXp(loadCollection(), card.name)
             const mLvl      = masteryLevel(xp)
+            const cost      = levelUpCost(mLvl)
+            const canAfford = city.gold >= cost
+            const level     = getCardLevel(city, card.name)
             return (
               <button
                 key={card.name}
@@ -357,9 +358,9 @@ export function CityBuilder({ onBack }: Props) {
   if (screen === 'levelup' && levelCard !== null) {
     const card     = catalog.find(c => c.name === levelCard)
     const level    = getCardLevel(city, levelCard)
-    const cost     = levelUpCost(level)
     const xp       = getMasteryXp(loadCollection(), levelCard)
     const { level: mLvl } = masteryProgress(xp)
+    const cost     = levelUpCost(mLvl)
     return (
       <div className="city-screen">
         <div className="city-picker-header">

--- a/web/src/game/cityBuilder.ts
+++ b/web/src/game/cityBuilder.ts
@@ -377,9 +377,9 @@ export function levelUpCost(currentLevel: number): number {
   return LEVEL_UP_COSTS[Math.min(currentLevel, LEVEL_UP_COSTS.length - 1)]
 }
 
-export function levelUpCard(state: CityState, cardName: string): CityState | null {
+export function levelUpCard(state: CityState, cardName: string, masteryLvl: number): CityState | null {
   const current = getCardLevel(state, cardName)
-  const cost    = levelUpCost(current)
+  const cost    = levelUpCost(masteryLvl)
   if (state.gold < cost) return null
   return {
     ...state,


### PR DESCRIPTION
Follow-up to #939.

The upgrade cost now reflects the card's mastery level rather than how many times the city builder upgrade button has been pressed. A card at mastery 0 costs 50,000 gold, mastery 1 costs 100,000, and so on — consistent with the `LEVEL_UP_COSTS` table.

## Test plan

- [ ] Upgrade a card at mastery 0 — cost should be 50,000
- [ ] Upgrade it again (now mastery 1) — cost should be 100,000
- [ ] Verify the cost shown in the upgrade grid and detail screen match
- [ ] If a card already has mastery from card grinding, the displayed cost should reflect that level

https://claude.ai/code/session_01F99TKBFLYZtNmqosjhqH4T

---
_Generated by [Claude Code](https://claude.ai/code/session_01F99TKBFLYZtNmqosjhqH4T)_