### PR TITLE
feat(sprites): building SVGs batch 4/19 — Chrono Spire → Crystal Cavern

### DIFF
--- a/web/public/sprites/chrono-spire.svg
+++ b/web/public/sprites/chrono-spire.svg
@@ -1,0 +1,41 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <ellipse cx="16" cy="31" rx="9" ry="1.5" fill="#1a1a2a" opacity="0.5"/>
+  <!-- Base platform -->
+  <rect x="6" y="25" width="20" height="6" rx="1" fill="#5a5070"/>
+  <rect x="6" y="25" width="20" height="2" fill="#6a6080"/>
+  <!-- Gear rings around base -->
+  <circle cx="16" cy="25" r="8" fill="none" stroke="#9090b0" stroke-width="1.2" stroke-dasharray="2,2"/>
+  <!-- Main spire body -->
+  <rect x="10" y="12" width="12" height="14" fill="#6a6080"/>
+  <rect x="10" y="12" width="12" height="3" fill="#7a7090"/>
+  <!-- Clock face on front -->
+  <circle cx="16" cy="19" r="4.5" fill="#2a2a3a"/>
+  <circle cx="16" cy="19" r="4" fill="#1a1a2a"/>
+  <circle cx="16" cy="19" r="3.5" fill="#e8e0c0" opacity="0.9"/>
+  <!-- Clock numerals (simplified dots) -->
+  <circle cx="16" cy="15.8" r="0.5" fill="#2a2a3a"/>
+  <circle cx="19" cy="17" r="0.4" fill="#2a2a3a"/>
+  <circle cx="19" cy="21" r="0.4" fill="#2a2a3a"/>
+  <circle cx="16" cy="22.2" r="0.5" fill="#2a2a3a"/>
+  <circle cx="13" cy="21" r="0.4" fill="#2a2a3a"/>
+  <circle cx="13" cy="17" r="0.4" fill="#2a2a3a"/>
+  <!-- Clock hands -->
+  <line x1="16" y1="19" x2="16" y2="16.5" stroke="#2a2a3a" stroke-width="0.8"/>
+  <line x1="16" y1="19" x2="18" y2="20" stroke="#2a2a3a" stroke-width="0.6"/>
+  <!-- Center pivot -->
+  <circle cx="16" cy="19" r="0.5" fill="#2a2a3a"/>
+  <!-- Upper spire -->
+  <rect x="13" y="6" width="6" height="7" fill="#7a7090"/>
+  <rect x="13" y="6" width="6" height="2" fill="#8a80a0"/>
+  <!-- Gear ornament at upper level -->
+  <circle cx="16" cy="9" r="2" fill="none" stroke="#9090b0" stroke-width="0.8"/>
+  <circle cx="16" cy="9" r="0.8" fill="#9090b0"/>
+  <!-- Thin spire tip -->
+  <polygon points="16,0 19,6 13,6" fill="#5a5070"/>
+  <polygon points="16,0 17,6 15,6" fill="#7a7090"/>
+  <!-- Floating hour particles (clockwork magic) -->
+  <circle cx="8" cy="18" r="0.7" fill="#9090ff" opacity="0.6"/>
+  <circle cx="24" cy="16" r="0.7" fill="#9090ff" opacity="0.6"/>
+  <circle cx="10" cy="10" r="0.6" fill="#b0b0ff" opacity="0.5"/>
+  <circle cx="22" cy="10" r="0.6" fill="#b0b0ff" opacity="0.5"/>
+</svg>

