### PR TITLE
feat(city-builder): building mastery multiplies output (#956)

### DIFF
--- a/web/src/components/minigames/CityBuilder.tsx
+++ b/web/src/components/minigames/CityBuilder.tsx
@@ -22,6 +22,7 @@ import {
   levelUpCost, levelUpCard, LEVEL_UP_COSTS,
   getBuildingProduces,
   INCOME_SPAWN, INCOME_UTILITY, INCOME_WALL,
+  spawnerUnitCount, masteryOutputMultiplier,
 } from '../../game/cityBuilder'
 import { MasteryBar } from '../MasteryBar'
 import { SpriteImg, AnimatedSpriteImg } from '../SpriteImg'
@@ -35,8 +36,9 @@ const UNIT_SIZE = 20
 const SPEED     = 0.8 // px per 100 ms tick
 
 interface Walker {
-  cellIndex: number
-  unitName:  string
+  cellIndex:  number
+  unitIndex:  number
+  unitName:   string
   affinityWith?: string
   x:   number
   y:   number
@@ -45,10 +47,11 @@ interface Walker {
   turnTimer: number
 }
 
-function makeWalker(cellIndex: number, unitName: string, affinityWith?: string): Walker {
+function makeWalker(cellIndex: number, unitIndex: number, unitName: string, affinityWith?: string): Walker {
   const angle = Math.random() * Math.PI * 2
   return {
     cellIndex,
+    unitIndex,
     unitName,
     affinityWith,
     x: Math.random() * (OVERLAY_W - UNIT_SIZE),
@@ -93,13 +96,16 @@ export function CityBuilder({ onBack }: Props) {
       for (let i = 0; i < city.grid.length; i++) {
         const cell = city.grid[i]
         if (!cell?.spawnedUnitName) continue
-        const existing = prev.find(w => w.cellIndex === i && w.unitName === cell.spawnedUnitName)
-        next.push(existing ?? makeWalker(i, cell.spawnedUnitName, cell.affinityWith))
+        const count = spawnerUnitCount(city, cell.cardName)
+        for (let u = 0; u < count; u++) {
+          const existing = prev.find(w => w.cellIndex === i && w.unitIndex === u && w.unitName === cell.spawnedUnitName)
+          next.push(existing ?? makeWalker(i, u, cell.spawnedUnitName, cell.affinityWith))
+        }
       }
       return next
     })
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [city.grid])
+  }, [city.grid, city.cardLevels])
 
   // ── Animation loop ────────────────────────────────────────────────────────────
 
@@ -263,6 +269,7 @@ export function CityBuilder({ onBack }: Props) {
               const affordable  = !isSpawner || canAffordPlacement(city, card.rarity)
               const cost        = isSpawner ? SPAWNER_PLACE_COST[card.rarity] : null
               const produces    = !isSpawner ? getBuildingProduces(card.name) : null
+              const masteryMult = !isSpawner ? masteryOutputMultiplier(city.cardLevels[card.name] ?? 0) : 1
               const producesEntries = produces ? Object.entries(produces).filter(([, v]) => (v ?? 0) > 0) : []
               const isWall      = !isSpawner && producesEntries.length === 0
               const incomeRate  = isSpawner
@@ -294,7 +301,7 @@ export function CityBuilder({ onBack }: Props) {
                   {producesEntries.length > 0 && (
                     <div className="city-picker-produces">
                       {producesEntries.map(([r, amt]) =>
-                        `+${amt} ${RESOURCE_ICONS[r as ResourceType]}/min`
+                        `+${Math.round((amt as number) * masteryMult)} ${RESOURCE_ICONS[r as ResourceType]}/min`
                       ).join(' ')}
                     </div>
                   )}
@@ -500,7 +507,7 @@ export function CityBuilder({ onBack }: Props) {
             const wantsFriend  = w.affinityWith && !presentUnitNames.has(w.affinityWith)
             return (
               <div
-                key={w.cellIndex}
+                key={`${w.cellIndex}-${w.unitIndex}`}
                 className={`city-walker${happiness === 0 ? ' city-walker--unhappy' : ''}`}
                 style={{ left: Math.round(w.x), top: Math.round(w.y) }}
               >

--- a/web/src/game/cityBuilder.ts
+++ b/web/src/game/cityBuilder.ts
@@ -188,6 +188,18 @@ export function saveCityState(state: CityState): void {
   }
 }
 
+// ── Mastery helpers ───────────────────────────────────────────────────────────
+
+/** Resource output multiplier for a building at the given mastery level: 2^level. */
+export function masteryOutputMultiplier(level: number): number {
+  return Math.pow(2, level)
+}
+
+/** How many units a spawner should field: mastery 0 → 1, mastery N → N+1. */
+export function spawnerUnitCount(state: CityState, cardName: string): number {
+  return (state.cardLevels[cardName] ?? 0) + 1
+}
+
 // ── Structure classification ──────────────────────────────────────────────────
 
 export function getStructureKind(cell: CityCell): StructureKind {
@@ -269,15 +281,17 @@ export function tickCity(state: CityState): CityState {
 
     // Resource production (utility/non-spawner buildings that produce resources)
     if (!cell.spawnedUnitName) {
+      const masteryMult = masteryOutputMultiplier(state.cardLevels[cell.cardName] ?? 0)
       const produces = getBuildingProduces(cell.cardName)
       for (const [res, rate] of Object.entries(produces) as [ResourceType, number][]) {
-        if (rate > 0) newResources[res] = (newResources[res] ?? 0) + rate * minutes
+        if (rate > 0) newResources[res] = (newResources[res] ?? 0) + rate * masteryMult * minutes
       }
     }
 
-    // Spawners consume food (wheat)
+    // Spawners consume food (wheat) — more units at higher mastery means more consumption
     if (cell.spawnedUnitName && happy) {
-      const consume = FOOD_CONSUME_RATE[cell.rarity] * minutes
+      const unitCount = spawnerUnitCount(state, cell.cardName)
+      const consume = FOOD_CONSUME_RATE[cell.rarity] * unitCount * minutes
       newResources.wheat = Math.max(0, (newResources.wheat ?? 0) - consume)
     }
   }
@@ -394,9 +408,10 @@ export function resourceProductionRate(state: CityState): Partial<ResourceStock>
   const rates: Partial<ResourceStock> = {}
   for (const cell of state.grid) {
     if (!cell || cell.spawnedUnitName) continue
+    const masteryMult = masteryOutputMultiplier(state.cardLevels[cell.cardName] ?? 0)
     const produces = getBuildingProduces(cell.cardName)
     for (const [res, rate] of Object.entries(produces) as [ResourceType, number][]) {
-      rates[res] = (rates[res] ?? 0) + rate
+      rates[res] = (rates[res] ?? 0) + rate * masteryMult
     }
   }
   return rates
@@ -409,7 +424,8 @@ export function resourceConsumptionRate(state: CityState): Partial<ResourceStock
     if (!cell?.spawnedUnitName) continue
     const happy = (state.happiness[i] ?? 100) > 0
     if (!happy) continue
-    rates.wheat = (rates.wheat ?? 0) + FOOD_CONSUME_RATE[cell.rarity]
+    const unitCount = spawnerUnitCount(state, cell.cardName)
+    rates.wheat = (rates.wheat ?? 0) + FOOD_CONSUME_RATE[cell.rarity] * unitCount
   }
   return rates
 }


### PR DESCRIPTION
## Summary

- Farm/utility buildings produce `baseRate × 2^mastery` resources per tick — mastery 1 doubles output, mastery 2 quadruples, etc.
- Spawner buildings field `mastery + 1` walking units (mastery 0 → 1 unit, mastery 1 → 2 units, mastery N → N+1 units)
- Food (wheat) consumption scales with unit count, so higher-mastery spawners consume more food
- Picker UI shows mastery-adjusted production rates so players see the real rate before placing

## Files changed

- `web/src/game/cityBuilder.ts` — added `masteryOutputMultiplier()` and `spawnerUnitCount()` helpers; applied both in `tickCity`, `resourceProductionRate`, and `resourceConsumptionRate`
- `web/src/components/minigames/CityBuilder.tsx` — walker sync creates `mastery+1` walkers per spawner; added `unitIndex` to `Walker` to keep multiple walkers from the same cell distinct; picker shows adjusted rates

## Test plan

- [ ] Place a Farm at mastery 0 — verify base wheat rate in stats bar
- [ ] Level up the Farm to mastery 1 — verify wheat rate doubles
- [ ] Level up to mastery 2 — verify wheat rate is ×4 base
- [ ] Place a spawner at mastery 0 — verify 1 walker appears
- [ ] Level up spawner to mastery 1 — verify 2 walkers appear from that cell
- [ ] Verify food consumption in stats bar increases with spawner mastery

Closes #956

https://claude.ai/code/session_019ePZocJmJ1Ju9jhwZHUYDH

---
_Generated by [Claude Code](https://claude.ai/code/session_019ePZocJmJ1Ju9jhwZHUYDH)_