### PR TITLE
Fix road wear shading appearing on wrong cell edges

### DIFF
--- a/web/src/components/minigames/citybuilder/CityGrid.stories.tsx
+++ b/web/src/components/minigames/citybuilder/CityGrid.stories.tsx
@@ -83,3 +83,69 @@ export const BulldozerMode: Story = {
     />
   ),
 }
+
+// ── Road wear debug stories ────────────────────────────────────────────────────
+// CITY_COLS=6, CITY_ROWS=4 → 24 cells, indices 0-23.
+// h[i] = horizontal road to the RIGHT of cell i (5 gaps per row).
+// v[i] = vertical road BELOW cell i (6 gaps per column, up to row 3).
+//
+// HorizontalRoadWear: walkers travelling left→right across row 0.
+//   h[0..4] = 100 → wear should appear on the LEFT edge of cells 1-5 in row 0.
+//
+// VerticalRoadWear: walkers travelling top→bottom down column 0.
+//   v[0,6,12] = 100 → wear should appear on the TOP edge of cells 6,12,18 in col 0.
+
+const COLS = 6
+
+const makeGrid = (occupied: number[]) =>
+  Array.from({ length: 24 }, (_, i) =>
+    occupied.includes(i) ? { cardName: 'Farm', rarity: 'common', stock: {} } : undefined
+  )
+
+const horizontalWearCity: any = {
+  ...emptyCity,
+  grid: makeGrid([0, 1, 2, 3, 4, 5]),   // row 0 all occupied
+  roadWear: {
+    h: Array.from({ length: 24 }, (_, i) => (i < COLS - 1 ? 100 : 0)),  // h[0..4] = 100
+    v: new Array(24).fill(0),
+  },
+}
+
+const verticalWearCity: any = {
+  ...emptyCity,
+  grid: makeGrid([0, COLS, COLS * 2, COLS * 3]),  // column 0 all occupied
+  roadWear: {
+    h: new Array(24).fill(0),
+    v: Array.from({ length: 24 }, (_, i) => (i % COLS === 0 && i < COLS * 3 ? 100 : 0)),  // v[0,6,12] = 100
+  },
+}
+
+export const HorizontalRoadWear: Story = {
+  args: {} as any,
+  render: () => (
+    <WithRef
+      city={horizontalWearCity}
+      walkers={[]}
+      builderWalkers={[]}
+      visualCarriers={[]}
+      bulldozerMode={false}
+      onCellTap={fn()}
+      onWalkerClick={fn()}
+    />
+  ),
+}
+
+export const VerticalRoadWear: Story = {
+  args: {} as any,
+  render: () => (
+    <WithRef
+      city={verticalWearCity}
+      walkers={[]}
+      builderWalkers={[]}
+      visualCarriers={[]}
+      bulldozerMode={false}
+      onCellTap={fn()}
+      onWalkerClick={fn()}
+    />
+  ),
+}

--- a/web/src/components/minigames/citybuilder/CityGrid.tsx
+++ b/web/src/components/minigames/citybuilder/CityGrid.tsx
@@ -73,24 +73,26 @@ export function CityGrid({
           const isFirstCol   = col === 0
           const isLastCol   = col === CITY_COLS - 1
           const isLastRow   = row === cityRows - 1
-          const wearR = isLastCol || isFirstCol ? 0 : ((city.roadWear?.h ?? [])[i] ?? 0)
-          const wearB = isLastRow || isFirstRow ? 0 : ((city.roadWear?.v ?? [])[i] ?? 0)
+          // Read wear from the cell to the left (h[i-1]) and above (v[i-CITY_COLS])
+          // so the mark appears on the incoming edge of each cell.
+          const wearL = isFirstCol ? 0 : ((city.roadWear?.h ?? [])[i - 1] ?? 0)
+          const wearT = isFirstRow ? 0 : ((city.roadWear?.v ?? [])[i - CITY_COLS] ?? 0)
           const shadows: string[] = []
           if (district !== 'none' && isRowStart) shadows.push(`inset 4px 0 0 ${distColor}`)
-          if (wearR > 0) {
-            const c = roadWearColor(wearR)
-            shadows.push(`3px 0 0 0 ${c}`)
-            if (wearR > 60) {
-              const w = (((wearR - 60) / 40) * 3).toFixed(1)
-              shadows.push(`inset -${w}px 0 0 0 ${c}`)
+          if (wearL > 0) {
+            const c = roadWearColor(wearL)
+            shadows.push(`-3px 0 0 0 ${c}`)
+            if (wearL > 60) {
+              const w = (((wearL - 60) / 40) * 3).toFixed(1)
+              shadows.push(`inset ${w}px 0 0 0 ${c}`)
             }
           }
-          if (wearB > 0) {
-            const c = roadWearColor(wearB)
-            shadows.push(`0 3px 0 0 ${c}`)
-            if (wearB > 60) {
-              const w = (((wearB - 60) / 40) * 3).toFixed(1)
-              shadows.push(`inset 0 -${w}px 0 0 ${c}`)
+          if (wearT > 0) {
+            const c = roadWearColor(wearT)
+            shadows.push(`0 -3px 0 0 ${c}`)
+            if (wearT > 60) {
+              const w = (((wearT - 60) / 40) * 3).toFixed(1)
+              shadows.push(`inset 0 ${w}px 0 0 ${c}`)
             }
           }
           return (


### PR DESCRIPTION
## Summary
Road wear was drawn on the **right** edge of cell `i` (using `h[i]`) and **bottom** edge (using `v[i]`), making paths look like they lead *away* from cells.

Now reads `h[i-1]` and `v[i-CITY_COLS]` and renders on the **left** and **top** edges, so the wear mark appears on the incoming side — paths look like they lead *into* each cell.

## Test plan
- [ ] Let carriers walk across the grid — road wear marks should appear on the left/top edges of traversed cells, not the right/bottom

https://claude.ai/code/session_01QoP8jPH6TsU5QUWDguGVYx

---
_Generated by [Claude Code](https://claude.ai/code/session_01QoP8jPH6TsU5QUWDguGVYx)_