### PR TITLE
Skip test workflow on push to main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,8 @@ name: Test
 
 on:
   push:
+    branches-ignore:
+      - main
     paths:
       - web/src/**
 


### PR DESCRIPTION
## Summary

- Adds `branches-ignore: [main]` to the test workflow so tests only run on feature branch pushes, not on the merge commit to main

## Test plan

- [ ] Push to a feature branch with `web/src/**` changes — test workflow should run
- [ ] Merge to main — test workflow should NOT run

https://claude.ai/code/session_011AggCstzicREssnGhC23Qd

---
_Generated by [Claude Code](https://claude.ai/code/session_011AggCstzicREssnGhC23Qd)_