### PR TITLE
fix(boss): fix broken boss traits, add Fracture trait, elite boss encounters

### DIFF
--- a/web/src/data/acts/act1.json
+++ b/web/src/data/acts/act1.json
@@ -977,7 +977,8 @@
         "Iron Skin"
       ],
       "opponentIntervalMs": 6000,
-      "opponentBaseHp": 92
+      "opponentBaseHp": 92,
+      "bossAI": "verdant-elite"
     },
     "deep-woods": {
       "id": "deep-woods",
@@ -1012,7 +1013,8 @@
         "Cave Bat",
         "Cave Bat",
         "Rally"
-      ]
+      ],
+      "bossAI": "verdant-elite"
     },
     "troll-bridge": {
       "id": "troll-bridge",

--- a/web/src/data/acts/act10.json
+++ b/web/src/data/acts/act10.json
@@ -43,7 +43,7 @@
   "intro": [
     {
       "title": "THE SAND MARKET",
-      "text": "The ley lines run straight through the desert, which the Sand Market has spent decades making commercially relevant. The market grew up around the ley convergence \u2014 vendors first, then traders, then mercenaries, then the Dune Baron, who saw the strategic value and started charging for it.\n\nEverything here has a price. Including passage through it.",
+      "text": "The ley lines run straight through the desert, which the Sand Market has spent decades making commercially relevant. The market grew up around the ley convergence — vendors first, then traders, then mercenaries, then the Dune Baron, who saw the strategic value and started charging for it.\n\nEverything here has a price. Including passage through it.",
       "image": "cutscenes/act10-intro-1.svg"
     },
     {
@@ -53,14 +53,14 @@
     },
     {
       "title": "THE MARKET ROUTE",
-      "text": "The ley lines converge beneath the market's central spire \u2014 the Dune Baron uses the energy surplus to power the lights, the forges, and the contract-binding seals that make his mercenary arrangements legally enforceable.\n\nYou need the convergence point. He isn't selling it.\n\nYou're going to take it. He'll probably factor this into his pricing for the next traveller.",
+      "text": "The ley lines converge beneath the market's central spire — the Dune Baron uses the energy surplus to power the lights, the forges, and the contract-binding seals that make his mercenary arrangements legally enforceable.\n\nYou need the convergence point. He isn't selling it.\n\nYou're going to take it. He'll probably factor this into his pricing for the next traveller.",
       "image": "cutscenes/act10-intro-3.svg"
     }
   ],
   "outro": [
     {
       "title": "THE DUNE BARON SETTLES",
-      "text": "The Dune Baron doesn't lose gracefully. He loses expensively \u2014 which means he calculates the cost of the outcome, determines it was within acceptable parameters, and files the result under 'resolved.'\n\nThe ley lines pulse through the market floor. The convergence point opens.\n\nHe's already thinking about what to charge the next person who shows up.",
+      "text": "The Dune Baron doesn't lose gracefully. He loses expensively — which means he calculates the cost of the outcome, determines it was within acceptable parameters, and files the result under 'resolved.'\n\nThe ley lines pulse through the market floor. The convergence point opens.\n\nHe's already thinking about what to charge the next person who shows up.",
       "image": "cutscenes/act10-outro-1.svg"
     },
     {
@@ -70,7 +70,7 @@
     },
     {
       "title": "THE GOLDEN COMPASS",
-      "text": "The Golden Compass sits warm in your palm \u2014 the Baron's personal navigation tool, used to track ley line convergences across the desert. It still points to them.\n\nIt also, apparently, makes you faster off the mark. The Baron claims he hadn't noticed that. You don't believe him.\n\nThe ley lines point on. The market recedes. The desert is, for once, quiet.",
+      "text": "The Golden Compass sits warm in your palm — the Baron's personal navigation tool, used to track ley line convergences across the desert. It still points to them.\n\nIt also, apparently, makes you faster off the mark. The Baron claims he hadn't noticed that. You don't believe him.\n\nThe ley lines point on. The market recedes. The desert is, for once, quiet.",
       "image": "cutscenes/act10-outro-3.svg"
     }
   ],
@@ -128,7 +128,7 @@
           [
             {
               "label": "Drink from the spring",
-              "consequence": "The water restores \u2014 healed 14 HP",
+              "consequence": "The water restores — healed 14 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 14
@@ -136,7 +136,7 @@
             },
             {
               "label": "Drink from the spring",
-              "consequence": "Something in it stings \u2014 lose 6 HP",
+              "consequence": "Something in it stings — lose 6 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 6
@@ -162,7 +162,7 @@
           [
             {
               "label": "Search the offering-stones",
-              "consequence": "Something useful left behind \u2014 uncommon card",
+              "consequence": "Something useful left behind — uncommon card",
               "effect": {
                 "type": "gainCard",
                 "rarity": "uncommon"
@@ -170,7 +170,7 @@
             },
             {
               "label": "Search the offering-stones",
-              "consequence": "Coins left as offerings \u2014 +22 crystals",
+              "consequence": "Coins left as offerings — +22 crystals",
               "effect": {
                 "type": "gainCrystals",
                 "amount": 22
@@ -187,7 +187,7 @@
           [
             {
               "label": "Fill your reserves",
-              "consequence": "The water heals on the road \u2014 healed 8 HP",
+              "consequence": "The water heals on the road — healed 8 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 8
@@ -332,7 +332,8 @@
         "Sandstorm",
         "Sand Wall",
         "Sand Wall"
-      ]
+      ],
+      "bossAI": "desert-elite"
     },
     "gold-standard": {
       "id": "gold-standard",
@@ -365,7 +366,8 @@
         "Sandstorm",
         "Sand Wall",
         "Sand Wall"
-      ]
+      ],
+      "bossAI": "desert-elite"
     },
     "sand-battery": {
       "id": "sand-battery",
@@ -431,7 +433,8 @@
         "Sandstorm",
         "Sand Wall",
         "Sand Wall"
-      ]
+      ],
+      "bossAI": "desert-elite"
     },
     "the-black-sands": {
       "id": "the-black-sands",
@@ -473,12 +476,12 @@
       "environment": "sand",
       "eventConfig": {
         "title": "The Mirage Cache",
-        "description": "A concealed depot in the dune face \u2014 the Baron's forces maintain several, and not all of them are decoys. This one is real. The lock is good but not insurmountable.",
+        "description": "A concealed depot in the dune face — the Baron's forces maintain several, and not all of them are decoys. This one is real. The lock is good but not insurmountable.",
         "pools": [
           [
             {
               "label": "Open the cache",
-              "consequence": "Weapons inside \u2014 rare card",
+              "consequence": "Weapons inside — rare card",
               "effect": {
                 "type": "gainCard",
                 "rarity": "rare"
@@ -486,7 +489,7 @@
             },
             {
               "label": "Open the cache",
-              "consequence": "Supplies \u2014 healed 15 HP",
+              "consequence": "Supplies — healed 15 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 15
@@ -494,7 +497,7 @@
             },
             {
               "label": "Open the cache",
-              "consequence": "It was a decoy \u2014 lose 12 HP",
+              "consequence": "It was a decoy — lose 12 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 12
@@ -520,7 +523,7 @@
             },
             {
               "label": "Sell the contents",
-              "consequence": "One item worth keeping \u2014 uncommon card",
+              "consequence": "One item worth keeping — uncommon card",
               "effect": {
                 "type": "gainCard",
                 "rarity": "uncommon"
@@ -569,7 +572,8 @@
         "Sandstorm",
         "Sand Wall",
         "Sand Wall"
-      ]
+      ],
+      "bossAI": "desert-elite"
     },
     "baron-approach": {
       "id": "baron-approach",
@@ -617,12 +621,12 @@
       "environment": "sand",
       "eventConfig": {
         "title": "The Baron's Ledger",
-        "description": "The Dune Baron's transaction records \u2014 every contract, every sale, every mercenary hired and dismissed since the market was established. His notes on the Fracture are in here. He logged it as a business disruption.",
+        "description": "The Dune Baron's transaction records — every contract, every sale, every mercenary hired and dismissed since the market was established. His notes on the Fracture are in here. He logged it as a business disruption.",
         "pools": [
           [
             {
               "label": "Study the contracts",
-              "consequence": "Exploitable intel \u2014 rare card",
+              "consequence": "Exploitable intel — rare card",
               "effect": {
                 "type": "gainCard",
                 "rarity": "rare"
@@ -630,7 +634,7 @@
             },
             {
               "label": "Study the contracts",
-              "consequence": "Supply chain map \u2014 +28 crystals",
+              "consequence": "Supply chain map — +28 crystals",
               "effect": {
                 "type": "gainCrystals",
                 "amount": 28
@@ -640,7 +644,7 @@
           [
             {
               "label": "Rest in the records room",
-              "consequence": "Quiet and warm \u2014 healed 15 HP",
+              "consequence": "Quiet and warm — healed 15 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 15
@@ -702,7 +706,8 @@
         "Gold Standard",
         "Mercenary Pact",
         "Sandstorm"
-      ]
+      ],
+      "bossAI": "desert-elite"
     },
     "dunebaron": {
       "id": "dunebaron",
@@ -839,7 +844,8 @@
         "Gold Standard",
         "Mercenary Pact",
         "Sandstorm"
-      ]
+      ],
+      "bossAI": "desert-elite"
     },
     "node-1777060884035": {
       "id": "node-1777060884035",

--- a/web/src/data/acts/act11.json
+++ b/web/src/data/acts/act11.json
@@ -43,34 +43,34 @@
   "intro": [
     {
       "title": "THE VERDANT CANOPY",
-      "text": "The ley lines rise into the high canopy here, threading through root systems older than memory. The forest above the treeline moves differently. It doesn't react to you \u2014 it notices you.\n\nThe Elder Warden has kept this canopy since before the Fracture. It has watched dozens of expeditions attempt passage. None returned changed for the better.",
+      "text": "The ley lines rise into the high canopy here, threading through root systems older than memory. The forest above the treeline moves differently. It doesn't react to you — it notices you.\n\nThe Elder Warden has kept this canopy since before the Fracture. It has watched dozens of expeditions attempt passage. None returned changed for the better.",
       "image": "cutscenes/act11-intro-1.svg"
     },
     {
       "title": "THE ELDER WARDEN",
-      "text": "It is not a creature in any familiar sense. The Warden is the canopy made sovereign \u2014 a convergence of root and memory and something older that has no name in any language you speak.\n\nIt does not hate you. Hatred requires noticing something as a peer. The Warden sees you as disruption. Disruptions are removed.",
+      "text": "It is not a creature in any familiar sense. The Warden is the canopy made sovereign — a convergence of root and memory and something older that has no name in any language you speak.\n\nIt does not hate you. Hatred requires noticing something as a peer. The Warden sees you as disruption. Disruptions are removed.",
       "image": "cutscenes/act11-intro-2.svg"
     },
     {
       "title": "THE PATH THROUGH",
-      "text": "The ley convergence runs through the ancient heartwood at the canopy's centre. Scholars have theorised about it for decades. None have gotten close enough to verify.\n\nYou will need to fight through layers of living defence \u2014 root walls, grove-spawned treants, flying watchers \u2014 before the Warden descends. And then you will need to convince it, by force, that disruption can be useful.",
+      "text": "The ley convergence runs through the ancient heartwood at the canopy's centre. Scholars have theorised about it for decades. None have gotten close enough to verify.\n\nYou will need to fight through layers of living defence — root walls, grove-spawned treants, flying watchers — before the Warden descends. And then you will need to convince it, by force, that disruption can be useful.",
       "image": "cutscenes/act11-intro-3.svg"
     }
   ],
   "outro": [
     {
       "title": "THE CANOPY YIELDS",
-      "text": "The Elder Warden does not fall. It withdraws \u2014 slowly, deliberately, as though choosing to end the engagement rather than being forced to. The distinction matters to it.\n\nThe ley convergence is exposed. The heartwood pulses with calm energy, older than anything you've touched before.",
+      "text": "The Elder Warden does not fall. It withdraws — slowly, deliberately, as though choosing to end the engagement rather than being forced to. The distinction matters to it.\n\nThe ley convergence is exposed. The heartwood pulses with calm energy, older than anything you've touched before.",
       "image": "cutscenes/act11-outro-1.svg"
     },
     {
       "title": "LIVING BARK",
-      "text": "Where the Warden stood, a strip of bark remains \u2014 thick, warm to the touch, and inexplicably alive. It hardens in your hands into something like armour, or maybe a shield, or maybe just the canopy saying: you've earned a layer of protection.\n\nYou don't question it. The canopy rewards results.",
+      "text": "Where the Warden stood, a strip of bark remains — thick, warm to the touch, and inexplicably alive. It hardens in your hands into something like armour, or maybe a shield, or maybe just the canopy saying: you've earned a layer of protection.\n\nYou don't question it. The canopy rewards results.",
       "image": "cutscenes/act11-outro-2.svg"
     },
     {
       "title": "THE ROAD AHEAD",
-      "text": "The Verdant Canopy recedes behind you as you descend. Above, you hear the canopy resume its ordinary rhythms \u2014 something enormous moving between branches, watchers returning to their posts.\n\nThe Warden is already repairing the damage. It won't hold a grudge. It's too old for that. It will simply be ready when you return.",
+      "text": "The Verdant Canopy recedes behind you as you descend. Above, you hear the canopy resume its ordinary rhythms — something enormous moving between branches, watchers returning to their posts.\n\nThe Warden is already repairing the damage. It won't hold a grudge. It's too old for that. It will simply be ready when you return.",
       "image": "cutscenes/act11-outro-3.svg"
     }
   ],
@@ -120,7 +120,7 @@
       ],
       "eventConfig": {
         "title": "The Root Shrine",
-        "description": "A gnarled shrine wrapped in glowing roots. You can feel something ancient in it. The options it presents are simple \u2014 give something, take something, or leave it alone.",
+        "description": "A gnarled shrine wrapped in glowing roots. You can feel something ancient in it. The options it presents are simple — give something, take something, or leave it alone.",
         "pools": [
           [
             {
@@ -277,7 +277,7 @@
       ],
       "eventConfig": {
         "title": "The Canopy Rift",
-        "description": "A gap in the ancient canopy shows the raw ley lines beneath \u2014 shimmering, strange, and old. You can attempt to draw on them, or simply study them from a safe distance.",
+        "description": "A gap in the ancient canopy shows the raw ley lines beneath — shimmering, strange, and old. You can attempt to draw on them, or simply study them from a safe distance.",
         "pools": [
           [
             {
@@ -362,7 +362,8 @@
         "Root Surge",
         "Root Network",
         "Canopy Growth"
-      ]
+      ],
+      "bossAI": "verdant-elite"
     },
     "heartwood-path": {
       "id": "heartwood-path",
@@ -410,7 +411,7 @@
       ],
       "eventConfig": {
         "title": "The Warden's Gaze",
-        "description": "You feel it before you see it \u2014 a presence older than stone watching from the high branches. It hasn't moved. It's waiting to see what you do. Your choice here will define what follows.",
+        "description": "You feel it before you see it — a presence older than stone watching from the high branches. It hasn't moved. It's waiting to see what you do. Your choice here will define what follows.",
         "pools": [
           [
             {
@@ -509,7 +510,8 @@
         "Root Surge",
         "Root Network",
         "Canopy Growth"
-      ]
+      ],
+      "bossAI": "verdant-elite"
     },
     "elder-warden": {
       "id": "elder-warden",

--- a/web/src/data/acts/act12.json
+++ b/web/src/data/acts/act12.json
@@ -43,17 +43,17 @@
   "intro": [
     {
       "title": "THE SHATTERED COAST",
-      "text": "The Shattered Coast was once a thriving port city \u2014 before the Fracture split it across seven separate shards.\n\nNow the channels between shards are controlled by a single authority: the Harbormaster. Nothing moves without his iron seal. No cargo. No people. No information.",
+      "text": "The Shattered Coast was once a thriving port city — before the Fracture split it across seven separate shards.\n\nNow the channels between shards are controlled by a single authority: the Harbormaster. Nothing moves without his iron seal. No cargo. No people. No information.",
       "image": "cutscenes/act12-intro-1.svg"
     },
     {
       "title": "THE HARBORMASTER",
-      "text": "He was a port inspector once, before the Fracture. Now he is something else \u2014 a man who discovered that chaos could be administered, and administration could be power.\n\nHis fleet patrols the shattered channels. His flags are the only law. The wreck divers answer to him. The storm hawks circle his flagship.",
+      "text": "He was a port inspector once, before the Fracture. Now he is something else — a man who discovered that chaos could be administered, and administration could be power.\n\nHis fleet patrols the shattered channels. His flags are the only law. The wreck divers answer to him. The storm hawks circle his flagship.",
       "image": "cutscenes/act12-intro-2.svg"
     },
     {
       "title": "NO PERMIT",
-      "text": "You don't have his permit. You don't intend to get one.\n\nThe coast is the only route forward, and the Harbormaster blocks it. Fight through his patrols, his reef wardens, his iron anchorage \u2014 and put an end to the toll.",
+      "text": "You don't have his permit. You don't intend to get one.\n\nThe coast is the only route forward, and the Harbormaster blocks it. Fight through his patrols, his reef wardens, his iron anchorage — and put an end to the toll.",
       "image": "cutscenes/act12-intro-3.svg"
     }
   ],
@@ -65,7 +65,7 @@
     },
     {
       "title": "SALVAGE HOOK",
-      "text": "Among the wreckage, half-buried in sand, you find a salvage hook \u2014 the symbol of passage along this coast. It's old. Pre-Fracture. It means something.\n\nYou pocket it. The channels open around you.",
+      "text": "Among the wreckage, half-buried in sand, you find a salvage hook — the symbol of passage along this coast. It's old. Pre-Fracture. It means something.\n\nYou pocket it. The channels open around you.",
       "image": "cutscenes/act12-outro-2.svg"
     },
     {
@@ -327,7 +327,8 @@
         "Riptide",
         "Storm Surge",
         "Wreck Golem"
-      ]
+      ],
+      "bossAI": "tidal-elite"
     },
     "stormwall": {
       "id": "stormwall",
@@ -437,7 +438,7 @@
       "id": "iron-anchorage",
       "type": "elite",
       "label": "Iron Anchorage",
-      "description": "The Harbormaster's advance guard \u2014 iron-hulled and merciless.",
+      "description": "The Harbormaster's advance guard — iron-hulled and merciless.",
       "row": 4,
       "col": 3,
       "rowCols": 4,
@@ -455,7 +456,8 @@
         "Maelstrom",
         "Stormgate",
         "Wreck Patch"
-      ]
+      ],
+      "bossAI": "tidal-elite"
     },
     "the-harbormaster-node": {
       "id": "the-harbormaster-node",

--- a/web/src/data/acts/act13.json
+++ b/web/src/data/acts/act13.json
@@ -43,12 +43,12 @@
   "intro": [
     {
       "title": "THE CLOCKWORK VAULTS",
-      "text": "Deep beneath the shattered earth, the Clockwork Vaults hum with ancient machinery \u2014 built before the Fracture by an artificer order that no longer exists.\n\nThe Grand Automaton maintains it all. Has maintained it for two hundred years. No one knows if it was told to stop.",
+      "text": "Deep beneath the shattered earth, the Clockwork Vaults hum with ancient machinery — built before the Fracture by an artificer order that no longer exists.\n\nThe Grand Automaton maintains it all. Has maintained it for two hundred years. No one knows if it was told to stop.",
       "image": "cutscenes/act13-intro-1.svg"
     },
     {
       "title": "THE GRAND AUTOMATON",
-      "text": "It is not hostile. Hostility implies intent. The Automaton simply optimises \u2014 calculating minimum-force resolutions for all threats to vault integrity.\n\nYou are a threat to vault integrity.",
+      "text": "It is not hostile. Hostility implies intent. The Automaton simply optimises — calculating minimum-force resolutions for all threats to vault integrity.\n\nYou are a threat to vault integrity.",
       "image": "cutscenes/act13-intro-2.svg"
     },
     {
@@ -65,7 +65,7 @@
     },
     {
       "title": "GEAR HEART",
-      "text": "Amid the cooling machinery, you find a small gear-shaped crystal \u2014 the Automaton's drive core, still faintly warm.\n\nA fitting trophy. It pulses with each heartbeat.",
+      "text": "Amid the cooling machinery, you find a small gear-shaped crystal — the Automaton's drive core, still faintly warm.\n\nA fitting trophy. It pulses with each heartbeat.",
       "image": "cutscenes/act13-outro-2.svg"
     },
     {
@@ -327,7 +327,8 @@
         "Drone Array",
         "Overload",
         "Overcharge"
-      ]
+      ],
+      "bossAI": "iron-elite"
     },
     "core-approach": {
       "id": "core-approach",
@@ -357,7 +358,7 @@
       "id": "repair-bay",
       "type": "rest",
       "label": "Salvaged Repair Bay",
-      "description": "Abandoned repair alcove \u2014 still functional.",
+      "description": "Abandoned repair alcove — still functional.",
       "row": 3,
       "col": 3,
       "rowCols": 4,
@@ -455,7 +456,8 @@
         "Overload",
         "Vault Guardian",
         "Overcharge"
-      ]
+      ],
+      "bossAI": "iron-elite"
     },
     "the-grand-automaton-node": {
       "id": "the-grand-automaton-node",

--- a/web/src/data/acts/act2.json
+++ b/web/src/data/acts/act2.json
@@ -666,7 +666,8 @@
         "Sharpen Blades"
       ],
       "opponentIntervalMs": 6000,
-      "opponentBaseHp": 82
+      "opponentBaseHp": 82,
+      "bossAI": "iron-elite"
     },
     "command-tent": {
       "id": "command-tent",
@@ -868,15 +869,25 @@
       "opponentIntervalMs": 5000,
       "opponentBaseHp": 95,
       "enemyDeck": [
-        "Stone Wall","Stone Wall","Stone Wall","Stone Wall",
-        "Catapult","Catapult","Catapult",
-        "Knight","Knight","Knight",
-        "Shield Guard","Shield Guard",
-        "Ballista","Ballista",
+        "Stone Wall",
+        "Stone Wall",
+        "Stone Wall",
+        "Stone Wall",
+        "Catapult",
+        "Catapult",
+        "Catapult",
+        "Knight",
+        "Knight",
+        "Knight",
+        "Shield Guard",
+        "Shield Guard",
+        "Ballista",
+        "Ballista",
         "Siege Works",
         "War Drums",
         "Fortify",
-        "Crossbow","Crossbow"
+        "Crossbow",
+        "Crossbow"
       ]
     },
     "citadel-crossing": {
@@ -931,7 +942,8 @@
         "Gallows",
         "Execution Post",
         "Execution Post"
-      ]
+      ],
+      "bossAI": "iron-elite"
     },
     "node-1776114718648": {
       "id": "node-1776114718648",

--- a/web/src/data/acts/act3.json
+++ b/web/src/data/acts/act3.json
@@ -687,7 +687,8 @@
         "\"I was a healer, before. The Wastes found that funny.\""
       ],
       "opponentIntervalMs": 5000,
-      "opponentBaseHp": 165
+      "opponentBaseHp": 165,
+      "bossAI": "ashen-elite"
     },
     "cursed-altar": {
       "id": "cursed-altar",
@@ -860,7 +861,8 @@
         "\"The Dominion is gone. My orders are not.\""
       ],
       "opponentIntervalMs": 7000,
-      "opponentBaseHp": 105
+      "opponentBaseHp": 105,
+      "bossAI": "ashen-elite"
     },
     "ashwalker": {
       "id": "ashwalker",

--- a/web/src/data/acts/act4.json
+++ b/web/src/data/acts/act4.json
@@ -678,7 +678,8 @@
         "Arcane Tower",
         "Iron Skin",
         "Iron Skin"
-      ]
+      ],
+      "bossAI": "arcane-elite"
     },
     "arcanist-champion": {
       "id": "arcanist-champion",
@@ -715,7 +716,8 @@
         "Build Wall",
         "Build Wall",
         "Iron Skin"
-      ]
+      ],
+      "bossAI": "arcane-elite"
     },
     "golem-forge": {
       "id": "golem-forge",

--- a/web/src/data/acts/act5.json
+++ b/web/src/data/acts/act5.json
@@ -420,7 +420,8 @@
         "Deep Resilience",
         "Deep Resilience",
         "Pearl Power"
-      ]
+      ],
+      "bossAI": "tidal-elite"
     },
     "kelp-crossing": {
       "id": "kelp-crossing",
@@ -561,7 +562,8 @@
         "Deep Resilience",
         "Current Mastery",
         "Pearl Power"
-      ]
+      ],
+      "bossAI": "tidal-elite"
     },
     "tidal-sovereign": {
       "id": "tidal-sovereign",

--- a/web/src/data/acts/act6.json
+++ b/web/src/data/acts/act6.json
@@ -412,7 +412,8 @@
         "Wind Surge",
         "Aerial Volley",
         "Feather Step"
-      ]
+      ],
+      "bossAI": "sky-elite"
     },
     "upper-platform": {
       "id": "upper-platform",
@@ -545,7 +546,8 @@
         "Wind Surge",
         "Wind Surge",
         "Feather Step"
-      ]
+      ],
+      "bossAI": "sky-elite"
     },
     "cloudmarshal": {
       "id": "cloudmarshal",

--- a/web/src/data/acts/act7.json
+++ b/web/src/data/acts/act7.json
@@ -413,7 +413,8 @@
         "Smelted Blade",
         "Smelted Blade",
         "Volcanic Hide"
-      ]
+      ],
+      "bossAI": "sky-elite"
     },
     "caldera-gate": {
       "id": "caldera-gate",
@@ -546,7 +547,8 @@
         "Smelted Blade",
         "Volcanic Hide",
         "Volcanic Hide"
-      ]
+      ],
+      "bossAI": "sky-elite"
     },
     "cinderwarlord": {
       "id": "cinderwarlord",

--- a/web/src/data/acts/act8.json
+++ b/web/src/data/acts/act8.json
@@ -415,7 +415,8 @@
         "Mycelium Surge",
         "Mycelium Surge",
         "Deep Growth"
-      ]
+      ],
+      "bossAI": "fungal-elite"
     },
     "queen-approach": {
       "id": "queen-approach",
@@ -548,7 +549,8 @@
         "Mycelium Surge",
         "Deep Growth",
         "Deep Growth"
-      ]
+      ],
+      "bossAI": "fungal-elite"
     },
     "rootqueen": {
       "id": "rootqueen",
@@ -729,7 +731,8 @@
         "Mycelium Surge",
         "Mycelium Surge",
         "Deep Growth"
-      ]
+      ],
+      "bossAI": "fungal-elite"
     },
     "node-1776872007977": {
       "id": "node-1776872007977",
@@ -762,7 +765,8 @@
         "Mycelium Surge",
         "Deep Growth",
         "Deep Growth"
-      ]
+      ],
+      "bossAI": "fungal-elite"
     },
     "node-1776872032924": {
       "id": "node-1776872032924",
@@ -1160,7 +1164,8 @@
         "Mycelium Surge",
         "Mycelium Surge",
         "Deep Growth"
-      ]
+      ],
+      "bossAI": "fungal-elite"
     },
     "node-1776872152088": {
       "id": "node-1776872152088",

--- a/web/src/data/acts/act9.json
+++ b/web/src/data/acts/act9.json
@@ -411,7 +411,8 @@
         "Permafrost",
         "Ice Wall",
         "Ice Wall"
-      ]
+      ],
+      "bossAI": "iron-elite"
     },
     "engine-approach": {
       "id": "engine-approach",
@@ -543,7 +544,8 @@
         "Glacier Hide",
         "Blizzard Blast",
         "Blizzard Blast"
-      ]
+      ],
+      "bossAI": "iron-elite"
     },
     "paleengine": {
       "id": "paleengine",
@@ -747,7 +749,8 @@
         "Permafrost",
         "Ice Wall",
         "Ice Wall"
-      ]
+      ],
+      "bossAI": "iron-elite"
     },
     "node-1776873661402": {
       "id": "node-1776873661402",

--- a/web/src/data/acts/actfinale.json
+++ b/web/src/data/acts/actfinale.json
@@ -39,12 +39,12 @@
   "intro": [
     {
       "title": "THE FRACTURED CORE",
-      "text": "You have crossed thirteen shards, faced their champions, and collected their secrets. The path has always led here \u2014 to the wound at the world's heart.\n\nThe Fracture Event tore reality apart and scattered the Dominion into pieces. Something caused it. Something remains at the centre.",
+      "text": "You have crossed thirteen shards, faced their champions, and collected their secrets. The path has always led here — to the wound at the world's heart.\n\nThe Fracture Event tore reality apart and scattered the Dominion into pieces. Something caused it. Something remains at the centre.",
       "image": "cutscenes/actfinale-intro-1.svg"
     },
     {
       "title": "THE FORCE WITHIN",
-      "text": "The Fractured Core does not feel like a place. It feels like the absence of one \u2014 a scar where the world used to be whole.\n\nThe entity within has no name. No origin. It simply is the fracture, given will and hunger.",
+      "text": "The Fractured Core does not feel like a place. It feels like the absence of one — a scar where the world used to be whole.\n\nThe entity within has no name. No origin. It simply is the fracture, given will and hunger.",
       "image": "cutscenes/actfinale-intro-2.svg"
     },
     {
@@ -56,7 +56,7 @@
   "outro": [
     {
       "title": "THE FRACTURE CLOSES",
-      "text": "The entity shudders. Writhes. And then \u2014 for the first time since the cataclysm \u2014 something at the heart of the world goes quiet.\n\nThe wound begins to close.",
+      "text": "The entity shudders. Writhes. And then — for the first time since the cataclysm — something at the heart of the world goes quiet.\n\nThe wound begins to close.",
       "image": "cutscenes/actfinale-outro-1.svg"
     },
     {
@@ -144,7 +144,7 @@
       "id": "fractures-herald",
       "type": "elite",
       "label": "The Fracture's Herald",
-      "description": "A projection of the Fracture itself \u2014 testing your limits before the end.",
+      "description": "A projection of the Fracture itself — testing your limits before the end.",
       "row": 3,
       "col": 0,
       "rowCols": 1,
@@ -162,13 +162,14 @@
         "Titan Forge",
         "Overload",
         "Temporal Loop"
-      ]
+      ],
+      "bossAI": "void-elite"
     },
     "the-fracture-node": {
       "id": "the-fracture-node",
       "type": "boss",
       "label": "The Fracture",
-      "description": "The source of the cataclysm. The end of the world \u2014 or yours.",
+      "description": "The source of the cataclysm. The end of the world — or yours.",
       "row": 4,
       "col": 0,
       "rowCols": 1,

--- a/web/src/data/bossAIs.json
+++ b/web/src/data/bossAIs.json
@@ -717,16 +717,16 @@
     "trait": {
       "name": "Root Surge",
       "implemented": true,
-      "trigger": "hp_pct_once",
+      "trigger": "hp_pct",
       "triggerHpPct": 50,
-      "type": "aoe_column",
+      "type": "column_aoe",
       "description": "At 50% HP the Elder Warden drives its roots into the earth, sending a shockwave along a random column. All player units in that column take 6 damage and are rooted (movement stopped) for 3 seconds.",
       "mechanics": {
-        "damage": 6,
-        "rootDurationMs": 3000,
-        "columnWidth": 60
+        "pulseDamage": 6,
+        "stunDurationMs": 3000
       },
-      "announceText": "THE ELDER WARDEN PLUNGES ITS ROOTS \u2014 the ground trembles!"
+      "announceText": "THE ELDER WARDEN PLUNGES ITS ROOTS \u2014 the ground trembles!",
+      "fireText": "The roots tear through the column \u2014 units are rooted!"
     },
     "phases": [
       {
@@ -822,10 +822,18 @@
     ],
     "trait": {
       "name": "Tidal Surge",
-      "type": "aoe_row",
       "implemented": true,
-      "triggerCondition": "playerBaseHpBelow50Pct",
-      "description": "At 50% HP, surges a wall of water across the front row, dealing 10 damage to all player units."
+      "trigger": "hp_pct",
+      "triggerHpPct": 50,
+      "type": "fly",
+      "description": "At 50% HP the Harbormaster calls the tide — he vanishes for 2.5 seconds then a wall of water crashes across the battlefield, dealing 10 damage to all player units and pushing them back 2 tiles.",
+      "mechanics": {
+        "invulnerableDurationMs": 2500,
+        "waveDamage": 10,
+        "wavePushTiles": 2
+      },
+      "announceText": "The Harbormaster calls the tide — BRACE YOURSELF!",
+      "surfaceText": "A wall of water crashes across the battlefield!"
     },
     "phases": [
       {
@@ -903,10 +911,17 @@
     ],
     "trait": {
       "name": "Gear Cascade",
-      "type": "aoe_column",
       "implemented": true,
-      "triggerCondition": "playerBaseHpBelow50Pct",
-      "description": "At 50% HP, releases a cascade of gears that deal 8 damage in a column AOE, slowing hit units for 3 seconds."
+      "trigger": "hp_pct",
+      "triggerHpPct": 50,
+      "type": "column_aoe",
+      "description": "At 50% HP the Grand Automaton releases a cascade of spinning gears down a random column, dealing 8 damage to all player units in that column and slowing their attacks for 3 seconds.",
+      "mechanics": {
+        "pulseDamage": 8,
+        "slowDurationMs": 3000
+      },
+      "announceText": "GEAR CASCADE INITIATED — the Automaton releases its payload!",
+      "fireText": "Gears shred through the column — units slow to a crawl!"
     },
     "phases": [
       {
@@ -915,22 +930,20 @@
         },
         "priorities": [
           {
-            "type": "structure",
-            "subType": "spawn",
-            "order": "first"
+            "cardType": "structure",
+            "structureEffect": "spawn"
           },
           {
-            "type": "structure",
-            "subType": "mana",
-            "order": "first"
+            "cardType": "structure",
+            "structureEffect": "mana"
           },
           {
-            "type": "unit",
-            "order": "cost_desc"
+            "cardType": "unit",
+            "isWall": false,
+            "sortBy": "cost_desc"
           },
           {
-            "type": "upgrade",
-            "order": "first"
+            "cardType": "upgrade"
           }
         ]
       },
@@ -941,17 +954,16 @@
         },
         "priorities": [
           {
-            "type": "unit",
-            "order": "cost_desc"
+            "cardType": "unit",
+            "isWall": false,
+            "sortBy": "cost_desc"
           },
           {
-            "type": "structure",
-            "subType": "spawn",
-            "order": "first"
+            "cardType": "structure",
+            "structureEffect": "spawn"
           },
           {
-            "type": "upgrade",
-            "order": "first"
+            "cardType": "upgrade"
           }
         ],
         "announceOnce": "ESCALATING TO THREAT LEVEL: MAXIMUM."
@@ -963,17 +975,16 @@
         "announceOnce": "ACTIVATING FINAL PROTOCOL. VAULT WILL NOT FALL.",
         "priorities": [
           {
-            "type": "unit",
-            "order": "cost_desc"
+            "cardType": "unit",
+            "isWall": false,
+            "sortBy": "cost_desc"
           },
           {
-            "type": "structure",
-            "subType": "spawn",
-            "order": "first"
+            "cardType": "structure",
+            "structureEffect": "spawn"
           },
           {
-            "type": "upgrade",
-            "order": "first"
+            "cardType": "upgrade"
           }
         ]
       }
@@ -988,6 +999,23 @@
       "THE FRACTURE awakens. The wound at the world's heart tears open.",
       "This is the end. Yours, or the Fracture's."
     ],
+    "trait": {
+      "name": "Void Tear",
+      "implemented": true,
+      "trigger": "hp_pct_multi",
+      "triggerHpPcts": [65, 35],
+      "type": "fly",
+      "description": "At 65% and again at 35% HP, the Fracture tears open a void rift and vanishes for 4 seconds. It then crashes back down onto the player's densest cluster, dealing 8 AOE damage in a 3-tile radius and silencing all hit units for 2 seconds.",
+      "mechanics": {
+        "invulnerableDurationMs": 4000,
+        "landingDamage": 8,
+        "landingRadiusTiles": 3,
+        "stunDurationMs": 2000,
+        "repositionTarget": "player_densest_cluster"
+      },
+      "announceText": "THE FRACTURE TEARS OPEN \u2014 reality dissolves around you!",
+      "landText": "Reality SNAPS back \u2014 the void shockwave tears through your ranks!"
+    },
     "phases": [
       {
         "condition": {
@@ -1044,6 +1072,343 @@
           {
             "cardType": "upgrade"
           }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "verdant-elite",
+    "intervalMs": 5000,
+    "idleMessage": "The forest watches…",
+    "maxPlaysPerTurn": 2,
+    "openingLog": [
+      "An elite guardian of the Verdant Shard blocks the path.",
+      "The roots run deep here."
+    ],
+    "trait": {
+      "name": "Burrow Strike",
+      "implemented": true,
+      "trigger": "hp_pct",
+      "triggerHpPct": 50,
+      "type": "burrow",
+      "description": "At 50% HP the guardian sinks underground then erupts at a random position, dealing 4 AOE damage.",
+      "mechanics": {
+        "invulnerableDurationMs": 2000,
+        "landingDamage": 4,
+        "landingRadiusTiles": 2,
+        "repositionTarget": "random"
+      },
+      "announceText": "The guardian sinks into the earth!",
+      "surfaceText": "The ground erupts beneath your feet!"
+    },
+    "phases": [
+      {
+        "condition": {
+          "gameTimeLt": 30000
+        },
+        "priorities": [
+          { "cardType": "structure", "isWall": true },
+          { "cardType": "structure", "structureEffect": "spawn" },
+          { "cardType": "unit", "isWall": false, "sortBy": "cost_asc" },
+          { "cardType": "upgrade" }
+        ]
+      },
+      {
+        "condition": null,
+        "priorities": [
+          { "cardType": "unit", "isWall": false, "sortBy": "cost_desc" },
+          { "cardType": "upgrade" },
+          { "cardType": "structure", "structureEffect": "spawn" }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "iron-elite",
+    "intervalMs": 5200,
+    "idleMessage": "The iron line holds…",
+    "maxPlaysPerTurn": 2,
+    "openingLog": [
+      "An elite Iron Citadel commander bars your advance.",
+      "Expect walls and siege fire."
+    ],
+    "trait": {
+      "name": "Iron Leap",
+      "implemented": true,
+      "trigger": "periodic",
+      "triggerIntervalMs": 35000,
+      "type": "jump_aoe",
+      "description": "Every 35 seconds the commander leaps and crashes down on the player's side, dealing 6 AOE damage and stunning nearby units for 1.5 seconds.",
+      "mechanics": {
+        "invulnerableDurationMs": 1500,
+        "landingDamage": 6,
+        "landingRadiusTiles": 2,
+        "stunDurationMs": 1500,
+        "landingTarget": "player_side_random"
+      },
+      "announceText": "Iron might descends upon you!",
+      "landText": "CRASH — the iron shockwave hits!"
+    },
+    "phases": [
+      {
+        "condition": null,
+        "priorities": [
+          { "cardType": "structure", "isWall": true },
+          { "cardType": "unit", "isWall": false, "sortBy": "cost_desc" },
+          { "cardType": "upgrade" },
+          { "cardType": "structure", "structureEffect": "spawn" }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "ashen-elite",
+    "intervalMs": 4800,
+    "idleMessage": "The ash whispers…",
+    "maxPlaysPerTurn": 2,
+    "openingLog": [
+      "An Ashen Wastes champion rises from the cinders.",
+      "The dead don't tire."
+    ],
+    "trait": {
+      "name": "Ash Wave",
+      "implemented": true,
+      "trigger": "hp_pct",
+      "triggerHpPct": 40,
+      "type": "fly",
+      "description": "At 40% HP the champion disperses into ash for 2 seconds, then a choking wave deals 3 damage to all player units and pushes them back.",
+      "mechanics": {
+        "invulnerableDurationMs": 2000,
+        "waveDamage": 3,
+        "wavePushTiles": 2
+      },
+      "announceText": "The Ashen champion disperses into dust!",
+      "surfaceText": "Ash and bone rain down — your units are pushed back!"
+    },
+    "phases": [
+      {
+        "condition": null,
+        "priorities": [
+          { "cardType": "unit", "isWall": false, "sortBy": "cost_asc" },
+          { "cardType": "structure", "structureEffect": "spawn" },
+          { "cardType": "upgrade" }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "arcane-elite",
+    "intervalMs": 5000,
+    "idleMessage": "The wards pulse…",
+    "maxPlaysPerTurn": 2,
+    "openingLog": [
+      "A Crystal Spire sentinel activates its ward protocols.",
+      "Arcane constructs and silence await."
+    ],
+    "trait": {
+      "name": "Arcane Silence",
+      "implemented": true,
+      "trigger": "game_time_gte",
+      "triggerGameTimeMs": 60000,
+      "type": "fly",
+      "description": "60 seconds into the fight the sentinel ascends for 3 seconds then descends at the battlefield centre, silencing all player units for 2 seconds.",
+      "mechanics": {
+        "invulnerableDurationMs": 3000,
+        "landingDamage": 0,
+        "landingRadiusTiles": 20,
+        "stunDurationMs": 2000,
+        "repositionTarget": "battlefield_centre"
+      },
+      "announceText": "The arcane sentinel reaches full power — silence descends!",
+      "landText": "Arcane silence! Your units are stunned!"
+    },
+    "phases": [
+      {
+        "condition": null,
+        "priorities": [
+          { "cardType": "structure", "structureEffect": "spawn" },
+          { "cardType": "unit", "isWall": false, "sortBy": "cost_desc" },
+          { "cardType": "upgrade", "sortBy": "cost_desc" }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "tidal-elite",
+    "intervalMs": 4800,
+    "idleMessage": "The tide rises…",
+    "maxPlaysPerTurn": 2,
+    "openingLog": [
+      "A Sunken Reef champion surges from the depths.",
+      "The reef provides cover for its waves."
+    ],
+    "trait": {
+      "name": "Riptide",
+      "implemented": true,
+      "trigger": "hp_pct",
+      "triggerHpPct": 50,
+      "type": "fly",
+      "description": "At 50% HP the champion dives under for 2 seconds then a wave crashes down, dealing 4 damage to all player units and pushing them back 2 tiles.",
+      "mechanics": {
+        "invulnerableDurationMs": 2000,
+        "waveDamage": 4,
+        "wavePushTiles": 2
+      },
+      "announceText": "A riptide surges — the wave is incoming!",
+      "surfaceText": "The wave CRASHES — all units pushed back!"
+    },
+    "phases": [
+      {
+        "condition": null,
+        "priorities": [
+          { "cardType": "unit", "flying": true, "sortBy": "cost_desc" },
+          { "cardType": "structure", "structureEffect": "spawn" },
+          { "cardType": "unit", "isWall": false, "sortBy": "cost_desc" },
+          { "cardType": "upgrade" }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "sky-elite",
+    "intervalMs": 4800,
+    "idleMessage": "Wings beat overhead…",
+    "maxPlaysPerTurn": 2,
+    "openingLog": [
+      "A Sky Dominion ace drops from the clouds.",
+      "Aerial and fast — keep your ranged units ready."
+    ],
+    "trait": {
+      "name": "Lightning Column",
+      "implemented": true,
+      "trigger": "periodic",
+      "triggerIntervalMs": 40000,
+      "type": "column_aoe",
+      "description": "Every 40 seconds the ace calls a lightning strike down a random column, dealing 5 damage and slowing hit units for 3 seconds.",
+      "mechanics": {
+        "pulseDamage": 5,
+        "slowDurationMs": 3000
+      },
+      "announceText": "Lightning strikes from above!",
+      "fireText": "A bolt of sky energy scorches the column!"
+    },
+    "phases": [
+      {
+        "condition": null,
+        "priorities": [
+          { "cardType": "unit", "flying": true, "sortBy": "cost_desc" },
+          { "cardType": "unit", "isWall": false, "sortBy": "cost_desc" },
+          { "cardType": "upgrade" },
+          { "cardType": "structure", "structureEffect": "spawn" }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "fungal-elite",
+    "intervalMs": 5000,
+    "idleMessage": "Spores drift through the air…",
+    "maxPlaysPerTurn": 2,
+    "openingLog": [
+      "A Fungal Deep overseer emerges from the mycelium.",
+      "The spore network is everywhere."
+    ],
+    "trait": {
+      "name": "Spore Burst",
+      "implemented": true,
+      "trigger": "periodic",
+      "triggerIntervalMs": 45000,
+      "type": "column_aoe",
+      "description": "Every 45 seconds the overseer erupts a spore column, dealing 4 damage to all units in the column and slowing them for 4 seconds.",
+      "mechanics": {
+        "pulseDamage": 4,
+        "slowDurationMs": 4000
+      },
+      "announceText": "Spores burst from the elite!",
+      "fireText": "Units caught in the spore cloud slow to a crawl!"
+    },
+    "phases": [
+      {
+        "condition": null,
+        "priorities": [
+          { "cardType": "unit", "isWall": false, "costLt": 3, "sortBy": "cost_asc" },
+          { "cardType": "structure", "structureEffect": "spawn" },
+          { "cardType": "unit", "isWall": false, "sortBy": "cost_desc" },
+          { "cardType": "upgrade" }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "desert-elite",
+    "intervalMs": 4800,
+    "idleMessage": "The sand shifts…",
+    "maxPlaysPerTurn": 2,
+    "openingLog": [
+      "A Scorched Expanse warlord strides from the dunes.",
+      "Fast and relentless — the desert does not tire."
+    ],
+    "trait": {
+      "name": "Sand Strike",
+      "implemented": true,
+      "trigger": "hp_pct",
+      "triggerHpPct": 50,
+      "type": "burrow",
+      "description": "At 50% HP the warlord dives into sand for 2 seconds then erupts next to the player's highest-HP unit, dealing 4 AOE damage.",
+      "mechanics": {
+        "invulnerableDurationMs": 2000,
+        "landingDamage": 4,
+        "landingRadiusTiles": 2,
+        "repositionTarget": "nearest_player_highest_hp"
+      },
+      "announceText": "The warlord vanishes into the sand!",
+      "surfaceText": "Sand erupts — the warlord strikes from below!"
+    },
+    "phases": [
+      {
+        "condition": null,
+        "priorities": [
+          { "cardType": "unit", "isWall": false, "costGte": 3, "sortBy": "cost_desc" },
+          { "cardType": "upgrade" },
+          { "cardType": "structure", "structureEffect": "spawn" },
+          { "cardType": "unit", "isWall": false }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "void-elite",
+    "intervalMs": 5000,
+    "idleMessage": "The void whispers…",
+    "maxPlaysPerTurn": 2,
+    "openingLog": [
+      "A herald of the Fracture blocks your path to the core.",
+      "It carries a shard of the void."
+    ],
+    "trait": {
+      "name": "Void Pulse",
+      "implemented": true,
+      "trigger": "hp_pct",
+      "triggerHpPct": 60,
+      "type": "fly",
+      "description": "At 60% HP the herald tears a void rift and vanishes for 3 seconds, then crashes down onto the player's densest cluster dealing 6 AOE damage and silencing units for 2 seconds.",
+      "mechanics": {
+        "invulnerableDurationMs": 3000,
+        "landingDamage": 6,
+        "landingRadiusTiles": 2,
+        "stunDurationMs": 2000,
+        "repositionTarget": "player_densest_cluster"
+      },
+      "announceText": "A void rift tears open around the herald!",
+      "landText": "The void pulse detonates — your units are silenced!"
+    },
+    "phases": [
+      {
+        "condition": null,
+        "priorities": [
+          { "cardType": "unit", "isWall": false, "sortBy": "cost_desc" },
+          { "cardType": "structure", "structureEffect": "spawn" },
+          { "cardType": "upgrade" }
         ]
       }
     ]

--- a/web/src/game/engine/bossTraits.ts
+++ b/web/src/game/engine/bossTraits.ts
@@ -66,6 +66,28 @@ function applyTraitAOE(
   if (hit > 0) log.push(`${hit} unit(s) caught in the blast!`)
 }
 
+// ─── Column AOE ───────────────────────────────────────────
+
+function fireColumnAOE(s: GameState, trait: BossTraitDef, log: string[]): void {
+  const dmg      = trait.mechanics.pulseDamage ?? 6
+  const colX     = 90 + Math.random() * 320
+  const bandWidth = 25
+  const slowMs   = trait.mechanics.slowDurationMs ?? 4000
+  const stunMs   = trait.mechanics.stunDurationMs
+  log.push('!!' + trait.announceText)
+  let hit = 0
+  for (const u of s.field) {
+    if (u.owner !== 'player' || u.hp <= 0) continue
+    if (Math.abs(u.x - colX) > bandWidth) continue
+    u.hp = Math.max(0, u.hp - dmg)
+    u.attackTimer = Math.max(u.attackTimer, slowMs)
+    if (stunMs) { u.stunTimer = stunMs; u.attackTimer = Math.max(u.attackTimer, stunMs) }
+    hit++
+  }
+  if (trait.fireText) log.push(trait.fireText)
+  if (hit > 0) log.push(`${hit} unit(s) hit by the pulse!`)
+}
+
 // ─── Split trait ──────────────────────────────────────────
 
 function fireSplitTrait(s: GameState, trait: BossTraitDef, log: string[]): void {
@@ -201,21 +223,7 @@ export function tickBossTrait(s: GameState, log: string[]): void {
     if (s.gameTime >= interval && s.gameTime - ts.lastTraitFireMs >= interval && ts.landingAtMs === undefined) {
       ts.lastTraitFireMs = s.gameTime
       if (trait.type === 'column_aoe') {
-        const dmg      = trait.mechanics.pulseDamage ?? 6
-        const colX     = 90 + Math.random() * 320
-        const bandWidth = 25
-        const slowMs   = trait.mechanics.slowDurationMs ?? 4000
-        log.push('!!' + trait.announceText)
-        let hit = 0
-        for (const u of s.field) {
-          if (u.owner !== 'player' || u.hp <= 0) continue
-          if (Math.abs(u.x - colX) > bandWidth) continue
-          u.hp = Math.max(0, u.hp - dmg)
-          u.attackTimer = Math.max(u.attackTimer, slowMs)
-          hit++
-        }
-        if (trait.fireText) log.push(trait.fireText)
-        if (hit > 0) log.push(`${hit} unit(s) hit by the pulse!`)
+        fireColumnAOE(s, trait, log)
       } else {
         fireInvulnerableLaunch(s, trait, ts, log)
       }
@@ -236,6 +244,7 @@ export function tickBossTrait(s: GameState, log: string[]): void {
     if (hpPct <= trait.triggerHpPct && !ts.firedThresholds.includes(trait.triggerHpPct)) {
       ts.firedThresholds.push(trait.triggerHpPct)
       if (trait.type === 'split') fireSplitTrait(s, trait, log)
+      else if (trait.type === 'column_aoe') fireColumnAOE(s, trait, log)
       else                        fireInvulnerableLaunch(s, trait, ts, log)
     }
   }
@@ -244,7 +253,8 @@ export function tickBossTrait(s: GameState, log: string[]): void {
     for (const threshold of trait.triggerHpPcts) {
       if (hpPct <= threshold && !ts.firedThresholds.includes(threshold) && ts.landingAtMs === undefined) {
         ts.firedThresholds.push(threshold)
-        fireInvulnerableLaunch(s, trait, ts, log)
+        if (trait.type === 'column_aoe') fireColumnAOE(s, trait, log)
+        else fireInvulnerableLaunch(s, trait, ts, log)
         break
       }
     }


### PR DESCRIPTION
## Summary

- **Bug fix:** 3 boss traits (Elder Warden, Harbormaster, Grand Automaton) had incorrect JSON structure and never fired — corrected trigger values, type names, and mechanics field names
- **Bug fix:** Grand Automaton's AI phases used a broken priority format (`type/subType/order`) that caused the AI to play nothing — rewritten to correct `cardType/structureEffect/sortBy` format
- **Enhancement:** Added Void Tear trait to The Fracture (fires at 65% and 35% HP — the final boss now has a dramatic mid-fight ability)
- **Feature (#903):** 9 themed elite commander AI entries added; all 35 elite nodes across Acts 1–13 and Finale now run a boss AI with a mid-fight trait ability

## Trait fixes in detail

| Boss | Was | Now |
|---|---|---|
| Elder Warden | `trigger: "hp_pct_once"`, `type: "aoe_column"` — unsupported values | `trigger: "hp_pct"`, `type: "column_aoe"` — roots units for 3s |
| Harbormaster | No trigger field, `type: "aoe_row"` — never ran | `trigger: "hp_pct"`, `type: "fly"` with `waveDamage`/`wavePushTiles` — tidal wave hits all units |
| Grand Automaton | No trigger field, wrong priority format | `trigger: "hp_pct"`, `type: "column_aoe"` — gear cascade slows units |
| The Fracture | No trait | `hp_pct_multi` at 65%/35%, fly type — void tear, AOE + silence |

## Engine change (`bossTraits.ts`)

- Extracted `fireColumnAOE()` helper from the periodic branch
- `hp_pct` and `hp_pct_multi` branches now also support `column_aoe` type
- `fireColumnAOE` respects `stunDurationMs` for root/silence effects

## Test plan

- [ ] Play an Act 11 boss fight — Elder Warden should plunge roots at 50% HP (column rooted)
- [ ] Play an Act 12 boss fight — Harbormaster should call the tide at 50% HP (all units pushed back + 10 dmg)
- [ ] Play an Act 13 boss fight — Grand Automaton should fire gear cascade at 50% HP (column slowed)
- [ ] Play the Finale boss fight — The Fracture should tear a void rift at 65% and 35% HP
- [ ] Play any elite node — opening log, boss AI card strategy, and trait fire mid-fight
- [ ] Build passes clean ✅

https://claude.ai/code/session_01VaCDhECLyMVPxCU4UMXCmS

---
_Generated by [Claude Code](https://claude.ai/code/session_01VaCDhECLyMVPxCU4UMXCmS)_