### PR TITLE
TD: multi-option upgrades, 10-unit buildings, sell refund fix

### DIFF
--- a/web/src/components/minigames/TowerDefence.tsx
+++ b/web/src/components/minigames/TowerDefence.tsx
@@ -8,11 +8,11 @@ import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react'
 import { UnitTemplate } from '../../game/types'
 import { SpriteImg, AnimatedSpriteImg } from '../BuildingBlocks/SpriteImg'
 import {
-  TD_COLS, TD_ROWS, TD_PATH, TD_TOTAL_WAVES, TD_MAX_LIVES, TD_CELL_PX, TD_MAX_UPGRADES, TD_MILESTONE_EVERY,
-  TDGameState, TDTower, TDUnit, TDEnemy, TDAttackEvent, TDHazard, MilestoneUpgrade,
+  TD_COLS, TD_ROWS, TD_PATH, TD_TOTAL_WAVES, TD_MAX_LIVES, TD_CELL_PX, TD_MAX_UPGRADES, TD_MAX_UPGRADE_PER_TYPE, TD_MAX_UNIT_UPGRADES, TD_MILESTONE_EVERY,
+  TDGameState, TDTower, TDUnit, TDEnemy, TDAttackEvent, TDHazard, MilestoneUpgrade, TDUpgradeType,
   isPathCell,
-  createTDGame, placeTower, removeTower, moveTower, upgradeTower, startWave, tickTD,
-  calcTicketReward, calcGoldReward, towerCost, upgradeCost, xpToUpgrade, buildingUnitCount, chooseMilestoneUpgrade,
+  createTDGame, placeTower, removeTower, moveTower, upgradeTowerWith, startWave, tickTD,
+  calcTicketReward, calcGoldReward, towerCost, upgradeCost, xpToUpgrade, sellRefund, buildingUnitCount, chooseMilestoneUpgrade,
 } from '../../game/towerDefence'
 import { Lives } from '../BuildingBlocks/Lives/Lives'
 
@@ -162,8 +162,8 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
     setHoveredTower(null)
   }
 
