### PR TITLE
feat(farm): placement gold costs + exclusive farm buildings

### DIFF
--- a/web/public/sprites/forest.svg
+++ b/web/public/sprites/forest.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- back tree trunk -->
+  <rect x="14" y="22" width="4" height="7" rx="1" fill="#5D4037"/>
+  <!-- left tree trunk -->
+  <rect x="4"  y="23" width="3" height="6" rx="1" fill="#6D4C41"/>
+  <!-- right tree trunk -->
+  <rect x="25" y="23" width="3" height="6" rx="1" fill="#6D4C41"/>
+  <!-- back (centre) tall tree -->
+  <polygon points="16,2 23,14 9,14" fill="#2E7D32"/>
+  <polygon points="16,6 22,17 10,17" fill="#388E3C"/>
+  <!-- left tree -->
+  <polygon points="5.5,8 11,18 0,18"  fill="#1B5E20"/>
+  <polygon points="5.5,12 10,20 1,20" fill="#2E7D32"/>
+  <!-- right tree -->
+  <polygon points="26.5,8 32,18 21,18"  fill="#1B5E20"/>
+  <polygon points="26.5,12 31,20 22,20" fill="#2E7D32"/>
+  <!-- ground -->
+  <rect x="2" y="28" width="28" height="3" rx="1" fill="#4E342E"/>
+</svg>

--- a/web/public/sprites/orchard.svg
+++ b/web/public/sprites/orchard.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- left tree trunk -->
+  <rect x="7" y="20" width="3" height="6" rx="1" fill="#7B4F2E"/>
+  <!-- right tree trunk -->
+  <rect x="22" y="20" width="3" height="6" rx="1" fill="#7B4F2E"/>
+  <!-- left tree canopy -->
+  <circle cx="8.5" cy="16" r="7" fill="#4CAF50"/>
+  <circle cx="8.5" cy="16" r="7" fill="#388E3C" opacity="0.4"/>
+  <!-- right tree canopy -->
+  <circle cx="23.5" cy="16" r="7" fill="#4CAF50"/>
+  <circle cx="23.5" cy="16" r="7" fill="#388E3C" opacity="0.4"/>
+  <!-- fruit left tree -->
+  <circle cx="6"  cy="14" r="2" fill="#F44336"/>
+  <circle cx="11" cy="13" r="2" fill="#FF9800"/>
+  <circle cx="8"  cy="19" r="2" fill="#F44336"/>
+  <!-- fruit right tree -->
+  <circle cx="21" cy="14" r="2" fill="#FF9800"/>
+  <circle cx="26" cy="13" r="2" fill="#F44336"/>
+  <circle cx="23" cy="19" r="2" fill="#FF9800"/>
+  <!-- ground -->
+  <rect x="2" y="26" width="28" height="3" rx="1" fill="#8B6340"/>
+</svg>

--- a/web/public/sprites/plantation.svg
+++ b/web/public/sprites/plantation.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- soil rows -->
+  <rect x="2" y="24" width="28" height="3" rx="1" fill="#8B6340"/>
+  <rect x="2" y="20" width="28" height="2" rx="1" fill="#7A5530" opacity="0.6"/>
+  <!-- tall stalks -->
+  <line x1="5"  y1="23" x2="5"  y2="9"  stroke="#558B2F" stroke-width="2"/>
+  <line x1="10" y1="23" x2="10" y2="7"  stroke="#558B2F" stroke-width="2"/>
+  <line x1="16" y1="23" x2="16" y2="8"  stroke="#558B2F" stroke-width="2"/>
+  <line x1="22" y1="23" x2="22" y2="7"  stroke="#558B2F" stroke-width="2"/>
+  <line x1="27" y1="23" x2="27" y2="9"  stroke="#558B2F" stroke-width="2"/>
+  <!-- large wheat heads -->
+  <ellipse cx="5"  cy="7"  rx="2.5" ry="3.5" fill="#F9A825"/>
+  <ellipse cx="10" cy="5"  rx="2.5" ry="3.5" fill="#F9A825"/>
+  <ellipse cx="16" cy="6"  rx="2.5" ry="3.5" fill="#F9A825"/>
+  <ellipse cx="22" cy="5"  rx="2.5" ry="3.5" fill="#F9A825"/>
+  <ellipse cx="27" cy="7"  rx="2.5" ry="3.5" fill="#F9A825"/>
+  <!-- leaves -->
+  <ellipse cx="8"  cy="14" rx="4" ry="1.5" fill="#7CB342" transform="rotate(-30 8 14)"/>
+  <ellipse cx="14" cy="13" rx="4" ry="1.5" fill="#7CB342" transform="rotate(30 14 13)"/>
+  <ellipse cx="19" cy="14" rx="4" ry="1.5" fill="#7CB342" transform="rotate(-30 19 14)"/>
+  <ellipse cx="25" cy="13" rx="4" ry="1.5" fill="#7CB342" transform="rotate(30 25 13)"/>
+</svg>

