### PR TITLE
feat(cutscenes): animate Act 2 intro panels

### DIFF
--- a/web/public/cutscenes/act2-intro-1.svg
+++ b/web/public/cutscenes/act2-intro-1.svg
@@ -8,6 +8,15 @@
   </linearGradient>
   <rect width="400" height="180" fill="url(#sky2)"/>
 
+  <!-- Ambient dread glow — pulses slowly -->
+  <radialGradient id="citadel-amb" cx="50%" cy="30%" r="45%">
+    <stop offset="0%" stop-color="#202840" stop-opacity="0.3">
+      <animate attributeName="stop-opacity" values="0.2;0.4;0.2" dur="8s" repeatCount="indefinite"/>
+    </stop>
+    <stop offset="100%" stop-color="#08090c" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#citadel-amb)"/>
+
   <!-- Ground / rubble base -->
   <rect x="0" y="185" width="400" height="55" fill="#0a0b0e"/>
   <line x1="0" y1="185" x2="400" y2="185" stroke="#151820" stroke-width="1"/>
@@ -89,27 +98,50 @@
   <!-- Gate arch shadow -->
   <ellipse cx="200" cy="140" rx="32" ry="6" fill="#0a0c10" opacity="0.8"/>
 
-  <!-- Warlord banner atop centre -->
-  <line x1="197" y1="10" x2="197" y2="44" stroke="#303548" stroke-width="2"/>
-  <polygon points="197,10 230,20 197,30" fill="#1e2438" stroke="#303548" stroke-width="1"/>
-  <!-- Iron cross on banner -->
-  <g stroke="#404860" stroke-width="1.5">
-    <line x1="206" y1="18" x2="206" y2="28"/>
-    <line x1="201" y1="23" x2="212" y2="23"/>
+  <!-- Warlord banner — sways gently -->
+  <g>
+    <animateTransform attributeName="transform" type="skewX"
+      values="0; 3; 0; -3; 0" dur="7s" repeatCount="indefinite"/>
+    <line x1="197" y1="10" x2="197" y2="44" stroke="#303548" stroke-width="2"/>
+    <polygon points="197,10 230,20 197,30" fill="#1e2438" stroke="#303548" stroke-width="1"/>
+    <g stroke="#404860" stroke-width="1.5">
+      <line x1="206" y1="18" x2="206" y2="28"/>
+      <line x1="201" y1="23" x2="212" y2="23"/>
+    </g>
   </g>
 
-  <!-- Distant torches on battlements — tiny warm glows -->
-  <circle cx="118" cy="59" r="2.5" fill="#c07020" opacity="0.7"/>
-  <circle cx="156" cy="59" r="2"   fill="#c07020" opacity="0.6"/>
-  <circle cx="244" cy="59" r="2"   fill="#c07020" opacity="0.6"/>
-  <circle cx="280" cy="59" r="2.5" fill="#c07020" opacity="0.7"/>
+  <!-- Torches — flickering warm glow -->
+  <circle cx="118" cy="59" r="2.5" fill="#c07020">
+    <animate attributeName="opacity" values="0.7;1;0.5;0.9;0.7" dur="1.8s" repeatCount="indefinite"/>
+    <animate attributeName="r" values="2.5;3.2;2;3;2.5" dur="1.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="156" cy="59" r="2" fill="#c07020">
+    <animate attributeName="opacity" values="0.6;0.9;0.4;0.8;0.6" dur="2.1s" repeatCount="indefinite"/>
+    <animate attributeName="r" values="2;2.8;1.8;2.6;2" dur="2.1s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="244" cy="59" r="2" fill="#c07020">
+    <animate attributeName="opacity" values="0.5;0.8;0.6;1;0.5" dur="1.6s" repeatCount="indefinite"/>
+    <animate attributeName="r" values="2;2.6;1.8;3;2" dur="1.6s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="280" cy="59" r="2.5" fill="#c07020">
+    <animate attributeName="opacity" values="0.7;0.5;1;0.8;0.7" dur="2.3s" repeatCount="indefinite"/>
+    <animate attributeName="r" values="2.5;3.4;2;2.8;2.5" dur="2.3s" repeatCount="indefinite"/>
+  </circle>
 
