### PR TITLE
Road wear strips: move to overlay so they render in gap between cells

### DIFF
--- a/web/src/components/minigames/citybuilder/CityGrid.tsx
+++ b/web/src/components/minigames/citybuilder/CityGrid.tsx
@@ -94,6 +94,35 @@ export function CityGrid({
 
   return (
     <div className="city-world" ref={worldRef}>
+
+      {/* ── Road wear overlay ─────────────────────────────────────────────────
+          Rendered BEHIND the main grid. Cell buttons paint on top, hiding the
+          in-cell portion of each strip. Only the portion that overflows into
+          the CSS grid gap is visible — exactly what the user sees as "road". */}
+      <div
+        className="city-road-layer"
+        style={{
+          gridTemplateColumns: `repeat(${CITY_COLS}, 1fr)`,
+          gridTemplateRows:    `repeat(${cityRows}, 1fr)`,
+        }}
+      >
+        {Array.from({ length: cityCells }, (_, i) => {
+          const row = Math.floor(i / CITY_COLS)
+          const col = i % CITY_COLS
+          const h = city.roadWear?.h ?? []
+          const v = city.roadWear?.v ?? []
+          const wearLeft   = col === 0             ? 0 : (h[i - 1]        ?? 0)
+          const wearRight  = col === CITY_COLS - 1 ? 0 : (h[i]             ?? 0)
+          const wearTop    = row === 0             ? 0 : (v[i - CITY_COLS] ?? 0)
+          const wearBottom = row === cityRows - 1  ? 0 : (v[i]             ?? 0)
+          return (
+            <div key={i} className="city-road-cell">
+              <RoadPath left={wearLeft} right={wearRight} top={wearTop} bottom={wearBottom} />
+            </div>
+          )
+        })}
+      </div>
+
       <div
         className="city-grid"
         style={{
@@ -114,14 +143,6 @@ export function CityGrid({
           const isLastCol  = col === CITY_COLS - 1
           const isLastRow  = row === cityRows - 1
 
-          // Four-edge wear: h = horizontal travel, v = vertical travel
-          const h = city.roadWear?.h ?? []
-          const v = city.roadWear?.v ?? []
-          const wearLeft   = col === 0        ? 0 : (h[i - 1]          ?? 0)
-          const wearRight  = isLastCol        ? 0 : (h[i]               ?? 0)
-          const wearTop    = row === 0        ? 0 : (v[i - CITY_COLS]   ?? 0)
-          const wearBottom = isLastRow        ? 0 : (v[i]               ?? 0)
-
           const distShadow = district !== 'none' && isRowStart
             ? `inset 4px 0 0 ${distColor}`
             : undefined
@@ -134,9 +155,6 @@ export function CityGrid({
               onClick={() => onCellTap(i)}
               title={cell ? (bulldozerMode ? `${cell.cardName} — tap to demolish` : `${cell.cardName} — tap to inspect`) : 'Empty — tap to place'}
             >
-              {/* Road wear path — rendered first so it sits under building sprites */}
-              <RoadPath left={wearLeft} right={wearRight} top={wearTop} bottom={wearBottom} />
-
               {cell ? (
                 <>
                   {(() => {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -8994,6 +8994,18 @@ html.light-mode .action-btn {
   height: 100%;
 }
 
+/* Road wear overlay — sits behind the grid; SVG overflow is visible in the gap */
+.city-road-layer {
+  position: absolute;
+  inset: 4px;   /* matches .city-grid border-width */
+  display: grid;
+  gap: 6px;     /* matches .city-grid gap */
+  pointer-events: none;
+}
+.city-road-cell {
+  position: relative;
+}
+
 .city-cell {
   background: #2d5a27;
   border: 2px solid rgba(0, 40, 0, .15);


### PR DESCRIPTION
## Summary

- Road wear strips now render in a separate `city-road-layer` div placed **behind** the main `city-grid` in the DOM
- The layer is a matching grid (same `gridTemplateColumns/Rows`, `gap: 6px`, `inset: 4px` to account for the grid border) with no `overflow: hidden`
- Each strip is an SVG with `overflow="visible"`, centered on the cell boundary so it straddles the CSS grid gap
- Inside cell areas: cell buttons paint on top, hiding the in-cell half of each strip
- In gap areas: no cell covers the overlay, so only the gap-overflow portion is visible — roads appear in the space **between** cells, not inside them

Root cause of the previous attempt failing: `.city-cell { overflow: hidden }` (needed for `border-radius`) clipped all SVG overflow before it could reach the gap.

## Test plan

- [ ] Open Storybook `HorizontalRoadWear` — confirm road strip appears in the row gap between row 0 and row 1, not inside cells
- [ ] Open Storybook `VerticalRoadWear` — confirm road strip appears in the column gap, not inside cells
- [ ] Play city — road wear accumulates and shows in gaps as walkers travel

https://claude.ai/code/session_01QoP8jPH6TsU5QUWDguGVYx

---
_Generated by [Claude Code](https://claude.ai/code/session_01QoP8jPH6TsU5QUWDguGVYx)_