### PR TITLE
feat(tower-defence): milestone upgrades, enemy abilities, higher upgrade costs

### DIFF
--- a/web/src/components/minigames/TowerDefence.tsx
+++ b/web/src/components/minigames/TowerDefence.tsx
@@ -9,10 +9,10 @@ import { UnitTemplate } from '../../game/types'
 import { SpriteImg, AnimatedSpriteImg } from '../SpriteImg'
 import {
   TD_COLS, TD_ROWS, TD_PATH, TD_TOTAL_WAVES, TD_MAX_LIVES, TD_CELL_PX, TD_MAX_UPGRADES, TD_MILESTONE_EVERY,
-  TDGameState, TDTower, TDUnit, TDEnemy, TDAttackEvent,
+  TDGameState, TDTower, TDUnit, TDEnemy, TDAttackEvent, MilestoneUpgrade,
   isPathCell,
   createTDGame, placeTower, removeTower, moveTower, upgradeTower, startWave, tickTD,
-  calcTicketReward, calcGoldReward, towerCost, upgradeCost, buildingUnitCount,
+  calcTicketReward, calcGoldReward, towerCost, upgradeCost, buildingUnitCount, chooseMilestoneUpgrade,
 } from '../../game/towerDefence'
 
 // ── Props ─────────────────────────────────────────────────────────────────────
@@ -166,6 +166,7 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
   }
 
   function handleStartWave() { setGame(prev => startWave(prev)) }
