### PR TITLE
feat: dynamic stance rules by node type (#1067)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4,7 +4,7 @@ import { usePlaytime } from './hooks/usePlaytime'
 import { useStartupData } from './hooks/useStartupData'
 import { useCloudSync } from './hooks/useCloudSync'
 import { useRegisterSW } from 'virtual:pwa-register/react'
-import { GameState, Card } from './game/types'
+import { GameState, Card, StanceRules } from './game/types'
 import { newGame, MAX_HANDICAP } from './game/engine'
 import { playCard, playAoeCard } from './game/engine/cards'
 import { makeNodeDeck } from './game/cards'
@@ -197,6 +197,15 @@ type Screen =
   | 'statupgrade'
   | 'camp'
 
+
+const STANCE_RULES_BY_NODE_TYPE: Partial<Record<string, StanceRules>> = {
+  // Normal battles: no restrictions (current behaviour)
+  battle: undefined,
+  // Elite: 15 s duration, 20 s cooldown — timing tactics matter
+  elite: { allowed: ['auto', 'attack', 'hold', 'defend'], durationMs: 15_000, cooldownMs: 20_000 },
+  // Boss: defend and auto only — must react to the boss, can't mass-charge
+  boss: { allowed: ['auto', 'defend'] },
+}
 
 function formatTimeAgo(date: Date): string {
   const diffMin = Math.round((Date.now() - date.getTime()) / 60_000)
@@ -809,6 +818,7 @@ export default function App() {
           const state = newGame({ playerCards, ...resolvedNodeOpts(node, act, loadRunCount(), mods) })
           state.playerBase = { hp: activeRun.playerHp, maxHp: activeRun.maxHp }
           if (activeRun.activeRelic) getRelicDef(activeRun.activeRelic)?.applyToGame(state)
+          state.stanceRules = STANCE_RULES_BY_NODE_TYPE[node.type]
           startBattle(state)
           rollRareEvent()
           return
@@ -990,6 +1000,7 @@ export default function App() {
     const state = newGame({ playerCards, ...resolvedNodeOpts(node, act, loadRunCount(), mods733) })
     state.playerBase = { hp: updatedRun.playerHp, maxHp: updatedRun.maxHp }
     if (updatedRun.activeRelic) getRelicDef(updatedRun.activeRelic)?.applyToGame(state)
+    state.stanceRules = STANCE_RULES_BY_NODE_TYPE[node.type]
     startBattle(state)
     rollRareEvent()
   }, [run])
@@ -1019,6 +1030,7 @@ export default function App() {
     const state = newGame({ playerCards, ...resolvedNodeOpts(node, act, loadRunCount(), mods761) })
     state.playerBase = { hp: run.playerHp, maxHp: run.maxHp }
     if (run.activeRelic) getRelicDef(run.activeRelic)?.applyToGame(state)
+    state.stanceRules = STANCE_RULES_BY_NODE_TYPE[node.type]
     startBattle(state)
     rollRareEvent()
   }, [bossDialogueNode, run])
@@ -1621,6 +1633,7 @@ export default function App() {
     const state = newGame({ playerCards, ...resolvedNodeOpts(node, act, loadRunCount(), modsRetry) })
     state.playerBase = { hp: withFail.playerHp, maxHp: withFail.maxHp }
     if (withFail.activeRelic) getRelicDef(withFail.activeRelic)?.applyToGame(state)
+    state.stanceRules = STANCE_RULES_BY_NODE_TYPE[node.type]
     startBattle(state)
     rollRareEvent()
   }, [run])

--- a/web/src/components/Battlefield.tsx
+++ b/web/src/components/Battlefield.tsx
@@ -1032,21 +1032,48 @@ export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPaus
       </div>
 
       {/* Stance + speed controls */}
