### PR TITLE
Stop warehouses dispatching carriers to other warehouses

### DIFF
--- a/web/src/game/cityBuilder.ts
+++ b/web/src/game/cityBuilder.ts
@@ -1517,6 +1517,7 @@ export function tickCity(state: CityState, nowMs?: number): CityState {
     const cell = newGrid[i]
     if (!cell || cell.spawnedUnitName) continue
     if (BUILDING_CONVERSION_COST[cell.cardName]) continue    // handled above
+    if (WAREHOUSE_PATTERN.test(cell.cardName)) continue      // warehouses only receive, never push
     for (const [res, amount] of Object.entries(cell.stock) as [ResourceType, number][]) {
       if (amount < CARRIER_LOAD) continue
       if (inFlightFrom.has(`${i}-${res}`)) continue


### PR DESCRIPTION
## Summary
The non-conversion producer push loop iterated over all non-conversion cells, including warehouses. A warehouse that had accumulated stock (e.g. 50 bread) would dispatch goblin carriers to the nearest other warehouse, bouncing resources between storage cells uselessly.

One-line fix: skip warehouse cells in the push loop so they only ever receive deliveries, never initiate them.

## Test plan
- [ ] Fill a warehouse with bread → no carrier spawns heading to another warehouse
- [ ] Producers (farms, windmills) still dispatch carriers to warehouses as normal

https://claude.ai/code/session_01QoP8jPH6TsU5QUWDguGVYx

---
_Generated by [Claude Code](https://claude.ai/code/session_01QoP8jPH6TsU5QUWDguGVYx)_