--- a/web/public/sprites/cinder-fortress.svg
+++ b/web/public/sprites/cinder-fortress.svg
@@ -1,0 +1,48 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <ellipse cx="16" cy="31" rx="14" ry="1.5" fill="#1a0a00" opacity="0.5"/>
+  <!-- Base walls (wide, heavy) -->
+  <rect x="1" y="16" width="30" height="15" rx="1" fill="#4a3020"/>
+  <rect x="1" y="16" width="30" height="3" fill="#5a4030"/>
+  <!-- Scorched stone blocks -->
+  <line x1="1" y1="20" x2="31" y2="20" stroke="#2a1808" stroke-width="0.7"/>
+  <line x1="1" y1="24" x2="31" y2="24" stroke="#2a1808" stroke-width="0.7"/>
+  <line x1="1" y1="28" x2="31" y2="28" stroke="#2a1808" stroke-width="0.7"/>
+  <line x1="8" y1="16" x2="8" y2="31" stroke="#2a1808" stroke-width="0.7"/>
+  <line x1="16" y1="16" x2="16" y2="31" stroke="#2a1808" stroke-width="0.7"/>
+  <line x1="24" y1="16" x2="24" y2="31" stroke="#2a1808" stroke-width="0.7"/>
+  <!-- Corner towers -->
+  <rect x="1" y="8" width="8" height="9" fill="#5a3a20"/>
+  <rect x="23" y="8" width="8" height="9" fill="#5a3a20"/>
+  <rect x="1" y="8" width="8" height="3" fill="#6a4a30"/>
+  <rect x="23" y="8" width="8" height="3" fill="#6a4a30"/>
+  <!-- Cinder/ember battlements -->
+  <rect x="1" y="5" width="2" height="4" fill="#5a3a20"/>
+  <rect x="4" y="5" width="2" height="4" fill="#5a3a20"/>
+  <rect x="7" y="5" width="2" height="4" fill="#5a3a20"/>
+  <rect x="23" y="5" width="2" height="4" fill="#5a3a20"/>
+  <rect x="26" y="5" width="2" height="4" fill="#5a3a20"/>
+  <rect x="29" y="5" width="2" height="4" fill="#5a3a20"/>
+  <!-- Glowing ember cores in battlements -->
+  <circle cx="2" cy="6" r="0.6" fill="#ff6600" opacity="0.6"/>
+  <circle cx="5" cy="6" r="0.6" fill="#ff4400" opacity="0.6"/>
+  <circle cx="8" cy="6" r="0.6" fill="#ff6600" opacity="0.6"/>
+  <circle cx="24" cy="6" r="0.6" fill="#ff4400" opacity="0.6"/>
+  <circle cx="27" cy="6" r="0.6" fill="#ff6600" opacity="0.6"/>
+  <circle cx="30" cy="6" r="0.6" fill="#ff4400" opacity="0.6"/>
+  <!-- Center keep -->
+  <rect x="9" y="10" width="14" height="7" fill="#6a4a30"/>
+  <rect x="9" y="10" width="14" height="2" fill="#7a5a40"/>
+  <!-- Flame-lit windows -->
+  <rect x="11" y="11" width="3" height="3" fill="#1a0800"/>
+  <rect x="11" y="11" width="3" height="2" fill="#ff6600" opacity="0.5" rx="1"/>
+  <rect x="18" y="11" width="3" height="3" fill="#1a0800"/>
+  <rect x="18" y="11" width="3" height="2" fill="#ff6600" opacity="0.5" rx="1"/>
+  <!-- Gate door -->
+  <rect x="13" y="22" width="6" height="9" fill="#1a0800"/>
+  <!-- Fire glow from gate interior -->
+  <ellipse cx="16" cy="28" rx="2.5" ry="2" fill="#cc3300" opacity="0.4"/>
+  <!-- Cinder particles floating -->
+  <circle cx="4" cy="14" r="0.7" fill="#ff6600" opacity="0.5"/>
+  <circle cx="28" cy="12" r="0.7" fill="#ff4400" opacity="0.5"/>
+  <circle cx="16" cy="6" r="0.8" fill="#ff8800" opacity="0.4"/>
+</svg>

