### PR TITLE
feat(tower-defence): scale enemy sprites to 15px

### DIFF
--- a/web/src/components/minigames/TowerDefence.tsx
+++ b/web/src/components/minigames/TowerDefence.tsx
@@ -550,7 +550,7 @@ function UnitGroupToken({ units }: { units: TDUnit[] }) {
 // ── Enemy token ───────────────────────────────────────────────────────────────
 
 function EnemyToken({ enemy }: { enemy: TDEnemy }) {
-  const size = 28
+  const size = 15
   const hpFrac = enemy.hp / enemy.maxHp
   return (
     <div


### PR DESCRIPTION
## Summary

Enemies now render at 15px, matching the unit sprite size for a consistent visual scale across all tokens on the grid.

## Test plan

- [ ] Enemies appear at the same scale as player unit sprites

https://claude.ai/code/session_014PWcdZxQ19J95UxKwDEvqz

---
_Generated by [Claude Code](https://claude.ai/code/session_014PWcdZxQ19J95UxKwDEvqz)_