### PR TITLE
feat: #1294 Shard Memory Fragments

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -41,6 +41,9 @@ import { CampScreen, CampChoice } from './components/campaign/CampScreen'
 import { EventScreen }          from './components/campaign/EventScreen'
 import { MerchantScreen, MerchantItem, cardMerchantItem } from './components/campaign/MerchantScreen'
 import { MysteryScreen } from './components/campaign/MysteryScreen'
+import { MemoryFragmentScreen } from './components/campaign/MemoryFragmentScreen'
+import { MemoryFragment, isFragmentDiscovered, markFragmentDiscovered } from './game/codex'
+import memoryFragmentsData from './data/memoryFragments.json'
 import { ItemFoundScreen }    from './components/modals/ItemFoundScreen'
 import { CharacterScreen }    from './components/screens/CharacterScreen'
 import { CutsceneScreen }       from './components/campaign/CutsceneScreen'
@@ -200,6 +203,7 @@ type Screen =
   | 'statupgrade'
   | 'camp'
   | 'codex'
+  | 'memory'
 
 
 const STANCE_RULES_BY_NODE_TYPE: Partial<Record<string, StanceRules>> = {
@@ -364,6 +368,7 @@ export default function App() {
   const [merchantItems, setMerchantItems] = useState<MerchantItem[]>([])
   const merchantBoughtRef = useRef(0)
   const [mysteryReward, setMysteryReward] = useState<RewardDef | null>(null)
+  const [activeMemoryFragment, setActiveMemoryFragment] = useState<{ fragment: MemoryFragment; alreadyFound: boolean; shardBonus: boolean } | null>(null)
   const [campNode, setCampNode] = useState<QuestNode | null>(null)
   const [campResult, setCampResult] = useState<string | null>(null)
   // Replay briefing state — stored so onBegin can proceed with the correct context
@@ -975,6 +980,17 @@ export default function App() {
       return
     }
 
+    if (node.type === 'memory' && node.fragmentId) {
+      const allFragments = memoryFragmentsData as MemoryFragment[]
+      const frag = allFragments.find(f => f.id === node.fragmentId)
+      if (frag) {
+        const alreadyFound = isFragmentDiscovered(frag.id)
+        setActiveMemoryFragment({ fragment: frag, alreadyFound, shardBonus: false })
+        setScreen('memory')
+        return
+      }
+    }
+
     // 10% chance: normal battle node becomes a mystery encounter
     if (node.type === 'battle' && Math.random() < 0.10) {
       setMysteryReward(computeReward(loadInventory()))
@@ -1224,6 +1240,39 @@ export default function App() {
     if (mysteryUnlocked.length > 0) setAchievementToasts(prev => [...prev, ...mysteryUnlocked])
     setScreen('nodemap')
   }, [run, mysteryReward])
+
+  const handleMemoryCollect = useCallback(() => {
+    const currentRun = run
+    if (!currentRun || !activeMemoryFragment) { setScreen('nodemap'); return }
+    const { fragment, alreadyFound } = activeMemoryFragment
+    let shardBonus = false
+    let updatedConsumables = currentRun.consumables
+    if (!alreadyFound) {
+      shardBonus = markFragmentDiscovered(fragment.id)
+      if (shardBonus) {
+        const existing = updatedConsumables.find(c => c.id === 'health_potion')
+        updatedConsumables = existing
+          ? updatedConsumables.map(c => c.id === 'health_potion' ? { ...c, count: c.count + 1 } : c)
+          : [...updatedConsumables, { id: 'health_potion', count: 1 }]
+      }
+    }
+    const nodeId = currentRun.pendingNodeId!
+    const updatedRun: RunState = {
+      ...currentRun,
+      completedNodeIds: [...currentRun.completedNodeIds, nodeId],
+      pendingNodeId: null,
+      consumables: updatedConsumables,
+    }
+    recordNodeComplete(updatedRun.actId, nodeId)
+    saveRun(updatedRun)
+    setRun(updatedRun)
+    if (shardBonus) {
+      setActiveMemoryFragment({ ...activeMemoryFragment, alreadyFound: false, shardBonus: true })
+      return
+    }
+    setActiveMemoryFragment(null)
+    setScreen('nodemap')
+  }, [run, activeMemoryFragment])
 
   const handleUseConsumable = useCallback((id: string) => {
     setRun(prev => {
@@ -2389,6 +2438,17 @@ export default function App() {
         <MysteryScreen
           reward={mysteryReward}
           onCollect={handleMysteryCollect}
+        />
+      )}
+
+      {(screen === 'memory' || activeMemoryFragment?.shardBonus) && activeMemoryFragment && (
+        <MemoryFragmentScreen
+          fragment={activeMemoryFragment.fragment}
+          alreadyFound={activeMemoryFragment.alreadyFound}
+          shardBonus={activeMemoryFragment.shardBonus}
+          onCollect={activeMemoryFragment.shardBonus
+            ? () => { setActiveMemoryFragment(null); setScreen('nodemap') }
+            : handleMemoryCollect}
         />
       )}
 

--- a/web/src/components/battle/PostBattleReward.tsx
+++ b/web/src/components/battle/PostBattleReward.tsx
@@ -29,6 +29,7 @@ const NODE_FLAVOUR: Record<NodeType, string> = {
   rest:     '',
   event:    '',
   merchant: '',
+  memory:   '',
 }
 
 export function PostBattleReward({ choices, nodeType, crystals, onPick, onSkip, headerOverride, battleSummary }: Props) {

--- a/web/src/components/campaign/MemoryFragmentScreen.tsx
+++ b/web/src/components/campaign/MemoryFragmentScreen.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import { MemoryFragment } from '../../game/codex'
+
+interface Props {
+  fragment: MemoryFragment
+  alreadyFound: boolean
+  shardBonus: boolean
+  onCollect: () => void
+}
+
+export function MemoryFragmentScreen({ fragment, alreadyFound, shardBonus, onCollect }: Props) {
+  return (
+    <div className="memory-screen">
+      <div className="memory-type-tag">[MEMORY FRAGMENT]</div>
+      <div className="memory-title">{fragment.title}</div>
+
+      <div className="memory-body">
+        {fragment.body.split('\n\n').map((para, i) => (
+          <p key={i} className="memory-para">{para}</p>
+        ))}
+      </div>
+
+      {alreadyFound && (
+        <div className="memory-already-found">— ALREADY DISCOVERED —</div>
+      )}
+
+      {!alreadyFound && shardBonus && (
+        <div className="memory-shard-bonus">
+          ◆ All shard memories restored. A gift from the past — Health Potion added to supplies.
+        </div>
+      )}
+
+      <button className="event-choice-btn memory-collect-btn" onClick={onCollect}>
+        {alreadyFound ? 'RETURN TO MAP ›' : 'ADD TO CODEX ›'}
+      </button>
+    </div>
+  )
+}

--- a/web/src/components/campaign/NodeMap.tsx
+++ b/web/src/components/campaign/NodeMap.tsx
@@ -29,6 +29,7 @@ const NODE_ICON: Record<string, string> = {
   rest:     '⛺',
   event:    '?',
   merchant: '⚖',
+  memory:   '◆',
 }
 
 const COL_WIDTH      = 112 // fixed pixel width per map column slot
@@ -68,12 +69,14 @@ const NODE_LABEL: Record<string, string> = {
   rest:     'REST',
   event:    'EVENT',
   merchant: 'SHOP',
+  memory:   'MEMORY',
 }
 
 function nodeSprite(node: QuestNode): string | null {
   if (node.type === 'rest')     return '/sprites/campfire.svg'
   if (node.type === 'merchant') return '/sprites/merchant.svg'
   if (node.type === 'event')    return '/sprites/event.svg'
+  if (node.type === 'memory')   return '/sprites/event.svg'
   if (node.type === 'boss' && node.bossAI)
     return `/sprites/boss-${node.bossAI}.svg`
   if ((node.type === 'battle' || node.type === 'elite') && node.enemyDeck?.length)

--- a/web/src/components/screens/CodexScreen.tsx
+++ b/web/src/components/screens/CodexScreen.tsx
@@ -1,11 +1,11 @@
 import React, { useState, useMemo } from 'react'
 import { OverlayScreen } from '../ui/OverlayScreen'
 import {
-  getCodexCards, getCodexRelics, getCodexWorld,
-  CodexCardEntry, CodexRelicEntry, CodexWorldEntry,
+  getCodexCards, getCodexRelics, getCodexWorld, getCodexFragments,
+  CodexCardEntry, CodexRelicEntry, CodexWorldEntry, CodexFragmentEntry,
 } from '../../game/codex'
 
-type CodexTab = 'cards' | 'relics' | 'world'
+type CodexTab = 'cards' | 'relics' | 'world' | 'fragments'
 type CardTypeFilter = 'all' | 'unit' | 'structure' | 'upgrade'
 
 const RARITY_ORDER: Record<string, number> = {
@@ -23,6 +23,28 @@ const RARITY_COLORS: Record<string, string> = {
   shiny:     '#ffe066',
   holofoil:  '#40e0d0',
   glass:     '#a0d8ef',
+}
+
+function FragmentLorePanel({ entry }: { entry: CodexFragmentEntry }) {
+  if (!entry.discovered) {
+    return (
+      <div className="codex-entry codex-entry--locked">
+        <div className="codex-entry-name">◆ ??? — {entry.actId.toUpperCase()}</div>
+        <div className="codex-entry-locked-hint">Find this memory fragment on the campaign map to unlock its entry.</div>
+      </div>
+    )
+  }
+  return (
+    <div className="codex-entry">
+      <div className="codex-entry-header">
+        <span className="codex-entry-name" style={{ color: '#aaddff' }}>◆ {entry.title}</span>
+        <span className="codex-entry-tag">{entry.actId.toUpperCase()}</span>
+      </div>
+      {entry.body.split('\n\n').map((para, i) => (
+        <div key={i} className="codex-entry-desc">{para}</div>
+      ))}
+    </div>
+  )
 }
 
 interface Props {
@@ -108,9 +130,10 @@ export function CodexScreen({ onDone }: Props) {
   const [search, setSearch] = useState('')
   const [showLocked, setShowLocked] = useState(true)
 
-  const cards  = useMemo(() => getCodexCards(),  [])
-  const relics = useMemo(() => getCodexRelics(), [])
-  const world  = useMemo(() => getCodexWorld(),  [])
+  const cards     = useMemo(() => getCodexCards(),     [])
+  const relics    = useMemo(() => getCodexRelics(),    [])
+  const world     = useMemo(() => getCodexWorld(),     [])
+  const fragments = useMemo(() => getCodexFragments(), [])
 
   const filteredCards = useMemo<CodexCardEntry[]>(() => {
     let list = cards
@@ -125,30 +148,34 @@ export function CodexScreen({ onDone }: Props) {
     })
   }, [cards, typeFilter, showLocked, search])
 
-  const unlockedCardCount  = cards.filter(c => c.unlocked).length
-  const unlockedRelicCount = relics.filter(r => r.unlocked).length
-  const unlockedWorldCount = world.filter(w => w.unlocked).length
+  const unlockedCardCount     = cards.filter(c => c.unlocked).length
+  const unlockedRelicCount    = relics.filter(r => r.unlocked).length
+  const unlockedWorldCount    = world.filter(w => w.unlocked).length
+  const discoveredFragCount   = fragments.filter(f => f.discovered).length
 
   const subtitle = tab === 'cards'
     ? `${unlockedCardCount} / ${cards.length} discovered`
     : tab === 'relics'
     ? `${unlockedRelicCount} / ${relics.length} earned`
-    : `${unlockedWorldCount} / ${world.length} shards explored`
+    : tab === 'world'
+    ? `${unlockedWorldCount} / ${world.length} shards explored`
+    : `${discoveredFragCount} / ${fragments.length} fragments recovered`
 
   return (
     <OverlayScreen title="CODEX" subtitle={subtitle} onBack={onDone}>
       <div className="codex-screen">
         {/* Tab bar */}
         <div className="codex-tabs">
-          {(['cards', 'relics', 'world'] as CodexTab[]).map(t => (
+          {(['cards', 'relics', 'world', 'fragments'] as CodexTab[]).map(t => (
             <button
               key={t}
               className={`filter-btn${tab === t ? ' filter-btn--active' : ''}`}
               onClick={() => setTab(t)}
             >
-              {t === 'cards' ? `CARDS (${unlockedCardCount})` :
-               t === 'relics' ? `RELICS (${unlockedRelicCount})` :
-               `WORLD (${unlockedWorldCount})`}
+              {t === 'cards'     ? `CARDS (${unlockedCardCount})` :
+               t === 'relics'    ? `RELICS (${unlockedRelicCount})` :
+               t === 'world'     ? `WORLD (${unlockedWorldCount})` :
+               `FRAGMENTS (${discoveredFragCount})`}
             </button>
           ))}
         </div>
@@ -195,6 +222,10 @@ export function CodexScreen({ onDone }: Props) {
 
           {tab === 'world' && world.map(entry => (
             <WorldLorePanel key={entry.actId} entry={entry} />
+          ))}
+
+          {tab === 'fragments' && fragments.map(entry => (
+            <FragmentLorePanel key={entry.id} entry={entry} />
           ))}
 
           {tab === 'cards' && filteredCards.length === 0 && (

--- a/web/src/components/title/TitleScreen.stories.tsx
+++ b/web/src/components/title/TitleScreen.stories.tsx
@@ -31,6 +31,7 @@ const callbacks = {
   onNews: fn(),
   onMiniGames: fn(),
   onPlayerStats: fn(),
+  onCodex: fn(),
   onSignOut: fn(),
   onSignIn: fn(),
   onFeedback: fn(),

--- a/web/src/data/acts/act1.json
+++ b/web/src/data/acts/act1.json
@@ -360,7 +360,8 @@
       "rowCols": 1,
       "childIds": [
         "shrine",
-        "camp"
+        "camp",
+        "mem-verdant-echo"
       ],
       "handicap": 7,
       "opponentIntervalMs": 7000,
@@ -387,7 +388,7 @@
       "description": "The camp was already occupied. Its new residents are not welcoming.",
       "row": 1,
       "col": 1,
-      "rowCols": 2,
+      "rowCols": 3,
       "childIds": [
         "node-1776083922801",
         "market"
@@ -414,7 +415,7 @@
       "description": "Goblins have claimed the shrine as their own. They're not interested in sharing.",
       "row": 1,
       "col": 0,
-      "rowCols": 2,
+      "rowCols": 3,
       "childIds": [
         "forest-path",
         "node-the-lonely-field"
@@ -438,31 +439,85 @@
     },
     "forest-path": {
       "id": "forest-path",
-      "type": "memory",
-      "label": "Memory Fragment",
-      "description": "Something lingers here — a memory pressed into the earth by the Fracture.",
+      "type": "event",
+      "label": "Ancient Shrine",
+      "description": "A moss-covered shrine pulses with faint forest magic.",
       "row": 2,
       "col": 0,
       "rowCols": 4,
       "childIds": [
         "captain"
       ],
-      "fragmentId": "act1-frag-1",
-      "environment": "forest"
+      "environment": "forest",
+      "eventConfig": {
+        "title": "A Forgotten Shrine",
+        "description": "Buried deep in moss and roots, an ancient shrine pulses with faint magic. Carved glyphs glow a dim green. Something still listens here.",
+        "pools": [
+          [
+            {"label": "Leave an offering", "consequence": "The shrine accepts your gift — restored 12 HP", "effect": {"type": "healHp", "amount": 12}},
+            {"label": "Leave an offering", "consequence": "The glow brightens — +15 crystals", "effect": {"type": "gainCrystals", "amount": 15}},
+            {"label": "Leave an offering", "consequence": "The shrine is silent. Nothing happens.", "effect": {"type": "nothing"}},
+            {"label": "Leave an offering", "consequence": "Something drains your offering — lose 5 HP", "effect": {"type": "damageHp", "amount": 5}},
+            {"label": "Leave an offering", "consequence": "Something small materialises at the altar's base — added to inventory", "effect": {"type": "gainItem"}},
+            {"label": "Leave an offering", "consequence": "The shrine blesses you with renewed fortune — +1 life", "effect": {"type": "gainLife", "amount": 1}}
+          ],
+          [
+            {"label": "Pray for strength", "consequence": "A card materialises from the glow — uncommon", "effect": {"type": "gainCard", "rarity": "uncommon"}},
+            {"label": "Pray for strength", "consequence": "The magic guides your wounds — restored 8 HP", "effect": {"type": "healHp", "amount": 8}},
+            {"label": "Pray for strength", "consequence": "The shrine tests you — lose 10 HP", "effect": {"type": "damageHp", "amount": 10}},
+            {"label": "Pray for strength", "consequence": "You feel oddly lucky — +20 crystals", "effect": {"type": "gainCrystals", "amount": 20}},
+            {"label": "Pray for strength", "consequence": "Something small and inexplicable materialises in your palm — added to inventory", "effect": {"type": "gainItem"}},
+            {"label": "Pray for strength", "consequence": "A strange object appears in your hand from nowhere — added to inventory", "effect": {"type": "gainItem"}}
+          ],
+          [
+            {"label": "Pocket the ritual stones", "consequence": "You grab them and run — +18 crystals, lose 8 HP", "effect": {"type": "compound", "effects": [{"type": "gainCrystals", "amount": 18}, {"type": "damageHp", "amount": 8}]}},
+            {"label": "Pocket the ritual stones", "consequence": "A common card falls from the stones", "effect": {"type": "gainCard", "rarity": "common"}},
+            {"label": "Pocket the ritual stones", "consequence": "The stones crumble to dust. Nothing.", "effect": {"type": "nothing"}},
+            {"label": "Pocket the ritual stones", "consequence": "The shrine curses you — lose 15 HP", "effect": {"type": "damageHp", "amount": 15}},
+            {"label": "Pocket the ritual stones", "consequence": "One of the stones turns out to be something stranger — added to inventory", "effect": {"type": "gainItem"}}
+          ]
+        ]
+      }
     },
     "ambush": {
       "id": "ambush",
-      "type": "memory",
-      "label": "Memory Fragment",
-      "description": "The bark of the ancient trees bears faint glyphs — words from before the sealing.",
+      "type": "event",
+      "label": "The Watching Wood",
+      "description": "Something has been following you since the first road. It steps out of the treeline.",
       "row": 4,
       "col": 1,
       "rowCols": 4,
       "childIds": [
         "deep-crossing"
       ],
-      "fragmentId": "act1-frag-2",
-      "environment": "forest"
+      "environment": "forest",
+      "eventConfig": {
+        "title": "The Watching Wood",
+        "description": "A great creature steps from the treeline. Not hostile — not yet. It tilts its head and watches you with ancient, patient eyes.",
+        "pools": [
+          [
+            {"label": "Stand your ground", "consequence": "It respects the stillness — +15 crystals from its abandoned cache", "effect": {"type": "gainCrystals", "amount": 15}},
+            {"label": "Stand your ground", "consequence": "It steps forward and presses something into your hand — added to inventory", "effect": {"type": "gainItem"}},
+            {"label": "Stand your ground", "consequence": "It growls and charges — lose 12 HP", "effect": {"type": "damageHp", "amount": 12}},
+            {"label": "Stand your ground", "consequence": "It holds your gaze for a long moment, then turns and vanishes.", "effect": {"type": "nothing"}},
+            {"label": "Stand your ground", "consequence": "Something in its posture says: not today — restored 10 HP", "effect": {"type": "healHp", "amount": 10}}
+          ],
+          [
+            {"label": "Offer it food", "consequence": "It takes your offering gently — restored 12 HP", "effect": {"type": "healHp", "amount": 12}},
+            {"label": "Offer it food", "consequence": "It sniffs and drops an uncommon card at your feet", "effect": {"type": "gainCard", "rarity": "uncommon"}},
+            {"label": "Offer it food", "consequence": "It takes the food and leaves. Nothing else.", "effect": {"type": "nothing"}},
+            {"label": "Offer it food", "consequence": "It lashes out — lose 8 HP", "effect": {"type": "damageHp", "amount": 8}},
+            {"label": "Offer it food", "consequence": "It drops something from its mouth — a common card", "effect": {"type": "gainCard", "rarity": "common"}}
+          ],
+          [
+            {"label": "Back away slowly", "consequence": "It lets you go — nothing happens", "effect": {"type": "nothing"}},
+            {"label": "Back away slowly", "consequence": "It follows you to the edge of its territory and leaves a crystal cache — +12 crystals", "effect": {"type": "gainCrystals", "amount": 12}},
+            {"label": "Back away slowly", "consequence": "It pounces — lose 15 HP", "effect": {"type": "damageHp", "amount": 15}},
+            {"label": "Back away slowly", "consequence": "You find something in the grass as you retreat — added to inventory", "effect": {"type": "gainItem"}},
+            {"label": "Back away slowly", "consequence": "It watches you leave and seems almost disappointed — restored 6 HP", "effect": {"type": "healHp", "amount": 6}}
+          ]
+        ]
+      }
     },
     "ruins": {
       "id": "ruins",
@@ -674,10 +729,11 @@
       "description": "A hardened veteran with well-drilled siege troops — and something the forest has been teaching him about patience.",
       "row": 3,
       "col": 0,
-      "rowCols": 2,
+      "rowCols": 3,
       "childIds": [
         "war-camp",
-        "ambush"
+        "ambush",
+        "mem-act1-1"
       ],
       "handicap": 1,
       "environment": "ruins",
@@ -712,7 +768,7 @@
       "description": "The deep woods belong to something older than the Fracture. It has been watching. Now it is done watching.",
       "row": 3,
       "col": 1,
-      "rowCols": 2,
+      "rowCols": 3,
       "childIds": [
         "troll-bridge",
         "ruins"
@@ -750,7 +806,8 @@
       "col": 3,
       "rowCols": 4,
       "childIds": [
-        "deep-crossing"
+        "deep-crossing",
+        "mem-root-memory"
       ],
       "handicap": 0,
       "opponentBaseHp": 95,
@@ -829,7 +886,7 @@
       "description": "A collapsed stone bridge over a dark ravine. Something is defending it.",
       "row": 5,
       "col": 0,
-      "rowCols": 1,
+      "rowCols": 2,
       "childIds": [
         "thornlord"
       ],
@@ -892,6 +949,34 @@
       ],
       "restHeal": 15,
       "environment": "farmland"
+    },
+    "mem-verdant-echo": {
+      "id": "mem-verdant-echo",
+      "type": "memory",
+      "label": "Memory Fragment",
+      "description": "A flicker of something pressed into the treeline — a voice that stopped mid-sentence when the Fracture sealed the shard.",
+      "row": 1,
+      "col": 2,
+      "rowCols": 3,
+      "childIds": [
+        "captain"
+      ],
+      "fragmentId": "act1-frag-3",
+      "environment": "forest"
+    },
+    "mem-root-memory": {
+      "id": "mem-root-memory",
+      "type": "memory",
+      "label": "Memory Fragment",
+      "description": "Deep roots hold something older than the Thornlord — a fragment of the shard before it was sealed.",
+      "row": 5,
+      "col": 1,
+      "rowCols": 2,
+      "childIds": [
+        "thornlord"
+      ],
+      "fragmentId": "act1-frag-4",
+      "environment": "forest"
     }
   },
   "mapMusicId": "map",

--- a/web/src/data/acts/act1.json
+++ b/web/src/data/acts/act1.json
@@ -360,8 +360,7 @@
       "rowCols": 1,
       "childIds": [
         "shrine",
-        "camp",
-        "mem-verdant-echo"
+        "camp"
       ],
       "handicap": 7,
       "opponentIntervalMs": 7000,
@@ -388,7 +387,7 @@
       "description": "The camp was already occupied. Its new residents are not welcoming.",
       "row": 1,
       "col": 1,
-      "rowCols": 3,
+      "rowCols": 2,
       "childIds": [
         "node-1776083922801",
         "market"
@@ -415,7 +414,7 @@
       "description": "Goblins have claimed the shrine as their own. They're not interested in sharing.",
       "row": 1,
       "col": 0,
-      "rowCols": 3,
+      "rowCols": 2,
       "childIds": [
         "forest-path",
         "node-the-lonely-field"
@@ -1029,8 +1028,7 @@
       "col": 3,
       "rowCols": 4,
       "childIds": [
-        "deep-crossing",
-        "mem-root-memory"
+        "deep-crossing"
       ],
       "handicap": 0,
       "opponentBaseHp": 95,
@@ -1109,7 +1107,7 @@
       "description": "A collapsed stone bridge over a dark ravine. Something is defending it.",
       "row": 5,
       "col": 0,
-      "rowCols": 3,
+      "rowCols": 2,
       "childIds": [
         "thornlord"
       ],
@@ -1174,20 +1172,6 @@
       "restHeal": 15,
       "environment": "farmland"
     },
-    "mem-verdant-echo": {
-      "id": "mem-verdant-echo",
-      "type": "memory",
-      "label": "Memory Fragment",
-      "description": "A flicker of something pressed into the treeline — a voice that stopped mid-sentence when the Fracture sealed the shard.",
-      "row": 1,
-      "col": 2,
-      "rowCols": 3,
-      "childIds": [
-        "captain"
-      ],
-      "fragmentId": "act1-frag-3",
-      "environment": "forest"
-    },
     "mem-act1-1": {
       "id": "mem-act1-1",
       "type": "memory",
@@ -1202,28 +1186,14 @@
       "fragmentId": "act1-frag-1",
       "environment": "forest"
     },
-    "mem-root-memory": {
-      "id": "mem-root-memory",
-      "type": "memory",
-      "label": "Memory Fragment",
-      "description": "Deep roots hold something older than the Thornlord \u2014 a fragment of the shard before it was sealed.",
-      "row": 5,
-      "col": 1,
-      "rowCols": 3,
-      "childIds": [
-        "thornlord"
-      ],
-      "fragmentId": "act1-frag-4",
-      "environment": "forest"
-    },
     "mem-act1-2": {
       "id": "mem-act1-2",
       "type": "memory",
       "label": "Memory Fragment",
       "description": "The bridge remembers what crossed it before the Fracture sealed the roads \u2014 a fragment pressed into the stone.",
       "row": 5,
-      "col": 2,
-      "rowCols": 3,
+      "col": 1,
+      "rowCols": 2,
       "childIds": [
         "thornlord"
       ],

--- a/web/src/data/acts/act1.json
+++ b/web/src/data/acts/act1.json
@@ -438,307 +438,31 @@
     },
     "forest-path": {
       "id": "forest-path",
-      "type": "event",
-      "label": "Ancient Shrine",
-      "description": "A moss-covered shrine pulses with faint forest magic.",
+      "type": "memory",
+      "label": "Memory Fragment",
+      "description": "Something lingers here — a memory pressed into the earth by the Fracture.",
       "row": 2,
       "col": 0,
       "rowCols": 4,
       "childIds": [
         "captain"
       ],
-      "environment": "forest",
-      "eventConfig": {
-        "title": "A Forgotten Shrine",
-        "description": "Buried deep in moss and roots, an ancient shrine pulses with faint magic. Carved glyphs glow a dim green. Something still listens here.",
-        "pools": [
-          [
-            {
-              "label": "Leave an offering",
-              "consequence": "The shrine accepts your gift — restored 12 HP",
-              "effect": {
-                "type": "healHp",
-                "amount": 12
-              }
-            },
-            {
-              "label": "Leave an offering",
-              "consequence": "The glow brightens — +15 crystals",
-              "effect": {
-                "type": "gainCrystals",
-                "amount": 15
-              }
-            },
-            {
-              "label": "Leave an offering",
-              "consequence": "The shrine is silent. Nothing happens.",
-              "effect": {
-                "type": "nothing"
-              }
-            },
-            {
-              "label": "Leave an offering",
-              "consequence": "Something drains your offering — lose 5 HP",
-              "effect": {
-                "type": "damageHp",
-                "amount": 5
-              }
-            },
-            {
-              "label": "Leave an offering",
-              "consequence": "Something small materialises at the altar's base — added to inventory",
-              "effect": {
-                "type": "gainItem"
-              }
-            },
-            {
-              "label": "Leave an offering",
-              "consequence": "The shrine blesses you with renewed fortune — +1 life",
-              "effect": {
-                "type": "gainLife",
-                "amount": 1
-              }
-            }
-          ],
-          [
-            {
-              "label": "Pray for strength",
-              "consequence": "A card materialises from the glow — uncommon",
-              "effect": {
-                "type": "gainCard",
-                "rarity": "uncommon"
-              }
-            },
-            {
-              "label": "Pray for strength",
-              "consequence": "The magic guides your wounds — restored 8 HP",
-              "effect": {
-                "type": "healHp",
-                "amount": 8
-              }
-            },
-            {
-              "label": "Pray for strength",
-              "consequence": "The shrine tests you — lose 10 HP",
-              "effect": {
-                "type": "damageHp",
-                "amount": 10
-              }
-            },
-            {
-              "label": "Pray for strength",
-              "consequence": "You feel oddly lucky — +20 crystals",
-              "effect": {
-                "type": "gainCrystals",
-                "amount": 20
-              }
-            },
-            {
-              "label": "Pray for strength",
-              "consequence": "Something small and inexplicable materialises in your palm — added to inventory",
-              "effect": {
-                "type": "gainItem"
-              }
-            },
-            {
-              "label": "Pray for strength",
-              "consequence": "A strange object appears in your hand from nowhere — added to inventory",
-              "effect": {
-                "type": "gainItem"
-              }
-            }
-          ],
-          [
-            {
-              "label": "Pocket the ritual stones",
-              "consequence": "You grab them and run — +18 crystals, lose 8 HP",
-              "effect": {
-                "type": "compound",
-                "effects": [
-                  {
-                    "type": "gainCrystals",
-                    "amount": 18
-                  },
-                  {
-                    "type": "damageHp",
-                    "amount": 8
-                  }
-                ]
-              }
-            },
-            {
-              "label": "Pocket the ritual stones",
-              "consequence": "A common card falls from the stones",
-              "effect": {
-                "type": "gainCard",
-                "rarity": "common"
-              }
-            },
-            {
-              "label": "Pocket the ritual stones",
-              "consequence": "The stones crumble to dust. Nothing.",
-              "effect": {
-                "type": "nothing"
-              }
-            },
-            {
-              "label": "Pocket the ritual stones",
-              "consequence": "The shrine curses you — lose 15 HP",
-              "effect": {
-                "type": "damageHp",
-                "amount": 15
-              }
-            },
-            {
-              "label": "Pocket the ritual stones",
-              "consequence": "One of the stones turns out to be something stranger — added to inventory",
-              "effect": {
-                "type": "gainItem"
-              }
-            }
-          ]
-        ]
-      }
+      "fragmentId": "act1-frag-1",
+      "environment": "forest"
     },
     "ambush": {
       "id": "ambush",
-      "type": "event",
-      "label": "The Watching Wood",
-      "description": "Something has been following you since the first road. It steps out of the treeline.",
+      "type": "memory",
+      "label": "Memory Fragment",
+      "description": "The bark of the ancient trees bears faint glyphs — words from before the sealing.",
       "row": 4,
       "col": 1,
       "rowCols": 4,
       "childIds": [
         "deep-crossing"
       ],
-      "environment": "forest",
-      "eventConfig": {
-        "title": "The Watching Wood",
-        "description": "A great creature steps from the treeline. Not hostile — not yet. It tilts its head and watches you with ancient, patient eyes.",
-        "pools": [
-          [
-            {
-              "label": "Stand your ground",
-              "consequence": "It respects the stillness — +15 crystals from its abandoned cache",
-              "effect": {
-                "type": "gainCrystals",
-                "amount": 15
-              }
-            },
-            {
-              "label": "Stand your ground",
-              "consequence": "It steps forward and presses something into your hand — added to inventory",
-              "effect": {
-                "type": "gainItem"
-              }
-            },
-            {
-              "label": "Stand your ground",
-              "consequence": "It growls and charges — lose 12 HP",
-              "effect": {
-                "type": "damageHp",
-                "amount": 12
-              }
-            },
-            {
-              "label": "Stand your ground",
-              "consequence": "It holds your gaze for a long moment, then turns and vanishes.",
-              "effect": {
-                "type": "nothing"
-              }
-            },
-            {
-              "label": "Stand your ground",
-              "consequence": "Something in its posture says: not today — restored 10 HP",
-              "effect": {
-                "type": "healHp",
-                "amount": 10
-              }
-            }
-          ],
-          [
-            {
-              "label": "Offer it food",
-              "consequence": "It takes your offering gently — restored 12 HP",
-              "effect": {
-                "type": "healHp",
-                "amount": 12
-              }
-            },
-            {
-              "label": "Offer it food",
-              "consequence": "It sniffs and drops an uncommon card at your feet",
-              "effect": {
-                "type": "gainCard",
-                "rarity": "uncommon"
-              }
-            },
-            {
-              "label": "Offer it food",
-              "consequence": "It takes the food and leaves. Nothing else.",
-              "effect": {
-                "type": "nothing"
-              }
-            },
-            {
-              "label": "Offer it food",
-              "consequence": "It lashes out — lose 8 HP",
-              "effect": {
-                "type": "damageHp",
-                "amount": 8
-              }
-            },
-            {
-              "label": "Offer it food",
-              "consequence": "It drops something from its mouth — a common card",
-              "effect": {
-                "type": "gainCard",
-                "rarity": "common"
-              }
-            }
-          ],
-          [
-            {
-              "label": "Back away slowly",
-              "consequence": "It lets you go — nothing happens",
-              "effect": {
-                "type": "nothing"
-              }
-            },
-            {
-              "label": "Back away slowly",
-              "consequence": "It follows you to the edge of its territory and leaves a crystal cache — +12 crystals",
-              "effect": {
-                "type": "gainCrystals",
-                "amount": 12
-              }
-            },
-            {
-              "label": "Back away slowly",
-              "consequence": "It pounces — lose 15 HP",
-              "effect": {
-                "type": "damageHp",
-                "amount": 15
-              }
-            },
-            {
-              "label": "Back away slowly",
-              "consequence": "You find something in the grass as you retreat — added to inventory",
-              "effect": {
-                "type": "gainItem"
-              }
-            },
-            {
-              "label": "Back away slowly",
-              "consequence": "It watches you leave and seems almost disappointed — restored 6 HP",
-              "effect": {
-                "type": "healHp",
-                "amount": 6
-              }
-            }
-          ]
-        ]
-      }
+      "fragmentId": "act1-frag-2",
+      "environment": "forest"
     },
     "ruins": {
       "id": "ruins",

--- a/web/src/data/acts/act1.json
+++ b/web/src/data/acts/act1.json
@@ -43,7 +43,7 @@
     {
       "title": "THE FRACTURE",
       "image": "cutscenes/act1-intro-1.svg",
-      "text": "Three years ago, the Grand Dominion shattered.\n\nNot in war. Not gradually. In a single catastrophic instant — a magical detonation the scholars call the Fracture Event. The realm split into isolated shards, each one sealed behind walls of warped space and collapsed ley lines.\n\nNobody knows who caused it. Nobody knows how to undo it."
+      "text": "Three years ago, the Grand Dominion shattered.\n\nNot in war. Not gradually. In a single catastrophic instant \u2014 a magical detonation the scholars call the Fracture Event. The realm split into isolated shards, each one sealed behind walls of warped space and collapsed ley lines.\n\nNobody knows who caused it. Nobody knows how to undo it."
     },
     {
       "title": "THE WANDERER",
@@ -53,19 +53,19 @@
     {
       "title": "THE VERDANT SHARD",
       "image": "cutscenes/act1-intro-3.svg",
-      "text": "Your compass points to the nearest reachable shard — a dense, ancient forest realm that has grown wild and hostile since the Fracture closed its borders.\n\nThe shard's guardian, a being called the Thornlord, has sealed its internal pathways. Local traders say he was old before the Dominion was founded.\n\nLocal traders also say he hasn't spoken to anyone in forty years. You're choosing to interpret that as optimistically as possible."
+      "text": "Your compass points to the nearest reachable shard \u2014 a dense, ancient forest realm that has grown wild and hostile since the Fracture closed its borders.\n\nThe shard's guardian, a being called the Thornlord, has sealed its internal pathways. Local traders say he was old before the Dominion was founded.\n\nLocal traders also say he hasn't spoken to anyone in forty years. You're choosing to interpret that as optimistically as possible."
     },
     {
       "title": "YOUR MISSION",
       "image": "cutscenes/act1-intro-4.svg",
-      "text": "Break through the shard. Reach the Thornlord. Defeat him. Earn passage.\n\nTake whatever cards and crystals you can carry out the other side — your collection grows with every run, your mastery deepens, and somewhere in the Fractured Core the answer to all of this is waiting.\n\nProbably."
+      "text": "Break through the shard. Reach the Thornlord. Defeat him. Earn passage.\n\nTake whatever cards and crystals you can carry out the other side \u2014 your collection grows with every run, your mastery deepens, and somewhere in the Fractured Core the answer to all of this is waiting.\n\nProbably."
     }
   ],
   "outro": [
     {
       "title": "THE THORNLORD FALLS",
       "image": "cutscenes/act1-outro-1.svg",
-      "text": "The ancient guardian crumples. Roots unravel. Bark splits along fracture lines older than the Dominion.\n\nFor a moment the whole forest holds its breath — then it exhales. The sealed pathways glow faintly and open like doors that have been waiting for exactly this."
+      "text": "The ancient guardian crumples. Roots unravel. Bark splits along fracture lines older than the Dominion.\n\nFor a moment the whole forest holds its breath \u2014 then it exhales. The sealed pathways glow faintly and open like doors that have been waiting for exactly this."
     },
     {
       "title": "WHAT HE WAS",
@@ -75,7 +75,7 @@
     {
       "title": "THE ROAD AHEAD",
       "image": "cutscenes/act1-outro-3.svg",
-      "text": "One shard cleared. The ley lines pulse — faint, but connected.\n\nYour deck returns to its bones. Your collection carries forward. Somewhere beyond the Verdant Shard, the Iron Citadel waits — and whoever controls it will not be glad to see you.\n\nGood."
+      "text": "One shard cleared. The ley lines pulse \u2014 faint, but connected.\n\nYour deck returns to its bones. Your collection carries forward. Somewhere beyond the Verdant Shard, the Iron Citadel waits \u2014 and whoever controls it will not be glad to see you.\n\nGood."
     }
   ],
   "variantPools": {
@@ -84,7 +84,7 @@
       "Now, technically, a free agent.",
       "Now, effectively, between employers.",
       "Now, in the administrative sense, without portfolio.",
-      "Now — if you were being generous — on sabbatical."
+      "Now \u2014 if you were being generous \u2014 on sabbatical."
     ],
     "jarvIntros": [
       "You have a deck of cards, a vague sense of mission, and the navigational instincts of someone who has been lost before and considers it acceptable.",
@@ -94,10 +94,10 @@
       "You have a deck of cards. You always have a deck of cards. That, at least, has been consistent."
     ],
     "forestDesc": [
-      "Your compass points to the nearest reachable shard — a dense, ancient forest realm that has grown wild and hostile since the Fracture closed its borders.",
-      "Your compass points to the Verdant Shard — a place that smells of pine resin and old magic, where the trees remember things the people forgot.",
+      "Your compass points to the nearest reachable shard \u2014 a dense, ancient forest realm that has grown wild and hostile since the Fracture closed its borders.",
+      "Your compass points to the Verdant Shard \u2014 a place that smells of pine resin and old magic, where the trees remember things the people forgot.",
       "Your compass points toward the Verdant Shard. The forest ahead is old enough to have opinions about you.",
-      "The Verdant Shard pulses at the edge of your compass bearing — a realm of old growth and older grudges, sealed since the Fracture."
+      "The Verdant Shard pulses at the edge of your compass bearing \u2014 a realm of old growth and older grudges, sealed since the Fracture."
     ],
     "thornlordDesc": [
       "The shard's guardian, a being called the Thornlord, has sealed its internal pathways. Local traders say he was old before the Dominion was founded.\n\nLocal traders also say he hasn't spoken to anyone in forty years. You're choosing to interpret that as optimistically as possible.",
@@ -106,16 +106,16 @@
       "The Thornlord seals every path through the Verdant Shard. Traders who've survived say he is patient, thorough, and has never once reconsidered a decision.\n\nYou have a plan. You've had plans before."
     ],
     "priorRunSummaries": [
-      "The path felt familiar — the way a dream feels familiar, just before it turns wrong.",
+      "The path felt familiar \u2014 the way a dream feels familiar, just before it turns wrong.",
       "You stepped into the Verdant Shard with the uneasy sense that you'd stepped here before. You pushed the feeling aside. There was work to do.",
-      "Something about the first battle. The angle of the light. The particular way the Goblins charged. A déjà vu so precise it was almost a memory.",
+      "Something about the first battle. The angle of the light. The particular way the Goblins charged. A d\u00e9j\u00e0 vu so precise it was almost a memory.",
       "The forest seemed quieter than it should have been. As though it recognised you, and was deciding whether to be pleased about it."
     ],
     "priorRunOpenings": [
-      "You remember — and here is the strange part — getting this far before. Not the same choices. But the same road.",
+      "You remember \u2014 and here is the strange part \u2014 getting this far before. Not the same choices. But the same road.",
       "The scholar on the boulder didn't look up when you approached. 'Again?' he said. 'You're ahead of schedule.'",
       "The Thornlord, when you finally stood before him, was already watching you. As though he had been expecting you. As though he had been expecting this for some time.",
-      "The goblins at the first barricade looked familiar. Not familiar the way people are familiar — familiar the way furniture in a childhood home is familiar. Something about the arrangement of them."
+      "The goblins at the first barricade looked familiar. Not familiar the way people are familiar \u2014 familiar the way furniture in a childhood home is familiar. Something about the arrangement of them."
     ],
     "milestoneOpenings5": [
       "The fifth time through the Verdant Shard, a bird called out your name. That was new.",
@@ -143,7 +143,7 @@
     "{n} campaigns in. The goblins at the first barricade have started placing bets on how quickly you'll get past them.",
     "{n} times you've stood at this shard's edge. The trees have started leaning away slightly when you approach.",
     "Run {n}. You walk in before dawn, which is new. Everything else is exactly as you left it.",
-    "The {ordinalLower} attempt. You recognise the smell now. Damp bark and old magic and something else — familiarity.",
+    "The {ordinalLower} attempt. You recognise the smell now. Damp bark and old magic and something else \u2014 familiarity.",
     "{n} campaigns. The Wandering Scholar has started making tea before you arrive. He knows the timing by heart."
   ],
   "introRules": [
@@ -344,7 +344,7 @@
         },
         {
           "title": "A FEELING",
-          "text": "And yet — {pool:priorRunOpenings:0}\n\nYou push the feeling aside. You've always pushed the feeling aside.\n\nThat's how you dreamt it happened, as you step out into the battlefield for the first time."
+          "text": "And yet \u2014 {pool:priorRunOpenings:0}\n\nYou push the feeling aside. You've always pushed the feeling aside.\n\nThat's how you dreamt it happened, as you step out into the battlefield for the first time."
         }
       ]
     }
@@ -454,27 +454,149 @@
         "description": "Buried deep in moss and roots, an ancient shrine pulses with faint magic. Carved glyphs glow a dim green. Something still listens here.",
         "pools": [
           [
-            {"label": "Leave an offering", "consequence": "The shrine accepts your gift — restored 12 HP", "effect": {"type": "healHp", "amount": 12}},
-            {"label": "Leave an offering", "consequence": "The glow brightens — +15 crystals", "effect": {"type": "gainCrystals", "amount": 15}},
-            {"label": "Leave an offering", "consequence": "The shrine is silent. Nothing happens.", "effect": {"type": "nothing"}},
-            {"label": "Leave an offering", "consequence": "Something drains your offering — lose 5 HP", "effect": {"type": "damageHp", "amount": 5}},
-            {"label": "Leave an offering", "consequence": "Something small materialises at the altar's base — added to inventory", "effect": {"type": "gainItem"}},
-            {"label": "Leave an offering", "consequence": "The shrine blesses you with renewed fortune — +1 life", "effect": {"type": "gainLife", "amount": 1}}
+            {
+              "label": "Leave an offering",
+              "consequence": "The shrine accepts your gift \u2014 restored 12 HP",
+              "effect": {
+                "type": "healHp",
+                "amount": 12
+              }
+            },
+            {
+              "label": "Leave an offering",
+              "consequence": "The glow brightens \u2014 +15 crystals",
+              "effect": {
+                "type": "gainCrystals",
+                "amount": 15
+              }
+            },
+            {
+              "label": "Leave an offering",
+              "consequence": "The shrine is silent. Nothing happens.",
+              "effect": {
+                "type": "nothing"
+              }
+            },
+            {
+              "label": "Leave an offering",
+              "consequence": "Something drains your offering \u2014 lose 5 HP",
+              "effect": {
+                "type": "damageHp",
+                "amount": 5
+              }
+            },
+            {
+              "label": "Leave an offering",
+              "consequence": "Something small materialises at the altar's base \u2014 added to inventory",
+              "effect": {
+                "type": "gainItem"
+              }
+            },
+            {
+              "label": "Leave an offering",
+              "consequence": "The shrine blesses you with renewed fortune \u2014 +1 life",
+              "effect": {
+                "type": "gainLife",
+                "amount": 1
+              }
+            }
           ],
           [
-            {"label": "Pray for strength", "consequence": "A card materialises from the glow — uncommon", "effect": {"type": "gainCard", "rarity": "uncommon"}},
-            {"label": "Pray for strength", "consequence": "The magic guides your wounds — restored 8 HP", "effect": {"type": "healHp", "amount": 8}},
-            {"label": "Pray for strength", "consequence": "The shrine tests you — lose 10 HP", "effect": {"type": "damageHp", "amount": 10}},
-            {"label": "Pray for strength", "consequence": "You feel oddly lucky — +20 crystals", "effect": {"type": "gainCrystals", "amount": 20}},
-            {"label": "Pray for strength", "consequence": "Something small and inexplicable materialises in your palm — added to inventory", "effect": {"type": "gainItem"}},
-            {"label": "Pray for strength", "consequence": "A strange object appears in your hand from nowhere — added to inventory", "effect": {"type": "gainItem"}}
+            {
+              "label": "Pray for strength",
+              "consequence": "A card materialises from the glow \u2014 uncommon",
+              "effect": {
+                "type": "gainCard",
+                "rarity": "uncommon"
+              }
+            },
+            {
+              "label": "Pray for strength",
+              "consequence": "The magic guides your wounds \u2014 restored 8 HP",
+              "effect": {
+                "type": "healHp",
+                "amount": 8
+              }
+            },
+            {
+              "label": "Pray for strength",
+              "consequence": "The shrine tests you \u2014 lose 10 HP",
+              "effect": {
+                "type": "damageHp",
+                "amount": 10
+              }
+            },
+            {
+              "label": "Pray for strength",
+              "consequence": "You feel oddly lucky \u2014 +20 crystals",
+              "effect": {
+                "type": "gainCrystals",
+                "amount": 20
+              }
+            },
+            {
+              "label": "Pray for strength",
+              "consequence": "Something small and inexplicable materialises in your palm \u2014 added to inventory",
+              "effect": {
+                "type": "gainItem"
+              }
+            },
+            {
+              "label": "Pray for strength",
+              "consequence": "A strange object appears in your hand from nowhere \u2014 added to inventory",
+              "effect": {
+                "type": "gainItem"
+              }
+            }
           ],
           [
-            {"label": "Pocket the ritual stones", "consequence": "You grab them and run — +18 crystals, lose 8 HP", "effect": {"type": "compound", "effects": [{"type": "gainCrystals", "amount": 18}, {"type": "damageHp", "amount": 8}]}},
-            {"label": "Pocket the ritual stones", "consequence": "A common card falls from the stones", "effect": {"type": "gainCard", "rarity": "common"}},
-            {"label": "Pocket the ritual stones", "consequence": "The stones crumble to dust. Nothing.", "effect": {"type": "nothing"}},
-            {"label": "Pocket the ritual stones", "consequence": "The shrine curses you — lose 15 HP", "effect": {"type": "damageHp", "amount": 15}},
-            {"label": "Pocket the ritual stones", "consequence": "One of the stones turns out to be something stranger — added to inventory", "effect": {"type": "gainItem"}}
+            {
+              "label": "Pocket the ritual stones",
+              "consequence": "You grab them and run \u2014 +18 crystals, lose 8 HP",
+              "effect": {
+                "type": "compound",
+                "effects": [
+                  {
+                    "type": "gainCrystals",
+                    "amount": 18
+                  },
+                  {
+                    "type": "damageHp",
+                    "amount": 8
+                  }
+                ]
+              }
+            },
+            {
+              "label": "Pocket the ritual stones",
+              "consequence": "A common card falls from the stones",
+              "effect": {
+                "type": "gainCard",
+                "rarity": "common"
+              }
+            },
+            {
+              "label": "Pocket the ritual stones",
+              "consequence": "The stones crumble to dust. Nothing.",
+              "effect": {
+                "type": "nothing"
+              }
+            },
+            {
+              "label": "Pocket the ritual stones",
+              "consequence": "The shrine curses you \u2014 lose 15 HP",
+              "effect": {
+                "type": "damageHp",
+                "amount": 15
+              }
+            },
+            {
+              "label": "Pocket the ritual stones",
+              "consequence": "One of the stones turns out to be something stranger \u2014 added to inventory",
+              "effect": {
+                "type": "gainItem"
+              }
+            }
           ]
         ]
       }
@@ -488,33 +610,134 @@
       "col": 1,
       "rowCols": 4,
       "childIds": [
-        "deep-crossing"
+        "deep-crossing",
+        "mem-act1-2"
       ],
       "environment": "forest",
       "eventConfig": {
         "title": "The Watching Wood",
-        "description": "A great creature steps from the treeline. Not hostile — not yet. It tilts its head and watches you with ancient, patient eyes.",
+        "description": "A great creature steps from the treeline. Not hostile \u2014 not yet. It tilts its head and watches you with ancient, patient eyes.",
         "pools": [
           [
-            {"label": "Stand your ground", "consequence": "It respects the stillness — +15 crystals from its abandoned cache", "effect": {"type": "gainCrystals", "amount": 15}},
-            {"label": "Stand your ground", "consequence": "It steps forward and presses something into your hand — added to inventory", "effect": {"type": "gainItem"}},
-            {"label": "Stand your ground", "consequence": "It growls and charges — lose 12 HP", "effect": {"type": "damageHp", "amount": 12}},
-            {"label": "Stand your ground", "consequence": "It holds your gaze for a long moment, then turns and vanishes.", "effect": {"type": "nothing"}},
-            {"label": "Stand your ground", "consequence": "Something in its posture says: not today — restored 10 HP", "effect": {"type": "healHp", "amount": 10}}
+            {
+              "label": "Stand your ground",
+              "consequence": "It respects the stillness \u2014 +15 crystals from its abandoned cache",
+              "effect": {
+                "type": "gainCrystals",
+                "amount": 15
+              }
+            },
+            {
+              "label": "Stand your ground",
+              "consequence": "It steps forward and presses something into your hand \u2014 added to inventory",
+              "effect": {
+                "type": "gainItem"
+              }
+            },
+            {
+              "label": "Stand your ground",
+              "consequence": "It growls and charges \u2014 lose 12 HP",
+              "effect": {
+                "type": "damageHp",
+                "amount": 12
+              }
+            },
+            {
+              "label": "Stand your ground",
+              "consequence": "It holds your gaze for a long moment, then turns and vanishes.",
+              "effect": {
+                "type": "nothing"
+              }
+            },
+            {
+              "label": "Stand your ground",
+              "consequence": "Something in its posture says: not today \u2014 restored 10 HP",
+              "effect": {
+                "type": "healHp",
+                "amount": 10
+              }
+            }
           ],
           [
-            {"label": "Offer it food", "consequence": "It takes your offering gently — restored 12 HP", "effect": {"type": "healHp", "amount": 12}},
-            {"label": "Offer it food", "consequence": "It sniffs and drops an uncommon card at your feet", "effect": {"type": "gainCard", "rarity": "uncommon"}},
-            {"label": "Offer it food", "consequence": "It takes the food and leaves. Nothing else.", "effect": {"type": "nothing"}},
-            {"label": "Offer it food", "consequence": "It lashes out — lose 8 HP", "effect": {"type": "damageHp", "amount": 8}},
-            {"label": "Offer it food", "consequence": "It drops something from its mouth — a common card", "effect": {"type": "gainCard", "rarity": "common"}}
+            {
+              "label": "Offer it food",
+              "consequence": "It takes your offering gently \u2014 restored 12 HP",
+              "effect": {
+                "type": "healHp",
+                "amount": 12
+              }
+            },
+            {
+              "label": "Offer it food",
+              "consequence": "It sniffs and drops an uncommon card at your feet",
+              "effect": {
+                "type": "gainCard",
+                "rarity": "uncommon"
+              }
+            },
+            {
+              "label": "Offer it food",
+              "consequence": "It takes the food and leaves. Nothing else.",
+              "effect": {
+                "type": "nothing"
+              }
+            },
+            {
+              "label": "Offer it food",
+              "consequence": "It lashes out \u2014 lose 8 HP",
+              "effect": {
+                "type": "damageHp",
+                "amount": 8
+              }
+            },
+            {
+              "label": "Offer it food",
+              "consequence": "It drops something from its mouth \u2014 a common card",
+              "effect": {
+                "type": "gainCard",
+                "rarity": "common"
+              }
+            }
           ],
           [
-            {"label": "Back away slowly", "consequence": "It lets you go — nothing happens", "effect": {"type": "nothing"}},
-            {"label": "Back away slowly", "consequence": "It follows you to the edge of its territory and leaves a crystal cache — +12 crystals", "effect": {"type": "gainCrystals", "amount": 12}},
-            {"label": "Back away slowly", "consequence": "It pounces — lose 15 HP", "effect": {"type": "damageHp", "amount": 15}},
-            {"label": "Back away slowly", "consequence": "You find something in the grass as you retreat — added to inventory", "effect": {"type": "gainItem"}},
-            {"label": "Back away slowly", "consequence": "It watches you leave and seems almost disappointed — restored 6 HP", "effect": {"type": "healHp", "amount": 6}}
+            {
+              "label": "Back away slowly",
+              "consequence": "It lets you go \u2014 nothing happens",
+              "effect": {
+                "type": "nothing"
+              }
+            },
+            {
+              "label": "Back away slowly",
+              "consequence": "It follows you to the edge of its territory and leaves a crystal cache \u2014 +12 crystals",
+              "effect": {
+                "type": "gainCrystals",
+                "amount": 12
+              }
+            },
+            {
+              "label": "Back away slowly",
+              "consequence": "It pounces \u2014 lose 15 HP",
+              "effect": {
+                "type": "damageHp",
+                "amount": 15
+              }
+            },
+            {
+              "label": "Back away slowly",
+              "consequence": "You find something in the grass as you retreat \u2014 added to inventory",
+              "effect": {
+                "type": "gainItem"
+              }
+            },
+            {
+              "label": "Back away slowly",
+              "consequence": "It watches you leave and seems almost disappointed \u2014 restored 6 HP",
+              "effect": {
+                "type": "healHp",
+                "amount": 6
+              }
+            }
           ]
         ]
       }
@@ -538,7 +761,7 @@
           [
             {
               "label": "Rest in the shelter",
-              "consequence": "The quiet heals — restored 15 HP",
+              "consequence": "The quiet heals \u2014 restored 15 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 15
@@ -554,7 +777,7 @@
             },
             {
               "label": "Rest in the shelter",
-              "consequence": "Something bites you in the night — lose 6 HP",
+              "consequence": "Something bites you in the night \u2014 lose 6 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 6
@@ -562,7 +785,7 @@
             },
             {
               "label": "Rest in the shelter",
-              "consequence": "You find a pouch under the floorboards — +14 crystals",
+              "consequence": "You find a pouch under the floorboards \u2014 +14 crystals",
               "effect": {
                 "type": "gainCrystals",
                 "amount": 14
@@ -570,14 +793,14 @@
             },
             {
               "label": "Rest in the shelter",
-              "consequence": "You wake to find a small curiosity beside you — added to inventory",
+              "consequence": "You wake to find a small curiosity beside you \u2014 added to inventory",
               "effect": {
                 "type": "gainItem"
               }
             },
             {
               "label": "Rest in the shelter",
-              "consequence": "Something rolls under your hand in the dark — added to inventory",
+              "consequence": "Something rolls under your hand in the dark \u2014 added to inventory",
               "effect": {
                 "type": "gainItem"
               }
@@ -594,7 +817,7 @@
             },
             {
               "label": "Search the armory",
-              "consequence": "A rare weapon contract — add a rare card",
+              "consequence": "A rare weapon contract \u2014 add a rare card",
               "effect": {
                 "type": "gainCard",
                 "rarity": "rare"
@@ -602,7 +825,7 @@
             },
             {
               "label": "Search the armory",
-              "consequence": "Old coin cache — +20 crystals",
+              "consequence": "Old coin cache \u2014 +20 crystals",
               "effect": {
                 "type": "gainCrystals",
                 "amount": 20
@@ -610,7 +833,7 @@
             },
             {
               "label": "Search the armory",
-              "consequence": "A rusted trap springs — lose 10 HP",
+              "consequence": "A rusted trap springs \u2014 lose 10 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 10
@@ -618,14 +841,14 @@
             },
             {
               "label": "Search the armory",
-              "consequence": "You find a curious object among the debris — added to inventory",
+              "consequence": "You find a curious object among the debris \u2014 added to inventory",
               "effect": {
                 "type": "gainItem"
               }
             },
             {
               "label": "Search the armory",
-              "consequence": "Something rolls out of the rubble — added to inventory",
+              "consequence": "Something rolls out of the rubble \u2014 added to inventory",
               "effect": {
                 "type": "gainItem"
               }
@@ -634,7 +857,7 @@
           [
             {
               "label": "Climb the watchtower",
-              "consequence": "Good vantage point — +12 crystals from spotted supply cache",
+              "consequence": "Good vantage point \u2014 +12 crystals from spotted supply cache",
               "effect": {
                 "type": "gainCrystals",
                 "amount": 12
@@ -650,7 +873,7 @@
             },
             {
               "label": "Climb the watchtower",
-              "consequence": "The stairs collapse — lose 12 HP",
+              "consequence": "The stairs collapse \u2014 lose 12 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 12
@@ -665,14 +888,14 @@
             },
             {
               "label": "Climb the watchtower",
-              "consequence": "Something is jammed in the bell — you pocket it — added to inventory",
+              "consequence": "Something is jammed in the bell \u2014 you pocket it \u2014 added to inventory",
               "effect": {
                 "type": "gainItem"
               }
             },
             {
               "label": "Climb the watchtower",
-              "consequence": "You spot a hidden passage to a safe camp below — +1 life",
+              "consequence": "You spot a hidden passage to a safe camp below \u2014 +1 life",
               "effect": {
                 "type": "gainLife",
                 "amount": 1
@@ -726,7 +949,7 @@
       "id": "captain",
       "type": "elite",
       "label": "Forest Captain",
-      "description": "A hardened veteran with well-drilled siege troops — and something the forest has been teaching him about patience.",
+      "description": "A hardened veteran with well-drilled siege troops \u2014 and something the forest has been teaching him about patience.",
       "row": 3,
       "col": 0,
       "rowCols": 3,
@@ -841,13 +1064,13 @@
       "bossName": "The Thornlord",
       "bossIntro": [
         {
-          "title": "ACT I — BOSS",
-          "text": "The path narrows. Ancient roots close behind you like fingers. The trees here have not seen sunlight in centuries — they have no need of it.\n\nSomething ahead breathes. Slowly. Like a forest exhaling.",
+          "title": "ACT I \u2014 BOSS",
+          "text": "The path narrows. Ancient roots close behind you like fingers. The trees here have not seen sunlight in centuries \u2014 they have no need of it.\n\nSomething ahead breathes. Slowly. Like a forest exhaling.",
           "image": "cutscenes/act1-boss-1.svg"
         },
         {
-          "title": "ACT I — BOSS",
-          "text": "The Thornlord does not move toward you. He does not need to.\n\nHe has been standing in this clearing since before the Dominion was built. His eyes open — two cold lights in a face of bark and centuries.\n\nHe is watching you the way a tree watches an axe.",
+          "title": "ACT I \u2014 BOSS",
+          "text": "The Thornlord does not move toward you. He does not need to.\n\nHe has been standing in this clearing since before the Dominion was built. His eyes open \u2014 two cold lights in a face of bark and centuries.\n\nHe is watching you the way a tree watches an axe.",
           "image": "cutscenes/act1-boss-2.svg"
         }
       ],
@@ -886,7 +1109,7 @@
       "description": "A collapsed stone bridge over a dark ravine. Something is defending it.",
       "row": 5,
       "col": 0,
-      "rowCols": 2,
+      "rowCols": 3,
       "childIds": [
         "thornlord"
       ],
@@ -917,7 +1140,8 @@
       "col": 2,
       "rowCols": 4,
       "childIds": [
-        "captain"
+        "captain",
+        "mem-act1-1"
       ],
       "enemyDeck": [
         "Goblin",
@@ -964,18 +1188,46 @@
       "fragmentId": "act1-frag-3",
       "environment": "forest"
     },
+    "mem-act1-1": {
+      "id": "mem-act1-1",
+      "type": "memory",
+      "label": "Memory Fragment",
+      "description": "A soldier's carved initials on a tree \u2014 the forest has grown over the name, but not the grief.",
+      "row": 3,
+      "col": 2,
+      "rowCols": 3,
+      "childIds": [
+        "war-camp"
+      ],
+      "fragmentId": "act1-frag-1",
+      "environment": "forest"
+    },
     "mem-root-memory": {
       "id": "mem-root-memory",
       "type": "memory",
       "label": "Memory Fragment",
-      "description": "Deep roots hold something older than the Thornlord — a fragment of the shard before it was sealed.",
+      "description": "Deep roots hold something older than the Thornlord \u2014 a fragment of the shard before it was sealed.",
       "row": 5,
       "col": 1,
-      "rowCols": 2,
+      "rowCols": 3,
       "childIds": [
         "thornlord"
       ],
       "fragmentId": "act1-frag-4",
+      "environment": "forest"
+    },
+    "mem-act1-2": {
+      "id": "mem-act1-2",
+      "type": "memory",
+      "label": "Memory Fragment",
+      "description": "The bridge remembers what crossed it before the Fracture sealed the roads \u2014 a fragment pressed into the stone.",
+      "row": 5,
+      "col": 2,
+      "rowCols": 3,
+      "childIds": [
+        "thornlord"
+      ],
+      "fragmentId": "act1-frag-2",
       "environment": "forest"
     }
   },

--- a/web/src/data/acts/act2.json
+++ b/web/src/data/acts/act2.json
@@ -397,143 +397,17 @@
     },
     "supply-cache": {
       "id": "supply-cache",
-      "type": "event",
-      "label": "Supply Cache",
-      "description": "A Citadel supply depot, hastily abandoned. The lock is already broken.",
+      "type": "memory",
+      "label": "Memory Fragment",
+      "description": "A military dispatch case, rusted shut — something inside has outlasted the soldiers who left it.",
       "row": 2,
       "col": 0,
       "rowCols": 4,
       "childIds": [
         "iron-guard"
       ],
-      "environment": "citadel",
-      "eventConfig": {
-        "title": "Supply Cache",
-        "description": "A Citadel supply depot, hastily abandoned. Crates lie open and torn sacks spill their contents.",
-        "pools": [
-          [
-            {
-              "label": "Search the crates",
-              "consequence": "+15 crystals from scavenged supplies",
-              "effect": {
-                "type": "gainCrystals",
-                "amount": 15
-              }
-            },
-            {
-              "label": "Search the crates",
-              "consequence": "A trap springs — lose 8 HP",
-              "effect": {
-                "type": "damageHp",
-                "amount": 8
-              }
-            },
-            {
-              "label": "Search the crates",
-              "consequence": "A common card wedged under packing material",
-              "effect": {
-                "type": "gainCard",
-                "rarity": "common"
-              }
-            },
-            {
-              "label": "Search the crates",
-              "consequence": "The crates are empty. Someone got here first.",
-              "effect": {
-                "type": "nothing"
-              }
-            },
-            {
-              "label": "Search the crates",
-              "consequence": "Restored 10 HP from emergency rations",
-              "effect": {
-                "type": "healHp",
-                "amount": 10
-              }
-            },
-            {
-              "label": "Search the crates",
-              "consequence": "Something rolls out of the straw packing — added to inventory",
-              "effect": {
-                "type": "gainItem"
-              }
-            }
-          ],
-          [
-            {
-              "label": "Pocket something useful",
-              "consequence": "You find an uncommon card folded in a dispatch pouch",
-              "effect": {
-                "type": "gainCard",
-                "rarity": "uncommon"
-              }
-            },
-            {
-              "label": "Pocket something useful",
-              "consequence": "+20 crystals of scavenged pay-roll coin",
-              "effect": {
-                "type": "gainCrystals",
-                "amount": 20
-              }
-            },
-            {
-              "label": "Pocket something useful",
-              "consequence": "The case is booby-trapped — lose 12 HP",
-              "effect": {
-                "type": "damageHp",
-                "amount": 12
-              }
-            },
-            {
-              "label": "Pocket something useful",
-              "consequence": "A rare card sealed in wax inside an officer's pack",
-              "effect": {
-                "type": "gainCard",
-                "rarity": "rare"
-              }
-            },
-            {
-              "label": "Pocket something useful",
-              "consequence": "Something personal and inexplicable — added to inventory",
-              "effect": {
-                "type": "gainItem"
-              }
-            }
-          ],
-          [
-            {
-              "label": "Leave quickly",
-              "consequence": "You're gone before the patrol returns. Nothing gained.",
-              "effect": {
-                "type": "nothing"
-              }
-            },
-            {
-              "label": "Leave quickly",
-              "consequence": "You trip an alarm on the way out — lose 6 HP",
-              "effect": {
-                "type": "damageHp",
-                "amount": 6
-              }
-            },
-            {
-              "label": "Leave quickly",
-              "consequence": "You spot a coin pouch by the door — +10 crystals",
-              "effect": {
-                "type": "gainCrystals",
-                "amount": 10
-              }
-            },
-            {
-              "label": "Leave quickly",
-              "consequence": "You grab something off a shelf reflexively — added to inventory",
-              "effect": {
-                "type": "gainItem"
-              }
-            }
-          ]
-        ]
-      }
+      "fragmentId": "act2-frag-1",
+      "environment": "citadel"
     },
     "outer-wall": {
       "id": "outer-wall",
@@ -715,137 +589,17 @@
     },
     "war-council": {
       "id": "war-council",
-      "type": "event",
-      "label": "War Council",
-      "description": "A sealed briefing room — the Citadel's last tactical maps still spread across the table, the officers' chairs still warm.",
+      "type": "memory",
+      "label": "Memory Fragment",
+      "description": "The old command table still has markers on it, frozen at the moment the Fracture sealed the roads.",
       "row": 5,
       "col": 1,
       "rowCols": 2,
       "childIds": [
         "citadel-crossing"
       ],
-      "environment": "citadel",
-      "eventConfig": {
-        "title": "The War Council Chamber",
-        "description": "The Citadel's last tactical briefing still covers the table — casualty projections, siege lines, contingency codes. No signature. No date. The officers left in a hurry and didn't come back.",
-        "pools": [
-          [
-            {
-              "label": "Study the tactical maps",
-              "consequence": "You spot an exploitable route ahead. +16 crystals.",
-              "effect": {
-                "type": "gainCrystals",
-                "amount": 16
-              }
-            },
-            {
-              "label": "Study the tactical maps",
-              "consequence": "The maps reveal a supply drop location. +20 crystals.",
-              "effect": {
-                "type": "gainCrystals",
-                "amount": 20
-              }
-            },
-            {
-              "label": "Study the tactical maps",
-              "consequence": "The strategies are outdated — they describe your own deck. Nothing useful.",
-              "effect": {
-                "type": "nothing"
-              }
-            },
-            {
-              "label": "Study the tactical maps",
-              "consequence": "The data is encoded. Hours wasted — lose 6 HP from exhaustion.",
-              "effect": {
-                "type": "damageHp",
-                "amount": 6
-              }
-            }
-          ],
-          [
-            {
-              "label": "Search the officers' packs",
-              "consequence": "Emergency rations. Restored 12 HP.",
-              "effect": {
-                "type": "healHp",
-                "amount": 12
-              }
-            },
-            {
-              "label": "Search the officers' packs",
-              "consequence": "A folded rare card tucked inside a dispatch pouch.",
-              "effect": {
-                "type": "gainCard",
-                "rarity": "rare"
-              }
-            },
-            {
-              "label": "Search the officers' packs",
-              "consequence": "A booby-trap springs — lose 10 HP.",
-              "effect": {
-                "type": "damageHp",
-                "amount": 10
-              }
-            },
-            {
-              "label": "Search the officers' packs",
-              "consequence": "An uncommon card hidden under a false bottom.",
-              "effect": {
-                "type": "gainCard",
-                "rarity": "uncommon"
-              }
-            },
-            {
-              "label": "Search the officers' packs",
-              "consequence": "+1 life — someone left a spare compass. You needed that.",
-              "effect": {
-                "type": "gainLife",
-                "amount": 1
-              }
-            },
-            {
-              "label": "Search the officers' packs",
-              "consequence": "Something personal left behind — added to inventory",
-              "effect": {
-                "type": "gainItem"
-              }
-            }
-          ],
-          [
-            {
-              "label": "Take the classified orders",
-              "consequence": "The enemy codes are yours. +24 crystals on the black market.",
-              "effect": {
-                "type": "gainCrystals",
-                "amount": 24
-              }
-            },
-            {
-              "label": "Take the classified orders",
-              "consequence": "The orders detail a hidden armoury. You find a rare card.",
-              "effect": {
-                "type": "gainCard",
-                "rarity": "rare"
-              }
-            },
-            {
-              "label": "Take the classified orders",
-              "consequence": "The seal breaks and releases a gas. Lose 14 HP.",
-              "effect": {
-                "type": "damageHp",
-                "amount": 14
-              }
-            },
-            {
-              "label": "Take the classified orders",
-              "consequence": "They're blank. Psychological warfare, apparently.",
-              "effect": {
-                "type": "nothing"
-              }
-            }
-          ]
-        ]
-      }
+      "fragmentId": "act2-frag-2",
+      "environment": "citadel"
     },
     "kragg": {
       "id": "kragg",

--- a/web/src/data/acts/act2.json
+++ b/web/src/data/acts/act2.json
@@ -360,7 +360,8 @@
       "rowCols": 1,
       "childIds": [
         "node-1776114717762",
-        "node-1776114718648"
+        "node-1776114718648",
+        "mem-act2-1"
       ],
       "handicap": 7,
       "opponentBaseHp": 100,
@@ -388,7 +389,7 @@
       "description": "An abandoned forward camp — rations still warm. Rest and recover.",
       "row": 3,
       "col": 1,
-      "rowCols": 2,
+      "rowCols": 3,
       "childIds": [
         "siege-captain"
       ],
@@ -397,17 +398,32 @@
     },
     "supply-cache": {
       "id": "supply-cache",
-      "type": "memory",
-      "label": "Memory Fragment",
-      "description": "A military dispatch case, rusted shut — something inside has outlasted the soldiers who left it.",
+      "type": "event",
+      "label": "Abandoned Supply Cache",
+      "description": "A military dispatch case, rusted shut — the garrison left it when they pulled back.",
       "row": 2,
       "col": 0,
       "rowCols": 4,
       "childIds": [
         "iron-guard"
       ],
-      "fragmentId": "act2-frag-1",
-      "environment": "citadel"
+      "environment": "citadel",
+      "eventConfig": {
+        "title": "Garrison Supply Cache",
+        "description": "A sealed iron crate stamped with the Citadel's quartermaster mark. Left in the retreat. Whatever is inside has been waiting for someone with the nerve to open it.",
+        "pools": [
+          [
+            {"label": "Force it open", "consequence": "Iron rations and coin — +20 crystals", "effect": {"type": "gainCrystals", "amount": 20}},
+            {"label": "Force it open", "consequence": "Field medicine inside — restored 15 HP", "effect": {"type": "healHp", "amount": 15}},
+            {"label": "Force it open", "consequence": "A booby trap springs — lose 12 HP", "effect": {"type": "damageHp", "amount": 12}}
+          ],
+          [
+            {"label": "Check the dispatch papers", "consequence": "Tactical documents — an uncommon card falls from the bundle", "effect": {"type": "gainCard", "rarity": "uncommon"}},
+            {"label": "Check the dispatch papers", "consequence": "Something useful wrapped in the orders — added to inventory", "effect": {"type": "gainItem"}},
+            {"label": "Check the dispatch papers", "consequence": "Orders only. Nothing useful.", "effect": {"type": "nothing"}}
+          ]
+        ]
+      }
     },
     "outer-wall": {
       "id": "outer-wall",
@@ -473,7 +489,7 @@
       "description": "Elite heavy infantry protecting the mid-canyon checkpoint.",
       "row": 3,
       "col": 0,
-      "rowCols": 2,
+      "rowCols": 3,
       "childIds": [
         "last-stand"
       ],
@@ -504,7 +520,8 @@
       "col": 3,
       "rowCols": 4,
       "childIds": [
-        "soldiers-camp"
+        "soldiers-camp",
+        "mem-act2-2"
       ],
       "environment": "citadel"
     },
@@ -589,8 +606,8 @@
     },
     "war-council": {
       "id": "war-council",
-      "type": "memory",
-      "label": "Memory Fragment",
+      "type": "event",
+      "label": "The War Council Chamber",
       "description": "The old command table still has markers on it, frozen at the moment the Fracture sealed the roads.",
       "row": 5,
       "col": 1,
@@ -598,8 +615,23 @@
       "childIds": [
         "citadel-crossing"
       ],
-      "fragmentId": "act2-frag-2",
-      "environment": "citadel"
+      "environment": "citadel",
+      "eventConfig": {
+        "title": "The War Council Chamber",
+        "description": "Kragg's inner sanctum. The campaign map is still pinned to the table, markers showing positions from three years ago. Someone was making decisions here when the Fracture hit. The markers are still where they left them.",
+        "pools": [
+          [
+            {"label": "Study the campaign map", "consequence": "You find a tactical advantage — +18 crystals recovered from a hidden drawer", "effect": {"type": "gainCrystals", "amount": 18}},
+            {"label": "Study the campaign map", "consequence": "A rare strategy document — add a rare card", "effect": {"type": "gainCard", "rarity": "rare"}},
+            {"label": "Study the campaign map", "consequence": "Nothing useful. Outdated positions.", "effect": {"type": "nothing"}}
+          ],
+          [
+            {"label": "Search the room", "consequence": "A field medic's kit in the footlocker — restored 14 HP", "effect": {"type": "healHp", "amount": 14}},
+            {"label": "Search the room", "consequence": "Something of value left in the rush — added to inventory", "effect": {"type": "gainItem"}},
+            {"label": "Search the room", "consequence": "The room has already been searched — lose 8 HP from a leftover trap", "effect": {"type": "damageHp", "amount": 8}}
+          ]
+        ]
+      }
     },
     "kragg": {
       "id": "kragg",
@@ -680,7 +712,7 @@
       "description": "The Executioner, known for the sharpness of their axe, stands and watches… his kin stand alongside. Today there will be blood. Maybe yours.",
       "row": 1,
       "col": 0,
-      "rowCols": 2,
+      "rowCols": 3,
       "childIds": [
         "supply-cache",
         "outer-wall"
@@ -706,7 +738,7 @@
       "description": "The reek of death fills the air. The battle hasn’t started yet.",
       "row": 1,
       "col": 1,
-      "rowCols": 2,
+      "rowCols": 3,
       "childIds": [
         "siege-trenches",
         "quartermaster"
@@ -720,6 +752,34 @@
         "Plague Spread",
         "Plague Burrow"
       ]
+    },
+    "mem-act2-1": {
+      "id": "mem-act2-1",
+      "type": "memory",
+      "label": "Memory Fragment",
+      "description": "A signal officer’s last dispatch, never sent — pressed into the canyon wall the day the Fracture sealed the roads.",
+      "row": 1,
+      "col": 2,
+      "rowCols": 3,
+      "childIds": [
+        "supply-cache"
+      ],
+      "fragmentId": "act2-frag-1",
+      "environment": "citadel"
+    },
+    "mem-act2-2": {
+      "id": "mem-act2-2",
+      "type": "memory",
+      "label": "Memory Fragment",
+      "description": "A command tent left exactly as it was — markers still on the map, orders mid-read. The Fracture froze everything in place.",
+      "row": 3,
+      "col": 2,
+      "rowCols": 3,
+      "childIds": [
+        "siege-captain"
+      ],
+      "fragmentId": "act2-frag-2",
+      "environment": "citadel"
     }
   },
   "mapMusicId": "map",

--- a/web/src/data/acts/act3.json
+++ b/web/src/data/acts/act3.json
@@ -388,138 +388,17 @@
     },
     "soul-shrine": {
       "id": "soul-shrine",
-      "type": "event",
-      "label": "Soul Shrine",
-      "description": "A shrine built from miners' tools, wrapped in old smoke. Something in it still listens.",
+      "type": "memory",
+      "label": "Memory Fragment",
+      "description": "Ash-covered field notes, still readable — someone was studying the wastes before they became this.",
       "row": 2,
       "col": 0,
       "rowCols": 3,
       "childIds": [
         "revenant-witch"
       ],
-      "environment": "ruins",
-      "eventConfig": {
-        "title": "The Soul Shrine",
-        "description": "A shrine built from miners' tools — pickaxes crossed at the base, lanterns fused into its flanks with old soot. The flame inside is black. Whatever souls it was built to honour, they haven't left.",
-        "pools": [
-          [
-            {
-              "label": "Leave an offering",
-              "consequence": "The black flame brightens briefly. Restored 14 HP.",
-              "effect": {
-                "type": "healHp",
-                "amount": 14
-              }
-            },
-            {
-              "label": "Leave an offering",
-              "consequence": "Ash coins fall at your feet. +16 crystals.",
-              "effect": {
-                "type": "gainCrystals",
-                "amount": 16
-              }
-            },
-            {
-              "label": "Leave an offering",
-              "consequence": "The flame flickers out and relights. Nothing changes.",
-              "effect": {
-                "type": "nothing"
-              }
-            },
-            {
-              "label": "Leave an offering",
-              "consequence": "The shrine takes more than offered — lose 10 HP.",
-              "effect": {
-                "type": "damageHp",
-                "amount": 10
-              }
-            },
-            {
-              "label": "Leave an offering",
-              "consequence": "A miner's spirit grants you another chance — +1 life.",
-              "effect": {
-                "type": "gainLife",
-                "amount": 1
-              }
-            }
-          ],
-          [
-            {
-              "label": "Speak a name into the smoke",
-              "consequence": "Someone answers. A common card drifts from the flame.",
-              "effect": {
-                "type": "gainCard",
-                "rarity": "common"
-              }
-            },
-            {
-              "label": "Speak a name into the smoke",
-              "consequence": "The smoke carries a warning back. Restored 8 HP.",
-              "effect": {
-                "type": "healHp",
-                "amount": 8
-              }
-            },
-            {
-              "label": "Speak a name into the smoke",
-              "consequence": "The name echoes endlessly. Lose 10 HP from the noise.",
-              "effect": {
-                "type": "damageHp",
-                "amount": 10
-              }
-            },
-            {
-              "label": "Speak a name into the smoke",
-              "consequence": "Ash falls around you like rain. +20 crystals.",
-              "effect": {
-                "type": "gainCrystals",
-                "amount": 20
-              }
-            }
-          ],
-          [
-            {
-              "label": "Reach into the black flame",
-              "consequence": "Cold, not hot. You pull out an uncommon card.",
-              "effect": {
-                "type": "gainCard",
-                "rarity": "uncommon"
-              }
-            },
-            {
-              "label": "Reach into the black flame",
-              "consequence": "It burns after all — lose 16 HP.",
-              "effect": {
-                "type": "damageHp",
-                "amount": 16
-              }
-            },
-            {
-              "label": "Reach into the black flame",
-              "consequence": "You find a rare card waiting inside.",
-              "effect": {
-                "type": "gainCard",
-                "rarity": "rare"
-              }
-            },
-            {
-              "label": "Reach into the black flame",
-              "consequence": "+24 crystals fall from your hand when you pull it free.",
-              "effect": {
-                "type": "gainCrystals",
-                "amount": 24
-              }
-            },
-            {
-              "label": "Reach into the black flame",
-              "consequence": "Something small and cold falls into your palm — added to inventory",
-              "effect": {
-                "type": "gainItem"
-              }
-            }
-          ]
-        ]
-      }
+      "fragmentId": "act3-frag-1",
+      "environment": "ashen"
     },
     "bone-fire": {
       "id": "bone-fire",
@@ -692,137 +571,17 @@
     },
     "cursed-altar": {
       "id": "cursed-altar",
-      "type": "event",
-      "label": "Cursed Altar",
-      "description": "A makeshift altar built from the bones of something large — whatever the Wastes worshipped before the Fracture gave it something better to do.",
+      "type": "memory",
+      "label": "Memory Fragment",
+      "description": "A broken altar stone, its inscription still faintly legible through the char.",
       "row": 4,
       "col": 2,
       "rowCols": 3,
       "childIds": [
         "death-knight"
       ],
-      "environment": "ashen",
-      "eventConfig": {
-        "title": "The Cursed Altar",
-        "description": "A makeshift altar built from the bones of something large — whatever the Wastes worshipped before the Fracture gave it something better to do. Dark ichor seeps between the joints. The altar hums.",
-        "pools": [
-          [
-            {
-              "label": "Make a blood offering",
-              "consequence": "The altar accepts the price. Restored 12 HP, lose 6 HP.",
-              "effect": {
-                "type": "damageHp",
-                "amount": 6
-              }
-            },
-            {
-              "label": "Make a blood offering",
-              "consequence": "Dark energy surges through you — +1 life, lose 8 HP.",
-              "effect": {
-                "type": "damageHp",
-                "amount": 8
-              }
-            },
-            {
-              "label": "Make a blood offering",
-              "consequence": "The altar is satisfied. Restored 18 HP.",
-              "effect": {
-                "type": "healHp",
-                "amount": 18
-              }
-            },
-            {
-              "label": "Make a blood offering",
-              "consequence": "The altar drinks deeply. Lose 20 HP. Worth it? Unclear.",
-              "effect": {
-                "type": "damageHp",
-                "amount": 20
-              }
-            }
-          ],
-          [
-            {
-              "label": "Pray to the bones",
-              "consequence": "A rare card materialises from the dark.",
-              "effect": {
-                "type": "gainCard",
-                "rarity": "rare"
-              }
-            },
-            {
-              "label": "Pray to the bones",
-              "consequence": "The bones rattle an answer. +22 crystals.",
-              "effect": {
-                "type": "gainCrystals",
-                "amount": 22
-              }
-            },
-            {
-              "label": "Pray to the bones",
-              "consequence": "The bones are silent. The hum intensifies. Nothing.",
-              "effect": {
-                "type": "nothing"
-              }
-            },
-            {
-              "label": "Pray to the bones",
-              "consequence": "An uncommon card rises from between the ribs.",
-              "effect": {
-                "type": "gainCard",
-                "rarity": "uncommon"
-              }
-            },
-            {
-              "label": "Pray to the bones",
-              "consequence": "The altar grants you one more chance — +1 life.",
-              "effect": {
-                "type": "gainLife",
-                "amount": 1
-              }
-            },
-            {
-              "label": "Pray to the bones",
-              "consequence": "A bone fragment shifts loose and lands in your hand — added to inventory",
-              "effect": {
-                "type": "gainItem"
-              }
-            }
-          ],
-          [
-            {
-              "label": "Desecrate the altar",
-              "consequence": "The altar shatters — +28 crystals from the gem fragments.",
-              "effect": {
-                "type": "gainCrystals",
-                "amount": 28
-              }
-            },
-            {
-              "label": "Desecrate the altar",
-              "consequence": "A legendary card erupts from the rubble.",
-              "effect": {
-                "type": "gainCard",
-                "rarity": "legendary"
-              }
-            },
-            {
-              "label": "Desecrate the altar",
-              "consequence": "The altar retaliates — lose 22 HP.",
-              "effect": {
-                "type": "damageHp",
-                "amount": 22
-              }
-            },
-            {
-              "label": "Desecrate the altar",
-              "consequence": "It was already ruined. Nothing happens. You feel watched.",
-              "effect": {
-                "type": "nothing"
-              }
-            }
-          ]
-        ]
-      }
+      "fragmentId": "act3-frag-2",
+      "environment": "ashen"
     },
     "death-knight": {
       "id": "death-knight",

--- a/web/src/data/acts/act3.json
+++ b/web/src/data/acts/act3.json
@@ -49,7 +49,7 @@
   "intro": [
     {
       "title": "THE ASHEN WASTES",
-      "text": "Before the Fracture, the Ashen Wastes were a mining region — coal seams, slag heaps, villages built around the work. Ordinary.\n\nThe Fracture hit differently here. The shard didn't just shatter. It burned. And whatever dark energy poured into the gap found the dead an accommodating host.\n\nThe Wastes are not quiet. The Wastes have never been quiet since.",
+      "text": "Before the Fracture, the Ashen Wastes were a mining region \u2014 coal seams, slag heaps, villages built around the work. Ordinary.\n\nThe Fracture hit differently here. The shard didn't just shatter. It burned. And whatever dark energy poured into the gap found the dead an accommodating host.\n\nThe Wastes are not quiet. The Wastes have never been quiet since.",
       "image": "cutscenes/act3-intro-1.svg"
     },
     {
@@ -59,7 +59,7 @@
     },
     {
       "title": "THE ASHEN WASTES",
-      "text": "The shard is a landscape of grey ash and collapsed mineshafts, lit by fires that burn without fuel and voices that carry without wind.\n\nAt its centre, the Ashwalker — a figure that predates the Fracture, that may predate the Dominion itself. It does not rule the Wastes. The Wastes simply organise themselves around it.",
+      "text": "The shard is a landscape of grey ash and collapsed mineshafts, lit by fires that burn without fuel and voices that carry without wind.\n\nAt its centre, the Ashwalker \u2014 a figure that predates the Fracture, that may predate the Dominion itself. It does not rule the Wastes. The Wastes simply organise themselves around it.",
       "image": "cutscenes/act3-intro-3.svg"
     },
     {
@@ -71,7 +71,7 @@
   "outro": [
     {
       "title": "THE ASHES SETTLE",
-      "text": "The Ashwalker collapses inward — not destroyed, exactly. Diminished. The fires that burned without fuel go out one by one.\n\nFor the first time in three years, the Ashen Wastes are quiet. Not silent. Quiet. There is a difference.\n\nYou stand in the ash and wait to see if anything gets back up. Nothing does. You consider this a victory.",
+      "text": "The Ashwalker collapses inward \u2014 not destroyed, exactly. Diminished. The fires that burned without fuel go out one by one.\n\nFor the first time in three years, the Ashen Wastes are quiet. Not silent. Quiet. There is a difference.\n\nYou stand in the ash and wait to see if anything gets back up. Nothing does. You consider this a victory.",
       "image": "cutscenes/act3-outro-1.svg"
     },
     {
@@ -85,7 +85,7 @@
       "Currently, technically, in a place that shouldn't exist.",
       "Professionally speaking, operating outside recommended parameters.",
       "In the occupational sense, doing something the guild specifically warned against.",
-      "Now — by any reasonable safety assessment — somewhere else.",
+      "Now \u2014 by any reasonable safety assessment \u2014 somewhere else.",
       "Technically alive, which puts you in a minority out here."
     ],
     "jarvIntros": [
@@ -96,25 +96,25 @@
       "You have a deck of cards. Something in the ash is watching you. You choose to treat that as an audience."
     ],
     "wastesDesc": [
-      "The Ashen Wastes spread across the shard like a wound that never healed — grey plains dotted with collapsed shafts, burning slag heaps, and the occasional structure that shouldn't still be standing. The silence is the worst part. Not quiet. Silent.",
+      "The Ashen Wastes spread across the shard like a wound that never healed \u2014 grey plains dotted with collapsed shafts, burning slag heaps, and the occasional structure that shouldn't still be standing. The silence is the worst part. Not quiet. Silent.",
       "The Wastes are navigable if you know the routes and avoid the unstable ground. Your map marks both. Your map was also drawn three years ago, before the dead started moving the landmarks.",
-      "Grey ash in every direction, fires that burn cold, and voices that carry meaning without words. The Wastes are not hostile — they are simply indifferent to whether you survive them.",
+      "Grey ash in every direction, fires that burn cold, and voices that carry meaning without words. The Wastes are not hostile \u2014 they are simply indifferent to whether you survive them.",
       "The shard smells of coal and old smoke and something older beneath both. The Wandering Scholar called it 'entropy made ambient.' You call it 'bad.'"
     ],
     "ashwalkerDesc": [
-      "The Ashwalker has no name in any record that predates the Fracture, which suggests it either wasn't important enough to name or was important enough to not name. Neither is reassuring.\n\nIt doesn't command the dead. It simply exists, and the dead — finding something more coherent than entropy to organise around — follow.",
+      "The Ashwalker has no name in any record that predates the Fracture, which suggests it either wasn't important enough to name or was important enough to not name. Neither is reassuring.\n\nIt doesn't command the dead. It simply exists, and the dead \u2014 finding something more coherent than entropy to organise around \u2014 follow.",
       "No one knows what the Ashwalker was before the Fracture. The current theory, held by exactly one scholar who has since stopped talking about it, is that it wasn't anything before the Fracture. That the Fracture made it.\n\nYou are choosing not to find this interesting.",
-      "The Ashwalker moves through the Wastes like weather — present everywhere, localised nowhere, and arriving at inconvenient moments. The dead it commands are an afterthought. The Ashwalker itself is the problem.\n\nYou have a plan for the problem. The plan involves cards.",
+      "The Ashwalker moves through the Wastes like weather \u2014 present everywhere, localised nowhere, and arriving at inconvenient moments. The dead it commands are an afterthought. The Ashwalker itself is the problem.\n\nYou have a plan for the problem. The plan involves cards.",
       "Old stories about the Ashwalker agree on one detail: it doesn't fight. It consumes. It converts. It uses what's already there.\n\nYou have made a professional decision to not be there when it arrives."
     ],
     "priorRunSummaries": [
       "The first ashfield looked exactly as you'd imagined it. Which was alarming, because you'd never been here before.",
       "You stepped into the Wastes with the specific sensation of having already made a mistake you couldn't identify yet.",
-      "Something about the first encounter — the way the risen dead were positioned, the angle of the burning slag heaps — felt rehearsed. Like a re-run.",
+      "Something about the first encounter \u2014 the way the risen dead were positioned, the angle of the burning slag heaps \u2014 felt rehearsed. Like a re-run.",
       "The Wastes felt familiar the way a recurring nightmare feels familiar: not pleasant, but navigable, and carrying a sense that you know how it ends."
     ],
     "priorRunOpenings": [
-      "You remember — and this is the strange part — walking this ash field before. Not recently. Not clearly. But the memory is there.",
+      "You remember \u2014 and this is the strange part \u2014 walking this ash field before. Not recently. Not clearly. But the memory is there.",
       "The Revenant Witch looked at you before you'd said anything. 'Again?' she said. You didn't ask what she meant.",
       "The Ashwalker, when you reached it, didn't seem surprised. It turned toward you with the deliberate patience of something that has been expecting a specific visitor.",
       "The first risen dead you encountered stopped. Just stopped. Then stepped aside. You kept walking and chose not to investigate why."
@@ -136,7 +136,7 @@
       "Fifty approaches. The Ashwalker sends an escort now. You follow the escort. The escort knows the shortest route."
     ],
     "milestoneOpenings100": [
-      "The Ashwalker is already waiting.\n\nNot in its usual position — at the centre of the Wastes, surrounded by the dead. Here, at the edge. Where you enter.\n\n'I have been counting,' it says. The voice comes from everywhere and nowhere simultaneously. 'A hundred times you have come. A hundred times the fire goes out.'\n\nThe ash around it moves in a slow circle.\n\n'I am beginning to think you might be a habit.'"
+      "The Ashwalker is already waiting.\n\nNot in its usual position \u2014 at the centre of the Wastes, surrounded by the dead. Here, at the edge. Where you enter.\n\n'I have been counting,' it says. The voice comes from everywhere and nowhere simultaneously. 'A hundred times you have come. A hundred times the fire goes out.'\n\nThe ash around it moves in a slow circle.\n\n'I am beginning to think you might be a habit.'"
     ]
   },
   "midRunTemplates": [
@@ -346,7 +346,7 @@
         },
         {
           "title": "A MEMORY",
-          "text": "And yet — {pool:priorRunOpenings:0}\n\nYou push the feeling aside. The Wastes are waiting.\n\nThey are always waiting."
+          "text": "And yet \u2014 {pool:priorRunOpenings:0}\n\nYou push the feeling aside. The Wastes are waiting.\n\nThey are always waiting."
         }
       ]
     }
@@ -359,13 +359,14 @@
       "id": "ashfield-scouts",
       "type": "battle",
       "label": "Ashfield Scouts",
-      "description": "The dead that patrol the Wastes' edge — faster than they should be, coordinated in ways the dead shouldn't be.",
+      "description": "The dead that patrol the Wastes' edge \u2014 faster than they should be, coordinated in ways the dead shouldn't be.",
       "row": 0,
       "col": 0,
       "rowCols": 1,
       "childIds": [
         "node-1776499580467",
-        "node-1776499578445"
+        "node-1776499578445",
+        "mem-act3-1"
       ],
       "handicap": 7,
       "opponentIntervalMs": 5500,
@@ -388,23 +389,150 @@
     },
     "soul-shrine": {
       "id": "soul-shrine",
-      "type": "memory",
-      "label": "Memory Fragment",
-      "description": "Ash-covered field notes, still readable — someone was studying the wastes before they became this.",
+      "type": "event",
+      "label": "Soul Shrine",
+      "description": "A crumbling altar still smoulders with residual magic. Something lingers here.",
       "row": 2,
       "col": 0,
       "rowCols": 3,
       "childIds": [
         "revenant-witch"
       ],
-      "fragmentId": "act3-frag-1",
-      "environment": "ashen"
+      "environment": "ashen",
+      "eventConfig": {
+        "title": "The Smouldering Shrine",
+        "description": "A stone altar, half-buried in ash. The offerings left here have been burning for years. Whatever answered prayers before the Fracture may still be listening.",
+        "pools": [
+          [
+            {
+              "label": "Leave an offering",
+              "consequence": "The shrine stirs \u2014 restored 10 HP",
+              "effect": {
+                "type": "healHp",
+                "amount": 10
+              }
+            },
+            {
+              "label": "Leave an offering",
+              "consequence": "Ash curls into crystals at your feet \u2014 +15 crystals",
+              "effect": {
+                "type": "gainCrystals",
+                "amount": 15
+              }
+            },
+            {
+              "label": "Leave an offering",
+              "consequence": "The shrine takes something in return \u2014 lose 8 HP",
+              "effect": {
+                "type": "damageHp",
+                "amount": 8
+              }
+            },
+            {
+              "label": "Leave an offering",
+              "consequence": "Nothing stirs. The offering burns to nothing.",
+              "effect": {
+                "type": "nothing"
+              }
+            },
+            {
+              "label": "Leave an offering",
+              "consequence": "Something small forms from the ash \u2014 added to inventory",
+              "effect": {
+                "type": "gainItem"
+              }
+            }
+          ],
+          [
+            {
+              "label": "Speak to the remnant",
+              "consequence": "It answers \u2014 an uncommon card rises from the embers",
+              "effect": {
+                "type": "gainCard",
+                "rarity": "uncommon"
+              }
+            },
+            {
+              "label": "Speak to the remnant",
+              "consequence": "The remnant heals your wounds \u2014 restored 12 HP",
+              "effect": {
+                "type": "healHp",
+                "amount": 12
+              }
+            },
+            {
+              "label": "Speak to the remnant",
+              "consequence": "It screams and takes something with it \u2014 lose 12 HP",
+              "effect": {
+                "type": "damageHp",
+                "amount": 12
+              }
+            },
+            {
+              "label": "Speak to the remnant",
+              "consequence": "Silence. Then ash. Nothing more.",
+              "effect": {
+                "type": "nothing"
+              }
+            },
+            {
+              "label": "Speak to the remnant",
+              "consequence": "+20 crystals fall from the altar cracks",
+              "effect": {
+                "type": "gainCrystals",
+                "amount": 20
+              }
+            }
+          ],
+          [
+            {
+              "label": "Extinguish the flame",
+              "consequence": "The smoke solidifies into a common card",
+              "effect": {
+                "type": "gainCard",
+                "rarity": "common"
+              }
+            },
+            {
+              "label": "Extinguish the flame",
+              "consequence": "The sudden cold heals \u2014 restored 8 HP",
+              "effect": {
+                "type": "healHp",
+                "amount": 8
+              }
+            },
+            {
+              "label": "Extinguish the flame",
+              "consequence": "Something punishes the act \u2014 lose 10 HP",
+              "effect": {
+                "type": "damageHp",
+                "amount": 10
+              }
+            },
+            {
+              "label": "Extinguish the flame",
+              "consequence": "+12 crystals from the cooling altar stones",
+              "effect": {
+                "type": "gainCrystals",
+                "amount": 12
+              }
+            },
+            {
+              "label": "Extinguish the flame",
+              "consequence": "A relic shard in the ashes \u2014 added to inventory",
+              "effect": {
+                "type": "gainItem"
+              }
+            }
+          ]
+        ]
+      }
     },
     "bone-fire": {
       "id": "bone-fire",
       "type": "rest",
       "label": "Bone Fire",
-      "description": "A fire that burns cold — but it burns, and in the Wastes that's enough. Rest here.",
+      "description": "A fire that burns cold \u2014 but it burns, and in the Wastes that's enough. Rest here.",
       "row": 2,
       "col": 2,
       "rowCols": 3,
@@ -447,7 +575,7 @@
       "id": "ash-grotto",
       "type": "rest",
       "label": "Ash Grotto",
-      "description": "A hollow in the ash-field — sheltered from the wind, the dead, and whatever else the Wastes have decided to send today. Rest here.",
+      "description": "A hollow in the ash-field \u2014 sheltered from the wind, the dead, and whatever else the Wastes have decided to send today. Rest here.",
       "row": 5,
       "col": 0,
       "rowCols": 2,
@@ -462,7 +590,7 @@
       "id": "risen-horde",
       "type": "battle",
       "label": "Risen Horde",
-      "description": "The Wastes' standing army — numberless, tireless, and pointed in your direction.",
+      "description": "The Wastes' standing army \u2014 numberless, tireless, and pointed in your direction.",
       "row": 3,
       "col": 1,
       "rowCols": 2,
@@ -493,7 +621,7 @@
       "id": "shadow-guard",
       "type": "battle",
       "label": "Shadow Guard",
-      "description": "Risen soldiers who remember their discipline — the most dangerous kind of dead.",
+      "description": "Risen soldiers who remember their discipline \u2014 the most dangerous kind of dead.",
       "row": 4,
       "col": 1,
       "rowCols": 3,
@@ -571,29 +699,176 @@
     },
     "cursed-altar": {
       "id": "cursed-altar",
-      "type": "memory",
-      "label": "Memory Fragment",
-      "description": "A broken altar stone, its inscription still faintly legible through the char.",
+      "type": "event",
+      "label": "Cursed Altar",
+      "description": "Dark sigils cover every surface. Whoever built this expected visitors.",
       "row": 4,
       "col": 2,
       "rowCols": 3,
       "childIds": [
         "death-knight"
       ],
-      "fragmentId": "act3-frag-2",
-      "environment": "ashen"
+      "environment": "ashen",
+      "eventConfig": {
+        "title": "The Cursed Altar",
+        "description": "Black stone inscribed with sigils that predate the Ash Covenant. A hollow bowl at the centre still holds something \u2014 dark, viscous, and very still.",
+        "pools": [
+          [
+            {
+              "label": "Touch the inscription",
+              "consequence": "Power courses through you \u2014 restored 15 HP",
+              "effect": {
+                "type": "healHp",
+                "amount": 15
+              }
+            },
+            {
+              "label": "Touch the inscription",
+              "consequence": "The sigil bites \u2014 lose 10 HP",
+              "effect": {
+                "type": "damageHp",
+                "amount": 10
+              }
+            },
+            {
+              "label": "Touch the inscription",
+              "consequence": "A card materialises \u2014 uncommon",
+              "effect": {
+                "type": "gainCard",
+                "rarity": "uncommon"
+              }
+            },
+            {
+              "label": "Touch the inscription",
+              "consequence": "+18 crystals from the cracking stone",
+              "effect": {
+                "type": "gainCrystals",
+                "amount": 18
+              }
+            },
+            {
+              "label": "Touch the inscription",
+              "consequence": "Something falls from the altar into your hand \u2014 added to inventory",
+              "effect": {
+                "type": "gainItem"
+              }
+            }
+          ],
+          [
+            {
+              "label": "Drink from the bowl",
+              "consequence": "Bitter, burning \u2014 lose 8 HP, then restored 15 HP",
+              "effect": {
+                "type": "compound",
+                "effects": [
+                  {
+                    "type": "damageHp",
+                    "amount": 8
+                  },
+                  {
+                    "type": "healHp",
+                    "amount": 15
+                  }
+                ]
+              }
+            },
+            {
+              "label": "Drink from the bowl",
+              "consequence": "Nothing. Your stomach disagrees \u2014 lose 5 HP",
+              "effect": {
+                "type": "damageHp",
+                "amount": 5
+              }
+            },
+            {
+              "label": "Drink from the bowl",
+              "consequence": "Clarity follows \u2014 +1 life",
+              "effect": {
+                "type": "gainLife",
+                "amount": 1
+              }
+            },
+            {
+              "label": "Drink from the bowl",
+              "consequence": "A rare card forms in the mist",
+              "effect": {
+                "type": "gainCard",
+                "rarity": "rare"
+              }
+            },
+            {
+              "label": "Drink from the bowl",
+              "consequence": "+25 crystals materialise",
+              "effect": {
+                "type": "gainCrystals",
+                "amount": 25
+              }
+            }
+          ],
+          [
+            {
+              "label": "Smash the altar",
+              "consequence": "Crystals everywhere \u2014 +20 crystals, lose 8 HP",
+              "effect": {
+                "type": "compound",
+                "effects": [
+                  {
+                    "type": "gainCrystals",
+                    "amount": 20
+                  },
+                  {
+                    "type": "damageHp",
+                    "amount": 8
+                  }
+                ]
+              }
+            },
+            {
+              "label": "Smash the altar",
+              "consequence": "A common card flies out from the rubble",
+              "effect": {
+                "type": "gainCard",
+                "rarity": "common"
+              }
+            },
+            {
+              "label": "Smash the altar",
+              "consequence": "Something inside retaliates \u2014 lose 15 HP",
+              "effect": {
+                "type": "damageHp",
+                "amount": 15
+              }
+            },
+            {
+              "label": "Smash the altar",
+              "consequence": "A shard lodges in your palm \u2014 added to inventory",
+              "effect": {
+                "type": "gainItem"
+              }
+            },
+            {
+              "label": "Smash the altar",
+              "consequence": "Nothing useful. Just dust and silence.",
+              "effect": {
+                "type": "nothing"
+              }
+            }
+          ]
+        ]
+      }
     },
     "death-knight": {
       "id": "death-knight",
       "type": "elite",
       "label": "Death Knight",
-      "description": "A Dominion officer who fell in the Fracture and rose again — armoured, organised, and entirely without mercy.",
+      "description": "A Dominion officer who fell in the Fracture and rose again \u2014 armoured, organised, and entirely without mercy.",
       "row": 5,
       "col": 1,
       "rowCols": 2,
       "childIds": [
         "node-1776499581232",
-        "node-1776499579223"
+        "node-1776499579223",
+        "mem-act3-2"
       ],
       "handicap": -1,
       "environment": "ruins",
@@ -702,7 +977,7 @@
       "description": "For as far as the eye can see - empty wastelands. Does not feel like home. Bones lie all around... suddenly there's movement...",
       "row": 1,
       "col": 1,
-      "rowCols": 2,
+      "rowCols": 3,
       "childIds": [
         "plague-front"
       ],
@@ -737,7 +1012,7 @@
       "description": "There used to be a lake here, but now there's nothing...",
       "row": 6,
       "col": 1,
-      "rowCols": 2,
+      "rowCols": 3,
       "childIds": [
         "ash-crossing"
       ],
@@ -765,7 +1040,7 @@
       "description": "A pool of bubbling magma simmers in the wastes, the enemy has set up a base here, the units sweat from teh heat emminating from teh steaming pools of liquid rock.",
       "row": 1,
       "col": 0,
-      "rowCols": 2,
+      "rowCols": 3,
       "childIds": [
         "soul-shrine",
         "bone-fire"
@@ -793,7 +1068,7 @@
       "description": "The River Is Red. Something Swims In It...",
       "row": 6,
       "col": 0,
-      "rowCols": 2,
+      "rowCols": 3,
       "childIds": [
         "ash-crossing"
       ],
@@ -806,6 +1081,34 @@
         "Eel Striker",
         "Eel Striker"
       ]
+    },
+    "mem-act3-1": {
+      "id": "mem-act3-1",
+      "type": "memory",
+      "label": "Memory Fragment",
+      "description": "A miner's last shift record, scorched but still legible \u2014 the ash holds the handwriting perfectly.",
+      "row": 1,
+      "col": 2,
+      "rowCols": 3,
+      "childIds": [
+        "plague-front"
+      ],
+      "fragmentId": "act3-frag-1",
+      "environment": "ashen"
+    },
+    "mem-act3-2": {
+      "id": "mem-act3-2",
+      "type": "memory",
+      "label": "Memory Fragment",
+      "description": "A dry lakebed etched with directions no longer useful \u2014 someone tried to find the way out when the ash first fell.",
+      "row": 6,
+      "col": 2,
+      "rowCols": 3,
+      "childIds": [
+        "ash-crossing"
+      ],
+      "fragmentId": "act3-frag-2",
+      "environment": "ashen"
     }
   },
   "mapMusicId": "map",

--- a/web/src/data/acts/act4.json
+++ b/web/src/data/acts/act4.json
@@ -50,7 +50,7 @@
   "intro": [
     {
       "title": "THE CRYSTAL SPIRE",
-      "text": "Before the Fracture, the Crystal Spire was the Dominion's arcane research division — a floating fortress of compressed ley-line energy, staffed by scholars who were very important and knew it.\n\nThe Fracture didn't destroy the Spire. It crystallised it. The entire shard froze mid-operation: experiments running, libraries mid-catalogue, staff mid-sentence. The crystal grew inward. The scholars who survived became part of the archive.\n\nThe Archivist survived better than most.",
+      "text": "Before the Fracture, the Crystal Spire was the Dominion's arcane research division \u2014 a floating fortress of compressed ley-line energy, staffed by scholars who were very important and knew it.\n\nThe Fracture didn't destroy the Spire. It crystallised it. The entire shard froze mid-operation: experiments running, libraries mid-catalogue, staff mid-sentence. The crystal grew inward. The scholars who survived became part of the archive.\n\nThe Archivist survived better than most.",
       "image": "cutscenes/act4-intro-1.svg"
     },
     {
@@ -60,7 +60,7 @@
     },
     {
       "title": "THE CRYSTAL SPIRE",
-      "text": "The Spire is a labyrinth of crystallised corridors, arcane constructs, and rooms that echo with the voices of people who stopped speaking three years ago.\n\nAt its heart, the Archivist — scholar, archivist, and now something considerably more and considerably less than either — catalogues everything that enters. He has been cataloguing you since you entered the shard.\n\nHe has extensive notes.",
+      "text": "The Spire is a labyrinth of crystallised corridors, arcane constructs, and rooms that echo with the voices of people who stopped speaking three years ago.\n\nAt its heart, the Archivist \u2014 scholar, archivist, and now something considerably more and considerably less than either \u2014 catalogues everything that enters. He has been cataloguing you since you entered the shard.\n\nHe has extensive notes.",
       "image": "cutscenes/act4-intro-3.svg"
     },
     {
@@ -72,12 +72,12 @@
   "outro": [
     {
       "title": "THE ARCHIVE FALLS SILENT",
-      "text": "The Archivist's crystal matrix collapses. Not violently — methodically. Each facet dims in order, as though even his defeat is being filed.\n\nThe Spire holds its breath. Then, for the first time in three years, a window opens somewhere deep in the structure. Not because it was unlocked. Because whoever had been locking it is no longer in a position to care.\n\nLight comes through. Ordinary, unremarkable light. In the Crystal Spire, it looks like a miracle.",
+      "text": "The Archivist's crystal matrix collapses. Not violently \u2014 methodically. Each facet dims in order, as though even his defeat is being filed.\n\nThe Spire holds its breath. Then, for the first time in three years, a window opens somewhere deep in the structure. Not because it was unlocked. Because whoever had been locking it is no longer in a position to care.\n\nLight comes through. Ordinary, unremarkable light. In the Crystal Spire, it looks like a miracle.",
       "image": "cutscenes/act4-outro-1.svg"
     },
     {
       "title": "PRISM LENS",
-      "text": "Among the Archivist's collection — catalogued, cross-referenced, annotated in a hand that had become increasingly less human — you find it.\n\nA lens ground from the Spire's heart crystal. It refracts mana the way a prism refracts light: input, multiplied, redirected.\n\nThe Archivist's note reads: *'Item 7,441: Prism Lens. Effect: mana amplification. Recommendation: do not give to wandering tactician.'\n\nYou take it.",
+      "text": "Among the Archivist's collection \u2014 catalogued, cross-referenced, annotated in a hand that had become increasingly less human \u2014 you find it.\n\nA lens ground from the Spire's heart crystal. It refracts mana the way a prism refracts light: input, multiplied, redirected.\n\nThe Archivist's note reads: *'Item 7,441: Prism Lens. Effect: mana amplification. Recommendation: do not give to wandering tactician.'\n\nYou take it.",
       "image": "cutscenes/act4-outro-2.svg"
     }
   ],
@@ -86,7 +86,7 @@
       "Currently, technically, trespassing in a building that has documented every trespasser since the Dominion era.",
       "Professionally speaking, now classified as a hostile anomaly in an active archive.",
       "In the scholarly sense, an unscheduled variable in someone else's extremely long experiment.",
-      "Now — by the Archivist's own notation — Specimen 7,441-B, Category: Recurring.",
+      "Now \u2014 by the Archivist's own notation \u2014 Specimen 7,441-B, Category: Recurring.",
       "Technically unenrolled, which puts you in a narrow category of people who have entered the Spire and stayed that way."
     ],
     "jarvIntros": [
@@ -98,15 +98,15 @@
     ],
     "spireDesc": [
       "The Crystal Spire floats above the shard floor on compressed ley lines, its corridors refracting light into colours that don't have names. The scholars called it the height of Dominion achievement. From the outside it looks like someone built a fortress out of a prism and forgot to add doors.",
-      "The Spire's outer lattice is a maze of crystallised arcane energy — walls that shift, corridors that echo with old spells still running, and constructs that patrol with the cheerful persistence of things that have never been told to stop.",
+      "The Spire's outer lattice is a maze of crystallised arcane energy \u2014 walls that shift, corridors that echo with old spells still running, and constructs that patrol with the cheerful persistence of things that have never been told to stop.",
       "Three years of isolation have given the Spire's internal systems time to optimise themselves. Every approach is monitored. Every intrusion is logged. The Archivist receives notification of your exact position in real time.",
       "The Crystal Spire hums. Constantly. A low, harmonic resonance that carries meaning if you listen long enough. You have been listening for forty minutes. The meaning is 'leave.'"
     ],
     "archivistDesc": [
-      "The Archivist was the Dominion's head of magical research before the Fracture — a precise, methodical scholar who believed that anything worth knowing was worth cataloguing and anything worth cataloguing was worth defending.\n\nThe Fracture gave him more to catalogue than he'd expected. He adapted.",
+      "The Archivist was the Dominion's head of magical research before the Fracture \u2014 a precise, methodical scholar who believed that anything worth knowing was worth cataloguing and anything worth cataloguing was worth defending.\n\nThe Fracture gave him more to catalogue than he'd expected. He adapted.",
       "No surviving record of the Archivist exists outside the Spire. This is because the Archivist controls all the surviving records.\n\nHe is, by his own notation, entry 1 in the archive. The entry runs to forty-seven pages and is still being updated.",
       "The Archivist doesn't fight. He categorises. He processes. He applies the appropriate countermeasures from the section labelled 'threats, external, category: persistent.'\n\nYou are in that section. You have been in that section since you crossed the shard boundary. You have a case number.",
-      "In the Spire's early catalogues, the Archivist noted that magic follows rules and rules can be mastered. His later entries — written after the Fracture, in a hand that grew steadily less human — simply note that mastery takes time.\n\nHe has had time."
+      "In the Spire's early catalogues, the Archivist noted that magic follows rules and rules can be mastered. His later entries \u2014 written after the Fracture, in a hand that grew steadily less human \u2014 simply note that mastery takes time.\n\nHe has had time."
     ],
     "priorRunSummaries": [
       "The outer lattice looked exactly as the recovered schematics described it. Which was suspicious, because the schematics were three years old and the lattice was known to rearrange itself.",
@@ -137,12 +137,12 @@
       "Fifty approaches. The crystal walls show you all your previous visits simultaneously. It looks like a gallery. The Archivist has curated it."
     ],
     "milestoneOpenings100": [
-      "The Archivist is at the entrance.\n\nNot in his chamber — at the entrance. Waiting.\n\n'One hundred visits,' he says. The crystal in his voice has grown, over the years, into something almost warm. 'Do you know what that means, in terms of the archive?'\n\nA pause. A soft chime, somewhere deep in the Spire.\n\n'You have generated more data than the Dominion's entire eastern campaign. I have seventeen volumes dedicated exclusively to your methodology. You are, empirically, the most significant external variable this archive has ever processed.'\n\nHe tilts his crystalline head.\n\n'I have decided to consider this a collaboration.'"
+      "The Archivist is at the entrance.\n\nNot in his chamber \u2014 at the entrance. Waiting.\n\n'One hundred visits,' he says. The crystal in his voice has grown, over the years, into something almost warm. 'Do you know what that means, in terms of the archive?'\n\nA pause. A soft chime, somewhere deep in the Spire.\n\n'You have generated more data than the Dominion's entire eastern campaign. I have seventeen volumes dedicated exclusively to your methodology. You are, empirically, the most significant external variable this archive has ever processed.'\n\nHe tilts his crystalline head.\n\n'I have decided to consider this a collaboration.'"
     ]
   },
   "midRunTemplates": [
     "The {ordinalLower} visit to the Crystal Spire. The archive has updated your file. It is now cross-referenced under seventeen categories.",
-    "Campaign {n}. The constructs recognise you on sight. The Archivist has stopped logging your entry time — he predicts it accurately enough to not bother.",
+    "Campaign {n}. The constructs recognise you on sight. The Archivist has stopped logging your entry time \u2014 he predicts it accurately enough to not bother.",
     "{n} campaigns through the lattice. The crystal corridors look the same. They always look the same. The Archivist prefers consistency.",
     "{n} times past the outer lattice. Your case number has gained a suffix: 'See also: the persistent one.'",
     "Run {n}. The Archivist's notes on you are now longer than his notes on the Fracture itself. He considers this an appropriate allocation of resources.",
@@ -347,7 +347,7 @@
         },
         {
           "title": "A NOTIFICATION",
-          "text": "And yet — {pool:priorRunOpenings:0}\n\nYou push the feeling aside. The Spire is waiting.\n\nIt has always been waiting. It files everything."
+          "text": "And yet \u2014 {pool:priorRunOpenings:0}\n\nYou push the feeling aside. The Spire is waiting.\n\nIt has always been waiting. It files everything."
         }
       ]
     }
@@ -366,7 +366,8 @@
       "rowCols": 1,
       "childIds": [
         "spire-left",
-        "spire-right"
+        "spire-right",
+        "mem-act4-1"
       ],
       "handicap": 5,
       "opponentIntervalMs": 7000,
@@ -391,7 +392,7 @@
       "description": "A columned hall filled with crystalline light and something unfriendly.",
       "row": 1,
       "col": 0,
-      "rowCols": 2,
+      "rowCols": 3,
       "childIds": [
         "echo-halls",
         "iron-approach"
@@ -418,7 +419,7 @@
       "description": "A market district reclaimed by the Spire's military wing. Hostile occupation.",
       "row": 1,
       "col": 1,
-      "rowCols": 2,
+      "rowCols": 3,
       "childIds": [
         "null-market",
         "arcane-court"
@@ -441,17 +442,144 @@
     },
     "arcane-court": {
       "id": "arcane-court",
-      "type": "memory",
-      "label": "Memory Fragment",
-      "description": "A researcher’s notebook, sealed in crystal and left on a window ledge overlooking the void.",
+      "type": "event",
+      "label": "Arcane Court",
+      "description": "A circular chamber where arcanists once debated. Their arguments still echo.",
       "row": 2,
       "col": 3,
       "rowCols": 4,
       "childIds": [
         "arcanist-champion"
       ],
-      "fragmentId": "act4-frag-1",
-      "environment": "spire"
+      "environment": "spire",
+      "eventConfig": {
+        "title": "The Arcane Court",
+        "description": "A vaulted chamber lined with crystal resonators, still humming with residual spellwork. The debating podiums are overturned. Something important was decided here, and not calmly.",
+        "pools": [
+          [
+            {
+              "label": "Attune to the resonators",
+              "consequence": "The crystals gift you insight \u2014 uncommon card",
+              "effect": {
+                "type": "gainCard",
+                "rarity": "uncommon"
+              }
+            },
+            {
+              "label": "Attune to the resonators",
+              "consequence": "Harmonic healing \u2014 restored 12 HP",
+              "effect": {
+                "type": "healHp",
+                "amount": 12
+              }
+            },
+            {
+              "label": "Attune to the resonators",
+              "consequence": "Dissonance \u2014 lose 10 HP",
+              "effect": {
+                "type": "damageHp",
+                "amount": 10
+              }
+            },
+            {
+              "label": "Attune to the resonators",
+              "consequence": "+18 crystals from amplified ambient energy",
+              "effect": {
+                "type": "gainCrystals",
+                "amount": 18
+              }
+            },
+            {
+              "label": "Attune to the resonators",
+              "consequence": "A calibration tool falls from a shelf \u2014 added to inventory",
+              "effect": {
+                "type": "gainItem"
+              }
+            }
+          ],
+          [
+            {
+              "label": "Search the archive stacks",
+              "consequence": "A rare spell contract \u2014 rare card",
+              "effect": {
+                "type": "gainCard",
+                "rarity": "rare"
+              }
+            },
+            {
+              "label": "Search the archive stacks",
+              "consequence": "+20 crystals in a research stipend pouch",
+              "effect": {
+                "type": "gainCrystals",
+                "amount": 20
+              }
+            },
+            {
+              "label": "Search the archive stacks",
+              "consequence": "A trapped shelf springs \u2014 lose 8 HP",
+              "effect": {
+                "type": "damageHp",
+                "amount": 8
+              }
+            },
+            {
+              "label": "Search the archive stacks",
+              "consequence": "A curious arcanist tool \u2014 added to inventory",
+              "effect": {
+                "type": "gainItem"
+              }
+            },
+            {
+              "label": "Search the archive stacks",
+              "consequence": "Nothing relevant. Dense theory. Footnotes everywhere.",
+              "effect": {
+                "type": "nothing"
+              }
+            }
+          ],
+          [
+            {
+              "label": "Touch the central crystal",
+              "consequence": "Pure mana pulse \u2014 restored 15 HP",
+              "effect": {
+                "type": "healHp",
+                "amount": 15
+              }
+            },
+            {
+              "label": "Touch the central crystal",
+              "consequence": "Overload \u2014 lose 12 HP",
+              "effect": {
+                "type": "damageHp",
+                "amount": 12
+              }
+            },
+            {
+              "label": "Touch the central crystal",
+              "consequence": "+25 crystals discharged from the lattice",
+              "effect": {
+                "type": "gainCrystals",
+                "amount": 25
+              }
+            },
+            {
+              "label": "Touch the central crystal",
+              "consequence": "+1 life from the stored renewal energy",
+              "effect": {
+                "type": "gainLife",
+                "amount": 1
+              }
+            },
+            {
+              "label": "Touch the central crystal",
+              "consequence": "A crystal shard detaches \u2014 added to inventory",
+              "effect": {
+                "type": "gainItem"
+              }
+            }
+          ]
+        ]
+      }
     },
     "echo-halls": {
       "id": "echo-halls",
@@ -665,17 +793,145 @@
     },
     "arcane-archive": {
       "id": "arcane-archive",
-      "type": "memory",
-      "label": "Memory Fragment",
-      "description": "A sealed crystal vial containing compressed parchment — the arcanists' final correspondence.",
+      "type": "event",
+      "label": "Arcane Archive",
+      "description": "Sealed research chambers line the walls. Most are still locked.",
       "row": 4,
       "col": 0,
       "rowCols": 4,
       "childIds": [
         "spire-gate"
       ],
-      "fragmentId": "act4-frag-2",
-      "environment": "spire"
+      "environment": "spire",
+      "eventConfig": {
+        "title": "The Arcane Archive",
+        "description": "Floor-to-ceiling shelves of sealed crystal vials \u2014 each one a compressed document. Half are cracked.",
+        "pools": [
+          [
+            {
+              "label": "Open a sealed vial",
+              "consequence": "Healing memory restores \u2014 restored 10 HP",
+              "effect": {
+                "type": "healHp",
+                "amount": 10
+              }
+            },
+            {
+              "label": "Open a sealed vial",
+              "consequence": "Explosive contents \u2014 lose 8 HP",
+              "effect": {
+                "type": "damageHp",
+                "amount": 8
+              }
+            },
+            {
+              "label": "Open a sealed vial",
+              "consequence": "Crystal residue \u2014 +15 crystals",
+              "effect": {
+                "type": "gainCrystals",
+                "amount": 15
+              }
+            },
+            {
+              "label": "Open a sealed vial",
+              "consequence": "A compressed common card spills out",
+              "effect": {
+                "type": "gainCard",
+                "rarity": "common"
+              }
+            },
+            {
+              "label": "Open a sealed vial",
+              "consequence": "An unusual instrument \u2014 added to inventory",
+              "effect": {
+                "type": "gainItem"
+              }
+            }
+          ],
+          [
+            {
+              "label": "Read the intact documents",
+              "consequence": "Research grant found \u2014 +20 crystals",
+              "effect": {
+                "type": "gainCrystals",
+                "amount": 20
+              }
+            },
+            {
+              "label": "Read the intact documents",
+              "consequence": "An uncommon card described within manifests",
+              "effect": {
+                "type": "gainCard",
+                "rarity": "uncommon"
+              }
+            },
+            {
+              "label": "Read the intact documents",
+              "consequence": "Unsettling content \u2014 lose 5 HP",
+              "effect": {
+                "type": "damageHp",
+                "amount": 5
+              }
+            },
+            {
+              "label": "Read the intact documents",
+              "consequence": "Restoring knowledge \u2014 restored 8 HP",
+              "effect": {
+                "type": "healHp",
+                "amount": 8
+              }
+            },
+            {
+              "label": "Read the intact documents",
+              "consequence": "An annotated tool falls from the pages \u2014 added to inventory",
+              "effect": {
+                "type": "gainItem"
+              }
+            }
+          ],
+          [
+            {
+              "label": "Smash the cracked vials",
+              "consequence": "+18 crystals from the residue",
+              "effect": {
+                "type": "gainCrystals",
+                "amount": 18
+              }
+            },
+            {
+              "label": "Smash the cracked vials",
+              "consequence": "Healing gas \u2014 restored 12 HP",
+              "effect": {
+                "type": "healHp",
+                "amount": 12
+              }
+            },
+            {
+              "label": "Smash the cracked vials",
+              "consequence": "Toxic gas \u2014 lose 10 HP",
+              "effect": {
+                "type": "damageHp",
+                "amount": 10
+              }
+            },
+            {
+              "label": "Smash the cracked vials",
+              "consequence": "A rare card crystallises from the vapour",
+              "effect": {
+                "type": "gainCard",
+                "rarity": "rare"
+              }
+            },
+            {
+              "label": "Smash the cracked vials",
+              "consequence": "A shard lodges safely in your pack \u2014 added to inventory",
+              "effect": {
+                "type": "gainItem"
+              }
+            }
+          ]
+        ]
+      }
     },
     "spire-gate": {
       "id": "spire-gate",
@@ -714,7 +970,8 @@
       "col": 1,
       "rowCols": 2,
       "childIds": [
-        "rune-descent"
+        "rune-descent",
+        "mem-act4-2"
       ],
       "handicap": 0,
       "opponentBaseHp": 205,
@@ -741,7 +998,7 @@
       "description": "A side chamber lined with dormant runes. Still enough to rest in, if you move quickly.",
       "row": 6,
       "col": 0,
-      "rowCols": 1,
+      "rowCols": 2,
       "childIds": [
         "spire-crossing"
       ],
@@ -799,6 +1056,34 @@
         "\"You think your deck is your own? I wrote the first copy.\"",
         "\"Close the door on your way in. We have work to do.\""
       ]
+    },
+    "mem-act4-1": {
+      "id": "mem-act4-1",
+      "type": "memory",
+      "label": "Memory Fragment",
+      "description": "A scholar's half-finished letter, crystallised mid-word \u2014 the Fracture caught them between sentences.",
+      "row": 1,
+      "col": 2,
+      "rowCols": 3,
+      "childIds": [
+        "echo-halls"
+      ],
+      "fragmentId": "act4-frag-1",
+      "environment": "spire"
+    },
+    "mem-act4-2": {
+      "id": "mem-act4-2",
+      "type": "memory",
+      "label": "Memory Fragment",
+      "description": "A dormant rune still broadcasting its last recorded message \u2014 the voice of someone who believed the Spire was safe.",
+      "row": 6,
+      "col": 1,
+      "rowCols": 2,
+      "childIds": [
+        "spire-crossing"
+      ],
+      "fragmentId": "act4-frag-2",
+      "environment": "spire"
     }
   },
   "mapMusicId": "map",

--- a/web/src/data/acts/act4.json
+++ b/web/src/data/acts/act4.json
@@ -441,142 +441,17 @@
     },
     "arcane-court": {
       "id": "arcane-court",
-      "type": "event",
-      "label": "The Arcane Court",
-      "description": "Hooded figures stand in a crystalline circle, studying something that floats at the centre.",
+      "type": "memory",
+      "label": "Memory Fragment",
+      "description": "A researcher’s notebook, sealed in crystal and left on a window ledge overlooking the void.",
       "row": 2,
       "col": 3,
       "rowCols": 4,
       "childIds": [
         "arcanist-champion"
       ],
-      "environment": "citadel",
-      "eventConfig": {
-        "title": "The Arcane Court",
-        "description": "Crystalline towers rise around you. Hooded figures stand in a circle, studying a glowing object that floats at the centre. They don’t seem hostile. Not yet.",
-        "pools": [
-          [
-            {
-              "label": "Step into the circle",
-              "consequence": "The magic steadies you — restored 10 HP",
-              "effect": {
-                "type": "healHp",
-                "amount": 10
-              }
-            },
-            {
-              "label": "Step into the circle",
-              "consequence": "The ritual grants you a boon — +18 crystals",
-              "effect": {
-                "type": "gainCrystals",
-                "amount": 18
-              }
-            },
-            {
-              "label": "Step into the circle",
-              "consequence": "The energy rejects you — lose 8 HP",
-              "effect": {
-                "type": "damageHp",
-                "amount": 8
-              }
-            },
-            {
-              "label": "Step into the circle",
-              "consequence": "An uncommon card materialises from the glow",
-              "effect": {
-                "type": "gainCard",
-                "rarity": "uncommon"
-              }
-            },
-            {
-              "label": "Step into the circle",
-              "consequence": "Something small falls from the air — added to inventory",
-              "effect": {
-                "type": "gainItem"
-              }
-            }
-          ],
-          [
-            {
-              "label": "Observe from the doorway",
-              "consequence": "You note weaknesses — +15 crystals",
-              "effect": {
-                "type": "gainCrystals",
-                "amount": 15
-              }
-            },
-            {
-              "label": "Observe from the doorway",
-              "consequence": "They don’t notice you. Nothing happens.",
-              "effect": {
-                "type": "nothing"
-              }
-            },
-            {
-              "label": "Observe from the doorway",
-              "consequence": "One of them nods. You find something on the floor — added to inventory",
-              "effect": {
-                "type": "gainItem"
-              }
-            },
-            {
-              "label": "Observe from the doorway",
-              "consequence": "A fragment drifts toward you — restored 6 HP",
-              "effect": {
-                "type": "healHp",
-                "amount": 6
-              }
-            },
-            {
-              "label": "Observe from the doorway",
-              "consequence": "A curious object rolls under your foot — added to inventory",
-              "effect": {
-                "type": "gainItem"
-              }
-            }
-          ],
-          [
-            {
-              "label": "Disrupt the ritual",
-              "consequence": "The backlash tears a rare card free",
-              "effect": {
-                "type": "gainCard",
-                "rarity": "rare"
-              }
-            },
-            {
-              "label": "Disrupt the ritual",
-              "consequence": "The explosion throws you back — lose 15 HP",
-              "effect": {
-                "type": "damageHp",
-                "amount": 15
-              }
-            },
-            {
-              "label": "Disrupt the ritual",
-              "consequence": "The figures scatter. +20 crystals from the remains.",
-              "effect": {
-                "type": "gainCrystals",
-                "amount": 20
-              }
-            },
-            {
-              "label": "Disrupt the ritual",
-              "consequence": "Nothing in the wreckage. Nothing.",
-              "effect": {
-                "type": "nothing"
-              }
-            },
-            {
-              "label": "Disrupt the ritual",
-              "consequence": "Something breaks loose in the chaos — added to inventory",
-              "effect": {
-                "type": "gainItem"
-              }
-            }
-          ]
-        ]
-      }
+      "fragmentId": "act4-frag-1",
+      "environment": "spire"
     },
     "echo-halls": {
       "id": "echo-halls",
@@ -790,144 +665,17 @@
     },
     "arcane-archive": {
       "id": "arcane-archive",
-      "type": "event",
-      "label": "The Arcane Archive",
-      "description": "Floor-to-ceiling shelves of crystallised knowledge. Some of the crystals pulse back when you enter.",
+      "type": "memory",
+      "label": "Memory Fragment",
+      "description": "A sealed crystal vial containing compressed parchment — the arcanists' final correspondence.",
       "row": 4,
       "col": 0,
       "rowCols": 4,
       "childIds": [
         "spire-gate"
       ],
-      "environment": "citadel",
-      "eventConfig": {
-        "title": "The Arcane Archive",
-        "description": "Floor-to-ceiling shelves of crystallised knowledge. Some of the crystals pulse with stored magic. A few of them pulse back when you enter.",
-        "pools": [
-          [
-            {
-              "label": "Study the crystals",
-              "consequence": "Absorbed energy restores you — restored 8 HP",
-              "effect": {
-                "type": "healHp",
-                "amount": 8
-              }
-            },
-            {
-              "label": "Study the crystals",
-              "consequence": "You extract a pattern — gain a common card",
-              "effect": {
-                "type": "gainCard",
-                "rarity": "common"
-              }
-            },
-            {
-              "label": "Study the crystals",
-              "consequence": "The knowledge costs you — lose 6 HP",
-              "effect": {
-                "type": "damageHp",
-                "amount": 6
-              }
-            },
-            {
-              "label": "Study the crystals",
-              "consequence": "You find a practical application — +12 crystals",
-              "effect": {
-                "type": "gainCrystals",
-                "amount": 12
-              }
-            },
-            {
-              "label": "Study the crystals",
-              "consequence": "A small crystal detaches from the shelf — added to inventory",
-              "effect": {
-                "type": "gainItem"
-              }
-            }
-          ],
-          [
-            {
-              "label": "Take a crystal shard",
-              "consequence": "The shard resonates with an uncommon card",
-              "effect": {
-                "type": "gainCard",
-                "rarity": "uncommon"
-              }
-            },
-            {
-              "label": "Take a crystal shard",
-              "consequence": "It dissolves into +20 crystals worth of stored magic",
-              "effect": {
-                "type": "gainCrystals",
-                "amount": 20
-              }
-            },
-            {
-              "label": "Take a crystal shard",
-              "consequence": "It releases a feedback pulse — lose 10 HP",
-              "effect": {
-                "type": "damageHp",
-                "amount": 10
-              }
-            },
-            {
-              "label": "Take a crystal shard",
-              "consequence": "Something shifts inside it. You keep it — added to inventory",
-              "effect": {
-                "type": "gainItem"
-              }
-            },
-            {
-              "label": "Take a crystal shard",
-              "consequence": "It crumbles to dust. Nothing.",
-              "effect": {
-                "type": "nothing"
-              }
-            }
-          ],
-          [
-            {
-              "label": "Leave an offering of mana",
-              "consequence": "The archive accepts. A rare card materialises.",
-              "effect": {
-                "type": "gainCard",
-                "rarity": "rare"
-              }
-            },
-            {
-              "label": "Leave an offering of mana",
-              "consequence": "Something flows back in return — restored 15 HP",
-              "effect": {
-                "type": "healHp",
-                "amount": 15
-              }
-            },
-            {
-              "label": "Leave an offering of mana",
-              "consequence": "The archive takes more than you offered — lose 5 HP",
-              "effect": {
-                "type": "damageHp",
-                "amount": 5
-              }
-            },
-            {
-              "label": "Leave an offering of mana",
-              "consequence": "Something small materialises at your feet — added to inventory",
-              "effect": {
-                "type": "gainItem"
-              }
-            },
-            {
-              "label": "Leave an offering of mana",
-              "consequence": "The archive blesses you with renewed vigour — +1 life",
-              "effect": {
-                "type": "gainLife",
-                "amount": 1
-              }
-            }
-          ]
-        ]
-      }
+      "fragmentId": "act4-frag-2",
+      "environment": "spire"
     },
     "spire-gate": {
       "id": "spire-gate",

--- a/web/src/data/acts/act5.json
+++ b/web/src/data/acts/act5.json
@@ -348,9 +348,9 @@
     },
     "tidal-shrine": {
       "id": "tidal-shrine",
-      "type": "event",
-      "label": "Tidal Shrine",
-      "description": "An ancient stone altar sits at low tide, its carvings still sharp despite everything.",
+      "type": "memory",
+      "label": "Memory Fragment",
+      "description": "A carved reef-stone marker, still standing despite the sinking — the inscription faces upward.",
       "row": 1,
       "col": 0,
       "rowCols": 2,
@@ -358,106 +358,8 @@
         "sunken-passage",
         "node-1776756542614"
       ],
-      "environment": "reef",
-      "eventConfig": {
-        "title": "The Tidal Shrine",
-        "description": "A stone altar stands at the reef's edge, carved with wave patterns and seal-glyphs. A small depression at its centre fills and empties with every tide.",
-        "pools": [
-          [
-            {
-              "label": "Leave an offering",
-              "consequence": "The tide takes it — and returns 12 HP",
-              "effect": {
-                "type": "healHp",
-                "amount": 12
-              }
-            },
-            {
-              "label": "Leave an offering",
-              "consequence": "The shrine accepts the gift — +15 crystals",
-              "effect": {
-                "type": "gainCrystals",
-                "amount": 15
-              }
-            },
-            {
-              "label": "Leave an offering",
-              "consequence": "Nothing stirs. The tide goes out.",
-              "effect": {
-                "type": "nothing"
-              }
-            },
-            {
-              "label": "Leave an offering",
-              "consequence": "Something beneath pulls harder than expected — lose 5 HP",
-              "effect": {
-                "type": "damageHp",
-                "amount": 5
-              }
-            }
-          ],
-          [
-            {
-              "label": "Read the carvings",
-              "consequence": "The glyphs resolve into a card — uncommon",
-              "effect": {
-                "type": "gainCard",
-                "rarity": "uncommon"
-              }
-            },
-            {
-              "label": "Read the carvings",
-              "consequence": "The pattern heals old wounds — restored 8 HP",
-              "effect": {
-                "type": "healHp",
-                "amount": 8
-              }
-            },
-            {
-              "label": "Read the carvings",
-              "consequence": "The knowledge is expensive — lose 10 HP",
-              "effect": {
-                "type": "damageHp",
-                "amount": 10
-              }
-            },
-            {
-              "label": "Read the carvings",
-              "consequence": "Salt and old magic — +20 crystals",
-              "effect": {
-                "type": "gainCrystals",
-                "amount": 20
-              }
-            }
-          ],
-          [
-            {
-              "label": "Smash it for components",
-              "consequence": "The components are worth something — +18 crystals",
-              "effect": {
-                "type": "gainCrystals",
-                "amount": 18
-              }
-            },
-            {
-              "label": "Smash it for components",
-              "consequence": "A common card falls from the rubble",
-              "effect": {
-                "type": "gainCard",
-                "rarity": "common"
-              }
-            },
-            {
-              "label": "Smash it for components",
-              "consequence": "The shrine curses you for the disrespect — lose 15 HP",
-              "effect": {
-                "type": "damageHp",
-                "amount": 15
-              }
-            }
-          ]
-        ]
-      }
+      "fragmentId": "act5-frag-1",
+      "environment": "reef"
     },
     "wreck-camp": {
       "id": "wreck-camp",
@@ -696,66 +598,17 @@
     },
     "drowned-shrine": {
       "id": "drowned-shrine",
-      "type": "event",
-      "label": "Drowned Archive",
-      "description": "A Dominion library, somehow preserved. Its books are unreadable but its cards are intact.",
+      "type": "memory",
+      "label": "Memory Fragment",
+      "description": "A message jar wedged against the old harbour steps, sealed and waiting.",
       "row": 3,
       "col": 2,
       "rowCols": 4,
       "childIds": [
         "reef-patrol-elite"
       ],
-      "environment": "reef",
-      "eventConfig": {
-        "title": "The Drowned Archive",
-        "description": "A Dominion archive sits perfectly preserved inside a sealed air pocket — marble shelves, brass fixtures, and a thousand books that have become coral. The card drawers, however, are watertight.",
-        "pools": [
-          [
-            {
-              "label": "Search the drawers",
-              "consequence": "A rare card, preserved in wax — yours",
-              "effect": {
-                "type": "gainCard",
-                "rarity": "rare"
-              }
-            },
-            {
-              "label": "Search the drawers",
-              "consequence": "Only common finds, but several — +20 crystals",
-              "effect": {
-                "type": "gainCrystals",
-                "amount": 20
-              }
-            },
-            {
-              "label": "Search the drawers",
-              "consequence": "A pressure seal breaks — lose 8 HP",
-              "effect": {
-                "type": "damageHp",
-                "amount": 8
-              }
-            }
-          ],
-          [
-            {
-              "label": "Rest among the stacks",
-              "consequence": "Dry floor, still air — restored 15 HP",
-              "effect": {
-                "type": "healHp",
-                "amount": 15
-              }
-            },
-            {
-              "label": "Rest among the stacks",
-              "consequence": "A forgotten card falls from a shelf — uncommon",
-              "effect": {
-                "type": "gainCard",
-                "rarity": "uncommon"
-              }
-            }
-          ]
-        ]
-      }
+      "fragmentId": "act5-frag-2",
+      "environment": "reef"
     },
     "depth-rest": {
       "id": "depth-rest",

--- a/web/src/data/acts/act5.json
+++ b/web/src/data/acts/act5.json
@@ -45,7 +45,7 @@
       "Now, technically, waterlogged in both the literal and professional sense.",
       "Now, somewhere between drowned and determined.",
       "Now, effectively, the sort of person who fights sea creatures for a living.",
-      "Now — by any measure — overdue for dry land."
+      "Now \u2014 by any measure \u2014 overdue for dry land."
     ],
     "jarvIntros": [
       "You have a deck of cards, an understanding of tidal patterns, and a strong conviction that the ocean does not care about you.",
@@ -55,25 +55,25 @@
       "You have a deck of cards. The sea has had your number since the first time. That hasn't stopped you yet."
     ],
     "reefDesc": [
-      "The shard hangs half-submerged — a lattice of coral, sunken ships, and old magic squeezed between two impossible tides.",
-      "The Sunken Reef smells like the bottom of the world — salt and brine and something older than weather.",
+      "The shard hangs half-submerged \u2014 a lattice of coral, sunken ships, and old magic squeezed between two impossible tides.",
+      "The Sunken Reef smells like the bottom of the world \u2014 salt and brine and something older than weather.",
       "The Sunken Reef waits at the edge of your bearing, half-drowned and utterly indifferent to your arrival.",
       "The ley lines thread through the reef like roots through rock. The water knows exactly what it's doing."
     ],
     "sovereignDesc": [
-      "The Reef's guardian calls itself the Tidal Sovereign — a being of compressed sea-memory and slow, grinding patience.\n\nIt does not rush. It does not need to. The tide has never once been in a hurry.",
+      "The Reef's guardian calls itself the Tidal Sovereign \u2014 a being of compressed sea-memory and slow, grinding patience.\n\nIt does not rush. It does not need to. The tide has never once been in a hurry.",
       "The Tidal Sovereign holds the Reef's pathways closed. It has been doing this since before your concept of 'waiting' existed.\n\nIt is not worried about you. That, ironically, is the problem.",
       "The Tidal Sovereign seals every passage through the Reef. Traders who've survived call it patient, deliberate, and entirely without urgency.\n\nYou've found urgency works well enough as a substitute.",
       "The Tidal Sovereign waits at the Reef's heart. It has not moved in a very long time. You suspect, this time, that it has been expecting exactly this."
     ],
     "priorRunSummaries": [
-      "The water felt familiar — the particular weight of it, the way it carried sound. Like walking back into a room you'd left a light on in.",
-      "The coral formations were wrong. Not wrong wrong — wrong the way a remembered face is wrong when you see it again after a long time.",
+      "The water felt familiar \u2014 the particular weight of it, the way it carried sound. Like walking back into a room you'd left a light on in.",
+      "The coral formations were wrong. Not wrong wrong \u2014 wrong the way a remembered face is wrong when you see it again after a long time.",
       "Something about the current. The angle of it. The way it pushed you slightly left at every junction. You pushed back. That felt familiar too.",
       "The reef was quieter on approach than it should have been. As though it knew you were coming, and had decided not to make a fuss about it."
     ],
     "priorRunOpenings": [
-      "You had been here. Not in the way that means you remembered it clearly — in the way that means your hands knew what to do before you told them.",
+      "You had been here. Not in the way that means you remembered it clearly \u2014 in the way that means your hands knew what to do before you told them.",
       "The first patrol of Sea Wraiths didn't seem surprised to see you. Not exactly. More like: resigned.",
       "The Tidal Sovereign's opening gambit was different this time. Slower. As though it had considered changing tactics and then thought better of it.",
       "The tide was going out when you arrived. Last time it was coming in. You noted this. You weren't sure what it meant, but you noted it."
@@ -91,11 +91,11 @@
       "After twenty-five runs, the Tidal Sovereign no longer opens with the speech about tide and inevitability. It just looks at you. Somehow that is worse."
     ],
     "milestoneOpenings50": [
-      "The fiftieth time through the Sunken Reef. The water is the wrong temperature — not cold, not warm. Exactly the same temperature as you. As though the sea has decided that fighting you on this particular front is no longer productive.",
+      "The fiftieth time through the Sunken Reef. The water is the wrong temperature \u2014 not cold, not warm. Exactly the same temperature as you. As though the sea has decided that fighting you on this particular front is no longer productive.",
       "Fifty campaigns. You walk in at low tide. The tide seems to have checked your schedule and adjusted accordingly."
     ],
     "milestoneOpenings100": [
-      "The Tidal Sovereign looks at you. Not at Jarv. At you — the person moving the pieces.\n\n'A hundred tides,' it says. Its voice sounds like a wave breaking on stone. 'A hundred returns. I have outlasted coral formations. I have outlasted ships. I have outlasted things that thought themselves permanent.'\n\nA pause. The water around it stills completely.\n\n'And yet here you are. Again. I believe I have been underestimating the situation.'\n\nIt sounds, if such a thing is possible, almost respectful."
+      "The Tidal Sovereign looks at you. Not at Jarv. At you \u2014 the person moving the pieces.\n\n'A hundred tides,' it says. Its voice sounds like a wave breaking on stone. 'A hundred returns. I have outlasted coral formations. I have outlasted ships. I have outlasted things that thought themselves permanent.'\n\nA pause. The water around it stills completely.\n\n'And yet here you are. Again. I believe I have been underestimating the situation.'\n\nIt sounds, if such a thing is possible, almost respectful."
     ]
   },
   "midRunTemplates": [
@@ -109,7 +109,10 @@
   ],
   "introRules": [
     {
-      "condition": { "op": "gte", "value": 100 },
+      "condition": {
+        "op": "gte",
+        "value": 100
+      },
       "panels": [
         {
           "title": "THE SOVEREIGN KNOWS",
@@ -122,7 +125,11 @@
       ]
     },
     {
-      "condition": { "op": "range", "min": 51, "max": 99 },
+      "condition": {
+        "op": "range",
+        "min": 51,
+        "max": 99
+      },
       "panels": [
         {
           "title": "THE {ORDINAL} TIME",
@@ -143,7 +150,10 @@
       ]
     },
     {
-      "condition": { "op": "eq", "value": 50 },
+      "condition": {
+        "op": "eq",
+        "value": 50
+      },
       "panels": [
         {
           "title": "FIFTY CAMPAIGNS",
@@ -164,7 +174,11 @@
       ]
     },
     {
-      "condition": { "op": "range", "min": 26, "max": 49 },
+      "condition": {
+        "op": "range",
+        "min": 26,
+        "max": 49
+      },
       "panels": [
         {
           "title": "THE {ORDINAL} TIME",
@@ -181,7 +195,10 @@
       ]
     },
     {
-      "condition": { "op": "eq", "value": 25 },
+      "condition": {
+        "op": "eq",
+        "value": 25
+      },
       "panels": [
         {
           "title": "TWENTY-FIVE",
@@ -198,7 +215,11 @@
       ]
     },
     {
-      "condition": { "op": "range", "min": 11, "max": 24 },
+      "condition": {
+        "op": "range",
+        "min": 11,
+        "max": 24
+      },
       "panels": [
         {
           "title": "THE {ORDINAL} TIME",
@@ -219,7 +240,10 @@
       ]
     },
     {
-      "condition": { "op": "eq", "value": 10 },
+      "condition": {
+        "op": "eq",
+        "value": 10
+      },
       "panels": [
         {
           "title": "THE TENTH TIME",
@@ -240,7 +264,11 @@
       ]
     },
     {
-      "condition": { "op": "range", "min": 5, "max": 9 },
+      "condition": {
+        "op": "range",
+        "min": 5,
+        "max": 9
+      },
       "panels": [
         {
           "title": "THE {ORDINAL} TIME",
@@ -257,11 +285,15 @@
       ]
     },
     {
-      "condition": { "op": "range", "min": 2, "max": 4 },
+      "condition": {
+        "op": "range",
+        "min": 2,
+        "max": 4
+      },
       "panels": [
         {
           "title": "THE SUNKEN REEF",
-          "text": "The shard hangs half-submerged — a lattice of coral, sunken ships, and old magic.\n\n{pool:priorRunSummaries:0}"
+          "text": "The shard hangs half-submerged \u2014 a lattice of coral, sunken ships, and old magic.\n\n{pool:priorRunSummaries:0}"
         },
         {
           "title": "THE WANDERER",
@@ -273,7 +305,7 @@
         },
         {
           "title": "A FEELING",
-          "text": "And yet — {pool:priorRunOpenings:0}\n\nYou push the feeling aside. There is work to do.\n\nAgain."
+          "text": "And yet \u2014 {pool:priorRunOpenings:0}\n\nYou push the feeling aside. There is work to do.\n\nAgain."
         }
       ]
     }
@@ -281,24 +313,24 @@
   "intro": [
     {
       "title": "THE SUNKEN REEF",
-      "text": "The shard hangs half-submerged — a lattice of coral, sunken ships, and old magic squeezed between two impossible tides.\n\nSomething large lives at its centre. Something old. The traders who escaped this shard don't talk about what they saw, but they all flinch at the same sounds: deep water, and bells.",
+      "text": "The shard hangs half-submerged \u2014 a lattice of coral, sunken ships, and old magic squeezed between two impossible tides.\n\nSomething large lives at its centre. Something old. The traders who escaped this shard don't talk about what they saw, but they all flinch at the same sounds: deep water, and bells.",
       "image": "cutscenes/act5-intro-1.svg"
     },
     {
       "title": "THE TIDAL SOVEREIGN",
-      "text": "The Reef's guardian calls itself the Tidal Sovereign — a being of compressed sea-memory and slow, grinding patience.\n\nIt does not distinguish between invaders and travellers. The ocean, it once said, does not distinguish between ships it sinks and ships it simply forgets about.\n\nYou have decided not to be forgotten.",
+      "text": "The Reef's guardian calls itself the Tidal Sovereign \u2014 a being of compressed sea-memory and slow, grinding patience.\n\nIt does not distinguish between invaders and travellers. The ocean, it once said, does not distinguish between ships it sinks and ships it simply forgets about.\n\nYou have decided not to be forgotten.",
       "image": "cutscenes/act5-intro-2.svg"
     },
     {
       "title": "THE PASSAGE",
-      "text": "The ley lines that thread through the Sunken Reef are old — older than the Fracture, older than the Dominion. They connect, somewhere in the deep, to the Fractured Core.\n\nIf you can break through the Sovereign's grip on the pathways, you might finally understand what the Fracture Event actually was.\n\nIf. The word is doing significant structural work in that sentence.",
+      "text": "The ley lines that thread through the Sunken Reef are old \u2014 older than the Fracture, older than the Dominion. They connect, somewhere in the deep, to the Fractured Core.\n\nIf you can break through the Sovereign's grip on the pathways, you might finally understand what the Fracture Event actually was.\n\nIf. The word is doing significant structural work in that sentence.",
       "image": "cutscenes/act5-intro-3.svg"
     }
   ],
   "outro": [
     {
       "title": "THE SOVEREIGN FALLS",
-      "text": "The Tidal Sovereign does not collapse. It recedes — like a wave pulling back from shore, leaving behind silence and the smell of deep ocean.\n\nThe coral pathways glow. Sealed ley lines crack open. The Reef's memory of the Fracture is vivid and specific and terrifying, and you carry it with you as you leave.",
+      "text": "The Tidal Sovereign does not collapse. It recedes \u2014 like a wave pulling back from shore, leaving behind silence and the smell of deep ocean.\n\nThe coral pathways glow. Sealed ley lines crack open. The Reef's memory of the Fracture is vivid and specific and terrifying, and you carry it with you as you leave.",
       "image": "cutscenes/act5-outro-1.svg"
     },
     {
@@ -308,7 +340,7 @@
     },
     {
       "title": "ONWARD",
-      "text": "The Coral Mantle settles around you — a gift from the Reef, or a remnant of the Sovereign's dissolved form. Either way it fits.\n\nAhead: the Sky Dominion, where the aerial shards drift above clouds no map has ever charted. The ley lines point upward.\n\nYou have always been bad at taking hints.",
+      "text": "The Coral Mantle settles around you \u2014 a gift from the Reef, or a remnant of the Sovereign's dissolved form. Either way it fits.\n\nAhead: the Sky Dominion, where the aerial shards drift above clouds no map has ever charted. The ley lines point upward.\n\nYou have always been bad at taking hints.",
       "image": "cutscenes/act5-outro-3.svg"
     }
   ],
@@ -348,9 +380,9 @@
     },
     "tidal-shrine": {
       "id": "tidal-shrine",
-      "type": "memory",
-      "label": "Memory Fragment",
-      "description": "A carved reef-stone marker, still standing despite the sinking — the inscription faces upward.",
+      "type": "event",
+      "label": "Tidal Shrine",
+      "description": "A coral-encrusted altar partially submerged by the tides. The carvings still glow faintly.",
       "row": 1,
       "col": 0,
       "rowCols": 2,
@@ -358,8 +390,135 @@
         "sunken-passage",
         "node-1776756542614"
       ],
-      "fragmentId": "act5-frag-1",
-      "environment": "reef"
+      "environment": "reef",
+      "eventConfig": {
+        "title": "The Tidal Shrine",
+        "description": "An ancient reef altar, half-buried by the sinking. Bioluminescent coral has grown over the old inscriptions. The sea recedes just enough to let you approach.",
+        "pools": [
+          [
+            {
+              "label": "Offer to the tide",
+              "consequence": "The reef accepts \u2014 restored 12 HP",
+              "effect": {
+                "type": "healHp",
+                "amount": 12
+              }
+            },
+            {
+              "label": "Offer to the tide",
+              "consequence": "Current pulls crystals to shore \u2014 +15 crystals",
+              "effect": {
+                "type": "gainCrystals",
+                "amount": 15
+              }
+            },
+            {
+              "label": "Offer to the tide",
+              "consequence": "The tide takes something back \u2014 lose 8 HP",
+              "effect": {
+                "type": "damageHp",
+                "amount": 8
+              }
+            },
+            {
+              "label": "Offer to the tide",
+              "consequence": "Nothing stirs. Salt and silence.",
+              "effect": {
+                "type": "nothing"
+              }
+            },
+            {
+              "label": "Offer to the tide",
+              "consequence": "A shell with something inside \u2014 added to inventory",
+              "effect": {
+                "type": "gainItem"
+              }
+            }
+          ],
+          [
+            {
+              "label": "Touch the coral glow",
+              "consequence": "Warmth flows through you \u2014 restored 15 HP",
+              "effect": {
+                "type": "healHp",
+                "amount": 15
+              }
+            },
+            {
+              "label": "Touch the coral glow",
+              "consequence": "A card materialises from the light \u2014 uncommon",
+              "effect": {
+                "type": "gainCard",
+                "rarity": "uncommon"
+              }
+            },
+            {
+              "label": "Touch the coral glow",
+              "consequence": "A sting \u2014 lose 10 HP",
+              "effect": {
+                "type": "damageHp",
+                "amount": 10
+              }
+            },
+            {
+              "label": "Touch the coral glow",
+              "consequence": "+20 crystals from the reef cache",
+              "effect": {
+                "type": "gainCrystals",
+                "amount": 20
+              }
+            },
+            {
+              "label": "Touch the coral glow",
+              "consequence": "A curious reef object \u2014 added to inventory",
+              "effect": {
+                "type": "gainItem"
+              }
+            }
+          ],
+          [
+            {
+              "label": "Dive for the inscription",
+              "consequence": "You find a rare card in the deep",
+              "effect": {
+                "type": "gainCard",
+                "rarity": "rare"
+              }
+            },
+            {
+              "label": "Dive for the inscription",
+              "consequence": "+18 crystals from a sunken cache",
+              "effect": {
+                "type": "gainCrystals",
+                "amount": 18
+              }
+            },
+            {
+              "label": "Dive for the inscription",
+              "consequence": "Something unseen bites \u2014 lose 12 HP",
+              "effect": {
+                "type": "damageHp",
+                "amount": 12
+              }
+            },
+            {
+              "label": "Dive for the inscription",
+              "consequence": "Restored 10 HP from the cool water",
+              "effect": {
+                "type": "healHp",
+                "amount": 10
+              }
+            },
+            {
+              "label": "Dive for the inscription",
+              "consequence": "An old reef relic \u2014 added to inventory",
+              "effect": {
+                "type": "gainItem"
+              }
+            }
+          ]
+        ]
+      }
     },
     "wreck-camp": {
       "id": "wreck-camp",
@@ -370,7 +529,8 @@
       "col": 0,
       "rowCols": 4,
       "childIds": [
-        "reef-patrol-elite"
+        "reef-patrol-elite",
+        "mem-act5-1"
       ],
       "environment": "reef",
       "restHeal": 10
@@ -456,7 +616,7 @@
       "id": "deep-current",
       "type": "event",
       "label": "Deep Current",
-      "description": "A ley-line current surfaces here — warm, electric, and full of lost things.",
+      "description": "A ley-line current surfaces here \u2014 warm, electric, and full of lost things.",
       "row": 1,
       "col": 1,
       "rowCols": 2,
@@ -467,7 +627,7 @@
       "environment": "reef",
       "eventConfig": {
         "title": "The Deep Current",
-        "description": "A ley-line current surfaces from a crack in the reef floor. It carries the smell of the Fractured Core — sharp, electric, and ancient. Fragments of Dominion magic swirl in its flow.",
+        "description": "A ley-line current surfaces from a crack in the reef floor. It carries the smell of the Fractured Core \u2014 sharp, electric, and ancient. Fragments of Dominion magic swirl in its flow.",
         "pools": [
           [
             {
@@ -480,7 +640,7 @@
             },
             {
               "label": "Reach in",
-              "consequence": "The current pulls you briefly under — lose 12 HP",
+              "consequence": "The current pulls you briefly under \u2014 lose 12 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 12
@@ -488,7 +648,7 @@
             },
             {
               "label": "Reach in",
-              "consequence": "Something warm and healing — restored 15 HP",
+              "consequence": "Something warm and healing \u2014 restored 15 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 15
@@ -506,7 +666,7 @@
           [
             {
               "label": "Follow it downstream",
-              "consequence": "You find a Dominion salvage cache — +30 crystals",
+              "consequence": "You find a Dominion salvage cache \u2014 +30 crystals",
               "effect": {
                 "type": "gainCrystals",
                 "amount": 30
@@ -514,7 +674,7 @@
             },
             {
               "label": "Follow it downstream",
-              "consequence": "The current ends at a dead drop — uncommon card",
+              "consequence": "The current ends at a dead drop \u2014 uncommon card",
               "effect": {
                 "type": "gainCard",
                 "rarity": "uncommon"
@@ -538,7 +698,7 @@
       "description": "The Tidal Sovereign's personal patrol. They've been waiting for someone like you.",
       "row": 4,
       "col": 0,
-      "rowCols": 2,
+      "rowCols": 3,
       "childIds": [
         "abyssal-ambush"
       ],
@@ -573,7 +733,8 @@
       "col": 1,
       "rowCols": 2,
       "childIds": [
-        "node-1776756544618"
+        "node-1776756544618",
+        "mem-act5-2"
       ],
       "handicap": 13,
       "opponentIntervalMs": 4400,
@@ -598,17 +759,145 @@
     },
     "drowned-shrine": {
       "id": "drowned-shrine",
-      "type": "memory",
-      "label": "Memory Fragment",
-      "description": "A message jar wedged against the old harbour steps, sealed and waiting.",
+      "type": "event",
+      "label": "Drowned Shrine",
+      "description": "A shrine that sank with the cities and was carried back up by the current.",
       "row": 3,
       "col": 2,
       "rowCols": 4,
       "childIds": [
         "reef-patrol-elite"
       ],
-      "fragmentId": "act5-frag-2",
-      "environment": "reef"
+      "environment": "reef",
+      "eventConfig": {
+        "title": "The Drowned Shrine",
+        "description": "This altar was built to last. The rest of the city did not. Salt-bleached carvings still hold shape after decades underwater. Something about it feels expectant.",
+        "pools": [
+          [
+            {
+              "label": "Leave an offering",
+              "consequence": "The shrine stirs the current \u2014 restored 12 HP",
+              "effect": {
+                "type": "healHp",
+                "amount": 12
+              }
+            },
+            {
+              "label": "Leave an offering",
+              "consequence": "Crystals surface from below \u2014 +15 crystals",
+              "effect": {
+                "type": "gainCrystals",
+                "amount": 15
+              }
+            },
+            {
+              "label": "Leave an offering",
+              "consequence": "The water chills sharply \u2014 lose 8 HP",
+              "effect": {
+                "type": "damageHp",
+                "amount": 8
+              }
+            },
+            {
+              "label": "Leave an offering",
+              "consequence": "A waterlogged common card rises",
+              "effect": {
+                "type": "gainCard",
+                "rarity": "common"
+              }
+            },
+            {
+              "label": "Leave an offering",
+              "consequence": "A sealed jar bobs up \u2014 added to inventory",
+              "effect": {
+                "type": "gainItem"
+              }
+            }
+          ],
+          [
+            {
+              "label": "Read the inscriptions",
+              "consequence": "Healing knowledge \u2014 restored 10 HP",
+              "effect": {
+                "type": "healHp",
+                "amount": 10
+              }
+            },
+            {
+              "label": "Read the inscriptions",
+              "consequence": "An uncommon card forms from the reading",
+              "effect": {
+                "type": "gainCard",
+                "rarity": "uncommon"
+              }
+            },
+            {
+              "label": "Read the inscriptions",
+              "consequence": "Something bad is written here \u2014 lose 6 HP",
+              "effect": {
+                "type": "damageHp",
+                "amount": 6
+              }
+            },
+            {
+              "label": "Read the inscriptions",
+              "consequence": "+18 crystals from a reef tribute box",
+              "effect": {
+                "type": "gainCrystals",
+                "amount": 18
+              }
+            },
+            {
+              "label": "Read the inscriptions",
+              "consequence": "A marker stone \u2014 added to inventory",
+              "effect": {
+                "type": "gainItem"
+              }
+            }
+          ],
+          [
+            {
+              "label": "Submerge yourself in prayer",
+              "consequence": "+1 life granted by the deep",
+              "effect": {
+                "type": "gainLife",
+                "amount": 1
+              }
+            },
+            {
+              "label": "Submerge yourself in prayer",
+              "consequence": "Rare card surfaces \u2014 rare",
+              "effect": {
+                "type": "gainCard",
+                "rarity": "rare"
+              }
+            },
+            {
+              "label": "Submerge yourself in prayer",
+              "consequence": "You stay too long \u2014 lose 15 HP",
+              "effect": {
+                "type": "damageHp",
+                "amount": 15
+              }
+            },
+            {
+              "label": "Submerge yourself in prayer",
+              "consequence": "+25 crystals drifting up",
+              "effect": {
+                "type": "gainCrystals",
+                "amount": 25
+              }
+            },
+            {
+              "label": "Submerge yourself in prayer",
+              "consequence": "Something presses into your hand \u2014 added to inventory",
+              "effect": {
+                "type": "gainItem"
+              }
+            }
+          ]
+        ]
+      }
     },
     "depth-rest": {
       "id": "depth-rest",
@@ -631,7 +920,7 @@
       "description": "A half-awake leviathan guards the approach to the Sovereign's sanctum.",
       "row": 4,
       "col": 1,
-      "rowCols": 2,
+      "rowCols": 3,
       "childIds": [
         "kelp-crossing"
       ],
@@ -702,7 +991,7 @@
       "id": "node-1776756542614",
       "type": "battle",
       "label": "The Kelp Forest",
-      "description": "So dense is the kelp, that you can’t see where you’ve been, or where to go…",
+      "description": "So dense is the kelp, that you can\u2019t see where you\u2019ve been, or where to go\u2026",
       "row": 2,
       "col": 1,
       "rowCols": 4,
@@ -801,10 +1090,10 @@
       "id": "node-1776756544618",
       "type": "battle",
       "label": "The Wash",
-      "description": "Water pulls your feet from under you, you struggle to steady yourself, and then you see something wrap around your leg…",
+      "description": "Water pulls your feet from under you, you struggle to steady yourself, and then you see something wrap around your leg\u2026",
       "row": 6,
       "col": 0,
-      "rowCols": 1,
+      "rowCols": 2,
       "childIds": [
         "tidal-sovereign"
       ],
@@ -815,6 +1104,34 @@
         "Tide Stable",
         "Tide Shrine"
       ]
+    },
+    "mem-act5-1": {
+      "id": "mem-act5-1",
+      "type": "memory",
+      "label": "Memory Fragment",
+      "description": "A ship's logbook pressed against coral \u2014 the last entry describes the reef before it sank, still legible in waterproof ink.",
+      "row": 4,
+      "col": 2,
+      "rowCols": 3,
+      "childIds": [
+        "abyssal-ambush"
+      ],
+      "fragmentId": "act5-frag-1",
+      "environment": "reef"
+    },
+    "mem-act5-2": {
+      "id": "mem-act5-2",
+      "type": "memory",
+      "label": "Memory Fragment",
+      "description": "A bell from a drowned tower, still tolling in the current \u2014 each ring carries the voice of someone who tried to warn the others.",
+      "row": 6,
+      "col": 1,
+      "rowCols": 2,
+      "childIds": [
+        "tidal-sovereign"
+      ],
+      "fragmentId": "act5-frag-2",
+      "environment": "reef"
     }
   }
 }

--- a/web/src/data/memoryFragments.json
+++ b/web/src/data/memoryFragments.json
@@ -1,0 +1,72 @@
+[
+  {
+    "id": "act1-frag-1",
+    "actId": "act1",
+    "nodeId": "memory-act1-1",
+    "title": "Fragment: The Fracture at Noon",
+    "body": "It happened during the mid-harvest. I remember because I was counting crates.\n\nOne moment the sky was blue. Then it split — not like a storm, but like a seam giving way on something enormous. A sound that wasn't quite sound. Every bird in the Verdant Shard lifted at once and didn't come back.\n\nThe paths sealed themselves before I could reach the gate. I found this note pressed into the bark of the oldest oak three days later, in handwriting that wasn't mine."
+  },
+  {
+    "id": "act1-frag-2",
+    "actId": "act1",
+    "nodeId": "memory-act1-2",
+    "title": "Fragment: The Thornlord's Oath",
+    "body": "He spoke only once about it, in the early days after the sealing.\n\n'I felt the Fracture the way a tree feels a root pulled free — not pain, but wrongness. A foundational thing, absent.' He pressed his bark-hands together. 'The Dominion built its roads through here for four hundred years and I permitted it. Now there are no roads and no Dominion and I am the only continuity this shard has left.'\n\nHe sealed the paths that same evening. Nobody argued. There was nobody left to argue."
+  },
+  {
+    "id": "act2-frag-1",
+    "actId": "act2",
+    "nodeId": "memory-act2-1",
+    "title": "Fragment: The General's Last Order",
+    "body": "CITADEL COMMAND LOG — DAY OF FRACTURE\n\nAll available troops to the inner walls. Communications to the capital: unresponsive. East road: sealed. Supply line from the valley: gone.\n\nThe General's final recorded order was: 'Hold the Citadel. Hold it until someone comes to relieve you or until you understand that no one is coming. Either outcome will teach you something.'\n\nThe relief never came. The troops held. This fragment was found between the stones of the main gate, folded small."
+  },
+  {
+    "id": "act2-frag-2",
+    "actId": "act2",
+    "nodeId": "memory-act2-2",
+    "title": "Fragment: The Commander's Dilemma",
+    "body": "Three hundred soldiers. Enough rations for six weeks, if we're careful. The gates are sealed and I don't know if we sealed them or the Fracture did.\n\nCivilians in the lower courtyard asked me what happens next. I told them we wait for orders. This was a lie — there are no orders, there is no chain of command, and the General hasn't spoken since the sealing.\n\nI closed the gate anyway. It seemed like the thing to do. Now I'm not sure if I was protecting them from outside, or protecting the Citadel from what we might become."
+  },
+  {
+    "id": "act3-frag-1",
+    "actId": "act3",
+    "nodeId": "memory-act3-1",
+    "title": "Fragment: The Scholar's Warning",
+    "body": "FIELD NOTES — ASHEN WASTES RESEARCH STATION — 14 DAYS BEFORE FRACTURE\n\nThe ley lines are not degrading. They are redirecting. This is categorically different from natural fluctuation and I cannot get the Academy to return my correspondence.\n\nSomething is drawing on the deep lines. Not slowly — aggressively. The stone here has begun to warm at the junctions. The ash deposits predate anything in our geological record, which means they predate the Dominion, which means the Wastes were on fire before we arrived and we built here anyway.\n\nI am beginning to think the Fracture is not an event. It is a disclosure."
+  },
+  {
+    "id": "act3-frag-2",
+    "actId": "act3",
+    "nodeId": "memory-act3-2",
+    "title": "Fragment: After the Flame",
+    "body": "When the sky cracked, the ash rose first. Not settled — rose. Against gravity, against wind, against sense.\n\nBy the time it came back down the paths were gone and the old things in the deep rock had woken. They aren't hostile, exactly. They're confused, the way you're confused when someone breaks into your house and then asks for directions.\n\nWe called ourselves the Ash Covenant, those of us who stayed. Not because we chose the ash. Because the ash was the only thing still there."
+  },
+  {
+    "id": "act4-frag-1",
+    "actId": "act4",
+    "nodeId": "memory-act4-1",
+    "title": "Fragment: Resonance Report 7",
+    "body": "CRYSTAL SPIRE RESEARCH DIVISION — INTERNAL DOCUMENT\n\nThe central array is responding to something it shouldn't be able to detect. Signal profile matches theoretical fracture-resonance — a frequency we modelled but never expected to observe because the conditions required to produce it are, under normal physics, impossible.\n\nWe are currently operating under conditions that are, under normal physics, impossible.\n\nRecommendation: reduce the amplification coefficient before the array begins reflecting rather than absorbing. Filed 11 days before the Fracture. No action was taken."
+  },
+  {
+    "id": "act4-frag-2",
+    "actId": "act4",
+    "nodeId": "memory-act4-2",
+    "title": "Fragment: The Arcanist's Theory",
+    "body": "My colleagues call it catastrophism. I call it the only model that fits the evidence.\n\nThe Fracture was not an accident. It was a result. Something — or someone — pushed energy through the deep ley network at a scale that the infrastructure couldn't carry, and the Dominion shattered along every fault line that had been quietly accumulating for centuries.\n\nThe question is not what caused the Fracture. The question is what wanted the Dominion gone badly enough to find a way. This note was sealed in crystal and hidden in the archive. I don't know by whom."
+  },
+  {
+    "id": "act5-frag-1",
+    "actId": "act5",
+    "nodeId": "memory-act5-1",
+    "title": "Fragment: The Reef Song",
+    "body": "Before the sinking we had seven cities. You could walk between them on the ridge paths at low tide, and the oldest ones say their grandparents did this barefoot without thinking.\n\nThe reef was a map. Every coral structure marked something — a boundary, a name, a history. We read the water the way inland people read roads.\n\nWe still read it. We just read it from further down now."
+  },
+  {
+    "id": "act5-frag-2",
+    "actId": "act5",
+    "nodeId": "memory-act5-2",
+    "title": "Fragment: The Great Sinking",
+    "body": "The sea didn't rise. The land fell.\n\nWe had two hours of warning — the fish went still, the current reversed, and then the whole shelf dropped three fathoms in a single breath. Most of us were already moving before we understood why.\n\nThe cities didn't collapse. They descended, intact, into the shallows. You can see them at low tide if the water is clear enough — spires and market squares and homes, perfectly preserved, perfectly unreachable. A shrine found this note sealed in a jar, lodged against the old harbour steps."
+  }
+]

--- a/web/src/game/codex.ts
+++ b/web/src/game/codex.ts
@@ -3,6 +3,7 @@ import { loadCollection } from './collection'
 import { getRelics } from './itemStore'
 import { loadActCount } from './questline'
 import relicsData from '../data/relics.json'
+import memoryFragmentsData from '../data/memoryFragments.json'
 
 import act1Data from '../data/acts/act1.json'
 import act2Data from '../data/acts/act2.json'
@@ -25,6 +26,53 @@ const ALL_ACTS: any[] = [
   act6Data, act7Data, act8Data, act9Data, act10Data,
   act11Data, act12Data, act13Data, actFinaleData,
 ]
+
+const FRAGMENT_KEY = 'jarv_memory_fragments'
+
+export interface MemoryFragment {
+  id: string
+  actId: string
+  nodeId: string
+  title: string
+  body: string
+}
+
+export interface CodexFragmentEntry extends MemoryFragment {
+  discovered: boolean
+}
+
+export function getDiscoveredFragmentIds(): Set<string> {
+  try {
+    const raw = localStorage.getItem(FRAGMENT_KEY)
+    if (!raw) return new Set()
+    return new Set(JSON.parse(raw) as string[])
+  } catch { return new Set() }
+}
+
+export function isFragmentDiscovered(id: string): boolean {
+  return getDiscoveredFragmentIds().has(id)
+}
+
+/** Returns true if this discovery completed all fragments for the act (bonus trigger). */
+export function markFragmentDiscovered(id: string): boolean {
+  const discovered = getDiscoveredFragmentIds()
+  if (discovered.has(id)) return false
+  discovered.add(id)
+  try { localStorage.setItem(FRAGMENT_KEY, JSON.stringify([...discovered])) } catch { /* ignore */ }
+  const frags = memoryFragmentsData as MemoryFragment[]
+  const frag = frags.find(f => f.id === id)
+  if (!frag) return false
+  const actFragIds = frags.filter(f => f.actId === frag.actId).map(f => f.id)
+  return actFragIds.every(fid => discovered.has(fid))
+}
+
+export function getCodexFragments(): CodexFragmentEntry[] {
+  const discovered = getDiscoveredFragmentIds()
+  return (memoryFragmentsData as MemoryFragment[]).map(f => ({
+    ...f,
+    discovered: discovered.has(f.id),
+  }))
+}
 
 export interface CodexCardEntry {
   name: string

--- a/web/src/game/questline.ts
+++ b/web/src/game/questline.ts
@@ -127,7 +127,7 @@ export interface ReplayModifier {
 
 // ─── Node & Act types ─────────────────────────────────────
 
-export type NodeType = 'battle' | 'elite' | 'boss' | 'rest' | 'event' | 'merchant'
+export type NodeType = 'battle' | 'elite' | 'boss' | 'rest' | 'event' | 'merchant' | 'memory'
 
 export interface QuestNode {
   id: string
@@ -145,6 +145,7 @@ export interface QuestNode {
   bossName?: string      // display name for the boss (overrides bossCard name in UI)
   bossHpMultiplier?: number  // multiplier applied to boss card unit's HP (default 10)
   eventConfig?: NodeEventConfig
+  fragmentId?: string
   bossDialogue?: string[]  // lines the boss speaks before the fight
   bossIntro?: CutscenePanel[]  // cutscene panels shown before boss dialogue
   /** Preset enemy deck — card names in order. Makes each node deterministic and learnable. */

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -5424,6 +5424,57 @@ body {
 }
 .mystery-collect-btn { margin-top: 8px; }
 
+/* ─── Memory Fragment Screen ─────────────────────────── */
+.memory-screen {
+  padding: 32px 16px;
+  max-width: 560px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+.memory-type-tag {
+  font-size: 0.7rem;
+  color: #aaddff;
+  letter-spacing: 0.3em;
+}
+.memory-title {
+  font-size: 1.1rem;
+  color: #aaddff;
+  letter-spacing: 0.05em;
+  border-bottom: 1px solid #334466;
+  padding-bottom: 12px;
+}
+.memory-body {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.memory-para {
+  font-size: 0.85rem;
+  color: var(--fg);
+  line-height: 1.7;
+  margin: 0;
+}
+.memory-already-found {
+  font-size: 0.65rem;
+  color: var(--game-text-color-muted);
+  letter-spacing: 0.25em;
+  text-align: center;
+}
+.memory-shard-bonus {
+  font-size: 0.8rem;
+  color: #aaddff;
+  border: 1px solid #334466;
+  background: #050a15;
+  padding: 12px 16px;
+  line-height: 1.6;
+}
+.memory-collect-btn {
+  align-self: flex-start;
+  margin-top: 8px;
+}
+
 /* ─── Item Found Screen ───────────────────────────────── */
 .item-found-screen {
   padding: 32px 16px;


### PR DESCRIPTION
## Summary

- Adds 10 authored lore fragments (2 per act, acts 1–5) that persist cross-run via localStorage
- New `memory` node type (◆ icon) replaces 2 event nodes per act in acts 1–5
- Discovering a fragment shows a lore screen; finding both in an act grants a Health Potion bonus
- Codex grows a 4th **FRAGMENTS** tab showing discovered entries and `???` for locked ones
- Already-discovered fragments are still readable on revisit with no re-reward

## Files changed

- `memoryFragments.json` — 10 lore fragments authored across acts 1–5
- `questline.ts` — `'memory'` added to `NodeType`; `fragmentId?` added to `QuestNode`
- `codex.ts` — `MemoryFragment`, `CodexFragmentEntry`, `getCodexFragments()`, `isFragmentDiscovered()`, `markFragmentDiscovered()`
- `MemoryFragmentScreen.tsx` — new discovery screen (reuses `.event-screen` CSS patterns)
- `NodeMap.tsx` — ◆ icon + MEMORY label + event sprite fallback
- `PostBattleReward.tsx` — `memory` entry added to exhaustive `NODE_FLAVOUR` record
- `CodexScreen.tsx` — FRAGMENTS tab (4th tab)
- `styles.css` — `.memory-screen` component styles
- `acts/act1–5.json` — 2 event nodes per act replaced with memory nodes

## Test plan

- [ ] Start a new campaign run on Act 1 — memory nodes (◆) appear on the map
- [ ] Click a memory node → MemoryFragmentScreen shows lore, "ADD TO CODEX ›" button
- [ ] Click "ADD TO CODEX ›" → returns to map, node shows as completed
- [ ] Open Codex → FRAGMENTS tab shows the discovered fragment; others show as `???`
- [ ] Discover both Act 1 fragments → Health Potion granted, confirmation shown on screen
- [ ] Start a new run → fragment still shows as discovered (persists cross-run), node completable but shows "ALREADY DISCOVERED" with no re-reward
- [ ] Build passes: `tsc && vite build` clean ✓

https://claude.ai/code/session_01X1dTjbXJx9e3ve32RDiebf

---
_Generated by [Claude Code](https://claude.ai/code/session_01X1dTjbXJx9e3ve32RDiebf)_