### PR TITLE
feat(sprites): building SVGs batch 3/19 — Bone Hall → Char Kennel

### DIFF
--- a/web/public/sprites/bone-hall.svg
+++ b/web/public/sprites/bone-hall.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#2a1a0a" opacity="0.4"/>
+  <!-- Main hall walls -->
+  <rect x="2" y="14" width="28" height="16" rx="1" fill="#7a6a50"/>
+  <rect x="2" y="14" width="28" height="3" fill="#8a7a60"/>
+  <!-- Stone block lines -->
+  <line x1="2" y1="18" x2="30" y2="18" stroke="#5a4a30" stroke-width="0.6"/>
+  <line x1="2" y1="22" x2="30" y2="22" stroke="#5a4a30" stroke-width="0.6"/>
+  <line x1="2" y1="26" x2="30" y2="26" stroke="#5a4a30" stroke-width="0.6"/>
+  <line x1="9" y1="14" x2="9" y2="30" stroke="#5a4a30" stroke-width="0.6"/>
+  <line x1="16" y1="14" x2="16" y2="30" stroke="#5a4a30" stroke-width="0.6"/>
+  <line x1="23" y1="14" x2="23" y2="30" stroke="#5a4a30" stroke-width="0.6"/>
+  <!-- Bone-draped roof gable -->
+  <polygon points="0,14 16,3 32,14" fill="#5a4a30"/>
+  <polygon points="2,14 16,5 30,14" fill="#6a5a40"/>
+  <!-- Skull ornaments on roofline -->
+  <circle cx="8" cy="11" r="2" fill="#c8b890"/>
+  <rect x="7" y="12" width="2" height="2" fill="#c8b890"/>
+  <circle cx="7.5" cy="10.5" r="0.4" fill="#2a1a0a"/>
+  <circle cx="8.5" cy="10.5" r="0.4" fill="#2a1a0a"/>
+  <circle cx="24" cy="11" r="2" fill="#c8b890"/>
+  <rect x="23" y="12" width="2" height="2" fill="#c8b890"/>
+  <circle cx="23.5" cy="10.5" r="0.4" fill="#2a1a0a"/>
+  <circle cx="24.5" cy="10.5" r="0.4" fill="#2a1a0a"/>
+  <!-- Bone crossbeams on walls -->
+  <line x1="4" y1="16" x2="8" y2="16" stroke="#c8b890" stroke-width="1.5"/>
+  <circle cx="4" cy="16" r="0.8" fill="#c8b890"/>
+  <circle cx="8" cy="16" r="0.8" fill="#c8b890"/>
+  <line x1="24" y1="16" x2="28" y2="16" stroke="#c8b890" stroke-width="1.5"/>
+  <circle cx="24" cy="16" r="0.8" fill="#c8b890"/>
+  <circle cx="28" cy="16" r="0.8" fill="#c8b890"/>
+  <!-- Door arch (bone-framed) -->
+  <path d="M12,30 L12,22 Q16,18 20,22 L20,30 Z" fill="#1a0a00"/>
+  <path d="M12,22 Q16,17 20,22" fill="none" stroke="#c8b890" stroke-width="1.2"/>
+  <!-- Windows with bone cross motif -->
+  <rect x="4" y="19" width="4" height="5" fill="#1a0a00"/>
+  <line x1="6" y1="19" x2="6" y2="24" stroke="#c8b890" stroke-width="0.8"/>
+  <line x1="4" y1="21.5" x2="8" y2="21.5" stroke="#c8b890" stroke-width="0.8"/>
+  <rect x="24" y="19" width="4" height="5" fill="#1a0a00"/>
+  <line x1="26" y1="19" x2="26" y2="24" stroke="#c8b890" stroke-width="0.8"/>
+  <line x1="24" y1="21.5" x2="28" y2="21.5" stroke="#c8b890" stroke-width="0.8"/>
+</svg>

