### PR TITLE
Add Wizard Academy, Barbarian Den, and Knight Barracks spawner cards

### DIFF
--- a/web/public/sprites/barbarian-den.svg
+++ b/web/public/sprites/barbarian-den.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="13" ry="1.5" fill="#0a0a0a" opacity="0.5"/>
+  <!-- Main log-wall building -->
+  <rect x="3" y="14" width="26" height="16" rx="1" fill="#7a4422"/>
+  <!-- Log texture (horizontal planks) -->
+  <line x1="3" y1="17" x2="29" y2="17" stroke="#5a2f11" stroke-width="1"/>
+  <line x1="3" y1="20" x2="29" y2="20" stroke="#5a2f11" stroke-width="1"/>
+  <line x1="3" y1="23" x2="29" y2="23" stroke="#5a2f11" stroke-width="1"/>
+  <line x1="3" y1="26" x2="29" y2="26" stroke="#5a2f11" stroke-width="1"/>
+  <!-- Rough thatched roof -->
+  <polygon points="1,14 16,4 31,14" fill="#8B6020"/>
+  <polygon points="3,14 16,6 29,14" fill="#aa7722"/>
+  <!-- Roof thatch texture -->
+  <line x1="8" y1="13" x2="14" y2="5" stroke="#7a5510" stroke-width="0.7" opacity="0.6"/>
+  <line x1="12" y1="14" x2="16" y2="6" stroke="#7a5510" stroke-width="0.7" opacity="0.6"/>
+  <line x1="16" y1="14" x2="20" y2="6" stroke="#7a5510" stroke-width="0.7" opacity="0.5"/>
+  <line x1="22" y1="13" x2="18" y2="5" stroke="#7a5510" stroke-width="0.7" opacity="0.6"/>
+  <!-- Skull decorations on corners -->
+  <circle cx="5" cy="13" r="2" fill="#ddd5bb"/>
+  <ellipse cx="4.5" cy="14" rx="1.2" ry="0.8" fill="#c8bfaa"/>
+  <circle cx="4.8" cy="12.5" r="0.5" fill="#444433"/>
+  <circle cx="5.8" cy="12.5" r="0.5" fill="#444433"/>
+  <circle cx="26" cy="13" r="2" fill="#ddd5bb"/>
+  <ellipse cx="26.5" cy="14" rx="1.2" ry="0.8" fill="#c8bfaa"/>
+  <circle cx="25.2" cy="12.5" r="0.5" fill="#444433"/>
+  <circle cx="26.2" cy="12.5" r="0.5" fill="#444433"/>
+  <!-- Animal horns on roof peak -->
+  <path d="M13,6 Q10,2 8,1" stroke="#ccaa77" stroke-width="1.5" fill="none"/>
+  <path d="M19,6 Q22,2 24,1" stroke="#ccaa77" stroke-width="1.5" fill="none"/>
+  <!-- Doorway (rough arch) -->
+  <path d="M13,30 L13,22 Q13,18 16,18 Q19,18 19,22 L19,30 Z" fill="#2a1208"/>
+  <!-- Fire/torch at door -->
+  <line x1="11" y1="22" x2="11" y2="28" stroke="#8B4513" stroke-width="1.2"/>
+  <ellipse cx="11" cy="21" rx="1.5" ry="2" fill="#ff6600" opacity="0.9"/>
+  <ellipse cx="11" cy="20.5" rx="0.8" ry="1.2" fill="#ffcc00"/>
+  <!-- Axe trophy on wall -->
+  <line x1="22" y1="14" x2="22" y2="20" stroke="#8B4513" stroke-width="1.2"/>
+  <path d="M20,13 Q22,13 22,15 Q22,17 20,17 Z" fill="#888"/>
+</svg>

