### PR TITLE
fix: tower defence path scale, animated sprites, attack effects

### DIFF
--- a/web/src/components/minigames/TowerDefence.tsx
+++ b/web/src/components/minigames/TowerDefence.tsx
@@ -6,10 +6,10 @@
 
 import React, { useState, useEffect, useRef, useCallback } from 'react'
 import { UnitTemplate } from '../../game/types'
-import { SpriteImg } from '../SpriteImg'
+import { SpriteImg, AnimatedSpriteImg } from '../SpriteImg'
 import {
-  TD_COLS, TD_ROWS, TD_PATH, TD_WAVES, TD_TOTAL_WAVES, TD_MAX_LIVES,
-  TDGameState, TDTower, TDEnemy,
+  TD_COLS, TD_ROWS, TD_PATH, TD_WAVES, TD_TOTAL_WAVES, TD_MAX_LIVES, TD_CELL_PX,
+  TDGameState, TDTower, TDEnemy, TDAttackEvent,
   isPathCell,
   createTDGame, placeTower, removeTower, startWave, tickTD,
   calcTicketReward, calcGoldReward,
@@ -30,7 +30,7 @@ interface Props {
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
-const CELL_PX = 48
+const CELL_PX = TD_CELL_PX   // single source of truth from game logic
 const TICK_MS = 50
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -232,6 +232,11 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
             <EnemyToken key={enemy.id} enemy={enemy} />
           ))}
 
