### PR TITLE
feat(cutscenes): animate Act 3 intro panels

### DIFF
--- a/web/public/cutscenes/act3-intro-1.svg
+++ b/web/public/cutscenes/act3-intro-1.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#090908"/>
 
-  <!-- Ashen sky — hazy smoke gradient -->
+  <!-- Ashen sky -->
   <linearGradient id="ash-sky" x1="0" y1="0" x2="0" y2="1">
     <stop offset="0%" stop-color="#0e0c0a"/>
     <stop offset="60%" stop-color="#1a1610"/>
@@ -9,138 +9,163 @@
   </linearGradient>
   <rect width="400" height="240" fill="url(#ash-sky)"/>
 
-  <!-- Distant glow of underground fires on horizon -->
+  <!-- Horizon fire glow — pulsing -->
   <linearGradient id="horizon-glow" x1="0" y1="1" x2="0" y2="0">
-    <stop offset="0%" stop-color="#c05010" stop-opacity="0.4"/>
+    <stop offset="0%" stop-color="#c05010" stop-opacity="0.4">
+      <animate attributeName="stop-opacity" values="0.3;0.6;0.3" dur="4s" repeatCount="indefinite"/>
+    </stop>
     <stop offset="100%" stop-color="#c05010" stop-opacity="0"/>
   </linearGradient>
   <rect x="0" y="140" width="400" height="60" fill="url(#horizon-glow)"/>
 
-  <!-- Ash ground — flat and grey -->
+  <!-- Ash ground -->
   <rect x="0" y="170" width="400" height="70" fill="#0f0e0c"/>
   <rect x="0" y="168" width="400" height="4" fill="#1a1714"/>
 
-  <!-- Ash ground texture — subtle ripples -->
+  <!-- Ground texture ripples -->
   <g stroke="#161410" stroke-width="0.6" opacity="0.5">
     <path d="M0,180 Q50,177 100,180 Q150,183 200,180 Q250,177 300,180 Q350,183 400,180"/>
     <path d="M0,192 Q60,189 120,192 Q180,195 240,192 Q300,189 360,192 Q390,194 400,192"/>
     <path d="M0,205 Q40,203 80,205 Q120,207 160,205 Q200,203 240,205 Q280,207 320,205 Q360,203 400,205"/>
   </g>
 
-  <!-- Collapsed mineshaft entrances — dark rectangles sunk into the ground -->
-  <!-- Mine shaft left -->
+  <!-- Mine shaft left — ember glow pulsing -->
   <rect x="30" y="152" width="50" height="22" fill="#060604" stroke="#1a1714" stroke-width="1"/>
   <rect x="28" y="149" width="6"  height="6"  fill="#1a1714"/>
   <rect x="72" y="149" width="6"  height="6"  fill="#1a1714"/>
-  <!-- Support beams -->
   <line x1="28" y1="149" x2="78" y2="149" stroke="#1e1c16" stroke-width="2"/>
-  <!-- Ember glow inside shaft -->
   <radialGradient id="shaft-glow-l" cx="50%" cy="100%" r="60%">
-    <stop offset="0%" stop-color="#c05010" stop-opacity="0.5"/>
+    <stop offset="0%" stop-color="#c05010" stop-opacity="0.5">
+      <animate attributeName="stop-opacity" values="0.3;0.7;0.4;0.8;0.3" dur="3s" repeatCount="indefinite"/>
+    </stop>
     <stop offset="100%" stop-color="#c05010" stop-opacity="0"/>
   </radialGradient>
   <rect x="30" y="152" width="50" height="22" fill="url(#shaft-glow-l)"/>
 
-  <!-- Mine shaft right -->
+  <!-- Mine shaft right — ember glow pulsing -->
   <rect x="310" y="155" width="55" height="20" fill="#060604" stroke="#1a1714" stroke-width="1"/>
   <line x1="308" y1="152" x2="367" y2="152" stroke="#1e1c16" stroke-width="2"/>
   <rect x="308" y="149" width="6" height="5" fill="#1a1714"/>
   <rect x="361" y="149" width="6" height="5" fill="#1a1714"/>
   <radialGradient id="shaft-glow-r" cx="50%" cy="100%" r="60%">
-    <stop offset="0%" stop-color="#c05010" stop-opacity="0.4"/>
+    <stop offset="0%" stop-color="#c05010" stop-opacity="0.4">
+      <animate attributeName="stop-opacity" values="0.5;0.2;0.6;0.3;0.5" dur="3.5s" repeatCount="indefinite"/>
+    </stop>
     <stop offset="100%" stop-color="#c05010" stop-opacity="0"/>
   </radialGradient>
   <rect x="310" y="155" width="55" height="20" fill="url(#shaft-glow-r)"/>
 
-  <!-- Slag heap — left mid -->
+  <!-- Slag heap left -->
   <polygon points="0,170 55,120 110,170" fill="#131210" stroke="#1e1c16" stroke-width="1"/>
   <polygon points="10,170 50,128 90,170"  fill="#0f0e0c"/>
-  <!-- Slag cracks with ember glow -->
-  <g stroke="#c05010" stroke-width="0.8" opacity="0.4">
+  <g stroke="#c05010" stroke-width="0.8">
+    <animate attributeName="opacity" values="0.2;0.5;0.2" dur="3s" repeatCount="indefinite"/>
     <path d="M40,155 Q48,148 55,142"/>
     <path d="M55,142 Q60,148 65,155"/>
     <path d="M50,162 Q55,155 62,162"/>
   </g>
 
-  <!-- Slag heap — right mid -->
+  <!-- Slag heap right -->
   <polygon points="290,170 345,118 400,170" fill="#131210" stroke="#1e1c16" stroke-width="1"/>
   <polygon points="300,170 344,126 395,170" fill="#0f0e0c"/>
-  <g stroke="#c05010" stroke-width="0.8" opacity="0.3">
+  <g stroke="#c05010" stroke-width="0.8">
+    <animate attributeName="opacity" values="0.1;0.4;0.1" dur="4s" repeatCount="indefinite"/>
     <path d="M328,152 Q335,145 342,138"/>
     <path d="M342,138 Q348,145 355,155"/>
   </g>
 
-  <!-- Ruined mining tower structure — centre -->
-  <!-- Main tower frame -->
+  <!-- Mining tower — centre -->
   <rect x="178" y="80" width="6"  height="90" fill="#161412" stroke="#221e18" stroke-width="0.5"/>
   <rect x="216" y="80" width="6"  height="90" fill="#161412" stroke="#221e18" stroke-width="0.5"/>
-  <!-- Cross beams -->
   <line x1="178" y1="95"  x2="222" y2="95"  stroke="#1e1c16" stroke-width="3"/>
   <line x1="178" y1="115" x2="222" y2="115" stroke="#1e1c16" stroke-width="3"/>
   <line x1="178" y1="135" x2="222" y2="135" stroke="#1e1c16" stroke-width="3"/>
