### PR TITLE
fix: animate commander sprites like other mobile units

### DIFF
--- a/web/src/components/Battlefield.tsx
+++ b/web/src/components/Battlefield.tsx
@@ -301,7 +301,7 @@ function LaneUnit({ unit, stackIndex = 0, wallStack, onInspect, showName, celebr
           : isStructure
             ? <SpriteImg name={unit.spriteName ?? unit.name} className={`lane-unit-sprite${spriteDamageClass(unit.hp, unit.maxHp)}`} />
             : unit.isCommander
-            ? <SpriteImg name={spriteOverride ?? unit.spriteName ?? unit.name} className={`lane-unit-sprite${spriteDamageClass(unit.hp, unit.maxHp)}`} />
+            ? <AnimatedSpriteImg name={spriteOverride ?? unit.spriteName ?? unit.name} frameCount={3} fps={6} className={`lane-unit-sprite${spriteDamageClass(unit.hp, unit.maxHp)}`} />
             : <AnimatedSpriteImg name={unit.spriteName ?? unit.name} frameCount={3} fps={6} className={`lane-unit-sprite${unit.isHero ? ' lane-unit-sprite--hero' : ''}${spriteDamageClass(unit.hp, unit.maxHp)}`} />
       }
       {!unit.isWall && !unit.isMoat && showName && (


### PR DESCRIPTION
Switches commander units from `SpriteImg` (static) to `AnimatedSpriteImg` (3-frame walk cycle at 6 fps), matching the behaviour of all other mobile units on the field.

https://claude.ai/code/session_01FFXw8rUxBVQRtJK8x762WJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01FFXw8rUxBVQRtJK8x762WJ)_