### PR TITLE
Farm: building inspect modal + goblin carrier animation

### DIFF
--- a/web/src/components/minigames/FarmingSim.tsx
+++ b/web/src/components/minigames/FarmingSim.tsx
@@ -2,7 +2,7 @@
 // Arable land outside the city walls. Mirrors the CityBuilder walker system
 // but all walkers are farmers sourced from city population.
 
-import React, { useState, useEffect, useRef, useCallback } from 'react'
+import React, { useState, useEffect, useRef } from 'react'
 import {
   FarmState, FarmRaidEvent,
   loadFarmState, saveFarmState, tickFarm,
@@ -12,24 +12,26 @@ import {
   getFarmProductionRate, farmDefense,
   canPlaceOnFarm, addFarmChronicle,
   canAffordFarmExpansion, expandFarm,
+  buildFarmCity,
   FARM_COLS, FARM_ROWS, MAX_FARM_SIZE, FARM_EXPANSION_COSTS,
 } from '../../game/farmingSim'
 import {
   CityState, ResourceType, CELL_PX,
-  cityPopulation, getBuildingProduces,
-  getNeighbourIndices,
+  cityPopulation, getBuildingProduces, getBuildingConsumes,
+  levelUpCost,
 } from '../../game/cityBuilder'
 import { ModalBackdrop } from '../ui/ModalBackdrop'
 import { getCardCatalog } from '../../game/cards'
-import { loadCollection, getOwnedCount } from '../../game/collection'
-import { logError } from '../../logger'
+import { loadCollection, getOwnedCount, saveCollection, getMasteryXp, masteryLevel, masteryXpForLevel } from '../../game/collection'
 import { OverlayScreen } from '../ui/OverlayScreen'
 import { Walker, WalkerTask, TaskType, PersonalityTrait } from './citybuilder/walkerTypes'
+import { VisualCarrier } from './CityBuilder'
 import { FarmGrid } from './farming/FarmGrid'
 import { FarmWorkerStrip } from './farming/FarmWorkerStrip'
 import { FarmRaidModal } from './farming/FarmRaidModal'
 import { FarmResourceBar } from './farming/FarmResourceBar'
 import { FarmBuildingPicker } from './farming/FarmBuildingPicker'
+import { BuildingInspectModal } from './citybuilder/BuildingInspectModal'
 import { ChroniclePanel } from './citybuilder/ChroniclePanel'
 import { Card } from '../../game/types'
 
@@ -132,10 +134,16 @@ export function FarmingSim({ city, onSaveCity, onBack }: Props) {
   const [currentTime, setCurrentTime] = useState(Date.now())
   const [showExpandModal, setShowExpandModal] = useState(false)
 
+  const [selectedCell, setSelectedCell]   = useState<number | null>(null)
+  const [buildingTab, setBuildingTab]     = useState<'residents' | 'upgrade'>('residents')
+  const [visualCarriers, setVisualCarriers] = useState<VisualCarrier[]>([])
+
   const farmRef    = useRef(farm)
   const walkersRef = useRef(walkers)
   const worldRef   = useRef<HTMLDivElement>(null)
   const worldDims  = useRef({ w: FARM_COLS * CELL_PX, h: FARM_ROWS * CELL_PX })
+  const visualCarriersRef   = useRef<VisualCarrier[]>([])
+  const carrierSeedTickRef  = useRef(0)
   const raidShownRef = useRef<number | null>(
     (() => {
       try { const v = localStorage.getItem('farm-raid-shown-at'); return v ? Number(v) : null } catch { return null }
@@ -287,6 +295,96 @@ export function FarmingSim({ city, onSaveCity, onBack }: Props) {
 
         return { ...w, x, y, vx, vy, turnTimer, task, taskTimer, bubbleTimer, waypoints }
       }))
+
+      // ── Farm carrier animation ─────────────────────────────────────────────────
+      const farmCurr  = farmRef.current
+      const farmRows2 = farmCurr.rows ?? FARM_ROWS
+      const farmCols2 = farmCurr.cols ?? FARM_COLS
+
+      // Every ~5s: clean up stale carriers and seed new producer→consumer ones
+      carrierSeedTickRef.current = (carrierSeedTickRef.current + 1) % 50
+      if (carrierSeedTickRef.current === 0) {
+        // Build set of valid carrier ids from current farm layout
+        const validIds = new Set<string>()
+        for (let i = 0; i < farmCurr.plots.length; i++) {
+          const plot = farmCurr.plots[i]
+          if (!plot) continue
+          const produces = getBuildingProduces(plot.cardName)
+          for (const [res, rate] of Object.entries(produces) as [ResourceType, number][]) {
+            if (!(rate > 0)) continue
+            for (let j = 0; j < farmCurr.plots.length; j++) {
+              if (i === j) continue
+              const other = farmCurr.plots[j]
+              if (!other) continue
+              if (!((getBuildingConsumes(other.cardName)[res as ResourceType] ?? 0) > 0)) continue
+              validIds.add(`fc-${i}-${j}-${res}`)
+              break
+            }
+          }
+        }
+        // Remove stale carriers and seed missing ones
+        const kept = visualCarriersRef.current.filter(vc => !vc.id.startsWith('fc-') || validIds.has(vc.id))
+        const existingIds = new Set(kept.map(vc => vc.id))
+        const toAdd: VisualCarrier[] = []
+        for (const id of validIds) {
+          if (existingIds.has(id)) continue
+          const parts = id.split('-')
+          const fromIdx = parseInt(parts[1]), toIdx = parseInt(parts[2])
+          const res = parts[3] as ResourceType
+          const c1 = fromIdx % farmCols2, r1 = Math.floor(fromIdx / farmCols2)
+          const c2 = toIdx % farmCols2, r2 = Math.floor(toIdx / farmCols2)
+          const pickX = (c1 + 0.5) * overlayW / farmCols2
+          const pickY = (r1 + 0.5) * overlayH / farmRows2
+          const dropX = (c2 + 0.5) * overlayW / farmCols2
+          const dropY = (r2 + 0.5) * overlayH / farmRows2
+          const dx = pickX - dropX, dy = pickY - dropY
+          const d = Math.sqrt(dx * dx + dy * dy) || 1
+          toAdd.push({
+            id, carrying: { [res]: 1 },
+            x: dropX, y: dropY,
+            vx: dx / d * SPEED, vy: dy / d * SPEED,
+            waypoints: [], scale: 0, phase: 'outbound',
+            pickX, pickY, dropX, dropY,
+          })
+        }
+        visualCarriersRef.current = [...kept, ...toAdd]
+      }
+
+      // Move carriers
+      const movedCarriers = visualCarriersRef.current.map(vc => {
+        let { x, y, vx, vy, scale, phase } = vc
+        if (scale < 1) {
+          scale = Math.min(1, scale + 0.1)
+          x += vx; y += vy
+          return { ...vc, x, y, scale }
+        }
+        const destX = phase === 'outbound' ? vc.pickX : vc.dropX
+        const destY = phase === 'outbound' ? vc.pickY : vc.dropY
+        const dx = destX - x, dy = destY - y
+        const dist = Math.sqrt(dx * dx + dy * dy)
+        if (dist < ARRIVE_DIST) {
+          if (phase === 'outbound') {
+            phase = 'returning'
+            const rdx = vc.dropX - x, rdy = vc.dropY - y
+            const rd = Math.sqrt(rdx * rdx + rdy * rdy) || 1
+            vx = rdx / rd * SPEED; vy = rdy / rd * SPEED
+          } else {
+            scale = Math.max(0, scale - 0.1)
+            vx = 0; vy = 0
+            if (scale <= 0) {
+              const rdx = vc.pickX - vc.dropX, rdy = vc.pickY - vc.dropY
+              const rd = Math.sqrt(rdx * rdx + rdy * rdy) || 1
+              return { ...vc, x: vc.dropX, y: vc.dropY, vx: rdx / rd * SPEED, vy: rdy / rd * SPEED, scale: 0, phase: 'outbound' as const }
+            }
+          }
+        } else if (dist > 0) {
+          vx = dx / dist * SPEED; vy = dy / dist * SPEED
+        }
+        x += vx; y += vy
+        return { ...vc, x, y, vx, vy, scale, phase }
+      })
+      visualCarriersRef.current = movedCarriers
+      setVisualCarriers([...movedCarriers])
     }, 100)
     return () => clearInterval(id)
   }, [])
