### PR TITLE
Add boss intro cutscenes for Act Finale — The Fracture (#870)

### DIFF
--- a/web/public/cutscenes/actfinale-boss-1.svg
+++ b/web/public/cutscenes/actfinale-boss-1.svg
@@ -1,0 +1,125 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
+  <rect width="400" height="240" fill="#040208"/>
+  <linearGradient id="core-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#060318"/>
+    <stop offset="50%" stop-color="#08041e"/>
+    <stop offset="100%" stop-color="#0c0624"/>
+  </linearGradient>
+  <rect width="400" height="240" fill="url(#core-sky)"/>
+
+  <!-- The Fracture Core glow — purple-void, vast -->
+  <radialGradient id="core-glow" cx="50%" cy="38%" r="60%">
+    <stop offset="0%" stop-color="#7010c0" stop-opacity="0.6"/>
+    <stop offset="40%" stop-color="#4008a0" stop-opacity="0.28"/>
+    <stop offset="100%" stop-color="#300868" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#core-glow)"/>
+
+  <!-- Secondary void pulse -->
+  <radialGradient id="core-pulse" cx="50%" cy="35%" r="35%">
+    <stop offset="0%" stop-color="#8020d0" stop-opacity="0.4"/>
+    <stop offset="100%" stop-color="#8020d0" stop-opacity="0"/>
+  </radialGradient>
+  <ellipse cx="200" cy="80" rx="120" ry="85" fill="url(#core-pulse)"/>
+
+  <!-- Void mass — the Fracture's heart -->
+  <ellipse cx="200" cy="72" rx="110" ry="78" fill="#080218" opacity="0.7"/>
+  <ellipse cx="200" cy="65" rx="75"  ry="55" fill="#06011a" opacity="0.8"/>
+  <ellipse cx="200" cy="62" rx="40"  ry="32" fill="#04010e" opacity="0.85"/>
+
+  <!-- PRIMARY FRACTURE RIFT — central wound -->
+  <g stroke="#b040e8" stroke-width="3" fill="none" opacity="0.9">
+    <path d="M200,0 L196,30 L215,48 L185,72 L208,92 L190,118 L208,138 L194,162"/>
+  </g>
+  <g stroke="#d878ff" stroke-width="1" fill="none" opacity="0.4">
+    <path d="M200,0 L196,30 L215,48 L185,72 L208,92 L190,118 L208,138 L194,162"/>
+  </g>
+  <!-- Rift core brightness -->
+  <g stroke="#e8a0ff" stroke-width="0.6" fill="none" opacity="0.25">
+    <path d="M200,0 L197,28 L213,44 L187,68 L208,88 L192,112 L207,132 L196,158"/>
+  </g>
+
+  <!-- Fracture branch arms — radiating reality tears -->
+  <!-- Left branches -->
+  <g stroke="#9020d0" stroke-width="1.5" fill="none" opacity="0.7">
+    <path d="M185,72 L155,62 L125,56"/>
+    <path d="M208,92 L172,86 L142,90"/>
+    <path d="M190,118 L155,112 L122,118"/>
+  </g>
+  <g stroke="#701090" stroke-width="0.8" fill="none" opacity="0.4">
+    <path d="M155,62 L130,52 L98,58"/>
+    <path d="M142,90 L112,96 L82,90"/>
+  </g>
+  <!-- Right branches -->
+  <g stroke="#9020d0" stroke-width="1.5" fill="none" opacity="0.7">
+    <path d="M215,48 L248,40 L278,34"/>
+    <path d="M208,92 L248,84 L280,88"/>
+    <path d="M208,138 L248,130 L282,134"/>
+  </g>
+  <g stroke="#701090" stroke-width="0.8" fill="none" opacity="0.4">
+    <path d="M278,34 L310,28 L345,35"/>
+    <path d="M280,88 L318,94 L350,88"/>
+  </g>
+
+  <!-- Floating void shards — reality breaking -->
+  <g fill="#501080" stroke="#8020c0" stroke-width="0.5" opacity="0.65">
+    <polygon points="138,42 148,37 152,47 143,51"/>
+    <polygon points="250,34 262,28 264,40 254,43"/>
+    <polygon points="108,75 118,70 122,80 113,84"/>
+    <polygon points="284,80 296,74 298,85 288,88"/>
+    <polygon points="120,105 130,100 133,110 124,114"/>
+    <polygon points="270,100 282,95 284,106 274,109"/>
+  </g>
+  <g fill="#301060" opacity="0.35">
+    <polygon points="90,50 98,46 100,54"/>
+    <polygon points="305,44 315,40 317,50"/>
+    <polygon points="165,20 172,16 174,24"/>
+    <polygon points="225,18 233,14 235,22"/>
+  </g>
+
+  <!-- RUINED FRACTURED CORE APPROACH — shattered stone around the wound -->
+  <!-- Ground mass — broken, tilted -->
+  <rect x="0" y="180" width="400" height="60" fill="#08060e"/>
+  <!-- Tilted rock slabs -->
+  <g fill="#0c0a14" stroke="#161228" stroke-width="0.8" opacity="0.7">
+    <polygon points="0,195 55,180 60,240 0,240"/>
+    <polygon points="340,180 400,195 400,240 345,240"/>
+    <polygon points="120,180 145,175 148,240 122,240"/>
+    <polygon points="258,175 282,180 280,240 256,240"/>
+  </g>
+
+  <!-- Broken arch ruins at the core threshold -->
+  <path d="M148,240 L148,150 Q148,130 170,128 Q200,124 230,128 Q252,130 252,150 L252,240" fill="#0a0810" stroke="#181428" stroke-width="2"/>
+  <!-- Arch rift crack -->
+  <g stroke="#601090" stroke-width="1" fill="none" opacity="0.4">
+    <path d="M200,126 L202,134 L199,144"/>
+    <path d="M200,126 L197,135"/>
+  </g>
+  <!-- Void arch interior -->
+  <rect x="150" y="126" width="100" height="114" fill="#040208"/>
+
+  <!-- Stone floor fractures -->
+  <g stroke="#2a1050" stroke-width="0.8" fill="none" opacity="0.4">
+    <line x1="0" y1="180" x2="400" y2="180"/>
+    <path d="M162,180 Q175,205 172,240"/>
+    <path d="M238,180 Q225,205 228,240"/>
+    <path d="M108,180 Q102,210 98,240"/>
+    <path d="M292,180 Q298,210 302,240"/>
+  </g>
+
+  <!-- Ley energy seeping up through cracks -->
+  <g stroke="#8020c0" stroke-width="0.8" fill="none" opacity="0.2">
+    <path d="M162,180 Q178,165 200,162"/>
+    <path d="M238,180 Q222,165 200,162"/>
+  </g>
+
+  <!-- Vignette -->
+  <radialGradient id="vign-fc1" cx="50%" cy="50%" r="68%">
+    <stop offset="0%" stop-color="#000000" stop-opacity="0"/>
+    <stop offset="100%" stop-color="#000000" stop-opacity="0.65"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#vign-fc1)"/>
+
+  <!-- Label -->
+  <text x="200" y="232" font-family="monospace" font-size="9" fill="#4a1878" text-anchor="middle" letter-spacing="3">THE FRACTURED CORE</text>
+</svg>

--- a/web/public/cutscenes/actfinale-boss-2.svg
+++ b/web/public/cutscenes/actfinale-boss-2.svg
@@ -1,0 +1,147 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" style="filter: brightness(1.4)">
+  <rect width="400" height="240" fill="#040208"/>
+
+  <!-- Void entity atmosphere — absolute darkness with fracture light -->
+  <radialGradient id="frac-atm" cx="50%" cy="50%" r="60%">
+    <stop offset="0%" stop-color="#0e0420" stop-opacity="0.8"/>
+    <stop offset="65%" stop-color="#07021a" stop-opacity="0.45"/>
+    <stop offset="100%" stop-color="#040208" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#frac-atm)"/>
+
+  <!-- Fracture eye glow — violet-white -->
+  <radialGradient id="frac-eyes" cx="50%" cy="42%" r="28%">
+    <stop offset="0%" stop-color="#d060ff" stop-opacity="0.6"/>
+    <stop offset="45%" stop-color="#8010c0" stop-opacity="0.24"/>
+    <stop offset="100%" stop-color="#8010c0" stop-opacity="0"/>
+  </radialGradient>
+  <ellipse cx="200" cy="100" rx="80" ry="52" fill="url(#frac-eyes)"/>
+
+  <!-- Outer fracture aura -->
+  <radialGradient id="frac-aura" cx="50%" cy="48%" r="55%">
+    <stop offset="0%" stop-color="#8020c0" stop-opacity="0.25"/>
+    <stop offset="100%" stop-color="#5008a0" stop-opacity="0"/>
+  </radialGradient>
+  <ellipse cx="200" cy="115" rx="130" ry="110" fill="url(#frac-aura)"/>
+
+  <!-- Background rift lines radiating from the entity -->
+  <g stroke="#a030e0" stroke-width="1.5" fill="none" opacity="0.7">
+    <path d="M200,25 L197,52 L214,68 L192,88"/>
+    <path d="M200,25 L203,52 L186,68 L208,88"/>
+    <path d="M280,55 L252,72 L238,90 L218,104"/>
+    <path d="M120,55 L148,72 L162,90 L182,104"/>
+    <path d="M300,108 L272,108 L252,114 L232,108"/>
+    <path d="M100,108 L128,108 L148,114 L168,108"/>
+  </g>
+  <g stroke="#c860f8" stroke-width="0.6" fill="none" opacity="0.3">
+    <path d="M200,15 L196,46 L216,64 L190,84"/>
+    <path d="M292,48 L262,68 L245,88 L220,102"/>
+    <path d="M108,48 L138,68 L155,88 L180,102"/>
+  </g>
+
+  <!-- Floating void shards around the entity -->
+  <g fill="#401068" stroke="#6810a0" stroke-width="0.5" opacity="0.65">
+    <polygon points="130,58 140,53 144,63 135,67"/>
+    <polygon points="258,55 268,50 272,60 263,64"/>
+    <polygon points="118,128 128,123 132,133 123,137"/>
+    <polygon points="268,126 278,121 282,131 273,135"/>
+    <polygon points="150,175 159,170 162,180 154,183"/>
+    <polygon points="245,172 255,167 258,177 249,180"/>
+    <polygon points="92,92"  />
+    <polygon points="92,92 100,87 103,97 95,100"/>
+    <polygon points="298,90 308,85 310,95 302,98"/>
+  </g>
+
+  <!-- THE FRACTURE — pure void entity, not humanoid -->
+  <!-- Floor shadow — barely present -->
+  <ellipse cx="200" cy="228" rx="65" ry="9" fill="#020104" opacity="0.6"/>
+
+  <!-- Body — absolute void given mass, but not form -->
+  <!-- Central void mass -->
+  <circle cx="200" cy="110" rx="65" ry="65" r="65" fill="#060118" stroke="#7010b0" stroke-width="1.5" opacity="0.9"/>
+  <circle cx="200" cy="110" r="50" fill="#040010" stroke="#5008a0" stroke-width="0.8" opacity="0.85"/>
+  <circle cx="200" cy="110" r="32" fill="#030008" opacity="0.9"/>
+
+  <!-- Internal fracture geometry — reality lattice -->
+  <g fill="none" stroke="#6010a0" stroke-width="0.8" opacity="0.5">
+    <polygon points="200,72 230,96 224,132 200,148 176,132 170,96"/>
+    <polygon points="200,80 224,100 218,130 200,140 182,130 176,100"/>
+  </g>
+  <g stroke="#8020c0" stroke-width="0.6" fill="none" opacity="0.3">
+    <line x1="200" y1="72"  x2="200" y2="110"/>
+    <line x1="230" y1="96"  x2="200" y2="110"/>
+    <line x1="224" y1="132" x2="200" y2="110"/>
+    <line x1="176" y1="132" x2="200" y2="110"/>
+    <line x1="170" y1="96"  x2="200" y2="110"/>
+  </g>
+
+  <!-- THE FRACTURE'S EYES — two voids within the void, fracture-light pupils -->
+  <ellipse cx="184" cy="102" rx="12" ry="9" fill="#08021a" stroke="#9020d0" stroke-width="1"/>
+  <ellipse cx="216" cy="102" rx="12" ry="9" fill="#08021a" stroke="#9020d0" stroke-width="1"/>
+  <!-- Iris — fracture-violet -->
+  <ellipse cx="184" cy="102" rx="6" ry="4.5" fill="#5010a0" opacity="0.75"/>
+  <ellipse cx="216" cy="102" rx="6" ry="4.5" fill="#5010a0" opacity="0.75"/>
+  <!-- Pupil — fracture light, white-violet -->
+  <radialGradient id="eye-fl" cx="50%" cy="50%" r="65%">
+    <stop offset="0%" stop-color="#f080ff"/>
+    <stop offset="50%" stop-color="#c040f0" stop-opacity="0.7"/>
+    <stop offset="100%" stop-color="#c040f0" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="eye-fr" cx="50%" cy="50%" r="65%">
+    <stop offset="0%" stop-color="#f080ff"/>
+    <stop offset="50%" stop-color="#c040f0" stop-opacity="0.7"/>
+    <stop offset="100%" stop-color="#c040f0" stop-opacity="0"/>
+  </radialGradient>
+  <ellipse cx="184" cy="101" rx="12" ry="9" fill="url(#eye-fl)" opacity="0.85"/>
+  <ellipse cx="216" cy="101" rx="12" ry="9" fill="url(#eye-fr)" opacity="0.85"/>
+  <ellipse cx="184" cy="100" rx="5" ry="3.5" fill="#e898ff" opacity="0.92"/>
+  <ellipse cx="216" cy="100" rx="5" ry="3.5" fill="#e898ff" opacity="0.92"/>
+  <circle cx="183" cy="99" r="2.5" fill="#ffffff" opacity="0.95"/>
+  <circle cx="215" cy="99" r="2.5" fill="#ffffff" opacity="0.95"/>
+  <!-- Secondary gleam -->
+  <circle cx="186" cy="103" r="1"   fill="#f0c0ff" opacity="0.55"/>
+  <circle cx="218" cy="103" r="1"   fill="#f0c0ff" opacity="0.55"/>
+
+  <!-- Fracture mouth — a wound, not a face feature -->
+  <path d="M180,122 Q192,132 200,130 Q208,132 220,122" stroke="#9020d0" stroke-width="1.5" fill="none" opacity="0.65"/>
+  <path d="M183,124 Q192,128 200,127 Q208,128 217,124" stroke="#c060f0" stroke-width="0.6" fill="none" opacity="0.3"/>
+
+  <!-- Outer crackling boundary arms — not body but presence -->
+  <g stroke="#a030e0" stroke-width="1.2" fill="none" opacity="0.6">
+    <!-- Left extension -->
+    <path d="M148,110 Q115,110 95,100 Q78,90 72,105"/>
+    <path d="M148,125 Q118,130 100,125"/>
+    <!-- Right extension -->
+    <path d="M252,110 Q285,110 305,100 Q322,90 328,105"/>
+    <path d="M252,125 Q282,130 300,125"/>
+  </g>
+  <!-- Extension tips — crackling void energy -->
+  <g fill="#601090" opacity="0.5">
+    <circle cx="72"  cy="105" r="5"/>
+    <circle cx="328" cy="105" r="5"/>
+  </g>
+  <g fill="#d060ff" opacity="0.4">
+    <circle cx="72"  cy="105" r="2.5"/>
+    <circle cx="328" cy="105" r="2.5"/>
+  </g>
+
+  <!-- Cracked void floor -->
+  <rect x="0" y="205" width="400" height="35" fill="#050410"/>
+  <g stroke="#2a1050" stroke-width="0.6" fill="none" opacity="0.35">
+    <line x1="0"   y1="205" x2="400" y2="205"/>
+    <path d="M155,205 Q168,220 165,240"/>
+    <path d="M245,205 Q232,220 235,240"/>
+    <path d="M80,205  Q75,222  72,240"/>
+    <path d="M320,205 Q325,222 328,240"/>
+  </g>
+
+  <!-- Vignette -->
+  <radialGradient id="vign-f2" cx="50%" cy="50%" r="65%">
+    <stop offset="0%" stop-color="#000000" stop-opacity="0"/>
+    <stop offset="100%" stop-color="#000000" stop-opacity="0.72"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#vign-f2)"/>
+
+  <!-- Label -->
+  <text x="200" y="232" font-family="monospace" font-size="9" fill="#4a1878" text-anchor="middle" letter-spacing="3">THE FRACTURE</text>
+</svg>

--- a/web/src/data/acts/actfinale.json
+++ b/web/src/data/acts/actfinale.json
@@ -190,6 +190,10 @@
       ],
       "bossAI": "thefracture",
       "bossCard": "Iron Colossus",
