### PR TITLE
fix: zoom +/- buttons unresponsive on touch (preventDefault suppressed click)

### DIFF
--- a/web/src/components/minigames/citybuilder/CityGrid.tsx
+++ b/web/src/components/minigames/citybuilder/CityGrid.tsx
@@ -192,6 +192,7 @@ export function CityGrid({
     }
 
     const onTouchStart = (e: TouchEvent) => {
+      if ((e.target as Element).closest('.city-zoom-controls')) return
       if (e.touches.length === 1) {
         // Single touch: start paint or pan
         const { s } = tRef.current
@@ -276,6 +277,7 @@ export function CityGrid({
 
   // ── Mouse pan (desktop, when zoomed) ────────────────────────────────────────
   const onMouseDown = useCallback((e: React.MouseEvent) => {
+    if ((e.target as Element).closest('.city-zoom-controls')) return
     if (paintBrush || tRef.current.s <= 1) return
     if (e.button !== 0) return
     isPanningRef.current = true


### PR DESCRIPTION
The native `touchstart` handler on `city-world` was calling `e.preventDefault()` when zoomed in (scale > 1). This suppresses the browser's synthetic `click` event, so button `onClick` handlers never fired — the zoom controls appeared to do nothing on touch.

Fix: bail out of the touchstart handler immediately when the touch originates inside `.city-zoom-controls`. Same guard added to the mouse `onMouseDown` pan handler.

https://claude.ai/code/session_01QoP8jPH6TsU5QUWDguGVYx

---
_Generated by [Claude Code](https://claude.ai/code/session_01QoP8jPH6TsU5QUWDguGVYx)_