### PR TITLE
feat(sprites): building SVGs batch 1/19 — Abyss Gate → Automaton Forge

### DIFF
--- a/web/public/sprites/abyss-gate.svg
+++ b/web/public/sprites/abyss-gate.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#1a0a2a" opacity="0.6"/>
+  <!-- Gate pillars -->
+  <rect x="2" y="8" width="6" height="22" rx="1" fill="#2a1a3a"/>
+  <rect x="24" y="8" width="6" height="22" rx="1" fill="#2a1a3a"/>
+  <!-- Pillar highlights -->
+  <rect x="2" y="8" width="2" height="22" fill="#3a2a4a"/>
+  <rect x="24" y="8" width="2" height="22" fill="#3a2a4a"/>
+  <!-- Pillar tops -->
+  <rect x="1" y="6" width="8" height="3" rx="1" fill="#3a2a4a"/>
+  <rect x="23" y="6" width="8" height="3" rx="1" fill="#3a2a4a"/>
+  <!-- Skull ornaments on top -->
+  <ellipse cx="5" cy="5" rx="3" ry="2.5" fill="#1a0a2a"/>
+  <ellipse cx="27" cy="5" rx="3" ry="2.5" fill="#1a0a2a"/>
+  <rect x="3.5" y="5" width="3" height="2" fill="#1a0a2a"/>
+  <rect x="25.5" y="5" width="3" height="2" fill="#1a0a2a"/>
+  <!-- Portal void in gate -->
+  <rect x="8" y="10" width="16" height="20" fill="#0d0010"/>
+  <!-- Swirling abyss energy -->
+  <ellipse cx="16" cy="20" rx="6" ry="8" fill="#1a0033" opacity="0.8"/>
+  <ellipse cx="16" cy="20" rx="4" ry="5.5" fill="#2a0055" opacity="0.7"/>
+  <ellipse cx="16" cy="20" rx="2.5" ry="3.5" fill="#4400aa" opacity="0.6"/>
+  <ellipse cx="16" cy="20" rx="1.2" ry="1.8" fill="#6600ff" opacity="0.8"/>
+  <!-- Portal swirl lines -->
+  <path d="M10,16 Q16,12 22,16" fill="none" stroke="#440088" stroke-width="0.8" opacity="0.7"/>
+  <path d="M10,20 Q16,15 22,20" fill="none" stroke="#5500aa" stroke-width="0.8" opacity="0.6"/>
+  <path d="M11,24 Q16,18 21,24" fill="none" stroke="#440088" stroke-width="0.8" opacity="0.5"/>
+  <!-- Gate arch -->
+  <path d="M8,10 Q16,4 24,10" fill="none" stroke="#3a2a4a" stroke-width="2"/>
+  <!-- Rune marks on pillars -->
+  <line x1="4" y1="14" x2="7" y2="14" stroke="#6600cc" stroke-width="0.8" opacity="0.8"/>
+  <line x1="4" y1="18" x2="7" y2="18" stroke="#6600cc" stroke-width="0.8" opacity="0.8"/>
+  <line x1="25" y1="14" x2="28" y2="14" stroke="#6600cc" stroke-width="0.8" opacity="0.8"/>
+  <line x1="25" y1="18" x2="28" y2="18" stroke="#6600cc" stroke-width="0.8" opacity="0.8"/>
+  <!-- Dark particles -->
+  <circle cx="12" cy="13" r="0.7" fill="#8844ff" opacity="0.7"/>
+  <circle cx="20" cy="15" r="0.7" fill="#6622dd" opacity="0.6"/>
+  <circle cx="14" cy="26" r="0.6" fill="#9955ff" opacity="0.5"/>
+</svg>

