### PR TITLE
Improve battle UI: popup toggle in settings, remove battle highlights

### DIFF
--- a/web/src/components/Battlefield.tsx
+++ b/web/src/components/Battlefield.tsx
@@ -13,6 +13,7 @@ import { getUnitLore, getCardCatalog } from '../game/cards'
 import { Button } from './Button'
 import { ConfirmModal } from './ConfirmModal'
 import { loadPlayerName, loadPlayerAvatar } from '../game/questline'
+import { loadBattlePopups } from './SettingsScreen'
 import { TutorialOverlay } from './TutorialOverlay'
 import { hasSeen, markSeen } from '../game/tutorial'
 
@@ -708,6 +709,7 @@ export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPaus
     if (state.log.length < lastLogLenRef.current) lastLogLenRef.current = 0  // new battle
     const newEntries = state.log.slice(lastLogLenRef.current)
     lastLogLenRef.current = state.log.length
+    if (!loadBattlePopups()) return
     const important = newEntries.filter(e => e.startsWith('!!')).map(e => e.slice(2))
     if (important.length === 0) return
     setImportantMsgQueue(q => [...q, ...important])

--- a/web/src/components/GameOver.tsx
+++ b/web/src/components/GameOver.tsx
@@ -129,19 +129,6 @@ export function GameOver({ state, winner, handicap, onOpenPack, onPlayAgain, onM
         )}
       </div>
 
-      {(() => {
-        const highlights = state.log.filter(e => e.startsWith('!!')).map(e => e.slice(2))
-        if (highlights.length === 0) return null
-        return (
-          <div className="gameover-highlights">
-            <div className="gameover-highlights-title">── BATTLE HIGHLIGHTS ──</div>
-            {highlights.map((entry, i) => (
-              <div key={i} className="gameover-highlights-entry">{entry}</div>
-            ))}
-          </div>
-        )
-      })()}
-
       {isEndlessDefeat && (
         <div className="gameover-endless-lb">
           <div className="gameover-endless-lb-title">∞ ENDLESS LEADERBOARD</div>

--- a/web/src/components/SettingsScreen.tsx
+++ b/web/src/components/SettingsScreen.tsx
@@ -33,6 +33,7 @@ const SKIP_INTRO_KEY     = 'jarv_skip_intro'
 const EIGHTBIT_UNLOCKED_KEY = 'jarv_8bit_unlocked'
 const EIGHTBIT_ENABLED_KEY  = 'jarv_8bit_enabled'
 const LIGHT_MODE_KEY        = 'jarv_light_mode'
+const BATTLE_POPUPS_KEY     = 'jarv_battle_popups'
 
 export function loadSkipIntro(): boolean {
   try { return localStorage.getItem(SKIP_INTRO_KEY) === 'true' }
@@ -98,6 +99,15 @@ export function applyLightMode(enabled: boolean): void {
   }
 }
 
+export function loadBattlePopups(): boolean {
+  try { return localStorage.getItem(BATTLE_POPUPS_KEY) !== 'false' }
+  catch { return true }
+}
+
+export function saveBattlePopups(val: boolean): void {
+  try { localStorage.setItem(BATTLE_POPUPS_KEY, String(val)) } catch { /* ignore */ }
+}
+
 export function applyTextSettings(): void {
   const size  = loadTextSize()
   const color = loadTextColor()
@@ -143,6 +153,7 @@ export function SettingsScreen({ onBack, onResetGame, user, authLoading, onDevCr
   const [eightbitOn,    setEightbitOn]    = useState(load8bitEnabled)
   const [eightbitUnlocked]               = useState(load8bitUnlocked)
   const [lightModeOn,   setLightModeOn]   = useState(loadLightMode)
+  const [battlePopups,  setBattlePopups]  = useState(loadBattlePopups)
   const [confirmReset,  setConfirmReset]  = useState(false)
   const [importMsg,     setImportMsg]     = useState<string | null>(null)
   const [rollbarMsg,    setRollbarMsg]    = useState<string | null>(null)
@@ -246,6 +257,12 @@ export function SettingsScreen({ onBack, onResetGame, user, authLoading, onDevCr
     setLightModeOn(next)
     saveLightMode(next)
     applyLightMode(next)
+  }
+
+  function handleBattlePopupsToggle() {
+    const next = !battlePopups
+    setBattlePopups(next)
+    saveBattlePopups(next)
   }
 
   function handleSkipIntroToggle() {
@@ -427,6 +444,17 @@ export function SettingsScreen({ onBack, onResetGame, user, authLoading, onDevCr
         )}
 
         <Section bordered title="DISPLAY">
+          <div className="settings-row">
+            <div>
+              <div className="settings-label">Battle event popups</div>
+              <div className="settings-sublabel">Show mid-battle popups for notable events (e.g. hero summons)</div>
+            </div>
+            <div className="settings-toggle" onClick={handleBattlePopupsToggle}>
+              <div className={`settings-toggle-track${battlePopups ? ' settings-toggle-track--on' : ''}`}>
+                <div className="settings-toggle-thumb" />
+              </div>
+            </div>
+          </div>
           <div className="settings-row">
             <div>
               <div className="settings-label">Light mode</div>


### PR DESCRIPTION
## Summary

- **Battle event popups** are now opt-out. A new toggle in Settings → Display ("Battle event popups") lets the player disable the mid-battle popups that pause the game. The preference is persisted to `localStorage` (`jarv_battle_popups`). Popups are on by default so existing players see no change until they opt out.
- **Battle Highlights removed** from the game-over screen. The non-scrollable post-battle log was cluttering the results screen without adding much value, so it's been cut entirely.

## Test plan

- [ ] Start a battle and verify the "Blood Summoner raises a Blood Wraith" style popups appear and pause the game as before
- [ ] Go to Settings → Display, toggle "Battle event popups" off, start another battle — no popups should appear and the game should not pause for events
- [ ] Toggle back on and verify popups return
- [ ] Refresh the page and confirm the setting is remembered
- [ ] Complete a battle and verify the game-over screen no longer shows a "BATTLE HIGHLIGHTS" section

https://claude.ai/code/session_019Hb7gceTR7DssGnTsPqrQZ

---
_Generated by [Claude Code](https://claude.ai/code/session_019Hb7gceTR7DssGnTsPqrQZ)_