### PR TITLE
feat(settings): separate sound effects & music volume sliders (#963)

### DIFF
--- a/web/src/components/SettingsScreen.tsx
+++ b/web/src/components/SettingsScreen.tsx
@@ -2,7 +2,7 @@ import React, { useState, useRef } from 'react'
 import {
   signOut as firebaseSignOut, type User,
 } from 'firebase/auth'
-import { isSoundEnabled, setSoundEnabled } from '../game/sound'
+import { isSoundEnabled, setSoundEnabled, getSoundVolume, setSoundVolume, getMusicVolume, setMusicVolume } from '../game/sound'
 import { OverlayScreen } from './OverlayScreen'
 import { Section } from './Section'
 import { LoginModal } from './LoginModal'
@@ -135,6 +135,8 @@ function exportLocalStorage(): void {
 
 export function SettingsScreen({ onBack, onResetGame, user, authLoading, onDevCrystalsChanged, onDevHandicapChanged, onGiftAdmin, onNewsAdmin, onCampaignAdmin, onFeedbackAdmin }: Props) {
   const [soundOn,       setSoundOn]       = useState(isSoundEnabled)
+  const [soundVolume,   setSoundVolumeState]   = useState(getSoundVolume)
+  const [musicVolume,   setMusicVolumeState]   = useState(getMusicVolume)
   const [textSize,      setTextSize]      = useState(loadTextSize)
   const [textColor,     setTextColor]     = useState(loadTextColor)
   const [skipIntro,     setSkipIntro]     = useState(loadSkipIntro)
@@ -222,6 +224,16 @@ export function SettingsScreen({ onBack, onResetGame, user, authLoading, onDevCr
     setSoundEnabled(next)
   }
 
+  function handleSoundVolumeChange(val: number) {
+    setSoundVolumeState(val)
+    setSoundVolume(val)
+  }
+
+  function handleMusicVolumeChange(val: number) {
+    setMusicVolumeState(val)
+    setMusicVolume(val)
+  }
+
   function handleEightbitToggle() {
     const next = !eightbitOn
     setEightbitOn(next)
@@ -291,10 +303,41 @@ export function SettingsScreen({ onBack, onResetGame, user, authLoading, onDevCr
               <div className="settings-label">Sound effects</div>
               <div className="settings-sublabel">Procedurally generated audio</div>
             </div>
-            <div className="settings-toggle" onClick={handleSoundToggle}>
-              <div className={`settings-toggle-track${soundOn ? ' settings-toggle-track--on' : ''}`}>
-                <div className="settings-toggle-thumb" />
+            <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+              <input
+                type="range"
+                className="settings-slider"
+                min={0}
+                max={1}
+                step={0.05}
+                value={soundVolume}
+                disabled={!soundOn}
+                onChange={e => handleSoundVolumeChange(Number(e.target.value))}
+              />
+              <span className="settings-value">{Math.round(soundVolume * 100)}%</span>
+              <div className="settings-toggle" onClick={handleSoundToggle}>
+                <div className={`settings-toggle-track${soundOn ? ' settings-toggle-track--on' : ''}`}>
+                  <div className="settings-toggle-thumb" />
+                </div>
               </div>
+            </div>
+          </div>
+          <div className="settings-row">
+            <div>
+              <div className="settings-label">Music</div>
+              <div className="settings-sublabel">Background music volume</div>
+            </div>
+            <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+              <input
+                type="range"
+                className="settings-slider"
+                min={0}
+                max={1}
+                step={0.05}
+                value={musicVolume}
+                onChange={e => handleMusicVolumeChange(Number(e.target.value))}
+              />
+              <span className="settings-value">{Math.round(musicVolume * 100)}%</span>
             </div>
           </div>
         </Section>

--- a/web/src/game/sound.ts
+++ b/web/src/game/sound.ts
@@ -4,7 +4,10 @@
 let ctx: AudioContext | null = null
 let masterGain: GainNode | null = null
 
-const SETTINGS_KEY = 'jarv_sound_enabled'
+const SETTINGS_KEY      = 'jarv_sound_enabled'
+const SOUND_VOLUME_KEY  = 'jarv_sound_volume'
+const MUSIC_VOLUME_KEY  = 'jarv_music_volume'
+const SOUND_BASE_GAIN   = 0.35
 
 export function isSoundEnabled(): boolean {
   try { return localStorage.getItem(SETTINGS_KEY) !== 'false' }
@@ -16,13 +19,37 @@ export function setSoundEnabled(val: boolean): void {
   catch { /* ignore */ }
 }
 
+export function getSoundVolume(): number {
+  try { return Math.min(1, Math.max(0, parseFloat(localStorage.getItem(SOUND_VOLUME_KEY) ?? '1') || 1)) }
+  catch { return 1 }
+}
+
+export function setSoundVolume(val: number): void {
+  try { localStorage.setItem(SOUND_VOLUME_KEY, String(val)) } catch { /* ignore */ }
+  if (masterGain) masterGain.gain.value = SOUND_BASE_GAIN * val
+}
+
+export function getMusicVolume(): number {
+  try { return Math.min(1, Math.max(0, parseFloat(localStorage.getItem(MUSIC_VOLUME_KEY) ?? '1') || 1)) }
+  catch { return 1 }
+}
+
+export function setMusicVolume(val: number): void {
+  try { localStorage.setItem(MUSIC_VOLUME_KEY, String(val)) } catch { /* ignore */ }
+  for (const track of _tracks.values()) {
+    if (track.gainNode && track.baseVol !== undefined) {
+      track.gainNode.gain.value = track.baseVol * val
+    }
+  }
+}
+
 function getCtx(): AudioContext | null {
   if (!isSoundEnabled()) return null
   try {
     if (!ctx) {
       ctx = new (window.AudioContext || (window as never as { webkitAudioContext: typeof AudioContext }).webkitAudioContext)()
       masterGain = ctx.createGain()
-      masterGain.gain.value = 0.35
+      masterGain.gain.value = SOUND_BASE_GAIN * getSoundVolume()
       masterGain.connect(ctx.destination)
     }
     return ctx
@@ -182,18 +209,20 @@ interface MusicTrack {
   nextBeatTime: number
   beatIndex:    number
   gainNode:     GainNode | null
+  baseVol:      number
 }
 
 function makeTrack(): MusicTrack {
-  return { scheduler: null, nextBeatTime: 0, beatIndex: 0, gainNode: null }
+  return { scheduler: null, nextBeatTime: 0, beatIndex: 0, gainNode: null, baseVol: 0.1 }
 }
 
 function trackGain(track: MusicTrack, vol: number): GainNode | null {
   const c = getCtx()
   if (!c) return null
   if (!track.gainNode) {
+    track.baseVol = vol
     track.gainNode = c.createGain()
-    track.gainNode.gain.value = vol
+    track.gainNode.gain.value = vol * getMusicVolume()
     track.gainNode.connect(c.destination)
   }
   return track.gainNode


### PR DESCRIPTION
Closes #963

## Summary

- **`sound.ts`** — two new localStorage-backed volume controls:
  - `getSoundVolume()` / `setSoundVolume(val)` (key `jarv_sound_volume`, default `1.0`) — scales `masterGain.gain.value` live so existing `play*()` / `emitSound()` callers pick it up automatically
  - `getMusicVolume()` / `setMusicVolume(val)` (key `jarv_music_volume`, default `1.0`) — `MusicTrack` gains a `baseVol` field; `trackGain()` applies the multiplier at creation, and `setMusicVolume()` updates all active track gain nodes immediately so the music duck/boost is audible in real time
  - `masterGain` is initialised at `SOUND_BASE_GAIN × getSoundVolume()` so the saved level applies on first AudioContext creation without needing a restart

- **`SettingsScreen.tsx`** — AUDIO section updated:
  - Sound Effects row: keeps the on/off toggle; adds a 0–100% `<input type="range">` slider to its right (disabled while the toggle is off)
  - Music row (new): a 0–100% `<input type="range">` slider with live percentage readout
  - Both values read initial state from the new getters and write back via the new setters on every `onChange`

## Test plan

- [ ] Open Settings → AUDIO; both sliders show at 100% by default
- [ ] Drag Sound Effects slider to 50% — battle/UI sounds play at half volume
- [ ] Drag Music slider to 0% — background music fades out immediately; drag back to 100% — music restores
- [ ] Toggle Sound Effects off — slider goes grey/disabled; no audio plays
- [ ] Toggle Sound Effects back on — slider re-enables at its previous value
- [ ] Reload page — both sliders restore to the last saved values
- [ ] Sound Effects at 0% but toggle on — effectively muted; toggle off and back on still silent

https://claude.ai/code/session_01XwbPy7Po7k7sRPoH2Z3Pto

---
_Generated by [Claude Code](https://claude.ai/code/session_01XwbPy7Po7k7sRPoH2Z3Pto)_