--- a/web/public/sprites/abyssal-crevasse.svg
+++ b/web/public/sprites/abyssal-crevasse.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground surface -->
+  <rect x="0" y="18" width="32" height="14" fill="#4a3a2a"/>
+  <rect x="0" y="18" width="32" height="3" fill="#5a4a3a"/>
+  <!-- Ground cracks radiating from crevasse -->
+  <line x1="16" y1="18" x2="5" y2="15" stroke="#2a1a0a" stroke-width="1"/>
+  <line x1="16" y1="18" x2="27" y2="14" stroke="#2a1a0a" stroke-width="1"/>
+  <line x1="16" y1="18" x2="8" y2="22" stroke="#2a1a0a" stroke-width="0.7"/>
+  <line x1="16" y1="18" x2="24" y2="23" stroke="#2a1a0a" stroke-width="0.7"/>
+  <!-- Crevasse opening -->
+  <path d="M6,18 Q10,14 16,12 Q22,14 26,18 Q22,20 16,22 Q10,20 6,18 Z" fill="#0a0510"/>
+  <!-- Depth layers -->
+  <ellipse cx="16" cy="18" rx="7" ry="4" fill="#0d0820"/>
+  <ellipse cx="16" cy="18" rx="5" ry="2.8" fill="#15083a"/>
+  <ellipse cx="16" cy="18" rx="3" ry="1.8" fill="#220055"/>
+  <ellipse cx="16" cy="18" rx="1.5" ry="1" fill="#4400aa"/>
+  <!-- Glowing abyss core -->
+  <ellipse cx="16" cy="18" rx="0.8" ry="0.5" fill="#8800ff" opacity="0.9"/>
+  <!-- Rock edges of crevasse -->
+  <path d="M6,18 Q10,14 16,12" fill="none" stroke="#3a2a1a" stroke-width="1.5"/>
+  <path d="M16,12 Q22,14 26,18" fill="none" stroke="#3a2a1a" stroke-width="1.5"/>
+  <!-- Rising dark mist -->
+  <ellipse cx="13" cy="15" rx="2" ry="1" fill="#220044" opacity="0.4"/>
+  <ellipse cx="19" cy="14" rx="2" ry="1" fill="#330055" opacity="0.3"/>
+  <ellipse cx="16" cy="12" rx="3" ry="1.5" fill="#2a0044" opacity="0.4"/>
+  <!-- Dark particles floating up -->
+  <circle cx="12" cy="11" r="0.8" fill="#6600cc" opacity="0.5"/>
+  <circle cx="18" cy="10" r="0.6" fill="#8822ee" opacity="0.4"/>
+  <circle cx="15" cy="9" r="0.5" fill="#5500aa" opacity="0.5"/>
+  <circle cx="21" cy="12" r="0.6" fill="#7700dd" opacity="0.4"/>
+  <!-- Broken rock chunks at edge -->
+  <polygon points="6,18 4,16 8,15 9,17" fill="#5a4a2a"/>
+  <polygon points="26,18 28,16 24,15 23,17" fill="#5a4a2a"/>
+</svg>

--- a/web/public/sprites/air-sanctum.svg
+++ b/web/public/sprites/air-sanctum.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="12" ry="1.5" fill="#5a7090" opacity="0.4"/>
+  <!-- Base platform -->
+  <rect x="3" y="25" width="26" height="5" rx="1" fill="#b0c8e8"/>
+  <rect x="3" y="25" width="26" height="2" fill="#c8dff5"/>
+  <!-- Columns -->
+  <rect x="5" y="12" width="4" height="15" fill="#c8dff5"/>
+  <rect x="13" y="10" width="4" height="17" fill="#d8eeff"/>
+  <rect x="21" y="12" width="4" height="15" fill="#c8dff5"/>
+  <!-- Column highlights -->
+  <rect x="5" y="12" width="1" height="15" fill="#e8f5ff"/>
+  <rect x="13" y="10" width="1" height="17" fill="#e8f5ff"/>
+  <rect x="21" y="12" width="1" height="15" fill="#e8f5ff"/>
+  <!-- Roof/dome -->
+  <ellipse cx="16" cy="10" rx="13" ry="4" fill="#b0c8e8"/>
+  <ellipse cx="16" cy="9" rx="11" ry="3" fill="#c8dff5"/>
+  <!-- Dome top -->
+  <ellipse cx="16" cy="6" rx="5" ry="3" fill="#d8eeff"/>
+  <ellipse cx="16" cy="5" rx="3" ry="2" fill="#e8f5ff"/>
+  <!-- Wind spire -->
+  <line x1="16" y1="3" x2="16" y2="0" stroke="#a0b8d8" stroke-width="1.5"/>
+  <ellipse cx="16" cy="0" rx="2" ry="1" fill="#b0c8e8"/>
+  <!-- Wind swirls around sanctum -->
+  <path d="M2,15 Q5,12 8,15 Q5,18 2,15" fill="none" stroke="#a0c0e0" stroke-width="1" opacity="0.6"/>
+  <path d="M24,13 Q27,10 30,13 Q27,16 24,13" fill="none" stroke="#a0c0e0" stroke-width="1" opacity="0.6"/>
+  <path d="M4,21 Q7,19 10,21" fill="none" stroke="#b0d0f0" stroke-width="0.8" opacity="0.5"/>
+  <path d="M22,21 Q25,19 28,21" fill="none" stroke="#b0d0f0" stroke-width="0.8" opacity="0.5"/>
+  <!-- Floating wind motes -->
+  <circle cx="8" cy="8" r="0.8" fill="#c8e0ff" opacity="0.7"/>
+  <circle cx="24" cy="7" r="0.8" fill="#c8e0ff" opacity="0.7"/>
+  <circle cx="6" cy="18" r="0.6" fill="#d0e8ff" opacity="0.6"/>
+  <circle cx="26" cy="17" r="0.6" fill="#d0e8ff" opacity="0.6"/>
+  <!-- Interior glow -->
+  <ellipse cx="16" cy="18" rx="5" ry="4" fill="#aac8ff" opacity="0.2"/>
+</svg>

