### PR TITLE
feat(sprites): building SVGs batch 2/19 — Ballista Works → Bloom Garden

### DIFF
--- a/web/public/sprites/ballista-works.svg
+++ b/web/public/sprites/ballista-works.svg
@@ -1,0 +1,37 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#3a2a1a" opacity="0.5"/>
+  <!-- Platform/fortification base -->
+  <rect x="2" y="22" width="28" height="9" rx="1" fill="#6a5a3a"/>
+  <rect x="2" y="22" width="28" height="2" fill="#7a6a4a"/>
+  <!-- Ballista frame legs -->
+  <line x1="8" y1="14" x2="6" y2="22" stroke="#5a3a1a" stroke-width="2.5"/>
+  <line x1="16" y1="12" x2="14" y2="22" stroke="#5a3a1a" stroke-width="2.5"/>
+  <line x1="16" y1="12" x2="18" y2="22" stroke="#5a3a1a" stroke-width="2.5"/>
+  <line x1="24" y1="14" x2="26" y2="22" stroke="#5a3a1a" stroke-width="2.5"/>
+  <!-- Cross braces -->
+  <line x1="6" y1="18" x2="14" y2="16" stroke="#7a5a2a" stroke-width="1.2"/>
+  <line x1="18" y1="16" x2="26" y2="18" stroke="#7a5a2a" stroke-width="1.2"/>
+  <!-- Main beam/trough -->
+  <rect x="4" y="12" width="24" height="4" rx="1" fill="#7a5a2a"/>
+  <rect x="4" y="12" width="24" height="2" fill="#9a7a3a"/>
+  <!-- Winch mechanism -->
+  <circle cx="6" cy="14" r="3" fill="none" stroke="#5a3a1a" stroke-width="1.2"/>
+  <circle cx="6" cy="14" r="1" fill="#5a3a1a"/>
+  <line x1="6" y1="11" x2="6" y2="17" stroke="#5a3a1a" stroke-width="0.8"/>
+  <line x1="3" y1="14" x2="9" y2="14" stroke="#5a3a1a" stroke-width="0.8"/>
+  <!-- Bowstring -->
+  <path d="M8,10 Q16,14 24,10" fill="none" stroke="#c0a060" stroke-width="1.2"/>
+  <!-- Large bolt/projectile loaded -->
+  <line x1="10" y1="14" x2="24" y2="14" stroke="#4a3a2a" stroke-width="2"/>
+  <polygon points="24,13 28,14 24,15" fill="#8a6a2a"/>
+  <!-- Fletching on bolt tail -->
+  <polygon points="10,12 13,14 10,16" fill="#8a2020"/>
+  <!-- Arrow slits in base -->
+  <rect x="6" y="23" width="2" height="3" fill="#3a2a0a" rx="1"/>
+  <rect x="14" y="23" width="2" height="3" fill="#3a2a0a" rx="1"/>
+  <rect x="22" y="23" width="2" height="3" fill="#3a2a0a" rx="1"/>
+  <!-- Ammo bolts stored -->
+  <line x1="20" y1="9" x2="28" y2="11" stroke="#6a4a1a" stroke-width="1.5"/>
+  <line x1="20" y1="7" x2="28" y2="9" stroke="#6a4a1a" stroke-width="1.5"/>
+</svg>

