### PR TITLE
Fix glitched card event overlay getting stuck after reveal

### DIFF
--- a/web/src/components/rare-events/GlitchedCardEvent.tsx
+++ b/web/src/components/rare-events/GlitchedCardEvent.tsx
@@ -22,7 +22,7 @@ const HOVER_REVEAL = 'Real card restored. The glitch has been... contained. Prob
 
 export function GlitchedCardEvent({ onDone }: Props) {
   const [revealed, setRevealed] = useState(false)
-  const glitchName = GLITCH_NAMES[Math.floor(Math.random() * GLITCH_NAMES.length)]
+  const [glitchName] = useState(() => GLITCH_NAMES[Math.floor(Math.random() * GLITCH_NAMES.length)])
 
   useEffect(() => {
     if (!revealed) return


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- `glitchName` in `GlitchedCardEvent.tsx` was computed with `Math.random()` on every render rather than being held in state
- Because it was listed in the `useEffect` dependency array, every game-loop re-render caused the 2-second dismiss timeout to be cleared and restarted
- The timeout never fired while the game was running, leaving the corruption overlay permanently on screen after tapping the card
- Fix: initialize `glitchName` with `useState(() => ...)` so it's computed once and stays stable across re-renders

## Test plan

- [ ] Start a game and trigger the glitched card rare event (use dev config `forcedRareEvent: "glitchedCard"` to force it)
- [ ] Tap the corrupt card — it should flip to show "Goblin" with the restored message
- [ ] After ~2 seconds the overlay should automatically dismiss and return to the battlefield
- [ ] Verify the battle log shows the `[SYSTEM] Card corruption detected...` message
- [ ] Verify the "It Was a Goblin All Along" achievement fires

https://claude.ai/code/session_015GndWNwMaHjProkZ6hgyiz
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_015GndWNwMaHjProkZ6hgyiz)_