### PR TITLE
fix: tower defence portrait layout

### DIFF
--- a/web/src/components/minigames/TowerDefence.tsx
+++ b/web/src/components/minigames/TowerDefence.tsx
@@ -1,6 +1,8 @@
 // ─── Tower Defence ─────────────────────────────────────────────────────────────
-// Wave-based tower defence. Towers come from the player's card collection or
-// their city residents. Enemies walk a fixed path; survive all 10 waves to win.
+// Wave-based tower defence. Portrait-first layout:
+//   [header]  lives · wave · score · start/quit
+//   [board]   scrollable grid (fills remaining height)
+//   [panel]   horizontal unit strip + log line
 
 import React, { useState, useEffect, useRef, useCallback } from 'react'
 import { UnitTemplate } from '../../game/types'
@@ -17,7 +19,7 @@ import {
 
 export interface TowerPool {
   template: UnitTemplate
-  total: number   // max times this unit can be placed
+  total: number
 }
 
 interface Props {
@@ -29,7 +31,7 @@ interface Props {
 // ── Constants ─────────────────────────────────────────────────────────────────
 
 const CELL_PX = 48
-const TICK_MS = 50   // ~20 fps simulation (RAF handles rendering)
+const TICK_MS = 50
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -39,38 +41,29 @@ function hpBarColor(frac: number): string {
   return '#f44336'
 }
 
-function livesIcons(lives: number, max: number): string {
-  return '❤️'.repeat(lives) + '🖤'.repeat(Math.max(0, max - lives))
-}
-
-// Map path index → waypoint set for quick membership check
 const PATH_CELL_SET = new Set(TD_PATH.map(p => `${p.col},${p.row}`))
-function isBorderPath(col: number, row: number): boolean {
+function isOnPath(col: number, row: number): boolean {
   return PATH_CELL_SET.has(`${col},${row}`)
 }
 
 // ── Component ─────────────────────────────────────────────────────────────────
 
 export function TowerDefence({ pool, mode, onDone }: Props) {
-  // Build initial placements map from pool
   const initialPlacements: Record<string, number> = {}
-  for (const entry of pool) {
-    initialPlacements[entry.template.name] = entry.total
-  }
+  for (const entry of pool) initialPlacements[entry.template.name] = entry.total
 
   const [game, setGame] = useState<TDGameState>(() =>
     createTDGame(pool.map(p => p.template), mode, initialPlacements)
   )
   const [selected, setSelected] = useState<UnitTemplate | null>(null)
-  const [hoveredCell, setHoveredCell] = useState<{ col: number; row: number } | null>(null)
   const [hoveredTower, setHoveredTower] = useState<TDTower | null>(null)
 
   const gameRef = useRef(game)
   gameRef.current = game
 
-  const rafRef = useRef<number | null>(null)
+  const rafRef      = useRef<number | null>(null)
   const lastTimeRef = useRef<number | null>(null)
-  const accRef = useRef(0)
+  const accRef      = useRef(0)
 
   // ── Game loop ───────────────────────────────────────────────────────────────
 
@@ -93,9 +86,7 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
 
   useEffect(() => {
     rafRef.current = requestAnimationFrame(tick)
-    return () => {
-      if (rafRef.current !== null) cancelAnimationFrame(rafRef.current)
-    }
+    return () => { if (rafRef.current !== null) cancelAnimationFrame(rafRef.current) }
   }, [tick])
 
   // ── Interactions ────────────────────────────────────────────────────────────
@@ -104,7 +95,6 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
     const g = gameRef.current
     if (g.phase !== 'prep' && g.phase !== 'between') return
 
-    // Click on existing tower → remove it
     const existing = g.towers.find(t => t.col === col && t.row === row)
     if (existing) {
       setGame(prev => removeTower(prev, existing.id))
@@ -113,15 +103,13 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
     }
 
     if (!selected) return
-    if (isPathCell(col, row)) return
+    if (isOnPath(col, row)) return
 
     const next = placeTower(g, selected, col, row)
     if (next) setGame(next)
   }
 
-  function handleStartWave() {
-    setGame(prev => startWave(prev))
-  }
+  function handleStartWave() { setGame(prev => startWave(prev)) }
 
   function handleSelectUnit(template: UnitTemplate) {
     setSelected(prev => prev?.name === template.name ? null : template)
@@ -129,12 +117,13 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
 
   // ── Derived ─────────────────────────────────────────────────────────────────
 
-  const canPlace = (template: UnitTemplate) => (game.remainingPlacements[template.name] ?? 0) > 0
   const isPlacingPhase = game.phase === 'prep' || game.phase === 'between'
   const reward = mode === 'city' ? calcGoldReward(game.wavesCompleted) : calcTicketReward(game.wavesCompleted)
-  const rewardLabel = mode === 'city' ? `${reward.toLocaleString()} 🪙 city gold` : `${reward} 🎫 tickets`
+  const rewardLabel = mode === 'city'
+    ? `${reward.toLocaleString()} 🪙 city gold`
+    : `${reward} 🎫 tickets`
 
-  // ── End screens ─────────────────────────────────────────────────────────────
+  // ── End screen ──────────────────────────────────────────────────────────────
 
   if (game.phase === 'victory' || game.phase === 'defeat') {
     const won = game.phase === 'victory'
@@ -155,37 +144,42 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
 
   // ── Main layout ─────────────────────────────────────────────────────────────
 
+  const lastLog = game.log[game.log.length - 1] ?? ''
+
   return (
     <div className="td-root">
+
       {/* ── Header ── */}
       <div className="td-header">
-        <div className="td-header-left">
-          <span className="td-lives">{livesIcons(game.lives, TD_MAX_LIVES)}</span>
-          <span className="td-wave-label">
-            Wave {game.wavesCompleted + 1} / {TD_TOTAL_WAVES}
-            {game.phase === 'between' && ' — Get ready!'}
-          </span>
+        <div className="td-header-lives">
+          {'❤️'.repeat(game.lives)}{'🖤'.repeat(Math.max(0, TD_MAX_LIVES - game.lives))}
         </div>
-        <div className="td-header-center">
-          {isPlacingPhase && (
-            <button className="action-btn action-btn--gold" onClick={handleStartWave}>
-              ▶ START WAVE
-            </button>
-          )}
-          {game.phase === 'wave' && (
-            <span className="td-wave-active">⚔ Wave in progress…</span>
-          )}
+
+        <div className="td-header-wave">
+          Wave {game.wavesCompleted + 1}/{TD_TOTAL_WAVES}
         </div>
-        <div className="td-header-right">
-          <span className="td-score">Score: {game.score}</span>
-          <button className="action-btn action-btn--danger td-quit-btn" onClick={() => onDone(reward)}>
-            QUIT
+
+        <div className="td-header-score">⭐ {game.score}</div>
+
+        {isPlacingPhase && (
+          <button className="action-btn action-btn--gold td-header-btn" onClick={handleStartWave}>
+            ▶ START
           </button>
-        </div>
+        )}
+        {game.phase === 'wave' && (
+          <span className="td-header-active">⚔ Fighting…</span>
+        )}
+        {game.phase === 'between' && (
+          <span className="td-header-active">⏳ Next wave…</span>
+        )}
+
+        <button className="action-btn action-btn--danger td-header-btn" onClick={() => onDone(reward)}>
+          ✕
+        </button>
       </div>
 
-      <div className="td-body">
-        {/* ── Grid ── */}
+      {/* ── Board (scrollable) ── */}
+      <div className="td-board-wrap">
         <div
           className="td-grid"
           style={{ width: TD_COLS * CELL_PX, height: TD_ROWS * CELL_PX }}
@@ -193,45 +187,38 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
           {/* Cells */}
           {Array.from({ length: TD_ROWS }, (_, row) =>
             Array.from({ length: TD_COLS }, (_, col) => {
-              const key = `${col},${row}`
-              const onPath = isBorderPath(col, row)
-              const isStart = col === TD_PATH[0].col && row === TD_PATH[0].row
-              const isEnd = col === TD_PATH[TD_PATH.length - 1].col && row === TD_PATH[TD_PATH.length - 1].row
-              const tower = game.towers.find(t => t.col === col && t.row === row)
-              const isHovered = hoveredCell?.col === col && hoveredCell?.row === row
-              const canDrop = isHovered && selected && !onPath && !tower && isPlacingPhase && canPlace(selected)
+              const onPath   = isOnPath(col, row)
+              const isStart  = col === TD_PATH[0].col && row === TD_PATH[0].row
+              const isEnd    = col === TD_PATH[TD_PATH.length - 1].col && row === TD_PATH[TD_PATH.length - 1].row
+              const tower    = game.towers.find(t => t.col === col && t.row === row)
+              const canDrop  = selected && !onPath && !tower && isPlacingPhase
 
               return (
                 <div
-                  key={key}
+                  key={`${col},${row}`}
                   className={[
                     'td-cell',
-                    onPath ? 'td-cell--path' : 'td-cell--grass',
-                    isStart ? 'td-cell--start' : '',
-                    isEnd ? 'td-cell--end' : '',
-                    tower ? 'td-cell--occupied' : '',
-                    canDrop ? 'td-cell--drop-target' : '',
+                    onPath   ? 'td-cell--path'   : 'td-cell--grass',
+                    isStart  ? 'td-cell--start'  : '',
+                    isEnd    ? 'td-cell--end'     : '',
+                    canDrop  ? 'td-cell--droppable' : '',
+                    tower    ? 'td-cell--occupied' : '',
                   ].filter(Boolean).join(' ')}
                   style={{ left: col * CELL_PX, top: row * CELL_PX, width: CELL_PX, height: CELL_PX }}
                   onClick={() => handleCellClick(col, row)}
-                  onMouseEnter={() => { setHoveredCell({ col, row }); if (tower) setHoveredTower(tower) }}
-                  onMouseLeave={() => { setHoveredCell(null); setHoveredTower(null) }}
+                  onMouseEnter={() => { if (tower) setHoveredTower(tower) }}
+                  onMouseLeave={() => setHoveredTower(null)}
                 >
                   {isStart && <span className="td-cell-label">IN</span>}
-                  {isEnd && <span className="td-cell-label">BASE</span>}
+                  {isEnd   && <span className="td-cell-label">BASE</span>}
                   {tower && (
-                    <div className="td-tower-sprite">
-                      <div style={{ width: CELL_PX - 8, height: CELL_PX - 8 }}>
-                        <SpriteImg name={tower.template.name} />
-                      </div>
+                    <div className="td-tower-inner">
+                      <SpriteImg name={tower.template.name} />
                       <div className="td-tower-hp-bar">
-                        <div
-                          className="td-tower-hp-fill"
-                          style={{
-                            width: `${(tower.hp / tower.maxHp) * 100}%`,
-                            background: hpBarColor(tower.hp / tower.maxHp),
-                          }}
-                        />
+                        <div className="td-tower-hp-fill" style={{
+                          width: `${(tower.hp / tower.maxHp) * 100}%`,
+                          background: hpBarColor(tower.hp / tower.maxHp),
+                        }} />
                       </div>
                     </div>
                   )}
@@ -240,70 +227,69 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
             })
           )}
 
-          {/* Enemies (absolutely positioned over grid) */}
+          {/* Enemies */}
           {game.enemies.map(enemy => (
             <EnemyToken key={enemy.id} enemy={enemy} />
           ))}
-        </div>
 
-        {/* ── Sidebar ── */}
-        <div className="td-sidebar">
-          <div className="td-sidebar-title">TOWERS</div>
-          {isPlacingPhase
-            ? <p className="td-sidebar-hint">Click a unit to select, then click a grass cell to place. Click a placed tower to remove it.</p>
-            : <p className="td-sidebar-hint">Wave in progress — placement locked.</p>
-          }
-
-          <div className="td-unit-list">
-            {pool.map(({ template }) => {
-              const remaining = game.remainingPlacements[template.name] ?? 0
-              const isSel = selected?.name === template.name
-              const disabled = !isPlacingPhase || remaining === 0
-              return (
-                <button
-                  key={template.name}
-                  className={[
-                    'td-unit-btn',
-                    isSel ? 'td-unit-btn--selected' : '',
-                    disabled ? 'td-unit-btn--disabled' : '',
-                  ].filter(Boolean).join(' ')}
-                  onClick={() => !disabled && handleSelectUnit(template)}
-                  title={`ATK ${template.attack} · HP ${template.maxHp} · Range ${Math.max(1, Math.round(template.attackRange / 64))} cells`}
-                >
-                  <div style={{ width: 32, height: 32, flexShrink: 0 }}>
-                    <SpriteImg name={template.name} />
-                  </div>
-                  <div className="td-unit-btn-info">
-                    <div className="td-unit-btn-name">{template.name}</div>
-                    <div className="td-unit-btn-stats">
-                      ⚔ {template.attack} · ❤ {template.maxHp}
-                    </div>
-                  </div>
-                  <span className={`td-unit-count ${remaining === 0 ? 'td-unit-count--zero' : ''}`}>
-                    ×{remaining}
-                  </span>
-                </button>
-              )
-            })}
-          </div>
-
-          {/* Tower tooltip */}
+          {/* Tower tooltip overlay */}
           {hoveredTower && (
-            <div className="td-tower-tooltip">
+            <div
+              className="td-tower-tooltip"
+              style={{
+                left: hoveredTower.col * CELL_PX,
+                top: Math.max(0, hoveredTower.row * CELL_PX - 72),
+              }}
+            >
               <strong>{hoveredTower.template.name}</strong>
-              <div>HP {hoveredTower.hp} / {hoveredTower.maxHp}</div>
-              <div>ATK {hoveredTower.template.attack}</div>
-              <div>Range {hoveredTower.rangeInCells} cells</div>
-              {isPlacingPhase && <div className="td-tooltip-hint">(click to remove)</div>}
+              <div>HP {hoveredTower.hp}/{hoveredTower.maxHp} · ATK {hoveredTower.template.attack} · R {hoveredTower.rangeInCells}</div>
+              {isPlacingPhase && <div className="td-tooltip-hint">Tap to remove</div>}
             </div>
           )}
+        </div>
+      </div>
 
-          {/* Log */}
-          <div className="td-log">
-            {[...game.log].reverse().slice(0, 5).map((line, i) => (
-              <div key={i} className="td-log-line">{line}</div>
-            ))}
+      {/* ── Bottom panel ── */}
+      <div className="td-panel">
+        {/* Log line */}
+        <div className="td-panel-log">{lastLog}</div>
+
+        {/* Hint */}
+        {isPlacingPhase && (
+          <div className="td-panel-hint">
+            {selected
+              ? `Placing ${selected.name} — tap a green cell`
+              : 'Tap a unit below to select, then tap the grid'}
           </div>
+        )}
+
+        {/* Unit strip */}
+        <div className="td-unit-strip">
+          {pool.map(({ template }) => {
+            const remaining = game.remainingPlacements[template.name] ?? 0
+            const isSel     = selected?.name === template.name
+            const disabled  = !isPlacingPhase || remaining === 0
+            return (
+              <button
+                key={template.name}
+                className={[
+                  'td-unit-chip',
+                  isSel    ? 'td-unit-chip--selected' : '',
+                  disabled ? 'td-unit-chip--disabled'  : '',
+                ].filter(Boolean).join(' ')}
+                onClick={() => !disabled && handleSelectUnit(template)}
+                title={`${template.name} — ATK ${template.attack}, HP ${template.maxHp}, Range ${Math.max(1, Math.round(template.attackRange / 64))} cells`}
+              >
+                <div className="td-unit-chip-sprite">
+                  <SpriteImg name={template.name} />
+                </div>
+                <div className="td-unit-chip-name">{template.name}</div>
+                <span className={`td-unit-chip-count ${remaining === 0 ? 'td-unit-chip-count--zero' : ''}`}>
+                  ×{remaining}
+                </span>
+              </button>
+            )
+          })}
         </div>
       </div>
     </div>
@@ -318,18 +304,12 @@ function EnemyToken({ enemy }: { enemy: TDEnemy }) {
   return (
     <div
       className="td-enemy"
-      style={{
-        left: enemy.x - size / 2,
-        top: enemy.y - size / 2,
-        width: size,
-      }}
+      style={{ left: enemy.x - size / 2, top: enemy.y - size / 2, width: size }}
     >
       <SpriteImg name={enemy.template.spriteName} className="td-enemy-sprite" />
       <div className="td-enemy-hp-bar">
-        <div
-          className="td-enemy-hp-fill"
-          style={{ width: `${hpFrac * 100}%`, background: hpBarColor(hpFrac) }}
-        />
+        <div className="td-enemy-hp-fill"
+          style={{ width: `${hpFrac * 100}%`, background: hpBarColor(hpFrac) }} />
       </div>
     </div>
   )

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -12030,6 +12030,7 @@ html.light-mode .action-btn {
   background-color: #0ff;
   box-shadow: 0px 0px 5px #0ff;
 }
+
 /* ─── Tower Defence ─────────────────────────────────────────────────────────── */
 
 .td-root {
@@ -12042,44 +12043,35 @@ html.light-mode .action-btn {
   overflow: hidden;
 }
 
-/* Header */
+/* ── Header ── */
 .td-header {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  padding: 6px 12px;
+  gap: 8px;
+  padding: 6px 10px;
   background: #111;
   border-bottom: 1px solid #333;
-  gap: 8px;
   flex-shrink: 0;
+  flex-wrap: wrap;
 }
-.td-header-left, .td-header-center, .td-header-right {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-}
-.td-header-right { margin-left: auto; }
-.td-lives { font-size: 16px; letter-spacing: 2px; }
-.td-wave-label { font-size: 13px; color: #aaa; }
-.td-wave-active { font-size: 13px; color: #f90; animation: pulse 1s ease-in-out infinite alternate; }
-.td-score { font-size: 13px; color: #4caf50; }
-.td-quit-btn { padding: 4px 10px; font-size: 11px; }
+.td-header-lives  { font-size: 14px; letter-spacing: 1px; }
+.td-header-wave   { font-size: 12px; color: #aaa; flex: 1; text-align: center; }
+.td-header-score  { font-size: 12px; color: #4caf50; }
+.td-header-active { font-size: 12px; color: #f90; }
+.td-header-btn    { padding: 4px 10px !important; font-size: 11px !important; }
 
-/* Body */
-.td-body {
-  display: flex;
+/* ── Board ── */
+.td-board-wrap {
   flex: 1;
   overflow: auto;
-  gap: 0;
   min-height: 0;
+  background: #0d0d0d;
 }
 
-/* Grid */
+/* ── Grid ── */
 .td-grid {
   position: relative;
   flex-shrink: 0;
-  border-right: 1px solid #333;
-  overflow: hidden;
 }
 
 .td-cell {
@@ -12090,38 +12082,20 @@ html.light-mode .action-btn {
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: background 0.1s;
   user-select: none;
+  transition: background 0.1s;
 }
-.td-cell--grass {
-  background: #1a2d1a;
-}
-.td-cell--grass:hover {
-  background: #243b24;
-}
-.td-cell--path {
-  background: #2a2008;
-  border-color: #3a2e10;
-  cursor: default;
-}
-.td-cell--start { background: #0d2b0d; }
-.td-cell--end   { background: #2b0d0d; }
-.td-cell--occupied { cursor: pointer; }
-.td-cell--drop-target {
-  background: #1a3d1a;
-  border-color: #4caf50;
-  box-shadow: inset 0 0 6px rgba(76,175,80,0.4);
-}
-.td-cell-label {
-  font-size: 9px;
-  color: #888;
-  letter-spacing: 1px;
-  font-weight: bold;
-  pointer-events: none;
-}
+.td-cell--grass       { background: #1a2d1a; }
+.td-cell--grass:hover { background: #243b24; }
+.td-cell--path        { background: #2a2008; border-color: #3a2e10; cursor: default; }
+.td-cell--start       { background: #0d2b0d; }
+.td-cell--end         { background: #2b0d0d; }
+.td-cell--droppable   { background: #1e3a1e; border-color: #4caf50; box-shadow: inset 0 0 5px rgba(76,175,80,0.3); }
+.td-cell--occupied    { cursor: pointer; }
+.td-cell-label { font-size: 8px; color: #888; letter-spacing: 1px; pointer-events: none; }
 
-/* Tower sprite inside cell */
-.td-tower-sprite {
+/* Tower inside cell */
+.td-tower-inner {
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -12130,17 +12104,28 @@ html.light-mode .action-btn {
 }
 .td-tower-hp-bar {
   width: 80%;
-  height: 4px;
+  height: 3px;
   background: #333;
   border-radius: 2px;
   overflow: hidden;
   margin-top: 2px;
 }
-.td-tower-hp-fill {
-  height: 100%;
-  border-radius: 2px;
-  transition: width 0.2s;
+.td-tower-hp-fill { height: 100%; border-radius: 2px; transition: width 0.2s; }
+
+/* Tower tooltip (positioned inside grid) */
+.td-tower-tooltip {
+  position: absolute;
+  background: rgba(0,0,0,0.85);
+  border: 1px solid #4caf50;
+  border-radius: 4px;
+  padding: 5px 7px;
+  font-size: 10px;
+  line-height: 1.5;
+  z-index: 20;
+  pointer-events: none;
+  white-space: nowrap;
 }
+.td-tooltip-hint { color: #f44; font-size: 9px; margin-top: 2px; }
 
 /* Enemies */
 .td-enemy {
@@ -12151,122 +12136,86 @@ html.light-mode .action-btn {
   pointer-events: none;
   z-index: 10;
 }
-.td-enemy-sprite {
-  width: 100%;
-  height: 100%;
-  display: block;
-}
+.td-enemy-sprite { width: 100%; display: block; }
 .td-enemy-hp-bar {
-  width: 28px;
-  height: 4px;
+  width: 100%;
+  height: 3px;
   background: #333;
   border-radius: 2px;
   overflow: hidden;
-  margin-top: 2px;
+  margin-top: 1px;
 }
-.td-enemy-hp-fill {
-  height: 100%;
-  border-radius: 2px;
-  transition: width 0.05s;
-}
+.td-enemy-hp-fill { height: 100%; border-radius: 2px; transition: width 0.05s; }
 
-/* Sidebar */
-.td-sidebar {
-  width: 220px;
+/* ── Bottom panel ── */
+.td-panel {
   flex-shrink: 0;
+  background: #111;
+  border-top: 1px solid #333;
   display: flex;
   flex-direction: column;
-  background: #111;
-  padding: 10px 8px;
-  overflow-y: auto;
-  gap: 6px;
+  gap: 2px;
+  padding: 4px 0 2px;
 }
-.td-sidebar-title {
-  font-size: 11px;
-  letter-spacing: 2px;
-  color: #888;
-  text-align: center;
-  border-bottom: 1px solid #333;
-  padding-bottom: 4px;
-}
-.td-sidebar-hint {
+.td-panel-log {
   font-size: 10px;
-  color: #555;
-  line-height: 1.4;
-  margin: 0;
+  color: #666;
+  padding: 0 10px;
+  min-height: 14px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.td-panel-hint {
+  font-size: 10px;
+  color: #4caf50;
+  padding: 0 10px;
+  min-height: 13px;
 }
 
-/* Unit list */
-.td-unit-list {
+/* Unit strip */
+.td-unit-strip {
+  display: flex;
+  flex-direction: row;
+  gap: 6px;
+  overflow-x: auto;
+  padding: 4px 8px 6px;
+  scrollbar-width: thin;
+  scrollbar-color: #333 transparent;
+}
+.td-unit-chip {
   display: flex;
   flex-direction: column;
-  gap: 4px;
-  flex: 1;
-  min-height: 0;
-  overflow-y: auto;
-}
-.td-unit-btn {
-  display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 2px;
   background: #1a1a1a;
   border: 1px solid #333;
-  border-radius: 4px;
-  padding: 4px 6px;
+  border-radius: 6px;
+  padding: 5px 6px;
   cursor: pointer;
   color: #e0e0e0;
   font-family: inherit;
-  font-size: 11px;
-  text-align: left;
+  flex-shrink: 0;
+  min-width: 52px;
   transition: border-color 0.1s, background 0.1s;
 }
-.td-unit-btn:hover:not(.td-unit-btn--disabled) {
-  background: #222;
-  border-color: #4caf50;
+.td-unit-chip:hover:not(.td-unit-chip--disabled) { background: #222; border-color: #4caf50; }
+.td-unit-chip--selected { border-color: #4caf50 !important; background: #162616 !important; }
+.td-unit-chip--disabled { opacity: 0.35; cursor: not-allowed; }
+.td-unit-chip-sprite { width: 36px; height: 36px; }
+.td-unit-chip-name {
+  font-size: 9px;
+  color: #aaa;
+  text-align: center;
+  max-width: 52px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
-.td-unit-btn--selected {
-  border-color: #4caf50 !important;
-  background: #162616 !important;
-}
-.td-unit-btn--disabled {
-  opacity: 0.4;
-  cursor: not-allowed;
-}
-.td-unit-btn-info { flex: 1; min-width: 0; }
-.td-unit-btn-name { font-size: 11px; font-weight: bold; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.td-unit-btn-stats { font-size: 10px; color: #888; }
-.td-unit-count {
-  font-size: 12px;
-  font-weight: bold;
-  color: #4caf50;
-  min-width: 20px;
-  text-align: right;
-}
-.td-unit-count--zero { color: #555; }
+.td-unit-chip-count { font-size: 11px; font-weight: bold; color: #4caf50; }
+.td-unit-chip-count--zero { color: #555; }
 
-/* Tower tooltip */
-.td-tower-tooltip {
-  background: #1a1a1a;
-  border: 1px solid #4caf50;
-  border-radius: 4px;
-  padding: 6px 8px;
-  font-size: 11px;
-  line-height: 1.6;
-}
-.td-tooltip-hint { color: #f44; font-size: 10px; margin-top: 4px; }
-
-/* Log */
-.td-log {
-  border-top: 1px solid #333;
-  padding-top: 6px;
-  font-size: 10px;
-  color: #666;
-  line-height: 1.6;
-  flex-shrink: 0;
-}
-.td-log-line { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-
-/* End screen */
+/* ── End screen ── */
 .td-end-screen {
   display: flex;
   flex-direction: column;
@@ -12278,13 +12227,8 @@ html.light-mode .action-btn {
   padding: 24px;
   text-align: center;
 }
-.td-end-title {
-  font-size: 32px;
-  font-weight: bold;
-  letter-spacing: 4px;
-  font-family: 'Courier New', monospace;
-}
+.td-end-title { font-size: 28px; font-weight: bold; letter-spacing: 4px; }
 .td-end-title--win  { color: #4caf50; text-shadow: 0 0 20px rgba(76,175,80,0.6); }
 .td-end-title--lose { color: #f44336; text-shadow: 0 0 20px rgba(244,67,54,0.6); }
-.td-end-stat  { font-size: 16px; color: #aaa; }
-.td-end-reward { font-size: 18px; color: #ffd700; font-weight: bold; }
+.td-end-stat   { font-size: 15px; color: #aaa; }
+.td-end-reward { font-size: 17px; color: #ffd700; font-weight: bold; }


### PR DESCRIPTION
## Summary

- Removes the right-side sidebar entirely — it was the source of the horizontal overflow that made the game unusable in portrait
- Grid now lives in a scrollable `td-board-wrap` that fills all available vertical space; the game works naturally in portrait orientation
- Unit selection moves to a **horizontal scrolling strip at the bottom** — compact chips (sprite + name + count) that scroll if there are many units
- Header is a single compact row: lives · wave · score · start/quit
- Tower tooltip is now an absolute overlay positioned inside the grid itself

## Layout comparison

| Before | After |
|---|---|
| Header + [Grid \| Sidebar] | Header + [Scrollable grid] + [Bottom strip] |
| Required landscape or wide screen | Works in portrait; grid scrolls if needed |

https://claude.ai/code/session_014PWcdZxQ19J95UxKwDEvqz

---
_Generated by [Claude Code](https://claude.ai/code/session_014PWcdZxQ19J95UxKwDEvqz)_