### PR TITLE
Warehouse upgrades raise storage cap

### DIFF
--- a/web/src/components/minigames/citybuilder/StatsScreen.tsx
+++ b/web/src/components/minigames/citybuilder/StatsScreen.tsx
@@ -2,8 +2,8 @@ import React, { useState } from 'react'
 import {
   CityState, HistorySample,
   RESOURCE_ICONS, ResourceType,
-  PER_CELL_STOCK_CAP, WAREHOUSE_PATTERN,
-  getBuildingProduces,
+  WAREHOUSE_PATTERN,
+  getBuildingProduces, cellStockCap,
 } from '../../../game/cityBuilder'
 import { StatsSparkline } from './StatsSparkline'
 
@@ -60,13 +60,13 @@ const TIME_RANGES = [
 
 /** Returns the total storage ceiling for a given resource across the current city. */
 function resourceCapacity(city: CityState, res: ResourceType): number {
-  const count = city.grid.filter(cell =>
-    cell && (
-      (getBuildingProduces(cell.cardName)[res] ?? 0) > 0 ||
-      WAREHOUSE_PATTERN.test(cell.cardName)
-    )
-  ).length
-  return count * PER_CELL_STOCK_CAP
+  return city.grid.reduce((sum, cell) => {
+    if (!cell) return sum
+    if ((getBuildingProduces(cell.cardName)[res] ?? 0) > 0 || WAREHOUSE_PATTERN.test(cell.cardName)) {
+      return sum + cellStockCap(cell)
+    }
+    return sum
+  }, 0)
 }
 
 // ── Sub-components ─────────────────────────────────────────────────────────────

--- a/web/src/game/cityBuilder.ts
+++ b/web/src/game/cityBuilder.ts
@@ -392,7 +392,7 @@ function findNearestConsumer(
       ? Boolean(BUILDING_CONVERSION_COST[cell.cardName]?.wheat)
       : WAREHOUSE_PATTERN.test(cell.cardName)
     if (!wants) continue
-    if ((cell.stock[res] ?? 0) >= PER_CELL_STOCK_CAP) continue  // destination already full
+    if ((cell.stock[res] ?? 0) >= cellStockCap(cell)) continue  // destination already full
     const d = cellManhattan(fromCell, i, cols)
     if (d < bestDist) { bestDist = d; best = i }
   }
@@ -955,6 +955,14 @@ export function masteryOutputMultiplier(level: number): number {
   return Math.pow(2, level)
 }
 
+/** Per-cell stock ceiling. Warehouses scale with mastery level; other buildings use the base cap. */
+export function cellStockCap(cell: CityCell): number {
+  if (WAREHOUSE_PATTERN.test(cell.cardName)) {
+    return PER_CELL_STOCK_CAP * masteryOutputMultiplier(getCardMasteryLevel(cell.cardName))
+  }
+  return PER_CELL_STOCK_CAP
+}
+
 /** How many units a spawner should field: mastery 0 → 1, mastery N → N+1. */
 export function spawnerUnitCount(state: CityState, cardName: string): number {
   return (getCardMasteryLevel(cardName) ?? 0) + 1
@@ -1472,7 +1480,7 @@ export function tickCity(state: CityState, nowMs?: number): CityState {
     const inputNeeds = BUILDING_CONVERSION_COST[cell.cardName]
     if (!inputNeeds) continue
     for (const [res] of Object.entries(inputNeeds) as [ResourceType, number][]) {
-      if ((cell.stock[res] ?? 0) >= PER_CELL_STOCK_CAP - CARRIER_LOAD) continue   // near capacity, don't overfill
+      if ((cell.stock[res] ?? 0) >= cellStockCap(cell) - CARRIER_LOAD) continue   // near capacity, don't overfill
       if (inFlightTo.has(`${i}-${res}`)) continue            // already fetching
       const source = findNearestProducer(res, i, newGrid as (CityCell|undefined)[], CITY_COLS)
       if (source === null) continue
@@ -1629,7 +1637,7 @@ export function tickCity(state: CityState, nowMs?: number): CityState {
   for (const cell of newGrid) {
     if (!cell) continue
     for (const key of Object.keys(cell.stock) as ResourceType[]) {
-      cell.stock[key] = Math.max(0, Math.min(cell.stock[key] ?? 0, PER_CELL_STOCK_CAP))
+      cell.stock[key] = Math.max(0, Math.min(cell.stock[key] ?? 0, cellStockCap(cell)))
     }
   }
 


### PR DESCRIPTION
## Summary
- New `cellStockCap(cell)` helper: warehouses multiply `PER_CELL_STOCK_CAP` (50) by `2^masteryLevel`, all other buildings keep the base 50
- Used in `findNearestConsumer` (destination-full guard), pull-carrier near-capacity check, and end-of-tick stock clamp — upgraded warehouses actually accept more and hold more
- `StatsScreen.resourceCapacity` now sums `cellStockCap` per cell so the cap line on resource sparklines reflects the true upgraded ceiling

## Test plan
- [ ] Level-0 Warehouse: cap stays at 50 per cell
- [ ] Level-1 Warehouse (first upgrade): cap rises to 100 per cell — carriers keep delivering past the old 50 limit
- [ ] Stats screen cap label updates immediately when Warehouse is upgraded
- [ ] Non-warehouse buildings (farms, windmills) are unaffected — their per-cell cap stays at 50

https://claude.ai/code/session_01QoP8jPH6TsU5QUWDguGVYx

---
_Generated by [Claude Code](https://claude.ai/code/session_01QoP8jPH6TsU5QUWDguGVYx)_