### PR TITLE
Allow up to 3 enemies per cell in tower defence minigame

### DIFF
--- a/web/src/game/towerDefence.ts
+++ b/web/src/game/towerDefence.ts
@@ -652,10 +652,10 @@ export function tickTD(state: TDGameState, dtMs: number): TDGameState {
     }]
   }
 
-  // ── Move enemies — max 1 per cell (leaders advance first) ───────────────
+  // ── Move enemies — max 3 per cell (leaders advance first) ──────────────
   const dtSec = dtMs / 1000
   let livesLost = 0
-  const claimedEnemyCells = new Set<string>()
+  const claimedEnemyCells = new Map<string, number>()  // "col,row" -> occupant count
   const survivingEnemies: TDEnemy[] = []
   // Process most-advanced enemies first so they claim cells before followers
   const enemiesByProgress = [...s.enemies].sort((a, b) => b.pathProgress - a.pathProgress)
@@ -667,13 +667,14 @@ export function tickTD(state: TDGameState, dtMs: number): TDGameState {
     }
     const xy = pathIndexToXY(np)
     const destKey = `${Math.floor(xy.x / TD_CELL_PX)},${Math.floor(xy.y / TD_CELL_PX)}`
-    if (claimedEnemyCells.has(destKey)) {
-      // Cell ahead occupied — hold position, claim current cell
+    const destCount = claimedEnemyCells.get(destKey) ?? 0
+    if (destCount >= 3) {
+      // Cell ahead full — hold position, claim current cell
       const curKey = `${Math.floor(enemy.x / TD_CELL_PX)},${Math.floor(enemy.y / TD_CELL_PX)}`
-      claimedEnemyCells.add(curKey)
+      claimedEnemyCells.set(curKey, (claimedEnemyCells.get(curKey) ?? 0) + 1)
       survivingEnemies.push(enemy)
     } else {
-      claimedEnemyCells.add(destKey)
+      claimedEnemyCells.set(destKey, destCount + 1)
       survivingEnemies.push({ ...enemy, pathProgress: np, x: xy.x, y: xy.y })
     }
   }


### PR DESCRIPTION
## Summary

- Enemy movement in the tower defence minigame now allows up to 3 enemies to share a cell simultaneously, instead of blocking at 1
- Leaders still advance first each tick; followers only queue when a destination cell already holds 3 enemies
- Waves will move more fluidly and bunch together, making them feel more like a proper swarm

## Test plan

- [ ] Start a tower defence game and confirm enemies bunch up in groups of up to 3 rather than forming a long single-file line
- [ ] Confirm enemies still queue behind full cells (don't pass through indefinitely)
- [ ] Confirm enemies that reach the end still cost lives correctly

https://claude.ai/code/session_01FFXw8rUxBVQRtJK8x762WJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01FFXw8rUxBVQRtJK8x762WJ)_