### PR TITLE
fix(tower-defence): group units by building into single cell entity

### DIFF
--- a/web/src/components/minigames/TowerDefence.tsx
+++ b/web/src/components/minigames/TowerDefence.tsx
@@ -369,9 +369,16 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
             })
           )}
 
-          {/* Player units — each at its own cell (cell occupancy enforced in game logic) */}
-          {game.units.map(unit => (
-            <UnitToken key={unit.id} unit={unit} />
+          {/* Player units — grouped per building, one cell per group */}
+          {Array.from(
+            game.units.reduce((map, u) => {
+              const g = map.get(u.towerId) ?? []
+              g.push(u)
+              map.set(u.towerId, g)
+              return map
+            }, new Map<number, TDUnit[]>())
+          ).map(([towerId, units]) => (
+            <UnitGroupToken key={towerId} units={units} />
           ))}
 
           {/* Enemies */}
@@ -496,19 +503,47 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
   )
 }
 
-// ── Player unit token ─────────────────────────────────────────────────────────
+// ── Player unit group token (all units from same building move as one) ────────
 
-function UnitToken({ unit }: { unit: TDUnit }) {
-  const size = 15
-  const hpFrac = unit.hp / unit.maxHp
+function UnitGroupToken({ units }: { units: TDUnit[] }) {
+  const lead = units[0]
+  const stationed = units.some(u => u.stationed)
+  const minHpFrac = Math.min(...units.map(u => u.hp / u.maxHp))
+  const n = units.length
+  const sz = 15, gap = 3
+
+  let slots: Array<{ dx: number; dy: number }>
+  let containerW: number, containerH: number
+
+  if (n >= 3) {
+    containerW = sz * 2 + gap; containerH = sz * 2 + gap
+    slots = [
+      { dx: (containerW - sz) / 2, dy: 0 },
+      { dx: 0, dy: sz + gap },
+      { dx: sz + gap, dy: sz + gap },
+    ]
+  } else if (n === 2) {
+    containerW = sz * 2 + gap; containerH = sz
+    slots = [{ dx: 0, dy: 0 }, { dx: sz + gap, dy: 0 }]
+  } else {
+    containerW = sz; containerH = sz
+    slots = [{ dx: 0, dy: 0 }]
+  }
+
   return (
     <div
-      className={`td-unit${unit.stationed ? ' td-unit--stationed' : ' td-unit--walking'}`}
-      style={{ transform: `translate(${unit.x - size / 2}px, ${unit.y - size / 2}px)`, width: size }}
+      className={`td-unit${stationed ? ' td-unit--stationed' : ' td-unit--walking'}`}
+      style={{ transform: `translate(${lead.x - containerW / 2}px, ${lead.y - containerH / 2}px)`, width: containerW }}
     >
-      <AnimatedSpriteImg name={unit.template.name} frameCount={3} fps={unit.stationed ? 4 : 8} className="td-unit-sprite" />
+      <div style={{ position: 'relative', width: containerW, height: containerH }}>
+        {slots.map((slot, i) => (
+          <div key={i} style={{ position: 'absolute', left: slot.dx, top: slot.dy, width: sz, height: sz }}>
+            <AnimatedSpriteImg name={units[i].template.name} frameCount={3} fps={stationed ? 4 : 8} className="td-unit-sprite" />
+          </div>
+        ))}
+      </div>
       <div className="td-enemy-hp-bar">
-        <div className="td-enemy-hp-fill" style={{ width: `${hpFrac * 100}%`, background: hpBarColor(hpFrac) }} />
+        <div className="td-enemy-hp-fill" style={{ width: `${minHpFrac * 100}%`, background: hpBarColor(minHpFrac) }} />
       </div>
     </div>
   )

--- a/web/src/game/towerDefence.ts
+++ b/web/src/game/towerDefence.ts
@@ -689,7 +689,7 @@ export function tickTD(state: TDGameState, dtMs: number): TDGameState {
   function claimCellNear(
     preferCol: number, preferRow: number,
     homeX: number, homeY: number,
-    unitId: number,
+    claimId: number,
   ): { x: number; y: number } | null {
     // Try preferred cell first, then 8 neighbours, all within UNIT_REACH_PX
     const candidates: Array<{ col: number; row: number }> = [
@@ -705,36 +705,49 @@ export function tickTD(state: TDGameState, dtMs: number): TDGameState {
       const cx = col * TD_CELL_PX + TD_CELL_PX / 2
       const cy = row * TD_CELL_PX + TD_CELL_PX / 2
       if (dist(cx, cy, homeX, homeY) > UNIT_REACH_PX) continue
-      claimedUnitCells.set(key, unitId)
+      claimedUnitCells.set(key, claimId)
       return { x: cx, y: cy }
     }
     return null
   }
 
-  const movedUnits: TDUnit[] = []
+  // Group by towerId so all units from the same building move as one entity
+  const unitsByTower = new Map<number, TDUnit[]>()
   for (const unit of s.units) {
-    const nearbyEnemy = s.enemies
-      .filter(e => dist(e.x, e.y, unit.homeX, unit.homeY) <= UNIT_REACH_PX + TD_CELL_PX * 0.5)
-      .sort((a, b) => dist(a.x, a.y, unit.x, unit.y) - dist(b.x, b.y, unit.x, unit.y))[0] ?? null
+    const g = unitsByTower.get(unit.towerId) ?? []
+    g.push(unit)
+    unitsByTower.set(unit.towerId, g)
+  }
 
+  const movedUnits: TDUnit[] = []
+  for (const [towerId, group] of unitsByTower) {
+    const leader = group[0]
+    const nearbyEnemy = s.enemies
+      .filter(e => dist(e.x, e.y, leader.homeX, leader.homeY) <= UNIT_REACH_PX + TD_CELL_PX * 0.5)
+      .sort((a, b) => dist(a.x, a.y, leader.x, leader.y) - dist(b.x, b.y, leader.x, leader.y))[0] ?? null
+
+    // One cell claimed for the whole group (towerId is the claim key)
     const destXY = nearbyEnemy
       ? claimCellNear(
           Math.floor(nearbyEnemy.x / TD_CELL_PX), Math.floor(nearbyEnemy.y / TD_CELL_PX),
-          unit.homeX, unit.homeY, unit.id,
+          leader.homeX, leader.homeY, towerId,
         )
       : claimCellNear(
-          Math.floor(unit.homeX / TD_CELL_PX), Math.floor(unit.homeY / TD_CELL_PX),
-          unit.homeX, unit.homeY, unit.id,
+          Math.floor(leader.homeX / TD_CELL_PX), Math.floor(leader.homeY / TD_CELL_PX),
+          leader.homeX, leader.homeY, towerId,
         )
 
-    let newX = unit.x, newY = unit.y
-    if (destXY) {
-      const dx = destXY.x - unit.x, dy = destXY.y - unit.y
-      const d = Math.sqrt(dx * dx + dy * dy)
-      const step = UNIT_WALK_SPEED_PX * dtSec
-      if (d > 2) { newX = unit.x + dx / d * Math.min(step, d); newY = unit.y + dy / d * Math.min(step, d) }
+    // Move every unit in the group toward the same destination
+    for (const unit of group) {
+      let newX = unit.x, newY = unit.y
+      if (destXY) {
+        const dx = destXY.x - unit.x, dy = destXY.y - unit.y
+        const d = Math.sqrt(dx * dx + dy * dy)
+        const step = UNIT_WALK_SPEED_PX * dtSec
+        if (d > 2) { newX = unit.x + dx / d * Math.min(step, d); newY = unit.y + dy / d * Math.min(step, d) }
+      }
+      movedUnits.push({ ...unit, x: newX, y: newY, stationed: nearbyEnemy !== null })
     }
-    movedUnits.push({ ...unit, x: newX, y: newY, stationed: nearbyEnemy !== null })
   }
   s.units = movedUnits
 


### PR DESCRIPTION
## Summary

Units from the same spawner building now claim a single cell as a group (keyed by `towerId`) and all move together to the same destination. This fixes the previous PR which accidentally spread each unit to its own individual cell.

- Movement: groups units by `towerId` before the cell-claiming loop; one `claimCellNear()` call per building, all units in the group follow that destination
- Rendering: restores `UnitGroupToken` (1 solo 15px sprite, 2 side-by-side, 3 in a V-shape)
- Cell occupancy still applies between groups — two different buildings can't occupy the same cell

## Test plan

- [ ] Single building: unit moves to enemy as before, renders as one sprite
- [ ] Upgraded building (2–3 units): group moves together as one entity, renders as tiled sprites
- [ ] Two buildings: their groups claim separate cells and don't overlap

https://claude.ai/code/session_014PWcdZxQ19J95UxKwDEvqz

---
_Generated by [Claude Code](https://claude.ai/code/session_014PWcdZxQ19J95UxKwDEvqz)_