### PR TITLE
feat(tower-defence): mana economy, wave progress bar, range preview, grid scaling

### DIFF
--- a/web/src/components/minigames/TowerDefence.tsx
+++ b/web/src/components/minigames/TowerDefence.tsx
@@ -4,7 +4,7 @@
 //   [board]   scrollable grid (fills remaining height)
 //   [panel]   horizontal unit strip + log line
 
-import React, { useState, useEffect, useRef, useCallback } from 'react'
+import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react'
 import { UnitTemplate } from '../../game/types'
 import { SpriteImg, AnimatedSpriteImg } from '../SpriteImg'
 import {
@@ -12,7 +12,7 @@ import {
   TDGameState, TDTower, TDEnemy, TDAttackEvent,
   isPathCell,
   createTDGame, placeTower, removeTower, startWave, tickTD,
-  calcTicketReward, calcGoldReward,
+  calcTicketReward, calcGoldReward, towerCost,
 } from '../../game/towerDefence'
 
 // ── Props ─────────────────────────────────────────────────────────────────────
@@ -57,13 +57,16 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
   )
   const [selected, setSelected] = useState<UnitTemplate | null>(null)
   const [hoveredTower, setHoveredTower] = useState<TDTower | null>(null)
+  const [hoveredCell, setHoveredCell] = useState<{ col: number; row: number } | null>(null)
+  const [gridScale, setGridScale] = useState(1)
 
   const gameRef = useRef(game)
   gameRef.current = game
 
-  const rafRef      = useRef<number | null>(null)
-  const lastTimeRef = useRef<number | null>(null)
-  const accRef      = useRef(0)
+  const boardWrapRef = useRef<HTMLDivElement>(null)
+  const rafRef       = useRef<number | null>(null)
+  const lastTimeRef  = useRef<number | null>(null)
+  const accRef       = useRef(0)
 
   // ── Game loop ───────────────────────────────────────────────────────────────
 
@@ -89,16 +92,35 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
     return () => { if (rafRef.current !== null) cancelAnimationFrame(rafRef.current) }
   }, [tick])
 
