### PR TITLE
Fix stock caps, multi-windmill routing, and building inspector stats

### DIFF
--- a/web/src/components/minigames/citybuilder/BuildingInspectModal.tsx
+++ b/web/src/components/minigames/citybuilder/BuildingInspectModal.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import {
   CityState, CityCell, RESOURCE_ICONS, ResourceType,
-  getBuildingProduces, masteryOutputMultiplier, getCardMasteryLevel,
+  getBuildingProduces, getBuildingConsumes, masteryOutputMultiplier, getCardMasteryLevel,
   levelUpCost, LEVEL_UP_COSTS, spawnerUnitCount,
   getCellSynergyBonuses, getCellIncomeBonus,
 } from '../../../game/cityBuilder'
@@ -32,8 +32,11 @@ export function BuildingInspectModal({
   const unitCount      = cell.spawnedUnitName ? spawnerUnitCount(city, cell.cardName) : 0
   const moodKey        = happiness === 0 ? 'gone' : happiness < 30 ? 'furious' : happiness < 60 ? 'unsettled' : 'content'
   const produces       = getBuildingProduces(cell.cardName)
+  const consumes       = getBuildingConsumes(cell.cardName)
   const masteryMult    = masteryOutputMultiplier(getCardMasteryLevel(cell.cardName) ?? 0)
   const produceEntries = Object.entries(produces).filter(([, v]) => (v ?? 0) > 0)
+  const consumeEntries = Object.entries(consumes).filter(([, v]) => (v ?? 0) > 0)
+  const stockEntries   = Object.entries(cell.stock ?? {}).filter(([, v]) => (v ?? 0) >= 0.01) as [ResourceType, number][]
   const synergies      = getCellSynergyBonuses(city, cellIndex)
   const synergyMap     = Object.fromEntries(synergies.map(s => [s.resource, s.multiplier]))
   const incomeBonus    = getCellIncomeBonus(city, cellIndex)
@@ -113,19 +116,43 @@ export function BuildingInspectModal({
                 })
               )}
             </>
