### PR TITLE
fix(achievements): prevent Full Set triggering on sold-then-reacquired items

### DIFF
--- a/web/src/game/achievements.ts
+++ b/web/src/game/achievements.ts
@@ -152,6 +152,22 @@ export function claimAllAchievementRewards(): { def: AchievementDef; reward: Ach
   return results
 }
 
+/**
+ * One-time retcon: if the Full Set achievement was incorrectly unlocked
+ * (via sold-and-reacquired items inflating the progress counter), reset it
+ * so the player can earn it legitimately. Returns true if a retcon occurred.
+ */
+export function retconFullSetAchievement(actualUniqueCount: number): boolean {
+  if (actualUniqueCount >= 423) return false
+  const save = loadAchievementSave()
+  if (!save.unlocked['misc:items_full_set']) return false
+  save.unlocked['misc:items_full_set'] = false
+  save.claimed['misc:items_full_set'] = false
+  save.progress['misc:unique_items'] = actualUniqueCount
+  saveAchievementSave(save)
+  return true
+}
+
 // ─── Helper: build kill achievement pair ─────────────────
 
 function killPair(

--- a/web/src/game/dailyLogin.ts
+++ b/web/src/game/dailyLogin.ts
@@ -8,6 +8,7 @@ import { CardRarity } from './types'
 import { addCollectible, removeCollectible, getCollectibles, ItemDisplayFields } from './itemStore'
 
 const DAILY_KEY = 'jarv_daily_login'
+const SEEN_COLLECTIBLES_KEY = 'jarv_seen_collectibles'
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -137,12 +138,52 @@ function resolveBrokenRelic(id: string): { name: string; icon: string; desc: str
 // Collectible item CRUD delegates to itemStore.ts (see the COLLECTIBLE ITEMS
 // section there). Achievement side-effects and display resolution stay here.
 
+// ── Seen-collectibles tracking ─────────────────────────────────────────────────
+//
+// SEEN_COLLECTIBLES_KEY persists the set of item IDs ever collected, surviving
+// sales. This prevents sold-then-reacquired items from re-incrementing the
+// misc:unique_items achievement counter.
+//
+// On first load (key absent) the set is seeded from the current inventory and a
+// one-time retcon runs: if misc:items_full_set was incorrectly unlocked due to
+// the old current-inventory check, it is cleared and the reward item removed.
+
+function getSeenCollectibles(): Set<string> {
+  try {
+    const raw = localStorage.getItem(SEEN_COLLECTIBLES_KEY)
+    if (raw) return new Set(JSON.parse(raw) as string[])
+  } catch { /* ignore */ }
+  return initSeenCollectibles()
+}
+
+function initSeenCollectibles(): Set<string> {
+  const initial = new Set(getCollectibles().map(e => e.id))
+  try {
+    localStorage.setItem(SEEN_COLLECTIBLES_KEY, JSON.stringify([...initial]))
+  } catch { /* ignore */ }
+  import('./achievements').then(({ retconFullSetAchievement }) => {
+    if (retconFullSetAchievement(initial.size)) {
+      removeCollectible('category_error')
+    }
+  })
+  return initial
+}
+
+function markCollectibleSeen(id: string): void {
+  const seen = getSeenCollectibles()
+  seen.add(id)
+  try {
+    localStorage.setItem(SEEN_COLLECTIBLES_KEY, JSON.stringify([...seen]))
+  } catch { /* ignore */ }
+}
+
 export function addToInventory(item: Omit<UselessItem, 'acquiredDate'>): void {
   try {
-    const isNew = !getCollectibles().some(e => e.id === item.id)
+    const isNew = !getSeenCollectibles().has(item.id)
     const display: ItemDisplayFields = { name: item.name, icon: item.icon, desc: item.desc, lore: item.lore }
     addCollectible(item.id, display)
     if (isNew) {
+      markCollectibleSeen(item.id)
       import('./achievements').then(({ incrementAchievementProgress }) => {
         incrementAchievementProgress('misc:unique_items')
       })


### PR DESCRIPTION
## Summary

- **Root cause:** `addToInventory` checked whether an item was in the *current* inventory to decide if it was "new". Selling an item and reacquiring it made it look new again, so `misc:unique_items` was incremented twice for the same ID. This let the progress counter reach 423 without the player ever holding all unique items.
- **Fix:** Introduce a `jarv_seen_collectibles` localStorage set that tracks item IDs *ever* collected. `addToInventory` now checks this set instead of current inventory, and marks each truly-new item as seen on acquisition.
- **Retcon:** On first load with the new code, `initSeenCollectibles` seeds the seen set from current inventory and runs a one-time check. If `misc:items_full_set` is unlocked but the player has fewer than 423 unique items, the achievement is cleared (unlock, claim, and progress reset) and the `category_error` reward item is removed — so the player can earn it legitimately.

## Test plan

- [ ] Add a new item → `misc:unique_items` increments once
- [ ] Sell that item, re-add it → `misc:unique_items` does **not** increment again
- [ ] Player with all 423 unique items currently in inventory → achievement kept on load
- [ ] Player with < 423 unique items but `misc:items_full_set` marked unlocked → achievement retconned, `category_error` removed, progress reset to seen-set size

https://claude.ai/code/session_01JSqwSvaRCFsfQf99PJ7xvY

---
_Generated by [Claude Code](https://claude.ai/code/session_01JSqwSvaRCFsfQf99PJ7xvY)_