### PR TITLE
feat(city-builder): double windmill output + add Bakery core building

### DIFF
--- a/web/public/sprites/bakery.svg
+++ b/web/public/sprites/bakery.svg
@@ -8,16 +8,30 @@
   <!-- Chimney -->
   <rect x="22" y="3" width="5" height="9" fill="#7A5230"/>
   <rect x="21" y="2" width="7" height="2" fill="#5C3E22"/>
-  <!-- Smoke puffs -->
-  <circle cx="24" cy="1" r="1" fill="#CCCCCC" opacity="0.7"/>
-  <circle cx="26" cy="2" r="1" fill="#DDDDDD" opacity="0.5"/>
+  <!-- Animated smoke puffs — three staggered puffs rising from chimney -->
+  <circle cx="24" cy="2" r="1.5" fill="#CCCCCC">
+    <animate attributeName="cy"      from="2"   to="-6"  dur="2.4s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" from="0.75" to="0"   dur="2.4s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="25" cy="2" r="1.2" fill="#DDDDDD">
+    <animate attributeName="cy"      from="2"   to="-6"  dur="2.4s" begin="0.8s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" from="0.6"  to="0"   dur="2.4s" begin="0.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="24" cy="2" r="1.0" fill="#CCCCCC">
+    <animate attributeName="cy"      from="2"   to="-6"  dur="2.4s" begin="1.6s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" from="0.5"  to="0"   dur="2.4s" begin="1.6s" repeatCount="indefinite"/>
+  </circle>
   <!-- Oven door arch -->
   <rect x="7" y="20" width="8" height="9" fill="#3D2010"/>
   <rect x="8" y="19" width="6" height="2" fill="#3D2010"/>
   <rect x="9" y="18" width="4" height="2" fill="#3D2010"/>
-  <!-- Oven glow -->
-  <rect x="8" y="22" width="6" height="5" fill="#C04010" opacity="0.6"/>
-  <rect x="9" y="24" width="4" height="3" fill="#FF8020" opacity="0.5"/>
+  <!-- Oven glow — pulses gently -->
+  <rect x="8" y="22" width="6" height="5" fill="#C04010">
+    <animate attributeName="opacity" values="0.5;0.75;0.5" dur="1.8s" repeatCount="indefinite"/>
+  </rect>
+  <rect x="9" y="24" width="4" height="3" fill="#FF8020">
+    <animate attributeName="opacity" values="0.4;0.65;0.4" dur="1.8s" repeatCount="indefinite"/>
+  </rect>
   <!-- Bread loaves on counter -->
   <rect x="17" y="21" width="9" height="4" fill="#D4954A"/>
   <rect x="18" y="20" width="3" height="2" fill="#C07830"/>

