### PR TITLE
TD: XP system gates spawner upgrades

### DIFF
--- a/web/src/components/minigames/TowerDefence.tsx
+++ b/web/src/components/minigames/TowerDefence.tsx
@@ -12,7 +12,7 @@ import {
   TDGameState, TDTower, TDUnit, TDEnemy, TDAttackEvent, TDHazard, MilestoneUpgrade,
   isPathCell,
   createTDGame, placeTower, removeTower, moveTower, upgradeTower, startWave, tickTD,
-  calcTicketReward, calcGoldReward, towerCost, upgradeCost, buildingUnitCount, chooseMilestoneUpgrade,
+  calcTicketReward, calcGoldReward, towerCost, upgradeCost, xpToUpgrade, buildingUnitCount, chooseMilestoneUpgrade,
 } from '../../game/towerDefence'
 import { Lives } from '../BuildingBlocks/Lives/Lives'
 
@@ -366,6 +366,9 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
                       {tower.respawnTimers.length > 0 && (
                         <div className="td-tower-respawn">⏳</div>
                       )}
+                      {tower.upgrades < TD_MAX_UPGRADES && tower.xp >= xpToUpgrade(tower) && (
+                        <div className="td-tower-upgrade-ready">⬆</div>
+                      )}
                     </div>
                   )}
                 </div>
@@ -405,6 +408,8 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
             const t = selectedTower ?? hoveredTower!
             const unitCount = buildingUnitCount(t)
             const activeUnits = game.units.filter(u => u.towerId === t.id)
+            const xpNeeded = xpToUpgrade(t)
+            const xpReady = t.upgrades < TD_MAX_UPGRADES && t.xp >= xpNeeded
             return (
               <div
                 className="td-tower-tooltip"
@@ -413,6 +418,11 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
                 <strong>{t.buildingName}</strong>
                 {t.upgrades > 0 && <span className="td-tower-tier-label"> {'★'.repeat(t.upgrades)}</span>}
                 <div>{t.template.name} · {activeUnits.length}/{unitCount} active</div>
+                {t.upgrades < TD_MAX_UPGRADES && (
+                  <div className={xpReady ? 'td-tooltip-xp-ready' : 'td-tooltip-xp'}>
+                    {xpReady ? '⬆ Upgrade ready!' : `XP ${t.xp}/${xpNeeded} kills`}
+                  </div>
+                )}
                 {t.id !== selectedTowerId && <div className="td-tooltip-hint">Tap to select</div>}
               </div>
             )
@@ -426,7 +436,10 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
         const t = selectedTower
         const sellRefund = Math.floor(towerCost(t.template) * 0.5)
         const upCost = upgradeCost(t)
+        const xpNeeded = xpToUpgrade(t)
+        const hasXp = t.xp >= xpNeeded
         const canAffordUp = game.mana >= upCost