--- a/web/public/sprites/ancient-spire.svg
+++ b/web/public/sprites/ancient-spire.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="9" ry="1.5" fill="#3a2a1a" opacity="0.5"/>
+  <!-- Base steps -->
+  <rect x="4" y="26" width="24" height="5" rx="1" fill="#7a6a4a"/>
+  <rect x="6" y="24" width="20" height="3" fill="#8a7a5a"/>
+  <rect x="8" y="22" width="16" height="3" fill="#7a6a4a"/>
+  <!-- Main tower body -->
+  <rect x="10" y="10" width="12" height="13" fill="#8a7a5a"/>
+  <rect x="10" y="10" width="12" height="3" fill="#9a8a6a"/>
+  <!-- Stone block detail -->
+  <line x1="10" y1="14" x2="22" y2="14" stroke="#6a5a3a" stroke-width="0.6"/>
+  <line x1="10" y1="17" x2="22" y2="17" stroke="#6a5a3a" stroke-width="0.6"/>
+  <line x1="10" y1="20" x2="22" y2="20" stroke="#6a5a3a" stroke-width="0.6"/>
+  <line x1="14" y1="10" x2="14" y2="22" stroke="#6a5a3a" stroke-width="0.6"/>
+  <line x1="18" y1="10" x2="18" y2="22" stroke="#6a5a3a" stroke-width="0.6"/>
+  <!-- Narrowing upper tower -->
+  <rect x="12" y="5" width="8" height="6" fill="#9a8a6a"/>
+  <rect x="12" y="5" width="8" height="2" fill="#aA9a7a"/>
+  <!-- Spire tip -->
+  <polygon points="16,0 20,5 12,5" fill="#6a5a3a"/>
+  <polygon points="16,0 18,5 14,5" fill="#8a7a5a"/>
+  <!-- Ancient glowing runes -->
+  <line x1="12" y1="15" x2="15" y2="15" stroke="#cc8800" stroke-width="0.8" opacity="0.8"/>
+  <line x1="12" y1="18" x2="15" y2="18" stroke="#cc8800" stroke-width="0.8" opacity="0.8"/>
+  <line x1="17" y1="15" x2="20" y2="15" stroke="#cc8800" stroke-width="0.8" opacity="0.7"/>
+  <line x1="13" y1="14" x2="13" y2="16" stroke="#cc8800" stroke-width="0.8" opacity="0.8"/>
+  <!-- Window slits -->
+  <rect x="14" y="12" width="4" height="2" fill="#2a1a0a"/>
+  <rect x="14" y="7" width="4" height="2" fill="#2a1a0a" opacity="0.8"/>
+  <!-- Glowing tip -->
+  <circle cx="16" cy="0" r="1.5" fill="#ffcc00" opacity="0.8"/>
+  <circle cx="16" cy="0" r="0.8" fill="#ffffff" opacity="0.9"/>
+  <!-- Magical aura -->
+  <ellipse cx="16" cy="0" rx="3" ry="2" fill="#ffaa00" opacity="0.2"/>
+  <!-- Ivy/age marks -->
+  <path d="M10,16 Q8,14 9,18 Q10,20 11,18" fill="#3a6a1a" opacity="0.5"/>
+  <path d="M22,14 Q24,12 23,16 Q22,18 21,16" fill="#3a6a1a" opacity="0.5"/>
+</svg>

