### PR TITLE
Tower Defence: 6 gameplay improvements

### DIFF
--- a/web/src/components/minigames/TowerDefence.tsx
+++ b/web/src/components/minigames/TowerDefence.tsx
@@ -6,8 +6,9 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
+  ENEMY_TEMPLATES,
   MilestoneUpgrade,
-  TDGameState, TDTower,
+  TDGameState, TDTargetingMode, TDTower,
   TDUpgradeType,
   TD_CELL_PX,
   TD_COLS,
@@ -22,9 +23,11 @@ import {
   calcTicketReward,
   chooseMilestoneUpgrade,
   createTDGame,
+  generateWave,
   moveTower,
   placeTower, removeTower,
   sellRefund,
+  setTowerTargetingMode,
   startWave, tickTD,
   towerCost, upgradeCost,
   upgradeTowerWith,
@@ -88,6 +91,9 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
   const gameSpeedRef = useRef(1)
   gameSpeedRef.current = gameSpeed
 
+  const [autoStart, setAutoStart] = useState(false)
+  const [lifeJustLost, setLifeJustLost] = useState(false)
+
   const gameRef = useRef(game)
   gameRef.current = game
 
@@ -96,12 +102,24 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
   const lastTimeRef = useRef<number | null>(null)
   const accRef = useRef(0)
 
-  // Drop to 1× whenever a life is lost
+  // Drop to 1× and flash whenever a life is lost
   const prevLivesRef = useRef(game.lives)
   useEffect(() => {
-    if (game.lives < prevLivesRef.current) setGameSpeed(1)
+    if (game.lives < prevLivesRef.current) {
+      setGameSpeed(1)
+      setLifeJustLost(true)
+      const t = setTimeout(() => setLifeJustLost(false), 700)
+      return () => clearTimeout(t)
+    }
     prevLivesRef.current = game.lives
   }, [game.lives])
+
+  // Auto-start next wave when the toggle is on
+  useEffect(() => {
+    if (autoStart && game.phase === 'between' && !game.milestoneChoices) {
+      setGame(prev => startWave(prev))
+    }
+  }, [autoStart, game.phase, game.milestoneChoices])
 
   // ── Game loop ───────────────────────────────────────────────────────────────
 
@@ -193,6 +211,10 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
     setGame(prev => upgradeTowerWith(prev, tower.id, type) ?? prev)
   }
 
+  function handleSetTargetingMode(towerId: number, mode: TDTargetingMode) {
+    setGame(prev => setTowerTargetingMode(prev, towerId, mode))
+  }
+
   function handleStartWave() { setGame(prev => startWave(prev)) }
   function handleChooseMilestone(id: string) { setGame(prev => chooseMilestoneUpgrade(prev, id)) }
 
@@ -202,6 +224,16 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
   }
 
   // ── Derived ─────────────────────────────────────────────────────────────────
+
+  // Wave preview: summarise the upcoming wave enemy composition
+  const nextWavePreview = useMemo(() => {
+    if (game.phase !== 'prep' && game.phase !== 'between' && game.phase !== 'milestone') return null
+    const waveDef = generateWave(game.currentWaveIndex)
+    return waveDef.spawns.map(s => {
+      const tpl = ENEMY_TEMPLATES[s.enemyId]
+      return { label: tpl?.label ?? s.enemyId, count: s.count, flying: tpl?.flying ?? false, boss: tpl?.tags.includes('boss') ?? false }
+    })
+  }, [game.phase, game.currentWaveIndex])
 
   const isPlacingPhase = game.phase === 'prep' || game.phase === 'between' || game.phase === 'milestone'
   const canPlaceTowers = isPlacingPhase || game.phase === 'wave'
@@ -254,7 +286,7 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
   const lastLog = game.log[game.log.length - 1] ?? ''
 
   return (
-    <div className="td-root">
+    <div className={`td-root${lifeJustLost ? ' td-root--life-lost' : ''}`}>
 
       {/* ── Header ── */}
       <div className="td-header u-flex u-items-c u-gap-4 u-wrap">
@@ -299,6 +331,11 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
               onClick={() => setGameSpeed(s)}
             >{s}×</button>
           ))}
