### PR TITLE
feat(sprites): add animation frames for all player avatar slugs

### DIFF
--- a/web/public/sprites/boss-archivist-1.svg
+++ b/web/public/sprites/boss-archivist-1.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="6" r="4" fill="#D4AC68"/>
+  <circle cx="14" cy="6" r="1.5" fill="none" stroke="#8B6B3D" stroke-width="0.7"/>
+  <circle cx="18" cy="6" r="1.5" fill="none" stroke="#8B6B3D" stroke-width="0.7"/>
+  <line x1="15.5" y1="6" x2="16.5" y2="6" stroke="#8B6B3D" stroke-width="0.7"/>
+  <line x1="12.5" y1="6" x2="12" y2="5.5" stroke="#8B6B3D" stroke-width="0.7"/>
+  <line x1="19.5" y1="6" x2="20" y2="5.5" stroke="#8B6B3D" stroke-width="0.7"/>
+  <circle cx="14" cy="6" r="0.7" fill="#4A2C17"/>
+  <circle cx="18" cy="6" r="0.7" fill="#4A2C17"/>
+  <ellipse cx="16" cy="3" rx="4" ry="2" fill="#4A2C17"/>
+  <rect x="10" y="10" width="12" height="13" rx="2" fill="#5C3A1E"/>
+  <rect x="10" y="10" width="12" height="3" rx="2" fill="#7A4E28"/>
+  <!-- Scroll raised up -->
+  <rect x="3" y="7" width="5" height="8" rx="1" fill="#D4AC68"/>
+  <line x1="4" y1="9" x2="7" y2="9" stroke="#8B6B3D" stroke-width="0.6"/>
+  <line x1="4" y1="11" x2="7" y2="11" stroke="#8B6B3D" stroke-width="0.6"/>
+  <line x1="4" y1="13" x2="7" y2="13" stroke="#8B6B3D" stroke-width="0.6"/>
+  <!-- Left arm raised -->
+  <rect x="5" y="7" width="5" height="9" rx="1" fill="#5C3A1E"/>
+  <!-- Right arm (quill) normal -->
+  <rect x="22" y="10" width="5" height="9" rx="1" fill="#5C3A1E"/>
+  <polygon points="25,4 27,1 27,8 25,8" fill="#F9CA24"/>
+  <rect x="25.5" y="8" width="1" height="5" fill="#4A2C17"/>
+  <!-- Legs stride A -->
+  <rect x="11" y="23" width="4" height="8" rx="1" fill="#5C3A1E" transform="rotate(-4 13 27)"/>
+  <rect x="17" y="23" width="4" height="8" rx="1" fill="#5C3A1E" transform="rotate(4 19 27)"/>
+</svg>

--- a/web/public/sprites/boss-archivist-2.svg
+++ b/web/public/sprites/boss-archivist-2.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="7" r="4" fill="#D4AC68"/>
+  <circle cx="14" cy="7" r="1.5" fill="none" stroke="#8B6B3D" stroke-width="0.7"/>
+  <circle cx="18" cy="7" r="1.5" fill="none" stroke="#8B6B3D" stroke-width="0.7"/>
+  <line x1="15.5" y1="7" x2="16.5" y2="7" stroke="#8B6B3D" stroke-width="0.7"/>
+  <line x1="12.5" y1="7" x2="12" y2="6.5" stroke="#8B6B3D" stroke-width="0.7"/>
+  <line x1="19.5" y1="7" x2="20" y2="6.5" stroke="#8B6B3D" stroke-width="0.7"/>
+  <circle cx="14" cy="7" r="0.7" fill="#4A2C17"/>
+  <circle cx="18" cy="7" r="0.7" fill="#4A2C17"/>
+  <ellipse cx="16" cy="4" rx="4" ry="2" fill="#4A2C17"/>
+  <rect x="10" y="11" width="12" height="13" rx="2" fill="#5C3A1E"/>
+  <rect x="10" y="11" width="12" height="3" rx="2" fill="#7A4E28"/>
+  <rect x="3" y="12" width="5" height="8" rx="1" fill="#D4AC68"/>
+  <line x1="4" y1="14" x2="7" y2="14" stroke="#8B6B3D" stroke-width="0.6"/>
+  <line x1="4" y1="16" x2="7" y2="16" stroke="#8B6B3D" stroke-width="0.6"/>
+  <line x1="4" y1="18" x2="7" y2="18" stroke="#8B6B3D" stroke-width="0.6"/>
+  <rect x="5" y="11" width="5" height="9" rx="1" fill="#5C3A1E"/>
+  <rect x="22" y="11" width="5" height="9" rx="1" fill="#5C3A1E"/>
+  <polygon points="25,5 27,2 27,9 25,9" fill="#F9CA24"/>
+  <rect x="25.5" y="9" width="1" height="5" fill="#4A2C17"/>
+  <!-- Legs bob down -->
+  <rect x="11" y="24" width="4" height="7" rx="1" fill="#5C3A1E"/>
+  <rect x="17" y="24" width="4" height="7" rx="1" fill="#5C3A1E"/>
+</svg>

--- a/web/public/sprites/boss-archivist-3.svg
+++ b/web/public/sprites/boss-archivist-3.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="6" r="4" fill="#D4AC68"/>
+  <circle cx="14" cy="6" r="1.5" fill="none" stroke="#8B6B3D" stroke-width="0.7"/>
+  <circle cx="18" cy="6" r="1.5" fill="none" stroke="#8B6B3D" stroke-width="0.7"/>
+  <line x1="15.5" y1="6" x2="16.5" y2="6" stroke="#8B6B3D" stroke-width="0.7"/>
+  <line x1="12.5" y1="6" x2="12" y2="5.5" stroke="#8B6B3D" stroke-width="0.7"/>
+  <line x1="19.5" y1="6" x2="20" y2="5.5" stroke="#8B6B3D" stroke-width="0.7"/>
+  <circle cx="14" cy="6" r="0.7" fill="#4A2C17"/>
+  <circle cx="18" cy="6" r="0.7" fill="#4A2C17"/>
+  <ellipse cx="16" cy="3" rx="4" ry="2" fill="#4A2C17"/>
+  <rect x="10" y="10" width="12" height="13" rx="2" fill="#5C3A1E"/>
+  <rect x="10" y="10" width="12" height="3" rx="2" fill="#7A4E28"/>
+  <!-- Scroll normal -->
+  <rect x="3" y="11" width="5" height="8" rx="1" fill="#D4AC68"/>
+  <line x1="4" y1="13" x2="7" y2="13" stroke="#8B6B3D" stroke-width="0.6"/>
+  <line x1="4" y1="15" x2="7" y2="15" stroke="#8B6B3D" stroke-width="0.6"/>
+  <line x1="4" y1="17" x2="7" y2="17" stroke="#8B6B3D" stroke-width="0.6"/>
+  <rect x="5" y="10" width="5" height="9" rx="1" fill="#5C3A1E"/>
+  <!-- Right arm (quill) raised -->
+  <rect x="22" y="7" width="5" height="9" rx="1" fill="#5C3A1E"/>
+  <polygon points="25,1 27,0" fill="none"/>
+  <polygon points="25,1 27,0 27,5 25,5" fill="#F9CA24"/>
+  <rect x="25.5" y="5" width="1" height="5" fill="#4A2C17"/>
+  <!-- Legs stride B -->
+  <rect x="11" y="23" width="4" height="8" rx="1" fill="#5C3A1E" transform="rotate(4 13 27)"/>
+  <rect x="17" y="23" width="4" height="8" rx="1" fill="#5C3A1E" transform="rotate(-4 19 27)"/>
+</svg>

--- a/web/public/sprites/boss-ashwalker-1.svg
+++ b/web/public/sprites/boss-ashwalker-1.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ash trails from raised arm -->
+  <circle cx="5" cy="5" r="1" fill="#636E72" opacity="0.6"/>
+  <circle cx="3" cy="8" r="0.8" fill="#636E72" opacity="0.6"/>
+  <circle cx="4" cy="11" r="0.7" fill="#636E72" opacity="0.5"/>
+  <circle cx="24" cy="8" r="0.8" fill="#636E72" opacity="0.4"/>
+  <circle cx="26" cy="12" r="0.7" fill="#636E72" opacity="0.4"/>
+  <circle cx="16" cy="6" r="4" fill="#4A4A4A"/>
+  <ellipse cx="14" cy="5.5" rx="1.5" ry="1.2" fill="#E17055"/>
+  <ellipse cx="18" cy="5.5" rx="1.5" ry="1.2" fill="#E17055"/>
+  <ellipse cx="14" cy="5.5" rx="0.8" ry="0.6" fill="#FDCB6E"/>
+  <ellipse cx="18" cy="5.5" rx="0.8" ry="0.6" fill="#FDCB6E"/>
+  <line x1="15" y1="3" x2="14" y2="7" stroke="#2D3436" stroke-width="0.8"/>
+  <line x1="18" y1="4" x2="17" y2="8" stroke="#2D3436" stroke-width="0.8"/>
+  <rect x="10" y="10" width="12" height="13" rx="2" fill="#3D3D3D"/>
+  <line x1="13" y1="11" x2="12" y2="16" stroke="#636E72" stroke-width="0.8"/>
+  <line x1="18" y1="12" x2="19" y2="17" stroke="#636E72" stroke-width="0.8"/>
+  <circle cx="16" cy="16" r="1.5" fill="#E17055" opacity="0.7"/>
+  <circle cx="16" cy="16" r="0.8" fill="#FDCB6E" opacity="0.8"/>
+  <polygon points="10,23 7,28 11,24" fill="#3D3D3D"/>
+  <polygon points="22,23 25,28 21,24" fill="#3D3D3D"/>
+  <!-- Left arm raised with ember glow -->
+  <rect x="4" y="7" width="6" height="9" rx="1" fill="#3D3D3D"/>
+  <line x1="6" y1="8" x2="5" y2="12" stroke="#636E72" stroke-width="0.7"/>
+  <circle cx="4" cy="7" r="1.5" fill="#E17055" opacity="0.8"/>
+  <circle cx="4" cy="7" r="0.7" fill="#FDCB6E"/>
+  <rect x="22" y="10" width="6" height="9" rx="1" fill="#3D3D3D"/>
+  <line x1="25" y1="12" x2="26" y2="16" stroke="#636E72" stroke-width="0.7"/>
+  <!-- Stride A -->
+  <rect x="11" y="23" width="4" height="8" rx="1" fill="#3D3D3D" transform="rotate(-4 13 27)"/>
+  <rect x="17" y="23" width="4" height="8" rx="1" fill="#3D3D3D" transform="rotate(4 19 27)"/>
+</svg>

--- a/web/public/sprites/boss-ashwalker-2.svg
+++ b/web/public/sprites/boss-ashwalker-2.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="8" cy="6" r="1" fill="#636E72" opacity="0.6"/>
+  <circle cx="24" cy="9" r="0.8" fill="#636E72" opacity="0.5"/>
+  <circle cx="6" cy="15" r="0.7" fill="#636E72" opacity="0.4"/>
+  <circle cx="26" cy="13" r="0.7" fill="#636E72" opacity="0.4"/>
+  <circle cx="16" cy="7" r="4" fill="#4A4A4A"/>
+  <ellipse cx="14" cy="6.5" rx="1.5" ry="1.2" fill="#E17055"/>
+  <ellipse cx="18" cy="6.5" rx="1.5" ry="1.2" fill="#E17055"/>
+  <ellipse cx="14" cy="6.5" rx="0.8" ry="0.6" fill="#FDCB6E"/>
+  <ellipse cx="18" cy="6.5" rx="0.8" ry="0.6" fill="#FDCB6E"/>
+  <line x1="15" y1="4" x2="14" y2="8" stroke="#2D3436" stroke-width="0.8"/>
+  <line x1="18" y1="5" x2="17" y2="9" stroke="#2D3436" stroke-width="0.8"/>
+  <rect x="10" y="11" width="12" height="13" rx="2" fill="#3D3D3D"/>
+  <line x1="13" y1="12" x2="12" y2="17" stroke="#636E72" stroke-width="0.8"/>
+  <line x1="18" y1="13" x2="19" y2="18" stroke="#636E72" stroke-width="0.8"/>
+  <circle cx="16" cy="17" r="1.5" fill="#E17055" opacity="0.7"/>
+  <circle cx="16" cy="17" r="0.8" fill="#FDCB6E" opacity="0.8"/>
+  <polygon points="10,24 7,29 11,25" fill="#3D3D3D"/>
+  <polygon points="22,24 25,29 21,25" fill="#3D3D3D"/>
+  <rect x="4" y="11" width="6" height="9" rx="1" fill="#3D3D3D"/>
+  <rect x="22" y="11" width="6" height="9" rx="1" fill="#3D3D3D"/>
+  <line x1="6" y1="12" x2="5" y2="16" stroke="#636E72" stroke-width="0.7"/>
+  <line x1="25" y1="13" x2="26" y2="17" stroke="#636E72" stroke-width="0.7"/>
+  <!-- Legs bob down -->
+  <rect x="11" y="24" width="4" height="7" rx="1" fill="#3D3D3D"/>
+  <rect x="17" y="24" width="4" height="7" rx="1" fill="#3D3D3D"/>
+</svg>

--- a/web/public/sprites/boss-ashwalker-3.svg
+++ b/web/public/sprites/boss-ashwalker-3.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ash trails from right raised arm -->
+  <circle cx="27" cy="5" r="1" fill="#636E72" opacity="0.6"/>
+  <circle cx="29" cy="8" r="0.8" fill="#636E72" opacity="0.6"/>
+  <circle cx="28" cy="11" r="0.7" fill="#636E72" opacity="0.5"/>
+  <circle cx="8" cy="8" r="0.8" fill="#636E72" opacity="0.4"/>
+  <circle cx="6" cy="12" r="0.7" fill="#636E72" opacity="0.4"/>
+  <circle cx="16" cy="6" r="4" fill="#4A4A4A"/>
+  <ellipse cx="14" cy="5.5" rx="1.5" ry="1.2" fill="#E17055"/>
+  <ellipse cx="18" cy="5.5" rx="1.5" ry="1.2" fill="#E17055"/>
+  <ellipse cx="14" cy="5.5" rx="0.8" ry="0.6" fill="#FDCB6E"/>
+  <ellipse cx="18" cy="5.5" rx="0.8" ry="0.6" fill="#FDCB6E"/>
+  <line x1="15" y1="3" x2="14" y2="7" stroke="#2D3436" stroke-width="0.8"/>
+  <line x1="18" y1="4" x2="17" y2="8" stroke="#2D3436" stroke-width="0.8"/>
+  <rect x="10" y="10" width="12" height="13" rx="2" fill="#3D3D3D"/>
+  <line x1="13" y1="11" x2="12" y2="16" stroke="#636E72" stroke-width="0.8"/>
+  <line x1="18" y1="12" x2="19" y2="17" stroke="#636E72" stroke-width="0.8"/>
+  <circle cx="16" cy="16" r="1.5" fill="#E17055" opacity="0.7"/>
+  <circle cx="16" cy="16" r="0.8" fill="#FDCB6E" opacity="0.8"/>
+  <polygon points="10,23 7,28 11,24" fill="#3D3D3D"/>
+  <polygon points="22,23 25,28 21,24" fill="#3D3D3D"/>
+  <!-- Left arm normal -->
+  <rect x="4" y="10" width="6" height="9" rx="1" fill="#3D3D3D"/>
+  <line x1="6" y1="11" x2="5" y2="15" stroke="#636E72" stroke-width="0.7"/>
+  <!-- Right arm raised with ember glow -->
+  <rect x="22" y="7" width="6" height="9" rx="1" fill="#3D3D3D"/>
+  <line x1="25" y1="8" x2="26" y2="12" stroke="#636E72" stroke-width="0.7"/>
+  <circle cx="28" cy="7" r="1.5" fill="#E17055" opacity="0.8"/>
+  <circle cx="28" cy="7" r="0.7" fill="#FDCB6E"/>
+  <!-- Stride B -->
+  <rect x="11" y="23" width="4" height="8" rx="1" fill="#3D3D3D" transform="rotate(4 13 27)"/>
+  <rect x="17" y="23" width="4" height="8" rx="1" fill="#3D3D3D" transform="rotate(-4 19 27)"/>
+</svg>

--- a/web/public/sprites/boss-cinderwarlord-1.svg
+++ b/web/public/sprites/boss-cinderwarlord-1.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect x="10" y="6" width="12" height="8" rx="2" fill="#1A0A0A"/>
+  <rect x="11" y="7" width="10" height="6" rx="1" fill="#3A1010"/>
+  <path d="M11,7 L8,3 L13,8" fill="#CC2200"/>
+  <path d="M21,7 L24,3 L19,8" fill="#CC2200"/>
+  <rect x="12" y="9" width="8" height="2" rx="1" fill="#FF4400"/>
+  <path d="M9,8 Q5,5 7,10" stroke="#FF6600" stroke-width="1.5" fill="none" opacity="0.7"/>
+  <path d="M23,8 Q27,5 25,10" stroke="#FF6600" stroke-width="1.5" fill="none" opacity="0.7"/>
+  <rect x="9" y="14" width="14" height="10" rx="2" fill="#2A0A0A"/>
+  <rect x="10" y="15" width="12" height="8" fill="#3A1010"/>
+  <path d="M16,16 Q14,19 15,21 Q16,18 17,21 Q18,19 16,16" fill="#FF4400"/>
+  <rect x="5"  y="14" width="5" height="6" rx="2" fill="#CC2200"/>
+  <rect x="22" y="14" width="5" height="6" rx="2" fill="#CC2200"/>
+  <!-- Arms stride A -->
+  <rect x="4"  y="20" width="4" height="7" rx="1" fill="#2A0A0A"/>
+  <rect x="24" y="20" width="4" height="7" rx="1" fill="#2A0A0A"/>
+  <rect x="2"  y="7" width="2" height="22" rx="0.5" fill="#888"/>
+  <rect x="1.5" y="7" width="3" height="1" fill="#555"/>
+  <path d="M2,7 Q0,4 3,5 Q4,3 3,7" fill="#FF4400" opacity="0.9"/>
+  <rect x="9" y="24" width="14" height="2" fill="#5C1010"/>
+  <!-- Legs stride A: left forward -->
+  <rect x="8"  y="26" width="5" height="6" rx="1" fill="#2A0A0A"/>
+  <rect x="18" y="26" width="5" height="4" rx="1" fill="#2A0A0A"/>
+  <rect x="7"  y="30" width="7" height="2" rx="1" fill="#1A0000"/>
+  <rect x="18" y="28" width="6" height="2" rx="1" fill="#1A0000"/>
+</svg>

--- a/web/public/sprites/boss-cinderwarlord-2.svg
+++ b/web/public/sprites/boss-cinderwarlord-2.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Body 1px higher -->
+  <rect x="10" y="4" width="12" height="8" rx="2" fill="#1A0A0A"/>
+  <rect x="11" y="5" width="10" height="6" rx="1" fill="#3A1010"/>
+  <path d="M11,5 L8,1 L13,6" fill="#CC2200"/>
+  <path d="M21,5 L24,1 L19,6" fill="#CC2200"/>
+  <rect x="12" y="7" width="8" height="2" rx="1" fill="#FF4400"/>
+  <path d="M9,6 Q5,3 7,8" stroke="#FF6600" stroke-width="1.5" fill="none" opacity="0.7"/>
+  <path d="M23,6 Q27,3 25,8" stroke="#FF6600" stroke-width="1.5" fill="none" opacity="0.7"/>
+  <rect x="9" y="12" width="14" height="10" rx="2" fill="#2A0A0A"/>
+  <rect x="10" y="13" width="12" height="8" fill="#3A1010"/>
+  <path d="M16,14 Q14,17 15,19 Q16,16 17,19 Q18,17 16,14" fill="#FF4400"/>
+  <rect x="5"  y="12" width="5" height="6" rx="2" fill="#CC2200"/>
+  <rect x="22" y="12" width="5" height="6" rx="2" fill="#CC2200"/>
+  <rect x="5"  y="18" width="4" height="8" rx="1" fill="#2A0A0A"/>
+  <rect x="23" y="18" width="4" height="8" rx="1" fill="#2A0A0A"/>
+  <rect x="2"  y="5" width="2" height="22" rx="0.5" fill="#888"/>
+  <rect x="1.5" y="5" width="3" height="1" fill="#555"/>
+  <path d="M2,5 Q0,2 3,3 Q4,1 3,5" fill="#FF4400" opacity="0.9"/>
+  <path d="M3,5 Q5,2 3,3" fill="#FF6600" opacity="0.7"/>
+  <rect x="9" y="22" width="14" height="2" fill="#5C1010"/>
+  <!-- Legs together -->
+  <rect x="10" y="24" width="5" height="8" rx="1" fill="#2A0A0A"/>
+  <rect x="17" y="24" width="5" height="8" rx="1" fill="#2A0A0A"/>
+  <rect x="9"  y="30" width="7" height="2" rx="1" fill="#1A0000"/>
+  <rect x="16" y="30" width="7" height="2" rx="1" fill="#1A0000"/>
+</svg>

