### PR TITLE
fix(city-builder): subtle zone indicator + move personality to inspector

### DIFF
--- a/web/src/components/minigames/citybuilder/CityGrid.tsx
+++ b/web/src/components/minigames/citybuilder/CityGrid.tsx
@@ -6,7 +6,7 @@ import {
 } from '../../../game/cityBuilder'
 import { SpriteImg, AnimatedSpriteImg } from '../../ui/SpriteImg'
 import { BuilderWalker } from '../CityBuilder'
-import { Walker, residentName, PERSONALITY_INFO } from './walkerTypes'
+import { Walker } from './walkerTypes'
 
 export interface Props {
   city:          CityState
@@ -46,14 +46,16 @@ export function CityGrid({
           const happiness = cell?.spawnedUnitName ? (city.happiness[i] ?? 100) : 100
           const rage      = 100 - happiness
           const despawned = cell?.spawnedUnitName && happiness === 0
-          const row       = Math.floor(i / CITY_COLS)
-          const district  = getRowDistrict(city, row)
-          const distColor = DISTRICT_INFO[district]?.color ?? 'transparent'
+          const row         = Math.floor(i / CITY_COLS)
+          const col         = i % CITY_COLS
+          const district    = getRowDistrict(city, row)
+          const distColor   = DISTRICT_INFO[district]?.color ?? 'transparent'
+          const isRowStart  = col === 0
           return (
             <button
               key={i}
               className={`city-cell u-col u-items-c u-just-c u-pointer u-relative${cell ? ' city-cell--occupied' : ''}${cell && bulldozerMode ? ' city-cell--bulldoze' : ''}`}
-              style={district !== 'none' ? { background: distColor } : undefined}
+              style={district !== 'none' && isRowStart ? { boxShadow: `inset 4px 0 0 ${distColor}` } : undefined}
               onClick={() => onCellTap(i)}
               title={cell ? (bulldozerMode ? `${cell.cardName} — tap to demolish` : `${cell.cardName} — tap to inspect`) : 'Empty — tap to place'}
             >
@@ -125,12 +127,6 @@ export function CityGrid({
               )}
               <AnimatedSpriteImg name={w.unitName} frameCount={3} fps={6} className="city-walker-sprite" />
               {rage >= 40 && <span className="city-walker-need">!</span>}
-              {w.trait && (
-                <span
-                  className="city-walker-trait"
-                  title={`${PERSONALITY_INFO[w.trait].label}: ${PERSONALITY_INFO[w.trait].desc}`}
-                >{PERSONALITY_INFO[w.trait].icon}</span>
-              )}
             </div>
           )
         })}

--- a/web/src/game/cityBuilder.ts
+++ b/web/src/game/cityBuilder.ts
@@ -268,10 +268,10 @@ export interface DistrictDef {
 
 export const DISTRICT_INFO: Record<DistrictType, DistrictDef> = {
   none:         { icon: '—',  label: 'Unzoned',      color: 'transparent' },
-  agricultural: { icon: '🌾', label: 'Agricultural', color: 'rgba(180,150,0,0.08)',   prodMult: 0.15 },
-  military:     { icon: '🛡', label: 'Military',     color: 'rgba(40,100,180,0.08)',  defBonus: 0.10 },
-  commercial:   { icon: '💰', label: 'Commercial',   color: 'rgba(200,160,0,0.08)',   goldMult: 0.15 },
-  industrial:   { icon: '⚙',  label: 'Industrial',   color: 'rgba(100,100,120,0.08)', prodMult: 0.10 },
+  agricultural: { icon: '🌾', label: 'Agricultural', color: 'rgba(180,150,0,0.55)',  prodMult: 0.15 },
+  military:     { icon: '🛡', label: 'Military',     color: 'rgba(40,120,200,0.55)', defBonus: 0.10 },
+  commercial:   { icon: '💰', label: 'Commercial',   color: 'rgba(200,160,0,0.55)',  goldMult: 0.15 },
+  industrial:   { icon: '⚙',  label: 'Industrial',   color: 'rgba(120,120,140,0.55)', prodMult: 0.10 },
 }
 
 const DISTRICT_CYCLE: DistrictType[] = ['none', 'agricultural', 'military', 'commercial', 'industrial']


### PR DESCRIPTION
## Summary

- **Zone display**: replaced the full-cell background tint (which overwrote the cell's green background, making the whole city look brown) with a 4px inset left-stripe on the first cell of each row only — gives a clear row label without repainting every cell
- **District colors**: bumped to ~55% opacity so the thin stripe remains visible against the dark cell background
- **Personality traits**: removed the always-on trait icon from the walker overlay — it's already shown in the ResidentInfoModal when you tap a resident

## Test plan

- [ ] Set a row to a district zone — first cell of the row should have a thin coloured left stripe; remaining cells should stay green as normal
- [ ] All four district types (Agricultural/Military/Commercial/Industrial) show distinct stripe colours
- [ ] Unzoned rows show no stripe
- [ ] Tap a resident → ResidentInfoModal shows the personality trait icon and label
- [ ] No personality icons visible on walkers in the grid view

https://claude.ai/code/session_01QoP8jPH6TsU5QUWDguGVYx

---
_Generated by [Claude Code](https://claude.ai/code/session_01QoP8jPH6TsU5QUWDguGVYx)_