### PR TITLE
Uniform toolbar button widths and corrected overflow threshold

### DIFF
--- a/web/src/components/minigames/CityBuilder.tsx
+++ b/web/src/components/minigames/CityBuilder.tsx
@@ -1641,8 +1641,9 @@ export function CityBuilder({ onBack }: Props) {
 
   const overflowToolbarButtons = (
     <>
-      <ToolbarButton onClick={() => setScreen('stats')} title="View economy charts" label="STATS" icon="📊" />
+      <ToolbarButton size="wide" onClick={() => setScreen('stats')} title="View economy charts" label="STATS" icon="📊" />
       <ToolbarButton
+        size="wide"
         className={city.tradeOffer && !city.activeCaravan ? 'city-trade-btn--ready' : undefined}
         onClick={() => setShowTrade(true)}
         title="Trade resources via caravan"
@@ -1655,23 +1656,26 @@ export function CityBuilder({ onBack }: Props) {
   const cityToolbar = (
     <Toolbar>
       <ToolbarButton
+        size="wide"
         active={bulldozerMode}
         onClick={toggleBulldozer}
         title={bulldozerMode ? 'Demolish mode ON' : 'Demolish a building'}
         label={bulldozerMode ? 'DEMOLISH' : 'BUILD'}
         icon={bulldozerMode ? '🧱' : '👷'}
       />
-      <ToolbarButton onClick={() => setScreen('fortify')} title="Manage city walls" label="FORTS" icon="🛡" />
+      <ToolbarButton size="wide" onClick={() => setScreen('fortify')} title="Manage city walls" label="FORTS" icon="🛡" />
       <ToolbarButton
+        size="wide"
         title={isFarmUnlocked(population) ? "Manage arable land outside the city" : `Farm unlocks at population 10 (currently ${population})`}
         onClick={() => isFarmUnlocked(population) ? setScreen('farming') : setShowFarmLockModal(true)}
         label="FARM"
         locked={!isFarmUnlocked(population)}
         icon="🌾"
       />
-      <ToolbarButton onClick={() => setScreen('towerdefence')} title="Defend the city using your residents as towers" label="DEFEND" icon="⚔" />
+      <ToolbarButton size="wide" onClick={() => setScreen('towerdefence')} title="Defend the city using your residents as towers" label="DEFEND" icon="⚔" />
       {city.activeDisaster && (
         <ToolbarButton
+          size="wide"
           className="city-disaster-btn"
           onClick={() => setShowDisaster(true)}
           title={city.activeDisaster.type === 'fire' ? 'Fire is raging!' : 'Plague is spreading!'}

--- a/web/src/components/ui/Toolbar/ToolbarButton.tsx
+++ b/web/src/components/ui/Toolbar/ToolbarButton.tsx
@@ -10,17 +10,22 @@ export interface ToolbarButtonProps {
   icon?: ReactNode
   locked?: boolean
 
+  size?: 'auto' | 'narrow' | 'wide' | 'fit'
+
   title?: string
   className?: string
   style?: React.CSSProperties
 }
 
-export function ToolbarButton({ onClick, active, disabled, label, icon, locked, title, className, style }: ToolbarButtonProps) {
+export function ToolbarButton({ onClick, active, disabled, label, icon, locked, size, title, className, style }: ToolbarButtonProps) {
   const cls = [
     'filter-btn',
     active && 'filter-btn--active',
     disabled && 'filter-btn--disabled',
     locked && 'filter-btn--locked',
+    size === 'narrow' && 'filter-btn--narrow',
+    size === 'wide'   && 'filter-btn--wide',
+    size === 'fit'    && 'filter-btn--fit',
     className,
   ].filter(Boolean).join(' ');
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2149,6 +2149,10 @@ body {
   padding: 2px 6px;
 }
 
+.filter-btn--narrow { min-width: 40px; }
+.filter-btn--wide   { min-width: 64px; }
+.filter-btn--fit    { flex: 1; }
+
 .filter-btn--gold.filter-btn--active {
   border-color: var(--color-gold);
   color: var(--color-gold);
@@ -8897,7 +8901,7 @@ html.light-mode .action-btn {
 }
 .toolbar-overflow-inline  { display: contents; }
 .toolbar-overflow-dropdown { display: none; }
-@container toolbar (max-width: 500px) {
+@container toolbar (max-width: 460px) {
   .toolbar-overflow-inline  { display: none; }
   .toolbar-overflow-dropdown { display: contents; }
 }


### PR DESCRIPTION
## Summary

- `ToolbarButton` gains a `size` prop: `auto` (default, current behaviour) | `narrow` (min-width 40px) | `wide` (min-width 64px) | `fit` (flex: 1)
- All CityBuilder toolbar buttons set to `size="wide"` so every button matches the width of the longest label ("DEFEND")
- Overflow container query threshold lowered from 500px → 460px — STATS and TRADE now stay visible on the toolbar until the toolbar is genuinely too narrow to fit them

## Test plan

- [ ] All CityBuilder toolbar buttons (BUILD/FORTS/FARM/DEFEND/STATS/TRADE) are the same width
- [ ] On a wide screen: STATS and TRADE sit left-aligned on the toolbar
- [ ] Narrowing the window below ~500px viewport: STATS and TRADE move into the dropdown
- [ ] No visual regressions on other `ToolbarButton` usages (no `size` prop = unchanged)

https://claude.ai/code/session_01Ej1agWiSPY6k6v3oLpsPDM

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ej1agWiSPY6k6v3oLpsPDM)_