--- a/web/public/sprites/boss-cinderwarlord-3.svg
+++ b/web/public/sprites/boss-cinderwarlord-3.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect x="10" y="6" width="12" height="8" rx="2" fill="#1A0A0A"/>
+  <rect x="11" y="7" width="10" height="6" rx="1" fill="#3A1010"/>
+  <path d="M11,7 L8,3 L13,8" fill="#CC2200"/>
+  <path d="M21,7 L24,3 L19,8" fill="#CC2200"/>
+  <rect x="12" y="9" width="8" height="2" rx="1" fill="#FF4400"/>
+  <path d="M9,8 Q5,5 7,10" stroke="#FF6600" stroke-width="1.5" fill="none" opacity="0.7"/>
+  <path d="M23,8 Q27,5 25,10" stroke="#FF6600" stroke-width="1.5" fill="none" opacity="0.7"/>
+  <rect x="9" y="14" width="14" height="10" rx="2" fill="#2A0A0A"/>
+  <rect x="10" y="15" width="12" height="8" fill="#3A1010"/>
+  <path d="M16,16 Q14,19 15,21 Q16,18 17,21 Q18,19 16,16" fill="#FF4400"/>
+  <rect x="5"  y="14" width="5" height="6" rx="2" fill="#CC2200"/>
+  <rect x="22" y="14" width="5" height="6" rx="2" fill="#CC2200"/>
+  <rect x="4"  y="20" width="4" height="7" rx="1" fill="#2A0A0A"/>
+  <rect x="24" y="20" width="4" height="7" rx="1" fill="#2A0A0A"/>
+  <rect x="2"  y="7" width="2" height="22" rx="0.5" fill="#888"/>
+  <rect x="1.5" y="7" width="3" height="1" fill="#555"/>
+  <path d="M2,7 Q0,4 3,5 Q4,3 3,7" fill="#FF4400" opacity="0.9"/>
+  <rect x="9" y="24" width="14" height="2" fill="#5C1010"/>
+  <!-- Legs stride B: right forward -->
+  <rect x="10" y="26" width="5" height="4" rx="1" fill="#2A0A0A"/>
+  <rect x="18" y="26" width="5" height="6" rx="1" fill="#2A0A0A"/>
+  <rect x="10" y="28" width="6" height="2" rx="1" fill="#1A0000"/>
+  <rect x="17" y="30" width="7" height="2" rx="1" fill="#1A0000"/>
+</svg>

--- a/web/public/sprites/boss-cloudmarshal-1.svg
+++ b/web/public/sprites/boss-cloudmarshal-1.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <path d="M12,9 Q16,4 20,9" fill="#4682B4"/>
+  <path d="M13,9 Q12,5 14,7 Q13,4 15,6 Q14,3 16,5 Q17,3 18,6 Q17,4 19,7 Q18,5 20,9" fill="#87CEEB"/>
+  <ellipse cx="16" cy="11" rx="5" ry="5" fill="#d4a870"/>
+  <rect x="11" y="9" width="10" height="3" rx="1" fill="#4682B4"/>
+  <circle cx="14" cy="11" r="0.8" fill="#333"/>
+  <circle cx="18" cy="11" r="0.8" fill="#333"/>
+  <path d="M10,16 L10,23 L22,23 L22,16 Q16,19 10,16 Z" fill="#4682B4"/>
+  <circle cx="16" cy="19" r="2" fill="#FFD700"/>
+  <circle cx="16" cy="19" r="1" fill="#DAA520"/>
+  <ellipse cx="10" cy="16" rx="3" ry="1.5" fill="#87CEEB"/>
+  <ellipse cx="22" cy="16" rx="3" ry="1.5" fill="#87CEEB"/>
+  <rect x="10" y="21" width="12" height="2" fill="#1C3A5E"/>
+  <rect x="23" y="13" width="2" height="10" rx="1" fill="#DAA520"/>
+  <rect x="22.5" y="12" width="3" height="3" rx="1" fill="#FFD700"/>
+  <rect x="6" y="16" width="4" height="7" rx="1" fill="#4682B4"/>
+  <ellipse cx="6" cy="21" rx="3" ry="4" fill="#1C3A5E"/>
+  <ellipse cx="6" cy="21" rx="2" ry="3" fill="#4682B4"/>
+  <circle cx="6" cy="21" r="1" fill="#87CEEB"/>
+  <!-- Legs stride A -->
+  <rect x="9"  y="23" width="5" height="8" rx="1" fill="#1C3A5E"/>
+  <rect x="18" y="23" width="5" height="6" rx="1" fill="#1C3A5E"/>
+  <rect x="8"  y="29" width="7" height="3" rx="1" fill="#4682B4"/>
+  <rect x="18" y="27" width="6" height="3" rx="1" fill="#4682B4"/>
+</svg>

--- a/web/public/sprites/boss-cloudmarshal-2.svg
+++ b/web/public/sprites/boss-cloudmarshal-2.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- 1px higher -->
+  <path d="M12,7 Q16,2 20,7" fill="#4682B4"/>
+  <path d="M13,7 Q12,3 14,5 Q13,2 15,4 Q14,1 16,3 Q17,1 18,4 Q17,2 19,5 Q18,3 20,7" fill="#87CEEB"/>
+  <ellipse cx="16" cy="9" rx="5" ry="5" fill="#d4a870"/>
+  <rect x="11" y="7" width="10" height="3" rx="1" fill="#4682B4"/>
+  <circle cx="14" cy="9" r="0.8" fill="#333"/>
+  <circle cx="18" cy="9" r="0.8" fill="#333"/>
+  <path d="M10,14 L10,21 L22,21 L22,14 Q16,17 10,14 Z" fill="#4682B4"/>
+  <circle cx="16" cy="17" r="2" fill="#FFD700"/>
+  <circle cx="16" cy="17" r="1" fill="#DAA520"/>
+  <ellipse cx="10" cy="14" rx="3" ry="1.5" fill="#87CEEB"/>
+  <ellipse cx="22" cy="14" rx="3" ry="1.5" fill="#87CEEB"/>
+  <rect x="10" y="19" width="12" height="2" fill="#1C3A5E"/>
+  <rect x="23" y="11" width="2" height="10" rx="1" fill="#DAA520"/>
+  <rect x="22.5" y="10" width="3" height="3" rx="1" fill="#FFD700"/>
+  <rect x="6" y="14" width="4" height="7" rx="1" fill="#4682B4"/>
+  <ellipse cx="6" cy="19" rx="3" ry="4" fill="#1C3A5E"/>
+  <ellipse cx="6" cy="19" rx="2" ry="3" fill="#4682B4"/>
+  <circle cx="6" cy="19" r="1" fill="#87CEEB"/>
+  <!-- Legs mid-stride -->
+  <rect x="11" y="21" width="5" height="9" rx="1" fill="#1C3A5E"/>
+  <rect x="17" y="21" width="5" height="9" rx="1" fill="#1C3A5E"/>
+  <rect x="10" y="28" width="7" height="3" rx="1" fill="#4682B4"/>
+  <rect x="16" y="28" width="7" height="3" rx="1" fill="#4682B4"/>
+</svg>

--- a/web/public/sprites/boss-cloudmarshal-3.svg
+++ b/web/public/sprites/boss-cloudmarshal-3.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <path d="M12,9 Q16,4 20,9" fill="#4682B4"/>
+  <path d="M13,9 Q12,5 14,7 Q13,4 15,6 Q14,3 16,5 Q17,3 18,6 Q17,4 19,7 Q18,5 20,9" fill="#87CEEB"/>
+  <ellipse cx="16" cy="11" rx="5" ry="5" fill="#d4a870"/>
+  <rect x="11" y="9" width="10" height="3" rx="1" fill="#4682B4"/>
+  <circle cx="14" cy="11" r="0.8" fill="#333"/>
+  <circle cx="18" cy="11" r="0.8" fill="#333"/>
+  <path d="M10,16 L10,23 L22,23 L22,16 Q16,19 10,16 Z" fill="#4682B4"/>
+  <circle cx="16" cy="19" r="2" fill="#FFD700"/>
+  <circle cx="16" cy="19" r="1" fill="#DAA520"/>
+  <ellipse cx="10" cy="16" rx="3" ry="1.5" fill="#87CEEB"/>
+  <ellipse cx="22" cy="16" rx="3" ry="1.5" fill="#87CEEB"/>
+  <rect x="10" y="21" width="12" height="2" fill="#1C3A5E"/>
+  <rect x="23" y="13" width="2" height="10" rx="1" fill="#DAA520"/>
+  <rect x="22.5" y="12" width="3" height="3" rx="1" fill="#FFD700"/>
+  <rect x="6" y="16" width="4" height="7" rx="1" fill="#4682B4"/>
+  <ellipse cx="6" cy="21" rx="3" ry="4" fill="#1C3A5E"/>
+  <ellipse cx="6" cy="21" rx="2" ry="3" fill="#4682B4"/>
+  <circle cx="6" cy="21" r="1" fill="#87CEEB"/>
+  <!-- Legs stride B -->
+  <rect x="11" y="23" width="5" height="6" rx="1" fill="#1C3A5E"/>
+  <rect x="18" y="23" width="5" height="8" rx="1" fill="#1C3A5E"/>
+  <rect x="11" y="27" width="6" height="3" rx="1" fill="#4682B4"/>
+  <rect x="17" y="29" width="7" height="3" rx="1" fill="#4682B4"/>
+</svg>

--- a/web/public/sprites/boss-dunebaron-1.svg
+++ b/web/public/sprites/boss-dunebaron-1.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <ellipse cx="16" cy="9" rx="6" ry="5" fill="#d4a030"/>
+  <path d="M10,8 Q16,3 22,8" fill="#DAA520"/>
+  <path d="M10,10 Q16,7 22,10" fill="#B8860B"/>
+  <path d="M22,9 Q25,8 24,12" fill="#DAA520"/>
+  <ellipse cx="16" cy="11" rx="4" ry="4" fill="#c8955a"/>
+  <rect x="12" y="12" width="8" height="3" rx="1" fill="#8B6914"/>
+  <circle cx="14" cy="11" r="0.8" fill="#333"/>
+  <circle cx="18" cy="11" r="0.8" fill="#333"/>
+  <path d="M10,15 L10,23 L22,23 L22,15 Q16,18 10,15 Z" fill="#C8A020"/>
+  <path d="M11,19 Q16,18 21,19" stroke="#8B6914" stroke-width="0.8" fill="none"/>
+  <rect x="10" y="21" width="12" height="2.5" fill="#8B6914"/>
+  <circle cx="13" cy="22" r="1" fill="#FF4444"/>
+  <circle cx="16" cy="22" r="1" fill="#4444FF"/>
+  <circle cx="19" cy="22" r="1" fill="#44AA44"/>
+  <path d="M22,14 Q26,16 28,13 Q27,19 22,20" stroke="#C0C0C0" stroke-width="1.5" fill="none"/>
+  <rect x="21.5" y="13" width="2" height="7" rx="0.5" fill="#888"/>
+  <rect x="21" y="11" width="3" height="4" rx="1" fill="#8B6914"/>
+  <!-- Legs stride A -->
+  <rect x="9"  y="23" width="5" height="8" rx="1" fill="#B8860B"/>
+  <rect x="18" y="23" width="5" height="6" rx="1" fill="#B8860B"/>
+  <rect x="8"  y="29" width="7" height="3" rx="1" fill="#8B6914"/>
+  <rect x="18" y="27" width="6" height="3" rx="1" fill="#8B6914"/>
+</svg>

--- a/web/public/sprites/boss-dunebaron-2.svg
+++ b/web/public/sprites/boss-dunebaron-2.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- 1px higher -->
+  <ellipse cx="16" cy="7" rx="6" ry="5" fill="#d4a030"/>
+  <path d="M10,6 Q16,1 22,6" fill="#DAA520"/>
+  <path d="M10,8 Q16,5 22,8" fill="#B8860B"/>
+  <path d="M22,7 Q25,6 24,10" fill="#DAA520"/>
+  <ellipse cx="16" cy="9" rx="4" ry="4" fill="#c8955a"/>
+  <rect x="12" y="10" width="8" height="3" rx="1" fill="#8B6914"/>
+  <circle cx="14" cy="9" r="0.8" fill="#333"/>
+  <circle cx="18" cy="9" r="0.8" fill="#333"/>
+  <path d="M10,13 Q9,21 10,29 L22,29 Q23,21 22,13 Q16,16 10,13 Z" fill="#C8A020"/>
+  <path d="M11,17 Q16,16 21,17" stroke="#8B6914" stroke-width="0.8" fill="none"/>
+  <path d="M11,21 Q16,20 21,21" stroke="#8B6914" stroke-width="0.8" fill="none"/>
+  <rect x="10" y="18" width="12" height="2.5" fill="#8B6914"/>
+  <circle cx="13" cy="19" r="1" fill="#FF4444"/>
+  <circle cx="16" cy="19" r="1" fill="#4444FF"/>
+  <circle cx="19" cy="19" r="1" fill="#44AA44"/>
+  <path d="M22,12 Q26,14 28,11 Q27,17 22,18" stroke="#C0C0C0" stroke-width="1.5" fill="none"/>
+  <rect x="21.5" y="11" width="2" height="7" rx="0.5" fill="#888"/>
+  <rect x="21" y="9" width="3" height="4" rx="1" fill="#8B6914"/>
+  <!-- Legs mid-stride -->
+  <rect x="11" y="21" width="5" height="9" rx="1" fill="#B8860B"/>
+  <rect x="17" y="21" width="5" height="9" rx="1" fill="#B8860B"/>
+  <rect x="10" y="28" width="7" height="3" rx="1" fill="#8B6914"/>
+  <rect x="16" y="28" width="7" height="3" rx="1" fill="#8B6914"/>
+</svg>

--- a/web/public/sprites/boss-dunebaron-3.svg
+++ b/web/public/sprites/boss-dunebaron-3.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <ellipse cx="16" cy="9" rx="6" ry="5" fill="#d4a030"/>
+  <path d="M10,8 Q16,3 22,8" fill="#DAA520"/>
+  <path d="M10,10 Q16,7 22,10" fill="#B8860B"/>
+  <path d="M22,9 Q25,8 24,12" fill="#DAA520"/>
+  <ellipse cx="16" cy="11" rx="4" ry="4" fill="#c8955a"/>
+  <rect x="12" y="12" width="8" height="3" rx="1" fill="#8B6914"/>
+  <circle cx="14" cy="11" r="0.8" fill="#333"/>
+  <circle cx="18" cy="11" r="0.8" fill="#333"/>
+  <path d="M10,15 L10,23 L22,23 L22,15 Q16,18 10,15 Z" fill="#C8A020"/>
+  <path d="M11,19 Q16,18 21,19" stroke="#8B6914" stroke-width="0.8" fill="none"/>
+  <rect x="10" y="21" width="12" height="2.5" fill="#8B6914"/>
+  <circle cx="13" cy="22" r="1" fill="#FF4444"/>
+  <circle cx="16" cy="22" r="1" fill="#4444FF"/>
+  <circle cx="19" cy="22" r="1" fill="#44AA44"/>
+  <path d="M22,14 Q26,16 28,13 Q27,19 22,20" stroke="#C0C0C0" stroke-width="1.5" fill="none"/>
+  <rect x="21.5" y="13" width="2" height="7" rx="0.5" fill="#888"/>
+  <rect x="21" y="11" width="3" height="4" rx="1" fill="#8B6914"/>
+  <!-- Legs stride B -->
+  <rect x="11" y="23" width="5" height="6" rx="1" fill="#B8860B"/>
+  <rect x="18" y="23" width="5" height="8" rx="1" fill="#B8860B"/>
+  <rect x="11" y="27" width="6" height="3" rx="1" fill="#8B6914"/>
+  <rect x="17" y="29" width="7" height="3" rx="1" fill="#8B6914"/>
+</svg>

--- a/web/public/sprites/boss-elderwarden-1.svg
+++ b/web/public/sprites/boss-elderwarden-1.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Staff raised - larger glow -->
+  <circle cx="5" cy="1" r="4" fill="#F9CA24" opacity="0.3"/>
+  <rect x="4" y="1" width="2" height="22" rx="1" fill="#8B5E3C"/>
+  <circle cx="5" cy="1" r="2.5" fill="#F9CA24"/>
+  <circle cx="5" cy="1" r="1.2" fill="#FFF9C4"/>
+  <circle cx="16" cy="6" r="4" fill="#C9A87C"/>
+  <ellipse cx="16" cy="11" rx="4" ry="4" fill="#E8E8E8"/>
+  <polygon points="13,14 16,20 19,14" fill="#E8E8E8"/>
+  <line x1="13.5" y1="6" x2="15.5" y2="6" stroke="#4A2C17" stroke-width="1.2"/>
+  <line x1="16.5" y1="6" x2="18.5" y2="6" stroke="#4A2C17" stroke-width="1.2"/>
+  <line x1="13" y1="5" x2="15.5" y2="5" stroke="#8B6B3D" stroke-width="0.8"/>
+  <line x1="16.5" y1="5" x2="19" y2="5" stroke="#8B6B3D" stroke-width="0.8"/>
+  <rect x="10" y="10" width="12" height="14" rx="2" fill="#1D4D35"/>
+  <rect x="10" y="10" width="12" height="4" rx="2" fill="#2D6A4F"/>
+  <polygon points="10,14 7,16 10,18" fill="#52B788"/>
+  <polygon points="22,14 25,16 22,18" fill="#52B788"/>
+  <rect x="10" y="20" width="12" height="2" rx="1" fill="#F9CA24"/>
+  <!-- Staff arm raised -->
+  <rect x="5" y="7" width="5" height="9" rx="1" fill="#1D4D35"/>
+  <rect x="17" y="10" width="5" height="9" rx="1" fill="#1D4D35"/>
+  <!-- Stride A -->
+  <rect x="11" y="24" width="4" height="7" rx="1" fill="#1D4D35" transform="rotate(-4 13 27.5)"/>
+  <rect x="17" y="24" width="4" height="7" rx="1" fill="#1D4D35" transform="rotate(4 19 27.5)"/>
+</svg>

--- a/web/public/sprites/boss-elderwarden-2.svg
+++ b/web/public/sprites/boss-elderwarden-2.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="5" cy="4" r="3.5" fill="#F9CA24" opacity="0.3"/>
+  <rect x="4" y="4" width="2" height="22" rx="1" fill="#8B5E3C"/>
+  <circle cx="5" cy="4" r="2.5" fill="#F9CA24"/>
+  <circle cx="5" cy="4" r="1.2" fill="#FFF9C4"/>
+  <circle cx="16" cy="7" r="4" fill="#C9A87C"/>
+  <ellipse cx="16" cy="12" rx="4" ry="4" fill="#E8E8E8"/>
+  <polygon points="13,15 16,21 19,15" fill="#E8E8E8"/>
+  <line x1="13.5" y1="7" x2="15.5" y2="7" stroke="#4A2C17" stroke-width="1.2"/>
+  <line x1="16.5" y1="7" x2="18.5" y2="7" stroke="#4A2C17" stroke-width="1.2"/>
+  <line x1="13" y1="6" x2="15.5" y2="6" stroke="#8B6B3D" stroke-width="0.8"/>
+  <line x1="16.5" y1="6" x2="19" y2="6" stroke="#8B6B3D" stroke-width="0.8"/>
+  <rect x="10" y="11" width="12" height="14" rx="2" fill="#1D4D35"/>
+  <rect x="10" y="11" width="12" height="4" rx="2" fill="#2D6A4F"/>
+  <polygon points="10,15 7,17 10,19" fill="#52B788"/>
+  <polygon points="22,15 25,17 22,19" fill="#52B788"/>
+  <rect x="10" y="21" width="12" height="2" rx="1" fill="#F9CA24"/>
+  <rect x="5" y="11" width="5" height="9" rx="1" fill="#1D4D35"/>
+  <rect x="17" y="11" width="5" height="9" rx="1" fill="#1D4D35"/>
+  <!-- Legs bob down -->
+  <rect x="11" y="25" width="4" height="6" rx="1" fill="#1D4D35"/>
+  <rect x="17" y="25" width="4" height="6" rx="1" fill="#1D4D35"/>
+</svg>

--- a/web/public/sprites/boss-elderwarden-3.svg
+++ b/web/public/sprites/boss-elderwarden-3.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="5" cy="3" r="3.5" fill="#F9CA24" opacity="0.3"/>
+  <rect x="4" y="3" width="2" height="22" rx="1" fill="#8B5E3C"/>
+  <circle cx="5" cy="3" r="2.5" fill="#F9CA24"/>
+  <circle cx="5" cy="3" r="1.2" fill="#FFF9C4"/>
+  <circle cx="16" cy="6" r="4" fill="#C9A87C"/>
+  <ellipse cx="16" cy="11" rx="4" ry="4" fill="#E8E8E8"/>
+  <polygon points="13,14 16,20 19,14" fill="#E8E8E8"/>
+  <line x1="13.5" y1="6" x2="15.5" y2="6" stroke="#4A2C17" stroke-width="1.2"/>
+  <line x1="16.5" y1="6" x2="18.5" y2="6" stroke="#4A2C17" stroke-width="1.2"/>
+  <line x1="13" y1="5" x2="15.5" y2="5" stroke="#8B6B3D" stroke-width="0.8"/>
+  <line x1="16.5" y1="5" x2="19" y2="5" stroke="#8B6B3D" stroke-width="0.8"/>
+  <rect x="10" y="10" width="12" height="14" rx="2" fill="#1D4D35"/>
+  <rect x="10" y="10" width="12" height="4" rx="2" fill="#2D6A4F"/>
+  <polygon points="10,14 7,16 10,18" fill="#52B788"/>
+  <polygon points="22,14 25,16 22,18" fill="#52B788"/>
+  <rect x="10" y="20" width="12" height="2" rx="1" fill="#F9CA24"/>
+  <!-- Staff arm normal -->
+  <rect x="5" y="10" width="5" height="9" rx="1" fill="#1D4D35"/>
+  <!-- Right arm raised in blessing -->
+  <rect x="17" y="7" width="5" height="9" rx="1" fill="#1D4D35"/>
+  <!-- Gold sparkle from raised hand -->
+  <circle cx="23" cy="7" r="2" fill="#F9CA24" opacity="0.6"/>
+  <circle cx="23" cy="7" r="1" fill="#FFF9C4" opacity="0.8"/>
+  <!-- Stride B -->
+  <rect x="11" y="24" width="4" height="7" rx="1" fill="#1D4D35" transform="rotate(4 13 27.5)"/>
+  <rect x="17" y="24" width="4" height="7" rx="1" fill="#1D4D35" transform="rotate(-4 19 27.5)"/>
+</svg>