@@ -391,6 +489,7 @@ export function FarmingSim({ city, onSaveCity, onBack }: Props) {
         <FarmGrid
           farm={farm}
           walkers={walkers}
+          visualCarriers={visualCarriers}
           bulldozer={bulldozer}
           worldRef={worldRef}
           onCellTap={index => {
@@ -408,7 +507,8 @@ export function FarmingSim({ city, onSaveCity, onBack }: Props) {
                 saveFarm(next)
                 showToast('Building returned to city.')
               } else {
-                showToast(`${farm.plots[index]?.cardName} — tap DEMOLISH to remove`)
+                setSelectedCell(index)
+                setBuildingTab('residents')
               }
             } else {
               setPickerIndex(index)
@@ -417,6 +517,44 @@ export function FarmingSim({ city, onSaveCity, onBack }: Props) {
           }}
           onWalkerClick={(ci) => showToast(`Farmer ${ci + 1} is ${walkers[ci]?.task.label ?? 'busy'}`)}
         />
+
+        {selectedCell !== null && (() => {
+          const plot = farm.plots[selectedCell]
+          if (!plot) return null
+          const farmCity = buildFarmCity(farm)
+          const cell = farmCity.grid[selectedCell]
+          if (!cell) return null
+          return (
+            <BuildingInspectModal
+              cellIndex={selectedCell}
+              cell={cell}
+              city={{ ...farmCity, gold: city.gold }}
+              collection={collection}
+              walkers={walkers}
+              buildingTab={buildingTab}
+              setBuildingTab={setBuildingTab}
+              onClose={() => setSelectedCell(null)}
+              onLevelUp={cardName => {
+                const col = loadCollection()
+                const currentXp = getMasteryXp(col, cardName)
+                const currentLvl = masteryLevel(currentXp)
+                const cost = levelUpCost(currentLvl, cardName)
+                if (city.gold < cost) { showToast('Not enough gold!'); return }
+                onSaveCity({ ...city, gold: city.gold - cost })
+                const xpToGrant = masteryXpForLevel(currentLvl + 1) - currentXp
+                const updated = col.map(e =>
+                  e.cardName === cardName ? { ...e, masteryXp: (e.masteryXp ?? 0) + xpToGrant } : e
+                )
+                if (!updated.find(e => e.cardName === cardName))
+                  updated.push({ cardName, count: 0, masteryXp: xpToGrant })
+                saveCollection(updated)
+                showToast(`${cardName} levelled up! Mastery ★${currentLvl + 1}`)
+                setBuildingTab('upgrade')
+              }}
+              onMoveIn={() => {}}
+            />
+          )
+        })()}
 
         <div className="city-header u-flex u-items-c u-just-c u-gap-3">
           <button

--- a/web/src/components/minigames/FarmingSim.tsx
+++ b/web/src/components/minigames/FarmingSim.tsx
@@ -198,9 +198,9 @@ export function FarmingSim({ city, onSaveCity, onBack }: Props) {
     return () => ro.disconnect()
   }, [screen])
 
-  // Clock for raid countdown
+  // Clock for raid countdown — 1 s for accurate countdown display
   useEffect(() => {
-    const id = setInterval(() => setCurrentTime(Date.now()), 60_000)
+    const id = setInterval(() => setCurrentTime(Date.now()), 1_000)
     return () => clearInterval(id)
   }, [])
 
@@ -533,6 +533,8 @@ export function FarmingSim({ city, onSaveCity, onBack }: Props) {
               walkers={walkers}
               buildingTab={buildingTab}
               setBuildingTab={setBuildingTab}
+              productionMultiplier={1.5}
+              productionNote="🌾 +50% farm bonus included"
               onClose={() => setSelectedCell(null)}
               onLevelUp={cardName => {
                 const col = loadCollection()

--- a/web/src/components/minigames/citybuilder/BuildingInspectModal.tsx
+++ b/web/src/components/minigames/citybuilder/BuildingInspectModal.tsx
@@ -12,22 +12,28 @@ import { SpriteImg, AnimatedSpriteImg } from '../../ui/SpriteImg'
 import { Walker, rageDescription, residentName, getUnitRequirements } from './walkerTypes'
 
 export interface Props {
-  cellIndex:      number
-  cell:           CityCell
-  city:           CityState
-  collection:     CollectionEntry[]
-  walkers:        Walker[]
-  buildingTab:    'residents' | 'upgrade'
-  setBuildingTab: (tab: 'residents' | 'upgrade') => void
-  onClose:        () => void
-  onLevelUp:      (cardName: string) => void
-  onMoveIn:       () => void
+  cellIndex:          number
+  cell:               CityCell
+  city:               CityState
+  collection:         CollectionEntry[]
+  walkers:            Walker[]
+  buildingTab:        'residents' | 'upgrade'
+  setBuildingTab:     (tab: 'residents' | 'upgrade') => void
+  onClose:            () => void
+  onLevelUp:          (cardName: string) => void
+  onMoveIn:           () => void
+  /** Optional multiplier applied to displayed production rates (e.g. 1.5 for farm bonus). */
+  productionMultiplier?: number
+  /** Optional label shown beside the production rate (e.g. "+50% farm bonus"). */
+  productionNote?:    string
 }
 
 export function BuildingInspectModal({
   cellIndex, cell, city, collection, walkers,
   buildingTab, setBuildingTab,
   onClose, onLevelUp, onMoveIn,
+  productionMultiplier = 1,
+  productionNote,
 }: Props) {
   const happiness      = cell.spawnedUnitName ? (city.happiness[cellIndex] ?? 100) : 100
   const unitCount      = cell.spawnedUnitName ? spawnerUnitCount(city, cell.cardName) : 0
@@ -146,7 +152,7 @@ export function BuildingInspectModal({
                   <div className="city-bld-section-title">Production rate</div>
                   {produceEntries.map(([res, amt]) => {
                     const sm = synergyMap[res as ResourceType] ?? 0
-                    const total = Math.round((amt as number) * masteryMult * (1 + sm))
+                    const total = Math.round((amt as number) * masteryMult * (1 + sm) * productionMultiplier)
                     return (
                       <div key={res} className="city-bld-produces-row">
                         +{total} {RESOURCE_ICONS[res as ResourceType]}/min
@@ -154,6 +160,7 @@ export function BuildingInspectModal({
                       </div>
                     )
                   })}
+                  {productionNote && <div className="city-synergy-label">{productionNote}</div>}
                 </>
               )}
               {consumeEntries.length > 0 && (

--- a/web/src/components/minigames/farming/FarmGrid.stories.tsx
+++ b/web/src/components/minigames/farming/FarmGrid.stories.tsx
@@ -29,6 +29,8 @@ const farm: FarmState = {
   lastRaid: null,
   chronicle: [],
   resources: { wheat: 5, wood: 2, ore: 0, bread: 0, planks: 0, metal: 0 },
+  carriers: [],
+  roadWear: { h: Array(24).fill(0), v: Array(24).fill(0) },
 }
 
 const sampleWalkers: Walker[] = [
@@ -55,6 +57,7 @@ function Wrapper() {
       <FarmGrid
         farm={farm}
         walkers={sampleWalkers}
+        visualCarriers={[]}
         bulldozer={false}
         worldRef={worldRef}
         onCellTap={(i) => console.log('cell', i)}
@@ -82,6 +85,7 @@ export const BulldozerMode: Story = {
         <FarmGrid
           farm={farm}
           walkers={[]}
+          visualCarriers={[]}
           bulldozer={true}
           worldRef={worldRef}
           onCellTap={(i) => console.log('bulldoze', i)}

--- a/web/src/components/minigames/farming/FarmGrid.tsx
+++ b/web/src/components/minigames/farming/FarmGrid.tsx
@@ -1,58 +1,26 @@
 import React from 'react'
-import { FarmState, FARM_COLS, FARM_ROWS } from '../../../game/farmingSim'
-import { CityState } from '../../../game/cityBuilder'
+import { FarmState, FARM_COLS, FARM_ROWS, buildFarmCity } from '../../../game/farmingSim'
 import { Walker } from '../citybuilder/walkerTypes'
 import { CityGrid } from '../citybuilder/CityGrid'
+import { VisualCarrier } from '../CityBuilder'
 
 export interface Props {
   farm:          FarmState
   walkers:       Walker[]
+  visualCarriers: VisualCarrier[]
   bulldozer:     boolean
   worldRef:      React.RefObject<HTMLDivElement>
   onCellTap:     (index: number) => void
   onWalkerClick: (cellIndex: number, unitIndex: number) => void
 }
 
-export function FarmGrid({ farm, walkers, bulldozer, worldRef, onCellTap, onWalkerClick }: Props) {
-  const rows = farm.rows ?? FARM_ROWS
-  const cols = farm.cols ?? FARM_COLS
-
-  // Fixed path wear on every interior edge gives the farm a plowed-field grid look
-  const h = Array.from({ length: rows * cols }, (_, i) => (i % cols < cols - 1 ? 40 : 0))
-  const v = Array.from({ length: rows * cols }, (_, i) => (Math.floor(i / cols) < rows - 1 ? 40 : 0))
-
-  const fakeCityState: CityState = {
-    grid:           farm.plots.map(p => p ? { cardName: p.cardName, rarity: p.rarity, stock: p.stock } : undefined),
-    rows,
-    cols,
-    gold:           0,
-    resources:      { ...farm.resources, bread: 1 },
-    lastTick:       0,
-    happiness:      {},
-    nextAttackAt:   0,
-    fortifications: [],
-    builderQueue:   [],
-    builderCount:   0,
-    lastAttack:     null,
-    chronicle:      [],
-    completedMilestones: [],
-    attacksProcessed:    0,
-    tradeOffer:          null,
-    activeCaravan:       null,
-    history:             [],
-    zones:               [],
-    activeDisaster:      null,
-    nextDisasterAt:      0,
-    roadWear:            { h, v },
-    carriers:            [],
-  }
-
+export function FarmGrid({ farm, walkers, visualCarriers, bulldozer, worldRef, onCellTap, onWalkerClick }: Props) {
   return (
     <CityGrid
-      city={fakeCityState}
+      city={buildFarmCity(farm)}
       walkers={walkers}
       builderWalkers={[]}
-      visualCarriers={[]}
+      visualCarriers={visualCarriers}
       bulldozerMode={bulldozer}
       worldRef={worldRef}
       paintBrush={false}

--- a/web/src/components/minigames/farming/FarmPlotCell.stories.tsx
+++ b/web/src/components/minigames/farming/FarmPlotCell.stories.tsx
@@ -11,6 +11,8 @@ const baseFarm: FarmState = {
   lastRaid: null,
   chronicle: [],
   resources: { wheat: 0, wood: 0, ore: 0, bread: 0, planks: 0, metal: 0 },
+  carriers: [],
+  roadWear: { h: Array(24).fill(0), v: Array(24).fill(0) },
 }
 
 const meta: Meta<typeof FarmPlotCell> = {

--- a/web/src/game/farmingSim.ts
+++ b/web/src/game/farmingSim.ts
@@ -9,6 +9,7 @@ import {
   getBuildingProduces, currentSeason, SEASON_INFO,
   CELL_PX,
   DEFAULT_BUILDER_COUNT, MAX_BUILDER_COUNT, BUILDER_HIRE_COSTS,
+  CityState, CityCell, CarrierState, RoadWearMap,
 } from './cityBuilder'
 import type { CardRarity } from './types'
 
@@ -90,6 +91,8 @@ export interface FarmState {
   lastRaid:   FarmRaidEvent | null
   chronicle:  string[]
   resources:  ResourceStock
+  carriers:   CarrierState[]
+  roadWear:   RoadWearMap
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -109,6 +112,45 @@ export function addFarmChronicle(state: FarmState, msg: string): FarmState {
   return { ...state, chronicle }
 }
 
+// ── Farm → CityState adapter ──────────────────────────────────────────────────
+
+/** Convert FarmState to a CityState for use with CityGrid and carrier animation. */
+export function buildFarmCity(farm: FarmState): CityState {
+  const rows = farm.rows ?? FARM_ROWS
+  const cols = farm.cols ?? FARM_COLS
+  const cells = rows * cols
+  const roadWear: RoadWearMap = farm.roadWear ?? {
+    h: Array.from({ length: cells }, (_, i) => (i % cols < cols - 1 ? 40 : 0)),
+    v: Array.from({ length: cells }, (_, i) => (Math.floor(i / cols) < rows - 1 ? 40 : 0)),
+  }
+  return {
+    grid: farm.plots.map(p =>
+      p ? ({ cardName: p.cardName, rarity: p.rarity, stock: p.stock ?? {} } as CityCell) : undefined
+    ),
+    rows, cols,
+    gold: 0,
+    resources: { ...farm.resources, bread: 1 },
+    lastTick: farm.lastTick,
+    happiness: {},
+    nextAttackAt: 0,
+    fortifications: [],
+    builderQueue: [],
+    builderCount: 0,
+    lastAttack: null,
+    chronicle: [],
+    completedMilestones: [],
+    attacksProcessed: 0,
+    tradeOffer: null,
+    activeCaravan: null,
+    history: [],
+    zones: [],
+    activeDisaster: null,
+    nextDisasterAt: 0,
+    roadWear,
+    carriers: farm.carriers ?? [],
+  }
+}
+
 // ── Default / load / save ─────────────────────────────────────────────────────
 
 function defaultFarmState(): FarmState {
@@ -123,6 +165,8 @@ function defaultFarmState(): FarmState {
     lastRaid:   null,
     chronicle:  [],
     resources:  emptyResources(),
+    carriers:   [],
+    roadWear:   { h: Array(FARM_CELLS).fill(0), v: Array(FARM_CELLS).fill(0) },
   }
 }
 
@@ -154,6 +198,7 @@ export function loadFarmState(): FarmState {
       ).map((p: FarmPlot | undefined) => p ? { ...p, stock: p.stock ?? {} } : p)
     }
     const savedRes = (parsed.resources ?? {}) as Partial<ResourceStock>
+    const cells = rows * cols
     return {
       plots,
       rows,
@@ -172,6 +217,8 @@ export function loadFarmState(): FarmState {
         planks: savedRes.planks ?? 0,
         metal:  savedRes.metal  ?? 0,
       },
+      carriers: [],
+      roadWear: (parsed as Partial<FarmState>).roadWear ?? { h: Array(cells).fill(0), v: Array(cells).fill(0) },
     }
   } catch (err) {
     logError('loadFarmState failed', err as Record<string, unknown>)
@@ -291,7 +338,7 @@ export function expandFarm(state: FarmState): FarmState {
       plots[newIdx] = state.plots[oldIdx]
     }
   }
-  let next = { ...state, rows: newRows, cols: newCols, plots }
+  let next: FarmState = { ...state, rows: newRows, cols: newCols, plots, carriers: [], roadWear: { h: Array(newCells).fill(0), v: Array(newCells).fill(0) } }
   next = addFarmChronicle(next, `🏗 Farm expanded to ${newRows}×${newCols}`)
   return next
 }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Building inspect modal on farm**: Tapping an occupied farm cell now opens the same `BuildingInspectModal` as the city screen — shows production rate, stockpile, and the upgrade tab. Gold for upgrades is deducted from the city.
- **Goblin carrier goblins**: Carriers now animate between producer→consumer building pairs on the farm (e.g. Wheat Farm → Windmill). They loop continuously and are cleaned up automatically when buildings are removed or the farm expands.
- **`buildFarmCity()` extracted**: Shared helper in `farmingSim.ts` converts `FarmState` to a `CityState` adapter, used by both `FarmGrid` and `FarmingSim`.
- **`FarmState` extended**: Added `carriers: CarrierState[]` and `roadWear: RoadWearMap` fields with migration support for old saves (defaults to empty arrays).

## Test plan

- [ ] Place a Wheat Farm and a Windmill on the farm → goblin carrier should appear and animate between them after ~5 seconds
- [ ] Tap an occupied farm cell (not in DEMOLISH mode) → BuildingInspectModal opens showing production rate
- [ ] Upgrade tab in modal deducts gold from city
- [ ] CLOSE button dismisses the modal
- [ ] Removing a building (DEMOLISH mode) stops the carrier animation for that pair
- [ ] Farm expansion clears carriers correctly (no stale goblins after expanding)
- [ ] Old saves without `carriers`/`roadWear` fields load correctly

https://claude.ai/code/session_011crFfA2JRe2ouRm8LfXSUA
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_011crFfA2JRe2ouRm8LfXSUA)_