### PR TITLE
Fix TD small-screen UX: scrollable grid + overlay upgrade panel

### DIFF
--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -12625,6 +12625,7 @@ html.light-mode .action-btn {
   color: #e0e0e0;
   font-family: 'Courier New', monospace;
   overflow: hidden;
+  position: relative;
 }
 
 /* ── Header ── */
@@ -12678,14 +12679,15 @@ html.light-mode .action-btn {
 /* ── Board ── */
 .td-board-wrap {
   flex: 1;
-  overflow: hidden;
+  overflow-y: auto;
+  overflow-x: hidden;
   min-height: 0;
   background: #0d0d0d;
 }
 
 /* Scaling wrapper — sized to the post-scale dimensions so the layout is correct */
 .td-grid-scaler {
-  overflow: hidden;
+  overflow: visible;
   flex-shrink: 0;
 }
 
@@ -12882,10 +12884,13 @@ html.light-mode .action-btn {
 
 /* ── Selected tower action panel ── */
 .td-selected-panel {
-  flex-shrink: 0;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 20;
   background: #131a13;
   border-top: 2px solid #ffd700;
-  border-bottom: 1px solid #333;
   padding: 8px 12px;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary

- **Upgrade panel overlays the unit strip** instead of pushing the grid up — tapping a tower near the bottom of the grid no longer makes those cells unreachable
- **Board is now scrollable** (`overflow-y: auto`) so if the grid is taller than the visible area on a short screen, you can scroll down to bottom cells
- `position: relative` on `.td-root` anchors the absolutely-positioned upgrade panel
- `.td-grid-scaler` changed to `overflow: visible` so scroll propagates through it correctly

## Test plan

- [ ] On a small screen (or narrow browser window), tap a tower near the bottom of the grid — the upgrade panel should slide over the unit strip, not push the grid up
- [ ] Bottom cells should remain tappable after the upgrade panel opens
- [ ] Scroll the grid on a short screen to confirm bottom rows are reachable

https://claude.ai/code/session_01FFXw8rUxBVQRtJK8x762WJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01FFXw8rUxBVQRtJK8x762WJ)_