### PR TITLE
fix(farm): show combined city+farm production rates in farm ResourceStrip

### DIFF
--- a/web/src/components/minigames/FarmingSim.tsx
+++ b/web/src/components/minigames/FarmingSim.tsx
@@ -20,7 +20,7 @@ import {
   CityState, ResourceType, CELL_PX,
   cityPopulation, getBuildingProduces, getBuildingConsumes,
   levelUpCost,
-  resourceConsumptionRate,
+  resourceConsumptionRate, resourceProductionRate,
   GOLD_SYMBOL,
   currentSeason,
   distributeIncomingResources,
@@ -501,7 +501,11 @@ export function FarmingSim({ city, onSaveCity, onBack }: Props) {
     return (getOwnedCount(collection, c.name) - (placedOnFarm[c.name] ?? 0)) > 0
   })
 
-  const prodRates   = getFarmProductionRate(farm)
+  const cityProdRates = resourceProductionRate(city)
+  const prodRates: Partial<Record<ResourceType, number>> = { ...cityProdRates }
+  for (const [res, rate] of Object.entries(getFarmProductionRate(farm)) as [ResourceType, number][]) {
+    prodRates[res as ResourceType] = (prodRates[res as ResourceType] ?? 0) + rate
+  }
   const consRates = resourceConsumptionRate(city)
   const defense     = farmDefense(farm)
   const nextRaidMs  = Math.max(0, farm.nextRaidAt - currentTime)


### PR DESCRIPTION
## Summary

- The farm view's `ResourceStrip` was passing only `getFarmProductionRate(farm)` as `prodRates`, so city buildings were excluded from the rate display.
- The city view already combined `resourceProductionRate(city) + getFarmProductionRate(farm)`.
- Now both views use the same combined formula, so the production rates shown are identical regardless of which screen is open.

## Test plan

- [ ] Note wheat/wood/ore production rates in the city view ResourceStrip.
- [ ] Open the farm view — rates should match exactly.
- [ ] `cd web && npm run build` passes clean.

https://claude.ai/code/session_01E1zKpS7dddS5eQtuNani5E

---
_Generated by [Claude Code](https://claude.ai/code/session_01E1zKpS7dddS5eQtuNani5E)_