--- a/web/public/sprites/boss-grandautomaton-1.svg
+++ b/web/public/sprites/boss-grandautomaton-1.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect x="7" y="1" width="18" height="13" rx="2" fill="#B8860B"/>
+  <rect x="7" y="1" width="18" height="6" rx="2" fill="#D4AF37"/>
+  <circle cx="9" cy="3" r="0.8" fill="#7D5A00"/>
+  <circle cx="23" cy="3" r="0.8" fill="#7D5A00"/>
+  <circle cx="9" cy="12" r="0.8" fill="#7D5A00"/>
+  <circle cx="23" cy="12" r="0.8" fill="#7D5A00"/>
+  <rect x="10" y="5" width="5" height="4" rx="1" fill="#00CEC9"/>
+  <rect x="17" y="5" width="5" height="4" rx="1" fill="#00CEC9"/>
+  <rect x="11" y="5.5" width="3" height="3" rx="0.5" fill="#81ECEC"/>
+  <rect x="18" y="5.5" width="3" height="3" rx="0.5" fill="#81ECEC"/>
+  <rect x="11" y="10" width="10" height="3" rx="1" fill="#7D5A00"/>
+  <line x1="14" y1="10" x2="14" y2="13" stroke="#B8860B" stroke-width="0.6"/>
+  <line x1="18" y1="10" x2="18" y2="13" stroke="#B8860B" stroke-width="0.6"/>
+  <rect x="5" y="14" width="22" height="13" rx="2" fill="#9A7000"/>
+  <rect x="12" y="17" width="8" height="6" rx="1" fill="#B8860B"/>
+  <circle cx="16" cy="20" r="3" fill="#00CEC9" opacity="0.9"/>
+  <circle cx="16" cy="20" r="1.5" fill="#81ECEC"/>
+  <!-- Left arm raised -->
+  <rect x="0" y="11" width="5" height="11" rx="1" fill="#9A7000"/>
+  <circle cx="2.5" cy="11" r="2" fill="#B8860B"/>
+  <rect x="0" y="20" width="6" height="5" rx="1" fill="#7D5A00"/>
+  <!-- Right arm normal -->
+  <rect x="27" y="14" width="5" height="11" rx="1" fill="#9A7000"/>
+  <circle cx="29.5" cy="14" r="2" fill="#B8860B"/>
+  <rect x="26" y="23" width="6" height="5" rx="1" fill="#7D5A00"/>
+  <!-- Legs stride A -->
+  <rect x="7" y="27" width="7" height="5" rx="1" fill="#9A7000" transform="rotate(-4 10.5 29.5)"/>
+  <rect x="18" y="27" width="7" height="5" rx="1" fill="#9A7000" transform="rotate(4 21.5 29.5)"/>
+</svg>

--- a/web/public/sprites/boss-grandautomaton-2.svg
+++ b/web/public/sprites/boss-grandautomaton-2.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect x="7" y="2" width="18" height="13" rx="2" fill="#B8860B"/>
+  <rect x="7" y="2" width="18" height="6" rx="2" fill="#D4AF37"/>
+  <circle cx="9" cy="4" r="0.8" fill="#7D5A00"/>
+  <circle cx="23" cy="4" r="0.8" fill="#7D5A00"/>
+  <circle cx="9" cy="13" r="0.8" fill="#7D5A00"/>
+  <circle cx="23" cy="13" r="0.8" fill="#7D5A00"/>
+  <rect x="10" y="6" width="5" height="4" rx="1" fill="#00CEC9"/>
+  <rect x="17" y="6" width="5" height="4" rx="1" fill="#00CEC9"/>
+  <rect x="11" y="6.5" width="3" height="3" rx="0.5" fill="#81ECEC"/>
+  <rect x="18" y="6.5" width="3" height="3" rx="0.5" fill="#81ECEC"/>
+  <rect x="11" y="11" width="10" height="3" rx="1" fill="#7D5A00"/>
+  <line x1="14" y1="11" x2="14" y2="14" stroke="#B8860B" stroke-width="0.6"/>
+  <line x1="18" y1="11" x2="18" y2="14" stroke="#B8860B" stroke-width="0.6"/>
+  <rect x="5" y="15" width="22" height="13" rx="2" fill="#9A7000"/>
+  <rect x="12" y="18" width="8" height="6" rx="1" fill="#B8860B"/>
+  <circle cx="16" cy="21" r="3" fill="#00CEC9" opacity="0.9"/>
+  <circle cx="16" cy="21" r="1.5" fill="#81ECEC"/>
+  <rect x="0" y="15" width="5" height="11" rx="1" fill="#9A7000"/>
+  <circle cx="2.5" cy="15" r="2" fill="#B8860B"/>
+  <rect x="0" y="24" width="6" height="5" rx="1" fill="#7D5A00"/>
+  <rect x="27" y="15" width="5" height="11" rx="1" fill="#9A7000"/>
+  <circle cx="29.5" cy="15" r="2" fill="#B8860B"/>
+  <rect x="26" y="24" width="6" height="5" rx="1" fill="#7D5A00"/>
+  <!-- Legs bob down -->
+  <rect x="7" y="28" width="7" height="4" rx="1" fill="#9A7000"/>
+  <rect x="18" y="28" width="7" height="4" rx="1" fill="#9A7000"/>
+</svg>

--- a/web/public/sprites/boss-grandautomaton-3.svg
+++ b/web/public/sprites/boss-grandautomaton-3.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect x="7" y="1" width="18" height="13" rx="2" fill="#B8860B"/>
+  <rect x="7" y="1" width="18" height="6" rx="2" fill="#D4AF37"/>
+  <circle cx="9" cy="3" r="0.8" fill="#7D5A00"/>
+  <circle cx="23" cy="3" r="0.8" fill="#7D5A00"/>
+  <circle cx="9" cy="12" r="0.8" fill="#7D5A00"/>
+  <circle cx="23" cy="12" r="0.8" fill="#7D5A00"/>
+  <rect x="10" y="5" width="5" height="4" rx="1" fill="#00CEC9"/>
+  <rect x="17" y="5" width="5" height="4" rx="1" fill="#00CEC9"/>
+  <rect x="11" y="5.5" width="3" height="3" rx="0.5" fill="#81ECEC"/>
+  <rect x="18" y="5.5" width="3" height="3" rx="0.5" fill="#81ECEC"/>
+  <rect x="11" y="10" width="10" height="3" rx="1" fill="#7D5A00"/>
+  <line x1="14" y1="10" x2="14" y2="13" stroke="#B8860B" stroke-width="0.6"/>
+  <line x1="18" y1="10" x2="18" y2="13" stroke="#B8860B" stroke-width="0.6"/>
+  <rect x="5" y="14" width="22" height="13" rx="2" fill="#9A7000"/>
+  <rect x="12" y="17" width="8" height="6" rx="1" fill="#B8860B"/>
+  <circle cx="16" cy="20" r="3" fill="#00CEC9" opacity="0.9"/>
+  <circle cx="16" cy="20" r="1.5" fill="#81ECEC"/>
+  <!-- Left arm normal -->
+  <rect x="0" y="14" width="5" height="11" rx="1" fill="#9A7000"/>
+  <circle cx="2.5" cy="14" r="2" fill="#B8860B"/>
+  <rect x="0" y="23" width="6" height="5" rx="1" fill="#7D5A00"/>
+  <!-- Right arm raised -->
+  <rect x="27" y="11" width="5" height="11" rx="1" fill="#9A7000"/>
+  <circle cx="29.5" cy="11" r="2" fill="#B8860B"/>
+  <rect x="26" y="20" width="6" height="5" rx="1" fill="#7D5A00"/>
+  <!-- Legs stride B -->
+  <rect x="7" y="27" width="7" height="5" rx="1" fill="#9A7000" transform="rotate(4 10.5 29.5)"/>
+  <rect x="18" y="27" width="7" height="5" rx="1" fill="#9A7000" transform="rotate(-4 21.5 29.5)"/>
+</svg>

--- a/web/public/sprites/boss-harbormaster-1.svg
+++ b/web/public/sprites/boss-harbormaster-1.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect x="9" y="3" width="14" height="2" rx="1" fill="#0D2137"/>
+  <rect x="11" y="1" width="10" height="4" rx="1" fill="#1B3A6B"/>
+  <rect x="14" y="1.5" width="4" height="2" rx="0.5" fill="#F39C12"/>
+  <circle cx="16" cy="8" r="4" fill="#D4AC68"/>
+  <ellipse cx="16" cy="10.5" rx="3" ry="1.2" fill="#4A3B2A"/>
+  <circle cx="14.5" cy="7.5" r="1" fill="#2C3E50"/>
+  <circle cx="17.5" cy="7.5" r="1" fill="#2C3E50"/>
+  <rect x="9" y="12" width="14" height="13" rx="2" fill="#1B3A6B"/>
+  <rect x="9" y="12" width="14" height="4" rx="2" fill="#2C5282"/>
+  <circle cx="16" cy="14" r="0.8" fill="#F39C12"/>
+  <circle cx="16" cy="17" r="0.8" fill="#F39C12"/>
+  <circle cx="16" cy="20" r="0.8" fill="#F39C12"/>
+  <rect x="7" y="12" width="4" height="2" rx="1" fill="#F39C12"/>
+  <rect x="21" y="12" width="4" height="2" rx="1" fill="#F39C12"/>
+  <!-- Left arm (telescope) raised to eye -->
+  <rect x="4" y="9" width="5" height="9" rx="1" fill="#1B3A6B"/>
+  <rect x="1" y="12" width="7" height="3" rx="1" fill="#8B6B3D"/>
+  <rect x="0" y="12.5" width="3" height="2" rx="0.5" fill="#C9A24C"/>
+  <rect x="23" y="12" width="5" height="9" rx="1" fill="#1B3A6B"/>
+  <!-- Stride A -->
+  <rect x="10" y="25" width="5" height="7" rx="1" fill="#0D2137" transform="rotate(-4 12.5 28.5)"/>
+  <rect x="17" y="25" width="5" height="7" rx="1" fill="#0D2137" transform="rotate(4 19.5 28.5)"/>
+</svg>

--- a/web/public/sprites/boss-harbormaster-2.svg
+++ b/web/public/sprites/boss-harbormaster-2.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect x="9" y="4" width="14" height="2" rx="1" fill="#0D2137"/>
+  <rect x="11" y="2" width="10" height="4" rx="1" fill="#1B3A6B"/>
+  <rect x="14" y="2.5" width="4" height="2" rx="0.5" fill="#F39C12"/>
+  <circle cx="16" cy="9" r="4" fill="#D4AC68"/>
+  <ellipse cx="16" cy="11.5" rx="3" ry="1.2" fill="#4A3B2A"/>
+  <circle cx="14.5" cy="8.5" r="1" fill="#2C3E50"/>
+  <circle cx="17.5" cy="8.5" r="1" fill="#2C3E50"/>
+  <rect x="9" y="13" width="14" height="13" rx="2" fill="#1B3A6B"/>
+  <rect x="9" y="13" width="14" height="4" rx="2" fill="#2C5282"/>
+  <circle cx="16" cy="15" r="0.8" fill="#F39C12"/>
+  <circle cx="16" cy="18" r="0.8" fill="#F39C12"/>
+  <circle cx="16" cy="21" r="0.8" fill="#F39C12"/>
+  <rect x="7" y="13" width="4" height="2" rx="1" fill="#F39C12"/>
+  <rect x="21" y="13" width="4" height="2" rx="1" fill="#F39C12"/>
+  <rect x="4" y="13" width="5" height="9" rx="1" fill="#1B3A6B"/>
+  <rect x="1" y="16" width="7" height="3" rx="1" fill="#8B6B3D"/>
+  <rect x="0" y="16.5" width="3" height="2" rx="0.5" fill="#C9A24C"/>
+  <rect x="23" y="13" width="5" height="9" rx="1" fill="#1B3A6B"/>
+  <!-- Legs bob down -->
+  <rect x="10" y="26" width="5" height="6" rx="1" fill="#0D2137"/>
+  <rect x="17" y="26" width="5" height="6" rx="1" fill="#0D2137"/>
+</svg>

--- a/web/public/sprites/boss-harbormaster-3.svg
+++ b/web/public/sprites/boss-harbormaster-3.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect x="9" y="3" width="14" height="2" rx="1" fill="#0D2137"/>
+  <rect x="11" y="1" width="10" height="4" rx="1" fill="#1B3A6B"/>
+  <rect x="14" y="1.5" width="4" height="2" rx="0.5" fill="#F39C12"/>
+  <circle cx="16" cy="8" r="4" fill="#D4AC68"/>
+  <ellipse cx="16" cy="10.5" rx="3" ry="1.2" fill="#4A3B2A"/>
+  <circle cx="14.5" cy="7.5" r="1" fill="#2C3E50"/>
+  <circle cx="17.5" cy="7.5" r="1" fill="#2C3E50"/>
+  <rect x="9" y="12" width="14" height="13" rx="2" fill="#1B3A6B"/>
+  <rect x="9" y="12" width="14" height="4" rx="2" fill="#2C5282"/>
+  <circle cx="16" cy="14" r="0.8" fill="#F39C12"/>
+  <circle cx="16" cy="17" r="0.8" fill="#F39C12"/>
+  <circle cx="16" cy="20" r="0.8" fill="#F39C12"/>
+  <rect x="7" y="12" width="4" height="2" rx="1" fill="#F39C12"/>
+  <rect x="21" y="12" width="4" height="2" rx="1" fill="#F39C12"/>
+  <!-- Left arm telescope normal -->
+  <rect x="4" y="12" width="5" height="9" rx="1" fill="#1B3A6B"/>
+  <rect x="1" y="15" width="7" height="3" rx="1" fill="#8B6B3D"/>
+  <rect x="0" y="15.5" width="3" height="2" rx="0.5" fill="#C9A24C"/>
+  <!-- Right arm raised in salute -->
+  <rect x="23" y="9" width="5" height="9" rx="1" fill="#1B3A6B"/>
+  <!-- Stride B -->
+  <rect x="10" y="25" width="5" height="7" rx="1" fill="#0D2137" transform="rotate(4 12.5 28.5)"/>
+  <rect x="17" y="25" width="5" height="7" rx="1" fill="#0D2137" transform="rotate(-4 19.5 28.5)"/>
+</svg>

--- a/web/public/sprites/boss-kragg-1.svg
+++ b/web/public/sprites/boss-kragg-1.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Warlord Kragg — frame 1 (body 1px down, left leg fwd, right leg back) -->
+  <!-- Left leg forward 2px -->
+  <rect x="9" y="23" width="4" height="8" rx="1" fill="#333344" transform="rotate(10,11,27)"/>
+  <!-- Right leg back -->
+  <rect x="19" y="23" width="4" height="8" rx="1" fill="#333344" transform="rotate(-6,21,27)"/>
+  <!-- Spiked shoulder pads shifted 1px down -->
+  <rect x="4" y="12" width="7" height="5" rx="1" fill="#333344" stroke="#222233" stroke-width="0.8"/>
+  <polygon points="4,12 5,9 6,12" fill="#ddcc88"/>
+  <polygon points="8,12 9,9 10,12" fill="#ddcc88"/>
+  <rect x="21" y="12" width="7" height="5" rx="1" fill="#333344" stroke="#222233" stroke-width="0.8"/>
+  <polygon points="22,12 23,9 24,12" fill="#ddcc88"/>
+  <polygon points="26,12 27,9 28,12" fill="#ddcc88"/>
+  <!-- Broad armored torso shifted 1px down -->
+  <rect x="9" y="13" width="14" height="11" rx="1" fill="#333344" stroke="#222233" stroke-width="1"/>
+  <rect x="9" y="17" width="14" height="2" fill="#aa2222" opacity="0.7"/>
+  <!-- Horned helmet -->
+  <rect x="11" y="5" width="10" height="9" rx="2" fill="#333344" stroke="#222233" stroke-width="1"/>
+  <polygon points="11,7 9,3 12,6" fill="#ddcc88"/>
+  <polygon points="21,7 23,3 20,6" fill="#ddcc88"/>
+  <!-- Orc face -->
+  <ellipse cx="16" cy="9" rx="4" ry="4" fill="#668833"/>
+  <circle cx="14.5" cy="8.5" r="0.8" fill="#aa2222"/>
+  <circle cx="17.5" cy="8.5" r="0.8" fill="#aa2222"/>
+  <rect x="14" y="12" width="1.5" height="2" rx="0.5" fill="#ddcc88"/>
+  <rect x="16.5" y="12" width="1.5" height="2" rx="0.5" fill="#ddcc88"/>
+  <!-- Axe -->
+  <line x1="23" y1="8" x2="25" y2="28" stroke="#222233" stroke-width="1.5"/>
+  <path d="M20,9 Q23,6 26,9 Q24,13 23,13 Z" fill="#333344" stroke="#222233" stroke-width="1"/>
+  <line x1="22" y1="9" x2="25" y2="10" stroke="#aabbcc" stroke-width="0.8"/>
+</svg>

--- a/web/public/sprites/boss-kragg-2.svg
+++ b/web/public/sprites/boss-kragg-2.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Warlord Kragg — frame 2 (mid-stride, both legs near center) -->
+  <!-- Both legs centered -->
+  <rect x="12" y="22" width="4" height="8" rx="1" fill="#333344"/>
+  <rect x="16" y="22" width="4" height="8" rx="1" fill="#333344"/>
+  <!-- Spiked shoulder pads -->
+  <rect x="4" y="11" width="7" height="5" rx="1" fill="#333344" stroke="#222233" stroke-width="0.8"/>
+  <polygon points="4,11 5,8 6,11" fill="#ddcc88"/>
+  <polygon points="8,11 9,8 10,11" fill="#ddcc88"/>
+  <rect x="21" y="11" width="7" height="5" rx="1" fill="#333344" stroke="#222233" stroke-width="0.8"/>
+  <polygon points="22,11 23,8 24,11" fill="#ddcc88"/>
+  <polygon points="26,11 27,8 28,11" fill="#ddcc88"/>
+  <!-- Broad armored torso -->
+  <rect x="9" y="12" width="14" height="11" rx="1" fill="#333344" stroke="#222233" stroke-width="1"/>
+  <rect x="9" y="16" width="14" height="2" fill="#aa2222" opacity="0.7"/>
+  <!-- Horned helmet -->
+  <rect x="11" y="4" width="10" height="9" rx="2" fill="#333344" stroke="#222233" stroke-width="1"/>
+  <polygon points="11,6 9,2 12,5" fill="#ddcc88"/>
+  <polygon points="21,6 23,2 20,5" fill="#ddcc88"/>
+  <!-- Orc face -->
+  <ellipse cx="16" cy="8" rx="4" ry="4" fill="#668833"/>
+  <circle cx="14.5" cy="7.5" r="0.8" fill="#aa2222"/>
+  <circle cx="17.5" cy="7.5" r="0.8" fill="#aa2222"/>
+  <rect x="14" y="11" width="1.5" height="2" rx="0.5" fill="#ddcc88"/>
+  <rect x="16.5" y="11" width="1.5" height="2" rx="0.5" fill="#ddcc88"/>
+  <!-- Axe -->
+  <line x1="23" y1="7" x2="25" y2="27" stroke="#222233" stroke-width="1.5"/>
+  <path d="M20,8 Q23,5 26,8 Q24,12 23,12 Z" fill="#333344" stroke="#222233" stroke-width="1"/>
+  <line x1="22" y1="8" x2="25" y2="9" stroke="#aabbcc" stroke-width="0.8"/>
+</svg>

--- a/web/public/sprites/boss-kragg-3.svg
+++ b/web/public/sprites/boss-kragg-3.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Warlord Kragg — frame 3 (body 1px down, right leg fwd, left leg back — mirror of 1) -->
+  <!-- Right leg forward 2px -->
+  <rect x="19" y="23" width="4" height="8" rx="1" fill="#333344" transform="rotate(-10,21,27)"/>
+  <!-- Left leg back -->
+  <rect x="9" y="23" width="4" height="8" rx="1" fill="#333344" transform="rotate(6,11,27)"/>
+  <!-- Spiked shoulder pads shifted 1px down -->
+  <rect x="4" y="12" width="7" height="5" rx="1" fill="#333344" stroke="#222233" stroke-width="0.8"/>
+  <polygon points="4,12 5,9 6,12" fill="#ddcc88"/>
+  <polygon points="8,12 9,9 10,12" fill="#ddcc88"/>
+  <rect x="21" y="12" width="7" height="5" rx="1" fill="#333344" stroke="#222233" stroke-width="0.8"/>
+  <polygon points="22,12 23,9 24,12" fill="#ddcc88"/>
+  <polygon points="26,12 27,9 28,12" fill="#ddcc88"/>
+  <!-- Broad armored torso shifted 1px down -->
+  <rect x="9" y="13" width="14" height="11" rx="1" fill="#333344" stroke="#222233" stroke-width="1"/>
+  <rect x="9" y="17" width="14" height="2" fill="#aa2222" opacity="0.7"/>
+  <!-- Horned helmet -->
+  <rect x="11" y="5" width="10" height="9" rx="2" fill="#333344" stroke="#222233" stroke-width="1"/>
+  <polygon points="11,7 9,3 12,6" fill="#ddcc88"/>
+  <polygon points="21,7 23,3 20,6" fill="#ddcc88"/>
+  <!-- Orc face -->
+  <ellipse cx="16" cy="9" rx="4" ry="4" fill="#668833"/>
+  <circle cx="14.5" cy="8.5" r="0.8" fill="#aa2222"/>
+  <circle cx="17.5" cy="8.5" r="0.8" fill="#aa2222"/>
+  <rect x="14" y="12" width="1.5" height="2" rx="0.5" fill="#ddcc88"/>
+  <rect x="16.5" y="12" width="1.5" height="2" rx="0.5" fill="#ddcc88"/>
+  <!-- Axe -->
+  <line x1="23" y1="8" x2="25" y2="28" stroke="#222233" stroke-width="1.5"/>
+  <path d="M20,9 Q23,6 26,9 Q24,13 23,13 Z" fill="#333344" stroke="#222233" stroke-width="1"/>
+  <line x1="22" y1="9" x2="25" y2="10" stroke="#aabbcc" stroke-width="0.8"/>
+</svg>

