### PR TITLE
feat(rarities): secret rarities — mythic, shiny, holofoil, glass (1/10,000)

### DIFF
--- a/web/src/components/Battlefield.tsx
+++ b/web/src/components/Battlefield.tsx
@@ -434,6 +434,7 @@ function LaneUnit({ unit, stackIndex = 0, wallStack, onInspect, showName, celebr
         unit.size ? `lane-unit--size-${unit.size}` : '',
         isCelebrating ? 'lane-unit--celebrating' : '',
         unit.invisTimer != null && unit.invisTimer > 0 ? 'lane-unit--invisible' : '',
+        unit.cardVariant ? `lane-unit--variant-${unit.cardVariant}` : '',
       ].filter(Boolean).join(' ')}
       style={isCelebrating ? { ...style, animationDelay: `${(unit.id.charCodeAt(0) % 7) * 0.1}s` } : style}
       title={`${unit.name} — ${unit.hp}/${unit.maxHp} HP, ${unit.attack} ATK`}

--- a/web/src/components/CardDetailModal.tsx
+++ b/web/src/components/CardDetailModal.tsx
@@ -33,6 +33,10 @@ const RARITY_COLOUR: Record<string, string> = {
   rare:      '#bb66ff',
   epic:      '#ff8800',
   legendary: '#ffcc00',
+  mythic:    '#e040fb',
+  shiny:     '#ffe066',
+  holofoil:  '#40e0d0',
+  glass:     '#a0d8ef',
 }
 
 
