### PR TITLE
fix(city-builder): tapping a walker shows only that resident, not all

### DIFF
--- a/web/src/components/minigames/CityBuilder.tsx
+++ b/web/src/components/minigames/CityBuilder.tsx
@@ -534,7 +534,7 @@ export function CityBuilder({ onBack }: Props) {
   const [toast, setToast] = useState<string | null>(null)
   const [walkers, setWalkers] = useState<Walker[]>([])
   const [builderWalkers, setBuilderWalkers] = useState<BuilderWalker[]>([])
-  const [selectedWalkerCell, setSelectedWalkerCell] = useState<number | null>(null)
+  const [selectedWalker, setSelectedWalker] = useState<{ cellIndex: number; unitIndex: number } | null>(null)
   const [selectedBuildingCell, setSelectedBuildingCell] = useState<number | null>(null)
   const [buildingTab, setBuildingTab] = useState<'residents' | 'upgrade'>('residents')
   const [pickerSearch, setPickerSearch] = useState('')
@@ -949,7 +949,7 @@ export function CityBuilder({ onBack }: Props) {
   function toggleBulldozer() {
     setBulldozerMode(prev => !prev)
     setSelectedBuildingCell(null)
-    setSelectedWalkerCell(null)
+    setSelectedWalker(null)
   }
 
   // ── Place a card ──────────────────────────────────────────────────────────────
@@ -1329,16 +1329,17 @@ export function CityBuilder({ onBack }: Props) {
           />
         )}
 
-        {selectedWalkerCell !== null && (() => {
-          const cell = city.grid[selectedWalkerCell]
+        {selectedWalker !== null && (() => {
+          const cell = city.grid[selectedWalker.cellIndex]
           if (!cell?.spawnedUnitName) return null
           return (
             <ResidentInfoModal
-              cellIndex={selectedWalkerCell}
+              cellIndex={selectedWalker.cellIndex}
+              unitIndex={selectedWalker.unitIndex}
               cell={cell}
               city={city}
               walkers={walkers}
-              onClose={() => setSelectedWalkerCell(null)}
+              onClose={() => setSelectedWalker(null)}
             />
           )
         })()}
@@ -1387,7 +1388,7 @@ export function CityBuilder({ onBack }: Props) {
           bulldozerMode={bulldozerMode}
           worldRef={worldRef}
           onCellTap={handleCellTap}
-          onWalkerClick={setSelectedWalkerCell}
+          onWalkerClick={(cellIndex, unitIndex) => setSelectedWalker({ cellIndex, unitIndex })}
         />
 
         <CityPerimeter

--- a/web/src/components/minigames/citybuilder/CityGrid.tsx
+++ b/web/src/components/minigames/citybuilder/CityGrid.tsx
@@ -15,7 +15,7 @@ export interface Props {
   bulldozerMode: boolean
   worldRef:      React.RefObject<HTMLDivElement>
   onCellTap:     (index: number) => void
-  onWalkerClick: (cellIndex: number) => void
+  onWalkerClick: (cellIndex: number, unitIndex: number) => void
 }
 
 export function CityGrid({
@@ -111,8 +111,8 @@ export function CityGrid({
               tabIndex={0}
               className={`city-walker${rage >= 60 ? ' city-walker--unhappy' : ''}`}
               style={{ left: Math.round(w.x), top: Math.round(w.y) }}
-              onClick={e => { e.stopPropagation(); onWalkerClick(w.cellIndex) }}
-              onKeyDown={e => { if (e.key === 'Enter') { e.stopPropagation(); onWalkerClick(w.cellIndex) } }}
+              onClick={e => { e.stopPropagation(); onWalkerClick(w.cellIndex, w.unitIndex) }}
+              onKeyDown={e => { if (e.key === 'Enter') { e.stopPropagation(); onWalkerClick(w.cellIndex, w.unitIndex) } }}
             >
               {w.task.type === 'chatting' && (
                 <div className="city-chat-bubble">{w.task.label}</div>

--- a/web/src/components/minigames/citybuilder/ResidentInfoModal.stories.tsx
+++ b/web/src/components/minigames/citybuilder/ResidentInfoModal.stories.tsx
@@ -39,6 +39,7 @@ export const HappyResident: Story = {
   render: () => (
     <ResidentInfoModal
       cellIndex={2}
+      unitIndex={0}
       cell={happyCell}
       city={{ ...baseCity, happiness: { 2: 100 } }}
       walkers={[walker]}
@@ -52,6 +53,7 @@ export const UnhappyResident: Story = {
   render: () => (
     <ResidentInfoModal
       cellIndex={2}
+      unitIndex={0}
       cell={{ ...happyCell, affinityWith: 'Knight' }}
       city={{ ...baseCity, happiness: { 2: 25 }, resources: { ...baseCity.resources, wheat: 1 } }}
       walkers={[{ ...walker, task: { type: 'resting' as const, label: '🏠 Taking shelter!' } }]}
@@ -65,6 +67,7 @@ export const ResidentGone: Story = {
   render: () => (
     <ResidentInfoModal
       cellIndex={2}
+      unitIndex={0}
       cell={happyCell}
       city={{ ...baseCity, happiness: { 2: 0 } }}
       walkers={[]}

--- a/web/src/components/minigames/citybuilder/ResidentInfoModal.tsx
+++ b/web/src/components/minigames/citybuilder/ResidentInfoModal.tsx
@@ -5,17 +5,18 @@ import { Walker, rageDescription, residentName, getUnitRequirements, PERSONALITY
 
 export interface Props {
   cellIndex: number
+  unitIndex: number
   cell:      CityCell
   city:      CityState
   walkers:   Walker[]
   onClose:   () => void
 }
 
-export function ResidentInfoModal({ cellIndex, cell, city, walkers, onClose }: Props) {
-  const happiness  = city.happiness[cellIndex] ?? 100
-  const reqs       = getUnitRequirements(cell, city, cellIndex)
-  const moodKey    = happiness === 0 ? 'gone' : happiness < 30 ? 'furious' : happiness < 60 ? 'unsettled' : 'content'
-  const cellWalkers = walkers.filter(w => w.cellIndex === cellIndex)
+export function ResidentInfoModal({ cellIndex, unitIndex, cell, city, walkers, onClose }: Props) {
+  const happiness = city.happiness[cellIndex] ?? 100
+  const reqs      = getUnitRequirements(cell, city, cellIndex)
+  const moodKey   = happiness === 0 ? 'gone' : happiness < 30 ? 'furious' : happiness < 60 ? 'unsettled' : 'content'
+  const w         = walkers.find(w => w.cellIndex === cellIndex && w.unitIndex === unitIndex)
 
   return (
     <div className="city-req-overlay" onClick={onClose}>
@@ -25,20 +26,18 @@ export function ResidentInfoModal({ cellIndex, cell, city, walkers, onClose }: P
           <div className="city-req-name">{cell.spawnedUnitName}</div>
         </div>
         <div className={`city-req-mood city-req-mood--${moodKey}`}>{rageDescription(happiness)}</div>
-        {cellWalkers.length > 0 && (
+        {w && (
           <div className="city-req-list">
-            {cellWalkers.map(w => (
-              <div key={`${w.cellIndex}-${w.unitIndex}`} className="city-req-item city-req-item--met">
-                <span className="city-req-icon">📍</span>
-                {residentName(w.unitName, w.cellIndex, w.unitIndex).split(' ')[0]}:{' '}
-                {w.hidden ? '🏠 Resting at home' : w.task.label}
-                {w.trait && (
-                  <span className="city-req-trait" title={PERSONALITY_INFO[w.trait].desc}>
-                    {' '}{PERSONALITY_INFO[w.trait].icon} {PERSONALITY_INFO[w.trait].label}
-                  </span>
-                )}
-              </div>
-            ))}
+            <div className="city-req-item city-req-item--met">
+              <span className="city-req-icon">📍</span>
+              {residentName(w.unitName, w.cellIndex, w.unitIndex)}:{' '}
+              {w.hidden ? '🏠 Resting at home' : w.task.label}
+              {w.trait && (
+                <span className="city-req-trait" title={PERSONALITY_INFO[w.trait].desc}>
+                  {' '}{PERSONALITY_INFO[w.trait].icon} {PERSONALITY_INFO[w.trait].label}
+                </span>
+              )}
+            </div>
           </div>
         )}
         <div className="city-req-list">


### PR DESCRIPTION
## Summary

- `onWalkerClick` now passes both `cellIndex` and `unitIndex` (previously only `cellIndex`)
- `CityBuilder` stores `{ cellIndex, unitIndex }` as `selectedWalker` instead of a bare cell index
- `ResidentInfoModal` finds the specific walker by both indices instead of filtering all walkers at the cell

**Before:** tapping any walker from a building showed the entire list of residents from that building.  
**After:** tapping a specific walker shows only that resident's name, current task, and personality trait.

## Test plan

- [ ] Tap individual walkers on buildings with multiple residents — each shows only that walker's info
- [ ] Personality trait shown in modal for the tapped walker
- [ ] Tapping a walker whose resident is resting shows "🏠 Resting at home"
- [ ] No regression on the building inspect modal (cell tap)

https://claude.ai/code/session_01QoP8jPH6TsU5QUWDguGVYx

---
_Generated by [Claude Code](https://claude.ai/code/session_01QoP8jPH6TsU5QUWDguGVYx)_