### PR TITLE
Fix city builder: attack notification repeats & residents tab resets

### DIFF
--- a/web/src/components/minigames/CityBuilder.tsx
+++ b/web/src/components/minigames/CityBuilder.tsx
@@ -257,7 +257,14 @@ export function CityBuilder({ onBack }: Props) {
   const bulldozerRef = useRef(false)
   const [residentThoughts, setResidentThoughts] = useState<ResidentThought[]>([])
   const [attackReport, setAttackReport] = useState<AttackEvent | null>(null)
-  const attackShownRef = useRef<number | null>(null)
+  const attackShownRef = useRef<number | null>(
+    (() => {
+      try {
+        const stored = localStorage.getItem('city-attack-shown-at')
+        return stored ? parseInt(stored, 10) : null
+      } catch { return null }
+    })()
+  )
   const [currentTime, setCurrentTime] = useState(Date.now())
   const worldRef = useRef<HTMLDivElement>(null)
   const worldDimsRef = useRef({ w: CITY_COLS * CELL_PX, h: CITY_ROWS * CELL_PX })
@@ -277,8 +284,14 @@ export function CityBuilder({ onBack }: Props) {
     if (city.lastAttack && city.lastAttack.at !== attackShownRef.current) {
       setAttackReport(city.lastAttack)
       attackShownRef.current = city.lastAttack.at
+      try { localStorage.setItem('city-attack-shown-at', String(city.lastAttack.at)) } catch { /* ignore */ }
     }
   }, [city.lastAttack])
+
+  // Reset building modal to residents tab when returning to city screen
+  useEffect(() => {
+    if (screen === 'city') setBuildingTab('residents')
+  }, [screen])
 
   // Update countdown clock every minute
   useEffect(() => {


### PR DESCRIPTION
## Summary

- **Attack notification repeating**: `attackShownRef` (a `useRef`) was reset to `null` every time the `CityBuilder` component unmounted, causing the attack report modal to re-appear on each visit. Fixed by persisting the last-acknowledged attack timestamp in `localStorage` so it survives navigation away and back.
- **Residents tab not shown after sub-screen**: When returning from the fortify/upgrade/picker sub-screens, `selectedBuildingCell` was still set so the building inspect modal re-opened — but `buildingTab` could still be `'upgrade'` from a prior interaction, hiding the Residents tab. Fixed by resetting `buildingTab` to `'residents'` whenever `screen` transitions back to `'city'`.

## Test plan

- [ ] Trigger a city attack, close the notification, navigate away from city builder and back — notification should not reappear
- [ ] Navigate to fortify or upgrade screen and back — building inspect modal (if open) should show the Residents tab
- [ ] Switch to the Upgrade tab in a building modal, go to the upgrade sub-screen, come back — modal should show Residents tab
- [ ] A new attack (different timestamp) should still show the notification once

https://claude.ai/code/session_01WxHSwsayd2NKw38T7jLSqg

---
_Generated by [Claude Code](https://claude.ai/code/session_01WxHSwsayd2NKw38T7jLSqg)_