### PR TITLE
feat: Tower Defence minigame

### DIFF
--- a/web/src/components/MiniGamesMenu.tsx
+++ b/web/src/components/MiniGamesMenu.tsx
@@ -11,7 +11,7 @@ import {
   loadLocalHighScore, saveLocalHighScore,
   publishMiniGameScore, fetchMiniGameLeaderboard, MiniGameLeaderboardEntry,
 } from '../game/miniGames'
-import { loadCrystals, saveCrystals, addCardsToCollection } from '../game/collection'
+import { loadCrystals, saveCrystals, addCardsToCollection, loadCollection, getOwnedCount } from '../game/collection'
 import { getCardCatalog } from '../game/cards'
 import { incrementAchievementProgress, setAchievementProgress } from '../game/achievements'
 import { MarbleRun }      from './minigames/MarbleRun'
@@ -24,6 +24,7 @@ import { FruitMachine }   from './minigames/FruitMachine'
 import { VideoPoker }     from './minigames/VideoPoker'
 import { CityBuilder }    from './minigames/CityBuilder'
 import { Fishing }        from './minigames/Fishing'
+import { TowerDefence, TowerPool } from './minigames/TowerDefence'
 
 interface Props {
   crystals:          number
@@ -33,7 +34,16 @@ interface Props {
   onBack:            () => void
 }
 
-type SubScreen = 'menu' | MiniGameId | 'prizes' | 'leaderboard' | 'citybuilder' | 'fishing'
+type SubScreen = 'menu' | MiniGameId | 'prizes' | 'leaderboard' | 'citybuilder' | 'fishing' | 'towerDefence'
+
+// Build tower pool from owned unit cards in the player's collection
+function buildCollectionTowerPool(): TowerPool[] {
+  const catalog    = getCardCatalog()
+  const collection = loadCollection()
+  return catalog
+    .filter(c => c.cardType === 'unit' && c.unit && !c.unit.isWall && getOwnedCount(collection, c.name) > 0)
+    .map(c => ({ template: c.unit!, total: getOwnedCount(collection, c.name) }))
+}
 
 // Pick N random cards from catalog, optionally filtered by rarity
 function pickRandomCards(count: number, rarity?: 'uncommon' | 'rare' | 'legendary'): string[] {
@@ -119,6 +129,8 @@ export function MiniGamesMenu({ crystals, onCrystalsChange, user, characterName,
     } else if (gameId === 'fishing') {
       setAchievementProgress('miniGame:fishing:bestScore', newBest)
       if (opts?.score) setAchievementProgress('miniGame:fishing:bestWeightG', opts.score)
+    } else if (gameId === 'towerDefence') {
+      setAchievementProgress('miniGame:towerDefence:bestScore', newBest)
     }
 
     // Publish to leaderboard if signed in
@@ -230,6 +242,16 @@ export function MiniGamesMenu({ crystals, onCrystalsChange, user, characterName,
       />
     )
   }
+  if (subScreen === 'towerDefence') {
+    const pool = buildCollectionTowerPool()
+    return (
+      <TowerDefence
+        pool={pool}
+        mode="collection"
+        onDone={(tickets) => handleGameDone('towerDefence', tickets)}
+      />
+    )
+  }
   if (subScreen === 'citybuilder') {
     return <CityBuilder onBack={() => setSubScreen('menu')} />
   }
@@ -264,7 +286,7 @@ export function MiniGamesMenu({ crystals, onCrystalsChange, user, characterName,
 
           {/* Game grid */}
           <div className="minigame-grid">
-            {(['marble', 'tileflip', 'crystalcatch', 'spinner', 'marblerace', 'higherOrLower', 'fruitMachine', 'videoPoker', 'fishing'] as MiniGameId[]).map(id => {
+            {(['marble', 'tileflip', 'crystalcatch', 'spinner', 'marblerace', 'higherOrLower', 'fruitMachine', 'videoPoker', 'fishing', 'towerDefence'] as MiniGameId[]).map(id => {
               const cost    = MINI_GAME_COSTS[id]
               const locked  = currentCrystals < cost
               const best    = loadLocalHighScore(id)
@@ -349,7 +371,7 @@ export function MiniGamesMenu({ crystals, onCrystalsChange, user, characterName,
 
           <div className="lb-controls">
             <div className="lb-game-tabs">
-              {(['marble', 'tileflip', 'crystalcatch', 'spinner', 'marblerace', 'higherOrLower', 'fruitMachine', 'videoPoker', 'fishing'] as MiniGameId[]).map(id => (
+              {(['marble', 'tileflip', 'crystalcatch', 'spinner', 'marblerace', 'higherOrLower', 'fruitMachine', 'videoPoker', 'fishing', 'towerDefence'] as MiniGameId[]).map(id => (
                 <button
                   key={id}
                   className={`filter-btn${lbGame === id ? ' filter-btn--active' : ''}`}

--- a/web/src/components/minigames/CityBuilder.tsx
+++ b/web/src/components/minigames/CityBuilder.tsx
@@ -33,7 +33,9 @@ import {
 } from '../../game/cityBuilder'
 import { MasteryBar } from '../MasteryBar'
 import { SpriteImg, AnimatedSpriteImg } from '../SpriteImg'
-import { Card } from '../../game/types'
+import { Card, UnitTemplate } from '../../game/types'
+import { TowerDefence, TowerPool } from './TowerDefence'
+import { calcGoldReward } from '../../game/towerDefence'
 
 // ── Unit requirement helpers ──────────────────────────────────────────────────
 
@@ -533,13 +535,43 @@ function formatCountdown(ms: number): string {
   return `${mins}m`
 }
 
+// ── City tower pool ───────────────────────────────────────────────────────────
+
+function buildCityTowerPool(city: CityState): TowerPool[] {
+  const catalog = getCardCatalog()
+  const counts: Record<string, number> = {}
+
+  for (let i = 0; i < city.grid.length; i++) {
+    const cell = city.grid[i]
+    if (!cell?.spawnedUnitName) continue
+    if ((city.happiness[i] ?? 100) <= 0) continue
+    const unitCount = spawnerUnitCount(city, cell.cardName)
+    counts[cell.spawnedUnitName] = (counts[cell.spawnedUnitName] ?? 0) + unitCount
+  }
+
+  const pool: TowerPool[] = []
+  for (const [unitName, total] of Object.entries(counts)) {
+    // Find the UnitTemplate by matching the name of the spawned unit
+    let template: UnitTemplate | undefined
+    for (const card of catalog) {
+      if (card.unit?.structureEffect?.type === 'spawn') {
+        const se = card.unit.structureEffect as { type: 'spawn'; unitTemplate: UnitTemplate }
+        if (se.unitTemplate.name === unitName) { template = se.unitTemplate; break }
+      }
+      if (card.unit?.name === unitName) { template = card.unit; break }
+    }
+    if (template) pool.push({ template, total })
+  }
+  return pool
+}
+
 // ── Component ─────────────────────────────────────────────────────────────────
 
 interface Props {
   onBack: () => void
 }
 
-type SubScreen = 'city' | 'picker' | 'upgrade' | 'levelup' | 'fortify'
+type SubScreen = 'city' | 'picker' | 'upgrade' | 'levelup' | 'fortify' | 'towerdefence'
 
 export function CityBuilder({ onBack }: Props) {
   const [city, setCity]       = useState<CityState>(() => tickCity(loadCityState()))
@@ -1341,6 +1373,44 @@ export function CityBuilder({ onBack }: Props) {
     )
   }
 
+  // ── Tower Defence sub-screen ──────────────────────────────────────────────────
+
+  if (screen === 'towerdefence') {
+    const pool = buildCityTowerPool(city)
+    function handleTDDone(score: number) {
+      const gold = calcGoldReward(score)
+      if (gold > 0) {
+        setCity(prev => ({ ...prev, gold: prev.gold + gold }))
+        saveCityState({ ...city, gold: city.gold + gold })
+        setToast(`Your defenders earned ${gold.toLocaleString()} 🪙 gold!`)
+        setTimeout(() => setToast(null), 4000)
+      }
+      setScreen('city')
+    }
+    if (pool.length === 0) {
+      return (
+        <div className="city-screen">
+          <div className="city-header">
+            <button className="action-btn" onClick={() => setScreen('city')}>← BACK</button>
+            <div className="city-title">⚔ DEFEND</div>
+          </div>
+          <div style={{ padding: 24, color: '#888', textAlign: 'center' }}>
+            <p>No residents available to defend the city.</p>
+            <p>Place some spawn buildings with happy residents first!</p>
+            <button className="action-btn" onClick={() => setScreen('city')}>BACK TO CITY</button>
+          </div>
+        </div>
+      )
+    }
+    return (
+      <TowerDefence
+        pool={pool}
+        mode="city"
+        onDone={handleTDDone}
+      />
+    )
+  }
+
   // ── Card picker sub-screen ────────────────────────────────────────────────────
 
   if (screen === 'picker') {
@@ -1785,10 +1855,10 @@ export function CityBuilder({ onBack }: Props) {
           
           </div>
         <div className="city-header-right">
-
-                    <div className="city-gold-display">⚙ {city.gold.toLocaleString() } (+{incomeRate}/min)</div>
-
-         
+          <div className="city-gold-display">⚙ {city.gold.toLocaleString()} (+{incomeRate}/min)</div>
+          <button className="action-btn" onClick={() => setScreen('towerdefence')} title="Defend the city using your residents as towers">
+            ⚔ DEFEND
+          </button>
         </div>
       </div>
 

--- a/web/src/components/minigames/TowerDefence.tsx
+++ b/web/src/components/minigames/TowerDefence.tsx
@@ -1,0 +1,337 @@
+// ─── Tower Defence ─────────────────────────────────────────────────────────────
+// Wave-based tower defence. Towers come from the player's card collection or
+// their city residents. Enemies walk a fixed path; survive all 10 waves to win.
+
+import React, { useState, useEffect, useRef, useCallback } from 'react'
+import { UnitTemplate } from '../../game/types'
+import { SpriteImg } from '../SpriteImg'
+import {
+  TD_COLS, TD_ROWS, TD_PATH, TD_WAVES, TD_TOTAL_WAVES, TD_MAX_LIVES,
+  TDGameState, TDTower, TDEnemy,
+  isPathCell,
+  createTDGame, placeTower, removeTower, startWave, tickTD,
+  calcTicketReward, calcGoldReward,
+} from '../../game/towerDefence'
+
+// ── Props ─────────────────────────────────────────────────────────────────────
+
+export interface TowerPool {
+  template: UnitTemplate
+  total: number   // max times this unit can be placed
+}
+
+interface Props {
+  pool: TowerPool[]
+  mode: 'collection' | 'city'
+  onDone: (score: number) => void
+}
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+const CELL_PX = 64
+const TICK_MS = 50   // ~20 fps simulation (RAF handles rendering)
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function hpBarColor(frac: number): string {
+  if (frac > 0.6) return '#4caf50'
+  if (frac > 0.3) return '#ff9800'
+  return '#f44336'
+}
+
+function livesIcons(lives: number, max: number): string {
+  return '❤️'.repeat(lives) + '🖤'.repeat(Math.max(0, max - lives))
+}
+
+// Map path index → waypoint set for quick membership check
+const PATH_CELL_SET = new Set(TD_PATH.map(p => `${p.col},${p.row}`))
+function isBorderPath(col: number, row: number): boolean {
+  return PATH_CELL_SET.has(`${col},${row}`)
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+export function TowerDefence({ pool, mode, onDone }: Props) {
+  // Build initial placements map from pool
+  const initialPlacements: Record<string, number> = {}
+  for (const entry of pool) {
+    initialPlacements[entry.template.name] = entry.total
+  }
+
+  const [game, setGame] = useState<TDGameState>(() =>
+    createTDGame(pool.map(p => p.template), mode, initialPlacements)
+  )
+  const [selected, setSelected] = useState<UnitTemplate | null>(null)
+  const [hoveredCell, setHoveredCell] = useState<{ col: number; row: number } | null>(null)
+  const [hoveredTower, setHoveredTower] = useState<TDTower | null>(null)
+
+  const gameRef = useRef(game)
+  gameRef.current = game
+
+  const rafRef = useRef<number | null>(null)
+  const lastTimeRef = useRef<number | null>(null)
+  const accRef = useRef(0)
+
+  // ── Game loop ───────────────────────────────────────────────────────────────
+
+  const tick = useCallback((timestamp: number) => {
+    if (lastTimeRef.current === null) lastTimeRef.current = timestamp
+    const dt = timestamp - lastTimeRef.current
+    lastTimeRef.current = timestamp
+    accRef.current += dt
+
+    while (accRef.current >= TICK_MS) {
+      accRef.current -= TICK_MS
+      setGame(prev => {
+        if (prev.phase === 'prep' || prev.phase === 'victory' || prev.phase === 'defeat') return prev
+        return tickTD(prev, TICK_MS)
+      })
+    }
+
+    rafRef.current = requestAnimationFrame(tick)
+  }, [])
+
+  useEffect(() => {
+    rafRef.current = requestAnimationFrame(tick)
+    return () => {
+      if (rafRef.current !== null) cancelAnimationFrame(rafRef.current)
+    }
+  }, [tick])
+
+  // ── Interactions ────────────────────────────────────────────────────────────
+
+  function handleCellClick(col: number, row: number) {
+    const g = gameRef.current
+    if (g.phase !== 'prep' && g.phase !== 'between') return
+
+    // Click on existing tower → remove it
+    const existing = g.towers.find(t => t.col === col && t.row === row)
+    if (existing) {
+      setGame(prev => removeTower(prev, existing.id))
+      setHoveredTower(null)
+      return
+    }
+
+    if (!selected) return
+    if (isPathCell(col, row)) return
+
+    const next = placeTower(g, selected, col, row)
+    if (next) setGame(next)
+  }
+
+  function handleStartWave() {
+    setGame(prev => startWave(prev))
+  }
+
+  function handleSelectUnit(template: UnitTemplate) {
+    setSelected(prev => prev?.name === template.name ? null : template)
+  }
+
+  // ── Derived ─────────────────────────────────────────────────────────────────
+
+  const canPlace = (template: UnitTemplate) => (game.remainingPlacements[template.name] ?? 0) > 0
+  const isPlacingPhase = game.phase === 'prep' || game.phase === 'between'
+  const reward = mode === 'city' ? calcGoldReward(game.wavesCompleted) : calcTicketReward(game.wavesCompleted)
+  const rewardLabel = mode === 'city' ? `${reward.toLocaleString()} 🪙 city gold` : `${reward} 🎫 tickets`
+
+  // ── End screens ─────────────────────────────────────────────────────────────
+
+  if (game.phase === 'victory' || game.phase === 'defeat') {
+    const won = game.phase === 'victory'
+    return (
+      <div className="td-end-screen">
+        <div className={`td-end-title ${won ? 'td-end-title--win' : 'td-end-title--lose'}`}>
+          {won ? '⚔ VICTORY!' : '💀 DEFEATED'}
+        </div>
+        <div className="td-end-stat">Waves cleared: {game.wavesCompleted} / {TD_TOTAL_WAVES}</div>
+        <div className="td-end-stat">Score: {game.score.toLocaleString()}</div>
+        <div className="td-end-reward">Reward: {rewardLabel}</div>
+        <button className="action-btn action-btn--gold" onClick={() => onDone(reward)}>
+          COLLECT &amp; EXIT
+        </button>
+      </div>
+    )
+  }
+
+  // ── Main layout ─────────────────────────────────────────────────────────────
+
+  return (
+    <div className="td-root">
+      {/* ── Header ── */}
+      <div className="td-header">
+        <div className="td-header-left">
+          <span className="td-lives">{livesIcons(game.lives, TD_MAX_LIVES)}</span>
+          <span className="td-wave-label">
+            Wave {game.wavesCompleted + 1} / {TD_TOTAL_WAVES}
+            {game.phase === 'between' && ' — Get ready!'}
+          </span>
+        </div>
+        <div className="td-header-center">
+          {isPlacingPhase && (
+            <button className="action-btn action-btn--gold" onClick={handleStartWave}>
+              ▶ START WAVE
+            </button>
+          )}
+          {game.phase === 'wave' && (
+            <span className="td-wave-active">⚔ Wave in progress…</span>
+          )}
+        </div>
+        <div className="td-header-right">
+          <span className="td-score">Score: {game.score}</span>
+          <button className="action-btn action-btn--danger td-quit-btn" onClick={() => onDone(reward)}>
+            QUIT
+          </button>
+        </div>
+      </div>
+
+      <div className="td-body">
+        {/* ── Grid ── */}
+        <div
+          className="td-grid"
+          style={{ width: TD_COLS * CELL_PX, height: TD_ROWS * CELL_PX }}
+        >
+          {/* Cells */}
+          {Array.from({ length: TD_ROWS }, (_, row) =>
+            Array.from({ length: TD_COLS }, (_, col) => {
+              const key = `${col},${row}`
+              const onPath = isBorderPath(col, row)
+              const isStart = col === TD_PATH[0].col && row === TD_PATH[0].row
+              const isEnd = col === TD_PATH[TD_PATH.length - 1].col && row === TD_PATH[TD_PATH.length - 1].row
+              const tower = game.towers.find(t => t.col === col && t.row === row)
+              const isHovered = hoveredCell?.col === col && hoveredCell?.row === row
+              const canDrop = isHovered && selected && !onPath && !tower && isPlacingPhase && canPlace(selected)
+
+              return (
+                <div
+                  key={key}
+                  className={[
+                    'td-cell',
+                    onPath ? 'td-cell--path' : 'td-cell--grass',
+                    isStart ? 'td-cell--start' : '',
+                    isEnd ? 'td-cell--end' : '',
+                    tower ? 'td-cell--occupied' : '',
+                    canDrop ? 'td-cell--drop-target' : '',
+                  ].filter(Boolean).join(' ')}
+                  style={{ left: col * CELL_PX, top: row * CELL_PX, width: CELL_PX, height: CELL_PX }}
+                  onClick={() => handleCellClick(col, row)}
+                  onMouseEnter={() => { setHoveredCell({ col, row }); if (tower) setHoveredTower(tower) }}
+                  onMouseLeave={() => { setHoveredCell(null); setHoveredTower(null) }}
+                >
+                  {isStart && <span className="td-cell-label">IN</span>}
+                  {isEnd && <span className="td-cell-label">BASE</span>}
+                  {tower && (
+                    <div className="td-tower-sprite">
+                      <div style={{ width: CELL_PX - 8, height: CELL_PX - 8 }}>
+                        <SpriteImg name={tower.template.name} />
+                      </div>
+                      <div className="td-tower-hp-bar">
+                        <div
+                          className="td-tower-hp-fill"
+                          style={{
+                            width: `${(tower.hp / tower.maxHp) * 100}%`,
+                            background: hpBarColor(tower.hp / tower.maxHp),
+                          }}
+                        />
+                      </div>
+                    </div>
+                  )}
+                </div>
+              )
+            })
+          )}
+
+          {/* Enemies (absolutely positioned over grid) */}
+          {game.enemies.map(enemy => (
+            <EnemyToken key={enemy.id} enemy={enemy} />
+          ))}
+        </div>
+
+        {/* ── Sidebar ── */}
+        <div className="td-sidebar">
+          <div className="td-sidebar-title">TOWERS</div>
+          {isPlacingPhase
+            ? <p className="td-sidebar-hint">Click a unit to select, then click a grass cell to place. Click a placed tower to remove it.</p>
+            : <p className="td-sidebar-hint">Wave in progress — placement locked.</p>
+          }
+
+          <div className="td-unit-list">
+            {pool.map(({ template }) => {
+              const remaining = game.remainingPlacements[template.name] ?? 0
+              const isSel = selected?.name === template.name
+              const disabled = !isPlacingPhase || remaining === 0
+              return (
+                <button
+                  key={template.name}
+                  className={[
+                    'td-unit-btn',
+                    isSel ? 'td-unit-btn--selected' : '',
+                    disabled ? 'td-unit-btn--disabled' : '',
+                  ].filter(Boolean).join(' ')}
+                  onClick={() => !disabled && handleSelectUnit(template)}
+                  title={`ATK ${template.attack} · HP ${template.maxHp} · Range ${Math.max(1, Math.round(template.attackRange / 64))} cells`}
+                >
+                  <div style={{ width: 32, height: 32, flexShrink: 0 }}>
+                    <SpriteImg name={template.name} />
+                  </div>
+                  <div className="td-unit-btn-info">
+                    <div className="td-unit-btn-name">{template.name}</div>
+                    <div className="td-unit-btn-stats">
+                      ⚔ {template.attack} · ❤ {template.maxHp}
+                    </div>
+                  </div>
+                  <span className={`td-unit-count ${remaining === 0 ? 'td-unit-count--zero' : ''}`}>
+                    ×{remaining}
+                  </span>
+                </button>
+              )
+            })}
+          </div>
+
+          {/* Tower tooltip */}
+          {hoveredTower && (
+            <div className="td-tower-tooltip">
+              <strong>{hoveredTower.template.name}</strong>
+              <div>HP {hoveredTower.hp} / {hoveredTower.maxHp}</div>
+              <div>ATK {hoveredTower.template.attack}</div>
+              <div>Range {hoveredTower.rangeInCells} cells</div>
+              {isPlacingPhase && <div className="td-tooltip-hint">(click to remove)</div>}
+            </div>
+          )}
+
+          {/* Log */}
+          <div className="td-log">
+            {[...game.log].reverse().slice(0, 5).map((line, i) => (
+              <div key={i} className="td-log-line">{line}</div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ── Enemy token ───────────────────────────────────────────────────────────────
+
+function EnemyToken({ enemy }: { enemy: TDEnemy }) {
+  const size = 36
+  const hpFrac = enemy.hp / enemy.maxHp
+  return (
+    <div
+      className="td-enemy"
+      style={{
+        left: enemy.x - size / 2,
+        top: enemy.y - size / 2,
+        width: size,
+        height: size,
+      }}
+    >
+      <div className="td-enemy-icon">{enemy.template.icon}</div>
+      <div className="td-enemy-hp-bar">
+        <div
+          className="td-enemy-hp-fill"
+          style={{ width: `${hpFrac * 100}%`, background: hpBarColor(hpFrac) }}
+        />
+      </div>
+    </div>
+  )
+}

--- a/web/src/data/economy.json
+++ b/web/src/data/economy.json
@@ -28,7 +28,8 @@
     "higherOrLower":  5,
     "fruitMachine":   50,
     "videoPoker":     0,
-    "fishing":       15
+    "fishing":       15,
+    "towerDefence":  50
   },
 
   "ticketPrizes": [

--- a/web/src/game/miniGames.ts
+++ b/web/src/game/miniGames.ts
@@ -20,7 +20,7 @@ export { getTickets as loadTickets, addTickets, spendTickets }
 
 // ── Game Costs ────────────────────────────────────────────────────────────────
 
-export type MiniGameId = 'marble' | 'tileflip' | 'crystalcatch' | 'spinner' | 'marblerace' | 'higherOrLower' | 'fruitMachine' | 'videoPoker' | 'fishing'
+export type MiniGameId = 'marble' | 'tileflip' | 'crystalcatch' | 'spinner' | 'marblerace' | 'higherOrLower' | 'fruitMachine' | 'videoPoker' | 'fishing' | 'towerDefence'
 
 export const MINI_GAME_COSTS = _MINI_GAME_COSTS as Record<MiniGameId, number>
 
@@ -34,6 +34,7 @@ export const MINI_GAME_LABELS: Record<MiniGameId, string> = {
   fruitMachine:   'Fruit Machine',
   videoPoker:     'Video Poker',
   fishing:        'Fishing',
+  towerDefence:   'Tower Defence',
 }
 
 export const MINI_GAME_DESCRIPTIONS: Record<MiniGameId, string> = {
@@ -46,6 +47,7 @@ export const MINI_GAME_DESCRIPTIONS: Record<MiniGameId, string> = {
   fruitMachine:   'Spin the reels, hold your lucky symbols, and cash out your winnings!',
   videoPoker:     'Jacks or Better. Hold your best cards, draw, and win big!',
   fishing:        'Cast your line and reel in a catch. Rare fish earn big tickets — and sometimes treasure!',
+  towerDefence:   'Place your cards as towers and defend your base from 10 waves of enemies!',
 }
 
 export const MINI_GAME_ICONS: Record<MiniGameId, string> = {
@@ -58,6 +60,7 @@ export const MINI_GAME_ICONS: Record<MiniGameId, string> = {
   fruitMachine:   '🎰',
   videoPoker:     '♠',
   fishing:        '🎣',
+  towerDefence:   '🏰',
 }
 
 // ── Ticket Prizes ─────────────────────────────────────────────────────────────

--- a/web/src/game/towerDefence.ts
+++ b/web/src/game/towerDefence.ts
@@ -1,0 +1,528 @@
+// ─── Tower Defence — pure game logic ──────────────────────────────────────────
+// No React imports. All state is plain objects; tick() returns a new state.
+
+import { UnitTemplate, UnitTag } from './types'
+
+// ── Grid ──────────────────────────────────────────────────────────────────────
+
+export const TD_COLS = 13
+export const TD_ROWS = 7
+
+export type GridPos = { col: number; row: number }
+
+// Path as ordered grid positions (enemies walk this route left → right).
+// Shape: enters top-left, winds down, exits bottom-right.
+export const TD_PATH: GridPos[] = [
+  { col: 0, row: 0 },
+  { col: 1, row: 0 },
+  { col: 2, row: 0 },
+  { col: 3, row: 0 },
+  { col: 3, row: 1 },
+  { col: 3, row: 2 },
+  { col: 2, row: 2 },
+  { col: 1, row: 2 },
+  { col: 0, row: 2 },
+  { col: 0, row: 3 },
+  { col: 0, row: 4 },
+  { col: 1, row: 4 },
+  { col: 2, row: 4 },
+  { col: 3, row: 4 },
+  { col: 4, row: 4 },
+  { col: 5, row: 4 },
+  { col: 5, row: 3 },
+  { col: 5, row: 2 },
+  { col: 6, row: 2 },
+  { col: 7, row: 2 },
+  { col: 8, row: 2 },
+  { col: 8, row: 1 },
+  { col: 8, row: 0 },
+  { col: 9, row: 0 },
+  { col: 10, row: 0 },
+  { col: 10, row: 1 },
+  { col: 10, row: 2 },
+  { col: 10, row: 3 },
+  { col: 10, row: 4 },
+  { col: 10, row: 5 },
+  { col: 10, row: 6 },
+  { col: 11, row: 6 },
+  { col: 12, row: 6 },
+]
+
+// Set of path cells for O(1) lookup
+export const PATH_SET: Set<string> = new Set(TD_PATH.map(p => `${p.col},${p.row}`))
+export function isPathCell(col: number, row: number): boolean {
+  return PATH_SET.has(`${col},${row}`)
+}
+
+// ── Enemy templates ───────────────────────────────────────────────────────────
+
+export interface TDEnemyTemplate {
+  id: string
+  label: string
+  icon: string
+  hp: number
+  speed: number       // path-cells per second
+  attack: number      // damage dealt to base on arrival
+  reward: number      // gold awarded on kill (city mode) or score points
+  tags: UnitTag[]
+  flying?: boolean
+}
+
+const ENEMY_TEMPLATES: Record<string, TDEnemyTemplate> = {
+  footSoldier: {
+    id: 'footSoldier', label: 'Foot Soldier', icon: '🗡️',
+    hp: 80, speed: 1.0, attack: 1, reward: 10,
+    tags: ['melee'],
+  },
+  scout: {
+    id: 'scout', label: 'Scout', icon: '🏹',
+    hp: 40, speed: 2.2, attack: 1, reward: 8,
+    tags: ['fast', 'ranged'],
+  },
+  brute: {
+    id: 'brute', label: 'Brute', icon: '🪨',
+    hp: 280, speed: 0.6, attack: 2, reward: 25,
+    tags: ['slow', 'large', 'armored'],
+  },
+  flyer: {
+    id: 'flyer', label: 'Flyer', icon: '🦅',
+    hp: 60, speed: 1.8, attack: 1, reward: 15,
+    tags: ['flying', 'fast'],
+    flying: true,
+  },
+  necromancer: {
+    id: 'necromancer', label: 'Necromancer', icon: '💀',
+    hp: 120, speed: 0.9, attack: 1, reward: 20,
+    tags: ['magic', 'undead'],
+  },
+  siegeEngine: {
+    id: 'siegeEngine', label: 'Siege Engine', icon: '⚙️',
+    hp: 400, speed: 0.4, attack: 3, reward: 40,
+    tags: ['siege', 'slow', 'large', 'armored'],
+  },
+}
+
+// ── Wave definitions ──────────────────────────────────────────────────────────
+
+export interface WaveSpawn {
+  enemyId: string
+  count: number
+  intervalMs: number  // delay between each spawn in this group
+  hpMult: number      // multiplier on base hp
+}
+
+export interface WaveDefinition {
+  wave: number
+  label: string
+  spawns: WaveSpawn[]
+}
+
+export const TD_WAVES: WaveDefinition[] = [
+  {
+    wave: 1, label: 'Wave 1 — Skirmishers',
+    spawns: [{ enemyId: 'footSoldier', count: 4, intervalMs: 1200, hpMult: 1 }],
+  },
+  {
+    wave: 2, label: 'Wave 2 — Scouts',
+    spawns: [
+      { enemyId: 'footSoldier', count: 3, intervalMs: 1200, hpMult: 1 },
+      { enemyId: 'scout',       count: 3, intervalMs: 800,  hpMult: 1 },
+    ],
+  },
+  {
+    wave: 3, label: 'Wave 3 — The Brute',
+    spawns: [
+      { enemyId: 'footSoldier', count: 5, intervalMs: 1000, hpMult: 1.1 },
+      { enemyId: 'brute',       count: 1, intervalMs: 0,    hpMult: 1   },
+    ],
+  },
+  {
+    wave: 4, label: 'Wave 4 — Air Raid',
+    spawns: [
+      { enemyId: 'flyer',       count: 4, intervalMs: 900,  hpMult: 1.1 },
+      { enemyId: 'footSoldier', count: 4, intervalMs: 1100, hpMult: 1.1 },
+    ],
+  },
+  {
+    wave: 5, label: 'Wave 5 — Dark Magic',
+    spawns: [
+      { enemyId: 'necromancer', count: 3, intervalMs: 1500, hpMult: 1.2 },
+      { enemyId: 'scout',       count: 5, intervalMs: 700,  hpMult: 1.2 },
+    ],
+  },
+  {
+    wave: 6, label: 'Wave 6 — Heavy Push',
+    spawns: [
+      { enemyId: 'brute',       count: 3, intervalMs: 2000, hpMult: 1.3 },
+      { enemyId: 'footSoldier', count: 6, intervalMs: 900,  hpMult: 1.3 },
+    ],
+  },
+  {
+    wave: 7, label: 'Wave 7 — Swarm',
+    spawns: [
+      { enemyId: 'scout',       count: 8, intervalMs: 500,  hpMult: 1.4 },
+      { enemyId: 'flyer',       count: 5, intervalMs: 700,  hpMult: 1.4 },
+    ],
+  },
+  {
+    wave: 8, label: 'Wave 8 — Siege',
+    spawns: [
+      { enemyId: 'siegeEngine', count: 2, intervalMs: 3000, hpMult: 1   },
+      { enemyId: 'footSoldier', count: 6, intervalMs: 800,  hpMult: 1.5 },
+      { enemyId: 'necromancer', count: 3, intervalMs: 1200, hpMult: 1.5 },
+    ],
+  },
+  {
+    wave: 9, label: 'Wave 9 — All Forces',
+    spawns: [
+      { enemyId: 'brute',       count: 4, intervalMs: 1800, hpMult: 1.7 },
+      { enemyId: 'flyer',       count: 6, intervalMs: 600,  hpMult: 1.7 },
+      { enemyId: 'scout',       count: 8, intervalMs: 500,  hpMult: 1.7 },
+    ],
+  },
+  {
+    wave: 10, label: 'Wave 10 — Final Assault',
+    spawns: [
+      { enemyId: 'siegeEngine', count: 3, intervalMs: 2500, hpMult: 2   },
+      { enemyId: 'brute',       count: 4, intervalMs: 1500, hpMult: 2   },
+      { enemyId: 'necromancer', count: 4, intervalMs: 1000, hpMult: 2   },
+      { enemyId: 'flyer',       count: 6, intervalMs: 500,  hpMult: 2   },
+    ],
+  },
+]
+
+// ── Runtime types ─────────────────────────────────────────────────────────────
+
+let _nextId = 1
+function nextId() { return _nextId++ }
+
+export interface TDTower {
+  id: number
+  col: number
+  row: number
+  template: UnitTemplate
+  hp: number
+  maxHp: number
+  attackCooldownRemaining: number   // ms until next attack
+  // attackRange in grid cells (converted from UnitTemplate.attackRange pixels)
+  rangeInCells: number
+}
+
+export interface TDEnemy {
+  id: number
+  template: TDEnemyTemplate
+  hp: number
+  maxHp: number
+  // Position along the path: integer = at node, fractional = between nodes
+  pathProgress: number   // 0 = start, TD_PATH.length-1 = end
+  // Pixel position (derived from pathProgress) — used only for UI
+  x: number
+  y: number
+}
+
+// Pending spawn queue entry
+interface SpawnEntry {
+  template: TDEnemyTemplate
+  hpMult: number
+  spawnAt: number   // game-time ms when this enemy should enter
+}
+
+export type TDPhase = 'prep' | 'wave' | 'between' | 'victory' | 'defeat'
+
+export interface TDGameState {
+  phase: TDPhase
+  lives: number
+  wavesCompleted: number
+  currentWaveIndex: number    // index into TD_WAVES
+  gameTimeMs: number
+  towers: TDTower[]
+  enemies: TDEnemy[]
+  spawnQueue: SpawnEntry[]
+  nextWaveAt: number          // game-time ms when next wave's first spawn fires (between phase)
+  log: string[]
+  score: number               // enemies killed × reward
+  // Available tower pool (derived from collection or city; passed in at start)
+  availableTemplates: UnitTemplate[]
+  // How many of each unit (by name) the player has left to place
+  remainingPlacements: Record<string, number>
+  mode: 'collection' | 'city'
+}
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+export const TD_MAX_LIVES = 3
+export const TD_TOTAL_WAVES = TD_WAVES.length
+// Pixels per cell (used to convert attackRange)
+const CELL_SIZE_PX = 64
+// Between-wave pause (ms)
+const BETWEEN_WAVE_MS = 5000
+// Strength bonus multiplier
+const STRENGTH_MULT = 1.5
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function cellToXY(col: number, row: number): { x: number; y: number } {
+  return { x: col * CELL_SIZE_PX + CELL_SIZE_PX / 2, y: row * CELL_SIZE_PX + CELL_SIZE_PX / 2 }
+}
+
+function pathIndexToXY(progress: number): { x: number; y: number } {
+  const i = Math.min(Math.floor(progress), TD_PATH.length - 2)
+  const frac = progress - i
+  const a = TD_PATH[i]
+  const b = TD_PATH[Math.min(i + 1, TD_PATH.length - 1)]
+  return {
+    x: (a.col + (b.col - a.col) * frac) * CELL_SIZE_PX + CELL_SIZE_PX / 2,
+    y: (a.row + (b.row - a.row) * frac) * CELL_SIZE_PX + CELL_SIZE_PX / 2,
+  }
+}
+
+function dist(ax: number, ay: number, bx: number, by: number): number {
+  return Math.sqrt((ax - bx) ** 2 + (ay - by) ** 2)
+}
+
+function towerCanHit(tower: TDTower, enemy: TDEnemy): boolean {
+  // Non-bypassing towers can't hit flying enemies
+  if (enemy.template.flying && !tower.template.bypassWall) return false
+  const tx = tower.col * CELL_SIZE_PX + CELL_SIZE_PX / 2
+  const ty = tower.row * CELL_SIZE_PX + CELL_SIZE_PX / 2
+  return dist(tx, ty, enemy.x, enemy.y) <= tower.rangeInCells * CELL_SIZE_PX
+}
+
+function damageDealt(tower: TDTower, enemy: TDEnemy): number {
+  let dmg = tower.template.attack
+  if (tower.template.strengths?.some(tag => enemy.template.tags.includes(tag))) {
+    dmg = Math.round(dmg * STRENGTH_MULT)
+  }
+  return dmg
+}
+
+function buildSpawnQueue(waveDef: WaveDefinition, startTimeMs: number): SpawnEntry[] {
+  const queue: SpawnEntry[] = []
+  let t = startTimeMs
+  for (const group of waveDef.spawns) {
+    const tpl = ENEMY_TEMPLATES[group.enemyId]
+    if (!tpl) continue
+    for (let i = 0; i < group.count; i++) {
+      queue.push({ template: tpl, hpMult: group.hpMult, spawnAt: t })
+      t += group.intervalMs
+    }
+  }
+  // sort ascending so we can pop from the end
+  queue.sort((a, b) => b.spawnAt - a.spawnAt)
+  return queue
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/** Build initial game state from a set of available unit templates. */
+export function createTDGame(
+  availableTemplates: UnitTemplate[],
+  mode: 'collection' | 'city',
+  placementsPerTemplate: Record<string, number>,
+): TDGameState {
+  _nextId = 1
+  return {
+    phase: 'prep',
+    lives: TD_MAX_LIVES,
+    wavesCompleted: 0,
+    currentWaveIndex: 0,
+    gameTimeMs: 0,
+    towers: [],
+    enemies: [],
+    spawnQueue: [],
+    nextWaveAt: 0,
+    log: ['Place your towers, then press START WAVE.'],
+    score: 0,
+    availableTemplates,
+    remainingPlacements: { ...placementsPerTemplate },
+    mode,
+  }
+}
+
+/** Place a tower on the grid. Returns updated state or null if invalid. */
+export function placeTower(
+  state: TDGameState,
+  template: UnitTemplate,
+  col: number,
+  row: number,
+): TDGameState | null {
+  if (isPathCell(col, row)) return null
+  if (col < 0 || col >= TD_COLS || row < 0 || row >= TD_ROWS) return null
+  if (state.towers.some(t => t.col === col && t.row === row)) return null
+  const remaining = state.remainingPlacements[template.name] ?? 0
+  if (remaining <= 0) return null
+
+  const rangeInCells = Math.max(1, Math.round(template.attackRange / CELL_SIZE_PX))
+  const tower: TDTower = {
+    id: nextId(),
+    col, row,
+    template,
+    hp: template.maxHp,
+    maxHp: template.maxHp,
+    attackCooldownRemaining: 0,
+    rangeInCells,
+  }
+  return {
+    ...state,
+    towers: [...state.towers, tower],
+    remainingPlacements: {
+      ...state.remainingPlacements,
+      [template.name]: remaining - 1,
+    },
+    log: [...state.log.slice(-9), `Placed ${template.name}.`],
+  }
+}
+
+/** Remove a tower and refund its placement slot. */
+export function removeTower(state: TDGameState, towerId: number): TDGameState {
+  const tower = state.towers.find(t => t.id === towerId)
+  if (!tower) return state
+  return {
+    ...state,
+    towers: state.towers.filter(t => t.id !== towerId),
+    remainingPlacements: {
+      ...state.remainingPlacements,
+      [tower.template.name]: (state.remainingPlacements[tower.template.name] ?? 0) + 1,
+    },
+    log: [...state.log.slice(-9), `Removed ${tower.template.name}.`],
+  }
+}
+
+/** Begin the next wave from prep or between phase. */
+export function startWave(state: TDGameState): TDGameState {
+  if (state.phase !== 'prep' && state.phase !== 'between') return state
+  const waveDef = TD_WAVES[state.currentWaveIndex]
+  if (!waveDef) return state
+  const queue = buildSpawnQueue(waveDef, state.gameTimeMs)
+  return {
+    ...state,
+    phase: 'wave',
+    spawnQueue: queue,
+    log: [...state.log.slice(-9), waveDef.label + '!'],
+  }
+}
+
+/** Advance simulation by dtMs milliseconds. Returns next state. */
+export function tickTD(state: TDGameState, dtMs: number): TDGameState {
+  if (state.phase === 'prep' || state.phase === 'victory' || state.phase === 'defeat') {
+    return state
+  }
+
+  let s = { ...state, gameTimeMs: state.gameTimeMs + dtMs }
+  s.towers = [...s.towers]
+  s.enemies = [...s.enemies]
+  s.spawnQueue = [...s.spawnQueue]
+  s.log = [...s.log]
+
+  // ── Spawn enemies from queue ───────────────────────────────────────────────
+  while (s.spawnQueue.length > 0) {
+    const next = s.spawnQueue[s.spawnQueue.length - 1]
+    if (next.spawnAt > s.gameTimeMs) break
+    s.spawnQueue = s.spawnQueue.slice(0, -1)
+    const hp = Math.round(next.template.hp * next.hpMult)
+    const startXY = pathIndexToXY(0)
+    s.enemies = [...s.enemies, {
+      id: nextId(),
+      template: next.template,
+      hp,
+      maxHp: hp,
+      pathProgress: 0,
+      x: startXY.x,
+      y: startXY.y,
+    }]
+  }
+
+  // ── Move enemies ───────────────────────────────────────────────────────────
+  const dtSec = dtMs / 1000
+  let livesLost = 0
+  const survivingEnemies: TDEnemy[] = []
+
+  for (const enemy of s.enemies) {
+    const newProgress = enemy.pathProgress + enemy.template.speed * dtSec
+    if (newProgress >= TD_PATH.length - 1) {
+      // Reached the end
+      livesLost += enemy.template.attack
+    } else {
+      const xy = pathIndexToXY(newProgress)
+      survivingEnemies.push({ ...enemy, pathProgress: newProgress, x: xy.x, y: xy.y })
+    }
+  }
+  s.enemies = survivingEnemies
+
+  if (livesLost > 0) {
+    s.lives = Math.max(0, s.lives - livesLost)
+    s.log = [...s.log.slice(-9), `${livesLost} ${livesLost === 1 ? 'enemy' : 'enemies'} reached your base!`]
+  }
+
+  // ── Tower attacks ──────────────────────────────────────────────────────────
+  const deadEnemyIds = new Set<number>()
+  const updatedTowers: TDTower[] = []
+
+  for (const tower of s.towers) {
+    let cd = Math.max(0, tower.attackCooldownRemaining - dtMs)
+    if (cd <= 0 && s.enemies.length > 0) {
+      // Pick the enemy furthest along the path that is in range
+      const targets = s.enemies
+        .filter(e => !deadEnemyIds.has(e.id) && towerCanHit(tower, e))
+        .sort((a, b) => b.pathProgress - a.pathProgress)
+      if (targets.length > 0) {
+        const target = targets[0]
+        const dmg = damageDealt(tower, target)
+        const idx = s.enemies.findIndex(e => e.id === target.id)
+        if (idx !== -1) {
+          const newHp = s.enemies[idx].hp - dmg
+          if (newHp <= 0) {
+            deadEnemyIds.add(target.id)
+            s.score += target.template.reward
+          } else {
+            s.enemies = s.enemies.map(e => e.id === target.id ? { ...e, hp: newHp } : e)
+          }
+        }
+        cd = tower.template.attackCooldownMs
+      }
+    }
+    updatedTowers.push({ ...tower, attackCooldownRemaining: cd })
+  }
+
+  s.towers = updatedTowers
+  s.enemies = s.enemies.filter(e => !deadEnemyIds.has(e.id))
+
+  // ── Check defeat ───────────────────────────────────────────────────────────
+  if (s.lives <= 0) {
+    s.log = [...s.log.slice(-9), 'Your base has fallen!']
+    return { ...s, phase: 'defeat' }
+  }
+
+  // ── Check wave complete ────────────────────────────────────────────────────
+  if (s.phase === 'wave' && s.spawnQueue.length === 0 && s.enemies.length === 0) {
+    s.wavesCompleted += 1
+    if (s.wavesCompleted >= TD_TOTAL_WAVES) {
+      s.log = [...s.log.slice(-9), 'All waves defeated! Victory!']
+      return { ...s, phase: 'victory' }
+    }
+    s.currentWaveIndex += 1
+    s.nextWaveAt = s.gameTimeMs + BETWEEN_WAVE_MS
+    const nextWave = TD_WAVES[s.currentWaveIndex]
+    s.log = [...s.log.slice(-9), `Wave ${s.wavesCompleted} cleared! Next wave in 5 s — ${nextWave?.label ?? ''}`]
+    return { ...s, phase: 'between' }
+  }
+
+  // ── Auto-advance between phase ─────────────────────────────────────────────
+  if (s.phase === 'between' && s.gameTimeMs >= s.nextWaveAt) {
+    return startWave(s)
+  }
+
+  return s
+}
+
+/** Compute ticket reward for arcade mode based on waves cleared. */
+export function calcTicketReward(wavesCompleted: number): number {
+  return wavesCompleted * 5
+}
+
+/** Compute city gold reward for city mode based on waves cleared. */
+export function calcGoldReward(wavesCompleted: number): number {
+  return wavesCompleted * 500
+}
+
+export { ENEMY_TEMPLATES }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -12030,3 +12030,259 @@ html.light-mode .action-btn {
   background-color: #0ff;
   box-shadow: 0px 0px 5px #0ff;
 }
+/* ─── Tower Defence ─────────────────────────────────────────────────────────── */
+
+.td-root {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: #0a0a0a;
+  color: #e0e0e0;
+  font-family: 'Courier New', monospace;
+  overflow: hidden;
+}
+
+/* Header */
+.td-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 12px;
+  background: #111;
+  border-bottom: 1px solid #333;
+  gap: 8px;
+  flex-shrink: 0;
+}
+.td-header-left, .td-header-center, .td-header-right {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.td-header-right { margin-left: auto; }
+.td-lives { font-size: 16px; letter-spacing: 2px; }
+.td-wave-label { font-size: 13px; color: #aaa; }
+.td-wave-active { font-size: 13px; color: #f90; animation: pulse 1s ease-in-out infinite alternate; }
+.td-score { font-size: 13px; color: #4caf50; }
+.td-quit-btn { padding: 4px 10px; font-size: 11px; }
+
+/* Body */
+.td-body {
+  display: flex;
+  flex: 1;
+  overflow: hidden;
+  gap: 0;
+}
+
+/* Grid */
+.td-grid {
+  position: relative;
+  flex-shrink: 0;
+  border-right: 1px solid #333;
+  overflow: hidden;
+}
+
+.td-cell {
+  position: absolute;
+  box-sizing: border-box;
+  border: 1px solid #1a1a1a;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.1s;
+  user-select: none;
+}
+.td-cell--grass {
+  background: #1a2d1a;
+}
+.td-cell--grass:hover {
+  background: #243b24;
+}
+.td-cell--path {
+  background: #2a2008;
+  border-color: #3a2e10;
+  cursor: default;
+}
+.td-cell--start { background: #0d2b0d; }
+.td-cell--end   { background: #2b0d0d; }
+.td-cell--occupied { cursor: pointer; }
+.td-cell--drop-target {
+  background: #1a3d1a;
+  border-color: #4caf50;
+  box-shadow: inset 0 0 6px rgba(76,175,80,0.4);
+}
+.td-cell-label {
+  font-size: 9px;
+  color: #888;
+  letter-spacing: 1px;
+  font-weight: bold;
+  pointer-events: none;
+}
+
+/* Tower sprite inside cell */
+.td-tower-sprite {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+  pointer-events: none;
+}
+.td-tower-hp-bar {
+  width: 80%;
+  height: 4px;
+  background: #333;
+  border-radius: 2px;
+  overflow: hidden;
+  margin-top: 2px;
+}
+.td-tower-hp-fill {
+  height: 100%;
+  border-radius: 2px;
+  transition: width 0.2s;
+}
+
+/* Enemies */
+.td-enemy {
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  pointer-events: none;
+  z-index: 10;
+}
+.td-enemy-icon {
+  font-size: 20px;
+  line-height: 1;
+}
+.td-enemy-hp-bar {
+  width: 28px;
+  height: 4px;
+  background: #333;
+  border-radius: 2px;
+  overflow: hidden;
+  margin-top: 2px;
+}
+.td-enemy-hp-fill {
+  height: 100%;
+  border-radius: 2px;
+  transition: width 0.05s;
+}
+
+/* Sidebar */
+.td-sidebar {
+  width: 220px;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  background: #111;
+  padding: 10px 8px;
+  overflow-y: auto;
+  gap: 6px;
+}
+.td-sidebar-title {
+  font-size: 11px;
+  letter-spacing: 2px;
+  color: #888;
+  text-align: center;
+  border-bottom: 1px solid #333;
+  padding-bottom: 4px;
+}
+.td-sidebar-hint {
+  font-size: 10px;
+  color: #555;
+  line-height: 1.4;
+  margin: 0;
+}
+
+/* Unit list */
+.td-unit-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+}
+.td-unit-btn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: #1a1a1a;
+  border: 1px solid #333;
+  border-radius: 4px;
+  padding: 4px 6px;
+  cursor: pointer;
+  color: #e0e0e0;
+  font-family: inherit;
+  font-size: 11px;
+  text-align: left;
+  transition: border-color 0.1s, background 0.1s;
+}
+.td-unit-btn:hover:not(.td-unit-btn--disabled) {
+  background: #222;
+  border-color: #4caf50;
+}
+.td-unit-btn--selected {
+  border-color: #4caf50 !important;
+  background: #162616 !important;
+}
+.td-unit-btn--disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+.td-unit-btn-info { flex: 1; min-width: 0; }
+.td-unit-btn-name { font-size: 11px; font-weight: bold; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.td-unit-btn-stats { font-size: 10px; color: #888; }
+.td-unit-count {
+  font-size: 12px;
+  font-weight: bold;
+  color: #4caf50;
+  min-width: 20px;
+  text-align: right;
+}
+.td-unit-count--zero { color: #555; }
+
+/* Tower tooltip */
+.td-tower-tooltip {
+  background: #1a1a1a;
+  border: 1px solid #4caf50;
+  border-radius: 4px;
+  padding: 6px 8px;
+  font-size: 11px;
+  line-height: 1.6;
+}
+.td-tooltip-hint { color: #f44; font-size: 10px; margin-top: 4px; }
+
+/* Log */
+.td-log {
+  border-top: 1px solid #333;
+  padding-top: 6px;
+  font-size: 10px;
+  color: #666;
+  line-height: 1.6;
+  flex-shrink: 0;
+}
+.td-log-line { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+
+/* End screen */
+.td-end-screen {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  height: 100%;
+  background: #0a0a0a;
+  padding: 24px;
+  text-align: center;
+}
+.td-end-title {
+  font-size: 32px;
+  font-weight: bold;
+  letter-spacing: 4px;
+  font-family: 'Courier New', monospace;
+}
+.td-end-title--win  { color: #4caf50; text-shadow: 0 0 20px rgba(76,175,80,0.6); }
+.td-end-title--lose { color: #f44336; text-shadow: 0 0 20px rgba(244,67,54,0.6); }
+.td-end-stat  { font-size: 16px; color: #aaa; }
+.td-end-reward { font-size: 18px; color: #ffd700; font-weight: bold; }


### PR DESCRIPTION
## Summary

- **New minigame: Tower Defence** — place your cards as towers on a 13×7 grid and defend your base against 10 waves of enemies
- **Two entry points:** the Arcade menu (costs 50 💎, rewards tickets) and the City Builder's new ⚔ DEFEND button (free, rewards city gold)
- **Towers come from your cards:** Arcade mode uses owned unit cards from your collection; City mode uses the residents of your spawn buildings (only happy ones count)

## How it works

- Enemies walk a winding fixed path from the entry to your base; your towers attack automatically
- Tower stats (ATK, HP, range, attack speed) come directly from the card's `UnitTemplate` — so card balance feeds into tower balance naturally
- Cards with `strengths` deal ×1.5 damage to matching enemy tags
- `bypassWall`/`flying` towers can hit flying enemies; melee towers cannot
- 3 lives — each enemy that breaks through costs 1 life
- Between waves you can freely place or remove towers
- **Arcade reward:** 5 tickets × waves survived (max 50 for a clean run)
- **City reward:** 500 gold × waves survived, written back to the city state

## Files changed

| File | Change |
|---|---|
| `web/src/game/towerDefence.ts` | New — pure game logic (grid, path, waves, tick loop) |
| `web/src/components/minigames/TowerDefence.tsx` | New — React component with RAF game loop |
| `web/src/game/miniGames.ts` | Added `'towerDefence'` to `MiniGameId` union + metadata |
| `web/src/data/economy.json` | Crystal cost (50) for arcade mode |
| `web/src/components/MiniGamesMenu.tsx` | Arcade grid entry + routing |
| `web/src/components/minigames/CityBuilder.tsx` | ⚔ DEFEND button + city tower pool + gold reward |
| `web/src/styles.css` | Tower defence CSS |

## Test plan

- [ ] Open Arcade → Tower Defence appears in the grid at 50 💎 cost
- [ ] Start game — grid renders with winding path, enemies spawn and walk the path
- [ ] Place a tower on a grass cell — it appears with HP bar; click again removes it
- [ ] Melee tower cannot hit flying enemies; ranged (bypassWall) tower can
- [ ] Enemies reaching the base reduce lives; 0 lives → defeat screen
- [ ] Surviving all 10 waves → victory screen with correct ticket count
- [ ] City Builder → ⚔ DEFEND button appears; launches with city residents
- [ ] City with no residents shows the "no residents" fallback screen
- [ ] After city mode game, gold is added to city state

https://claude.ai/code/session_014PWcdZxQ19J95UxKwDEvqz

---
_Generated by [Claude Code](https://claude.ai/code/session_014PWcdZxQ19J95UxKwDEvqz)_