### PR TITLE
feat(city-builder): affinity becomes neighbour requirement

### DIFF
--- a/web/src/components/minigames/CityBuilder.tsx
+++ b/web/src/components/minigames/CityBuilder.tsx
@@ -23,6 +23,7 @@ import {
   getBuildingProduces,
   INCOME_SPAWN, INCOME_UTILITY, INCOME_WALL,
   spawnerUnitCount, masteryOutputMultiplier,
+  getNeighbourIndices,
 } from '../../game/cityBuilder'
 import { MasteryBar } from '../MasteryBar'
 import { SpriteImg, AnimatedSpriteImg } from '../SpriteImg'
@@ -41,14 +42,18 @@ function rageDescription(happiness: number): string {
 function getUnitRequirements(
   cell: CityCell,
   cityState: CityState,
-  presentNames: Set<string>,
+  cellIndex: number,
 ): { text: string; met: boolean }[] {
   const reqs: { text: string; met: boolean }[] = []
 
   if (cell.affinityWith) {
+    const neighbourMet = getNeighbourIndices(cellIndex).some(ni => {
+      const nc = cityState.grid[ni]
+      return nc?.spawnedUnitName === cell.affinityWith && (cityState.happiness[ni] ?? 100) > 0
+    })
     reqs.push({
-      text: `Wants a ${cell.affinityWith} in the city`,
-      met: presentNames.has(cell.affinityWith),
+      text: `Wants a ${cell.affinityWith} next door`,
+      met: neighbourMet,
     })
   }
 
@@ -312,13 +317,6 @@ export function CityBuilder({ onBack }: Props) {
   const prodRates = resourceProductionRate(city)
   const consRates = resourceConsumptionRate(city)
 
-  // Unit names that are alive (happiness > 0) — despawned units don't count for affinity
-  const presentUnitNames = new Set(
-    city.grid
-      .filter((c, i) => c?.spawnedUnitName && (city.happiness[i] ?? 100) > 0)
-      .map(c => c!.spawnedUnitName!) as string[]
-  )
-
   // ── Card picker sub-screen ────────────────────────────────────────────────────
 
   if (screen === 'picker') {
@@ -489,7 +487,7 @@ export function CityBuilder({ onBack }: Props) {
         const cell = city.grid[selectedWalkerCell]
         if (!cell?.spawnedUnitName) return null
         const happiness = city.happiness[selectedWalkerCell] ?? 100
-        const reqs = getUnitRequirements(cell, city, presentUnitNames)
+        const reqs = getUnitRequirements(cell, city, selectedWalkerCell)
         const moodKey = happiness === 0 ? 'gone' : happiness < 30 ? 'furious' : happiness < 60 ? 'unsettled' : 'content'
         return (
           <div className="city-req-overlay" onClick={() => setSelectedWalkerCell(null)}>
@@ -537,7 +535,7 @@ export function CityBuilder({ onBack }: Props) {
                     <div className="city-bld-vacant">Building is vacant — unit left the city</div>
                   ) : (
                     Array.from({ length: unitCount }, (_, u) => {
-                      const reqs = getUnitRequirements(cell, city, presentUnitNames)
+                      const reqs = getUnitRequirements(cell, city, selectedBuildingCell)
                       const unmet = reqs.filter(r => !r.met)
                       return (
                         <div key={u} className="city-bld-resident">
@@ -675,7 +673,10 @@ export function CityBuilder({ onBack }: Props) {
           {walkers.map(w => {
             const happiness   = city.happiness[w.cellIndex] ?? 100
             const rage        = 100 - happiness
-            const wantsFriend = w.affinityWith && !presentUnitNames.has(w.affinityWith)
+            const wantsFriend = w.affinityWith && !getNeighbourIndices(w.cellIndex).some(ni => {
+              const nc = city.grid[ni]
+              return nc?.spawnedUnitName === w.affinityWith && (city.happiness[ni] ?? 100) > 0
+            })
             return (
               <div
                 key={`${w.cellIndex}-${w.unitIndex}`}

--- a/web/src/game/cityBuilder.ts
+++ b/web/src/game/cityBuilder.ts
@@ -207,6 +207,18 @@ export function getStructureKind(cell: CityCell): StructureKind {
   return 'utility'
 }
 
+/** Returns grid indices of the 4 orthogonally adjacent cells (no diagonals, no wrap). */
+export function getNeighbourIndices(index: number): number[] {
+  const row = Math.floor(index / CITY_COLS)
+  const col = index % CITY_COLS
+  const result: number[] = []
+  if (col > 0)             result.push(index - 1)
+  if (col < CITY_COLS - 1) result.push(index + 1)
+  if (row > 0)             result.push(index - CITY_COLS)
+  if (row < CITY_ROWS - 1) result.push(index + CITY_COLS)
+  return result
+}
+
 function cellIncomeRate(cell: CityCell, happy: boolean, unitCount: number): number {
   const kind = getStructureKind(cell)
   if (kind === 'spawn') {
@@ -301,19 +313,15 @@ export function tickCity(state: CityState): CityState {
   const defenseScore = Math.min(100, (defense / population) * 8)
   const baseTarget   = Math.round(foodScore * 0.6 + defenseScore * 0.4)
 
-  // Unit names that are currently alive (happiness > 0) — used for affinity checks
-  const aliveUnitNames = new Set(
-    state.grid
-      .map((c, i) => c?.spawnedUnitName && (newHappy[i] ?? 100) > 0 ? c.spawnedUnitName : null)
-      .filter(Boolean) as string[]
-  )
-
   for (let i = 0; i < state.grid.length; i++) {
     const cell = state.grid[i]
     if (!cell?.spawnedUnitName) continue
 
-    // Affinity is a hard requirement: missing friend → target forced to 0
-    const affinityMet = !cell.affinityWith || aliveUnitNames.has(cell.affinityWith)
+    // Affinity is a neighbour requirement: wants the named unit in an adjacent cell
+    const affinityMet = !cell.affinityWith || getNeighbourIndices(i).some(ni => {
+      const nc = state.grid[ni]
+      return nc?.spawnedUnitName === cell.affinityWith && (state.happiness[ni] ?? 100) > 0
+    })
     const cellTarget  = affinityMet ? baseTarget : 0
 
     const current = newHappy[i] ?? 100


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Residents now want their affinity unit (`affinity.withName`) placed in an **adjacent cell** rather than anywhere in the city
- Missing the neighbour drains happiness to zero (same hard-requirement behaviour as before)
- Requirement text in the inspect modal updated from "Wants a X in the city" → "Wants a X next door"
- Speech bubble above walkers now appears when the neighbour slot is empty

## Changes

- `cityBuilder.ts`: added `getNeighbourIndices` (4-directional, no wrap); replaced city-wide `aliveUnitNames` set with a per-cell neighbour check inside `tickCity`
- `CityBuilder.tsx`: `getUnitRequirements` now takes `cellIndex` and checks neighbours directly; removed unused `presentUnitNames` set; speech bubble logic updated to match

## Test plan

- [ ] Place a Vampire spawner — walker should show speech bubble and unhappy indicator until a Bat spawner is placed in an adjacent cell
- [ ] Place two buildings with matching affinity next to each other — requirement shows ✓ and happiness recovers
- [ ] Move one building away (demolish + replace elsewhere) — requirement flips back to ✗ and happiness drains

https://claude.ai/code/session_01K3tuy2DDWYq28yKBKAREx6
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01K3tuy2DDWYq28yKBKAREx6)_