### PR TITLE
feat(city-builder): correct builder walker positions per-view + grass background

### DIFF
--- a/web/src/components/minigames/CityBuilder.tsx
+++ b/web/src/components/minigames/CityBuilder.tsx
@@ -204,33 +204,89 @@ function buildResidentThoughts(
 
 // ── Builder walker (construction) ─────────────────────────────────────────────
 
-const BUILDER_SPEED = 1.1  // slightly faster than residents
+const BUILDER_SPEED    = 1.1  // slightly faster than residents
+const RING_UNIT_SIZE   = 14   // smaller sprite on the ring view
+const RING_ARRIVE_DIST = 12
+
+// Slot → [row, col] in the 4-column ring grid:
+//   row 0: cols 0-3  (slots 0-3, top)
+//   row 1: col 0 (slot 4) and col 3 (slot 5)
+//   row 2: col 0 (slot 6) and col 3 (slot 7)
+//   row 3: cols 0-3  (slots 8-11, bottom)
+const SLOT_GRID_POS: [number, number][] = [
+  [0,0],[0,1],[0,2],[0,3],
+  [1,0],[1,3],
+  [2,0],[2,3],
+  [3,0],[3,1],[3,2],[3,3],
+]
 
 interface BuilderWalker {
-  queueIndex: number
-  cardName:   string
-  x:          number
-  y:          number
-  vx:         number
-  vy:         number
-  phase:      'fetching' | 'delivering'
-  targetX:    number
-  targetY:    number
-  label:      string
+  queueIndex:  number
+  cardName:    string
+  // City-world position
+  x: number; y: number; vx: number; vy: number
+  phase:       'fetching' | 'delivering'
+  targetX:     number;  targetY:     number
+  label:       string
+  // Ring-view position (independent animation, own phase)
+  ringX:       number;  ringY:       number
+  ringVx:      number;  ringVy:      number
+  ringPhase:   'fetching' | 'delivering'
+  ringTargetX: number;  ringTargetY: number
+}
+
+function pickRingTarget(
+  phase: 'fetching' | 'delivering',
+  queueIndex: number,
+  city: CityState,
+  ringW: number,
+  ringH: number,
+): { targetX: number; targetY: number } {
+  if (phase === 'delivering') {
+    const slotIndex = Math.min(city.fortifications.length + queueIndex, 11)
+    const [row, col] = SLOT_GRID_POS[slotIndex]
+    return {
+      targetX: (col + 0.3 + Math.random() * 0.4) / 4 * ringW,
+      targetY: (row + 0.3 + Math.random() * 0.4) / 4 * ringH,
+    }
+  } else {
+    // Fetch from inside the city thumbnail (cols 1-2, rows 1-2 of the 4x4 ring)
+    const cityRows = city.rows ?? CITY_ROWS
+    const resourceCells = city.grid
+      .map((cell, i) => ({ cell, i }))
+      .filter(({ cell }) => cell && !cell.spawnedUnitName && Object.values(getBuildingProduces(cell.cardName)).some(v => (v ?? 0) > 0))
+    if (resourceCells.length > 0) {
+      const { i } = resourceCells[Math.floor(Math.random() * resourceCells.length)]
+      const gCol = i % CITY_COLS
+      const gRow = Math.floor(i / CITY_COLS)
+      return {
+        targetX: ringW * (0.25 + (gCol + 0.3 + Math.random() * 0.4) / CITY_COLS * 0.5),
+        targetY: ringH * (0.25 + (gRow + 0.3 + Math.random() * 0.4) / cityRows * 0.5),
+      }
+    }
+    return { targetX: ringW * (0.3 + Math.random() * 0.4), targetY: ringH * (0.3 + Math.random() * 0.4) }
+  }
 }
 
 function makeBuilderWalker(queueIndex: number, cardName: string, overlayW: number, overlayH: number): BuilderWalker {
+  const ringW = CITY_COLS * CELL_PX
+  const ringH = CITY_ROWS * CELL_PX
   return {
     queueIndex,
     cardName,
     x: Math.random() * Math.max(1, overlayW - UNIT_SIZE),
     y: Math.random() * Math.max(1, overlayH * 0.5),
-    vx: 0,
-    vy: 0,
+    vx: 0, vy: 0,
     phase: 'fetching',
     targetX: Math.random() * overlayW,
     targetY: Math.random() * overlayH * 0.7,
     label: '🪵 Fetching materials',
+    ringX:     ringW * (0.3 + Math.random() * 0.4),
+    ringY:     ringH * (0.3 + Math.random() * 0.4),
+    ringVx: 0, ringVy: 0,
+    ringPhase: 'fetching',
+    ringTargetX: ringW * 0.5,
+    ringTargetY: ringH * 0.5,
   }
 }
 
@@ -719,32 +775,37 @@ export function CityBuilder({ onBack }: Props) {
 
       // Animate builder walkers
       setBuilderWalkers(prev => prev.map(b => {
-        let { x, y, vx, vy, phase, targetX, targetY, label } = b
-        const dx = targetX - x
-        const dy = targetY - y
+        let { x, y, vx, vy, phase, targetX, targetY, label,
+              ringX, ringY, ringVx, ringVy, ringPhase, ringTargetX, ringTargetY } = b
+        const { w: rw, h: rh } = fortRingDimsRef.current
+
+        // ── City-world movement ─────────────────────────────────────────────
+        const dx = targetX - x, dy = targetY - y
         const dist = Math.sqrt(dx * dx + dy * dy)
-
         if (dist < 18) {
-          // Arrived — flip phase and pick next target
           const next = pickBuilderTarget(phase, cityRef.current, overlayW, overlayH)
-          phase   = next.nextPhase
-          targetX = next.targetX
-          targetY = next.targetY
-          label   = next.label
+          phase = next.nextPhase; targetX = next.targetX; targetY = next.targetY; label = next.label
         }
-
-        // Steer toward target
-        if (dist > 1) {
-          vx = (dx / dist) * BUILDER_SPEED
-          vy = (dy / dist) * BUILDER_SPEED
-        }
-
-        x += vx
-        y += vy
+        if (dist > 1) { vx = (dx / dist) * BUILDER_SPEED; vy = (dy / dist) * BUILDER_SPEED }
+        x += vx; y += vy
         x = Math.max(0, Math.min(overlayW - UNIT_SIZE, x))
         y = Math.max(0, Math.min(overlayH - UNIT_SIZE, y))
 
-        return { ...b, x, y, vx, vy, phase, targetX, targetY, label }
+        // ── Ring-view movement (independent phase, correct slot targets) ────
+        const rdx = ringTargetX - ringX, rdy = ringTargetY - ringY
+        const rdist = Math.sqrt(rdx * rdx + rdy * rdy)
+        if (rdist < RING_ARRIVE_DIST) {
+          ringPhase = ringPhase === 'fetching' ? 'delivering' : 'fetching'
+          const rt = pickRingTarget(ringPhase, b.queueIndex, cityRef.current, rw || CITY_COLS * CELL_PX, rh || CITY_ROWS * CELL_PX)
+          ringTargetX = rt.targetX; ringTargetY = rt.targetY
+        }
+        if (rdist > 1) { ringVx = (rdx / rdist) * BUILDER_SPEED; ringVy = (rdy / rdist) * BUILDER_SPEED }
+        ringX += ringVx; ringY += ringVy
+        ringX = Math.max(0, Math.min((rw || CITY_COLS * CELL_PX) - RING_UNIT_SIZE, ringX))
+        ringY = Math.max(0, Math.min((rh || CITY_ROWS * CELL_PX) - RING_UNIT_SIZE, ringY))
+
+        return { ...b, x, y, vx, vy, phase, targetX, targetY, label,
+                 ringX, ringY, ringVx, ringVy, ringPhase, ringTargetX, ringTargetY }
       }))
     }, 100)
     return () => clearInterval(id)
