### PR TITLE
feat: fort picker full-screen, farm uses CityGrid, fix asymmetric grid saves

### DIFF
--- a/web/src/components/minigames/CityBuilder.tsx
+++ b/web/src/components/minigames/CityBuilder.tsx
@@ -667,8 +667,6 @@ export function CityBuilder({ onBack }: Props) {
   )
   const [currentTime, setCurrentTime] = useState(Date.now())
   const [fortSlotSel, setFortSlotSel] = useState<number | null>(null)
-  const [fortFilter, setFortFilter] = useState<string>('all')
-  const [fortSort, setFortSort] = useState<'defense' | 'name' | 'rarity'>('defense')
   const [showFarmLockModal, setShowFarmLockModal] = useState(false)
   const [showExpandModal, setShowExpandModal] = useState(false)
   const worldRef = useRef<HTMLDivElement>(null)
@@ -1499,10 +1497,6 @@ export function CityBuilder({ onBack }: Props) {
         fortRingRef={fortRingRef}
         fortSlotSel={fortSlotSel}
         setFortSlotSel={setFortSlotSel}
-        fortFilter={fortFilter}
-        setFortFilter={setFortFilter}
-        fortSort={fortSort}
-        setFortSort={setFortSort}
         availableDefenceCards={availableDefenceCards}
         onBack={() => { setFortSlotSel(null); setScreen('city') }}
         onAddFort={handleAddFort}

--- a/web/src/components/minigames/citybuilder/FortSlotModal.stories.tsx
+++ b/web/src/components/minigames/citybuilder/FortSlotModal.stories.tsx
@@ -1,7 +1,7 @@
-import React, { useState } from 'react'
+import React from 'react'
 import { fn } from 'storybook/test'
 import type { Meta, StoryObj } from '@storybook/react-vite'
-import { FortSlotModal, Props } from './FortSlotModal'
+import { FortSlotModal } from './FortSlotModal'
 import { FORT_MAX_HP } from '../../../game/cityBuilder'
 import { getCardCatalog } from '../../../game/cards'
 
@@ -23,48 +23,15 @@ const baseCity: any = {
   resources: { wheat: 100, wood: 50, stone: 30, iron: 10 },
 }
 
-function Wrapper(props: Omit<Props, 'fortFilter' | 'setFortFilter' | 'fortSort' | 'setFortSort'>) {
-  const [fortFilter, setFortFilter] = useState('all')
-  const [fortSort, setFortSort] = useState<'defense' | 'name' | 'rarity'>('defense')
-  return <FortSlotModal {...props} fortFilter={fortFilter} setFortFilter={setFortFilter} fortSort={fortSort} setFortSort={setFortSort} />
-}
-
-const callbacks = { onClose: fn(), onAddFort: fn(), onRemoveFort: fn() }
-
-export const EmptySlotWithCards: Story = {
-  args: {} as any,
-  render: () => (
-    <Wrapper
-      slot={{ kind: 'empty' }}
-      city={baseCity}
-      currentTime={Date.now()}
-      availableDefenceCards={defenceCards}
-      {...callbacks}
-    />
-  ),
-}
-
-export const EmptySlotNoCards: Story = {
-  args: {} as any,
-  render: () => (
-    <Wrapper
-      slot={{ kind: 'empty' }}
-      city={baseCity}
-      currentTime={Date.now()}
-      availableDefenceCards={[]}
-      {...callbacks}
-    />
-  ),
-}
+const callbacks = { onClose: fn(), onRemoveFort: fn() }
 
 export const BuildingSlot: Story = {
   args: {} as any,
   render: () => (
-    <Wrapper
+    <FortSlotModal
       slot={{ kind: 'building', entry: { cardName: defenceCards[0]?.name ?? 'Wall', rarity: 'uncommon', completesAt: Date.now() + 12 * 60_000 }, queueIndex: 0 }}
       city={baseCity}
       currentTime={Date.now()}
-      availableDefenceCards={defenceCards}
       {...callbacks}
     />
   ),
@@ -73,11 +40,10 @@ export const BuildingSlot: Story = {
 export const ActiveFortHealthy: Story = {
   args: {} as any,
   render: () => (
-    <Wrapper
+    <FortSlotModal
       slot={{ kind: 'active', fort: { cardName: defenceCards[1]?.name ?? 'Tower', rarity: 'rare', hp: FORT_MAX_HP.rare, maxHp: FORT_MAX_HP.rare, attacksTaken: 0 }, fortIndex: 0 }}
       city={baseCity}
       currentTime={Date.now()}
-      availableDefenceCards={defenceCards}
       {...callbacks}
     />
   ),
@@ -86,11 +52,10 @@ export const ActiveFortHealthy: Story = {
 export const ActiveFortDamaged: Story = {
   args: {} as any,
   render: () => (
-    <Wrapper
+    <FortSlotModal
       slot={{ kind: 'active', fort: { cardName: defenceCards[1]?.name ?? 'Tower', rarity: 'rare', hp: Math.round(FORT_MAX_HP.rare * 0.2), maxHp: FORT_MAX_HP.rare, attacksTaken: 4 }, fortIndex: 0 }}
       city={baseCity}
       currentTime={Date.now()}
-      availableDefenceCards={defenceCards}
       {...callbacks}
     />
   ),

--- a/web/src/components/minigames/citybuilder/FortSlotModal.tsx
+++ b/web/src/components/minigames/citybuilder/FortSlotModal.tsx
@@ -1,126 +1,22 @@
 import React from 'react'
 import {
   CityState,
-  FORT_DEFENSE, FORT_MAX_HP, FORT_MAX_ATTACKS, FORT_PLACE_COST, FORT_BUILD_MINUTES,
-  canAffordFortification, canQueueFortification,
+  FORT_DEFENSE, FORT_MAX_HP, FORT_MAX_ATTACKS,
   RESOURCE_ICONS, ResourceType,
 } from '../../../game/cityBuilder'
-import { Card } from '../../../game/types'
 import { SpriteImg } from '../../ui/SpriteImg'
 import { formatCountdown } from '../CityBuilder'
 import { FortSlot } from './FortCell'
 
-const RARITY_ORDER = ['common','uncommon','rare','epic','legendary','mythic','shiny','holofoil','glass']
-
 export interface Props {
-  slot: FortSlot
-  city: CityState
-  currentTime: number
-  availableDefenceCards: Card[]
-  fortFilter: string
-  setFortFilter: (f: string) => void
-  fortSort: 'defense' | 'name' | 'rarity'
-  setFortSort: (s: 'defense' | 'name' | 'rarity') => void
-  onClose: () => void
-  onAddFort: (card: Card) => void
-  onRemoveFort: (fortIndex: number) => void
+  slot:          Exclude<FortSlot, { kind: 'empty' }>
+  city:          CityState
+  currentTime:   number
+  onClose:       () => void
+  onRemoveFort:  (fortIndex: number) => void
 }
 
-export function FortSlotModal({
-  slot, city, currentTime, availableDefenceCards,
-  fortFilter, setFortFilter, fortSort, setFortSort,
-  onClose, onAddFort, onRemoveFort,
-}: Props) {
-  if (slot.kind === 'empty') {
-    const canQueue = canQueueFortification(city)
-    const rarities = [...new Set(availableDefenceCards.map(c => c.rarity))]
-    const filtered = fortFilter === 'all'
-      ? availableDefenceCards
-      : availableDefenceCards.filter(c => c.rarity === fortFilter)
-    const sorted = [...filtered].sort((a, b) => {
-      if (fortSort === 'defense') return FORT_DEFENSE[b.rarity] - FORT_DEFENSE[a.rarity]
-      if (fortSort === 'name')    return a.name.localeCompare(b.name)
-      return RARITY_ORDER.indexOf(a.rarity) - RARITY_ORDER.indexOf(b.rarity)
-    })
-
-    return (
-      <div className="city-req-overlay" onClick={onClose}>
-        <div className="city-req-modal" onClick={e => e.stopPropagation()}>
-          <div className="city-req-header u-flex u-items-c u-gap-4">
-            <div className="city-req-name">Build a Fortification</div>
-          </div>
-          {!canQueue ? (
-            <div className="city-picker-empty" style={{ padding: '12px 0' }}>
-              All builders are busy — wait for one to finish, or hire another.
-            </div>
-          ) : availableDefenceCards.length === 0 ? (
-            <div className="city-picker-empty" style={{ padding: '12px 0' }}>
-              No defence cards available. Earn them in battles!
-            </div>
-          ) : (
-            <>
-              <div className="city-fort-controls u-flex u-just-sb u-items-c u-gap-3 u-wrap">
-                <div className="city-fort-filter">
-                  {(['all', ...rarities] as string[]).map(r => (
-                    <button key={r}
-                      className={`city-fort-filter-btn${fortFilter === r ? ' city-fort-filter-btn--active' : ''}`}
-                      onClick={() => setFortFilter(r)}>
-                      {r === 'all' ? 'All' : r}
-                    </button>
-                  ))}
-                </div>
-                <div className="city-fort-sort">
-                  {(['defense','name','rarity'] as const).map(s => (
-                    <button key={s}
-                      className={`city-fort-sort-btn${fortSort === s ? ' city-fort-sort-btn--active' : ''}`}
-                      onClick={() => setFortSort(s)}>
-                      {s === 'defense' ? '🛡' : s === 'name' ? 'A–Z' : '★'}
-                    </button>
-                  ))}
-                </div>
-              </div>
-              <div className="city-picker-section">
-                <div className="city-picker-grid">
-                  {sorted.length === 0 ? (
-                    <div className="city-picker-empty">No cards match this filter.</div>
-                  ) : sorted.map(card => {
-                    const cost       = FORT_PLACE_COST[card.rarity]
-                    const affordable = canAffordFortification(city, card.rarity)
-                    return (
-                      <button key={card.name}
-                        className={`city-picker-card u-col u-items-c u-gap-2 u-pointer${!affordable ? ' city-picker-card--unaffordable' : ''}`}
-                        disabled={!affordable}
-                        onClick={() => { onAddFort(card); onClose() }}>
-                        <SpriteImg name={card.name} className="city-picker-sprite" />
-                        <div className="city-picker-name">{card.name}</div>
-                        <div className={`city-picker-rarity city-picker-rarity--${card.rarity}`}>{card.rarity}</div>
-                        <div className="city-picker-income">🛡{FORT_DEFENSE[card.rarity]} · {FORT_MAX_HP[card.rarity]}HP · {FORT_MAX_ATTACKS[card.rarity]} raids</div>
-                        <div className="city-picker-income" style={{ color: '#888' }}>🔨 {
-                          FORT_BUILD_MINUTES[card.rarity] >= 1440
-                            ? `${Math.round(FORT_BUILD_MINUTES[card.rarity] / 1440)} days`
-                            : FORT_BUILD_MINUTES[card.rarity] >= 60
-                            ? `${Math.round(FORT_BUILD_MINUTES[card.rarity] / 60)} hrs`
-                            : `${FORT_BUILD_MINUTES[card.rarity]} min`
-                        }</div>
-                        <div className="city-picker-cost">
-                          ⚙{cost.gold.toLocaleString()}
-                          {(Object.keys(cost) as (keyof typeof cost)[])
-                            .filter(k => k !== 'gold' && (cost[k] ?? 0) > 0)
-                            .map(k => ` ${RESOURCE_ICONS[k as ResourceType]}${cost[k]}`).join('')}
-                        </div>
-                      </button>
-                    )
-                  })}
-                </div>
-              </div>
-            </>
-          )}
-          <button className="action-btn" onClick={onClose}>CLOSE</button>
-        </div>
-      </div>
-    )
-  }
-
+export function FortSlotModal({ slot, currentTime, onClose, onRemoveFort }: Props) {
   if (slot.kind === 'building') {
     const msLeft = Math.max(0, slot.entry.completesAt - currentTime)
     return (

--- a/web/src/components/minigames/citybuilder/Fortifications.stories.tsx
+++ b/web/src/components/minigames/citybuilder/Fortifications.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react'
+import React, { useRef, useState } from 'react' // useState kept for fortSlotSel
 import { fn } from 'storybook/test'
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { Fortifications, Props } from './Fortifications'
@@ -27,21 +27,15 @@ const baseCity: any = {
   happiness: {},
 }
 
-function Wrapper(props: Omit<Props, 'fortRingRef' | 'fortSlotSel' | 'setFortSlotSel' | 'fortFilter' | 'setFortFilter' | 'fortSort' | 'setFortSort'>) {
+function Wrapper(props: Omit<Props, 'fortRingRef' | 'fortSlotSel' | 'setFortSlotSel'>) {
   const fortRingRef = useRef<HTMLDivElement>(null)
   const [fortSlotSel, setFortSlotSel] = useState<number | null>(null)
-  const [fortFilter, setFortFilter] = useState('all')
-  const [fortSort, setFortSort] = useState<'defense' | 'name' | 'rarity'>('defense')
   return (
     <Fortifications
       {...props}
       fortRingRef={fortRingRef}
       fortSlotSel={fortSlotSel}
       setFortSlotSel={setFortSlotSel}
-      fortFilter={fortFilter}
-      setFortFilter={setFortFilter}
-      fortSort={fortSort}
-      setFortSort={setFortSort}
     />
   )
 }

--- a/web/src/components/minigames/citybuilder/Fortifications.tsx
+++ b/web/src/components/minigames/citybuilder/Fortifications.tsx
@@ -1,33 +1,33 @@
-import React from 'react'
+import React, { useState } from 'react'
 import {
-  CityState, FORT_DEFENSE,
+  CityState, FORT_DEFENSE, FORT_MAX_HP, FORT_MAX_ATTACKS, FORT_PLACE_COST, FORT_BUILD_MINUTES,
   MAX_TOTAL_FORTS, MAX_BUILDER_COUNT, DEFAULT_BUILDER_COUNT,
-  canQueueFortification, nextBuilderCost, CITY_COLS, CITY_ROWS,
+  canAffordFortification, canQueueFortification,
+  nextBuilderCost, CITY_COLS, CITY_ROWS,
+  RESOURCE_ICONS, ResourceType,
 } from '../../../game/cityBuilder'
 import { Card } from '../../../game/types'
-import { AnimatedSpriteImg } from '../../ui/SpriteImg'
+import { AnimatedSpriteImg, SpriteImg } from '../../ui/SpriteImg'
 import { OverlayScreen } from '../../ui/OverlayScreen'
 import { BuilderWalker } from '../CityBuilder'
 import { FortCell, FortSlot } from './FortCell'
 import { FortSlotModal } from './FortSlotModal'
 import { CityThumbnail } from './CityThumbnail'
 
+const RARITY_ORDER = ['common','uncommon','rare','epic','legendary','mythic','shiny','holofoil','glass']
+
 export interface Props {
-  city: CityState
-  currentTime: number
-  builderWalkers: BuilderWalker[]
-  fortRingRef: React.RefObject<HTMLDivElement>
-  fortSlotSel: number | null
-  setFortSlotSel: (idx: number | null) => void
-  fortFilter: string
-  setFortFilter: (f: string) => void
-  fortSort: 'defense' | 'name' | 'rarity'
-  setFortSort: (s: 'defense' | 'name' | 'rarity') => void
+  city:                 CityState
+  currentTime:          number
+  builderWalkers:       BuilderWalker[]
+  fortRingRef:          React.RefObject<HTMLDivElement>
+  fortSlotSel:          number | null
+  setFortSlotSel:       (idx: number | null) => void
   availableDefenceCards: Card[]
-  onBack: () => void
-  onAddFort: (card: Card) => void
-  onBuyBuilder: () => void
-  onRemoveFort: (index: number) => void
+  onBack:               () => void
+  onAddFort:            (card: Card) => void
+  onBuyBuilder:         () => void
+  onRemoveFort:         (index: number) => void
 }
 
 const SLOT_AREA = ['f0','f1','f2','f3','f4','f5','f6','f7','f8','f9','f10','f11']
@@ -35,11 +35,13 @@ const SLOT_AREA = ['f0','f1','f2','f3','f4','f5','f6','f7','f8','f9','f10','f11'
 export function Fortifications({
   city, currentTime, builderWalkers, fortRingRef,
   fortSlotSel, setFortSlotSel,
-  fortFilter, setFortFilter,
-  fortSort, setFortSort,
   availableDefenceCards,
   onBack, onAddFort, onBuyBuilder, onRemoveFort,
 }: Props) {
+  const [subScreen, setSubScreen] = useState<'slots' | 'picker'>('slots')
+  const [fortFilter, setFortFilter] = useState<string>('all')
+  const [fortSort, setFortSort]     = useState<'defense' | 'name' | 'rarity'>('defense')
+
   const builderCount = city.builderCount ?? DEFAULT_BUILDER_COUNT
   const freeBuilders = builderCount - city.builderQueue.length
   const builderCost  = nextBuilderCost(city)
@@ -59,6 +61,100 @@ export function Fortifications({
   })
 
   const selSlot = fortSlotSel !== null ? fortSlots[fortSlotSel] : null
+
+  // ── Full-screen fort picker ───────────────────────────────────────────────────
+
+  if (subScreen === 'picker') {
+    const canQueue  = canQueueFortification(city)
+    const rarities  = [...new Set(availableDefenceCards.map(c => c.rarity))]
+    const filtered  = fortFilter === 'all'
+      ? availableDefenceCards
+      : availableDefenceCards.filter(c => c.rarity === fortFilter)
+    const sorted = [...filtered].sort((a, b) => {
+      if (fortSort === 'defense') return FORT_DEFENSE[b.rarity] - FORT_DEFENSE[a.rarity]
+      if (fortSort === 'name')    return a.name.localeCompare(b.name)
+      return RARITY_ORDER.indexOf(a.rarity) - RARITY_ORDER.indexOf(b.rarity)
+    })
+
+    return (
+      <OverlayScreen title="🛡 BUILD FORTIFICATION" onBack={() => setSubScreen('slots')}>
+        <div className="city-screen u-relative u-col u-gap-2">
+          <div className="city-subscreen-scroll">
+            {!canQueue ? (
+              <div className="city-picker-empty">
+                All builders are busy — wait for one to finish, or hire another.
+              </div>
+            ) : availableDefenceCards.length === 0 ? (
+              <div className="city-picker-empty">
+                No defence cards available. Earn them in battles!
+              </div>
+            ) : (
+              <>
+                <div className="city-fort-controls u-flex u-just-sb u-items-c u-gap-3 u-wrap">
+                  <div className="city-fort-filter">
+                    {(['all', ...rarities] as string[]).map(r => (
+                      <button key={r}
+                        className={`city-fort-filter-btn${fortFilter === r ? ' city-fort-filter-btn--active' : ''}`}
+                        onClick={() => setFortFilter(r)}>
+                        {r === 'all' ? 'All' : r}
+                      </button>
+                    ))}
+                  </div>
+                  <div className="city-fort-sort">
+                    {(['defense','name','rarity'] as const).map(s => (
+                      <button key={s}
+                        className={`city-fort-sort-btn${fortSort === s ? ' city-fort-sort-btn--active' : ''}`}
+                        onClick={() => setFortSort(s)}>
+                        {s === 'defense' ? '🛡' : s === 'name' ? 'A–Z' : '★'}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
+                <div className="city-picker-section">
+                  <div className="city-picker-section-label">DEFENCE CARDS</div>
+                  <div className="city-picker-grid">
+                    {sorted.length === 0 ? (
+                      <div className="city-picker-empty">No cards match this filter.</div>
+                    ) : sorted.map(card => {
+                      const cost       = FORT_PLACE_COST[card.rarity]
+                      const affordable = canAffordFortification(city, card.rarity)
+                      return (
+                        <button key={card.name}
+                          className={`city-picker-card u-col u-items-c u-gap-2 u-pointer${!affordable ? ' city-picker-card--unaffordable' : ''}`}
+                          disabled={!affordable}
+                          onClick={() => { onAddFort(card); setSubScreen('slots') }}>
+                          <SpriteImg name={card.name} className="city-picker-sprite" />
+                          <div className="city-picker-name">{card.name}</div>
+                          <div className={`city-picker-rarity city-picker-rarity--${card.rarity}`}>{card.rarity}</div>
+                          <div className="city-picker-income">🛡{FORT_DEFENSE[card.rarity]} · {FORT_MAX_HP[card.rarity]}HP · {FORT_MAX_ATTACKS[card.rarity]} raids</div>
+                          <div className="city-picker-income" style={{ color: '#888' }}>🔨 {
+                            FORT_BUILD_MINUTES[card.rarity] >= 1440
+                              ? `${Math.round(FORT_BUILD_MINUTES[card.rarity] / 1440)} days`
+                              : FORT_BUILD_MINUTES[card.rarity] >= 60
+                              ? `${Math.round(FORT_BUILD_MINUTES[card.rarity] / 60)} hrs`
+                              : `${FORT_BUILD_MINUTES[card.rarity]} min`
+                          }</div>
+                          <div className="city-picker-cost">
+                            ⚙{cost.gold.toLocaleString()}
+                            {(Object.keys(cost) as (keyof typeof cost)[])
+                              .filter(k => k !== 'gold' && (cost[k] ?? 0) > 0)
+                              .map(k => ` ${RESOURCE_ICONS[k as ResourceType]}${cost[k]}`).join('')}
+                          </div>
+                        </button>
+                      )
+                    })}
+                  </div>
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+      </OverlayScreen>
+    )
+  }
+
+  // ── Slots view ────────────────────────────────────────────────────────────────
 
   return (
     <OverlayScreen
@@ -89,7 +185,13 @@ export function Fortifications({
                 key={idx}
                 slot={slot}
                 area={SLOT_AREA[idx]}
-                onClick={() => setFortSlotSel(idx)}
+                onClick={() => {
+                  if (slot.kind === 'empty') {
+                    setSubScreen('picker')
+                  } else {
+                    setFortSlotSel(idx)
+                  }
+                }}
               />
             ))}
             <CityThumbnail grid={city.grid.map(c => c ?? null)} cols={cityCols} rows={cityRows} />
@@ -109,19 +211,13 @@ export function Fortifications({
           </div>
         </div>
 
-        {/* Fort slot modal */}
-        {fortSlotSel !== null && selSlot !== null && (
+        {/* Info modal for active/building slots only */}
+        {fortSlotSel !== null && selSlot !== null && selSlot.kind !== 'empty' && (
           <FortSlotModal
             slot={selSlot}
             city={city}
             currentTime={currentTime}
-            availableDefenceCards={availableDefenceCards}
-            fortFilter={fortFilter}
-            setFortFilter={setFortFilter}
-            fortSort={fortSort}
-            setFortSort={setFortSort}
             onClose={() => setFortSlotSel(null)}
-            onAddFort={onAddFort}
             onRemoveFort={onRemoveFort}
           />
         )}

--- a/web/src/components/minigames/farming/FarmGrid.tsx
+++ b/web/src/components/minigames/farming/FarmGrid.tsx
@@ -1,10 +1,8 @@
-import React, { useCallback } from 'react'
+import React from 'react'
 import { FarmState, FARM_COLS, FARM_ROWS } from '../../../game/farmingSim'
-import { AnimatedSpriteImg } from '../../ui/SpriteImg'
+import { CityState } from '../../../game/cityBuilder'
 import { Walker } from '../citybuilder/walkerTypes'
-import { CityZoomControls } from '../citybuilder/CityZoomControls'
-import { useZoomPan } from '../citybuilder/useZoomPan'
-import { FarmPlotCell } from './FarmPlotCell'
+import { CityGrid } from '../citybuilder/CityGrid'
 
 export interface Props {
   farm:          FarmState
@@ -15,118 +13,52 @@ export interface Props {
   onWalkerClick: (cellIndex: number, unitIndex: number) => void
 }
 
-const UNIT_SIZE = 20
-
 export function FarmGrid({ farm, walkers, bulldozer, worldRef, onCellTap, onWalkerClick }: Props) {
-  const cols = farm.cols ?? FARM_COLS
   const rows = farm.rows ?? FARM_ROWS
-  const cells = cols * rows
+  const cols = farm.cols ?? FARM_COLS
 
-  const { wrapperRef, displayScale, stepZoom, zoomTo, getCellFromPoint: getCellFromPointRaw } =
-    useZoomPan(worldRef)
+  // Fixed path wear on every interior edge gives the farm a plowed-field grid look
+  const h = Array.from({ length: rows * cols }, (_, i) => (i % cols < cols - 1 ? 40 : 0))
+  const v = Array.from({ length: rows * cols }, (_, i) => (Math.floor(i / cols) < rows - 1 ? 40 : 0))
 
-  const getCellFromPoint = useCallback(
-    (cx: number, cy: number) => getCellFromPointRaw(cx, cy, cols, rows),
-    [getCellFromPointRaw, cols, rows],
-  )
-  void getCellFromPoint // used by touch handler in useZoomPan
+  const fakeCityState: CityState = {
+    grid:           farm.plots.map(p => p ? { cardName: p.cardName, rarity: p.rarity, stock: p.stock } : undefined),
+    rows,
+    cols,
+    gold:           0,
+    resources:      { ...farm.resources, bread: 1 },
+    lastTick:       0,
+    happiness:      {},
+    nextAttackAt:   0,
+    fortifications: [],
+    builderQueue:   [],
+    builderCount:   0,
+    lastAttack:     null,
+    chronicle:      [],
+    completedMilestones: [],
+    attacksProcessed:    0,
+    tradeOffer:          null,
+    activeCaravan:       null,
+    history:             [],
+    zones:               [],
+    activeDisaster:      null,
+    nextDisasterAt:      0,
+    roadWear:            { h, v },
+    carriers:            [],
+  }
 
   return (
-    <div
-      className="farm-world"
-      ref={worldRef}
-      style={{ position: 'relative', overflow: 'hidden', touchAction: 'none' }}
-    >
-      <CityZoomControls
-        scale={displayScale}
-        onZoomIn={() => stepZoom(1)}
-        onZoomOut={() => stepZoom(-1)}
-        onZoomTo={zoomTo}
-      />
-
-      <div className="farm-zoom-wrapper" ref={wrapperRef}>
-        {/* Farm grid — fills the wrapper, cells are proportional */}
-        <div
-          className="farm-grid"
-          style={{
-            display: 'grid',
-            gridTemplateColumns: `repeat(${cols}, 1fr)`,
-            gridTemplateRows:    `repeat(${rows}, 1fr)`,
-            width: '100%',
-            height: '100%',
-            gap: 2,
-          }}
-        >
-          {Array.from({ length: cells }).map((_, i) => (
-            <FarmPlotCell
-              key={i}
-              plot={farm.plots[i]}
-              index={i}
-              farmState={farm}
-              highlighted={false}
-              bulldozer={bulldozer}
-              onTap={onCellTap}
-            />
-          ))}
-        </div>
-
-        {/* Walker overlay inside zoom wrapper so walkers scale/pan with the grid */}
-        <div
-          style={{
-            position: 'absolute',
-            inset: 0,
-            pointerEvents: 'none',
-            overflow: 'hidden',
-          }}
-        >
-          {walkers.map((w, i) => {
-            if (w.hidden) return null
-            return (
-              <div
-                key={`${w.cellIndex}-${w.unitIndex}`}
-                style={{
-                  position: 'absolute',
-                  left: w.x,
-                  top: w.y,
-                  width: UNIT_SIZE,
-                  height: UNIT_SIZE,
-                  cursor: 'pointer',
-                  pointerEvents: 'auto',
-                  zIndex: 10,
-                }}
-                onClick={() => onWalkerClick(w.cellIndex, w.unitIndex)}
-                title={`Farmer ${i + 1}`}
-              >
-                <AnimatedSpriteImg
-                  name="farmer"
-                  frameCount={3}
-                  fps={w.vx !== 0 || w.vy !== 0 ? 6 : 1}
-                  style={{ width: UNIT_SIZE, height: UNIT_SIZE, imageRendering: 'pixelated' }}
-                />
-                {w.bubbleTimer > 0 && w.task.type !== 'idle' && (
-                  <div
-                    style={{
-                      position: 'absolute',
-                      bottom: UNIT_SIZE + 2,
-                      left: '50%',
-                      transform: 'translateX(-50%)',
-                      background: 'rgba(0,0,0,0.8)',
-                      color: '#c0f0c0',
-                      fontSize: 9,
-                      padding: '1px 3px',
-                      borderRadius: 2,
-                      whiteSpace: 'nowrap',
-                      pointerEvents: 'none',
-                    }}
-                  >
-                    {w.task.label}
-                  </div>
-                )}
-              </div>
-            )
-          })}
-        </div>
-      </div>
-    </div>
+    <CityGrid
+      city={fakeCityState}
+      walkers={walkers}
+      builderWalkers={[]}
+      visualCarriers={[]}
+      bulldozerMode={bulldozer}
+      worldRef={worldRef}
+      paintBrush={false}
+      onCellTap={onCellTap}
+      onPaint={() => {}}
+      onWalkerClick={onWalkerClick}
+    />
   )
 }

--- a/web/src/game/cityBuilder.ts
+++ b/web/src/game/cityBuilder.ts
@@ -835,14 +835,29 @@ export function loadCityState(): CityState {
     if (!raw) return defaultState()
     const parsed = JSON.parse(raw) as Partial<CityState>
     const savedResources = (parsed.resources ?? {}) as Partial<ResourceStock>
-    const rows = parsed.rows ?? CITY_ROWS
-    const cols = parsed.cols ?? CITY_COLS
-    const cells = cols * rows
-    const savedGrid = parsed.grid ?? Array(cells).fill(undefined)
-    const grid = (savedGrid.length < cells
-      ? [...savedGrid, ...Array(cells - savedGrid.length).fill(undefined)]
-      : savedGrid
-    ).map((c: CityCell | undefined) => c ? { ...c, stock: c.stock ?? {} } : c)
+    const savedRows = parsed.rows ?? CITY_ROWS
+    const savedCols = parsed.cols ?? CITY_COLS
+    // Migrate old saves where only rows grew (cols stayed at 6): normalize to square
+    const rows = savedRows
+    const cols = savedRows > savedCols ? savedRows : savedCols
+    const savedGrid = (parsed.grid ?? []) as (CityCell | undefined)[]
+    let grid: (CityCell | undefined)[]
+    if (savedCols !== cols) {
+      // Expand the grid columns to match the new (larger) cols count
+      grid = Array(rows * cols).fill(undefined)
+      for (let r = 0; r < rows; r++) {
+        for (let c = 0; c < savedCols; c++) {
+          const cell = savedGrid[r * savedCols + c]
+          grid[r * cols + c] = cell ? { ...cell, stock: cell.stock ?? {} } : undefined
+        }
+      }
+    } else {
+      const cells = cols * rows
+      grid = (savedGrid.length < cells
+        ? [...savedGrid, ...Array(cells - savedGrid.length).fill(undefined)]
+        : savedGrid
+      ).map((c: CityCell | undefined) => c ? { ...c, stock: c.stock ?? {} } : c)
+    }
     return {
       grid,
       gold:           parsed.gold       ?? 0,

--- a/web/src/game/farmingSim.ts
+++ b/web/src/game/farmingSim.ts
@@ -34,6 +34,7 @@ export const FARM_EXPANSION_COSTS: Record<number, { gold: number; resources: Par
   7: { gold: 5_000_000, resources: { wood: 5000, ore: 2000, planks: 1000 } },
 }
 
+
 /** Production multiplier applied to farm buildings vs their city equivalent. */
 const FARM_PRODUCTION_BONUS = 1.5
 

--- a/web/src/game/farmingSim.ts
+++ b/web/src/game/farmingSim.ts
@@ -131,14 +131,28 @@ export function loadFarmState(): FarmState {
     const raw = localStorage.getItem(STORAGE_KEY)
     if (!raw) return defaultFarmState()
     const parsed = JSON.parse(raw) as Partial<FarmState>
-    const rows = parsed.rows ?? FARM_ROWS
-    const cols = parsed.cols ?? FARM_COLS
-    const cells = rows * cols
-    const savedPlots = parsed.plots ?? Array(cells).fill(undefined)
-    const plots = (savedPlots.length < cells
-      ? [...savedPlots, ...Array(cells - savedPlots.length).fill(undefined)]
-      : savedPlots
-    ).map((p: FarmPlot | undefined) => p ? { ...p, stock: p.stock ?? {} } : p)
+    const savedRows = parsed.rows ?? FARM_ROWS
+    const savedCols = parsed.cols ?? FARM_COLS
+    // Migrate old 6×4 default to square: trim extra cols down to rows×rows
+    const rows = savedRows
+    const cols = savedCols > savedRows ? savedRows : savedCols
+    const savedPlots = (parsed.plots ?? []) as (FarmPlot | undefined)[]
+    let plots: (FarmPlot | undefined)[]
+    if (savedCols !== cols) {
+      plots = Array(rows * cols).fill(undefined)
+      for (let r = 0; r < rows; r++) {
+        for (let c = 0; c < cols; c++) {
+          const p = savedPlots[r * savedCols + c]
+          plots[r * cols + c] = p ? { ...p, stock: p.stock ?? {} } : undefined
+        }
+      }
+    } else {
+      const cells = rows * cols
+      plots = (savedPlots.length < cells
+        ? [...savedPlots, ...Array(cells - savedPlots.length).fill(undefined)]
+        : savedPlots
+      ).map((p: FarmPlot | undefined) => p ? { ...p, stock: p.stock ?? {} } : p)
+    }
     const savedRes = (parsed.resources ?? {}) as Partial<ResourceStock>
     return {
       plots,

--- a/web/src/game/farmingSim.ts
+++ b/web/src/game/farmingSim.ts
@@ -34,7 +34,6 @@ export const FARM_EXPANSION_COSTS: Record<number, { gold: number; resources: Par
   7: { gold: 5_000_000, resources: { wood: 5000, ore: 2000, planks: 1000 } },
 }
 
-
 /** Production multiplier applied to farm buildings vs their city equivalent. */
 const FARM_PRODUCTION_BONUS = 1.5
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -8992,8 +8992,7 @@ html.light-mode .action-btn {
 }
 .city-world--paint { cursor: crosshair; }
 
-.city-zoom-wrapper,
-.farm-zoom-wrapper {
+.city-zoom-wrapper {
   position: absolute;
   top: 0; left: 0;
   width: 100%; height: 100%;
@@ -13016,21 +13015,6 @@ html.light-mode .action-btn {
 .farm-raid-pill--soon     { color: #c08020; }
 .farm-raid-pill--imminent { color: #d06030; animation: city-pulse 1.2s ease-in-out infinite; }
 
-/* Farm grid */
-.farm-world {
-  position: relative;
-  width: 100%;
-  flex: 0 0 50vh;
-  height: 50vh;
-  min-height: 180px;
-  overflow: hidden;
-  background: #1a2e10;
-  border-radius: 4px;
-  touch-action: none;
-  user-select: none;
-  -webkit-user-select: none;
-}
-.farm-grid  { padding: 4px; background: #1a2e10; width: 100%; height: 100%; box-sizing: border-box; }
 
 /* Farm plot cells */
 .farm-cell {


### PR DESCRIPTION
## Summary

- **Fort building selector**: Empty-slot picker is now a full-screen sub-screen (matching the city `CardPicker` flow) instead of a modal overlay. Filter/sort state moved local to `Fortifications`. `FortSlotModal` now only handles active/building-slot inspect dialogs.

- **Farm grid = CityGrid**: `FarmGrid` now delegates entirely to `CityGrid` with a synthetic `CityState` adapter. The farm shares the exact same cell rendering, road/path overlay (fixed wear on all interior edges for a plowed-field look), zoom/pan, bulldoze UI, and building sprites as the city. Only production buildings can be placed via the farm picker.

- **Save migration**: `loadCityState` normalises old asymmetric saves where rows grew but cols stayed at 6 — expands cols to match rows so the grid is square. `loadFarmState` trims the old 6×4 default to the new 4×4 minimum.

## Test plan

- [ ] Fort screen: tap an empty fort slot → navigates to full-screen card picker (not a modal)
- [ ] Fort picker has filter (rarity) and sort controls; tapping a card goes back to fort slots
- [ ] Tapping an active/building fort slot still shows the info modal
- [ ] Farm grid renders identical to city grid: same cell style, path/road overlay between plots, zoom/pan
- [ ] Farm building tap → picker shows only production buildings (no spawners)
- [ ] Old city save with 6-col×7-row grid loads as 7×7 (empty column added on right)
- [ ] Old farm save with 6-col×4-row grid loads as 4×4 (extra columns trimmed)

https://claude.ai/code/session_011crFfA2JRe2ouRm8LfXSUA

---
_Generated by [Claude Code](https://claude.ai/code/session_011crFfA2JRe2ouRm8LfXSUA)_