--- a/web/public/sprites/bone-pit.svg
+++ b/web/public/sprites/bone-pit.svg
@@ -1,0 +1,47 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground -->
+  <rect x="0" y="20" width="32" height="12" fill="#4a3a2a"/>
+  <rect x="0" y="20" width="32" height="2" fill="#5a4a3a"/>
+  <!-- Pit opening -->
+  <ellipse cx="16" cy="22" rx="12" ry="5" fill="#1a0a00"/>
+  <ellipse cx="16" cy="22" rx="10" ry="4" fill="#0d0500"/>
+  <!-- Pit depth darkness -->
+  <ellipse cx="16" cy="23" rx="7" ry="3" fill="#050200"/>
+  <!-- Bone pile inside pit -->
+  <line x1="10" y1="24" x2="16" y2="21" stroke="#c8b890" stroke-width="1.5"/>
+  <circle cx="10" cy="24" r="1" fill="#c8b890"/>
+  <circle cx="16" cy="21" r="1" fill="#c8b890"/>
+  <line x1="14" y1="25" x2="20" y2="22" stroke="#c8b890" stroke-width="1.5"/>
+  <circle cx="14" cy="25" r="1" fill="#c8b890"/>
+  <circle cx="20" cy="22" r="1" fill="#c8b890"/>
+  <line x1="12" y1="26" x2="18" y2="23" stroke="#b0a070" stroke-width="1.2"/>
+  <!-- Skulls scattered in pit -->
+  <circle cx="13" cy="23" r="1.5" fill="#c8b890"/>
+  <circle cx="12.5" cy="22.5" r="0.4" fill="#1a0a00"/>
+  <circle cx="13.5" cy="22.5" r="0.4" fill="#1a0a00"/>
+  <circle cx="21" cy="24" r="1.5" fill="#b8a880"/>
+  <circle cx="20.5" cy="23.5" r="0.4" fill="#1a0a00"/>
+  <circle cx="21.5" cy="23.5" r="0.4" fill="#1a0a00"/>
+  <!-- Wooden stake barrier around pit -->
+  <line x1="4" y1="17" x2="4" y2="22" stroke="#5a3a1a" stroke-width="2"/>
+  <line x1="8" y1="16" x2="8" y2="21" stroke="#5a3a1a" stroke-width="2"/>
+  <line x1="12" y1="16" x2="12" y2="20" stroke="#5a3a1a" stroke-width="2"/>
+  <line x1="20" y1="16" x2="20" y2="20" stroke="#5a3a1a" stroke-width="2"/>
+  <line x1="24" y1="16" x2="24" y2="21" stroke="#5a3a1a" stroke-width="2"/>
+  <line x1="28" y1="17" x2="28" y2="22" stroke="#5a3a1a" stroke-width="2"/>
+  <!-- Stake tips (sharpened) -->
+  <polygon points="3,17 5,17 4,14" fill="#5a3a1a"/>
+  <polygon points="7,16 9,16 8,13" fill="#5a3a1a"/>
+  <polygon points="11,16 13,16 12,13" fill="#5a3a1a"/>
+  <polygon points="19,16 21,16 20,13" fill="#5a3a1a"/>
+  <polygon points="23,16 25,16 24,13" fill="#5a3a1a"/>
+  <polygon points="27,17 29,17 28,14" fill="#5a3a1a"/>
+  <!-- Rail connecting stakes -->
+  <line x1="4" y1="20" x2="28" y2="20" stroke="#7a5a2a" stroke-width="1"/>
+  <!-- Warning skull on stake -->
+  <circle cx="16" cy="12" r="2" fill="#c8b890"/>
+  <rect x="15" y="13" width="2" height="2" fill="#c8b890"/>
+  <circle cx="15.5" cy="11.5" r="0.4" fill="#1a0a00"/>
+  <circle cx="16.5" cy="11.5" r="0.4" fill="#1a0a00"/>
+  <line x1="15.5" y1="13" x2="16.5" y2="13" stroke="#1a0a00" stroke-width="0.5"/>
+</svg>