-      <div className="stance-bar">
-        {(['attack', 'hold', 'defend', 'auto'] as const).map(s => (
-          <button
-            key={s}
-            className={`filter-btn${stance === s ? ' filter-btn--active' : ''}`}
-            onClick={() => onSetStance?.(s)}
-            disabled={state.suddenDeath && s !== 'attack'}
-          >
-            {s === 'attack' ? 'ATTACK' : s === 'hold' ? 'HOLD' : s === 'defend' ? 'DEFEND' : 'AUTO'}
-          </button>
-        ))}
-        <button className="filter-btn stance-bar__speed" onClick={onCycleSpeed}>
-          x{speedMultiplier}
-        </button>
-      </div>
+      {(() => {
+        const rules = state.stanceRules
+        const onCooldown = rules?.cooldownMs !== undefined &&
+          state.stanceCooldownUntil !== undefined &&
+          state.gameTime < state.stanceCooldownUntil
+        const cooldownSecsLeft = onCooldown
+          ? Math.ceil((state.stanceCooldownUntil! - state.gameTime) / 1000)
+          : 0
+        const durationSecsLeft = (state.stanceActiveUntil !== undefined && stance !== 'auto')
+          ? Math.ceil((state.stanceActiveUntil - state.gameTime) / 1000)
+          : 0
+
+        return (
+          <div className="stance-bar">
+            {(['attack', 'hold', 'defend', 'auto'] as const).map(s => {
+              const isAllowed = !rules || rules.allowed.includes(s)
+              if (!isAllowed) return null
+              const label = s === 'attack' ? 'ATTACK' : s === 'hold' ? 'HOLD' : s === 'defend' ? 'DEFEND' : 'AUTO'
+              const isActive = stance === s
+              const isCoolingDown = onCooldown && s !== 'auto' && !isActive
+              const showCountdown = isActive && s !== 'auto' && durationSecsLeft > 0
+              const showCooldown  = isCoolingDown && cooldownSecsLeft > 0
+              return (
+                <button
+                  key={s}
+                  className={`filter-btn${isActive ? ' filter-btn--active' : ''}${isCoolingDown ? ' filter-btn--cooldown' : ''}`}
+                  onClick={() => onSetStance?.(s)}
+                  disabled={(state.suddenDeath && s !== 'attack') || isCoolingDown}
+                  title={isCoolingDown ? `Available in ${cooldownSecsLeft}s` : undefined}
+                >
+                  {label}
+                  {showCountdown && <span className="stance-timer"> {durationSecsLeft}s</span>}
+                  {showCooldown  && <span className="stance-timer stance-timer--cd"> {cooldownSecsLeft}s</span>}
+                </button>
+              )
+            })}
+            <button className="filter-btn stance-bar__speed" onClick={onCycleSpeed}>
+              x{speedMultiplier}
+            </button>
+          </div>
+        )
+      })()}
 
       {/* Hand */}
       <div className="hand-panel">

--- a/web/src/game/battleReducer.ts
+++ b/web/src/game/battleReducer.ts
@@ -166,7 +166,39 @@ export function battleReducer(state: BattleState, action: BattleAction): BattleS
 
     case 'SET_STANCE': {
       if (!state.gameState) return state
-      return { ...state, gameState: { ...state.gameState, playerStance: action.stance } }
+      const gs = state.gameState
+      const rules = gs.stanceRules
+      const newStance = action.stance
+
+      // Block disallowed stances
+      if (rules && !rules.allowed.includes(newStance)) return state
+
+      // Block non-auto activation while on cooldown
+      if (newStance !== 'auto' && rules?.cooldownMs !== undefined &&
+          gs.stanceCooldownUntil !== undefined && gs.gameTime < gs.stanceCooldownUntil) {
+        return state
+      }
+
+      // When manually switching back to auto from a non-auto stance, start cooldown
+      const wasNonAuto = (gs.playerStance ?? 'auto') !== 'auto'
+      const cooldownUntil = (wasNonAuto && newStance === 'auto' && rules?.cooldownMs !== undefined)
+        ? gs.gameTime + rules.cooldownMs
+        : gs.stanceCooldownUntil
+
+      // Set expiry for timed non-auto stances
+      const activeUntil = (newStance !== 'auto' && rules?.durationMs !== undefined)
+        ? gs.gameTime + rules.durationMs
+        : undefined
+
+      return {
+        ...state,
+        gameState: {
+          ...gs,
+          playerStance: newStance,
+          stanceActiveUntil: activeUntil,
+          stanceCooldownUntil: cooldownUntil,
+        },
+      }
     }
 
     case 'SET_SPEED':

