### PR TITLE
feat(sprites): building SVGs batch 5/19 — Crucible Hall → Dust Track

### DIFF
--- a/web/public/sprites/crucible-hall.svg
+++ b/web/public/sprites/crucible-hall.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#2a0a00" opacity="0.5"/>
+  <!-- Hall base -->
+  <rect x="2" y="18" width="28" height="13" rx="1" fill="#5a3a20"/>
+  <rect x="2" y="18" width="28" height="3" fill="#6a4a30"/>
+  <!-- Stone block lines -->
+  <line x1="2" y1="22" x2="30" y2="22" stroke="#3a1a08" stroke-width="0.6"/>
+  <line x1="2" y1="26" x2="30" y2="26" stroke="#3a1a08" stroke-width="0.6"/>
+  <line x1="9" y1="18" x2="9" y2="31" stroke="#3a1a08" stroke-width="0.6"/>
+  <line x1="16" y1="18" x2="16" y2="31" stroke="#3a1a08" stroke-width="0.6"/>
+  <line x1="23" y1="18" x2="23" y2="31" stroke="#3a1a08" stroke-width="0.6"/>
+  <!-- Gabled roof -->
+  <polygon points="0,18 16,4 32,18" fill="#3a1a08"/>
+  <polygon points="2,18 16,6 30,18" fill="#4a2a18"/>
+  <!-- Central crucible chimney (huge) -->
+  <rect x="12" y="4" width="8" height="15" rx="1" fill="#4a4040"/>
+  <rect x="12" y="4" width="8" height="3" fill="#5a5050"/>
+  <!-- Molten metal glow from chimney top -->
+  <ellipse cx="16" cy="4" rx="5" ry="2.5" fill="#ff4400" opacity="0.7"/>
+  <ellipse cx="16" cy="3" rx="3.5" ry="2" fill="#ff7700" opacity="0.8"/>
+  <ellipse cx="16" cy="2" rx="2" ry="1.5" fill="#ffaa00" opacity="0.9"/>
+  <!-- Side chimneys -->
+  <rect x="5" y="10" width="5" height="9" rx="1" fill="#4a4040"/>
+  <rect x="22" y="10" width="5" height="9" rx="1" fill="#4a4040"/>
+  <circle cx="7.5" cy="9" r="2" fill="#ff5500" opacity="0.6"/>
+  <circle cx="24.5" cy="9" r="2" fill="#ff5500" opacity="0.6"/>
+  <!-- Crucible/cauldron visible in doorway -->
+  <path d="M13,31 L13,24 Q16,21 19,24 L19,31 Z" fill="#1a0800"/>
+  <ellipse cx="16" cy="24" rx="3.5" ry="1.5" fill="#cc3300" opacity="0.7"/>
+  <ellipse cx="16" cy="23.5" rx="2.5" ry="1" fill="#ff6600" opacity="0.8"/>
+  <!-- Flame eruptions from base -->
+  <circle cx="5" cy="17" r="1.5" fill="#ff6600" opacity="0.4"/>
+  <circle cx="27" cy="17" r="1.5" fill="#ff4400" opacity="0.4"/>
+  <!-- Rivets/bolts on chimney -->
+  <circle cx="13" cy="7" r="0.6" fill="#7a7060"/>
+  <circle cx="19" cy="7" r="0.6" fill="#7a7060"/>
+  <circle cx="13" cy="12" r="0.6" fill="#7a7060"/>
+  <circle cx="19" cy="12" r="0.6" fill="#7a7060"/>
+</svg>