--- a/web/public/sprites/knight-barracks.svg
+++ b/web/public/sprites/knight-barracks.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="14" ry="1.5" fill="#0a0a0a" opacity="0.5"/>
+  <!-- Main building (stone) -->
+  <rect x="2" y="13" width="28" height="17" rx="1" fill="#888899"/>
+  <!-- Stone texture -->
+  <line x1="2" y1="18" x2="30" y2="18" stroke="#6a6a7a" stroke-width="0.7"/>
+  <line x1="2" y1="23" x2="30" y2="23" stroke="#6a6a7a" stroke-width="0.7"/>
+  <line x1="2" y1="28" x2="30" y2="28" stroke="#6a6a7a" stroke-width="0.5"/>
+  <line x1="9" y1="13" x2="9" y2="30" stroke="#6a6a7a" stroke-width="0.5"/>
+  <line x1="23" y1="13" x2="23" y2="30" stroke="#6a6a7a" stroke-width="0.5"/>
+  <!-- Battlements along top -->
+  <rect x="2" y="8" width="5" height="6" rx="0.5" fill="#777788"/>
+  <rect x="9" y="8" width="5" height="6" rx="0.5" fill="#777788"/>
+  <rect x="18" y="8" width="5" height="6" rx="0.5" fill="#777788"/>
+  <rect x="25" y="8" width="5" height="6" rx="0.5" fill="#777788"/>
+  <!-- Wall connecting battlements -->
+  <rect x="2" y="11" width="28" height="3" fill="#888899"/>
+  <!-- Corner towers -->
+  <rect x="0" y="9" width="6" height="21" rx="0.5" fill="#999aaa"/>
+  <rect x="26" y="9" width="6" height="21" rx="0.5" fill="#999aaa"/>
+  <!-- Tower windows -->
+  <rect x="1" y="14" width="3" height="4" rx="1" fill="#2a2a44"/>
+  <rect x="28" y="14" width="3" height="4" rx="1" fill="#2a2a44"/>
+  <!-- Gate arch -->
+  <path d="M12,30 L12,21 Q12,16 16,16 Q20,16 20,21 L20,30 Z" fill="#1a1a2a"/>
+  <!-- Shield emblem above gate -->
+  <path d="M14,12 L14,8 L18,8 L18,12 L16,14 Z" fill="#ccccdd"/>
+  <path d="M14.5,12 L14.5,8.5 L17.5,8.5 L17.5,12 L16,13.5 Z" fill="#aaaacc"/>
+  <!-- Cross on shield -->
+  <line x1="16" y1="8.5" x2="16" y2="13" stroke="#cc2222" stroke-width="0.9"/>
+  <line x1="14.5" y1="10.5" x2="17.5" y2="10.5" stroke="#cc2222" stroke-width="0.9"/>
+  <!-- Flagpole -->
+  <line x1="16" y1="3" x2="16" y2="8" stroke="#555566" stroke-width="1.2"/>
+  <!-- Flag (silver/blue) -->
+  <polygon points="16,3 24,5 16,7" fill="#4444cc"/>
+  <!-- Sword on flag -->
+  <line x1="18" y1="4" x2="22" y2="6" stroke="#ffcc00" stroke-width="0.8"/>
+  <line x1="20" y1="3.5" x2="20" y2="6.5" stroke="#ffcc00" stroke-width="0.6"/>
+</svg>

--- a/web/public/sprites/wizard-academy.svg
+++ b/web/public/sprites/wizard-academy.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground shadow -->
+  <ellipse cx="16" cy="31" rx="12" ry="1.5" fill="#0a0a1a" opacity="0.5"/>
+  <!-- Tower base -->
+  <rect x="8" y="14" width="16" height="16" rx="1" fill="#5533aa"/>
+  <!-- Stone texture bands -->
+  <line x1="8" y1="19" x2="24" y2="19" stroke="#3a1f88" stroke-width="0.7"/>
+  <line x1="8" y1="24" x2="24" y2="24" stroke="#3a1f88" stroke-width="0.7"/>
+  <!-- Conical roof (wizard hat style) -->
+  <polygon points="16,1 7,14 25,14" fill="#3311aa"/>
+  <polygon points="16,3 9,14 23,14" fill="#4422bb"/>
+  <!-- Star on roof -->
+  <circle cx="16" cy="7" r="1.5" fill="#ffdd00" opacity="0.9"/>
+  <circle cx="13" cy="10" r="0.8" fill="#ffdd00" opacity="0.7"/>
+  <circle cx="19" cy="9" r="0.8" fill="#ffdd00" opacity="0.7"/>
+  <!-- Glowing orb at spire tip -->
+  <circle cx="16" cy="1" r="2" fill="#44ffaa" opacity="0.9"/>
+  <circle cx="16" cy="1" r="1" fill="#aaffdd"/>
+  <!-- Arched windows with magic glow -->
+  <rect x="12" y="16" width="8" height="7" rx="4" fill="#110033"/>
+  <rect x="12.5" y="16" width="7" height="6" rx="3.5" fill="#7733ff" opacity="0.5"/>
+  <!-- Side windows -->
+  <rect x="9" y="20" width="3" height="3" rx="1" fill="#110033"/>
+  <rect x="9.3" y="20" width="2.4" height="2.4" rx="0.8" fill="#5522cc" opacity="0.5"/>
+  <rect x="20" y="20" width="3" height="3" rx="1" fill="#110033"/>
+  <rect x="20.3" y="20" width="2.4" height="2.4" rx="0.8" fill="#5522cc" opacity="0.5"/>
+  <!-- Doorway -->
+  <rect x="13" y="26" width="6" height="4" rx="3" fill="#110033"/>
+  <!-- Rune markings -->
+  <line x1="10" y1="16" x2="10" y2="13" stroke="#8844ff" stroke-width="0.8" opacity="0.8"/>
+  <line x1="22" y1="16" x2="22" y2="13" stroke="#8844ff" stroke-width="0.8" opacity="0.8"/>
+  <!-- Magical sparks -->
+  <circle cx="6" cy="18" r="0.8" fill="#aa44ff" opacity="0.7"/>
+  <circle cx="26" cy="20" r="0.8" fill="#44ffaa" opacity="0.7"/>
+  <circle cx="5" cy="24" r="0.6" fill="#ffdd00" opacity="0.5"/>
+  <circle cx="27" cy="15" r="0.6" fill="#aa44ff" opacity="0.5"/>
+  <!-- Banner -->
+  <line x1="16" y1="1" x2="16" y2="-1" stroke="#3311aa" stroke-width="0.8"/>
+</svg>