+        const canUpgrade = hasXp && canAffordUp
         const unitCount = buildingUnitCount(t)
         const activeUnits = game.units.filter(u => u.towerId === t.id)
         return (
@@ -436,6 +449,19 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
               {t.upgrades > 0 && <span className="td-tower-tier-label"> {'★'.repeat(t.upgrades)}</span>}
               <span className="td-selected-panel-stats"> · {t.template.name} · {activeUnits.length}/{unitCount} units</span>
             </div>
+            {t.upgrades < TD_MAX_UPGRADES && (
+              <div className="td-selected-panel-xp">
+                <div className="td-selected-panel-xp-bar">
+                  <div
+                    className="td-selected-panel-xp-fill"
+                    style={{ width: `${Math.min(100, (t.xp / xpNeeded) * 100)}%` }}
+                  />
+                </div>
+                <span className={hasXp ? 'td-selected-panel-xp-label--ready' : 'td-selected-panel-xp-label'}>
+                  {hasXp ? '⬆ Ready to upgrade!' : `${t.xp}/${xpNeeded} kills to unlock`}
+                </span>
+              </div>
+            )}
             <div className="td-selected-panel-actions">
               <button className="td-selected-action-btn td-selected-action-btn--sell"
                 onClick={() => handleSellTower(t)}>
@@ -443,8 +469,8 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
               </button>
               {t.upgrades < TD_MAX_UPGRADES ? (
                 <button
-                  className={`td-selected-action-btn td-selected-action-btn--upgrade${canAffordUp ? '' : ' td-selected-action-btn--disabled'}`}
-                  onClick={() => canAffordUp && handleUpgradeTower(t)}>
+                  className={`td-selected-action-btn td-selected-action-btn--upgrade${canUpgrade ? '' : ' td-selected-action-btn--disabled'}`}
+                  onClick={() => canUpgrade && handleUpgradeTower(t)}>
                   ★ UPGRADE (+1 unit) 💧{upCost}
                 </button>
               ) : (

--- a/web/src/game/towerDefence.ts
+++ b/web/src/game/towerDefence.ts
@@ -199,6 +199,7 @@ export interface TDTower {
   buildingName: string        // card name for building sprite
   upgrades: number            // 0–TD_MAX_UPGRADES; determines how many units it spawns
   respawnTimers: number[]     // countdown (ms) for each dead unit awaiting respawn
+  xp: number                  // kills earned by this tower's units; upgrade unlocks at threshold
 }
 
 // A unit spawned by a building — roams within 1 cell of the building, chases nearby enemies.
@@ -342,6 +343,11 @@ export function towerCost(template: UnitTemplate): number {
 /** Mana cost to upgrade a building (spawns one more unit). */
 export function upgradeCost(tower: TDTower): number {
   return Math.round(towerCost(tower.template) * Math.pow(2, tower.upgrades + 1))
+}
+
+/** Kills required to unlock the next upgrade tier. */
+export function xpToUpgrade(tower: TDTower): number {
+  return (tower.upgrades + 1) * 5
 }
 
 /** Number of units a building spawns at its current upgrade level. */
@@ -537,6 +543,7 @@ export function placeTower(
     buildingName,
     upgrades: 0,
     respawnTimers: [],
+    xp: 0,
   }
   const unit = spawnUnitFromBuilding(tower)
   return {
@@ -575,9 +582,10 @@ export function upgradeTower(state: TDGameState, towerId: number): TDGameState |
   const tower = state.towers.find(t => t.id === towerId)
   if (!tower) return null
   if (tower.upgrades >= TD_MAX_UPGRADES) return null
+  if (tower.xp < xpToUpgrade(tower)) return null
   const cost = upgradeCost(tower)
   if (state.mana < cost) return null
-  const upgradedTower = { ...tower, upgrades: tower.upgrades + 1 }
+  const upgradedTower = { ...tower, upgrades: tower.upgrades + 1, xp: 0 }
   const newUnit = spawnUnitFromBuilding(upgradedTower)
   return {
     ...state,
@@ -813,6 +821,7 @@ export function tickTD(state: TDGameState, dtMs: number): TDGameState {
   const deadEnemyIds = new Set<number>()
   const shieldedEnemyIds = new Set<number>()  // shield absorbed a hit this tick
   const newAttackEvents: TDAttackEvent[] = s.attackEvents.filter(e => e.expiresAt > s.gameTimeMs)
+  const towerXpGains: Record<number, number> = {}
 
   s.units = s.units.map(unit => {
     let cd = Math.max(0, unit.attackCooldownRemaining - dtMs)
@@ -849,7 +858,7 @@ export function tickTD(state: TDGameState, dtMs: number): TDGameState {
                 if (e.id === target.id || deadEnemyIds.has(e.id) || e.hp <= 0) return e
                 if (dist(e.x, e.y, target.x, target.y) > eff.aoeRadius!) return e
                 const splashHp = e.hp - dmg
-                if (splashHp <= 0) { deadEnemyIds.add(e.id); s.score += e.template.reward; s.mana += e.template.reward }
+                if (splashHp <= 0) { deadEnemyIds.add(e.id); s.score += e.template.reward; s.mana += e.template.reward; towerXpGains[unit.towerId] = (towerXpGains[unit.towerId] ?? 0) + 1 }
                 return { ...e, hp: Math.max(0, splashHp) }
               })
               // AOE ring visual
@@ -863,6 +872,7 @@ export function tickTD(state: TDGameState, dtMs: number): TDGameState {
             deadEnemyIds.add(target.id)
             s.score += target.template.reward
             s.mana += target.template.reward
+            towerXpGains[unit.towerId] = (towerXpGains[unit.towerId] ?? 0) + 1
           } else {
             s.enemies = s.enemies.map(e => e.id === target.id ? { ...e, hp: newHp } : e)
           }
@@ -882,6 +892,13 @@ export function tickTD(state: TDGameState, dtMs: number): TDGameState {
     return { ...unit, attackCooldownRemaining: cd }
   })
   s.attackEvents = newAttackEvents
+
+  // Award kill XP to the towers whose units made the kills
+  if (Object.keys(towerXpGains).length > 0) {
+    s.towers = s.towers.map(t =>
+      towerXpGains[t.id] ? { ...t, xp: t.xp + towerXpGains[t.id] } : t
+    )
+  }
 
   // Split-on-death: collect offspring before removing dead enemies
   const splitOffspring: TDEnemy[] = []

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -12739,6 +12739,22 @@ html.light-mode .action-btn {
 .td-tower-hp-fill { height: 100%; border-radius: 2px; transition: width 0.2s; }
 .td-tower-tier { font-size: 8px; color: #ffd700; line-height: 1; text-align: center; pointer-events: none; }
 .td-tower-respawn { font-size: 10px; line-height: 1; text-align: center; pointer-events: none; }
+.td-tower-upgrade-ready {
+  position: absolute;
+  top: -10px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 13px;
+  color: #4caf50;
+  pointer-events: none;
+  animation: td-upgrade-pulse 0.8s ease-in-out infinite alternate;
+  text-shadow: 0 0 6px #4caf50;
+  z-index: 10;
+}
+@keyframes td-upgrade-pulse {
+  from { transform: translateX(-50%) translateY(0px); opacity: 0.8; }
+  to   { transform: translateX(-50%) translateY(-3px); opacity: 1; }
+}
 
 /* Player units — walk from building to path cell, then fight */
 .td-unit {
@@ -12770,6 +12786,8 @@ html.light-mode .action-btn {
   white-space: nowrap;
 }
 .td-tooltip-hint { color: #f44; font-size: 9px; margin-top: 2px; }
+.td-tooltip-xp       { font-size: 9px; color: #888; margin-top: 1px; }
+.td-tooltip-xp-ready { font-size: 9px; color: #4caf50; font-weight: bold; margin-top: 1px; }
 .td-tower-tier-label { color: #ffd700; }
 
 /* Tower action buttons (inside tooltip) */
@@ -12900,6 +12918,23 @@ html.light-mode .action-btn {
 .td-selected-panel-stats { color: #aaa; font-size: 11px; }
 .td-selected-panel-hint { font-size: 10px; color: #666; }
 .td-selected-panel-maxed { font-size: 12px; color: #ffd700; align-self: center; }
+.td-selected-panel-xp { display: flex; align-items: center; gap: 6px; }
+.td-selected-panel-xp-bar {
+  flex: 1;
+  height: 5px;
+  background: #222;
+  border-radius: 3px;
+  overflow: hidden;
+  border: 1px solid #333;
+}
+.td-selected-panel-xp-fill {
+  height: 100%;
+  background: linear-gradient(90deg, #2e7d32, #4caf50);
+  border-radius: 3px;
+  transition: width 0.3s;
+}
+.td-selected-panel-xp-label       { font-size: 10px; color: #888; white-space: nowrap; }
+.td-selected-panel-xp-label--ready { font-size: 10px; color: #4caf50; font-weight: bold; white-space: nowrap; animation: td-upgrade-pulse 0.8s ease-in-out infinite alternate; }
 .td-selected-panel-actions {
   display: flex;
   gap: 8px;


### PR DESCRIPTION
## Summary

- Each tower earns **1 XP per kill** made by the units it spawns (direct hits and AOE splash)
- Upgrades are **locked** until the XP threshold is met: **5 kills** to unlock ★1, **10 kills** to unlock ★2
- On upgrade the XP resets to 0 so each tier must be earned independently
- A pulsing **⬆ badge** appears above the building sprite when an upgrade is ready
- The selected-tower panel shows an **XP progress bar** and a `X/Y kills to unlock` label — turns green and animated when ready
- The hover tooltip also shows XP progress or "Upgrade ready!"
- The upgrade button stays visually disabled until both XP and mana conditions are met

## Test plan

- [ ] Place a building and play a wave — confirm the ⬆ badge appears after 5 kills
- [ ] Tap the building before 5 kills — confirm the upgrade button is greyed out and the bar is partially filled
- [ ] After the badge appears, upgrade and confirm XP resets and the badge disappears
- [ ] Earn 10 more kills on the ★1 building — confirm the ★2 upgrade unlocks correctly

https://claude.ai/code/session_01FFXw8rUxBVQRtJK8x762WJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01FFXw8rUxBVQRtJK8x762WJ)_