--- a/web/public/sprites/bandit-hideout.svg
+++ b/web/public/sprites/bandit-hideout.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#2a1a0a" opacity="0.5"/>
+  <!-- Rocky hillside base -->
+  <polygon points="0,32 0,22 5,18 12,20 16,16 20,20 27,18 32,22 32,32" fill="#5a4a2a"/>
+  <!-- Cave entrance -->
+  <path d="M8,25 Q16,12 24,25 Z" fill="#1a0a00"/>
+  <!-- Cave arch rocks -->
+  <path d="M8,25 Q16,12 24,25" fill="none" stroke="#6a5a2a" stroke-width="2"/>
+  <!-- Cave depth darkness -->
+  <ellipse cx="16" cy="22" rx="6" ry="5" fill="#0d0500"/>
+  <ellipse cx="16" cy="22" rx="4" ry="3.5" fill="#050200"/>
+  <!-- Dim torchlight inside -->
+  <ellipse cx="16" cy="22" rx="2" ry="2" fill="#7a3a00" opacity="0.4"/>
+  <!-- Barricade/fence across entrance -->
+  <line x1="9" y1="24" x2="23" y2="24" stroke="#5a3a0a" stroke-width="1.5"/>
+  <line x1="10" y1="22" x2="10" y2="26" stroke="#5a3a0a" stroke-width="1.2"/>
+  <line x1="13" y1="21" x2="13" y2="26" stroke="#5a3a0a" stroke-width="1.2"/>
+  <line x1="16" y1="20" x2="16" y2="26" stroke="#5a3a0a" stroke-width="1.2"/>
+  <line x1="19" y1="21" x2="19" y2="26" stroke="#5a3a0a" stroke-width="1.2"/>
+  <line x1="22" y1="22" x2="22" y2="26" stroke="#5a3a0a" stroke-width="1.2"/>
+  <!-- Watch post above -->
+  <rect x="12" y="8" width="8" height="6" fill="#5a4a2a"/>
+  <rect x="12" y="8" width="8" height="2" fill="#6a5a3a"/>
+  <!-- Lookout window -->
+  <rect x="14" y="9" width="4" height="3" fill="#1a0a00"/>
+  <!-- Torchlight flicker from post -->
+  <circle cx="11" cy="8" r="1.5" fill="#ff8800" opacity="0.7"/>
+  <circle cx="21" cy="8" r="1.5" fill="#ff8800" opacity="0.7"/>
+  <!-- Skull on post warning -->
+  <circle cx="16" cy="5" r="2" fill="#c0b090"/>
+  <rect x="15" y="6" width="2" height="2" fill="#c0b090"/>
+  <circle cx="15" cy="4.5" r="0.5" fill="#1a0a00"/>
+  <circle cx="17" cy="4.5" r="0.5" fill="#1a0a00"/>
+  <line x1="15" y1="6" x2="17" y2="6" stroke="#1a0a00" stroke-width="0.5"/>
+  <!-- Flag/banner -->
+  <line x1="16" y1="3" x2="16" y2="1" stroke="#4a3a1a" stroke-width="1"/>
+  <polygon points="16,1 22,2 16,3" fill="#551111"/>
+</svg>

--- a/web/public/sprites/bark-kennel.svg
+++ b/web/public/sprites/bark-kennel.svg
@@ -1,0 +1,37 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#2a1a0a" opacity="0.4"/>
+  <!-- Ground/yard -->
+  <rect x="0" y="24" width="32" height="8" fill="#5a4a2a"/>
+  <rect x="0" y="24" width="32" height="2" fill="#6a5a3a"/>
+  <!-- Kennel building main structure -->
+  <rect x="4" y="14" width="24" height="11" rx="1" fill="#7a5a2a"/>
+  <rect x="4" y="14" width="24" height="3" fill="#8a6a3a"/>
+  <!-- Wood plank lines -->
+  <line x1="4" y1="18" x2="28" y2="18" stroke="#5a3a0a" stroke-width="0.7"/>
+  <line x1="4" y1="21" x2="28" y2="21" stroke="#5a3a0a" stroke-width="0.7"/>
+  <line x1="10" y1="14" x2="10" y2="24" stroke="#5a3a0a" stroke-width="0.7"/>
+  <line x1="22" y1="14" x2="22" y2="24" stroke="#5a3a0a" stroke-width="0.7"/>
+  <!-- Pitched bark/wood roof -->
+  <polygon points="2,14 16,5 30,14" fill="#6a4a1a"/>
+  <polygon points="4,14 16,6 28,14" fill="#7a5a2a"/>
+  <!-- Roof ridge -->
+  <line x1="16" y1="5" x2="16" y2="14" stroke="#5a3a0a" stroke-width="0.8"/>
+  <!-- Kennel door openings (2 stalls) -->
+  <path d="M7,24 L7,19 Q10,16 13,19 L13,24 Z" fill="#2a1a0a"/>
+  <path d="M19,24 L19,19 Q22,16 25,19 L25,24 Z" fill="#2a1a0a"/>
+  <!-- Dog/wolf paw prints on ground -->
+  <circle cx="8" cy="26" r="0.8" fill="#4a3a1a"/>
+  <circle cx="10" cy="27" r="0.8" fill="#4a3a1a"/>
+  <circle cx="6" cy="28" r="0.8" fill="#4a3a1a"/>
+  <circle cx="22" cy="26" r="0.8" fill="#4a3a1a"/>
+  <circle cx="24" cy="27" r="0.8" fill="#4a3a1a"/>
+  <circle cx="20" cy="28" r="0.8" fill="#4a3a1a"/>
+  <!-- Bone on ground -->
+  <line x1="14" y1="27" x2="18" y2="27" stroke="#c0b090" stroke-width="1.2"/>
+  <circle cx="14" cy="27" r="1" fill="#c0b090"/>
+  <circle cx="18" cy="27" r="1" fill="#c0b090"/>
+  <!-- Chain post -->
+  <line x1="16" y1="24" x2="16" y2="28" stroke="#6a6060" stroke-width="1"/>
+  <circle cx="16" cy="24" r="1" fill="#7a7070"/>
+</svg>