-  <!-- Arrow slit windows — dim glow -->
-  <g fill="#c07020" opacity="0.3">
-    <rect x="126" y="100" width="4" height="10" rx="2"/>
-    <rect x="150" y="100" width="4" height="10" rx="2"/>
-    <rect x="246" y="100" width="4" height="10" rx="2"/>
-    <rect x="270" y="100" width="4" height="10" rx="2"/>
+  <!-- Arrow slit windows — pulsing dim glow -->
+  <g fill="#c07020">
+    <rect x="126" y="100" width="4" height="10" rx="2">
+      <animate attributeName="opacity" values="0.3;0.6;0.3" dur="4s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="150" y="100" width="4" height="10" rx="2">
+      <animate attributeName="opacity" values="0.3;0.5;0.2;0.6;0.3" dur="5s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="246" y="100" width="4" height="10" rx="2">
+      <animate attributeName="opacity" values="0.3;0.6;0.3" dur="3.5s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="270" y="100" width="4" height="10" rx="2">
+      <animate attributeName="opacity" values="0.2;0.5;0.3;0.6;0.2" dur="4.5s" repeatCount="indefinite"/>
+    </rect>
   </g>
 
   <!-- Rubble at base -->
@@ -121,5 +153,7 @@
   </g>
 
   <!-- Label -->
-  <text x="200" y="230" font-family="monospace" font-size="9" fill="#303548" text-anchor="middle" letter-spacing="3">THE IRON CITADEL</text>
+  <text x="200" y="230" font-family="monospace" font-size="9" fill="#303548" text-anchor="middle" letter-spacing="3">THE IRON CITADEL
+    <animate attributeName="opacity" values="0.5;1;0.5" dur="6s" repeatCount="indefinite"/>
+  </text>
 </svg>

--- a/web/public/cutscenes/act2-intro-2.svg
+++ b/web/public/cutscenes/act2-intro-2.svg
@@ -10,9 +10,7 @@
 
   <!-- Distant citadel silhouette on horizon -->
   <g fill="#0f1220" opacity="0.9">
-    <!-- Wall mass -->
     <rect x="220" y="110" width="180" height="90"/>
-    <!-- Battlements -->
     <rect x="220" y="100" width="12" height="12"/>
     <rect x="236" y="100" width="12" height="12"/>
     <rect x="252" y="100" width="12" height="12"/>
@@ -24,16 +22,16 @@
     <rect x="348" y="100" width="12" height="12"/>
     <rect x="364" y="100" width="12" height="12"/>
     <rect x="380" y="100" width="20" height="12"/>
-    <!-- Left tower -->
     <rect x="206" y="90"  width="22" height="110"/>
-    <!-- Tower merlons -->
     <rect x="206" y="80" width="8" height="12"/>
     <rect x="218" y="80" width="8" height="12"/>
   </g>
 
-  <!-- Dim torch glow from distant citadel -->
+  <!-- Citadel glow — pulsing -->
   <radialGradient id="citadel-glow" cx="75%" cy="52%" r="20%">
-    <stop offset="0%" stop-color="#c06818" stop-opacity="0.15"/>
+    <stop offset="0%" stop-color="#c06818" stop-opacity="0.15">
+      <animate attributeName="stop-opacity" values="0.1;0.25;0.1" dur="4s" repeatCount="indefinite"/>
+    </stop>
     <stop offset="100%" stop-color="#c06818" stop-opacity="0"/>
   </radialGradient>
   <rect width="400" height="240" fill="url(#citadel-glow)"/>
@@ -41,41 +39,39 @@
   <!-- Rocky road / broken ground -->
   <rect x="0" y="200" width="400" height="40" fill="#0a0b0e"/>
   <rect x="0" y="185" width="400" height="16" fill="#0d0f14"/>
-  <!-- Path line -->
   <path d="M0,195 Q100,190 200,193 Q300,196 400,192" stroke="#151820" stroke-width="2" fill="none"/>
 
   <!-- Canyon walls flanking the road -->
   <polygon points="0,240 0,130 70,150 60,185 50,240" fill="#0b0d12"/>
   <polygon points="0,240 0,160 50,170 45,200 30,240" fill="#0d1018"/>
 
-  <!-- Wanderer figure — Jarv — mid-left, walking right toward citadel -->
-  <!-- Shadow on ground -->
-  <ellipse cx="140" cy="198" rx="18" ry="5" fill="#060709" opacity="0.8"/>
+  <!-- Wanderer — walking bob -->
+  <g>
+    <animateTransform attributeName="transform" type="translate"
+      values="0 0; 0 -1.5; 0 0; 0 -1.5; 0 0" dur="0.8s" repeatCount="indefinite"/>
 
-  <!-- Cloak / body -->
-  <polygon points="128,180 152,180 156,200 124,200" fill="#1a1c28" stroke="#252838" stroke-width="1"/>
-  <!-- Hood -->
-  <ellipse cx="140" cy="175" rx="10" ry="8" fill="#161820" stroke="#222432" stroke-width="1"/>
-  <!-- Face shadow under hood -->
-  <ellipse cx="141" cy="178" rx="6" ry="4" fill="#0e1018"/>
+    <ellipse cx="140" cy="198" rx="18" ry="5" fill="#060709" opacity="0.8"/>
+    <polygon points="128,180 152,180 156,200 124,200" fill="#1a1c28" stroke="#252838" stroke-width="1"/>
+    <ellipse cx="140" cy="175" rx="10" ry="8" fill="#161820" stroke="#222432" stroke-width="1"/>
+    <ellipse cx="141" cy="178" rx="6" ry="4" fill="#0e1018"/>
 