--- a/web/public/sprites/cinder-watch.svg
+++ b/web/public/sprites/cinder-watch.svg
@@ -1,0 +1,41 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <ellipse cx="16" cy="31" rx="8" ry="1.5" fill="#1a0a00" opacity="0.5"/>
+  <!-- Base -->
+  <rect x="8" y="25" width="16" height="6" rx="1" fill="#3a2a10"/>
+  <rect x="8" y="25" width="16" height="2" fill="#4a3a20"/>
+  <!-- Scorched stone tower -->
+  <rect x="10" y="10" width="12" height="16" fill="#4a3020"/>
+  <rect x="10" y="10" width="12" height="3" fill="#5a4030"/>
+  <!-- Scorch marks on stone -->
+  <path d="M12,14 Q11,18 12,22" fill="none" stroke="#2a1008" stroke-width="1.5" opacity="0.6"/>
+  <path d="M20,14 Q21,17 20,21" fill="none" stroke="#2a1008" stroke-width="1.5" opacity="0.6"/>
+  <line x1="10" y1="15" x2="22" y2="15" stroke="#2a1008" stroke-width="0.6"/>
+  <line x1="10" y1="19" x2="22" y2="19" stroke="#2a1008" stroke-width="0.6"/>
+  <!-- Upper watch platform -->
+  <rect x="8" y="6" width="16" height="5" fill="#5a4030"/>
+  <rect x="8" y="6" width="16" height="2" fill="#6a5040"/>
+  <!-- Ember battlements -->
+  <rect x="8" y="3" width="3" height="4" fill="#4a3020"/>
+  <rect x="12.5" y="3" width="3" height="4" fill="#4a3020"/>
+  <rect x="17" y="3" width="3" height="4" fill="#4a3020"/>
+  <rect x="21" y="3" width="3" height="4" fill="#4a3020"/>
+  <!-- Glowing embers in battlements -->
+  <circle cx="9.5" cy="4" r="0.8" fill="#ff5500" opacity="0.7"/>
+  <circle cx="14" cy="4" r="0.8" fill="#ff7700" opacity="0.7"/>
+  <circle cx="18.5" cy="4" r="0.8" fill="#ff5500" opacity="0.7"/>
+  <circle cx="22.5" cy="4" r="0.8" fill="#ff7700" opacity="0.7"/>
+  <!-- Arrow slits -->
+  <rect x="13" y="12" width="2" height="5" fill="#1a0800" rx="1"/>
+  <rect x="17" y="12" width="2" height="5" fill="#1a0800" rx="1"/>
+  <!-- Fire brazier on top -->
+  <rect x="14" y="2" width="4" height="2" rx="1" fill="#3a2010"/>
+  <ellipse cx="16" cy="2" rx="3" ry="1.5" fill="#ff4400" opacity="0.8"/>
+  <ellipse cx="16" cy="1.5" rx="2" ry="1.2" fill="#ff8800" opacity="0.7"/>
+  <ellipse cx="16" cy="1" rx="1.2" ry="0.8" fill="#ffcc00" opacity="0.8"/>
+  <!-- Smoke from brazier -->
+  <path d="M14,1 Q13,0 14,-1" fill="none" stroke="#555040" stroke-width="0.8" opacity="0.5"/>
+  <path d="M18,1 Q19,0 18,-1" fill="none" stroke="#555040" stroke-width="0.8" opacity="0.5"/>
+  <!-- Cinder sparks rising -->
+  <circle cx="13" cy="8" r="0.6" fill="#ff6600" opacity="0.5"/>
+  <circle cx="19" cy="7" r="0.6" fill="#ff4400" opacity="0.5"/>
+</svg>

--- a/web/public/sprites/clockwork-armory.svg
+++ b/web/public/sprites/clockwork-armory.svg
@@ -1,0 +1,43 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#1a1a2a" opacity="0.5"/>
+  <!-- Armory base -->
+  <rect x="2" y="22" width="28" height="9" rx="1" fill="#4a4a5a"/>
+  <rect x="2" y="22" width="28" height="2" fill="#5a5a6a"/>
+  <!-- Main building -->
+  <rect x="4" y="11" width="24" height="12" fill="#5a5a6a"/>
+  <rect x="4" y="11" width="24" height="3" fill="#6a6a7a"/>
+  <!-- Metal panel lines -->
+  <line x1="4" y1="15" x2="28" y2="15" stroke="#3a3a4a" stroke-width="0.7"/>
+  <line x1="4" y1="18" x2="28" y2="18" stroke="#3a3a4a" stroke-width="0.7"/>
+  <line x1="11" y1="11" x2="11" y2="22" stroke="#3a3a4a" stroke-width="0.7"/>
+  <line x1="21" y1="11" x2="21" y2="22" stroke="#3a3a4a" stroke-width="0.7"/>
+  <!-- Large gears on facade -->
+  <circle cx="7" cy="17" r="3" fill="none" stroke="#9090b0" stroke-width="1.2"/>
+  <circle cx="7" cy="17" r="1.2" fill="#8080a0"/>
+  <line x1="7" y1="13.5" x2="7" y2="20.5" stroke="#9090b0" stroke-width="0.8"/>
+  <line x1="3.5" y1="17" x2="10.5" y2="17" stroke="#9090b0" stroke-width="0.8"/>
+  <line x1="4.9" y1="14.4" x2="9.1" y2="19.6" stroke="#9090b0" stroke-width="0.8"/>
+  <line x1="4.9" y1="19.6" x2="9.1" y2="14.4" stroke="#9090b0" stroke-width="0.8"/>
+  <circle cx="25" cy="17" r="3" fill="none" stroke="#9090b0" stroke-width="1.2"/>
+  <circle cx="25" cy="17" r="1.2" fill="#8080a0"/>
+  <line x1="25" y1="13.5" x2="25" y2="20.5" stroke="#9090b0" stroke-width="0.8"/>
+  <line x1="21.5" y1="17" x2="28.5" y2="17" stroke="#9090b0" stroke-width="0.8"/>
+  <line x1="22.9" y1="14.4" x2="27.1" y2="19.6" stroke="#9090b0" stroke-width="0.8"/>
+  <line x1="22.9" y1="19.6" x2="27.1" y2="14.4" stroke="#9090b0" stroke-width="0.8"/>
+  <!-- Weapon display on central panel -->
+  <!-- Crossed swords -->
+  <line x1="13" y1="13" x2="19" y2="20" stroke="#c8c0a0" stroke-width="1.2"/>
+  <line x1="19" y1="13" x2="13" y2="20" stroke="#c8c0a0" stroke-width="1.2"/>
+  <!-- Roof with clockwork dome -->
+  <ellipse cx="16" cy="11" rx="12" ry="3" fill="#4a4a5a"/>
+  <ellipse cx="16" cy="10" rx="8" ry="3" fill="#5a5a6a"/>
+  <circle cx="16" cy="8" r="4" fill="#4a4a5a"/>
+  <circle cx="16" cy="8" r="2.5" fill="#3a3a4a"/>
+  <!-- Clock on dome -->
+  <circle cx="16" cy="8" r="2" fill="#e8e0c0" opacity="0.8"/>
+  <line x1="16" y1="8" x2="16" y2="6.5" stroke="#2a2a3a" stroke-width="0.7"/>
+  <line x1="16" y1="8" x2="17" y2="8.5" stroke="#2a2a3a" stroke-width="0.5"/>
+  <circle cx="16" cy="8" r="0.4" fill="#2a2a3a"/>
+  <!-- Door -->
+  <rect x="13" y="18" width="6" height="5" fill="#2a2a3a"/>
+</svg>

