### PR TITLE
Publish news item when Grand jackpot is won on the fruit machine

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -45,5 +45,13 @@ service cloud.firestore {
       allow write: if request.auth != null && request.auth.uid == uid;
     }
 
+    // ── Jackpot wins (news feed) ─────────────────────────────────────────────
+    // Any authenticated player can record a Grand jackpot win.
+    // Everyone can read (displayed in the news feed).
+    match /jackpotWins/{winId} {
+      allow read: if true;
+      allow write: if request.auth != null;
+    }
+
   }
 }

--- a/web/src/components/minigames/FruitMachine.tsx
+++ b/web/src/components/minigames/FruitMachine.tsx
@@ -22,7 +22,9 @@ import {
   fetchGrandJackpot,
   incrementGrandJackpot,
   claimAndResetGrandJackpot,
+  publishGrandJackpotWin,
 } from '../../game/fruitMachineJackpot'
+import { loadPlayerName } from '../../game/questline'
 
 interface Props {
   onDone: (ticketsEarned: number) => void
@@ -327,6 +329,7 @@ export function FruitMachine({ onDone }: Props) {
           setBoardPos(0)
           try { localStorage.setItem('fm_board_pos', '0') } catch (e) { logError('fm_board_pos grand reset', { error: String(e) }) }
           setPhase('jackpot-win')
+          publishGrandJackpotWin(loadPlayerName(), amount)
         })
         break
       }

--- a/web/src/game/fruitMachineJackpot.ts
+++ b/web/src/game/fruitMachineJackpot.ts
@@ -4,10 +4,12 @@
 // claiming the same pot simultaneously.
 
 import {
-  doc, getDoc, setDoc, runTransaction, increment, Timestamp,
+  doc, getDoc, setDoc, runTransaction, increment, Timestamp, collection, addDoc,
 } from 'firebase/firestore'
 import { db } from '../firebase'
 import { logError } from '../logger'
+
+const JACKPOT_WINS_COLLECTION = 'jackpotWins'
 
 const JACKPOT_DOC = doc(db, 'globalState', 'fruitMachineJackpot')
 const GRAND_BASE = 500
@@ -63,6 +65,19 @@ export async function claimAndResetGrandJackpot(): Promise<number> {
     const local = localJackpot()
     try { localStorage.setItem(LOCAL_KEY, String(GRAND_BASE)) } catch { /* ignore */ }
     return local
+  }
+}
+
+/** Records a Grand jackpot win in Firestore for display in the news feed. */
+export async function publishGrandJackpotWin(playerName: string, amount: number): Promise<void> {
+  try {
+    await addDoc(collection(db, JACKPOT_WINS_COLLECTION), {
+      playerName,
+      amount,
+      wonAt: Timestamp.now(),
+    })
+  } catch (e) {
+    logError('publishGrandJackpotWin', { error: String(e) })
   }
 }
 

--- a/web/src/game/news.ts
+++ b/web/src/game/news.ts
@@ -15,7 +15,7 @@
 //   tag:      string  (optional, e.g. "NEW FEATURE", "BUG FIX", "UPDATE", "EVENT")
 //   imageUrl: string  (optional, URL of an image to display in the post)
 
-import { collection, getDocs, doc, setDoc, deleteDoc } from 'firebase/firestore'
+import { collection, getDocs, doc, setDoc, deleteDoc, Timestamp } from 'firebase/firestore'
 import { db } from '../firebase'
 import { logError } from '../logger'
 import newsData from '../data/news.json'
@@ -82,23 +82,47 @@ async function fetchNewsFromFirestore(): Promise<NewsItem[]> {
   return snap.docs.map(d => ({ id: d.id, ...d.data() } as NewsItem))
 }
 
+async function fetchJackpotWinsAsNews(): Promise<NewsItem[]> {
+  const snap = await getDocs(collection(db, 'jackpotWins'))
+  return snap.docs.map(d => {
+    const data = d.data() as { playerName: string; amount: number; wonAt: Timestamp }
+    const date = data.wonAt ? data.wonAt.toDate() : new Date()
+    const dateStr = date.toISOString().split('T')[0]
+    const timeStr = date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+    return {
+      id: `jackpot-win-${d.id}`,
+      title: '🎰 Grand Jackpot Won!',
+      body: `${data.playerName} won the Grand Jackpot of ${data.amount} credits at ${timeStr} on ${dateStr}!`,
+      date: dateStr,
+      tag: 'EVENT',
+    } satisfies NewsItem
+  })
+}
+
 // ── Registry ─────────────────────────────────────────────────────────────────
 
 /**
  * Fetch all news: Firestore first, local news.json as fallback.
- * Merges both sources; Firestore items take precedence over local ones.
+ * Also merges jackpot win events from the jackpotWins collection.
+ * Firestore items take precedence over local ones.
  */
 export async function getAllNews(): Promise<NewsItem[]> {
   let remote: NewsItem[] = []
+  let jackpotNews: NewsItem[] = []
   try {
     remote = await fetchNewsFromFirestore()
   } catch (e) {
     logError('fetchNewsFromFirestore failed, using local fallback', { error: String(e) })
   }
+  try {
+    jackpotNews = await fetchJackpotWinsAsNews()
+  } catch (e) {
+    logError('fetchJackpotWinsAsNews failed', { error: String(e) })
+  }
 
   const remoteIds = new Set(remote.map(n => n.id))
   const local = (newsData as NewsItem[]).filter(n => !remoteIds.has(n.id))
-  const all = [...remote, ...local]
+  const all = [...remote, ...jackpotNews, ...local]
   return all.sort((a, b) => b.date.localeCompare(a.date))
 }
 


### PR DESCRIPTION
## Summary

- When a player lands on the Grand jackpot board node, their name, the jackpot amount, and the win timestamp are written to a new Firestore `jackpotWins` collection
- `getAllNews()` now fetches jackpot wins alongside regular news and surfaces them as `EVENT`-tagged news items in the What's New screen
- A Firestore security rule is added allowing any authenticated user to write jackpot win records (readable by all)

## How it works

1. **`fruitMachineJackpot.ts`** — new `publishGrandJackpotWin(playerName, amount)` writes a doc `{ playerName, amount, wonAt: Timestamp }` to `jackpotWins/`
2. **`FruitMachine.tsx`** — calls `publishGrandJackpotWin(loadPlayerName(), amount)` immediately after the jackpot claim transaction resolves
3. **`news.ts`** — `fetchJackpotWinsAsNews()` converts each `jackpotWins` doc into a `NewsItem` with the player name, amount, and formatted win time; `getAllNews()` merges these in
4. **`firestore.rules`** — adds `jackpotWins/{winId}` rule: `read: true`, `write: if request.auth != null`

## Test plan

- [ ] Win the Grand jackpot (land on board node 38 "GRAND ⭐")
- [ ] Verify a news item appears in What's New with the correct player name, credit amount, and win time
- [ ] Verify the news item is tagged EVENT
- [ ] Verify Firestore `jackpotWins` collection is populated with the correct document
- [ ] Verify unauthenticated users cannot write to `jackpotWins` but can read it

https://claude.ai/code/session_013TcYTGPjwQFqEN4SypTH1R

---
_Generated by [Claude Code](https://claude.ai/code/session_013TcYTGPjwQFqEN4SypTH1R)_