### PR TITLE
feat(tower-defence): sell/move/upgrade towers, fix gold payout

### DIFF
--- a/web/src/components/minigames/TowerDefence.tsx
+++ b/web/src/components/minigames/TowerDefence.tsx
@@ -8,11 +8,11 @@ import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react'
 import { UnitTemplate } from '../../game/types'
 import { SpriteImg, AnimatedSpriteImg } from '../SpriteImg'
 import {
-  TD_COLS, TD_ROWS, TD_PATH, TD_WAVES, TD_TOTAL_WAVES, TD_MAX_LIVES, TD_CELL_PX,
+  TD_COLS, TD_ROWS, TD_PATH, TD_WAVES, TD_TOTAL_WAVES, TD_MAX_LIVES, TD_CELL_PX, TD_MAX_UPGRADES,
   TDGameState, TDTower, TDEnemy, TDAttackEvent,
   isPathCell,
-  createTDGame, placeTower, removeTower, startWave, tickTD,
-  calcTicketReward, calcGoldReward, towerCost,
+  createTDGame, placeTower, removeTower, moveTower, upgradeTower, startWave, tickTD,
+  calcTicketReward, calcGoldReward, towerCost, upgradeCost, upgradeAttackMult,
 } from '../../game/towerDefence'
 
 // ── Props ─────────────────────────────────────────────────────────────────────
@@ -57,8 +57,14 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
   )
   const [selected, setSelected] = useState<UnitTemplate | null>(null)
   const [hoveredTower, setHoveredTower] = useState<TDTower | null>(null)
+  const [selectedTowerId, setSelectedTowerId] = useState<number | null>(null)
   const [hoveredCell, setHoveredCell] = useState<{ col: number; row: number } | null>(null)
   const [gridScale, setGridScale] = useState(1)
+
+  // Always derived from game state so it stays in sync after upgrades/moves
+  const selectedTower = selectedTowerId !== null
+    ? game.towers.find(t => t.id === selectedTowerId) ?? null
+    : null
 
   const gameRef = useRef(game)
   gameRef.current = game
@@ -112,29 +118,50 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
 
   function handleCellClick(col: number, row: number) {
     const g = gameRef.current
-    if (g.phase !== 'prep' && g.phase !== 'between' && g.phase !== 'wave') return
+    if (g.phase === 'victory' || g.phase === 'defeat') return
 
-    const existing = g.towers.find(t => t.col === col && t.row === row)
-    if (existing) {
-      // Only allow removal during non-wave phases
-      if (g.phase === 'prep' || g.phase === 'between') {
-        setGame(prev => removeTower(prev, existing.id))
-        setHoveredTower(null)
+    const towerAtCell = g.towers.find(t => t.col === col && t.row === row)
+
+    // A tower is selected in move-mode: clicking an empty valid cell moves it
+    if (selectedTowerId !== null && !towerAtCell && !isOnPath(col, row)) {
+      const next = moveTower(g, selectedTowerId, col, row)
+      if (next) { setGame(next); setSelectedTowerId(null) }
+      return
+    }
+
+    // Clicking a tower: select/deselect
+    if (towerAtCell) {
+      if (selectedTowerId === towerAtCell.id) {
+        setSelectedTowerId(null)
+      } else {
+        setSelectedTowerId(towerAtCell.id)
+        setSelected(null)
       }
       return
     }
 
-    if (!selected) return
-    if (isOnPath(col, row)) return
-
+    // No tower selected, no tower at cell: place if a unit chip is chosen
+    if (!selected || isOnPath(col, row)) return
+    if (g.phase !== 'prep' && g.phase !== 'between' && g.phase !== 'wave') return
     const next = placeTower(g, selected, col, row)
     if (next) setGame(next)
+  }
+
+  function handleSellTower(tower: TDTower) {
+    setGame(prev => removeTower(prev, tower.id))
+    setSelectedTowerId(null)
+    setHoveredTower(null)
+  }
+
+  function handleUpgradeTower(tower: TDTower) {
+    setGame(prev => upgradeTower(prev, tower.id) ?? prev)
   }
 
   function handleStartWave() { setGame(prev => startWave(prev)) }
 
   function handleSelectUnit(template: UnitTemplate) {
     setSelected(prev => prev?.name === template.name ? null : template)
+    setSelectedTowerId(null)
   }
 
   // ── Derived ─────────────────────────────────────────────────────────────────
@@ -156,8 +183,9 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
     let refCol: number | null = null
     let refRow: number | null = null
     let rangeInCells = 1
-    if (hoveredTower) {
-      refCol = hoveredTower.col; refRow = hoveredTower.row; rangeInCells = hoveredTower.rangeInCells
+    const refTower = selectedTower ?? hoveredTower
+    if (refTower) {
+      refCol = refTower.col; refRow = refTower.row; rangeInCells = refTower.rangeInCells
     } else if (selected && hoveredCell) {
       refCol = hoveredCell.col; refRow = hoveredCell.row
       rangeInCells = Math.max(1, Math.round(selected.attackRange / CELL_PX))
@@ -172,7 +200,7 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
       }
     }
     return cells
-  }, [hoveredTower, selected, hoveredCell])
+  }, [selectedTower, hoveredTower, selected, hoveredCell])
 
   // ── End screen ──────────────────────────────────────────────────────────────
 
