### PR TITLE
feat(city-builder): full resource logistics simulation

### DIFF
--- a/web/src/components/minigames/CityBuilder.tsx
+++ b/web/src/components/minigames/CityBuilder.tsx
@@ -975,6 +975,7 @@ export function CityBuilder({ onBack }: Props) {
       rarity: card.rarity,
       spawnedUnitName,
       affinityWith,
+      stock: {},
     }
     save(placeCard(city, pickerIndex, cell))
     setScreen('city')

--- a/web/src/components/minigames/CityBuilder.tsx
+++ b/web/src/components/minigames/CityBuilder.tsx
@@ -305,6 +305,34 @@ const TASK_RESOURCE_GOLD: Partial<Record<ResourceType, number>> = {
 }
 
 
+// Compute edge-following waypoints from (fromX,fromY) to (toX,toY) through cell-border midpoints
+function computeWaypoints(
+  fromX: number, fromY: number,
+  toX: number, toY: number,
+  overlayW: number, overlayH: number,
+  cityRows: number,
+): { x: number; y: number }[] {
+  const cellW = overlayW / CITY_COLS
+  const cellH = overlayH / cityRows
+  const fc = Math.max(0, Math.min(CITY_COLS - 1, Math.floor(fromX / cellW)))
+  const fr = Math.max(0, Math.min(cityRows - 1, Math.floor(fromY / cellH)))
+  const tc = Math.max(0, Math.min(CITY_COLS - 1, Math.floor(toX / cellW)))
+  const tr = Math.max(0, Math.min(cityRows - 1, Math.floor(toY / cellH)))
+  const pts: { x: number; y: number }[] = []
+  let r = fr, c = fc
+  while (c !== tc) {
+    const dc = tc > c ? 1 : -1
+    pts.push({ x: (c + (dc > 0 ? 1 : 0)) * cellW, y: (r + 0.5) * cellH })
+    c += dc
+  }
+  while (r !== tr) {
+    const dr = tr > r ? 1 : -1
+    pts.push({ x: (c + 0.5) * cellW, y: (r + (dr > 0 ? 1 : 0)) * cellH })
+    r += dr
+  }
+  return pts
+}
+
 function makeWalker(cellIndex: number, unitIndex: number, unitName: string, affinityWith?: string, w = CITY_COLS * CELL_PX, h = CITY_ROWS * CELL_PX): Walker {
   const angle = Math.random() * Math.PI * 2
   // Deterministic trait so the same resident always has the same personality
@@ -326,6 +354,7 @@ function makeWalker(cellIndex: number, unitIndex: number, unitName: string, affi
     hidden: false,
     hiddenTimer: 0,
     trait: TRAITS[traitSeed],
+    waypoints: [],
   }
 }
 
@@ -702,6 +731,12 @@ export function CityBuilder({ onBack }: Props) {
         }
 
         // ── Pass 2: update each walker ────────────────────────────────────────
+        const cityRows = cityRef.current?.rows ?? CITY_ROWS
+        function wayptsFor(task: WalkerTask, fx: number, fy: number) {
+          if (task.type === 'idle' || task.type === 'visiting' || task.type === 'chatting' || task.targetX === undefined) return []
+          return computeWaypoints(fx, fy, task.targetX, task.targetY!, overlayW, overlayH, cityRows)
+        }
+
         return prev.map(w => {
           const wKey = `${w.cellIndex}-${w.unitIndex}`
 
@@ -714,7 +749,7 @@ export function CityBuilder({ onBack }: Props) {
               return {
                 ...w, hidden: false, hiddenTimer: 0,
                 task, taskTimer: task.type === 'idle' ? IDLE_TASK_TICKS + Math.floor(Math.random() * IDLE_TASK_TICKS) : 0,
-                bubbleTimer,
+                bubbleTimer, waypoints: wayptsFor(task, w.x, w.y),
               }
             }
             return { ...w, hiddenTimer }
@@ -727,10 +762,12 @@ export function CityBuilder({ onBack }: Props) {
               task: { type: 'chatting', label: chatPairs.get(wKey)! },
               taskTimer: CHAT_TICKS,
               bubbleTimer: CHAT_TICKS,
+              waypoints: [],
             }
           }
 
           let { x, y, vx, vy, turnTimer, task, taskTimer, bubbleTimer } = w
+          let waypoints = w.waypoints ?? []
           bubbleTimer = Math.max(0, bubbleTimer - 1)
 
           // ── Chatting: count down, then resume ──────────────────────────────
@@ -740,11 +777,12 @@ export function CityBuilder({ onBack }: Props) {
               task = pickTask(w, prev, cityRef.current, overlayW, overlayH)
               taskTimer = task.type === 'idle' ? IDLE_TASK_TICKS + Math.floor(Math.random() * IDLE_TASK_TICKS) : 0
               bubbleTimer = BUBBLE_TICKS
+              waypoints = wayptsFor(task, x, y)
               const angle = Math.random() * Math.PI * 2
               vx = Math.cos(angle) * SPEED
               vy = Math.sin(angle) * SPEED
             }
-            return { ...w, vx, vy, task, taskTimer, bubbleTimer }
+            return { ...w, vx, vy, task, taskTimer, bubbleTimer, waypoints }
           }
 
           // ── Update visiting target to follow the other walker ──────────────
@@ -757,6 +795,7 @@ export function CityBuilder({ onBack }: Props) {
               task = pickTask(w, prev, cityRef.current, overlayW, overlayH)
               taskTimer = task.type === 'idle' ? IDLE_TASK_TICKS + Math.floor(Math.random() * IDLE_TASK_TICKS) : 0
               if (task.type !== 'idle') bubbleTimer = BUBBLE_TICKS
+              waypoints = wayptsFor(task, x, y)
             }
           }
 
@@ -767,26 +806,43 @@ export function CityBuilder({ onBack }: Props) {
               task = pickTask(w, prev, cityRef.current, overlayW, overlayH)
               taskTimer = task.type === 'idle' ? IDLE_TASK_TICKS + Math.floor(Math.random() * IDLE_TASK_TICKS) : 0
               if (task.type !== 'idle') bubbleTimer = BUBBLE_TICKS
+              waypoints = wayptsFor(task, x, y)
             }
           }
 
