### PR TITLE
fix(shop): anchor weekend discount badge inside consumable buttons

### DIFF
--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1893,6 +1893,7 @@ body {
 .shop-card-name { font-size: var(--font-md); color: var(--game-text-color); text-align: center; }
 .shop-card-buy-btn { position: relative; font-size: var(--font-md); }
 .shop-card-buy-btn--poor { opacity: 0.45; cursor: not-allowed; }
+.shop-consumable-buy-btn { position: relative; }
 .shop-purchased { font-size: var(--font-xxs); color: #33cc66; letter-spacing: 2px; }
 .shop-discount-badge {
   position: absolute;


### PR DESCRIPTION
## Summary

- The `-10%` discount badge (`shop-discount-badge`) uses `position: absolute; top: -8px; right: -8px`
- The consumable buy button (`action-btn action-btn--gold shop-consumable-buy-btn`) had no `position: relative`
- With no positioned ancestor in the chain (none of shop-consumable-tile, shop-consumables, shop-content, shop-wrapper, overlay-screen, or game-container are positioned), the badge escaped to the top-right corner of the entire viewport on weekends
- The card buy buttons already had the correct fix via `.shop-card-buy-btn { position: relative; }` — this PR adds the same for `.shop-consumable-buy-btn`

## Test plan

- [ ] Open the shop screen on a weekend (or temporarily set `isWeekend()` to return `true`)
- [ ] With an Apprentice NPC active, confirm the `-10%` badge appears on the Health Potion and Second Wind buttons, not floating in the top-right corner of the screen
- [ ] Confirm no visual regression on non-weekend days (badges simply don't render)

https://claude.ai/code/session_01AF7fPqUC72DUJq4fcu7Hkv

---
_Generated by [Claude Code](https://claude.ai/code/session_01AF7fPqUC72DUJq4fcu7Hkv)_