-  <!-- X-brace -->
   <line x1="178" y1="80"  x2="222" y2="160" stroke="#1a1814" stroke-width="1.5" opacity="0.6"/>
   <line x1="222" y1="80"  x2="178" y2="160" stroke="#1a1814" stroke-width="1.5" opacity="0.6"/>
-  <!-- Pulley wheel at top -->
-  <circle cx="200" cy="78" r="10" fill="none" stroke="#221e18" stroke-width="2"/>
+  <!-- Pulley wheel -->
+  <circle cx="200" cy="78" r="10" fill="none" stroke="#221e18" stroke-width="2">
+    <animateTransform attributeName="transform" type="rotate" values="0 200 78; 5 200 78; 0 200 78; -5 200 78; 0 200 78" dur="8s" repeatCount="indefinite"/>
+  </circle>
   <circle cx="200" cy="78" r="4"  fill="#161412"/>
-  <!-- Cable hanging down -->
+  <!-- Cable and swinging ore bucket -->
   <line x1="200" y1="88" x2="200" y2="170" stroke="#1a1814" stroke-width="1.5" stroke-dasharray="4,3"/>
-  <!-- Ore bucket on cable -->
-  <polygon points="194,140 206,140 208,155 192,155" fill="#1a1814" stroke="#221e18" stroke-width="0.8"/>
+  <polygon points="194,140 206,140 208,155 192,155" fill="#1a1814" stroke="#221e18" stroke-width="0.8">
+    <animateTransform attributeName="transform" type="translate" values="0 0; 3 0; 0 0; -3 0; 0 0" dur="5s" repeatCount="indefinite"/>
+  </polygon>
 
-  <!-- Fire/ember patches on ground -->
-  <g opacity="0.7">
-    <radialGradient id="ember1" cx="50%" cy="50%" r="50%">
-      <stop offset="0%" stop-color="#e06010" stop-opacity="0.8"/>
-      <stop offset="100%" stop-color="#e06010" stop-opacity="0"/>
-    </radialGradient>
-    <ellipse cx="145" cy="175" rx="12" ry="6" fill="url(#ember1)"/>
-    <radialGradient id="ember2" cx="50%" cy="50%" r="50%">
-      <stop offset="0%" stop-color="#c04808" stop-opacity="0.7"/>
-      <stop offset="100%" stop-color="#c04808" stop-opacity="0"/>
-    </radialGradient>
-    <ellipse cx="255" cy="178" rx="9"  ry="5" fill="url(#ember2)"/>
-    <radialGradient id="ember3" cx="50%" cy="50%" r="50%">
-      <stop offset="0%" stop-color="#d05810" stop-opacity="0.6"/>
-      <stop offset="100%" stop-color="#d05810" stop-opacity="0"/>
-    </radialGradient>
-    <ellipse cx="90"  cy="182" rx="7"  ry="4" fill="url(#ember3)"/>
+  <!-- Ground embers — pulsing -->
+  <radialGradient id="ember1" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#e06010" stop-opacity="0.8">
+      <animate attributeName="stop-opacity" values="0.5;0.9;0.5" dur="2.5s" repeatCount="indefinite"/>
+    </stop>
+    <stop offset="100%" stop-color="#e06010" stop-opacity="0"/>
+  </radialGradient>
+  <ellipse cx="145" cy="175" rx="12" ry="6" fill="url(#ember1)"/>
+  <radialGradient id="ember2" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#c04808" stop-opacity="0.7">
+      <animate attributeName="stop-opacity" values="0.4;0.8;0.4" dur="3.2s" repeatCount="indefinite"/>
+    </stop>
+    <stop offset="100%" stop-color="#c04808" stop-opacity="0"/>
+  </radialGradient>
+  <ellipse cx="255" cy="178" rx="9"  ry="5" fill="url(#ember2)"/>
+  <radialGradient id="ember3" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#d05810" stop-opacity="0.6">
+      <animate attributeName="stop-opacity" values="0.6;0.3;0.7;0.4;0.6" dur="2s" repeatCount="indefinite"/>
+    </stop>
+    <stop offset="100%" stop-color="#d05810" stop-opacity="0"/>
+  </radialGradient>
+  <ellipse cx="90"  cy="182" rx="7"  ry="4" fill="url(#ember3)"/>
+
+  <!-- Falling ash — drifting down -->
+  <g fill="#302c24">
+    <circle cx="60"  cy="40"  r="1.5">
+      <animateTransform attributeName="transform" type="translate" values="0 0; -4 60; -4 120" dur="12s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.5;0.5;0" dur="12s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="110" cy="25"  r="1">
+      <animateTransform attributeName="transform" type="translate" values="0 0; -3 80; -3 160" dur="16s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.4;0.4;0" dur="16s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="160" cy="55"  r="1.5">
+      <animateTransform attributeName="transform" type="translate" values="0 0; -5 50; -5 100" dur="10s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.5;0.5;0" dur="10s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="240" cy="30"  r="1">
+      <animateTransform attributeName="transform" type="translate" values="0 0; -4 70; -4 140" dur="14s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.4;0.4;0" dur="14s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="290" cy="50"  r="1.5">
+      <animateTransform attributeName="transform" type="translate" values="0 0; -3 55; -3 110" dur="11s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.5;0.5;0" dur="11s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="340" cy="20"  r="1">
+      <animateTransform attributeName="transform" type="translate" values="0 0; -4 90; -4 180" dur="18s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.4;0.4;0" dur="18s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="380" cy="65"  r="1.5">
+      <animateTransform attributeName="transform" type="translate" values="0 0; -3 45; -3 90" dur="9s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.5;0.5;0" dur="9s" repeatCount="indefinite"/>
+    </circle>
   </g>
 
-  <!-- Falling ash particles -->
-  <g fill="#302c24" opacity="0.5">
-    <circle cx="60"  cy="40"  r="1.5"/>
-    <circle cx="110" cy="25"  r="1"/>
-    <circle cx="160" cy="55"  r="1.5"/>
-    <circle cx="240" cy="30"  r="1"/>
-    <circle cx="290" cy="50"  r="1.5"/>
-    <circle cx="340" cy="20"  r="1"/>
-    <circle cx="380" cy="65"  r="1.5"/>
-    <circle cx="20"  cy="70"  r="1"/>
-    <circle cx="320" cy="75"  r="1"/>
-    <circle cx="80"  cy="85"  r="1.5"/>
-    <circle cx="200" cy="45"  r="1"/>
-  </g>
-  <!-- Ash streaks falling diagonally -->
-  <g stroke="#302c24" stroke-width="0.5" opacity="0.3">
-    <line x1="50"  y1="20" x2="46"  y2="35"/>
-    <line x1="130" y1="10" x2="126" y2="28"/>
-    <line x1="220" y1="15" x2="216" y2="30"/>
-    <line x1="310" y1="25" x2="306" y2="40"/>
-    <line x1="370" y1="10" x2="366" y2="28"/>
-  </g>
-
-  <!-- Smoke columns rising from slag and shafts -->
+  <!-- Smoke columns rising -->
   <g fill="#1a1814" opacity="0.25">