--- a/web/public/sprites/deeproot-hall.svg
+++ b/web/public/sprites/deeproot-hall.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#1a3010" opacity="0.5"/>
+  <!-- Deep roots spreading from building into ground -->
+  <path d="M8,28 Q4,30 2,32" fill="none" stroke="#3a2a10" stroke-width="2"/>
+  <path d="M12,28 Q8,32 5,32" fill="none" stroke="#3a2a10" stroke-width="1.5"/>
+  <path d="M20,28 Q24,32 27,32" fill="none" stroke="#3a2a10" stroke-width="2"/>
+  <path d="M24,28 Q28,31 30,32" fill="none" stroke="#3a2a10" stroke-width="1.5"/>
+  <path d="M16,30 Q14,32 12,32" fill="none" stroke="#4a3a18" stroke-width="1.2"/>
+  <path d="M16,30 Q18,32 20,32" fill="none" stroke="#4a3a18" stroke-width="1.2"/>
+  <!-- Hall walls (carved from living wood/roots) -->
+  <rect x="3" y="14" width="26" height="15" rx="2" fill="#5a4020"/>
+  <rect x="3" y="14" width="26" height="3" fill="#6a5030"/>
+  <!-- Wood grain lines -->
+  <line x1="3" y1="18" x2="29" y2="18" stroke="#3a2a10" stroke-width="0.7"/>
+  <line x1="3" y1="22" x2="29" y2="22" stroke="#3a2a10" stroke-width="0.7"/>
+  <line x1="3" y1="26" x2="29" y2="26" stroke="#3a2a10" stroke-width="0.7"/>
+  <!-- Gnarled wood columns -->
+  <path d="M5,14 Q4,10 6,8 Q5,11 7,14" fill="#4a3018" stroke="#3a2008" stroke-width="0.5"/>
+  <path d="M27,14 Q28,10 26,8 Q27,11 25,14" fill="#4a3018" stroke="#3a2008" stroke-width="0.5"/>
+  <!-- Living tree roof with large canopy -->
+  <ellipse cx="16" cy="10" rx="14" ry="5" fill="#2a6010"/>
+  <ellipse cx="10" cy="9" rx="7" ry="4" fill="#3a7018"/>
+  <ellipse cx="22" cy="9" rx="7" ry="4" fill="#3a7018"/>
+  <ellipse cx="16" cy="7" rx="10" ry="4" fill="#4a8020"/>
+  <!-- Canopy top detail -->
+  <circle cx="8" cy="7" r="3.5" fill="#3a7018"/>
+  <circle cx="16" cy="5" r="4" fill="#4a8020"/>
+  <circle cx="24" cy="7" r="3.5" fill="#3a7018"/>
+  <!-- Hall entrance (root-framed arch) -->
+  <path d="M12,29 L12,22 Q16,18 20,22 L20,29 Z" fill="#1a0a00"/>
+  <path d="M12,22 Q16,17 20,22" fill="none" stroke="#4a3018" stroke-width="1.5"/>
+  <!-- Glowing lights from windows -->
+  <rect x="5" y="19" width="3" height="4" fill="#1a0a00"/>
+  <rect x="5" y="19" width="3" height="2" fill="#88cc44" opacity="0.4" rx="1"/>
+  <rect x="24" y="19" width="3" height="4" fill="#1a0a00"/>
+  <rect x="24" y="19" width="3" height="2" fill="#88cc44" opacity="0.4" rx="1"/>
+  <!-- Hanging moss -->
+  <path d="M8,18 Q7,22 8,26" fill="none" stroke="#2a5010" stroke-width="1" opacity="0.6"/>
+  <path d="M24,18 Q25,22 24,26" fill="none" stroke="#2a5010" stroke-width="1" opacity="0.6"/>
+</svg>

--- a/web/public/sprites/demo-depot.svg
+++ b/web/public/sprites/demo-depot.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#3a2a10" opacity="0.4"/>
+  <!-- Depot base -->
+  <rect x="2" y="20" width="28" height="11" rx="1" fill="#5a4a2a"/>
+  <rect x="2" y="20" width="28" height="2" fill="#6a5a3a"/>
+  <!-- Warehouse-style building -->
+  <rect x="4" y="10" width="24" height="11" fill="#7a6a3a"/>
+  <rect x="4" y="10" width="24" height="3" fill="#8a7a4a"/>
+  <!-- Corrugated metal panels -->
+  <line x1="4" y1="14" x2="28" y2="14" stroke="#5a4a1a" stroke-width="0.7"/>
+  <line x1="4" y1="17" x2="28" y2="17" stroke="#5a4a1a" stroke-width="0.7"/>
+  <line x1="8" y1="10" x2="8" y2="20" stroke="#5a4a1a" stroke-width="0.7"/>
+  <line x1="24" y1="10" x2="24" y2="20" stroke="#5a4a1a" stroke-width="0.7"/>
+  <!-- Barrel bombs stored on shelves -->
+  <circle cx="10" cy="12" r="2" fill="#3a2a1a"/>
+  <rect x="8" y="12" width="4" height="2" fill="#3a2a1a" rx="1"/>
+  <line x1="10" y1="10" x2="10" y2="12" stroke="#cc4400" stroke-width="0.8"/>
+  <circle cx="16" cy="12" r="2" fill="#3a2a1a"/>
+  <rect x="14" y="12" width="4" height="2" fill="#3a2a1a" rx="1"/>
+  <line x1="16" y1="10" x2="16" y2="12" stroke="#cc4400" stroke-width="0.8"/>
+  <circle cx="22" cy="12" r="2" fill="#3a2a1a"/>
+  <rect x="20" y="12" width="4" height="2" fill="#3a2a1a" rx="1"/>
+  <line x1="22" y1="10" x2="22" y2="12" stroke="#cc4400" stroke-width="0.8"/>
+  <!-- Warning skull on door -->
+  <path d="M13,20 L13,15 Q16,12 19,15 L19,20 Z" fill="#1a0a00"/>
+  <!-- Skull & crossbones sign -->
+  <circle cx="16" cy="15.5" r="1.5" fill="#ffee88"/>
+  <circle cx="15.3" cy="15.2" r="0.4" fill="#1a0a00"/>
+  <circle cx="16.7" cy="15.2" r="0.4" fill="#1a0a00"/>
+  <line x1="14.5" y1="17" x2="17.5" y2="19" stroke="#ffee88" stroke-width="0.8"/>
+  <line x1="17.5" y1="17" x2="14.5" y2="19" stroke="#ffee88" stroke-width="0.8"/>
+  <!-- Flat roof with warning stripes -->
+  <rect x="4" y="7" width="24" height="4" fill="#cc8800"/>
+  <line x1="7" y1="7" x2="4" y2="11" stroke="#111" stroke-width="2"/>
+  <line x1="12" y1="7" x2="8" y2="11" stroke="#111" stroke-width="2"/>
+  <line x1="17" y1="7" x2="13" y2="11" stroke="#111" stroke-width="2"/>
+  <line x1="22" y1="7" x2="18" y2="11" stroke="#111" stroke-width="2"/>
+  <line x1="27" y1="7" x2="23" y2="11" stroke="#111" stroke-width="2"/>
+  <!-- Fuse sparks -->
+  <circle cx="10" cy="9.5" r="1" fill="#ffee44" opacity="0.8"/>
+  <circle cx="22" cy="9.5" r="1" fill="#ffee44" opacity="0.8"/>
+</svg>

