### PR TITLE
feat(city-builder): gold on repelled attack, higher fort costs, resident chit-chat

### DIFF
--- a/web/src/components/minigames/CityBuilder.tsx
+++ b/web/src/components/minigames/CityBuilder.tsx
@@ -350,13 +350,16 @@ const IDLE_TASK_TICKS = 80   // ~8 s of random wandering before picking a new ta
 const REST_TICKS_MIN  = 4 * IDLE_TASK_TICKS   // ~32 s — at least 4 task cycles at home
 const REST_TICKS_MAX  = 7 * IDLE_TASK_TICKS   // ~56 s
 const BUBBLE_TICKS    = 30   // 3 s — how long a task bubble stays visible
+const CHAT_TICKS      = 80   // 8 s — how long two walkers chat when they meet
+const CHAT_DIST       = ARRIVE_DIST * 2.5  // proximity to trigger chat
+const CHAT_EMOJIS     = ['😅', '😬', '😢', '🤔', '🥳', '🥱', '😎', '🤣', '😍', '🥰', '🤩', '😤', '🤬', '🤯', '🥵']
 const ATTACK_WARN_MS  = 30 * 60 * 1000  // show panic tasks when attack < 30 min away
 const PATROL_DEFENSE_PER_WALKER = 5     // defense units added per patrolling resident
 const TASK_RESOURCE_GOLD: Partial<Record<ResourceType, number>> = {
   wheat: 2, wood: 2, ore: 3, bread: 4, planks: 4, metal: 5,
 }
 
