### PR TITLE
Add boss intro cutscenes for Act VII — The Cinderwarlord (#863)

### DIFF
--- a/web/public/cutscenes/act7-boss-1.svg
+++ b/web/public/cutscenes/act7-boss-1.svg
@@ -1,0 +1,127 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
+  <rect width="400" height="240" fill="#0e0400"/>
+  <linearGradient id="caldera-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#120500"/>
+    <stop offset="40%" stop-color="#1a0600"/>
+    <stop offset="100%" stop-color="#220800"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#caldera-sky)"/>
+
+  <!-- Volcanic fire glow — horizon bleeding upward -->
+  <radialGradient id="caldera-glow" cx="50%" cy="72%" r="60%">
+    <stop offset="0%" stop-color="#801810" stop-opacity="0.55"/>
+    <stop offset="40%" stop-color="#501008" stop-opacity="0.28"/>
+    <stop offset="100%" stop-color="#400800" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#caldera-glow)"/>
+
+  <!-- Ash cloud ceiling — oppressive, lit from below -->
+  <g fill="#180a00" opacity="0.75">
+    <ellipse cx="80"  cy="22" rx="90" ry="20"/>
+    <ellipse cx="240" cy="16" rx="110" ry="18"/>
+    <ellipse cx="380" cy="25" rx="80" ry="18"/>
+    <ellipse cx="150" cy="38" rx="70" ry="14"/>
+    <ellipse cx="310" cy="35" rx="75" ry="14"/>
+  </g>
+  <!-- Cloud undersides lit by lava glow -->
+  <g fill="#401008" opacity="0.25">
+    <ellipse cx="80"  cy="38" rx="80" ry="10"/>
+    <ellipse cx="240" cy="30" rx="90" ry="10"/>
+    <ellipse cx="380" cy="40" rx="70" ry="10"/>
+  </g>
+
+  <!-- Left volcano flank -->
+  <polygon points="0,240 0,80 80,175" fill="#110600" stroke="#1c0800" stroke-width="1"/>
+  <polygon points="0,80 55,55 130,175" fill="#140700" stroke="#1e0900" stroke-width="0.8"/>
+  <!-- Left lava channel -->
+  <path d="M30,80 Q40,110 38,140 Q36,160 40,175" stroke="#802010" stroke-width="3" fill="none" opacity="0.7"/>
+  <path d="M30,80 Q40,110 38,140 Q36,160 40,175" stroke="#c04020" stroke-width="1" fill="none" opacity="0.4"/>
+
+  <!-- Right volcano flank -->
+  <polygon points="400,240 400,75 320,175" fill="#110600" stroke="#1c0800" stroke-width="1"/>
+  <polygon points="400,75 345,50 270,175" fill="#140700" stroke="#1e0900" stroke-width="0.8"/>
+  <!-- Right lava channel -->
+  <path d="M370,75 Q360,108 362,138 Q364,160 360,175" stroke="#802010" stroke-width="3" fill="none" opacity="0.7"/>
+  <path d="M370,75 Q360,108 362,138 Q364,160 360,175" stroke="#c04020" stroke-width="1" fill="none" opacity="0.4"/>
+
+  <!-- THE CALDERA FLOOR — lava lake in the heart -->
+  <!-- Outer rock ring -->
+  <ellipse cx="200" cy="200" rx="150" ry="45" fill="#140800" stroke="#201000" stroke-width="1"/>
+  <!-- Inner lava lake -->
+  <ellipse cx="200" cy="200" rx="100" ry="30" fill="#5a1008" stroke="#802010" stroke-width="1.5"/>
+  <ellipse cx="200" cy="200" rx="70"  ry="20" fill="#7a1810" opacity="0.8"/>
+  <!-- Lava surface cracks — bright -->
+  <g stroke="#e04020" stroke-width="1.5" fill="none" opacity="0.6">
+    <path d="M155,200 Q175,195 200,197 Q225,195 245,200"/>
+    <path d="M170,205 Q185,200 200,202 Q215,200 230,205"/>
+  </g>
+  <!-- Lava glow reflected on rock walls -->
+  <g fill="#601008" opacity="0.2">
+    <ellipse cx="130" cy="195" rx="30" ry="12"/>
+    <ellipse cx="270" cy="195" rx="30" ry="12"/>
+  </g>
+
+  <!-- COMMAND BRIDGE over the caldera -->
+  <!-- Bridge pillars -->
+  <g fill="#140800" stroke="#201000" stroke-width="1.5">
+    <rect x="154" y="162" width="12" height="38"/>
+    <rect x="234" y="162" width="12" height="38"/>
+  </g>
+  <!-- Bridge span -->
+  <rect x="148" y="155" width="104" height="12" rx="1" fill="#160900" stroke="#221100" stroke-width="1.5"/>
+  <!-- Bridge guard rails -->
+  <g stroke="#201000" stroke-width="1" fill="none" opacity="0.7">
+    <line x1="148" y1="158" x2="252" y2="158"/>
+    <line x1="148" y1="165" x2="252" y2="165"/>
+    <!-- Rail posts -->
+    <line x1="162" y1="155" x2="162" y2="167"/>
+    <line x1="180" y1="155" x2="180" y2="167"/>
+    <line x1="200" y1="155" x2="200" y2="167"/>
+    <line x1="220" y1="155" x2="220" y2="167"/>
+    <line x1="238" y1="155" x2="238" y2="167"/>
+  </g>
+  <!-- Heat shimmer above lava -->
+  <g stroke="#602010" stroke-width="0.5" fill="none" opacity="0.2">
+    <path d="M160,195 Q165,180 162,165"/>
+    <path d="M200,192 Q205,175 202,160"/>
+    <path d="M240,195 Q235,180 238,165"/>
+  </g>
+
+  <!-- Ember particles rising -->
+  <g fill="#d04018" opacity="0.35">
+    <circle cx="168" cy="152" r="1.2"/>
+    <circle cx="185" cy="138" r="0.8"/>
+    <circle cx="200" cy="130" r="1"/>
+    <circle cx="218" cy="142" r="0.8"/>
+    <circle cx="232" cy="150" r="1.2"/>
+    <circle cx="145" cy="125" r="0.8"/>
+    <circle cx="255" cy="128" r="0.8"/>
+    <circle cx="110" cy="148" r="0.7"/>
+    <circle cx="290" cy="145" r="0.7"/>
+  </g>
+
+  <!-- Distant fortification on the caldera rim -->
+  <g fill="#120700" stroke="#1c0c00" stroke-width="1" opacity="0.7">
+    <rect x="65"  y="155" width="35" height="25"/>
+    <rect x="300" y="152" width="35" height="28"/>
+  </g>
+  <!-- Fortification battlements -->
+  <g fill="#160900" stroke="#1c0c00" stroke-width="0.8" opacity="0.6">
+    <rect x="65"  y="149" width="6" height="9"/>
+    <rect x="76"  y="149" width="6" height="9"/>
+    <rect x="87"  y="149" width="6" height="9"/>
+    <rect x="300" y="146" width="6" height="9"/>
+    <rect x="311" y="146" width="6" height="9"/>
+    <rect x="322" y="146" width="6" height="9"/>
+  </g>
+
+  <!-- Vignette -->
+  <radialGradient id="vign-cv" cx="50%" cy="50%" r="68%">
+    <stop offset="0%" stop-color="#000000" stop-opacity="0"/>
+    <stop offset="100%" stop-color="#000000" stop-opacity="0.65"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#vign-cv)"/>
+
+  <!-- Label -->
+  <text x="200" y="232" font-family="monospace" font-size="9" fill="#281008" text-anchor="middle" letter-spacing="3">THE EMBERFALL CALDERA</text>
+</svg>

--- a/web/public/cutscenes/act7-boss-2.svg
+++ b/web/public/cutscenes/act7-boss-2.svg
@@ -1,0 +1,160 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
+  <rect width="400" height="240" fill="#0e0400"/>
+
+  <!-- Volcanic forge atmosphere -->
+  <radialGradient id="cw-atm" cx="50%" cy="55%" r="58%">
+    <stop offset="0%" stop-color="#1e0800" stop-opacity="0.75"/>
+    <stop offset="65%" stop-color="#120500" stop-opacity="0.4"/>
+    <stop offset="100%" stop-color="#0e0400" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#cw-atm)"/>
+
+  <!-- Fire eye glow -->
+  <radialGradient id="cw-eyes" cx="50%" cy="41%" r="22%">
+    <stop offset="0%" stop-color="#e06010" stop-opacity="0.55"/>
+    <stop offset="45%" stop-color="#802010" stop-opacity="0.22"/>
+    <stop offset="100%" stop-color="#802010" stop-opacity="0"/>
+  </radialGradient>
+  <ellipse cx="200" cy="98" rx="65" ry="42" fill="url(#cw-eyes)"/>
+
+  <!-- Lava glow from below -->
+  <radialGradient id="cw-lava" cx="50%" cy="92%" r="50%">
+    <stop offset="0%" stop-color="#802010" stop-opacity="0.4"/>
+    <stop offset="100%" stop-color="#802010" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#cw-lava)"/>
+
+  <!-- Ember particles in the air -->
+  <g fill="#e04018" opacity="0.3">
+    <circle cx="120" cy="80"  r="1.2"/>
+    <circle cx="148" cy="55"  r="0.8"/>
+    <circle cx="165" cy="100" r="1"/>
+    <circle cx="238" cy="92"  r="1"/>
+    <circle cx="258" cy="62"  r="0.8"/>
+    <circle cx="280" cy="85"  r="1.2"/>
+    <circle cx="140" cy="145" r="0.9"/>
+    <circle cx="262" cy="140" r="0.9"/>
+    <circle cx="100" cy="168" r="0.7"/>
+    <circle cx="298" cy="160" r="0.7"/>
+  </g>
+
+  <!-- THE CINDERWARLORD — armoured volcanic commander -->
+  <!-- Shadow -->
+  <ellipse cx="200" cy="228" rx="55" ry="8" fill="#060200" opacity="0.7"/>
+
+  <!-- Legs — thick volcanic armour -->
+  <rect x="180" y="188" width="16" height="38" rx="2" fill="#180800" stroke="#281400" stroke-width="1"/>
+  <rect x="204" y="188" width="16" height="38" rx="2" fill="#180800" stroke="#281400" stroke-width="1"/>
+  <!-- Boot plates — heavy, reinforced -->
+  <rect x="177" y="220" width="22" height="8" rx="1" fill="#141000" stroke="#201400" stroke-width="0.8"/>
+  <rect x="201" y="220" width="22" height="8" rx="1" fill="#141000" stroke="#201400" stroke-width="0.8"/>
+
+  <!-- Tassets — volcanic plate skirting -->
+  <polygon points="176,188 224,188 220,202 180,202" fill="#180800" stroke="#281400" stroke-width="1"/>
+  <!-- Lava seam in tasset join -->
+  <line x1="180" y1="195" x2="220" y2="195" stroke="#802010" stroke-width="0.8" opacity="0.5"/>
+
+  <!-- Body — massive forge-plate cuirass -->
+  <rect x="168" y="128" width="64" height="65" rx="3" fill="#1a0900" stroke="#2a1400" stroke-width="1.5"/>
+  <!-- Chest ridge — central keel plate -->
+  <line x1="200" y1="130" x2="200" y2="190" stroke="#281200" stroke-width="3" opacity="0.7"/>
+  <!-- Forge rivets on chest -->
+  <g fill="#221000" opacity="0.6">
+    <circle cx="178" cy="135" r="2"/>
+    <circle cx="178" cy="145" r="2"/>
+    <circle cx="222" cy="135" r="2"/>
+    <circle cx="222" cy="145" r="2"/>
+  </g>
+  <!-- Volcanic ore inlaid on chest — glowing seams -->
+  <g stroke="#a03018" stroke-width="1" fill="none" opacity="0.45">
+    <path d="M178,155 L190,148 L200,152 L210,148 L222,155"/>
+    <path d="M178,165 L190,158 L200,162 L210,158 L222,165"/>
+  </g>
+  <!-- Command insignia — forged iron mountain symbol -->
+  <polygon points="200,140 206,152 200,158 194,152" fill="#281400" stroke="#401800" stroke-width="0.8"/>
+  <circle cx="200" cy="149" r="3" fill="#401800" opacity="0.7"/>
+
+  <!-- PAULDRONS — huge, multi-layered, smoking -->
+  <!-- Left pauldron -->
+  <path d="M168,132 Q138,122 128,145 Q124,168 146,175 L168,168" fill="#1a0900" stroke="#2a1600" stroke-width="1.5"/>
+  <!-- Pauldron edge rims -->
+  <g stroke="#221200" stroke-width="1" fill="#140800" opacity="0.7">
+    <rect x="134" y="148" width="22" height="7" rx="1"/>
+    <rect x="130" y="158" width="22" height="7" rx="1"/>
+    <rect x="134" y="168" width="20" height="6" rx="1"/>
+  </g>
+  <!-- Lava vent crack on pauldron -->
+  <path d="M140,155 Q138,160 141,165" stroke="#c03018" stroke-width="1.5" fill="none" opacity="0.6"/>
+
+  <!-- Right pauldron -->
+  <path d="M232,132 Q262,122 272,145 Q276,168 254,175 L232,168" fill="#1a0900" stroke="#2a1600" stroke-width="1.5"/>
+  <g stroke="#221200" stroke-width="1" fill="#140800" opacity="0.7">
+    <rect x="244" y="148" width="22" height="7" rx="1"/>
+    <rect x="248" y="158" width="22" height="7" rx="1"/>
+    <rect x="246" y="168" width="20" height="6" rx="1"/>
+  </g>
+  <path d="M260,155 Q262,160 259,165" stroke="#c03018" stroke-width="1.5" fill="none" opacity="0.6"/>
+
+  <!-- Right arm — holding volcanic war axe -->
+  <line x1="254" y1="155" x2="278" y2="192" stroke="#1a0900" stroke-width="12" stroke-linecap="round"/>
+  <!-- Gauntlet right -->
+  <ellipse cx="282" cy="196" rx="9" ry="8" fill="#160800" stroke="#221200" stroke-width="1"/>
+  <!-- War axe handle -->
+  <line x1="282" y1="202" x2="286" y2="240" stroke="#1e1000" stroke-width="5"/>
+  <!-- Axe head -->
+  <polygon points="275,200 295,195 298,215 272,218" fill="#180a00" stroke="#281400" stroke-width="1"/>
+  <!-- Axe lava crack -->
+  <path d="M278,205 Q283,208 280,215" stroke="#c03018" stroke-width="1.2" fill="none" opacity="0.7"/>
+
+  <!-- Left arm — raised fist -->
+  <line x1="146" y1="155" x2="122" y2="188" stroke="#1a0900" stroke-width="12" stroke-linecap="round"/>
+  <!-- Gauntlet left -->
+  <ellipse cx="118" cy="192" rx="9" ry="8" fill="#160800" stroke="#221200" stroke-width="1"/>
+
+  <!-- Neck gorget — high, protective -->
+  <rect x="186" y="120" width="28" height="14" rx="2" fill="#180900" stroke="#281400" stroke-width="1"/>
+
+  <!-- HELM — full great helm with forged crest -->
+  <!-- Helm base -->
+  <path d="M172,100 Q172,70 200,67 Q228,70 228,100 L228,122 Q200,128 172,122 Z" fill="#1a0900" stroke="#2a1600" stroke-width="1.5"/>
+  <!-- Helm ridge crest -->
+  <rect x="197" y="48" width="6" height="22" rx="1" fill="#160900" stroke="#221200" stroke-width="0.8"/>
+  <polygon points="194,48 206,48 203,38 197,36 191,38" fill="#1c0a00" stroke="#2a1400" stroke-width="0.8"/>
+  <!-- Crest lava marking -->
+  <line x1="200" y1="38" x2="200" y2="65" stroke="#a02010" stroke-width="0.8" opacity="0.6"/>
+  <!-- T-shaped visor -->
+  <rect x="180" y="91" width="40" height="9" rx="1" fill="#0e0600" stroke="#181000" stroke-width="0.8"/>
+  <rect x="196" y="85" width="8"  height="22" rx="1" fill="#0e0600" stroke="#181000" stroke-width="0.8"/>
+  <!-- EYE GLOW — volcanic fire, amber-orange -->
+  <radialGradient id="eye-cl" cx="30%" cy="50%" r="60%">
+    <stop offset="0%" stop-color="#e06010"/>
+    <stop offset="55%" stop-color="#901808" stop-opacity="0.7"/>
+    <stop offset="100%" stop-color="#901808" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="eye-cr" cx="70%" cy="50%" r="60%">
+    <stop offset="0%" stop-color="#e06010"/>
+    <stop offset="55%" stop-color="#901808" stop-opacity="0.7"/>
+    <stop offset="100%" stop-color="#901808" stop-opacity="0"/>
+  </radialGradient>
+  <rect x="180" y="91" width="40" height="9" rx="1" fill="url(#eye-cl)" opacity="0.85"/>
+  <!-- Fire eye gleams -->
+  <ellipse cx="188" cy="95" rx="5" ry="3" fill="#f08030" opacity="0.9"/>
+  <ellipse cx="212" cy="95" rx="5" ry="3" fill="#f08030" opacity="0.9"/>
+  <circle cx="187" cy="94" r="2" fill="#ffe040" opacity="0.9"/>
+  <circle cx="211" cy="94" r="2" fill="#ffe040" opacity="0.9"/>
+  <!-- Helm brow ridge — heavy -->
+  <path d="M172,95 Q200,88 228,95" stroke="#281600" stroke-width="2.5" fill="none" opacity="0.7"/>
+  <!-- Helm cheek plates -->
+  <path d="M172,102 Q168,112 170,122" stroke="#221200" stroke-width="2" fill="none"/>
+  <path d="M228,102 Q232,112 230,122" stroke="#221200" stroke-width="2" fill="none"/>
+
+  <!-- Vignette -->
+  <radialGradient id="vign-cw2" cx="50%" cy="50%" r="65%">
+    <stop offset="0%" stop-color="#000000" stop-opacity="0"/>
+    <stop offset="100%" stop-color="#000000" stop-opacity="0.72"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#vign-cw2)"/>
+
+  <!-- Label -->
+  <text x="200" y="232" font-family="monospace" font-size="9" fill="#281008" text-anchor="middle" letter-spacing="3">THE CINDERWARLORD</text>
+</svg>

--- a/web/src/data/acts/act7.json
+++ b/web/src/data/acts/act7.json
@@ -564,6 +564,10 @@
       "opponentBaseHp": 260,
       "bossAI": "cinderwarlord",
       "environment": "volcano",
+      "bossIntro": [
+        {"title": "THE EMBERFALL CALDERA", "image": "cutscenes/act7-boss-1.svg", "text": "The Emberfall Caldera is the Cinderwarlord's seat of power — a volcanic command post built above an active lava lake, its bridge spanning the heat of eleven years of unbroken authority. The mountains do what he tells them."},
+        {"title": "THE CINDERWARLORD", "image": "cutscenes/act7-boss-2.svg", "text": "The Cinderwarlord has held the caldera for eleven years. His forge-plate armour runs with active lava seams. His eyes burn with command-fire. He has never lost a defensive position, and he does not intend to start this afternoon."}
+      ],
       "bossDialogue": [
         "You walked through my mountains. I respect that. I'm still going to end this.",
         "The volcanoes do what I tell them. You should factor that into your strategy.",


### PR DESCRIPTION
Closes #863

## Summary
- `act7-boss-1.svg` — The Emberfall Caldera: volcanic command post with lava lake, chain-rail bridge spanning the caldera, ash clouds lit orange from below
- `act7-boss-2.svg` — The Cinderwarlord: massive forge-plate armour with active lava seam cracks, T-visor great helm with amber-orange fire eye glow, war axe
- `bossIntro` JSON wired into the `cinderwarlord` boss node in `act7.json`

https://claude.ai/code/session_01QjAWeyHiDWwKa8oZQFU7yn

---
_Generated by [Claude Code](https://claude.ai/code/session_01QjAWeyHiDWwKa8oZQFU7yn)_