--- a/web/public/sprites/bat-cavern.svg
+++ b/web/public/sprites/bat-cavern.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Cave/cliff background -->
+  <rect x="0" y="10" width="32" height="22" fill="#2a2030"/>
+  <rect x="0" y="10" width="32" height="4" fill="#3a3040"/>
+  <!-- Stalactites from ceiling -->
+  <polygon points="4,10 6,10 5,16" fill="#1a1525"/>
+  <polygon points="10,10 13,10 11.5,18" fill="#1a1525"/>
+  <polygon points="18,10 21,10 19.5,17" fill="#1a1525"/>
+  <polygon points="26,10 29,10 27.5,15" fill="#1a1525"/>
+  <!-- Cave entrance arch (top portion cut off by frame) -->
+  <ellipse cx="16" cy="10" rx="14" ry="6" fill="#3a3040"/>
+  <!-- Bats hanging from ceiling -->
+  <ellipse cx="8" cy="12" rx="2" ry="1" fill="#1a1020"/>
+  <path d="M6,12 Q7,10 8,12 Q9,10 10,12" fill="#2a1530" stroke="#3a2040" stroke-width="0.5"/>
+  <circle cx="8" cy="13" r="0.8" fill="#1a1020"/>
+  <ellipse cx="22" cy="11" rx="2" ry="1" fill="#1a1020"/>
+  <path d="M20,11 Q21,9 22,11 Q23,9 24,11" fill="#2a1530" stroke="#3a2040" stroke-width="0.5"/>
+  <circle cx="22" cy="12" r="0.8" fill="#1a1020"/>
+  <!-- Flying bats in cavern -->
+  <path d="M13,18 Q14,16 15,18 Q16,16 17,18" fill="#2a1530" stroke="#3a2040" stroke-width="0.5"/>
+  <circle cx="15" cy="19" r="0.7" fill="#1a1020"/>
+  <path d="M4,22 Q5,20 6,22 Q7,20 8,22" fill="#2a1530" stroke="#3a2040" stroke-width="0.5"/>
+  <circle cx="6" cy="23" r="0.6" fill="#1a1020"/>
+  <path d="M24,20 Q25,18 26,20 Q27,18 28,20" fill="#2a1530" stroke="#3a2040" stroke-width="0.5"/>
+  <circle cx="26" cy="21" r="0.6" fill="#1a1020"/>
+  <!-- Roost platform/wooden structure -->
+  <rect x="3" y="24" width="26" height="5" rx="1" fill="#4a3a1a"/>
+  <rect x="3" y="24" width="26" height="2" fill="#5a4a2a"/>
+  <!-- Wood post supports -->
+  <rect x="5" y="18" width="3" height="7" fill="#3a2a0a"/>
+  <rect x="14" y="16" width="3" height="9" fill="#3a2a0a"/>
+  <rect x="24" y="18" width="3" height="7" fill="#3a2a0a"/>
+  <!-- Glowing bat eyes in dark -->
+  <circle cx="8" cy="13.5" r="0.4" fill="#ff4400" opacity="0.8"/>
+  <circle cx="22" cy="12.5" r="0.4" fill="#ff4400" opacity="0.8"/>
+  <circle cx="15" cy="19.5" r="0.3" fill="#ff4400" opacity="0.7"/>
+  <!-- Guano pile (comical detail) -->
+  <ellipse cx="16" cy="29" rx="4" ry="1.2" fill="#2a2020" opacity="0.5"/>
+</svg>

