### PR TITLE
feat(city-builder): tap building to view residents and requirements (#960)

### DIFF
--- a/web/src/components/minigames/CityBuilder.tsx
+++ b/web/src/components/minigames/CityBuilder.tsx
@@ -65,6 +65,19 @@ function getUnitRequirements(
   return reqs
 }
 
+// ── Resident name generator ───────────────────────────────────────────────────
+
+const RESIDENT_FIRST_NAMES = [
+  'Bob', 'Grak', 'Mira', 'Thorin', 'Zyx', 'Elda', 'Fang', 'Nix', 'Wren', 'Dusk',
+  'Pip', 'Crux', 'Vale', 'Sorn', 'Brix', 'Holt', 'Vera', 'Kurn', 'Dex', 'Ori',
+  'Sable', 'Flint', 'Rook', 'Ivy', 'Bryn', 'Quill', 'Ash', 'Moss', 'Thorn', 'Lark',
+]
+
+function residentName(unitName: string, cellIndex: number, unitIndex: number): string {
+  const seed = cellIndex * 17 + unitIndex * 31
+  return `${RESIDENT_FIRST_NAMES[seed % RESIDENT_FIRST_NAMES.length]} the ${unitName}`
+}
+
 // ── Walking unit state ────────────────────────────────────────────────────────
 
 const OVERLAY_W = CITY_COLS * CELL_PX
@@ -115,6 +128,7 @@ export function CityBuilder({ onBack }: Props) {
   const [toast, setToast]     = useState<string | null>(null)
   const [walkers, setWalkers] = useState<Walker[]>([])
   const [selectedWalkerCell, setSelectedWalkerCell] = useState<number | null>(null)
+  const [selectedBuildingCell, setSelectedBuildingCell] = useState<number | null>(null)
 
   function showToast(msg: string) {
     setToast(msg)
@@ -189,9 +203,7 @@ export function CityBuilder({ onBack }: Props) {
 
   function handleCellTap(index: number) {
     if (city.grid[index]) {
-      const cell = city.grid[index]!
-      save(removeCard(city, index))
-      showToast(`${cell.cardName} removed.`)
+      setSelectedBuildingCell(index)
     } else {
       setPickerIndex(index)
       setScreen('picker')
@@ -483,6 +495,65 @@ export function CityBuilder({ onBack }: Props) {
         )
       })()}
 
+      {/* Building resident panel */}
+      {selectedBuildingCell !== null && (() => {
+        const cell = city.grid[selectedBuildingCell]
+        if (!cell) return null
+        const happiness  = cell.spawnedUnitName ? (city.happiness[selectedBuildingCell] ?? 100) : 100
+        const unitCount  = cell.spawnedUnitName ? spawnerUnitCount(city, cell.cardName) : 0
+        const moodKey    = happiness === 0 ? 'gone' : happiness < 30 ? 'furious' : happiness < 60 ? 'unsettled' : 'content'
+        const produces   = getBuildingProduces(cell.cardName)
+        const masteryMult = masteryOutputMultiplier(city.cardLevels[cell.cardName] ?? 0)
+        const produceEntries = Object.entries(produces).filter(([, v]) => (v ?? 0) > 0)
+        return (
+          <div className="city-req-overlay" onClick={() => setSelectedBuildingCell(null)}>
+            <div className="city-req-modal" onClick={e => e.stopPropagation()}>
+              <div className="city-req-header">
+                <SpriteImg name={cell.cardName} className="city-req-sprite" />
+                <div className="city-req-name">{cell.cardName}</div>
+              </div>
+              {cell.spawnedUnitName ? (
+                <>
+                  <div className="city-bld-section-title">Residents ({happiness === 0 ? 0 : unitCount})</div>
+                  {happiness === 0 ? (
+                    <div className="city-bld-vacant">Building is vacant — unit left the city</div>
+                  ) : (
+                    Array.from({ length: unitCount }, (_, u) => {
+                      const reqs = getUnitRequirements(cell, city, presentUnitNames)
+                      const unmet = reqs.filter(r => !r.met)
+                      return (
+                        <div key={u} className="city-bld-resident">
+                          <AnimatedSpriteImg name={cell.spawnedUnitName!} frameCount={3} fps={6} className="city-bld-resident-sprite" />
+                          <div className="city-bld-resident-info">
+                            <div className="city-bld-resident-name">{residentName(cell.spawnedUnitName!, selectedBuildingCell, u)}</div>
+                            <div className={`city-req-mood city-req-mood--${moodKey}`}>{rageDescription(happiness)}</div>
+                            {unmet.map((r, i) => (
+                              <div key={i} className="city-bld-resident-req">✗ {r.text}</div>
+                            ))}
+                          </div>
+                        </div>
+                      )
+                    })
+                  )}
+                </>
+              ) : produceEntries.length > 0 ? (
+                <>
+                  <div className="city-bld-section-title">Produces</div>
+                  {produceEntries.map(([res, amt]) => (
+                    <div key={res} className="city-bld-produces-row">
+                      +{Math.round((amt as number) * masteryMult)} {RESOURCE_ICONS[res as ResourceType]}/min
+                    </div>
+                  ))}
+                </>
+              ) : (
+                <div className="city-bld-section-title">Defensive structure</div>
+              )}
+              <button className="action-btn" onClick={() => setSelectedBuildingCell(null)}>CLOSE</button>
+            </div>
+          </div>
+        )
+      })()}
+
       {/* Header */}
       <div className="city-header">
         <button className="action-btn" onClick={onBack}>← BACK</button>
@@ -544,7 +615,7 @@ export function CityBuilder({ onBack }: Props) {
                 key={i}
                 className={`city-cell${cell ? ' city-cell--occupied' : ''}`}
                 onClick={() => handleCellTap(i)}
-                title={cell ? `${cell.cardName} — tap to remove` : 'Empty — tap to place'}
+                title={cell ? `${cell.cardName} — tap to inspect` : 'Empty — tap to place'}
               >
                 {cell ? (
                   <>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -9431,6 +9431,23 @@ html.light-mode .action-btn {
 .city-req-item--met   { color: #60a060; }
 .city-req-item--unmet { color: #c08080; }
 
+/* ── City Builder — building resident panel ─────────────────────────────── */
+.city-bld-section-title { font-size: 10px; color: #609060; letter-spacing: 1px; text-transform: uppercase; align-self: flex-start; }
+.city-bld-vacant        { font-size: 10px; color: #606060; font-style: italic; }
+.city-bld-resident {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  width: 100%;
+  padding: 4px 0;
+  border-top: 1px solid #2a3a2a;
+}
+.city-bld-resident-sprite { width: 24px; height: 24px; image-rendering: pixelated; flex-shrink: 0; }
+.city-bld-resident-info   { display: flex; flex-direction: column; gap: 2px; }
+.city-bld-resident-name   { font-size: 11px; color: #90d090; }
+.city-bld-resident-req    { font-size: 9px; color: #d07070; }
+.city-bld-produces-row    { font-size: 11px; color: #a0d0a0; align-self: flex-start; }
+
 /* Title screen button */
 .title-minigames-btn {
   border-color: #6040a0 !important;


### PR DESCRIPTION
## Summary

- Tapping an occupied building now opens a **resident panel** instead of deleting it
- Spawner buildings list each resident with a randomly generated name (e.g. "Bob the Goblin", "Mira the Skeleton") and their current mood + any unmet requirements
- Vacant spawners (unit has despawned) show a clear "Building is vacant" notice
- Utility/farm buildings show their mastery-adjusted production rate
- Defensive structures are labelled as such
- 30-name first-name pool; names are deterministic per cell+unit index so they're stable across re-renders

## Test plan

- [ ] Tap a spawner building — panel opens showing residents with names and moods
- [ ] With unmet requirements (low food / missing friend) — unmet requirements listed under each resident
- [ ] Let a unit despawn — tap building — shows "vacant" state
- [ ] Tap a farm/utility building — shows production rate
- [ ] Tap a wall — shows "Defensive structure"
- [ ] Tap the overlay or CLOSE — panel dismisses without removing the building

Closes #960

https://claude.ai/code/session_019ePZocJmJ1Ju9jhwZHUYDH

---
_Generated by [Claude Code](https://claude.ai/code/session_019ePZocJmJ1Ju9jhwZHUYDH)_