### PR TITLE
Fix friendly units taking damage from own moats

### DIFF
--- a/web/src/components/rare-events/GlitchedCardEvent.tsx
+++ b/web/src/components/rare-events/GlitchedCardEvent.tsx
@@ -22,7 +22,7 @@ const HOVER_REVEAL = 'Real card restored. The glitch has been... contained. Prob
 
 export function GlitchedCardEvent({ onDone }: Props) {
   const [revealed, setRevealed] = useState(false)
-  const glitchName = GLITCH_NAMES[Math.floor(Math.random() * GLITCH_NAMES.length)]
+  const [glitchName] = useState(() => GLITCH_NAMES[Math.floor(Math.random() * GLITCH_NAMES.length)])
 
   useEffect(() => {
     if (!revealed) return

--- a/web/src/game/engine/units.ts
+++ b/web/src/game/engine/units.ts
@@ -233,7 +233,7 @@ export function moveUnits(s: GameState, deltaMs: number): void {
         if (!m.isMoat) continue
         const effect = m.structureEffect as { type: 'slowZone'; slowFactor: number; radius: number; damagePerSec?: number } | undefined
         if (!effect || effect.type !== 'slowZone') continue
-        if (Math.abs(unit.x - m.x) <= effect.radius) {
+        if (m.owner !== unit.owner && Math.abs(unit.x - m.x) <= effect.radius) {
           if (unit.tags?.includes('swim')) {
             moatSlowFactor = Math.max(moatSlowFactor, 1.25)
           } else {


### PR DESCRIPTION
## Summary

- The moat slow/damage loop in `units.ts` applied effects to **all** nearby units with no owner check
- This caused the player's own units to be slowed and damaged by their own Lava/Acid/Frost Moats
- Fix: added `m.owner !== unit.owner` guard so moats only affect enemy units (same pattern used everywhere else in the engine)

## Test plan

- [ ] Place a Lava Moat or Acid Moat and send your own units past it — they should pass through unharmed
- [ ] Confirm enemy units still take slow + damage when crossing the moat
- [ ] Test units with the `swim` tag still get the speed bonus when crossing enemy moats
- [ ] Verify flying units are unaffected by moats (existing behaviour unchanged)

https://claude.ai/code/session_015GndWNwMaHjProkZ6hgyiz

---
_Generated by [Claude Code](https://claude.ai/code/session_015GndWNwMaHjProkZ6hgyiz)_