--- a/web/public/sprites/bear-run.svg
+++ b/web/public/sprites/bear-run.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#2a1a0a" opacity="0.4"/>
+  <!-- Fenced enclosure ground -->
+  <rect x="0" y="22" width="32" height="10" fill="#5a4a2a"/>
+  <rect x="0" y="22" width="32" height="2" fill="#6a5a3a"/>
+  <!-- Fence posts and rails -->
+  <line x1="2" y1="18" x2="2" y2="28" stroke="#5a3a1a" stroke-width="2"/>
+  <line x1="8" y1="17" x2="8" y2="27" stroke="#5a3a1a" stroke-width="2"/>
+  <line x1="24" y1="17" x2="24" y2="27" stroke="#5a3a1a" stroke-width="2"/>
+  <line x1="30" y1="18" x2="30" y2="28" stroke="#5a3a1a" stroke-width="2"/>
+  <!-- Fence rail top -->
+  <line x1="2" y1="19" x2="30" y2="19" stroke="#7a5a2a" stroke-width="1.5"/>
+  <!-- Fence rail bottom -->
+  <line x1="2" y1="23" x2="30" y2="23" stroke="#7a5a2a" stroke-width="1.5"/>
+  <!-- Bear shelter/den building -->
+  <rect x="8" y="10" width="16" height="12" rx="1" fill="#6a5030"/>
+  <rect x="8" y="10" width="16" height="3" fill="#7a6040"/>
+  <!-- Log wall texture lines -->
+  <line x1="8" y1="13" x2="24" y2="13" stroke="#5a3a1a" stroke-width="0.7"/>
+  <line x1="8" y1="16" x2="24" y2="16" stroke="#5a3a1a" stroke-width="0.7"/>
+  <line x1="8" y1="19" x2="24" y2="19" stroke="#5a3a1a" stroke-width="0.7"/>
+  <!-- Heavy log roof -->
+  <polygon points="6,10 16,3 26,10" fill="#5a3a1a"/>
+  <polygon points="8,10 16,4 24,10" fill="#6a4a2a"/>
+  <!-- Den entrance (wide arched) -->
+  <path d="M12,22 L12,16 Q16,13 20,16 L20,22 Z" fill="#1a0a00"/>
+  <!-- Bear paw prints inside enclosure -->
+  <circle cx="5" cy="25" r="1.2" fill="#4a3a1a"/>
+  <circle cx="4" cy="27.5" r="1" fill="#4a3a1a"/>
+  <circle cx="7" cy="28" r="1" fill="#4a3a1a"/>
+  <circle cx="26" cy="24" r="1.2" fill="#4a3a1a"/>
+  <circle cx="28" cy="26" r="1" fill="#4a3a1a"/>
+  <!-- Fish in enclosure (bear food) -->
+  <path d="M14,26 Q16,24 18,26 Q16,28 14,26 Z" fill="#6a8a9a"/>
+  <polygon points="18,26 21,24 21,28" fill="#6a8a9a"/>
+  <!-- Feeding trough -->
+  <rect x="10" y="26" width="12" height="3" rx="1" fill="#5a3a1a"/>
+  <rect x="11" y="26" width="10" height="2" fill="#3a1a00"/>
+</svg>

--- a/web/public/sprites/behemoth-hold.svg
+++ b/web/public/sprites/behemoth-hold.svg
@@ -1,0 +1,44 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="14" ry="1.5" fill="#2a1a0a" opacity="0.5"/>
+  <!-- Massive base walls -->
+  <rect x="1" y="18" width="30" height="13" rx="1" fill="#6a5030"/>
+  <rect x="1" y="18" width="30" height="3" fill="#7a6040"/>
+  <!-- Heavy stone blocks -->
+  <line x1="1" y1="22" x2="31" y2="22" stroke="#4a3010" stroke-width="0.8"/>
+  <line x1="1" y1="26" x2="31" y2="26" stroke="#4a3010" stroke-width="0.8"/>
+  <line x1="8" y1="18" x2="8" y2="31" stroke="#4a3010" stroke-width="0.8"/>
+  <line x1="16" y1="18" x2="16" y2="31" stroke="#4a3010" stroke-width="0.8"/>
+  <line x1="24" y1="18" x2="24" y2="31" stroke="#4a3010" stroke-width="0.8"/>
+  <!-- Corner towers (thick) -->
+  <rect x="1" y="10" width="8" height="9" fill="#7a6040"/>
+  <rect x="23" y="10" width="8" height="9" fill="#7a6040"/>
+  <rect x="1" y="10" width="8" height="3" fill="#8a7050"/>
+  <rect x="23" y="10" width="8" height="3" fill="#8a7050"/>
+  <!-- Corner tower battlements -->
+  <rect x="1" y="7" width="2" height="4" fill="#7a6040"/>
+  <rect x="4" y="7" width="2" height="4" fill="#7a6040"/>
+  <rect x="7" y="7" width="2" height="4" fill="#7a6040"/>
+  <rect x="23" y="7" width="2" height="4" fill="#7a6040"/>
+  <rect x="26" y="7" width="2" height="4" fill="#7a6040"/>
+  <rect x="29" y="7" width="2" height="4" fill="#7a6040"/>
+  <!-- Keep top center -->
+  <rect x="9" y="12" width="14" height="7" fill="#8a7050"/>
+  <rect x="9" y="12" width="14" height="3" fill="#9a8060"/>
+  <!-- Chains/shackles on gate -->
+  <line x1="11" y1="22" x2="14" y2="25" stroke="#8a7a5a" stroke-width="1.2"/>
+  <line x1="21" y1="22" x2="18" y2="25" stroke="#8a7a5a" stroke-width="1.2"/>
+  <!-- Reinforced gate door -->
+  <rect x="11" y="22" width="10" height="9" fill="#3a2010"/>
+  <!-- Gate iron bars -->
+  <line x1="13" y1="22" x2="13" y2="31" stroke="#5a5040" stroke-width="1"/>
+  <line x1="16" y1="22" x2="16" y2="31" stroke="#5a5040" stroke-width="1"/>
+  <line x1="19" y1="22" x2="19" y2="31" stroke="#5a5040" stroke-width="1"/>
+  <line x1="11" y1="25" x2="21" y2="25" stroke="#5a5040" stroke-width="1"/>
+  <line x1="11" y1="28" x2="21" y2="28" stroke="#5a5040" stroke-width="1"/>
+  <!-- Deep crack in walls (from behemoth inside) -->
+  <path d="M16,18 L14,22 L17,26 L15,31" fill="none" stroke="#2a1000" stroke-width="1.2" opacity="0.6"/>
+  <!-- Arrow slits on towers -->
+  <rect x="4" y="12" width="2" height="4" fill="#1a0a00" rx="1"/>
+  <rect x="26" y="12" width="2" height="4" fill="#1a0a00" rx="1"/>
+</svg>