--- a/web/public/sprites/desert-watch.svg
+++ b/web/public/sprites/desert-watch.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <ellipse cx="16" cy="31" rx="11" ry="1.5" fill="#4a3010" opacity="0.4"/>
+  <!-- Sand dune base -->
+  <ellipse cx="16" cy="30" rx="14" ry="4" fill="#c8a040"/>
+  <ellipse cx="16" cy="29" rx="12" ry="3" fill="#d8b050"/>
+  <!-- Tower base (sandstone) -->
+  <rect x="8" y="22" width="16" height="8" rx="1" fill="#c8a040"/>
+  <rect x="8" y="22" width="16" height="2" fill="#d8b050"/>
+  <!-- Main tower -->
+  <rect x="10" y="10" width="12" height="13" fill="#c8a040"/>
+  <rect x="10" y="10" width="12" height="3" fill="#d8b050"/>
+  <!-- Sandstone block lines -->
+  <line x1="10" y1="14" x2="22" y2="14" stroke="#a08020" stroke-width="0.6"/>
+  <line x1="10" y1="17" x2="22" y2="17" stroke="#a08020" stroke-width="0.6"/>
+  <line x1="10" y1="20" x2="22" y2="20" stroke="#a08020" stroke-width="0.6"/>
+  <line x1="14" y1="10" x2="14" y2="22" stroke="#a08020" stroke-width="0.6"/>
+  <line x1="18" y1="10" x2="18" y2="22" stroke="#a08020" stroke-width="0.6"/>
+  <!-- Upper watch platform -->
+  <rect x="8" y="6" width="16" height="5" fill="#d8b050"/>
+  <rect x="8" y="6" width="16" height="2" fill="#e8c060"/>
+  <!-- Battlements (desert-style stepped) -->
+  <rect x="8" y="3" width="3" height="4" fill="#c8a040"/>
+  <rect x="13" y="3" width="3" height="4" fill="#c8a040"/>
+  <rect x="18" y="3" width="3" height="4" fill="#c8a040"/>
+  <rect x="22" y="4" width="2" height="3" fill="#c8a040"/>
+  <!-- Arrow slits -->
+  <rect x="13" y="12" width="2" height="4" fill="#4a2a00" rx="1"/>
+  <rect x="17" y="12" width="2" height="4" fill="#4a2a00" rx="1"/>
+  <!-- Observation window -->
+  <rect x="13" y="8" width="6" height="2" fill="#4a2a00" rx="1"/>
+  <!-- Signal fire on top -->
+  <rect x="14" y="1" width="4" height="3" rx="1" fill="#8a6820"/>
+  <ellipse cx="16" cy="1" rx="3" ry="1.5" fill="#ff8800" opacity="0.8"/>
+  <ellipse cx="16" cy="0.5" rx="2" ry="1" fill="#ffcc00" opacity="0.7"/>
+  <!-- Sand swirls at base -->
+  <path d="M4,28 Q8,26 12,28" fill="none" stroke="#d8b050" stroke-width="1" opacity="0.5"/>
+  <path d="M20,28 Q24,26 28,28" fill="none" stroke="#d8b050" stroke-width="1" opacity="0.5"/>
+  <!-- Sand particles -->
+  <circle cx="4" cy="26" r="0.6" fill="#d8b050" opacity="0.4"/>
+  <circle cx="28" cy="25" r="0.6" fill="#c8a040" opacity="0.4"/>
+  <circle cx="6" cy="22" r="0.5" fill="#d8b050" opacity="0.3"/>
+</svg>

