### PR TITLE
feat(title): city alert button navigates directly to city builder

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -286,6 +286,7 @@ export default function App() {
   })
 
   const [screen, setScreen]             = useState<Screen>(_startup.screen)
+  const [miniGamesEntry, setMiniGamesEntry] = useState<'menu' | 'citybuilder'>('menu')
   const [showTitleLoginModal, setShowTitleLoginModal] = useState(false)
   const [feedbackOpen, setFeedbackOpen] = useState(false)
   // ── Battle state (all ephemeral state that exists only during a battle) ──────
@@ -2248,6 +2249,7 @@ export default function App() {
             onNews={() => setScreen('news')}
             hasUnreadNews={newsUnreadCount > 0}
             onMiniGames={() => setScreen('minigames')}
+            onCityBuilder={() => { setMiniGamesEntry('citybuilder'); setScreen('minigames') }}
             onPlayerStats={() => setScreen('playerstats')}
             user={user}
             onSignOut={() => { import('firebase/auth').then(({ signOut }) => signOut(auth)) }}
@@ -2627,7 +2629,8 @@ export default function App() {
           onCrystalsChange={(n) => { saveCrystals(n); setCrystals(n) }}
           user={user}
           characterName={loadPlayerName()}
-          onBack={() => setScreen('title')}
+          onBack={() => { setMiniGamesEntry('menu'); setScreen('title') }}
+          initialSubScreen={miniGamesEntry}
         />
       )}
 

--- a/web/src/components/screens/MiniGamesMenu.tsx
+++ b/web/src/components/screens/MiniGamesMenu.tsx
@@ -26,15 +26,16 @@ import { CityBuilder }    from '../minigames/CityBuilder'
 import { Fishing }        from '../minigames/Fishing'
 import { TowerDefence, TowerPool } from '../minigames/TowerDefence'
 
-interface Props {
-  crystals:          number
-  onCrystalsChange:  (n: number) => void
-  user:              User | null
-  characterName:     string
-  onBack:            () => void
-}
-
 type SubScreen = 'menu' | MiniGameId | 'prizes' | 'leaderboard' | 'citybuilder' | 'fishing' | 'towerDefence'
+
+interface Props {
+  crystals:           number
+  onCrystalsChange:   (n: number) => void
+  user:               User | null
+  characterName:      string
+  onBack:             () => void
+  initialSubScreen?:  SubScreen
+}
 
 // Build tower pool from owned unit cards in the player's collection
 function buildCollectionTowerPool(): TowerPool[] {
@@ -64,8 +65,8 @@ function pickRandomCards(count: number, rarity?: 'uncommon' | 'rare' | 'legendar
   return results
 }
 
-export function MiniGamesMenu({ crystals, onCrystalsChange, user, characterName, onBack }: Props) {
-  const [subScreen, setSubScreen] = useState<SubScreen>('menu')
+export function MiniGamesMenu({ crystals, onCrystalsChange, user, characterName, onBack, initialSubScreen }: Props) {
+  const [subScreen, setSubScreen] = useState<SubScreen>(initialSubScreen ?? 'menu')
   const [tickets, setTickets]     = useState(() => loadTickets())
   const [toast, setToast]         = useState<string | null>(null)
   const [lbEntries, setLbEntries] = useState<MiniGameLeaderboardEntry[]>([])

--- a/web/src/components/title/TitleScreen.tsx
+++ b/web/src/components/title/TitleScreen.tsx
@@ -45,6 +45,7 @@ interface Props {
   onNews: () => void
   hasUnreadNews: boolean
   onMiniGames: () => void
+  onCityBuilder: () => void
   onPlayerStats: () => void
   user: User | null
   onSignOut: () => void
@@ -52,7 +53,7 @@ interface Props {
   onFeedback: () => void
 }
 
-export function TitleScreen({ crystals, onPlay, onEndless, onCampaign, onCollection, onShop, onDeckBuilder, onSettings, onInventory, onAchievements, onHeroCards, onCharacter, on8bitUnlocked, onDailyChallenge, onEndlessLeaderboard, onCommander, commanderName, onTraining, onNews, hasUnreadNews, onMiniGames, onPlayerStats, user, onSignOut, onSignIn, onFeedback }: Props) {
+export function TitleScreen({ crystals, onPlay, onEndless, onCampaign, onCollection, onShop, onDeckBuilder, onSettings, onInventory, onAchievements, onHeroCards, onCharacter, on8bitUnlocked, onDailyChallenge, onEndlessLeaderboard, onCommander, commanderName, onTraining, onNews, hasUnreadNews, onMiniGames, onCityBuilder, onPlayerStats, user, onSignOut, onSignIn, onFeedback }: Props) {
   const deck             = loadDeck()
   const count            = deckTotalCards(deck)
   const valid            = isDeckValid(deck)
@@ -239,12 +240,11 @@ export function TitleScreen({ crystals, onPlay, onEndless, onCampaign, onCollect
         <TitleButton onClick={onMiniGames} extraClass={`title-minigames-btn`}>
           🎮  MINI GAMES
         </TitleButton>
-        {cityAttackAlert &&
-        // TODO: Make this button go straight to the city view.
-                <TitleButton           variant="large" onClick={onMiniGames} extraClass={`title-campaign-btn title-minigames-btn title-btn--alert title-alert-badge`}>
-         ⚔ CITY ALERT
-        </TitleButton>
-}
+        {cityAttackAlert && (
+          <TitleButton variant="large" onClick={onCityBuilder} extraClass="title-campaign-btn title-minigames-btn title-btn--alert title-alert-badge">
+            ⚔ CITY ALERT
+          </TitleButton>
+        )}
       </div>
 
       {!campaignUnlocked && (


### PR DESCRIPTION
Resolves the TODO on the ⚔ CITY ALERT button in TitleScreen.

## Changes
- `MiniGamesMenu`: added `initialSubScreen?` prop; state initialises from it instead of always `'menu'`
- `TitleScreen`: added `onCityBuilder` prop; CITY ALERT button calls it instead of `onMiniGames`
- `App.tsx`: new `miniGamesEntry` state (`'menu' | 'citybuilder'`); `onCityBuilder` sets it to `'citybuilder'` before navigating; `onBack` resets it to `'menu'`

## Test plan
- [x] All 231 tests pass
- [ ] CITY ALERT button (trigger: city attack overdue or recent defeat) opens city builder directly
- [ ] Regular MINI GAMES button still opens the hub menu
- [ ] Back from city builder returns to title, then MINI GAMES opens hub as normal

🤖 Generated with [Claude Code](https://claude.com/claude-code)