--- a/web/public/sprites/bone-tower.svg
+++ b/web/public/sprites/bone-tower.svg
@@ -1,0 +1,41 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <ellipse cx="16" cy="31" rx="9" ry="1.5" fill="#2a1a0a" opacity="0.4"/>
+  <!-- Tower base -->
+  <rect x="7" y="24" width="18" height="7" rx="1" fill="#6a5a40"/>
+  <rect x="7" y="24" width="18" height="2" fill="#7a6a50"/>
+  <!-- Main tower body -->
+  <rect x="9" y="12" width="14" height="13" fill="#7a6a50"/>
+  <rect x="9" y="12" width="14" height="3" fill="#8a7a60"/>
+  <!-- Bone inlay on walls (horizontal) -->
+  <line x1="9" y1="16" x2="23" y2="16" stroke="#c8b890" stroke-width="0.8"/>
+  <line x1="9" y1="20" x2="23" y2="20" stroke="#c8b890" stroke-width="0.8"/>
+  <!-- Bone cross motif -->
+  <line x1="13" y1="13" x2="13" y2="24" stroke="#c8b890" stroke-width="0.6" opacity="0.6"/>
+  <line x1="19" y1="13" x2="19" y2="24" stroke="#c8b890" stroke-width="0.6" opacity="0.6"/>
+  <!-- Upper tower (narrower) -->
+  <rect x="11" y="5" width="10" height="8" fill="#8a7a60"/>
+  <rect x="11" y="5" width="10" height="2" fill="#9a8a70"/>
+  <!-- Bone battlements -->
+  <rect x="11" y="2" width="2" height="4" fill="#c8b890"/>
+  <rect x="15" y="2" width="2" height="4" fill="#c8b890"/>
+  <rect x="19" y="2" width="2" height="4" fill="#c8b890"/>
+  <!-- Skull on top -->
+  <circle cx="16" cy="1" r="2" fill="#c8b890"/>
+  <circle cx="15.3" cy="0.5" r="0.5" fill="#2a1a0a"/>
+  <circle cx="16.7" cy="0.5" r="0.5" fill="#2a1a0a"/>
+  <rect x="15" y="1.5" width="2" height="1.5" fill="#c8b890"/>
+  <!-- Arrow slits -->
+  <rect x="13" y="7" width="2" height="4" fill="#1a0a00" rx="1"/>
+  <rect x="17" y="7" width="2" height="4" fill="#1a0a00" rx="1"/>
+  <rect x="11" y="15" width="2" height="3" fill="#1a0a00" rx="1"/>
+  <rect x="19" y="15" width="2" height="3" fill="#1a0a00" rx="1"/>
+  <!-- Bone trim on base -->
+  <line x1="7" y1="26" x2="25" y2="26" stroke="#c8b890" stroke-width="1"/>
+  <!-- Femur bones stacked on base sides -->
+  <line x1="8" y1="25" x2="11" y2="23" stroke="#c8b890" stroke-width="1.5"/>
+  <circle cx="8" cy="25" r="0.7" fill="#c8b890"/>
+  <circle cx="11" cy="23" r="0.7" fill="#c8b890"/>
+  <line x1="24" y1="25" x2="21" y2="23" stroke="#c8b890" stroke-width="1.5"/>
+  <circle cx="24" cy="25" r="0.7" fill="#c8b890"/>
+  <circle cx="21" cy="23" r="0.7" fill="#c8b890"/>
+</svg>

--- a/web/public/sprites/brass-works.svg
+++ b/web/public/sprites/brass-works.svg
@@ -1,0 +1,50 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#2a1a00" opacity="0.5"/>
+  <!-- Workshop floor/base -->
+  <rect x="2" y="22" width="28" height="9" rx="1" fill="#4a3a20"/>
+  <rect x="2" y="22" width="28" height="2" fill="#5a4a30"/>
+  <!-- Main brass works building -->
+  <rect x="4" y="12" width="24" height="11" fill="#8a7030"/>
+  <rect x="4" y="12" width="24" height="3" fill="#aa9040"/>
+  <!-- Brass panel rivets -->
+  <circle cx="7" cy="13.5" r="0.7" fill="#ccaa40"/>
+  <circle cx="12" cy="13.5" r="0.7" fill="#ccaa40"/>
+  <circle cx="17" cy="13.5" r="0.7" fill="#ccaa40"/>
+  <circle cx="22" cy="13.5" r="0.7" fill="#ccaa40"/>
+  <circle cx="27" cy="13.5" r="0.7" fill="#ccaa40"/>
+  <!-- Horizontal brass pipes -->
+  <rect x="4" y="16" width="24" height="2" rx="1" fill="#b89030"/>
+  <rect x="4" y="20" width="24" height="2" rx="1" fill="#b89030"/>
+  <!-- Brass chimney stacks -->
+  <rect x="7" y="5" width="4" height="8" rx="1" fill="#9a8030"/>
+  <rect x="14" y="3" width="4" height="10" rx="1" fill="#9a8030"/>
+  <rect x="21" y="5" width="4" height="8" rx="1" fill="#9a8030"/>
+  <!-- Chimney brass bands -->
+  <rect x="7" y="7" width="4" height="1" fill="#ccaa40"/>
+  <rect x="7" y="10" width="4" height="1" fill="#ccaa40"/>
+  <rect x="14" y="5" width="4" height="1" fill="#ccaa40"/>
+  <rect x="14" y="9" width="4" height="1" fill="#ccaa40"/>
+  <rect x="21" y="7" width="4" height="1" fill="#ccaa40"/>
+  <rect x="21" y="10" width="4" height="1" fill="#ccaa40"/>
+  <!-- Steam/smoke puffs -->
+  <ellipse cx="9" cy="4" rx="3" ry="2" fill="#888060" opacity="0.5"/>
+  <ellipse cx="16" cy="2" rx="3" ry="2" fill="#888060" opacity="0.5"/>
+  <ellipse cx="23" cy="4" rx="3" ry="2" fill="#888060" opacity="0.5"/>
+  <!-- Workshop door -->
+  <rect x="13" y="18" width="6" height="5" fill="#2a1a00"/>
+  <rect x="14" y="19" width="4" height="4" fill="#3a2a10" rx="1"/>
+  <!-- Gear emblem on door -->
+  <circle cx="16" cy="21" r="2" fill="none" stroke="#ccaa40" stroke-width="0.8"/>
+  <circle cx="16" cy="21" r="0.8" fill="#ccaa40"/>
+  <line x1="16" y1="18.5" x2="16" y2="23.5" stroke="#ccaa40" stroke-width="0.6"/>
+  <line x1="13.5" y1="21" x2="18.5" y2="21" stroke="#ccaa40" stroke-width="0.6"/>
+  <!-- Valve wheels on wall -->
+  <circle cx="7" cy="19" r="1.8" fill="none" stroke="#ccaa40" stroke-width="0.8"/>
+  <circle cx="7" cy="19" r="0.6" fill="#ccaa40"/>
+  <line x1="7" y1="17" x2="7" y2="21" stroke="#ccaa40" stroke-width="0.6"/>
+  <line x1="5" y1="19" x2="9" y2="19" stroke="#ccaa40" stroke-width="0.6"/>
+  <circle cx="25" cy="19" r="1.8" fill="none" stroke="#ccaa40" stroke-width="0.8"/>
+  <circle cx="25" cy="19" r="0.6" fill="#ccaa40"/>
+  <line x1="25" y1="17" x2="25" y2="21" stroke="#ccaa40" stroke-width="0.6"/>
+  <line x1="23" y1="19" x2="27" y2="19" stroke="#ccaa40" stroke-width="0.6"/>
+</svg>