--- a/web/public/sprites/drift-garden.svg
+++ b/web/public/sprites/drift-garden.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Sky/water gradient suggestion -->
+  <rect x="0" y="20" width="32" height="12" fill="#1a6a8a"/>
+  <rect x="0" y="20" width="32" height="3" fill="#2a7a9a"/>
+  <!-- Floating garden platform -->
+  <ellipse cx="16" cy="22" rx="14" ry="4" fill="#5a4020"/>
+  <ellipse cx="16" cy="21" rx="13" ry="3.5" fill="#6a5030"/>
+  <!-- Dirt and roots hanging below platform -->
+  <rect x="4" y="22" width="24" height="3" fill="#4a3010"/>
+  <path d="M8,25 Q7,28 9,30" fill="none" stroke="#3a2010" stroke-width="1.5"/>
+  <path d="M13,25 Q12,29 14,31" fill="none" stroke="#3a2010" stroke-width="1.2"/>
+  <path d="M19,25 Q20,28 18,31" fill="none" stroke="#3a2010" stroke-width="1.2"/>
+  <path d="M24,25 Q25,28 23,30" fill="none" stroke="#3a2010" stroke-width="1.5"/>
+  <!-- Garden plants on top of platform -->
+  <!-- Small shrubs -->
+  <circle cx="6" cy="19" r="3" fill="#3a8018"/>
+  <circle cx="10" cy="18" r="3.5" fill="#4a9020"/>
+  <circle cx="16" cy="17" r="4" fill="#5aa028"/>
+  <circle cx="22" cy="18" r="3.5" fill="#4a9020"/>
+  <circle cx="26" cy="19" r="3" fill="#3a8018"/>
+  <!-- Flowers on garden -->
+  <circle cx="7" cy="17" r="1.5" fill="#ff6688"/>
+  <circle cx="7" cy="17" r="0.8" fill="#ffdd00"/>
+  <circle cx="14" cy="16" r="1.5" fill="#ffaa00"/>
+  <circle cx="14" cy="16" r="0.8" fill="#ffee44"/>
+  <circle cx="20" cy="16" r="1.5" fill="#ff6688"/>
+  <circle cx="20" cy="16" r="0.8" fill="#ffdd00"/>
+  <circle cx="24" cy="17" r="1.5" fill="#88ccff"/>
+  <circle cx="24" cy="17" r="0.8" fill="#ffffff"/>
+  <!-- Floating particles/pollen drifting away -->
+  <circle cx="3" cy="16" r="0.8" fill="#ffee88" opacity="0.7"/>
+  <circle cx="5" cy="13" r="0.7" fill="#ff88aa" opacity="0.6"/>
+  <circle cx="28" cy="15" r="0.8" fill="#88ccff" opacity="0.6"/>
+  <circle cx="30" cy="11" r="0.7" fill="#ffee88" opacity="0.5"/>
+  <circle cx="10" cy="10" r="0.6" fill="#ff88aa" opacity="0.5"/>
+  <circle cx="22" cy="11" r="0.6" fill="#88ffaa" opacity="0.5"/>
+  <!-- Light post/garden lantern -->
+  <line x1="16" y1="13" x2="16" y2="19" stroke="#7a6a3a" stroke-width="1"/>
+  <circle cx="16" cy="12" r="1.5" fill="#ffee88" opacity="0.8"/>
+</svg>