-    <ellipse cx="55"  cy="115" rx="18" ry="30" transform="translate(0,-10)"/>
-    <ellipse cx="55"  cy="95"  rx="12" ry="20"/>
-    <ellipse cx="55"  cy="75"  rx="8"  ry="15"/>
-    <ellipse cx="344" cy="110" rx="16" ry="28" transform="translate(0,-8)"/>
-    <ellipse cx="344" cy="92"  rx="10" ry="18"/>
-    <ellipse cx="200" cy="60"  rx="6"  ry="12"/>
+    <ellipse cx="55"  cy="115" rx="18" ry="30">
+      <animateTransform attributeName="transform" type="translate" values="0 0; 2 -8; 0 0" dur="10s" repeatCount="indefinite"/>
+    </ellipse>
+    <ellipse cx="55"  cy="95"  rx="12" ry="20">
+      <animateTransform attributeName="transform" type="translate" values="0 0; 3 -10; 0 0" dur="8s" repeatCount="indefinite"/>
+    </ellipse>
+    <ellipse cx="344" cy="110" rx="16" ry="28">
+      <animateTransform attributeName="transform" type="translate" values="0 0; -2 -9; 0 0" dur="11s" repeatCount="indefinite"/>
+    </ellipse>
+    <ellipse cx="200" cy="60"  rx="6"  ry="12">
+      <animateTransform attributeName="transform" type="translate" values="0 0; 1 -6; 0 0" dur="7s" repeatCount="indefinite"/>
+    </ellipse>
   </g>
 
   <!-- Label -->
-  <text x="200" y="228" font-family="monospace" font-size="9" fill="#3a2c1a" text-anchor="middle" letter-spacing="3">THE ASHEN WASTES</text>
+  <text x="200" y="228" font-family="monospace" font-size="9" fill="#3a2c1a" text-anchor="middle" letter-spacing="3">THE ASHEN WASTES
+    <animate attributeName="opacity" values="0.5;1;0.5" dur="6s" repeatCount="indefinite"/>
+  </text>
 </svg>

--- a/web/public/cutscenes/act3-intro-2.svg
+++ b/web/public/cutscenes/act3-intro-2.svg
@@ -8,9 +8,11 @@
   </linearGradient>
   <rect width="400" height="240" fill="url(#ash-sky2)"/>
 
-  <!-- Distant ember glow on horizon — the Wastes ahead -->
+  <!-- Ember glow on horizon — pulsing -->
   <radialGradient id="wastes-glow" cx="65%" cy="75%" r="35%">
-    <stop offset="0%" stop-color="#c04808" stop-opacity="0.35"/>
+    <stop offset="0%" stop-color="#c04808" stop-opacity="0.35">
+      <animate attributeName="stop-opacity" values="0.2;0.5;0.2" dur="5s" repeatCount="indefinite"/>
+    </stop>
     <stop offset="100%" stop-color="#c04808" stop-opacity="0"/>
   </radialGradient>
   <rect width="400" height="240" fill="url(#wastes-glow)"/>
@@ -19,95 +21,89 @@
   <rect x="0" y="196" width="400" height="44" fill="#0d0c0a"/>
   <rect x="0" y="192" width="400" height="6"  fill="#121008"/>
 
-  <!-- Distant silhouette of the Wastes — slag heaps and fire on horizon -->
+  <!-- Distant slag heaps and ember dots -->
   <polygon points="230,170 270,145 310,168 350,138 400,155 400,170 230,170" fill="#0f0d0a"/>
   <polygon points="280,170 320,148 360,158 400,148 400,170 280,170" fill="#0c0b08"/>
-  <!-- Ember dots on horizon -->
-  <g fill="#c04808" opacity="0.5">
-    <circle cx="270" cy="148" r="2"/>
-    <circle cx="310" cy="155" r="1.5"/>
-    <circle cx="355" cy="140" r="2"/>
-    <circle cx="340" cy="152" r="1.5"/>
+  <g fill="#c04808">
+    <circle cx="270" cy="148" r="2">
+      <animate attributeName="opacity" values="0.5;0.9;0.3;0.7;0.5" dur="2s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="310" cy="155" r="1.5">
+      <animate attributeName="opacity" values="0.3;0.7;0.5;0.9;0.3" dur="2.5s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="355" cy="140" r="2">
+      <animate attributeName="opacity" values="0.6;0.2;0.8;0.4;0.6" dur="1.8s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="340" cy="152" r="1.5">
+      <animate attributeName="opacity" values="0.4;0.8;0.3;0.6;0.4" dur="3s" repeatCount="indefinite"/>
+    </circle>
   </g>
 
-  <!-- WANDERER — centre frame, looking toward the wastes (right) -->
-  <!-- Ground shadow -->
-  <ellipse cx="155" cy="205" rx="22" ry="6" fill="#060604" opacity="0.7"/>
+  <!-- WANDERER — walking bob -->
+  <g>
+    <animateTransform attributeName="transform" type="translate"
+      values="0 0; 0 -1.5; 0 0; 0 -1.5; 0 0" dur="0.8s" repeatCount="indefinite"/>
 
-  <!-- Boots -->
-  <ellipse cx="144" cy="208" rx="6" ry="3" fill="#0d0b08"/>
-  <ellipse cx="163" cy="207" rx="6" ry="3" fill="#0d0b08"/>
-
-  <!-- Legs -->
-  <line x1="148" y1="196" x2="144" y2="208" stroke="#141210" stroke-width="4" stroke-linecap="round"/>
-  <line x1="158" y1="196" x2="163" y2="207" stroke="#141210" stroke-width="4" stroke-linecap="round"/>
-
-  <!-- Cloak body — ash-dusted grey-brown -->
-  <polygon points="138,178 170,178 174,198 134,198" fill="#1e1a14" stroke="#2a2418" stroke-width="1"/>
-  <!-- Ash dust on cloak shoulders -->
-  <g fill="#2a2620" opacity="0.4">
-    <ellipse cx="141" cy="180" rx="6" ry="2"/>
-    <ellipse cx="167" cy="180" rx="5" ry="2"/>
+    <ellipse cx="155" cy="205" rx="22" ry="6" fill="#060604" opacity="0.7"/>
+    <ellipse cx="144" cy="208" rx="6" ry="3" fill="#0d0b08"/>
+    <ellipse cx="163" cy="207" rx="6" ry="3" fill="#0d0b08"/>
+    <line x1="148" y1="196" x2="144" y2="208" stroke="#141210" stroke-width="4" stroke-linecap="round"/>
+    <line x1="158" y1="196" x2="163" y2="207" stroke="#141210" stroke-width="4" stroke-linecap="round"/>
+    <polygon points="138,178 170,178 174,198 134,198" fill="#1e1a14" stroke="#2a2418" stroke-width="1"/>
+    <g fill="#2a2620" opacity="0.4">
+      <ellipse cx="141" cy="180" rx="6" ry="2"/>
+      <ellipse cx="167" cy="180" rx="5" ry="2"/>
+    </g>
+    <ellipse cx="154" cy="172" rx="11" ry="9" fill="#181410" stroke="#262018" stroke-width="1"/>
+    <ellipse cx="155" cy="175" rx="7" ry="5" fill="#0e0c08"/>
+    <line x1="168" y1="182" x2="195" y2="170" stroke="#1e1a14" stroke-width="3" stroke-linecap="round"/>
   </g>
 
