### PR TITLE
feat(moats): add 10 moat variants with damage, unique visuals, and SVG sprites

### DIFF
--- a/web/public/sprites/acid-moat.svg
+++ b/web/public/sprites/acid-moat.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Stone edges -->
+  <rect x="1" y="10" width="30" height="4" rx="1" fill="#556644"/>
+  <rect x="1" y="20" width="30" height="4" rx="1" fill="#556644"/>
+  <!-- Acid body -->
+  <rect x="1" y="14" width="30" height="6" fill="#1a3a00"/>
+  <rect x="1" y="14" width="30" height="2" fill="#4aaa00" opacity="0.5"/>
+  <!-- Bubbles -->
+  <circle cx="7"  cy="16" r="1.5" fill="#60cc10" opacity="0.6"/>
+  <circle cx="16" cy="17" r="1"   fill="#70dd20" opacity="0.5"/>
+  <circle cx="24" cy="15.5" r="2" fill="#50bb00" opacity="0.55"/>
+  <!-- Acid ripples -->
+  <path d="M3,18 Q7,17 11,18 Q15,19 19,18 Q23,17 27,18" stroke="#80ee30" stroke-width="0.8" fill="none" opacity="0.6"/>
+  <!-- Corroded stone -->
+  <rect x="4"  y="11" width="6" height="2" rx="0" fill="#3a4a20" opacity="0.5"/>
+  <rect x="22" y="11" width="6" height="2" rx="0" fill="#3a4a20" opacity="0.5"/>
+  <!-- Drip marks -->
+  <line x1="8"  y1="14" x2="8"  y2="11" stroke="#60cc10" stroke-width="0.6" opacity="0.4"/>
+  <line x1="20" y1="20" x2="20" y2="23" stroke="#60cc10" stroke-width="0.6" opacity="0.4"/>
+</svg>

--- a/web/public/sprites/blood-pool.svg
+++ b/web/public/sprites/blood-pool.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Dark stone edges -->
+  <rect x="1" y="10" width="30" height="4" rx="1" fill="#4a2028"/>
+  <rect x="1" y="20" width="30" height="4" rx="1" fill="#4a2028"/>
+  <!-- Blood body -->
+  <rect x="1" y="14" width="30" height="6" fill="#5a0010"/>
+  <rect x="1" y="14" width="30" height="2" fill="#a00028" opacity="0.6"/>
+  <!-- Blood ripples -->
+  <path d="M3,17 Q7,16 11,17 Q15,18 19,17 Q23,16 27,17" stroke="#cc0030" stroke-width="0.8" fill="none" opacity="0.5"/>
+  <path d="M3,18.5 Q8,17.5 13,18.5 Q18,19.5 23,18.5 Q26,17.5 29,18.5" stroke="#900020" stroke-width="0.6" fill="none" opacity="0.4"/>
+  <!-- Dark clots -->
+  <ellipse cx="9"  cy="17" rx="2.5" ry="1" fill="#3a0010" opacity="0.55"/>
+  <ellipse cx="23" cy="16.5" rx="3" ry="1" fill="#3a0010" opacity="0.5"/>
+  <!-- Stone staining -->
+  <rect x="3"  y="13" width="5" height="1" rx="0" fill="#800020" opacity="0.4"/>
+  <rect x="24" y="20" width="5" height="1" rx="0" fill="#800020" opacity="0.4"/>
+</svg>

--- a/web/public/sprites/frost-moat.svg
+++ b/web/public/sprites/frost-moat.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ice edges -->
+  <rect x="1" y="10" width="30" height="4" rx="1" fill="#8ab8d8"/>
+  <rect x="1" y="20" width="30" height="4" rx="1" fill="#8ab8d8"/>
+  <!-- Frozen water body -->
+  <rect x="1" y="14" width="30" height="6" fill="#1a4a6a"/>
+  <!-- Ice sheet on top -->
+  <rect x="1" y="14" width="30" height="2" fill="#c0e0f8" opacity="0.45"/>
+  <!-- Ice cracks -->
+  <path d="M5,14 L8,17 L6,20"  stroke="#9ad0f0" stroke-width="0.6" fill="none" opacity="0.6"/>
+  <path d="M20,14 L23,18 L21,20" stroke="#9ad0f0" stroke-width="0.6" fill="none" opacity="0.6"/>
+  <!-- Snowflake hints -->
+  <text x="10" y="19" font-size="4" fill="#c8e8ff" opacity="0.5" text-anchor="middle">❄</text>
+  <text x="22" y="18" font-size="3" fill="#c8e8ff" opacity="0.4" text-anchor="middle">❄</text>
+  <!-- Frost on stone -->
+  <rect x="2"  y="10" width="8" height="2" rx="0" fill="#b0d8f0" opacity="0.35"/>
+  <rect x="22" y="11" width="8" height="2" rx="0" fill="#b0d8f0" opacity="0.35"/>
+</svg>

--- a/web/public/sprites/lava-moat.svg
+++ b/web/public/sprites/lava-moat.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Stone edges -->
+  <rect x="1" y="10" width="30" height="4" rx="1" fill="#5a3020"/>
+  <rect x="1" y="20" width="30" height="4" rx="1" fill="#5a3020"/>
+  <!-- Lava body -->
+  <rect x="1" y="14" width="30" height="6" fill="#8a1500"/>
+  <rect x="1" y="14" width="30" height="2" fill="#c83000" opacity="0.7"/>
+  <!-- Lava glow patches -->
+  <ellipse cx="8" cy="17" rx="4" ry="1.5" fill="#ff6000" opacity="0.6"/>
+  <ellipse cx="20" cy="16.5" rx="5" ry="1.5" fill="#ff8000" opacity="0.5"/>
+  <!-- Molten ripples -->
+  <path d="M3,16 Q7,15 11,16.5 Q15,18 19,16 Q23,14.5 27,16" stroke="#ff4400" stroke-width="0.9" fill="none" opacity="0.7"/>
+  <!-- Heat shimmer lines -->
+  <line x1="6"  y1="10" x2="5"  y2="7"  stroke="#ff6020" stroke-width="0.5" opacity="0.5"/>
+  <line x1="14" y1="10" x2="15" y2="7"  stroke="#ff6020" stroke-width="0.5" opacity="0.5"/>
+  <line x1="22" y1="10" x2="21" y2="7"  stroke="#ff6020" stroke-width="0.5" opacity="0.5"/>
+  <!-- Rock cracks -->
+  <rect x="4"  y="11" width="6" height="2" rx="0" fill="#3a2010" opacity="0.5"/>
+  <rect x="22" y="11" width="6" height="2" rx="0" fill="#3a2010" opacity="0.5"/>
+</svg>

