### PR TITLE
fix(ui): standardise navigation screen headers across all overlay screens

### DIFF
--- a/web/src/components/minigames/CityBuilder.tsx
+++ b/web/src/components/minigames/CityBuilder.tsx
@@ -1979,12 +1979,16 @@ export function CityBuilder({ onBack }: Props) {
         </div>
       </div>
 
-      {/* Info + resource strip: attack pill · stats · resources */}
-      <div className="city-res-strip">
+      {/* Attack strip */}
+      <div className="city-attack-strip">
         <div className={`city-attack-pill city-attack-pill--${attackUrgency}`}>
           ⚔ ATTACK INCOMING {msToAttack <= 0 ? 'NOW!' : attackCountdown}
           <span className={`city-attack-strength ${attackStrengthLabel.cls}`}>{attackStrengthLabel.text}</span>
         </div>
+      </div>
+
+      {/* Resource strip: defence · population · resources */}
+      <div className="city-res-strip">
         <span className="city-info-chip" title={`Defense: ${defense}`}>🛡 {defense}</span>
         <span className="city-info-chip" title={`Population: ${population}`}>👥 {population}</span>
         {(['wheat', 'wood', 'ore', 'bread', 'planks', 'metal'] as ResourceType[]).map(res => {

--- a/web/src/components/minigames/CityBuilder.tsx
+++ b/web/src/components/minigames/CityBuilder.tsx
@@ -2143,7 +2143,7 @@ export function CityBuilder({ onBack }: Props) {
         </div>
       )}
 
-      <div className="city-header u-flex u-items-c u-gap-3">
+      <div className="city-header u-flex u-items-c u-just-c u-gap-3">
         <button
           className={`filter-btn${bulldozerMode ? ' city-bulldozer-btn--active' : ''}`}
           onClick={toggleBulldozer}

--- a/web/src/components/minigames/CityBuilder.tsx
+++ b/web/src/components/minigames/CityBuilder.tsx
@@ -1208,9 +1208,9 @@ export function CityBuilder({ onBack }: Props) {
     return (
       <div className="city-screen u-relative u-col u-gap-2">
         {/* Header */}
-        <div className="city-picker-header u-flex u-items-c u-gap-5">
+        <div className="overlay-header u-flex u-items-c u-gap-6">
           <button className="action-btn" onClick={() => { setFortSlotSel(null); setScreen('city') }}>← BACK</button>
-          <div className="city-picker-title">🛡 WALLS &amp; FORTIFICATIONS</div>
+          <div className="overlay-title">🛡 WALLS &amp; FORTIFICATIONS</div>
         </div>
 
         {/* Stats + builder info strip */}
@@ -1544,9 +1544,9 @@ export function CityBuilder({ onBack }: Props) {
 
     return (
       <div className="city-screen u-relative u-col u-gap-2">
-        <div className="city-picker-header u-flex u-items-c u-gap-5">
+        <div className="overlay-header u-flex u-items-c u-gap-6">
           <button className="action-btn" onClick={() => setScreen('city')}>← BACK</button>
-          <div className="city-picker-title">PLACE A BUILDING</div>
+          <div className="overlay-title">PLACE A BUILDING</div>
         </div>
         <div className="city-subscreen-scroll">
           <input
@@ -1661,9 +1661,9 @@ export function CityBuilder({ onBack }: Props) {
 
     return (
       <div className="city-screen u-relative u-col u-gap-2">
-        <div className="city-picker-header u-flex u-items-c u-gap-5">
+        <div className="overlay-header u-flex u-items-c u-gap-6">
           <button className="action-btn" onClick={() => setScreen('city')}>← BACK</button>
-          <div className="city-picker-title">UPGRADE BUILDINGS</div>
+          <div className="overlay-title">UPGRADE BUILDINGS</div>
         </div>
         <div className="city-subscreen-scroll">
           <div className="city-gold-display" style={{ textAlign: 'center', padding: '4px' }}>
@@ -1723,9 +1723,9 @@ export function CityBuilder({ onBack }: Props) {
     const cost     = levelUpCost(mLvl)
     return (
       <div className="city-screen u-relative u-col u-gap-2">
-        <div className="city-picker-header u-flex u-items-c u-gap-5">
+        <div className="overlay-header u-flex u-items-c u-gap-6">
           <button className="action-btn" onClick={() => setScreen('upgrade')}>← BACK</button>
-          <div className="city-picker-title">LEVEL UP CARD</div>
+          <div className="overlay-title">LEVEL UP CARD</div>
         </div>
         <div className="city-level-detail u-col u-items-c u-gap-5">
           {card && <SpriteImg name={card.name} className="city-level-sprite" />}
@@ -1963,14 +1963,9 @@ export function CityBuilder({ onBack }: Props) {
       })()}
 
       {/* Header: back | title | gold | action buttons */}
-      <div className="city-header u-flex u-items-c u-gap-3">
+      <div className="overlay-header u-flex u-items-c u-gap-6">
         <button className="action-btn" onClick={onBack}>← BACK</button>
-        <div className="city-title">
-          {bulldozerMode
-            ? '⏸ PAUSED'
-            : '🏙 CITY'}
-          
-          </div>
+        <span className="overlay-title">{bulldozerMode ? '⏸ PAUSED' : '🏙 CITY'}</span>
         <div className="city-header-right u-flex u-items-c u-gap-2">
           <div className="city-gold-display">⚙ {city.gold.toLocaleString()} (+{incomeRate}/min)</div>
           <button className="action-btn" onClick={() => setScreen('towerdefence')} title="Defend the city using your residents as towers">

--- a/web/src/components/screens/DailyChallengeScreen.tsx
+++ b/web/src/components/screens/DailyChallengeScreen.tsx
@@ -38,8 +38,11 @@ export function DailyChallengeScreen({ onStart, onBack }: Props) {
 
   return (
     <div className="dc-screen">
-      <div className="dc-header u-text-c">
-        <div className="dc-label">DAILY CHALLENGE</div>
+      <div className="overlay-header u-flex u-items-c u-gap-6">
+        <button className="action-btn" onClick={onBack}>← BACK</button>
+        <span className="overlay-title">DAILY CHALLENGE</span>
+      </div>
+      <div className="u-text-c">
         <div className="dc-date">{today}</div>
         <div className="dc-reset-time">Resets at {getResetTimeLocal()}</div>
       </div>
@@ -101,7 +104,6 @@ export function DailyChallengeScreen({ onStart, onBack }: Props) {
         <button className="action-btn action-btn--large" onClick={onStart}>
           {state.attempts === 0 ? '▶ START CHALLENGE' : '▶ TRY AGAIN'}
         </button>
-        <button className="action-btn" onClick={onBack}>← BACK</button>
       </div>
     </div>
   )

--- a/web/src/components/screens/EndlessLeaderboardScreen.tsx
+++ b/web/src/components/screens/EndlessLeaderboardScreen.tsx
@@ -62,8 +62,9 @@ export function EndlessLeaderboardScreen({ onBack }: Props) {
 
   return (
     <div className="el-screen">
-      <div className="el-header u-text-c">
-        <div className="el-label">🏆 LEADERBOARDS</div>
+      <div className="overlay-header u-flex u-items-c u-gap-6">
+        <button className="action-btn" onClick={onBack}>← BACK</button>
+        <span className="overlay-title">🏆 LEADERBOARDS</span>
       </div>
 
       <div className="el-section u-col u-gap-3">
@@ -110,9 +111,6 @@ export function EndlessLeaderboardScreen({ onBack }: Props) {
         </div>
       </div>
 
-      <div className="el-actions u-col u-gap-4">
-        <button className="action-btn" onClick={onBack}>← BACK</button>
-      </div>
     </div>
   )
 }

--- a/web/src/components/screens/MiniGamesMenu.tsx
+++ b/web/src/components/screens/MiniGamesMenu.tsx
@@ -270,9 +270,9 @@ export function MiniGamesMenu({ crystals, onCrystalsChange, user, characterName,
       {toast && <div className="minigame-toast" role="alert">{toast}</div>}
 
       {/* Header */}
-      <div className="minigame-hub-header u-flex u-items-c u-just-sb">
+      <div className="overlay-header u-flex u-items-c u-gap-6">
         <button className="action-btn" onClick={onBack}>← BACK</button>
-        <div className="minigame-hub-title">🎮 ARCADE</div>
+        <span className="overlay-title">🎮 ARCADE</span>
         <div className="ticket-balance">🎫 {tickets} tickets</div>
       </div>
 
@@ -336,9 +336,9 @@ export function MiniGamesMenu({ crystals, onCrystalsChange, user, characterName,
 
       {subScreen === 'prizes' && (
         <div className="prize-screen u-col">
-          <div className="prize-screen-header u-flex u-items-c u-just-sb">
+          <div className="overlay-header u-flex u-items-c u-gap-6">
             <button className="action-btn" onClick={() => setSubScreen('menu')}>← BACK</button>
-            <div className="prize-screen-title">🎁 PRIZE SHOP</div>
+            <span className="overlay-title">🎁 PRIZE SHOP</span>
             <div className="ticket-balance">🎫 {tickets}</div>
           </div>
 
@@ -372,9 +372,9 @@ export function MiniGamesMenu({ crystals, onCrystalsChange, user, characterName,
 
       {subScreen === 'leaderboard' && (
         <div className="lb-screen u-col">
-          <div className="lb-screen-header u-flex u-items-c u-just-sb">
+          <div className="overlay-header u-flex u-items-c u-gap-6">
             <button className="action-btn" onClick={() => setSubScreen('menu')}>← BACK</button>
-            <div className="lb-screen-title">🏆 LEADERBOARDS</div>
+            <span className="overlay-title">🏆 LEADERBOARDS</span>
           </div>
 
           <div className="lb-controls u-col u-gap-3">

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -8890,6 +8890,7 @@ html.light-mode .action-btn {
   font-size: 13px;
   color: var(--color-gold-dim);
   font-weight: bold;
+  white-space: nowrap;
 }
 
 /* ── Compact info strip ───────────────────────────────────────────────────── */
@@ -9218,17 +9219,6 @@ html.light-mode .action-btn {
 
 /* ── Card Picker ──────────────────────────────────────────────────────────── */
 
-.city-picker-header {
-  margin-bottom: 8px;
-}
-
-.city-picker-title {
-  flex: 1;
-  font-size: 14px;
-  color: #60d060;
-  letter-spacing: 2px;
-  text-align: center;
-}
 
 .city-picker-empty { text-align: center; color: #4a7a4a; font-size: 12px; margin-top: 40px; }
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1794,6 +1794,7 @@ body {
 }
 
 .overlay-header {
+  width: 100%;
   padding: 6px 0 8px;
   border-bottom: 2px solid var(--game-border);
   flex-shrink: 0;
@@ -7169,12 +7170,6 @@ html.eightbit-mode .lane-layer {
   font-family: var(--game-font);
   color: var(--game-text-color);
 }
-.dc-label {
-  font-size: 1.429rem;
-  font-weight: bold;
-  letter-spacing: 2px;
-  color: #8bc34a;
-}
 .dc-date {
   font-size: var(--font-md);
   color: var(--game-text-color-muted);
@@ -7318,12 +7313,6 @@ html.eightbit-mode .lane-layer {
   font-family: var(--game-font);
   color: var(--game-text-color);
 }
-.el-label {
-  font-size: 1.429rem;
-  font-weight: bold;
-  letter-spacing: 2px;
-  color: #80cbc4;
-}
 .el-subtitle {
   font-size: var(--font-md);
   color: var(--game-text-color-muted);
@@ -7368,12 +7357,6 @@ html.eightbit-mode .lane-layer {
   border-bottom: 1px solid var(--game-border);
   padding-bottom: 4px;
 }
-.el-actions {
-  width: 100%;
-  max-width: 260px;
-  margin-top: 4px;
-}
-
 /* ── Replay Briefing Screen ─────────────────────────────────────────────── */
 
 .replay-briefing {
@@ -8748,19 +8731,6 @@ html.light-mode .action-btn {
   color: #c8c8d8;
   font-family: monospace;
   box-sizing: border-box;
-}
-
-.minigame-hub-header {
-  width: 100%;
-  max-width: 600px;
-  margin-bottom: 4px;
-}
-
-.minigame-hub-title {
-  font-size: 1.571rem;
-  font-weight: bold;
-  color: var(--color-gold);
-  letter-spacing: 2px;
 }
 
 .ticket-balance {
@@ -10322,17 +10292,6 @@ html.light-mode .action-btn {
   max-width: 600px;
 }
 
-.prize-screen-header {
-  margin-bottom: 12px;
-}
-
-.prize-screen-title {
-  font-size: var(--font-xl);
-  font-weight: bold;
-  color: var(--color-gold);
-  letter-spacing: 2px;
-}
-
 .prize-list {
   width: 100%;
   max-height: 65vh;
@@ -10374,17 +10333,6 @@ html.light-mode .action-btn {
 .lb-screen {
   width: 100%;
   max-width: 500px;
-}
-
-.lb-screen-header {
-  margin-bottom: 12px;
-}
-
-.lb-screen-title {
-  font-size: var(--font-xl);
-  font-weight: bold;
-  color: var(--color-gold);
-  letter-spacing: 2px;
 }
 
 .lb-controls {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -8955,6 +8955,13 @@ html.light-mode .action-btn {
   background: rgba(208,160,48,0.08) !important;
 }
 
+/* ── Attack strip ────────────────────────────────────────────────────────── */
+.city-attack-strip {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+
 /* ── Resource chip strip ─────────────────────────────────────────────────── */
 .city-res-strip {
   display: flex;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -8959,6 +8959,7 @@ html.light-mode .action-btn {
 .city-attack-strip {
   display: flex;
   align-items: center;
+  justify-content: center;
   flex-shrink: 0;
 }
 
@@ -8966,6 +8967,7 @@ html.light-mode .action-btn {
 .city-res-strip {
   display: flex;
   align-items: center;
+  justify-content: center;
   gap: 5px;
   overflow-x: auto;
   flex-shrink: 0;


### PR DESCRIPTION
## Summary

Systematic fix for inconsistent BACK button and page header styling across all navigation screens.

- City builder: all 5 sub-screens (main, build, fortifications, upgrades, expand) now use `overlay-header` / `overlay-title`; attack warning and resource strip split into separate rows
- MiniGamesMenu: main menu, Prize Shop, and Leaderboard sub-screens converted
- EndlessLeaderboardScreen: BACK moved from bottom to top header; old `el-header`/`el-label` removed
- DailyChallengeScreen: BACK moved from bottom to top header; date/reset-time kept as content below header; old `dc-header`/`dc-label` removed
- `overlay-header` gains `width: 100%` so it spans full width inside centred-column containers
- Dead CSS removed: `minigame-hub-header`, `minigame-hub-title`, `prize-screen-header`, `prize-screen-title`, `lb-screen-header`, `lb-screen-title`, `el-label`, `el-actions`, `dc-label`

## Test plan
- [ ] Arcade hub — BACK button and "🎮 ARCADE" title in consistent header; ticket balance on right
- [ ] Prize Shop sub-screen — consistent header with BACK + title + ticket balance
- [ ] Leaderboard sub-screen — consistent header with BACK + title
- [ ] Daily Challenge screen — BACK in top header, date/reset below it, no BACK at bottom
- [ ] Endless Leaderboard screen — BACK in top header, no BACK at bottom
- [ ] City builder (all sub-screens) — consistent header styling throughout
- [ ] Attack warning and resource strip on separate, fully readable rows

https://claude.ai/code/session_01AF7fPqUC72DUJq4fcu7Hkv