--- a/web/public/sprites/caldera-forge.svg
+++ b/web/public/sprites/caldera-forge.svg
@@ -1,0 +1,41 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <ellipse cx="16" cy="31" rx="14" ry="1.5" fill="#2a0a00" opacity="0.5"/>
+  <!-- Volcanic rock base/caldera rim -->
+  <ellipse cx="16" cy="26" rx="14" ry="5" fill="#3a2010"/>
+  <ellipse cx="16" cy="25" rx="13" ry="4" fill="#4a2a18"/>
+  <!-- Lava channel rim -->
+  <ellipse cx="16" cy="24" rx="11" ry="3.5" fill="#2a1008"/>
+  <!-- Lava pool surface -->
+  <ellipse cx="16" cy="24" rx="9" ry="3" fill="#cc3300"/>
+  <ellipse cx="16" cy="24" rx="7" ry="2.5" fill="#ee5500"/>
+  <ellipse cx="16" cy="24" rx="5" ry="1.8" fill="#ff8800"/>
+  <!-- Lava bright core -->
+  <ellipse cx="16" cy="24" rx="3" ry="1.2" fill="#ffcc00" opacity="0.8"/>
+  <!-- Forge structure over caldera -->
+  <rect x="6" y="12" width="20" height="12" rx="1" fill="#3a3030"/>
+  <rect x="6" y="12" width="20" height="3" fill="#4a4040"/>
+  <!-- Metal wall panels -->
+  <line x1="6" y1="16" x2="26" y2="16" stroke="#2a2020" stroke-width="0.7"/>
+  <line x1="6" y1="19" x2="26" y2="19" stroke="#2a2020" stroke-width="0.7"/>
+  <line x1="12" y1="12" x2="12" y2="24" stroke="#2a2020" stroke-width="0.7"/>
+  <line x1="20" y1="12" x2="20" y2="24" stroke="#2a2020" stroke-width="0.7"/>
+  <!-- Furnace mouth (glowing orange) -->
+  <rect x="13" y="14" width="6" height="7" fill="#1a0800"/>
+  <rect x="14" y="15" width="4" height="5" fill="#cc4400" opacity="0.8" rx="1"/>
+  <ellipse cx="16" cy="17.5" rx="1.5" ry="1.2" fill="#ffaa00" opacity="0.9"/>
+  <!-- Exhaust chimneys -->
+  <rect x="7" y="5" width="4" height="8" rx="1" fill="#3a3030"/>
+  <rect x="21" y="5" width="4" height="8" rx="1" fill="#3a3030"/>
+  <!-- Lava glow from chimneys -->
+  <circle cx="9" cy="4" r="2.5" fill="#ff4400" opacity="0.6"/>
+  <circle cx="9" cy="4" r="1.2" fill="#ff8800" opacity="0.7"/>
+  <circle cx="23" cy="4" r="2.5" fill="#ff4400" opacity="0.6"/>
+  <circle cx="23" cy="4" r="1.2" fill="#ff8800" opacity="0.7"/>
+  <!-- Lava drips down forge sides -->
+  <path d="M6,18 Q5,21 6,24" fill="none" stroke="#ff6600" stroke-width="1" opacity="0.6"/>
+  <path d="M26,18 Q27,21 26,24" fill="none" stroke="#ff6600" stroke-width="1" opacity="0.6"/>
+  <!-- Heat shimmer particles -->
+  <circle cx="12" cy="10" r="0.7" fill="#ff6600" opacity="0.4"/>
+  <circle cx="20" cy="9" r="0.7" fill="#ff8800" opacity="0.4"/>
+  <circle cx="16" cy="8" r="0.8" fill="#ffaa00" opacity="0.3"/>
+</svg>

