### PR TITLE
Add boss intro cutscenes for Act X — The Dune Baron (#866)

### DIFF
--- a/web/public/cutscenes/act10-boss-1.svg
+++ b/web/public/cutscenes/act10-boss-1.svg
@@ -1,0 +1,162 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
+  <rect width="400" height="240" fill="#100c06"/>
+  <linearGradient id="sand-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#120e08"/>
+    <stop offset="40%" stop-color="#180e06"/>
+    <stop offset="100%" stop-color="#201408"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#sand-sky)"/>
+
+  <!-- Desert heat glow — warm amber baking upward -->
+  <radialGradient id="sand-glow" cx="50%" cy="68%" r="60%">
+    <stop offset="0%" stop-color="#704818" stop-opacity="0.45"/>
+    <stop offset="50%" stop-color="#483010" stop-opacity="0.2"/>
+    <stop offset="100%" stop-color="#483010" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#sand-glow)"/>
+
+  <!-- Stars in the desert sky — sparse, clear night -->
+  <g fill="#c0a060" opacity="0.25">
+    <circle cx="42"  cy="18" r="0.8"/>
+    <circle cx="88"  cy="28" r="1"/>
+    <circle cx="135" cy="12" r="0.8"/>
+    <circle cx="178" cy="22" r="0.7"/>
+    <circle cx="220" cy="8"  r="1"/>
+    <circle cx="258" cy="20" r="0.8"/>
+    <circle cx="305" cy="14" r="0.8"/>
+    <circle cx="355" cy="25" r="0.7"/>
+    <circle cx="390" cy="10" r="0.8"/>
+    <circle cx="68"  cy="45" r="0.7"/>
+    <circle cx="330" cy="40" r="0.7"/>
+  </g>
+
+  <!-- THE SAND MARKET — vast mercantile citadel -->
+  <!-- Distant sand dunes horizon -->
+  <path d="M0,115 Q50,100 120,108 Q180,95 240,105 Q300,92 380,102 L400,110 L400,240 L0,240 Z" fill="#1a1008"/>
+  <!-- Dune highlight ridge -->
+  <path d="M0,115 Q50,100 120,108 Q180,95 240,105 Q300,92 380,102 L400,110" stroke="#281808" stroke-width="1" fill="none" opacity="0.5"/>
+
+  <!-- Market towers — left cluster -->
+  <g fill="#141008" stroke="#201408" stroke-width="1">
+    <rect x="30"  y="88" width="28" height="87"/>
+    <rect x="62"  y="100" width="22" height="75"/>
+    <rect x="18"  y="105" width="18" height="70"/>
+  </g>
+  <!-- Left tower domes / tops -->
+  <ellipse cx="44"  cy="86" rx="16" ry="7" fill="#181208" stroke="#241808" stroke-width="0.8"/>
+  <ellipse cx="73"  cy="98" rx="12" ry="6" fill="#181208" stroke="#241808" stroke-width="0.8"/>
+  <!-- Left tower lantern glow -->
+  <g fill="#906020" opacity="0.35">
+    <circle cx="44" cy="85" r="5"/>
+    <circle cx="73" cy="97" r="4"/>
+  </g>
+  <!-- Left tower windows -->
+  <g fill="#806030" opacity="0.4">
+    <rect x="38"  y="100" width="6" height="9" rx="2"/>
+    <rect x="48"  y="100" width="6" height="9" rx="2"/>
+    <rect x="38"  y="118" width="6" height="9" rx="2"/>
+    <rect x="65"  y="112" width="5" height="8" rx="2"/>
+  </g>
+
+  <!-- Market towers — right cluster -->
+  <g fill="#141008" stroke="#201408" stroke-width="1">
+    <rect x="350" y="90" width="28" height="85"/>
+    <rect x="316" y="102" width="22" height="73"/>
+    <rect x="362" y="108" width="18" height="67"/>
+  </g>
+  <ellipse cx="364" cy="88" rx="16" ry="7" fill="#181208" stroke="#241808" stroke-width="0.8"/>
+  <ellipse cx="327" cy="100" rx="12" ry="6" fill="#181208" stroke="#241808" stroke-width="0.8"/>
+  <g fill="#906020" opacity="0.35">
+    <circle cx="364" cy="87" r="5"/>
+    <circle cx="327" cy="99" r="4"/>
+  </g>
+  <g fill="#806030" opacity="0.4">
+    <rect x="358" y="102" width="6" height="9" rx="2"/>
+    <rect x="368" y="102" width="6" height="9" rx="2"/>
+    <rect x="358" y="120" width="6" height="9" rx="2"/>
+    <rect x="320" y="114" width="5" height="8" rx="2"/>
+  </g>
+
+  <!-- Central SAND MARKET entrance — grand, ornate -->
+  <!-- Market gate towers -->
+  <rect x="142" y="70" width="36" height="105" fill="#151008" stroke="#221608" stroke-width="1.5"/>
+  <rect x="222" y="70" width="36" height="105" fill="#151008" stroke="#221608" stroke-width="1.5"/>
+  <!-- Tower domes -->
+  <ellipse cx="160" cy="68" rx="20" ry="10" fill="#1a1208" stroke="#282008" stroke-width="1"/>
+  <ellipse cx="240" cy="68" rx="20" ry="10" fill="#1a1208" stroke="#282008" stroke-width="1"/>
+  <!-- Dome finials -->
+  <line x1="160" y1="52" x2="160" y2="64" stroke="#281808" stroke-width="2"/>
+  <polygon points="156,52 164,52 160,44" fill="#201408"/>
+  <line x1="240" y1="52" x2="240" y2="64" stroke="#281808" stroke-width="2"/>
+  <polygon points="236,52 244,52 240,44" fill="#201408"/>
+  <!-- Dome lantern glows -->
+  <radialGradient id="dome-l" cx="50%" cy="60%" r="60%">
+    <stop offset="0%" stop-color="#c08030" stop-opacity="0.5"/>
+    <stop offset="100%" stop-color="#c08030" stop-opacity="0"/>
+  </radialGradient>
+  <ellipse cx="160" cy="67" rx="15" ry="8" fill="url(#dome-l)"/>
+  <ellipse cx="240" cy="67" rx="15" ry="8" fill="url(#dome-l)"/>
+  <!-- Gate tower windows -->
+  <g fill="#c08030" opacity="0.35">
+    <rect x="150" y="82"  width="8" height="14" rx="2"/>
+    <rect x="163" y="82"  width="8" height="14" rx="2"/>
+    <rect x="150" y="105" width="8" height="14" rx="2"/>
+    <rect x="163" y="105" width="8" height="14" rx="2"/>
+    <rect x="230" y="82"  width="8" height="14" rx="2"/>
+    <rect x="243" y="82"  width="8" height="14" rx="2"/>
+    <rect x="230" y="105" width="8" height="14" rx="2"/>
+    <rect x="243" y="105" width="8" height="14" rx="2"/>
+  </g>
+
+  <!-- Grand gate arch -->
+  <path d="M178,175 L178,118 Q178,100 200,97 Q222,100 222,118 L222,175" fill="#0e0c06" stroke="#1e1608" stroke-width="2"/>
+  <!-- Arch decorative border -->
+  <path d="M180,120 Q180,104 200,101 Q220,104 220,120" stroke="#302010" stroke-width="1.5" fill="none" opacity="0.7"/>
+  <!-- Gate light beyond arch -->
+  <radialGradient id="gate-sand" cx="50%" cy="75%" r="40%">
+    <stop offset="0%" stop-color="#c08020" stop-opacity="0.2"/>
+    <stop offset="100%" stop-color="#c08020" stop-opacity="0"/>
+  </radialGradient>
+  <rect x="178" y="97" width="44" height="78" fill="url(#gate-sand)"/>
+  <!-- Gate market banner -->
+  <rect x="188" y="90" width="24" height="14" rx="1" fill="#1e1408" stroke="#2c2010" stroke-width="0.8"/>
+  <!-- Banner gold accent -->
+  <path d="M191,93 L197,90 L200,96 L203,90 L209,93" stroke="#806020" stroke-width="0.8" fill="none" opacity="0.6"/>
+
+  <!-- Market stalls in foreground -->
+  <!-- Left stall canopy -->
+  <path d="M95,175 L95,155 L145,155 L145,175" fill="#120e06" stroke="#1e1608" stroke-width="1"/>
+  <path d="M92,158 L148,158" stroke="#201808" stroke-width="2" opacity="0.8"/>
+  <!-- Stall goods piles (silhouette) -->
+  <g fill="#0e0c06" opacity="0.7">
+    <ellipse cx="105" cy="175" rx="8"  ry="5"/>
+    <ellipse cx="125" cy="175" rx="10" ry="4"/>
+    <ellipse cx="140" cy="175" rx="6"  ry="4"/>
+  </g>
+  <!-- Right stall canopy -->
+  <path d="M255,175 L255,155 L305,155 L305,175" fill="#120e06" stroke="#1e1608" stroke-width="1"/>
+  <path d="M252,158 L308,158" stroke="#201808" stroke-width="2" opacity="0.8"/>
+  <g fill="#0e0c06" opacity="0.7">
+    <ellipse cx="265" cy="175" rx="8"  ry="5"/>
+    <ellipse cx="280" cy="175" rx="10" ry="4"/>
+    <ellipse cx="298" cy="175" rx="6"  ry="4"/>
+  </g>
+
+  <!-- Sand ground — drifted -->
+  <rect x="0" y="175" width="400" height="65" fill="#181008"/>
+  <g fill="#201408" opacity="0.4">
+    <ellipse cx="80"  cy="185" rx="55" ry="6"/>
+    <ellipse cx="220" cy="190" rx="70" ry="7"/>
+    <ellipse cx="340" cy="183" rx="50" ry="6"/>
+  </g>
+
+  <!-- Vignette -->
+  <radialGradient id="vign-sm" cx="50%" cy="50%" r="68%">
+    <stop offset="0%" stop-color="#000000" stop-opacity="0"/>
+    <stop offset="100%" stop-color="#000000" stop-opacity="0.65"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#vign-sm)"/>
+
+  <!-- Label -->
+  <text x="200" y="232" font-family="monospace" font-size="9" fill="#281808" text-anchor="middle" letter-spacing="3">THE SAND MARKET</text>
+</svg>

--- a/web/public/cutscenes/act10-boss-2.svg
+++ b/web/public/cutscenes/act10-boss-2.svg
@@ -1,0 +1,168 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
+  <rect width="400" height="240" fill="#100c06"/>
+
+  <!-- Desert merchant hall atmosphere -->
+  <radialGradient id="db-atm" cx="50%" cy="55%" r="60%">
+    <stop offset="0%" stop-color="#201408" stop-opacity="0.75"/>
+    <stop offset="65%" stop-color="#140e06" stop-opacity="0.4"/>
+    <stop offset="100%" stop-color="#100c06" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#db-atm)"/>
+
+  <!-- Gold eye glow -->
+  <radialGradient id="db-eyes" cx="50%" cy="40%" r="22%">
+    <stop offset="0%" stop-color="#d09020" stop-opacity="0.55"/>
+    <stop offset="45%" stop-color="#906010" stop-opacity="0.22"/>
+    <stop offset="100%" stop-color="#906010" stop-opacity="0"/>
+  </radialGradient>
+  <ellipse cx="200" cy="97" rx="65" ry="42" fill="url(#db-eyes)"/>
+
+  <!-- Lantern light — warm amber from above -->
+  <radialGradient id="db-lantern" cx="50%" cy="20%" r="40%">
+    <stop offset="0%" stop-color="#c08030" stop-opacity="0.25"/>
+    <stop offset="100%" stop-color="#c08030" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#db-lantern)"/>
+
+  <!-- Background market hall — ornate pillars -->
+  <g fill="#140e08" stroke="#201408" stroke-width="1" opacity="0.7">
+    <rect x="0"   y="0" width="80"  height="240"/>
+    <rect x="320" y="0" width="80"  height="240"/>
+  </g>
+  <!-- Pillar decorative bands -->
+  <g stroke="#281808" stroke-width="0.8" fill="none" opacity="0.4">
+    <line x1="0"   y1="60"  x2="80"  y2="60"/>
+    <line x1="0"   y1="120" x2="80"  y2="120"/>
+    <line x1="0"   y1="180" x2="80"  y2="180"/>
+    <line x1="320" y1="60"  x2="400" y2="60"/>
+    <line x1="320" y1="120" x2="400" y2="120"/>
+    <line x1="320" y1="180" x2="400" y2="180"/>
+  </g>
+  <!-- Hanging lanterns -->
+  <g fill="#c08030" opacity="0.3">
+    <circle cx="40"  cy="18" r="5"/>
+    <circle cx="360" cy="18" r="5"/>
+    <circle cx="200" cy="15" r="6"/>
+  </g>
+  <!-- Lantern chains -->
+  <g stroke="#201408" stroke-width="1" opacity="0.5">
+    <line x1="40"  y1="0"  x2="40"  y2="18"/>
+    <line x1="360" y1="0"  x2="360" y2="18"/>
+    <line x1="200" y1="0"  x2="200" y2="15"/>
+  </g>
+
+  <!-- Goods stacked in background — crates, urns, draped silks -->
+  <g fill="#120e06" stroke="#1e1408" stroke-width="0.5" opacity="0.6">
+    <rect x="88"  y="180" width="30" height="20" rx="1"/>
+    <rect x="92"  y="168" width="22" height="14" rx="1"/>
+    <rect x="282" y="182" width="30" height="18" rx="1"/>
+    <rect x="286" y="170" width="22" height="14" rx="1"/>
+  </g>
+  <!-- Silk drape left -->
+  <path d="M82,60 Q88,90 85,120 Q83,150 88,180" stroke="#281808" stroke-width="4" fill="none" opacity="0.4"/>
+  <!-- Silk drape right -->
+  <path d="M318,60 Q312,90 315,120 Q317,150 312,180" stroke="#281808" stroke-width="4" fill="none" opacity="0.4"/>
+
+  <!-- THE DUNE BARON — merchant lord, draped in wealth -->
+  <!-- Floor shadow -->
+  <ellipse cx="200" cy="228" rx="52" ry="8" fill="#060402" opacity="0.6"/>
+
+  <!-- Robe / kaftan — layers of rich fabric -->
+  <!-- Outer kaftan robe -->
+  <polygon points="166,145 234,145 240,230 160,230" fill="#181008" stroke="#281808" stroke-width="1.2"/>
+  <!-- Inner robe — lighter sand colour -->
+  <polygon points="178,148 222,148 228,228 172,228" fill="#1c1208" stroke="#241808" stroke-width="0.8"/>
+  <!-- Robe hem — gold embroidery -->
+  <g stroke="#806020" stroke-width="1" fill="none" opacity="0.4">
+    <path d="M164,210 L171,204 L178,210 L185,204 L192,210 L199,204 L206,210 L213,204 L220,210 L227,204 L234,210 L240,210"/>
+    <path d="M164,220 L171,214 L178,220 L185,214 L192,220 L199,214 L206,220 L213,214 L220,220 L227,214 L234,220"/>
+  </g>
+  <!-- Sash / belt — broad, merchant gold -->
+  <rect x="174" y="172" width="52" height="10" rx="1" fill="#1e1408" stroke="#806020" stroke-width="1"/>
+  <!-- Belt clasp — large, ostentatious -->
+  <rect x="195" y="170" width="10" height="14" rx="1" fill="#c08020" opacity="0.6"/>
+  <circle cx="200" cy="177" r="4" fill="#e0a030" opacity="0.55"/>
+
+  <!-- Arms — draped in broad sleeves -->
+  <!-- Left arm — gesturing open -->
+  <line x1="170" y1="155" x2="142" y2="182" stroke="#181008" stroke-width="10" stroke-linecap="round"/>
+  <!-- Left hand with gold rings -->
+  <ellipse cx="138" cy="186" rx="8" ry="6" fill="#1a1008" stroke="#241808" stroke-width="0.8"/>
+  <g fill="#c08020" opacity="0.5">
+    <circle cx="134" cy="184" r="1.5"/>
+    <circle cx="140" cy="183" r="1.5"/>
+    <circle cx="143" cy="187" r="1.5"/>
+  </g>
+
+  <!-- Right arm — holds scales / ledger -->
+  <line x1="230" y1="155" x2="258" y2="178" stroke="#181008" stroke-width="10" stroke-linecap="round"/>
+  <!-- Right hand -->
+  <ellipse cx="262" cy="182" rx="8" ry="6" fill="#1a1008" stroke="#241808" stroke-width="0.8"/>
+  <!-- Merchant scales in right hand -->
+  <line x1="262" y1="178" x2="262" y2="164" stroke="#281808" stroke-width="1.5"/>
+  <line x1="254" y1="164" x2="270" y2="164" stroke="#c08020" stroke-width="1.5" opacity="0.7"/>
+  <!-- Scale pans -->
+  <path d="M254,164 Q252,170 256,172 Q258,173 260,172 Q264,170 262,164" stroke="#906010" stroke-width="1" fill="none" opacity="0.6"/>
+  <path d="M270,164 Q272,170 268,172 Q266,173 264,172 Q260,170 262,164" stroke="#906010" stroke-width="1" fill="none" opacity="0.6"/>
+
+  <!-- Neck collar — high, layered -->
+  <rect x="186" y="128" width="28" height="20" rx="2" fill="#181008" stroke="#281808" stroke-width="1"/>
+  <!-- Collar gold trim -->
+  <path d="M188,130 Q200,126 212,130" stroke="#806020" stroke-width="1.2" fill="none" opacity="0.6"/>
+
+  <!-- HEAD — broad, confident, merchant lord -->
+  <!-- Neck -->
+  <rect x="192" y="118" width="16" height="14" rx="1" fill="#181008" stroke="#221408" stroke-width="0.8"/>
+  <!-- Head — round, well-fed, assured -->
+  <ellipse cx="200" cy="104" rx="24" ry="22" fill="#181008" stroke="#241808" stroke-width="1.2"/>
+  <!-- Beard — full, merchant lord beard -->
+  <path d="M180,112 Q185,124 192,128 Q200,132 208,128 Q215,124 220,112" fill="#141008" stroke="#1e1408" stroke-width="0.8"/>
+  <path d="M184,114 Q190,126 200,130 Q210,126 216,114" stroke="#201408" stroke-width="1" fill="none" opacity="0.5"/>
+  <!-- Moustache -->
+  <path d="M188,108 Q194,111 200,110 Q206,111 212,108" stroke="#201408" stroke-width="2" fill="none" opacity="0.7"/>
+  <!-- Brow — prominent, calculating -->
+  <path d="M180,100 Q200,94 220,100" stroke="#201408" stroke-width="2" fill="none" opacity="0.6"/>
+
+  <!-- Eyes — gold, calculating, merchant's eyes -->
+  <ellipse cx="189" cy="103" rx="9" ry="7" fill="#0e0c06"/>
+  <ellipse cx="211" cy="103" rx="9" ry="7" fill="#0e0c06"/>
+  <!-- Eye glow — merchant gold -->
+  <radialGradient id="eye-dbl" cx="50%" cy="50%" r="65%">
+    <stop offset="0%" stop-color="#e0a020"/>
+    <stop offset="55%" stop-color="#906010" stop-opacity="0.7"/>
+    <stop offset="100%" stop-color="#906010" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="eye-dbr" cx="50%" cy="50%" r="65%">
+    <stop offset="0%" stop-color="#e0a020"/>
+    <stop offset="55%" stop-color="#906010" stop-opacity="0.7"/>
+    <stop offset="100%" stop-color="#906010" stop-opacity="0"/>
+  </radialGradient>
+  <ellipse cx="189" cy="103" rx="9" ry="7" fill="url(#eye-dbl)" opacity="0.85"/>
+  <ellipse cx="211" cy="103" rx="9" ry="7" fill="url(#eye-dbr)" opacity="0.85"/>
+  <ellipse cx="189" cy="102" rx="4" ry="3" fill="#f0c040" opacity="0.9"/>
+  <ellipse cx="211" cy="102" rx="4" ry="3" fill="#f0c040" opacity="0.9"/>
+  <circle cx="188" cy="101" r="1.5" fill="#ffe080" opacity="0.95"/>
+  <circle cx="210" cy="101" r="1.5" fill="#ffe080" opacity="0.95"/>
+
+  <!-- Turban / merchant headwear -->
+  <ellipse cx="200" cy="86" rx="26" ry="10" fill="#181008" stroke="#241808" stroke-width="1"/>
+  <ellipse cx="200" cy="84" rx="22" ry="8"  fill="#1c1208" stroke="#282010" stroke-width="0.8"/>
+  <!-- Turban jewel centre -->
+  <circle cx="200" cy="80" r="4" fill="#c08020" opacity="0.5"/>
+  <circle cx="200" cy="80" r="2" fill="#e0b030" opacity="0.6"/>
+  <!-- Turban folds -->
+  <g stroke="#221808" stroke-width="0.6" fill="none" opacity="0.4">
+    <path d="M180,86 Q190,82 200,84 Q210,82 220,86"/>
+    <path d="M184,90 Q192,86 200,88 Q208,86 216,90"/>
+  </g>
+
+  <!-- Vignette -->
+  <radialGradient id="vign-db2" cx="50%" cy="50%" r="65%">
+    <stop offset="0%" stop-color="#000000" stop-opacity="0"/>
+    <stop offset="100%" stop-color="#000000" stop-opacity="0.72"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#vign-db2)"/>
+
+  <!-- Label -->
+  <text x="200" y="232" font-family="monospace" font-size="9" fill="#281808" text-anchor="middle" letter-spacing="3">THE DUNE BARON</text>
+</svg>

--- a/web/src/data/acts/act10.json
+++ b/web/src/data/acts/act10.json
@@ -723,6 +723,10 @@
       "opponentBaseHp": 285,
       "bossAI": "dunebaron",
       "environment": "sand",
+      "bossIntro": [
+        {"title": "THE SAND MARKET", "image": "cutscenes/act10-boss-1.svg", "text": "The Sand Market rises from the desert night — a merchant citadel of domed towers and lantern-lit gate arches, where everything that crosses the Fracture has a price and the Dune Baron sets it."},
+        {"title": "THE DUNE BARON", "image": "cutscenes/act10-boss-2.svg", "text": "The Dune Baron treats this as a transaction. His gold eyes weigh you the way a merchant weighs a questionable coin — measuring worth, calculating risk, deciding the terms. He doesn't lose deals. He renegotiates them."}
+      ],
       "bossDialogue": [
         "Everything has a price. Your passage through my market has one too. This is the negotiation.",
         "I've hired the best. You're fighting the best. Consider it a compliment.",


### PR DESCRIPTION
Closes #866

## Summary
- `act10-boss-1.svg` — The Sand Market: desert night cityscape with domed towers, lantern-lit gate arch, merchant stall canopies
- `act10-boss-2.svg` — The Dune Baron: rotund merchant lord in layered kaftan with turban and jewel, gold eye glow, merchant scales in one hand, gold ring-adorned fingers
- `bossIntro` JSON wired into the `dunebaron` boss node in `act10.json`

https://claude.ai/code/session_01QjAWeyHiDWwKa8oZQFU7yn

---
_Generated by [Claude Code](https://claude.ai/code/session_01QjAWeyHiDWwKa8oZQFU7yn)_