--- a/web/public/sprites/wheat-field.svg
+++ b/web/public/sprites/wheat-field.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- soil rows -->
+  <rect x="2" y="22" width="28" height="4" rx="1" fill="#8B6340"/>
+  <!-- stalks -->
+  <line x1="7"  y1="21" x2="7"  y2="12" stroke="#8BC34A" stroke-width="1.5"/>
+  <line x1="12" y1="21" x2="12" y2="10" stroke="#8BC34A" stroke-width="1.5"/>
+  <line x1="17" y1="21" x2="17" y2="12" stroke="#8BC34A" stroke-width="1.5"/>
+  <line x1="22" y1="21" x2="22" y2="10" stroke="#8BC34A" stroke-width="1.5"/>
+  <line x1="27" y1="21" x2="27" y2="12" stroke="#8BC34A" stroke-width="1.5"/>
+  <!-- wheat heads -->
+  <ellipse cx="7"  cy="10" rx="2" ry="3" fill="#F5C842"/>
+  <ellipse cx="12" cy="8"  rx="2" ry="3" fill="#F5C842"/>
+  <ellipse cx="17" cy="10" rx="2" ry="3" fill="#F5C842"/>
+  <ellipse cx="22" cy="8"  rx="2" ry="3" fill="#F5C842"/>
+  <ellipse cx="27" cy="10" rx="2" ry="3" fill="#F5C842"/>
+  <!-- awns -->
+  <line x1="7"  y1="7"  x2="6"  y2="5"  stroke="#D4A820" stroke-width="1"/>
+  <line x1="12" y1="5"  x2="11" y2="3"  stroke="#D4A820" stroke-width="1"/>
+  <line x1="17" y1="7"  x2="16" y2="5"  stroke="#D4A820" stroke-width="1"/>
+  <line x1="22" y1="5"  x2="21" y2="3"  stroke="#D4A820" stroke-width="1"/>
+  <line x1="27" y1="7"  x2="26" y2="5"  stroke="#D4A820" stroke-width="1"/>
+</svg>

--- a/web/src/components/minigames/FarmingSim.tsx
+++ b/web/src/components/minigames/FarmingSim.tsx
@@ -20,7 +20,7 @@ import {
   CityState, ResourceType, CELL_PX,
   cityPopulation, getBuildingProduces, getBuildingConsumes,
   levelUpCost,
-  resourceConsumptionRate,
+  resourceConsumptionRate, resourceProductionRate,
   GOLD_SYMBOL,
   currentSeason,
   distributeIncomingResources,
@@ -501,7 +501,11 @@ export function FarmingSim({ city, onSaveCity, onBack }: Props) {
     return (getOwnedCount(collection, c.name) - (placedOnFarm[c.name] ?? 0)) > 0
   })
 
