### PR TITLE
fix(city-builder): modal clipping, walker taps, bulldozer layout

### DIFF
--- a/web/src/components/minigames/CityBuilder.tsx
+++ b/web/src/components/minigames/CityBuilder.tsx
@@ -578,16 +578,11 @@ export function CityBuilder({ onBack }: Props) {
         <div className="city-title">🏙 CITY</div>
         <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
           <div className="city-gold-display">⚙ {city.gold.toLocaleString()}</div>
-          <button
-            className={`filter-btn${bulldozerMode ? ' city-bulldozer-btn--active' : ''}`}
-            onClick={toggleBulldozer}
-            title={bulldozerMode ? 'Bulldozer mode ON — tap buildings to demolish' : 'Bulldozer mode OFF — tap to toggle'}
-          >🏗 BULLDOZE</button>
           <button className="filter-btn" onClick={() => setScreen('upgrade')}>★ UPGRADES</button>
         </div>
       </div>
 
-      {/* Income summary */}
+      {/* Income summary + bulldozer toggle */}
       <div className="city-income-row">
         <span className="city-income-in">+{incomeRate} gold</span>
         {bulldozerMode
@@ -596,6 +591,11 @@ export function CityBuilder({ onBack }: Props) {
               {netRate >= 0 ? `+${netRate}` : `${netRate}`}/min
             </span>
         }
+        <button
+          className={`filter-btn${bulldozerMode ? ' city-bulldozer-btn--active' : ''}`}
+          onClick={toggleBulldozer}
+          title={bulldozerMode ? 'Bulldozer ON — tap to demolish' : 'Toggle bulldozer to demolish buildings'}
+        >🏗{bulldozerMode ? ' ON' : ''}</button>
       </div>
 
       {/* City stats */}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -9070,6 +9070,8 @@ html.light-mode .action-btn {
   position: absolute;
   width: 20px;
   height: 20px;
+  pointer-events: auto;
+  cursor: pointer;
 }
 
 .city-walker-sprite {
@@ -9392,7 +9394,7 @@ html.light-mode .action-btn {
 
 /* ── City Builder — unit requirements modal ─────────────────────────────── */
 .city-req-overlay {
-  position: absolute;
+  position: fixed;
   inset: 0;
   background: rgba(0,0,0,0.7);
   display: flex;


### PR DESCRIPTION
## Bugs fixed

**1. Building/unit modals were invisible**
`.city-req-overlay` was `position: absolute` inside a `overflow-y: auto` scroll container (`city-screen`). Absolutely positioned elements are clipped by overflow ancestors, so the modal was rendered but hidden. Fixed by changing to `position: fixed`.

**2. Tapping walkers did nothing**
`.city-unit-overlay` correctly has `pointer-events: none` so clicks pass through to the grid. But walker child elements didn't override this, so they also had `pointer-events: none` and couldn't be tapped. Added `pointer-events: auto; cursor: pointer` to `.city-walker`.

**3. Bulldozer button not visible on mobile**
The header already contains BACK + title + gold display + UPGRADES. Adding BULLDOZE to the same row overflowed on narrow screens. Moved the 🏗 toggle to the income row as a compact icon-only button (shows `🏗 ON` when active).

Also includes the full bulldozer mode implementation from #961.

## Test plan
- [ ] Tap any building — resident panel appears
- [ ] Tap a walking unit — requirements modal appears  
- [ ] Close modal by tapping overlay or CLOSE
- [ ] 🏗 button visible in income row; tap to enable bulldozer mode
- [ ] In bulldozer mode, cells turn red; tapping demolishes the building
- [ ] In bulldozer mode, income row shows ⏸ PAUSED

https://claude.ai/code/session_019ePZocJmJ1Ju9jhwZHUYDH

---
_Generated by [Claude Code](https://claude.ai/code/session_019ePZocJmJ1Ju9jhwZHUYDH)_