--- a/web/public/sprites/drift-lagoon.svg
+++ b/web/public/sprites/drift-lagoon.svg
@@ -1,0 +1,41 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Lagoon water -->
+  <ellipse cx="16" cy="22" rx="15" ry="10" fill="#1a7a9a"/>
+  <ellipse cx="16" cy="21" rx="14" ry="9" fill="#2a8aaa"/>
+  <!-- Water surface ripples -->
+  <ellipse cx="16" cy="20" rx="10" ry="5" fill="none" stroke="#3a9abb" stroke-width="0.8" opacity="0.6"/>
+  <ellipse cx="16" cy="20" rx="6" ry="3" fill="none" stroke="#4aaace" stroke-width="0.6" opacity="0.5"/>
+  <!-- Sandy shores -->
+  <ellipse cx="16" cy="30" rx="15" ry="4" fill="#c8a040"/>
+  <ellipse cx="4" cy="22" rx="5" ry="6" fill="#b89030" opacity="0.7"/>
+  <ellipse cx="28" cy="22" rx="5" ry="6" fill="#b89030" opacity="0.7"/>
+  <!-- Drifting log/platform structure -->
+  <rect x="8" y="17" width="16" height="5" rx="2" fill="#7a5a2a"/>
+  <rect x="8" y="17" width="16" height="2" fill="#8a6a3a"/>
+  <!-- Log plank lines -->
+  <line x1="10" y1="17" x2="10" y2="22" stroke="#5a3a0a" stroke-width="0.7"/>
+  <line x1="14" y1="17" x2="14" y2="22" stroke="#5a3a0a" stroke-width="0.7"/>
+  <line x1="18" y1="17" x2="18" y2="22" stroke="#5a3a0a" stroke-width="0.7"/>
+  <line x1="22" y1="17" x2="22" y2="22" stroke="#5a3a0a" stroke-width="0.7"/>
+  <!-- Rope moorings to shore -->
+  <line x1="8" y1="19" x2="3" y2="22" stroke="#9a8a5a" stroke-width="1"/>
+  <line x1="24" y1="19" x2="29" y2="22" stroke="#9a8a5a" stroke-width="1"/>
+  <!-- Tent/shelter on platform -->
+  <polygon points="8,17 16,10 24,17" fill="#cc8822"/>
+  <polygon points="10,17 16,12 22,17" fill="#dd9933"/>
+  <!-- Shelter entrance -->
+  <path d="M14,17 Q16,14 18,17 Z" fill="#1a0a00"/>
+  <!-- Tropical palm trees on shore -->
+  <!-- Left palm -->
+  <line x1="4" y1="28" x2="6" y2="18" stroke="#5a3a10" stroke-width="1.5"/>
+  <ellipse cx="7" cy="16" rx="4" ry="2" fill="#3a7a18" transform="rotate(-20 7 16)"/>
+  <ellipse cx="5" cy="15" rx="3" ry="1.5" fill="#4a8a20" transform="rotate(10 5 15)"/>
+  <ellipse cx="8" cy="14" rx="3" ry="1.5" fill="#3a7a18" transform="rotate(-30 8 14)"/>
+  <!-- Right palm -->
+  <line x1="28" y1="28" x2="26" y2="18" stroke="#5a3a10" stroke-width="1.5"/>
+  <ellipse cx="25" cy="16" rx="4" ry="2" fill="#3a7a18" transform="rotate(20 25 16)"/>
+  <ellipse cx="27" cy="15" rx="3" ry="1.5" fill="#4a8a20" transform="rotate(-10 27 15)"/>
+  <!-- Coconuts -->
+  <circle cx="6" cy="18" r="1" fill="#7a4a1a"/>
+  <circle cx="26" cy="18" r="1" fill="#7a4a1a"/>
+</svg>

