### PR TITLE
feat(city-builder): show estimated attack strength on incoming attack warning

### DIFF
--- a/web/src/components/minigames/CityBuilder.tsx
+++ b/web/src/components/minigames/CityBuilder.tsx
@@ -1159,6 +1159,16 @@ export function CityBuilder({ onBack }: Props) {
   const attackCountdown = formatCountdown(msToAttack)
   const attackUrgency = msToAttack < 3_600_000 ? 'imminent' : msToAttack < 10_800_000 ? 'soon' : 'calm'
 
+  // Estimate incoming attack strength (mirrors processAttack formula)
+  const occupiedCount = city.grid.filter(c => c != null).length
+  const attackPowerMid = 20 + occupiedCount * 3 + 12  // midpoint of rand(25)
+  const attackRatio = defense / Math.max(attackPowerMid, 1)
+  const attackStrengthLabel =
+    attackRatio >= 1.5 ? { text: 'Weak',       cls: 'strength--weak'   } :
+    attackRatio >= 1.0 ? { text: 'Moderate',   cls: 'strength--mod'    } :
+    attackRatio >= 0.6 ? { text: 'Strong',     cls: 'strength--strong' } :
+                         { text: 'Overwhelming', cls: 'strength--overwhelm' }
+
   // ── Fortify sub-screen ────────────────────────────────────────────────────────
 
   if (screen === 'fortify') {
@@ -1947,6 +1957,7 @@ export function CityBuilder({ onBack }: Props) {
       <div className="city-header">
                        <div className={`city-attack-pill city-attack-pill--${attackUrgency}`}>    
           ⚔ ATTACK INCOMING {msToAttack <= 0 ? 'NOW!' : attackCountdown}
+          <span className={`city-attack-strength ${attackStrengthLabel.cls}`}>{attackStrengthLabel.text}</span>
         
                   </div>
                 <div className="city-header-right">

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -9083,6 +9083,22 @@ html.light-mode .action-btn {
 .city-attack-pill--soon     { color: #c08020; }
 .city-attack-pill--imminent { color: #d06030; animation: city-pulse 1.2s ease-in-out infinite; }
 
+/* Attack strength badge inside the pill */
+.city-attack-strength {
+  display: inline-block;
+  margin-left: 6px;
+  font-size: 10px;
+  font-weight: bold;
+  padding: 1px 5px;
+  border-radius: 3px;
+  letter-spacing: 0.5px;
+  vertical-align: middle;
+}
+.strength--weak      { background: rgba(76,175,80,0.2);  color: #4caf50; border: 1px solid #4caf50; }
+.strength--mod       { background: rgba(255,193,7,0.15); color: #ffc107; border: 1px solid #ffc107; }
+.strength--strong    { background: rgba(255,87,34,0.15); color: #ff5722; border: 1px solid #ff5722; }
+.strength--overwhelm { background: rgba(176,0,32,0.2);  color: #ff1744; border: 1px solid #ff1744; }
+
 .city-info-chip {
   font-size: 11px;
   color: #608060;


### PR DESCRIPTION
## Summary

The "⚔ ATTACK INCOMING" pill now shows a colour-coded strength badge next to the countdown:

| Badge | Meaning | Colour |
|---|---|---|
| **Weak** | Defence comfortably wins (ratio ≥ 1.5×) | Green |
| **Moderate** | Defence likely holds (ratio ≥ 1.0×) | Yellow |
| **Strong** | Attacker probably breaks through (ratio ≥ 0.6×) | Orange |
| **Overwhelming** | City will likely be defeated (ratio < 0.6×) | Red |

Strength is estimated using the same power formula as `processAttack` (`20 + occupiedCells × 3 + 12` midpoint jitter) compared against the current `cityDefense()` value.

## Test plan

- [ ] With strong defences — badge shows **Weak** in green
- [ ] With weak/no defences — badge shows **Overwhelming** in red
- [ ] Badge updates live as fortifications are built or destroyed
- [ ] Attack pill still animates correctly at each urgency level

https://claude.ai/code/session_014PWcdZxQ19J95UxKwDEvqz

---
_Generated by [Claude Code](https://claude.ai/code/session_014PWcdZxQ19J95UxKwDEvqz)_