--- a/web/public/sprites/cloud-eyrie.svg
+++ b/web/public/sprites/cloud-eyrie.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Sky background suggestion -->
+  <rect x="0" y="0" width="32" height="32" fill="#c8dcf0" opacity="0.2"/>
+  <!-- Cloud platform base -->
+  <ellipse cx="16" cy="24" rx="14" ry="5" fill="#e8f0ff"/>
+  <ellipse cx="10" cy="23" rx="7" ry="4" fill="#f0f5ff"/>
+  <ellipse cx="22" cy="23" rx="7" ry="4" fill="#f0f5ff"/>
+  <ellipse cx="16" cy="22" rx="12" ry="4.5" fill="#ffffff"/>
+  <!-- Fluffy cloud puffs -->
+  <circle cx="5" cy="21" r="4" fill="#f0f5ff"/>
+  <circle cx="10" cy="19" r="4.5" fill="#ffffff"/>
+  <circle cx="16" cy="18" rx="5" r="5" fill="#f0f5ff"/>
+  <circle cx="22" cy="19" r="4.5" fill="#ffffff"/>
+  <circle cx="27" cy="21" r="4" fill="#f0f5ff"/>
+  <!-- Nest perch on top of cloud -->
+  <ellipse cx="16" cy="17" rx="6" ry="2" fill="#8a6a3a"/>
+  <ellipse cx="16" cy="16.5" rx="5" ry="1.5" fill="#9a7a4a"/>
+  <!-- Twig details of nest -->
+  <line x1="11" y1="17" x2="14" y2="15" stroke="#6a4a1a" stroke-width="0.8"/>
+  <line x1="18" y1="15" x2="21" y2="17" stroke="#6a4a1a" stroke-width="0.8"/>
+  <line x1="13" y1="16" x2="12" y2="14" stroke="#6a4a1a" stroke-width="0.6"/>
+  <line x1="19" y1="16" x2="20" y2="14" stroke="#6a4a1a" stroke-width="0.6"/>
+  <!-- Eggs in nest -->
+  <ellipse cx="14" cy="16" rx="1.5" ry="1" fill="#ddd8c0"/>
+  <ellipse cx="17" cy="15.5" rx="1.5" ry="1" fill="#e8e4cc"/>
+  <!-- Perch post -->
+  <line x1="16" y1="17" x2="16" y2="22" stroke="#7a5a2a" stroke-width="1.5"/>
+  <!-- Bird/gryphon silhouette soaring above -->
+  <path d="M8,10 Q12,6 16,10 Q20,6 24,10" fill="none" stroke="#5a5a6a" stroke-width="1.5"/>
+  <ellipse cx="16" cy="10" rx="2" ry="1.2" fill="#6a6a7a"/>
+  <!-- Feathers floating down -->
+  <ellipse cx="9" cy="15" rx="0.8" ry="2" fill="#d0d8e8" opacity="0.7" transform="rotate(-20 9 15)"/>
+  <ellipse cx="23" cy="14" rx="0.8" ry="2" fill="#d0d8e8" opacity="0.7" transform="rotate(20 23 14)"/>
+  <ellipse cx="6" cy="24" rx="0.6" ry="1.5" fill="#d0d8e8" opacity="0.5" transform="rotate(-10 6 24)"/>
+  <ellipse cx="26" cy="26" rx="0.6" ry="1.5" fill="#d0d8e8" opacity="0.5" transform="rotate(10 26 26)"/>
+</svg>