--- a/web/public/sprites/boss-paleengine-1.svg
+++ b/web/public/sprites/boss-paleengine-1.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect x="11" y="5" width="10" height="9" rx="3" fill="#DDD"/>
+  <rect x="12" y="6" width="8" height="7" rx="2" fill="#EEE"/>
+  <circle cx="16" cy="10" r="3" fill="#BBB"/>
+  <circle cx="16" cy="10" r="2" fill="#CCDDFF" opacity="0.8"/>
+  <circle cx="16" cy="10" r="1" fill="#FFFFFF" opacity="0.9"/>
+  <rect x="13" y="14" width="6" height="3" rx="1" fill="#CCC"/>
+  <line x1="14" y1="14" x2="14" y2="17" stroke="#AAA" stroke-width="0.7"/>
+  <line x1="16" y1="14" x2="16" y2="17" stroke="#AAA" stroke-width="0.7"/>
+  <line x1="18" y1="14" x2="18" y2="17" stroke="#AAA" stroke-width="0.7"/>
+  <rect x="10" y="17" width="12" height="10" rx="2" fill="#CCC"/>
+  <rect x="11" y="18" width="10" height="8" fill="#DDD"/>
+  <line x1="12" y1="18" x2="12" y2="25" stroke="#AABBFF" stroke-width="1.2" opacity="0.7"/>
+  <line x1="16" y1="18" x2="16" y2="25" stroke="#AABBFF" stroke-width="1.2" opacity="0.7"/>
+  <line x1="20" y1="18" x2="20" y2="25" stroke="#AABBFF" stroke-width="1.2" opacity="0.7"/>
+  <circle cx="10" cy="18" r="2.5" fill="#BBB"/>
+  <circle cx="22" cy="18" r="2.5" fill="#BBB"/>
+  <rect x="6"  y="18" width="4" height="9" rx="1" fill="#CCC"/>
+  <rect x="22" y="18" width="4" height="9" rx="1" fill="#CCC"/>
+  <path d="M5,26 L4,30 M7,26 L8,30" stroke="#BBB" stroke-width="1.5"/>
+  <path d="M22,26 L21,30 M25,26 L26,30" stroke="#BBB" stroke-width="1.5"/>
+  <!-- Legs stride A -->
+  <rect x="9"  y="27" width="4" height="5" rx="1" fill="#CCC"/>
+  <rect x="18" y="27" width="4" height="3" rx="1" fill="#CCC"/>
+  <rect x="8"  y="30" width="6" height="2" rx="1" fill="#BBB"/>
+  <rect x="18" y="28" width="5" height="2" rx="1" fill="#BBB"/>
+</svg>

--- a/web/public/sprites/boss-paleengine-2.svg
+++ b/web/public/sprites/boss-paleengine-2.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- 1px higher -->
+  <rect x="11" y="3" width="10" height="9" rx="3" fill="#DDD"/>
+  <rect x="12" y="4" width="8" height="7" rx="2" fill="#EEE"/>
+  <circle cx="16" cy="8" r="3" fill="#BBB"/>
+  <circle cx="16" cy="8" r="2" fill="#CCDDFF" opacity="0.8"/>
+  <circle cx="16" cy="8" r="1" fill="#FFFFFF" opacity="0.9"/>
+  <rect x="13" y="12" width="6" height="3" rx="1" fill="#CCC"/>
+  <line x1="14" y1="12" x2="14" y2="15" stroke="#AAA" stroke-width="0.7"/>
+  <line x1="16" y1="12" x2="16" y2="15" stroke="#AAA" stroke-width="0.7"/>
+  <line x1="18" y1="12" x2="18" y2="15" stroke="#AAA" stroke-width="0.7"/>
+  <rect x="10" y="15" width="12" height="10" rx="2" fill="#CCC"/>
+  <rect x="11" y="16" width="10" height="8" fill="#DDD"/>
+  <line x1="12" y1="16" x2="12" y2="23" stroke="#AABBFF" stroke-width="1.2" opacity="0.7"/>
+  <line x1="16" y1="16" x2="16" y2="23" stroke="#AABBFF" stroke-width="1.2" opacity="0.7"/>
+  <line x1="20" y1="16" x2="20" y2="23" stroke="#AABBFF" stroke-width="1.2" opacity="0.7"/>
+  <circle cx="10" cy="15" r="2.5" fill="#BBB"/>
+  <circle cx="22" cy="15" r="2.5" fill="#BBB"/>
+  <rect x="6"  y="15" width="4" height="9" rx="1" fill="#CCC"/>
+  <rect x="22" y="15" width="4" height="9" rx="1" fill="#CCC"/>
+  <path d="M5,23 L4,27 M7,23 L8,27" stroke="#BBB" stroke-width="1.5"/>
+  <path d="M22,23 L21,27 M25,23 L26,27" stroke="#BBB" stroke-width="1.5"/>
+  <!-- Legs mid-stride -->
+  <rect x="11" y="25" width="4" height="7" rx="1" fill="#CCC"/>
+  <rect x="17" y="25" width="4" height="7" rx="1" fill="#CCC"/>
+  <rect x="10" y="30" width="6" height="2" rx="1" fill="#BBB"/>
+  <rect x="16" y="30" width="6" height="2" rx="1" fill="#BBB"/>
+</svg>

--- a/web/public/sprites/boss-paleengine-3.svg
+++ b/web/public/sprites/boss-paleengine-3.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect x="11" y="5" width="10" height="9" rx="3" fill="#DDD"/>
+  <rect x="12" y="6" width="8" height="7" rx="2" fill="#EEE"/>
+  <circle cx="16" cy="10" r="3" fill="#BBB"/>
+  <circle cx="16" cy="10" r="2" fill="#CCDDFF" opacity="0.8"/>
+  <circle cx="16" cy="10" r="1" fill="#FFFFFF" opacity="0.9"/>
+  <rect x="13" y="14" width="6" height="3" rx="1" fill="#CCC"/>
+  <line x1="14" y1="14" x2="14" y2="17" stroke="#AAA" stroke-width="0.7"/>
+  <line x1="16" y1="14" x2="16" y2="17" stroke="#AAA" stroke-width="0.7"/>
+  <line x1="18" y1="14" x2="18" y2="17" stroke="#AAA" stroke-width="0.7"/>
+  <rect x="10" y="17" width="12" height="10" rx="2" fill="#CCC"/>
+  <rect x="11" y="18" width="10" height="8" fill="#DDD"/>
+  <line x1="12" y1="18" x2="12" y2="25" stroke="#AABBFF" stroke-width="1.2" opacity="0.7"/>
+  <line x1="16" y1="18" x2="16" y2="25" stroke="#AABBFF" stroke-width="1.2" opacity="0.7"/>
+  <line x1="20" y1="18" x2="20" y2="25" stroke="#AABBFF" stroke-width="1.2" opacity="0.7"/>
+  <circle cx="10" cy="18" r="2.5" fill="#BBB"/>
+  <circle cx="22" cy="18" r="2.5" fill="#BBB"/>
+  <rect x="6"  y="18" width="4" height="9" rx="1" fill="#CCC"/>
+  <rect x="22" y="18" width="4" height="9" rx="1" fill="#CCC"/>
+  <path d="M5,26 L4,30 M7,26 L8,30" stroke="#BBB" stroke-width="1.5"/>
+  <path d="M22,26 L21,30 M25,26 L26,30" stroke="#BBB" stroke-width="1.5"/>
+  <!-- Legs stride B -->
+  <rect x="11" y="27" width="4" height="3" rx="1" fill="#CCC"/>
+  <rect x="17" y="27" width="4" height="5" rx="1" fill="#CCC"/>
+  <rect x="11" y="28" width="5" height="2" rx="1" fill="#BBB"/>
+  <rect x="16" y="30" width="6" height="2" rx="1" fill="#BBB"/>
+</svg>

--- a/web/public/sprites/boss-rootqueen-1.svg
+++ b/web/public/sprites/boss-rootqueen-1.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Root Queen walk frame 1 — left leg forward -->
+  <path d="M12,5 Q10,2 9,1 M14,4 Q13,1 12,0 M16,3 Q16,0 16,0 M18,4 Q19,1 20,0 M20,5 Q22,2 23,1" stroke="#5C3A1A" stroke-width="1.5" fill="none" stroke-linecap="round"/>
+  <circle cx="9" cy="2" r="1.5" fill="#228B22"/>
+  <circle cx="12" cy="1" r="1.5" fill="#228B22"/>
+  <circle cx="16" cy="0" r="1.5" fill="#228B22"/>
+  <circle cx="20" cy="1" r="1.5" fill="#228B22"/>
+  <circle cx="23" cy="2" r="1.5" fill="#228B22"/>
+  <ellipse cx="16" cy="10" rx="5" ry="5" fill="#7A4A28"/>
+  <ellipse cx="16" cy="10" rx="4" ry="4" fill="#9A6A3A"/>
+  <circle cx="14" cy="9" r="1.2" fill="#90EE90"/>
+  <circle cx="14" cy="9" r="0.6" fill="#006400"/>
+  <circle cx="18" cy="9" r="1.2" fill="#90EE90"/>
+  <circle cx="18" cy="9" r="0.6" fill="#006400"/>
+  <path d="M14,12 Q16,13 18,12" stroke="#5C3A1A" stroke-width="0.8" fill="none"/>
+  <rect x="12" y="15" width="8" height="10" rx="1" fill="#5C3A1A"/>
+  <rect x="13" y="15" width="6" height="10" rx="1" fill="#7A4A28"/>
+  <path d="M13,17 Q16,18 19,17" stroke="#5C3A1A" stroke-width="0.7" fill="none"/>
+  <path d="M13,20 Q16,21 19,20" stroke="#5C3A1A" stroke-width="0.7" fill="none"/>
+  <path d="M13,23 Q16,24 19,23" stroke="#5C3A1A" stroke-width="0.7" fill="none"/>
+  <path d="M12,17 Q7,16 5,18 Q7,19 6,21" stroke="#5C3A1A" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+  <circle cx="5" cy="21" r="1.5" fill="#228B22"/>
+  <path d="M20,17 Q25,16 27,18 Q25,19 26,21" stroke="#5C3A1A" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+  <circle cx="27" cy="21" r="1.5" fill="#228B22"/>
+  <!-- Left leg forward -->
+  <rect x="10" y="25" width="4" height="7" rx="1" fill="#5C3A1A"/>
+  <rect x="17" y="25" width="4" height="5" rx="1" fill="#5C3A1A"/>
+  <path d="M10,31 Q8,32 7,32" stroke="#5C3A1A" stroke-width="2" fill="none" stroke-linecap="round"/>
+  <path d="M14,31 Q14,32 13,32" stroke="#5C3A1A" stroke-width="2" fill="none" stroke-linecap="round"/>
+  <path d="M17,30 Q19,32 20,32" stroke="#5C3A1A" stroke-width="2" fill="none" stroke-linecap="round"/>
+  <path d="M21,30 Q22,31 23,31" stroke="#5C3A1A" stroke-width="2" fill="none" stroke-linecap="round"/>
+</svg>

--- a/web/public/sprites/boss-rootqueen-2.svg
+++ b/web/public/sprites/boss-rootqueen-2.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Root Queen walk frame 2 — body 1px higher, legs together -->
+  <path d="M12,4 Q10,1 9,0 M14,3 Q13,0 12,0 M16,2 Q16,0 16,0 M18,3 Q19,0 20,0 M20,4 Q22,1 23,0" stroke="#5C3A1A" stroke-width="1.5" fill="none" stroke-linecap="round"/>
+  <circle cx="9" cy="1" r="1.5" fill="#228B22"/>
+  <circle cx="12" cy="0" r="1.5" fill="#228B22"/>
+  <circle cx="16" cy="0" r="1.5" fill="#228B22"/>
+  <circle cx="20" cy="0" r="1.5" fill="#228B22"/>
+  <circle cx="23" cy="1" r="1.5" fill="#228B22"/>
+  <ellipse cx="16" cy="8" rx="5" ry="5" fill="#7A4A28"/>
+  <ellipse cx="16" cy="8" rx="4" ry="4" fill="#9A6A3A"/>
+  <circle cx="14" cy="7" r="1.2" fill="#90EE90"/>
+  <circle cx="14" cy="7" r="0.6" fill="#006400"/>
+  <circle cx="18" cy="7" r="1.2" fill="#90EE90"/>
+  <circle cx="18" cy="7" r="0.6" fill="#006400"/>
+  <path d="M14,10 Q16,11 18,10" stroke="#5C3A1A" stroke-width="0.8" fill="none"/>
+  <rect x="12" y="13" width="8" height="10" rx="1" fill="#5C3A1A"/>
+  <rect x="13" y="13" width="6" height="10" rx="1" fill="#7A4A28"/>
+  <path d="M13,15 Q16,16 19,15" stroke="#5C3A1A" stroke-width="0.7" fill="none"/>
+  <path d="M13,18 Q16,19 19,18" stroke="#5C3A1A" stroke-width="0.7" fill="none"/>
+  <path d="M13,21 Q16,22 19,21" stroke="#5C3A1A" stroke-width="0.7" fill="none"/>
+  <path d="M12,15 Q7,14 5,16 Q7,17 6,19" stroke="#5C3A1A" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+  <circle cx="5" cy="19" r="1.5" fill="#228B22"/>
+  <path d="M20,15 Q25,14 27,16 Q25,17 26,19" stroke="#5C3A1A" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+  <circle cx="27" cy="19" r="1.5" fill="#228B22"/>
+  <!-- Legs together (mid-stride) -->
+  <rect x="12" y="23" width="4" height="8" rx="1" fill="#5C3A1A"/>
+  <rect x="17" y="23" width="4" height="8" rx="1" fill="#5C3A1A"/>
+  <path d="M12,30 Q10,32 9,32" stroke="#5C3A1A" stroke-width="2" fill="none" stroke-linecap="round"/>
+  <path d="M16,31 Q16,32 15,32" stroke="#5C3A1A" stroke-width="2" fill="none" stroke-linecap="round"/>
+  <path d="M17,31 Q19,32 20,32" stroke="#5C3A1A" stroke-width="2" fill="none" stroke-linecap="round"/>
+  <path d="M21,30 Q23,32 24,32" stroke="#5C3A1A" stroke-width="2" fill="none" stroke-linecap="round"/>
+</svg>

--- a/web/public/sprites/boss-rootqueen-3.svg
+++ b/web/public/sprites/boss-rootqueen-3.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Root Queen walk frame 3 — right leg forward -->
+  <path d="M12,5 Q10,2 9,1 M14,4 Q13,1 12,0 M16,3 Q16,0 16,0 M18,4 Q19,1 20,0 M20,5 Q22,2 23,1" stroke="#5C3A1A" stroke-width="1.5" fill="none" stroke-linecap="round"/>
+  <circle cx="9" cy="2" r="1.5" fill="#228B22"/>
+  <circle cx="12" cy="1" r="1.5" fill="#228B22"/>
+  <circle cx="16" cy="0" r="1.5" fill="#228B22"/>
+  <circle cx="20" cy="1" r="1.5" fill="#228B22"/>
+  <circle cx="23" cy="2" r="1.5" fill="#228B22"/>
+  <ellipse cx="16" cy="10" rx="5" ry="5" fill="#7A4A28"/>
+  <ellipse cx="16" cy="10" rx="4" ry="4" fill="#9A6A3A"/>
+  <circle cx="14" cy="9" r="1.2" fill="#90EE90"/>
+  <circle cx="14" cy="9" r="0.6" fill="#006400"/>
+  <circle cx="18" cy="9" r="1.2" fill="#90EE90"/>
+  <circle cx="18" cy="9" r="0.6" fill="#006400"/>
+  <path d="M14,12 Q16,13 18,12" stroke="#5C3A1A" stroke-width="0.8" fill="none"/>
+  <rect x="12" y="15" width="8" height="10" rx="1" fill="#5C3A1A"/>
+  <rect x="13" y="15" width="6" height="10" rx="1" fill="#7A4A28"/>
+  <path d="M13,17 Q16,18 19,17" stroke="#5C3A1A" stroke-width="0.7" fill="none"/>
+  <path d="M13,20 Q16,21 19,20" stroke="#5C3A1A" stroke-width="0.7" fill="none"/>
+  <path d="M13,23 Q16,24 19,23" stroke="#5C3A1A" stroke-width="0.7" fill="none"/>
+  <path d="M12,17 Q7,16 5,18 Q7,19 6,21" stroke="#5C3A1A" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+  <circle cx="5" cy="21" r="1.5" fill="#228B22"/>
+  <path d="M20,17 Q25,16 27,18 Q25,19 26,21" stroke="#5C3A1A" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+  <circle cx="27" cy="21" r="1.5" fill="#228B22"/>
+  <!-- Right leg forward -->
+  <rect x="12" y="25" width="4" height="5" rx="1" fill="#5C3A1A"/>
+  <rect x="17" y="25" width="4" height="7" rx="1" fill="#5C3A1A"/>
+  <path d="M12,30 Q10,31 9,31" stroke="#5C3A1A" stroke-width="2" fill="none" stroke-linecap="round"/>
+  <path d="M16,30 Q16,31 15,31" stroke="#5C3A1A" stroke-width="2" fill="none" stroke-linecap="round"/>
+  <path d="M17,31 Q19,32 20,32" stroke="#5C3A1A" stroke-width="2" fill="none" stroke-linecap="round"/>
+  <path d="M21,31 Q23,32 24,32" stroke="#5C3A1A" stroke-width="2" fill="none" stroke-linecap="round"/>
+</svg>

--- a/web/public/sprites/boss-thornlord-1.svg
+++ b/web/public/sprites/boss-thornlord-1.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Thornlord — frame 1 (stride A: left root-leg forward) -->
+  <!-- trunk -->
+  <rect x="12" y="18" width="8" height="10" rx="2" fill="#5a3010"/>
+  <rect x="13" y="20" width="6" height="8" fill="#7a4820" opacity="0.5"/>
+  <!-- body/crown -->
+  <ellipse cx="16" cy="14" rx="9" ry="10" fill="#2d5a1b"/>
+  <ellipse cx="16" cy="13" rx="7" ry="8" fill="#3a7222" opacity="0.7"/>
+  <!-- left branch-arm (raised) -->
+  <line x1="7" y1="12" x2="1" y2="7" stroke="#5a3010" stroke-width="2.5" stroke-linecap="round"/>
+  <line x1="1" y1="7" x2="0" y2="4" stroke="#5a3010" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="1" y1="7" x2="0" y2="10" stroke="#5a3010" stroke-width="1.5" stroke-linecap="round"/>
+  <!-- right branch-arm -->
+  <line x1="25" y1="13" x2="30" y2="9" stroke="#5a3010" stroke-width="2.5" stroke-linecap="round"/>
+  <line x1="30" y1="9" x2="32" y2="6" stroke="#5a3010" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="30" y1="9" x2="31" y2="12" stroke="#5a3010" stroke-width="1.5" stroke-linecap="round"/>
+  <!-- thorns -->
+  <polygon points="10,6 9,2 12,5" fill="#1a4010"/>
+  <polygon points="16,4 15,0 17,0 18,4" fill="#1a4010"/>
+  <polygon points="22,6 23,2 20,5" fill="#1a4010"/>
+  <polygon points="8,12 5,10 9,10" fill="#1a4010"/>
+  <polygon points="24,12 27,10 23,10" fill="#1a4010"/>
+  <!-- glowing eyes -->
+  <ellipse cx="12" cy="14" rx="2.5" ry="2" fill="#00ff44"/>
+  <ellipse cx="20" cy="14" rx="2.5" ry="2" fill="#00ff44"/>
+  <ellipse cx="12" cy="14" rx="1" ry="1" fill="#ccffcc"/>
+  <ellipse cx="20" cy="14" rx="1" ry="1" fill="#ccffcc"/>
+  <ellipse cx="12" cy="14" rx="3" ry="2.5" fill="#00ff44" opacity="0.2"/>
+  <ellipse cx="20" cy="14" rx="3" ry="2.5" fill="#00ff44" opacity="0.2"/>
+  <!-- Roots: left forward, right back -->
+  <ellipse cx="11" cy="31" rx="5" ry="1.5" fill="#4a2a10" transform="rotate(-10,11,31)"/>
+  <ellipse cx="21" cy="29" rx="4" ry="1.5" fill="#4a2a10" transform="rotate(15,21,29)"/>
+</svg>

--- a/web/public/sprites/boss-thornlord-2.svg
+++ b/web/public/sprites/boss-thornlord-2.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Thornlord — frame 2 (mid-stride, body 1px higher) -->
+  <!-- trunk -->
+  <rect x="12" y="17" width="8" height="10" rx="2" fill="#5a3010"/>
+  <rect x="13" y="19" width="6" height="8" fill="#7a4820" opacity="0.5"/>
+  <!-- body/crown (1px higher) -->
+  <ellipse cx="16" cy="13" rx="9" ry="10" fill="#2d5a1b"/>
+  <ellipse cx="16" cy="12" rx="7" ry="8" fill="#3a7222" opacity="0.7"/>
+  <!-- left branch-arm -->
+  <line x1="7" y1="12" x2="2" y2="8" stroke="#5a3010" stroke-width="2.5" stroke-linecap="round"/>
+  <line x1="2" y1="8" x2="0" y2="5" stroke="#5a3010" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="2" y1="8" x2="1" y2="11" stroke="#5a3010" stroke-width="1.5" stroke-linecap="round"/>
+  <!-- right branch-arm -->
+  <line x1="25" y1="12" x2="30" y2="8" stroke="#5a3010" stroke-width="2.5" stroke-linecap="round"/>
+  <line x1="30" y1="8" x2="32" y2="5" stroke="#5a3010" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="30" y1="8" x2="31" y2="11" stroke="#5a3010" stroke-width="1.5" stroke-linecap="round"/>
+  <!-- thorns -->
+  <polygon points="10,5 9,1 12,4" fill="#1a4010"/>
+  <polygon points="16,3 15,0 17,0 18,3" fill="#1a4010"/>
+  <polygon points="22,5 23,1 20,4" fill="#1a4010"/>
+  <polygon points="8,11 5,9 9,9" fill="#1a4010"/>
+  <polygon points="24,11 27,9 23,9" fill="#1a4010"/>
+  <!-- glowing eyes -->
+  <ellipse cx="12" cy="13" rx="2.5" ry="2" fill="#00ff44"/>
+  <ellipse cx="20" cy="13" rx="2.5" ry="2" fill="#00ff44"/>
+  <ellipse cx="12" cy="13" rx="1" ry="1" fill="#ccffcc"/>
+  <ellipse cx="20" cy="13" rx="1" ry="1" fill="#ccffcc"/>
+  <ellipse cx="12" cy="13" rx="3" ry="2.5" fill="#00ff44" opacity="0.2"/>
+  <ellipse cx="20" cy="13" rx="3" ry="2.5" fill="#00ff44" opacity="0.2"/>
+  <!-- Roots mid-stride (both level) -->
+  <ellipse cx="11" cy="30" rx="5" ry="1.5" fill="#4a2a10" transform="rotate(-15,11,30)"/>
+  <ellipse cx="21" cy="30" rx="4" ry="1.5" fill="#4a2a10" transform="rotate(15,21,30)"/>
+</svg>

