### PR TITLE
fix: axis-aligned road following + idle walkers stay on roads

### DIFF
--- a/web/src/components/minigames/CityBuilder.tsx
+++ b/web/src/components/minigames/CityBuilder.tsx
@@ -935,8 +935,14 @@ export function CityBuilder({ onBack }: Props) {
                              Math.max(0, Math.min(cityCols - 1, Math.floor(x / cellW)))
                   const ns = getNeighbourIndices(cc, cityRows, cityCols)
                   const pick = ns[Math.floor(Math.random() * ns.length)] ?? cc
-                  const tx = (pick % cityCols + 0.5) * cellW
-                  const ty = (Math.floor(pick / cityCols) + 0.5) * cellH
+                  const ccCol = cc % cityCols, ccRow = Math.floor(cc / cityCols)
+                  // Target the road gap (border midpoint between current cell and neighbour)
+                  // so idle walkers stay on roads rather than parking in cell centres.
+                  let tx: number, ty: number
+                  if      (pick === cc + 1)           { tx = (ccCol + 1) * cellW; ty = (ccRow + 0.5) * cellH }
+                  else if (pick === cc - 1)            { tx =  ccCol      * cellW; ty = (ccRow + 0.5) * cellH }
+                  else if (pick === cc + cityCols)     { tx = (ccCol + 0.5) * cellW; ty = (ccRow + 1) * cellH }
+                  else                                 { tx = (ccCol + 0.5) * cellW; ty =  ccRow      * cellH }
                   const rw = (cityRef.current?.roadWear as RoadWearMap | undefined) ?? { h: [], v: [] }
                   const wps = computeRoadWaypoints(x, y, tx, ty, overlayW, overlayH, cityRows, rw, cityCols)
                   waypoints = wps.length > 0 ? wps : [{ x: tx, y: ty }]


### PR DESCRIPTION
## Summary

- **Axis-aligned road following**: Rewrote `computeRoadWaypoints` so every movement segment is axis-aligned. Going right/left keeps Y constant until the walker reaches the vertical road gap (`x = col×cellW`); going up/down keeps X constant until the horizontal road gap (`y = row×cellH`). Turns happen at road junctions. Applied to residents, idle walkers, and carriers.
- **Walkers stay on roads when idle**: Idle wander targets are now the border midpoint between the current cell and the chosen neighbour (the road gap itself), not the cell centre. Walkers pause on the road between wanders instead of parking in the middle of a cell.

## Test plan

- [ ] Observe residents walking between buildings — movement should be axis-aligned (horizontal then vertical, no diagonals), turning at road junctions
- [ ] Idle walkers should never be visibly stationary in the centre of a cell — they should be on or near road gaps when pausing
- [ ] Carriers (resource delivery) should also follow road gaps between cells
- [ ] Verify walkers correctly enter buildings (cell interiors) as the final step of directed tasks (eating, gathering, resting)

https://claude.ai/code/session_01QoP8jPH6TsU5QUWDguGVYx

---
_Generated by [Claude Code](https://claude.ai/code/session_01QoP8jPH6TsU5QUWDguGVYx)_