+          <button
+            className={`td-speed-btn${autoStart ? ' td-speed-btn--active' : ''}`}
+            onClick={() => setAutoStart(v => !v)}
+            title="Auto-start next wave"
+          >⚡Auto</button>
         </div>
 
         <button className="action-btn action-btn--danger td-header-btn" onClick={() => onDone(reward)}>
@@ -306,17 +343,42 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
         </button>
       </div>
 
+      {/* ── Wave preview ── */}
+      {nextWavePreview && (
+        <div className="td-wave-preview">
+          <span className="td-wave-preview-label">Next: </span>
+          {nextWavePreview.map((g, i) => (
+            <span key={i} className={`td-wave-preview-group${g.boss ? ' td-wave-preview-group--boss' : ''}`}>
+              {g.flying ? '🦅' : g.boss ? '☠' : '👹'} {g.count}× {g.label}
+            </span>
+          ))}
+        </div>
+      )}
+
       {/* ── Milestone reward choices ── */}
       {game.milestoneChoices && (
         <div className="td-milestone-choices">
           <div className="td-milestone-choices-title">Choose your reward</div>
           <div className="td-milestone-choices-cards u-flex u-gap-4">
-            {game.milestoneChoices.map((choice: MilestoneUpgrade) => (
-              <button key={choice.id} className="td-milestone-choice-card" onClick={() => handleChooseMilestone(choice.id)}>
-                <div className="td-milestone-choice-label">{choice.label}</div>
-                <div className="td-milestone-choice-desc">{choice.description}</div>
-              </button>
-            ))}
+            {game.milestoneChoices.map((choice: MilestoneUpgrade) => {
+              const p = game.passives
+              let delta = ''
+              switch (choice.id) {
+                case 'attack_speed': delta = `${p.attackSpeedMult.toFixed(2)}× → ${(p.attackSpeedMult * 1.2).toFixed(2)}×`; break
+                case 'range':        delta = `+${p.rangeBonus} → +${p.rangeBonus + 1} cells`; break
+                case 'damage':       delta = `${p.damageMult.toFixed(2)}× → ${(p.damageMult * 1.15).toFixed(2)}×`; break
+                case 'mana':         delta = `${game.mana} → ${game.mana + 100} 💧`; break
+                case 'life':         delta = `${game.lives} → ${game.lives + 2} ❤️`; break
+                case 'respawn':      delta = `${p.respawnMult.toFixed(1)}× → ${(p.respawnMult * 2).toFixed(1)}× faster`; break
+              }
+              return (
+                <button key={choice.id} className="td-milestone-choice-card" onClick={() => handleChooseMilestone(choice.id)}>
+                  <div className="td-milestone-choice-label">{choice.label}</div>
+                  <div className="td-milestone-choice-desc">{choice.description}</div>
+                  {delta && <div className="td-milestone-choice-delta">{delta}</div>}
+                </button>
+              )
+            })}
           </div>
         </div>
       )}
@@ -350,14 +412,28 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
         const activeUnits = game.units.filter(u => u.towerId === t.id)
         const totalMaxed = t.upgrades >= TD_MAX_UPGRADES
 
+        // Actual computed stats
+        const speedMult = 1 + t.upgradeSpeed * 0.10
+        const cooldownSec = (t.template.attackCooldownMs / 1000) / (speedMult * game.passives.attackSpeedMult)
+        const dmgMult = (1 + t.upgradeDamage * 0.10) * game.passives.damageMult
+        const dps = t.template.attack * dmgMult / cooldownSec
+        const rangeInCells = Math.max(1.5, Math.round(t.template.attackRange / CELL_PX)) + t.upgradeRange + game.passives.rangeBonus
+
         const upgradeOptions: Array<{
-          type: TDUpgradeType; icon: string; label: string; current: number; max: number
+          type: TDUpgradeType; icon: string; label: string; current: number; max: number; statLabel: string
         }> = [
-            { type: 'units', icon: '👤', label: '+Unit', current: t.upgradeUnits, max: TD_MAX_UNIT_UPGRADES },
-            { type: 'speed', icon: '⚡', label: 'Speed', current: t.upgradeSpeed, max: TD_MAX_UPGRADE_PER_TYPE },
-            { type: 'range', icon: '🎯', label: 'Range', current: t.upgradeRange, max: TD_MAX_UPGRADE_PER_TYPE },
-            { type: 'damage', icon: '⚔', label: 'Damage', current: t.upgradeDamage, max: TD_MAX_UPGRADE_PER_TYPE },
+            { type: 'units', icon: '👤', label: '+Unit', current: t.upgradeUnits, max: TD_MAX_UNIT_UPGRADES, statLabel: `${unitCount} units` },
+            { type: 'speed', icon: '⚡', label: 'Speed', current: t.upgradeSpeed, max: TD_MAX_UPGRADE_PER_TYPE, statLabel: `${cooldownSec.toFixed(1)}s cd` },
+            { type: 'range', icon: '🎯', label: 'Range', current: t.upgradeRange, max: TD_MAX_UPGRADE_PER_TYPE, statLabel: `${rangeInCells.toFixed(1)} cells` },
+            { type: 'damage', icon: '⚔', label: 'Damage', current: t.upgradeDamage, max: TD_MAX_UPGRADE_PER_TYPE, statLabel: `${dps.toFixed(1)} dps` },
           ]
