### PR TITLE
Tower defence: buildings spawn walking units that fight on the path

### DIFF
--- a/web/src/game/towerDefence.ts
+++ b/web/src/game/towerDefence.ts
@@ -282,23 +282,51 @@ export function upgradeAttackMult(upgrades: number): number {
 
 /**
  * Generate wave definition for any wave index 0–(TD_TOTAL_WAVES-1).
- * Cycles through TD_WAVES with escalating HP and count per 10-wave cycle.
+ *
+ * Waves 1–10 use the base definitions directly.
+ * Wave 11 onward is cumulative: it starts from wave 10's content and for every
+ * wave after that we add the corresponding base wave cycling through 1–10.
+ *   wave 11 = wave 10 + wave 1
+ *   wave 12 = wave 11 + wave 2
+ *   …
+ *   wave 20 = wave 19 + wave 10  (= all base waves combined)
+ *   wave 100 ≈ wave 10 × 10
  */
 function generateWave(waveIndex: number): WaveDefinition {
-  const baseIdx = waveIndex % TD_WAVES.length
-  const cycle   = Math.floor(waveIndex / TD_WAVES.length)
-  const base    = TD_WAVES[baseIdx]
-  const hpScale = 1 + cycle * 0.5                               // +50% HP per cycle
-  const countMult = cycle >= 4 ? 1 + Math.floor((cycle - 3) / 2) : 1  // more enemies in later cycles
-  const baseLabel = base.label.replace(/^Wave \d+ — /, '')
+  const n   = waveIndex + 1
+  const len = TD_WAVES.length  // 10
+
+  if (waveIndex < len) {
+    const base = TD_WAVES[waveIndex]
+    return {
+      wave: n,
+      label: `Wave ${n} — ${base.label.replace(/^Wave \d+ — /, '')}`,
+      spawns: base.spawns.map(s => ({ ...s })),
+    }
+  }
+
+  // Merge spawn lists, keyed by enemyId+hpMult+intervalMs to preserve HP variety.
+  const merged = new Map<string, WaveSpawn>()
+  const add = (baseIdx: number) => {
+    for (const s of TD_WAVES[baseIdx].spawns) {
+      const key = `${s.enemyId}|${s.hpMult}|${s.intervalMs}`
+      const ex  = merged.get(key)
+      merged.set(key, ex ? { ...ex, count: ex.count + s.count } : { ...s })
+    }
+  }
+
+  // Base: always include wave 10
+  add(9)
+  // Wave 11 adds W1, wave 12 adds W2, … cycling through W1–W10
+  for (let i = 10; i <= waveIndex; i++) add((i - 10) % len)
+
+  const cycle    = Math.floor((waveIndex - 10) / len) + 2
+  const addedIdx = (waveIndex - 10) % len
+  const baseLabel = TD_WAVES[addedIdx].label.replace(/^Wave \d+ — /, '')
   return {
-    wave: waveIndex + 1,
-    label: `Wave ${waveIndex + 1} — ${baseLabel}${cycle > 0 ? ` [×${hpScale.toFixed(1)}]` : ''}`,
-    spawns: base.spawns.map(s => ({
-      ...s,
-      count:  Math.round(s.count * countMult),
-      hpMult: +(s.hpMult * hpScale).toFixed(2),
-    })),
+    wave: n,
+    label: `Wave ${n} — ${baseLabel} [Cycle ${cycle}]`,
+    spawns: [...merged.values()],
   }
 }
 


### PR DESCRIPTION
## Summary

- Buildings spawn walking units that march to the nearest path cell and fight enemies there
- Enemies retaliate against stationed units (units have HP bars and can be killed)
- Killed units respawn from their building after 5 s (⏳ shown on building)
- Upgrading a building spawns one more unit: ★1=1 unit, ★2=2, ★3=3
- Cell shows the spawner building's sprite with star level (not the unit sprite)
- Unit walk animation (8 fps) transitions to stationary glow when on path
- Range preview reflects attack coverage from the unit's stationed path-cell position
- Cumulative wave stacking after wave 10 (wave 11 = wave 10 + wave 1, …, wave 100 ≈ 10× wave 10)

## Test plan

- [ ] Place a building — unit should walk to the nearest path cell and start attacking
- [ ] Let a unit get killed — building shows ⏳ and respawns after ~5 s
- [ ] Upgrade a building to ★2 — second unit dispatched immediately
- [ ] Sell a building — all its units disappear
- [ ] Move a building — units walk from new position to new nearest path cell
- [ ] Complete waves 10–12 — wave 11 should contain more enemies than wave 10

https://claude.ai/code/session_014PWcdZxQ19J95UxKwDEvqz