--- a/web/public/sprites/coastal-abyss.svg
+++ b/web/public/sprites/coastal-abyss.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Sea surface -->
+  <rect x="0" y="16" width="32" height="16" fill="#1a4060"/>
+  <rect x="0" y="16" width="32" height="3" fill="#2a5070"/>
+  <!-- Wave crests -->
+  <path d="M0,17 Q4,15 8,17 Q12,19 16,17 Q20,15 24,17 Q28,19 32,17" fill="none" stroke="#3a7090" stroke-width="1" opacity="0.7"/>
+  <!-- Coastal cliff face -->
+  <polygon points="0,16 0,0 12,0 14,16" fill="#6a5a3a"/>
+  <polygon points="0,0 12,0 14,16 0,16" fill="#7a6a4a"/>
+  <!-- Cliff rock texture -->
+  <line x1="2" y1="4" x2="8" y2="6" stroke="#5a4a2a" stroke-width="0.7"/>
+  <line x1="3" y1="9" x2="9" y2="11" stroke="#5a4a2a" stroke-width="0.7"/>
+  <line x1="4" y1="14" x2="10" y2="15" stroke="#5a4a2a" stroke-width="0.7"/>
+  <!-- Abyss opening in sea floor (visible through clear water) -->
+  <ellipse cx="22" cy="26" rx="8" ry="4" fill="#0a1520" opacity="0.8"/>
+  <ellipse cx="22" cy="26" rx="6" ry="3" fill="#050810"/>
+  <ellipse cx="22" cy="26" rx="4" ry="2" fill="#020408"/>
+  <!-- Glowing abyss core deep below -->
+  <ellipse cx="22" cy="26" rx="2" ry="1" fill="#2200aa" opacity="0.5"/>
+  <!-- Dark tentacle/creature emerging from abyss -->
+  <path d="M20,24 Q18,20 16,18" fill="none" stroke="#0a0820" stroke-width="2"/>
+  <path d="M22,23 Q24,19 26,17" fill="none" stroke="#0a0820" stroke-width="2"/>
+  <path d="M24,25 Q26,22 28,20" fill="none" stroke="#0a0820" stroke-width="1.5"/>
+  <!-- Water foam/bubbles near abyss -->
+  <circle cx="16" cy="20" r="0.8" fill="#4a90b0" opacity="0.5"/>
+  <circle cx="28" cy="21" r="0.8" fill="#4a90b0" opacity="0.5"/>
+  <circle cx="19" cy="18" r="0.6" fill="#5aa0c0" opacity="0.4"/>
+  <!-- Lighthouse-like beacon on cliff -->
+  <rect x="4" y="2" width="4" height="8" fill="#9a8a6a"/>
+  <rect x="3" y="1" width="6" height="2" rx="1" fill="#7a6a4a"/>
+  <circle cx="6" cy="1" r="1.5" fill="#ffee88" opacity="0.8"/>
+</svg>

