### PR TITLE
Increase boss phase 2 HP multiplier from 10x to 25x

### DIFF
--- a/web/src/game/engine.ts
+++ b/web/src/game/engine.ts
@@ -272,7 +272,7 @@ export function newGame(
     bossCard,
     bossName,
     bossCardActive: false,
-    bossHpMultiplier: bossHpMultiplier ?? (bossCard ? 10 : undefined),
+    bossHpMultiplier: bossHpMultiplier ?? (bossCard ? 25 : undefined),
     bossTraitState: boss ? {
       firedThresholds: [],
       lastTraitFireMs: 0,
@@ -348,7 +348,7 @@ function checkGameOver(s: GameState): boolean {
       s.field.forEach(u => { if (u.owner === 'player') u.x = PLAYER_SPAWN_X })
       const template = getCardUnit(s.bossCard)
       if (template) {
-        const mult = s.bossHpMultiplier ?? 10
+        const mult = s.bossHpMultiplier ?? 25
         const boostedTemplate = { ...template, maxHp: Math.round(template.maxHp * mult) }
         const bossUnit = spawnUnit(boostedTemplate, 'opponent')
         s.field.push(bossUnit)


### PR DESCRIPTION
Boss cards have base HP of 60–90. At 10× (600–900 HP) phase 2 was ending too quickly once players have earned strong cards. 25× gives 1,500–2,250 HP, making phase 2 a meaningful endurance fight without touching any card stats.

Both default sites updated (`newGame` initialisation and phase 2 spawn fallback). Any node that explicitly sets `bossHpMultiplier` in its JSON is unaffected.

https://claude.ai/code/session_01QnqtgLLxaH8EXSxo3E5YtJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01QnqtgLLxaH8EXSxo3E5YtJ)_