### PR TITLE
TD & city: gas cloud XP fix, enemy flow, auto-wave, fort build times

### DIFF
--- a/web/src/components/minigames/CityBuilder.tsx
+++ b/web/src/components/minigames/CityBuilder.tsx
@@ -13,7 +13,7 @@ import {
 import {
   CITY_COLS, CITY_ROWS, CELL_PX, MAX_CITY_ROWS,
   CityCell, CityState, BuildQueueEntry, ResourceType, AttackEvent,
-  FORT_MAX_HP, EXPANSION_COSTS, MAX_TOTAL_FORTS,
+  FORT_MAX_HP, FORT_BUILD_MINUTES, EXPANSION_COSTS, MAX_TOTAL_FORTS,
   DEFAULT_BUILDER_COUNT, MAX_BUILDER_COUNT,
   canAffordFortification, canQueueFortification,
   loadCityState, saveCityState, tickCity,
@@ -978,9 +978,14 @@ export function CityBuilder({ onBack }: Props) {
     if (!canAffordFortification(city, card.rarity)) { showToast('Not enough resources!'); return }
     const next = addFortification(city, card.name, card.rarity)
     if (!next) { showToast('Cannot build — check builder slots and resources.'); return }
-    const buildMinutes = FORT_MAX_HP[card.rarity]
+    const buildMinutes = FORT_BUILD_MINUTES[card.rarity]
+    const buildLabel = buildMinutes >= 1440
+      ? `${(buildMinutes / 1440).toFixed(1).replace(/\.0$/, '')} days`
+      : buildMinutes >= 60
+        ? `${(buildMinutes / 60).toFixed(1).replace(/\.0$/, '')} hrs`
+        : `${buildMinutes} min`
     save(next)
-    showToast(`${card.name} queued — ${buildMinutes} min build time.`)
+    showToast(`${card.name} queued — ${buildLabel} build time.`)
   }
 
   function handleBuyBuilder() {

--- a/web/src/components/minigames/citybuilder/CardPicker.tsx
+++ b/web/src/components/minigames/citybuilder/CardPicker.tsx
@@ -5,8 +5,9 @@ import {
   canAffordPlacement, getBuildingProduces, masteryOutputMultiplier, getCardMasteryLevel,
 } from '../../../game/cityBuilder'
 import { CollectionEntry, getMasteryXp, masteryLevel } from '../../../game/collection'
-import { Card } from '../../../game/types'
+import { Card, UnitTemplate } from '../../../game/types'
 import { SpriteImg } from '../../ui/SpriteImg'
+import { EFFECT_META } from '../towerdefence/UnitChip'
 
 export interface Props {
   availableForPlace: Card[]
@@ -82,6 +83,10 @@ export function CardPicker({
                   const spawnName   = isSpawner
                     ? (spawnEffect as { type: 'spawn'; unitTemplate: { name: string }; intervalMs: number }).unitTemplate.name
                     : null
+                  const spawnEffect2 = isSpawner
+                    ? (spawnEffect as { type: 'spawn'; unitTemplate: UnitTemplate }).unitTemplate.attackEffect
+                    : undefined
+                  const spawnEffectMeta = spawnEffect2 ? EFFECT_META[spawnEffect2.type] : null
                   const affordable  = !isSpawner || canAffordPlacement(city, card.rarity)
                   const cost        = isSpawner ? SPAWNER_PLACE_COST[card.rarity] : null
                   const produces    = !isSpawner ? getBuildingProduces(card.name) : null
@@ -107,6 +112,11 @@ export function CardPicker({
                         <div className="city-picker-spawns">
                           <SpriteImg name={spawnName} className="city-picker-spawn-icon" />
                           <span>{spawnName}</span>
+                          {spawnEffectMeta && (
+                            <span className={`td-unit-chip-effect ${spawnEffectMeta.cls}`} title={spawnEffectMeta.label}>
+                              {spawnEffectMeta.icon}
+                            </span>
+                          )}
                         </div>
                       )}
                       {cost && (

--- a/web/src/components/minigames/towerdefence/UnitChip.tsx
+++ b/web/src/components/minigames/towerdefence/UnitChip.tsx
@@ -1,7 +1,7 @@
 import { UnitTemplate } from '../../../game/types'
 import { SpriteImg } from '../../ui/SpriteImg'
 
-const EFFECT_META: Record<string, { icon: string; label: string; cls: string }> = {
+export const EFFECT_META: Record<string, { icon: string; label: string; cls: string }> = {
   burn:     { icon: '🔥', label: 'Burn',     cls: 'effect--burn'     },
   freeze:   { icon: '❄',  label: 'Freeze',   cls: 'effect--freeze'   },
   poison:   { icon: '☠',  label: 'Poison',   cls: 'effect--poison'   },

--- a/web/src/game/cards.ts
+++ b/web/src/game/cards.ts
@@ -121,7 +121,9 @@ function resolveUnit(raw: RawUnitDef): UnitTemplate {
     console.error('[cards]', msg)
     _pendingValidationErrors.push({ msg, ctx: { unitName: raw.name, unitTemplateRef: unitTemplateRef ?? null } })
   }
-  const unitTemplate = (resolved ?? {}) as UnitTemplate
+  const unitRaw = (resolved ?? {}) as RawUnitDef
+  const unitEffect = resolved ? deriveAttackEffect(resolved.tags, resolved.attack) : undefined
+  const unitTemplate: UnitTemplate = { ...(unitRaw as unknown as UnitTemplate), ...(unitEffect ? { attackEffect: unitEffect } : {}) }
   return {
     ...(raw as unknown as UnitTemplate),
     ...(attackEffect ? { attackEffect } : {}),

--- a/web/src/game/cityBuilder.ts
+++ b/web/src/game/cityBuilder.ts
@@ -70,6 +70,19 @@ export const RESOURCE_ICONS: Record<ResourceType, string> = {
 
 // ── Fortification constants ───────────────────────────────────────────────────
 
+/** Build time in minutes per rarity. Legendary = 3 days; others scaled proportionally. */
+export const FORT_BUILD_MINUTES: Record<CardRarity, number> = {
+  common:    432,   // ~7 h
+  uncommon:  864,   // ~14 h
+  rare:     1728,   // ~1.2 days
+  epic:     3024,   // ~2.1 days
+  legendary: 4320,  // 3 days
+  mythic:    6912,  // ~4.8 days
+  shiny:     4320,
+  holofoil:  4320,
+  glass:     4320,
+}
+
 /** Max HP for a fortification of each rarity. */
 export const FORT_MAX_HP: Record<CardRarity, number> = {
   common: 50, uncommon: 100, rare: 200, epic: 350, legendary: 500,
@@ -732,7 +745,7 @@ export function addFortification(state: CityState, cardName: string, rarity: Car
   for (const res of Object.keys(newResources) as ResourceType[]) {
     newResources[res] = Math.max(0, newResources[res] - ((cost[res] as number) ?? 0))
   }
-  const buildMinutes = FORT_MAX_HP[rarity]
+  const buildMinutes = FORT_BUILD_MINUTES[rarity]
   const completesAt = Date.now() + buildMinutes * 60_000
   const entry: BuildQueueEntry = { cardName, rarity, completesAt }
   return {

--- a/web/src/game/towerDefence.ts
+++ b/web/src/game/towerDefence.ts
@@ -266,6 +266,7 @@ export interface TDHazard {
   radius: number
   dps: number
   expiresAt: number  // gameTimeMs when it expires
+  sourceTowerId: number
 }
 
 // Global passive bonuses accumulated through milestone upgrades
@@ -552,7 +553,7 @@ export function createTDGame(
     enemies: [],
     spawnQueue: [],
     waveSpawnTotal: 0,
-    nextWaveAt: 0,
+    nextWaveAt: Infinity,
     log: ['Place your buildings, then press START WAVE.'],
     attackEvents: [],
     hazards: [],
@@ -722,6 +723,7 @@ export function startWave(state: TDGameState): TDGameState {
     phase: 'wave',
     spawnQueue: queue,
     waveSpawnTotal: queue.length,
+    nextWaveAt: Infinity,
     log: [...state.log.slice(-9), waveDef.label + '!'],
   }
 }
@@ -760,6 +762,11 @@ export function tickTD(state: TDGameState, dtMs: number): TDGameState {
     }]
   }
 
+  // Start auto-next-wave countdown when last enemy of this wave spawns
+  if (s.phase === 'wave' && state.spawnQueue.length > 0 && s.spawnQueue.length === 0 && s.nextWaveAt === Infinity) {
+    s.nextWaveAt = s.gameTimeMs + 5000
+  }
+
   // ── Elemental DoT on enemies ─────────────────────────────────────────────
   s.enemies = s.enemies.map(enemy => {
     let e = { ...enemy }
@@ -782,13 +789,10 @@ export function tickTD(state: TDGameState, dtMs: number): TDGameState {
   }
   s.enemies = s.enemies.filter(e => e.hp > 0)
 
-  // ── Move enemies — max 3 per cell (leaders advance first) ──────────────
+  // ── Move enemies ──────────────────────────────────────────────────────────
   let livesLost = 0
-  const claimedEnemyCells = new Map<string, number>()  // "col,row" -> occupant count
   const survivingEnemies: TDEnemy[] = []
-  // Process most-advanced enemies first so they claim cells before followers
-  const enemiesByProgress = [...s.enemies].sort((a, b) => b.pathProgress - a.pathProgress)
-  for (const enemy of enemiesByProgress) {
+  for (const enemy of s.enemies) {
     const freezeFactor = (enemy.freezeTimer != null && enemy.freezeTimer > 0 && enemy.freezeSlow != null)
       ? enemy.freezeSlow : 1
     const np = enemy.pathProgress + enemy.template.speed * enemy.speedMult * dtSec * freezeFactor
@@ -797,17 +801,7 @@ export function tickTD(state: TDGameState, dtMs: number): TDGameState {
       continue
     }
     const xy = pathIndexToXY(np)
-    const destKey = `${Math.floor(xy.x / TD_CELL_PX)},${Math.floor(xy.y / TD_CELL_PX)}`
-    const destCount = claimedEnemyCells.get(destKey) ?? 0
-    if (destCount >= 3) {
-      // Cell ahead full — hold position, claim current cell
-      const curKey = `${Math.floor(enemy.x / TD_CELL_PX)},${Math.floor(enemy.y / TD_CELL_PX)}`
-      claimedEnemyCells.set(curKey, (claimedEnemyCells.get(curKey) ?? 0) + 1)
-      survivingEnemies.push(enemy)
-    } else {
-      claimedEnemyCells.set(destKey, destCount + 1)
-      survivingEnemies.push({ ...enemy, pathProgress: np, x: xy.x, y: xy.y })
-    }
+    survivingEnemies.push({ ...enemy, pathProgress: np, x: xy.x, y: xy.y })
   }
   s.enemies = survivingEnemies
   if (livesLost > 0) {
@@ -943,7 +937,7 @@ export function tickTD(state: TDGameState, dtMs: number): TDGameState {
               newAttackEvents.push({ id: nextId(), fromX: target.x, fromY: target.y, toX: target.x, toY: target.y, expiresAt: s.gameTimeMs + 500, aoeRadius: eff.aoeRadius })
             } else if (eff.type === 'gascloud' && eff.aoeRadius) {
               // Drop lingering gas cloud at target position
-              s.hazards = [...s.hazards, { id: nextId(), x: target.x, y: target.y, radius: eff.aoeRadius, dps: eff.dps ?? 6, expiresAt: s.gameTimeMs + eff.durationMs }]
+              s.hazards = [...s.hazards, { id: nextId(), x: target.x, y: target.y, radius: eff.aoeRadius, dps: eff.dps ?? 6, expiresAt: s.gameTimeMs + eff.durationMs, sourceTowerId: unit.towerId }]
             }
           }
           if (newHp <= 0) {
@@ -970,13 +964,6 @@ export function tickTD(state: TDGameState, dtMs: number): TDGameState {
     return { ...unit, attackCooldownRemaining: cd }
   })
   s.attackEvents = newAttackEvents
-
-  // Award kill XP to the towers whose units made the kills
-  if (Object.keys(towerXpGains).length > 0) {
-    s.towers = s.towers.map(t =>
-      towerXpGains[t.id] ? { ...t, xp: t.xp + towerXpGains[t.id] } : t
-    )
-  }
 
   // Split-on-death: collect offspring before removing dead enemies
   const splitOffspring: TDEnemy[] = []
@@ -1058,6 +1045,7 @@ export function tickTD(state: TDGameState, dtMs: number): TDGameState {
             hazardDeadIds.add(e.id)
             s.score += e.template.reward
             s.mana += e.template.reward
+            towerXpGains[hazard.sourceTowerId] = (towerXpGains[hazard.sourceTowerId] ?? 0) + 1
           }
         }
       }
@@ -1066,14 +1054,23 @@ export function tickTD(state: TDGameState, dtMs: number): TDGameState {
     s.enemies = s.enemies.filter(e => !hazardDeadIds.has(e.id))
   }
 
+  // Award kill XP to towers (from direct attacks and gas cloud kills)
+  if (Object.keys(towerXpGains).length > 0) {
+    s.towers = s.towers.map(t =>
+      towerXpGains[t.id] ? { ...t, xp: t.xp + towerXpGains[t.id] } : t
+    )
+  }
+
   // ── Check defeat ──────────────────────────────────────────────────────────
   if (s.lives <= 0) {
     s.log = [...s.log.slice(-9), 'Your base has fallen!']
     return { ...s, phase: 'defeat' }
   }
 
-  // ── Check wave complete ───────────────────────────────────────────────────
-  if (s.phase === 'wave' && s.spawnQueue.length === 0 && s.enemies.length === 0) {
+  // ── Check wave complete: all clear, or 5 s after last spawn ─────────────
+  const allSpawned = s.spawnQueue.length === 0
+  const autoStart  = allSpawned && s.gameTimeMs >= s.nextWaveAt
+  if (s.phase === 'wave' && allSpawned && (s.enemies.length === 0 || autoStart)) {
     s.wavesCompleted += 1
     if (s.wavesCompleted >= TD_TOTAL_WAVES) {
       s.log = [...s.log.slice(-9), 'All 100 waves defeated! Legendary victory!']
@@ -1082,12 +1079,12 @@ export function tickTD(state: TDGameState, dtMs: number): TDGameState {
     s.currentWaveIndex += 1
     if (s.wavesCompleted % TD_MILESTONE_EVERY === 0) {
       s.log = [...s.log.slice(-9), `🎉 ${s.wavesCompleted} waves cleared! Choose a reward, then reorganise!`]
-      return { ...s, phase: 'milestone', milestoneChoices: sampleMilestoneChoices() }
+      return { ...s, phase: 'milestone', milestoneChoices: sampleMilestoneChoices(), nextWaveAt: Infinity }
     }
-    s.nextWaveAt = s.gameTimeMs + BETWEEN_WAVE_MS
     const nextWave = generateWave(s.currentWaveIndex)
-    s.log = [...s.log.slice(-9), `Wave ${s.wavesCompleted} cleared! Next in 5 s — ${nextWave.label}`]
-    return { ...s, phase: 'between' }
+    const queue = buildSpawnQueue(nextWave, s.gameTimeMs, s.currentWaveIndex)
+    s.log = [...s.log.slice(-9), nextWave.label + '!']
+    return { ...s, phase: 'wave', spawnQueue: queue, waveSpawnTotal: queue.length, nextWaveAt: Infinity }
   }
 
   if (s.phase === 'between' && s.gameTimeMs >= s.nextWaveAt) return startWave(s)

--- a/web/src/game/types.sample.ts
+++ b/web/src/game/types.sample.ts
@@ -265,4 +265,5 @@ export const exampleTDHazard: TDHazard = {
   radius: 20,
   dps: 20,
   expiresAt: 2000,
+  sourceTowerId: 0,
 };


### PR DESCRIPTION
## Summary

### Tower Defence fixes
- **Gas cloud XP attribution** — `TDHazard` now carries `sourceTowerId`; kills from lingering clouds correctly credit XP to the tower that dropped them
- **Enemy cell cap removed** — the max-3-per-cell queuing system caused enemies to bunch up and break path-following at high game speeds (8×); enemies now flow freely along the path
- **Auto-start next wave** — 5 seconds after the last enemy of a wave spawns, the next wave begins automatically (remaining enemies carry over); clearing all enemies early still advances immediately; milestone waves still pause for the upgrade picker

### City Builder
- **Fortification build times scaled up** — added `FORT_BUILD_MINUTES` constant (decoupled from `FORT_MAX_HP`); legendary now takes 3 days (was ~8 h), all others scaled proportionally:
  - Common ~7 h · Uncommon ~14 h · Rare ~1.2 d · Epic ~2.1 d · Legendary 3 d · Mythic ~4.8 d
  - Toast message now shows days/hrs instead of raw minutes

## Test plan

- [ ] Gas cloud units gain XP when the cloud kills enemies
- [ ] Enemies flow past each other freely (no queuing at cell boundaries)
- [ ] At 8× speed enemies move smoothly along the path
- [ ] Next wave auto-starts ~5 s after last enemy spawns
- [ ] Clearing a wave early still advances immediately
- [ ] Milestone every 10 waves still pauses for upgrade selection
- [ ] Fortification build toast shows e.g. "3 days" for legendary
- [ ] Builder queue completion time reflects the new durations

https://claude.ai/code/session_01FFXw8rUxBVQRtJK8x762WJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01FFXw8rUxBVQRtJK8x762WJ)_