### PR TITLE
fix(farm): unify city+farm tick so farm resources persist in city

### DIFF
--- a/web/src/components/minigames/CityBuilder.tsx
+++ b/web/src/components/minigames/CityBuilder.tsx
@@ -64,7 +64,8 @@ import { OverlayScreen } from '../ui/OverlayScreen'
 import { Toolbar, ToolbarButton, ToolbarDropdown } from '../ui/Toolbar'
 import { ModalBackdrop } from '../ui/ModalBackdrop'
 import { FarmingSim } from './FarmingSim'
-import { isFarmUnlocked, loadFarmState, saveFarmState, tickFarm, getFarmProductionRate } from '../../game/farmingSim'
+import { isFarmUnlocked, loadFarmState, saveFarmState, getFarmProductionRate } from '../../game/farmingSim'
+import { tickAll } from '../../game/tick'
 
 
 // ── Resident thought lines ────────────────────────────────────────────────────
@@ -1141,22 +1142,16 @@ export function CityBuilder({ onBack }: Props) {
     const id = setInterval(() => {
       if (bulldozerRef.current) return
       setCity(prev => {
-        let next = tickCity(prev)
-
-        // Tick the farm and apply its output to city resources when farm screen
-        // is not open (FarmingSim handles its own tick when the farm is visible).
-        if (screenRef.current !== 'farming' && isFarmUnlocked(cityPopulation(next))) {
-          const farmState = loadFarmState()
-          const { nextState: nextFarm, resourcesForCity } = tickFarm(farmState)
+        // When farm is visible, FarmingSim owns the unified tick (tickAll).
+        // When farm is not visible, run tickAll here so farm resources are
+        // distributed into city cell stocks before aggregation (not lost).
+        let next: CityState
+        if (screenRef.current !== 'farming' && isFarmUnlocked(cityPopulation(prev))) {
+          const { nextCity, nextFarm } = tickAll(prev, loadFarmState())
           saveFarmState(nextFarm)
-          const hasResources = Object.values(resourcesForCity).some(v => (v ?? 0) > 0)
-          if (hasResources) {
-            const newRes = { ...next.resources }
-            for (const [res, amt] of Object.entries(resourcesForCity) as [ResourceType, number][]) {
-              newRes[res] = Math.round((newRes[res] ?? 0) + amt)
-            }
-            next = { ...next, resources: newRes }
-          }
+          next = nextCity
+        } else {
+          next = tickCity(prev)
         }
 
         saveCityState(next)

--- a/web/src/components/minigames/FarmingSim.tsx
+++ b/web/src/components/minigames/FarmingSim.tsx
@@ -3,6 +3,7 @@
 // but all walkers are farmers sourced from city population.
 
 import React, { useState, useEffect, useRef } from 'react'
+import { tickAll } from '../../game/tick'
 import {
   FarmState, FarmRaidEvent,
   loadFarmState, saveFarmState, tickFarm,
@@ -22,6 +23,7 @@ import {
   resourceConsumptionRate,
   GOLD_SYMBOL,
   currentSeason,
+  distributeIncomingResources,
 } from '../../game/cityBuilder'
 import { ModalBackdrop } from '../ui/ModalBackdrop'
 import { getCardCatalog } from '../../game/cards'
@@ -186,11 +188,7 @@ export function FarmingSim({ city, onSaveCity, onBack }: Props) {
     const rfc = initCatchUpRef.current
     if (!rfc || !Object.values(rfc).some(v => (v ?? 0) > 0)) return
     initCatchUpRef.current = {}
-    const newCityRes = { ...city.resources }
-    for (const [res, amt] of Object.entries(rfc) as [ResourceType, number][]) {
-      newCityRes[res] = Math.round((newCityRes[res] ?? 0) + amt)
-    }
-    onSaveCity({ ...city, resources: newCityRes })
+    onSaveCity(distributeIncomingResources(city, rfc))
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
@@ -235,21 +233,13 @@ export function FarmingSim({ city, onSaveCity, onBack }: Props) {
     return () => clearInterval(id)
   }, [])
 
-  // Farm tick every 10 s
+  // Farm + city unified tick every 10 s
   useEffect(() => {
     const id = setInterval(() => {
-      const { nextState, resourcesForCity } = tickFarm(farmRef.current)
-      saveFarmState(nextState)
-      setFarm(nextState)
-
-      const hasResources = Object.values(resourcesForCity).some(v => (v ?? 0) > 0)
-      if (hasResources) {
-        const newCityRes = { ...cityRef.current.resources }
-        for (const [res, amt] of Object.entries(resourcesForCity) as [ResourceType, number][]) {
-          newCityRes[res] = Math.round((newCityRes[res] ?? 0) + amt)
-        }
-        onSaveCity({ ...cityRef.current, resources: newCityRes })
-      }
+      const { nextCity, nextFarm } = tickAll(cityRef.current, farmRef.current)
+      saveFarmState(nextFarm)
+      setFarm(nextFarm)
+      onSaveCity(nextCity)
     }, 10_000)
     return () => clearInterval(id)
   // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/web/src/game/cityBuilder.ts
+++ b/web/src/game/cityBuilder.ts
@@ -503,6 +503,26 @@ function aggregateResources(
   return r
 }
 
+/** Deposits incoming resources (e.g. from farm shipments) into city cell stocks
+ *  so they survive the next aggregateResources() recomputation inside tickCity.
+ *  Prefers warehouse cells; falls back to any non-spawner cell. */
+export function distributeIncomingResources(
+  city: CityState,
+  incoming: Partial<ResourceStock>,
+): CityState {
+  if (!Object.values(incoming).some(v => (v ?? 0) > 0)) return city
+  const newGrid = city.grid.map(c => c ? { ...c, stock: { ...c.stock } } : c) as CityState['grid']
+  for (const [res, amt] of Object.entries(incoming) as [ResourceType, number][]) {
+    if (!(amt > 0)) continue
+    const warehouses = newGrid.filter((c): c is CityCell => Boolean(c && !c.spawnedUnitName && WAREHOUSE_PATTERN.test(c.cardName)))
+    const cells = warehouses.length > 0 ? warehouses : (newGrid.filter((c): c is CityCell => Boolean(c && !c.spawnedUnitName)))
+    if (cells.length === 0) continue
+    const each = amt / cells.length
+    for (const c of cells) c.stock[res as ResourceType] = (c.stock[res as ResourceType] ?? 0) + each
+  }
+  return { ...city, grid: newGrid }
+}
+
 export function calculateStorageCaps(state: CityState): ResourceStock {
   let bonus = 0
   for (const cell of state.grid) {

--- a/web/src/game/tick.ts
+++ b/web/src/game/tick.ts
@@ -1,0 +1,29 @@
+// ─── Unified Tick ────────────────────────────────────────────────────────────
+// Single entry-point that advances both city and farm together so resource
+// computation is identical regardless of which screen is currently visible.
+//
+// Import order matters: farmingSim imports from cityBuilder, so tickAll lives
+// here to avoid a circular dependency between the two modules.
+
+import { CityState, tickCity, distributeIncomingResources } from './cityBuilder'
+import { FarmState, tickFarm } from './farmingSim'
+
+/**
+ * Advances both city and farm to nowMs in a single pass.
+ *
+ * Order:
+ *  1. tickFarm  — produces resources and accumulates in farm pool
+ *  2. distributeIncomingResources — deposits shipped resources into city cell
+ *     stocks so they survive the next aggregateResources() recomputation
+ *  3. tickCity  — aggregates stocks, runs consumption, carriers, happiness
+ */
+export function tickAll(
+  city: CityState,
+  farm: FarmState,
+  nowMs = Date.now(),
+): { nextCity: CityState; nextFarm: FarmState } {
+  const { nextState: nextFarm, resourcesForCity } = tickFarm(farm, nowMs)
+  const cityWithFarm = distributeIncomingResources(city, resourcesForCity)
+  const nextCity = tickCity(cityWithFarm, nowMs)
+  return { nextCity, nextFarm }
+}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Root cause fixed:** `tickCity()` recomputes `city.resources` via `aggregateResources()` from cell stocks on every tick. Farm-shipped resources were being added only to the aggregate (not to any cell stock), so they were silently discarded on the very next tick — making a full 4×4 farm grid have no lasting effect on city totals.
- **`distributeIncomingResources(city, incoming)`** added to `cityBuilder.ts`: deposits farm-shipped resources into warehouse cell stocks first (falling back to any non-spawner cell), so they survive the next `aggregateResources()` call inside `tickCity`.
- **`tickAll(city, farm)`** added in new `tick.ts`: runs `tickFarm → distributeIncomingResources → tickCity` in a single pass — same code path regardless of which screen is visible.
- **FarmingSim** 10 s tick and mount catch-up both now use `tickAll` / `distributeIncomingResources` instead of directly mutating the aggregate.
- **CityBuilder** 10 s tick uses `tickAll` when the farm screen is not visible.

## Test plan

- [ ] Place several Farm / Quarry / Lumber buildings on the 4×4 farm grid; confirm city resource totals (wheat, ore, wood) increase each 10 s cycle.
- [ ] Switch between farm and city screens; resource growth rate should be identical regardless of which is active.
- [ ] Offline catch-up: close the tab for a few minutes, reopen — farm resources should appear in city stocks.
- [ ] Raids still work and stolen resources are correctly reflected.
- [ ] `cd web && npm run build` passes clean (TypeScript + Vite).

https://claude.ai/code/session_01E1zKpS7dddS5eQtuNani5E
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01E1zKpS7dddS5eQtuNani5E)_