### PR TITLE
Fix walker idle movement to follow grid gaps (no diagonal wandering)

### DIFF
--- a/web/src/components/minigames/CityBuilder.tsx
+++ b/web/src/components/minigames/CityBuilder.tsx
@@ -312,6 +312,8 @@ const UNIT_SIZE = 20
 const SPEED = 0.8
 const ARRIVE_DIST = 14   // pixels — close enough to count as "arrived"
 const IDLE_TASK_TICKS = 80   // ~8 s of random wandering before picking a new task
+const IDLE_WANDER_TICKS_MIN = 20  // ticks between wander cell picks
+const IDLE_WANDER_TICKS_RANGE = 30
 const REST_TICKS_MIN = 4 * IDLE_TASK_TICKS   // ~32 s — at least 4 task cycles at home
 const REST_TICKS_MAX = 7 * IDLE_TASK_TICKS   // ~56 s
 const BUBBLE_TICKS = 30   // 3 s — how long a task bubble stays visible
@@ -896,6 +898,38 @@ export function CityBuilder({ onBack }: Props) {
               if (task.type !== 'idle') bubbleTimer = BUBBLE_TICKS
               waypoints = wayptsFor(task, x, y)
             }
+            // Grid-following wander: navigate to a random adjacent cell via gap waypoints
+            if (task.type === 'idle') {
+              if (waypoints.length > 0) {
+                // Follow current wander path
+                const next = waypoints[0]
+                const dx = next.x - x, dy = next.y - y
+                const dist = Math.sqrt(dx * dx + dy * dy)
+                if (dist < ARRIVE_DIST) {
+                  waypoints = waypoints.slice(1)
+                  turnTimer = 0  // immediately pick next cell
+                } else {
+                  vx = (dx / dist) * SPEED
+                  vy = (dy / dist) * SPEED
+                }
+              }
+              if (waypoints.length === 0) {
+                turnTimer--
+                if (turnTimer <= 0) {
+                  const cellW = overlayW / cityCols
+                  const cellH = overlayH / cityRows
+                  const cc = Math.max(0, Math.min(cityRows - 1, Math.floor(y / cellH))) * cityCols +
+                             Math.max(0, Math.min(cityCols - 1, Math.floor(x / cellW)))
+                  const ns = getNeighbourIndices(cc, cityRows, cityCols)
+                  const pick = ns[Math.floor(Math.random() * ns.length)] ?? cc
+                  const tx = (pick % cityCols + 0.5) * cellW
+                  const ty = (Math.floor(pick / cityCols) + 0.5) * cellH
+                  const wps = computeWaypoints(x, y, tx, ty, overlayW, overlayH, cityRows, cityCols)
+                  waypoints = wps.length > 0 ? wps : [{ x: tx, y: ty }]
+                  turnTimer = IDLE_WANDER_TICKS_MIN + Math.floor(Math.random() * IDLE_WANDER_TICKS_RANGE)
+                }
+              }
+            }
           }
 
           // ── Directed movement (waypoint-following) ─────────────────────────
@@ -946,17 +980,6 @@ export function CityBuilder({ onBack }: Props) {
           if (x > overlayW - UNIT_SIZE) { x = overlayW - UNIT_SIZE; vx = -Math.abs(vx) }
           if (y < 0) { y = 0; vy = Math.abs(vy) }
           if (y > overlayH - UNIT_SIZE) { y = overlayH - UNIT_SIZE; vy = -Math.abs(vy) }
-
-          // Random direction changes for idle wandering only
-          if (task.type === 'idle') {
-            turnTimer--
-            if (turnTimer <= 0) {
-              const angle = Math.random() * Math.PI * 2
-              vx = Math.cos(angle) * SPEED
-              vy = Math.sin(angle) * SPEED
-              turnTimer = 20 + Math.floor(Math.random() * 30)
-            }
-          }
 
           return { ...w, x, y, vx, vy, turnTimer, task, taskTimer, bubbleTimer, waypoints }
         })

--- a/web/src/components/minigames/CityBuilder.tsx
+++ b/web/src/components/minigames/CityBuilder.tsx
@@ -22,7 +22,7 @@ import {
   addFortification, removeFortification,
   expandCity, canAffordExpansion,
   goldIncomeRate, goldNetRate,
-  cityDefense, cityPopulation,
+  cityDefense, cityPopulation, getCityFoodScore,
   canAffordPlacement,
   resourceProductionRate, resourceConsumptionRate,
   levelUpCost, levelUpCard,
@@ -105,9 +105,10 @@ function buildResidentThoughts(
 ): ResidentThought[] {
   const thoughts: ResidentThought[] = []
   const pop = Math.max(population, 1)
-  const foodScore = Math.min(100, (city.resources.wheat / pop) * 5)
+  const foodScore = getCityFoodScore(city)
   const defenseScore = Math.min(100, (cityDefense(city) / pop) * 8)
   const gridRows = city.rows ?? CITY_ROWS
+  const gridCols = city.cols ?? CITY_COLS
 
   for (let i = 0; i < city.grid.length; i++) {
     const cell = city.grid[i]
@@ -123,7 +124,7 @@ function buildResidentThoughts(
       let happy = true
 
       const wantedNeighbour = cell.affinityWith ?? cell.spawnedUnitName
-      const neighbourMet = getNeighbourIndices(i, gridRows).some(ni => {
+      const neighbourMet = getNeighbourIndices(i, gridRows, gridCols).some(ni => {
         const nc = city.grid[ni]
         return nc?.spawnedUnitName === wantedNeighbour && (city.happiness[ni] ?? 100) > 0
       })


### PR DESCRIPTION
## Summary

- Idle walkers previously chose random angles (including diagonals), making residents appear to walk straight through buildings
- Replaced the random-angle turn timer with waypoint-based cell-hopping: each wander tick picks a random adjacent cell and calls `computeWaypoints` to route through the gap between cells
- Added `IDLE_WANDER_TICKS_MIN` / `IDLE_WANDER_TICKS_RANGE` constants to control wander pace
- ALL walker movement (idle and directed) now stays axis-aligned and follows the visual road network

## Test plan

- [ ] Watch idle residents wander — they should move along cell edges (H/V only), not diagonally
- [ ] Watch directed tasks (eating, patrolling, gathering) — walkers should take L-shaped paths through gaps
- [ ] Confirm walkers don't get stuck at boundaries

https://claude.ai/code/session_01QoP8jPH6TsU5QUWDguGVYx

---
_Generated by [Claude Code](https://claude.ai/code/session_01QoP8jPH6TsU5QUWDguGVYx)_