### PR TITLE
Add boss intro cutscenes for Act XII — The Harbormaster (#868)

### DIFF
--- a/web/public/cutscenes/act12-boss-1.svg
+++ b/web/public/cutscenes/act12-boss-1.svg
@@ -1,0 +1,142 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
+  <rect width="400" height="240" fill="#040810"/>
+  <linearGradient id="coast-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#060c18"/>
+    <stop offset="40%" stop-color="#081018"/>
+    <stop offset="100%" stop-color="#0c1420"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#coast-sky)"/>
+
+  <!-- Storm sea glow — dark, cold, maritime -->
+  <radialGradient id="coast-glow" cx="50%" cy="62%" r="55%">
+    <stop offset="0%" stop-color="#1a3050" stop-opacity="0.35"/>
+    <stop offset="50%" stop-color="#101828" stop-opacity="0.15"/>
+    <stop offset="100%" stop-color="#101828" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#coast-glow)"/>
+
+  <!-- Storm clouds — heavy, rolling -->
+  <g fill="#060e18" opacity="0.8">
+    <ellipse cx="60"  cy="25" rx="80" ry="22"/>
+    <ellipse cx="200" cy="18" rx="100" ry="20"/>
+    <ellipse cx="350" cy="28" rx="75" ry="20"/>
+    <ellipse cx="140" cy="42" rx="65" ry="15"/>
+    <ellipse cx="290" cy="38" rx="70" ry="16"/>
+  </g>
+  <!-- Lightning in clouds -->
+  <g stroke="#303858" stroke-width="0.8" fill="none" opacity="0.4">
+    <path d="M75,25 L72,35 L78,35 L74,48"/>
+    <path d="M315,22 L312,32 L318,32 L313,46"/>
+  </g>
+
+  <!-- THE SHATTERED COAST — ruined harbour infrastructure -->
+  <!-- Left sea wall ruins -->
+  <g fill="#080c14" stroke="#101828" stroke-width="1" opacity="0.8">
+    <rect x="0"  y="100" width="45" height="140"/>
+    <rect x="28" y="88"  width="25" height="155"/>
+  </g>
+  <!-- Wall battlements -->
+  <g fill="#0a0e16" stroke="#101828" stroke-width="0.8">
+    <rect x="0"  y="94"  width="8" height="10"/>
+    <rect x="12" y="94"  width="8" height="10"/>
+    <rect x="24" y="94"  width="8" height="10"/>
+    <rect x="28" y="82"  width="8" height="10"/>
+    <rect x="38" y="82"  width="8" height="10"/>
+  </g>
+  <!-- Cannon on wall -->
+  <rect x="18" y="100" width="18" height="6" rx="1" fill="#080c12" stroke="#141e28" stroke-width="0.8"/>
+  <!-- Wall signal lantern -->
+  <circle cx="20" cy="90" r="3" fill="#4060a0" opacity="0.5"/>
+
+  <!-- Right sea wall ruins -->
+  <g fill="#080c14" stroke="#101828" stroke-width="1" opacity="0.8">
+    <rect x="355" y="100" width="45" height="140"/>
+    <rect x="347" y="88"  width="25" height="155"/>
+  </g>
+  <g fill="#0a0e16" stroke="#101828" stroke-width="0.8">
+    <rect x="355" y="94" width="8" height="10"/>
+    <rect x="367" y="94" width="8" height="10"/>
+    <rect x="379" y="94" width="8" height="10"/>
+    <rect x="347" y="82" width="8" height="10"/>
+    <rect x="359" y="82" width="8" height="10"/>
+  </g>
+  <rect x="364" y="100" width="18" height="6" rx="1" fill="#080c12" stroke="#141e28" stroke-width="0.8"/>
+  <circle cx="380" cy="90" r="3" fill="#4060a0" opacity="0.5"/>
+
+  <!-- HARBOUR GATE — great chain boom across the entrance -->
+  <!-- Gate towers -->
+  <rect x="85"  y="82" width="35" height="118" fill="#090c16" stroke="#101828" stroke-width="1.5"/>
+  <rect x="280" y="82" width="35" height="118" fill="#090c16" stroke="#101828" stroke-width="1.5"/>
+  <!-- Tower tops battlemented -->
+  <g fill="#0b0e18" stroke="#101828" stroke-width="0.8">
+    <rect x="85"  y="75" width="8" height="10"/>
+    <rect x="97"  y="75" width="8" height="10"/>
+    <rect x="109" y="75" width="8" height="10"/>
+    <rect x="280" y="75" width="8" height="10"/>
+    <rect x="292" y="75" width="8" height="10"/>
+    <rect x="304" y="75" width="8" height="10"/>
+  </g>
+  <!-- Tower signal fires -->
+  <radialGradient id="sig1" cx="50%" cy="40%" r="60%">
+    <stop offset="0%" stop-color="#3060a0" stop-opacity="0.5"/>
+    <stop offset="100%" stop-color="#3060a0" stop-opacity="0"/>
+  </radialGradient>
+  <ellipse cx="103" cy="74" rx="10" ry="8" fill="url(#sig1)"/>
+  <ellipse cx="297" cy="74" rx="10" ry="8" fill="url(#sig1)"/>
+
+  <!-- CHAIN BOOM across the harbour entrance -->
+  <!-- Chain links -->
+  <g stroke="#182030" stroke-width="3" fill="none" opacity="0.8">
+    <path d="M120,155 Q160,148 200,150 Q240,148 280,155"/>
+  </g>
+  <g stroke="#202838" stroke-width="1.5" fill="none" opacity="0.5">
+    <path d="M120,155 Q160,148 200,150 Q240,148 280,155"/>
+  </g>
+  <!-- Chain link detail marks -->
+  <g fill="#182030" opacity="0.6">
+    <circle cx="140" cy="151" r="3"/>
+    <circle cx="160" cy="149" r="3"/>
+    <circle cx="180" cy="150" r="3"/>
+    <circle cx="200" cy="150" r="3"/>
+    <circle cx="220" cy="150" r="3"/>
+    <circle cx="240" cy="149" r="3"/>
+    <circle cx="260" cy="151" r="3"/>
+  </g>
+  <!-- Chain anchor cleats on towers -->
+  <rect x="116" y="150" width="8" height="12" rx="1" fill="#0c1018" stroke="#182030" stroke-width="0.8"/>
+  <rect x="276" y="150" width="8" height="12" rx="1" fill="#0c1018" stroke="#182030" stroke-width="0.8"/>
+
+  <!-- Harbour water — dark, choppy -->
+  <rect x="55" y="175" width="290" height="65" fill="#070a10"/>
+  <!-- Wave lines -->
+  <g stroke="#0e1828" stroke-width="1" fill="none" opacity="0.5">
+    <path d="M55,185 Q90,180 130,183 Q170,186 210,182 Q250,178 290,182 Q310,184 345,180"/>
+    <path d="M55,198 Q90,193 130,196 Q170,199 210,195 Q250,191 290,195 Q310,197 345,193"/>
+    <path d="M55,212 Q90,207 130,210 Q170,213 210,209 Q250,205 290,209 Q310,211 345,207"/>
+  </g>
+
+  <!-- Wrecked ships -->
+  <!-- Left wreck -->
+  <path d="M72,175 Q85,168 105,170 Q120,172 125,178 L72,178 Z" fill="#070a10" stroke="#0e1828" stroke-width="0.8" opacity="0.8"/>
+  <line x1="95" y1="165" x2="95" y2="148" stroke="#0c1420" stroke-width="2" opacity="0.6"/>
+  <!-- Right wreck -->
+  <path d="M278,175 Q295,168 315,170 Q330,172 335,178 L278,178 Z" fill="#070a10" stroke="#0e1828" stroke-width="0.8" opacity="0.8"/>
+  <line x1="310" y1="165" x2="310" y2="148" stroke="#0c1420" stroke-width="2" opacity="0.6"/>
+
+  <!-- Coastline approach road -->
+  <rect x="0" y="215" width="400" height="25" fill="#060810"/>
+  <g fill="#0a0e14" opacity="0.4">
+    <ellipse cx="100" cy="222" rx="55" ry="5"/>
+    <ellipse cx="300" cy="220" rx="55" ry="5"/>
+  </g>
+
+  <!-- Vignette -->
+  <radialGradient id="vign-hm1" cx="50%" cy="50%" r="68%">
+    <stop offset="0%" stop-color="#000000" stop-opacity="0"/>
+    <stop offset="100%" stop-color="#000000" stop-opacity="0.65"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#vign-hm1)"/>
+
+  <!-- Label -->
+  <text x="200" y="232" font-family="monospace" font-size="9" fill="#182030" text-anchor="middle" letter-spacing="3">THE SHATTERED COAST</text>
+</svg>

--- a/web/public/cutscenes/act12-boss-2.svg
+++ b/web/public/cutscenes/act12-boss-2.svg
@@ -1,0 +1,186 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
+  <rect width="400" height="240" fill="#040810"/>
+
+  <!-- Iron maritime atmosphere -->
+  <radialGradient id="hm-atm" cx="50%" cy="55%" r="60%">
+    <stop offset="0%" stop-color="#0c1828" stop-opacity="0.75"/>
+    <stop offset="65%" stop-color="#081020" stop-opacity="0.4"/>
+    <stop offset="100%" stop-color="#040810" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#hm-atm)"/>
+
+  <!-- Cold sea eye glow -->
+  <radialGradient id="hm-eyes" cx="50%" cy="40%" r="22%">
+    <stop offset="0%" stop-color="#3060a0" stop-opacity="0.55"/>
+    <stop offset="45%" stop-color="#1a3060" stop-opacity="0.22"/>
+    <stop offset="100%" stop-color="#1a3060" stop-opacity="0"/>
+  </radialGradient>
+  <ellipse cx="200" cy="97" rx="65" ry="42" fill="url(#hm-eyes)"/>
+
+  <!-- Storm light from above -->
+  <radialGradient id="hm-storm" cx="50%" cy="12%" r="40%">
+    <stop offset="0%" stop-color="#203060" stop-opacity="0.2"/>
+    <stop offset="100%" stop-color="#203060" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#hm-storm)"/>
+
+  <!-- Stone harbour wall background -->
+  <g fill="#080c14" stroke="#0e1828" stroke-width="0.5" opacity="0.5">
+    <rect x="0"   y="0" width="85"  height="240"/>
+    <rect x="315" y="0" width="85"  height="240"/>
+  </g>
+  <!-- Wall courses -->
+  <g stroke="#0c1420" stroke-width="0.6" fill="none" opacity="0.4">
+    <line x1="0"   y1="50"  x2="85"  y2="50"/>
+    <line x1="0"   y1="100" x2="85"  y2="100"/>
+    <line x1="0"   y1="150" x2="85"  y2="150"/>
+    <line x1="315" y1="50"  x2="400" y2="50"/>
+    <line x1="315" y1="100" x2="400" y2="100"/>
+    <line x1="315" y1="150" x2="400" y2="150"/>
+  </g>
+  <!-- Mounted cannon silhouettes -->
+  <g fill="#060a10" stroke="#0c1420" stroke-width="0.8" opacity="0.5">
+    <rect x="10"  y="92" width="25" height="8" rx="1"/>
+    <rect x="315" y="92" width="25" height="8" rx="1"/>
+  </g>
+
+  <!-- THE HARBORMASTER — iron admiral, imposing naval commander -->
+  <!-- Floor shadow -->
+  <ellipse cx="200" cy="228" rx="52" ry="8" fill="#020408" opacity="0.65"/>
+
+  <!-- Legs — naval uniform trousers, heavy boots -->
+  <rect x="182" y="188" width="14" height="38" rx="1" fill="#0a1020" stroke="#141e2e" stroke-width="1"/>
+  <rect x="204" y="188" width="14" height="38" rx="1" fill="#0a1020" stroke="#141e2e" stroke-width="1"/>
+  <!-- Boot tops — tall maritime boots -->
+  <rect x="179" y="210" width="20" height="16" rx="1" fill="#080c18" stroke="#121e28" stroke-width="0.8"/>
+  <rect x="201" y="210" width="20" height="16" rx="1" fill="#080c18" stroke="#121e28" stroke-width="0.8"/>
+
+  <!-- Officer frock coat — naval, long, double-breasted -->
+  <!-- Main coat body -->
+  <polygon points="170,138 230,138 235,230 165,230" fill="#090e1c" stroke="#121e2e" stroke-width="1.2"/>
+  <!-- Double-breast buttons — gold -->
+  <g fill="#c09020" opacity="0.45">
+    <circle cx="192" cy="148" r="2"/>
+    <circle cx="192" cy="160" r="2"/>
+    <circle cx="192" cy="172" r="2"/>
+    <circle cx="192" cy="184" r="2"/>
+    <circle cx="208" cy="148" r="2"/>
+    <circle cx="208" cy="160" r="2"/>
+    <circle cx="208" cy="172" r="2"/>
+    <circle cx="208" cy="184" r="2"/>
+  </g>
+  <!-- Coat lapels -->
+  <path d="M185,138 L178,152 L185,160" stroke="#141e2e" stroke-width="1" fill="none" opacity="0.7"/>
+  <path d="M215,138 L222,152 L215,160" stroke="#141e2e" stroke-width="1" fill="none" opacity="0.7"/>
+  <!-- Coat skirt vent -->
+  <line x1="200" y1="192" x2="200" y2="228" stroke="#0c1828" stroke-width="1.5" opacity="0.5"/>
+  <!-- Sash and rank device -->
+  <rect x="175" y="170" width="50" height="8" rx="1" fill="#0e1828" stroke="#203860" stroke-width="1"/>
+  <!-- Admiral rank insignia -->
+  <g fill="#c09020" opacity="0.35">
+    <polygon points="200,168 204,174 200,180 196,174"/>
+    <circle cx="200" cy="174" r="2.5"/>
+  </g>
+
+  <!-- Epaulettes — naval rank, broad fringed -->
+  <!-- Left epaulette -->
+  <ellipse cx="163" cy="140" rx="18" ry="8" fill="#0a1020" stroke="#182840" stroke-width="1"/>
+  <g stroke="#c09020" stroke-width="0.8" fill="none" opacity="0.3">
+    <line x1="148" y1="148" x2="148" y2="155"/>
+    <line x1="153" y1="148" x2="153" y2="157"/>
+    <line x1="158" y1="148" x2="158" y2="158"/>
+    <line x1="163" y1="148" x2="163" y2="158"/>
+    <line x1="168" y1="148" x2="168" y2="157"/>
+    <line x1="173" y1="148" x2="173" y2="155"/>
+  </g>
+  <!-- Right epaulette -->
+  <ellipse cx="237" cy="140" rx="18" ry="8" fill="#0a1020" stroke="#182840" stroke-width="1"/>
+  <g stroke="#c09020" stroke-width="0.8" fill="none" opacity="0.3">
+    <line x1="222" y1="148" x2="222" y2="155"/>
+    <line x1="227" y1="148" x2="227" y2="157"/>
+    <line x1="232" y1="148" x2="232" y2="158"/>
+    <line x1="237" y1="148" x2="237" y2="158"/>
+    <line x1="242" y1="148" x2="242" y2="157"/>
+    <line x1="247" y1="148" x2="247" y2="155"/>
+  </g>
+
+  <!-- Arms -->
+  <!-- Left arm — holding harbour logbook -->
+  <line x1="170" y1="148" x2="145" y2="178" stroke="#090e1c" stroke-width="9" stroke-linecap="round"/>
+  <ellipse cx="141" cy="182" rx="8" ry="6" fill="#0a1020" stroke="#141e2e" stroke-width="0.8"/>
+  <!-- Logbook -->
+  <rect x="126" y="180" width="20" height="25" rx="1" fill="#0a1020" stroke="#182840" stroke-width="1"/>
+  <line x1="126" y1="186" x2="146" y2="186" stroke="#1a3060" stroke-width="0.6" opacity="0.5"/>
+  <line x1="126" y1="191" x2="146" y2="191" stroke="#1a3060" stroke-width="0.6" opacity="0.5"/>
+  <line x1="126" y1="196" x2="146" y2="196" stroke="#1a3060" stroke-width="0.6" opacity="0.5"/>
+  <!-- Logbook binding -->
+  <line x1="130" y1="180" x2="130" y2="205" stroke="#c09020" stroke-width="1.2" opacity="0.4"/>
+
+  <!-- Right arm — raised, commanding -->
+  <line x1="230" y1="148" x2="255" y2="170" stroke="#090e1c" stroke-width="9" stroke-linecap="round"/>
+  <ellipse cx="259" cy="174" rx="8" ry="6" fill="#0a1020" stroke="#141e2e" stroke-width="0.8"/>
+  <!-- Pointing finger -->
+  <line x1="260" y1="170" x2="268" y2="160" stroke="#141e28" stroke-width="2.5" stroke-linecap="round"/>
+
+  <!-- Neck stock -->
+  <rect x="190" y="125" width="20" height="16" rx="1" fill="#0a1020" stroke="#141e2e" stroke-width="0.8"/>
+
+  <!-- HEAD — weathered, authoritative, maritime commander -->
+  <ellipse cx="200" cy="110" rx="22" ry="20" fill="#0a1020" stroke="#141e2e" stroke-width="1.2"/>
+  <!-- Weather lines on face -->
+  <g stroke="#121c2e" stroke-width="0.6" fill="none" opacity="0.4">
+    <path d="M184,108 Q188,106 193,108"/>
+    <path d="M207,108 Q212,106 216,108"/>
+  </g>
+  <!-- Strong jaw / jaw line -->
+  <path d="M182,116 Q190,124 200,126 Q210,124 218,116" fill="#090e1e" stroke="#121e2e" stroke-width="0.8"/>
+  <!-- Brow — heavy, command presence -->
+  <path d="M182,104 Q200,98 218,104" stroke="#182840" stroke-width="2.5" fill="none" opacity="0.7"/>
+
+  <!-- Eyes — cold sea blue, iron command -->
+  <ellipse cx="190" cy="108" rx="8" ry="6" fill="#050810"/>
+  <ellipse cx="210" cy="108" rx="8" ry="6" fill="#050810"/>
+  <radialGradient id="eye-hml" cx="50%" cy="50%" r="65%">
+    <stop offset="0%" stop-color="#4080c0"/>
+    <stop offset="55%" stop-color="#204080" stop-opacity="0.7"/>
+    <stop offset="100%" stop-color="#204080" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="eye-hmr" cx="50%" cy="50%" r="65%">
+    <stop offset="0%" stop-color="#4080c0"/>
+    <stop offset="55%" stop-color="#204080" stop-opacity="0.7"/>
+    <stop offset="100%" stop-color="#204080" stop-opacity="0"/>
+  </radialGradient>
+  <ellipse cx="190" cy="108" rx="8" ry="6" fill="url(#eye-hml)" opacity="0.85"/>
+  <ellipse cx="210" cy="108" rx="8" ry="6" fill="url(#eye-hmr)" opacity="0.85"/>
+  <ellipse cx="190" cy="107" rx="3.5" ry="2.5" fill="#80b0e0" opacity="0.9"/>
+  <ellipse cx="210" cy="107" rx="3.5" ry="2.5" fill="#80b0e0" opacity="0.9"/>
+  <circle cx="189" cy="106" r="1.5" fill="#d0e8ff" opacity="0.95"/>
+  <circle cx="209" cy="106" r="1.5" fill="#d0e8ff" opacity="0.95"/>
+
+  <!-- ADMIRAL'S HAT — peaked naval cap, tall -->
+  <!-- Cap brim -->
+  <rect x="180" y="94" width="40" height="5" rx="1" fill="#090e1e" stroke="#141e2e" stroke-width="0.8"/>
+  <!-- Cap crown -->
+  <path d="M182,94 L182,72 Q182,62 200,60 Q218,62 218,72 L218,94" fill="#0a1020" stroke="#141e2e" stroke-width="1"/>
+  <!-- Hat badge — anchor/admiral device -->
+  <circle cx="200" cy="78" r="8" fill="#08101e" stroke="#182840" stroke-width="0.8"/>
+  <g stroke="#c09020" stroke-width="0.8" fill="none" opacity="0.4">
+    <!-- Anchor shape -->
+    <line x1="200" y1="72" x2="200" y2="84"/>
+    <line x1="196" y1="74" x2="204" y2="74"/>
+    <path d="M196,84 Q195,82 197,80"/>
+    <path d="M204,84 Q205,82 203,80"/>
+  </g>
+  <!-- Hat brim gold trim -->
+  <line x1="180" y1="94" x2="220" y2="94" stroke="#c09020" stroke-width="0.8" opacity="0.4"/>
+
+  <!-- Vignette -->
+  <radialGradient id="vign-hm2" cx="50%" cy="50%" r="65%">
+    <stop offset="0%" stop-color="#000000" stop-opacity="0"/>
+    <stop offset="100%" stop-color="#000000" stop-opacity="0.72"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#vign-hm2)"/>
+
+  <!-- Label -->
+  <text x="200" y="232" font-family="monospace" font-size="9" fill="#182030" text-anchor="middle" letter-spacing="3">THE HARBORMASTER</text>
+</svg>

--- a/web/src/data/acts/act12.json
+++ b/web/src/data/acts/act12.json
@@ -482,6 +482,10 @@
         "Storm Beacon"
       ],
       "bossAI": "harbormaster",
