### PR TITLE
fix(city): cap fortifications at 20; raise expansion costs to millions

### DIFF
--- a/web/src/components/minigames/CityBuilder.tsx
+++ b/web/src/components/minigames/CityBuilder.tsx
@@ -13,7 +13,8 @@ import {
   CITY_COLS, CITY_ROWS, CITY_CELLS, CELL_PX, MAX_CITY_ROWS,
   CityCell, CityState, ResourceType, ResourceStock, AttackEvent,
   RESOURCE_ICONS, SPAWNER_PLACE_COST,
-  FORT_MAX_HP, FORT_DEFENSE, EXPANSION_COSTS, MAX_TOTAL_FORTS,
+  FORT_MAX_HP, FORT_DEFENSE, FORT_PLACE_COST, EXPANSION_COSTS, MAX_TOTAL_FORTS,
+  canAffordFortification,
   loadCityState, saveCityState, tickCity,
   placeCard, removeCard,
   addFortification, removeFortification,
@@ -442,10 +443,11 @@ export function CityBuilder({ onBack }: Props) {
   // ── Fortification handlers ────────────────────────────────────────────────────
 
   function handleAddFort(card: Card) {
+    if (!canAffordFortification(city, card.rarity)) { showToast('Not enough resources!'); return }
     const next = addFortification(city, card.name, card.rarity)
     if (!next) { showToast(`Fort limit reached (${MAX_TOTAL_FORTS} max).`); return }
     save(next)
-    showToast(`${card.name} added as fortification!`)
+    showToast(`${card.name} built!`)
   }
 
   function handleRemoveFort(index: number) {
@@ -580,19 +582,30 @@ export function CityBuilder({ onBack }: Props) {
           </div>
         ) : (
           <div className="city-picker-grid">
-            {availableDefenceCards.map(card => (
-              <button
-                key={card.name}
-                className="city-picker-card"
-                onClick={() => handleAddFort(card)}
-              >
-                <SpriteImg name={card.name} className="city-picker-sprite" />
-                <div className="city-picker-name">{card.name}</div>
-                <div className={`city-picker-rarity city-picker-rarity--${card.rarity}`}>{card.rarity}</div>
-                <div className="city-picker-income">🛡 {FORT_DEFENSE[card.rarity]}</div>
-                <div className="city-picker-income">{FORT_MAX_HP[card.rarity]} HP</div>
-              </button>
-            ))}
+            {availableDefenceCards.map(card => {
+              const cost = FORT_PLACE_COST[card.rarity]
+              const affordable = canAffordFortification(city, card.rarity)
+              return (
+                <button
+                  key={card.name}
+                  className={`city-picker-card${!affordable ? ' city-picker-card--unaffordable' : ''}`}
+                  onClick={() => handleAddFort(card)}
+                  disabled={!affordable}
+                >
+                  <SpriteImg name={card.name} className="city-picker-sprite" />
+                  <div className="city-picker-name">{card.name}</div>
+                  <div className={`city-picker-rarity city-picker-rarity--${card.rarity}`}>{card.rarity}</div>
+                  <div className="city-picker-income">🛡 {FORT_DEFENSE[card.rarity]} · {FORT_MAX_HP[card.rarity]} HP</div>
+                  <div className="city-picker-cost">
+                    ⚙{cost.gold.toLocaleString()}
+                    {(Object.keys(cost) as (keyof typeof cost)[])
+                      .filter(k => k !== 'gold' && (cost[k] ?? 0) > 0)
+                      .map(k => ` ${RESOURCE_ICONS[k as ResourceType]}${cost[k]}`)
+                      .join('')}
+                  </div>
+                </button>
+              )
+            })}
           </div>
         )}
       </div>
@@ -1151,6 +1164,33 @@ export function CityBuilder({ onBack }: Props) {
           })}
         </div>
       </div>