--- a/web/public/sprites/ancient-spring.svg
+++ b/web/public/sprites/ancient-spring.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground -->
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#3a5020" opacity="0.5"/>
+  <!-- Mossy stone base ring -->
+  <ellipse cx="16" cy="26" rx="13" ry="4" fill="#5a6a3a"/>
+  <ellipse cx="16" cy="25" rx="12" ry="3.5" fill="#6a7a4a"/>
+  <!-- Stone wall of well -->
+  <rect x="4" y="16" width="24" height="11" rx="2" fill="#7a6a4a"/>
+  <rect x="4" y="16" width="24" height="3" fill="#8a7a5a"/>
+  <!-- Stone block lines -->
+  <line x1="4" y1="20" x2="28" y2="20" stroke="#5a4a2a" stroke-width="0.6"/>
+  <line x1="4" y1="23" x2="28" y2="23" stroke="#5a4a2a" stroke-width="0.6"/>
+  <line x1="10" y1="16" x2="10" y2="27" stroke="#5a4a2a" stroke-width="0.6"/>
+  <line x1="16" y1="16" x2="16" y2="27" stroke="#5a4a2a" stroke-width="0.6"/>
+  <line x1="22" y1="16" x2="22" y2="27" stroke="#5a4a2a" stroke-width="0.6"/>
+  <!-- Spring water surface -->
+  <ellipse cx="16" cy="16" rx="10" ry="3.5" fill="#2a6a8a"/>
+  <ellipse cx="16" cy="15.5" rx="9" ry="3" fill="#3a88aa"/>
+  <!-- Water shimmer -->
+  <ellipse cx="13" cy="14.5" rx="3" ry="1" fill="#5aaac8" opacity="0.5"/>
+  <ellipse cx="19" cy="15" rx="2" ry="0.8" fill="#6abbd8" opacity="0.4"/>
+  <!-- Water ripples -->
+  <ellipse cx="16" cy="15.5" rx="5" ry="1.5" fill="none" stroke="#4a99bb" stroke-width="0.6" opacity="0.7"/>
+  <ellipse cx="16" cy="15.5" rx="8" ry="2.5" fill="none" stroke="#3a88aa" stroke-width="0.5" opacity="0.5"/>
+  <!-- Ancient stone arch over spring -->
+  <path d="M4,16 Q16,4 28,16" fill="none" stroke="#6a5a3a" stroke-width="2.5"/>
+  <path d="M5,16 Q16,5 27,16" fill="none" stroke="#7a6a4a" stroke-width="1"/>
+  <!-- Keystone -->
+  <rect x="14" y="3" width="4" height="5" rx="1" fill="#8a7a5a"/>
+  <!-- Moss on stones -->
+  <path d="M4,18 Q6,16 7,19 Q5,21 4,19 Z" fill="#4a7a1a" opacity="0.6"/>
+  <path d="M25,18 Q27,16 28,19 Q26,21 25,19 Z" fill="#4a7a1a" opacity="0.6"/>
+  <!-- Glowing spring energy -->
+  <circle cx="16" cy="15" r="2" fill="#44aacc" opacity="0.3"/>
+  <circle cx="16" cy="15" r="1" fill="#66ccee" opacity="0.4"/>
+</svg>

--- a/web/public/sprites/angler-s-trench.svg
+++ b/web/public/sprites/angler-s-trench.svg
@@ -1,0 +1,43 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Water surface -->
+  <rect x="0" y="18" width="32" height="14" fill="#1a4a6a"/>
+  <rect x="0" y="18" width="32" height="3" fill="#2a6a8a"/>
+  <!-- Water ripples -->
+  <line x1="4" y1="21" x2="12" y2="21" stroke="#3a8aaa" stroke-width="0.8" opacity="0.6"/>
+  <line x1="20" y1="21" x2="28" y2="21" stroke="#3a8aaa" stroke-width="0.8" opacity="0.6"/>
+  <line x1="8" y1="24" x2="16" y2="24" stroke="#2a7090" stroke-width="0.6" opacity="0.5"/>
+  <line x1="18" y1="25" x2="26" y2="25" stroke="#2a7090" stroke-width="0.6" opacity="0.5"/>
+  <!-- Dark deep trench below water -->
+  <ellipse cx="16" cy="24" rx="8" ry="4" fill="#0a2030" opacity="0.7"/>
+  <ellipse cx="16" cy="25" rx="5" ry="3" fill="#050f1a" opacity="0.8"/>
+  <!-- Dock/platform structure -->
+  <rect x="2" y="14" width="28" height="5" rx="1" fill="#5a3a1a"/>
+  <rect x="2" y="14" width="28" height="2" fill="#7a5a2a"/>
+  <!-- Dock planks -->
+  <line x1="5" y1="14" x2="5" y2="19" stroke="#4a2a0a" stroke-width="0.8"/>
+  <line x1="9" y1="14" x2="9" y2="19" stroke="#4a2a0a" stroke-width="0.8"/>
+  <line x1="13" y1="14" x2="13" y2="19" stroke="#4a2a0a" stroke-width="0.8"/>
+  <line x1="17" y1="14" x2="17" y2="19" stroke="#4a2a0a" stroke-width="0.8"/>
+  <line x1="21" y1="14" x2="21" y2="19" stroke="#4a2a0a" stroke-width="0.8"/>
+  <line x1="25" y1="14" x2="25" y2="19" stroke="#4a2a0a" stroke-width="0.8"/>
+  <!-- Dock posts going into water -->
+  <rect x="4" y="15" width="2" height="8" fill="#3a2a0a"/>
+  <rect x="12" y="15" width="2" height="10" fill="#3a2a0a"/>
+  <rect x="20" y="15" width="2" height="10" fill="#3a2a0a"/>
+  <rect x="27" y="15" width="2" height="8" fill="#3a2a0a"/>
+  <!-- Fishing rod/equipment -->
+  <line x1="8" y1="4" x2="8" y2="14" stroke="#6a4a2a" stroke-width="1.5"/>
+  <line x1="8" y1="4" x2="18" y2="8" stroke="#6a4a2a" stroke-width="1"/>
+  <!-- Fishing line -->
+  <line x1="18" y1="8" x2="18" y2="22" stroke="#aaaaaa" stroke-width="0.5" opacity="0.6"/>
+  <!-- Fish hook glint in water -->
+  <circle cx="18" cy="22" r="0.8" fill="#cccccc" opacity="0.7"/>
+  <!-- Net hanging from dock -->
+  <path d="M21,14 L21,18 L27,18 L27,14" fill="none" stroke="#8a6a3a" stroke-width="0.5" opacity="0.7"/>
+  <line x1="23" y1="14" x2="23" y2="18" stroke="#8a6a3a" stroke-width="0.4" opacity="0.7"/>
+  <line x1="25" y1="14" x2="25" y2="18" stroke="#8a6a3a" stroke-width="0.4" opacity="0.7"/>
+  <line x1="21" y1="16" x2="27" y2="16" stroke="#8a6a3a" stroke-width="0.4" opacity="0.7"/>
+  <!-- Glowing lure bait in depths -->
+  <circle cx="14" cy="25" r="1" fill="#00ff88" opacity="0.5"/>
+  <circle cx="20" cy="27" r="0.7" fill="#00dd66" opacity="0.4"/>
+</svg>