--- a/web/public/sprites/boss-thornlord-3.svg
+++ b/web/public/sprites/boss-thornlord-3.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Thornlord — frame 3 (stride B: right root-leg forward, left back) -->
+  <!-- trunk -->
+  <rect x="12" y="18" width="8" height="10" rx="2" fill="#5a3010"/>
+  <rect x="13" y="20" width="6" height="8" fill="#7a4820" opacity="0.5"/>
+  <!-- body/crown -->
+  <ellipse cx="16" cy="14" rx="9" ry="10" fill="#2d5a1b"/>
+  <ellipse cx="16" cy="13" rx="7" ry="8" fill="#3a7222" opacity="0.7"/>
+  <!-- left branch-arm -->
+  <line x1="7" y1="13" x2="2" y2="9" stroke="#5a3010" stroke-width="2.5" stroke-linecap="round"/>
+  <line x1="2" y1="9" x2="0" y2="6" stroke="#5a3010" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="2" y1="9" x2="1" y2="12" stroke="#5a3010" stroke-width="1.5" stroke-linecap="round"/>
+  <!-- right branch-arm (raised) -->
+  <line x1="25" y1="12" x2="31" y2="7" stroke="#5a3010" stroke-width="2.5" stroke-linecap="round"/>
+  <line x1="31" y1="7" x2="32" y2="4" stroke="#5a3010" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="31" y1="7" x2="32" y2="10" stroke="#5a3010" stroke-width="1.5" stroke-linecap="round"/>
+  <!-- thorns -->
+  <polygon points="10,6 9,2 12,5" fill="#1a4010"/>
+  <polygon points="16,4 15,0 17,0 18,4" fill="#1a4010"/>
+  <polygon points="22,6 23,2 20,5" fill="#1a4010"/>
+  <polygon points="8,12 5,10 9,10" fill="#1a4010"/>
+  <polygon points="24,12 27,10 23,10" fill="#1a4010"/>
+  <!-- glowing eyes -->
+  <ellipse cx="12" cy="14" rx="2.5" ry="2" fill="#00ff44"/>
+  <ellipse cx="20" cy="14" rx="2.5" ry="2" fill="#00ff44"/>
+  <ellipse cx="12" cy="14" rx="1" ry="1" fill="#ccffcc"/>
+  <ellipse cx="20" cy="14" rx="1" ry="1" fill="#ccffcc"/>
+  <ellipse cx="12" cy="14" rx="3" ry="2.5" fill="#00ff44" opacity="0.2"/>
+  <ellipse cx="20" cy="14" rx="3" ry="2.5" fill="#00ff44" opacity="0.2"/>
+  <!-- Roots: right forward, left back (opposite of frame 1) -->
+  <ellipse cx="11" cy="29" rx="4" ry="1.5" fill="#4a2a10" transform="rotate(-15,11,29)"/>
+  <ellipse cx="21" cy="31" rx="5" ry="1.5" fill="#4a2a10" transform="rotate(10,21,31)"/>
+</svg>

--- a/web/public/sprites/boss-tidal-sovereign-1.svg
+++ b/web/public/sprites/boss-tidal-sovereign-1.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Tidal Sovereign — frame 1 (hover tilt left, body 1px lower) -->
+  <!-- Robe body shifted down 1px -->
+  <polygon points="10,29 22,29 20,15 12,15" fill="#1a4a8a"/>
+  <polygon points="11,29 21,29 19,17 13,17" fill="#3366bb" opacity="0.5"/>
+  <path d="M12,15 Q8,21 9,29" fill="#1a4a8a" stroke="#3366bb" stroke-width="0.5"/>
+  <rect x="13" y="11" width="6" height="5" rx="1" fill="#1a4a8a"/>
+  <!-- Head slightly lower -->
+  <ellipse cx="16" cy="9" rx="4" ry="4" fill="#ffccaa"/>
+  <polygon points="12,6 13,3 15,5 16,2 17,5 19,3 20,6 12,6" fill="#ddaa22"/>
+  <rect x="12" y="6" width="8" height="1.5" fill="#ddaa22"/>
+  <circle cx="14.5" cy="9" r="0.7" fill="#002244"/>
+  <circle cx="17.5" cy="9" r="0.7" fill="#002244"/>
+  <!-- Trident tilted left slightly -->
+  <line x1="21" y1="7" x2="20" y2="27" stroke="#44aadd" stroke-width="1.2"/>
+  <path d="M19,7 L21,5 L23,7" fill="none" stroke="#44aadd" stroke-width="1"/>
+  <line x1="21" y1="5" x2="21" y2="8" stroke="#44aadd" stroke-width="1"/>
+  <line x1="10" y1="29" x2="22" y2="29" stroke="#ddaa22" stroke-width="1"/>
+  <line x1="13" y1="15" x2="19" y2="15" stroke="#ddaa22" stroke-width="0.8"/>
+  <ellipse cx="13" cy="29" rx="2" ry="1" fill="#1a3a6a"/>
+  <ellipse cx="19" cy="29" rx="2" ry="1" fill="#1a3a6a"/>
+</svg>

--- a/web/public/sprites/boss-tidal-sovereign-2.svg
+++ b/web/public/sprites/boss-tidal-sovereign-2.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Tidal Sovereign — frame 2 (hover mid, normal height) -->
+  <!-- Robe body at normal height -->
+  <polygon points="10,28 22,28 20,14 12,14" fill="#1a4a8a"/>
+  <polygon points="11,28 21,28 19,16 13,16" fill="#3366bb" opacity="0.5"/>
+  <path d="M12,14 Q8,20 9,28" fill="#1a4a8a" stroke="#3366bb" stroke-width="0.5"/>
+  <rect x="13" y="10" width="6" height="5" rx="1" fill="#1a4a8a"/>
+  <ellipse cx="16" cy="8" rx="4" ry="4" fill="#ffccaa"/>
+  <polygon points="12,5 13,2 15,4 16,1 17,4 19,2 20,5 12,5" fill="#ddaa22"/>
+  <rect x="12" y="5" width="8" height="1.5" fill="#ddaa22"/>
+  <circle cx="14.5" cy="8" r="0.7" fill="#002244"/>
+  <circle cx="17.5" cy="8" r="0.7" fill="#002244"/>
+  <!-- Trident straight -->
+  <line x1="21" y1="6" x2="21" y2="26" stroke="#44aadd" stroke-width="1.2"/>
+  <path d="M19,6 L21,4 L23,6" fill="none" stroke="#44aadd" stroke-width="1"/>
+  <line x1="21" y1="4" x2="21" y2="7" stroke="#44aadd" stroke-width="1"/>
+  <line x1="10" y1="28" x2="22" y2="28" stroke="#ddaa22" stroke-width="1"/>
+  <line x1="13" y1="14" x2="19" y2="14" stroke="#ddaa22" stroke-width="0.8"/>
+  <!-- Feet centered (mid-hover) -->
+  <ellipse cx="14" cy="28" rx="2" ry="1" fill="#1a3a6a"/>
+  <ellipse cx="18" cy="28" rx="2" ry="1" fill="#1a3a6a"/>
+</svg>

--- a/web/public/sprites/boss-tidal-sovereign-3.svg
+++ b/web/public/sprites/boss-tidal-sovereign-3.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Tidal Sovereign — frame 3 (hover tilt right, body 1px lower, mirror of frame 1) -->
+  <!-- Robe body shifted down 1px -->
+  <polygon points="10,29 22,29 20,15 12,15" fill="#1a4a8a"/>
+  <polygon points="11,29 21,29 19,17 13,17" fill="#3366bb" opacity="0.5"/>
+  <path d="M20,15 Q24,21 23,29" fill="#1a4a8a" stroke="#3366bb" stroke-width="0.5"/>
+  <rect x="13" y="11" width="6" height="5" rx="1" fill="#1a4a8a"/>
+  <!-- Head slightly lower -->
+  <ellipse cx="16" cy="9" rx="4" ry="4" fill="#ffccaa"/>
+  <polygon points="12,6 13,3 15,5 16,2 17,5 19,3 20,6 12,6" fill="#ddaa22"/>
+  <rect x="12" y="6" width="8" height="1.5" fill="#ddaa22"/>
+  <circle cx="14.5" cy="9" r="0.7" fill="#002244"/>
+  <circle cx="17.5" cy="9" r="0.7" fill="#002244"/>
+  <!-- Trident tilted right slightly -->
+  <line x1="21" y1="7" x2="22" y2="27" stroke="#44aadd" stroke-width="1.2"/>
+  <path d="M19,7 L21,5 L23,7" fill="none" stroke="#44aadd" stroke-width="1"/>
+  <line x1="21" y1="5" x2="21" y2="8" stroke="#44aadd" stroke-width="1"/>
+  <line x1="10" y1="29" x2="22" y2="29" stroke="#ddaa22" stroke-width="1"/>
+  <line x1="13" y1="15" x2="19" y2="15" stroke="#ddaa22" stroke-width="0.8"/>
+  <ellipse cx="13" cy="29" rx="2" ry="1" fill="#1a3a6a"/>
+  <ellipse cx="19" cy="29" rx="2" ry="1" fill="#1a3a6a"/>
+</svg>

--- a/web/public/sprites/jarv-gold-1.svg
+++ b/web/public/sprites/jarv-gold-1.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- cloak/body — 1px higher -->
+  <path d="M8,27 L10,15 Q16,13 22,15 L24,27 Z" fill="#5a4a10"/>
+  <path d="M10,27 L11,17 Q16,15 21,17 L22,27 Z" fill="#8a7020" opacity="0.6"/>
+  <!-- shoulders/pauldrons -->
+  <rect x="7" y="15" width="5" height="4" rx="2" fill="#3a3008"/>
+  <rect x="20" y="15" width="5" height="4" rx="2" fill="#3a3008"/>
+  <!-- neck -->
+  <rect x="14" y="12" width="4" height="4" fill="#c8a080"/>
+  <!-- hood -->
+  <ellipse cx="16" cy="10" rx="7" ry="7" fill="#3a3008"/>
+  <ellipse cx="16" cy="9" rx="5" ry="5" fill="#5a4a10" opacity="0.7"/>
+  <!-- face -->
+  <ellipse cx="16" cy="11" rx="4" ry="4" fill="#c8a080"/>
+  <!-- eyes -->
+  <ellipse cx="14" cy="10" rx="1.2" ry="1" fill="#664400"/>
+  <ellipse cx="18" cy="10" rx="1.2" ry="1" fill="#664400"/>
+  <ellipse cx="14" cy="10" rx="0.5" ry="0.5" fill="#ffee88"/>
+  <ellipse cx="18" cy="10" rx="0.5" ry="0.5" fill="#ffee88"/>
+  <!-- hood shadow -->
+  <path d="M9,7 Q16,3 23,7 Q20,5 16,5 Q12,5 9,7" fill="#1a1500" opacity="0.5"/>
+  <!-- belt buckle -->
+  <rect x="14" y="20" width="4" height="3" rx="1" fill="#d4a820"/>
+  <!-- legs: left forward, right back -->
+  <rect x="11" y="22" width="4" height="7" rx="1" fill="#449922"/>
+  <rect x="17" y="25" width="4" height="4" rx="1" fill="#449922"/>
+</svg>

--- a/web/public/sprites/jarv-gold-2.svg
+++ b/web/public/sprites/jarv-gold-2.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- cloak/body — 1px higher, mid-stride -->
+  <path d="M8,27 L10,15 Q16,13 22,15 L24,27 Z" fill="#5a4a10"/>
+  <path d="M10,27 L11,17 Q16,15 21,17 L22,27 Z" fill="#8a7020" opacity="0.6"/>
+  <!-- shoulders/pauldrons -->
+  <rect x="7" y="15" width="5" height="4" rx="2" fill="#3a3008"/>
+  <rect x="20" y="15" width="5" height="4" rx="2" fill="#3a3008"/>
+  <!-- neck -->
+  <rect x="14" y="12" width="4" height="4" fill="#c8a080"/>
+  <!-- hood -->
+  <ellipse cx="16" cy="10" rx="7" ry="7" fill="#3a3008"/>
+  <ellipse cx="16" cy="9" rx="5" ry="5" fill="#5a4a10" opacity="0.7"/>
+  <!-- face -->
+  <ellipse cx="16" cy="11" rx="4" ry="4" fill="#c8a080"/>
+  <!-- eyes -->
+  <ellipse cx="14" cy="10" rx="1.2" ry="1" fill="#664400"/>
+  <ellipse cx="18" cy="10" rx="1.2" ry="1" fill="#664400"/>
+  <ellipse cx="14" cy="10" rx="0.5" ry="0.5" fill="#ffee88"/>
+  <ellipse cx="18" cy="10" rx="0.5" ry="0.5" fill="#ffee88"/>
+  <!-- hood shadow -->
+  <path d="M9,7 Q16,3 23,7 Q20,5 16,5 Q12,5 9,7" fill="#1a1500" opacity="0.5"/>
+  <!-- belt buckle -->
+  <rect x="14" y="20" width="4" height="3" rx="1" fill="#d4a820"/>
+  <!-- legs: mid-stride, both even -->
+  <rect x="11" y="23" width="4" height="6" rx="1" fill="#449922"/>
+  <rect x="17" y="23" width="4" height="6" rx="1" fill="#449922"/>
+</svg>

--- a/web/public/sprites/jarv-gold-3.svg
+++ b/web/public/sprites/jarv-gold-3.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- cloak/body — 1px higher -->
+  <path d="M8,27 L10,15 Q16,13 22,15 L24,27 Z" fill="#5a4a10"/>
+  <path d="M10,27 L11,17 Q16,15 21,17 L22,27 Z" fill="#8a7020" opacity="0.6"/>
+  <!-- shoulders/pauldrons -->
+  <rect x="7" y="15" width="5" height="4" rx="2" fill="#3a3008"/>
+  <rect x="20" y="15" width="5" height="4" rx="2" fill="#3a3008"/>
+  <!-- neck -->
+  <rect x="14" y="12" width="4" height="4" fill="#c8a080"/>
+  <!-- hood -->
+  <ellipse cx="16" cy="10" rx="7" ry="7" fill="#3a3008"/>
+  <ellipse cx="16" cy="9" rx="5" ry="5" fill="#5a4a10" opacity="0.7"/>
+  <!-- face -->
+  <ellipse cx="16" cy="11" rx="4" ry="4" fill="#c8a080"/>
+  <!-- eyes -->
+  <ellipse cx="14" cy="10" rx="1.2" ry="1" fill="#664400"/>
+  <ellipse cx="18" cy="10" rx="1.2" ry="1" fill="#664400"/>
+  <ellipse cx="14" cy="10" rx="0.5" ry="0.5" fill="#ffee88"/>
+  <ellipse cx="18" cy="10" rx="0.5" ry="0.5" fill="#ffee88"/>
+  <!-- hood shadow -->
+  <path d="M9,7 Q16,3 23,7 Q20,5 16,5 Q12,5 9,7" fill="#1a1500" opacity="0.5"/>
+  <!-- belt buckle -->
+  <rect x="14" y="20" width="4" height="3" rx="1" fill="#d4a820"/>
+  <!-- legs: right forward, left back -->
+  <rect x="17" y="22" width="4" height="7" rx="1" fill="#449922"/>
+  <rect x="11" y="25" width="4" height="4" rx="1" fill="#449922"/>
+</svg>

--- a/web/public/sprites/jarv-green-1.svg
+++ b/web/public/sprites/jarv-green-1.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- cloak/body — 1px higher -->
+  <path d="M8,27 L10,15 Q16,13 22,15 L24,27 Z" fill="#1e4a2a"/>
+  <path d="M10,27 L11,17 Q16,15 21,17 L22,27 Z" fill="#2e6a3a" opacity="0.6"/>
+  <!-- shoulders/pauldrons -->
+  <rect x="7" y="15" width="5" height="4" rx="2" fill="#143320"/>
+  <rect x="20" y="15" width="5" height="4" rx="2" fill="#143320"/>
+  <!-- neck -->
+  <rect x="14" y="12" width="4" height="4" fill="#c8a080"/>
+  <!-- hood -->
+  <ellipse cx="16" cy="10" rx="7" ry="7" fill="#143320"/>
+  <ellipse cx="16" cy="9" rx="5" ry="5" fill="#1e4a2a" opacity="0.7"/>
+  <!-- face -->
+  <ellipse cx="16" cy="11" rx="4" ry="4" fill="#c8a080"/>
+  <!-- eyes -->
+  <ellipse cx="14" cy="10" rx="1.2" ry="1" fill="#224422"/>
+  <ellipse cx="18" cy="10" rx="1.2" ry="1" fill="#224422"/>
+  <ellipse cx="14" cy="10" rx="0.5" ry="0.5" fill="#aaffaa"/>
+  <ellipse cx="18" cy="10" rx="0.5" ry="0.5" fill="#aaffaa"/>
+  <!-- hood shadow -->
+  <path d="M9,7 Q16,3 23,7 Q20,5 16,5 Q12,5 9,7" fill="#0a1a0e" opacity="0.5"/>
+  <!-- belt buckle -->
+  <rect x="14" y="20" width="4" height="3" rx="1" fill="#d4a820"/>
+  <!-- legs: left forward, right back -->
+  <rect x="11" y="22" width="4" height="7" rx="1" fill="#449922"/>
+  <rect x="17" y="25" width="4" height="4" rx="1" fill="#449922"/>
+</svg>

--- a/web/public/sprites/jarv-green-2.svg
+++ b/web/public/sprites/jarv-green-2.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- cloak/body — 1px higher, mid-stride -->
+  <path d="M8,27 L10,15 Q16,13 22,15 L24,27 Z" fill="#1e4a2a"/>
+  <path d="M10,27 L11,17 Q16,15 21,17 L22,27 Z" fill="#2e6a3a" opacity="0.6"/>
+  <!-- shoulders/pauldrons -->
+  <rect x="7" y="15" width="5" height="4" rx="2" fill="#143320"/>
+  <rect x="20" y="15" width="5" height="4" rx="2" fill="#143320"/>
+  <!-- neck -->
+  <rect x="14" y="12" width="4" height="4" fill="#c8a080"/>
+  <!-- hood -->
+  <ellipse cx="16" cy="10" rx="7" ry="7" fill="#143320"/>
+  <ellipse cx="16" cy="9" rx="5" ry="5" fill="#1e4a2a" opacity="0.7"/>
+  <!-- face -->
+  <ellipse cx="16" cy="11" rx="4" ry="4" fill="#c8a080"/>
+  <!-- eyes -->
+  <ellipse cx="14" cy="10" rx="1.2" ry="1" fill="#224422"/>
+  <ellipse cx="18" cy="10" rx="1.2" ry="1" fill="#224422"/>
+  <ellipse cx="14" cy="10" rx="0.5" ry="0.5" fill="#aaffaa"/>
+  <ellipse cx="18" cy="10" rx="0.5" ry="0.5" fill="#aaffaa"/>
+  <!-- hood shadow -->
+  <path d="M9,7 Q16,3 23,7 Q20,5 16,5 Q12,5 9,7" fill="#0a1a0e" opacity="0.5"/>
+  <!-- belt buckle -->
+  <rect x="14" y="20" width="4" height="3" rx="1" fill="#d4a820"/>
+  <!-- legs: mid-stride, both even -->
+  <rect x="11" y="23" width="4" height="6" rx="1" fill="#449922"/>
+  <rect x="17" y="23" width="4" height="6" rx="1" fill="#449922"/>
+</svg>

--- a/web/public/sprites/jarv-green-3.svg
+++ b/web/public/sprites/jarv-green-3.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- cloak/body — 1px higher -->
+  <path d="M8,27 L10,15 Q16,13 22,15 L24,27 Z" fill="#1e4a2a"/>
+  <path d="M10,27 L11,17 Q16,15 21,17 L22,27 Z" fill="#2e6a3a" opacity="0.6"/>
+  <!-- shoulders/pauldrons -->
+  <rect x="7" y="15" width="5" height="4" rx="2" fill="#143320"/>
+  <rect x="20" y="15" width="5" height="4" rx="2" fill="#143320"/>
+  <!-- neck -->
+  <rect x="14" y="12" width="4" height="4" fill="#c8a080"/>
+  <!-- hood -->
+  <ellipse cx="16" cy="10" rx="7" ry="7" fill="#143320"/>
+  <ellipse cx="16" cy="9" rx="5" ry="5" fill="#1e4a2a" opacity="0.7"/>
+  <!-- face -->
+  <ellipse cx="16" cy="11" rx="4" ry="4" fill="#c8a080"/>
+  <!-- eyes -->
+  <ellipse cx="14" cy="10" rx="1.2" ry="1" fill="#224422"/>
+  <ellipse cx="18" cy="10" rx="1.2" ry="1" fill="#224422"/>
+  <ellipse cx="14" cy="10" rx="0.5" ry="0.5" fill="#aaffaa"/>
+  <ellipse cx="18" cy="10" rx="0.5" ry="0.5" fill="#aaffaa"/>
+  <!-- hood shadow -->
+  <path d="M9,7 Q16,3 23,7 Q20,5 16,5 Q12,5 9,7" fill="#0a1a0e" opacity="0.5"/>
+  <!-- belt buckle -->
+  <rect x="14" y="20" width="4" height="3" rx="1" fill="#d4a820"/>
+  <!-- legs: right forward, left back -->
+  <rect x="17" y="22" width="4" height="7" rx="1" fill="#449922"/>
+  <rect x="11" y="25" width="4" height="4" rx="1" fill="#449922"/>
+</svg>