-  <!-- Arm outstretched toward citadel — holding card -->
-  <line x1="152" y1="183" x2="167" y2="176" stroke="#1a1c28" stroke-width="3" stroke-linecap="round"/>
-  <!-- Card in hand (small rectangle) -->
-  <rect x="164" y="171" width="10" height="14" rx="1" fill="#1e2438" stroke="#404860" stroke-width="1"/>
-  <!-- Card glow hint -->
-  <rect x="165" y="172" width="8" height="12" rx="1" fill="#303860" opacity="0.4"/>
+    <!-- Arm outstretched toward citadel -->
+    <line x1="152" y1="183" x2="167" y2="176" stroke="#1a1c28" stroke-width="3" stroke-linecap="round"/>
+    <!-- Card in hand — glowing -->
+    <rect x="164" y="171" width="10" height="14" rx="1" fill="#1e2438" stroke="#404860" stroke-width="1"/>
+    <rect x="165" y="172" width="8" height="12" rx="1" fill="#303860">
+      <animate attributeName="opacity" values="0.4;0.8;0.4" dur="2.5s" repeatCount="indefinite"/>
+    </rect>
 
-  <!-- Other arm — at side -->
-  <line x1="128" y1="183" x2="118" y2="192" stroke="#1a1c28" stroke-width="3" stroke-linecap="round"/>
+    <!-- Other arm -->
+    <line x1="128" y1="183" x2="118" y2="192" stroke="#1a1c28" stroke-width="3" stroke-linecap="round"/>
 
-  <!-- Legs -->
-  <line x1="136" y1="200" x2="132" y2="215" stroke="#151720" stroke-width="3" stroke-linecap="round"/>
-  <line x1="144" y1="200" x2="148" y2="214" stroke="#151720" stroke-width="3" stroke-linecap="round"/>
-
-  <!-- Boot detail -->
-  <ellipse cx="131" cy="215" rx="5" ry="3" fill="#111318"/>
-  <ellipse cx="149" cy="214" rx="5" ry="3" fill="#111318"/>
+    <!-- Legs — alternating stride -->
+    <line x1="136" y1="200" x2="132" y2="215" stroke="#151720" stroke-width="3" stroke-linecap="round"/>
+    <line x1="144" y1="200" x2="148" y2="214" stroke="#151720" stroke-width="3" stroke-linecap="round"/>
+    <ellipse cx="131" cy="215" rx="5" ry="3" fill="#111318"/>
+    <ellipse cx="149" cy="214" rx="5" ry="3" fill="#111318"/>
+  </g>
 
   <!-- Footprints in dust behind wanderer -->
   <g fill="#101218" opacity="0.5">
@@ -84,24 +80,48 @@
     <ellipse cx="84"  cy="197" rx="4" ry="2" transform="rotate(-10,84,197)"/>
   </g>
 
-  <!-- Dust motes in foreground -->
-  <g fill="#1a1e2a" opacity="0.4">
-    <circle cx="65"  cy="190" r="2"/>
-    <circle cx="55"  cy="196" r="1.5"/>
-    <circle cx="170" cy="205" r="1.5"/>
-    <circle cx="185" cy="200" r="1"/>
+  <!-- Dust motes drifting -->
+  <g fill="#1a1e2a">
+    <circle cx="65" cy="190" r="2">
+      <animateTransform attributeName="transform" type="translate" values="0 0; 8 -4; 0 0" dur="9s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.4;0.6;0.4" dur="9s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="55" cy="196" r="1.5">
+      <animateTransform attributeName="transform" type="translate" values="0 0; 6 -3; 0 0" dur="7s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.3;0.5;0.3" dur="7s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="170" cy="205" r="1.5">
+      <animateTransform attributeName="transform" type="translate" values="0 0; 5 -2; 0 0" dur="11s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="185" cy="200" r="1">
+      <animateTransform attributeName="transform" type="translate" values="0 0; 4 -3; 0 0" dur="8s" repeatCount="indefinite"/>
+    </circle>
   </g>
 
