### PR TITLE
feat: farming simulation sub-screen with walkers, raids, and +50% production bonus

### DIFF
--- a/web/public/sprites/farmer-1.svg
+++ b/web/public/sprites/farmer-1.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Walk frame 1: stride A — left leg forward -->
+  <!-- Body -->
+  <rect x="11" y="12" width="10" height="11" rx="2" fill="#8B6914"/>
+  <!-- Head -->
+  <circle cx="16" cy="9" r="4" fill="#F5CBA7"/>
+  <!-- Hat -->
+  <ellipse cx="16" cy="5.5" rx="7" ry="2" fill="#DAA520"/>
+  <rect x="13" y="3.5" width="6" height="4" rx="1" fill="#DAA520"/>
+  <!-- Arms (swinging) -->
+  <rect x="6" y="14" width="5" height="2" rx="1" fill="#8B6914"/>
+  <rect x="21" y="12" width="5" height="2" rx="1" fill="#8B6914"/>
+  <!-- Hoe -->
+  <rect x="25" y="10" width="2" height="10" rx="1" fill="#A0522D"/>
+  <rect x="22" y="9" width="5" height="2" rx="1" fill="#7F8C8D"/>
+  <!-- Legs: left forward -->
+  <rect x="12" y="23" width="3" height="5" rx="1" fill="#5D4037" transform="rotate(-12 13.5 23)"/>
+  <rect x="17" y="23" width="3" height="5" rx="1" fill="#5D4037" transform="rotate(12 18.5 23)"/>
+  <!-- Boots -->
+  <rect x="10" y="27" width="4" height="2" rx="1" fill="#3E2723"/>
+  <rect x="18" y="27" width="4" height="2" rx="1" fill="#3E2723"/>
+</svg>

--- a/web/public/sprites/farmer-2.svg
+++ b/web/public/sprites/farmer-2.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Walk frame 2: mid-stride, body 1px higher -->
+  <!-- Body -->
+  <rect x="11" y="11" width="10" height="11" rx="2" fill="#8B6914"/>
+  <!-- Head -->
+  <circle cx="16" cy="8" r="4" fill="#F5CBA7"/>
+  <!-- Hat -->
+  <ellipse cx="16" cy="4.5" rx="7" ry="2" fill="#DAA520"/>
+  <rect x="13" y="2.5" width="6" height="4" rx="1" fill="#DAA520"/>
+  <!-- Arms -->
+  <rect x="7" y="12" width="4" height="2" rx="1" fill="#8B6914"/>
+  <rect x="21" y="11" width="4" height="2" rx="1" fill="#8B6914"/>
+  <!-- Hoe -->
+  <rect x="24" y="9" width="2" height="10" rx="1" fill="#A0522D"/>
+  <rect x="21" y="8" width="5" height="2" rx="1" fill="#7F8C8D"/>
+  <!-- Legs straight -->
+  <rect x="12" y="22" width="3" height="5" rx="1" fill="#5D4037"/>
+  <rect x="17" y="22" width="3" height="5" rx="1" fill="#5D4037"/>
+  <!-- Boots -->
+  <rect x="11" y="26" width="4" height="2" rx="1" fill="#3E2723"/>
+  <rect x="16" y="26" width="4" height="2" rx="1" fill="#3E2723"/>
+</svg>

--- a/web/public/sprites/farmer-3.svg
+++ b/web/public/sprites/farmer-3.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Walk frame 3: stride B — right leg forward -->
+  <!-- Body -->
+  <rect x="11" y="12" width="10" height="11" rx="2" fill="#8B6914"/>
+  <!-- Head -->
+  <circle cx="16" cy="9" r="4" fill="#F5CBA7"/>
+  <!-- Hat -->
+  <ellipse cx="16" cy="5.5" rx="7" ry="2" fill="#DAA520"/>
+  <rect x="13" y="3.5" width="6" height="4" rx="1" fill="#DAA520"/>
+  <!-- Arms: opposite swing to frame 1 -->
+  <rect x="21" y="14" width="5" height="2" rx="1" fill="#8B6914"/>
+  <rect x="6" y="12" width="5" height="2" rx="1" fill="#8B6914"/>
+  <!-- Hoe -->
+  <rect x="24" y="10" width="2" height="10" rx="1" fill="#A0522D"/>
+  <rect x="21" y="9" width="5" height="2" rx="1" fill="#7F8C8D"/>
+  <!-- Legs: right forward -->
+  <rect x="17" y="23" width="3" height="5" rx="1" fill="#5D4037" transform="rotate(-12 18.5 23)"/>
+  <rect x="12" y="23" width="3" height="5" rx="1" fill="#5D4037" transform="rotate(12 13.5 23)"/>
+  <!-- Boots -->
+  <rect x="18" y="27" width="4" height="2" rx="1" fill="#3E2723"/>
+  <rect x="10" y="27" width="4" height="2" rx="1" fill="#3E2723"/>
+</svg>

--- a/web/public/sprites/farmer.svg
+++ b/web/public/sprites/farmer.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Body -->
+  <rect x="11" y="12" width="10" height="11" rx="2" fill="#8B6914"/>
+  <!-- Head -->
+  <circle cx="16" cy="9" r="4" fill="#F5CBA7"/>
+  <!-- Hat (straw) -->
+  <ellipse cx="16" cy="5.5" rx="7" ry="2" fill="#DAA520"/>
+  <rect x="13" y="3.5" width="6" height="4" rx="1" fill="#DAA520"/>
+  <!-- Left arm -->
+  <rect x="7" y="13" width="4" height="2" rx="1" fill="#8B6914"/>
+  <!-- Right arm (holding hoe) -->
+  <rect x="21" y="12" width="4" height="2" rx="1" fill="#8B6914"/>
+  <!-- Hoe handle -->
+  <rect x="24" y="10" width="2" height="10" rx="1" fill="#A0522D"/>
+  <!-- Hoe head -->
+  <rect x="21" y="9" width="5" height="2" rx="1" fill="#7F8C8D"/>
+  <!-- Legs -->
+  <rect x="12" y="23" width="3" height="5" rx="1" fill="#5D4037"/>
+  <rect x="17" y="23" width="3" height="5" rx="1" fill="#5D4037"/>
+  <!-- Boots -->
+  <rect x="11" y="27" width="4" height="2" rx="1" fill="#3E2723"/>
+  <rect x="16" y="27" width="4" height="2" rx="1" fill="#3E2723"/>
+</svg>

--- a/web/src/components/minigames/CityBuilder.tsx
+++ b/web/src/components/minigames/CityBuilder.tsx
@@ -60,6 +60,8 @@ import { StatsScreen } from './citybuilder/StatsScreen'
 import { ZoneEditor } from './citybuilder/ZoneEditor'
 import { DisasterModal } from './citybuilder/DisasterModal'
 import { OverlayScreen } from '../ui/OverlayScreen'
+import { FarmingSim } from './FarmingSim'
+import { isFarmUnlocked } from '../../game/farmingSim'
 
 
 // ── Resident thought lines ────────────────────────────────────────────────────
@@ -629,7 +631,7 @@ interface Props {
   onBack: () => void
 }
 
