### PR TITLE
feat(city-builder): bulldozer mode toggle for building deletion (#961)

### DIFF
--- a/web/src/components/minigames/CityBuilder.tsx
+++ b/web/src/components/minigames/CityBuilder.tsx
@@ -129,6 +129,8 @@ export function CityBuilder({ onBack }: Props) {
   const [walkers, setWalkers] = useState<Walker[]>([])
   const [selectedWalkerCell, setSelectedWalkerCell] = useState<number | null>(null)
   const [selectedBuildingCell, setSelectedBuildingCell] = useState<number | null>(null)
+  const [bulldozerMode, setBulldozerMode] = useState(false)
+  const bulldozerRef = useRef(false)
 
   function showToast(msg: string) {
     setToast(msg)
@@ -186,10 +188,14 @@ export function CityBuilder({ onBack }: Props) {
     return () => clearInterval(id)
   }, [])
 
+  // Keep ref in sync so the tick interval can read current bulldozer state
+  useEffect(() => { bulldozerRef.current = bulldozerMode }, [bulldozerMode])
+
   // ── Gold + resource tick (every 10 s while screen is open) ───────────────────
 
   useEffect(() => {
     const id = setInterval(() => {
+      if (bulldozerRef.current) return  // paused while bulldozer is active
       setCity(prev => {
         const next = tickCity(prev)
         saveCityState(next)
@@ -203,11 +209,23 @@ export function CityBuilder({ onBack }: Props) {
 
   function handleCellTap(index: number) {
     if (city.grid[index]) {
-      setSelectedBuildingCell(index)
+      if (bulldozerMode) {
+        const cell = city.grid[index]!
+        save(removeCard(city, index))
+        showToast(`${cell.cardName} demolished.`)
+      } else {
+        setSelectedBuildingCell(index)
+      }
     } else {
       setPickerIndex(index)
       setScreen('picker')
     }
+  }
+
+  function toggleBulldozer() {
+    setBulldozerMode(prev => !prev)
+    setSelectedBuildingCell(null)
+    setSelectedWalkerCell(null)
   }
 
   // ── Place a card ──────────────────────────────────────────────────────────────
@@ -560,6 +578,11 @@ export function CityBuilder({ onBack }: Props) {
         <div className="city-title">🏙 CITY</div>
         <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
           <div className="city-gold-display">⚙ {city.gold.toLocaleString()}</div>
+          <button
+            className={`filter-btn${bulldozerMode ? ' city-bulldozer-btn--active' : ''}`}
+            onClick={toggleBulldozer}
+            title={bulldozerMode ? 'Bulldozer mode ON — tap buildings to demolish' : 'Bulldozer mode OFF — tap to toggle'}
+          >🏗 BULLDOZE</button>
           <button className="filter-btn" onClick={() => setScreen('upgrade')}>★ UPGRADES</button>
         </div>
       </div>
@@ -567,9 +590,12 @@ export function CityBuilder({ onBack }: Props) {
       {/* Income summary */}
       <div className="city-income-row">
         <span className="city-income-in">+{incomeRate} gold</span>
-        <span className={`city-income-net${netRate >= 0 ? ' city-income-net--pos' : ' city-income-net--neg'}`}>
-          {netRate >= 0 ? `+${netRate}` : `${netRate}`}/min
-        </span>
+        {bulldozerMode
+          ? <span className="city-bulldozer-paused">⏸ PAUSED</span>
+          : <span className={`city-income-net${netRate >= 0 ? ' city-income-net--pos' : ' city-income-net--neg'}`}>
+              {netRate >= 0 ? `+${netRate}` : `${netRate}`}/min
+            </span>
+        }
       </div>
 
       {/* City stats */}
@@ -613,9 +639,9 @@ export function CityBuilder({ onBack }: Props) {
             return (
               <button
                 key={i}
-                className={`city-cell${cell ? ' city-cell--occupied' : ''}`}
+                className={`city-cell${cell ? ' city-cell--occupied' : ''}${cell && bulldozerMode ? ' city-cell--bulldoze' : ''}`}
                 onClick={() => handleCellTap(i)}
-                title={cell ? `${cell.cardName} — tap to inspect` : 'Empty — tap to place'}
+                title={cell ? (bulldozerMode ? `${cell.cardName} — tap to demolish` : `${cell.cardName} — tap to inspect`) : 'Empty — tap to place'}
               >
                 {cell ? (
                   <>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -9431,6 +9431,19 @@ html.light-mode .action-btn {
 .city-req-item--met   { color: #60a060; }
 .city-req-item--unmet { color: #c08080; }
 
+/* ── City Builder — bulldozer mode ─────────────────────────────────────── */
+.city-bulldozer-btn--active {
+  border-color: #a03020 !important;
+  color: #e06040 !important;
+  background: rgba(160,48,32,0.15) !important;
+}
+.city-cell--bulldoze {
+  border-color: #a03020 !important;
+  background: rgba(160,48,32,0.2) !important;
+}
+.city-cell--bulldoze:hover { background: rgba(160,48,32,0.4) !important; }
+.city-bulldozer-paused { font-size: 10px; color: #e06040; letter-spacing: 1px; }
+
 /* ── City Builder — building resident panel ─────────────────────────────── */
 .city-bld-section-title { font-size: 10px; color: #609060; letter-spacing: 1px; text-transform: uppercase; align-self: flex-start; }
 .city-bld-vacant        { font-size: 10px; color: #606060; font-style: italic; }


### PR DESCRIPTION
## Summary

- Added a **🏗 BULLDOZE** toggle button to the city header
- **Bulldozer mode ON**: tapping a building demolishes it immediately; city tick pauses (⏸ PAUSED shown in income row); occupied cells get a red tint
- **Bulldozer mode OFF** (default): tapping a building opens the resident panel from #960
- Game tick is paused via a `useRef` so the `setInterval` doesn't need to restart on every toggle
- Opening bulldozer mode auto-closes any open building/walker modals

## Test plan

- [ ] Toggle BULLDOZE button — button turns red, occupied cells get red tint
- [ ] Tap an occupied cell in bulldozer mode — building is removed with "demolished" toast
- [ ] Tap an empty cell in bulldozer mode — picker still opens normally
- [ ] Check income row shows ⏸ PAUSED while bulldozer is active
- [ ] Toggle off — normal inspect behaviour resumes, tint clears
- [ ] Wait 10s in bulldozer mode — confirm city gold/resources don't tick

Closes #961

https://claude.ai/code/session_019ePZocJmJ1Ju9jhwZHUYDH

---
_Generated by [Claude Code](https://claude.ai/code/session_019ePZocJmJ1Ju9jhwZHUYDH)_