-  <!-- Stars / debris in sky -->
-  <g fill="#252a38" opacity="0.3">
-    <circle cx="40"  cy="30"  r="1"/>
-    <circle cx="90"  cy="20"  r="0.8"/>
-    <circle cx="150" cy="40"  r="1"/>
-    <circle cx="110" cy="55"  r="0.8"/>
-    <circle cx="30"  cy="65"  r="1"/>
-    <circle cx="180" cy="25"  r="0.8"/>
+  <!-- Stars — twinkling -->
+  <g fill="#252a38">
+    <circle cx="40"  cy="30"  r="1">
+      <animate attributeName="opacity" values="0.2;0.6;0.2" dur="4s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="90"  cy="20"  r="0.8">
+      <animate attributeName="opacity" values="0.1;0.5;0.1" dur="5.5s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="150" cy="40"  r="1">
+      <animate attributeName="opacity" values="0.3;0.7;0.3" dur="3.8s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="110" cy="55"  r="0.8">
+      <animate attributeName="opacity" values="0.2;0.5;0.2" dur="6s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="30"  cy="65"  r="1">
+      <animate attributeName="opacity" values="0.1;0.4;0.1" dur="4.5s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="180" cy="25"  r="0.8">
+      <animate attributeName="opacity" values="0.2;0.6;0.2" dur="5s" repeatCount="indefinite"/>
+    </circle>
   </g>
 
   <!-- Label -->
-  <text x="200" y="230" font-family="monospace" font-size="9" fill="#303548" text-anchor="middle" letter-spacing="3">THE WANDERER</text>
+  <text x="200" y="230" font-family="monospace" font-size="9" fill="#303548" text-anchor="middle" letter-spacing="3">THE WANDERER
+    <animate attributeName="opacity" values="0.5;1;0.5" dur="5s" repeatCount="indefinite"/>
+  </text>
 </svg>

--- a/web/public/cutscenes/act2-intro-3.svg
+++ b/web/public/cutscenes/act2-intro-3.svg
@@ -11,9 +11,11 @@
 
   <!-- Canyon floor — deep dark chasm -->
   <rect x="80" y="148" width="240" height="92" fill="#050608"/>
-  <!-- Canyon floor glow — sickly pale -->
+  <!-- Chasm glow — pulsing -->
   <radialGradient id="chasm-glow" cx="50%" cy="90%" r="40%">
-    <stop offset="0%" stop-color="#202840" stop-opacity="0.4"/>
+    <stop offset="0%" stop-color="#202840" stop-opacity="0.4">
+      <animate attributeName="stop-opacity" values="0.3;0.6;0.3" dur="5s" repeatCount="indefinite"/>
+    </stop>
     <stop offset="100%" stop-color="#202840" stop-opacity="0"/>
   </radialGradient>
   <rect x="80" y="148" width="240" height="92" fill="url(#chasm-glow)"/>
@@ -36,9 +38,8 @@
     <line x1="332" y1="160" x2="392" y2="152"/>
   </g>
 
-  <!-- Garrison point A — left wall ledge -->
+  <!-- Garrison A — left wall ledge -->
   <rect x="5" y="105" width="68" height="40" fill="#131620" stroke="#1e2230" stroke-width="1"/>
-  <!-- Battlements A -->
   <g fill="#1a1e2c" stroke="#1e2230" stroke-width="0.8">
     <rect x="5"  y="96" width="10" height="11"/>
     <rect x="18" y="96" width="10" height="11"/>
@@ -46,12 +47,14 @@
     <rect x="44" y="96" width="10" height="11"/>
     <rect x="57" y="96" width="10" height="11"/>
   </g>
-  <!-- Torch A -->
-  <circle cx="36" cy="102" r="2" fill="#b06010" opacity="0.7"/>
+  <!-- Torch A — flickering -->
+  <circle cx="36" cy="102" r="2" fill="#b06010">
+    <animate attributeName="opacity" values="0.7;1;0.4;0.9;0.7" dur="1.9s" repeatCount="indefinite"/>
+    <animate attributeName="r" values="2;2.8;1.6;2.6;2" dur="1.9s" repeatCount="indefinite"/>
+  </circle>
 
-  <!-- Garrison point B — right wall ledge -->
+  <!-- Garrison B — right wall ledge -->
   <rect x="327" y="100" width="68" height="40" fill="#131620" stroke="#1e2230" stroke-width="1"/>
-  <!-- Battlements B -->
   <g fill="#1a1e2c" stroke="#1e2230" stroke-width="0.8">
     <rect x="327" y="91" width="10" height="11"/>
     <rect x="340" y="91" width="10" height="11"/>
@@ -59,10 +62,13 @@
     <rect x="366" y="91" width="10" height="11"/>
     <rect x="379" y="91" width="16" height="11"/>
   </g>
-  <!-- Torch B -->
-  <circle cx="360" cy="97" r="2" fill="#b06010" opacity="0.7"/>
+  <!-- Torch B — flickering -->
+  <circle cx="360" cy="97" r="2" fill="#b06010">
+    <animate attributeName="opacity" values="0.5;0.9;0.7;1;0.5" dur="2.2s" repeatCount="indefinite"/>
+    <animate attributeName="r" values="2;2.5;1.8;3;2" dur="2.2s" repeatCount="indefinite"/>
+  </circle>
 
