### PR TITLE
City Builder v2 — City Events Chronicle

### DIFF
--- a/web/src/components/minigames/CityBuilder.tsx
+++ b/web/src/components/minigames/CityBuilder.tsx
@@ -31,6 +31,7 @@ import {
   nextBuilderCost, buyBuilder,
   checkMilestones, MilestoneDef,
   currentSeason,
+  dispatchCaravan,
 } from '../../game/cityBuilder'
 import { AnimatedSpriteImg } from '../ui/SpriteImg'
 import { Card, UnitTemplate } from '../../game/types'
@@ -49,6 +50,7 @@ import { AttackStrip } from './citybuilder/AttackStrip'
 import { ResourceStrip } from './citybuilder/ResourceStrip'
 import { ChroniclePanel } from './citybuilder/ChroniclePanel'
 import { MilestoneBanner } from './citybuilder/MilestoneBanner'
+import { TradeRouteModal } from './citybuilder/TradeRouteModal'
 import { OverlayScreen } from '../ui/OverlayScreen'
 
 
@@ -496,6 +498,7 @@ export function CityBuilder({ onBack }: Props) {
   const [city, setCity] = useState<CityState>(() => tickCity(loadCityState()))
   const [screen, setScreen] = useState<SubScreen>('city')
   const [pendingMilestone, setPendingMilestone] = useState<MilestoneDef | null>(null)
+  const [showTrade, setShowTrade] = useState(false)
   const [pickerIndex, setPickerIndex] = useState<number>(0)
   const [levelCard, setLevelCard] = useState<string | null>(null)
   const [toast, setToast] = useState<string | null>(null)
@@ -1238,6 +1241,19 @@ export function CityBuilder({ onBack }: Props) {
           />
         )}
 
