### PR TITLE
Fix 3 commander bugs: endless mode, boss phase 1 leash, boss player commander

### DIFF
--- a/web/src/game/engine.ts
+++ b/web/src/game/engine.ts
@@ -8,7 +8,7 @@ import { BASE_MAX_MANA, BLOOD_POOL_FADE_MS, BASE_STOP_MARGIN, MANA_REGEN_MS, OPP
 import { genericBossAI, getBossAIDef } from './engine/boss'
 import { tickBossTrait } from './engine/bossTraits'
 import { getManaBonus, getManaSpeedMult } from './engine/bonusEffects'
-import { uid, shuffle, spawnUnit } from './engine/helpers'
+import { uid, shuffle, spawnUnit, spawnCommander } from './engine/helpers'
 import { MAX_UPGRADE_LEVEL } from './engine/cards'
 import { unitDist } from './engine/targeting'
 import { opponentAI } from './engine/opponentAI'
@@ -92,21 +92,6 @@ const STRATEGY_LABELS: Record<GameState['opponentStrategy'], string> = {
 }
 
 /** Inject one hero card into the first ~8 positions of a shuffled deck. */
-function spawnCommander(owner: 'player' | 'opponent', hp: number): import('./types').Unit {
-  const homeX = owner === 'player' ? COMMANDER_HOME_X : LANE_WIDTH - COMMANDER_HOME_X
-  const unit = spawnUnit(
-    { name: owner === 'player' ? 'Commander' : 'Warlord',
-      attack: 15, maxHp: hp, isWall: false, bypassWall: false,
-      moveSpeed: 8, attackRange: 35, attackCooldownMs: 2000, size: 'large' },
-    owner
-  )
-  unit.isCommander    = true
-  unit.commanderHomeX = homeX
-  unit.x              = homeX
-  unit.y              = 0
-  return unit
-}
-
 function injectHero(deck: Card[], heroPool: Card[]): void {
   if (heroPool.length === 0) return
   const hero = heroPool[Math.floor(Math.random() * heroPool.length)]
@@ -271,12 +256,19 @@ export function newGame(
       const boostedHp  = Math.round(template.maxHp * mult)
       const totalHp    = boostedHp + baseOpponentHp
       const bossUnit   = spawnUnit({ ...template, maxHp: totalHp }, 'opponent')
+      // Phase 1: treat boss as a leashed commander so it doesn't charge straight to the player
+      const bossHomeX  = LANE_WIDTH - COMMANDER_HOME_X
+      bossUnit.isCommander    = true
+      bossUnit.commanderHomeX = bossHomeX
+      bossUnit.x              = bossHomeX
+      bossUnit.y              = 0
       initialField.push(bossUnit)
+      initialField.push(spawnCommander('player', 50))
       opponentBaseHp = totalHp
       bossPhase2Hp   = boostedHp   // phase 2 triggers when boss.hp drops to this
     }
-  } else if (!endlessMode) {
-    // Normal/elite battle: spawn commander units at each base
+  } else {
+    // Normal/elite/endless: spawn commander units at each base
     initialField.push(spawnCommander('player', 50))
     initialField.push(spawnCommander('opponent', baseOpponentHp))
   }
@@ -384,6 +376,9 @@ function checkGameOver(s: GameState): boolean {
     const bossUnit = s.field.find(u => u.owner === 'opponent' && u.name === s.bossCard && u.hp > 0)
     if (bossUnit && bossUnit.hp <= s.bossPhase2Hp) {
       const displayName = s.bossName ?? s.bossCard
+      // Release boss from leash so it charges freely in phase 2
+      bossUnit.isCommander    = false
+      bossUnit.commanderHomeX = undefined
       // Clear minions but keep the boss unit
       s.field = s.field.filter(u => u.owner !== 'opponent' || u.name === s.bossCard)
       s.field.forEach(u => { if (u.owner === 'player') u.x = PLAYER_SPAWN_X })
@@ -392,7 +387,7 @@ function checkGameOver(s: GameState): boolean {
 
       // Shockwave: kills a scaling fraction of player's mobile non-hero units, always leaving at least 3
       const shockwavePool = s.field.filter(
-        u => u.owner === 'player' && u.moveSpeed > 0 && !u.isHero && !u.dyingTimer
+        u => u.owner === 'player' && u.moveSpeed > 0 && !u.isHero && !u.isCommander && !u.dyingTimer
       )
       const MIN_SURVIVORS = 3
       const killPct = Math.min(1.0, s.bossSpawnKillPct ?? 0.5)

--- a/web/src/game/engine/endlessMode.ts
+++ b/web/src/game/engine/endlessMode.ts
@@ -1,6 +1,6 @@
 import { GameState } from '../types'
 import { BLOOD_POOL_MAX, PLAYER_SPAWN_X } from './constants'
-import { shuffle, drawCard, recycleCardId } from './helpers'
+import { shuffle, drawCard, recycleCardId, spawnCommander } from './helpers'
 
 // ─── Wave transition ──────────────────────────────────────
 
@@ -13,8 +13,9 @@ export function triggerNextEndlessWave(s: GameState): false {
   const wave   = (s.endlessWave ?? 1) + 1
   s.endlessWave = wave
 
-  const hpMult = 1 + (wave - 1) * 0.8
-  s.opponentBase = { hp: Math.round(82 * hpMult), maxHp: Math.round(82 * hpMult) }
+  const hpMult  = 1 + (wave - 1) * 0.8
+  const newOpHp = Math.round(82 * hpMult)
+  s.opponentBase = { hp: newOpHp, maxHp: newOpHp }
 
   // Scale opponent speed aggressively each wave (min 2000ms)
   s.opponentIntervalMs = Math.max(2000, s.opponentIntervalMs - 500)
@@ -23,8 +24,9 @@ export function triggerNextEndlessWave(s: GameState): false {
   // Boost opponent mana regen each wave (capped at 2.5×)
   s.endlessOpponentManaMult = Math.min(2.5, (s.endlessOpponentManaMult ?? 1) + 0.2)
 
-  // Clear opponent units + reshuffle opponent deck
+  // Clear opponent units + reshuffle opponent deck, then spawn fresh opponent commander
   s.field = s.field.filter(u => u.owner !== 'opponent')
+  s.field.push(spawnCommander('opponent', newOpHp))
   s.opponentDeck = shuffle([...(s.endlessOpponentDeckTemplate ?? [])])
 
   // Draw bonus cards into opponent hand based on wave number
@@ -39,8 +41,8 @@ export function triggerNextEndlessWave(s: GameState): false {
     }
   })
 
-  // Finger smash: a giant finger crushes 75–95% of the player's units/structures
-  const playerUnits   = s.field.filter(u => u.owner === 'player' && !u.dyingTimer)
+  // Finger smash: a giant finger crushes 75–95% of the player's units/structures (commander is spared)
+  const playerUnits   = s.field.filter(u => u.owner === 'player' && !u.dyingTimer && !u.isCommander)
   const smashFraction = 0.75 + Math.random() * 0.20
   const smashCount    = Math.round(playerUnits.length * smashFraction)
   const smashedNames: string[] = []

--- a/web/src/game/engine/helpers.ts
+++ b/web/src/game/engine/helpers.ts
@@ -1,6 +1,6 @@
 import { logError } from '../../logger';
 import { Card, UnitTemplate, Unit, LANE_WIDTH } from '../types';
-import { PLAYER_SPAWN_X, OPPONENT_SPAWN_X } from './constants';
+import { PLAYER_SPAWN_X, OPPONENT_SPAWN_X, COMMANDER_HOME_X } from './constants';
 
 // ─── Helpers ─────────────────────────────────────────────
 let _unitId = 0;
@@ -58,4 +58,19 @@ export function spawnUnit(template: UnitTemplate, owner: 'player' | 'opponent'):
     unit.y = LANE_POSITIONS[Math.floor(Math.random() * LANE_POSITIONS.length)];
   }
   return unit;
+}
+
+export function spawnCommander(owner: 'player' | 'opponent', hp: number): Unit {
+  const homeX = owner === 'player' ? COMMANDER_HOME_X : LANE_WIDTH - COMMANDER_HOME_X
+  const unit = spawnUnit(
+    { name: owner === 'player' ? 'Commander' : 'Warlord',
+      attack: 15, maxHp: hp, isWall: false, bypassWall: false,
+      moveSpeed: 8, attackRange: 35, attackCooldownMs: 2000, size: 'large' },
+    owner
+  )
+  unit.isCommander    = true
+  unit.commanderHomeX = homeX
+  unit.x              = homeX
+  unit.y              = 0
+  return unit
 }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Endless mode can't win/lose**: Commanders were never spawned in endless mode due to an `!endlessMode` guard. Removed the guard so both sides always get commanders. Also spawns a fresh opponent commander each wave transition in `triggerNextEndlessWave`.
- **Boss charges straight to player base**: Boss unit was spawned without leash properties. Now sets `isCommander + commanderHomeX` on the boss in phase 1 so it stays near its end. Phase 2 clears these so the boss charges freely.
- **No player commander in boss battles**: The boss path in `newGame` only spawned the boss unit. Now also spawns a player commander alongside it.

## Additional fixes

- Player commander is spared from the endless-mode finger smash between waves.
- Boss phase 2 shockwave excludes the player commander from its kill pool.
- `spawnCommander` moved to `engine/helpers.ts` (exported) so both `engine.ts` and `endlessMode.ts` can share it without duplication.

## Test plan

- [ ] Endless mode: player and opponent commanders appear on the field at wave 1
- [ ] Endless mode: killing the opponent commander triggers a wave transition with a new opponent commander spawning
- [ ] Endless mode: player commander survives the finger-smash between waves
- [ ] Endless mode: player commander dying → game over screen appears
- [ ] Boss battle: boss unit stays near its end of the field in phase 1, doesn't charge the player base
- [ ] Boss battle: player commander appears on the player side
- [ ] Boss battle: phase 2 triggers correctly, boss charges freely after the threshold

https://claude.ai/code/session_01FFXw8rUxBVQRtJK8x762WJ
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FFXw8rUxBVQRtJK8x762WJ)_