-  <!-- Garrison point C — hanging chain bridge platform centre-left -->
+  <!-- Garrison C — hanging platform centre-left -->
   <rect x="100" y="130" width="60" height="30" fill="#131620" stroke="#1e2230" stroke-width="1"/>
   <g fill="#1a1e2c" stroke="#1e2230" stroke-width="0.8">
     <rect x="100" y="121" width="9"  height="11"/>
@@ -71,12 +77,16 @@
     <rect x="136" y="121" width="9"  height="11"/>
     <rect x="148" y="121" width="12" height="11"/>
   </g>
-  <!-- Chain to left wall -->
-  <path d="M73,120 Q87,128 100,130" stroke="#252a38" stroke-width="1.5" fill="none" stroke-dasharray="4,3"/>
+  <!-- Chain to left wall — swaying -->
+  <path d="M73,120 Q87,128 100,130" stroke="#252a38" stroke-width="1.5" fill="none" stroke-dasharray="4,3">
+    <animateTransform attributeName="transform" type="translate" values="0 0; 1 2; 0 0; -1 2; 0 0" dur="6s" repeatCount="indefinite"/>
+  </path>
   <!-- Chain to right (toward D) -->
-  <path d="M160,140 Q195,145 240,140" stroke="#252a38" stroke-width="1.5" fill="none" stroke-dasharray="4,3"/>
+  <path d="M160,140 Q195,145 240,140" stroke="#252a38" stroke-width="1.5" fill="none" stroke-dasharray="4,3">
+    <animateTransform attributeName="transform" type="translate" values="0 0; 0 2; 0 0; 0 -1; 0 0" dur="7s" repeatCount="indefinite"/>
+  </path>
 
-  <!-- Garrison point D — centre-right platform -->
+  <!-- Garrison D — centre-right platform -->
   <rect x="240" y="128" width="60" height="32" fill="#131620" stroke="#1e2230" stroke-width="1"/>
   <g fill="#1a1e2c" stroke="#1e2230" stroke-width="0.8">
     <rect x="240" y="119" width="9"  height="11"/>
@@ -86,7 +96,9 @@
     <rect x="288" y="119" width="12" height="11"/>
   </g>
   <!-- Chain to right wall -->
-  <path d="M300,138 Q311,132 327,125" stroke="#252a38" stroke-width="1.5" fill="none" stroke-dasharray="4,3"/>
+  <path d="M300,138 Q311,132 327,125" stroke="#252a38" stroke-width="1.5" fill="none" stroke-dasharray="4,3">
+    <animateTransform attributeName="transform" type="translate" values="0 0; -1 2; 0 0; 1 1; 0 0" dur="8s" repeatCount="indefinite"/>
+  </path>
 
   <!-- Chains dropping into chasm -->
   <g stroke="#252a38" stroke-width="1" fill="none" opacity="0.4" stroke-dasharray="3,4">
@@ -96,15 +108,13 @@
     <line x1="285" y1="160" x2="288" y2="200"/>
   </g>
 
-  <!-- INNER WALL — Kragg's sanctum — back of canyon, elevated -->
+  <!-- Inner wall — Kragg's sanctum -->
   <rect x="130" y="45" width="140" height="75" fill="#161924" stroke="#2a3040" stroke-width="2"/>
-  <!-- Inner wall stone courses -->
   <g stroke="#1e2230" stroke-width="0.8" opacity="0.5">
     <line x1="130" y1="65"  x2="270" y2="65"/>
     <line x1="130" y1="85"  x2="270" y2="85"/>
     <line x1="130" y1="105" x2="270" y2="105"/>
   </g>
-  <!-- Inner wall battlements -->
   <g fill="#1e2232" stroke="#2a3040" stroke-width="1">
     <rect x="130" y="33" width="14" height="14"/>
     <rect x="148" y="33" width="14" height="14"/>
@@ -115,17 +125,29 @@
     <rect x="238" y="33" width="14" height="14"/>
     <rect x="256" y="33" width="14" height="14"/>
   </g>