--- a/web/public/sprites/blade-sanctum.svg
+++ b/web/public/sprites/blade-sanctum.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="12" ry="1.5" fill="#2a1a1a" opacity="0.5"/>
+  <!-- Base platform -->
+  <rect x="3" y="24" width="26" height="7" rx="1" fill="#5a4a4a"/>
+  <rect x="3" y="24" width="26" height="2" fill="#6a5a5a"/>
+  <!-- Main temple walls -->
+  <rect x="6" y="13" width="20" height="12" fill="#6a5555"/>
+  <rect x="6" y="13" width="20" height="3" fill="#7a6565"/>
+  <!-- Stone block detail -->
+  <line x1="6" y1="17" x2="26" y2="17" stroke="#4a3535" stroke-width="0.6"/>
+  <line x1="6" y1="20" x2="26" y2="20" stroke="#4a3535" stroke-width="0.6"/>
+  <line x1="12" y1="13" x2="12" y2="24" stroke="#4a3535" stroke-width="0.6"/>
+  <line x1="20" y1="13" x2="20" y2="24" stroke="#4a3535" stroke-width="0.6"/>
+  <!-- Peaked roof -->
+  <polygon points="4,13 16,3 28,13" fill="#4a3535"/>
+  <polygon points="6,13 16,5 26,13" fill="#5a4545"/>
+  <!-- Crossed blades on facade -->
+  <line x1="10" y1="19" x2="22" y2="14" stroke="#c8a020" stroke-width="1.5"/>
+  <line x1="10" y1="14" x2="22" y2="19" stroke="#c8a020" stroke-width="1.5"/>
+  <!-- Blade tips -->
+  <polygon points="10,19 8,21 11,20" fill="#c8a020"/>
+  <polygon points="22,14 24,12 21,13" fill="#c8a020"/>
+  <polygon points="10,14 8,12 11,13" fill="#c8a020"/>
+  <polygon points="22,19 24,21 21,20" fill="#c8a020"/>
+  <!-- Door -->
+  <path d="M13,24 L13,19 Q16,16 19,19 L19,24 Z" fill="#1a0a0a"/>
+  <!-- Glowing altar light through door -->
+  <ellipse cx="16" cy="21" rx="2" ry="1.5" fill="#ff6600" opacity="0.3"/>
+  <!-- Blade ornaments on roofline -->
+  <polygon points="16,3 17.5,6 14.5,6" fill="#c8a020"/>
+  <line x1="16" y1="0" x2="16" y2="3" stroke="#a08010" stroke-width="1.5"/>
+  <!-- Wall sconces with blade designs -->
+  <line x1="8" y1="15" x2="8" y2="18" stroke="#c8a020" stroke-width="0.8" opacity="0.7"/>
+  <line x1="24" y1="15" x2="24" y2="18" stroke="#c8a020" stroke-width="0.8" opacity="0.7"/>
+  <!-- Red trim on walls (blood/honour) -->
+  <line x1="6" y1="13" x2="26" y2="13" stroke="#880000" stroke-width="0.8"/>
+  <line x1="3" y1="24" x2="29" y2="24" stroke="#880000" stroke-width="0.8"/>
+</svg>

