### PR TITLE
fix(test): make prebuiltPlayerDeck test robust to hero injection

### DIFF
--- a/web/src/game/engine.test.ts
+++ b/web/src/game/engine.test.ts
@@ -65,9 +65,10 @@ describe('newGame', () => {
   it('supports prebuiltPlayerDeck without reshuffling', () => {
     const deck = makeDeck().slice(0, 12)
     const state = newGame({ prebuiltPlayerDeck: deck })
-    // Hand should consist of the first 4 cards of the supplied deck (in order)
-    expect(state.playerHand[0].name).toBe(deck[0].name)
-    expect(state.playerHand[1].name).toBe(deck[1].name)
+    // A hero may be injected at a random position; exclude it before checking order
+    const nonHero = state.playerHand.filter(c => !c.isHero)
+    expect(nonHero[0].name).toBe(deck[0].name)
+    expect(nonHero[1].name).toBe(deck[1].name)
   })
 })
 


### PR DESCRIPTION
## Summary
- `injectHero` places a hero card at a random position 0–8 in the deck, even when `prebuiltPlayerDeck` is supplied (intentional — daily challenge players still get a hero)
- The existing test asserted `playerHand[0]` and `playerHand[1]` by absolute index, so it failed ~11% of the time when the hero landed at slot 1
- Fix: filter out the hero card before checking positional order, which correctly validates that the prebuilt deck order is preserved

## Test plan
- [ ] `vitest run src/game/engine.test.ts` — all 14 tests pass
- [ ] CI green on this PR