-  <!-- Hood / head -->
-  <ellipse cx="154" cy="172" rx="11" ry="9" fill="#181410" stroke="#262018" stroke-width="1"/>
-  <!-- Face shadow under hood -->
-  <ellipse cx="155" cy="175" rx="7" ry="5" fill="#0e0c08"/>
-
-  <!-- Arm holding Iron Standard pole — right arm outstretched -->
-  <line x1="168" y1="182" x2="195" y2="170" stroke="#1e1a14" stroke-width="3" stroke-linecap="round"/>
-
-  <!-- The Iron Standard (carried from Act 2) -->
-  <!-- Pole -->
-  <line x1="195" y1="140" x2="195" y2="210" stroke="#2a3040" stroke-width="2.5"/>
-  <!-- Spike finial -->
-  <polygon points="193,140 197,140 195,132" fill="#404860"/>
-  <!-- Banner — small, wind-blown left (Jarv moving right) -->
-  <polygon points="195,143 235,149 232,165 195,160" fill="#1e2438" stroke="#303548" stroke-width="1"/>
-  <!-- Iron cross on small banner -->
-  <g stroke="#3a4060" stroke-width="1.2">
-    <line x1="215" y1="147" x2="215" y2="161"/>
-    <line x1="208" y1="154" x2="222" y2="154"/>
+  <!-- Iron Standard — sways in ash wind -->
+  <g>
+    <animateTransform attributeName="transform" type="skewX"
+      values="0; 3; 0; -2; 0" dur="5s" repeatCount="indefinite"/>
+    <line x1="195" y1="140" x2="195" y2="210" stroke="#2a3040" stroke-width="2.5"/>
+    <polygon points="193,140 197,140 195,132" fill="#404860"/>
+    <polygon points="195,143 235,149 232,165 195,160" fill="#1e2438" stroke="#303548" stroke-width="1"/>
+    <g stroke="#3a4060" stroke-width="1.2">
+      <line x1="215" y1="147" x2="215" y2="161"/>
+      <line x1="208" y1="154" x2="222" y2="154"/>
+    </g>
   </g>
 
-  <!-- Left arm — holding cloak closed against ashen wind -->
+  <!-- Left arm -->
   <line x1="140" y1="182" x2="130" y2="191" stroke="#1e1a14" stroke-width="3" stroke-linecap="round"/>
 
-  <!-- Falling ash — particles across whole frame -->
-  <g fill="#2e2a20" opacity="0.55">
-    <circle cx="45"  cy="30"  r="1.5"/>
-    <circle cx="85"  cy="20"  r="1"/>
-    <circle cx="120" cy="50"  r="1.5"/>
-    <circle cx="175" cy="35"  r="1"/>
-    <circle cx="240" cy="25"  r="1.5"/>
-    <circle cx="290" cy="45"  r="1"/>
-    <circle cx="330" cy="20"  r="1.5"/>
-    <circle cx="370" cy="55"  r="1"/>
-    <circle cx="30"  cy="75"  r="1"/>
-    <circle cx="95"  cy="90"  r="1.5"/>
-    <circle cx="200" cy="80"  r="1"/>
-    <circle cx="260" cy="70"  r="1.5"/>
-    <circle cx="350" cy="85"  r="1"/>
-    <circle cx="65"  cy="110" r="1.5"/>
-    <circle cx="140" cy="120" r="1"/>
-    <circle cx="310" cy="100" r="1.5"/>
-    <circle cx="380" cy="115" r="1"/>
-    <circle cx="20"  cy="145" r="1"/>
-    <circle cx="220" cy="130" r="1.5"/>
-  </g>
-  <!-- Diagonal ash streaks (wind from right) -->
-  <g stroke="#2e2a20" stroke-width="0.5" opacity="0.35">
-    <line x1="80"  y1="35"  x2="74"  y2="50"/>
-    <line x1="160" y1="15"  x2="154" y2="32"/>
-    <line x1="260" y1="40"  x2="254" y2="55"/>
-    <line x1="350" y1="25"  x2="344" y2="42"/>
-    <line x1="30"  y1="60"  x2="24"  y2="78"/>
-    <line x1="110" y1="95"  x2="104" y2="112"/>
-    <line x1="300" y1="110" x2="294" y2="128"/>
+  <!-- Falling ash — drifting diagonally -->
+  <g fill="#2e2a20">
+    <circle cx="45"  cy="30"  r="1.5">
+      <animateTransform attributeName="transform" type="translate" values="0 0; -6 100; -6 200" dur="20s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.55;0.55;0" dur="20s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="120" cy="50"  r="1.5">
+      <animateTransform attributeName="transform" type="translate" values="0 0; -5 80; -5 160" dur="16s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.55;0.55;0" dur="16s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="240" cy="25"  r="1.5">
+      <animateTransform attributeName="transform" type="translate" values="0 0; -6 90; -6 180" dur="18s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.55;0.55;0" dur="18s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="330" cy="20"  r="1.5">
+      <animateTransform attributeName="transform" type="translate" values="0 0; -5 100; -5 200" dur="20s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.55;0.55;0" dur="20s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="95"  cy="90"  r="1.5">
+      <animateTransform attributeName="transform" type="translate" values="0 0; -4 70; -4 140" dur="14s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.55;0.55;0" dur="14s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="200" cy="80"  r="1">
+      <animateTransform attributeName="transform" type="translate" values="0 0; -5 80; -5 160" dur="16s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.55;0.55;0" dur="16s" repeatCount="indefinite"/>
+    </circle>
   </g>
 
-  <!-- Footprints in the ash behind Jarv -->
+  <!-- Footprints in the ash -->
   <g fill="#0f0d0a" opacity="0.5">
     <ellipse cx="126" cy="202" rx="4" ry="2" transform="rotate(-12,126,202)"/>
     <ellipse cx="112" cy="203" rx="4" ry="2" transform="rotate(10,112,203)"/>
