### PR TITLE
feat(tower-defence): max 1 unit/enemy per cell with spread-to-adjacent logic

### DIFF
--- a/web/src/components/minigames/TowerDefence.tsx
+++ b/web/src/components/minigames/TowerDefence.tsx
@@ -369,16 +369,9 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
             })
           )}
 
-          {/* Player units — grouped per building to avoid sprite stacking */}
-          {Array.from(
-            game.units.reduce((map, u) => {
-              const list = map.get(u.towerId) ?? []
-              list.push(u)
-              map.set(u.towerId, list)
-              return map
-            }, new Map<number, TDUnit[]>())
-          ).map(([towerId, units]) => (
-            <UnitGroupToken key={towerId} units={units} />
+          {/* Player units — each at its own cell (cell occupancy enforced in game logic) */}
+          {game.units.map(unit => (
+            <UnitToken key={unit.id} unit={unit} />
           ))}
 
           {/* Enemies */}
@@ -503,61 +496,19 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
   )
 }
 
-// ── Player unit group token (tiled sprites per building) ─────────────────────
+// ── Player unit token ─────────────────────────────────────────────────────────
 
-function UnitGroupToken({ units }: { units: TDUnit[] }) {
-  const lead = units[0]
-  const stationed = units.some(u => u.stationed)
-  const minHpFrac = Math.min(...units.map(u => u.hp / u.maxHp))
-  const n = units.length
-
-  let spriteSize: number
-  let slots: Array<{ dx: number; dy: number }>
-  let containerW: number
-  let containerH: number
-
-  spriteSize = 15
-  const gap = 3
-  if (n >= 3) {
-    // V shape: top-center, bottom-left, bottom-right
-    containerW = spriteSize * 2 + gap
-    containerH = spriteSize * 2 + gap
-    slots = [
-      { dx: (containerW - spriteSize) / 2, dy: 0 },
-      { dx: 0,                             dy: spriteSize + gap },
-      { dx: spriteSize + gap,              dy: spriteSize + gap },
-    ]
-  } else if (n === 2) {
-    // Side by side
-    containerW = spriteSize * 2 + gap
-    containerH = spriteSize
-    slots = [
-      { dx: 0,                dy: 0 },
-      { dx: spriteSize + gap, dy: 0 },
-    ]
-  } else {
-    containerW = spriteSize
-    containerH = spriteSize
-    slots = [{ dx: 0, dy: 0 }]
-  }
-
+function UnitToken({ unit }: { unit: TDUnit }) {
+  const size = 15
+  const hpFrac = unit.hp / unit.maxHp
   return (
     <div
-      className={`td-unit${stationed ? ' td-unit--stationed' : ' td-unit--walking'}`}
-      style={{ transform: `translate(${lead.x - containerW / 2}px, ${lead.y - containerH / 2}px)`, width: containerW }}
+      className={`td-unit${unit.stationed ? ' td-unit--stationed' : ' td-unit--walking'}`}
+      style={{ transform: `translate(${unit.x - size / 2}px, ${unit.y - size / 2}px)`, width: size }}
     >
-      <div style={{ position: 'relative', width: containerW, height: containerH }}>
-        {slots.map((slot, i) => (
-          <div
-            key={i}
-            style={{ position: 'absolute', left: slot.dx, top: slot.dy, width: spriteSize, height: spriteSize }}
-          >
-            <AnimatedSpriteImg name={units[i].template.name} frameCount={3} fps={stationed ? 4 : 8} className="td-unit-sprite" />
-          </div>
-        ))}
-      </div>
+      <AnimatedSpriteImg name={unit.template.name} frameCount={3} fps={unit.stationed ? 4 : 8} className="td-unit-sprite" />
       <div className="td-enemy-hp-bar">
-        <div className="td-enemy-hp-fill" style={{ width: `${minHpFrac * 100}%`, background: hpBarColor(minHpFrac) }} />
+        <div className="td-enemy-hp-fill" style={{ width: `${hpFrac * 100}%`, background: hpBarColor(hpFrac) }} />
       </div>
     </div>
   )

--- a/web/src/components/minigames/TowerDefence.tsx
+++ b/web/src/components/minigames/TowerDefence.tsx
@@ -9,10 +9,10 @@ import { UnitTemplate } from '../../game/types'
 import { SpriteImg, AnimatedSpriteImg } from '../SpriteImg'
 import {
   TD_COLS, TD_ROWS, TD_PATH, TD_TOTAL_WAVES, TD_MAX_LIVES, TD_CELL_PX, TD_MAX_UPGRADES, TD_MILESTONE_EVERY,
-  TDGameState, TDTower, TDUnit, TDEnemy, TDAttackEvent,
+  TDGameState, TDTower, TDUnit, TDEnemy, TDAttackEvent, MilestoneUpgrade,
   isPathCell,
   createTDGame, placeTower, removeTower, moveTower, upgradeTower, startWave, tickTD,
-  calcTicketReward, calcGoldReward, towerCost, upgradeCost, buildingUnitCount,
+  calcTicketReward, calcGoldReward, towerCost, upgradeCost, buildingUnitCount, chooseMilestoneUpgrade,
 } from '../../game/towerDefence'
 
 // ── Props ─────────────────────────────────────────────────────────────────────
@@ -166,6 +166,7 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
   }
 
   function handleStartWave() { setGame(prev => startWave(prev)) }
+  function handleChooseMilestone(id: string) { setGame(prev => chooseMilestoneUpgrade(prev, id)) }
 
   function handleSelectUnit(template: UnitTemplate) {
     setSelected(prev => prev?.name === template.name ? null : template)
@@ -253,7 +254,7 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
         <div className="td-header-score">⭐ {game.score}</div>
         <div className="td-header-mana">💧 {game.mana}</div>
 
-        {isPlacingPhase && (
+        {isPlacingPhase && !game.milestoneChoices && (
           <button className="action-btn action-btn--gold td-header-btn" onClick={handleStartWave}>
             ▶ START
           </button>
@@ -277,6 +278,21 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
           ✕
         </button>
       </div>
+
+      {/* ── Milestone reward choices ── */}
+      {game.milestoneChoices && (
+        <div className="td-milestone-choices">
+          <div className="td-milestone-choices-title">Choose your reward</div>
+          <div className="td-milestone-choices-cards">
+            {game.milestoneChoices.map((choice: MilestoneUpgrade) => (
+              <button key={choice.id} className="td-milestone-choice-card" onClick={() => handleChooseMilestone(choice.id)}>
+                <div className="td-milestone-choice-label">{choice.label}</div>
+                <div className="td-milestone-choice-desc">{choice.description}</div>
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
 
       {/* ── Board (scrollable) ── */}
       <div className="td-board-wrap" ref={boardWrapRef}>
@@ -552,9 +568,14 @@ function UnitGroupToken({ units }: { units: TDUnit[] }) {
 function EnemyToken({ enemy }: { enemy: TDEnemy }) {
   const size = 15
   const hpFrac = enemy.hp / enemy.maxHp
+  const cls = [
+    'td-enemy',
+    enemy.shielded    ? 'td-enemy--shielded' : '',
+    enemy.slowsUnits  ? 'td-enemy--slows'    : '',
+  ].filter(Boolean).join(' ')
   return (
     <div
-      className="td-enemy"
+      className={cls}
       style={{ transform: `translate(${enemy.x - size / 2}px, ${enemy.y - size / 2}px)`, width: size }}
     >
       <AnimatedSpriteImg name={enemy.template.spriteName} frameCount={3} fps={6} className="td-enemy-sprite" />

--- a/web/src/components/minigames/TowerDefence.tsx
+++ b/web/src/components/minigames/TowerDefence.tsx
@@ -550,7 +550,7 @@ function UnitGroupToken({ units }: { units: TDUnit[] }) {
 // ── Enemy token ───────────────────────────────────────────────────────────────
 
 function EnemyToken({ enemy }: { enemy: TDEnemy }) {
-  const size = 28
+  const size = 15
   const hpFrac = enemy.hp / enemy.maxHp
   return (
     <div

--- a/web/src/game/towerDefence.ts
+++ b/web/src/game/towerDefence.ts
@@ -652,16 +652,28 @@ export function tickTD(state: TDGameState, dtMs: number): TDGameState {
     }]
   }
 
-  // ── Move enemies ──────────────────────────────────────────────────────────
+  // ── Move enemies — max 1 per cell (leaders advance first) ───────────────
   const dtSec = dtMs / 1000
   let livesLost = 0
+  const claimedEnemyCells = new Set<string>()
   const survivingEnemies: TDEnemy[] = []
-  for (const enemy of s.enemies) {
+  // Process most-advanced enemies first so they claim cells before followers
+  const enemiesByProgress = [...s.enemies].sort((a, b) => b.pathProgress - a.pathProgress)
+  for (const enemy of enemiesByProgress) {
     const np = enemy.pathProgress + enemy.template.speed * enemy.speedMult * dtSec
     if (np >= TD_PATH.length - 1) {
       livesLost += enemy.template.attack
+      continue
+    }
+    const xy = pathIndexToXY(np)
+    const destKey = `${Math.floor(xy.x / TD_CELL_PX)},${Math.floor(xy.y / TD_CELL_PX)}`
+    if (claimedEnemyCells.has(destKey)) {
+      // Cell ahead occupied — hold position, claim current cell
+      const curKey = `${Math.floor(enemy.x / TD_CELL_PX)},${Math.floor(enemy.y / TD_CELL_PX)}`
+      claimedEnemyCells.add(curKey)
+      survivingEnemies.push(enemy)
     } else {
-      const xy = pathIndexToXY(np)
+      claimedEnemyCells.add(destKey)
       survivingEnemies.push({ ...enemy, pathProgress: np, x: xy.x, y: xy.y })
     }
   }
@@ -671,37 +683,60 @@ export function tickTD(state: TDGameState, dtMs: number): TDGameState {
     s.log = [...s.log.slice(-9), `${livesLost} ${livesLost === 1 ? 'enemy' : 'enemies'} reached your base!`]
   }
 
-  // ── Move units — chase nearby enemies, return home when idle ─────────────
-  s.units = s.units.map(unit => {
-    // Find the closest enemy within reach of the building
+  // ── Move units — max 1 per cell; overflow to adjacent cells within reach ─
+  const claimedUnitCells = new Map<string, number>()  // "col,row" -> unit id
+
+  function claimCellNear(
+    preferCol: number, preferRow: number,
+    homeX: number, homeY: number,
+    unitId: number,
+  ): { x: number; y: number } | null {
+    // Try preferred cell first, then 8 neighbours, all within UNIT_REACH_PX
+    const candidates: Array<{ col: number; row: number }> = [
+      { col: preferCol, row: preferRow },
+      ...[-1, 0, 1].flatMap(dc => [-1, 0, 1]
+        .filter(dr => dc !== 0 || dr !== 0)
+        .map(dr => ({ col: preferCol + dc, row: preferRow + dr }))),
+    ]
+    for (const { col, row } of candidates) {
+      if (col < 0 || col >= TD_COLS || row < 0 || row >= TD_ROWS) continue
+      const key = `${col},${row}`
+      if (claimedUnitCells.has(key)) continue
+      const cx = col * TD_CELL_PX + TD_CELL_PX / 2
+      const cy = row * TD_CELL_PX + TD_CELL_PX / 2
+      if (dist(cx, cy, homeX, homeY) > UNIT_REACH_PX) continue
+      claimedUnitCells.set(key, unitId)
+      return { x: cx, y: cy }
+    }
+    return null
+  }
+
+  const movedUnits: TDUnit[] = []
+  for (const unit of s.units) {
     const nearbyEnemy = s.enemies
       .filter(e => dist(e.x, e.y, unit.homeX, unit.homeY) <= UNIT_REACH_PX + TD_CELL_PX * 0.5)
       .sort((a, b) => dist(a.x, a.y, unit.x, unit.y) - dist(b.x, b.y, unit.x, unit.y))[0] ?? null
 
-    const tx = nearbyEnemy ? nearbyEnemy.x : unit.homeX
-    const ty = nearbyEnemy ? nearbyEnemy.y : unit.homeY
-    const dx = tx - unit.x
-    const dy = ty - unit.y
-    const d  = Math.sqrt(dx * dx + dy * dy)
-    const step = UNIT_WALK_SPEED_PX * dtSec
+    const destXY = nearbyEnemy
+      ? claimCellNear(
+          Math.floor(nearbyEnemy.x / TD_CELL_PX), Math.floor(nearbyEnemy.y / TD_CELL_PX),
+          unit.homeX, unit.homeY, unit.id,
+        )
+      : claimCellNear(
+          Math.floor(unit.homeX / TD_CELL_PX), Math.floor(unit.homeY / TD_CELL_PX),
+          unit.homeX, unit.homeY, unit.id,
+        )
 
     let newX = unit.x, newY = unit.y
-    if (d > 2) {
-      const mx = unit.x + dx / d * Math.min(step, d)
-      const my = unit.y + dy / d * Math.min(step, d)
-      // Clamp position to within reach of home
-      const dFromHome = dist(mx, my, unit.homeX, unit.homeY)
-      if (dFromHome <= UNIT_REACH_PX) {
-        newX = mx; newY = my
-      } else {
-        const cx = mx - unit.homeX, cy = my - unit.homeY
-        const cl = Math.sqrt(cx * cx + cy * cy)
-        newX = unit.homeX + cx / cl * UNIT_REACH_PX
-        newY = unit.homeY + cy / cl * UNIT_REACH_PX
-      }
+    if (destXY) {
+      const dx = destXY.x - unit.x, dy = destXY.y - unit.y
+      const d = Math.sqrt(dx * dx + dy * dy)
+      const step = UNIT_WALK_SPEED_PX * dtSec
+      if (d > 2) { newX = unit.x + dx / d * Math.min(step, d); newY = unit.y + dy / d * Math.min(step, d) }
     }
-    return { ...unit, x: newX, y: newY, stationed: nearbyEnemy !== null }
-  })
+    movedUnits.push({ ...unit, x: newX, y: newY, stationed: nearbyEnemy !== null })
+  }
+  s.units = movedUnits
 
   // ── Units attack enemies ──────────────────────────────────────────────────
   const { attackSpeedMult, rangeBonus, damageMult, respawnMult } = s.passives

--- a/web/src/game/towerDefence.ts
+++ b/web/src/game/towerDefence.ts
@@ -227,6 +227,9 @@ export interface TDEnemy {
   y: number
   unitAttackCd: number    // ms until this enemy next attacks a player unit
   speedMult: number       // 1.05^(waveIndex-10) for waves > 10
+  shielded: boolean       // absorbs next hit entirely (introduced wave 30+)
+  splitsOnDeath: boolean  // spawns 2 half-hp copies on death (wave 50+)
+  slowsUnits: boolean     // emits aura that delays nearby unit attacks (wave 70+)
 }
 
 // Attack visual event — used by the UI to show projectile + hit spark
@@ -239,11 +242,37 @@ export interface TDAttackEvent {
   expiresAt: number   // game-time ms
 }
 
+// Global passive bonuses accumulated through milestone upgrades
+export interface TDPassives {
+  attackSpeedMult: number  // divides attack cooldown reset (>1 = faster)
+  rangeBonus: number       // extra cells added to each unit's range
+  damageMult: number       // multiplied onto damage dealt
+  respawnMult: number      // divides respawn timer (>1 = faster)
+}
+
+export interface MilestoneUpgrade {
+  id: string
+  label: string
+  description: string
+}
+
+export const ALL_MILESTONE_UPGRADES: MilestoneUpgrade[] = [
+  { id: 'attack_speed', label: '⚡ Battle Rhythm',   description: 'All units attack 20% faster' },
+  { id: 'range',        label: '🎯 Eagle Eye',        description: 'All units gain +1 range' },
+  { id: 'damage',       label: '💥 Sharpened Blades', description: 'Units deal 25% more damage' },
+  { id: 'mana',         label: '💧 Mana Spring',      description: 'Gain 100 bonus mana' },
+  { id: 'life',         label: '❤️ Fortified Walls',  description: 'Gain 2 extra lives' },
+  { id: 'respawn',      label: '🔄 Quick Recovery',   description: 'Units respawn twice as fast' },
+]
+
 // Pending spawn queue entry
 interface SpawnEntry {
   template: TDEnemyTemplate
   hpMult: number
   speedMult: number
+  shielded: boolean
+  splitsOnDeath: boolean
+  slowsUnits: boolean
   spawnAt: number   // game-time ms when this enemy should enter
 }
 
@@ -268,6 +297,8 @@ export interface TDGameState {
   availableTemplates: UnitTemplate[]
   remainingPlacements: Record<string, number>
   mode: 'collection' | 'city'
+  passives: TDPassives
+  milestoneChoices: MilestoneUpgrade[] | null
 }
 
 // ── Constants ─────────────────────────────────────────────────────────────────
@@ -291,7 +322,7 @@ export function towerCost(template: UnitTemplate): number {
 
 /** Mana cost to upgrade a building (spawns one more unit). */
 export function upgradeCost(tower: TDTower): number {
-  return Math.round(towerCost(tower.template) * (tower.upgrades + 1))
+  return Math.round(towerCost(tower.template) * Math.pow(2, tower.upgrades + 1))
 }
 
 /** Number of units a building spawns at its current upgrade level. */
@@ -370,9 +401,9 @@ function dist(ax: number, ay: number, bx: number, by: number): number {
   return Math.sqrt((ax - bx) ** 2 + (ay - by) ** 2)
 }
 
-function unitCanHit(unit: TDUnit, enemy: TDEnemy): boolean {
+function unitCanHit(unit: TDUnit, enemy: TDEnemy, rangeBonus: number): boolean {
   if (enemy.template.flying && !unit.template.bypassWall) return false
-  return dist(unit.x, unit.y, enemy.x, enemy.y) <= unit.rangeInCells * TD_CELL_PX
+  return dist(unit.x, unit.y, enemy.x, enemy.y) <= (unit.rangeInCells + rangeBonus) * TD_CELL_PX
 }
 
 function unitDamageDealt(unit: TDUnit, enemy: TDEnemy): number {
@@ -409,14 +440,25 @@ function buildSpawnQueue(waveDef: WaveDefinition, startTimeMs: number, waveIndex
   for (const group of waveDef.spawns) {
     const tpl = ENEMY_TEMPLATES[group.enemyId]
     if (!tpl) continue
+    const isArmored = tpl.tags.includes('armored')
+    const isLarge   = tpl.tags.includes('large')
+    const isMagic   = tpl.tags.includes('magic')
+    const shielded     = waveIndex >= 30 && isArmored
+    const splitsOnDeath = waveIndex >= 50 && isLarge
+    const slowsUnits    = waveIndex >= 70 && isMagic
     for (let i = 0; i < group.count; i++) {
-      queue.push({ template: tpl, hpMult: group.hpMult, speedMult, spawnAt: t })
+      queue.push({ template: tpl, hpMult: group.hpMult, speedMult, shielded, splitsOnDeath, slowsUnits, spawnAt: t })
       t += group.intervalMs
     }
   }
   // sort ascending so we can pop from the end
   queue.sort((a, b) => b.spawnAt - a.spawnAt)
   return queue
+}
+
+function sampleMilestoneChoices(): MilestoneUpgrade[] {
+  const shuffled = [...ALL_MILESTONE_UPGRADES].sort(() => Math.random() - 0.5)
+  return shuffled.slice(0, 3)
 }
 
 // ── Public API ────────────────────────────────────────────────────────────────
@@ -447,6 +489,8 @@ export function createTDGame(
     availableTemplates,
     remainingPlacements: { ...placementsPerTemplate },
     mode,
+    passives: { attackSpeedMult: 1, rangeBonus: 0, damageMult: 1, respawnMult: 1 },
+    milestoneChoices: null,
   }
 }
 
@@ -544,9 +588,27 @@ export function moveTower(state: TDGameState, towerId: number, col: number, row:
   }
 }
 
+/** Apply a chosen milestone upgrade and clear the pending choices. */
+export function chooseMilestoneUpgrade(state: TDGameState, id: string): TDGameState {
+  if (!state.milestoneChoices) return state
+  const p = { ...state.passives }
+  let extra: Partial<TDGameState> = {}
+  switch (id) {
+    case 'attack_speed': p.attackSpeedMult *= 1.2; break
+    case 'range':        p.rangeBonus += 1; break
+    case 'damage':       p.damageMult *= 1.25; break
+    case 'mana':         extra = { mana: state.mana + 100 }; break
+    case 'life':         extra = { lives: state.lives + 2 }; break
+    case 'respawn':      p.respawnMult *= 2; break
+  }
+  return { ...state, ...extra, passives: p, milestoneChoices: null,
+    log: [...state.log.slice(-9), `Upgrade chosen: ${ALL_MILESTONE_UPGRADES.find(u => u.id === id)?.label ?? id}`] }
+}
+
 /** Begin the next wave from prep, between, or milestone phase. */
 export function startWave(state: TDGameState): TDGameState {
   if (state.phase !== 'prep' && state.phase !== 'between' && state.phase !== 'milestone') return state
+  if (state.milestoneChoices !== null) return state  // must pick upgrade first
   const waveDef = generateWave(state.currentWaveIndex)
   const queue = buildSpawnQueue(waveDef, state.gameTimeMs, state.currentWaveIndex)
   return {
@@ -584,6 +646,9 @@ export function tickTD(state: TDGameState, dtMs: number): TDGameState {
       x: startXY.x, y: startXY.y,
       unitAttackCd: 0,
       speedMult: next.speedMult,
+      shielded: next.shielded,
+      splitsOnDeath: next.splitsOnDeath,
+      slowsUnits: next.slowsUnits,
     }]
   }
 
@@ -639,25 +704,44 @@ export function tickTD(state: TDGameState, dtMs: number): TDGameState {
   })
 
   // ── Units attack enemies ──────────────────────────────────────────────────
+  const { attackSpeedMult, rangeBonus, damageMult, respawnMult } = s.passives
+
+  // Compute which units are within a slow aura this tick
+  const slowedUnitIds = new Set<number>()
+  for (const enemy of s.enemies) {
+    if (enemy.slowsUnits) {
+      for (const unit of s.units) {
+        if (dist(unit.x, unit.y, enemy.x, enemy.y) <= TD_CELL_PX * 2) slowedUnitIds.add(unit.id)
+      }
+    }
+  }
+
   const deadEnemyIds = new Set<number>()
+  const shieldedEnemyIds = new Set<number>()  // shield absorbed a hit this tick
   const newAttackEvents: TDAttackEvent[] = s.attackEvents.filter(e => e.expiresAt > s.gameTimeMs)
 
   s.units = s.units.map(unit => {
     let cd = Math.max(0, unit.attackCooldownRemaining - dtMs)
     if (cd <= 0 && s.enemies.length > 0) {
       const targets = s.enemies
-        .filter(e => !deadEnemyIds.has(e.id) && unitCanHit(unit, e))
+        .filter(e => !deadEnemyIds.has(e.id) && !shieldedEnemyIds.has(e.id) && unitCanHit(unit, e, rangeBonus))
         .sort((a, b) => b.pathProgress - a.pathProgress)
       if (targets.length > 0) {
         const target = targets[0]
-        const dmg = unitDamageDealt(unit, target)
-        const newHp = target.hp - dmg
-        if (newHp <= 0) {
-          deadEnemyIds.add(target.id)
-          s.score += target.template.reward
-          s.mana += target.template.reward
+        if (target.shielded) {
+          // Shield absorbs the hit — break it and skip damage
+          shieldedEnemyIds.add(target.id)
+          s.enemies = s.enemies.map(e => e.id === target.id ? { ...e, shielded: false } : e)
         } else {
-          s.enemies = s.enemies.map(e => e.id === target.id ? { ...e, hp: newHp } : e)
+          const dmg = Math.round(unitDamageDealt(unit, target) * damageMult)
+          const newHp = target.hp - dmg
+          if (newHp <= 0) {
+            deadEnemyIds.add(target.id)
+            s.score += target.template.reward
+            s.mana += target.template.reward
+          } else {
+            s.enemies = s.enemies.map(e => e.id === target.id ? { ...e, hp: newHp } : e)
+          }
         }
         newAttackEvents.push({
           id: nextId(),
@@ -665,13 +749,31 @@ export function tickTD(state: TDGameState, dtMs: number): TDGameState {
           toX: target.x, toY: target.y,
           expiresAt: s.gameTimeMs + 400,
         })
-        cd = unit.template.attackCooldownMs
+        const slowPenalty = slowedUnitIds.has(unit.id) ? 1.5 : 1
+        cd = unit.template.attackCooldownMs / attackSpeedMult * slowPenalty
       }
     }
     return { ...unit, attackCooldownRemaining: cd }
   })
   s.attackEvents = newAttackEvents
-  s.enemies = s.enemies.filter(e => !deadEnemyIds.has(e.id))
+
+  // Split-on-death: collect offspring before removing dead enemies
+  const splitOffspring: TDEnemy[] = []
+  for (const enemy of s.enemies) {
+    if (deadEnemyIds.has(enemy.id) && enemy.splitsOnDeath) {
+      const halfHp = Math.max(1, Math.floor(enemy.maxHp / 2))
+      for (let i = 0; i < 2; i++) {
+        splitOffspring.push({
+          ...enemy,
+          id: nextId(),
+          hp: halfHp, maxHp: halfHp,
+          splitsOnDeath: false,
+          shielded: false,
+        })
+      }
+    }
+  }
+  s.enemies = [...s.enemies.filter(e => !deadEnemyIds.has(e.id)), ...splitOffspring]
 
   // ── Enemies retaliate against stationed units ─────────────────────────────
   const unitHpDeltas: Record<number, number> = {}
@@ -714,7 +816,7 @@ export function tickTD(state: TDGameState, dtMs: number): TDGameState {
   s.towers = s.towers.map(tower => {
     let timers = tower.respawnTimers.map(t => t - dtMs)
     const addCount = respawnAdditions[tower.id] ?? 0
-    for (let i = 0; i < addCount; i++) timers.push(RESPAWN_DELAY_MS)
+    for (let i = 0; i < addCount; i++) timers.push(RESPAWN_DELAY_MS / respawnMult)
     const toSpawn = timers.filter(t => t <= 0).length
     timers = timers.filter(t => t > 0)
     for (let i = 0; i < toSpawn; i++) newlySpawned.push(spawnUnitFromBuilding(tower))
@@ -737,8 +839,8 @@ export function tickTD(state: TDGameState, dtMs: number): TDGameState {
     }
     s.currentWaveIndex += 1
     if (s.wavesCompleted % TD_MILESTONE_EVERY === 0) {
-      s.log = [...s.log.slice(-9), `🎉 ${s.wavesCompleted} waves cleared! Take a break — sell, move or upgrade!`]
-      return { ...s, phase: 'milestone' }
+      s.log = [...s.log.slice(-9), `🎉 ${s.wavesCompleted} waves cleared! Choose a reward, then reorganise!`]
+      return { ...s, phase: 'milestone', milestoneChoices: sampleMilestoneChoices() }
     }
     s.nextWaveAt = s.gameTimeMs + BETWEEN_WAVE_MS
     const nextWave = generateWave(s.currentWaveIndex)

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -12279,6 +12279,46 @@ html.light-mode .action-btn {
   margin-top: 1px;
 }
 .td-enemy-hp-fill { height: 100%; border-radius: 2px; transition: width 0.05s; }
+.td-enemy--shielded { filter: drop-shadow(0 0 3px #4fc3f7) drop-shadow(0 0 6px #0288d1); }
+.td-enemy--slows    { filter: drop-shadow(0 0 3px #ce93d8) drop-shadow(0 0 6px #7b1fa2); }
+
+/* ── Milestone reward choices ── */
+.td-milestone-choices {
+  flex-shrink: 0;
+  padding: 8px 10px;
+  background: rgba(0,0,0,0.7);
+  border-bottom: 1px solid #ffd700;
+}
+.td-milestone-choices-title {
+  font-size: 11px;
+  font-weight: bold;
+  color: #ffd700;
+  text-align: center;
+  margin-bottom: 6px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+}
+.td-milestone-choices-cards {
+  display: flex;
+  gap: 8px;
+}
+.td-milestone-choice-card {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3px;
+  padding: 8px 6px;
+  background: #111;
+  border: 1px solid #444;
+  border-radius: 6px;
+  cursor: pointer;
+  font-family: 'Courier New', monospace;
+  transition: border-color 0.15s, background 0.15s;
+}
+.td-milestone-choice-card:hover { border-color: #ffd700; background: #1a1600; }
+.td-milestone-choice-label { font-size: 11px; font-weight: bold; color: #ffd700; }
+.td-milestone-choice-desc  { font-size: 9px; color: #bbb; text-align: center; }
 
 /* ── Selected tower action panel ── */
 .td-selected-panel {


### PR DESCRIPTION
## Summary

- **Enemies**: sorted by path progress each tick so the most-advanced enemy claims its destination cell first. A trailing enemy that would enter an occupied cell holds position and claims its current cell instead — creating a natural convoy/traffic-jam effect.
- **Units**: `claimCellNear()` tries the ideal target cell (enemy's cell or home cell) then its 8 neighbours, all filtered to within `UNIT_REACH_PX` of the unit's building. Multiple units from the same building naturally spread to adjacent cells around an enemy and continue attacking from there if in range.
- **Rendering**: reverts from grouped `UnitGroupToken` back to individual `UnitToken` — since units are now at distinct positions they no longer stack, so grouping isn't needed.

## Test plan

- [ ] Two enemies at the same path segment — confirm they don't overlap; the trailing one pauses behind the leader
- [ ] Place a building, upgrade to 3 units — when an enemy approaches, the 3 units spread to 3 adjacent cells rather than all piling on the same pixel
- [ ] Units in adjacent cells still attack the enemy (range ≥ 1 cell)
- [ ] When no enemy is nearby, multiple units from the same building spread to adjacent idle cells rather than all returning to the exact same building cell

https://claude.ai/code/session_014PWcdZxQ19J95UxKwDEvqz

---
_Generated by [Claude Code](https://claude.ai/code/session_014PWcdZxQ19J95UxKwDEvqz)_