### PR TITLE
feat: zoom controls + fix city grid height on larger screens

### DIFF
--- a/web/src/components/minigames/citybuilder/CityGrid.tsx
+++ b/web/src/components/minigames/citybuilder/CityGrid.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect, useCallback } from 'react'
+import React, { useRef, useEffect, useCallback, useState } from 'react'
 import {
   CityState, CITY_COLS, CITY_ROWS,
   spawnerUnitCount, getNeighbourIndices,
@@ -86,10 +86,11 @@ export function CityGrid({
   const cityCols  = city.cols ?? CITY_COLS
   const cityCells = cityCols * cityRows
 
-  // ── Zoom / pan state (refs to avoid re-renders during gestures) ──────────────
+  // ── Zoom / pan state ─────────────────────────────────────────────────────────
   const wrapperRef  = useRef<HTMLDivElement>(null)
   // t = { s: scale, x: panX in screen px, y: panY in screen px }
   const tRef        = useRef({ s: 1, x: 0, y: 0 })
+  const [displayScale, setDisplayScale] = useState(1)
 
   // Paint gesture state
   const isPaintingRef   = useRef(false)
@@ -118,10 +119,32 @@ export function CityGrid({
     return { s, x, y }
   }
 
-  function setTransform(s: number, x: number, y: number) {
+  function setTransform(s: number, x: number, y: number, updateDisplay = false) {
     const t = clamp(s, x, y)
     tRef.current = t
     applyTransform(t.s, t.x, t.y)
+    if (updateDisplay) setDisplayScale(t.s)
+  }
+
+  const ZOOM_STEPS = [1, 1.5, 2, 3, 4]
+
+  function zoomTo(targetScale: number) {
+    const el = worldRef.current
+    const cw = el?.clientWidth  ?? 300
+    const ch = el?.clientHeight ?? 300
+    const { s, x, y } = tRef.current
+    const cx = cw / 2
+    const cy = ch / 2
+    const factor = targetScale / s
+    setTransform(targetScale, cx - (cx - x) * factor, cy - (cy - y) * factor, true)
+  }
+
+  function stepZoom(dir: 1 | -1) {
+    const cur = tRef.current.s
+    const next = dir > 0
+      ? ZOOM_STEPS.find(z => z > cur + 0.01) ?? ZOOM_STEPS[ZOOM_STEPS.length - 1]
+      : [...ZOOM_STEPS].reverse().find(z => z < cur - 0.01) ?? ZOOM_STEPS[0]
+    zoomTo(next)
   }
 
   // Map a client-space point to a cell index, accounting for current zoom/pan
@@ -151,7 +174,7 @@ export function CityGrid({
       const delta = e.deltaY > 0 ? 0.85 : 1 / 0.85
       const sNew = Math.max(1, Math.min(4, s * delta))
       const factor = sNew / s
-      setTransform(sNew, cx - (cx - x) * factor, cy - (cy - y) * factor)
+      setTransform(sNew, cx - (cx - x) * factor, cy - (cy - y) * factor, true)
     }
     el.addEventListener('wheel', onWheel, { passive: false })
     return () => el.removeEventListener('wheel', onWheel)
@@ -233,8 +256,10 @@ export function CityGrid({
       if (e.touches.length === 0) {
         isPaintingRef.current = false
         isPanningRef.current  = false
+        if (isPinchingRef.current) setDisplayScale(tRef.current.s)
         isPinchingRef.current = false
       } else if (e.touches.length === 1) {
+        if (isPinchingRef.current) setDisplayScale(tRef.current.s)
         isPinchingRef.current = false
       }
     }
@@ -305,6 +330,24 @@ export function CityGrid({
       onMouseUp={onMouseUp}
       onMouseLeave={onMouseUp}
     >
+      {/* Zoom controls — outside the zoom wrapper so they don't scale */}
+      <div className="city-zoom-controls" onPointerDown={e => e.stopPropagation()}>
+        <button className="city-zoom-btn" onClick={() => stepZoom(-1)} title="Zoom out" disabled={displayScale <= 1}>−</button>
+        <div className="city-zoom-bar">
+          {ZOOM_STEPS.map((z, i) => (
+            <button
+              key={z}
+              className={`city-zoom-tick${displayScale >= z - 0.01 ? ' city-zoom-tick--active' : ''}`}
+              onClick={() => zoomTo(z)}
+              title={`${z}×`}
+            >
+              {i === ZOOM_STEPS.length - 1 ? '|' : '·'}
+            </button>
+          ))}
+        </div>
+        <button className="city-zoom-btn" onClick={() => stepZoom(1)} title="Zoom in" disabled={displayScale >= 4}>+</button>
+      </div>
+
       <div className="city-zoom-wrapper" ref={wrapperRef}>
         {/* ── Road wear overlay ───────────────────────────────────────────────
             Rendered BEHIND the main grid. */}

--- a/web/src/components/minigames/citybuilder/CityGrid.tsx
+++ b/web/src/components/minigames/citybuilder/CityGrid.tsx
@@ -8,6 +8,7 @@ import {
 import { SpriteImg, AnimatedSpriteImg } from '../../ui/SpriteImg'
 import { BuilderWalker, VisualCarrier } from '../CityBuilder'
 import { Walker } from './walkerTypes'
+import { CityZoomControls, ZOOM_STEPS } from './CityZoomControls'
 
 // ── Road path SVG ─────────────────────────────────────────────────────────────
 // Strips are centred on the cell boundary (bottom / right) so they straddle
@@ -125,8 +126,6 @@ export function CityGrid({
     applyTransform(t.s, t.x, t.y)
     if (updateDisplay) setDisplayScale(t.s)
   }
-
-  const ZOOM_STEPS = [1, 1.5, 2, 3, 4]
 
   function zoomTo(targetScale: number) {
     const el = worldRef.current
@@ -331,22 +330,12 @@ export function CityGrid({
       onMouseLeave={onMouseUp}
     >
       {/* Zoom controls — outside the zoom wrapper so they don't scale */}
-      <div className="city-zoom-controls" onPointerDown={e => e.stopPropagation()}>
-        <button className="city-zoom-btn" onClick={() => stepZoom(-1)} title="Zoom out" disabled={displayScale <= 1}>−</button>
-        <div className="city-zoom-bar">
-          {ZOOM_STEPS.map((z, i) => (
-            <button
-              key={z}
-              className={`city-zoom-tick${displayScale >= z - 0.01 ? ' city-zoom-tick--active' : ''}`}
-              onClick={() => zoomTo(z)}
-              title={`${z}×`}
-            >
-              {i === ZOOM_STEPS.length - 1 ? '|' : '·'}
-            </button>
-          ))}
-        </div>
-        <button className="city-zoom-btn" onClick={() => stepZoom(1)} title="Zoom in" disabled={displayScale >= 4}>+</button>
-      </div>
+      <CityZoomControls
+        scale={displayScale}
+        onZoomIn={() => stepZoom(1)}
+        onZoomOut={() => stepZoom(-1)}
+        onZoomTo={zoomTo}
+      />
 
       <div className="city-zoom-wrapper" ref={wrapperRef}>
         {/* ── Road wear overlay ───────────────────────────────────────────────

--- a/web/src/components/minigames/citybuilder/CityZoomControls.stories.tsx
+++ b/web/src/components/minigames/citybuilder/CityZoomControls.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { fn } from 'storybook/test'
+import { CityZoomControls } from './CityZoomControls'
+
+const meta: Meta<typeof CityZoomControls> = {
+  title: 'CityBuilder/CityZoomControls',
+  component: CityZoomControls,
+  parameters: { backgrounds: { default: 'dark' } },
+}
+export default meta
+type Story = StoryObj<typeof CityZoomControls>
+
+export const AtMin: Story = {
+  args: { scale: 1, onZoomIn: fn(), onZoomOut: fn(), onZoomTo: fn() },
+}
+
+export const AtMid: Story = {
+  args: { scale: 2, onZoomIn: fn(), onZoomOut: fn(), onZoomTo: fn() },
+}
+
+export const AtMax: Story = {
+  args: { scale: 4, onZoomIn: fn(), onZoomOut: fn(), onZoomTo: fn() },
+}

--- a/web/src/components/minigames/citybuilder/CityZoomControls.tsx
+++ b/web/src/components/minigames/citybuilder/CityZoomControls.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+
+export const ZOOM_STEPS = [1, 1.5, 2, 3, 4]
+
+export interface Props {
+  scale:    number
+  onZoomIn: () => void
+  onZoomOut: () => void
+  onZoomTo: (scale: number) => void
+}
+
+export function CityZoomControls({ scale, onZoomIn, onZoomOut, onZoomTo }: Props) {
+  return (
+    <div className="city-zoom-controls" onPointerDown={e => e.stopPropagation()}>
+      <button className="city-zoom-btn" onClick={onZoomOut} title="Zoom out" disabled={scale <= 1}>−</button>
+      <div className="city-zoom-bar">
+        {ZOOM_STEPS.map((z, i) => (
+          <button
+            key={z}
+            className={`city-zoom-tick${scale >= z - 0.01 ? ' city-zoom-tick--active' : ''}`}
+            onClick={() => onZoomTo(z)}
+            title={`${z}×`}
+          >
+            {i === ZOOM_STEPS.length - 1 ? '|' : '·'}
+          </button>
+        ))}
+      </div>
+      <button className="city-zoom-btn" onClick={onZoomIn} title="Zoom in" disabled={scale >= 4}>+</button>
+    </div>
+  )
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -9000,6 +9000,53 @@ html.light-mode .action-btn {
   will-change: transform;
 }
 
+/* ── Zoom controls overlay ───────────────────────────────────────────────── */
+.city-zoom-controls {
+  position: absolute;
+  bottom: 6px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  background: rgba(0,0,0,0.55);
+  border-radius: 20px;
+  padding: 3px 8px;
+  pointer-events: all;
+}
+.city-zoom-btn {
+  background: none;
+  border: none;
+  color: #90d090;
+  font-size: 16px;
+  font-weight: bold;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 2px;
+  width: 20px;
+  text-align: center;
+}
+.city-zoom-btn:disabled { color: #3a6a3a; cursor: default; }
+.city-zoom-btn:not(:disabled):hover { color: #c0f0c0; }
+.city-zoom-bar {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+}
+.city-zoom-tick {
+  background: none;
+  border: none;
+  color: #4a7a4a;
+  font-size: 13px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0;
+  transition: color 0.1s;
+}
+.city-zoom-tick--active { color: #80d080; }
+.city-zoom-tick:hover { color: #a0f0a0; }
+
 /* ── Brush / paint mode bar ──────────────────────────────────────────────── */
 .city-brush-bar {
   display: flex;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -8980,8 +8980,9 @@ html.light-mode .action-btn {
 .city-world {
   position: relative;
   width: 100%;
-  flex: 0 0 clamp(180px, 50vh, 55vw);
-  height: clamp(180px, 50vh, 55vw);
+  flex: 0 0 50vh;
+  height: 50vh;
+  min-height: 180px;
   overflow: hidden;
   background: #2d5a27;
   border-radius: 5px;


### PR DESCRIPTION
## Changes

### Zoom controls
Adds a floating `[−] · · · · [+]` strip at the bottom of the city grid:
- **[−] / [+]** buttons step through zoom levels: 1× → 1.5× → 2× → 3× → 4×
- Dot/tick markers light up to show the current zoom level
- Zooming via pinch or scroll wheel also updates the indicator in sync
- Controls live outside the zoom wrapper so they don't scale with the grid

### Fix: grid height on larger screens
The `55vw` upper-bound from the previous zoom PR was unintentionally capping the grid on portrait-orientation tablets (e.g. 768×1024: 50vh = 512px but 55vw = 422px). Restored the original `50vh` sizing with only `min-height: 180px` as a floor for very small screens.

## Test plan
- [ ] [−] / [+] buttons step zoom and highlight the correct tick
- [ ] Pinch/scroll zoom updates the tick indicator
- [ ] Buttons are disabled at the min/max zoom boundaries
- [ ] Grid fills 50vh on a desktop browser (no height regression)
- [ ] Grid still has a minimum height on a very small screen

https://claude.ai/code/session_01QoP8jPH6TsU5QUWDguGVYx