### PR TITLE
feat(city-builder): fortification durability, build queue & builder system (#1037)

### DIFF
--- a/web/src/components/minigames/CityBuilder.tsx
+++ b/web/src/components/minigames/CityBuilder.tsx
@@ -13,8 +13,9 @@ import {
   CITY_COLS, CITY_ROWS, CITY_CELLS, CELL_PX, MAX_CITY_ROWS,
   CityCell, CityState, ResourceType, ResourceStock, AttackEvent,
   RESOURCE_ICONS, SPAWNER_PLACE_COST,
-  FORT_MAX_HP, FORT_DEFENSE, FORT_PLACE_COST, EXPANSION_COSTS, MAX_TOTAL_FORTS,
-  canAffordFortification,
+  FORT_MAX_HP, FORT_DEFENSE, FORT_PLACE_COST, FORT_MAX_ATTACKS, EXPANSION_COSTS, MAX_TOTAL_FORTS,
+  DEFAULT_BUILDER_COUNT, MAX_BUILDER_COUNT, BUILDER_HIRE_COSTS,
+  canAffordFortification, canQueueFortification,
   loadCityState, saveCityState, tickCity,
   placeCard, removeCard,
   addFortification, removeFortification,
@@ -28,6 +29,7 @@ import {
   INCOME_SPAWN, INCOME_UTILITY, INCOME_WALL,
   spawnerUnitCount, masteryOutputMultiplier,
   getNeighbourIndices,
+  nextBuilderCost, buyBuilder,
 } from '../../game/cityBuilder'
 import { MasteryBar } from '../MasteryBar'
 import { SpriteImg, AnimatedSpriteImg } from '../SpriteImg'
@@ -760,11 +762,31 @@ export function CityBuilder({ onBack }: Props) {
   // ── Fortification handlers ────────────────────────────────────────────────────
 
   function handleAddFort(card: Card) {
+    if (!canQueueFortification(city)) {
+      const builderCount = city.builderCount ?? DEFAULT_BUILDER_COUNT
+      if (city.builderQueue.length >= builderCount) {
+        showToast('All builders are busy! Wait for one to finish.')
+      } else {
+        showToast(`Fort limit reached (${MAX_TOTAL_FORTS} max).`)
+      }
+      return
+    }
     if (!canAffordFortification(city, card.rarity)) { showToast('Not enough resources!'); return }
     const next = addFortification(city, card.name, card.rarity)
-    if (!next) { showToast(`Fort limit reached (${MAX_TOTAL_FORTS} max).`); return }
+    if (!next) { showToast('Cannot build — check builder slots and resources.'); return }
+    const buildMinutes = FORT_MAX_HP[card.rarity]
     save(next)
-    showToast(`${card.name} built!`)
+    showToast(`${card.name} queued — ${buildMinutes} min build time.`)
+  }
+
+  function handleBuyBuilder() {
+    const cost = nextBuilderCost(city)
+    if (cost === null) { showToast('Maximum builders reached!'); return }
+    if (city.gold < cost) { showToast(`Need ⚙ ${cost.toLocaleString()} gold to hire a builder.`); return }
+    const next = buyBuilder(city)
+    if (!next) return
+    save(next)
+    showToast(`Builder hired! Now ${next.builderCount} builders.`)
   }
 
   function handleRemoveFort(index: number) {
@@ -852,28 +874,72 @@ export function CityBuilder({ onBack }: Props) {
   // ── Fortify sub-screen ────────────────────────────────────────────────────────
 
   if (screen === 'fortify') {
+    const builderCount = city.builderCount ?? DEFAULT_BUILDER_COUNT
+    const freeBuilders = builderCount - city.builderQueue.length
+    const builderCost  = nextBuilderCost(city)
+    const totalSlots   = city.fortifications.length + city.builderQueue.length
     return (
       <div className="city-screen">
         <div className="city-picker-header">
           <button className="action-btn" onClick={() => setScreen('city')}>← BACK</button>
-          <div className="city-picker-title">🛡 FORTIFICATIONS ({city.fortifications.length}/{MAX_TOTAL_FORTS})</div>
+          <div className="city-picker-title">🛡 FORTIFICATIONS ({totalSlots}/{MAX_TOTAL_FORTS})</div>
         </div>
 
         <div className="city-subscreen-scroll">
         <div className="city-fort-info-row">
-          <span>Total defence from forts: <strong>{
+          <span>Total defence: <strong>{
             city.fortifications.reduce((sum, f) => sum + Math.round(FORT_DEFENSE[f.rarity] * (f.hp / f.maxHp)), 0)
           } 🛡</strong></span>
-          <span className="city-fort-repair-note">Residents repair walls using 🪵</span>
+          <span className="city-fort-repair-note">🪵 Repairs: 1 HP / 5 min</span>
+        </div>
+
+        {/* Builder slots */}
+        <div className="city-picker-section-label">
+          BUILDERS ({freeBuilders}/{builderCount} free)
+        </div>
+        <div className="city-fort-builders-row">
+          {Array.from({ length: builderCount }, (_, i) => {
+            const entry = city.builderQueue[i]
+            if (entry) {
+              const msLeft = Math.max(0, entry.completesAt - currentTime)
+              return (
+                <div key={i} className="city-fort-builder city-fort-builder--busy">
+                  <SpriteImg name={entry.cardName} className="city-fort-builder-sprite" />
+                  <div className="city-fort-builder-label">🔨 {entry.cardName}</div>
+                  <div className="city-fort-builder-eta">{formatCountdown(msLeft)}</div>
+                </div>
+              )
+            }
+            return (
+              <div key={i} className="city-fort-builder city-fort-builder--free">
+                🏗 Builder available
+              </div>
+            )
+          })}
+          {builderCount < MAX_BUILDER_COUNT && builderCost !== null && (
+            <button
+              className={`city-fort-builder city-fort-builder--hire${city.gold >= builderCost ? ' city-fort-builder--hire-ready' : ''}`}
+              onClick={handleBuyBuilder}
+              disabled={city.gold < builderCost}
+              title={`Hire builder for ⚙ ${builderCost.toLocaleString()}`}
+            >
+              + Hire Builder<br/>
+              <span className="city-fort-builder-cost">⚙ {builderCost.toLocaleString()}</span>
+            </button>
+          )}
         </div>
 
         {city.fortifications.length > 0 && (
           <>
-            <div className="city-picker-section-label">BUILT ({city.fortifications.length})</div>
+            <div className="city-picker-section-label">ACTIVE ({city.fortifications.length})</div>
             <div className="city-fort-list">
               {city.fortifications.map((fort, idx) => {
                 const hpPct = Math.round((fort.hp / fort.maxHp) * 100)
                 const hpColor = hpPct > 60 ? '#40a040' : hpPct > 30 ? '#c08020' : '#c04020'
+                const maxAtks = FORT_MAX_ATTACKS[fort.rarity]
+                const atksLeft = maxAtks - (fort.attacksTaken ?? 0)
+                const lifePct = Math.round((atksLeft / maxAtks) * 100)
+                const lifeColor = lifePct > 60 ? '#305080' : lifePct > 30 ? '#705020' : '#702020'
                 return (
                   <div key={idx} className="city-fort-item">
                     <SpriteImg name={fort.cardName} className="city-fort-sprite" />
@@ -883,7 +949,15 @@ export function CityBuilder({ onBack }: Props) {
                         <div className="city-fort-hp-bar">
                           <div className="city-fort-hp-fill" style={{ width: `${hpPct}%`, background: hpColor }} />
                         </div>
-                        <span className="city-fort-hp-text">{Math.round(fort.hp)}/{fort.maxHp}</span>
+                        <span className="city-fort-hp-text">{Math.round(fort.hp)}/{fort.maxHp} HP</span>
+                      </div>
+                      <div className="city-fort-hp-track" title={`${atksLeft} attacks remaining before permanent destruction`}>
+                        <div className="city-fort-hp-bar">
+                          <div className="city-fort-hp-fill" style={{ width: `${lifePct}%`, background: lifeColor }} />
+                        </div>
+                        <span className="city-fort-hp-text" style={{ color: lifeColor }}>
+                          {atksLeft}/{maxAtks} raids
+                        </span>
                       </div>
                       <div className="city-fort-defense-val">🛡 {Math.round(FORT_DEFENSE[fort.rarity] * (fort.hp / fort.maxHp))}</div>
                     </div>
@@ -896,8 +970,10 @@ export function CityBuilder({ onBack }: Props) {
         )}
 
         <div className="city-picker-section-label">ADD WALL / MOAT</div>
-        {city.fortifications.length >= MAX_TOTAL_FORTS ? (
+        {totalSlots >= MAX_TOTAL_FORTS ? (
           <div className="city-picker-empty">Fort limit reached ({MAX_TOTAL_FORTS}/{MAX_TOTAL_FORTS}). Remove one to add another.</div>
+        ) : !canQueueFortification(city) ? (
+          <div className="city-picker-empty">All builders are busy. Wait for a fort to finish, or hire another builder.</div>
         ) : availableDefenceCards.length === 0 ? (
           <div className="city-picker-empty">
             {ownedStructures.some(c => isDefenceCard(c.name, c.unit?.structureEffect?.type === 'spawn'))
@@ -908,7 +984,8 @@ export function CityBuilder({ onBack }: Props) {
           <div className="city-picker-grid">
             {availableDefenceCards.map(card => {
               const cost = FORT_PLACE_COST[card.rarity]
-              const affordable = canAffordFortification(city, card.rarity)
+              const affordable = canAffordFortification(city, card.rarity) && canQueueFortification(city)
+              const buildMins = FORT_MAX_HP[card.rarity]
               return (
                 <button
                   key={card.name}
@@ -919,7 +996,8 @@ export function CityBuilder({ onBack }: Props) {
                   <SpriteImg name={card.name} className="city-picker-sprite" />
                   <div className="city-picker-name">{card.name}</div>
                   <div className={`city-picker-rarity city-picker-rarity--${card.rarity}`}>{card.rarity}</div>
-                  <div className="city-picker-income">🛡 {FORT_DEFENSE[card.rarity]} · {FORT_MAX_HP[card.rarity]} HP</div>
+                  <div className="city-picker-income">🛡 {FORT_DEFENSE[card.rarity]} · {FORT_MAX_HP[card.rarity]} HP · {FORT_MAX_ATTACKS[card.rarity]} raids</div>
+                  <div className="city-picker-income" style={{ color: '#888' }}>🔨 {buildMins} min build</div>
                   <div className="city-picker-cost">
                     ⚙{cost.gold.toLocaleString()}
                     {(Object.keys(cost) as (keyof typeof cost)[])

--- a/web/src/game/cityBuilder.ts
+++ b/web/src/game/cityBuilder.ts
@@ -84,10 +84,22 @@ export const FORT_PLACE_COST: Record<CardRarity, { gold: number } & Partial<Reso
   legendary: { gold: 15000, wood: 300, ore: 150, planks: 60 },
 }
 
-/** HP repaired per minute per fortification per population point (capped). */
-const FORT_REPAIR_RATE = 3
+/** HP repaired per minute per fortification (1 HP every 5 minutes). */
+const FORT_REPAIR_RATE = 0.2
 /** Wood cost per 20 HP repaired. */
 const FORT_REPAIR_WOOD_PER_HP = 1 / 20
+
+/** Number of attacks a fortification can survive before permanent destruction. */
+export const FORT_MAX_ATTACKS: Record<CardRarity, number> = {
+  common: 5, uncommon: 8, rare: 12, epic: 18, legendary: 25,
+}
+
+/** Gold cost to hire additional builders (index = number of extras already hired). */
+export const BUILDER_HIRE_COSTS = [1_000_000, 5_000_000, 10_000_000, 20_000_000, 40_000_000, 80_000_000, 160_000_000, 320_000_000]
+
+/** Default and max number of builders. */
+export const DEFAULT_BUILDER_COUNT = 2
+export const MAX_BUILDER_COUNT = 10
 
 // ── Attack constants ──────────────────────────────────────────────────────────
 
@@ -171,10 +183,17 @@ export interface CityCell {
 }
 
 export interface Fortification {
-  cardName: string
-  rarity:   CardRarity
-  hp:       number
-  maxHp:    number
+  cardName:     string
+  rarity:       CardRarity
+  hp:           number
+  maxHp:        number
+  attacksTaken: number
+}
+
+export interface BuildQueueEntry {
+  cardName:     string
+  rarity:       CardRarity
+  completesAt:  number
 }
 
 export interface AttackEvent {
@@ -200,6 +219,10 @@ export interface CityState {
   nextAttackAt:   number
   /** Wall/moat fortifications outside the building grid. */
   fortifications: Fortification[]
+  /** Fortifications currently under construction. */
+  builderQueue:   BuildQueueEntry[]
+  /** Number of available builders (default 2). */
+  builderCount:   number
   /** Most recent attack result (shown as notification). */
   lastAttack:     AttackEvent | null
   /** Temporary defense bonus from actively patrolling residents. */
@@ -225,6 +248,8 @@ function defaultState(): CityState {
     rows:           CITY_ROWS,
     nextAttackAt:   Date.now() + BASE_ATTACK_INTERVAL_MS + Math.random() * ATTACK_INTERVAL_JITTER_MS,
     fortifications: [],
+    builderQueue:   [],
+    builderCount:   DEFAULT_BUILDER_COUNT,
     lastAttack:     null,
   }
 }
@@ -257,7 +282,12 @@ export function loadCityState(): CityState {
       happiness:      parsed.happiness  ?? {},
       rows,
       nextAttackAt:   parsed.nextAttackAt ?? Date.now() + BASE_ATTACK_INTERVAL_MS,
-      fortifications: parsed.fortifications ?? [],
+      fortifications: (parsed.fortifications ?? []).map(f => ({
+        ...f,
+        attacksTaken: (f as Fortification).attacksTaken ?? 0,
+      })),
+      builderQueue:   parsed.builderQueue ?? [],
+      builderCount:   parsed.builderCount ?? DEFAULT_BUILDER_COUNT,
       lastAttack:     parsed.lastAttack ?? null,
     }
   } catch (err) {
@@ -413,10 +443,14 @@ function processAttack(state: CityState): CityState {
     }
   }
 
-  // Apply damage to fortifications
+  // Apply damage to fortifications and track attack count
   for (const fort of newForts) {
     fort.hp = Math.max(0, fort.hp - fortDmg)
+    fort.attacksTaken = (fort.attacksTaken ?? 0) + 1
   }
+
+  // Remove permanently destroyed forts (exceeded max attacks)
+  const survivingForts = newForts.filter(f => f.attacksTaken < FORT_MAX_ATTACKS[f.rarity])
 
   const nextInterval = BASE_ATTACK_INTERVAL_MS + Math.random() * ATTACK_INTERVAL_JITTER_MS
 
@@ -434,7 +468,7 @@ function processAttack(state: CityState): CityState {
     gold:           Math.max(0, newGold),
     resources:      newResources,
     grid:           newGrid,
-    fortifications: newForts,
+    fortifications: survivingForts,
     nextAttackAt:   state.nextAttackAt + nextInterval,
     lastAttack:     event,
   }
@@ -506,20 +540,32 @@ export function tickCity(state: CityState): CityState {
     }
   }
 
-  // Repair fortifications using wood
-  const pop = cityPopulation(state)
+  // Repair fortifications using wood (1 HP every 5 minutes = 0.2 HP/min)
   const newForts = state.fortifications.map(f => ({ ...f }))
-  if (pop > 0) {
-    for (const fort of newForts) {
-      if (fort.hp < fort.maxHp && newResources.wood > 0) {
-        const repairRate = Math.min(pop * FORT_REPAIR_RATE, 10)
-        const toRepair = Math.min(fort.maxHp - fort.hp, repairRate * minutes)
-        const woodCost = toRepair * FORT_REPAIR_WOOD_PER_HP
-        if (newResources.wood >= woodCost) {
-          fort.hp = Math.min(fort.maxHp, fort.hp + toRepair)
-          newResources.wood = Math.max(0, newResources.wood - woodCost)
-        }
+  for (const fort of newForts) {
+    if (fort.hp < fort.maxHp && newResources.wood > 0) {
+      const toRepair = Math.min(fort.maxHp - fort.hp, FORT_REPAIR_RATE * minutes)
+      const woodCost = toRepair * FORT_REPAIR_WOOD_PER_HP
+      if (newResources.wood >= woodCost) {
+        fort.hp = Math.min(fort.maxHp, fort.hp + toRepair)
+        newResources.wood = Math.max(0, newResources.wood - woodCost)
       }
+    }
+  }
+
+  // Process builder queue: move completed forts into fortifications
+  const now2 = now
+  const remainingQueue = state.builderQueue.filter(e => e.completesAt > now2)
+  const completedBuilds = state.builderQueue.filter(e => e.completesAt <= now2)
+  for (const entry of completedBuilds) {
+    if (newForts.length < MAX_TOTAL_FORTS) {
+      newForts.push({
+        cardName:     entry.cardName,
+        rarity:       entry.rarity,
+        hp:           FORT_MAX_HP[entry.rarity],
+        maxHp:        FORT_MAX_HP[entry.rarity],
+        attacksTaken: 0,
+      })
     }
   }
 
@@ -535,6 +581,7 @@ export function tickCity(state: CityState): CityState {
     lastTick:       now,
     happiness:      newHappy,
     fortifications: newForts,
+    builderQueue:   remainingQueue,
   }
 
   // Process attack if due (only one per tick to avoid runaway offline destruction)
@@ -584,21 +631,46 @@ export function canAffordFortification(state: CityState, rarity: CardRarity): bo
   return true
 }
 
+/** Returns true if a builder slot is free (queue not full). */
+export function canQueueFortification(state: CityState): boolean {
+  return state.builderQueue.length < (state.builderCount ?? DEFAULT_BUILDER_COUNT) &&
+    (state.fortifications.length + state.builderQueue.length) < MAX_TOTAL_FORTS
+}
+
 export function addFortification(state: CityState, cardName: string, rarity: CardRarity): CityState | null {
-  if (state.fortifications.length >= MAX_TOTAL_FORTS) return null
+  if (!canQueueFortification(state)) return null
   if (!canAffordFortification(state, rarity)) return null
   const cost = FORT_PLACE_COST[rarity]
   const newResources = { ...state.resources }
   for (const res of Object.keys(newResources) as ResourceType[]) {
     newResources[res] = Math.max(0, newResources[res] - ((cost[res] as number) ?? 0))
   }
-  const maxHp = FORT_MAX_HP[rarity]
-  const fort: Fortification = { cardName, rarity, hp: maxHp, maxHp }
+  const buildMinutes = FORT_MAX_HP[rarity]
+  const completesAt = Date.now() + buildMinutes * 60_000
+  const entry: BuildQueueEntry = { cardName, rarity, completesAt }
   return {
     ...state,
-    gold:           state.gold - cost.gold,
-    resources:      newResources,
-    fortifications: [...state.fortifications, fort],
+    gold:         state.gold - cost.gold,
+    resources:    newResources,
+    builderQueue: [...state.builderQueue, entry],
+  }
+}
+
+/** Cost to hire the next extra builder (beyond DEFAULT_BUILDER_COUNT). */
+export function nextBuilderCost(state: CityState): number | null {
+  const extras = (state.builderCount ?? DEFAULT_BUILDER_COUNT) - DEFAULT_BUILDER_COUNT
+  if (extras >= BUILDER_HIRE_COSTS.length) return null
+  if ((state.builderCount ?? DEFAULT_BUILDER_COUNT) >= MAX_BUILDER_COUNT) return null
+  return BUILDER_HIRE_COSTS[extras]
+}
+
+export function buyBuilder(state: CityState): CityState | null {
+  const cost = nextBuilderCost(state)
+  if (cost === null || state.gold < cost) return null
+  return {
+    ...state,
+    gold:         state.gold - cost,
+    builderCount: (state.builderCount ?? DEFAULT_BUILDER_COUNT) + 1,
   }
 }
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -9750,6 +9750,52 @@ html.light-mode .action-btn {
 .city-fort-defense-val { font-size: 9px; color: #40a060; }
 .city-fort-remove { font-size: 14px !important; padding: 2px 6px !important; line-height: 1; }
 
+/* ── City Builder — builder slots ────────────────────────────────────────── */
+.city-fort-builders-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 4px 0;
+  width: 100%;
+}
+.city-fort-builder {
+  flex: 1;
+  min-width: 90px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3px;
+  padding: 6px 8px;
+  border-radius: 3px;
+  font-size: 10px;
+  text-align: center;
+  border: 1px solid #1a2a1a;
+}
+.city-fort-builder--free {
+  background: #060e06;
+  color: #408040;
+  border-color: #204020;
+}
+.city-fort-builder--busy {
+  background: #0a0f06;
+  color: #90c080;
+  border-color: #30501a;
+}
+.city-fort-builder-sprite { width: 24px; height: 24px; image-rendering: pixelated; }
+.city-fort-builder-label { font-size: 10px; color: #80c060; }
+.city-fort-builder-eta { font-size: 9px; color: #c09040; font-weight: bold; }
+.city-fort-builder--hire {
+  background: #06080a;
+  color: #6080a0;
+  border-color: #203040;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+.city-fort-builder--hire:hover:not(:disabled) { background: #0a1018; }
+.city-fort-builder--hire-ready { color: #c0d040; border-color: #506020; }
+.city-fort-builder--hire-ready:hover:not(:disabled) { background: #0c1004; }
+.city-fort-builder-cost { font-size: 9px; color: #809040; }
+
 /* ── City Builder — city perimeter (wall/moat visual strip) ─────────────── */
 .city-perimeter {
   border-top: 2px solid #204a20;


### PR DESCRIPTION
Closes #1037

## Summary

- **Finite lifespan**: Each fortification now tracks `attacksTaken`. After `FORT_MAX_ATTACKS` raids (5 common → 25 legendary) it is permanently destroyed and removed from the city
- **Slower repairs**: Repair rate changed to 1 HP / 5 minutes (0.2 HP/min) using wood, down from the previous population-scaled 3 HP/min — repairs now feel impactful
- **Build time**: Forts now take 1 minute per HP to construct (50–500 min). They enter a **builder queue** instead of appearing instantly
- **Builder system**: City starts with 2 builders. Only one fort can be built per builder at a time, preventing instant-stacking. Extra builders can be hired for escalating gold costs: 1M → 5M → 10M → 20M → … up to 10 total builders
- **UI updates (Fortify screen)**:
  - Builder slot panel showing free/busy status with countdown timers
  - "Hire Builder" button with cost, disabled if unaffordable
  - Each active fort shows a second bar for **raids remaining** (e.g. `3/12 raids`)
  - Fort cards in the picker show build time and raid lifespan

## Test plan

- [ ] Place a defence card and confirm it enters the builder queue (not fortifications immediately)
- [ ] Confirm the builder slot shows busy with a countdown
- [ ] Confirm a second fort can be queued simultaneously (2 free builders), third is blocked
- [ ] Trigger an attack (via dev menu / time skip) and confirm `attacksTaken` increments + fort HP drops
- [ ] Confirm forts are permanently removed after the raid limit is reached
- [ ] Confirm forts auto-repair slowly over time when wood is available
- [ ] Hire an extra builder and confirm the queue capacity increases

https://claude.ai/code/session_019X8ZQvnTrdLNuwinDZa1yG

---
_Generated by [Claude Code](https://claude.ai/code/session_019X8ZQvnTrdLNuwinDZa1yG)_