--- a/web/public/sprites/dune-roost.svg
+++ b/web/public/sprites/dune-roost.svg
@@ -1,0 +1,38 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Sand dune landscape -->
+  <ellipse cx="16" cy="30" rx="16" ry="5" fill="#c8a040"/>
+  <ellipse cx="8" cy="28" rx="10" ry="4" fill="#d8b050"/>
+  <ellipse cx="24" cy="29" rx="10" ry="4" fill="#c8a040"/>
+  <!-- Tall sandstone pillar/roost post -->
+  <rect x="13" y="8" width="6" height="22" rx="1" fill="#c8a040"/>
+  <rect x="13" y="8" width="6" height="3" fill="#d8b050"/>
+  <!-- Pillar weathering lines -->
+  <line x1="13" y1="12" x2="19" y2="12" stroke="#a08020" stroke-width="0.6"/>
+  <line x1="13" y1="16" x2="19" y2="16" stroke="#a08020" stroke-width="0.6"/>
+  <line x1="13" y1="20" x2="19" y2="20" stroke="#a08020" stroke-width="0.6"/>
+  <line x1="13" y1="24" x2="19" y2="24" stroke="#a08020" stroke-width="0.6"/>
+  <!-- Horizontal roost branches -->
+  <rect x="6" y="9" width="20" height="2" rx="1" fill="#8a6820"/>
+  <rect x="8" y="14" width="16" height="2" rx="1" fill="#8a6820"/>
+  <!-- Nests on branches -->
+  <ellipse cx="8" cy="9" rx="3" ry="1.5" fill="#9a7a3a"/>
+  <ellipse cx="24" cy="9" rx="3" ry="1.5" fill="#9a7a3a"/>
+  <ellipse cx="11" cy="14" rx="2.5" ry="1.2" fill="#9a7a3a"/>
+  <ellipse cx="21" cy="14" rx="2.5" ry="1.2" fill="#9a7a3a"/>
+  <!-- Bird silhouettes perched -->
+  <ellipse cx="8" cy="8" rx="2" ry="1" fill="#3a2a1a"/>
+  <path d="M6,7.5 Q8,5 10,7.5" fill="none" stroke="#2a1a0a" stroke-width="1"/>
+  <ellipse cx="24" cy="8" rx="2" ry="1" fill="#3a2a1a"/>
+  <path d="M22,7.5 Q24,5 26,7.5" fill="none" stroke="#2a1a0a" stroke-width="1"/>
+  <!-- Flying bird silhouette above -->
+  <path d="M10,3 Q13,0 16,3 Q19,0 22,3" fill="none" stroke="#2a1a0a" stroke-width="1.2"/>
+  <!-- Sand ripples around base -->
+  <path d="M4,29 Q8,27 12,29" fill="none" stroke="#d8b050" stroke-width="0.8" opacity="0.6"/>
+  <path d="M20,29 Q24,27 28,29" fill="none" stroke="#d8b050" stroke-width="0.8" opacity="0.6"/>
+  <!-- Scorpion/beetle on sand (desert detail) -->
+  <ellipse cx="5" cy="28" rx="1.5" ry="1" fill="#8a6820"/>
+  <line x1="3.5" y1="28" x2="2" y2="27" stroke="#8a6820" stroke-width="0.6"/>
+  <line x1="3.5" y1="28" x2="2" y2="29" stroke="#8a6820" stroke-width="0.6"/>
+  <line x1="6.5" y1="28" x2="8" y2="27" stroke="#8a6820" stroke-width="0.6"/>
+  <line x1="6.5" y1="28" x2="8" y2="29" stroke="#8a6820" stroke-width="0.6"/>
+</svg>

--- a/web/public/sprites/dune-stronghold.svg
+++ b/web/public/sprites/dune-stronghold.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <ellipse cx="16" cy="31" rx="14" ry="1.5" fill="#7a5010" opacity="0.5"/>
+  <!-- Sand dune base -->
+  <ellipse cx="16" cy="30" rx="15" ry="4" fill="#c8a040"/>
+  <!-- Massive sandstone walls -->
+  <rect x="1" y="16" width="30" height="14" rx="1" fill="#c8a040"/>
+  <rect x="1" y="16" width="30" height="3" fill="#d8b050"/>
+  <!-- Stone block detail -->
+  <line x1="1" y1="20" x2="31" y2="20" stroke="#a08020" stroke-width="0.7"/>
+  <line x1="1" y1="24" x2="31" y2="24" stroke="#a08020" stroke-width="0.7"/>
+  <line x1="1" y1="28" x2="31" y2="28" stroke="#a08020" stroke-width="0.7"/>
+  <line x1="8" y1="16" x2="8" y2="30" stroke="#a08020" stroke-width="0.7"/>
+  <line x1="16" y1="16" x2="16" y2="30" stroke="#a08020" stroke-width="0.7"/>
+  <line x1="24" y1="16" x2="24" y2="30" stroke="#a08020" stroke-width="0.7"/>
+  <!-- Corner towers -->
+  <rect x="1" y="8" width="8" height="9" fill="#d8b050"/>
+  <rect x="23" y="8" width="8" height="9" fill="#d8b050"/>
+  <rect x="1" y="8" width="8" height="3" fill="#e8c060"/>
+  <rect x="23" y="8" width="8" height="3" fill="#e8c060"/>
+  <!-- Tower battlements (stepped pyramid style) -->
+  <rect x="1" y="5" width="2" height="4" fill="#c8a040"/>
+  <rect x="4" y="5" width="2" height="4" fill="#c8a040"/>
+  <rect x="7" y="5" width="2" height="4" fill="#c8a040"/>
+  <rect x="23" y="5" width="2" height="4" fill="#c8a040"/>
+  <rect x="26" y="5" width="2" height="4" fill="#c8a040"/>
+  <rect x="29" y="5" width="2" height="4" fill="#c8a040"/>
+  <!-- Central keep -->
+  <rect x="9" y="10" width="14" height="7" fill="#d8b050"/>
+  <rect x="9" y="10" width="14" height="2" fill="#e8c060"/>
+  <!-- Arrow slits on towers -->
+  <rect x="4" y="10" width="2" height="5" fill="#4a2a00" rx="1"/>
+  <rect x="26" y="10" width="2" height="5" fill="#4a2a00" rx="1"/>
+  <!-- Gate (ornate arch) -->
+  <path d="M13,30 L13,22 Q16,18 19,22 L19,30 Z" fill="#4a2a00"/>
+  <path d="M13,22 Q16,17 19,22" fill="none" stroke="#d8b050" stroke-width="1.5"/>
+  <!-- Sand drifting against walls -->
+  <ellipse cx="5" cy="28" rx="4" ry="2" fill="#d8b050" opacity="0.4"/>
+  <ellipse cx="27" cy="28" rx="4" ry="2" fill="#d8b050" opacity="0.4"/>
+  <!-- Banner/flag -->
+  <line x1="16" y1="8" x2="16" y2="5" stroke="#a08020" stroke-width="1"/>
+  <polygon points="16,5 22,6.5 16,8" fill="#cc8800"/>
+</svg>