-  <!-- Kragg's banner flying above inner wall -->
-  <line x1="197" y1="5"  x2="197" y2="34" stroke="#2a3040" stroke-width="2"/>
-  <polygon points="197,6 236,14 197,24" fill="#1e2438" stroke="#3a4060" stroke-width="1"/>
-  <g stroke="#4a5880" stroke-width="1.5">
-    <line x1="208" y1="12" x2="208" y2="20"/>
-    <line x1="202" y1="16" x2="215" y2="16"/>
+
+  <!-- Kragg's banner — swaying -->
+  <g>
+    <animateTransform attributeName="transform" type="skewX"
+      values="0; 4; 0; -4; 0" dur="6s" repeatCount="indefinite"/>
+    <line x1="197" y1="5"  x2="197" y2="34" stroke="#2a3040" stroke-width="2"/>
+    <polygon points="197,6 236,14 197,24" fill="#1e2438" stroke="#3a4060" stroke-width="1"/>
+    <g stroke="#4a5880" stroke-width="1.5">
+      <line x1="208" y1="12" x2="208" y2="20"/>
+      <line x1="202" y1="16" x2="215" y2="16"/>
+    </g>
   </g>
-  <!-- Inner wall torches — slightly warmer than outer -->
-  <circle cx="148" cy="40" r="2.5" fill="#c07020" opacity="0.8"/>
-  <circle cx="200" cy="40" r="2.5" fill="#c07020" opacity="0.8"/>
-  <circle cx="252" cy="40" r="2.5" fill="#c07020" opacity="0.8"/>
+
+  <!-- Inner wall torches — flickering -->
+  <circle cx="148" cy="40" r="2.5" fill="#c07020">
+    <animate attributeName="opacity" values="0.8;1;0.5;0.9;0.8" dur="2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="200" cy="40" r="2.5" fill="#c07020">
+    <animate attributeName="opacity" values="0.7;0.4;1;0.8;0.7" dur="1.7s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="252" cy="40" r="2.5" fill="#c07020">
+    <animate attributeName="opacity" values="0.9;0.6;0.8;1;0.9" dur="2.4s" repeatCount="indefinite"/>
+  </circle>
 
   <!-- Inner wall gate — sealed -->
   <rect x="178" y="90" width="44" height="30" fill="#0c0e14" stroke="#2a3040" stroke-width="1.5"/>
@@ -144,5 +166,7 @@
   <path d="M130,145 Q145,115 155,120" stroke="#1e2230" stroke-width="2" fill="none"/>
 
   <!-- Label -->
-  <text x="200" y="232" font-family="monospace" font-size="9" fill="#2a3040" text-anchor="middle" letter-spacing="3">THE GARRISON NETWORK</text>
+  <text x="200" y="232" font-family="monospace" font-size="9" fill="#2a3040" text-anchor="middle" letter-spacing="3">THE GARRISON NETWORK
+    <animate attributeName="opacity" values="0.5;1;0.5" dur="6s" repeatCount="indefinite"/>
+  </text>
 </svg>

--- a/web/public/cutscenes/act2-intro-4.svg
+++ b/web/public/cutscenes/act2-intro-4.svg
@@ -1,15 +1,18 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#08090c"/>
 
-  <!-- Dark background -->
+  <!-- Dark background — pulsing -->
   <radialGradient id="mission-glow" cx="50%" cy="50%" r="50%">
-    <stop offset="0%" stop-color="#1a1e30" stop-opacity="0.6"/>
+    <stop offset="0%" stop-color="#1a1e30" stop-opacity="0.6">
+      <animate attributeName="stop-opacity" values="0.4;0.7;0.4" dur="7s" repeatCount="indefinite"/>
+    </stop>
     <stop offset="100%" stop-color="#08090c" stop-opacity="0"/>
   </radialGradient>
   <rect width="400" height="240" fill="url(#mission-glow)"/>
 
-  <!-- Tactical map grid lines — faint -->
-  <g stroke="#141820" stroke-width="0.5" opacity="0.6">
+  <!-- Tactical map grid lines — scanning pulse -->
+  <g stroke="#141820" stroke-width="0.5">
+    <animate attributeName="opacity" values="0.4;0.8;0.4" dur="4s" repeatCount="indefinite"/>
     <line x1="0"   y1="40"  x2="400" y2="40"/>
     <line x1="0"   y1="80"  x2="400" y2="80"/>
     <line x1="0"   y1="120" x2="400" y2="120"/>
@@ -24,13 +27,12 @@
     <line x1="350" y1="0"   x2="350" y2="240"/>
   </g>
 
-  <!-- Left side: player position marker -->
-  <!-- Small shield / base icon at left -->
-  <polygon points="30,120 48,110 66,120 66,140 48,150 30,140" fill="#0f1820" stroke="#204060" stroke-width="1.5"/>
-  <!-- Player star -->
+  <!-- Player position marker -->
+  <polygon points="30,120 48,110 66,120 66,140 48,150 30,140" fill="#0f1820" stroke="#204060" stroke-width="1.5">
+    <animate attributeName="opacity" values="0.7;1;0.7" dur="3s" repeatCount="indefinite"/>
+  </polygon>
   <polygon points="48,118 51,126 59,126 53,131 55,139 48,134 41,139 43,131 37,126 45,126" fill="#204060" opacity="0.8"/>
 