--- a/web/public/sprites/canopy-blind.svg
+++ b/web/public/sprites/canopy-blind.svg
@@ -1,0 +1,38 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Tree trunks -->
+  <rect x="5" y="14" width="4" height="18" rx="1" fill="#5a3a1a"/>
+  <rect x="23" y="14" width="4" height="18" rx="1" fill="#5a3a1a"/>
+  <rect x="14" y="16" width="4" height="16" rx="1" fill="#5a3a1a"/>
+  <!-- Bark texture -->
+  <line x1="6" y1="16" x2="8" y2="20" stroke="#3a1a00" stroke-width="0.6"/>
+  <line x1="24" y1="16" x2="26" y2="20" stroke="#3a1a00" stroke-width="0.6"/>
+  <!-- Platform/blind structure -->
+  <rect x="2" y="12" width="28" height="5" rx="1" fill="#6a4a2a"/>
+  <rect x="2" y="12" width="28" height="2" fill="#7a5a3a"/>
+  <!-- Plank lines -->
+  <line x1="6" y1="12" x2="6" y2="17" stroke="#4a2a0a" stroke-width="0.6"/>
+  <line x1="11" y1="12" x2="11" y2="17" stroke="#4a2a0a" stroke-width="0.6"/>
+  <line x1="16" y1="12" x2="16" y2="17" stroke="#4a2a0a" stroke-width="0.6"/>
+  <line x1="21" y1="12" x2="21" y2="17" stroke="#4a2a0a" stroke-width="0.6"/>
+  <line x1="26" y1="12" x2="26" y2="17" stroke="#4a2a0a" stroke-width="0.6"/>
+  <!-- Canopy of leaves above blind -->
+  <ellipse cx="16" cy="8" rx="15" ry="5" fill="#2a6a10"/>
+  <ellipse cx="10" cy="7" rx="8" ry="4" fill="#3a7a18"/>
+  <ellipse cx="22" cy="7" rx="8" ry="4" fill="#3a7a18"/>
+  <ellipse cx="16" cy="6" rx="10" ry="4" fill="#4a8a20"/>
+  <!-- Leaf cluster details -->
+  <circle cx="6" cy="7" r="3" fill="#3a7a18"/>
+  <circle cx="12" cy="5" r="3.5" fill="#4a8a20"/>
+  <circle cx="20" cy="5" r="3.5" fill="#4a8a20"/>
+  <circle cx="26" cy="7" r="3" fill="#3a7a18"/>
+  <!-- Observation slit -->
+  <rect x="10" y="13" width="12" height="2" fill="#1a0a00" opacity="0.7"/>
+  <!-- Rope/lashing on posts -->
+  <line x1="2" y1="13" x2="5" y2="13" stroke="#8a6a3a" stroke-width="0.8"/>
+  <line x1="27" y1="13" x2="30" y2="13" stroke="#8a6a3a" stroke-width="0.8"/>
+  <!-- Camouflage leaves hanging from platform -->
+  <line x1="8" y1="17" x2="6" y2="22" stroke="#3a7a18" stroke-width="1"/>
+  <line x1="14" y1="17" x2="12" y2="22" stroke="#4a8a20" stroke-width="1"/>
+  <line x1="19" y1="17" x2="21" y2="22" stroke="#3a7a18" stroke-width="1"/>
+  <line x1="25" y1="17" x2="27" y2="22" stroke="#4a8a20" stroke-width="1"/>
+</svg>