@@ -116,5 +112,7 @@
   </g>
 
   <!-- Label -->
-  <text x="200" y="228" font-family="monospace" font-size="9" fill="#3a2c1a" text-anchor="middle" letter-spacing="3">THE WANDERER</text>
+  <text x="200" y="228" font-family="monospace" font-size="9" fill="#3a2c1a" text-anchor="middle" letter-spacing="3">THE WANDERER
+    <animate attributeName="opacity" values="0.5;1;0.5" dur="6s" repeatCount="indefinite"/>
+  </text>
 </svg>

--- a/web/public/cutscenes/act3-intro-3.svg
+++ b/web/public/cutscenes/act3-intro-3.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#090908"/>
 
-  <!-- Smoky overcast sky — almost no distinction between sky and land -->
+  <!-- Smoky overcast sky -->
   <linearGradient id="waste-sky" x1="0" y1="0" x2="0" y2="1">
     <stop offset="0%" stop-color="#0d0b08"/>
     <stop offset="50%" stop-color="#161210"/>
@@ -9,14 +9,18 @@
   </linearGradient>
   <rect width="400" height="240" fill="url(#waste-sky)"/>
 
-  <!-- Multiple underground fire glows — fires that never went out -->
+  <!-- Underground fire glows — pulsing -->
   <radialGradient id="fire-glow1" cx="30%" cy="78%" r="20%">
-    <stop offset="0%" stop-color="#d04808" stop-opacity="0.5"/>
+    <stop offset="0%" stop-color="#d04808" stop-opacity="0.5">
+      <animate attributeName="stop-opacity" values="0.3;0.7;0.4;0.6;0.3" dur="3s" repeatCount="indefinite"/>
+    </stop>
     <stop offset="100%" stop-color="#d04808" stop-opacity="0"/>
   </radialGradient>
   <rect width="400" height="240" fill="url(#fire-glow1)"/>
   <radialGradient id="fire-glow2" cx="70%" cy="80%" r="18%">
-    <stop offset="0%" stop-color="#b83808" stop-opacity="0.4"/>
+    <stop offset="0%" stop-color="#b83808" stop-opacity="0.4">
+      <animate attributeName="stop-opacity" values="0.5;0.2;0.6;0.3;0.5" dur="4s" repeatCount="indefinite"/>
+    </stop>
     <stop offset="100%" stop-color="#b83808" stop-opacity="0"/>
   </radialGradient>
   <rect width="400" height="240" fill="url(#fire-glow2)"/>
@@ -25,7 +29,7 @@
   <rect x="0" y="170" width="400" height="70" fill="#0c0b08"/>
   <rect x="0" y="168" width="400" height="4" fill="#161410"/>
 
-  <!-- Cracked ash ground surface -->
+  <!-- Cracked ash ground -->
   <g stroke="#1a1610" stroke-width="0.7" opacity="0.6">
     <path d="M20,190 Q60,185 80,195 Q100,205 140,198"/>
     <path d="M160,182 Q200,178 230,185 Q260,192 300,186"/>
@@ -33,46 +37,52 @@
     <path d="M50,210 Q90,206 120,212"/>
     <path d="M200,208 Q250,204 290,210"/>
   </g>
-  <!-- Ash cracks glowing orange from below -->
-  <g stroke="#c04808" stroke-width="0.6" opacity="0.3">
+  <!-- Glowing cracks — pulsing -->
+  <g stroke="#c04808" stroke-width="0.6">
+    <animate attributeName="opacity" values="0.2;0.5;0.2" dur="3s" repeatCount="indefinite"/>
     <path d="M80,185  Q95,178  105,188"/>
     <path d="M230,180 Q240,172 252,182"/>
     <path d="M150,200 Q160,194 170,202"/>
   </g>
 
-  <!-- Ruined mineshaft openings — wider view -->
+  <!-- Mineshaft left — glow pulsing -->
   <rect x="50"  y="155" width="44" height="18" fill="#050503" stroke="#141210" stroke-width="1"/>
   <line x1="48"  y1="152" x2="96"  y2="152" stroke="#181612" stroke-width="2"/>
   <radialGradient id="shaft1" cx="50%" cy="100%" r="70%">
-    <stop offset="0%" stop-color="#d04808" stop-opacity="0.6"/>
+    <stop offset="0%" stop-color="#d04808" stop-opacity="0.6">
+      <animate attributeName="stop-opacity" values="0.4;0.8;0.4;0.7;0.4" dur="2.5s" repeatCount="indefinite"/>
+    </stop>
     <stop offset="100%" stop-color="#d04808" stop-opacity="0"/>
   </radialGradient>
   <rect x="50" y="155" width="44" height="18" fill="url(#shaft1)"/>
 
+  <!-- Mineshaft right -->
   <rect x="290" y="158" width="44" height="18" fill="#050503" stroke="#141210" stroke-width="1"/>
   <line x1="288" y1="155" x2="336" y2="155" stroke="#181612" stroke-width="2"/>
   <radialGradient id="shaft2" cx="50%" cy="100%" r="70%">
-    <stop offset="0%" stop-color="#b83808" stop-opacity="0.5"/>
+    <stop offset="0%" stop-color="#b83808" stop-opacity="0.5">
+      <animate attributeName="stop-opacity" values="0.6;0.3;0.7;0.4;0.6" dur="3.2s" repeatCount="indefinite"/>
+    </stop>
     <stop offset="100%" stop-color="#b83808" stop-opacity="0"/>
   </radialGradient>
   <rect x="290" y="158" width="44" height="18" fill="url(#shaft2)"/>
 
-  <!-- UNDEAD FIGURES roaming the wastes — bone-white silhouettes -->
-  <!-- Undead 1 — left, standing still -->
+  <!-- Undead 1 — slow sway -->
   <g fill="#252018" opacity="0.85">
-    <circle cx="110" cy="160" r="5"/><!-- head (skull) -->
-    <rect   cx="107" cy="165" width="6" height="12"/><!-- torso -->
-    <line x1="108" y1="167" x2="100" y2="174" stroke="#252018" stroke-width="2"/><!-- left arm -->
-    <line x1="113" y1="167" x2="120" y2="172" stroke="#252018" stroke-width="2"/><!-- right arm outstretched -->
-    <line x1="108" y1="177" x2="105" y2="188" stroke="#252018" stroke-width="2"/><!-- left leg -->
-    <line x1="112" y1="177" x2="115" y2="188" stroke="#252018" stroke-width="2"/><!-- right leg -->
+    <animateTransform attributeName="transform" type="translate" values="0 0; 2 0; 0 0; -2 0; 0 0" dur="9s" repeatCount="indefinite"/>
+    <circle cx="110" cy="160" r="5"/>
+    <rect   cx="107" cy="165" width="6" height="12"/>
+    <line x1="108" y1="167" x2="100" y2="174" stroke="#252018" stroke-width="2"/>
+    <line x1="113" y1="167" x2="120" y2="172" stroke="#252018" stroke-width="2"/>
+    <line x1="108" y1="177" x2="105" y2="188" stroke="#252018" stroke-width="2"/>
+    <line x1="112" y1="177" x2="115" y2="188" stroke="#252018" stroke-width="2"/>
   </g>
