### PR TITLE
Fix residents appearing hungry despite plentiful bread

### DIFF
--- a/web/src/components/minigames/citybuilder/CityGrid.tsx
+++ b/web/src/components/minigames/citybuilder/CityGrid.tsx
@@ -107,7 +107,7 @@ export function CityGrid({
                         : (cell.stock?.wheat ?? 0) > 0 ? 'Windmill Slow'
                         : 'Windmill Stopped'
                       : cell.cardName
-                    return <SpriteImg key={spriteName} name={spriteName} className="city-cell-sprite" />
+                    return <SpriteImg name={spriteName} className="city-cell-sprite" />
                   })()}
                   {cell.spawnedUnitName && rage > 0 && (
                     <div

--- a/web/src/components/minigames/citybuilder/walkerTypes.ts
+++ b/web/src/components/minigames/citybuilder/walkerTypes.ts
@@ -1,6 +1,6 @@
 import {
   CityCell, CityState, CITY_ROWS, CITY_COLS,
-  cityDefense, getNeighbourIndices, spawnerUnitCount,
+  cityDefense, getNeighbourIndices, spawnerUnitCount, getCityFoodScore,
 } from '../../../game/cityBuilder'
 
 export type TaskType = 'idle' | 'resting' | 'eating' | 'patrolling' | 'gathering' | 'visiting' | 'playing' | 'chatting'
@@ -111,12 +111,10 @@ export function getUnitRequirements(
     })
   }
 
-  const pop = Math.max(spawnerUnitCount(cityState, cell.cardName), 1)
-  const wheatScore = Math.min(100, (cityState.resources.wheat / pop) * 5)
-  const breadScore = Math.min(100, (cityState.resources.bread / pop) * 10)
-  const foodScore  = Math.min(100, wheatScore + breadScore)
+  const foodScore = getCityFoodScore(cityState)
   reqs.push({ text: 'Needs adequate food supply', met: foodScore >= 50 })
 