-type SubScreen = 'city' | 'picker' | 'upgrade' | 'levelup' | 'fortify' | 'towerdefence' | 'chronicle' | 'stats' | 'zones'
+type SubScreen = 'city' | 'picker' | 'upgrade' | 'levelup' | 'fortify' | 'towerdefence' | 'chronicle' | 'stats' | 'zones' | 'farming'
 
 export function CityBuilder({ onBack }: Props) {
   const [city, setCity] = useState<CityState>(() => tickCity(loadCityState()))
@@ -1461,6 +1463,18 @@ export function CityBuilder({ onBack }: Props) {
         attackRatio >= 0.6 ? { text: 'Strong', cls: 'strength--strong' } :
           { text: 'Overwhelming', cls: 'strength--overwhelm' }
 
+  // ── Farming sub-screen ───────────────────────────────────────────────────────
+
+  if (screen === 'farming') {
+    return (
+      <FarmingSim
+        city={city}
+        onSaveCity={next => { setCity(next); saveCityState(next) }}
+        onBack={() => setScreen('city')}
+      />
+    )
+  }
+
   // ── Fortify sub-screen ────────────────────────────────────────────────────────
 
   if (screen === 'fortify') {
@@ -1736,6 +1750,21 @@ export function CityBuilder({ onBack }: Props) {
             title={bulldozerMode ? 'Demolish mode ON' : 'Demolish a building'}
           >{bulldozerMode ? '🧱 DEMOLISH' : '👷 BUILD'}</button>
           <button className="filter-btn" onClick={() => setScreen('fortify')} title="Manage city walls and moats">🛡 FORTS</button>
+          {isFarmUnlocked(population) ? (
+            <button
+              className="filter-btn action-btn--gold"
+              style={{ fontSize: 11 }}
+              onClick={() => setScreen('farming')}
+              title="Manage arable land outside the city"
+            >🌾 FARM</button>
+          ) : (
+            <button
+              className="filter-btn"
+              style={{ opacity: 0.5 }}
+              title={`Farm unlocks at population 10 (currently ${population})`}
+              disabled
+            >🌾 FARM 🔒</button>
+          )}
           <button className="filter-btn" onClick={() => setScreen('upgrade')} title="Upgrade buildings">★ UPGRADES</button>
           <button className="filter-btn" onClick={() => setScreen('chronicle')} title="View city history">📜 HISTORY</button>
           <button className="filter-btn" onClick={() => setScreen('stats')} title="View economy charts">📊 STATS</button>

--- a/web/src/components/minigames/FarmingSim.stories.tsx
+++ b/web/src/components/minigames/FarmingSim.stories.tsx
@@ -1,0 +1,47 @@
+import React from 'react'
+import type { Meta, StoryObj } from '@storybook/react'
+import { FarmingSim } from './FarmingSim'
+import type { CityState } from '../../game/cityBuilder'
+import { CITY_COLS, CITY_ROWS } from '../../game/cityBuilder'
+
+// Minimal CityState for story rendering
+const mockCity: CityState = {
+  grid: Array(CITY_COLS * CITY_ROWS).fill(undefined),
+  gold: 5000,
+  resources: { wheat: 50, wood: 30, ore: 10, bread: 0, planks: 0, metal: 0 },
+  lastTick: Date.now(),
+  happiness: {},
+  rows: CITY_ROWS,
+  cols: CITY_COLS,
+  nextAttackAt: Date.now() + 4 * 3600 * 1000,
+  fortifications: [],
+  builderQueue: [],
+  builderCount: 2,
+  lastAttack: null,
+  chronicle: [],
+  completedMilestones: [],
+  attacksProcessed: 0,
+  tradeOffer: null,
+  activeCaravan: null,
+  history: [],
+  zones: [],
+  activeDisaster: null,
+  nextDisasterAt: Date.now() + 24 * 3600 * 1000,
+  roadWear: { h: [], v: [] },
+  carriers: [],
+}
+
+const meta: Meta<typeof FarmingSim> = {
+  title: 'Farming/FarmingSim',
+  component: FarmingSim,
+}
+export default meta
+type Story = StoryObj<typeof FarmingSim>
+
+export const Default: Story = {
+  args: {
+    city: mockCity,
+    onSaveCity: (next) => console.log('save city', next.resources),
+    onBack: () => console.log('back'),
+  },
+}

--- a/web/src/components/minigames/FarmingSim.tsx
+++ b/web/src/components/minigames/FarmingSim.tsx
@@ -1,0 +1,426 @@
+// ─── Farming Simulation ────────────────────────────────────────────────────────
+// Arable land outside the city walls. Mirrors the CityBuilder walker system
+// but all walkers are farmers sourced from city population.
+
+import React, { useState, useEffect, useRef, useCallback } from 'react'
+import {
+  FarmState, FarmRaidEvent,
+  loadFarmState, saveFarmState, tickFarm,
+  placeFarmBuilding, removeFarmBuilding,
+  assignWorker, unassignWorker,
+  getFarmProductionRate, farmDefense,
+  canPlaceOnFarm, addFarmChronicle,
+  FARM_COLS, FARM_ROWS,
+} from '../../game/farmingSim'
+import {
+  CityState, ResourceType, CELL_PX,
+  cityPopulation, getBuildingProduces,
+  getNeighbourIndices,
+} from '../../game/cityBuilder'
+import { getCardCatalog } from '../../game/cards'
+import { loadCollection, getOwnedCount } from '../../game/collection'
+import { logError } from '../../logger'
+import { OverlayScreen } from '../ui/OverlayScreen'
+import { Walker, WalkerTask, TaskType, PersonalityTrait } from './citybuilder/walkerTypes'
+import { FarmGrid } from './farming/FarmGrid'
+import { FarmWorkerStrip } from './farming/FarmWorkerStrip'
+import { FarmRaidModal } from './farming/FarmRaidModal'
+import { FarmResourceBar } from './farming/FarmResourceBar'
+import { FarmBuildingPicker } from './farming/FarmBuildingPicker'
+import { ChroniclePanel } from './citybuilder/ChroniclePanel'
+import { Card } from '../../game/types'
+
+// ── Walker constants ──────────────────────────────────────────────────────────
+
+const UNIT_SIZE    = 20
+const SPEED        = 0.8
+const ARRIVE_DIST  = 14
+const IDLE_TICKS   = 80
+const BUBBLE_TICKS = 30
+const REST_MIN     = 4 * IDLE_TICKS
+const REST_MAX     = 7 * IDLE_TICKS
+const TRAITS: PersonalityTrait[] = ['brave', 'glutton', 'industrious', 'sociable', 'reclusive']
+
+// ── Walker factory ────────────────────────────────────────────────────────────
+
+function makeFarmerWalker(workerIndex: number, w: number, h: number): Walker {
+  const angle = Math.random() * Math.PI * 2
+  return {
+    cellIndex:  workerIndex,
+    unitIndex:  0,
+    unitName:   'farmer',
+    x:          Math.random() * Math.max(1, w - UNIT_SIZE),
+    y:          Math.random() * Math.max(1, h - UNIT_SIZE),
+    vx:         Math.cos(angle) * SPEED,
+    vy:         Math.sin(angle) * SPEED,
+    turnTimer:  20 + Math.floor(Math.random() * 30),
+    task:       { type: 'idle', label: '🚶 Taking a stroll' },
+    taskTimer:  Math.floor(Math.random() * IDLE_TICKS),
+    bubbleTimer: 0,
+    hidden:     false,
+    hiddenTimer: 0,
+    trait:      TRAITS[(workerIndex * 13) % 5],
+    waypoints:  [],
+  }
+}
+
+// ── Task picker for farm walkers ──────────────────────────────────────────────
+
+function pickFarmerTask(
+  w: Walker,
+  farm: FarmState,
+  overlayW: number,
+  overlayH: number,
+): WalkerTask {
+  const cols = farm.cols ?? FARM_COLS
+  const rows = farm.rows ?? FARM_ROWS
+
+  function cellPos(idx: number) {
+    return {
+      x: ((idx % cols) + 0.5) * (overlayW / cols),
+      y: (Math.floor(idx / cols) + 0.5) * (overlayH / rows),
+    }
+  }
+
+  const availablePlots = farm.plots
+    .map((p, i) => ({ p, i }))
+    .filter(({ p }) => p != null)
+
+  const tasks: WalkerTask[] = [
+    { type: 'idle' as TaskType, label: '🚶 Taking a stroll' },
+  ]
+
+  if (availablePlots.length > 0) {
+    const { i } = availablePlots[Math.floor(Math.random() * availablePlots.length)]
+    const pos = cellPos(i)
+    tasks.push({ type: 'farming' as TaskType, label: '🌾 Working the fields', targetX: pos.x, targetY: pos.y })
+    tasks.push({ type: 'gathering' as TaskType, label: '⛏ Gathering crops', targetX: pos.x, targetY: pos.y })
+  }
+
+  tasks.push({
+    type: 'resting' as TaskType, label: '💤 Taking a break',
+    targetX: (Math.random() * 0.6 + 0.2) * overlayW,
+    targetY: (Math.random() * 0.6 + 0.2) * overlayH,
+  })
+
+  return tasks[Math.floor(Math.random() * tasks.length)]
+}
+
+// ── Props / SubScreen ─────────────────────────────────────────────────────────
+
+interface Props {
+  city:       CityState
+  onSaveCity: (next: CityState) => void
+  onBack:     () => void
+}
+
+type SubScreen = 'farm' | 'picker' | 'chronicle'
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+export function FarmingSim({ city, onSaveCity, onBack }: Props) {
+  const [farm, setFarm]             = useState<FarmState>(() => tickFarm(loadFarmState()).nextState)
+  const [screen, setScreen]         = useState<SubScreen>('farm')
+  const [walkers, setWalkers]       = useState<Walker[]>([])
+  const [pickerIndex, setPickerIndex] = useState<number>(0)
+  const [bulldozer, setBulldozer]   = useState(false)
+  const [toast, setToast]           = useState<string | null>(null)
+  const [raidReport, setRaidReport] = useState<FarmRaidEvent | null>(null)
+  const [currentTime, setCurrentTime] = useState(Date.now())
+
+  const farmRef    = useRef(farm)
+  const walkersRef = useRef(walkers)
+  const worldRef   = useRef<HTMLDivElement>(null)
+  const worldDims  = useRef({ w: FARM_COLS * CELL_PX, h: FARM_ROWS * CELL_PX })
+  const raidShownRef = useRef<number | null>(
+    (() => {
+      try { const v = localStorage.getItem('farm-raid-shown-at'); return v ? Number(v) : null } catch { return null }
+    })()
+  )
+
+  function showToast(msg: string) {
+    setToast(msg)
+    setTimeout(() => setToast(null), 3000)
+  }
+
+  function saveFarm(next: FarmState) {
+    setFarm(next)
+    saveFarmState(next)
+  }
+
+  useEffect(() => { farmRef.current = farm }, [farm])
+  useEffect(() => { walkersRef.current = walkers }, [walkers])
+
+  // Show raid modal when a new raid is detected
+  useEffect(() => {
+    if (farm.lastRaid && farm.lastRaid.at !== raidShownRef.current) {
+      setRaidReport(farm.lastRaid)
+      raidShownRef.current = farm.lastRaid.at
+      try { localStorage.setItem('farm-raid-shown-at', String(farm.lastRaid.at)) } catch { /* ignore */ }
+    }
+  }, [farm.lastRaid])
+
+  // Sync walkers to worker count
+  useEffect(() => {
+    setWalkers(prev => {
+      const { w, h } = worldDims.current
+      const next: Walker[] = []
+      for (let i = 0; i < farm.workers; i++) {
+        next.push(prev[i] ?? makeFarmerWalker(i, w || FARM_COLS * CELL_PX, h || FARM_ROWS * CELL_PX))
+      }
+      return next
+    })
+  }, [farm.workers])
+
+  // Track overlay dimensions
+  useEffect(() => {
+    const el = worldRef.current
+    if (!el) return
+    const update = () => {
+      if (el.clientWidth > 0 && el.clientHeight > 0)
+        worldDims.current = { w: el.clientWidth, h: el.clientHeight }
+    }
+    update()
+    const ro = new ResizeObserver(update)
+    ro.observe(el)
+    return () => ro.disconnect()
+  }, [screen])
+
+  // Clock for raid countdown
+  useEffect(() => {
+    const id = setInterval(() => setCurrentTime(Date.now()), 60_000)
+    return () => clearInterval(id)
+  }, [])
+
+  // Farm tick every 10 s
+  useEffect(() => {
+    const id = setInterval(() => {
+      const { nextState, resourcesForCity } = tickFarm(farmRef.current)
+      saveFarmState(nextState)
+      setFarm(nextState)
+
+      const hasResources = Object.values(resourcesForCity).some(v => (v ?? 0) > 0)
+      if (hasResources) {
+        const newCityRes = { ...city.resources }
+        for (const [res, amt] of Object.entries(resourcesForCity) as [ResourceType, number][]) {
+          newCityRes[res] = Math.round((newCityRes[res] ?? 0) + amt)
+        }
+        onSaveCity({ ...city, resources: newCityRes })
+      }
+    }, 10_000)
+    return () => clearInterval(id)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  // Walker animation loop (100 ms)
+  useEffect(() => {
+    const id = setInterval(() => {
+      const { w: _w, h: _h } = worldDims.current
+      const overlayW = _w || FARM_COLS * CELL_PX
+      const overlayH = _h || FARM_ROWS * CELL_PX
+
+      setWalkers(prev => prev.map(w => {
+        let { x, y, vx, vy, turnTimer, task, taskTimer, bubbleTimer, waypoints } = w
+        waypoints = waypoints ?? []
+        bubbleTimer = Math.max(0, bubbleTimer - 1)
+
+        // Resting (hidden)
+        if (w.hidden) {
+          const t = w.hiddenTimer - 1
+          if (t <= 0) {
+            const newTask = pickFarmerTask(w, farmRef.current, overlayW, overlayH)
+            return { ...w, hidden: false, hiddenTimer: 0, task: newTask,
+              taskTimer: newTask.type === 'idle' ? IDLE_TICKS + Math.floor(Math.random() * IDLE_TICKS) : 0,
+              bubbleTimer: newTask.type !== 'idle' ? BUBBLE_TICKS : 0, waypoints: [] }
+          }
+          return { ...w, hiddenTimer: t }
+        }
+
+        // Idle countdown
+        if (task.type === 'idle') {
+          taskTimer--
+          if (taskTimer <= 0) {
+            task = pickFarmerTask(w, farmRef.current, overlayW, overlayH)
+            taskTimer = task.type === 'idle' ? IDLE_TICKS + Math.floor(Math.random() * IDLE_TICKS) : 0
+            if (task.type !== 'idle') bubbleTimer = BUBBLE_TICKS
+          }
+          // Random wander
+          turnTimer--
+          if (turnTimer <= 0) {
+            const angle = Math.random() * Math.PI * 2
+            vx = Math.cos(angle) * SPEED
+            vy = Math.sin(angle) * SPEED
+            turnTimer = 20 + Math.floor(Math.random() * 30)
+          }
+        }
+
+        // Directed movement
+        if (task.type !== 'idle' && task.targetX !== undefined && task.targetY !== undefined) {
+          const dx = task.targetX - x
+          const dy = task.targetY - y
+          const dist = Math.sqrt(dx * dx + dy * dy)
+
+          if (dist < ARRIVE_DIST) {
+            if (task.type === 'resting') {
+              return { ...w, x, y, vx: 0, vy: 0, task, bubbleTimer,
+                hidden: true, hiddenTimer: REST_MIN + Math.floor(Math.random() * (REST_MAX - REST_MIN)), waypoints: [] }
+            }
+            vx = 0; vy = 0
+            task = pickFarmerTask(w, farmRef.current, overlayW, overlayH)
+            taskTimer = task.type === 'idle' ? IDLE_TICKS + Math.floor(Math.random() * IDLE_TICKS) : 0
+            if (task.type !== 'idle') bubbleTimer = BUBBLE_TICKS
+          } else {
+            vx = (dx / dist) * SPEED
+            vy = (dy / dist) * SPEED
+          }
+        }
+
+        x += vx; y += vy
+        if (x < 0) { x = 0; vx = Math.abs(vx) }
+        if (x > overlayW - UNIT_SIZE) { x = overlayW - UNIT_SIZE; vx = -Math.abs(vx) }
+        if (y < 0) { y = 0; vy = Math.abs(vy) }
+        if (y > overlayH - UNIT_SIZE) { y = overlayH - UNIT_SIZE; vy = -Math.abs(vy) }
+
+        return { ...w, x, y, vx, vy, turnTimer, task, taskTimer, bubbleTimer, waypoints }
+      }))
+    }, 100)
+    return () => clearInterval(id)
+  }, [])
+
+  // ── Derived data ──────────────────────────────────────────────────────────────
+
+  const catalog    = getCardCatalog()
+  const collection = loadCollection()
+  const pop        = cityPopulation(city)
+
+  const placedOnFarm: Record<string, number> = {}
+  for (const p of farm.plots) {
+    if (p) placedOnFarm[p.cardName] = (placedOnFarm[p.cardName] ?? 0) + 1
+  }
+
+  const availableForFarm = catalog.filter(c => {
+    if (c.cardType !== 'structure') return false
+    const isSpawner = c.unit?.structureEffect?.type === 'spawn'
+    if (!canPlaceOnFarm(c.name, isSpawner ?? false)) return false
+    return (getOwnedCount(collection, c.name) - (placedOnFarm[c.name] ?? 0)) > 0
+  })
+
+  const prodRates   = getFarmProductionRate(farm)
+  const defense     = farmDefense(farm)
+  const nextRaidMs  = Math.max(0, farm.nextRaidAt - currentTime)
+
+  // ── Sub-screens ───────────────────────────────────────────────────────────────
+
+  if (screen === 'picker') {
+    return (
+      <FarmBuildingPicker
+        availableCards={availableForFarm}
+        onPick={(card: Card) => {
+          const isSpawner = card.unit?.structureEffect?.type === 'spawn'
+          if (!canPlaceOnFarm(card.name, isSpawner ?? false)) {
+            showToast('Only production buildings may be placed on the farm.')
+            setScreen('farm')
+            return
+          }
+          saveFarm(placeFarmBuilding(farm, pickerIndex, { cardName: card.name, rarity: card.rarity, stock: {} }))
+          setScreen('farm')
+        }}
+        onBack={() => setScreen('farm')}
+      />
+    )
+  }
+
+  if (screen === 'chronicle') {
+    return (
+      <ChroniclePanel
+        chronicle={farm.chronicle}
+        onBack={() => setScreen('farm')}
+      />
+    )
+  }
+
+  // ── Main farm view ────────────────────────────────────────────────────────────
+
+  return (
+    <OverlayScreen title={`🌾 FARM${bulldozer ? ' — DEMOLISH' : ''}`} onBack={onBack}>
+      <div className="farm-screen u-col u-gap-2">
+        {toast && <div className="city-toast" role="alert">{toast}</div>}
+
+        {raidReport && (
+          <FarmRaidModal
+            raid={raidReport}
+            onClose={() => setRaidReport(null)}
+          />
+        )}
+
+        <FarmWorkerStrip
+          assignedWorkers={farm.workers}
+          cityPopulation={pop}
+          onAssign={() => {
+            if (farm.workers >= pop) { showToast('No spare city residents to assign!'); return }
+            saveFarm(assignWorker(farm))
+          }}
+          onUnassign={() => {
+            if (farm.workers === 0) return
+            saveFarm(unassignWorker(farm))
+          }}
+        />
+
+        <FarmResourceBar
+          resources={farm.resources}
+          prodRates={prodRates}
+          workers={farm.workers}
+          farmDefense={defense}
+          nextRaidMs={nextRaidMs}
+        />
+
+        <FarmGrid
+          farm={farm}
+          walkers={walkers}
+          bulldozer={bulldozer}
+          worldRef={worldRef}
+          onCellTap={index => {
+            if (farm.plots[index]) {
+              if (bulldozer) {
+                const { state: next, returnedResources } = removeFarmBuilding(farm, index)
+                const hasReturned = Object.values(returnedResources).some(v => (v ?? 0) > 0)
+                if (hasReturned) {
+                  const newCityRes = { ...city.resources }
+                  for (const [res, amt] of Object.entries(returnedResources) as [ResourceType, number][]) {
+                    newCityRes[res] = Math.round((newCityRes[res] ?? 0) + (amt ?? 0))
+                  }
+                  onSaveCity({ ...city, resources: newCityRes })
+                }
+                saveFarm(next)
+                showToast('Building returned to city.')
+              } else {
+                showToast(`${farm.plots[index]?.cardName} — tap DEMOLISH to remove`)
+              }
+            } else {
+              setPickerIndex(index)
+              setScreen('picker')
+            }
+          }}
+          onWalkerClick={(ci) => showToast(`Farmer ${ci + 1} is ${walkers[ci]?.task.label ?? 'busy'}`)}
+        />
+
+        <div className="city-header u-flex u-items-c u-just-c u-gap-3">
+          <button
+            className={`filter-btn${bulldozer ? ' city-bulldozer-btn--active' : ''}`}
+            onClick={() => setBulldozer(prev => !prev)}
+          >
+            {bulldozer ? '🏗 DEMOLISH' : '👷 BUILD'}
+          </button>
+          <button className="filter-btn" onClick={() => setScreen('chronicle')}>
+            📜 HISTORY
+          </button>
+        </div>
+
+        <div style={{ fontSize: 11, color: '#557755', padding: '4px 8px', textAlign: 'center' }}>
+          Farms earn +50% resources but are raided every 3–4 hours with minimal defence.
+          Assign more farmers to boost output and defence.
+        </div>
+      </div>
+    </OverlayScreen>
+  )
+}

--- a/web/src/components/minigames/citybuilder/walkerTypes.ts
+++ b/web/src/components/minigames/citybuilder/walkerTypes.ts
@@ -3,7 +3,7 @@ import {
   cityDefense, getNeighbourIndices, spawnerUnitCount, getCityFoodScore,
 } from '../../../game/cityBuilder'
 
-export type TaskType = 'idle' | 'resting' | 'eating' | 'patrolling' | 'gathering' | 'visiting' | 'playing' | 'chatting'
+export type TaskType = 'idle' | 'resting' | 'eating' | 'patrolling' | 'gathering' | 'visiting' | 'playing' | 'chatting' | 'farming'
 
 export type PersonalityTrait = 'brave' | 'glutton' | 'industrious' | 'sociable' | 'reclusive'
 

--- a/web/src/components/minigames/farming/FarmBuildingPicker.stories.tsx
+++ b/web/src/components/minigames/farming/FarmBuildingPicker.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { FarmBuildingPicker } from './FarmBuildingPicker'
+import type { Card } from '../../../game/types'
+
+const sampleCards: Card[] = [
+  { id: 'farm-1', name: 'Farm', rarity: 'common', cost: 2, cardType: 'structure', description: 'Produces wheat' },
+  { id: 'lumber-camp-1', name: 'Lumber Camp', rarity: 'uncommon', cost: 3, cardType: 'structure', description: 'Produces wood' },
+  { id: 'quarry-1', name: 'Quarry', rarity: 'rare', cost: 4, cardType: 'structure', description: 'Produces ore and planks' },
+  { id: 'canopy-farm-1', name: 'Canopy Farm', rarity: 'uncommon', cost: 3, cardType: 'structure', description: 'Produces wheat' },
+  { id: 'blacksmith-1', name: 'Blacksmith', rarity: 'uncommon', cost: 3, cardType: 'structure', description: 'Produces metal' },
+  { id: 'windmill-1', name: 'Windmill', rarity: 'common', cost: 2, cardType: 'structure', description: 'Converts wheat to bread' },
+]
+
+const meta: Meta<typeof FarmBuildingPicker> = {
+  title: 'Farming/FarmBuildingPicker',
+  component: FarmBuildingPicker,
+}
+export default meta
+type Story = StoryObj<typeof FarmBuildingPicker>
+
+export const Default: Story = {
+  args: {
+    availableCards: sampleCards,
+    onPick: (c) => console.log('picked', c.name),
+    onBack: () => {},
+  },
+}
+
+export const Empty: Story = {
+  args: {
+    availableCards: [],
+    onPick: () => {},
+    onBack: () => {},
+  },
+}

--- a/web/src/components/minigames/farming/FarmBuildingPicker.tsx
+++ b/web/src/components/minigames/farming/FarmBuildingPicker.tsx
@@ -1,0 +1,72 @@
+import React, { useState } from 'react'
+import { Card } from '../../../game/types'
+import { getBuildingProduces, RESOURCE_ICONS, ResourceType } from '../../../game/cityBuilder'
+
+export interface Props {
+  availableCards: Card[]
+  onPick:         (card: Card) => void
+  onBack:         () => void
+}
+
+export function FarmBuildingPicker({ availableCards, onPick, onBack }: Props) {
+  const [search, setSearch] = useState('')
+
+  const filtered = availableCards.filter(c =>
+    c.name.toLowerCase().includes(search.toLowerCase())
+  )
+
+  return (
+    <div className="farm-picker u-col u-gap-3">
+      <div className="overlay-header u-flex u-items-c u-gap-6">
+        <button className="action-btn" onClick={onBack}>← BACK</button>
+        <span className="overlay-title">🌾 FARM BUILDINGS</span>
+      </div>
+
+      <div style={{ fontSize: 11, color: '#669966', padding: '0 4px' }}>
+        Only production buildings may be placed on the farm. Farms earn +50% resources but face
+        raids every 3–4 hours.
+      </div>
+
+      <input
+        className="city-picker-search"
+        placeholder="Search buildings…"
+        value={search}
+        onChange={e => setSearch(e.target.value)}
+      />
+
+      {filtered.length === 0 && (
+        <div style={{ color: '#668866', padding: 16, textAlign: 'center' }}>
+          {availableCards.length === 0
+            ? 'No production buildings available to place on the farm.'
+            : 'No buildings match your search.'}
+        </div>
+      )}
+
+      <div className="farm-picker-grid">
+        {filtered.map(card => {
+          const produces = getBuildingProduces(card.name)
+          const prodEntries = Object.entries(produces).filter(([, v]) => (v as number) > 0) as [ResourceType, number][]
+
+          return (
+            <div
+              key={card.name}
+              className="farm-picker-card"
+              onClick={() => onPick(card)}
+              title={`Place ${card.name} on the farm`}
+            >
+              <div className="farm-picker-card-name">{card.name}</div>
+              <div className="farm-picker-card-rarity">{card.rarity}</div>
+              <div className="farm-picker-card-produces">
+                {prodEntries.map(([res, rate]) => (
+                  <span key={res} className="farm-picker-prod-chip">
+                    {RESOURCE_ICONS[res]} +{(rate * 1.5).toFixed(1)}/min
+                  </span>
+                ))}
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/minigames/farming/FarmGrid.stories.tsx
+++ b/web/src/components/minigames/farming/FarmGrid.stories.tsx
@@ -1,0 +1,93 @@
+import React, { useRef } from 'react'
+import type { Meta, StoryObj } from '@storybook/react'
+import { FarmGrid } from './FarmGrid'
+import { FarmState } from '../../../game/farmingSim'
+import { Walker } from '../citybuilder/walkerTypes'
+
+const farm: FarmState = {
+  plots: [
+    { cardName: 'Farm', rarity: 'common', stock: {} },
+    { cardName: 'Lumber Camp', rarity: 'uncommon', stock: {} },
+    undefined,
+    { cardName: 'Farm', rarity: 'common', stock: {} },
+    undefined,
+    undefined,
+    undefined,
+    { cardName: 'Farm', rarity: 'common', stock: {} },
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined, undefined, undefined, undefined,
+    undefined, undefined, undefined, undefined,
+    undefined, undefined, undefined, undefined,
+  ],
+  rows: 4, cols: 6,
+  workers: 2,
+  lastTick: Date.now(),
+  nextRaidAt: Date.now() + 3_600_000,
+  lastRaid: null,
+  chronicle: [],
+  resources: { wheat: 5, wood: 2, ore: 0, bread: 0, planks: 0, metal: 0 },
+}
+
+const sampleWalkers: Walker[] = [
+  {
+    cellIndex: 0, unitIndex: 0, unitName: 'farmer', x: 50, y: 60,
+    vx: 1, vy: 0,
+    turnTimer: 20, task: { type: 'farming', label: '🌾 Working the fields' },
+    taskTimer: 10, bubbleTimer: 20, hidden: false, hiddenTimer: 0,
+    trait: 'industrious', waypoints: [],
+  },
+  {
+    cellIndex: 1, unitIndex: 0, unitName: 'farmer', x: 130, y: 100,
+    vx: 0, vy: 1,
+    turnTimer: 30, task: { type: 'idle', label: '🚶 Taking a stroll' },
+    taskTimer: 40, bubbleTimer: 0, hidden: false, hiddenTimer: 0,
+    trait: 'sociable', waypoints: [],
+  },
+]
+
+function Wrapper() {
+  const worldRef = useRef<HTMLDivElement>(null)
+  return (
+    <div style={{ padding: 16, background: '#1a2a1a' }}>
+      <FarmGrid
+        farm={farm}
+        walkers={sampleWalkers}
+        bulldozer={false}
+        worldRef={worldRef}
+        onCellTap={(i) => console.log('cell', i)}
+        onWalkerClick={(ci, ui) => console.log('walker', ci, ui)}
+      />
+    </div>
+  )
+}
+
+const meta: Meta<typeof FarmGrid> = {
+  title: 'Farming/FarmGrid',
+  component: FarmGrid,
+  render: () => <Wrapper />,
+}
+export default meta
+type Story = StoryObj<typeof FarmGrid>
+
+export const Default: Story = {}
+
+export const BulldozerMode: Story = {
+  render: () => {
+    const worldRef = useRef<HTMLDivElement>(null)
+    return (
+      <div style={{ padding: 16, background: '#1a2a1a' }}>
+        <FarmGrid
+          farm={farm}
+          walkers={[]}
+          bulldozer={true}
+          worldRef={worldRef}
+          onCellTap={(i) => console.log('bulldoze', i)}
+          onWalkerClick={() => {}}
+        />
+      </div>
+    )
+  },
+}

--- a/web/src/components/minigames/farming/FarmGrid.tsx
+++ b/web/src/components/minigames/farming/FarmGrid.tsx
@@ -1,0 +1,127 @@
+import React, { useRef, useCallback } from 'react'
+import { FarmState, FARM_COLS, FARM_ROWS } from '../../../game/farmingSim'
+import { CELL_PX } from '../../../game/cityBuilder'
+import { AnimatedSpriteImg } from '../../ui/SpriteImg'
+import { Walker } from '../citybuilder/walkerTypes'
+import { FarmPlotCell } from './FarmPlotCell'
+
+export interface Props {
+  farm:          FarmState
+  walkers:       Walker[]
+  bulldozer:     boolean
+  worldRef:      React.RefObject<HTMLDivElement>
+  onCellTap:     (index: number) => void
+  onWalkerClick: (cellIndex: number, unitIndex: number) => void
+}
+
+const UNIT_SIZE = 20
+
+export function FarmGrid({ farm, walkers, bulldozer, worldRef, onCellTap, onWalkerClick }: Props) {
+  const cols = farm.cols ?? FARM_COLS
+  const rows = farm.rows ?? FARM_ROWS
+  const cells = cols * rows
+
+  const isPaintingRef = useRef(false)
+  const lastTappedRef = useRef(-1)
+
+  const handlePointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    isPaintingRef.current = true
+    lastTappedRef.current = -1
+    ;(e.currentTarget as HTMLDivElement).setPointerCapture(e.pointerId)
+  }, [])
+
+  const handlePointerUp = useCallback(() => {
+    isPaintingRef.current = false
+  }, [])
+
+  return (
+    <div
+      className="farm-world"
+      ref={worldRef}
+      style={{ position: 'relative', touchAction: 'none' }}
+      onPointerDown={handlePointerDown}
+      onPointerUp={handlePointerUp}
+    >
+      {/* Farm grid */}
+      <div
+        className="farm-grid"
+        style={{
+          display: 'grid',
+          gridTemplateColumns: `repeat(${cols}, ${CELL_PX}px)`,
+          gridTemplateRows: `repeat(${rows}, ${CELL_PX}px)`,
+          gap: 2,
+          position: 'relative',
+        }}
+      >
+        {Array.from({ length: cells }).map((_, i) => (
+          <FarmPlotCell
+            key={i}
+            plot={farm.plots[i]}
+            index={i}
+            farmState={farm}
+            highlighted={false}
+            bulldozer={bulldozer}
+            onTap={onCellTap}
+          />
+        ))}
+      </div>
+
+      {/* Walker overlay — absolutely positioned over the grid */}
+      <div
+        style={{
+          position: 'absolute',
+          inset: 0,
+          pointerEvents: 'none',
+          overflow: 'hidden',
+        }}
+      >
+        {walkers.map((w, i) => {
+          if (w.hidden) return null
+          return (
+            <div
+              key={`${w.cellIndex}-${w.unitIndex}`}
+              style={{
+                position: 'absolute',
+                left: w.x,
+                top: w.y,
+                width: UNIT_SIZE,
+                height: UNIT_SIZE,
+                cursor: 'pointer',
+                pointerEvents: 'auto',
+                zIndex: 10,
+              }}
+              onClick={() => onWalkerClick(w.cellIndex, w.unitIndex)}
+              title={`Farmer ${i + 1}`}
+            >
+              <AnimatedSpriteImg
+                name="farmer"
+                frameCount={3}
+                fps={w.vx !== 0 || w.vy !== 0 ? 6 : 1}
+                style={{ width: UNIT_SIZE, height: UNIT_SIZE, imageRendering: 'pixelated' }}
+              />
+              {w.bubbleTimer > 0 && w.task.type !== 'idle' && (
+                <div
+                  style={{
+                    position: 'absolute',
+                    bottom: UNIT_SIZE + 2,
+                    left: '50%',
+                    transform: 'translateX(-50%)',
+                    background: 'rgba(0,0,0,0.8)',
+                    color: '#c0f0c0',
+                    fontSize: 9,
+                    padding: '1px 3px',
+                    borderRadius: 2,
+                    whiteSpace: 'nowrap',
+                    pointerEvents: 'none',
+                  }}
+                >
+                  {w.task.label}
+                </div>
+              )}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/minigames/farming/FarmPlotCell.stories.tsx
+++ b/web/src/components/minigames/farming/FarmPlotCell.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { FarmPlotCell } from './FarmPlotCell'
+import { FarmState } from '../../../game/farmingSim'
+
+const baseFarm: FarmState = {
+  plots: Array(24).fill(undefined),
+  rows: 4, cols: 6,
+  workers: 3,
+  lastTick: Date.now(),
+  nextRaidAt: Date.now() + 3_600_000,
+  lastRaid: null,
+  chronicle: [],
+  resources: { wheat: 0, wood: 0, ore: 0, bread: 0, planks: 0, metal: 0 },
+}
+
+const meta: Meta<typeof FarmPlotCell> = {
+  title: 'Farming/FarmPlotCell',
+  component: FarmPlotCell,
+}
+export default meta
+type Story = StoryObj<typeof FarmPlotCell>
+
+export const Empty: Story = {
+  args: {
+    plot: undefined, index: 0, farmState: baseFarm,
+    highlighted: false, bulldozer: false, onTap: () => {},
+  },
+}
+
+export const OccupiedFarm: Story = {
+  args: {
+    plot: { cardName: 'Farm', rarity: 'common', stock: {} },
+    index: 0, farmState: baseFarm,
+    highlighted: false, bulldozer: false, onTap: () => {},
+  },
+}
+
+export const OccupiedLumber: Story = {
+  args: {
+    plot: { cardName: 'Lumber Camp', rarity: 'uncommon', stock: {} },
+    index: 1, farmState: baseFarm,
+    highlighted: false, bulldozer: false, onTap: () => {},
+  },
+}
+
+export const BulldozerMode: Story = {
+  args: {
+    plot: { cardName: 'Farm', rarity: 'common', stock: {} },
+    index: 0, farmState: baseFarm,
+    highlighted: false, bulldozer: true, onTap: () => {},
+  },
+}
+
+export const Highlighted: Story = {
+  args: {
+    plot: undefined, index: 0, farmState: baseFarm,
+    highlighted: true, bulldozer: false, onTap: () => {},
+  },
+}

--- a/web/src/components/minigames/farming/FarmPlotCell.tsx
+++ b/web/src/components/minigames/farming/FarmPlotCell.tsx
@@ -1,0 +1,47 @@
+import React from 'react'
+import { FarmPlot, getFarmProductionRate, FarmState } from '../../../game/farmingSim'
+import { getBuildingProduces, RESOURCE_ICONS, ResourceType } from '../../../game/cityBuilder'
+import { SpriteImg } from '../../ui/SpriteImg'
+
+export interface Props {
+  plot:        FarmPlot | undefined
+  index:       number
+  farmState:   FarmState
+  highlighted: boolean
+  bulldozer:   boolean
+  onTap:       (index: number) => void
+}
+
+export function FarmPlotCell({ plot, index, farmState, highlighted, bulldozer, onTap }: Props) {
+  if (!plot) {
+    return (
+      <div
+        className={`farm-cell farm-cell--empty${highlighted ? ' farm-cell--highlighted' : ''}`}
+        onClick={() => onTap(index)}
+        title="Empty plot — tap to place a building"
+      >
+        <span className="farm-cell-plus">+</span>
+      </div>
+    )
+  }
+
+  const produces = getBuildingProduces(plot.cardName)
+  const prodEntries = Object.entries(produces).filter(([, v]) => (v as number) > 0) as [ResourceType, number][]
+
+  return (
+    <div
+      className={`farm-cell farm-cell--occupied${bulldozer ? ' farm-cell--bulldozer' : ''}${highlighted ? ' farm-cell--highlighted' : ''}`}
+      onClick={() => onTap(index)}
+      title={bulldozer ? `Remove ${plot.cardName}` : plot.cardName}
+    >
+      <SpriteImg name={plot.cardName} className="farm-cell-sprite" />
+      <span className="farm-cell-name">{plot.cardName}</span>
+      {prodEntries.length > 0 && (
+        <span className="farm-cell-rate">
+          {prodEntries.map(([res]) => RESOURCE_ICONS[res]).join('')}
+        </span>
+      )}
+      {bulldozer && <span className="farm-cell-demolish">✕</span>}
+    </div>
+  )
+}

--- a/web/src/components/minigames/farming/FarmRaidModal.stories.tsx
+++ b/web/src/components/minigames/farming/FarmRaidModal.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { FarmRaidModal } from './FarmRaidModal'
+
+const meta: Meta<typeof FarmRaidModal> = {
+  title: 'Farming/FarmRaidModal',
+  component: FarmRaidModal,
+}
+export default meta
+type Story = StoryObj<typeof FarmRaidModal>
+
+export const Repelled: Story = {
+  args: {
+    raid: {
+      at: Date.now(), power: 20, defense: 30,
+      outcome: 'repelled',
+      stolenResources: {},
+      destroyedPlots: [],
+    },
+    onClose: () => {},
+  },
+}
+
+export const PartialRaid: Story = {
+  args: {
+    raid: {
+      at: Date.now(), power: 35, defense: 20,
+      outcome: 'partial',
+      stolenResources: { wheat: 18, wood: 6 },
+      destroyedPlots: [],
+    },
+    onClose: () => {},
+  },
+}
+
+export const Defeated: Story = {
+  args: {
+    raid: {
+      at: Date.now(), power: 60, defense: 4,
+      outcome: 'defeated',
+      stolenResources: { wheat: 45, wood: 20, ore: 8 },
+      destroyedPlots: ['Farm', 'Lumber Camp'],
+    },
+    onClose: () => {},
+  },
+}

--- a/web/src/components/minigames/farming/FarmRaidModal.tsx
+++ b/web/src/components/minigames/farming/FarmRaidModal.tsx
@@ -1,0 +1,66 @@
+import React from 'react'
+import { FarmRaidEvent } from '../../../game/farmingSim'
+import { RESOURCE_ICONS, ResourceType } from '../../../game/cityBuilder'
+import { ModalBackdrop } from '../../ui/ModalBackdrop'
+
+export interface Props {
+  raid:    FarmRaidEvent
+  onClose: () => void
+}
+
+const OUTCOME_META: Record<FarmRaidEvent['outcome'], { icon: string; cls: string; label: string }> = {
+  repelled: { icon: '🛡', cls: 'farm-raid--repelled', label: 'REPELLED' },
+  partial:  { icon: '⚠',  cls: 'farm-raid--partial',  label: 'PARTIAL RAID' },
+  defeated: { icon: '💀', cls: 'farm-raid--defeated',  label: 'OVERRUN' },
+}
+
+export function FarmRaidModal({ raid, onClose }: Props) {
+  const meta = OUTCOME_META[raid.outcome]
+  const stolenEntries = Object.entries(raid.stolenResources).filter(([, v]) => (v as number) > 0) as [ResourceType, number][]
+
+  return (
+    <ModalBackdrop onClose={onClose}>
+      <div className={`farm-raid-modal ${meta.cls}`}>
+        <div className="farm-raid-icon">{meta.icon}</div>
+        <div className="farm-raid-outcome">{meta.label}</div>
+
+        <div className="farm-raid-row">
+          <span>Raid power</span><span>{raid.power}</span>
+        </div>
+        <div className="farm-raid-row">
+          <span>Farm defence</span><span>{raid.defense}</span>
+        </div>
+
+        {stolenEntries.length > 0 && (
+          <div className="farm-raid-stolen">
+            <div className="farm-raid-stolen-title">Stolen resources</div>
+            <div className="u-flex u-gap-3 u-wrap">
+              {stolenEntries.map(([res, amt]) => (
+                <span key={res} className="city-res-chip">
+                  {RESOURCE_ICONS[res]} {Math.round(amt)}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {raid.destroyedPlots.length > 0 && (
+          <div className="farm-raid-destroyed">
+            <div className="farm-raid-destroyed-title">Destroyed buildings</div>
+            {raid.destroyedPlots.map((name, i) => (
+              <div key={i} className="farm-raid-destroyed-item">💥 {name}</div>
+            ))}
+          </div>
+        )}
+
+        {raid.outcome === 'repelled' && (
+          <div className="farm-raid-success">No damage — your farmers held the line!</div>
+        )}
+
+        <button className="action-btn" onClick={onClose} style={{ marginTop: 12 }}>
+          DISMISS
+        </button>
+      </div>
+    </ModalBackdrop>
+  )
+}

--- a/web/src/components/minigames/farming/FarmResourceBar.stories.tsx
+++ b/web/src/components/minigames/farming/FarmResourceBar.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { FarmResourceBar } from './FarmResourceBar'
+
+const meta: Meta<typeof FarmResourceBar> = {
+  title: 'Farming/FarmResourceBar',
+  component: FarmResourceBar,
+}
+export default meta
+type Story = StoryObj<typeof FarmResourceBar>
+
+export const Producing: Story = {
+  args: {
+    resources: { wheat: 42, wood: 18, ore: 5, bread: 0, planks: 0, metal: 0 },
+    prodRates: { wheat: 4.5, wood: 2.1 },
+    workers: 3,
+    farmDefense: 6,
+    nextRaidMs: 2 * 3600 * 1000,
+  },
+}
+
+export const RaidImminent: Story = {
+  args: {
+    resources: { wheat: 10, wood: 5, ore: 0, bread: 0, planks: 0, metal: 0 },
+    prodRates: { wheat: 3 },
+    workers: 1,
+    farmDefense: 2,
+    nextRaidMs: 15 * 60 * 1000,
+  },
+}
+
+export const Empty: Story = {
+  args: {
+    resources: { wheat: 0, wood: 0, ore: 0, bread: 0, planks: 0, metal: 0 },
+    prodRates: {},
+    workers: 0,
+    farmDefense: 0,
+    nextRaidMs: 4 * 3600 * 1000,
+  },
+}

--- a/web/src/components/minigames/farming/FarmResourceBar.tsx
+++ b/web/src/components/minigames/farming/FarmResourceBar.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+import { ResourceStock, ResourceType, RESOURCE_ICONS } from '../../../game/cityBuilder'
+
+export interface Props {
+  resources:   ResourceStock
+  prodRates:   Partial<ResourceStock>
+  workers:     number
+  farmDefense: number
+  nextRaidMs:  number
+}
+
+const RESOURCE_ORDER: ResourceType[] = ['wheat', 'wood', 'ore', 'bread', 'planks', 'metal']
+
+function fmtCountdown(ms: number): string {
+  if (ms <= 0) return 'IMMINENT'
+  const mins = Math.floor(ms / 60_000)
+  const h = Math.floor(mins / 60)
+  const m = mins % 60
+  return h > 0 ? `${h}h ${m}m` : `${m}m`
+}
+
+export function FarmResourceBar({ resources, prodRates, workers, farmDefense, nextRaidMs }: Props) {
+  const urgency = nextRaidMs < 1_800_000 ? 'imminent' : nextRaidMs < 5_400_000 ? 'soon' : 'calm'
+
+  return (
+    <div className="farm-res-bar">
+      {RESOURCE_ORDER.map(res => {
+        const stock = Math.round(resources[res] ?? 0)
+        const rate  = Math.round((prodRates[res] ?? 0) * 10) / 10
+        if (stock === 0 && rate === 0) return null
+        return (
+          <span key={res} className="city-res-chip" title={`${res}: ${stock} stock, +${rate}/min`}>
+            {RESOURCE_ICONS[res]} {stock}
+            {rate > 0 && <span className="city-res-pos"> +{rate}</span>}
+          </span>
+        )
+      })}
+      <span className="farm-res-stat">👨‍🌾 {workers}</span>
+      <span className="farm-res-stat">🛡 {farmDefense}</span>
+      <span className={`farm-raid-pill farm-raid-pill--${urgency}`}>
+        ⚔ {fmtCountdown(nextRaidMs)}
+      </span>
+    </div>
+  )
+}

--- a/web/src/components/minigames/farming/FarmWorkerStrip.stories.tsx
+++ b/web/src/components/minigames/farming/FarmWorkerStrip.stories.tsx
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { FarmWorkerStrip } from './FarmWorkerStrip'
+
+const meta: Meta<typeof FarmWorkerStrip> = {
+  title: 'Farming/FarmWorkerStrip',
+  component: FarmWorkerStrip,
+}
+export default meta
+type Story = StoryObj<typeof FarmWorkerStrip>
+
+export const ThreeOfEight: Story = {
+  args: { assignedWorkers: 3, cityPopulation: 8, onAssign: () => {}, onUnassign: () => {} },
+}
+
+export const None: Story = {
+  args: { assignedWorkers: 0, cityPopulation: 12, onAssign: () => {}, onUnassign: () => {} },
+}
+
+export const Full: Story = {
+  args: { assignedWorkers: 10, cityPopulation: 10, onAssign: () => {}, onUnassign: () => {} },
+}

--- a/web/src/components/minigames/farming/FarmWorkerStrip.tsx
+++ b/web/src/components/minigames/farming/FarmWorkerStrip.tsx
@@ -1,0 +1,43 @@
+import React from 'react'
+
+export interface Props {
+  assignedWorkers: number
+  cityPopulation:  number
+  onAssign:        () => void
+  onUnassign:      () => void
+}
+
+export function FarmWorkerStrip({ assignedWorkers, cityPopulation, onAssign, onUnassign }: Props) {
+  const canAssign   = assignedWorkers < cityPopulation
+  const canUnassign = assignedWorkers > 0
+
+  return (
+    <div className="farm-worker-strip">
+      <span className="farm-worker-label">👨‍🌾 Farmers</span>
+      <button
+        className="farm-worker-btn"
+        onClick={onUnassign}
+        disabled={!canUnassign}
+        title="Send a farmer back to the city"
+        aria-label="Unassign farmer"
+      >
+        −
+      </button>
+      <span className="farm-worker-count">
+        {assignedWorkers}<span className="farm-worker-sep">/</span>{cityPopulation}
+      </span>
+      <button
+        className="farm-worker-btn"
+        onClick={onAssign}
+        disabled={!canAssign}
+        title={canAssign ? 'Assign a city resident as a farmer' : 'No spare city residents'}
+        aria-label="Assign farmer"
+      >
+        +
+      </button>
+      <span className="farm-worker-hint">
+        +{(assignedWorkers * 5).toFixed(0)}% production · {assignedWorkers * 2} def
+      </span>
+    </div>
+  )
+}

--- a/web/src/components/ui/SpriteImg.tsx
+++ b/web/src/components/ui/SpriteImg.tsx
@@ -17,7 +17,7 @@ function isMonochromeMode(): boolean {
 }
 
 /** Draws src onto a tiny canvas and subscribes to 8-bit mode changes. */
-function EightbitCanvas({ src, alt, className, onError }: { src: string; alt: string; className?: string; onError?: () => void }) {
+function EightbitCanvas({ src, alt, className, style, onError }: { src: string; alt: string; className?: string; style?: React.CSSProperties; onError?: () => void }) {
   const canvasRef = useRef<HTMLCanvasElement>(null)
 
   useEffect(() => {
@@ -44,13 +44,14 @@ function EightbitCanvas({ src, alt, className, onError }: { src: string; alt: st
       width={EIGHTBIT_PX}
       height={EIGHTBIT_PX}
       className={className}
+      style={style}
       aria-label={alt}
     />
   )
 }
 
 /** Draws src onto a black and white canvas. */
-function MonochromeCanvas({ src, alt, className, onError }: { src: string; alt: string; className?: string; onError?: () => void }) {
+function MonochromeCanvas({ src, alt, className, style, onError }: { src: string; alt: string; className?: string; style?: React.CSSProperties; onError?: () => void }) {
   const canvasRef = useRef<HTMLCanvasElement>(null)
 
   useEffect(() => {
@@ -77,7 +78,7 @@ function MonochromeCanvas({ src, alt, className, onError }: { src: string; alt: 
     return () => { cancelled = true }
   }, [src, onError])
 
-  return <canvas ref={canvasRef} className={className} aria-label={alt} />
+  return <canvas ref={canvasRef} className={className} style={style} aria-label={alt} />
 }
 
 
@@ -87,6 +88,7 @@ interface Props {
   /** Optional secondary name to try if the primary name has no sprite file. */
   fallbackName?: string
   className?: string
+  style?: React.CSSProperties
 }
 
 /**
@@ -95,7 +97,7 @@ interface Props {
  * `sprites/fallback.svg`. Renders nothing only if all fail.
  * In 8-bit mode renders via a low-res canvas for a pixelated look.
  */
-export function SpriteImg({ name, fallbackName, className }: Props) {
+export function SpriteImg({ name, fallbackName, className, style }: Props) {
   const slug            = spriteSlug(name)
   const pngSrc          = `${BASE}sprites/${slug}.png`
   const svgSrc          = `${BASE}sprites/${slug}.svg`
@@ -145,10 +147,10 @@ export function SpriteImg({ name, fallbackName, className }: Props) {
   if (failed) return null
 
   if (eightbit && loaded) {
-    return <EightbitCanvas src={src} alt={name} className={className} />
+    return <EightbitCanvas src={src} alt={name} className={className} style={style} />
   }
   if (monochrome && loaded) {
-    return <MonochromeCanvas src={src} alt={name} className={className} />
+    return <MonochromeCanvas src={src} alt={name} className={className} style={style} />
   }
 
   return (
@@ -156,7 +158,7 @@ export function SpriteImg({ name, fallbackName, className }: Props) {
       src={src}
       alt={name}
       className={className}
-      style={{ display: loaded ? undefined : 'none' }}
+      style={{ display: loaded ? undefined : 'none', ...style }}
       onLoad={() => setLoaded(true)}
       onError={() => {
         if (src === pngSrc) setSrc(svgSrc)
@@ -176,6 +178,7 @@ interface AnimatedProps {
   /** Frames per second for the walking animation. */
   fps: number
   className?: string
+  style?: React.CSSProperties
 }
 
 /**
@@ -183,7 +186,7 @@ interface AnimatedProps {
  * Falls back to `SpriteImg` (static sprite) if frame files are missing.
  * In 8-bit mode renders each frame via a low-res canvas.
  */
-export function AnimatedSpriteImg({ name, frameCount, fps, className }: AnimatedProps) {
+export function AnimatedSpriteImg({ name, frameCount, fps, className, style }: AnimatedProps) {
   const slug = spriteSlug(name)
   const [frame,       setFrame]       = useState(1)
   const [useFallback, setUseFallback] = useState(false)
@@ -213,7 +216,7 @@ export function AnimatedSpriteImg({ name, frameCount, fps, className }: Animated
   }, [frameCount, fps, useFallback])
 
   if (useFallback) {
-    return <SpriteImg name={name} className={className} />
+    return <SpriteImg name={name} className={className} style={style} />
   }
 
   const src = `${BASE}sprites/${slug}-${frame}.svg`
@@ -224,10 +227,10 @@ export function AnimatedSpriteImg({ name, frameCount, fps, className }: Animated
   }
 
   if (eightbit) {
-    return <EightbitCanvas src={src} alt={name} className={className} onError={handleFrameError} />
+    return <EightbitCanvas src={src} alt={name} className={className} style={style} onError={handleFrameError} />
   }
   if (monochrome) {
-    return <MonochromeCanvas src={src} alt={name} className={className} onError={handleFrameError} />
+    return <MonochromeCanvas src={src} alt={name} className={className} style={style} onError={handleFrameError} />
   }
 
 
@@ -236,6 +239,7 @@ export function AnimatedSpriteImg({ name, frameCount, fps, className }: Animated
       src={src}
       alt={name}
       className={className}
+      style={style}
       onError={() => {
         if (intervalRef.current) clearInterval(intervalRef.current)
         setUseFallback(true)

--- a/web/src/game/farmingSim.ts
+++ b/web/src/game/farmingSim.ts
@@ -1,0 +1,395 @@
+// ─── Farming Simulation ────────────────────────────────────────────────────────
+// Arable land outside the city walls. Production buildings relocated here earn
+// a 50 % resource bonus but are raided twice as often and have minimal defence.
+// Workers come from the city population. Resources are shipped to the city pool.
+
+import { logError } from '../logger'
+import {
+  ResourceType, ResourceStock,
+  getBuildingProduces, currentSeason, SEASON_INFO,
+  CELL_PX,
+} from './cityBuilder'
+import type { CardRarity } from './types'
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+export const FARM_COLS = 6
+export const FARM_ROWS = 4
+export const FARM_CELLS = FARM_COLS * FARM_ROWS
+
+/** Production multiplier applied to farm buildings vs their city equivalent. */
+const FARM_PRODUCTION_BONUS = 1.5
+
+/** Defence contributed per assigned farm worker. */
+const WORKER_DEFENSE = 2
+
+/** Production multiplier bonus per farm worker (+5 % each). */
+const WORKER_PROD_BONUS = 0.05
+
+/** Base raid interval in ms (3 hours — twice as frequent as city's 6 h). */
+const BASE_RAID_INTERVAL_MS = 3 * 3600 * 1000
+/** Random jitter added to each raid interval (up to 2 hours). */
+const RAID_INTERVAL_JITTER_MS = 2 * 3600 * 1000
+
+/** Max offline minutes tracked (same as city). */
+const MAX_OFFLINE_MINUTES = 480
+/** Sub-step for offline catch-up (5-minute chunks). */
+const FARM_STEP_MS = 5 * 60_000
+
+/** Resources per farm plot that accumulate before shipping to the city. */
+const SHIP_THRESHOLD = 5
+
+/** Chronicle log cap. */
+const CHRONICLE_MAX = 30
+
+const STORAGE_KEY = 'jarv_farming_sim'
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export interface FarmPlot {
+  cardName:  string
+  rarity:    CardRarity
+  stock:     Partial<ResourceStock>
+}
+
+export interface FarmRaidEvent {
+  at:              number
+  power:           number
+  defense:         number
+  outcome:         'repelled' | 'partial' | 'defeated'
+  stolenResources: Partial<ResourceStock>
+  destroyedPlots:  string[]
+}
+
+export interface FarmState {
+  plots:      (FarmPlot | undefined)[]
+  rows:       number
+  cols:       number
+  workers:    number
+  lastTick:   number
+  nextRaidAt: number
+  lastRaid:   FarmRaidEvent | null
+  chronicle:  string[]
+  resources:  ResourceStock
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function emptyResources(): ResourceStock {
+  return { wheat: 0, wood: 0, ore: 0, bread: 0, planks: 0, metal: 0 }
+}
+
+function fmtTime(ts: number): string {
+  const d = new Date(ts)
+  return d.toLocaleString(undefined, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })
+}
+
+export function addFarmChronicle(state: FarmState, msg: string): FarmState {
+  const entry = `[${fmtTime(Date.now())}] ${msg}`
+  const chronicle = [entry, ...(state.chronicle ?? [])].slice(0, CHRONICLE_MAX)
+  return { ...state, chronicle }
+}
+
+// ── Default / load / save ─────────────────────────────────────────────────────
+
+function defaultFarmState(): FarmState {
+  return {
+    plots:      Array(FARM_CELLS).fill(undefined),
+    rows:       FARM_ROWS,
+    cols:       FARM_COLS,
+    workers:    0,
+    lastTick:   Date.now(),
+    nextRaidAt: Date.now() + BASE_RAID_INTERVAL_MS + Math.random() * RAID_INTERVAL_JITTER_MS,
+    lastRaid:   null,
+    chronicle:  [],
+    resources:  emptyResources(),
+  }
+}
+
+export function loadFarmState(): FarmState {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return defaultFarmState()
+    const parsed = JSON.parse(raw) as Partial<FarmState>
+    const rows = parsed.rows ?? FARM_ROWS
+    const cols = parsed.cols ?? FARM_COLS
+    const cells = rows * cols
+    const savedPlots = parsed.plots ?? Array(cells).fill(undefined)
+    const plots = (savedPlots.length < cells
+      ? [...savedPlots, ...Array(cells - savedPlots.length).fill(undefined)]
+      : savedPlots
+    ).map((p: FarmPlot | undefined) => p ? { ...p, stock: p.stock ?? {} } : p)
+    const savedRes = (parsed.resources ?? {}) as Partial<ResourceStock>
+    return {
+      plots,
+      rows,
+      cols,
+      workers:    parsed.workers    ?? 0,
+      lastTick:   parsed.lastTick   ?? Date.now(),
+      nextRaidAt: parsed.nextRaidAt ?? Date.now() + BASE_RAID_INTERVAL_MS,
+      lastRaid:   parsed.lastRaid   ?? null,
+      chronicle:  parsed.chronicle  ?? [],
+      resources: {
+        wheat:  savedRes.wheat  ?? 0,
+        wood:   savedRes.wood   ?? 0,
+        ore:    savedRes.ore    ?? 0,
+        bread:  savedRes.bread  ?? 0,
+        planks: savedRes.planks ?? 0,
+        metal:  savedRes.metal  ?? 0,
+      },
+    }
+  } catch (err) {
+    logError('loadFarmState failed', err as Record<string, unknown>)
+    return defaultFarmState()
+  }
+}
+
+export function saveFarmState(state: FarmState): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state))
+  } catch (err) {
+    logError('saveFarmState failed', err as Record<string, unknown>)
+  }
+}
+
+// ── Unlock & placement guards ─────────────────────────────────────────────────
+
+/** Farm unlocks when the city reaches a population of 10. */
+export function isFarmUnlocked(cityPop: number): boolean {
+  return cityPop >= 10
+}
+
+/** Returns true if the given building card is a pure production building
+ *  that may be placed on the farm (no spawner units, must produce ≥1 resource). */
+export function canPlaceOnFarm(cardName: string, isSpawner: boolean): boolean {
+  if (isSpawner) return false
+  const produces = getBuildingProduces(cardName)
+  return Object.values(produces).some(v => (v ?? 0) > 0)
+}
+
+// ── Farm aggregate stats ──────────────────────────────────────────────────────
+
+/** Production rates (per minute) for the entire farm, including worker bonus and season. */
+export function getFarmProductionRate(state: FarmState, nowMs = Date.now()): Partial<ResourceStock> {
+  const rates: Partial<ResourceStock> = {}
+  const si = SEASON_INFO[currentSeason(nowMs)]
+  const workerMult = 1 + state.workers * WORKER_PROD_BONUS
+
+  for (const plot of state.plots) {
+    if (!plot) continue
+    const produces = getBuildingProduces(plot.cardName)
+    for (const [res, rate] of Object.entries(produces) as [ResourceType, number][]) {
+      const seasonMult = res === 'wheat' ? 1 + si.wheat
+                       : res === 'wood'  ? 1 + si.wood
+                       : res === 'ore'   ? 1 + si.ore
+                       : 1
+      const amount = rate * FARM_PRODUCTION_BONUS * Math.max(0, seasonMult) * workerMult
+      rates[res as ResourceType] = (rates[res as ResourceType] ?? 0) + amount
+    }
+  }
+  return rates
+}
+
+/** Defence value of the farm (based solely on assigned workers). */
+export function farmDefense(state: FarmState): number {
+  return state.workers * WORKER_DEFENSE
+}
+
+/** Number of production plots occupied. */
+export function farmPlotCount(state: FarmState): number {
+  return state.plots.filter(p => p != null).length
+}
+
+// ── Plot placement / removal ──────────────────────────────────────────────────
+
+export function placeFarmBuilding(state: FarmState, index: number, plot: FarmPlot): FarmState {
+  if (state.plots[index]) return state
+  const plots = [...state.plots]
+  plots[index] = { ...plot, stock: {} }
+  let next = { ...state, plots }
+  next = addFarmChronicle(next, `🌾 ${plot.cardName} placed on the farm`)
+  return next
+}
+
+export function removeFarmBuilding(state: FarmState, index: number): { state: FarmState; returnedResources: Partial<ResourceStock> } {
+  const plot = state.plots[index]
+  if (!plot) return { state, returnedResources: {} }
+  const returnedResources = { ...plot.stock }
+  const plots = [...state.plots]
+  plots[index] = undefined
+  let next = { ...state, plots }
+  next = addFarmChronicle(next, `🏗 ${plot.cardName} moved back to city`)
+  return { state: next, returnedResources }
+}
+
+// ── Worker assignment ─────────────────────────────────────────────────────────
+
+/** Assign one city resident as a farm worker. Returns updated state. */
+export function assignWorker(state: FarmState): FarmState {
+  return { ...state, workers: state.workers + 1 }
+}
+
+/** Unassign one farm worker (min 0). Returns updated state. */
+export function unassignWorker(state: FarmState): FarmState {
+  return { ...state, workers: Math.max(0, state.workers - 1) }
+}
+
+// ── Raid processing ───────────────────────────────────────────────────────────
+
+function processFarmRaid(state: FarmState): FarmState {
+  const defense = farmDefense(state)
+  const occupied = state.plots.filter(p => p != null).length
+  const power = 15 + occupied * 4 + Math.floor(Math.random() * 20)
+
+  const ratio = defense / Math.max(power, 1)
+  let outcome: FarmRaidEvent['outcome']
+  const stolenResources: Partial<ResourceStock> = {}
+  const destroyedPlots: string[] = []
+
+  const newResources = { ...state.resources }
+  const newPlots = [...state.plots]
+
+  if (ratio >= 1.0) {
+    outcome = 'repelled'
+  } else if (ratio >= 0.5) {
+    outcome = 'partial'
+    for (const [res, amt] of Object.entries(newResources) as [ResourceType, number][]) {
+      const stolen = Math.floor(amt * 0.25)
+      if (stolen > 0) { stolenResources[res] = stolen; newResources[res] = amt - stolen }
+    }
+    // Damage one plot's stock
+    const occupiedIndices = newPlots.map((p, i) => p ? i : -1).filter(i => i >= 0)
+    if (occupiedIndices.length > 0) {
+      const target = occupiedIndices[Math.floor(Math.random() * occupiedIndices.length)]
+      const plot = newPlots[target]!
+      const damaged = { ...plot, stock: Object.fromEntries(
+        Object.entries(plot.stock).map(([k, v]) => [k, Math.floor((v as number) * 0.5)])
+      ) as Partial<ResourceStock> }
+      newPlots[target] = damaged
+    }
+  } else {
+    outcome = 'defeated'
+    for (const [res, amt] of Object.entries(newResources) as [ResourceType, number][]) {
+      const stolen = Math.floor(amt * 0.5)
+      if (stolen > 0) { stolenResources[res] = stolen; newResources[res] = Math.max(0, amt - stolen) }
+    }
+    // Destroy 1–3 plots
+    const occupiedIndices = newPlots.map((p, i) => p ? i : -1).filter(i => i >= 0)
+    const toDestroy = Math.min(occupiedIndices.length, 1 + Math.floor(Math.random() * 3))
+    const shuffled = [...occupiedIndices].sort(() => Math.random() - 0.5)
+    for (let k = 0; k < toDestroy; k++) {
+      const idx = shuffled[k]
+      destroyedPlots.push(newPlots[idx]!.cardName)
+      newPlots[idx] = undefined
+    }
+  }
+
+  const event: FarmRaidEvent = {
+    at: Date.now(),
+    power, defense, outcome, stolenResources, destroyedPlots,
+  }
+
+  const msg =
+    outcome === 'repelled' ? '⚔ Farm raid repelled — no damage!' :
+    outcome === 'partial'  ? `⚠ Farm raided — resources stolen` :
+    `💀 Farm overrun — ${destroyedPlots.length} building${destroyedPlots.length > 1 ? 's' : ''} destroyed`
+
+  let next = addFarmChronicle(
+    { ...state, resources: newResources, plots: newPlots },
+    msg,
+  )
+  next = {
+    ...next,
+    lastRaid:   event,
+    nextRaidAt: Date.now() + BASE_RAID_INTERVAL_MS + Math.random() * RAID_INTERVAL_JITTER_MS,
+  }
+  return next
+}
+
+// ── Tick ──────────────────────────────────────────────────────────────────────
+
+/**
+ * Advances the farm simulation forward to `nowMs`.
+ *
+ * Returns:
+ * - `nextState`: updated FarmState (save this to localStorage)
+ * - `resourcesForCity`: resources produced this tick that should be added to CityState.resources
+ */
+export function tickFarm(
+  state: FarmState,
+  nowMs = Date.now(),
+): { nextState: FarmState; resourcesForCity: Partial<ResourceStock> } {
+  const elapsed = nowMs - state.lastTick
+
+  // Sub-step for long offline gaps so production accumulates correctly
+  if (elapsed > FARM_STEP_MS * 1.5) {
+    const steps = Math.min(Math.ceil(elapsed / FARM_STEP_MS), MAX_OFFLINE_MINUTES / 5)
+    const stepMs = elapsed / steps
+    let current = state
+    const totalForCity: Partial<ResourceStock> = {}
+
+    for (let i = 0; i < steps; i++) {
+      const { nextState, resourcesForCity } = tickFarm(current, state.lastTick + stepMs * (i + 1))
+      current = nextState
+      for (const [res, amt] of Object.entries(resourcesForCity) as [ResourceType, number][]) {
+        totalForCity[res as ResourceType] = (totalForCity[res as ResourceType] ?? 0) + amt
+      }
+    }
+    return { nextState: current, resourcesForCity: totalForCity }
+  }
+
+  const minutes = Math.min(elapsed / 60_000, MAX_OFFLINE_MINUTES)
+
+  // ── 1. Production — write to farm resource pool ──────────────────────────────
+  const rates = getFarmProductionRate(state, nowMs)
+  const newResources = { ...state.resources }
+  for (const [res, rate] of Object.entries(rates) as [ResourceType, number][]) {
+    newResources[res as ResourceType] = (newResources[res as ResourceType] ?? 0) + rate * minutes
+  }
+
+  let next: FarmState = { ...state, resources: newResources, lastTick: nowMs }
+
+  // ── 2. Check for raid ────────────────────────────────────────────────────────
+  if (nowMs >= state.nextRaidAt) {
+    next = processFarmRaid(next)
+  }
+
+  // ── 3. Ship resources to the city (above threshold) ──────────────────────────
+  const resourcesForCity: Partial<ResourceStock> = {}
+  const shipped = { ...next.resources }
+  let anyShipped = false
+
+  for (const [res, amt] of Object.entries(next.resources) as [ResourceType, number][]) {
+    if (amt >= SHIP_THRESHOLD) {
+      resourcesForCity[res as ResourceType] = Math.floor(amt)
+      shipped[res as ResourceType] = 0
+      anyShipped = true
+    }
+  }
+
+  if (anyShipped) {
+    next = { ...next, resources: shipped }
+  }
+
+  return { nextState: next, resourcesForCity }
+}
+
+// ── Neighbour helper (same as city) ──────────────────────────────────────────
+
+export function getFarmNeighbourIndices(index: number, rows = FARM_ROWS, cols = FARM_COLS): number[] {
+  const row = Math.floor(index / cols)
+  const col = index % cols
+  const result: number[] = []
+  if (col > 0)           result.push(index - 1)
+  if (col < cols - 1)    result.push(index + 1)
+  if (row > 0)           result.push(index - cols)
+  if (row < rows - 1)    result.push(index + cols)
+  return result
+}
+
+/** Cell centre in overlay pixels — mirrors cityBuilder.cellCenter for FARM_COLS. */
+export function farmCellCenter(idx: number): { x: number; y: number } {
+  const col = idx % FARM_COLS
+  const row = Math.floor(idx / FARM_COLS)
+  return { x: (col + 0.5) * CELL_PX, y: (row + 0.5) * CELL_PX }
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -12951,3 +12951,121 @@ html.light-mode .action-btn {
 .td-end-title--lose { color: #f44336; text-shadow: 0 0 20px rgba(244,67,54,0.6); }
 .td-end-stat   { font-size: 15px; color: #aaa; }
 .td-end-reward { font-size: 17px; color: var(--color-gold); font-weight: bold; }
+
+/* ── Farming Simulation ──────────────────────────────────────────────────────── */
+
+.farm-screen { padding: 4px 6px; }
+
+/* Worker strip */
+.farm-worker-strip {
+  display: flex; align-items: center; gap: 8px;
+  padding: 6px 10px;
+  background: rgba(80, 120, 40, 0.18);
+  border: 1px solid #3a6a2a;
+  border-radius: 4px;
+  font-size: 12px; color: #a0d080;
+  flex-wrap: wrap;
+}
+.farm-worker-label { font-weight: bold; letter-spacing: 1px; }
+.farm-worker-btn {
+  background: #2a4a1a; border: 1px solid #4a7a2a; color: #80c060;
+  width: 22px; height: 22px; font-size: 14px; line-height: 1;
+  cursor: pointer; border-radius: 3px; padding: 0;
+  display: flex; align-items: center; justify-content: center;
+}
+.farm-worker-btn:disabled { opacity: 0.4; cursor: default; }
+.farm-worker-btn:not(:disabled):hover { background: #3a6a2a; }
+.farm-worker-count { font-weight: bold; font-size: 13px; min-width: 40px; text-align: center; }
+.farm-worker-sep { color: #507040; margin: 0 1px; }
+.farm-worker-hint { font-size: 10px; color: #608050; }
+
+/* Resource bar */
+.farm-res-bar {
+  display: flex; align-items: center; gap: 6px;
+  padding: 4px 8px;
+  overflow-x: auto; flex-wrap: wrap;
+  font-size: 11px;
+}
+.farm-res-bar::-webkit-scrollbar { display: none; }
+.farm-res-stat { color: #80a060; font-size: 11px; white-space: nowrap; }
+.farm-raid-pill {
+  white-space: nowrap; font-size: 11px;
+  padding: 2px 6px; border-radius: 3px;
+  border: 1px solid currentColor;
+}
+.farm-raid-pill--calm     { color: #508050; }
+.farm-raid-pill--soon     { color: #c08020; }
+.farm-raid-pill--imminent { color: #d06030; animation: city-pulse 1.2s ease-in-out infinite; }
+
+/* Farm grid */
+.farm-world { background: #1a2e10; border-radius: 4px; overflow: hidden; }
+.farm-grid  { padding: 4px; background: #1a2e10; }
+
+/* Farm plot cells */
+.farm-cell {
+  width: 100%; height: 100%;
+  display: flex; flex-direction: column; align-items: center; justify-content: center;
+  border: 1px solid #2a4a1a; border-radius: 3px;
+  background: #1e3414; cursor: pointer;
+  position: relative; overflow: hidden;
+  font-size: 10px;
+  transition: border-color 0.15s;
+  box-sizing: border-box;
+}
+.farm-cell:hover { border-color: #60a040; }
+.farm-cell--empty { border-style: dashed; border-color: #2a4a1a; color: #3a6a2a; }
+.farm-cell--empty:hover { border-color: #60a040; color: #60a040; }
+.farm-cell--highlighted { border-color: #80c060 !important; box-shadow: 0 0 6px rgba(80,160,40,0.5); }
+.farm-cell--bulldozer { border-color: #804020 !important; cursor: crosshair; }
+.farm-cell--bulldozer:hover { background: rgba(120, 40, 20, 0.2); }
+.farm-cell--occupied { background: #1e3414; }
+.farm-cell-plus { font-size: 18px; color: inherit; }
+.farm-cell-sprite { width: 32px; height: 32px; image-rendering: pixelated; }
+.farm-cell-name { font-size: 9px; color: #80b060; text-align: center; padding: 0 2px; line-height: 1.2; }
+.farm-cell-rate { font-size: 10px; color: #a0c060; }
+.farm-cell-demolish {
+  position: absolute; top: 2px; right: 4px;
+  font-size: 12px; color: #c06040;
+}
+
+/* Raid modal */
+.farm-raid-modal {
+  background: #1a2a1a; border: 2px solid #3a6a2a;
+  border-radius: 6px; padding: 20px 24px;
+  max-width: 340px; width: 100%; text-align: center;
+  display: flex; flex-direction: column; align-items: center; gap: 10px;
+}
+.farm-raid--repelled { border-color: #4a8a4a; }
+.farm-raid--partial  { border-color: #9a7a20; }
+.farm-raid--defeated { border-color: #8a3030; }
+.farm-raid-icon { font-size: 36px; }
+.farm-raid-outcome { font-size: 18px; font-weight: bold; letter-spacing: 2px; color: #c0f0c0; }
+.farm-raid--partial .farm-raid-outcome  { color: #e0c060; }
+.farm-raid--defeated .farm-raid-outcome { color: #e06060; }
+.farm-raid-row { display: flex; justify-content: space-between; width: 100%; font-size: 12px; color: #80a080; }
+.farm-raid-stolen, .farm-raid-destroyed { text-align: left; width: 100%; }
+.farm-raid-stolen-title, .farm-raid-destroyed-title { font-size: 11px; color: #608060; margin-bottom: 4px; }
+.farm-raid-destroyed-item { font-size: 12px; color: #e08080; }
+.farm-raid-success { font-size: 12px; color: #80d080; }
+
+/* Building picker */
+.farm-picker { padding: 4px; }
+.farm-picker-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  gap: 6px; padding: 4px;
+}
+.farm-picker-card {
+  background: #1a2e10; border: 1px solid #3a5a2a; border-radius: 4px;
+  padding: 8px; cursor: pointer;
+  display: flex; flex-direction: column; gap: 4px;
+  transition: border-color 0.15s;
+}
+.farm-picker-card:hover { border-color: #70c050; }
+.farm-picker-card-name   { font-size: 12px; color: #a0d080; font-weight: bold; }
+.farm-picker-card-rarity { font-size: 10px; color: #608060; text-transform: capitalize; }
+.farm-picker-card-produces { display: flex; flex-wrap: wrap; gap: 4px; }
+.farm-picker-prod-chip {
+  font-size: 10px; color: #80c060;
+  background: rgba(80,120,40,0.2); border-radius: 2px; padding: 1px 4px;
+}


### PR DESCRIPTION
## Summary

- **Farming simulation sub-screen** unlocks when city reaches population ≥ 10. Players can move production buildings out of the city into arable land outside the walls for a +50% resource bonus at the cost of much higher raid frequency (every 3–4 hours vs the city's 6–8 hours).
- **Walker animation** — farmers walk around the farm grid using the same 100ms `setInterval` system as city residents. Workers are sourced from city population.
- **Offline tick catch-up** — `tickFarm` applies sub-steps (up to 8 hours backlog) so resources and raids resolve correctly after the game is closed.

## New files

| File | Purpose |
|---|---|
| `game/farmingSim.ts` | Pure game logic — production rates, raids, worker assignment, localStorage persistence |
| `components/minigames/FarmingSim.tsx` | Main orchestrating component (10s game tick + 100ms walker loop) |
| `farming/FarmGrid.tsx` | 6×4 grid with absolutely-positioned farmer walkers |
| `farming/FarmPlotCell.tsx` | Individual plot — empty dashed cell or occupied building card |
| `farming/FarmWorkerStrip.tsx` | Assign/unassign workers (drawn from city population) |
| `farming/FarmResourceBar.tsx` | Resource chips + defense + raid countdown |
| `farming/FarmBuildingPicker.tsx` | Filtered building picker showing +50% farm rates |
| `farming/FarmRaidModal.tsx` | Raid outcome modal (repelled / partial / defeated) |
| `public/sprites/farmer.svg` + frames | Farmer sprite with 3-frame walking animation |
| Each component has a `.stories.tsx` | Storybook stories for isolated development |

## Modified files

- **`CityBuilder.tsx`** — added `🌾 FARM` button to bottom action bar (locked until pop ≥ 10)
- **`walkerTypes.ts`** — added `'farming'` to the `TaskType` union
- **`SpriteImg.tsx`** — added `style?: React.CSSProperties` prop to `SpriteImg` and `AnimatedSpriteImg`
- **`styles.css`** — farming CSS classes appended (farm-screen, farm-grid, farm-cell variants, farm-raid-modal, farm-picker, farm-worker-strip, farm-res-bar)

## Test plan

- [ ] City with pop < 10 shows locked FARM button
- [ ] City with pop ≥ 10 shows active FARM button
- [ ] Open farm → grid shows empty plots and farmer walkers
- [ ] Tap empty cell → building picker opens, shows only production buildings with +50% rates
- [ ] Place a building → it appears in the cell, resources accumulate after ~10s
- [ ] Assign/unassign workers → walker count changes, defense updates
- [ ] DEMOLISH mode → tap occupied cell removes building and returns resources to city
- [ ] Raid fires after ~3 hours (or test by adjusting `nextRaidAt` in localStorage)
- [ ] Close and reopen app → farm state persists and offline resources catch up

https://claude.ai/code/session_011crFfA2JRe2ouRm8LfXSUA

---
_Generated by [Claude Code](https://claude.ai/code/session_011crFfA2JRe2ouRm8LfXSUA)_