### PR TITLE
Farm: fix wheat resource icon and city-resource stale closure

### DIFF
--- a/web/src/components/minigames/FarmingSim.tsx
+++ b/web/src/components/minigames/FarmingSim.tsx
@@ -147,6 +147,7 @@ export function FarmingSim({ city, onSaveCity, onBack }: Props) {
   const [visualCarriers, setVisualCarriers] = useState<VisualCarrier[]>([])
 
   const farmRef    = useRef(farm)
+  const cityRef    = useRef(city)
   const walkersRef = useRef(walkers)
   const worldRef   = useRef<HTMLDivElement>(null)
   const worldDims  = useRef({ w: FARM_COLS * CELL_PX, h: FARM_ROWS * CELL_PX })
@@ -169,6 +170,7 @@ export function FarmingSim({ city, onSaveCity, onBack }: Props) {
   }
 
   useEffect(() => { farmRef.current = farm }, [farm])
+  useEffect(() => { cityRef.current = city }, [city])
   useEffect(() => { walkersRef.current = walkers }, [walkers])
 
   // Ship any resources produced during the offline catch-up tick to the city
@@ -234,11 +236,11 @@ export function FarmingSim({ city, onSaveCity, onBack }: Props) {
 
       const hasResources = Object.values(resourcesForCity).some(v => (v ?? 0) > 0)
       if (hasResources) {
-        const newCityRes = { ...city.resources }
+        const newCityRes = { ...cityRef.current.resources }
         for (const [res, amt] of Object.entries(resourcesForCity) as [ResourceType, number][]) {
           newCityRes[res] = Math.round((newCityRes[res] ?? 0) + amt)
         }
-        onSaveCity({ ...city, resources: newCityRes })
+        onSaveCity({ ...cityRef.current, resources: newCityRes })
       }
     }, 10_000)
     return () => clearInterval(id)

--- a/web/src/game/farmingSim.ts
+++ b/web/src/game/farmingSim.ts
@@ -143,8 +143,8 @@ export function buildFarmCity(farm: FarmState): CityState {
     const stock: Partial<Record<ResourceType, number>> = {}
     for (const [res, rate] of Object.entries(produces) as [ResourceType, number][]) {
       if ((rate ?? 0) > 0) {
-        const farmAmt = farm.resources[res] ?? 0
-        if (farmAmt >= 0.01) stock[res] = farmAmt
+        // Always show icon for producing buildings — buffer frequently resets to 0 after shipping
+        stock[res] = Math.max(farm.resources[res] ?? 0, 0.1)
       }
     }
     for (const [res, rate] of Object.entries(consumes) as [ResourceType, number][]) {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Wheat icon missing in Farm cells** — `buildFarmCity` only showed a resource icon when `farm.resources[res] >= 0.01`. Since the farm buffer ships to the city whenever it hits 5 and immediately resets to 0, wheat was almost always below the threshold. Fixed by always setting `stock[res] = Math.max(buffer, 0.1)` for producing buildings, so the icon is visible regardless of whether the buffer just shipped.

- **Wheat value flipping in resource bar** — the 10s farm tick `useEffect` captured `city` in a stale closure (empty deps array). Every time farm shipped wheat, it called `onSaveCity({ ...city_at_mount, ... })`, overwriting any city-state changes that occurred since the farm screen opened. Fixed by adding `cityRef` (kept in sync via a separate `useEffect`) and reading `cityRef.current` inside the interval.

## Test plan

- [ ] Place a Farm on the farm grid — wheat icon should always be visible on the Farm cell, not flicker in and out
- [ ] Open the farm screen, wait for a few 10s ticks — wheat value in the resource bar should only go up, never jump back to an old value
- [ ] Windmill animation behaviour unchanged (still animates based on actual wheat in pool)

https://claude.ai/code/session_011crFfA2JRe2ouRm8LfXSUA
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_011crFfA2JRe2ouRm8LfXSUA)_