--- a/web/public/sprites/blizzard-gate.svg
+++ b/web/public/sprites/blizzard-gate.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Snow/ice ground -->
+  <rect x="0" y="26" width="32" height="6" fill="#c8ddf0"/>
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#aaccdd" opacity="0.5"/>
+  <!-- Gate pillars (ice-encrusted stone) -->
+  <rect x="2" y="8" width="7" height="20" rx="1" fill="#7a9ab0"/>
+  <rect x="23" y="8" width="7" height="20" rx="1" fill="#7a9ab0"/>
+  <!-- Ice layer on pillars -->
+  <rect x="2" y="8" width="2" height="20" fill="#a8c8e0" opacity="0.7"/>
+  <rect x="23" y="8" width="2" height="20" fill="#a8c8e0" opacity="0.7"/>
+  <!-- Pillar tops with icicles -->
+  <rect x="1" y="6" width="9" height="3" rx="1" fill="#8aaac0"/>
+  <rect x="22" y="6" width="9" height="3" rx="1" fill="#8aaac0"/>
+  <!-- Icicles hanging from pillar tops -->
+  <polygon points="3,9 4,9 3.5,14" fill="#c8e0f0"/>
+  <polygon points="5,9 6,9 5.5,16" fill="#c8e0f0"/>
+  <polygon points="7,9 8,9 7.5,13" fill="#c8e0f0"/>
+  <polygon points="24,9 25,9 24.5,14" fill="#c8e0f0"/>
+  <polygon points="26,9 27,9 26.5,16" fill="#c8e0f0"/>
+  <polygon points="28,9 29,9 28.5,13" fill="#c8e0f0"/>
+  <!-- Arch crossbar (ice crystal) -->
+  <rect x="9" y="7" width="14" height="3" rx="1" fill="#a0c0d8"/>
+  <!-- Blizzard portal between pillars -->
+  <rect x="9" y="10" width="14" height="18" fill="#d0eaff" opacity="0.3"/>
+  <!-- Snowstorm swirls in gate -->
+  <path d="M10,14 Q16,10 22,14 Q16,18 10,22 Q16,18 22,22" fill="none" stroke="#ffffff" stroke-width="0.8" opacity="0.6"/>
+  <ellipse cx="16" cy="18" rx="4" ry="6" fill="#c0dfff" opacity="0.2"/>
+  <!-- Snowflakes -->
+  <line x1="13" y1="12" x2="13" y2="15" stroke="#ffffff" stroke-width="0.7" opacity="0.7"/>
+  <line x1="11.5" y1="13.5" x2="14.5" y2="13.5" stroke="#ffffff" stroke-width="0.7" opacity="0.7"/>
+  <line x1="19" y1="16" x2="19" y2="19" stroke="#ffffff" stroke-width="0.7" opacity="0.7"/>
+  <line x1="17.5" y1="17.5" x2="20.5" y2="17.5" stroke="#ffffff" stroke-width="0.7" opacity="0.7"/>
+  <line x1="14" y1="21" x2="14" y2="24" stroke="#ffffff" stroke-width="0.7" opacity="0.6"/>
+  <line x1="12.5" y1="22.5" x2="15.5" y2="22.5" stroke="#ffffff" stroke-width="0.7" opacity="0.6"/>
+  <!-- Snow drifts at base -->
+  <ellipse cx="5" cy="26" rx="5" ry="2" fill="#e0f0ff"/>
+  <ellipse cx="27" cy="26" rx="5" ry="2" fill="#e0f0ff"/>
+  <ellipse cx="16" cy="28" rx="8" ry="1.5" fill="#e8f4ff"/>
+</svg>

