### PR TITLE
feat(tower-defence): tile unit sprites side-by-side or V-shape

### DIFF
--- a/web/src/components/minigames/TowerDefence.tsx
+++ b/web/src/components/minigames/TowerDefence.tsx
@@ -487,20 +487,62 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
   )
 }
 
-// ── Player unit group token (one sprite per building, ×N badge) ───────────────
+// ── Player unit group token (tiled sprites per building) ─────────────────────
 
 function UnitGroupToken({ units }: { units: TDUnit[] }) {
   const lead = units[0]
-  const size = 26
-  const minHpFrac = Math.min(...units.map(u => u.hp / u.maxHp))
   const stationed = units.some(u => u.stationed)
+  const minHpFrac = Math.min(...units.map(u => u.hp / u.maxHp))
+  const n = units.length
+
+  let spriteSize: number
+  let slots: Array<{ dx: number; dy: number }>
+  let containerW: number
+  let containerH: number
+
+  if (n >= 3) {
+    // V shape: top-center, bottom-left, bottom-right
+    spriteSize = 15
+    const gap = 3
+    containerW = spriteSize * 2 + gap
+    containerH = spriteSize * 2 + gap
+    slots = [
+      { dx: (containerW - spriteSize) / 2, dy: 0 },
+      { dx: 0,                             dy: spriteSize + gap },
+      { dx: spriteSize + gap,              dy: spriteSize + gap },
+    ]
+  } else if (n === 2) {
+    // Side by side
+    spriteSize = 18
+    const gap = 4
+    containerW = spriteSize * 2 + gap
+    containerH = spriteSize
+    slots = [
+      { dx: 0,               dy: 0 },
+      { dx: spriteSize + gap, dy: 0 },
+    ]
+  } else {
+    spriteSize = 26
+    containerW = spriteSize
+    containerH = spriteSize
+    slots = [{ dx: 0, dy: 0 }]
+  }
+
   return (
     <div
       className={`td-unit${stationed ? ' td-unit--stationed' : ' td-unit--walking'}`}
-      style={{ transform: `translate(${lead.x - size / 2}px, ${lead.y - size / 2}px)`, width: size }}
+      style={{ transform: `translate(${lead.x - containerW / 2}px, ${lead.y - containerH / 2}px)`, width: containerW }}
     >
-      <AnimatedSpriteImg name={lead.template.name} frameCount={3} fps={stationed ? 4 : 8} className="td-unit-sprite" />
-      {units.length > 1 && <div className="td-unit-count">×{units.length}</div>}
+      <div style={{ position: 'relative', width: containerW, height: containerH }}>
+        {slots.map((slot, i) => (
+          <div
+            key={i}
+            style={{ position: 'absolute', left: slot.dx, top: slot.dy, width: spriteSize, height: spriteSize }}
+          >
+            <AnimatedSpriteImg name={units[i].template.name} frameCount={3} fps={stationed ? 4 : 8} className="td-unit-sprite" />
+          </div>
+        ))}
+      </div>
       <div className="td-enemy-hp-bar">
         <div className="td-enemy-hp-fill" style={{ width: `${minHpFrac * 100}%`, background: hpBarColor(minHpFrac) }} />
       </div>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -12212,10 +12212,9 @@ html.light-mode .action-btn {
   will-change: transform;
   transition: transform 100ms linear;
 }
-.td-unit-sprite { width: 26px; height: 26px; image-rendering: pixelated; }
+.td-unit-sprite { width: 100%; height: 100%; display: block; image-rendering: pixelated; }
 .td-unit--walking { opacity: 0.85; }
 .td-unit--stationed { filter: drop-shadow(0 0 3px #4caf50); }
-.td-unit-count { font-size: 8px; font-weight: bold; color: #fff; background: rgba(0,0,0,0.6); border-radius: 3px; padding: 0 2px; line-height: 1.3; }
 
 /* Tower tooltip (positioned inside grid) */
 .td-tower-tooltip {


### PR DESCRIPTION
## Summary

- **1 unit**: single 26px sprite (unchanged)
- **2 units**: two 18px sprites side by side
- **3 units**: three 15px sprites in a V — top-center, bottom-left, bottom-right

Removes the ×N count badge in favour of visually distinct tiled sprites. `.td-unit-sprite` now uses `width/height: 100%` so each absolutely-positioned slot div controls the sprite size.

## Test plan

- [ ] Place a building — single sprite renders at normal size
- [ ] Upgrade once — two sprites appear side by side
- [ ] Upgrade again (max) — three sprites appear in a V shape
- [ ] All three layouts should animate and show the HP bar below

https://claude.ai/code/session_014PWcdZxQ19J95UxKwDEvqz

---
_Generated by [Claude Code](https://claude.ai/code/session_014PWcdZxQ19J95UxKwDEvqz)_