--- a/web/public/sprites/jarv-red-1.svg
+++ b/web/public/sprites/jarv-red-1.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- cloak/body — 1px higher -->
+  <path d="M8,27 L10,15 Q16,13 22,15 L24,27 Z" fill="#662a2a"/>
+  <path d="M10,27 L11,17 Q16,15 21,17 L22,27 Z" fill="#883a3a" opacity="0.6"/>
+  <!-- shoulders/pauldrons -->
+  <rect x="7" y="15" width="5" height="4" rx="2" fill="#501e1e"/>
+  <rect x="20" y="15" width="5" height="4" rx="2" fill="#501e1e"/>
+  <!-- neck -->
+  <rect x="14" y="12" width="4" height="4" fill="#c8a080"/>
+  <!-- hood -->
+  <ellipse cx="16" cy="10" rx="7" ry="7" fill="#501e1e"/>
+  <ellipse cx="16" cy="9" rx="5" ry="5" fill="#662a2a" opacity="0.7"/>
+  <!-- face -->
+  <ellipse cx="16" cy="11" rx="4" ry="4" fill="#c8a080"/>
+  <!-- eyes -->
+  <ellipse cx="14" cy="10" rx="1.2" ry="1" fill="#882222"/>
+  <ellipse cx="18" cy="10" rx="1.2" ry="1" fill="#882222"/>
+  <ellipse cx="14" cy="10" rx="0.5" ry="0.5" fill="#ffaaaa"/>
+  <ellipse cx="18" cy="10" rx="0.5" ry="0.5" fill="#ffaaaa"/>
+  <!-- hood shadow -->
+  <path d="M9,7 Q16,3 23,7 Q20,5 16,5 Q12,5 9,7" fill="#330e0e" opacity="0.5"/>
+  <!-- belt buckle -->
+  <rect x="14" y="20" width="4" height="3" rx="1" fill="#d4a820"/>
+  <!-- legs: left forward, right back -->
+  <rect x="11" y="22" width="4" height="7" rx="1" fill="#449922"/>
+  <rect x="17" y="25" width="4" height="4" rx="1" fill="#449922"/>
+</svg>

--- a/web/public/sprites/jarv-red-2.svg
+++ b/web/public/sprites/jarv-red-2.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- cloak/body — 1px higher, mid-stride -->
+  <path d="M8,27 L10,15 Q16,13 22,15 L24,27 Z" fill="#662a2a"/>
+  <path d="M10,27 L11,17 Q16,15 21,17 L22,27 Z" fill="#883a3a" opacity="0.6"/>
+  <!-- shoulders/pauldrons -->
+  <rect x="7" y="15" width="5" height="4" rx="2" fill="#501e1e"/>
+  <rect x="20" y="15" width="5" height="4" rx="2" fill="#501e1e"/>
+  <!-- neck -->
+  <rect x="14" y="12" width="4" height="4" fill="#c8a080"/>
+  <!-- hood -->
+  <ellipse cx="16" cy="10" rx="7" ry="7" fill="#501e1e"/>
+  <ellipse cx="16" cy="9" rx="5" ry="5" fill="#662a2a" opacity="0.7"/>
+  <!-- face -->
+  <ellipse cx="16" cy="11" rx="4" ry="4" fill="#c8a080"/>
+  <!-- eyes -->
+  <ellipse cx="14" cy="10" rx="1.2" ry="1" fill="#882222"/>
+  <ellipse cx="18" cy="10" rx="1.2" ry="1" fill="#882222"/>
+  <ellipse cx="14" cy="10" rx="0.5" ry="0.5" fill="#ffaaaa"/>
+  <ellipse cx="18" cy="10" rx="0.5" ry="0.5" fill="#ffaaaa"/>
+  <!-- hood shadow -->
+  <path d="M9,7 Q16,3 23,7 Q20,5 16,5 Q12,5 9,7" fill="#330e0e" opacity="0.5"/>
+  <!-- belt buckle -->
+  <rect x="14" y="20" width="4" height="3" rx="1" fill="#d4a820"/>
+  <!-- legs: mid-stride, both even -->
+  <rect x="11" y="23" width="4" height="6" rx="1" fill="#449922"/>
+  <rect x="17" y="23" width="4" height="6" rx="1" fill="#449922"/>
+</svg>

--- a/web/public/sprites/jarv-red-3.svg
+++ b/web/public/sprites/jarv-red-3.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- cloak/body — 1px higher -->
+  <path d="M8,27 L10,15 Q16,13 22,15 L24,27 Z" fill="#662a2a"/>
+  <path d="M10,27 L11,17 Q16,15 21,17 L22,27 Z" fill="#883a3a" opacity="0.6"/>
+  <!-- shoulders/pauldrons -->
+  <rect x="7" y="15" width="5" height="4" rx="2" fill="#501e1e"/>
+  <rect x="20" y="15" width="5" height="4" rx="2" fill="#501e1e"/>
+  <!-- neck -->
+  <rect x="14" y="12" width="4" height="4" fill="#c8a080"/>
+  <!-- hood -->
+  <ellipse cx="16" cy="10" rx="7" ry="7" fill="#501e1e"/>
+  <ellipse cx="16" cy="9" rx="5" ry="5" fill="#662a2a" opacity="0.7"/>
+  <!-- face -->
+  <ellipse cx="16" cy="11" rx="4" ry="4" fill="#c8a080"/>
+  <!-- eyes -->
+  <ellipse cx="14" cy="10" rx="1.2" ry="1" fill="#882222"/>
+  <ellipse cx="18" cy="10" rx="1.2" ry="1" fill="#882222"/>
+  <ellipse cx="14" cy="10" rx="0.5" ry="0.5" fill="#ffaaaa"/>
+  <ellipse cx="18" cy="10" rx="0.5" ry="0.5" fill="#ffaaaa"/>
+  <!-- hood shadow -->
+  <path d="M9,7 Q16,3 23,7 Q20,5 16,5 Q12,5 9,7" fill="#330e0e" opacity="0.5"/>
+  <!-- belt buckle -->
+  <rect x="14" y="20" width="4" height="3" rx="1" fill="#d4a820"/>
+  <!-- legs: right forward, left back -->
+  <rect x="17" y="22" width="4" height="7" rx="1" fill="#449922"/>
+  <rect x="11" y="25" width="4" height="4" rx="1" fill="#449922"/>
+</svg>

--- a/web/public/sprites/streak-celestial-1.svg
+++ b/web/public/sprites/streak-celestial-1.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Celestial Guardian: white/gold divine armour, halo, star motifs -->
+  <!-- Divine glow -->
+  <ellipse cx="16" cy="16" rx="14" ry="15" fill="#ffffaa" opacity="0.15"/>
+  <!-- Halo -->
+  <ellipse cx="16" cy="5" rx="7" ry="2" fill="none" stroke="#ffd700" stroke-width="1.5" opacity="0.9"/>
+  <!-- Body -->
+  <rect x="10" y="14" width="12" height="11" rx="1" fill="#e8e0c8"/>
+  <!-- Gold trim lines -->
+  <rect x="10" y="14" width="12" height="1.5" fill="#ffd700"/>
+  <rect x="10" y="24" width="12" height="1.5" fill="#ffd700"/>
+  <rect x="15" y="14" width="2" height="11" fill="#ffd700" opacity="0.4"/>
+  <!-- Star on chest -->
+  <polygon points="16,16 17,19 20,19 17.5,21 18.5,24 16,22 13.5,24 14.5,21 12,19 15,19" fill="#ffd700" transform="scale(0.6) translate(10.7,11)"/>
+  <!-- Wings -->
+  <path d="M10,15 Q2,12 3,22 Q7,18 10,21Z" fill="#f0e8c0" opacity="0.85"/>
+  <path d="M22,15 Q30,12 29,22 Q25,18 22,21Z" fill="#f0e8c0" opacity="0.85"/>
+  <!-- Helm -->
+  <rect x="11" y="7" width="10" height="8" rx="3" fill="#e8e0c8"/>
+  <rect x="11" y="7" width="10" height="1.5" fill="#ffd700"/>
+  <!-- Visor -->
+  <rect x="12" y="10" width="8" height="2" rx="1" fill="#b8a870"/>
+  <rect x="13" y="10" width="6" height="1" fill="#fff8d0"/>
+  <!-- Legs -->
+  <rect x="11" y="25" width="4" height="5" rx="1" fill="#e8e0c8"/>
+  <rect x="17" y="25" width="4" height="5" rx="1" fill="#e8e0c8"/>
+  <rect x="10" y="29" width="6" height="2" rx="1" fill="#ffd700"/>
+  <rect x="16" y="29" width="6" height="2" rx="1" fill="#ffd700"/>
+</svg>

--- a/web/public/sprites/streak-celestial-2.svg
+++ b/web/public/sprites/streak-celestial-2.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Celestial Guardian: white/gold divine armour, halo, star motifs -->
+  <!-- Divine glow -->
+  <ellipse cx="16" cy="16" rx="14" ry="15" fill="#ffffaa" opacity="0.15"/>
+  <!-- Halo -->
+  <ellipse cx="16" cy="5" rx="7" ry="2" fill="none" stroke="#ffd700" stroke-width="1.5" opacity="0.9"/>
+  <!-- Body -->
+  <rect x="10" y="14" width="12" height="11" rx="1" fill="#e8e0c8"/>
+  <!-- Gold trim lines -->
+  <rect x="10" y="14" width="12" height="1.5" fill="#ffd700"/>
+  <rect x="10" y="24" width="12" height="1.5" fill="#ffd700"/>
+  <rect x="15" y="14" width="2" height="11" fill="#ffd700" opacity="0.4"/>
+  <!-- Star on chest -->
+  <polygon points="16,16 17,19 20,19 17.5,21 18.5,24 16,22 13.5,24 14.5,21 12,19 15,19" fill="#ffd700" transform="scale(0.6) translate(10.7,11)"/>
+  <!-- Wings -->
+  <path d="M10,15 Q2,12 3,22 Q7,18 10,21Z" fill="#f0e8c0" opacity="0.85"/>
+  <path d="M22,15 Q30,12 29,22 Q25,18 22,21Z" fill="#f0e8c0" opacity="0.85"/>
+  <!-- Helm -->
+  <rect x="11" y="7" width="10" height="8" rx="3" fill="#e8e0c8"/>
+  <rect x="11" y="7" width="10" height="1.5" fill="#ffd700"/>
+  <!-- Visor -->
+  <rect x="12" y="10" width="8" height="2" rx="1" fill="#b8a870"/>
+  <rect x="13" y="10" width="6" height="1" fill="#fff8d0"/>
+  <!-- Legs -->
+  <rect x="11" y="25" width="4" height="5" rx="1" fill="#e8e0c8"/>
+  <rect x="17" y="25" width="4" height="5" rx="1" fill="#e8e0c8"/>
+  <rect x="10" y="29" width="6" height="2" rx="1" fill="#ffd700"/>
+  <rect x="16" y="29" width="6" height="2" rx="1" fill="#ffd700"/>
+</svg>

--- a/web/public/sprites/streak-celestial-3.svg
+++ b/web/public/sprites/streak-celestial-3.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Celestial Guardian: white/gold divine armour, halo, star motifs -->
+  <!-- Divine glow -->
+  <ellipse cx="16" cy="16" rx="14" ry="15" fill="#ffffaa" opacity="0.15"/>
+  <!-- Halo -->
+  <ellipse cx="16" cy="5" rx="7" ry="2" fill="none" stroke="#ffd700" stroke-width="1.5" opacity="0.9"/>
+  <!-- Body -->
+  <rect x="10" y="14" width="12" height="11" rx="1" fill="#e8e0c8"/>
+  <!-- Gold trim lines -->
+  <rect x="10" y="14" width="12" height="1.5" fill="#ffd700"/>
+  <rect x="10" y="24" width="12" height="1.5" fill="#ffd700"/>
+  <rect x="15" y="14" width="2" height="11" fill="#ffd700" opacity="0.4"/>
+  <!-- Star on chest -->
+  <polygon points="16,16 17,19 20,19 17.5,21 18.5,24 16,22 13.5,24 14.5,21 12,19 15,19" fill="#ffd700" transform="scale(0.6) translate(10.7,11)"/>
+  <!-- Wings -->
+  <path d="M10,15 Q2,12 3,22 Q7,18 10,21Z" fill="#f0e8c0" opacity="0.85"/>
+  <path d="M22,15 Q30,12 29,22 Q25,18 22,21Z" fill="#f0e8c0" opacity="0.85"/>
+  <!-- Helm -->
+  <rect x="11" y="7" width="10" height="8" rx="3" fill="#e8e0c8"/>
+  <rect x="11" y="7" width="10" height="1.5" fill="#ffd700"/>
+  <!-- Visor -->
+  <rect x="12" y="10" width="8" height="2" rx="1" fill="#b8a870"/>
+  <rect x="13" y="10" width="6" height="1" fill="#fff8d0"/>
+  <!-- Legs -->
+  <rect x="11" y="25" width="4" height="5" rx="1" fill="#e8e0c8"/>
+  <rect x="17" y="25" width="4" height="5" rx="1" fill="#e8e0c8"/>
+  <rect x="10" y="29" width="6" height="2" rx="1" fill="#ffd700"/>
+  <rect x="16" y="29" width="6" height="2" rx="1" fill="#ffd700"/>
+</svg>

--- a/web/public/sprites/streak-crystal-1.svg
+++ b/web/public/sprites/streak-crystal-1.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Crystal Champion: cyan/white crystalline armour, gem facets, prismatic glow -->
+  <!-- Crystal aura -->
+  <ellipse cx="16" cy="16" rx="13" ry="15" fill="#aaffff" opacity="0.1"/>
+  <!-- Body -->
+  <rect x="10" y="14" width="12" height="11" rx="1" fill="#cceeff"/>
+  <!-- Crystal facet pattern on body -->
+  <polygon points="10,14 16,14 13,20" fill="#99ddff" opacity="0.7"/>
+  <polygon points="22,14 16,14 19,20" fill="#bbffff" opacity="0.7"/>
+  <polygon points="10,25 16,25 13,20" fill="#bbffff" opacity="0.6"/>
+  <polygon points="22,25 16,25 19,20" fill="#99ddff" opacity="0.6"/>
+  <!-- Gem on chest -->
+  <polygon points="16,17 18,19 16,21 14,19" fill="#00eeff"/>
+  <polygon points="16,17 18,19 16,18" fill="#ffffff" opacity="0.6"/>
+  <!-- Crystal shoulders -->
+  <polygon points="10,14 7,13 8,18 10,19" fill="#99ddff"/>
+  <polygon points="22,14 25,13 24,18 22,19" fill="#99ddff"/>
+  <!-- Helm -->
+  <rect x="11" y="6" width="10" height="9" rx="2" fill="#cceeff"/>
+  <!-- Crystal crown spikes -->
+  <polygon points="13,6 14,2 15,6" fill="#00ddff"/>
+  <polygon points="15,6 16,1 17,6" fill="#aaffff"/>
+  <polygon points="17,6 18,2 19,6" fill="#00ddff"/>
+  <!-- Visor -->
+  <rect x="12" y="10" width="8" height="2" rx="1" fill="#006688"/>
+  <rect x="13" y="10" width="6" height="1" fill="#00ffff"/>
+  <!-- Legs -->
+  <rect x="11" y="25" width="4" height="5" rx="1" fill="#aaddee"/>
+  <rect x="17" y="25" width="4" height="5" rx="1" fill="#aaddee"/>
+  <!-- Crystal boots -->
+  <polygon points="10,29 16,29 15,31 11,31" fill="#00ccdd"/>
+  <polygon points="16,29 22,29 21,31 17,31" fill="#00ccdd"/>
+</svg>

--- a/web/public/sprites/streak-crystal-2.svg
+++ b/web/public/sprites/streak-crystal-2.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Crystal Champion: cyan/white crystalline armour, gem facets, prismatic glow -->
+  <!-- Crystal aura -->
+  <ellipse cx="16" cy="16" rx="13" ry="15" fill="#aaffff" opacity="0.1"/>
+  <!-- Body -->
+  <rect x="10" y="14" width="12" height="11" rx="1" fill="#cceeff"/>
+  <!-- Crystal facet pattern on body -->
+  <polygon points="10,14 16,14 13,20" fill="#99ddff" opacity="0.7"/>
+  <polygon points="22,14 16,14 19,20" fill="#bbffff" opacity="0.7"/>
+  <polygon points="10,25 16,25 13,20" fill="#bbffff" opacity="0.6"/>
+  <polygon points="22,25 16,25 19,20" fill="#99ddff" opacity="0.6"/>
+  <!-- Gem on chest -->
+  <polygon points="16,17 18,19 16,21 14,19" fill="#00eeff"/>
+  <polygon points="16,17 18,19 16,18" fill="#ffffff" opacity="0.6"/>
+  <!-- Crystal shoulders -->
+  <polygon points="10,14 7,13 8,18 10,19" fill="#99ddff"/>
+  <polygon points="22,14 25,13 24,18 22,19" fill="#99ddff"/>
+  <!-- Helm -->
+  <rect x="11" y="6" width="10" height="9" rx="2" fill="#cceeff"/>
+  <!-- Crystal crown spikes -->
+  <polygon points="13,6 14,2 15,6" fill="#00ddff"/>
+  <polygon points="15,6 16,1 17,6" fill="#aaffff"/>
+  <polygon points="17,6 18,2 19,6" fill="#00ddff"/>
+  <!-- Visor -->
+  <rect x="12" y="10" width="8" height="2" rx="1" fill="#006688"/>
+  <rect x="13" y="10" width="6" height="1" fill="#00ffff"/>
+  <!-- Legs -->
+  <rect x="11" y="25" width="4" height="5" rx="1" fill="#aaddee"/>
+  <rect x="17" y="25" width="4" height="5" rx="1" fill="#aaddee"/>
+  <!-- Crystal boots -->
+  <polygon points="10,29 16,29 15,31 11,31" fill="#00ccdd"/>
+  <polygon points="16,29 22,29 21,31 17,31" fill="#00ccdd"/>
+</svg>

--- a/web/public/sprites/streak-crystal-3.svg
+++ b/web/public/sprites/streak-crystal-3.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Crystal Champion: cyan/white crystalline armour, gem facets, prismatic glow -->
+  <!-- Crystal aura -->
+  <ellipse cx="16" cy="16" rx="13" ry="15" fill="#aaffff" opacity="0.1"/>
+  <!-- Body -->
+  <rect x="10" y="14" width="12" height="11" rx="1" fill="#cceeff"/>
+  <!-- Crystal facet pattern on body -->
+  <polygon points="10,14 16,14 13,20" fill="#99ddff" opacity="0.7"/>
+  <polygon points="22,14 16,14 19,20" fill="#bbffff" opacity="0.7"/>
+  <polygon points="10,25 16,25 13,20" fill="#bbffff" opacity="0.6"/>
+  <polygon points="22,25 16,25 19,20" fill="#99ddff" opacity="0.6"/>
+  <!-- Gem on chest -->
+  <polygon points="16,17 18,19 16,21 14,19" fill="#00eeff"/>
+  <polygon points="16,17 18,19 16,18" fill="#ffffff" opacity="0.6"/>
+  <!-- Crystal shoulders -->
+  <polygon points="10,14 7,13 8,18 10,19" fill="#99ddff"/>
+  <polygon points="22,14 25,13 24,18 22,19" fill="#99ddff"/>
+  <!-- Helm -->
+  <rect x="11" y="6" width="10" height="9" rx="2" fill="#cceeff"/>
+  <!-- Crystal crown spikes -->
+  <polygon points="13,6 14,2 15,6" fill="#00ddff"/>
+  <polygon points="15,6 16,1 17,6" fill="#aaffff"/>
+  <polygon points="17,6 18,2 19,6" fill="#00ddff"/>
+  <!-- Visor -->
+  <rect x="12" y="10" width="8" height="2" rx="1" fill="#006688"/>
+  <rect x="13" y="10" width="6" height="1" fill="#00ffff"/>
+  <!-- Legs -->
+  <rect x="11" y="25" width="4" height="5" rx="1" fill="#aaddee"/>
+  <rect x="17" y="25" width="4" height="5" rx="1" fill="#aaddee"/>
+  <!-- Crystal boots -->
+  <polygon points="10,29 16,29 15,31 11,31" fill="#00ccdd"/>
+  <polygon points="16,29 22,29 21,31 17,31" fill="#00ccdd"/>
+</svg>

