### PR TITLE
feat(sound): shop ka-ching, fruit machine & map footstep sounds (#964 #965 #966)

### DIFF
--- a/web/src/components/MerchantScreen.tsx
+++ b/web/src/components/MerchantScreen.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react'
+import { emitSound } from '../game/sound'
 import { Card } from '../game/types'
 import { UselessItem } from '../game/dailyLogin'
 import { MERCHANT_PRICES, ConsumableDef } from '../game/questline'
@@ -37,6 +38,7 @@ export function MerchantScreen({ items, crystals, onBuy, onDone }: Props) {
     // Consumables can be bought multiple times
     if (item.kind !== 'consumable' && purchased.has(key)) return
     if (balance < item.price) return
+    emitSound('shopPurchase')
     setBalance(b => b - item.price)
     if (item.kind !== 'consumable') setPurchased(p => new Set([...p, key]))
     onBuy(item)

--- a/web/src/components/NodeMap.tsx
+++ b/web/src/components/NodeMap.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo, useRef, useEffect, useState } from 'react'
+import { emitSound } from '../game/sound'
 import { Act, QuestNode, RunState, ReplayModifier, getAvailableNodeIds, loadNodeHistory, getModifiersByCount, ALL_CONSUMABLES, loadPlayerAvatar } from '../game/questline'
 import { spriteSlug } from '../game/sprites'
 import { StatRow } from './StatRow'
@@ -793,6 +794,7 @@ export function NodeMap({ act, run, onSelectNode, onUseConsumable, onBack }: Pro
     if (!mapInnerEl || !nodeBtn) return
     const target = getRelativeCenter(nodeBtn, mapInnerEl)
 
+    emitSound('mapFootstep')
     setIsWalking(true)
     setAvatarPos(target)  // CSS transition animates the move
     const frameTimer = setInterval(() => setWalkFrame(f => (f % 3) + 1), 175)

--- a/web/src/components/ShopScreen.tsx
+++ b/web/src/components/ShopScreen.tsx
@@ -17,6 +17,7 @@ import {
 import { loadInventory, removeFromInventory } from '../game/dailyLogin'
 import { ALL_CONSUMABLES, addToConsumableStash } from '../game/questline'
 import { saveCrystals } from '../game/collection'
+import { emitSound } from '../game/sound'
 import { SpriteImg } from './SpriteImg'
 import { OverlayScreen } from './OverlayScreen'
 import { getCardCatalog } from '../game/cards'
@@ -149,6 +150,7 @@ export function ShopScreen({ crystals, onBuyCrystalPack, onCrystalsChange, onBac
       return
     }
     const next = crystals - effectivePrice
+    emitSound('shopPurchase')
     saveCrystals(next)
     onCrystalsChange(next)
     addToConsumableStash(id)
@@ -156,6 +158,7 @@ export function ShopScreen({ crystals, onBuyCrystalPack, onCrystalsChange, onBac
 
   function handleBuyPackClick() {
     if (canBuyPack) {
+      emitSound('shopPurchase')
       onBuyCrystalPack(packQty)
     } else {
       incrementAchievementProgress('misc:shop_broke_click')
@@ -166,6 +169,7 @@ export function ShopScreen({ crystals, onBuyCrystalPack, onCrystalsChange, onBac
     const price = cardPrice(deal)
     if (crystals < price || deal.cardName === '') return
     const next = crystals - price
+    emitSound('shopPurchase')
     onCrystalsChange(next)
     addCardsToCollection([{ cardName: deal.cardName, count: 1 }])
     const updated = { ...shopState, boughtCardNames: [...shopState.boughtCardNames, deal.cardName] }

--- a/web/src/components/minigames/FruitMachine.tsx
+++ b/web/src/components/minigames/FruitMachine.tsx
@@ -16,6 +16,7 @@
 //   Stay (rest) — no board movement
 
 import React, { useState, useRef, useEffect } from 'react'
+import { emitSound } from '../../game/sound'
 import { loadCrystals, saveCrystals } from '../../game/collection'
 import { logError } from '../../logger'
 import {
@@ -390,6 +391,7 @@ export function FruitMachine({ onDone }: Props) {
   }
 
   function resetBoardToZero() {
+    emitSound('fruitMachineLose')
     boardPosRef.current = 0
     setBoardPos(0)
     try { localStorage.setItem('fm_board_pos', '0') } catch (e) { logError('fm_board_pos reset', { error: String(e) }) }
@@ -537,6 +539,7 @@ function regressBoardBy(steps: number) {
     try { localStorage.setItem('fm_grand', String(newGrand)) } catch (e) { logError('fm_grand save', { error: String(e) }) }
     incrementGrandJackpot()
 
+    emitSound('fruitMachineSpin')
     setPhase('spinning')
     const spinCost = freeSpin ? 0 : 1
     setFreeSpin(false)
@@ -593,6 +596,7 @@ function regressBoardBy(steps: number) {
 
       setLastWin(totalWin)
       setCredits(c => Math.max(0, c + totalWin))
+      if (totalWin > 0) emitSound('fruitMachineWin')
       // After a winning spin, block all holds so the player can't chain wins by holding
       if (totalWin > 0) setRecentlyHeld([true, true, true])
 

--- a/web/src/data/sounds.json
+++ b/web/src/data/sounds.json
@@ -15,6 +15,11 @@
     { "id": "restHeal",         "name": "Rest Heal",          "category": "ui",       "description": "Gentle ascending chord at rest-node healing" },
     { "id": "manaGain",         "name": "Mana Gain",          "category": "ui",       "description": "Rising double-tone when mana increases" },
     { "id": "minigameCorrect",  "name": "Minigame Correct",   "category": "minigame", "description": "Bright ping for a correct guess or successful catch" },
-    { "id": "minigameWrong",    "name": "Minigame Wrong",     "category": "minigame", "description": "Low buzz for a wrong guess, mismatch, or bomb" }
+    { "id": "minigameWrong",    "name": "Minigame Wrong",     "category": "minigame", "description": "Low buzz for a wrong guess, mismatch, or bomb" },
+    { "id": "shopPurchase",     "name": "Shop Purchase",      "category": "ui",       "description": "Ka-ching ascending coin tink when buying from a shop or merchant" },
+    { "id": "fruitMachineSpin", "name": "Fruit Machine Spin", "category": "minigame", "description": "Short mechanical click-whirr each time the reels begin spinning" },
+    { "id": "fruitMachineWin",  "name": "Fruit Machine Win",  "category": "minigame", "description": "Punchy ascending fanfare when the fruit machine pays out" },
+    { "id": "fruitMachineLose", "name": "Fruit Machine Lose", "category": "minigame", "description": "Descending sawtooth lament when the fruit machine resets to zero" },
+    { "id": "mapFootstep",      "name": "Map Footstep",       "category": "ui",       "description": "Soft thud when the player avatar begins walking to a new node" }
   ]
 }

--- a/web/src/game/sound.ts
+++ b/web/src/game/sound.ts
@@ -197,6 +197,43 @@ export function playMinigameWrong() {
   node(180, 'square',   t + 0.08, 0.12, 0.22)
 }
 
+export function playShopPurchase() {
+  const t = now()
+  // "Ka-ching": high coin tink + mid register + low resonance
+  node(1200, 'sine',     t,        0.05, 0.32)
+  node(1800, 'sine',     t + 0.02, 0.06, 0.28)
+  node(900,  'triangle', t + 0.05, 0.10, 0.24)
+  node(600,  'sine',     t + 0.10, 0.12, 0.20)
+}
+
+export function playFruitMachineSpin() {
+  const t = now()
+  // Short mechanical click-whirr
+  node(180, 'sawtooth', t,        0.03, 0.18)
+  node(260, 'square',   t + 0.02, 0.03, 0.14)
+  node(140, 'sawtooth', t + 0.05, 0.04, 0.12)
+}
+
+export function playFruitMachineWin() {
+  const t = now()
+  // Punchy ascending win fanfare
+  const melody = [523, 659, 784, 1047, 1318]
+  melody.forEach((f, i) => node(f, 'sine', t + i * 0.09, 0.14, 0.32))
+}
+
+export function playFruitMachineLose() {
+  const t = now()
+  const melody = [440, 370, 294, 220]
+  melody.forEach((f, i) => node(f, 'sawtooth', t + i * 0.12, 0.16, 0.26))
+}
+
+export function playMapFootstep() {
+  const t = now()
+  // Soft thud — low sine click
+  node(120, 'sine',     t,        0.05, 0.22)
+  node(80,  'sawtooth', t + 0.02, 0.04, 0.14)
+}
+
 // ─── Music Engine ─────────────────────────────────────────────────────────────
 // Look-ahead scheduler pattern — runs a setInterval every SCHEDULE_MS and
 // pre-schedules Web Audio notes up to LOOKAHEAD_SEC ahead of playback.
@@ -633,6 +670,8 @@ export type SoundId =
   | 'victory' | 'defeat' | 'battleEvent'
   | 'buttonClick' | 'cardFlip' | 'restHeal' | 'manaGain'
   | 'minigameCorrect' | 'minigameWrong'
+  | 'shopPurchase' | 'fruitMachineSpin' | 'fruitMachineWin' | 'fruitMachineLose'
+  | 'mapFootstep'
 
 const SOUND_MAP: Record<SoundId, () => void> = {
   cardPlay:          playCardPlay,
@@ -651,6 +690,11 @@ const SOUND_MAP: Record<SoundId, () => void> = {
   manaGain:          playManaGain,
   minigameCorrect:   playMinigameCorrect,
   minigameWrong:     playMinigameWrong,
+  shopPurchase:      playShopPurchase,
+  fruitMachineSpin:  playFruitMachineSpin,
+  fruitMachineWin:   playFruitMachineWin,
+  fruitMachineLose:  playFruitMachineLose,
+  mapFootstep:       playMapFootstep,
 }
 
 export function emitSound(id: SoundId): void {


### PR DESCRIPTION
Closes #964, #965, #966

## Summary

- **#964 Shop ka-ching**: `playShopPurchase()` — ascending coin-tink synth added to `sound.ts`; `emitSound('shopPurchase')` wired into every buy path in `MerchantScreen` and `ShopScreen` (cards, consumables, card packs)
- **#965 Fruit machine sounds**: `playFruitMachineSpin/Win/Lose()` added to `sound.ts`; spin sound fires at reel start, win fanfare fires when `totalWin > 0`, lose lament fires in `resetBoardToZero()`
- **#966 Campaign map footstep**: `playMapFootstep()` — soft low-frequency thud added to `sound.ts`; `emitSound('mapFootstep')` fires in `NodeMap.handleNodeClick()` when the avatar begins walking
- Extended `SoundId` union type and `SOUND_MAP` with all 5 new IDs
- Added 5 entries to `src/data/sounds.json`

## Test plan

- [ ] Open Merchant screen, buy a card or consumable — hear ka-ching
- [ ] Open Shop, buy a card deal, consumable, and card pack — hear ka-ching on each
- [ ] Open Fruit Machine, press SPIN — hear mechanical click-whirr
- [ ] Win credits on Fruit Machine — hear ascending fanfare
- [ ] Hit a Lose trail result — hear descending lament and board resets to 0
- [ ] On Campaign map, click an available node — hear soft footstep thud as avatar starts walking
- [ ] Disable sound in Settings — all above sounds are silent

https://claude.ai/code/session_01XwbPy7Po7k7sRPoH2Z3Pto

---
_Generated by [Claude Code](https://claude.ai/code/session_01XwbPy7Po7k7sRPoH2Z3Pto)_