### PR TITLE
feat(city-builder): tap unit to show happiness requirements (#959)

### DIFF
--- a/web/src/components/minigames/CityBuilder.tsx
+++ b/web/src/components/minigames/CityBuilder.tsx
@@ -28,6 +28,43 @@ import { MasteryBar } from '../MasteryBar'
 import { SpriteImg, AnimatedSpriteImg } from '../SpriteImg'
 import { Card } from '../../game/types'
 
+// ── Unit requirement helpers ──────────────────────────────────────────────────
+
+function rageDescription(happiness: number): string {
+  if (happiness === 0)   return 'Left the city'
+  if (happiness < 30)    return 'Furious — leaving soon!'
+  if (happiness < 60)    return 'Unsettled'
+  if (happiness < 90)    return 'A little uneasy'
+  return 'Content'
+}
+
+function getUnitRequirements(
+  cell: CityCell,
+  cityState: CityState,
+  presentNames: Set<string>,
+): { text: string; met: boolean }[] {
+  const reqs: { text: string; met: boolean }[] = []
+
+  if (cell.affinityWith) {
+    reqs.push({
+      text: `Wants a ${cell.affinityWith} in the city`,
+      met: presentNames.has(cell.affinityWith),
+    })
+  }
+
+  const pop = Math.max(cityPopulation(cityState), 1)
+  const foodScore = Math.min(100, (cityState.resources.wheat / pop) * 5)
+  reqs.push({ text: 'Needs adequate food supply', met: foodScore >= 50 })
+
+  const defense = cityDefense(cityState)
+  const defenseScore = Math.min(100, (defense / pop) * 8)
+  if (defense > 0 || defenseScore < 30) {
+    reqs.push({ text: 'Needs city defenses', met: defenseScore >= 50 })
+  }
+
+  return reqs
+}
+
 // ── Walking unit state ────────────────────────────────────────────────────────
 
 const OVERLAY_W = CITY_COLS * CELL_PX
@@ -77,6 +114,7 @@ export function CityBuilder({ onBack }: Props) {
   const [levelCard, setLevelCard]     = useState<string | null>(null)
   const [toast, setToast]     = useState<string | null>(null)
   const [walkers, setWalkers] = useState<Walker[]>([])
+  const [selectedWalkerCell, setSelectedWalkerCell] = useState<number | null>(null)
 
   function showToast(msg: string) {
     setToast(msg)
@@ -416,6 +454,35 @@ export function CityBuilder({ onBack }: Props) {
     <div className="city-screen">
       {toast && <div className="city-toast" role="alert">{toast}</div>}
 
+      {/* Unit requirements modal */}
+      {selectedWalkerCell !== null && (() => {
+        const cell = city.grid[selectedWalkerCell]
+        if (!cell?.spawnedUnitName) return null
+        const happiness = city.happiness[selectedWalkerCell] ?? 100
+        const reqs = getUnitRequirements(cell, city, presentUnitNames)
+        const moodKey = happiness === 0 ? 'gone' : happiness < 30 ? 'furious' : happiness < 60 ? 'unsettled' : 'content'
+        return (
+          <div className="city-req-overlay" onClick={() => setSelectedWalkerCell(null)}>
+            <div className="city-req-modal" onClick={e => e.stopPropagation()}>
+              <div className="city-req-header">
+                <AnimatedSpriteImg name={cell.spawnedUnitName} frameCount={3} fps={6} className="city-req-sprite" />
+                <div className="city-req-name">{cell.spawnedUnitName}</div>
+              </div>
+              <div className={`city-req-mood city-req-mood--${moodKey}`}>{rageDescription(happiness)}</div>
+              <div className="city-req-list">
+                {reqs.map((r, idx) => (
+                  <div key={idx} className={`city-req-item${r.met ? ' city-req-item--met' : ' city-req-item--unmet'}`}>
+                    <span className="city-req-icon">{r.met ? '✓' : '✗'}</span>
+                    {r.text}
+                  </div>
+                ))}
+              </div>
+              <button className="action-btn" onClick={() => setSelectedWalkerCell(null)}>CLOSE</button>
+            </div>
+          </div>
+        )
+      })()}
+
       {/* Header */}
       <div className="city-header">
         <button className="action-btn" onClick={onBack}>← BACK</button>
@@ -507,7 +574,7 @@ export function CityBuilder({ onBack }: Props) {
         </div>
 
         {/* Walking units overlay */}
-        <div className="city-unit-overlay" aria-hidden="true">
+        <div className="city-unit-overlay">
           {walkers.map(w => {
             const happiness   = city.happiness[w.cellIndex] ?? 100
             const rage        = 100 - happiness
@@ -515,8 +582,12 @@ export function CityBuilder({ onBack }: Props) {
             return (
               <div
                 key={`${w.cellIndex}-${w.unitIndex}`}
+                role="button"
+                tabIndex={0}
                 className={`city-walker${rage >= 60 ? ' city-walker--unhappy' : ''}`}
                 style={{ left: Math.round(w.x), top: Math.round(w.y) }}
+                onClick={e => { e.stopPropagation(); setSelectedWalkerCell(w.cellIndex) }}
+                onKeyDown={e => { if (e.key === 'Enter') { e.stopPropagation(); setSelectedWalkerCell(w.cellIndex) } }}
               >
                 {wantsFriend && (
                   <div className="city-speech-bubble" title={`Wants a ${w.affinityWith}!`}>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -8936,6 +8936,7 @@ html.light-mode .action-btn {
 /* ── City Builder Screen ──────────────────────────────────────────────────── */
 
 .city-screen {
+  position: relative;
   display: flex;
   flex-direction: column;
   gap: 10px;
@@ -9388,6 +9389,47 @@ html.light-mode .action-btn {
   text-align: center;
   margin-top: 4px;
 }
+
+/* ── City Builder — unit requirements modal ─────────────────────────────── */
+.city-req-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(0,0,0,0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 200;
+}
+.city-req-modal {
+  background: #1a2a1a;
+  border: 1px solid #3a6a3a;
+  border-radius: 4px;
+  padding: 14px 16px;
+  min-width: 200px;
+  max-width: 260px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+}
+.city-req-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.city-req-sprite  { width: 36px; height: 36px; image-rendering: pixelated; }
+.city-req-name    { font-size: 14px; color: #90e090; letter-spacing: 1px; }
+.city-req-mood              { font-size: 11px; letter-spacing: 1px; padding: 2px 6px; border-radius: 2px; }
+.city-req-mood--content     { color: #60d060; border: 1px solid #3a6a3a; }
+.city-req-mood--unsettled   { color: #d0a030; border: 1px solid #6a5010; }
+.city-req-mood--furious     { color: #e06030; border: 1px solid #6a3010; }
+.city-req-mood--gone        { color: #808080; border: 1px solid #404040; }
+.city-req-list  { width: 100%; display: flex; flex-direction: column; gap: 4px; }
+.city-req-item  { font-size: 10px; color: #a0a0a0; display: flex; align-items: flex-start; gap: 5px; line-height: 1.4; }
+.city-req-item--met   .city-req-icon { color: #60d060; }
+.city-req-item--unmet .city-req-icon { color: #d06060; }
+.city-req-item--met   { color: #60a060; }
+.city-req-item--unmet { color: #c08080; }
 
 /* Title screen button */
 .title-minigames-btn {


### PR DESCRIPTION
## Summary

- Walking units are now tappable — clicking a walker opens a requirements modal instead of deleting the building
- Modal shows the unit's name, current mood, and a checklist of its happiness requirements with ✓/✗ indicators
- Three requirement types: affinity friend present in city, adequate food supply, city defenses
- Mood descriptions: Content → A little uneasy → Unsettled → Furious — leaving soon! → Left the city
- `stopPropagation` prevents the tap from hitting the grid cell underneath (no accidental removals)

## Test plan

- [ ] Tap a walker — modal appears with unit name and requirements
- [ ] Tap the overlay or CLOSE — modal dismisses
- [ ] With full food and a friend present — all requirements show ✓
- [ ] Drain wheat — food requirement shows ✗
- [ ] Remove a unit's affinity friend — affinity requirement shows ✗
- [ ] Tapping a walker does NOT remove the building

Closes #959

https://claude.ai/code/session_019ePZocJmJ1Ju9jhwZHUYDH

---
_Generated by [Claude Code](https://claude.ai/code/session_019ePZocJmJ1Ju9jhwZHUYDH)_