--- a/web/src/data/cards.json
+++ b/web/src/data/cards.json
@@ -11213,6 +11213,102 @@
         "melee",
         "armored"
       ]
+    },
+    "wizard": {
+      "name": "Wizard",
+      "attack": 6,
+      "maxHp": 12,
+      "isWall": false,
+      "bypassWall": true,
+      "moveSpeed": 22,
+      "attackRange": 70,
+      "attackCooldownMs": 2000,
+      "flying": false
+    },
+    "barbarian": {
+      "name": "Barbarian",
+      "attack": 7,
+      "maxHp": 15,
+      "isWall": false,
+      "bypassWall": false,
+      "moveSpeed": 35,
+      "attackRange": 5,
+      "attackCooldownMs": 1800,
+      "flying": false,
+      "tags": [
+        "forest"
+      ]
+    },
+    "knight": {
+      "name": "Knight",
+      "attack": 4,
+      "maxHp": 25,
+      "isWall": false,
+      "bypassWall": false,
+      "moveSpeed": 22,
+      "attackRange": 5,
+      "attackCooldownMs": 1500,
+      "flying": false,
+      "tags": [
+        "citadel"
+      ]
+    },
+    "wizard-academy": {
+      "name": "Wizard Academy",
+      "attack": 0,
+      "maxHp": 30,
+      "isWall": false,
+      "bypassWall": false,
+      "moveSpeed": 0,
+      "attackRange": 0,
+      "attackCooldownMs": 99999,
+      "flying": false,
+      "structureEffect": {
+        "type": "spawn",
+        "unitTemplateRef": "wizard",
+        "intervalMs": 14000
+      },
+      "tags": [
+        "magic"
+      ]
+    },
+    "barbarian-den": {
+      "name": "Barbarian Den",
+      "attack": 0,
+      "maxHp": 30,
+      "isWall": false,
+      "bypassWall": false,
+      "moveSpeed": 0,
+      "attackRange": 0,
+      "attackCooldownMs": 99999,
+      "flying": false,
+      "structureEffect": {
+        "type": "spawn",
+        "unitTemplateRef": "barbarian",
+        "intervalMs": 12500
+      },
+      "tags": [
+        "forest"
+      ]
+    },
+    "knight-barracks": {
+      "name": "Knight Barracks",
+      "attack": 0,
+      "maxHp": 35,
+      "isWall": false,
+      "bypassWall": false,
+      "moveSpeed": 0,
+      "attackRange": 0,
+      "attackCooldownMs": 99999,
+      "flying": false,
+      "structureEffect": {
+        "type": "spawn",
+        "unitTemplateRef": "knight",
+        "intervalMs": 12000
+      },
+      "tags": [
+        "citadel"
+      ]
     }
   },
   "cards": [
@@ -15157,7 +15253,7 @@
       "cost": 3,
       "cardType": "structure",
       "unitRef": "sniper-post",
-      "description": "Spawner. Deploys a Marksman — extreme range, slow reload.",
+      "description": "Spawner. Deploys a Marksman \u2014 extreme range, slow reload.",
       "deckCount": 1,
       "tags": [
         "forest"
@@ -20856,6 +20952,45 @@
       "description": "Mythic siege engine \u2014 absurd HP, unstoppable advance. At 50% HP detonates for 60 AoE.",
       "lore": "There is no wall it cannot break. There is no army it cannot outlast.",
       "deckCount": 0
+    },
+    {
+      "name": "Wizard Academy",
+      "rarity": "rare",
+      "cost": 4,
+      "cardType": "structure",
+      "unitRef": "wizard-academy",
+      "description": "Spawner. Periodically releases Wizards whose magic bypasses walls.",
+      "deckCount": 1,
+      "tags": [
+        "magic"
+      ],
+      "lore": "Knowledge is power. Power is deployable."
+    },
+    {
+      "name": "Barbarian Den",
+      "rarity": "uncommon",
+      "cost": 3,
+      "cardType": "structure",
+      "unitRef": "barbarian-den",
+      "description": "Spawner. Periodically releases rampaging Barbarians.",
+      "deckCount": 2,
+      "tags": [
+        "forest"
+      ],
+      "lore": "The screaming is intentional. Mostly."
+    },
+    {
+      "name": "Knight Barracks",
+      "rarity": "uncommon",
+      "cost": 3,
+      "cardType": "structure",
+      "unitRef": "knight-barracks",
+      "description": "Spawner. Periodically releases armoured Knights.",
+      "deckCount": 2,
+      "tags": [
+        "citadel"
+      ],
+      "lore": "Honor is a shield. The actual shields help too."
     }
   ],
   "heroCards": [

--- a/web/src/data/cards.json
+++ b/web/src/data/cards.json
@@ -11346,19 +11346,10 @@
       "tags": [
         "forest"
       ],
-      "unit": {
-        "name": "Barbarian",
-        "attack": 7,
-        "maxHp": 15,
-        "isWall": false,
-        "bypassWall": false,
-        "moveSpeed": 35,
-        "attackRange": 5,
-        "attackCooldownMs": 1800
-      },
       "description": "Hard-hitting melee fighter.",
       "deckCount": 3,
-      "lore": "Trained by no one, feared by everyone. Mostly feared because of the screaming."
+      "lore": "Trained by no one, feared by everyone. Mostly feared because of the screaming.",
+      "unitRef": "barbarian"
     },
     {
       "name": "Knight",
@@ -11368,38 +11359,20 @@
       "tags": [
         "citadel"
       ],
-      "unit": {
-        "name": "Knight",
-        "attack": 4,
-        "maxHp": 25,
-        "isWall": false,
-        "bypassWall": false,
-        "moveSpeed": 22,
-        "attackRange": 5,
-        "attackCooldownMs": 1500
-      },
       "description": "Armored frontline tank.",
       "deckCount": 3,
-      "lore": "The kingdom's finest. Polished armour hides a spectacular collection of bruises."
+      "lore": "The kingdom's finest. Polished armour hides a spectacular collection of bruises.",
+      "unitRef": "knight"
     },
     {
       "name": "Wizard",
       "rarity": "rare",
       "cost": 3,
       "cardType": "unit",
-      "unit": {
-        "name": "Wizard",
-        "attack": 6,
-        "maxHp": 12,
-        "isWall": false,
-        "bypassWall": true,
-        "moveSpeed": 22,
-        "attackRange": 70,
-        "attackCooldownMs": 2000
-      },
       "description": "Magic bypasses walls.",
       "deckCount": 2,
-      "lore": "Years of magical study. Thousands of gold in reagents. Wages still less than a goblin."
+      "lore": "Years of magical study. Thousands of gold in reagents. Wages still less than a goblin.",
+      "unitRef": "wizard"
     },
     {
       "name": "Dragon",


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Wizard Academy** (rare, cost 4): spawner building that releases a Wizard every 14s. Purple tower with glowing orb spire, star decorations, and magic-glow windows.
- **Barbarian Den** (uncommon, cost 3): spawner building that releases a Barbarian every 12.5s. Rough log-and-thatch lodge with skull trophies, horns, and an axe on the wall.
- **Knight Barracks** (uncommon, cost 3): spawner building that releases a Knight every 12s. Stone castle barracks with battlements, corner towers, a heraldic shield above the gate, and a blue flag.

Also adds `wizard`, `barbarian`, and `knight` unit templates to `cards.json` so the spawners' `unitTemplateRef` resolution works correctly (previously those units only existed as inline definitions embedded in their unit cards).

## Test plan

- [ ] All three new cards appear in the card browser / deck builder
- [ ] Each card shows the "spawner" category icon
- [ ] Deploying each building spawns the correct unit type after its interval
- [ ] Sprites render correctly in-game and on card tiles
- [ ] Existing wizard, barbarian, and knight unit cards are unaffected

https://claude.ai/code/session_01DNAajZHa3FQC44L3kA74Kt
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DNAajZHa3FQC44L3kA74Kt)_