--- a/web/public/sprites/streak-dragon-1.svg
+++ b/web/public/sprites/streak-dragon-1.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Dragon Rider: red/gold dragon-scale armour, wing motifs, horned helm -->
+  <!-- Body / scale armour -->
+  <rect x="10" y="14" width="12" height="11" rx="1" fill="#8b0000"/>
+  <!-- Scale pattern -->
+  <ellipse cx="12" cy="16" rx="2" ry="1.5" fill="#a00000" opacity="0.7"/>
+  <ellipse cx="16" cy="16" rx="2" ry="1.5" fill="#a00000" opacity="0.7"/>
+  <ellipse cx="20" cy="16" rx="2" ry="1.5" fill="#a00000" opacity="0.7"/>
+  <ellipse cx="14" cy="19" rx="2" ry="1.5" fill="#a00000" opacity="0.7"/>
+  <ellipse cx="18" cy="19" rx="2" ry="1.5" fill="#a00000" opacity="0.7"/>
+  <!-- Gold trim -->
+  <rect x="10" y="14" width="12" height="1.5" fill="#ffd700"/>
+  <rect x="10" y="24" width="12" height="1.5" fill="#ffd700"/>
+  <!-- Wing motifs on shoulders -->
+  <path d="M10,14 Q4,10 5,18 Q8,16 10,19Z" fill="#8b0000"/>
+  <path d="M22,14 Q28,10 27,18 Q24,16 22,19Z" fill="#8b0000"/>
+  <!-- Helm -->
+  <rect x="11" y="6" width="10" height="9" rx="2" fill="#6b0000"/>
+  <!-- Dragon horns -->
+  <polygon points="11,7 8,2 12,7" fill="#ffd700"/>
+  <polygon points="21,7 24,2 20,7" fill="#ffd700"/>
+  <!-- Gold visor -->
+  <rect x="12" y="10" width="8" height="2" rx="1" fill="#4a0000"/>
+  <rect x="13" y="10" width="6" height="1" fill="#ffd700"/>
+  <!-- Legs -->
+  <rect x="11" y="25" width="4" height="5" rx="1" fill="#8b0000"/>
+  <rect x="17" y="25" width="4" height="5" rx="1" fill="#8b0000"/>
+  <rect x="10" y="29" width="6" height="2" rx="1" fill="#6b0000"/>
+  <rect x="16" y="29" width="6" height="2" rx="1" fill="#6b0000"/>
+  <!-- Spear -->
+  <rect x="25" y="8" width="2" height="18" rx="1" fill="#ffd700"/>
+  <polygon points="24,8 28,8 26,3" fill="#ff4400"/>
+</svg>

--- a/web/public/sprites/streak-dragon-2.svg
+++ b/web/public/sprites/streak-dragon-2.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Dragon Rider: red/gold dragon-scale armour, wing motifs, horned helm -->
+  <!-- Body / scale armour -->
+  <rect x="10" y="14" width="12" height="11" rx="1" fill="#8b0000"/>
+  <!-- Scale pattern -->
+  <ellipse cx="12" cy="16" rx="2" ry="1.5" fill="#a00000" opacity="0.7"/>
+  <ellipse cx="16" cy="16" rx="2" ry="1.5" fill="#a00000" opacity="0.7"/>
+  <ellipse cx="20" cy="16" rx="2" ry="1.5" fill="#a00000" opacity="0.7"/>
+  <ellipse cx="14" cy="19" rx="2" ry="1.5" fill="#a00000" opacity="0.7"/>
+  <ellipse cx="18" cy="19" rx="2" ry="1.5" fill="#a00000" opacity="0.7"/>
+  <!-- Gold trim -->
+  <rect x="10" y="14" width="12" height="1.5" fill="#ffd700"/>
+  <rect x="10" y="24" width="12" height="1.5" fill="#ffd700"/>
+  <!-- Wing motifs on shoulders -->
+  <path d="M10,14 Q4,10 5,18 Q8,16 10,19Z" fill="#8b0000"/>
+  <path d="M22,14 Q28,10 27,18 Q24,16 22,19Z" fill="#8b0000"/>
+  <!-- Helm -->
+  <rect x="11" y="6" width="10" height="9" rx="2" fill="#6b0000"/>
+  <!-- Dragon horns -->
+  <polygon points="11,7 8,2 12,7" fill="#ffd700"/>
+  <polygon points="21,7 24,2 20,7" fill="#ffd700"/>
+  <!-- Gold visor -->
+  <rect x="12" y="10" width="8" height="2" rx="1" fill="#4a0000"/>
+  <rect x="13" y="10" width="6" height="1" fill="#ffd700"/>
+  <!-- Legs -->
+  <rect x="11" y="25" width="4" height="5" rx="1" fill="#8b0000"/>
+  <rect x="17" y="25" width="4" height="5" rx="1" fill="#8b0000"/>
+  <rect x="10" y="29" width="6" height="2" rx="1" fill="#6b0000"/>
+  <rect x="16" y="29" width="6" height="2" rx="1" fill="#6b0000"/>
+  <!-- Spear -->
+  <rect x="25" y="8" width="2" height="18" rx="1" fill="#ffd700"/>
+  <polygon points="24,8 28,8 26,3" fill="#ff4400"/>
+</svg>

--- a/web/public/sprites/streak-dragon-3.svg
+++ b/web/public/sprites/streak-dragon-3.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Dragon Rider: red/gold dragon-scale armour, wing motifs, horned helm -->
+  <!-- Body / scale armour -->
+  <rect x="10" y="14" width="12" height="11" rx="1" fill="#8b0000"/>
+  <!-- Scale pattern -->
+  <ellipse cx="12" cy="16" rx="2" ry="1.5" fill="#a00000" opacity="0.7"/>
+  <ellipse cx="16" cy="16" rx="2" ry="1.5" fill="#a00000" opacity="0.7"/>
+  <ellipse cx="20" cy="16" rx="2" ry="1.5" fill="#a00000" opacity="0.7"/>
+  <ellipse cx="14" cy="19" rx="2" ry="1.5" fill="#a00000" opacity="0.7"/>
+  <ellipse cx="18" cy="19" rx="2" ry="1.5" fill="#a00000" opacity="0.7"/>
+  <!-- Gold trim -->
+  <rect x="10" y="14" width="12" height="1.5" fill="#ffd700"/>
+  <rect x="10" y="24" width="12" height="1.5" fill="#ffd700"/>
+  <!-- Wing motifs on shoulders -->
+  <path d="M10,14 Q4,10 5,18 Q8,16 10,19Z" fill="#8b0000"/>
+  <path d="M22,14 Q28,10 27,18 Q24,16 22,19Z" fill="#8b0000"/>
+  <!-- Helm -->
+  <rect x="11" y="6" width="10" height="9" rx="2" fill="#6b0000"/>
+  <!-- Dragon horns -->
+  <polygon points="11,7 8,2 12,7" fill="#ffd700"/>
+  <polygon points="21,7 24,2 20,7" fill="#ffd700"/>
+  <!-- Gold visor -->
+  <rect x="12" y="10" width="8" height="2" rx="1" fill="#4a0000"/>
+  <rect x="13" y="10" width="6" height="1" fill="#ffd700"/>
+  <!-- Legs -->
+  <rect x="11" y="25" width="4" height="5" rx="1" fill="#8b0000"/>
+  <rect x="17" y="25" width="4" height="5" rx="1" fill="#8b0000"/>
+  <rect x="10" y="29" width="6" height="2" rx="1" fill="#6b0000"/>
+  <rect x="16" y="29" width="6" height="2" rx="1" fill="#6b0000"/>
+  <!-- Spear -->
+  <rect x="25" y="8" width="2" height="18" rx="1" fill="#ffd700"/>
+  <polygon points="24,8 28,8 26,3" fill="#ff4400"/>
+</svg>

--- a/web/public/sprites/streak-flame-1.svg
+++ b/web/public/sprites/streak-flame-1.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Flame Walker: dark armour wreathed in orange/yellow fire -->
+  <!-- Flame aura -->
+  <ellipse cx="16" cy="16" rx="13" ry="15" fill="#ff6600" opacity="0.18"/>
+  <!-- Body -->
+  <rect x="10" y="14" width="12" height="11" rx="1" fill="#2a1a00"/>
+  <!-- Fire trim on body -->
+  <rect x="10" y="14" width="12" height="2" fill="#ff8800"/>
+  <rect x="10" y="23" width="12" height="2" fill="#ff6600"/>
+  <!-- Helm -->
+  <rect x="11" y="6" width="10" height="9" rx="2" fill="#1a0e00"/>
+  <!-- Flame crown -->
+  <polygon points="11,6 13,2 14,6" fill="#ff4400"/>
+  <polygon points="14,6 16,1 18,6" fill="#ffaa00"/>
+  <polygon points="18,6 19,3 21,6" fill="#ff4400"/>
+  <!-- Glowing eyes -->
+  <ellipse cx="14" cy="10" rx="2" ry="1.5" fill="#ff6600"/>
+  <ellipse cx="18" cy="10" rx="2" ry="1.5" fill="#ff6600"/>
+  <ellipse cx="14" cy="10" rx="1" ry="0.8" fill="#ffee00"/>
+  <ellipse cx="18" cy="10" rx="1" ry="0.8" fill="#ffee00"/>
+  <!-- Legs -->
+  <rect x="11" y="25" width="4" height="5" rx="1" fill="#2a1a00"/>
+  <rect x="17" y="25" width="4" height="5" rx="1" fill="#2a1a00"/>
+  <!-- Flame feet -->
+  <rect x="10" y="29" width="6" height="2" rx="1" fill="#ff6600"/>
+  <rect x="16" y="29" width="6" height="2" rx="1" fill="#ff6600"/>
+  <!-- Arms -->
+  <rect x="7" y="14" width="3" height="10" rx="1" fill="#2a1a00"/>
+  <rect x="22" y="14" width="3" height="10" rx="1" fill="#2a1a00"/>
+  <!-- Flaming fists -->
+  <ellipse cx="8.5" cy="25" rx="3" ry="3" fill="#ff6600" opacity="0.7"/>
+  <ellipse cx="23.5" cy="25" rx="3" ry="3" fill="#ff6600" opacity="0.7"/>
+</svg>

--- a/web/public/sprites/streak-flame-2.svg
+++ b/web/public/sprites/streak-flame-2.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Flame Walker: dark armour wreathed in orange/yellow fire -->
+  <!-- Flame aura -->
+  <ellipse cx="16" cy="16" rx="13" ry="15" fill="#ff6600" opacity="0.18"/>
+  <!-- Body -->
+  <rect x="10" y="14" width="12" height="11" rx="1" fill="#2a1a00"/>
+  <!-- Fire trim on body -->
+  <rect x="10" y="14" width="12" height="2" fill="#ff8800"/>
+  <rect x="10" y="23" width="12" height="2" fill="#ff6600"/>
+  <!-- Helm -->
+  <rect x="11" y="6" width="10" height="9" rx="2" fill="#1a0e00"/>
+  <!-- Flame crown -->
+  <polygon points="11,6 13,2 14,6" fill="#ff4400"/>
+  <polygon points="14,6 16,1 18,6" fill="#ffaa00"/>
+  <polygon points="18,6 19,3 21,6" fill="#ff4400"/>
+  <!-- Glowing eyes -->
+  <ellipse cx="14" cy="10" rx="2" ry="1.5" fill="#ff6600"/>
+  <ellipse cx="18" cy="10" rx="2" ry="1.5" fill="#ff6600"/>
+  <ellipse cx="14" cy="10" rx="1" ry="0.8" fill="#ffee00"/>
+  <ellipse cx="18" cy="10" rx="1" ry="0.8" fill="#ffee00"/>
+  <!-- Legs -->
+  <rect x="11" y="25" width="4" height="5" rx="1" fill="#2a1a00"/>
+  <rect x="17" y="25" width="4" height="5" rx="1" fill="#2a1a00"/>
+  <!-- Flame feet -->
+  <rect x="10" y="29" width="6" height="2" rx="1" fill="#ff6600"/>
+  <rect x="16" y="29" width="6" height="2" rx="1" fill="#ff6600"/>
+  <!-- Arms -->
+  <rect x="7" y="14" width="3" height="10" rx="1" fill="#2a1a00"/>
+  <rect x="22" y="14" width="3" height="10" rx="1" fill="#2a1a00"/>
+  <!-- Flaming fists -->
+  <ellipse cx="8.5" cy="25" rx="3" ry="3" fill="#ff6600" opacity="0.7"/>
+  <ellipse cx="23.5" cy="25" rx="3" ry="3" fill="#ff6600" opacity="0.7"/>
+</svg>

--- a/web/public/sprites/streak-flame-3.svg
+++ b/web/public/sprites/streak-flame-3.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Flame Walker: dark armour wreathed in orange/yellow fire -->
+  <!-- Flame aura -->
+  <ellipse cx="16" cy="16" rx="13" ry="15" fill="#ff6600" opacity="0.18"/>
+  <!-- Body -->
+  <rect x="10" y="14" width="12" height="11" rx="1" fill="#2a1a00"/>
+  <!-- Fire trim on body -->
+  <rect x="10" y="14" width="12" height="2" fill="#ff8800"/>
+  <rect x="10" y="23" width="12" height="2" fill="#ff6600"/>
+  <!-- Helm -->
+  <rect x="11" y="6" width="10" height="9" rx="2" fill="#1a0e00"/>
+  <!-- Flame crown -->
+  <polygon points="11,6 13,2 14,6" fill="#ff4400"/>
+  <polygon points="14,6 16,1 18,6" fill="#ffaa00"/>
+  <polygon points="18,6 19,3 21,6" fill="#ff4400"/>
+  <!-- Glowing eyes -->
+  <ellipse cx="14" cy="10" rx="2" ry="1.5" fill="#ff6600"/>
+  <ellipse cx="18" cy="10" rx="2" ry="1.5" fill="#ff6600"/>
+  <ellipse cx="14" cy="10" rx="1" ry="0.8" fill="#ffee00"/>
+  <ellipse cx="18" cy="10" rx="1" ry="0.8" fill="#ffee00"/>
+  <!-- Legs -->
+  <rect x="11" y="25" width="4" height="5" rx="1" fill="#2a1a00"/>
+  <rect x="17" y="25" width="4" height="5" rx="1" fill="#2a1a00"/>
+  <!-- Flame feet -->
+  <rect x="10" y="29" width="6" height="2" rx="1" fill="#ff6600"/>
+  <rect x="16" y="29" width="6" height="2" rx="1" fill="#ff6600"/>
+  <!-- Arms -->
+  <rect x="7" y="14" width="3" height="10" rx="1" fill="#2a1a00"/>
+  <rect x="22" y="14" width="3" height="10" rx="1" fill="#2a1a00"/>
+  <!-- Flaming fists -->
+  <ellipse cx="8.5" cy="25" rx="3" ry="3" fill="#ff6600" opacity="0.7"/>
+  <ellipse cx="23.5" cy="25" rx="3" ry="3" fill="#ff6600" opacity="0.7"/>
+</svg>

--- a/web/public/sprites/streak-fracture-1.svg
+++ b/web/public/sprites/streak-fracture-1.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Fracture Lord: reality-shattered armour, multi-colour cracks, void and light collide -->
+  <!-- Reality distortion ring -->
+  <ellipse cx="16" cy="16" rx="14" ry="15" fill="none" stroke="#ff00ff" stroke-width="0.5" opacity="0.4"/>
+  <ellipse cx="16" cy="16" rx="12" ry="13" fill="none" stroke="#00ffff" stroke-width="0.4" opacity="0.3"/>
+  <!-- Body: split between void and light -->
+  <rect x="10" y="14" width="6" height="11" rx="1" fill="#050510"/>
+  <rect x="16" y="14" width="6" height="11" rx="1" fill="#fffff0"/>
+  <!-- Fracture cracks across body -->
+  <line x1="16" y1="14" x2="13" y2="25" stroke="#ff00ff" stroke-width="1" opacity="0.9"/>
+  <line x1="16" y1="14" x2="19" y2="25" stroke="#00ffff" stroke-width="1" opacity="0.9"/>
+  <line x1="10" y1="18" x2="22" y2="20" stroke="#ffff00" stroke-width="0.6" opacity="0.7"/>
+  <line x1="11" y1="22" x2="21" y2="17" stroke="#ff4400" stroke-width="0.5" opacity="0.6"/>
+  <!-- Helm: split dark/light -->
+  <rect x="11" y="6" width="5" height="9" rx="2" fill="#050510"/>
+  <rect x="16" y="6" width="5" height="9" rx="2" fill="#fffff0"/>
+  <!-- Crown: chaos spikes -->
+  <polygon points="11,6 10,2 13,6" fill="#ff00ff"/>
+  <polygon points="14,6 15,1 17,6" fill="#ffff00"/>
+  <polygon points="21,6 22,2 19,6" fill="#00ffff"/>
+  <!-- Eye slit: prismatic -->
+  <rect x="12" y="10" width="8" height="2" rx="1" fill="#111"/>
+  <rect x="12" y="10" width="3" height="1" fill="#ff00ff"/>
+  <rect x="15" y="10" width="2" height="1" fill="#ffffff"/>
+  <rect x="17" y="10" width="3" height="1" fill="#00ffff"/>
+  <!-- Fractured pauldrons -->
+  <polygon points="10,14 6,12 7,17 10,18" fill="#220033" opacity="0.8"/>
+  <polygon points="22,14 26,12 25,17 22,18" fill="#fffff0" opacity="0.7"/>
+  <!-- Legs -->
+  <rect x="11" y="25" width="4" height="5" rx="1" fill="#050510"/>
+  <rect x="17" y="25" width="4" height="5" rx="1" fill="#ddddcc"/>
+  <!-- Fracture portal feet -->
+  <ellipse cx="13" cy="31" rx="4" ry="1.5" fill="#ff00ff" opacity="0.6"/>
+  <ellipse cx="19" cy="31" rx="4" ry="1.5" fill="#00ffff" opacity="0.6"/>
+</svg>

--- a/web/public/sprites/streak-fracture-2.svg
+++ b/web/public/sprites/streak-fracture-2.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Fracture Lord: reality-shattered armour, multi-colour cracks, void and light collide -->
+  <!-- Reality distortion ring -->
+  <ellipse cx="16" cy="16" rx="14" ry="15" fill="none" stroke="#ff00ff" stroke-width="0.5" opacity="0.4"/>
+  <ellipse cx="16" cy="16" rx="12" ry="13" fill="none" stroke="#00ffff" stroke-width="0.4" opacity="0.3"/>
+  <!-- Body: split between void and light -->
+  <rect x="10" y="14" width="6" height="11" rx="1" fill="#050510"/>
+  <rect x="16" y="14" width="6" height="11" rx="1" fill="#fffff0"/>
+  <!-- Fracture cracks across body -->
+  <line x1="16" y1="14" x2="13" y2="25" stroke="#ff00ff" stroke-width="1" opacity="0.9"/>
+  <line x1="16" y1="14" x2="19" y2="25" stroke="#00ffff" stroke-width="1" opacity="0.9"/>
+  <line x1="10" y1="18" x2="22" y2="20" stroke="#ffff00" stroke-width="0.6" opacity="0.7"/>
+  <line x1="11" y1="22" x2="21" y2="17" stroke="#ff4400" stroke-width="0.5" opacity="0.6"/>
+  <!-- Helm: split dark/light -->
+  <rect x="11" y="6" width="5" height="9" rx="2" fill="#050510"/>
+  <rect x="16" y="6" width="5" height="9" rx="2" fill="#fffff0"/>
+  <!-- Crown: chaos spikes -->
+  <polygon points="11,6 10,2 13,6" fill="#ff00ff"/>
+  <polygon points="14,6 15,1 17,6" fill="#ffff00"/>
+  <polygon points="21,6 22,2 19,6" fill="#00ffff"/>
+  <!-- Eye slit: prismatic -->
+  <rect x="12" y="10" width="8" height="2" rx="1" fill="#111"/>
+  <rect x="12" y="10" width="3" height="1" fill="#ff00ff"/>
+  <rect x="15" y="10" width="2" height="1" fill="#ffffff"/>
+  <rect x="17" y="10" width="3" height="1" fill="#00ffff"/>
+  <!-- Fractured pauldrons -->
+  <polygon points="10,14 6,12 7,17 10,18" fill="#220033" opacity="0.8"/>
+  <polygon points="22,14 26,12 25,17 22,18" fill="#fffff0" opacity="0.7"/>
+  <!-- Legs -->
+  <rect x="11" y="25" width="4" height="5" rx="1" fill="#050510"/>
+  <rect x="17" y="25" width="4" height="5" rx="1" fill="#ddddcc"/>
+  <!-- Fracture portal feet -->
+  <ellipse cx="13" cy="31" rx="4" ry="1.5" fill="#ff00ff" opacity="0.6"/>
+  <ellipse cx="19" cy="31" rx="4" ry="1.5" fill="#00ffff" opacity="0.6"/>
+</svg>

--- a/web/public/sprites/streak-fracture-3.svg
+++ b/web/public/sprites/streak-fracture-3.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Fracture Lord: reality-shattered armour, multi-colour cracks, void and light collide -->
+  <!-- Reality distortion ring -->
+  <ellipse cx="16" cy="16" rx="14" ry="15" fill="none" stroke="#ff00ff" stroke-width="0.5" opacity="0.4"/>
+  <ellipse cx="16" cy="16" rx="12" ry="13" fill="none" stroke="#00ffff" stroke-width="0.4" opacity="0.3"/>
+  <!-- Body: split between void and light -->
+  <rect x="10" y="14" width="6" height="11" rx="1" fill="#050510"/>
+  <rect x="16" y="14" width="6" height="11" rx="1" fill="#fffff0"/>
+  <!-- Fracture cracks across body -->
+  <line x1="16" y1="14" x2="13" y2="25" stroke="#ff00ff" stroke-width="1" opacity="0.9"/>
+  <line x1="16" y1="14" x2="19" y2="25" stroke="#00ffff" stroke-width="1" opacity="0.9"/>
+  <line x1="10" y1="18" x2="22" y2="20" stroke="#ffff00" stroke-width="0.6" opacity="0.7"/>
+  <line x1="11" y1="22" x2="21" y2="17" stroke="#ff4400" stroke-width="0.5" opacity="0.6"/>
+  <!-- Helm: split dark/light -->
+  <rect x="11" y="6" width="5" height="9" rx="2" fill="#050510"/>
+  <rect x="16" y="6" width="5" height="9" rx="2" fill="#fffff0"/>
+  <!-- Crown: chaos spikes -->
+  <polygon points="11,6 10,2 13,6" fill="#ff00ff"/>
+  <polygon points="14,6 15,1 17,6" fill="#ffff00"/>
+  <polygon points="21,6 22,2 19,6" fill="#00ffff"/>
+  <!-- Eye slit: prismatic -->
+  <rect x="12" y="10" width="8" height="2" rx="1" fill="#111"/>
+  <rect x="12" y="10" width="3" height="1" fill="#ff00ff"/>
+  <rect x="15" y="10" width="2" height="1" fill="#ffffff"/>
+  <rect x="17" y="10" width="3" height="1" fill="#00ffff"/>
+  <!-- Fractured pauldrons -->
+  <polygon points="10,14 6,12 7,17 10,18" fill="#220033" opacity="0.8"/>
+  <polygon points="22,14 26,12 25,17 22,18" fill="#fffff0" opacity="0.7"/>
+  <!-- Legs -->
+  <rect x="11" y="25" width="4" height="5" rx="1" fill="#050510"/>
+  <rect x="17" y="25" width="4" height="5" rx="1" fill="#ddddcc"/>
+  <!-- Fracture portal feet -->
+  <ellipse cx="13" cy="31" rx="4" ry="1.5" fill="#ff00ff" opacity="0.6"/>
+  <ellipse cx="19" cy="31" rx="4" ry="1.5" fill="#00ffff" opacity="0.6"/>
+</svg>