--- a/web/public/sprites/lightning-rift.svg
+++ b/web/public/sprites/lightning-rift.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Dark stone edges -->
+  <rect x="1" y="10" width="30" height="4" rx="1" fill="#2a2840"/>
+  <rect x="1" y="20" width="30" height="4" rx="1" fill="#2a2840"/>
+  <!-- Void body -->
+  <rect x="1" y="14" width="30" height="6" fill="#08081e"/>
+  <!-- Electric glow at base of rift -->
+  <rect x="1" y="14" width="30" height="2" fill="#2a40ff" opacity="0.25"/>
+  <!-- Lightning bolts -->
+  <polyline points="7,10  5,14  8,14  5,20"  fill="none" stroke="#a0c0ff" stroke-width="1.2" opacity="0.8"/>
+  <polyline points="17,10 15,14 18,14 15,20" fill="none" stroke="#c0d8ff" stroke-width="1"   opacity="0.7"/>
+  <polyline points="27,10 25,14 28,14 25,20" fill="none" stroke="#a0c0ff" stroke-width="1.2" opacity="0.8"/>
+  <!-- Electric arcs -->
+  <path d="M3,16 Q7,15 11,16.5 Q15,18 19,16 Q23,14.5 27,16" stroke="#6080ff" stroke-width="0.6" fill="none" opacity="0.5"/>
+  <!-- Stone glow -->
+  <rect x="3"  y="10" width="6" height="2" rx="0" fill="#3a50cc" opacity="0.3"/>
+  <rect x="22" y="21" width="6" height="2" rx="0" fill="#3a50cc" opacity="0.3"/>
+</svg>

--- a/web/public/sprites/poison-bog.svg
+++ b/web/public/sprites/poison-bog.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Muddy edges -->
+  <rect x="1" y="10" width="30" height="4" rx="1" fill="#3a4a28"/>
+  <rect x="1" y="20" width="30" height="4" rx="1" fill="#3a4a28"/>
+  <!-- Bog body -->
+  <rect x="1" y="14" width="30" height="6" fill="#0e200e"/>
+  <rect x="1" y="14" width="30" height="2" fill="#3a6020" opacity="0.5"/>
+  <!-- Murky ripples -->
+  <path d="M3,17 Q7,16 11,17 Q15,18 19,17 Q23,16 27,17" stroke="#3a8020" stroke-width="0.7" fill="none" opacity="0.5"/>
+  <!-- Algae patches -->
+  <ellipse cx="8"  cy="17" rx="3" ry="1.2" fill="#2a6018" opacity="0.5"/>
+  <ellipse cx="22" cy="17" rx="4" ry="1.5" fill="#2a6018" opacity="0.45"/>
+  <!-- Poison bubbles -->
+  <circle cx="14" cy="16" r="1.2" fill="rgba(100,200,40,0.4)"/>
+  <circle cx="26" cy="18" r="0.9" fill="rgba(100,200,40,0.35)"/>
+  <!-- Exposed roots -->
+  <path d="M4,14 Q5,12 7,11" stroke="#4a3820" stroke-width="0.7" fill="none" opacity="0.6"/>
+  <path d="M28,14 Q27,12 25,11" stroke="#4a3820" stroke-width="0.7" fill="none" opacity="0.6"/>
+</svg>

--- a/web/public/sprites/quicksand.svg
+++ b/web/public/sprites/quicksand.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Sandy edges -->
+  <rect x="1" y="10" width="30" height="4" rx="1" fill="#b8904a"/>
+  <rect x="1" y="20" width="30" height="4" rx="1" fill="#b8904a"/>
+  <!-- Sand body -->
+  <rect x="1" y="14" width="30" height="6" fill="#a07830"/>
+  <rect x="1" y="14" width="30" height="2" fill="#d0aa60" opacity="0.5"/>
+  <!-- Sand ripples / vortex lines -->
+  <ellipse cx="16" cy="17" rx="11" ry="2.5" fill="none" stroke="#c09040" stroke-width="0.8" opacity="0.5"/>
+  <ellipse cx="16" cy="17" rx="7"  ry="1.5" fill="none" stroke="#c09040" stroke-width="0.6" opacity="0.4"/>
+  <ellipse cx="16" cy="17" rx="3"  ry="0.8" fill="#8a6010" opacity="0.4"/>
+  <!-- Sinking indicator (footprint) -->
+  <ellipse cx="10" cy="16.5" rx="1.5" ry="0.8" fill="#7a5820" opacity="0.5"/>
+  <ellipse cx="22" cy="17.5" rx="1.5" ry="0.8" fill="#7a5820" opacity="0.5"/>
+  <!-- Sandy texture -->
+  <rect x="3"  y="11" width="7" height="2" rx="0" fill="#c89a50" opacity="0.4"/>
+  <rect x="22" y="21" width="7" height="2" rx="0" fill="#c89a50" opacity="0.4"/>
+</svg>