--- a/web/public/sprites/dusk-sanctum.svg
+++ b/web/public/sprites/dusk-sanctum.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <ellipse cx="16" cy="31" rx="12" ry="1.5" fill="#1a1a3a" opacity="0.5"/>
+  <!-- Twilight gradient suggestion on building face -->
+  <!-- Base platform -->
+  <rect x="3" y="24" width="26" height="7" rx="1" fill="#3a3050"/>
+  <rect x="3" y="24" width="26" height="2" fill="#4a4060"/>
+  <!-- Main sanctum building -->
+  <rect x="5" y="13" width="22" height="12" fill="#4a3a5a"/>
+  <rect x="5" y="13" width="22" height="3" fill="#5a4a6a"/>
+  <!-- Stone block lines -->
+  <line x1="5" y1="17" x2="27" y2="17" stroke="#2a2038" stroke-width="0.6"/>
+  <line x1="5" y1="20" x2="27" y2="20" stroke="#2a2038" stroke-width="0.6"/>
+  <line x1="11" y1="13" x2="11" y2="24" stroke="#2a2038" stroke-width="0.6"/>
+  <line x1="21" y1="13" x2="21" y2="24" stroke="#2a2038" stroke-width="0.6"/>
+  <!-- Domed roof -->
+  <ellipse cx="16" cy="13" rx="11" ry="4" fill="#3a2a4a"/>
+  <ellipse cx="16" cy="11" rx="8" ry="4" fill="#4a3a5a"/>
+  <ellipse cx="16" cy="9" rx="5" ry="3" fill="#5a4a6a"/>
+  <!-- Crescent moon and star ornament on dome -->
+  <path d="M14,7 Q12,9 14,11 Q12,10 12,9 Q12,7 14,7" fill="#ffcc44"/>
+  <circle cx="17" cy="7" r="1" fill="#ffee88"/>
+  <circle cx="19" cy="9" r="0.7" fill="#ffee88"/>
+  <!-- Windows with dusk glow -->
+  <rect x="7" y="15" width="3" height="4" fill="#1a0a10" rx="1"/>
+  <rect x="7" y="15" width="3" height="2" fill="#ff8844" opacity="0.5"/>
+  <rect x="22" y="15" width="3" height="4" fill="#1a0a10" rx="1"/>
+  <rect x="22" y="15" width="3" height="2" fill="#ff8844" opacity="0.5"/>
+  <rect x="14" y="14" width="4" height="4" fill="#1a0a10" rx="1"/>
+  <rect x="14" y="14" width="4" height="2" fill="#ff6633" opacity="0.6"/>
+  <!-- Door -->
+  <path d="M13,24 L13,19 Q16,16 19,19 L19,24 Z" fill="#1a0a10"/>
+  <!-- Dusk light glow through door -->
+  <ellipse cx="16" cy="22" rx="2.5" ry="2" fill="#ff6633" opacity="0.3"/>
+  <!-- Stars around sanctum -->
+  <circle cx="3" cy="8" r="0.7" fill="#ffee88" opacity="0.7"/>
+  <circle cx="29" cy="7" r="0.7" fill="#ffee88" opacity="0.7"/>
+  <circle cx="6" cy="5" r="0.5" fill="#ffcc44" opacity="0.6"/>
+  <circle cx="26" cy="5" r="0.5" fill="#ffcc44" opacity="0.6"/>
+  <circle cx="16" cy="3" r="0.6" fill="#ffee88" opacity="0.6"/>
+</svg>

