### PR TITLE
Road wear strips centred on cell boundaries (in the gap)

### DIFF
--- a/web/src/components/minigames/citybuilder/CityGrid.tsx
+++ b/web/src/components/minigames/citybuilder/CityGrid.tsx
@@ -10,13 +10,15 @@ import { BuilderWalker, VisualCarrier } from '../CityBuilder'
 import { Walker } from './walkerTypes'
 
 // ── Road path SVG ─────────────────────────────────────────────────────────────
-// Roads are drawn at cell EDGES, not through the centre.
-// Horizontal (left-right) travel → strip along the BOTTOM edge.
-// Vertical  (top-bottom)  travel → strip along the RIGHT  edge.
-// Adjacent cells' strips meet at shared boundaries, forming continuous lanes.
+// Strips are centred on the cell boundary (bottom / right) so they straddle
+// the CSS grid gap, appearing IN the gap rather than deep inside the cell.
+// ROAD_EXT extends each strip beyond the cell boundary to bridge the gap.
+//   Horizontal (h wear) → full-width strip centred on the bottom boundary (y=100)
+//   Vertical   (v wear) → full-height strip centred on the right  boundary (x=100)
+// overflow="visible" on the SVG lets the ±ROAD_EXT portions render in the gap.
 
-const ROAD_START = 80  // strip starts at 80% from the top/left edge
-const ROAD_W     = 20  // strip width = 20% of cell (100 - ROAD_START)
+const ROAD_W   = 20  // strip width as % of cell
+const ROAD_EXT = 12  // extra SVG units beyond boundary to cover the CSS grid gap
 
 function pathFill(wear: number, highlight = false): string {
   const t = Math.min(1, wear / 100)
@@ -42,19 +44,23 @@ function RoadPath({ left, right, top, bottom }: RoadPathProps) {
   const wearV = Math.max(top, bottom)
 
   const wearX = Math.max(wearH, wearV)
+  const HALF  = ROAD_W / 2
+  const hy    = 100 - HALF  // strip top, centred on bottom boundary y=100
+  const vx    = 100 - HALF  // strip left, centred on right boundary x=100
   return (
     <svg
       viewBox="0 0 100 100"
       preserveAspectRatio="none"
       aria-hidden
-      style={{ position: 'absolute', inset: 0, width: '100%', height: '100%', pointerEvents: 'none' }}
+      overflow="visible"
+      style={{ position: 'absolute', inset: 0, width: '100%', height: '100%', pointerEvents: 'none', overflow: 'visible' }}
     >
-      {/* Horizontal travel → lane along the BOTTOM of this cell */}
-      {hasH && <rect x={0} y={ROAD_START} width={100} height={ROAD_W} fill={pathFill(wearH)} />}
-      {/* Vertical travel → lane along the RIGHT of this cell */}
-      {hasV && <rect x={ROAD_START} y={0} width={ROAD_W} height={100} fill={pathFill(wearV)} />}
-      {/* Intersection square — brighter node where the two lanes cross */}
-      {hasH && hasV && <rect x={ROAD_START} y={ROAD_START} width={ROAD_W} height={ROAD_W} fill={pathFill(wearX, true)} />}
+      {/* Horizontal lane — full-width, centred on bottom boundary, extended to bridge column gap */}
+      {hasH && <rect x={-ROAD_EXT} y={hy} width={100 + ROAD_EXT * 2} height={ROAD_W} fill={pathFill(wearH)} />}
+      {/* Vertical lane — full-height, centred on right boundary, extended to bridge row gap */}
+      {hasV && <rect x={vx} y={-ROAD_EXT} width={ROAD_W} height={100 + ROAD_EXT * 2} fill={pathFill(wearV)} />}
+      {/* Intersection — brighter node at the corner where both lanes cross */}
+      {hasH && hasV && <rect x={vx} y={hy} width={ROAD_W} height={ROAD_W} fill={pathFill(wearX, true)} />}
     </svg>
   )
 }


### PR DESCRIPTION
## Summary

- Road strips are now centred on the cell boundary (`y=90..110` for horizontal, `x=90..110` for vertical) so they straddle the 4 px CSS grid gap rather than sitting inside the cell
- `overflow="visible"` on each cell's SVG lets the strip extend into the gap area
- `ROAD_EXT=12` extends each strip ±12 SVG units beyond the boundary, ensuring full gap coverage regardless of cell size
- Narrower strip (20% of cell) and a brighter intersection node at the crossing corner are retained from the previous iteration

## Test plan

- [ ] Open Storybook `HorizontalRoadWear` story — confirm strip appears in the gap between row 0 and row 1, not inside cells
- [ ] Open Storybook `VerticalRoadWear` story — confirm strip appears in the gap between column 0 and column 1
- [ ] Check intersection cell (both h + v wear) — corner node is visibly brighter

https://claude.ai/code/session_01QoP8jPH6TsU5QUWDguGVYx

---
_Generated by [Claude Code](https://claude.ai/code/session_01QoP8jPH6TsU5QUWDguGVYx)_