--- a/web/public/sprites/shadow-mire.svg
+++ b/web/public/sprites/shadow-mire.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Dark void edges -->
+  <rect x="1" y="10" width="30" height="4" rx="1" fill="#1e1030"/>
+  <rect x="1" y="20" width="30" height="4" rx="1" fill="#1e1030"/>
+  <!-- Shadow void body -->
+  <rect x="1" y="14" width="30" height="6" fill="#080012"/>
+  <rect x="1" y="14" width="30" height="2" fill="#380060" opacity="0.5"/>
+  <!-- Purple ripples -->
+  <path d="M3,17 Q7,16 11,17 Q15,18 19,17 Q23,16 27,17" stroke="#6010a0" stroke-width="0.7" fill="none" opacity="0.5"/>
+  <!-- Shadow orbs -->
+  <circle cx="8"  cy="17" r="2"   fill="#400080" opacity="0.45"/>
+  <circle cx="20" cy="16.5" r="2.5" fill="#300060" opacity="0.4"/>
+  <!-- Void wisps -->
+  <path d="M12,14 Q14,12 16,14 Q18,16 20,14" stroke="#8020c0" stroke-width="0.6" fill="none" opacity="0.4"/>
+  <!-- Faint star in darkness -->
+  <circle cx="25" cy="17" r="0.7" fill="#c080ff" opacity="0.5"/>
+  <circle cx="5"  cy="18" r="0.5" fill="#c080ff" opacity="0.4"/>
+  <!-- Stone seep -->
+  <rect x="3"  y="10" width="6" height="2" rx="0" fill="#3a1860" opacity="0.3"/>
+  <rect x="22" y="21" width="6" height="2" rx="0" fill="#3a1860" opacity="0.3"/>
+</svg>

--- a/web/public/sprites/spike-pit.svg
+++ b/web/public/sprites/spike-pit.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Pit walls -->
+  <rect x="1" y="10" width="30" height="3" rx="1" fill="#5a4a38"/>
+  <rect x="1" y="20" width="30" height="3" rx="1" fill="#5a4a38"/>
+  <!-- Pit floor (dark earth) -->
+  <rect x="1" y="13" width="30" height="7" fill="#2a1a0a"/>
+  <!-- Iron spikes -->
+  <polygon points="5,20  3,13  7,13"  fill="#8a8a8a" stroke="#4a4a4a" stroke-width="0.4"/>
+  <polygon points="11,20 9,13  13,13" fill="#9a9a9a" stroke="#4a4a4a" stroke-width="0.4"/>
+  <polygon points="17,20 15,13 19,13" fill="#8a8a8a" stroke="#4a4a4a" stroke-width="0.4"/>
+  <polygon points="23,20 21,13 25,13" fill="#9a9a9a" stroke="#4a4a4a" stroke-width="0.4"/>
+  <polygon points="29,20 27,13 31,13" fill="#8a8a8a" stroke="#4a4a4a" stroke-width="0.4"/>
+  <!-- Blood stains on spikes -->
+  <ellipse cx="5"  cy="19" rx="1.5" ry="0.8" fill="#800020" opacity="0.6"/>
+  <ellipse cx="17" cy="19" rx="1.5" ry="0.8" fill="#800020" opacity="0.5"/>
+  <!-- Pit edge stones -->
+  <rect x="2"  y="10" width="8" height="2" rx="0" fill="#4a3a28" opacity="0.5"/>
+  <rect x="22" y="10" width="8" height="2" rx="0" fill="#4a3a28" opacity="0.5"/>
+</svg>

--- a/web/public/sprites/tar-pit.svg
+++ b/web/public/sprites/tar-pit.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Stone edges -->
+  <rect x="1" y="10" width="30" height="4" rx="1" fill="#3a3028"/>
+  <rect x="1" y="20" width="30" height="4" rx="1" fill="#3a3028"/>
+  <!-- Tar body (near-black) -->
+  <rect x="1" y="14" width="30" height="6" fill="#0a0808"/>
+  <!-- Tar sheen -->
+  <ellipse cx="10" cy="16.5" rx="5" ry="1.5" fill="#1e1a14" opacity="0.7"/>
+  <ellipse cx="23" cy="17"   rx="4" ry="1.2" fill="#1e1a14" opacity="0.6"/>
+  <!-- Slow ripples (barely visible) -->
+  <path d="M4,17 Q8,16.5 12,17 Q16,17.5 20,17 Q24,16.5 28,17" stroke="#2a2218" stroke-width="0.6" fill="none"/>
+  <!-- Bubble -->
+  <circle cx="15" cy="15.5" r="1" fill="#1a1510" stroke="#3a3020" stroke-width="0.4" opacity="0.7"/>
+  <circle cx="22" cy="18"   r="0.7" fill="#1a1510" opacity="0.6"/>
+  <!-- Stone texture -->
+  <rect x="3"  y="11" width="7" height="2" rx="0" fill="#2a2820" opacity="0.5"/>
+  <rect x="22" y="21" width="7" height="2" rx="0" fill="#2a2820" opacity="0.5"/>
+</svg>

