### PR TITLE
Fix city builder root causes: attack float precision & walker off-screen

### DIFF
--- a/web/src/components/minigames/CityBuilder.tsx
+++ b/web/src/components/minigames/CityBuilder.tsx
@@ -261,7 +261,7 @@ export function CityBuilder({ onBack }: Props) {
     (() => {
       try {
         const stored = localStorage.getItem('city-attack-shown-at')
-        return stored ? parseInt(stored, 10) : null
+        return stored ? Number(stored) : null
       } catch { return null }
     })()
   )
@@ -299,16 +299,23 @@ export function CityBuilder({ onBack }: Props) {
     return () => clearInterval(id)
   }, [])
 
-  // Track actual grid pixel dimensions for walker bounds
+  // Track actual grid pixel dimensions for walker bounds.
+  // Re-run on screen changes so the observer re-attaches to the remounted city-world div
+  // and ignores the zero-size callback fired when the div is removed from the DOM.
   useEffect(() => {
     const el = worldRef.current
     if (!el) return
-    const update = () => { worldDimsRef.current = { w: el.clientWidth, h: el.clientHeight } }
+    const update = () => {
+      if (el.clientWidth > 0 && el.clientHeight > 0) {
+        worldDimsRef.current = { w: el.clientWidth, h: el.clientHeight }
+      }
+    }
     update()
     const ro = new ResizeObserver(update)
     ro.observe(el)
     return () => ro.disconnect()
-  }, [])
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [screen])
 
   // ── Sync walkers when grid changes ───────────────────────────────────────────
 
@@ -323,7 +330,9 @@ export function CityBuilder({ onBack }: Props) {
         for (let u = 0; u < count; u++) {
           const existing = prev.find(w => w.cellIndex === i && w.unitIndex === u && w.unitName === cell.spawnedUnitName)
           const { w: dw, h: dh } = worldDimsRef.current
-          next.push(existing ?? makeWalker(i, u, cell.spawnedUnitName, cell.affinityWith, dw, dh))
+          const effectiveDw = dw || CITY_COLS * CELL_PX
+          const effectiveDh = dh || CITY_ROWS * CELL_PX
+          next.push(existing ?? makeWalker(i, u, cell.spawnedUnitName, cell.affinityWith, effectiveDw, effectiveDh))
         }
       }
       return next
@@ -335,7 +344,9 @@ export function CityBuilder({ onBack }: Props) {
 
   useEffect(() => {
     const id = setInterval(() => {
-      const { w: overlayW, h: overlayH } = worldDimsRef.current
+      const { w: _w, h: _h } = worldDimsRef.current
+      const overlayW = _w || CITY_COLS * CELL_PX
+      const overlayH = _h || CITY_ROWS * CELL_PX
       setWalkers(prev => prev.map(w => {
         let { x, y, vx, vy, turnTimer } = w
         x += vx


### PR DESCRIPTION
## What was actually wrong

### Attack notification repeats every session

The previous fix stored the attack timestamp in `localStorage` but read it back with `parseInt()`. Since `nextAttackAt` includes `Math.random() * ATTACK_INTERVAL_JITTER_MS`, it's a float (e.g. `1746603847291.58`). `parseInt` truncates to `1746603847291`, which never equals the float in `city.lastAttack.at`, so the notification always showed again.

**Fix:** `parseInt(stored, 10)` → `Number(stored)`.

### Residents (walkers) invisible after returning from sub-screens

When the user navigates to a sub-screen (upgrade/fortify/picker), the `city-world` div is removed from the DOM. The `ResizeObserver` fires with size `(0, 0)`, setting `worldDimsRef.current = {w:0, h:0}`. The animation loop's bounds checks then clamp all walker positions to `(-UNIT_SIZE, -UNIT_SIZE)` = `(-20, -20)` — completely outside the overlay. With `overflow: hidden`, walkers are invisible. When the user returns to city view, the observer was still watching the old detached element, so dims stayed at zero and walkers remained off-screen permanently.

**Fix:**
- ResizeObserver effect now depends on `screen` so it re-attaches to the remounted `city-world` div on return, immediately restoring correct dimensions
- Observer callback guards against zero-size reports (element-removed callbacks) so a racing callback can't corrupt `worldDimsRef`
- Animation loop and walker sync both fall back to `CITY_COLS * CELL_PX` / `CITY_ROWS * CELL_PX` if dims are somehow still zero

## Test plan

- [ ] Trigger an attack, dismiss the notification, leave city builder, return — notification should NOT reappear
- [ ] Navigate to upgrade/fortify/picker sub-screen and back — walker sprites should remain visible and distributed across the grid
- [ ] Place a new spawner building from the picker — its walker should appear correctly positioned (not stacked at top-left)
- [ ] Resize the browser window while on the city screen after returning from a sub-screen — walker bounds should update correctly

https://claude.ai/code/session_01WxHSwsayd2NKw38T7jLSqg

---
_Generated by [Claude Code](https://claude.ai/code/session_01WxHSwsayd2NKw38T7jLSqg)_