--- a/web/public/sprites/bakery.svg
+++ b/web/public/sprites/bakery.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" shape-rendering="crispEdges">
+  <!-- Building body -->
+  <rect x="3" y="10" width="26" height="19" fill="#8B5E3C"/>
+  <!-- Brick rows -->
+  <rect x="3" y="10" width="6" height="3" fill="#7A5230"/><rect x="11" y="10" width="6" height="3" fill="#7A5230"/><rect x="19" y="10" width="6" height="3" fill="#7A5230"/>
+  <rect x="7"  y="14" width="6" height="3" fill="#7A5230"/><rect x="15" y="14" width="6" height="3" fill="#7A5230"/><rect x="23" y="14" width="6" height="3" fill="#7A5230"/>
+  <rect x="3" y="18" width="6" height="3" fill="#7A5230"/><rect x="11" y="18" width="6" height="3" fill="#7A5230"/><rect x="19" y="18" width="6" height="3" fill="#7A5230"/>
+  <!-- Chimney -->
+  <rect x="22" y="3" width="5" height="9" fill="#7A5230"/>
+  <rect x="21" y="2" width="7" height="2" fill="#5C3E22"/>
+  <!-- Smoke puffs -->
+  <circle cx="24" cy="1" r="1" fill="#CCCCCC" opacity="0.7"/>
+  <circle cx="26" cy="2" r="1" fill="#DDDDDD" opacity="0.5"/>
+  <!-- Oven door arch -->
+  <rect x="7" y="20" width="8" height="9" fill="#3D2010"/>
+  <rect x="8" y="19" width="6" height="2" fill="#3D2010"/>
+  <rect x="9" y="18" width="4" height="2" fill="#3D2010"/>
+  <!-- Oven glow -->
+  <rect x="8" y="22" width="6" height="5" fill="#C04010" opacity="0.6"/>
+  <rect x="9" y="24" width="4" height="3" fill="#FF8020" opacity="0.5"/>
+  <!-- Bread loaves on counter -->
+  <rect x="17" y="21" width="9" height="4" fill="#D4954A"/>
+  <rect x="18" y="20" width="3" height="2" fill="#C07830"/>
+  <rect x="22" y="20" width="3" height="2" fill="#C07830"/>
+  <!-- Score lines on loaves -->
+  <rect x="19" y="21" width="1" height="3" fill="#A06020"/>
+  <rect x="23" y="21" width="1" height="3" fill="#A06020"/>
+  <!-- Sign above door -->
+  <rect x="3" y="8" width="16" height="3" fill="#D4954A"/>
+  <rect x="4" y="9" width="2" height="1" fill="#5C3E22"/>
+  <rect x="7" y="9" width="2" height="1" fill="#5C3E22"/>
+  <rect x="10" y="9" width="2" height="1" fill="#5C3E22"/>
+  <rect x="13" y="9" width="2" height="1" fill="#5C3E22"/>
+  <!-- Ground line -->
+  <rect x="3" y="29" width="26" height="1" fill="#5C3E22"/>
+</svg>

--- a/web/public/sprites/windmill.svg
+++ b/web/public/sprites/windmill.svg
@@ -12,19 +12,27 @@
   <polygon points="16,5 10,14 22,14" fill="#6a3a18"/>
   <line x1="10" y1="14" x2="22" y2="14" stroke="#4a2a08" stroke-width="1"/>
 
-  <!-- Sails (drawn before hub so hub sits on top) -->
-  <!-- upper-right -->
-  <line x1="16" y1="14" x2="27" y2="5"  stroke="#d4b445" stroke-width="3" stroke-linecap="round"/>
-  <!-- lower-right -->
-  <line x1="16" y1="14" x2="27" y2="23" stroke="#c4a435" stroke-width="3" stroke-linecap="round"/>
-  <!-- lower-left -->
-  <line x1="16" y1="14" x2="5"  y2="23" stroke="#d4b445" stroke-width="3" stroke-linecap="round"/>
-  <!-- upper-left -->
-  <line x1="16" y1="14" x2="5"  y2="5"  stroke="#c4a435" stroke-width="3" stroke-linecap="round"/>
-
-  <!-- Hub -->
-  <circle cx="16" cy="14" r="2.5" fill="#5a3820"/>
-  <circle cx="16" cy="14" r="1"   fill="#d4b020"/>
+  <!-- Rotating sails + hub — pivot at hub centre (16, 14) -->
+  <g>
+    <!-- upper-right -->
+    <line x1="16" y1="14" x2="27" y2="5"  stroke="#d4b445" stroke-width="3" stroke-linecap="round"/>
+    <!-- lower-right -->
+    <line x1="16" y1="14" x2="27" y2="23" stroke="#c4a435" stroke-width="3" stroke-linecap="round"/>
+    <!-- lower-left -->
+    <line x1="16" y1="14" x2="5"  y2="23" stroke="#d4b445" stroke-width="3" stroke-linecap="round"/>
+    <!-- upper-left -->
+    <line x1="16" y1="14" x2="5"  y2="5"  stroke="#c4a435" stroke-width="3" stroke-linecap="round"/>
+    <!-- Hub -->
+    <circle cx="16" cy="14" r="2.5" fill="#5a3820"/>
+    <circle cx="16" cy="14" r="1"   fill="#d4b020"/>
+    <animateTransform
+      attributeName="transform"
+      type="rotate"
+      from="0 16 14"
+      to="360 16 14"
+      dur="6s"
+      repeatCount="indefinite"/>
+  </g>
 
   <!-- Door (arched) -->
   <rect x="14" y="21" width="4" height="7" rx="2" fill="#2a1808"/>

