### PR TITLE
fix: Eternal Forge spawner — add forge-knight template, fix unitTemplateRef (#1087)

### DIFF
--- a/web/src/data/cards.json
+++ b/web/src/data/cards.json
@@ -11104,6 +11104,20 @@
         "arcane",
         "armored"
       ]
+    },
+    "forge-knight": {
+      "name": "Forge Knight",
+      "attack": 22,
+      "maxHp": 55,
+      "isWall": false,
+      "bypassWall": false,
+      "moveSpeed": 38,
+      "attackRange": 8,
+      "attackCooldownMs": 1400,
+      "tags": [
+        "melee",
+        "armored"
+      ]
     }
   },
   "cards": [
@@ -20658,20 +20672,7 @@
         "structureEffect": {
           "type": "spawn",
           "intervalMs": 2000,
-          "unitTemplate": {
-            "name": "Forge Knight",
-            "attack": 22,
-            "maxHp": 55,
-            "isWall": false,
-            "bypassWall": false,
-            "moveSpeed": 38,
-            "attackRange": 8,
-            "attackCooldownMs": 1400,
-            "tags": [
-              "melee",
-              "armored"
-            ]
-          }
+          "unitTemplateRef": "forge-knight"
         }
       },
       "description": "Mythic structure \u2014 forges an armoured knight every 2 seconds. Cannot be destroyed.",


### PR DESCRIPTION
Fixes #1087

`resolveUnit()` only resolves spawn templates via `unitTemplateRef` string lookups against the `templates` map. Eternal Forge had an inline `unitTemplate` object instead, which was silently ignored — causing the Rollbar error `unknown unitTemplateRef '(none)' for unit 'Eternal Forge'` and spawners producing invalid units.

**Fix:**
- Added `forge-knight` entry to the `templates` section of `cards.json`
- Changed Eternal Forge's `structureEffect` to use `unitTemplateRef: "forge-knight"` instead of the inline object

https://claude.ai/code/session_01FFXw8rUxBVQRtJK8x762WJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01FFXw8rUxBVQRtJK8x762WJ)_