### PR TITLE
fix(city-builder): read affinity from spawned unit template not structure card

### DIFF
--- a/web/src/components/minigames/CityBuilder.tsx
+++ b/web/src/components/minigames/CityBuilder.tsx
@@ -364,7 +364,10 @@ export function CityBuilder({ onBack }: Props) {
       return
     }
 
-    const affinityWith = card.unit?.affinity?.withName
+    // For spawners, affinity lives on the spawned unit template, not the structure card itself
+    const affinityWith = isSpawner
+      ? (spawnEffect as { type: 'spawn'; unitTemplate: { affinity?: { withName: string } }; intervalMs: number }).unitTemplate.affinity?.withName
+      : card.unit?.affinity?.withName
 
     const cell: CityCell = {
       cardName: card.name,


### PR DESCRIPTION
## Bug

Dragon Lair was falling back to "wants another Dragon next door" because `card.unit.affinity` points to the **structure card's** own affinity (which is usually undefined). The Dragon's `affinity.withName = "Catapult"` lives inside `structureEffect.unitTemplate.affinity`.

## Fix

At placement time, spawner buildings now read affinity from `spawnEffect.unitTemplate.affinity?.withName` instead of `card.unit?.affinity?.withName`.

## Test plan

- [ ] Place a Dragon Lair — requirement should read "Wants a Catapult next door", not "Wants another Dragon next door"
- [ ] Place a Vampire spawner — should still read "Wants a Bat next door"
- [ ] Place a building with no affinity on its spawned unit — should still fall back to same-type neighbour

https://claude.ai/code/session_01K3tuy2DDWYq28yKBKAREx6

---
_Generated by [Claude Code](https://claude.ai/code/session_01K3tuy2DDWYq28yKBKAREx6)_