### PR TITLE
Status effect visuals + commander retreat and ally rally

### DIFF
--- a/web/src/components/Battlefield.tsx
+++ b/web/src/components/Battlefield.tsx
@@ -414,6 +414,10 @@ function LaneUnit({ unit, stackIndex = 0, wallStack, onInspect, showName, celebr
   const isDamageFlash = unit.damageFlashTimer != null && unit.damageFlashTimer > 0
   const isKillFlash = unit.killFlashTimer != null && unit.killFlashTimer > 0
   const isCelebrating = celebrating && !isDying && !isStructure && !unit.isWall
+  const isBurning  = !isDying && unit.burnTimer   != null && unit.burnTimer   > 0
+  const isFrozen   = !isDying && unit.freezeTimer  != null && unit.freezeTimer  > 0
+  const isPoisoned = !isDying && unit.poisonTimer  != null && unit.poisonTimer  > 0
+  const isShocked  = !isDying && unit.stunTimer    != null && unit.stunTimer    > 0 && !isBurning && !isFrozen && !isPoisoned
 
   return (
     <div
@@ -435,6 +439,10 @@ function LaneUnit({ unit, stackIndex = 0, wallStack, onInspect, showName, celebr
         isCelebrating ? 'lane-unit--celebrating' : '',
         unit.invisTimer != null && unit.invisTimer > 0 ? 'lane-unit--invisible' : '',
         unit.cardVariant ? `lane-unit--variant-${unit.cardVariant}` : '',
+        isBurning  ? 'lane-unit--burning'  : '',
+        isFrozen   ? 'lane-unit--frozen'   : '',
+        isPoisoned ? 'lane-unit--poisoned' : '',
+        isShocked  ? 'lane-unit--shocked'  : '',
       ].filter(Boolean).join(' ')}
       style={isCelebrating ? { ...style, animationDelay: `${(unit.id.charCodeAt(0) % 7) * 0.1}s` } : style}
       title={`${unit.name} — ${unit.hp}/${unit.maxHp} HP, ${unit.attack} ATK`}
@@ -495,6 +503,10 @@ function LaneUnit({ unit, stackIndex = 0, wallStack, onInspect, showName, celebr
           )}
         </div>
       )}
+      {isBurning  && <div className="status-overlay status-overlay--burning"  aria-hidden />}
+      {isFrozen   && <div className="status-overlay status-overlay--frozen"   aria-hidden />}
+      {isPoisoned && <div className="status-overlay status-overlay--poisoned" aria-hidden />}
+      {isShocked  && <div className="status-overlay status-overlay--shocked"  aria-hidden />}
     </div>
   )
 }

