### PR TITLE
Expand attack types: AOE, sniper, gas cloud, typed projectile visuals

### DIFF
--- a/web/src/components/Battlefield.tsx
+++ b/web/src/components/Battlefield.tsx
@@ -1098,6 +1098,18 @@ export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPaus
             />
           )
         })}
+        {/* Ground hazards — poison gas clouds */}
+        {(state.hazards ?? []).map(h => {
+          const topPct  = (1 - h.x / LANE_WIDTH) * 100
+          const leftPct = 50 + (h.y / 80) * 36
+          return (
+            <div
+              key={h.id}
+              className="battlefield-hazard"
+              style={{ top: `${topPct}%`, left: `${leftPct}%` }}
+            />
+          )
+        })}
         {(() => {
           // Group walls by owner+x so stacked wall types can share a composite graphic
           const wallGroups = new Map<string, Unit[]>()
@@ -1127,9 +1139,9 @@ export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPaus
             return <LaneUnit key={u.id} unit={u} stackIndex={stackIndex} onInspect={paused ? u => { setInspectedUnit(u) } : undefined} showName={paused} celebrating={playerWon && u.owner === 'player'} spriteOverride={commanderSprite} />
           })
         })()}
-        {/* Animation events: projectiles and hit sparks */}
+        {/* Animation events: projectiles, hit sparks, AOE rings, gas clouds */}
         {(state.animEvents ?? []).map(ev => {
-          // Convert game coords to CSS % (same mapping as LaneUnit)
+          // Convert game coords to CSS %
           // x (forward 0-500) → top% = (1 - x/500)*100
           // y (lateral -80..80) → left% = 50 + (y/80)*36
           const fromJitter = ev.fromUnitId ? unitJitter(ev.fromUnitId) : { dxPct: 0, dyPct: 0 }
@@ -1137,6 +1149,26 @@ export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPaus
           const fromLeft = 50 + (ev.fromY / 80) * 36 + fromJitter.dxPct
           const toTop    = (1 - ev.toX / LANE_WIDTH) * 100
           const toLeft   = 50 + (ev.toY / 80) * 36
+          const pType = ev.projectileType ?? 'magic'
+
+          if (ev.kind === 'gascloud') {
+            return (
+              <div
+                key={ev.id}
+                className="battlefield-gascloud"
+                style={{ position: 'absolute', top: `${toTop}%`, left: `${toLeft}%`, pointerEvents: 'none', zIndex: 12 }}
+              />
+            )
+          }
+          if (ev.kind === 'aoe') {
+            return (
+              <div
+                key={ev.id}
+                className="anim-aoe-ring"
+                style={{ position: 'absolute', top: `${toTop}%`, left: `${toLeft}%`, transform: 'translate(-50%,-50%)', pointerEvents: 'none', zIndex: 60 }}
+              />
+            )
+          }
           if (ev.kind === 'projectile') {
             const dx = toLeft - fromLeft
             const dy = toTop  - fromTop
@@ -1145,13 +1177,12 @@ export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPaus
             return (
               <div
                 key={ev.id}
-                className="anim-projectile"
+                className={`anim-projectile anim-projectile--${pType}`}
                 style={{
                   position: 'absolute',
                   top: `${fromTop}%`,
                   left: `${fromLeft}%`,
                   width: `${len}%`,
-                  height: 4,
                   transform: `translate(-0%, -50%) rotate(${angleDeg}deg)`,
                   transformOrigin: '0 50%',
                   pointerEvents: 'none',
@@ -1164,7 +1195,7 @@ export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPaus
           return (
             <div
               key={ev.id}
-              className="anim-hit"
+              className={`anim-hit anim-hit--${pType}`}
               style={{
                 position: 'absolute',
                 top: `${fromTop}%`,

--- a/web/src/components/minigames/TowerDefence.tsx
+++ b/web/src/components/minigames/TowerDefence.tsx
@@ -9,7 +9,7 @@ import { UnitTemplate } from '../../game/types'
 import { SpriteImg, AnimatedSpriteImg } from '../SpriteImg'
 import {
   TD_COLS, TD_ROWS, TD_PATH, TD_TOTAL_WAVES, TD_MAX_LIVES, TD_CELL_PX, TD_MAX_UPGRADES, TD_MILESTONE_EVERY,
-  TDGameState, TDTower, TDUnit, TDEnemy, TDAttackEvent, MilestoneUpgrade,
+  TDGameState, TDTower, TDUnit, TDEnemy, TDAttackEvent, TDHazard, MilestoneUpgrade,
   isPathCell,
   createTDGame, placeTower, removeTower, moveTower, upgradeTower, startWave, tickTD,
   calcTicketReward, calcGoldReward, towerCost, upgradeCost, buildingUnitCount, chooseMilestoneUpgrade,
@@ -386,6 +386,11 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
             <EnemyToken key={enemy.id} enemy={enemy} />
           ))}
 
+          {/* Gas cloud hazards */}
+          {game.hazards.map(h => (
+            <HazardCloud key={h.id} hazard={h} />
+          ))}
+
           {/* Attack effects */}
           {game.attackEvents.map(ev => (
             <AttackEffect key={ev.id} ev={ev} />
@@ -556,8 +561,11 @@ function EnemyToken({ enemy }: { enemy: TDEnemy }) {
   const hpFrac = enemy.hp / enemy.maxHp
   const cls = [
     'td-enemy',
-    enemy.shielded    ? 'td-enemy--shielded' : '',
-    enemy.slowsUnits  ? 'td-enemy--slows'    : '',
+    enemy.shielded                                            ? 'td-enemy--shielded' : '',
+    enemy.slowsUnits                                          ? 'td-enemy--slows'    : '',
+    enemy.burnTimer   != null && enemy.burnTimer   > 0        ? 'td-enemy--burning'  : '',
+    enemy.freezeTimer != null && enemy.freezeTimer > 0        ? 'td-enemy--frozen'   : '',
+    enemy.poisonTimer != null && enemy.poisonTimer > 0        ? 'td-enemy--poisoned' : '',
   ].filter(Boolean).join(' ')
   return (
     <div
@@ -573,31 +581,71 @@ function EnemyToken({ enemy }: { enemy: TDEnemy }) {
   )
 }
 
+function HazardCloud({ hazard }: { hazard: TDHazard }) {
+  const d = hazard.radius * 2
+  return (
+    <div
+      className="td-hazard"
+      style={{
+        position: 'absolute',
+        left: hazard.x - hazard.radius,
+        top:  hazard.y - hazard.radius,
+        width: d,
+        height: d,
+        borderRadius: '50%',
+        pointerEvents: 'none',
+        zIndex: 8,
+      }}
+    />
+  )
+}
+
 function AttackEffect({ ev }: { ev: TDAttackEvent }) {
   const dx = ev.toX - ev.fromX
   const dy = ev.toY - ev.fromY
   const len = Math.hypot(dx, dy)
   const angle = Math.atan2(dy, dx) * 180 / Math.PI
+  const pType = ev.projectileType ?? 'magic'
+
+  // AOE ring: no travel line, just an expanding ring at target
+  if (pType === 'aoe' || (ev.aoeRadius && len < 2)) {
+    const r = ev.aoeRadius ?? 48
+    return (
+      <div
+        className="anim-aoe-ring"
+        style={{
+          position: 'absolute',
+          left: ev.toX - r,
+          top:  ev.toY - r,
+          width: r * 2,
+          height: r * 2,
+          borderRadius: '50%',
+          pointerEvents: 'none',
+          zIndex: 16,
+        }}
+      />
+    )
+  }
+
   return (
     <>
-      {/* Projectile line */}
+      {/* Projectile line — typed class drives colour/thickness */}
       <div
-        className="anim-projectile"
+        className={`anim-projectile anim-projectile--${pType}`}
         style={{
           position: 'absolute',
           left: ev.fromX,
           top: ev.fromY,
           width: len,
-          height: 4,
           transform: `translate(0, -50%) rotate(${angle}deg)`,
           transformOrigin: '0 50%',
           pointerEvents: 'none',
           zIndex: 15,
         }}
       />
-      {/* Hit spark */}
+      {/* Hit spark — typed class drives colour */}
       <div
-        className="anim-hit"
+        className={`anim-hit anim-hit--${pType}`}
         style={{
           position: 'absolute',
           left: ev.toX,

--- a/web/src/data/cards.json
+++ b/web/src/data/cards.json
@@ -3279,7 +3279,7 @@
       "attack": 8,
       "maxHp": 24,
       "isWall": false,
-      "bypassWall": false,
+      "bypassWall": true,
       "moveSpeed": 50,
       "attackRange": 85,
       "attackCooldownMs": 1500,
@@ -3287,7 +3287,8 @@
       "tags": [
         "ranged",
         "magic",
-        "lightning"
+        "lightning",
+        "aoe"
       ],
       "strengths": [
         "armored",
@@ -3363,7 +3364,8 @@
         "flying",
         "large",
         "magic",
-        "lightning"
+        "lightning",
+        "aoe"
       ],
       "strengths": [
         "melee",
@@ -3384,6 +3386,61 @@
         "effectType": "attackSpeed",
         "effectAmount": 1.25,
         "label": "Storm Pact"
+      }
+    },
+    "plague-shaman": {
+      "name": "Plague Shaman",
+      "attack": 4,
+      "maxHp": 22,
+      "isWall": false,
+      "bypassWall": true,
+      "moveSpeed": 28,
+      "attackRange": 100,
+      "attackCooldownMs": 2500,
+      "flying": false,
+      "tags": [
+        "ranged",
+        "magic",
+        "poison",
+        "gascloud"
+      ],
+      "strengths": [
+        "melee",
+        "beast"
+      ],
+      "weaknesses": [
+        "fire",
+        "fast"
+      ],
+      "size": "medium"
+    },
+    "marksman": {
+      "name": "Marksman",
+      "attack": 20,
+      "maxHp": 18,
+      "isWall": false,
+      "bypassWall": true,
+      "moveSpeed": 22,
+      "attackRange": 200,
+      "attackCooldownMs": 3500,
+      "flying": false,
+      "tags": [
+        "ranged",
+        "slow"
+      ],
+      "strengths": [
+        "large",
+        "flying"
+      ],
+      "weaknesses": [
+        "fast",
+        "melee"
+      ],
+      "size": "medium",
+      "unitTrait": {
+        "guardBase": true,
+        "baseGuardRange": 120,
+        "engageRange": 250
       }
     },
     "sky-leviathan": {
@@ -12000,6 +12057,19 @@
       "lore": "One is an annoyance. A hundred is a catastrophe."
     },
     {
+      "name": "Plague Shaman",
+      "rarity": "rare",
+      "cost": 3,
+      "cardType": "unit",
+      "unitRef": "plague-shaman",
+      "description": "Ranged magic. Lobs poison gas clouds that linger on the battlefield.",
+      "deckCount": 1,
+      "tags": [
+        "ashen"
+      ],
+      "lore": "The cloud arrives before the caster does. The caster prefers it that way."
+    },
+    {
       "name": "Bandit",
       "rarity": "common",
       "cost": 1,
@@ -15020,6 +15090,19 @@
         "sky"
       ],
       "lore": "The arrows are made of compressed storm. The quiver is a weather system."
+    },
+    {
+      "name": "Marksman",
+      "rarity": "uncommon",
+      "cost": 3,
+      "cardType": "unit",
+      "unitRef": "marksman",
+      "description": "Slow-firing sniper. Extreme range, very high damage per shot.",
+      "deckCount": 1,
+      "tags": [
+        "forest"
+      ],
+      "lore": "One bolt. One corpse. No wasted words."
     },
     {
       "name": "Gale Warden",

--- a/web/src/game/battleReducer.test.ts
+++ b/web/src/game/battleReducer.test.ts
@@ -51,6 +51,7 @@ function makeGameState(overrides: Partial<GameState> = {}): GameState {
     battleStats: { cardsPlayed: {}, playerKills: 0, playerUnitsLost: 0 } satisfies BattleStats,
     animEvents: [],
     bloodPools: [],
+    hazards: [],
     ...overrides,
   }
 }

--- a/web/src/game/cards.ts
+++ b/web/src/game/cards.ts
@@ -64,13 +64,17 @@ interface RawUnitDef {
 function deriveAttackEffect(tags: string[] | undefined, attack: number): AttackEffect | undefined {
   if (!tags || attack === 0) return undefined
   if (tags.includes('fire') || tags.includes('ember'))
-    return { type: 'burn',   chance: 0.70, durationMs: 3000, dps: 8 }
+    return { type: 'burn',     chance: 0.70, durationMs: 3000, dps: 8 }
   if (tags.includes('frost') || tags.includes('glacier'))
-    return { type: 'freeze', chance: 0.75, durationMs: 2500, slowFactor: 0.35 }
+    return { type: 'freeze',   chance: 0.75, durationMs: 2500, slowFactor: 0.35 }
+  if (tags.includes('gascloud'))
+    return { type: 'gascloud', chance: 1.00, durationMs: 8000, aoeRadius: 72, dps: 6 }
+  if (tags.includes('aoe'))
+    return { type: 'aoe',      chance: 1.00, durationMs: 500,  aoeRadius: 72 }
   if (tags.includes('lightning'))
-    return { type: 'shock',  chance: 0.50, durationMs: 600 }
+    return { type: 'shock',    chance: 0.50, durationMs: 600 }
   if (tags.includes('poison'))
-    return { type: 'poison', chance: 0.65, durationMs: 5000, dps: 5 }
+    return { type: 'poison',   chance: 0.65, durationMs: 5000, dps: 5 }
   return undefined
 }
 

--- a/web/src/game/engine.ts
+++ b/web/src/game/engine.ts
@@ -315,6 +315,7 @@ export function newGame(
     battleStats: { cardsPlayed: {}, playerKills: 0, playerUnitsLost: 0 },
     animEvents: [],
     bloodPools: [],
+    hazards: [],
     endlessMode: endlessMode ?? false,
     endlessWave: endlessMode ? 1 : undefined,
     endlessSurvivalMs: endlessMode ? 0 : undefined,
@@ -526,6 +527,7 @@ export function tick(state: GameState, deltaMs: number): GameState {
 function tidyBattlefield(s: GameState) {
   s.animEvents = s.animEvents.filter(e => e.expiresAt > s.gameTime)
   s.bloodPools = s.bloodPools.filter(p => p.fadingAt === undefined || s.gameTime - p.fadingAt <= BLOOD_POOL_FADE_MS)
+  s.hazards    = s.hazards.filter(h => h.expiresAt > s.gameTime)
 }
 
 function processBattleEvents(s: GameState, deltaMs: number, log: string[]) {
@@ -605,6 +607,19 @@ function performUnitMaintenance(s: GameState, deltaMs: number, log: string[]) {
         unit.dyingTimer = DEATH_LINGER_MS
         if (!unit.flying) s.bloodPools.push({ id: `poison-${unit.id}`, x: unit.x, y: unit.y ?? 0 })
         log.push(`${unit.name} succumbs to poison!`)
+      }
+    }
+    // Ground hazard damage (gas clouds, etc.)
+    for (const hazard of s.hazards) {
+      if (hazard.owner === unit.owner || unit.hp <= 0) continue
+      if (Math.hypot(unit.x - hazard.x, unit.y - hazard.y) <= hazard.radius) {
+        unit.hp = Math.max(0, Math.round(unit.hp - hazard.dps * deltaMs / 1000))
+        if (!unit.damageFlashTimer || unit.damageFlashTimer <= 0) unit.damageFlashTimer = 80
+        if (unit.hp <= 0 && unit.moveSpeed > 0 && !unit.isWall) {
+          unit.dyingTimer = DEATH_LINGER_MS
+          if (!unit.flying) s.bloodPools.push({ id: `hazard-${unit.id}`, x: unit.x, y: unit.y ?? 0 })
+          log.push(`${unit.name} chokes in the gas!`)
+        }
       }
     }
     // Update climbing flag: true when climber unit is inside an enemy wall zone

--- a/web/src/game/engine.ts
+++ b/web/src/game/engine.ts
@@ -588,7 +588,7 @@ function performUnitMaintenance(s: GameState, deltaMs: number, log: string[]) {
     // Burn DoT — ticks down and deals damage each frame
     if (unit.burnTimer != null && unit.burnTimer > 0 && unit.hp > 0) {
       unit.burnTimer = Math.max(0, unit.burnTimer - deltaMs)
-      unit.hp = Math.max(0, unit.hp - (unit.burnDps ?? 8) * deltaMs / 1000)
+      unit.hp = Math.max(0, Math.round(unit.hp - (unit.burnDps ?? 8) * deltaMs / 1000))
       if (!unit.damageFlashTimer || unit.damageFlashTimer <= 0) unit.damageFlashTimer = 80
       if (unit.hp <= 0 && unit.moveSpeed > 0 && !unit.isWall) {
         unit.dyingTimer = DEATH_LINGER_MS
@@ -599,7 +599,7 @@ function performUnitMaintenance(s: GameState, deltaMs: number, log: string[]) {
     // Poison DoT — ticks down and deals damage each frame
     if (unit.poisonTimer != null && unit.poisonTimer > 0 && unit.hp > 0) {
       unit.poisonTimer = Math.max(0, unit.poisonTimer - deltaMs)
-      unit.hp = Math.max(0, unit.hp - (unit.poisonDps ?? 5) * deltaMs / 1000)
+      unit.hp = Math.max(0, Math.round(unit.hp - (unit.poisonDps ?? 5) * deltaMs / 1000))
       if (!unit.damageFlashTimer || unit.damageFlashTimer <= 0) unit.damageFlashTimer = 80
       if (unit.hp <= 0 && unit.moveSpeed > 0 && !unit.isWall) {
         unit.dyingTimer = DEATH_LINGER_MS

--- a/web/src/game/engine/combat.ts
+++ b/web/src/game/engine/combat.ts
@@ -1,6 +1,6 @@
 import { isNoDamageMode } from '../debug'
 import { playBuildingDestroyed, playUnitDeath, playUnitAttack } from '../sound'
-import { AnimEvent, GameState, Unit } from '../types'
+import { AnimEvent, GameState, Unit, getProjectileType } from '../types'
 import { DAMAGE_FLASH_MS, BLOOD_POOL_MAX } from './constants'
 import { getAttackAura } from './bonusEffects'
 import { animUid, spawnUnit } from './helpers'
@@ -67,6 +67,8 @@ export function processAttacks(s: GameState, deltaMs: number, log: string[]): vo
           fromX: unit.x, fromY: unit.y,
           toX: target.x, toY: target.y,
           expiresAt: s.gameTime + travelMs,
+          projectileType: getProjectileType(unit.tags),
+          aoeRadius: unit.attackEffect?.aoeRadius,
         }
         s.animEvents.push(proj)
       }
@@ -83,7 +85,7 @@ export function processAttacks(s: GameState, deltaMs: number, log: string[]): vo
           target.targetId = unit.id
         }
         target.damageFlashTimer = DAMAGE_FLASH_MS
-        // Apply elemental on-hit effect (burn, freeze, poison, shock)
+        // Apply elemental on-hit effect (burn, freeze, poison, shock, aoe, gascloud)
         const eff = unit.attackEffect
         if (eff && target.hp > 0 && Math.random() < eff.chance) {
           if (eff.type === 'burn') {
@@ -97,6 +99,44 @@ export function processAttacks(s: GameState, deltaMs: number, log: string[]): vo
             target.poisonDps   = eff.dps ?? 5
           } else if (eff.type === 'shock') {
             target.stunTimer = Math.max(target.stunTimer ?? 0, eff.durationMs)
+          } else if (eff.type === 'aoe' && eff.aoeRadius) {
+            // AOE burst: deal same damage to all enemies within radius
+            const aoeTargets = s.field.filter(
+              e => e.owner !== unit.owner && e.hp > 0 && e.id !== target.id &&
+                   Math.hypot(e.x - target.x, e.y - target.y) <= eff.aoeRadius!
+            )
+            for (const e of aoeTargets) {
+              e.hp = Math.max(0, e.hp - dmg)
+              e.damageFlashTimer = DAMAGE_FLASH_MS
+              if (isPlayer) s.playerScore += Math.min(dmg, prevHp)
+              else          s.opponentScore += Math.min(dmg, prevHp)
+            }
+            // AOE ring visual
+            s.animEvents.push({
+              id: animUid(), kind: 'aoe',
+              fromX: target.x, fromY: target.y,
+              toX: target.x,   toY: target.y,
+              expiresAt: s.gameTime + 500,
+              aoeRadius: eff.aoeRadius,
+            })
+          } else if (eff.type === 'gascloud' && eff.aoeRadius) {
+            // Drop a lingering gas cloud at the target position
+            s.hazards.push({
+              id: animUid(),
+              x: target.x, y: target.y,
+              radius: eff.aoeRadius,
+              dps: eff.dps ?? 6,
+              owner: unit.owner,
+              expiresAt: s.gameTime + eff.durationMs,
+            })
+            // Cloud visual (long-lived AnimEvent used for rendering)
+            s.animEvents.push({
+              id: animUid(), kind: 'gascloud',
+              fromX: target.x, fromY: target.y,
+              toX: target.x,   toY: target.y,
+              expiresAt: s.gameTime + eff.durationMs,
+              aoeRadius: eff.aoeRadius,
+            })
           }
         }
         s.animEvents.push({

--- a/web/src/game/towerDefence.ts
+++ b/web/src/game/towerDefence.ts
@@ -663,11 +663,11 @@ export function tickTD(state: TDGameState, dtMs: number): TDGameState {
     let e = { ...enemy }
     if (e.burnTimer != null && e.burnTimer > 0) {
       e.burnTimer = Math.max(0, e.burnTimer - dtMs)
-      e.hp = Math.max(0, e.hp - (e.burnDps ?? 8) * dtSec)
+      e.hp = Math.max(0, Math.round(e.hp - (e.burnDps ?? 8) * dtSec))
     }
     if (e.poisonTimer != null && e.poisonTimer > 0) {
       e.poisonTimer = Math.max(0, e.poisonTimer - dtMs)
-      e.hp = Math.max(0, e.hp - (e.poisonDps ?? 5) * dtSec)
+      e.hp = Math.max(0, Math.round(e.hp - (e.poisonDps ?? 5) * dtSec))
     }
     if (e.freezeTimer != null && e.freezeTimer > 0) {
       e.freezeTimer = Math.max(0, e.freezeTimer - dtMs)

--- a/web/src/game/towerDefence.ts
+++ b/web/src/game/towerDefence.ts
@@ -1,7 +1,7 @@
 // ─── Tower Defence — pure game logic ──────────────────────────────────────────
 // No React imports. All state is plain objects; tick() returns a new state.
 
-import { UnitTemplate, UnitTag } from './types'
+import { UnitTemplate, UnitTag, ProjectileType, getProjectileType } from './types'
 
 // ── Grid ──────────────────────────────────────────────────────────────────────
 
@@ -246,6 +246,18 @@ export interface TDAttackEvent {
   toX: number
   toY: number
   expiresAt: number   // game-time ms
+  projectileType?: ProjectileType
+  aoeRadius?: number
+}
+
+// Persistent ground hazard — gas cloud, etc.
+export interface TDHazard {
+  id: number
+  x: number
+  y: number
+  radius: number
+  dps: number
+  expiresAt: number  // gameTimeMs when it expires
 }
 
 // Global passive bonuses accumulated through milestone upgrades
@@ -300,6 +312,7 @@ export interface TDGameState {
   log: string[]
   score: number
   attackEvents: TDAttackEvent[]
+  hazards: TDHazard[]
   availableTemplates: UnitTemplate[]
   remainingPlacements: Record<string, number>
   mode: 'collection' | 'city'
@@ -491,6 +504,7 @@ export function createTDGame(
     nextWaveAt: 0,
     log: ['Place your buildings, then press START WAVE.'],
     attackEvents: [],
+    hazards: [],
     score: 0,
     availableTemplates,
     remainingPlacements: { ...placementsPerTemplate },
@@ -630,11 +644,13 @@ export function startWave(state: TDGameState): TDGameState {
 export function tickTD(state: TDGameState, dtMs: number): TDGameState {
   if (state.phase === 'prep' || state.phase === 'victory' || state.phase === 'defeat') return state
 
+  const dtSec = dtMs / 1000
   let s = { ...state, gameTimeMs: state.gameTimeMs + dtMs }
   s.towers = [...s.towers]
   s.units = [...s.units]
   s.enemies = [...s.enemies]
   s.spawnQueue = [...s.spawnQueue]
+  s.hazards = [...s.hazards]
   s.log = [...s.log]
 
   // ── Spawn enemies ─────────────────────────────────────────────────────────
@@ -681,7 +697,6 @@ export function tickTD(state: TDGameState, dtMs: number): TDGameState {
   s.enemies = s.enemies.filter(e => e.hp > 0)
 
   // ── Move enemies — max 3 per cell (leaders advance first) ──────────────
-  const dtSec = dtMs / 1000
   let livesLost = 0
   const claimedEnemyCells = new Map<string, number>()  // "col,row" -> occupant count
   const survivingEnemies: TDEnemy[] = []
@@ -816,15 +831,33 @@ export function tickTD(state: TDGameState, dtMs: number): TDGameState {
           const newHp = target.hp - dmg
           // Apply elemental on-hit effect
           const eff = unit.template.attackEffect
-          if (eff && newHp > 0 && Math.random() < eff.chance) {
-            s.enemies = s.enemies.map(e => {
-              if (e.id !== target.id) return e
-              if (eff.type === 'burn')    return { ...e, burnTimer:   eff.durationMs, burnDps:   eff.dps ?? 8 }
-              if (eff.type === 'freeze')  return { ...e, freezeTimer: eff.durationMs, freezeSlow: eff.slowFactor ?? 0.35 }
-              if (eff.type === 'poison')  return { ...e, poisonTimer: eff.durationMs, poisonDps: eff.dps ?? 5 }
-              if (eff.type === 'shock')   return { ...e, freezeTimer: eff.durationMs, freezeSlow: 0 }
-              return e
-            })
+          if (eff && Math.random() < eff.chance) {
+            if (eff.type === 'burn' || eff.type === 'freeze' || eff.type === 'poison' || eff.type === 'shock') {
+              if (newHp > 0) {
+                s.enemies = s.enemies.map(e => {
+                  if (e.id !== target.id) return e
+                  if (eff.type === 'burn')   return { ...e, burnTimer:   eff.durationMs, burnDps:   eff.dps ?? 8 }
+                  if (eff.type === 'freeze') return { ...e, freezeTimer: eff.durationMs, freezeSlow: eff.slowFactor ?? 0.35 }
+                  if (eff.type === 'poison') return { ...e, poisonTimer: eff.durationMs, poisonDps: eff.dps ?? 5 }
+                  if (eff.type === 'shock')  return { ...e, freezeTimer: eff.durationMs, freezeSlow: 0 }
+                  return e
+                })
+              }
+            } else if (eff.type === 'aoe' && eff.aoeRadius) {
+              // AOE burst: deal same damage to all enemies in radius
+              s.enemies = s.enemies.map(e => {
+                if (e.id === target.id || deadEnemyIds.has(e.id) || e.hp <= 0) return e
+                if (dist(e.x, e.y, target.x, target.y) > eff.aoeRadius!) return e
+                const splashHp = e.hp - dmg
+                if (splashHp <= 0) { deadEnemyIds.add(e.id); s.score += e.template.reward; s.mana += e.template.reward }
+                return { ...e, hp: Math.max(0, splashHp) }
+              })
+              // AOE ring visual
+              newAttackEvents.push({ id: nextId(), fromX: target.x, fromY: target.y, toX: target.x, toY: target.y, expiresAt: s.gameTimeMs + 500, aoeRadius: eff.aoeRadius })
+            } else if (eff.type === 'gascloud' && eff.aoeRadius) {
+              // Drop lingering gas cloud at target position
+              s.hazards = [...s.hazards, { id: nextId(), x: target.x, y: target.y, radius: eff.aoeRadius, dps: eff.dps ?? 6, expiresAt: s.gameTimeMs + eff.durationMs }]
+            }
           }
           if (newHp <= 0) {
             deadEnemyIds.add(target.id)
@@ -839,6 +872,8 @@ export function tickTD(state: TDGameState, dtMs: number): TDGameState {
           fromX: unit.x, fromY: unit.y,
           toX: target.x, toY: target.y,
           expiresAt: s.gameTimeMs + 400,
+          projectileType: getProjectileType(unit.template.tags),
+          aoeRadius: unit.template.attackEffect?.aoeRadius,
         })
         const slowPenalty = slowedUnitIds.has(unit.id) ? 1.5 : 1
         cd = unit.template.attackCooldownMs / attackSpeedMult * slowPenalty
@@ -914,6 +949,27 @@ export function tickTD(state: TDGameState, dtMs: number): TDGameState {
     return { ...tower, respawnTimers: timers }
   })
   s.units = [...s.units, ...newlySpawned]
+
+  // ── Hazard damage on enemies ─────────────────────────────────────────────
+  s.hazards = s.hazards.filter(h => h.expiresAt > s.gameTimeMs)
+  if (s.hazards.length > 0) {
+    const hazardDeadIds = new Set<number>()
+    s.enemies = s.enemies.map(enemy => {
+      let e = { ...enemy }
+      for (const hazard of s.hazards) {
+        if (dist(e.x, e.y, hazard.x, hazard.y) <= hazard.radius) {
+          e.hp = Math.max(0, Math.round(e.hp - hazard.dps * dtSec))
+          if (e.hp <= 0 && !hazardDeadIds.has(e.id)) {
+            hazardDeadIds.add(e.id)
+            s.score += e.template.reward
+            s.mana += e.template.reward
+          }
+        }
+      }
+      return e
+    })
+    s.enemies = s.enemies.filter(e => !hazardDeadIds.has(e.id))
+  }
 
   // ── Check defeat ──────────────────────────────────────────────────────────
   if (s.lives <= 0) {

--- a/web/src/game/types.sample.ts
+++ b/web/src/game/types.sample.ts
@@ -93,4 +93,5 @@ terrain: [],
 battleStats: exampleBattleStats,
 animEvents: [exampleAnimEvent],
 bloodPools: [{ id: 'bp1', x: 2, y: 3 }],
+hazards: [],
 };

--- a/web/src/game/types.ts
+++ b/web/src/game/types.ts
@@ -97,19 +97,35 @@ export interface UnitTemplate {
 
 export type BuffTag = 'atk' | 'spd' | 'hp' | 'range'
 
-export type UnitTag = 'flying' | 'ranged' | 'melee' | 'fast' | 'slow' | 'large' | 'magic' | 'undead' | 'beast' | 'armored' | 'siege' | 'fire' | 'swim' | 'ember' | 'frost' | 'glacier' | 'lightning' | 'poison'
+export type UnitTag = 'flying' | 'ranged' | 'melee' | 'fast' | 'slow' | 'large' | 'magic' | 'undead' | 'beast' | 'armored' | 'siege' | 'fire' | 'swim' | 'ember' | 'frost' | 'glacier' | 'lightning' | 'poison' | 'aoe' | 'gascloud'
+
+/** Visual style of a projectile — drives rendering in both the battle and TD renderers. */
+export type ProjectileType = 'arrow' | 'fireball' | 'icebolt' | 'poisonblob' | 'magic' | 'lightning' | 'aoe'
+
+/** Derive a projectile visual type from a unit's tags. */
+export function getProjectileType(tags: UnitTag[] | undefined): ProjectileType {
+  if (!tags) return 'magic'
+  if (tags.includes('fire') || tags.includes('ember'))          return 'fireball'
+  if (tags.includes('frost') || tags.includes('glacier'))       return 'icebolt'
+  if (tags.includes('poison') || tags.includes('gascloud'))     return 'poisonblob'
+  if (tags.includes('lightning') || tags.includes('aoe'))       return 'lightning'
+  if (tags.includes('ranged'))                                   return 'arrow'
+  return 'magic'
+}
 
 /** Elemental on-hit effect applied by units with matching tags (fire→burn, frost→freeze, etc.). */
 export interface AttackEffect {
-  type: 'burn' | 'freeze' | 'poison' | 'shock'
+  type: 'burn' | 'freeze' | 'poison' | 'shock' | 'aoe' | 'gascloud'
   /** 0–1 probability per hit. */
   chance: number
-  /** Duration in ms. */
+  /** Duration in ms — for burn/poison: DoT duration; for freeze: slow duration; for gascloud: cloud lifetime. */
   durationMs: number
-  /** Damage per second — for burn and poison. */
+  /** Damage per second — for burn, poison, and gascloud. */
   dps?: number
-  /** 0–1 speed multiplier while frozen — 0 = complete stop, 0.35 = 35 % speed. */
+  /** 0–1 speed multiplier while frozen — 0 = complete stop. */
   slowFactor?: number
+  /** Pixel radius — for aoe: splash radius; for gascloud: cloud radius on the map. */
+  aoeRadius?: number
 }
 export type TargetPriority = 'walls' | 'buildings' | 'boss' | 'ranged_first'
 
@@ -205,9 +221,24 @@ export interface Unit extends UnitTemplate {
   poisonDps?: number
 }
 
+// ─── Ground Hazards ───────────────────────────────────────
+
+/** Persistent ground hazard (e.g. poison gas cloud) — damages units that move through it. */
+export interface Hazard {
+  id: string
+  x: number
+  y: number
+  radius: number
+  /** Damage per second dealt to enemies within radius. */
+  dps: number
+  owner: 'player' | 'opponent'
+  /** Absolute ms game-time when this hazard expires. */
+  expiresAt: number
+}
+
 // ─── Animation Events ─────────────────────────────────────
 
-export type AnimEventKind = 'projectile' | 'hit'
+export type AnimEventKind = 'projectile' | 'hit' | 'aoe' | 'gascloud'
 
 export interface AnimEvent {
   id: string
@@ -222,6 +253,10 @@ export interface AnimEvent {
   toY: number
   /** Absolute game-time (ms) when this event expires and should be removed. */
   expiresAt: number
+  /** Visual style of the projectile — arrow, fireball, icebolt, etc. */
+  projectileType?: ProjectileType
+  /** For AOE projectiles: radius of the impact ring in px. */
+  aoeRadius?: number
 }
 
 export interface Card {
@@ -355,6 +390,8 @@ export interface GameState {
   animEvents: AnimEvent[]
   /** Persistent blood pool stains left by fallen units. FIFO-capped at 25; older pools fade out. */
   bloodPools: Array<{ id: string; x: number; y: number; fadingAt?: number }>
+  /** Active ground hazards (e.g. gas clouds) — damage units within radius while alive. */
+  hazards: Hazard[]
   /** True when running in Endless Mode (wave survival). */
   endlessMode?: boolean
   /** Current wave number in Endless Mode (starts at 1). */

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -8299,11 +8299,54 @@ html.light-mode .action-btn {
   80%  { clip-path: inset(0 0% 0 0);   opacity: 1; }
   100% { clip-path: inset(0 0% 0 0);   opacity: 0; }
 }
+/* Base projectile — magic (default, golden) */
 .anim-projectile {
+  height: 4px;
   background: linear-gradient(90deg, transparent, rgba(255,220,80,0.9), #fff);
   border-radius: 2px;
   box-shadow: 0 0 4px 1px rgba(255,200,50,0.7);
   animation: projectile-travel 0.5s ease-out forwards;
+}
+
+/* Arrow — thin brown shaft */
+.anim-projectile--arrow {
+  height: 2px;
+  background: linear-gradient(90deg, transparent, #8B5E3C, #c8a472);
+  box-shadow: none;
+  border-radius: 1px;
+}
+
+/* Fireball — thick bright orange glow */
+.anim-projectile--fireball {
+  height: 7px;
+  background: linear-gradient(90deg, transparent, rgba(255,80,0,0.8), #ffcc00);
+  box-shadow: 0 0 8px 3px rgba(255,120,0,0.8);
+  border-radius: 4px;
+}
+
+/* Icebolt — thin blue-white streak */
+.anim-projectile--icebolt {
+  height: 3px;
+  background: linear-gradient(90deg, transparent, rgba(100,200,255,0.8), #e0f7ff);
+  box-shadow: 0 0 5px 2px rgba(80,180,255,0.6);
+  border-radius: 2px;
+}
+
+/* Poison blob — rounded green glob */
+.anim-projectile--poisonblob {
+  height: 8px;
+  background: linear-gradient(90deg, transparent, rgba(60,180,60,0.8), #90ee90);
+  box-shadow: 0 0 6px 3px rgba(40,160,40,0.7);
+  border-radius: 4px;
+}
+
+/* Lightning — very thin bright-white/yellow flash */
+.anim-projectile--lightning {
+  height: 2px;
+  background: linear-gradient(90deg, transparent, rgba(200,220,255,0.9), #fff);
+  box-shadow: 0 0 6px 2px rgba(180,200,255,0.9);
+  border-radius: 1px;
+  animation: projectile-travel 0.15s ease-out forwards;
 }
 
 /* Hit spark: brief starburst at impact point */
@@ -8318,6 +8361,49 @@ html.light-mode .action-btn {
   background: radial-gradient(circle, rgba(255,230,80,0.95) 0%, rgba(255,100,20,0.6) 50%, transparent 80%);
   border-radius: 50%;
   animation: hit-spark-anim 0.3s ease-out forwards;
+}
+/* Typed hit sparks */
+.anim-hit--arrow     { background: radial-gradient(circle, rgba(200,160,80,0.95) 0%, rgba(120,80,20,0.5) 60%, transparent 80%); }
+.anim-hit--fireball  { background: radial-gradient(circle, #fff 0%, rgba(255,140,0,0.9) 40%, rgba(200,40,0,0.4) 70%, transparent 90%); width: 34px; height: 34px; }
+.anim-hit--icebolt   { background: radial-gradient(circle, #e8f8ff 0%, rgba(100,200,255,0.8) 50%, transparent 80%); }
+.anim-hit--poisonblob{ background: radial-gradient(circle, rgba(180,255,180,0.95) 0%, rgba(40,160,40,0.7) 55%, transparent 80%); }
+.anim-hit--lightning { background: radial-gradient(circle, #fff 0%, rgba(200,220,255,0.9) 50%, transparent 80%); width: 20px; height: 20px; }
+
+/* AOE ring: expanding ring at impact */
+@keyframes aoe-ring-expand {
+  0%   { transform: translate(-50%,-50%) scale(0.1); opacity: 0.9; }
+  70%  { opacity: 0.6; }
+  100% { transform: translate(-50%,-50%) scale(1);   opacity: 0; }
+}
+.anim-aoe-ring {
+  width: 96px;
+  height: 96px;
+  border: 3px solid rgba(200,220,255,0.9);
+  border-radius: 50%;
+  box-shadow: 0 0 12px 4px rgba(180,200,255,0.5);
+  animation: aoe-ring-expand 0.5s ease-out forwards;
+}
+
+/* Gas cloud hazard — battlefield lane version */
+@keyframes hazard-drift {
+  0%   { opacity: 0.35; transform: translate(-50%,-50%) scale(0.9); }
+  50%  { opacity: 0.55; transform: translate(-50%,-50%) scale(1.05); }
+  100% { opacity: 0.35; transform: translate(-50%,-50%) scale(0.9); }
+}
+.battlefield-hazard {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(80,200,80,0.55) 0%, rgba(40,140,40,0.3) 60%, transparent 85%);
+  animation: hazard-drift 2s ease-in-out infinite;
+}
+.battlefield-gascloud {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(80,200,80,0.6) 0%, rgba(40,140,40,0.35) 60%, transparent 85%);
+  transform: translate(-50%,-50%);
+  animation: hazard-drift 1.8s ease-in-out infinite;
 }
 
 /* ─────────────────────────────────────────────────────────
@@ -12625,6 +12711,28 @@ html.light-mode .action-btn {
 .td-enemy-hp-fill { height: 100%; border-radius: 2px; transition: width 0.05s; }
 .td-enemy--shielded { filter: drop-shadow(0 0 3px #4fc3f7) drop-shadow(0 0 6px #0288d1); }
 .td-enemy--slows    { filter: drop-shadow(0 0 3px #ce93d8) drop-shadow(0 0 6px #7b1fa2); }
+.td-enemy--burning  { filter: drop-shadow(0 0 3px #ff6a00) drop-shadow(0 0 6px #ff2200); animation: td-burning-flicker 0.4s ease-in-out infinite alternate; }
+.td-enemy--frozen   { filter: drop-shadow(0 0 4px #80d8ff) saturate(0.4) brightness(1.2); }
+.td-enemy--poisoned { filter: drop-shadow(0 0 3px #4caf50) drop-shadow(0 0 6px #1b5e20) hue-rotate(60deg); }
+
+@keyframes td-burning-flicker {
+  from { filter: drop-shadow(0 0 3px #ff6a00) drop-shadow(0 0 5px #ff2200) brightness(1.1); }
+  to   { filter: drop-shadow(0 0 5px #ffaa00) drop-shadow(0 0 8px #ff4400) brightness(1.3); }
+}
+
+/* TD hazard cloud (gas) */
+@keyframes td-hazard-pulse {
+  0%   { opacity: 0.4; transform: scale(0.92); }
+  50%  { opacity: 0.65; transform: scale(1.05); }
+  100% { opacity: 0.4; transform: scale(0.92); }
+}
+.td-hazard {
+  background: radial-gradient(circle, rgba(80,200,80,0.6) 0%, rgba(40,140,40,0.35) 60%, transparent 85%);
+  border-radius: 50%;
+  animation: td-hazard-pulse 2s ease-in-out infinite;
+  position: absolute;
+  transform-origin: center;
+}
 
 /* ── Milestone reward choices ── */
 .td-milestone-choices {


### PR DESCRIPTION
## Summary

- **New unit types**: Plague Shaman (drops lingering poison gas clouds), Marksman (slow-firing sniper with extreme 200px range), Stormcaller and Thunder Drake upgraded to AOE attackers
- **Typed projectile visuals**: arrows (thin brown shaft), fireballs (thick orange glow), icebolt (blue streak), poison blob (green glob), lightning (thin white flash) — each with a distinct hit spark colour
- **Gas cloud hazard system**: Plague Shaman lobs clouds that linger on the map dealing poison DoT to any enemy that walks through. Rendered as a pulsing green glow in both the main battle and Tower Defence
- **AOE attack effect**: splash damage hits all enemies in radius on impact, with an expanding ring animation
- **Tower Defence**: enemy status glows (orange burning flicker, blue desaturated frozen, green poisoned hue-rotate), hazard cloud rendering, typed projectiles
- **Bug fix**: `dtSec` temporal dead zone in towerDefence.ts DoT processing (was declared after first use)

## Test plan

- [ ] Play a battle with a Stormcaller or Thunder Drake — verify expanding AOE ring appears on hit and nearby enemies take splash damage
- [ ] Deploy a Plague Shaman — verify green gas cloud appears at the target position and enemies walking through it take damage over time
- [ ] Observe an Archer vs Fireling — arrow projectile should look different from a fireball projectile
- [ ] Tower Defence: place a fire unit, verify burning orange glow on hit enemies; place a frost unit, verify blue desaturated frozen glow
- [ ] Tower Defence: verify gas cloud hazard appears on map and damages enemies passing through it
- [ ] Score should remain integer throughout (no floating point)

https://claude.ai/code/session_01FFXw8rUxBVQRtJK8x762WJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01FFXw8rUxBVQRtJK8x762WJ)_