--- a/web/public/sprites/blood-tower.svg
+++ b/web/public/sprites/blood-tower.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow (dark stained) -->
+  <ellipse cx="16" cy="31" rx="10" ry="1.5" fill="#2a0000" opacity="0.6"/>
+  <!-- Tower base -->
+  <rect x="6" y="24" width="20" height="7" rx="1" fill="#5a2020"/>
+  <rect x="6" y="24" width="20" height="2" fill="#6a3030"/>
+  <!-- Main tower body -->
+  <rect x="8" y="10" width="16" height="15" fill="#6a2020"/>
+  <rect x="8" y="10" width="16" height="3" fill="#7a3030"/>
+  <!-- Stone block lines -->
+  <line x1="8" y1="14" x2="24" y2="14" stroke="#4a1010" stroke-width="0.6"/>
+  <line x1="8" y1="18" x2="24" y2="18" stroke="#4a1010" stroke-width="0.6"/>
+  <line x1="8" y1="21" x2="24" y2="21" stroke="#4a1010" stroke-width="0.6"/>
+  <line x1="13" y1="10" x2="13" y2="24" stroke="#4a1010" stroke-width="0.6"/>
+  <line x1="19" y1="10" x2="19" y2="24" stroke="#4a1010" stroke-width="0.6"/>
+  <!-- Upper tower (narrower) -->
+  <rect x="10" y="4" width="12" height="7" fill="#7a2020"/>
+  <rect x="10" y="4" width="12" height="2" fill="#8a3030"/>
+  <!-- Battlements -->
+  <rect x="10" y="1" width="3" height="4" fill="#7a2020"/>
+  <rect x="14.5" y="1" width="3" height="4" fill="#7a2020"/>
+  <rect x="19" y="1" width="3" height="4" fill="#7a2020"/>
+  <!-- Dripping blood from battlements -->
+  <path d="M11.5,5 Q11.5,8 11,10" fill="none" stroke="#cc0000" stroke-width="1" opacity="0.8"/>
+  <circle cx="11" cy="10" r="0.8" fill="#cc0000" opacity="0.8"/>
+  <path d="M16,5 Q16,9 15.5,12" fill="none" stroke="#cc0000" stroke-width="1" opacity="0.7"/>
+  <circle cx="15.5" cy="12" r="0.8" fill="#cc0000" opacity="0.7"/>
+  <path d="M20.5,5 Q20.5,8 21,10" fill="none" stroke="#cc0000" stroke-width="1" opacity="0.8"/>
+  <circle cx="21" cy="10" r="0.8" fill="#cc0000" opacity="0.8"/>
+  <!-- Blood-stained wall streaks -->
+  <path d="M12,10 Q11,15 12,20" fill="none" stroke="#880000" stroke-width="0.8" opacity="0.5"/>
+  <path d="M20,10 Q21,16 20,21" fill="none" stroke="#880000" stroke-width="0.8" opacity="0.5"/>
+  <!-- Arrow slits (glowing red inside) -->
+  <rect x="11" y="12" width="2" height="4" fill="#440000" rx="1"/>
+  <rect x="11" y="12" width="2" height="2" fill="#cc2200" rx="1" opacity="0.5"/>
+  <rect x="19" y="12" width="2" height="4" fill="#440000" rx="1"/>
+  <rect x="19" y="12" width="2" height="2" fill="#cc2200" rx="1" opacity="0.5"/>
+  <!-- Gated doorway -->
+  <path d="M13,24 L13,19 Q16,16 19,19 L19,24 Z" fill="#220000"/>
+  <!-- Blood pool at base -->
+  <ellipse cx="16" cy="30" rx="6" ry="1.5" fill="#880000" opacity="0.5"/>
+</svg>