--- a/web/src/components/minigames/citybuilder/CityGrid.tsx
+++ b/web/src/components/minigames/citybuilder/CityGrid.tsx
@@ -79,6 +79,9 @@ export function CityGrid({
                   {city.activeDisaster?.type === 'plague' && city.grid[i]?.spawnedUnitName && (
                     <span className="city-cell-plague">☠</span>
                   )}
+                  {!city.activeDisaster && (city.resources.bread ?? 0) < 1 && cell.spawnedUnitName && (
+                    <span className="city-cell-bread-warn" title="No bread — residents are hungry">🍞</span>
+                  )}
                 </>
               ) : (
                 <span className="city-cell-empty u-col u-items-c u-just-end">

--- a/web/src/game/cityBuilder.ts
+++ b/web/src/game/cityBuilder.ts
@@ -51,10 +51,12 @@ const BREAD_CONSUME_RATE = 0.5
 const WOOD_CONSUME_RATE  = 0.3
 /** Wood consumption multiplier in winter (heating demand). */
 const WINTER_WOOD_MULT   = 1.8
-/** Happiness target bonus (points) when bread coverage ≥ 80%. */
-const BREAD_HAPPY_BONUS  = 20
+/** Happiness target bonus (points) when bread coverage is full. */
+const BREAD_HAPPY_BONUS    = 20
+/** Happiness target penalty (points) when bread coverage is zero. */
+const BREAD_SHORTAGE_PENALTY = 15
 /** Happiness target penalty (points) when wood supply covers < 50% of demand. */
-const WOOD_SHORTAGE_PENALTY = 15
+const WOOD_SHORTAGE_PENALTY  = 15
 
 /**
  * Buildings that convert an input resource into their output resource.
@@ -1234,7 +1236,10 @@ export function tickCity(state: CityState): CityState {
   // ── Base happiness target from food, defence, bread quality, wood supply ──
   const foodScore    = Math.min(100, (newResources.wheat / population) * 5)
   const defenseScore = Math.min(100, (defense / population) * 8)
-  const breadScore   = Math.round(breadCoverage * BREAD_HAPPY_BONUS)
+  // Linear scale: -BREAD_SHORTAGE_PENALTY at 0% coverage → +BREAD_HAPPY_BONUS at 100%
+  const breadScore   = breadCoverage >= 1
+    ? BREAD_HAPPY_BONUS
+    : Math.round(breadCoverage * (BREAD_HAPPY_BONUS + BREAD_SHORTAGE_PENALTY) - BREAD_SHORTAGE_PENALTY)
   const woodScore    = woodShort ? -WOOD_SHORTAGE_PENALTY : 0
   const baseTarget   = Math.min(100, Math.max(0, Math.round(foodScore * 0.6 + defenseScore * 0.4) + breadScore + woodScore))
 

--- a/web/src/game/cityBuilder.ts
+++ b/web/src/game/cityBuilder.ts
@@ -58,8 +58,8 @@ const WOOD_SHORTAGE_PENALTY = 15
 
 /**
  * Buildings that convert an input resource into their output resource.
- * The value is the amount of input consumed per unit of output produced.
- * e.g. Windmill produces 1 bread/min and consumes 2 wheat/min.
+ * Values are per-minute consumption rates, matching BUILDING_RESOURCE_CONFIG.
+ * e.g. Windmill produces 2 bread/min and consumes 2 wheat/min.
  */
 const BUILDING_CONVERSION_COST: Record<string, Partial<ResourceStock>> = {
   'Windmill': { wheat: 2 },
@@ -375,7 +375,8 @@ export function currentSeason(now = Date.now()): Season {
  */
 const BUILDING_RESOURCE_CONFIG: Record<string, Partial<ResourceStock>> = {
   // ── Core buildings (always available, built with gold) ──
-  'Windmill':    { bread: 1 },
+  'Windmill':    { bread: 2 },
+  'Bakery':      { bread: 1.5 },
   'Quarry':      { ore: 2, planks: 1 },
   'Granary':     {},           // storage handled by WAREHOUSE_PATTERN; no per-tick produce
   'Watchtower':  {},           // defense handled as wall-type (non-spawner, non-producer)
@@ -1144,7 +1145,8 @@ export function tickCity(state: CityState): CityState {
   const population = Math.max(cityPopulation(state), 1)
 
   // Deferred bread from conversion buildings (applied after loop with wheat-efficiency check)
-  let windmillBreadPending = 0
+  let breadConversionPending = 0
+  let wheatConversionCost    = 0
 
   for (let i = 0; i < state.grid.length; i++) {
     const cell = state.grid[i]
@@ -1182,7 +1184,9 @@ export function tickCity(state: CityState): CityState {
           const amount = rate * masteryMult * synergyMult * Math.max(0, seasonMult) * distProdMult * minutes
           // Conversion buildings: defer bread production — it depends on wheat availability
           if (BUILDING_CONVERSION_COST[cell.cardName] && res === 'bread') {
-            windmillBreadPending += amount
+            breadConversionPending += amount
+            const wheatRate = BUILDING_CONVERSION_COST[cell.cardName].wheat ?? 0
+            wheatConversionCost += wheatRate * masteryMult * synergyMult * Math.max(0, seasonMult) * distProdMult * minutes
           } else {
             newResources[res] = (newResources[res] ?? 0) + amount
           }
@@ -1199,14 +1203,13 @@ export function tickCity(state: CityState): CityState {
     }
   }
 
-  // ── Windmill wheat → bread conversion ────────────────────────────────────────
-  if (windmillBreadPending > 0) {
-    const wheatNeeded = windmillBreadPending * 2   // 2 wheat consumed per 1 bread produced
-    const eff = newResources.wheat > 0
-      ? Math.min(1, newResources.wheat / wheatNeeded)
-      : 0
-    newResources.bread  = (newResources.bread ?? 0) + windmillBreadPending * eff
-    newResources.wheat  = Math.max(0, (newResources.wheat ?? 0) - wheatNeeded * eff)
+  // ── Wheat → bread conversion (Windmill and any future conversion buildings) ──
+  if (breadConversionPending > 0) {
+    const eff = wheatConversionCost > 0
+      ? Math.min(1, (newResources.wheat ?? 0) / wheatConversionCost)
+      : 1
+    newResources.bread = (newResources.bread ?? 0) + breadConversionPending * eff
+    newResources.wheat = Math.max(0, (newResources.wheat ?? 0) - wheatConversionCost * eff)
   }
 
   // ── Resident resource consumption (bread & wood) ──────────────────────────
@@ -1554,10 +1557,11 @@ export interface CoreBuilding {
 }
 
 export const CORE_BUILDINGS: CoreBuilding[] = [
-  { name: 'Windmill',   goldCost:  500, rarity: 'common', hint: 'Needs wheat to run. +50% output next to a Farm.' },
-  { name: 'Granary',    goldCost:  600, rarity: 'common', hint: 'Extends all resource storage caps by 200.' },
-  { name: 'Watchtower', goldCost:  800, rarity: 'common', hint: 'Garrisoned lookout. Contributes to city defense.' },
-  { name: 'Quarry',     goldCost:  700, rarity: 'common', hint: 'Mines raw ore and cuts stone into planks.' },
+  { name: 'Windmill',   goldCost:  500, rarity: 'common',   hint: 'Grinds wheat into bread (2/min). Needs 2 wheat/min — output ×1.5 next to a Farm.' },
+  { name: 'Bakery',     goldCost:  750, rarity: 'uncommon', hint: 'Bakes bread directly (1.5/min). No wheat cost — pure gold investment.' },
+  { name: 'Granary',    goldCost:  600, rarity: 'common',   hint: 'Extends all resource storage caps by 200.' },
+  { name: 'Watchtower', goldCost:  800, rarity: 'common',   hint: 'Garrisoned lookout. Contributes to city defense.' },
+  { name: 'Quarry',     goldCost:  700, rarity: 'common',   hint: 'Mines raw ore and cuts stone into planks.' },
 ]
 
 export function canAffordCoreBuild(state: CityState, building: CoreBuilding): boolean {
@@ -1747,10 +1751,10 @@ export function resourceConsumptionRate(state: CityState): Partial<ResourceStock
       rates.wood  = (rates.wood  ?? 0) + WOOD_CONSUME_RATE * unitCount * woodMult
     }
 
-    // Windmill wheat input (2 wheat consumed per 1 bread produced)
+    // Conversion building wheat input (per-minute rate from BUILDING_CONVERSION_COST)
     if (!cell.spawnedUnitName && BUILDING_CONVERSION_COST[cell.cardName]) {
-      const breadRate = getBuildingProduces(cell.cardName).bread ?? 0
-      rates.wheat = (rates.wheat ?? 0) + breadRate * 2
+      const wheatRate = BUILDING_CONVERSION_COST[cell.cardName].wheat ?? 0
+      rates.wheat = (rates.wheat ?? 0) + wheatRate
     }
   }
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -9597,6 +9597,16 @@ html.light-mode .action-btn {
 }
 .city-cell-plague { font-size: 11px; top: 3px; }
 
+.city-cell-bread-warn {
+  position: absolute;
+  bottom: 2px;
+  left: 2px;
+  font-size: 11px;
+  pointer-events: none;
+  animation: city-pulse 2s ease-in-out infinite;
+  filter: grayscale(0.3);
+}
+
 .city-disaster-btn {
   border-color: #884400 !important;
   color: #ff8800 !important;


### PR DESCRIPTION
## Summary

- **Windmill output doubled**: 1 → 2 bread/min, same 2 wheat/min cost (double efficiency per wheat). A Windmill adjacent to a Farm now yields **3 bread/min** — the farm adjacency synergy actually feels meaningful now
- **Bakery** core building (750g): produces 1.5 bread/min with **no wheat cost** — a reliable bread income when wheat supply is the bottleneck
- **Refactor**: wheat consumption in `tickCity` now derived from `BUILDING_CONVERSION_COST` instead of a hardcoded `× 2`, so any future conversion building with a different ratio will just work. `resourceConsumptionRate` likewise uses the config directly

## Test plan

- [ ] Windmill shows +2 🍞/min and −2 🌾/min in CardPicker
- [ ] Windmill adjacent to Farm produces 3 bread/min (×1.5 synergy)
- [ ] Bakery shows +1.5 🍞/min, no wheat consumption listed
- [ ] Bakery available in INFRASTRUCTURE section of CardPicker
- [ ] Wheat efficiency throttle still works: if wheat runs out, windmill bread production scales down proportionally
- [ ] ResourceStrip shows correct wheat consumption rate for windmills

https://claude.ai/code/session_01QoP8jPH6TsU5QUWDguGVYx

---
_Generated by [Claude Code](https://claude.ai/code/session_01QoP8jPH6TsU5QUWDguGVYx)_