--- a/web/public/sprites/archer-s-keep.svg
+++ b/web/public/sprites/archer-s-keep.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="12" ry="1.5" fill="#3a2a1a" opacity="0.5"/>
+  <!-- Keep base -->
+  <rect x="3" y="16" width="26" height="15" rx="1" fill="#7a6a4a"/>
+  <rect x="3" y="16" width="26" height="3" fill="#8a7a5a"/>
+  <!-- Stone blocks on base -->
+  <line x1="3" y1="20" x2="29" y2="20" stroke="#5a4a2a" stroke-width="0.6"/>
+  <line x1="3" y1="24" x2="29" y2="24" stroke="#5a4a2a" stroke-width="0.6"/>
+  <line x1="3" y1="28" x2="29" y2="28" stroke="#5a4a2a" stroke-width="0.6"/>
+  <line x1="9" y1="16" x2="9" y2="31" stroke="#5a4a2a" stroke-width="0.6"/>
+  <line x1="16" y1="16" x2="16" y2="31" stroke="#5a4a2a" stroke-width="0.6"/>
+  <line x1="23" y1="16" x2="23" y2="31" stroke="#5a4a2a" stroke-width="0.6"/>
+  <!-- Main tower -->
+  <rect x="9" y="5" width="14" height="12" fill="#8a7a5a"/>
+  <rect x="9" y="5" width="14" height="3" fill="#9a8a6a"/>
+  <!-- Tower stone detail -->
+  <line x1="9" y1="9" x2="23" y2="9" stroke="#6a5a3a" stroke-width="0.6"/>
+  <line x1="9" y1="12" x2="23" y2="12" stroke="#6a5a3a" stroke-width="0.6"/>
+  <line x1="13" y1="5" x2="13" y2="16" stroke="#6a5a3a" stroke-width="0.6"/>
+  <line x1="19" y1="5" x2="19" y2="16" stroke="#6a5a3a" stroke-width="0.6"/>
+  <!-- Battlements on tower -->
+  <rect x="9" y="2" width="3" height="4" fill="#8a7a5a"/>
+  <rect x="14" y="2" width="3" height="4" fill="#8a7a5a"/>
+  <rect x="19" y="2" width="3" height="4" fill="#8a7a5a"/>
+  <!-- Arrow slits on tower -->
+  <rect x="12" y="7" width="2" height="4" fill="#1a0a00" rx="1"/>
+  <rect x="18" y="7" width="2" height="4" fill="#1a0a00" rx="1"/>
+  <!-- Arrow slits on keep base -->
+  <rect x="6" y="19" width="2" height="3" fill="#1a0a00" rx="1"/>
+  <rect x="21" y="19" width="2" height="3" fill="#1a0a00" rx="1"/>
+  <!-- Gate door -->
+  <path d="M13,31 L13,24 Q16,21 19,24 L19,31 Z" fill="#2a1a0a"/>
+  <!-- Drawbridge chains -->
+  <line x1="13" y1="24" x2="8" y2="22" stroke="#6a5a3a" stroke-width="0.8"/>
+  <line x1="19" y1="24" x2="24" y2="22" stroke="#6a5a3a" stroke-width="0.8"/>
+  <!-- Banner/flag on tower -->
+  <line x1="16" y1="0" x2="16" y2="3" stroke="#5a4a2a" stroke-width="1"/>
+  <polygon points="16,0 23,1.5 16,3" fill="#aa2222"/>
+</svg>