+      "bossIntro": [
+        {"title": "THE SHATTERED COAST", "image": "cutscenes/act12-boss-1.svg", "text": "The Shattered Coast is locked behind iron harbour gates and a chain boom that has turned back every ship since the Fracture. Wrecks line the approach. The Harbormaster has never issued a permit to pass."},
+        {"title": "THE HARBORMASTER", "image": "cutscenes/act12-boss-2.svg", "text": "The Harbormaster commands the Shattered Coast from an iron admiral's authority — logbook in one hand, the sea's word in the other. His cold blue eyes have watched every wreck earn its fate. He will not make an exception for a card player."}
+      ],
       "bossDialogue": [
         "You have no permit to pass.",
         "Every wreck on this coast earned its fate.",


### PR DESCRIPTION
Closes #868

## Summary
- `act12-boss-1.svg` — The Shattered Coast: storm harbour at night with iron gate towers, chain boom across the entrance, wrecked ships in the foreground
- `act12-boss-2.svg` — The Harbormaster: naval admiral in double-breasted frock coat with fringed epaulettes, peaked cap with anchor badge, cold sea-blue eye glow, logbook in hand
- `bossIntro` JSON wired into the `the-harbormaster-node` boss node in `act12.json`

https://claude.ai/code/session_01QjAWeyHiDWwKa8oZQFU7yn

---
_Generated by [Claude Code](https://claude.ai/code/session_01QjAWeyHiDWwKa8oZQFU7yn)_