### PR TITLE
feat(city-builder): City Stats Dashboard (#1190)

### DIFF
--- a/web/src/components/minigames/CityBuilder.tsx
+++ b/web/src/components/minigames/CityBuilder.tsx
@@ -51,6 +51,7 @@ import { ResourceStrip } from './citybuilder/ResourceStrip'
 import { ChroniclePanel } from './citybuilder/ChroniclePanel'
 import { MilestoneBanner } from './citybuilder/MilestoneBanner'
 import { TradeRouteModal } from './citybuilder/TradeRouteModal'
+import { StatsScreen } from './citybuilder/StatsScreen'
 import { OverlayScreen } from '../ui/OverlayScreen'
 
 
@@ -492,7 +493,7 @@ interface Props {
   onBack: () => void
 }
 
-type SubScreen = 'city' | 'picker' | 'upgrade' | 'levelup' | 'fortify' | 'towerdefence' | 'chronicle'
+type SubScreen = 'city' | 'picker' | 'upgrade' | 'levelup' | 'fortify' | 'towerdefence' | 'chronicle' | 'stats'
 
 export function CityBuilder({ onBack }: Props) {
   const [city, setCity] = useState<CityState>(() => tickCity(loadCityState()))
@@ -1220,6 +1221,15 @@ export function CityBuilder({ onBack }: Props) {
     )
   }
 
+  if (screen === 'stats') {
+    return (
+      <StatsScreen
+        city={city}
+        onBack={() => setScreen('city')}
+      />
+    )
+  }
+
   // ── Main city view ────────────────────────────────────────────────────────────
 
   return (
@@ -1337,6 +1347,7 @@ export function CityBuilder({ onBack }: Props) {
           <button className="filter-btn" onClick={() => setScreen('fortify')} title="Manage city walls and moats">🛡 FORTS</button>
           <button className="filter-btn" onClick={() => setScreen('upgrade')} title="Upgrade buildings">★ UPGRADES</button>
           <button className="filter-btn" onClick={() => setScreen('chronicle')} title="View city history">📜 HISTORY</button>
+          <button className="filter-btn" onClick={() => setScreen('stats')} title="View economy charts">📊 STATS</button>
           <button
             className={`filter-btn${city.tradeOffer && !city.activeCaravan ? ' city-trade-btn--ready' : ''}`}
             onClick={() => setShowTrade(true)}

--- a/web/src/components/minigames/citybuilder/StatsScreen.stories.tsx
+++ b/web/src/components/minigames/citybuilder/StatsScreen.stories.tsx
@@ -1,0 +1,90 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { StatsScreen } from './StatsScreen'
+import { CityState, HistorySample } from '../../../game/cityBuilder'
+
+const meta = {
+  component: StatsScreen,
+  parameters: { layout: 'fullscreen' },
+} satisfies Meta<typeof StatsScreen>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+// Minimal CityState shape — only fields StatsScreen actually reads
+function makeCity(history: HistorySample[]): CityState {
+  return {
+    grid:                [],
+    gold:                history[history.length - 1]?.gold ?? 0,
+    resources:           { wheat: 0, wood: 0, ore: 0, bread: 0, planks: 0, metal: 0 },
+    lastTick:            Date.now(),
+    happiness:           {},
+    rows:                4,
+    nextAttackAt:        Date.now() + 3_600_000,
+    fortifications:      [],
+    builderQueue:        [],
+    builderCount:        2,
+    lastAttack:          null,
+    chronicle:           [],
+    completedMilestones: [],
+    attacksProcessed:    0,
+    tradeOffer:          null,
+    activeCaravan:       null,
+    history,
+  }
+}
+
+// Generate a plausible 24h history with a growth trend and a few attacks
+function generateHistory(samples = 24): HistorySample[] {
+  const now = Date.now()
+  const out: HistorySample[] = []
+  let gold  = 8_000
+  let wheat = 200
+  let wood  = 80
+  let pop   = 4
+  let def   = 30
+
+  for (let i = 0; i < samples; i++) {
+    const t = now - (samples - 1 - i) * 10 * 60_000
+    gold  += 400 + Math.random() * 200 - 50
+    wheat  = Math.max(0, wheat + 10 - Math.random() * 8)
+    wood   = Math.max(0, wood  + 4  - Math.random() * 3)
+    if (i % 8 === 0 && pop < 12) pop++
+    const attacked = i === 6 || i === 15
+    if (attacked) { gold -= 1_200; def = Math.max(10, def - 5) }
+    out.push({
+      t,
+      gold:   Math.round(gold),
+      pop,
+      def,
+      wheat:  Math.round(wheat),
+      wood:   Math.round(wood),
+      ore:    Math.round(20 + i * 2),
+      bread:  Math.round(Math.max(0, 30 - i)),
+      planks: Math.round(10 + i * 0.5),
+      metal:  Math.round(5 + i * 0.8),
+      attacked,
+    })
+  }
+  return out
+}
+
+export const WithData: Story = {
+  args: {
+    city: makeCity(generateHistory(36)),
+    onBack: () => {},
+  },
+}
+
+export const FewSamples: Story = {
+  args: {
+    city: makeCity(generateHistory(3)),
+    onBack: () => {},
+  },
+}
+
+export const NoData: Story = {
+  args: {
+    city: makeCity([]),
+    onBack: () => {},
+  },
+}

--- a/web/src/components/minigames/citybuilder/StatsScreen.tsx
+++ b/web/src/components/minigames/citybuilder/StatsScreen.tsx
@@ -1,0 +1,280 @@
+import React from 'react'
+import {
+  CityState, HistorySample,
+  RESOURCE_ICONS, ResourceType,
+} from '../../../game/cityBuilder'
+import { StatsSparkline } from './StatsSparkline'
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function fmtGold(n: number): string {
+  const abs = Math.abs(n)
+  let s: string
+  if (abs >= 1_000_000) s = `${(abs / 1_000_000).toFixed(1)}M`
+  else if (abs >= 1_000) s = `${(abs / 1_000).toFixed(1)}K`
+  else s = String(Math.round(abs))
+  return n < 0 ? `-${s}` : s
+}
+
+function fmtDelta(n: number, isGold = false): string {
+  if (n === 0) return '—'
+  const str = isGold ? fmtGold(n) : String(Math.round(n))
+  return n > 0 ? `+${str}` : str
+}
+
+function fmtDuration(ms: number): string {
+  const h = Math.floor(ms / 3_600_000)
+  const m = Math.floor((ms % 3_600_000) / 60_000)
+  if (h > 0) return `${h}h ${m}m`
+  return `${m}m`
+}
+
+// ── Series colors ─────────────────────────────────────────────────────────────
+
+const COLORS: Record<string, string> = {
+  gold:   '#c8a020',
+  pop:    '#40b0c0',
+  def:    '#50c878',
+  wheat:  '#d4a020',
+  wood:   '#8b6030',
+  ore:    '#9090a0',
+  bread:  '#d0a84c',
+  planks: '#a07040',
+  metal:  '#6888a8',
+}
+
+const RES_ORDER: ResourceType[] = ['wheat', 'wood', 'ore', 'bread', 'planks', 'metal']
+
+// ── Sub-components ─────────────────────────────────────────────────────────────
+
+interface StatCardProps {
+  icon:    string
+  label:   string
+  value:   string
+  delta?:  number
+  isGold?: boolean
+}
+
+function StatCard({ icon, label, value, delta, isGold }: StatCardProps) {
+  const deltaStr = delta !== undefined ? fmtDelta(delta, isGold) : null
+  const deltaClass = !deltaStr || deltaStr === '—'
+    ? 'city-stat-card-delta--zero'
+    : delta! > 0 ? 'city-stat-card-delta--pos' : 'city-stat-card-delta--neg'
+  return (
+    <div className="city-stat-card">
+      <div className="city-stat-card-label">{icon} {label}</div>
+      <div className="city-stat-card-value">{value}</div>
+      {deltaStr && (
+        <div className={`city-stat-card-delta ${deltaClass}`}>{deltaStr}</div>
+      )}
+    </div>
+  )
+}
+
+interface ChartSectionProps {
+  title:   string
+  children: React.ReactNode
+}
+function ChartSection({ title, children }: ChartSectionProps) {
+  return (
+    <div className="city-stats-section">
+      <div className="city-stats-section-header">{title}</div>
+      {children}
+    </div>
+  )
+}
+
+// ── Main component ─────────────────────────────────────────────────────────────
+
+interface Props {
+  city:   CityState
+  onBack: () => void
+}
+
+export function StatsScreen({ city, onBack }: Props) {
+  const history: HistorySample[] = city.history ?? []
+  const n = history.length
+
+  const latest = history[n - 1]
+  const oldest = history[0]
+
+  const extract = (key: keyof HistorySample) =>
+    history.map(s => s[key] as number)
+
+  const goldData  = extract('gold')
+  const popData   = extract('pop')
+  const defData   = extract('def')
+  const attackMask = history.map(s => s.attacked ?? false)
+
+  const resData: Record<ResourceType, number[]> = {
+    wheat:  extract('wheat'),
+    wood:   extract('wood'),
+    ore:    extract('ore'),
+    bread:  extract('bread'),
+    planks: extract('planks'),
+    metal:  extract('metal'),
+  }
+
+  // Window duration label
+  const windowLabel = n >= 2
+    ? `Last ${fmtDuration(latest.t - oldest.t)}`
+    : n === 1 ? 'First sample' : 'No data yet'
+
+  // Deltas (change over entire history window)
+  const goldDelta = n >= 2 ? latest.gold  - oldest.gold  : 0
+  const popDelta  = n >= 2 ? latest.pop   - oldest.pop   : 0
+  const defDelta  = n >= 2 ? latest.def   - oldest.def   : 0
+
+  // Time axis labels for the gold chart
+  function timeLabel(i: number): string {
+    if (n < 2) return ''
+    const ageMs  = latest.t - history[i].t
+    if (ageMs < 60_000) return 'now'
+    return `${fmtDuration(ageMs)} ago`
+  }
+
+  if (n === 0) {
+    return (
+      <div className="city-screen u-col u-gap-2">
+        <div className="city-header u-flex u-items-c u-gap-3">
+          <button className="action-btn" onClick={onBack}>← BACK</button>
+          <div className="city-title">📊 CITY STATS</div>
+        </div>
+        <div className="city-stats-empty">
+          <div className="city-stats-empty-icon">📊</div>
+          <div>No data yet.</div>
+          <div className="city-stats-empty-hint">
+            Stats are sampled every 10 minutes of play.<br />
+            Check back after a little while!
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="city-screen u-relative u-col u-gap-2">
+      {/* Header */}
+      <div className="city-header u-flex u-items-c u-gap-3">
+        <button className="action-btn" onClick={onBack}>← BACK</button>
+        <div className="city-title">📊 CITY STATS</div>
+        <span className="city-stats-window-label">{windowLabel}</span>
+      </div>
+
+      {/* Scrollable content */}
+      <div className="city-stats-scroll">
+
+        {/* Summary cards */}
+        <div className="city-stats-summary">
+          <StatCard
+            icon="💰" label="GOLD"
+            value={fmtGold(latest.gold)}
+            delta={goldDelta}
+            isGold
+          />
+          <StatCard
+            icon="👥" label="POP"
+            value={String(latest.pop)}
+            delta={popDelta}
+          />
+          <StatCard
+            icon="🛡" label="DEFENSE"
+            value={String(latest.def)}
+            delta={defDelta}
+          />
+          <StatCard
+            icon="⚔" label="ATTACKS"
+            value={String(attackMask.filter(Boolean).length)}
+          />
+        </div>
+
+        {/* Gold chart */}
+        <ChartSection title="GOLD OVER TIME">
+          <div className="city-stats-chart-wrap">
+            <StatsSparkline
+              data={goldData}
+              attacks={attackMask}
+              color={COLORS.gold}
+              height={80}
+            />
+            <div className="city-stats-chart-labels">
+              <span>{timeLabel(0)}</span>
+              <span className="city-stats-chart-range">
+                {fmtGold(Math.min(...goldData))} – {fmtGold(Math.max(...goldData))}
+              </span>
+              <span>now</span>
+            </div>
+          </div>
+          {attackMask.some(Boolean) && (
+            <div className="city-stats-attack-legend">
+              <span className="city-sparkline-attack-mark city-sparkline-attack-mark--inline" />
+              {' '}attack event
+            </div>
+          )}
+        </ChartSection>
+
+        {/* Resources */}
+        <ChartSection title="RESOURCES">
+          <div className="city-stats-res-grid">
+            {RES_ORDER.map(res => {
+              const d = resData[res]
+              const cur = d[d.length - 1] ?? 0
+              const delta = d.length >= 2 ? cur - d[0] : 0
+              const allZero = d.every(v => v === 0)
+              if (allZero) return null
+              return (
+                <div key={res} className="city-stats-res-cell">
+                  <div className="city-stats-res-label">
+                    {RESOURCE_ICONS[res]} {res.toUpperCase()}
+                  </div>
+                  <div className="city-stats-chart-wrap city-stats-chart-wrap--sm">
+                    <StatsSparkline
+                      data={d}
+                      color={COLORS[res]}
+                      height={40}
+                    />
+                  </div>
+                  <div className="city-stats-res-footer">
+                    <span className="city-stats-res-cur">{Math.floor(cur)}</span>
+                    <span className={`city-stats-res-delta ${delta > 0 ? 'city-stat-card-delta--pos' : delta < 0 ? 'city-stat-card-delta--neg' : 'city-stat-card-delta--zero'}`}>
+                      {fmtDelta(delta)}
+                    </span>
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        </ChartSection>
+
+        {/* Population & Defense */}
+        <ChartSection title="POPULATION &amp; DEFENSE">
+          <div className="city-stats-duo">
+            <div>
+              <div className="city-stats-res-label">👥 POPULATION</div>
+              <div className="city-stats-chart-wrap">
+                <StatsSparkline data={popData} color={COLORS.pop} height={50} />
+              </div>
+              <div className="city-stats-chart-labels">
+                <span>{Math.min(...popData)}</span>
+                <span></span>
+                <span>{Math.max(...popData)}</span>
+              </div>
+            </div>
+            <div>
+              <div className="city-stats-res-label">🛡 DEFENSE</div>
+              <div className="city-stats-chart-wrap">
+                <StatsSparkline data={defData} color={COLORS.def} height={50} />
+              </div>
+              <div className="city-stats-chart-labels">
+                <span>{Math.min(...defData)}</span>
+                <span></span>
+                <span>{Math.max(...defData)}</span>
+              </div>
+            </div>
+          </div>
+        </ChartSection>
+
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/minigames/citybuilder/StatsSparkline.tsx
+++ b/web/src/components/minigames/citybuilder/StatsSparkline.tsx
@@ -1,0 +1,98 @@
+import React from 'react'
+
+interface Props {
+  data:     number[]
+  attacks?: boolean[]  // parallel array, true = attack occurred at that sample
+  color:    string
+  height?:  number     // chart height in px, default 54
+  dimColor?: string    // fill/glow color override (defaults to color)
+}
+
+export function StatsSparkline({ data, attacks, color, height = 54, dimColor }: Props) {
+  const n = data.length
+  const fill = dimColor ?? color
+
+  if (n < 2) {
+    return (
+      <div className="city-sparkline city-sparkline--empty" style={{ height }}>
+        <span className="city-sparkline-nodata">collecting data…</span>
+      </div>
+    )
+  }
+
+  // viewBox: x in [0,100], y in [0, height]. preserveAspectRatio="none" stretches
+  // horizontally to fill container width without distorting y-scale.
+  const W   = 100
+  const H   = height
+  const PAD = 3   // top/bottom padding in viewBox units
+
+  const min   = Math.min(...data)
+  const max   = Math.max(...data)
+  const range = Math.max(max - min, 1)
+
+  const toX = (i: number) => (i / (n - 1)) * W
+  const toY = (v: number) => PAD + (H - PAD * 2) * (1 - (v - min) / range)
+
+  const pts      = data.map((v, i) => `${toX(i).toFixed(2)},${toY(v).toFixed(2)}`)
+  const linePath = `M ${pts.join(' L ')}`
+  const baseY    = (H - PAD).toFixed(2)
+  const areaPath = `${linePath} L ${W},${baseY} L 0,${baseY} Z`
+
+  // Subtle horizontal grid lines at 25 / 50 / 75 %
+  const gridYs = [0.25, 0.5, 0.75].map(f => (PAD + (H - PAD * 2) * (1 - f)).toFixed(2))
+
+  const hasAttacks = attacks?.some(Boolean)
+
+  return (
+    <div className="city-sparkline" style={{ position: 'relative' }}>
+      <svg
+        viewBox={`0 0 ${W} ${H}`}
+        preserveAspectRatio="none"
+        width="100%"
+        height={height}
+        style={{ display: 'block' }}
+        aria-hidden
+      >
+        {/* Grid lines */}
+        {gridYs.map((y, i) => (
+          <line key={i} x1="0" y1={y} x2={W} y2={y}
+            stroke="rgba(255,255,255,0.05)" strokeWidth="0.6" />
+        ))}
+
+        {/* Area fill with gradient fade */}
+        <defs>
+          <linearGradient id={`sg-${color.replace('#', '')}`} x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%"   stopColor={fill} stopOpacity="0.25" />
+            <stop offset="100%" stopColor={fill} stopOpacity="0.02" />
+          </linearGradient>
+        </defs>
+        <path d={areaPath} fill={`url(#sg-${color.replace('#', '')})`} stroke="none" />
+
+        {/* Line */}
+        <path
+          d={linePath}
+          stroke={color}
+          strokeWidth="1.5"
+          fill="none"
+          vectorEffect="non-scaling-stroke"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
+
+      {/* Attack markers — HTML positioned so they don't distort */}
+      {hasAttacks && (
+        <div className="city-sparkline-attack-row" aria-label="Attack events" style={{ height: 10 }}>
+          {attacks!.map((a, i) => a ? (
+            <span
+              key={i}
+              className="city-sparkline-attack-mark"
+              title="Attack"
+              style={{ left: `${toX(i)}%` }}
+            />
+          ) : null)}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/game/cityBuilder.ts
+++ b/web/src/game/cityBuilder.ts
@@ -145,6 +145,25 @@ export const EXPANSION_COSTS: Record<number, { gold: number; resources: Partial<
 /** Hard cap on total fortifications (prevents unlimited stacking). */
 export const MAX_TOTAL_FORTS = 12
 
+// ── Stats history ─────────────────────────────────────────────────────────────
+
+const HISTORY_MAX         = 144          // 24 h at 10-min resolution
+const HISTORY_INTERVAL_MS = 10 * 60_000  // sample at most once per 10 minutes
+
+export interface HistorySample {
+  t:        number   // Unix ms timestamp
+  gold:     number
+  pop:      number
+  def:      number
+  wheat:    number
+  wood:     number
+  ore:      number
+  bread:    number
+  planks:   number
+  metal:    number
+  attacked?: boolean
+}
+
 // ── Seasonal cycles ───────────────────────────────────────────────────────────
 
 export type Season = 'spring' | 'summer' | 'autumn' | 'winter'
@@ -379,6 +398,8 @@ export interface CityState {
   tradeOffer:    TradeOffer | null
   /** Caravan currently away on a trade mission. */
   activeCaravan: ActiveCaravan | null
+  /** Periodic economy snapshots for the Stats dashboard (newest last, max 144). */
+  history:       HistorySample[]
 }
 
 // ── Storage ───────────────────────────────────────────────────────────────────
@@ -408,6 +429,7 @@ function defaultState(): CityState {
     attacksProcessed:    0,
     tradeOffer:          null,
     activeCaravan:       null,
+    history:             [],
   }
 }
 
@@ -451,6 +473,7 @@ export function loadCityState(): CityState {
       attacksProcessed:    parsed.attacksProcessed ?? 0,
       tradeOffer:          parsed.tradeOffer ?? null,
       activeCaravan:       parsed.activeCaravan ?? null,
+      history:             parsed.history ?? [],
     }
   } catch (err) {
     logError('loadCityState failed', err as Record<string, unknown>)
@@ -970,6 +993,29 @@ export function tickCity(state: CityState): CityState {
   }
 
   const { state: resultWithMilestones } = checkMilestones(result)
+
+  // Append a history sample at most once per HISTORY_INTERVAL_MS
+  const hist = resultWithMilestones.history ?? []
+  const lastSampleAt = hist.length > 0 ? hist[hist.length - 1].t : 0
+  if (now - lastSampleAt >= HISTORY_INTERVAL_MS) {
+    const attacked = resultWithMilestones.lastAttack != null &&
+      resultWithMilestones.lastAttack.at > (state.lastTick ?? 0)
+    const sample: HistorySample = {
+      t:       now,
+      gold:    resultWithMilestones.gold,
+      pop:     cityPopulation(resultWithMilestones),
+      def:     cityDefense(resultWithMilestones),
+      wheat:   Math.floor(resultWithMilestones.resources.wheat),
+      wood:    Math.floor(resultWithMilestones.resources.wood),
+      ore:     Math.floor(resultWithMilestones.resources.ore),
+      bread:   Math.floor(resultWithMilestones.resources.bread),
+      planks:  Math.floor(resultWithMilestones.resources.planks),
+      metal:   Math.floor(resultWithMilestones.resources.metal),
+      attacked,
+    }
+    const history = [...hist, sample].slice(-HISTORY_MAX)
+    return { ...resultWithMilestones, history }
+  }
   return resultWithMilestones
 }
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -9254,6 +9254,213 @@ html.light-mode .action-btn {
   text-align: center;
 }
 
+/* ── City Stats Dashboard ─────────────────────────────────────────────────── */
+
+.city-stats-scroll {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0 4px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.city-stats-scroll::-webkit-scrollbar { width: 4px; }
+.city-stats-scroll::-webkit-scrollbar-thumb { background: #1a3a1a; border-radius: 2px; }
+
+.city-stats-window-label {
+  font-size: 10px;
+  color: #406040;
+  font-family: monospace;
+  margin-left: auto;
+  white-space: nowrap;
+}
+
+/* Summary stat cards */
+.city-stats-summary {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  padding: 4px 0 6px;
+}
+.city-stat-card {
+  flex: 1;
+  min-width: 70px;
+  background: #020702;
+  border: 1px solid #1a3a1a;
+  border-radius: 2px;
+  padding: 6px 8px;
+}
+.city-stat-card-label {
+  font-size: 9px;
+  color: #50704e;
+  letter-spacing: 1px;
+  font-family: monospace;
+}
+.city-stat-card-value {
+  font-size: 15px;
+  font-weight: bold;
+  color: var(--game-text-color);
+  font-family: monospace;
+  line-height: 1.3;
+  white-space: nowrap;
+}
+.city-stat-card-delta {
+  font-size: 10px;
+  font-family: monospace;
+}
+.city-stat-card-delta--pos  { color: #50d060; }
+.city-stat-card-delta--neg  { color: #e04040; }
+.city-stat-card-delta--zero { color: #304830; }
+
+/* Sections */
+.city-stats-section {
+  padding: 6px 0 2px;
+}
+.city-stats-section-header {
+  font-size: 9px;
+  letter-spacing: 2px;
+  color: #406040;
+  border-bottom: 1px solid #152415;
+  padding-bottom: 4px;
+  margin-bottom: 6px;
+  font-family: monospace;
+}
+
+/* Chart wrappers */
+.city-stats-chart-wrap {
+  background: #020602;
+  border: 1px solid #152015;
+  border-radius: 2px;
+  padding: 4px 6px 2px;
+  position: relative;
+  overflow: hidden;
+}
+.city-stats-chart-wrap--sm {
+  padding: 2px 4px 1px;
+}
+.city-stats-chart-labels {
+  display: flex;
+  justify-content: space-between;
+  font-size: 9px;
+  color: #355535;
+  font-family: monospace;
+  margin-top: 3px;
+}
+.city-stats-chart-range {
+  color: #406040;
+}
+.city-stats-attack-legend {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 9px;
+  color: #804040;
+  font-family: monospace;
+  margin-top: 4px;
+}
+
+/* Resource grid */
+.city-stats-res-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 6px;
+}
+.city-stats-res-cell {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.city-stats-res-label {
+  font-size: 9px;
+  color: #508050;
+  letter-spacing: 1px;
+  font-family: monospace;
+}
+.city-stats-res-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  padding: 1px 4px 0;
+}
+.city-stats-res-cur {
+  font-size: 11px;
+  color: var(--game-text-color);
+  font-family: monospace;
+}
+.city-stats-res-delta {
+  font-size: 9px;
+  font-family: monospace;
+}
+
+/* Population & Defense duo */
+.city-stats-duo {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+
+/* Sparkline */
+.city-sparkline {
+  display: block;
+  width: 100%;
+}
+.city-sparkline--empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.city-sparkline-nodata {
+  font-size: 9px;
+  color: #304830;
+  font-family: monospace;
+  font-style: italic;
+}
+.city-sparkline-attack-row {
+  position: relative;
+  width: 100%;
+}
+.city-sparkline-attack-mark {
+  position: absolute;
+  top: 0;
+  display: block;
+  width: 0;
+  height: 0;
+  border-left:   4px solid transparent;
+  border-right:  4px solid transparent;
+  border-bottom: 7px solid #c03030;
+  transform: translateX(-4px);
+}
+.city-sparkline-attack-mark--inline {
+  position: static;
+  display: inline-block;
+  transform: none;
+  vertical-align: middle;
+  margin-right: 2px;
+}
+
+/* Empty state */
+.city-stats-empty {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 32px 16px;
+  color: #406040;
+  font-family: monospace;
+  text-align: center;
+}
+.city-stats-empty-icon {
+  font-size: 32px;
+  opacity: 0.4;
+}
+.city-stats-empty-hint {
+  font-size: 11px;
+  color: #305030;
+  line-height: 1.6;
+}
+
 /* ── Misc city UI ─────────────────────────────────────────────────────────── */
 
 .city-section-title {


### PR DESCRIPTION
Closes #1190

## What's in this PR

A new **📊 STATS** screen for the City Builder — a proper economy dashboard that helps players see whether their city is growing or declining.

### Data layer
- New `HistorySample` interface: captures gold, population, defense, all 6 resources, and whether an attack occurred
- Sampled at most once per 10 real minutes inside `tickCity` (max 144 samples = 24h rolling window)
- Safe migration: `history: parsed.history ?? []` in `loadCityState`

### UI — `StatsScreen`
- **Summary cards** at the top: current gold / population / defense / attack count, each with a trend delta vs the oldest sample in the window
- **Gold over time** — full-width sparkline (80px tall) with ⚔ attack event markers positioned below the chart
- **Resources** — 2×3 grid, one cell per active resource; each shows a 40px sparkline, current stock, and window delta
- **Population & Defense** — side-by-side 50px sparklines with min/max labels
- **Empty state** — friendly message for new cities with no samples yet
- **Window label** — "Last 4h 20m" shown in the header

### `StatsSparkline`
- Pure SVG using `preserveAspectRatio="none"` + `vectorEffect="non-scaling-stroke"` for responsive width
- `viewBox="0 0 100 H"` with x coords as percentages — clean coordinate math
- Gradient area fill, subtle grid lines, round-capped line
- Attack markers rendered as HTML `<span>` triangles positioned by `left: X%` — avoids SVG distortion artifacts

### Storybook
- `WithData` (36 samples, growth trend + 2 attacks)
- `FewSamples` (3 samples)
- `NoData` (empty state)

## Test plan
- [ ] Open city builder — "📊 STATS" button appears in the action bar
- [ ] After 10+ minutes of play, stats screen shows real data (gold/pop/def/resources all charted)
- [ ] Attack events show ⚔ triangles below the gold chart
- [ ] Empty state shows a helpful message for a brand-new city
- [ ] Resource cells with all-zero history are hidden
- [ ] Storybook stories render without errors

https://claude.ai/code/session_01QoP8jPH6TsU5QUWDguGVYx


---
_Generated by [Claude Code](https://claude.ai/code/session_01QoP8jPH6TsU5QUWDguGVYx)_