### PR TITLE
feat(city-builder): same-type neighbour fallback when no affinity defined

### DIFF
--- a/web/src/components/minigames/CityBuilder.tsx
+++ b/web/src/components/minigames/CityBuilder.tsx
@@ -46,13 +46,16 @@ function getUnitRequirements(
 ): { text: string; met: boolean }[] {
   const reqs: { text: string; met: boolean }[] = []
 
-  if (cell.affinityWith) {
+  const wantedNeighbour = cell.affinityWith ?? cell.spawnedUnitName
+  if (wantedNeighbour) {
     const neighbourMet = getNeighbourIndices(cellIndex).some(ni => {
       const nc = cityState.grid[ni]
-      return nc?.spawnedUnitName === cell.affinityWith && (cityState.happiness[ni] ?? 100) > 0
+      return nc?.spawnedUnitName === wantedNeighbour && (cityState.happiness[ni] ?? 100) > 0
     })
     reqs.push({
-      text: `Wants a ${cell.affinityWith} next door`,
+      text: cell.affinityWith
+        ? `Wants a ${wantedNeighbour} next door`
+        : `Wants another ${wantedNeighbour} next door`,
       met: neighbourMet,
     })
   }
@@ -148,27 +151,19 @@ function buildResidentThoughts(
       let thought: string
       let happy = true
 
+      const wantedNeighbour = cell.affinityWith ?? cell.spawnedUnitName
+      const neighbourMet = getNeighbourIndices(i).some(ni => {
+        const nc = city.grid[ni]
+        return nc?.spawnedUnitName === wantedNeighbour && (city.happiness[ni] ?? 100) > 0
+      })
+
       if (happiness === 0) {
         thought = LEAVING_THOUGHTS[seed % LEAVING_THOUGHTS.length]
         happy = false
-      } else if (cell.affinityWith) {
-        const neighbourMet = getNeighbourIndices(i).some(ni => {
-          const nc = city.grid[ni]
-          return nc?.spawnedUnitName === cell.affinityWith && (city.happiness[ni] ?? 100) > 0
-        })
-        if (!neighbourMet) {
-          const lines = AFFINITY_THOUGHTS(cell.affinityWith)
-          thought = lines[seed % lines.length]
-          happy = false
-        } else if (foodScore < 50) {
-          thought = FOOD_THOUGHTS[seed % FOOD_THOUGHTS.length]
-          happy = false
-        } else if (defenseScore < 50) {
-          thought = DEFENCE_THOUGHTS[seed % DEFENCE_THOUGHTS.length]
-          happy = false
-        } else {
-          thought = HAPPY_THOUGHTS[seed % HAPPY_THOUGHTS.length]
-        }
+      } else if (!neighbourMet) {
+        const lines = AFFINITY_THOUGHTS(wantedNeighbour)
+        thought = lines[seed % lines.length]
+        happy = false
       } else if (foodScore < 50) {
         thought = FOOD_THOUGHTS[seed % FOOD_THOUGHTS.length]
         happy = false
@@ -795,9 +790,10 @@ export function CityBuilder({ onBack }: Props) {
           {walkers.map(w => {
             const happiness   = city.happiness[w.cellIndex] ?? 100
             const rage        = 100 - happiness
-            const wantsFriend = w.affinityWith && !getNeighbourIndices(w.cellIndex).some(ni => {
+            const wantedNeighbour = w.affinityWith ?? w.unitName
+            const wantsFriend = !getNeighbourIndices(w.cellIndex).some(ni => {
               const nc = city.grid[ni]
-              return nc?.spawnedUnitName === w.affinityWith && (city.happiness[ni] ?? 100) > 0
+              return nc?.spawnedUnitName === wantedNeighbour && (city.happiness[ni] ?? 100) > 0
             })
             return (
               <div
@@ -810,8 +806,8 @@ export function CityBuilder({ onBack }: Props) {
                 onKeyDown={e => { if (e.key === 'Enter') { e.stopPropagation(); setSelectedWalkerCell(w.cellIndex) } }}
               >
                 {wantsFriend && (
-                  <div className="city-speech-bubble" title={`Wants a ${w.affinityWith}!`}>
-                    <SpriteImg name={w.affinityWith!} className="city-speech-icon" />
+                  <div className="city-speech-bubble" title={`Wants a ${wantedNeighbour} next door!`}>
+                    <SpriteImg name={wantedNeighbour} className="city-speech-icon" />
                   </div>
                 )}
                 <AnimatedSpriteImg

--- a/web/src/game/cityBuilder.ts
+++ b/web/src/game/cityBuilder.ts
@@ -317,10 +317,11 @@ export function tickCity(state: CityState): CityState {
     const cell = state.grid[i]
     if (!cell?.spawnedUnitName) continue
 
-    // Affinity is a neighbour requirement: wants the named unit in an adjacent cell
-    const affinityMet = !cell.affinityWith || getNeighbourIndices(i).some(ni => {
+    // Wants affinity unit next door; falls back to same unit type if no affinity defined
+    const wantedNeighbour = cell.affinityWith ?? cell.spawnedUnitName
+    const affinityMet = getNeighbourIndices(i).some(ni => {
       const nc = state.grid[ni]
-      return nc?.spawnedUnitName === cell.affinityWith && (state.happiness[ni] ?? 100) > 0
+      return nc?.spawnedUnitName === wantedNeighbour && (state.happiness[ni] ?? 100) > 0
     })
     const cellTarget  = affinityMet ? baseTarget : 0
 


### PR DESCRIPTION
## Summary

- Units with no `affinity.withName` now want another unit of their own type in an adjacent cell
- Happiness drains to zero if the requirement is unmet, same as the explicit affinity behaviour
- Requirement text distinguishes: "Wants a Bat next door" vs "Wants another Dragon next door"
- Speech bubble and resident thoughts updated to reflect the fallback

## Test plan

- [ ] Place two of the same spawner adjacent — no unhappy indicator
- [ ] Move one away — speech bubble appears, happiness drains, thought shows neighbour complaint
- [ ] Place a spawner with explicit affinity (e.g. Vampire) — still uses `affinityWith` unit, not same-type

https://claude.ai/code/session_01K3tuy2DDWYq28yKBKAREx6

---
_Generated by [Claude Code](https://claude.ai/code/session_01K3tuy2DDWYq28yKBKAREx6)_