--- a/web/public/sprites/streak-iron-1.svg
+++ b/web/public/sprites/streak-iron-1.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Iron Wanderer: steel grey armour, slit visor -->
+  <!-- Body -->
+  <rect x="10" y="14" width="12" height="11" rx="1" fill="#8a9ba8"/>
+  <!-- Pauldrons -->
+  <rect x="7" y="14" width="4" height="5" rx="1" fill="#6d7f8c"/>
+  <rect x="21" y="14" width="4" height="5" rx="1" fill="#6d7f8c"/>
+  <!-- Helm -->
+  <rect x="11" y="6" width="10" height="9" rx="2" fill="#6d7f8c"/>
+  <!-- Visor slit -->
+  <rect x="12" y="10" width="8" height="2" rx="1" fill="#1a2a33"/>
+  <rect x="13" y="10" width="6" height="1" fill="#3af"/>
+  <!-- Belt -->
+  <rect x="10" y="22" width="12" height="2" fill="#4a5a64"/>
+  <!-- Legs -->
+  <rect x="11" y="25" width="4" height="5" rx="1" fill="#6d7f8c"/>
+  <rect x="17" y="25" width="4" height="5" rx="1" fill="#6d7f8c"/>
+  <!-- Boots -->
+  <rect x="10" y="29" width="6" height="2" rx="1" fill="#4a5a64"/>
+  <rect x="16" y="29" width="6" height="2" rx="1" fill="#4a5a64"/>
+  <!-- Arms -->
+  <rect x="7" y="19" width="3" height="7" rx="1" fill="#8a9ba8"/>
+  <rect x="22" y="19" width="3" height="7" rx="1" fill="#8a9ba8"/>
+  <!-- Sword -->
+  <rect x="25" y="14" width="2" height="14" rx="1" fill="#c0cdd4"/>
+  <rect x="23" y="20" width="6" height="2" rx="1" fill="#8a9ba8"/>
+</svg>

--- a/web/public/sprites/streak-iron-2.svg
+++ b/web/public/sprites/streak-iron-2.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Iron Wanderer: steel grey armour, slit visor -->
+  <!-- Body -->
+  <rect x="10" y="14" width="12" height="11" rx="1" fill="#8a9ba8"/>
+  <!-- Pauldrons -->
+  <rect x="7" y="14" width="4" height="5" rx="1" fill="#6d7f8c"/>
+  <rect x="21" y="14" width="4" height="5" rx="1" fill="#6d7f8c"/>
+  <!-- Helm -->
+  <rect x="11" y="6" width="10" height="9" rx="2" fill="#6d7f8c"/>
+  <!-- Visor slit -->
+  <rect x="12" y="10" width="8" height="2" rx="1" fill="#1a2a33"/>
+  <rect x="13" y="10" width="6" height="1" fill="#3af"/>
+  <!-- Belt -->
+  <rect x="10" y="22" width="12" height="2" fill="#4a5a64"/>
+  <!-- Legs -->
+  <rect x="11" y="25" width="4" height="5" rx="1" fill="#6d7f8c"/>
+  <rect x="17" y="25" width="4" height="5" rx="1" fill="#6d7f8c"/>
+  <!-- Boots -->
+  <rect x="10" y="29" width="6" height="2" rx="1" fill="#4a5a64"/>
+  <rect x="16" y="29" width="6" height="2" rx="1" fill="#4a5a64"/>
+  <!-- Arms -->
+  <rect x="7" y="19" width="3" height="7" rx="1" fill="#8a9ba8"/>
+  <rect x="22" y="19" width="3" height="7" rx="1" fill="#8a9ba8"/>
+  <!-- Sword -->
+  <rect x="25" y="14" width="2" height="14" rx="1" fill="#c0cdd4"/>
+  <rect x="23" y="20" width="6" height="2" rx="1" fill="#8a9ba8"/>
+</svg>

--- a/web/public/sprites/streak-iron-3.svg
+++ b/web/public/sprites/streak-iron-3.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Iron Wanderer: steel grey armour, slit visor -->
+  <!-- Body -->
+  <rect x="10" y="14" width="12" height="11" rx="1" fill="#8a9ba8"/>
+  <!-- Pauldrons -->
+  <rect x="7" y="14" width="4" height="5" rx="1" fill="#6d7f8c"/>
+  <rect x="21" y="14" width="4" height="5" rx="1" fill="#6d7f8c"/>
+  <!-- Helm -->
+  <rect x="11" y="6" width="10" height="9" rx="2" fill="#6d7f8c"/>
+  <!-- Visor slit -->
+  <rect x="12" y="10" width="8" height="2" rx="1" fill="#1a2a33"/>
+  <rect x="13" y="10" width="6" height="1" fill="#3af"/>
+  <!-- Belt -->
+  <rect x="10" y="22" width="12" height="2" fill="#4a5a64"/>
+  <!-- Legs -->
+  <rect x="11" y="25" width="4" height="5" rx="1" fill="#6d7f8c"/>
+  <rect x="17" y="25" width="4" height="5" rx="1" fill="#6d7f8c"/>
+  <!-- Boots -->
+  <rect x="10" y="29" width="6" height="2" rx="1" fill="#4a5a64"/>
+  <rect x="16" y="29" width="6" height="2" rx="1" fill="#4a5a64"/>
+  <!-- Arms -->
+  <rect x="7" y="19" width="3" height="7" rx="1" fill="#8a9ba8"/>
+  <rect x="22" y="19" width="3" height="7" rx="1" fill="#8a9ba8"/>
+  <!-- Sword -->
+  <rect x="25" y="14" width="2" height="14" rx="1" fill="#c0cdd4"/>
+  <rect x="23" y="20" width="6" height="2" rx="1" fill="#8a9ba8"/>
+</svg>

--- a/web/public/sprites/streak-shadow-1.svg
+++ b/web/public/sprites/streak-shadow-1.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Shadow Lord: near-black armour, purple energy, tattered cloak -->
+  <!-- Shadow pool -->
+  <ellipse cx="16" cy="30" rx="10" ry="2" fill="#1a0033" opacity="0.5"/>
+  <!-- Cloak -->
+  <polygon points="8,13 6,31 12,26 16,31 20,26 26,31 24,13" fill="#1a0028"/>
+  <!-- Body -->
+  <rect x="11" y="14" width="10" height="10" rx="1" fill="#0d001a"/>
+  <!-- Purple rune on chest -->
+  <rect x="14" y="17" width="4" height="1" fill="#aa44ff"/>
+  <rect x="15" y="16" width="2" height="3" fill="#aa44ff"/>
+  <!-- Helm -->
+  <rect x="11" y="6" width="10" height="9" rx="2" fill="#0d001a"/>
+  <!-- Horns -->
+  <polygon points="11,8 9,3 12,7" fill="#330055"/>
+  <polygon points="21,8 23,3 20,7" fill="#330055"/>
+  <!-- Purple eye slit -->
+  <rect x="12" y="10" width="8" height="2" rx="1" fill="#220033"/>
+  <rect x="13" y="10" width="6" height="1" fill="#cc44ff"/>
+  <!-- Legs -->
+  <rect x="11" y="25" width="4" height="5" rx="1" fill="#0d001a"/>
+  <rect x="17" y="25" width="4" height="5" rx="1" fill="#0d001a"/>
+  <!-- Boots -->
+  <rect x="10" y="29" width="6" height="2" rx="1" fill="#330055"/>
+  <rect x="16" y="29" width="6" height="2" rx="1" fill="#330055"/>
+  <!-- Scythe -->
+  <rect x="24" y="10" width="2" height="20" rx="1" fill="#330055"/>
+  <path d="M26,10 Q32,8 30,16 Q26,14 26,10Z" fill="#aa44ff"/>
+</svg>

--- a/web/public/sprites/streak-shadow-2.svg
+++ b/web/public/sprites/streak-shadow-2.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Shadow Lord: near-black armour, purple energy, tattered cloak -->
+  <!-- Shadow pool -->
+  <ellipse cx="16" cy="30" rx="10" ry="2" fill="#1a0033" opacity="0.5"/>
+  <!-- Cloak -->
+  <polygon points="8,13 6,31 12,26 16,31 20,26 26,31 24,13" fill="#1a0028"/>
+  <!-- Body -->
+  <rect x="11" y="14" width="10" height="10" rx="1" fill="#0d001a"/>
+  <!-- Purple rune on chest -->
+  <rect x="14" y="17" width="4" height="1" fill="#aa44ff"/>
+  <rect x="15" y="16" width="2" height="3" fill="#aa44ff"/>
+  <!-- Helm -->
+  <rect x="11" y="6" width="10" height="9" rx="2" fill="#0d001a"/>
+  <!-- Horns -->
+  <polygon points="11,8 9,3 12,7" fill="#330055"/>
+  <polygon points="21,8 23,3 20,7" fill="#330055"/>
+  <!-- Purple eye slit -->
+  <rect x="12" y="10" width="8" height="2" rx="1" fill="#220033"/>
+  <rect x="13" y="10" width="6" height="1" fill="#cc44ff"/>
+  <!-- Legs -->
+  <rect x="11" y="25" width="4" height="5" rx="1" fill="#0d001a"/>
+  <rect x="17" y="25" width="4" height="5" rx="1" fill="#0d001a"/>
+  <!-- Boots -->
+  <rect x="10" y="29" width="6" height="2" rx="1" fill="#330055"/>
+  <rect x="16" y="29" width="6" height="2" rx="1" fill="#330055"/>
+  <!-- Scythe -->
+  <rect x="24" y="10" width="2" height="20" rx="1" fill="#330055"/>
+  <path d="M26,10 Q32,8 30,16 Q26,14 26,10Z" fill="#aa44ff"/>
+</svg>

--- a/web/public/sprites/streak-shadow-3.svg
+++ b/web/public/sprites/streak-shadow-3.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Shadow Lord: near-black armour, purple energy, tattered cloak -->
+  <!-- Shadow pool -->
+  <ellipse cx="16" cy="30" rx="10" ry="2" fill="#1a0033" opacity="0.5"/>
+  <!-- Cloak -->
+  <polygon points="8,13 6,31 12,26 16,31 20,26 26,31 24,13" fill="#1a0028"/>
+  <!-- Body -->
+  <rect x="11" y="14" width="10" height="10" rx="1" fill="#0d001a"/>
+  <!-- Purple rune on chest -->
+  <rect x="14" y="17" width="4" height="1" fill="#aa44ff"/>
+  <rect x="15" y="16" width="2" height="3" fill="#aa44ff"/>
+  <!-- Helm -->
+  <rect x="11" y="6" width="10" height="9" rx="2" fill="#0d001a"/>
+  <!-- Horns -->
+  <polygon points="11,8 9,3 12,7" fill="#330055"/>
+  <polygon points="21,8 23,3 20,7" fill="#330055"/>
+  <!-- Purple eye slit -->
+  <rect x="12" y="10" width="8" height="2" rx="1" fill="#220033"/>
+  <rect x="13" y="10" width="6" height="1" fill="#cc44ff"/>
+  <!-- Legs -->
+  <rect x="11" y="25" width="4" height="5" rx="1" fill="#0d001a"/>
+  <rect x="17" y="25" width="4" height="5" rx="1" fill="#0d001a"/>
+  <!-- Boots -->
+  <rect x="10" y="29" width="6" height="2" rx="1" fill="#330055"/>
+  <rect x="16" y="29" width="6" height="2" rx="1" fill="#330055"/>
+  <!-- Scythe -->
+  <rect x="24" y="10" width="2" height="20" rx="1" fill="#330055"/>
+  <path d="M26,10 Q32,8 30,16 Q26,14 26,10Z" fill="#aa44ff"/>
+</svg>

--- a/web/public/sprites/streak-void-1.svg
+++ b/web/public/sprites/streak-void-1.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Void Master: fractured reality armour, starfield body, unstable outline -->
+  <!-- Void distortion -->
+  <ellipse cx="16" cy="16" rx="13" ry="15" fill="#000011" opacity="0.6"/>
+  <!-- Stars in body -->
+  <circle cx="12" cy="17" r="0.6" fill="white" opacity="0.8"/>
+  <circle cx="15" cy="20" r="0.5" fill="white" opacity="0.7"/>
+  <circle cx="19" cy="16" r="0.7" fill="white" opacity="0.9"/>
+  <circle cx="13" cy="22" r="0.4" fill="#aaf" opacity="0.8"/>
+  <circle cx="18" cy="22" r="0.5" fill="#aaf" opacity="0.7"/>
+  <!-- Body -->
+  <rect x="10" y="14" width="12" height="11" rx="1" fill="#050510"/>
+  <!-- Void cracks -->
+  <line x1="12" y1="14" x2="14" y2="25" stroke="#5533ff" stroke-width="0.7" opacity="0.8"/>
+  <line x1="20" y1="14" x2="18" y2="25" stroke="#5533ff" stroke-width="0.7" opacity="0.8"/>
+  <line x1="10" y1="19" x2="22" y2="19" stroke="#5533ff" stroke-width="0.7" opacity="0.6"/>
+  <!-- Helm -->
+  <rect x="11" y="6" width="10" height="9" rx="2" fill="#050510"/>
+  <!-- Void eye slit — glows white/blue -->
+  <rect x="12" y="10" width="8" height="2" rx="1" fill="#000020"/>
+  <rect x="13" y="10" width="6" height="1" fill="#ffffff"/>
+  <rect x="14" y="10" width="4" height="1" fill="#aaccff"/>
+  <!-- Void tendrils from shoulders -->
+  <path d="M10,14 Q4,16 3,24 Q7,20 10,22Z" fill="#220044" opacity="0.7"/>
+  <path d="M22,14 Q28,16 29,24 Q25,20 22,22Z" fill="#220044" opacity="0.7"/>
+  <!-- Legs -->
+  <rect x="11" y="25" width="4" height="5" rx="1" fill="#050510"/>
+  <rect x="17" y="25" width="4" height="5" rx="1" fill="#050510"/>
+  <!-- Void portal feet -->
+  <ellipse cx="13" cy="31" rx="4" ry="1.5" fill="#5533ff" opacity="0.5"/>
+  <ellipse cx="19" cy="31" rx="4" ry="1.5" fill="#5533ff" opacity="0.5"/>
+</svg>

--- a/web/public/sprites/streak-void-2.svg
+++ b/web/public/sprites/streak-void-2.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Void Master: fractured reality armour, starfield body, unstable outline -->
+  <!-- Void distortion -->
+  <ellipse cx="16" cy="16" rx="13" ry="15" fill="#000011" opacity="0.6"/>
+  <!-- Stars in body -->
+  <circle cx="12" cy="17" r="0.6" fill="white" opacity="0.8"/>
+  <circle cx="15" cy="20" r="0.5" fill="white" opacity="0.7"/>
+  <circle cx="19" cy="16" r="0.7" fill="white" opacity="0.9"/>
+  <circle cx="13" cy="22" r="0.4" fill="#aaf" opacity="0.8"/>
+  <circle cx="18" cy="22" r="0.5" fill="#aaf" opacity="0.7"/>
+  <!-- Body -->
+  <rect x="10" y="14" width="12" height="11" rx="1" fill="#050510"/>
+  <!-- Void cracks -->
+  <line x1="12" y1="14" x2="14" y2="25" stroke="#5533ff" stroke-width="0.7" opacity="0.8"/>
+  <line x1="20" y1="14" x2="18" y2="25" stroke="#5533ff" stroke-width="0.7" opacity="0.8"/>
+  <line x1="10" y1="19" x2="22" y2="19" stroke="#5533ff" stroke-width="0.7" opacity="0.6"/>
+  <!-- Helm -->
+  <rect x="11" y="6" width="10" height="9" rx="2" fill="#050510"/>
+  <!-- Void eye slit — glows white/blue -->
+  <rect x="12" y="10" width="8" height="2" rx="1" fill="#000020"/>
+  <rect x="13" y="10" width="6" height="1" fill="#ffffff"/>
+  <rect x="14" y="10" width="4" height="1" fill="#aaccff"/>
+  <!-- Void tendrils from shoulders -->
+  <path d="M10,14 Q4,16 3,24 Q7,20 10,22Z" fill="#220044" opacity="0.7"/>
+  <path d="M22,14 Q28,16 29,24 Q25,20 22,22Z" fill="#220044" opacity="0.7"/>
+  <!-- Legs -->
+  <rect x="11" y="25" width="4" height="5" rx="1" fill="#050510"/>
+  <rect x="17" y="25" width="4" height="5" rx="1" fill="#050510"/>
+  <!-- Void portal feet -->
+  <ellipse cx="13" cy="31" rx="4" ry="1.5" fill="#5533ff" opacity="0.5"/>
+  <ellipse cx="19" cy="31" rx="4" ry="1.5" fill="#5533ff" opacity="0.5"/>
+</svg>

--- a/web/public/sprites/streak-void-3.svg
+++ b/web/public/sprites/streak-void-3.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Void Master: fractured reality armour, starfield body, unstable outline -->
+  <!-- Void distortion -->
+  <ellipse cx="16" cy="16" rx="13" ry="15" fill="#000011" opacity="0.6"/>
+  <!-- Stars in body -->
+  <circle cx="12" cy="17" r="0.6" fill="white" opacity="0.8"/>
+  <circle cx="15" cy="20" r="0.5" fill="white" opacity="0.7"/>
+  <circle cx="19" cy="16" r="0.7" fill="white" opacity="0.9"/>
+  <circle cx="13" cy="22" r="0.4" fill="#aaf" opacity="0.8"/>
+  <circle cx="18" cy="22" r="0.5" fill="#aaf" opacity="0.7"/>
+  <!-- Body -->
+  <rect x="10" y="14" width="12" height="11" rx="1" fill="#050510"/>
+  <!-- Void cracks -->
+  <line x1="12" y1="14" x2="14" y2="25" stroke="#5533ff" stroke-width="0.7" opacity="0.8"/>
+  <line x1="20" y1="14" x2="18" y2="25" stroke="#5533ff" stroke-width="0.7" opacity="0.8"/>
+  <line x1="10" y1="19" x2="22" y2="19" stroke="#5533ff" stroke-width="0.7" opacity="0.6"/>
+  <!-- Helm -->
+  <rect x="11" y="6" width="10" height="9" rx="2" fill="#050510"/>
+  <!-- Void eye slit — glows white/blue -->
+  <rect x="12" y="10" width="8" height="2" rx="1" fill="#000020"/>
+  <rect x="13" y="10" width="6" height="1" fill="#ffffff"/>
+  <rect x="14" y="10" width="4" height="1" fill="#aaccff"/>
+  <!-- Void tendrils from shoulders -->
+  <path d="M10,14 Q4,16 3,24 Q7,20 10,22Z" fill="#220044" opacity="0.7"/>
+  <path d="M22,14 Q28,16 29,24 Q25,20 22,22Z" fill="#220044" opacity="0.7"/>
+  <!-- Legs -->
+  <rect x="11" y="25" width="4" height="5" rx="1" fill="#050510"/>
+  <rect x="17" y="25" width="4" height="5" rx="1" fill="#050510"/>
+  <!-- Void portal feet -->
+  <ellipse cx="13" cy="31" rx="4" ry="1.5" fill="#5533ff" opacity="0.5"/>
+  <ellipse cx="19" cy="31" rx="4" ry="1.5" fill="#5533ff" opacity="0.5"/>
+</svg>


### PR DESCRIPTION
## Summary

All 23 player avatar slugs now have `-1/-2/-3.svg` animation frames, so the player commander animates on the battlefield for any avatar choice.

| Group | Count | Approach |
|---|---|---|
| `jarv-red`, `jarv-green`, `jarv-gold` | 3 × 3 frames | Proper walking frames — same leg positions as `jarv-1/2/3` with each variant's colour palette applied |
| Boss avatars (`boss-thornlord`, `boss-kragg`, etc.) | 13 × 3 frames | Copied from the existing boss unit walking sprites (`thornlord-1/2/3`, `warlord-kragg-1/2/3`, etc.) |
| Streak avatars (`streak-iron`, `streak-flame`, etc.) | 8 × 3 frames | Static sprite copied as 3 identical frames — prevents the `AnimatedSpriteImg` error fallback; walking animation can be added later |

Previously only `jarv` had animation frames; all other avatars fell back to a static image via the `onError` handler.

## Test plan

- [ ] Select `jarv-red` avatar — player commander animates on the battlefield
- [ ] Select `jarv-green` avatar — colours match the character select portrait
- [ ] Select `jarv-gold` avatar — colours match the character select portrait  
- [ ] Select a boss avatar (e.g. `boss-kragg`) — commander shows the boss walking animation
- [ ] Select a streak avatar (e.g. `streak-iron`) — commander shows the static sprite without error fallback

https://claude.ai/code/session_01FFXw8rUxBVQRtJK8x762WJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01FFXw8rUxBVQRtJK8x762WJ)_