### PR TITLE
fix(tower-defence): move tower actions to tappable panel below the grid

### DIFF
--- a/web/src/components/minigames/TowerDefence.tsx
+++ b/web/src/components/minigames/TowerDefence.tsx
@@ -349,43 +349,19 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
             <AttackEffect key={ev.id} ev={ev} />
           ))}
 
-          {/* Tower tooltip — show for selected or hovered tower */}
+          {/* Tower tooltip — hover info only, no action buttons */}
           {(selectedTower || hoveredTower) && (() => {
             const t = selectedTower ?? hoveredTower!
-            const isSel = t.id === selectedTowerId
             const atk = Math.round(t.template.attack * upgradeAttackMult(t.upgrades))
-            const sellRefund = Math.floor(towerCost(t.template) * 0.5)
-            const upCost = upgradeCost(t)
-            const canAffordUp = game.mana >= upCost
             return (
               <div
                 className="td-tower-tooltip"
-                style={{
-                  left: t.col * CELL_PX,
-                  top: Math.max(0, t.row * CELL_PX - (isSel ? 100 : 72)),
-                }}
+                style={{ left: t.col * CELL_PX, top: Math.max(0, t.row * CELL_PX - 56) }}
               >
                 <strong>{t.template.name}</strong>
                 {t.upgrades > 0 && <span className="td-tower-tier-label"> {'★'.repeat(t.upgrades)}</span>}
                 <div>HP {t.hp}/{t.maxHp} · ATK {atk} · R {t.rangeInCells}</div>
-                {isSel ? (
-                  <div className="td-tower-actions">
-                    <button className="td-tower-action-btn td-tower-action-btn--sell"
-                      onClick={e => { e.stopPropagation(); handleSellTower(t) }}>
-                      SELL +💧{sellRefund}
-                    </button>
-                    {t.upgrades < TD_MAX_UPGRADES && (
-                      <button
-                        className={`td-tower-action-btn td-tower-action-btn--upgrade${canAffordUp ? '' : ' td-tower-action-btn--disabled'}`}
-                        onClick={e => { e.stopPropagation(); if (canAffordUp) handleUpgradeTower(t) }}>
-                        ★ UP 💧{upCost}
-                      </button>
-                    )}
-                    <div className="td-tooltip-hint">Tap empty cell to move</div>
-                  </div>
-                ) : (
-                  <div className="td-tooltip-hint">Tap to select</div>
-                )}
+                {t.id !== selectedTowerId && <div className="td-tooltip-hint">Tap to select</div>}
               </div>
             )
           })()}
@@ -393,13 +369,51 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
         </div>{/* td-grid-scaler */}
       </div>
 
+      {/* ── Selected tower action panel ── */}
+      {selectedTower && (() => {
+        const t = selectedTower
+        const atk = Math.round(t.template.attack * upgradeAttackMult(t.upgrades))
+        const sellRefund = Math.floor(towerCost(t.template) * 0.5)
+        const upCost = upgradeCost(t)
+        const canAffordUp = game.mana >= upCost
+        return (
+          <div className="td-selected-panel">
+            <div className="td-selected-panel-info">
+              <strong>{t.template.name}</strong>
+              {t.upgrades > 0 && <span className="td-tower-tier-label"> {'★'.repeat(t.upgrades)}</span>}
+              <span className="td-selected-panel-stats"> · ATK {atk} · HP {t.hp}/{t.maxHp} · R {t.rangeInCells}</span>
+            </div>
+            <div className="td-selected-panel-actions">
+              <button className="td-selected-action-btn td-selected-action-btn--sell"
+                onClick={() => handleSellTower(t)}>
+                SELL +💧{sellRefund}
+              </button>
+              {t.upgrades < TD_MAX_UPGRADES ? (
+                <button
+                  className={`td-selected-action-btn td-selected-action-btn--upgrade${canAffordUp ? '' : ' td-selected-action-btn--disabled'}`}
+                  onClick={() => canAffordUp && handleUpgradeTower(t)}>
+                  ★ UPGRADE 💧{upCost}
+                </button>
+              ) : (
+                <span className="td-selected-panel-maxed">★★ MAX</span>
+              )}
+              <button className="td-selected-action-btn td-selected-action-btn--cancel"
+                onClick={() => setSelectedTowerId(null)}>
+                ✕
+              </button>
+            </div>
+            <div className="td-selected-panel-hint">Tap an empty cell on the grid to move this tower</div>
+          </div>
+        )
+      })()}
+
       {/* ── Bottom panel ── */}
       <div className="td-panel">
         {/* Log line */}
         <div className="td-panel-log">{lastLog}</div>
 
         {/* Hint */}
