### PR TITLE
fix(sprites): use card name for upgrade sprites, fall back to type-generic

### DIFF
--- a/web/src/components/CardTile.tsx
+++ b/web/src/components/CardTile.tsx
@@ -175,7 +175,7 @@ export function CardTile({ card, canAfford = true, disabled = false, onClick, lo
         {card.unit
           ? <SpriteImg name={card.unit.name} className="card-sprite" />
           : card.upgradeEffect
-            ? <SpriteImg name={UPGRADE_SPRITE[card.upgradeEffect.type] ?? 'upgrade'} className="card-sprite" />
+            ? <SpriteImg name={card.name} fallbackName={UPGRADE_SPRITE[card.upgradeEffect.type] ?? 'upgrade'} className="card-sprite" />
             : null
         }
       </div>

--- a/web/src/components/SpriteImg.tsx
+++ b/web/src/components/SpriteImg.tsx
@@ -44,19 +44,23 @@ function EightbitCanvas({ src, alt, className }: { src: string; alt: string; cla
 interface Props {
   /** Unit or building name — used to derive the sprite slug. */
   name: string
+  /** Optional secondary name to try if the primary name has no sprite file. */
+  fallbackName?: string
   className?: string
 }
 
 /**
  * Tries to load `sprites/{slug}.png`, then `sprites/{slug}.svg`, then
- * `sprites/fallback.svg`. Renders nothing only if all three fail.
+ * `sprites/{fallbackSlug}.svg` (if fallbackName provided), then
+ * `sprites/fallback.svg`. Renders nothing only if all fail.
  * In 8-bit mode renders via a low-res canvas for a pixelated look.
  */
-export function SpriteImg({ name, className }: Props) {
-  const slug        = spriteSlug(name)
-  const pngSrc      = `${BASE}sprites/${slug}.png`
-  const svgSrc      = `${BASE}sprites/${slug}.svg`
-  const fallbackSrc = `${BASE}sprites/fallback.svg`
+export function SpriteImg({ name, fallbackName, className }: Props) {
+  const slug            = spriteSlug(name)
+  const pngSrc          = `${BASE}sprites/${slug}.png`
+  const svgSrc          = `${BASE}sprites/${slug}.svg`
+  const fallbackNameSrc = fallbackName ? `${BASE}sprites/${spriteSlug(fallbackName)}.svg` : null
+  const genericSrc      = `${BASE}sprites/fallback.svg`
 
   const [src,     setSrc]     = useState(pngSrc)
   const [loaded,  setLoaded]  = useState(false)
@@ -84,7 +88,8 @@ export function SpriteImg({ name, className }: Props) {
       onLoad={() => setLoaded(true)}
       onError={() => {
         if (src === pngSrc) setSrc(svgSrc)
-        else if (src === svgSrc) setSrc(fallbackSrc)
+        else if (src === svgSrc) setSrc(fallbackNameSrc ?? genericSrc)
+        else if (fallbackNameSrc && src === fallbackNameSrc) setSrc(genericSrc)
         else setFailed(true)
       }}
     />


### PR DESCRIPTION
## Summary

- `SpriteImg` gains an optional `fallbackName` prop. The resolution chain is now: `{name}.png` → `{name}.svg` → `{fallbackName}.svg` → `fallback.svg`
- `CardTile` now passes `card.name` as the primary sprite lookup for upgrade cards, with the existing type-generic slug (`upgrade-attack`, `upgrade-speed`, etc.) as the fallback

Previously, upgrade cards with unmapped effect types (e.g. `aoe` — Maelstrom, Salvage Charge) silently showed nothing because `UPGRADE_SPRITE['aoe']` is undefined, causing a lookup for `upgrade.svg` which doesn't exist. The 36 per-card SVGs added in #993 were also never being used.

## Test plan
- [ ] Open collection screen — Maelstrom, Salvage Charge, and other AOE-type cards should now show their individual sprites
- [ ] Cards with `buffAttack`/`buffSpeed`/etc. types should still show their type-generic sprite if no individual card sprite exists
- [ ] No cards should show a broken/empty sprite slot that previously showed one

https://claude.ai/code/session_01TWFNogtCtcNR4qd2ZbxCCx

---
_Generated by [Claude Code](https://claude.ai/code/session_01TWFNogtCtcNR4qd2ZbxCCx)_