--- a/web/public/sprites/ash-vortex.svg
+++ b/web/public/sprites/ash-vortex.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground scorched ring -->
+  <ellipse cx="16" cy="28" rx="13" ry="3" fill="#2a2020" opacity="0.7"/>
+  <ellipse cx="16" cy="28" rx="10" ry="2" fill="#3a2a2a" opacity="0.5"/>
+  <!-- Outer ash swirl - wide -->
+  <path d="M4,22 Q2,16 6,10 Q10,4 16,4 Q22,4 26,10 Q30,16 28,22" fill="none" stroke="#888080" stroke-width="2" opacity="0.4"/>
+  <!-- Mid ash swirl -->
+  <path d="M7,22 Q5,17 8,12 Q11,7 16,7 Q21,7 24,12 Q27,17 25,22" fill="none" stroke="#aaa0a0" stroke-width="1.5" opacity="0.5"/>
+  <!-- Inner swirl -->
+  <path d="M10,22 Q8,18 10,14 Q13,9 16,9 Q19,9 22,14 Q24,18 22,22" fill="none" stroke="#bbafaf" stroke-width="1" opacity="0.6"/>
+  <!-- Core vortex -->
+  <ellipse cx="16" cy="18" rx="5" ry="6" fill="#4a3a3a" opacity="0.6"/>
+  <ellipse cx="16" cy="18" rx="3.5" ry="4" fill="#5a4a4a" opacity="0.5"/>
+  <ellipse cx="16" cy="18" rx="2" ry="2.5" fill="#6a5a5a" opacity="0.6"/>
+  <ellipse cx="16" cy="18" rx="1" ry="1.5" fill="#888080" opacity="0.7"/>
+  <!-- Rotating ash particles outer ring -->
+  <circle cx="6" cy="14" r="1" fill="#9a9090" opacity="0.6"/>
+  <circle cx="26" cy="14" r="1" fill="#9a9090" opacity="0.6"/>
+  <circle cx="5" cy="22" r="0.8" fill="#aaa0a0" opacity="0.5"/>
+  <circle cx="27" cy="22" r="0.8" fill="#aaa0a0" opacity="0.5"/>
+  <circle cx="11" cy="6" r="0.8" fill="#9a9090" opacity="0.5"/>
+  <circle cx="21" cy="6" r="0.8" fill="#9a9090" opacity="0.5"/>
+  <!-- Inner particles -->
+  <circle cx="11" cy="15" r="0.7" fill="#bbb0b0" opacity="0.7"/>
+  <circle cx="21" cy="15" r="0.7" fill="#bbb0b0" opacity="0.7"/>
+  <circle cx="13" cy="23" r="0.6" fill="#ccbfbf" opacity="0.6"/>
+  <circle cx="19" cy="23" r="0.6" fill="#ccbfbf" opacity="0.6"/>
+  <!-- Ember glow in center -->
+  <circle cx="16" cy="18" r="1.5" fill="#ff6600" opacity="0.4"/>
+  <circle cx="16" cy="18" r="0.7" fill="#ff8800" opacity="0.6"/>
+  <!-- Ash streaks spinning -->
+  <line x1="8" y1="12" x2="11" y2="15" stroke="#aaa0a0" stroke-width="0.8" opacity="0.5"/>
+  <line x1="24" y1="12" x2="21" y2="15" stroke="#aaa0a0" stroke-width="0.8" opacity="0.5"/>
+  <line x1="9" y1="24" x2="12" y2="21" stroke="#aaa0a0" stroke-width="0.8" opacity="0.5"/>
+  <line x1="23" y1="24" x2="20" y2="21" stroke="#aaa0a0" stroke-width="0.8" opacity="0.5"/>
+</svg>

