### PR TITLE
City: vacant building reason, invite-back button, slower happiness drain

### DIFF
--- a/web/src/components/minigames/CityBuilder.tsx
+++ b/web/src/components/minigames/CityBuilder.tsx
@@ -17,7 +17,7 @@ import {
   DEFAULT_BUILDER_COUNT, MAX_BUILDER_COUNT,
   canAffordFortification, canQueueFortification,
   loadCityState, saveCityState, tickCity,
-  placeCard, removeCard,
+  placeCard, removeCard, reoccupyBuilding,
   addFortification, removeFortification,
   expandCity, canAffordExpansion,
   goldIncomeRate, goldNetRate,
@@ -1247,6 +1247,7 @@ export function CityBuilder({ onBack }: Props) {
               setBuildingTab={setBuildingTab}
               onClose={() => setSelectedBuildingCell(null)}
               onLevelUp={cardName => { handleLevelUp(cardName); setBuildingTab('upgrade') }}
+              onMoveIn={() => { save(reoccupyBuilding(city, selectedBuildingCell!)); showToast('Residents invited back!') }}
             />
           )
         })()}

--- a/web/src/components/minigames/citybuilder/BuildingInspectModal.stories.tsx
+++ b/web/src/components/minigames/citybuilder/BuildingInspectModal.stories.tsx
@@ -58,6 +58,7 @@ export const SpawnerResidents: Story = {
       walkers={walkers}
       onClose={fn()}
       onLevelUp={fn()}
+      onMoveIn={fn()}
     />
   ),
 }
@@ -73,6 +74,7 @@ export const ProducerBuilding: Story = {
       walkers={[]}
       onClose={fn()}
       onLevelUp={fn()}
+      onMoveIn={fn()}
     />
   ),
 }
@@ -88,6 +90,7 @@ export const UnhappyUnit: Story = {
       walkers={[]}
       onClose={fn()}
       onLevelUp={fn()}
+      onMoveIn={fn()}
     />
   ),
 }

