### PR TITLE
fix(test): guard UnitGroupToken against empty units array

### DIFF
--- a/web/src/components/minigames/towerdefence/UnitGroupToken.tsx
+++ b/web/src/components/minigames/towerdefence/UnitGroupToken.tsx
@@ -7,6 +7,7 @@ import { AnimatedSpriteImg } from "../../ui/SpriteImg"
 export interface Props { units: TDUnit[] }
 
 export function UnitGroupToken({ units }: Props) {
+  if (units.length === 0) return null
   const lead = units[0]
   const stationed = units.some(u => u.stationed)
   const minHpFrac = Math.min(...units.map(u => u.hp / u.maxHp))


### PR DESCRIPTION
## Summary

- `UnitGroupToken` crashed with a `TypeError` when `units` is an empty array because `units[0]` is `undefined` and accessing `.x` on it throws
- Added an early `if (units.length === 0) return null` guard — this is also the correct production behaviour (no token to render for an empty group)
- Fixes the `UnitGroupToken.stories.tsx > Empty` Storybook test failure that was blocking the CI pipeline on PR #1152

## Test plan

- [ ] `npm test` passes with no test failures (all 235 tests green)
- [ ] `Empty` story in `UnitGroupToken.stories.tsx` renders without crashing

https://claude.ai/code/session_01NCE2A88s7HmWQAVWi3pwnH

---
_Generated by [Claude Code](https://claude.ai/code/session_01NCE2A88s7HmWQAVWi3pwnH)_