--- a/web/public/sprites/ashen-altar.svg
+++ b/web/public/sprites/ashen-altar.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground ash/dust -->
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#3a2a1a" opacity="0.4"/>
+  <!-- Altar base slab -->
+  <rect x="2" y="24" width="28" height="6" rx="1" fill="#5a4a3a"/>
+  <rect x="2" y="24" width="28" height="2" fill="#6a5a4a"/>
+  <!-- Ash covering base -->
+  <ellipse cx="16" cy="24" rx="12" ry="2" fill="#9a9090" opacity="0.3"/>
+  <!-- Altar table top -->
+  <rect x="4" y="18" width="24" height="7" rx="1" fill="#6a5a3a"/>
+  <rect x="4" y="18" width="24" height="2.5" fill="#7a6a4a"/>
+  <!-- Altar stone blocks -->
+  <line x1="4" y1="21" x2="28" y2="21" stroke="#4a3a1a" stroke-width="0.6"/>
+  <line x1="12" y1="18" x2="12" y2="25" stroke="#4a3a1a" stroke-width="0.6"/>
+  <line x1="20" y1="18" x2="20" y2="25" stroke="#4a3a1a" stroke-width="0.6"/>
+  <!-- Ash piles on altar surface -->
+  <ellipse cx="10" cy="18" rx="3" ry="1" fill="#9a9080" opacity="0.5"/>
+  <ellipse cx="22" cy="18" rx="3" ry="1" fill="#9a9080" opacity="0.5"/>
+  <ellipse cx="16" cy="18" rx="4" ry="1.2" fill="#aaa090" opacity="0.4"/>
+  <!-- Central charred bowl -->
+  <ellipse cx="16" cy="17.5" rx="4" ry="2" fill="#2a1a0a"/>
+  <ellipse cx="16" cy="17" rx="3" ry="1.5" fill="#1a0a00"/>
+  <!-- Smouldering embers -->
+  <ellipse cx="14" cy="17" rx="1.5" ry="0.7" fill="#cc4400" opacity="0.6"/>
+  <ellipse cx="18" cy="17" rx="1" ry="0.6" fill="#dd5500" opacity="0.5"/>
+  <circle cx="16" cy="16.5" rx="1" r="0.8" fill="#ff6600" opacity="0.7"/>
+  <!-- Rising ash smoke -->
+  <path d="M14,16 Q12,12 14,8 Q15,5 16,4" fill="none" stroke="#8a8078" stroke-width="1.5" opacity="0.5"/>
+  <path d="M16,16 Q17,11 15,7 Q14,4 15,2" fill="none" stroke="#9a9088" stroke-width="1.2" opacity="0.4"/>
+  <path d="M18,16 Q20,12 18,8 Q17,5 17,3" fill="none" stroke="#8a8078" stroke-width="1" opacity="0.4"/>
+  <!-- Ash cloud top -->
+  <ellipse cx="15" cy="4" rx="4" ry="2" fill="#9a9080" opacity="0.3"/>
+  <ellipse cx="16" cy="3" rx="3" ry="1.5" fill="#aaa090" opacity="0.25"/>
+  <!-- Bone/relic fragments on altar -->
+  <line x1="8" y1="19" x2="11" y2="17.5" stroke="#c0b0a0" stroke-width="0.8" opacity="0.6"/>
+  <line x1="23" y1="19" x2="21" y2="17.5" stroke="#c0b0a0" stroke-width="0.8" opacity="0.6"/>
+  <!-- Rune marks burned into stone -->
+  <line x1="6" y1="20" x2="9" y2="20" stroke="#cc4400" stroke-width="0.7" opacity="0.5"/>
+  <line x1="23" y1="20" x2="26" y2="20" stroke="#cc4400" stroke-width="0.7" opacity="0.5"/>
+</svg>