+
+        const targetingModes: Array<{ mode: TDTargetingMode; icon: string; label: string }> = [
+          { mode: 'first',    icon: '▶', label: 'First' },
+          { mode: 'weakest',  icon: '💔', label: 'Weak' },
+          { mode: 'strongest',icon: '💪', label: 'Strong' },
+          { mode: 'flying',   icon: '🦅', label: 'Flying' },
+        ]
 
         return (
           <div className="td-selected-panel">
@@ -365,7 +441,7 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
               <div className="td-selected-panel-info">
                 <strong>{t.buildingName}</strong>
                 {t.upgrades > 0 && <span className="td-tower-tier-label u-text-gold"> ★{t.upgrades}</span>}
-                <span className="td-selected-panel-stats"> · {activeUnits.length}/{unitCount} units</span>
+                <span className="td-selected-panel-stats"> · {activeUnits.length}/{unitCount} units · {dps.toFixed(1)} dps · {rangeInCells.toFixed(1)}r</span>
               </div>
               <div className="td-selected-panel-row-actions">
                 <button className="td-selected-action-btn td-selected-action-btn--sell"
@@ -377,6 +453,17 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
                   ✕
                 </button>
               </div>
+            </div>
+
+            {/* Targeting mode row */}
+            <div className="td-targeting-modes">
+              {targetingModes.map(({ mode, icon, label }) => (
+                <button
+                  key={mode}
+                  className={`td-targeting-btn${t.targetingMode === mode ? ' td-targeting-btn--active' : ''}`}
+                  onClick={() => handleSetTargetingMode(t.id, mode)}
+                >{icon} {label}</button>
+              ))}
             </div>
 
             {!totalMaxed && (
@@ -397,7 +484,7 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
               <div className="td-selected-panel-maxed">★ FULLY UPGRADED ({unitCount} units)</div>
             ) : (
               <div className="td-upgrade-options">
-                {upgradeOptions.map(({ type, icon, label, current, max }) => {
+                {upgradeOptions.map(({ type, icon, label, current, max, statLabel }) => {
                   const maxed = current >= max
                   const enabled = hasXp && canAfford && !maxed
                   const dotsMax = Math.min(max, 10)
@@ -413,6 +500,7 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
                         {current}/{max}
                         {max <= 5 ? ' ' + '●'.repeat(current) + '○'.repeat(dotsMax - current) : ''}
                       </span>
+                      <span className="td-upgrade-option-stat">{statLabel}</span>
                     </button>
                   )
                 })}

--- a/web/src/game/towerDefence.ts
+++ b/web/src/game/towerDefence.ts
@@ -294,6 +294,8 @@ export const TD_WAVES: WaveDefinition[] = [
 let _nextId = 1
 function nextId() { return _nextId++ }
 
+export type TDTargetingMode = 'first' | 'weakest' | 'strongest' | 'flying'
+
 // Building placed by the player on a non-path cell.
 export interface TDTower {
   id: number
@@ -308,6 +310,7 @@ export interface TDTower {
   upgradeDamage: number       // 0–TD_MAX_UPGRADE_PER_TYPE: damage bonus
   respawnTimers: number[]     // countdown (ms) for each dead unit awaiting respawn
   xp: number                  // kills earned by this tower's units; upgrade unlocks at threshold
+  targetingMode: TDTargetingMode
 }
 
 // A unit spawned by a building — roams within 1 cell of the building, chases nearby enemies.
@@ -504,7 +507,7 @@ export function hpBarColor(frac: number): string {
  *   wave 20 = wave 19 + wave 10  (= all base waves combined)
  *   wave 100 ≈ wave 10 × 10
  */
-function generateWave(waveIndex: number): WaveDefinition {
+export function generateWave(waveIndex: number): WaveDefinition {
   const n   = waveIndex + 1
   const len = TD_WAVES.length  // 10
 
@@ -710,6 +713,7 @@ export function placeTower(
     upgradeDamage: 0,
     respawnTimers: [],
     xp: 0,
+    targetingMode: 'first',
   }
   const unit = spawnUnitFromBuilding(tower)
   return {
@@ -826,6 +830,11 @@ export function chooseMilestoneUpgrade(state: TDGameState, id: string): TDGameSt
   }
   return { ...state, ...extra, passives: p, milestoneChoices: null,
     log: [...state.log.slice(-9), `Upgrade chosen: ${ALL_MILESTONE_UPGRADES.find(u => u.id === id)?.label ?? id}`] }
+}
+
+/** Change a tower's targeting priority mode. */
+export function setTowerTargetingMode(state: TDGameState, towerId: number, mode: TDTargetingMode): TDGameState {
+  return { ...state, towers: state.towers.map(t => t.id === towerId ? { ...t, targetingMode: mode } : t) }
 }
 
 /** Begin the next wave from prep, between, or milestone phase. */
@@ -1015,12 +1024,21 @@ export function tickTD(state: TDGameState, dtMs: number): TDGameState {
   const newAttackEvents: TDAttackEvent[] = s.attackEvents.filter(e => e.expiresAt > s.gameTimeMs)
   const towerXpGains: Record<number, number> = {}
 
+  // Pre-build a map of tower targeting modes for O(1) lookup per unit
+  const towerTargetingModes = new Map<number, TDTargetingMode>(s.towers.map(t => [t.id, t.targetingMode]))
+
   s.units = s.units.map(unit => {
     let cd = Math.max(0, unit.attackCooldownRemaining - dtMs)
     if (cd <= 0 && s.enemies.length > 0) {
-      const targets = s.enemies
-        .filter(e => !deadEnemyIds.has(e.id) && !shieldedEnemyIds.has(e.id) && unitCanHit(unit, e, rangeBonus + unit.rangeBonus))
-        .sort((a, b) => b.pathProgress - a.pathProgress)
+      const mode = towerTargetingModes.get(unit.towerId) ?? 'first'
+      const reachable = s.enemies.filter(e => !deadEnemyIds.has(e.id) && !shieldedEnemyIds.has(e.id) && unitCanHit(unit, e, rangeBonus + unit.rangeBonus))
+      const flyingOnly = reachable.filter(e => e.template.flying)
+      const pool = mode === 'flying' && flyingOnly.length > 0 ? flyingOnly : reachable
+      const targets = pool.sort((a, b) => {
+        if (mode === 'weakest')   return a.hp - b.hp
+        if (mode === 'strongest') return b.hp - a.hp
+        return b.pathProgress - a.pathProgress  // 'first' and 'flying' fallback
+      })
       if (targets.length > 0) {
         const target = targets[0]
         if (target.shielded) {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -12326,6 +12326,30 @@ html.light-mode .action-btn {
   position: relative;
 }
 
+@keyframes td-life-lost-flash {
+  0%   { box-shadow: inset 0 0 0 0 rgba(255,40,40,0); }
+  25%  { box-shadow: inset 0 0 60px 20px rgba(255,40,40,0.55); }
+  100% { box-shadow: inset 0 0 0 0 rgba(255,40,40,0); }
+}
+.td-root--life-lost { animation: td-life-lost-flash 0.7s ease-out forwards; }
+
+/* ── Wave preview ── */
+.td-wave-preview {
+  padding: 4px 10px;
+  background: #0d1a0d;
+  border-bottom: 1px solid #2a3a2a;
+  font-size: 10px;
+  color: #aaa;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+.td-wave-preview-label { color: #666; }
+.td-wave-preview-group { color: #ccc; }
+.td-wave-preview-group--boss { color: var(--color-gold); font-weight: bold; }
+
 /* ── Header ── */
 .td-header {
   padding: 6px 10px;
@@ -12594,6 +12618,7 @@ html.light-mode .action-btn {
 .td-milestone-choice-card:hover { border-color: var(--color-gold); background: #1a1600; }
 .td-milestone-choice-label { font-size: 11px; font-weight: bold; color: var(--color-gold); }
 .td-milestone-choice-desc  { font-size: 9px; color: #bbb; text-align: center; }
+.td-milestone-choice-delta { font-size: 9px; color: var(--color-green-bright); text-align: center; margin-top: 2px; font-weight: bold; }
 
 /* ── Selected tower action panel ── */
 .td-selected-panel {
@@ -12683,6 +12708,7 @@ html.light-mode .action-btn {
 .td-upgrade-option-label { flex: 1; font-weight: bold; }
 .td-upgrade-option-dots  { font-size: 10px; color: var(--color-green-bright); letter-spacing: 1px; flex-shrink: 0; }
 .td-upgrade-option--maxed .td-upgrade-option-dots { color: var(--color-gold); }
+.td-upgrade-option-stat { font-size: 9px; color: #64b5f6; flex-shrink: 0; margin-left: auto; }
 
 /* 2×2 upgrade option grid */
 .td-upgrade-options {
@@ -12713,6 +12739,24 @@ html.light-mode .action-btn {
 .td-upgrade-option-label { flex: 1; font-weight: bold; }
 .td-upgrade-option-dots  { font-size: 10px; color: #4caf50; letter-spacing: 1px; flex-shrink: 0; }
 .td-upgrade-option--maxed .td-upgrade-option-dots { color: #ffd700; }
+.td-upgrade-option-stat { font-size: 9px; color: #64b5f6; flex-shrink: 0; margin-left: auto; }
+
+/* ── Targeting mode row ── */
+.td-targeting-modes { display: flex; gap: 4px; }
+.td-targeting-btn {
+  flex: 1;
+  background: #1a1a1a;
+  border: 1px solid #444;
+  border-radius: 4px;
+  color: #aaa;
+  font-size: 9px;
+  font-family: 'Courier New', monospace;
+  cursor: pointer;
+  padding: 3px 4px;
+  transition: border-color 0.15s, background 0.15s;
+}
+.td-targeting-btn:hover { border-color: #888; color: #ccc; }
+.td-targeting-btn--active { border-color: var(--color-green-bright); color: var(--color-green-bright); background: #162616; }
 
 /* ── Bottom panel ── */
 .td-panel {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Implements all 6 improvements raised in issues #1239–#1244.

- **Targeting priority mode per tower** (#1239) — Each building now has First / Weak / Strong / Flying buttons. Units sort their attack targets accordingly; flying mode prioritises flyers and falls back to "first" when none are in range. New `setTowerTargetingMode` public API in `towerDefence.ts`.

- **Wave preview** (#1240) — A compact strip below the header shows the upcoming wave's enemy composition (icon + count × name) during prep/between/milestone phases. Boss waves are highlighted in gold.

- **Actual stat numbers in upgrade panel** (#1241) — The selected tower panel now shows live DPS, range in cells, and cooldown (accounting for passive multipliers) both in the info line and as a per-button stat label alongside the upgrade dots.

- **Milestone before/after values** (#1242) — Each milestone card now shows a computed delta line, e.g. `1.00× → 1.20×` for attack speed or `3 → 5 ❤️` for lives.

- **Life-lost flash** (#1243) — When lives drop, a red vignette pulse animates on `.td-root` for 700 ms. The existing speed-reset logic was extended to set `lifeJustLost` state, which adds the CSS class.

- **Auto-start toggle** (#1244) — An `⚡Auto` button sits next to the speed controls. When active, a `useEffect` automatically calls `startWave()` whenever the game enters the `between` phase with no pending milestone choices.

## Test plan

- [ ] Place towers and start a wave — verify wave preview shows correct enemy breakdown
- [ ] Select a tower — verify targeting mode buttons appear and cycle correctly
- [ ] Select a tower — verify DPS / range / cooldown numbers update after upgrades
- [ ] Reach a milestone wave — verify cards show before → after values
- [ ] Let an enemy through — verify red screen flash triggers
- [ ] Enable Auto toggle — verify waves start automatically; disable and verify it stops

https://claude.ai/code/session_017F2aujBh6QQCQRBHFCKGYh
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_017F2aujBh6QQCQRBHFCKGYh)_