### PR TITLE
Add storage capacity line and time range selector to city stats

### DIFF
--- a/web/src/components/minigames/citybuilder/StatsScreen.tsx
+++ b/web/src/components/minigames/citybuilder/StatsScreen.tsx
@@ -1,7 +1,9 @@
-import React from 'react'
+import React, { useState } from 'react'
 import {
   CityState, HistorySample,
   RESOURCE_ICONS, ResourceType,
+  PER_CELL_STOCK_CAP, WAREHOUSE_PATTERN,
+  getBuildingProduces,
 } from '../../../game/cityBuilder'
 import { StatsSparkline } from './StatsSparkline'
 
@@ -45,6 +47,28 @@ const COLORS: Record<string, string> = {
 
 const RES_ORDER: ResourceType[] = ['wheat', 'wood', 'ore', 'bread', 'planks', 'metal']
 
+// ── Time range options ────────────────────────────────────────────────────────
+
+const TIME_RANGES = [
+  { label: '1H',  ms: 60 * 60_000 },
+  { label: '6H',  ms: 6  * 60 * 60_000 },
+  { label: '24H', ms: 24 * 60 * 60_000 },
+  { label: '7D',  ms: 7  * 24 * 60 * 60_000 },
+] as const
+
+// ── Capacity helpers ──────────────────────────────────────────────────────────
+
+/** Returns the total storage ceiling for a given resource across the current city. */
+function resourceCapacity(city: CityState, res: ResourceType): number {
+  const count = city.grid.filter(cell =>
+    cell && (
+      (getBuildingProduces(cell.cardName)[res] ?? 0) > 0 ||
+      WAREHOUSE_PATTERN.test(cell.cardName)
+    )
+  ).length
+  return count * PER_CELL_STOCK_CAP
+}
+
 // ── Sub-components ─────────────────────────────────────────────────────────────
 
 interface StatCardProps {
@@ -72,7 +96,7 @@ function StatCard({ icon, label, value, delta, isGold }: StatCardProps) {
 }
 
 interface ChartSectionProps {
-  title:   string
+  title:    string
   children: React.ReactNode
 }
 function ChartSection({ title, children }: ChartSectionProps) {
@@ -92,18 +116,22 @@ interface Props {
 }
 
 export function StatsScreen({ city, onBack }: Props) {
-  const history: HistorySample[] = city.history ?? []
-  const n = history.length
+  const [rangeMs, setRangeMs] = useState(24 * 60 * 60_000)
 
+  const allHistory: HistorySample[] = city.history ?? []
+  const now = allHistory.length > 0 ? allHistory[allHistory.length - 1].t : Date.now()
+  const history = allHistory.filter(s => s.t >= now - rangeMs)
+
+  const n      = history.length
   const latest = history[n - 1]
   const oldest = history[0]
 
   const extract = (key: keyof HistorySample) =>
     history.map(s => s[key] as number)
 
-  const goldData  = extract('gold')
-  const popData   = extract('pop')
-  const defData   = extract('def')
+  const goldData   = extract('gold')
+  const popData    = extract('pop')
+  const defData    = extract('def')
   const attackMask = history.map(s => s.attacked ?? false)
 
   const resData: Record<ResourceType, number[]> = {
@@ -120,20 +148,20 @@ export function StatsScreen({ city, onBack }: Props) {
     ? `Last ${fmtDuration(latest.t - oldest.t)}`
     : n === 1 ? 'First sample' : 'No data yet'
 
-  // Deltas (change over entire history window)
-  const goldDelta = n >= 2 ? latest.gold  - oldest.gold  : 0
-  const popDelta  = n >= 2 ? latest.pop   - oldest.pop   : 0
-  const defDelta  = n >= 2 ? latest.def   - oldest.def   : 0
+  // Deltas (change over filtered window)
+  const goldDelta = n >= 2 ? latest.gold - oldest.gold : 0
+  const popDelta  = n >= 2 ? latest.pop  - oldest.pop  : 0
+  const defDelta  = n >= 2 ? latest.def  - oldest.def  : 0
 
   // Time axis labels for the gold chart
   function timeLabel(i: number): string {
     if (n < 2) return ''
-    const ageMs  = latest.t - history[i].t
+    const ageMs = latest.t - history[i].t
     if (ageMs < 60_000) return 'now'
     return `${fmtDuration(ageMs)} ago`
   }
 
-  if (n === 0) {
+  if (allHistory.length === 0) {
     return (
       <div className="city-screen u-col u-gap-2">
         <div className="city-header u-flex u-items-c u-gap-3">
@@ -159,6 +187,19 @@ export function StatsScreen({ city, onBack }: Props) {
         <button className="action-btn" onClick={onBack}>← BACK</button>
         <div className="city-title">📊 CITY STATS</div>
         <span className="city-stats-window-label">{windowLabel}</span>
+
+        {/* Time range selector */}
+        <div className="city-stats-range-btns">
+          {TIME_RANGES.map(tr => (
+            <button
+              key={tr.label}
+              className={`city-stats-range-btn${rangeMs === tr.ms ? ' city-stats-range-btn--active' : ''}`}
+              onClick={() => setRangeMs(tr.ms)}
+            >
+              {tr.label}
+            </button>
+          ))}
+        </div>
       </div>
 
       {/* Scrollable content */}
@@ -168,18 +209,18 @@ export function StatsScreen({ city, onBack }: Props) {
         <div className="city-stats-summary">
           <StatCard
             icon="💰" label="GOLD"
-            value={fmtGold(latest.gold)}
+            value={fmtGold(latest?.gold ?? 0)}
             delta={goldDelta}
             isGold
           />
           <StatCard
             icon="👥" label="POP"
-            value={String(latest.pop)}
+            value={String(latest?.pop ?? 0)}
             delta={popDelta}
           />
           <StatCard
             icon="🛡" label="DEFENSE"
-            value={String(latest.def)}
+            value={String(latest?.def ?? 0)}
             delta={defDelta}
           />
           <StatCard
@@ -188,94 +229,101 @@ export function StatsScreen({ city, onBack }: Props) {
           />
         </div>
 
-        {/* Gold chart */}
-        <ChartSection title="GOLD OVER TIME">
-          <div className="city-stats-chart-wrap">
-            <StatsSparkline
-              data={goldData}
-              attacks={attackMask}
-              color={COLORS.gold}
-              height={80}
-              showMax
-              formatMax={fmtGold}
-            />
-            <div className="city-stats-chart-labels">
-              <span>{timeLabel(0)}</span>
-              <span className="city-stats-chart-range">
-                {fmtGold(Math.min(...goldData))} – {fmtGold(Math.max(...goldData))}
-              </span>
-              <span>now</span>
-            </div>
+        {n < 2 ? (
+          <div className="city-stats-empty city-stats-empty--inline">
+            <span>No data in this time window — try a wider range.</span>
           </div>
-          {attackMask.some(Boolean) && (
-            <div className="city-stats-attack-legend">
-              <span className="city-sparkline-attack-mark city-sparkline-attack-mark--inline" />
-              {' '}attack event
-            </div>
-          )}
-        </ChartSection>
+        ) : (
+          <>
+            {/* Gold chart */}
+            <ChartSection title="GOLD OVER TIME">
+              <div className="city-stats-chart-wrap">
+                <StatsSparkline
+                  data={goldData}
+                  attacks={attackMask}
+                  color={COLORS.gold}
+                  height={80}
+                />
+                <div className="city-stats-chart-labels">
+                  <span>{timeLabel(0)}</span>
+                  <span className="city-stats-chart-range">
+                    {fmtGold(Math.min(...goldData))} – {fmtGold(Math.max(...goldData))}
+                  </span>
+                  <span>now</span>
+                </div>
+              </div>
+              {attackMask.some(Boolean) && (
+                <div className="city-stats-attack-legend">
+                  <span className="city-sparkline-attack-mark city-sparkline-attack-mark--inline" />
+                  {' '}attack event
+                </div>
+              )}
+            </ChartSection>
 
-        {/* Resources */}
-        <ChartSection title="RESOURCES">
-          <div className="city-stats-res-grid">
-            {RES_ORDER.map(res => {
-              const d = resData[res]
-              const cur = d[d.length - 1] ?? 0
-              const delta = d.length >= 2 ? cur - d[0] : 0
-              const allZero = d.every(v => v === 0)
-              if (allZero) return null
-              return (
-                <div key={res} className="city-stats-res-cell">
-                  <div className="city-stats-res-label">
-                    {RESOURCE_ICONS[res]} {res.toUpperCase()}
+            {/* Resources */}
+            <ChartSection title="RESOURCES">
+              <div className="city-stats-res-grid">
+                {RES_ORDER.map(res => {
+                  const d = resData[res]
+                  const cur = d[d.length - 1] ?? 0
+                  const delta = d.length >= 2 ? cur - d[0] : 0
+                  const allZero = d.every(v => v === 0)
+                  if (allZero) return null
+                  const cap = resourceCapacity(city, res)
+                  return (
+                    <div key={res} className="city-stats-res-cell">
+                      <div className="city-stats-res-label">
+                        {RESOURCE_ICONS[res]} {res.toUpperCase()}
+                      </div>
+                      <div className="city-stats-chart-wrap city-stats-chart-wrap--sm">
+                        <StatsSparkline
+                          data={d}
+                          color={COLORS[res]}
+                          height={40}
+                          capacity={cap > 0 ? cap : undefined}
+                        />
+                      </div>
+                      <div className="city-stats-res-footer">
+                        <span className="city-stats-res-cur">{Math.floor(cur)}</span>
+                        <span className={`city-stats-res-delta ${delta > 0 ? 'city-stat-card-delta--pos' : delta < 0 ? 'city-stat-card-delta--neg' : 'city-stat-card-delta--zero'}`}>
+                          {fmtDelta(delta)}
+                        </span>
+                      </div>
+                    </div>
+                  )
+                })}
+              </div>
+            </ChartSection>
+
+            {/* Population & Defense */}
+            <ChartSection title="POPULATION &amp; DEFENSE">
+              <div className="city-stats-duo">
+                <div>
+                  <div className="city-stats-res-label">👥 POPULATION</div>
+                  <div className="city-stats-chart-wrap">
+                    <StatsSparkline data={popData} color={COLORS.pop} height={50} />
                   </div>
-                  <div className="city-stats-chart-wrap city-stats-chart-wrap--sm">
-                    <StatsSparkline
-                      data={d}
-                      color={COLORS[res]}
-                      height={40}
-                      showMax
-                    />
-                  </div>
-                  <div className="city-stats-res-footer">
-                    <span className="city-stats-res-cur">{Math.floor(cur)}</span>
-                    <span className={`city-stats-res-delta ${delta > 0 ? 'city-stat-card-delta--pos' : delta < 0 ? 'city-stat-card-delta--neg' : 'city-stat-card-delta--zero'}`}>
-                      {fmtDelta(delta)}
-                    </span>
+                  <div className="city-stats-chart-labels">
+                    <span>{Math.min(...popData)}</span>
+                    <span></span>
+                    <span>{Math.max(...popData)}</span>
                   </div>
                 </div>
-              )
-            })}
-          </div>
-        </ChartSection>
-
-        {/* Population & Defense */}
-        <ChartSection title="POPULATION &amp; DEFENSE">
-          <div className="city-stats-duo">
-            <div>
-              <div className="city-stats-res-label">👥 POPULATION</div>
-              <div className="city-stats-chart-wrap">
-                <StatsSparkline data={popData} color={COLORS.pop} height={50} showMax />
+                <div>
+                  <div className="city-stats-res-label">🛡 DEFENSE</div>
+                  <div className="city-stats-chart-wrap">
+                    <StatsSparkline data={defData} color={COLORS.def} height={50} />
+                  </div>
+                  <div className="city-stats-chart-labels">
+                    <span>{Math.min(...defData)}</span>
+                    <span></span>
+                    <span>{Math.max(...defData)}</span>
+                  </div>
+                </div>
               </div>
-              <div className="city-stats-chart-labels">
-                <span>{Math.min(...popData)}</span>
-                <span></span>
-                <span>{Math.max(...popData)}</span>
-              </div>
-            </div>
-            <div>
-              <div className="city-stats-res-label">🛡 DEFENSE</div>
-              <div className="city-stats-chart-wrap">
-                <StatsSparkline data={defData} color={COLORS.def} height={50} showMax />
-              </div>
-              <div className="city-stats-chart-labels">
-                <span>{Math.min(...defData)}</span>
-                <span></span>
-                <span>{Math.max(...defData)}</span>
-              </div>
-            </div>
-          </div>
-        </ChartSection>
+            </ChartSection>
+          </>
+        )}
 
       </div>
     </div>

--- a/web/src/components/minigames/citybuilder/StatsSparkline.tsx
+++ b/web/src/components/minigames/citybuilder/StatsSparkline.tsx
@@ -1,17 +1,18 @@
 import React from 'react'
 
 interface Props {
-  data:       number[]
-  attacks?:   boolean[]  // parallel array, true = attack occurred at that sample
-  color:      string
-  height?:    number     // chart height in px, default 54
-  dimColor?:  string     // fill/glow color override (defaults to color)
-  showMax?:   boolean
-  formatMax?: (n: number) => string
+  data:            number[]
+  attacks?:        boolean[]  // parallel array, true = attack occurred at that sample
+  color:           string
+  height?:         number     // chart height in px, default 54
+  dimColor?:       string     // fill/glow color override (defaults to color)
+  /** Storage ceiling for this series. Scales Y to [0, capacity] and draws a cap line. */
+  capacity?:       number
+  formatCapacity?: (n: number) => string
 }
 
-export function StatsSparkline({ data, attacks, color, height = 54, dimColor, showMax, formatMax }: Props) {
-  const n = data.length
+export function StatsSparkline({ data, attacks, color, height = 54, dimColor, capacity, formatCapacity }: Props) {
+  const n    = data.length
   const fill = dimColor ?? color
 
   if (n < 2) {
@@ -28,12 +29,17 @@ export function StatsSparkline({ data, attacks, color, height = 54, dimColor, sh
   const H   = height
   const PAD = 3   // top/bottom padding in viewBox units
 
-  const min   = Math.min(...data)
-  const max   = Math.max(...data)
-  const range = Math.max(max - min, 1)
+  const dataMin = Math.min(...data)
+  const dataMax = Math.max(...data)
+
+  // When a capacity is provided scale Y from 0 → max(dataMax, capacity)
+  // so the cap line is meaningful and data is shown relative to the ceiling.
+  const yMin = capacity !== undefined ? 0 : dataMin
+  const yMax = capacity !== undefined ? Math.max(dataMax, capacity) : dataMax
+  const range = Math.max(yMax - yMin, 1)
 
   const toX = (i: number) => (i / (n - 1)) * W
-  const toY = (v: number) => PAD + (H - PAD * 2) * (1 - (v - min) / range)
+  const toY = (v: number) => PAD + (H - PAD * 2) * (1 - (v - yMin) / range)
 
   const pts      = data.map((v, i) => `${toX(i).toFixed(2)},${toY(v).toFixed(2)}`)
   const linePath = `M ${pts.join(' L ')}`
@@ -44,7 +50,11 @@ export function StatsSparkline({ data, attacks, color, height = 54, dimColor, sh
   const gridYs = [0.25, 0.5, 0.75].map(f => (PAD + (H - PAD * 2) * (1 - f)).toFixed(2))
 
   const hasAttacks = attacks?.some(Boolean)
-  const maxLabel   = showMax ? (formatMax ? formatMax(max) : String(Math.floor(max))) : null
+
+  const capY     = capacity !== undefined ? toY(capacity) : null
+  const capLabel = capacity !== undefined
+    ? (formatCapacity ? formatCapacity(capacity) : String(Math.floor(capacity)))
+    : null
 
   return (
     <div className="city-sparkline" style={{ position: 'relative' }}>
@@ -71,11 +81,11 @@ export function StatsSparkline({ data, attacks, color, height = 54, dimColor, sh
         </defs>
         <path d={areaPath} fill={`url(#sg-${color.replace('#', '')})`} stroke="none" />
 
-        {/* Max line */}
-        {showMax && (
+        {/* Capacity line */}
+        {capY !== null && (
           <line
-            x1="0" y1={PAD} x2={W} y2={PAD}
-            stroke="rgba(255,255,255,0.22)"
+            x1="0" y1={capY.toFixed(2)} x2={W} y2={capY.toFixed(2)}
+            stroke="rgba(255,255,255,0.28)"
             strokeWidth="0.8"
             strokeDasharray="3,2"
             vectorEffect="non-scaling-stroke"
@@ -94,9 +104,11 @@ export function StatsSparkline({ data, attacks, color, height = 54, dimColor, sh
         />
       </svg>
 
-      {/* Max label */}
-      {maxLabel && (
-        <span className="city-sparkline-max-label">{maxLabel}</span>
+      {/* Capacity label */}
+      {capLabel && (
+        <span className="city-sparkline-cap-label" title={`Storage cap: ${capLabel}`}>
+          cap {capLabel}
+        </span>
       )}
 
       {/* Attack markers — HTML positioned so they don't distort */}

--- a/web/src/game/cityBuilder.ts
+++ b/web/src/game/cityBuilder.ts
@@ -307,7 +307,7 @@ export const WAREHOUSE_PATTERN = /warehouse|barn|granary|silo|storehouse|vault/i
 const CARRIER_LOAD          = 5     // units loaded per carrier trip
 const CARRIER_BASE_SPEED    = 2.5   // cells per minute on grass (faster = shorter game delivery time = goblins dispatched more frequently)
 const ROAD_WEAR_PER_CARRIER = 0.4   // wear added per carrier per minute
-const PER_CELL_STOCK_CAP    = 50    // max units any single cell can stockpile of one resource
+export const PER_CELL_STOCK_CAP = 50    // max units any single cell can stockpile of one resource
 export const ROAD_TIER_THRESHOLDS = [25, 60] as const  // tier 1 at 25, tier 2 at 60
 const ROAD_SPEED_MULT = [1.0, 1.4, 2.0]  // multiplier per road tier
 
@@ -466,7 +466,7 @@ export function calculateStorageCaps(state: CityState): ResourceStock {
 
 // ── Stats history ─────────────────────────────────────────────────────────────
 
-const HISTORY_MAX         = 144          // 24 h at 10-min resolution
+const HISTORY_MAX         = 1008         // 7 days at 10-min resolution
 const HISTORY_INTERVAL_MS = 10 * 60_000  // sample at most once per 10 minutes
 
 export interface HistorySample {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -9294,8 +9294,33 @@ html.light-mode .action-btn {
   font-size: 10px;
   color: #406040;
   font-family: monospace;
-  margin-left: auto;
   white-space: nowrap;
+}
+.city-stats-range-btns {
+  display: flex;
+  gap: 3px;
+  margin-left: auto;
+}
+.city-stats-range-btn {
+  font-size: 9px;
+  font-family: monospace;
+  padding: 2px 6px;
+  border: 1px solid #2a4a2a;
+  border-radius: 3px;
+  background: transparent;
+  color: #406040;
+  cursor: pointer;
+  line-height: 1.4;
+  transition: background 0.1s, color 0.1s, border-color 0.1s;
+}
+.city-stats-range-btn:hover {
+  border-color: #4a7a4a;
+  color: #80b080;
+}
+.city-stats-range-btn--active {
+  background: #1a3a1a;
+  border-color: #50c050;
+  color: #90e090;
 }
 
 /* Summary stat cards */
@@ -9460,7 +9485,7 @@ html.light-mode .action-btn {
   vertical-align: middle;
   margin-right: 2px;
 }
-.city-sparkline-max-label {
+.city-sparkline-cap-label {
   position: absolute;
   top: 2px;
   right: 3px;
@@ -9484,6 +9509,11 @@ html.light-mode .action-btn {
   color: #406040;
   font-family: monospace;
   text-align: center;
+}
+.city-stats-empty--inline {
+  flex: none;
+  padding: 16px;
+  font-size: 11px;
 }
 .city-stats-empty-icon {
   font-size: 32px;


### PR DESCRIPTION
## Summary
- Each resource sparkline now shows a dashed cap line at the city's current storage ceiling (producers + warehouses × `PER_CELL_STOCK_CAP`), with the Y-axis scaled to `[0, cap]` so the chart shows how full the city is rather than just relative trends
- A **1H / 6H / 24H / 7D** range picker in the stats header filters the history window; switching to a narrow window with no data shows a prompt to widen the range
- `HISTORY_MAX` bumped from 144 → 1008 so a full week of 10-minute samples can accumulate
- `PER_CELL_STOCK_CAP` exported from `cityBuilder.ts` for use in the UI

## Test plan
- [ ] Open City Stats → resource sparklines each show a faint dashed line at their storage cap with a `cap N` label in the top-right
- [ ] City with 2 farms + 1 warehouse for wheat → cap label = `(2+1) × 50 = 150`
- [ ] Switch range to 1H → only last hour of data shown; switching to 7D shows full history
- [ ] Selecting a window with no history shows "No data in this time window — try a wider range"

https://claude.ai/code/session_01QoP8jPH6TsU5QUWDguGVYx

---
_Generated by [Claude Code](https://claude.ai/code/session_01QoP8jPH6TsU5QUWDguGVYx)_