### PR TITLE
feat: commander units replace base HP + stance label rename

### DIFF
--- a/web/public/sprites/commander.svg
+++ b/web/public/sprites/commander.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Body -->
+  <rect x="11" y="14" width="10" height="11" rx="2" fill="#4a9e4a"/>
+  <!-- Head -->
+  <circle cx="16" cy="10" r="5" fill="#f0c87a"/>
+  <!-- Helmet -->
+  <path d="M11 10 Q11 4 16 4 Q21 4 21 10" fill="#3a7a3a"/>
+  <!-- Plume -->
+  <path d="M16 4 Q14 1 13 0 Q15 2 16 4 Q17 2 19 0 Q18 1 16 4" fill="#e04040"/>
+  <!-- Shield (left arm) -->
+  <rect x="7" y="14" width="5" height="8" rx="1" fill="#2a5a8a"/>
+  <line x1="9.5" y1="14" x2="9.5" y2="22" stroke="#4a8acc" stroke-width="1"/>
+  <!-- Sword (right arm) -->
+  <rect x="20" y="11" width="2.5" height="13" rx="0.5" fill="#c0c0c0"/>
+  <rect x="18.5" y="16" width="5.5" height="1.5" rx="0.5" fill="#8a6a20"/>
+  <!-- Legs -->
+  <rect x="11" y="24" width="4" height="5" rx="1" fill="#3a7a3a"/>
+  <rect x="16" y="24" width="4" height="5" rx="1" fill="#3a7a3a"/>
+  <!-- Boots -->
+  <rect x="10.5" y="28" width="5" height="3" rx="1" fill="#3a2010"/>
+  <rect x="15.5" y="28" width="5" height="3" rx="1" fill="#3a2010"/>
+</svg>

--- a/web/public/sprites/warlord.svg
+++ b/web/public/sprites/warlord.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Body -->
+  <rect x="11" y="14" width="10" height="11" rx="2" fill="#8a2020"/>
+  <!-- Head -->
+  <circle cx="16" cy="10" r="5" fill="#c8a060"/>
+  <!-- Helmet -->
+  <path d="M11 10 Q11 4 16 4 Q21 4 21 10" fill="#6a1818"/>
+  <!-- Horns -->
+  <path d="M11 6 Q8 2 7 0 Q10 3 11 6" fill="#d0c040"/>
+  <path d="M21 6 Q24 2 25 0 Q22 3 21 6" fill="#d0c040"/>
+  <!-- Axe (right arm) -->
+  <rect x="20" y="10" width="2.5" height="14" rx="0.5" fill="#7a5020"/>
+  <path d="M20 10 Q25 8 25 14 Q23 13 20 14 Z" fill="#9a9a9a"/>
+  <!-- Shield arm (left) -->
+  <rect x="7" y="14" width="5" height="8" rx="1" fill="#5a1818"/>
+  <circle cx="9.5" cy="18" r="2" fill="#d0c040"/>
+  <!-- Legs -->
+  <rect x="11" y="24" width="4" height="5" rx="1" fill="#6a1818"/>
+  <rect x="16" y="24" width="4" height="5" rx="1" fill="#6a1818"/>
+  <!-- Boots -->
+  <rect x="10.5" y="28" width="5" height="3" rx="1" fill="#201008"/>
+  <rect x="15.5" y="28" width="5" height="3" rx="1" fill="#201008"/>
+</svg>

