### PR TITLE
feat(sound): emitSound() API and sounds.json registry (#962)

### DIFF
--- a/web/src/data/sounds.json
+++ b/web/src/data/sounds.json
@@ -1,0 +1,20 @@
+{
+  "sounds": [
+    { "id": "cardPlay",         "name": "Card Play",          "category": "battle",   "description": "Played when any card is placed from hand" },
+    { "id": "unitDeath",        "name": "Unit Death",         "category": "battle",   "description": "Short descending cry when a mobile unit is destroyed" },
+    { "id": "buildingDestroyed","name": "Building Destroyed", "category": "battle",   "description": "Deep crumbling crash when a structure is destroyed" },
+    { "id": "unitAttack",       "name": "Unit Attack",        "category": "battle",   "description": "Quick strike sound when a player unit attacks (throttled)" },
+    { "id": "baseHit",          "name": "Base Hit",           "category": "battle",   "description": "Heavy impact when a unit damages a base" },
+    { "id": "battleStart",      "name": "Battle Start",       "category": "battle",   "description": "Rising 3-note war-horn fanfare at the start of a battle" },
+    { "id": "upgrade",          "name": "Upgrade",            "category": "battle",   "description": "Ascending sparkle when a player structure is upgraded" },
+    { "id": "victory",          "name": "Victory",            "category": "battle",   "description": "Short ascending melody on winning a battle" },
+    { "id": "defeat",           "name": "Defeat",             "category": "battle",   "description": "Descending lament on losing a battle" },
+    { "id": "battleEvent",      "name": "Battle Event",       "category": "battle",   "description": "Dramatic sting when a mid-battle event fires" },
+    { "id": "buttonClick",      "name": "Button Click",       "category": "ui",       "description": "Subtle tick on UI button presses" },
+    { "id": "cardFlip",         "name": "Card Flip",          "category": "ui",       "description": "Soft swish when cards are revealed or flipped" },
+    { "id": "restHeal",         "name": "Rest Heal",          "category": "ui",       "description": "Gentle ascending chord at rest-node healing" },
+    { "id": "manaGain",         "name": "Mana Gain",          "category": "ui",       "description": "Rising double-tone when mana increases" },
+    { "id": "minigameCorrect",  "name": "Minigame Correct",   "category": "minigame", "description": "Bright ping for a correct guess or successful catch" },
+    { "id": "minigameWrong",    "name": "Minigame Wrong",     "category": "minigame", "description": "Low buzz for a wrong guess, mismatch, or bomb" }
+  ]
+}

--- a/web/src/game/sound.ts
+++ b/web/src/game/sound.ts
@@ -592,3 +592,38 @@ export const MUSIC_TRACKS: Record<string, MusicTrackConfig> = {
   map:     MAP_MUSIC,
   gameover: GAME_OVER_MUSIC_VICTORY,
 }
+
+// ─── emitSound — unified dispatch API ────────────────────────────────────────
+// Single entry point for all one-shot sound effects.  IDs match the `id`
+// fields in src/data/sounds.json.  Existing play*() helpers remain exported
+// for direct use; emitSound() is the preferred API for new call-sites.
+
+export type SoundId =
+  | 'cardPlay' | 'unitDeath' | 'buildingDestroyed'
+  | 'unitAttack' | 'baseHit' | 'battleStart' | 'upgrade'
+  | 'victory' | 'defeat' | 'battleEvent'
+  | 'buttonClick' | 'cardFlip' | 'restHeal' | 'manaGain'
+  | 'minigameCorrect' | 'minigameWrong'
+
+const SOUND_MAP: Record<SoundId, () => void> = {
+  cardPlay:          playCardPlay,
+  unitDeath:         playUnitDeath,
+  buildingDestroyed: playBuildingDestroyed,
+  unitAttack:        playUnitAttack,
+  baseHit:           playBaseHit,
+  battleStart:       playBattleStart,
+  upgrade:           playUpgrade,
+  victory:           playVictory,
+  defeat:            playDefeat,
+  battleEvent:       playBattleEvent,
+  buttonClick:       playButtonClick,
+  cardFlip:          playCardFlip,
+  restHeal:          playRestHeal,
+  manaGain:          playManaGain,
+  minigameCorrect:   playMinigameCorrect,
+  minigameWrong:     playMinigameWrong,
+}
+
+export function emitSound(id: SoundId): void {
+  SOUND_MAP[id]?.()
+}


### PR DESCRIPTION
Closes #962

## Summary

- **`web/src/data/sounds.json`** — new JSON registry listing all 16 synthesized sound effects with `id`, `name`, `category` (`battle` | `ui` | `minigame`), and `description`. Satisfies the JSON config requirement and provides a single authoritative catalogue for future tooling (e.g. a sound-test panel in Settings).

- **`sound.ts` additions:**
  - `SoundId` — exported union type of all valid sound IDs, matching the JSON registry
  - `SOUND_MAP` — internal `Record<SoundId, () => void>` wiring each ID to its synthesizer function
  - `emitSound(id: SoundId)` — exported unified dispatch function; any component or game-logic file can `import { emitSound } from '../game/sound'` and call `emitSound('baseHit')` etc.

- All existing `play*()` exports are **unchanged** — backward compatible with the callers already wired up in #967.

- Sound-enabled/volume gating is inherited automatically: every `play*()` function already checks `isSoundEnabled()` and routes through the shared `masterGain` node, so `emitSound()` gets the same behaviour for free.

## Test plan

- [ ] `import { emitSound } from '../game/sound'; emitSound('battleStart')` plays the war-horn fanfare in a browser console (AudioContext must be unlocked first)
- [ ] TypeScript: `emitSound('unknown')` produces a compile error (invalid `SoundId`)
- [ ] All existing battle and minigame sounds still play correctly (no regression from #967)
- [ ] Sound disabled in Settings → `emitSound()` calls produce no audio

https://claude.ai/code/session_01XwbPy7Po7k7sRPoH2Z3Pto

---
_Generated by [Claude Code](https://claude.ai/code/session_01XwbPy7Po7k7sRPoH2Z3Pto)_