-  <!-- Skull details -->
   <circle cx="108" cy="159" r="1.5" fill="#181410"/>
   <circle cx="112" cy="159" r="1.5" fill="#181410"/>
 
-  <!-- Undead 2 — centre-left, hunched -->
+  <!-- Undead 2 — slow sway offset -->
   <g fill="#221e16" opacity="0.8">
+    <animateTransform attributeName="transform" type="translate" values="0 0; -2 0; 0 0; 2 0; 0 0" dur="11s" repeatCount="indefinite"/>
     <circle cx="170" cy="163" r="5"/>
     <rect   x="167" y="168" width="6" height="10" transform="rotate(10,170,172)"/>
     <line x1="167" y1="170" x2="158" y2="178" stroke="#221e16" stroke-width="2"/>
@@ -83,8 +93,9 @@
   <circle cx="168" cy="162" r="1.5" fill="#151210"/>
   <circle cx="172" cy="162" r="1.5" fill="#151210"/>
 
-  <!-- Undead 3 — right, walking -->
+  <!-- Undead 3 — slow walk -->
   <g fill="#201c14" opacity="0.75">
+    <animateTransform attributeName="transform" type="translate" values="0 0; 3 0; 6 0; 9 0; 12 0" dur="15s" repeatCount="indefinite"/>
     <circle cx="270" cy="161" r="5"/>
     <rect   x="267" y="166" width="6" height="11"/>
     <line x1="267" y1="168" x2="258" y2="174" stroke="#201c14" stroke-width="2"/>
@@ -95,8 +106,9 @@
   <circle cx="268" cy="160" r="1.5" fill="#141210"/>
   <circle cx="272" cy="160" r="1.5" fill="#141210"/>
 
-  <!-- Undead 4 — far right, in distance (smaller) -->
+  <!-- Undead 4 — distant -->
   <g fill="#1a1810" opacity="0.6">
+    <animateTransform attributeName="transform" type="translate" values="0 0; -3 0; 0 0; 3 0; 0 0" dur="13s" repeatCount="indefinite"/>
     <circle cx="340" cy="166" r="4"/>
     <rect   x="337" y="170" width="5" height="9"/>
     <line x1="337" y1="172" x2="330" y2="177" stroke="#1a1810" stroke-width="1.5"/>
@@ -105,38 +117,57 @@
     <line x1="341" y1="179" x2="345" y2="188" stroke="#1a1810" stroke-width="1.5"/>
   </g>
 
-  <!-- Floating ash spirits — wispy shapes -->
-  <g stroke="#3a2c18" stroke-width="0.8" fill="none" opacity="0.25">
-    <ellipse cx="60"  cy="130" rx="20" ry="10" transform="rotate(-20,60,130)"/>
-    <ellipse cx="220" cy="120" rx="18" ry="8"  transform="rotate(15,220,120)"/>
-    <ellipse cx="360" cy="135" rx="15" ry="7"  transform="rotate(-10,360,135)"/>
+  <!-- Ash spirits — drifting -->
+  <g stroke="#3a2c18" stroke-width="0.8" fill="none">
+    <ellipse cx="60"  cy="130" rx="20" ry="10" transform="rotate(-20,60,130)">
+      <animateTransform attributeName="transform" type="translate" values="0 0; 15 -10; 30 -20; 45 -30" dur="20s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.25;0.35;0.25;0.1;0" dur="20s" repeatCount="indefinite"/>
+    </ellipse>
+    <ellipse cx="220" cy="120" rx="18" ry="8"  transform="rotate(15,220,120)">
+      <animateTransform attributeName="transform" type="translate" values="0 0; -10 -8; -20 -16" dur="18s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.25;0.3;0.1;0" dur="18s" repeatCount="indefinite"/>
+    </ellipse>
+    <ellipse cx="360" cy="135" rx="15" ry="7"  transform="rotate(-10,360,135)">
+      <animateTransform attributeName="transform" type="translate" values="0 0; 8 -6; 16 -12" dur="22s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.25;0.35;0.15;0" dur="22s" repeatCount="indefinite"/>
+    </ellipse>
   </g>
 
-  <!-- Smoke columns from ground cracks -->
+  <!-- Smoke columns — rising -->
   <g fill="#201a12" opacity="0.2">
-    <ellipse cx="72"  cy="145" rx="10" ry="25"/>
-    <ellipse cx="72"  cy="120" rx="7"  ry="18"/>
-    <ellipse cx="312" cy="148" rx="9"  ry="22"/>
-    <ellipse cx="312" cy="126" rx="6"  ry="16"/>
-    <ellipse cx="190" cy="140" rx="8"  ry="20"/>
-    <ellipse cx="190" cy="118" rx="5"  ry="15"/>
+    <ellipse cx="72"  cy="145" rx="10" ry="25">
+      <animateTransform attributeName="transform" type="translate" values="0 0; 2 -10; 0 0" dur="9s" repeatCount="indefinite"/>
+    </ellipse>
+    <ellipse cx="312" cy="148" rx="9"  ry="22">
+      <animateTransform attributeName="transform" type="translate" values="0 0; -2 -8; 0 0" dur="11s" repeatCount="indefinite"/>
+    </ellipse>
+    <ellipse cx="190" cy="140" rx="8"  ry="20">
+      <animateTransform attributeName="transform" type="translate" values="0 0; 1 -7; 0 0" dur="8s" repeatCount="indefinite"/>
+    </ellipse>
   </g>
 
   <!-- Falling ash -->
-  <g fill="#2a2418" opacity="0.45">
-    <circle cx="35"  cy="25"  r="1.5"/>
-    <circle cx="90"  cy="15"  r="1"/>
-    <circle cx="150" cy="40"  r="1.5"/>
-    <circle cx="210" cy="20"  r="1"/>
-    <circle cx="280" cy="35"  r="1.5"/>
-    <circle cx="340" cy="18"  r="1"/>
-    <circle cx="390" cy="50"  r="1.5"/>
-    <circle cx="30"  cy="65"  r="1"/>
-    <circle cx="130" cy="80"  r="1.5"/>
-    <circle cx="250" cy="60"  r="1"/>
-    <circle cx="370" cy="75"  r="1.5"/>
+  <g fill="#2a2418">
+    <circle cx="35"  cy="25"  r="1.5">
+      <animateTransform attributeName="transform" type="translate" values="0 0; -5 80; -5 160" dur="16s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.45;0.45;0" dur="16s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="150" cy="40"  r="1.5">
+      <animateTransform attributeName="transform" type="translate" values="0 0; -4 60; -4 120" dur="12s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.45;0.45;0" dur="12s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="280" cy="35"  r="1.5">
+      <animateTransform attributeName="transform" type="translate" values="0 0; -5 90; -5 180" dur="18s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.45;0.45;0" dur="18s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="390" cy="50"  r="1.5">
+      <animateTransform attributeName="transform" type="translate" values="0 0; -4 70; -4 140" dur="14s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.45;0.45;0" dur="14s" repeatCount="indefinite"/>
+    </circle>
   </g>
 
   <!-- Label -->
