### PR TITLE
fix(sprites): use card name for upgrade sprites, fall back to type-generic

### DIFF
--- a/web/src/components/CardTile.tsx
+++ b/web/src/components/CardTile.tsx
@@ -175,7 +175,7 @@ export function CardTile({ card, canAfford = true, disabled = false, onClick, lo
         {card.unit
           ? <SpriteImg name={card.unit.name} className="card-sprite" />
           : card.upgradeEffect
-            ? <SpriteImg name={UPGRADE_SPRITE[card.upgradeEffect.type] ?? 'upgrade'} className="card-sprite" />
+            ? <SpriteImg name={card.name} fallbackName={UPGRADE_SPRITE[card.upgradeEffect.type] ?? 'upgrade'} className="card-sprite" />
             : null
         }
       </div>

--- a/web/src/components/SpriteImg.tsx
+++ b/web/src/components/SpriteImg.tsx
@@ -44,19 +44,23 @@ function EightbitCanvas({ src, alt, className }: { src: string; alt: string; cla
 interface Props {
   /** Unit or building name — used to derive the sprite slug. */
   name: string
+  /** Optional secondary name to try if the primary name has no sprite file. */
+  fallbackName?: string
   className?: string
 }
 
 /**
  * Tries to load `sprites/{slug}.png`, then `sprites/{slug}.svg`, then
- * `sprites/fallback.svg`. Renders nothing only if all three fail.
+ * `sprites/{fallbackSlug}.svg` (if fallbackName provided), then
+ * `sprites/fallback.svg`. Renders nothing only if all fail.
  * In 8-bit mode renders via a low-res canvas for a pixelated look.
  */
-export function SpriteImg({ name, className }: Props) {
-  const slug        = spriteSlug(name)
-  const pngSrc      = `${BASE}sprites/${slug}.png`
-  const svgSrc      = `${BASE}sprites/${slug}.svg`
-  const fallbackSrc = `${BASE}sprites/fallback.svg`
+export function SpriteImg({ name, fallbackName, className }: Props) {
+  const slug            = spriteSlug(name)
+  const pngSrc          = `${BASE}sprites/${slug}.png`
+  const svgSrc          = `${BASE}sprites/${slug}.svg`
+  const fallbackNameSrc = fallbackName ? `${BASE}sprites/${spriteSlug(fallbackName)}.svg` : null
+  const genericSrc      = `${BASE}sprites/fallback.svg`
 
   const [src,     setSrc]     = useState(pngSrc)
   const [loaded,  setLoaded]  = useState(false)
@@ -84,7 +88,8 @@ export function SpriteImg({ name, className }: Props) {
       onLoad={() => setLoaded(true)}
       onError={() => {
         if (src === pngSrc) setSrc(svgSrc)
-        else if (src === svgSrc) setSrc(fallbackSrc)
+        else if (src === svgSrc) setSrc(fallbackNameSrc ?? genericSrc)
+        else if (fallbackNameSrc && src === fallbackNameSrc) setSrc(genericSrc)
         else setFailed(true)
       }}
     />


### PR DESCRIPTION
## Summary

- `CardTile` was looking up upgrade sprites by effect type slug (e.g. `upgrade-attack.svg`) which skipped per-card SVGs entirely and showed nothing for any effect type not in `UPGRADE_SPRITE` (e.g. `aoe`)
- `SpriteImg` now accepts an optional `fallbackName` prop
- `CardTile` passes `card.name` as the primary lookup and the type-generic slug as the fallback, giving the resolution chain: `{cardName}.png → {cardName}.svg → {typeName}.svg → fallback.svg`

## Test plan

- [ ] Play a card of each upgrade type — sprite should load from the per-card SVG if present
- [ ] A card with no per-card SVG should fall back to the type-generic sprite (`upgrade-attack.svg` etc.)
- [ ] A card with no sprite at all should fall back to `fallback.svg`


---
_Generated by [Claude Code](https://claude.ai/code/session_01TWFNogtCtcNR4qd2ZbxCCx)_