### PR TITLE
Walker road-speed pathfinding + square grid expansion

### DIFF
--- a/web/src/components/minigames/CityBuilder.tsx
+++ b/web/src/components/minigames/CityBuilder.tsx
@@ -35,6 +35,8 @@ import {
   currentSeason,
   dispatchCaravan,
   extinguishFire, curePlague,
+  findFastestPath, ROAD_SPEED_MULT, RoadWearMap,
+  roadTier,
 } from '../../game/cityBuilder'
 import { AnimatedSpriteImg } from '../ui/SpriteImg'
 import { Card, UnitTemplate } from '../../game/types'
@@ -346,6 +348,46 @@ function computeWaypoints(
     { x: bxEnter, y: borderY },              // travel along row gap to dest column gap
     { x: bxEnter, y: (tr + 0.5) * cellH },  // travel along dest column gap
   ]
+}
+
+/** Like computeWaypoints but uses Dijkstra's to route walkers along the fastest roads. */
+function computeRoadWaypoints(
+  fromX: number, fromY: number,
+  toX: number, toY: number,
+  overlayW: number, overlayH: number,
+  cityRows: number,
+  roadWear: RoadWearMap,
+): { x: number; y: number; speed?: number }[] {
+  const cellW = overlayW / CITY_COLS
+  const cellH = overlayH / cityRows
+  const fc = Math.max(0, Math.min(CITY_COLS - 1, Math.floor(fromX / cellW)))
+  const fr = Math.max(0, Math.min(cityRows - 1, Math.floor(fromY / cellH)))
+  const tc = Math.max(0, Math.min(CITY_COLS - 1, Math.floor(toX / cellW)))
+  const tr = Math.max(0, Math.min(cityRows - 1, Math.floor(toY / cellH)))
+  const fromCell = fr * CITY_COLS + fc
+  const toCell   = tr * CITY_COLS + tc
+  if (fromCell === toCell) return []
+
+  const cellPath = findFastestPath(fromCell, toCell, roadWear, CITY_COLS, cityRows)
+  if (cellPath.length <= 1) return []
+
+  const result: { x: number; y: number; speed?: number }[] = []
+  for (let i = 1; i < cellPath.length; i++) {
+    const a  = cellPath[i - 1]
+    const b  = cellPath[i]
+    const lo = Math.min(a, b)
+    const hi = Math.max(a, b)
+    const wear  = hi === lo + 1 ? (roadWear.h[lo] ?? 0) : (roadWear.v[lo] ?? 0)
+    const speed = ROAD_SPEED_MULT[roadTier(wear)]
+    const bRow = Math.floor(b / CITY_COLS), bCol = b % CITY_COLS
+    result.push({ x: (bCol + 0.5) * cellW, y: (bRow + 0.5) * cellH, speed })
+  }
+  // Snap final waypoint to actual target coords
+  if (result.length > 0) {
+    result[result.length - 1].x = toX
+    result[result.length - 1].y = toY
+  }
+  return result
 }
 
 function makeWalker(cellIndex: number, unitIndex: number, unitName: string, affinityWith?: string, w = CITY_COLS * CELL_PX, h = CITY_ROWS * CELL_PX): Walker {
@@ -763,6 +805,10 @@ export function CityBuilder({ onBack }: Props) {
         const cityRows = cityRef.current?.rows ?? CITY_ROWS
         function wayptsFor(task: WalkerTask, fx: number, fy: number) {
           if (task.type === 'idle' || task.type === 'visiting' || task.type === 'chatting' || task.targetX === undefined) return []
+          const rw = cityRef.current?.roadWear as RoadWearMap | undefined
+          if (rw && (rw.h.length > 0 || rw.v.length > 0)) {
+            return computeRoadWaypoints(fx, fy, task.targetX, task.targetY!, overlayW, overlayH, cityRows, rw)
+          }
           return computeWaypoints(fx, fy, task.targetX, task.targetY!, overlayW, overlayH, cityRows)
         }
 
@@ -858,7 +904,8 @@ export function CityBuilder({ onBack }: Props) {
                 const next = waypoints.length > 0 ? waypoints[0] : { x: task.targetX, y: task.targetY }
                 const ndx = next.x - x, ndy = next.y - y
                 const nd  = Math.sqrt(ndx * ndx + ndy * ndy)
-                if (nd > 1) { vx = (ndx / nd) * SPEED; vy = (ndy / nd) * SPEED }
+                const nextSpd = (waypoints.length > 0 ? (waypoints[0].speed ?? 1) : 1)
+                if (nd > 1) { vx = (ndx / nd) * SPEED * nextSpd; vy = (ndy / nd) * SPEED * nextSpd }
               } else if (task.type === 'resting') {
                 return {
                   ...w, x, y, vx: 0, vy: 0, task, bubbleTimer,
@@ -873,8 +920,9 @@ export function CityBuilder({ onBack }: Props) {
                 waypoints = wayptsFor(task, x, y)
               }
             } else {
-              vx = (dx / dist) * SPEED
-              vy = (dy / dist) * SPEED
+              const curSpd = (currentTarget as { speed?: number }).speed ?? 1
+              vx = (dx / dist) * SPEED * curSpd
+              vy = (dy / dist) * SPEED * curSpd
             }
           }
 

--- a/web/src/components/minigames/CityBuilder.tsx
+++ b/web/src/components/minigames/CityBuilder.tsx
@@ -223,15 +223,16 @@ function pickRingTarget(
   } else {
     // Fetch from inside the city thumbnail (cols 1-2, rows 1-2 of the 4x4 ring)
     const cityRows = city.rows ?? CITY_ROWS
+    const cityCols = city.cols ?? CITY_COLS
     const resourceCells = city.grid
       .map((cell, i) => ({ cell, i }))
       .filter(({ cell }) => cell && !cell.spawnedUnitName && Object.values(getBuildingProduces(cell.cardName)).some(v => (v ?? 0) > 0))
     if (resourceCells.length > 0) {
       const { i } = resourceCells[Math.floor(Math.random() * resourceCells.length)]
-      const gCol = i % CITY_COLS
-      const gRow = Math.floor(i / CITY_COLS)
+      const gCol = i % cityCols
+      const gRow = Math.floor(i / cityCols)
       return {
-        targetX: ringW * (0.25 + (gCol + 0.3 + Math.random() * 0.4) / CITY_COLS * 0.5),
+        targetX: ringW * (0.25 + (gCol + 0.3 + Math.random() * 0.4) / cityCols * 0.5),
         targetY: ringH * (0.25 + (gRow + 0.3 + Math.random() * 0.4) / cityRows * 0.5),
       }
     }
@@ -269,6 +270,7 @@ function pickBuilderTarget(
 ): { targetX: number; targetY: number; nextPhase: BuilderWalker['phase']; label: string } {
   if (phase === 'fetching') {
     const cityRows = city.rows ?? CITY_ROWS
+    const cityCols = city.cols ?? CITY_COLS
     const allCells = city.grid.map((cell, i) => ({ cell, i })).filter(({ cell }) => cell && !cell.spawnedUnitName)
     // Prefer warehouses with materials stocked, then fall back to any producer
     const warehouses = allCells.filter(({ cell }) => WAREHOUSE_PATTERN.test(cell!.cardName) &&
@@ -277,10 +279,10 @@ function pickBuilderTarget(
     const candidates = warehouses.length > 0 ? warehouses : producers
     if (candidates.length > 0) {
       const { i } = candidates[Math.floor(Math.random() * candidates.length)]
-      const col = i % CITY_COLS
-      const row = Math.floor(i / CITY_COLS)
+      const col = i % cityCols
+      const row = Math.floor(i / cityCols)
       return {
-        targetX: (col + 0.3 + Math.random() * 0.4) * (overlayW / CITY_COLS),
+        targetX: (col + 0.3 + Math.random() * 0.4) * (overlayW / cityCols),
         targetY: (row + 0.3 + Math.random() * 0.4) * (overlayH / cityRows),
         nextPhase: 'delivering',
         label: warehouses.length > 0 ? '📦 Collecting from warehouse' : '🪵 Fetching materials',
@@ -329,19 +331,20 @@ function computeWaypoints(
   toX: number, toY: number,
   overlayW: number, overlayH: number,
   cityRows: number,
+  cityCols: number,
 ): { x: number; y: number }[] {
-  const cellW = overlayW / CITY_COLS
+  const cellW = overlayW / cityCols
   const cellH = overlayH / cityRows
-  const fc = Math.max(0, Math.min(CITY_COLS - 1, Math.floor(fromX / cellW)))
+  const fc = Math.max(0, Math.min(cityCols - 1, Math.floor(fromX / cellW)))
   const fr = Math.max(0, Math.min(cityRows - 1, Math.floor(fromY / cellH)))
-  const tc = Math.max(0, Math.min(CITY_COLS - 1, Math.floor(toX / cellW)))
+  const tc = Math.max(0, Math.min(cityCols - 1, Math.floor(toX / cellW)))
   const tr = Math.max(0, Math.min(cityRows - 1, Math.floor(toY / cellH)))
   if (fr === tr) return []  // same row: direct horizontal movement is fine
   const borderY  = fr < tr ? (fr + 1) * cellH : fr * cellH
   // Column border to use: the gap on the side of source/dest facing each other
   // (or right gap for same-column). Vertical legs run along these gaps, not column centres.
-  const bxExit  = fc < tc ? (fc + 1) * cellW : fc < CITY_COLS - 1 ? (fc + 1) * cellW : fc * cellW
-  const bxEnter = fc < tc ? tc * cellW        : fc > 0             ? tc * cellW        : (tc + 1) * cellW
+  const bxExit  = fc < tc ? (fc + 1) * cellW : fc < cityCols - 1 ? (fc + 1) * cellW : fc * cellW
+  const bxEnter = fc < tc ? tc * cellW        : fc > 0            ? tc * cellW        : (tc + 1) * cellW
   return [
     { x: bxExit,  y: (fr + 0.5) * cellH },  // exit source col to column-border gap
     { x: bxExit,  y: borderY },              // travel down/up to row-border gap
@@ -357,18 +360,19 @@ function computeRoadWaypoints(
   overlayW: number, overlayH: number,
   cityRows: number,
   roadWear: RoadWearMap,
+  cityCols: number,
 ): { x: number; y: number; speed?: number }[] {
-  const cellW = overlayW / CITY_COLS
+  const cellW = overlayW / cityCols
   const cellH = overlayH / cityRows
-  const fc = Math.max(0, Math.min(CITY_COLS - 1, Math.floor(fromX / cellW)))
+  const fc = Math.max(0, Math.min(cityCols - 1, Math.floor(fromX / cellW)))
   const fr = Math.max(0, Math.min(cityRows - 1, Math.floor(fromY / cellH)))
-  const tc = Math.max(0, Math.min(CITY_COLS - 1, Math.floor(toX / cellW)))
+  const tc = Math.max(0, Math.min(cityCols - 1, Math.floor(toX / cellW)))
   const tr = Math.max(0, Math.min(cityRows - 1, Math.floor(toY / cellH)))
-  const fromCell = fr * CITY_COLS + fc
-  const toCell   = tr * CITY_COLS + tc
+  const fromCell = fr * cityCols + fc
+  const toCell   = tr * cityCols + tc
   if (fromCell === toCell) return []
 
-  const cellPath = findFastestPath(fromCell, toCell, roadWear, CITY_COLS, cityRows)
+  const cellPath = findFastestPath(fromCell, toCell, roadWear, cityCols, cityRows)
   if (cellPath.length <= 1) return []
 
   const result: { x: number; y: number; speed?: number }[] = []
@@ -379,7 +383,7 @@ function computeRoadWaypoints(
     const hi = Math.max(a, b)
     const wear  = hi === lo + 1 ? (roadWear.h[lo] ?? 0) : (roadWear.v[lo] ?? 0)
     const speed = ROAD_SPEED_MULT[roadTier(wear)]
-    const bRow = Math.floor(b / CITY_COLS), bCol = b % CITY_COLS
+    const bRow = Math.floor(b / cityCols), bCol = b % cityCols
     result.push({ x: (bCol + 0.5) * cellW, y: (bRow + 0.5) * cellH, speed })
   }
   // Snap final waypoint to actual target coords
@@ -425,11 +429,12 @@ function pickTask(
   overlayH: number,
 ): WalkerTask {
   const cityRows = city.rows ?? CITY_ROWS
+  const cityCols = city.cols ?? CITY_COLS
 
   function cellPos(idx: number) {
     return {
-      x: ((idx % CITY_COLS) + 0.5) * (overlayW / CITY_COLS),
-      y: (Math.floor(idx / CITY_COLS) + 0.5) * (overlayH / cityRows),
+      x: ((idx % cityCols) + 0.5) * (overlayW / cityCols),
+      y: (Math.floor(idx / cityCols) + 0.5) * (overlayH / cityRows),
     }
   }
 
@@ -437,11 +442,11 @@ function pickTask(
 
   // Perimeter cells (shared by patrol and panic tasks)
   const perimCells: { col: number; row: number }[] = []
-  for (let col = 0; col < CITY_COLS; col++) {
+  for (let col = 0; col < cityCols; col++) {
     perimCells.push({ col, row: 0 }, { col, row: cityRows - 1 })
   }
   for (let row = 1; row < cityRows - 1; row++) {
-    perimCells.push({ col: 0, row }, { col: CITY_COLS - 1, row })
+    perimCells.push({ col: 0, row }, { col: cityCols - 1, row })
   }
 
   // ── Attack imminent: residents panic ─────────────────────────────────────────
@@ -449,7 +454,7 @@ function pickTask(
   if (msToAttack > 0 && msToAttack <= ATTACK_WARN_MS) {
     const perim = perimCells[Math.floor(Math.random() * perimCells.length)]
     const defendTarget = {
-      targetX: (perim.col + 0.5) * (overlayW / CITY_COLS),
+      targetX: (perim.col + 0.5) * (overlayW / cityCols),
       targetY: (perim.row + 0.5) * (overlayH / cityRows),
     }
     const panicTasks: WalkerTask[] = [
@@ -497,7 +502,7 @@ function pickTask(
   available.push({
     type: 'patrolling',
     label: '🛡 Patrolling the walls',
-    targetX: (perim.col + 0.5) * (overlayW / CITY_COLS),
+    targetX: (perim.col + 0.5) * (overlayW / cityCols),
     targetY: (perim.row + 0.5) * (overlayH / cityRows),
   })
 
@@ -803,13 +808,14 @@ export function CityBuilder({ onBack }: Props) {
 
         // ── Pass 2: update each walker ────────────────────────────────────────
         const cityRows = cityRef.current?.rows ?? CITY_ROWS
+        const cityCols = cityRef.current?.cols ?? CITY_COLS
         function wayptsFor(task: WalkerTask, fx: number, fy: number) {
           if (task.type === 'idle' || task.type === 'visiting' || task.type === 'chatting' || task.targetX === undefined) return []
           const rw = cityRef.current?.roadWear as RoadWearMap | undefined
           if (rw && (rw.h.length > 0 || rw.v.length > 0)) {
-            return computeRoadWaypoints(fx, fy, task.targetX, task.targetY!, overlayW, overlayH, cityRows, rw)
+            return computeRoadWaypoints(fx, fy, task.targetX, task.targetY!, overlayW, overlayH, cityRows, rw, cityCols)
           }
-          return computeWaypoints(fx, fy, task.targetX, task.targetY!, overlayW, overlayH, cityRows)
+          return computeWaypoints(fx, fy, task.targetX, task.targetY!, overlayW, overlayH, cityRows, cityCols)
         }
 
         return prev.map(w => {
@@ -990,6 +996,7 @@ export function CityBuilder({ onBack }: Props) {
       const gameCarriers = cityRef.current?.carriers ?? []
       const gameCarrierIds = new Set(gameCarriers.map(c => c.id))
       const cityRows = cityRef.current?.rows ?? CITY_ROWS
+      const cityCols = cityRef.current?.cols ?? CITY_COLS
 
       // Sync: keep carriers still in game state OR still finishing their shrink-out animation
       let nextVis = visualCarriersRef.current.filter(vc => gameCarrierIds.has(vc.id) || vc.scale > 0)
@@ -998,14 +1005,14 @@ export function CityBuilder({ onBack }: Props) {
       const visIds = new Set(nextVis.map(vc => vc.id))
       for (const gc of gameCarriers) {
         if (visIds.has(gc.id)) continue
-        const c1 = gc.fromCell % CITY_COLS, r1 = Math.floor(gc.fromCell / CITY_COLS)
-        const pickX = (c1 + 0.5) * overlayW / CITY_COLS
+        const c1 = gc.fromCell % cityCols, r1 = Math.floor(gc.fromCell / cityCols)
+        const pickX = (c1 + 0.5) * overlayW / cityCols
         const pickY = (r1 + 0.5) * overlayH / cityRows
-        const c2 = gc.toCell % CITY_COLS, r2 = Math.floor(gc.toCell / CITY_COLS)
-        const dropX = (c2 + 0.5) * overlayW / CITY_COLS
+        const c2 = gc.toCell % cityCols, r2 = Math.floor(gc.toCell / cityCols)
+        const dropX = (c2 + 0.5) * overlayW / cityCols
         const dropY = (r2 + 0.5) * overlayH / cityRows
         // Outbound: start at drop-off (consumer), walk to pick-up (producer)
-        const wps = computeWaypoints(dropX, dropY, pickX, pickY, overlayW, overlayH, cityRows)
+        const wps = computeWaypoints(dropX, dropY, pickX, pickY, overlayW, overlayH, cityRows, cityCols)
         const first = wps.length > 0 ? wps[0] : { x: pickX, y: pickY }
         const dd = Math.sqrt((first.x - dropX) ** 2 + (first.y - dropY) ** 2)
         nextVis.push({
@@ -1045,7 +1052,7 @@ export function CityBuilder({ onBack }: Props) {
           if (nd > 0) { vx = (next.x - x) / nd * SPEED; vy = (next.y - y) / nd * SPEED }
         } else if (dist < ARRIVE_DIST && phase === 'outbound') {
           // Arrived at producer — switch to returning, compute return waypoints
-          const wps = computeWaypoints(x, y, vc.dropX, vc.dropY, overlayW, overlayH, cityRows)
+          const wps = computeWaypoints(x, y, vc.dropX, vc.dropY, overlayW, overlayH, cityRows, cityCols)
           const first = wps.length > 0 ? wps[0] : { x: vc.dropX, y: vc.dropY }
           const nd = Math.sqrt((first.x - x) ** 2 + (first.y - y) ** 2)
           phase = 'returning'
@@ -1334,7 +1341,8 @@ export function CityBuilder({ onBack }: Props) {
   const consRates = resourceConsumptionRate(city)
 
   const cityRows = city.rows ?? CITY_ROWS
-  const cityCells = CITY_COLS * cityRows
+  const cityCols = city.cols ?? CITY_COLS
+  const cityCells = cityCols * cityRows
   const expansionCost = EXPANSION_COSTS[cityRows]
   const affordable = canAffordExpansion(city)
 
@@ -1640,7 +1648,7 @@ export function CityBuilder({ onBack }: Props) {
             <button
               className={`filter-btn city-expand-btn${affordable ? ' city-expand-btn--ready' : ''}`}
               onClick={handleExpand}
-              title={affordable ? `Expand city to ${cityRows + 1} rows` : 'Not enough resources to expand'}
+              title={affordable ? `Expand city to ${cityRows + 1}×${cityCols + 1}` : 'Not enough resources to expand'}
             >🏢 EXPAND</button>
           )}
         </div>

--- a/web/src/components/minigames/citybuilder/CityGrid.tsx
+++ b/web/src/components/minigames/citybuilder/CityGrid.tsx
@@ -84,7 +84,8 @@ export function CityGrid({
   city, walkers, builderWalkers, visualCarriers, bulldozerMode, worldRef, onCellTap, onWalkerClick,
 }: Props) {
   const cityRows  = city.rows ?? CITY_ROWS
-  const cityCells = CITY_COLS * cityRows
+  const cityCols  = city.cols ?? CITY_COLS
+  const cityCells = cityCols * cityRows
 
   const visibleBubbleSet = new Set(
     walkers
@@ -104,19 +105,19 @@ export function CityGrid({
       <div
         className="city-road-layer"
         style={{
-          gridTemplateColumns: `repeat(${CITY_COLS}, 1fr)`,
+          gridTemplateColumns: `repeat(${cityCols}, 1fr)`,
           gridTemplateRows:    `repeat(${cityRows}, 1fr)`,
         }}
       >
         {Array.from({ length: cityCells }, (_, i) => {
-          const row = Math.floor(i / CITY_COLS)
-          const col = i % CITY_COLS
+          const row = Math.floor(i / cityCols)
+          const col = i % cityCols
           const h = city.roadWear?.h ?? []
           const v = city.roadWear?.v ?? []
-          const wearLeft   = col === 0             ? 0 : (h[i - 1]        ?? 0)
-          const wearRight  = col === CITY_COLS - 1 ? 0 : (h[i]             ?? 0)
-          const wearTop    = row === 0             ? 0 : (v[i - CITY_COLS] ?? 0)
-          const wearBottom = row === cityRows - 1  ? 0 : (v[i]             ?? 0)
+          const wearLeft   = col === 0            ? 0 : (h[i - 1]       ?? 0)
+          const wearRight  = col === cityCols - 1 ? 0 : (h[i]            ?? 0)
+          const wearTop    = row === 0            ? 0 : (v[i - cityCols] ?? 0)
+          const wearBottom = row === cityRows - 1 ? 0 : (v[i]            ?? 0)
           return (
             <div key={i} className="city-road-cell">
               <RoadPath left={wearLeft} right={wearRight} top={wearTop} bottom={wearBottom} />
@@ -128,7 +129,7 @@ export function CityGrid({
       <div
         className="city-grid"
         style={{
-          gridTemplateColumns: `repeat(${CITY_COLS}, 1fr)`,
+          gridTemplateColumns: `repeat(${cityCols}, 1fr)`,
           gridTemplateRows:    `repeat(${cityRows}, 1fr)`,
         }}
       >
@@ -137,8 +138,8 @@ export function CityGrid({
           const happiness = cell?.spawnedUnitName ? (city.happiness[i] ?? 100) : 100
           const rage      = 100 - happiness
           const despawned = cell?.spawnedUnitName && happiness === 0
-          const row        = Math.floor(i / CITY_COLS)
-          const col        = i % CITY_COLS
+          const row        = Math.floor(i / cityCols)
+          const col        = i % cityCols
           const district   = getRowDistrict(city, row)
           const distColor  = DISTRICT_INFO[district]?.color ?? 'transparent'
           const isRowStart = col === 0
@@ -219,7 +220,7 @@ export function CityGrid({
           const rage            = 100 - happiness
           const wantedNeighbour = w.affinityWith ?? w.unitName
           const gridRows        = city.rows ?? CITY_ROWS
-          const wantsFriend     = !getNeighbourIndices(w.cellIndex, gridRows).some(ni => {
+          const wantsFriend     = !getNeighbourIndices(w.cellIndex, gridRows, city.cols ?? CITY_COLS).some(ni => {
             const nc = city.grid[ni]
             return nc?.spawnedUnitName === wantedNeighbour && (city.happiness[ni] ?? 100) > 0
           })

--- a/web/src/components/minigames/citybuilder/DisasterModal.tsx
+++ b/web/src/components/minigames/citybuilder/DisasterModal.tsx
@@ -21,6 +21,7 @@ function fmtElapsed(ms: number): string {
 export function DisasterModal({ city, disaster, onExtinguish, onCure, onClose }: Props) {
   const { type, affectedCells, startedAt, severity } = disaster
   const elapsed = Date.now() - startedAt
+  const cityCols = city.cols ?? CITY_COLS
 
   const isFire    = type === 'fire'
   const woodCost  = fireExtinguishCost(city)
@@ -36,7 +37,7 @@ export function DisasterModal({ city, disaster, onExtinguish, onCure, onClose }:
   }).length
   const braveDiscount    = affectedCells.length * 40 - woodCost
   const isIndustrialFire = affectedCells.some(
-    ci => getRowDistrict(city, Math.floor(ci / CITY_COLS)) === 'industrial',
+    ci => getRowDistrict(city, Math.floor(ci / cityCols)) === 'industrial',
   )
 
   // ── Plague context ────────────────────────────────────────────────────────────
@@ -47,7 +48,7 @@ export function DisasterModal({ city, disaster, onExtinguish, onCure, onClose }:
     if (cell?.spawnedUnitName) {
       totalSpawners++
       const trait = getCellTrait(cell, i)
-      if (getRowDistrict(city, Math.floor(i / CITY_COLS)) === 'military') militarySpawners++
+      if (getRowDistrict(city, Math.floor(i / cityCols)) === 'military') militarySpawners++
       if (trait === 'glutton')  gluttonCount++
       if (trait === 'sociable') sociableCount++
     }

--- a/web/src/components/minigames/citybuilder/Fortifications.tsx
+++ b/web/src/components/minigames/citybuilder/Fortifications.tsx
@@ -47,6 +47,7 @@ export function Fortifications({
     (s, f) => s + Math.round(FORT_DEFENSE[f.rarity] * (f.hp / f.maxHp)), 0
   )
   const cityRows = city.rows ?? CITY_ROWS
+  const cityCols = city.cols ?? CITY_COLS
 
   const fortSlots: FortSlot[] = Array.from({ length: MAX_TOTAL_FORTS }, (_, i) => {
     if (i < city.fortifications.length)
@@ -91,7 +92,7 @@ export function Fortifications({
                 onClick={() => setFortSlotSel(idx)}
               />
             ))}
-            <CityThumbnail grid={city.grid.map(c => c ?? null)} cols={CITY_COLS} rows={cityRows} />
+            <CityThumbnail grid={city.grid.map(c => c ?? null)} cols={cityCols} rows={cityRows} />
           </div>
 
           {/* Builder walkers overlay */}

--- a/web/src/components/minigames/citybuilder/ResourceStrip.stories.tsx
+++ b/web/src/components/minigames/citybuilder/ResourceStrip.stories.tsx
@@ -15,7 +15,7 @@ const emptyResources = { wheat: 0, wood: 0, ore: 0, bread: 0, planks: 0, metal: 
 function stubCity(resources = emptyResources): CityState {
   return {
     grid: [], gold: 0, resources, lastTick: Date.now(),
-    happiness: {}, rows: 4,
+    happiness: {}, rows: 4, cols: 4,
     nextAttackAt: Date.now() + 3_600_000,
     fortifications: [], builderQueue: [], builderCount: 2,
     lastAttack: null, chronicle: [], completedMilestones: [],

--- a/web/src/components/minigames/citybuilder/StatsScreen.stories.tsx
+++ b/web/src/components/minigames/citybuilder/StatsScreen.stories.tsx
@@ -19,6 +19,7 @@ function makeCity(history: HistorySample[]): CityState {
     lastTick:            Date.now(),
     happiness:           {},
     rows:                4,
+    cols:                4,
     nextAttackAt:        Date.now() + 3_600_000,
     fortifications:      [],
     builderQueue:        [],

--- a/web/src/components/minigames/citybuilder/walkerTypes.ts
+++ b/web/src/components/minigames/citybuilder/walkerTypes.ts
@@ -96,10 +96,11 @@ export function getUnitRequirements(
 ): { text: string; met: boolean }[] {
   const reqs: { text: string; met: boolean }[] = []
   const gridRows = cityState.rows ?? CITY_ROWS
+  const gridCols = cityState.cols ?? CITY_COLS
 
   const wantedNeighbour = cell.affinityWith ?? cell.spawnedUnitName
   if (wantedNeighbour) {
-    const neighbourMet = getNeighbourIndices(cellIndex, gridRows).some(ni => {
+    const neighbourMet = getNeighbourIndices(cellIndex, gridRows, gridCols).some(ni => {
       const nc = cityState.grid[ni]
       return nc?.spawnedUnitName === wantedNeighbour && (cityState.happiness[ni] ?? 100) > 0
     })

--- a/web/src/components/minigames/citybuilder/walkerTypes.ts
+++ b/web/src/components/minigames/citybuilder/walkerTypes.ts
@@ -48,7 +48,7 @@ export interface Walker {
   hidden:       boolean
   hiddenTimer:  number
   trait:        PersonalityTrait
-  waypoints:    { x: number; y: number }[]
+  waypoints:    { x: number; y: number; speed?: number }[]
 }
 
 export interface ResidentThought {

--- a/web/src/game/cityBuilder.ts
+++ b/web/src/game/cityBuilder.ts
@@ -309,7 +309,7 @@ const CARRIER_BASE_SPEED    = 2.5   // cells per minute on grass (faster = short
 const ROAD_WEAR_PER_CARRIER = 0.4   // wear added per carrier per minute
 export const PER_CELL_STOCK_CAP = 50    // max units any single cell can stockpile of one resource
 export const ROAD_TIER_THRESHOLDS = [25, 60] as const  // tier 1 at 25, tier 2 at 60
-const ROAD_SPEED_MULT = [1.0, 1.4, 2.0]  // multiplier per road tier
+export const ROAD_SPEED_MULT = [1.0, 1.4, 2.0]  // multiplier per road tier
 
 /** Per-edge road wear. h[i] = right edge of cell i; v[i] = bottom edge of cell i. */
 export interface RoadWearMap { h: number[]; v: number[] }
@@ -330,6 +330,51 @@ function cellManhattan(a: number, b: number, cols: number): number {
 // Road tier 0/1/2 from wear score
 export function roadTier(wear: number): 0 | 1 | 2 {
   return wear >= ROAD_TIER_THRESHOLDS[1] ? 2 : wear >= ROAD_TIER_THRESHOLDS[0] ? 1 : 0
+}
+
+/** Dijkstra's shortest-time path through the road wear graph.
+ *  Cost of each edge = 1 / ROAD_SPEED_MULT[roadTier(wear)], so better roads are cheaper. */
+export function findFastestPath(
+  from: number, to: number,
+  roadWear: RoadWearMap,
+  cols: number, rows: number,
+): number[] {
+  if (from === to) return [from]
+  const n = cols * rows
+  const dist    = new Float32Array(n).fill(Infinity)
+  const prev    = new Int16Array(n).fill(-1)
+  const visited = new Uint8Array(n)
+  dist[from] = 0
+  const queue = new Set<number>([from])
+
+  while (queue.size > 0) {
+    let u = -1, minD = Infinity
+    for (const c of queue) { if (dist[c] < minD) { minD = dist[c]; u = c } }
+    queue.delete(u)
+    if (u === to) break
+    if (visited[u]) continue
+    visited[u] = 1
+
+    const row = Math.floor(u / cols)
+    const col = u % cols
+    const tryN = (v: number, lo: number, hi: number) => {
+      if (visited[v]) return
+      const wear  = hi === lo + 1 ? (roadWear.h[lo] ?? 0) : (roadWear.v[lo] ?? 0)
+      const cost  = 1 / ROAD_SPEED_MULT[roadTier(wear)]
+      const alt   = dist[u] + cost
+      if (alt < dist[v]) { dist[v] = alt; prev[v] = u; queue.add(v) }
+    }
+    if (col < cols - 1) tryN(u + 1,    u,        u + 1)
+    if (col > 0)        tryN(u - 1,    u - 1,    u)
+    if (row < rows - 1) tryN(u + cols, u,        u + cols)
+    if (row > 0)        tryN(u - cols, u - cols, u)
+  }
+
+  if (dist[to] === Infinity) return [from, to]
+  const path: number[] = []
+  let cur = to
+  while (cur !== -1) { path.unshift(cur); cur = prev[cur] }
+  return path
 }
 
 // Centre pixel of a cell in the overlay (for carrier rendering)

--- a/web/src/game/cityBuilder.ts
+++ b/web/src/game/cityBuilder.ts
@@ -378,13 +378,13 @@ export function findFastestPath(
 }
 
 // Centre pixel of a cell in the overlay (for carrier rendering)
-export function cellCenter(idx: number, rows: number): { x: number; y: number } {
-  const gridRows = rows
-  const col = idx % CITY_COLS
-  const row = Math.floor(idx / CITY_COLS)
+export function cellCenter(idx: number, rows: number, cols?: number): { x: number; y: number } {
+  const gridCols = cols ?? CITY_COLS
+  const col = idx % gridCols
+  const row = Math.floor(idx / gridCols)
   return {
     x: (col + 0.5) * CELL_PX,
-    y: (row + 0.5) * CELL_PX * (gridRows / CITY_ROWS),
+    y: (row + 0.5) * CELL_PX * (rows / CITY_ROWS),
   }
 }
 
@@ -649,7 +649,8 @@ export function getCellSynergyBonuses(
   const cell = state.grid[cellIndex]
   if (!cell) return []
   const gridRows = state.rows ?? CITY_ROWS
-  const neighbours = getNeighbourIndices(cellIndex, gridRows)
+  const gridCols = state.cols ?? CITY_COLS
+  const neighbours = getNeighbourIndices(cellIndex, gridRows, gridCols)
     .map(ni => state.grid[ni])
     .filter((nb): nb is CityCell => nb != null)
   const produces = getBuildingProduces(cell.cardName)
@@ -672,7 +673,8 @@ export function getCellIncomeBonus(state: CityState, cellIndex: number): number 
   const cell = state.grid[cellIndex]
   if (!cell?.spawnedUnitName) return 0
   const gridRows = state.rows ?? CITY_ROWS
-  const hasFoodNeighbour = getNeighbourIndices(cellIndex, gridRows).some(ni => {
+  const gridCols = state.cols ?? CITY_COLS
+  const hasFoodNeighbour = getNeighbourIndices(cellIndex, gridRows, gridCols).some(ni => {
     const nb = state.grid[ni]
     return nb && (getBuildingProduces(nb.cardName).wheat ?? 0) > 0
   })
@@ -748,6 +750,8 @@ export interface CityState {
   happiness:      Record<number, number>
   /** Dynamic grid height; starts at CITY_ROWS (4). */
   rows:           number
+  /** Dynamic grid width; starts at CITY_ROWS (matching rows for a square grid). */
+  cols:           number
   /** Timestamp when the next attack will occur. */
   nextAttackAt:   number
   /** Wall/moat fortifications outside the building grid. */
@@ -801,6 +805,7 @@ function defaultState(): CityState {
     // cardLevels:     {},
     happiness:      {},
     rows:           CITY_ROWS,
+    cols:           CITY_ROWS,
     nextAttackAt:   Date.now() + BASE_ATTACK_INTERVAL_MS + Math.random() * ATTACK_INTERVAL_JITTER_MS,
     fortifications: [],
     builderQueue:   [],
@@ -827,7 +832,8 @@ export function loadCityState(): CityState {
     const parsed = JSON.parse(raw) as Partial<CityState>
     const savedResources = (parsed.resources ?? {}) as Partial<ResourceStock>
     const rows = parsed.rows ?? CITY_ROWS
-    const cells = CITY_COLS * rows
+    const cols = parsed.cols ?? CITY_COLS
+    const cells = cols * rows
     const savedGrid = parsed.grid ?? Array(cells).fill(undefined)
     const grid = (savedGrid.length < cells
       ? [...savedGrid, ...Array(cells - savedGrid.length).fill(undefined)]
@@ -848,6 +854,7 @@ export function loadCityState(): CityState {
       // cardLevels:     parsed.cardLevels ?? {},
       happiness:      parsed.happiness  ?? {},
       rows,
+      cols,
       nextAttackAt:   parsed.nextAttackAt ?? Date.now() + BASE_ATTACK_INTERVAL_MS,
       fortifications: (parsed.fortifications ?? []).map(f => ({
         ...f,
@@ -952,8 +959,8 @@ export const MILESTONES: MilestoneDef[] = [
   },
   {
     id: 'max_expansion', label: 'Metropolis', icon: '🏙',
-    description: `Expand the city to ${MAX_CITY_ROWS} rows`,
-    condition: s => (s.rows ?? CITY_ROWS) >= MAX_CITY_ROWS,
+    description: `Expand the city to a ${MAX_CITY_ROWS}×${MAX_CITY_ROWS} grid`,
+    condition: s => (s.rows ?? CITY_ROWS) >= MAX_CITY_ROWS && (s.cols ?? CITY_COLS) >= MAX_CITY_ROWS,
     goldReward: 50000,
   },
 ]
@@ -1035,16 +1042,16 @@ export function isDefenceCard(cardName: string, isSpawner: boolean): boolean {
 }
 
 /** Returns grid indices of the 4 orthogonally adjacent cells (no diagonals, no wrap). */
-export function getNeighbourIndices(index: number, rows?: number): number[] {
+export function getNeighbourIndices(index: number, rows?: number, cols?: number): number[] {
   const gridRows = rows ?? CITY_ROWS
-  const cols = CITY_COLS
-  const row = Math.floor(index / cols)
-  const col = index % cols
+  const gridCols = cols ?? CITY_COLS
+  const row = Math.floor(index / gridCols)
+  const col = index % gridCols
   const result: number[] = []
-  if (col > 0)          result.push(index - 1)
-  if (col < cols - 1)   result.push(index + 1)
-  if (row > 0)          result.push(index - cols)
-  if (row < gridRows-1) result.push(index + cols)
+  if (col > 0)             result.push(index - 1)
+  if (col < gridCols - 1)  result.push(index + 1)
+  if (row > 0)             result.push(index - gridCols)
+  if (row < gridRows - 1)  result.push(index + gridCols)
   return result
 }
 
@@ -1066,12 +1073,13 @@ function wallDefense(cell: CityCell, cityHasSpawners: boolean): number {
 
 export function cityDefense(state: CityState): number {
   const hasSpawners = state.grid.some(c => c?.spawnedUnitName)
+  const defCols = state.cols ?? CITY_COLS
   let total = 0
   let militaryBonus = 0
   for (let i = 0; i < state.grid.length; i++) {
     const cell = state.grid[i]
     if (!cell) continue
-    const row = Math.floor(i / CITY_COLS)
+    const row = Math.floor(i / defCols)
     const isMilitary = getRowDistrict(state, row) === 'military'
     if (cell.spawnedUnitName) {
       const contrib = SPAWN_DEFENSE[cell.rarity]
@@ -1273,15 +1281,16 @@ function processDisaster(
     }
 
     // Industrial zones have abundant dry materials — fire spreads 40% faster there
+    const disCols = s.cols ?? CITY_COLS
     let newAffected = [...affectedCells]
-    const hasIndustrialCell = newAffected.some(ci => getRowDistrict(s, Math.floor(ci / CITY_COLS)) === 'industrial')
+    const hasIndustrialCell = newAffected.some(ci => getRowDistrict(s, Math.floor(ci / disCols)) === 'industrial')
     const spreadInterval    = hasIndustrialCell ? FIRE_SPREAD_INTERVAL_MIN * 0.6 : FIRE_SPREAD_INTERVAL_MIN
     const spreadCount       = Math.floor(elapsedMin / spreadInterval)
     while (newAffected.length < Math.min(spreadCount + 1, FIRE_MAX_CELLS)) {
       // Pick an unaffected neighbour of any burning cell
       const candidates: number[] = []
       for (const ci of newAffected) {
-        for (const ni of getNeighbourIndices(ci, s.rows ?? CITY_ROWS)) {
+        for (const ni of getNeighbourIndices(ci, s.rows ?? CITY_ROWS, s.cols ?? CITY_COLS)) {
           if (s.grid[ni] && !newAffected.includes(ni)) candidates.push(ni)
         }
       }
@@ -1312,7 +1321,7 @@ function processDisaster(
     for (let i = 0; i < s.grid.length; i++) {
       if (s.grid[i]?.spawnedUnitName) {
         totalSpawners++
-        if (getRowDistrict(s, Math.floor(i / CITY_COLS)) === 'military') militarySpawners++
+        if (getRowDistrict(s, Math.floor(i / (s.cols ?? CITY_COLS))) === 'military') militarySpawners++
       }
     }
     const milFraction = totalSpawners > 0 ? militarySpawners / totalSpawners : 0
@@ -1395,6 +1404,7 @@ export function tickCity(state: CityState, nowMs?: number): CityState {
 
   // ── Build mutable grid (copy cell stocks) ───────────────────────────────────
   const gridRows = state.rows ?? CITY_ROWS
+  const gridCols = state.cols ?? CITY_COLS
   const newGrid = state.grid.map(c => c ? { ...c, stock: { ...(c.stock ?? {}) } } : c)
   const rawRW = state.roadWear as unknown
   const rwBase: RoadWearMap = (rawRW && typeof rawRW === 'object' && !Array.isArray(rawRW))
@@ -1439,9 +1449,9 @@ export function tickCity(state: CityState, nowMs?: number): CityState {
   const arrivedIds = new Set<string>()
   const newCarriers = (state.carriers ?? []).map(c => ({ ...c }))
   for (const carrier of newCarriers) {
-    const dist = Math.max(1, cellManhattan(carrier.fromCell, carrier.toCell, CITY_COLS))
-    const speed = (CARRIER_BASE_SPEED / dist) * pathSpeedMult(carrier.fromCell, carrier.toCell, newRoadWear, CITY_COLS)
-    wearPath(carrier.fromCell, carrier.toCell, newRoadWear, CITY_COLS, ROAD_WEAR_PER_CARRIER * minutes)
+    const dist = Math.max(1, cellManhattan(carrier.fromCell, carrier.toCell, gridCols))
+    const speed = (CARRIER_BASE_SPEED / dist) * pathSpeedMult(carrier.fromCell, carrier.toCell, newRoadWear, gridCols)
+    wearPath(carrier.fromCell, carrier.toCell, newRoadWear, gridCols, ROAD_WEAR_PER_CARRIER * minutes)
     carrier.progress = Math.min(1, carrier.progress + speed * minutes)
     if (carrier.progress >= 1) {
       const dest = newGrid[carrier.toCell]
@@ -1463,7 +1473,7 @@ export function tickCity(state: CityState, nowMs?: number): CityState {
     const happy = (newHappy[i] ?? 100) > 0
     const unitCount = cell.spawnedUnitName ? spawnerUnitCount(state, cell.cardName) : 1
 
-    const cellRow      = Math.floor(i / CITY_COLS)
+    const cellRow      = Math.floor(i / gridCols)
     const cellDistrict = getRowDistrict(state, cellRow)
     const distInfo     = DISTRICT_INFO[cellDistrict]
 
@@ -1527,7 +1537,7 @@ export function tickCity(state: CityState, nowMs?: number): CityState {
     for (const [res] of Object.entries(inputNeeds) as [ResourceType, number][]) {
       if ((cell.stock[res] ?? 0) >= cellStockCap(cell) - CARRIER_LOAD) continue   // near capacity, don't overfill
       if (inFlightTo.has(`${i}-${res}`)) continue            // already fetching
-      const source = findNearestProducer(res, i, newGrid as (CityCell|undefined)[], CITY_COLS)
+      const source = findNearestProducer(res, i, newGrid as (CityCell|undefined)[], gridCols)
       if (source === null) continue
       const sourceCell = newGrid[source]!
       const load = Math.min(sourceCell.stock[res] ?? 0, CARRIER_LOAD)
@@ -1548,7 +1558,7 @@ export function tickCity(state: CityState, nowMs?: number): CityState {
       if (res === Object.keys(BUILDING_CONVERSION_COST[cell.cardName])[0]) continue  // skip input res
       if (amount < CARRIER_LOAD) continue
       if (inFlightFrom.has(`${i}-${res}`)) continue
-      const target = findNearestConsumer(res, i, newGrid as (CityCell|undefined)[], CITY_COLS)
+      const target = findNearestConsumer(res, i, newGrid as (CityCell|undefined)[], gridCols)
       if (target === null) continue
       const load = Math.min(amount, CARRIER_LOAD)
       activeCarriers.push({ id: `${Date.now()}-${carrierSeq++}-${i}-${target}-${res}`, fromCell: i, toCell: target, carrying: { [res]: load }, progress: 0 })
@@ -1566,7 +1576,7 @@ export function tickCity(state: CityState, nowMs?: number): CityState {
     for (const [res, amount] of Object.entries(cell.stock) as [ResourceType, number][]) {
       if (amount < CARRIER_LOAD) continue
       if (inFlightFrom.has(`${i}-${res}`)) continue
-      const target = findNearestConsumer(res, i, newGrid as (CityCell|undefined)[], CITY_COLS)
+      const target = findNearestConsumer(res, i, newGrid as (CityCell|undefined)[], gridCols)
       if (target === null) continue
       const load = Math.min(amount, CARRIER_LOAD)
       activeCarriers.push({ id: `${Date.now()}-${carrierSeq++}-${i}-${target}-${res}`, fromCell: i, toCell: target, carrying: { [res]: load }, progress: 0 })
@@ -1914,27 +1924,63 @@ export function canAffordExpansion(state: CityState): boolean {
 
 export function expandCity(state: CityState): CityState | null {
   const rows = state.rows ?? CITY_ROWS
+  const cols = state.cols ?? CITY_COLS
   if (rows >= MAX_CITY_ROWS) return null
   const cost = EXPANSION_COSTS[rows]
   if (!cost) return null
   if (!canAffordExpansion(state)) return null
 
   const newRows = rows + 1
-  const newCells = CITY_COLS * newRows
-  const newGrid = [...state.grid, ...Array(newCells - state.grid.length).fill(undefined)]
-  const newResources = { ...state.resources, gold: state.gold }
+  const newCols = cols < MAX_CITY_ROWS ? cols + 1 : cols
+
+  // Remap existing cells into the wider grid (insert empty column on right of each row)
+  const newGrid: (CityCell | undefined)[] = Array(newRows * newCols).fill(undefined)
+  for (let row = 0; row < rows; row++) {
+    for (let col = 0; col < cols; col++) {
+      newGrid[row * newCols + col] = state.grid[row * cols + col]
+    }
+  }
+
+  // Remap happiness keys to new cell indices
+  const newHappiness: Record<number, number> = {}
+  for (const [idxStr, h] of Object.entries(state.happiness)) {
+    const i = parseInt(idxStr)
+    const row = Math.floor(i / cols)
+    const col = i % cols
+    newHappiness[row * newCols + col] = h
+  }
+
+  // Remap road wear arrays to new cell indices
+  const oldH = state.roadWear.h
+  const oldV = state.roadWear.v
+  const newH = Array(newRows * newCols).fill(0)
+  const newV = Array(newRows * newCols).fill(0)
+  for (let row = 0; row < rows; row++) {
+    for (let col = 0; col < cols; col++) {
+      const oldIdx = row * cols + col
+      const newIdx = row * newCols + col
+      newH[newIdx] = oldH[oldIdx] ?? 0
+      newV[newIdx] = oldV[oldIdx] ?? 0
+    }
+  }
+
+  const newResources = { ...state.resources }
   for (const [res, amt] of Object.entries(cost.resources) as [ResourceType, number][]) {
     newResources[res] = Math.max(0, (state.resources[res] ?? 0) - amt)
   }
 
-  const next = {
+  const next: CityState = {
     ...state,
     rows:      newRows,
+    cols:      newCols,
     grid:      newGrid,
     gold:      state.gold - cost.gold,
     resources: newResources,
+    happiness: newHappiness,
+    roadWear:  { h: newH, v: newV },
+    carriers:  [],
   }
-  return addChronicleEvent(next, `🏙 City expanded to ${newRows} rows`)
+  return addChronicleEvent(next, `🏙 City expanded to ${newRows}×${newCols}`)
 }
 
 // ── Affordability ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

### Walker road-speed pathfinding (Dijkstra's)
- Adds `findFastestPath` (Dijkstra's) to `cityBuilder.ts` — walkers pick the route with the lowest travel time, weighing each edge by road tier (`grass=1.0×`, `path=1.4×`, `road=2.0×`)
- Extends `Walker.waypoints` with an optional `speed` field; each waypoint carries the movement multiplier for that edge
- `computeRoadWaypoints` routes walkers through cell centres respecting road wear; falls back to straight-line when no wear data exists
- Walker movement multiplies base `SPEED` by the current waypoint's speed → walkers visibly accelerate on worn roads

Because walkers preferentially travel on high-wear edges, those edges accumulate wear faster. Edges avoided decay back to grass — roads emerge organically from usage patterns.

### Always-square grid expansion
- Adds `cols` field to `CityState` — new cities start at `CITY_ROWS×CITY_ROWS` (4×4); old saves default to `CITY_COLS` (6) for backward compatibility
- `expandCity` now adds 1 row **and** 1 column simultaneously, with full remapping of grid, happiness, and road wear arrays so existing cell indices stay correct; in-flight carriers are cleared on expansion
- `getNeighbourIndices` and `cellCenter` accept an optional `cols` param; all callers pass `state.cols`
- Walker waypoint functions, task picker, carrier visuals, and animation loop all use dynamic `cityCols`
- Metropolis milestone now requires both max rows and max cols; expansion tooltip shows new `N×N` dimensions

## Test plan
- [ ] Place two buildings across the grid, watch walkers route and accelerate along worn paths
- [ ] Confirm road wear decays on unused edges over time
- [ ] Expand city and verify grid grows by 1 row and 1 column each time (e.g. 4×4 → 5×5)
- [ ] Verify existing buildings remain in correct positions after expansion
- [ ] Load an old save (6-col layout) and confirm it still renders correctly
- [ ] Verify no TypeScript errors (`npx tsc --noEmit`)

https://claude.ai/code/session_01QoP8jPH6TsU5QUWDguGVYx