-  const prodRates   = getFarmProductionRate(farm)
+  const cityProdRates = resourceProductionRate(city)
+  const prodRates: Partial<Record<ResourceType, number>> = { ...cityProdRates }
+  for (const [res, rate] of Object.entries(getFarmProductionRate(farm)) as [ResourceType, number][]) {
+    prodRates[res as ResourceType] = (prodRates[res as ResourceType] ?? 0) + rate
+  }
   const consRates = resourceConsumptionRate(city)
   const defense     = farmDefense(farm)
   const nextRaidMs  = Math.max(0, farm.nextRaidAt - currentTime)

--- a/web/src/components/minigames/FarmingSim.tsx
+++ b/web/src/components/minigames/FarmingSim.tsx
@@ -15,6 +15,7 @@ import {
   canAffordFarmExpansion, expandFarm,
   buildFarmCity, getFarmNeighbourIndices,
   FARM_COLS, FARM_ROWS, MAX_FARM_SIZE, FARM_EXPANSION_COSTS,
+  FARM_PLACE_COST, CoreFarmBuilding, CORE_FARM_BUILDINGS,
 } from '../../game/farmingSim'
 import {
   CityState, ResourceType, CELL_PX,
@@ -516,6 +517,8 @@ export function FarmingSim({ city, onSaveCity, onBack }: Props) {
     return (
       <FarmBuildingPicker
         availableCards={availableForFarm}
+        coreFarmBuildings={CORE_FARM_BUILDINGS}
+        gold={city.gold}
         onPick={(card: Card) => {
           const isSpawner = card.unit?.structureEffect?.type === 'spawn'
           if (!canPlaceOnFarm(card.name, isSpawner ?? false)) {
@@ -523,7 +526,22 @@ export function FarmingSim({ city, onSaveCity, onBack }: Props) {
             setScreen('farm')
             return
           }
+          const cost = FARM_PLACE_COST[card.rarity] ?? 200
+          if (cityRef.current.gold < cost) {
+            showToast(`Need ${GOLD_SYMBOL} ${cost.toLocaleString()} to establish this building on the farm.`)
+            return
+          }
+          onSaveCity({ ...cityRef.current, gold: cityRef.current.gold - cost })
           saveFarm(placeFarmBuilding(farm, pickerIndex, { cardName: card.name, rarity: card.rarity, stock: {} }))
+          setScreen('farm')
+        }}
+        onPickCore={(building: CoreFarmBuilding) => {
+          if (cityRef.current.gold < building.goldCost) {
+            showToast(`Need ${GOLD_SYMBOL} ${building.goldCost.toLocaleString()} to build ${building.name}.`)
+            return
+          }
+          onSaveCity({ ...cityRef.current, gold: cityRef.current.gold - building.goldCost })
+          saveFarm(placeFarmBuilding(farm, pickerIndex, { cardName: building.name, rarity: building.rarity, stock: {} }))
           setScreen('farm')
         }}
         onBack={() => setScreen('farm')}

--- a/web/src/components/minigames/citybuilder/farming/FarmBuildingPicker.stories.tsx
+++ b/web/src/components/minigames/citybuilder/farming/FarmBuildingPicker.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { FarmBuildingPicker } from './FarmBuildingPicker'
 import type { Card } from '../../../../game/types'
+import { CORE_FARM_BUILDINGS } from '../../../../game/farmingSim'
 
 const sampleCards: Card[] = [
   { id: 'farm-1', name: 'Farm', rarity: 'common', cost: 2, cardType: 'structure', description: 'Produces wheat' },
@@ -20,16 +21,33 @@ type Story = StoryObj<typeof FarmBuildingPicker>
 
 export const Default: Story = {
   args: {
-    availableCards: sampleCards,
-    onPick: (c) => console.log('picked', c.name),
-    onBack: () => {},
+    availableCards:    sampleCards,
+    coreFarmBuildings: CORE_FARM_BUILDINGS,
+    gold:              1000,
+    onPick:            (c) => console.log('picked', c.name),
+    onPickCore:        (b) => console.log('picked core', b.name),
+    onBack:            () => {},
+  },
+}
+
+export const Broke: Story = {
+  args: {
+    availableCards:    sampleCards,
+    coreFarmBuildings: CORE_FARM_BUILDINGS,
+    gold:              0,
+    onPick:            () => {},
+    onPickCore:        () => {},
+    onBack:            () => {},
   },
 }
 
 export const Empty: Story = {
   args: {
-    availableCards: [],
-    onPick: () => {},
-    onBack: () => {},
+    availableCards:    [],
+    coreFarmBuildings: [],
+    gold:              500,
+    onPick:            () => {},
+    onPickCore:        () => {},
+    onBack:            () => {},
   },
 }

--- a/web/src/components/minigames/citybuilder/farming/FarmBuildingPicker.tsx
+++ b/web/src/components/minigames/citybuilder/farming/FarmBuildingPicker.tsx
@@ -1,21 +1,49 @@
 import React, { useState } from 'react'
 import { Card } from '../../../../game/types'
-import { getBuildingProduces, RESOURCE_ICONS, ResourceType } from '../../../../game/cityBuilder'
+import { getBuildingProduces, RESOURCE_ICONS, ResourceType, GOLD_SYMBOL } from '../../../../game/cityBuilder'
+import { CoreFarmBuilding, FARM_PLACE_COST } from '../../../../game/farmingSim'
 import { SpriteImg } from '../../../ui/SpriteImg'
 
 export interface Props {
-  availableCards: Card[]
-  onPick:         (card: Card) => void
-  onBack:         () => void
+  availableCards:    Card[]
+  coreFarmBuildings: CoreFarmBuilding[]
+  gold:              number
+  onPick:            (card: Card) => void
+  onPickCore:        (b: CoreFarmBuilding) => void
+  onBack:            () => void
 }
 
-export function FarmBuildingPicker({ availableCards, onPick, onBack }: Props) {
+function ProdLine({ name, gold, canAfford }: { name: string; gold: number; canAfford: boolean }) {
+  const produces   = getBuildingProduces(name)
+  const prodEntries = (Object.entries(produces).filter(([, v]) => (v as number) > 0)) as [ResourceType, number][]
+  return (
+    <>
+      {prodEntries.length > 0 && (
+        <div className="city-picker-produces">
+          {prodEntries.map(([res, rate]) =>
+            `+${(rate * 1.5).toFixed(1)} ${RESOURCE_ICONS[res]}/min`
+          ).join(' ')}
+        </div>
+      )}
+      <div className={`city-picker-cost${canAfford ? '' : ' city-picker-cost--cant'}`}>
+        {GOLD_SYMBOL} {gold.toLocaleString()}
+      </div>
+    </>
+  )
+}
+
+export function FarmBuildingPicker({ availableCards, coreFarmBuildings, gold, onPick, onPickCore, onBack }: Props) {
   const [search, setSearch] = useState('')
 
   const q = search.toLowerCase()
-  const filtered = q
+  const filteredCards = q
     ? availableCards.filter(c => c.name.toLowerCase().includes(q))
     : availableCards
+  const filteredCore = q
+    ? coreFarmBuildings.filter(b => b.name.toLowerCase().includes(q))
+    : coreFarmBuildings
+
+  const hasResults = filteredCards.length > 0 || filteredCore.length > 0
 
   return (
     <div className="city-screen u-relative u-col u-gap-2">
@@ -32,42 +60,69 @@ export function FarmBuildingPicker({ availableCards, onPick, onBack }: Props) {
           onChange={e => setSearch(e.target.value)}
         />
 
-        {availableCards.length === 0 ? (
-          <div className="city-picker-empty">No production buildings available to place on the farm.</div>
-        ) : filtered.length === 0 ? (
-          <div className="city-picker-empty">No buildings match "{search}"</div>
+        {!hasResults ? (
+          q
+            ? <div className="city-picker-empty">No buildings match "{search}"</div>
+            : <div className="city-picker-empty">No production buildings available to place on the farm.</div>
         ) : (
-          <div className="city-picker-section">
-            <div className="city-picker-section-label">
-              PRODUCERS
-              <span className="city-picker-section-sub"> · +50% output on the farm · raids every 3–4 hrs</span>
-            </div>
-            <div className="city-picker-grid">
-              {filtered.map(card => {
-                const produces = getBuildingProduces(card.name)
-                const prodEntries = (Object.entries(produces).filter(([, v]) => (v as number) > 0)) as [ResourceType, number][]
-                return (
-                  <button
-                    key={card.name}
-                    className="city-picker-card u-col u-items-c u-gap-2 u-pointer"
-                    onClick={() => onPick(card)}
-                    title={`Place ${card.name} on the farm`}
-                  >
-                    <SpriteImg name={card.name} className="city-picker-sprite" />
-                    <div className="city-picker-name">{card.name}</div>
-                    <div className={`city-picker-rarity city-picker-rarity--${card.rarity}`}>{card.rarity}</div>
-                    {prodEntries.length > 0 && (
-                      <div className="city-picker-produces">
-                        {prodEntries.map(([res, rate]) =>
-                          `+${(rate * 1.5).toFixed(1)} ${RESOURCE_ICONS[res]}/min`
-                        ).join(' ')}
-                      </div>
-                    )}
-                  </button>
-                )
-              })}
-            </div>
-          </div>
+          <>
+            {filteredCore.length > 0 && (
+              <div className="city-picker-section">
+                <div className="city-picker-section-label">
+                  FARM EXCLUSIVE
+                  <span className="city-picker-section-sub"> · always available · +50% output on the farm</span>
+                </div>
+                <div className="city-picker-grid">
+                  {filteredCore.map(b => {
+                    const canAfford = gold >= b.goldCost
+                    return (
+                      <button
+                        key={b.name}
+                        className={`city-picker-card u-col u-items-c u-gap-2 u-pointer${canAfford ? '' : ' city-picker-card--disabled'}`}
+                        onClick={() => canAfford && onPickCore(b)}
+                        title={b.hint}
+                        disabled={!canAfford}
+                      >
+                        <SpriteImg name={b.name} className="city-picker-sprite" />
+                        <div className="city-picker-name">{b.name}</div>
+                        <div className={`city-picker-rarity city-picker-rarity--${b.rarity}`}>{b.rarity}</div>
+                        <ProdLine name={b.name} gold={b.goldCost} canAfford={canAfford} />
+                      </button>
+                    )
+                  })}
+                </div>
+              </div>
+            )}
+
+            {filteredCards.length > 0 && (
+              <div className="city-picker-section">
+                <div className="city-picker-section-label">
+                  PRODUCERS
+                  <span className="city-picker-section-sub"> · from your collection · +50% output on the farm · raids every 3–4 hrs</span>
+                </div>
+                <div className="city-picker-grid">
+                  {filteredCards.map(card => {
+                    const cost      = FARM_PLACE_COST[card.rarity] ?? 200
+                    const canAfford = gold >= cost
+                    return (
+                      <button
+                        key={card.name}
+                        className={`city-picker-card u-col u-items-c u-gap-2 u-pointer${canAfford ? '' : ' city-picker-card--disabled'}`}
+                        onClick={() => canAfford && onPick(card)}
+                        title={`Place ${card.name} on the farm`}
+                        disabled={!canAfford}
+                      >
+                        <SpriteImg name={card.name} className="city-picker-sprite" />
+                        <div className="city-picker-name">{card.name}</div>
+                        <div className={`city-picker-rarity city-picker-rarity--${card.rarity}`}>{card.rarity}</div>
+                        <ProdLine name={card.name} gold={cost} canAfford={canAfford} />
+                      </button>
+                    )
+                  })}
+                </div>
+              </div>
+            )}
+          </>
         )}
       </div>
     </div>

--- a/web/src/game/cityBuilder.ts
+++ b/web/src/game/cityBuilder.ts
@@ -597,6 +597,11 @@ export function currentSeason(now = Date.now()): Season {
  * Buildings not listed here fall back to keyword matching in getBuildingResourceConfig.
  */
 const BUILDING_RESOURCE_CONFIG: Record<string, Partial<ResourceStock>> = {
+  // ── Core farm buildings (farm-exclusive, always available) ──
+  'Wheat Field': { wheat: 3 },
+  'Orchard':     { wheat: 2, bread: 1 },
+  'Plantation':  { wheat: 5 },
+  'Forest':      { wood: 4 },
   // ── Core buildings (always available, built with gold) ──
   'Windmill':    { bread: 2 },
   'Bakery':      { bread: 1.5 },

--- a/web/src/game/farmingSim.ts
+++ b/web/src/game/farmingSim.ts
@@ -62,6 +62,35 @@ const CHRONICLE_MAX = 30
 
 const STORAGE_KEY = 'jarv_farming_sim'
 
+/** Gold cost to place an owned collection building on the farm (scales by rarity). */
+export const FARM_PLACE_COST: Record<CardRarity, number> = {
+  common:    200,
+  uncommon:  500,
+  rare:     1000,
+  epic:     2000,
+  legendary:5000,
+  mythic:  10000,
+  shiny:    1000,
+  holofoil: 1500,
+  glass:    2000,
+}
+
+/** A farm-exclusive building that is always available to place (no card required). */
+export interface CoreFarmBuilding {
+  name:     string
+  goldCost: number
+  rarity:   CardRarity
+  hint:     string
+}
+
+/** Farm-only buildings available to all players regardless of card collection. */
+export const CORE_FARM_BUILDINGS: CoreFarmBuilding[] = [
+  { name: 'Wheat Field', goldCost:  250, rarity: 'common',   hint: 'Planted crop rows producing 3 wheat/min. The backbone of any farm.' },
+  { name: 'Orchard',     goldCost:  600, rarity: 'uncommon', hint: 'Fruit trees yielding 2 wheat/min and 1 bread/min.' },
+  { name: 'Plantation',  goldCost: 1500, rarity: 'rare',     hint: 'Industrial-scale crops producing 5 wheat/min.' },
+  { name: 'Forest',      goldCost:  350, rarity: 'common',   hint: 'Managed woodland producing 4 wood/min.' },
+]
+
 // ── Road wear constants (mirror city values) ─────────────────────────────────
 const ROAD_DECAY_PER_MIN    = 0.3   // wear lost per minute on unused edges (same as city)
 const ROAD_WEAR_PER_CARRIER = 0.4   // wear per carrier route per minute (same as city)

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -10314,6 +10314,15 @@ html.light-mode .action-btn {
   letter-spacing: 0.5px;
 }
 
+.city-picker-cost--cant {
+  color: #c04040;
+}
+
+.city-picker-card--disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
 .city-picker-produces {
   font-size: 9px;
   color: #4a9a4a;


### PR DESCRIPTION
## Summary

- **Placement costs:** Placing any owned collection building on the farm now costs gold (scaled by rarity via `FARM_PLACE_COST`). The picker shows the cost on every card and greys out unaffordable options.
- **Farm-exclusive buildings:** Four always-available buildings (no card ownership needed) shown in a new FARM EXCLUSIVE section:
  - Wheat Field (common, 🪙250) → 3 wheat/min
  - Orchard (uncommon, 🪙600) → 2 wheat + 1 bread/min
  - Plantation (rare, 🪙1500) → 5 wheat/min
  - Forest (common, 🪙350) → 4 wood/min
- Four matching sprites committed individually.

## Test plan

- [ ] Open farm → tap empty cell → picker shows FARM EXCLUSIVE section above PRODUCERS.
- [ ] Place a Wheat Field — gold deducted by 250; field appears on farm grid and produces wheat.
- [ ] Attempt to place when broke — toast appears, no placement.
- [ ] Place an owned collection building — correct rarity-based gold deducted.
- [ ] City ResourceStrip shows production from new farm buildings.
- [ ] New buildings do NOT appear in city builder placement options.
- [ ] `cd web && npm run build` passes clean.

https://claude.ai/code/session_01E1zKpS7dddS5eQtuNani5E

---
_Generated by [Claude Code](https://claude.ai/code/session_01E1zKpS7dddS5eQtuNani5E)_