--- a/web/public/sprites/canopy-eyrie.svg
+++ b/web/public/sprites/canopy-eyrie.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="11" ry="1.5" fill="#2a1a0a" opacity="0.4"/>
+  <!-- Thick trunk -->
+  <rect x="12" y="18" width="8" height="14" rx="2" fill="#6a4a1a"/>
+  <line x1="14" y1="18" x2="16" y2="25" stroke="#4a2a00" stroke-width="0.8"/>
+  <line x1="18" y1="18" x2="16" y2="24" stroke="#4a2a00" stroke-width="0.8"/>
+  <!-- Branch supports for eyrie -->
+  <line x1="16" y1="14" x2="6" y2="18" stroke="#5a3a1a" stroke-width="2.5"/>
+  <line x1="16" y1="14" x2="26" y2="18" stroke="#5a3a1a" stroke-width="2.5"/>
+  <line x1="16" y1="14" x2="4" y2="12" stroke="#5a3a1a" stroke-width="2"/>
+  <line x1="16" y1="14" x2="28" y2="12" stroke="#5a3a1a" stroke-width="2"/>
+  <!-- Eyrie nest platform -->
+  <ellipse cx="16" cy="13" rx="13" ry="4" fill="#7a5a2a"/>
+  <ellipse cx="16" cy="12" rx="12" ry="3.5" fill="#8a6a3a"/>
+  <!-- Nest bowl rim (twigs) -->
+  <ellipse cx="16" cy="12" rx="10" ry="3" fill="none" stroke="#5a3a1a" stroke-width="1.5"/>
+  <ellipse cx="16" cy="11.5" rx="8" ry="2.5" fill="#9a7a4a"/>
+  <!-- Eggs or chicks in nest -->
+  <ellipse cx="13" cy="11" rx="2" ry="1.5" fill="#e8e0c0"/>
+  <ellipse cx="17" cy="10.5" rx="2" ry="1.5" fill="#ddd8b0"/>
+  <ellipse cx="20" cy="11.5" rx="2" ry="1.5" fill="#e8e0c0"/>
+  <!-- Bird/flying creature silhouette above -->
+  <path d="M10,4 Q13,1 16,4 Q19,1 22,4" fill="none" stroke="#2a1a0a" stroke-width="1.5"/>
+  <ellipse cx="16" cy="4" rx="2" ry="1.2" fill="#3a2a1a"/>
+  <!-- Leafy canopy around eyrie -->
+  <circle cx="3" cy="10" r="4" fill="#3a7a18" opacity="0.8"/>
+  <circle cx="29" cy="10" r="4" fill="#3a7a18" opacity="0.8"/>
+  <circle cx="8" cy="6" r="3.5" fill="#4a8a20" opacity="0.7"/>
+  <circle cx="24" cy="6" r="3.5" fill="#4a8a20" opacity="0.7"/>
+  <ellipse cx="16" cy="4" rx="6" ry="3" fill="#3a7a18" opacity="0.4"/>
+</svg>

--- a/web/public/sprites/catapult-works.svg
+++ b/web/public/sprites/catapult-works.svg
@@ -1,0 +1,38 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#3a2a1a" opacity="0.4"/>
+  <!-- Reinforced base platform -->
+  <rect x="2" y="23" width="28" height="8" rx="1" fill="#6a5030"/>
+  <rect x="2" y="23" width="28" height="2" fill="#7a6040"/>
+  <!-- Wheels -->
+  <circle cx="7" cy="26" r="4" fill="none" stroke="#5a3a1a" stroke-width="2"/>
+  <circle cx="7" cy="26" r="1.5" fill="#5a3a1a"/>
+  <line x1="7" y1="22" x2="7" y2="30" stroke="#5a3a1a" stroke-width="1"/>
+  <line x1="3" y1="26" x2="11" y2="26" stroke="#5a3a1a" stroke-width="1"/>
+  <circle cx="25" cy="26" r="4" fill="none" stroke="#5a3a1a" stroke-width="2"/>
+  <circle cx="25" cy="26" r="1.5" fill="#5a3a1a"/>
+  <line x1="25" y1="22" x2="25" y2="30" stroke="#5a3a1a" stroke-width="1"/>
+  <line x1="21" y1="26" x2="29" y2="26" stroke="#5a3a1a" stroke-width="1"/>
+  <!-- Frame sides -->
+  <line x1="10" y1="23" x2="8" y2="14" stroke="#6a4a1a" stroke-width="2.5"/>
+  <line x1="22" y1="23" x2="24" y2="14" stroke="#6a4a1a" stroke-width="2.5"/>
+  <!-- Cross brace -->
+  <line x1="8" y1="20" x2="24" y2="20" stroke="#7a5a2a" stroke-width="1.5"/>
+  <line x1="8" y1="14" x2="24" y2="14" stroke="#6a4a1a" stroke-width="2"/>
+  <!-- Pivot axle -->
+  <circle cx="16" cy="14" r="2" fill="#5a4a2a"/>
+  <!-- Throwing arm (angled, pulled back) -->
+  <line x1="16" y1="14" x2="26" y2="8" stroke="#6a4a1a" stroke-width="2.5"/>
+  <!-- Counterweight bucket -->
+  <rect x="24" y="4" width="5" height="5" rx="1" fill="#5a4030"/>
+  <rect x="24" y="4" width="5" height="2" fill="#6a5040"/>
+  <!-- Weight chain -->
+  <line x1="26.5" y1="4" x2="26" y2="8" stroke="#6a6050" stroke-width="1"/>
+  <!-- Sling cup at end with boulder -->
+  <circle cx="4" cy="20" r="3" fill="#7a7060"/>
+  <circle cx="4" cy="20" r="2" fill="#8a8070"/>
+  <!-- Sling rope -->
+  <line x1="4" y1="17" x2="10" y2="14" stroke="#9a8060" stroke-width="1"/>
+  <!-- Tensioning ropes -->
+  <line x1="10" y1="20" x2="14" y2="23" stroke="#8a6a3a" stroke-width="0.8"/>
+  <line x1="22" y1="20" x2="18" y2="23" stroke="#8a6a3a" stroke-width="0.8"/>
+</svg>

