### PR TITLE
feat(fruit-machine): TRAIL and LOSER word mechanics (#898, #899)

### DIFF
--- a/web/src/components/minigames/FruitMachine.tsx
+++ b/web/src/components/minigames/FruitMachine.tsx
@@ -43,6 +43,8 @@ const TICKETS_PER_CREDIT = 2
 const SPIN_DURATION_MS = 1200
 const FEATURE_THRESHOLD = 5    // feature triggers needed for bonus
 const FEATURE_BONUS_CREDITS = 15  // credits awarded when feature fires
+const LOSER_THRESHOLD = 5    // 'Lose' hits needed to light full LOSER word
+const LOSER_JUMP_POS = 35    // board position jumped to on full LOSER word
 
 const JACKPOT_TIERS = [
   { name: 'Mini', credits: 10, progressive: false, base: 10 },
@@ -195,6 +197,7 @@ export function FruitMachine({ onDone }: Props) {
   const [cashOutTickets, setCashOutTickets] = useState(0)
   const [availCrystals, setAvailCrystals] = useState(() => loadCrystals())
   const [featureTriggerCount, setFeatureTriggerCount] = useState(0)
+  const [loserCount, setLoserCount] = useState(0)
   const [grandJackpot, setGrandJackpot] = useState<number>(() => {
     try { return parseInt(localStorage.getItem('fm_grand') ?? '500', 10) } catch { return 500 }
   })
@@ -217,6 +220,7 @@ export function FruitMachine({ onDone }: Props) {
   const ladderSpinRef = useRef(false)
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const featureCountRef = useRef(0)  // mirrors featureTriggerCount for use inside setTimeout
+  const loserCountRef = useRef(0)   // mirrors loserCount for use inside setTimeout
   const grandJackpotRef = useRef(grandJackpot)
   const boardPosRef = useRef(boardPos)
   const boardMultRef = useRef(boardMult)
@@ -520,7 +524,20 @@ function regressBoardBy(steps: number) {
       const featureStep = featureBonus > 0 ? 1 : 0
       const ladderProgress = (nextLadder === '+1' ? 1 : nextLadder === '+2' ? 2 : nextLadder === '-1' ? -1 : nextLadder === '-2' ? -2 : 0) + featureStep
       if (nextLadder === 'Lose') {
-        resetBoardToZero()
+        const newLoserCount = loserCountRef.current + 1
+        if (newLoserCount >= LOSER_THRESHOLD) {
+          loserCountRef.current = 0
+          setLoserCount(0)
+          boardPosRef.current = LOSER_JUMP_POS
+          setBoardPos(LOSER_JUMP_POS)
+          try { localStorage.setItem('fm_board_pos', String(LOSER_JUMP_POS)) } catch (e) { logError('fm_board_pos loser jump', { error: String(e) }) }
+          setBoardMessage('L-O-S-E-R complete! Jump to position 35!')
+          setPhase('idle')
+        } else {
+          loserCountRef.current = newLoserCount
+          setLoserCount(newLoserCount)
+          resetBoardToZero()
+        }
       } else if (ladderProgress < 0) {
         regressBoardBy(ladderProgress)
       } else {
@@ -684,10 +701,18 @@ function regressBoardBy(steps: number) {
 
       <div className="fm-header">
         <span className="fm-credits">Credits: {credits}</span>
-        <span className="fm-feature-counter" title="Land 🌟 symbols to fill the feature meter">
-          Feature: {featureCountRef.current}/{FEATURE_THRESHOLD} 🌟
-        </span>
-
+        <div className="fm-word-meters">
+          <div className="fm-word-meter" title="Land 🌟 symbols to spell TRAIL and advance the board">
+            {['T','R','A','I','L'].map((letter, i) => (
+              <span key={letter} className={`fm-word-letter${i < featureTriggerCount ? ' fm-word-letter--lit' : ''}`}>{letter}</span>
+            ))}
+          </div>
+          <div className="fm-word-meter" title="Each trail Lose lights a letter — spell LOSER to jump to position 35">
+            {['L','O','S','E','R'].map((letter, i) => (
+              <span key={letter+i} className={`fm-word-letter fm-word-letter--loser${i < loserCount ? ' fm-word-letter--lit' : ''}`}>{letter}</span>
+            ))}
+          </div>
+        </div>
       </div>
 
       {/* Feature board trail */}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -10271,6 +10271,36 @@ html.light-mode .action-btn {
   opacity: 0.85;
 }
 
+.fm-word-meters {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.fm-word-meter {
+  display: flex;
+  gap: 3px;
+}
+
+.fm-word-letter {
+  font-size: 1.1rem;
+  font-weight: bold;
+  color: #444;
+  text-shadow: none;
+  transition: color 0.2s, text-shadow 0.2s;
+  letter-spacing: 1px;
+}
+
+.fm-word-letter--lit {
+  color: #ffd700;
+  text-shadow: 0 0 6px #ffd700, 0 0 12px #ffaa00;
+}
+
+.fm-word-letter--loser.fm-word-letter--lit {
+  color: #ff4444;
+  text-shadow: 0 0 6px #ff4444, 0 0 12px #cc0000;
+}
+
 .fm-win-flash {
   font-size: 1rem;
   font-weight: bold;


### PR DESCRIPTION
## Summary

- **#898 TRAIL:** Replaces the `Feature: n/5 🌟` counter with 5 lit/dim letters `T R A I L`. Each 🌟 symbol lights the next letter (gold glow). When all 5 are lit the trail board advances by 1 step and the letters reset to dim. (Underlying logic was already correct — this is a UI swap.)
- **#899 LOSER:** Adds a `L O S E R` letter display alongside TRAIL. Each trail `Lose` result lights the next letter (red glow). When all 5 are lit the player jumps to board position 35 (MAJOR 🏆) and the letters reset. Individual `Lose` results still reset the board to 0 as before.
- CSS: `.fm-word-meters` flex layout, `.fm-word-letter` dim state, `.fm-word-letter--lit` gold glow, `.fm-word-letter--loser.fm-word-letter--lit` red glow.

## Test plan

- [ ] Start a fruit machine session and verify `T R A I L` letters appear instead of the old feature counter
- [ ] Land 🌟 symbols and confirm letters light up gold left-to-right; on the 5th the trail board advances and all letters return to dim
- [ ] Trigger `Lose` on the trail reel; confirm `L O S E R` letters light up red one at a time and board resets to 0 each time
- [ ] On the 5th `Lose`, confirm the board jumps to position 35 and LOSER letters all return to dim

https://claude.ai/code/session_01RCehBSoe67K5ko2ga8yUBc

---
_Generated by [Claude Code](https://claude.ai/code/session_01RCehBSoe67K5ko2ga8yUBc)_