### PR TITLE
feat(sound): battle & minigame sound effects (#967)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -84,7 +84,7 @@ import { FeedbackModal } from './components/FeedbackModal'
 import { FeedbackAdminScreen } from './components/FeedbackAdminScreen'
 import { getDailyPlayerDeck, getDailyOpponentDeck, getDailyChallengeState, saveDailyChallengeResult, recordDailyWin, publishDailyResult, publishEndlessResult, DailyChallengeState } from './game/dailyChallenge'
 import { getRelicDef, addEarnedRelic, removeEarnedRelic, loadEarnedRelics, addBrokenRelic } from './game/relics'
-import { playCardPlay, playButtonClick, playBattleEvent, playCardFlip, playRestHeal, stopBattleMusic, stopGameOverMusic } from './game/sound'
+import { playCardPlay, playButtonClick, playBattleEvent, playCardFlip, playRestHeal, playBattleStart, playVictory, playDefeat, stopBattleMusic, stopGameOverMusic } from './game/sound'
 import { useMusic } from './hooks/useMusic'
 import { getIntegrityViolations, clearIntegrityViolations } from './game/integrity'
 import { useRareEvents } from './hooks/useRareEvents'
@@ -290,6 +290,7 @@ export default function App() {
   const startBattle = useCallback((gs: GameState) => {
     dispatch({ type: 'START', gameState: gs })
     setScreen('playing')
+    playBattleStart()
   }, [])
 
   /**
@@ -585,6 +586,7 @@ export default function App() {
   // Victory celebration: auto-transition to gameOver after 3 seconds
   useEffect(() => {
     if (gameState?.phase.type !== 'celebration') return
+    playVictory()
     const t = setTimeout(() => {
       const gs = gameStateRef.current
       if (gs?.phase.type === 'celebration') {
@@ -592,6 +594,12 @@ export default function App() {
       }
     }, 3000)
     return () => clearTimeout(t)
+  }, [gameState?.phase.type])
+
+  // Defeat fanfare: play when player loses
+  useEffect(() => {
+    if (gameState?.phase.type !== 'gameOver') return
+    if ((gameState.phase as { type: 'gameOver'; winner: string }).winner !== 'player') playDefeat()
   }, [gameState?.phase.type])
 
   // Trigger SW update check whenever the title screen is shown

--- a/web/src/components/minigames/CrystalCatch.tsx
+++ b/web/src/components/minigames/CrystalCatch.tsx
@@ -3,6 +3,7 @@
 // Crystals = +3 tickets, coins = +1, bombs = -10 (game ends if tickets hit 0).
 
 import React, { useState, useEffect, useRef } from 'react'
+import { playMinigameCorrect, playMinigameWrong } from '../../game/sound'
 
 interface Props {
   onDone: (ticketsEarned: number) => void
@@ -117,6 +118,8 @@ export function CrystalCatch({ onDone }: Props) {
   function catchItem(id: number, kind: ItemKind, x: number, y: number) {
     setItems(prev => prev.filter(i => i.id !== id))
     const delta = VALUE[kind]
+    if (kind === 'bomb') playMinigameWrong()
+    else playMinigameCorrect()
     const newTickets = Math.max(0, ticketsRef.current + delta)
     ticketsRef.current = newTickets
     setTickets(newTickets)

--- a/web/src/components/minigames/HigherOrLower.tsx
+++ b/web/src/components/minigames/HigherOrLower.tsx
@@ -4,6 +4,7 @@
 // Ties always count as a loss.
 
 import React, { useState } from 'react'
+import { playMinigameCorrect, playMinigameWrong } from '../../game/sound'
 
 interface Props {
   onDone: (ticketsEarned: number) => void
@@ -61,11 +62,13 @@ export function HigherOrLower({ onDone }: Props) {
     setRevealed(newRevealed)
 
     if (!correct) {
+      playMinigameWrong()
       setFeedback('wrong')
       setPhase('lost')
       return
     }
 
+    playMinigameCorrect()
     setFeedback('correct')
     setTimeout(() => setFeedback(null), 600)
 

--- a/web/src/components/minigames/TileFlip.tsx
+++ b/web/src/components/minigames/TileFlip.tsx
@@ -3,6 +3,7 @@
 // Earn 5 tickets per match + bonus for zero mistakes or fast completion.
 
 import React, { useState, useEffect, useRef, useCallback } from 'react'
+import { playMinigameCorrect, playMinigameWrong } from '../../game/sound'
 
 interface Props {
   onDone: (ticketsEarned: number, perfect: boolean) => void
@@ -76,6 +77,7 @@ export function TileFlip({ onDone }: Props) {
       const [a, b] = newSelected
       if (tiles[a] === tiles[b]) {
         // Match!
+        playMinigameCorrect()
         setTimeout(() => {
           const newMatched = [...matched]
           newMatched[a] = true
@@ -87,6 +89,7 @@ export function TileFlip({ onDone }: Props) {
         }, 400)
       } else {
         // No match
+        playMinigameWrong()
         setMistakes(m => m + 1)
         setTimeout(() => {
           const resetFlipped = [...newFlipped]

--- a/web/src/game/engine/cards.ts
+++ b/web/src/game/engine/cards.ts
@@ -3,6 +3,7 @@ import { GameState, UpgradeEffect, Unit, BuffTag, LANE_WIDTH } from '../types';
 import { spawnUnit } from './helpers';
 import { drawCard } from './helpers';
 import {  Card, UnitTemplate } from '../types';
+import { playUpgrade } from '../sound';
 
 // ─── Deploy a card onto the field ────────────────────────
 export function deployCard(s: GameState, card: Card, owner: 'player' | 'opponent', log: string[]): void {
@@ -57,6 +58,7 @@ export function deployCard(s: GameState, card: Card, owner: 'player' | 'opponent
         }
         const who = owner === 'player' ? 'You' : 'Opponent';
         log.push(`${who} upgraded ${existing.name}! (${note})`);
+        if (owner === 'player') playUpgrade();
         return;
       }
     }

--- a/web/src/game/engine/combat.ts
+++ b/web/src/game/engine/combat.ts
@@ -1,5 +1,5 @@
 import { isNoDamageMode } from '../debug'
-import { playBuildingDestroyed, playUnitDeath } from '../sound'
+import { playBuildingDestroyed, playUnitDeath, playUnitAttack, playBaseHit } from '../sound'
 import { AnimEvent, GameState, LANE_WIDTH, Unit } from '../types'
 import { DAMAGE_FLASH_MS, BLOOD_POOL_MAX } from './constants'
 import { getAttackAura } from './bonusEffects'
@@ -46,6 +46,7 @@ export function processAttacks(s: GameState, deltaMs: number, log: string[]): vo
     const atkAura   = isPlayer ? playerAtkAura : opponentAtkAura
 
     if (target) {
+      if (unit.owner === 'player') playUnitAttack()
       const prevHp         = target.hp
       const bloodMoonMult  = s.activeBattleEvent?.type === 'bloodMoon' ? 2 : 1
       const targetTags     = target.tags ?? []
@@ -160,6 +161,7 @@ export function processAttacks(s: GameState, deltaMs: number, log: string[]): vo
             s.opponentBase.hp = Math.max(0, s.opponentBase.hp - dmg)
             s.playerScore += prev - s.opponentBase.hp
             log.push(`${unit.name} hits Enemy Base! -${dmg}HP`)
+            playBaseHit()
           }
         } else {
           if (!isNoDamageMode()) {
@@ -167,6 +169,7 @@ export function processAttacks(s: GameState, deltaMs: number, log: string[]): vo
             s.playerBase.hp = Math.max(0, s.playerBase.hp - dmg)
             s.opponentScore += prev - s.playerBase.hp
             log.push(`${unit.name} hits Your Base! -${dmg}HP`)
+            playBaseHit()
           } else {
             log.push(`${unit.name} hits Your Base! (dev mode — no damage)`)
           }

--- a/web/src/game/sound.ts
+++ b/web/src/game/sound.ts
@@ -125,6 +125,51 @@ export function playManaGain() {
   node(1050, 'sine', t + 0.05, 0.07, 0.15)
 }
 
+// Throttle so rapid multi-unit attacks don't flood the audio channel
+let _lastAttackSoundMs = 0
+export function playUnitAttack() {
+  const now2 = Date.now()
+  if (now2 - _lastAttackSoundMs < 80) return
+  _lastAttackSoundMs = now2
+  const t = now()
+  node(180, 'sawtooth', t,        0.04, 0.22)
+  node(280, 'square',   t + 0.02, 0.03, 0.15)
+}
+
+export function playBaseHit() {
+  const t = now()
+  node(100, 'sawtooth', t,        0.10, 0.38)
+  node(60,  'sine',     t,        0.15, 0.32)
+  node(220, 'square',   t + 0.04, 0.06, 0.20)
+}
+
+export function playBattleStart() {
+  const t = now()
+  // Rising 3-note war horn fanfare
+  node(220, 'sawtooth', t,        0.14, 0.35)
+  node(330, 'sawtooth', t + 0.15, 0.14, 0.38)
+  node(440, 'sawtooth', t + 0.30, 0.22, 0.42)
+  node(440, 'sine',     t + 0.30, 0.22, 0.28)
+}
+
+export function playUpgrade() {
+  const t = now()
+  const notes = [523, 659, 784, 1047]
+  notes.forEach((f, i) => node(f, 'sine', t + i * 0.07, 0.12, 0.22))
+}
+
+export function playMinigameCorrect() {
+  const t = now()
+  node(880,  'sine', t,        0.07, 0.28)
+  node(1320, 'sine', t + 0.07, 0.10, 0.24)
+}
+
+export function playMinigameWrong() {
+  const t = now()
+  node(280, 'sawtooth', t,        0.09, 0.30)
+  node(180, 'square',   t + 0.08, 0.12, 0.22)
+}
+
 // ─── Music Engine ─────────────────────────────────────────────────────────────
 // Look-ahead scheduler pattern — runs a setInterval every SCHEDULE_MS and
 // pre-schedules Web Audio notes up to LOOKAHEAD_SEC ahead of playback.


### PR DESCRIPTION
Closes #967

## Summary

- **New sounds in `sound.ts`** (all procedurally generated via Web Audio API, no external files):
  - `playUnitAttack()` — quick sawtooth/square strike; internally throttled to 80ms so rapid multi-unit attacks don't flood the audio channel
  - `playBaseHit()` — heavy low-frequency impact when a unit damages a base
  - `playBattleStart()` — 3-note rising war-horn fanfare played at battle start
  - `playUpgrade()` — ascending 4-note sparkle for structure upgrades
  - `playMinigameCorrect()` / `playMinigameWrong()` — bright ping / low buzz for minigame feedback

- **Battle engine wire-up:**
  - `combat.ts`: `playUnitAttack()` on player unit attacks; `playBaseHit()` on any unit damaging a base
  - `engine/cards.ts`: `playUpgrade()` when the player upgrades a structure

- **App.tsx wire-up:**
  - `playBattleStart()` called in `startBattle()`
  - `playVictory()` called when phase transitions to `celebration`
  - `playDefeat()` called when phase reaches `gameOver` with a non-player winner

- **Minigame wire-up:**
  - `HigherOrLower`: correct guess → `playMinigameCorrect()`, wrong → `playMinigameWrong()`
  - `CrystalCatch`: crystal/coin catch → `playMinigameCorrect()`, bomb → `playMinigameWrong()`
  - `TileFlip`: pair match → `playMinigameCorrect()`, mismatch → `playMinigameWrong()`

## Test plan

- [ ] Start a battle — hear the war-horn fanfare at the start
- [ ] Play units and watch them attack — hear subtle strike sounds (not overwhelming)
- [ ] A player unit reaches the enemy base — hear heavier impact sound
- [ ] An enemy unit reaches the player base — hear the base-hit sound
- [ ] Upgrade a structure by replaying its card — hear the sparkle upgrade sound
- [ ] Win a battle — hear the victory cheer before the game-over screen
- [ ] Lose a battle — hear the defeat descend before the game-over screen
- [ ] Play Higher or Lower — correct/wrong guess triggers distinct sounds
- [ ] Play Crystal Catch — catching items and hitting bombs produce different sounds
- [ ] Play Tile Flip — match and mismatch produce distinct sounds
- [ ] Sound disabled in Settings — no sounds play for any of the above

https://claude.ai/code/session_01XwbPy7Po7k7sRPoH2Z3Pto

---
_Generated by [Claude Code](https://claude.ai/code/session_01XwbPy7Po7k7sRPoH2Z3Pto)_