### PR TITLE
Add Codex (Grimoire system) — #1293

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -111,6 +111,7 @@ import { CampaignVictoryScreen } from './components/battle/CampaignVictoryScreen
 import { CampaignFailedScreen }  from './components/battle/CampaignFailedScreen'
 import { StatUpgradeScreen }     from './components/campaign/StatUpgradeScreen'
 import { PlayerStatsScreen }     from './components/screens/PlayerStatsScreen'
+import { CodexScreen }          from './components/screens/CodexScreen'
 import { DailyChallengeScreen } from './components/screens/DailyChallengeScreen'
 import { ConfirmModal }          from './components/modals/ConfirmModal'
 import { EndlessLeaderboardScreen } from './components/screens/EndlessLeaderboardScreen'
@@ -198,6 +199,7 @@ type Screen =
   | 'quickbattle'
   | 'statupgrade'
   | 'camp'
+  | 'codex'
 
 
 const STANCE_RULES_BY_NODE_TYPE: Partial<Record<string, StanceRules>> = {
@@ -2251,6 +2253,7 @@ export default function App() {
             onMiniGames={() => setScreen('minigames')}
             onCityBuilder={() => { setMiniGamesEntry('citybuilder'); setScreen('minigames') }}
             onPlayerStats={() => setScreen('playerstats')}
+            onCodex={() => setScreen('codex')}
             user={user}
             onSignOut={() => { import('firebase/auth').then(({ signOut }) => signOut(auth)) }}
             onSignIn={() => setShowTitleLoginModal(true)}
@@ -2548,6 +2551,10 @@ export default function App() {
 
       {screen === 'heroCards' && (
         <HeroCardsScreen onBack={() => setScreen('title')} />
+      )}
+
+      {screen === 'codex' && (
+        <CodexScreen onDone={() => setScreen('title')} />
       )}
 
       {screen === 'campaignvictory' && (

--- a/web/src/components/screens/CodexScreen.tsx
+++ b/web/src/components/screens/CodexScreen.tsx
@@ -1,0 +1,207 @@
+import React, { useState, useMemo } from 'react'
+import { OverlayScreen } from '../ui/OverlayScreen'
+import {
+  getCodexCards, getCodexRelics, getCodexWorld,
+  CodexCardEntry, CodexRelicEntry, CodexWorldEntry,
+} from '../../game/codex'
+
+type CodexTab = 'cards' | 'relics' | 'world'
+type CardTypeFilter = 'all' | 'unit' | 'structure' | 'upgrade'
+
+const RARITY_ORDER: Record<string, number> = {
+  common: 1, uncommon: 2, rare: 3, epic: 4,
+  legendary: 5, mythic: 6, shiny: 7, holofoil: 8, glass: 9,
+}
+
+const RARITY_COLORS: Record<string, string> = {
+  common:    '#55cc55',
+  uncommon:  '#4499ff',
+  rare:      '#bb66ff',
+  epic:      '#ff8844',
+  legendary: '#ffcc00',
+  mythic:    '#e040fb',
+  shiny:     '#ffe066',
+  holofoil:  '#40e0d0',
+  glass:     '#a0d8ef',
+}
+
+interface Props {
+  onDone: () => void
+}
+
+function CardLorePanel({ card }: { card: CodexCardEntry }) {
+  if (!card.unlocked) {
+    return (
+      <div className="codex-entry codex-entry--locked">
+        <div className="codex-entry-name">??? — {card.cardType}</div>
+        <div className="codex-entry-locked-hint">Discover this card to unlock its entry.</div>
+      </div>
+    )
+  }
+  return (
+    <div className="codex-entry">
+      <div className="codex-entry-header">
+        <span className="codex-entry-name" style={{ color: RARITY_COLORS[card.rarity] ?? '#aaffaa' }}>
+          {card.name}
+        </span>
+        <span className="codex-entry-tag">{card.rarity.toUpperCase()}</span>
+        <span className="codex-entry-tag">{card.cardType.toUpperCase()}</span>
+      </div>
+      <div className="codex-entry-desc">{card.description}</div>
+      {card.lore && <div className="codex-entry-lore">"{card.lore}"</div>}
+    </div>
+  )
+}
+
+function RelicLorePanel({ relic }: { relic: CodexRelicEntry }) {
+  if (!relic.unlocked) {
+    return (
+      <div className="codex-entry codex-entry--locked">
+        <div className="codex-entry-name">{relic.icon} ???</div>
+        <div className="codex-entry-locked-hint">Earn this relic to unlock its entry.</div>
+      </div>
+    )
+  }
+  return (
+    <div className="codex-entry">
+      <div className="codex-entry-header">
+        <span className="codex-entry-name">{relic.icon} {relic.name}</span>
+      </div>
+      <div className="codex-entry-desc">{relic.desc}</div>
+      {relic.lore && <div className="codex-entry-lore">"{relic.lore}"</div>}
+    </div>
+  )
+}
+
+function WorldLorePanel({ entry }: { entry: CodexWorldEntry }) {
+  if (!entry.unlocked) {
+    return (
+      <div className="codex-entry codex-entry--locked">
+        <div className="codex-entry-name">??? — {entry.title}</div>
+        <div className="codex-entry-locked-hint">Complete this act to unlock its entry.</div>
+      </div>
+    )
+  }
+  return (
+    <div className="codex-entry">
+      <div className="codex-entry-header">
+        <span className="codex-entry-name" style={{ color: '#aaffaa' }}>{entry.subtitle}</span>
+        <span className="codex-entry-tag">{entry.title}</span>
+      </div>
+      {entry.shardLore && <div className="codex-entry-lore">"{entry.shardLore}"</div>}
+      {entry.bossName !== '???' && (
+        <div className="codex-entry-boss">
+          <span className="codex-entry-boss-label">GUARDIAN</span>
+          <span className="codex-entry-boss-name">{entry.bossName}</span>
+          {entry.bossDescription && (
+            <span className="codex-entry-desc"> — {entry.bossDescription}</span>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export function CodexScreen({ onDone }: Props) {
+  const [tab, setTab] = useState<CodexTab>('cards')
+  const [typeFilter, setTypeFilter] = useState<CardTypeFilter>('all')
+  const [search, setSearch] = useState('')
+  const [showLocked, setShowLocked] = useState(true)
+
+  const cards  = useMemo(() => getCodexCards(),  [])
+  const relics = useMemo(() => getCodexRelics(), [])
+  const world  = useMemo(() => getCodexWorld(),  [])
+
+  const filteredCards = useMemo<CodexCardEntry[]>(() => {
+    let list = cards
+    if (typeFilter !== 'all') list = list.filter(c => c.cardType === typeFilter)
+    if (!showLocked)          list = list.filter(c => c.unlocked)
+    if (search.trim())        list = list.filter(c =>
+      c.unlocked && c.name.toLowerCase().includes(search.toLowerCase()),
+    )
+    return [...list].sort((a, b) => {
+      if (a.unlocked !== b.unlocked) return a.unlocked ? -1 : 1
+      return (RARITY_ORDER[a.rarity] ?? 0) - (RARITY_ORDER[b.rarity] ?? 0)
+    })
+  }, [cards, typeFilter, showLocked, search])
+
+  const unlockedCardCount  = cards.filter(c => c.unlocked).length
+  const unlockedRelicCount = relics.filter(r => r.unlocked).length
+  const unlockedWorldCount = world.filter(w => w.unlocked).length
+
+  const subtitle = tab === 'cards'
+    ? `${unlockedCardCount} / ${cards.length} discovered`
+    : tab === 'relics'
+    ? `${unlockedRelicCount} / ${relics.length} earned`
+    : `${unlockedWorldCount} / ${world.length} shards explored`
+
+  return (
+    <OverlayScreen title="CODEX" subtitle={subtitle} onBack={onDone}>
+      <div className="codex-screen">
+        {/* Tab bar */}
+        <div className="codex-tabs">
+          {(['cards', 'relics', 'world'] as CodexTab[]).map(t => (
+            <button
+              key={t}
+              className={`filter-btn${tab === t ? ' filter-btn--active' : ''}`}
+              onClick={() => setTab(t)}
+            >
+              {t === 'cards' ? `CARDS (${unlockedCardCount})` :
+               t === 'relics' ? `RELICS (${unlockedRelicCount})` :
+               `WORLD (${unlockedWorldCount})`}
+            </button>
+          ))}
+        </div>
+
+        {/* Cards tab controls */}
+        {tab === 'cards' && (
+          <div className="codex-controls">
+            <input
+              className="codex-search"
+              type="text"
+              placeholder="Search cards..."
+              value={search}
+              onChange={e => setSearch(e.target.value)}
+            />
+            <div className="codex-filters">
+              {(['all', 'unit', 'structure', 'upgrade'] as CardTypeFilter[]).map(t => (
+                <button
+                  key={t}
+                  className={`filter-btn filter-btn--sm${typeFilter === t ? ' filter-btn--active' : ''}`}
+                  onClick={() => setTypeFilter(t)}
+                >
+                  {t.toUpperCase()}
+                </button>
+              ))}
+              <button
+                className={`filter-btn filter-btn--sm${!showLocked ? ' filter-btn--active' : ''}`}
+                onClick={() => setShowLocked(v => !v)}
+              >
+                {showLocked ? 'HIDE LOCKED' : 'SHOW LOCKED'}
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* Content */}
+        <div className="codex-list">
+          {tab === 'cards' && filteredCards.map(card => (
+            <CardLorePanel key={card.name} card={card} />
+          ))}
+
+          {tab === 'relics' && relics.map(relic => (
+            <RelicLorePanel key={relic.name} relic={relic} />
+          ))}
+
+          {tab === 'world' && world.map(entry => (
+            <WorldLorePanel key={entry.actId} entry={entry} />
+          ))}
+
+          {tab === 'cards' && filteredCards.length === 0 && (
+            <div className="codex-empty">No cards match the current filter.</div>
+          )}
+        </div>
+      </div>
+    </OverlayScreen>
+  )
+}

--- a/web/src/components/title/TitleScreen.tsx
+++ b/web/src/components/title/TitleScreen.tsx
@@ -50,13 +50,14 @@ export interface Props {
   onMiniGames: () => void
   onCityBuilder: () => void
   onPlayerStats: () => void
+  onCodex: () => void
   user: User | null
   onSignOut: () => void
   onSignIn: () => void
   onFeedback: () => void
 }
 
-export function TitleScreen({ crystals, onPlay, onEndless, onCampaign, onCollection, onShop, onDeckBuilder, onSettings, onInventory, onAchievements, onHeroCards, onCharacter, on8bitUnlocked, onDailyChallenge, onEndlessLeaderboard, onCommander, commanderName, onTraining, onNews, hasUnreadNews, onMiniGames, onCityBuilder, onPlayerStats, user, onSignOut, onSignIn, onFeedback }: Props) {
+export function TitleScreen({ crystals, onPlay, onEndless, onCampaign, onCollection, onShop, onDeckBuilder, onSettings, onInventory, onAchievements, onHeroCards, onCharacter, on8bitUnlocked, onDailyChallenge, onEndlessLeaderboard, onCommander, commanderName, onTraining, onNews, hasUnreadNews, onMiniGames, onCityBuilder, onPlayerStats, onCodex, user, onSignOut, onSignIn, onFeedback }: Props) {
   const deck             = loadDeck()
   const count            = deckTotalCards(deck)
   const valid            = isDeckValid(deck)
@@ -258,6 +259,7 @@ export function TitleScreen({ crystals, onPlay, onEndless, onCampaign, onCollect
           <TitleButton onClick={onInventory}>🎒 INVENTORY</TitleButton>
           <TitleButton onClick={onAchievements} badge={achievementAlert}>🏆 ACHIEVEMENTS</TitleButton>
           <TitleButton onClick={onPlayerStats}>📊 PLAYER STATS</TitleButton>
+          <TitleButton onClick={onCodex}>📖 CODEX</TitleButton>
           <TitleButton onClick={onCharacter}>👤 CHARACTER</TitleButton>
           <TitleButton onClick={onNews} badge={hasUnreadNews}>📰 WHAT'S NEW</TitleButton>
           <TitleButton onClick={onSettings} extraClass="title-settings-btn">⚙ SETTINGS</TitleButton>

--- a/web/src/data/relics.json
+++ b/web/src/data/relics.json
@@ -3,42 +3,49 @@
     "name": "Bark Shield",
     "icon": "🛡️",
     "desc": "Your base gains +10 max HP at the start of every battle.",
+    "lore": "Carved from the heartwood of the Verdant Shard's oldest tree. The Thornlord wore it as a badge of office for three hundred years. He seemed surprised when you took it.",
     "effects": [{ "type": "baseHp", "amount": 10 }]
   },
   {
     "name": "Iron Standard",
     "icon": "⚔️",
     "desc": "All your units start with +1 ATK.",
+    "lore": "Warlord Kragg's battle standard. His army would follow it anywhere. Several of them followed it into the ground. You've repurposed it.",
     "effects": [{ "type": "unitAtk", "amount": 1 }]
   },
   {
     "name": "Soulstone",
     "icon": "💎",
     "desc": "Once per battle, when one of your units is destroyed, it is immediately revived with half its original HP.",
+    "lore": "Found warm in the Ashen Wastes, long after the fires went cold. The Ashwalker refused to say what it once contained. You decided not to press the matter.",
     "effects": [{ "type": "unitRevive", "hp": "half" }]
   },
   {
     "name": "Prism Lens",
     "icon": "🔮",
     "desc": "Your maximum mana is increased by 1.",
+    "lore": "Removed from the Crystal Spire's central focusing array. The Archivist catalogued it under 'Misappropriated — see entry: Jarv'. He was not pleased.",
     "effects": [{ "type": "maxMana", "amount": 1 }]
   },
   {
     "name": "Coral Mantle",
     "icon": "🐚",
     "desc": "At the start of every battle your units gain +3 max HP.",
+    "lore": "Woven from living reef-thread by the Tidal Sovereign's deep-court attendants. It still smells of cold water and old stone. Your units seem healthier just being near it.",
     "effects": [{ "type": "unitHp", "amount": 3 }]
   },
   {
     "name": "Stormcaller's Badge",
     "icon": "⚡",
     "desc": "All your units gain +2 attack at battle start.",
+    "lore": "A rank insignia of the Sky Dominion, awarded only to generals who won three engagements against impossible odds. The Cloudmarshal had six. You have one now.",
     "effects": [{ "type": "unitAtk", "amount": 2 }]
   },
   {
     "name": "Frost Mantle",
     "icon": "🧊",
     "desc": "All your units gain +2 max HP and your base gains +8 max HP at the start of every battle.",
+    "lore": "Standard-issue gear for the Pale Engine's vanguard units. The cold does not affect them. It does affect you. Fortunately, the toughening effect more than compensates.",
     "effects": [
       { "type": "baseHp", "amount": 8 },
       { "type": "unitHp", "amount": 2 }
@@ -48,24 +55,28 @@
     "name": "Golden Compass",
     "icon": "🧭",
     "desc": "You start each battle with full mana.",
+    "lore": "Points not north, but toward wherever mana flows strongest. In the old Dominion, scholars spent lifetimes following it in circles. In your hands, it just points at you.",
     "effects": [{ "type": "startMana", "amount": 99 }]
   },
   {
     "name": "Spore Bloom",
     "icon": "🍄",
     "desc": "Your units regenerate 1 HP every 3 seconds during battle.",
+    "lore": "A living relic from the Fungal Deep. The Root Queen called it 'a gift freely given'. She was smiling when she said it. You chose to accept anyway.",
     "effects": [{ "type": "tickHeal", "amount": 1, "intervalMs": 3000 }]
   },
   {
     "name": "Magma Core",
     "icon": "🌋",
     "desc": "Your units gain +2 ATK at battle start whenever your base HP is below 50%.",
+    "lore": "Extracted from the Emberfall Peaks at considerable personal cost. It stays cold until danger arrives. Then it wakes up. Your units can feel it.",
     "effects": [{ "type": "unitAtk", "amount": 2, "condition": "baseBelowHalf" }]
   },
   {
     "name": "Living Bark",
     "icon": "🌿",
     "desc": "Your base gains +25 max HP and all your units gain +4 max HP at the start of every battle.",
+    "lore": "A cutting from the Verdant Canopy's Elder Warden. Still growing. It has added another ring since you picked it up. It seems to approve of the places you take it.",
     "effects": [
       { "type": "baseHp", "amount": 25 },
       { "type": "unitHp", "amount": 4 }
@@ -75,12 +86,14 @@
     "name": "Salvage Hook",
     "icon": "🪝",
     "desc": "Once per battle, one of your destroyed units is revived at full HP.",
+    "lore": "A clockwork relic from the Vaults, originally built to retrieve and reassemble damaged automata. The Grand Automaton considered it essential equipment. You agree.",
     "effects": [{ "type": "unitRevive", "hp": "full" }]
   },
   {
     "name": "Gear Heart",
     "icon": "⚙️",
     "desc": "All your units gain +3 ATK and +3 max HP at battle start, and gain an additional +2 ATK whenever any card is played.",
+    "lore": "The Grand Automaton's secondary processing core. It doesn't know it's outside the Vaults. Your units seem to receive its instructions regardless. Don't tell it the truth.",
     "effects": [
       { "type": "unitAtk", "amount": 3 },
       { "type": "unitHp", "amount": 3 },
@@ -91,6 +104,7 @@
     "name": "Worldmender's Crest",
     "icon": "🌐",
     "desc": "The mark of the Worldmender. Your base gains +30 max HP, all units gain +6 ATK and +8 max HP, and your maximum mana is increased by 2.",
+    "lore": "The mark of someone who walked every shard and returned. The Dominion was shattered and you were the one who chose not to let it stay that way. The world is still broken. Less so than before.",
     "effects": [
       { "type": "baseHp", "amount": 30 },
       { "type": "unitAtk", "amount": 6 },

--- a/web/src/game/codex.ts
+++ b/web/src/game/codex.ts
@@ -1,0 +1,114 @@
+import { getCardCatalog } from './cards'
+import { loadCollection } from './collection'
+import { getRelics } from './itemStore'
+import { loadActCount } from './questline'
+import relicsData from '../data/relics.json'
+
+import act1Data from '../data/acts/act1.json'
+import act2Data from '../data/acts/act2.json'
+import act3Data from '../data/acts/act3.json'
+import act4Data from '../data/acts/act4.json'
+import act5Data from '../data/acts/act5.json'
+import act6Data from '../data/acts/act6.json'
+import act7Data from '../data/acts/act7.json'
+import act8Data from '../data/acts/act8.json'
+import act9Data from '../data/acts/act9.json'
+import act10Data from '../data/acts/act10.json'
+import act11Data from '../data/acts/act11.json'
+import act12Data from '../data/acts/act12.json'
+import act13Data from '../data/acts/act13.json'
+import actFinaleData from '../data/acts/actfinale.json'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const ALL_ACTS: any[] = [
+  act1Data, act2Data, act3Data, act4Data, act5Data,
+  act6Data, act7Data, act8Data, act9Data, act10Data,
+  act11Data, act12Data, act13Data, actFinaleData,
+]
+
+export interface CodexCardEntry {
+  name: string
+  rarity: string
+  cardType: string
+  description: string
+  lore: string
+  unlocked: boolean
+}
+
+export interface CodexRelicEntry {
+  name: string
+  icon: string
+  desc: string
+  lore: string
+  unlocked: boolean
+}
+
+export interface CodexWorldEntry {
+  actId: string
+  title: string
+  subtitle: string
+  environment: string
+  bossName: string
+  bossDescription: string
+  shardLore: string
+  unlocked: boolean
+}
+
+export function getCodexCards(): CodexCardEntry[] {
+  const catalog = getCardCatalog()
+  const collection = loadCollection()
+  const ownedNames = new Set(collection.map(e => e.cardName))
+
+  return catalog.map(card => ({
+    name: card.name,
+    rarity: card.rarity,
+    cardType: card.cardType,
+    description: card.description,
+    lore: card.lore ?? '',
+    unlocked: ownedNames.has(card.name),
+  }))
+}
+
+export function getCodexRelics(): CodexRelicEntry[] {
+  const earned = new Set(getRelics())
+  return (relicsData as Array<{ name: string; icon: string; desc: string; lore?: string; effects: unknown[] }>).map(r => ({
+    name: r.name,
+    icon: r.icon,
+    desc: r.desc,
+    lore: r.lore ?? '',
+    unlocked: earned.has(r.name),
+  }))
+}
+
+/** Shard lore is derived from act data rather than a separate file. */
+function buildShardLore(act: {
+  id: string
+  subtitle?: string
+  environment?: string
+  intro?: Array<{ text?: string }>
+  outro?: Array<{ text?: string }>
+}): string {
+  const lines: string[] = []
+  if (act.intro?.[0]?.text) lines.push(act.intro[0].text.split('\n')[0])
+  if (act.outro?.[0]?.text) lines.push(act.outro[0].text.split('\n')[0])
+  return lines.join(' ') || `One of the shards of the shattered Dominion.`
+}
+
+export function getCodexWorld(): CodexWorldEntry[] {
+  return ALL_ACTS.map(act => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const bossNode = Object.values(act.nodes as Record<string, any>).find((n: any) => n.type === 'boss') as any
+    const actCompleted = loadActCount(act.id) > 0
+
+    return {
+      actId: act.id as string,
+      title: act.title as string,
+      subtitle: act.subtitle as string ?? '',
+      environment: act.environment as string ?? '',
+      bossName: bossNode ? (bossNode.bossName ?? bossNode.label ?? '???') : '???',
+      bossDescription: bossNode?.description ?? '',
+      shardLore: buildShardLore(act),
+      unlocked: actCompleted,
+    }
+  })
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -7092,6 +7092,139 @@ html.eightbit-mode .lane-layer {
 
 /* ─── Character Screen ───────────────────────────────── */
 
+/* ── Codex Screen ──────────────────────────────────────────── */
+.codex-screen {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  overflow: hidden;
+  padding: 0.5rem;
+  gap: 0.5rem;
+}
+
+.codex-tabs {
+  display: flex;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.codex-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.codex-search {
+  background: var(--game-bg, #0a0a0a);
+  border: 1px solid var(--game-border, #2a5a2a);
+  color: var(--color-text, #aaffaa);
+  font-family: inherit;
+  font-size: 0.8rem;
+  padding: 4px 8px;
+  width: 100%;
+  max-width: 320px;
+}
+.codex-search:focus { outline: 1px solid #aaffaa; }
+
+.codex-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.codex-list {
+  flex: 1;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding-right: 4px;
+}
+
+.codex-entry {
+  border: 1px solid var(--game-border, #2a5a2a);
+  padding: 0.6rem 0.8rem;
+  background: rgba(0, 20, 0, 0.4);
+}
+
+.codex-entry--locked {
+  opacity: 0.45;
+  border-style: dashed;
+}
+
+.codex-entry-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 6px;
+  margin-bottom: 4px;
+}
+
+.codex-entry-name {
+  font-size: 0.95rem;
+  font-weight: bold;
+  color: #aaffaa;
+}
+
+.codex-entry-tag {
+  font-size: 0.65rem;
+  color: #668866;
+  border: 1px solid #335533;
+  padding: 1px 5px;
+}
+
+.codex-entry-desc {
+  font-size: 0.75rem;
+  color: #88aa88;
+  margin-bottom: 6px;
+}
+
+.codex-entry-lore {
+  font-size: 0.78rem;
+  color: #99cc99;
+  font-style: italic;
+  border-left: 2px solid #2a5a2a;
+  padding-left: 8px;
+  margin-top: 4px;
+}
+
+.codex-entry-locked-hint {
+  font-size: 0.72rem;
+  color: #556655;
+  margin-top: 2px;
+}
+
+.codex-entry-boss {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 6px;
+  margin-top: 6px;
+  padding-top: 6px;
+  border-top: 1px solid #1a3a1a;
+}
+
+.codex-entry-boss-label {
+  font-size: 0.65rem;
+  color: #ff8844;
+  border: 1px solid #774422;
+  padding: 1px 5px;
+}
+
+.codex-entry-boss-name {
+  font-size: 0.85rem;
+  color: #ffaa66;
+}
+
+.codex-empty {
+  color: #556655;
+  font-size: 0.8rem;
+  text-align: center;
+  padding: 2rem;
+}
+
+/* ── Character Screen ─────────────────────────────────── */
 .character-screen-scroll {
   flex: 1;
   overflow-y: auto;


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Closes #1293 — The Codex (Grimoire System), the first deliverable of [Epic #1290: Pillar 1 — Story & World Building](https://github.com/Jarvichi/jarvs-amazing-web-game/issues/1290).

Every card, relic, boss, and shard in the Shattered Dominion now has a discoverable lore entry. Accessible via a new **📖 CODEX** button in the main menu.

### What's in this PR

- **`src/game/codex.ts`** — New module that derives unlock state from your existing collection and item store (no new storage key needed — if you own it, you can read it)
- **`src/components/screens/CodexScreen.tsx`** — Browsable 3-tab screen:
  - **CARDS** — 610 cards with lore, searchable, filterable by type (unit/structure/upgrade), locked entries shown as `???` until discovered
  - **RELICS** — All 14 relics with new lore entries, locked until earned
  - **WORLD** — All 14 shards and their bosses, locked until you complete the act
- **`src/data/relics.json`** — Lore written for all 14 relics (e.g. *"Carved from the heartwood of the Verdant Shard's oldest tree. The Thornlord wore it as a badge of office for three hundred years. He seemed surprised when you took it."*)
- **`src/App.tsx` + `TitleScreen.tsx`** — `CODEX` button wired into the main navigation

### Content note

All 610 cards already had lore fields in `cards.json` — great writing already in place. Relic lore is new in this PR. Shard/boss entries are derived from the richly-authored act data that already existed.

## Test plan

- [ ] Open the game, go to title screen — confirm **📖 CODEX** button is visible
- [ ] Click Codex → Cards tab shows cards (locked if not in collection, unlocked with lore if owned)
- [ ] Search works; type filter (ALL / UNIT / STRUCTURE / UPGRADE) works; HIDE LOCKED toggle works
- [ ] Relics tab shows locked relics as `???` until earned; earned relics show lore
- [ ] World tab shows `???` for acts not yet completed; completed acts show shard name, boss name, and description
- [ ] Back button returns to title screen

https://github.com/Jarvichi/jarvs-amazing-web-game/issues/1293
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X1dTjbXJx9e3ve32RDiebf)_