### PR TITLE
Defend stance: spread defenders and overflow 5 attackers when ≥15 defending

### DIFF
--- a/web/src/game/engine/units.ts
+++ b/web/src/game/engine/units.ts
@@ -32,6 +32,23 @@ export function moveUnits(s: GameState, deltaMs: number): void {
   const livingOpponentUnits = s.field.some(u => u.owner === 'opponent' && u.hp > 0)
   const livingPlayerUnits   = s.field.some(u => u.owner === 'player'   && u.hp > 0)
 
+  // Defend overflow: if ≥15 defenders, the 5 furthest-forward units charge instead.
+  const defendOverflowAttackers = new Set<string>()
+  if (stance === 'defend') {
+    const defenders = s.field.filter(
+      u => u.owner === 'player' && u.hp > 0 && u.moveSpeed > 0 &&
+           (u.spawnGrowTimer == null || u.spawnGrowTimer <= 0) &&
+           (u.stunTimer      == null || u.stunTimer      <= 0)
+    )
+    if (defenders.length >= 15) {
+      defenders.sort((a, b) => b.x - a.x)
+      defenders.slice(0, 5).forEach(u => defendOverflowAttackers.add(u.id))
+    }
+  }
+
+  // Y positions defenders spread across so they don't all converge on a single point.
+  const DEFEND_Y_SLOTS = [-64, -40, -20, 0, 20, 40, 64]
+
   for (const unit of s.field) {
     if (unit.moveSpeed === 0) continue
     if (unit.spawnGrowTimer != null && unit.spawnGrowTimer > 0) continue
@@ -67,10 +84,11 @@ export function moveUnits(s: GameState, deltaMs: number): void {
       }
     }
 
-    // Defend: pull back toward the player spawn area
-    if (unit.owner === 'player' && stance === 'defend') {
+    // Defend: pull back toward spawn, spread across Y slots; overflow units charge forward.
+    if (unit.owner === 'player' && stance === 'defend' && !defendOverflowAttackers.has(unit.id)) {
+      const idNum = parseInt(unit.id.replace(/\D/g, ''), 10) || 0
       tx = PLAYER_SPAWN_X + 40
-      ty = 0
+      ty = DEFEND_Y_SLOTS[idNum % DEFEND_Y_SLOTS.length]
       hasTarget = false
     }
 


### PR DESCRIPTION
## Summary

Follow-up to the stance buttons feature — fixes two issues with Defend mode that made it unplayable at scale:

- **Y spread**: defenders now fan out across 7 Y slots (`-64, -40, -20, 0, 20, 40, 64`) keyed off their unit ID, so they don't all converge on the same point and cause a traffic jam.
- **Overflow rule**: before each tick, if 15+ player units are defending, the 5 furthest-forward (highest X) are skipped from the defend override and charge as normal attackers. This keeps the defensive blob at ~10 units while the rest continue pushing.

## Test plan

- [ ] Enter Defend stance with a large army (15+ units); confirm they spread out along Y rather than stacking
- [ ] Once 15 defenders accumulate, confirm 5 of the most-advanced units break off and attack
- [ ] Dropping below 15 defenders stops the overflow (all remaining units defend)
- [ ] Game performance remains normal with large armies in defend mode

https://claude.ai/code/session_01VaCDhECLyMVPxCU4UMXCmS

---
_Generated by [Claude Code](https://claude.ai/code/session_01VaCDhECLyMVPxCU4UMXCmS)_