--- a/web/public/sprites/cog-works.svg
+++ b/web/public/sprites/cog-works.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#2a2010" opacity="0.5"/>
+  <!-- Workshop base -->
+  <rect x="2" y="22" width="28" height="9" rx="1" fill="#5a5030"/>
+  <rect x="2" y="22" width="28" height="2" fill="#6a6040"/>
+  <!-- Main workshop building -->
+  <rect x="4" y="12" width="24" height="11" fill="#6a6040"/>
+  <rect x="4" y="12" width="24" height="3" fill="#7a7050"/>
+  <!-- Shed roof (slanted) -->
+  <polygon points="2,12 30,12 28,6 4,6" fill="#5a5030"/>
+  <polygon points="4,12 28,12 26,7 6,7" fill="#6a6040"/>
+  <!-- Large display gear on front -->
+  <circle cx="16" cy="18" r="6" fill="none" stroke="#b0a040" stroke-width="1.5"/>
+  <circle cx="16" cy="18" r="4" fill="none" stroke="#8a8030" stroke-width="1"/>
+  <circle cx="16" cy="18" r="2" fill="#b0a040"/>
+  <!-- Gear teeth (8 teeth) -->
+  <rect x="15" y="11.5" width="2" height="2" fill="#b0a040" rx="0.3"/>
+  <rect x="15" y="22.5" width="2" height="2" fill="#b0a040" rx="0.3"/>
+  <rect x="9.5" y="17" width="2" height="2" fill="#b0a040" rx="0.3"/>
+  <rect x="20.5" y="17" width="2" height="2" fill="#b0a040" rx="0.3"/>
+  <rect x="11" y="13" width="1.5" height="1.5" fill="#b0a040" rx="0.3" transform="rotate(45 11.75 13.75)"/>
+  <rect x="19.5" y="13" width="1.5" height="1.5" fill="#b0a040" rx="0.3" transform="rotate(45 20.25 13.75)"/>
+  <rect x="11" y="21.5" width="1.5" height="1.5" fill="#b0a040" rx="0.3" transform="rotate(45 11.75 22.25)"/>
+  <rect x="19.5" y="21.5" width="1.5" height="1.5" fill="#b0a040" rx="0.3" transform="rotate(45 20.25 22.25)"/>
+  <!-- Gear spokes -->
+  <line x1="16" y1="14" x2="16" y2="22" stroke="#8a8030" stroke-width="0.7"/>
+  <line x1="12" y1="18" x2="20" y2="18" stroke="#8a8030" stroke-width="0.7"/>
+  <line x1="13.2" y1="15.2" x2="18.8" y2="20.8" stroke="#8a8030" stroke-width="0.7"/>
+  <line x1="18.8" y1="15.2" x2="13.2" y2="20.8" stroke="#8a8030" stroke-width="0.7"/>
+  <!-- Small gear top right -->
+  <circle cx="26" cy="9" r="2.5" fill="none" stroke="#b0a040" stroke-width="1"/>
+  <circle cx="26" cy="9" r="1" fill="#9a9030"/>
+  <!-- Small gear top left -->
+  <circle cx="6" cy="10" r="2" fill="none" stroke="#b0a040" stroke-width="1"/>
+  <circle cx="6" cy="10" r="0.8" fill="#9a9030"/>
+  <!-- Gear connecting shaft -->
+  <line x1="8" y1="10" x2="23.5" y2="9.5" stroke="#8a8030" stroke-width="0.8"/>
+  <!-- Workshop door -->
+  <rect x="13" y="18" width="6" height="5" fill="#2a2010"/>
+</svg>

--- a/web/public/sprites/coral-redoubt.svg
+++ b/web/public/sprites/coral-redoubt.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#0a3050" opacity="0.5"/>
+  <!-- Sandy ocean floor base -->
+  <rect x="0" y="26" width="32" height="6" fill="#7a6040"/>
+  <rect x="0" y="26" width="32" height="2" fill="#8a7050"/>
+  <!-- Coral structure walls -->
+  <rect x="4" y="14" width="24" height="13" rx="2" fill="#c84040"/>
+  <rect x="4" y="14" width="24" height="3" fill="#e05050"/>
+  <!-- Coral texture bumps on walls -->
+  <circle cx="8" cy="16" r="1.5" fill="#d04848"/>
+  <circle cx="12" cy="15" r="1.2" fill="#e05858"/>
+  <circle cx="16" cy="16" r="1.5" fill="#d04848"/>
+  <circle cx="20" cy="15" r="1.2" fill="#e05858"/>
+  <circle cx="24" cy="16" r="1.5" fill="#d04848"/>
+  <circle cx="7" cy="20" r="1" fill="#c03838"/>
+  <circle cx="25" cy="20" r="1" fill="#c03838"/>
+  <!-- Coral towers (irregular organic shapes) -->
+  <ellipse cx="8" cy="12" rx="4" ry="3" fill="#d04040"/>
+  <ellipse cx="24" cy="11" rx="4" ry="4" fill="#c83838"/>
+  <!-- Coral spires growing up -->
+  <path d="M6,12 Q5,6 8,4 Q9,9 8,12" fill="#c04040"/>
+  <path d="M10,12 Q12,5 11,2 Q13,5 12,12" fill="#d04848"/>
+  <path d="M22,11 Q20,4 23,2 Q24,6 22,11" fill="#c03838"/>
+  <path d="M26,11 Q27,5 24,3 Q26,6 26,11" fill="#d04040"/>
+  <!-- Gateway arch (coral frame) -->
+  <path d="M11,27 L11,20 Q16,15 21,20 L21,27 Z" fill="#1a0a00"/>
+  <path d="M11,20 Q16,14 21,20" fill="none" stroke="#e06060" stroke-width="2"/>
+  <!-- Sea anemones on walls -->
+  <circle cx="6" cy="22" r="2" fill="#ff88aa" opacity="0.6"/>
+  <circle cx="26" cy="22" r="2" fill="#ff88aa" opacity="0.6"/>
+  <circle cx="8" cy="25" r="1.5" fill="#ff66aa" opacity="0.5"/>
+  <circle cx="24" cy="25" r="1.5" fill="#ff66aa" opacity="0.5"/>
+  <!-- Kelp/seaweed -->
+  <path d="M2,30 Q3,26 2,22 Q3,18 2,14" fill="none" stroke="#2a8a2a" stroke-width="1.5" opacity="0.7"/>
+  <path d="M30,30 Q29,26 30,22 Q29,18 30,14" fill="none" stroke="#2a8a2a" stroke-width="1.5" opacity="0.7"/>
+  <!-- Bubbles rising -->
+  <circle cx="14" cy="12" r="0.7" fill="#aaccee" opacity="0.5"/>
+  <circle cx="19" cy="10" r="0.6" fill="#aaccee" opacity="0.5"/>
+  <circle cx="10" cy="8" r="0.5" fill="#aaccee" opacity="0.4"/>
+</svg>

