### PR TITLE
fix(fruitMachine): replace runTransaction with increment sentinel in incrementGrandJackpot

### DIFF
--- a/web/src/game/fruitMachineJackpot.ts
+++ b/web/src/game/fruitMachineJackpot.ts
@@ -41,12 +41,8 @@ export async function fetchGrandJackpot(): Promise<number> {
 
 /** Atomically increments the shared jackpot by a specified amount per spin (fire-and-forget). */
 export function incrementGrandJackpot(amount: number = 1): void {
-  runTransaction(db, async tx => {
-    const snap = await tx.get(JACKPOT_DOC)
-    const current = snap.exists() ? (snap.data().value as number) : GRAND_BASE
-    const newValue = current + amount
-    tx.set(JACKPOT_DOC, { value: newValue, updatedAt: Timestamp.now() }, { merge: true })
-  }).catch(e => logError('fm_grand increment', { error: String(e) }))
+  setDoc(JACKPOT_DOC, { value: increment(amount), updatedAt: Timestamp.now() }, { merge: true })
+    .catch(e => logError('fm_grand increment', { error: String(e) }))
 }
 
 /**


### PR DESCRIPTION
## Summary

- Fixes the `fm_grand increment` Rollbar error (issue #1270)
- Replaces the manual read-modify-write `runTransaction` in `incrementGrandJackpot` with a `setDoc` call using Firestore's `increment` FieldValue sentinel
- The `increment` sentinel is a server-side atomic operation — no read needed, no contention, immune to simultaneous-spin failures that were triggering the error

## Test plan

- [ ] `npm run build` passes clean ✅
- [ ] Open FruitMachine, spin several times — no new `fm_grand increment` errors in Rollbar
- [ ] Grand jackpot value in Firestore increments correctly across multiple sessions

Closes #1270

---
_Generated by [Claude Code](https://claude.ai/code/session_016d3xJENFnPdQ1b6NyAFrBn)_