### PR TITLE
Animate Act 5 intro cutscene panels (#1101)

### DIFF
--- a/web/public/cutscenes/act5-intro-1.svg
+++ b/web/public/cutscenes/act5-intro-1.svg
@@ -9,9 +9,11 @@
   </linearGradient>
   <rect width="400" height="240" fill="url(#ocean-depth)"/>
 
-  <!-- Bioluminescent ambient glow -->
+  <!-- Bioluminescent ambient glow — pulsing -->
   <radialGradient id="bio-glow" cx="50%" cy="60%" r="45%">
-    <stop offset="0%" stop-color="#00a8a8" stop-opacity="0.15"/>
+    <stop offset="0%" stop-color="#00a8a8" stop-opacity="0.15">
+      <animate attributeName="stop-opacity" values="0.15;0.3;0.15" dur="7s" repeatCount="indefinite"/>
+    </stop>
     <stop offset="100%" stop-color="#00a8a8" stop-opacity="0"/>
   </radialGradient>
   <rect width="400" height="240" fill="url(#bio-glow)"/>
@@ -45,13 +47,23 @@
     <path d="M65,128 Q68,113 72,105"/>
     <path d="M85,130 Q88,115 92,105"/>
   </g>
-  <!-- Coral polyps glow -->
-  <g fill="#00c0a0" opacity="0.5">
-    <circle cx="55"  cy="105" r="2"/>
-    <circle cx="72"  cy="105" r="2"/>
-    <circle cx="92"  cy="105" r="2"/>
-    <circle cx="65"  cy="128" r="1.5"/>
-    <circle cx="85"  cy="130" r="1.5"/>
+  <!-- Coral polyps glow — twinkling -->
+  <g fill="#00c0a0">
+    <circle cx="55"  cy="105" r="2" opacity="0.5">
+      <animate attributeName="opacity" values="0.5;1;0.2;0.8;0.5" dur="4s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="72"  cy="105" r="2" opacity="0.5">
+      <animate attributeName="opacity" values="0.5;0.2;1;0.5" dur="5s" begin="1s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="92"  cy="105" r="2" opacity="0.5">
+      <animate attributeName="opacity" values="0.5;1;0.3;0.5" dur="3.5s" begin="0.5s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="65"  cy="128" r="1.5" opacity="0.5">
+      <animate attributeName="opacity" values="0.5;0.9;0.2;0.5" dur="6s" begin="2s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="85"  cy="130" r="1.5" opacity="0.5">
+      <animate attributeName="opacity" values="0.5;0.2;0.8;0.5" dur="4.5s" begin="1.5s" repeatCount="indefinite"/>
+    </circle>
   </g>
 
   <!-- Coral formations — right cluster -->
@@ -63,12 +75,22 @@
     <path d="M304,118 Q307,102 312,90"/>
     <path d="M328,120 Q332,104 337,90"/>
   </g>
-  <g fill="#00c0a0" opacity="0.5">
-    <circle cx="295" cy="90"  r="2"/>
-    <circle cx="312" cy="90"  r="2"/>
-    <circle cx="337" cy="90"  r="2"/>
-    <circle cx="304" cy="118" r="1.5"/>
-    <circle cx="328" cy="120" r="1.5"/>
+  <g fill="#00c0a0">
+    <circle cx="295" cy="90"  r="2" opacity="0.5">
+      <animate attributeName="opacity" values="0.5;0.2;1;0.5" dur="4s" begin="0.8s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="312" cy="90"  r="2" opacity="0.5">
+      <animate attributeName="opacity" values="0.5;1;0.3;0.5" dur="5.5s" begin="2.2s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="337" cy="90"  r="2" opacity="0.5">
+      <animate attributeName="opacity" values="0.5;0.8;0.2;0.5" dur="3.8s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="304" cy="118" r="1.5" opacity="0.5">
+      <animate attributeName="opacity" values="0.5;0.2;0.9;0.5" dur="6s" begin="3s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="328" cy="120" r="1.5" opacity="0.5">
+      <animate attributeName="opacity" values="0.5;1;0.2;0.5" dur="4.5s" begin="1s" repeatCount="indefinite"/>
+    </circle>
   </g>
 
   <!-- Brain coral right -->
@@ -88,11 +110,14 @@
     <line x1="138" y1="163" x2="290" y2="152"/>
     <line x1="136" y1="171" x2="290" y2="162"/>
   </g>
-  <!-- Mast — broken, listing -->
-  <line x1="200" y1="130" x2="196" y2="50" stroke="#162030" stroke-width="4" transform="rotate(-8,200,130)"/>
-  <line x1="196" y1="75"  x2="230" y2="95" stroke="#162030" stroke-width="2.5" transform="rotate(-8,200,130)"/>
-  <!-- Torn sail remnant -->
-  <polygon points="196,55 225,72 210,90 196,80" fill="#0e1828" stroke="#182838" stroke-width="0.8" opacity="0.7" transform="rotate(-8,200,130)"/>
+  <!-- Mast — broken, listing, gentle sway -->
+  <g>
+    <animateTransform attributeName="transform" type="rotate" values="-8 200 130; -6 200 130; -8 200 130; -10 200 130; -8 200 130" dur="14s" repeatCount="indefinite"/>
+    <line x1="200" y1="130" x2="196" y2="50" stroke="#162030" stroke-width="4"/>
+    <line x1="196" y1="75"  x2="230" y2="95" stroke="#162030" stroke-width="2.5"/>
+    <!-- Torn sail remnant -->
+    <polygon points="196,55 225,72 210,90 196,80" fill="#0e1828" stroke="#182838" stroke-width="0.8" opacity="0.7"/>
+  </g>
   <!-- Coral growth on ship -->
   <g fill="#3a1808" stroke="#5a2810" stroke-width="0.5">
     <ellipse cx="155" cy="175" rx="8" ry="5"/>
@@ -100,10 +125,11 @@
     <ellipse cx="210" cy="170" rx="9" ry="5"/>
   </g>
 
-  <!-- Half-submerged section — water surface line (the shard is half above) -->
+  <!-- Half-submerged section — water surface line -->
   <rect x="0" y="0" width="400" height="50" fill="#060e14" opacity="0.7"/>
-  <!-- Water surface shimmer -->
-  <g stroke="#1a3040" stroke-width="1" opacity="0.6">
+  <!-- Water surface shimmer — pulsing -->
+  <g stroke="#1a3040" stroke-width="1">
+    <animate attributeName="opacity" values="0.6;1;0.6" dur="5s" repeatCount="indefinite"/>
     <path d="M0,48 Q30,44 60,48 Q90,52 120,48 Q150,44 180,48 Q210,52 240,48 Q270,44 300,48 Q330,52 360,48 Q390,44 400,48"/>
   </g>
   <!-- Surface light ripples -->
@@ -112,28 +138,70 @@
     <path d="M0,54 Q50,50 100,54 Q150,58 200,54 Q250,50 300,54 Q350,58 400,54"/>
   </g>
 
-  <!-- Bioluminescent particles drifting in water -->
+  <!-- Bioluminescent particles drifting upward in water -->
   <g fill="#00d0b0" opacity="0.4">
-    <circle cx="50"  cy="80"  r="1.5"/>
-    <circle cx="100" cy="65"  r="1"/>
-    <circle cx="160" cy="95"  r="1.5"/>
-    <circle cx="240" cy="70"  r="1"/>
-    <circle cx="300" cy="85"  r="1.5"/>
-    <circle cx="360" cy="60"  r="1"/>
-    <circle cx="30"  cy="120" r="1.5"/>
-    <circle cx="130" cy="110" r="1"/>
-    <circle cx="270" cy="115" r="1.5"/>
-    <circle cx="380" cy="100" r="1"/>
-    <circle cx="70"  cy="145" r="1"/>
-    <circle cx="340" cy="140" r="1.5"/>
+    <circle cx="50"  cy="80"  r="1.5">
+      <animateTransform attributeName="transform" type="translate" values="0 0; -2 -30; -2 -60" dur="12s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.4;0.4;0" dur="12s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="100" cy="65"  r="1">
+      <animateTransform attributeName="transform" type="translate" values="0 0; 2 -40; 2 -80" dur="14s" begin="3s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.4;0.4;0" dur="14s" begin="3s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="160" cy="95"  r="1.5">
+      <animateTransform attributeName="transform" type="translate" values="0 0; -3 -35; -3 -70" dur="13s" begin="1s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.4;0.4;0" dur="13s" begin="1s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="240" cy="70"  r="1">
+      <animateTransform attributeName="transform" type="translate" values="0 0; 2 -25; 2 -50" dur="11s" begin="5s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.4;0.4;0" dur="11s" begin="5s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="300" cy="85"  r="1.5">
+      <animateTransform attributeName="transform" type="translate" values="0 0; -2 -30; -2 -60" dur="12s" begin="2s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.4;0.4;0" dur="12s" begin="2s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="360" cy="60"  r="1">
+      <animateTransform attributeName="transform" type="translate" values="0 0; 3 -20; 3 -40" dur="10s" begin="4s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.4;0.4;0" dur="10s" begin="4s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="30"  cy="120" r="1.5">
+      <animateTransform attributeName="transform" type="translate" values="0 0; -2 -40; -2 -80" dur="15s" begin="6s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.4;0.4;0" dur="15s" begin="6s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="130" cy="110" r="1">
+      <animateTransform attributeName="transform" type="translate" values="0 0; 2 -35; 2 -70" dur="13s" begin="7s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.4;0.4;0" dur="13s" begin="7s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="270" cy="115" r="1.5">
+      <animateTransform attributeName="transform" type="translate" values="0 0; -3 -30; -3 -60" dur="14s" begin="8s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.4;0.4;0" dur="14s" begin="8s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="380" cy="100" r="1">
+      <animateTransform attributeName="transform" type="translate" values="0 0; 2 -25; 2 -50" dur="12s" begin="9s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.4;0.4;0" dur="12s" begin="9s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="70"  cy="145" r="1">
+      <animateTransform attributeName="transform" type="translate" values="0 0; -2 -50; -2 -100" dur="18s" begin="10s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.4;0.4;0" dur="18s" begin="10s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="340" cy="140" r="1.5">
+      <animateTransform attributeName="transform" type="translate" values="0 0; 3 -45; 3 -90" dur="16s" begin="11s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.4;0.4;0" dur="16s" begin="11s" repeatCount="indefinite"/>
+    </circle>
   </g>
 
-  <!-- Ley line threads — faintly visible in the water -->
-  <g stroke="#00a8a8" stroke-width="0.8" fill="none" opacity="0.2">
-    <path d="M0,120 Q100,108 200,115 Q300,122 400,110"/>
-    <path d="M0,150 Q80,138 160,145 Q240,152 400,140"/>
+  <!-- Ley line threads — animated flow -->
+  <g fill="none" opacity="0.2">
+    <path d="M0,120 Q100,108 200,115 Q300,122 400,110" stroke="#00a8a8" stroke-width="0.8" stroke-dasharray="8,4">
+      <animate attributeName="stroke-dashoffset" from="0" to="-24" dur="3s" repeatCount="indefinite"/>
+    </path>
+    <path d="M0,150 Q80,138 160,145 Q240,152 400,140" stroke="#00a8a8" stroke-width="0.8" stroke-dasharray="8,4">
+      <animate attributeName="stroke-dashoffset" from="0" to="-24" dur="3.5s" repeatCount="indefinite"/>
+    </path>
   </g>
 
   <!-- Label -->
-  <text x="200" y="228" font-family="monospace" font-size="9" fill="#1a4040" text-anchor="middle" letter-spacing="3">THE SUNKEN REEF</text>
+  <text x="200" y="228" font-family="monospace" font-size="9" fill="#1a4040" text-anchor="middle" letter-spacing="3">THE SUNKEN REEF
+    <animate attributeName="opacity" values="0.7;1;0.7" dur="8s" repeatCount="indefinite"/>
+  </text>
 </svg>

--- a/web/public/cutscenes/act5-intro-2.svg
+++ b/web/public/cutscenes/act5-intro-2.svg
@@ -7,10 +7,14 @@
   </linearGradient>
   <rect width="400" height="240" fill="url(#sov-bg)"/>
 
-  <!-- Sovereign's presence — cold deep-water glow -->
+  <!-- Sovereign's presence — cold deep-water glow — pulsing -->
   <radialGradient id="sov-glow" cx="50%" cy="45%" r="45%">
-    <stop offset="0%" stop-color="#0080a0" stop-opacity="0.3"/>
-    <stop offset="60%" stop-color="#004060" stop-opacity="0.15"/>
+    <stop offset="0%" stop-color="#0080a0" stop-opacity="0.3">
+      <animate attributeName="stop-opacity" values="0.3;0.6;0.3" dur="6s" repeatCount="indefinite"/>
+    </stop>
+    <stop offset="60%" stop-color="#004060" stop-opacity="0.15">
+      <animate attributeName="stop-opacity" values="0.15;0.3;0.15" dur="6s" repeatCount="indefinite"/>
+    </stop>
     <stop offset="100%" stop-color="#04080e" stop-opacity="0"/>
   </radialGradient>
   <rect width="400" height="240" fill="url(#sov-glow)"/>
@@ -19,110 +23,168 @@
   <rect x="0" y="195" width="400" height="45" fill="#060e10"/>
   <rect x="0" y="192" width="400" height="5"  fill="#0a1618"/>
 
-  <!-- THE TIDAL SOVEREIGN — massive, looming figure made of water, coral, memory -->
-  <!-- Lower body — wave base, crashing water form -->
-  <g fill="#0a2030" opacity="0.9">
-    <ellipse cx="200" cy="192" rx="80" ry="18"/>
-    <ellipse cx="200" cy="182" rx="65" ry="20"/>
-  </g>
-  <!-- Wave foam at base -->
-  <g fill="#1a3848" opacity="0.5">
-    <ellipse cx="140" cy="188" rx="20" ry="6"/>
-    <ellipse cx="200" cy="190" rx="30" ry="7"/>
-    <ellipse cx="260" cy="188" rx="20" ry="6"/>
+  <!-- THE TIDAL SOVEREIGN — massive, looming figure, slow sway -->
+  <g>
+    <animateTransform attributeName="transform" type="translate" values="0 0; 2 0; 0 0; -2 0; 0 0" dur="10s" repeatCount="indefinite"/>
+
+    <!-- Lower body — wave base -->
+    <g fill="#0a2030" opacity="0.9">
+      <ellipse cx="200" cy="192" rx="80" ry="18"/>
+      <ellipse cx="200" cy="182" rx="65" ry="20"/>
+    </g>
+    <!-- Wave foam at base -->
+    <g fill="#1a3848" opacity="0.5">
+      <ellipse cx="140" cy="188" rx="20" ry="6"/>
+      <ellipse cx="200" cy="190" rx="30" ry="7"/>
+      <ellipse cx="260" cy="188" rx="20" ry="6"/>
+    </g>
+
+    <!-- Body trunk — compressed water column -->
+    <g fill="#0c2838" opacity="0.85">
+      <polygon points="165,80 235,80 245,182 155,182"/>
+    </g>
+    <!-- Body striations -->
+    <g stroke="#1a4050" stroke-width="1" opacity="0.5">
+      <line x1="162" y1="100" x2="238" y2="100"/>
+      <line x1="160" y1="120" x2="240" y2="120"/>
+      <line x1="158" y1="140" x2="242" y2="140"/>
+      <line x1="156" y1="160" x2="244" y2="160"/>
+    </g>
+    <!-- Body outer edge glow -->
+    <polygon points="165,80 235,80 245,182 155,182" fill="none" stroke="#00a0b8" stroke-width="1.5" opacity="0.4"/>
+
+    <!-- Arms — massive sweeping water tendrils -->
+    <!-- Left arm -->
+    <g fill="#0a2030" opacity="0.8">
+      <path d="M165,120 Q130,110 95,90 Q65,72 40,58"/>
+      <path d="M165,130 Q132,122 100,104 Q72,88 48,76"/>
+    </g>
+    <path d="M165,125 Q130,116 95,97 Q65,80 40,67" stroke="#1a4050" stroke-width="3" fill="none"/>
+
+    <!-- Right arm -->
+    <g fill="#0a2030" opacity="0.8">
+      <path d="M235,115 Q270,100 305,78 Q332,60 355,45"/>
+      <path d="M235,125 Q268,112 302,92 Q330,76 352,62"/>
+    </g>
+    <path d="M235,120 Q268,106 303,85 Q331,68 354,53" stroke="#1a4050" stroke-width="3" fill="none"/>
+
+    <!-- Head — ancient face -->
+    <ellipse cx="200" cy="62" rx="36" ry="28" fill="#0e2838" stroke="#1a4050" stroke-width="1.5"/>
+    <!-- Coral growths on head -->
+    <g stroke="#4a1808" stroke-width="2" fill="none" opacity="0.7">
+      <path d="M182,40 Q178,30 175,22"/>
+      <path d="M175,22 Q168,14 165,8"/>
+      <path d="M175,22 Q180,14 183,8"/>
+      <path d="M200,38 Q198,28 198,18"/>
+      <path d="M218,40 Q222,30 225,22"/>
+      <path d="M225,22 Q220,14 218,8"/>
+      <path d="M225,22 Q232,14 235,8"/>
+    </g>
+
+    <!-- Mouth -->
+    <path d="M183,74 Q200,80 217,74" stroke="#1a4050" stroke-width="2" fill="none" opacity="0.6"/>
   </g>
 
-  <!-- Body trunk — compressed water column -->
-  <g fill="#0c2838" opacity="0.85">
-    <polygon points="165,80 235,80 245,182 155,182"/>
+  <!-- Coral polyp glows on head — twinkling (outside sway group for independent timing) -->
+  <g fill="#00c090">
+    <circle cx="165" cy="8"  r="2" opacity="0.6">
+      <animate attributeName="opacity" values="0.6;1;0.2;0.8;0.6" dur="4s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="183" cy="8"  r="2" opacity="0.6">
+      <animate attributeName="opacity" values="0.6;0.2;1;0.6" dur="5s" begin="1s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="198" cy="18" r="2" opacity="0.6">
+      <animate attributeName="opacity" values="0.6;1;0.3;0.6" dur="3.5s" begin="0.5s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="218" cy="8"  r="2" opacity="0.6">
+      <animate attributeName="opacity" values="0.6;0.3;1;0.6" dur="6s" begin="2s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="235" cy="8"  r="2" opacity="0.6">
+      <animate attributeName="opacity" values="0.6;1;0.2;0.6" dur="4.5s" begin="1.5s" repeatCount="indefinite"/>
+    </circle>
   </g>
-  <!-- Body striations — layers of compressed sea memory -->
-  <g stroke="#1a4050" stroke-width="1" opacity="0.5">
-    <line x1="162" y1="100" x2="238" y2="100"/>
-    <line x1="160" y1="120" x2="240" y2="120"/>
-    <line x1="158" y1="140" x2="242" y2="140"/>
-    <line x1="156" y1="160" x2="244" y2="160"/>
-  </g>
-  <!-- Body outer edge glow -->
-  <polygon points="165,80 235,80 245,182 155,182" fill="none" stroke="#00a0b8" stroke-width="1.5" opacity="0.4"/>
 
-  <!-- Arms — massive sweeping water tendrils -->
-  <!-- Left arm — reaching out -->
-  <g fill="#0a2030" opacity="0.8">
-    <path d="M165,120 Q130,110 95,90 Q65,72 40,58"/>
-    <path d="M165,130 Q132,122 100,104 Q72,88 48,76"/>
-  </g>
-  <path d="M165,125 Q130,116 95,97 Q65,80 40,67" stroke="#1a4050" stroke-width="3" fill="none"/>
-  <!-- Tendril tip glow -->
+  <!-- Eyes — pulsing cold light -->
+  <circle cx="188" cy="60" r="7" fill="#04101a"/>
+  <circle cx="212" cy="60" r="7" fill="#04101a"/>
+  <circle cx="188" cy="60" r="4" fill="#0090b0" opacity="0.8">
+    <animate attributeName="opacity" values="0.8;0.3;0.8" dur="3s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="212" cy="60" r="4" fill="#0090b0" opacity="0.8">
+    <animate attributeName="opacity" values="0.8;0.3;0.8" dur="3s" begin="0.5s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="188" cy="60" r="2" fill="#00d0e8" opacity="0.9">
+    <animate attributeName="r" values="2;3;2" dur="3s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0.4;0.9" dur="3s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="212" cy="60" r="2" fill="#00d0e8" opacity="0.9">
+    <animate attributeName="r" values="2;3;2" dur="3s" begin="0.5s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0.4;0.9" dur="3s" begin="0.5s" repeatCount="indefinite"/>
+  </circle>
+
+  <!-- Tendril tip glow — pulsing -->
   <radialGradient id="tendril-l" cx="50%" cy="50%" r="50%">
-    <stop offset="0%" stop-color="#00c0d0" stop-opacity="0.6"/>
+    <stop offset="0%" stop-color="#00c0d0" stop-opacity="0.6">
+      <animate attributeName="stop-opacity" values="0.6;1;0.3;0.6" dur="5s" repeatCount="indefinite"/>
+    </stop>
     <stop offset="100%" stop-color="#00c0d0" stop-opacity="0"/>
   </radialGradient>
   <ellipse cx="40" cy="67" rx="12" ry="8" fill="url(#tendril-l)"/>
 
-  <!-- Right arm — raised, threatening -->
-  <g fill="#0a2030" opacity="0.8">
-    <path d="M235,115 Q270,100 305,78 Q332,60 355,45"/>
-    <path d="M235,125 Q268,112 302,92 Q330,76 352,62"/>
-  </g>
-  <path d="M235,120 Q268,106 303,85 Q331,68 354,53" stroke="#1a4050" stroke-width="3" fill="none"/>
   <radialGradient id="tendril-r" cx="50%" cy="50%" r="50%">
-    <stop offset="0%" stop-color="#00c0d0" stop-opacity="0.6"/>
+    <stop offset="0%" stop-color="#00c0d0" stop-opacity="0.6">
+      <animate attributeName="stop-opacity" values="0.6;0.3;1;0.6" dur="5s" begin="2s" repeatCount="indefinite"/>
+    </stop>
     <stop offset="100%" stop-color="#00c0d0" stop-opacity="0"/>
   </radialGradient>
   <ellipse cx="354" cy="53" rx="12" ry="8" fill="url(#tendril-r)"/>
 
-  <!-- Head — a compressed mass of coral and water, ancient face -->
-  <ellipse cx="200" cy="62" rx="36" ry="28" fill="#0e2838" stroke="#1a4050" stroke-width="1.5"/>
-  <!-- Coral growths on head -->
-  <g stroke="#4a1808" stroke-width="2" fill="none" opacity="0.7">
-    <path d="M182,40 Q178,30 175,22"/>
-    <path d="M175,22 Q168,14 165,8"/>
-    <path d="M175,22 Q180,14 183,8"/>
-    <path d="M200,38 Q198,28 198,18"/>
-    <path d="M218,40 Q222,30 225,22"/>
-    <path d="M225,22 Q220,14 218,8"/>
-    <path d="M225,22 Q232,14 235,8"/>
-  </g>
-  <!-- Coral polyp glows on head -->
-  <g fill="#00c090" opacity="0.6">
-    <circle cx="165" cy="8"  r="2"/>
-    <circle cx="183" cy="8"  r="2"/>
-    <circle cx="198" cy="18" r="2"/>
-    <circle cx="218" cy="8"  r="2"/>
-    <circle cx="235" cy="8"  r="2"/>
+  <!-- Water particles swirling — drifting -->
+  <g fill="#00c0c8">
+    <circle cx="100" cy="105" r="2" opacity="0.3">
+      <animateTransform attributeName="transform" type="translate" values="0 0; -5 -10; 0 0; 5 10; 0 0" dur="8s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="80"  cy="140" r="1.5" opacity="0.3">
+      <animateTransform attributeName="transform" type="translate" values="0 0; 4 -8; 0 0; -4 8; 0 0" dur="9s" begin="2s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="60"  cy="170" r="2" opacity="0.3">
+      <animateTransform attributeName="transform" type="translate" values="0 0; -3 -6; 0 0; 3 6; 0 0" dur="7s" begin="1s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="310" cy="100" r="2" opacity="0.3">
+      <animateTransform attributeName="transform" type="translate" values="0 0; 5 -10; 0 0; -5 10; 0 0" dur="8s" begin="3s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="330" cy="135" r="1.5" opacity="0.3">
+      <animateTransform attributeName="transform" type="translate" values="0 0; -4 -8; 0 0; 4 8; 0 0" dur="10s" begin="4s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="350" cy="165" r="2" opacity="0.3">
+      <animateTransform attributeName="transform" type="translate" values="0 0; 3 -5; 0 0; -3 5; 0 0" dur="6s" begin="2s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="130" cy="60"  r="1.5" opacity="0.3">
+      <animateTransform attributeName="transform" type="translate" values="0 0; -4 -6; 0 0; 4 6; 0 0" dur="9s" begin="5s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="270" cy="55"  r="1.5" opacity="0.3">
+      <animateTransform attributeName="transform" type="translate" values="0 0; 4 -5; 0 0; -4 5; 0 0" dur="7s" begin="1s" repeatCount="indefinite"/>
+    </circle>
   </g>
 
-  <!-- Eyes — two cold, deep-ocean lights -->
-  <circle cx="188" cy="60" r="7" fill="#04101a"/>
-  <circle cx="212" cy="60" r="7" fill="#04101a"/>
-  <circle cx="188" cy="60" r="4" fill="#0090b0" opacity="0.8"/>
-  <circle cx="212" cy="60" r="4" fill="#0090b0" opacity="0.8"/>
-  <circle cx="188" cy="60" r="2" fill="#00d0e8" opacity="0.9"/>
-  <circle cx="212" cy="60" r="2" fill="#00d0e8" opacity="0.9"/>
-
-  <!-- "Mouth" — a slow grinding current -->
-  <path d="M183,74 Q200,80 217,74" stroke="#1a4050" stroke-width="2" fill="none" opacity="0.6"/>
-
-  <!-- Water particles swirling around the Sovereign -->
-  <g fill="#00c0c8" opacity="0.3">
-    <circle cx="100" cy="105" r="2"/>
-    <circle cx="80"  cy="140" r="1.5"/>
-    <circle cx="60"  cy="170" r="2"/>
-    <circle cx="310" cy="100" r="2"/>
-    <circle cx="330" cy="135" r="1.5"/>
-    <circle cx="350" cy="165" r="2"/>
-    <circle cx="130" cy="60"  r="1.5"/>
-    <circle cx="270" cy="55"  r="1.5"/>
-  </g>
-  <!-- Orbiting water droplets -->
-  <g fill="#1a4060" opacity="0.5">
-    <circle cx="150" cy="95" r="3"/>
-    <circle cx="255" cy="92" r="3"/>
-    <circle cx="125" cy="145" r="2.5"/>
-    <circle cx="278" cy="140" r="2.5"/>
+  <!-- Orbiting water droplets — slow circular drift -->
+  <g fill="#1a4060">
+    <circle cx="150" cy="95" r="3" opacity="0.5">
+      <animateTransform attributeName="transform" type="translate" values="0 0; -8 -4; -4 -8; 4 -8; 8 4; 4 8; -4 8; -8 4; 0 0" dur="18s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="255" cy="92" r="3" opacity="0.5">
+      <animateTransform attributeName="transform" type="translate" values="0 0; 8 4; 4 8; -4 8; -8 -4; -4 -8; 4 -8; 8 -4; 0 0" dur="18s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="125" cy="145" r="2.5" opacity="0.5">
+      <animateTransform attributeName="transform" type="translate" values="0 0; -6 -3; 0 0; 6 3; 0 0" dur="12s" begin="3s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="278" cy="140" r="2.5" opacity="0.5">
+      <animateTransform attributeName="transform" type="translate" values="0 0; 6 -3; 0 0; -6 3; 0 0" dur="12s" begin="6s" repeatCount="indefinite"/>
+    </circle>
   </g>
 
   <!-- Label -->
-  <text x="200" y="228" font-family="monospace" font-size="9" fill="#1a4040" text-anchor="middle" letter-spacing="3">THE TIDAL SOVEREIGN</text>
+  <text x="200" y="228" font-family="monospace" font-size="9" fill="#1a4040" text-anchor="middle" letter-spacing="3">THE TIDAL SOVEREIGN
+    <animate attributeName="opacity" values="0.7;1;0.7" dur="8s" repeatCount="indefinite"/>
+  </text>
 </svg>

--- a/web/public/cutscenes/act5-intro-3.svg
+++ b/web/public/cutscenes/act5-intro-3.svg
@@ -7,9 +7,11 @@
   </linearGradient>
   <rect width="400" height="240" fill="url(#ley-bg)"/>
 
-  <!-- Ley line central glow -->
+  <!-- Ley line central glow — pulsing -->
   <radialGradient id="ley-glow" cx="50%" cy="50%" r="50%">
-    <stop offset="0%" stop-color="#00a8c0" stop-opacity="0.25"/>
+    <stop offset="0%" stop-color="#00a8c0" stop-opacity="0.25">
+      <animate attributeName="stop-opacity" values="0.25;0.5;0.25" dur="6s" repeatCount="indefinite"/>
+    </stop>
     <stop offset="100%" stop-color="#00a8c0" stop-opacity="0"/>
   </radialGradient>
   <rect width="400" height="240" fill="url(#ley-glow)"/>
@@ -25,7 +27,7 @@
   <rect x="80"  y="80" width="20" height="115" fill="#0e1e18" stroke="#182e28" stroke-width="1"/>
   <!-- Right pillar -->
   <rect x="300" y="80" width="20" height="115" fill="#0e1e18" stroke="#182e28" stroke-width="1"/>
-  <!-- Arch spanning pillars — carved stone, coral-encrusted -->
+  <!-- Arch spanning pillars -->
   <path d="M80,80 Q200,20 320,80" stroke="#182e28" stroke-width="12" fill="none"/>
   <path d="M80,80 Q200,20 320,80" stroke="#0e1e18" stroke-width="8"  fill="none"/>
   <!-- Coral on arch -->
@@ -36,33 +38,64 @@
     <path d="M240,42 Q242,32 244,24"/>
     <path d="M280,62 Q282,52 284,44"/>
   </g>
-  <g fill="#00c090" opacity="0.5">
-    <circle cx="116" cy="44" r="2"/>
-    <circle cx="156" cy="24" r="2"/>
-    <circle cx="200" cy="12" r="2.5"/>
-    <circle cx="244" cy="24" r="2"/>
-    <circle cx="284" cy="44" r="2"/>
+  <!-- Coral polyp tips — twinkling -->
+  <g fill="#00c090">
+    <circle cx="116" cy="44" r="2" opacity="0.5">
+      <animate attributeName="opacity" values="0.5;1;0.2;0.8;0.5" dur="5s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="156" cy="24" r="2" opacity="0.5">
+      <animate attributeName="opacity" values="0.5;0.2;1;0.5" dur="4s" begin="1s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="200" cy="12" r="2.5" opacity="0.5">
+      <animate attributeName="opacity" values="0.5;1;0.3;0.5" dur="6s" begin="2s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="244" cy="24" r="2" opacity="0.5">
+      <animate attributeName="opacity" values="0.5;0.3;0.9;0.5" dur="4.5s" begin="0.5s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="284" cy="44" r="2" opacity="0.5">
+      <animate attributeName="opacity" values="0.5;1;0.2;0.5" dur="5.5s" begin="1.5s" repeatCount="indefinite"/>
+    </circle>
   </g>
   <!-- Arch keystone -->
   <polygon points="190,28 210,28 214,42 186,42" fill="#0e1e18" stroke="#182e28" stroke-width="1"/>
-  <!-- Glowing rune on keystone -->
-  <text x="200" y="39" font-family="monospace" font-size="8" fill="#00a8c0" text-anchor="middle" opacity="0.7">◈</text>
+  <!-- Glowing rune on keystone — pulsing -->
+  <text x="200" y="39" font-family="monospace" font-size="8" fill="#00a8c0" text-anchor="middle" opacity="0.7">◈
+    <animate attributeName="opacity" values="0.7;1;0.3;0.7" dur="4s" repeatCount="indefinite"/>
+  </text>
 
-  <!-- LEY LINES — glowing threads running through the arch -->
-  <!-- Primary ley line — strong, central -->
-  <path d="M0,118 Q100,110 200,115 Q300,120 400,112" stroke="#00c0d0" stroke-width="2" fill="none" opacity="0.7"/>
+  <!-- LEY LINES — animated flow -->
+  <!-- Primary ley line -->
+  <path d="M0,118 Q100,110 200,115 Q300,120 400,112" stroke="#00c0d0" stroke-width="2" fill="none" opacity="0.7" stroke-dasharray="12,6">
+    <animate attributeName="stroke-dashoffset" from="0" to="-36" dur="2s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.7;1;0.7" dur="5s" repeatCount="indefinite"/>
+  </path>
   <!-- Glow around primary ley line -->
-  <path d="M0,118 Q100,110 200,115 Q300,120 400,112" stroke="#00c0d0" stroke-width="8" fill="none" opacity="0.1"/>
-  <!-- Secondary ley lines — fainter, weaving -->
-  <path d="M0,100 Q80,92 160,98 Q240,104 320,96 Q370,92 400,98"  stroke="#0090a8" stroke-width="1" fill="none" opacity="0.4"/>
-  <path d="M0,132 Q90,125 180,130 Q270,135 360,128 Q390,126 400,128" stroke="#0090a8" stroke-width="1" fill="none" opacity="0.4"/>
-  <path d="M0,88  Q120,78 200,84  Q280,90 400,82"  stroke="#006880" stroke-width="0.8" fill="none" opacity="0.25"/>
-  <path d="M0,148 Q100,140 200,144 Q300,148 400,142" stroke="#006880" stroke-width="0.8" fill="none" opacity="0.25"/>
+  <path d="M0,118 Q100,110 200,115 Q300,120 400,112" stroke="#00c0d0" stroke-width="8" fill="none" opacity="0.1">
+    <animate attributeName="opacity" values="0.1;0.2;0.1" dur="5s" repeatCount="indefinite"/>
+  </path>
+  <!-- Secondary ley lines — animated flow, fainter -->
+  <path d="M0,100 Q80,92 160,98 Q240,104 320,96 Q370,92 400,98" stroke="#0090a8" stroke-width="1" fill="none" opacity="0.4" stroke-dasharray="8,4">
+    <animate attributeName="stroke-dashoffset" from="0" to="-24" dur="2.5s" repeatCount="indefinite"/>
+  </path>
+  <path d="M0,132 Q90,125 180,130 Q270,135 360,128 Q390,126 400,128" stroke="#0090a8" stroke-width="1" fill="none" opacity="0.4" stroke-dasharray="8,4">
+    <animate attributeName="stroke-dashoffset" from="0" to="-24" dur="2.5s" repeatCount="indefinite"/>
+  </path>
+  <path d="M0,88  Q120,78 200,84  Q280,90 400,82" stroke="#006880" stroke-width="0.8" fill="none" opacity="0.25" stroke-dasharray="6,4">
+    <animate attributeName="stroke-dashoffset" from="0" to="-20" dur="3s" repeatCount="indefinite"/>
+  </path>
+  <path d="M0,148 Q100,140 200,144 Q300,148 400,142" stroke="#006880" stroke-width="0.8" fill="none" opacity="0.25" stroke-dasharray="6,4">
+    <animate attributeName="stroke-dashoffset" from="0" to="-20" dur="3s" repeatCount="indefinite"/>
+  </path>
 
-  <!-- Ley node — intersection point at centre of arch -->
-  <circle cx="200" cy="115" r="12" fill="#041018" stroke="#00c0d0" stroke-width="1.5" opacity="0.8"/>
+  <!-- Ley node — intersection point — pulsing -->
+  <circle cx="200" cy="115" r="12" fill="#041018" stroke="#00c0d0" stroke-width="1.5" opacity="0.8">
+    <animate attributeName="stroke-opacity" values="0.8;0.3;0.8" dur="4s" repeatCount="indefinite"/>
+  </circle>
   <circle cx="200" cy="115" r="7"  fill="#061420" stroke="#00a8c0" stroke-width="1"/>
-  <circle cx="200" cy="115" r="3"  fill="#00d0e0" opacity="0.9"/>
+  <circle cx="200" cy="115" r="3"  fill="#00d0e0" opacity="0.9">
+    <animate attributeName="r" values="3;5;3" dur="4s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0.4;0.9" dur="4s" repeatCount="indefinite"/>
+  </circle>
   <!-- Node spokes -->
   <g stroke="#00a0b8" stroke-width="0.8" opacity="0.5">
     <line x1="200" y1="103" x2="200" y2="115"/>
@@ -72,36 +105,72 @@
     <line x1="208" y1="107" x2="192" y2="123"/>
   </g>
 
-  <!-- Ancient marker stones flanking the passage — engraved with ley symbols -->
+  <!-- Ancient marker stones — rune text fading -->
   <!-- Left markers -->
   <rect x="55"  y="158" width="16" height="35" fill="#0a1818" stroke="#162828" stroke-width="1"/>
-  <text x="63"  y="175" font-family="monospace" font-size="7" fill="#1a4040" text-anchor="middle" opacity="0.6">◇</text>
-  <text x="63"  y="186" font-family="monospace" font-size="7" fill="#1a4040" text-anchor="middle" opacity="0.6">◆</text>
+  <text x="63"  y="175" font-family="monospace" font-size="7" fill="#1a4040" text-anchor="middle" opacity="0.6">◇
+    <animate attributeName="opacity" values="0.6;1;0.2;0.6" dur="7s" repeatCount="indefinite"/>
+  </text>
+  <text x="63"  y="186" font-family="monospace" font-size="7" fill="#1a4040" text-anchor="middle" opacity="0.6">◆
+    <animate attributeName="opacity" values="0.6;0.2;1;0.6" dur="9s" begin="2s" repeatCount="indefinite"/>
+  </text>
   <!-- Right markers -->
   <rect x="329" y="158" width="16" height="35" fill="#0a1818" stroke="#162828" stroke-width="1"/>
-  <text x="337" y="175" font-family="monospace" font-size="7" fill="#1a4040" text-anchor="middle" opacity="0.6">◇</text>
-  <text x="337" y="186" font-family="monospace" font-size="7" fill="#1a4040" text-anchor="middle" opacity="0.6">◆</text>
+  <text x="337" y="175" font-family="monospace" font-size="7" fill="#1a4040" text-anchor="middle" opacity="0.6">◇
+    <animate attributeName="opacity" values="0.6;0.2;0.9;0.6" dur="8s" begin="1s" repeatCount="indefinite"/>
+  </text>
+  <text x="337" y="186" font-family="monospace" font-size="7" fill="#1a4040" text-anchor="middle" opacity="0.6">◆
+    <animate attributeName="opacity" values="0.6;1;0.2;0.6" dur="6s" begin="3s" repeatCount="indefinite"/>
+  </text>
 
-  <!-- Beyond the arch — the passage tunnel, dim but beckoning -->
+  <!-- Beyond the arch — passage tunnel — glow pulse -->
   <ellipse cx="200" cy="155" rx="35" ry="30" fill="#030810" stroke="#0a1820" stroke-width="1" opacity="0.8"/>
   <radialGradient id="tunnel-light" cx="50%" cy="50%" r="50%">
-    <stop offset="0%" stop-color="#00a0b0" stop-opacity="0.2"/>
+    <stop offset="0%" stop-color="#00a0b0" stop-opacity="0.2">
+      <animate attributeName="stop-opacity" values="0.2;0.5;0.2" dur="5s" repeatCount="indefinite"/>
+    </stop>
     <stop offset="100%" stop-color="#00a0b0" stop-opacity="0"/>
   </radialGradient>
   <ellipse cx="200" cy="155" rx="35" ry="30" fill="url(#tunnel-light)"/>
 
   <!-- Bioluminescent particles drifting through the arch -->
-  <g fill="#00d0b0" opacity="0.35">
-    <circle cx="150" cy="95"  r="1.5"/>
-    <circle cx="175" cy="108" r="1"/>
-    <circle cx="225" cy="105" r="1.5"/>
-    <circle cx="250" cy="92"  r="1"/>
-    <circle cx="130" cy="130" r="1"/>
-    <circle cx="270" cy="128" r="1"/>
-    <circle cx="185" cy="145" r="1.5"/>
-    <circle cx="215" cy="142" r="1.5"/>
+  <g fill="#00d0b0">
+    <circle cx="150" cy="95"  r="1.5" opacity="0.35">
+      <animateTransform attributeName="transform" type="translate" values="0 0; 5 5; 10 10; 15 15" dur="10s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.35;0.35;0" dur="10s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="175" cy="108" r="1" opacity="0.35">
+      <animateTransform attributeName="transform" type="translate" values="0 0; 4 4; 8 8; 12 12" dur="12s" begin="2s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.35;0.35;0" dur="12s" begin="2s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="225" cy="105" r="1.5" opacity="0.35">
+      <animateTransform attributeName="transform" type="translate" values="0 0; -4 5; -8 10; -12 15" dur="11s" begin="1s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.35;0.35;0" dur="11s" begin="1s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="250" cy="92"  r="1" opacity="0.35">
+      <animateTransform attributeName="transform" type="translate" values="0 0; -5 4; -10 8; -15 12" dur="13s" begin="4s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.35;0.35;0" dur="13s" begin="4s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="130" cy="130" r="1" opacity="0.35">
+      <animateTransform attributeName="transform" type="translate" values="0 0; 6 3; 12 6; 18 9" dur="9s" begin="3s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.35;0.35;0" dur="9s" begin="3s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="270" cy="128" r="1" opacity="0.35">
+      <animateTransform attributeName="transform" type="translate" values="0 0; -6 3; -12 6; -18 9" dur="9s" begin="6s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.35;0.35;0" dur="9s" begin="6s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="185" cy="145" r="1.5" opacity="0.35">
+      <animateTransform attributeName="transform" type="translate" values="0 0; 2 6; 4 12; 6 18" dur="10s" begin="5s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.35;0.35;0" dur="10s" begin="5s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="215" cy="142" r="1.5" opacity="0.35">
+      <animateTransform attributeName="transform" type="translate" values="0 0; -2 6; -4 12; -6 18" dur="10s" begin="7s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.35;0.35;0" dur="10s" begin="7s" repeatCount="indefinite"/>
+    </circle>
   </g>
 
   <!-- Label -->
-  <text x="200" y="228" font-family="monospace" font-size="9" fill="#1a4040" text-anchor="middle" letter-spacing="3">THE PASSAGE</text>
+  <text x="200" y="228" font-family="monospace" font-size="9" fill="#1a4040" text-anchor="middle" letter-spacing="3">THE PASSAGE
+    <animate attributeName="opacity" values="0.7;1;0.7" dur="8s" repeatCount="indefinite"/>
+  </text>
 </svg>

--- a/web/public/sprites/cave-bat-1.svg
+++ b/web/public/sprites/cave-bat-1.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Body -->
+  <ellipse cx="16" cy="18" rx="5" ry="4" fill="#2a1a2a"/>
+  <!-- Head -->
+  <ellipse cx="16" cy="13" rx="4" ry="3.5" fill="#3a2a3a"/>
+  <!-- Ears -->
+  <polygon points="13,13 11,8 14,12" fill="#2a1a2a"/>
+  <polygon points="19,13 21,8 18,12" fill="#2a1a2a"/>
+  <!-- Eyes (glowing red) -->
+  <circle cx="14.5" cy="12.5" r="1" fill="#cc0000"/>
+  <circle cx="17.5" cy="12.5" r="1" fill="#cc0000"/>
+  <circle cx="14.5" cy="12.5" r="0.5" fill="#ff4444"/>
+  <circle cx="17.5" cy="12.5" r="0.5" fill="#ff4444"/>
+  <!-- Wings raised up -->
+  <path d="M12,16 Q7,8 2,10 Q4,15 12,18" fill="#2a1a2a"/>
+  <path d="M20,16 Q25,8 30,10 Q28,15 20,18" fill="#2a1a2a"/>
+  <!-- Wing membrane detail -->
+  <line x1="12" y1="16" x2="4" y2="11" stroke="#3a2a3a" stroke-width="0.5"/>
+  <line x1="20" y1="16" x2="28" y2="11" stroke="#3a2a3a" stroke-width="0.5"/>
+  <!-- Feet -->
+  <line x1="14" y1="22" x2="13" y2="26" stroke="#2a1a2a" stroke-width="1"/>
+  <line x1="18" y1="22" x2="19" y2="26" stroke="#2a1a2a" stroke-width="1"/>
+</svg>

--- a/web/public/sprites/cave-bat-2.svg
+++ b/web/public/sprites/cave-bat-2.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Body (raised 1px at top of wing stroke) -->
+  <ellipse cx="16" cy="17" rx="5" ry="4" fill="#2a1a2a"/>
+  <!-- Head -->
+  <ellipse cx="16" cy="12" rx="4" ry="3.5" fill="#3a2a3a"/>
+  <!-- Ears -->
+  <polygon points="13,12 11,7 14,11" fill="#2a1a2a"/>
+  <polygon points="19,12 21,7 18,11" fill="#2a1a2a"/>
+  <!-- Eyes (glowing red) -->
+  <circle cx="14.5" cy="11.5" r="1" fill="#cc0000"/>
+  <circle cx="17.5" cy="11.5" r="1" fill="#cc0000"/>
+  <circle cx="14.5" cy="11.5" r="0.5" fill="#ff4444"/>
+  <circle cx="17.5" cy="11.5" r="0.5" fill="#ff4444"/>
+  <!-- Wings at peak spread (horizontal) -->
+  <path d="M12,15 Q5,11 1,14 Q3,18 12,17" fill="#2a1a2a"/>
+  <path d="M20,15 Q27,11 31,14 Q29,18 20,17" fill="#2a1a2a"/>
+  <!-- Wing membrane detail -->
+  <line x1="12" y1="15" x2="2" y2="14" stroke="#3a2a3a" stroke-width="0.5"/>
+  <line x1="20" y1="15" x2="30" y2="14" stroke="#3a2a3a" stroke-width="0.5"/>
+  <!-- Feet -->
+  <line x1="14" y1="21" x2="13" y2="25" stroke="#2a1a2a" stroke-width="1"/>
+  <line x1="18" y1="21" x2="19" y2="25" stroke="#2a1a2a" stroke-width="1"/>
+</svg>

--- a/web/public/sprites/cave-bat-3.svg
+++ b/web/public/sprites/cave-bat-3.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Body -->
+  <ellipse cx="16" cy="18" rx="5" ry="4" fill="#2a1a2a"/>
+  <!-- Head -->
+  <ellipse cx="16" cy="13" rx="4" ry="3.5" fill="#3a2a3a"/>
+  <!-- Ears -->
+  <polygon points="13,13 11,8 14,12" fill="#2a1a2a"/>
+  <polygon points="19,13 21,8 18,12" fill="#2a1a2a"/>
+  <!-- Eyes (glowing red) -->
+  <circle cx="14.5" cy="12.5" r="1" fill="#cc0000"/>
+  <circle cx="17.5" cy="12.5" r="1" fill="#cc0000"/>
+  <circle cx="14.5" cy="12.5" r="0.5" fill="#ff4444"/>
+  <circle cx="17.5" cy="12.5" r="0.5" fill="#ff4444"/>
+  <!-- Wings swept down -->
+  <path d="M12,16 Q7,22 2,22 Q4,17 12,16" fill="#2a1a2a"/>
+  <path d="M20,16 Q25,22 30,22 Q28,17 20,16" fill="#2a1a2a"/>
+  <!-- Wing membrane detail -->
+  <line x1="12" y1="16" x2="2" y2="22" stroke="#3a2a3a" stroke-width="0.5"/>
+  <line x1="20" y1="16" x2="30" y2="22" stroke="#3a2a3a" stroke-width="0.5"/>
+  <!-- Feet -->
+  <line x1="14" y1="22" x2="13" y2="26" stroke="#2a1a2a" stroke-width="1"/>
+  <line x1="18" y1="22" x2="19" y2="26" stroke="#2a1a2a" stroke-width="1"/>
+</svg>

--- a/web/public/sprites/cave-bat.svg
+++ b/web/public/sprites/cave-bat.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Body -->
+  <ellipse cx="16" cy="18" rx="5" ry="4" fill="#2a1a2a"/>
+  <!-- Head -->
+  <ellipse cx="16" cy="13" rx="4" ry="3.5" fill="#3a2a3a"/>
+  <!-- Ears -->
+  <polygon points="13,13 11,8 14,12" fill="#2a1a2a"/>
+  <polygon points="19,13 21,8 18,12" fill="#2a1a2a"/>
+  <!-- Eyes (glowing red) -->
+  <circle cx="14.5" cy="12.5" r="1" fill="#cc0000"/>
+  <circle cx="17.5" cy="12.5" r="1" fill="#cc0000"/>
+  <circle cx="14.5" cy="12.5" r="0.5" fill="#ff4444"/>
+  <circle cx="17.5" cy="12.5" r="0.5" fill="#ff4444"/>
+  <!-- Wings mid-flap -->
+  <path d="M12,16 Q5,12 2,16 Q5,20 12,18" fill="#2a1a2a"/>
+  <path d="M20,16 Q27,12 30,16 Q27,20 20,18" fill="#2a1a2a"/>
+  <!-- Wing membrane detail -->
+  <line x1="12" y1="16" x2="2" y2="16" stroke="#3a2a3a" stroke-width="0.5"/>
+  <line x1="20" y1="16" x2="30" y2="16" stroke="#3a2a3a" stroke-width="0.5"/>
+  <!-- Feet -->
+  <line x1="14" y1="22" x2="13" y2="26" stroke="#2a1a2a" stroke-width="1"/>
+  <line x1="18" y1="22" x2="19" y2="26" stroke="#2a1a2a" stroke-width="1"/>
+</svg>

--- a/web/public/sprites/eel-trench.svg
+++ b/web/public/sprites/eel-trench.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#0a1a0a" opacity="0.6"/>
+  <!-- Trench walls -->
+  <rect x="2" y="12" width="28" height="18" rx="1" fill="#1a3a2a"/>
+  <!-- Water fill -->
+  <rect x="3" y="16" width="26" height="13" rx="1" fill="#0a2a3a"/>
+  <!-- Water surface shimmer -->
+  <path d="M4,17 Q10,15 16,17 Q22,19 28,17" fill="none" stroke="#1a5a7a" stroke-width="1" opacity="0.8"/>
+  <path d="M4,20 Q10,18 16,20 Q22,22 28,20" fill="none" stroke="#1a4a6a" stroke-width="0.8" opacity="0.5"/>
+  <!-- Eel silhouettes -->
+  <path d="M5,22 Q10,19 15,22 Q20,25 25,22" fill="none" stroke="#2a7a4a" stroke-width="2" opacity="0.8"/>
+  <path d="M7,26 Q12,23 17,26 Q22,28 27,26" fill="none" stroke="#1a6a3a" stroke-width="1.5" opacity="0.7"/>
+  <!-- Eel eyes -->
+  <circle cx="5" cy="22" r="1" fill="#88ffaa" opacity="0.9"/>
+  <circle cx="7" cy="26" r="1" fill="#66ee88" opacity="0.8"/>
+  <!-- Electric sparks -->
+  <path d="M14,18 L16,15 L18,18" fill="none" stroke="#aaff00" stroke-width="0.8" opacity="0.7"/>
+  <circle cx="16" cy="14" r="1" fill="#ccff44" opacity="0.6"/>
+  <!-- Trench rim top -->
+  <rect x="2" y="10" width="28" height="3" rx="1" fill="#2a4a3a"/>
+  <rect x="4" y="9" width="5" height="2" rx="0.5" fill="#3a5a4a"/>
+  <rect x="14" y="9" width="5" height="2" rx="0.5" fill="#3a5a4a"/>
+  <rect x="23" y="9" width="5" height="2" rx="0.5" fill="#3a5a4a"/>
+</svg>

--- a/web/public/sprites/elder-mammoth-pen.svg
+++ b/web/public/sprites/elder-mammoth-pen.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#2a1a0a" opacity="0.5"/>
+  <!-- Pen fence posts -->
+  <rect x="2" y="14" width="3" height="16" rx="0.5" fill="#6a4a2a"/>
+  <rect x="9" y="14" width="3" height="16" rx="0.5" fill="#6a4a2a"/>
+  <rect x="20" y="14" width="3" height="16" rx="0.5" fill="#6a4a2a"/>
+  <rect x="27" y="14" width="3" height="16" rx="0.5" fill="#6a4a2a"/>
+  <!-- Fence rails -->
+  <rect x="2" y="16" width="28" height="2" rx="0.5" fill="#8a6a3a"/>
+  <rect x="2" y="22" width="28" height="2" rx="0.5" fill="#8a6a3a"/>
+  <!-- Mammoth silhouette -->
+  <ellipse cx="16" cy="24" rx="9" ry="5" fill="#5a4a3a"/>
+  <!-- Mammoth head -->
+  <circle cx="25" cy="21" r="4" fill="#6a5a4a"/>
+  <!-- Tusks -->
+  <path d="M27,23 Q31,26 29,29" fill="none" stroke="#eeddaa" stroke-width="1.5" stroke-linecap="round"/>
+  <path d="M26,24 Q30,27 28,30" fill="none" stroke="#ddcc99" stroke-width="1" stroke-linecap="round"/>
+  <!-- Trunk -->
+  <path d="M25,24 Q28,28 26,30" fill="none" stroke="#5a4a3a" stroke-width="2" stroke-linecap="round"/>
+  <!-- Eye -->
+  <circle cx="27" cy="20" r="1" fill="#2a1a0a"/>
+  <!-- Fur texture lines -->
+  <path d="M8,22 Q12,19 16,22" fill="none" stroke="#7a6a5a" stroke-width="0.6" opacity="0.6"/>
+  <!-- Roof over pen -->
+  <polygon points="2,14 16,6 30,14" fill="#4a3a1a"/>
+  <polygon points="4,14 16,8 28,14" fill="#5a4a2a"/>
+</svg>

--- a/web/public/sprites/elder-sanctum.svg
+++ b/web/public/sprites/elder-sanctum.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#1a2a1a" opacity="0.5"/>
+  <!-- Base stone platform -->
+  <rect x="4" y="22" width="24" height="8" rx="1" fill="#5a7a4a"/>
+  <!-- Main sanctum tower -->
+  <rect x="8" y="10" width="16" height="14" rx="1" fill="#6a8a5a"/>
+  <!-- Ancient stone texture -->
+  <line x1="8" y1="15" x2="24" y2="15" stroke="#4a6a3a" stroke-width="0.6"/>
+  <line x1="8" y1="20" x2="24" y2="20" stroke="#4a6a3a" stroke-width="0.6"/>
+  <line x1="16" y1="10" x2="16" y2="24" stroke="#4a6a3a" stroke-width="0.5"/>
+  <!-- Peaked roof -->
+  <polygon points="6,10 16,2 26,10" fill="#4a6a3a"/>
+  <polygon points="8,10 16,4 24,10" fill="#5a7a4a"/>
+  <!-- Central rune glow -->
+  <circle cx="16" cy="16" r="3" fill="#88ff88" opacity="0.3"/>
+  <circle cx="16" cy="16" r="1.5" fill="#aaffaa" opacity="0.5"/>
+  <!-- Rune marks -->
+  <line x1="13" y1="16" x2="19" y2="16" stroke="#66cc66" stroke-width="0.8"/>
+  <line x1="16" y1="13" x2="16" y2="19" stroke="#66cc66" stroke-width="0.8"/>
+  <!-- Arched entrance -->
+  <path d="M12,24 L12,18 Q16,14 20,18 L20,24 Z" fill="#2a3a1a"/>
+  <!-- Vines on walls -->
+  <path d="M8,12 Q6,16 8,20" fill="none" stroke="#3a6a1a" stroke-width="1.2" opacity="0.7"/>
+  <path d="M24,13 Q26,17 24,21" fill="none" stroke="#3a6a1a" stroke-width="1.2" opacity="0.7"/>
+  <!-- Glowing orbs on roof peak -->
+  <circle cx="16" cy="2" r="1.5" fill="#88ff88" opacity="0.8"/>
+  <circle cx="6" cy="10" r="1" fill="#66cc66" opacity="0.6"/>
+  <circle cx="26" cy="10" r="1" fill="#66cc66" opacity="0.6"/>
+</svg>

--- a/web/public/sprites/elderwood-fort.svg
+++ b/web/public/sprites/elderwood-fort.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#1a2a0a" opacity="0.5"/>
+  <!-- Fort base walls -->
+  <rect x="3" y="14" width="26" height="16" rx="1" fill="#5a7a3a"/>
+  <!-- Wood plank texture -->
+  <line x1="3" y1="18" x2="29" y2="18" stroke="#3a5a1a" stroke-width="0.7"/>
+  <line x1="3" y1="22" x2="29" y2="22" stroke="#3a5a1a" stroke-width="0.7"/>
+  <line x1="3" y1="26" x2="29" y2="26" stroke="#3a5a1a" stroke-width="0.7"/>
+  <!-- Corner towers -->
+  <rect x="1" y="10" width="8" height="20" rx="1" fill="#6a8a4a"/>
+  <rect x="23" y="10" width="8" height="20" rx="1" fill="#6a8a4a"/>
+  <!-- Tower battlements -->
+  <rect x="1" y="8" width="3" height="4" rx="0.5" fill="#7a9a5a"/>
+  <rect x="6" y="8" width="3" height="4" rx="0.5" fill="#7a9a5a"/>
+  <rect x="23" y="8" width="3" height="4" rx="0.5" fill="#7a9a5a"/>
+  <rect x="28" y="8" width="3" height="4" rx="0.5" fill="#7a9a5a"/>
+  <!-- Gate opening -->
+  <path d="M12,30 L12,20 Q16,16 20,20 L20,30 Z" fill="#1a2a0a"/>
+  <!-- Gate door bars -->
+  <line x1="14" y1="22" x2="14" y2="30" stroke="#3a4a1a" stroke-width="1"/>
+  <line x1="18" y1="22" x2="18" y2="30" stroke="#3a4a1a" stroke-width="1"/>
+  <!-- Elderwood tree growing through fort -->
+  <rect x="14" y="2" width="4" height="14" fill="#6a4a1a"/>
+  <ellipse cx="16" cy="5" rx="7" ry="5" fill="#2a6a1a"/>
+  <ellipse cx="11" cy="8" rx="4" ry="3" fill="#3a7a2a"/>
+  <ellipse cx="21" cy="8" rx="4" ry="3" fill="#3a7a2a"/>
+  <!-- Ivy on fort walls -->
+  <path d="M3,15 Q5,13 6,16" fill="none" stroke="#2a5a0a" stroke-width="1" opacity="0.8"/>
+  <path d="M26,16 Q28,14 29,17" fill="none" stroke="#2a5a0a" stroke-width="1" opacity="0.8"/>
+</svg>

--- a/web/public/sprites/ember-pit.svg
+++ b/web/public/sprites/ember-pit.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#2a0a00" opacity="0.6"/>
+  <!-- Pit rim/stone ring -->
+  <ellipse cx="16" cy="24" rx="13" ry="5" fill="#4a2a1a"/>
+  <ellipse cx="16" cy="23" rx="12" ry="4" fill="#5a3a1a"/>
+  <!-- Pit interior (deep dark) -->
+  <ellipse cx="16" cy="24" rx="9" ry="3.5" fill="#1a0800"/>
+  <!-- Ember glow layers -->
+  <ellipse cx="16" cy="24" rx="7" ry="2.5" fill="#aa2200" opacity="0.8"/>
+  <ellipse cx="16" cy="24" rx="5" ry="1.8" fill="#dd4400" opacity="0.7"/>
+  <ellipse cx="16" cy="24" rx="3" ry="1.2" fill="#ff8800" opacity="0.8"/>
+  <ellipse cx="16" cy="24" rx="1.5" ry="0.7" fill="#ffcc00" opacity="0.9"/>
+  <!-- Rising flames -->
+  <path d="M13,22 Q14,17 16,14 Q18,17 19,22" fill="#ff4400" opacity="0.6"/>
+  <path d="M14,22 Q15,18 16,16 Q17,18 18,22" fill="#ff8800" opacity="0.7"/>
+  <path d="M15,22 Q15.5,19 16,17 Q16.5,19 17,22" fill="#ffcc00" opacity="0.6"/>
+  <!-- Ember sparks floating up -->
+  <circle cx="12" cy="12" r="0.8" fill="#ff6600" opacity="0.7"/>
+  <circle cx="18" cy="9" r="0.6" fill="#ff8800" opacity="0.6"/>
+  <circle cx="20" cy="13" r="0.7" fill="#ffaa00" opacity="0.5"/>
+  <circle cx="11" cy="7" r="0.5" fill="#ff4400" opacity="0.4"/>
+  <!-- Stone ring detail -->
+  <line x1="6" y1="21" x2="4" y2="24" stroke="#3a1a0a" stroke-width="0.8" opacity="0.6"/>
+  <line x1="26" y1="21" x2="28" y2="24" stroke="#3a1a0a" stroke-width="0.8" opacity="0.6"/>
+</svg>

--- a/web/public/sprites/ember-sanctum.svg
+++ b/web/public/sprites/ember-sanctum.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#2a0a00" opacity="0.6"/>
+  <!-- Sanctum base -->
+  <rect x="4" y="18" width="24" height="12" rx="1" fill="#5a2a1a"/>
+  <!-- Black stone walls -->
+  <rect x="6" y="10" width="20" height="10" rx="1" fill="#4a1a0a"/>
+  <!-- Flame channel grooves -->
+  <line x1="6" y1="14" x2="26" y2="14" stroke="#aa3300" stroke-width="0.8" opacity="0.7"/>
+  <line x1="6" y1="17" x2="26" y2="17" stroke="#aa3300" stroke-width="0.6" opacity="0.5"/>
+  <!-- Peaked roof with flame tip -->
+  <polygon points="4,10 16,2 28,10" fill="#3a1a0a"/>
+  <polygon points="6,10 16,4 26,10" fill="#4a2a1a"/>
+  <!-- Flame at peak -->
+  <path d="M14,4 Q16,0 18,4 Q17,6 16,5 Q15,6 14,4Z" fill="#ff4400"/>
+  <path d="M15,4 Q16,1 17,4 Q16.5,5.5 16,5 Q15.5,5.5 15,4Z" fill="#ffaa00"/>
+  <!-- Ember windows -->
+  <rect x="9" y="13" width="4" height="5" rx="1" fill="#1a0800"/>
+  <rect x="19" y="13" width="4" height="5" rx="1" fill="#1a0800"/>
+  <ellipse cx="11" cy="15.5" rx="1.5" ry="2" fill="#ff6600" opacity="0.7"/>
+  <ellipse cx="21" cy="15.5" rx="1.5" ry="2" fill="#ff6600" opacity="0.7"/>
+  <!-- Arched door -->
+  <path d="M13,30 L13,22 Q16,18 19,22 L19,30 Z" fill="#1a0800"/>
+  <!-- Ember glow at base -->
+  <ellipse cx="16" cy="29" rx="10" ry="1.5" fill="#ff4400" opacity="0.2"/>
+  <!-- Floating embers -->
+  <circle cx="9" cy="8" r="0.7" fill="#ff6600" opacity="0.6"/>
+  <circle cx="23" cy="7" r="0.6" fill="#ffaa00" opacity="0.5"/>
+</svg>

--- a/web/public/sprites/engineer-s-yard.svg
+++ b/web/public/sprites/engineer-s-yard.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#1a1a1a" opacity="0.5"/>
+  <!-- Yard ground / work surface -->
+  <rect x="1" y="20" width="30" height="10" rx="1" fill="#4a4a3a"/>
+  <!-- Workshop building -->
+  <rect x="2" y="10" width="18" height="12" rx="1" fill="#5a5a4a"/>
+  <!-- Roof -->
+  <polygon points="1,10 11,3 21,10" fill="#3a3a2a"/>
+  <polygon points="3,10 11,5 19,10" fill="#4a4a3a"/>
+  <!-- Workshop window -->
+  <rect x="6" y="13" width="5" height="4" rx="0.5" fill="#2a2a1a"/>
+  <line x1="8.5" y1="13" x2="8.5" y2="17" stroke="#6a6a4a" stroke-width="0.5"/>
+  <line x1="6" y1="15" x2="11" y2="15" stroke="#6a6a4a" stroke-width="0.5"/>
+  <!-- Workshop door -->
+  <rect x="13" y="16" width="5" height="6" rx="0.5" fill="#2a2a1a"/>
+  <!-- Equipment in yard: siege engine / catapult arm -->
+  <rect x="21" y="16" width="9" height="5" rx="1" fill="#6a5a2a"/>
+  <rect x="24" y="11" width="3" height="8" rx="0.5" fill="#8a6a2a"/>
+  <ellipse cx="25.5" cy="11" rx="2.5" ry="1.5" fill="#4a3a1a"/>
+  <!-- Wheels -->
+  <circle cx="23" cy="21" r="2.5" fill="#3a2a1a"/>
+  <circle cx="23" cy="21" r="1.5" fill="#5a4a2a"/>
+  <circle cx="29" cy="21" r="2.5" fill="#3a2a1a"/>
+  <circle cx="29" cy="21" r="1.5" fill="#5a4a2a"/>
+  <!-- Tools on ground -->
+  <line x1="3" y1="22" x2="7" y2="22" stroke="#8a7a4a" stroke-width="1.5"/>
+  <line x1="4" y1="25" x2="4" y2="22" stroke="#8a7a4a" stroke-width="1.5"/>
+  <!-- Chimney smoke -->
+  <circle cx="10" cy="4" r="1.5" fill="#8a8a7a" opacity="0.4"/>
+  <circle cx="9" cy="2" r="1" fill="#8a8a7a" opacity="0.3"/>
+</svg>

--- a/web/public/sprites/execution-post.svg
+++ b/web/public/sprites/execution-post.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#1a0a0a" opacity="0.6"/>
+  <!-- Stone platform base -->
+  <rect x="4" y="24" width="24" height="6" rx="1" fill="#4a3a3a"/>
+  <rect x="6" y="22" width="20" height="4" rx="0.5" fill="#5a4a4a"/>
+  <!-- Central execution post -->
+  <rect x="14" y="6" width="4" height="18" rx="0.5" fill="#3a2a2a"/>
+  <!-- Cross beam -->
+  <rect x="9" y="8" width="14" height="3" rx="0.5" fill="#4a3a3a"/>
+  <!-- Iron chains hanging -->
+  <line x1="10" y1="11" x2="10" y2="18" stroke="#5a5a5a" stroke-width="1"/>
+  <line x1="10" y1="12" x2="12" y2="13" stroke="#5a5a5a" stroke-width="0.8"/>
+  <line x1="10" y1="14" x2="12" y2="15" stroke="#5a5a5a" stroke-width="0.8"/>
+  <line x1="10" y1="16" x2="12" y2="17" stroke="#5a5a5a" stroke-width="0.8"/>
+  <line x1="22" y1="11" x2="22" y2="18" stroke="#5a5a5a" stroke-width="1"/>
+  <line x1="22" y1="12" x2="20" y2="13" stroke="#5a5a5a" stroke-width="0.8"/>
+  <line x1="22" y1="14" x2="20" y2="15" stroke="#5a5a5a" stroke-width="0.8"/>
+  <line x1="22" y1="16" x2="20" y2="17" stroke="#5a5a5a" stroke-width="0.8"/>
+  <!-- Skull ornament on top -->
+  <ellipse cx="16" cy="5" rx="3" ry="2.5" fill="#2a1a1a"/>
+  <rect x="14" y="5" width="4" height="2" fill="#2a1a1a"/>
+  <!-- Eye sockets glow red -->
+  <circle cx="14.5" cy="4.5" r="0.8" fill="#cc0000" opacity="0.7"/>
+  <circle cx="17.5" cy="4.5" r="0.8" fill="#cc0000" opacity="0.7"/>
+  <!-- Warning flag -->
+  <line x1="22" y1="6" x2="22" y2="1" stroke="#4a3a3a" stroke-width="0.8"/>
+  <polygon points="22,1 28,2.5 22,4" fill="#aa2222"/>
+  <!-- Blood/dark stain at base of post -->
+  <ellipse cx="16" cy="23" rx="3" ry="1" fill="#4a0000" opacity="0.5"/>
+</svg>

--- a/web/public/sprites/flame-spire.svg
+++ b/web/public/sprites/flame-spire.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="10" ry="1.5" fill="#2a0a00" opacity="0.6"/>
+  <!-- Spire base -->
+  <rect x="10" y="22" width="12" height="8" rx="1" fill="#4a1a0a"/>
+  <!-- Main tower -->
+  <rect x="12" y="10" width="8" height="14" rx="1" fill="#5a2a1a"/>
+  <!-- Tower taper (upper) -->
+  <polygon points="10,10 16,2 22,10" fill="#3a1a0a"/>
+  <!-- Lava/fire channel grooves on tower -->
+  <line x1="12" y1="14" x2="20" y2="14" stroke="#ff4400" stroke-width="0.8" opacity="0.6"/>
+  <line x1="12" y1="18" x2="20" y2="18" stroke="#ff4400" stroke-width="0.6" opacity="0.5"/>
+  <!-- Flame at peak -->
+  <path d="M13,3 Q16,0 19,3 Q18,7 16,6 Q14,7 13,3Z" fill="#ff4400" opacity="0.9"/>
+  <path d="M14,3 Q16,1 18,3 Q17,6 16,5.5 Q15,6 14,3Z" fill="#ff8800" opacity="0.8"/>
+  <path d="M15,3 Q16,2 17,3 Q16.5,5 16,5 Q15.5,5 15,3Z" fill="#ffcc00" opacity="0.9"/>
+  <!-- Side flame vents -->
+  <circle cx="12" cy="13" r="2" fill="#1a0800"/>
+  <ellipse cx="12" cy="13" rx="1.5" ry="1.5" fill="#ff4400" opacity="0.7"/>
+  <circle cx="20" cy="13" r="2" fill="#1a0800"/>
+  <ellipse cx="20" cy="13" rx="1.5" ry="1.5" fill="#ff4400" opacity="0.7"/>
+  <!-- Ember particles -->
+  <circle cx="10" cy="8" r="0.8" fill="#ff6600" opacity="0.6"/>
+  <circle cx="22" cy="6" r="0.7" fill="#ffaa00" opacity="0.5"/>
+  <circle cx="19" cy="4" r="0.6" fill="#ff4400" opacity="0.7"/>
+  <!-- Base platform detail -->
+  <line x1="10" y1="25" x2="22" y2="25" stroke="#3a1a0a" stroke-width="0.6"/>
+</svg>

--- a/web/public/sprites/frost-barrow.svg
+++ b/web/public/sprites/frost-barrow.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#0a1a2a" opacity="0.5"/>
+  <!-- Burial mound (snowy hill) -->
+  <ellipse cx="16" cy="26" rx="14" ry="8" fill="#3a5a6a"/>
+  <ellipse cx="16" cy="24" rx="13" ry="7" fill="#4a6a8a"/>
+  <!-- Snow cap -->
+  <ellipse cx="16" cy="22" rx="10" ry="5" fill="#aaccdd"/>
+  <ellipse cx="16" cy="20" rx="8" ry="4" fill="#cce8f0"/>
+  <!-- Stone entrance lintel -->
+  <rect x="10" y="22" width="12" height="3" rx="0.5" fill="#5a7a8a"/>
+  <!-- Dark entrance -->
+  <path d="M12,30 L12,24 Q16,20 20,24 L20,30 Z" fill="#0a1a2a"/>
+  <!-- Ice crystals at entrance -->
+  <polygon points="12,22 10,18 14,21" fill="#88ccee" opacity="0.8"/>
+  <polygon points="20,22 22,18 18,21" fill="#88ccee" opacity="0.8"/>
+  <!-- Snowflake decoration on lintel -->
+  <line x1="16" y1="21" x2="16" y2="25" stroke="#aaccdd" stroke-width="0.8"/>
+  <line x1="14" y1="23" x2="18" y2="23" stroke="#aaccdd" stroke-width="0.8"/>
+  <line x1="14.5" y1="21.5" x2="17.5" y2="24.5" stroke="#aaccdd" stroke-width="0.5"/>
+  <line x1="17.5" y1="21.5" x2="14.5" y2="24.5" stroke="#aaccdd" stroke-width="0.5"/>
+  <!-- Ice spikes above mound -->
+  <polygon points="8,18 10,12 12,18" fill="#88ccee" opacity="0.7"/>
+  <polygon points="21,18 23,11 25,18" fill="#88ccee" opacity="0.6"/>
+  <polygon points="14,16 16,10 18,16" fill="#aaddff" opacity="0.8"/>
+  <!-- Snow particles -->
+  <circle cx="5" cy="15" r="0.8" fill="#cce8f0" opacity="0.6"/>
+  <circle cx="27" cy="13" r="0.7" fill="#cce8f0" opacity="0.5"/>
+  <circle cx="22" cy="8" r="0.6" fill="#cce8f0" opacity="0.4"/>
+</svg>

--- a/web/public/sprites/frost-eyrie.svg
+++ b/web/public/sprites/frost-eyrie.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="11" ry="1.5" fill="#0a1a2a" opacity="0.5"/>
+  <!-- Rocky cliff base -->
+  <polygon points="4,30 8,20 14,24 18,18 24,22 28,30" fill="#4a5a6a"/>
+  <!-- Ice tower -->
+  <rect x="11" y="8" width="10" height="16" rx="1" fill="#5a8aaa"/>
+  <!-- Ice texture -->
+  <line x1="11" y1="12" x2="21" y2="12" stroke="#4a7a9a" stroke-width="0.6"/>
+  <line x1="11" y1="17" x2="21" y2="17" stroke="#4a7a9a" stroke-width="0.6"/>
+  <line x1="16" y1="8" x2="16" y2="24" stroke="#4a7a9a" stroke-width="0.4"/>
+  <!-- Icy spire peak -->
+  <polygon points="9,8 16,1 23,8" fill="#3a6a8a"/>
+  <polygon points="11,8 16,3 21,8" fill="#6aaabb"/>
+  <!-- Ice crystal tip -->
+  <polygon points="14,3 16,0 18,3 16,5" fill="#aaddff"/>
+  <!-- Nest at top (eyrie) -->
+  <path d="M11,9 Q13,7 16,8 Q19,7 21,9" fill="none" stroke="#6a4a2a" stroke-width="1.5"/>
+  <!-- Egg in nest -->
+  <ellipse cx="16" cy="9" rx="2" ry="1.5" fill="#cce8f0"/>
+  <!-- Arrow slits -->
+  <rect x="13" y="14" width="2" height="4" rx="0.3" fill="#1a2a3a"/>
+  <rect x="17" y="14" width="2" height="4" rx="0.3" fill="#1a2a3a"/>
+  <!-- Icicles hanging -->
+  <polygon points="12,24 13,28 14,24" fill="#88ccee"/>
+  <polygon points="15,24 16,29 17,24" fill="#88ccee"/>
+  <polygon points="18,24 19,27 20,24" fill="#88ccee"/>
+  <!-- Ice sparkles -->
+  <circle cx="9" cy="6" r="0.7" fill="#aaddff" opacity="0.7"/>
+  <circle cx="23" cy="5" r="0.6" fill="#aaddff" opacity="0.6"/>
+</svg>

--- a/web/public/sprites/frost-watch.svg
+++ b/web/public/sprites/frost-watch.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="10" ry="1.5" fill="#0a1a2a" opacity="0.5"/>
+  <!-- Watchtower base -->
+  <rect x="10" y="20" width="12" height="10" rx="1" fill="#4a6a7a"/>
+  <!-- Tower shaft -->
+  <rect x="12" y="8" width="8" height="14" rx="0.5" fill="#5a7a8a"/>
+  <!-- Ice cladding -->
+  <rect x="11" y="10" width="2" height="10" fill="#6a9aaa" opacity="0.7"/>
+  <rect x="19" y="10" width="2" height="10" fill="#6a9aaa" opacity="0.7"/>
+  <!-- Observation platform top -->
+  <rect x="9" y="7" width="14" height="3" rx="0.5" fill="#6a8a9a"/>
+  <!-- Battlements -->
+  <rect x="9" y="4" width="3" height="4" rx="0.3" fill="#5a7a8a"/>
+  <rect x="14" y="4" width="3" height="4" rx="0.3" fill="#5a7a8a"/>
+  <rect x="19" y="4" width="3" height="4" rx="0.3" fill="#5a7a8a"/>
+  <!-- Ice crystal flagpole -->
+  <line x1="16" y1="4" x2="16" y2="1" stroke="#4a6a8a" stroke-width="0.8"/>
+  <polygon points="14,2 16,1 18,2 16,4" fill="#aaddff"/>
+  <!-- Arrow slit window -->
+  <rect x="14" y="12" width="4" height="6" rx="0.5" fill="#1a2a3a"/>
+  <path d="M14,12 Q16,10 18,12" fill="#1a2a3a"/>
+  <!-- Icicles on platform -->
+  <polygon points="10,10 11,14 12,10" fill="#88ccee"/>
+  <polygon points="15,10 16,15 17,10" fill="#88ccee"/>
+  <polygon points="20,10 21,13 22,10" fill="#88ccee"/>
+  <!-- Frost glow -->
+  <ellipse cx="16" cy="6" rx="8" ry="2" fill="#aaddff" opacity="0.15"/>
+  <!-- Guard torch (lit with cold fire) -->
+  <circle cx="22" cy="9" r="1.5" fill="#88aaff" opacity="0.6"/>
+  <circle cx="22" cy="9" r="0.8" fill="#ccddff" opacity="0.8"/>
+</svg>

--- a/web/public/sprites/frozen-vault.svg
+++ b/web/public/sprites/frozen-vault.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#0a1a2a" opacity="0.5"/>
+  <!-- Vault body -->
+  <rect x="3" y="12" width="26" height="18" rx="2" fill="#3a5a6a"/>
+  <!-- Ice encasing -->
+  <rect x="2" y="11" width="28" height="20" rx="2" fill="#4a7a8a" opacity="0.5"/>
+  <!-- Stone block texture -->
+  <line x1="3" y1="17" x2="29" y2="17" stroke="#2a4a5a" stroke-width="0.7"/>
+  <line x1="3" y1="22" x2="29" y2="22" stroke="#2a4a5a" stroke-width="0.7"/>
+  <line x1="10" y1="12" x2="10" y2="30" stroke="#2a4a5a" stroke-width="0.5"/>
+  <line x1="22" y1="12" x2="22" y2="30" stroke="#2a4a5a" stroke-width="0.5"/>
+  <!-- Vault top dome with ice -->
+  <ellipse cx="16" cy="12" rx="13" ry="4" fill="#4a6a7a"/>
+  <ellipse cx="16" cy="11" rx="12" ry="3" fill="#6aaabb"/>
+  <!-- Ice crystal on top -->
+  <polygon points="12,8 16,2 20,8 16,11" fill="#aaddff"/>
+  <polygon points="13,8 16,4 19,8 16,10" fill="#cceeff"/>
+  <!-- Heavy vault door -->
+  <rect x="11" y="18" width="10" height="12" rx="1" fill="#2a3a4a"/>
+  <!-- Door frame -->
+  <rect x="10" y="17" width="12" height="14" rx="1" fill="none" stroke="#5a8a9a" stroke-width="1.5"/>
+  <!-- Lock mechanism -->
+  <circle cx="16" cy="24" r="2.5" fill="#3a5a6a"/>
+  <circle cx="16" cy="24" r="1.5" fill="#4a6a7a"/>
+  <circle cx="16" cy="24" r="0.8" fill="#88ccee"/>
+  <!-- Ice cracks on door -->
+  <path d="M12,20 L14,23 L13,26" fill="none" stroke="#88ccee" stroke-width="0.6" opacity="0.5"/>
+  <path d="M19,21 L18,24 L20,27" fill="none" stroke="#88ccee" stroke-width="0.6" opacity="0.5"/>
+  <!-- Frost sparkles -->
+  <circle cx="5" cy="15" r="0.7" fill="#aaddff" opacity="0.6"/>
+  <circle cx="27" cy="16" r="0.6" fill="#aaddff" opacity="0.5"/>
+</svg>

--- a/web/public/sprites/gale-shrine.svg
+++ b/web/public/sprites/gale-shrine.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="11" ry="1.5" fill="#1a1a2a" opacity="0.5"/>
+  <!-- Stone platform -->
+  <rect x="5" y="24" width="22" height="6" rx="1" fill="#6a6a7a"/>
+  <!-- Shrine pillars -->
+  <rect x="7" y="10" width="4" height="16" rx="0.5" fill="#7a7a8a"/>
+  <rect x="21" y="10" width="4" height="16" rx="0.5" fill="#7a7a8a"/>
+  <!-- Shrine roof (torii style) -->
+  <rect x="4" y="8" width="24" height="3" rx="0.5" fill="#5a5a6a"/>
+  <rect x="2" y="6" width="28" height="2.5" rx="0.5" fill="#6a6a7a"/>
+  <!-- Wind swirls in shrine -->
+  <path d="M10,16 Q16,10 22,16 Q16,22 10,16Z" fill="none" stroke="#aaaaff" stroke-width="1" opacity="0.6"/>
+  <path d="M11,16 Q16,12 21,16 Q16,20 11,16Z" fill="none" stroke="#8888ff" stroke-width="0.8" opacity="0.5"/>
+  <ellipse cx="16" cy="16" rx="3" ry="3" fill="#aaaaff" opacity="0.2"/>
+  <ellipse cx="16" cy="16" rx="1.5" ry="1.5" fill="#ccccff" opacity="0.3"/>
+  <!-- Wind spiral marks -->
+  <path d="M13,14 Q15,12 17,14 Q18,16 16,18 Q14,17 13,14Z" fill="none" stroke="#8888ff" stroke-width="0.7" opacity="0.7"/>
+  <!-- Flying leaves/petals in wind -->
+  <ellipse cx="8" cy="12" rx="1.5" ry="0.5" fill="#aaaaff" opacity="0.5" transform="rotate(-30 8 12)"/>
+  <ellipse cx="24" cy="11" rx="1.5" ry="0.5" fill="#aaaaff" opacity="0.4" transform="rotate(20 24 11)"/>
+  <ellipse cx="20" cy="19" rx="1" ry="0.4" fill="#8888ff" opacity="0.5" transform="rotate(-15 20 19)"/>
+  <!-- Bell hanging from roof -->
+  <path d="M14,9 Q16,12 18,9" fill="#8a8a7a" stroke="#5a5a6a" stroke-width="0.5"/>
+  <line x1="16" y1="9" x2="16" y2="8" stroke="#5a5a6a" stroke-width="0.6"/>
+  <!-- Cloud wisps at top -->
+  <ellipse cx="8" cy="5" rx="3" ry="1.5" fill="#ddddff" opacity="0.3"/>
+  <ellipse cx="24" cy="4" rx="3" ry="1.5" fill="#ddddff" opacity="0.3"/>
+</svg>

--- a/web/public/sprites/giant-s-hold.svg
+++ b/web/public/sprites/giant-s-hold.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="14" ry="1.5" fill="#1a1a0a" opacity="0.5"/>
+  <!-- Massive stone wall base -->
+  <rect x="1" y="16" width="30" height="14" rx="1" fill="#7a7a5a"/>
+  <!-- Giant-sized stone blocks -->
+  <line x1="1" y1="21" x2="31" y2="21" stroke="#5a5a3a" stroke-width="1"/>
+  <line x1="1" y1="26" x2="31" y2="26" stroke="#5a5a3a" stroke-width="1"/>
+  <line x1="8" y1="16" x2="8" y2="30" stroke="#5a5a3a" stroke-width="0.8"/>
+  <line x1="16" y1="16" x2="16" y2="30" stroke="#5a5a3a" stroke-width="0.8"/>
+  <line x1="24" y1="16" x2="24" y2="30" stroke="#5a5a3a" stroke-width="0.8"/>
+  <!-- Towers flanking hold -->
+  <rect x="1" y="8" width="9" height="22" rx="1" fill="#8a8a6a"/>
+  <rect x="22" y="8" width="9" height="22" rx="1" fill="#8a8a6a"/>
+  <!-- Tower tops (extra large battlements) -->
+  <rect x="1" y="5" width="4" height="5" rx="0.5" fill="#9a9a7a"/>
+  <rect x="6" y="5" width="4" height="5" rx="0.5" fill="#9a9a7a"/>
+  <rect x="22" y="5" width="4" height="5" rx="0.5" fill="#9a9a7a"/>
+  <rect x="27" y="5" width="4" height="5" rx="0.5" fill="#9a9a7a"/>
+  <!-- Giant footprint above door -->
+  <ellipse cx="16" cy="14" rx="5" ry="3" fill="#5a5a3a" opacity="0.5"/>
+  <!-- Enormous arched gate -->
+  <path d="M11,30 L11,18 Q16,12 21,18 L21,30 Z" fill="#1a1a0a"/>
+  <!-- Gate chain/bar -->
+  <line x1="11" y1="22" x2="21" y2="22" stroke="#5a5a3a" stroke-width="1.5"/>
+  <!-- Bone trophies on wall -->
+  <line x1="5" y1="10" x2="5" y2="15" stroke="#ccbb99" stroke-width="1.5"/>
+  <ellipse cx="5" cy="9" rx="2" ry="1.5" fill="#ccbb99"/>
+  <line x1="27" y1="10" x2="27" y2="15" stroke="#ccbb99" stroke-width="1.5"/>
+  <ellipse cx="27" cy="9" rx="2" ry="1.5" fill="#ccbb99"/>
+</svg>

--- a/web/public/sprites/glacial-forge.svg
+++ b/web/public/sprites/glacial-forge.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#0a1a2a" opacity="0.5"/>
+  <!-- Forge base -->
+  <rect x="4" y="20" width="24" height="10" rx="2" fill="#3a5a6a"/>
+  <!-- Forge body -->
+  <rect x="6" y="12" width="20" height="10" rx="1" fill="#4a6a7a"/>
+  <!-- Ice-stone chimney -->
+  <rect x="12" y="4" width="5" height="10" rx="1" fill="#5a7a8a"/>
+  <rect x="10" y="3" width="9" height="3" rx="0.5" fill="#4a6a7a"/>
+  <!-- Forge opening (fire cooled by ice = blue-white) -->
+  <ellipse cx="16" cy="22" rx="6" ry="3.5" fill="#0a0a1a"/>
+  <ellipse cx="16" cy="22" rx="5" ry="2.5" fill="#003366" opacity="0.8"/>
+  <ellipse cx="16" cy="22" rx="3.5" ry="1.8" fill="#0055aa" opacity="0.8"/>
+  <ellipse cx="16" cy="22" rx="2" ry="1.2" fill="#0088cc" opacity="0.9"/>
+  <ellipse cx="16" cy="22" rx="1" ry="0.6" fill="#aaddff"/>
+  <!-- Icy exhaust from chimney -->
+  <ellipse cx="14.5" cy="4" rx="3" ry="1.5" fill="#88ccee" opacity="0.4"/>
+  <circle cx="13" cy="2" r="1.5" fill="#aaddff" opacity="0.3"/>
+  <!-- Ice crystal accents on body -->
+  <polygon points="6,14 8,10 10,14" fill="#4a9abb" opacity="0.7"/>
+  <polygon points="22,14 24,10 26,14" fill="#4a9abb" opacity="0.7"/>
+  <!-- Cold runes -->
+  <line x1="8" y1="16" x2="10" y2="16" stroke="#88ccee" stroke-width="0.8"/>
+  <line x1="9" y1="15" x2="9" y2="17" stroke="#88ccee" stroke-width="0.8"/>
+  <line x1="22" y1="16" x2="24" y2="16" stroke="#88ccee" stroke-width="0.8"/>
+  <line x1="23" y1="15" x2="23" y2="17" stroke="#88ccee" stroke-width="0.8"/>
+  <!-- Ice sparkles -->
+  <circle cx="8" cy="9" r="0.7" fill="#aaddff" opacity="0.6"/>
+  <circle cx="24" cy="8" r="0.6" fill="#aaddff" opacity="0.5"/>
+</svg>

--- a/web/public/sprites/glass-spire.svg
+++ b/web/public/sprites/glass-spire.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="9" ry="1.5" fill="#1a1a2a" opacity="0.5"/>
+  <!-- Crystal base -->
+  <polygon points="8,30 12,24 20,24 24,30" fill="#5a6a8a"/>
+  <!-- Main glass spire body -->
+  <polygon points="10,24 13,12 19,12 22,24" fill="#7a9abb" opacity="0.85"/>
+  <!-- Glass highlight (refraction) -->
+  <polygon points="11,24 13,13 15,12 16,24" fill="#aaccdd" opacity="0.4"/>
+  <!-- Upper narrow spire -->
+  <polygon points="12,12 16,2 20,12" fill="#6a9abb" opacity="0.9"/>
+  <polygon points="13,12 16,4 17,12" fill="#aaddff" opacity="0.5"/>
+  <!-- Very tip crystal -->
+  <polygon points="15,4 16,0 17,4 16,6" fill="#ffffff" opacity="0.8"/>
+  <!-- Prismatic light refraction lines -->
+  <line x1="10" y1="18" x2="6" y2="22" stroke="#ffaaaa" stroke-width="0.8" opacity="0.4"/>
+  <line x1="22" y1="17" x2="27" y2="21" stroke="#aaffaa" stroke-width="0.8" opacity="0.4"/>
+  <line x1="10" y1="14" x2="5" y2="15" stroke="#aaaaff" stroke-width="0.8" opacity="0.4"/>
+  <line x1="22" y1="14" x2="27" y2="14" stroke="#ffffaa" stroke-width="0.8" opacity="0.4"/>
+  <!-- Facet lines on spire -->
+  <line x1="13" y1="12" x2="11" y2="24" stroke="#4a7a9a" stroke-width="0.5" opacity="0.6"/>
+  <line x1="16" y1="4" x2="14" y2="24" stroke="#4a7a9a" stroke-width="0.4" opacity="0.5"/>
+  <!-- Glow at base -->
+  <ellipse cx="16" cy="29" rx="7" ry="1.5" fill="#88aadd" opacity="0.25"/>
+</svg>

--- a/web/public/sprites/goblin-warrens.svg
+++ b/web/public/sprites/goblin-warrens.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="14" ry="1.5" fill="#1a1a0a" opacity="0.5"/>
+  <!-- Underground hill/mound -->
+  <ellipse cx="16" cy="26" rx="14" ry="7" fill="#4a4a1a"/>
+  <ellipse cx="16" cy="25" rx="13" ry="6" fill="#5a5a2a"/>
+  <!-- Grass on top of mound -->
+  <ellipse cx="16" cy="20" rx="10" ry="3" fill="#4a6a1a"/>
+  <!-- Multiple tunnel entrances -->
+  <ellipse cx="8" cy="27" rx="3.5" ry="2.5" fill="#1a1a0a"/>
+  <ellipse cx="16" cy="28" rx="3.5" ry="2.5" fill="#1a1a0a"/>
+  <ellipse cx="24" cy="27" rx="3.5" ry="2.5" fill="#1a1a0a"/>
+  <!-- Glowing goblin eyes in tunnels -->
+  <circle cx="7" cy="27" r="0.8" fill="#aaff00" opacity="0.9"/>
+  <circle cx="9" cy="27" r="0.8" fill="#aaff00" opacity="0.9"/>
+  <circle cx="15" cy="28" r="0.8" fill="#88ff00" opacity="0.8"/>
+  <circle cx="17" cy="28" r="0.8" fill="#88ff00" opacity="0.8"/>
+  <circle cx="23" cy="27" r="0.8" fill="#aaff00" opacity="0.7"/>
+  <circle cx="25" cy="27" r="0.8" fill="#aaff00" opacity="0.7"/>
+  <!-- Crude wooden sign post -->
+  <line x1="16" y1="15" x2="16" y2="20" stroke="#6a4a1a" stroke-width="1"/>
+  <rect x="12" y="13" width="8" height="4" rx="0.5" fill="#6a4a1a"/>
+  <!-- Junk/loot scattered around -->
+  <circle cx="5" cy="28" r="1" fill="#aa8800" opacity="0.7"/>
+  <circle cx="27" cy="29" r="0.8" fill="#888800" opacity="0.6"/>
+  <rect x="3" y="27" width="2" height="1" fill="#888800" opacity="0.5"/>
+  <!-- Smoke from mound -->
+  <circle cx="12" cy="16" r="1.5" fill="#8a8a6a" opacity="0.4"/>
+  <circle cx="14" cy="13" r="1" fill="#8a8a6a" opacity="0.3"/>
+</svg>

--- a/web/public/sprites/golem-forge.svg
+++ b/web/public/sprites/golem-forge.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#1a1a1a" opacity="0.5"/>
+  <!-- Heavy stone forge base -->
+  <rect x="3" y="20" width="26" height="10" rx="2" fill="#4a4a4a"/>
+  <!-- Main forge body -->
+  <rect x="5" y="11" width="22" height="11" rx="1" fill="#5a5a5a"/>
+  <!-- Golem mould/frame visible inside -->
+  <rect x="10" y="13" width="12" height="8" rx="1" fill="#2a2a2a"/>
+  <!-- Humanoid golem silhouette being forged -->
+  <rect x="13" y="14" width="6" height="6" rx="0.5" fill="#3a3a4a"/>
+  <ellipse cx="16" cy="14" rx="2.5" ry="2" fill="#4a4a5a"/>
+  <!-- Molten metal glow around golem -->
+  <ellipse cx="16" cy="17" rx="6" ry="4" fill="#ff6600" opacity="0.2"/>
+  <ellipse cx="16" cy="17" rx="4" ry="2.5" fill="#ff8800" opacity="0.2"/>
+  <!-- Roof with large chimney stacks -->
+  <polygon points="3,11 16,3 29,11" fill="#3a3a3a"/>
+  <polygon points="5,11 16,5 27,11" fill="#4a4a4a"/>
+  <rect x="9" y="3" width="4" height="9" rx="0.5" fill="#4a4a4a"/>
+  <rect x="20" y="3" width="4" height="9" rx="0.5" fill="#4a4a4a"/>
+  <!-- Smoke from chimneys -->
+  <circle cx="11" cy="3" r="2" fill="#6a6a6a" opacity="0.5"/>
+  <circle cx="10" cy="1" r="1.5" fill="#6a6a6a" opacity="0.4"/>
+  <circle cx="22" cy="2" r="2" fill="#6a6a6a" opacity="0.5"/>
+  <circle cx="23" cy="0" r="1" fill="#6a6a6a" opacity="0.3"/>
+  <!-- Rune glow on forge body -->
+  <line x1="6" y1="14" x2="8" y2="14" stroke="#ff6600" stroke-width="0.8" opacity="0.7"/>
+  <line x1="24" y1="14" x2="26" y2="14" stroke="#ff6600" stroke-width="0.8" opacity="0.7"/>
+  <line x1="7" y1="13" x2="7" y2="17" stroke="#ff6600" stroke-width="0.8" opacity="0.6"/>
+  <line x1="25" y1="13" x2="25" y2="17" stroke="#ff6600" stroke-width="0.8" opacity="0.6"/>
+</svg>

--- a/web/public/sprites/golem-foundry.svg
+++ b/web/public/sprites/golem-foundry.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="14" ry="1.5" fill="#1a1a1a" opacity="0.5"/>
+  <!-- Large industrial foundry base -->
+  <rect x="1" y="18" width="30" height="12" rx="1" fill="#4a4a4a"/>
+  <!-- Main hall -->
+  <rect x="3" y="9" width="26" height="11" rx="1" fill="#5a5a5a"/>
+  <!-- Large rooftop with multi-chimney array -->
+  <polygon points="1,9 16,2 31,9" fill="#3a3a3a"/>
+  <polygon points="3,9 16,4 29,9" fill="#4a4a4a"/>
+  <!-- Three chimneys -->
+  <rect x="7" y="2" width="4" height="8" rx="0.5" fill="#4a4a4a"/>
+  <rect x="14" y="1" width="4" height="9" rx="0.5" fill="#4a4a4a"/>
+  <rect x="21" y="2" width="4" height="8" rx="0.5" fill="#4a4a4a"/>
+  <!-- Heavy smoke columns -->
+  <ellipse cx="9" cy="2" rx="3" ry="2" fill="#6a6a6a" opacity="0.6"/>
+  <ellipse cx="9" cy="0" rx="2" ry="1.5" fill="#5a5a5a" opacity="0.4"/>
+  <ellipse cx="16" cy="1" rx="3" ry="2" fill="#6a6a6a" opacity="0.6"/>
+  <ellipse cx="16" cy="-1" rx="2" ry="1.5" fill="#5a5a5a" opacity="0.4"/>
+  <ellipse cx="23" cy="2" rx="3" ry="2" fill="#6a6a6a" opacity="0.6"/>
+  <!-- Foundry vents with molten glow -->
+  <circle cx="8" cy="12" r="2.5" fill="#1a1a1a"/>
+  <circle cx="8" cy="12" r="1.8" fill="#cc4400" opacity="0.8"/>
+  <circle cx="8" cy="12" r="1" fill="#ff8800" opacity="0.9"/>
+  <circle cx="24" cy="12" r="2.5" fill="#1a1a1a"/>
+  <circle cx="24" cy="12" r="1.8" fill="#cc4400" opacity="0.8"/>
+  <circle cx="24" cy="12" r="1" fill="#ff8800" opacity="0.9"/>
+  <!-- Completed golem displayed at front -->
+  <rect x="13" y="20" width="6" height="8" rx="0.5" fill="#6a6a7a"/>
+  <ellipse cx="16" cy="19" rx="3" ry="2.5" fill="#7a7a8a"/>
+  <!-- Golem eye slits -->
+  <line x1="14" y1="19" x2="15.5" y2="19" stroke="#ff4400" stroke-width="0.8"/>
+  <line x1="16.5" y1="19" x2="18" y2="19" stroke="#ff4400" stroke-width="0.8"/>
+</svg>

--- a/web/public/sprites/grand-dragon-lair.svg
+++ b/web/public/sprites/grand-dragon-lair.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="14" ry="1.5" fill="#1a0a00" opacity="0.6"/>
+  <!-- Mountain cave base -->
+  <polygon points="1,30 5,16 12,20 16,12 20,20 27,16 31,30" fill="#5a3a1a"/>
+  <!-- Cave entrance (grand arch) -->
+  <ellipse cx="16" cy="26" rx="10" ry="8" fill="#1a0800"/>
+  <ellipse cx="16" cy="28" rx="9" ry="6" fill="#1a0800"/>
+  <!-- Dragon glow deep within -->
+  <ellipse cx="16" cy="28" rx="7" ry="4" fill="#aa2200" opacity="0.5"/>
+  <ellipse cx="16" cy="29" rx="5" ry="2.5" fill="#dd4400" opacity="0.4"/>
+  <ellipse cx="16" cy="30" rx="3" ry="1.5" fill="#ff8800" opacity="0.3"/>
+  <!-- Dragon silhouette in lair -->
+  <path d="M8,28 Q12,22 16,24 Q20,22 24,28" fill="#2a1200" opacity="0.8"/>
+  <!-- Dragon eyes -->
+  <circle cx="13" cy="25" r="1.2" fill="#ffaa00" opacity="0.9"/>
+  <circle cx="19" cy="25" r="1.2" fill="#ffaa00" opacity="0.9"/>
+  <!-- Gold treasure glint at cave floor -->
+  <ellipse cx="16" cy="30" rx="6" ry="1" fill="#cc8800" opacity="0.4"/>
+  <circle cx="12" cy="30" r="0.8" fill="#ffaa00" opacity="0.5"/>
+  <circle cx="20" cy="30" r="0.6" fill="#ffaa00" opacity="0.5"/>
+  <!-- Mountain rock textures -->
+  <path d="M1,30 Q5,22 8,26" fill="none" stroke="#3a2a1a" stroke-width="1" opacity="0.5"/>
+  <path d="M31,30 Q27,22 24,26" fill="none" stroke="#3a2a1a" stroke-width="1" opacity="0.5"/>
+  <!-- Bone trophies on cave entrance -->
+  <line x1="7" y1="21" x2="7" y2="25" stroke="#ccbb99" stroke-width="1.2"/>
+  <ellipse cx="7" cy="20" rx="1.5" ry="1.2" fill="#ccbb99"/>
+  <line x1="25" y1="21" x2="25" y2="25" stroke="#ccbb99" stroke-width="1.2"/>
+  <ellipse cx="25" cy="20" rx="1.5" ry="1.2" fill="#ccbb99"/>
+  <!-- Smoke/steam wisps -->
+  <circle cx="10" cy="14" r="1.5" fill="#8a6a4a" opacity="0.3"/>
+  <circle cx="22" cy="13" r="1.2" fill="#8a6a4a" opacity="0.3"/>
+</svg>

--- a/web/public/sprites/griffin-aerie.svg
+++ b/web/public/sprites/griffin-aerie.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="11" ry="1.5" fill="#1a1a0a" opacity="0.5"/>
+  <!-- Rocky cliff pillar -->
+  <rect x="10" y="16" width="12" height="14" rx="2" fill="#6a6a5a"/>
+  <!-- Cliff texture -->
+  <line x1="10" y1="20" x2="22" y2="20" stroke="#5a5a4a" stroke-width="0.6"/>
+  <line x1="10" y1="25" x2="22" y2="25" stroke="#5a5a4a" stroke-width="0.6"/>
+  <!-- Nest platform on top -->
+  <ellipse cx="16" cy="16" rx="10" ry="3" fill="#8a6a3a"/>
+  <ellipse cx="16" cy="15" rx="9" ry="2.5" fill="#6a4a1a"/>
+  <!-- Nest twigs/straw detail -->
+  <path d="M8,15 Q12,12 16,14 Q20,12 24,15" fill="none" stroke="#9a7a4a" stroke-width="1"/>
+  <path d="M9,16 Q13,14 16,15 Q19,14 23,16" fill="none" stroke="#7a5a2a" stroke-width="0.8"/>
+  <!-- Eggs in nest -->
+  <ellipse cx="13" cy="14" rx="2.5" ry="1.8" fill="#ddd0aa"/>
+  <ellipse cx="19" cy="14" rx="2.5" ry="1.8" fill="#ddcc99"/>
+  <!-- Griffin silhouette flying above -->
+  <path d="M8,8 Q16,4 24,8" fill="none" stroke="#8a7a5a" stroke-width="1.5"/>
+  <!-- Griffin wings -->
+  <path d="M8,8 Q4,5 6,3 Q10,6 8,8Z" fill="#aa9966" opacity="0.8"/>
+  <path d="M24,8 Q28,5 26,3 Q22,6 24,8Z" fill="#aa9966" opacity="0.8"/>
+  <!-- Griffin body -->
+  <ellipse cx="16" cy="8" rx="4" ry="2.5" fill="#aa9966"/>
+  <!-- Griffin head (eagle) -->
+  <circle cx="20" cy="7" r="2" fill="#cc9933"/>
+  <polygon points="22,6 25,7 22,8" fill="#cc8800"/>
+  <!-- Feathers detail -->
+  <line x1="10" y1="8" x2="14" y2="6" stroke="#9a8855" stroke-width="0.6"/>
+  <line x1="22" y1="8" x2="18" y2="6" stroke="#9a8855" stroke-width="0.6"/>
+</svg>

--- a/web/public/sprites/guardian-post.svg
+++ b/web/public/sprites/guardian-post.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="10" ry="1.5" fill="#1a1a1a" opacity="0.5"/>
+  <!-- Post base platform -->
+  <rect x="8" y="24" width="16" height="6" rx="1" fill="#5a5a6a"/>
+  <!-- Guard post tower -->
+  <rect x="11" y="10" width="10" height="16" rx="1" fill="#6a6a7a"/>
+  <!-- Roof overhang -->
+  <rect x="8" y="9" width="16" height="3" rx="0.5" fill="#5a5a6a"/>
+  <!-- Pointed roof -->
+  <polygon points="7,9 16,2 25,9" fill="#4a4a5a"/>
+  <polygon points="9,9 16,4 23,9" fill="#5a5a6a"/>
+  <!-- Arrow slit windows -->
+  <rect x="13" y="13" width="3" height="5" rx="0.3" fill="#2a2a3a"/>
+  <path d="M13,13 Q14.5,11 16,13" fill="#2a2a3a"/>
+  <!-- Shield emblem on front -->
+  <polygon points="16,17 12,19 12,23 16,25 20,23 20,19" fill="#7a7a8a"/>
+  <polygon points="16,18 13,20 13,23 16,24.5 19,23 19,20" fill="#4a4a5a"/>
+  <!-- Cross on shield -->
+  <line x1="16" y1="19" x2="16" y2="24" stroke="#aaaacc" stroke-width="0.8"/>
+  <line x1="13.5" y1="21.5" x2="18.5" y2="21.5" stroke="#aaaacc" stroke-width="0.8"/>
+  <!-- Flagpole with pennant -->
+  <line x1="16" y1="2" x2="16" y2="0" stroke="#4a4a5a" stroke-width="0.8"/>
+  <polygon points="16,0 22,1 16,2" fill="#4a6a9a"/>
+  <!-- Torch lights flanking -->
+  <circle cx="9" cy="11" r="1.5" fill="#ffaa00" opacity="0.7"/>
+  <circle cx="23" cy="11" r="1.5" fill="#ffaa00" opacity="0.7"/>
+</svg>

--- a/web/public/sprites/hauler-s-dock.svg
+++ b/web/public/sprites/hauler-s-dock.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Water/sea -->
+  <rect x="0" y="22" width="32" height="10" fill="#0a2a4a"/>
+  <!-- Water shimmer -->
+  <path d="M0,24 Q8,22 16,24 Q24,26 32,24" fill="none" stroke="#1a4a6a" stroke-width="0.8" opacity="0.6"/>
+  <!-- Ground shadow -->
+  <ellipse cx="8" cy="31" rx="8" ry="1" fill="#0a1a2a" opacity="0.4"/>
+  <!-- Dock platform/pier -->
+  <rect x="0" y="20" width="22" height="4" rx="0.5" fill="#6a4a2a"/>
+  <!-- Dock planks -->
+  <line x1="4" y1="20" x2="4" y2="24" stroke="#5a3a1a" stroke-width="0.6"/>
+  <line x1="8" y1="20" x2="8" y2="24" stroke="#5a3a1a" stroke-width="0.6"/>
+  <line x1="12" y1="20" x2="12" y2="24" stroke="#5a3a1a" stroke-width="0.6"/>
+  <line x1="16" y1="20" x2="16" y2="24" stroke="#5a3a1a" stroke-width="0.6"/>
+  <!-- Dock warehouse building -->
+  <rect x="0" y="10" width="14" height="12" rx="1" fill="#7a6a4a"/>
+  <!-- Warehouse roof -->
+  <polygon points="0,10 7,4 14,10" fill="#5a4a2a"/>
+  <!-- Warehouse door (loading bay) -->
+  <rect x="4" y="14" width="6" height="8" rx="0.5" fill="#3a2a1a"/>
+  <!-- Cargo crates stacked -->
+  <rect x="16" y="15" width="5" height="5" rx="0.3" fill="#8a6a3a"/>
+  <rect x="17" y="11" width="5" height="5" rx="0.3" fill="#7a5a2a"/>
+  <rect x="22" y="17" width="5" height="7" rx="0.3" fill="#9a7a4a"/>
+  <!-- Crane/pulley arm -->
+  <line x1="11" y1="4" x2="11" y2="10" stroke="#5a4a2a" stroke-width="1.2"/>
+  <line x1="7" y1="4" x2="18" y2="4" stroke="#5a4a2a" stroke-width="1"/>
+  <line x1="18" y1="4" x2="18" y2="12" stroke="#5a4a2a" stroke-width="0.8"/>
+  <!-- Rope with cargo -->
+  <line x1="15" y1="4" x2="15" y2="13" stroke="#8a7a5a" stroke-width="0.6"/>
+  <rect x="13" y="13" width="4" height="4" rx="0.3" fill="#7a6a3a"/>
+  <!-- Boat at dock -->
+  <path d="M0,26 Q6,24 12,26 Q10,30 2,30 Q0,28 0,26Z" fill="#5a4a2a"/>
+  <line x1="6" y1="24" x2="6" y2="20" stroke="#6a5a2a" stroke-width="0.8"/>
+</svg>

--- a/web/public/sprites/hulk-growth.svg
+++ b/web/public/sprites/hulk-growth.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#0a2a0a" opacity="0.5"/>
+  <!-- Massive overgrown root mound -->
+  <ellipse cx="16" cy="27" rx="14" ry="6" fill="#2a5a1a"/>
+  <!-- Giant mushroom cap -->
+  <ellipse cx="16" cy="18" rx="13" ry="7" fill="#5a8a2a"/>
+  <ellipse cx="16" cy="17" rx="12" ry="6" fill="#6a9a3a"/>
+  <!-- Mushroom highlight -->
+  <ellipse cx="12" cy="15" rx="4" ry="3" fill="#7aaa4a" opacity="0.5"/>
+  <!-- Mushroom stalk/trunk -->
+  <rect x="12" y="18" width="8" height="12" rx="2" fill="#4a7a2a"/>
+  <!-- Oversized pulsing vines -->
+  <path d="M3,28 Q6,20 10,18" fill="none" stroke="#3a6a1a" stroke-width="2.5"/>
+  <path d="M29,28 Q26,20 22,18" fill="none" stroke="#3a6a1a" stroke-width="2.5"/>
+  <!-- Growth spores/bubbles -->
+  <circle cx="5" cy="22" r="1.5" fill="#88cc44" opacity="0.6"/>
+  <circle cx="27" cy="21" r="1.2" fill="#88cc44" opacity="0.5"/>
+  <circle cx="8" cy="15" r="1" fill="#aadd66" opacity="0.5"/>
+  <circle cx="24" cy="14" r="1" fill="#aadd66" opacity="0.5"/>
+  <!-- Toxic drips from cap edge -->
+  <circle cx="5" cy="21" r="0.8" fill="#aaff00" opacity="0.6"/>
+  <circle cx="10" cy="23" r="0.6" fill="#aaff00" opacity="0.5"/>
+  <circle cx="22" cy="23" r="0.7" fill="#aaff00" opacity="0.5"/>
+  <circle cx="27" cy="21" r="0.8" fill="#aaff00" opacity="0.6"/>
+  <!-- Spots on cap -->
+  <circle cx="10" cy="16" r="2" fill="#ffffff" opacity="0.2"/>
+  <circle cx="19" cy="14" r="1.5" fill="#ffffff" opacity="0.2"/>
+  <circle cx="23" cy="17" r="1.2" fill="#ffffff" opacity="0.15"/>
+</svg>

--- a/web/public/sprites/ice-cathedral.svg
+++ b/web/public/sprites/ice-cathedral.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="14" ry="1.5" fill="#0a1a2a" opacity="0.5"/>
+  <!-- Cathedral base -->
+  <rect x="3" y="16" width="26" height="14" rx="1" fill="#4a6a7a"/>
+  <!-- Ice block texture -->
+  <line x1="3" y1="20" x2="29" y2="20" stroke="#3a5a6a" stroke-width="0.6"/>
+  <line x1="3" y1="24" x2="29" y2="24" stroke="#3a5a6a" stroke-width="0.6"/>
+  <line x1="3" y1="28" x2="29" y2="28" stroke="#3a5a6a" stroke-width="0.6"/>
+  <!-- Side aisles -->
+  <rect x="3" y="14" width="7" height="16" rx="0.5" fill="#5a7a8a"/>
+  <rect x="22" y="14" width="7" height="16" rx="0.5" fill="#5a7a8a"/>
+  <!-- Central nave roof (high pointed arch) -->
+  <polygon points="8,14 16,4 24,14" fill="#3a5a6a"/>
+  <polygon points="10,14 16,6 22,14" fill="#5a7a8a"/>
+  <!-- Side roof spires -->
+  <polygon points="3,14 5,8 7,14" fill="#3a5a6a"/>
+  <polygon points="25,14 27,8 29,14" fill="#3a5a6a"/>
+  <!-- Ice spire tips -->
+  <polygon points="14,6 16,1 18,6 16,8" fill="#aaddff"/>
+  <polygon points="4,8 5,4 6,8 5,9" fill="#88ccee"/>
+  <polygon points="26,8 27,4 28,8 27,9" fill="#88ccee"/>
+  <!-- Rose window (circular stained glass) -->
+  <circle cx="16" cy="10" r="3" fill="#1a2a3a"/>
+  <circle cx="16" cy="10" r="2" fill="#2a6a8a" opacity="0.7"/>
+  <circle cx="16" cy="10" r="1" fill="#6aaabb" opacity="0.8"/>
+  <line x1="13" y1="10" x2="19" y2="10" stroke="#4a8a9a" stroke-width="0.6"/>
+  <line x1="16" y1="7" x2="16" y2="13" stroke="#4a8a9a" stroke-width="0.6"/>
+  <!-- Arched entrance -->
+  <path d="M13,30 L13,22 Q16,18 19,22 L19,30 Z" fill="#1a2a3a"/>
+  <!-- Icicles hanging from eaves -->
+  <polygon points="8,14 9,18 10,14" fill="#88ccee"/>
+  <polygon points="11,14 12,19 13,14" fill="#88ccee"/>
+  <polygon points="19,14 20,18 21,14" fill="#88ccee"/>
+  <polygon points="22,14 23,17 24,14" fill="#88ccee"/>
+</svg>

--- a/web/public/sprites/imp-array.svg
+++ b/web/public/sprites/imp-array.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#1a0a1a" opacity="0.5"/>
+  <!-- Dark stone platform -->
+  <rect x="2" y="22" width="28" height="8" rx="1" fill="#3a2a4a"/>
+  <!-- Summoning circle on platform -->
+  <circle cx="16" cy="25" r="10" fill="none" stroke="#8800cc" stroke-width="0.8" opacity="0.6"/>
+  <circle cx="16" cy="25" r="7" fill="none" stroke="#6600aa" stroke-width="0.5" opacity="0.5"/>
+  <!-- Rune marks on circle -->
+  <line x1="16" y1="15" x2="16" y2="22" stroke="#8800cc" stroke-width="0.6" opacity="0.7"/>
+  <line x1="16" y1="28" x2="16" y2="35" stroke="#8800cc" stroke-width="0.6" opacity="0.7"/>
+  <line x1="6" y1="25" x2="13" y2="25" stroke="#8800cc" stroke-width="0.6" opacity="0.7"/>
+  <line x1="19" y1="25" x2="26" y2="25" stroke="#8800cc" stroke-width="0.6" opacity="0.7"/>
+  <!-- Multiple imp cage pillars -->
+  <rect x="4" y="10" width="4" height="14" rx="0.5" fill="#4a3a5a"/>
+  <rect x="14" y="8" width="4" height="16" rx="0.5" fill="#4a3a5a"/>
+  <rect x="24" y="10" width="4" height="14" rx="0.5" fill="#4a3a5a"/>
+  <!-- Cage bars connecting pillars -->
+  <line x1="8" y1="12" x2="14" y2="10" stroke="#5a4a6a" stroke-width="0.7"/>
+  <line x1="8" y1="15" x2="14" y2="13" stroke="#5a4a6a" stroke-width="0.6"/>
+  <line x1="18" y1="10" x2="24" y2="12" stroke="#5a4a6a" stroke-width="0.7"/>
+  <line x1="18" y1="13" x2="24" y2="15" stroke="#5a4a6a" stroke-width="0.6"/>
+  <!-- Imp silhouettes (small, winged) -->
+  <ellipse cx="6" cy="9" rx="2" ry="1.5" fill="#6a1a6a"/>
+  <polygon points="4,8 3,6 6,7" fill="#6a1a6a" opacity="0.8"/>
+  <polygon points="8,8 9,6 6,7" fill="#6a1a6a" opacity="0.8"/>
+  <circle cx="6" cy="8" r="0.6" fill="#ff4444" opacity="0.8"/>
+  <ellipse cx="16" cy="7" rx="2" ry="1.5" fill="#7a1a7a"/>
+  <circle cx="16" cy="6" r="0.6" fill="#ff4444" opacity="0.8"/>
+  <ellipse cx="26" cy="9" rx="2" ry="1.5" fill="#6a1a6a"/>
+  <circle cx="26" cy="8" r="0.6" fill="#ff4444" opacity="0.8"/>
+  <!-- Dark energy wisps -->
+  <circle cx="10" cy="20" r="0.8" fill="#aa44cc" opacity="0.5"/>
+  <circle cx="22" cy="19" r="0.7" fill="#aa44cc" opacity="0.5"/>
+</svg>

--- a/web/public/sprites/inferno-lair.svg
+++ b/web/public/sprites/inferno-lair.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#2a0a00" opacity="0.6"/>
+  <!-- Volcanic rock base -->
+  <polygon points="1,30 5,18 11,22 16,14 21,22 27,18 31,30" fill="#3a1a0a"/>
+  <!-- Lava channels on rock -->
+  <path d="M5,26 Q8,22 11,24" fill="none" stroke="#dd4400" stroke-width="1.5" opacity="0.7"/>
+  <path d="M21,24 Q24,22 27,26" fill="none" stroke="#dd4400" stroke-width="1.5" opacity="0.7"/>
+  <!-- Cave entrance with hellfire -->
+  <ellipse cx="16" cy="26" rx="9" ry="7" fill="#1a0000"/>
+  <!-- Inferno glow -->
+  <ellipse cx="16" cy="27" rx="7" ry="5" fill="#aa1100" opacity="0.7"/>
+  <ellipse cx="16" cy="28" rx="5" ry="3.5" fill="#dd3300" opacity="0.6"/>
+  <ellipse cx="16" cy="29" rx="3" ry="2" fill="#ff6600" opacity="0.7"/>
+  <ellipse cx="16" cy="30" rx="1.5" ry="1" fill="#ffcc00" opacity="0.8"/>
+  <!-- Flame pillars -->
+  <path d="M9,24 Q11,18 13,22 Q11,26 9,24Z" fill="#ff4400" opacity="0.6"/>
+  <path d="M23,24 Q21,18 19,22 Q21,26 23,24Z" fill="#ff4400" opacity="0.6"/>
+  <!-- Lava pools on ground -->
+  <ellipse cx="6" cy="29" rx="4" ry="1.5" fill="#cc3300" opacity="0.6"/>
+  <ellipse cx="26" cy="29" rx="4" ry="1.5" fill="#cc3300" opacity="0.6"/>
+  <!-- Smoke rising -->
+  <circle cx="12" cy="12" r="2" fill="#4a2a1a" opacity="0.4"/>
+  <circle cx="16" cy="9" r="2.5" fill="#4a2a1a" opacity="0.3"/>
+  <circle cx="20" cy="11" r="1.5" fill="#4a2a1a" opacity="0.4"/>
+  <!-- Fire sparks -->
+  <circle cx="8" cy="16" r="0.8" fill="#ff6600" opacity="0.6"/>
+  <circle cx="24" cy="15" r="0.7" fill="#ff4400" opacity="0.5"/>
+  <circle cx="16" cy="13" r="0.8" fill="#ffaa00" opacity="0.6"/>
+</svg>

--- a/web/public/sprites/iron-barracks.svg
+++ b/web/public/sprites/iron-barracks.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="14" ry="1.5" fill="#1a1a1a" opacity="0.5"/>
+  <!-- Barracks base/walls -->
+  <rect x="2" y="14" width="28" height="16" rx="1" fill="#4a4a5a"/>
+  <!-- Iron plate texture -->
+  <line x1="2" y1="18" x2="30" y2="18" stroke="#3a3a4a" stroke-width="0.7"/>
+  <line x1="2" y1="22" x2="30" y2="22" stroke="#3a3a4a" stroke-width="0.7"/>
+  <line x1="2" y1="26" x2="30" y2="26" stroke="#3a3a4a" stroke-width="0.7"/>
+  <line x1="8" y1="14" x2="8" y2="30" stroke="#3a3a4a" stroke-width="0.5"/>
+  <line x1="24" y1="14" x2="24" y2="30" stroke="#3a3a4a" stroke-width="0.5"/>
+  <!-- Rivet details -->
+  <circle cx="4" cy="16" r="0.7" fill="#6a6a7a"/>
+  <circle cx="4" cy="20" r="0.7" fill="#6a6a7a"/>
+  <circle cx="28" cy="16" r="0.7" fill="#6a6a7a"/>
+  <circle cx="28" cy="20" r="0.7" fill="#6a6a7a"/>
+  <!-- Peaked iron roof -->
+  <polygon points="0,14 16,5 32,14" fill="#3a3a4a"/>
+  <polygon points="2,14 16,7 30,14" fill="#4a4a5a"/>
+  <!-- Corner towers -->
+  <rect x="0" y="10" width="6" height="20" rx="0.5" fill="#5a5a6a"/>
+  <rect x="26" y="10" width="6" height="20" rx="0.5" fill="#5a5a6a"/>
+  <!-- Tower battlements -->
+  <rect x="0" y="8" width="2.5" height="3" rx="0.3" fill="#6a6a7a"/>
+  <rect x="3.5" y="8" width="2.5" height="3" rx="0.3" fill="#6a6a7a"/>
+  <rect x="26" y="8" width="2.5" height="3" rx="0.3" fill="#6a6a7a"/>
+  <rect x="29.5" y="8" width="2.5" height="3" rx="0.3" fill="#6a6a7a"/>
+  <!-- Entrance gate -->
+  <path d="M13,30 L13,20 Q16,16 19,20 L19,30 Z" fill="#1a1a2a"/>
+  <!-- Crossed swords emblem above gate -->
+  <line x1="13" y1="16" x2="19" y2="12" stroke="#8a8a9a" stroke-width="1"/>
+  <line x1="19" y1="16" x2="13" y2="12" stroke="#8a8a9a" stroke-width="1"/>
+  <!-- Iron banner -->
+  <line x1="16" y1="5" x2="16" y2="2" stroke="#3a3a4a" stroke-width="0.8"/>
+  <polygon points="16,2 22,3.5 16,5" fill="#6a3a3a"/>
+</svg>

--- a/web/public/sprites/iron-hall.svg
+++ b/web/public/sprites/iron-hall.svg
@@ -1,0 +1,37 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="14" ry="1.5" fill="#1a1a1a" opacity="0.5"/>
+  <!-- Massive iron hall base -->
+  <rect x="1" y="14" width="30" height="16" rx="1" fill="#4a4a5a"/>
+  <!-- Iron plate lines (horizontal) -->
+  <line x1="1" y1="19" x2="31" y2="19" stroke="#3a3a4a" stroke-width="0.8"/>
+  <line x1="1" y1="24" x2="31" y2="24" stroke="#3a3a4a" stroke-width="0.8"/>
+  <line x1="1" y1="28" x2="31" y2="28" stroke="#3a3a4a" stroke-width="0.8"/>
+  <!-- Iron plate lines (vertical) -->
+  <line x1="7" y1="14" x2="7" y2="30" stroke="#3a3a4a" stroke-width="0.6"/>
+  <line x1="16" y1="14" x2="16" y2="30" stroke="#3a3a4a" stroke-width="0.6"/>
+  <line x1="25" y1="14" x2="25" y2="30" stroke="#3a3a4a" stroke-width="0.6"/>
+  <!-- Rivet grid -->
+  <circle cx="3" cy="17" r="0.8" fill="#6a6a7a"/>
+  <circle cx="3" cy="22" r="0.8" fill="#6a6a7a"/>
+  <circle cx="29" cy="17" r="0.8" fill="#6a6a7a"/>
+  <circle cx="29" cy="22" r="0.8" fill="#6a6a7a"/>
+  <!-- Flat iron roof with raised centre -->
+  <rect x="0" y="11" width="32" height="4" fill="#3a3a4a"/>
+  <rect x="6" y="8" width="20" height="4" rx="0.5" fill="#4a4a5a"/>
+  <rect x="10" y="6" width="12" height="3" rx="0.5" fill="#3a3a4a"/>
+  <!-- Large double doors (iron-banded) -->
+  <rect x="11" y="18" width="6" height="12" rx="0.3" fill="#2a2a3a"/>
+  <rect x="17" y="18" width="6" height="12" rx="0.3" fill="#2a2a3a"/>
+  <!-- Door handle rings -->
+  <circle cx="16" cy="24" r="1.2" fill="none" stroke="#6a6a7a" stroke-width="0.8"/>
+  <circle cx="18" cy="24" r="1.2" fill="none" stroke="#6a6a7a" stroke-width="0.8"/>
+  <!-- Tall narrow windows -->
+  <rect x="4" y="16" width="3" height="7" rx="0.3" fill="#1a1a2a"/>
+  <rect x="25" y="16" width="3" height="7" rx="0.3" fill="#1a1a2a"/>
+  <!-- Iron sigil above door -->
+  <polygon points="16,14 14,16 16,18 18,16" fill="#6a6a7a"/>
+  <!-- Torch sconces -->
+  <circle cx="9" cy="15" r="1.5" fill="#ffaa00" opacity="0.7"/>
+  <circle cx="23" cy="15" r="1.5" fill="#ffaa00" opacity="0.7"/>
+</svg>

--- a/web/public/sprites/jungle-hollow.svg
+++ b/web/public/sprites/jungle-hollow.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#0a1a0a" opacity="0.5"/>
+  <!-- Dense jungle foliage canopy -->
+  <ellipse cx="16" cy="14" rx="15" ry="10" fill="#1a5a0a"/>
+  <ellipse cx="8" cy="16" rx="8" ry="7" fill="#2a6a1a"/>
+  <ellipse cx="24" cy="16" rx="8" ry="7" fill="#2a6a1a"/>
+  <ellipse cx="16" cy="12" rx="10" ry="8" fill="#3a7a2a"/>
+  <!-- Hollow entrance in tree base -->
+  <ellipse cx="16" cy="26" rx="14" ry="7" fill="#2a4a1a"/>
+  <ellipse cx="16" cy="27" rx="7" ry="5" fill="#0a1a00"/>
+  <!-- Tree trunks framing hollow -->
+  <rect x="5" y="16" width="5" height="14" rx="2" fill="#3a2a0a"/>
+  <rect x="22" y="16" width="5" height="14" rx="2" fill="#3a2a0a"/>
+  <!-- Glowing eyes in hollow darkness -->
+  <circle cx="13" cy="26" r="1" fill="#aaff00" opacity="0.8"/>
+  <circle cx="19" cy="26" r="1" fill="#aaff00" opacity="0.8"/>
+  <!-- Tropical flowers on canopy -->
+  <circle cx="6" cy="12" r="1.5" fill="#ff4488" opacity="0.7"/>
+  <circle cx="26" cy="13" r="1.5" fill="#ff8844" opacity="0.7"/>
+  <circle cx="16" cy="8" r="1.5" fill="#ffcc00" opacity="0.7"/>
+  <!-- Vines hanging -->
+  <path d="M9,16 Q8,22 9,28" fill="none" stroke="#2a7a1a" stroke-width="1"/>
+  <path d="M23,16 Q24,22 23,28" fill="none" stroke="#2a7a1a" stroke-width="1"/>
+  <path d="M15,12 Q14,18 15,26" fill="none" stroke="#2a7a1a" stroke-width="0.8"/>
+  <!-- Firefly glow points in hollow -->
+  <circle cx="11" cy="22" r="0.6" fill="#aaff44" opacity="0.6"/>
+  <circle cx="21" cy="23" r="0.5" fill="#aaff44" opacity="0.5"/>
+</svg>

--- a/web/public/sprites/lava-pool.svg
+++ b/web/public/sprites/lava-pool.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#2a0a00" opacity="0.6"/>
+  <!-- Rocky rim of pool -->
+  <ellipse cx="16" cy="24" rx="14" ry="8" fill="#3a1a0a"/>
+  <ellipse cx="16" cy="23" rx="13" ry="7" fill="#4a2a1a"/>
+  <!-- Lava pool surface -->
+  <ellipse cx="16" cy="24" rx="10" ry="5.5" fill="#cc2200"/>
+  <ellipse cx="16" cy="24" rx="8" ry="4.5" fill="#ee4400"/>
+  <!-- Lava flow lines (cooling crust pattern) -->
+  <path d="M8,22 Q12,20 16,22 Q20,24 24,22" fill="none" stroke="#aa1100" stroke-width="1"/>
+  <path d="M10,25 Q13,23 16,25 Q19,23 22,25" fill="none" stroke="#991100" stroke-width="0.8"/>
+  <!-- Hot spots -->
+  <circle cx="12" cy="23" r="2" fill="#ff8800" opacity="0.7"/>
+  <circle cx="20" cy="25" r="2.5" fill="#ff6600" opacity="0.7"/>
+  <circle cx="16" cy="21" r="1.5" fill="#ffaa00" opacity="0.8"/>
+  <!-- Lava bubbles -->
+  <circle cx="14" cy="24" r="1.2" fill="#ff4400" opacity="0.6"/>
+  <circle cx="18" cy="23" r="1" fill="#ff6600" opacity="0.6"/>
+  <circle cx="16" cy="26" r="0.8" fill="#ff8800" opacity="0.5"/>
+  <!-- Steam/gas vents -->
+  <path d="M9,20 Q10,16 11,14" fill="none" stroke="#8a6a4a" stroke-width="1" opacity="0.4"/>
+  <path d="M23,20 Q22,16 21,14" fill="none" stroke="#8a6a4a" stroke-width="1" opacity="0.4"/>
+  <!-- Rock fragments in lava -->
+  <polygon points="9,23 11,21 12,24" fill="#2a1a0a" opacity="0.5"/>
+  <polygon points="20,23 22,22 21,25" fill="#2a1a0a" opacity="0.5"/>
+  <!-- Glow from below rocks -->
+  <circle cx="7" cy="27" r="1" fill="#ff6600" opacity="0.3"/>
+  <circle cx="25" cy="27" r="1" fill="#ff6600" opacity="0.3"/>
+</svg>

--- a/web/public/sprites/lich-spire.svg
+++ b/web/public/sprites/lich-spire.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="10" ry="1.5" fill="#0a0a1a" opacity="0.6"/>
+  <!-- Bone/necromantic base -->
+  <rect x="8" y="23" width="16" height="7" rx="1" fill="#2a2a3a"/>
+  <!-- Skull decorations at base corners -->
+  <ellipse cx="9" cy="23" rx="1.5" ry="1.2" fill="#ccbb99"/>
+  <ellipse cx="23" cy="23" rx="1.5" ry="1.2" fill="#ccbb99"/>
+  <!-- Main undead spire -->
+  <rect x="11" y="9" width="10" height="16" rx="0.5" fill="#3a2a4a"/>
+  <!-- Spire taper -->
+  <polygon points="9,9 16,1 23,9" fill="#2a1a3a"/>
+  <polygon points="11,9 16,3 21,9" fill="#3a2a4a"/>
+  <!-- Dark crystal tip -->
+  <polygon points="14,3 16,0 18,3 16,5" fill="#6600cc"/>
+  <!-- Death rune glows on spire body -->
+  <line x1="11" y1="13" x2="21" y2="13" stroke="#8800cc" stroke-width="0.8" opacity="0.7"/>
+  <line x1="11" y1="17" x2="21" y2="17" stroke="#6600aa" stroke-width="0.6" opacity="0.6"/>
+  <!-- Skull windows -->
+  <ellipse cx="14" cy="20" rx="2" ry="1.5" fill="#0a0a1a"/>
+  <circle cx="13" cy="20" r="0.6" fill="#8800cc" opacity="0.7"/>
+  <circle cx="15" cy="20" r="0.6" fill="#8800cc" opacity="0.7"/>
+  <ellipse cx="18" cy="20" rx="2" ry="1.5" fill="#0a0a1a"/>
+  <circle cx="17" cy="20" r="0.6" fill="#8800cc" opacity="0.7"/>
+  <circle cx="19" cy="20" r="0.6" fill="#8800cc" opacity="0.7"/>
+  <!-- Undead energy orbs orbiting -->
+  <circle cx="8" cy="13" r="1.5" fill="#4400aa" opacity="0.6"/>
+  <circle cx="8" cy="13" r="0.8" fill="#8800ff" opacity="0.8"/>
+  <circle cx="24" cy="16" r="1.5" fill="#4400aa" opacity="0.6"/>
+  <circle cx="24" cy="16" r="0.8" fill="#8800ff" opacity="0.8"/>
+  <!-- Dark particle wisps -->
+  <circle cx="10" cy="7" r="0.7" fill="#6600cc" opacity="0.5"/>
+  <circle cx="22" cy="5" r="0.6" fill="#8800ff" opacity="0.5"/>
+</svg>

--- a/web/public/sprites/lightning-tower.svg
+++ b/web/public/sprites/lightning-tower.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="9" ry="1.5" fill="#1a1a0a" opacity="0.5"/>
+  <!-- Stone tower base -->
+  <rect x="10" y="20" width="12" height="10" rx="1" fill="#5a5a4a"/>
+  <!-- Tower shaft -->
+  <rect x="12" y="8" width="8" height="14" rx="0.5" fill="#6a6a5a"/>
+  <!-- Metal conductor ring at top -->
+  <rect x="9" y="7" width="14" height="3" rx="0.5" fill="#7a7a8a"/>
+  <!-- Conductor spikes -->
+  <line x1="11" y1="7" x2="9" y2="3" stroke="#8a8a9a" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="14" y1="7" x2="13" y2="2" stroke="#aaaaaa" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="16" y1="7" x2="16" y2="1" stroke="#cccccc" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="18" y1="7" x2="19" y2="2" stroke="#aaaaaa" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="21" y1="7" x2="23" y2="3" stroke="#8a8a9a" stroke-width="1.5" stroke-linecap="round"/>
+  <!-- Lightning bolt descending from tip -->
+  <path d="M16,1 L13,8 L16,7 L13,14 L17,12 L14,18" stroke="#ffff00" stroke-width="1.5" fill="none" stroke-linecap="round" opacity="0.9"/>
+  <!-- Electrical glow around tip -->
+  <circle cx="16" cy="4" r="3" fill="#ffff00" opacity="0.15"/>
+  <circle cx="16" cy="4" r="1.5" fill="#ffff00" opacity="0.2"/>
+  <!-- Insulator rings on tower -->
+  <rect x="11" y="11" width="10" height="1.5" rx="0.5" fill="#8a8a7a"/>
+  <rect x="11" y="16" width="10" height="1.5" rx="0.5" fill="#8a8a7a"/>
+  <!-- Ground energy discharge -->
+  <ellipse cx="16" cy="30" rx="8" ry="1.5" fill="#ffffaa" opacity="0.2"/>
+  <!-- Side sparks -->
+  <line x1="9" y1="9" x2="6" y2="7" stroke="#ffff00" stroke-width="0.8" opacity="0.6"/>
+  <line x1="23" y1="9" x2="26" y2="7" stroke="#ffff00" stroke-width="0.8" opacity="0.6"/>
+</svg>

--- a/web/public/sprites/lizardman-burrow.svg
+++ b/web/public/sprites/lizardman-burrow.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#0a1a0a" opacity="0.5"/>
+  <!-- Sandy/muddy mound -->
+  <ellipse cx="16" cy="26" rx="14" ry="7" fill="#5a5a1a"/>
+  <ellipse cx="16" cy="25" rx="13" ry="6" fill="#6a6a2a"/>
+  <!-- Swamp water around mound -->
+  <ellipse cx="5" cy="29" rx="5" ry="2" fill="#1a3a1a" opacity="0.6"/>
+  <ellipse cx="27" cy="29" rx="5" ry="2" fill="#1a3a1a" opacity="0.6"/>
+  <!-- Main burrow entrance -->
+  <ellipse cx="16" cy="27" rx="5" ry="4" fill="#1a1a0a"/>
+  <!-- Secondary entrances -->
+  <ellipse cx="7" cy="28" rx="3" ry="2.5" fill="#1a1a0a"/>
+  <ellipse cx="25" cy="28" rx="3" ry="2.5" fill="#1a1a0a"/>
+  <!-- Lizardman eyes in main entrance -->
+  <circle cx="14" cy="26" r="0.9" fill="#ffcc00" opacity="0.9"/>
+  <circle cx="18" cy="26" r="0.9" fill="#ffcc00" opacity="0.9"/>
+  <!-- Lizardman eyes in side entrances -->
+  <circle cx="7" cy="28" r="0.7" fill="#aacc00" opacity="0.8"/>
+  <circle cx="25" cy="28" r="0.7" fill="#aacc00" opacity="0.8"/>
+  <!-- Bones and trophies -->
+  <line x1="5" y1="22" x2="5" y2="26" stroke="#ccbb99" stroke-width="1.2"/>
+  <line x1="4" y1="22" x2="6" y2="24" stroke="#ccbb99" stroke-width="0.8"/>
+  <line x1="27" y1="22" x2="27" y2="26" stroke="#ccbb99" stroke-width="1.2"/>
+  <line x1="26" y1="22" x2="28" y2="24" stroke="#ccbb99" stroke-width="0.8"/>
+  <!-- Mud/scale patterns on mound -->
+  <path d="M8,23 Q10,21 12,23" fill="none" stroke="#4a4a10" stroke-width="0.8" opacity="0.6"/>
+  <path d="M20,22 Q22,20 24,22" fill="none" stroke="#4a4a10" stroke-width="0.8" opacity="0.6"/>
+  <!-- Swamp grass tufts -->
+  <path d="M2,26 Q3,22 4,26" fill="none" stroke="#3a5a1a" stroke-width="1"/>
+  <path d="M28,26 Q29,22 30,26" fill="none" stroke="#3a5a1a" stroke-width="1"/>
+</svg>

--- a/web/public/sprites/lumber-camp.svg
+++ b/web/public/sprites/lumber-camp.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="14" ry="1.5" fill="#1a1a0a" opacity="0.5"/>
+  <!-- Ground -->
+  <rect x="0" y="26" width="32" height="5" fill="#4a3a1a" opacity="0.6"/>
+  <!-- Main cabin -->
+  <rect x="2" y="14" width="16" height="12" rx="1" fill="#7a5a2a"/>
+  <!-- Log texture on cabin -->
+  <line x1="2" y1="17" x2="18" y2="17" stroke="#6a4a1a" stroke-width="0.7"/>
+  <line x1="2" y1="20" x2="18" y2="20" stroke="#6a4a1a" stroke-width="0.7"/>
+  <line x1="2" y1="23" x2="18" y2="23" stroke="#6a4a1a" stroke-width="0.7"/>
+  <!-- Cabin roof -->
+  <polygon points="0,14 9,7 18,14" fill="#5a3a1a"/>
+  <polygon points="2,14 9,9 16,14" fill="#6a4a2a"/>
+  <!-- Chimney -->
+  <rect x="11" y="7" width="3" height="7" rx="0.5" fill="#5a4a3a"/>
+  <circle cx="12.5" cy="7" r="2" fill="#7a7a6a" opacity="0.4"/>
+  <!-- Cabin door -->
+  <rect x="7" y="18" width="5" height="8" rx="0.5" fill="#4a2a0a"/>
+  <!-- Stacked lumber logs to the right -->
+  <rect x="20" y="20" width="11" height="4" rx="0.5" fill="#8a6a2a"/>
+  <rect x="20" y="17" width="11" height="4" rx="0.5" fill="#9a7a3a"/>
+  <rect x="20" y="14" width="11" height="4" rx="0.5" fill="#8a6a2a"/>
+  <!-- Log end circles -->
+  <circle cx="30" cy="22" r="1.5" fill="#7a5a1a"/>
+  <circle cx="30" cy="19" r="1.5" fill="#6a4a1a"/>
+  <circle cx="30" cy="16" r="1.5" fill="#7a5a1a"/>
+  <!-- Axe leaning against logs -->
+  <line x1="19" y1="13" x2="19" y2="26" stroke="#8a6a3a" stroke-width="1.5"/>
+  <polygon points="16,14 19,13 19,17 17,17" fill="#8a8a8a"/>
+  <!-- Tree stump -->
+  <ellipse cx="5" cy="27" rx="4" ry="2" fill="#8a6a2a"/>
+  <ellipse cx="5" cy="26" rx="3.5" ry="1.5" fill="#9a7a3a"/>
+  <!-- Cut log on stump -->
+  <ellipse cx="5" cy="25" rx="3" ry="1.2" fill="#7a5a1a"/>
+</svg>

--- a/web/public/sprites/magma-den.svg
+++ b/web/public/sprites/magma-den.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#2a0a00" opacity="0.6"/>
+  <!-- Volcanic rock formation -->
+  <polygon points="2,30 6,16 12,20 16,10 20,20 26,16 30,30" fill="#2a1a0a"/>
+  <!-- Magma cracks glowing through rock -->
+  <path d="M6,24 Q9,20 12,22" fill="none" stroke="#ff4400" stroke-width="1.5" opacity="0.8"/>
+  <path d="M20,22 Q23,20 26,24" fill="none" stroke="#ff4400" stroke-width="1.5" opacity="0.8"/>
+  <path d="M12,26 Q14,22 16,24 Q18,22 20,26" fill="none" stroke="#ff6600" stroke-width="1" opacity="0.7"/>
+  <!-- Den entrance -->
+  <ellipse cx="16" cy="24" rx="7" ry="5" fill="#1a0000"/>
+  <!-- Magma glow within -->
+  <ellipse cx="16" cy="25" rx="5" ry="3.5" fill="#aa2200" opacity="0.7"/>
+  <ellipse cx="16" cy="26" rx="3" ry="2" fill="#ff4400" opacity="0.6"/>
+  <ellipse cx="16" cy="27" rx="1.5" ry="1" fill="#ff8800" opacity="0.7"/>
+  <!-- Lava flow from entrance -->
+  <path d="M12,28 Q14,30 16,29 Q18,30 20,28" fill="#cc3300" opacity="0.5"/>
+  <!-- Smoke columns -->
+  <circle cx="10" cy="12" r="2" fill="#3a2a1a" opacity="0.4"/>
+  <circle cx="22" cy="11" r="1.8" fill="#3a2a1a" opacity="0.4"/>
+  <circle cx="16" cy="8" r="2.5" fill="#3a2a1a" opacity="0.3"/>
+  <!-- Ember sparks -->
+  <circle cx="8" cy="18" r="0.8" fill="#ff6600" opacity="0.6"/>
+  <circle cx="24" cy="17" r="0.7" fill="#ff4400" opacity="0.5"/>
+  <circle cx="14" cy="14" r="0.7" fill="#ffaa00" opacity="0.6"/>
+</svg>

--- a/web/public/sprites/mana-well.svg
+++ b/web/public/sprites/mana-well.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="11" ry="1.5" fill="#1a1a2a" opacity="0.5"/>
+  <!-- Well base/rim -->
+  <ellipse cx="16" cy="24" rx="11" ry="4" fill="#4a4a6a"/>
+  <ellipse cx="16" cy="23" rx="10" ry="3.5" fill="#5a5a7a"/>
+  <!-- Stone well cylinder -->
+  <rect x="6" y="16" width="20" height="9" rx="1" fill="#4a4a6a"/>
+  <ellipse cx="16" cy="16" rx="10" ry="3.5" fill="#5a5a7a"/>
+  <!-- Mana water inside well -->
+  <ellipse cx="16" cy="16" rx="8" ry="2.5" fill="#2244aa"/>
+  <ellipse cx="16" cy="16" rx="6" ry="1.8" fill="#3366cc"/>
+  <ellipse cx="16" cy="16" rx="3" ry="1" fill="#5588ff" opacity="0.8"/>
+  <!-- Mana glow overflowing -->
+  <ellipse cx="16" cy="16" rx="11" ry="4" fill="#4466ff" opacity="0.15"/>
+  <!-- Well roof structure -->
+  <line x1="9" y1="8" x2="9" y2="16" stroke="#5a5a6a" stroke-width="1.5"/>
+  <line x1="23" y1="8" x2="23" y2="16" stroke="#5a5a6a" stroke-width="1.5"/>
+  <polygon points="6,8 16,2 26,8" fill="#3a3a5a"/>
+  <polygon points="8,8 16,4 24,8" fill="#4a4a6a"/>
+  <!-- Arcane crystal at peak -->
+  <polygon points="14,4 16,1 18,4 16,6" fill="#8899ff"/>
+  <circle cx="16" cy="3" r="1" fill="#aabbff" opacity="0.9"/>
+  <!-- Pulley and rope -->
+  <circle cx="16" cy="8" r="1.5" fill="#6a6a7a"/>
+  <line x1="16" y1="9" x2="14" y2="16" stroke="#8a7a5a" stroke-width="0.7"/>
+  <!-- Mana rune stones around base -->
+  <circle cx="7" cy="25" r="1" fill="#5577ff" opacity="0.6"/>
+  <circle cx="25" cy="25" r="1" fill="#5577ff" opacity="0.6"/>
+  <circle cx="16" cy="27" r="1" fill="#5577ff" opacity="0.5"/>
+  <!-- Stone block lines on well -->
+  <line x1="6" y1="19" x2="26" y2="19" stroke="#3a3a5a" stroke-width="0.5"/>
+  <line x1="11" y1="16" x2="11" y2="25" stroke="#3a3a5a" stroke-width="0.4"/>
+  <line x1="21" y1="16" x2="21" y2="25" stroke="#3a3a5a" stroke-width="0.4"/>
+</svg>

--- a/web/public/sprites/marsh-keep.svg
+++ b/web/public/sprites/marsh-keep.svg
@@ -1,0 +1,38 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Murky swamp water at base -->
+  <rect x="0" y="25" width="32" height="7" fill="#1a3a1a" opacity="0.6"/>
+  <!-- Water ripples -->
+  <path d="M2,27 Q8,25 14,27" fill="none" stroke="#2a4a2a" stroke-width="0.7" opacity="0.5"/>
+  <path d="M18,27 Q24,25 30,27" fill="none" stroke="#2a4a2a" stroke-width="0.7" opacity="0.5"/>
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#0a1a0a" opacity="0.5"/>
+  <!-- Stilted platform rising from swamp -->
+  <line x1="8" y1="20" x2="6" y2="30" stroke="#5a4a2a" stroke-width="2"/>
+  <line x1="14" y1="20" x2="12" y2="30" stroke="#5a4a2a" stroke-width="2"/>
+  <line x1="20" y1="20" x2="20" y2="30" stroke="#5a4a2a" stroke-width="2"/>
+  <line x1="24" y1="20" x2="26" y2="30" stroke="#5a4a2a" stroke-width="2"/>
+  <!-- Platform base -->
+  <rect x="5" y="18" width="22" height="3" rx="0.5" fill="#6a5a2a"/>
+  <!-- Keep walls (weathered stone) -->
+  <rect x="6" y="7" width="20" height="13" rx="1" fill="#5a6a4a"/>
+  <!-- Moss/algae on walls -->
+  <rect x="6" y="7" width="4" height="13" fill="#3a5a2a" opacity="0.4"/>
+  <rect x="22" y="9" width="4" height="11" fill="#3a5a2a" opacity="0.3"/>
+  <!-- Stone block lines -->
+  <line x1="6" y1="11" x2="26" y2="11" stroke="#4a5a3a" stroke-width="0.6"/>
+  <line x1="6" y1="15" x2="26" y2="15" stroke="#4a5a3a" stroke-width="0.6"/>
+  <line x1="16" y1="7" x2="16" y2="20" stroke="#4a5a3a" stroke-width="0.4"/>
+  <!-- Battlements -->
+  <rect x="6" y="4" width="3" height="4" rx="0.3" fill="#5a6a4a"/>
+  <rect x="11" y="4" width="3" height="4" rx="0.3" fill="#5a6a4a"/>
+  <rect x="18" y="4" width="3" height="4" rx="0.3" fill="#5a6a4a"/>
+  <rect x="23" y="4" width="3" height="4" rx="0.3" fill="#5a6a4a"/>
+  <!-- Arrow slits -->
+  <rect x="9" y="10" width="2" height="4" rx="0.2" fill="#1a2a1a"/>
+  <rect x="21" y="10" width="2" height="4" rx="0.2" fill="#1a2a1a"/>
+  <!-- Gate -->
+  <path d="M13,20 L13,13 Q16,10 19,13 L19,20 Z" fill="#1a2a1a"/>
+  <!-- Reeds/marsh plants at base -->
+  <path d="M2,24 Q3,20 4,22" fill="none" stroke="#3a5a2a" stroke-width="1"/>
+  <path d="M29,24 Q28,20 27,22" fill="none" stroke="#3a5a2a" stroke-width="1"/>
+</svg>

--- a/web/public/sprites/mirage-gate.svg
+++ b/web/public/sprites/mirage-gate.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Sand/heat shimmer base -->
+  <ellipse cx="16" cy="30" rx="14" ry="2" fill="#aa7700" opacity="0.3"/>
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#1a1a0a" opacity="0.4"/>
+  <!-- Desert sandstone pillars -->
+  <rect x="3" y="10" width="7" height="20" rx="1" fill="#cc9933"/>
+  <rect x="22" y="10" width="7" height="20" rx="1" fill="#cc9933"/>
+  <!-- Pillar highlights -->
+  <rect x="3" y="10" width="2" height="20" fill="#ddaa44" opacity="0.5"/>
+  <rect x="22" y="10" width="2" height="20" fill="#ddaa44" opacity="0.5"/>
+  <!-- Pillar carved lines -->
+  <line x1="3" y1="16" x2="10" y2="16" stroke="#aa7722" stroke-width="0.6"/>
+  <line x1="3" y1="22" x2="10" y2="22" stroke="#aa7722" stroke-width="0.6"/>
+  <line x1="22" y1="16" x2="29" y2="16" stroke="#aa7722" stroke-width="0.6"/>
+  <line x1="22" y1="22" x2="29" y2="22" stroke="#aa7722" stroke-width="0.6"/>
+  <!-- Pillar top ornaments -->
+  <rect x="2" y="8" width="9" height="3" rx="0.5" fill="#ddaa44"/>
+  <rect x="21" y="8" width="9" height="3" rx="0.5" fill="#ddaa44"/>
+  <!-- Mirage shimmer portal between pillars -->
+  <rect x="10" y="12" width="12" height="18" fill="#aa8800" opacity="0.1"/>
+  <ellipse cx="16" cy="21" rx="6" ry="9" fill="#ffcc44" opacity="0.08"/>
+  <!-- Heat wave lines -->
+  <path d="M10,15 Q13,13 16,15 Q19,17 22,15" fill="none" stroke="#ffdd88" stroke-width="0.7" opacity="0.4"/>
+  <path d="M10,19 Q13,17 16,19 Q19,21 22,19" fill="none" stroke="#ffdd88" stroke-width="0.7" opacity="0.3"/>
+  <path d="M10,23 Q13,21 16,23 Q19,25 22,23" fill="none" stroke="#ffdd88" stroke-width="0.7" opacity="0.3"/>
+  <!-- Connecting arch -->
+  <path d="M10,12 Q16,5 22,12" fill="none" stroke="#ddaa44" stroke-width="2"/>
+  <!-- Sun ornament at arch top -->
+  <circle cx="16" cy="6" r="2.5" fill="#ffcc00"/>
+  <circle cx="16" cy="6" r="1.5" fill="#ffee44"/>
+  <!-- Sun rays -->
+  <line x1="16" y1="2" x2="16" y2="4" stroke="#ffcc00" stroke-width="0.8"/>
+  <line x1="19" y1="3" x2="18" y2="4.5" stroke="#ffcc00" stroke-width="0.8"/>
+  <line x1="13" y1="3" x2="14" y2="4.5" stroke="#ffcc00" stroke-width="0.8"/>
+</svg>

--- a/web/public/sprites/mossy-ruin.svg
+++ b/web/public/sprites/mossy-ruin.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="14" ry="1.5" fill="#0a1a0a" opacity="0.5"/>
+  <!-- Crumbled stone wall sections -->
+  <rect x="2" y="18" width="8" height="12" rx="0.5" fill="#6a6a5a"/>
+  <rect x="22" y="16" width="8" height="14" rx="0.5" fill="#6a6a5a"/>
+  <!-- Fallen blocks scattered -->
+  <rect x="12" y="24" width="5" height="4" rx="0.3" fill="#5a5a4a"/>
+  <rect x="16" y="22" width="4" height="4" rx="0.3" fill="#6a6a5a"/>
+  <rect x="1" y="14" width="5" height="5" rx="0.3" fill="#5a5a4a"/>
+  <rect x="26" y="12" width="5" height="5" rx="0.3" fill="#5a5a4a"/>
+  <!-- Partial arch remnant -->
+  <path d="M10,18 Q16,10 22,16" fill="none" stroke="#6a6a5a" stroke-width="3"/>
+  <!-- Stone texture on walls -->
+  <line x1="2" y1="21" x2="10" y2="21" stroke="#5a5a4a" stroke-width="0.6"/>
+  <line x1="2" y1="25" x2="10" y2="25" stroke="#5a5a4a" stroke-width="0.6"/>
+  <line x1="22" y1="20" x2="30" y2="20" stroke="#5a5a4a" stroke-width="0.6"/>
+  <line x1="22" y1="24" x2="30" y2="24" stroke="#5a5a4a" stroke-width="0.6"/>
+  <!-- Thick moss patches on ruins -->
+  <ellipse cx="4" cy="18" rx="4" ry="2" fill="#3a6a1a" opacity="0.7"/>
+  <ellipse cx="27" cy="16" rx="4" ry="2" fill="#3a6a1a" opacity="0.6"/>
+  <ellipse cx="14" cy="24" rx="3" ry="1.5" fill="#2a5a0a" opacity="0.7"/>
+  <!-- Vines growing over arch -->
+  <path d="M10,18 Q13,14 16,15" fill="none" stroke="#2a6a0a" stroke-width="1.2"/>
+  <path d="M22,16 Q19,13 16,15" fill="none" stroke="#2a6a0a" stroke-width="1.2"/>
+  <!-- Small flowering weeds in cracks -->
+  <circle cx="6" cy="17" r="1" fill="#ffcc44" opacity="0.6"/>
+  <circle cx="25" cy="15" r="1" fill="#ff8844" opacity="0.6"/>
+  <circle cx="15" cy="22" r="0.8" fill="#ffaa44" opacity="0.5"/>
+  <!-- Rubble pile on ground -->
+  <polygon points="10,30 14,26 18,30" fill="#5a5a4a"/>
+  <polygon points="14,30 17,27 20,30" fill="#6a6a5a"/>
+</svg>

--- a/web/public/sprites/mushroom-mound.svg
+++ b/web/public/sprites/mushroom-mound.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#1a1a0a" opacity="0.5"/>
+  <!-- Earthy mound base -->
+  <ellipse cx="16" cy="27" rx="14" ry="6" fill="#4a3a1a"/>
+  <ellipse cx="16" cy="26" rx="13" ry="5" fill="#5a4a2a"/>
+  <!-- Large central mushroom -->
+  <rect x="13" y="19" width="6" height="9" rx="1" fill="#aa5533"/>
+  <ellipse cx="16" cy="19" rx="10" ry="5" fill="#cc6644"/>
+  <ellipse cx="16" cy="18" rx="9" ry="4" fill="#dd7755"/>
+  <!-- White spots on cap -->
+  <circle cx="10" cy="17" r="1.5" fill="#ffffff" opacity="0.5"/>
+  <circle cx="16" cy="15" r="2" fill="#ffffff" opacity="0.5"/>
+  <circle cx="22" cy="17" r="1.5" fill="#ffffff" opacity="0.5"/>
+  <circle cx="13" cy="19" r="1" fill="#ffffff" opacity="0.4"/>
+  <circle cx="20" cy="19" r="1" fill="#ffffff" opacity="0.4"/>
+  <!-- Medium mushrooms flanking -->
+  <rect x="5" y="22" width="4" height="7" rx="0.5" fill="#996633"/>
+  <ellipse cx="7" cy="22" rx="5.5" ry="3" fill="#bb7744"/>
+  <circle cx="5" cy="21" r="1" fill="#ffffff" opacity="0.4"/>
+  <circle cx="9" cy="21" r="0.8" fill="#ffffff" opacity="0.4"/>
+  <rect x="23" y="22" width="4" height="7" rx="0.5" fill="#996633"/>
+  <ellipse cx="25" cy="22" rx="5.5" ry="3" fill="#bb7744"/>
+  <circle cx="23" cy="21" r="1" fill="#ffffff" opacity="0.4"/>
+  <!-- Small mushrooms -->
+  <rect x="9" y="25" width="2" height="4" rx="0.3" fill="#aa6644"/>
+  <ellipse cx="10" cy="25" rx="3" ry="1.5" fill="#cc7755"/>
+  <rect x="21" y="25" width="2" height="4" rx="0.3" fill="#aa6644"/>
+  <ellipse cx="22" cy="25" rx="3" ry="1.5" fill="#cc7755"/>
+  <!-- Spore particles -->
+  <circle cx="8" cy="13" r="0.7" fill="#ffcc44" opacity="0.5"/>
+  <circle cx="24" cy="12" r="0.6" fill="#ffcc44" opacity="0.4"/>
+  <circle cx="16" cy="10" r="0.8" fill="#ffdd66" opacity="0.5"/>
+</svg>

--- a/web/public/sprites/mycelium-post.svg
+++ b/web/public/sprites/mycelium-post.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="11" ry="1.5" fill="#1a1a0a" opacity="0.5"/>
+  <!-- Root network spreading from post base -->
+  <path d="M16,26 Q8,28 2,30" fill="none" stroke="#8a6a2a" stroke-width="1.2" opacity="0.6"/>
+  <path d="M16,26 Q24,28 30,30" fill="none" stroke="#8a6a2a" stroke-width="1.2" opacity="0.6"/>
+  <path d="M16,26 Q10,30 6,32" fill="none" stroke="#7a5a1a" stroke-width="0.8" opacity="0.5"/>
+  <path d="M16,26 Q22,30 26,32" fill="none" stroke="#7a5a1a" stroke-width="0.8" opacity="0.5"/>
+  <!-- Stone post base -->
+  <rect x="12" y="22" width="8" height="8" rx="1" fill="#5a5a3a"/>
+  <!-- Mushroom-cluster post -->
+  <rect x="14" y="8" width="4" height="16" rx="1" fill="#7a5a2a"/>
+  <!-- Mycelium web on post -->
+  <path d="M14,12 Q12,10 14,8" fill="none" stroke="#ccaa44" stroke-width="0.6" opacity="0.6"/>
+  <path d="M18,14 Q20,11 18,8" fill="none" stroke="#ccaa44" stroke-width="0.6" opacity="0.6"/>
+  <!-- Top mushroom cap cluster -->
+  <ellipse cx="16" cy="9" rx="9" ry="4" fill="#996633"/>
+  <ellipse cx="16" cy="8" rx="8" ry="3" fill="#bb7744"/>
+  <!-- Cap spots -->
+  <circle cx="11" cy="8" r="1.2" fill="#ffffff" opacity="0.4"/>
+  <circle cx="16" cy="6" r="1.5" fill="#ffffff" opacity="0.4"/>
+  <circle cx="21" cy="8" r="1.2" fill="#ffffff" opacity="0.4"/>
+  <!-- Hanging spore filaments -->
+  <line x1="9" y1="12" x2="8" y2="16" stroke="#ccaa44" stroke-width="0.6" opacity="0.5"/>
+  <line x1="11" y1="12" x2="10" y2="17" stroke="#ccaa44" stroke-width="0.5" opacity="0.4"/>
+  <line x1="21" y1="12" x2="22" y2="17" stroke="#ccaa44" stroke-width="0.6" opacity="0.5"/>
+  <line x1="23" y1="12" x2="24" y2="16" stroke="#ccaa44" stroke-width="0.5" opacity="0.4"/>
+  <!-- Spore puffs -->
+  <circle cx="8" cy="6" r="1.5" fill="#ddcc77" opacity="0.3"/>
+  <circle cx="24" cy="5" r="1.2" fill="#ddcc77" opacity="0.3"/>
+  <!-- Small mushrooms at base -->
+  <ellipse cx="10" cy="22" rx="3" ry="1.5" fill="#aa7744"/>
+  <rect x="9.5" y="22" width="1.5" height="4" rx="0.3" fill="#8a5533"/>
+  <ellipse cx="22" cy="22" rx="3" ry="1.5" fill="#aa7744"/>
+  <rect x="21.5" y="22" width="1.5" height="4" rx="0.3" fill="#8a5533"/>
+</svg>

--- a/web/public/sprites/necropolis.svg
+++ b/web/public/sprites/necropolis.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="14" ry="1.5" fill="#0a0a1a" opacity="0.6"/>
+  <!-- Outer wall -->
+  <rect x="1" y="18" width="30" height="12" rx="1" fill="#2a2a3a"/>
+  <!-- Wall block lines -->
+  <line x1="1" y1="22" x2="31" y2="22" stroke="#1a1a2a" stroke-width="0.7"/>
+  <line x1="1" y1="26" x2="31" y2="26" stroke="#1a1a2a" stroke-width="0.7"/>
+  <line x1="8" y1="18" x2="8" y2="30" stroke="#1a1a2a" stroke-width="0.5"/>
+  <line x1="24" y1="18" x2="24" y2="30" stroke="#1a1a2a" stroke-width="0.5"/>
+  <!-- Corner towers -->
+  <rect x="0" y="12" width="8" height="18" rx="0.5" fill="#3a3a4a"/>
+  <rect x="24" y="12" width="8" height="18" rx="0.5" fill="#3a3a4a"/>
+  <!-- Tower battlements -->
+  <rect x="0" y="10" width="3" height="4" rx="0.3" fill="#4a4a5a"/>
+  <rect x="5" y="10" width="3" height="4" rx="0.3" fill="#4a4a5a"/>
+  <rect x="24" y="10" width="3" height="4" rx="0.3" fill="#4a4a5a"/>
+  <rect x="29" y="10" width="3" height="4" rx="0.3" fill="#4a4a5a"/>
+  <!-- Central death spire -->
+  <rect x="12" y="6" width="8" height="14" rx="0.5" fill="#2a2a3a"/>
+  <polygon points="10,6 16,0 22,6" fill="#1a1a2a"/>
+  <!-- Skull at spire peak -->
+  <ellipse cx="16" cy="2" rx="2.5" ry="2" fill="#2a2a3a"/>
+  <circle cx="14.5" cy="1.8" r="0.7" fill="#8800cc" opacity="0.8"/>
+  <circle cx="17.5" cy="1.8" r="0.7" fill="#8800cc" opacity="0.8"/>
+  <!-- Gate: large archway -->
+  <path d="M13,30 L13,20 Q16,15 19,20 L19,30 Z" fill="#0a0a1a"/>
+  <!-- Death energy swirling -->
+  <ellipse cx="16" cy="24" rx="4" ry="2" fill="#4400aa" opacity="0.2"/>
+  <ellipse cx="16" cy="24" rx="2" ry="1" fill="#6600cc" opacity="0.2"/>
+  <!-- Flying wraith silhouettes -->
+  <path d="M5,15 Q7,13 9,15 Q7,17 5,15Z" fill="#4a4a5a" opacity="0.7"/>
+  <path d="M23,14 Q25,12 27,14 Q25,16 23,14Z" fill="#4a4a5a" opacity="0.7"/>
+  <!-- Tombstones visible within walls -->
+  <rect x="10" y="20" width="2" height="4" rx="0.3" fill="#1a1a2a"/>
+  <path d="M10,20 Q11,18 12,20" fill="#1a1a2a"/>
+  <rect x="20" y="21" width="2" height="3" rx="0.3" fill="#1a1a2a"/>
+  <path d="M20,21 Q21,19 22,21" fill="#1a1a2a"/>
+</svg>

--- a/web/public/sprites/paladin-s-chapel.svg
+++ b/web/public/sprites/paladin-s-chapel.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#1a1a0a" opacity="0.5"/>
+  <!-- Chapel base -->
+  <rect x="4" y="16" width="24" height="14" rx="1" fill="#c8b98a"/>
+  <!-- Stone block texture -->
+  <line x1="4" y1="20" x2="28" y2="20" stroke="#aa9966" stroke-width="0.6"/>
+  <line x1="4" y1="24" x2="28" y2="24" stroke="#aa9966" stroke-width="0.6"/>
+  <line x1="4" y1="28" x2="28" y2="28" stroke="#aa9966" stroke-width="0.6"/>
+  <line x1="12" y1="16" x2="12" y2="30" stroke="#aa9966" stroke-width="0.4"/>
+  <line x1="20" y1="16" x2="20" y2="30" stroke="#aa9966" stroke-width="0.4"/>
+  <!-- Chapel roof (pointed) -->
+  <polygon points="2,16 16,5 30,16" fill="#9a8855"/>
+  <polygon points="4,16 16,7 28,16" fill="#bbaa77"/>
+  <!-- Bell tower above roof -->
+  <rect x="13" y="1" width="6" height="8" rx="0.5" fill="#bbaa77"/>
+  <rect x="11" y="0" width="10" height="2" rx="0.3" fill="#9a8855"/>
+  <!-- Holy cross at peak -->
+  <line x1="16" y1="0" x2="16" y2="-4" stroke="#9a8855" stroke-width="1"/>
+  <line x1="16" y1="5" x2="16" y2="1" stroke="#ffffff" stroke-width="1.2"/>
+  <line x1="14" y1="3" x2="18" y2="3" stroke="#ffffff" stroke-width="1.2"/>
+  <!-- Stained glass window (rose) -->
+  <circle cx="16" cy="12" r="3" fill="#1a1a2a"/>
+  <circle cx="16" cy="12" r="2" fill="#3355aa" opacity="0.7"/>
+  <circle cx="16" cy="12" r="1" fill="#aabbff" opacity="0.8"/>
+  <line x1="13" y1="12" x2="19" y2="12" stroke="#5577cc" stroke-width="0.5"/>
+  <line x1="16" y1="9" x2="16" y2="15" stroke="#5577cc" stroke-width="0.5"/>
+  <!-- Arched entrance -->
+  <path d="M13,30 L13,22 Q16,18 19,22 L19,30 Z" fill="#1a1a2a"/>
+  <!-- Holy light glow from windows -->
+  <ellipse cx="8" cy="20" rx="2" ry="3" fill="#ffffaa" opacity="0.15"/>
+  <ellipse cx="24" cy="20" rx="2" ry="3" fill="#ffffaa" opacity="0.15"/>
+  <!-- Banner -->
+  <line x1="16" y1="0" x2="16" y2="-3" stroke="#9a8855" stroke-width="0.8"/>
+  <polygon points="16,-3 22,-1.5 16,0" fill="#4466aa"/>
+</svg>

--- a/web/public/sprites/permafrost-lair.svg
+++ b/web/public/sprites/permafrost-lair.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#0a1a2a" opacity="0.5"/>
+  <!-- Frozen tundra ground -->
+  <rect x="0" y="27" width="32" height="5" fill="#3a5a6a" opacity="0.7"/>
+  <!-- Ice-crusted hill/lair -->
+  <ellipse cx="16" cy="24" rx="15" ry="9" fill="#3a5a6a"/>
+  <ellipse cx="16" cy="23" rx="14" ry="8" fill="#4a6a7a"/>
+  <!-- Snow/ice cap -->
+  <ellipse cx="16" cy="19" rx="10" ry="5" fill="#99bbcc"/>
+  <ellipse cx="16" cy="18" rx="9" ry="4" fill="#bbddee"/>
+  <!-- Lair entrance (frozen over arch) -->
+  <ellipse cx="16" cy="26" rx="7" ry="5.5" fill="#1a2a3a"/>
+  <!-- Ice stalactites over entrance -->
+  <polygon points="10,21 11,25 12,21" fill="#88ccee"/>
+  <polygon points="13,21 14,26 15,21" fill="#88ccee"/>
+  <polygon points="17,21 18,25 19,21" fill="#88ccee"/>
+  <polygon points="20,21 21,24 22,21" fill="#88ccee"/>
+  <!-- Cold breath/mist from lair -->
+  <ellipse cx="16" cy="27" rx="5" ry="2" fill="#aaccdd" opacity="0.3"/>
+  <ellipse cx="16" cy="26" rx="3" ry="1.2" fill="#cce8f0" opacity="0.2"/>
+  <!-- Eyes of creature inside -->
+  <circle cx="14" cy="25" r="1" fill="#aaddff" opacity="0.9"/>
+  <circle cx="18" cy="25" r="1" fill="#aaddff" opacity="0.9"/>
+  <!-- Ice formation peaks around lair -->
+  <polygon points="3,20 5,13 7,20" fill="#6a9aaa" opacity="0.8"/>
+  <polygon points="25,20 27,13 29,20" fill="#6a9aaa" opacity="0.8"/>
+  <polygon points="6,18 7,12 8,18" fill="#88aacc" opacity="0.7"/>
+  <polygon points="24,18 25,12 26,18" fill="#88aacc" opacity="0.7"/>
+  <!-- Snow particles -->
+  <circle cx="5" cy="12" r="0.8" fill="#cce8f0" opacity="0.5"/>
+  <circle cx="27" cy="11" r="0.7" fill="#cce8f0" opacity="0.4"/>
+  <circle cx="15" cy="9" r="0.7" fill="#cce8f0" opacity="0.5"/>
+</svg>

--- a/web/public/sprites/pixie-garden.svg
+++ b/web/public/sprites/pixie-garden.svg
@@ -1,0 +1,41 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="14" ry="1.5" fill="#0a1a0a" opacity="0.5"/>
+  <!-- Garden ground (lush green) -->
+  <ellipse cx="16" cy="28" rx="14" ry="5" fill="#2a6a1a"/>
+  <!-- Floral garden bed -->
+  <ellipse cx="16" cy="27" rx="12" ry="4" fill="#3a7a2a"/>
+  <!-- Colorful flowers -->
+  <circle cx="7" cy="26" r="2" fill="#ff4488"/>
+  <circle cx="7" cy="26" r="1" fill="#ff88bb"/>
+  <circle cx="12" cy="25" r="2" fill="#ffcc00"/>
+  <circle cx="12" cy="25" r="1" fill="#ffee88"/>
+  <circle cx="16" cy="24" r="2.5" fill="#ff6644"/>
+  <circle cx="16" cy="24" r="1.2" fill="#ffaa88"/>
+  <circle cx="20" cy="25" r="2" fill="#aa44ff"/>
+  <circle cx="20" cy="25" r="1" fill="#cc88ff"/>
+  <circle cx="25" cy="26" r="2" fill="#44aaff"/>
+  <circle cx="25" cy="26" r="1" fill="#88ccff"/>
+  <!-- Flower stems -->
+  <line x1="7" y1="26" x2="7" y2="29" stroke="#2a6a1a" stroke-width="0.8"/>
+  <line x1="12" y1="25" x2="12" y2="29" stroke="#2a6a1a" stroke-width="0.8"/>
+  <line x1="16" y1="24" x2="16" y2="29" stroke="#2a6a1a" stroke-width="0.8"/>
+  <line x1="20" y1="25" x2="20" y2="29" stroke="#2a6a1a" stroke-width="0.8"/>
+  <line x1="25" y1="26" x2="25" y2="29" stroke="#2a6a1a" stroke-width="0.8"/>
+  <!-- Pixie sprites flying above -->
+  <ellipse cx="9" cy="18" rx="1.5" ry="1" fill="#ffccee"/>
+  <path d="M7,17 Q9,15 11,17" fill="none" stroke="#ffccee" stroke-width="0.8" opacity="0.7"/>
+  <path d="M7,19 Q9,21 11,19" fill="none" stroke="#ffccee" stroke-width="0.8" opacity="0.7"/>
+  <circle cx="9" cy="18" r="0.7" fill="#ff88cc"/>
+  <ellipse cx="23" cy="16" rx="1.5" ry="1" fill="#ccffee"/>
+  <path d="M21,15 Q23,13 25,15" fill="none" stroke="#ccffee" stroke-width="0.8" opacity="0.7"/>
+  <path d="M21,17 Q23,19 25,17" fill="none" stroke="#ccffee" stroke-width="0.8" opacity="0.7"/>
+  <circle cx="23" cy="16" r="0.7" fill="#88ffcc"/>
+  <!-- Sparkle trails -->
+  <circle cx="5" cy="14" r="0.7" fill="#ffff88" opacity="0.6"/>
+  <circle cx="18" cy="11" r="0.6" fill="#ff88ff" opacity="0.5"/>
+  <circle cx="27" cy="13" r="0.7" fill="#88ffff" opacity="0.6"/>
+  <circle cx="14" cy="9" r="0.5" fill="#ffcc44" opacity="0.5"/>
+  <!-- Mushroom ring (fairy ring) -->
+  <ellipse cx="16" cy="27" rx="10" ry="3" fill="none" stroke="#8a5533" stroke-width="0.5" opacity="0.4"/>
+</svg>

--- a/web/public/sprites/plague-burrow.svg
+++ b/web/public/sprites/plague-burrow.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#0a1a0a" opacity="0.6"/>
+  <!-- Diseased mound (sickly green-brown) -->
+  <ellipse cx="16" cy="26" rx="14" ry="7" fill="#3a4a1a"/>
+  <ellipse cx="16" cy="25" rx="13" ry="6" fill="#4a5a2a"/>
+  <!-- Putrid pustules on mound -->
+  <circle cx="8" cy="23" r="2" fill="#6a7a1a" opacity="0.7"/>
+  <circle cx="22" cy="22" r="1.5" fill="#5a6a1a" opacity="0.7"/>
+  <circle cx="12" cy="21" r="1.8" fill="#7a8a2a" opacity="0.6"/>
+  <circle cx="20" cy="24" r="1.2" fill="#6a7a1a" opacity="0.6"/>
+  <!-- Main burrow entrance -->
+  <ellipse cx="16" cy="27" rx="6" ry="4.5" fill="#0a1a00"/>
+  <!-- Secondary burrows -->
+  <ellipse cx="7" cy="27" rx="3.5" ry="3" fill="#0a1a00"/>
+  <ellipse cx="25" cy="27" rx="3.5" ry="3" fill="#0a1a00"/>
+  <!-- Glowing sick-green eyes -->
+  <circle cx="15" cy="27" r="0.9" fill="#88ff00" opacity="0.8"/>
+  <circle cx="17" cy="27" r="0.9" fill="#88ff00" opacity="0.8"/>
+  <circle cx="6" cy="27" r="0.7" fill="#66cc00" opacity="0.7"/>
+  <circle cx="24" cy="27" r="0.7" fill="#66cc00" opacity="0.7"/>
+  <!-- Toxic gas clouds -->
+  <circle cx="10" cy="18" r="3" fill="#4a6a00" opacity="0.3"/>
+  <circle cx="22" cy="17" r="2.5" fill="#4a6a00" opacity="0.3"/>
+  <circle cx="16" cy="14" r="3.5" fill="#5a7a00" opacity="0.25"/>
+  <!-- Plague flies swarming -->
+  <circle cx="6" cy="14" r="0.5" fill="#1a1a0a" opacity="0.7"/>
+  <circle cx="8" cy="12" r="0.5" fill="#1a1a0a" opacity="0.7"/>
+  <circle cx="25" cy="13" r="0.5" fill="#1a1a0a" opacity="0.7"/>
+  <circle cx="27" cy="15" r="0.5" fill="#1a1a0a" opacity="0.7"/>
+  <!-- Bones scattered nearby -->
+  <line x1="3" y1="28" x2="5" y2="27" stroke="#ccbb99" stroke-width="1"/>
+  <line x1="29" y1="28" x2="27" y2="27" stroke="#ccbb99" stroke-width="1"/>
+</svg>

--- a/web/public/sprites/pollen-rush.svg
+++ b/web/public/sprites/pollen-rush.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Background glow -->
+  <ellipse cx="16" cy="16" rx="14" ry="14" fill="#2a4a1a" opacity="0.4"/>
+  <!-- Pollen burst center flower -->
+  <circle cx="16" cy="16" r="5" fill="#aacc44"/>
+  <circle cx="16" cy="16" r="3" fill="#ddff44"/>
+  <!-- Pollen petals -->
+  <ellipse cx="16" cy="9" rx="2" ry="3" fill="#88bb22"/>
+  <ellipse cx="16" cy="23" rx="2" ry="3" fill="#88bb22"/>
+  <ellipse cx="9" cy="16" rx="3" ry="2" fill="#88bb22"/>
+  <ellipse cx="23" cy="16" rx="3" ry="2" fill="#88bb22"/>
+  <ellipse cx="11" cy="11" rx="2" ry="2.5" fill="#88bb22" transform="rotate(-45 11 11)"/>
+  <ellipse cx="21" cy="11" rx="2" ry="2.5" fill="#88bb22" transform="rotate(45 21 11)"/>
+  <ellipse cx="11" cy="21" rx="2" ry="2.5" fill="#88bb22" transform="rotate(45 11 21)"/>
+  <ellipse cx="21" cy="21" rx="2" ry="2.5" fill="#88bb22" transform="rotate(-45 21 21)"/>
+  <!-- Floating pollen dots -->
+  <circle cx="6" cy="8" r="1.2" fill="#ddff44" opacity="0.8"/>
+  <circle cx="26" cy="7" r="1" fill="#ddff44" opacity="0.7"/>
+  <circle cx="28" cy="22" r="1.2" fill="#ddff44" opacity="0.8"/>
+  <circle cx="4" cy="24" r="1" fill="#ddff44" opacity="0.6"/>
+  <circle cx="9" cy="28" r="0.8" fill="#aacc44" opacity="0.7"/>
+  <circle cx="24" cy="26" r="0.8" fill="#aacc44" opacity="0.7"/>
+  <!-- Speed streaks -->
+  <line x1="3" y1="16" x2="8" y2="16" stroke="#ddff44" stroke-width="1" opacity="0.5"/>
+  <line x1="24" y1="16" x2="29" y2="16" stroke="#ddff44" stroke-width="1" opacity="0.5"/>
+</svg>

--- a/web/public/sprites/prism-vault.svg
+++ b/web/public/sprites/prism-vault.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#1a1a2a" opacity="0.5"/>
+  <!-- Vault base (crystal/stone) -->
+  <rect x="4" y="18" width="24" height="12" rx="1" fill="#3a3a5a"/>
+  <!-- Crystal lattice on walls -->
+  <line x1="4" y1="22" x2="28" y2="22" stroke="#5577aa" stroke-width="0.6"/>
+  <line x1="4" y1="26" x2="28" y2="26" stroke="#5577aa" stroke-width="0.6"/>
+  <line x1="10" y1="18" x2="10" y2="30" stroke="#5577aa" stroke-width="0.4"/>
+  <line x1="22" y1="18" x2="22" y2="30" stroke="#5577aa" stroke-width="0.4"/>
+  <!-- Prism dome top -->
+  <polygon points="4,18 16,6 28,18" fill="#2a2a4a"/>
+  <polygon points="6,18 16,8 26,18" fill="#3a3a5a" opacity="0.8"/>
+  <!-- Rainbow refraction lines from dome -->
+  <line x1="16" y1="7" x2="3" y2="19" stroke="#ff4444" stroke-width="0.8" opacity="0.4"/>
+  <line x1="16" y1="7" x2="6" y2="19" stroke="#ffaa00" stroke-width="0.8" opacity="0.4"/>
+  <line x1="16" y1="7" x2="10" y2="19" stroke="#ffff00" stroke-width="0.8" opacity="0.3"/>
+  <line x1="16" y1="7" x2="22" y2="19" stroke="#00ff88" stroke-width="0.8" opacity="0.3"/>
+  <line x1="16" y1="7" x2="26" y2="19" stroke="#4488ff" stroke-width="0.8" opacity="0.4"/>
+  <line x1="16" y1="7" x2="29" y2="19" stroke="#aa44ff" stroke-width="0.8" opacity="0.4"/>
+  <!-- Crystal prism at apex -->
+  <polygon points="13,8 16,2 19,8 16,11" fill="#ccddff"/>
+  <polygon points="14,8 16,4 18,8 16,10" fill="#ffffff" opacity="0.6"/>
+  <!-- Vault heavy door -->
+  <rect x="12" y="20" width="8" height="10" rx="0.5" fill="#1a1a2a"/>
+  <rect x="11" y="19" width="10" height="12" rx="0.5" fill="none" stroke="#5577aa" stroke-width="1"/>
+  <!-- Lock -->
+  <circle cx="16" cy="25" r="2" fill="#2a2a4a"/>
+  <circle cx="16" cy="25" r="1" fill="#4455aa"/>
+  <!-- Spectral glow -->
+  <ellipse cx="16" cy="14" rx="6" ry="4" fill="#aabbff" opacity="0.1"/>
+</svg>

--- a/web/public/sprites/pyroclast-vent.svg
+++ b/web/public/sprites/pyroclast-vent.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="12" ry="1.5" fill="#2a0a00" opacity="0.6"/>
+  <!-- Volcanic rock cone -->
+  <polygon points="4,30 16,10 28,30" fill="#3a1a0a"/>
+  <polygon points="6,30 16,13 26,30" fill="#4a2a1a"/>
+  <!-- Lava cracks on cone sides -->
+  <path d="M8,26 Q10,22 12,24" fill="none" stroke="#ff4400" stroke-width="1" opacity="0.7"/>
+  <path d="M20,24 Q22,22 24,26" fill="none" stroke="#ff4400" stroke-width="1" opacity="0.7"/>
+  <path d="M12,28 Q14,25 16,26" fill="none" stroke="#ff6600" stroke-width="0.8" opacity="0.6"/>
+  <path d="M16,26 Q18,25 20,28" fill="none" stroke="#ff6600" stroke-width="0.8" opacity="0.6"/>
+  <!-- Vent opening at top -->
+  <ellipse cx="16" cy="11" rx="5" ry="3" fill="#1a0000"/>
+  <ellipse cx="16" cy="11" rx="4" ry="2.5" fill="#aa1100" opacity="0.8"/>
+  <ellipse cx="16" cy="11" rx="2.5" ry="1.5" fill="#dd3300" opacity="0.8"/>
+  <ellipse cx="16" cy="11" rx="1.2" ry="0.8" fill="#ff6600" opacity="0.9"/>
+  <!-- Pyroclastic eruption plume -->
+  <path d="M13,9 Q14,5 16,2 Q18,5 19,9" fill="#882200" opacity="0.5"/>
+  <path d="M14,9 Q15,6 16,3 Q17,6 18,9" fill="#aa3300" opacity="0.5"/>
+  <path d="M15,9 Q15.5,7 16,4 Q16.5,7 17,9" fill="#ffaa00" opacity="0.4"/>
+  <!-- Rock fragments ejected -->
+  <circle cx="10" cy="4" r="1.5" fill="#2a1a0a" opacity="0.7"/>
+  <circle cx="22" cy="5" r="1.2" fill="#2a1a0a" opacity="0.7"/>
+  <circle cx="8" cy="8" r="0.8" fill="#3a2a1a" opacity="0.6"/>
+  <!-- Ember sparks -->
+  <circle cx="12" cy="5" r="0.7" fill="#ff6600" opacity="0.6"/>
+  <circle cx="20" cy="3" r="0.6" fill="#ff8800" opacity="0.5"/>
+  <circle cx="17" cy="2" r="0.5" fill="#ffaa00" opacity="0.6"/>
+</svg>

--- a/web/public/sprites/ram-barracks.svg
+++ b/web/public/sprites/ram-barracks.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="14" ry="1.5" fill="#1a1a0a" opacity="0.5"/>
+  <!-- Barracks wall -->
+  <rect x="2" y="14" width="28" height="16" rx="1" fill="#7a6a4a"/>
+  <!-- Stone texture lines -->
+  <line x1="2" y1="18" x2="30" y2="18" stroke="#5a4a2a" stroke-width="0.7"/>
+  <line x1="2" y1="22" x2="30" y2="22" stroke="#5a4a2a" stroke-width="0.7"/>
+  <line x1="2" y1="26" x2="30" y2="26" stroke="#5a4a2a" stroke-width="0.7"/>
+  <line x1="9" y1="14" x2="9" y2="30" stroke="#5a4a2a" stroke-width="0.5"/>
+  <line x1="23" y1="14" x2="23" y2="30" stroke="#5a4a2a" stroke-width="0.5"/>
+  <!-- Roof with ram horn arch -->
+  <polygon points="0,14 16,5 32,14" fill="#4a3a1a"/>
+  <polygon points="2,14 16,7 30,14" fill="#6a5a2a"/>
+  <!-- Ram skull and horn emblem above gate -->
+  <ellipse cx="16" cy="9" rx="3" ry="2.5" fill="#4a3a1a"/>
+  <!-- Ram horns (curved) -->
+  <path d="M13,9 Q9,6 10,11" fill="none" stroke="#8a7a5a" stroke-width="2" stroke-linecap="round"/>
+  <path d="M19,9 Q23,6 22,11" fill="none" stroke="#8a7a5a" stroke-width="2" stroke-linecap="round"/>
+  <!-- Corner guard towers -->
+  <rect x="0" y="10" width="7" height="20" rx="0.5" fill="#8a7a5a"/>
+  <rect x="25" y="10" width="7" height="20" rx="0.5" fill="#8a7a5a"/>
+  <!-- Tower battlements -->
+  <rect x="0" y="8" width="3" height="3" rx="0.3" fill="#9a8a6a"/>
+  <rect x="4" y="8" width="3" height="3" rx="0.3" fill="#9a8a6a"/>
+  <rect x="25" y="8" width="3" height="3" rx="0.3" fill="#9a8a6a"/>
+  <rect x="29" y="8" width="3" height="3" rx="0.3" fill="#9a8a6a"/>
+  <!-- Gate entrance -->
+  <path d="M13,30 L13,20 Q16,16 19,20 L19,30 Z" fill="#1a1a0a"/>
+  <!-- Battering ram leaning against wall -->
+  <rect x="4" y="22" width="12" height="3" rx="1" fill="#6a4a1a" transform="rotate(-10 10 24)"/>
+  <!-- Ram head on battering ram -->
+  <ellipse cx="5" cy="21" rx="2.5" ry="2" fill="#5a4a1a" transform="rotate(-10 5 21)"/>
+</svg>

--- a/web/public/sprites/reef-shallows.svg
+++ b/web/public/sprites/reef-shallows.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ocean water background -->
+  <rect x="0" y="14" width="32" height="18" fill="#0a3a5a"/>
+  <!-- Water surface shimmer -->
+  <path d="M0,16 Q8,14 16,16 Q24,18 32,16" fill="none" stroke="#1a5a7a" stroke-width="0.8" opacity="0.6"/>
+  <!-- Sandy shallow bottom -->
+  <rect x="0" y="24" width="32" height="8" fill="#8a7a3a" opacity="0.7"/>
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="14" ry="1.5" fill="#0a1a2a" opacity="0.4"/>
+  <!-- Coral formations -->
+  <!-- Left coral cluster -->
+  <rect x="4" y="20" width="3" height="8" rx="1" fill="#cc4422"/>
+  <ellipse cx="5.5" cy="20" rx="3" ry="2" fill="#dd5533"/>
+  <rect x="2" y="22" width="2" height="6" rx="0.5" fill="#cc3311"/>
+  <rect x="7" y="21" width="2" height="7" rx="0.5" fill="#ee6644"/>
+  <!-- Right coral cluster -->
+  <rect x="24" y="19" width="3" height="9" rx="1" fill="#cc4422"/>
+  <ellipse cx="25.5" cy="19" rx="3" ry="2" fill="#dd5533"/>
+  <rect x="22" y="21" width="2" height="7" rx="0.5" fill="#bb3311"/>
+  <!-- Centre kelp/sea plants -->
+  <path d="M15,28 Q13,24 15,20 Q17,16 16,18 Q14,22 16,25" fill="none" stroke="#2a8a2a" stroke-width="1.5"/>
+  <path d="M18,28 Q20,24 18,20 Q16,16 17,18 Q19,22 17,25" fill="none" stroke="#2a7a2a" stroke-width="1.5"/>
+  <!-- Anemone -->
+  <circle cx="11" cy="25" r="2.5" fill="#ff8844" opacity="0.7"/>
+  <circle cx="11" cy="25" r="1" fill="#ffaa66" opacity="0.8"/>
+  <circle cx="22" cy="26" r="2" fill="#ff6688" opacity="0.7"/>
+  <!-- Fish silhouettes in water -->
+  <ellipse cx="8" cy="18" rx="2.5" ry="1" fill="#4488aa" opacity="0.5"/>
+  <polygon points="10.5,18 12,17 12,19" fill="#4488aa" opacity="0.5"/>
+  <ellipse cx="24" cy="17" rx="2" ry="0.8" fill="#3377aa" opacity="0.5"/>
+  <!-- Bubbles -->
+  <circle cx="6" cy="16" r="0.6" fill="#aaddff" opacity="0.4"/>
+  <circle cx="26" cy="15" r="0.5" fill="#aaddff" opacity="0.4"/>
+</svg>

--- a/web/public/sprites/reef-stronghold.svg
+++ b/web/public/sprites/reef-stronghold.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ocean water at base -->
+  <rect x="0" y="22" width="32" height="10" fill="#0a3a5a"/>
+  <!-- Water shimmer -->
+  <path d="M0,24 Q8,22 16,24 Q24,26 32,24" fill="none" stroke="#1a5a7a" stroke-width="0.7" opacity="0.5"/>
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="12" ry="1.5" fill="#0a1a2a" opacity="0.4"/>
+  <!-- Coral-encrusted tower base -->
+  <rect x="6" y="14" width="20" height="12" rx="1" fill="#4a5a6a"/>
+  <!-- Coral growth on walls -->
+  <rect x="6" y="16" width="3" height="8" fill="#cc4422" opacity="0.7"/>
+  <rect x="23" y="17" width="3" height="7" fill="#dd5533" opacity="0.6"/>
+  <circle cx="8" cy="15" r="1.5" fill="#ee6644" opacity="0.7"/>
+  <circle cx="24" cy="15" r="1.5" fill="#cc4422" opacity="0.7"/>
+  <!-- Tower upper section -->
+  <rect x="9" y="6" width="14" height="10" rx="0.5" fill="#5a6a7a"/>
+  <!-- Battlements -->
+  <rect x="8" y="4" width="3" height="3" rx="0.3" fill="#4a5a6a"/>
+  <rect x="13" y="4" width="3" height="3" rx="0.3" fill="#4a5a6a"/>
+  <rect x="18" y="4" width="3" height="3" rx="0.3" fill="#4a5a6a"/>
+  <rect x="23" y="4" width="3" height="3" rx="0.3" fill="#4a5a6a"/>
+  <!-- Arrow slits -->
+  <rect x="12" y="9" width="2" height="4" rx="0.2" fill="#1a2a3a"/>
+  <rect x="18" y="9" width="2" height="4" rx="0.2" fill="#1a2a3a"/>
+  <!-- Gate arch -->
+  <path d="M13,26 L13,18 Q16,14 19,18 L19,26 Z" fill="#0a1a2a"/>
+  <!-- Trident banner -->
+  <line x1="16" y1="4" x2="16" y2="0" stroke="#4a5a6a" stroke-width="0.8"/>
+  <line x1="13" y1="1" x2="19" y2="1" stroke="#5a9aaa" stroke-width="0.8"/>
+  <line x1="13" y1="1" x2="13" y2="3" stroke="#5a9aaa" stroke-width="0.8"/>
+  <line x1="16" y1="0" x2="16" y2="3" stroke="#5a9aaa" stroke-width="0.8"/>
+  <line x1="19" y1="1" x2="19" y2="3" stroke="#5a9aaa" stroke-width="0.8"/>
+  <!-- Bubbles rising from water -->
+  <circle cx="5" cy="20" r="0.7" fill="#aaddff" opacity="0.4"/>
+  <circle cx="27" cy="19" r="0.6" fill="#aaddff" opacity="0.4"/>
+</svg>

--- a/web/public/sprites/revenant-gate.svg
+++ b/web/public/sprites/revenant-gate.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#0a0a1a" opacity="0.6"/>
+  <!-- Gate pillars (ancient dark stone) -->
+  <rect x="2" y="8" width="7" height="22" rx="1" fill="#2a2a3a"/>
+  <rect x="23" y="8" width="7" height="22" rx="1" fill="#2a2a3a"/>
+  <!-- Pillar highlights -->
+  <rect x="2" y="8" width="2" height="22" fill="#3a3a4a"/>
+  <rect x="23" y="8" width="2" height="22" fill="#3a3a4a"/>
+  <!-- Pillar cap stones -->
+  <rect x="1" y="6" width="9" height="3" rx="0.5" fill="#3a3a4a"/>
+  <rect x="22" y="6" width="9" height="3" rx="0.5" fill="#3a3a4a"/>
+  <!-- Ghost/revenant skull ornaments -->
+  <ellipse cx="5.5" cy="4.5" rx="3" ry="2.5" fill="#1a1a2a"/>
+  <circle cx="4.2" cy="4" r="0.8" fill="#8888ff" opacity="0.8"/>
+  <circle cx="6.8" cy="4" r="0.8" fill="#8888ff" opacity="0.8"/>
+  <ellipse cx="26.5" cy="4.5" rx="3" ry="2.5" fill="#1a1a2a"/>
+  <circle cx="25.2" cy="4" r="0.8" fill="#8888ff" opacity="0.8"/>
+  <circle cx="27.8" cy="4" r="0.8" fill="#8888ff" opacity="0.8"/>
+  <!-- Ghostly portal between pillars -->
+  <rect x="9" y="10" width="14" height="20" fill="#0a0014"/>
+  <ellipse cx="16" cy="20" rx="5" ry="8" fill="#1a0044" opacity="0.7"/>
+  <ellipse cx="16" cy="20" rx="3" ry="5.5" fill="#2a0066" opacity="0.6"/>
+  <ellipse cx="16" cy="20" rx="1.5" ry="3" fill="#4400aa" opacity="0.7"/>
+  <!-- Revenant spirit swirls -->
+  <path d="M12,16 Q16,11 20,16" fill="none" stroke="#6666ff" stroke-width="0.8" opacity="0.5"/>
+  <path d="M11,20 Q16,14 21,20" fill="none" stroke="#4444cc" stroke-width="0.8" opacity="0.4"/>
+  <path d="M12,24 Q16,18 20,24" fill="none" stroke="#6666ff" stroke-width="0.8" opacity="0.4"/>
+  <!-- Arch over gate -->
+  <path d="M9,10 Q16,3 23,10" fill="none" stroke="#3a3a4a" stroke-width="2"/>
+  <!-- Rune marks -->
+  <line x1="3" y1="14" x2="7" y2="14" stroke="#6644aa" stroke-width="0.7" opacity="0.7"/>
+  <line x1="3" y1="18" x2="7" y2="18" stroke="#6644aa" stroke-width="0.7" opacity="0.7"/>
+  <line x1="25" y1="14" x2="29" y2="14" stroke="#6644aa" stroke-width="0.7" opacity="0.7"/>
+  <line x1="25" y1="18" x2="29" y2="18" stroke="#6644aa" stroke-width="0.7" opacity="0.7"/>
+</svg>

--- a/web/public/sprites/rime-warren.svg
+++ b/web/public/sprites/rime-warren.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Snow ground -->
+  <rect x="0" y="26" width="32" height="6" fill="#aaccdd" opacity="0.4"/>
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#0a1a2a" opacity="0.5"/>
+  <!-- Frozen mound (snow-covered warren) -->
+  <ellipse cx="16" cy="25" rx="14" ry="8" fill="#5a7a8a"/>
+  <ellipse cx="16" cy="24" rx="13" ry="7" fill="#6a8a9a"/>
+  <!-- Snow cap -->
+  <ellipse cx="16" cy="20" rx="11" ry="5" fill="#aaccdd"/>
+  <ellipse cx="16" cy="19" rx="9" ry="4" fill="#cce8f0"/>
+  <!-- Frost rime pattern on snow -->
+  <path d="M8,19 Q12,17 16,19 Q20,21 24,19" fill="none" stroke="#88aacc" stroke-width="0.6" opacity="0.5"/>
+  <!-- Main tunnel entrance (frozen arch) -->
+  <ellipse cx="16" cy="26" rx="5.5" ry="4.5" fill="#1a2a3a"/>
+  <!-- Ice framing entrance -->
+  <polygon points="11,23 12,27 13,23" fill="#88ccee"/>
+  <polygon points="19,23 20,27 21,23" fill="#88ccee"/>
+  <!-- Side warrens -->
+  <ellipse cx="7" cy="27" rx="3.5" ry="3" fill="#1a2a3a"/>
+  <ellipse cx="25" cy="27" rx="3.5" ry="3" fill="#1a2a3a"/>
+  <!-- Glowing icy-white eyes -->
+  <circle cx="15" cy="26" r="0.9" fill="#aaddff" opacity="0.9"/>
+  <circle cx="17" cy="26" r="0.9" fill="#aaddff" opacity="0.9"/>
+  <circle cx="6" cy="27" r="0.7" fill="#88ccee" opacity="0.8"/>
+  <circle cx="24" cy="27" r="0.7" fill="#88ccee" opacity="0.8"/>
+  <!-- Ice spikes protruding from mound -->
+  <polygon points="6,16 7,11 8,16" fill="#88ccee" opacity="0.7"/>
+  <polygon points="14,14 15,9 16,14" fill="#aaddff" opacity="0.8"/>
+  <polygon points="24,15 25,10 26,15" fill="#88ccee" opacity="0.7"/>
+  <!-- Snow particles -->
+  <circle cx="4" cy="14" r="0.7" fill="#cce8f0" opacity="0.5"/>
+  <circle cx="28" cy="12" r="0.6" fill="#cce8f0" opacity="0.4"/>
+  <circle cx="20" cy="10" r="0.6" fill="#cce8f0" opacity="0.4"/>
+</svg>

--- a/web/public/sprites/rogue-s-guild.svg
+++ b/web/public/sprites/rogue-s-guild.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#1a1a1a" opacity="0.5"/>
+  <!-- Dark building base -->
+  <rect x="3" y="14" width="26" height="16" rx="1" fill="#2a2a2a"/>
+  <!-- Dark wood planking texture -->
+  <line x1="3" y1="18" x2="29" y2="18" stroke="#1a1a1a" stroke-width="0.7"/>
+  <line x1="3" y1="22" x2="29" y2="22" stroke="#1a1a1a" stroke-width="0.7"/>
+  <line x1="3" y1="26" x2="29" y2="26" stroke="#1a1a1a" stroke-width="0.7"/>
+  <!-- Low-profile sloped roof (inconspicuous) -->
+  <polygon points="1,14 16,7 31,14" fill="#1a1a1a"/>
+  <polygon points="3,14 16,9 29,14" fill="#2a2a2a"/>
+  <!-- Crossed daggers sign (guild emblem) -->
+  <line x1="13" y1="10" x2="19" y2="16" stroke="#8a8a6a" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="19" y1="10" x2="13" y2="16" stroke="#8a8a6a" stroke-width="1.5" stroke-linecap="round"/>
+  <!-- Dagger hilts -->
+  <line x1="12" y1="10" x2="14" y2="10" stroke="#8a8a6a" stroke-width="1"/>
+  <line x1="18" y1="10" x2="20" y2="10" stroke="#8a8a6a" stroke-width="1"/>
+  <!-- Dimly lit windows (slight glow) -->
+  <rect x="5" y="16" width="4" height="4" rx="0.3" fill="#1a1a1a"/>
+  <rect x="6" y="17" width="2" height="2" fill="#aa8800" opacity="0.3"/>
+  <rect x="23" y="16" width="4" height="4" rx="0.3" fill="#1a1a1a"/>
+  <rect x="24" y="17" width="2" height="2" fill="#aa8800" opacity="0.3"/>
+  <!-- Hidden entrance (narrow door) -->
+  <rect x="14" y="22" width="4" height="8" rx="0.3" fill="#0a0a0a"/>
+  <!-- Hooded figure silhouette in doorway -->
+  <ellipse cx="16" cy="24" rx="1.5" ry="1.5" fill="#1a1a1a"/>
+  <rect x="14.5" y="25.5" width="3" height="4" rx="0.5" fill="#1a1a1a"/>
+  <!-- Coin tossed on step (gold glint) -->
+  <circle cx="12" cy="30" r="1" fill="#aa8800" opacity="0.5"/>
+  <!-- Night lamp post near entrance -->
+  <line x1="25" y1="14" x2="25" y2="8" stroke="#3a3a2a" stroke-width="0.8"/>
+  <circle cx="25" cy="8" r="1.5" fill="#cc9900" opacity="0.5"/>
+</svg>

--- a/web/public/sprites/root-maze.svg
+++ b/web/public/sprites/root-maze.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="14" ry="1.5" fill="#0a1a0a" opacity="0.5"/>
+  <!-- Earthy ground -->
+  <rect x="0" y="25" width="32" height="7" fill="#3a2a1a" opacity="0.5"/>
+  <!-- Maze of thick roots forming walls -->
+  <!-- Outer root ring -->
+  <path d="M2,28 Q4,20 8,16 Q12,10 16,8 Q20,10 24,16 Q28,20 30,28" fill="none" stroke="#5a3a1a" stroke-width="4"/>
+  <!-- Inner root passages -->
+  <path d="M8,28 Q10,22 12,18 Q14,14 16,12" fill="none" stroke="#6a4a2a" stroke-width="3"/>
+  <path d="M24,28 Q22,22 20,18 Q18,14 16,12" fill="none" stroke="#6a4a2a" stroke-width="3"/>
+  <!-- Cross root -->
+  <path d="M6,20 Q10,18 14,20 Q18,22 22,20 Q26,18 28,22" fill="none" stroke="#7a5a2a" stroke-width="2"/>
+  <!-- Central tree/root node -->
+  <circle cx="16" cy="12" r="4" fill="#4a3a1a"/>
+  <circle cx="16" cy="12" r="2.5" fill="#5a4a2a"/>
+  <!-- Glowing eye in center -->
+  <circle cx="16" cy="12" r="1.5" fill="#22aa22" opacity="0.7"/>
+  <circle cx="16" cy="12" r="0.8" fill="#44ff44" opacity="0.8"/>
+  <!-- Leaf clusters on roots -->
+  <ellipse cx="5" cy="17" rx="3" ry="2" fill="#2a6a1a" opacity="0.7"/>
+  <ellipse cx="27" cy="17" rx="3" ry="2" fill="#2a6a1a" opacity="0.7"/>
+  <ellipse cx="16" cy="8" rx="4" ry="2.5" fill="#3a7a2a" opacity="0.7"/>
+  <!-- Small glowing orbs marking path -->
+  <circle cx="10" cy="24" r="0.8" fill="#44ff44" opacity="0.5"/>
+  <circle cx="22" cy="24" r="0.8" fill="#44ff44" opacity="0.5"/>
+  <circle cx="7" cy="20" r="0.7" fill="#22cc22" opacity="0.4"/>
+</svg>

--- a/web/public/sprites/root-tap.svg
+++ b/web/public/sprites/root-tap.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="10" ry="1.5" fill="#0a1a0a" opacity="0.5"/>
+  <!-- Taproot going deep into ground (visible cross-section look) -->
+  <!-- Ground surface -->
+  <rect x="0" y="20" width="32" height="12" fill="#4a3a1a" opacity="0.6"/>
+  <!-- Main taproot trunk -->
+  <rect x="13" y="8" width="6" height="24" rx="2" fill="#6a4a1a"/>
+  <!-- Root branches spreading underground -->
+  <path d="M14,24 Q8,26 4,30" fill="none" stroke="#5a3a1a" stroke-width="2.5"/>
+  <path d="M18,24 Q24,26 28,30" fill="none" stroke="#5a3a1a" stroke-width="2.5"/>
+  <path d="M13,28 Q7,28 3,32" fill="none" stroke="#4a2a0a" stroke-width="1.5"/>
+  <path d="M19,28 Q25,28 29,32" fill="none" stroke="#4a2a0a" stroke-width="1.5"/>
+  <!-- Mana sap glowing within tap root -->
+  <rect x="14.5" y="8" width="3" height="24" rx="1" fill="#22aa44" opacity="0.4"/>
+  <!-- Tap/spigot mechanism at top -->
+  <rect x="11" y="7" width="10" height="4" rx="1" fill="#5a5a2a"/>
+  <rect x="15" y="4" width="2" height="4" rx="0.5" fill="#6a6a3a"/>
+  <!-- Mana droplets falling from tap -->
+  <circle cx="16" cy="12" r="1" fill="#22cc44" opacity="0.7"/>
+  <circle cx="14" cy="14" r="0.8" fill="#22cc44" opacity="0.5"/>
+  <circle cx="18" cy="15" r="0.7" fill="#33dd55" opacity="0.5"/>
+  <!-- Surface foliage above tap -->
+  <ellipse cx="16" cy="5" rx="8" ry="4" fill="#2a6a1a"/>
+  <ellipse cx="11" cy="6" rx="4" ry="3" fill="#3a7a2a"/>
+  <ellipse cx="21" cy="6" rx="4" ry="3" fill="#3a7a2a"/>
+  <!-- Root node connection sparkles -->
+  <circle cx="6" cy="28" r="1" fill="#44ff66" opacity="0.5"/>
+  <circle cx="26" cy="28" r="1" fill="#44ff66" opacity="0.5"/>
+</svg>

--- a/web/public/sprites/root-wall.svg
+++ b/web/public/sprites/root-wall.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="14" ry="1.5" fill="#0a1a0a" opacity="0.5"/>
+  <!-- Wall of interwoven roots -->
+  <!-- Base root layer (thick) -->
+  <path d="M0,28 Q8,24 16,26 Q24,28 32,24" fill="none" stroke="#5a3a1a" stroke-width="5"/>
+  <!-- Middle root layer -->
+  <path d="M0,22 Q6,18 12,20 Q18,22 24,18 Q28,16 32,18" fill="none" stroke="#6a4a2a" stroke-width="4.5"/>
+  <!-- Upper root layer -->
+  <path d="M0,16 Q8,12 16,14 Q24,16 32,12" fill="none" stroke="#5a3a1a" stroke-width="4"/>
+  <!-- Top root layer -->
+  <path d="M2,10 Q10,6 16,8 Q22,10 30,6" fill="none" stroke="#6a4a2a" stroke-width="3.5"/>
+  <!-- Vertical binding roots -->
+  <line x1="6" y1="8" x2="5" y2="28" stroke="#4a2a0a" stroke-width="2"/>
+  <line x1="16" y1="6" x2="16" y2="28" stroke="#4a2a0a" stroke-width="2"/>
+  <line x1="26" y1="8" x2="27" y2="28" stroke="#4a2a0a" stroke-width="2"/>
+  <!-- Leaf/sprout nodes where roots cross -->
+  <circle cx="6" cy="20" r="3" fill="#2a6a1a" opacity="0.7"/>
+  <circle cx="16" cy="18" r="3" fill="#3a7a2a" opacity="0.7"/>
+  <circle cx="26" cy="20" r="3" fill="#2a6a1a" opacity="0.7"/>
+  <!-- Thorny spikes on top roots -->
+  <polygon points="4,9 5,6 6,9" fill="#4a3a1a"/>
+  <polygon points="10,7 11,4 12,7" fill="#4a3a1a"/>
+  <polygon points="16,5 17,2 18,5" fill="#4a3a1a"/>
+  <polygon points="21,7 22,4 23,7" fill="#4a3a1a"/>
+  <polygon points="27,8 28,5 29,8" fill="#4a3a1a"/>
+  <!-- Green glow from life force -->
+  <ellipse cx="16" cy="16" rx="15" ry="8" fill="#22aa22" opacity="0.07"/>
+</svg>

--- a/web/public/sprites/rot-burrow.svg
+++ b/web/public/sprites/rot-burrow.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#1a1a0a" opacity="0.6"/>
+  <!-- Decayed, rotting mound -->
+  <ellipse cx="16" cy="26" rx="14" ry="7" fill="#3a2a1a"/>
+  <ellipse cx="16" cy="25" rx="13" ry="6" fill="#4a3a2a"/>
+  <!-- Rot/decay patches (dark splotches) -->
+  <ellipse cx="8" cy="23" rx="3" ry="2" fill="#2a1a0a" opacity="0.6"/>
+  <ellipse cx="22" cy="24" rx="2.5" ry="1.5" fill="#2a1a0a" opacity="0.5"/>
+  <ellipse cx="15" cy="22" rx="2" ry="1.5" fill="#1a0a00" opacity="0.6"/>
+  <!-- Decomposing wood/bone sticking out -->
+  <line x1="5" y1="22" x2="7" y2="27" stroke="#5a3a1a" stroke-width="2"/>
+  <line x1="27" y1="23" x2="25" y2="27" stroke="#5a3a1a" stroke-width="2"/>
+  <!-- Main burrow (dark rot-brown) -->
+  <ellipse cx="16" cy="27" rx="6" ry="4.5" fill="#0a0800"/>
+  <!-- Side burrows -->
+  <ellipse cx="7" cy="27" rx="3.5" ry="3" fill="#0a0800"/>
+  <ellipse cx="25" cy="27" rx="3.5" ry="3" fill="#0a0800"/>
+  <!-- Glowing yellow rot-eyes -->
+  <circle cx="15" cy="27" r="0.9" fill="#cc8800" opacity="0.8"/>
+  <circle cx="17" cy="27" r="0.9" fill="#cc8800" opacity="0.8"/>
+  <circle cx="6" cy="27" r="0.7" fill="#aa6600" opacity="0.7"/>
+  <circle cx="24" cy="27" r="0.7" fill="#aa6600" opacity="0.7"/>
+  <!-- Fungal growth on mound -->
+  <ellipse cx="10" cy="21" rx="2" ry="1" fill="#7a6a2a" opacity="0.6"/>
+  <rect x="9.5" y="21" width="1" height="2" rx="0.3" fill="#5a4a1a"/>
+  <ellipse cx="21" cy="21" rx="1.5" ry="0.8" fill="#7a6a2a" opacity="0.5"/>
+  <!-- Gas bubbles -->
+  <circle cx="12" cy="18" r="1.5" fill="#6a6a1a" opacity="0.3"/>
+  <circle cx="20" cy="17" r="1.2" fill="#6a6a1a" opacity="0.3"/>
+  <circle cx="16" cy="15" r="1.8" fill="#5a5a10" opacity="0.25"/>
+</svg>

--- a/web/public/sprites/rot-hall.svg
+++ b/web/public/sprites/rot-hall.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="14" ry="1.5" fill="#1a1a0a" opacity="0.5"/>
+  <!-- Crumbling, rotted hall walls -->
+  <rect x="2" y="14" width="28" height="16" rx="1" fill="#3a2a1a"/>
+  <!-- Rot/decay patches on walls -->
+  <rect x="2" y="14" width="5" height="16" fill="#2a1a0a" opacity="0.4"/>
+  <rect x="20" y="16" width="10" height="14" fill="#2a1a0a" opacity="0.3"/>
+  <!-- Stone lines (degraded) -->
+  <line x1="2" y1="18" x2="30" y2="18" stroke="#1a1a0a" stroke-width="0.6"/>
+  <line x1="2" y1="23" x2="30" y2="23" stroke="#1a1a0a" stroke-width="0.5"/>
+  <!-- Collapsed section of wall (missing brick) -->
+  <polygon points="20,14 24,14 24,16 21,17" fill="#1a0a00"/>
+  <polygon points="26,14 30,14 30,17 27,16" fill="#1a0a00"/>
+  <!-- Sagging, partially collapsed roof -->
+  <polygon points="0,14 16,5 32,14" fill="#2a1a0a"/>
+  <polygon points="2,14 10,7 20,10 30,14" fill="#3a2a1a"/>
+  <!-- Holes in roof -->
+  <ellipse cx="8" cy="10" rx="3" ry="2" fill="#1a0a00"/>
+  <ellipse cx="22" cy="11" rx="2" ry="1.5" fill="#1a0a00"/>
+  <!-- Fungus growing through rot -->
+  <ellipse cx="5" cy="16" rx="2.5" ry="1.5" fill="#6a6a1a" opacity="0.6"/>
+  <rect x="4.5" y="14" width="1" height="3" fill="#4a4a0a"/>
+  <ellipse cx="25" cy="17" rx="2" ry="1.2" fill="#5a5a1a" opacity="0.5"/>
+  <!-- Gate (rotted wooden door) -->
+  <rect x="13" y="20" width="6" height="10" rx="0.3" fill="#3a2a0a"/>
+  <line x1="14" y1="21" x2="14" y2="30" stroke="#2a1a0a" stroke-width="0.8"/>
+  <line x1="18" y1="21" x2="18" y2="30" stroke="#2a1a0a" stroke-width="0.8"/>
+  <!-- Ooze/slime drips from roof -->
+  <path d="M9,14 Q9.5,16 9,18" fill="none" stroke="#5a6a1a" stroke-width="0.8" opacity="0.5"/>
+  <path d="M23,14 Q23.5,17 23,20" fill="none" stroke="#5a6a1a" stroke-width="0.8" opacity="0.5"/>
+  <!-- Bones on ground near entrance -->
+  <line x1="9" y1="29" x2="12" y2="28" stroke="#ccbb99" stroke-width="1"/>
+  <line x1="20" y1="28" x2="23" y2="29" stroke="#ccbb99" stroke-width="1"/>
+</svg>

--- a/web/public/sprites/rune-forge.svg
+++ b/web/public/sprites/rune-forge.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="12" ry="1.5" fill="#1a1a2a" opacity="0.5"/>
+  <!-- Forge base (stone and rune-carved) -->
+  <rect x="4" y="20" width="24" height="10" rx="1" fill="#3a3a5a"/>
+  <!-- Forge body -->
+  <rect x="6" y="12" width="20" height="10" rx="1" fill="#4a4a6a"/>
+  <!-- Rune carvings glowing on walls -->
+  <line x1="8" y1="15" x2="10" y2="15" stroke="#4488ff" stroke-width="0.8" opacity="0.8"/>
+  <line x1="9" y1="14" x2="9" y2="16" stroke="#4488ff" stroke-width="0.8" opacity="0.8"/>
+  <line x1="22" y1="15" x2="24" y2="15" stroke="#4488ff" stroke-width="0.8" opacity="0.8"/>
+  <line x1="23" y1="14" x2="23" y2="16" stroke="#4488ff" stroke-width="0.8" opacity="0.8"/>
+  <!-- Rune symbols (simplified) -->
+  <path d="M13,17 L14,15 L15,17" fill="none" stroke="#6699ff" stroke-width="0.7" opacity="0.7"/>
+  <path d="M17,17 L18,15 L19,17" fill="none" stroke="#6699ff" stroke-width="0.7" opacity="0.7"/>
+  <!-- Forge chimney -->
+  <rect x="13" y="4" width="6" height="10" rx="0.5" fill="#3a3a5a"/>
+  <rect x="11" y="3" width="10" height="3" rx="0.5" fill="#4a4a6a"/>
+  <!-- Arcane fire in forge opening -->
+  <ellipse cx="16" cy="22" rx="6" ry="3.5" fill="#0a0a1a"/>
+  <ellipse cx="16" cy="22" rx="5" ry="2.5" fill="#2233aa" opacity="0.8"/>
+  <ellipse cx="16" cy="22" rx="3.5" ry="1.8" fill="#4455cc" opacity="0.8"/>
+  <ellipse cx="16" cy="22" rx="2" ry="1" fill="#8899ff" opacity="0.9"/>
+  <!-- Runic exhaust from chimney -->
+  <circle cx="14.5" cy="4" rx="3" r="2" fill="#4466ff" opacity="0.25"/>
+  <circle cx="14" cy="2" r="1.5" fill="#6688ff" opacity="0.2"/>
+  <!-- Glowing rune aura -->
+  <ellipse cx="16" cy="17" rx="12" ry="6" fill="#4466ff" opacity="0.06"/>
+  <!-- Enchanted weapon in forge -->
+  <line x1="14" y1="24" x2="18" y2="20" stroke="#aabbff" stroke-width="1.2" opacity="0.7"/>
+  <polygon points="18,20 20,18 19,21" fill="#aabbff" opacity="0.7"/>
+</svg>

--- a/web/public/sprites/sacred-grove.svg
+++ b/web/public/sprites/sacred-grove.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="14" ry="1.5" fill="#0a1a0a" opacity="0.5"/>
+  <!-- Grove ground (lush) -->
+  <ellipse cx="16" cy="28" rx="14" ry="5" fill="#2a5a1a"/>
+  <!-- Three sacred trees -->
+  <!-- Left tree -->
+  <rect x="5" y="16" width="4" height="14" rx="1" fill="#5a3a0a"/>
+  <ellipse cx="7" cy="14" rx="6" ry="6" fill="#2a7a1a"/>
+  <ellipse cx="4" cy="16" rx="4" ry="4" fill="#3a8a2a"/>
+  <ellipse cx="10" cy="16" rx="4" ry="4" fill="#3a8a2a"/>
+  <!-- Centre tree (tallest) -->
+  <rect x="13" y="10" width="6" height="20" rx="1" fill="#6a4a1a"/>
+  <ellipse cx="16" cy="8" rx="9" ry="7" fill="#1a6a0a"/>
+  <ellipse cx="10" cy="12" rx="5" ry="5" fill="#2a7a1a"/>
+  <ellipse cx="22" cy="12" rx="5" ry="5" fill="#2a7a1a"/>
+  <ellipse cx="16" cy="5" rx="6" ry="5" fill="#3a8a2a"/>
+  <!-- Right tree -->
+  <rect x="23" y="16" width="4" height="14" rx="1" fill="#5a3a0a"/>
+  <ellipse cx="25" cy="14" rx="6" ry="6" fill="#2a7a1a"/>
+  <ellipse cx="22" cy="16" rx="4" ry="4" fill="#3a8a2a"/>
+  <ellipse cx="28" cy="16" rx="4" ry="4" fill="#3a8a2a"/>
+  <!-- Sacred light filtering through -->
+  <ellipse cx="16" cy="20" rx="6" ry="4" fill="#ffffaa" opacity="0.12"/>
+  <!-- Firefly/spirit lights in grove -->
+  <circle cx="8" cy="20" r="0.8" fill="#aaff44" opacity="0.6"/>
+  <circle cx="24" cy="19" r="0.7" fill="#aaff44" opacity="0.5"/>
+  <circle cx="16" cy="16" r="0.8" fill="#ffff88" opacity="0.5"/>
+  <circle cx="11" cy="24" r="0.6" fill="#88ffaa" opacity="0.4"/>
+  <!-- Mossy stone altar in centre -->
+  <rect x="13" y="26" width="6" height="3" rx="0.5" fill="#5a6a3a"/>
+  <rect x="12" y="25" width="8" height="2" rx="0.3" fill="#6a7a4a"/>
+</svg>

--- a/web/public/sprites/sand-veil.svg
+++ b/web/public/sprites/sand-veil.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#1a1a0a" opacity="0.4"/>
+  <!-- Desert sand ground -->
+  <rect x="0" y="26" width="32" height="6" fill="#cc9933" opacity="0.3"/>
+  <!-- Shimmering sand veil curtain (translucent layers) -->
+  <rect x="0" y="4" width="32" height="28" fill="#ddbb55" opacity="0.07"/>
+  <!-- Veil pillars/support posts -->
+  <rect x="3" y="8" width="3" height="22" rx="0.5" fill="#aa7722"/>
+  <rect x="26" y="8" width="3" height="22" rx="0.5" fill="#aa7722"/>
+  <!-- Hanging veil fabric waves -->
+  <path d="M3,10 Q8,8 13,12 Q18,16 23,12 Q27,8 29,10" fill="#ddbb55" stroke="#cc9933" stroke-width="0.5" opacity="0.4"/>
+  <path d="M3,14 Q8,12 13,16 Q18,20 23,16 Q27,12 29,14" fill="#ddcc77" stroke="#cc9933" stroke-width="0.5" opacity="0.35"/>
+  <path d="M3,18 Q8,16 13,20 Q18,24 23,20 Q27,16 29,18" fill="#ddbb55" stroke="#cc9933" stroke-width="0.5" opacity="0.3"/>
+  <path d="M3,22 Q8,20 13,24 Q18,28 23,24 Q27,20 29,22" fill="#ddcc77" stroke="#cc9933" stroke-width="0.5" opacity="0.25"/>
+  <!-- Sand particle swirl (the veil effect) -->
+  <circle cx="9" cy="12" r="1.5" fill="#ffdd88" opacity="0.3"/>
+  <circle cx="16" cy="16" r="2" fill="#ffdd88" opacity="0.25"/>
+  <circle cx="23" cy="12" r="1.5" fill="#ffdd88" opacity="0.3"/>
+  <circle cx="13" cy="20" r="1.2" fill="#eebb66" opacity="0.25"/>
+  <circle cx="20" cy="22" r="1" fill="#eebb66" opacity="0.2"/>
+  <!-- Top crossbar -->
+  <rect x="2" y="6" width="28" height="2.5" rx="0.5" fill="#aa7722"/>
+  <!-- Sun ornament on crossbar centre -->
+  <circle cx="16" cy="7" r="2" fill="#ffcc00"/>
+  <circle cx="16" cy="7" r="1" fill="#ffee44"/>
+  <!-- Sand dune at base -->
+  <ellipse cx="16" cy="29" rx="14" ry="3" fill="#cc9933" opacity="0.4"/>
+</svg>

--- a/web/public/sprites/sandstone-citadel.svg
+++ b/web/public/sprites/sandstone-citadel.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="14" ry="1.5" fill="#1a1a0a" opacity="0.5"/>
+  <!-- Massive sandstone walls -->
+  <rect x="1" y="14" width="30" height="16" rx="1" fill="#cc9944"/>
+  <!-- Sandstone block lines -->
+  <line x1="1" y1="19" x2="31" y2="19" stroke="#aa7722" stroke-width="0.8"/>
+  <line x1="1" y1="24" x2="31" y2="24" stroke="#aa7722" stroke-width="0.8"/>
+  <line x1="1" y1="28" x2="31" y2="28" stroke="#aa7722" stroke-width="0.6"/>
+  <line x1="7" y1="14" x2="7" y2="30" stroke="#aa7722" stroke-width="0.6"/>
+  <line x1="16" y1="14" x2="16" y2="30" stroke="#aa7722" stroke-width="0.4"/>
+  <line x1="25" y1="14" x2="25" y2="30" stroke="#aa7722" stroke-width="0.6"/>
+  <!-- Flanking towers -->
+  <rect x="0" y="8" width="9" height="22" rx="1" fill="#ddaa55"/>
+  <rect x="23" y="8" width="9" height="22" rx="1" fill="#ddaa55"/>
+  <!-- Tower battlements -->
+  <rect x="0" y="6" width="3.5" height="4" rx="0.3" fill="#cc9944"/>
+  <rect x="5.5" y="6" width="3.5" height="4" rx="0.3" fill="#cc9944"/>
+  <rect x="23" y="6" width="3.5" height="4" rx="0.3" fill="#cc9944"/>
+  <rect x="28.5" y="6" width="3.5" height="4" rx="0.3" fill="#cc9944"/>
+  <!-- Central keep tower -->
+  <rect x="11" y="4" width="10" height="12" rx="0.5" fill="#eebb66"/>
+  <rect x="10" y="3" width="12" height="2.5" rx="0.3" fill="#cc9944"/>
+  <!-- Pyramid-like ornament on top -->
+  <polygon points="13,3 16,0 19,3" fill="#aa7722"/>
+  <!-- Ornate arched gate -->
+  <path d="M12,30 L12,20 Q16,14 20,20 L20,30 Z" fill="#2a1a0a"/>
+  <!-- Carved relief above gate -->
+  <ellipse cx="16" cy="17" rx="3" ry="2" fill="#cc9944"/>
+  <circle cx="16" cy="17" r="1.5" fill="#ffcc55"/>
+  <circle cx="16" cy="17" r="0.8" fill="#ffee88"/>
+  <!-- Desert heat shimmer at base -->
+  <ellipse cx="16" cy="30" rx="12" ry="1" fill="#ffdd88" opacity="0.15"/>
+</svg>

--- a/web/public/sprites/sandstorm-camp.svg
+++ b/web/public/sprites/sandstorm-camp.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="14" ry="1.5" fill="#1a1a0a" opacity="0.4"/>
+  <!-- Desert sand ground -->
+  <rect x="0" y="25" width="32" height="7" fill="#cc9933" opacity="0.4"/>
+  <!-- Central tent (large command tent) -->
+  <polygon points="4,22 16,10 28,22" fill="#cc8833"/>
+  <polygon points="6,22 16,12 26,22" fill="#ddaa44"/>
+  <!-- Tent stripes -->
+  <path d="M8,22 Q12,15 16,12 Q20,15 24,22" fill="none" stroke="#bb7722" stroke-width="1"/>
+  <path d="M10,22 Q13,16 16,13 Q19,16 22,22" fill="none" stroke="#bb7722" stroke-width="0.7"/>
+  <!-- Tent entrance flap -->
+  <polygon points="13,22 16,17 19,22" fill="#aa7722"/>
+  <!-- Tent pole/peak ornament -->
+  <line x1="16" y1="10" x2="16" y2="7" stroke="#8a6a2a" stroke-width="1"/>
+  <circle cx="16" cy="6" r="1.5" fill="#ffcc00"/>
+  <!-- Smaller flanking tents -->
+  <polygon points="1,26 7,18 13,26" fill="#bb7733" opacity="0.9"/>
+  <polygon points="19,26 25,18 31,26" fill="#bb7733" opacity="0.9"/>
+  <!-- Sand swirling around camp -->
+  <path d="M0,20 Q4,18 8,20" fill="none" stroke="#ddcc77" stroke-width="1" opacity="0.4"/>
+  <path d="M24,20 Q28,18 32,20" fill="none" stroke="#ddcc77" stroke-width="1" opacity="0.4"/>
+  <!-- Campfire between tents -->
+  <circle cx="9" cy="25" r="1.5" fill="#1a0800"/>
+  <path d="M8,23 Q9,21 10,23" fill="#ff6600" opacity="0.8"/>
+  <path d="M8.5,23 Q9,22 9.5,23" fill="#ffcc00" opacity="0.7"/>
+  <circle cx="23" cy="25" r="1.5" fill="#1a0800"/>
+  <path d="M22,23 Q23,21 24,23" fill="#ff6600" opacity="0.8"/>
+  <!-- Sand particle drifts -->
+  <ellipse cx="5" cy="18" rx="3" ry="1" fill="#ddbb66" opacity="0.25" transform="rotate(-10 5 18)"/>
+  <ellipse cx="27" cy="17" rx="3" ry="1" fill="#ddbb66" opacity="0.25" transform="rotate(10 27 17)"/>
+</svg>

--- a/web/public/sprites/sapper-works.svg
+++ b/web/public/sprites/sapper-works.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#1a1a1a" opacity="0.5"/>
+  <!-- Workshop building -->
+  <rect x="2" y="14" width="20" height="16" rx="1" fill="#5a5a4a"/>
+  <!-- Roof -->
+  <polygon points="0,14 11,6 22,14" fill="#3a3a2a"/>
+  <polygon points="2,14 11,8 20,14" fill="#4a4a3a"/>
+  <!-- Workshop window -->
+  <rect x="5" y="17" width="5" height="4" rx="0.3" fill="#2a2a1a"/>
+  <line x1="7.5" y1="17" x2="7.5" y2="21" stroke="#5a5a3a" stroke-width="0.4"/>
+  <line x1="5" y1="19" x2="10" y2="19" stroke="#5a5a3a" stroke-width="0.4"/>
+  <!-- Door -->
+  <rect x="13" y="20" width="5" height="10" rx="0.3" fill="#2a2a1a"/>
+  <!-- Chimney with smoke -->
+  <rect x="14" y="7" width="3" height="8" rx="0.3" fill="#4a4a3a"/>
+  <circle cx="15.5" cy="7" r="2" fill="#6a6a5a" opacity="0.4"/>
+  <!-- Mining/sapping equipment to right -->
+  <!-- Barrel of explosives -->
+  <rect x="23" y="20" width="5" height="6" rx="1" fill="#8a6a2a"/>
+  <line x1="23" y1="22" x2="28" y2="22" stroke="#6a4a1a" stroke-width="0.7"/>
+  <line x1="23" y1="24" x2="28" y2="24" stroke="#6a4a1a" stroke-width="0.7"/>
+  <!-- Fuse on barrel -->
+  <path d="M28,21 Q30,19 31,17" fill="none" stroke="#8a6a2a" stroke-width="0.8"/>
+  <circle cx="31" cy="17" r="1" fill="#ff6600" opacity="0.7"/>
+  <!-- Pickaxe and shovel leaning -->
+  <line x1="25" y1="13" x2="25" y2="20" stroke="#7a6a4a" stroke-width="1.5"/>
+  <polygon points="22,13 25,13 24,16" fill="#8a8a8a"/>
+  <line x1="29" y1="14" x2="28" y2="20" stroke="#7a6a4a" stroke-width="1.5"/>
+  <polygon points="26,14 30,14 29,17 27,17" fill="#8a7a5a"/>
+  <!-- Tunnel entrance dug in ground -->
+  <ellipse cx="7" cy="30" rx="5" ry="2.5" fill="#2a2a1a"/>
+  <ellipse cx="7" cy="29" rx="4" ry="2" fill="#3a2a1a"/>
+</svg>

--- a/web/public/sprites/scorch-redoubt.svg
+++ b/web/public/sprites/scorch-redoubt.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#2a0a00" opacity="0.5"/>
+  <!-- Scorched, blackened earth base -->
+  <rect x="2" y="24" width="28" height="6" rx="1" fill="#2a1a0a"/>
+  <!-- Burnt/scorched redoubt walls -->
+  <rect x="3" y="12" width="26" height="14" rx="1" fill="#3a2a1a"/>
+  <!-- Scorch marks on walls -->
+  <rect x="3" y="12" width="6" height="14" fill="#1a0a00" opacity="0.4"/>
+  <rect x="23" y="14" width="6" height="12" fill="#1a0a00" opacity="0.3"/>
+  <!-- Stone block texture (partly melted) -->
+  <line x1="3" y1="16" x2="29" y2="16" stroke="#1a1a0a" stroke-width="0.7"/>
+  <line x1="3" y1="21" x2="29" y2="21" stroke="#1a1a0a" stroke-width="0.6"/>
+  <!-- Scorched battlements -->
+  <rect x="3" y="9" width="4" height="4" rx="0.3" fill="#2a1a0a"/>
+  <rect x="10" y="9" width="4" height="4" rx="0.3" fill="#3a2a1a"/>
+  <rect x="18" y="9" width="4" height="4" rx="0.3" fill="#2a1a0a"/>
+  <rect x="25" y="9" width="4" height="4" rx="0.3" fill="#3a2a1a"/>
+  <!-- Fire still burning in redoubt -->
+  <path d="M11,20 Q13,15 15,18 Q13,21 11,20Z" fill="#ff4400" opacity="0.6"/>
+  <path d="M17,19 Q19,14 21,17 Q19,20 17,19Z" fill="#ff6600" opacity="0.5"/>
+  <path d="M13,21 Q14,18 15.5,20" fill="none" stroke="#ffaa00" stroke-width="0.8" opacity="0.6"/>
+  <!-- Fire embrasures (arrow slits with fire) -->
+  <rect x="6" y="14" width="2" height="4" rx="0.2" fill="#1a0a00"/>
+  <rect x="24" y="14" width="2" height="4" rx="0.2" fill="#1a0a00"/>
+  <circle cx="7" cy="15" r="1" fill="#ff4400" opacity="0.6"/>
+  <circle cx="25" cy="15" r="1" fill="#ff4400" opacity="0.6"/>
+  <!-- Gate (fire-blasted) -->
+  <path d="M13,26 L13,18 Q16,14 19,18 L19,26 Z" fill="#0a0500"/>
+  <!-- Ember glow at base -->
+  <ellipse cx="16" cy="27" rx="10" ry="1.5" fill="#ff4400" opacity="0.15"/>
+</svg>

--- a/web/public/sprites/scorch-roost.svg
+++ b/web/public/sprites/scorch-roost.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="10" ry="1.5" fill="#2a0a00" opacity="0.5"/>
+  <!-- Scorched rocky pillar -->
+  <rect x="10" y="18" width="12" height="12" rx="1" fill="#2a1a0a"/>
+  <!-- Char marks on pillar -->
+  <rect x="10" y="20" width="3" height="8" fill="#1a0a00" opacity="0.5"/>
+  <rect x="19" y="22" width="3" height="8" fill="#1a0a00" opacity="0.4"/>
+  <!-- Burnt nest platform on top -->
+  <ellipse cx="16" cy="18" rx="10" ry="3" fill="#3a2a0a"/>
+  <ellipse cx="16" cy="17" rx="9" ry="2.5" fill="#4a3a1a"/>
+  <!-- Charred twigs in nest -->
+  <path d="M8,17 Q12,14 16,16 Q20,14 24,17" fill="none" stroke="#2a1a0a" stroke-width="1.2"/>
+  <path d="M10,18 Q13,16 16,17 Q19,16 22,18" fill="none" stroke="#1a0a00" stroke-width="0.8"/>
+  <!-- Fire creature/phoenix egg glowing in nest -->
+  <ellipse cx="16" cy="16" rx="3.5" ry="2.5" fill="#aa2200"/>
+  <ellipse cx="16" cy="16" rx="2" ry="1.5" fill="#ff4400"/>
+  <ellipse cx="16" cy="16" rx="1" ry="0.8" fill="#ffcc00"/>
+  <!-- Scorched bird/phoenix silhouette above -->
+  <path d="M8,10 Q16,5 24,10" fill="none" stroke="#5a2a0a" stroke-width="1.5"/>
+  <path d="M8,10 Q4,7 6,5 Q10,8 8,10Z" fill="#8a3a1a" opacity="0.7"/>
+  <path d="M24,10 Q28,7 26,5 Q22,8 24,10Z" fill="#8a3a1a" opacity="0.7"/>
+  <ellipse cx="16" cy="9" rx="3.5" ry="2" fill="#aa4a1a"/>
+  <circle cx="19" cy="8" r="1.5" fill="#cc6622"/>
+  <!-- Flame trail from wings -->
+  <path d="M5,9 Q3,7 4,5" fill="none" stroke="#ff6600" stroke-width="0.8" opacity="0.5"/>
+  <path d="M27,9 Q29,7 28,5" fill="none" stroke="#ff6600" stroke-width="0.8" opacity="0.5"/>
+  <!-- Ember sparks -->
+  <circle cx="9" cy="6" r="0.7" fill="#ff4400" opacity="0.5"/>
+  <circle cx="22" cy="4" r="0.6" fill="#ff8800" opacity="0.5"/>
+</svg>

--- a/web/public/sprites/scout-blind.svg
+++ b/web/public/sprites/scout-blind.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="11" ry="1.5" fill="#0a1a0a" opacity="0.5"/>
+  <!-- Ground / undergrowth -->
+  <rect x="0" y="26" width="32" height="6" fill="#2a5a1a" opacity="0.4"/>
+  <!-- Camouflage frame (wooden) -->
+  <rect x="6" y="12" width="20" height="16" rx="0.5" fill="#5a4a1a" opacity="0.8"/>
+  <!-- Dense leafy covering (camouflage) -->
+  <ellipse cx="16" cy="11" rx="14" ry="5" fill="#2a7a1a"/>
+  <ellipse cx="8" cy="13" rx="7" ry="5" fill="#3a8a2a"/>
+  <ellipse cx="24" cy="13" rx="7" ry="5" fill="#3a8a2a"/>
+  <ellipse cx="16" cy="14" rx="10" ry="5" fill="#4a9a3a"/>
+  <!-- Side leaf clusters -->
+  <ellipse cx="4" cy="18" rx="5" ry="4" fill="#2a7a1a"/>
+  <ellipse cx="28" cy="17" rx="5" ry="4" fill="#2a7a1a"/>
+  <!-- Narrow observation slit -->
+  <rect x="8" y="16" width="16" height="3" rx="0.3" fill="#0a0a0a"/>
+  <!-- Scout eye in slit -->
+  <ellipse cx="16" cy="17.5" rx="3" ry="1" fill="#0a0a0a"/>
+  <circle cx="16" cy="17.5" r="0.7" fill="#ff4400" opacity="0.7"/>
+  <!-- Stilts holding blind above ground -->
+  <line x1="8" y1="22" x2="7" y2="30" stroke="#5a4a1a" stroke-width="1.5"/>
+  <line x1="14" y1="22" x2="13" y2="30" stroke="#5a4a1a" stroke-width="1.5"/>
+  <line x1="20" y1="22" x2="21" y2="30" stroke="#5a4a1a" stroke-width="1.5"/>
+  <line x1="24" y1="22" x2="25" y2="30" stroke="#5a4a1a" stroke-width="1.5"/>
+  <!-- Small flowers on top (camouflage) -->
+  <circle cx="6" cy="10" r="1.2" fill="#ff4488" opacity="0.5"/>
+  <circle cx="26" cy="11" r="1" fill="#ffcc00" opacity="0.5"/>
+  <circle cx="16" cy="8" r="1" fill="#ff8844" opacity="0.4"/>
+</svg>

--- a/web/public/sprites/scout-garden.svg
+++ b/web/public/sprites/scout-garden.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="14" ry="1.5" fill="#0a1a0a" opacity="0.5"/>
+  <!-- Garden ground -->
+  <ellipse cx="16" cy="28" rx="14" ry="5" fill="#3a5a1a"/>
+  <!-- Low hedge walls (camouflage) -->
+  <rect x="2" y="18" width="28" height="8" rx="1" fill="#2a6a1a" opacity="0.9"/>
+  <ellipse cx="6" cy="18" rx="5" ry="3" fill="#3a7a2a"/>
+  <ellipse cx="14" cy="17" rx="5" ry="3" fill="#4a8a3a"/>
+  <ellipse cx="22" cy="18" rx="5" ry="3" fill="#3a7a2a"/>
+  <ellipse cx="28" cy="19" rx="4" ry="3" fill="#2a6a1a"/>
+  <!-- Scout post inside garden (camouflaged tower) -->
+  <rect x="12" y="8" width="8" height="12" rx="0.5" fill="#4a6a2a"/>
+  <!-- Leafy camouflage on tower -->
+  <ellipse cx="16" cy="8" rx="8" ry="4" fill="#3a7a2a"/>
+  <ellipse cx="10" cy="10" rx="4" ry="3" fill="#2a6a1a"/>
+  <ellipse cx="22" cy="10" rx="4" ry="3" fill="#2a6a1a"/>
+  <!-- Observation slit on tower -->
+  <rect x="14" y="11" width="4" height="2" rx="0.2" fill="#0a1a0a"/>
+  <!-- Patrol path markers (stones) -->
+  <circle cx="6" cy="25" r="1" fill="#7a7a5a"/>
+  <circle cx="12" cy="26" r="0.8" fill="#7a7a5a"/>
+  <circle cx="20" cy="26" r="0.8" fill="#7a7a5a"/>
+  <circle cx="26" cy="25" r="1" fill="#7a7a5a"/>
+  <!-- Flowers scattered (camouflage) -->
+  <circle cx="4" cy="21" r="1.2" fill="#ff4488" opacity="0.5"/>
+  <circle cx="28" cy="21" r="1.2" fill="#ffcc00" opacity="0.5"/>
+  <circle cx="16" cy="20" r="1" fill="#ff8844" opacity="0.4"/>
+  <!-- Scout flag (small, hidden) -->
+  <line x1="16" y1="4" x2="16" y2="2" stroke="#4a5a2a" stroke-width="0.7"/>
+  <polygon points="16,2 20,3 16,4" fill="#4a8a2a" opacity="0.7"/>
+</svg>

--- a/web/public/sprites/scout-stable.svg
+++ b/web/public/sprites/scout-stable.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="14" ry="1.5" fill="#1a1a0a" opacity="0.5"/>
+  <!-- Stable building -->
+  <rect x="2" y="14" width="28" height="16" rx="1" fill="#8a6a3a"/>
+  <!-- Wooden plank texture -->
+  <line x1="2" y1="18" x2="30" y2="18" stroke="#6a4a1a" stroke-width="0.7"/>
+  <line x1="2" y1="22" x2="30" y2="22" stroke="#6a4a1a" stroke-width="0.7"/>
+  <line x1="2" y1="26" x2="30" y2="26" stroke="#6a4a1a" stroke-width="0.7"/>
+  <line x1="10" y1="14" x2="10" y2="30" stroke="#6a4a1a" stroke-width="0.5"/>
+  <line x1="22" y1="14" x2="22" y2="30" stroke="#6a4a1a" stroke-width="0.5"/>
+  <!-- Low-pitched roof (stable style) -->
+  <polygon points="0,14 16,6 32,14" fill="#5a3a1a"/>
+  <polygon points="2,14 16,8 30,14" fill="#7a5a2a"/>
+  <!-- Ventilation gap in roof peak -->
+  <line x1="16" y1="6" x2="16" y2="14" stroke="#4a2a0a" stroke-width="1"/>
+  <!-- Stable stalls (divided) -->
+  <rect x="12" y="18" width="8" height="12" rx="0.3" fill="#2a1a0a"/>
+  <!-- Horse silhouette in stall -->
+  <ellipse cx="16" cy="23" rx="3" ry="4" fill="#4a3a2a"/>
+  <ellipse cx="16" cy="19" rx="2" ry="2" fill="#5a4a3a"/>
+  <path d="M18,19 Q21,17 21,20" fill="none" stroke="#5a4a3a" stroke-width="1.5"/>
+  <!-- Hay bale outside stall -->
+  <rect x="3" y="22" width="6" height="5" rx="0.5" fill="#cc9933"/>
+  <line x1="3" y1="24.5" x2="9" y2="24.5" stroke="#aa7722" stroke-width="0.8"/>
+  <!-- Saddle/tack on wall -->
+  <path d="M23" fill="none"/>
+  <rect x="24" y="16" width="4" height="3" rx="0.5" fill="#6a4a2a"/>
+  <ellipse cx="26" cy="15" rx="2.5" ry="1.5" fill="#7a5a3a"/>
+  <!-- Scout banner (lightweight pennant) -->
+  <line x1="16" y1="6" x2="16" y2="3" stroke="#5a4a2a" stroke-width="0.8"/>
+  <polygon points="16,3 22,4.5 16,6" fill="#2a6a2a"/>
+</svg>

--- a/web/public/sprites/shadow-burrow.svg
+++ b/web/public/sprites/shadow-burrow.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#0a0a1a" opacity="0.6"/>
+  <!-- Dark shadowy mound -->
+  <ellipse cx="16" cy="26" rx="14" ry="7" fill="#1a1a2a"/>
+  <ellipse cx="16" cy="25" rx="13" ry="6" fill="#2a2a3a"/>
+  <!-- Shadow tendrils spreading from mound -->
+  <path d="M3,29 Q6,24 10,26" fill="none" stroke="#1a1a2a" stroke-width="2" opacity="0.7"/>
+  <path d="M29,29 Q26,24 22,26" fill="none" stroke="#1a1a2a" stroke-width="2" opacity="0.7"/>
+  <path d="M1,31 Q4,26 7,28" fill="none" stroke="#0a0a1a" stroke-width="1.5" opacity="0.5"/>
+  <!-- Main shadow burrow entrance -->
+  <ellipse cx="16" cy="27" rx="6" ry="4.5" fill="#0a0a0a"/>
+  <!-- Shadow void within -->
+  <ellipse cx="16" cy="27.5" rx="4" ry="3" fill="#000000" opacity="0.9"/>
+  <!-- Glowing purple eyes in void -->
+  <circle cx="14" cy="27" r="1" fill="#8800ff" opacity="0.9"/>
+  <circle cx="18" cy="27" r="1" fill="#8800ff" opacity="0.9"/>
+  <!-- Secondary shadow holes -->
+  <ellipse cx="7" cy="28" rx="3.5" ry="2.5" fill="#0a0a0a"/>
+  <circle cx="7" cy="28" r="0.8" fill="#6600cc" opacity="0.7"/>
+  <ellipse cx="25" cy="28" rx="3.5" ry="2.5" fill="#0a0a0a"/>
+  <circle cx="25" cy="28" r="0.8" fill="#6600cc" opacity="0.7"/>
+  <!-- Shadow miasma cloud above -->
+  <ellipse cx="16" cy="20" rx="10" ry="4" fill="#1a1a2a" opacity="0.5"/>
+  <ellipse cx="16" cy="17" rx="7" ry="3" fill="#2a1a3a" opacity="0.4"/>
+  <ellipse cx="16" cy="14" rx="5" ry="3" fill="#3a1a4a" opacity="0.3"/>
+  <!-- Shadow wisps -->
+  <circle cx="8" cy="18" r="1" fill="#6600cc" opacity="0.3"/>
+  <circle cx="24" cy="17" r="1" fill="#8800ff" opacity="0.3"/>
+</svg>

--- a/web/public/sprites/shaman-s-totem.svg
+++ b/web/public/sprites/shaman-s-totem.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="9" ry="1.5" fill="#1a1a0a" opacity="0.5"/>
+  <!-- Totem base stone -->
+  <rect x="12" y="26" width="8" height="4" rx="1" fill="#5a4a2a"/>
+  <!-- Main totem pole -->
+  <rect x="14" y="6" width="4" height="22" rx="0.5" fill="#7a5a2a"/>
+  <!-- Top face (spirit face) -->
+  <ellipse cx="16" cy="7" rx="4" ry="4" fill="#8a6a3a"/>
+  <!-- Top face features -->
+  <ellipse cx="14.5" cy="6.5" rx="1" ry="0.8" fill="#1a0a00"/>
+  <ellipse cx="17.5" cy="6.5" rx="1" ry="0.8" fill="#1a0a00"/>
+  <circle cx="14.5" cy="6.5" r="0.5" fill="#ff4400" opacity="0.7"/>
+  <circle cx="17.5" cy="6.5" r="0.5" fill="#ff4400" opacity="0.7"/>
+  <path d="M14,8.5 Q16,9.5 18,8.5" fill="none" stroke="#1a0a00" stroke-width="0.7"/>
+  <!-- Headdress feathers -->
+  <line x1="12" y1="4" x2="10" y2="0" stroke="#cc4422" stroke-width="1.5"/>
+  <line x1="14" y1="3" x2="13" y2="0" stroke="#dd6633" stroke-width="1.5"/>
+  <line x1="16" y1="3" x2="16" y2="0" stroke="#ffaa00" stroke-width="1.5"/>
+  <line x1="18" y1="3" x2="19" y2="0" stroke="#dd6633" stroke-width="1.5"/>
+  <line x1="20" y1="4" x2="22" y2="0" stroke="#cc4422" stroke-width="1.5"/>
+  <!-- Middle carved face -->
+  <ellipse cx="16" cy="15" rx="3.5" ry="3" fill="#7a5a2a"/>
+  <ellipse cx="14.5" cy="14.5" rx="0.8" ry="0.7" fill="#1a0a00"/>
+  <ellipse cx="17.5" cy="14.5" rx="0.8" ry="0.7" fill="#1a0a00"/>
+  <path d="M14.5,16.5 Q16,17.5 17.5,16.5" fill="none" stroke="#1a0a00" stroke-width="0.6"/>
+  <!-- Tribal rings/decorations -->
+  <rect x="13" y="19" width="6" height="1.5" rx="0.3" fill="#cc4422"/>
+  <rect x="13" y="22" width="6" height="1.5" rx="0.3" fill="#ffaa00"/>
+  <!-- Spiritual energy glow -->
+  <ellipse cx="16" cy="10" rx="6" ry="5" fill="#ffaa00" opacity="0.1"/>
+</svg>

--- a/web/public/sprites/shard-sanctum.svg
+++ b/web/public/sprites/shard-sanctum.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="12" ry="1.5" fill="#1a1a2a" opacity="0.5"/>
+  <!-- Crystal shard base cluster -->
+  <polygon points="4,30 7,22 10,28 13,20 16,26 19,20 22,28 25,22 28,30" fill="#3a3a5a"/>
+  <!-- Sanctum central building -->
+  <rect x="8" y="12" width="16" height="16" rx="1" fill="#4a4a6a"/>
+  <!-- Crystal lattice on walls -->
+  <line x1="8" y1="16" x2="24" y2="16" stroke="#5577aa" stroke-width="0.6"/>
+  <line x1="8" y1="20" x2="24" y2="20" stroke="#5577aa" stroke-width="0.5"/>
+  <line x1="16" y1="12" x2="16" y2="28" stroke="#5577aa" stroke-width="0.4"/>
+  <!-- Shard spire roof -->
+  <polygon points="6,12 16,2 26,12" fill="#2a2a4a"/>
+  <polygon points="8,12 16,4 24,12" fill="#3a3a5a"/>
+  <!-- Multiple shard tips -->
+  <polygon points="12,4 14,1 16,4 14,6" fill="#8899ff"/>
+  <polygon points="16,3 18,0 20,3 18,5" fill="#aabbff"/>
+  <polygon points="9,7 10,5 11,7 10,8" fill="#7788ee"/>
+  <!-- Glowing crystal windows -->
+  <rect x="10" y="14" width="4" height="5" rx="0.5" fill="#1a1a2a"/>
+  <rect x="11" y="15" width="2" height="3" fill="#6677ff" opacity="0.6"/>
+  <rect x="18" y="14" width="4" height="5" rx="0.5" fill="#1a1a2a"/>
+  <rect x="19" y="15" width="2" height="3" fill="#6677ff" opacity="0.6"/>
+  <!-- Arcane arch entrance -->
+  <path d="M13,28 L13,22 Q16,18 19,22 L19,28 Z" fill="#1a1a2a"/>
+  <!-- Crystal shards orbiting sanctum -->
+  <polygon points="5,10 6,8 7,10 6,11" fill="#8899ff" opacity="0.7"/>
+  <polygon points="25,10 26,8 27,10 26,11" fill="#8899ff" opacity="0.7"/>
+</svg>

--- a/web/public/sprites/shard-spire.svg
+++ b/web/public/sprites/shard-spire.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="9" ry="1.5" fill="#1a1a2a" opacity="0.5"/>
+  <!-- Crystal shard cluster base -->
+  <polygon points="8,30 10,24 13,28 16,22 19,28 22,24 24,30" fill="#4a4a6a"/>
+  <!-- Main central spire -->
+  <polygon points="10,22 16,4 22,22" fill="#5566aa" opacity="0.9"/>
+  <polygon points="11,22 16,6 21,22" fill="#7788cc" opacity="0.8"/>
+  <!-- Highlight -->
+  <polygon points="12,22 14,8 15,22" fill="#aabbee" opacity="0.4"/>
+  <!-- Left shard -->
+  <polygon points="7,22 10,10 13,22" fill="#4455aa" opacity="0.8"/>
+  <polygon points="8,22 10,12 12,22" fill="#6677cc" opacity="0.7"/>
+  <!-- Right shard -->
+  <polygon points="19,22 22,10 25,22" fill="#4455aa" opacity="0.8"/>
+  <polygon points="20,22 22,12 24,22" fill="#6677cc" opacity="0.7"/>
+  <!-- Tiny flanking shards -->
+  <polygon points="4,22 6,15 8,22" fill="#3344aa" opacity="0.7"/>
+  <polygon points="24,22 26,15 28,22" fill="#3344aa" opacity="0.7"/>
+  <!-- Crystal tips glow -->
+  <circle cx="16" cy="4" r="1.5" fill="#aabbff" opacity="0.8"/>
+  <circle cx="10" cy="10" r="1" fill="#8899ff" opacity="0.7"/>
+  <circle cx="22" cy="10" r="1" fill="#8899ff" opacity="0.7"/>
+  <!-- Prismatic refraction lines -->
+  <line x1="16" y1="5" x2="5" y2="23" stroke="#ff8888" stroke-width="0.6" opacity="0.25"/>
+  <line x1="16" y1="5" x2="27" y2="23" stroke="#8888ff" stroke-width="0.6" opacity="0.25"/>
+  <line x1="16" y1="5" x2="16" y2="23" stroke="#88ffaa" stroke-width="0.6" opacity="0.2"/>
+  <!-- Ground glow -->
+  <ellipse cx="16" cy="30" rx="10" ry="1.5" fill="#8899ff" opacity="0.2"/>
+</svg>

--- a/web/public/sprites/shark-run.svg
+++ b/web/public/sprites/shark-run.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ocean water channel -->
+  <rect x="0" y="16" width="32" height="16" fill="#0a3a5a"/>
+  <!-- Water ripples -->
+  <path d="M0,18 Q8,16 16,18 Q24,20 32,18" fill="none" stroke="#1a5a7a" stroke-width="0.7" opacity="0.5"/>
+  <path d="M0,22 Q8,20 16,22 Q24,24 32,22" fill="none" stroke="#1a4a6a" stroke-width="0.6" opacity="0.4"/>
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="14" ry="1.5" fill="#0a1a2a" opacity="0.4"/>
+  <!-- Channel walls/banks -->
+  <rect x="0" y="14" width="32" height="3" fill="#5a5a3a"/>
+  <!-- Arena viewing platform -->
+  <rect x="2" y="4" width="28" height="12" rx="1" fill="#4a4a3a"/>
+  <!-- Platform battlements/railing -->
+  <line x1="2" y1="5" x2="30" y2="5" stroke="#3a3a2a" stroke-width="0.7"/>
+  <line x1="2" y1="9" x2="30" y2="9" stroke="#3a3a2a" stroke-width="0.5"/>
+  <line x1="2" y1="13" x2="30" y2="13" stroke="#3a3a2a" stroke-width="0.5"/>
+  <!-- Shark fin breaking surface -->
+  <polygon points="13,14 16,8 19,14" fill="#4a5a6a"/>
+  <polygon points="14,14 16,10 18,14" fill="#5a6a7a"/>
+  <!-- Second shark fin further back -->
+  <polygon points="6,16 8,12 10,16" fill="#3a4a5a" opacity="0.7"/>
+  <!-- Blood in water (danger) -->
+  <ellipse cx="16" cy="20" rx="4" ry="1.5" fill="#aa0000" opacity="0.3"/>
+  <!-- Shark teeth at surface -->
+  <polygon points="15,16 16,14 17,16" fill="#dddddd"/>
+  <polygon points="13,16 14,14 15,16" fill="#cccccc"/>
+  <polygon points="17,16 18,14 19,16" fill="#cccccc"/>
+  <!-- Crowd/spectator silhouettes on platform -->
+  <ellipse cx="6" cy="7" rx="2" ry="2" fill="#3a3a2a"/>
+  <ellipse cx="12" cy="6" rx="2" ry="2" fill="#3a3a2a"/>
+  <ellipse cx="20" cy="7" rx="2" ry="2" fill="#3a3a2a"/>
+  <ellipse cx="26" cy="6" rx="2" ry="2" fill="#3a3a2a"/>
+</svg>

--- a/web/public/sprites/siege-yard.svg
+++ b/web/public/sprites/siege-yard.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="14" ry="1.5" fill="#1a1a1a" opacity="0.5"/>
+  <!-- Yard ground -->
+  <rect x="0" y="24" width="32" height="7" fill="#4a4a3a" opacity="0.5"/>
+  <!-- Workshop/shed building -->
+  <rect x="0" y="12" width="14" height="14" rx="0.5" fill="#5a5a4a"/>
+  <!-- Shed roof -->
+  <polygon points="0,12 7,5 14,12" fill="#3a3a2a"/>
+  <!-- Shed door -->
+  <rect x="5" y="18" width="4" height="8" rx="0.3" fill="#2a2a1a"/>
+  <!-- Large trebuchet/catapult in yard -->
+  <rect x="16" y="16" width="14" height="6" rx="1" fill="#6a5a2a"/>
+  <!-- Catapult arm (raised) -->
+  <rect x="22" y="8" width="2.5" height="12" rx="0.5" fill="#8a6a2a" transform="rotate(-20 23 16)"/>
+  <!-- Counterweight -->
+  <ellipse cx="19" cy="19" rx="2.5" ry="2" fill="#4a4a3a"/>
+  <!-- Sling/cup at arm tip -->
+  <circle cx="27" cy="9" r="2" fill="#5a4a1a"/>
+  <!-- Catapult wheels -->
+  <circle cx="18" cy="22" r="2.5" fill="#3a2a1a"/>
+  <circle cx="18" cy="22" r="1.5" fill="#5a3a1a"/>
+  <circle cx="28" cy="22" r="2.5" fill="#3a2a1a"/>
+  <circle cx="28" cy="22" r="1.5" fill="#5a3a1a"/>
+  <!-- Stacked cannonballs/boulders -->
+  <circle cx="4" cy="25" r="1.5" fill="#4a4a4a"/>
+  <circle cx="7" cy="25" r="1.5" fill="#4a4a4a"/>
+  <circle cx="5.5" cy="23" r="1.5" fill="#5a5a5a"/>
+  <!-- Ladder leaning against shed -->
+  <line x1="2" y1="12" x2="3" y2="24" stroke="#7a6a3a" stroke-width="1"/>
+  <line x1="5" y1="12" x2="6" y2="24" stroke="#7a6a3a" stroke-width="1"/>
+  <line x1="2.5" y1="14" x2="5.5" y2="14" stroke="#7a6a3a" stroke-width="0.7"/>
+  <line x1="2.7" y1="17" x2="5.7" y2="17" stroke="#7a6a3a" stroke-width="0.7"/>
+  <line x1="2.9" y1="20" x2="5.9" y2="20" stroke="#7a6a3a" stroke-width="0.7"/>
+</svg>

--- a/web/public/sprites/skirmisher-s-cove.svg
+++ b/web/public/sprites/skirmisher-s-cove.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Sea water -->
+  <rect x="0" y="20" width="32" height="12" fill="#0a3a5a"/>
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="14" ry="1.5" fill="#0a1a2a" opacity="0.4"/>
+  <!-- Rocky cove walls -->
+  <polygon points="0,30 0,14 6,18 10,12 14,18 18,12 22,18 26,12 30,18 32,14 32,30" fill="#4a5a4a"/>
+  <!-- Cave/cove entrance -->
+  <ellipse cx="16" cy="22" rx="10" ry="8" fill="#0a1a2a"/>
+  <!-- Torchlight inside cove -->
+  <ellipse cx="16" cy="26" rx="7" ry="4" fill="#cc6600" opacity="0.2"/>
+  <!-- Boat inside cove -->
+  <path d="M9,26 Q12,24 16,25 Q20,24 23,26 Q21,30 11,30 Q9,28 9,26Z" fill="#6a4a1a"/>
+  <!-- Boat mast -->
+  <line x1="16" y1="20" x2="16" y2="25" stroke="#5a3a0a" stroke-width="1"/>
+  <!-- Skull and crossbones flag -->
+  <polygon points="16,20 22,21.5 16,23" fill="#2a2a2a"/>
+  <!-- Rope ladder down cliff -->
+  <line x1="8" y1="12" x2="9" y2="22" stroke="#8a6a2a" stroke-width="0.8"/>
+  <line x1="12" y1="12" x2="13" y2="22" stroke="#8a6a2a" stroke-width="0.8"/>
+  <line x1="8.3" y1="14" x2="12.3" y2="14" stroke="#8a6a2a" stroke-width="0.6"/>
+  <line x1="8.6" y1="17" x2="12.6" y2="17" stroke="#8a6a2a" stroke-width="0.6"/>
+  <line x1="8.9" y1="20" x2="12.9" y2="20" stroke="#8a6a2a" stroke-width="0.6"/>
+  <!-- Water shimmer -->
+  <path d="M0,22 Q8,20 16,22 Q24,24 32,22" fill="none" stroke="#1a5a7a" stroke-width="0.7" opacity="0.5"/>
+</svg>

--- a/web/public/sprites/sky-cradle.svg
+++ b/web/public/sprites/sky-cradle.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="9" ry="1.5" fill="#1a1a2a" opacity="0.4"/>
+  <!-- Clouds below cradle (high altitude) -->
+  <ellipse cx="6" cy="24" rx="7" ry="3" fill="#ddddff" opacity="0.3"/>
+  <ellipse cx="26" cy="25" rx="7" ry="3" fill="#ddddff" opacity="0.3"/>
+  <ellipse cx="16" cy="28" rx="10" ry="3" fill="#ccccee" opacity="0.25"/>
+  <!-- Chains suspending cradle from above -->
+  <line x1="8" y1="0" x2="10" y2="14" stroke="#8a8a9a" stroke-width="1.2"/>
+  <line x1="24" y1="0" x2="22" y2="14" stroke="#8a8a9a" stroke-width="1.2"/>
+  <!-- Chain links detail -->
+  <ellipse cx="9" cy="5" rx="1" ry="1.5" fill="none" stroke="#7a7a8a" stroke-width="0.8"/>
+  <ellipse cx="23" cy="5" rx="1" ry="1.5" fill="none" stroke="#7a7a8a" stroke-width="0.8"/>
+  <!-- Cradle platform (wooden and stone) -->
+  <ellipse cx="16" cy="16" rx="13" ry="4" fill="#5a5a6a"/>
+  <ellipse cx="16" cy="15" rx="12" ry="3.5" fill="#6a6a7a"/>
+  <!-- Cradle walls -->
+  <rect x="4" y="12" width="24" height="6" rx="1" fill="#5a5a6a"/>
+  <!-- Building on the cradle -->
+  <rect x="8" y="6" width="16" height="8" rx="1" fill="#6a6a7a"/>
+  <!-- Sky building roof -->
+  <polygon points="6,6 16,0 26,6" fill="#4a4a5a"/>
+  <polygon points="8,6 16,2 24,6" fill="#5a5a6a"/>
+  <!-- Cloud wisps at roof level -->
+  <ellipse cx="5" cy="4" rx="4" ry="2" fill="#ddddff" opacity="0.4"/>
+  <ellipse cx="27" cy="4" rx="4" ry="2" fill="#ddddff" opacity="0.4"/>
+  <!-- Window with sky glow -->
+  <rect x="12" y="8" width="4" height="4" rx="0.3" fill="#1a2a3a"/>
+  <rect x="13" y="9" width="2" height="2" fill="#88aaff" opacity="0.5"/>
+  <!-- Wind streamers on cradle edge -->
+  <path d="M4,14 Q2,12 4,10" fill="none" stroke="#aabbff" stroke-width="0.8" opacity="0.5"/>
+  <path d="M28,14 Q30,12 28,10" fill="none" stroke="#aabbff" stroke-width="0.8" opacity="0.5"/>
+</svg>

--- a/web/public/sprites/sky-fortress.svg
+++ b/web/public/sprites/sky-fortress.svg
@@ -1,0 +1,38 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow (faint — high altitude) -->
+  <ellipse cx="16" cy="31" rx="12" ry="1" fill="#1a1a2a" opacity="0.2"/>
+  <!-- Clouds -->
+  <ellipse cx="4" cy="26" rx="6" ry="3" fill="#ddddff" opacity="0.3"/>
+  <ellipse cx="28" cy="27" rx="6" ry="3" fill="#ddddff" opacity="0.25"/>
+  <!-- Massive floating stone fortress base -->
+  <ellipse cx="16" cy="22" rx="14" ry="5" fill="#5a5a6a"/>
+  <ellipse cx="16" cy="21" rx="13" ry="4.5" fill="#6a6a7a"/>
+  <!-- Floating rock underside -->
+  <polygon points="4,22 6,26 10,24 14,28 18,24 22,26 26,22 28,26 30,24" fill="#4a4a5a" opacity="0.7"/>
+  <!-- Main fortress walls -->
+  <rect x="4" y="10" width="24" height="13" rx="1" fill="#5a5a6a"/>
+  <!-- Wall details -->
+  <line x1="4" y1="15" x2="28" y2="15" stroke="#4a4a5a" stroke-width="0.7"/>
+  <line x1="4" y1="19" x2="28" y2="19" stroke="#4a4a5a" stroke-width="0.6"/>
+  <!-- Corner towers -->
+  <rect x="2" y="6" width="8" height="17" rx="0.5" fill="#6a6a7a"/>
+  <rect x="22" y="6" width="8" height="17" rx="0.5" fill="#6a6a7a"/>
+  <!-- Tower battlements -->
+  <rect x="2" y="4" width="3" height="3" rx="0.3" fill="#7a7a8a"/>
+  <rect x="7" y="4" width="3" height="3" rx="0.3" fill="#7a7a8a"/>
+  <rect x="22" y="4" width="3" height="3" rx="0.3" fill="#7a7a8a"/>
+  <rect x="27" y="4" width="3" height="3" rx="0.3" fill="#7a7a8a"/>
+  <!-- Central keep -->
+  <rect x="10" y="4" width="12" height="8" rx="0.5" fill="#7a7a8a"/>
+  <!-- Keep roof/spire -->
+  <polygon points="8,4 16,0 24,4" fill="#4a4a5a"/>
+  <line x1="16" y1="0" x2="16" y2="-2" stroke="#4a4a5a" stroke-width="0.8"/>
+  <!-- Gate with drawbridge -->
+  <path d="M13,23 L13,16 Q16,12 19,16 L19,23 Z" fill="#1a1a2a"/>
+  <!-- Drawbridge chains -->
+  <line x1="13" y1="20" x2="10" y2="22" stroke="#7a7a8a" stroke-width="0.7"/>
+  <line x1="19" y1="20" x2="22" y2="22" stroke="#7a7a8a" stroke-width="0.7"/>
+  <!-- Cloud wisps at sides -->
+  <ellipse cx="2" cy="15" rx="3" ry="2" fill="#ddddff" opacity="0.3"/>
+  <ellipse cx="30" cy="14" rx="3" ry="2" fill="#ddddff" opacity="0.3"/>
+</svg>

--- a/web/public/sprites/sky-mage-1.svg
+++ b/web/public/sprites/sky-mage-1.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Hat -->
+  <polygon points="10,10 16,1 22,10" fill="#2a4a6a"/>
+  <rect x="9" y="9" width="14" height="2" rx="0.5" fill="#3a5a7a"/>
+  <!-- Head -->
+  <ellipse cx="16" cy="13" rx="5" ry="4.5" fill="#f4c07a"/>
+  <!-- Eyes -->
+  <circle cx="14" cy="12.5" r="0.9" fill="#1a2a4a"/>
+  <circle cx="18" cy="12.5" r="0.9" fill="#1a2a4a"/>
+  <!-- Beard -->
+  <ellipse cx="16" cy="16" rx="3" ry="2" fill="#ccddee" opacity="0.8"/>
+  <!-- Robe body -->
+  <path d="M11,17 L11,24 L21,24 L21,17 Q16,20 11,17 Z" fill="#3a5a7a"/>
+  <!-- Robe belt -->
+  <rect x="11" y="22" width="10" height="1.5" fill="#2a3a5a"/>
+  <!-- Staff -->
+  <line x1="24" y1="5" x2="24" y2="28" stroke="#6a5a3a" stroke-width="1.5"/>
+  <!-- Staff orb -->
+  <circle cx="24" cy="5" r="2.5" fill="#2a3a5a"/>
+  <circle cx="24" cy="5" r="1.5" fill="#4488cc"/>
+  <circle cx="24" cy="5" r="0.8" fill="#88ccff" opacity="0.8"/>
+  <!-- Magic aura -->
+  <ellipse cx="24" cy="5" rx="4" ry="3" fill="#4488cc" opacity="0.15"/>
+  <!-- Legs: left forward, right back -->
+  <rect x="10" y="24" width="5" height="6" rx="1" fill="#2a4a6a"/>
+  <rect x="17" y="24" width="5" height="4" rx="1" fill="#2a4a6a"/>
+  <!-- Boots -->
+  <rect x="9" y="28" width="7" height="3" rx="1" fill="#1a2a3a"/>
+  <rect x="17" y="26" width="6" height="3" rx="1" fill="#1a2a3a"/>
+</svg>

--- a/web/public/sprites/sky-mage-2.svg
+++ b/web/public/sprites/sky-mage-2.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Hat (raised 1px mid-stride) -->
+  <polygon points="10,9 16,0 22,9" fill="#2a4a6a"/>
+  <rect x="9" y="8" width="14" height="2" rx="0.5" fill="#3a5a7a"/>
+  <!-- Head (raised 1px) -->
+  <ellipse cx="16" cy="12" rx="5" ry="4.5" fill="#f4c07a"/>
+  <!-- Eyes -->
+  <circle cx="14" cy="11.5" r="0.9" fill="#1a2a4a"/>
+  <circle cx="18" cy="11.5" r="0.9" fill="#1a2a4a"/>
+  <!-- Beard -->
+  <ellipse cx="16" cy="15" rx="3" ry="2" fill="#ccddee" opacity="0.8"/>
+  <!-- Robe body -->
+  <path d="M11,16 L11,23 L21,23 L21,16 Q16,19 11,16 Z" fill="#3a5a7a"/>
+  <!-- Robe belt -->
+  <rect x="11" y="21" width="10" height="1.5" fill="#2a3a5a"/>
+  <!-- Staff -->
+  <line x1="24" y1="4" x2="24" y2="27" stroke="#6a5a3a" stroke-width="1.5"/>
+  <!-- Staff orb -->
+  <circle cx="24" cy="4" r="2.5" fill="#2a3a5a"/>
+  <circle cx="24" cy="4" r="1.5" fill="#4488cc"/>
+  <circle cx="24" cy="4" r="0.8" fill="#88ccff" opacity="0.8"/>
+  <!-- Magic aura (brighter mid-stride) -->
+  <ellipse cx="24" cy="4" rx="5" ry="4" fill="#4488cc" opacity="0.2"/>
+  <!-- Legs: both symmetric mid-stride -->
+  <rect x="11" y="23" width="5" height="5" rx="1" fill="#2a4a6a"/>
+  <rect x="17" y="23" width="5" height="5" rx="1" fill="#2a4a6a"/>
+  <!-- Boots -->
+  <rect x="10" y="26" width="7" height="3" rx="1" fill="#1a2a3a"/>
+  <rect x="17" y="26" width="7" height="3" rx="1" fill="#1a2a3a"/>
+</svg>

--- a/web/public/sprites/sky-mage-3.svg
+++ b/web/public/sprites/sky-mage-3.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Hat -->
+  <polygon points="10,10 16,1 22,10" fill="#2a4a6a"/>
+  <rect x="9" y="9" width="14" height="2" rx="0.5" fill="#3a5a7a"/>
+  <!-- Head -->
+  <ellipse cx="16" cy="13" rx="5" ry="4.5" fill="#f4c07a"/>
+  <!-- Eyes -->
+  <circle cx="14" cy="12.5" r="0.9" fill="#1a2a4a"/>
+  <circle cx="18" cy="12.5" r="0.9" fill="#1a2a4a"/>
+  <!-- Beard -->
+  <ellipse cx="16" cy="16" rx="3" ry="2" fill="#ccddee" opacity="0.8"/>
+  <!-- Robe body -->
+  <path d="M11,17 L11,24 L21,24 L21,17 Q16,20 11,17 Z" fill="#3a5a7a"/>
+  <!-- Robe belt -->
+  <rect x="11" y="22" width="10" height="1.5" fill="#2a3a5a"/>
+  <!-- Staff -->
+  <line x1="24" y1="5" x2="24" y2="28" stroke="#6a5a3a" stroke-width="1.5"/>
+  <!-- Staff orb -->
+  <circle cx="24" cy="5" r="2.5" fill="#2a3a5a"/>
+  <circle cx="24" cy="5" r="1.5" fill="#4488cc"/>
+  <circle cx="24" cy="5" r="0.8" fill="#88ccff" opacity="0.8"/>
+  <!-- Magic aura -->
+  <ellipse cx="24" cy="5" rx="4" ry="3" fill="#4488cc" opacity="0.15"/>
+  <!-- Legs: right forward, left back -->
+  <rect x="10" y="24" width="5" height="4" rx="1" fill="#2a4a6a"/>
+  <rect x="17" y="24" width="5" height="6" rx="1" fill="#2a4a6a"/>
+  <!-- Boots -->
+  <rect x="9" y="26" width="6" height="3" rx="1" fill="#1a2a3a"/>
+  <rect x="17" y="28" width="7" height="3" rx="1" fill="#1a2a3a"/>
+</svg>

--- a/web/public/sprites/sky-mage.svg
+++ b/web/public/sprites/sky-mage.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Hat -->
+  <polygon points="10,10 16,1 22,10" fill="#2a4a6a"/>
+  <rect x="9" y="9" width="14" height="2" rx="0.5" fill="#3a5a7a"/>
+  <!-- Head -->
+  <ellipse cx="16" cy="13" rx="5" ry="4.5" fill="#f4c07a"/>
+  <!-- Eyes -->
+  <circle cx="14" cy="12.5" r="0.9" fill="#1a2a4a"/>
+  <circle cx="18" cy="12.5" r="0.9" fill="#1a2a4a"/>
+  <!-- Beard -->
+  <ellipse cx="16" cy="16" rx="3" ry="2" fill="#ccddee" opacity="0.8"/>
+  <!-- Robe body -->
+  <path d="M11,17 L10,30 L22,30 L21,17 Q16,20 11,17 Z" fill="#3a5a7a"/>
+  <!-- Robe belt -->
+  <rect x="11" y="22" width="10" height="1.5" fill="#2a3a5a"/>
+  <!-- Staff (right side) -->
+  <line x1="24" y1="5" x2="24" y2="30" stroke="#6a5a3a" stroke-width="1.5"/>
+  <!-- Staff orb -->
+  <circle cx="24" cy="5" r="2.5" fill="#2a3a5a"/>
+  <circle cx="24" cy="5" r="1.5" fill="#4488cc"/>
+  <circle cx="24" cy="5" r="0.8" fill="#88ccff" opacity="0.8"/>
+  <!-- Magic aura -->
+  <ellipse cx="24" cy="5" rx="4" ry="3" fill="#4488cc" opacity="0.15"/>
+</svg>

--- a/web/public/sprites/sky-post.svg
+++ b/web/public/sprites/sky-post.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="8" ry="1.5" fill="#1a1a2a" opacity="0.3"/>
+  <!-- Tall slender post/tower -->
+  <rect x="13" y="6" width="6" height="24" rx="1" fill="#5a5a6a"/>
+  <!-- Platform at top -->
+  <rect x="8" y="5" width="16" height="3" rx="0.5" fill="#6a6a7a"/>
+  <!-- Observation capsule at top -->
+  <ellipse cx="16" cy="4" rx="6" ry="3.5" fill="#5a5a6a"/>
+  <ellipse cx="16" cy="3.5" rx="5" ry="3" fill="#6a6a7a"/>
+  <!-- Viewing windows on capsule -->
+  <ellipse cx="12" cy="3.5" rx="1.5" ry="1.2" fill="#1a2a3a"/>
+  <ellipse cx="16" cy="2.5" rx="1.5" ry="1.2" fill="#1a2a3a"/>
+  <ellipse cx="20" cy="3.5" rx="1.5" ry="1.2" fill="#1a2a3a"/>
+  <!-- Sky glow in windows -->
+  <ellipse cx="12" cy="3.5" rx="1" ry="0.8" fill="#88aaff" opacity="0.5"/>
+  <ellipse cx="20" cy="3.5" rx="1" ry="0.8" fill="#88aaff" opacity="0.5"/>
+  <!-- Antenna/signal array at peak -->
+  <line x1="16" y1="1" x2="16" y2="-2" stroke="#6a6a7a" stroke-width="0.8"/>
+  <line x1="13" y1="0" x2="19" y2="0" stroke="#6a6a7a" stroke-width="0.6"/>
+  <circle cx="13" cy="0" r="0.6" fill="#aaddff" opacity="0.7"/>
+  <circle cx="19" cy="0" r="0.6" fill="#aaddff" opacity="0.7"/>
+  <circle cx="16" cy="-2" r="0.8" fill="#88bbff" opacity="0.8"/>
+  <!-- Tower strut details -->
+  <line x1="13" y1="14" x2="10" y2="18" stroke="#4a4a5a" stroke-width="0.8"/>
+  <line x1="19" y1="14" x2="22" y2="18" stroke="#4a4a5a" stroke-width="0.8"/>
+  <line x1="13" y1="20" x2="9" y2="24" stroke="#4a4a5a" stroke-width="0.8"/>
+  <line x1="19" y1="20" x2="23" y2="24" stroke="#4a4a5a" stroke-width="0.8"/>
+  <!-- Cloud at base of post -->
+  <ellipse cx="16" cy="29" rx="8" ry="2.5" fill="#ddddff" opacity="0.3"/>
+</svg>

--- a/web/public/sprites/sky-sanctum.svg
+++ b/web/public/sprites/sky-sanctum.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow (faint) -->
+  <ellipse cx="16" cy="31" rx="11" ry="1" fill="#1a1a2a" opacity="0.2"/>
+  <!-- Cloud base supporting sanctum -->
+  <ellipse cx="16" cy="24" rx="14" ry="5" fill="#ddddff" opacity="0.5"/>
+  <ellipse cx="16" cy="23" rx="12" ry="4" fill="#eeeeff" opacity="0.4"/>
+  <ellipse cx="8" cy="24" rx="7" ry="3" fill="#ddddff" opacity="0.4"/>
+  <ellipse cx="24" cy="24" rx="7" ry="3" fill="#ddddff" opacity="0.4"/>
+  <!-- Sanctum building on clouds -->
+  <rect x="6" y="12" width="20" height="13" rx="1" fill="#9aaecc"/>
+  <!-- Marble/stone texture -->
+  <line x1="6" y1="16" x2="26" y2="16" stroke="#7a9aaa" stroke-width="0.5"/>
+  <line x1="6" y1="20" x2="26" y2="20" stroke="#7a9aaa" stroke-width="0.5"/>
+  <!-- Domed roof -->
+  <ellipse cx="16" cy="12" rx="10" ry="5" fill="#8a9abb"/>
+  <ellipse cx="16" cy="11" rx="8" ry="4" fill="#aabbcc"/>
+  <!-- Gold cross at dome peak -->
+  <line x1="16" y1="7" x2="16" y2="3" stroke="#ffcc00" stroke-width="1.2"/>
+  <line x1="14" y1="5" x2="18" y2="5" stroke="#ffcc00" stroke-width="1.2"/>
+  <!-- Celestial glow around dome -->
+  <ellipse cx="16" cy="9" rx="12" ry="6" fill="#aabbff" opacity="0.1"/>
+  <!-- Arched windows -->
+  <rect x="8" y="14" width="3" height="5" rx="0.5" fill="#1a2a3a"/>
+  <path d="M8,14 Q9.5,12 11,14" fill="#1a2a3a"/>
+  <rect x="13" y="13" width="6" height="6" rx="0.5" fill="#1a2a3a"/>
+  <path d="M13,13 Q16,10 19,13" fill="#1a2a3a"/>
+  <rect x="21" y="14" width="3" height="5" rx="0.5" fill="#1a2a3a"/>
+  <path d="M21,14 Q22.5,12 24,14" fill="#1a2a3a"/>
+  <!-- Holy light from windows -->
+  <rect x="9" y="15" width="1.5" height="3" fill="#ffffaa" opacity="0.25"/>
+  <rect x="14" y="14" width="4" height="4" fill="#ffffaa" opacity="0.2"/>
+  <!-- Entrance arch -->
+  <path d="M13,25 L13,20 Q16,17 19,20 L19,25 Z" fill="#0a1a2a"/>
+</svg>

--- a/web/public/sprites/sky-surge.svg
+++ b/web/public/sprites/sky-surge.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Sky background -->
+  <ellipse cx="16" cy="16" rx="14" ry="14" fill="#1a2a4a" opacity="0.4"/>
+  <!-- Storm cloud -->
+  <ellipse cx="16" cy="10" rx="10" ry="5" fill="#4a5a7a"/>
+  <ellipse cx="10" cy="11" rx="6" ry="4" fill="#5a6a8a"/>
+  <ellipse cx="22" cy="11" rx="6" ry="4" fill="#5a6a8a"/>
+  <!-- Lightning bolt (attack buff symbol) -->
+  <polygon points="18,10 14,18 17,18 13,28 20,17 16,17" fill="#ffff44"/>
+  <polygon points="18,10 14,18 17,18 13,28 20,17 16,17" fill="#ffee00" opacity="0.5" transform="translate(0.5,0.5)"/>
+  <!-- Lightning glow -->
+  <ellipse cx="16" cy="19" rx="4" ry="5" fill="#ffff44" opacity="0.15"/>
+  <!-- Spark dots -->
+  <circle cx="8" cy="20" r="1" fill="#ffff44" opacity="0.7"/>
+  <circle cx="24" cy="22" r="1" fill="#ffff44" opacity="0.7"/>
+  <circle cx="6" cy="25" r="0.8" fill="#ffffaa" opacity="0.5"/>
+  <circle cx="26" cy="14" r="0.8" fill="#ffffaa" opacity="0.5"/>
+  <!-- Wind streaks -->
+  <path d="M3,14 Q8,12 12,14" fill="none" stroke="#8899cc" stroke-width="0.7" opacity="0.5"/>
+  <path d="M20,22 Q25,20 29,22" fill="none" stroke="#8899cc" stroke-width="0.7" opacity="0.5"/>
+</svg>

--- a/web/public/sprites/soul-hollow.svg
+++ b/web/public/sprites/soul-hollow.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#0a0a1a" opacity="0.6"/>
+  <!-- Hollow tree trunk -->
+  <rect x="10" y="8" width="12" height="22" rx="3" fill="#2a1a2a"/>
+  <!-- Hollow opening -->
+  <ellipse cx="16" cy="20" rx="5" ry="7" fill="#0a0014"/>
+  <!-- Soul energy swirling within -->
+  <ellipse cx="16" cy="22" rx="3.5" ry="5" fill="#1a0033" opacity="0.8"/>
+  <ellipse cx="16" cy="22" rx="2" ry="3.5" fill="#3300aa" opacity="0.6"/>
+  <ellipse cx="16" cy="22" rx="1" ry="2" fill="#6600ff" opacity="0.7"/>
+  <!-- Soul wisp spirals -->
+  <path d="M14,18 Q17,15 18,20 Q17,25 14,22" fill="none" stroke="#8844ff" stroke-width="0.8" opacity="0.6"/>
+  <path d="M18,17 Q15,14 14,19 Q15,24 18,21" fill="none" stroke="#6622ee" stroke-width="0.7" opacity="0.5"/>
+  <!-- Tree bark texture on trunk -->
+  <path d="M10,12 Q8,16 10,20" fill="none" stroke="#1a0a1a" stroke-width="1" opacity="0.5"/>
+  <path d="M22,14 Q24,18 22,22" fill="none" stroke="#1a0a1a" stroke-width="1" opacity="0.5"/>
+  <!-- Gnarled roots at base -->
+  <path d="M10,28 Q6,30 3,32" fill="none" stroke="#2a1a2a" stroke-width="2.5"/>
+  <path d="M22,28 Q26,30 29,32" fill="none" stroke="#2a1a2a" stroke-width="2.5"/>
+  <path d="M11,30 Q8,32 6,32" fill="none" stroke="#1a0a1a" stroke-width="1.5"/>
+  <!-- Canopy of dark leaves -->
+  <ellipse cx="16" cy="8" rx="10" ry="6" fill="#1a1a2a"/>
+  <ellipse cx="10" cy="10" rx="6" ry="5" fill="#2a2a3a"/>
+  <ellipse cx="22" cy="10" rx="6" ry="5" fill="#2a2a3a"/>
+  <!-- Floating soul orbs in canopy -->
+  <circle cx="8" cy="7" r="1.2" fill="#6622ee" opacity="0.5"/>
+  <circle cx="24" cy="6" r="1" fill="#8844ff" opacity="0.5"/>
+  <circle cx="16" cy="4" r="1" fill="#aa66ff" opacity="0.4"/>
+</svg>

--- a/web/public/sprites/specter-vault.svg
+++ b/web/public/sprites/specter-vault.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#0a0a1a" opacity="0.6"/>
+  <!-- Dark stone vault -->
+  <rect x="3" y="14" width="26" height="16" rx="1" fill="#2a2a3a"/>
+  <!-- Stone blocks -->
+  <line x1="3" y1="18" x2="29" y2="18" stroke="#1a1a2a" stroke-width="0.7"/>
+  <line x1="3" y1="23" x2="29" y2="23" stroke="#1a1a2a" stroke-width="0.7"/>
+  <line x1="3" y1="27" x2="29" y2="27" stroke="#1a1a2a" stroke-width="0.5"/>
+  <!-- Ghostly arched roof -->
+  <ellipse cx="16" cy="14" rx="13" ry="5" fill="#3a3a4a"/>
+  <ellipse cx="16" cy="13" rx="11" ry="4" fill="#4a4a5a"/>
+  <!-- Spectral energy dome -->
+  <ellipse cx="16" cy="12" rx="9" ry="4" fill="#2200aa" opacity="0.2"/>
+  <ellipse cx="16" cy="11" rx="6" ry="3" fill="#4400cc" opacity="0.15"/>
+  <!-- Vault door -->
+  <rect x="11" y="18" width="10" height="12" rx="0.5" fill="#1a1a2a"/>
+  <rect x="10" y="17" width="12" height="14" rx="0.5" fill="none" stroke="#5555aa" stroke-width="1"/>
+  <!-- Lock with specter glow -->
+  <circle cx="16" cy="24" r="2.5" fill="#2a2a3a"/>
+  <circle cx="16" cy="24" r="1.5" fill="#3333aa"/>
+  <circle cx="16" cy="24" r="0.7" fill="#8888ff"/>
+  <!-- Ghostly figures floating at sides -->
+  <ellipse cx="5" cy="17" rx="2.5" ry="3.5" fill="#4444aa" opacity="0.25"/>
+  <circle cx="5" cy="14.5" r="1.5" fill="#5555bb" opacity="0.3"/>
+  <ellipse cx="27" cy="17" rx="2.5" ry="3.5" fill="#4444aa" opacity="0.25"/>
+  <circle cx="27" cy="14.5" r="1.5" fill="#5555bb" opacity="0.3"/>
+  <!-- Specter eye glows -->
+  <circle cx="4.5" cy="15" r="0.6" fill="#8888ff" opacity="0.7"/>
+  <circle cx="5.5" cy="15" r="0.6" fill="#8888ff" opacity="0.7"/>
+  <circle cx="26.5" cy="15" r="0.6" fill="#8888ff" opacity="0.7"/>
+  <circle cx="27.5" cy="15" r="0.6" fill="#8888ff" opacity="0.7"/>
+</svg>

--- a/web/public/sprites/spore-canopy.svg
+++ b/web/public/sprites/spore-canopy.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="14" ry="1.5" fill="#1a1a0a" opacity="0.5"/>
+  <!-- Forest floor -->
+  <ellipse cx="16" cy="28" rx="14" ry="5" fill="#2a3a1a"/>
+  <!-- Massive mushroom canopy -->
+  <ellipse cx="16" cy="16" rx="15" ry="8" fill="#774422"/>
+  <ellipse cx="16" cy="15" rx="14" ry="7" fill="#995533"/>
+  <ellipse cx="16" cy="14" rx="12" ry="6" fill="#aa6644"/>
+  <!-- Canopy highlight -->
+  <ellipse cx="11" cy="13" rx="5" ry="3" fill="#bb7755" opacity="0.5"/>
+  <!-- White spore spots on canopy -->
+  <circle cx="6" cy="15" r="2" fill="#ffffff" opacity="0.3"/>
+  <circle cx="12" cy="12" r="2.5" fill="#ffffff" opacity="0.3"/>
+  <circle cx="20" cy="12" r="2" fill="#ffffff" opacity="0.3"/>
+  <circle cx="26" cy="15" r="1.5" fill="#ffffff" opacity="0.3"/>
+  <circle cx="16" cy="10" r="2" fill="#ffffff" opacity="0.25"/>
+  <!-- Thick spore trunk -->
+  <rect x="12" y="16" width="8" height="14" rx="2" fill="#663311"/>
+  <!-- Spore cloud erupting from canopy -->
+  <circle cx="10" cy="8" r="3" fill="#ddcc77" opacity="0.3"/>
+  <circle cx="16" cy="5" r="3.5" fill="#ccbb66" opacity="0.25"/>
+  <circle cx="22" cy="7" r="3" fill="#ddcc77" opacity="0.3"/>
+  <circle cx="8" cy="5" r="2" fill="#eedd88" opacity="0.2"/>
+  <circle cx="24" cy="4" r="2.5" fill="#eedd88" opacity="0.2"/>
+  <!-- Spore particles floating -->
+  <circle cx="5" cy="10" r="0.8" fill="#ffee88" opacity="0.5"/>
+  <circle cx="27" cy="9" r="0.7" fill="#ffee88" opacity="0.4"/>
+  <circle cx="14" cy="4" r="0.7" fill="#ffdd77" opacity="0.4"/>
+  <circle cx="20" cy="3" r="0.6" fill="#ffee88" opacity="0.3"/>
+  <!-- Support stalks -->
+  <path d="M6,24 Q4,20 6,16" fill="none" stroke="#552200" stroke-width="1.5"/>
+  <path d="M26,24 Q28,20 26,16" fill="none" stroke="#552200" stroke-width="1.5"/>
+</svg>

--- a/web/public/sprites/spore-cathedral.svg
+++ b/web/public/sprites/spore-cathedral.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#1a1a0a" opacity="0.5"/>
+  <!-- Cathedral body (organic/fungal) -->
+  <rect x="3" y="14" width="26" height="16" rx="1" fill="#5a3a2a"/>
+  <!-- Fungal texture on walls -->
+  <rect x="3" y="14" width="4" height="16" fill="#6a4a3a" opacity="0.4"/>
+  <rect x="25" y="16" width="4" height="14" fill="#6a4a3a" opacity="0.3"/>
+  <!-- Mushroom arch/spires on roof -->
+  <ellipse cx="8" cy="13" rx="5" ry="4" fill="#774422"/>
+  <ellipse cx="8" cy="12" rx="4" ry="3" fill="#995533"/>
+  <rect x="6.5" y="12" width="3" height="5" rx="0.5" fill="#663311"/>
+  <ellipse cx="24" cy="13" rx="5" ry="4" fill="#774422"/>
+  <ellipse cx="24" cy="12" rx="4" ry="3" fill="#995533"/>
+  <rect x="22.5" y="12" width="3" height="5" rx="0.5" fill="#663311"/>
+  <!-- Central giant mushroom spire -->
+  <ellipse cx="16" cy="9" rx="7" ry="5" fill="#884422"/>
+  <ellipse cx="16" cy="8" rx="6" ry="4" fill="#aa6633"/>
+  <rect x="13.5" y="8" width="5" height="8" rx="1" fill="#6a3311"/>
+  <!-- Spots on mushrooms -->
+  <circle cx="5" cy="12" r="1.2" fill="#ffffff" opacity="0.3"/>
+  <circle cx="16" cy="6" r="1.5" fill="#ffffff" opacity="0.3"/>
+  <circle cx="27" cy="12" r="1.2" fill="#ffffff" opacity="0.3"/>
+  <!-- Spore windows (glowing) -->
+  <rect x="6" y="17" width="4" height="6" rx="0.5" fill="#1a0a00"/>
+  <rect x="7" y="18" width="2" height="4" fill="#ccaa44" opacity="0.4"/>
+  <rect x="22" y="17" width="4" height="6" rx="0.5" fill="#1a0a00"/>
+  <rect x="23" y="18" width="2" height="4" fill="#ccaa44" opacity="0.4"/>
+  <!-- Arched entrance -->
+  <path d="M13,30 L13,20 Q16,16 19,20 L19,30 Z" fill="#1a0a00"/>
+  <!-- Spore cloud above cathedral -->
+  <circle cx="10" cy="4" r="2.5" fill="#ddcc77" opacity="0.2"/>
+  <circle cx="22" cy="3" r="2" fill="#ddcc77" opacity="0.2"/>
+  <circle cx="16" cy="2" r="2.5" fill="#eedd88" opacity="0.15"/>
+</svg>

--- a/web/public/sprites/spore-cave.svg
+++ b/web/public/sprites/spore-cave.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#1a1a0a" opacity="0.5"/>
+  <!-- Rocky cave exterior -->
+  <polygon points="1,30 4,16 10,20 16,10 22,20 28,16 31,30" fill="#3a2a1a"/>
+  <!-- Cave entrance -->
+  <ellipse cx="16" cy="24" rx="9" ry="7" fill="#1a0a00"/>
+  <!-- Fungal spore glow within cave -->
+  <ellipse cx="16" cy="26" rx="7" ry="5" fill="#6a4a1a" opacity="0.4"/>
+  <ellipse cx="16" cy="27" rx="5" ry="3.5" fill="#8a6a2a" opacity="0.35"/>
+  <ellipse cx="16" cy="28" rx="3" ry="2" fill="#ccaa44" opacity="0.25"/>
+  <!-- Mushrooms growing in cave mouth -->
+  <rect x="9" y="22" width="3" height="6" rx="0.5" fill="#663311"/>
+  <ellipse cx="10.5" cy="22" rx="4" ry="2.5" fill="#885522"/>
+  <circle cx="9" cy="21" r="1" fill="#ffffff" opacity="0.25"/>
+  <rect x="20" y="23" width="3" height="5" rx="0.5" fill="#663311"/>
+  <ellipse cx="21.5" cy="23" rx="3.5" ry="2" fill="#885522"/>
+  <!-- Stalactites with spore drips -->
+  <polygon points="12,18 13,22 14,18" fill="#4a3a2a"/>
+  <polygon points="16,16 17,21 18,16" fill="#4a3a2a"/>
+  <polygon points="20,18 21,22 22,18" fill="#4a3a2a"/>
+  <circle cx="13" cy="22" r="0.8" fill="#ccaa44" opacity="0.6"/>
+  <circle cx="17" cy="21" r="0.7" fill="#ccaa44" opacity="0.5"/>
+  <!-- Spore mist drifting out -->
+  <ellipse cx="16" cy="22" rx="8" ry="3" fill="#ddcc77" opacity="0.15"/>
+  <!-- Glowing fungi on cave walls -->
+  <circle cx="5" cy="22" r="1.2" fill="#ccaa00" opacity="0.4"/>
+  <circle cx="27" cy="22" r="1" fill="#ccaa00" opacity="0.4"/>
+</svg>

--- a/web/public/sprites/spore-roost.svg
+++ b/web/public/sprites/spore-roost.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="10" ry="1.5" fill="#1a1a0a" opacity="0.5"/>
+  <!-- Rocky pillar base -->
+  <rect x="11" y="20" width="10" height="10" rx="1" fill="#4a3a2a"/>
+  <!-- Giant mushroom cap as roost -->
+  <ellipse cx="16" cy="19" rx="14" ry="6" fill="#884422"/>
+  <ellipse cx="16" cy="18" rx="13" ry="5" fill="#aa5533"/>
+  <ellipse cx="16" cy="17" rx="11" ry="4" fill="#bb6644"/>
+  <!-- Cap highlight -->
+  <ellipse cx="11" cy="16" rx="4" ry="2.5" fill="#cc7755" opacity="0.5"/>
+  <!-- Spore spots on cap -->
+  <circle cx="6" cy="18" r="2" fill="#ffffff" opacity="0.25"/>
+  <circle cx="14" cy="14" r="2.5" fill="#ffffff" opacity="0.25"/>
+  <circle cx="24" cy="17" r="2" fill="#ffffff" opacity="0.25"/>
+  <!-- Roost stalk/stem -->
+  <rect x="13" y="18" width="6" height="4" rx="1" fill="#663311"/>
+  <!-- Creature (spore bat) perched on edge -->
+  <ellipse cx="5" cy="16" rx="3" ry="2" fill="#4a3a2a"/>
+  <path d="M2,15 Q5,12 8,15" fill="none" stroke="#4a3a2a" stroke-width="1.5"/>
+  <!-- Second bat -->
+  <ellipse cx="27" cy="17" rx="2.5" ry="1.5" fill="#4a3a2a"/>
+  <path d="M25,16 Q27,13 29,16" fill="none" stroke="#4a3a2a" stroke-width="1.5"/>
+  <!-- Spore cloud from cap -->
+  <circle cx="8" cy="11" r="2.5" fill="#ddcc77" opacity="0.25"/>
+  <circle cx="16" cy="9" r="3" fill="#ccbb66" opacity="0.2"/>
+  <circle cx="24" cy="11" r="2.5" fill="#ddcc77" opacity="0.2"/>
+  <!-- Floating spores -->
+  <circle cx="4" cy="8" r="0.7" fill="#eedd88" opacity="0.4"/>
+  <circle cx="28" cy="9" r="0.6" fill="#eedd88" opacity="0.4"/>
+  <circle cx="12" cy="6" r="0.7" fill="#ffee99" opacity="0.3"/>
+</svg>

--- a/web/public/sprites/spore-surge.svg
+++ b/web/public/sprites/spore-surge.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Dark spore background -->
+  <ellipse cx="16" cy="16" rx="14" ry="14" fill="#1a2a1a" opacity="0.4"/>
+  <!-- Central mushroom cap -->
+  <ellipse cx="16" cy="16" rx="10" ry="6" fill="#4a3a6a"/>
+  <ellipse cx="16" cy="15" rx="9" ry="5" fill="#6a4a8a"/>
+  <!-- Mushroom stem -->
+  <rect x="13" y="16" width="6" height="8" rx="1" fill="#3a2a5a"/>
+  <!-- Spore burst cloud -->
+  <circle cx="16" cy="14" r="7" fill="#5a3a7a" opacity="0.5"/>
+  <!-- Spore particles erupting outward -->
+  <circle cx="6" cy="8" r="1.5" fill="#cc88ff" opacity="0.8"/>
+  <circle cx="26" cy="9" r="1.5" fill="#cc88ff" opacity="0.8"/>
+  <circle cx="4" cy="18" r="1.2" fill="#aa66dd" opacity="0.7"/>
+  <circle cx="28" cy="17" r="1.2" fill="#aa66dd" opacity="0.7"/>
+  <circle cx="10" cy="4" r="1" fill="#cc88ff" opacity="0.6"/>
+  <circle cx="22" cy="5" r="1" fill="#cc88ff" opacity="0.6"/>
+  <circle cx="8" cy="26" r="1" fill="#8844bb" opacity="0.6"/>
+  <circle cx="24" cy="26" r="1" fill="#8844bb" opacity="0.6"/>
+  <!-- Attack buff streaks -->
+  <line x1="16" y1="7" x2="16" y2="3" stroke="#cc88ff" stroke-width="1.2" opacity="0.6"/>
+  <line x1="10" y1="9" x2="7" y2="6" stroke="#cc88ff" stroke-width="1" opacity="0.5"/>
+  <line x1="22" y1="9" x2="25" y2="6" stroke="#cc88ff" stroke-width="1" opacity="0.5"/>
+  <!-- Glow center -->
+  <ellipse cx="16" cy="14" rx="5" ry="4" fill="#aa66ff" opacity="0.2"/>
+</svg>

--- a/web/public/sprites/spore-throne.svg
+++ b/web/public/sprites/spore-throne.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="12" ry="1.5" fill="#1a1a0a" opacity="0.5"/>
+  <!-- Throne base platform (fungal stone) -->
+  <rect x="5" y="24" width="22" height="6" rx="1" fill="#4a3a2a"/>
+  <!-- Throne seat (grown from mushroom) -->
+  <rect x="9" y="15" width="14" height="10" rx="1" fill="#6a4a2a"/>
+  <!-- Throne back (giant mushroom cap) -->
+  <ellipse cx="16" cy="14" rx="10" ry="5" fill="#884422"/>
+  <ellipse cx="16" cy="13" rx="9" ry="4.5" fill="#995533"/>
+  <ellipse cx="16" cy="12" rx="7" ry="3.5" fill="#aa6644"/>
+  <!-- Spots on cap back -->
+  <circle cx="10" cy="13" r="1.5" fill="#ffffff" opacity="0.25"/>
+  <circle cx="16" cy="10" r="2" fill="#ffffff" opacity="0.25"/>
+  <circle cx="22" cy="13" r="1.5" fill="#ffffff" opacity="0.25"/>
+  <!-- Throne armrests (smaller mushrooms) -->
+  <ellipse cx="10" cy="16" rx="3" ry="1.5" fill="#774422"/>
+  <rect x="9" y="16" width="2" height="3" rx="0.5" fill="#663311"/>
+  <ellipse cx="22" cy="16" rx="3" ry="1.5" fill="#774422"/>
+  <rect x="21" y="16" width="2" height="3" rx="0.5" fill="#663311"/>
+  <!-- Glowing spore seat cushion -->
+  <ellipse cx="16" cy="21" rx="5" ry="2.5" fill="#ccaa44" opacity="0.3"/>
+  <!-- Crown/spore halo above throne -->
+  <ellipse cx="16" cy="8" rx="8" ry="3" fill="#ddcc77" opacity="0.2"/>
+  <circle cx="11" cy="7" r="1.2" fill="#ffee88" opacity="0.4"/>
+  <circle cx="16" cy="5" r="1.5" fill="#ffee88" opacity="0.4"/>
+  <circle cx="21" cy="7" r="1.2" fill="#ffee88" opacity="0.4"/>
+  <!-- Creeping vines on throne legs -->
+  <path d="M9,25 Q7,22 9,19" fill="none" stroke="#2a5a1a" stroke-width="1"/>
+  <path d="M23,25 Q25,22 23,19" fill="none" stroke="#2a5a1a" stroke-width="1"/>
+  <!-- Spore particles -->
+  <circle cx="5" cy="13" r="0.7" fill="#ddcc77" opacity="0.4"/>
+  <circle cx="27" cy="12" r="0.6" fill="#ddcc77" opacity="0.4"/>
+</svg>

--- a/web/public/sprites/stalker-s-cove.svg
+++ b/web/public/sprites/stalker-s-cove.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Sea water -->
+  <rect x="0" y="20" width="32" height="12" fill="#0a2a3a"/>
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#0a1a2a" opacity="0.4"/>
+  <!-- Dark rock formation around cove -->
+  <polygon points="0,30 0,10 6,14 10,8 16,12 22,8 26,14 32,10 32,30" fill="#2a2a3a"/>
+  <!-- Cove entrance (dark, narrow) -->
+  <ellipse cx="16" cy="22" rx="8" ry="7" fill="#0a0a14"/>
+  <!-- Bioluminescent glow from within -->
+  <ellipse cx="16" cy="24" rx="5" ry="4" fill="#004488" opacity="0.3"/>
+  <ellipse cx="16" cy="26" rx="3" ry="2.5" fill="#0066aa" opacity="0.25"/>
+  <!-- Stalker creature eyes (multiple pairs) in darkness -->
+  <circle cx="13" cy="21" r="0.8" fill="#00aaff" opacity="0.8"/>
+  <circle cx="15" cy="21" r="0.8" fill="#00aaff" opacity="0.8"/>
+  <circle cx="17.5" cy="23" r="0.7" fill="#0088dd" opacity="0.7"/>
+  <circle cx="19.5" cy="23" r="0.7" fill="#0088dd" opacity="0.7"/>
+  <circle cx="12" cy="25" r="0.6" fill="#0066bb" opacity="0.6"/>
+  <!-- Sharp rock spikes around entrance -->
+  <polygon points="9,18 10,14 11,18" fill="#3a3a4a"/>
+  <polygon points="22,18 23,14 24,18" fill="#3a3a4a"/>
+  <polygon points="7,22 8,17 9,22" fill="#2a2a3a"/>
+  <polygon points="24,22 25,17 26,22" fill="#2a2a3a"/>
+  <!-- Dark kelp/seaweed -->
+  <path d="M4,28 Q5,24 6,20 Q7,24 6,28" fill="none" stroke="#0a3a1a" stroke-width="1.2"/>
+  <path d="M28,28 Q27,24 26,20 Q25,24 26,28" fill="none" stroke="#0a3a1a" stroke-width="1.2"/>
+  <!-- Water shimmer -->
+  <path d="M0,22 Q8,20 16,22 Q24,24 32,22" fill="none" stroke="#1a4a6a" stroke-width="0.7" opacity="0.4"/>
+</svg>

--- a/web/public/sprites/steam-works.svg
+++ b/web/public/sprites/steam-works.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="14" ry="1.5" fill="#1a1a1a" opacity="0.5"/>
+  <!-- Main industrial building -->
+  <rect x="2" y="14" width="28" height="16" rx="1" fill="#5a5a4a"/>
+  <!-- Metal plate texture -->
+  <line x1="2" y1="18" x2="30" y2="18" stroke="#4a4a3a" stroke-width="0.7"/>
+  <line x1="2" y1="22" x2="30" y2="22" stroke="#4a4a3a" stroke-width="0.6"/>
+  <line x1="2" y1="26" x2="30" y2="26" stroke="#4a4a3a" stroke-width="0.5"/>
+  <line x1="9" y1="14" x2="9" y2="30" stroke="#4a4a3a" stroke-width="0.5"/>
+  <line x1="23" y1="14" x2="23" y2="30" stroke="#4a4a3a" stroke-width="0.5"/>
+  <!-- Flat industrial roof -->
+  <rect x="0" y="12" width="32" height="3" fill="#4a4a3a"/>
+  <!-- Four steam chimney stacks -->
+  <rect x="4" y="3" width="4" height="11" rx="0.5" fill="#4a4a3a"/>
+  <rect x="11" y="2" width="4" height="12" rx="0.5" fill="#4a4a3a"/>
+  <rect x="18" y="2" width="4" height="12" rx="0.5" fill="#4a4a3a"/>
+  <rect x="25" y="3" width="4" height="11" rx="0.5" fill="#4a4a3a"/>
+  <!-- Steam billowing from each chimney -->
+  <ellipse cx="6" cy="3" rx="4" ry="3" fill="#ccccbb" opacity="0.5"/>
+  <ellipse cx="6" cy="1" rx="3" ry="2" fill="#ddddcc" opacity="0.4"/>
+  <ellipse cx="13" cy="2" rx="4" ry="3" fill="#ccccbb" opacity="0.5"/>
+  <ellipse cx="13" cy="-1" rx="3" ry="2" fill="#ddddcc" opacity="0.4"/>
+  <ellipse cx="20" cy="2" rx="4" ry="3" fill="#ccccbb" opacity="0.5"/>
+  <ellipse cx="27" cy="3" rx="4" ry="3" fill="#ccccbb" opacity="0.5"/>
+  <!-- Pressure gauge window -->
+  <circle cx="16" cy="20" r="3.5" fill="#2a2a1a"/>
+  <circle cx="16" cy="20" r="2.5" fill="#3a3a2a"/>
+  <circle cx="16" cy="20" r="1.5" fill="#cc4400" opacity="0.7"/>
+  <!-- Pipe connectors on walls -->
+  <rect x="2" y="16" width="4" height="2" rx="0.5" fill="#6a6a5a"/>
+  <rect x="26" y="16" width="4" height="2" rx="0.5" fill="#6a6a5a"/>
+  <!-- Large door -->
+  <rect x="12" y="20" width="8" height="10" rx="0.3" fill="#2a2a1a"/>
+</svg>

--- a/web/public/sprites/storm-altar.svg
+++ b/web/public/sprites/storm-altar.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="12" ry="1.5" fill="#1a1a2a" opacity="0.5"/>
+  <!-- Storm cloud gathering above altar -->
+  <ellipse cx="16" cy="8" rx="14" ry="6" fill="#3a3a5a" opacity="0.7"/>
+  <ellipse cx="10" cy="10" rx="8" ry="4" fill="#4a4a6a" opacity="0.6"/>
+  <ellipse cx="22" cy="9" rx="8" ry="4" fill="#4a4a6a" opacity="0.6"/>
+  <ellipse cx="16" cy="6" rx="10" ry="4" fill="#5a5a7a" opacity="0.5"/>
+  <!-- Lightning bolt from cloud to altar -->
+  <path d="M16,12 L13,16 L16,15 L13,22 L17,20 L14,26" stroke="#ffff00" stroke-width="1.8" fill="none" stroke-linecap="round" opacity="0.9"/>
+  <!-- Altar stone base -->
+  <rect x="5" y="24" width="22" height="6" rx="1" fill="#4a4a5a"/>
+  <!-- Altar platform -->
+  <rect x="7" y="20" width="18" height="5" rx="0.5" fill="#5a5a6a"/>
+  <!-- Altar top surface (conducting stone) -->
+  <rect x="9" y="18" width="14" height="3" rx="0.3" fill="#6a6a7a"/>
+  <!-- Rune etched on altar top -->
+  <line x1="12" y1="19.5" x2="20" y2="19.5" stroke="#ffffaa" stroke-width="0.8" opacity="0.7"/>
+  <line x1="16" y1="18" x2="16" y2="21" stroke="#ffffaa" stroke-width="0.8" opacity="0.7"/>
+  <!-- Four lightning rod pillars flanking altar -->
+  <line x1="8" y1="18" x2="8" y2="12" stroke="#7a7a8a" stroke-width="1.2"/>
+  <circle cx="8" cy="12" r="1" fill="#ffff88" opacity="0.7"/>
+  <line x1="24" y1="18" x2="24" y2="12" stroke="#7a7a8a" stroke-width="1.2"/>
+  <circle cx="24" cy="12" r="1" fill="#ffff88" opacity="0.7"/>
+  <!-- Ground energy discharge -->
+  <ellipse cx="16" cy="30" rx="10" ry="1.5" fill="#ffffaa" opacity="0.15"/>
+  <!-- Rain lines -->
+  <line x1="5" y1="14" x2="4" y2="18" stroke="#aabbff" stroke-width="0.5" opacity="0.3"/>
+  <line x1="10" y1="13" x2="9" y2="17" stroke="#aabbff" stroke-width="0.5" opacity="0.3"/>
+  <line x1="26" y1="14" x2="25" y2="18" stroke="#aabbff" stroke-width="0.5" opacity="0.3"/>
+</svg>

--- a/web/public/sprites/storm-citadel.svg
+++ b/web/public/sprites/storm-citadel.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="14" ry="1.5" fill="#1a1a2a" opacity="0.5"/>
+  <!-- Dark storm walls -->
+  <rect x="1" y="14" width="30" height="16" rx="1" fill="#3a3a5a"/>
+  <!-- Wall detail lines -->
+  <line x1="1" y1="19" x2="31" y2="19" stroke="#2a2a4a" stroke-width="0.8"/>
+  <line x1="1" y1="24" x2="31" y2="24" stroke="#2a2a4a" stroke-width="0.7"/>
+  <!-- Corner towers -->
+  <rect x="0" y="8" width="9" height="22" rx="0.5" fill="#4a4a6a"/>
+  <rect x="23" y="8" width="9" height="22" rx="0.5" fill="#4a4a6a"/>
+  <!-- Tower battlements (jagged like lightning) -->
+  <polygon points="0,8 2,4 4,8" fill="#3a3a5a"/>
+  <polygon points="5,8 7,4 9,8" fill="#3a3a5a"/>
+  <polygon points="23,8 25,4 27,8" fill="#3a3a5a"/>
+  <polygon points="28,8 30,4 32,8" fill="#3a3a5a"/>
+  <!-- Central storm spire -->
+  <rect x="12" y="4" width="8" height="12" rx="0.5" fill="#4a4a6a"/>
+  <polygon points="10,4 16,0 22,4" fill="#2a2a4a"/>
+  <!-- Lightning conductor at peak -->
+  <line x1="16" y1="0" x2="16" y2="-3" stroke="#7a7a8a" stroke-width="1.2"/>
+  <circle cx="16" cy="-3" r="1" fill="#ffff88" opacity="0.7"/>
+  <!-- Lightning crackling down spire -->
+  <path d="M16,0 L14,3 L16,2.5 L14,7" stroke="#ffff44" stroke-width="1" fill="none" opacity="0.7"/>
+  <!-- Storm windows (glowing) -->
+  <rect x="3" y="12" width="3" height="5" rx="0.2" fill="#1a1a2a"/>
+  <rect x="4" y="13" width="1.5" height="3" fill="#ffffaa" opacity="0.3"/>
+  <rect x="26" y="12" width="3" height="5" rx="0.2" fill="#1a1a2a"/>
+  <rect x="27" y="13" width="1.5" height="3" fill="#ffffaa" opacity="0.3"/>
+  <!-- Gate arch -->
+  <path d="M13,30 L13,20 Q16,15 19,20 L19,30 Z" fill="#1a1a2a"/>
+  <!-- Storm cloud wisps at top -->
+  <ellipse cx="8" cy="6" rx="5" ry="2.5" fill="#4a4a6a" opacity="0.5"/>
+  <ellipse cx="24" cy="6" rx="5" ry="2.5" fill="#4a4a6a" opacity="0.5"/>
+</svg>

--- a/web/public/sprites/storm-eyrie.svg
+++ b/web/public/sprites/storm-eyrie.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="10" ry="1.5" fill="#1a1a2a" opacity="0.4"/>
+  <!-- Storm cloud base swirling around eyrie -->
+  <ellipse cx="16" cy="20" rx="15" ry="6" fill="#3a3a5a" opacity="0.4"/>
+  <ellipse cx="6" cy="22" rx="8" ry="4" fill="#4a4a6a" opacity="0.3"/>
+  <ellipse cx="26" cy="22" rx="8" ry="4" fill="#4a4a6a" opacity="0.3"/>
+  <!-- Rocky mountain peak -->
+  <polygon points="4,30 8,16 14,20 16,10 18,20 24,16 28,30" fill="#4a4a5a"/>
+  <!-- Eyrie nest platform at peak -->
+  <ellipse cx="16" cy="10" rx="9" ry="3.5" fill="#5a5a4a"/>
+  <ellipse cx="16" cy="9.5" rx="8" ry="3" fill="#7a6a3a"/>
+  <!-- Nest material (sticks, lightning-scorched) -->
+  <path d="M9,9 Q12,7 16,8.5 Q20,7 23,9" fill="none" stroke="#4a3a1a" stroke-width="1.2"/>
+  <!-- Storm eagle silhouette in nest -->
+  <ellipse cx="16" cy="9" rx="3" ry="2" fill="#3a3a4a"/>
+  <circle cx="18" cy="8" r="1.5" fill="#4a4a5a"/>
+  <!-- Eagle wings spread (storm-dark) -->
+  <path d="M9,9 Q6,7 7,5 Q11,8 9,9Z" fill="#5a5a6a" opacity="0.8"/>
+  <path d="M23,9 Q26,7 25,5 Q21,8 23,9Z" fill="#5a5a6a" opacity="0.8"/>
+  <!-- Lightning crackling from wings -->
+  <line x1="7" y1="7" x2="4" y2="5" stroke="#ffff44" stroke-width="0.8" opacity="0.6"/>
+  <line x1="25" y1="7" x2="28" y2="5" stroke="#ffff44" stroke-width="0.8" opacity="0.6"/>
+  <!-- Eagle yellow eye -->
+  <circle cx="18.5" cy="7.5" r="0.6" fill="#ffcc00" opacity="0.9"/>
+  <!-- Rain streaks -->
+  <line x1="4" y1="15" x2="3" y2="20" stroke="#aabbff" stroke-width="0.5" opacity="0.3"/>
+  <line x1="28" y1="14" x2="27" y2="19" stroke="#aabbff" stroke-width="0.5" opacity="0.3"/>
+  <line x1="8" y1="25" x2="7" y2="30" stroke="#aabbff" stroke-width="0.5" opacity="0.25"/>
+</svg>

--- a/web/public/sprites/storm-roost.svg
+++ b/web/public/sprites/storm-roost.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="10" ry="1.5" fill="#1a1a2a" opacity="0.4"/>
+  <!-- Thunder-dark pillar -->
+  <rect x="11" y="18" width="10" height="12" rx="1" fill="#3a3a5a"/>
+  <!-- Storm-darkened nest platform -->
+  <ellipse cx="16" cy="18" rx="11" ry="3.5" fill="#4a4a5a"/>
+  <ellipse cx="16" cy="17.5" rx="10" ry="3" fill="#5a5a6a"/>
+  <!-- Singed nest material -->
+  <path d="M7,17 Q11,14 16,16 Q21,14 25,17" fill="none" stroke="#3a2a1a" stroke-width="1.2"/>
+  <!-- Storm bird silhouette perched -->
+  <ellipse cx="16" cy="16" rx="3.5" ry="2.5" fill="#3a3a4a"/>
+  <circle cx="19" cy="15" r="2" fill="#4a4a5a"/>
+  <!-- Wings half-spread (showing lightning) -->
+  <path d="M8,16 Q5,14 6,12 Q10,15 8,16Z" fill="#5a5a6a" opacity="0.8"/>
+  <path d="M24,16 Q27,14 26,12 Q22,15 24,16Z" fill="#5a5a6a" opacity="0.8"/>
+  <!-- Lightning bolt emanating from bird -->
+  <path d="M19,14 L22,10 L20,11 L23,6" stroke="#ffff44" stroke-width="1.5" fill="none" opacity="0.8"/>
+  <!-- Storm clouds swirling around roost top -->
+  <ellipse cx="10" cy="12" rx="6" ry="3" fill="#3a3a5a" opacity="0.5"/>
+  <ellipse cx="22" cy="11" rx="6" ry="3" fill="#4a4a6a" opacity="0.4"/>
+  <ellipse cx="16" cy="9" rx="8" ry="3.5" fill="#3a3a5a" opacity="0.4"/>
+  <!-- Rain streaks -->
+  <line x1="6" y1="22" x2="5" y2="28" stroke="#aabbff" stroke-width="0.5" opacity="0.3"/>
+  <line x1="26" y1="22" x2="25" y2="28" stroke="#aabbff" stroke-width="0.5" opacity="0.3"/>
+  <!-- Thunder crack marks on pillar -->
+  <path d="M13,22 L14,25 L12,28" fill="none" stroke="#ffffaa" stroke-width="0.6" opacity="0.3"/>
+</svg>

--- a/web/public/sprites/sunken-altar.svg
+++ b/web/public/sprites/sunken-altar.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Deep water background -->
+  <rect x="0" y="12" width="32" height="20" fill="#0a2a4a"/>
+  <!-- Water shimmer layers -->
+  <path d="M0,14 Q8,12 16,14 Q24,16 32,14" fill="none" stroke="#1a4a6a" stroke-width="0.7" opacity="0.5"/>
+  <path d="M0,18 Q8,16 16,18 Q24,20 32,18" fill="none" stroke="#1a3a5a" stroke-width="0.5" opacity="0.3"/>
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="12" ry="1.5" fill="#0a1a2a" opacity="0.5"/>
+  <!-- Ancient submerged altar steps -->
+  <rect x="4" y="26" width="24" height="5" rx="0.5" fill="#3a4a5a"/>
+  <rect x="6" y="22" width="20" height="5" rx="0.5" fill="#4a5a6a"/>
+  <rect x="8" y="18" width="16" height="5" rx="0.5" fill="#5a6a7a"/>
+  <!-- Coral encrusting the altar -->
+  <ellipse cx="6" cy="24" rx="3" ry="2" fill="#cc4422" opacity="0.6"/>
+  <ellipse cx="26" cy="24" rx="3" ry="2" fill="#dd5533" opacity="0.5"/>
+  <ellipse cx="8" cy="19" rx="2" ry="1.5" fill="#cc4422" opacity="0.5"/>
+  <!-- Ancient carved idol/face on altar -->
+  <rect x="12" y="15" width="8" height="5" rx="0.5" fill="#4a5a6a"/>
+  <ellipse cx="14" cy="17" rx="1" ry="0.8" fill="#1a2a3a"/>
+  <ellipse cx="18" cy="17" rx="1" ry="0.8" fill="#1a2a3a"/>
+  <circle cx="14" cy="17" r="0.5" fill="#0088ff" opacity="0.7"/>
+  <circle cx="18" cy="17" r="0.5" fill="#0088ff" opacity="0.7"/>
+  <!-- Bioluminescent glow from altar -->
+  <ellipse cx="16" cy="20" rx="10" ry="3" fill="#0066aa" opacity="0.2"/>
+  <!-- Air bubbles rising -->
+  <circle cx="10" cy="16" r="0.7" fill="#aaddff" opacity="0.4"/>
+  <circle cx="22" cy="15" r="0.6" fill="#aaddff" opacity="0.4"/>
+  <circle cx="16" cy="13" r="0.8" fill="#aaddff" opacity="0.3"/>
+  <!-- Kelp swaying around altar -->
+  <path d="M4,30 Q3,24 4,18 Q5,22 4,26" fill="none" stroke="#1a5a2a" stroke-width="1.2"/>
+  <path d="M28,30 Q29,24 28,18 Q27,22 28,26" fill="none" stroke="#1a5a2a" stroke-width="1.2"/>
+</svg>

--- a/web/public/sprites/swamp-den.svg
+++ b/web/public/sprites/swamp-den.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Swamp water -->
+  <rect x="0" y="22" width="32" height="10" fill="#1a3a1a" opacity="0.7"/>
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#0a1a0a" opacity="0.5"/>
+  <!-- Murky water ripples -->
+  <path d="M0,24 Q8,22 16,24 Q24,26 32,24" fill="none" stroke="#2a4a2a" stroke-width="0.7" opacity="0.4"/>
+  <!-- Swamp mound above water -->
+  <ellipse cx="16" cy="22" rx="13" ry="5" fill="#2a3a1a"/>
+  <ellipse cx="16" cy="21" rx="12" ry="4.5" fill="#3a4a2a"/>
+  <!-- Den entrance (mud/root-framed) -->
+  <ellipse cx="16" cy="24" rx="7" ry="5.5" fill="#0a1a00"/>
+  <!-- Swamp gas glow within -->
+  <ellipse cx="16" cy="25" rx="5" ry="3.5" fill="#336600" opacity="0.3"/>
+  <ellipse cx="16" cy="26" rx="3" ry="2" fill="#448800" opacity="0.25"/>
+  <!-- Yellow predator eyes in darkness -->
+  <circle cx="14" cy="23" r="1" fill="#ccff00" opacity="0.8"/>
+  <circle cx="18" cy="23" r="1" fill="#ccff00" opacity="0.8"/>
+  <!-- Gnarled roots framing entrance -->
+  <path d="M9,22 Q8,18 10,16" fill="none" stroke="#3a2a0a" stroke-width="2"/>
+  <path d="M23,22 Q24,18 22,16" fill="none" stroke="#3a2a0a" stroke-width="2"/>
+  <!-- Lily pads on water -->
+  <ellipse cx="5" cy="26" rx="3.5" ry="1.5" fill="#2a6a1a" opacity="0.7"/>
+  <ellipse cx="27" cy="26" rx="3.5" ry="1.5" fill="#2a6a1a" opacity="0.7"/>
+  <!-- Swamp gas bubbles -->
+  <circle cx="8" cy="25" r="1" fill="#88cc00" opacity="0.3"/>
+  <circle cx="24" cy="25" r="0.8" fill="#88cc00" opacity="0.3"/>
+  <!-- Reeds/tall grass -->
+  <path d="M2,20 Q3,16 4,18" fill="none" stroke="#4a7a2a" stroke-width="1"/>
+  <path d="M4,19 Q5,15 6,17" fill="none" stroke="#3a6a1a" stroke-width="1"/>
+  <path d="M28,20 Q27,16 26,18" fill="none" stroke="#4a7a2a" stroke-width="1"/>
+  <!-- Skull half-submerged in water -->
+  <ellipse cx="10" cy="28" rx="2.5" ry="1.8" fill="#ccbb99" opacity="0.6"/>
+  <circle cx="9" cy="27.5" r="0.5" fill="#1a0a0a" opacity="0.5"/>
+  <circle cx="11" cy="27.5" r="0.5" fill="#1a0a0a" opacity="0.5"/>
+</svg>

--- a/web/public/sprites/the-grand-harbor.svg
+++ b/web/public/sprites/the-grand-harbor.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Harbor water -->
+  <rect x="0" y="18" width="32" height="14" fill="#0a3a5a"/>
+  <!-- Water shimmer -->
+  <path d="M0,20 Q8,18 16,20 Q24,22 32,20" fill="none" stroke="#1a5a7a" stroke-width="0.8" opacity="0.5"/>
+  <!-- Ground shadow -->
+  <ellipse cx="8" cy="31" rx="10" ry="1" fill="#0a1a2a" opacity="0.3"/>
+  <!-- Grand stone harbor wall/quay -->
+  <rect x="0" y="16" width="32" height="4" rx="0.5" fill="#7a6a4a"/>
+  <line x1="0" y1="17.5" x2="32" y2="17.5" stroke="#5a4a2a" stroke-width="0.6"/>
+  <!-- Lighthouse on left pier -->
+  <rect x="1" y="3" width="6" height="15" rx="0.5" fill="#ddcc99"/>
+  <!-- Lighthouse stripes -->
+  <rect x="1" y="6" width="6" height="2" fill="#cc3322" opacity="0.7"/>
+  <rect x="1" y="10" width="6" height="2" fill="#cc3322" opacity="0.7"/>
+  <rect x="1" y="14" width="6" height="2" fill="#cc3322" opacity="0.7"/>
+  <!-- Lighthouse top -->
+  <rect x="0" y="1" width="8" height="3" rx="0.5" fill="#ccbb88"/>
+  <circle cx="4" cy="1" r="2" fill="#ffcc00" opacity="0.7"/>
+  <!-- Harbor master's building -->
+  <rect x="8" y="8" width="14" height="10" rx="0.5" fill="#bb9966"/>
+  <polygon points="8,8 15,3 22,8" fill="#998855"/>
+  <!-- Building flag -->
+  <line x1="15" y1="3" x2="15" y2="0" stroke="#7a6a3a" stroke-width="0.8"/>
+  <polygon points="15,0 21,1.5 15,3" fill="#2255aa"/>
+  <!-- Building windows -->
+  <rect x="10" y="10" width="3" height="3" rx="0.3" fill="#1a2a3a"/>
+  <rect x="17" y="10" width="3" height="3" rx="0.3" fill="#1a2a3a"/>
+  <!-- Sailing ship in harbor -->
+  <path d="M22,22 Q26,20 30,22 Q28,26 24,26 Q22,24 22,22Z" fill="#8a6a2a"/>
+  <line x1="26" y1="18" x2="26" y2="22" stroke="#6a4a1a" stroke-width="0.8"/>
+  <path d="M23,18 Q26,16 29,18" fill="#ddddcc" opacity="0.6"/>
+  <!-- Dock pilings -->
+  <line x1="22" y1="18" x2="20" y2="26" stroke="#6a5a2a" stroke-width="1.5"/>
+  <line x1="30" y1="18" x2="32" y2="26" stroke="#6a5a2a" stroke-width="1.5"/>
+</svg>

--- a/web/public/sprites/thorn-nest.svg
+++ b/web/public/sprites/thorn-nest.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#0a1a0a" opacity="0.5"/>
+  <!-- Thorny tree trunk -->
+  <rect x="13" y="10" width="6" height="20" rx="1" fill="#3a2a0a"/>
+  <!-- Thorn spikes on trunk -->
+  <polygon points="13,14 9,13 13,16" fill="#2a1a0a"/>
+  <polygon points="19,16 23,15 19,19" fill="#2a1a0a"/>
+  <polygon points="13,20 9,19 13,22" fill="#2a1a0a"/>
+  <polygon points="19,22 23,21 19,25" fill="#2a1a0a"/>
+  <!-- Ground roots spreading -->
+  <path d="M13,28 Q7,30 3,32" fill="none" stroke="#3a2a0a" stroke-width="2.5"/>
+  <path d="M19,28 Q25,30 29,32" fill="none" stroke="#3a2a0a" stroke-width="2.5"/>
+  <!-- Thorn nest woven at top -->
+  <ellipse cx="16" cy="11" rx="12" ry="5" fill="#4a3a1a"/>
+  <ellipse cx="16" cy="10" rx="11" ry="4.5" fill="#5a4a2a"/>
+  <!-- Thorny weave pattern -->
+  <path d="M5,10 Q10,7 16,9 Q22,7 27,10" fill="none" stroke="#2a1a0a" stroke-width="1"/>
+  <path d="M6,12 Q11,9 16,11 Q21,9 26,12" fill="none" stroke="#3a2a0a" stroke-width="0.8"/>
+  <!-- Thorn spikes on nest rim -->
+  <polygon points="7,8 8,5 9,8" fill="#2a1a0a"/>
+  <polygon points="12,7 13,4 14,7" fill="#2a1a0a"/>
+  <polygon points="18,7 19,4 20,7" fill="#2a1a0a"/>
+  <polygon points="23,8 24,5 25,8" fill="#2a1a0a"/>
+  <!-- Eggs/contents in nest -->
+  <ellipse cx="13" cy="9" rx="2.5" ry="1.8" fill="#6a5a1a"/>
+  <ellipse cx="19" cy="9" rx="2.5" ry="1.8" fill="#7a6a2a"/>
+  <ellipse cx="16" cy="7" rx="2" ry="1.5" fill="#6a5a1a"/>
+  <!-- Dark thorny creature eyes in nest -->
+  <circle cx="16" cy="9" r="1" fill="#cc0000" opacity="0.5"/>
+</svg>

--- a/web/public/sprites/thunder-pinnacle.svg
+++ b/web/public/sprites/thunder-pinnacle.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="9" ry="1.5" fill="#1a1a2a" opacity="0.5"/>
+  <!-- Stone base -->
+  <rect x="10" y="24" width="12" height="6" rx="1" fill="#4a4a5a"/>
+  <!-- Tower shaft -->
+  <rect x="12" y="8" width="8" height="18" rx="0.5" fill="#5a5a6a"/>
+  <!-- Narrowing upper section -->
+  <polygon points="10,8 16,1 22,8" fill="#3a3a4a"/>
+  <polygon points="12,8 16,3 20,8" fill="#4a4a5a"/>
+  <!-- Thunder pinnacle tip (pointed, charged) -->
+  <polygon points="14,3 16,0 18,3 16,5" fill="#6688aa"/>
+  <!-- Lightning arcing constantly at tip -->
+  <path d="M16,0 L14,4 L16,3 L14,8" stroke="#ffff44" stroke-width="1.5" fill="none" opacity="0.8"/>
+  <!-- Side lightning arcs -->
+  <path d="M16,2 L10,5" stroke="#ffff44" stroke-width="0.8" opacity="0.5"/>
+  <path d="M16,2 L22,5" stroke="#ffff44" stroke-width="0.8" opacity="0.5"/>
+  <!-- Thunder cloud rings around pinnacle -->
+  <ellipse cx="16" cy="6" rx="9" ry="3" fill="#4a4a6a" opacity="0.3"/>
+  <ellipse cx="16" cy="4" rx="6" ry="2" fill="#5a5a7a" opacity="0.25"/>
+  <!-- Metal-banded rings on tower -->
+  <rect x="11" y="11" width="10" height="1.5" rx="0.3" fill="#7a7a8a"/>
+  <rect x="11" y="16" width="10" height="1.5" rx="0.3" fill="#7a7a8a"/>
+  <rect x="11" y="21" width="10" height="1.5" rx="0.3" fill="#7a7a8a"/>
+  <!-- Glow at tip -->
+  <circle cx="16" cy="1" r="2" fill="#ffffaa" opacity="0.25"/>
+  <!-- Ground energy pulse -->
+  <ellipse cx="16" cy="30" rx="8" ry="1.5" fill="#ffffaa" opacity="0.15"/>
+</svg>

--- a/web/public/sprites/tidal-lair.svg
+++ b/web/public/sprites/tidal-lair.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Tidal water -->
+  <rect x="0" y="20" width="32" height="12" fill="#0a3a5a"/>
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#0a1a2a" opacity="0.4"/>
+  <!-- Tidal rock formation -->
+  <polygon points="1,30 3,14 8,18 12,10 16,16 20,10 24,18 29,14 31,30" fill="#3a4a4a"/>
+  <!-- Sea cave lair entrance -->
+  <ellipse cx="16" cy="24" rx="9" ry="7" fill="#0a1a2a"/>
+  <!-- Tidal creature glow within -->
+  <ellipse cx="16" cy="26" rx="7" ry="5" fill="#003355" opacity="0.5"/>
+  <ellipse cx="16" cy="27" rx="5" ry="3" fill="#0055aa" opacity="0.4"/>
+  <ellipse cx="16" cy="28" rx="3" ry="1.8" fill="#0088cc" opacity="0.3"/>
+  <!-- Tidal creature eyes -->
+  <circle cx="13" cy="23" r="1.2" fill="#00aaff" opacity="0.8"/>
+  <circle cx="19" cy="23" r="1.2" fill="#00aaff" opacity="0.8"/>
+  <!-- Barnacles/coral on rocks -->
+  <circle cx="6" cy="18" r="1.5" fill="#cc4422" opacity="0.6"/>
+  <circle cx="26" cy="18" r="1.5" fill="#cc4422" opacity="0.5"/>
+  <circle cx="10" cy="14" r="1" fill="#dd5533" opacity="0.5"/>
+  <!-- Seaweed at entrance -->
+  <path d="M8,26 Q7,22 8,18 Q9,22 8,25" fill="none" stroke="#1a5a2a" stroke-width="1.2"/>
+  <path d="M24,26 Q25,22 24,18 Q23,22 24,25" fill="none" stroke="#1a5a2a" stroke-width="1.2"/>
+  <!-- Water shimmer -->
+  <path d="M0,22 Q8,20 16,22 Q24,24 32,22" fill="none" stroke="#1a5a7a" stroke-width="0.7" opacity="0.4"/>
+  <!-- Sea foam at rock base -->
+  <ellipse cx="6" cy="26" rx="4" ry="1.5" fill="#aaccdd" opacity="0.2"/>
+  <ellipse cx="26" cy="26" rx="4" ry="1.5" fill="#aaccdd" opacity="0.2"/>
+</svg>

--- a/web/public/sprites/tidal-spring.svg
+++ b/web/public/sprites/tidal-spring.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="12" ry="1.5" fill="#0a1a2a" opacity="0.5"/>
+  <!-- Rocky basin rim -->
+  <ellipse cx="16" cy="24" rx="13" ry="5" fill="#4a5a6a"/>
+  <ellipse cx="16" cy="23" rx="12" ry="4.5" fill="#5a6a7a"/>
+  <!-- Tidal spring water (bubbling up) -->
+  <ellipse cx="16" cy="23" rx="9" ry="3.5" fill="#0a3a5a"/>
+  <ellipse cx="16" cy="22" rx="7" ry="2.8" fill="#1a4a6a"/>
+  <!-- Water surface shimmer -->
+  <path d="M9,22 Q13,20 16,22 Q19,20 23,22" fill="none" stroke="#2a6a8a" stroke-width="0.8" opacity="0.6"/>
+  <!-- Spring upwelling in center -->
+  <ellipse cx="16" cy="21" rx="3" ry="2" fill="#2a6a8a"/>
+  <ellipse cx="16" cy="20.5" rx="2" ry="1.5" fill="#4a8aaa"/>
+  <ellipse cx="16" cy="20" rx="1" ry="1" fill="#6aaabb"/>
+  <!-- Water spray from spring -->
+  <line x1="14" y1="19" x2="13" y2="16" stroke="#88bbdd" stroke-width="0.7" opacity="0.5"/>
+  <line x1="16" y1="18" x2="16" y2="15" stroke="#aaccee" stroke-width="0.8" opacity="0.5"/>
+  <line x1="18" y1="19" x2="19" y2="16" stroke="#88bbdd" stroke-width="0.7" opacity="0.5"/>
+  <!-- Droplets at spray tips -->
+  <circle cx="13" cy="15" r="0.8" fill="#aaddff" opacity="0.5"/>
+  <circle cx="16" cy="14" r="1" fill="#aaddff" opacity="0.5"/>
+  <circle cx="19" cy="15" r="0.8" fill="#aaddff" opacity="0.5"/>
+  <!-- Rocky outcroppings around spring -->
+  <polygon points="3,25 5,20 7,24" fill="#3a4a5a"/>
+  <polygon points="25,24 27,20 29,25" fill="#3a4a5a"/>
+  <!-- Sea anemones/marine life on rocks -->
+  <circle cx="6" cy="24" r="1.5" fill="#ff6644" opacity="0.5"/>
+  <circle cx="26" cy="24" r="1.5" fill="#ff4488" opacity="0.5"/>
+  <!-- Bubbles rising from spring -->
+  <circle cx="13" cy="19" r="0.7" fill="#aaddff" opacity="0.4"/>
+  <circle cx="19" cy="18" r="0.6" fill="#aaddff" opacity="0.4"/>
+  <circle cx="16" cy="17" r="0.8" fill="#aaddff" opacity="0.35"/>
+</svg>

--- a/web/public/sprites/tide-altar.svg
+++ b/web/public/sprites/tide-altar.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Tidal water at base -->
+  <rect x="0" y="24" width="32" height="8" fill="#0a3a5a" opacity="0.7"/>
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="11" ry="1.5" fill="#0a1a2a" opacity="0.4"/>
+  <!-- Altar steps (partially submerged) -->
+  <rect x="6" y="22" width="20" height="5" rx="0.5" fill="#4a5a6a"/>
+  <rect x="8" y="18" width="16" height="5" rx="0.5" fill="#5a6a7a"/>
+  <rect x="10" y="14" width="12" height="5" rx="0.5" fill="#6a7a8a"/>
+  <!-- Altar top stone -->
+  <rect x="11" y="11" width="10" height="4" rx="0.3" fill="#7a8a9a"/>
+  <!-- Wave/tide symbol carved in altar -->
+  <path d="M12,13 Q14,11 16,13 Q18,15 20,13" fill="none" stroke="#4a8aaa" stroke-width="1" opacity="0.7"/>
+  <!-- Trident idol on altar -->
+  <line x1="16" y1="6" x2="16" y2="11" stroke="#6a8aaa" stroke-width="1.2"/>
+  <line x1="13" y1="8" x2="19" y2="8" stroke="#6a8aaa" stroke-width="0.8"/>
+  <line x1="13" y1="8" x2="13" y2="6" stroke="#6a8aaa" stroke-width="0.8"/>
+  <line x1="16" y1="6" x2="16" y2="5" stroke="#6a8aaa" stroke-width="0.8"/>
+  <line x1="19" y1="8" x2="19" y2="6" stroke="#6a8aaa" stroke-width="0.8"/>
+  <!-- Tide water lapping at altar steps -->
+  <path d="M0,25 Q8,23 16,25 Q24,27 32,25" fill="none" stroke="#2a6a8a" stroke-width="0.8" opacity="0.5"/>
+  <!-- Sea foam around altar base -->
+  <ellipse cx="8" cy="27" rx="5" ry="1.5" fill="#aaccdd" opacity="0.25"/>
+  <ellipse cx="24" cy="27" rx="5" ry="1.5" fill="#aaccdd" opacity="0.25"/>
+  <!-- Coral on submerged steps -->
+  <ellipse cx="6" cy="24" rx="2.5" ry="1.5" fill="#cc4422" opacity="0.5"/>
+  <ellipse cx="26" cy="24" rx="2.5" ry="1.5" fill="#dd5533" opacity="0.4"/>
+  <!-- Shell offering on altar -->
+  <ellipse cx="14" cy="11" rx="1.5" ry="1" fill="#ccaa88"/>
+  <ellipse cx="18" cy="11" rx="1.5" ry="1" fill="#bbaa77"/>
+</svg>

--- a/web/public/sprites/tide-barracks.svg
+++ b/web/public/sprites/tide-barracks.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Tidal water at base -->
+  <rect x="0" y="26" width="32" height="6" fill="#0a3a5a" opacity="0.5"/>
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="14" ry="1.5" fill="#0a1a2a" opacity="0.4"/>
+  <!-- Barracks walls (sea-worn stone) -->
+  <rect x="2" y="12" width="28" height="16" rx="1" fill="#4a5a6a"/>
+  <!-- Coral/barnacle encrusting on lower walls -->
+  <rect x="2" y="22" width="28" height="6" fill="#5a4a4a" opacity="0.4"/>
+  <!-- Stone block lines -->
+  <line x1="2" y1="16" x2="30" y2="16" stroke="#3a4a5a" stroke-width="0.7"/>
+  <line x1="2" y1="20" x2="30" y2="20" stroke="#3a4a5a" stroke-width="0.6"/>
+  <line x1="2" y1="24" x2="30" y2="24" stroke="#3a4a5a" stroke-width="0.5"/>
+  <!-- Wave-arched roof -->
+  <path d="M0,12 Q8,6 16,9 Q24,6 32,12" fill="#3a4a5a"/>
+  <!-- Battlements -->
+  <rect x="2" y="9" width="3" height="4" rx="0.3" fill="#4a5a6a"/>
+  <rect x="8" y="9" width="3" height="4" rx="0.3" fill="#4a5a6a"/>
+  <rect x="21" y="9" width="3" height="4" rx="0.3" fill="#4a5a6a"/>
+  <rect x="27" y="9" width="3" height="4" rx="0.3" fill="#4a5a6a"/>
+  <!-- Water-arched gate entrance -->
+  <path d="M13,28 L13,18 Q16,14 19,18 L19,28 Z" fill="#0a1a2a"/>
+  <!-- Wave crest banner above gate -->
+  <path d="M12,14 Q14,11 16,13 Q18,11 20,14" fill="none" stroke="#5a9aaa" stroke-width="1.5"/>
+  <!-- Arrow slits (fish-eye shaped) -->
+  <ellipse cx="7" cy="17" rx="1.5" ry="2" fill="#0a1a2a"/>
+  <ellipse cx="25" cy="17" rx="1.5" ry="2" fill="#0a1a2a"/>
+  <!-- Seaweed on walls -->
+  <path d="M4,22 Q3,18 4,14 Q5,18 4,21" fill="none" stroke="#1a5a2a" stroke-width="1"/>
+  <path d="M28,22 Q29,18 28,14 Q27,18 28,21" fill="none" stroke="#1a5a2a" stroke-width="1"/>
+</svg>

--- a/web/public/sprites/tide-stable.svg
+++ b/web/public/sprites/tide-stable.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Tidal water around base -->
+  <rect x="0" y="26" width="32" height="6" fill="#0a3a5a" opacity="0.4"/>
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#0a1a2a" opacity="0.4"/>
+  <!-- Stable on stilts above tidal zone -->
+  <line x1="5" y1="20" x2="4" y2="30" stroke="#5a4a2a" stroke-width="1.5"/>
+  <line x1="12" y1="20" x2="11" y2="30" stroke="#5a4a2a" stroke-width="1.5"/>
+  <line x1="20" y1="20" x2="21" y2="30" stroke="#5a4a2a" stroke-width="1.5"/>
+  <line x1="27" y1="20" x2="28" y2="30" stroke="#5a4a2a" stroke-width="1.5"/>
+  <!-- Platform -->
+  <rect x="3" y="18" width="26" height="3" rx="0.5" fill="#6a5a3a"/>
+  <!-- Stable building -->
+  <rect x="3" y="8" width="26" height="11" rx="1" fill="#7a6a4a"/>
+  <!-- Stable roof (sea-green thatching) -->
+  <polygon points="1,8 16,1 31,8" fill="#4a6a4a"/>
+  <polygon points="3,8 16,3 29,8" fill="#5a7a5a"/>
+  <!-- Seaweed thatch detail -->
+  <line x1="16" y1="1" x2="8" y2="8" stroke="#3a5a3a" stroke-width="0.5"/>
+  <line x1="16" y1="1" x2="24" y2="8" stroke="#3a5a3a" stroke-width="0.5"/>
+  <!-- Sea horse silhouette inside stall (tide stable = sea horses!) -->
+  <path d="M10,14 Q11,10 13,11 Q14,12 13,14 Q12,15 11,15 Q10,15 10,14Z" fill="#4a5a6a"/>
+  <line x1="13" y1="14" x2="14" y2="18" stroke="#4a5a6a" stroke-width="1.5"/>
+  <!-- Second sea horse -->
+  <path d="M20,14 Q21,10 23,11 Q24,12 23,14 Q22,15 21,15 Q20,15 20,14Z" fill="#4a5a6a"/>
+  <line x1="23" y1="14" x2="24" y2="18" stroke="#4a5a6a" stroke-width="1.5"/>
+  <!-- Water shimmer -->
+  <path d="M0,28 Q8,26 16,28 Q24,30 32,28" fill="none" stroke="#1a5a7a" stroke-width="0.6" opacity="0.4"/>
+</svg>

--- a/web/public/sprites/titan-dune.svg
+++ b/web/public/sprites/titan-dune.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="14" ry="1.5" fill="#1a1a0a" opacity="0.4"/>
+  <!-- Massive sand dune -->
+  <ellipse cx="16" cy="24" rx="16" ry="10" fill="#cc9933"/>
+  <ellipse cx="16" cy="23" rx="15" ry="9" fill="#ddaa44"/>
+  <!-- Dune crest highlights -->
+  <path d="M2,20 Q8,15 16,18 Q24,15 30,20" fill="none" stroke="#eebb55" stroke-width="1.5"/>
+  <!-- Dune surface ripple lines -->
+  <path d="M5,22 Q10,20 16,21 Q22,20 27,22" fill="none" stroke="#cc8822" stroke-width="0.6" opacity="0.5"/>
+  <path d="M6,25 Q11,23 16,24 Q21,23 26,25" fill="none" stroke="#cc8822" stroke-width="0.5" opacity="0.4"/>
+  <!-- Giant buried titan statue head emerging -->
+  <ellipse cx="16" cy="19" rx="7" ry="6" fill="#9a8855"/>
+  <ellipse cx="16" cy="18" rx="6" ry="5" fill="#aa9966"/>
+  <!-- Titan eye sockets -->
+  <ellipse cx="13" cy="17" rx="2" ry="1.5" fill="#2a1a0a"/>
+  <ellipse cx="19" cy="17" rx="2" ry="1.5" fill="#2a1a0a"/>
+  <!-- Titan eyes glowing ancient orange -->
+  <circle cx="13" cy="17" r="1" fill="#cc6600" opacity="0.7"/>
+  <circle cx="19" cy="17" r="1" fill="#cc6600" opacity="0.7"/>
+  <!-- Titan nose ridge -->
+  <path d="M15,18 Q16,20 17,18" fill="none" stroke="#9a8855" stroke-width="1"/>
+  <!-- Ancient crown half-buried -->
+  <path d="M10,13 Q13,10 16,12 Q19,10 22,13" fill="none" stroke="#ccaa44" stroke-width="2"/>
+  <polygon points="10,13 11,9 12,13" fill="#ccaa44"/>
+  <polygon points="15,12 16,7 17,12" fill="#ddbb55"/>
+  <polygon points="20,13 21,9 22,13" fill="#ccaa44"/>
+  <!-- Sandstorm wisps at dune peak -->
+  <ellipse cx="8" cy="15" rx="4" ry="1.5" fill="#ddbb66" opacity="0.3" transform="rotate(-15 8 15)"/>
+  <ellipse cx="24" cy="14" rx="4" ry="1.5" fill="#ddbb66" opacity="0.3" transform="rotate(15 24 14)"/>
+</svg>

--- a/web/public/sprites/toadstool-keep.svg
+++ b/web/public/sprites/toadstool-keep.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#1a1a0a" opacity="0.5"/>
+  <!-- Keep base (earth and roots) -->
+  <rect x="4" y="20" width="24" height="10" rx="1" fill="#4a3a1a"/>
+  <!-- Massive toadstool cap forming keep roof -->
+  <ellipse cx="16" cy="16" rx="15" ry="7" fill="#8b2020"/>
+  <ellipse cx="16" cy="15" rx="14" ry="6.5" fill="#aa3333"/>
+  <ellipse cx="16" cy="14" rx="12" ry="5.5" fill="#cc4444"/>
+  <!-- White spots on cap -->
+  <circle cx="6" cy="15" r="2.5" fill="#ffffff" opacity="0.5"/>
+  <circle cx="12" cy="11" r="3" fill="#ffffff" opacity="0.5"/>
+  <circle cx="20" cy="11" r="2.5" fill="#ffffff" opacity="0.5"/>
+  <circle cx="26" cy="15" r="2" fill="#ffffff" opacity="0.5"/>
+  <circle cx="16" cy="9" r="2" fill="#ffffff" opacity="0.4"/>
+  <!-- Keep walls forming stalk -->
+  <rect x="8" y="14" width="16" height="8" rx="0.5" fill="#5a4a2a"/>
+  <!-- Stone block lines on stalk/walls -->
+  <line x1="8" y1="17" x2="24" y2="17" stroke="#3a2a1a" stroke-width="0.6"/>
+  <line x1="16" y1="14" x2="16" y2="22" stroke="#3a2a1a" stroke-width="0.4"/>
+  <!-- Battlements peaking through cap edge -->
+  <rect x="5" y="13" width="3" height="4" rx="0.3" fill="#6a3333"/>
+  <rect x="24" y="13" width="3" height="4" rx="0.3" fill="#6a3333"/>
+  <!-- Gate arch -->
+  <path d="M13,30 L13,22 Q16,18 19,22 L19,30 Z" fill="#1a0a00"/>
+  <!-- Spore puffs from cap -->
+  <circle cx="5" cy="9" r="2" fill="#ddcc77" opacity="0.2"/>
+  <circle cx="27" cy="8" r="2" fill="#ddcc77" opacity="0.2"/>
+  <circle cx="16" cy="6" r="2.5" fill="#ddcc77" opacity="0.15"/>
+</svg>

--- a/web/public/sprites/troll-bridge.svg
+++ b/web/public/sprites/troll-bridge.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- River below bridge -->
+  <rect x="0" y="20" width="32" height="12" fill="#1a3a5a"/>
+  <!-- Water shimmer -->
+  <path d="M0,22 Q8,20 16,22 Q24,24 32,22" fill="none" stroke="#2a5a7a" stroke-width="0.7" opacity="0.4"/>
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="14" ry="1" fill="#0a1a2a" opacity="0.3"/>
+  <!-- Bridge supports/pylons -->
+  <rect x="5" y="16" width="6" height="16" rx="1" fill="#6a5a4a"/>
+  <rect x="21" y="16" width="6" height="16" rx="1" fill="#6a5a4a"/>
+  <!-- Stone arch -->
+  <path d="M5,20 Q16,10 27,20" fill="#5a4a3a" stroke="#4a3a2a" stroke-width="1"/>
+  <!-- Bridge deck (stone slabs) -->
+  <rect x="3" y="14" width="26" height="5" rx="0.5" fill="#7a6a4a"/>
+  <line x1="3" y1="15.5" x2="29" y2="15.5" stroke="#5a4a2a" stroke-width="0.6"/>
+  <line x1="8" y1="14" x2="8" y2="19" stroke="#5a4a2a" stroke-width="0.5"/>
+  <line x1="14" y1="14" x2="14" y2="19" stroke="#5a4a2a" stroke-width="0.5"/>
+  <line x1="18" y1="14" x2="18" y2="19" stroke="#5a4a2a" stroke-width="0.5"/>
+  <line x1="24" y1="14" x2="24" y2="19" stroke="#5a4a2a" stroke-width="0.5"/>
+  <!-- Troll under bridge (classic) -->
+  <ellipse cx="16" cy="22" rx="5" ry="4" fill="#4a6a2a"/>
+  <circle cx="16" cy="19" r="3.5" fill="#5a7a3a"/>
+  <!-- Troll eyes -->
+  <circle cx="14.5" cy="18.5" r="0.8" fill="#ffcc00" opacity="0.9"/>
+  <circle cx="17.5" cy="18.5" r="0.8" fill="#ffcc00" opacity="0.9"/>
+  <!-- Troll club -->
+  <line x1="20" y1="20" x2="24" y2="16" stroke="#6a4a1a" stroke-width="2" stroke-linecap="round"/>
+  <circle cx="24" cy="15" r="2" fill="#5a3a0a"/>
+  <!-- Bridge railing (rough stones) -->
+  <rect x="3" y="12" width="5" height="2.5" rx="0.3" fill="#8a7a5a"/>
+  <rect x="9" y="12" width="5" height="2.5" rx="0.3" fill="#7a6a4a"/>
+  <rect x="18" y="12" width="5" height="2.5" rx="0.3" fill="#8a7a5a"/>
+  <rect x="24" y="12" width="5" height="2.5" rx="0.3" fill="#7a6a4a"/>
+</svg>

--- a/web/public/sprites/vault-burst.svg
+++ b/web/public/sprites/vault-burst.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Dark industrial background -->
+  <ellipse cx="16" cy="16" rx="14" ry="14" fill="#2a2a1a" opacity="0.4"/>
+  <!-- Explosion burst -->
+  <ellipse cx="16" cy="16" rx="10" ry="10" fill="#ff6600" opacity="0.4"/>
+  <ellipse cx="16" cy="16" rx="7" ry="7" fill="#ff8800" opacity="0.5"/>
+  <ellipse cx="16" cy="16" rx="4" ry="4" fill="#ffaa00" opacity="0.7"/>
+  <ellipse cx="16" cy="16" rx="2" ry="2" fill="#ffff44"/>
+  <!-- Explosion rays -->
+  <line x1="16" y1="6" x2="16" y2="2" stroke="#ff8800" stroke-width="2" opacity="0.7"/>
+  <line x1="16" y1="26" x2="16" y2="30" stroke="#ff8800" stroke-width="2" opacity="0.7"/>
+  <line x1="6" y1="16" x2="2" y2="16" stroke="#ff8800" stroke-width="2" opacity="0.7"/>
+  <line x1="26" y1="16" x2="30" y2="16" stroke="#ff8800" stroke-width="2" opacity="0.7"/>
+  <line x1="9" y1="9" x2="6" y2="6" stroke="#ff8800" stroke-width="1.5" opacity="0.6"/>
+  <line x1="23" y1="9" x2="26" y2="6" stroke="#ff8800" stroke-width="1.5" opacity="0.6"/>
+  <line x1="9" y1="23" x2="6" y2="26" stroke="#ff8800" stroke-width="1.5" opacity="0.6"/>
+  <line x1="23" y1="23" x2="26" y2="26" stroke="#ff8800" stroke-width="1.5" opacity="0.6"/>
+  <!-- Metal scrap shards flying outward -->
+  <polygon points="5,12 3,10 6,14" fill="#6a6a5a"/>
+  <polygon points="27,12 29,10 26,14" fill="#6a6a5a"/>
+  <polygon points="12,5 10,3 14,6" fill="#6a6a5a"/>
+  <polygon points="20,5 22,3 18,6" fill="#6a6a5a"/>
+  <!-- Vault door fragment in center -->
+  <rect x="13" y="13" width="6" height="6" rx="0.5" fill="#4a4a3a"/>
+  <circle cx="16" cy="16" r="1.5" fill="#6a6a5a"/>
+</svg>

--- a/web/public/sprites/vault-gate.svg
+++ b/web/public/sprites/vault-gate.svg
@@ -1,0 +1,37 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="14" ry="1.5" fill="#1a1a1a" opacity="0.5"/>
+  <!-- Massive vault gate pillars -->
+  <rect x="1" y="6" width="9" height="24" rx="1" fill="#4a4a5a"/>
+  <rect x="22" y="6" width="9" height="24" rx="1" fill="#4a4a5a"/>
+  <!-- Pillar highlights -->
+  <rect x="1" y="6" width="3" height="24" fill="#5a5a6a"/>
+  <rect x="22" y="6" width="3" height="24" fill="#5a5a6a"/>
+  <!-- Rivet rows on pillars -->
+  <circle cx="3" cy="10" r="0.8" fill="#7a7a8a"/>
+  <circle cx="3" cy="16" r="0.8" fill="#7a7a8a"/>
+  <circle cx="3" cy="22" r="0.8" fill="#7a7a8a"/>
+  <circle cx="29" cy="10" r="0.8" fill="#7a7a8a"/>
+  <circle cx="29" cy="16" r="0.8" fill="#7a7a8a"/>
+  <circle cx="29" cy="22" r="0.8" fill="#7a7a8a"/>
+  <!-- Pillar cap stones -->
+  <rect x="0" y="4" width="11" height="3" rx="0.5" fill="#5a5a6a"/>
+  <rect x="21" y="4" width="11" height="3" rx="0.5" fill="#5a5a6a"/>
+  <!-- Heavy vault doors between pillars -->
+  <rect x="10" y="8" width="6" height="22" rx="0.3" fill="#3a3a4a"/>
+  <rect x="16" y="8" width="6" height="22" rx="0.3" fill="#3a3a4a"/>
+  <!-- Door seam (center line) -->
+  <line x1="16" y1="8" x2="16" y2="30" stroke="#2a2a3a" stroke-width="0.8"/>
+  <!-- Iron banding on doors -->
+  <rect x="10" y="12" width="12" height="2" rx="0.3" fill="#5a5a6a"/>
+  <rect x="10" y="18" width="12" height="2" rx="0.3" fill="#5a5a6a"/>
+  <rect x="10" y="24" width="12" height="2" rx="0.3" fill="#5a5a6a"/>
+  <!-- Locking mechanism center -->
+  <circle cx="16" cy="16" r="3" fill="#2a2a3a"/>
+  <circle cx="16" cy="16" r="2" fill="#3a3a4a"/>
+  <circle cx="16" cy="16" r="1" fill="#6a6a7a"/>
+  <!-- Arch over gate -->
+  <path d="M10,8 Q16,1 22,8" fill="none" stroke="#5a5a6a" stroke-width="2.5"/>
+  <!-- Keystone -->
+  <ellipse cx="16" cy="3" rx="2.5" ry="2" fill="#6a6a7a"/>
+</svg>

--- a/web/public/sprites/vault-scrap.svg
+++ b/web/public/sprites/vault-scrap.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Industrial background -->
+  <ellipse cx="16" cy="16" rx="14" ry="14" fill="#2a2a1a" opacity="0.4"/>
+  <!-- Central HP heart/shield (buff symbol) -->
+  <path d="M16,22 Q9,17 9,12 Q9,8 13,8 Q15,8 16,10 Q17,8 19,8 Q23,8 23,12 Q23,17 16,22 Z" fill="#cc4444"/>
+  <path d="M16,20 Q10.5,15.5 10.5,12 Q10.5,9.5 13,9.5 Q14.5,9.5 16,11.5 Q17.5,9.5 19,9.5 Q21.5,9.5 21.5,12 Q21.5,15.5 16,20 Z" fill="#ee6666"/>
+  <!-- Metal scrap pieces around it -->
+  <rect x="3" y="8" width="4" height="3" rx="0.3" fill="#5a5a4a" transform="rotate(-20 5 9.5)"/>
+  <rect x="25" y="8" width="4" height="3" rx="0.3" fill="#5a5a4a" transform="rotate(20 27 9.5)"/>
+  <rect x="4" y="20" width="3" height="4" rx="0.3" fill="#6a6a5a" transform="rotate(15 5.5 22)"/>
+  <rect x="25" y="20" width="3" height="4" rx="0.3" fill="#6a6a5a" transform="rotate(-15 26.5 22)"/>
+  <rect x="13" y="25" width="3" height="4" rx="0.3" fill="#5a5a4a" transform="rotate(5 14.5 27)"/>
+  <rect x="16" y="24" width="4" height="3" rx="0.3" fill="#6a6a5a" transform="rotate(-10 18 25.5)"/>
+  <!-- Rivets/bolts on scrap -->
+  <circle cx="5" cy="9" r="0.5" fill="#8a8a7a"/>
+  <circle cx="27" cy="9" r="0.5" fill="#8a8a7a"/>
+  <!-- HP glow -->
+  <ellipse cx="16" cy="15" rx="6" ry="6" fill="#cc4444" opacity="0.12"/>
+  <!-- Plus symbol (HP buff indicator) -->
+  <line x1="14" y1="14" x2="18" y2="14" stroke="#ffaaaa" stroke-width="1" opacity="0.6"/>
+  <line x1="16" y1="12" x2="16" y2="16" stroke="#ffaaaa" stroke-width="1" opacity="0.6"/>
+</svg>

--- a/web/public/sprites/venom-pit.svg
+++ b/web/public/sprites/venom-pit.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#0a1a0a" opacity="0.6"/>
+  <!-- Pit rim/stone ring -->
+  <ellipse cx="16" cy="24" rx="14" ry="6" fill="#2a3a1a"/>
+  <ellipse cx="16" cy="23" rx="13" ry="5.5" fill="#3a4a2a"/>
+  <!-- Venom/acid fill (sickly green) -->
+  <ellipse cx="16" cy="24" rx="10" ry="4" fill="#1a3a00"/>
+  <ellipse cx="16" cy="24" rx="8" ry="3" fill="#225500" opacity="0.9"/>
+  <ellipse cx="16" cy="24" rx="5" ry="2" fill="#338800" opacity="0.8"/>
+  <ellipse cx="16" cy="24" rx="2.5" ry="1.2" fill="#55cc00" opacity="0.7"/>
+  <!-- Venom bubbles -->
+  <circle cx="12" cy="23" r="1.2" fill="#44aa00" opacity="0.6"/>
+  <circle cx="20" cy="24" r="1" fill="#55bb00" opacity="0.6"/>
+  <circle cx="16" cy="22" r="1.5" fill="#66cc00" opacity="0.5"/>
+  <!-- Rising toxic fumes -->
+  <path d="M12,20 Q13,17 14,15" fill="none" stroke="#4a6a1a" stroke-width="1" opacity="0.4"/>
+  <path d="M20,20 Q19,17 18,15" fill="none" stroke="#4a6a1a" stroke-width="1" opacity="0.4"/>
+  <circle cx="13" cy="14" r="1.5" fill="#6a8a1a" opacity="0.3"/>
+  <circle cx="18" cy="13" r="1.2" fill="#6a8a1a" opacity="0.3"/>
+  <!-- Fanged snake lurking at rim -->
+  <path d="M5,22 Q8,20 11,22 Q9,24 7,23 Q5,23 5,22Z" fill="#2a4a1a"/>
+  <!-- Snake eyes -->
+  <circle cx="6" cy="22" r="0.6" fill="#ffcc00" opacity="0.8"/>
+  <!-- Thorn/spike decorations on rim -->
+  <polygon points="4,20 5,17 6,20" fill="#1a2a0a"/>
+  <polygon points="26,20 27,17 28,20" fill="#1a2a0a"/>
+</svg>

--- a/web/public/sprites/veterans-post.svg
+++ b/web/public/sprites/veterans-post.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="12" ry="1.5" fill="#1a1a1a" opacity="0.5"/>
+  <!-- Post/building base -->
+  <rect x="6" y="18" width="20" height="12" rx="1" fill="#6a5a3a"/>
+  <!-- Stone/wood texture -->
+  <line x1="6" y1="22" x2="26" y2="22" stroke="#5a4a2a" stroke-width="0.7"/>
+  <line x1="6" y1="26" x2="26" y2="26" stroke="#5a4a2a" stroke-width="0.6"/>
+  <line x1="14" y1="18" x2="14" y2="30" stroke="#5a4a2a" stroke-width="0.4"/>
+  <!-- Roof -->
+  <polygon points="4,18 16,9 28,18" fill="#4a3a1a"/>
+  <polygon points="6,18 16,11 26,18" fill="#5a4a2a"/>
+  <!-- Battle-worn door -->
+  <rect x="13" y="22" width="6" height="8" rx="0.3" fill="#2a1a0a"/>
+  <!-- Notch marks on door (battle tally) -->
+  <line x1="14" y1="23" x2="14" y2="28" stroke="#3a2a0a" stroke-width="0.5"/>
+  <line x1="15.5" y1="23" x2="15.5" y2="28" stroke="#3a2a0a" stroke-width="0.5"/>
+  <line x1="17" y1="23" x2="17" y2="28" stroke="#3a2a0a" stroke-width="0.5"/>
+  <line x1="18.5" y1="23" x2="18.5" y2="28" stroke="#3a2a0a" stroke-width="0.5"/>
+  <!-- Medal/honor shield hanging above door -->
+  <polygon points="16,14 13,16 13,19 16,21 19,19 19,16" fill="#8a7a4a"/>
+  <polygon points="16,15 14,17 14,19 16,20.5 18,19 18,17" fill="#aa9955"/>
+  <!-- Cross/symbol on shield -->
+  <line x1="16" y1="15.5" x2="16" y2="20" stroke="#ffcc00" stroke-width="0.8"/>
+  <line x1="14" y1="17.5" x2="18" y2="17.5" stroke="#ffcc00" stroke-width="0.8"/>
+  <!-- Trophy weapons on walls -->
+  <line x1="8" y1="20" x2="11" y2="18" stroke="#8a8a8a" stroke-width="1.2"/>
+  <polygon points="11,18 13,16 12,19" fill="#8a8a8a"/>
+  <line x1="24" y1="20" x2="21" y2="18" stroke="#8a8a8a" stroke-width="1.2"/>
+  <polygon points="21,18 19,16 20,19" fill="#8a8a8a"/>
+</svg>

--- a/web/public/sprites/vine-cathedral.svg
+++ b/web/public/sprites/vine-cathedral.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="14" ry="1.5" fill="#0a1a0a" opacity="0.5"/>
+  <!-- Cathedral body (overgrown with vines) -->
+  <rect x="3" y="14" width="26" height="16" rx="1" fill="#3a4a2a"/>
+  <!-- Vine-covered walls -->
+  <rect x="3" y="14" width="5" height="16" fill="#2a5a1a" opacity="0.5"/>
+  <rect x="24" y="16" width="5" height="14" fill="#2a5a1a" opacity="0.4"/>
+  <!-- Stone texture under vines -->
+  <line x1="3" y1="18" x2="29" y2="18" stroke="#2a3a1a" stroke-width="0.6"/>
+  <line x1="3" y1="23" x2="29" y2="23" stroke="#2a3a1a" stroke-width="0.5"/>
+  <!-- Cathedral spire (vine-wrapped) -->
+  <polygon points="3,14 16,3 29,14" fill="#2a3a1a"/>
+  <polygon points="5,14 16,5 27,14" fill="#3a4a2a"/>
+  <!-- Large vine spiraling up spire -->
+  <path d="M16,14 Q14,11 15,8 Q17,5 16,3" fill="none" stroke="#2a7a1a" stroke-width="1.5"/>
+  <!-- Flower blooms at vine tips -->
+  <circle cx="15" cy="4" r="1.5" fill="#ff4488" opacity="0.7"/>
+  <circle cx="5" cy="12" r="1.2" fill="#ff6644" opacity="0.6"/>
+  <circle cx="27" cy="12" r="1.2" fill="#ffcc00" opacity="0.6"/>
+  <!-- Gothic windows (arched, filled with vines) -->
+  <rect x="6" y="16" width="4" height="6" rx="0.5" fill="#1a2a1a"/>
+  <path d="M6,16 Q8,13 10,16" fill="#1a2a1a"/>
+  <circle cx="8" cy="17" r="1" fill="#2a6a1a" opacity="0.5"/>
+  <rect x="22" y="16" width="4" height="6" rx="0.5" fill="#1a2a1a"/>
+  <path d="M22,16 Q24,13 26,16" fill="#1a2a1a"/>
+  <!-- Main entrance arch (overgrown) -->
+  <path d="M13,30 L13,20 Q16,16 19,20 L19,30 Z" fill="#1a2a0a"/>
+  <path d="M13,20 Q16,14 19,20" fill="none" stroke="#2a7a1a" stroke-width="1.5"/>
+  <!-- Creeping ivy on entire facade -->
+  <path d="M3,14 Q1,18 3,22 Q2,19 4,17" fill="none" stroke="#2a6a1a" stroke-width="0.8" opacity="0.6"/>
+  <path d="M29,16 Q31,20 29,24 Q30,21 28,19" fill="none" stroke="#2a6a1a" stroke-width="0.8" opacity="0.6"/>
+</svg>

--- a/web/public/sprites/vine-hollow.svg
+++ b/web/public/sprites/vine-hollow.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#0a1a0a" opacity="0.5"/>
+  <!-- Large hollow tree trunk -->
+  <rect x="9" y="6" width="14" height="24" rx="4" fill="#4a3a1a"/>
+  <!-- Hollow opening -->
+  <ellipse cx="16" cy="20" rx="6" ry="8" fill="#1a0a00"/>
+  <!-- Vine life within hollow -->
+  <ellipse cx="16" cy="22" rx="4" ry="5.5" fill="#0a2000" opacity="0.8"/>
+  <circle cx="14" cy="19" r="1.5" fill="#2a7a1a" opacity="0.6"/>
+  <circle cx="18" cy="21" r="1.2" fill="#2a6a1a" opacity="0.5"/>
+  <!-- Vines climbing in/out -->
+  <path d="M11,26 Q10,22 12,18 Q11,22 10,26" fill="none" stroke="#2a7a1a" stroke-width="1.2"/>
+  <path d="M21,26 Q22,22 20,18 Q21,22 22,26" fill="none" stroke="#2a6a1a" stroke-width="1.2"/>
+  <!-- Tree bark texture -->
+  <path d="M9,10 Q7,15 9,20" fill="none" stroke="#3a2a0a" stroke-width="1" opacity="0.5"/>
+  <path d="M23,12 Q25,17 23,22" fill="none" stroke="#3a2a0a" stroke-width="1" opacity="0.5"/>
+  <!-- Dense canopy at top -->
+  <ellipse cx="16" cy="6" rx="12" ry="7" fill="#2a6a1a"/>
+  <ellipse cx="9" cy="8" rx="7" ry="5" fill="#3a7a2a"/>
+  <ellipse cx="23" cy="8" rx="7" ry="5" fill="#3a7a2a"/>
+  <ellipse cx="16" cy="4" rx="9" ry="5" fill="#4a8a3a"/>
+  <!-- Flower blooms on canopy -->
+  <circle cx="7" cy="6" r="1.5" fill="#ffaa44" opacity="0.6"/>
+  <circle cx="25" cy="5" r="1.5" fill="#ff4488" opacity="0.6"/>
+  <circle cx="16" cy="2" r="1.5" fill="#ffcc00" opacity="0.5"/>
+  <!-- Glowing fireflies in hollow -->
+  <circle cx="14" cy="22" r="0.7" fill="#aaff44" opacity="0.5"/>
+  <circle cx="18" cy="24" r="0.6" fill="#88ff44" opacity="0.4"/>
+</svg>

--- a/web/public/sprites/void-rift.svg
+++ b/web/public/sprites/void-rift.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="11" ry="1.5" fill="#0a0a1a" opacity="0.6"/>
+  <!-- Rift tear in reality (dark oval crack) -->
+  <ellipse cx="16" cy="18" rx="12" ry="14" fill="#0a0014" opacity="0.9"/>
+  <!-- Void layers -->
+  <ellipse cx="16" cy="18" rx="10" ry="12" fill="#000000"/>
+  <ellipse cx="16" cy="18" rx="7" ry="9" fill="#0a0033"/>
+  <ellipse cx="16" cy="18" rx="4" ry="6" fill="#110044"/>
+  <ellipse cx="16" cy="18" rx="2" ry="3.5" fill="#220066"/>
+  <!-- Void core -->
+  <ellipse cx="16" cy="18" rx="0.8" ry="1.5" fill="#4400aa" opacity="0.8"/>
+  <!-- Reality crack marks emanating from rift -->
+  <path d="M5,10 Q8,14 7,18" fill="none" stroke="#4400aa" stroke-width="1" opacity="0.5"/>
+  <path d="M27,10 Q24,14 25,18" fill="none" stroke="#4400aa" stroke-width="1" opacity="0.5"/>
+  <path d="M4,20 Q7,18 5,22" fill="none" stroke="#3300aa" stroke-width="0.8" opacity="0.4"/>
+  <path d="M28,20 Q25,18 27,22" fill="none" stroke="#3300aa" stroke-width="0.8" opacity="0.4"/>
+  <!-- Void energy crackling at rift edges -->
+  <path d="M8,8 Q10,10 8,12" fill="none" stroke="#8800ff" stroke-width="1.2" opacity="0.6"/>
+  <path d="M24,8 Q22,10 24,12" fill="none" stroke="#8800ff" stroke-width="1.2" opacity="0.6"/>
+  <!-- Void wisps escaping rift -->
+  <circle cx="6" cy="12" r="1.5" fill="#4400aa" opacity="0.4"/>
+  <circle cx="26" cy="11" r="1.2" fill="#5500bb" opacity="0.4"/>
+  <circle cx="10" cy="6" r="1" fill="#6600cc" opacity="0.3"/>
+  <circle cx="22" cy="5" r="1.2" fill="#6600cc" opacity="0.3"/>
+  <!-- Stars disappearing into rift -->
+  <circle cx="3" cy="8" r="0.7" fill="#8888ff" opacity="0.4"/>
+  <circle cx="29" cy="7" r="0.6" fill="#8888ff" opacity="0.4"/>
+  <circle cx="16" cy="4" r="0.8" fill="#aaaaff" opacity="0.3"/>
+</svg>

--- a/web/public/sprites/wall-barracks.svg
+++ b/web/public/sprites/wall-barracks.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="14" ry="1.5" fill="#1a1a1a" opacity="0.5"/>
+  <!-- Very thick wall (reinforced barracks) -->
+  <rect x="0" y="12" width="32" height="18" rx="0.5" fill="#7a7a6a"/>
+  <!-- Wall blocks (larger than normal) -->
+  <line x1="0" y1="17" x2="32" y2="17" stroke="#5a5a4a" stroke-width="0.8"/>
+  <line x1="0" y1="22" x2="32" y2="22" stroke="#5a5a4a" stroke-width="0.8"/>
+  <line x1="0" y1="27" x2="32" y2="27" stroke="#5a5a4a" stroke-width="0.7"/>
+  <line x1="8" y1="12" x2="8" y2="30" stroke="#5a5a4a" stroke-width="0.6"/>
+  <line x1="16" y1="12" x2="16" y2="30" stroke="#5a5a4a" stroke-width="0.5"/>
+  <line x1="24" y1="12" x2="24" y2="30" stroke="#5a5a4a" stroke-width="0.6"/>
+  <!-- Battlements (large crenels) -->
+  <rect x="0" y="8" width="5" height="5" rx="0.3" fill="#8a8a7a"/>
+  <rect x="7" y="8" width="5" height="5" rx="0.3" fill="#8a8a7a"/>
+  <rect x="14" y="8" width="5" height="5" rx="0.3" fill="#8a8a7a"/>
+  <rect x="21" y="8" width="5" height="5" rx="0.3" fill="#8a8a7a"/>
+  <rect x="28" y="8" width="4" height="5" rx="0.3" fill="#8a8a7a"/>
+  <!-- Barracks building set INTO the wall -->
+  <rect x="10" y="10" width="12" height="10" rx="0.5" fill="#6a6a5a"/>
+  <!-- Barracks roof (flush with wall top) -->
+  <rect x="9" y="9" width="14" height="2" rx="0.3" fill="#5a5a4a"/>
+  <!-- Barracks windows -->
+  <rect x="12" y="12" width="3" height="3" rx="0.2" fill="#2a2a1a"/>
+  <rect x="17" y="12" width="3" height="3" rx="0.2" fill="#2a2a1a"/>
+  <!-- Wall gate passage -->
+  <rect x="13" y="22" width="6" height="8" rx="0.3" fill="#1a1a1a"/>
+  <!-- Gate portcullis bars -->
+  <line x1="14" y1="22" x2="14" y2="30" stroke="#3a3a3a" stroke-width="0.7"/>
+  <line x1="16" y1="22" x2="16" y2="30" stroke="#3a3a3a" stroke-width="0.7"/>
+  <line x1="18" y1="22" x2="18" y2="30" stroke="#3a3a3a" stroke-width="0.7"/>
+  <line x1="13" y1="24" x2="19" y2="24" stroke="#3a3a3a" stroke-width="0.5"/>
+  <line x1="13" y1="27" x2="19" y2="27" stroke="#3a3a3a" stroke-width="0.5"/>
+</svg>

--- a/web/public/sprites/war-drum.svg
+++ b/web/public/sprites/war-drum.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="11" ry="1.5" fill="#1a1a0a" opacity="0.5"/>
+  <!-- Drum platform/stand -->
+  <rect x="8" y="26" width="16" height="4" rx="0.5" fill="#5a4a2a"/>
+  <line x1="10" y1="27" x2="10" y2="30" stroke="#4a3a1a" stroke-width="1.5"/>
+  <line x1="22" y1="27" x2="22" y2="30" stroke="#4a3a1a" stroke-width="1.5"/>
+  <!-- Drum body (large war drum) -->
+  <ellipse cx="16" cy="16" rx="12" ry="5" fill="#8a6a2a"/>
+  <rect x="4" y="12" width="24" height="14" rx="1" fill="#7a5a1a"/>
+  <ellipse cx="16" cy="26" rx="12" ry="5" fill="#6a4a1a"/>
+  <!-- Drum heads -->
+  <ellipse cx="16" cy="12" rx="12" ry="5" fill="#cc9944"/>
+  <ellipse cx="16" cy="12" rx="11" ry="4.5" fill="#ddaa55"/>
+  <!-- Drum head lacing (zig-zag rope) -->
+  <path d="M5,14 L7,10 L9,14 L11,10 L13,14 L15,10 L17,14 L19,10 L21,14 L23,10 L25,14 L27,10" fill="none" stroke="#8a6a2a" stroke-width="0.8"/>
+  <!-- Drum beaters/sticks laid on drum -->
+  <line x1="9" y1="10" x2="14" y2="14" stroke="#8a6a2a" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="23" y1="10" x2="18" y2="14" stroke="#8a6a2a" stroke-width="1.5" stroke-linecap="round"/>
+  <!-- Impact marks on drum head (battle-worn) -->
+  <circle cx="14" cy="12" r="1.5" fill="#bb8833" opacity="0.5"/>
+  <circle cx="18" cy="11" r="1" fill="#bb8833" opacity="0.4"/>
+  <!-- Tribal symbols painted on drum body -->
+  <line x1="12" y1="18" x2="14" y2="18" stroke="#cc6622" stroke-width="0.8" opacity="0.6"/>
+  <line x1="13" y1="17" x2="13" y2="19" stroke="#cc6622" stroke-width="0.8" opacity="0.6"/>
+  <line x1="18" y1="18" x2="20" y2="18" stroke="#cc6622" stroke-width="0.8" opacity="0.6"/>
+  <!-- Sound waves radiating -->
+  <path d="M0,12 Q3,12 3,12" fill="none" stroke="#cc9944" stroke-width="0.5" opacity="0.25"/>
+  <path d="M32,12 Q29,12 29,12" fill="none" stroke="#cc9944" stroke-width="0.5" opacity="0.25"/>
+</svg>

--- a/web/public/sprites/warlord-s-den.svg
+++ b/web/public/sprites/warlord-s-den.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="14" ry="1.5" fill="#1a1a0a" opacity="0.5"/>
+  <!-- Rough stone den walls -->
+  <rect x="2" y="12" width="28" height="18" rx="1" fill="#5a4a2a"/>
+  <!-- Stone texture -->
+  <line x1="2" y1="17" x2="30" y2="17" stroke="#3a2a1a" stroke-width="0.8"/>
+  <line x1="2" y1="22" x2="30" y2="22" stroke="#3a2a1a" stroke-width="0.7"/>
+  <line x1="2" y1="27" x2="30" y2="27" stroke="#3a2a1a" stroke-width="0.6"/>
+  <line x1="9" y1="12" x2="9" y2="30" stroke="#3a2a1a" stroke-width="0.5"/>
+  <line x1="23" y1="12" x2="23" y2="30" stroke="#3a2a1a" stroke-width="0.5"/>
+  <!-- Brutal flat roof with spikes -->
+  <rect x="0" y="10" width="32" height="3" fill="#3a2a1a"/>
+  <!-- Iron spikes on roof -->
+  <polygon points="3,10 4,6 5,10" fill="#5a5a5a"/>
+  <polygon points="8,10 9,6 10,10" fill="#5a5a5a"/>
+  <polygon points="14,10 15,6 16,10" fill="#5a5a5a"/>
+  <polygon points="22,10 23,6 24,10" fill="#5a5a5a"/>
+  <polygon points="27,10 28,6 29,10" fill="#5a5a5a"/>
+  <!-- Skull trophies on spikes -->
+  <ellipse cx="9" cy="5" rx="2" ry="1.5" fill="#ccbb99"/>
+  <circle cx="8.2" cy="4.5" r="0.5" fill="#1a0a0a"/>
+  <circle cx="9.8" cy="4.5" r="0.5" fill="#1a0a0a"/>
+  <ellipse cx="23" cy="5" rx="2" ry="1.5" fill="#ccbb99"/>
+  <circle cx="22.2" cy="4.5" r="0.5" fill="#1a0a0a"/>
+  <circle cx="23.8" cy="4.5" r="0.5" fill="#1a0a0a"/>
+  <!-- Heavy gate/entrance -->
+  <rect x="12" y="18" width="8" height="12" rx="0.3" fill="#1a0a00"/>
+  <!-- Gate bars (iron portcullis) -->
+  <line x1="13" y1="18" x2="13" y2="30" stroke="#4a4a4a" stroke-width="0.8"/>
+  <line x1="15" y1="18" x2="15" y2="30" stroke="#4a4a4a" stroke-width="0.8"/>
+  <line x1="17" y1="18" x2="17" y2="30" stroke="#4a4a4a" stroke-width="0.8"/>
+  <line x1="19" y1="18" x2="19" y2="30" stroke="#4a4a4a" stroke-width="0.8"/>
+  <line x1="12" y1="21" x2="20" y2="21" stroke="#4a4a4a" stroke-width="0.6"/>
+  <line x1="12" y1="25" x2="20" y2="25" stroke="#4a4a4a" stroke-width="0.6"/>
+  <!-- War banner/trophy -->
+  <line x1="16" y1="10" x2="16" y2="6" stroke="#4a3a1a" stroke-width="0.8"/>
+  <polygon points="16,6 22,7.5 16,9" fill="#8b2222"/>
+</svg>

--- a/web/public/sprites/wave-pit.svg
+++ b/web/public/sprites/wave-pit.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#0a1a2a" opacity="0.5"/>
+  <!-- Pit stone rim -->
+  <ellipse cx="16" cy="24" rx="14" ry="5.5" fill="#3a4a5a"/>
+  <ellipse cx="16" cy="23" rx="13" ry="5" fill="#4a5a6a"/>
+  <!-- Wave/tidal water in pit -->
+  <ellipse cx="16" cy="24" rx="10" ry="3.5" fill="#0a3a5a"/>
+  <ellipse cx="16" cy="24" rx="8" ry="2.8" fill="#1a4a6a"/>
+  <!-- Wave crests in pit -->
+  <path d="M8,23 Q11,21 14,23 Q17,25 20,23 Q23,21 24,23" fill="none" stroke="#3a7a9a" stroke-width="1" opacity="0.7"/>
+  <path d="M9,25 Q12,23 15,25 Q18,27 21,25" fill="none" stroke="#2a6a8a" stroke-width="0.8" opacity="0.5"/>
+  <!-- Wave spray rising from pit center -->
+  <path d="M14,22 Q15,19 16,17" fill="none" stroke="#aaddff" stroke-width="0.8" opacity="0.5"/>
+  <path d="M18,22 Q17,19 16,17" fill="none" stroke="#aaddff" stroke-width="0.8" opacity="0.5"/>
+  <circle cx="16" cy="16" r="1.5" fill="#aaddff" opacity="0.4"/>
+  <!-- Water bubbling upward -->
+  <circle cx="13" cy="21" r="1" fill="#4a8aaa" opacity="0.5"/>
+  <circle cx="19" cy="22" r="0.8" fill="#3a7a9a" opacity="0.5"/>
+  <!-- Tidal creature eyes in wave -->
+  <circle cx="13.5" cy="23" r="0.8" fill="#00aaff" opacity="0.7"/>
+  <circle cx="18.5" cy="23" r="0.8" fill="#00aaff" opacity="0.7"/>
+  <!-- Sea foam at rim -->
+  <ellipse cx="7" cy="26" rx="3" ry="1" fill="#aaccdd" opacity="0.2"/>
+  <ellipse cx="25" cy="26" rx="3" ry="1" fill="#aaccdd" opacity="0.2"/>
+  <!-- Anchor chain decorating pit rim -->
+  <path d="M4,22 Q6,21 8,22" fill="none" stroke="#5a6a7a" stroke-width="1" opacity="0.5"/>
+  <path d="M24,22 Q26,21 28,22" fill="none" stroke="#5a6a7a" stroke-width="1" opacity="0.5"/>
+</svg>

--- a/web/public/sprites/wight-barracks.svg
+++ b/web/public/sprites/wight-barracks.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="14" ry="1.5" fill="#0a0a1a" opacity="0.5"/>
+  <!-- Pale stone barracks walls (wight - undead) -->
+  <rect x="2" y="12" width="28" height="18" rx="1" fill="#4a4a5a"/>
+  <!-- Bone-white stone texture -->
+  <line x1="2" y1="17" x2="30" y2="17" stroke="#3a3a4a" stroke-width="0.7"/>
+  <line x1="2" y1="22" x2="30" y2="22" stroke="#3a3a4a" stroke-width="0.7"/>
+  <line x1="2" y1="27" x2="30" y2="27" stroke="#3a3a4a" stroke-width="0.5"/>
+  <line x1="9" y1="12" x2="9" y2="30" stroke="#3a3a4a" stroke-width="0.5"/>
+  <line x1="23" y1="12" x2="23" y2="30" stroke="#3a3a4a" stroke-width="0.5"/>
+  <!-- Pale roof with pointed battlement -->
+  <polygon points="0,12 16,4 32,12" fill="#2a2a3a"/>
+  <polygon points="2,12 16,6 30,12" fill="#3a3a4a"/>
+  <!-- Corner towers -->
+  <rect x="0" y="8" width="7" height="22" rx="0.5" fill="#5a5a6a"/>
+  <rect x="25" y="8" width="7" height="22" rx="0.5" fill="#5a5a6a"/>
+  <!-- Wight eye-glow windows -->
+  <ellipse cx="4" cy="13" rx="1.5" ry="1" fill="#0a0a1a"/>
+  <ellipse cx="4" cy="13" rx="1" ry="0.7" fill="#8888ff" opacity="0.6"/>
+  <ellipse cx="28" cy="13" rx="1.5" ry="1" fill="#0a0a1a"/>
+  <ellipse cx="28" cy="13" rx="1" ry="0.7" fill="#8888ff" opacity="0.6"/>
+  <!-- Gate arch with death rune -->
+  <path d="M13,30 L13,20 Q16,15 19,20 L19,30 Z" fill="#0a0a14"/>
+  <!-- Wight rune above gate -->
+  <line x1="14" y1="16" x2="18" y2="16" stroke="#6666ff" stroke-width="0.7" opacity="0.7"/>
+  <line x1="16" y1="14" x2="16" y2="18" stroke="#6666ff" stroke-width="0.7" opacity="0.7"/>
+  <!-- Undead mist at ground level -->
+  <ellipse cx="16" cy="30" rx="13" ry="1.5" fill="#4444aa" opacity="0.1"/>
+  <!-- Pale banners -->
+  <line x1="16" y1="4" x2="16" y2="1" stroke="#2a2a3a" stroke-width="0.8"/>
+  <polygon points="16,1 22,2.5 16,4" fill="#3a3a5a"/>
+</svg>

--- a/web/public/sprites/windspire.svg
+++ b/web/public/sprites/windspire.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="10" ry="1.5" fill="#1a1a2a" opacity="0.5"/>
+  <!-- Tall slender tower -->
+  <rect x="13" y="6" width="6" height="24" rx="1" fill="#6a7a8a"/>
+  <!-- Tower base -->
+  <rect x="10" y="24" width="12" height="6" rx="1" fill="#5a6a7a"/>
+  <!-- Wind fins (horizontal blades) -->
+  <ellipse cx="16" cy="10" rx="12" ry="2" fill="#8a9aaa" opacity="0.8"/>
+  <ellipse cx="16" cy="10" rx="10" ry="1.2" fill="#aabbcc" opacity="0.6"/>
+  <!-- Second wind ring -->
+  <ellipse cx="16" cy="16" rx="9" ry="1.5" fill="#8a9aaa" opacity="0.6"/>
+  <!-- Spire tip -->
+  <polygon points="14,6 16,1 18,6" fill="#4a5a6a"/>
+  <line x1="16" y1="1" x2="16" y2="4" stroke="#ccddee" stroke-width="0.8"/>
+  <!-- Wind swirl lines -->
+  <path d="M5,10 Q10,8 16,10 Q22,12 27,10" fill="none" stroke="#ccddee" stroke-width="0.6" opacity="0.5"/>
+  <path d="M7,16 Q11,14 16,16 Q21,18 25,16" fill="none" stroke="#ccddee" stroke-width="0.5" opacity="0.4"/>
+  <!-- Tower window -->
+  <rect x="14.5" y="18" width="3" height="4" rx="0.3" fill="#2a3a4a"/>
+  <rect x="15" y="18.5" width="2" height="3" fill="#aaddff" opacity="0.3"/>
+</svg>

--- a/web/public/sprites/wisp-grove.svg
+++ b/web/public/sprites/wisp-grove.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="14" ry="1.5" fill="#0a1a0a" opacity="0.5"/>
+  <!-- Grove ground -->
+  <ellipse cx="16" cy="28" rx="14" ry="4" fill="#1a2a1a"/>
+  <!-- Dark ancient trees -->
+  <rect x="2" y="14" width="4" height="16" rx="0.5" fill="#2a3a2a"/>
+  <ellipse cx="4" cy="13" rx="5" ry="6" fill="#1a2a1a"/>
+  <rect x="26" y="14" width="4" height="16" rx="0.5" fill="#2a3a2a"/>
+  <ellipse cx="28" cy="13" rx="5" ry="6" fill="#1a2a1a"/>
+  <!-- Central glade -->
+  <rect x="10" y="18" width="4" height="12" rx="0.5" fill="#2a3a2a"/>
+  <ellipse cx="12" cy="16" rx="5" ry="5" fill="#1a3a1a"/>
+  <rect x="18" y="18" width="4" height="12" rx="0.5" fill="#2a3a2a"/>
+  <ellipse cx="20" cy="16" rx="5" ry="5" fill="#1a3a1a"/>
+  <!-- Floating wisps -->
+  <circle cx="10" cy="10" r="2" fill="#aaffaa" opacity="0.6"/>
+  <circle cx="10" cy="10" r="1" fill="#ccffcc" opacity="0.8"/>
+  <circle cx="22" cy="8" r="2" fill="#aaffaa" opacity="0.6"/>
+  <circle cx="22" cy="8" r="1" fill="#ccffcc" opacity="0.8"/>
+  <circle cx="16" cy="6" r="1.5" fill="#88ff88" opacity="0.7"/>
+  <circle cx="16" cy="6" r="0.8" fill="#ccffcc" opacity="0.9"/>
+  <!-- Wisp trails -->
+  <path d="M10,10 Q13,7 16,6" fill="none" stroke="#88ff88" stroke-width="0.5" opacity="0.4"/>
+  <path d="M22,8 Q19,7 16,6" fill="none" stroke="#88ff88" stroke-width="0.5" opacity="0.4"/>
+  <!-- Ground glow -->
+  <ellipse cx="16" cy="28" rx="8" ry="2" fill="#44ff44" opacity="0.1"/>
+</svg>

--- a/web/public/sprites/wisp-hollow.svg
+++ b/web/public/sprites/wisp-hollow.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#0a1a0a" opacity="0.5"/>
+  <!-- Hollow tree stump -->
+  <ellipse cx="16" cy="28" rx="12" ry="4" fill="#2a3a2a"/>
+  <!-- Hollow interior dark -->
+  <ellipse cx="16" cy="22" rx="7" ry="9" fill="#1a2a1a"/>
+  <ellipse cx="16" cy="24" rx="5" ry="7" fill="#0a1a0a"/>
+  <!-- Bark texture around hollow -->
+  <path d="M9,22 Q7,15 9,8 Q12,4 16,3 Q20,4 23,8 Q25,15 23,22" fill="#2a3a1a" stroke="#1a2a1a" stroke-width="0.5"/>
+  <!-- Wisp glows inside hollow -->
+  <circle cx="14" cy="20" r="1.5" fill="#aaffaa" opacity="0.7"/>
+  <circle cx="18" cy="22" r="1.2" fill="#88ffaa" opacity="0.6"/>
+  <circle cx="15" cy="25" r="1" fill="#aaffaa" opacity="0.5"/>
+  <!-- Floating wisps above -->
+  <circle cx="12" cy="8" r="1.5" fill="#88ff88" opacity="0.7"/>
+  <circle cx="12" cy="8" r="0.7" fill="#ccffcc" opacity="0.9"/>
+  <circle cx="20" cy="6" r="1.5" fill="#88ff88" opacity="0.7"/>
+  <circle cx="20" cy="6" r="0.7" fill="#ccffcc" opacity="0.9"/>
+  <!-- Moss on bark -->
+  <ellipse cx="8" cy="16" rx="2" ry="1" fill="#2a4a2a" opacity="0.7"/>
+  <ellipse cx="24" cy="14" rx="2" ry="1" fill="#2a4a2a" opacity="0.7"/>
+  <!-- Ground glow -->
+  <ellipse cx="16" cy="30" rx="10" ry="1.5" fill="#44ff44" opacity="0.08"/>
+</svg>

--- a/web/public/sprites/wolfpack-den.svg
+++ b/web/public/sprites/wolfpack-den.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="14" ry="1.5" fill="#1a1a0a" opacity="0.5"/>
+  <!-- Rocky hillside den -->
+  <polygon points="0,30 4,16 10,20 16,12 22,20 28,16 32,30" fill="#4a4a3a"/>
+  <!-- Den entrance (cave mouth) -->
+  <ellipse cx="16" cy="24" rx="7" ry="6" fill="#1a1a0a"/>
+  <ellipse cx="16" cy="26" rx="5" ry="4" fill="#0a0a00"/>
+  <!-- Rocky arch above entrance -->
+  <path d="M9,24 Q16,14 23,24" fill="#5a5a4a" stroke="#3a3a2a" stroke-width="0.5"/>
+  <!-- Claw marks on rock face -->
+  <line x1="6" y1="18" x2="8" y2="24" stroke="#3a3a2a" stroke-width="0.8"/>
+  <line x1="7" y1="17" x2="9" y2="23" stroke="#3a3a2a" stroke-width="0.6"/>
+  <line x1="24" y1="18" x2="22" y2="24" stroke="#3a3a2a" stroke-width="0.8"/>
+  <line x1="23" y1="17" x2="21" y2="23" stroke="#3a3a2a" stroke-width="0.6"/>
+  <!-- Wolf eyes glowing in darkness -->
+  <circle cx="13" cy="22" r="1" fill="#ffaa00" opacity="0.9"/>
+  <circle cx="13" cy="22" r="0.5" fill="#ffdd44" opacity="0.9"/>
+  <circle cx="19" cy="22" r="1" fill="#ffaa00" opacity="0.9"/>
+  <circle cx="19" cy="22" r="0.5" fill="#ffdd44" opacity="0.9"/>
+  <!-- Bones at entrance -->
+  <line x1="11" y1="29" x2="14" y2="29" stroke="#ccbbaa" stroke-width="1"/>
+  <line x1="18" y1="29" x2="21" y2="29" stroke="#ccbbaa" stroke-width="1"/>
+  <!-- Pine trees flanking -->
+  <polygon points="2,20 5,10 8,20" fill="#2a3a2a"/>
+  <polygon points="24,20 27,10 30,20" fill="#2a3a2a"/>
+</svg>

--- a/web/public/sprites/wraith-hollow.svg
+++ b/web/public/sprites/wraith-hollow.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#0a0a1a" opacity="0.5"/>
+  <!-- Dead hollow tree -->
+  <rect x="12" y="8" width="8" height="22" rx="1" fill="#2a2a3a"/>
+  <!-- Hollow opening -->
+  <ellipse cx="16" cy="20" rx="3" ry="5" fill="#0a0a14"/>
+  <!-- Gnarled roots -->
+  <path d="M12,28 Q8,30 5,30" fill="none" stroke="#2a2a3a" stroke-width="1.5"/>
+  <path d="M20,28 Q24,30 27,30" fill="none" stroke="#2a2a3a" stroke-width="1.5"/>
+  <path d="M12,26 Q9,28 7,31" fill="none" stroke="#2a2a3a" stroke-width="1.2"/>
+  <!-- Dead branches -->
+  <line x1="12" y1="12" x2="5" y2="8" stroke="#2a2a3a" stroke-width="1.2"/>
+  <line x1="5" y1="8" x2="3" y2="5" stroke="#2a2a3a" stroke-width="0.8"/>
+  <line x1="20" y1="12" x2="27" y2="8" stroke="#2a2a3a" stroke-width="1.2"/>
+  <line x1="27" y1="8" x2="29" y2="5" stroke="#2a2a3a" stroke-width="0.8"/>
+  <line x1="16" y1="8" x2="13" y2="4" stroke="#2a2a3a" stroke-width="1"/>
+  <line x1="16" y1="8" x2="19" y2="4" stroke="#2a2a3a" stroke-width="1"/>
+  <!-- Wraith energy inside hollow -->
+  <ellipse cx="16" cy="20" rx="2" ry="3" fill="#5555cc" opacity="0.4"/>
+  <ellipse cx="16" cy="20" rx="1" ry="2" fill="#8888ff" opacity="0.5"/>
+  <!-- Ghostly mist at base -->
+  <ellipse cx="16" cy="30" rx="10" ry="1.5" fill="#4444aa" opacity="0.15"/>
+  <ellipse cx="16" cy="29" rx="7" ry="1" fill="#6666cc" opacity="0.1"/>
+</svg>

--- a/web/public/sprites/wraith-shrine.svg
+++ b/web/public/sprites/wraith-shrine.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#0a0a1a" opacity="0.5"/>
+  <!-- Shrine base platform -->
+  <rect x="3" y="24" width="26" height="6" rx="0.5" fill="#3a3a4a"/>
+  <!-- Shrine steps -->
+  <rect x="5" y="22" width="22" height="3" rx="0.3" fill="#4a4a5a"/>
+  <rect x="8" y="20" width="16" height="3" rx="0.3" fill="#5a5a6a"/>
+  <!-- Central obelisk -->
+  <rect x="13" y="6" width="6" height="14" rx="0.5" fill="#4a4a5a"/>
+  <polygon points="13,6 16,1 19,6" fill="#3a3a4a"/>
+  <!-- Rune glyphs on obelisk -->
+  <line x1="14" y1="10" x2="18" y2="10" stroke="#6666ff" stroke-width="0.6" opacity="0.8"/>
+  <line x1="16" y1="8" x2="16" y2="12" stroke="#6666ff" stroke-width="0.6" opacity="0.8"/>
+  <line x1="14" y1="15" x2="18" y2="15" stroke="#6666ff" stroke-width="0.5" opacity="0.7"/>
+  <!-- Wraith energy at obelisk tip -->
+  <ellipse cx="16" cy="2" rx="2" ry="1.5" fill="#8888ff" opacity="0.6"/>
+  <!-- Corner grave markers -->
+  <rect x="4" y="16" width="3" height="7" rx="0.3" fill="#3a3a4a"/>
+  <polygon points="4,16 5.5,13 7,16" fill="#2a2a3a"/>
+  <rect x="25" y="16" width="3" height="7" rx="0.3" fill="#3a3a4a"/>
+  <polygon points="25,16 26.5,13 28,16" fill="#2a2a3a"/>
+  <!-- Ghostly mist -->
+  <ellipse cx="16" cy="29" rx="11" ry="1.5" fill="#4444aa" opacity="0.12"/>
+  <ellipse cx="16" cy="27" rx="8" ry="1" fill="#6666cc" opacity="0.1"/>
+</svg>

--- a/web/public/sprites/wraith-thicket.svg
+++ b/web/public/sprites/wraith-thicket.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="14" ry="1.5" fill="#0a0a1a" opacity="0.5"/>
+  <!-- Dark gnarled thicket ground -->
+  <ellipse cx="16" cy="28" rx="14" ry="4" fill="#1a1a2a"/>
+  <!-- Twisted dead trees -->
+  <rect x="2" y="12" width="3" height="18" rx="0.5" fill="#2a2a3a"/>
+  <path d="M3.5,14 Q0,10 2,7" fill="none" stroke="#2a2a3a" stroke-width="1.2"/>
+  <path d="M3.5,16 Q7,12 5,9" fill="none" stroke="#2a2a3a" stroke-width="1"/>
+  <rect x="27" y="12" width="3" height="18" rx="0.5" fill="#2a2a3a"/>
+  <path d="M28.5,14 Q32,10 30,7" fill="none" stroke="#2a2a3a" stroke-width="1.2"/>
+  <path d="M28.5,16 Q25,12 27,9" fill="none" stroke="#2a2a3a" stroke-width="1"/>
+  <!-- Middle dead tree -->
+  <rect x="14" y="8" width="4" height="22" rx="0.5" fill="#2a2a3a"/>
+  <path d="M16,10 Q11,6 13,3" fill="none" stroke="#2a2a3a" stroke-width="1.2"/>
+  <path d="M16,10 Q21,6 19,3" fill="none" stroke="#2a2a3a" stroke-width="1.2"/>
+  <!-- Thorny underbrush -->
+  <polygon points="6,28 8,22 10,28" fill="#2a2a3a"/>
+  <polygon points="22,28 24,22 26,28" fill="#2a2a3a"/>
+  <polygon points="10,28 12,24 14,28" fill="#2a2a3a"/>
+  <polygon points="18,28 20,24 22,28" fill="#2a2a3a"/>
+  <!-- Wraith wisps floating -->
+  <ellipse cx="8" cy="14" rx="2" ry="1.2" fill="#5555cc" opacity="0.4"/>
+  <ellipse cx="24" cy="12" rx="2" ry="1.2" fill="#5555cc" opacity="0.4"/>
+  <ellipse cx="16" cy="6" rx="2" ry="1" fill="#7777dd" opacity="0.5"/>
+  <!-- Ghostly mist ground -->
+  <ellipse cx="16" cy="30" rx="12" ry="1.5" fill="#4444aa" opacity="0.12"/>
+</svg>

--- a/web/public/sprites/wreck-forge.svg
+++ b/web/public/sprites/wreck-forge.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="14" ry="1.5" fill="#1a1a0a" opacity="0.5"/>
+  <!-- Ruined forge walls -->
+  <rect x="3" y="14" width="26" height="16" rx="1" fill="#4a4a3a"/>
+  <!-- Crumbling sections -->
+  <polygon points="3,14 3,22 6,22 6,14 8,14 8,18 10,18 10,14" fill="#5a5a4a"/>
+  <polygon points="22,14 22,18 24,18 24,14 26,14 26,22 29,22 29,14" fill="#5a5a4a"/>
+  <!-- Collapsed roof remnants -->
+  <polygon points="5,14 14,8 20,14" fill="#3a3a2a"/>
+  <polygon points="16,14 22,10 28,14" fill="#3a3a2a" opacity="0.7"/>
+  <!-- Rubble piles -->
+  <ellipse cx="6" cy="29" rx="4" ry="2" fill="#5a5a4a"/>
+  <ellipse cx="26" cy="29" rx="4" ry="2" fill="#5a5a4a"/>
+  <!-- Forge fire pit (still active) -->
+  <rect x="12" y="20" width="8" height="6" rx="0.5" fill="#2a2a1a"/>
+  <ellipse cx="16" cy="20" rx="4" ry="2" fill="#ff6600" opacity="0.8"/>
+  <ellipse cx="16" cy="20" rx="2.5" ry="1.2" fill="#ffaa00" opacity="0.8"/>
+  <ellipse cx="16" cy="19" rx="1.5" ry="1" fill="#ffff44" opacity="0.7"/>
+  <!-- Smoke rising from fire -->
+  <ellipse cx="16" cy="15" rx="3" ry="2" fill="#5a5a5a" opacity="0.4"/>
+  <ellipse cx="15" cy="12" rx="2" ry="1.5" fill="#4a4a4a" opacity="0.3"/>
+  <!-- Broken tools -->
+  <line x1="8" y1="26" x2="11" y2="23" stroke="#6a6a5a" stroke-width="1"/>
+  <line x1="24" y1="26" x2="21" y2="23" stroke="#6a6a5a" stroke-width="1"/>
+</svg>

--- a/web/public/sprites/wreck-pile.svg
+++ b/web/public/sprites/wreck-pile.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="14" ry="1.5" fill="#1a1a0a" opacity="0.5"/>
+  <!-- Rubble mound base -->
+  <ellipse cx="16" cy="27" rx="14" ry="5" fill="#4a4a3a"/>
+  <!-- Large stone blocks scattered -->
+  <rect x="2" y="22" width="7" height="6" rx="0.5" fill="#5a5a4a"/>
+  <rect x="23" y="23" width="6" height="5" rx="0.5" fill="#5a5a4a"/>
+  <rect x="10" y="20" width="8" height="5" rx="0.5" fill="#5a5a4a" transform="rotate(-5 14 22)"/>
+  <!-- Collapsed tower section -->
+  <rect x="6" y="14" width="8" height="10" rx="0.5" fill="#4a4a3a" transform="rotate(8 10 19)"/>
+  <rect x="18" y="16" width="8" height="8" rx="0.5" fill="#4a4a3a" transform="rotate(-6 22 20)"/>
+  <!-- Broken arch piece -->
+  <path d="M11,18 Q16,12 21,18" fill="none" stroke="#3a3a2a" stroke-width="2"/>
+  <!-- Wooden beam sticking out -->
+  <rect x="0" y="24" width="12" height="2" rx="0.3" fill="#6a5a3a" transform="rotate(-15 6 25)"/>
+  <rect x="20" y="23" width="12" height="2" rx="0.3" fill="#6a5a3a" transform="rotate(12 26 24)"/>
+  <!-- Small debris -->
+  <circle cx="9" cy="27" r="1" fill="#3a3a2a"/>
+  <circle cx="21" cy="26" r="1.2" fill="#3a3a2a"/>
+  <circle cx="15" cy="29" r="0.8" fill="#3a3a2a"/>
+  <!-- Dust cloud -->
+  <ellipse cx="16" cy="19" rx="6" ry="3" fill="#8a8a7a" opacity="0.2"/>
+</svg>

--- a/web/public/sprites/wyrm-burrow.svg
+++ b/web/public/sprites/wyrm-burrow.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="14" ry="1.5" fill="#1a1a0a" opacity="0.5"/>
+  <!-- Sandy/earthy mound -->
+  <ellipse cx="16" cy="26" rx="14" ry="6" fill="#5a4a2a"/>
+  <!-- Burrow tunnel entrance (large wyrm-sized) -->
+  <ellipse cx="16" cy="24" rx="8" ry="7" fill="#2a1a0a"/>
+  <ellipse cx="16" cy="26" rx="6" ry="5" fill="#1a0a00"/>
+  <!-- Disturbed earth around hole -->
+  <ellipse cx="6" cy="22" rx="4" ry="2" fill="#6a5a3a" transform="rotate(-20 6 22)"/>
+  <ellipse cx="26" cy="22" rx="4" ry="2" fill="#6a5a3a" transform="rotate(20 26 22)"/>
+  <ellipse cx="16" cy="18" rx="5" ry="2" fill="#6a5a3a"/>
+  <!-- Scales visible in darkness -->
+  <ellipse cx="14" cy="24" rx="2" ry="1" fill="#2a4a1a" opacity="0.7"/>
+  <ellipse cx="18" cy="25" rx="2" ry="1" fill="#2a4a1a" opacity="0.7"/>
+  <!-- Wyrm eyes glowing -->
+  <circle cx="13" cy="22" r="1.2" fill="#aaff00" opacity="0.9"/>
+  <circle cx="13" cy="22" r="0.6" fill="#ddff44" opacity="0.9"/>
+  <circle cx="19" cy="22" r="1.2" fill="#aaff00" opacity="0.9"/>
+  <circle cx="19" cy="22" r="0.6" fill="#ddff44" opacity="0.9"/>
+  <!-- Claw marks radiating from burrow -->
+  <line x1="7" y1="18" x2="10" y2="22" stroke="#3a2a1a" stroke-width="1"/>
+  <line x1="5" y1="20" x2="8" y2="23" stroke="#3a2a1a" stroke-width="0.8"/>
+  <line x1="25" y1="18" x2="22" y2="22" stroke="#3a2a1a" stroke-width="1"/>
+  <line x1="27" y1="20" x2="24" y2="23" stroke="#3a2a1a" stroke-width="0.8"/>
+  <!-- Bones in excavated earth -->
+  <line x1="4" y1="27" x2="8" y2="27" stroke="#ccbbaa" stroke-width="0.8"/>
+  <line x1="24" y1="28" x2="28" y2="27" stroke="#ccbbaa" stroke-width="0.8"/>
+</svg>

--- a/web/public/sprites/wyrm-cradle.svg
+++ b/web/public/sprites/wyrm-cradle.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#1a1a0a" opacity="0.5"/>
+  <!-- Stone nest base -->
+  <ellipse cx="16" cy="27" rx="13" ry="5" fill="#4a4a3a"/>
+  <!-- Nest walls (curved stone) -->
+  <path d="M3,24 Q5,16 16,15 Q27,16 29,24" fill="#5a5a4a" stroke="#3a3a2a" stroke-width="0.5"/>
+  <!-- Nest interior -->
+  <ellipse cx="16" cy="23" rx="10" ry="6" fill="#3a3a2a"/>
+  <!-- Straw/grass nest lining -->
+  <ellipse cx="16" cy="24" rx="8" ry="4.5" fill="#4a4a1a"/>
+  <!-- Large wyrm eggs -->
+  <ellipse cx="11" cy="24" rx="3" ry="4" fill="#3a5a2a"/>
+  <ellipse cx="16" cy="23" rx="3" ry="4" fill="#4a5a2a"/>
+  <ellipse cx="21" cy="24" rx="3" ry="4" fill="#3a5a2a"/>
+  <!-- Egg scale pattern -->
+  <path d="M9,24 Q11,22 13,24 Q11,26 9,24" fill="#2a4a1a" opacity="0.5"/>
+  <path d="M14,23 Q16,21 18,23 Q16,25 14,23" fill="#3a4a1a" opacity="0.5"/>
+  <path d="M19,24 Q21,22 23,24 Q21,26 19,24" fill="#2a4a1a" opacity="0.5"/>
+  <!-- Glowing egg cracks (about to hatch) -->
+  <line x1="16" y1="20" x2="17" y2="22" stroke="#aaff00" stroke-width="0.5" opacity="0.7"/>
+  <line x1="16" y1="22" x2="15" y2="23" stroke="#aaff00" stroke-width="0.5" opacity="0.7"/>
+  <!-- Flanking stone pillars -->
+  <rect x="1" y="14" width="4" height="14" rx="0.5" fill="#5a5a4a"/>
+  <rect x="27" y="14" width="4" height="14" rx="0.5" fill="#5a5a4a"/>
+  <!-- Pillar caps -->
+  <rect x="0" y="12" width="6" height="3" rx="0.3" fill="#6a6a5a"/>
+  <rect x="26" y="12" width="6" height="3" rx="0.3" fill="#6a6a5a"/>
+</svg>

--- a/web/public/sprites/wyvern-aerie.svg
+++ b/web/public/sprites/wyvern-aerie.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#1a1a2a" opacity="0.5"/>
+  <!-- Tall cliff spire -->
+  <polygon points="10,30 10,10 16,4 22,10 22,30" fill="#4a4a5a"/>
+  <!-- Rock face detail -->
+  <line x1="10" y1="16" x2="22" y2="16" stroke="#3a3a4a" stroke-width="0.6"/>
+  <line x1="10" y1="22" x2="22" y2="22" stroke="#3a3a4a" stroke-width="0.5"/>
+  <!-- Aerie platform jutting from cliff face -->
+  <rect x="7" y="10" width="18" height="4" rx="0.5" fill="#5a5a6a"/>
+  <!-- Nest on platform -->
+  <ellipse cx="16" cy="11" rx="7" ry="3" fill="#3a3a2a"/>
+  <ellipse cx="16" cy="11" rx="5" ry="2" fill="#4a4a2a"/>
+  <!-- Wyvern eggs in nest -->
+  <ellipse cx="13" cy="11" rx="2" ry="2.5" fill="#6a4a2a"/>
+  <ellipse cx="19" cy="11" rx="2" ry="2.5" fill="#5a3a2a"/>
+  <!-- Wyvern perched silhouette -->
+  <polygon points="14,10 16,5 18,10" fill="#2a2a3a"/>
+  <!-- Wings spread -->
+  <polygon points="14,7 8,4 10,9" fill="#2a2a3a" opacity="0.7"/>
+  <polygon points="18,7 24,4 22,9" fill="#2a2a3a" opacity="0.7"/>
+  <!-- Claw marks on cliff -->
+  <line x1="11" y1="18" x2="13" y2="14" stroke="#3a3a4a" stroke-width="0.7"/>
+  <line x1="12" y1="19" x2="14" y2="15" stroke="#3a3a4a" stroke-width="0.5"/>
+  <!-- Base rock rubble -->
+  <ellipse cx="6" cy="29" rx="5" ry="2.5" fill="#3a3a4a"/>
+  <ellipse cx="26" cy="29" rx="5" ry="2.5" fill="#3a3a4a"/>
+  <!-- Gate at cliff base -->
+  <rect x="13" y="22" width="6" height="8" rx="0.3" fill="#1a1a2a"/>
+  <path d="M13,22 Q16,18 19,22" fill="#2a2a3a"/>
+</svg>

--- a/web/public/sprites/zephyr-post.svg
+++ b/web/public/sprites/zephyr-post.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="12" ry="1.5" fill="#1a1a2a" opacity="0.5"/>
+  <!-- Post base -->
+  <rect x="10" y="22" width="12" height="8" rx="1" fill="#5a6a7a"/>
+  <!-- Main post tower -->
+  <rect x="13" y="8" width="6" height="16" rx="0.5" fill="#6a7a8a"/>
+  <!-- Wind vane crossbar -->
+  <rect x="4" y="10" width="24" height="2" rx="0.5" fill="#7a8a9a"/>
+  <!-- Spinning wind cups (anemometer style) -->
+  <circle cx="4" cy="11" r="2.5" fill="#4a5a6a"/>
+  <circle cx="4" cy="11" r="1.5" fill="#8a9aaa"/>
+  <circle cx="28" cy="11" r="2.5" fill="#4a5a6a"/>
+  <circle cx="28" cy="11" r="1.5" fill="#8a9aaa"/>
+  <!-- Weather vane arrow -->
+  <polygon points="13,6 16,2 19,6" fill="#aabbcc"/>
+  <line x1="16" y1="2" x2="16" y2="8" stroke="#8a9aaa" stroke-width="1"/>
+  <!-- Wind direction flag -->
+  <line x1="16" y1="2" x2="24" y2="4" stroke="#7a8a9a" stroke-width="0.8"/>
+  <polygon points="24,4 20,3 20,5" fill="#aabbcc" opacity="0.7"/>
+  <!-- Wind stream lines -->
+  <path d="M2,16 Q8,14 16,16 Q24,18 30,16" fill="none" stroke="#aabbcc" stroke-width="0.6" opacity="0.4"/>
+  <path d="M2,20 Q8,18 16,20 Q24,22 30,20" fill="none" stroke="#aabbcc" stroke-width="0.5" opacity="0.3"/>
+  <!-- Signal beacon on post -->
+  <circle cx="16" cy="8" r="2" fill="#2a3a4a"/>
+  <circle cx="16" cy="8" r="1" fill="#aaddff" opacity="0.6"/>
+  <!-- Base windows -->
+  <rect x="12" y="24" width="3" height="4" rx="0.2" fill="#2a3a4a"/>
+  <rect x="17" y="24" width="3" height="4" rx="0.2" fill="#2a3a4a"/>
+</svg>


### PR DESCRIPTION
Closes #1101

## Summary
- **act5-intro-1** (The Sunken Reef): bio-glow pulse, coral polyp twinkle (x10, staggered), bioluminescent particle upward drift (x12 with opacity fade), ship mast gentle sway, water surface shimmer pulse, ley line animated flow
- **act5-intro-2** (The Tidal Sovereign): full-body slow sway (animateTransform translate), sovereign glow pulse, eye inner-light pulse x2 (radius + opacity), tendril tip glow pulse x2 (offset timing), coral polyp twinkle x5, water particle drift x8, orbiting droplet movement x4
- **act5-intro-3** (The Passage): ley line animated flow (stroke-dashoffset on all 5 paths), ley node radius+opacity pulse, bio-glow pulse, coral polyp twinkle x5, keystone rune pulse, ancient marker rune fade x4 (staggered), tunnel light pulse, bioluminescent particle drift x8

All animations use SMIL following the Act 1 reference style.

https://claude.ai/code/session_01QjAWeyHiDWwKa8oZQFU7yn

---
_Generated by [Claude Code](https://claude.ai/code/session_01QjAWeyHiDWwKa8oZQFU7yn)_