### PR TITLE
Tower Defence: fix units stat label to show active/capacity format

### DIFF
--- a/web/src/components/minigames/TowerDefence.tsx
+++ b/web/src/components/minigames/TowerDefence.tsx
@@ -422,7 +422,7 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
         const upgradeOptions: Array<{
           type: TDUpgradeType; icon: string; label: string; current: number; max: number; statLabel: string
         }> = [
-            { type: 'units', icon: '👤', label: '+Unit', current: t.upgradeUnits, max: TD_MAX_UNIT_UPGRADES, statLabel: `${unitCount} units` },
+            { type: 'units', icon: '👤', label: '+Unit', current: t.upgradeUnits, max: TD_MAX_UNIT_UPGRADES, statLabel: `${activeUnits.length}/${unitCount}` },
             { type: 'speed', icon: '⚡', label: 'Speed', current: t.upgradeSpeed, max: TD_MAX_UPGRADE_PER_TYPE, statLabel: `${cooldownSec.toFixed(1)}s cd` },
             { type: 'range', icon: '🎯', label: 'Range', current: t.upgradeRange, max: TD_MAX_UPGRADE_PER_TYPE, statLabel: `${rangeInCells.toFixed(1)} cells` },
             { type: 'damage', icon: '⚔', label: 'Damage', current: t.upgradeDamage, max: TD_MAX_UPGRADE_PER_TYPE, statLabel: `${dps.toFixed(1)} dps` },


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Small follow-up to #1246. The units upgrade button stat label was showing `2 units` (just capacity) instead of the `2/4` format requested in #1241.

Now shows `activeUnits.length / unitCount` — e.g. `1/2` — so players can see both how many units are currently alive and the building's current max capacity. Updates live as units die and respawn during a wave.

Closes #1241

https://claude.ai/code/session_017F2aujBh6QQCQRBHFCKGYh
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_017F2aujBh6QQCQRBHFCKGYh)_