### PR TITLE
Fix farm carrier goblins stuck at consumer building

### DIFF
--- a/web/src/components/minigames/FarmingSim.tsx
+++ b/web/src/components/minigames/FarmingSim.tsx
@@ -353,7 +353,8 @@ export function FarmingSim({ city, onSaveCity, onBack }: Props) {
       // Move carriers
       const movedCarriers = visualCarriersRef.current.map(vc => {
         let { x, y, vx, vy, scale, phase } = vc
-        if (scale < 1) {
+        // Grow only on outbound spawn — returning shrink must not trigger this
+        if (scale < 1 && phase === 'outbound') {
           scale = Math.min(1, scale + 0.1)
           x += vx; y += vy
           return { ...vc, x, y, scale }


### PR DESCRIPTION
## Summary

- The grow-on-spawn check (`if (scale < 1)`) fired every tick during the shrink-out animation, incrementing scale back to 1.0 and trapping the goblin permanently at the consumer building.
- Fix: guard the grow path with `phase === 'outbound'` so only newly-spawned goblins grow in; the returning shrink is never interrupted.

## Test plan

- [ ] Place a Wheat Farm and a Windmill (or other producer→consumer pair) on the farm
- [ ] After ~5 seconds a goblin carrier appears and walks from consumer to producer
- [ ] On the return trip, goblin carries the resource icon back to the consumer
- [ ] Goblin shrinks into the consumer building and then re-spawns — no longer gets stuck

https://claude.ai/code/session_011crFfA2JRe2ouRm8LfXSUA

---
_Generated by [Claude Code](https://claude.ai/code/session_011crFfA2JRe2ouRm8LfXSUA)_