### PR TITLE
Fix React error #300 in FruitMachine (hooks after early returns)

### DIFF
--- a/web/src/components/minigames/FruitMachine.tsx
+++ b/web/src/components/minigames/FruitMachine.tsx
@@ -222,6 +222,8 @@ export function FruitMachine({ onDone }: Props) {
   const [bonusPicksLeft, setBonusPicksLeft] = useState(0)
   const [bonusTotalWin, setBonusTotalWin] = useState(0)
 
+  const [messages, setMessages] = useState([] as LedScrollerMessage[])
+
   const spinningRef = useRef<[boolean, boolean, boolean]>([false, false, false])
   const ladderSpinRef = useRef(false)
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
@@ -260,6 +262,26 @@ export function FruitMachine({ onDone }: Props) {
       setPhase('done')
     }
   }, [credits, phase])
+
+  function publishMessage(newMessage: string) {
+    setMessages(prev => [...prev, { text: newMessage, id: Date.now().toString() }])
+  }
+
+  function dismissMessage() {
+    setMessages(prev => prev.slice(1))
+  }
+
+  function clearMessages() {
+    setMessages([])
+  }
+
+  useEffect(() => {
+    if (boardMessage) {
+      publishMessage(boardMessage)
+    } else {
+      clearMessages()
+    }
+  }, [boardMessage])
 
   function toggleHold(i: 0 | 1 | 2) {
     if (phase !== 'idle' || recentlyHeld[i]) return
@@ -718,29 +740,6 @@ function regressBoardBy(steps: number) {
   })
 
   // const message = boardMessage ? boardMessage : freeSpin ? 'FREE SPIN ready!' : boardMult > 1 ? `×${boardMult} multiplier active!` : lastWin !== null && totalWin > 0 ? winLabel ?? `+${totalWin} credit${totalWin > 1 ? 's' : ''}!` : lastWin === 0 ? 'No win' : ''
-  const [messages, setMessages] = useState([] as LedScrollerMessage[])
-
-  function publishMessage(newMessage: string) {
-    console.log('Publishing message:', newMessage)
-    setMessages(prev => [...prev, { text: newMessage, id: Date.now().toString() }])
-  }
-
-  function dismissMessage() {
-    setMessages(prev => prev.slice(1))
-  }
-
-  function clearMessages() {
-    setMessages([])
-  }
-
-
-    useEffect(() => {
-    if (boardMessage) {
-      publishMessage(boardMessage)
-    } else {
-      clearMessages()
-    }
-  }, [ boardMessage])
 
 
   return (


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- `useState` for the LED scroller `messages` and a `useEffect` watching `boardMessage` were declared **after** three conditional early returns in `FruitMachine.tsx` (the bonus, jackpot-win, and done screens)
- When a user pressed **Cash Out** (or triggered any of those phases), React hit a different hook call count than on the previous render — this is the "Minified React error #300" invariant violation ("rendered fewer hooks than expected")
- Moved `messages` useState, the three helper functions (`publishMessage`, `dismissMessage`, `clearMessages`), and the `useEffect` to before any conditional returns, alongside all other hooks

## Test plan

- [ ] Open Fruit Machine and spin a few times
- [ ] Press **Cash Out** — should show the done screen without crashing
- [ ] Trigger bonus game, jackpot win, and run out of credits — all phase transitions should work without error
- [ ] Verify LED scroller messages still appear during normal play

https://claude.ai/code/session_014mzFjPMovwjBSURvMbC6gj
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_014mzFjPMovwjBSURvMbC6gj)_