-  <text x="200" y="228" font-family="monospace" font-size="9" fill="#3a2c1a" text-anchor="middle" letter-spacing="3">THE ASHEN WASTES</text>
+  <text x="200" y="228" font-family="monospace" font-size="9" fill="#3a2c1a" text-anchor="middle" letter-spacing="3">THE ASHEN WASTES
+    <animate attributeName="opacity" values="0.5;1;0.5" dur="6s" repeatCount="indefinite"/>
+  </text>
 </svg>

--- a/web/public/cutscenes/act3-intro-4.svg
+++ b/web/public/cutscenes/act3-intro-4.svg
@@ -1,15 +1,18 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
   <rect width="400" height="240" fill="#090908"/>
 
-  <!-- Dark background with ember glow at centre -->
+  <!-- Ember glow at centre — pulsing -->
   <radialGradient id="mission3-glow" cx="50%" cy="50%" r="50%">
-    <stop offset="0%" stop-color="#1e1408" stop-opacity="0.7"/>
+    <stop offset="0%" stop-color="#1e1408" stop-opacity="0.7">
+      <animate attributeName="stop-opacity" values="0.5;0.9;0.5" dur="5s" repeatCount="indefinite"/>
+    </stop>
     <stop offset="100%" stop-color="#090908" stop-opacity="0"/>
   </radialGradient>
   <rect width="400" height="240" fill="url(#mission3-glow)"/>
 
-  <!-- Map grid lines -->
-  <g stroke="#161210" stroke-width="0.5" opacity="0.5">
+  <!-- Map grid lines — scanning pulse -->
+  <g stroke="#161210" stroke-width="0.5">
+    <animate attributeName="opacity" values="0.3;0.7;0.3" dur="5s" repeatCount="indefinite"/>
     <line x1="0"   y1="40"  x2="400" y2="40"/>
     <line x1="0"   y1="80"  x2="400" y2="80"/>
     <line x1="0"   y1="120" x2="400" y2="120"/>
@@ -24,34 +27,39 @@
     <line x1="350" y1="0"   x2="350" y2="240"/>
   </g>
 
-  <!-- Player position marker — left side -->
-  <polygon points="30,120 48,110 66,120 66,140 48,150 30,140" fill="#0f1410" stroke="#204030" stroke-width="1.5"/>
+  <!-- Player marker — pulsing -->
+  <polygon points="30,120 48,110 66,120 66,140 48,150 30,140" fill="#0f1410" stroke="#204030" stroke-width="1.5">
+    <animate attributeName="opacity" values="0.7;1;0.7" dur="3s" repeatCount="indefinite"/>
+  </polygon>
   <polygon points="48,118 51,126 59,126 53,131 55,139 48,134 41,139 43,131 37,126 45,126" fill="#204030" opacity="0.8"/>
 
-  <!-- Ash zone hazard markers along the path -->
-  <!-- Zone 1 — patch of cracked ground -->
-  <ellipse cx="125" cy="120" rx="20" ry="12" fill="#1a1208" stroke="#c04808" stroke-width="0.8" stroke-dasharray="3,2"/>
-  <!-- Undead cluster in zone 1 -->
+  <!-- Hazard zone 1 — ember border pulsing -->
+  <ellipse cx="125" cy="120" rx="20" ry="12" fill="#1a1208" stroke="#c04808" stroke-width="0.8" stroke-dasharray="3,2">
+    <animate attributeName="stroke-opacity" values="0.5;1;0.5" dur="2s" repeatCount="indefinite"/>
+  </ellipse>
   <g fill="#201a10" opacity="0.7">
     <circle cx="118" cy="117" r="3"/>
     <circle cx="126" cy="115" r="3"/>
     <circle cx="132" cy="120" r="3"/>
   </g>
 
-  <!-- Zone 2 — collapsed mine area -->
-  <ellipse cx="205" cy="112" rx="22" ry="14" fill="#1a1208" stroke="#c04808" stroke-width="0.8" stroke-dasharray="3,2"/>
+  <!-- Hazard zone 2 -->
+  <ellipse cx="205" cy="112" rx="22" ry="14" fill="#1a1208" stroke="#c04808" stroke-width="0.8" stroke-dasharray="3,2">
+    <animate attributeName="stroke-opacity" values="0.4;0.9;0.4" dur="2.5s" repeatCount="indefinite"/>
+  </ellipse>
   <g fill="#201a10" opacity="0.7">
     <circle cx="196" cy="108" r="3"/>
     <circle cx="207" cy="106" r="3"/>
     <circle cx="215" cy="112" r="3"/>
     <circle cx="200" cy="116" r="3"/>
   </g>
-  <!-- Mine shaft icon in zone 2 -->
   <rect x="200" y="117" width="10" height="6" fill="#0a0808"/>
   <line x1="198" y1="115" x2="212" y2="115" stroke="#2a2014" stroke-width="1.5"/>
 
-  <!-- Zone 3 — pre-boss undead horde -->
-  <ellipse cx="285" cy="115" rx="20" ry="13" fill="#1a1208" stroke="#c04808" stroke-width="0.8" stroke-dasharray="3,2"/>
+  <!-- Hazard zone 3 -->
+  <ellipse cx="285" cy="115" rx="20" ry="13" fill="#1a1208" stroke="#c04808" stroke-width="0.8" stroke-dasharray="3,2">
+    <animate attributeName="stroke-opacity" values="0.6;1;0.6" dur="1.8s" repeatCount="indefinite"/>
+  </ellipse>
   <g fill="#201a10" opacity="0.7">
     <circle cx="276" cy="110" r="3"/>
     <circle cx="283" cy="108" r="3"/>
@@ -60,49 +68,51 @@
     <circle cx="288" cy="119" r="3"/>
   </g>
 
-  <!-- THE ASHWALKER boss marker — far right, ominous column of smoke -->
-  <rect x="342" y="72" width="48" height="68" fill="#120e08" stroke="#3a2808" stroke-width="2"/>
-  <!-- Ashwalker silhouette inside marker -->
-  <!-- Body — elongated smoke form -->
+  <!-- Ashwalker boss marker — threat pulse -->
+  <rect x="342" y="72" width="48" height="68" fill="#120e08" stroke="#3a2808" stroke-width="2">
+    <animate attributeName="stroke-opacity" values="0.5;1;0.5" dur="3s" repeatCount="indefinite"/>
+  </rect>
   <g fill="#1e1610" opacity="0.9">
