### PR TITLE
feat: show deck selector before campaign entry

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -784,6 +784,7 @@ export default function App() {
   // ── Campaign ─────────────────────────────────────────────
 
   const handleCampaign = useCallback(() => {
+    const doLaunch = () => {
     const existing = loadRun()
 
     const goToNodemap = () => {
@@ -926,6 +927,13 @@ export default function App() {
 
     // First-time run (or act has no modifiers): start normally with 0 active modifiers
     proceedWithModifiers(0)
+    } // end doLaunch
+
+    if (loadDeckSlot('b').length > 0) {
+      setPendingBattleFn(() => doLaunch)
+    } else {
+      doLaunch()
+    }
   }, [])
 
   const handleSelectNode = useCallback((node: QuestNode) => {


### PR DESCRIPTION
## Summary

- `handleCampaign` now shows the deck selector modal (same as quick battle and endless) when Deck B has cards
- The entire campaign launch body is wrapped in a `doLaunch` closure, so all paths — resume pending battle, resume to nodemap, fresh run with cutscene/relic select — go through the single selector prompt

## Test plan

- [ ] With Deck B empty: tapping Campaign goes straight in with no prompt
- [ ] With Deck B populated: tapping Campaign shows the side-by-side deck preview; selecting A or B and confirming proceeds normally
- [ ] Confirm resume flow (existing run with pending battle node) works correctly after selecting a deck
- [ ] Confirm fresh run flow (cutscene, relic select) works correctly after selecting a deck

https://claude.ai/code/session_01FFXw8rUxBVQRtJK8x762WJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01FFXw8rUxBVQRtJK8x762WJ)_