### PR TITLE
Farm: road wear builds organically from carrier routes and walker traffic

### DIFF
--- a/web/src/game/farmingSim.ts
+++ b/web/src/game/farmingSim.ts
@@ -6,7 +6,7 @@
 import { logError } from '../logger'
 import {
   ResourceType, ResourceStock,
-  getBuildingProduces, currentSeason, SEASON_INFO,
+  getBuildingProduces, getBuildingConsumes, currentSeason, SEASON_INFO,
   CELL_PX,
   DEFAULT_BUILDER_COUNT, MAX_BUILDER_COUNT, BUILDER_HIRE_COSTS,
   CityState, CityCell, CarrierState, RoadWearMap,
@@ -61,6 +61,11 @@ const SHIP_THRESHOLD = 5
 const CHRONICLE_MAX = 30
 
 const STORAGE_KEY = 'jarv_farming_sim'
+
+// ── Road wear constants (mirror city values) ─────────────────────────────────
+const ROAD_DECAY_PER_MIN    = 0.3   // wear lost per minute on unused edges (same as city)
+const ROAD_WEAR_PER_CARRIER = 0.4   // wear per carrier route per minute (same as city)
+const ROAD_WEAR_WALKER_BG   = 3.0   // background wear per adjacent occupied-pair per minute
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -120,11 +125,11 @@ export function buildFarmCity(farm: FarmState): CityState {
   const cols = farm.cols ?? FARM_COLS
   const cells = rows * cols
 
-  // Farm always shows roads between all cells at tier-1 (wear=40),
-  // regardless of the stored roadWear which starts at zero.
-  const roadWear: RoadWearMap = {
-    h: Array.from({ length: cells }, (_, i) => (i % cols < cols - 1 ? 40 : 0)),
-    v: Array.from({ length: cells }, (_, i) => (Math.floor(i / cols) < rows - 1 ? 40 : 0)),
+  // Use the farm's live road wear so roads build up and decay organically,
+  // matching the city view's behaviour (wear driven by carrier routes + decay).
+  const roadWear: RoadWearMap = farm.roadWear ?? {
+    h: Array(cells).fill(0),
+    v: Array(cells).fill(0),
   }
 
   // Count how many plots produce each resource so we can split the farm pool.
@@ -467,6 +472,22 @@ function processFarmRaid(state: FarmState): FarmState {
   return next
 }
 
+// ── Road wear helpers ─────────────────────────────────────────────────────────
+
+/** Add wear to every edge on the Manhattan path from→to (mirrors city wearPath). */
+function farmWearPath(from: number, to: number, roadWear: RoadWearMap, cols: number, amount: number): void {
+  let c = from % cols, r = Math.floor(from / cols)
+  const tc = to % cols, tr = Math.floor(to / cols)
+  while (c !== tc || r !== tr) {
+    const pc = c, pr = r
+    if (c !== tc) c += c < tc ? 1 : -1; else r += r < tr ? 1 : -1
+    const lo = Math.min(pr * cols + pc, r * cols + c)
+    const hi = Math.max(pr * cols + pc, r * cols + c)
+    if (hi === lo + 1) roadWear.h[lo] = Math.min(100, (roadWear.h[lo] ?? 0) + amount)
+    else               roadWear.v[lo] = Math.min(100, (roadWear.v[lo] ?? 0) + amount)
+  }
+}
+
 // ── Tick ──────────────────────────────────────────────────────────────────────
 
 /**
@@ -515,7 +536,57 @@ export function tickFarm(
     next = processFarmRaid(next)
   }
 
-  // ── 3. Ship resources to the city (above threshold) ──────────────────────────
+  // ── 3. Road wear — mirrors city carrier + decay logic ───────────────────────
+  {
+    const cols = next.cols ?? FARM_COLS
+    const rows = next.rows ?? FARM_ROWS
+    const rw: RoadWearMap = {
+      h: [...(next.roadWear?.h ?? [])],
+      v: [...(next.roadWear?.v ?? [])],
+    }
+
+    // a) Background wear: adjacent occupied-plot pairs (farmers moving between plots)
+    for (let i = 0; i < next.plots.length; i++) {
+      if (!next.plots[i]) continue
+      const col = i % cols, row = Math.floor(i / cols)
+      if (col < cols - 1 && next.plots[i + 1]) {
+        rw.h[i] = Math.min(100, (rw.h[i] ?? 0) + ROAD_WEAR_WALKER_BG * minutes)
+      }
+      if (row < rows - 1 && next.plots[i + cols]) {
+        rw.v[i] = Math.min(100, (rw.v[i] ?? 0) + ROAD_WEAR_WALKER_BG * minutes)
+      }
+    }
+
+    // b) Carrier-route wear: producer→nearest-consumer (same pairs the visual goblins use)
+    for (let i = 0; i < next.plots.length; i++) {
+      const plot = next.plots[i]
+      if (!plot) continue
+      const produces = getBuildingProduces(plot.cardName)
+      for (const [res, rate] of Object.entries(produces) as [ResourceType, number][]) {
+        if (!(rate > 0)) continue
+        for (let j = 0; j < next.plots.length; j++) {
+          if (i === j) continue
+          const other = next.plots[j]
+          if (!other) continue
+          if (!((getBuildingConsumes(other.cardName)[res] ?? 0) > 0)) continue
+          farmWearPath(i, j, rw, cols, ROAD_WEAR_PER_CARRIER * minutes)
+          break
+        }
+      }
+    }
+
+    // c) Decay all edges (unused roads revert to grass)
+    for (let idx = 0; idx < rw.h.length; idx++) {
+      if (rw.h[idx] > 0) rw.h[idx] = Math.max(0, rw.h[idx] - ROAD_DECAY_PER_MIN * minutes)
+    }
+    for (let idx = 0; idx < rw.v.length; idx++) {
+      if (rw.v[idx] > 0) rw.v[idx] = Math.max(0, rw.v[idx] - ROAD_DECAY_PER_MIN * minutes)
+    }
+
+    next = { ...next, roadWear: rw }
+  }
+
+  // ── 4. Ship resources to the city (above threshold) ──────────────────────────
   const resourcesForCity: Partial<ResourceStock> = {}
   const shipped = { ...next.resources }
   let anyShipped = false


### PR DESCRIPTION
## Summary

Makes farm road wear work identically to the city view:

- **Background walker wear** — adjacent occupied plots generate wear at `3/min` per edge pair, representing farmers moving between buildings. Roads reach tier-1 (~25 wear) after ~9 minutes of a farm being active.
- **Carrier-route wear** — producer→consumer routes (e.g. Farm→Mill) add extra `0.4/min` per route, identical to the city's carrier wear constant.
- **Decay** — all edges decay at `0.3/min` (same as city). Unused roads revert to grass, active routes cap at full wear.
- **`buildFarmCity` uses live `farm.roadWear`** instead of the previous hardcoded-40 override, so roads are absent at first and grow organically as the farm runs — exactly matching city behaviour.

Roads start at zero on a new farm and reach tier-1 within ~9 minutes. Removing adjacent buildings causes the connecting road to fade over time.

## Test plan

- [ ] Place buildings on farm grid — no roads visible at start
- [ ] After ~5–10 minutes of play, paths should appear between adjacent occupied cells
- [ ] Roads between producer→consumer pairs (e.g. Farm + Mill on farm) should be visibly stronger/wider
- [ ] Removing a building should cause its connecting roads to fade over time
- [ ] Walker sprites should visually follow the road paths (through cell gaps)

https://claude.ai/code/session_011crFfA2JRe2ouRm8LfXSUA

---
_Generated by [Claude Code](https://claude.ai/code/session_011crFfA2JRe2ouRm8LfXSUA)_