--- a/web/src/components/Battlefield.tsx
+++ b/web/src/components/Battlefield.tsx
@@ -1049,7 +1049,7 @@ export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPaus
             {(['attack', 'hold', 'defend', 'auto'] as const).map(s => {
               const isAllowed = !rules || rules.allowed.includes(s)
               if (!isAllowed) return null
-              const label = s === 'attack' ? 'ATTACK' : s === 'hold' ? 'HOLD' : s === 'defend' ? 'DEFEND' : 'AUTO'
+              const label = s === 'attack' ? 'CHARGE' : s === 'hold' ? 'HOLD' : s === 'defend' ? 'DEFEND' : 'ATTACK'
               const isActive = stance === s
               const isCoolingDown = onCooldown && s !== 'auto' && !isActive
               const showCountdown = isActive && s !== 'auto' && durationSecsLeft > 0

--- a/web/src/game/engine.ts
+++ b/web/src/game/engine.ts
@@ -4,7 +4,7 @@ import { loadPlayerStats } from './playerStats'
 
 import { moveUnits, processAffinities } from './engine/units'
 import { processAttacks } from './engine/combat'
-import { BASE_MAX_MANA, BLOOD_POOL_FADE_MS, BASE_STOP_MARGIN, MANA_REGEN_MS, OPPONENT_INTERVAL_MS, PLAYER_SPAWN_X, SPAWN_GROW_MS } from './engine/constants'
+import { BASE_MAX_MANA, BLOOD_POOL_FADE_MS, BASE_STOP_MARGIN, MANA_REGEN_MS, OPPONENT_INTERVAL_MS, PLAYER_SPAWN_X, SPAWN_GROW_MS, COMMANDER_HOME_X } from './engine/constants'
 import { genericBossAI, getBossAIDef } from './engine/boss'
 import { tickBossTrait } from './engine/bossTraits'
 import { getManaBonus, getManaSpeedMult } from './engine/bonusEffects'
@@ -92,6 +92,21 @@ const STRATEGY_LABELS: Record<GameState['opponentStrategy'], string> = {
 }
 
 /** Inject one hero card into the first ~8 positions of a shuffled deck. */
+function spawnCommander(owner: 'player' | 'opponent', hp: number): import('./types').Unit {
+  const homeX = owner === 'player' ? COMMANDER_HOME_X : LANE_WIDTH - COMMANDER_HOME_X
+  const unit = spawnUnit(
+    { name: owner === 'player' ? 'Commander' : 'Warlord',
+      attack: 15, maxHp: hp, isWall: false, bypassWall: false,
+      moveSpeed: 8, attackRange: 35, attackCooldownMs: 2000 },
+    owner
+  )
+  unit.isCommander    = true
+  unit.commanderHomeX = homeX
+  unit.x              = homeX
+  unit.y              = 0
+  return unit
+}
+
 function injectHero(deck: Card[], heroPool: Card[]): void {
   if (heroPool.length === 0) return
   const hero = heroPool[Math.floor(Math.random() * heroPool.length)]
@@ -243,10 +258,33 @@ export function newGame(
     : undefined
   const maxMana = forgiveManaLimit ? 9 : Math.max(BASE_MAX_MANA, deckMaxMana ?? 0, loadPlayerStats().maxMana)
 
+  const baseOpponentHp = hpOverride ?? (boss ? 95 : 82)
+  const initialField: import('./types').Unit[] = []
+  let opponentBaseHp  = baseOpponentHp
+  let bossPhase2Hp: number | undefined
+
+  if (bossCard && !endlessMode) {
+    // Boss battle: spawn boss immediately with combined HP (base portion + boss portion)
+    const template = getCardUnit(bossCard)
+    if (template) {
+      const mult       = bossHpMultiplier ?? 25
+      const boostedHp  = Math.round(template.maxHp * mult)
+      const totalHp    = boostedHp + baseOpponentHp
+      const bossUnit   = spawnUnit({ ...template, maxHp: totalHp }, 'opponent')
+      initialField.push(bossUnit)
+      opponentBaseHp = totalHp
+      bossPhase2Hp   = boostedHp   // phase 2 triggers when boss.hp drops to this
+    }
+  } else if (!endlessMode) {
+    // Normal/elite battle: spawn commander units at each base
+    initialField.push(spawnCommander('player', 50))
+    initialField.push(spawnCommander('opponent', baseOpponentHp))
+  }
+
   return {
     playerBase: { hp: 50, maxHp: 50 },
-    opponentBase: { hp: hpOverride ?? (boss ? 95 : 82), maxHp: hpOverride ?? (boss ? 95 : 82) },
-    field: [],
+    opponentBase: { hp: opponentBaseHp, maxHp: opponentBaseHp },
+    field: initialField,
     playerHand,
     playerDeck,
     opponentHand,
@@ -292,6 +330,7 @@ export function newGame(
     bossSpawnKillPct: bossSpawnKillPct ?? 0.5,
     forgiveManaLimit: forgiveManaLimit ?? false,
     deckMaxMana,
+    bossPhase2Hp,
   }
 }
 
@@ -339,51 +378,45 @@ function checkGameOver(s: GameState): boolean {
     s.phase = { type: 'gameOver', winner: 'opponent' }
     return true
   }
-  if (s.opponentBase.hp <= 0) {
-    if (s.endlessMode) return triggerNextEndlessWave(s)
-    if (s.bossCard && !s.bossCardActive) {
-      // Trigger phase 2: restore base, clear opponent minions, push player units back, deploy boss
-      s.opponentBase.hp = s.opponentBase.maxHp
-      s.field = s.field.filter(u => u.owner !== 'opponent')
-      s.field.forEach(u => { if (u.owner === 'player') u.x = PLAYER_SPAWN_X })
-      const template = getCardUnit(s.bossCard)
-      if (template) {
-        const mult = s.bossHpMultiplier ?? 25
-        const boostedTemplate = { ...template, maxHp: Math.round(template.maxHp * mult) }
-        const bossUnit = spawnUnit(boostedTemplate, 'opponent')
-        s.field.push(bossUnit)
-        const displayName = s.bossName ?? s.bossCard
-        s.log.push(`!!⚡ PHASE 2! ${displayName} rises from the ruins!`)
-        s.log.push(`!!Destroy ${displayName} to win!`)
 
-        // Shockwave: kills a scaling fraction of player's mobile non-hero units, always leaving at least 3
-        const shockwavePool = s.field.filter(
-          u => u.owner === 'player' && u.moveSpeed > 0 && !u.isHero && !u.dyingTimer
-        )
-        const MIN_SURVIVORS = 3
-        const killPct = Math.min(1.0, s.bossSpawnKillPct ?? 0.5)
-        let killCount = Math.floor(shockwavePool.length * killPct)
-        killCount = Math.min(killCount, Math.max(0, shockwavePool.length - MIN_SURVIVORS))
-        if (killCount > 0) {
-          const shuffled = [...shockwavePool]
-          for (let i = shuffled.length - 1; i > 0; i--) {
-            const j = Math.floor(Math.random() * (i + 1));
-            [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]]
-          }
-          const victims = shuffled.slice(0, killCount)
-          const victimIds = new Set(victims.map(u => u.id))
-          s.field = s.field.filter(u => !victimIds.has(u.id))
-          s.log.push(`💥 The shockwave obliterates ${victims.map(u => u.name).join(', ')}!`)
+  // Boss battle phase 2: boss spawns at game start — trigger phase 2 when HP drops to the threshold
+  if (s.bossCard && !s.bossCardActive && s.bossPhase2Hp !== undefined && !s.endlessMode) {
+    const bossUnit = s.field.find(u => u.owner === 'opponent' && u.name === s.bossCard && u.hp > 0)
+    if (bossUnit && bossUnit.hp <= s.bossPhase2Hp) {
+      const displayName = s.bossName ?? s.bossCard
+      // Clear minions but keep the boss unit
+      s.field = s.field.filter(u => u.owner !== 'opponent' || u.name === s.bossCard)
+      s.field.forEach(u => { if (u.owner === 'player') u.x = PLAYER_SPAWN_X })
+      s.log.push(`!!⚡ PHASE 2! ${displayName} stomps the ground in fury!`)
+      s.log.push(`!!Destroy ${displayName} to win!`)
+
+      // Shockwave: kills a scaling fraction of player's mobile non-hero units, always leaving at least 3
+      const shockwavePool = s.field.filter(
+        u => u.owner === 'player' && u.moveSpeed > 0 && !u.isHero && !u.dyingTimer
+      )
+      const MIN_SURVIVORS = 3
+      const killPct = Math.min(1.0, s.bossSpawnKillPct ?? 0.5)
+      let killCount = Math.floor(shockwavePool.length * killPct)
+      killCount = Math.min(killCount, Math.max(0, shockwavePool.length - MIN_SURVIVORS))
+      if (killCount > 0) {
+        const shuffled = [...shockwavePool]
+        for (let i = shuffled.length - 1; i > 0; i--) {
+          const j = Math.floor(Math.random() * (i + 1))
+          ;[shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]]
         }
+        const victims = shuffled.slice(0, killCount)
+        const victimIds = new Set(victims.map(u => u.id))
+        s.field = s.field.filter(u => !victimIds.has(u.id))
+        s.log.push(`💥 The shockwave obliterates ${victims.map(u => u.name).join(', ')}!`)
       }
+
       s.bossCardActive = true
-      // Reset boss trait state so hp_pct thresholds re-fire against the boss unit HP in phase 2
+      // Reset boss trait state so hp_pct thresholds re-fire in phase 2
       if (s.bossTraitState) {
         s.bossTraitState.firedThresholds = []
         s.bossTraitState.traitFired = false
         const bDef = s.bossAI ? getBossAIDef(s.bossAI) : undefined
         if (bDef?.trait?.trigger === 'periodic') {
-          // Allow first periodic ability to fire ~5s after phase 2 starts
           const interval = bDef.trait.triggerIntervalMs ?? 30000
           s.bossTraitState.lastTraitFireMs = s.gameTime - interval + 5000
         } else {
@@ -392,10 +425,19 @@ function checkGameOver(s: GameState): boolean {
       }
       return false
     }
+    return false
+  }
+
+  // Endless mode: wave clear when opponent base reaches 0
+  if (s.opponentBase.hp <= 0 && s.endlessMode) return triggerNextEndlessWave(s)
+
+  // Non-boss win: opponent commander dead (synced to opponentBase.hp)
+  if (s.opponentBase.hp <= 0 && !s.bossCard) {
     s.playerScore += VICTORY_BONUS
     s.phase = { type: 'celebration', winner: 'player' }
     return true
   }
+
   return false
 }
 
@@ -434,6 +476,22 @@ export function tick(state: GameState, deltaMs: number): GameState {
 
   // 4. Process per-unit attacks
   processAttacks(s, deltaMs, log)
+
+  // 4a. Sync commander/boss HP → base HP so game-over check and UI bars are accurate
+  const playerCmd = s.field.find(u => u.isCommander && u.owner === 'player')
+  if (playerCmd) {
+    s.playerBase.hp = Math.max(0, playerCmd.hp)
+  } else if (s.field.some(u => u.isCommander && u.owner === 'player')) {
+    s.playerBase.hp = 0  // commander is dying (dyingTimer still running)
+  }
+  if (s.bossCard && !s.endlessMode) {
+    const bossUnit = s.field.find(u => u.owner === 'opponent' && u.name === s.bossCard && u.hp > 0)
+    if (bossUnit) s.opponentBase.hp = bossUnit.hp
+  } else {
+    const opCmd = s.field.find(u => u.isCommander && u.owner === 'opponent')
+    if (opCmd) s.opponentBase.hp = Math.max(0, opCmd.hp)
+    else if (s.field.some(u => u.isCommander && u.owner === 'opponent')) s.opponentBase.hp = 0
+  }
 
   // 4b. Check for game over before processing timers, so player still gets credit for killing a boss in the same tick that it kills them
   if (checkGameOver(s)) {

--- a/web/src/game/engine/combat.ts
+++ b/web/src/game/engine/combat.ts
@@ -1,6 +1,6 @@
 import { isNoDamageMode } from '../debug'
-import { playBuildingDestroyed, playUnitDeath, playUnitAttack, playBaseHit } from '../sound'
-import { AnimEvent, GameState, LANE_WIDTH, Unit } from '../types'
+import { playBuildingDestroyed, playUnitDeath, playUnitAttack } from '../sound'
+import { AnimEvent, GameState, Unit } from '../types'
 import { DAMAGE_FLASH_MS, BLOOD_POOL_MAX } from './constants'
 import { getAttackAura } from './bonusEffects'
 import { animUid, spawnUnit } from './helpers'
@@ -141,43 +141,6 @@ export function processAttacks(s: GameState, deltaMs: number, log: string[]): vo
       const affSpeedMult = (unit.affinityActive && unit.affinity?.effectType === 'attackSpeed')
         ? unit.affinity.effectAmount : 1
       unit.attackTimer = unit.attackCooldownMs / affSpeedMult
-    } else {
-      // No enemies in range — attack the base if close enough
-      const baseDist = isPlayer
-        ? Math.hypot(LANE_WIDTH - unit.x, unit.y)
-        : Math.hypot(unit.x, unit.y)
-
-      if (baseDist <= unit.attackRange) {
-        const bloodMoonMult = s.activeBattleEvent?.type === 'bloodMoon' ? 2 : 1
-        const dmg = (unit.attack + atkAura) * bloodMoonMult
-        if (isPlayer) {
-          const traitProtected = s.bossTraitState != null && s.bossTraitState.baseInvulnerableUntilMs > s.gameTime
-          if (s.endlessWaveTruceMs != null && s.endlessWaveTruceMs > 0) {
-            log.push(`${unit.name} hits Enemy Base! (truce — no damage)`)
-          } else if (traitProtected) {
-            log.push(`${unit.name} hits Enemy Base — it's protected!`)
-          } else {
-            const prev = s.opponentBase.hp
-            s.opponentBase.hp = Math.max(0, s.opponentBase.hp - dmg)
-            s.playerScore += prev - s.opponentBase.hp
-            log.push(`${unit.name} hits Enemy Base! -${dmg}HP`)
-            playBaseHit()
-          }
-        } else {
-          if (!isNoDamageMode()) {
-            const prev = s.playerBase.hp
-            s.playerBase.hp = Math.max(0, s.playerBase.hp - dmg)
-            s.opponentScore += prev - s.playerBase.hp
-            log.push(`${unit.name} hits Your Base! -${dmg}HP`)
-            playBaseHit()
-          } else {
-            log.push(`${unit.name} hits Your Base! (dev mode — no damage)`)
-          }
-        }
-        const affSpeedMult2 = (unit.affinityActive && unit.affinity?.effectType === 'attackSpeed')
-          ? unit.affinity.effectAmount : 1
-        unit.attackTimer = unit.attackCooldownMs / affSpeedMult2
-      }
     }
   }
 

--- a/web/src/game/engine/constants.ts
+++ b/web/src/game/engine/constants.ts
@@ -12,6 +12,8 @@ export const DAMAGE_FLASH_MS      = 200    // how long the damage-flash effect l
 export const BLOOD_POOL_MAX       = 25     // FIFO cap — older pools begin fading when exceeded
 export const BLOOD_POOL_FADE_MS   = 2000   // how long a fading blood pool takes to disappear
 
-export const PLAYER_SPAWN_X   = 30               // where player units appear
-export const OPPONENT_SPAWN_X = LANE_WIDTH - 30  // where opponent units appear
-export const BASE_STOP_MARGIN = 0                // units may reach the base character position exactly
+export const PLAYER_SPAWN_X      = 30               // where player units appear
+export const OPPONENT_SPAWN_X    = LANE_WIDTH - 30  // where opponent units appear
+export const BASE_STOP_MARGIN    = 0                // units may reach the base character position exactly
+export const COMMANDER_HOME_X    = 15               // player commander's home position
+export const COMMANDER_LEASH_PX  = 80              // max px a commander can stray from home

--- a/web/src/game/engine/units.ts
+++ b/web/src/game/engine/units.ts
@@ -1,5 +1,5 @@
 import { GameState, LANE_WIDTH, TERRAIN_AVOID_SHAPE, Unit, UnitTag } from '../types'
-import { BASE_STOP_MARGIN, DAMAGE_FLASH_MS, PLAYER_SPAWN_X } from './constants'
+import { BASE_STOP_MARGIN, COMMANDER_LEASH_PX, DAMAGE_FLASH_MS, PLAYER_SPAWN_X } from './constants'
 import { LANE_MAX_Y, LANE_MIN_Y } from './helpers'
 import { unitDist, findNearestEnemy, findNearestEnemyByPriority, findEnemyBehind } from './targeting'
 
@@ -290,6 +290,11 @@ export function moveUnits(s: GameState, deltaMs: number): void {
     const step = Math.min(speed, d)
     unit.x = Math.min(LANE_WIDTH - BASE_STOP_MARGIN, Math.max(BASE_STOP_MARGIN, unit.x + (dx / d) * step))
     unit.y = Math.min(LANE_MAX_Y, Math.max(LANE_MIN_Y, unit.y + (dy / d) * step + avoidY * deltaSec))
+
+    // Commanders cannot stray beyond their leash radius
+    if (unit.isCommander && unit.commanderHomeX !== undefined) {
+      unit.x = Math.min(unit.commanderHomeX + COMMANDER_LEASH_PX, Math.max(unit.commanderHomeX - COMMANDER_LEASH_PX, unit.x))
+    }
   }
 }
 

--- a/web/src/game/types.ts
+++ b/web/src/game/types.ts
@@ -147,6 +147,10 @@ export interface Unit extends UnitTemplate {
   killFlashTimer?: number
   /** ms remaining stunned — unit cannot move or attack while > 0 (boss trait effect). */
   stunTimer?: number
+  /** True for commander units — the base avatar that fights on the field. */
+  isCommander?: boolean
+  /** X position the commander is leashed to; cannot wander beyond COMMANDER_LEASH_PX from here. */
+  commanderHomeX?: number
   /** Persistent random y position assigned to a guardBase unit (lazy, set on first guard tick). */
   guardY?: number
   /** ID of the enemy unit this unit is currently locked onto as an attack target. */
@@ -345,6 +349,8 @@ export interface GameState {
   stanceActiveUntil?: number
   /** gameTime ms before which no non-auto stance can be activated (cooldown). */
   stanceCooldownUntil?: number
+  /** Boss HP value at which phase 2 triggers (boss battles only — boss spawned at game start). */
+  bossPhase2Hp?: number
 }
 
 export interface StanceRules {


### PR DESCRIPTION
## Summary

**Stance label rename**
- ATTACK → CHARGE (units ignore enemies and sprint to the base)
- AUTO → ATTACK (units pick targets and fight normally)

**Commander units replace base HP**

Normal & elite battles:
- A **Commander** (player, green armour) and **Warlord** (opponent, red armour + horns) spawn at each base position at game start
- Stats equivalent to a 5-mana unit: attack 15, range 35 px, 2 s cooldown, speed 8
- Leashed to within 80 px of their home position — they skirmish but don't roam
- Units fight them naturally via the existing combat system; the old "attack base at end of lane" block is removed

Boss battles:
- Boss spawns immediately at turn 1 with combined HP = `(mult × template HP) + base HP` — no commander, no separate phase-1 base to deplete
- Phase 2 triggers when boss HP drops to the pure boss-HP threshold (base portion exhausted); boss stays on the field, stomps the ground, shockwave fires, and the fight continues
- Win condition: boss HP reaches 0

HP bars and campaign HP persistence unchanged — commander/boss HP syncs back to `playerBase`/`opponentBase` each tick.

## Test plan

- [ ] Normal battle: Commander and Warlord visible at each end; units walk up and fight them; game ends when one dies
- [ ] Elite battle: same, with 15 s stance duration / 20 s cooldown active
- [ ] Boss battle: boss present from turn 1 with boosted HP; phase 2 stomp triggers mid-fight; fight continues until boss dies
- [ ] Campaign HP persists correctly between nodes
- [ ] Stance buttons: ATTACK label gone, replaced by CHARGE; AUTO gone, replaced by ATTACK

https://claude.ai/code/session_01FFXw8rUxBVQRtJK8x762WJ