--- a/web/public/sprites/centaur-run.svg
+++ b/web/public/sprites/centaur-run.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <ellipse cx="16" cy="31" rx="14" ry="1.5" fill="#3a2a1a" opacity="0.4"/>
+  <!-- Grassy track ground -->
+  <rect x="0" y="24" width="32" height="8" fill="#5a7020"/>
+  <rect x="0" y="24" width="32" height="2" fill="#6a8030"/>
+  <!-- Track lane markings -->
+  <line x1="0" y1="27" x2="32" y2="27" stroke="#8a9040" stroke-width="0.6" stroke-dasharray="3,3"/>
+  <!-- Archway entrance posts -->
+  <rect x="2" y="8" width="5" height="17" rx="1" fill="#7a6a40"/>
+  <rect x="25" y="8" width="5" height="17" rx="1" fill="#7a6a40"/>
+  <rect x="2" y="8" width="5" height="2" fill="#8a7a50"/>
+  <rect x="25" y="8" width="5" height="2" fill="#8a7a50"/>
+  <!-- Arch over gate -->
+  <path d="M2,8 Q16,0 30,8" fill="none" stroke="#7a6a40" stroke-width="3"/>
+  <path d="M3,8 Q16,1 29,8" fill="none" stroke="#8a7a50" stroke-width="1"/>
+  <!-- Centaur silhouette on arch banner -->
+  <!-- Horse body -->
+  <ellipse cx="16" cy="5" rx="4" ry="2" fill="#6a4a20"/>
+  <!-- Horse legs -->
+  <line x1="13" y1="6" x2="12" y2="9" stroke="#5a3a10" stroke-width="1.2"/>
+  <line x1="15" y1="6.5" x2="14" y2="9" stroke="#5a3a10" stroke-width="1.2"/>
+  <line x1="17" y1="6.5" x2="18" y2="9" stroke="#5a3a10" stroke-width="1.2"/>
+  <line x1="19" y1="6" x2="20" y2="9" stroke="#5a3a10" stroke-width="1.2"/>
+  <!-- Human torso -->
+  <rect x="15" y="2" width="3" height="4" fill="#6a4a20"/>
+  <!-- Head -->
+  <circle cx="16.5" cy="1.5" r="1.5" fill="#8a6a40"/>
+  <!-- Arrow/bow raised -->
+  <line x1="17" y1="2" x2="22" y2="0" stroke="#5a3a10" stroke-width="0.8"/>
+  <!-- Decorative wreaths on posts -->
+  <circle cx="4.5" cy="9" r="2" fill="none" stroke="#3a7a18" stroke-width="1"/>
+  <circle cx="27.5" cy="9" r="2" fill="none" stroke="#3a7a18" stroke-width="1"/>
+  <!-- Hurdle/fence on track -->
+  <rect x="13" y="21" width="6" height="3" rx="1" fill="#7a5a2a"/>
+  <line x1="14" y1="21" x2="14" y2="25" stroke="#5a3a0a" stroke-width="1.2"/>
+  <line x1="18" y1="21" x2="18" y2="25" stroke="#5a3a0a" stroke-width="1.2"/>
+  <!-- Hoof marks on track -->
+  <ellipse cx="7" cy="26" rx="1.2" ry="0.8" fill="#4a5a18" opacity="0.5"/>
+  <ellipse cx="9" cy="28" rx="1.2" ry="0.8" fill="#4a5a18" opacity="0.5"/>
+  <ellipse cx="22" cy="25" rx="1.2" ry="0.8" fill="#4a5a18" opacity="0.5"/>
+  <ellipse cx="25" cy="28" rx="1.2" ry="0.8" fill="#4a5a18" opacity="0.5"/>
+</svg>

