### PR TITLE
Fix road strip inside-cell bleed from border-radius corners

### DIFF
--- a/web/src/components/minigames/citybuilder/CityGrid.tsx
+++ b/web/src/components/minigames/citybuilder/CityGrid.tsx
@@ -44,9 +44,8 @@ function RoadPath({ left, right, top, bottom }: RoadPathProps) {
   const wearV = Math.max(top, bottom)
 
   const wearX = Math.max(wearH, wearV)
-  const HALF  = ROAD_W / 2
-  const hy    = 100 - HALF  // strip top, centred on bottom boundary y=100
-  const vx    = 100 - HALF  // strip left, centred on right boundary x=100
+  const hy    = 100  // horizontal strip starts at bottom boundary (y=100), fully in gap
+  const vx    = 100  // vertical strip starts at right boundary (x=100), fully in gap
   return (
     <svg
       viewBox="0 0 100 100"


### PR DESCRIPTION
## Summary

- Road strips were rendering slightly inside cells due to `border-radius: 5px` + `overflow: hidden` on `.city-cell` — the transparent corner cutouts let the road overlay show through
- Fix: move `hy` and `vx` from `100 - HALF` (centred on boundary) to exactly `100` (starts at boundary), so zero inside-cell area is rendered and only the CSS gap receives colour

## Test plan

- [ ] Check city grid — road wear strips should appear only in the gaps between cells, with no colour bleeding into cell corners

https://claude.ai/code/session_01QoP8jPH6TsU5QUWDguGVYx

---
_Generated by [Claude Code](https://claude.ai/code/session_01QoP8jPH6TsU5QUWDguGVYx)_