-  <!-- Garrison points along the path — enemy positions (left to right) -->
   <!-- Garrison 1 -->
   <rect x="108" y="104" width="24" height="32" fill="#141820" stroke="#2a3040" stroke-width="1.5"/>
   <g fill="#2a3040">
@@ -38,8 +40,9 @@
     <rect x="118" y="97" width="7" height="9"/>
     <rect x="128" y="97" width="4" height="9"/>
   </g>
-  <!-- Garrison 1 torch -->
-  <circle cx="120" cy="103" r="2" fill="#b05820" opacity="0.6"/>
+  <circle cx="120" cy="103" r="2" fill="#b05820">
+    <animate attributeName="opacity" values="0.6;1;0.4;0.8;0.6" dur="1.8s" repeatCount="indefinite"/>
+  </circle>
 
   <!-- Garrison 2 -->
   <rect x="188" y="96" width="24" height="34" fill="#141820" stroke="#2a3040" stroke-width="1.5"/>
@@ -48,49 +51,61 @@
     <rect x="198" y="88" width="7" height="10"/>
     <rect x="208" y="88" width="4" height="10"/>
   </g>
-  <circle cx="200" cy="95" r="2" fill="#b05820" opacity="0.6"/>
+  <circle cx="200" cy="95" r="2" fill="#b05820">
+    <animate attributeName="opacity" values="0.4;0.9;0.6;1;0.4" dur="2.1s" repeatCount="indefinite"/>
+  </circle>
 
-  <!-- Garrison 3 — final before boss -->
+  <!-- Garrison 3 -->
   <rect x="268" y="100" width="24" height="30" fill="#141820" stroke="#2a3040" stroke-width="1.5"/>
   <g fill="#2a3040">
     <rect x="268" y="92" width="7" height="10"/>
     <rect x="278" y="92" width="7" height="10"/>
     <rect x="288" y="92" width="4" height="10"/>
   </g>
-  <circle cx="280" cy="98" r="2" fill="#b05820" opacity="0.6"/>
+  <circle cx="280" cy="98" r="2" fill="#b05820">
+    <animate attributeName="opacity" values="0.7;0.4;1;0.8;0.7" dur="1.6s" repeatCount="indefinite"/>
+  </circle>
 
-  <!-- BOSS marker — Warlord Kragg — far right, fortress icon -->
-  <rect x="342" y="80" width="48" height="60" fill="#161c28" stroke="#3a4060" stroke-width="2"/>
+  <!-- Boss marker — pulsing threat -->
+  <rect x="342" y="80" width="48" height="60" fill="#161c28" stroke="#3a4060" stroke-width="2">
+    <animate attributeName="stroke-opacity" values="0.6;1;0.6" dur="2.5s" repeatCount="indefinite"/>
+  </rect>
   <g fill="#202838" stroke="#3a4060" stroke-width="1">
     <rect x="342" y="70" width="13" height="12"/>
     <rect x="358" y="70" width="13" height="12"/>
     <rect x="374" y="70" width="16" height="12"/>
   </g>
-  <!-- Boss skull icon -->
-  <circle cx="366" cy="104" r="10" fill="#0e1220" stroke="#3a4060" stroke-width="1"/>
+  <circle cx="366" cy="104" r="10" fill="#0e1220" stroke="#3a4060" stroke-width="1">
+    <animate attributeName="r" values="10;12;10" dur="2.5s" repeatCount="indefinite"/>
+    <animate attributeName="stroke-opacity" values="0.6;1;0.6" dur="2.5s" repeatCount="indefinite"/>
+  </circle>
   <circle cx="362" cy="101" r="2.5" fill="#3a4060"/>
   <circle cx="370" cy="101" r="2.5" fill="#3a4060"/>
   <path d="M360,108 Q366,112 372,108" stroke="#3a4060" stroke-width="1" fill="none"/>
   <line x1="362" y1="110" x2="362" y2="113" stroke="#3a4060" stroke-width="1"/>
   <line x1="366" y1="111" x2="366" y2="113" stroke="#3a4060" stroke-width="1"/>
   <line x1="370" y1="110" x2="370" y2="113" stroke="#3a4060" stroke-width="1"/>
-  <!-- Boss name text -->
   <text x="366" y="130" font-family="monospace" font-size="7" fill="#3a4060" text-anchor="middle">KRAGG</text>
 