+  // ── Grid scaling ────────────────────────────────────────────────────────────
+
+  useEffect(() => {
+    const el = boardWrapRef.current
+    if (!el) return
+    const obs = new ResizeObserver(entries => {
+      for (const entry of entries) {
+        const w = entry.contentRect.width
+        const factor = Math.min(1, w / (TD_COLS * CELL_PX))
+        setGridScale(factor)
+      }
+    })
+    obs.observe(el)
+    return () => obs.disconnect()
+  }, [])
+
   // ── Interactions ────────────────────────────────────────────────────────────
 
   function handleCellClick(col: number, row: number) {
     const g = gameRef.current
-    if (g.phase !== 'prep' && g.phase !== 'between') return
+    if (g.phase !== 'prep' && g.phase !== 'between' && g.phase !== 'wave') return
 
     const existing = g.towers.find(t => t.col === col && t.row === row)
     if (existing) {
-      setGame(prev => removeTower(prev, existing.id))
-      setHoveredTower(null)
+      // Only allow removal during non-wave phases
+      if (g.phase === 'prep' || g.phase === 'between') {
+        setGame(prev => removeTower(prev, existing.id))
+        setHoveredTower(null)
+      }
       return
     }
 
@@ -117,11 +139,40 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
 
   // ── Derived ─────────────────────────────────────────────────────────────────
 
-  const isPlacingPhase = game.phase === 'prep' || game.phase === 'between'
+  const isPlacingPhase  = game.phase === 'prep' || game.phase === 'between'
+  const canPlaceTowers  = isPlacingPhase || game.phase === 'wave'
   const reward = mode === 'city' ? calcGoldReward(game.wavesCompleted) : calcTicketReward(game.wavesCompleted)
   const rewardLabel = mode === 'city'
     ? `${reward.toLocaleString()} 🪙 city gold`
     : `${reward} 🎫 tickets`
+
+  // Wave progress (0..1): proportion of enemies that have been spawned
+  const waveProgress = game.waveSpawnTotal > 0
+    ? (game.waveSpawnTotal - game.spawnQueue.length) / game.waveSpawnTotal
+    : 0
+
+  // Cells to highlight for range preview
+  const rangeHighlight = useMemo<Set<string>>(() => {
+    let refCol: number | null = null
+    let refRow: number | null = null
+    let rangeInCells = 1
+    if (hoveredTower) {
+      refCol = hoveredTower.col; refRow = hoveredTower.row; rangeInCells = hoveredTower.rangeInCells
+    } else if (selected && hoveredCell) {
+      refCol = hoveredCell.col; refRow = hoveredCell.row
+      rangeInCells = Math.max(1, Math.round(selected.attackRange / CELL_PX))
+    }
+    if (refCol === null || refRow === null) return new Set()
+    const cells = new Set<string>()
+    for (let r = 0; r < TD_ROWS; r++) {
+      for (let c = 0; c < TD_COLS; c++) {
+        if (Math.sqrt((c - refCol) ** 2 + (r - refRow) ** 2) <= rangeInCells) {
+          cells.add(`${c},${r}`)
+        }
+      }
+    }
+    return cells
+  }, [hoveredTower, selected, hoveredCell])
 
   // ── End screen ──────────────────────────────────────────────────────────────
 
@@ -160,6 +211,7 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
         </div>
 
         <div className="td-header-score">⭐ {game.score}</div>
+        <div className="td-header-mana">💧 {game.mana}</div>
 
         {isPlacingPhase && (
           <button className="action-btn action-btn--gold td-header-btn" onClick={handleStartWave}>
@@ -167,7 +219,10 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
           </button>
         )}
         {game.phase === 'wave' && (
-          <span className="td-header-active">⚔ Fighting…</span>
+          <div className="td-wave-progress-wrap">
+            <div className="td-wave-progress-fill" style={{ width: `${waveProgress * 100}%` }} />
+            <span className="td-wave-progress-label">⚔ {Math.round(waveProgress * 100)}%</span>
+          </div>
         )}
         {game.phase === 'between' && (
           <span className="td-header-active">⏳ Next wave…</span>
@@ -179,19 +234,32 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
       </div>
 
       {/* ── Board (scrollable) ── */}
-      <div className="td-board-wrap">
+      <div className="td-board-wrap" ref={boardWrapRef}>
+        <div
+          className="td-grid-scaler"
+          style={{
+            width: TD_COLS * CELL_PX * gridScale,
+            height: TD_ROWS * CELL_PX * gridScale,
+          }}
+        >
         <div
           className="td-grid"
-          style={{ width: TD_COLS * CELL_PX, height: TD_ROWS * CELL_PX }}
+          style={{
+            width: TD_COLS * CELL_PX,
+            height: TD_ROWS * CELL_PX,
+            transform: `scale(${gridScale})`,
+            transformOrigin: 'top left',
+          }}
         >
           {/* Cells */}
           {Array.from({ length: TD_ROWS }, (_, row) =>
             Array.from({ length: TD_COLS }, (_, col) => {
-              const onPath   = isOnPath(col, row)
-              const isStart  = col === TD_PATH[0].col && row === TD_PATH[0].row
-              const isEnd    = col === TD_PATH[TD_PATH.length - 1].col && row === TD_PATH[TD_PATH.length - 1].row
-              const tower    = game.towers.find(t => t.col === col && t.row === row)
-              const canDrop  = selected && !onPath && !tower && isPlacingPhase
+              const onPath    = isOnPath(col, row)
+              const isStart   = col === TD_PATH[0].col && row === TD_PATH[0].row
+              const isEnd     = col === TD_PATH[TD_PATH.length - 1].col && row === TD_PATH[TD_PATH.length - 1].row
+              const tower     = game.towers.find(t => t.col === col && t.row === row)
+              const canDrop   = selected && !onPath && !tower && canPlaceTowers
+              const inRange   = rangeHighlight.has(`${col},${row}`)
 
               return (
                 <div
@@ -203,11 +271,18 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
                     isEnd    ? 'td-cell--end'     : '',
                     canDrop  ? 'td-cell--droppable' : '',
                     tower    ? 'td-cell--occupied' : '',
+                    inRange  ? 'td-cell--in-range' : '',
                   ].filter(Boolean).join(' ')}
                   style={{ left: col * CELL_PX, top: row * CELL_PX, width: CELL_PX, height: CELL_PX }}
                   onClick={() => handleCellClick(col, row)}
-                  onMouseEnter={() => { if (tower) setHoveredTower(tower) }}
-                  onMouseLeave={() => setHoveredTower(null)}
+                  onMouseEnter={() => {
+                    if (tower) setHoveredTower(tower)
+                    setHoveredCell({ col, row })
+                  }}
+                  onMouseLeave={() => {
+                    setHoveredTower(null)
+                    setHoveredCell(null)
+                  }}
                 >
                   {isStart && <span className="td-cell-label">IN</span>}
                   {isEnd   && <span className="td-cell-label">BASE</span>}
@@ -252,6 +327,7 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
             </div>
           )}
         </div>
+        </div>{/* td-grid-scaler */}
       </div>
 
       {/* ── Bottom panel ── */}
@@ -260,10 +336,10 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
         <div className="td-panel-log">{lastLog}</div>
 
         {/* Hint */}
-        {isPlacingPhase && (
+        {canPlaceTowers && (
           <div className="td-panel-hint">
             {selected
-              ? `Placing ${selected.name} — tap a green cell`
+              ? `Placing ${selected.name} (💧${towerCost(selected)}) — tap a green cell`
               : 'Tap a unit below to select, then tap the grid'}
           </div>
         )}
@@ -272,8 +348,10 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
         <div className="td-unit-strip">
           {pool.map(({ template }) => {
             const remaining = game.remainingPlacements[template.name] ?? 0
+            const cost      = towerCost(template)
             const isSel     = selected?.name === template.name
-            const disabled  = !isPlacingPhase || remaining === 0
+            const cantAfford = game.mana < cost
+            const disabled  = !canPlaceTowers || remaining === 0 || cantAfford
             return (
               <button
                 key={template.name}
@@ -283,7 +361,7 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
                   disabled ? 'td-unit-chip--disabled'  : '',
                 ].filter(Boolean).join(' ')}
                 onClick={() => !disabled && handleSelectUnit(template)}
-                title={`${template.name} — ATK ${template.attack}, HP ${template.maxHp}, Range ${Math.max(1, Math.round(template.attackRange / 64))} cells`}
+                title={`${template.name} — ATK ${template.attack}, HP ${template.maxHp}, Range ${Math.max(1, Math.round(template.attackRange / CELL_PX))} cells, Cost ${cost} mana`}
               >
                 <div className="td-unit-chip-sprite">
                   <SpriteImg name={template.name} />
@@ -291,6 +369,9 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
                 <div className="td-unit-chip-name">{template.name}</div>
                 <span className={`td-unit-chip-count ${remaining === 0 ? 'td-unit-chip-count--zero' : ''}`}>
                   ×{remaining}
+                </span>
+                <span className={`td-unit-chip-cost ${cantAfford ? 'td-unit-chip-cost--unaffordable' : ''}`}>
+                  💧{cost}
                 </span>
               </button>
             )

--- a/web/src/game/towerDefence.ts
+++ b/web/src/game/towerDefence.ts
@@ -242,19 +242,19 @@ export type TDPhase = 'prep' | 'wave' | 'between' | 'victory' | 'defeat'
 export interface TDGameState {
   phase: TDPhase
   lives: number
+  mana: number                  // spendable currency (earn from kills, spend to place towers)
   wavesCompleted: number
-  currentWaveIndex: number    // index into TD_WAVES
+  currentWaveIndex: number
   gameTimeMs: number
   towers: TDTower[]
   enemies: TDEnemy[]
   spawnQueue: SpawnEntry[]
-  nextWaveAt: number          // game-time ms when next wave's first spawn fires (between phase)
+  waveSpawnTotal: number        // total spawns queued when current wave started (for progress bar)
+  nextWaveAt: number
   log: string[]
-  score: number               // enemies killed × reward
+  score: number
   attackEvents: TDAttackEvent[]
-  // Available tower pool (derived from collection or city; passed in at start)
   availableTemplates: UnitTemplate[]
-  // How many of each unit (by name) the player has left to place
   remainingPlacements: Record<string, number>
   mode: 'collection' | 'city'
 }
@@ -265,10 +265,16 @@ export const TD_MAX_LIVES = 3
 export const TD_TOTAL_WAVES = TD_WAVES.length
 /** Pixel size of each grid cell — shared with the React component. */
 export const TD_CELL_PX = 48
+export const TD_STARTING_MANA = 80
 // Between-wave pause (ms)
 const BETWEEN_WAVE_MS = 5000
 // Strength bonus multiplier
 const STRENGTH_MULT = 1.5
+
+/** Mana cost to place a tower based on its stats. */
+export function towerCost(template: UnitTemplate): number {
+  return Math.max(5, Math.round(template.attack * 2 + template.maxHp / 20))
+}
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -335,12 +341,14 @@ export function createTDGame(
   return {
     phase: 'prep',
     lives: TD_MAX_LIVES,
+    mana: TD_STARTING_MANA,
     wavesCompleted: 0,
     currentWaveIndex: 0,
     gameTimeMs: 0,
     towers: [],
     enemies: [],
     spawnQueue: [],
+    waveSpawnTotal: 0,
     nextWaveAt: 0,
     log: ['Place your towers, then press START WAVE.'],
     attackEvents: [],
@@ -363,6 +371,8 @@ export function placeTower(
   if (state.towers.some(t => t.col === col && t.row === row)) return null
   const remaining = state.remainingPlacements[template.name] ?? 0
   if (remaining <= 0) return null
+  const cost = towerCost(template)
+  if (state.mana < cost) return null
 
   const rangeInCells = Math.max(1, Math.round(template.attackRange / TD_CELL_PX))
   const tower: TDTower = {
@@ -376,12 +386,13 @@ export function placeTower(
   }
   return {
     ...state,
+    mana: state.mana - cost,
     towers: [...state.towers, tower],
     remainingPlacements: {
       ...state.remainingPlacements,
       [template.name]: remaining - 1,
     },
-    log: [...state.log.slice(-9), `Placed ${template.name}.`],
+    log: [...state.log.slice(-9), `Placed ${template.name} (-${cost} mana).`],
   }
 }
 
@@ -389,14 +400,16 @@ export function placeTower(
 export function removeTower(state: TDGameState, towerId: number): TDGameState {
   const tower = state.towers.find(t => t.id === towerId)
   if (!tower) return state
+  const refund = Math.floor(towerCost(tower.template) * 0.5)
   return {
     ...state,
+    mana: state.mana + refund,
     towers: state.towers.filter(t => t.id !== towerId),
     remainingPlacements: {
       ...state.remainingPlacements,
       [tower.template.name]: (state.remainingPlacements[tower.template.name] ?? 0) + 1,
     },
-    log: [...state.log.slice(-9), `Removed ${tower.template.name}.`],
+    log: [...state.log.slice(-9), `Removed ${tower.template.name} (+${refund} mana).`],
   }
 }
 
@@ -410,6 +423,7 @@ export function startWave(state: TDGameState): TDGameState {
     ...state,
     phase: 'wave',
     spawnQueue: queue,
+    waveSpawnTotal: queue.length,
     log: [...state.log.slice(-9), waveDef.label + '!'],
   }
 }
@@ -488,6 +502,7 @@ export function tickTD(state: TDGameState, dtMs: number): TDGameState {
           if (newHp <= 0) {
             deadEnemyIds.add(target.id)
             s.score += target.template.reward
+            s.mana += target.template.reward
           } else {
             s.enemies = s.enemies.map(e => e.id === target.id ? { ...e, hp: newHp } : e)
           }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -12057,15 +12057,51 @@ html.light-mode .action-btn {
 .td-header-lives  { font-size: 14px; letter-spacing: 1px; }
 .td-header-wave   { font-size: 12px; color: #aaa; flex: 1; text-align: center; }
 .td-header-score  { font-size: 12px; color: #4caf50; }
+.td-header-mana   { font-size: 12px; color: #64b5f6; font-weight: bold; }
 .td-header-active { font-size: 12px; color: #f90; }
 .td-header-btn    { padding: 4px 10px !important; font-size: 11px !important; }
+
+/* Wave progress bar */
+.td-wave-progress-wrap {
+  position: relative;
+  flex: 1;
+  height: 18px;
+  background: #222;
+  border: 1px solid #444;
+  border-radius: 3px;
+  overflow: hidden;
+  min-width: 60px;
+}
+.td-wave-progress-fill {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, #b71c1c, #f44336);
+  transition: width 0.3s;
+}
+.td-wave-progress-label {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 10px;
+  color: #fff;
+  text-shadow: 0 0 4px #000;
+  z-index: 1;
+}
 
 /* ── Board ── */
 .td-board-wrap {
   flex: 1;
-  overflow: auto;
+  overflow: hidden;
   min-height: 0;
   background: #0d0d0d;
+}
+
+/* Scaling wrapper — sized to the post-scale dimensions so the layout is correct */
+.td-grid-scaler {
+  overflow: hidden;
+  flex-shrink: 0;
 }
 
 /* ── Grid ── */
@@ -12092,6 +12128,8 @@ html.light-mode .action-btn {
 .td-cell--end         { background: #2b0d0d; }
 .td-cell--droppable   { background: #1e3a1e; border-color: #4caf50; box-shadow: inset 0 0 5px rgba(76,175,80,0.3); }
 .td-cell--occupied    { cursor: pointer; }
+.td-cell--in-range    { box-shadow: inset 0 0 0 2px rgba(100,181,246,0.45); background-color: rgba(100,181,246,0.08); }
+.td-cell--path.td-cell--in-range { box-shadow: inset 0 0 0 2px rgba(100,181,246,0.3); }
 .td-cell-label { font-size: 8px; color: #888; letter-spacing: 1px; pointer-events: none; }
 
 /* Tower inside cell */
@@ -12214,6 +12252,8 @@ html.light-mode .action-btn {
 }
 .td-unit-chip-count { font-size: 11px; font-weight: bold; color: #4caf50; }
 .td-unit-chip-count--zero { color: #555; }
+.td-unit-chip-cost  { font-size: 9px; color: #64b5f6; }
+.td-unit-chip-cost--unaffordable { color: #f44336; }
 
 /* ── End screen ── */
 .td-end-screen {


### PR DESCRIPTION
## Summary

- **Mana economy**: towers cost mana to place (based on ATK + HP stats), removing a tower refunds 50%. Killing enemies earns mana equal to their reward value. Starting mana is 80.
- **Placement during waves**: towers can now be placed while a wave is active, not just in prep/between phases.
- **Wave progress bar**: the header shows a red fill bar + percentage during active waves, indicating how far through the spawn queue we are.
- **Range preview overlay**: hovering a unit chip or a placed tower highlights all cells within its attack range with a blue tint overlay.
- **Grid auto-scaling**: a `ResizeObserver` on the board wrapper scales the grid down via `transform: scale()` to fit the available width on portrait/small screens — no more horizontal overflow.
- **Mana displayed in header** (💧) and **cost shown on each unit chip** (red when unaffordable).

## Test plan

- [ ] Launch tower defence from collection (arcade) and city builder
- [ ] Confirm mana counter decreases on placement, increases on kill
- [ ] Confirm can't place when mana < cost (chip turns red, placement rejected)
- [ ] Confirm placement works mid-wave
- [ ] Confirm wave progress bar advances during wave and resets between waves
- [ ] Hover a unit chip — range overlay appears on grid cells
- [ ] Hover a placed tower — its range is highlighted
- [ ] On a narrow viewport the grid scales down to fit without scrolling

https://claude.ai/code/session_014PWcdZxQ19J95UxKwDEvqz

---
_Generated by [Claude Code](https://claude.ai/code/session_014PWcdZxQ19J95UxKwDEvqz)_