--- a/web/src/components/Battlefield.tsx
+++ b/web/src/components/Battlefield.tsx
@@ -55,22 +55,194 @@ interface Props {
 const SPAWN_GROW_MS = 1500
 
 // ─── Moat graphic ────────────────────────────────────────────────────────────
-// Full-width water channel rendered in place of the sprite for moat units.
+// Full-width terrain channel rendered in place of the sprite for moat units.
+// Each variant has distinct colours and detail elements.
 
-function MoatSvg({ owner }: { owner: 'player' | 'opponent' }) {
+function MoatSvg({ owner, name }: { owner: 'player' | 'opponent'; name: string }) {
+  const W = 360, H = 16
+  const edgeCol = 'rgba(0,0,0,0.55)'
+  const rippleXs = [20, 65, 110, 155, 200, 245, 290, 335]
+
+  // ── Lava Moat ─────────────────────────────────────────────────────────────
+  if (name === 'Lava Moat') {
+    return (
+      <div style={{ display:'block', width:'100%', height: H }}>
+        <svg width="100%" height={H} viewBox={`0 0 ${W} ${H}`} preserveAspectRatio="none" style={{ display:'block' }} xmlns="http://www.w3.org/2000/svg">
+          <rect x="0" y="0" width={W} height={H} fill="#6a1000"/>
+          <rect x="0" y="2" width={W} height="12" fill="#c83000" opacity="0.7"/>
+          {rippleXs.map((x, i) => <ellipse key={i} cx={x} cy="8" rx="20" ry="3" fill="none" stroke="rgba(255,180,0,0.45)" strokeWidth="1"/>)}
+          {[40, 120, 200, 280].map((x, i) => <ellipse key={i} cx={x} cy="8" rx="8" ry="4" fill="#ff6a00" opacity="0.5"/>)}
+          <rect x="0" y="0"  width={W} height="2" fill={edgeCol}/>
+          <rect x="0" y={H-2} width={W} height="2" fill={edgeCol}/>
+        </svg>
+      </div>
+    )
+  }
+
+  // ── Acid Moat ─────────────────────────────────────────────────────────────
+  if (name === 'Acid Moat') {
+    return (
+      <div style={{ display:'block', width:'100%', height: H }}>
+        <svg width="100%" height={H} viewBox={`0 0 ${W} ${H}`} preserveAspectRatio="none" style={{ display:'block' }} xmlns="http://www.w3.org/2000/svg">
+          <rect x="0" y="0" width={W} height={H} fill="#1a3a00"/>
+          <rect x="0" y="2" width={W} height="12" fill="#4aaa00" opacity="0.6"/>
+          {rippleXs.map((x, i) => <ellipse key={i} cx={x} cy="8" rx="20" ry="3" fill="none" stroke="rgba(150,255,50,0.4)" strokeWidth="0.9"/>)}
+          {[55, 135, 215, 300].map((x, i) => <circle key={i} cx={x} cy="6" r="3" fill="rgba(180,255,0,0.5)"/>)}
+          <rect x="0" y="0"  width={W} height="2" fill={edgeCol}/>
+          <rect x="0" y={H-2} width={W} height="2" fill={edgeCol}/>
+        </svg>
+      </div>
+    )
+  }
+
+  // ── Spike Pit ─────────────────────────────────────────────────────────────
+  if (name === 'Spike Pit') {
+    const spikePts = (cx: number) => `${cx},2 ${cx-4},14 ${cx},10 ${cx+4},14`
+    return (
+      <div style={{ display:'block', width:'100%', height: H }}>
+        <svg width="100%" height={H} viewBox={`0 0 ${W} ${H}`} preserveAspectRatio="none" style={{ display:'block' }} xmlns="http://www.w3.org/2000/svg">
+          <rect x="0" y="0" width={W} height={H} fill="#2a1a0a"/>
+          <rect x="0" y="10" width={W} height="6" fill="#3a2a18" opacity="0.9"/>
+          {[30, 75, 120, 165, 210, 255, 300, 345].map((x, i) => (
+            <polygon key={i} points={spikePts(x)} fill="#8a8a8a" stroke="#4a4a4a" strokeWidth="0.5"/>
+          ))}
+          <rect x="0" y="0"  width={W} height="2" fill={edgeCol}/>
+          <rect x="0" y={H-2} width={W} height="2" fill={edgeCol}/>
+        </svg>
+      </div>
+    )
+  }
+
+  // ── Tar Pit ───────────────────────────────────────────────────────────────
+  if (name === 'Tar Pit') {
+    return (
+      <div style={{ display:'block', width:'100%', height: H }}>
+        <svg width="100%" height={H} viewBox={`0 0 ${W} ${H}`} preserveAspectRatio="none" style={{ display:'block' }} xmlns="http://www.w3.org/2000/svg">
+          <rect x="0" y="0" width={W} height={H} fill="#0a0808"/>
+          <rect x="0" y="2" width={W} height="12" fill="#1a1212" opacity="0.85"/>
+          {rippleXs.map((x, i) => <ellipse key={i} cx={x} cy="8" rx="18" ry="2.5" fill="none" stroke="rgba(80,60,40,0.5)" strokeWidth="0.8"/>)}
+          {[90, 180, 270].map((x, i) => <circle key={i} cx={x} cy="7" r="4" fill="rgba(30,20,10,0.8)" stroke="rgba(60,40,20,0.4)" strokeWidth="0.5"/>)}
+          <rect x="0" y="0"  width={W} height="2" fill={edgeCol}/>
+          <rect x="0" y={H-2} width={W} height="2" fill={edgeCol}/>
+        </svg>
+      </div>
+    )
+  }
+
+  // ── Frost Moat ────────────────────────────────────────────────────────────
+  if (name === 'Frost Moat') {
+    return (
+      <div style={{ display:'block', width:'100%', height: H }}>
+        <svg width="100%" height={H} viewBox={`0 0 ${W} ${H}`} preserveAspectRatio="none" style={{ display:'block' }} xmlns="http://www.w3.org/2000/svg">
+          <rect x="0" y="0" width={W} height={H} fill="#0a2040"/>
+          <rect x="0" y="2" width={W} height="12" fill="#3080b0" opacity="0.55"/>
+          <rect x="0" y="0" width={W} height="5" fill="#c8e8ff" opacity="0.3"/>
+          {rippleXs.map((x, i) => <ellipse key={i} cx={x} cy="8" rx="20" ry="3" fill="none" stroke="rgba(200,240,255,0.45)" strokeWidth="0.9"/>)}
+          {[50, 150, 250, 350].map((x, i) => <polygon key={i} points={`${x},4 ${x-3},9 ${x},7 ${x+3},9`} fill="rgba(200,240,255,0.55)"/>)}
+          <rect x="0" y="0"  width={W} height="2" fill={edgeCol}/>
+          <rect x="0" y={H-2} width={W} height="2" fill={edgeCol}/>
+        </svg>
+      </div>
+    )
+  }
+
+  // ── Poison Bog ────────────────────────────────────────────────────────────
+  if (name === 'Poison Bog') {
+    return (
+      <div style={{ display:'block', width:'100%', height: H }}>
+        <svg width="100%" height={H} viewBox={`0 0 ${W} ${H}`} preserveAspectRatio="none" style={{ display:'block' }} xmlns="http://www.w3.org/2000/svg">
+          <rect x="0" y="0" width={W} height={H} fill="#0e200e"/>
+          <rect x="0" y="2" width={W} height="12" fill="#2a5020" opacity="0.7"/>
+          {rippleXs.map((x, i) => <ellipse key={i} cx={x} cy="8" rx="18" ry="2.5" fill="none" stroke="rgba(100,200,50,0.3)" strokeWidth="0.8"/>)}
+          {[45, 130, 210, 295].map((x, i) => <ellipse key={i} cx={x} cy="7" rx="6" ry="3" fill="rgba(60,150,20,0.45)"/>)}
+          {[80, 185, 275].map((x, i) => <circle key={i} cx={x} cy="9" r="2" fill="rgba(160,255,80,0.35)"/>)}
+          <rect x="0" y="0"  width={W} height="2" fill={edgeCol}/>
+          <rect x="0" y={H-2} width={W} height="2" fill={edgeCol}/>
+        </svg>
+      </div>
+    )
+  }
+
+  // ── Lightning Rift ────────────────────────────────────────────────────────
+  if (name === 'Lightning Rift') {
+    return (
+      <div style={{ display:'block', width:'100%', height: H }}>
+        <svg width="100%" height={H} viewBox={`0 0 ${W} ${H}`} preserveAspectRatio="none" style={{ display:'block' }} xmlns="http://www.w3.org/2000/svg">
+          <rect x="0" y="0" width={W} height={H} fill="#0a0a30"/>
+          <rect x="0" y="2" width={W} height="12" fill="#1a1a60" opacity="0.7"/>
+          {[40, 120, 200, 280].map((x, i) => (
+            <polyline key={i} points={`${x},2 ${x-5},7 ${x+3},7 ${x-3},14`} fill="none" stroke="rgba(180,200,255,0.7)" strokeWidth="1.2"/>
+          ))}
+          {rippleXs.map((x, i) => <ellipse key={i} cx={x} cy="8" rx="18" ry="2.5" fill="none" stroke="rgba(100,120,255,0.35)" strokeWidth="0.8"/>)}
+          <rect x="0" y="0"  width={W} height="2" fill={edgeCol}/>
+          <rect x="0" y={H-2} width={W} height="2" fill={edgeCol}/>
+        </svg>
+      </div>
+    )
+  }
+
+  // ── Quicksand ─────────────────────────────────────────────────────────────
+  if (name === 'Quicksand') {
+    return (
+      <div style={{ display:'block', width:'100%', height: H }}>
+        <svg width="100%" height={H} viewBox={`0 0 ${W} ${H}`} preserveAspectRatio="none" style={{ display:'block' }} xmlns="http://www.w3.org/2000/svg">
+          <rect x="0" y="0" width={W} height={H} fill="#a08040"/>
+          <rect x="0" y="2" width={W} height="12" fill="#c8a850" opacity="0.6"/>
+          {rippleXs.map((x, i) => <ellipse key={i} cx={x} cy="8" rx="20" ry="3" fill="none" stroke="rgba(200,160,80,0.4)" strokeWidth="0.9"/>)}
+          {[60, 160, 260].map((x, i) => <ellipse key={i} cx={x} cy="9" rx="9" ry="4" fill="rgba(140,100,30,0.45)"/>)}
+          <rect x="0" y="0"  width={W} height="2" fill={edgeCol}/>
+          <rect x="0" y={H-2} width={W} height="2" fill={edgeCol}/>
+        </svg>
+      </div>
+    )
+  }
+
+  // ── Blood Pool ────────────────────────────────────────────────────────────
+  if (name === 'Blood Pool') {
+    return (
+      <div style={{ display:'block', width:'100%', height: H }}>
+        <svg width="100%" height={H} viewBox={`0 0 ${W} ${H}`} preserveAspectRatio="none" style={{ display:'block' }} xmlns="http://www.w3.org/2000/svg">
+          <rect x="0" y="0" width={W} height={H} fill="#3a0010"/>
+          <rect x="0" y="2" width={W} height="12" fill="#800020" opacity="0.75"/>
+          {rippleXs.map((x, i) => <ellipse key={i} cx={x} cy="8" rx="20" ry="3" fill="none" stroke="rgba(200,0,40,0.35)" strokeWidth="0.8"/>)}
+          {[70, 170, 270].map((x, i) => <ellipse key={i} cx={x} cy="8" rx="7" ry="3.5" fill="rgba(180,0,30,0.45)"/>)}
+          <rect x="0" y="0"  width={W} height="2" fill={edgeCol}/>
+          <rect x="0" y={H-2} width={W} height="2" fill={edgeCol}/>
+        </svg>
+      </div>
+    )
+  }
+
+  // ── Shadow Mire ───────────────────────────────────────────────────────────
+  if (name === 'Shadow Mire') {
+    return (
+      <div style={{ display:'block', width:'100%', height: H }}>
+        <svg width="100%" height={H} viewBox={`0 0 ${W} ${H}`} preserveAspectRatio="none" style={{ display:'block' }} xmlns="http://www.w3.org/2000/svg">
+          <rect x="0" y="0" width={W} height={H} fill="#0a0018"/>
+          <rect x="0" y="2" width={W} height="12" fill="#280050" opacity="0.7"/>
+          {rippleXs.map((x, i) => <ellipse key={i} cx={x} cy="8" rx="20" ry="3" fill="none" stroke="rgba(160,80,255,0.35)" strokeWidth="0.9"/>)}
+          {[50, 150, 250, 320].map((x, i) => <circle key={i} cx={x} cy="7" r="3" fill="rgba(120,0,200,0.4)"/>)}
+          <rect x="0" y="0"  width={W} height="2" fill={edgeCol}/>
+          <rect x="0" y={H-2} width={W} height="2" fill={edgeCol}/>
+        </svg>
+      </div>
+    )
+  }
+
+  // ── Default water moat ────────────────────────────────────────────────────
   const deep = owner === 'player' ? '#1a4a68' : '#1a3050'
   const mid  = owner === 'player' ? '#2a6888' : '#243858'
   return (
-    <div style={{ display: 'block', width: '100%', height: 16 }}>
-      <svg width="100%" height="16" viewBox="0 0 360 16" preserveAspectRatio="none"
+    <div style={{ display: 'block', width: '100%', height: H }}>
+      <svg width="100%" height={H} viewBox={`0 0 ${W} ${H}`} preserveAspectRatio="none"
         style={{ display: 'block' }} xmlns="http://www.w3.org/2000/svg">
-        <rect x="0" y="0" width="360" height="16" fill={deep} opacity="0.9"/>
-        <rect x="0" y="2" width="360" height="12" fill={mid} opacity="0.6"/>
-        {[20, 65, 110, 155, 200, 245, 290, 335].map((x, i) => (
+        <rect x="0" y="0" width={W} height={H} fill={deep} opacity="0.9"/>
+        <rect x="0" y="2" width={W} height="12" fill={mid} opacity="0.6"/>
+        {rippleXs.map((x, i) => (
           <ellipse key={i} cx={x} cy="8" rx="22" ry="3" fill="none" stroke="rgba(120,210,255,0.35)" strokeWidth="0.9"/>
         ))}
-        <rect x="0" y="0"  width="360" height="2" fill="rgba(0,0,0,0.5)"/>
-        <rect x="0" y="14" width="360" height="2" fill="rgba(0,0,0,0.5)"/>
+        <rect x="0" y="0"  width={W} height="2" fill={edgeCol}/>
+        <rect x="0" y={H-2} width={W} height="2" fill={edgeCol}/>
       </svg>
     </div>
   )
@@ -296,7 +468,7 @@ function LaneUnit({ unit, stackIndex = 0, wallStack, onInspect, showName, celebr
         </div>
       )}
       {unit.isMoat
-        ? <MoatSvg owner={unit.owner} />
+        ? <MoatSvg owner={unit.owner} name={unit.name} />
         : unit.isWall
           ? <WallSvg hp={unit.hp} maxHp={unit.maxHp} owner={unit.owner} wallNames={(wallStack ?? [unit]).map(w => w.name)} />
           : isStructure

--- a/web/src/data/cards.json
+++ b/web/src/data/cards.json
@@ -13686,6 +13686,273 @@
       "deckCount": 0
     },
     {
+      "name": "Lava Moat",
+      "rarity": "rare",
+      "cost": 3,
+      "cardType": "structure",
+      "tags": ["fire"],
+      "unit": {
+        "name": "Lava Moat",
+        "attack": 0,
+        "maxHp": 9999,
+        "isWall": false,
+        "bypassWall": false,
+        "moveSpeed": 0,
+        "attackRange": 0,
+        "attackCooldownMs": 0,
+        "structureEffect": {
+          "type": "slowZone",
+          "slowFactor": 0.35,
+          "radius": 28,
+          "damagePerSec": 15
+        },
+        "isMoat": true
+      },
+      "description": "River of molten rock \u2014 slows enemies and burns them for 15 damage/s. Cannot be destroyed.",
+      "lore": "The screaming gets quieter as the lava deepens.",
+      "deckCount": 0
+    },
+    {
+      "name": "Acid Moat",
+      "rarity": "uncommon",
+      "cost": 2,
+      "cardType": "structure",
+      "tags": ["iron"],
+      "unit": {
+        "name": "Acid Moat",
+        "attack": 0,
+        "maxHp": 9999,
+        "isWall": false,
+        "bypassWall": false,
+        "moveSpeed": 0,
+        "attackRange": 0,
+        "attackCooldownMs": 0,
+        "structureEffect": {
+          "type": "slowZone",
+          "slowFactor": 0.45,
+          "radius": 26,
+          "damagePerSec": 8
+        },
+        "isMoat": true
+      },
+      "description": "Corrosive channel \u2014 slows and deals 8 damage/s to crossing units. Cannot be destroyed.",
+      "lore": "Armour is merely seasoning.",
+      "deckCount": 0
+    },
+    {
+      "name": "Spike Pit",
+      "rarity": "uncommon",
+      "cost": 2,
+      "cardType": "structure",
+      "tags": ["iron"],
+      "unit": {
+        "name": "Spike Pit",
+        "attack": 0,
+        "maxHp": 9999,
+        "isWall": false,
+        "bypassWall": false,
+        "moveSpeed": 0,
+        "attackRange": 0,
+        "attackCooldownMs": 0,
+        "structureEffect": {
+          "type": "slowZone",
+          "slowFactor": 0.5,
+          "radius": 24,
+          "damagePerSec": 12
+        },
+        "isMoat": true
+      },
+      "description": "Pit of iron spikes \u2014 slows and impales crossing units for 12 damage/s. Cannot be destroyed.",
+      "lore": "Every step a decision. Most of them bad.",
+      "deckCount": 0
+    },
+    {
+      "name": "Tar Pit",
+      "rarity": "uncommon",
+      "cost": 2,
+      "cardType": "structure",
+      "tags": ["iron"],
+      "unit": {
+        "name": "Tar Pit",
+        "attack": 0,
+        "maxHp": 9999,
+        "isWall": false,
+        "bypassWall": false,
+        "moveSpeed": 0,
+        "attackRange": 0,
+        "attackCooldownMs": 0,
+        "structureEffect": {
+          "type": "slowZone",
+          "slowFactor": 0.2,
+          "radius": 30
+        },
+        "isMoat": true
+      },
+      "description": "Thick black tar \u2014 dramatically slows all units that cross it. Cannot be destroyed.",
+      "lore": "Armies have been lost here. Most of them still are.",
+      "deckCount": 0
+    },
+    {
+      "name": "Frost Moat",
+      "rarity": "rare",
+      "cost": 3,
+      "cardType": "structure",
+      "tags": ["iron"],
+      "unit": {
+        "name": "Frost Moat",
+        "attack": 0,
+        "maxHp": 9999,
+        "isWall": false,
+        "bypassWall": false,
+        "moveSpeed": 0,
+        "attackRange": 0,
+        "attackCooldownMs": 0,
+        "structureEffect": {
+          "type": "slowZone",
+          "slowFactor": 0.25,
+          "radius": 28,
+          "damagePerSec": 4
+        },
+        "isMoat": true
+      },
+      "description": "Frozen channel \u2014 severely slows enemies and freezes them for 4 damage/s. Cannot be destroyed.",
+      "lore": "The cold doesn't kill. It just makes you wish it would.",
+      "deckCount": 0
+    },
+    {
+      "name": "Poison Bog",
+      "rarity": "uncommon",
+      "cost": 2,
+      "cardType": "structure",
+      "tags": ["iron"],
+      "unit": {
+        "name": "Poison Bog",
+        "attack": 0,
+        "maxHp": 9999,
+        "isWall": false,
+        "bypassWall": false,
+        "moveSpeed": 0,
+        "attackRange": 0,
+        "attackCooldownMs": 0,
+        "structureEffect": {
+          "type": "slowZone",
+          "slowFactor": 0.4,
+          "radius": 26,
+          "damagePerSec": 6
+        },
+        "isMoat": true
+      },
+      "description": "Murky poisonous swamp \u2014 slows and poisons crossing units for 6 damage/s. Cannot be destroyed.",
+      "lore": "The bubbles are from the bodies below.",
+      "deckCount": 0
+    },
+    {
+      "name": "Lightning Rift",
+      "rarity": "rare",
+      "cost": 3,
+      "cardType": "structure",
+      "tags": ["iron"],
+      "unit": {
+        "name": "Lightning Rift",
+        "attack": 0,
+        "maxHp": 9999,
+        "isWall": false,
+        "bypassWall": false,
+        "moveSpeed": 0,
+        "attackRange": 0,
+        "attackCooldownMs": 0,
+        "structureEffect": {
+          "type": "slowZone",
+          "slowFactor": 0.45,
+          "radius": 26,
+          "damagePerSec": 10
+        },
+        "isMoat": true
+      },
+      "description": "Crackling chasm of electricity \u2014 slows and shocks crossing units for 10 damage/s. Cannot be destroyed.",
+      "lore": "You can hear it from a mile away. You can smell it from two.",
+      "deckCount": 0
+    },
+    {
+      "name": "Quicksand",
+      "rarity": "common",
+      "cost": 1,
+      "cardType": "structure",
+      "tags": ["iron"],
+      "unit": {
+        "name": "Quicksand",
+        "attack": 0,
+        "maxHp": 9999,
+        "isWall": false,
+        "bypassWall": false,
+        "moveSpeed": 0,
+        "attackRange": 0,
+        "attackCooldownMs": 0,
+        "structureEffect": {
+          "type": "slowZone",
+          "slowFactor": 0.15,
+          "radius": 28
+        },
+        "isMoat": true
+      },
+      "description": "Treacherous sand trap \u2014 nearly halts all units that cross it. Cannot be destroyed.",
+      "lore": "Fighting it only makes it worse.",
+      "deckCount": 0
+    },
+    {
+      "name": "Blood Pool",
+      "rarity": "uncommon",
+      "cost": 2,
+      "cardType": "structure",
+      "tags": ["iron"],
+      "unit": {
+        "name": "Blood Pool",
+        "attack": 0,
+        "maxHp": 9999,
+        "isWall": false,
+        "bypassWall": false,
+        "moveSpeed": 0,
+        "attackRange": 0,
+        "attackCooldownMs": 0,
+        "structureEffect": {
+          "type": "slowZone",
+          "slowFactor": 0.35,
+          "radius": 28,
+          "damagePerSec": 5
+        },
+        "isMoat": true
+      },
+      "description": "Grim pool of blood \u2014 slows and drains crossing units for 5 damage/s. Cannot be destroyed.",
+      "lore": "Nobody ever asks whose blood it is.",
+      "deckCount": 0
+    },
+    {
+      "name": "Shadow Mire",
+      "rarity": "uncommon",
+      "cost": 2,
+      "cardType": "structure",
+      "tags": ["iron"],
+      "unit": {
+        "name": "Shadow Mire",
+        "attack": 0,
+        "maxHp": 9999,
+        "isWall": false,
+        "bypassWall": false,
+        "moveSpeed": 0,
+        "attackRange": 0,
+        "attackCooldownMs": 0,
+        "structureEffect": {
+          "type": "slowZone",
+          "slowFactor": 0.3,
+          "radius": 30
+        },
+        "isMoat": true
+      },
+      "description": "Void of shadow \u2014 heavily slows all units that cross it. Cannot be destroyed.",
+      "lore": "Where shadows pool, so does dread.",
+      "deckCount": 0
+    },
+    {
       "name": "Battle Hardened",
       "rarity": "uncommon",
       "cost": 1,

--- a/web/src/game/engine/cards.ts
+++ b/web/src/game/engine/cards.ts
@@ -19,15 +19,21 @@ export function deployCard(s: GameState, card: Card, owner: 'player' | 'opponent
       if (existing) {
         // Moat: indestructible — upgrade widens and deepens the slow zone instead of doubling HP
         if (existing.isMoat) {
-          const effect = existing.structureEffect as { type: 'slowZone'; slowFactor: number; radius: number } | undefined
+          const effect = existing.structureEffect as { type: 'slowZone'; slowFactor: number; radius: number; damagePerSec?: number } | undefined
           if (effect?.type === 'slowZone') {
             const oldRadius = effect.radius
-            effect.radius      = Math.round(effect.radius * 1.5)
-            effect.slowFactor  = Math.max(0.15, parseFloat((effect.slowFactor - 0.05).toFixed(2)))
+            effect.radius     = Math.round(effect.radius * 1.5)
+            effect.slowFactor = Math.max(0.15, parseFloat((effect.slowFactor - 0.05).toFixed(2)))
             existing.upgradeLevel = (existing.upgradeLevel ?? 1) + 1
             const pct = Math.round(effect.slowFactor * 100)
             const who = owner === 'player' ? 'You' : 'Opponent'
-            log.push(`${who} upgraded ${existing.name}! (${oldRadius}→${effect.radius}px wide, slows to ${pct}% speed)`)
+            let note = `${oldRadius}→${effect.radius}px wide, slows to ${pct}% speed`
+            if (effect.damagePerSec) {
+              const oldDmg = effect.damagePerSec
+              effect.damagePerSec = Math.round(effect.damagePerSec * 1.35)
+              note += `, dmg ${oldDmg}→${effect.damagePerSec}/s`
+            }
+            log.push(`${who} upgraded ${existing.name}! (${note})`)
             if (owner === 'player') playUpgrade()
           }
           return

--- a/web/src/game/engine/units.ts
+++ b/web/src/game/engine/units.ts
@@ -227,16 +227,25 @@ export function moveUnits(s: GameState, deltaMs: number): void {
     const inWallZone = unit.climber && s.field.some(w =>
       w.isWall && w.owner !== unit.owner && w.hp > 0 && Math.abs(unit.x - w.x) <= WALL_CLIMB_ZONE
     )
-    const moatSlowFactor = unit.flying ? 1 : s.field.reduce((factor, m) => {
-      if (!m.isMoat) return factor
-      const effect = m.structureEffect as { type: 'slowZone'; slowFactor: number; radius: number } | undefined
-      if (!effect || effect.type !== 'slowZone') return factor
-      if (Math.abs(unit.x - m.x) <= effect.radius) {
-        if (unit.tags?.includes('swim')) return 1.25  // swim bonus: cross moat faster
-        return Math.min(factor, effect.slowFactor)
+    let moatSlowFactor = 1
+    if (!unit.flying) {
+      for (const m of s.field) {
+        if (!m.isMoat) continue
+        const effect = m.structureEffect as { type: 'slowZone'; slowFactor: number; radius: number; damagePerSec?: number } | undefined
+        if (!effect || effect.type !== 'slowZone') continue
+        if (Math.abs(unit.x - m.x) <= effect.radius) {
+          if (unit.tags?.includes('swim')) {
+            moatSlowFactor = Math.max(moatSlowFactor, 1.25)
+          } else {
+            moatSlowFactor = Math.min(moatSlowFactor, effect.slowFactor)
+          }
+          if (effect.damagePerSec && unit.hp > 0) {
+            unit.hp = Math.max(0, unit.hp - effect.damagePerSec * deltaSec)
+            if (unit.damageFlashTimer == null || unit.damageFlashTimer <= 0) unit.damageFlashTimer = 80
+          }
+        }
       }
-      return factor
-    }, 1)
+    }
     // Moat never halts a unit: effective speed stays ≥ 1 px/s
     const clampedMoatFactor = unit.moveSpeed > 0
       ? Math.max(moatSlowFactor, 1 / unit.moveSpeed)

--- a/web/src/game/types.ts
+++ b/web/src/game/types.ts
@@ -22,7 +22,7 @@ export type StructureEffect =
   | { type: 'healAura'; amount: number; intervalMs: number }
   | { type: 'repairAura'; amount: number; intervalMs: number }
   | { type: 'attackAura'; amount: number }
-  | { type: 'slowZone'; slowFactor: number; radius: number }
+  | { type: 'slowZone'; slowFactor: number; radius: number; damagePerSec?: number }
 
 export type UpgradeEffect =
   | { type: 'buffAttack'; amount: number }


### PR DESCRIPTION
## Summary

- Adds 10 new moat-type structure cards, each with distinct gameplay and visuals
- Extends the `slowZone` StructureEffect with an optional `damagePerSec` field — damaging moats tick damage onto any unit crossing them
- `MoatSvg` in Battlefield.tsx now renders a unique inline SVG per variant (colour palette, detail elements: lava glow, acid bubbles, iron spikes, tar sheen, ice cracks, murky algae, lightning bolts, sand vortex, blood clots, shadow orbs)
- Moat upgrades now also scale `damagePerSec` ×1.35 per level in addition to widening radius and deepening slow
- 10 new card-art SVG sprites added to `public/sprites/`

### New cards

| Card | Cost | Rarity | Slow | Damage/s |
|---|---|---|---|---|
| Lava Moat | 3 | Rare | 35% speed | 15 |
| Acid Moat | 2 | Uncommon | 45% speed | 8 |
| Spike Pit | 2 | Uncommon | 50% speed | 12 |
| Tar Pit | 2 | Uncommon | 20% speed | — |
| Frost Moat | 3 | Rare | 25% speed | 4 |
| Poison Bog | 2 | Uncommon | 40% speed | 6 |
| Lightning Rift | 3 | Rare | 45% speed | 10 |
| Quicksand | 1 | Common | 15% speed | — |
| Blood Pool | 2 | Uncommon | 35% speed | 5 |
| Shadow Mire | 2 | Uncommon | 30% speed | — |

Flying units bypass both the slow and the damage (unchanged from existing moat behaviour).

## Test plan

- [ ] Play each new moat card and confirm the correct coloured channel appears on the field
- [ ] Verify enemy units crossing a damaging moat (e.g. Lava Moat) lose HP while traversing
- [ ] Verify flying units cross undamaged and at full speed
- [ ] Upgrade a damaging moat to level 2 and confirm the log shows updated damage/s
- [ ] Confirm Quicksand / Tar Pit / Shadow Mire (no damage) do not flash units
- [ ] Check card art thumbnails display for all 10 new cards in the hand

https://claude.ai/code/session_01FFXw8rUxBVQRtJK8x762WJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01FFXw8rUxBVQRtJK8x762WJ)_