### PR TITLE
Show resting cards with strikethrough in deck selector modal

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2875,6 +2875,7 @@ export default function App() {
       {/* Deck selector — shown before quick battle / endless when Deck B has content */}
       {pendingBattleFn && (
         <DeckSelectorModal
+          fatiguedCards={fatiguedCards}
           onConfirm={() => {
             const fn = pendingBattleFn
             setPendingBattleFn(null)

--- a/web/src/components/DeckSelectorModal.tsx
+++ b/web/src/components/DeckSelectorModal.tsx
@@ -10,14 +10,16 @@ import {
 } from '../game/collection'
 
 interface Props {
+  fatiguedCards?: string[]
   onConfirm: () => void
   onCancel: () => void
 }
 
-function DeckPreview({ entries, slot, selected, onSelect }: {
+function DeckPreview({ entries, slot, selected, fatiguedCards, onSelect }: {
   entries: DeckEntry[]
   slot: DeckSlot
   selected: boolean
+  fatiguedCards: string[]
   onSelect: () => void
 }) {
   const catalog = useMemo(() => getCardCatalog(), [])
@@ -27,6 +29,7 @@ function DeckPreview({ entries, slot, selected, onSelect }: {
     return (ca?.cost ?? 0) - (cb?.cost ?? 0) || a.cardName.localeCompare(b.cardName)
   })
   const total = entries.reduce((s, e) => s + e.count, 0)
+  const restingCount = entries.filter(e => fatiguedCards.includes(e.cardName)).length
 
   return (
     <div
@@ -39,7 +42,9 @@ function DeckPreview({ entries, slot, selected, onSelect }: {
       <div className="deck-selector-panel-header">
         <span className="deck-selector-slot-label">DECK {slot.toUpperCase()}</span>
         {selected && <span className="deck-selector-active-badge">✓ ACTIVE</span>}
-        <span className="deck-selector-count">{total} cards</span>
+        <span className="deck-selector-count">
+          {total} cards{restingCount > 0 && <span className="deck-selector-resting"> · {restingCount} resting</span>}
+        </span>
       </div>
       {entries.length === 0 ? (
         <div className="deck-selector-empty">No cards — build one in Deck Builder</div>
@@ -47,11 +52,13 @@ function DeckPreview({ entries, slot, selected, onSelect }: {
         <div className="deck-selector-list">
           {sorted.map(e => {
             const card = catalog.find(c => c.name === e.cardName)
+            const resting = fatiguedCards.includes(e.cardName)
             return (
-              <div key={e.cardName} className="deck-selector-row">
+              <div key={e.cardName} className={`deck-selector-row${resting ? ' deck-selector-row--resting' : ''}`}>
                 <span className="deck-selector-cost">{card?.cost ?? '?'}</span>
                 <span className="deck-selector-name">{e.cardName}</span>
                 {e.count > 1 && <span className="deck-selector-qty">×{e.count}</span>}
+                {resting && <span className="deck-selector-rest-badge">zzz</span>}
               </div>
             )
           })}
@@ -61,7 +68,7 @@ function DeckPreview({ entries, slot, selected, onSelect }: {
   )
 }
 
-export function DeckSelectorModal({ onConfirm, onCancel }: Props) {
+export function DeckSelectorModal({ fatiguedCards = [], onConfirm, onCancel }: Props) {
   const [selected, setSelected] = useState<DeckSlot>(getActiveDeckSlot)
   const deckA = useMemo(() => loadDeckSlot('a'), [])
   const deckB = useMemo(() => loadDeckSlot('b'), [])
@@ -80,12 +87,14 @@ export function DeckSelectorModal({ onConfirm, onCancel }: Props) {
             entries={deckA}
             slot="a"
             selected={selected === 'a'}
+            fatiguedCards={fatiguedCards}
             onSelect={() => setSelected('a')}
           />
           <DeckPreview
             entries={deckB}
             slot="b"
             selected={selected === 'b'}
+            fatiguedCards={fatiguedCards}
             onSelect={() => setSelected('b')}
           />
         </div>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -3457,6 +3457,25 @@ body {
   font-size: 0.65rem;
 }
 
+.deck-selector-row--resting .deck-selector-name,
+.deck-selector-row--resting .deck-selector-cost,
+.deck-selector-row--resting .deck-selector-qty {
+  text-decoration: line-through;
+  opacity: 0.45;
+}
+
+.deck-selector-rest-badge {
+  flex-shrink: 0;
+  font-size: 0.6rem;
+  color: #f0a040;
+  letter-spacing: 0;
+}
+
+.deck-selector-resting {
+  color: #f0a040;
+  font-size: 0.65rem;
+}
+
 .deck-selector-actions {
   display: flex;
   gap: 10px;


### PR DESCRIPTION
## Summary

- Fatigued/resting cards in the deck selector modal now render with line-through text and reduced opacity so the player can clearly see which cards won't be available before entering a campaign battle
- Added a `zzz` badge next to each resting card row
- Panel header shows a resting card count (e.g. `· 3 resting`) when any cards are fatigued

## Test plan

- [ ] Enter campaign with some fatigued cards; open the deck selector modal and confirm resting cards appear struck-through with the `zzz` badge
- [ ] Confirm non-resting cards are unaffected
- [ ] Confirm the resting count appears in the panel header only when at least one card is resting
- [ ] Confirm both Deck A and Deck B panels reflect the correct resting state

https://claude.ai/code/session_01FFXw8rUxBVQRtJK8x762WJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01FFXw8rUxBVQRtJK8x762WJ)_