### PR TITLE
Add boss intro cutscenes for Act II — Warlord Kragg (#858)

### DIFF
--- a/web/public/cutscenes/act2-boss-1.svg
+++ b/web/public/cutscenes/act2-boss-1.svg
@@ -1,0 +1,154 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
+  <rect width="400" height="240" fill="#080c14"/>
+  <linearGradient id="citadel-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#080c14"/>
+    <stop offset="60%" stop-color="#0e1220"/>
+    <stop offset="100%" stop-color="#141828"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#citadel-sky)"/>
+
+  <!-- Torchlight glow from below — warm amber -->
+  <radialGradient id="torch-glow" cx="50%" cy="75%" r="55%">
+    <stop offset="0%" stop-color="#604010" stop-opacity="0.45"/>
+    <stop offset="50%" stop-color="#402808" stop-opacity="0.2"/>
+    <stop offset="100%" stop-color="#402808" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#torch-glow)"/>
+
+  <!-- Distant sky — overcast iron clouds -->
+  <g fill="#0c1018" opacity="0.6">
+    <ellipse cx="80"  cy="30" rx="70" ry="18"/>
+    <ellipse cx="220" cy="20" rx="90" ry="14"/>
+    <ellipse cx="350" cy="35" rx="65" ry="16"/>
+  </g>
+
+  <!-- Far towers — left -->
+  <rect x="30"  y="60" width="30" height="115" fill="#0c0e14" stroke="#14182a" stroke-width="1"/>
+  <rect x="26"  y="55" width="38" height="10"  fill="#0e1018" stroke="#14182a" stroke-width="0.8"/>
+  <g fill="#0e1018" stroke="#14182a" stroke-width="0.8">
+    <rect x="26"  y="50" width="7" height="8"/>
+    <rect x="38"  y="50" width="7" height="8"/>
+    <rect x="50"  y="50" width="7" height="8"/>
+  </g>
+  <!-- Far tower window glow -->
+  <rect x="40" y="80" width="8" height="10" rx="1" fill="#6a4010" opacity="0.7"/>
+
+  <!-- Far towers — right -->
+  <rect x="340" y="55" width="30" height="120" fill="#0c0e14" stroke="#14182a" stroke-width="1"/>
+  <rect x="336" y="50" width="38" height="10"  fill="#0e1018" stroke="#14182a" stroke-width="0.8"/>
+  <g fill="#0e1018" stroke="#14182a" stroke-width="0.8">
+    <rect x="336" y="45" width="7" height="8"/>
+    <rect x="348" y="45" width="7" height="8"/>
+    <rect x="360" y="45" width="7" height="8"/>
+  </g>
+  <rect x="350" y="78" width="8" height="10" rx="1" fill="#6a4010" opacity="0.7"/>
+
+  <!-- Main keep — central mass -->
+  <rect x="100" y="75" width="200" height="100" fill="#0c0e18" stroke="#181c2c" stroke-width="1.5"/>
+
+  <!-- Keep battlements -->
+  <g fill="#0e1018" stroke="#181c2c" stroke-width="0.8">
+    <rect x="100" y="66" width="12" height="12"/>
+    <rect x="118" y="66" width="12" height="12"/>
+    <rect x="136" y="66" width="12" height="12"/>
+    <rect x="154" y="66" width="12" height="12"/>
+    <rect x="172" y="66" width="12" height="12"/>
+    <rect x="190" y="66" width="12" height="12"/>
+    <rect x="208" y="66" width="12" height="12"/>
+    <rect x="226" y="66" width="12" height="12"/>
+    <rect x="244" y="66" width="12" height="12"/>
+    <rect x="262" y="66" width="12" height="12"/>
+    <rect x="280" y="66" width="12" height="12"/>
+  </g>
+
+  <!-- Keep windows — arrow slits -->
+  <g fill="#5a3808" opacity="0.7">
+    <rect x="130" y="92"  width="5" height="14" rx="1"/>
+    <rect x="155" y="92"  width="5" height="14" rx="1"/>
+    <rect x="240" y="92"  width="5" height="14" rx="1"/>
+    <rect x="265" y="92"  width="5" height="14" rx="1"/>
+    <rect x="130" y="118" width="5" height="14" rx="1"/>
+    <rect x="265" y="118" width="5" height="14" rx="1"/>
+  </g>
+
+  <!-- Iron war banner — left -->
+  <line x1="170" y1="68" x2="170" y2="40" stroke="#202436" stroke-width="1.5"/>
+  <rect x="170" y="40" width="24" height="16" rx="1" fill="#181c30" stroke="#2a2e40" stroke-width="0.8"/>
+  <path d="M170,48 L185,44 L185,52 Z" fill="#252838" opacity="0.7"/>
+
+  <!-- Iron war banner — right -->
+  <line x1="230" y1="68" x2="230" y2="40" stroke="#202436" stroke-width="1.5"/>
+  <rect x="206" y="40" width="24" height="16" rx="1" fill="#181c30" stroke="#2a2e40" stroke-width="0.8"/>
+  <path d="M230,48 L215,44 L215,52 Z" fill="#252838" opacity="0.7"/>
+
+  <!-- Central gate arch — iron portcullis -->
+  <path d="M160,175 L160,120 Q160,108 175,108 Q200,105 225,108 Q240,108 240,120 L240,175" fill="#080c14" stroke="#181c2c" stroke-width="2"/>
+  <!-- Portcullis bars vertical -->
+  <g stroke="#141828" stroke-width="1.5" opacity="0.8">
+    <line x1="172" y1="108" x2="172" y2="175"/>
+    <line x1="184" y1="107" x2="184" y2="175"/>
+    <line x1="196" y1="106" x2="196" y2="175"/>
+    <line x1="208" y1="106" x2="208" y2="175"/>
+    <line x1="220" y1="107" x2="220" y2="175"/>
+    <line x1="232" y1="108" x2="232" y2="175"/>
+  </g>
+  <!-- Portcullis bars horizontal -->
+  <g stroke="#141828" stroke-width="1" opacity="0.6">
+    <line x1="162" y1="120" x2="238" y2="120"/>
+    <line x1="162" y1="132" x2="238" y2="132"/>
+    <line x1="162" y1="144" x2="238" y2="144"/>
+    <line x1="162" y1="156" x2="238" y2="156"/>
+  </g>
+  <!-- Gate torch glow through portcullis -->
+  <radialGradient id="gate-glow" cx="50%" cy="80%" r="30%">
+    <stop offset="0%" stop-color="#804010" stop-opacity="0.3"/>
+    <stop offset="100%" stop-color="#804010" stop-opacity="0"/>
+  </radialGradient>
+  <rect x="160" y="108" width="80" height="67" fill="url(#gate-glow)"/>
+
+  <!-- Wall torches — left -->
+  <line x1="140" y1="82" x2="140" y2="92" stroke="#302010" stroke-width="2"/>
+  <polygon points="136,80 144,80 142,74 138,74" fill="#402808"/>
+  <radialGradient id="t1" cx="50%" cy="40%" r="60%">
+    <stop offset="0%" stop-color="#e08020" stop-opacity="0.6"/>
+    <stop offset="100%" stop-color="#e08020" stop-opacity="0"/>
+  </radialGradient>
+  <ellipse cx="140" cy="76" rx="10" ry="12" fill="url(#t1)"/>
+
+  <!-- Wall torches — right -->
+  <line x1="260" y1="82" x2="260" y2="92" stroke="#302010" stroke-width="2"/>
+  <polygon points="256,80 264,80 262,74 258,74" fill="#402808"/>
+  <radialGradient id="t2" cx="50%" cy="40%" r="60%">
+    <stop offset="0%" stop-color="#e08020" stop-opacity="0.6"/>
+    <stop offset="100%" stop-color="#e08020" stop-opacity="0"/>
+  </radialGradient>
+  <ellipse cx="260" cy="76" rx="10" ry="12" fill="url(#t2)"/>
+
+  <!-- Cobblestone approach road -->
+  <rect x="0" y="175" width="400" height="65" fill="#0a0c10"/>
+  <path d="M140,175 L0,240 M260,175 L400,240" stroke="#141828" stroke-width="1" opacity="0.5"/>
+  <!-- Stone flags -->
+  <g stroke="#12161e" stroke-width="0.6" fill="none" opacity="0.3">
+    <path d="M0,192 Q100,188 200,190 Q300,192 400,188"/>
+    <path d="M0,210 Q100,206 200,208 Q300,210 400,206"/>
+    <path d="M0,228 Q100,224 200,226 Q300,228 400,224"/>
+  </g>
+
+  <!-- Guard silhouettes on battlements -->
+  <g fill="#0a0c14" opacity="0.85">
+    <rect x="113" y="58" width="5" height="8"/>
+    <ellipse cx="115" cy="56" rx="3" ry="3"/>
+    <rect x="285" y="58" width="5" height="8"/>
+    <ellipse cx="287" cy="56" rx="3" ry="3"/>
+  </g>
+
+  <!-- Vignette -->
+  <radialGradient id="vign" cx="50%" cy="50%" r="70%">
+    <stop offset="0%" stop-color="#000000" stop-opacity="0"/>
+    <stop offset="100%" stop-color="#000000" stop-opacity="0.65"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#vign)"/>
+
+  <!-- Label -->
+  <text x="200" y="232" font-family="monospace" font-size="9" fill="#1a2030" text-anchor="middle" letter-spacing="3">THE IRON CITADEL</text>
+</svg>

--- a/web/public/cutscenes/act2-boss-2.svg
+++ b/web/public/cutscenes/act2-boss-2.svg
@@ -1,0 +1,145 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
+  <rect width="400" height="240" fill="#080c14"/>
+
+  <!-- Deep iron atmosphere -->
+  <radialGradient id="kragg-atm" cx="50%" cy="55%" r="55%">
+    <stop offset="0%" stop-color="#141828" stop-opacity="0.8"/>
+    <stop offset="60%" stop-color="#0c1018" stop-opacity="0.5"/>
+    <stop offset="100%" stop-color="#080c14" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#kragg-atm)"/>
+
+  <!-- Amber eye glow -->
+  <radialGradient id="kragg-eyes" cx="50%" cy="42%" r="20%">
+    <stop offset="0%" stop-color="#c08030" stop-opacity="0.5"/>
+    <stop offset="50%" stop-color="#805020" stop-opacity="0.2"/>
+    <stop offset="100%" stop-color="#805020" stop-opacity="0"/>
+  </radialGradient>
+  <ellipse cx="200" cy="100" rx="60" ry="40" fill="url(#kragg-eyes)"/>
+
+  <!-- Torchlight from below — illuminating the figure -->
+  <radialGradient id="kragg-torch" cx="50%" cy="85%" r="50%">
+    <stop offset="0%" stop-color="#604010" stop-opacity="0.35"/>
+    <stop offset="100%" stop-color="#604010" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#kragg-torch)"/>
+
+  <!-- Stone wall background texture -->
+  <g fill="#0c0e18" stroke="#10141e" stroke-width="1" opacity="0.5">
+    <rect x="0"   y="0"   width="100" height="240"/>
+    <rect x="300" y="0"   width="100" height="240"/>
+  </g>
+  <!-- Wall joints -->
+  <g stroke="#0e1220" stroke-width="0.6" fill="none" opacity="0.4">
+    <line x1="0"   y1="40"  x2="100" y2="40"/>
+    <line x1="0"   y1="80"  x2="100" y2="80"/>
+    <line x1="0"   y1="120" x2="100" y2="120"/>
+    <line x1="300" y1="40"  x2="400" y2="40"/>
+    <line x1="300" y1="80"  x2="400" y2="80"/>
+    <line x1="300" y1="120" x2="400" y2="120"/>
+  </g>
+
+  <!-- WARLORD KRAGG — armoured commander -->
+  <!-- Shadow on floor -->
+  <ellipse cx="200" cy="228" rx="55" ry="8" fill="#020408" opacity="0.7"/>
+
+  <!-- Legs — greaves -->
+  <rect x="182" y="185" width="14" height="38" rx="2" fill="#141828" stroke="#1e2438" stroke-width="1"/>
+  <rect x="204" y="185" width="14" height="38" rx="2" fill="#141828" stroke="#1e2438" stroke-width="1"/>
+  <!-- Boot sabaton -->
+  <rect x="180" y="218" width="18" height="8"  rx="1" fill="#10141e" stroke="#181e2c" stroke-width="0.8"/>
+  <rect x="202" y="218" width="18" height="8"  rx="1" fill="#10141e" stroke="#181e2c" stroke-width="0.8"/>
+
+  <!-- Tassets (hip armor) -->
+  <polygon points="178,185 222,185 218,198 182,198" fill="#141828" stroke="#1e2438" stroke-width="1"/>
+
+  <!-- Body — heavy plate cuirass -->
+  <rect x="172" y="130" width="56" height="60" rx="3" fill="#141828" stroke="#202438" stroke-width="1.5"/>
+  <!-- Chest ridge detail -->
+  <line x1="200" y1="132" x2="200" y2="188" stroke="#1e2840" stroke-width="2" opacity="0.7"/>
+  <!-- Pauldron insets -->
+  <g fill="#181e30" opacity="0.5">
+    <rect x="175" y="132" width="20" height="8"/>
+    <rect x="205" y="132" width="20" height="8"/>
+  </g>
+  <!-- Iron command medal / insignia -->
+  <polygon points="200,148 204,155 200,162 196,155" fill="#282c3e" stroke="#3a4060" stroke-width="0.8"/>
+  <circle cx="200" cy="155" r="3" fill="#3a4060" opacity="0.7"/>
+
+  <!-- Pauldrons — massive shoulderplates -->
+  <!-- Left pauldron -->
+  <path d="M172,134 Q148,128 142,148 Q140,165 158,170 L172,165" fill="#141828" stroke="#1e2840" stroke-width="1.5"/>
+  <path d="M156,132 Q140,126 134,146" stroke="#242c42" stroke-width="2.5" fill="none" opacity="0.7"/>
+  <!-- Pauldron edge plates -->
+  <g stroke="#202438" stroke-width="1" fill="#10141e" opacity="0.6">
+    <rect x="148" y="148" width="18" height="6" rx="1"/>
+    <rect x="144" y="156" width="18" height="6" rx="1"/>
+  </g>
+
+  <!-- Right pauldron -->
+  <path d="M228,134 Q252,128 258,148 Q260,165 242,170 L228,165" fill="#141828" stroke="#1e2840" stroke-width="1.5"/>
+  <path d="M244,132 Q260,126 266,146" stroke="#242c42" stroke-width="2.5" fill="none" opacity="0.7"/>
+  <g stroke="#202438" stroke-width="1" fill="#10141e" opacity="0.6">
+    <rect x="234" y="148" width="18" height="6" rx="1"/>
+    <rect x="238" y="156" width="18" height="6" rx="1"/>
+  </g>
+
+  <!-- Arms — right arm holding sword hilt -->
+  <line x1="258" y1="158" x2="278" y2="195" stroke="#141828" stroke-width="10" stroke-linecap="round"/>
+  <!-- Gauntlet right -->
+  <ellipse cx="280" cy="198" rx="8" ry="7" fill="#10141e" stroke="#1a2030" stroke-width="1"/>
+  <!-- Sword grip -->
+  <line x1="280" y1="202" x2="285" y2="240" stroke="#1a2030" stroke-width="4"/>
+  <!-- Cross-guard -->
+  <line x1="273" y1="206" x2="293" y2="206" stroke="#242c40" stroke-width="3"/>
+
+  <!-- Arms — left arm, fist raised -->
+  <line x1="142" y1="158" x2="124" y2="190" stroke="#141828" stroke-width="10" stroke-linecap="round"/>
+  <!-- Gauntlet left -->
+  <ellipse cx="122" cy="193" rx="8" ry="7" fill="#10141e" stroke="#1a2030" stroke-width="1"/>
+
+  <!-- Neck gorget -->
+  <rect x="188" y="122" width="24" height="12" rx="2" fill="#141828" stroke="#1e2440" stroke-width="1"/>
+
+  <!-- HELM — full face great helm -->
+  <!-- Helm base -->
+  <path d="M178,100 Q178,75 200,72 Q222,75 222,100 L222,122 Q200,126 178,122 Z" fill="#141828" stroke="#1e2840" stroke-width="1.5"/>
+  <!-- Helm top ridge -->
+  <line x1="200" y1="72" x2="200" y2="100" stroke="#242c42" stroke-width="2" opacity="0.7"/>
+  <!-- Visor slit — where eyes glow -->
+  <rect x="182" y="93" width="36" height="8" rx="1" fill="#080c12" stroke="#141a28" stroke-width="0.8"/>
+  <!-- EYE GLOW through visor — amber, iron-willed -->
+  <radialGradient id="eye-l" cx="38%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#c08030"/>
+    <stop offset="60%" stop-color="#805020" stop-opacity="0.6"/>
+    <stop offset="100%" stop-color="#805020" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="eye-r" cx="62%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#c08030"/>
+    <stop offset="60%" stop-color="#805020" stop-opacity="0.6"/>
+    <stop offset="100%" stop-color="#805020" stop-opacity="0"/>
+  </radialGradient>
+  <rect x="182" y="93" width="36" height="8" rx="1" fill="url(#eye-l)" opacity="0.85"/>
+  <!-- Inner eye glints -->
+  <ellipse cx="192" cy="97" rx="4" ry="2.5" fill="#d09040" opacity="0.9"/>
+  <ellipse cx="208" cy="97" rx="4" ry="2.5" fill="#d09040" opacity="0.9"/>
+  <circle cx="191" cy="96" r="1.5" fill="#ffe0a0" opacity="0.9"/>
+  <circle cx="207" cy="96" r="1.5" fill="#ffe0a0" opacity="0.9"/>
+  <!-- Helm cheek plates -->
+  <path d="M178,100 Q174,110 176,122" stroke="#1e2840" stroke-width="2" fill="none"/>
+  <path d="M222,100 Q226,110 224,122" stroke="#1e2840" stroke-width="2" fill="none"/>
+  <!-- Helm brow ridge -->
+  <path d="M178,95 Q200,90 222,95" stroke="#252e48" stroke-width="2" fill="none" opacity="0.7"/>
+  <!-- Plume socket (empty — no plume, pure iron) -->
+  <circle cx="200" cy="73" r="3" fill="#1a2030" stroke="#242c40" stroke-width="0.8"/>
+
+  <!-- Vignette -->
+  <radialGradient id="vign2" cx="50%" cy="50%" r="65%">
+    <stop offset="0%" stop-color="#000000" stop-opacity="0"/>
+    <stop offset="100%" stop-color="#000000" stop-opacity="0.72"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#vign2)"/>
+
+  <!-- Label -->
+  <text x="200" y="232" font-family="monospace" font-size="9" fill="#1a2030" text-anchor="middle" letter-spacing="3">WARLORD KRAGG</text>
+</svg>

--- a/web/src/data/acts/act2.json
+++ b/web/src/data/acts/act2.json
@@ -861,6 +861,10 @@
       "bossAI": "kragg",
       "bossCard": "Golem",
       "bossName": "Warlord Kragg",
+      "bossIntro": [
+        {"title": "THE IRON CITADEL", "image": "cutscenes/act2-boss-1.svg", "text": "The inner keep of the Iron Citadel rises from the bedrock of the Marches — three years of war and not one gate has been breached. Torchlight flickers through iron portcullis bars. The garrison is silent. Disciplined. Ready."},
+        {"title": "WARLORD KRAGG", "image": "cutscenes/act2-boss-2.svg", "text": "Warlord Kragg commands from the keep's heart, amber eyes burning through his great helm's visor. He has broken every assault that has ever come to these walls. He will not yield — not to steel, not to strategy, not to a stranger with a deck of cards."}
+      ],
       "bossDialogue": [
         "\"You walked through my garrison. My garrison that has held for three years.\"",
         "\"I don't know what you are. But I know what I am. And I have not lost a defensive engagement in my career.\"",


### PR DESCRIPTION
Closes #858

## Summary
- `act2-boss-1.svg` — The Iron Citadel: stone keep with iron portcullis, torchlit battlements, cobblestone approach
- `act2-boss-2.svg` — Warlord Kragg: full plate great helm with amber eye glow through visor slit, massive pauldrons, war axe
- `bossIntro` JSON wired into the `kragg` boss node in `act2.json`

https://claude.ai/code/session_01QjAWeyHiDWwKa8oZQFU7yn

---
_Generated by [Claude Code](https://claude.ai/code/session_01QjAWeyHiDWwKa8oZQFU7yn)_