### PR TITLE
Drop game speed to 1x when player's commander takes damage

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -392,6 +392,8 @@ export default function App() {
   // Unit death tracking
   const prevPlayerUnitsRef   = useRef<Map<string, string>>(new Map())
   const prevOpponentUnitsRef = useRef<Map<string, string>>(new Map())
+  // Commander HP tracking (null = not yet sampled this battle)
+  const prevCommanderHpRef   = useRef<number | null>(null)
 
   // Achievement toast notifications
   const { achievementToasts, setAchievementToasts } = useAchievements()
@@ -1830,6 +1832,25 @@ export default function App() {
       battleFlawlessRef.current = false
     }
   }, [gameState?.playerBase?.hp, screen])
+
+  // Reset commander HP ref between battles so a new battle never false-triggers
+  useEffect(() => {
+    prevCommanderHpRef.current = null
+  }, [screen])
+
+  // Drop to 1x speed when the player's commander takes damage
+  useEffect(() => {
+    if (!gameState || screen !== 'playing') return
+    let commander: (typeof gameState.field)[number] | undefined
+    for (const u of gameState.field) {
+      if (u.isCommander && u.owner === 'player') { commander = u; break }
+    }
+    const currentHp = commander?.hp ?? null
+    if (prevCommanderHpRef.current !== null && currentHp !== null && currentHp < prevCommanderHpRef.current) {
+      if (battle.speedMultiplier > 1) dispatch({ type: 'SET_SPEED', multiplier: 1 })
+    }
+    prevCommanderHpRef.current = currentHp
+  }, [gameState?.field])
 
   // Secret 4 — Tired Game: after midnight, units occasionally yawn
   useEffect(() => {


### PR DESCRIPTION
## Summary

- Each game tick, checks if the player's commander HP has decreased since the previous tick
- If it has and the current speed is above 1x, dispatches `SET_SPEED` with `multiplier: 1`
- A `screen`-change effect resets the HP tracking ref between battles, preventing false positives when a new battle starts

## Implementation

Added to `App.tsx` alongside the existing field-watching effects (unit death tracking, flawless flag, etc.):

```ts
// Reset between battles
useEffect(() => {
  prevCommanderHpRef.current = null
}, [screen])

// Slow down on commander hit
useEffect(() => {
  if (!gameState || screen !== 'playing') return
  let commander: ...
  for (const u of gameState.field) {
    if (u.isCommander && u.owner === 'player') { commander = u; break }
  }
  const currentHp = commander?.hp ?? null
  if (prevCommanderHpRef.current !== null && currentHp !== null && currentHp < prevCommanderHpRef.current) {
    if (battle.speedMultiplier > 1) dispatch({ type: 'SET_SPEED', multiplier: 1 })
  }
  prevCommanderHpRef.current = currentHp
}, [gameState?.field])
```

No changes to the engine, reducer, or speed UI — the existing `SET_SPEED` action handles it.

## Test plan

- [ ] Play at 2x/4x/8x — when the commander takes a hit the speed snaps back to 1x
- [ ] Player can manually increase speed again after the slowdown
- [ ] Starting a new battle at elevated speed doesn't immediately reset (no false positive on the first tick)
- [ ] Opponent commander taking damage does not trigger a speed reset

https://claude.ai/code/session_01DNAajZHa3FQC44L3kA74Kt

---
_Generated by [Claude Code](https://claude.ai/code/session_01DNAajZHa3FQC44L3kA74Kt)_