### PR TITLE
feat(city-builder): limit thoughts feed to 5 random residents

### DIFF
--- a/web/src/components/minigames/CityBuilder.tsx
+++ b/web/src/components/minigames/CityBuilder.tsx
@@ -182,7 +182,12 @@ function buildResidentThoughts(
       thoughts.push({ name, unitName: cell.spawnedUnitName, thought, happy })
     }
   }
-  return thoughts
+  // Shuffle and cap at 5 so the feed shows a rotating sample
+  for (let i = thoughts.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [thoughts[i], thoughts[j]] = [thoughts[j], thoughts[i]]
+  }
+  return thoughts.slice(0, 5)
 }
 
 // ── Walking unit state ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Shuffles the full resident list and slices to 5 before rendering
- Each 15-second refresh shows a different random sample of residents

## Test plan

- [ ] City with more than 5 residents — feed shows exactly 5
- [ ] Thoughts rotate to different residents each refresh

https://claude.ai/code/session_01K3tuy2DDWYq28yKBKAREx6

---
_Generated by [Claude Code](https://claude.ai/code/session_01K3tuy2DDWYq28yKBKAREx6)_