### PR TITLE
Add boss intro cutscenes for Act IV — The Archivist (#860)

### DIFF
--- a/web/public/cutscenes/act4-boss-1.svg
+++ b/web/public/cutscenes/act4-boss-1.svg
@@ -1,0 +1,141 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
+  <rect width="400" height="240" fill="#06040e"/>
+  <linearGradient id="spire-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#080618"/>
+    <stop offset="50%" stop-color="#0c0820"/>
+    <stop offset="100%" stop-color="#100c28"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#spire-sky)"/>
+
+  <!-- Deep arcane glow -->
+  <radialGradient id="spire-glow" cx="50%" cy="55%" r="55%">
+    <stop offset="0%" stop-color="#3010a0" stop-opacity="0.35"/>
+    <stop offset="50%" stop-color="#200880" stop-opacity="0.15"/>
+    <stop offset="100%" stop-color="#200880" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#spire-glow)"/>
+
+  <!-- Crystal lattice ceiling — vaulted, geometrically precise -->
+  <g fill="#0a0820" stroke="#180c40" stroke-width="0.8" opacity="0.7">
+    <polygon points="0,0 200,45 400,0 400,12 200,58 0,12"/>
+    <polygon points="0,12 200,58 400,12 400,24 200,70 0,24"/>
+  </g>
+  <!-- Hanging crystal prisms from ceiling -->
+  <g fill="#120a30" stroke="#2010a0" stroke-width="0.7" opacity="0.6">
+    <polygon points="80,24 88,24 84,48"/>
+    <polygon points="140,30 150,30 145,56"/>
+    <polygon points="200,28 210,28 205,55"/>
+    <polygon points="252,32 260,32 256,52"/>
+    <polygon points="316,26 324,26 320,50"/>
+  </g>
+  <!-- Crystal inner glow -->
+  <g fill="#3010a0" opacity="0.3">
+    <polygon points="83,26 87,26 85,44"/>
+    <polygon points="143,32 149,32 146,52"/>
+    <polygon points="203,30 209,30 206,50"/>
+    <polygon points="254,34 259,34 257,50"/>
+    <polygon points="318,28 323,28 321,46"/>
+  </g>
+
+  <!-- Crystal walls — left -->
+  <rect x="0" y="0" width="70" height="240" fill="#080618" stroke="#160c38" stroke-width="1"/>
+  <!-- Crystal formation left -->
+  <g fill="#0c0828" stroke="#2010a0" stroke-width="0.8" opacity="0.65">
+    <polygon points="0,60 22,48 28,80 8,85"/>
+    <polygon points="0,100 18,90 24,120 5,122"/>
+    <polygon points="10,140 30,128 35,158 14,162"/>
+    <polygon points="0,170 20,162 22,190 0,192"/>
+  </g>
+
+  <!-- Crystal walls — right -->
+  <rect x="330" y="0" width="70" height="240" fill="#080618" stroke="#160c38" stroke-width="1"/>
+  <g fill="#0c0828" stroke="#2010a0" stroke-width="0.8" opacity="0.65">
+    <polygon points="400,58 378,46 372,78 392,83"/>
+    <polygon points="400,98 382,88 376,118 395,120"/>
+    <polygon points="390,138 370,126 365,156 386,160"/>
+    <polygon points="400,168 380,160 378,188 400,190"/>
+  </g>
+
+  <!-- Crystal columns — left pair -->
+  <rect x="85"  y="55" width="18" height="175" rx="2" fill="#0a0824" stroke="#1c0c50" stroke-width="1"/>
+  <rect x="92"  y="55" width="4"  height="175" fill="#180a40" opacity="0.4"/>
+  <!-- Column crystal cap -->
+  <polygon points="85,55 103,55 97,40 91,38 85,40" fill="#0e0a30" stroke="#200c60" stroke-width="0.8"/>
+
+  <!-- Crystal columns — right pair -->
+  <rect x="297" y="55" width="18" height="175" rx="2" fill="#0a0824" stroke="#1c0c50" stroke-width="1"/>
+  <rect x="301" y="55" width="4"  height="175" fill="#180a40" opacity="0.4"/>
+  <polygon points="297,55 315,55 309,40 303,38 297,40" fill="#0e0a30" stroke="#200c60" stroke-width="0.8"/>
+
+  <!-- Index shelves receding into depth — rows of catalogued crystals -->
+  <g fill="#0a0820" stroke="#140a38" stroke-width="0.8" opacity="0.7">
+    <rect x="110" y="80"  width="55" height="6"/>
+    <rect x="110" y="100" width="55" height="6"/>
+    <rect x="110" y="120" width="55" height="6"/>
+    <rect x="110" y="140" width="55" height="6"/>
+    <rect x="235" y="80"  width="55" height="6"/>
+    <rect x="235" y="100" width="55" height="6"/>
+    <rect x="235" y="120" width="55" height="6"/>
+    <rect x="235" y="140" width="55" height="6"/>
+  </g>
+  <!-- Crystal records on shelves — tiny prisms -->
+  <g fill="#2010a0" opacity="0.35">
+    <rect x="113" y="75" width="3" height="6"/>
+    <rect x="118" y="74" width="3" height="7"/>
+    <rect x="123" y="76" width="3" height="5"/>
+    <rect x="128" y="74" width="3" height="7"/>
+    <rect x="133" y="75" width="3" height="6"/>
+    <rect x="138" y="73" width="3" height="8"/>
+    <rect x="143" y="76" width="3" height="5"/>
+    <rect x="238" y="75" width="3" height="6"/>
+    <rect x="243" y="74" width="3" height="7"/>
+    <rect x="248" y="76" width="3" height="5"/>
+    <rect x="253" y="74" width="3" height="7"/>
+    <rect x="258" y="75" width="3" height="6"/>
+    <rect x="263" y="73" width="3" height="8"/>
+    <rect x="268" y="76" width="3" height="5"/>
+  </g>
+
+  <!-- Central archway to the inner vault -->
+  <path d="M152,230 L152,140 Q152,118 175,115 Q200,110 225,115 Q248,118 248,140 L248,230" fill="#080618" stroke="#1a0c48" stroke-width="2"/>
+  <!-- Arch crystal trim -->
+  <g stroke="#3010a0" stroke-width="1" fill="none" opacity="0.5">
+    <path d="M155,142 Q155,122 175,118 Q200,114 225,118 Q245,122 245,142"/>
+  </g>
+  <!-- Arcane runes inscribed on arch -->
+  <g fill="none" stroke="#2010a0" stroke-width="0.6" opacity="0.4">
+    <path d="M162,150 L162,158 M158,154 L166,154"/>
+    <path d="M238,150 L238,158 M234,154 L242,154"/>
+    <path d="M162,168 L164,174 L162,180"/>
+    <path d="M238,168 L236,174 L238,180"/>
+  </g>
+  <!-- Inner arch glow — the vault chamber beyond -->
+  <radialGradient id="arch-glow" cx="50%" cy="65%" r="30%">
+    <stop offset="0%" stop-color="#4010c0" stop-opacity="0.25"/>
+    <stop offset="100%" stop-color="#4010c0" stop-opacity="0"/>
+  </radialGradient>
+  <rect x="152" y="110" width="96" height="120" fill="url(#arch-glow)"/>
+
+  <!-- Crystal floor — reflective -->
+  <rect x="70" y="210" width="260" height="30" fill="#090720" opacity="0.8"/>
+  <g stroke="#1a0c48" stroke-width="0.6" fill="none" opacity="0.3">
+    <line x1="70" y1="210" x2="330" y2="210"/>
+    <line x1="120" y1="210" x2="120" y2="240"/>
+    <line x1="170" y1="210" x2="170" y2="240"/>
+    <line x1="200" y1="210" x2="200" y2="240"/>
+    <line x1="230" y1="210" x2="230" y2="240"/>
+    <line x1="280" y1="210" x2="280" y2="240"/>
+  </g>
+  <!-- Floor arcane light -->
+  <line x1="70" y1="212" x2="330" y2="212" stroke="#3010a0" stroke-width="1" opacity="0.3"/>
+
+  <!-- Vignette -->
+  <radialGradient id="vign-sp" cx="50%" cy="50%" r="68%">
+    <stop offset="0%" stop-color="#000000" stop-opacity="0"/>
+    <stop offset="100%" stop-color="#000000" stop-opacity="0.65"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#vign-sp)"/>
+
+  <!-- Label -->
+  <text x="200" y="232" font-family="monospace" font-size="9" fill="#1e1040" text-anchor="middle" letter-spacing="3">THE CRYSTAL SPIRE</text>
+</svg>

--- a/web/public/cutscenes/act4-boss-2.svg
+++ b/web/public/cutscenes/act4-boss-2.svg
@@ -1,0 +1,149 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
+  <rect width="400" height="240" fill="#06040e"/>
+
+  <!-- Deep arcane library atmosphere -->
+  <radialGradient id="arch-atm" cx="50%" cy="50%" r="60%">
+    <stop offset="0%" stop-color="#120a30" stop-opacity="0.8"/>
+    <stop offset="70%" stop-color="#08041a" stop-opacity="0.4"/>
+    <stop offset="100%" stop-color="#06040e" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#arch-atm)"/>
+
+  <!-- Violet eye aura -->
+  <radialGradient id="arch-eyes-glow" cx="50%" cy="40%" r="24%">
+    <stop offset="0%" stop-color="#8060e0" stop-opacity="0.5"/>
+    <stop offset="50%" stop-color="#5030c0" stop-opacity="0.2"/>
+    <stop offset="100%" stop-color="#5030c0" stop-opacity="0"/>
+  </radialGradient>
+  <ellipse cx="200" cy="96" rx="70" ry="45" fill="url(#arch-eyes-glow)"/>
+
+  <!-- Background crystal wall — indexed records filling every surface -->
+  <g fill="#0a0820" stroke="#14083a" stroke-width="0.5" opacity="0.5">
+    <rect x="0"   y="0" width="90"  height="240"/>
+    <rect x="310" y="0" width="90"  height="240"/>
+  </g>
+  <g fill="#180a48" opacity="0.2">
+    <rect x="6"  y="10" width="4" height="12"/>
+    <rect x="14" y="10" width="4" height="12"/>
+    <rect x="22" y="10" width="4" height="12"/>
+    <rect x="6"  y="30" width="4" height="12"/>
+    <rect x="14" y="30" width="4" height="12"/>
+    <rect x="320" y="10" width="4" height="12"/>
+    <rect x="328" y="10" width="4" height="12"/>
+    <rect x="336" y="10" width="4" height="12"/>
+    <rect x="320" y="30" width="4" height="12"/>
+    <rect x="328" y="30" width="4" height="12"/>
+  </g>
+
+  <!-- Floating crystal index nodes — orbiting the Archivist -->
+  <g fill="#1a0a50" stroke="#4020c0" stroke-width="0.8" opacity="0.7">
+    <polygon points="130,70 140,65 145,76 136,80"/>
+    <polygon points="255,68 266,63 270,74 261,78"/>
+    <polygon points="118,108 128,103 133,114 124,118"/>
+    <polygon points="268,106 279,101 283,112 274,116"/>
+    <polygon points="135,148 145,142 149,154 140,157"/>
+    <polygon points="252,145 263,140 266,151 257,155"/>
+  </g>
+  <!-- Crystal node inner glow -->
+  <g fill="#5030c0" opacity="0.4">
+    <polygon points="133,72 138,68 141,75 137,78"/>
+    <polygon points="258,70 264,66 267,73 263,76"/>
+  </g>
+
+  <!-- THE ARCHIVIST — robed scholar figure, tall and angular -->
+  <!-- Floor shadow -->
+  <ellipse cx="200" cy="228" rx="45" ry="7" fill="#020108" opacity="0.6"/>
+
+  <!-- Robes — long, layered, arcane scholar attire -->
+  <!-- Outer robe -->
+  <polygon points="168,145 232,145 238,230 162,230" fill="#0c0828" stroke="#1a0c50" stroke-width="1"/>
+  <!-- Inner robe lighter layer -->
+  <polygon points="180,148 220,148 225,228 175,228" fill="#0e0a30" stroke="#16083a" stroke-width="0.8"/>
+  <!-- Robe hem geometric trim -->
+  <g stroke="#2510a0" stroke-width="0.8" fill="none" opacity="0.4">
+    <path d="M168,208 L175,202 L182,208 L189,202 L196,208 L203,202 L210,208 L217,202 L224,208 L231,202 L238,208"/>
+    <path d="M168,218 L175,212 L182,218 L189,212 L196,218 L203,212 L210,218 L217,212 L224,218 L231,212 L238,218"/>
+  </g>
+
+  <!-- Sash / belt with crystal clasp -->
+  <rect x="180" y="170" width="40" height="7" rx="1" fill="#140a38" stroke="#2010a0" stroke-width="0.8"/>
+  <polygon points="197,170 203,170 205,177 195,177" fill="#3010a0" opacity="0.7"/>
+
+  <!-- Arms — stretched forward, open palms, crystal index hovering between them -->
+  <!-- Left arm -->
+  <line x1="174" y1="152" x2="148" y2="172" stroke="#0c0828" stroke-width="7" stroke-linecap="round"/>
+  <!-- Left hand -->
+  <ellipse cx="144" cy="175" rx="7" ry="5" fill="#0e0a2a" stroke="#1a0c48" stroke-width="0.8"/>
+  <!-- Right arm -->
+  <line x1="226" y1="152" x2="252" y2="172" stroke="#0c0828" stroke-width="7" stroke-linecap="round"/>
+  <!-- Right hand -->
+  <ellipse cx="256" cy="175" rx="7" ry="5" fill="#0e0a2a" stroke="#1a0c48" stroke-width="0.8"/>
+  <!-- Crystal tome / index shard floating between hands -->
+  <polygon points="170,158 200,150 230,158 215,178 185,178" fill="#100830" stroke="#3010a0" stroke-width="1" opacity="0.8"/>
+  <polygon points="180,160 200,154 220,160 210,174 190,174" fill="#180a48" stroke="#4020c0" stroke-width="0.6" opacity="0.6"/>
+  <!-- Tome inner glow -->
+  <ellipse cx="200" cy="164" rx="14" ry="8" fill="#4020c0" opacity="0.25"/>
+  <!-- Rune lines on tome -->
+  <g stroke="#6040e0" stroke-width="0.5" fill="none" opacity="0.5">
+    <line x1="188" y1="160" x2="212" y2="160"/>
+    <line x1="186" y1="164" x2="214" y2="164"/>
+    <line x1="188" y1="168" x2="212" y2="168"/>
+    <line x1="200" y1="156" x2="200" y2="172"/>
+  </g>
+
+  <!-- Body beneath robes — tall, gaunt -->
+  <rect x="186" y="118" width="28" height="30" rx="1" fill="#0c0828" stroke="#1a0c48" stroke-width="0.8"/>
+  <!-- Chest arcane sigil -->
+  <g stroke="#3010a0" stroke-width="0.7" fill="none" opacity="0.5">
+    <polygon points="200,122 204,128 200,134 196,128"/>
+    <circle cx="200" cy="128" r="4"/>
+  </g>
+
+  <!-- Neck collar -->
+  <rect x="194" y="110" width="12" height="12" rx="1" fill="#0c0828" stroke="#1a0a40" stroke-width="0.8"/>
+
+  <!-- HEAD — angular, thin-faced scholar -->
+  <ellipse cx="200" cy="100" rx="20" ry="18" fill="#0c0828" stroke="#1a0c48" stroke-width="1.2"/>
+  <!-- Brow ridge — high, intellectual -->
+  <path d="M182,96 Q200,90 218,96" stroke="#201050" stroke-width="2" fill="none" opacity="0.7"/>
+  <!-- High collar behind head -->
+  <path d="M182,110 Q178,100 180,94" stroke="#1a0c48" stroke-width="2" fill="none"/>
+  <path d="M218,110 Q222,100 220,94" stroke="#1a0c48" stroke-width="2" fill="none"/>
+
+  <!-- Eyes — violet, luminous, all-cataloguing -->
+  <ellipse cx="188" cy="100" rx="9" ry="7" fill="#06040e"/>
+  <ellipse cx="212" cy="100" rx="9" ry="7" fill="#06040e"/>
+  <!-- Eye glow — violet, deep -->
+  <radialGradient id="eye-vl" cx="50%" cy="50%" r="65%">
+    <stop offset="0%" stop-color="#a070f0"/>
+    <stop offset="55%" stop-color="#6040c0" stop-opacity="0.7"/>
+    <stop offset="100%" stop-color="#6040c0" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="eye-vr" cx="50%" cy="50%" r="65%">
+    <stop offset="0%" stop-color="#a070f0"/>
+    <stop offset="55%" stop-color="#6040c0" stop-opacity="0.7"/>
+    <stop offset="100%" stop-color="#6040c0" stop-opacity="0"/>
+  </radialGradient>
+  <ellipse cx="188" cy="100" rx="9" ry="7" fill="url(#eye-vl)" opacity="0.85"/>
+  <ellipse cx="212" cy="100" rx="9" ry="7" fill="url(#eye-vr)" opacity="0.85"/>
+  <ellipse cx="188" cy="99" rx="4" ry="3" fill="#c090ff" opacity="0.9"/>
+  <ellipse cx="212" cy="99" rx="4" ry="3" fill="#c090ff" opacity="0.9"/>
+  <circle cx="187" cy="98" r="1.5" fill="#e8d0ff" opacity="0.95"/>
+  <circle cx="211" cy="98" r="1.5" fill="#e8d0ff" opacity="0.95"/>
+
+  <!-- Tall archivist's hat / cowl -->
+  <polygon points="192,82 208,82 206,60 200,55 194,60" fill="#0c0828" stroke="#1a0a48" stroke-width="1"/>
+  <rect x="186" y="80" width="28" height="5" rx="1" fill="#10093a" stroke="#1c0c50" stroke-width="0.8"/>
+  <!-- Hat trim arcane marking -->
+  <line x1="192" y1="82" x2="208" y2="82" stroke="#3010a0" stroke-width="0.8" opacity="0.5"/>
+
+  <!-- Vignette -->
+  <radialGradient id="vign-a4" cx="50%" cy="50%" r="65%">
+    <stop offset="0%" stop-color="#000000" stop-opacity="0"/>
+    <stop offset="100%" stop-color="#000000" stop-opacity="0.72"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#vign-a4)"/>
+
+  <!-- Label -->
+  <text x="200" y="232" font-family="monospace" font-size="9" fill="#1e1040" text-anchor="middle" letter-spacing="3">THE ARCHIVIST</text>
+</svg>

--- a/web/src/data/acts/act4.json
+++ b/web/src/data/acts/act4.json
@@ -1046,6 +1046,10 @@
       "bossAI": "archivist",
       "bossCard": "Giant",
       "bossName": "The Archivist",
+      "bossIntro": [
+        {"title": "THE CRYSTAL SPIRE", "image": "cutscenes/act4-boss-1.svg", "text": "The Crystal Spire is a labyrinth of catalogued corridors and indexed vaults — every surface inscribed, every chamber filed. Whatever knowledge the Fracture shattered, it was brought here. Sorted. Kept."},
+        {"title": "THE ARCHIVIST", "image": "cutscenes/act4-boss-2.svg", "text": "The Archivist has catalogued every card you carry, every decision you made to reach this room. He was a scholar once. Now he is the index — and he has very thorough notes on you."}
+      ],
       "bossDialogue": [
         "\"Every card you carry. Every decision you made to reach this room. I have catalogued all of it.\"",
         "\"You think your deck is your own? I wrote the first copy.\"",


### PR DESCRIPTION
Closes #860

## Summary
- `act4-boss-1.svg` — The Crystal Spire: arcane library vaults with hanging crystal prisms, indexed shelves, central archway lit by violet ley energy
- `act4-boss-2.svg` — The Archivist: tall robed scholar with tall cowl, violet eye glow, floating crystal tome index between outstretched hands
- `bossIntro` JSON wired into the `archivist` boss node in `act4.json`

https://claude.ai/code/session_01QjAWeyHiDWwKa8oZQFU7yn

---
_Generated by [Claude Code](https://claude.ai/code/session_01QjAWeyHiDWwKa8oZQFU7yn)_