### PR TITLE
refactor(city): fixed 50vh grid, compact layout, clear action buttons

### DIFF
--- a/web/src/components/minigames/CityBuilder.tsx
+++ b/web/src/components/minigames/CityBuilder.tsx
@@ -192,7 +192,6 @@ function buildResidentThoughts(
 
 // ── Walking unit state ────────────────────────────────────────────────────────
 
-const OVERLAY_W = CITY_COLS * CELL_PX
 const UNIT_SIZE = 20
 const SPEED     = 0.8
 
@@ -208,15 +207,15 @@ interface Walker {
   turnTimer: number
 }
 
-function makeWalker(cellIndex: number, unitIndex: number, unitName: string, affinityWith?: string): Walker {
+function makeWalker(cellIndex: number, unitIndex: number, unitName: string, affinityWith?: string, w = CITY_COLS * CELL_PX, h = CITY_ROWS * CELL_PX): Walker {
   const angle = Math.random() * Math.PI * 2
   return {
     cellIndex,
     unitIndex,
     unitName,
     affinityWith,
-    x: Math.random() * (OVERLAY_W - UNIT_SIZE),
-    y: Math.random() * (OVERLAY_W - UNIT_SIZE),
+    x: Math.random() * Math.max(1, w - UNIT_SIZE),
+    y: Math.random() * Math.max(1, h - UNIT_SIZE),
     vx: Math.cos(angle) * SPEED,
     vy: Math.sin(angle) * SPEED,
     turnTimer: 20 + Math.floor(Math.random() * 30),
@@ -260,6 +259,8 @@ export function CityBuilder({ onBack }: Props) {
   const [attackReport, setAttackReport] = useState<AttackEvent | null>(null)
   const attackShownRef = useRef<number | null>(null)
   const [currentTime, setCurrentTime] = useState(Date.now())
+  const worldRef = useRef<HTMLDivElement>(null)
+  const worldDimsRef = useRef({ w: CITY_COLS * CELL_PX, h: CITY_ROWS * CELL_PX })
 
   function showToast(msg: string) {
     setToast(msg)
@@ -285,6 +286,17 @@ export function CityBuilder({ onBack }: Props) {
     return () => clearInterval(id)
   }, [])
 
+  // Track actual grid pixel dimensions for walker bounds
+  useEffect(() => {
+    const el = worldRef.current
+    if (!el) return
+    const update = () => { worldDimsRef.current = { w: el.clientWidth, h: el.clientHeight } }
+    update()
+    const ro = new ResizeObserver(update)
+    ro.observe(el)
+    return () => ro.disconnect()
+  }, [])
+
   // ── Sync walkers when grid changes ───────────────────────────────────────────
 
   useEffect(() => {
@@ -297,7 +309,8 @@ export function CityBuilder({ onBack }: Props) {
         const count = spawnerUnitCount(city, cell.cardName)
         for (let u = 0; u < count; u++) {
           const existing = prev.find(w => w.cellIndex === i && w.unitIndex === u && w.unitName === cell.spawnedUnitName)
-          next.push(existing ?? makeWalker(i, u, cell.spawnedUnitName, cell.affinityWith))
+          const { w: dw, h: dh } = worldDimsRef.current
+          next.push(existing ?? makeWalker(i, u, cell.spawnedUnitName, cell.affinityWith, dw, dh))
         }
       }
       return next
@@ -308,17 +321,16 @@ export function CityBuilder({ onBack }: Props) {
   // ── Animation loop ────────────────────────────────────────────────────────────
 
   useEffect(() => {
-    const gridRows = city.rows ?? CITY_ROWS
-    const overlayH = gridRows * CELL_PX
     const id = setInterval(() => {
+      const { w: overlayW, h: overlayH } = worldDimsRef.current
       setWalkers(prev => prev.map(w => {
         let { x, y, vx, vy, turnTimer } = w
         x += vx
         y += vy
-        if (x < 0)                     { x = 0;                    vx = Math.abs(vx) }
-        if (x > OVERLAY_W - UNIT_SIZE) { x = OVERLAY_W - UNIT_SIZE; vx = -Math.abs(vx) }
-        if (y < 0)                     { y = 0;                    vy = Math.abs(vy) }
-        if (y > overlayH - UNIT_SIZE)  { y = overlayH - UNIT_SIZE; vy = -Math.abs(vy) }
+        if (x < 0)                      { x = 0;                     vx = Math.abs(vx) }
+        if (x > overlayW - UNIT_SIZE)   { x = overlayW - UNIT_SIZE;  vx = -Math.abs(vx) }
+        if (y < 0)                      { y = 0;                     vy = Math.abs(vy) }
+        if (y > overlayH - UNIT_SIZE)   { y = overlayH - UNIT_SIZE;  vy = -Math.abs(vy) }
         turnTimer--
         if (turnTimer <= 0) {
           const angle = Math.random() * Math.PI * 2
@@ -330,8 +342,7 @@ export function CityBuilder({ onBack }: Props) {
       }))
     }, 100)
     return () => clearInterval(id)
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [city.rows])
+  }, [])
 
   useEffect(() => { bulldozerRef.current = bulldozerMode }, [bulldozerMode])
 
@@ -1022,71 +1033,70 @@ export function CityBuilder({ onBack }: Props) {
         )
       })()}
 
-      {/* Header */}
+      {/* Header: back | title | gold | action buttons */}
       <div className="city-header">
         <button className="action-btn" onClick={onBack}>← BACK</button>
         <div className="city-title">🏙 CITY</div>
-        <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+        <div className="city-header-right">
           <div className="city-gold-display">⚙ {city.gold.toLocaleString()}</div>
-          <button className="filter-btn" onClick={() => setScreen('fortify')}>🛡</button>
-          <button className="filter-btn" onClick={() => setScreen('upgrade')}>★</button>
+          <button className="filter-btn" onClick={() => setScreen('fortify')} title="Manage city walls and moats">🛡 WALLS</button>
+          <button className="filter-btn" onClick={() => setScreen('upgrade')} title="Upgrade buildings">★ UP</button>
+          <button
+            className={`filter-btn${bulldozerMode ? ' city-bulldozer-btn--active' : ''}`}
+            onClick={toggleBulldozer}
+            title={bulldozerMode ? 'Demolish mode ON' : 'Demolish a building'}
+          >{bulldozerMode ? '🏗 ON' : '🏗'}</button>
         </div>
       </div>
 
-      {/* Income + bulldozer row */}
-      <div className="city-income-row">
-        <span className="city-income-in">+{incomeRate} gold</span>
-        {bulldozerMode
-          ? <span className="city-bulldozer-paused">⏸ PAUSED</span>
-          : <span className={`city-income-net${netRate >= 0 ? ' city-income-net--pos' : ' city-income-net--neg'}`}>
-              {netRate >= 0 ? `+${netRate}` : `${netRate}`}/min
-            </span>
-        }
-        <button
-          className={`filter-btn${bulldozerMode ? ' city-bulldozer-btn--active' : ''}`}
-          onClick={toggleBulldozer}
-          title={bulldozerMode ? 'Bulldozer ON — tap to demolish' : 'Toggle bulldozer to demolish buildings'}
-        >🏗{bulldozerMode ? ' ON' : ''}</button>
-      </div>
-
-      {/* Attack countdown */}
-      <div className={`city-attack-row city-attack-row--${attackUrgency}`}>
-        <span className="city-attack-icon">⚔</span>
-        <span className="city-attack-label">
-          {msToAttack <= 0 ? 'ATTACK IMMINENT' : `ATTACK IN ${attackCountdown}`}
+      {/* Compact info strip: attack countdown + defence + income + pop */}
+      <div className="city-info-strip">
+        <span className={`city-attack-pill city-attack-pill--${attackUrgency}`}>
+          ⚔ {msToAttack <= 0 ? 'NOW!' : attackCountdown}
         </span>
-        <span className="city-attack-defense">🛡 {defense}</span>
+        <span className="city-info-chip">🛡 {defense}</span>
+        <span className="city-info-chip">
+          {bulldozerMode
+            ? <span className="city-bulldozer-paused">⏸ PAUSED</span>
+            : `+${incomeRate}/m`}
+        </span>
+        <span className="city-info-chip">👥 {population}</span>
+        {cityRows < MAX_CITY_ROWS && expansionCost && (
+          <button
+            className={`filter-btn city-expand-btn${affordable ? ' city-expand-btn--ready' : ''}`}
+            onClick={handleExpand}
+            disabled={!affordable}
+            title={affordable ? `Expand city to ${cityRows + 1} rows` : 'Not enough resources to expand'}
+          >+ EXPAND</button>
+        )}
       </div>
 
-      {/* City stats */}
-      <div className="city-stats-row">
-        <div className="city-stat city-stat--population" title="Population">
-          👥 {population}
-        </div>
+      {/* Resources: horizontally scrollable chip strip */}
+      <div className="city-res-strip">
         {(['wheat', 'wood', 'ore', 'bread', 'planks', 'metal'] as ResourceType[]).map(res => {
-          const stock   = Math.floor(city.resources[res])
-          const prod    = prodRates[res] ?? 0
-          const cons    = consRates[res] ?? 0
-          const net     = prod - cons
+          const stock = Math.floor(city.resources[res])
+          const prod  = prodRates[res] ?? 0
+          const cons  = consRates[res] ?? 0
+          const net   = prod - cons
           if (stock === 0 && prod === 0) return null
+          const label = stock >= 10000 ? `${(stock / 1000).toFixed(0)}k` : stock >= 1000 ? `${(stock / 1000).toFixed(1)}k` : `${stock}`
           return (
-            <div key={res} className="city-stat" title={`${res}: ${stock} stock, ${net >= 0 ? '+' : ''}${net}/min`}>
-              {RESOURCE_ICONS[res]} {stock}
-              {net !== 0 && (
-                <span className={net > 0 ? 'city-res-pos' : 'city-res-neg'}>
-                  {net > 0 ? `+${net}` : net}/m
-                </span>
-              )}
-            </div>
+            <span key={res} className="city-res-chip" title={`${res}: ${stock} stock, ${net >= 0 ? '+' : ''}${net}/min`}>
+              {RESOURCE_ICONS[res]}{label}
+              {net !== 0 && <span className={net > 0 ? 'city-res-pos' : 'city-res-neg'}>{net > 0 ? `+${net}` : net}</span>}
+            </span>
           )
         })}
       </div>
 
-      {/* City world: grid + walker overlay */}
-      <div className="city-world">
+      {/* City world: fixed 50vh, scales with rows */}
+      <div className="city-world" ref={worldRef}>
         <div
           className="city-grid"
-          style={{ gridTemplateColumns: `repeat(${CITY_COLS}, 1fr)` }}
+          style={{
+            gridTemplateColumns: `repeat(${CITY_COLS}, 1fr)`,
+            gridTemplateRows:    `repeat(${cityRows}, 1fr)`,
+          }}
         >
           {Array.from({ length: cityCells }, (_, i) => {
             const cell      = city.grid[i]
@@ -1129,11 +1139,11 @@ export function CityBuilder({ onBack }: Props) {
         {/* Walking units overlay */}
         <div className="city-unit-overlay">
           {walkers.map(w => {
-            const happiness   = city.happiness[w.cellIndex] ?? 100
-            const rage        = 100 - happiness
+            const happiness       = city.happiness[w.cellIndex] ?? 100
+            const rage            = 100 - happiness
             const wantedNeighbour = w.affinityWith ?? w.unitName
-            const gridRows2 = city.rows ?? CITY_ROWS
-            const wantsFriend = !getNeighbourIndices(w.cellIndex, gridRows2).some(ni => {
+            const gridRows2       = city.rows ?? CITY_ROWS
+            const wantsFriend     = !getNeighbourIndices(w.cellIndex, gridRows2).some(ni => {
               const nc = city.grid[ni]
               return nc?.spawnedUnitName === wantedNeighbour && (city.happiness[ni] ?? 100) > 0
             })
@@ -1152,12 +1162,7 @@ export function CityBuilder({ onBack }: Props) {
                     <SpriteImg name={wantedNeighbour} className="city-speech-icon" />
                   </div>
                 )}
-                <AnimatedSpriteImg
-                  name={w.unitName}
-                  frameCount={3}
-                  fps={6}
-                  className="city-walker-sprite"
-                />
+                <AnimatedSpriteImg name={w.unitName} frameCount={3} fps={6} className="city-walker-sprite" />
                 {rage >= 40 && <span className="city-walker-need">!</span>}
               </div>
             )
@@ -1165,7 +1170,7 @@ export function CityBuilder({ onBack }: Props) {
         </div>
       </div>
 
-      {/* City perimeter — fortification sprites shown as the city wall */}
+      {/* City perimeter — fortification sprites as the city wall */}
       {city.fortifications.length > 0 && (
         <div
           className="city-perimeter"
@@ -1175,14 +1180,13 @@ export function CityBuilder({ onBack }: Props) {
           onKeyDown={e => { if (e.key === 'Enter') setScreen('fortify') }}
           title="City fortifications — tap to manage"
         >
-          <div className="city-perimeter-label">🛡 CITY WALLS</div>
           <div className="city-perimeter-forts">
             {city.fortifications.map((fort, idx) => {
-              const hpPct = fort.hp / fort.maxHp
+              const hpPct  = fort.hp / fort.maxHp
               const hpColor = hpPct > 0.6 ? '#308030' : hpPct > 0.3 ? '#806020' : '#803020'
               return (
                 <div key={idx} className="city-perimeter-fort">
-                  <div className="city-perimeter-fort-bg" style={{ opacity: 0.25 + hpPct * 0.55, background: hpColor }} />
+                  <div className="city-perimeter-fort-bg" style={{ opacity: 0.2 + hpPct * 0.5, background: hpColor }} />
                   <SpriteImg name={fort.cardName} className="city-perimeter-sprite" />
                   <div className="city-perimeter-hp" style={{ width: `${Math.round(hpPct * 100)}%`, background: hpColor }} />
                 </div>
@@ -1192,37 +1196,21 @@ export function CityBuilder({ onBack }: Props) {
         </div>
       )}
 
-      {/* Expand city button */}
-      {cityRows < MAX_CITY_ROWS && expansionCost && (
-        <div className="city-expand-row">
-          <button
-            className={`action-btn${affordable ? ' action-btn--gold' : ''}`}
-            onClick={handleExpand}
-            disabled={!affordable}
-            title={affordable ? 'Expand your city by one row' : 'Not enough resources to expand'}
-          >
-            EXPAND CITY ({cityRows}→{cityRows + 1} rows)
-            {' '}⚙{expansionCost.gold.toLocaleString()}
-            {Object.entries(expansionCost.resources).map(([r, a]) =>
-              ` ${RESOURCE_ICONS[r as ResourceType]}${a}`
-            ).join('')}
-          </button>
-        </div>
-      )}
-
-      {/* Resident thoughts feed */}
-      {residentThoughts.length > 0 && (
-        <div className="city-thoughts">
-          <div className="city-thoughts-title">RESIDENT THOUGHTS</div>
-          {residentThoughts.map((t, idx) => (
-            <div key={idx} className={`city-thought-row${t.happy ? ' city-thought-row--happy' : ' city-thought-row--unhappy'}`}>
-              <AnimatedSpriteImg name={t.unitName} frameCount={3} fps={6} className="city-thought-sprite" />
-              <span className="city-thought-name">{t.name}:</span>
-              <span className="city-thought-text">"{t.thought}"</span>
-            </div>
-          ))}
-        </div>
-      )}
+      {/* Scrollable bottom: resident thoughts */}
+      <div className="city-bottom-scroll">
+        {residentThoughts.length > 0 && (
+          <div className="city-thoughts">
+            <div className="city-thoughts-title">RESIDENT THOUGHTS</div>
+            {residentThoughts.map((t, idx) => (
+              <div key={idx} className={`city-thought-row${t.happy ? ' city-thought-row--happy' : ' city-thought-row--unhappy'}`}>
+                <AnimatedSpriteImg name={t.unitName} frameCount={3} fps={6} className="city-thought-sprite" />
+                <span className="city-thought-name">{t.name}:</span>
+                <span className="city-thought-text">"{t.thought}"</span>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
     </div>
   )
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -8964,17 +8964,25 @@ html.light-mode .action-btn {
   position: relative;
   display: flex;
   flex-direction: column;
-  gap: 10px;
-  padding: 12px;
+  gap: 4px;
+  padding: 8px 8px 0;
   height: 100%;
-  overflow-y: auto;
+  overflow: hidden;
   box-sizing: border-box;
 }
 
 .city-header {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 6px;
+  flex-shrink: 0;
+}
+.city-header-right {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-left: auto;
+  flex-wrap: nowrap;
 }
 
 .city-title {
@@ -8992,17 +9000,84 @@ html.light-mode .action-btn {
   font-weight: bold;
 }
 
-/* Income / wage row */
-.city-income-row {
-  font-size: 11px;
-  text-align: center;
+/* ── Compact info strip ───────────────────────────────────────────────────── */
+.city-info-strip {
   display: flex;
-  justify-content: center;
-  gap: 6px;
-  flex-wrap: wrap;
+  align-items: center;
+  gap: 5px;
+  flex-shrink: 0;
+  flex-wrap: nowrap;
+  overflow-x: auto;
+  scrollbar-width: none;
+  padding-bottom: 1px;
 }
+.city-info-strip::-webkit-scrollbar { display: none; }
+
+.city-attack-pill {
+  font-size: 9px;
+  font-weight: bold;
+  letter-spacing: 0.5px;
+  padding: 2px 5px;
+  border-radius: 3px;
+  border: 1px solid currentColor;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+.city-attack-pill--calm     { color: #508050; }
+.city-attack-pill--soon     { color: #c08020; }
+.city-attack-pill--imminent { color: #d06030; animation: city-pulse 1.2s ease-in-out infinite; }
+
+.city-info-chip {
+  font-size: 10px;
+  color: #608060;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.city-expand-btn {
+  font-size: 9px !important;
+  padding: 2px 5px !important;
+  letter-spacing: 0.5px;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+.city-expand-btn--ready {
+  border-color: #d0a030 !important;
+  color: #d0a030 !important;
+  background: rgba(208,160,48,0.08) !important;
+}
+
+/* ── Resource chip strip ─────────────────────────────────────────────────── */
+.city-res-strip {
+  display: flex;
+  gap: 5px;
+  overflow-x: auto;
+  flex-shrink: 0;
+  scrollbar-width: none;
+  padding-bottom: 2px;
+}
+.city-res-strip::-webkit-scrollbar { display: none; }
+
+.city-res-chip {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  font-size: 10px;
+  color: #80a080;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+/* ── Scrollable bottom ───────────────────────────────────────────────────── */
+.city-bottom-scroll {
+  flex: 1;
+  overflow-y: auto;
+  min-height: 0;
+  padding-bottom: 8px;
+}
+
+/* Legacy income row kept for sub-screens that still use it */
 .city-income-in   { color: #60a060; }
-.city-income-wage { color: #a06060; }
 .city-income-net--pos { color: #60d060; font-weight: bold; }
 .city-income-net--neg { color: #d06060; font-weight: bold; }
 
@@ -9011,26 +9086,28 @@ html.light-mode .action-btn {
 .city-world {
   position: relative;
   width: 100%;
-  /* height is determined by grid content */
+  flex: 0 0 50vh;
+  height: 50vh;
+  overflow: hidden;
 }
 
 .city-grid {
   display: grid;
-  gap: 3px;
+  gap: 2px;
   width: 100%;
+  height: 100%;
 }
 
 .city-cell {
   background: #050a05;
   border: 1px dashed #1a3a1a;
-  border-radius: 3px;
-  min-height: 72px;
+  border-radius: 2px;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  padding: 4px 2px 8px;
+  padding: 1px;
   position: relative;
   transition: border-color 0.15s;
   overflow: hidden;
@@ -9040,7 +9117,7 @@ html.light-mode .action-btn {
 .city-cell--occupied         { border-style: dashed; border-color: #1a3a1a; background: #061006; }
 .city-cell--occupied:hover   { border-color: #aa3030; background: #120606; }
 
-.city-cell-sprite  { width: 32px; height: 32px; image-rendering: pixelated; }
+.city-cell-sprite  { width: 65%; height: 65%; max-width: 36px; max-height: 36px; image-rendering: pixelated; }
 
 .city-cell-name { display: none; }
 
@@ -9511,28 +9588,10 @@ html.light-mode .action-btn {
 .city-cell--bulldoze:hover { background: rgba(160,48,32,0.4) !important; }
 .city-bulldozer-paused { font-size: 10px; color: #e06040; letter-spacing: 1px; }
 
-/* ── City Builder — attack countdown row ────────────────────────────────── */
-.city-attack-row {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  font-size: 11px;
-  font-family: monospace;
-  padding: 4px 6px;
-  border: 1px solid #1a3a1a;
-  border-radius: 3px;
-  background: #040a04;
-}
-.city-attack-row--calm    { border-color: #204020; color: #508050; }
-.city-attack-row--soon    { border-color: #604010; color: #c08020; }
-.city-attack-row--imminent { border-color: #602010; color: #d06030; animation: city-pulse 1.2s ease-in-out infinite; }
 @keyframes city-pulse {
   0%, 100% { opacity: 1; }
   50%       { opacity: 0.5; }
 }
-.city-attack-icon  { font-size: 13px; }
-.city-attack-label { flex: 1; font-weight: bold; letter-spacing: 1px; }
-.city-attack-defense { color: #40a060; font-size: 10px; }
 
 /* ── City Builder — attack report modal ─────────────────────────────────── */
 .city-attack-report-header {
@@ -9596,28 +9655,21 @@ html.light-mode .action-btn {
 
 /* ── City Builder — city perimeter (wall/moat visual strip) ─────────────── */
 .city-perimeter {
-  border: 1px solid #1a3a1a;
   border-top: 2px solid #204a20;
   background: #040a04;
-  padding: 4px 6px 6px;
+  padding: 3px 6px 4px;
   cursor: pointer;
-  border-radius: 0 0 4px 4px;
+  flex-shrink: 0;
 }
-.city-perimeter:hover { border-color: #308030; }
-.city-perimeter-label {
-  font-size: 9px;
-  color: #406040;
-  letter-spacing: 2px;
-  margin-bottom: 4px;
-}
+.city-perimeter:hover { border-top-color: #308030; }
 .city-perimeter-forts {
   display: flex;
   flex-wrap: wrap;
-  gap: 3px;
+  gap: 2px;
 }
 .city-perimeter-fort {
   position: relative;
-  width: 28px;
+  width: 24px;
   flex-shrink: 0;
 }
 .city-perimeter-fort-bg {
@@ -9626,8 +9678,8 @@ html.light-mode .action-btn {
   border-radius: 2px;
 }
 .city-perimeter-sprite {
-  width: 28px;
-  height: 28px;
+  width: 24px;
+  height: 24px;
   image-rendering: pixelated;
   display: block;
   position: relative;
@@ -9639,16 +9691,6 @@ html.light-mode .action-btn {
   transition: width 0.5s, background 0.5s;
 }
 
-/* ── City Builder — expand city ──────────────────────────────────────────── */
-.city-expand-row {
-  display: flex;
-  justify-content: center;
-  padding: 4px 0;
-}
-.city-expand-row .action-btn {
-  font-size: 10px;
-  letter-spacing: 1px;
-}
 
 /* ── City Builder — building resident panel ─────────────────────────────── */
 .city-search {


### PR DESCRIPTION
## Summary

- **Grid fixed to 50vh**: `city-world` is `flex: 0 0 50vh` — grid always occupies exactly half the screen. `grid-template-rows: repeat(N, 1fr)` scales cells down proportionally as rows are added (no scrolling, no overflow).
- **Sprites scale with cells**: changed from fixed `32px` to `65% / max 36px` so they fill each cell at any size.
- **Walker bounds from ResizeObserver**: walkers use actual pixel dimensions of the rendered grid element instead of the old hard-coded `CELL_PX` constant.
- **Compact header**: BACK | 🏙 CITY | ⚙gold | **🛡 WALLS** | **★ UP** | **🏗** — all in one row with clear text labels on the previously-unlabelled icon buttons.
- **Single info strip**: attack countdown pill + 🛡 defence + income/min + 👥 pop + **+ EXPAND** (inline, colour-coded gold when affordable) — no separate rows.
- **Resource chips**: horizontally-scrollable single-line strip with `k` abbreviation for large numbers.
- **Resident thoughts**: moved to a `flex: 1 / overflow-y: auto` bottom zone — never pushes grid off screen.
- **City perimeter**: slimmed to 24px sprites, no label text.

## Test plan
- [ ] City grid occupies ~50% screen height on phone; cells scale proportionally with 4/5/6 rows
- [ ] Header buttons clearly labelled: WALLS, UP, 🏗
- [ ] Info strip shows attack countdown, defence, income, pop, expand in one line
- [ ] + EXPAND button goes gold when affordable, hidden at max rows
- [ ] Resident thoughts scroll independently without affecting grid position
- [ ] `npm run build` passes clean

https://claude.ai/code/session_01PTMuAwadf8DsBHAvxSVU3U

---
_Generated by [Claude Code](https://claude.ai/code/session_01PTMuAwadf8DsBHAvxSVU3U)_