-        {canPlaceTowers && (
+        {canPlaceTowers && !selectedTower && (
           <div className="td-panel-hint">
             {selected
               ? `Placing ${selected.name} (💧${towerCost(selected)}) — tap a green cell`

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -12213,6 +12213,47 @@ html.light-mode .action-btn {
 }
 .td-enemy-hp-fill { height: 100%; border-radius: 2px; transition: width 0.05s; }
 
+/* ── Selected tower action panel ── */
+.td-selected-panel {
+  flex-shrink: 0;
+  background: #131a13;
+  border-top: 2px solid #ffd700;
+  border-bottom: 1px solid #333;
+  padding: 8px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.td-selected-panel-info { font-size: 13px; color: #e0e0e0; }
+.td-selected-panel-stats { color: #aaa; font-size: 11px; }
+.td-selected-panel-hint { font-size: 10px; color: #666; }
+.td-selected-panel-maxed { font-size: 12px; color: #ffd700; align-self: center; }
+.td-selected-panel-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+.td-selected-action-btn {
+  font-family: 'Courier New', monospace;
+  font-size: 12px;
+  font-weight: bold;
+  padding: 6px 14px;
+  border-radius: 4px;
+  border: 1px solid #555;
+  background: #1a1a1a;
+  color: #e0e0e0;
+  cursor: pointer;
+  letter-spacing: 0.5px;
+}
+.td-selected-action-btn:hover:not(.td-selected-action-btn--disabled) { background: #252525; }
+.td-selected-action-btn--sell    { border-color: #f44336; color: #f44336; }
+.td-selected-action-btn--sell:hover { background: rgba(244,67,54,0.12); }
+.td-selected-action-btn--upgrade { border-color: #ffd700; color: #ffd700; }
+.td-selected-action-btn--upgrade:hover:not(.td-selected-action-btn--disabled) { background: rgba(255,215,0,0.08); }
+.td-selected-action-btn--cancel  { border-color: #444; color: #777; padding: 6px 10px; }
+.td-selected-action-btn--disabled { opacity: 0.35; cursor: not-allowed; }
+
 /* ── Bottom panel ── */
 .td-panel {
   flex-shrink: 0;


### PR DESCRIPTION
## Problem

The SELL / UPGRADE buttons were rendered inside the grid which has a CSS `transform: scale()` applied. This caused the click targets to be in the wrong position, making them unresponsive to taps.

## Fix

- Removed action buttons from the in-grid tooltip entirely
- Added a new `td-selected-panel` that renders **below the board**, outside the scale transform
- Panel shows tower name, stats, SELL / ★ UPGRADE / ✕ cancel buttons at full size — easy to tap
- In-grid tooltip simplified to hover-only stats + "Tap to select" hint
- Upgrade panel also shows "★★ MAX" label when tower is fully upgraded

## Test plan

- [ ] Tap a placed tower — gold-bordered cell + action panel appears below the board
- [ ] SELL button works and returns mana
- [ ] UPGRADE button works and deducts mana; button greyed out when unaffordable
- [ ] ✕ cancel closes the panel without any action
- [ ] Tapping an empty cell while panel is open moves the tower

https://claude.ai/code/session_014PWcdZxQ19J95UxKwDEvqz

---
_Generated by [Claude Code](https://claude.ai/code/session_014PWcdZxQ19J95UxKwDEvqz)_