### PR TITLE
fix: tower defence placement layout + enemy sprites

### DIFF
--- a/web/src/components/minigames/TowerDefence.tsx
+++ b/web/src/components/minigames/TowerDefence.tsx
@@ -28,7 +28,7 @@ interface Props {
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
-const CELL_PX = 64
+const CELL_PX = 48
 const TICK_MS = 50   // ~20 fps simulation (RAF handles rendering)
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -313,7 +313,7 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
 // ── Enemy token ───────────────────────────────────────────────────────────────
 
 function EnemyToken({ enemy }: { enemy: TDEnemy }) {
-  const size = 36
+  const size = 28
   const hpFrac = enemy.hp / enemy.maxHp
   return (
     <div
@@ -322,10 +322,9 @@ function EnemyToken({ enemy }: { enemy: TDEnemy }) {
         left: enemy.x - size / 2,
         top: enemy.y - size / 2,
         width: size,
-        height: size,
       }}
     >
-      <div className="td-enemy-icon">{enemy.template.icon}</div>
+      <SpriteImg name={enemy.template.spriteName} className="td-enemy-sprite" />
       <div className="td-enemy-hp-bar">
         <div
           className="td-enemy-hp-fill"

--- a/web/src/game/towerDefence.ts
+++ b/web/src/game/towerDefence.ts
@@ -59,7 +59,7 @@ export function isPathCell(col: number, row: number): boolean {
 export interface TDEnemyTemplate {
   id: string
   label: string
-  icon: string
+  spriteName: string  // name passed to SpriteImg
   hp: number
   speed: number       // path-cells per second
   attack: number      // damage dealt to base on arrival
@@ -70,33 +70,33 @@ export interface TDEnemyTemplate {
 
 const ENEMY_TEMPLATES: Record<string, TDEnemyTemplate> = {
   footSoldier: {
-    id: 'footSoldier', label: 'Foot Soldier', icon: '🗡️',
+    id: 'footSoldier', label: 'Foot Soldier', spriteName: 'Goblin',
     hp: 80, speed: 1.0, attack: 1, reward: 10,
     tags: ['melee'],
   },
   scout: {
-    id: 'scout', label: 'Scout', icon: '🏹',
+    id: 'scout', label: 'Scout', spriteName: 'Archer',
     hp: 40, speed: 2.2, attack: 1, reward: 8,
     tags: ['fast', 'ranged'],
   },
   brute: {
-    id: 'brute', label: 'Brute', icon: '🪨',
+    id: 'brute', label: 'Brute', spriteName: 'Ogre',
     hp: 280, speed: 0.6, attack: 2, reward: 25,
     tags: ['slow', 'large', 'armored'],
   },
   flyer: {
-    id: 'flyer', label: 'Flyer', icon: '🦅',
+    id: 'flyer', label: 'Flyer', spriteName: 'Harpy',
     hp: 60, speed: 1.8, attack: 1, reward: 15,
     tags: ['flying', 'fast'],
     flying: true,
   },
   necromancer: {
-    id: 'necromancer', label: 'Necromancer', icon: '💀',
+    id: 'necromancer', label: 'Necromancer', spriteName: 'Necromancer',
     hp: 120, speed: 0.9, attack: 1, reward: 20,
     tags: ['magic', 'undead'],
   },
   siegeEngine: {
-    id: 'siegeEngine', label: 'Siege Engine', icon: '⚙️',
+    id: 'siegeEngine', label: 'Siege Engine', spriteName: 'Ballista',
     hp: 400, speed: 0.4, attack: 3, reward: 40,
     tags: ['siege', 'slow', 'large', 'armored'],
   },

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -12069,8 +12069,9 @@ html.light-mode .action-btn {
 .td-body {
   display: flex;
   flex: 1;
-  overflow: hidden;
+  overflow: auto;
   gap: 0;
+  min-height: 0;
 }
 
 /* Grid */
@@ -12150,9 +12151,10 @@ html.light-mode .action-btn {
   pointer-events: none;
   z-index: 10;
 }
-.td-enemy-icon {
-  font-size: 20px;
-  line-height: 1;
+.td-enemy-sprite {
+  width: 100%;
+  height: 100%;
+  display: block;
 }
 .td-enemy-hp-bar {
   width: 28px;


### PR DESCRIPTION
Fixes two issues reported after the initial tower defence PR:

## Fixes

**1. Can't place towers** — the sidebar (where you select a tower to place) was being clipped because the grid at 13×64px = 832px left no room for the 220px sidebar on most screens.
- Reduced `CELL_PX` from 64→48 (grid is now 624px wide, total ~844px)
- Changed `td-body` from `overflow: hidden` → `overflow: auto` so the board scrolls horizontally if still needed, rather than clipping the sidebar entirely

**2. Emoji attacker icons** — replaced the emoji icons on enemy tokens with existing sprite SVGs:
| Enemy | Sprite |
|---|---|
| Foot Soldier | Goblin |
| Scout | Archer |
| Brute | Ogre |
| Flyer | Harpy |
| Necromancer | Necromancer |
| Siege Engine | Ballista |

Also fixed the `EnemyToken` container so the HP bar beneath the sprite isn't clipped.

https://claude.ai/code/session_014PWcdZxQ19J95UxKwDEvqz

---
_Generated by [Claude Code](https://claude.ai/code/session_014PWcdZxQ19J95UxKwDEvqz)_