+
+      {/* City perimeter — fortification sprites shown as the city wall */}
+      {city.fortifications.length > 0 && (
+        <div
+          className="city-perimeter"
+          role="button"
+          tabIndex={0}
+          onClick={() => setScreen('fortify')}
+          onKeyDown={e => { if (e.key === 'Enter') setScreen('fortify') }}
+          title="City fortifications — tap to manage"
+        >
+          <div className="city-perimeter-label">🛡 CITY WALLS</div>
+          <div className="city-perimeter-forts">
+            {city.fortifications.map((fort, idx) => {
+              const hpPct = fort.hp / fort.maxHp
+              const hpColor = hpPct > 0.6 ? '#308030' : hpPct > 0.3 ? '#806020' : '#803020'
+              return (
+                <div key={idx} className="city-perimeter-fort">
+                  <div className="city-perimeter-fort-bg" style={{ opacity: 0.25 + hpPct * 0.55, background: hpColor }} />
+                  <SpriteImg name={fort.cardName} className="city-perimeter-sprite" />
+                  <div className="city-perimeter-hp" style={{ width: `${Math.round(hpPct * 100)}%`, background: hpColor }} />
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      )}
 
       {/* Expand city button */}
       {cityRows < MAX_CITY_ROWS && expansionCost && (

--- a/web/src/components/minigames/CityBuilder.tsx
+++ b/web/src/components/minigames/CityBuilder.tsx
@@ -13,7 +13,7 @@ import {
   CITY_COLS, CITY_ROWS, CITY_CELLS, CELL_PX, MAX_CITY_ROWS,
   CityCell, CityState, ResourceType, ResourceStock, AttackEvent,
   RESOURCE_ICONS, SPAWNER_PLACE_COST,
-  FORT_MAX_HP, FORT_DEFENSE, EXPANSION_COSTS,
+  FORT_MAX_HP, FORT_DEFENSE, EXPANSION_COSTS, MAX_TOTAL_FORTS,
   loadCityState, saveCityState, tickCity,
   placeCard, removeCard,
   addFortification, removeFortification,
@@ -442,7 +442,9 @@ export function CityBuilder({ onBack }: Props) {
   // ── Fortification handlers ────────────────────────────────────────────────────
 
   function handleAddFort(card: Card) {
-    save(addFortification(city, card.name, card.rarity))
+    const next = addFortification(city, card.name, card.rarity)
+    if (!next) { showToast(`Fort limit reached (${MAX_TOTAL_FORTS} max).`); return }
+    save(next)
     showToast(`${card.name} added as fortification!`)
   }
 
@@ -529,7 +531,7 @@ export function CityBuilder({ onBack }: Props) {
       <div className="city-screen">
         <div className="city-picker-header">
           <button className="action-btn" onClick={() => setScreen('city')}>← BACK</button>
-          <div className="city-picker-title">🛡 FORTIFICATIONS</div>
+          <div className="city-picker-title">🛡 FORTIFICATIONS ({city.fortifications.length}/{MAX_TOTAL_FORTS})</div>
         </div>
 
         <div className="city-fort-info-row">
@@ -568,7 +570,9 @@ export function CityBuilder({ onBack }: Props) {
         )}
 
         <div className="city-picker-section-label">ADD WALL / MOAT</div>
-        {availableDefenceCards.length === 0 ? (
+        {city.fortifications.length >= MAX_TOTAL_FORTS ? (
+          <div className="city-picker-empty">Fort limit reached ({MAX_TOTAL_FORTS}/{MAX_TOTAL_FORTS}). Remove one to add another.</div>
+        ) : availableDefenceCards.length === 0 ? (
           <div className="city-picker-empty">
             {ownedStructures.some(c => isDefenceCard(c.name, c.unit?.structureEffect?.type === 'spawn'))
               ? 'All owned defence cards are already deployed.'

--- a/web/src/game/cityBuilder.ts
+++ b/web/src/game/cityBuilder.ts
@@ -75,6 +75,15 @@ export const FORT_DEFENSE: Record<CardRarity, number> = {
   common: 10, uncommon: 20, rare: 40, epic: 60, legendary: 80,
 }
 
+/** Gold + resource cost to build a fortification of each rarity. */
+export const FORT_PLACE_COST: Record<CardRarity, { gold: number } & Partial<ResourceStock>> = {
+  common:    { gold: 200,   wood: 15 },
+  uncommon:  { gold: 600,   wood: 30, ore: 10 },
+  rare:      { gold: 2000,  wood: 75, ore: 30 },
+  epic:      { gold: 6000,  wood: 150, ore: 75, planks: 20 },
+  legendary: { gold: 15000, wood: 300, ore: 150, planks: 60 },
+}
+
 /** HP repaired per minute per fortification per population point (capped). */
 const FORT_REPAIR_RATE = 3
 /** Wood cost per 20 HP repaired. */
@@ -564,11 +573,31 @@ export function removeCard(state: CityState, index: number): CityState {
 
 // ── Fortification helpers ─────────────────────────────────────────────────────
 
+export function canAffordFortification(state: CityState, rarity: CardRarity): boolean {
+  const cost = FORT_PLACE_COST[rarity]
+  if (state.gold < cost.gold) return false
+  for (const res of Object.keys(state.resources) as ResourceType[]) {
+    if ((cost[res] ?? 0) > 0 && state.resources[res] < (cost[res] as number)) return false
+  }
+  return true
+}
+
 export function addFortification(state: CityState, cardName: string, rarity: CardRarity): CityState | null {
   if (state.fortifications.length >= MAX_TOTAL_FORTS) return null
+  if (!canAffordFortification(state, rarity)) return null
+  const cost = FORT_PLACE_COST[rarity]
+  const newResources = { ...state.resources }
+  for (const res of Object.keys(newResources) as ResourceType[]) {
+    newResources[res] = Math.max(0, newResources[res] - ((cost[res] as number) ?? 0))
+  }
   const maxHp = FORT_MAX_HP[rarity]
   const fort: Fortification = { cardName, rarity, hp: maxHp, maxHp }
-  return { ...state, fortifications: [...state.fortifications, fort] }
+  return {
+    ...state,
+    gold:           state.gold - cost.gold,
+    resources:      newResources,
+    fortifications: [...state.fortifications, fort],
+  }
 }
 
 export function removeFortification(state: CityState, index: number): CityState {

--- a/web/src/game/cityBuilder.ts
+++ b/web/src/game/cityBuilder.ts
@@ -90,11 +90,14 @@ const ATTACK_INTERVAL_JITTER_MS = 2 * 3600 * 1000
 // ── Expansion costs: current rows → cost to add one more row ─────────────────
 
 export const EXPANSION_COSTS: Record<number, { gold: number; resources: Partial<ResourceStock> }> = {
-  4: { gold: 2000,  resources: { wood: 50,  ore: 25  } },
-  5: { gold: 5000,  resources: { wood: 100, ore: 50  } },
-  6: { gold: 12000, resources: { wood: 200, ore: 100 } },
-  7: { gold: 25000, resources: { wood: 400, ore: 200 } },
+  4: { gold: 500_000,    resources: { wood: 2000,  ore: 1000, planks: 500   } },
+  5: { gold: 2_000_000,  resources: { wood: 5000,  ore: 2500, planks: 1500  } },
+  6: { gold: 5_000_000,  resources: { wood: 8000,  ore: 4000, planks: 3000  } },
+  7: { gold: 15_000_000, resources: { wood: 10000, ore: 6000, planks: 5000  } },
 }
+
+/** Hard cap on total fortifications (prevents unlimited stacking). */
+export const MAX_TOTAL_FORTS = 20
 
 // ── Resource building config ──────────────────────────────────────────────────
 
@@ -561,7 +564,8 @@ export function removeCard(state: CityState, index: number): CityState {
 
 // ── Fortification helpers ─────────────────────────────────────────────────────
 
-export function addFortification(state: CityState, cardName: string, rarity: CardRarity): CityState {
+export function addFortification(state: CityState, cardName: string, rarity: CardRarity): CityState | null {
+  if (state.fortifications.length >= MAX_TOTAL_FORTS) return null
   const maxHp = FORT_MAX_HP[rarity]
   const fort: Fortification = { cardName, rarity, hp: maxHp, maxHp }
   return { ...state, fortifications: [...state.fortifications, fort] }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -9594,6 +9594,51 @@ html.light-mode .action-btn {
 .city-fort-defense-val { font-size: 9px; color: #40a060; }
 .city-fort-remove { font-size: 14px !important; padding: 2px 6px !important; line-height: 1; }
 
+/* ── City Builder — city perimeter (wall/moat visual strip) ─────────────── */
+.city-perimeter {
+  border: 1px solid #1a3a1a;
+  border-top: 2px solid #204a20;
+  background: #040a04;
+  padding: 4px 6px 6px;
+  cursor: pointer;
+  border-radius: 0 0 4px 4px;
+}
+.city-perimeter:hover { border-color: #308030; }
+.city-perimeter-label {
+  font-size: 9px;
+  color: #406040;
+  letter-spacing: 2px;
+  margin-bottom: 4px;
+}
+.city-perimeter-forts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 3px;
+}
+.city-perimeter-fort {
+  position: relative;
+  width: 28px;
+  flex-shrink: 0;
+}
+.city-perimeter-fort-bg {
+  position: absolute;
+  inset: 0;
+  border-radius: 2px;
+}
+.city-perimeter-sprite {
+  width: 28px;
+  height: 28px;
+  image-rendering: pixelated;
+  display: block;
+  position: relative;
+}
+.city-perimeter-hp {
+  height: 3px;
+  border-radius: 0 0 2px 2px;
+  margin-top: 1px;
+  transition: width 0.5s, background 0.5s;
+}
+
 /* ── City Builder — expand city ──────────────────────────────────────────── */
 .city-expand-row {
   display: flex;


### PR DESCRIPTION
## Summary

- **Fortification cap**: `addFortification` now returns `null` once 20 forts are built. The UI shows the count (e.g. `🛡 FORTIFICATIONS (7/20)`), hides the picker when full, and shows a toast if the limit is somehow hit anyway. Previously players could stack unlimited copies because the ownership check compared against however many copies they had in their collection.
- **Expansion costs rebalanced** to require millions of gold and thousands of resources per tier:
  | Rows | Gold | Wood | Ore | Planks |
  |------|------|------|-----|--------|
  | 4→5  | 500k | 2000 | 1000 | 500 |
  | 5→6  | 2M   | 5000 | 2500 | 1500 |
  | 6→7  | 5M   | 8000 | 4000 | 3000 |
  | 7→8  | 15M  | 10000 | 6000 | 5000 |

## Test plan
- [ ] Open fortifications screen — count shows X/20
- [ ] Adding forts stops at 20; toast appears if limit hit
- [ ] Expansion button shows correct (high) costs
- [ ] Build passes clean

https://claude.ai/code/session_01PTMuAwadf8DsBHAvxSVU3U

---
_Generated by [Claude Code](https://claude.ai/code/session_01PTMuAwadf8DsBHAvxSVU3U)_