### PR TITLE
Fix fruit machine: count wilds and feature symbols after nudge

### DIFF
--- a/web/src/components/minigames/FruitMachine.tsx
+++ b/web/src/components/minigames/FruitMachine.tsx
@@ -438,13 +438,46 @@ function regressBoardBy(steps: number) {
     setReels(nudgedReels)
     setDisplay(nudgedReels)
     const { credits: win, winType } = calcPayout(nudgedReels)
-    if (win > 0) {
-      setLastWin(win)
-      setCredits(c => Math.max(0, c + win))
-      if (winType === 'wild') setBoardMessage(`🃏 WILD! +${win} credits!`)
-      else if (winType === 'bonus') setBoardMessage(`💰 BONUS! +${win} credits! `)
-      else setBoardMessage(`+${win} credits!`)
+    const featureHits = nudgedReels.filter(x => x === FEATURE).length
+
+    let featureBonus = 0
+    const newFeatureCount = featureCountRef.current + featureHits
+    if (featureHits > 0 && newFeatureCount >= FEATURE_THRESHOLD) {
+      featureBonus = FEATURE_BONUS_CREDITS
+      featureCountRef.current = newFeatureCount % FEATURE_THRESHOLD
+    } else {
+      featureCountRef.current = newFeatureCount
     }
+    setFeatureTriggerCount(featureCountRef.current)
+    try { localStorage.setItem('fm_trail', String(featureCountRef.current)) } catch (e) { logError('fm_trail save', { error: String(e) }) }
+
+    const mult = boardMultRef.current
+    const totalWin = (win + featureBonus) * mult
+    if (mult > 1) {
+      boardMultRef.current = 1
+      setBoardMult(1)
+      try { localStorage.setItem('fm_board_mult', '1') } catch (e) { logError('fm_board_mult reset', { error: String(e) }) }
+    }
+
+    if (totalWin > 0) {
+      setLastWin(totalWin)
+      setCredits(c => Math.max(0, c + totalWin))
+    }
+
+    if (featureBonus > 0) {
+      setBoardMessage(`🌟 FEATURE!${mult > 1 ? ` ×${mult}` : ''} +${totalWin} credits!`)
+    } else if (winType === 'wild') {
+      if (totalWin > 0) setBoardMessage(`🃏 WILD!${mult > 1 ? ` ×${mult}` : ''} +${totalWin} credits!`)
+      else setBoardMessage('🃏 WILD!')
+    } else if (winType === 'bonus') {
+      if (totalWin > 0) setBoardMessage(`💰 BONUS! +${totalWin} credits!`)
+      else setBoardMessage('💰 BONUS!')
+    } else if (mult > 1 && totalWin > 0) {
+      setBoardMessage(`×${mult} MULTIPLIER! +${totalWin} credits!`)
+    } else if (totalWin > 0) {
+      setBoardMessage(`+${totalWin} credits!`)
+    }
+
     setNudgesAvailable(0)
     setPhase('idle')
   }


### PR DESCRIPTION
Fixes #896.

## Summary

- `finishNudge()` now counts 🌟 Feature symbols and updates `featureTriggerCount` (persisted to `localStorage`), exactly as the spin timeout does
- The active board multiplier is applied to the nudge payout and then reset, so a ×2/×3 square is consumed correctly on a nudge win
- The 🃏 WILD! banner now appears even when the wild doesn't form a paying combination (matching spin behaviour)

## Test plan

- [ ] Nudge a reel onto 🌟 — TRAIL meter advances and `fm_trail` in localStorage updates
- [ ] Nudge so three 🌟s appear — feature bonus credits (+15) awarded and TRAIL resets
- [ ] With a ×2 multiplier active, nudge to a winning line — payout is doubled and multiplier resets
- [ ] Nudge onto a 🃏 that doesn't complete a paying line — "🃏 WILD!" banner still appears

https://claude.ai/code/session_01LAmgw7X1kToY5Xt6rvdK3o

---
_Generated by [Claude Code](https://claude.ai/code/session_01LAmgw7X1kToY5Xt6rvdK3o)_