--- a/web/src/game/engine.ts
+++ b/web/src/game/engine.ts
@@ -411,6 +411,15 @@ export function tick(state: GameState, deltaMs: number): GameState {
 
   s.gameTime += deltaMs
 
+  // 0. Expire timed stance → revert to auto, start cooldown
+  if (s.stanceActiveUntil !== undefined && s.gameTime >= s.stanceActiveUntil) {
+    s.playerStance = 'auto'
+    s.stanceActiveUntil = undefined
+    if (s.stanceRules?.cooldownMs !== undefined) {
+      s.stanceCooldownUntil = s.gameTime + s.stanceRules.cooldownMs
+    }
+  }
+
   // 1. Mana regen
   regenerateMana(s, deltaMs)
 

--- a/web/src/game/types.ts
+++ b/web/src/game/types.ts
@@ -339,4 +339,18 @@ export interface GameState {
   deckMaxMana?: number
   /** Player unit movement stance. Defaults to 'auto' (original behaviour). */
   playerStance?: 'auto' | 'attack' | 'hold' | 'defend'
+  /** Rules governing stance availability; undefined = no restrictions (current behaviour). */
+  stanceRules?: StanceRules
+  /** gameTime ms at which the current non-auto stance auto-expires. */
+  stanceActiveUntil?: number
+  /** gameTime ms before which no non-auto stance can be activated (cooldown). */
+  stanceCooldownUntil?: number
+}
+
+export interface StanceRules {
+  allowed: Array<'auto' | 'attack' | 'hold' | 'defend'>
+  /** How long a non-auto stance lasts before auto-reverting to 'auto' (ms). Omit for no limit. */
+  durationMs?: number
+  /** How long the player must wait after a stance expires before activating another (ms). */
+  cooldownMs?: number
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1952,6 +1952,21 @@ body {
   background: rgba(51, 255, 51, 0.08);
 }
 
+.filter-btn--cooldown {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.stance-timer {
+  font-size: 0.7em;
+  opacity: 0.85;
+  margin-left: 3px;
+}
+
+.stance-timer--cd {
+  color: #ff9944;
+}
+
 .filter-group-label {
   font-size: 0.643rem;
   color: var(--game-text-color-muted);


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Normal battles**: all stances available, no duration limit, no cooldown — current behaviour preserved
- **Elite battles**: all stances available; each non-auto stance lasts 15 s then auto-reverts to AUTO, followed by a 20 s cooldown before the next stance can be activated
- **Boss battles**: only AUTO and DEFEND are available — mass-charge via ATTACK is removed, forcing reactive play against the boss

## How it works

- New `StanceRules` type (`allowed`, `durationMs`, `cooldownMs`) injected into `GameState` at battle start based on `node.type`
- Engine tick expires timed stances and starts the cooldown automatically
- `SET_STANCE` reducer validates allowed list and blocks activation during cooldown
- Battlefield UI: active stance shows a live countdown (`DEFEND 12s`), cooling-down buttons show remaining wait time and are dimmed/disabled

## Test plan

- [ ] Normal battle — all four stance buttons work freely with no timer
- [ ] Elite battle — activating ATTACK/HOLD/DEFEND shows a countdown; after 15 s it reverts to AUTO; buttons show cooldown timer for 20 s
- [ ] Elite battle — manually switching back to AUTO while a stance is active also triggers the 20 s cooldown
- [ ] Boss battle — only AUTO and DEFEND buttons are visible; ATTACK and HOLD are hidden
- [ ] Sudden death still forces ATTACK and disables other stances as before

https://claude.ai/code/session_01FFXw8rUxBVQRtJK8x762WJ
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FFXw8rUxBVQRtJK8x762WJ)_