--- a/web/src/game/engine/units.ts
+++ b/web/src/game/engine/units.ts
@@ -32,6 +32,15 @@ export function moveUnits(s: GameState, deltaMs: number): void {
   const livingOpponentUnits = s.field.some(u => u.owner === 'opponent' && u.hp > 0)
   const livingPlayerUnits   = s.field.some(u => u.owner === 'player'   && u.hp > 0)
 
+  // Pre-find commanders so rally logic can reference them without re-scanning per unit.
+  const playerCommander   = s.field.find(u => u.owner === 'player'   && u.isCommander && u.hp > 0)
+  const opponentCommander = s.field.find(u => u.owner === 'opponent' && u.isCommander && u.hp > 0)
+
+  // Distance within which units rally to protect their commander.
+  const COMMANDER_RALLY_PX  = 180
+  // Distance within which the commander itself retreats from enemies.
+  const COMMANDER_FLEE_PX   = 90
+
   // Defend overflow: if ≥15 defenders, the 5 furthest-forward units charge instead.
   const defendOverflowAttackers = new Set<string>()
   if (stance === 'defend') {
@@ -195,6 +204,39 @@ export function moveUnits(s: GameState, deltaMs: number): void {
             tx = nearest.x
             ty = nearest.y
           }
+          hasTarget = true
+        }
+      }
+    }
+
+    // Commander: retreat from nearby enemies rather than engaging them directly.
+    // Moves back toward commanderHomeX so allies can intercept first.
+    if (unit.isCommander && unit.commanderHomeX !== undefined && useTraitMovement) {
+      const threats = s.field.filter(
+        e => e.owner !== unit.owner && e.hp > 0 && unitDist(unit, e) <= COMMANDER_FLEE_PX
+      )
+      if (threats.length > 0) {
+        tx = unit.commanderHomeX
+        ty = unit.y
+        hasTarget = true
+      }
+    }
+
+    // Ally rally: when the commander is actively taking damage, nearby allies override their
+    // movement target to intercept the commander's attacker.
+    if (!unit.isCommander && useTraitMovement) {
+      const ownCommander = unit.owner === 'player' ? playerCommander : opponentCommander
+      if (
+        ownCommander &&
+        ownCommander.damageFlashTimer != null && ownCommander.damageFlashTimer > 0 &&
+        ownCommander.lastAttackerId &&
+        unitDist(unit, ownCommander) <= COMMANDER_RALLY_PX
+      ) {
+        const attacker = s.field.find(u => u.id === ownCommander.lastAttackerId && u.hp > 0)
+        if (attacker) {
+          if (unitDist(unit, attacker) <= unit.attackRange) continue
+          tx = attacker.x
+          ty = attacker.y
           hasTarget = true
         }
       }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -8273,6 +8273,102 @@ html.light-mode .action-btn {
   animation: kill-flash-anim 0.5s ease-out forwards;
 }
 
+/* ─── Elemental status effect overlays ────────────────────────────────────── */
+
+/* Shared overlay base */
+.status-overlay {
+  position: absolute;
+  inset: 0;
+  border-radius: 4px;
+  pointer-events: none;
+  z-index: 4;
+}
+
+/* ── Burning ── */
+@keyframes flame-flicker {
+  0%   { transform: scaleY(1)    scaleX(1)    translateY(0);   opacity: 0.85; }
+  25%  { transform: scaleY(1.08) scaleX(0.95) translateY(-1px); opacity: 1; }
+  50%  { transform: scaleY(0.95) scaleX(1.05) translateY(1px);  opacity: 0.75; }
+  75%  { transform: scaleY(1.1)  scaleX(0.92) translateY(-2px); opacity: 0.9; }
+  100% { transform: scaleY(1)    scaleX(1)    translateY(0);   opacity: 0.85; }
+}
+.lane-unit--burning {
+  filter: drop-shadow(0 0 5px rgba(255,100,0,0.9)) drop-shadow(0 -2px 8px rgba(255,60,0,0.7));
+}
+.status-overlay--burning {
+  background: linear-gradient(
+    to top,
+    rgba(255,80,0,0.55) 0%,
+    rgba(255,160,0,0.35) 45%,
+    rgba(255,220,0,0.15) 70%,
+    transparent 100%
+  );
+  animation: flame-flicker 0.35s ease-in-out infinite alternate;
+  mix-blend-mode: screen;
+}
+
+/* ── Frozen ── */
+@keyframes frost-shimmer {
+  0%   { opacity: 0.55; filter: brightness(1.1); }
+  50%  { opacity: 0.75; filter: brightness(1.3); }
+  100% { opacity: 0.55; filter: brightness(1.1); }
+}
+.lane-unit--frozen {
+  filter: saturate(0.3) brightness(1.2) drop-shadow(0 0 6px rgba(120,200,255,0.9)) drop-shadow(0 0 12px rgba(80,160,255,0.5));
+}
+.status-overlay--frozen {
+  background: radial-gradient(
+    ellipse at 50% 40%,
+    rgba(180,230,255,0.55) 0%,
+    rgba(100,180,255,0.30) 55%,
+    transparent 80%
+  );
+  animation: frost-shimmer 1.2s ease-in-out infinite;
+}
+
+/* ── Poisoned ── */
+@keyframes poison-bubble {
+  0%   { transform: translateY(0)    scale(1);    opacity: 0.7; }
+  40%  { transform: translateY(-4px) scale(1.05); opacity: 0.9; }
+  100% { transform: translateY(0)    scale(1);    opacity: 0.7; }
+}
+.lane-unit--poisoned {
+  filter: hue-rotate(55deg) saturate(1.4) drop-shadow(0 0 5px rgba(60,180,60,0.8));
+}
+.status-overlay--poisoned {
+  background: radial-gradient(
+    ellipse at 50% 60%,
+    rgba(80,200,80,0.45) 0%,
+    rgba(40,140,40,0.25) 55%,
+    transparent 80%
+  );
+  animation: poison-bubble 0.9s ease-in-out infinite;
+  mix-blend-mode: screen;
+}
+
+/* ── Shocked ── */
+@keyframes shock-arc {
+  0%   { opacity: 0;    transform: scale(0.8); }
+  15%  { opacity: 1;    transform: scale(1.1); }
+  30%  { opacity: 0.3;  transform: scale(0.9); }
+  45%  { opacity: 0.9;  transform: scale(1.05); }
+  60%  { opacity: 0;    transform: scale(1); }
+  100% { opacity: 0;    transform: scale(1); }
+}
+.lane-unit--shocked {
+  filter: brightness(1.4) drop-shadow(0 0 8px rgba(200,230,255,1)) drop-shadow(0 0 16px rgba(160,200,255,0.7));
+}
+.status-overlay--shocked {
+  background: radial-gradient(
+    ellipse at 50% 50%,
+    rgba(200,230,255,0.7) 0%,
+    rgba(120,180,255,0.4) 40%,
+    transparent 70%
+  );
+  animation: shock-arc 0.6s ease-out infinite;
+  mix-blend-mode: screen;
+}
+
 /* ─── Secret-variant unit visual effects ──────────────────────────────────── */
 @keyframes variant-shiny-glow {
   0%, 100% { filter: brightness(1.1) drop-shadow(0 0 3px rgba(255,220,60,0.6)); }
@@ -8386,24 +8482,35 @@ html.light-mode .action-btn {
 
 /* Gas cloud hazard — battlefield lane version */
 @keyframes hazard-drift {
-  0%   { opacity: 0.35; transform: translate(-50%,-50%) scale(0.9); }
-  50%  { opacity: 0.55; transform: translate(-50%,-50%) scale(1.05); }
-  100% { opacity: 0.35; transform: translate(-50%,-50%) scale(0.9); }
+  0%   { opacity: 0.55; transform: translate(-50%,-50%) scale(0.88) rotate(-4deg); }
+  30%  { opacity: 0.80; transform: translate(-50%,-50%) scale(1.06) rotate(2deg); }
+  60%  { opacity: 0.60; transform: translate(-50%,-50%) scale(0.95) rotate(-2deg); }
+  100% { opacity: 0.55; transform: translate(-50%,-50%) scale(0.88) rotate(-4deg); }
+}
+@keyframes hazard-drift-inner {
+  0%   { opacity: 0.7; transform: scale(0.6) rotate(8deg); }
+  50%  { opacity: 1;   transform: scale(0.8) rotate(-5deg); }
+  100% { opacity: 0.7; transform: scale(0.6) rotate(8deg); }
 }
 .battlefield-hazard {
-  width: 48px;
-  height: 48px;
+  position: absolute;
+  width: 64px;
+  height: 64px;
   border-radius: 50%;
-  background: radial-gradient(circle, rgba(80,200,80,0.55) 0%, rgba(40,140,40,0.3) 60%, transparent 85%);
-  animation: hazard-drift 2s ease-in-out infinite;
+  background: radial-gradient(circle, rgba(60,210,60,0.7) 0%, rgba(30,160,30,0.45) 50%, rgba(20,100,20,0.2) 75%, transparent 90%);
+  box-shadow: 0 0 18px 6px rgba(40,200,40,0.4), inset 0 0 10px rgba(100,255,100,0.3);
+  animation: hazard-drift 2.4s ease-in-out infinite;
+  mix-blend-mode: screen;
 }
 .battlefield-gascloud {
-  width: 40px;
-  height: 40px;
+  position: absolute;
+  width: 56px;
+  height: 56px;
   border-radius: 50%;
-  background: radial-gradient(circle, rgba(80,200,80,0.6) 0%, rgba(40,140,40,0.35) 60%, transparent 85%);
-  transform: translate(-50%,-50%);
-  animation: hazard-drift 1.8s ease-in-out infinite;
+  background: radial-gradient(circle, rgba(60,210,60,0.75) 0%, rgba(30,160,30,0.5) 50%, rgba(20,100,20,0.2) 75%, transparent 90%);
+  box-shadow: 0 0 16px 5px rgba(40,200,40,0.45), inset 0 0 8px rgba(100,255,100,0.3);
+  animation: hazard-drift 1.9s ease-in-out infinite;
+  mix-blend-mode: screen;
 }
 
 /* ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

### Status effect visuals on battlefield units
- **Burning**: orange-red flame gradient overlay that flickers, plus red drop-shadow glow on the unit
- **Frozen**: blue desaturated filter + shimmering frost overlay
- **Poisoned**: green hue-rotate + pulsing bubble overlay
- **Shocked/stunned**: bright white-blue arc flash repeating on the unit
- Gas cloud hazards made larger (56-64 px) with glow, box-shadow, and a rotating drift animation so they read clearly on screen

### Commander behaviour
- **Retreat**: when enemies close within 90 px of the commander, it backs toward its home X instead of standing its ground — letting the army intercept first
- **Ally rally**: when the commander is actively taking damage, all friendly units within 180 px override their movement target to rush the attacker

## Test plan

- [ ] Set a unit on fire (e.g. via a fire unit attacking) — confirm orange flame overlay and red glow appear and flicker
- [ ] Freeze a unit — confirm blue desaturated + shimmer
- [ ] Poison a unit — confirm green hue-shift + bubble pulse
- [ ] Place a Plague Shaman and have it attack — confirm gas cloud appears on map and glows clearly
- [ ] In a battle, let enemies reach your commander — confirm the commander backs away and nearby allies turn to engage the attacker

https://claude.ai/code/session_01FFXw8rUxBVQRtJK8x762WJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01FFXw8rUxBVQRtJK8x762WJ)_