### PR TITLE
Pull-based logistics, two-phase carriers, visible stockpiles, windmill animation fix

### DIFF
--- a/web/public/sprites/windmill-slow.svg
+++ b/web/public/sprites/windmill-slow.svg
@@ -1,0 +1,54 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground -->
+  <rect x="0" y="27" width="32" height="5" fill="#3a4a1a"/>
+
+  <!-- Tower body (tapered) -->
+  <polygon points="11,28 12,14 20,14 21,28" fill="#9a8565"/>
+  <!-- Stone course lines -->
+  <line x1="11.3" y1="20" x2="20.7" y2="20" stroke="#7a6545" stroke-width="0.8"/>
+  <line x1="11.6" y1="24" x2="20.4" y2="24" stroke="#7a6545" stroke-width="0.8"/>
+
+  <!-- Conical cap -->
+  <polygon points="16,5 10,14 22,14" fill="#6a3a18"/>
+  <line x1="10" y1="14" x2="22" y2="14" stroke="#4a2a08" stroke-width="1"/>
+
+  <!-- Rotating sails + hub — pivot at hub centre (16, 14) -->
+  <g>
+    <!-- upper-right -->
+    <line x1="16" y1="14" x2="27" y2="5"  stroke="#d4b445" stroke-width="3" stroke-linecap="round"/>
+    <!-- lower-right -->
+    <line x1="16" y1="14" x2="27" y2="23" stroke="#c4a435" stroke-width="3" stroke-linecap="round"/>
+    <!-- lower-left -->
+    <line x1="16" y1="14" x2="5"  y2="23" stroke="#d4b445" stroke-width="3" stroke-linecap="round"/>
+    <!-- upper-left -->
+    <line x1="16" y1="14" x2="5"  y2="5"  stroke="#c4a435" stroke-width="3" stroke-linecap="round"/>
+    <!-- Hub -->
+    <circle cx="16" cy="14" r="2.5" fill="#5a3820"/>
+    <circle cx="16" cy="14" r="1"   fill="#d4b020"/>
+    <animateTransform
+      attributeName="transform"
+      type="rotate"
+      from="0 16 14"
+      to="360 16 14"
+      dur="20s"
+      repeatCount="indefinite"/>
+  </g>
+
+  <!-- Door (arched) -->
+  <rect x="14" y="21" width="4" height="7" rx="2" fill="#2a1808"/>
+
+  <!-- Window -->
+  <rect x="14" y="15.5" width="4" height="3" fill="#a8d0e8" rx="0.5"/>
+
+  <!-- Wheat left -->
+  <line x1="3"  y1="28" x2="4"  y2="23" stroke="#c8a020" stroke-width="1.2"/>
+  <ellipse cx="4.5" cy="22" rx="1.5" ry="1" fill="#d4b020"/>
+  <line x1="6"  y1="28" x2="7"  y2="23" stroke="#c8a020" stroke-width="1.2"/>
+  <ellipse cx="7.5" cy="22" rx="1.5" ry="1" fill="#d4b020"/>
+
+  <!-- Wheat right -->
+  <line x1="26" y1="28" x2="25" y2="23" stroke="#c8a020" stroke-width="1.2"/>
+  <ellipse cx="24.5" cy="22" rx="1.5" ry="1" fill="#d4b020"/>
+  <line x1="29" y1="28" x2="28" y2="23" stroke="#c8a020" stroke-width="1.2"/>
+  <ellipse cx="27.5" cy="22" rx="1.5" ry="1" fill="#d4b020"/>
+</svg>

