### PR TITLE
feat: watchtower defense, mastery scaling, cheaper upgrades, richer inspect modal

### DIFF
--- a/web/src/components/minigames/citybuilder/BuildingInspectModal.tsx
+++ b/web/src/components/minigames/citybuilder/BuildingInspectModal.tsx
@@ -2,9 +2,9 @@ import React from 'react'
 import {
   CityState, CityCell, RESOURCE_ICONS, ResourceType,
   getBuildingProduces, getBuildingConsumes, masteryOutputMultiplier, getCardMasteryLevel,
-  levelUpCost, LEVEL_UP_COSTS, spawnerUnitCount,
+  levelUpCost, LEVEL_UP_COSTS, WATCHTOWER_LEVEL_UP_COSTS, spawnerUnitCount,
   getCellSynergyBonuses, getCellIncomeBonus,
-  cellStockCap,
+  cellStockCap, getCellDefenseContrib, INCOME_WALL, CORE_BUILDINGS,
 } from '../../../game/cityBuilder'
 import { CollectionEntry, getMasteryXp, masteryProgress } from '../../../game/collection'
 import { MasteryBar } from '../../ui/MasteryBar'
@@ -43,8 +43,11 @@ export function BuildingInspectModal({
   const incomeBonus    = getCellIncomeBonus(city, cellIndex)
   const xp             = getMasteryXp(collection, cell.cardName)
   const { level: mLvl } = masteryProgress(xp)
-  const upgradeCost    = levelUpCost(mLvl)
+  const upgradeCost    = levelUpCost(mLvl, cell.cardName)
   const canAfford      = city.gold >= upgradeCost
+  const levelUpCosts   = cell.cardName === 'Watchtower' ? WATCHTOWER_LEVEL_UP_COSTS : LEVEL_UP_COSTS
+  const defenseContrib = getCellDefenseContrib(cell, city)
+  const coreHint       = CORE_BUILDINGS.find(b => b.name === cell.cardName)?.hint
 
   return (
     <div className="city-req-overlay" onClick={onClose}>
@@ -172,7 +175,26 @@ export function BuildingInspectModal({
               )}
             </>
           ) : (
-            <div className="city-bld-section-title">Defensive structure</div>
+            <>
+              {coreHint && <div className="city-bld-hint">{coreHint}</div>}
+              {defenseContrib > 0 && (
+                <>
+                  <div className="city-bld-section-title">Defense contribution</div>
+                  <div className="city-bld-produces-row">⚔ +{defenseContrib} defense</div>
+                  {mLvl < levelUpCosts.length && (
+                    <div className="city-bld-produces-row city-synergy-label">
+                      Upgrade to ★{mLvl + 1} → ⚔ +{Math.round(defenseContrib * 2)} defense
+                    </div>
+                  )}
+                </>
+              )}
+              {INCOME_WALL[cell.rarity] > 0 && (
+                <>
+                  <div className="city-bld-section-title">Income</div>
+                  <div className="city-bld-produces-row">+{INCOME_WALL[cell.rarity]} 💰/min</div>
+                </>
+              )}
+            </>
           )
         )}
 