--- a/web/public/sprites/crossbow-tower.svg
+++ b/web/public/sprites/crossbow-tower.svg
@@ -1,0 +1,41 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <ellipse cx="16" cy="31" rx="9" ry="1.5" fill="#3a2a1a" opacity="0.4"/>
+  <!-- Tower base -->
+  <rect x="8" y="24" width="16" height="7" rx="1" fill="#6a5a3a"/>
+  <rect x="8" y="24" width="16" height="2" fill="#7a6a4a"/>
+  <!-- Tower body -->
+  <rect x="10" y="12" width="12" height="13" fill="#7a6a4a"/>
+  <rect x="10" y="12" width="12" height="3" fill="#8a7a5a"/>
+  <!-- Stone block detail -->
+  <line x1="10" y1="16" x2="22" y2="16" stroke="#5a4a2a" stroke-width="0.6"/>
+  <line x1="10" y1="19" x2="22" y2="19" stroke="#5a4a2a" stroke-width="0.6"/>
+  <line x1="10" y1="22" x2="22" y2="22" stroke="#5a4a2a" stroke-width="0.6"/>
+  <line x1="14" y1="12" x2="14" y2="24" stroke="#5a4a2a" stroke-width="0.6"/>
+  <line x1="18" y1="12" x2="18" y2="24" stroke="#5a4a2a" stroke-width="0.6"/>
+  <!-- Upper platform with crossbow mount -->
+  <rect x="8" y="7" width="16" height="6" fill="#8a7a5a"/>
+  <rect x="8" y="7" width="16" height="2" fill="#9a8a6a"/>
+  <!-- Crossbow mounted on platform -->
+  <!-- Bow limbs -->
+  <path d="M9,9 Q12,7 16,9" fill="none" stroke="#5a3a1a" stroke-width="2"/>
+  <path d="M16,9 Q20,7 23,9" fill="none" stroke="#5a3a1a" stroke-width="2"/>
+  <!-- Stock/tiller -->
+  <rect x="13" y="8" width="8" height="2" rx="1" fill="#6a4a1a"/>
+  <!-- Bowstring -->
+  <line x1="9" y1="9" x2="23" y2="9" stroke="#c0a060" stroke-width="0.8"/>
+  <!-- Bolt loaded -->
+  <line x1="14" y1="9" x2="22" y2="9" stroke="#4a2a0a" stroke-width="1.5"/>
+  <polygon points="22,8.3 25,9 22,9.7" fill="#8a6a2a"/>
+  <!-- Battlements -->
+  <rect x="8" y="4" width="3" height="4" fill="#7a6a4a"/>
+  <rect x="13" y="4" width="3" height="4" fill="#7a6a4a"/>
+  <rect x="18" y="4" width="3" height="4" fill="#7a6a4a"/>
+  <!-- Arrow slits on tower body -->
+  <rect x="12" y="14" width="2" height="4" fill="#1a0a00" rx="1"/>
+  <rect x="18" y="14" width="2" height="4" fill="#1a0a00" rx="1"/>
+  <!-- Quiver of bolts leaning on tower -->
+  <rect x="8" y="16" width="2" height="6" rx="1" fill="#6a4a1a"/>
+  <line x1="8.5" y1="14" x2="8.5" y2="16" stroke="#8a6a2a" stroke-width="1"/>
+  <line x1="9.5" y1="14" x2="9.5" y2="16" stroke="#8a6a2a" stroke-width="1"/>
+  <line x1="9" y1="14" x2="9" y2="16" stroke="#8a6a2a" stroke-width="1"/>
+</svg>