+        {showTrade && (
+          <TradeRouteModal
+            city={city}
+            currentTime={currentTime}
+            onDispatch={() => {
+              const next = dispatchCaravan(city)
+              if (next) save(next)
+              else showToast('Cannot dispatch caravan right now.')
+            }}
+            onClose={() => setShowTrade(false)}
+          />
+        )}
+
         {attackReport && (
           <AttackReportModal
             attackReport={attackReport}
@@ -1321,6 +1337,11 @@ export function CityBuilder({ onBack }: Props) {
           <button className="filter-btn" onClick={() => setScreen('fortify')} title="Manage city walls and moats">🛡 FORTIFICATIONS</button>
           <button className="filter-btn" onClick={() => setScreen('upgrade')} title="Upgrade buildings">★ UPGRADES</button>
           <button className="filter-btn" onClick={() => setScreen('chronicle')} title="View city history">📜 HISTORY</button>
+          <button
+            className={`filter-btn${city.tradeOffer && !city.activeCaravan ? ' city-trade-btn--ready' : ''}`}
+            onClick={() => setShowTrade(true)}
+            title="Trade resources via caravan"
+          >🐪 TRADE{city.activeCaravan ? ' (away)' : city.tradeOffer ? ' !' : ''}</button>
           {cityRows < MAX_CITY_ROWS && expansionCost && (
             <button
               className={`filter-btn city-expand-btn${affordable ? ' city-expand-btn--ready' : ''}`}

--- a/web/src/components/minigames/CityBuilder.tsx
+++ b/web/src/components/minigames/CityBuilder.tsx
@@ -45,6 +45,7 @@ import { CityGrid } from './citybuilder/CityGrid'
 import { CityPerimeter } from './citybuilder/CityPerimeter'
 import { AttackStrip } from './citybuilder/AttackStrip'
 import { ResourceStrip } from './citybuilder/ResourceStrip'
+import { ChroniclePanel } from './citybuilder/ChroniclePanel'
 import { OverlayScreen } from '../ui/OverlayScreen'
 
 
@@ -486,7 +487,7 @@ interface Props {
   onBack: () => void
 }
 
-type SubScreen = 'city' | 'picker' | 'upgrade' | 'levelup' | 'fortify' | 'towerdefence'
+type SubScreen = 'city' | 'picker' | 'upgrade' | 'levelup' | 'fortify' | 'towerdefence' | 'chronicle'
 
 export function CityBuilder({ onBack }: Props) {
   const [city, setCity] = useState<CityState>(() => tickCity(loadCityState()))
@@ -1197,6 +1198,17 @@ export function CityBuilder({ onBack }: Props) {
     )
   }
 
+  // ── Chronicle sub-screen ─────────────────────────────────────────────────────
+
+  if (screen === 'chronicle') {
+    return (
+      <ChroniclePanel
+        chronicle={city.chronicle ?? []}
+        onBack={() => setScreen('city')}
+      />
+    )
+  }
+
   // ── Main city view ────────────────────────────────────────────────────────────
 
   return (
@@ -1292,6 +1304,7 @@ export function CityBuilder({ onBack }: Props) {
           >{bulldozerMode ? '🧱 DEMOLISH' : '👷 BUILD'}</button>
           <button className="filter-btn" onClick={() => setScreen('fortify')} title="Manage city walls and moats">🛡 FORTIFICATIONS</button>
           <button className="filter-btn" onClick={() => setScreen('upgrade')} title="Upgrade buildings">★ UPGRADES</button>
+          <button className="filter-btn" onClick={() => setScreen('chronicle')} title="View city history">📜 HISTORY</button>
           {cityRows < MAX_CITY_ROWS && expansionCost && (
             <button
               className={`filter-btn city-expand-btn${affordable ? ' city-expand-btn--ready' : ''}`}

--- a/web/src/components/minigames/CityBuilder.tsx
+++ b/web/src/components/minigames/CityBuilder.tsx
@@ -29,6 +29,7 @@ import {
   spawnerUnitCount,
   getNeighbourIndices,
   nextBuilderCost, buyBuilder,
+  checkMilestones, MilestoneDef,
 } from '../../game/cityBuilder'
 import { AnimatedSpriteImg } from '../ui/SpriteImg'
 import { Card, UnitTemplate } from '../../game/types'
@@ -46,6 +47,7 @@ import { CityPerimeter } from './citybuilder/CityPerimeter'
 import { AttackStrip } from './citybuilder/AttackStrip'
 import { ResourceStrip } from './citybuilder/ResourceStrip'
 import { ChroniclePanel } from './citybuilder/ChroniclePanel'
+import { MilestoneBanner } from './citybuilder/MilestoneBanner'
 import { OverlayScreen } from '../ui/OverlayScreen'
 
 
@@ -492,6 +494,7 @@ type SubScreen = 'city' | 'picker' | 'upgrade' | 'levelup' | 'fortify' | 'towerd
 export function CityBuilder({ onBack }: Props) {
   const [city, setCity] = useState<CityState>(() => tickCity(loadCityState()))
   const [screen, setScreen] = useState<SubScreen>('city')
+  const [pendingMilestone, setPendingMilestone] = useState<MilestoneDef | null>(null)
   const [pickerIndex, setPickerIndex] = useState<number>(0)
   const [levelCard, setLevelCard] = useState<string | null>(null)
   const [toast, setToast] = useState<string | null>(null)
@@ -532,8 +535,12 @@ export function CityBuilder({ onBack }: Props) {
   }
 
   function save(next: CityState) {
-    setCity(next)
-    saveCityState(next)
+    const { state: checked, newlyCompleted } = checkMilestones(next)
+    setCity(checked)
+    saveCityState(checked)
+    if (newlyCompleted.length > 0 && !pendingMilestone) {
+      setPendingMilestone(newlyCompleted[0])
+    }
   }
 
   // Keep refs in sync so the animation loop and intervals always see the latest state
@@ -1222,6 +1229,13 @@ export function CityBuilder({ onBack }: Props) {
 
       <div className="city-screen u-relative u-col u-gap-2">
         {toast && <div className="city-toast" role="alert">{toast}</div>}
+
+        {pendingMilestone && (
+          <MilestoneBanner
+            milestone={pendingMilestone}
+            onDone={() => setPendingMilestone(null)}
+          />
+        )}
 
         {attackReport && (
           <AttackReportModal

--- a/web/src/components/minigames/CityBuilder.tsx
+++ b/web/src/components/minigames/CityBuilder.tsx
@@ -30,6 +30,7 @@ import {
   getNeighbourIndices,
   nextBuilderCost, buyBuilder,
   checkMilestones, MilestoneDef,
+  currentSeason,
 } from '../../game/cityBuilder'
 import { AnimatedSpriteImg } from '../ui/SpriteImg'
 import { Card, UnitTemplate } from '../../game/types'
@@ -1292,6 +1293,7 @@ export function CityBuilder({ onBack }: Props) {
           resources={city.resources}
           prodRates={prodRates}
           consRates={consRates}
+          season={currentSeason()}
         />
 
         <CityGrid

--- a/web/src/components/minigames/citybuilder/BuildingInspectModal.tsx
+++ b/web/src/components/minigames/citybuilder/BuildingInspectModal.tsx
@@ -3,6 +3,7 @@ import {
   CityState, CityCell, RESOURCE_ICONS, ResourceType,
   getBuildingProduces, masteryOutputMultiplier, getCardMasteryLevel,
   levelUpCost, LEVEL_UP_COSTS, spawnerUnitCount,
+  getCellSynergyBonuses, getCellIncomeBonus,
 } from '../../../game/cityBuilder'
 import { CollectionEntry, getMasteryXp, masteryProgress } from '../../../game/collection'
 import { MasteryBar } from '../../ui/MasteryBar'
@@ -33,6 +34,9 @@ export function BuildingInspectModal({
   const produces       = getBuildingProduces(cell.cardName)
   const masteryMult    = masteryOutputMultiplier(getCardMasteryLevel(cell.cardName) ?? 0)
   const produceEntries = Object.entries(produces).filter(([, v]) => (v ?? 0) > 0)
+  const synergies      = getCellSynergyBonuses(city, cellIndex)
+  const synergyMap     = Object.fromEntries(synergies.map(s => [s.resource, s.multiplier]))
+  const incomeBonus    = getCellIncomeBonus(city, cellIndex)
   const xp             = getMasteryXp(collection, cell.cardName)
   const { level: mLvl } = masteryProgress(xp)
   const upgradeCost    = levelUpCost(mLvl)
@@ -112,11 +116,25 @@ export function BuildingInspectModal({
           ) : produceEntries.length > 0 ? (
             <>
               <div className="city-bld-section-title">Produces</div>
-              {produceEntries.map(([res, amt]) => (
-                <div key={res} className="city-bld-produces-row">
-                  +{Math.round((amt as number) * masteryMult)} {RESOURCE_ICONS[res as ResourceType]}/min
-                </div>
+              {produceEntries.map(([res, amt]) => {
+                const sm = synergyMap[res as ResourceType] ?? 0
+                const total = Math.round((amt as number) * masteryMult * (1 + sm))
+                return (
+                  <div key={res} className="city-bld-produces-row">
+                    +{total} {RESOURCE_ICONS[res as ResourceType]}/min
+                    {sm > 0 && <span className="city-synergy-bonus"> ✦ synergy</span>}
+                  </div>
+                )
+              })}
+              {synergies.map((s, i) => (
+                <div key={i} className="city-synergy-label">{s.label}</div>
               ))}
+            </>
+          ) : cell.spawnedUnitName ? (
+            <>
+              {incomeBonus > 0 && (
+                <div className="city-synergy-label">🌾 Food producer nearby: +{Math.round(incomeBonus * 100)}% gold income</div>
+              )}
             </>
           ) : (
             <div className="city-bld-section-title">Defensive structure</div>

--- a/web/src/components/minigames/citybuilder/ChroniclePanel.tsx
+++ b/web/src/components/minigames/citybuilder/ChroniclePanel.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+
+export interface Props {
+  chronicle: string[]
+  onBack:    () => void
+}
+
+export function ChroniclePanel({ chronicle, onBack }: Props) {
+  return (
+    <div className="city-screen u-relative u-col u-gap-2">
+      <div className="city-header u-flex u-items-c u-gap-3">
+        <button className="action-btn" onClick={onBack}>← BACK</button>
+        <div className="city-title">📜 CITY CHRONICLE</div>
+      </div>
+
+      <div className="city-chronicle-list">
+        {chronicle.length === 0 ? (
+          <div className="city-chronicle-empty">No events recorded yet. Build, expand, and defend your city!</div>
+        ) : (
+          chronicle.map((entry, i) => (
+            <div key={i} className="city-chronicle-entry">{entry}</div>
+          ))
+        )}
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/minigames/citybuilder/MilestoneBanner.tsx
+++ b/web/src/components/minigames/citybuilder/MilestoneBanner.tsx
@@ -1,0 +1,29 @@
+import React, { useEffect, useState } from 'react'
+import { MilestoneDef } from '../../../game/cityBuilder'
+
+export interface Props {
+  milestone: MilestoneDef
+  onDone: () => void
+}
+
+export function MilestoneBanner({ milestone, onDone }: Props) {
+  const [fading, setFading] = useState(false)
+
+  useEffect(() => {
+    const fadeTimer = setTimeout(() => setFading(true), 3200)
+    const doneTimer = setTimeout(onDone, 4000)
+    return () => { clearTimeout(fadeTimer); clearTimeout(doneTimer) }
+  }, [onDone])
+
+  return (
+    <div className={`city-milestone-banner${fading ? ' city-milestone-banner--fading' : ''}`}>
+      <div className="city-milestone-icon">{milestone.icon}</div>
+      <div className="city-milestone-text">
+        <div className="city-milestone-title">MILESTONE: {milestone.label.toUpperCase()}</div>
+        <div className="city-milestone-reward">+{milestone.goldReward.toLocaleString()} gold
+          {milestone.resourceReward && Object.entries(milestone.resourceReward).map(([r, v]) => ` · +${v} ${r}`).join('')}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/minigames/citybuilder/ResourceStrip.stories.tsx
+++ b/web/src/components/minigames/citybuilder/ResourceStrip.stories.tsx
@@ -18,6 +18,7 @@ export const Empty: Story = {
     resources: emptyResources,
     prodRates: {},
     consRates: {},
+    season: 'spring',
   },
 }
 
@@ -28,6 +29,7 @@ export const WithResources: Story = {
     resources: { wheat: 120, wood: 35, ore: 12, bread: 8, planks: 5, metal: 2 },
     prodRates: { wheat: 10, wood: 4, ore: 2 },
     consRates: { wheat: 6, bread: 1 },
+    season: 'summer',
   },
 }
 
@@ -38,5 +40,6 @@ export const CriticalResources: Story = {
     resources: { wheat: 3, wood: 0, ore: 0, bread: 0, planks: 0, metal: 0 },
     prodRates: { wheat: 2 },
     consRates: { wheat: 8 },
+    season: 'winter',
   },
 }

--- a/web/src/components/minigames/citybuilder/ResourceStrip.tsx
+++ b/web/src/components/minigames/citybuilder/ResourceStrip.tsx
@@ -13,7 +13,7 @@ export interface Props {
 }
 
 export function ResourceStrip({ defense, population, resources, prodRates, consRates, season }: Props) {
-  const si = SEASON_INFO[season]
+  const si = SEASON_INFO[season] ?? SEASON_INFO['spring']
   return (
     <div className="city-res-strip">
       <span className="city-info-chip" title={`Defense: ${defense}`}>🛡 {defense}</span>

--- a/web/src/components/minigames/citybuilder/ResourceStrip.tsx
+++ b/web/src/components/minigames/citybuilder/ResourceStrip.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { RESOURCE_ICONS, ResourceType, ResourceStock } from '../../../game/cityBuilder'
+import { RESOURCE_ICONS, ResourceType, ResourceStock, Season, SEASON_INFO } from '../../../game/cityBuilder'
 
 const RESOURCE_TYPES: ResourceType[] = ['wheat', 'wood', 'ore', 'bread', 'planks', 'metal']
 
@@ -9,13 +9,16 @@ export interface Props {
   resources:  ResourceStock
   prodRates:  Partial<Record<ResourceType, number>>
   consRates:  Partial<Record<ResourceType, number>>
+  season:     Season
 }
 
-export function ResourceStrip({ defense, population, resources, prodRates, consRates }: Props) {
+export function ResourceStrip({ defense, population, resources, prodRates, consRates, season }: Props) {
+  const si = SEASON_INFO[season]
   return (
     <div className="city-res-strip">
       <span className="city-info-chip" title={`Defense: ${defense}`}>🛡 {defense}</span>
       <span className="city-info-chip" title={`Population: ${population}`}>👥 {population}</span>
+      <span className="city-info-chip city-season-chip" title={si.flavour}>{si.icon} {si.name}</span>
       {RESOURCE_TYPES.map(res => {
         const stock = Math.floor(resources[res])
         const prod  = prodRates[res] ?? 0

--- a/web/src/components/minigames/citybuilder/TradeRouteModal.tsx
+++ b/web/src/components/minigames/citybuilder/TradeRouteModal.tsx
@@ -1,0 +1,112 @@
+import React from 'react'
+import { CityState, TradeOffer, ActiveCaravan, RESOURCE_ICONS } from '../../../game/cityBuilder'
+
+function fmtMs(ms: number): string {
+  const totalMin = Math.floor(ms / 60_000)
+  const h = Math.floor(totalMin / 60)
+  const m = totalMin % 60
+  if (h > 0) return `${h}h ${m}m`
+  return `${m}m`
+}
+
+export interface Props {
+  city:             CityState
+  currentTime:      number
+  onDispatch:       () => void
+  onClose:          () => void
+}
+
+function OfferCard({ offer, city, currentTime, onDispatch, onClose }: {
+  offer: TradeOffer
+  city: CityState
+  currentTime: number
+  onDispatch: () => void
+  onClose: () => void
+}) {
+  const isSell = offer.direction === 'sell'
+  const canAfford = isSell
+    ? city.resources[offer.resource] >= offer.amount
+    : city.gold >= offer.gold
+  const expiresIn = Math.max(0, offer.expiresAt - currentTime)
+
+  return (
+    <div className="city-trade-offer">
+      <div className="city-trade-offer-title">
+        {isSell ? '📤 SELL OFFER' : '📥 BUY OFFER'}
+        <span className="city-trade-expires"> expires {fmtMs(expiresIn)}</span>
+      </div>
+      <div className="city-trade-offer-body">
+        {isSell ? (
+          <>
+            Send <strong>{offer.amount} {RESOURCE_ICONS[offer.resource]} {offer.resource}</strong>
+            {' '}→ receive <strong>⚙ {offer.gold.toLocaleString()} gold</strong>
+          </>
+        ) : (
+          <>
+            Pay <strong>⚙ {offer.gold.toLocaleString()} gold</strong>
+            {' '}→ receive <strong>{offer.amount} {RESOURCE_ICONS[offer.resource]} {offer.resource}</strong>
+          </>
+        )}
+      </div>
+      {!canAfford && (
+        <div className="city-trade-warn">
+          {isSell ? `Need ${offer.amount} ${offer.resource} (have ${Math.floor(city.resources[offer.resource])})` : `Need ⚙ ${offer.gold.toLocaleString()} gold`}
+        </div>
+      )}
+      <button
+        className={`action-btn${canAfford ? ' action-btn--gold' : ''}`}
+        disabled={!canAfford}
+        onClick={() => { onDispatch(); onClose() }}
+      >
+        🐪 DISPATCH CARAVAN
+      </button>
+    </div>
+  )
+}
+
+function CaravanStatus({ caravan, currentTime }: { caravan: ActiveCaravan; currentTime: number }) {
+  const returnsIn = Math.max(0, caravan.returnsAt - currentTime)
+  const isSell = caravan.offer.direction === 'sell'
+  return (
+    <div className="city-trade-caravan">
+      <div className="city-trade-caravan-title">🐪 CARAVAN AWAY</div>
+      <div className="city-trade-caravan-body">
+        {isSell
+          ? `Delivering ${caravan.offer.amount} ${caravan.offer.resource} — returning with ⚙ ${caravan.offer.gold.toLocaleString()} gold`
+          : `Fetching ${caravan.offer.amount} ${caravan.offer.resource} — returning in ${fmtMs(returnsIn)}`
+        }
+      </div>
+      <div className="city-trade-returns">Returns in {fmtMs(returnsIn)}</div>
+    </div>
+  )
+}
+
+export function TradeRouteModal({ city, currentTime, onDispatch, onClose }: Props) {
+  return (
+    <div className="city-req-overlay" onClick={onClose}>
+      <div className="city-req-modal" onClick={e => e.stopPropagation()}>
+        <div className="city-req-header">🐪 TRADE ROUTES</div>
+        <div className="city-trade-desc">
+          Dispatch a caravan to trade resources. A new offer arrives every 4 hours.
+          The caravan returns with goods after 2 hours.
+        </div>
+
+        {city.activeCaravan ? (
+          <CaravanStatus caravan={city.activeCaravan} currentTime={currentTime} />
+        ) : city.tradeOffer ? (
+          <OfferCard
+            offer={city.tradeOffer}
+            city={city}
+            currentTime={currentTime}
+            onDispatch={onDispatch}
+            onClose={onClose}
+          />
+        ) : (
+          <div className="city-trade-waiting">No offer available yet — check back soon.</div>
+        )}
+
+        <button className="action-btn" onClick={onClose}>CLOSE</button>
+      </div>
+    </div>
+  )
+}

--- a/web/src/game/cityBuilder.ts
+++ b/web/src/game/cityBuilder.ts
@@ -191,6 +191,68 @@ export function getBuildingProduces(name: string): Partial<ResourceStock> {
   return {}
 }
 
+// ── Adjacency synergy rules ───────────────────────────────────────────────────
+
+interface SynergyRule {
+  /** Resource this building must produce to be eligible. */
+  needs: ResourceType
+  /** Resource a neighbour must produce to activate the synergy. */
+  feeds: ResourceType
+  /** Additive production multiplier bonus (e.g. 0.5 = +50%). */
+  bonus: number
+  label: string
+}
+
+const SYNERGY_RULES: SynergyRule[] = [
+  { needs: 'bread',  feeds: 'wheat', bonus: 0.5, label: '🌾 Farm nearby: +50% bread'   },
+  { needs: 'metal',  feeds: 'wood',  bonus: 0.5, label: '🪵 Lumber nearby: +50% metal'  },
+  { needs: 'planks', feeds: 'ore',   bonus: 0.5, label: '⛏ Mine nearby: +50% planks'   },
+]
+
+/** Additive gold income bonus for a spawn building adjacent to a food producer. */
+const SPAWN_FOOD_ADJACENCY_BONUS = 0.2  // +20% gold income
+
+/**
+ * Returns active synergy bonuses for a resource-producing building.
+ * Each entry is an additive multiplier on that resource's output.
+ */
+export function getCellSynergyBonuses(
+  state: CityState,
+  cellIndex: number,
+): Array<{ resource: ResourceType; multiplier: number; label: string }> {
+  const cell = state.grid[cellIndex]
+  if (!cell) return []
+  const gridRows = state.rows ?? CITY_ROWS
+  const neighbours = getNeighbourIndices(cellIndex, gridRows)
+    .map(ni => state.grid[ni])
+    .filter((nb): nb is CityCell => nb != null)
+  const produces = getBuildingProduces(cell.cardName)
+  const bonuses: Array<{ resource: ResourceType; multiplier: number; label: string }> = []
+  for (const rule of SYNERGY_RULES) {
+    if ((produces[rule.needs] ?? 0) > 0) {
+      if (neighbours.some(nb => (getBuildingProduces(nb.cardName)[rule.feeds] ?? 0) > 0)) {
+        bonuses.push({ resource: rule.needs, multiplier: rule.bonus, label: rule.label })
+      }
+    }
+  }
+  return bonuses
+}
+
+/**
+ * Additive gold income bonus for a spawn building that has a food producer
+ * as an orthogonal neighbour.
+ */
+export function getCellIncomeBonus(state: CityState, cellIndex: number): number {
+  const cell = state.grid[cellIndex]
+  if (!cell?.spawnedUnitName) return 0
+  const gridRows = state.rows ?? CITY_ROWS
+  const hasFoodNeighbour = getNeighbourIndices(cellIndex, gridRows).some(ni => {
+    const nb = state.grid[ni]
+    return nb && (getBuildingProduces(nb.cardName).wheat ?? 0) > 0
+  })
+  return hasFoodNeighbour ? SPAWN_FOOD_ADJACENCY_BONUS : 0
+}
+
 // ── Types ─────────────────────────────────────────────────────────────────────
 
 export type ResourceType = 'wheat' | 'wood' | 'ore' | 'bread' | 'planks' | 'metal'
@@ -572,15 +634,22 @@ export function tickCity(state: CityState): CityState {
     const happy = (newHappy[i] ?? 100) > 0
     const unitCount = cell.spawnedUnitName ? spawnerUnitCount(state, cell.cardName) : 1
 
-    // Gold income
-    goldEarned += cellIncomeRate(cell, happy, unitCount) * minutes
+    // Gold income (with adjacency bonus for spawn buildings near food)
+    const incomeBonus = cell.spawnedUnitName ? getCellIncomeBonus(state, i) : 0
+    goldEarned += cellIncomeRate(cell, happy, unitCount) * (1 + incomeBonus) * minutes
 
     // Resource production (utility/non-spawner buildings that produce resources)
     if (!cell.spawnedUnitName) {
       const masteryMult = masteryOutputMultiplier(getCardMasteryLevel(cell.cardName) ?? 0)
       const produces = getBuildingProduces(cell.cardName)
+      const synergies = getCellSynergyBonuses(state, i)
+      const synergyMap: Partial<Record<ResourceType, number>> = {}
+      for (const s of synergies) synergyMap[s.resource] = (synergyMap[s.resource] ?? 0) + s.multiplier
       for (const [res, rate] of Object.entries(produces) as [ResourceType, number][]) {
-        if (rate > 0) newResources[res] = (newResources[res] ?? 0) + rate * masteryMult * minutes
+        if (rate > 0) {
+          const synergyMult = 1 + (synergyMap[res as ResourceType] ?? 0)
+          newResources[res] = (newResources[res] ?? 0) + rate * masteryMult * synergyMult * minutes
+        }
       }
     }
 
@@ -915,12 +984,17 @@ export function levelUpCard(state: CityState, cardName: string, masteryLvl: numb
 
 export function resourceProductionRate(state: CityState): Partial<ResourceStock> {
   const rates: Partial<ResourceStock> = {}
-  for (const cell of state.grid) {
+  for (let i = 0; i < state.grid.length; i++) {
+    const cell = state.grid[i]
     if (!cell || cell.spawnedUnitName) continue
     const masteryMult = masteryOutputMultiplier(getCardMasteryLevel(cell.cardName) ?? 0)
     const produces = getBuildingProduces(cell.cardName)
+    const synergies = getCellSynergyBonuses(state, i)
+    const synergyMap: Partial<Record<ResourceType, number>> = {}
+    for (const s of synergies) synergyMap[s.resource] = (synergyMap[s.resource] ?? 0) + s.multiplier
     for (const [res, rate] of Object.entries(produces) as [ResourceType, number][]) {
-      rates[res] = (rates[res] ?? 0) + rate * masteryMult
+      const synergyMult = 1 + (synergyMap[res as ResourceType] ?? 0)
+      rates[res] = (rates[res] ?? 0) + rate * masteryMult * synergyMult
     }
   }
   return rates

--- a/web/src/game/cityBuilder.ts
+++ b/web/src/game/cityBuilder.ts
@@ -254,6 +254,8 @@ export interface CityState {
   lastAttack:     AttackEvent | null
   /** Temporary defense bonus from actively patrolling residents. */
   patrolBonus?:   number
+  /** Chronological log of notable city events, newest first (max 50). */
+  chronicle:      string[]
 }
 
 // ── Storage ───────────────────────────────────────────────────────────────────
@@ -278,6 +280,7 @@ function defaultState(): CityState {
     builderQueue:   [],
     builderCount:   DEFAULT_BUILDER_COUNT,
     lastAttack:     null,
+    chronicle:      [],
   }
 }
 
@@ -316,6 +319,7 @@ export function loadCityState(): CityState {
       builderQueue:   parsed.builderQueue ?? [],
       builderCount:   parsed.builderCount ?? DEFAULT_BUILDER_COUNT,
       lastAttack:     parsed.lastAttack ?? null,
+      chronicle:      parsed.chronicle ?? [],
     }
   } catch (err) {
     logError('loadCityState failed', err as Record<string, unknown>)
@@ -329,6 +333,21 @@ export function saveCityState(state: CityState): void {
   } catch (err) {
     logError('saveCityState failed', err as Record<string, unknown>)
   }
+}
+
+// ── Chronicle helpers ─────────────────────────────────────────────────────────
+
+const CHRONICLE_MAX = 50
+
+function fmtTime(ts: number): string {
+  const d = new Date(ts)
+  return d.toLocaleString(undefined, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })
+}
+
+export function addChronicleEvent(state: CityState, msg: string): CityState {
+  const entry = `[${fmtTime(Date.now())}] ${msg}`
+  const chronicle = [entry, ...(state.chronicle ?? [])].slice(0, CHRONICLE_MAX)
+  return { ...state, chronicle }
 }
 
 // ── Mastery helpers ───────────────────────────────────────────────────────────
@@ -514,8 +533,15 @@ function processAttack(state: CityState): CityState {
     destroyedBuildings,
   }
 
+  const attackMsg =
+    outcome === 'repelled' ? `⚔ Attack repelled — +${goldEarned.toLocaleString()} gold earned` :
+    outcome === 'partial'  ? `⚠ City raided — ${stolenGold.toLocaleString()} gold stolen` :
+    `💀 City defeated — ${stolenGold.toLocaleString()} gold stolen${destroyedBuildings.length > 0 ? `, lost: ${destroyedBuildings.join(', ')}` : ''}`
+
+  const stateWithChronicle = addChronicleEvent(state, attackMsg)
+
   return {
-    ...state,
+    ...stateWithChronicle,
     gold:           Math.max(0, newGold),
     resources:      newResources,
     grid:           newGrid,
@@ -608,6 +634,7 @@ export function tickCity(state: CityState): CityState {
   const now2 = now
   const remainingQueue = state.builderQueue.filter(e => e.completesAt > now2)
   const completedBuilds = state.builderQueue.filter(e => e.completesAt <= now2)
+  const completedFortNames: string[] = []
   for (const entry of completedBuilds) {
     if (newForts.length < MAX_TOTAL_FORTS) {
       newForts.push({
@@ -617,6 +644,7 @@ export function tickCity(state: CityState): CityState {
         maxHp:        FORT_MAX_HP[entry.rarity],
         attacksTaken: 0,
       })
+      completedFortNames.push(entry.cardName)
     }
   }
 
@@ -633,6 +661,10 @@ export function tickCity(state: CityState): CityState {
     happiness:      newHappy,
     fortifications: newForts,
     builderQueue:   remainingQueue,
+  }
+
+  for (const name of completedFortNames) {
+    result = addChronicleEvent(result, `🏗 ${name} construction complete`)
   }
 
   // Process any pending attacks — batch if more than one was missed while offline
@@ -709,7 +741,8 @@ export function placeCard(state: CityState, index: number, cell: CityCell): City
     }
   }
 
-  return { ...state, grid, happiness, resources }
+  const placed = addChronicleEvent({ ...state, grid, happiness, resources }, `🏛 ${cell.cardName} placed`)
+  return placed
 }
 
 /** Invite a vacant unit back into their building, restoring partial happiness. */
@@ -717,15 +750,18 @@ export function reoccupyBuilding(state: CityState, index: number): CityState {
   const cell = state.grid[index]
   if (!cell?.spawnedUnitName) return state
   if ((state.happiness[index] ?? 100) > 0) return state
-  return { ...state, happiness: { ...state.happiness, [index]: 50 } }
+  const next = { ...state, happiness: { ...state.happiness, [index]: 50 } }
+  return addChronicleEvent(next, `🏠 ${cell.spawnedUnitName} moved back into ${cell.cardName}`)
 }
 
 export function removeCard(state: CityState, index: number): CityState {
+  const cell = state.grid[index]
   const grid = [...state.grid]
   grid[index] = undefined
   const happiness = { ...state.happiness }
   delete happiness[index]
-  return { ...state, grid, happiness }
+  const next = { ...state, grid, happiness }
+  return cell ? addChronicleEvent(next, `🔨 ${cell.cardName} demolished`) : next
 }
 
 // ── Fortification helpers ─────────────────────────────────────────────────────
@@ -756,12 +792,13 @@ export function addFortification(state: CityState, cardName: string, rarity: Car
   const buildMinutes = FORT_BUILD_MINUTES[rarity]
   const completesAt = Date.now() + buildMinutes * 60_000
   const entry: BuildQueueEntry = { cardName, rarity, completesAt }
-  return {
+  const next = {
     ...state,
     gold:         state.gold - cost.gold,
     resources:    newResources,
     builderQueue: [...state.builderQueue, entry],
   }
+  return addChronicleEvent(next, `🧱 ${cardName} fortification queued`)
 }
 
 /** Cost to hire the next extra builder (beyond DEFAULT_BUILDER_COUNT). */
@@ -816,13 +853,14 @@ export function expandCity(state: CityState): CityState | null {
     newResources[res] = Math.max(0, (state.resources[res] ?? 0) - amt)
   }
 
-  return {
+  const next = {
     ...state,
     rows:      newRows,
     grid:      newGrid,
     gold:      state.gold - cost.gold,
     resources: newResources,
   }
+  return addChronicleEvent(next, `🏙 City expanded to ${newRows} rows`)
 }
 
 // ── Affordability ─────────────────────────────────────────────────────────────

--- a/web/src/game/cityBuilder.ts
+++ b/web/src/game/cityBuilder.ts
@@ -318,6 +318,10 @@ export interface CityState {
   patrolBonus?:   number
   /** Chronological log of notable city events, newest first (max 50). */
   chronicle:      string[]
+  /** IDs of milestones already awarded (prevents duplicate rewards). */
+  completedMilestones: string[]
+  /** Total number of attacks processed (used for milestone checks). */
+  attacksProcessed: number
 }
 
 // ── Storage ───────────────────────────────────────────────────────────────────
@@ -341,8 +345,10 @@ function defaultState(): CityState {
     fortifications: [],
     builderQueue:   [],
     builderCount:   DEFAULT_BUILDER_COUNT,
-    lastAttack:     null,
-    chronicle:      [],
+    lastAttack:          null,
+    chronicle:           [],
+    completedMilestones: [],
+    attacksProcessed:    0,
   }
 }
 
@@ -381,7 +387,9 @@ export function loadCityState(): CityState {
       builderQueue:   parsed.builderQueue ?? [],
       builderCount:   parsed.builderCount ?? DEFAULT_BUILDER_COUNT,
       lastAttack:     parsed.lastAttack ?? null,
-      chronicle:      parsed.chronicle ?? [],
+      chronicle:           parsed.chronicle ?? [],
+      completedMilestones: parsed.completedMilestones ?? [],
+      attacksProcessed:    parsed.attacksProcessed ?? 0,
     }
   } catch (err) {
     logError('loadCityState failed', err as Record<string, unknown>)
@@ -410,6 +418,102 @@ export function addChronicleEvent(state: CityState, msg: string): CityState {
   const entry = `[${fmtTime(Date.now())}] ${msg}`
   const chronicle = [entry, ...(state.chronicle ?? [])].slice(0, CHRONICLE_MAX)
   return { ...state, chronicle }
+}
+
+// ── Milestones ────────────────────────────────────────────────────────────────
+
+export interface MilestoneDef {
+  id:              string
+  label:           string
+  icon:            string
+  description:     string
+  condition:       (state: CityState) => boolean
+  goldReward:      number
+  resourceReward?: Partial<ResourceStock>
+}
+
+export const MILESTONES: MilestoneDef[] = [
+  {
+    id: 'first_building', label: 'First Steps', icon: '🏛',
+    description: 'Place your first building',
+    condition: s => s.grid.some(c => c != null),
+    goldReward: 500,
+  },
+  {
+    id: 'population_10', label: 'Growing City', icon: '👥',
+    description: 'Reach a population of 10',
+    condition: s => cityPopulation(s) >= 10,
+    goldReward: 5000,
+  },
+  {
+    id: 'first_fort', label: 'Fortified', icon: '🧱',
+    description: 'Complete your first fortification',
+    condition: s => s.fortifications.length > 0,
+    goldReward: 2000,
+    resourceReward: { wood: 50 },
+  },
+  {
+    id: 'gold_100k', label: 'Prosperous', icon: '🪙',
+    description: 'Accumulate 100,000 gold',
+    condition: s => s.gold >= 100000,
+    goldReward: 10000,
+  },
+  {
+    id: 'five_attacks', label: 'Battle-Hardened', icon: '⚔',
+    description: 'Survive 5 attacks',
+    condition: s => (s.attacksProcessed ?? 0) >= 5,
+    goldReward: 25000,
+  },
+  {
+    id: 'all_resources', label: 'Self-Sufficient', icon: '🌾',
+    description: 'Produce all 6 resource types',
+    condition: s => {
+      const types: ResourceType[] = ['wheat', 'wood', 'ore', 'bread', 'planks', 'metal']
+      return types.every(r => s.grid.some(c => c && !c.spawnedUnitName && (getBuildingProduces(c.cardName)[r] ?? 0) > 0))
+    },
+    goldReward: 5000,
+  },
+  {
+    id: 'max_expansion', label: 'Metropolis', icon: '🏙',
+    description: `Expand the city to ${MAX_CITY_ROWS} rows`,
+    condition: s => (s.rows ?? CITY_ROWS) >= MAX_CITY_ROWS,
+    goldReward: 50000,
+  },
+]
+
+/**
+ * Checks all milestones and awards any newly completed ones.
+ * Returns the updated state and the list of newly completed milestone IDs.
+ */
+export function checkMilestones(state: CityState): { state: CityState; newlyCompleted: MilestoneDef[] } {
+  const completed = new Set(state.completedMilestones ?? [])
+  const newlyCompleted: MilestoneDef[] = []
+  let next = state
+
+  for (const m of MILESTONES) {
+    if (completed.has(m.id)) continue
+    if (!m.condition(next)) continue
+
+    // Award reward
+    let gold = next.gold + m.goldReward
+    let resources = { ...next.resources }
+    if (m.resourceReward) {
+      for (const [res, amt] of Object.entries(m.resourceReward) as [ResourceType, number][]) {
+        resources[res] = (resources[res] ?? 0) + amt
+      }
+    }
+    const chronicle = addChronicleEvent(next, `${m.icon} Milestone: ${m.label} — +${m.goldReward.toLocaleString()} gold!`).chronicle
+    next = {
+      ...next,
+      gold,
+      resources,
+      chronicle,
+      completedMilestones: [...(next.completedMilestones ?? []), m.id],
+    }
+    newlyCompleted.push(m)
+  }
+
+  return { state: next, newlyCompleted }
 }
 
 // ── Mastery helpers ───────────────────────────────────────────────────────────
@@ -604,12 +708,13 @@ function processAttack(state: CityState): CityState {
 
   return {
     ...stateWithChronicle,
-    gold:           Math.max(0, newGold),
-    resources:      newResources,
-    grid:           newGrid,
-    fortifications: survivingForts,
-    nextAttackAt:   state.nextAttackAt + nextInterval,
-    lastAttack:     event,
+    gold:             Math.max(0, newGold),
+    resources:        newResources,
+    grid:             newGrid,
+    fortifications:   survivingForts,
+    nextAttackAt:     state.nextAttackAt + nextInterval,
+    lastAttack:       event,
+    attacksProcessed: (state.attacksProcessed ?? 0) + 1,
   }
 }
 
@@ -790,7 +895,8 @@ export function tickCity(state: CityState): CityState {
     }
   }
 
-  return result
+  const { state: resultWithMilestones } = checkMilestones(result)
+  return resultWithMilestones
 }
 
 // ── Grid helpers ──────────────────────────────────────────────────────────────
@@ -811,7 +917,7 @@ export function placeCard(state: CityState, index: number, cell: CityCell): City
   }
 
   const placed = addChronicleEvent({ ...state, grid, happiness, resources }, `🏛 ${cell.cardName} placed`)
-  return placed
+  return checkMilestones(placed).state
 }
 
 /** Invite a vacant unit back into their building, restoring partial happiness. */

--- a/web/src/game/cityBuilder.ts
+++ b/web/src/game/cityBuilder.ts
@@ -330,6 +330,23 @@ export interface AttackEvent {
   count?:              number   // set when summarising multiple missed attacks
 }
 
+export type TradeDirection = 'sell' | 'buy'
+
+export interface TradeOffer {
+  resource:   ResourceType
+  direction:  TradeDirection
+  /** Amount of resource traded. */
+  amount:     number
+  /** Gold received (sell) or paid (buy). */
+  gold:       number
+  expiresAt:  number
+}
+
+export interface ActiveCaravan {
+  offer:       TradeOffer
+  returnsAt:   number
+}
+
 export interface CityState {
   grid:           (CityCell | undefined)[]
   gold:           number
@@ -358,6 +375,10 @@ export interface CityState {
   completedMilestones: string[]
   /** Total number of attacks processed (used for milestone checks). */
   attacksProcessed: number
+  /** Current trade offer available to dispatch (null = generating). */
+  tradeOffer:    TradeOffer | null
+  /** Caravan currently away on a trade mission. */
+  activeCaravan: ActiveCaravan | null
 }
 
 // ── Storage ───────────────────────────────────────────────────────────────────
@@ -385,6 +406,8 @@ function defaultState(): CityState {
     chronicle:           [],
     completedMilestones: [],
     attacksProcessed:    0,
+    tradeOffer:          null,
+    activeCaravan:       null,
   }
 }
 
@@ -426,6 +449,8 @@ export function loadCityState(): CityState {
       chronicle:           parsed.chronicle ?? [],
       completedMilestones: parsed.completedMilestones ?? [],
       attacksProcessed:    parsed.attacksProcessed ?? 0,
+      tradeOffer:          parsed.tradeOffer ?? null,
+      activeCaravan:       parsed.activeCaravan ?? null,
     }
   } catch (err) {
     logError('loadCityState failed', err as Record<string, unknown>)
@@ -887,6 +912,9 @@ export function tickCity(state: CityState): CityState {
     result = addChronicleEvent(result, `🏗 ${name} construction complete`)
   }
 
+  // Process trade routes (caravan returns, new offer generation)
+  result = processTrade(result, now)
+
   // Process any pending attacks — batch if more than one was missed while offline
   if (now >= result.nextAttackAt) {
     // Count how many attacks are overdue
@@ -1110,6 +1138,98 @@ export function goldIncomeRate(state: CityState): number {
 
 export function goldNetRate(state: CityState): number {
   return goldIncomeRate(state)
+}
+
+// ── Trade routes ──────────────────────────────────────────────────────────────
+
+/** New offer every 4 hours; caravan returns after 2 hours. */
+const TRADE_OFFER_INTERVAL_MS = 4 * 3600 * 1000
+const CARAVAN_RETURN_MS       = 2 * 3600 * 1000
+
+function generateTradeOffer(now: number): TradeOffer {
+  const resources: ResourceType[] = ['wheat', 'wood', 'ore', 'bread', 'planks', 'metal']
+  const resource  = resources[Math.floor(Math.random() * resources.length)]
+  const direction: TradeDirection = Math.random() < 0.6 ? 'sell' : 'buy'
+  // Base amounts and gold values per resource
+  const BASE: Record<ResourceType, { amount: number; goldPerUnit: number }> = {
+    wheat:  { amount: 100, goldPerUnit: 20  },
+    wood:   { amount: 80,  goldPerUnit: 25  },
+    ore:    { amount: 60,  goldPerUnit: 35  },
+    bread:  { amount: 50,  goldPerUnit: 50  },
+    planks: { amount: 40,  goldPerUnit: 60  },
+    metal:  { amount: 30,  goldPerUnit: 80  },
+  }
+  const { amount, goldPerUnit } = BASE[resource]
+  const jitter = 0.8 + Math.random() * 0.4  // ±20% variance
+  const finalAmount = Math.round(amount * jitter)
+  const finalGold   = Math.round(finalAmount * goldPerUnit * (direction === 'sell' ? 1 : 0.7))
+  return {
+    resource,
+    direction,
+    amount:    finalAmount,
+    gold:      finalGold,
+    expiresAt: now + TRADE_OFFER_INTERVAL_MS,
+  }
+}
+
+export function dispatchCaravan(state: CityState): CityState | null {
+  const offer = state.tradeOffer
+  if (!offer || state.activeCaravan) return null
+  if (Date.now() > offer.expiresAt) return null
+
+  let newGold      = state.gold
+  const newRes     = { ...state.resources }
+
+  if (offer.direction === 'sell') {
+    if (newRes[offer.resource] < offer.amount) return null
+    newRes[offer.resource] = Math.max(0, newRes[offer.resource] - offer.amount)
+  } else {
+    if (newGold < offer.gold) return null
+    newGold -= offer.gold
+  }
+
+  const caravan: ActiveCaravan = { offer, returnsAt: Date.now() + CARAVAN_RETURN_MS }
+  const next: CityState = {
+    ...state,
+    gold:          newGold,
+    resources:     newRes,
+    tradeOffer:    null,
+    activeCaravan: caravan,
+  }
+  return addChronicleEvent(next, `🐪 Caravan dispatched — trading ${offer.amount} ${offer.resource}`)
+}
+
+/** Processes caravan return and new offer generation inside tickCity. */
+function processTrade(state: CityState, now: number): CityState {
+  let next = state
+
+  // Resolve returning caravan
+  if (next.activeCaravan && now >= next.activeCaravan.returnsAt) {
+    const { offer } = next.activeCaravan
+    const newRes = { ...next.resources }
+    let newGold  = next.gold
+    if (offer.direction === 'sell') {
+      newGold += offer.gold
+    } else {
+      newRes[offer.resource] = (newRes[offer.resource] ?? 0) + offer.amount
+    }
+    const msg = offer.direction === 'sell'
+      ? `🐪 Caravan returned — +${offer.gold.toLocaleString()} gold from selling ${offer.amount} ${offer.resource}`
+      : `🐪 Caravan returned — +${offer.amount} ${offer.resource} delivered`
+    next = addChronicleEvent({ ...next, gold: newGold, resources: newRes, activeCaravan: null }, msg)
+  }
+
+  // Generate new offer if none present and not waiting on a caravan
+  if (!next.tradeOffer && !next.activeCaravan) {
+    next = { ...next, tradeOffer: generateTradeOffer(now) }
+  }
+
+  // Expire stale offer
+  if (next.tradeOffer && now > next.tradeOffer.expiresAt) {
+    next = { ...next, tradeOffer: generateTradeOffer(now) }
+  }
+
+  return next
 }
 
 // ── Card levelling ────────────────────────────────────────────────────────────

--- a/web/src/game/cityBuilder.ts
+++ b/web/src/game/cityBuilder.ts
@@ -145,6 +145,42 @@ export const EXPANSION_COSTS: Record<number, { gold: number; resources: Partial<
 /** Hard cap on total fortifications (prevents unlimited stacking). */
 export const MAX_TOTAL_FORTS = 12
 
+// ── Seasonal cycles ───────────────────────────────────────────────────────────
+
+export type Season = 'spring' | 'summer' | 'autumn' | 'winter'
+
+export interface SeasonInfo {
+  name:   string
+  icon:   string
+  /** Additive wheat production modifier (e.g. 0.1 = +10%). */
+  wheat:  number
+  /** Additive wood production modifier. */
+  wood:   number
+  /** Additive ore production modifier. */
+  ore:    number
+  /** Additive happiness regen modifier. */
+  regen:  number
+  /** Additive wheat consumption modifier for spawners (positive = more hungry). */
+  hunger: number
+  flavour: string
+}
+
+export const SEASON_INFO: Record<Season, SeasonInfo> = {
+  spring: { name: 'Spring', icon: '🌸', wheat: 0.10, wood: 0,    ore: 0,    regen:  0.15, hunger:  0,    flavour: 'Mild weather, good harvests' },
+  summer: { name: 'Summer', icon: '☀️', wheat: 0.30, wood: 0,    ore: 0,    regen:  0,    hunger:  0.10, flavour: 'Bountiful wheat, hungry residents' },
+  autumn: { name: 'Autumn', icon: '🍂', wheat: 0,    wood: 0.25, ore: 0.25, regen:  0,    hunger:  0,    flavour: 'Rich timber and ore yields' },
+  winter: { name: 'Winter', icon: '❄️', wheat:-0.20, wood: 0,    ore: 0,    regen: -0.10, hunger:  0.15, flavour: 'Cold reduces food supply' },
+}
+
+/** Returns the current season based on the real-world month. */
+export function currentSeason(now = Date.now()): Season {
+  const month = new Date(now).getMonth()  // 0 = Jan
+  if (month >= 2 && month <= 4) return 'spring'
+  if (month >= 5 && month <= 7) return 'summer'
+  if (month >= 8 && month <= 10) return 'autumn'
+  return 'winter'
+}
+
 // ── Resource building config ──────────────────────────────────────────────────
 
 /**
@@ -725,6 +761,9 @@ export function tickCity(state: CityState): CityState {
   const elapsed = now - state.lastTick
   const minutes = Math.min(elapsed / 60_000, MAX_OFFLINE_MINUTES)
 
+  const season = currentSeason(now)
+  const si = SEASON_INFO[season]
+
   const newResources = { ...state.resources }
   let goldEarned = 0
   const newHappy = { ...state.happiness }
@@ -753,15 +792,21 @@ export function tickCity(state: CityState): CityState {
       for (const [res, rate] of Object.entries(produces) as [ResourceType, number][]) {
         if (rate > 0) {
           const synergyMult = 1 + (synergyMap[res as ResourceType] ?? 0)
-          newResources[res] = (newResources[res] ?? 0) + rate * masteryMult * synergyMult * minutes
+          // Season modifier: wheat/wood/ore get seasonal multipliers
+          const seasonMult = res === 'wheat' ? 1 + si.wheat
+                           : res === 'wood'  ? 1 + si.wood
+                           : res === 'ore'   ? 1 + si.ore
+                           : 1
+          newResources[res] = (newResources[res] ?? 0) + rate * masteryMult * synergyMult * Math.max(0, seasonMult) * minutes
         }
       }
     }
 
-    // Spawners consume food (wheat)
+    // Spawners consume food (wheat) — more in summer/winter
     if (cell.spawnedUnitName && happy) {
       const unitCount = spawnerUnitCount(state, cell.cardName)
-      const consume = FOOD_CONSUME_RATE[cell.rarity] * unitCount * minutes
+      const hungerMult = 1 + si.hunger
+      const consume = FOOD_CONSUME_RATE[cell.rarity] * unitCount * hungerMult * minutes
       newResources.wheat = Math.max(0, (newResources.wheat ?? 0) - consume)
     }
   }
@@ -784,8 +829,9 @@ export function tickCity(state: CityState): CityState {
     const cellTarget  = affinityMet ? baseTarget : 0
 
     const current = newHappy[i] ?? 100
+    const seasonRegen = HAPPINESS_REGEN * (1 + si.regen)
     if (current < cellTarget) {
-      newHappy[i] = Math.min(cellTarget, current + HAPPINESS_REGEN * minutes)
+      newHappy[i] = Math.min(cellTarget, current + seasonRegen * minutes)
     } else if (current > cellTarget) {
       newHappy[i] = Math.max(0, current - HAPPINESS_DRAIN * minutes)
     }
@@ -1090,6 +1136,7 @@ export function levelUpCard(state: CityState, cardName: string, masteryLvl: numb
 
 export function resourceProductionRate(state: CityState): Partial<ResourceStock> {
   const rates: Partial<ResourceStock> = {}
+  const si = SEASON_INFO[currentSeason()]
   for (let i = 0; i < state.grid.length; i++) {
     const cell = state.grid[i]
     if (!cell || cell.spawnedUnitName) continue
@@ -1100,7 +1147,11 @@ export function resourceProductionRate(state: CityState): Partial<ResourceStock>
     for (const s of synergies) synergyMap[s.resource] = (synergyMap[s.resource] ?? 0) + s.multiplier
     for (const [res, rate] of Object.entries(produces) as [ResourceType, number][]) {
       const synergyMult = 1 + (synergyMap[res as ResourceType] ?? 0)
-      rates[res] = (rates[res] ?? 0) + rate * masteryMult * synergyMult
+      const seasonMult = res === 'wheat' ? 1 + si.wheat
+                       : res === 'wood'  ? 1 + si.wood
+                       : res === 'ore'   ? 1 + si.ore
+                       : 1
+      rates[res] = (rates[res] ?? 0) + rate * masteryMult * synergyMult * Math.max(0, seasonMult)
     }
   }
   return rates

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -9157,6 +9157,32 @@ html.light-mode .action-btn {
 .city-thought-row--unhappy .city-thought-name { color: #c07050; }
 .city-thought-row--unhappy .city-thought-text { color: #b08060; }
 
+/* ── City Chronicle ──────────────────────────────────────────────────────── */
+.city-chronicle-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-family: monospace;
+  font-size: 11px;
+}
+.city-chronicle-entry {
+  padding: 4px 6px;
+  border-left: 2px solid #2a5a2a;
+  background: #040a04;
+  color: #90b890;
+  line-height: 1.4;
+}
+.city-chronicle-entry:hover { background: #081408; }
+.city-chronicle-empty {
+  color: #508050;
+  font-style: italic;
+  padding: 16px;
+  text-align: center;
+}
+
 /* ── Misc city UI ─────────────────────────────────────────────────────────── */
 
 .city-section-title {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -9157,6 +9157,21 @@ html.light-mode .action-btn {
 .city-thought-row--unhappy .city-thought-name { color: #c07050; }
 .city-thought-row--unhappy .city-thought-text { color: #b08060; }
 
+/* ── Adjacency Synergies ─────────────────────────────────────────────────── */
+.city-synergy-bonus {
+  color: #60c860;
+  font-size: 10px;
+  margin-left: 4px;
+}
+.city-synergy-label {
+  font-size: 10px;
+  color: #60c860;
+  padding: 2px 0;
+  border-left: 2px solid #2a5a2a;
+  padding-left: 6px;
+  margin-top: 2px;
+}
+
 /* ── City Chronicle ──────────────────────────────────────────────────────── */
 .city-chronicle-list {
   flex: 1;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -9157,6 +9157,40 @@ html.light-mode .action-btn {
 .city-thought-row--unhappy .city-thought-name { color: #c07050; }
 .city-thought-row--unhappy .city-thought-text { color: #b08060; }
 
+/* ── Milestone Banner ────────────────────────────────────────────────────── */
+.city-milestone-banner {
+  position: absolute;
+  top: 48px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 200;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: #0a1f0a;
+  border: 2px solid #60c860;
+  padding: 10px 18px;
+  font-family: monospace;
+  pointer-events: none;
+  transition: opacity 0.8s;
+  opacity: 1;
+  box-shadow: 0 0 20px #40a84088;
+  min-width: 220px;
+}
+.city-milestone-banner--fading { opacity: 0; }
+.city-milestone-icon { font-size: 24px; flex-shrink: 0; }
+.city-milestone-title {
+  color: #60c860;
+  font-size: 11px;
+  letter-spacing: 1px;
+  font-weight: bold;
+}
+.city-milestone-reward {
+  color: #a0d8a0;
+  font-size: 12px;
+  margin-top: 2px;
+}
+
 /* ── Adjacency Synergies ─────────────────────────────────────────────────── */
 .city-synergy-bonus {
   color: #60c860;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -9157,6 +9157,20 @@ html.light-mode .action-btn {
 .city-thought-row--unhappy .city-thought-name { color: #c07050; }
 .city-thought-row--unhappy .city-thought-text { color: #b08060; }
 
+/* ── Trade Routes ────────────────────────────────────────────────────────── */
+.city-trade-btn--ready { color: #ffdd44; border-color: #887700; }
+.city-trade-desc { font-size: 11px; color: #708870; margin-bottom: 8px; }
+.city-trade-offer { border: 1px solid #2a5a2a; padding: 10px; background: #040a04; }
+.city-trade-offer-title { color: #60c860; font-size: 11px; letter-spacing: 1px; margin-bottom: 6px; }
+.city-trade-expires { color: #507050; margin-left: 8px; font-size: 10px; }
+.city-trade-offer-body { color: #a0c0a0; font-size: 12px; margin-bottom: 8px; }
+.city-trade-warn { color: #c07050; font-size: 11px; margin-bottom: 6px; }
+.city-trade-caravan { border: 1px solid #556622; padding: 10px; background: #040a04; }
+.city-trade-caravan-title { color: #aacc44; font-size: 11px; letter-spacing: 1px; margin-bottom: 6px; }
+.city-trade-caravan-body { color: #a0c0a0; font-size: 12px; margin-bottom: 4px; }
+.city-trade-returns { color: #708870; font-size: 10px; }
+.city-trade-waiting { color: #508050; font-style: italic; padding: 12px 0; text-align: center; font-size: 12px; }
+
 /* ── Seasonal Cycles ─────────────────────────────────────────────────────── */
 .city-season-chip {
   color: #90d090;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -9157,6 +9157,12 @@ html.light-mode .action-btn {
 .city-thought-row--unhappy .city-thought-name { color: #c07050; }
 .city-thought-row--unhappy .city-thought-text { color: #b08060; }
 
+/* ── Seasonal Cycles ─────────────────────────────────────────────────────── */
+.city-season-chip {
+  color: #90d090;
+  border-color: #2a5a2a;
+}
+
 /* ── Milestone Banner ────────────────────────────────────────────────────── */
 .city-milestone-banner {
   position: absolute;


### PR DESCRIPTION
## Summary

Implements City Events Chronicle (#1184) — the first feature from the City Builder v2 roadmap (#1180).

- Adds `chronicle: string[]` to `CityState` (max 50 entries, newest first, persisted in localStorage)
- Adds `addChronicleEvent()` helper with human-readable timestamps
- Events are recorded automatically for all major city moments:
  - ⚔ Attack outcomes (repelled / raided / defeated) with gold amounts
  - 🏗 Fortification construction completions
  - 🏛 Buildings placed on the grid
  - 🔨 Buildings demolished
  - 🧱 Fortifications queued
  - 🏙 City grid expansions
  - 🏠 Residents invited back after leaving
- New `ChroniclePanel` sub-screen accessible via **📜 HISTORY** button in the city controls bar
- Existing saves migrate cleanly (missing `chronicle` field defaults to `[]`)

## Test plan

- [ ] Open city builder — HISTORY button appears in controls
- [ ] Place a building → open HISTORY → entry appears
- [ ] Demolish a building → entry appears
- [ ] Queue a fortification → entry appears, and completion entry appears after build time elapses
- [ ] Trigger/simulate an attack → attack outcome appears in chronicle
- [ ] Expand the city → expansion entry appears
- [ ] Invite a resident back → move-in entry appears
- [ ] Chronicle caps at 50 entries (oldest drop off)
- [ ] Reload page — chronicle persists from localStorage

Closes #1184

https://claude.ai/code/session_01QoP8jPH6TsU5QUWDguGVYx

---
_Generated by [Claude Code](https://claude.ai/code/session_01QoP8jPH6TsU5QUWDguGVYx)_