### PR TITLE
Rename Granary to Warehouse and fix resident eating task priority

### DIFF
--- a/web/public/sprites/warehouse.svg
+++ b/web/public/sprites/warehouse.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground -->
+  <rect x="0" y="26" width="32" height="6" fill="#3a4a1a"/>
+
+  <!-- Building body -->
+  <rect x="4" y="16" width="24" height="12" fill="#8a6a3a"/>
+  <!-- Vertical board planks -->
+  <line x1="10" y1="16" x2="10" y2="28" stroke="#6a4a1a" stroke-width="0.8"/>
+  <line x1="16" y1="16" x2="16" y2="28" stroke="#6a4a1a" stroke-width="0.8"/>
+  <line x1="22" y1="16" x2="22" y2="28" stroke="#6a4a1a" stroke-width="0.8"/>
+
+  <!-- Domed roof -->
+  <path d="M3,16 Q16,5 29,16 Z" fill="#6a3a18"/>
+  <!-- Roof highlight -->
+  <path d="M7,15 Q16,8 25,15" fill="none" stroke="#8a5030" stroke-width="1" opacity="0.6"/>
+
+  <!-- Double barn doors -->
+  <rect x="12" y="20" width="4"  height="8" fill="#3a2010" rx="0.5"/>
+  <rect x="16" y="20" width="4"  height="8" fill="#2a1808" rx="0.5"/>
+  <line x1="12" y1="24" x2="16" y2="24" stroke="#1a0a00" stroke-width="0.5"/>
+  <line x1="16" y1="24" x2="20" y2="24" stroke="#1a0a00" stroke-width="0.5"/>
+
+  <!-- Side windows -->
+  <rect x="5"  y="18" width="4" height="3" fill="#88aacc" rx="0.3"/>
+  <rect x="23" y="18" width="4" height="3" fill="#88aacc" rx="0.3"/>
+
+  <!-- Grain sacks on ground -->
+  <ellipse cx="7"  cy="27.5" rx="3"   ry="1.5" fill="#9a8a5a"/>
+  <ellipse cx="25" cy="27.5" rx="3"   ry="1.5" fill="#9a8a5a"/>
+
+  <!-- Wheat sprig on peak -->
+  <line x1="16" y1="5" x2="16" y2="9" stroke="#c8a020" stroke-width="1"/>
+  <ellipse cx="16" cy="4.5" rx="2" ry="1.2" fill="#d4b020" transform="rotate(-15,16,4.5)"/>
+</svg>

--- a/web/src/components/minigames/CityBuilder.tsx
+++ b/web/src/components/minigames/CityBuilder.tsx
@@ -425,14 +425,26 @@ function pickTask(
   // Resting — return to home building
   available.push({ type: 'resting', label: '💤 Heading home', targetX: home.x, targetY: home.y })
 
-  // Eating — walk to a wheat-producing building
-  const farms = city.grid
+  // Eating — walk to best available food source: warehouse with stock → bread producer → wheat producer
+  const warehousesWithFood = city.grid
+    .map((cell, i) => ({ cell, i }))
+    .filter(({ cell }) => cell && !cell.spawnedUnitName &&
+      /warehouse|barn|granary|silo|storehouse|vault/i.test(cell.cardName) &&
+      ((cell.stock?.bread ?? 0) > 1 || (cell.stock?.wheat ?? 0) > 1))
+  const breadProducers = city.grid
+    .map((cell, i) => ({ cell, i }))
+    .filter(({ cell }) => cell && !cell.spawnedUnitName && (getBuildingProduces(cell.cardName).bread ?? 0) > 0)
+  const wheatProducers = city.grid
     .map((cell, i) => ({ cell, i }))
     .filter(({ cell }) => cell && !cell.spawnedUnitName && (getBuildingProduces(cell.cardName).wheat ?? 0) > 0)
-  if (farms.length > 0) {
-    const { i } = farms[Math.floor(Math.random() * farms.length)]
+  const foodSources = warehousesWithFood.length > 0 ? warehousesWithFood
+    : breadProducers.length > 0 ? breadProducers
+    : wheatProducers
+  if (foodSources.length > 0) {
+    const { i } = foodSources[Math.floor(Math.random() * foodSources.length)]
     const pos = cellPos(i)
-    available.push({ type: 'eating', label: '🌾 Getting food', targetX: pos.x, targetY: pos.y, resource: 'wheat' })
+    const foodResource = warehousesWithFood.length > 0 || breadProducers.length > 0 ? 'bread' : 'wheat'
+    available.push({ type: 'eating', label: '🌾 Getting food', targetX: pos.x, targetY: pos.y, resource: foodResource })
   }
 
   // Patrolling — walk to a random perimeter cell

--- a/web/src/game/cityBuilder.ts
+++ b/web/src/game/cityBuilder.ts
@@ -529,7 +529,7 @@ const BUILDING_RESOURCE_CONFIG: Record<string, Partial<ResourceStock>> = {
   'Windmill':    { bread: 2 },
   'Bakery':      { bread: 1.5 },
   'Quarry':      { ore: 2, planks: 1 },
-  'Granary':     {},           // storage handled by WAREHOUSE_PATTERN; no per-tick produce
+  'Warehouse':   {},           // storage handled by WAREHOUSE_PATTERN; no per-tick produce
   'Watchtower':  {},           // defense handled as wall-type (non-spawner, non-producer)
   // ── Card buildings ──
   'Farm':            { wheat: 3 },
@@ -1854,7 +1854,7 @@ export interface CoreBuilding {
 export const CORE_BUILDINGS: CoreBuilding[] = [
   { name: 'Windmill',   goldCost:  500, rarity: 'common',   hint: 'Grinds wheat into bread (2/min). Needs 2 wheat/min — output ×1.5 next to a Farm.' },
   { name: 'Bakery',     goldCost:  750, rarity: 'uncommon', hint: 'Bakes bread directly (1.5/min). No wheat cost — pure gold investment.' },
-  { name: 'Granary',    goldCost:  600, rarity: 'common',   hint: 'Extends all resource storage caps by 200.' },
+  { name: 'Warehouse',  goldCost:  600, rarity: 'common',   hint: 'Extends all resource storage caps by 200.' },
   { name: 'Watchtower', goldCost:  800, rarity: 'common',   hint: 'Garrisoned lookout. Contributes to city defense.' },
   { name: 'Quarry',     goldCost:  700, rarity: 'common',   hint: 'Mines raw ore and cuts stone into planks.' },
 ]


### PR DESCRIPTION
## Summary
- Renames the "Granary" core building to "Warehouse" (BUILDING_RESOURCE_CONFIG + CORE_BUILDINGS + sprite)
- Adds `warehouse.svg` sprite (copied from granary.svg; WAREHOUSE_PATTERN still matches both for save-game compatibility)
- Fixes resident eating task priority: residents now walk to **warehouse with food in stock → bread producers (windmill/bakery) → wheat producers (farm)** instead of always heading to farms even when bread is plentiful elsewhere

## Test plan
- [ ] Build a Warehouse — card picker shows "Warehouse", correct sprite renders
- [ ] Tap the Warehouse — stockpile screen shows current stock
- [ ] Residents with windmills + warehouses stocked with bread head to the warehouse/windmill, not a distant farm
- [ ] Existing saves with "Granary" cells still recognised as storage (WAREHOUSE_PATTERN unchanged)

https://claude.ai/code/session_01QoP8jPH6TsU5QUWDguGVYx

---
_Generated by [Claude Code](https://claude.ai/code/session_01QoP8jPH6TsU5QUWDguGVYx)_