### PR TITLE
Add elemental attack effects: burn, freeze, poison, shock

### DIFF
--- a/web/src/data/cards.json
+++ b/web/src/data/cards.json
@@ -501,7 +501,8 @@
       "tags": [
         "melee",
         "fast",
-        "beast"
+        "beast",
+        "poison"
       ],
       "strengths": [
         "slow",
@@ -3285,7 +3286,8 @@
       "flying": false,
       "tags": [
         "ranged",
-        "magic"
+        "magic",
+        "lightning"
       ],
       "strengths": [
         "armored",
@@ -3322,7 +3324,8 @@
       "flying": true,
       "tags": [
         "ranged",
-        "magic"
+        "magic",
+        "lightning"
       ],
       "strengths": [
         "melee",
@@ -3359,7 +3362,8 @@
         "ranged",
         "flying",
         "large",
-        "magic"
+        "magic",
+        "lightning"
       ],
       "strengths": [
         "melee",

--- a/web/src/game/cards.ts
+++ b/web/src/game/cards.ts
@@ -1,4 +1,4 @@
-import { Card, CardRarity, CardType, UnitTemplate, UpgradeEffect } from './types'
+import { AttackEffect, Card, CardRarity, CardType, UnitTemplate, UpgradeEffect } from './types'
 import { logError } from '../logger'
 import cardsData from '../data/cards.json'
 
@@ -53,11 +53,25 @@ interface RawUnitDef {
   attackCooldownMs: number
   flying?: boolean
   climber?: boolean
+  tags?: string[]
   structureEffect?: RawStructureEffect
   onDeathEffect?: { damage: number; range: number }
   teleportAbility?: { cooldownMs: number; distancePx: number }
   invisibilityAbility?: { activeMs: number; cooldownMs: number }
   bloodSummonAbility?: { cooldownMs: number; minionTemplate: RawUnitDef; range: number }
+}
+
+function deriveAttackEffect(tags: string[] | undefined, attack: number): AttackEffect | undefined {
+  if (!tags || attack === 0) return undefined
+  if (tags.includes('fire') || tags.includes('ember'))
+    return { type: 'burn',   chance: 0.70, durationMs: 3000, dps: 8 }
+  if (tags.includes('frost') || tags.includes('glacier'))
+    return { type: 'freeze', chance: 0.75, durationMs: 2500, slowFactor: 0.35 }
+  if (tags.includes('lightning'))
+    return { type: 'shock',  chance: 0.50, durationMs: 600 }
+  if (tags.includes('poison'))
+    return { type: 'poison', chance: 0.65, durationMs: 5000, dps: 5 }
+  return undefined
 }
 
 interface RawCardDef {
@@ -92,8 +106,9 @@ interface RawHeroCard {
 const TEMPLATES = cardsData.templates as Record<string, RawUnitDef>
 
 function resolveUnit(raw: RawUnitDef): UnitTemplate {
+  const attackEffect = deriveAttackEffect(raw.tags, raw.attack)
   if (!raw.structureEffect || raw.structureEffect.type !== 'spawn') {
-    return raw as UnitTemplate
+    return attackEffect ? { ...(raw as UnitTemplate), attackEffect } : raw as UnitTemplate
   }
   const { unitTemplateRef, intervalMs } = raw.structureEffect
   const resolved = unitTemplateRef ? TEMPLATES[unitTemplateRef] : undefined
@@ -105,6 +120,7 @@ function resolveUnit(raw: RawUnitDef): UnitTemplate {
   const unitTemplate = (resolved ?? {}) as UnitTemplate
   return {
     ...(raw as unknown as UnitTemplate),
+    ...(attackEffect ? { attackEffect } : {}),
     structureEffect: { type: 'spawn' as const, unitTemplate, intervalMs: intervalMs ?? 0 },
   }
 }

--- a/web/src/game/engine.ts
+++ b/web/src/game/engine.ts
@@ -3,7 +3,7 @@ import { makeDeck, makeNodeDeck, HERO_CARDS, getCardUnit, getCardCatalog, flushC
 import { loadPlayerStats } from './playerStats'
 
 import { moveUnits, processAffinities } from './engine/units'
-import { processAttacks } from './engine/combat'
+import { processAttacks, DEATH_LINGER_MS } from './engine/combat'
 import { BASE_MAX_MANA, BLOOD_POOL_FADE_MS, BASE_STOP_MARGIN, MANA_REGEN_MS, OPPONENT_INTERVAL_MS, PLAYER_SPAWN_X, SPAWN_GROW_MS, COMMANDER_HOME_X } from './engine/constants'
 import { genericBossAI, getBossAIDef } from './engine/boss'
 import { tickBossTrait } from './engine/bossTraits'
@@ -580,6 +580,32 @@ function performUnitMaintenance(s: GameState, deltaMs: number, log: string[]) {
     }
     if (unit.stunTimer != null && unit.stunTimer > 0) {
       unit.stunTimer = Math.max(0, unit.stunTimer - deltaMs)
+    }
+    // Freeze timer
+    if (unit.freezeTimer != null && unit.freezeTimer > 0) {
+      unit.freezeTimer = Math.max(0, unit.freezeTimer - deltaMs)
+    }
+    // Burn DoT — ticks down and deals damage each frame
+    if (unit.burnTimer != null && unit.burnTimer > 0 && unit.hp > 0) {
+      unit.burnTimer = Math.max(0, unit.burnTimer - deltaMs)
+      unit.hp = Math.max(0, unit.hp - (unit.burnDps ?? 8) * deltaMs / 1000)
+      if (!unit.damageFlashTimer || unit.damageFlashTimer <= 0) unit.damageFlashTimer = 80
+      if (unit.hp <= 0 && unit.moveSpeed > 0 && !unit.isWall) {
+        unit.dyingTimer = DEATH_LINGER_MS
+        if (!unit.flying) s.bloodPools.push({ id: `burn-${unit.id}`, x: unit.x, y: unit.y ?? 0 })
+        log.push(`${unit.name} burns to ash!`)
+      }
+    }
+    // Poison DoT — ticks down and deals damage each frame
+    if (unit.poisonTimer != null && unit.poisonTimer > 0 && unit.hp > 0) {
+      unit.poisonTimer = Math.max(0, unit.poisonTimer - deltaMs)
+      unit.hp = Math.max(0, unit.hp - (unit.poisonDps ?? 5) * deltaMs / 1000)
+      if (!unit.damageFlashTimer || unit.damageFlashTimer <= 0) unit.damageFlashTimer = 80
+      if (unit.hp <= 0 && unit.moveSpeed > 0 && !unit.isWall) {
+        unit.dyingTimer = DEATH_LINGER_MS
+        if (!unit.flying) s.bloodPools.push({ id: `poison-${unit.id}`, x: unit.x, y: unit.y ?? 0 })
+        log.push(`${unit.name} succumbs to poison!`)
+      }
     }
     // Update climbing flag: true when climber unit is inside an enemy wall zone
     if (unit.climber && unit.moveSpeed > 0) {

--- a/web/src/game/engine/combat.ts
+++ b/web/src/game/engine/combat.ts
@@ -83,6 +83,22 @@ export function processAttacks(s: GameState, deltaMs: number, log: string[]): vo
           target.targetId = unit.id
         }
         target.damageFlashTimer = DAMAGE_FLASH_MS
+        // Apply elemental on-hit effect (burn, freeze, poison, shock)
+        const eff = unit.attackEffect
+        if (eff && target.hp > 0 && Math.random() < eff.chance) {
+          if (eff.type === 'burn') {
+            target.burnTimer  = eff.durationMs
+            target.burnDps    = eff.dps ?? 8
+          } else if (eff.type === 'freeze') {
+            target.freezeTimer = eff.durationMs
+            target.freezeSlow  = eff.slowFactor ?? 0.35
+          } else if (eff.type === 'poison') {
+            target.poisonTimer = eff.durationMs
+            target.poisonDps   = eff.dps ?? 5
+          } else if (eff.type === 'shock') {
+            target.stunTimer = Math.max(target.stunTimer ?? 0, eff.durationMs)
+          }
+        }
         s.animEvents.push({
           id: animUid(), kind: 'hit',
           fromX: target.x, fromY: target.y,

--- a/web/src/game/engine/units.ts
+++ b/web/src/game/engine/units.ts
@@ -253,8 +253,10 @@ export function moveUnits(s: GameState, deltaMs: number): void {
     const fogMult     = s.activeBattleEvent?.type === 'fogOfWar' ? 0.5 : 1
     const affMoveMult = (unit.affinityActive && unit.affinity?.effectType === 'moveSpeed')
       ? unit.affinity.effectAmount : 1
+    const freezeFactor = (unit.freezeTimer != null && unit.freezeTimer > 0 && unit.freezeSlow != null)
+      ? unit.freezeSlow : 1
     const speed = (inWallZone ? unit.moveSpeed * CLIMB_SPEED_FACTOR : unit.moveSpeed)
-      * deltaSec * fogMult * affMoveMult * clampedMoatFactor
+      * deltaSec * fogMult * affMoveMult * clampedMoatFactor * freezeFactor
 
     // Terrain avoidance: lateral repulsion from nearby obstacles
     let avoidY = 0

--- a/web/src/game/towerDefence.ts
+++ b/web/src/game/towerDefence.ts
@@ -230,6 +230,12 @@ export interface TDEnemy {
   shielded: boolean       // absorbs next hit entirely (introduced wave 30+)
   splitsOnDeath: boolean  // spawns 2 half-hp copies on death (wave 50+)
   slowsUnits: boolean     // emits aura that delays nearby unit attacks (wave 70+)
+  burnTimer?: number
+  burnDps?: number
+  freezeTimer?: number
+  freezeSlow?: number
+  poisonTimer?: number
+  poisonDps?: number
 }
 
 // Attack visual event — used by the UI to show projectile + hit spark
@@ -652,6 +658,28 @@ export function tickTD(state: TDGameState, dtMs: number): TDGameState {
     }]
   }
 
+  // ── Elemental DoT on enemies ─────────────────────────────────────────────
+  s.enemies = s.enemies.map(enemy => {
+    let e = { ...enemy }
+    if (e.burnTimer != null && e.burnTimer > 0) {
+      e.burnTimer = Math.max(0, e.burnTimer - dtMs)
+      e.hp = Math.max(0, e.hp - (e.burnDps ?? 8) * dtSec)
+    }
+    if (e.poisonTimer != null && e.poisonTimer > 0) {
+      e.poisonTimer = Math.max(0, e.poisonTimer - dtMs)
+      e.hp = Math.max(0, e.hp - (e.poisonDps ?? 5) * dtSec)
+    }
+    if (e.freezeTimer != null && e.freezeTimer > 0) {
+      e.freezeTimer = Math.max(0, e.freezeTimer - dtMs)
+    }
+    return e
+  })
+  // Award score/mana for DoT kills before movement removes them
+  for (const e of s.enemies) {
+    if (e.hp <= 0) { s.score += e.template.reward; s.mana += e.template.reward }
+  }
+  s.enemies = s.enemies.filter(e => e.hp > 0)
+
   // ── Move enemies — max 3 per cell (leaders advance first) ──────────────
   const dtSec = dtMs / 1000
   let livesLost = 0
@@ -660,7 +688,9 @@ export function tickTD(state: TDGameState, dtMs: number): TDGameState {
   // Process most-advanced enemies first so they claim cells before followers
   const enemiesByProgress = [...s.enemies].sort((a, b) => b.pathProgress - a.pathProgress)
   for (const enemy of enemiesByProgress) {
-    const np = enemy.pathProgress + enemy.template.speed * enemy.speedMult * dtSec
+    const freezeFactor = (enemy.freezeTimer != null && enemy.freezeTimer > 0 && enemy.freezeSlow != null)
+      ? enemy.freezeSlow : 1
+    const np = enemy.pathProgress + enemy.template.speed * enemy.speedMult * dtSec * freezeFactor
     if (np >= TD_PATH.length - 1) {
       livesLost += enemy.template.attack
       continue
@@ -784,6 +814,18 @@ export function tickTD(state: TDGameState, dtMs: number): TDGameState {
         } else {
           const dmg = Math.round(unitDamageDealt(unit, target) * damageMult)
           const newHp = target.hp - dmg
+          // Apply elemental on-hit effect
+          const eff = unit.template.attackEffect
+          if (eff && newHp > 0 && Math.random() < eff.chance) {
+            s.enemies = s.enemies.map(e => {
+              if (e.id !== target.id) return e
+              if (eff.type === 'burn')    return { ...e, burnTimer:   eff.durationMs, burnDps:   eff.dps ?? 8 }
+              if (eff.type === 'freeze')  return { ...e, freezeTimer: eff.durationMs, freezeSlow: eff.slowFactor ?? 0.35 }
+              if (eff.type === 'poison')  return { ...e, poisonTimer: eff.durationMs, poisonDps: eff.dps ?? 5 }
+              if (eff.type === 'shock')   return { ...e, freezeTimer: eff.durationMs, freezeSlow: 0 }
+              return e
+            })
+          }
           if (newHp <= 0) {
             deadEnemyIds.add(target.id)
             s.score += target.template.reward

--- a/web/src/game/types.ts
+++ b/web/src/game/types.ts
@@ -91,11 +91,26 @@ export interface UnitTemplate {
   invisibilityAbility?: { activeMs: number; cooldownMs: number }
   /** Blood pool consumption — unit raises a minion from a nearby blood pool every cooldownMs. */
   bloodSummonAbility?: { cooldownMs: number; minionTemplate: UnitTemplate; range: number }
+  /** Elemental on-hit effect applied when this unit attacks. Auto-derived from tags when not set. */
+  attackEffect?: AttackEffect
 }
 
 export type BuffTag = 'atk' | 'spd' | 'hp' | 'range'
 
-export type UnitTag = 'flying' | 'ranged' | 'melee' | 'fast' | 'slow' | 'large' | 'magic' | 'undead' | 'beast' | 'armored' | 'siege' | 'fire' | 'swim'
+export type UnitTag = 'flying' | 'ranged' | 'melee' | 'fast' | 'slow' | 'large' | 'magic' | 'undead' | 'beast' | 'armored' | 'siege' | 'fire' | 'swim' | 'ember' | 'frost' | 'glacier' | 'lightning' | 'poison'
+
+/** Elemental on-hit effect applied by units with matching tags (fire→burn, frost→freeze, etc.). */
+export interface AttackEffect {
+  type: 'burn' | 'freeze' | 'poison' | 'shock'
+  /** 0–1 probability per hit. */
+  chance: number
+  /** Duration in ms. */
+  durationMs: number
+  /** Damage per second — for burn and poison. */
+  dps?: number
+  /** 0–1 speed multiplier while frozen — 0 = complete stop, 0.35 = 35 % speed. */
+  slowFactor?: number
+}
 export type TargetPriority = 'walls' | 'buildings' | 'boss' | 'ranged_first'
 
 export interface AffinityDef {
@@ -179,6 +194,15 @@ export interface Unit extends UnitTemplate {
   builderSaboteurMode?: boolean
   /** ID of the last building the builder serviced — excluded when picking next target. */
   builderLastBuildingId?: string
+  /** ms remaining burning — unit takes burnDps damage per second while > 0. */
+  burnTimer?: number
+  burnDps?: number
+  /** ms remaining frozen — unit's move speed is multiplied by freezeSlow while > 0. */
+  freezeTimer?: number
+  freezeSlow?: number
+  /** ms remaining poisoned — unit takes poisonDps damage per second while > 0. */
+  poisonTimer?: number
+  poisonDps?: number
 }
 
 // ─── Animation Events ─────────────────────────────────────


### PR DESCRIPTION
## Summary

Units with elemental tags now apply status effects on hit, in both the main battle engine and the tower defence minigame:

| Tag | Effect | Chance | Duration | Detail |
|-----|--------|--------|----------|--------|
| `fire` / `ember` | 🔥 Burn | 70% | 3 s | 8 dps DoT |
| `frost` / `glacier` | ❄️ Freeze | 75% | 2.5 s | 35% move speed |
| `lightning` | ⚡ Shock | 50% | 0.6 s | brief stun |
| `poison` | ☠️ Poison | 65% | 5 s | 5 dps DoT |

Effects are auto-derived from unit tags in `cards.ts` — no per-card JSON changes needed for existing units. New tags added to cards.json templates: `lightning` (Lightning Archer, Thunder Drake, Stormcaller) and `poison` (Plague Rat).

### Implementation
- `types.ts` — `AttackEffect` interface + `attackEffect` field on `UnitTemplate`; runtime `burnTimer/burnDps/freezeTimer/freezeSlow/poisonTimer/poisonDps` fields on `Unit`; new UnitTags (`ember`, `frost`, `glacier`, `lightning`, `poison`)
- `cards.ts` — `deriveAttackEffect()` auto-wires effects from tags in `resolveUnit()`
- `engine/combat.ts` — applies effect to target on each hit
- `engine.ts` — ticks burn/poison DoT + freeze timer in `performUnitMaintenance`; handles DoT deaths with blood pool + linger
- `engine/units.ts` — applies `freezeSlow` factor to movement speed
- `towerDefence.ts` — mirrors all of the above for tower defence enemies

## Test plan

- [ ] Fire Mage / Fire Salamander attacks leave enemies burning (orange flash, hp draining)
- [ ] Frost Archer / Ice Wraith attacks slow enemy movement speed visibly
- [ ] Lightning Archer / Thunder Drake attacks briefly stun targets
- [ ] Plague Rat attacks apply a poison DoT
- [ ] Burn and poison can kill enemies (log message appears)
- [ ] Frozen enemies still move, just slower — they don't stop completely
- [ ] Effects work in tower defence minigame (fire towers burn, frost towers slow)
- [ ] No TypeScript errors, no regression in normal battles

https://claude.ai/code/session_01FFXw8rUxBVQRtJK8x762WJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01FFXw8rUxBVQRtJK8x762WJ)_