+      "bossIntro": [
+        {"title": "THE FRACTURED CORE", "image": "cutscenes/actfinale-boss-1.svg", "text": "The Fractured Core is the wound at the centre of everything — a void tear that has been bleeding reality for three years, radiating fracture energy through every shard you have crossed. This is where it began. This is where it ends."},
+        {"title": "THE FRACTURE", "image": "cutscenes/actfinale-boss-2.svg", "text": "The Fracture is not a creature. It is the absence of the world that used to be here — an entity of pure void, its fracture-light eyes burning with the weight of a shattered age. You should not have come here. Everything breaks. Everything."}
+      ],
       "bossDialogue": [
         "YOU SHOULD NOT HAVE COME HERE.",
         "THE FRACTURE IS ETERNAL. YOU ARE NOT.",


### PR DESCRIPTION
Closes #870

## Summary
- `actfinale-boss-1.svg` — The Fractured Core: vast void rift with primary fracture tear, radiating branch tears, void mass at the heart, ruined stone approach arch
- `actfinale-boss-2.svg` — The Fracture: pure void entity with circular body of absolute darkness, fracture geometry lattice interior, violet-white fracture-light eye glow, crackling boundary arms extending outward
- `bossIntro` JSON wired into the `the-fracture-node` boss node in `actfinale.json`

https://claude.ai/code/session_01QjAWeyHiDWwKa8oZQFU7yn

---
_Generated by [Claude Code](https://claude.ai/code/session_01QjAWeyHiDWwKa8oZQFU7yn)_