### PR TITLE
fix(city-builder): wrap action bar on small screens; round resource rates to int

### DIFF
--- a/web/src/components/minigames/CityBuilder.tsx
+++ b/web/src/components/minigames/CityBuilder.tsx
@@ -1334,7 +1334,7 @@ export function CityBuilder({ onBack }: Props) {
             onClick={toggleBulldozer}
             title={bulldozerMode ? 'Demolish mode ON' : 'Demolish a building'}
           >{bulldozerMode ? '🧱 DEMOLISH' : '👷 BUILD'}</button>
-          <button className="filter-btn" onClick={() => setScreen('fortify')} title="Manage city walls and moats">🛡 FORTIFICATIONS</button>
+          <button className="filter-btn" onClick={() => setScreen('fortify')} title="Manage city walls and moats">🛡 FORTS</button>
           <button className="filter-btn" onClick={() => setScreen('upgrade')} title="Upgrade buildings">★ UPGRADES</button>
           <button className="filter-btn" onClick={() => setScreen('chronicle')} title="View city history">📜 HISTORY</button>
           <button
@@ -1347,7 +1347,7 @@ export function CityBuilder({ onBack }: Props) {
               className={`filter-btn city-expand-btn${affordable ? ' city-expand-btn--ready' : ''}`}
               onClick={handleExpand}
               title={affordable ? `Expand city to ${cityRows + 1} rows` : 'Not enough resources to expand'}
-            >🏢 EXPAND CITY</button>
+            >🏢 EXPAND</button>
           )}
         </div>
 

--- a/web/src/components/minigames/citybuilder/ResourceStrip.tsx
+++ b/web/src/components/minigames/citybuilder/ResourceStrip.tsx
@@ -21,8 +21,8 @@ export function ResourceStrip({ defense, population, resources, prodRates, consR
       <span className="city-info-chip city-season-chip" title={si.flavour}>{si.icon} {si.name}</span>
       {RESOURCE_TYPES.map(res => {
         const stock = Math.floor(resources[res])
-        const prod  = prodRates[res] ?? 0
-        const cons  = consRates[res] ?? 0
+        const prod  = Math.round(prodRates[res] ?? 0)
+        const cons  = Math.round(consRates[res] ?? 0)
         const net   = prod - cons
         if (stock === 0 && prod === 0) return null
         return (

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -8841,6 +8841,8 @@ html.light-mode .action-btn {
 
 .city-header {
   flex-shrink: 0;
+  flex-wrap: wrap;
+  row-gap: 4px;
 }
 .city-header-right {
   margin-left: auto;


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Shorten button labels: "FORTIFICATIONS" → "FORTS", "EXPAND CITY" → "EXPAND" so the action bar fits on narrow viewports
- Allow `.city-header` to `flex-wrap` so buttons reflow to a second line instead of overflowing off-screen
- Round `prod`/`cons` rates to integers in `ResourceStrip` — season multipliers were producing float deltas (e.g. `+2.4`)

## Test plan

- [ ] Open city builder on a narrow viewport — action bar should wrap cleanly to two lines, no overflow
- [ ] Check resource strip — net rate deltas should show whole numbers only (e.g. `+2` not `+2.4`)
- [ ] Verify "FORTS" button still navigates to the fortifications screen
- [ ] Verify "EXPAND" button still triggers city expansion

https://claude.ai/code/session_01QoP8jPH6TsU5QUWDguGVYx
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QoP8jPH6TsU5QUWDguGVYx)_