-type TaskType = 'idle' | 'resting' | 'eating' | 'patrolling' | 'gathering' | 'visiting' | 'playing'
+type TaskType = 'idle' | 'resting' | 'eating' | 'patrolling' | 'gathering' | 'visiting' | 'playing' | 'chatting'
 
 interface WalkerTask {
   type:             TaskType
@@ -723,95 +726,139 @@ export function CityBuilder({ onBack }: Props) {
       const overlayW = _w || CITY_COLS * CELL_PX
       const overlayH = _h || CITY_ROWS * CELL_PX
 
-      setWalkers(prev => prev.map(w => {
-        // ── Resting at home ──────────────────────────────────────────────────
-        if (w.hidden) {
-          const hiddenTimer = w.hiddenTimer - 1
-          if (hiddenTimer <= 0) {
-            const task = pickTask(w, prev, cityRef.current, overlayW, overlayH)
-            const bubbleTimer = task.type !== 'idle' ? BUBBLE_TICKS : 0
-            return {
-              ...w, hidden: false, hiddenTimer: 0,
-              task, taskTimer: task.type === 'idle' ? IDLE_TASK_TICKS + Math.floor(Math.random() * IDLE_TASK_TICKS) : 0,
-              bubbleTimer,
-            }
-          }
-          return { ...w, hiddenTimer }
-        }
-
-        let { x, y, vx, vy, turnTimer, task, taskTimer, bubbleTimer } = w
-        bubbleTimer = Math.max(0, bubbleTimer - 1)
-
-        // ── Update visiting target to follow the other walker ─────────────────
-        if (task.type === 'visiting' && task.targetWalkerKey) {
-          const [ci, ui] = task.targetWalkerKey.split('-').map(Number)
+      setWalkers(prev => {
+        // ── Pass 1: find visiting walkers close enough to trigger chat ────────
+        const chatPairs = new Map<string, string>()  // walkerKey → emoji
+        for (const w of prev) {
+          if (w.hidden || w.task.type !== 'visiting' || !w.task.targetWalkerKey) continue
+          const wKey = `${w.cellIndex}-${w.unitIndex}`
+          if (chatPairs.has(wKey)) continue
+          const [ci, ui] = w.task.targetWalkerKey.split('-').map(Number)
           const target = prev.find(o => o.cellIndex === ci && o.unitIndex === ui && !o.hidden)
-          if (target) {
-            task = { ...task, targetX: target.x, targetY: target.y }
-          } else {
-            task = pickTask(w, prev, cityRef.current, overlayW, overlayH)
-            taskTimer = task.type === 'idle' ? IDLE_TASK_TICKS + Math.floor(Math.random() * IDLE_TASK_TICKS) : 0
-            if (task.type !== 'idle') bubbleTimer = BUBBLE_TICKS
+          if (!target || target.task.type === 'chatting') continue
+          const dx = target.x - w.x
+          const dy = target.y - w.y
+          if (Math.sqrt(dx * dx + dy * dy) < CHAT_DIST) {
+            const tKey = `${target.cellIndex}-${target.unitIndex}`
+            chatPairs.set(wKey, CHAT_EMOJIS[Math.floor(Math.random() * CHAT_EMOJIS.length)])
+            chatPairs.set(tKey, CHAT_EMOJIS[Math.floor(Math.random() * CHAT_EMOJIS.length)])
           }
         }
 
-        // ── Idle: count down and pick a new task when timer expires ──────────
-        if (task.type === 'idle') {
-          taskTimer--
-          if (taskTimer <= 0) {
-            task = pickTask(w, prev, cityRef.current, overlayW, overlayH)
-            taskTimer = task.type === 'idle' ? IDLE_TASK_TICKS + Math.floor(Math.random() * IDLE_TASK_TICKS) : 0
-            if (task.type !== 'idle') bubbleTimer = BUBBLE_TICKS
-          }
-        }
+        // ── Pass 2: update each walker ────────────────────────────────────────
+        return prev.map(w => {
+          const wKey = `${w.cellIndex}-${w.unitIndex}`
 
-        // ── Directed movement ────────────────────────────────────────────────
-        if (task.type !== 'idle' && task.targetX !== undefined && task.targetY !== undefined) {
-          const dx = task.targetX - x
-          const dy = task.targetY - y
-          const dist = Math.sqrt(dx * dx + dy * dy)
-
-          if (dist < ARRIVE_DIST) {
-            // Arrived!
-            if (task.type === 'resting') {
+          // ── Resting at home ────────────────────────────────────────────────
+          if (w.hidden) {
+            const hiddenTimer = w.hiddenTimer - 1
+            if (hiddenTimer <= 0) {
+              const task = pickTask(w, prev, cityRef.current, overlayW, overlayH)
+              const bubbleTimer = task.type !== 'idle' ? BUBBLE_TICKS : 0
               return {
-                ...w, x, y, vx: 0, vy: 0, task, bubbleTimer,
-                hidden: true,
-                hiddenTimer: REST_TICKS_MIN + Math.floor(Math.random() * (REST_TICKS_MAX - REST_TICKS_MIN)),
+                ...w, hidden: false, hiddenTimer: 0,
+                task, taskTimer: task.type === 'idle' ? IDLE_TASK_TICKS + Math.floor(Math.random() * IDLE_TASK_TICKS) : 0,
+                bubbleTimer,
               }
             }
-            // For all other tasks: pick new task immediately
-            task = pickTask(w, prev, cityRef.current, overlayW, overlayH)
-            taskTimer = task.type === 'idle' ? IDLE_TASK_TICKS + Math.floor(Math.random() * IDLE_TASK_TICKS) : 0
-            if (task.type !== 'idle') bubbleTimer = BUBBLE_TICKS
-            // Keep moving with current velocity until next tick steers differently
-          } else {
-            vx = (dx / dist) * SPEED
-            vy = (dy / dist) * SPEED
+            return { ...w, hiddenTimer }
           }
-        }
 
-        // ── Apply movement ───────────────────────────────────────────────────
-        x += vx
-        y += vy
-        if (x < 0)                    { x = 0;                    vx = Math.abs(vx) }
-        if (x > overlayW - UNIT_SIZE) { x = overlayW - UNIT_SIZE; vx = -Math.abs(vx) }
-        if (y < 0)                    { y = 0;                    vy = Math.abs(vy) }
-        if (y > overlayH - UNIT_SIZE) { y = overlayH - UNIT_SIZE; vy = -Math.abs(vy) }
-
-        // Random direction changes for idle wandering only
-        if (task.type === 'idle') {
-          turnTimer--
-          if (turnTimer <= 0) {
-            const angle = Math.random() * Math.PI * 2
-            vx = Math.cos(angle) * SPEED
-            vy = Math.sin(angle) * SPEED
-            turnTimer = 20 + Math.floor(Math.random() * 30)
+          // ── Start chatting (triggered by Pass 1) ───────────────────────────
+          if (chatPairs.has(wKey) && w.task.type !== 'chatting') {
+            return {
+              ...w, vx: 0, vy: 0,
+              task: { type: 'chatting', label: chatPairs.get(wKey)! },
+              taskTimer: CHAT_TICKS,
+              bubbleTimer: CHAT_TICKS,
+            }
           }
-        }
 
-        return { ...w, x, y, vx, vy, turnTimer, task, taskTimer, bubbleTimer }
-      }))
+          let { x, y, vx, vy, turnTimer, task, taskTimer, bubbleTimer } = w
+          bubbleTimer = Math.max(0, bubbleTimer - 1)
+
+          // ── Chatting: count down, then resume ──────────────────────────────
+          if (task.type === 'chatting') {
+            taskTimer--
+            if (taskTimer <= 0) {
+              task = pickTask(w, prev, cityRef.current, overlayW, overlayH)
+              taskTimer = task.type === 'idle' ? IDLE_TASK_TICKS + Math.floor(Math.random() * IDLE_TASK_TICKS) : 0
+              bubbleTimer = BUBBLE_TICKS
+              const angle = Math.random() * Math.PI * 2
+              vx = Math.cos(angle) * SPEED
+              vy = Math.sin(angle) * SPEED
+            }
+            return { ...w, vx, vy, task, taskTimer, bubbleTimer }
+          }
+
+          // ── Update visiting target to follow the other walker ──────────────
+          if (task.type === 'visiting' && task.targetWalkerKey) {
+            const [ci, ui] = task.targetWalkerKey.split('-').map(Number)
+            const target = prev.find(o => o.cellIndex === ci && o.unitIndex === ui && !o.hidden)
+            if (target) {
+              task = { ...task, targetX: target.x, targetY: target.y }
+            } else {
+              task = pickTask(w, prev, cityRef.current, overlayW, overlayH)
+              taskTimer = task.type === 'idle' ? IDLE_TASK_TICKS + Math.floor(Math.random() * IDLE_TASK_TICKS) : 0
+              if (task.type !== 'idle') bubbleTimer = BUBBLE_TICKS
+            }
+          }
+
+          // ── Idle: count down and pick a new task when timer expires ────────
+          if (task.type === 'idle') {
+            taskTimer--
+            if (taskTimer <= 0) {
+              task = pickTask(w, prev, cityRef.current, overlayW, overlayH)
+              taskTimer = task.type === 'idle' ? IDLE_TASK_TICKS + Math.floor(Math.random() * IDLE_TASK_TICKS) : 0
+              if (task.type !== 'idle') bubbleTimer = BUBBLE_TICKS
+            }
+          }
+
+          // ── Directed movement ──────────────────────────────────────────────
+          if (task.type !== 'idle' && task.targetX !== undefined && task.targetY !== undefined) {
+            const dx = task.targetX - x
+            const dy = task.targetY - y
+            const dist = Math.sqrt(dx * dx + dy * dy)
+
+            if (dist < ARRIVE_DIST) {
+              if (task.type === 'resting') {
+                return {
+                  ...w, x, y, vx: 0, vy: 0, task, bubbleTimer,
+                  hidden: true,
+                  hiddenTimer: REST_TICKS_MIN + Math.floor(Math.random() * (REST_TICKS_MAX - REST_TICKS_MIN)),
+                }
+              }
+              task = pickTask(w, prev, cityRef.current, overlayW, overlayH)
+              taskTimer = task.type === 'idle' ? IDLE_TASK_TICKS + Math.floor(Math.random() * IDLE_TASK_TICKS) : 0
+              if (task.type !== 'idle') bubbleTimer = BUBBLE_TICKS
+            } else {
+              vx = (dx / dist) * SPEED
+              vy = (dy / dist) * SPEED
+            }
+          }
+
+          // ── Apply movement ─────────────────────────────────────────────────
+          x += vx
+          y += vy
+          if (x < 0)                    { x = 0;                    vx = Math.abs(vx) }
+          if (x > overlayW - UNIT_SIZE) { x = overlayW - UNIT_SIZE; vx = -Math.abs(vx) }
+          if (y < 0)                    { y = 0;                    vy = Math.abs(vy) }
+          if (y > overlayH - UNIT_SIZE) { y = overlayH - UNIT_SIZE; vy = -Math.abs(vy) }
+
+          // Random direction changes for idle wandering only
+          if (task.type === 'idle') {
+            turnTimer--
+            if (turnTimer <= 0) {
+              const angle = Math.random() * Math.PI * 2
+              vx = Math.cos(angle) * SPEED
+              vy = Math.sin(angle) * SPEED
+              turnTimer = 20 + Math.floor(Math.random() * 30)
+            }
+          }
+
+          return { ...w, x, y, vx, vy, turnTimer, task, taskTimer, bubbleTimer }
+        })
+      })
 
       // Animate builder walkers
       setBuilderWalkers(prev => prev.map(b => {
@@ -1677,6 +1724,9 @@ export function CityBuilder({ onBack }: Props) {
               {attackReport.outcome === 'repelled' && (
                 <div className="city-attack-good">Your defences held! Minor wall damage only.</div>
               )}
+              {attackReport.goldEarned > 0 && (
+                <div className="city-attack-good">🪙 +{attackReport.goldEarned.toLocaleString()} gold — enemy loot seized!</div>
+              )}
               {attackReport.stolenGold > 0 && (
                 <div className="city-attack-bad">⚙ {attackReport.stolenGold.toLocaleString()} gold stolen</div>
               )}
@@ -1991,7 +2041,10 @@ export function CityBuilder({ onBack }: Props) {
                 onClick={e => { e.stopPropagation(); setSelectedWalkerCell(w.cellIndex) }}
                 onKeyDown={e => { if (e.key === 'Enter') { e.stopPropagation(); setSelectedWalkerCell(w.cellIndex) } }}
               >
-                {showTaskBubble && (
+                {w.task.type === 'chatting' && (
+                  <div className="city-chat-bubble">{w.task.label}</div>
+                )}
+                {showTaskBubble && w.task.type !== 'chatting' && (
                   <div className="city-task-bubble">{w.task.label}</div>
                 )}
                 {!showTaskBubble && wantsFriend && (

--- a/web/src/components/minigames/TowerDefence.tsx
+++ b/web/src/components/minigames/TowerDefence.tsx
@@ -349,43 +349,19 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
             <AttackEffect key={ev.id} ev={ev} />
           ))}
 
-          {/* Tower tooltip — show for selected or hovered tower */}
+          {/* Tower tooltip — hover info only, no action buttons */}
           {(selectedTower || hoveredTower) && (() => {
             const t = selectedTower ?? hoveredTower!
-            const isSel = t.id === selectedTowerId
             const atk = Math.round(t.template.attack * upgradeAttackMult(t.upgrades))
-            const sellRefund = Math.floor(towerCost(t.template) * 0.5)
-            const upCost = upgradeCost(t)
-            const canAffordUp = game.mana >= upCost
             return (
               <div
                 className="td-tower-tooltip"
-                style={{
-                  left: t.col * CELL_PX,
-                  top: Math.max(0, t.row * CELL_PX - (isSel ? 100 : 72)),
-                }}
+                style={{ left: t.col * CELL_PX, top: Math.max(0, t.row * CELL_PX - 56) }}
               >
                 <strong>{t.template.name}</strong>
                 {t.upgrades > 0 && <span className="td-tower-tier-label"> {'★'.repeat(t.upgrades)}</span>}
                 <div>HP {t.hp}/{t.maxHp} · ATK {atk} · R {t.rangeInCells}</div>
-                {isSel ? (
-                  <div className="td-tower-actions">
-                    <button className="td-tower-action-btn td-tower-action-btn--sell"
-                      onClick={e => { e.stopPropagation(); handleSellTower(t) }}>
-                      SELL +💧{sellRefund}
-                    </button>
-                    {t.upgrades < TD_MAX_UPGRADES && (
-                      <button
-                        className={`td-tower-action-btn td-tower-action-btn--upgrade${canAffordUp ? '' : ' td-tower-action-btn--disabled'}`}
-                        onClick={e => { e.stopPropagation(); if (canAffordUp) handleUpgradeTower(t) }}>
-                        ★ UP 💧{upCost}
-                      </button>
-                    )}
-                    <div className="td-tooltip-hint">Tap empty cell to move</div>
-                  </div>
-                ) : (
-                  <div className="td-tooltip-hint">Tap to select</div>
-                )}
+                {t.id !== selectedTowerId && <div className="td-tooltip-hint">Tap to select</div>}
               </div>
             )
           })()}
@@ -393,13 +369,51 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
         </div>{/* td-grid-scaler */}
       </div>
 
+      {/* ── Selected tower action panel ── */}
+      {selectedTower && (() => {
+        const t = selectedTower
+        const atk = Math.round(t.template.attack * upgradeAttackMult(t.upgrades))
+        const sellRefund = Math.floor(towerCost(t.template) * 0.5)
+        const upCost = upgradeCost(t)
+        const canAffordUp = game.mana >= upCost
+        return (
+          <div className="td-selected-panel">
+            <div className="td-selected-panel-info">
+              <strong>{t.template.name}</strong>
+              {t.upgrades > 0 && <span className="td-tower-tier-label"> {'★'.repeat(t.upgrades)}</span>}
+              <span className="td-selected-panel-stats"> · ATK {atk} · HP {t.hp}/{t.maxHp} · R {t.rangeInCells}</span>
+            </div>
+            <div className="td-selected-panel-actions">
+              <button className="td-selected-action-btn td-selected-action-btn--sell"
+                onClick={() => handleSellTower(t)}>
+                SELL +💧{sellRefund}
+              </button>
+              {t.upgrades < TD_MAX_UPGRADES ? (
+                <button
+                  className={`td-selected-action-btn td-selected-action-btn--upgrade${canAffordUp ? '' : ' td-selected-action-btn--disabled'}`}
+                  onClick={() => canAffordUp && handleUpgradeTower(t)}>
+                  ★ UPGRADE 💧{upCost}
+                </button>
+              ) : (
+                <span className="td-selected-panel-maxed">★★ MAX</span>
+              )}
+              <button className="td-selected-action-btn td-selected-action-btn--cancel"
+                onClick={() => setSelectedTowerId(null)}>
+                ✕
+              </button>
+            </div>
+            <div className="td-selected-panel-hint">Tap an empty cell on the grid to move this tower</div>
+          </div>
+        )
+      })()}
+
       {/* ── Bottom panel ── */}
       <div className="td-panel">
         {/* Log line */}
         <div className="td-panel-log">{lastLog}</div>
 
         {/* Hint */}
-        {canPlaceTowers && (
+        {canPlaceTowers && !selectedTower && (
           <div className="td-panel-hint">
             {selected
               ? `Placing ${selected.name} (💧${towerCost(selected)}) — tap a green cell`

--- a/web/src/game/cityBuilder.ts
+++ b/web/src/game/cityBuilder.ts
@@ -78,11 +78,11 @@ export const FORT_DEFENSE: Record<CardRarity, number> = {
 
 /** Gold + resource cost to build a fortification of each rarity. */
 export const FORT_PLACE_COST: Record<CardRarity, { gold: number } & Partial<ResourceStock>> = {
-  common:    { gold: 200,   wood: 15 },
-  uncommon:  { gold: 600,   wood: 30, ore: 10 },
-  rare:      { gold: 2000,  wood: 75, ore: 30 },
-  epic:      { gold: 6000,  wood: 150, ore: 75, planks: 20 },
-  legendary: { gold: 15000, wood: 300, ore: 150, planks: 60 },
+  common:    { gold: 1000,   wood: 25 },
+  uncommon:  { gold: 3500,   wood: 50,  ore: 20 },
+  rare:      { gold: 12000,  wood: 120, ore: 50 },
+  epic:      { gold: 40000,  wood: 250, ore: 120, planks: 35 },
+  legendary: { gold: 100000, wood: 500, ore: 250, planks: 100 },
 }
 
 /** HP repaired per minute per fortification (1 HP every 5 minutes). */
@@ -203,6 +203,7 @@ export interface AttackEvent {
   defense:             number
   outcome:             'repelled' | 'partial' | 'defeated'
   stolenGold:          number
+  goldEarned:          number   // loot dropped by attacker on successful defence
   destroyedBuildings:  string[]
 }
 
@@ -420,9 +421,12 @@ function processAttack(state: CityState): CityState {
   const destroyedBuildings: string[] = []
   let fortDmg: number
 
+  let goldEarned = 0
   if (ratio >= 1.0) {
     outcome = 'repelled'
     fortDmg = 5 + Math.floor(Math.random() * 10)
+    goldEarned = 10000 + Math.floor(Math.random() * 15001)
+    newGold += goldEarned
   } else if (ratio >= 0.6) {
     outcome = 'partial'
     fortDmg = 15 + Math.floor(Math.random() * 20)
@@ -468,6 +472,7 @@ function processAttack(state: CityState): CityState {
     defense,
     outcome,
     stolenGold,
+    goldEarned,
     destroyedBuildings,
   }
 

--- a/web/src/game/towerDefence.ts
+++ b/web/src/game/towerDefence.ts
@@ -5,47 +5,41 @@ import { UnitTemplate, UnitTag } from './types'
 
 // ── Grid ──────────────────────────────────────────────────────────────────────
 
-export const TD_COLS = 13
-export const TD_ROWS = 7
+export const TD_COLS = 7
+export const TD_ROWS = 13
 
 export type GridPos = { col: number; row: number }
 
-// Path as ordered grid positions (enemies walk this route left → right).
-// Shape: enters top-left, winds down, exits bottom-right.
+// Portrait path: enters top-left, winds down through 7×13 grid, exits bottom-right.
 export const TD_PATH: GridPos[] = [
-  { col: 0, row: 0 },
-  { col: 1, row: 0 },
-  { col: 2, row: 0 },
-  { col: 3, row: 0 },
-  { col: 3, row: 1 },
-  { col: 3, row: 2 },
-  { col: 2, row: 2 },
-  { col: 1, row: 2 },
-  { col: 0, row: 2 },
-  { col: 0, row: 3 },
-  { col: 0, row: 4 },
-  { col: 1, row: 4 },
-  { col: 2, row: 4 },
-  { col: 3, row: 4 },
-  { col: 4, row: 4 },
-  { col: 5, row: 4 },
-  { col: 5, row: 3 },
-  { col: 5, row: 2 },
-  { col: 6, row: 2 },
-  { col: 7, row: 2 },
-  { col: 8, row: 2 },
-  { col: 8, row: 1 },
-  { col: 8, row: 0 },
-  { col: 9, row: 0 },
-  { col: 10, row: 0 },
-  { col: 10, row: 1 },
-  { col: 10, row: 2 },
-  { col: 10, row: 3 },
-  { col: 10, row: 4 },
-  { col: 10, row: 5 },
-  { col: 10, row: 6 },
-  { col: 11, row: 6 },
-  { col: 12, row: 6 },
+  // Right along row 0
+  { col: 0, row: 0 }, { col: 1, row: 0 }, { col: 2, row: 0 }, { col: 3, row: 0 }, { col: 4, row: 0 },
+  // Down col 4
+  { col: 4, row: 1 }, { col: 4, row: 2 },
+  // Left along row 2
+  { col: 3, row: 2 }, { col: 2, row: 2 }, { col: 1, row: 2 },
+  // Down col 1
+  { col: 1, row: 3 }, { col: 1, row: 4 }, { col: 1, row: 5 },
+  // Right along row 5
+  { col: 2, row: 5 }, { col: 3, row: 5 }, { col: 4, row: 5 }, { col: 5, row: 5 },
+  // Up col 5
+  { col: 5, row: 4 }, { col: 5, row: 3 },
+  // Right to col 6
+  { col: 6, row: 3 },
+  // Down col 6
+  { col: 6, row: 4 }, { col: 6, row: 5 }, { col: 6, row: 6 }, { col: 6, row: 7 },
+  // Left along row 7
+  { col: 5, row: 7 }, { col: 4, row: 7 }, { col: 3, row: 7 }, { col: 2, row: 7 },
+  // Down col 2
+  { col: 2, row: 8 }, { col: 2, row: 9 },
+  // Right along row 9
+  { col: 3, row: 9 }, { col: 4, row: 9 }, { col: 5, row: 9 }, { col: 6, row: 9 },
+  // Down col 6
+  { col: 6, row: 10 }, { col: 6, row: 11 },
+  // Left along row 11
+  { col: 5, row: 11 }, { col: 4, row: 11 }, { col: 3, row: 11 },
+  // Down col 3 to row 12, then right to exit
+  { col: 3, row: 12 }, { col: 4, row: 12 }, { col: 5, row: 12 }, { col: 6, row: 12 },
 ]
 
 // Set of path cells for O(1) lookup

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -12213,6 +12213,47 @@ html.light-mode .action-btn {
 }
 .td-enemy-hp-fill { height: 100%; border-radius: 2px; transition: width 0.05s; }
 
+/* ── Selected tower action panel ── */
+.td-selected-panel {
+  flex-shrink: 0;
+  background: #131a13;
+  border-top: 2px solid #ffd700;
+  border-bottom: 1px solid #333;
+  padding: 8px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.td-selected-panel-info { font-size: 13px; color: #e0e0e0; }
+.td-selected-panel-stats { color: #aaa; font-size: 11px; }
+.td-selected-panel-hint { font-size: 10px; color: #666; }
+.td-selected-panel-maxed { font-size: 12px; color: #ffd700; align-self: center; }
+.td-selected-panel-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+.td-selected-action-btn {
+  font-family: 'Courier New', monospace;
+  font-size: 12px;
+  font-weight: bold;
+  padding: 6px 14px;
+  border-radius: 4px;
+  border: 1px solid #555;
+  background: #1a1a1a;
+  color: #e0e0e0;
+  cursor: pointer;
+  letter-spacing: 0.5px;
+}
+.td-selected-action-btn:hover:not(.td-selected-action-btn--disabled) { background: #252525; }
+.td-selected-action-btn--sell    { border-color: #f44336; color: #f44336; }
+.td-selected-action-btn--sell:hover { background: rgba(244,67,54,0.12); }
+.td-selected-action-btn--upgrade { border-color: #ffd700; color: #ffd700; }
+.td-selected-action-btn--upgrade:hover:not(.td-selected-action-btn--disabled) { background: rgba(255,215,0,0.08); }
+.td-selected-action-btn--cancel  { border-color: #444; color: #777; padding: 6px 10px; }
+.td-selected-action-btn--disabled { opacity: 0.35; cursor: not-allowed; }
+
 /* ── Bottom panel ── */
 .td-panel {
   flex-shrink: 0;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -9629,6 +9629,36 @@ html.light-mode .action-btn {
   border-top-color: #5080c0;
 }
 
+/* Chat bubble — shown when two residents stop to talk */
+.city-chat-bubble {
+  position: absolute;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #1a1a2e;
+  border: 1px solid #9060d0;
+  border-radius: 50%;
+  width: 22px;
+  height: 22px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+  pointer-events: none;
+  animation: city-bubble-pulse 1.5s ease-in-out infinite;
+  box-shadow: 0 0 6px rgba(150, 80, 220, 0.5);
+}
+
+.city-chat-bubble::after {
+  content: '';
+  position: absolute;
+  bottom: -5px;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 4px solid transparent;
+  border-top-color: #9060d0;
+}
+
 /* ── Picker resource cost ─────────────────────────────────────────────────── */
 
 .city-picker-cost {


### PR DESCRIPTION
Closes #1034, #1035, #1036, #1041

## #1035 — Attacker drops gold on failed assault
Repelled attacks now add **10,000–25,000 gold** to the city treasury (loot dropped by the retreating attacker). Shown as a green line in the attack report: *"🪙 +X gold — enemy loot seized!"*

## #1036 — Fortification build costs raised
| Rarity | Before | After |
|---|---|---|
| Common | 200g, 15w | 1,000g, 25w |
| Uncommon | 600g, 30w, 10o | 3,500g, 50w, 20o |
| Rare | 2,000g, 75w, 30o | 12,000g, 120w, 50o |
| Epic | 6,000g, 150w, 75o, 20p | 40,000g, 250w, 120o, 35p |
| Legendary | 15,000g, 300w, 150o, 60p | 100,000g, 500w, 250o, 100p |

## #1041 — Resident chit-chat
When a visiting walker gets close to their target resident, both stop for ~8 seconds and show a round purple emoji speech bubble (randomly chosen from 😅😬😢🤔🥳🥱😎🤣😍🥰🤩😤🤬🤯🥵). After the timer expires both pick a new task and walk off. Uses a two-pass update: pass 1 detects chat pairs, pass 2 updates all walkers.

## Test plan
- [ ] Trigger or simulate a repelled attack — gold counter increases by 10k–25k and attack report shows green line
- [ ] Try to build a common fortification — confirm cost is now 1,000 gold
- [ ] Watch residents until two walkers meet — both should freeze with emoji bubbles for ~8s then walk away
- [ ] No console errors, walkers still eat/gather/patrol normally after chatting

https://claude.ai/code/session_014PWcdZxQ19J95UxKwDEvqz

---
_Generated by [Claude Code](https://claude.ai/code/session_014PWcdZxQ19J95UxKwDEvqz)_