### PR TITLE
Farm: fix roads, per-cell stock display, and resource flow to city

### DIFF
--- a/web/src/components/minigames/CityBuilder.tsx
+++ b/web/src/components/minigames/CityBuilder.tsx
@@ -62,7 +62,7 @@ import { DisasterModal } from './citybuilder/DisasterModal'
 import { OverlayScreen } from '../ui/OverlayScreen'
 import { ModalBackdrop } from '../ui/ModalBackdrop'
 import { FarmingSim } from './FarmingSim'
-import { isFarmUnlocked, loadFarmState, getFarmProductionRate } from '../../game/farmingSim'
+import { isFarmUnlocked, loadFarmState, saveFarmState, tickFarm, getFarmProductionRate } from '../../game/farmingSim'
 
 
 // ── Resident thought lines ────────────────────────────────────────────────────
@@ -676,6 +676,7 @@ export function CityBuilder({ onBack }: Props) {
   const cityRef = useRef(city)
   const walkersRef = useRef(walkers)
   const builderWalkersRef = useRef(builderWalkers)
+  const screenRef = useRef(screen)
 
   function showToast(msg: string) {
     setToast(msg)
@@ -695,6 +696,7 @@ export function CityBuilder({ onBack }: Props) {
   useEffect(() => { cityRef.current = city }, [city])
   useEffect(() => { walkersRef.current = walkers }, [walkers])
   useEffect(() => { builderWalkersRef.current = builderWalkers }, [builderWalkers])
+  useEffect(() => { screenRef.current = screen }, [screen])
 
   // Show attack report when a new attack is detected
   useEffect(() => {
@@ -1137,7 +1139,24 @@ export function CityBuilder({ onBack }: Props) {
     const id = setInterval(() => {
       if (bulldozerRef.current) return
       setCity(prev => {
-        const next = tickCity(prev)
+        let next = tickCity(prev)
+
+        // Tick the farm and apply its output to city resources when farm screen
+        // is not open (FarmingSim handles its own tick when the farm is visible).
+        if (screenRef.current !== 'farming' && isFarmUnlocked(cityPopulation(next))) {
+          const farmState = loadFarmState()
+          const { nextState: nextFarm, resourcesForCity } = tickFarm(farmState)
+          saveFarmState(nextFarm)
+          const hasResources = Object.values(resourcesForCity).some(v => (v ?? 0) > 0)
+          if (hasResources) {
+            const newRes = { ...next.resources }
+            for (const [res, amt] of Object.entries(resourcesForCity) as [ResourceType, number][]) {
+              newRes[res] = Math.round((newRes[res] ?? 0) + amt)
+            }
+            next = { ...next, resources: newRes }
+          }
+        }
+
         saveCityState(next)
         return next
       })

--- a/web/src/components/minigames/FarmingSim.tsx
+++ b/web/src/components/minigames/FarmingSim.tsx
@@ -124,7 +124,15 @@ type SubScreen = 'farm' | 'picker' | 'chronicle'
 // ── Component ─────────────────────────────────────────────────────────────────
 
 export function FarmingSim({ city, onSaveCity, onBack }: Props) {
-  const [farm, setFarm]             = useState<FarmState>(() => tickFarm(loadFarmState()).nextState)
+  // Catch-up tick on mount: advance farm state for offline time, capture resources
+  // to ship to city (applied in the mount useEffect below).
+  const initCatchUpRef = useRef<Partial<Record<ResourceType, number>>>({})
+  const [farm, setFarm]             = useState<FarmState>(() => {
+    const { nextState, resourcesForCity } = tickFarm(loadFarmState())
+    saveFarmState(nextState)
+    initCatchUpRef.current = resourcesForCity
+    return nextState
+  })
   const [screen, setScreen]         = useState<SubScreen>('farm')
   const [walkers, setWalkers]       = useState<Walker[]>([])
   const [pickerIndex, setPickerIndex] = useState<number>(0)
@@ -162,6 +170,19 @@ export function FarmingSim({ city, onSaveCity, onBack }: Props) {
 
   useEffect(() => { farmRef.current = farm }, [farm])
   useEffect(() => { walkersRef.current = walkers }, [walkers])
+
+  // Ship any resources produced during the offline catch-up tick to the city
+  useEffect(() => {
+    const rfc = initCatchUpRef.current
+    if (!rfc || !Object.values(rfc).some(v => (v ?? 0) > 0)) return
+    initCatchUpRef.current = {}
+    const newCityRes = { ...city.resources }
+    for (const [res, amt] of Object.entries(rfc) as [ResourceType, number][]) {
+      newCityRes[res] = Math.round((newCityRes[res] ?? 0) + amt)
+    }
+    onSaveCity({ ...city, resources: newCityRes })
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   // Show raid modal when a new raid is detected
   useEffect(() => {

--- a/web/src/game/farmingSim.ts
+++ b/web/src/game/farmingSim.ts
@@ -119,15 +119,39 @@ export function buildFarmCity(farm: FarmState): CityState {
   const rows = farm.rows ?? FARM_ROWS
   const cols = farm.cols ?? FARM_COLS
   const cells = rows * cols
-  const roadWear: RoadWearMap = farm.roadWear ?? {
+
+  // Farm always shows roads between all cells at tier-1 (wear=40),
+  // regardless of the stored roadWear which starts at zero.
+  const roadWear: RoadWearMap = {
     h: Array.from({ length: cells }, (_, i) => (i % cols < cols - 1 ? 40 : 0)),
     v: Array.from({ length: cells }, (_, i) => (Math.floor(i / cols) < rows - 1 ? 40 : 0)),
   }
+
+  // Count how many plots produce each resource so we can split the farm pool.
+  const producerCount: Partial<Record<ResourceType, number>> = {}
+  for (const p of farm.plots) {
+    if (!p) continue
+    for (const [res, rate] of Object.entries(getBuildingProduces(p.cardName)) as [ResourceType, number][]) {
+      if ((rate ?? 0) > 0) producerCount[res] = (producerCount[res] ?? 0) + 1
+    }
+  }
+
+  // Each producing plot shows its proportional share of the farm resource pool.
+  const grid = farm.plots.map(p => {
+    if (!p) return undefined
+    const produces = getBuildingProduces(p.cardName)
+    const stock: Partial<Record<ResourceType, number>> = {}
+    for (const [res, rate] of Object.entries(produces) as [ResourceType, number][]) {
+      if ((rate ?? 0) > 0) {
+        const share = (farm.resources[res] ?? 0) / (producerCount[res] ?? 1)
+        if (share >= 0.01) stock[res] = share
+      }
+    }
+    return { cardName: p.cardName, rarity: p.rarity, stock } as CityCell
+  })
+
   return {
-    grid: farm.plots.map(p =>
-      p ? ({ cardName: p.cardName, rarity: p.rarity, stock: p.stock ?? {} } as CityCell) : undefined
-    ),
-    rows, cols,
+    grid, rows, cols,
     gold: 0,
     resources: { ...farm.resources, bread: 1 },
     lastTick: farm.lastTick,


### PR DESCRIPTION
## Summary

- **Roads now visible on farm grid** — `buildFarmCity` always computes road wear as 40 for all inner cell edges instead of reading from `farm.roadWear` (which defaults to all zeros, making `RoadPath` render nothing)
- **Resource icons now appear on farm cells** — producing plots now show their proportional share of `farm.resources` as per-cell stock, matching how city grid cells display accumulated resources
- **Farm resources now flow to city continuously** — CityBuilder's 10s resource tick now also ticks the farm and applies `resourcesForCity` when the farming screen is not open; previously farm production only reached the city while the FarmingSim screen was mounted
- **Initial catch-up resources correctly shipped** — on FarmingSim mount, offline-period resources captured from the catch-up tick are now applied to the city via a mount-only `useEffect`

## Test plan

- [ ] Open city screen with farm buildings placed on farm grid — city resource bar should increase every 10s
- [ ] Navigate to farm screen — roads/paths should be visible between all grid cells
- [ ] Farm cells with production buildings should show resource icons (🌾 wheat, 🪵 wood, etc.)
- [ ] Walkers should visually follow the road paths between cells
- [ ] Leave app for a few minutes, return to city screen — offline farm production should appear in city resources

https://claude.ai/code/session_011crFfA2JRe2ouRm8LfXSUA

---
_Generated by [Claude Code](https://claude.ai/code/session_011crFfA2JRe2ouRm8LfXSUA)_