@@ -1148,21 +1209,15 @@ export function CityBuilder({ onBack }: Props) {
             </div>
           </div>
 
-          {/* Builder walkers overlay — same sprites, coords mapped to ring dims */}
+          {/* Builder walkers overlay — ring-space coords, scaled-down sprite */}
           <div className="city-unit-overlay" style={{ pointerEvents: 'none' }}>
-            {builderWalkers.map((b, idx) => {
-              const { w: rw, h: rh } = fortRingDimsRef.current
-              const { w: ww, h: wh } = worldDimsRef.current
-              const rx = ww > 0 ? b.x * (rw / ww) : b.x
-              const ry = wh > 0 ? b.y * (rh / wh) : b.y
-              return (
-                <div key={idx} className="city-walker city-builder-walker"
-                  style={{ left: Math.round(rx), top: Math.round(ry) }}>
-                  <div className="city-builder-bubble">{b.label}</div>
-                  <AnimatedSpriteImg name="Builder" frameCount={3} fps={8} className="city-walker-sprite" />
-                </div>
-              )
-            })}
+            {builderWalkers.map((b, idx) => (
+              <div key={idx} className="city-walker city-builder-walker city-builder-walker--ring"
+                style={{ left: Math.round(b.ringX), top: Math.round(b.ringY) }}>
+                <div className="city-builder-bubble">{b.ringPhase === 'delivering' ? '🏗 Building the wall' : '🪵 Fetching materials'}</div>
+                <AnimatedSpriteImg name="Builder" frameCount={3} fps={8} className="city-builder-walker-sprite--ring" />
+              </div>
+            ))}
           </div>
         </div>
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -9832,6 +9832,7 @@ html.light-mode .action-btn {
   position: relative;
   flex-shrink: 0;
   padding: 4px 6px;
+  background: #6b4c2a; /* dirt/path — same as city world, shows through gaps */
 }
 .fort-ring-grid {
   display: grid;
@@ -9844,7 +9845,7 @@ html.light-mode .action-btn {
     "f8  f9  f10 f11";
   gap: 4px;
 }
-/* Fort cells */
+/* Fort cells — grass background matching the city */
 .fort-ring-cell {
   position: relative;
   display: flex;
@@ -9852,32 +9853,29 @@ html.light-mode .action-btn {
   align-items: center;
   justify-content: center;
   aspect-ratio: 1;
-  background: #050d05;
-  border: 1px dashed #1a3a1a;
-  border-radius: 3px;
+  background: #2d5a27;
+  border: none;
+  border-radius: 2px;
   cursor: pointer;
   padding: 2px;
   gap: 1px;
   overflow: hidden;
-  transition: border-color 0.15s;
+  transition: background 0.15s;
 }
-.fort-ring-cell:hover { border-color: #308030; }
+.fort-ring-cell:hover { background: #3a6e33; }
 .fort-ring-cell .city-cell-forsale-sign {
   font-size: 7px;
   line-height: 1.2;
+  color: #c8a060;
 }
 .fort-ring-cell .city-cell-forsale-post {
   height: 6px;
 }
 .fort-ring-cell--building {
-  border-style: solid;
-  border-color: #304820;
-  background: #08100a;
+  background: #304828;
 }
 .fort-ring-cell--active {
-  border-style: solid;
-  border-color: #204a20;
-  background: #060e06;
+  background: #233a1e;
 }
 .fort-ring-sprite {
   width: 28px;
@@ -9924,10 +9922,9 @@ html.light-mode .action-btn {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  background: #040a04;
-  border: 1px solid #1a3a1a;
-  border-radius: 3px;
-  padding: 4px;
+  background: #6b4c2a; /* dirt bg like city world */
+  border-radius: 2px;
+  padding: 2px;
   gap: 2px;
   overflow: hidden;
 }
@@ -9935,10 +9932,10 @@ html.light-mode .action-btn {
   display: grid;
   width: 100%;
   flex: 1;
-  gap: 1px;
+  gap: 2px;
 }
 .fort-ring-city-cell {
-  background: #060e06;
+  background: #2d5a27; /* grass */
   border-radius: 1px;
   display: flex;
   align-items: center;
@@ -9953,9 +9950,20 @@ html.light-mode .action-btn {
 }
 .fort-ring-city-label {
   font-size: 8px;
-  color: #204a20;
+  color: #4a7a30;
   letter-spacing: 2px;
   flex-shrink: 0;
+}
+
+/* Builder walker scaled down for ring view */
+.city-builder-walker--ring {
+  width: 14px;
+  height: 14px;
+}
+.city-builder-walker-sprite--ring {
+  width: 14px;
+  height: 14px;
+  image-rendering: pixelated;
 }
 
 /* ── City Builder — city perimeter (wall/moat visual strip) ─────────────── */


### PR DESCRIPTION
Follow-up to the fortification ring view.

## Summary

- Each `BuilderWalker` now carries **separate ring-space coordinates** (`ringX/Y`, `ringVx/Y`, `ringPhase`, `ringTargetX/Y`) animated independently of the city-world coordinates
- **City view**: builders walk between resource buildings and the bottom edge (fort perimeter strip) — unchanged
- **Ring view**: builders walk between resource cells *inside* the city thumbnail and the **exact fort slot cell** being built, using `SLOT_GRID_POS[fortifications.length + queueIndex]` to compute pixel targets
- Builder sprite scaled down to **14 px** on the ring view (was 20 px city-world size)
- Fort ring wrap and city thumbnail now use the same **grass (`#2d5a27`) + dirt gap (`#6b4c2a`)** background as the city world, making the two views feel consistent

## Test plan

- [ ] Open the city view with a fort in the builder queue — confirm builder walks to the perimeter strip at the bottom
- [ ] Open the fortify ring view — confirm builder walks to the correct fort slot cell and back to a resource cell in the city thumbnail
- [ ] Queue a second fort — confirm the second builder targets the second slot
- [ ] Confirm the ring view has the same grass/dirt background as the city

https://claude.ai/code/session_019X8ZQvnTrdLNuwinDZa1yG

---
_Generated by [Claude Code](https://claude.ai/code/session_019X8ZQvnTrdLNuwinDZa1yG)_