--- a/web/public/sprites/automaton-forge.svg
+++ b/web/public/sprites/automaton-forge.svg
@@ -1,0 +1,54 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#2a1a0a" opacity="0.5"/>
+  <!-- Forge base/foundation -->
+  <rect x="2" y="22" width="28" height="9" rx="1" fill="#4a3a2a"/>
+  <rect x="2" y="22" width="28" height="2" fill="#5a4a3a"/>
+  <!-- Main forge building -->
+  <rect x="4" y="12" width="24" height="11" fill="#5a5050"/>
+  <rect x="4" y="12" width="24" height="3" fill="#6a6060"/>
+  <!-- Metal panel lines -->
+  <line x1="4" y1="16" x2="28" y2="16" stroke="#3a3030" stroke-width="0.7"/>
+  <line x1="4" y1="19" x2="28" y2="19" stroke="#3a3030" stroke-width="0.7"/>
+  <line x1="10" y1="12" x2="10" y2="22" stroke="#3a3030" stroke-width="0.7"/>
+  <line x1="22" y1="12" x2="22" y2="22" stroke="#3a3030" stroke-width="0.7"/>
+  <!-- Rivets/bolts on panels -->
+  <circle cx="7" cy="14" r="0.7" fill="#7a7070"/>
+  <circle cx="13" cy="14" r="0.7" fill="#7a7070"/>
+  <circle cx="19" cy="14" r="0.7" fill="#7a7070"/>
+  <circle cx="25" cy="14" r="0.7" fill="#7a7070"/>
+  <circle cx="7" cy="20" r="0.7" fill="#7a7070"/>
+  <circle cx="25" cy="20" r="0.7" fill="#7a7070"/>
+  <!-- Forge chimney stacks -->
+  <rect x="6" y="5" width="5" height="8" fill="#4a4040"/>
+  <rect x="21" y="5" width="5" height="8" fill="#4a4040"/>
+  <!-- Chimney metal bands -->
+  <rect x="6" y="7" width="5" height="1" fill="#6a6060"/>
+  <rect x="6" y="10" width="5" height="1" fill="#6a6060"/>
+  <rect x="21" y="7" width="5" height="1" fill="#6a6060"/>
+  <rect x="21" y="10" width="5" height="1" fill="#6a6060"/>
+  <!-- Smoke/fire from chimneys -->
+  <ellipse cx="8.5" cy="4" rx="3" ry="2" fill="#3a3030" opacity="0.6"/>
+  <ellipse cx="8.5" cy="3" rx="2" ry="1.5" fill="#5a5050" opacity="0.5"/>
+  <ellipse cx="23.5" cy="4" rx="3" ry="2" fill="#3a3030" opacity="0.6"/>
+  <ellipse cx="23.5" cy="3" rx="2" ry="1.5" fill="#5a5050" opacity="0.5"/>
+  <!-- Fire glow from chimney tops -->
+  <circle cx="8.5" cy="5" r="2" fill="#ff6600" opacity="0.5"/>
+  <circle cx="8.5" cy="5" r="1" fill="#ffaa00" opacity="0.7"/>
+  <circle cx="23.5" cy="5" r="2" fill="#ff6600" opacity="0.5"/>
+  <circle cx="23.5" cy="5" r="1" fill="#ffaa00" opacity="0.7"/>
+  <!-- Furnace door (glowing) -->
+  <rect x="12" y="14" width="8" height="7" rx="1" fill="#1a0a00"/>
+  <rect x="13" y="15" width="6" height="5" rx="1" fill="#cc4400" opacity="0.8"/>
+  <rect x="14" y="16" width="4" height="3" rx="1" fill="#ff8800" opacity="0.7"/>
+  <ellipse cx="16" cy="17.5" rx="1.5" ry="1" fill="#ffcc00" opacity="0.8"/>
+  <!-- Gear on front panel -->
+  <circle cx="7" cy="17" r="2.5" fill="none" stroke="#6a6060" stroke-width="1"/>
+  <circle cx="7" cy="17" r="1" fill="#5a5050"/>
+  <line x1="7" y1="14" x2="7" y2="20" stroke="#6a6060" stroke-width="0.8"/>
+  <line x1="4" y1="17" x2="10" y2="17" stroke="#6a6060" stroke-width="0.8"/>
+  <circle cx="25" cy="17" r="2.5" fill="none" stroke="#6a6060" stroke-width="1"/>
+  <circle cx="25" cy="17" r="1" fill="#5a5050"/>
+  <line x1="25" y1="14" x2="25" y2="20" stroke="#6a6060" stroke-width="0.8"/>
+  <line x1="22" y1="17" x2="28" y2="17" stroke="#6a6060" stroke-width="0.8"/>
+</svg>


### PR DESCRIPTION
Adds 10 building SVG sprites for batch 1/19, closing #995.

## Buildings added

| Card | File |
|---|---|
| Abyss Gate | `abyss-gate.svg` — dark gate with swirling void portal |
| Abyssal Crevasse | `abyssal-crevasse.svg` — ground crack with glowing abyss depths |
| Air Sanctum | `air-sanctum.svg` — airy columned temple with wind swirls |
| Ancient Spring | `ancient-spring.svg` — mossy stone well with glowing water |
| Ancient Spire | `ancient-spire.svg` — tall rune-marked stone tower |
| Angler's Trench | `angler-s-trench.svg` — dock over dark water trench |
| Archer's Keep | `archer-s-keep.svg` — fortified keep with arrow slits and battlements |
| Ash Vortex | `ash-vortex.svg` — spinning ash funnel with ember core |
| Ashen Altar | `ashen-altar.svg` — charred altar with smouldering embers and smoke |
| Automaton Forge | `automaton-forge.svg` — metal forge with twin chimneys, gears and furnace |

## Test plan

- [ ] Each sprite visible in card collection view
- [ ] Each sprite visible in battle when the structure is placed


---
_Generated by [Claude Code](https://claude.ai/code/session_01TWFNogtCtcNR4qd2ZbxCCx)_