--- a/web/public/sprites/bloom-garden.svg
+++ b/web/public/sprites/bloom-garden.svg
@@ -1,0 +1,55 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground/soil -->
+  <ellipse cx="16" cy="30" rx="14" ry="2.5" fill="#5a3a1a" opacity="0.6"/>
+  <rect x="0" y="27" width="32" height="5" fill="#5a4a2a"/>
+  <!-- Grass/growth around garden -->
+  <rect x="0" y="25" width="32" height="3" fill="#3a6a1a"/>
+  <!-- Garden fence (white picket) -->
+  <line x1="2" y1="22" x2="2" y2="28" stroke="#d0c8a0" stroke-width="1.5"/>
+  <line x1="6" y1="21" x2="6" y2="27" stroke="#d0c8a0" stroke-width="1.5"/>
+  <line x1="10" y1="21" x2="10" y2="27" stroke="#d0c8a0" stroke-width="1.5"/>
+  <line x1="14" y1="21" x2="14" y2="27" stroke="#d0c8a0" stroke-width="1.5"/>
+  <line x1="18" y1="21" x2="18" y2="27" stroke="#d0c8a0" stroke-width="1.5"/>
+  <line x1="22" y1="21" x2="22" y2="27" stroke="#d0c8a0" stroke-width="1.5"/>
+  <line x1="26" y1="21" x2="26" y2="27" stroke="#d0c8a0" stroke-width="1.5"/>
+  <line x1="30" y1="22" x2="30" y2="28" stroke="#d0c8a0" stroke-width="1.5"/>
+  <line x1="2" y1="23" x2="30" y2="23" stroke="#d0c8a0" stroke-width="1"/>
+  <!-- Fence post tips (pointed) -->
+  <polygon points="2,22 3,22 2.5,20" fill="#d0c8a0"/>
+  <polygon points="6,21 7,21 6.5,19" fill="#d0c8a0"/>
+  <polygon points="10,21 11,21 10.5,19" fill="#d0c8a0"/>
+  <polygon points="14,21 15,21 14.5,19" fill="#d0c8a0"/>
+  <!-- Large blooming flowers -->
+  <circle cx="7" cy="16" r="4" fill="#ff6688" opacity="0.9"/>
+  <circle cx="7" cy="16" r="2" fill="#ffaacc"/>
+  <circle cx="7" cy="16" r="1" fill="#ffdd00"/>
+  <!-- Flower petals -->
+  <ellipse cx="7" cy="12" rx="1.5" ry="2" fill="#ff6688" opacity="0.7"/>
+  <ellipse cx="7" cy="20" rx="1.5" ry="2" fill="#ff6688" opacity="0.7"/>
+  <ellipse cx="3" cy="16" rx="2" ry="1.5" fill="#ff6688" opacity="0.7"/>
+  <ellipse cx="11" cy="16" rx="2" ry="1.5" fill="#ff6688" opacity="0.7"/>
+  <!-- Second flower -->
+  <circle cx="25" cy="14" r="4" fill="#cc44ff" opacity="0.9"/>
+  <circle cx="25" cy="14" r="2" fill="#ee88ff"/>
+  <circle cx="25" cy="14" r="1" fill="#ffdd00"/>
+  <ellipse cx="25" cy="10" rx="1.5" ry="2" fill="#cc44ff" opacity="0.7"/>
+  <ellipse cx="25" cy="18" rx="1.5" ry="2" fill="#cc44ff" opacity="0.7"/>
+  <ellipse cx="21" cy="14" rx="2" ry="1.5" fill="#cc44ff" opacity="0.7"/>
+  <ellipse cx="29" cy="14" rx="2" ry="1.5" fill="#cc44ff" opacity="0.7"/>
+  <!-- Central large flower -->
+  <circle cx="16" cy="13" r="5" fill="#ffaa00" opacity="0.9"/>
+  <circle cx="16" cy="13" r="3" fill="#ffcc44"/>
+  <circle cx="16" cy="13" r="1.5" fill="#ff8800"/>
+  <ellipse cx="16" cy="8" rx="2" ry="2.5" fill="#ffaa00" opacity="0.7"/>
+  <ellipse cx="16" cy="18" rx="2" ry="2.5" fill="#ffaa00" opacity="0.7"/>
+  <ellipse cx="11" cy="13" rx="2.5" ry="2" fill="#ffaa00" opacity="0.7"/>
+  <ellipse cx="21" cy="13" rx="2.5" ry="2" fill="#ffaa00" opacity="0.7"/>
+  <!-- Stems -->
+  <line x1="7" y1="20" x2="7" y2="25" stroke="#3a7a1a" stroke-width="1.5"/>
+  <line x1="16" y1="18" x2="16" y2="25" stroke="#3a7a1a" stroke-width="1.5"/>
+  <line x1="25" y1="18" x2="25" y2="25" stroke="#3a7a1a" stroke-width="1.5"/>
+  <!-- Butterflies -->
+  <path d="M12,9 Q13,7 14,9" fill="#88ddff" opacity="0.7" stroke="#44aadd" stroke-width="0.4"/>
+  <path d="M12,9 Q13,11 14,9" fill="#88ddff" opacity="0.7" stroke="#44aadd" stroke-width="0.4"/>
+  <circle cx="13" cy="9" r="0.4" fill="#224488"/>
+</svg>


### PR DESCRIPTION
Adds 10 building SVG sprites for batch 2/19, closing #996.

## Buildings added

| Card | File |
|---|---|
| Ballista Works | `ballista-works.svg` — siege platform with loaded bolt and winch |
| Bandit Hideout | `bandit-hideout.svg` — cave lair with barricade and skull warning |
| Bark Kennel | `bark-kennel.svg` — log kennel with dual stalls and paw prints |
| Bat Cavern | `bat-cavern.svg` — dark cave with stalactites, roosting and flying bats |
| Bear Run | `bear-run.svg` — fenced enclosure with log den and feeding trough |
| Behemoth Hold | `behemoth-hold.svg` — massive fortified prison with iron-barred gate |
| Blade Sanctum | `blade-sanctum.svg` — temple with crossed golden blades on facade |
| Blizzard Gate | `blizzard-gate.svg` — icy gate pillars with snowstorm portal and icicles |
| Blood Tower | `blood-tower.svg` — dark crimson tower with dripping battlements |
| Bloom Garden | `bloom-garden.svg` — colourful garden with three large flowers and picket fence |

## Test plan

- [ ] Each sprite visible in card collection view
- [ ] Each sprite visible in battle when the structure is placed


---
_Generated by [Claude Code](https://claude.ai/code/session_01TWFNogtCtcNR4qd2ZbxCCx)_