--- a/web/public/sprites/dust-track.svg
+++ b/web/public/sprites/dust-track.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Dusty ground -->
+  <rect x="0" y="22" width="32" height="10" fill="#9a7a40"/>
+  <rect x="0" y="22" width="32" height="2" fill="#aa8a50"/>
+  <!-- Track surface (worn dirt path) -->
+  <rect x="4" y="18" width="24" height="10" fill="#c8a050"/>
+  <rect x="4" y="18" width="24" height="2" fill="#d8b060"/>
+  <!-- Track lane markings -->
+  <line x1="16" y1="18" x2="16" y2="28" stroke="#b89040" stroke-width="0.6" stroke-dasharray="2,2"/>
+  <!-- Starting gate posts -->
+  <rect x="3" y="10" width="3" height="10" rx="1" fill="#6a4a1a"/>
+  <rect x="26" y="10" width="3" height="10" rx="1" fill="#6a4a1a"/>
+  <!-- Starting gate crossbar -->
+  <rect x="3" y="10" width="26" height="2" rx="1" fill="#8a6a2a"/>
+  <!-- Gate mechanism details -->
+  <circle cx="6" cy="11" r="1.5" fill="#5a4a2a"/>
+  <circle cx="26" cy="11" r="1.5" fill="#5a4a2a"/>
+  <!-- Warning/flag poles -->
+  <line x1="5" y1="4" x2="5" y2="10" stroke="#5a3a0a" stroke-width="1.5"/>
+  <polygon points="5,4 11,5.5 5,7" fill="#cc2222"/>
+  <line x1="27" y1="4" x2="27" y2="10" stroke="#5a3a0a" stroke-width="1.5"/>
+  <polygon points="27,4 21,5.5 27,7" fill="#cc2222"/>
+  <!-- Dust clouds on track -->
+  <ellipse cx="9" cy="22" rx="4" ry="2" fill="#d8b060" opacity="0.5"/>
+  <ellipse cx="23" cy="21" rx="4" ry="2" fill="#d8b060" opacity="0.5"/>
+  <ellipse cx="16" cy="24" rx="5" ry="1.5" fill="#c8a050" opacity="0.4"/>
+  <!-- Hoof/wheel ruts in track -->
+  <line x1="6" y1="20" x2="14" y2="26" stroke="#a88030" stroke-width="0.8" opacity="0.6"/>
+  <line x1="8" y1="20" x2="16" y2="26" stroke="#a88030" stroke-width="0.8" opacity="0.6"/>
+  <line x1="18" y1="20" x2="26" y2="26" stroke="#a88030" stroke-width="0.8" opacity="0.6"/>
+  <line x1="20" y1="20" x2="28" y2="26" stroke="#a88030" stroke-width="0.8" opacity="0.6"/>
+  <!-- Dust particles drifting -->
+  <circle cx="4" cy="17" r="0.8" fill="#c8a050" opacity="0.5"/>
+  <circle cx="28" cy="16" r="0.8" fill="#d8b060" opacity="0.4"/>
+  <circle cx="12" cy="15" r="0.6" fill="#c8a050" opacity="0.4"/>
+  <circle cx="22" cy="16" r="0.6" fill="#d8b060" opacity="0.4"/>
+  <!-- Finish line chalk marks -->
+  <line x1="4" y1="28" x2="28" y2="28" stroke="#ffffff" stroke-width="1" opacity="0.5" stroke-dasharray="2,2"/>
+</svg>


### PR DESCRIPTION
Adds 10 building SVG sprites for batch 5/19, closing #999.

## Buildings added

| Card | File |
|---|---|
| Crucible Hall | `crucible-hall.svg` — smelting hall with massive central chimney and molten crucible |
| Deeproot Hall | `deeproot-hall.svg` — living wood hall with spreading roots and canopy roof |
| Demo Depot | `demo-depot.svg` — warehouse with barrel bombs and hazard stripes |
| Desert Watch | `desert-watch.svg` — sandstone watch tower on a dune with signal fire |
| Drift Garden | `drift-garden.svg` — floating garden platform with flowers and drifting pollen |
| Drift Lagoon | `drift-lagoon.svg` — moored log platform with tent shelter and palm shore |
| Dune Roost | `dune-roost.svg` — sandstone perch pillar with roosting birds on branch rungs |
| Dune Stronghold | `dune-stronghold.svg` — massive desert fortress with sand-blasted battlements |
| Dusk Sanctum | `dusk-sanctum.svg` — twilight temple with crescent moon, stars and warm glow |
| Dust Track | `dust-track.svg` — starting gate race track with flags, ruts and dust clouds |

## Test plan

- [ ] Each sprite visible in card collection view
- [ ] Each sprite visible in battle when the structure is placed


---
_Generated by [Claude Code](https://claude.ai/code/session_01TWFNogtCtcNR4qd2ZbxCCx)_