### PR TITLE
feat: city level badge, farm lock modal, and expansion progression modal

### DIFF
--- a/web/src/components/minigames/CityBuilder.tsx
+++ b/web/src/components/minigames/CityBuilder.tsx
@@ -60,6 +60,7 @@ import { StatsScreen } from './citybuilder/StatsScreen'
 import { ZoneEditor } from './citybuilder/ZoneEditor'
 import { DisasterModal } from './citybuilder/DisasterModal'
 import { OverlayScreen } from '../ui/OverlayScreen'
+import { ModalBackdrop } from '../ui/ModalBackdrop'
 import { FarmingSim } from './FarmingSim'
 import { isFarmUnlocked } from '../../game/farmingSim'
 
@@ -668,6 +669,8 @@ export function CityBuilder({ onBack }: Props) {
   const [fortSlotSel, setFortSlotSel] = useState<number | null>(null)
   const [fortFilter, setFortFilter] = useState<string>('all')
   const [fortSort, setFortSort] = useState<'defense' | 'name' | 'rarity'>('defense')
+  const [showFarmLockModal, setShowFarmLockModal] = useState(false)
+  const [showExpandModal, setShowExpandModal] = useState(false)
   const worldRef = useRef<HTMLDivElement>(null)
   const worldDimsRef = useRef({ w: CITY_COLS * CELL_PX, h: CITY_ROWS * CELL_PX })
   const fortRingRef = useRef<HTMLDivElement>(null)
@@ -1448,6 +1451,7 @@ export function CityBuilder({ onBack }: Props) {
   const cityCells = cityCols * cityRows
   const expansionCost = EXPANSION_COSTS[cityRows]
   const affordable = canAffordExpansion(city)
+  const cityLevel = cityRows - CITY_ROWS + 1
 
   const msToAttack = Math.max(0, city.nextAttackAt - currentTime)
   const attackCountdown = formatCountdown(msToAttack)
@@ -1618,7 +1622,9 @@ export function CityBuilder({ onBack }: Props) {
   return (
     <OverlayScreen title={bulldozerMode ? '⏸ PAUSED' : '🏙 CITY'} onBack={onBack}
 
-      right={<> <div className="city-gold-display">⚙ {city.gold.toLocaleString()} (+{incomeRate}/min)</div>
+      right={<>
+        <div className="city-level-badge" title={`City level ${cityLevel} — ${cityRows}×${cityCols} grid`}>LVL {cityLevel}</div>
+        <div className="city-gold-display">⚙ {city.gold.toLocaleString()} (+{incomeRate}/min)</div>
         <button className="action-btn" onClick={() => setScreen('towerdefence')} title="Defend the city using your residents as towers">
           ⚔ DEFEND
         </button></>}
@@ -1663,6 +1669,68 @@ export function CityBuilder({ onBack }: Props) {
             hasDamagedForts={city.fortifications.some(f => f.hp < f.maxHp)}
             onClose={() => setAttackReport(null)}
           />
+        )}
+
+        {showFarmLockModal && (
+          <ModalBackdrop onClose={() => setShowFarmLockModal(false)}>
+            <div className="city-info-modal">
+              <div className="city-info-modal-title">🌾 FARM — LOCKED</div>
+              <div className="city-info-modal-body">
+                <p>Move production buildings to fertile land outside the city walls for a <strong>+50% resource bonus</strong>.</p>
+                <p style={{ color: '#cc9944' }}>⚠ Farms are raided every 3–4 hours with minimal defence.</p>
+                <div className="city-info-modal-req">
+                  <span className={population >= 10 ? 'req--met' : 'req--unmet'}>
+                    {population >= 10 ? '✓' : '✗'} Population ≥ 10 (currently {population})
+                  </span>
+                </div>
+                <p style={{ fontSize: 11, color: '#668866' }}>Grow your city by placing more spawning buildings to unlock the farm.</p>
+              </div>
+              <button className="action-btn" onClick={() => setShowFarmLockModal(false)}>CLOSE</button>
+            </div>
+          </ModalBackdrop>
+        )}
+
+        {showExpandModal && (
+          <ModalBackdrop onClose={() => setShowExpandModal(false)}>
+            <div className="city-info-modal">
+              <div className="city-info-modal-title">🏢 CITY EXPANSION</div>
+              <div className="city-info-modal-body">
+                {([4, 5, 6, 7, 8] as const).map(rows => {
+                  const lvl = rows - CITY_ROWS + 1
+                  const cost = EXPANSION_COSTS[rows as 4|5|6|7]
+                  const isCurrent = cityRows === rows
+                  const isCompleted = cityRows > rows
+                  const isNext = cityRows === rows
+                  return (
+                    <div key={rows} className={`city-expand-row${isCurrent ? ' city-expand-row--current' : ''}${isCompleted ? ' city-expand-row--done' : ''}`}>
+                      <span className="city-expand-lvl">LVL {lvl} — {rows}×{rows}</span>
+                      {isCompleted && <span className="city-expand-status">✓ Unlocked</span>}
+                      {isCurrent && rows < MAX_CITY_ROWS && cost && (
+                        <span className="city-expand-cost">
+                          ⚙ {cost.gold.toLocaleString()}
+                          {Object.entries(cost.resources).map(([r, v]) => ` · ${v?.toLocaleString()} ${r}`).join('')}
+                        </span>
+                      )}
+                      {isCurrent && rows >= MAX_CITY_ROWS && <span className="city-expand-status">MAX SIZE</span>}
+                    </div>
+                  )
+                })}
+              </div>
+              <div className="u-flex u-gap-3 u-just-c">
+                {cityRows < MAX_CITY_ROWS && expansionCost && (
+                  <button
+                    className={`action-btn${affordable ? ' action-btn--gold' : ''}`}
+                    onClick={() => { handleExpand(); setShowExpandModal(false) }}
+                    disabled={!affordable}
+                    title={affordable ? 'Expand the city now' : 'Not enough resources'}
+                  >
+                    {affordable ? '🏢 EXPAND NOW' : '🔒 NEED RESOURCES'}
+                  </button>
+                )}
+                <button className="action-btn" onClick={() => setShowExpandModal(false)}>CLOSE</button>
+              </div>
+            </div>
+          </ModalBackdrop>
         )}
 
         {selectedWalker !== null && (() => {
@@ -1760,9 +1828,9 @@ export function CityBuilder({ onBack }: Props) {
           ) : (
             <button
               className="filter-btn"
-              style={{ opacity: 0.5 }}
+              style={{ opacity: 0.7 }}
               title={`Farm unlocks at population 10 (currently ${population})`}
-              disabled
+              onClick={() => setShowFarmLockModal(true)}
             >🌾 FARM 🔒</button>
           )}
           <button className="filter-btn" onClick={() => setScreen('upgrade')} title="Upgrade buildings">★ UPGRADES</button>
@@ -1783,11 +1851,11 @@ export function CityBuilder({ onBack }: Props) {
             onClick={() => setShowTrade(true)}
             title="Trade resources via caravan"
           >🐪 TRADE{city.activeCaravan ? ' (away)' : city.tradeOffer ? ' !' : ''}</button>
-          {cityRows < MAX_CITY_ROWS && expansionCost && (
+          {cityRows <= MAX_CITY_ROWS && (
             <button
               className={`filter-btn city-expand-btn${affordable ? ' city-expand-btn--ready' : ''}`}
-              onClick={handleExpand}
-              title={affordable ? `Expand city to ${cityRows + 1}×${cityCols + 1}` : 'Not enough resources to expand'}
+              onClick={() => setShowExpandModal(true)}
+              title="View city expansion levels and costs"
             >🏢 EXPAND</button>
           )}
         </div>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -13069,3 +13069,75 @@ html.light-mode .action-btn {
   font-size: 10px; color: #80c060;
   background: rgba(80,120,40,0.2); border-radius: 2px; padding: 1px 4px;
 }
+
+/* ── City level badge ──────────────────────────────────────────────────────── */
+.city-level-badge {
+  font-family: var(--font-mono, monospace);
+  font-size: 11px;
+  font-weight: bold;
+  color: #c0f0a0;
+  background: rgba(40,80,20,0.5);
+  border: 1px solid #507040;
+  border-radius: 3px;
+  padding: 2px 7px;
+  letter-spacing: 0.05em;
+  white-space: nowrap;
+}
+
+/* ── City info modal (farm lock + expand) ──────────────────────────────────── */
+.city-info-modal {
+  background: #111a0e;
+  border: 1px solid #50804a;
+  border-radius: 6px;
+  padding: 20px 24px;
+  min-width: 280px;
+  max-width: 380px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  color: #a0c090;
+  font-family: var(--font-mono, monospace);
+}
+.city-info-modal-title {
+  font-size: 14px;
+  font-weight: bold;
+  color: #c0e8a0;
+  letter-spacing: 0.05em;
+  border-bottom: 1px solid #304828;
+  padding-bottom: 8px;
+}
+.city-info-modal-body {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-size: 12px;
+  line-height: 1.5;
+}
+.city-info-modal-body p { margin: 0; }
+.city-info-modal-body strong { color: #d0f0a0; }
+.city-info-modal-req {
+  background: rgba(0,0,0,0.3);
+  border-radius: 4px;
+  padding: 6px 10px;
+}
+.req--met   { color: #60c060; }
+.req--unmet { color: #c07070; }
+
+/* ── Expand progression rows ────────────────────────────────────────────────── */
+.city-expand-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  border-radius: 4px;
+  border: 1px solid transparent;
+  font-size: 11px;
+}
+.city-expand-row--current {
+  border-color: #70c050;
+  background: rgba(50,90,30,0.3);
+}
+.city-expand-row--done { opacity: 0.5; }
+.city-expand-lvl   { color: #c0e8a0; font-weight: bold; min-width: 90px; }
+.city-expand-cost  { color: #a0c080; font-size: 10px; flex: 1; }
+.city-expand-status { color: #80b060; font-size: 10px; flex: 1; }


### PR DESCRIPTION
## Summary

Three small city builder UX improvements:

- **City level badge** — `LVL N` chip shown in the header next to the gold counter. Level is derived from grid size (4×4 = LVL 1 through 8×8 = LVL 5).
- **Farm lock modal** — Tapping the locked 🌾 FARM button now opens an info modal explaining the unlock requirement (population ≥ 10) and the current population, instead of being a silently disabled button.
- **Expansion modal** — The 🏢 EXPAND button now opens a progression modal listing all 5 city tiers with their costs. The current level is highlighted, completed tiers are dimmed, and an EXPAND NOW button (gold-coloured when affordable) triggers the expansion directly from the modal. The button always shows now (even at max size) so players can always review the progression.

## Test plan

- [ ] Header shows `LVL 1` on a fresh city (4×4 grid), `LVL 2` after first expansion, etc.
- [ ] Tapping locked FARM button (pop < 10) shows the lock modal with current population
- [ ] Lock modal CLOSE button dismisses it; tapping the backdrop also closes it
- [ ] FARM button works normally when pop ≥ 10
- [ ] EXPAND button always visible; clicking opens the modal
- [ ] Expansion modal shows all 5 tiers, highlights the current one, dims completed ones
- [ ] EXPAND NOW button is gold-coloured when affordable, grey + disabled when not
- [ ] EXPAND NOW triggers expansion and closes the modal
- [ ] At max size (8×8), modal shows MAX SIZE status for the final tier

https://claude.ai/code/session_011crFfA2JRe2ouRm8LfXSUA

---
_Generated by [Claude Code](https://claude.ai/code/session_011crFfA2JRe2ouRm8LfXSUA)_