### PR TITLE
feat(city-builder): gold income scales with population (#957)

### DIFF
--- a/web/src/components/minigames/CityBuilder.tsx
+++ b/web/src/components/minigames/CityBuilder.tsx
@@ -435,7 +435,7 @@ export function CityBuilder({ onBack }: Props) {
         <div className="city-stat city-stat--defense" title="City Defence">
           🛡 {defense}
         </div>
-        <div className="city-stat city-stat--population" title="Population (active units)">
+        <div className="city-stat city-stat--population" title="Population — each unit earns gold for its spawner">
           👥 {population}
         </div>
         {(['wheat', 'wood', 'ore', 'bread', 'planks', 'metal'] as ResourceType[]).map(res => {

--- a/web/src/game/cityBuilder.ts
+++ b/web/src/game/cityBuilder.ts
@@ -207,13 +207,12 @@ export function getStructureKind(cell: CityCell): StructureKind {
   return 'utility'
 }
 
-function cellIncomeRate(cell: CityCell, happy: boolean): number {
+function cellIncomeRate(cell: CityCell, happy: boolean, unitCount: number): number {
   const kind = getStructureKind(cell)
-  const base = kind === 'spawn'
-    ? INCOME_SPAWN[cell.rarity]
-    : INCOME_UTILITY[cell.rarity]
-  if (kind === 'spawn' && !happy) return base * 0.5
-  return base
+  if (kind === 'spawn') {
+    return happy ? INCOME_SPAWN[cell.rarity] * unitCount : 0
+  }
+  return INCOME_UTILITY[cell.rarity]
 }
 
 /** Defence value a wall contributes (full if city has any spawners, half otherwise). */
@@ -275,9 +274,10 @@ export function tickCity(state: CityState): CityState {
     if (!cell) continue
 
     const happy = (newHappy[i] ?? 100) > 0
+    const unitCount = cell.spawnedUnitName ? spawnerUnitCount(state, cell.cardName) : 1
 
     // Gold income
-    goldEarned += cellIncomeRate(cell, happy) * minutes
+    goldEarned += cellIncomeRate(cell, happy, unitCount) * minutes
 
     // Resource production (utility/non-spawner buildings that produce resources)
     if (!cell.spawnedUnitName) {
@@ -372,7 +372,8 @@ export function goldIncomeRate(state: CityState): number {
     const cell = state.grid[i]
     if (!cell) continue
     const happy = (state.happiness[i] ?? 100) > 0
-    total += cellIncomeRate(cell, happy)
+    const unitCount = cell.spawnedUnitName ? spawnerUnitCount(state, cell.cardName) : 1
+    total += cellIncomeRate(cell, happy, unitCount)
   }
   return total
 }


### PR DESCRIPTION
## Summary

- Spawner buildings now earn `INCOME_SPAWN[rarity] × unitCount` gold/min, so a mastery-1 spawner fielding 2 units earns twice the gold of a mastery-0 spawner
- Unhappy spawners earn **0** gold — if a unit's requirements aren't met and it's left, that building stops contributing income
- Non-spawner buildings (utility, wall) keep their flat passive income unchanged
- Population tooltip updated to clarify it drives gold income

## Test plan

- [ ] Place a spawner at mastery 0 — note gold/min in header
- [ ] Level spawner to mastery 1 (2 units) — gold/min should double for that building
- [ ] Trigger unhappy state (drain wheat) — spawner gold drops to 0
- [ ] Restore wheat — gold recovers as units return (happiness regen)
- [ ] Utility/wall buildings unaffected by population changes

Closes #957

https://claude.ai/code/session_019ePZocJmJ1Ju9jhwZHUYDH

---
_Generated by [Claude Code](https://claude.ai/code/session_019ePZocJmJ1Ju9jhwZHUYDH)_