-    <!-- Lower trunk -->
     <ellipse cx="366" cy="122" rx="12" ry="8"/>
-    <!-- Mid body widening upward -->
     <ellipse cx="366" cy="108" rx="10" ry="10"/>
-    <!-- Upper body -->
     <ellipse cx="366" cy="94" rx="8"  ry="8"/>
-    <!-- Skull-head -->
     <circle  cx="366" cy="82" r="7"/>
-    <!-- Eye sockets -->
     <circle cx="363" cy="80" r="2" fill="#090806"/>
     <circle cx="369" cy="80" r="2" fill="#090806"/>
-    <!-- Arms — wisps -->
     <ellipse cx="352" cy="100" rx="8" ry="3" transform="rotate(-30,352,100)"/>
     <ellipse cx="380" cy="100" rx="8" ry="3" transform="rotate(30,380,100)"/>
   </g>
-  <!-- Ember glow emanating from Ashwalker -->
   <radialGradient id="boss-glow3" cx="50%" cy="50%" r="50%">
-    <stop offset="0%" stop-color="#c04808" stop-opacity="0.3"/>
+    <stop offset="0%" stop-color="#c04808" stop-opacity="0.3">
+      <animate attributeName="stop-opacity" values="0.2;0.5;0.2" dur="3s" repeatCount="indefinite"/>
+    </stop>
     <stop offset="100%" stop-color="#c04808" stop-opacity="0"/>
   </radialGradient>
   <rect x="342" y="72" width="48" height="68" fill="url(#boss-glow3)"/>
   <text x="366" y="148" font-family="monospace" font-size="6" fill="#3a2808" text-anchor="middle">ASHWALKER</text>
 
-  <!-- Route arrows -->
-  <path d="M66,120 Q90,120 105,120" stroke="#204030" stroke-width="1.5" fill="none" stroke-dasharray="5,3"/>
+  <!-- Route arrows — marching ants -->
+  <path d="M66,120 Q90,120 105,120" stroke="#204030" stroke-width="1.5" fill="none" stroke-dasharray="5,3">
+    <animate attributeName="stroke-dashoffset" from="0" to="-16" dur="1.2s" repeatCount="indefinite"/>
+  </path>
   <polygon points="102,117 109,120 102,123" fill="#204030"/>
-  <!-- Through zone 1 -->
-  <path d="M145,120 Q172,116 183,113" stroke="#204030" stroke-width="1.5" fill="none" stroke-dasharray="5,3"/>
+  <path d="M145,120 Q172,116 183,113" stroke="#204030" stroke-width="1.5" fill="none" stroke-dasharray="5,3">
+    <animate attributeName="stroke-dashoffset" from="0" to="-16" dur="1.4s" repeatCount="indefinite"/>
+  </path>
   <polygon points="180,110 187,113 180,116" fill="#204030"/>
-  <!-- Through zone 2 -->
-  <path d="M227,111 Q253,113 265,114" stroke="#204030" stroke-width="1.5" fill="none" stroke-dasharray="5,3"/>
+  <path d="M227,111 Q253,113 265,114" stroke="#204030" stroke-width="1.5" fill="none" stroke-dasharray="5,3">
+    <animate attributeName="stroke-dashoffset" from="0" to="-16" dur="1.3s" repeatCount="indefinite"/>
+  </path>
   <polygon points="262,111 269,114 262,117" fill="#204030"/>
-  <!-- To boss -->
-  <path d="M305,115 Q322,110 342,105" stroke="#3a2808" stroke-width="2" fill="none" stroke-dasharray="5,3"/>
+  <path d="M305,115 Q322,110 342,105" stroke="#3a2808" stroke-width="2" fill="none" stroke-dasharray="5,3">
+    <animate attributeName="stroke-dashoffset" from="0" to="-16" dur="1s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.6;1;0.6" dur="2s" repeatCount="indefinite"/>
+  </path>
   <polygon points="339,102 346,105 339,108" fill="#3a2808"/>
 
-  <!-- Hazard X marks on zones -->
-  <g stroke="#c04808" stroke-width="1" opacity="0.5">
+  <!-- Hazard X marks — flicker -->
+  <g stroke="#c04808" stroke-width="1">
+    <animate attributeName="opacity" values="0.4;0.7;0.4" dur="2s" repeatCount="indefinite"/>
     <line x1="112" y1="112" x2="138" y2="128"/>
     <line x1="138" y1="112" x2="112" y2="128"/>
     <line x1="190" y1="104" x2="220" y2="120"/>
@@ -112,9 +122,13 @@
   </g>
 
   <!-- Objective text -->
-  <text x="200" y="22" font-family="monospace" font-size="8" fill="#3a2808" text-anchor="middle" letter-spacing="2">OBJECTIVE: FIND AND DESTROY THE ASHWALKER</text>
+  <text x="200" y="22" font-family="monospace" font-size="8" fill="#3a2808" text-anchor="middle" letter-spacing="2">OBJECTIVE: FIND AND DESTROY THE ASHWALKER
+    <animate attributeName="opacity" values="0.5;1;0.5" dur="4s" repeatCount="indefinite"/>
+  </text>
   <line x1="50" y1="27" x2="350" y2="27" stroke="#201808" stroke-width="0.8"/>
 
   <!-- Label -->
-  <text x="200" y="232" font-family="monospace" font-size="9" fill="#3a2c1a" text-anchor="middle" letter-spacing="3">YOUR MISSION</text>
+  <text x="200" y="232" font-family="monospace" font-size="9" fill="#3a2c1a" text-anchor="middle" letter-spacing="3">YOUR MISSION
+    <animate attributeName="opacity" values="0.5;1;0.5" dur="5s" repeatCount="indefinite"/>
+  </text>
 </svg>


### PR DESCRIPTION
Adds CSS/SVG animations to all 4 Act 3 (The Ashen Wastes) intro cutscene panels.

- **Panel 1** (The Ashen Wastes): ember glow pulse in mine shafts, falling ash particles, rising smoke columns, pulley wheel rotation, ore bucket sway, slag crack flicker
- **Panel 2** (The Wanderer): walking body-bob, banner sway in ash wind, drifting ash particles, ember glow pulse on horizon
- **Panel 3** (The Ashen Wastes — undead): fire glow pulse, ground crack flicker, undead figures slow sway, ash spirits drift, smoke rising, falling ash
- **Panel 4** (Your Mission): marching-ant route arrows, hazard zone ember border pulse, Ashwalker boss glow pulse, grid scan, objective text fade

Closes #1099

---
_Generated by [Claude Code](https://claude.ai/code/session_01QjAWeyHiDWwKa8oZQFU7yn)_