### PR TITLE
fix: tapping buildings/walkers while zoomed now opens inspect modal

### DIFF
--- a/web/src/components/minigames/citybuilder/CityGrid.tsx
+++ b/web/src/components/minigames/citybuilder/CityGrid.tsx
@@ -204,10 +204,9 @@ export function CityGrid({
           if (idx >= 0) { lastPaintedRef.current = idx; onPaint(idx) }
           e.preventDefault()
         } else if (s > 1) {
-          // Pan start
-          isPanningRef.current = true
+          // Record pan origin but don't preventDefault — a tap must still fire click
+          // (isPanningRef is set on first touchmove, not here)
           panStartRef.current = { px: e.touches[0].clientX, py: e.touches[0].clientY, tx: tRef.current.x, ty: tRef.current.y }
-          e.preventDefault()
         }
       } else if (e.touches.length === 2) {
         // Pinch start
@@ -231,7 +230,9 @@ export function CityGrid({
             lastPaintedRef.current = idx
             onPaint(idx)
           }
-        } else if (isPanningRef.current) {
+        } else if (tRef.current.s > 1 && !isPinchingRef.current) {
+          // Engage pan on first actual move (not on touchstart, so taps fire click)
+          isPanningRef.current = true
           const { px, py, tx, ty } = panStartRef.current
           setTransform(tRef.current.s, tx + e.touches[0].clientX - px, ty + e.touches[0].clientY - py)
         }

--- a/web/src/components/minigames/citybuilder/CityGrid.tsx
+++ b/web/src/components/minigames/citybuilder/CityGrid.tsx
@@ -192,6 +192,7 @@ export function CityGrid({
     }
 
     const onTouchStart = (e: TouchEvent) => {
+      if ((e.target as Element).closest('.city-zoom-controls')) return
       if (e.touches.length === 1) {
         // Single touch: start paint or pan
         const { s } = tRef.current
@@ -276,6 +277,7 @@ export function CityGrid({
 
   // ── Mouse pan (desktop, when zoomed) ────────────────────────────────────────
   const onMouseDown = useCallback((e: React.MouseEvent) => {
+    if ((e.target as Element).closest('.city-zoom-controls')) return
     if (paintBrush || tRef.current.s <= 1) return
     if (e.button !== 0) return
     isPanningRef.current = true


### PR DESCRIPTION
## Summary

- `e.preventDefault()` in the native `touchstart` handler was suppressing the browser's synthetic `click` event whenever `scale > 1`
- This meant tapping any building or walker while zoomed in was silently swallowed — the inspect modal never opened
- Fix: don't call `preventDefault` in `touchstart` for the pan case; instead activate the pan on the first `touchmove` (which still calls `preventDefault` to block browser scroll)
- Pure taps (touchstart + touchend with no touchmove) now reach cell `onClick` and walker `onClick` handlers normally, regardless of zoom level

## Test plan

- [ ] Zoom in (pinch or +/- buttons), then tap a building — inspect modal opens
- [ ] Zoom in, tap a walker — resident info modal opens
- [ ] Zoom in and drag — grid pans correctly, no accidental cell taps
- [ ] Zoom in, drag, release, then tap — only the final tap opens the modal (no phantom taps during drag)
- [ ] At scale=1 — tap to inspect still works (unchanged path)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QoP8jPH6TsU5QUWDguGVYx)_