### PR TITLE
feat(city-builder): happiness system — unhappy units despawn (#958)

### DIFF
--- a/web/src/components/minigames/CityBuilder.tsx
+++ b/web/src/components/minigames/CityBuilder.tsx
@@ -96,6 +96,8 @@ export function CityBuilder({ onBack }: Props) {
       for (let i = 0; i < city.grid.length; i++) {
         const cell = city.grid[i]
         if (!cell?.spawnedUnitName) continue
+        // Skip despawned units (happiness reached 0)
+        if ((city.happiness[i] ?? 100) === 0) continue
         const count = spawnerUnitCount(city, cell.cardName)
         for (let u = 0; u < count; u++) {
           const existing = prev.find(w => w.cellIndex === i && w.unitIndex === u && w.unitName === cell.spawnedUnitName)
@@ -242,9 +244,11 @@ export function CityBuilder({ onBack }: Props) {
   const prodRates = resourceProductionRate(city)
   const consRates = resourceConsumptionRate(city)
 
-  // Which unit names are currently present in the city as walkers
+  // Unit names that are alive (happiness > 0) — despawned units don't count for affinity
   const presentUnitNames = new Set(
-    city.grid.filter(Boolean).map(c => c!.spawnedUnitName).filter(Boolean) as string[]
+    city.grid
+      .filter((c, i) => c?.spawnedUnitName && (city.happiness[i] ?? 100) > 0)
+      .map(c => c!.spawnedUnitName!) as string[]
   )
 
   // ── Card picker sub-screen ────────────────────────────────────────────────────
@@ -466,7 +470,8 @@ export function CityBuilder({ onBack }: Props) {
           {Array.from({ length: CITY_CELLS }, (_, i) => {
             const cell      = city.grid[i]
             const happiness = cell?.spawnedUnitName ? (city.happiness[i] ?? 100) : 100
-            const unhappy   = happiness === 0
+            const rage      = 100 - happiness
+            const despawned = cell?.spawnedUnitName && happiness === 0
             return (
               <button
                 key={i}
@@ -481,16 +486,17 @@ export function CityBuilder({ onBack }: Props) {
                     {masteryLevel(getMasteryXp(collection, cell.cardName)) > 0 && (
                       <div className="city-cell-level">★{masteryLevel(getMasteryXp(collection, cell.cardName))}</div>
                     )}
-                    {cell.spawnedUnitName && (
+                    {cell.spawnedUnitName && rage > 0 && (
                       <div
                         className="city-cell-happiness"
                         style={{
-                          width: `${happiness}%`,
-                          background: happiness > 60 ? '#40a040' : happiness > 30 ? '#a0a020' : '#a03020',
+                          width: `${rage}%`,
+                          background: rage < 40 ? '#a0a020' : rage < 70 ? '#c05010' : '#a03020',
                         }}
                       />
                     )}
-                    {unhappy && <span className="city-cell-unhappy-icon">⚠</span>}
+                    {despawned && <span className="city-cell-unhappy-icon">💀</span>}
+                    {!despawned && rage >= 60 && <span className="city-cell-unhappy-icon">⚠</span>}
                   </>
                 ) : (
                   <span className="city-cell-empty">+</span>
@@ -503,12 +509,13 @@ export function CityBuilder({ onBack }: Props) {
         {/* Walking units overlay */}
         <div className="city-unit-overlay" aria-hidden="true">
           {walkers.map(w => {
-            const happiness    = city.happiness[w.cellIndex] ?? 100
-            const wantsFriend  = w.affinityWith && !presentUnitNames.has(w.affinityWith)
+            const happiness   = city.happiness[w.cellIndex] ?? 100
+            const rage        = 100 - happiness
+            const wantsFriend = w.affinityWith && !presentUnitNames.has(w.affinityWith)
             return (
               <div
                 key={`${w.cellIndex}-${w.unitIndex}`}
-                className={`city-walker${happiness === 0 ? ' city-walker--unhappy' : ''}`}
+                className={`city-walker${rage >= 60 ? ' city-walker--unhappy' : ''}`}
                 style={{ left: Math.round(w.x), top: Math.round(w.y) }}
               >
                 {wantsFriend && (
@@ -522,7 +529,7 @@ export function CityBuilder({ onBack }: Props) {
                   fps={6}
                   className="city-walker-sprite"
                 />
-                {happiness < 30 && <span className="city-walker-need">!</span>}
+                {rage >= 40 && <span className="city-walker-need">!</span>}
               </div>
             )
           })}

--- a/web/src/game/cityBuilder.ts
+++ b/web/src/game/cityBuilder.ts
@@ -27,8 +27,8 @@ export const INCOME_WALL: Record<CardRarity, number> = { common: 0, uncommon: 1,
 
 /** Happiness regeneration per minute toward the target value. */
 const HAPPINESS_REGEN = 15
-/** Happiness drain per minute away from target when conditions not met. */
-const HAPPINESS_DRAIN = 10
+/** Happiness drain per minute away from target when conditions not met (~50 min to fully despawn). */
+const HAPPINESS_DRAIN = 2
 
 /** Level-up costs: index = target level (1-based). Beyond the table, the last entry repeats. */
 export const LEVEL_UP_COSTS = [50000, 100000, 250000, 500000, 1000000]
@@ -296,19 +296,31 @@ export function tickCity(state: CityState): CityState {
     }
   }
 
-  // Update happiness toward target based on food and defence
+  // Base happiness target from food and defence (applies to all spawners)
   const foodScore    = Math.min(100, (newResources.wheat / population) * 5)
   const defenseScore = Math.min(100, (defense / population) * 8)
-  const happyTarget  = Math.round(foodScore * 0.6 + defenseScore * 0.4)
+  const baseTarget   = Math.round(foodScore * 0.6 + defenseScore * 0.4)
+
+  // Unit names that are currently alive (happiness > 0) — used for affinity checks
+  const aliveUnitNames = new Set(
+    state.grid
+      .map((c, i) => c?.spawnedUnitName && (newHappy[i] ?? 100) > 0 ? c.spawnedUnitName : null)
+      .filter(Boolean) as string[]
+  )
 
   for (let i = 0; i < state.grid.length; i++) {
     const cell = state.grid[i]
     if (!cell?.spawnedUnitName) continue
+
+    // Affinity is a hard requirement: missing friend → target forced to 0
+    const affinityMet = !cell.affinityWith || aliveUnitNames.has(cell.affinityWith)
+    const cellTarget  = affinityMet ? baseTarget : 0
+
     const current = newHappy[i] ?? 100
-    if (current < happyTarget) {
-      newHappy[i] = Math.min(happyTarget, current + HAPPINESS_REGEN * minutes)
-    } else if (current > happyTarget) {
-      newHappy[i] = Math.max(happyTarget, current - HAPPINESS_DRAIN * minutes)
+    if (current < cellTarget) {
+      newHappy[i] = Math.min(cellTarget, current + HAPPINESS_REGEN * minutes)
+    } else if (current > cellTarget) {
+      newHappy[i] = Math.max(0, current - HAPPINESS_DRAIN * minutes)
     }
   }
 


### PR DESCRIPTION
## Summary

- Unhappy units now actually **despawn** (walker disappears, building earns 0 gold) when happiness drains to 0
- Drain rate slowed to ~50 minutes for a full despawn, matching the "roughly every hour" feel from the issue
- **Affinity is a hard requirement** — if a unit's desired friend is missing from the city (or has itself despawned), its happiness target is forced to 0 and it will eventually leave
- Despawned units don't count as "present" for other units' affinity checks, so a chain reaction is possible
- When requirements are met again (food restored, friend returns), happiness regenerates and the unit respawns
- The whole city can empty out if requirements go unmet long enough

## UI changes

- Happiness bar replaced with **bar of rage**: invisible when content, fills yellow → orange → red as the unit gets angrier
- Despawned spawner cell shows 💀
- Units with rage ≥ 60% show ⚠ on their cell and the walker shows `!`

## Test plan

- [ ] Place a spawner + drain wheat — watch rage bar fill over time, unit eventually despawns
- [ ] Restore wheat — unit respawns as happiness recovers
- [ ] Place two units where one has `affinityWith` the other; remove the friend — verify rage fills and unit despawns even with full food
- [ ] Verify a despawned unit's spawner still shows in the grid (building remains, just empty)
- [ ] Let all units despawn — verify city population = 0 and gold income = 0

Closes #958

https://claude.ai/code/session_019ePZocJmJ1Ju9jhwZHUYDH

---
_Generated by [Claude Code](https://claude.ai/code/session_019ePZocJmJ1Ju9jhwZHUYDH)_