### PR TITLE
Add sprites and spawn buildings for Plague Shaman and Marksman

### DIFF
--- a/web/src/data/cards.json
+++ b/web/src/data/cards.json
@@ -3443,6 +3443,40 @@
         "engageRange": 250
       }
     },
+    "plague-den": {
+      "name": "Plague Den",
+      "attack": 0,
+      "maxHp": 30,
+      "isWall": false,
+      "bypassWall": false,
+      "moveSpeed": 0,
+      "attackRange": 0,
+      "attackCooldownMs": 99999,
+      "structureEffect": {
+        "type": "spawn",
+        "unitTemplateRef": "plague-shaman",
+        "intervalMs": 12000
+      },
+      "tags": [
+        "ashen"
+      ]
+    },
+    "sniper-post": {
+      "name": "Sniper Post",
+      "attack": 0,
+      "maxHp": 20,
+      "isWall": false,
+      "bypassWall": false,
+      "moveSpeed": 0,
+      "attackRange": 0,
+      "attackCooldownMs": 99999,
+      "structureEffect": {
+        "type": "spawn",
+        "unitTemplateRef": "marksman",
+        "intervalMs": 15000
+      },
+      "tags": []
+    },
     "sky-leviathan": {
       "name": "Sky Leviathan",
       "attack": 20,
@@ -12070,6 +12104,19 @@
       "lore": "The cloud arrives before the caster does. The caster prefers it that way."
     },
     {
+      "name": "Plague Den",
+      "rarity": "rare",
+      "cost": 4,
+      "cardType": "structure",
+      "unitRef": "plague-den",
+      "description": "Spawner. Periodically releases Plague Shamans who drop lingering gas clouds.",
+      "deckCount": 1,
+      "tags": [
+        "ashen"
+      ],
+      "lore": "The smell arrives a full minute before the shamans do."
+    },
+    {
       "name": "Bandit",
       "rarity": "common",
       "cost": 1,
@@ -15103,6 +15150,19 @@
         "forest"
       ],
       "lore": "One bolt. One corpse. No wasted words."
+    },
+    {
+      "name": "Sniper Post",
+      "rarity": "uncommon",
+      "cost": 3,
+      "cardType": "structure",
+      "unitRef": "sniper-post",
+      "description": "Spawner. Deploys a Marksman — extreme range, slow reload.",
+      "deckCount": 1,
+      "tags": [
+        "forest"
+      ],
+      "lore": "High ground. Clear line of sight. No witnesses."
     },
     {
       "name": "Gale Warden",

--- a/web/src/game/sprites.ts
+++ b/web/src/game/sprites.ts
@@ -9,6 +9,11 @@ const NAME_MAP: Record<string, string> = {
   'Eternal Forge': 'arcane-forge',
   'Dreadnought':   'iron-colossus',
   'Forge Knight':  'cinder-knight',
+  // New units without dedicated sprites — reuse closest visual match
+  'Plague Shaman': 'sandstorm-shaman',
+  'Marksman':      'desert-archer',
+  'Plague Den':    'rot-shrine',
+  'Sniper Post':   'aerie-tower',
 }
 
 /** Returns the sprite filename slug for a given unit name. */


### PR DESCRIPTION
## Summary

Follow-up to #1094 — the new Plague Shaman and Marksman units were missing sprites and spawn buildings.

- **Sprite mappings** (`sprites.ts` NAME_MAP):
  - Plague Shaman → `sandstorm-shaman` (full 3-frame animation)
  - Marksman → `desert-archer` (full 3-frame animation)
  - Plague Den building → `rot-shrine` sprite
  - Sniper Post building → `aerie-tower` sprite

- **New spawn buildings**:
  - **Plague Den** (rare, 4 mana, structure) — spawns a Plague Shaman every 12 s
  - **Sniper Post** (uncommon, 3 mana, structure) — deploys a Marksman every 15 s

## Test plan

- [ ] Place a Plague Shaman unit card — verify the sandstorm-shaman sprite renders and animates
- [ ] Place a Marksman unit card — verify the desert-archer sprite renders and animates
- [ ] Place a Plague Den structure — verify it periodically emits Plague Shamans
- [ ] Place a Sniper Post structure — verify it periodically emits Marksmen

https://claude.ai/code/session_01FFXw8rUxBVQRtJK8x762WJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01FFXw8rUxBVQRtJK8x762WJ)_