### PR TITLE
Pull-based logistics, two-phase carriers, visible stockpiles, windmill animation fix

### DIFF
--- a/web/src/components/minigames/CityBuilder.tsx
+++ b/web/src/components/minigames/CityBuilder.tsx
@@ -181,6 +181,11 @@ export interface VisualCarrier {
   x: number; y: number; vx: number; vy: number
   waypoints: { x: number; y: number }[]
   scale: number
+  phase: 'outbound' | 'returning'
+  /** pixel coords of the pickup point (fromCell centre) */
+  pickX: number; pickY: number
+  /** pixel coords of the drop-off point (toCell centre) */
+  dropX: number; dropY: number
 }
 
 export interface BuilderWalker {
@@ -923,44 +928,47 @@ export function CityBuilder({ onBack }: Props) {
       const gameCarrierIds = new Set(gameCarriers.map(c => c.id))
       const cityRows = cityRef.current?.rows ?? CITY_ROWS
 
-      // Sync: keep carriers still in game state OR still playing their shrink-out animation
+      // Sync: keep carriers still in game state OR still finishing their shrink-out animation
       let nextVis = visualCarriersRef.current.filter(vc => gameCarrierIds.has(vc.id) || vc.scale > 0)
 
-      // Spawn new carriers that haven't been given a visual yet
+      // Spawn new carriers — goblin starts at toCell (consumer) and walks outbound to fromCell (producer)
       const visIds = new Set(nextVis.map(vc => vc.id))
       for (const gc of gameCarriers) {
         if (visIds.has(gc.id)) continue
         const c1 = gc.fromCell % CITY_COLS, r1 = Math.floor(gc.fromCell / CITY_COLS)
-        const sx = (c1 + 0.5) * overlayW / CITY_COLS
-        const sy = (r1 + 0.5) * overlayH / cityRows
+        const pickX = (c1 + 0.5) * overlayW / CITY_COLS
+        const pickY = (r1 + 0.5) * overlayH / cityRows
         const c2 = gc.toCell % CITY_COLS, r2 = Math.floor(gc.toCell / CITY_COLS)
-        const tx = (c2 + 0.5) * overlayW / CITY_COLS
-        const ty = (r2 + 0.5) * overlayH / cityRows
-        const wps = computeWaypoints(sx, sy, tx, ty, overlayW, overlayH, cityRows)
-        const first = wps.length > 0 ? wps[0] : { x: tx, y: ty }
-        const dd = Math.sqrt((first.x - sx) ** 2 + (first.y - sy) ** 2)
+        const dropX = (c2 + 0.5) * overlayW / CITY_COLS
+        const dropY = (r2 + 0.5) * overlayH / cityRows
+        // Outbound: start at drop-off (consumer), walk to pick-up (producer)
+        const wps = computeWaypoints(dropX, dropY, pickX, pickY, overlayW, overlayH, cityRows)
+        const first = wps.length > 0 ? wps[0] : { x: pickX, y: pickY }
+        const dd = Math.sqrt((first.x - dropX) ** 2 + (first.y - dropY) ** 2)
         nextVis.push({
           id: gc.id, carrying: gc.carrying,
-          x: sx, y: sy,
-          vx: dd > 0 ? (first.x - sx) / dd * SPEED : 0,
-          vy: dd > 0 ? (first.y - sy) / dd * SPEED : 0,
+          x: dropX, y: dropY,
+          vx: dd > 0 ? (first.x - dropX) / dd * SPEED : 0,
+          vy: dd > 0 ? (first.y - dropY) / dd * SPEED : 0,
           waypoints: wps,
           scale: 0,
+          phase: 'outbound',
+          pickX, pickY, dropX, dropY,
         })
       }
 
-      // Move each carrier toward its next waypoint
+      // Move each carrier toward its current phase target
       nextVis = nextVis.map(vc => {
-        const gc = gameCarriers.find(c => c.id === vc.id)
-        const destX = gc ? ((gc.toCell % CITY_COLS) + 0.5) * overlayW / CITY_COLS : vc.x
-        const destY = gc ? (Math.floor(gc.toCell / CITY_COLS) + 0.5) * overlayH / cityRows : vc.y
-        const target = vc.waypoints.length > 0 ? vc.waypoints[0] : { x: destX, y: destY }
+        const phaseDestX = vc.phase === 'outbound' ? vc.pickX : vc.dropX
+        const phaseDestY = vc.phase === 'outbound' ? vc.pickY : vc.dropY
+        const target = vc.waypoints.length > 0 ? vc.waypoints[0] : { x: phaseDestX, y: phaseDestY }
         let { x, y, vx, vy } = vc
         let waypoints = vc.waypoints
         let scale = vc.scale
-        // Scale up from building on spawn before moving
-        if (scale < 1 && !waypoints.length && Math.sqrt((target.x - x) ** 2 + (target.y - y) ** 2) < ARRIVE_DIST) {
-          // Already arrived (same-cell carrier) — skip to shrink phase
+        let phase = vc.phase
+        // Scale up from spawn building before moving
+        if (scale < 1 && waypoints.length === 0 && Math.sqrt((target.x - x) ** 2 + (target.y - y) ** 2) < ARRIVE_DIST) {
+          // already at destination — skip to shrink
         } else if (scale < 1) {
           scale = Math.min(1, scale + 0.1)
           return { ...vc, waypoints, scale }
@@ -969,18 +977,26 @@ export function CityBuilder({ onBack }: Props) {
         const dist = Math.sqrt(dx * dx + dy * dy)
         if (dist < ARRIVE_DIST && waypoints.length > 0) {
           waypoints = waypoints.slice(1)
-          const next = waypoints.length > 0 ? waypoints[0] : { x: destX, y: destY }
+          const next = waypoints.length > 0 ? waypoints[0] : { x: phaseDestX, y: phaseDestY }
           const nd = Math.sqrt((next.x - x) ** 2 + (next.y - y) ** 2)
           if (nd > 0) { vx = (next.x - x) / nd * SPEED; vy = (next.y - y) / nd * SPEED }
-        } else if (dist < ARRIVE_DIST) {
-          // Arrived — shrink into the building
+        } else if (dist < ARRIVE_DIST && phase === 'outbound') {
+          // Arrived at producer — switch to returning, compute return waypoints
+          const wps = computeWaypoints(x, y, vc.dropX, vc.dropY, overlayW, overlayH, cityRows)
+          const first = wps.length > 0 ? wps[0] : { x: vc.dropX, y: vc.dropY }
+          const nd = Math.sqrt((first.x - x) ** 2 + (first.y - y) ** 2)
+          phase = 'returning'
+          waypoints = wps
+          if (nd > 0) { vx = (first.x - x) / nd * SPEED; vy = (first.y - y) / nd * SPEED }
+        } else if (dist < ARRIVE_DIST && phase === 'returning') {
+          // Arrived at consumer — shrink into building
           vx = 0; vy = 0
           scale = Math.max(0, scale - 0.1)
         } else if (dist > 0) {
           vx = dx / dist * SPEED; vy = dy / dist * SPEED
         }
         x += vx; y += vy
-        return { ...vc, x, y, vx, vy, waypoints, scale }
+        return { ...vc, x, y, vx, vy, waypoints, scale, phase }
       })
 
       visualCarriersRef.current = nextVis

--- a/web/src/components/minigames/citybuilder/CityGrid.tsx
+++ b/web/src/components/minigames/citybuilder/CityGrid.tsx
@@ -101,16 +101,14 @@ export function CityGrid({
             >
               {cell ? (
                 <>
-                  <SpriteImg
-                    name={
-                      cell.cardName === 'Windmill'
-                        ? (cell.stock?.wheat ?? 0) >= 3 ? 'Windmill'
-                          : (cell.stock?.wheat ?? 0) > 0 ? 'Windmill Slow'
-                          : 'Windmill Stopped'
-                        : cell.cardName
-                    }
-                    className="city-cell-sprite"
-                  />
+                  {(() => {
+                    const spriteName = cell.cardName === 'Windmill'
+                      ? (cell.stock?.wheat ?? 0) >= 3 ? 'Windmill'
+                        : (cell.stock?.wheat ?? 0) > 0 ? 'Windmill Slow'
+                        : 'Windmill Stopped'
+                      : cell.cardName
+                    return <SpriteImg key={spriteName} name={spriteName} className="city-cell-sprite" />
+                  })()}
                   {cell.spawnedUnitName && rage > 0 && (
                     <div
                       className="city-cell-happiness"
@@ -130,6 +128,18 @@ export function CityGrid({
                   )}
                   {!city.activeDisaster && (city.resources.bread ?? 0) < 1 && cell.spawnedUnitName && (
                     <span className="city-cell-bread-warn" title="No bread — residents are hungry">🍞</span>
+                  )}
+                  {Object.entries(cell.stock ?? {}).some(([, v]) => (v ?? 0) >= 1) && (
+                    <div className="city-cell-stock">
+                      {(Object.entries(cell.stock ?? {}) as [ResourceType, number][])
+                        .filter(([, v]) => (v ?? 0) >= 1)
+                        .slice(0, 2)
+                        .map(([res, v]) => (
+                          <span key={res} className="city-cell-stock-item">
+                            {RESOURCE_ICONS[res]}{Math.floor(v)}
+                          </span>
+                        ))}
+                    </div>
                   )}
                 </>
               ) : (
@@ -203,7 +213,7 @@ export function CityGrid({
           const res = Object.keys(vc.carrying)[0] as ResourceType
           return (
             <div key={vc.id} className="city-walker city-carrier-goblin" style={{ left: Math.round(vc.x), top: Math.round(vc.y), transform: `translate(-50%,-50%) scale(${vc.scale})` }}>
-              <div className="city-carrier-load">{RESOURCE_ICONS[res]}</div>
+              {vc.phase === 'returning' && <div className="city-carrier-load">{RESOURCE_ICONS[res]}</div>}
               <AnimatedSpriteImg name="Goblin" frameCount={3} fps={8} className="city-walker-sprite" />
             </div>
           )

--- a/web/src/game/cityBuilder.ts
+++ b/web/src/game/cityBuilder.ts
@@ -397,6 +397,23 @@ function findNearestConsumer(
   return best
 }
 
+// Find nearest non-spawner building that has available stock of a resource
+function findNearestProducer(
+  res: ResourceType, fromCell: number,
+  grid: (CityCell | undefined)[], cols: number,
+): number | null {
+  let best: number | null = null, bestDist = Infinity
+  for (let i = 0; i < grid.length; i++) {
+    if (i === fromCell) continue
+    const cell = grid[i]
+    if (!cell) continue
+    if ((cell.stock[res] ?? 0) < CARRIER_LOAD) continue
+    const d = cellManhattan(fromCell, i, cols)
+    if (d < bestDist) { bestDist = d; best = i }
+  }
+  return best
+}
+
 // Proportionally deduct `amount` of `res` from all cell stocks
 function deductResource(
   res: ResourceType, amount: number,
@@ -1397,27 +1414,65 @@ export function tickCity(state: CityState): CityState {
     }
   }
 
-  // ── Spawn new carriers from production buildings ─────────────────────────────
-  // Track which (fromCell, res) combos already have a carrier in flight to avoid flooding
-  const inFlight = new Set(activeCarriers.map(c => `${c.fromCell}-${Object.keys(c.carrying)[0]}`))
+  // ── Spawn carriers — pull-based for inputs, push-based for outputs ──────────
+  // inFlightTo: one inbound carrier per (toCell, resource) to avoid flooding
+  const inFlightTo  = new Set(activeCarriers.map(c => `${c.toCell}-${Object.keys(c.carrying)[0]}`))
+  // inFlightFrom: one outbound carrier per (fromCell, resource) to avoid double-spending
+  const inFlightFrom = new Set(activeCarriers.map(c => `${c.fromCell}-${Object.keys(c.carrying)[0]}`))
+
+  // Pull-based: conversion buildings request their input resource from nearest producer
   for (let i = 0; i < newGrid.length; i++) {
     const cell = newGrid[i]
     if (!cell || cell.spawnedUnitName) continue
+    const inputNeeds = BUILDING_CONVERSION_COST[cell.cardName]
+    if (!inputNeeds) continue
+    for (const [res] of Object.entries(inputNeeds) as [ResourceType, number][]) {
+      if ((cell.stock[res] ?? 0) >= CARRIER_LOAD) continue   // already stocked
+      if (inFlightTo.has(`${i}-${res}`)) continue            // already fetching
+      const source = findNearestProducer(res, i, newGrid as (CityCell|undefined)[], CITY_COLS)
+      if (source === null) continue
+      if (inFlightFrom.has(`${source}-${res}`)) continue     // source already spoken for
+      const sourceCell = newGrid[source]!
+      const load = Math.min(sourceCell.stock[res] ?? 0, CARRIER_LOAD)
+      activeCarriers.push({ id: `${Date.now()}-${source}-${res}`, fromCell: source, toCell: i, carrying: { [res]: load }, progress: 0 })
+      sourceCell.stock[res] = Math.max(0, (sourceCell.stock[res] ?? 0) - load)
+      inFlightTo.add(`${i}-${res}`)
+      inFlightFrom.add(`${source}-${res}`)
+    }
+  }
+
+  // Push-based: conversion buildings push their output to nearest warehouse/storage
+  for (let i = 0; i < newGrid.length; i++) {
+    const cell = newGrid[i]
+    if (!cell || cell.spawnedUnitName) continue
+    if (!BUILDING_CONVERSION_COST[cell.cardName]) continue   // only conversion output buildings
     for (const [res, amount] of Object.entries(cell.stock) as [ResourceType, number][]) {
+      if (res === Object.keys(BUILDING_CONVERSION_COST[cell.cardName])[0]) continue  // skip input res
       if (amount < CARRIER_LOAD) continue
-      if (inFlight.has(`${i}-${res}`)) continue
-      const target = findNearestConsumer(res as ResourceType, i, newGrid as (CityCell|undefined)[], CITY_COLS)
+      if (inFlightFrom.has(`${i}-${res}`)) continue
+      const target = findNearestConsumer(res, i, newGrid as (CityCell|undefined)[], CITY_COLS)
       if (target === null) continue
       const load = Math.min(amount, CARRIER_LOAD)
-      activeCarriers.push({
-        id:       `${Date.now()}-${i}-${res}`,
-        fromCell: i,
-        toCell:   target,
-        carrying: { [res]: load },
-        progress: 0,
-      })
-      cell.stock[res as ResourceType] = Math.max(0, amount - load)
-      inFlight.add(`${i}-${res}`)
+      activeCarriers.push({ id: `${Date.now()}-${i}-${res}`, fromCell: i, toCell: target, carrying: { [res]: load }, progress: 0 })
+      cell.stock[res] = Math.max(0, amount - load)
+      inFlightFrom.add(`${i}-${res}`)
+    }
+  }
+
+  // Push-based: non-conversion producers push surplus to nearest consumer
+  for (let i = 0; i < newGrid.length; i++) {
+    const cell = newGrid[i]
+    if (!cell || cell.spawnedUnitName) continue
+    if (BUILDING_CONVERSION_COST[cell.cardName]) continue    // handled above
+    for (const [res, amount] of Object.entries(cell.stock) as [ResourceType, number][]) {
+      if (amount < CARRIER_LOAD) continue
+      if (inFlightFrom.has(`${i}-${res}`)) continue
+      const target = findNearestConsumer(res, i, newGrid as (CityCell|undefined)[], CITY_COLS)
+      if (target === null) continue
+      const load = Math.min(amount, CARRIER_LOAD)
+      activeCarriers.push({ id: `${Date.now()}-${i}-${res}`, fromCell: i, toCell: target, carrying: { [res]: load }, progress: 0 })
+      cell.stock[res] = Math.max(0, amount - load)
+      inFlightFrom.add(`${i}-${res}`)
     }
   }
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -9627,6 +9627,25 @@ html.light-mode .action-btn {
   animation: city-pulse 2s ease-in-out infinite;
   filter: grayscale(0.3);
 }
+.city-cell-stock {
+  position: absolute;
+  bottom: 2px;
+  right: 2px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 1px;
+  pointer-events: none;
+}
+.city-cell-stock-item {
+  font-size: 7px;
+  line-height: 1.1;
+  background: rgba(0,0,0,0.55);
+  color: #fff;
+  padding: 0 2px;
+  border-radius: 2px;
+  letter-spacing: -0.2px;
+}
 
 .city-disaster-btn {
   border-color: #884400 !important;


### PR DESCRIPTION
## Summary

**Pull-based logistics**
- Windmill now pulls wheat from the nearest farm instead of the farm pushing to the nearest windmill — multiple windmills can each draw from different farms simultaneously
- Output resources (bread from windmill) are still pushed to the nearest warehouse/storage
- Non-conversion producers (farm, sawmill) continue pushing surplus as before

**Two-phase goblin carriers**
- Goblin spawns at the consumer (windmill), walks empty to the producer (farm), picks up the resource, then walks back loaded
- Resource icon only appears on the return leg — outbound goblin has no load
- `VisualCarrier` gains `phase: 'outbound' | 'returning'` plus stored pick-up / drop-off coords

**Windmill animation fix**
- `SpriteImg` uses `useState(src)` which only initialises once, so the windmill sprite never updated when wheat stock changed
- Fixed by passing `key={spriteName}` to force a remount whenever the sprite name crosses a threshold

**Visible stockpiles**
- Cells with stock ≥ 1 show a small resource emoji + integer count in the lower-right corner
- Lets players watch wheat pile up at a farm and bread ready at a windmill

## Test plan

- [ ] Place Farm + Windmill — goblin should walk empty from Windmill to Farm, then return carrying 🌾
- [ ] Place two Windmills — each should send its own goblin to the Farm independently
- [ ] Windmill sails should start spinning once wheat arrives and stop when stock runs out
- [ ] Farm cell should show a 🌾N badge as wheat accumulates; Windmill should show 🍞N as bread builds up
- [ ] Bread carrier should walk from Windmill to nearest Warehouse/Granary

https://claude.ai/code/session_01QoP8jPH6TsU5QUWDguGVYx

---
_Generated by [Claude Code](https://claude.ai/code/session_01QoP8jPH6TsU5QUWDguGVYx)_