-          // ── Directed movement ──────────────────────────────────────────────
-          if (task.type !== 'idle' && task.targetX !== undefined && task.targetY !== undefined) {
-            const dx = task.targetX - x
-            const dy = task.targetY - y
+          // ── Directed movement (waypoint-following) ─────────────────────────
+          if (task.type !== 'idle' && task.type !== 'chatting' && task.targetX !== undefined && task.targetY !== undefined) {
+            // Visiting walkers move directly toward their (moving) target
+            const useWaypoints = task.type !== 'visiting'
+            const currentTarget = (useWaypoints && waypoints.length > 0)
+              ? waypoints[0]
+              : { x: task.targetX, y: task.targetY }
+
+            const dx = currentTarget.x - x
+            const dy = currentTarget.y - y
             const dist = Math.sqrt(dx * dx + dy * dy)
 
             if (dist < ARRIVE_DIST) {
-              if (task.type === 'resting') {
+              if (useWaypoints && waypoints.length > 0) {
+                // Pop waypoint, aim at next
+                waypoints = waypoints.slice(1)
+                const next = waypoints.length > 0 ? waypoints[0] : { x: task.targetX, y: task.targetY }
+                const ndx = next.x - x, ndy = next.y - y
+                const nd  = Math.sqrt(ndx * ndx + ndy * ndy)
+                if (nd > 1) { vx = (ndx / nd) * SPEED; vy = (ndy / nd) * SPEED }
+              } else if (task.type === 'resting') {
                 return {
                   ...w, x, y, vx: 0, vy: 0, task, bubbleTimer,
-                  hidden: true,
+                  hidden: true, waypoints: [],
                   hiddenTimer: REST_TICKS_MIN + Math.floor(Math.random() * (REST_TICKS_MAX - REST_TICKS_MIN)),
                 }
+              } else {
+                vx = 0; vy = 0
+                task = pickTask(w, prev, cityRef.current, overlayW, overlayH)
+                taskTimer = task.type === 'idle' ? IDLE_TASK_TICKS + Math.floor(Math.random() * IDLE_TASK_TICKS) : 0
+                if (task.type !== 'idle') bubbleTimer = BUBBLE_TICKS
+                waypoints = wayptsFor(task, x, y)
               }
-              task = pickTask(w, prev, cityRef.current, overlayW, overlayH)
-              taskTimer = task.type === 'idle' ? IDLE_TASK_TICKS + Math.floor(Math.random() * IDLE_TASK_TICKS) : 0
-              if (task.type !== 'idle') bubbleTimer = BUBBLE_TICKS
             } else {
               vx = (dx / dist) * SPEED
               vy = (dy / dist) * SPEED
@@ -812,7 +868,7 @@ export function CityBuilder({ onBack }: Props) {
             }
           }
 
-          return { ...w, x, y, vx, vy, turnTimer, task, taskTimer, bubbleTimer }
+          return { ...w, x, y, vx, vy, turnTimer, task, taskTimer, bubbleTimer, waypoints }
         })
       })
 

--- a/web/src/components/minigames/citybuilder/BuildingInspectModal.stories.tsx
+++ b/web/src/components/minigames/citybuilder/BuildingInspectModal.stories.tsx
@@ -39,6 +39,7 @@ const walkers = [
     turnTimer: 10,
     task: { type: 'patrolling' as const, label: '🛡 Patrolling the walls' },
     taskTimer: 20, bubbleTimer: 5, hidden: false, hiddenTimer: 0, trait: 'brave' as const,
+    waypoints: [],
   },
 ]
 

--- a/web/src/components/minigames/citybuilder/CityGrid.tsx
+++ b/web/src/components/minigames/citybuilder/CityGrid.tsx
@@ -1,8 +1,10 @@
 import React from 'react'
 import {
-  CityState, CITY_COLS, CITY_ROWS,
+  CityState, CITY_COLS, CITY_ROWS, CELL_PX,
   spawnerUnitCount, getNeighbourIndices,
   getRowDistrict, DISTRICT_INFO,
+  roadTier, cellCenter,
+  RESOURCE_ICONS, ResourceType,
 } from '../../../game/cityBuilder'
 import { SpriteImg, AnimatedSpriteImg } from '../../ui/SpriteImg'
 import { BuilderWalker } from '../CityBuilder'
