### PR TITLE
feat(act9): replay dialogue variants — The Frozen Expanse

### DIFF
--- a/web/src/data/acts/act9.json
+++ b/web/src/data/acts/act9.json
@@ -40,6 +40,245 @@
   "startNodeIds": [
     "glacier-gate"
   ],
+  "variantPools": {
+    "jarvMoods": [
+      "Now, technically, hypothermic by proximity.",
+      "Now, effectively, the sort of person who fights ancient machinery in sub-zero conditions as a career.",
+      "Now, professionally speaking, well outside the recommended operating temperature for a human being.",
+      "Now — by every sensible measure — in a place that does not want to be visited.",
+      "Now, technically, on a landscape that is actively trying to preserve you in the wrong way."
+    ],
+    "jarvIntros": [
+      "You have a deck of cards, several layers of what counts as cold-weather gear in your profession, and the absolute certainty that the cold does not decide who wins.",
+      "You have a deck of cards, a familiarity with the Expanse's patrol timing that suggests you've been studying, and the uneasy sense that the Pale Engine has also been studying.",
+      "You have a deck of cards, a working knowledge of which ice sheets are structurally sound and which are not, and the growing certainty that the Engine already knows which ones you prefer.",
+      "You have a deck of cards, an instinctive feel for the Engine's cycle timing, and the slowly dawning realisation that the Engine has an instinctive feel for yours.",
+      "You have a deck of cards. The Engine has been calculating your arrival since your last departure. You have both been thorough."
+    ],
+    "expanseDesc": [
+      "The ley lines run straight through the ice, bright orange against the white, like cracks in something that is trying to hold itself together.",
+      "The Frozen Expanse smells like cold metal and compressed time — the smell of a place that has been holding still for longer than anything should.",
+      "The Frozen Expanse stretches to every horizon, perfectly white and perfectly indifferent. The ley lines are the only thing here that moves.",
+      "The ley lines run through the glacier here. The ice formed around them. The Expanse has been here long enough to have opinions about what passes through it."
+    ],
+    "engineDesc": [
+      "Nobody built the Pale Engine — or if they did, they did it so long ago that the Engine has stopped caring about the distinction.\n\nIt optimises. It calculates. It applies minimum necessary force. It has been doing this since before the Fracture, and the Fracture only gave it more variables to account for.",
+      "The Pale Engine holds every route through the Expanse with the calm efficiency of something that does not get tired, does not get angry, and does not stop.\n\nYou are a variable it has not yet fully resolved.",
+      "The Pale Engine processes the Expanse with mechanical certainty. It does not distinguish between friend and obstacle. You are, to it, an ongoing optimisation problem.\n\nYou've found that problems like that tend to underestimate you.",
+      "The Pale Engine has updated its models since your last visit. You know this because its patrol routes are different. It has been thorough. You will need to be more thorough."
+    ],
+    "priorRunSummaries": [
+      "The cold felt familiar — not the temperature itself but the quality of it, the way it pressed in from every direction at once. Like a place that had been waiting to be cold at you again.",
+      "The first glacier crossing was wrong. Not icy wrong — patterned wrong, the way a route feels wrong when someone has moved the signposts since you were last here.",
+      "Something about the Engine's patrol cycle at the outer gate. The exact timing of it. You adjusted without thinking, which meant you'd made that adjustment before.",
+      "The Expanse was quieter than it should have been. The wind had stopped. As though the entire landscape was holding its breath at your return."
+    ],
+    "priorRunOpenings": [
+      "You had been here. Your feet found the safe ice before your eyes confirmed it.",
+      "The Frost Sentinel unit at the glacier gate ran its scan cycle slightly longer than the standard interval. It had a new variable to account for: you.",
+      "The Pale Engine's first move was different this time — a half-cycle adjustment in the outer patrol. It had been running simulations.",
+      "The glacier groaned when you stepped onto it. Just once. Just enough."
+    ],
+    "milestoneOpenings5": [
+      "The fifth time through the Frozen Expanse, the Engine has pre-deployed its reserves before you reach the outer gate. It has been running probability calculations.",
+      "Fifth run. The patrol cycle at the glacier crossing has been tightened by 12%. Someone — something — filed a systems update specifically in response to your previous four visits."
+    ],
+    "milestoneOpenings10": [
+      "Ten campaigns. The Pale Engine has dedicated a processing thread specifically to modelling your behaviour. You are officially a standing variable in its optimisation functions.",
+      "The tenth time through the Frozen Expanse, you notice the ice is thicker along your preferred route. The Engine has been doing infrastructure work between your visits."
+    ],
+    "milestoneOpenings25": [
+      "Twenty-five campaigns. The Expanse does not resist when you arrive. It recalibrates. There is a difference, and the Engine has stopped pretending it doesn't know what it means.",
+      "After twenty-five runs, the Pale Engine runs a new subroutine when it detects your approach. You've been told its internal designation translates, roughly, as 'the persistent factor.'"
+    ],
+    "milestoneOpenings50": [
+      "The fiftieth time through the Frozen Expanse. The patrol routes have been optimised so many times in response to you that they no longer resemble the original configuration. You have rebuilt the Engine's doctrine from the outside.",
+      "Fifty campaigns. The Frost Sentinels at the outer gate step aside. Not in welcome. The Engine has calculated that this costs fewer resources than the alternative."
+    ],
+    "milestoneOpenings100": [
+      "The Pale Engine stops.\n\nNot powered down. Not damaged. It stops — a full cessation of all non-essential processes — and turns its primary sensors toward you.\n\nYou have learned, over a hundred crossings, that the Engine does not do anything without a reason.\n\n'Variable,' it says. Its voice sounds like ice cracking in a very controlled way. 'One hundred iterations. My models predicted a ninety-three percent attrition rate by iteration forty.' A pause. The processing lights dim as it runs a calculation. 'I have updated my models.'\n\nThe glacier gate opens.\n\n'Proceed,' it says. 'I have allocated a route. It is faster than your usual one. Consider it a data point.'"
+    ]
+  },
+  "midRunTemplates": [
+    "The {ordinalLower} time through the Frozen Expanse. The Pale Engine has pre-adjusted its patrol cycles before you've reached the outer gate.",
+    "Campaign {n}. The glacier gate has been reinforced again. An engineering order was filed between visits, citing a persistent variable.",
+    "{n} campaigns in. The Frost Sentinels at the outer post have started forming up before you crest the approach ridge. They've learned your pace.",
+    "{n} times you've crossed the Expanse. The ice groans the same way it always does when you step on it. You've started to think of it as a greeting.",
+    "Run {n}. You arrive at the glacier gate and find the Engine has already repositioned. It's been running projections.",
+    "The {ordinalLower} attempt. The cold presses in the same way it always has. Your tolerance for it has become something the Engine is actively modelling.",
+    "{n} campaigns. The Pale Engine has dedicated more processing cycles to the Jarv variable than to anything else in the Expanse."
+  ],
+  "introRules": [
+    {
+      "condition": { "op": "gte", "value": 100 },
+      "panels": [
+        {
+          "title": "THE ENGINE RECALCULATES",
+          "text": "{pool:milestoneOpenings100:0}"
+        },
+        {
+          "title": "THE FROZEN EXPANSE",
+          "text": "{pool:expanseDesc:3}\n\n{pool:engineDesc:2}"
+        }
+      ]
+    },
+    {
+      "condition": { "op": "range", "min": 51, "max": 99 },
+      "panels": [
+        {
+          "title": "THE {ORDINAL} TIME",
+          "text": "{midRunTemplate}"
+        },
+        {
+          "title": "THE WANDERER",
+          "text": "You are Jarv. {pool:jarvMoods:0}\n\n{pool:jarvIntros:1}"
+        },
+        {
+          "title": "THE FROZEN EXPANSE",
+          "text": "{pool:expanseDesc:2}\n\n{pool:engineDesc:1}"
+        },
+        {
+          "title": "INTO THE WHITE",
+          "text": "Break through. Reach the Engine. Defeat it.\n\nYou know the crossing. You always know the crossing."
+        }
+      ]
+    },
+    {
+      "condition": { "op": "eq", "value": 50 },
+      "panels": [
+        {
+          "title": "FIFTY CAMPAIGNS",
+          "text": "{pool:milestoneOpenings50:0}"
+        },
+        {
+          "title": "THE WANDERER",
+          "text": "You are Jarv. {pool:jarvMoods:0}\n\n{pool:jarvIntros:1}"
+        },
+        {
+          "title": "THE FROZEN EXPANSE",
+          "text": "{pool:expanseDesc:2}\n\n{pool:engineDesc:1}"
+        },
+        {
+          "title": "INTO THE WHITE",
+          "text": "Break through. Reach the Engine. Defeat it.\n\nYou know the crossing. You always know the crossing."
+        }
+      ]
+    },
+    {
+      "condition": { "op": "range", "min": 26, "max": 49 },
+      "panels": [
+        {
+          "title": "THE {ORDINAL} TIME",
+          "text": "{midRunTemplate}"
+        },
+        {
+          "title": "THE WANDERER",
+          "text": "You are Jarv. {pool:jarvMoods:0}\n\n{pool:jarvIntros:2}"
+        },
+        {
+          "title": "THE FROZEN EXPANSE",
+          "text": "{pool:expanseDesc:1}\n\n{pool:engineDesc:0}"
+        }
+      ]
+    },
+    {
+      "condition": { "op": "eq", "value": 25 },
+      "panels": [
+        {
+          "title": "TWENTY-FIVE",
+          "text": "{pool:milestoneOpenings25:0}"
+        },
+        {
+          "title": "THE WANDERER",
+          "text": "You are Jarv. {pool:jarvMoods:0}\n\n{pool:jarvIntros:2}"
+        },
+        {
+          "title": "THE FROZEN EXPANSE",
+          "text": "{pool:expanseDesc:1}\n\n{pool:engineDesc:0}"
+        }
+      ]
+    },
+    {
+      "condition": { "op": "range", "min": 11, "max": 24 },
+      "panels": [
+        {
+          "title": "THE {ORDINAL} TIME",
+          "text": "{midRunTemplate}"
+        },
+        {
+          "title": "THE WANDERER",
+          "text": "You are Jarv. {pool:jarvMoods:0}\n\n{pool:jarvIntros:3}"
+        },
+        {
+          "title": "THE FROZEN EXPANSE",
+          "text": "{pool:expanseDesc:0}\n\n{pool:engineDesc:0}"
+        },
+        {
+          "title": "INTO THE WHITE",
+          "text": "Break through the shard. Reach the Engine.\n\nYou know how this goes. You've always known how this goes."
+        }
+      ]
+    },
+    {
+      "condition": { "op": "eq", "value": 10 },
+      "panels": [
+        {
+          "title": "THE TENTH TIME",
+          "text": "{pool:milestoneOpenings10:0}"
+        },
+        {
+          "title": "THE WANDERER",
+          "text": "You are Jarv. {pool:jarvMoods:0}\n\n{pool:jarvIntros:3}"
+        },
+        {
+          "title": "THE FROZEN EXPANSE",
+          "text": "{pool:expanseDesc:0}\n\n{pool:engineDesc:0}"
+        },
+        {
+          "title": "INTO THE WHITE",
+          "text": "Break through the shard. Reach the Engine.\n\nYou know how this goes. You've always known how this goes."
+        }
+      ]
+    },
+    {
+      "condition": { "op": "range", "min": 5, "max": 9 },
+      "panels": [
+        {
+          "title": "THE {ORDINAL} TIME",
+          "text": "{pool:milestoneOpenings5:0}"
+        },
+        {
+          "title": "THE WANDERER",
+          "text": "You are Jarv. {pool:jarvMoods:0}\n\n{pool:jarvIntros:0}"
+        },
+        {
+          "title": "THE FROZEN EXPANSE",
+          "text": "{pool:expanseDesc:0}\n\n{pool:engineDesc:0}"
+        }
+      ]
+    },
+    {
+      "condition": { "op": "range", "min": 2, "max": 4 },
+      "panels": [
+        {
+          "title": "THE FROZEN EXPANSE",
+          "text": "The ley lines run straight through the ice — again.\n\n{pool:priorRunSummaries:0}"
+        },
+        {
+          "title": "THE WANDERER",
+          "text": "You are Jarv. {pool:jarvMoods:0}\n\n{pool:jarvIntros:0}"
+        },
+        {
+          "title": "THE PALE ENGINE",
+          "text": "{pool:engineDesc:0}"
+        },
+        {
+          "title": "A FEELING",
+          "text": "And yet — {pool:priorRunOpenings:0}\n\nYou push the feeling aside. There is work to do.\n\nAgain."
+        }
+      ]
+    }
+  ],
   "intro": [
     {
       "title": "THE FROZEN EXPANSE",


### PR DESCRIPTION
## Summary

- Adds `variantPools`, `midRunTemplates`, and `introRules` to `act9.json`
- 9 intro rule conditions (runs 2–4 through 100+)
- Tone: Pale Engine escalates from treating Jarv as an unresolved variable to dedicating a processing thread to the "persistent factor"; run 100 it recalibrates its 93% attrition prediction and allocates Jarv a faster route as a data point

Part of #920

---
_Generated by [Claude Code](https://claude.ai/code/session_012LCPDECTfn6149xLnsfkdq)_