### PR TITLE
Fix TitleScreen stories missing onCodex prop

### DIFF
--- a/web/src/components/title/TitleScreen.stories.tsx
+++ b/web/src/components/title/TitleScreen.stories.tsx
@@ -31,6 +31,7 @@ const callbacks = {
   onNews: fn(),
   onMiniGames: fn(),
   onPlayerStats: fn(),
+  onCodex: fn(),
   onSignOut: fn(),
   onSignIn: fn(),
   onFeedback: fn(),


### PR DESCRIPTION
Follow-up fix for #1303.

The deploy CI failed because `TitleScreen.stories.tsx` wasn't updated when the `onCodex` prop was added to `TitleScreen`'s `Props` interface.

**Fix:** Add `onCodex: fn()` to the stories callbacks object — one line.

```
error TS2741: Property 'onCodex' is missing in type '{ ... }'
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01X1dTjbXJx9e3ve32RDiebf)_