@@ -184,7 +206,7 @@ export function BuildingInspectModal({
               Next upgrade: <span className="city-gold">⚙ {upgradeCost.toLocaleString()}</span> → ★{mLvl + 1}
             </div>
             <div className="city-level-costs-table u-col u-gap-2">
-              {LEVEL_UP_COSTS.map((c, i) => (
+              {levelUpCosts.map((c, i) => (
                 <div key={i} className={`city-cost-row${i < mLvl ? ' city-cost-row--done' : ''}`}>
                   <span>★{i} → ★{i + 1}</span>
                   <span>⚙ {c.toLocaleString()}</span>

--- a/web/src/components/minigames/citybuilder/BuildingUpgradeList.tsx
+++ b/web/src/components/minigames/citybuilder/BuildingUpgradeList.tsx
@@ -76,7 +76,7 @@ export function BuildingUpgradeList({
                 {group.cards.map(card => {
                   const xp        = getMasteryXp(collection, card.name)
                   const mLvl      = masteryLevel(xp)
-                  const cost      = levelUpCost(mLvl)
+                  const cost      = levelUpCost(mLvl, card.name)
                   const canAfford = city.gold >= cost
                   return (
                     <button

--- a/web/src/components/minigames/citybuilder/LevelUpDetail.tsx
+++ b/web/src/components/minigames/citybuilder/LevelUpDetail.tsx
@@ -16,7 +16,7 @@ export interface Props {
 export function LevelUpDetail({ levelCard, card, city, onBack, onLevelUp }: Props) {
   const xp               = getMasteryXp(loadCollection(), levelCard)
   const { level: mLvl }  = masteryProgress(xp)
-  const cost             = levelUpCost(mLvl)
+  const cost             = levelUpCost(mLvl, levelCard)
 
   return (
     <div className="city-screen u-relative u-col u-gap-2">

--- a/web/src/game/cityBuilder.ts
+++ b/web/src/game/cityBuilder.ts
@@ -34,11 +34,15 @@ const HAPPINESS_DRAIN = 0.07
 
 /** Level-up costs: index = target level (1-based). Beyond the table, the last entry repeats. */
 export const LEVEL_UP_COSTS = [50000, 100000, 250000, 500000, 1000000]
+/** Cheaper upgrade costs for Watchtower — early-game defensive building meant to be temporary. */
+export const WATCHTOWER_LEVEL_UP_COSTS = [500, 2500, 8000, 25000, 100000]
 
 // ── Resource constants ────────────────────────────────────────────────────────
 
 /** Defence value contributed by walls (per rarity). */
 const WALL_DEFENSE: Record<CardRarity, number> = { common: 5, uncommon: 10, rare: 20, epic: 30, legendary: 40, mythic: 60, shiny: 40, holofoil: 40, glass: 40 }
+/** Base defense for a Watchtower — higher than a generic common wall since it is purpose-built for defence. */
+const WATCHTOWER_BASE_DEFENSE = 15
 /** Defence value contributed by spawn buildings (per rarity) — intentionally small; fortifications carry the load. */
 const SPAWN_DEFENSE: Record<CardRarity, number> = { common: 1, uncommon: 2, rare: 3, epic: 4, legendary: 5, mythic: 6, shiny: 5, holofoil: 5, glass: 5 }
 
@@ -1063,10 +1067,21 @@ function cellIncomeRate(cell: CityCell, happy: boolean, unitCount: number): numb
   return INCOME_UTILITY[cell.rarity]
 }
 
-/** Defence value a wall contributes (full if city has any spawners, half otherwise). */
+/** Defence value a wall contributes. Mastery scales the contribution; Watchtower has a higher base. */
 function wallDefense(cell: CityCell, cityHasSpawners: boolean): number {
-  const base = WALL_DEFENSE[cell.rarity]
-  return cityHasSpawners ? Math.round(base * 1.5) : base
+  const base    = cell.cardName === 'Watchtower' ? WATCHTOWER_BASE_DEFENSE : WALL_DEFENSE[cell.rarity]
+  const mastery = masteryOutputMultiplier(getCardMasteryLevel(cell.cardName))
+  const scaled  = Math.round(base * mastery)
+  return cityHasSpawners ? Math.round(scaled * 1.5) : scaled
+}
+
+/** Defense contributed by a single grid cell at its current mastery level. */
+export function getCellDefenseContrib(cell: CityCell, state: CityState): number {
+  if (cell.spawnedUnitName) return SPAWN_DEFENSE[cell.rarity]
+  const produces = getBuildingProduces(cell.cardName)
+  if (Object.values(produces).some(v => (v ?? 0) > 0)) return 0
+  const hasSpawners = state.grid.some(c => c?.spawnedUnitName)
+  return wallDefense(cell, hasSpawners)
 }
 
 // ── City aggregate stats ──────────────────────────────────────────────────────
@@ -2014,7 +2029,7 @@ export const CORE_BUILDINGS: CoreBuilding[] = [
   { name: 'Windmill',   goldCost:  500, rarity: 'common',   hint: 'Grinds wheat into bread (2/min). Needs 2 wheat/min — output ×1.5 next to a Farm.' },
   { name: 'Bakery',     goldCost:  750, rarity: 'uncommon', hint: 'Bakes bread directly (1.5/min). No wheat cost — pure gold investment.' },
   { name: 'Warehouse',  goldCost:  600, rarity: 'common',   hint: 'Extends all resource storage caps by 200.' },
-  { name: 'Watchtower', goldCost:  800, rarity: 'common',   hint: 'Garrisoned lookout. Contributes to city defense.' },
+  { name: 'Watchtower', goldCost:  800, rarity: 'common',   hint: 'Garrisoned lookout. Strong early defense (+15, scales with upgrades). Cheap to upgrade — but replace it once your city grows.' },
   { name: 'Quarry',     goldCost:  700, rarity: 'common',   hint: 'Mines raw ore and cuts stone into planks.' },
 ]
 
@@ -2144,13 +2159,14 @@ export function getCardLevel(state: CityState, cardName: string): number {
   return getCardMasteryLevel(cardName) ?? 0
 }
 
-export function levelUpCost(currentLevel: number): number {
-  return LEVEL_UP_COSTS[Math.min(currentLevel, LEVEL_UP_COSTS.length - 1)]
+export function levelUpCost(currentLevel: number, cardName?: string): number {
+  const costs = cardName === 'Watchtower' ? WATCHTOWER_LEVEL_UP_COSTS : LEVEL_UP_COSTS
+  return costs[Math.min(currentLevel, costs.length - 1)]
 }
 
 export function levelUpCard(state: CityState, cardName: string, masteryLvl: number): CityState | null {
   const current = getCardLevel(state, cardName)
-  const cost    = levelUpCost(masteryLvl)
+  const cost    = levelUpCost(masteryLvl, cardName)
   if (state.gold < cost) return null
   return {
     ...state,

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -10565,6 +10565,7 @@ html.light-mode .action-btn {
 }
 
 .city-bld-section-title { font-size: 10px; color: #609060; letter-spacing: 1px; text-transform: uppercase; align-self: flex-start; }
+.city-bld-hint { font-size: 10px; color: #80a080; font-style: italic; line-height: 1.4; }
 .city-bld-vacant        { font-size: 10px; color: #606060; font-style: italic; }
 .city-bld-vacant-section { display: flex; flex-direction: column; gap: 6px; width: 100%; }
 .city-bld-vacant-reasons { display: flex; flex-direction: column; gap: 3px; }


### PR DESCRIPTION
## Summary

- **Higher defense**: Watchtower base defense raised from 5 → 15. It's a purpose-built defensive structure so should clearly outperform any generic common wall card
- **Mastery scaling**: Wall defense (all wall-type buildings, including Watchtower) now scales with `masteryOutputMultiplier` — each upgrade level doubles the defense contribution. Previously upgrading a wall building did nothing
- **Cheaper upgrades**: Watchtower costs `[500, 2.5K, 8K, 25K, 100K]` gold to upgrade vs the standard `[50K, 100K, 250K, 500K, 1M]`. Early levels are affordable from the start; later levels scale up to justify eventually replacing it
- **Richer modal**: Tapping a Watchtower (or any pure-defense building) now shows its hint text, current defense contribution, a preview of what upgrading to the next level would give, and any gold income

## Numbers at a glance

| Mastery | Base | With spawners (×1.5) |
|---|---|---|
| ★0 | +15 | +22 |
| ★1 | +30 | +45 |
| ★2 | +60 | +90 |

## Test plan

- [ ] Place a Watchtower — confirm defense bar increases meaningfully
- [ ] Tap Watchtower → Residents tab shows hint, defense value, and next-upgrade preview
- [ ] Tap Watchtower → Upgrade tab shows cheaper cost table (500, 2500, 8000…) not the standard 50K table
- [ ] Upgrade the Watchtower — confirm defense contribution doubles
- [ ] Other buildings (non-Watchtower) still show the standard 50K upgrade cost table
- [ ] Upgrading a non-Watchtower wall card also increases its defense (mastery scaling now applies)

https://claude.ai/code/session_01QoP8jPH6TsU5QUWDguGVYx

---
_Generated by [Claude Code](https://claude.ai/code/session_01QoP8jPH6TsU5QUWDguGVYx)_