@@ -258,7 +286,12 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
               const isStart   = col === TD_PATH[0].col && row === TD_PATH[0].row
               const isEnd     = col === TD_PATH[TD_PATH.length - 1].col && row === TD_PATH[TD_PATH.length - 1].row
               const tower     = game.towers.find(t => t.col === col && t.row === row)
-              const canDrop   = selected && !onPath && !tower && canPlaceTowers
+              const isTowerSelected = tower?.id === selectedTowerId
+              // canDrop: valid placement cell, or valid move destination for selected tower
+              const canDrop   = !onPath && !tower && (
+                (selected && canPlaceTowers) ||
+                (selectedTowerId !== null)
+              )
               const inRange   = rangeHighlight.has(`${col},${row}`)
 
               return (
@@ -266,12 +299,13 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
                   key={`${col},${row}`}
                   className={[
                     'td-cell',
-                    onPath   ? 'td-cell--path'   : 'td-cell--grass',
-                    isStart  ? 'td-cell--start'  : '',
-                    isEnd    ? 'td-cell--end'     : '',
-                    canDrop  ? 'td-cell--droppable' : '',
-                    tower    ? 'td-cell--occupied' : '',
-                    inRange  ? 'td-cell--in-range' : '',
+                    onPath          ? 'td-cell--path'     : 'td-cell--grass',
+                    isStart         ? 'td-cell--start'    : '',
+                    isEnd           ? 'td-cell--end'      : '',
+                    canDrop         ? 'td-cell--droppable' : '',
+                    tower           ? 'td-cell--occupied' : '',
+                    inRange         ? 'td-cell--in-range' : '',
+                    isTowerSelected ? 'td-cell--tower-selected' : '',
                   ].filter(Boolean).join(' ')}
                   style={{ left: col * CELL_PX, top: row * CELL_PX, width: CELL_PX, height: CELL_PX }}
                   onClick={() => handleCellClick(col, row)}
@@ -289,6 +323,9 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
                   {tower && (
                     <div className="td-tower-inner">
                       <SpriteImg name={tower.template.name} />
+                      {tower.upgrades > 0 && (
+                        <div className="td-tower-tier">{'★'.repeat(tower.upgrades)}</div>
+                      )}
                       <div className="td-tower-hp-bar">
                         <div className="td-tower-hp-fill" style={{
                           width: `${(tower.hp / tower.maxHp) * 100}%`,
@@ -312,20 +349,46 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
             <AttackEffect key={ev.id} ev={ev} />
           ))}
 
-          {/* Tower tooltip overlay */}
-          {hoveredTower && (
-            <div
-              className="td-tower-tooltip"
-              style={{
-                left: hoveredTower.col * CELL_PX,
-                top: Math.max(0, hoveredTower.row * CELL_PX - 72),
-              }}
-            >
-              <strong>{hoveredTower.template.name}</strong>
-              <div>HP {hoveredTower.hp}/{hoveredTower.maxHp} · ATK {hoveredTower.template.attack} · R {hoveredTower.rangeInCells}</div>
-              {isPlacingPhase && <div className="td-tooltip-hint">Tap to remove</div>}
-            </div>
-          )}
+          {/* Tower tooltip — show for selected or hovered tower */}
+          {(selectedTower || hoveredTower) && (() => {
+            const t = selectedTower ?? hoveredTower!
+            const isSel = t.id === selectedTowerId
+            const atk = Math.round(t.template.attack * upgradeAttackMult(t.upgrades))
+            const sellRefund = Math.floor(towerCost(t.template) * 0.5)
+            const upCost = upgradeCost(t)
+            const canAffordUp = game.mana >= upCost
+            return (
+              <div
+                className="td-tower-tooltip"
+                style={{
+                  left: t.col * CELL_PX,
+                  top: Math.max(0, t.row * CELL_PX - (isSel ? 100 : 72)),
+                }}
+              >
+                <strong>{t.template.name}</strong>
+                {t.upgrades > 0 && <span className="td-tower-tier-label"> {'★'.repeat(t.upgrades)}</span>}
+                <div>HP {t.hp}/{t.maxHp} · ATK {atk} · R {t.rangeInCells}</div>
+                {isSel ? (
+                  <div className="td-tower-actions">
+                    <button className="td-tower-action-btn td-tower-action-btn--sell"
+                      onClick={e => { e.stopPropagation(); handleSellTower(t) }}>
+                      SELL +💧{sellRefund}
+                    </button>
+                    {t.upgrades < TD_MAX_UPGRADES && (
+                      <button
+                        className={`td-tower-action-btn td-tower-action-btn--upgrade${canAffordUp ? '' : ' td-tower-action-btn--disabled'}`}
+                        onClick={e => { e.stopPropagation(); if (canAffordUp) handleUpgradeTower(t) }}>
+                        ★ UP 💧{upCost}
+                      </button>
+                    )}
+                    <div className="td-tooltip-hint">Tap empty cell to move</div>
+                  </div>
+                ) : (
+                  <div className="td-tooltip-hint">Tap to select</div>
+                )}
+              </div>
+            )
+          })()}
         </div>
         </div>{/* td-grid-scaler */}
       </div>

--- a/web/src/game/towerDefence.ts
+++ b/web/src/game/towerDefence.ts
@@ -204,8 +204,8 @@ export interface TDTower {
   hp: number
   maxHp: number
   attackCooldownRemaining: number   // ms until next attack
-  // attackRange in grid cells (converted from UnitTemplate.attackRange pixels)
   rangeInCells: number
+  upgrades: number                  // 0–TD_MAX_UPGRADES
 }
 
 export interface TDEnemy {
@@ -263,10 +263,9 @@ export interface TDGameState {
 
 export const TD_MAX_LIVES = 3
 export const TD_TOTAL_WAVES = TD_WAVES.length
-/** Pixel size of each grid cell — shared with the React component. */
 export const TD_CELL_PX = 48
 export const TD_STARTING_MANA = 120
-// Between-wave pause (ms)
+export const TD_MAX_UPGRADES = 2
 const BETWEEN_WAVE_MS = 5000
 // Strength bonus multiplier
 const STRENGTH_MULT = 1.5
@@ -274,6 +273,16 @@ const STRENGTH_MULT = 1.5
 /** Mana cost to place a tower based on its stats. */
 export function towerCost(template: UnitTemplate): number {
   return Math.max(5, Math.round(template.attack * 2 + template.maxHp / 20))
+}
+
+/** Mana cost to upgrade a tower to the next tier. */
+export function upgradeCost(tower: TDTower): number {
+  return Math.round(towerCost(tower.template) * (tower.upgrades + 1))
+}
+
+/** ATK multiplier for a tower at its current upgrade tier. */
+export function upgradeAttackMult(upgrades: number): number {
+  return 1 + upgrades * 0.5
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -306,7 +315,7 @@ function towerCanHit(tower: TDTower, enemy: TDEnemy): boolean {
 }
 
 function damageDealt(tower: TDTower, enemy: TDEnemy): number {
-  let dmg = tower.template.attack
+  let dmg = Math.round(tower.template.attack * upgradeAttackMult(tower.upgrades))
   if (tower.template.strengths?.some(tag => enemy.template.tags.includes(tag))) {
     dmg = Math.round(dmg * STRENGTH_MULT)
   }
@@ -383,6 +392,7 @@ export function placeTower(
     maxHp: template.maxHp,
     attackCooldownRemaining: 0,
     rangeInCells,
+    upgrades: 0,
   }
   return {
     ...state,
@@ -410,6 +420,37 @@ export function removeTower(state: TDGameState, towerId: number): TDGameState {
       [tower.template.name]: (state.remainingPlacements[tower.template.name] ?? 0) + 1,
     },
     log: [...state.log.slice(-9), `Removed ${tower.template.name} (+${refund} mana).`],
+  }
+}
+
+/** Upgrade a tower's attack power. Returns null if not affordable or at max tier. */
+export function upgradeTower(state: TDGameState, towerId: number): TDGameState | null {
+  const tower = state.towers.find(t => t.id === towerId)
+  if (!tower) return null
+  if (tower.upgrades >= TD_MAX_UPGRADES) return null
+  const cost = upgradeCost(tower)
+  if (state.mana < cost) return null
+  return {
+    ...state,
+    mana: state.mana - cost,
+    towers: state.towers.map(t =>
+      t.id === towerId ? { ...t, upgrades: t.upgrades + 1 } : t,
+    ),
+    log: [...state.log.slice(-9), `${tower.template.name} upgraded to tier ${tower.upgrades + 1}! (-${cost} mana)`],
+  }
+}
+
+/** Move a placed tower to a new cell at no mana cost. */
+export function moveTower(state: TDGameState, towerId: number, col: number, row: number): TDGameState | null {
+  if (isPathCell(col, row)) return null
+  if (col < 0 || col >= TD_COLS || row < 0 || row >= TD_ROWS) return null
+  const tower = state.towers.find(t => t.id === towerId)
+  if (!tower) return null
+  if (state.towers.some(t => t.id !== towerId && t.col === col && t.row === row)) return null
+  return {
+    ...state,
+    towers: state.towers.map(t => t.id === towerId ? { ...t, col, row } : t),
+    log: [...state.log.slice(-9), `Moved ${tower.template.name}.`],
   }
 }
 
@@ -560,7 +601,7 @@ export function calcTicketReward(wavesCompleted: number): number {
 
 /** Compute city gold reward for city mode based on waves cleared. */
 export function calcGoldReward(wavesCompleted: number): number {
-  return wavesCompleted * 500
+  return wavesCompleted * 5
 }
 
 export { ENEMY_TEMPLATES }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -12126,10 +12126,11 @@ html.light-mode .action-btn {
 .td-cell--path        { background: #2a2008; border-color: #3a2e10; cursor: default; }
 .td-cell--start       { background: #0d2b0d; }
 .td-cell--end         { background: #2b0d0d; }
-.td-cell--droppable   { background: #1e3a1e; border-color: #4caf50; box-shadow: inset 0 0 5px rgba(76,175,80,0.3); }
-.td-cell--occupied    { cursor: pointer; }
-.td-cell--in-range    { box-shadow: inset 0 0 0 2px rgba(100,181,246,0.45); background-color: rgba(100,181,246,0.08); }
+.td-cell--droppable      { background: #1e3a1e; border-color: #4caf50; box-shadow: inset 0 0 5px rgba(76,175,80,0.3); }
+.td-cell--occupied       { cursor: pointer; }
+.td-cell--in-range       { box-shadow: inset 0 0 0 2px rgba(100,181,246,0.45); background-color: rgba(100,181,246,0.08); }
 .td-cell--path.td-cell--in-range { box-shadow: inset 0 0 0 2px rgba(100,181,246,0.3); }
+.td-cell--tower-selected { box-shadow: inset 0 0 0 2px #ffd700 !important; background-color: rgba(255,215,0,0.12) !important; }
 .td-cell-label { font-size: 8px; color: #888; letter-spacing: 1px; pointer-events: none; }
 
 /* Tower inside cell */
@@ -12149,6 +12150,7 @@ html.light-mode .action-btn {
   margin-top: 2px;
 }
 .td-tower-hp-fill { height: 100%; border-radius: 2px; transition: width 0.2s; }
+.td-tower-tier { font-size: 8px; color: #ffd700; line-height: 1; text-align: center; pointer-events: none; }
 
 /* Tower tooltip (positioned inside grid) */
 .td-tower-tooltip {
@@ -12164,6 +12166,32 @@ html.light-mode .action-btn {
   white-space: nowrap;
 }
 .td-tooltip-hint { color: #f44; font-size: 9px; margin-top: 2px; }
+.td-tower-tier-label { color: #ffd700; }
+
+/* Tower action buttons (inside tooltip) */
+.td-tower-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 4px;
+}
+.td-tower-action-btn {
+  font-family: 'Courier New', monospace;
+  font-size: 9px;
+  padding: 2px 6px;
+  border-radius: 3px;
+  border: 1px solid #555;
+  background: #1a1a1a;
+  color: #e0e0e0;
+  cursor: pointer;
+  line-height: 1.4;
+}
+.td-tower-action-btn:hover:not(.td-tower-action-btn--disabled) { background: #2a2a2a; }
+.td-tower-action-btn--sell   { border-color: #f44336; color: #f44336; }
+.td-tower-action-btn--sell:hover { background: rgba(244,67,54,0.15); }
+.td-tower-action-btn--upgrade { border-color: #ffd700; color: #ffd700; }
+.td-tower-action-btn--upgrade:hover:not(.td-tower-action-btn--disabled) { background: rgba(255,215,0,0.1); }
+.td-tower-action-btn--disabled { opacity: 0.4; cursor: not-allowed; }
 
 /* Enemies */
 .td-enemy {


### PR DESCRIPTION
## Summary

- **Sell**: tap a placed tower to select it (gold border), then tap SELL to remove it for a 50% mana refund — works at any phase including during a wave
- **Move**: while a tower is selected, tap any valid empty cell to reposition it for free
- **Upgrade (★)**: tap a selected tower's UPGRADE button to spend mana for +50% ATK; max 2 tiers; ★ stars shown on the cell and in the tooltip
- **Gold payout fix**: `calcGoldReward` was `wavesCompleted * 500`, now `* 5` (÷100)

## Interaction flow

1. Tap a tower → gold highlight + tooltip shows SELL / ★ UP buttons + "Tap empty cell to move"
2. Tap same tower again → deselects
3. While selected, tap empty valid cell → tower moves there
4. Tapping a unit chip while a tower is selected → deselects the tower and enters placement mode

## Test plan

- [ ] Tap a placed tower — it gains a gold border, tooltip shows SELL and UPGRADE buttons
- [ ] SELL returns 50% mana; tower disappears
- [ ] UPGRADE costs mana; tower gains ★ and deals more damage
- [ ] UPGRADE button greyed out when mana insufficient or tower is at max tier (★★)
- [ ] While tower selected, tap an empty grass cell — tower moves there
- [ ] All three actions work mid-wave as well as during prep
- [ ] City mode reward is now reasonable (≤ 50 gold for 10 waves)

https://claude.ai/code/session_014PWcdZxQ19J95UxKwDEvqz

---
_Generated by [Claude Code](https://claude.ai/code/session_014PWcdZxQ19J95UxKwDEvqz)_