### PR TITLE
Fix bread happiness and granary inspector stats

### DIFF
--- a/web/src/components/minigames/citybuilder/BuildingInspectModal.tsx
+++ b/web/src/components/minigames/citybuilder/BuildingInspectModal.tsx
@@ -116,7 +116,7 @@ export function BuildingInspectModal({
                 })
               )}
             </>
-          ) : produceEntries.length > 0 || consumeEntries.length > 0 ? (
+          ) : produceEntries.length > 0 || consumeEntries.length > 0 || stockEntries.length > 0 || /warehouse|barn|granary|silo|storehouse|vault/i.test(cell.cardName) ? (
             <>
               {stockEntries.length > 0 && (
                 <>
@@ -127,6 +127,9 @@ export function BuildingInspectModal({
                     </div>
                   ))}
                 </>
+              )}
+              {stockEntries.length === 0 && /warehouse|barn|granary|silo|storehouse|vault/i.test(cell.cardName) && (
+                <div className="city-bld-section-title">No stock yet</div>
               )}
               {produceEntries.length > 0 && (
                 <>
@@ -152,6 +155,9 @@ export function BuildingInspectModal({
                     </div>
                   ))}
                 </>
+              )}
+              {/warehouse|barn|granary|silo|storehouse|vault/i.test(cell.cardName) && (
+                <div className="city-synergy-label">📦 Storage hub — raises all resource caps by +200</div>
               )}
               {synergies.map((s, i) => (
                 <div key={i} className="city-synergy-label">{s.label}</div>

--- a/web/src/game/cityBuilder.ts
+++ b/web/src/game/cityBuilder.ts
@@ -1511,10 +1511,13 @@ export function tickCity(state: CityState): CityState {
   deductResource('wood',  woodConsumed,  newGrid as (CityCell|undefined)[], newResources)
 
   // ── Base happiness target from food, defence, bread quality, wood supply ──
-  const foodScore    = Math.min(100, (newResources.wheat / population) * 5)
-  const defenseScore = Math.min(100, (defense / population) * 8)
+  const rawFoodScore  = Math.min(100, (newResources.wheat / population) * 5)
+  // Bread is a superior food: full bread coverage raises food floor to 70 so windmill
+  // cities aren't penalised for converting all wheat into bread.
+  const foodScore     = breadCoverage >= 1 ? Math.max(rawFoodScore, 70) : rawFoodScore
+  const defenseScore  = Math.min(100, (defense / population) * 8)
   // Linear scale: -BREAD_SHORTAGE_PENALTY at 0% coverage → +BREAD_HAPPY_BONUS at 100%
-  const breadScore   = breadCoverage >= 1
+  const breadScore    = breadCoverage >= 1
     ? BREAD_HAPPY_BONUS
     : Math.round(breadCoverage * (BREAD_HAPPY_BONUS + BREAD_SHORTAGE_PENALTY) - BREAD_SHORTAGE_PENALTY)
   const woodScore    = woodShort ? -WOOD_SHORTAGE_PENALTY : 0


### PR DESCRIPTION
## Summary

- **Bread now satisfies residents**: The happiness `foodScore` was wheat-only, so windmill cities (where all wheat gets converted to bread) showed residents as perpetually hungry even with 183+ bread in stock. When breadCoverage ≥ 1, `foodScore` is now floored at 70, meaning a well-fed-with-bread city keeps residents content.
- **Granary shows stockpile**: Tapping a Granary (or other warehouse) showed nothing useful because it has no produce/consume entries. The inspector condition now also triggers for any building that has stock or matches the warehouse pattern, showing the current stockpile plus a "Storage hub — raises all resource caps by +200" description.

## Test plan

- [ ] Place Farm + Windmill. After windmill starts producing bread, tapping residential buildings should show food supply as ✓ met
- [ ] Residents should not show ⚠ "hungry" warning when global bread stock is plentiful
- [ ] Tap a Granary — should show current stockpile (or "No stock yet") and the storage cap description
- [ ] Tap a Farm with stock — still shows stockpile + production rate
- [ ] No regression in happiness, road wear, or attack systems

https://claude.ai/code/session_01QoP8jPH6TsU5QUWDguGVYx

---
_Generated by [Claude Code](https://claude.ai/code/session_01QoP8jPH6TsU5QUWDguGVYx)_