+  function handleChooseMilestone(id: string) { setGame(prev => chooseMilestoneUpgrade(prev, id)) }
 
   function handleSelectUnit(template: UnitTemplate) {
     setSelected(prev => prev?.name === template.name ? null : template)
@@ -253,7 +254,7 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
         <div className="td-header-score">⭐ {game.score}</div>
         <div className="td-header-mana">💧 {game.mana}</div>
 
-        {isPlacingPhase && (
+        {isPlacingPhase && !game.milestoneChoices && (
           <button className="action-btn action-btn--gold td-header-btn" onClick={handleStartWave}>
             ▶ START
           </button>
@@ -277,6 +278,21 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
           ✕
         </button>
       </div>
+
+      {/* ── Milestone reward choices ── */}
+      {game.milestoneChoices && (
+        <div className="td-milestone-choices">
+          <div className="td-milestone-choices-title">Choose your reward</div>
+          <div className="td-milestone-choices-cards">
+            {game.milestoneChoices.map((choice: MilestoneUpgrade) => (
+              <button key={choice.id} className="td-milestone-choice-card" onClick={() => handleChooseMilestone(choice.id)}>
+                <div className="td-milestone-choice-label">{choice.label}</div>
+                <div className="td-milestone-choice-desc">{choice.description}</div>
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
 
       {/* ── Board (scrollable) ── */}
       <div className="td-board-wrap" ref={boardWrapRef}>
@@ -552,9 +568,14 @@ function UnitGroupToken({ units }: { units: TDUnit[] }) {
 function EnemyToken({ enemy }: { enemy: TDEnemy }) {
   const size = 15
   const hpFrac = enemy.hp / enemy.maxHp
+  const cls = [
+    'td-enemy',
+    enemy.shielded    ? 'td-enemy--shielded' : '',
+    enemy.slowsUnits  ? 'td-enemy--slows'    : '',
+  ].filter(Boolean).join(' ')
   return (
     <div
-      className="td-enemy"
+      className={cls}
       style={{ transform: `translate(${enemy.x - size / 2}px, ${enemy.y - size / 2}px)`, width: size }}
     >
       <AnimatedSpriteImg name={enemy.template.spriteName} frameCount={3} fps={6} className="td-enemy-sprite" />

--- a/web/src/components/minigames/TowerDefence.tsx
+++ b/web/src/components/minigames/TowerDefence.tsx
@@ -550,7 +550,7 @@ function UnitGroupToken({ units }: { units: TDUnit[] }) {
 // ── Enemy token ───────────────────────────────────────────────────────────────
 
 function EnemyToken({ enemy }: { enemy: TDEnemy }) {
-  const size = 28
+  const size = 15
   const hpFrac = enemy.hp / enemy.maxHp
   return (
     <div

--- a/web/src/game/towerDefence.ts
+++ b/web/src/game/towerDefence.ts
@@ -227,6 +227,9 @@ export interface TDEnemy {
   y: number
   unitAttackCd: number    // ms until this enemy next attacks a player unit
   speedMult: number       // 1.05^(waveIndex-10) for waves > 10
+  shielded: boolean       // absorbs next hit entirely (introduced wave 30+)
+  splitsOnDeath: boolean  // spawns 2 half-hp copies on death (wave 50+)
+  slowsUnits: boolean     // emits aura that delays nearby unit attacks (wave 70+)
 }
 
 // Attack visual event — used by the UI to show projectile + hit spark
@@ -239,11 +242,37 @@ export interface TDAttackEvent {
   expiresAt: number   // game-time ms
 }
 
+// Global passive bonuses accumulated through milestone upgrades
+export interface TDPassives {
+  attackSpeedMult: number  // divides attack cooldown reset (>1 = faster)
+  rangeBonus: number       // extra cells added to each unit's range
+  damageMult: number       // multiplied onto damage dealt
+  respawnMult: number      // divides respawn timer (>1 = faster)
+}
+
+export interface MilestoneUpgrade {
+  id: string
+  label: string
+  description: string
+}
+
+export const ALL_MILESTONE_UPGRADES: MilestoneUpgrade[] = [
+  { id: 'attack_speed', label: '⚡ Battle Rhythm',   description: 'All units attack 20% faster' },
+  { id: 'range',        label: '🎯 Eagle Eye',        description: 'All units gain +1 range' },
+  { id: 'damage',       label: '💥 Sharpened Blades', description: 'Units deal 25% more damage' },
+  { id: 'mana',         label: '💧 Mana Spring',      description: 'Gain 100 bonus mana' },
+  { id: 'life',         label: '❤️ Fortified Walls',  description: 'Gain 2 extra lives' },
+  { id: 'respawn',      label: '🔄 Quick Recovery',   description: 'Units respawn twice as fast' },
+]
+
 // Pending spawn queue entry
 interface SpawnEntry {
   template: TDEnemyTemplate
   hpMult: number
   speedMult: number
+  shielded: boolean
+  splitsOnDeath: boolean
+  slowsUnits: boolean
   spawnAt: number   // game-time ms when this enemy should enter
 }
 
@@ -268,6 +297,8 @@ export interface TDGameState {
   availableTemplates: UnitTemplate[]
   remainingPlacements: Record<string, number>
   mode: 'collection' | 'city'
+  passives: TDPassives
+  milestoneChoices: MilestoneUpgrade[] | null
 }
 
 // ── Constants ─────────────────────────────────────────────────────────────────
@@ -291,7 +322,7 @@ export function towerCost(template: UnitTemplate): number {
 
 /** Mana cost to upgrade a building (spawns one more unit). */
 export function upgradeCost(tower: TDTower): number {
-  return Math.round(towerCost(tower.template) * (tower.upgrades + 1))
+  return Math.round(towerCost(tower.template) * Math.pow(2, tower.upgrades + 1))
 }
 
 /** Number of units a building spawns at its current upgrade level. */
@@ -370,9 +401,9 @@ function dist(ax: number, ay: number, bx: number, by: number): number {
   return Math.sqrt((ax - bx) ** 2 + (ay - by) ** 2)
 }
 
-function unitCanHit(unit: TDUnit, enemy: TDEnemy): boolean {
+function unitCanHit(unit: TDUnit, enemy: TDEnemy, rangeBonus: number): boolean {
   if (enemy.template.flying && !unit.template.bypassWall) return false
-  return dist(unit.x, unit.y, enemy.x, enemy.y) <= unit.rangeInCells * TD_CELL_PX
+  return dist(unit.x, unit.y, enemy.x, enemy.y) <= (unit.rangeInCells + rangeBonus) * TD_CELL_PX
 }
 
 function unitDamageDealt(unit: TDUnit, enemy: TDEnemy): number {
@@ -409,14 +440,25 @@ function buildSpawnQueue(waveDef: WaveDefinition, startTimeMs: number, waveIndex
   for (const group of waveDef.spawns) {
     const tpl = ENEMY_TEMPLATES[group.enemyId]
     if (!tpl) continue
+    const isArmored = tpl.tags.includes('armored')
+    const isLarge   = tpl.tags.includes('large')
+    const isMagic   = tpl.tags.includes('magic')
+    const shielded     = waveIndex >= 30 && isArmored
+    const splitsOnDeath = waveIndex >= 50 && isLarge
+    const slowsUnits    = waveIndex >= 70 && isMagic
     for (let i = 0; i < group.count; i++) {
-      queue.push({ template: tpl, hpMult: group.hpMult, speedMult, spawnAt: t })
+      queue.push({ template: tpl, hpMult: group.hpMult, speedMult, shielded, splitsOnDeath, slowsUnits, spawnAt: t })
       t += group.intervalMs
     }
   }
   // sort ascending so we can pop from the end
   queue.sort((a, b) => b.spawnAt - a.spawnAt)
   return queue
+}
+
+function sampleMilestoneChoices(): MilestoneUpgrade[] {
+  const shuffled = [...ALL_MILESTONE_UPGRADES].sort(() => Math.random() - 0.5)
+  return shuffled.slice(0, 3)
 }
 
 // ── Public API ────────────────────────────────────────────────────────────────
@@ -447,6 +489,8 @@ export function createTDGame(
     availableTemplates,
     remainingPlacements: { ...placementsPerTemplate },
     mode,
+    passives: { attackSpeedMult: 1, rangeBonus: 0, damageMult: 1, respawnMult: 1 },
+    milestoneChoices: null,
   }
 }
 
@@ -544,9 +588,27 @@ export function moveTower(state: TDGameState, towerId: number, col: number, row:
   }
 }
 
+/** Apply a chosen milestone upgrade and clear the pending choices. */
+export function chooseMilestoneUpgrade(state: TDGameState, id: string): TDGameState {
+  if (!state.milestoneChoices) return state
+  const p = { ...state.passives }
+  let extra: Partial<TDGameState> = {}
+  switch (id) {
+    case 'attack_speed': p.attackSpeedMult *= 1.2; break
+    case 'range':        p.rangeBonus += 1; break
+    case 'damage':       p.damageMult *= 1.25; break
+    case 'mana':         extra = { mana: state.mana + 100 }; break
+    case 'life':         extra = { lives: state.lives + 2 }; break
+    case 'respawn':      p.respawnMult *= 2; break
+  }
+  return { ...state, ...extra, passives: p, milestoneChoices: null,
+    log: [...state.log.slice(-9), `Upgrade chosen: ${ALL_MILESTONE_UPGRADES.find(u => u.id === id)?.label ?? id}`] }
+}
+
 /** Begin the next wave from prep, between, or milestone phase. */
 export function startWave(state: TDGameState): TDGameState {
   if (state.phase !== 'prep' && state.phase !== 'between' && state.phase !== 'milestone') return state
+  if (state.milestoneChoices !== null) return state  // must pick upgrade first
   const waveDef = generateWave(state.currentWaveIndex)
   const queue = buildSpawnQueue(waveDef, state.gameTimeMs, state.currentWaveIndex)
   return {
@@ -584,6 +646,9 @@ export function tickTD(state: TDGameState, dtMs: number): TDGameState {
       x: startXY.x, y: startXY.y,
       unitAttackCd: 0,
       speedMult: next.speedMult,
+      shielded: next.shielded,
+      splitsOnDeath: next.splitsOnDeath,
+      slowsUnits: next.slowsUnits,
     }]
   }
 
@@ -639,25 +704,44 @@ export function tickTD(state: TDGameState, dtMs: number): TDGameState {
   })
 
   // ── Units attack enemies ──────────────────────────────────────────────────
+  const { attackSpeedMult, rangeBonus, damageMult, respawnMult } = s.passives
+
+  // Compute which units are within a slow aura this tick
+  const slowedUnitIds = new Set<number>()
+  for (const enemy of s.enemies) {
+    if (enemy.slowsUnits) {
+      for (const unit of s.units) {
+        if (dist(unit.x, unit.y, enemy.x, enemy.y) <= TD_CELL_PX * 2) slowedUnitIds.add(unit.id)
+      }
+    }
+  }
+
   const deadEnemyIds = new Set<number>()
+  const shieldedEnemyIds = new Set<number>()  // shield absorbed a hit this tick
   const newAttackEvents: TDAttackEvent[] = s.attackEvents.filter(e => e.expiresAt > s.gameTimeMs)
 
   s.units = s.units.map(unit => {
     let cd = Math.max(0, unit.attackCooldownRemaining - dtMs)
     if (cd <= 0 && s.enemies.length > 0) {
       const targets = s.enemies
-        .filter(e => !deadEnemyIds.has(e.id) && unitCanHit(unit, e))
+        .filter(e => !deadEnemyIds.has(e.id) && !shieldedEnemyIds.has(e.id) && unitCanHit(unit, e, rangeBonus))
         .sort((a, b) => b.pathProgress - a.pathProgress)
       if (targets.length > 0) {
         const target = targets[0]
-        const dmg = unitDamageDealt(unit, target)
-        const newHp = target.hp - dmg
-        if (newHp <= 0) {
-          deadEnemyIds.add(target.id)
-          s.score += target.template.reward
-          s.mana += target.template.reward
+        if (target.shielded) {
+          // Shield absorbs the hit — break it and skip damage
+          shieldedEnemyIds.add(target.id)
+          s.enemies = s.enemies.map(e => e.id === target.id ? { ...e, shielded: false } : e)
         } else {
-          s.enemies = s.enemies.map(e => e.id === target.id ? { ...e, hp: newHp } : e)
+          const dmg = Math.round(unitDamageDealt(unit, target) * damageMult)
+          const newHp = target.hp - dmg
+          if (newHp <= 0) {
+            deadEnemyIds.add(target.id)
+            s.score += target.template.reward
+            s.mana += target.template.reward
+          } else {
+            s.enemies = s.enemies.map(e => e.id === target.id ? { ...e, hp: newHp } : e)
+          }
         }
         newAttackEvents.push({
           id: nextId(),
@@ -665,13 +749,31 @@ export function tickTD(state: TDGameState, dtMs: number): TDGameState {
           toX: target.x, toY: target.y,
           expiresAt: s.gameTimeMs + 400,
         })
-        cd = unit.template.attackCooldownMs
+        const slowPenalty = slowedUnitIds.has(unit.id) ? 1.5 : 1
+        cd = unit.template.attackCooldownMs / attackSpeedMult * slowPenalty
       }
     }
     return { ...unit, attackCooldownRemaining: cd }
   })
   s.attackEvents = newAttackEvents
-  s.enemies = s.enemies.filter(e => !deadEnemyIds.has(e.id))
+
+  // Split-on-death: collect offspring before removing dead enemies
+  const splitOffspring: TDEnemy[] = []
+  for (const enemy of s.enemies) {
+    if (deadEnemyIds.has(enemy.id) && enemy.splitsOnDeath) {
+      const halfHp = Math.max(1, Math.floor(enemy.maxHp / 2))
+      for (let i = 0; i < 2; i++) {
+        splitOffspring.push({
+          ...enemy,
+          id: nextId(),
+          hp: halfHp, maxHp: halfHp,
+          splitsOnDeath: false,
+          shielded: false,
+        })
+      }
+    }
+  }
+  s.enemies = [...s.enemies.filter(e => !deadEnemyIds.has(e.id)), ...splitOffspring]
 
   // ── Enemies retaliate against stationed units ─────────────────────────────
   const unitHpDeltas: Record<number, number> = {}
@@ -714,7 +816,7 @@ export function tickTD(state: TDGameState, dtMs: number): TDGameState {
   s.towers = s.towers.map(tower => {
     let timers = tower.respawnTimers.map(t => t - dtMs)
     const addCount = respawnAdditions[tower.id] ?? 0
-    for (let i = 0; i < addCount; i++) timers.push(RESPAWN_DELAY_MS)
+    for (let i = 0; i < addCount; i++) timers.push(RESPAWN_DELAY_MS / respawnMult)
     const toSpawn = timers.filter(t => t <= 0).length
     timers = timers.filter(t => t > 0)
     for (let i = 0; i < toSpawn; i++) newlySpawned.push(spawnUnitFromBuilding(tower))
@@ -737,8 +839,8 @@ export function tickTD(state: TDGameState, dtMs: number): TDGameState {
     }
     s.currentWaveIndex += 1
     if (s.wavesCompleted % TD_MILESTONE_EVERY === 0) {
-      s.log = [...s.log.slice(-9), `🎉 ${s.wavesCompleted} waves cleared! Take a break — sell, move or upgrade!`]
-      return { ...s, phase: 'milestone' }
+      s.log = [...s.log.slice(-9), `🎉 ${s.wavesCompleted} waves cleared! Choose a reward, then reorganise!`]
+      return { ...s, phase: 'milestone', milestoneChoices: sampleMilestoneChoices() }
     }
     s.nextWaveAt = s.gameTimeMs + BETWEEN_WAVE_MS
     const nextWave = generateWave(s.currentWaveIndex)

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -12279,6 +12279,46 @@ html.light-mode .action-btn {
   margin-top: 1px;
 }
 .td-enemy-hp-fill { height: 100%; border-radius: 2px; transition: width 0.05s; }
+.td-enemy--shielded { filter: drop-shadow(0 0 3px #4fc3f7) drop-shadow(0 0 6px #0288d1); }
+.td-enemy--slows    { filter: drop-shadow(0 0 3px #ce93d8) drop-shadow(0 0 6px #7b1fa2); }
+
+/* ── Milestone reward choices ── */
+.td-milestone-choices {
+  flex-shrink: 0;
+  padding: 8px 10px;
+  background: rgba(0,0,0,0.7);
+  border-bottom: 1px solid #ffd700;
+}
+.td-milestone-choices-title {
+  font-size: 11px;
+  font-weight: bold;
+  color: #ffd700;
+  text-align: center;
+  margin-bottom: 6px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+}
+.td-milestone-choices-cards {
+  display: flex;
+  gap: 8px;
+}
+.td-milestone-choice-card {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3px;
+  padding: 8px 6px;
+  background: #111;
+  border: 1px solid #444;
+  border-radius: 6px;
+  cursor: pointer;
+  font-family: 'Courier New', monospace;
+  transition: border-color 0.15s, background 0.15s;
+}
+.td-milestone-choice-card:hover { border-color: #ffd700; background: #1a1600; }
+.td-milestone-choice-label { font-size: 11px; font-weight: bold; color: #ffd700; }
+.td-milestone-choice-desc  { font-size: 9px; color: #bbb; text-align: center; }
 
 /* ── Selected tower action panel ── */
 .td-selected-panel {


### PR DESCRIPTION
## Summary

### Upgrade costs
- First upgrade: **2× placement cost** (was 1×)
- Second upgrade: **4× placement cost** (was 2×)

### Milestone upgrade picks (every 10 waves)
At each milestone break, 3 random upgrades are offered — pick one before the Start button unlocks:
- ⚡ **Battle Rhythm** — all units attack 20% faster
- 🎯 **Eagle Eye** — all units gain +1 range
- 💥 **Sharpened Blades** — units deal 25% more damage
- 💧 **Mana Spring** — gain 100 bonus mana
- ❤️ **Fortified Walls** — gain 2 extra lives
- 🔄 **Quick Recovery** — units respawn twice as fast

Passives stack across milestones (e.g. two Battle Rhythm picks = ×1.44 speed).

### Enemy abilities (wave thresholds, tag-based)
- **Wave 30+**: armored enemies (Brute, Siege Engine) gain a blue-glowing **shield** that absorbs one hit entirely
- **Wave 50+**: large enemies **split into 2 half-HP copies** on death
- **Wave 70+**: magic enemies (Necromancer) emit a **purple slow aura** — units within 2 cells attack 50% slower

## Test plan
- [ ] Upgrade costs are 2× and 4× placement cost
- [ ] Hitting wave 10 shows 3 choice cards; Start Wave is blocked until one is chosen
- [ ] Chosen passive applies correctly (e.g. Eagle Eye visibly extends unit range)
- [ ] Wave 30+: Brutes and Siege Engines have blue shield glow; one hit breaks it
- [ ] Wave 50+: killing a Brute spawns 2 smaller copies
- [ ] Wave 70+: Necromancers have purple glow; units near them attack noticeably slower

https://claude.ai/code/session_014PWcdZxQ19J95UxKwDEvqz

---
_Generated by [Claude Code](https://claude.ai/code/session_014PWcdZxQ19J95UxKwDEvqz)_