-          ) : produceEntries.length > 0 ? (
+          ) : produceEntries.length > 0 || consumeEntries.length > 0 ? (
             <>
-              <div className="city-bld-section-title">Produces</div>
-              {produceEntries.map(([res, amt]) => {
-                const sm = synergyMap[res as ResourceType] ?? 0
-                const total = Math.round((amt as number) * masteryMult * (1 + sm))
-                return (
-                  <div key={res} className="city-bld-produces-row">
-                    +{total} {RESOURCE_ICONS[res as ResourceType]}/min
-                    {sm > 0 && <span className="city-synergy-bonus"> ✦ synergy</span>}
-                  </div>
-                )
-              })}
+              {stockEntries.length > 0 && (
+                <>
+                  <div className="city-bld-section-title">Stockpile</div>
+                  {stockEntries.map(([res, v]) => (
+                    <div key={res} className="city-bld-produces-row">
+                      {RESOURCE_ICONS[res]} {Math.floor(v)} {res}
+                    </div>
+                  ))}
+                </>
+              )}
+              {produceEntries.length > 0 && (
+                <>
+                  <div className="city-bld-section-title">Production rate</div>
+                  {produceEntries.map(([res, amt]) => {
+                    const sm = synergyMap[res as ResourceType] ?? 0
+                    const total = Math.round((amt as number) * masteryMult * (1 + sm))
+                    return (
+                      <div key={res} className="city-bld-produces-row">
+                        +{total} {RESOURCE_ICONS[res as ResourceType]}/min
+                        {sm > 0 && <span className="city-synergy-bonus"> ✦ synergy</span>}
+                      </div>
+                    )
+                  })}
+                </>
+              )}
+              {consumeEntries.length > 0 && (
+                <>
+                  <div className="city-bld-section-title">Consumes</div>
+                  {consumeEntries.map(([res, amt]) => (
+                    <div key={res} className="city-bld-produces-row">
+                      −{amt} {RESOURCE_ICONS[res as ResourceType]}/min
+                    </div>
+                  ))}
+                </>
+              )}
               {synergies.map((s, i) => (
                 <div key={i} className="city-synergy-label">{s.label}</div>
               ))}

--- a/web/src/game/cityBuilder.ts
+++ b/web/src/game/cityBuilder.ts
@@ -307,6 +307,7 @@ const WAREHOUSE_PATTERN = /warehouse|barn|granary|silo|storehouse|vault/i
 const CARRIER_LOAD          = 5     // units loaded per carrier trip
 const CARRIER_BASE_SPEED    = 1.0   // cells per minute on grass
 const ROAD_WEAR_PER_CARRIER = 0.4   // wear added per carrier per minute
+const PER_CELL_STOCK_CAP    = 50    // max units any single cell can stockpile of one resource
 export const ROAD_TIER_THRESHOLDS = [25, 60] as const  // tier 1 at 25, tier 2 at 60
 const ROAD_SPEED_MULT = [1.0, 1.4, 2.0]  // multiplier per road tier
 
@@ -1431,9 +1432,9 @@ export function tickCity(state: CityState): CityState {
       if (inFlightTo.has(`${i}-${res}`)) continue            // already fetching
       const source = findNearestProducer(res, i, newGrid as (CityCell|undefined)[], CITY_COLS)
       if (source === null) continue
-      if (inFlightFrom.has(`${source}-${res}`)) continue     // source already spoken for
       const sourceCell = newGrid[source]!
       const load = Math.min(sourceCell.stock[res] ?? 0, CARRIER_LOAD)
+      if (load <= 0) continue                                // producer empty after prior deductions
       activeCarriers.push({ id: `${Date.now()}-${source}-${res}`, fromCell: source, toCell: i, carrying: { [res]: load }, progress: 0 })
       sourceCell.stock[res] = Math.max(0, (sourceCell.stock[res] ?? 0) - load)
       inFlightTo.add(`${i}-${res}`)
@@ -1574,11 +1575,11 @@ export function tickCity(state: CityState): CityState {
     newResources[key] = Math.max(0, Math.min(newResources[key], storageCaps[key]))
   }
 
-  // Also cap each cell's individual stock
+  // Also cap each cell's individual stock (small per-cell cap regardless of global storage)
   for (const cell of newGrid) {
     if (!cell) continue
     for (const key of Object.keys(cell.stock) as ResourceType[]) {
-      cell.stock[key] = Math.max(0, Math.min(cell.stock[key] ?? 0, storageCaps[key]))
+      cell.stock[key] = Math.max(0, Math.min(cell.stock[key] ?? 0, PER_CELL_STOCK_CAP))
     }
   }
 


### PR DESCRIPTION
## Summary

- **Per-cell stock cap**: Individual cells (farms, etc.) were limited by the global storage cap (~500–900), letting a single farm accumulate 900 wheat. Added `PER_CELL_STOCK_CAP = 50` so no cell overflows beyond a sensible local stockpile.
- **Multi-windmill routing**: A guard (`inFlightFrom.has`) was blocking a second windmill from pulling from the same farm in the same tick, even when the farm had plenty. Removed the guard — stock is deducted immediately, so `findNearestProducer` naturally skips drained sources on subsequent iterations.
- **Building inspector stats**: Tapping a production building now shows a **Stockpile** section (current stock levels), a **Production rate** section (output/min with synergy), and a **Consumes** section (input/min for conversion buildings like the Windmill).

## Test plan

- [ ] Farm stockpile stays at or below 50 wheat (not 900)
- [ ] Multiple windmills with low wheat all receive goblin deliveries from the same farm
- [ ] Tapping a Farm shows stockpile + production rate
- [ ] Tapping a Windmill shows stockpile, production rate (bread), and consumes (wheat/min)
- [ ] Tapping a residential building still shows residents tab as before
- [ ] No regression in happiness / attack / road wear systems

https://claude.ai/code/session_01QoP8jPH6TsU5QUWDguGVYx

---
_Generated by [Claude Code](https://claude.ai/code/session_01QoP8jPH6TsU5QUWDguGVYx)_