-  <!-- Path / route arrows from player to garrison 1 -->
-  <path d="M66,120 Q87,120 108,120" stroke="#204060" stroke-width="1.5" fill="none" stroke-dasharray="5,3" marker-end="url(#arr)"/>
-  <!-- Path from garrison 1 to 2 -->
-  <path d="M132,120 Q160,112 188,113" stroke="#204060" stroke-width="1.5" fill="none" stroke-dasharray="5,3"/>
-  <!-- Arrow head manually -->
+  <!-- Animated route arrows — marching ants -->
+  <path d="M66,120 Q87,120 108,120" stroke="#204060" stroke-width="1.5" fill="none" stroke-dasharray="5,3">
+    <animate attributeName="stroke-dashoffset" from="0" to="-16" dur="1.2s" repeatCount="indefinite"/>
+  </path>
+  <path d="M132,120 Q160,112 188,113" stroke="#204060" stroke-width="1.5" fill="none" stroke-dasharray="5,3">
+    <animate attributeName="stroke-dashoffset" from="0" to="-16" dur="1.4s" repeatCount="indefinite"/>
+  </path>
   <polygon points="185,110 192,113 185,116" fill="#204060"/>
-  <!-- Path from garrison 2 to 3 -->
-  <path d="M212,113 Q240,106 268,110" stroke="#204060" stroke-width="1.5" fill="none" stroke-dasharray="5,3"/>
+  <path d="M212,113 Q240,106 268,110" stroke="#204060" stroke-width="1.5" fill="none" stroke-dasharray="5,3">
+    <animate attributeName="stroke-dashoffset" from="0" to="-16" dur="1.3s" repeatCount="indefinite"/>
+  </path>
   <polygon points="265,107 272,110 265,113" fill="#204060"/>
-  <!-- Path from garrison 3 to boss -->
-  <path d="M292,115 Q317,110 342,110" stroke="#3a4060" stroke-width="2" fill="none" stroke-dasharray="5,3"/>
+  <path d="M292,115 Q317,110 342,110" stroke="#3a4060" stroke-width="2" fill="none" stroke-dasharray="5,3">
+    <animate attributeName="stroke-dashoffset" from="0" to="-16" dur="1s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.6;1;0.6" dur="2s" repeatCount="indefinite"/>
+  </path>
   <polygon points="339,107 346,110 339,113" fill="#3a4060"/>
 
-  <!-- X markers on garrison positions — "must clear" -->
+  <!-- X markers on garrison positions -->
   <g stroke="#3a4060" stroke-width="1.5" opacity="0.6">
     <line x1="112" y1="115" x2="128" y2="130"/>
     <line x1="128" y1="115" x2="112" y2="130"/>
@@ -106,10 +121,14 @@
   <path d="M330,55 Q320,95 330,145" stroke="#1a1e2a" stroke-width="3" fill="none"/>
   <path d="M330,145 Q320,175 325,218" stroke="#1a1e2a" stroke-width="3" fill="none"/>
 
-  <!-- Objective text at top -->
-  <text x="200" y="22" font-family="monospace" font-size="8" fill="#204060" text-anchor="middle" letter-spacing="2">OBJECTIVE: BREACH THE INNER WALL</text>
+  <!-- Objective text -->
+  <text x="200" y="22" font-family="monospace" font-size="8" fill="#204060" text-anchor="middle" letter-spacing="2">OBJECTIVE: BREACH THE INNER WALL
+    <animate attributeName="opacity" values="0.5;1;0.5" dur="4s" repeatCount="indefinite"/>
+  </text>
   <line x1="60" y1="27" x2="340" y2="27" stroke="#1a2030" stroke-width="0.8"/>
 
   <!-- Label -->
-  <text x="200" y="232" font-family="monospace" font-size="9" fill="#2a3040" text-anchor="middle" letter-spacing="3">YOUR MISSION</text>
+  <text x="200" y="232" font-family="monospace" font-size="9" fill="#2a3040" text-anchor="middle" letter-spacing="3">YOUR MISSION
+    <animate attributeName="opacity" values="0.5;1;0.5" dur="5s" repeatCount="indefinite"/>
+  </text>
 </svg>


### PR DESCRIPTION
Adds CSS/SVG animations to all 4 Act 2 intro cutscene panels, using Act 1 as a reference.

- **Panel 1** (The Iron Citadel): torch flicker on battlements, banner sway, window glow pulse, ambient dread glow
- **Panel 2** (The Wanderer): walking body-bob, card glow pulse, star twinkle, dust mote drift, citadel glow pulse
- **Panel 3** (The Garrison Network): torch flicker x3, chain sway, chasm glow pulse, banner sway
- **Panel 4** (Your Mission): marching-ant route arrows (animated stroke-dashoffset), garrison torch flicker, boss marker pulse, grid scan pulse, objective text fade

Closes #1098

---
_Generated by [Claude Code](https://claude.ai/code/session_01QjAWeyHiDWwKa8oZQFU7yn)_