-  function handleUpgradeTower(tower: TDTower) {
-    setGame(prev => upgradeTower(prev, tower.id) ?? prev)
+  function handleUpgradeTower(tower: TDTower, type: TDUpgradeType) {
+    setGame(prev => upgradeTowerWith(prev, tower.id, type) ?? prev)
   }
 
   function handleStartWave() { setGame(prev => startWave(prev)) }
@@ -361,7 +361,7 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
                     <div className="td-tower-inner">
                       <SpriteImg name={tower.buildingName} />
                       {tower.upgrades > 0 && (
-                        <div className="td-tower-tier">{'★'.repeat(tower.upgrades)}</div>
+                        <div className="td-tower-tier">★{tower.upgrades}</div>
                       )}
                       {tower.respawnTimers.length > 0 && (
                         <div className="td-tower-respawn">⏳</div>
@@ -434,22 +434,45 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
       {/* ── Selected tower action panel ── */}
       {selectedTower && (() => {
         const t = selectedTower
-        const sellRefund = Math.floor(towerCost(t.template) * 0.5)
-        const upCost = upgradeCost(t)
+        const refund   = sellRefund(t)
+        const upCost   = upgradeCost(t)
         const xpNeeded = xpToUpgrade(t)
-        const hasXp = t.xp >= xpNeeded
-        const canAffordUp = game.mana >= upCost
-        const canUpgrade = hasXp && canAffordUp
+        const hasXp    = t.xp >= xpNeeded
+        const canAfford = game.mana >= upCost
         const unitCount = buildingUnitCount(t)
         const activeUnits = game.units.filter(u => u.towerId === t.id)
+        const totalMaxed = t.upgrades >= TD_MAX_UPGRADES
+
+        const upgradeOptions: Array<{
+          type: TDUpgradeType; icon: string; label: string; current: number; max: number
+        }> = [
+          { type: 'units',  icon: '👤', label: '+Unit',  current: t.upgradeUnits,  max: TD_MAX_UNIT_UPGRADES  },
+          { type: 'speed',  icon: '⚡', label: 'Speed',  current: t.upgradeSpeed,  max: TD_MAX_UPGRADE_PER_TYPE },
+          { type: 'range',  icon: '🎯', label: 'Range',  current: t.upgradeRange,  max: TD_MAX_UPGRADE_PER_TYPE },
+          { type: 'damage', icon: '⚔',  label: 'Damage', current: t.upgradeDamage, max: TD_MAX_UPGRADE_PER_TYPE },
+        ]
+
         return (
           <div className="td-selected-panel">
-            <div className="td-selected-panel-info">
-              <strong>{t.buildingName}</strong>
-              {t.upgrades > 0 && <span className="td-tower-tier-label"> {'★'.repeat(t.upgrades)}</span>}
-              <span className="td-selected-panel-stats"> · {t.template.name} · {activeUnits.length}/{unitCount} units</span>
+            <div className="td-selected-panel-row">
+              <div className="td-selected-panel-info">
+                <strong>{t.buildingName}</strong>
+                {t.upgrades > 0 && <span className="td-tower-tier-label"> ★{t.upgrades}</span>}
+                <span className="td-selected-panel-stats"> · {activeUnits.length}/{unitCount} units</span>
+              </div>
+              <div className="td-selected-panel-row-actions">
+                <button className="td-selected-action-btn td-selected-action-btn--sell"
+                  onClick={() => handleSellTower(t)}>
+                  SELL +💧{refund}
+                </button>
+                <button className="td-selected-action-btn td-selected-action-btn--cancel"
+                  onClick={() => setSelectedTowerId(null)}>
+                  ✕
+                </button>
+              </div>
             </div>
-            {t.upgrades < TD_MAX_UPGRADES && (
+
+            {!totalMaxed && (
               <div className="td-selected-panel-xp">
                 <div className="td-selected-panel-xp-bar">
                   <div
@@ -458,29 +481,37 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
                   />
                 </div>
                 <span className={hasXp ? 'td-selected-panel-xp-label--ready' : 'td-selected-panel-xp-label'}>
-                  {hasXp ? '⬆ Ready to upgrade!' : `${t.xp}/${xpNeeded} kills to unlock`}
+                  {hasXp ? `⬆ Upgrade ready! 💧${upCost}` : `${t.xp}/${xpNeeded} kills to unlock`}
                 </span>
               </div>
             )}
-            <div className="td-selected-panel-actions">
-              <button className="td-selected-action-btn td-selected-action-btn--sell"
-                onClick={() => handleSellTower(t)}>
-                SELL +💧{sellRefund}
-              </button>
-              {t.upgrades < TD_MAX_UPGRADES ? (
-                <button
-                  className={`td-selected-action-btn td-selected-action-btn--upgrade${canUpgrade ? '' : ' td-selected-action-btn--disabled'}`}
-                  onClick={() => canUpgrade && handleUpgradeTower(t)}>
-                  ★ UPGRADE (+1 unit) 💧{upCost}
-                </button>
-              ) : (
-                <span className="td-selected-panel-maxed">★★ MAX ({unitCount} units)</span>
-              )}
-              <button className="td-selected-action-btn td-selected-action-btn--cancel"
-                onClick={() => setSelectedTowerId(null)}>
-                ✕
-              </button>
-            </div>
+
+            {totalMaxed ? (
+              <div className="td-selected-panel-maxed">★ FULLY UPGRADED ({unitCount} units)</div>
+            ) : (
+              <div className="td-upgrade-options">
+                {upgradeOptions.map(({ type, icon, label, current, max }) => {
+                  const maxed   = current >= max
+                  const enabled = hasXp && canAfford && !maxed
+                  const dotsMax = Math.min(max, 10)
+                  return (
+                    <button
+                      key={type}
+                      className={`td-upgrade-option${enabled ? '' : ' td-upgrade-option--disabled'}${maxed ? ' td-upgrade-option--maxed' : ''}`}
+                      onClick={() => enabled && handleUpgradeTower(t, type)}
+                    >
+                      <span className="td-upgrade-option-icon">{icon}</span>
+                      <span className="td-upgrade-option-label">{label}</span>
+                      <span className="td-upgrade-option-dots">
+                        {current}/{max}
+                        {max <= 5 ? ' ' + '●'.repeat(current) + '○'.repeat(dotsMax - current) : ''}
+                      </span>
+                    </button>
+                  )
+                })}
+              </div>
+            )}
+
             <div className="td-selected-panel-hint">Tap an empty cell on the grid to move this building</div>
           </div>
         )
@@ -544,25 +575,20 @@ function UnitGroupToken({ units }: { units: TDUnit[] }) {
   const lead = units[0]
   const stationed = units.some(u => u.stationed)
   const minHpFrac = Math.min(...units.map(u => u.hp / u.maxHp))
-  const n = units.length
-  const sz = 15, gap = 3
+  const n = Math.min(units.length, 10)
+  const sz = 11, gap = 2
+  const COLS = 5
 
-  let slots: Array<{ dx: number; dy: number }>
-  let containerW: number, containerH: number
+  const rows = Math.ceil(n / COLS)
+  const cols = Math.min(n, COLS)
+  const containerW = cols * sz + (cols - 1) * gap
+  const containerH = rows * sz + (rows - 1) * gap
 
-  if (n >= 3) {
-    containerW = sz * 2 + gap; containerH = sz * 2 + gap
-    slots = [
-      { dx: (containerW - sz) / 2, dy: 0 },
-      { dx: 0, dy: sz + gap },
-      { dx: sz + gap, dy: sz + gap },
-    ]
-  } else if (n === 2) {
-    containerW = sz * 2 + gap; containerH = sz
-    slots = [{ dx: 0, dy: 0 }, { dx: sz + gap, dy: 0 }]
-  } else {
-    containerW = sz; containerH = sz
-    slots = [{ dx: 0, dy: 0 }]
+  const slots: Array<{ dx: number; dy: number }> = []
+  for (let i = 0; i < n; i++) {
+    const row = Math.floor(i / COLS)
+    const col = i % COLS
+    slots.push({ dx: col * (sz + gap), dy: row * (sz + gap) })
   }
 
   return (

--- a/web/src/game/towerDefence.ts
+++ b/web/src/game/towerDefence.ts
@@ -196,8 +196,12 @@ export interface TDTower {
   col: number
   row: number
   template: UnitTemplate
-  buildingName: string        // card name for building sprite
-  upgrades: number            // 0–TD_MAX_UPGRADES; determines how many units it spawns
+  buildingName: string
+  upgrades: number            // total upgrades purchased (XP/cost gate)
+  upgradeUnits: number        // 0–TD_MAX_UPGRADE_PER_TYPE: extra units spawned
+  upgradeSpeed: number        // 0–TD_MAX_UPGRADE_PER_TYPE: attack speed bonus
+  upgradeRange: number        // 0–TD_MAX_UPGRADE_PER_TYPE: range bonus (cells)
+  upgradeDamage: number       // 0–TD_MAX_UPGRADE_PER_TYPE: damage bonus
   respawnTimers: number[]     // countdown (ms) for each dead unit awaiting respawn
   xp: number                  // kills earned by this tower's units; upgrade unlocks at threshold
 }
@@ -216,6 +220,9 @@ export interface TDUnit {
   stationed: boolean      // true = engaged chasing an enemy, false = idle at home
   attackCooldownRemaining: number
   rangeInCells: number
+  speedMult: number       // reduces attack cooldown (1 = base, 1.25 = 25% faster, etc.)
+  rangeBonus: number      // extra cells of range from tower upgrades
+  damageMult: number      // damage multiplier from tower upgrades
 }
 
 export interface TDEnemy {
@@ -328,7 +335,10 @@ export const TD_TOTAL_WAVES = 100
 export const TD_MILESTONE_EVERY = 10
 export const TD_CELL_PX = 48
 export const TD_STARTING_MANA = 120
-export const TD_MAX_UPGRADES = 2
+export const TD_MAX_UNIT_UPGRADES = 9        // units type: allows up to 10 spawned units total
+export const TD_MAX_UPGRADE_PER_TYPE = 2     // max levels for speed / range / damage
+export const TD_MAX_UPGRADES = TD_MAX_UNIT_UPGRADES + TD_MAX_UPGRADE_PER_TYPE * 3  // = 15
+export type TDUpgradeType = 'units' | 'speed' | 'range' | 'damage'
 const BETWEEN_WAVE_MS = 5000
 const STRENGTH_MULT = 1.5
 const RESPAWN_DELAY_MS = 5000
@@ -340,9 +350,24 @@ export function towerCost(template: UnitTemplate): number {
   return Math.max(5, Math.round(template.attack * 2 + template.maxHp / 20))
 }
 
-/** Mana cost to upgrade a building (spawns one more unit). */
+/** Mana cost for the next upgrade purchase (scales linearly with total upgrades purchased). */
 export function upgradeCost(tower: TDTower): number {
-  return Math.round(towerCost(tower.template) * Math.pow(2, tower.upgrades + 1))
+  return Math.round(towerCost(tower.template) * (tower.upgrades + 1) * 2)
+}
+
+/** Total mana spent on a tower (placement + all upgrades). */
+export function totalManaSpent(tower: TDTower): number {
+  const base = towerCost(tower.template)
+  let total = base
+  for (let i = 0; i < tower.upgrades; i++) {
+    total += Math.round(base * (i + 1) * 2)
+  }
+  return total
+}
+
+/** Sell refund = half of all mana spent on this tower. */
+export function sellRefund(tower: TDTower): number {
+  return Math.floor(totalManaSpent(tower) * 0.5)
 }
 
 /** Kills required to unlock the next upgrade tier. */
@@ -352,7 +377,7 @@ export function xpToUpgrade(tower: TDTower): number {
 
 /** Number of units a building spawns at its current upgrade level. */
 export function buildingUnitCount(tower: TDTower): number {
-  return tower.upgrades + 1
+  return tower.upgradeUnits + 1
 }
 
 /**
@@ -455,7 +480,20 @@ function spawnUnitFromBuilding(tower: TDTower): TDUnit {
     stationed: false,
     attackCooldownRemaining: 0,
     rangeInCells: Math.max(1.5, Math.round(tower.template.attackRange / TD_CELL_PX)),
+    speedMult:   1 + tower.upgradeSpeed  * 0.25,
+    rangeBonus:  tower.upgradeRange,
+    damageMult:  1 + tower.upgradeDamage * 0.30,
   }
+}
+
+/** Refresh per-unit multipliers on all units belonging to a tower (call after upgrade). */
+function refreshTowerUnits(units: TDUnit[], tower: TDTower): TDUnit[] {
+  const sm = 1 + tower.upgradeSpeed  * 0.25
+  const rb = tower.upgradeRange
+  const dm = 1 + tower.upgradeDamage * 0.30
+  return units.map(u =>
+    u.towerId === tower.id ? { ...u, speedMult: sm, rangeBonus: rb, damageMult: dm } : u
+  )
 }
 
 function buildSpawnQueue(waveDef: WaveDefinition, startTimeMs: number, waveIndex: number): SpawnEntry[] {
@@ -542,6 +580,10 @@ export function placeTower(
     template,
     buildingName,
     upgrades: 0,
+    upgradeUnits: 0,
+    upgradeSpeed: 0,
+    upgradeRange: 0,
+    upgradeDamage: 0,
     respawnTimers: [],
     xp: 0,
   }
@@ -563,7 +605,7 @@ export function placeTower(
 export function removeTower(state: TDGameState, towerId: number): TDGameState {
   const tower = state.towers.find(t => t.id === towerId)
   if (!tower) return state
-  const refund = Math.floor(towerCost(tower.template) * 0.5)
+  const refund = sellRefund(tower)
   return {
     ...state,
     mana: state.mana + refund,
@@ -578,21 +620,50 @@ export function removeTower(state: TDGameState, towerId: number): TDGameState {
 }
 
 /** Upgrade a building — spawns one more unit. Returns null if not affordable or at max. */
-export function upgradeTower(state: TDGameState, towerId: number): TDGameState | null {
+const UPGRADE_LABELS: Record<TDUpgradeType, string> = {
+  units:  'extra unit dispatched',
+  speed:  'attack speed increased',
+  range:  'attack range extended',
+  damage: 'damage boosted',
+}
+
+export function upgradeTowerWith(
+  state: TDGameState,
+  towerId: number,
+  type: TDUpgradeType,
+): TDGameState | null {
   const tower = state.towers.find(t => t.id === towerId)
   if (!tower) return null
   if (tower.upgrades >= TD_MAX_UPGRADES) return null
   if (tower.xp < xpToUpgrade(tower)) return null
+  const currentLevel = type === 'units'  ? tower.upgradeUnits
+                     : type === 'speed'  ? tower.upgradeSpeed
+                     : type === 'range'  ? tower.upgradeRange
+                     :                    tower.upgradeDamage
+  const maxForType = type === 'units' ? TD_MAX_UNIT_UPGRADES : TD_MAX_UPGRADE_PER_TYPE
+  if (currentLevel >= maxForType) return null
   const cost = upgradeCost(tower)
   if (state.mana < cost) return null
-  const upgradedTower = { ...tower, upgrades: tower.upgrades + 1, xp: 0 }
-  const newUnit = spawnUnitFromBuilding(upgradedTower)
+
+  const upgradedTower: TDTower = {
+    ...tower,
+    upgrades:      tower.upgrades + 1,
+    xp:            0,
+    upgradeUnits:  type === 'units'  ? tower.upgradeUnits  + 1 : tower.upgradeUnits,
+    upgradeSpeed:  type === 'speed'  ? tower.upgradeSpeed  + 1 : tower.upgradeSpeed,
+    upgradeRange:  type === 'range'  ? tower.upgradeRange  + 1 : tower.upgradeRange,
+    upgradeDamage: type === 'damage' ? tower.upgradeDamage + 1 : tower.upgradeDamage,
+  }
+
+  let units = refreshTowerUnits(state.units, upgradedTower)
+  if (type === 'units') units = [...units, spawnUnitFromBuilding(upgradedTower)]
+
   return {
     ...state,
     mana: state.mana - cost,
     towers: state.towers.map(t => t.id === towerId ? upgradedTower : t),
-    units: [...state.units, newUnit],
-    log: [...state.log.slice(-9), `${tower.buildingName} upgraded to ★${tower.upgrades + 1} — extra ${tower.template.name} dispatched! (-${cost} mana)`],
+    units,
+    log: [...state.log.slice(-9), `${tower.buildingName} ★${upgradedTower.upgrades} — ${UPGRADE_LABELS[type]}! (-${cost} mana)`],
   }
 }
 
@@ -827,7 +898,7 @@ export function tickTD(state: TDGameState, dtMs: number): TDGameState {
     let cd = Math.max(0, unit.attackCooldownRemaining - dtMs)
     if (cd <= 0 && s.enemies.length > 0) {
       const targets = s.enemies
-        .filter(e => !deadEnemyIds.has(e.id) && !shieldedEnemyIds.has(e.id) && unitCanHit(unit, e, rangeBonus))
+        .filter(e => !deadEnemyIds.has(e.id) && !shieldedEnemyIds.has(e.id) && unitCanHit(unit, e, rangeBonus + unit.rangeBonus))
         .sort((a, b) => b.pathProgress - a.pathProgress)
       if (targets.length > 0) {
         const target = targets[0]
@@ -836,7 +907,7 @@ export function tickTD(state: TDGameState, dtMs: number): TDGameState {
           shieldedEnemyIds.add(target.id)
           s.enemies = s.enemies.map(e => e.id === target.id ? { ...e, shielded: false } : e)
         } else {
-          const dmg = Math.round(unitDamageDealt(unit, target) * damageMult)
+          const dmg = Math.round(unitDamageDealt(unit, target) * damageMult * unit.damageMult)
           const newHp = target.hp - dmg
           // Apply elemental on-hit effect
           const eff = unit.template.attackEffect
@@ -886,7 +957,7 @@ export function tickTD(state: TDGameState, dtMs: number): TDGameState {
           aoeRadius: unit.template.attackEffect?.aoeRadius,
         })
         const slowPenalty = slowedUnitIds.has(unit.id) ? 1.5 : 1
-        cd = unit.template.attackCooldownMs / attackSpeedMult * slowPenalty
+        cd = unit.template.attackCooldownMs / (attackSpeedMult * unit.speedMult) * slowPenalty
       }
     }
     return { ...unit, attackCooldownRemaining: cd }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -12935,12 +12935,13 @@ html.light-mode .action-btn {
 }
 .td-selected-panel-xp-label       { font-size: 10px; color: #888; white-space: nowrap; }
 .td-selected-panel-xp-label--ready { font-size: 10px; color: #4caf50; font-weight: bold; white-space: nowrap; animation: td-upgrade-pulse 0.8s ease-in-out infinite alternate; }
-.td-selected-panel-actions {
+.td-selected-panel-row {
   display: flex;
-  gap: 8px;
-  flex-wrap: wrap;
   align-items: center;
+  justify-content: space-between;
+  gap: 8px;
 }
+.td-selected-panel-row-actions { display: flex; gap: 6px; flex-shrink: 0; }
 .td-selected-action-btn {
   font-family: 'Courier New', monospace;
   font-size: 12px;
@@ -12956,10 +12957,38 @@ html.light-mode .action-btn {
 .td-selected-action-btn:hover:not(.td-selected-action-btn--disabled) { background: #252525; }
 .td-selected-action-btn--sell    { border-color: #f44336; color: #f44336; }
 .td-selected-action-btn--sell:hover { background: rgba(244,67,54,0.12); }
-.td-selected-action-btn--upgrade { border-color: #ffd700; color: #ffd700; }
-.td-selected-action-btn--upgrade:hover:not(.td-selected-action-btn--disabled) { background: rgba(255,215,0,0.08); }
 .td-selected-action-btn--cancel  { border-color: #444; color: #777; padding: 6px 10px; }
 .td-selected-action-btn--disabled { opacity: 0.35; cursor: not-allowed; }
+
+/* 2×2 upgrade option grid */
+.td-upgrade-options {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 5px;
+}
+.td-upgrade-option {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  background: #1a1a1a;
+  border: 1px solid #4caf50;
+  border-radius: 5px;
+  padding: 5px 8px;
+  cursor: pointer;
+  color: #e0e0e0;
+  font-family: 'Courier New', monospace;
+  font-size: 11px;
+  transition: background 0.1s, border-color 0.1s;
+}
+.td-upgrade-option:hover:not(.td-upgrade-option--disabled):not(.td-upgrade-option--maxed) {
+  background: #162616;
+}
+.td-upgrade-option--disabled { border-color: #333; opacity: 0.45; cursor: not-allowed; }
+.td-upgrade-option--maxed    { border-color: #ffd700; color: #ffd700; cursor: default; opacity: 0.7; }
+.td-upgrade-option-icon  { font-size: 14px; flex-shrink: 0; }
+.td-upgrade-option-label { flex: 1; font-weight: bold; }
+.td-upgrade-option-dots  { font-size: 10px; color: #4caf50; letter-spacing: 1px; flex-shrink: 0; }
+.td-upgrade-option--maxed .td-upgrade-option-dots { color: #ffd700; }
 
 /* ── Bottom panel ── */
 .td-panel {


### PR DESCRIPTION
## Summary

### Multi-option upgrade system
Instead of a single "add unit" upgrade, tapping a selected building now shows a 2×2 grid of upgrade options — all gated behind the same XP threshold and escalating mana cost:

| Option | Effect | Max level |
|---|---|---|
| 👤 +Unit | Spawn one more unit | ★9 (10 total) |
| ⚡ Speed | +25% attack speed/level | ★2 |
| 🎯 Range | +1 cell range/level | ★2 |
| ⚔ Damage | +30% damage/level | ★2 |

Fully upgrading a single building requires 15 purchases: 5+10+15…+75 XP = 600 kills, and costs scale as `towerCost × (n+1) × 2` mana per purchase.

### Sell refund reflects full investment
Sell refund is now half of all mana spent on a building (placement + all upgrades purchased), so players don't lose disproportionately when reorganising.

### Up to 10 units visible
`UnitGroupToken` redesigned from a 3-sprite triangle to a 5-wide grid — supports displaying up to 10 units at once.

## Test plan

- [ ] Place a building, earn 5 kills — confirm ⬆ badge appears and 4 upgrade options are shown
- [ ] Buy Speed ★1 — confirm units attack noticeably faster
- [ ] Buy Range ★1 — confirm attack range visually extends
- [ ] Buy Damage ★1 — confirm enemies die faster
- [ ] Buy +Unit several times — confirm unit count grows and all sprites are shown
- [ ] Sell an upgraded building — confirm refund includes upgrade costs at 50%

https://claude.ai/code/session_01FFXw8rUxBVQRtJK8x762WJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01FFXw8rUxBVQRtJK8x762WJ)_