### PR TITLE
Stop resident thoughts from rebuilding every animation tick

### DIFF
--- a/web/src/components/minigames/CityBuilder.tsx
+++ b/web/src/components/minigames/CityBuilder.tsx
@@ -619,8 +619,9 @@ export function CityBuilder({ onBack }: Props) {
 
   useEffect(() => {
     setResidentThoughts(buildResidentThoughts(city, cityPopulation(city), walkersRef.current))
+  // walkersRef.current used intentionally — avoids rebuilding every animation tick
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [city, walkers])
+  }, [city])
 
   useEffect(() => {
     const id = setInterval(() => {


### PR DESCRIPTION
## Summary

- Removed `walkers` from the `useEffect` dependency array in the resident thoughts effect
- `walkersRef.current` is already used inside the effect, so it stays correct without the dep
- Thoughts now rebuild only on `city` changes and via the existing 15-second interval, instead of every 100 ms animation tick

https://claude.ai/code/session_01WxHSwsayd2NKw38T7jLSqg

---
_Generated by [Claude Code](https://claude.ai/code/session_01WxHSwsayd2NKw38T7jLSqg)_