--- a/web/public/sprites/crystal-cavern.svg
+++ b/web/public/sprites/crystal-cavern.svg
@@ -1,0 +1,37 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Cave background -->
+  <rect x="0" y="8" width="32" height="24" fill="#1a1030"/>
+  <rect x="0" y="8" width="32" height="4" fill="#2a2040"/>
+  <!-- Cave entrance arch -->
+  <path d="M2,32 L2,16 Q16,4 30,16 L30,32 Z" fill="#2a2040"/>
+  <path d="M4,32 L4,16 Q16,6 28,16 L28,32 Z" fill="#1a1030"/>
+  <!-- Ground crystals cluster bottom -->
+  <polygon points="12,32 14,26 16,32" fill="#6644cc"/>
+  <polygon points="14,32 16,24 18,32" fill="#8866ee"/>
+  <polygon points="16,32 18,27 20,32" fill="#6644cc"/>
+  <polygon points="10,32 11,28 13,32" fill="#5533bb"/>
+  <polygon points="19,32 21,27 22,32" fill="#7755dd"/>
+  <!-- Large crystal formations on sides -->
+  <!-- Left cluster -->
+  <polygon points="2,28 5,18 7,28" fill="#5533bb"/>
+  <polygon points="5,28 8,15 10,28" fill="#7755dd"/>
+  <polygon points="3,28 4,22 6,28" fill="#8866ee" opacity="0.8"/>
+  <!-- Right cluster -->
+  <polygon points="22,28 24,16 27,28" fill="#5533bb"/>
+  <polygon points="25,28 27,18 30,28" fill="#7755dd"/>
+  <polygon points="26,28 28,22 30,28" fill="#8866ee" opacity="0.8"/>
+  <!-- Ceiling crystals (stalactite-style) -->
+  <polygon points="8,8 10,8 9,16" fill="#6644cc" opacity="0.8"/>
+  <polygon points="14,8 16,8 15,18" fill="#8866ee" opacity="0.8"/>
+  <polygon points="22,8 24,8 23,15" fill="#6644cc" opacity="0.8"/>
+  <!-- Crystal glow reflections -->
+  <ellipse cx="10" cy="24" rx="3" ry="1.5" fill="#aa88ff" opacity="0.3"/>
+  <ellipse cx="22" cy="22" rx="3" ry="1.5" fill="#aa88ff" opacity="0.3"/>
+  <ellipse cx="16" cy="26" rx="4" ry="1.5" fill="#cc99ff" opacity="0.3"/>
+  <!-- Sparkling crystal facets -->
+  <circle cx="9" cy="20" r="0.8" fill="#ffffff" opacity="0.8"/>
+  <circle cx="24" cy="18" r="0.8" fill="#ffffff" opacity="0.8"/>
+  <circle cx="15" cy="25" r="0.6" fill="#ffffff" opacity="0.7"/>
+  <circle cx="6" cy="26" r="0.6" fill="#ddccff" opacity="0.6"/>
+  <circle cx="26" cy="25" r="0.6" fill="#ddccff" opacity="0.6"/>
+</svg>


### PR DESCRIPTION
Adds 10 building SVG sprites for batch 4/19, closing #998.

## Buildings added

| Card | File |
|---|---|
| Chrono Spire | `chrono-spire.svg` — clockwork spire with giant clock face and gear rings |
| Cinder Fortress | `cinder-fortress.svg` — scorched fortress with glowing ember battlements |
| Cinder Watch | `cinder-watch.svg` — fire-blackened watch tower with brazier on top |
| Clockwork Armory | `clockwork-armory.svg` — gear-covered armory with crossed swords and clock dome |
| Cloud Eyrie | `cloud-eyrie.svg` — nest platform atop a fluffy cloud with soaring gryphon |
| Coastal Abyss | `coastal-abyss.svg` — sea cliff with dark underwater abyss and tentacles |
| Cog Works | `cog-works.svg` — workshop dominated by a large gear display on the facade |
| Coral Redoubt | `coral-redoubt.svg` — underwater coral fortress with sea anemones and kelp |
| Crossbow Tower | `crossbow-tower.svg` — tower with mounted crossbow on upper platform |
| Crystal Cavern | `crystal-cavern.svg` — dark cave filled with glowing purple crystal formations |

## Test plan

- [ ] Each sprite visible in card collection view
- [ ] Each sprite visible in battle when the structure is placed


---
_Generated by [Claude Code](https://claude.ai/code/session_01TWFNogtCtcNR4qd2ZbxCCx)_