+  const pop = Math.max(spawnerUnitCount(cityState, cell.cardName), 1)
   const defense = cityDefense(cityState)
   const defenseScore = Math.min(100, (defense / pop) * 8)
   if (defense > 0 || defenseScore < 30) {

--- a/web/src/components/ui/SpriteImg.tsx
+++ b/web/src/components/ui/SpriteImg.tsx
@@ -107,6 +107,7 @@ export function SpriteImg({ name, fallbackName, className }: Props) {
   const [failed,  setFailed]  = useState(false)
   const [eightbit, setEightbit] = useState(is8bitMode)
   const [monochrome, setMonochrome] = useState(isMonochromeMode)
+  const prevNameRef = useRef(name)
 
   useEffect(() => {
     const handler = () => setEightbit(is8bitMode())
@@ -119,6 +120,27 @@ export function SpriteImg({ name, fallbackName, className }: Props) {
     window.addEventListener('monochrome-change', handler)
     return () => window.removeEventListener('monochrome-change', handler)
   }, [])
+
+  // When name changes, preload the new image before swapping src so the old
+  // sprite stays visible (no flash) until the new one is ready.
+  useEffect(() => {
+    if (name === prevNameRef.current) return
+    prevNameRef.current = name
+    const newSlug   = spriteSlug(name)
+    const newPng    = `${BASE}sprites/${newSlug}.png`
+    const newSvg    = `${BASE}sprites/${newSlug}.svg`
+    const newFb     = fallbackName ? `${BASE}sprites/${spriteSlug(fallbackName)}.svg` : genericSrc
+    let cancelled   = false
+    const tryLoad = (srcs: string[], idx = 0) => {
+      if (cancelled || idx >= srcs.length) return
+      const img = new window.Image()
+      img.onload  = () => { if (!cancelled) { setFailed(false); setSrc(srcs[idx]) } }
+      img.onerror = () => tryLoad(srcs, idx + 1)
+      img.src = srcs[idx]
+    }
+    tryLoad([newPng, newSvg, newFb, genericSrc])
+    return () => { cancelled = true }
+  }, [name, fallbackName, genericSrc])
 
   if (failed) return null
 

--- a/web/src/game/cityBuilder.ts
+++ b/web/src/game/cityBuilder.ts
@@ -1290,9 +1290,26 @@ function processDisaster(
   return s
 }
 
-export function tickCity(state: CityState): CityState {
-  const now     = Date.now()
+// 5-minute sub-step size for offline catch-up — keeps the carrier pipeline cycling
+// so conversion buildings (windmills, bakeries) receive inputs between each step.
+const OFFLINE_STEP_MS = 5 * 60_000
+
+export function tickCity(state: CityState, nowMs?: number): CityState {
+  const now     = nowMs ?? Date.now()
   const elapsed = now - state.lastTick
+
+  // For long offline periods, sub-step so carriers complete trips between steps.
+  // Without this, a windmill sitting empty for 30 minutes produces zero bread.
+  if (elapsed > OFFLINE_STEP_MS * 1.5) {
+    const steps   = Math.min(Math.ceil(elapsed / OFFLINE_STEP_MS), MAX_OFFLINE_MINUTES / 5)
+    const stepMs  = elapsed / steps
+    let current   = state
+    for (let i = 0; i < steps; i++) {
+      current = tickCity(current, state.lastTick + stepMs * (i + 1))
+    }
+    return current
+  }
+
   const minutes = Math.min(elapsed / 60_000, MAX_OFFLINE_MINUTES)
 
   const season = currentSeason(now)

--- a/web/src/game/cityBuilder.ts
+++ b/web/src/game/cityBuilder.ts
@@ -1052,6 +1052,24 @@ export function cityPopulation(state: CityState): number {
   return count
 }
 
+/**
+ * Returns a 0-100 food score for the current city state, using the same
+ * bread-coverage floor logic as the happiness tick. Exported so that
+ * requirement-check helpers outside cityBuilder can stay in sync.
+ */
+export function getCityFoodScore(state: CityState): number {
+  const population = Math.max(cityPopulation(state), 1)
+  const rawWheatScore = Math.min(100, (state.resources.wheat / population) * 5)
+  // 1-minute bread demand — if stockpile covers it, floor food score at 70.
+  const breadDemand1min = population * BREAD_CONSUME_RATE
+  const breadCoverage   = breadDemand1min > 0
+    ? Math.min(1, (state.resources.bread ?? 0) / breadDemand1min)
+    : 1
+  return breadCoverage >= 1
+    ? Math.max(rawWheatScore, 70)
+    : Math.min(100, rawWheatScore + breadCoverage * 30)
+}
+
 // ── Attack resolution ─────────────────────────────────────────────────────────
 
 function processAttack(state: CityState): CityState {
@@ -1549,7 +1567,10 @@ export function tickCity(state: CityState, nowMs?: number): CityState {
       const nc = newGrid[ni]
       return nc?.spawnedUnitName === wantedNeighbour && (state.happiness[ni] ?? 100) > 0
     })
-    const cellTarget  = affinityMet ? baseTarget : 0
+    // Affinity: same-type neighbour gives full target; absence caps happiness at
+    // baseTarget - 30 so residents stay but remain somewhat unsettled rather
+    // than always leaving, which confused players who had plenty of food.
+    const cellTarget  = affinityMet ? baseTarget : Math.max(0, baseTarget - 30)
 
     const current = newHappy[i] ?? 100
     const seasonRegen = HAPPINESS_REGEN * (1 + si.regen)


### PR DESCRIPTION
## Summary

Two root causes fixed:

**1. Affinity system was too punishing**
`cellTarget = affinityMet ? baseTarget : 0` caused all buildings without a same-type neighbour to inevitably depopulate regardless of food supply. This confused players who had plenty of bread. Changed to `max(0, baseTarget - 30)` — affinity now grants a meaningful +30 happiness bonus without forcing residents out entirely.

**2. Food requirement check didn't match the tick**
`getUnitRequirements` divided global bread by one building's unit count (always looked abundant regardless of city size). Replaced with a new `getCityFoodScore()` helper that mirrors the tick's bread-coverage floor logic (`breadCoverage >= 1 → foodScore ≥ 70`), so the inspector agrees with what's actually driving happiness.

Also included in this branch: offline food production fix (sub-step ticking) and Warehouse/eating task priority.

## Test plan
- [ ] City with lots of bread → "Needs adequate food supply" shows as ✓ met
- [ ] Building with no same-type neighbour → residents are "unsettled" (not evicted)
- [ ] Building with same-type neighbour → residents reach full happiness target
- [ ] "Needs adequate food supply" shows as ✗ only when bread genuinely runs low

https://claude.ai/code/session_01QoP8jPH6TsU5QUWDguGVYx

---
_Generated by [Claude Code](https://claude.ai/code/session_01QoP8jPH6TsU5QUWDguGVYx)_