### PR TITLE
Road wear smoothing + windmill animation states

### DIFF
--- a/web/src/components/minigames/citybuilder/CityGrid.tsx
+++ b/web/src/components/minigames/citybuilder/CityGrid.tsx
@@ -75,8 +75,22 @@ export function CityGrid({
           const wearB = isLastRow ? 0 : ((city.roadWear?.v ?? [])[i] ?? 0)
           const shadows: string[] = []
           if (district !== 'none' && isRowStart) shadows.push(`inset 4px 0 0 ${distColor}`)
-          if (wearR > 0) shadows.push(`3px 0 0 0 ${roadWearColor(wearR)}`)
-          if (wearB > 0) shadows.push(`0 3px 0 0 ${roadWearColor(wearB)}`)
+          if (wearR > 0) {
+            const c = roadWearColor(wearR)
+            shadows.push(`3px 0 0 0 ${c}`)
+            if (wearR > 60) {
+              const w = (((wearR - 60) / 40) * 3).toFixed(1)
+              shadows.push(`inset -${w}px 0 0 0 ${c}`)
+            }
+          }
+          if (wearB > 0) {
+            const c = roadWearColor(wearB)
+            shadows.push(`0 3px 0 0 ${c}`)
+            if (wearB > 60) {
+              const w = (((wearB - 60) / 40) * 3).toFixed(1)
+              shadows.push(`inset 0 -${w}px 0 0 ${c}`)
+            }
+          }
           return (
             <button
               key={i}

--- a/web/src/components/minigames/citybuilder/CityGrid.tsx
+++ b/web/src/components/minigames/citybuilder/CityGrid.tsx
@@ -3,9 +3,24 @@ import {
   CityState, CITY_COLS, CITY_ROWS,
   spawnerUnitCount, getNeighbourIndices,
   getRowDistrict, DISTRICT_INFO,
-  roadTier,
   RESOURCE_ICONS, ResourceType,
 } from '../../../game/cityBuilder'
+
+// Lerp wear 0-100 → rgba string: transparent → brown → grey
+function roadWearColor(wear: number): string {
+  if (wear <= 0) return 'transparent'
+  const BROWN: [number,number,number] = [120, 80, 20]
+  const GREY:  [number,number,number] = [160,150,110]
+  if (wear < 25) {
+    const t = wear / 25
+    return `rgba(${BROWN[0]},${BROWN[1]},${BROWN[2]},${(t * 0.85).toFixed(2)})`
+  }
+  const t = Math.min(1, (wear - 25) / 75)
+  const r = Math.round(BROWN[0] + (GREY[0] - BROWN[0]) * t)
+  const g = Math.round(BROWN[1] + (GREY[1] - BROWN[1]) * t)
+  const b = Math.round(BROWN[2] + (GREY[2] - BROWN[2]) * t)
+  return `rgba(${r},${g},${b},0.85)`
+}
 import { SpriteImg, AnimatedSpriteImg } from '../../ui/SpriteImg'
 import { BuilderWalker, VisualCarrier } from '../CityBuilder'
 import { Walker } from './walkerTypes'
@@ -56,14 +71,12 @@ export function CityGrid({
           const isRowStart  = col === 0
           const isLastCol   = col === CITY_COLS - 1
           const isLastRow   = row === cityRows - 1
-          const tierR = isLastCol ? 0 : roadTier((city.roadWear?.h ?? [])[i] ?? 0)
-          const tierB = isLastRow ? 0 : roadTier((city.roadWear?.v ?? [])[i] ?? 0)
-          const ROAD1 = 'rgba(120,80,20,0.75)'
-          const ROAD2 = 'rgba(160,150,110,0.85)'
+          const wearR = isLastCol ? 0 : ((city.roadWear?.h ?? [])[i] ?? 0)
+          const wearB = isLastRow ? 0 : ((city.roadWear?.v ?? [])[i] ?? 0)
           const shadows: string[] = []
           if (district !== 'none' && isRowStart) shadows.push(`inset 4px 0 0 ${distColor}`)
-          if (tierR > 0) shadows.push(`3px 0 0 0 ${tierR === 2 ? ROAD2 : ROAD1}`)
-          if (tierB > 0) shadows.push(`0 3px 0 0 ${tierB === 2 ? ROAD2 : ROAD1}`)
+          if (wearR > 0) shadows.push(`3px 0 0 0 ${roadWearColor(wearR)}`)
+          if (wearB > 0) shadows.push(`0 3px 0 0 ${roadWearColor(wearB)}`)
           return (
             <button
               key={i}

--- a/web/src/game/cityBuilder.ts
+++ b/web/src/game/cityBuilder.ts
@@ -1295,6 +1295,16 @@ export function tickCity(state: CityState): CityState {
     : { h: [], v: [] }
   const newRoadWear: RoadWearMap = { h: [...(rwBase.h ?? [])], v: [...(rwBase.v ?? [])] }
 
+  // Decay road wear over time so unused roads revert to green
+  const ROAD_DECAY_PER_MIN = 0.3
+  const decay = ROAD_DECAY_PER_MIN * minutes
+  for (let idx = 0; idx < newRoadWear.h.length; idx++) {
+    if (newRoadWear.h[idx] > 0) newRoadWear.h[idx] = Math.max(0, newRoadWear.h[idx] - decay)
+  }
+  for (let idx = 0; idx < newRoadWear.v.length; idx++) {
+    if (newRoadWear.v[idx] > 0) newRoadWear.v[idx] = Math.max(0, newRoadWear.v[idx] - decay)
+  }
+
   // ── Migration: first tick on old save — seed cell stocks from state.resources ─
   const hasAnyStock = newGrid.some(c => c && Object.values(c.stock).some(v => (v ?? 0) > 0))
   if (!hasAnyStock && Object.values(state.resources).some(v => v > 0)) {


### PR DESCRIPTION
## Summary

**Road wear (smooth colour + width)**
- Wear 0–25: brown fades in from transparent
- Wear 25–60: lerps brown → grey
- Wear 60–100: road grows 3→6 px wide (inset shadow bleeds into cell)
- Wear decays at 0.3/min — unused roads revert to green over ~5.5 hrs

**Windmill animation states**
- Added `windmill-slow.svg` (20 s rotation) and `windmill-stopped.svg` (no animation)
- Windmill picks its sprite based on local wheat stock: ≥3 → normal, 1–2 → slow, 0 → stopped
- Sails resume as soon as a carrier delivers wheat

## Test plan

- [ ] Watch a road build up from green to brown to grey with carrier traffic
- [ ] Verify no hard colour jumps at any wear level; width grows visibly at high wear
- [ ] Stop traffic and confirm the road fades back toward green
- [ ] Place a Windmill with no wheat supply — sails should be stopped
- [ ] Deliver wheat (via Farm + carrier) — sails spin up as stock arrives
- [ ] With low stock (1–2 units) sails should spin noticeably slower than when well-stocked

https://claude.ai/code/session_01QoP8jPH6TsU5QUWDguGVYx