--- a/web/public/sprites/char-kennel.svg
+++ b/web/public/sprites/char-kennel.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#1a0a00" opacity="0.5"/>
+  <!-- Scorched ground -->
+  <rect x="0" y="24" width="32" height="8" fill="#2a1a0a"/>
+  <ellipse cx="16" cy="28" rx="12" ry="3" fill="#3a2010" opacity="0.5"/>
+  <!-- Burnt/charred kennel building -->
+  <rect x="4" y="14" width="24" height="11" rx="1" fill="#2a2010"/>
+  <rect x="4" y="14" width="24" height="3" fill="#3a3020"/>
+  <!-- Charred wood grain -->
+  <line x1="4" y1="18" x2="28" y2="18" stroke="#1a1008" stroke-width="0.7"/>
+  <line x1="4" y1="21" x2="28" y2="21" stroke="#1a1008" stroke-width="0.7"/>
+  <line x1="10" y1="14" x2="10" y2="24" stroke="#1a1008" stroke-width="0.7"/>
+  <line x1="22" y1="14" x2="22" y2="24" stroke="#1a1008" stroke-width="0.7"/>
+  <!-- Scorched/warped roof -->
+  <polygon points="2,14 16,4 30,14" fill="#1a1008"/>
+  <polygon points="4,14 16,5 28,14" fill="#2a2010"/>
+  <!-- Ember glows in damaged sections -->
+  <circle cx="8" cy="12" r="1.5" fill="#ff4400" opacity="0.5"/>
+  <circle cx="24" cy="11" r="1.5" fill="#ff6600" opacity="0.4"/>
+  <circle cx="16" cy="7" r="2" fill="#ff3300" opacity="0.3"/>
+  <!-- Smoke rising from roof -->
+  <path d="M10,5 Q9,2 11,0" fill="none" stroke="#444030" stroke-width="1.2" opacity="0.6"/>
+  <path d="M16,4 Q15,1 17,0" fill="none" stroke="#555040" stroke-width="1.2" opacity="0.5"/>
+  <path d="M22,5 Q23,2 21,0" fill="none" stroke="#444030" stroke-width="1.2" opacity="0.6"/>
+  <!-- Fire-hound lair opening (glowing inside) -->
+  <path d="M12,24 L12,18 Q16,15 20,18 L20,24 Z" fill="#1a0a00"/>
+  <ellipse cx="16" cy="20" rx="3" ry="2.5" fill="#cc3300" opacity="0.4"/>
+  <ellipse cx="16" cy="20" rx="1.5" ry="1.5" fill="#ff6600" opacity="0.5"/>
+  <!-- Burn marks/scorch patterns on walls -->
+  <path d="M6,16 Q8,13 9,16" fill="#1a0808" opacity="0.6"/>
+  <path d="M23,16 Q25,13 26,16" fill="#1a0808" opacity="0.6"/>
+  <!-- Chain stake (fire-proof) -->
+  <line x1="16" y1="24" x2="16" y2="28" stroke="#5a5040" stroke-width="1.5"/>
+  <circle cx="16" cy="24" r="1.2" fill="#6a6050"/>
+  <!-- Red embers on ground -->
+  <circle cx="8" cy="26" r="0.8" fill="#ff4400" opacity="0.4"/>
+  <circle cx="24" cy="27" r="0.8" fill="#ff3300" opacity="0.4"/>
+  <circle cx="12" cy="29" r="0.6" fill="#cc2200" opacity="0.5"/>
+</svg>


### PR DESCRIPTION
Adds 10 building SVG sprites for batch 3/19, closing #997.

## Buildings added

| Card | File |
|---|---|
| Bone Hall | `bone-hall.svg` — stone hall with bone inlay, skull ornaments and cross windows |
| Bone Pit | `bone-pit.svg` — staked pit filled with skulls and bones |
| Bone Tower | `bone-tower.svg` — tower with bone battlements and skull pinnacle |
| Brass Works | `brass-works.svg` — brass-pipe workshop with gear valves and steam chimneys |
| Caldera Forge | `caldera-forge.svg` — forge over a lava caldera with molten core |
| Canopy Blind | `canopy-blind.svg` — elevated treehouse platform hidden under leaf canopy |
| Canopy Eyrie | `canopy-eyrie.svg` — high nest on tree branches with eggs and flying bird |
| Catapult Works | `catapult-works.svg` — wheeled catapult frame with counterweight and loaded sling |
| Centaur Run | `centaur-run.svg` — arched gate track with centaur silhouette and hurdle |
| Char Kennel | `char-kennel.svg` — scorched fire-hound kennel with embers and smoke |

## Test plan

- [ ] Each sprite visible in card collection view
- [ ] Each sprite visible in battle when the structure is placed


---
_Generated by [Claude Code](https://claude.ai/code/session_01TWFNogtCtcNR4qd2ZbxCCx)_