@@ -90,7 +94,7 @@ export function CardDetailModal({ card, collection, deckEntries, onClose, extras
         <div className="cdm-header">
           <span className="cdm-name" style={{ color: rarityCol }}>{card.name}</span>
           <span className="cdm-rarity" style={{ color: rarityCol }}>
-            {'★'.repeat({ common: 1, uncommon: 2, rare: 3, epic: 4, legendary: 5 }[card.rarity])}
+            {'★'.repeat(({ common: 1, uncommon: 2, rare: 3, epic: 4, legendary: 5, mythic: 6, shiny: 4, holofoil: 4, glass: 4 } as Record<string,number>)[card.rarity] ?? 1)}
             {' '}{card.rarity.toUpperCase()}
           </span>
           <button className="cdm-close" onClick={onClose}>✕</button>

--- a/web/src/components/CardTile.tsx
+++ b/web/src/components/CardTile.tsx
@@ -156,6 +156,9 @@ export function CardTile({ card, canAfford = true, disabled = false, onClick, lo
     stats = ''
   }
 
+  const isSecret = card.rarity === 'mythic' || card.rarity === 'shiny' || card.rarity === 'holofoil' || card.rarity === 'glass'
+  const secretLabel: Record<string, string> = { mythic: 'MYTHIC', shiny: 'SHINY', holofoil: 'HOLO', glass: 'GLASS' }
+
   return (
     <div
       className={[
@@ -166,13 +169,21 @@ export function CardTile({ card, canAfford = true, disabled = false, onClick, lo
       onClick={clickable ? onClick : undefined}
       title={heroLocked ? `Hero cards unlock after 30 seconds (${lockedSecs}s remaining)` : card.description}
     >
+      {isSecret && (
+        <div className={`card-secret-badge card-secret-badge--${card.rarity}`}>
+          {secretLabel[card.rarity]}
+        </div>
+      )}
+      {card.rarity === 'glass' && card.glassBreakChance && (
+        <div className="card-glass-warning" title={`${Math.round(card.glassBreakChance * 100)}% chance to shatter on play`}>💎</div>
+      )}
       {card.isHero && <>
-      
+
 
         <div className="hero-badge-wrap">
          <span className="hero-badge">HERO</span>
         </div>
-      </>}     
+      </>}
 
 
 

--- a/web/src/components/CollectionScreen.tsx
+++ b/web/src/components/CollectionScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react'
-import { Card, CardRarity, CardType, UnitTag } from '../game/types'
+import { Card, CardRarity, CardType, UnitTag, SECRET_RARITIES } from '../game/types'
 import { getCardCatalog, getCardThemeTags } from '../game/cards'
 import {
   loadCollection,
@@ -121,6 +121,8 @@ export function CollectionScreen({ crystals, onCrystalsChanged, onBack, commande
   const totalUpgradeable = collection.reduce((s, e) => s + (Math.max(0, e.count - COPIES_MAX) > 0 ? 1 : 0), 0)
 
   const filtered = catalog.filter(c => {
+    // Secret rarities are hidden until the player has obtained at least one copy
+    if (SECRET_RARITIES.has(c.rarity) && getOwnedCount(collection, c.name) === 0) return false
     if (typeFilter   !== 'all' && c.cardType !== typeFilter)   return false
     if (rarityFilter !== 'all' && c.rarity   !== rarityFilter) return false
     if (specialFilter === 'upgradeable') {
@@ -138,7 +140,7 @@ export function CollectionScreen({ crystals, onCrystalsChanged, onBack, commande
     return true
   })
 
-  const RARITY_ORDER: Record<CardRarity, number> = { common: 0, uncommon: 1, rare: 2, epic: 3, legendary: 4 }
+  const RARITY_ORDER: Record<CardRarity, number> = { common: 0, uncommon: 1, rare: 2, epic: 3, legendary: 4, mythic: 5, shiny: 6, holofoil: 7, glass: 8 }
   const TYPE_ORDER: Record<CardType, number>     = { unit: 0, structure: 1, upgrade: 2 }
 
   // Default sort: spawn buildings appear immediately after the unit they spawn.

--- a/web/src/components/DeckBuilder.tsx
+++ b/web/src/components/DeckBuilder.tsx
@@ -250,7 +250,7 @@ export function DeckBuilder({ onBack, fatiguedCards = [] }: Props) {
     return map
   }, [catalog])
 
-  const RARITY_ORDER: Record<CardRarity, number> = { common: 0, uncommon: 1, rare: 2, epic: 3, legendary: 4 }
+  const RARITY_ORDER: Record<CardRarity, number> = { common: 0, uncommon: 1, rare: 2, epic: 3, legendary: 4, mythic: 5, shiny: 6, holofoil: 7, glass: 8 }
   const TYPE_ORDER: Record<CardType, number>     = { unit: 0, structure: 1, upgrade: 2 }
 
   const catalogPos = useMemo(() => new Map<string, number>(catalog.map((c, i) => [c.name, i])), [catalog])

--- a/web/src/data/cards.json
+++ b/web/src/data/cards.json
@@ -20978,6 +20978,124 @@
       },
       "description": "HERO: Deploys the Builder \u2014 repairs or upgrades a building every 3s (3 charges). After all charges are spent, he sprints to the enemy base avoiding enemies and detonates on the first enemy building he reaches! All units gain +18 max HP.",
       "lore": "Can fix anything. Given enough time. And lumber."
+    },
+    {
+      "name": "Void Titan",
+      "rarity": "mythic",
+      "cost": 5,
+      "cardType": "unit",
+      "unit": {
+        "name": "Void Titan",
+        "attack": 80,
+        "maxHp": 350,
+        "isWall": false,
+        "bypassWall": false,
+        "moveSpeed": 20,
+        "attackRange": 8,
+        "attackCooldownMs": 1400,
+        "size": "large",
+        "tags": ["melee", "large", "armored"],
+        "cardVariant": "mythic",
+        "onDeathEffect": { "damage": 40, "range": 120 }
+      },
+      "description": "Mythic colossus of absolute destruction. On death, detonates for 40 damage in 120px.",
+      "lore": "The void does not hunger. It simply consumes.",
+      "deckCount": 0
+    },
+    {
+      "name": "Prism Wyrm",
+      "rarity": "mythic",
+      "cost": 5,
+      "cardType": "unit",
+      "unit": {
+        "name": "Prism Wyrm",
+        "attack": 55,
+        "maxHp": 220,
+        "isWall": false,
+        "bypassWall": true,
+        "flying": true,
+        "moveSpeed": 45,
+        "attackRange": 100,
+        "attackCooldownMs": 1200,
+        "size": "large",
+        "tags": ["flying", "ranged", "magic", "large"],
+        "cardVariant": "mythic"
+      },
+      "description": "Mythic sky serpent. Bypasses walls, flies over all obstacles, fires iridescent blasts.",
+      "lore": "Light bends around it. So does loyalty.",
+      "deckCount": 0
+    },
+    {
+      "name": "World's End",
+      "rarity": "mythic",
+      "cost": 5,
+      "cardType": "upgrade",
+      "upgradeEffect": {
+        "type": "aoe",
+        "damage": 180
+      },
+      "description": "Mythic cataclysm \u2014 deals 180 damage to all enemies on the field instantly.",
+      "lore": "Some spells cannot be uncast.",
+      "deckCount": 0
+    },
+    {
+      "name": "Eternal Forge",
+      "rarity": "mythic",
+      "cost": 5,
+      "cardType": "structure",
+      "unit": {
+        "name": "Eternal Forge",
+        "attack": 0,
+        "maxHp": 280,
+        "isWall": false,
+        "bypassWall": false,
+        "moveSpeed": 0,
+        "attackRange": 0,
+        "attackCooldownMs": 0,
+        "size": "large",
+        "cardVariant": "mythic",
+        "structureEffect": {
+          "type": "spawn",
+          "intervalMs": 2000,
+          "unitTemplate": {
+            "name": "Forge Knight",
+            "attack": 22,
+            "maxHp": 55,
+            "isWall": false,
+            "bypassWall": false,
+            "moveSpeed": 38,
+            "attackRange": 8,
+            "attackCooldownMs": 1400,
+            "tags": ["melee", "armored"]
+          }
+        }
+      },
+      "description": "Mythic structure \u2014 forges an armoured knight every 2 seconds. Cannot be destroyed.",
+      "lore": "The hammer never rests. The forge never cools.",
+      "deckCount": 0
+    },
+    {
+      "name": "Dreadnought",
+      "rarity": "mythic",
+      "cost": 5,
+      "cardType": "unit",
+      "unit": {
+        "name": "Dreadnought",
+        "attack": 45,
+        "maxHp": 500,
+        "isWall": false,
+        "bypassWall": false,
+        "moveSpeed": 14,
+        "attackRange": 10,
+        "attackCooldownMs": 1800,
+        "size": "large",
+        "tags": ["melee", "large", "armored", "siege"],
+        "cardVariant": "mythic",
+        "halfHealthEffect": { "damage": 60, "range": 100 }
+      },
+      "description": "Mythic siege engine \u2014 absurd HP, unstoppable advance. At 50% HP detonates for 60 AoE.",
+      "lore": "There is no wall it cannot break. There is no army it cannot outlast.",
+      "deckCount": 0
     }
   ]
 }

--- a/web/src/data/economy.json
+++ b/web/src/data/economy.json
@@ -8,7 +8,11 @@
     "uncommon": 15,
     "rare":     40,
     "epic":     65,
-    "legendary": 100
+    "legendary": 100,
+    "mythic":   500,
+    "shiny":    250,
+    "holofoil": 250,
+    "glass":    200
   },
 
   "merchantPrices": {
@@ -16,7 +20,11 @@
     "uncommon":  90,
     "rare":     200,
     "epic":     280,
-    "legendary": 400
+    "legendary": 400,
+    "mythic":   2000,
+    "shiny":    1000,
+    "holofoil": 1000,
+    "glass":    800
   },
 
   "miniGameCosts": {

--- a/web/src/game/cards.ts
+++ b/web/src/game/cards.ts
@@ -251,5 +251,6 @@ export function getCardUnit(cardName: string): UnitTemplate | undefined {
 }
 
 export function rarityStars(r: CardRarity): string {
-  return '\u2605'.repeat({ common: 1, uncommon: 2, rare: 3, epic: 4, legendary: 5 }[r])
+  const counts: Record<CardRarity, number> = { common: 1, uncommon: 2, rare: 3, epic: 4, legendary: 5, mythic: 6, shiny: 4, holofoil: 4, glass: 4 }
+  return '\u2605'.repeat(counts[r] ?? 1)
 }

--- a/web/src/game/cityBuilder.ts
+++ b/web/src/game/cityBuilder.ts
@@ -21,11 +21,11 @@ export const CELL_PX = 72
 const MAX_OFFLINE_MINUTES = 480
 
 /** Income per minute for spawn buildings. */
-export const INCOME_SPAWN: Record<CardRarity, number> = { common: 2, uncommon: 4, rare: 6, epic: 8, legendary: 10 }
+export const INCOME_SPAWN: Record<CardRarity, number> = { common: 2, uncommon: 4, rare: 6, epic: 8, legendary: 10, mythic: 15, shiny: 10, holofoil: 10, glass: 10 }
 /** Income per minute for utility buildings. */
-export const INCOME_UTILITY: Record<CardRarity, number> = { common: 1, uncommon: 3, rare: 5, epic: 7, legendary: 8 }
+export const INCOME_UTILITY: Record<CardRarity, number> = { common: 1, uncommon: 3, rare: 5, epic: 7, legendary: 8, mythic: 12, shiny: 8, holofoil: 8, glass: 8 }
 /** Income per minute for wall / no-effect structures. */
-export const INCOME_WALL: Record<CardRarity, number> = { common: 0, uncommon: 1, rare: 1, epic: 2, legendary: 2 }
+export const INCOME_WALL: Record<CardRarity, number> = { common: 0, uncommon: 1, rare: 1, epic: 2, legendary: 2, mythic: 3, shiny: 2, holofoil: 2, glass: 2 }
 
 /** Happiness regeneration per minute toward the target value. */
 const HAPPINESS_REGEN = 15
@@ -38,12 +38,12 @@ export const LEVEL_UP_COSTS = [50000, 100000, 250000, 500000, 1000000]
 // ── Resource constants ────────────────────────────────────────────────────────
 
 /** Defence value contributed by walls (per rarity). */
-const WALL_DEFENSE: Record<CardRarity, number> = { common: 5, uncommon: 10, rare: 20, epic: 30, legendary: 40 }
+const WALL_DEFENSE: Record<CardRarity, number> = { common: 5, uncommon: 10, rare: 20, epic: 30, legendary: 40, mythic: 60, shiny: 40, holofoil: 40, glass: 40 }
 /** Defence value contributed by spawn buildings (per rarity). */
-const SPAWN_DEFENSE: Record<CardRarity, number> = { common: 3, uncommon: 6, rare: 12, epic: 18, legendary: 25 }
+const SPAWN_DEFENSE: Record<CardRarity, number> = { common: 3, uncommon: 6, rare: 12, epic: 18, legendary: 25, mythic: 40, shiny: 25, holofoil: 25, glass: 25 }
 
 /** Wheat consumed per minute by a spawn building (units need feeding). */
-const FOOD_CONSUME_RATE: Record<CardRarity, number> = { common: 1, uncommon: 2, rare: 3, epic: 4, legendary: 5 }
+const FOOD_CONSUME_RATE: Record<CardRarity, number> = { common: 1, uncommon: 2, rare: 3, epic: 4, legendary: 5, mythic: 6, shiny: 5, holofoil: 5, glass: 5 }
 
 /** Resource cost to place a spawner of a given rarity. */
 export const SPAWNER_PLACE_COST: Record<CardRarity, Partial<ResourceStock>> = {
@@ -52,6 +52,10 @@ export const SPAWNER_PLACE_COST: Record<CardRarity, Partial<ResourceStock>> = {
   rare:      { wheat: 50, wood: 20, ore: 10 },
   epic:      { wheat: 65, wood: 30, ore: 15 },
   legendary: { wheat: 80, wood: 40, ore: 20 },
+  mythic:    { wheat: 100, wood: 60, ore: 30 },
+  shiny:     { wheat: 80, wood: 40, ore: 20 },
+  holofoil:  { wheat: 80, wood: 40, ore: 20 },
+  glass:     { wheat: 80, wood: 40, ore: 20 },
 }
 
 /** Icons for each resource type (used in UI). */
@@ -69,11 +73,13 @@ export const RESOURCE_ICONS: Record<ResourceType, string> = {
 /** Max HP for a fortification of each rarity. */
 export const FORT_MAX_HP: Record<CardRarity, number> = {
   common: 50, uncommon: 100, rare: 200, epic: 350, legendary: 500,
+  mythic: 800, shiny: 500, holofoil: 500, glass: 500,
 }
 
 /** Defense value contributed by a fortification at full HP. */
 export const FORT_DEFENSE: Record<CardRarity, number> = {
   common: 10, uncommon: 20, rare: 40, epic: 60, legendary: 80,
+  mythic: 120, shiny: 80, holofoil: 80, glass: 80,
 }
 
 /** Gold + resource cost to build a fortification of each rarity. */
@@ -83,6 +89,10 @@ export const FORT_PLACE_COST: Record<CardRarity, { gold: number } & Partial<Reso
   rare:      { gold: 12000,  wood: 120, ore: 50 },
   epic:      { gold: 40000,  wood: 250, ore: 120, planks: 35 },
   legendary: { gold: 100000, wood: 500, ore: 250, planks: 100 },
+  mythic:    { gold: 500000, wood: 1000, ore: 500, planks: 250 },
+  shiny:     { gold: 100000, wood: 500, ore: 250, planks: 100 },
+  holofoil:  { gold: 100000, wood: 500, ore: 250, planks: 100 },
+  glass:     { gold: 100000, wood: 500, ore: 250, planks: 100 },
 }
 
 /** HP repaired per minute per fortification (1 HP every 5 minutes). */
@@ -93,6 +103,7 @@ const FORT_REPAIR_WOOD_PER_HP = 1 / 20
 /** Number of attacks a fortification can survive before permanent destruction. */
 export const FORT_MAX_ATTACKS: Record<CardRarity, number> = {
   common: 5, uncommon: 8, rare: 12, epic: 18, legendary: 25,
+  mythic: 40, shiny: 25, holofoil: 25, glass: 25,
 }
 
 /** Gold cost to hire additional builders (index = number of extras already hired). */

--- a/web/src/game/engine.ts
+++ b/web/src/game/engine.ts
@@ -40,7 +40,7 @@ export const MAX_HANDICAP = 20
 // Thresholds also apply to campaign nodes: a node with handicap 8 puts the
 // opponent on uncommon-max, making early acts beatable with a starter deck.
 
-const RARITY_RANK: Record<CardRarity, number> = { common: 0, uncommon: 1, rare: 2, epic: 3, legendary: 4 }
+const RARITY_RANK: Record<CardRarity, number> = { common: 0, uncommon: 1, rare: 2, epic: 3, legendary: 4, mythic: 5, shiny: 5, holofoil: 5, glass: 5 }
 
 const QUICKPLAY_DECK_SIZE    = 20
 const QUICKPLAY_MIN_UNITS    = 3

--- a/web/src/game/engine/cards.ts
+++ b/web/src/game/engine/cards.ts
@@ -116,6 +116,12 @@ export function deployCard(s: GameState, card: Card, owner: 'player' | 'opponent
     } else {
       log.push(`${who} ${verb} ${unit.name}.`);
     }
+    // Glass cards: chance to shatter immediately after deployment
+    if (card.glassBreakChance && Math.random() < card.glassBreakChance) {
+      unit.hp = 0;
+      unit.dyingTimer = 400;
+      log.push(`💎 ${unit.name} shattered!`);
+    }
   } else if (card.cardType === 'upgrade' && card.upgradeEffect) {
     applyUpgrade(s, card.upgradeEffect, owner, log);
   }
@@ -154,7 +160,8 @@ export function playCard(state: GameState, cardId: string): GameState {
   s.mana -= card.cost
 
   deployCard(s, card, 'player', s.log)
-  drawCard(s.playerDeck, s.playerHand)
+  if (!s.secretRaresObtained) s.secretRaresObtained = []
+  drawCard(s.playerDeck, s.playerHand, s.secretRaresObtained)
   return s
 }
 /** Play an AoE upgrade card with a player-chosen target point (cx, cy in game units). */
@@ -184,7 +191,8 @@ export function playAoeCard(state: GameState, cardId: string, cx: number, cy: nu
   }
   s.log.push(`Your AOE! ${targets.length} enem${targets.length === 1 ? 'y' : 'ies'} hit for ${dmg} damage.`)
 
-  drawCard(s.playerDeck, s.playerHand)
+  if (!s.secretRaresObtained) s.secretRaresObtained = []
+  drawCard(s.playerDeck, s.playerHand, s.secretRaresObtained)
   return s
 }
 // ─── Apply Upgrade ────────────────────────────────────────

--- a/web/src/game/engine/endlessMode.ts
+++ b/web/src/game/engine/endlessMode.ts
@@ -160,6 +160,7 @@ export function processEndlessModeAdditions(s: GameState, deltaMs: number, log: 
     s.opponentDeck.push(...fresh)
   }
 
-  while (s.playerHand.length < 4   && s.playerDeck.length > 0)   drawCard(s.playerDeck, s.playerHand)
+  if (!s.secretRaresObtained) s.secretRaresObtained = []
+  while (s.playerHand.length < 4   && s.playerDeck.length > 0)   drawCard(s.playerDeck, s.playerHand, s.secretRaresObtained)
   while (s.opponentHand.length < 4 && s.opponentDeck.length > 0) drawCard(s.opponentDeck, s.opponentHand)
 }

--- a/web/src/game/engine/helpers.ts
+++ b/web/src/game/engine/helpers.ts
@@ -1,5 +1,7 @@
 import { logError } from '../../logger';
 import { Card, UnitTemplate, Unit, LANE_WIDTH } from '../types';
+import { rollSecretRarity, makeShinyVariant, makeHolofoilVariant, makeGlassVariant } from '../secretRarities';
+import { getCardCatalog } from '../cards';
 import { PLAYER_SPAWN_X, OPPONENT_SPAWN_X, COMMANDER_HOME_X } from './constants';
 
 // ─── Helpers ─────────────────────────────────────────────
@@ -16,8 +18,30 @@ export function shuffle<T>(arr: T[]): T[] {
   }
   return a;
 }
-export function drawCard(deck: Card[], hand: Card[]): void {
-  if (deck.length > 0) hand.push(deck.shift()!);
+export function drawCard(deck: Card[], hand: Card[], secretLog?: string[]): void {
+  if (deck.length === 0) return
+  let card = deck.shift()!
+  const secretType = rollSecretRarity()
+  if (secretType !== null) {
+    if (secretType === 'shiny') {
+      card = makeShinyVariant(card)
+    } else if (secretType === 'holofoil') {
+      card = makeHolofoilVariant(card)
+    } else if (secretType === 'glass') {
+      card = makeGlassVariant(card)
+    } else {
+      // mythic — inject a random mythic card from the catalog; fall back to shiny if none exist
+      const mythics = getCardCatalog().filter((c: Card) => c.rarity === 'mythic')
+      if (mythics.length > 0) {
+        const base = mythics[Math.floor(Math.random() * mythics.length)] as Card
+        card = { ...base, id: `mythic-${Math.random().toString(36).slice(2, 9)}` }
+      } else {
+        card = makeShinyVariant(card)
+      }
+    }
+    secretLog?.push(card.name)
+  }
+  hand.push(card)
 }
 // Five lanes evenly spread across the battle-field's lateral (Y) axis.
 // Y=0 is centre; units move continuously between these positions.

--- a/web/src/game/secretRarities.ts
+++ b/web/src/game/secretRarities.ts
@@ -1,0 +1,62 @@
+import { Card, CardRarity } from './types'
+
+/** 1-in-N chance any drawn card becomes a secret rare. */
+export const SECRET_RARITY_ODDS = 10000
+
+type SecretType = 'mythic' | 'shiny' | 'holofoil' | 'glass'
+
+/** Roll for a secret-rare trigger. Returns the type if triggered, null otherwise. */
+export function rollSecretRarity(): SecretType | null {
+  if (Math.random() >= 1 / SECRET_RARITY_ODDS) return null
+  const r = Math.random()
+  if (r < 0.25) return 'mythic'
+  if (r < 0.50) return 'shiny'
+  if (r < 0.75) return 'holofoil'
+  return 'glass'
+}
+
+/** Stamp a unique runtime ID onto a card without mutating the original. */
+function secretId(card: Card, suffix: string): string {
+  return `${card.id}-${suffix}-${Math.random().toString(36).slice(2, 7)}`
+}
+
+export function makeShinyVariant(card: Card): Card {
+  return {
+    ...card,
+    id: secretId(card, 'shiny'),
+    name: `Shiny ${card.name}`,
+    rarity: 'shiny' as CardRarity,
+    variant: 'shiny',
+    unit: card.unit ? { ...card.unit, cardVariant: 'shiny' } : undefined,
+  }
+}
+
+export function makeHolofoilVariant(card: Card): Card {
+  return {
+    ...card,
+    id: secretId(card, 'holo'),
+    name: `Holo ${card.name}`,
+    rarity: 'holofoil' as CardRarity,
+    variant: 'holofoil',
+    unit: card.unit ? { ...card.unit, cardVariant: 'holofoil' } : undefined,
+  }
+}
+
+export function makeGlassVariant(card: Card): Card {
+  const boostedUnit = card.unit ? {
+    ...card.unit,
+    attack: Math.round(card.unit.attack * 1.6),
+    maxHp: Math.round(card.unit.maxHp * 1.4),
+    cardVariant: 'glass' as const,
+  } : undefined
+  return {
+    ...card,
+    id: secretId(card, 'glass'),
+    name: `Glass ${card.name}`,
+    rarity: 'glass' as CardRarity,
+    variant: 'glass',
+    cost: Math.max(0, card.cost - 1),
+    glassBreakChance: 0.35,
+    unit: boostedUnit,
+  }
+}

--- a/web/src/game/shopSchedule.ts
+++ b/web/src/game/shopSchedule.ts
@@ -168,6 +168,10 @@ export const SHOP_CARD_PRICES: Record<CardRarity, number> = {
   rare:      180,
   epic:      250,
   legendary: 350,
+  mythic:    2000,
+  shiny:     1000,
+  holofoil:  1000,
+  glass:     800,
 }
 
 export interface ShopCardDeal {

--- a/web/src/game/types.ts
+++ b/web/src/game/types.ts
@@ -37,7 +37,9 @@ export type UpgradeEffect =
 
 // ─── Cards ───────────────────────────────────────────────
 
-export type CardRarity = 'common' | 'uncommon' | 'rare' | 'epic' | 'legendary'
+export type CardRarity = 'common' | 'uncommon' | 'rare' | 'epic' | 'legendary' | 'mythic' | 'shiny' | 'holofoil' | 'glass'
+/** Rarities that are secret — hidden in collections until obtained. */
+export const SECRET_RARITIES: ReadonlySet<CardRarity> = new Set(['mythic', 'shiny', 'holofoil', 'glass'])
 export type CardType = 'unit' | 'structure' | 'upgrade'
 
 export interface UnitTemplate {
@@ -75,6 +77,8 @@ export interface UnitTemplate {
   lore?: string
   /** Visual size of the unit sprite on the battlefield. Defaults to 'medium'. */
   size?: 'small' | 'medium' | 'large'
+  /** Secret-rarity visual tag — applied to units spawned from shiny/holofoil/glass/mythic cards. */
+  cardVariant?: 'shiny' | 'holofoil' | 'glass' | 'mythic'
   /** Mastery level of this card from the player's collection (0 = unmastered). */
   masteryLevel?: number
   /** AOE explosion triggered once when this unit first drops to ≤50% HP. */
@@ -208,6 +212,10 @@ export interface Card {
   lore?: string              // flavour text shown in the card detail view
   isHero?: boolean           // hero cards deploy a unit AND trigger a heroEffect buff
   heroEffect?: UpgradeEffect // the permanent buff applied to all friendly units when played
+  /** Secret variant type — set on dynamically-generated shiny/holofoil/glass cards. */
+  variant?: 'shiny' | 'holofoil' | 'glass'
+  /** Glass cards: probability (0–1) the card shatters when played (unit instantly dies). */
+  glassBreakChance?: number
 }
 
 // ─── Boss Trait State ─────────────────────────────────────
@@ -351,6 +359,8 @@ export interface GameState {
   stanceCooldownUntil?: number
   /** Boss HP value at which phase 2 triggers (boss battles only — boss spawned at game start). */
   bossPhase2Hp?: number
+  /** Names of secret-rare cards obtained during this game session (flushed to collection on win/end). */
+  secretRaresObtained?: string[]
 }
 
 export interface StanceRules {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -759,6 +759,100 @@ body {
 .card-tile--rare      { border-color: rgba(187, 102, 255, 0.55); background: rgba(187, 102, 255, 0.05); }
 .card-tile--legendary { border-color: rgba(255, 204, 0, 0.6);   background: rgba(255, 204, 0, 0.04); }
 
+/* ─── Secret-rarity card tiles ────────────────────────────────────────────── */
+@keyframes secret-shimmer {
+  0%   { background-position: -200% center; }
+  100% { background-position:  200% center; }
+}
+@keyframes holo-shift {
+  0%   { background-position: 0%   50%; }
+  50%  { background-position: 100% 50%; }
+  100% { background-position: 0%   50%; }
+}
+@keyframes mythic-pulse {
+  0%, 100% { box-shadow: 0 0 8px 2px rgba(224,64,251,0.55), inset 0 0 12px rgba(224,64,251,0.18); }
+  50%       { box-shadow: 0 0 18px 5px rgba(224,64,251,0.85), inset 0 0 20px rgba(224,64,251,0.3); }
+}
+@keyframes glass-crack {
+  0%, 90%, 100% { opacity: 0; }
+  93%, 97%      { opacity: 0.4; }
+}
+
+/* Shiny: warm gold shimmer sweep */
+.card-tile--shiny {
+  border-color: rgba(255, 220, 60, 0.8);
+  background: linear-gradient(
+    105deg,
+    rgba(255,220,60,0.04) 0%,
+    rgba(255,255,180,0.22) 48%,
+    rgba(255,220,60,0.04) 100%
+  );
+  background-size: 200% auto;
+  animation: secret-shimmer 2.4s linear infinite;
+}
+.card-tile--shiny .card-rarity { color: #ffe066; text-shadow: 0 0 8px rgba(255,220,60,0.9); }
+
+/* Holofoil: rainbow prism shift */
+.card-tile--holofoil {
+  border-color: rgba(64, 224, 208, 0.75);
+  background: linear-gradient(
+    120deg,
+    rgba(255,80,120,0.08) 0%,
+    rgba(64,224,208,0.12) 25%,
+    rgba(100,180,255,0.10) 50%,
+    rgba(200,80,255,0.10) 75%,
+    rgba(255,220,60,0.08) 100%
+  );
+  background-size: 300% 300%;
+  animation: holo-shift 3s ease infinite;
+}
+.card-tile--holofoil .card-rarity { color: #40e0d0; text-shadow: 0 0 8px rgba(64,224,208,0.9); }
+
+/* Glass: frosted crystal look, subtle crack flash */
+.card-tile--glass {
+  border-color: rgba(160, 216, 239, 0.8);
+  background: rgba(200, 235, 255, 0.06);
+  backdrop-filter: blur(1px);
+  position: relative;
+}
+.card-tile--glass::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: repeating-linear-gradient(
+    65deg,
+    transparent 0px,
+    transparent 18px,
+    rgba(200,235,255,0.07) 18px,
+    rgba(200,235,255,0.07) 19px
+  );
+  animation: glass-crack 5s ease-in-out infinite;
+  pointer-events: none;
+  border-radius: inherit;
+}
+.card-tile--glass .card-rarity { color: #a0d8ef; text-shadow: 0 0 6px rgba(160,216,239,0.8); }
+
+/* Mythic: deep void purple with cosmic pulse */
+.card-tile--mythic {
+  border-color: rgba(224, 64, 251, 0.85);
+  background: linear-gradient(160deg, rgba(40,0,60,0.55) 0%, rgba(10,0,20,0.55) 100%);
+  animation: mythic-pulse 2s ease-in-out infinite;
+}
+.card-tile--mythic .card-rarity { color: #e040fb; text-shadow: 0 0 10px rgba(224,64,251,1); }
+.card-tile--mythic .card-title  { color: #e8b0ff; }
+.card-tile--mythic .card-cost   { color: #e040fb; text-shadow: 0 0 10px rgba(224,64,251,0.9); }
+
+/* pack reveal / shop rarity labels */
+.pack-card-rarity--mythic   { color: #e040fb; text-shadow: 0 0 8px rgba(224,64,251,0.8); }
+.pack-card-rarity--shiny    { color: #ffe066; text-shadow: 0 0 6px rgba(255,220,60,0.9); }
+.pack-card-rarity--holofoil { color: #40e0d0; text-shadow: 0 0 6px rgba(64,224,208,0.9); }
+.pack-card-rarity--glass    { color: #a0d8ef; text-shadow: 0 0 6px rgba(160,216,239,0.8); }
+
+.shop-card-deal--mythic   { border-top: 2px solid #e040fb; }
+.shop-card-deal--shiny    { border-top: 2px solid #ffe066; }
+.shop-card-deal--holofoil { border-top: 2px solid #40e0d0; }
+.shop-card-deal--glass    { border-top: 2px solid #a0d8ef; }
+
 .card-cost {
   position: absolute;
   top: 3px;
@@ -782,6 +876,36 @@ body {
   background: #ffd700;
   padding: 2px 0;
   text-shadow: none;
+}
+
+/* Secret rarity badge (top-left ribbon) */
+.card-secret-badge {
+  position: absolute;
+  top: 5px;
+  left: 5px;
+  font-size: 0.52rem;
+  font-weight: 900;
+  letter-spacing: 0.06em;
+  padding: 1px 5px;
+  border-radius: 3px;
+  pointer-events: none;
+  z-index: 12;
+  text-transform: uppercase;
+}
+.card-secret-badge--mythic   { background: rgba(224,64,251,0.25); color: #e040fb; border: 1px solid rgba(224,64,251,0.6); }
+.card-secret-badge--shiny    { background: rgba(255,220,60,0.2);  color: #ffe066; border: 1px solid rgba(255,220,60,0.6); }
+.card-secret-badge--holofoil { background: rgba(64,224,208,0.2);  color: #40e0d0; border: 1px solid rgba(64,224,208,0.6); }
+.card-secret-badge--glass    { background: rgba(160,216,239,0.15); color: #a0d8ef; border: 1px solid rgba(160,216,239,0.6); }
+
+/* Glass break-chance icon */
+.card-glass-warning {
+  position: absolute;
+  bottom: 50px;
+  right: 5px;
+  font-size: 0.75rem;
+  opacity: 0.75;
+  pointer-events: none;
+  z-index: 12;
 }
 
 .hero-badge-wrap {
@@ -7963,6 +8087,26 @@ html.light-mode .action-btn {
 .lane-unit--kill-flash {
   animation: kill-flash-anim 0.5s ease-out forwards;
 }
+
+/* ─── Secret-variant unit visual effects ──────────────────────────────────── */
+@keyframes variant-shiny-glow {
+  0%, 100% { filter: brightness(1.1) drop-shadow(0 0 3px rgba(255,220,60,0.6)); }
+  50%       { filter: brightness(1.3) drop-shadow(0 0 8px rgba(255,220,60,1)); }
+}
+@keyframes variant-holo-shift {
+  0%   { filter: hue-rotate(0deg)   brightness(1.15) saturate(1.4); }
+  50%  { filter: hue-rotate(180deg) brightness(1.25) saturate(1.6); }
+  100% { filter: hue-rotate(360deg) brightness(1.15) saturate(1.4); }
+}
+@keyframes variant-mythic-aura {
+  0%, 100% { filter: brightness(1.1) drop-shadow(0 0 4px rgba(224,64,251,0.7)); }
+  50%       { filter: brightness(1.35) drop-shadow(0 0 12px rgba(224,64,251,1)); }
+}
+
+.lane-unit--variant-shiny    { animation: variant-shiny-glow   2s ease-in-out infinite; }
+.lane-unit--variant-holofoil { animation: variant-holo-shift   3s linear infinite; }
+.lane-unit--variant-glass    { opacity: 0.88; filter: brightness(1.15) drop-shadow(0 0 4px rgba(160,216,239,0.7)); }
+.lane-unit--variant-mythic   { animation: variant-mythic-aura  1.8s ease-in-out infinite; }
 
 /* Projectile: a glowing streak travelling from attacker to target */
 @keyframes projectile-travel {


### PR DESCRIPTION
## Summary

- **4 secret rarity tiers**: `mythic`, `shiny`, `holofoil`, `glass` — each has a 1/10,000 per-draw chance of triggering
- **Mythic**: 5 completely new cards (always cost 5 mana, absurdly powerful). Hidden in Collection until obtained
- **Shiny / Holofoil**: dynamically-generated variants of whatever card is drawn — same stats, different visual identity (`Shiny Dragon`, `Holo Dragon`). Count as separate cards in hand and deck
- **Glass**: variant with ×1.6 attack / ×1.4 HP / −1 cost, but **35% chance to shatter** on play (unit dies instantly)
- Secret rarities are hidden in the Collection screen until you own at least one copy

### Mythic cards

| Card | Type | ATK | HP | Notes |
|---|---|---|---|---|
| Void Titan | Unit | 80 | 350 | On-death 40 AoE |
| Prism Wyrm | Unit | 55 | 220 | Flying, bypassWall, range 100 |
| World's End | Upgrade | — | — | 180 AoE damage to all enemies |
| Eternal Forge | Structure | — | 280 | Spawns Forge Knight every 2 s |
| Dreadnought | Unit | 45 | 500 | 60 AoE at 50% HP |

### Visual effects

| Rarity | Card tile | Field unit |
|---|---|---|
| Shiny | Gold shimmer sweep animation | Pulsing gold drop-shadow |
| Holofoil | Cycling rainbow gradient | Continuous hue-rotate |
| Glass | Frosted crystal, periodic crack flash | Frosted opacity + cyan glow |
| Mythic | Deep void purple, cosmic pulse animation | Slow purple aura throb |

All secret rarities show a colour-coded badge (SHINY / HOLO / GLASS / MYTHIC) in the top-left of the card tile, and glass cards show a 💎 break-chance indicator.

## Architecture

- `game/secretRarities.ts` — roll logic + variant-creation helpers
- `game/types.ts` — `CardRarity` extended, `variant` + `glassBreakChance` on `Card`, `cardVariant` on `UnitTemplate`/`Unit`, `secretRaresObtained` on `GameState`
- `engine/helpers.ts` — `drawCard` accepts optional `secretLog` array; performs roll and transformation
- `engine/cards.ts` — glass shatter mechanic inside `deployCard`
- `CollectionScreen` — secret rarities filtered from view until `ownedCount > 0`

## Test plan

- [ ] Temporarily set `SECRET_RARITY_ODDS = 1` in `secretRarities.ts` to force every draw to trigger — verify all 4 variant types appear
- [ ] Confirm shiny/holofoil cards have boosted-name but same stats as base card
- [ ] Confirm glass card has higher stats, lower cost, and sometimes shatters ("💎 Glass X shattered!" log line)
- [ ] Confirm mythic cards (cost 5) appear and deploy correctly
- [ ] Confirm field units from secret variants have animated glow effects
- [ ] Confirm mythic cards do NOT appear in Collection screen with zero owned copies
- [ ] Reset `SECRET_RARITY_ODDS = 10000` after testing
- [ ] TypeScript: `npx tsc --noEmit` passes (verified clean)

https://claude.ai/code/session_01FFXw8rUxBVQRtJK8x762WJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01FFXw8rUxBVQRtJK8x762WJ)_