### PR TITLE
Fix boss traits not executing in correct phase (#945, #921)

### DIFF
--- a/web/src/game/engine.ts
+++ b/web/src/game/engine.ts
@@ -381,7 +381,14 @@ function checkGameOver(s: GameState): boolean {
       if (s.bossTraitState) {
         s.bossTraitState.firedThresholds = []
         s.bossTraitState.traitFired = false
-        s.bossTraitState.lastTraitFireMs = s.gameTime
+        const bDef = s.bossAI ? getBossAIDef(s.bossAI) : undefined
+        if (bDef?.trait?.trigger === 'periodic') {
+          // Allow first periodic ability to fire ~5s after phase 2 starts
+          const interval = bDef.trait.triggerIntervalMs ?? 30000
+          s.bossTraitState.lastTraitFireMs = s.gameTime - interval + 5000
+        } else {
+          s.bossTraitState.lastTraitFireMs = s.gameTime
+        }
       }
       return false
     }

--- a/web/src/game/engine/bossTraits.ts
+++ b/web/src/game/engine/bossTraits.ts
@@ -20,6 +20,12 @@ function chooseTraitLandingPos(target: string | undefined, field: Unit[]): { x: 
   if (target === 'battlefield_centre') {
     return { x: LANE_WIDTH / 2, y: 0 }
   }
+  if (target === 'random') {
+    return {
+      x: OPPONENT_SPAWN_X - 40 - Math.random() * 60,
+      y: LANE_POSITIONS[Math.floor(Math.random() * LANE_POSITIONS.length)],
+    }
+  }
   if (target === 'player_densest_cluster') {
     const players = field.filter(u => u.owner === 'player' && u.hp > 0)
     let bx = LANE_WIDTH / 4, by = 0, best = 0
@@ -109,6 +115,12 @@ function fireInvulnerableLaunch(
   ts.landX = pos.x
   ts.landY = pos.y
   log.push('!!' + trait.announceText)
+
+  // Make the boss unit untargetable during the launch sequence
+  if (s.bossCardActive && s.bossCard) {
+    const bossUnit = s.field.find(u => u.owner === 'opponent' && u.name === s.bossCard && u.hp > 0)
+    if (bossUnit) bossUnit.invisTimer = duration + 500
+  }
 }
 
 // ─── Tick ─────────────────────────────────────────────────
@@ -161,6 +173,18 @@ export function tickBossTrait(s: GameState, log: string[]): void {
       }
     }
 
+    // For burrow-type traits: teleport the boss unit to the landing position
+    if (trait.type === 'burrow' && s.bossCardActive && s.bossCard) {
+      const bossUnit = s.field.find(u => u.owner === 'opponent' && u.name === s.bossCard && u.hp > 0)
+      if (bossUnit) { bossUnit.x = lx; bossUnit.y = ly }
+    }
+
+    // Restore boss unit visibility
+    if (s.bossCardActive && s.bossCard) {
+      const bossUnit = s.field.find(u => u.owner === 'opponent' && u.name === s.bossCard && u.hp > 0)
+      if (bossUnit) bossUnit.invisTimer = 0
+    }
+
     ts.baseInvulnerableUntilMs = 0
     ts.landingAtMs = undefined
     ts.landX = undefined
@@ -170,6 +194,9 @@ export function tickBossTrait(s: GameState, log: string[]): void {
 
   // ── Periodic traits ───────────────────────────────────────
   if (trait.trigger === 'periodic') {
+    // Don't fire before the boss unit enters in a two-phase fight
+    if (s.bossCard && !s.bossCardActive) return
+
     const interval = trait.triggerIntervalMs ?? 30000
     if (s.gameTime >= interval && s.gameTime - ts.lastTraitFireMs >= interval && ts.landingAtMs === undefined) {
       ts.lastTraitFireMs = s.gameTime


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Fixes two related boss trait bugs reported in #945 (Kragg) and #921 (Thornlord) — both caused by the trait engine announcing effects without executing the intended unit behaviour.

- **#945 (Kragg) — messages before boss phase:** Kragg's periodic `Earthshaker` trait was firing every 30s from game start, showing "KRAGG LEAPS" during Phase 1 before the boss unit (Golem) had entered the field. A guard (`bossCard && !bossCardActive`) now prevents periodic traits from firing in Phase 1 of two-phase fights.
- **#945 (Kragg) — no abilities in Phase 2:** The Phase 2 transition reset `lastTraitFireMs` to the current game time, requiring a full 30s wait before the first Earthshaker. If Phase 2 ended sooner, no ability ever fired. The reset now subtracts `interval - 5000ms`, so the first leap fires ~5s into Phase 2.
- **#921 (Thornlord) / common root — boss unit doesn't disappear or reposition:** `fireInvulnerableLaunch` only protected the base; the boss *unit* stayed visible and in place. Now, when `bossCardActive`, the boss unit's `invisTimer` is set for the duration (making it untargetable in all targeting selectors) and cleared on landing. For `burrow`-type traits (Thornlord), the boss unit is also teleported to the landing position on resolution.
- Added `"random"` handler in `chooseTraitLandingPos`, returning a position near the opponent spawn (away from player units) — used by Thornlord's `repositionTarget`.

## Test plan

- [ ] Play Act 2 Kragg boss fight — no "KRAGG LEAPS" messages should appear during Phase 1
- [ ] Phase 2 (Golem): Earthshaker should fire within ~5s of Phase 2 start, then every 30s; Golem goes untargetable briefly, AOE damage lands on player side
- [ ] Play Act 1 Thornlord boss fight — at 50% HP the Thornlord announces burrow, disappears (untargetable), then reappears near its own base with an AOE splash

https://claude.ai/code/session_01QnqtgLLxaH8EXSxo3E5YtJ
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QnqtgLLxaH8EXSxo3E5YtJ)_