### PR TITLE
City builder: road wear, stats dashboard, storage caps & more

### DIFF
--- a/web/src/components/minigames/citybuilder/CityGrid.tsx
+++ b/web/src/components/minigames/citybuilder/CityGrid.tsx
@@ -15,15 +15,17 @@ import { Walker } from './walkerTypes'
 // Vertical  (top-bottom)  travel → strip along the RIGHT  edge.
 // Adjacent cells' strips meet at shared boundaries, forming continuous lanes.
 
-const ROAD_START = 74  // strip starts at 74% from the top/left edge
-const ROAD_W     = 26  // strip width = 26% of cell (100 - ROAD_START)
+const ROAD_START = 80  // strip starts at 80% from the top/left edge
+const ROAD_W     = 20  // strip width = 20% of cell (100 - ROAD_START)
 
-function pathFill(wear: number): string {
+function pathFill(wear: number, highlight = false): string {
   const t = Math.min(1, wear / 100)
   const r = Math.round(140 + (170 - 140) * t)
   const g = Math.round(100 + (155 - 100) * t)
   const b = Math.round(40  + (110 - 40)  * t)
-  const a = (0.25 + t * 0.45).toFixed(2)
+  const a = highlight
+    ? (0.55 + t * 0.35).toFixed(2)
+    : (0.25 + t * 0.45).toFixed(2)
   return `rgba(${r},${g},${b},${a})`
 }
 
@@ -39,6 +41,7 @@ function RoadPath({ left, right, top, bottom }: RoadPathProps) {
   const wearH = Math.max(left, right)
   const wearV = Math.max(top, bottom)
 
+  const wearX = Math.max(wearH, wearV)
   return (
     <svg
       viewBox="0 0 100 100"
@@ -50,6 +53,8 @@ function RoadPath({ left, right, top, bottom }: RoadPathProps) {
       {hasH && <rect x={0} y={ROAD_START} width={100} height={ROAD_W} fill={pathFill(wearH)} />}
       {/* Vertical travel → lane along the RIGHT of this cell */}
       {hasV && <rect x={ROAD_START} y={0} width={ROAD_W} height={100} fill={pathFill(wearV)} />}
+      {/* Intersection square — brighter node where the two lanes cross */}
+      {hasH && hasV && <rect x={ROAD_START} y={ROAD_START} width={ROAD_W} height={ROAD_W} fill={pathFill(wearX, true)} />}
     </svg>
   )
 }


### PR DESCRIPTION
## Summary

- **Road wear visualisation** — SVG dirt-path strips drawn at cell edges (bottom for horizontal travel, right for vertical). Narrower lanes (20%), brighter intersection node at crossroads corners, colour lerps brown→grey with wear intensity.
- **Stats dashboard time range selector** — 1H / 6H / 24H / 7D buttons filter the history window; `HISTORY_MAX` bumped to 1008 (7 days at 10-min resolution).
- **Storage capacity sparkline** — dashed reference line on each resource chart showing city-wide storage ceiling; Y-axis scaled to `[0, capacity]`.
- **Warehouse mastery cap scaling** — upgrading a Warehouse card doubles its per-cell stock cap (`×2^masteryLevel`); other buildings keep the base 50-unit cap.
- **Block warehouse-to-warehouse dispatch** — non-conversion producers no longer push surplus to other warehouses (warehouses only receive).

## Test plan

- [ ] Place Farm + Sawmill, tick forward — walkers walk, road wear accumulates, strips appear at cell edges
- [ ] Place two adjacent warehouses — confirm goblins never carry between them
- [ ] Upgrade a Warehouse card — confirm higher cap shown on resource sparkline
- [ ] Open Stats screen — verify time range buttons filter charts correctly
- [ ] Disaster / attack flow — confirm no regression in happiness/attack systems

https://claude.ai/code/session_01QoP8jPH6TsU5QUWDguGVYx

---
_Generated by [Claude Code](https://claude.ai/code/session_01QoP8jPH6TsU5QUWDguGVYx)_