@@ -51,10 +53,11 @@ export function CityGrid({
           const district    = getRowDistrict(city, row)
           const distColor   = DISTRICT_INFO[district]?.color ?? 'transparent'
           const isRowStart  = col === 0
+          const tier = roadTier((city.roadWear ?? [])[i] ?? 0)
           return (
             <button
               key={i}
-              className={`city-cell u-col u-items-c u-just-c u-pointer u-relative${cell ? ' city-cell--occupied' : ''}${cell && bulldozerMode ? ' city-cell--bulldoze' : ''}`}
+              className={`city-cell u-col u-items-c u-just-c u-pointer u-relative${cell ? ' city-cell--occupied' : ''}${cell && bulldozerMode ? ' city-cell--bulldoze' : ''}${tier > 0 ? ` city-cell--road-${tier}` : ''}`}
               style={district !== 'none' && isRowStart ? { boxShadow: `inset 4px 0 0 ${distColor}` } : undefined}
               onClick={() => onCellTap(i)}
               title={cell ? (bulldozerMode ? `${cell.cardName} — tap to demolish` : `${cell.cardName} — tap to inspect`) : 'Empty — tap to place'}
@@ -146,6 +149,28 @@ export function CityGrid({
             <AnimatedSpriteImg name="Builder" frameCount={3} fps={8} className="city-walker-sprite" />
           </div>
         ))}
+      </div>
+
+      {/* Carrier overlay */}
+      <div className="city-unit-overlay city-carrier-overlay">
+        {(city.carriers ?? []).map(carrier => {
+          const rows = city.rows ?? CITY_ROWS
+          const f    = cellCenter(carrier.fromCell, rows)
+          const t    = cellCenter(carrier.toCell,   rows)
+          // Scale positions to actual overlay dimensions
+          const overlayW = CITY_COLS * CELL_PX
+          const overlayH = rows * CELL_PX
+          const scaleX = worldRef.current ? worldRef.current.clientWidth  / overlayW : 1
+          const scaleY = worldRef.current ? worldRef.current.clientHeight / overlayH : 1
+          const x = (f.x + (t.x - f.x) * carrier.progress) * scaleX
+          const y = (f.y + (t.y - f.y) * carrier.progress) * scaleY
+          const res = Object.keys(carrier.carrying)[0] as ResourceType
+          return (
+            <div key={carrier.id} className="city-carrier" style={{ left: Math.round(x), top: Math.round(y) }}>
+              <span className="city-carrier-icon">{RESOURCE_ICONS[res]}</span>
+            </div>
+          )
+        })}
       </div>
     </div>
   )

--- a/web/src/components/minigames/citybuilder/CityGrid.tsx
+++ b/web/src/components/minigames/citybuilder/CityGrid.tsx
@@ -3,7 +3,7 @@ import {
   CityState, CITY_COLS, CITY_ROWS, CELL_PX,
   spawnerUnitCount, getNeighbourIndices,
   getRowDistrict, DISTRICT_INFO,
-  roadTier, cellCenter,
+  roadTier,
   RESOURCE_ICONS, ResourceType,
 } from '../../../game/cityBuilder'
 import { SpriteImg, AnimatedSpriteImg } from '../../ui/SpriteImg'
@@ -53,12 +53,21 @@ export function CityGrid({
           const district    = getRowDistrict(city, row)
           const distColor   = DISTRICT_INFO[district]?.color ?? 'transparent'
           const isRowStart  = col === 0
-          const tier = roadTier((city.roadWear ?? [])[i] ?? 0)
+          const isLastCol   = col === CITY_COLS - 1
+          const isLastRow   = row === cityRows - 1
+          const tierR = isLastCol ? 0 : roadTier((city.roadWear?.h ?? [])[i] ?? 0)
+          const tierB = isLastRow ? 0 : roadTier((city.roadWear?.v ?? [])[i] ?? 0)
+          const ROAD1 = 'rgba(120,80,20,0.75)'
+          const ROAD2 = 'rgba(160,150,110,0.85)'
+          const shadows: string[] = []
+          if (district !== 'none' && isRowStart) shadows.push(`inset 4px 0 0 ${distColor}`)
+          if (tierR > 0) shadows.push(`inset -3px 0 0 ${tierR === 2 ? ROAD2 : ROAD1}`)
+          if (tierB > 0) shadows.push(`inset 0 -3px 0 ${tierB === 2 ? ROAD2 : ROAD1}`)
           return (
             <button
               key={i}
-              className={`city-cell u-col u-items-c u-just-c u-pointer u-relative${cell ? ' city-cell--occupied' : ''}${cell && bulldozerMode ? ' city-cell--bulldoze' : ''}${tier > 0 ? ` city-cell--road-${tier}` : ''}`}
-              style={district !== 'none' && isRowStart ? { boxShadow: `inset 4px 0 0 ${distColor}` } : undefined}
+              className={`city-cell u-col u-items-c u-just-c u-pointer u-relative${cell ? ' city-cell--occupied' : ''}${cell && bulldozerMode ? ' city-cell--bulldoze' : ''}`}
+              style={shadows.length > 0 ? { boxShadow: shadows.join(', ') } : undefined}
               onClick={() => onCellTap(i)}
               title={cell ? (bulldozerMode ? `${cell.cardName} — tap to demolish` : `${cell.cardName} — tap to inspect`) : 'Empty — tap to place'}
             >
@@ -151,22 +160,45 @@ export function CityGrid({
         ))}
       </div>
 
-      {/* Carrier overlay */}
+      {/* Carrier overlay — follow Manhattan road edges */}
       <div className="city-unit-overlay city-carrier-overlay">
         {(city.carriers ?? []).map(carrier => {
-          const rows = city.rows ?? CITY_ROWS
-          const f    = cellCenter(carrier.fromCell, rows)
-          const t    = cellCenter(carrier.toCell,   rows)
-          // Scale positions to actual overlay dimensions
-          const overlayW = CITY_COLS * CELL_PX
-          const overlayH = rows * CELL_PX
-          const scaleX = worldRef.current ? worldRef.current.clientWidth  / overlayW : 1
-          const scaleY = worldRef.current ? worldRef.current.clientHeight / overlayH : 1
-          const x = (f.x + (t.x - f.x) * carrier.progress) * scaleX
-          const y = (f.y + (t.y - f.y) * carrier.progress) * scaleY
+          const rows   = city.rows ?? CITY_ROWS
+          const baseW  = CITY_COLS * CELL_PX
+          const baseH  = rows      * CELL_PX
+          const scaleX = worldRef.current ? worldRef.current.clientWidth  / baseW : 1
+          const scaleY = worldRef.current ? worldRef.current.clientHeight / baseH : 1
+          const cellW  = baseW / CITY_COLS
+          const cellH  = baseH / rows
+
+          // Build waypoints: fromCenter → edge midpoints → toCenter
+          const r1 = Math.floor(carrier.fromCell / CITY_COLS), c1 = carrier.fromCell % CITY_COLS
+          const r2 = Math.floor(carrier.toCell   / CITY_COLS), c2 = carrier.toCell   % CITY_COLS
+          const pts: { x: number; y: number }[] = [{ x: (c1 + 0.5) * cellW, y: (r1 + 0.5) * cellH }]
+          let r = r1, c = c1
+          while (c !== c2) {
+            const dc = c2 > c ? 1 : -1
+            pts.push({ x: (c + (dc > 0 ? 1 : 0)) * cellW, y: (r + 0.5) * cellH })
+            c += dc; pts.push({ x: (c + 0.5) * cellW, y: (r + 0.5) * cellH })
+          }
+          while (r !== r2) {
+            const dr = r2 > r ? 1 : -1
+            pts.push({ x: (c + 0.5) * cellW, y: (r + (dr > 0 ? 1 : 0)) * cellH })
+            r += dr; pts.push({ x: (c + 0.5) * cellW, y: (r + 0.5) * cellH })
+          }
+
+          // Lerp through waypoints by progress
+          const segs  = Math.max(1, pts.length - 1)
+          const segF  = carrier.progress * segs
+          const segI  = Math.min(segs - 1, Math.floor(segF))
+          const segT  = segF - segI
+          const a = pts[segI], b = pts[segI + 1] ?? pts[segI]
+          const px = (a.x + (b.x - a.x) * segT) * scaleX
+          const py = (a.y + (b.y - a.y) * segT) * scaleY
+
           const res = Object.keys(carrier.carrying)[0] as ResourceType
           return (
-            <div key={carrier.id} className="city-carrier" style={{ left: Math.round(x), top: Math.round(y) }}>
+            <div key={carrier.id} className="city-carrier" style={{ left: Math.round(px), top: Math.round(py) }}>
               <span className="city-carrier-icon">{RESOURCE_ICONS[res]}</span>
             </div>
           )

--- a/web/src/components/minigames/citybuilder/ResidentInfoModal.stories.tsx
+++ b/web/src/components/minigames/citybuilder/ResidentInfoModal.stories.tsx
@@ -32,6 +32,7 @@ const walker = {
   turnTimer: 10,
   task: { type: 'patrolling' as const, label: '🛡 Patrolling the walls' },
   taskTimer: 20, bubbleTimer: 5, hidden: false, hiddenTimer: 0, trait: 'industrious' as const,
+  waypoints: [],
 }
 
 export const HappyResident: Story = {

--- a/web/src/components/minigames/citybuilder/ResourceStrip.stories.tsx
+++ b/web/src/components/minigames/citybuilder/ResourceStrip.stories.tsx
@@ -21,7 +21,7 @@ function stubCity(resources = emptyResources): CityState {
     lastAttack: null, chronicle: [], completedMilestones: [],
     attacksProcessed: 0, tradeOffer: null, activeCaravan: null, history: [],
     zones: [], activeDisaster: null, nextDisasterAt: Date.now() + 86_400_000,
-    roadWear: [], carriers: [],
+    roadWear: { h: [], v: [] }, carriers: [],
   }
 }
 

--- a/web/src/components/minigames/citybuilder/ResourceStrip.stories.tsx
+++ b/web/src/components/minigames/citybuilder/ResourceStrip.stories.tsx
@@ -21,6 +21,7 @@ function stubCity(resources = emptyResources): CityState {
     lastAttack: null, chronicle: [], completedMilestones: [],
     attacksProcessed: 0, tradeOffer: null, activeCaravan: null, history: [],
     zones: [], activeDisaster: null, nextDisasterAt: Date.now() + 86_400_000,
+    roadWear: [], carriers: [],
   }
 }
 

--- a/web/src/components/minigames/citybuilder/StatsScreen.stories.tsx
+++ b/web/src/components/minigames/citybuilder/StatsScreen.stories.tsx
@@ -33,6 +33,8 @@ function makeCity(history: HistorySample[]): CityState {
     zones:               [],
     activeDisaster:      null,
     nextDisasterAt:      Date.now() + 86_400_000,
+    roadWear:            [],
+    carriers:            [],
   }
 }
 

--- a/web/src/components/minigames/citybuilder/StatsScreen.stories.tsx
+++ b/web/src/components/minigames/citybuilder/StatsScreen.stories.tsx
@@ -33,7 +33,7 @@ function makeCity(history: HistorySample[]): CityState {
     zones:               [],
     activeDisaster:      null,
     nextDisasterAt:      Date.now() + 86_400_000,
-    roadWear:            [],
+    roadWear:            { h: [], v: [] },
     carriers:            [],
   }
 }

--- a/web/src/components/minigames/citybuilder/walkerTypes.ts
+++ b/web/src/components/minigames/citybuilder/walkerTypes.ts
@@ -48,6 +48,7 @@ export interface Walker {
   hidden:       boolean
   hiddenTimer:  number
   trait:        PersonalityTrait
+  waypoints:    { x: number; y: number }[]
 }
 
 export interface ResidentThought {

--- a/web/src/game/cityBuilder.ts
+++ b/web/src/game/cityBuilder.ts
@@ -302,6 +302,123 @@ export const STORAGE_BASE_CAPS: ResourceStock = {
 const STORAGE_PER_WAREHOUSE = 200  // added to all caps per warehouse building placed
 const WAREHOUSE_PATTERN = /warehouse|barn|granary|silo|storehouse|vault/i
 
+// ── Carrier / road transport constants ───────────────────────────────────────
+
+const CARRIER_LOAD          = 5     // units loaded per carrier trip
+const CARRIER_BASE_SPEED    = 1.0   // cells per minute on grass
+const ROAD_WEAR_PER_CARRIER = 0.4   // wear added per carrier per minute
+export const ROAD_TIER_THRESHOLDS = [25, 60] as const  // tier 1 at 25, tier 2 at 60
+const ROAD_SPEED_MULT = [1.0, 1.4, 2.0]  // multiplier per road tier
+
+export interface CarrierState {
+  id:       string
+  fromCell: number   // source cell index
+  toCell:   number   // destination cell index
+  carrying: Partial<ResourceStock>
+  progress: number   // 0..1 journey progress
+}
+
+// Manhattan distance between two cell indices
+function cellManhattan(a: number, b: number, cols: number): number {
+  return Math.abs(a % cols - b % cols) + Math.abs(Math.floor(a / cols) - Math.floor(b / cols))
+}
+
+// Road tier 0/1/2 from wear score
+export function roadTier(wear: number): 0 | 1 | 2 {
+  return wear >= ROAD_TIER_THRESHOLDS[1] ? 2 : wear >= ROAD_TIER_THRESHOLDS[0] ? 1 : 0
+}
+
+// Centre pixel of a cell in the overlay (for carrier rendering)
+export function cellCenter(idx: number, rows: number): { x: number; y: number } {
+  const gridRows = rows
+  const col = idx % CITY_COLS
+  const row = Math.floor(idx / CITY_COLS)
+  return {
+    x: (col + 0.5) * CELL_PX,
+    y: (row + 0.5) * CELL_PX * (gridRows / CITY_ROWS),
+  }
+}
+
+// Average road speed multiplier along the Manhattan path from→to
+function pathSpeedMult(from: number, to: number, roadWear: number[], cols: number): number {
+  let c = from % cols, r = Math.floor(from / cols)
+  const tc = to % cols, tr = Math.floor(to / cols)
+  let steps = 0, total = 0
+  while (c !== tc || r !== tr) {
+    if (c !== tc) c += c < tc ? 1 : -1; else r += r < tr ? 1 : -1
+    total += ROAD_SPEED_MULT[roadTier(roadWear[r * cols + c] ?? 0)]
+    steps++
+  }
+  return steps > 0 ? total / steps : ROAD_SPEED_MULT[0]
+}
+
+// Add wear to every cell on the Manhattan path from→to
+function wearPath(from: number, to: number, roadWear: number[], cols: number, amount: number): void {
+  let c = from % cols, r = Math.floor(from / cols)
+  const tc = to % cols, tr = Math.floor(to / cols)
+  while (c !== tc || r !== tr) {
+    if (c !== tc) c += c < tc ? 1 : -1; else r += r < tr ? 1 : -1
+    const idx = r * cols + c
+    roadWear[idx] = Math.min(100, (roadWear[idx] ?? 0) + amount)
+  }
+}
+
+// Find nearest building that wants this resource
+function findNearestConsumer(
+  res: ResourceType, fromCell: number,
+  grid: (CityCell | undefined)[], cols: number,
+): number | null {
+  let best: number | null = null, bestDist = Infinity
+  for (let i = 0; i < grid.length; i++) {
+    if (i === fromCell) continue
+    const cell = grid[i]
+    if (!cell || cell.spawnedUnitName) continue
+    const wants = res === 'wheat'
+      ? Boolean(BUILDING_CONVERSION_COST[cell.cardName]?.wheat)
+      : WAREHOUSE_PATTERN.test(cell.cardName)
+    if (!wants) continue
+    const d = cellManhattan(fromCell, i, cols)
+    if (d < bestDist) { bestDist = d; best = i }
+  }
+  return best
+}
+
+// Proportionally deduct `amount` of `res` from all cell stocks
+function deductResource(
+  res: ResourceType, amount: number,
+  grid: (CityCell | undefined)[], totalStock: ResourceStock,
+): void {
+  const total = totalStock[res] ?? 0
+  if (total <= 0 || amount <= 0) return
+  const consumed = Math.min(total, amount)
+  const fraction = consumed / total
+  for (const cell of grid) {
+    if (!cell) continue
+    const s = cell.stock[res] ?? 0
+    if (s > 0) cell.stock[res] = Math.max(0, s * (1 - fraction))
+  }
+  totalStock[res] = Math.max(0, total - consumed)
+}
+
+// Compute ResourceStock as the sum of all cell stocks + in-transit carriers
+function aggregateResources(
+  grid: (CityCell | undefined)[], carriers: CarrierState[],
+): ResourceStock {
+  const r: ResourceStock = { wheat: 0, wood: 0, ore: 0, bread: 0, planks: 0, metal: 0 }
+  for (const cell of grid) {
+    if (!cell) continue
+    for (const [k, v] of Object.entries(cell.stock) as [ResourceType, number][]) {
+      if (v > 0) r[k] = (r[k] ?? 0) + v
+    }
+  }
+  for (const c of carriers) {
+    for (const [k, v] of Object.entries(c.carrying) as [ResourceType, number][]) {
+      if (v > 0) r[k] = (r[k] ?? 0) + v
+    }
+  }
+  return r
+}
+
 export function calculateStorageCaps(state: CityState): ResourceStock {
   let bonus = 0
   for (const cell of state.grid) {
@@ -498,6 +615,7 @@ export interface CityCell {
   spawnedUnitName?:  string
   /** Unit name this walker wants as an affinity friend (stored at placement). */
   affinityWith?:     string
+  stock:             Partial<ResourceStock>  // local building storage
 }
 
 export interface Fortification {
@@ -582,6 +700,10 @@ export interface CityState {
   activeDisaster: Disaster | null
   /** Timestamp when the next disaster may be triggered. */
   nextDisasterAt: number
+  /** Per-cell wear score 0–100, drives road visual tier. */
+  roadWear: number[]
+  /** Workers currently transporting resources between buildings. */
+  carriers: CarrierState[]
 }
 
 // ── Storage ───────────────────────────────────────────────────────────────────
@@ -615,6 +737,8 @@ function defaultState(): CityState {
     zones:               [],
     activeDisaster:      null,
     nextDisasterAt:      Date.now() + (18 + Math.random() * 12) * 3_600_000,
+    roadWear:            [],
+    carriers:            [],
   }
 }
 
@@ -627,9 +751,10 @@ export function loadCityState(): CityState {
     const rows = parsed.rows ?? CITY_ROWS
     const cells = CITY_COLS * rows
     const savedGrid = parsed.grid ?? Array(cells).fill(undefined)
-    const grid = savedGrid.length < cells
+    const grid = (savedGrid.length < cells
       ? [...savedGrid, ...Array(cells - savedGrid.length).fill(undefined)]
       : savedGrid
+    ).map((c: CityCell | undefined) => c ? { ...c, stock: c.stock ?? {} } : c)
     return {
       grid,
       gold:           parsed.gold       ?? 0,
@@ -662,6 +787,8 @@ export function loadCityState(): CityState {
       zones:               (parsed.zones ?? []) as DistrictType[],
       activeDisaster:      parsed.activeDisaster ?? null,
       nextDisasterAt:      parsed.nextDisasterAt ?? Date.now() + (18 + Math.random() * 12) * 3_600_000,
+      roadWear:            (parsed.roadWear ?? []) as number[],
+      carriers:            (parsed.carriers ?? []) as CarrierState[],
     }
   } catch (err) {
     logError('loadCityState failed', err as Record<string, unknown>)
@@ -1139,99 +1266,163 @@ export function tickCity(state: CityState): CityState {
   const season = currentSeason(now)
   const si = SEASON_INFO[season]
 
-  const newResources = { ...state.resources }
   let goldEarned = 0
   const newHappy = { ...state.happiness }
 
   const defense   = cityDefense(state)
   const population = Math.max(cityPopulation(state), 1)
 
-  // Deferred bread from conversion buildings (applied after loop with wheat-efficiency check)
-  let breadConversionPending = 0
-  let wheatConversionCost    = 0
+  // ── Build mutable grid (copy cell stocks) ───────────────────────────────────
+  const gridRows = state.rows ?? CITY_ROWS
+  const newGrid = state.grid.map(c => c ? { ...c, stock: { ...(c.stock ?? {}) } } : c)
+  const newRoadWear = (state.roadWear?.length ? [...state.roadWear] : new Array(newGrid.length).fill(0)) as number[]
 
-  for (let i = 0; i < state.grid.length; i++) {
-    const cell = state.grid[i]
+  // ── Migration: first tick on old save — seed cell stocks from state.resources ─
+  const hasAnyStock = newGrid.some(c => c && Object.values(c.stock).some(v => (v ?? 0) > 0))
+  if (!hasAnyStock && Object.values(state.resources).some(v => v > 0)) {
+    const RES_PRODUCERS: Partial<Record<ResourceType, RegExp>> = {
+      wheat: /farm|garden|orchard|oasis|spring/i,
+      wood:  /lumber|sawmill|timber/i,
+      ore:   /quarry|mine|iron/i,
+    }
+    for (const [res, amount] of Object.entries(state.resources) as [ResourceType, number][]) {
+      if (amount <= 0) continue
+      const pattern = RES_PRODUCERS[res]
+      const targets = newGrid.filter((c): c is CityCell => Boolean(c && !c.spawnedUnitName && (pattern ? pattern.test(c.cardName) : WAREHOUSE_PATTERN.test(c.cardName))))
+      if (targets.length === 0) {
+        // Fall back to any non-spawner building
+        const any = newGrid.find(c => c && !c.spawnedUnitName)
+        if (any) any.stock[res] = (any.stock[res] ?? 0) + amount
+      } else {
+        const each = amount / targets.length
+        for (const t of targets) t.stock[res] = (t.stock[res] ?? 0) + each
+      }
+    }
+  }
+
+  // ── Move carriers — advance progress, handle deliveries ─────────────────────
+  const arrivedIds = new Set<string>()
+  const newCarriers = (state.carriers ?? []).map(c => ({ ...c }))
+  for (const carrier of newCarriers) {
+    const dist = Math.max(1, cellManhattan(carrier.fromCell, carrier.toCell, CITY_COLS))
+    const speed = (CARRIER_BASE_SPEED / dist) * pathSpeedMult(carrier.fromCell, carrier.toCell, newRoadWear, CITY_COLS)
+    wearPath(carrier.fromCell, carrier.toCell, newRoadWear, CITY_COLS, ROAD_WEAR_PER_CARRIER * minutes)
+    carrier.progress = Math.min(1, carrier.progress + speed * minutes)
+    if (carrier.progress >= 1) {
+      const dest = newGrid[carrier.toCell]
+      if (dest) {
+        for (const [res, amt] of Object.entries(carrier.carrying) as [ResourceType, number][]) {
+          dest.stock[res] = (dest.stock[res] ?? 0) + amt
+        }
+      }
+      arrivedIds.add(carrier.id)
+    }
+  }
+  const activeCarriers = newCarriers.filter(c => !arrivedIds.has(c.id))
+
+  // ── Production loop — writes to local cell stock ─────────────────────────────
+  for (let i = 0; i < newGrid.length; i++) {
+    const cell = newGrid[i]
     if (!cell) continue
 
     const happy = (newHappy[i] ?? 100) > 0
     const unitCount = cell.spawnedUnitName ? spawnerUnitCount(state, cell.cardName) : 1
 
-    // District zone bonus for this cell's row
-    const cellRow     = Math.floor(i / CITY_COLS)
+    const cellRow      = Math.floor(i / CITY_COLS)
     const cellDistrict = getRowDistrict(state, cellRow)
-    const distInfo    = DISTRICT_INFO[cellDistrict]
+    const distInfo     = DISTRICT_INFO[cellDistrict]
 
-    // Gold income (with adjacency bonus for spawn buildings near food, and commercial district)
-    const incomeBonus   = cell.spawnedUnitName ? getCellIncomeBonus(state, i) : 0
-    const distGoldMult  = 1 + (distInfo.goldMult ?? 0)
+    // Gold income
+    const incomeBonus  = cell.spawnedUnitName ? getCellIncomeBonus(state, i) : 0
+    const distGoldMult = 1 + (distInfo.goldMult ?? 0)
     goldEarned += cellIncomeRate(cell, happy, unitCount) * (1 + incomeBonus) * distGoldMult * minutes
 
-    // Resource production (utility/non-spawner buildings that produce resources)
+    // Resource production — write to local stock
     if (!cell.spawnedUnitName) {
-      const masteryMult = masteryOutputMultiplier(getCardMasteryLevel(cell.cardName) ?? 0)
-      const produces = getBuildingProduces(cell.cardName)
-      const synergies = getCellSynergyBonuses(state, i)
+      const masteryMult  = masteryOutputMultiplier(getCardMasteryLevel(cell.cardName) ?? 0)
+      const produces     = getBuildingProduces(cell.cardName)
+      const synergies    = getCellSynergyBonuses(state, i)
       const synergyMap: Partial<Record<ResourceType, number>> = {}
       for (const s of synergies) synergyMap[s.resource] = (synergyMap[s.resource] ?? 0) + s.multiplier
       const distProdMult = 1 + (distInfo.prodMult ?? 0)
+
       for (const [res, rate] of Object.entries(produces) as [ResourceType, number][]) {
-        if (rate > 0) {
-          const synergyMult = 1 + (synergyMap[res as ResourceType] ?? 0)
-          // Season modifier: wheat/wood/ore get seasonal multipliers
-          const seasonMult = res === 'wheat' ? 1 + si.wheat
-                           : res === 'wood'  ? 1 + si.wood
-                           : res === 'ore'   ? 1 + si.ore
-                           : 1
-          const amount = rate * masteryMult * synergyMult * Math.max(0, seasonMult) * distProdMult * minutes
-          // Conversion buildings: defer bread production — it depends on wheat availability
-          if (BUILDING_CONVERSION_COST[cell.cardName] && res === 'bread') {
-            breadConversionPending += amount
-            const wheatRate = BUILDING_CONVERSION_COST[cell.cardName].wheat ?? 0
-            wheatConversionCost += wheatRate * masteryMult * synergyMult * Math.max(0, seasonMult) * distProdMult * minutes
-          } else {
-            newResources[res] = (newResources[res] ?? 0) + amount
-          }
+        if (rate <= 0) continue
+        const synergyMult = 1 + (synergyMap[res as ResourceType] ?? 0)
+        const seasonMult  = res === 'wheat' ? 1 + si.wheat
+                          : res === 'wood'  ? 1 + si.wood
+                          : res === 'ore'   ? 1 + si.ore : 1
+        const amount = rate * masteryMult * synergyMult * Math.max(0, seasonMult) * distProdMult * minutes
+
+        if (BUILDING_CONVERSION_COST[cell.cardName] && res === 'bread') {
+          // Conversion building (mill/bakery that needs wheat): use LOCAL wheat stock
+          const wheatRate   = BUILDING_CONVERSION_COST[cell.cardName].wheat ?? 0
+          const wheatNeeded = wheatRate * masteryMult * synergyMult * Math.max(0, seasonMult) * distProdMult * minutes
+          const localWheat  = cell.stock.wheat ?? 0
+          const eff = wheatNeeded > 0 ? Math.min(1, localWheat / wheatNeeded) : 1
+          cell.stock.bread  = (cell.stock.bread  ?? 0) + amount * eff
+          cell.stock.wheat  = Math.max(0, localWheat - wheatNeeded * eff)
+        } else {
+          cell.stock[res as ResourceType] = (cell.stock[res as ResourceType] ?? 0) + amount
         }
       }
     }
+  }
 
-    // Spawners consume food (wheat) — more in summer/winter
-    if (cell.spawnedUnitName && happy) {
-      const unitCount = spawnerUnitCount(state, cell.cardName)
-      const hungerMult = 1 + si.hunger
-      const consume = FOOD_CONSUME_RATE[cell.rarity] * unitCount * hungerMult * minutes
-      newResources.wheat = Math.max(0, (newResources.wheat ?? 0) - consume)
+  // ── Spawn new carriers from production buildings ─────────────────────────────
+  // Track which (fromCell, res) combos already have a carrier in flight to avoid flooding
+  const inFlight = new Set(activeCarriers.map(c => `${c.fromCell}-${Object.keys(c.carrying)[0]}`))
+  for (let i = 0; i < newGrid.length; i++) {
+    const cell = newGrid[i]
+    if (!cell || cell.spawnedUnitName) continue
+    for (const [res, amount] of Object.entries(cell.stock) as [ResourceType, number][]) {
+      if (amount < CARRIER_LOAD) continue
+      if (inFlight.has(`${i}-${res}`)) continue
+      const target = findNearestConsumer(res as ResourceType, i, newGrid as (CityCell|undefined)[], CITY_COLS)
+      if (target === null) continue
+      const load = Math.min(amount, CARRIER_LOAD)
+      activeCarriers.push({
+        id:       `${Date.now()}-${i}-${res}`,
+        fromCell: i,
+        toCell:   target,
+        carrying: { [res]: load },
+        progress: 0,
+      })
+      cell.stock[res as ResourceType] = Math.max(0, amount - load)
+      inFlight.add(`${i}-${res}`)
     }
   }
 
-  // ── Wheat → bread conversion (Windmill and any future conversion buildings) ──
-  if (breadConversionPending > 0) {
-    const eff = wheatConversionCost > 0
-      ? Math.min(1, (newResources.wheat ?? 0) / wheatConversionCost)
-      : 1
-    newResources.bread = (newResources.bread ?? 0) + breadConversionPending * eff
-    newResources.wheat = Math.max(0, (newResources.wheat ?? 0) - wheatConversionCost * eff)
+  // ── Aggregate global resource view from cell stocks ──────────────────────────
+  const newResources = aggregateResources(newGrid as (CityCell|undefined)[], activeCarriers)
+
+  // ── Spawners consume food (wheat) from global aggregate ─────────────────────
+  for (let i = 0; i < newGrid.length; i++) {
+    const cell = newGrid[i]
+    if (!cell?.spawnedUnitName || (newHappy[i] ?? 100) <= 0) continue
+    const uCount     = spawnerUnitCount(state, cell.cardName)
+    const hungerMult = 1 + si.hunger
+    const consume    = FOOD_CONSUME_RATE[cell.rarity] * uCount * hungerMult * minutes
+    deductResource('wheat', consume, newGrid as (CityCell|undefined)[], newResources)
   }
 
-  // ── Resident resource consumption (bread & wood) ──────────────────────────
+  // ── Resident bread & wood consumption ────────────────────────────────────────
   let totalBreadDemand = 0
   let totalWoodDemand  = 0
-  for (let i = 0; i < state.grid.length; i++) {
-    const cell = state.grid[i]
+  for (let i = 0; i < newGrid.length; i++) {
+    const cell = newGrid[i]
     if (!cell?.spawnedUnitName || (newHappy[i] ?? 100) <= 0) continue
     const uCount   = spawnerUnitCount(state, cell.cardName)
     totalBreadDemand += BREAD_CONSUME_RATE * uCount * minutes
     const woodMult   = season === 'winter' ? WINTER_WOOD_MULT : 1
-    totalWoodDemand  += WOOD_CONSUME_RATE * uCount * woodMult * minutes
+    totalWoodDemand  += WOOD_CONSUME_RATE  * uCount * woodMult * minutes
   }
-
-  const breadConsumed  = Math.min(newResources.bread ?? 0, totalBreadDemand)
-  const woodConsumed   = Math.min(newResources.wood  ?? 0, totalWoodDemand)
-  const breadCoverage  = totalBreadDemand > 0 ? breadConsumed / totalBreadDemand : 1
-  const woodShort      = totalWoodDemand  > 0 && woodConsumed < totalWoodDemand * 0.5
-  newResources.bread   = Math.max(0, (newResources.bread ?? 0) - breadConsumed)
-  newResources.wood    = Math.max(0, (newResources.wood  ?? 0) - woodConsumed)
+  const breadConsumed = Math.min(newResources.bread ?? 0, totalBreadDemand)
+  const woodConsumed  = Math.min(newResources.wood  ?? 0, totalWoodDemand)
+  const breadCoverage = totalBreadDemand > 0 ? breadConsumed / totalBreadDemand : 1
+  const woodShort     = totalWoodDemand  > 0 && woodConsumed < totalWoodDemand * 0.5
+  deductResource('bread', breadConsumed, newGrid as (CityCell|undefined)[], newResources)
+  deductResource('wood',  woodConsumed,  newGrid as (CityCell|undefined)[], newResources)
 
   // ── Base happiness target from food, defence, bread quality, wood supply ──
   const foodScore    = Math.min(100, (newResources.wheat / population) * 5)
@@ -1243,14 +1434,13 @@ export function tickCity(state: CityState): CityState {
   const woodScore    = woodShort ? -WOOD_SHORTAGE_PENALTY : 0
   const baseTarget   = Math.min(100, Math.max(0, Math.round(foodScore * 0.6 + defenseScore * 0.4) + breadScore + woodScore))
 
-  const gridRows = state.rows ?? CITY_ROWS
-  for (let i = 0; i < state.grid.length; i++) {
-    const cell = state.grid[i]
+  for (let i = 0; i < newGrid.length; i++) {
+    const cell = newGrid[i]
     if (!cell?.spawnedUnitName) continue
 
     const wantedNeighbour = cell.affinityWith ?? cell.spawnedUnitName
     const affinityMet = getNeighbourIndices(i, gridRows).some(ni => {
-      const nc = state.grid[ni]
+      const nc = newGrid[ni]
       return nc?.spawnedUnitName === wantedNeighbour && (state.happiness[ni] ?? 100) > 0
     })
     const cellTarget  = affinityMet ? baseTarget : 0
@@ -1272,7 +1462,7 @@ export function tickCity(state: CityState): CityState {
       const woodCost = toRepair * FORT_REPAIR_WOOD_PER_HP
       if (newResources.wood >= woodCost) {
         fort.hp = Math.min(fort.maxHp, fort.hp + toRepair)
-        newResources.wood = Math.max(0, newResources.wood - woodCost)
+        deductResource('wood', woodCost, newGrid as (CityCell|undefined)[], newResources)
       }
     }
   }
@@ -1301,14 +1491,25 @@ export function tickCity(state: CityState): CityState {
     newResources[key] = Math.max(0, Math.min(newResources[key], storageCaps[key]))
   }
 
+  // Also cap each cell's individual stock
+  for (const cell of newGrid) {
+    if (!cell) continue
+    for (const key of Object.keys(cell.stock) as ResourceType[]) {
+      cell.stock[key] = Math.max(0, Math.min(cell.stock[key] ?? 0, storageCaps[key]))
+    }
+  }
+
   let result: CityState = {
     ...state,
+    grid:           newGrid as CityState['grid'],
     gold:           Math.max(0, state.gold + Math.floor(goldEarned)),
     resources:      newResources,
     lastTick:       now,
     happiness:      newHappy,
     fortifications: newForts,
     builderQueue:   remainingQueue,
+    roadWear:       newRoadWear,
+    carriers:       activeCarriers,
   }
 
   for (const name of completedFortNames) {
@@ -1406,7 +1607,7 @@ export function tickCity(state: CityState): CityState {
 
 export function placeCard(state: CityState, index: number, cell: CityCell): CityState {
   const grid = [...state.grid]
-  grid[index] = cell
+  grid[index] = { ...cell, stock: cell.stock ?? {} }
   const happiness = { ...state.happiness }
   if (cell.spawnedUnitName) happiness[index] = 100
 
@@ -1575,7 +1776,7 @@ export function canAffordCoreBuild(state: CityState, building: CoreBuilding): bo
 
 export function placeCoreBuild(state: CityState, index: number, building: CoreBuilding): CityState {
   if (!canAffordCoreBuild(state, building)) return state
-  const cell: CityCell = { cardName: building.name, rarity: building.rarity }
+  const cell: CityCell = { cardName: building.name, rarity: building.rarity, stock: {} }
   return placeCard({ ...state, gold: state.gold - building.goldCost }, index, cell)
 }
 

--- a/web/src/game/cityBuilder.ts
+++ b/web/src/game/cityBuilder.ts
@@ -310,6 +310,9 @@ const ROAD_WEAR_PER_CARRIER = 0.4   // wear added per carrier per minute
 export const ROAD_TIER_THRESHOLDS = [25, 60] as const  // tier 1 at 25, tier 2 at 60
 const ROAD_SPEED_MULT = [1.0, 1.4, 2.0]  // multiplier per road tier
 
+/** Per-edge road wear. h[i] = right edge of cell i; v[i] = bottom edge of cell i. */
+export interface RoadWearMap { h: number[]; v: number[] }
+
 export interface CarrierState {
   id:       string
   fromCell: number   // source cell index
@@ -339,27 +342,38 @@ export function cellCenter(idx: number, rows: number): { x: number; y: number } 
   }
 }
 
+// Get edge wear between two adjacent cells (lo = smaller index, hi = larger)
+function edgeWear(rw: RoadWearMap, lo: number, hi: number, cols: number): number {
+  return hi === lo + 1 ? (rw.h[lo] ?? 0) : (rw.v[lo] ?? 0)
+}
+
 // Average road speed multiplier along the Manhattan path from→to
-function pathSpeedMult(from: number, to: number, roadWear: number[], cols: number): number {
+function pathSpeedMult(from: number, to: number, roadWear: RoadWearMap, cols: number): number {
   let c = from % cols, r = Math.floor(from / cols)
   const tc = to % cols, tr = Math.floor(to / cols)
   let steps = 0, total = 0
   while (c !== tc || r !== tr) {
+    const pc = c, pr = r
     if (c !== tc) c += c < tc ? 1 : -1; else r += r < tr ? 1 : -1
-    total += ROAD_SPEED_MULT[roadTier(roadWear[r * cols + c] ?? 0)]
+    const lo = Math.min(pr * cols + pc, r * cols + c)
+    const hi = Math.max(pr * cols + pc, r * cols + c)
+    total += ROAD_SPEED_MULT[roadTier(edgeWear(roadWear, lo, hi, cols))]
     steps++
   }
   return steps > 0 ? total / steps : ROAD_SPEED_MULT[0]
 }
 
-// Add wear to every cell on the Manhattan path from→to
-function wearPath(from: number, to: number, roadWear: number[], cols: number, amount: number): void {
+// Add wear to every edge on the Manhattan path from→to
+function wearPath(from: number, to: number, roadWear: RoadWearMap, cols: number, amount: number): void {
   let c = from % cols, r = Math.floor(from / cols)
   const tc = to % cols, tr = Math.floor(to / cols)
   while (c !== tc || r !== tr) {
+    const pc = c, pr = r
     if (c !== tc) c += c < tc ? 1 : -1; else r += r < tr ? 1 : -1
-    const idx = r * cols + c
-    roadWear[idx] = Math.min(100, (roadWear[idx] ?? 0) + amount)
+    const lo = Math.min(pr * cols + pc, r * cols + c)
+    const hi = Math.max(pr * cols + pc, r * cols + c)
+    if (hi === lo + 1) roadWear.h[lo] = Math.min(100, (roadWear.h[lo] ?? 0) + amount)
+    else               roadWear.v[lo] = Math.min(100, (roadWear.v[lo] ?? 0) + amount)
   }
 }
 
@@ -700,8 +714,8 @@ export interface CityState {
   activeDisaster: Disaster | null
   /** Timestamp when the next disaster may be triggered. */
   nextDisasterAt: number
-  /** Per-cell wear score 0–100, drives road visual tier. */
-  roadWear: number[]
+  /** Per-edge road wear. h[i] = right edge of cell i; v[i] = bottom edge of cell i. */
+  roadWear: RoadWearMap
   /** Workers currently transporting resources between buildings. */
   carriers: CarrierState[]
 }
@@ -737,7 +751,7 @@ function defaultState(): CityState {
     zones:               [],
     activeDisaster:      null,
     nextDisasterAt:      Date.now() + (18 + Math.random() * 12) * 3_600_000,
-    roadWear:            [],
+    roadWear:            { h: [], v: [] },
     carriers:            [],
   }
 }
@@ -787,7 +801,7 @@ export function loadCityState(): CityState {
       zones:               (parsed.zones ?? []) as DistrictType[],
       activeDisaster:      parsed.activeDisaster ?? null,
       nextDisasterAt:      parsed.nextDisasterAt ?? Date.now() + (18 + Math.random() * 12) * 3_600_000,
-      roadWear:            (parsed.roadWear ?? []) as number[],
+      roadWear:            (Array.isArray(parsed.roadWear) ? { h: [], v: [] } : (parsed.roadWear ?? { h: [], v: [] })) as RoadWearMap,
       carriers:            (parsed.carriers ?? []) as CarrierState[],
     }
   } catch (err) {
@@ -1275,7 +1289,11 @@ export function tickCity(state: CityState): CityState {
   // ── Build mutable grid (copy cell stocks) ───────────────────────────────────
   const gridRows = state.rows ?? CITY_ROWS
   const newGrid = state.grid.map(c => c ? { ...c, stock: { ...(c.stock ?? {}) } } : c)
-  const newRoadWear = (state.roadWear?.length ? [...state.roadWear] : new Array(newGrid.length).fill(0)) as number[]
+  const rawRW = state.roadWear as unknown
+  const rwBase: RoadWearMap = (rawRW && typeof rawRW === 'object' && !Array.isArray(rawRW))
+    ? rawRW as RoadWearMap
+    : { h: [], v: [] }
+  const newRoadWear: RoadWearMap = { h: [...(rwBase.h ?? [])], v: [...(rwBase.v ?? [])] }
 
   // ── Migration: first tick on old save — seed cell stocks from state.resources ─
   const hasAnyStock = newGrid.some(c => c && Object.values(c.stock).some(v => (v ?? 0) > 0))

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -9005,6 +9005,12 @@ html.light-mode .action-btn {
 .city-cell--occupied         { background: #244d1e; }
 .city-cell--occupied:hover   { background: #4a1010; }
 
+/* Road wear tiers — subtle background overlay on cells */
+.city-cell--road-1 { background-image: repeating-linear-gradient(45deg, rgba(120,80,20,0.10) 0 2px, transparent 2px 6px); }
+.city-cell--road-2 { background-image: repeating-linear-gradient(45deg, rgba(100,90,70,0.18) 0 2px, transparent 2px 5px); }
+.city-cell--occupied.city-cell--road-1,
+.city-cell--occupied.city-cell--road-2 { background-image: none; }
+
 .city-cell-sprite  { width: 65%; height: 65%; max-width: 36px; max-height: 36px; image-rendering: pixelated; }
 
 .city-cell-level {
@@ -9099,6 +9105,28 @@ html.light-mode .action-btn {
   font-weight: bold;
   line-height: 1;
 }
+
+.city-carrier-overlay { position: absolute; inset: 0; pointer-events: none; }
+
+.city-carrier {
+  position:   absolute;
+  width:      14px;
+  height:     14px;
+  transform:  translate(-50%, -50%);
+  background: rgba(20, 30, 20, 0.75);
+  border:     1px solid #33ff33;
+  border-radius: 50%;
+  display:    flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 8;
+}
+
+.city-carrier-icon {
+  font-size: 8px;
+  line-height: 1;
+}
+
 
 /* Builder walkers (construction) */
 .city-builder-walker {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -9005,11 +9005,7 @@ html.light-mode .action-btn {
 .city-cell--occupied         { background: #244d1e; }
 .city-cell--occupied:hover   { background: #4a1010; }
 
-/* Road wear tiers — subtle background overlay on cells */
-.city-cell--road-1 { background-image: repeating-linear-gradient(45deg, rgba(120,80,20,0.10) 0 2px, transparent 2px 6px); }
-.city-cell--road-2 { background-image: repeating-linear-gradient(45deg, rgba(100,90,70,0.18) 0 2px, transparent 2px 5px); }
-.city-cell--occupied.city-cell--road-1,
-.city-cell--occupied.city-cell--road-2 { background-image: none; }
+/* Road tier edges are rendered as inset box-shadows in CityGrid.tsx — tier 1 = dirt brown, tier 2 = stone grey */
 
 .city-cell-sprite  { width: 65%; height: 65%; max-width: 36px; max-height: 36px; image-rendering: pixelated; }
 


### PR DESCRIPTION
## Summary

- **Per-cell resource stocks**: each building now holds its own inventory (`cell.stock`) rather than everything living in a single global pool. Mills can only bake bread if they have wheat on hand.
- **Carrier system**: when a production building's local stock hits the load threshold (5 units), a carrier spawns and physically routes toward the nearest consumer building. Progress-based movement plays out each tick.
- **Road wear & tiers**: every carrier trip wears down the cells it crosses. At 25 wear the tile becomes a dirt path (subtle diagonal stripe); at 60 it upgrades to a stone road (stronger stripe). Carriers move faster on upgraded roads (`1.0× → 1.4× → 2.0×`).
- **Visual carrier overlay**: small resource-emoji dots float across the grid, interpolated between source and destination by their `progress` value.
- **Save migration**: existing saves without cell stocks are detected on the first tick and their global resources are seeded into the appropriate producer buildings.

## Test plan

- [ ] Place a Farm + Windmill — watch wheat carriers appear and travel from Farm to Windmill
- [ ] Windmill should stop producing bread once its local wheat stock is depleted and no carriers arrive
- [ ] Road tiles under busy carrier routes should visually upgrade over time
- [ ] Old save games should load without errors and migrate gracefully
- [ ] TypeScript compiles cleanly (`npx tsc --noEmit`)

https://claude.ai/code/session_01QoP8jPH6TsU5QUWDguGVYx

---
_Generated by [Claude Code](https://claude.ai/code/session_01QoP8jPH6TsU5QUWDguGVYx)_