### PR TITLE
feat(endless): randomise opponent commander type each wave from card pool

### DIFF
--- a/web/src/components/Battlefield.tsx
+++ b/web/src/components/Battlefield.tsx
@@ -930,7 +930,11 @@ export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPaus
           const playerWon = (state.phase.type === 'gameOver' || state.phase.type === 'celebration') && state.phase.winner === 'player'
           return state.field.map((u, i) => {
             const commanderSprite = u.isCommander
-              ? (u.owner === 'player' ? playerAvatar : opponentPortraitSlug(state.bossAI, actTheme))
+              ? u.owner === 'player'
+                ? playerAvatar
+                : state.endlessMode
+                  ? undefined  // use the unit's own sprite so it changes each wave
+                  : opponentPortraitSlug(state.bossAI, actTheme)
               : undefined
             if (u.isWall) {
               const key = `${u.owner}:${Math.round(u.x)}`

--- a/web/src/game/engine.ts
+++ b/web/src/game/engine.ts
@@ -14,7 +14,7 @@ import { unitDist } from './engine/targeting'
 import { opponentAI } from './engine/opponentAI'
 import { triggerBattleEvent, BATTLE_EVENT_BASE_MS } from './engine/battleEvents'
 import { generateTerrain } from './engine/terrain'
-import { processEndlessModeAdditions, triggerNextEndlessWave } from './engine/endlessMode'
+import { processEndlessModeAdditions, triggerNextEndlessWave, spawnEndlessCommander } from './engine/endlessMode'
 import { handleSuddentDeath } from './engine/suddenDeath'
 
 
@@ -270,7 +270,8 @@ export function newGame(
   } else {
     // Normal/elite/endless: spawn commander units at each base
     initialField.push(spawnCommander('player', 50))
-    initialField.push(spawnCommander('opponent', baseOpponentHp))
+    // In endless mode wave 1: pick a random card-pool unit as the commander
+    initialField.push(endlessMode ? spawnEndlessCommander(1, baseOpponentHp) : spawnCommander('opponent', baseOpponentHp))
   }
 
   return {

--- a/web/src/game/engine/endlessMode.ts
+++ b/web/src/game/engine/endlessMode.ts
@@ -1,6 +1,40 @@
-import { GameState } from '../types'
-import { BLOOD_POOL_MAX, PLAYER_SPAWN_X } from './constants'
-import { shuffle, drawCard, recycleCardId, spawnCommander } from './helpers'
+import { GameState, UnitTemplate, LANE_WIDTH } from '../types'
+import { BLOOD_POOL_MAX, PLAYER_SPAWN_X, COMMANDER_HOME_X } from './constants'
+import { shuffle, drawCard, recycleCardId, spawnCommander, spawnUnit } from './helpers'
+import { getCardCatalog, getCardUnit } from '../cards'
+
+// ─── Wave commander selection ─────────────────────────────
+// Each wave the opponent gets a random unit from the card pool as their
+// commander. Max card cost scales with wave number so early waves face
+// cheap/weak commanders and later waves face heavier ones.
+function maxCostForWave(wave: number): number {
+  return Math.min(6, 2 + Math.floor((wave - 1) / 2))
+}
+
+function pickEndlessCommanderTemplate(wave: number): UnitTemplate | undefined {
+  const maxCost = maxCostForWave(wave)
+  const templates = getCardCatalog()
+    .filter(c => c.cardType === 'unit' && c.cost >= 1 && c.cost <= maxCost)
+    .map(c => getCardUnit(c.name))
+    .filter((t): t is UnitTemplate => t != null && !t.isWall && !t.isMoat && (t.moveSpeed ?? 0) > 0)
+  if (templates.length === 0) return undefined
+  return templates[Math.floor(Math.random() * templates.length)]
+}
+
+export function spawnEndlessCommander(wave: number, hp: number): import('../types').Unit {
+  const homeX   = LANE_WIDTH - COMMANDER_HOME_X
+  const template = pickEndlessCommanderTemplate(wave)
+  if (template) {
+    const unit = spawnUnit({ ...template, maxHp: hp, size: 'large' }, 'opponent')
+    unit.isCommander    = true
+    unit.commanderHomeX = homeX
+    unit.x              = homeX
+    unit.y              = 0
+    return unit
+  }
+  // Fallback: generic warlord if catalog lookup fails
+  return spawnCommander('opponent', hp)
+}
 
 // ─── Wave transition ──────────────────────────────────────
 
@@ -26,7 +60,7 @@ export function triggerNextEndlessWave(s: GameState): false {
 
   // Clear opponent units + reshuffle opponent deck, then spawn fresh opponent commander
   s.field = s.field.filter(u => u.owner !== 'opponent')
-  s.field.push(spawnCommander('opponent', newOpHp))
+  s.field.push(spawnEndlessCommander(wave, newOpHp))
   s.opponentDeck = shuffle([...(s.endlessOpponentDeckTemplate ?? [])])
 
   // Draw bonus cards into opponent hand based on wave number


### PR DESCRIPTION
## Summary

- Each endless wave the opponent commander is a **random unit from the card catalog** rather than always the same Warlord/skeleton.
- The commander gets full unit stats from the template — attack damage, attack range, move speed, and any special properties. An archer-type unit will have ranged attacks; a heavy unit will hit harder, etc.
- **Max card cost scales with wave**: ≤2 on wave 1, increasing by 1 every two waves, capped at 6. Early waves face cheap/weak commanders; later waves face heavier, more dangerous ones.
- The commander's **HP** remains wave-scaled (`82 × hpMult`) regardless of the template — this represents the base's strength.
- In `Battlefield.tsx`, the opponent commander now shows its own unit sprite in endless mode (rather than the fixed portrait slug), so the visual changes each wave.
- A `spawnEndlessCommander(wave, hp)` helper is exported from `endlessMode.ts` and shared by both `newGame` (wave 1) and `triggerNextEndlessWave` (subsequent waves).

## Test plan

- [ ] Wave 1 opponent commander is a random mobile unit (not always Warlord)
- [ ] Wave 2+ opponent commander is a different random unit each time
- [ ] Later waves (5+) spawn noticeably beefier commander unit types
- [ ] Commander uses the correct animated sprite on the battlefield
- [ ] Commander stats match the unit card (ranged units attack at range, fast units move quickly)
- [ ] Commander HP still reflects the wave-scaled amount, not the template HP

https://claude.ai/code/session_01FFXw8rUxBVQRtJK8x762WJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01FFXw8rUxBVQRtJK8x762WJ)_