--- a/web/public/sprites/windmill-stopped.svg
+++ b/web/public/sprites/windmill-stopped.svg
@@ -1,0 +1,47 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground -->
+  <rect x="0" y="27" width="32" height="5" fill="#3a4a1a"/>
+
+  <!-- Tower body (tapered) -->
+  <polygon points="11,28 12,14 20,14 21,28" fill="#9a8565"/>
+  <!-- Stone course lines -->
+  <line x1="11.3" y1="20" x2="20.7" y2="20" stroke="#7a6545" stroke-width="0.8"/>
+  <line x1="11.6" y1="24" x2="20.4" y2="24" stroke="#7a6545" stroke-width="0.8"/>
+
+  <!-- Conical cap -->
+  <polygon points="16,5 10,14 22,14" fill="#6a3a18"/>
+  <line x1="10" y1="14" x2="22" y2="14" stroke="#4a2a08" stroke-width="1"/>
+
+  <!-- Static sails + hub (no animation) -->
+  <g>
+    <!-- upper-right -->
+    <line x1="16" y1="14" x2="27" y2="5"  stroke="#d4b445" stroke-width="3" stroke-linecap="round"/>
+    <!-- lower-right -->
+    <line x1="16" y1="14" x2="27" y2="23" stroke="#c4a435" stroke-width="3" stroke-linecap="round"/>
+    <!-- lower-left -->
+    <line x1="16" y1="14" x2="5"  y2="23" stroke="#d4b445" stroke-width="3" stroke-linecap="round"/>
+    <!-- upper-left -->
+    <line x1="16" y1="14" x2="5"  y2="5"  stroke="#c4a435" stroke-width="3" stroke-linecap="round"/>
+    <!-- Hub -->
+    <circle cx="16" cy="14" r="2.5" fill="#5a3820"/>
+    <circle cx="16" cy="14" r="1"   fill="#d4b020"/>
+  </g>
+
+  <!-- Door (arched) -->
+  <rect x="14" y="21" width="4" height="7" rx="2" fill="#2a1808"/>
+
+  <!-- Window -->
+  <rect x="14" y="15.5" width="4" height="3" fill="#a8d0e8" rx="0.5"/>
+
+  <!-- Wheat left -->
+  <line x1="3"  y1="28" x2="4"  y2="23" stroke="#c8a020" stroke-width="1.2"/>
+  <ellipse cx="4.5" cy="22" rx="1.5" ry="1" fill="#d4b020"/>
+  <line x1="6"  y1="28" x2="7"  y2="23" stroke="#c8a020" stroke-width="1.2"/>
+  <ellipse cx="7.5" cy="22" rx="1.5" ry="1" fill="#d4b020"/>
+
+  <!-- Wheat right -->
+  <line x1="26" y1="28" x2="25" y2="23" stroke="#c8a020" stroke-width="1.2"/>
+  <ellipse cx="24.5" cy="22" rx="1.5" ry="1" fill="#d4b020"/>
+  <line x1="29" y1="28" x2="28" y2="23" stroke="#c8a020" stroke-width="1.2"/>
+  <ellipse cx="27.5" cy="22" rx="1.5" ry="1" fill="#d4b020"/>
+</svg>

--- a/web/src/components/minigames/citybuilder/CityGrid.tsx
+++ b/web/src/components/minigames/citybuilder/CityGrid.tsx
@@ -101,7 +101,16 @@ export function CityGrid({
             >
               {cell ? (
                 <>
-                  <SpriteImg name={cell.cardName} className="city-cell-sprite" />
+                  <SpriteImg
+                    name={
+                      cell.cardName === 'Windmill'
+                        ? (cell.stock?.wheat ?? 0) >= 3 ? 'Windmill'
+                          : (cell.stock?.wheat ?? 0) > 0 ? 'Windmill Slow'
+                          : 'Windmill Stopped'
+                        : cell.cardName
+                    }
+                    className="city-cell-sprite"
+                  />
                   {cell.spawnedUnitName && rage > 0 && (
                     <div
                       className="city-cell-happiness"


### PR DESCRIPTION
## Summary

**Pull-based logistics**
- Windmill now pulls wheat from the nearest farm instead of the farm pushing to the nearest windmill — multiple windmills can each draw from different farms simultaneously
- Output resources (bread from windmill) are still pushed to the nearest warehouse/storage
- Non-conversion producers (farm, sawmill) continue pushing surplus as before

**Two-phase goblin carriers**
- Goblin spawns at the consumer (windmill), walks empty to the producer (farm), picks up the resource, then walks back loaded
- Resource icon only appears on the return leg — outbound goblin has no load
- `VisualCarrier` gains `phase: 'outbound' | 'returning'` plus stored pick-up / drop-off coords

**Windmill animation fix**
- `SpriteImg` uses `useState(src)` which only initialises once, so the windmill sprite never updated when wheat stock changed
- Fixed by passing `key={spriteName}` to force a remount whenever the sprite name crosses a threshold

**Visible stockpiles**
- Cells with stock ≥ 1 show a small resource emoji + integer count in the lower-right corner
- Lets players watch wheat pile up at a farm and bread ready at a windmill

## Test plan

- [ ] Place Farm + Windmill — goblin should walk empty from Windmill to Farm, then return carrying 🌾
- [ ] Place two Windmills — each should send its own goblin to the Farm independently
- [ ] Windmill sails should start spinning once wheat arrives and stop when stock runs out
- [ ] Farm cell should show a 🌾N badge as wheat accumulates; Windmill should show 🍞N as bread builds up
- [ ] Bread carrier should walk from Windmill to nearest Warehouse/Granary

https://claude.ai/code/session_01QoP8jPH6TsU5QUWDguGVYx