--- a/web/src/components/minigames/citybuilder/BuildingInspectModal.tsx
+++ b/web/src/components/minigames/citybuilder/BuildingInspectModal.tsx
@@ -19,12 +19,13 @@ export interface Props {
   setBuildingTab: (tab: 'residents' | 'upgrade') => void
   onClose:        () => void
   onLevelUp:      (cardName: string) => void
+  onMoveIn:       () => void
 }
 
 export function BuildingInspectModal({
   cellIndex, cell, city, collection, walkers,
   buildingTab, setBuildingTab,
-  onClose, onLevelUp,
+  onClose, onLevelUp, onMoveIn,
 }: Props) {
   const happiness      = cell.spawnedUnitName ? (city.happiness[cellIndex] ?? 100) : 100
   const unitCount      = cell.spawnedUnitName ? spawnerUnitCount(city, cell.cardName) : 0
@@ -62,9 +63,31 @@ export function BuildingInspectModal({
           cell.spawnedUnitName ? (
             <>
               <div className="city-bld-section-title">Residents ({happiness === 0 ? 0 : unitCount})</div>
-              {happiness === 0 ? (
-                <div className="city-bld-vacant">Building is vacant — unit left the city</div>
-              ) : (
+              {happiness === 0 ? (() => {
+                const reqs   = getUnitRequirements(cell, city, cellIndex)
+                const unmet  = reqs.filter(r => !r.met)
+                const allMet = unmet.length === 0
+                return (
+                  <div className="city-bld-vacant-section">
+                    <div className="city-bld-vacant">🚪 Vacant — residents left the city</div>
+                    <div className="city-bld-vacant-reasons">
+                      {unmet.length > 0
+                        ? unmet.map((r, i) => <div key={i} className="city-bld-resident-req">✗ {r.text}</div>)
+                        : <div className="city-bld-resident-req city-bld-req--met">✓ All conditions now met</div>
+                      }
+                    </div>
+                    <button
+                      className={`action-btn${allMet ? '' : ' action-btn--muted'}`}
+                      onClick={() => { onMoveIn(); onClose() }}
+                    >
+                      {allMet ? '🏠 INVITE BACK' : '🏠 INVITE BACK ANYWAY'}
+                    </button>
+                    {!allMet && (
+                      <div className="city-bld-vacant-warn">They may leave again if conditions aren't improved.</div>
+                    )}
+                  </div>
+                )
+              })() : (
                 Array.from({ length: unitCount }, (_, u) => {
                   const reqs    = getUnitRequirements(cell, city, cellIndex)
                   const unmet   = reqs.filter(r => !r.met)

--- a/web/src/game/cityBuilder.ts
+++ b/web/src/game/cityBuilder.ts
@@ -29,8 +29,8 @@ export const INCOME_WALL: Record<CardRarity, number> = { common: 0, uncommon: 1,
 
 /** Happiness regeneration per minute toward the target value. */
 const HAPPINESS_REGEN = 15
-/** Happiness drain per minute away from target when conditions not met (~50 min to fully despawn). */
-const HAPPINESS_DRAIN = 2
+/** Happiness drain per minute away from target when conditions not met (~24 hrs to fully despawn). */
+const HAPPINESS_DRAIN = 0.07
 
 /** Level-up costs: index = target level (1-based). Beyond the table, the last entry repeats. */
 export const LEVEL_UP_COSTS = [50000, 100000, 250000, 500000, 1000000]
@@ -710,6 +710,14 @@ export function placeCard(state: CityState, index: number, cell: CityCell): City
   }
 
   return { ...state, grid, happiness, resources }
+}
+
+/** Invite a vacant unit back into their building, restoring partial happiness. */
+export function reoccupyBuilding(state: CityState, index: number): CityState {
+  const cell = state.grid[index]
+  if (!cell?.spawnedUnitName) return state
+  if ((state.happiness[index] ?? 100) > 0) return state
+  return { ...state, happiness: { ...state.happiness, [index]: 50 } }
 }
 
 export function removeCard(state: CityState, index: number): CityState {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -9854,6 +9854,10 @@ html.light-mode .action-btn {
 
 .city-bld-section-title { font-size: 10px; color: #609060; letter-spacing: 1px; text-transform: uppercase; align-self: flex-start; }
 .city-bld-vacant        { font-size: 10px; color: #606060; font-style: italic; }
+.city-bld-vacant-section { display: flex; flex-direction: column; gap: 6px; width: 100%; }
+.city-bld-vacant-reasons { display: flex; flex-direction: column; gap: 3px; }
+.city-bld-req--met      { color: #609060 !important; }
+.city-bld-vacant-warn   { font-size: 9px; color: #887040; font-style: italic; }
 .city-bld-resident {
   display: flex;
   align-items: flex-start;


### PR DESCRIPTION
## Summary

- **Vacancy reason**: tapping a vacant spawn building now shows which conditions caused the residents to leave (food supply, city defence, affinity requirement), with a green tick if those conditions have since been resolved
- **Invite back**: new "🏠 INVITE BACK" button restores happiness to 50 so residents move back in immediately. If conditions are still unmet, the button changes to "INVITE BACK ANYWAY" with a warning that they may leave again
- **Slower drain**: `HAPPINESS_DRAIN` reduced from 2/min → 0.07/min — residents now take ~24 hrs of game time to fully drain from content to gone, so players have time to notice and fix the problem before losing units permanently

## Test plan
- [ ] Vacant building modal shows correct unmet condition(s)
- [ ] If you fix the condition (add food/defence) the tick turns green before inviting back
- [ ] "INVITE BACK" restores the resident; walker appears in the city
- [ ] If conditions still unmet, resident's happiness drains again (slowly)
- [ ] Non-vacant buildings unaffected

https://claude.ai/code/session_01FFXw8rUxBVQRtJK8x762WJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01FFXw8rUxBVQRtJK8x762WJ)_