### PR TITLE
Fix carrier idle gaps, duplicate IDs, and food inspector display

### DIFF
--- a/web/src/components/minigames/citybuilder/walkerTypes.ts
+++ b/web/src/components/minigames/citybuilder/walkerTypes.ts
@@ -112,7 +112,9 @@ export function getUnitRequirements(
   }
 
   const pop = Math.max(spawnerUnitCount(cityState, cell.cardName), 1)
-  const foodScore = Math.min(100, (cityState.resources.wheat / pop) * 5)
+  const wheatScore = Math.min(100, (cityState.resources.wheat / pop) * 5)
+  const breadScore = Math.min(100, (cityState.resources.bread / pop) * 10)
+  const foodScore  = Math.min(100, wheatScore + breadScore)
   reqs.push({ text: 'Needs adequate food supply', met: foodScore >= 50 })
 
   const defense = cityDefense(cityState)

--- a/web/src/game/cityBuilder.ts
+++ b/web/src/game/cityBuilder.ts
@@ -305,7 +305,7 @@ const WAREHOUSE_PATTERN = /warehouse|barn|granary|silo|storehouse|vault/i
 // ── Carrier / road transport constants ───────────────────────────────────────
 
 const CARRIER_LOAD          = 5     // units loaded per carrier trip
-const CARRIER_BASE_SPEED    = 1.0   // cells per minute on grass
+const CARRIER_BASE_SPEED    = 2.5   // cells per minute on grass (faster = shorter game delivery time = goblins dispatched more frequently)
 const ROAD_WEAR_PER_CARRIER = 0.4   // wear added per carrier per minute
 const PER_CELL_STOCK_CAP    = 50    // max units any single cell can stockpile of one resource
 export const ROAD_TIER_THRESHOLDS = [25, 60] as const  // tier 1 at 25, tier 2 at 60
@@ -1420,6 +1420,8 @@ export function tickCity(state: CityState): CityState {
   const inFlightTo  = new Set(activeCarriers.map(c => `${c.toCell}-${Object.keys(c.carrying)[0]}`))
   // inFlightFrom: one outbound carrier per (fromCell, resource) to avoid double-spending
   const inFlightFrom = new Set(activeCarriers.map(c => `${c.fromCell}-${Object.keys(c.carrying)[0]}`))
+  // Counter to ensure unique IDs even when multiple carriers share the same source+resource in one tick
+  let carrierSeq = 0
 
   // Pull-based: conversion buildings request their input resource from nearest producer
   for (let i = 0; i < newGrid.length; i++) {
@@ -1435,7 +1437,7 @@ export function tickCity(state: CityState): CityState {
       const sourceCell = newGrid[source]!
       const load = Math.min(sourceCell.stock[res] ?? 0, CARRIER_LOAD)
       if (load <= 0) continue                                // producer empty after prior deductions
-      activeCarriers.push({ id: `${Date.now()}-${source}-${res}`, fromCell: source, toCell: i, carrying: { [res]: load }, progress: 0 })
+      activeCarriers.push({ id: `${Date.now()}-${carrierSeq++}-${source}-${i}-${res}`, fromCell: source, toCell: i, carrying: { [res]: load }, progress: 0 })
       sourceCell.stock[res] = Math.max(0, (sourceCell.stock[res] ?? 0) - load)
       inFlightTo.add(`${i}-${res}`)
       inFlightFrom.add(`${source}-${res}`)
@@ -1454,7 +1456,7 @@ export function tickCity(state: CityState): CityState {
       const target = findNearestConsumer(res, i, newGrid as (CityCell|undefined)[], CITY_COLS)
       if (target === null) continue
       const load = Math.min(amount, CARRIER_LOAD)
-      activeCarriers.push({ id: `${Date.now()}-${i}-${res}`, fromCell: i, toCell: target, carrying: { [res]: load }, progress: 0 })
+      activeCarriers.push({ id: `${Date.now()}-${carrierSeq++}-${i}-${target}-${res}`, fromCell: i, toCell: target, carrying: { [res]: load }, progress: 0 })
       cell.stock[res] = Math.max(0, amount - load)
       inFlightFrom.add(`${i}-${res}`)
     }
@@ -1471,7 +1473,7 @@ export function tickCity(state: CityState): CityState {
       const target = findNearestConsumer(res, i, newGrid as (CityCell|undefined)[], CITY_COLS)
       if (target === null) continue
       const load = Math.min(amount, CARRIER_LOAD)
-      activeCarriers.push({ id: `${Date.now()}-${i}-${res}`, fromCell: i, toCell: target, carrying: { [res]: load }, progress: 0 })
+      activeCarriers.push({ id: `${Date.now()}-${carrierSeq++}-${i}-${target}-${res}`, fromCell: i, toCell: target, carrying: { [res]: load }, progress: 0 })
       cell.stock[res] = Math.max(0, amount - load)
       inFlightFrom.add(`${i}-${res}`)
     }


### PR DESCRIPTION
## Summary

- **Carrier idle gaps (walkers stopping)**: The game carrier's delivery speed (1.0 cell/min) was 3× slower than the visual goblin animation, so after a goblin completed its visual round-trip (~45s) there'd be a 2+ minute gap before the next one was dispatched — making it look like goblins stopped going to the farm. Raised `CARRIER_BASE_SPEED` from 1.0 → 2.5 cells/min so deliveries complete faster and the cycle of dispatching stays continuous.
- **Duplicate carrier IDs**: Two windmills pulling from the same farm in the same 10-second tick produced identical IDs (`Date.now()-fromCell-res`), causing one visual goblin to be silently dropped. Added a per-tick `carrierSeq` counter so every dispatched carrier has a unique ID.
- **Food inspector false alarm**: The building inspector showed "✗ Needs adequate food supply" even when bread stock was 150+, because it only checked `resources.wheat` (which gets consumed by windmills). The score now adds bread to the food adequacy calculation, so windmill-fed cities correctly show food as adequate.

## Test plan

- [ ] Place a Farm + Windmill. Goblins should continuously travel back and forth without long gaps
- [ ] Place two Windmills near one Farm. Both should dispatch independent goblins (no drops)
- [ ] Tap a Windmill with low wheat but high bread — inspector should show food supply as ✓ met
- [ ] Tap a Farm — inspector shows production rate and stockpile
- [ ] No regression in road wear, happiness, or attack systems

https://claude.ai/code/session_01QoP8jPH6TsU5QUWDguGVYx

---
_Generated by [Claude Code](https://claude.ai/code/session_01QoP8jPH6TsU5QUWDguGVYx)_