+          {/* Attack effects */}
+          {game.attackEvents.map(ev => (
+            <AttackEffect key={ev.id} ev={ev} />
+          ))}
+
           {/* Tower tooltip overlay */}
           {hoveredTower && (
             <div
@@ -306,11 +311,49 @@ function EnemyToken({ enemy }: { enemy: TDEnemy }) {
       className="td-enemy"
       style={{ left: enemy.x - size / 2, top: enemy.y - size / 2, width: size }}
     >
-      <SpriteImg name={enemy.template.spriteName} className="td-enemy-sprite" />
+      <AnimatedSpriteImg name={enemy.template.spriteName} frameCount={3} fps={6} className="td-enemy-sprite" />
       <div className="td-enemy-hp-bar">
         <div className="td-enemy-hp-fill"
           style={{ width: `${hpFrac * 100}%`, background: hpBarColor(hpFrac) }} />
       </div>
     </div>
+  )
+}
+
+function AttackEffect({ ev }: { ev: TDAttackEvent }) {
+  const dx = ev.toX - ev.fromX
+  const dy = ev.toY - ev.fromY
+  const len = Math.hypot(dx, dy)
+  const angle = Math.atan2(dy, dx) * 180 / Math.PI
+  return (
+    <>
+      {/* Projectile line */}
+      <div
+        className="anim-projectile"
+        style={{
+          position: 'absolute',
+          left: ev.fromX,
+          top: ev.fromY,
+          width: len,
+          height: 4,
+          transform: `translate(0, -50%) rotate(${angle}deg)`,
+          transformOrigin: '0 50%',
+          pointerEvents: 'none',
+          zIndex: 15,
+        }}
+      />
+      {/* Hit spark */}
+      <div
+        className="anim-hit"
+        style={{
+          position: 'absolute',
+          left: ev.toX,
+          top: ev.toY,
+          transform: 'translate(-50%, -50%)',
+          pointerEvents: 'none',
+          zIndex: 16,
+        }}
+      />
+    </>
   )
 }

--- a/web/src/game/towerDefence.ts
+++ b/web/src/game/towerDefence.ts
@@ -220,6 +220,16 @@ export interface TDEnemy {
   y: number
 }
 
+// Attack visual event — used by the UI to show projectile + hit spark
+export interface TDAttackEvent {
+  id: number
+  fromX: number
+  fromY: number
+  toX: number
+  toY: number
+  expiresAt: number   // game-time ms
+}
+
 // Pending spawn queue entry
 interface SpawnEntry {
   template: TDEnemyTemplate
@@ -241,6 +251,7 @@ export interface TDGameState {
   nextWaveAt: number          // game-time ms when next wave's first spawn fires (between phase)
   log: string[]
   score: number               // enemies killed × reward
+  attackEvents: TDAttackEvent[]
   // Available tower pool (derived from collection or city; passed in at start)
   availableTemplates: UnitTemplate[]
   // How many of each unit (by name) the player has left to place
@@ -252,8 +263,8 @@ export interface TDGameState {
 
 export const TD_MAX_LIVES = 3
 export const TD_TOTAL_WAVES = TD_WAVES.length
-// Pixels per cell (used to convert attackRange)
-const CELL_SIZE_PX = 64
+/** Pixel size of each grid cell — shared with the React component. */
+export const TD_CELL_PX = 48
 // Between-wave pause (ms)
 const BETWEEN_WAVE_MS = 5000
 // Strength bonus multiplier
@@ -262,7 +273,7 @@ const STRENGTH_MULT = 1.5
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 function cellToXY(col: number, row: number): { x: number; y: number } {
-  return { x: col * CELL_SIZE_PX + CELL_SIZE_PX / 2, y: row * CELL_SIZE_PX + CELL_SIZE_PX / 2 }
+  return { x: col * TD_CELL_PX + TD_CELL_PX / 2, y: row * TD_CELL_PX + TD_CELL_PX / 2 }
 }
 
 function pathIndexToXY(progress: number): { x: number; y: number } {
@@ -271,8 +282,8 @@ function pathIndexToXY(progress: number): { x: number; y: number } {
   const a = TD_PATH[i]
   const b = TD_PATH[Math.min(i + 1, TD_PATH.length - 1)]
   return {
-    x: (a.col + (b.col - a.col) * frac) * CELL_SIZE_PX + CELL_SIZE_PX / 2,
-    y: (a.row + (b.row - a.row) * frac) * CELL_SIZE_PX + CELL_SIZE_PX / 2,
+    x: (a.col + (b.col - a.col) * frac) * TD_CELL_PX + TD_CELL_PX / 2,
+    y: (a.row + (b.row - a.row) * frac) * TD_CELL_PX + TD_CELL_PX / 2,
   }
 }
 
@@ -283,9 +294,9 @@ function dist(ax: number, ay: number, bx: number, by: number): number {
 function towerCanHit(tower: TDTower, enemy: TDEnemy): boolean {
   // Non-bypassing towers can't hit flying enemies
   if (enemy.template.flying && !tower.template.bypassWall) return false
-  const tx = tower.col * CELL_SIZE_PX + CELL_SIZE_PX / 2
-  const ty = tower.row * CELL_SIZE_PX + CELL_SIZE_PX / 2
-  return dist(tx, ty, enemy.x, enemy.y) <= tower.rangeInCells * CELL_SIZE_PX
+  const tx = tower.col * TD_CELL_PX + TD_CELL_PX / 2
+  const ty = tower.row * TD_CELL_PX + TD_CELL_PX / 2
+  return dist(tx, ty, enemy.x, enemy.y) <= tower.rangeInCells * TD_CELL_PX
 }
 
 function damageDealt(tower: TDTower, enemy: TDEnemy): number {
@@ -332,6 +343,7 @@ export function createTDGame(
     spawnQueue: [],
     nextWaveAt: 0,
     log: ['Place your towers, then press START WAVE.'],
+    attackEvents: [],
     score: 0,
     availableTemplates,
     remainingPlacements: { ...placementsPerTemplate },
@@ -352,7 +364,7 @@ export function placeTower(
   const remaining = state.remainingPlacements[template.name] ?? 0
   if (remaining <= 0) return null
 
-  const rangeInCells = Math.max(1, Math.round(template.attackRange / CELL_SIZE_PX))
+  const rangeInCells = Math.max(1, Math.round(template.attackRange / TD_CELL_PX))
   const tower: TDTower = {
     id: nextId(),
     col, row,
@@ -457,6 +469,8 @@ export function tickTD(state: TDGameState, dtMs: number): TDGameState {
   // ── Tower attacks ──────────────────────────────────────────────────────────
   const deadEnemyIds = new Set<number>()
   const updatedTowers: TDTower[] = []
+  // Prune expired attack events, then collect new ones this tick
+  const newAttackEvents: TDAttackEvent[] = s.attackEvents.filter(e => e.expiresAt > s.gameTimeMs)
 
   for (const tower of s.towers) {
     let cd = Math.max(0, tower.attackCooldownRemaining - dtMs)
@@ -478,11 +492,20 @@ export function tickTD(state: TDGameState, dtMs: number): TDGameState {
             s.enemies = s.enemies.map(e => e.id === target.id ? { ...e, hp: newHp } : e)
           }
         }
+        // Emit visual attack event
+        const txy = cellToXY(tower.col, tower.row)
+        newAttackEvents.push({
+          id: nextId(),
+          fromX: txy.x, fromY: txy.y,
+          toX: target.x, toY: target.y,
+          expiresAt: s.gameTimeMs + 500,
+        })
         cd = tower.template.attackCooldownMs
       }
     }
     updatedTowers.push({ ...tower, attackCooldownRemaining: cd })
   }
+  s.attackEvents = newAttackEvents
 
   s.towers = updatedTowers
   s.enemies = s.enemies.filter(e => !deadEnemyIds.has(e.id))


### PR DESCRIPTION
## Summary

- **Path scale fix** — `towerDefence.ts` had `CELL_SIZE_PX = 64` hardcoded while the component rendered at 48px. Enemies were walking along the correct logical path but visually offset because all pixel coordinates (enemy position, tower range checks, `pathIndexToXY`) were calculated at the wrong scale. Now exports `TD_CELL_PX = 48` as the single source of truth used by both files.
- **Animated enemy sprites** — `EnemyToken` now uses `AnimatedSpriteImg` (frameCount=3, fps=6) matching the city builder walker style, so enemies cycle through their walk frames as they move.
- **Attack effects** — Added `TDAttackEvent` to game state; emitted each time a tower fires (expires after 500ms). Component renders the same `anim-projectile` + `anim-hit` CSS classes used by the main battlefield — a travelling line from tower to target and a hit spark at the target.

https://claude.ai/code/session_014PWcdZxQ19J95UxKwDEvqz

---
_Generated by [Claude Code](https://claude.ai/code/session_014PWcdZxQ19J95UxKwDEvqz)_