### PR TITLE
feat: memory fragments for acts 6–13

### DIFF
--- a/web/src/data/acts/act10.json
+++ b/web/src/data/acts/act10.json
@@ -45,7 +45,7 @@
       "Now, technically, a recurring customer the Dune Baron has stopped finding surprising.",
       "Now, effectively, the sort of person who fights through desert markets for a living.",
       "Now, in the commercial sense, back for another transaction the Baron didn't invoice for.",
-      "Now — by every merchant's assessment — bad for business in ways that keep being underestimated.",
+      "Now \u2014 by every merchant's assessment \u2014 bad for business in ways that keep being underestimated.",
       "Now, technically, a repeat visitor the Baron has started factoring into his quarterly projections."
     ],
     "jarvIntros": [
@@ -56,7 +56,7 @@
       "You have a deck of cards. The Baron has you in his books now. He has had you in his books for some time. This doesn't seem to be helping him."
     ],
     "marketDesc": [
-      "The ley lines run straight through the desert, which the Sand Market has spent decades making commercially relevant. The market sits at the convergence — spice stalls, weapon traders, and things that aren't technically legal but are priced very professionally.",
+      "The ley lines run straight through the desert, which the Sand Market has spent decades making commercially relevant. The market sits at the convergence \u2014 spice stalls, weapon traders, and things that aren't technically legal but are priced very professionally.",
       "The Sand Market smells like spice and hot metal and the particular anxiety of an economy that is built on top of a ley convergence and hoping nobody destabilises it.",
       "The Sand Market waits at the desert's heart, its spire visible from two days out. The Baron's banners hang in the windless heat. They have been there since before you arrived. They will be there after.",
       "The ley lines converge beneath the market's central spire. The Dune Baron uses the energy surplus to power his lights, his weapons, and his extremely comprehensive record-keeping."
@@ -68,15 +68,15 @@
       "The Dune Baron has been briefed on your approach. His response, according to his aide, was to update the insurance on the central spire and order more of whatever he lost last time."
     ],
     "priorRunSummaries": [
-      "The heat felt familiar — the particular weight of it, the way it turned sound sluggish and light sharp. Like a market you'd been overcharged in before.",
-      "The first approach through the dune corridor was wrong. Not directionally wrong — patterned wrong, the way a route feels wrong when someone has added defensive positions since you were last here.",
+      "The heat felt familiar \u2014 the particular weight of it, the way it turned sound sluggish and light sharp. Like a market you'd been overcharged in before.",
+      "The first approach through the dune corridor was wrong. Not directionally wrong \u2014 patterned wrong, the way a route feels wrong when someone has added defensive positions since you were last here.",
       "Something about the patrol spacing at the market perimeter. The exact interval of it. You adjusted your approach without thinking, which meant you'd made that adjustment before.",
       "The market was quieter on approach than it should have been. As though someone had sent a message ahead that a particular customer was returning."
     ],
     "priorRunOpenings": [
       "You had been here. Your feet found the route through the first dune corridor before the heat haze cleared enough to confirm it.",
       "The Sand Raider unit at the outer perimeter didn't charge. They looked at each other. Then sent a runner to the Baron. Then charged.",
-      "The Dune Baron's opening deployment was different this time — heavier on the left flank, lighter on the spire approach. He'd been studying your patterns.",
+      "The Dune Baron's opening deployment was different this time \u2014 heavier on the left flank, lighter on the spire approach. He'd been studying your patterns.",
       "The market bells rang when you arrived. Not the welcoming ones. The other ones."
     ],
     "milestoneOpenings5": [
@@ -105,12 +105,15 @@
     "{n} campaigns in. The Sand Raiders at the outer perimeter have started placing bets. The smart money has been consistently on you for some time.",
     "{n} times you've walked through the Baron's market. The heat is the same. Your tolerance for the Baron's particular brand of economic warfare has become something he finds professionally frustrating.",
     "Run {n}. You arrive at the outer dunes and find the patrol already in position. The Baron has been running projections.",
-    "The {ordinalLower} attempt. The market smells the same — spice and hot metal and something expensive. Your reaction to it has become something close to routine.",
+    "The {ordinalLower} attempt. The market smells the same \u2014 spice and hot metal and something expensive. Your reaction to it has become something close to routine.",
     "{n} campaigns. The Dune Baron's ledger entry for 'the Jarv problem' is now the longest single entry in his accounting history."
   ],
   "introRules": [
     {
-      "condition": { "op": "gte", "value": 100 },
+      "condition": {
+        "op": "gte",
+        "value": 100
+      },
       "panels": [
         {
           "title": "THE BARON SETTLES ACCOUNTS",
@@ -123,7 +126,11 @@
       ]
     },
     {
-      "condition": { "op": "range", "min": 51, "max": 99 },
+      "condition": {
+        "op": "range",
+        "min": 51,
+        "max": 99
+      },
       "panels": [
         {
           "title": "THE {ORDINAL} TIME",
@@ -144,7 +151,10 @@
       ]
     },
     {
-      "condition": { "op": "eq", "value": 50 },
+      "condition": {
+        "op": "eq",
+        "value": 50
+      },
       "panels": [
         {
           "title": "FIFTY CAMPAIGNS",
@@ -165,7 +175,11 @@
       ]
     },
     {
-      "condition": { "op": "range", "min": 26, "max": 49 },
+      "condition": {
+        "op": "range",
+        "min": 26,
+        "max": 49
+      },
       "panels": [
         {
           "title": "THE {ORDINAL} TIME",
@@ -182,7 +196,10 @@
       ]
     },
     {
-      "condition": { "op": "eq", "value": 25 },
+      "condition": {
+        "op": "eq",
+        "value": 25
+      },
       "panels": [
         {
           "title": "TWENTY-FIVE",
@@ -199,7 +216,11 @@
       ]
     },
     {
-      "condition": { "op": "range", "min": 11, "max": 24 },
+      "condition": {
+        "op": "range",
+        "min": 11,
+        "max": 24
+      },
       "panels": [
         {
           "title": "THE {ORDINAL} TIME",
@@ -220,7 +241,10 @@
       ]
     },
     {
-      "condition": { "op": "eq", "value": 10 },
+      "condition": {
+        "op": "eq",
+        "value": 10
+      },
       "panels": [
         {
           "title": "THE TENTH TIME",
@@ -241,7 +265,11 @@
       ]
     },
     {
-      "condition": { "op": "range", "min": 5, "max": 9 },
+      "condition": {
+        "op": "range",
+        "min": 5,
+        "max": 9
+      },
       "panels": [
         {
           "title": "THE {ORDINAL} TIME",
@@ -258,11 +286,15 @@
       ]
     },
     {
-      "condition": { "op": "range", "min": 2, "max": 4 },
+      "condition": {
+        "op": "range",
+        "min": 2,
+        "max": 4
+      },
       "panels": [
         {
           "title": "THE SAND MARKET",
-          "text": "The ley lines run through the desert — again.\n\n{pool:priorRunSummaries:0}"
+          "text": "The ley lines run through the desert \u2014 again.\n\n{pool:priorRunSummaries:0}"
         },
         {
           "title": "THE WANDERER",
@@ -274,7 +306,7 @@
         },
         {
           "title": "A FEELING",
-          "text": "And yet — {pool:priorRunOpenings:0}\n\nYou push the feeling aside. There is work to do.\n\nAgain."
+          "text": "And yet \u2014 {pool:priorRunOpenings:0}\n\nYou push the feeling aside. There is work to do.\n\nAgain."
         }
       ]
     }
@@ -282,7 +314,7 @@
   "intro": [
     {
       "title": "THE SAND MARKET",
-      "text": "The ley lines run straight through the desert, which the Sand Market has spent decades making commercially relevant. The market grew up around the ley convergence — vendors first, then traders, then mercenaries, then the Dune Baron, who saw the strategic value and started charging for it.\n\nEverything here has a price. Including passage through it.",
+      "text": "The ley lines run straight through the desert, which the Sand Market has spent decades making commercially relevant. The market grew up around the ley convergence \u2014 vendors first, then traders, then mercenaries, then the Dune Baron, who saw the strategic value and started charging for it.\n\nEverything here has a price. Including passage through it.",
       "image": "cutscenes/act10-intro-1.svg"
     },
     {
@@ -292,14 +324,14 @@
     },
     {
       "title": "THE MARKET ROUTE",
-      "text": "The ley lines converge beneath the market's central spire — the Dune Baron uses the energy surplus to power the lights, the forges, and the contract-binding seals that make his mercenary arrangements legally enforceable.\n\nYou need the convergence point. He isn't selling it.\n\nYou're going to take it. He'll probably factor this into his pricing for the next traveller.",
+      "text": "The ley lines converge beneath the market's central spire \u2014 the Dune Baron uses the energy surplus to power the lights, the forges, and the contract-binding seals that make his mercenary arrangements legally enforceable.\n\nYou need the convergence point. He isn't selling it.\n\nYou're going to take it. He'll probably factor this into his pricing for the next traveller.",
       "image": "cutscenes/act10-intro-3.svg"
     }
   ],
   "outro": [
     {
       "title": "THE DUNE BARON SETTLES",
-      "text": "The Dune Baron doesn't lose gracefully. He loses expensively — which means he calculates the cost of the outcome, determines it was within acceptable parameters, and files the result under 'resolved.'\n\nThe ley lines pulse through the market floor. The convergence point opens.\n\nHe's already thinking about what to charge the next person who shows up.",
+      "text": "The Dune Baron doesn't lose gracefully. He loses expensively \u2014 which means he calculates the cost of the outcome, determines it was within acceptable parameters, and files the result under 'resolved.'\n\nThe ley lines pulse through the market floor. The convergence point opens.\n\nHe's already thinking about what to charge the next person who shows up.",
       "image": "cutscenes/act10-outro-1.svg"
     },
     {
@@ -309,7 +341,7 @@
     },
     {
       "title": "THE GOLDEN COMPASS",
-      "text": "The Golden Compass sits warm in your palm — the Baron's personal navigation tool, used to track ley line convergences across the desert. It still points to them.\n\nIt also, apparently, makes you faster off the mark. The Baron claims he hadn't noticed that. You don't believe him.\n\nThe ley lines point on. The market recedes. The desert is, for once, quiet.",
+      "text": "The Golden Compass sits warm in your palm \u2014 the Baron's personal navigation tool, used to track ley line convergences across the desert. It still points to them.\n\nIt also, apparently, makes you faster off the mark. The Baron claims he hadn't noticed that. You don't believe him.\n\nThe ley lines point on. The market recedes. The desert is, for once, quiet.",
       "image": "cutscenes/act10-outro-3.svg"
     }
   ],
@@ -355,7 +387,7 @@
       "description": "A spring shrine at a desert oasis. The water is real. The hospitality is negotiable.",
       "row": 2,
       "col": 0,
-      "rowCols": 3,
+      "rowCols": 4,
       "childIds": [
         "caravan-elite"
       ],
@@ -367,7 +399,7 @@
           [
             {
               "label": "Drink from the spring",
-              "consequence": "The water restores — healed 14 HP",
+              "consequence": "The water restores \u2014 healed 14 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 14
@@ -375,7 +407,7 @@
             },
             {
               "label": "Drink from the spring",
-              "consequence": "Something in it stings — lose 6 HP",
+              "consequence": "Something in it stings \u2014 lose 6 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 6
@@ -401,7 +433,7 @@
           [
             {
               "label": "Search the offering-stones",
-              "consequence": "Something useful left behind — uncommon card",
+              "consequence": "Something useful left behind \u2014 uncommon card",
               "effect": {
                 "type": "gainCard",
                 "rarity": "uncommon"
@@ -409,7 +441,7 @@
             },
             {
               "label": "Search the offering-stones",
-              "consequence": "Coins left as offerings — +22 crystals",
+              "consequence": "Coins left as offerings \u2014 +22 crystals",
               "effect": {
                 "type": "gainCrystals",
                 "amount": 22
@@ -426,7 +458,7 @@
           [
             {
               "label": "Fill your reserves",
-              "consequence": "The water heals on the road — healed 8 HP",
+              "consequence": "The water heals on the road \u2014 healed 8 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 8
@@ -473,7 +505,7 @@
       "description": "A sheltered hollow in the dune line. Out of the wind and out of sight.",
       "row": 2,
       "col": 2,
-      "rowCols": 3,
+      "rowCols": 4,
       "childIds": [
         "desert-spire"
       ],
@@ -487,7 +519,7 @@
       "description": "The market's fringe traders. Lower prices than inside. Fewer questions.",
       "row": 2,
       "col": 1,
-      "rowCols": 3,
+      "rowCols": 4,
       "childIds": [
         "caravan-elite",
         "desert-spire"
@@ -715,12 +747,12 @@
       "environment": "sand",
       "eventConfig": {
         "title": "The Mirage Cache",
-        "description": "A concealed depot in the dune face — the Baron's forces maintain several, and not all of them are decoys. This one is real. The lock is good but not insurmountable.",
+        "description": "A concealed depot in the dune face \u2014 the Baron's forces maintain several, and not all of them are decoys. This one is real. The lock is good but not insurmountable.",
         "pools": [
           [
             {
               "label": "Open the cache",
-              "consequence": "Weapons inside — rare card",
+              "consequence": "Weapons inside \u2014 rare card",
               "effect": {
                 "type": "gainCard",
                 "rarity": "rare"
@@ -728,7 +760,7 @@
             },
             {
               "label": "Open the cache",
-              "consequence": "Supplies — healed 15 HP",
+              "consequence": "Supplies \u2014 healed 15 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 15
@@ -736,7 +768,7 @@
             },
             {
               "label": "Open the cache",
-              "consequence": "It was a decoy — lose 12 HP",
+              "consequence": "It was a decoy \u2014 lose 12 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 12
@@ -762,7 +794,7 @@
             },
             {
               "label": "Sell the contents",
-              "consequence": "One item worth keeping — uncommon card",
+              "consequence": "One item worth keeping \u2014 uncommon card",
               "effect": {
                 "type": "gainCard",
                 "rarity": "uncommon"
@@ -853,19 +885,19 @@
       "description": "The Baron's records room. Every transaction since the market opened.",
       "row": 13,
       "col": 0,
-      "rowCols": 2,
+      "rowCols": 3,
       "childIds": [
         "baron-vanguard"
       ],
       "environment": "sand",
       "eventConfig": {
         "title": "The Baron's Ledger",
-        "description": "The Dune Baron's transaction records — every contract, every sale, every mercenary hired and dismissed since the market was established. His notes on the Fracture are in here. He logged it as a business disruption.",
+        "description": "The Dune Baron's transaction records \u2014 every contract, every sale, every mercenary hired and dismissed since the market was established. His notes on the Fracture are in here. He logged it as a business disruption.",
         "pools": [
           [
             {
               "label": "Study the contracts",
-              "consequence": "Exploitable intel — rare card",
+              "consequence": "Exploitable intel \u2014 rare card",
               "effect": {
                 "type": "gainCard",
                 "rarity": "rare"
@@ -873,7 +905,7 @@
             },
             {
               "label": "Study the contracts",
-              "consequence": "Supply chain map — +28 crystals",
+              "consequence": "Supply chain map \u2014 +28 crystals",
               "effect": {
                 "type": "gainCrystals",
                 "amount": 28
@@ -883,7 +915,7 @@
           [
             {
               "label": "Rest in the records room",
-              "consequence": "Quiet and warm — healed 15 HP",
+              "consequence": "Quiet and warm \u2014 healed 15 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 15
@@ -908,7 +940,7 @@
       "description": "The Baron's personal guest quarters. Better than anything outside the market walls.",
       "row": 13,
       "col": 1,
-      "rowCols": 2,
+      "rowCols": 3,
       "childIds": [
         "baron-vanguard"
       ],
@@ -1029,7 +1061,8 @@
       "col": 2,
       "rowCols": 3,
       "childIds": [
-        "dune-hollow"
+        "dune-hollow",
+        "mem-act10-1"
       ],
       "handicap": 20,
       "opponentIntervalMs": 4500,
@@ -1062,7 +1095,8 @@
       "rowCols": 1,
       "childIds": [
         "trade-archive",
-        "market-rest"
+        "market-rest",
+        "mem-act10-2"
       ],
       "handicap": 28,
       "opponentIntervalMs": 3800,
@@ -1409,6 +1443,34 @@
         "Mercenary Pact",
         "Sandstorm"
       ]
+    },
+    "mem-act10-1": {
+      "id": "mem-act10-1",
+      "type": "memory",
+      "label": "Memory Fragment",
+      "description": "The last trade ledger \u2014 fourteen caravans dispatched the morning of the Fracture, none arrived.",
+      "row": 2,
+      "col": 3,
+      "rowCols": 4,
+      "childIds": [
+        "desert-spire"
+      ],
+      "fragmentId": "act10-frag-1",
+      "environment": "sand"
+    },
+    "mem-act10-2": {
+      "id": "mem-act10-2",
+      "type": "memory",
+      "label": "Memory Fragment",
+      "description": "The Dune Baron's memo on pivoting from trade routes to information brokerage.",
+      "row": 13,
+      "col": 2,
+      "rowCols": 3,
+      "childIds": [
+        "baron-vanguard"
+      ],
+      "fragmentId": "act10-frag-2",
+      "environment": "sand"
     }
   }
 }

--- a/web/src/data/acts/act11.json
+++ b/web/src/data/acts/act11.json
@@ -45,7 +45,7 @@
       "Now, technically, in a forest that is old enough to have an opinion about it.",
       "Now, effectively, the sort of person who disturbs ancient canopy ecosystems for professional reasons.",
       "Now, professionally speaking, back under a canopy that has been watching you since the first time.",
-      "Now — by any arborist's estimate — somewhere that was perfectly quiet before you arrived.",
+      "Now \u2014 by any arborist's estimate \u2014 somewhere that was perfectly quiet before you arrived.",
       "Now, technically, in a place that has been alive longer than the concept of visiting it has existed."
     ],
     "jarvIntros": [
@@ -57,25 +57,25 @@
     ],
     "canopyDesc": [
       "The ley lines rise into the high canopy here, threading through root systems older than memory and up into the living dark of the oldest forest in the shards.",
-      "The Verdant Canopy smells like green age — the particular scent of a place that has been photosynthesising since before the things living near it had names.",
+      "The Verdant Canopy smells like green age \u2014 the particular scent of a place that has been photosynthesising since before the things living near it had names.",
       "The Verdant Canopy waits above the treeline, its interlocking branches forming a second sky. The ley lines are somewhere in the dark above. Something sovereign is between you and them.",
       "The ley lines thread through the heartwood of the Canopy's oldest trees. The Warden grew around them. They are, in some sense the Warden understands and you are still working out, the same thing."
     ],
     "wardenDesc": [
-      "The Elder Warden is not a creature in any familiar sense — it is the canopy made sovereign, a convergence of root and memory and the particular will that forms when something old enough stops being patient.\n\nIt does not distinguish between threats and visitors. The canopy doesn't make that distinction. Neither does it.",
+      "The Elder Warden is not a creature in any familiar sense \u2014 it is the canopy made sovereign, a convergence of root and memory and the particular will that forms when something old enough stops being patient.\n\nIt does not distinguish between threats and visitors. The canopy doesn't make that distinction. Neither does it.",
       "The Elder Warden holds every approach through the Canopy closed. It is ancient, distributed, and aware of everything that passes beneath the oldest branches.\n\nIt was aware of you before you reached the treeline.",
       "The Elder Warden tends the Canopy with the unhurried certainty of something that has outlasted every other argument against its existence.\n\nYou are about to become its most recent argument.",
       "The Elder Warden has been aware of your approach since your last departure. It has been growing responses. The Canopy is very good at growing things."
     ],
     "priorRunSummaries": [
-      "The canopy felt familiar — the particular quality of the light through it, the way it filtered everything into green patience. Like a place that had been waiting to be returned to.",
-      "The first branch crossing was wrong. Not physically wrong — patterned wrong, the way a route feels wrong when the things guarding it have had time to reconsider the arrangement.",
+      "The canopy felt familiar \u2014 the particular quality of the light through it, the way it filtered everything into green patience. Like a place that had been waiting to be returned to.",
+      "The first branch crossing was wrong. Not physically wrong \u2014 patterned wrong, the way a route feels wrong when the things guarding it have had time to reconsider the arrangement.",
       "Something about the root configuration at the outer treeline. The exact placement of it. You adjusted your approach without thinking, which meant you'd adjusted it before.",
       "The canopy was quieter than it should have been on approach. Not birdsong-quiet. Decision-quiet. The kind of quiet that means something is finishing a thought."
     ],
     "priorRunOpenings": [
       "You had been here. Your feet found the gap between the outer roots before the light confirmed it was passable.",
-      "The Bark Sentinel unit at the treeline didn't engage immediately. They swayed slightly — the way the Warden sways when it's processing something — and then engaged.",
+      "The Bark Sentinel unit at the treeline didn't engage immediately. They swayed slightly \u2014 the way the Warden sways when it's processing something \u2014 and then engaged.",
       "The Warden's first extension was different this time. A branch that hadn't been there before. It had been growing it between your visits.",
       "The canopy breathed when you arrived. A long, slow movement through the highest branches. You've learned, by now, that this is the Warden noticing."
     ],
@@ -85,7 +85,7 @@
     ],
     "milestoneOpenings10": [
       "Ten campaigns. The Elder Warden has grown new branches across your usual route through the mid-canopy. It has been studying your movement and doing infrastructure work.",
-      "The tenth time through the Verdant Canopy, the light is slightly different — filtered through leaves that weren't there before. The Warden has been growing countermeasures."
+      "The tenth time through the Verdant Canopy, the light is slightly different \u2014 filtered through leaves that weren't there before. The Warden has been growing countermeasures."
     ],
     "milestoneOpenings25": [
       "Twenty-five campaigns. The Canopy does not resist when you arrive. It observes. There is a difference, and the Warden has been alive long enough to know exactly what it means.",
@@ -96,7 +96,7 @@
       "Fifty campaigns. The Bark Sentinels stand aside when your silhouette appears at the outer treeline. The Warden has calculated something and reached a conclusion it hasn't shared yet."
     ],
     "milestoneOpenings100": [
-      "The Warden is at the treeline. Not distributed through the canopy — concentrated, in the way it concentrates when it wants to be understood as a single thing.\n\nIt does not speak with words. It speaks with the canopy.\n\nThe branches above you shift into a pattern you have seen before. You have been seeing it for a hundred visits. You have only just started to read it.\n\nIt means: I have been here since before the Dominion. I have watched things it would take you several lifetimes to name. And you — you small, relentless, unkillable thing — you are the most interesting visitor I have ever had.\n\nThe canopy parts.\n\nThe heartwood path is clear.\n\nThe branches above you make the pattern one more time, in case you missed it."
+      "The Warden is at the treeline. Not distributed through the canopy \u2014 concentrated, in the way it concentrates when it wants to be understood as a single thing.\n\nIt does not speak with words. It speaks with the canopy.\n\nThe branches above you shift into a pattern you have seen before. You have been seeing it for a hundred visits. You have only just started to read it.\n\nIt means: I have been here since before the Dominion. I have watched things it would take you several lifetimes to name. And you \u2014 you small, relentless, unkillable thing \u2014 you are the most interesting visitor I have ever had.\n\nThe canopy parts.\n\nThe heartwood path is clear.\n\nThe branches above you make the pattern one more time, in case you missed it."
     ]
   },
   "midRunTemplates": [
@@ -294,7 +294,7 @@
       "panels": [
         {
           "title": "THE VERDANT CANOPY",
-          "text": "The ley lines rise into the high canopy — again.\n\n{pool:priorRunSummaries:0}"
+          "text": "The ley lines rise into the high canopy \u2014 again.\n\n{pool:priorRunSummaries:0}"
         },
         {
           "title": "THE WANDERER",
@@ -306,7 +306,7 @@
         },
         {
           "title": "A FEELING",
-          "text": "And yet — {pool:priorRunOpenings:0}\n\nYou push the feeling aside. There is work to do.\n\nAgain."
+          "text": "And yet \u2014 {pool:priorRunOpenings:0}\n\nYou push the feeling aside. There is work to do.\n\nAgain."
         }
       ]
     }
@@ -314,34 +314,34 @@
   "intro": [
     {
       "title": "THE VERDANT CANOPY",
-      "text": "The ley lines rise into the high canopy here, threading through root systems older than memory. The forest above the treeline moves differently. It doesn't react to you — it notices you.\n\nThe Elder Warden has kept this canopy since before the Fracture. It has watched dozens of expeditions attempt passage. None returned changed for the better.",
+      "text": "The ley lines rise into the high canopy here, threading through root systems older than memory. The forest above the treeline moves differently. It doesn't react to you \u2014 it notices you.\n\nThe Elder Warden has kept this canopy since before the Fracture. It has watched dozens of expeditions attempt passage. None returned changed for the better.",
       "image": "cutscenes/act11-intro-1.svg"
     },
     {
       "title": "THE ELDER WARDEN",
-      "text": "It is not a creature in any familiar sense. The Warden is the canopy made sovereign — a convergence of root and memory and something older that has no name in any language you speak.\n\nIt does not hate you. Hatred requires noticing something as a peer. The Warden sees you as disruption. Disruptions are removed.",
+      "text": "It is not a creature in any familiar sense. The Warden is the canopy made sovereign \u2014 a convergence of root and memory and something older that has no name in any language you speak.\n\nIt does not hate you. Hatred requires noticing something as a peer. The Warden sees you as disruption. Disruptions are removed.",
       "image": "cutscenes/act11-intro-2.svg"
     },
     {
       "title": "THE PATH THROUGH",
-      "text": "The ley convergence runs through the ancient heartwood at the canopy's centre. Scholars have theorised about it for decades. None have gotten close enough to verify.\n\nYou will need to fight through layers of living defence — root walls, grove-spawned treants, flying watchers — before the Warden descends. And then you will need to convince it, by force, that disruption can be useful.",
+      "text": "The ley convergence runs through the ancient heartwood at the canopy's centre. Scholars have theorised about it for decades. None have gotten close enough to verify.\n\nYou will need to fight through layers of living defence \u2014 root walls, grove-spawned treants, flying watchers \u2014 before the Warden descends. And then you will need to convince it, by force, that disruption can be useful.",
       "image": "cutscenes/act11-intro-3.svg"
     }
   ],
   "outro": [
     {
       "title": "THE CANOPY YIELDS",
-      "text": "The Elder Warden does not fall. It withdraws — slowly, deliberately, as though choosing to end the engagement rather than being forced to. The distinction matters to it.\n\nThe ley convergence is exposed. The heartwood pulses with calm energy, older than anything you've touched before.",
+      "text": "The Elder Warden does not fall. It withdraws \u2014 slowly, deliberately, as though choosing to end the engagement rather than being forced to. The distinction matters to it.\n\nThe ley convergence is exposed. The heartwood pulses with calm energy, older than anything you've touched before.",
       "image": "cutscenes/act11-outro-1.svg"
     },
     {
       "title": "LIVING BARK",
-      "text": "Where the Warden stood, a strip of bark remains — thick, warm to the touch, and inexplicably alive. It hardens in your hands into something like armour, or maybe a shield, or maybe just the canopy saying: you've earned a layer of protection.\n\nYou don't question it. The canopy rewards results.",
+      "text": "Where the Warden stood, a strip of bark remains \u2014 thick, warm to the touch, and inexplicably alive. It hardens in your hands into something like armour, or maybe a shield, or maybe just the canopy saying: you've earned a layer of protection.\n\nYou don't question it. The canopy rewards results.",
       "image": "cutscenes/act11-outro-2.svg"
     },
     {
       "title": "THE ROAD AHEAD",
-      "text": "The Verdant Canopy recedes behind you as you descend. Above, you hear the canopy resume its ordinary rhythms — something enormous moving between branches, watchers returning to their posts.\n\nThe Warden is already repairing the damage. It won't hold a grudge. It's too old for that. It will simply be ready when you return.",
+      "text": "The Verdant Canopy recedes behind you as you descend. Above, you hear the canopy resume its ordinary rhythms \u2014 something enormous moving between branches, watchers returning to their posts.\n\nThe Warden is already repairing the damage. It won't hold a grudge. It's too old for that. It will simply be ready when you return.",
       "image": "cutscenes/act11-outro-3.svg"
     }
   ],
@@ -391,7 +391,7 @@
       ],
       "eventConfig": {
         "title": "The Root Shrine",
-        "description": "A gnarled shrine wrapped in glowing roots. You can feel something ancient in it. The options it presents are simple — give something, take something, or leave it alone.",
+        "description": "A gnarled shrine wrapped in glowing roots. You can feel something ancient in it. The options it presents are simple \u2014 give something, take something, or leave it alone.",
         "pools": [
           [
             {
@@ -480,7 +480,8 @@
       "col": 0,
       "rowCols": 4,
       "childIds": [
-        "ancient-garrison"
+        "ancient-garrison",
+        "mem-act11-1"
       ],
       "handicap": 21,
       "opponentIntervalMs": 4200,
@@ -548,7 +549,7 @@
       ],
       "eventConfig": {
         "title": "The Canopy Rift",
-        "description": "A gap in the ancient canopy shows the raw ley lines beneath — shimmering, strange, and old. You can attempt to draw on them, or simply study them from a safe distance.",
+        "description": "A gap in the ancient canopy shows the raw ley lines beneath \u2014 shimmering, strange, and old. You can attempt to draw on them, or simply study them from a safe distance.",
         "pools": [
           [
             {
@@ -682,7 +683,7 @@
       ],
       "eventConfig": {
         "title": "The Warden's Gaze",
-        "description": "You feel it before you see it — a presence older than stone watching from the high branches. It hasn't moved. It's waiting to see what you do. Your choice here will define what follows.",
+        "description": "You feel it before you see it \u2014 a presence older than stone watching from the high branches. It hasn't moved. It's waiting to see what you do. Your choice here will define what follows.",
         "pools": [
           [
             {
@@ -746,7 +747,8 @@
       "rowCols": 4,
       "restHeal": 10,
       "childIds": [
-        "deep-grove"
+        "deep-grove",
+        "mem-act11-2"
       ]
     },
     "deep-grove": {
@@ -827,6 +829,34 @@
         "Ancient Blessing"
       ],
       "bossCard": "Vine Colossus"
+    },
+    "mem-act11-1": {
+      "id": "mem-act11-1",
+      "type": "memory",
+      "label": "Memory Fragment",
+      "description": "Pressed into fourteen-hundred-year-old heartwood \u2014 the Canopy has seen collapse before.",
+      "row": 3,
+      "col": 1,
+      "rowCols": 4,
+      "childIds": [
+        "elder-watch"
+      ],
+      "fragmentId": "act11-frag-1",
+      "environment": "forest"
+    },
+    "mem-act11-2": {
+      "id": "mem-act11-2",
+      "type": "memory",
+      "label": "Memory Fragment",
+      "description": "The Elder Warden's testimony \u2014 what the root network felt on the day of the Fracture.",
+      "row": 4,
+      "col": 1,
+      "rowCols": 4,
+      "childIds": [
+        "heartwood-path"
+      ],
+      "fragmentId": "act11-frag-2",
+      "environment": "forest"
     }
   }
 }

--- a/web/src/data/acts/act12.json
+++ b/web/src/data/acts/act12.json
@@ -45,7 +45,7 @@
       "Now, technically, a nautical problem the Harbormaster has stopped being surprised by.",
       "Now, effectively, the sort of person who fights through fractured port cities without a permit.",
       "Now, in the maritime sense, an unlicensed vessel the Harbormaster cannot seem to impound.",
-      "Now — by every coastal regulation — in violation of several statutes the Harbormaster has stopped bothering to cite.",
+      "Now \u2014 by every coastal regulation \u2014 in violation of several statutes the Harbormaster has stopped bothering to cite.",
       "Now, technically, a repeat offender the Harbormaster has started filing standing orders against."
     ],
     "jarvIntros": [
@@ -56,27 +56,27 @@
       "You have a deck of cards. The Harbormaster has a file on you now. It is the thickest file in the port authority's history and it hasn't helped him once."
     ],
     "coastDesc": [
-      "The Shattered Coast was once a thriving port city — before the Fracture split it across seven separate shards. Now the docks connect pieces that don't belong together, and the iron tide brings things from one piece that don't belong in the others.",
+      "The Shattered Coast was once a thriving port city \u2014 before the Fracture split it across seven separate shards. Now the docks connect pieces that don't belong together, and the iron tide brings things from one piece that don't belong in the others.",
       "The Shattered Coast smells like salt water and impounded cargo and the particular frustration of a bureaucracy trying to regulate something that fundamentally does not want to be regulated.",
-      "The Shattered Coast waits at the edge of your bearing — fractured, grey, and defended by someone who has made chaos into a system.",
+      "The Shattered Coast waits at the edge of your bearing \u2014 fractured, grey, and defended by someone who has made chaos into a system.",
       "The ley lines run through the old harbour bed here. The Harbormaster uses the energy surplus to run his iron fleet and his extremely comprehensive permit system."
     ],
     "harbormasterDesc": [
-      "The Harbormaster was a port inspector once, before the Fracture. Now he controls the coast's only viable passage — with an iron fleet, a permit system, and the particular authority of someone who has turned disorder into a personal monopoly.\n\nYou don't have his permit. You're not going to get one.",
+      "The Harbormaster was a port inspector once, before the Fracture. Now he controls the coast's only viable passage \u2014 with an iron fleet, a permit system, and the particular authority of someone who has turned disorder into a personal monopoly.\n\nYou don't have his permit. You're not going to get one.",
       "The Harbormaster holds every coastal route with the methodical determination of someone who has converted bureaucratic principle into military doctrine.\n\nYou are a permit violation he can't seem to close.",
       "The Harbormaster defends the Shattered Coast with the calm stubbornness of a man who has decided that rules are what he says they are.\n\nYou've found that stubbornness like that makes people predictable.",
       "The Harbormaster has been briefed on your approach. His response was to update the standing violation on your file and order additional iron for the harbour defences. He has also, apparently, updated the permit requirements specifically to exclude you."
     ],
     "priorRunSummaries": [
-      "The salt air felt familiar — the particular way it carried the sound of iron hulls and tide bells. Like a port you'd been refused entry to before.",
-      "The first shoreline approach was wrong. Not navigationally wrong — defensively wrong, the way a route feels wrong when the checkpoints have been moved since your last visit.",
+      "The salt air felt familiar \u2014 the particular way it carried the sound of iron hulls and tide bells. Like a port you'd been refused entry to before.",
+      "The first shoreline approach was wrong. Not navigationally wrong \u2014 defensively wrong, the way a route feels wrong when the checkpoints have been moved since your last visit.",
       "Something about the patrol pattern at the harbour mouth. The exact interval of it. You adjusted your approach without thinking, which meant you'd made that adjustment before.",
       "The iron tide sounded different on approach. Lower. More deliberate. As though someone had changed the bell pattern after reviewing the footage of your last visit."
     ],
     "priorRunOpenings": [
       "You had been here. Your feet found the gap in the harbour defences before the tide charts confirmed it was still there.",
       "The Iron Guard unit at the shore landing didn't engage immediately. One of them checked a document. Then engaged.",
-      "The Harbormaster's opening blockade was different this time — heavier on the right flank. He'd been reviewing his formation after your last visit.",
+      "The Harbormaster's opening blockade was different this time \u2014 heavier on the right flank. He'd been reviewing his formation after your last visit.",
       "The harbour bells rang when you landed. A specific pattern. You've learned, by now, that this is the code for 'that one again'."
     ],
     "milestoneOpenings5": [
@@ -96,7 +96,7 @@
       "Fifty campaigns. The Iron Guard at the shore landing steps aside when your silhouette appears on the approach. The Harbormaster has calculated something and decided the opening engagement is no longer cost-effective."
     ],
     "milestoneOpenings100": [
-      "The Harbormaster is at the shore landing. Not in uniform. In his old inspector's coat — the one he wore before all of this.\n\n'A hundred crossings,' he says. 'I have the file here.' He holds it up. It is very thick. 'A hundred violations. A hundred failed containments. A hundred updated protocols.'\n\nHe sets it down on the dock.\n\n'I was a port inspector,' he says. 'Before the Fracture. I inspected things. I approved things. I denied things.' He looks at you — not at Jarv, at you. 'I have never, in forty years of this work, encountered something I could not eventually process correctly.'\n\nA pause. The tide moves.\n\n'I am going to process this correctly.' He steps aside. 'The coast is clear. The permit is granted retroactively for all previous crossings. Do not tell anyone I said that.'"
+      "The Harbormaster is at the shore landing. Not in uniform. In his old inspector's coat \u2014 the one he wore before all of this.\n\n'A hundred crossings,' he says. 'I have the file here.' He holds it up. It is very thick. 'A hundred violations. A hundred failed containments. A hundred updated protocols.'\n\nHe sets it down on the dock.\n\n'I was a port inspector,' he says. 'Before the Fracture. I inspected things. I approved things. I denied things.' He looks at you \u2014 not at Jarv, at you. 'I have never, in forty years of this work, encountered something I could not eventually process correctly.'\n\nA pause. The tide moves.\n\n'I am going to process this correctly.' He steps aside. 'The coast is clear. The permit is granted retroactively for all previous crossings. Do not tell anyone I said that.'"
     ]
   },
   "midRunTemplates": [
@@ -105,12 +105,15 @@
     "{n} campaigns in. The Iron Guard at the shore landing has started forming up before you're visible from the post. They've learned your approach timing.",
     "{n} times you've landed on this coast. The salt air is the same. Your outstanding permit violations have become something the Harbormaster finds professionally destabilising.",
     "Run {n}. You arrive at the shore and find the first patrol already in position. The Harbormaster has been running projections.",
-    "The {ordinalLower} attempt. The coast smells the same — salt and iron and the particular frustration of a system that keeps failing to process one specific person.",
+    "The {ordinalLower} attempt. The coast smells the same \u2014 salt and iron and the particular frustration of a system that keeps failing to process one specific person.",
     "{n} campaigns. The Harbormaster's file on you is the longest active case in the port authority's history. It has achieved a kind of institutional legend."
   ],
   "introRules": [
     {
-      "condition": { "op": "gte", "value": 100 },
+      "condition": {
+        "op": "gte",
+        "value": 100
+      },
       "panels": [
         {
           "title": "THE HARBORMASTER DECIDES",
@@ -123,7 +126,11 @@
       ]
     },
     {
-      "condition": { "op": "range", "min": 51, "max": 99 },
+      "condition": {
+        "op": "range",
+        "min": 51,
+        "max": 99
+      },
       "panels": [
         {
           "title": "THE {ORDINAL} TIME",
@@ -144,7 +151,10 @@
       ]
     },
     {
-      "condition": { "op": "eq", "value": 50 },
+      "condition": {
+        "op": "eq",
+        "value": 50
+      },
       "panels": [
         {
           "title": "FIFTY CAMPAIGNS",
@@ -165,7 +175,11 @@
       ]
     },
     {
-      "condition": { "op": "range", "min": 26, "max": 49 },
+      "condition": {
+        "op": "range",
+        "min": 26,
+        "max": 49
+      },
       "panels": [
         {
           "title": "THE {ORDINAL} TIME",
@@ -182,7 +196,10 @@
       ]
     },
     {
-      "condition": { "op": "eq", "value": 25 },
+      "condition": {
+        "op": "eq",
+        "value": 25
+      },
       "panels": [
         {
           "title": "TWENTY-FIVE",
@@ -199,7 +216,11 @@
       ]
     },
     {
-      "condition": { "op": "range", "min": 11, "max": 24 },
+      "condition": {
+        "op": "range",
+        "min": 11,
+        "max": 24
+      },
       "panels": [
         {
           "title": "THE {ORDINAL} TIME",
@@ -220,7 +241,10 @@
       ]
     },
     {
-      "condition": { "op": "eq", "value": 10 },
+      "condition": {
+        "op": "eq",
+        "value": 10
+      },
       "panels": [
         {
           "title": "THE TENTH TIME",
@@ -241,7 +265,11 @@
       ]
     },
     {
-      "condition": { "op": "range", "min": 5, "max": 9 },
+      "condition": {
+        "op": "range",
+        "min": 5,
+        "max": 9
+      },
       "panels": [
         {
           "title": "THE {ORDINAL} TIME",
@@ -258,11 +286,15 @@
       ]
     },
     {
-      "condition": { "op": "range", "min": 2, "max": 4 },
+      "condition": {
+        "op": "range",
+        "min": 2,
+        "max": 4
+      },
       "panels": [
         {
           "title": "THE SHATTERED COAST",
-          "text": "The coast, again — fractured, grey, and still not issuing permits.\n\n{pool:priorRunSummaries:0}"
+          "text": "The coast, again \u2014 fractured, grey, and still not issuing permits.\n\n{pool:priorRunSummaries:0}"
         },
         {
           "title": "THE WANDERER",
@@ -274,7 +306,7 @@
         },
         {
           "title": "A FEELING",
-          "text": "And yet — {pool:priorRunOpenings:0}\n\nYou push the feeling aside. There is work to do.\n\nAgain."
+          "text": "And yet \u2014 {pool:priorRunOpenings:0}\n\nYou push the feeling aside. There is work to do.\n\nAgain."
         }
       ]
     }
@@ -282,17 +314,17 @@
   "intro": [
     {
       "title": "THE SHATTERED COAST",
-      "text": "The Shattered Coast was once a thriving port city — before the Fracture split it across seven separate shards.\n\nNow the channels between shards are controlled by a single authority: the Harbormaster. Nothing moves without his iron seal. No cargo. No people. No information.",
+      "text": "The Shattered Coast was once a thriving port city \u2014 before the Fracture split it across seven separate shards.\n\nNow the channels between shards are controlled by a single authority: the Harbormaster. Nothing moves without his iron seal. No cargo. No people. No information.",
       "image": "cutscenes/act12-intro-1.svg"
     },
     {
       "title": "THE HARBORMASTER",
-      "text": "He was a port inspector once, before the Fracture. Now he is something else — a man who discovered that chaos could be administered, and administration could be power.\n\nHis fleet patrols the shattered channels. His flags are the only law. The wreck divers answer to him. The storm hawks circle his flagship.",
+      "text": "He was a port inspector once, before the Fracture. Now he is something else \u2014 a man who discovered that chaos could be administered, and administration could be power.\n\nHis fleet patrols the shattered channels. His flags are the only law. The wreck divers answer to him. The storm hawks circle his flagship.",
       "image": "cutscenes/act12-intro-2.svg"
     },
     {
       "title": "NO PERMIT",
-      "text": "You don't have his permit. You don't intend to get one.\n\nThe coast is the only route forward, and the Harbormaster blocks it. Fight through his patrols, his reef wardens, his iron anchorage — and put an end to the toll.",
+      "text": "You don't have his permit. You don't intend to get one.\n\nThe coast is the only route forward, and the Harbormaster blocks it. Fight through his patrols, his reef wardens, his iron anchorage \u2014 and put an end to the toll.",
       "image": "cutscenes/act12-intro-3.svg"
     }
   ],
@@ -304,7 +336,7 @@
     },
     {
       "title": "SALVAGE HOOK",
-      "text": "Among the wreckage, half-buried in sand, you find a salvage hook — the symbol of passage along this coast. It's old. Pre-Fracture. It means something.\n\nYou pocket it. The channels open around you.",
+      "text": "Among the wreckage, half-buried in sand, you find a salvage hook \u2014 the symbol of passage along this coast. It's old. Pre-Fracture. It means something.\n\nYou pocket it. The channels open around you.",
       "image": "cutscenes/act12-outro-2.svg"
     },
     {
@@ -486,7 +518,8 @@
       "col": 1,
       "rowCols": 4,
       "childIds": [
-        "diver-cove"
+        "diver-cove",
+        "mem-act12-1"
       ],
       "eventConfig": {
         "title": "The Storm Crossing",
@@ -576,7 +609,7 @@
       "description": "The storm wall cuts off the inner coast.",
       "row": 5,
       "col": 0,
-      "rowCols": 1,
+      "rowCols": 2,
       "childIds": [
         "the-harbormaster-node"
       ],
@@ -677,12 +710,13 @@
       "id": "iron-anchorage",
       "type": "elite",
       "label": "Iron Anchorage",
-      "description": "The Harbormaster's advance guard — iron-hulled and merciless.",
+      "description": "The Harbormaster's advance guard \u2014 iron-hulled and merciless.",
       "row": 4,
       "col": 3,
       "rowCols": 4,
       "childIds": [
-        "stormwall"
+        "stormwall",
+        "mem-act12-2"
       ],
       "handicap": 30,
       "opponentIntervalMs": 2800,
@@ -728,6 +762,34 @@
       ],
       "bossCard": "Coast Leviathan",
       "bossName": "The Grand Serpent "
+    },
+    "mem-act12-1": {
+      "id": "mem-act12-1",
+      "type": "memory",
+      "label": "Memory Fragment",
+      "description": "The Harbormaster's final log \u2014 the lighthouse is still flashing under forty metres of water.",
+      "row": 3,
+      "col": 1,
+      "rowCols": 4,
+      "childIds": [
+        "reef-outpost"
+      ],
+      "fragmentId": "act12-frag-1",
+      "environment": "coast"
+    },
+    "mem-act12-2": {
+      "id": "mem-act12-2",
+      "type": "memory",
+      "label": "Memory Fragment",
+      "description": "Salvage Report Zero \u2014 everything that used to be up here is preserved perfectly below.",
+      "row": 5,
+      "col": 1,
+      "rowCols": 2,
+      "childIds": [
+        "the-harbormaster-node"
+      ],
+      "fragmentId": "act12-frag-2",
+      "environment": "coast"
     }
   }
 }

--- a/web/src/data/acts/act13.json
+++ b/web/src/data/acts/act13.json
@@ -45,7 +45,7 @@
       "Now, technically, an unauthorised variable in a system that does not tolerate unauthorised variables.",
       "Now, effectively, the sort of person who breaks into ancient automated vaults for professional reasons.",
       "Now, in the mechanical sense, a fault condition the Grand Automaton has been trying to resolve since your last visit.",
-      "Now — by every schematic on record — somewhere that has no documented procedure for handling you.",
+      "Now \u2014 by every schematic on record \u2014 somewhere that has no documented procedure for handling you.",
       "Now, technically, present in a facility that has revised its operating parameters around you more times than any other single event in its history."
     ],
     "jarvIntros": [
@@ -56,27 +56,27 @@
       "You have a deck of cards. The Grand Automaton has dedicated significant processing to you. You have been thorough about giving it reasons to."
     ],
     "vaultDesc": [
-      "Deep beneath the shattered earth, the Clockwork Vaults hum with ancient machinery — built before the Fracture by an artificer whose name the Automaton has never recorded as relevant.",
-      "The Clockwork Vaults smell like machine oil and old purpose — the smell of a place that has been running continuously for longer than any surface civilisation has existed.",
+      "Deep beneath the shattered earth, the Clockwork Vaults hum with ancient machinery \u2014 built before the Fracture by an artificer whose name the Automaton has never recorded as relevant.",
+      "The Clockwork Vaults smell like machine oil and old purpose \u2014 the smell of a place that has been running continuously for longer than any surface civilisation has existed.",
       "The Clockwork Vaults wait beneath the surface, their gears turning in rhythms that haven't changed since before the Fracture. The ley lines power them. They have never stopped.",
       "The ley lines run through the Vault's drive cores here. The Automaton uses the energy to power every system, every patrol, and every revision to its operating parameters that your visits have necessitated."
     ],
     "automatonDesc": [
-      "The Grand Automaton is not hostile. Hostility implies intent. It simply optimises — calculating minimum-force resolutions for every variable in its facility.\n\nYou are a variable it has not yet resolved. It has been working on it.",
+      "The Grand Automaton is not hostile. Hostility implies intent. It simply optimises \u2014 calculating minimum-force resolutions for every variable in its facility.\n\nYou are a variable it has not yet resolved. It has been working on it.",
       "The Grand Automaton holds every passage through the Vaults with the mechanical certainty of something that does not get tired, does not get distracted, and does not stop refining its approach.\n\nYou are the one variable that keeps requiring revision.",
       "The Grand Automaton runs the Vaults with the perfect efficiency of something that has never once needed to second-guess a decision.\n\nYou have given it reasons to second-guess. It is revising.",
       "The Grand Automaton has already modelled your approach. It modelled it before you arrived. It has been running simulations since your last visit, and it has found seventeen improvements to its protocol. None of them have worked on you yet."
     ],
     "priorRunSummaries": [
-      "The hum felt familiar — the particular frequency of the Vault's primary drive, the way it carried through the stone underfoot. Like machinery that remembered being stopped.",
-      "The first gear-gate was wrong. Not mechanically wrong — configured wrong, the way a system feels wrong when someone has updated it since your last access.",
+      "The hum felt familiar \u2014 the particular frequency of the Vault's primary drive, the way it carried through the stone underfoot. Like machinery that remembered being stopped.",
+      "The first gear-gate was wrong. Not mechanically wrong \u2014 configured wrong, the way a system feels wrong when someone has updated it since your last access.",
       "Something about the patrol cycle at the entrance. The exact timing of it. You adjusted your approach without thinking, which meant you'd calculated the same window before.",
       "The Vault was louder on approach than it should have been. Extra gear-work. The Automaton had been busy between your visits."
     ],
     "priorRunOpenings": [
       "You had been here. Your hands found the correct bypass sequence before your eyes confirmed the panel hadn't changed.",
       "The Gear Sentinel unit at the entrance ran its identification scan twice. It found a match. You got the impression this was not the outcome it preferred.",
-      "The Automaton's first deployment was different this time — a full configuration update. It had been working on this since your last visit.",
+      "The Automaton's first deployment was different this time \u2014 a full configuration update. It had been working on this since your last visit.",
       "The primary drive pitch changed when you entered. A frequency shift the Automaton uses internally for status updates. You have learned, across many visits, what the different frequencies mean. This one meant: there it is again."
     ],
     "milestoneOpenings5": [
@@ -294,7 +294,7 @@
       "panels": [
         {
           "title": "THE CLOCKWORK VAULTS",
-          "text": "The Vaults hum beneath the earth — again.\n\n{pool:priorRunSummaries:0}"
+          "text": "The Vaults hum beneath the earth \u2014 again.\n\n{pool:priorRunSummaries:0}"
         },
         {
           "title": "THE WANDERER",
@@ -306,7 +306,7 @@
         },
         {
           "title": "A FEELING",
-          "text": "And yet — {pool:priorRunOpenings:0}\n\nYou push the feeling aside. There is work to do.\n\nAgain."
+          "text": "And yet \u2014 {pool:priorRunOpenings:0}\n\nYou push the feeling aside. There is work to do.\n\nAgain."
         }
       ]
     }
@@ -314,12 +314,12 @@
   "intro": [
     {
       "title": "THE CLOCKWORK VAULTS",
-      "text": "Deep beneath the shattered earth, the Clockwork Vaults hum with ancient machinery — built before the Fracture by an artificer order that no longer exists.\n\nThe Grand Automaton maintains it all. Has maintained it for two hundred years. No one knows if it was told to stop.",
+      "text": "Deep beneath the shattered earth, the Clockwork Vaults hum with ancient machinery \u2014 built before the Fracture by an artificer order that no longer exists.\n\nThe Grand Automaton maintains it all. Has maintained it for two hundred years. No one knows if it was told to stop.",
       "image": "cutscenes/act13-intro-1.svg"
     },
     {
       "title": "THE GRAND AUTOMATON",
-      "text": "It is not hostile. Hostility implies intent. The Automaton simply optimises — calculating minimum-force resolutions for all threats to vault integrity.\n\nYou are a threat to vault integrity.",
+      "text": "It is not hostile. Hostility implies intent. The Automaton simply optimises \u2014 calculating minimum-force resolutions for all threats to vault integrity.\n\nYou are a threat to vault integrity.",
       "image": "cutscenes/act13-intro-2.svg"
     },
     {
@@ -336,7 +336,7 @@
     },
     {
       "title": "GEAR HEART",
-      "text": "Amid the cooling machinery, you find a small gear-shaped crystal — the Automaton's drive core, still faintly warm.\n\nA fitting trophy. It pulses with each heartbeat.",
+      "text": "Amid the cooling machinery, you find a small gear-shaped crystal \u2014 the Automaton's drive core, still faintly warm.\n\nA fitting trophy. It pulses with each heartbeat.",
       "image": "cutscenes/act13-outro-2.svg"
     },
     {
@@ -472,7 +472,8 @@
       "col": 0,
       "rowCols": 4,
       "childIds": [
-        "forge-vault"
+        "forge-vault",
+        "mem-act13-1"
       ],
       "handicap": 24,
       "opponentIntervalMs": 3000,
@@ -608,7 +609,7 @@
       "description": "The Automaton's drones defend the inner sanctum.",
       "row": 5,
       "col": 0,
-      "rowCols": 1,
+      "rowCols": 2,
       "childIds": [
         "the-grand-automaton-node"
       ],
@@ -629,7 +630,7 @@
       "id": "repair-bay",
       "type": "rest",
       "label": "Salvaged Repair Bay",
-      "description": "Abandoned repair alcove — still functional.",
+      "description": "Abandoned repair alcove \u2014 still functional.",
       "row": 3,
       "col": 3,
       "rowCols": 4,
@@ -714,7 +715,8 @@
       "col": 3,
       "rowCols": 4,
       "childIds": [
-        "core-approach"
+        "core-approach",
+        "mem-act13-2"
       ],
       "handicap": 31,
       "opponentIntervalMs": 2700,
@@ -759,6 +761,34 @@
         "VAULT INTEGRITY IS PARAMOUNT."
       ],
       "bossCard": "Clockwork Titan"
+    },
+    "mem-act13-1": {
+      "id": "mem-act13-1",
+      "type": "memory",
+      "label": "Memory Fragment",
+      "description": "The artificers chose convenience over caution \u2014 a dissenting note filed in the archive.",
+      "row": 3,
+      "col": 1,
+      "rowCols": 4,
+      "childIds": [
+        "piston-wing"
+      ],
+      "fragmentId": "act13-frag-1",
+      "environment": "vault"
+    },
+    "mem-act13-2": {
+      "id": "mem-act13-2",
+      "type": "memory",
+      "label": "Memory Fragment",
+      "description": "Year one alone \u2014 the Grand Automaton maintains everything, asking no questions aloud.",
+      "row": 5,
+      "col": 1,
+      "rowCols": 2,
+      "childIds": [
+        "the-grand-automaton-node"
+      ],
+      "fragmentId": "act13-frag-2",
+      "environment": "vault"
     }
   }
 }

--- a/web/src/data/acts/act6.json
+++ b/web/src/data/acts/act6.json
@@ -45,7 +45,7 @@
       "Now, effectively, the ground-based problem the Sky Dominion forgot to account for.",
       "Now, professionally speaking, operating outside intended parameters.",
       "Now, in the tactical sense, at an elevation disadvantage everyone keeps mentioning.",
-      "Now — by most measures — the only person in this shard who arrived by climbing."
+      "Now \u2014 by most measures \u2014 the only person in this shard who arrived by climbing."
     ],
     "jarvIntros": [
       "You have a deck of cards, no wings, and a history of winning fights where the terrain was supposed to be the deciding factor.",
@@ -55,20 +55,20 @@
       "You have a deck of cards. You have always had a deck of cards. The Cloudmarshal is learning what that means."
     ],
     "dominionDesc": [
-      "The Sky Dominion exists on drifting islands — chunks of terrain that broke loose during the Fracture and simply refused to come back down.",
+      "The Sky Dominion exists on drifting islands \u2014 chunks of terrain that broke loose during the Fracture and simply refused to come back down.",
       "The Sky Dominion smells like ozone and old stone and the particular anxiety of a military operation that has run unchallenged for too long.",
       "The Sky Dominion drifts above the cloud line, its rope-bridges and siege platforms and anti-air weaponry pointed at everything that moves.",
       "The ley lines rise through the clouds here. The Sky Dominion has built its entire doctrine around the assumption that anything worth fighting is beneath them."
     ],
     "marshalDesc": [
-      "Command belongs to the Cloudmarshal — a general who has never lost a battle because, practically speaking, her armies have always had the high ground.\n\nShe does not consider a tactician without wings a credible threat. You are going to prove her wrong.",
+      "Command belongs to the Cloudmarshal \u2014 a general who has never lost a battle because, practically speaking, her armies have always had the high ground.\n\nShe does not consider a tactician without wings a credible threat. You are going to prove her wrong.",
       "The Cloudmarshal holds every aerial pathway closed. She is methodical, experienced, and completely certain that altitude is destiny.\n\nYou've found certainty like that makes people predictable.",
       "The Cloudmarshal commands the Sky Dominion with the calm precision of someone who has never once had to reconsider a strategy.\n\nYou are about to give her that opportunity.",
       "The Cloudmarshal waits at the upper platforms. She has been told you're coming. She has been told this, apparently, several times now, and her briefings have become increasingly specific."
     ],
     "priorRunSummaries": [
-      "The clouds felt familiar — the particular weight of the air up here, the way sound carried differently above the treeline. Like a place you'd been to in a dream that was trying very hard to be remembered.",
-      "The first island was wrong. Not visually wrong — wrong the way a route feels wrong when you've taken it before and know it doesn't end well.",
+      "The clouds felt familiar \u2014 the particular weight of the air up here, the way sound carried differently above the treeline. Like a place you'd been to in a dream that was trying very hard to be remembered.",
+      "The first island was wrong. Not visually wrong \u2014 wrong the way a route feels wrong when you've taken it before and know it doesn't end well.",
       "Something about the patrol formation on the bridge platform. The exact spacing of it. You adjusted your approach accordingly, which meant you'd adjusted it before.",
       "The rope-bridge to the upper tier was already swaying when you arrived. As though someone had crossed it recently. As though you had crossed it recently."
     ],
@@ -109,7 +109,10 @@
   ],
   "introRules": [
     {
-      "condition": { "op": "gte", "value": 100 },
+      "condition": {
+        "op": "gte",
+        "value": 100
+      },
       "panels": [
         {
           "title": "THE MARSHAL KNOWS",
@@ -122,7 +125,11 @@
       ]
     },
     {
-      "condition": { "op": "range", "min": 51, "max": 99 },
+      "condition": {
+        "op": "range",
+        "min": 51,
+        "max": 99
+      },
       "panels": [
         {
           "title": "THE {ORDINAL} TIME",
@@ -143,7 +150,10 @@
       ]
     },
     {
-      "condition": { "op": "eq", "value": 50 },
+      "condition": {
+        "op": "eq",
+        "value": 50
+      },
       "panels": [
         {
           "title": "FIFTY CAMPAIGNS",
@@ -164,7 +174,11 @@
       ]
     },
     {
-      "condition": { "op": "range", "min": 26, "max": 49 },
+      "condition": {
+        "op": "range",
+        "min": 26,
+        "max": 49
+      },
       "panels": [
         {
           "title": "THE {ORDINAL} TIME",
@@ -181,7 +195,10 @@
       ]
     },
     {
-      "condition": { "op": "eq", "value": 25 },
+      "condition": {
+        "op": "eq",
+        "value": 25
+      },
       "panels": [
         {
           "title": "TWENTY-FIVE",
@@ -198,7 +215,11 @@
       ]
     },
     {
-      "condition": { "op": "range", "min": 11, "max": 24 },
+      "condition": {
+        "op": "range",
+        "min": 11,
+        "max": 24
+      },
       "panels": [
         {
           "title": "THE {ORDINAL} TIME",
@@ -219,7 +240,10 @@
       ]
     },
     {
-      "condition": { "op": "eq", "value": 10 },
+      "condition": {
+        "op": "eq",
+        "value": 10
+      },
       "panels": [
         {
           "title": "THE TENTH TIME",
@@ -240,7 +264,11 @@
       ]
     },
     {
-      "condition": { "op": "range", "min": 5, "max": 9 },
+      "condition": {
+        "op": "range",
+        "min": 5,
+        "max": 9
+      },
       "panels": [
         {
           "title": "THE {ORDINAL} TIME",
@@ -257,11 +285,15 @@
       ]
     },
     {
-      "condition": { "op": "range", "min": 2, "max": 4 },
+      "condition": {
+        "op": "range",
+        "min": 2,
+        "max": 4
+      },
       "panels": [
         {
           "title": "THE SKY DOMINION",
-          "text": "You've climbed out of the sea and into the air — again.\n\n{pool:priorRunSummaries:0}"
+          "text": "You've climbed out of the sea and into the air \u2014 again.\n\n{pool:priorRunSummaries:0}"
         },
         {
           "title": "THE WANDERER",
@@ -273,7 +305,7 @@
         },
         {
           "title": "A FEELING",
-          "text": "And yet — {pool:priorRunOpenings:0}\n\nYou push the feeling aside. There is work to do.\n\nAgain."
+          "text": "And yet \u2014 {pool:priorRunOpenings:0}\n\nYou push the feeling aside. There is work to do.\n\nAgain."
         }
       ]
     }
@@ -281,17 +313,17 @@
   "intro": [
     {
       "title": "THE SKY DOMINION",
-      "text": "You've climbed out of the sea and into the air.\n\nThe Sky Dominion exists on drifting islands — chunks of terrain that broke loose during the Fracture and simply refused to come back down. They've been up here so long they've built cities on them. Militarised them. Connected them with rope-bridges and siege platforms and weapons specifically designed to hit things that are also in the air.\n\nThey do not like visitors.",
+      "text": "You've climbed out of the sea and into the air.\n\nThe Sky Dominion exists on drifting islands \u2014 chunks of terrain that broke loose during the Fracture and simply refused to come back down. They've been up here so long they've built cities on them. Militarised them. Connected them with rope-bridges and siege platforms and weapons specifically designed to hit things that are also in the air.\n\nThey do not like visitors.",
       "image": "cutscenes/act6-intro-1.svg"
     },
     {
       "title": "THE CLOUDMARSHAL",
-      "text": "Command of the Sky Dominion belongs to the Cloudmarshal — a general who has never lost a battle because, practically speaking, her armies have always had the high ground.\n\nShe does not consider a tactician without wings a credible threat. She's said this, publicly, several times.\n\nYou are going to prove her wrong. You always find this kind of statement motivating.",
+      "text": "Command of the Sky Dominion belongs to the Cloudmarshal \u2014 a general who has never lost a battle because, practically speaking, her armies have always had the high ground.\n\nShe does not consider a tactician without wings a credible threat. She's said this, publicly, several times.\n\nYou are going to prove her wrong. You always find this kind of statement motivating.",
       "image": "cutscenes/act6-intro-2.svg"
     },
     {
       "title": "THE LEY BRIDGE",
-      "text": "The ley lines rise here — thick, crackling columns of energy that punch up through the clouds and connect to something far above. If the Fractured Core exists anywhere, the ley lines suggest it's in a direction the Cloudmarshal considers her personal airspace.\n\nYou will need to break through her defences to reach it.\n\nAt least the view will be good.",
+      "text": "The ley lines rise here \u2014 thick, crackling columns of energy that punch up through the clouds and connect to something far above. If the Fractured Core exists anywhere, the ley lines suggest it's in a direction the Cloudmarshal considers her personal airspace.\n\nYou will need to break through her defences to reach it.\n\nAt least the view will be good.",
       "image": "cutscenes/act6-intro-3.svg"
     }
   ],
@@ -308,7 +340,7 @@
     },
     {
       "title": "HIGHER STILL",
-      "text": "The Stormcaller's Badge sits in your hand — a Sky Dominion medal, given to the first enemy officer who ever reached the upper platforms.\n\nYou aren't an officer. Close enough.\n\nThe ley lines point upward. They always do. You've stopped being surprised by that.",
+      "text": "The Stormcaller's Badge sits in your hand \u2014 a Sky Dominion medal, given to the first enemy officer who ever reached the upper platforms.\n\nYou aren't an officer. Close enough.\n\nThe ley lines point upward. They always do. You've stopped being surprised by that.",
       "image": "cutscenes/act6-outro-3.svg"
     }
   ],
@@ -323,7 +355,8 @@
       "rowCols": 1,
       "childIds": [
         "wind-shrine",
-        "archive-isle"
+        "archive-isle",
+        "mem-act6-1"
       ],
       "handicap": 10,
       "opponentIntervalMs": 5000,
@@ -353,7 +386,7 @@
       "description": "A weathervane shrine rattles in the high-altitude gale. Something still listens to it.",
       "row": 1,
       "col": 0,
-      "rowCols": 2,
+      "rowCols": 3,
       "childIds": [
         "gale-crossing"
       ],
@@ -388,7 +421,7 @@
             },
             {
               "label": "Offer something to the wind",
-              "consequence": "A downdraft hits you — lose 5 HP",
+              "consequence": "A downdraft hits you \u2014 lose 5 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 5
@@ -398,7 +431,7 @@
           [
             {
               "label": "Read the wind patterns",
-              "consequence": "The patterns describe a rare card's construction — yours",
+              "consequence": "The patterns describe a rare card's construction \u2014 yours",
               "effect": {
                 "type": "gainCard",
                 "rarity": "rare"
@@ -406,7 +439,7 @@
             },
             {
               "label": "Read the wind patterns",
-              "consequence": "The patterns heal — restored 8 HP",
+              "consequence": "The patterns heal \u2014 restored 8 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 8
@@ -424,7 +457,7 @@
           [
             {
               "label": "Pocket the shrine parts",
-              "consequence": "Sold in the next port — +18 crystals",
+              "consequence": "Sold in the next port \u2014 +18 crystals",
               "effect": {
                 "type": "gainCrystals",
                 "amount": 18
@@ -440,7 +473,7 @@
             },
             {
               "label": "Pocket the shrine parts",
-              "consequence": "Something electrical discharges — lose 12 HP",
+              "consequence": "Something electrical discharges \u2014 lose 12 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 12
@@ -556,7 +589,7 @@
       "environment": "sky",
       "eventConfig": {
         "title": "The Thermal Column",
-        "description": "A powerful updraft punches through a gap in the island's floor. It carries the smell of the shards below — and loose objects that fell off other islands during the Fracture.",
+        "description": "A powerful updraft punches through a gap in the island's floor. It carries the smell of the shards below \u2014 and loose objects that fell off other islands during the Fracture.",
         "pools": [
           [
             {
@@ -569,7 +602,7 @@
             },
             {
               "label": "Reach in",
-              "consequence": "The updraft carries something warm — healed 15 HP",
+              "consequence": "The updraft carries something warm \u2014 healed 15 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 15
@@ -577,7 +610,7 @@
             },
             {
               "label": "Reach in",
-              "consequence": "Something comes up fast and hits you — lose 10 HP",
+              "consequence": "Something comes up fast and hits you \u2014 lose 10 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 10
@@ -595,7 +628,7 @@
           [
             {
               "label": "Follow the column up",
-              "consequence": "You find a supply cache on the way — +30 crystals",
+              "consequence": "You find a supply cache on the way \u2014 +30 crystals",
               "effect": {
                 "type": "gainCrystals",
                 "amount": 30
@@ -658,10 +691,10 @@
       "id": "upper-platform",
       "type": "battle",
       "label": "Upper Platform",
-      "description": "The highest inhabited island. From here you can see the ley bridge — and everything defending it.",
+      "description": "The highest inhabited island. From here you can see the ley bridge \u2014 and everything defending it.",
       "row": 5,
       "col": 0,
-      "rowCols": 1,
+      "rowCols": 2,
       "childIds": [
         "cloudmarshal"
       ],
@@ -693,19 +726,19 @@
       "description": "A command post, abandoned in the retreat. The tactical logs are still open.",
       "row": 1,
       "col": 1,
-      "rowCols": 2,
+      "rowCols": 3,
       "childIds": [
         "sky-elite"
       ],
       "environment": "sky",
       "eventConfig": {
         "title": "The Command Post",
-        "description": "An abandoned Dominion command post, still warm from use. Maps, tactical notes, and a half-eaten ration. The logs describe the Fracture from above — and something the Cloudmarshal calls 'the signal.'",
+        "description": "An abandoned Dominion command post, still warm from use. Maps, tactical notes, and a half-eaten ration. The logs describe the Fracture from above \u2014 and something the Cloudmarshal calls 'the signal.'",
         "pools": [
           [
             {
               "label": "Read the tactical logs",
-              "consequence": "The strategy is useful — rare card",
+              "consequence": "The strategy is useful \u2014 rare card",
               "effect": {
                 "type": "gainCard",
                 "rarity": "rare"
@@ -713,7 +746,7 @@
             },
             {
               "label": "Read the tactical logs",
-              "consequence": "You find supply caches marked on the map — +25 crystals",
+              "consequence": "You find supply caches marked on the map \u2014 +25 crystals",
               "effect": {
                 "type": "gainCrystals",
                 "amount": 25
@@ -723,7 +756,7 @@
           [
             {
               "label": "Rest in the shelter",
-              "consequence": "First proper shelter in hours — healed 15 HP",
+              "consequence": "First proper shelter in hours \u2014 healed 15 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 15
@@ -764,7 +797,8 @@
       "col": 0,
       "rowCols": 2,
       "childIds": [
-        "upper-platform"
+        "upper-platform",
+        "mem-act6-2"
       ],
       "handicap": 20,
       "opponentIntervalMs": 3800,
@@ -804,12 +838,12 @@
       "environment": "sky",
       "bossIntro": [
         {
-          "title": "ACT VI — BOSS",
-          "text": "The Sky Dominion rises above the cloud line — towers of pale stone that catch no light because they have never needed to. You are looking up at a place that has never been approached from below.\n\nUntil now.",
+          "title": "ACT VI \u2014 BOSS",
+          "text": "The Sky Dominion rises above the cloud line \u2014 towers of pale stone that catch no light because they have never needed to. You are looking up at a place that has never been approached from below.\n\nUntil now.",
           "image": "cutscenes/act6-boss-1.svg"
         },
         {
-          "title": "ACT VI — BOSS",
+          "title": "ACT VI \u2014 BOSS",
           "text": "She is already watching when you reach the parapet. She does not draw a weapon. She is holding a logbook.\n\nThe Cloudmarshal of the Sky Dominion has commanded every engagement from this height for forty years. She has notes on everything.\n\nShe does not have notes on this.",
           "image": "cutscenes/act6-boss-2.svg"
         }
@@ -840,6 +874,34 @@
         "Feather Step"
       ],
       "bossCard": "Sky Leviathan"
+    },
+    "mem-act6-1": {
+      "id": "mem-act6-1",
+      "type": "memory",
+      "label": "Memory Fragment",
+      "description": "A cartographer's final log, stashed in the archive vault before the sky routes closed.",
+      "row": 1,
+      "col": 2,
+      "rowCols": 3,
+      "childIds": [
+        "gale-crossing"
+      ],
+      "fragmentId": "act6-frag-1",
+      "environment": "sky"
+    },
+    "mem-act6-2": {
+      "id": "mem-act6-2",
+      "type": "memory",
+      "label": "Memory Fragment",
+      "description": "The Cloudmarshal's proclamation of independence \u2014 shaky ink, sealed twice.",
+      "row": 5,
+      "col": 1,
+      "rowCols": 2,
+      "childIds": [
+        "cloudmarshal"
+      ],
+      "fragmentId": "act6-frag-2",
+      "environment": "sky"
     }
   }
 }

--- a/web/src/data/acts/act7.json
+++ b/web/src/data/acts/act7.json
@@ -45,7 +45,7 @@
       "Now, technically, on fire in the metaphorical sense. Possibly also the literal one.",
       "Now, effectively, the sort of person who climbs active volcanoes as a professional choice.",
       "Now, in the thermal sense, significantly overdressed for the ambient temperature.",
-      "Now — by any rational measure — somewhere that a reasonable person would not be.",
+      "Now \u2014 by any rational measure \u2014 somewhere that a reasonable person would not be.",
       "Now, technically, at an elevation where the ground is a suggestion rather than a guarantee."
     ],
     "jarvIntros": [
@@ -56,27 +56,27 @@
       "You have a deck of cards. The mountain has been here for ten thousand years. You have been here enough times that it has started to feel personal."
     ],
     "peaksDesc": [
-      "The Emberfall Peaks rise through sulphur clouds — a range of active volcanoes threaded with ley lines that glow orange through the rock.",
-      "The Peaks smell like the end of something — sulphur and scorched stone and the particular heat of a place that has been on fire for longer than anyone has been alive.",
+      "The Emberfall Peaks rise through sulphur clouds \u2014 a range of active volcanoes threaded with ley lines that glow orange through the rock.",
+      "The Peaks smell like the end of something \u2014 sulphur and scorched stone and the particular heat of a place that has been on fire for longer than anyone has been alive.",
       "The Emberfall Peaks wait at your bearing's edge, exhaling steam and ash. They have been waiting exactly this long for exactly this reason.",
       "The ley lines glow through the volcanic rock like veins. The Peaks have been channelling this energy since before the Dominion had a name for what they were doing."
     ],
     "warlordDesc": [
-      "The Peaks are held by the Cinderwarlord — a commander who built an army out of whatever the volcanoes threw up: crawlers, fire spirits, things that are basically lava with ambitions.\n\nHe does not negotiate. The mountain does not negotiate. He considers this a professional alignment.",
+      "The Peaks are held by the Cinderwarlord \u2014 a commander who built an army out of whatever the volcanoes threw up: crawlers, fire spirits, things that are basically lava with ambitions.\n\nHe does not negotiate. The mountain does not negotiate. He considers this a professional alignment.",
       "The Cinderwarlord commands every approach through the Peaks. He was forged here, in the practical sense, by decades of fighting in conditions that kill most soldiers before they can become problems.\n\nYou are about to become a problem.",
       "The Cinderwarlord holds the caldera pass with the patience of a man who knows the terrain will do most of the work for him.\n\nYou've found that patience like that makes generals predictable.",
       "The Cinderwarlord waits at the caldera. He has been told you're coming. His response, according to scouts, was: 'Again?'"
     ],
     "priorRunSummaries": [
-      "The heat felt familiar — the particular way it pressed against everything, the way it made distance hard to judge. Like a memory that had been stored somewhere warm.",
-      "The first lava field was wrong. Not impassable wrong — arranged wrong, the way things are arranged when someone has recently moved them and not yet put them back.",
+      "The heat felt familiar \u2014 the particular way it pressed against everything, the way it made distance hard to judge. Like a memory that had been stored somewhere warm.",
+      "The first lava field was wrong. Not impassable wrong \u2014 arranged wrong, the way things are arranged when someone has recently moved them and not yet put them back.",
       "Something about the patrol spacing on the obsidian ridge. The exact interval of it. You adjusted your approach without thinking, which meant you'd thought about it before.",
       "The Peaks were louder on approach than they should have been. As though the mountain had something to say about your return."
     ],
     "priorRunOpenings": [
       "You had been here. Your hands knew the footing on the first lava crossing before your eyes confirmed it was safe.",
       "The Ember Crawler unit at the base camp didn't charge immediately. They looked at each other first. Then charged.",
-      "The Cinderwarlord's opening formation was different this time — denser on the left flank. He'd adjusted for you. You adjusted for his adjustment.",
+      "The Cinderwarlord's opening formation was different this time \u2014 denser on the left flank. He'd adjusted for you. You adjusted for his adjustment.",
       "The caldera was venting more aggressively when you arrived. You chose to interpret this as the mountain expressing an opinion."
     ],
     "milestoneOpenings5": [
@@ -92,11 +92,11 @@
       "After twenty-five runs, the Cinderwarlord meets you at the base of the caldera pass instead of the summit. He's stopped holding the high ground. Something in him has recalibrated."
     ],
     "milestoneOpenings50": [
-      "The fiftieth time through the Emberfall Peaks. The lava flows are the wrong temperature — cooler near the paths you use, as though the mountain has been making accommodations it hasn't mentioned.",
+      "The fiftieth time through the Emberfall Peaks. The lava flows are the wrong temperature \u2014 cooler near the paths you use, as though the mountain has been making accommodations it hasn't mentioned.",
       "Fifty campaigns. The base camp sentinels step aside when your silhouette crests the ridge. Not in welcome. In the way of people who have learned that certain things are inevitable and have made their peace with it."
     ],
     "milestoneOpenings100": [
-      "The Cinderwarlord is standing at the base of the caldera pass. Not in formation. Not surrounded by soldiers. Just standing.\n\n'A hundred campaigns,' he says. The volcanic glow makes his expression hard to read. It doesn't matter. His voice says everything. 'I built my army out of this mountain. I have fought in conditions that have killed things that were supposed to be immortal.'\n\nA rumble. A slow exhalation of steam from the caldera above.\n\n'And you keep coming back.' He looks at you — not at Jarv, at you. 'I have stopped calling this a problem. I am calling it a fact.'\n\nHe steps aside.\n\n'The path is yours. It has been yours for some time.'"
+      "The Cinderwarlord is standing at the base of the caldera pass. Not in formation. Not surrounded by soldiers. Just standing.\n\n'A hundred campaigns,' he says. The volcanic glow makes his expression hard to read. It doesn't matter. His voice says everything. 'I built my army out of this mountain. I have fought in conditions that have killed things that were supposed to be immortal.'\n\nA rumble. A slow exhalation of steam from the caldera above.\n\n'And you keep coming back.' He looks at you \u2014 not at Jarv, at you. 'I have stopped calling this a problem. I am calling it a fact.'\n\nHe steps aside.\n\n'The path is yours. It has been yours for some time.'"
     ]
   },
   "midRunTemplates": [
@@ -294,7 +294,7 @@
       "panels": [
         {
           "title": "THE EMBERFALL PEAKS",
-          "text": "The ley lines cut through the mountains here — again.\n\n{pool:priorRunSummaries:0}"
+          "text": "The ley lines cut through the mountains here \u2014 again.\n\n{pool:priorRunSummaries:0}"
         },
         {
           "title": "THE WANDERER",
@@ -306,7 +306,7 @@
         },
         {
           "title": "A FEELING",
-          "text": "And yet — {pool:priorRunOpenings:0}\n\nYou push the feeling aside. There is work to do.\n\nAgain."
+          "text": "And yet \u2014 {pool:priorRunOpenings:0}\n\nYou push the feeling aside. There is work to do.\n\nAgain."
         }
       ]
     }
@@ -314,17 +314,17 @@
   "intro": [
     {
       "title": "THE EMBERFALL PEAKS",
-      "text": "The ley lines cut through the mountains here — through layers of volcanic rock still warm from the last eruption. This is the Emberfall Peaks: a chain of active volcanoes that the Fracture cracked open and left to simmer.\n\nThings live here. Heat-adapted things. Things that were dangerous before the Fracture made them angrier.\n\nThe ley path goes through the caldera. There's no route around.",
+      "text": "The ley lines cut through the mountains here \u2014 through layers of volcanic rock still warm from the last eruption. This is the Emberfall Peaks: a chain of active volcanoes that the Fracture cracked open and left to simmer.\n\nThings live here. Heat-adapted things. Things that were dangerous before the Fracture made them angrier.\n\nThe ley path goes through the caldera. There's no route around.",
       "image": "cutscenes/act7-intro-1.svg"
     },
     {
       "title": "THE CINDERWARLORD",
-      "text": "The Peaks are held by the Cinderwarlord — a commander who built an army out of whatever the volcanoes threw up: crawlers, hounds, archers who fire molten shot, constructs assembled from cooled lava-flow.\n\nHe has not lost the mountains once. The mountains are on his side. Literally. He has an understanding with them.\n\nYou are going to walk through his territory regardless.",
+      "text": "The Peaks are held by the Cinderwarlord \u2014 a commander who built an army out of whatever the volcanoes threw up: crawlers, hounds, archers who fire molten shot, constructs assembled from cooled lava-flow.\n\nHe has not lost the mountains once. The mountains are on his side. Literally. He has an understanding with them.\n\nYou are going to walk through his territory regardless.",
       "image": "cutscenes/act7-intro-2.svg"
     },
     {
       "title": "HEAT AND PRESSURE",
-      "text": "The deeper you go, the hotter it gets. The ley lines are visible here — they glow faintly orange, like metal near a forge, and they point straight toward the caldera at the heart of the range.\n\nWhatever is at the Fracture Core, the ley lines think this is the way.\n\nYou have learned to trust the ley lines. You have also learned to bring extra water.",
+      "text": "The deeper you go, the hotter it gets. The ley lines are visible here \u2014 they glow faintly orange, like metal near a forge, and they point straight toward the caldera at the heart of the range.\n\nWhatever is at the Fracture Core, the ley lines think this is the way.\n\nYou have learned to trust the ley lines. You have also learned to bring extra water.",
       "image": "cutscenes/act7-intro-3.svg"
     }
   ],
@@ -341,7 +341,7 @@
     },
     {
       "title": "DEEPER IN",
-      "text": "The Magma Core sits in your hand — a solid chunk of volcanic glass with something still burning at the centre. The Cinderwarlord's mark of command.\n\nThe ley lines glow brighter past the caldera. Whatever the Fracture Core is, it's warmer on this side.\n\nYou move forward. The mountains stop objecting.",
+      "text": "The Magma Core sits in your hand \u2014 a solid chunk of volcanic glass with something still burning at the centre. The Cinderwarlord's mark of command.\n\nThe ley lines glow brighter past the caldera. Whatever the Fracture Core is, it's warmer on this side.\n\nYou move forward. The mountains stop objecting.",
       "image": "cutscenes/act7-outro-3.svg"
     }
   ],
@@ -394,12 +394,12 @@
       "environment": "volcano",
       "eventConfig": {
         "title": "The Ash Shrine",
-        "description": "A ring of fused volcanic rock, still warm. Ash coils upward in slow spirals — too slow for the wind to explain. Whatever was worshipped here, something is still paying attention.",
+        "description": "A ring of fused volcanic rock, still warm. Ash coils upward in slow spirals \u2014 too slow for the wind to explain. Whatever was worshipped here, something is still paying attention.",
         "pools": [
           [
             {
               "label": "Leave an offering",
-              "consequence": "The ash spirals outward — healed 12 HP",
+              "consequence": "The ash spirals outward \u2014 healed 12 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 12
@@ -407,7 +407,7 @@
             },
             {
               "label": "Leave an offering",
-              "consequence": "Hot ash stings your hands — lose 6 HP",
+              "consequence": "Hot ash stings your hands \u2014 lose 6 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 6
@@ -433,7 +433,7 @@
           [
             {
               "label": "Read the ash patterns",
-              "consequence": "The patterns describe something useful — uncommon card",
+              "consequence": "The patterns describe something useful \u2014 uncommon card",
               "effect": {
                 "type": "gainCard",
                 "rarity": "uncommon"
@@ -441,7 +441,7 @@
             },
             {
               "label": "Read the ash patterns",
-              "consequence": "The patterns heal — restored 8 HP",
+              "consequence": "The patterns heal \u2014 restored 8 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 8
@@ -459,7 +459,7 @@
           [
             {
               "label": "Pocket the shrine stones",
-              "consequence": "Still warm — good for +18 crystals in the next market",
+              "consequence": "Still warm \u2014 good for +18 crystals in the next market",
               "effect": {
                 "type": "gainCrystals",
                 "amount": 18
@@ -475,7 +475,7 @@
             },
             {
               "label": "Pocket the shrine stones",
-              "consequence": "One stone discharges — lose 10 HP",
+              "consequence": "One stone discharges \u2014 lose 10 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 10
@@ -551,9 +551,10 @@
       "description": "Artillery emplacements built into the crater wall. Magma vents power the launchers.",
       "row": 4,
       "col": 0,
-      "rowCols": 2,
+      "rowCols": 3,
       "childIds": [
-        "crater-rest"
+        "crater-rest",
+        "mem-act7-2"
       ],
       "handicap": 16,
       "opponentIntervalMs": 4400,
@@ -603,7 +604,7 @@
             },
             {
               "label": "Reach into the column",
-              "consequence": "The heat is a balm — healed 15 HP",
+              "consequence": "The heat is a balm \u2014 healed 15 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 15
@@ -611,7 +612,7 @@
             },
             {
               "label": "Reach into the column",
-              "consequence": "Something comes out hot — lose 12 HP",
+              "consequence": "Something comes out hot \u2014 lose 12 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 12
@@ -629,7 +630,7 @@
           [
             {
               "label": "Follow the vent up the slope",
-              "consequence": "Supply cache wedged in the cooled rim — +30 crystals",
+              "consequence": "Supply cache wedged in the cooled rim \u2014 +30 crystals",
               "effect": {
                 "type": "gainCrystals",
                 "amount": 30
@@ -663,7 +664,8 @@
       "col": 1,
       "rowCols": 3,
       "childIds": [
-        "crater-rest"
+        "crater-rest",
+        "mem-act7-1"
       ],
       "handicap": 20,
       "opponentIntervalMs": 4000,
@@ -733,12 +735,12 @@
       "environment": "volcano",
       "eventConfig": {
         "title": "The Forge Post",
-        "description": "A Cinderwarlord field post, evacuated in the fighting. Forge tools, tactical slates, and a map of the caldera. The slate shows the Cinderwarlord's actual position — and something he marked 'signal origin' in the deep caldera.",
+        "description": "A Cinderwarlord field post, evacuated in the fighting. Forge tools, tactical slates, and a map of the caldera. The slate shows the Cinderwarlord's actual position \u2014 and something he marked 'signal origin' in the deep caldera.",
         "pools": [
           [
             {
               "label": "Study the tactical slates",
-              "consequence": "Useful knowledge — rare card",
+              "consequence": "Useful knowledge \u2014 rare card",
               "effect": {
                 "type": "gainCard",
                 "rarity": "rare"
@@ -746,7 +748,7 @@
             },
             {
               "label": "Study the tactical slates",
-              "consequence": "The supply caches are marked — +25 crystals",
+              "consequence": "The supply caches are marked \u2014 +25 crystals",
               "effect": {
                 "type": "gainCrystals",
                 "amount": 25
@@ -756,7 +758,7 @@
           [
             {
               "label": "Use the forge rest area",
-              "consequence": "Proper heat for once — healed 15 HP",
+              "consequence": "Proper heat for once \u2014 healed 15 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 15
@@ -781,7 +783,7 @@
       "description": "A shallow alcove cut into the crater wall. Surprisingly calm.",
       "row": 5,
       "col": 0,
-      "rowCols": 1,
+      "rowCols": 2,
       "childIds": [
         "caldera-gate"
       ],
@@ -795,7 +797,7 @@
       "description": "The Cinderwarlord's personal guard. They've been briefed on you specifically.",
       "row": 4,
       "col": 1,
-      "rowCols": 2,
+      "rowCols": 3,
       "childIds": [
         "crater-rest"
       ],
@@ -952,6 +954,34 @@
         "Burning Rush",
         "Smelted Blade"
       ]
+    },
+    "mem-act7-1": {
+      "id": "mem-act7-1",
+      "type": "memory",
+      "label": "Memory Fragment",
+      "description": "The Forge Master's log \u2014 the volcanoes were listening before anyone understood what they heard.",
+      "row": 4,
+      "col": 2,
+      "rowCols": 3,
+      "childIds": [
+        "crater-rest"
+      ],
+      "fragmentId": "act7-frag-1",
+      "environment": "volcano"
+    },
+    "mem-act7-2": {
+      "id": "mem-act7-2",
+      "type": "memory",
+      "label": "Memory Fragment",
+      "description": "A note sealed in cooling lava \u2014 the first eruption after the Fracture was not natural.",
+      "row": 5,
+      "col": 1,
+      "rowCols": 2,
+      "childIds": [
+        "caldera-gate"
+      ],
+      "fragmentId": "act7-frag-2",
+      "environment": "volcano"
     }
   }
 }

--- a/web/src/data/acts/act8.json
+++ b/web/src/data/acts/act8.json
@@ -45,7 +45,7 @@
       "Now, technically, underground in both the geographic and philosophical sense.",
       "Now, effectively, the sort of person who descends into fungal cave systems by choice.",
       "Now, professionally speaking, operating at depths where the sky is a concept rather than a fact.",
-      "Now — by any measure — somewhere that smells significantly worse than the previous shard.",
+      "Now \u2014 by any measure \u2014 somewhere that smells significantly worse than the previous shard.",
       "Now, technically, in a place that is alive in ways that make the word 'alive' do a lot of work."
     ],
     "jarvIntros": [
@@ -56,27 +56,27 @@
       "You have a deck of cards. The network has been tracking you since your first descent. You have both learned from the experience."
     ],
     "deepDesc": [
-      "The ley lines go down here — descending through collapsed caverns, through layered rock, into something old and wet and completely unbothered by the concept of visitors.",
+      "The ley lines go down here \u2014 descending through collapsed caverns, through layered rock, into something old and wet and completely unbothered by the concept of visitors.",
       "The Fungal Deep smells like the inside of something that has been growing for longer than any surface thing has been alive.",
-      "The Fungal Deep waits beneath the surface, its bioluminescent light pulsing in rhythms that are almost — almost — regular enough to ignore.",
+      "The Fungal Deep waits beneath the surface, its bioluminescent light pulsing in rhythms that are almost \u2014 almost \u2014 regular enough to ignore.",
       "The ley lines thread through the mycelium here. The network and the ley lines have reached an arrangement. You were not consulted."
     ],
     "queenDesc": [
-      "The Root Queen is not a person in any conventional sense — she's the oldest fungal network in the shard, given something like will by the Fracture's magic.\n\nShe does not fight. She tends. The distinction, from inside the network, is not always clear.",
+      "The Root Queen is not a person in any conventional sense \u2014 she's the oldest fungal network in the shard, given something like will by the Fracture's magic.\n\nShe does not fight. She tends. The distinction, from inside the network, is not always clear.",
       "The Root Queen holds every pathway through the Deep. She is patient, distributed, and aware of everything that moves through her mycelium.\n\nShe was aware of you before you started descending.",
       "The Root Queen tends the Deep with the calm certainty of something that has never once needed to hurry.\n\nYou are about to give her a reason to reconsider her pace.",
       "The Root Queen is already aware of your approach. She has been aware since your last visit. The network has very good memory, and it has been waiting to see what you do differently."
     ],
     "priorRunSummaries": [
-      "The dark felt familiar — the particular quality of it, the way the bioluminescence pulsed. Like something that had been waiting to be recognised.",
-      "The first tunnel fork was wrong. Not structurally wrong — arranged wrong, the way a path feels wrong when you've taken the other one before.",
+      "The dark felt familiar \u2014 the particular quality of it, the way the bioluminescence pulsed. Like something that had been waiting to be recognised.",
+      "The first tunnel fork was wrong. Not structurally wrong \u2014 arranged wrong, the way a path feels wrong when you've taken the other one before.",
       "Something about the spore density in the upper tunnels. The exact pattern of it. You adjusted your breathing accordingly, which meant you'd breathed here before.",
       "The network was quieter on approach than it should have been. As though it had already finished deciding something about your visit."
     ],
     "priorRunOpenings": [
       "You had been here. Your feet found the route through the first cavern before your eyes adjusted to the dark.",
       "The Spore Drifter colony at the first tunnel junction didn't spread defensively. They observed. Then spread.",
-      "The Root Queen's first pulse through the network was different this time — slower, more deliberate. She had considered her approach.",
+      "The Root Queen's first pulse through the network was different this time \u2014 slower, more deliberate. She had considered her approach.",
       "The bioluminescence changed colour when you entered. Just slightly. A frequency shift that might have been a greeting, or might have been an alarm. The distinction, down here, is not always clear."
     ],
     "milestoneOpenings5": [
@@ -92,16 +92,16 @@
       "After twenty-five runs, the Root Queen sends a single pulse through the network when you cross the threshold. You've learned to read it as acknowledgement rather than warning."
     ],
     "milestoneOpenings50": [
-      "The fiftieth time through the Fungal Deep. The tunnels are the wrong temperature — warmer than they should be near your route, as though the network has been warming them between visits.",
+      "The fiftieth time through the Fungal Deep. The tunnels are the wrong temperature \u2014 warmer than they should be near your route, as though the network has been warming them between visits.",
       "Fifty campaigns. The Spore Drifters at the entrance form a corridor when they see you. Not a welcoming corridor. A resigned one. The distinction matters to them."
     ],
     "milestoneOpenings100": [
-      "The Root Queen does not speak. She pulses.\n\nThe pulse travels through the entire network — every tunnel, every cavern, every thread of mycelium from the surface to the deepest chamber. It reaches you before you've taken three steps into the dark.\n\nYou have learned, over a hundred descents, what the pulses mean.\n\nThis one means: I know. I have always known. A hundred times you have come here and I have tried to tend you out. A hundred times I have failed.\n\nA pause. The bioluminescence dims.\n\nThe network parts.\n\nThis one means: go, then. You have earned the passage, if nothing else."
+      "The Root Queen does not speak. She pulses.\n\nThe pulse travels through the entire network \u2014 every tunnel, every cavern, every thread of mycelium from the surface to the deepest chamber. It reaches you before you've taken three steps into the dark.\n\nYou have learned, over a hundred descents, what the pulses mean.\n\nThis one means: I know. I have always known. A hundred times you have come here and I have tried to tend you out. A hundred times I have failed.\n\nA pause. The bioluminescence dims.\n\nThe network parts.\n\nThis one means: go, then. You have earned the passage, if nothing else."
     ]
   },
   "midRunTemplates": [
     "The {ordinalLower} time through the Fungal Deep. The Root Queen has pre-reconfigured the mycelium before you've reached the lower caverns.",
-    "Campaign {n}. The tunnel network has been restructured again. Someone — something — submitted the work order specifically in response to your last visit.",
+    "Campaign {n}. The tunnel network has been restructured again. Someone \u2014 something \u2014 submitted the work order specifically in response to your last visit.",
     "{n} campaigns in. The Spore Drifters at the upper junction have started forming defensively before you reach them. They've learned your pace.",
     "{n} times you've descended into the Deep. The bioluminescence pulses differently when you're here. The network notices.",
     "Run {n}. You enter the first tunnel and find the air already adjusted to your preferred breathable ratio. The network has been doing maintenance.",
@@ -110,7 +110,10 @@
   ],
   "introRules": [
     {
-      "condition": { "op": "gte", "value": 100 },
+      "condition": {
+        "op": "gte",
+        "value": 100
+      },
       "panels": [
         {
           "title": "THE QUEEN KNOWS",
@@ -123,7 +126,11 @@
       ]
     },
     {
-      "condition": { "op": "range", "min": 51, "max": 99 },
+      "condition": {
+        "op": "range",
+        "min": 51,
+        "max": 99
+      },
       "panels": [
         {
           "title": "THE {ORDINAL} TIME",
@@ -144,7 +151,10 @@
       ]
     },
     {
-      "condition": { "op": "eq", "value": 50 },
+      "condition": {
+        "op": "eq",
+        "value": 50
+      },
       "panels": [
         {
           "title": "FIFTY CAMPAIGNS",
@@ -165,7 +175,11 @@
       ]
     },
     {
-      "condition": { "op": "range", "min": 26, "max": 49 },
+      "condition": {
+        "op": "range",
+        "min": 26,
+        "max": 49
+      },
       "panels": [
         {
           "title": "THE {ORDINAL} TIME",
@@ -182,7 +196,10 @@
       ]
     },
     {
-      "condition": { "op": "eq", "value": 25 },
+      "condition": {
+        "op": "eq",
+        "value": 25
+      },
       "panels": [
         {
           "title": "TWENTY-FIVE",
@@ -199,7 +216,11 @@
       ]
     },
     {
-      "condition": { "op": "range", "min": 11, "max": 24 },
+      "condition": {
+        "op": "range",
+        "min": 11,
+        "max": 24
+      },
       "panels": [
         {
           "title": "THE {ORDINAL} TIME",
@@ -220,7 +241,10 @@
       ]
     },
     {
-      "condition": { "op": "eq", "value": 10 },
+      "condition": {
+        "op": "eq",
+        "value": 10
+      },
       "panels": [
         {
           "title": "THE TENTH TIME",
@@ -241,7 +265,11 @@
       ]
     },
     {
-      "condition": { "op": "range", "min": 5, "max": 9 },
+      "condition": {
+        "op": "range",
+        "min": 5,
+        "max": 9
+      },
       "panels": [
         {
           "title": "THE {ORDINAL} TIME",
@@ -258,11 +286,15 @@
       ]
     },
     {
-      "condition": { "op": "range", "min": 2, "max": 4 },
+      "condition": {
+        "op": "range",
+        "min": 2,
+        "max": 4
+      },
       "panels": [
         {
           "title": "THE FUNGAL DEEP",
-          "text": "The ley lines go down here — again.\n\n{pool:priorRunSummaries:0}"
+          "text": "The ley lines go down here \u2014 again.\n\n{pool:priorRunSummaries:0}"
         },
         {
           "title": "THE WANDERER",
@@ -274,7 +306,7 @@
         },
         {
           "title": "A FEELING",
-          "text": "And yet — {pool:priorRunOpenings:0}\n\nYou push the feeling aside. There is work to do.\n\nAgain."
+          "text": "And yet \u2014 {pool:priorRunOpenings:0}\n\nYou push the feeling aside. There is work to do.\n\nAgain."
         }
       ]
     }
@@ -287,7 +319,7 @@
     },
     {
       "title": "THE ROOT QUEEN",
-      "text": "The Fungal Deep is not ruled. It is tended.\n\nThe Root Queen is not a person in any conventional sense — she's the oldest node in the mycelium network, the point everything connects back to. She doesn't give orders. She pulses. Things respond.\n\nShe has been aware of you since you entered the first cavern. She has been deciding what to do about you. She has decided.",
+      "text": "The Fungal Deep is not ruled. It is tended.\n\nThe Root Queen is not a person in any conventional sense \u2014 she's the oldest node in the mycelium network, the point everything connects back to. She doesn't give orders. She pulses. Things respond.\n\nShe has been aware of you since you entered the first cavern. She has been deciding what to do about you. She has decided.",
       "image": "cutscenes/act8-intro-2.svg"
     },
     {
@@ -299,7 +331,7 @@
   "outro": [
     {
       "title": "THE ROOT QUEEN STILLS",
-      "text": "The network doesn't die. That would be too simple.\n\nIt stills — a long, slow reduction, like a fire burning down rather than going out. The Root Queen doesn't speak exactly, but something that constitutes speech passes through the mycelium and reaches you: something that means 'enough.'\n\nThe ley lines pulse clear. The way opens downward.",
+      "text": "The network doesn't die. That would be too simple.\n\nIt stills \u2014 a long, slow reduction, like a fire burning down rather than going out. The Root Queen doesn't speak exactly, but something that constitutes speech passes through the mycelium and reaches you: something that means 'enough.'\n\nThe ley lines pulse clear. The way opens downward.",
       "image": "cutscenes/act8-outro-1.svg"
     },
     {
@@ -309,7 +341,7 @@
     },
     {
       "title": "THE SPORE BLOOM",
-      "text": "The Spore Bloom sits in your hand — a dense, warm cluster of something that is technically a seed but feels considerably more significant than that.\n\nThe mycelium connected to it as you left, briefly. You got the impression it was saying goodbye.\n\nThe ley lines run deeper. They always run deeper. That, at least, is consistent.",
+      "text": "The Spore Bloom sits in your hand \u2014 a dense, warm cluster of something that is technically a seed but feels considerably more significant than that.\n\nThe mycelium connected to it as you left, briefly. You got the impression it was saying goodbye.\n\nThe ley lines run deeper. They always run deeper. That, at least, is consistent.",
       "image": "cutscenes/act8-outro-3.svg"
     }
   ],
@@ -324,7 +356,8 @@
       "rowCols": 1,
       "childIds": [
         "spore-shrine",
-        "root-hollow"
+        "root-hollow",
+        "mem-act8-1"
       ],
       "handicap": 14,
       "opponentIntervalMs": 4800,
@@ -354,7 +387,7 @@
       "description": "A growth of bioluminescent fungus forms a rough altar. Something in the mycelium is paying attention.",
       "row": 1,
       "col": 0,
-      "rowCols": 2,
+      "rowCols": 3,
       "childIds": [
         "mycelium-crossing",
         "node-1776871962308"
@@ -367,7 +400,7 @@
           [
             {
               "label": "Touch the largest cap",
-              "consequence": "The network sends something back — healed 12 HP",
+              "consequence": "The network sends something back \u2014 healed 12 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 12
@@ -375,7 +408,7 @@
             },
             {
               "label": "Touch the largest cap",
-              "consequence": "The spores sting — lose 6 HP",
+              "consequence": "The spores sting \u2014 lose 6 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 6
@@ -401,7 +434,7 @@
           [
             {
               "label": "Listen to the network",
-              "consequence": "Something useful echoes back — uncommon card",
+              "consequence": "Something useful echoes back \u2014 uncommon card",
               "effect": {
                 "type": "gainCard",
                 "rarity": "uncommon"
@@ -409,7 +442,7 @@
             },
             {
               "label": "Listen to the network",
-              "consequence": "The pulse heals — restored 10 HP",
+              "consequence": "The pulse heals \u2014 restored 10 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 10
@@ -427,7 +460,7 @@
           [
             {
               "label": "Harvest the caps",
-              "consequence": "Valuable in the right market — +18 crystals",
+              "consequence": "Valuable in the right market \u2014 +18 crystals",
               "effect": {
                 "type": "gainCrystals",
                 "amount": 18
@@ -443,7 +476,7 @@
             },
             {
               "label": "Harvest the caps",
-              "consequence": "The network objects — lose 10 HP",
+              "consequence": "The network objects \u2014 lose 10 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 10
@@ -460,7 +493,7 @@
       "description": "A dry pocket in the root mass. Quiet and surprisingly warm.",
       "row": 1,
       "col": 1,
-      "rowCols": 2,
+      "rowCols": 3,
       "childIds": [
         "node-1776871963818",
         "node-1776871965007"
@@ -560,12 +593,12 @@
       "environment": "fungal",
       "eventConfig": {
         "title": "The Bloom Vent",
-        "description": "A wide fissure in the cavern floor, releasing slow pulses of warm spores. The clouds carry bioluminescent fragments — and, somehow, impressions. The network remembers everything that died down here.",
+        "description": "A wide fissure in the cavern floor, releasing slow pulses of warm spores. The clouds carry bioluminescent fragments \u2014 and, somehow, impressions. The network remembers everything that died down here.",
         "pools": [
           [
             {
               "label": "Walk through the bloom",
-              "consequence": "The spores knit wounds — healed 15 HP",
+              "consequence": "The spores knit wounds \u2014 healed 15 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 15
@@ -581,7 +614,7 @@
             },
             {
               "label": "Walk through the bloom",
-              "consequence": "The bloom is toxic here — lose 12 HP",
+              "consequence": "The bloom is toxic here \u2014 lose 12 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 12
@@ -664,7 +697,7 @@
       "description": "The final tunnel. The mycelium here is dense enough to slow movement. The Root Queen is close.",
       "row": 12,
       "col": 0,
-      "rowCols": 1,
+      "rowCols": 2,
       "childIds": [
         "rootqueen"
       ],
@@ -703,12 +736,12 @@
       "environment": "fungal",
       "eventConfig": {
         "title": "The Root Archive",
-        "description": "Columns of crystallised mycelium, each one preserving impressions of things the network witnessed. The Root Queen's full memory of the Fracture is here — she saw it from below. It reads differently from down here.",
+        "description": "Columns of crystallised mycelium, each one preserving impressions of things the network witnessed. The Root Queen's full memory of the Fracture is here \u2014 she saw it from below. It reads differently from down here.",
         "pools": [
           [
             {
               "label": "Absorb the archive",
-              "consequence": "The memory includes something useful — rare card",
+              "consequence": "The memory includes something useful \u2014 rare card",
               "effect": {
                 "type": "gainCard",
                 "rarity": "rare"
@@ -716,7 +749,7 @@
             },
             {
               "label": "Absorb the archive",
-              "consequence": "The network supply routes are mapped — +25 crystals",
+              "consequence": "The network supply routes are mapped \u2014 +25 crystals",
               "effect": {
                 "type": "gainCrystals",
                 "amount": 25
@@ -726,7 +759,7 @@
           [
             {
               "label": "Rest in the archive chamber",
-              "consequence": "The spores here are restorative — healed 15 HP",
+              "consequence": "The spores here are restorative \u2014 healed 15 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 15
@@ -834,12 +867,12 @@
         {
           "title": "THE DEEP REMEMBERS",
           "image": "cutscenes/act8-boss-1.svg",
-          "text": "The network thickens. Every surface here breathes — wall, floor, ceiling interwoven with roots that pulse with slow, cold light. This is the oldest part of the Fungal Deep. Nothing here has ever been separate.\n\nSomething knows you are here."
+          "text": "The network thickens. Every surface here breathes \u2014 wall, floor, ceiling interwoven with roots that pulse with slow, cold light. This is the oldest part of the Fungal Deep. Nothing here has ever been separate.\n\nSomething knows you are here."
         },
         {
           "title": "THE ROOT QUEEN",
           "image": "cutscenes/act8-boss-2.svg",
-          "text": "She does not rise to meet you. She was already here — has always been here, rooted at the centre of everything, extending through every tendril you have ever seen in this place.\n\nThe Root Queen opens her eyes. All of them."
+          "text": "She does not rise to meet you. She was already here \u2014 has always been here, rooted at the centre of everything, extending through every tendril you have ever seen in this place.\n\nThe Root Queen opens her eyes. All of them."
         }
       ]
     },
@@ -977,7 +1010,7 @@
       "id": "node-1776872007977",
       "type": "elite",
       "label": "Vanguard Cluster",
-      "description": "Fragments of the Root Queen’s will, acting in eerie synchrony.",
+      "description": "Fragments of the Root Queen\u2019s will, acting in eerie synchrony.",
       "row": 6,
       "col": 0,
       "rowCols": 2,
@@ -1240,12 +1273,12 @@
       "environment": "fungal",
       "eventConfig": {
         "title": "The Root Archive",
-        "description": "Columns of crystallised mycelium, each one preserving impressions of things the network witnessed. The Root Queen's full memory of the Fracture is here — she saw it from below. It reads differently from down here.",
+        "description": "Columns of crystallised mycelium, each one preserving impressions of things the network witnessed. The Root Queen's full memory of the Fracture is here \u2014 she saw it from below. It reads differently from down here.",
         "pools": [
           [
             {
               "label": "Absorb the archive",
-              "consequence": "The memory includes something useful — rare card",
+              "consequence": "The memory includes something useful \u2014 rare card",
               "effect": {
                 "type": "gainCard",
                 "rarity": "rare"
@@ -1253,7 +1286,7 @@
             },
             {
               "label": "Absorb the archive",
-              "consequence": "The network supply routes are mapped — +25 crystals",
+              "consequence": "The network supply routes are mapped \u2014 +25 crystals",
               "effect": {
                 "type": "gainCrystals",
                 "amount": 25
@@ -1263,7 +1296,7 @@
           [
             {
               "label": "Rest in the archive chamber",
-              "consequence": "The spores here are restorative — healed 15 HP",
+              "consequence": "The spores here are restorative \u2014 healed 15 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 15
@@ -1295,12 +1328,12 @@
       "environment": "fungal",
       "eventConfig": {
         "title": "The Bloom Vent",
-        "description": "A wide fissure in the cavern floor, releasing slow pulses of warm spores. The clouds carry bioluminescent fragments — and, somehow, impressions. The network remembers everything that died down here.",
+        "description": "A wide fissure in the cavern floor, releasing slow pulses of warm spores. The clouds carry bioluminescent fragments \u2014 and, somehow, impressions. The network remembers everything that died down here.",
         "pools": [
           [
             {
               "label": "Walk through the bloom",
-              "consequence": "The spores knit wounds — healed 15 HP",
+              "consequence": "The spores knit wounds \u2014 healed 15 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 15
@@ -1316,7 +1349,7 @@
             },
             {
               "label": "Walk through the bloom",
-              "consequence": "The bloom is toxic here — lose 12 HP",
+              "consequence": "The bloom is toxic here \u2014 lose 12 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 12
@@ -1382,7 +1415,8 @@
       "col": 0,
       "rowCols": 1,
       "childIds": [
-        "node-1776872129768"
+        "node-1776872129768",
+        "mem-act8-2"
       ],
       "handicap": 22,
       "opponentIntervalMs": 4000,
@@ -1437,6 +1471,34 @@
         "Deep Growth",
         "Mycelium Surge"
       ]
+    },
+    "mem-act8-1": {
+      "id": "mem-act8-1",
+      "type": "memory",
+      "label": "Memory Fragment",
+      "description": "A spore-memory of the Fracture \u2014 the mycelial network felt it everywhere at once.",
+      "row": 1,
+      "col": 2,
+      "rowCols": 3,
+      "childIds": [
+        "node-1776871963818"
+      ],
+      "fragmentId": "act8-frag-1",
+      "environment": "fungal"
+    },
+    "mem-act8-2": {
+      "id": "mem-act8-2",
+      "type": "memory",
+      "label": "Memory Fragment",
+      "description": "A deep node that spent eleven months answering questions before anyone came to read the replies.",
+      "row": 12,
+      "col": 1,
+      "rowCols": 2,
+      "childIds": [
+        "rootqueen"
+      ],
+      "fragmentId": "act8-frag-2",
+      "environment": "fungal"
     }
   }
 }

--- a/web/src/data/acts/act9.json
+++ b/web/src/data/acts/act9.json
@@ -45,7 +45,7 @@
       "Now, technically, hypothermic by proximity.",
       "Now, effectively, the sort of person who fights ancient machinery in sub-zero conditions as a career.",
       "Now, professionally speaking, well outside the recommended operating temperature for a human being.",
-      "Now — by every sensible measure — in a place that does not want to be visited.",
+      "Now \u2014 by every sensible measure \u2014 in a place that does not want to be visited.",
       "Now, technically, on a landscape that is actively trying to preserve you in the wrong way."
     ],
     "jarvIntros": [
@@ -57,31 +57,31 @@
     ],
     "expanseDesc": [
       "The ley lines run straight through the ice, bright orange against the white, like cracks in something that is trying to hold itself together.",
-      "The Frozen Expanse smells like cold metal and compressed time — the smell of a place that has been holding still for longer than anything should.",
+      "The Frozen Expanse smells like cold metal and compressed time \u2014 the smell of a place that has been holding still for longer than anything should.",
       "The Frozen Expanse stretches to every horizon, perfectly white and perfectly indifferent. The ley lines are the only thing here that moves.",
       "The ley lines run through the glacier here. The ice formed around them. The Expanse has been here long enough to have opinions about what passes through it."
     ],
     "engineDesc": [
-      "Nobody built the Pale Engine — or if they did, they did it so long ago that the Engine has stopped caring about the distinction.\n\nIt optimises. It calculates. It applies minimum necessary force. It has been doing this since before the Fracture, and the Fracture only gave it more variables to account for.",
+      "Nobody built the Pale Engine \u2014 or if they did, they did it so long ago that the Engine has stopped caring about the distinction.\n\nIt optimises. It calculates. It applies minimum necessary force. It has been doing this since before the Fracture, and the Fracture only gave it more variables to account for.",
       "The Pale Engine holds every route through the Expanse with the calm efficiency of something that does not get tired, does not get angry, and does not stop.\n\nYou are a variable it has not yet fully resolved.",
       "The Pale Engine processes the Expanse with mechanical certainty. It does not distinguish between friend and obstacle. You are, to it, an ongoing optimisation problem.\n\nYou've found that problems like that tend to underestimate you.",
       "The Pale Engine has updated its models since your last visit. You know this because its patrol routes are different. It has been thorough. You will need to be more thorough."
     ],
     "priorRunSummaries": [
-      "The cold felt familiar — not the temperature itself but the quality of it, the way it pressed in from every direction at once. Like a place that had been waiting to be cold at you again.",
-      "The first glacier crossing was wrong. Not icy wrong — patterned wrong, the way a route feels wrong when someone has moved the signposts since you were last here.",
+      "The cold felt familiar \u2014 not the temperature itself but the quality of it, the way it pressed in from every direction at once. Like a place that had been waiting to be cold at you again.",
+      "The first glacier crossing was wrong. Not icy wrong \u2014 patterned wrong, the way a route feels wrong when someone has moved the signposts since you were last here.",
       "Something about the Engine's patrol cycle at the outer gate. The exact timing of it. You adjusted without thinking, which meant you'd made that adjustment before.",
       "The Expanse was quieter than it should have been. The wind had stopped. As though the entire landscape was holding its breath at your return."
     ],
     "priorRunOpenings": [
       "You had been here. Your feet found the safe ice before your eyes confirmed it.",
       "The Frost Sentinel unit at the glacier gate ran its scan cycle slightly longer than the standard interval. It had a new variable to account for: you.",
-      "The Pale Engine's first move was different this time — a half-cycle adjustment in the outer patrol. It had been running simulations.",
+      "The Pale Engine's first move was different this time \u2014 a half-cycle adjustment in the outer patrol. It had been running simulations.",
       "The glacier groaned when you stepped onto it. Just once. Just enough."
     ],
     "milestoneOpenings5": [
       "The fifth time through the Frozen Expanse, the Engine has pre-deployed its reserves before you reach the outer gate. It has been running probability calculations.",
-      "Fifth run. The patrol cycle at the glacier crossing has been tightened by 12%. Someone — something — filed a systems update specifically in response to your previous four visits."
+      "Fifth run. The patrol cycle at the glacier crossing has been tightened by 12%. Someone \u2014 something \u2014 filed a systems update specifically in response to your previous four visits."
     ],
     "milestoneOpenings10": [
       "Ten campaigns. The Pale Engine has dedicated a processing thread specifically to modelling your behaviour. You are officially a standing variable in its optimisation functions.",
@@ -96,7 +96,7 @@
       "Fifty campaigns. The Frost Sentinels at the outer gate step aside. Not in welcome. The Engine has calculated that this costs fewer resources than the alternative."
     ],
     "milestoneOpenings100": [
-      "The Pale Engine stops.\n\nNot powered down. Not damaged. It stops — a full cessation of all non-essential processes — and turns its primary sensors toward you.\n\nYou have learned, over a hundred crossings, that the Engine does not do anything without a reason.\n\n'Variable,' it says. Its voice sounds like ice cracking in a very controlled way. 'One hundred iterations. My models predicted a ninety-three percent attrition rate by iteration forty.' A pause. The processing lights dim as it runs a calculation. 'I have updated my models.'\n\nThe glacier gate opens.\n\n'Proceed,' it says. 'I have allocated a route. It is faster than your usual one. Consider it a data point.'"
+      "The Pale Engine stops.\n\nNot powered down. Not damaged. It stops \u2014 a full cessation of all non-essential processes \u2014 and turns its primary sensors toward you.\n\nYou have learned, over a hundred crossings, that the Engine does not do anything without a reason.\n\n'Variable,' it says. Its voice sounds like ice cracking in a very controlled way. 'One hundred iterations. My models predicted a ninety-three percent attrition rate by iteration forty.' A pause. The processing lights dim as it runs a calculation. 'I have updated my models.'\n\nThe glacier gate opens.\n\n'Proceed,' it says. 'I have allocated a route. It is faster than your usual one. Consider it a data point.'"
     ]
   },
   "midRunTemplates": [
@@ -110,7 +110,10 @@
   ],
   "introRules": [
     {
-      "condition": { "op": "gte", "value": 100 },
+      "condition": {
+        "op": "gte",
+        "value": 100
+      },
       "panels": [
         {
           "title": "THE ENGINE RECALCULATES",
@@ -123,7 +126,11 @@
       ]
     },
     {
-      "condition": { "op": "range", "min": 51, "max": 99 },
+      "condition": {
+        "op": "range",
+        "min": 51,
+        "max": 99
+      },
       "panels": [
         {
           "title": "THE {ORDINAL} TIME",
@@ -144,7 +151,10 @@
       ]
     },
     {
-      "condition": { "op": "eq", "value": 50 },
+      "condition": {
+        "op": "eq",
+        "value": 50
+      },
       "panels": [
         {
           "title": "FIFTY CAMPAIGNS",
@@ -165,7 +175,11 @@
       ]
     },
     {
-      "condition": { "op": "range", "min": 26, "max": 49 },
+      "condition": {
+        "op": "range",
+        "min": 26,
+        "max": 49
+      },
       "panels": [
         {
           "title": "THE {ORDINAL} TIME",
@@ -182,7 +196,10 @@
       ]
     },
     {
-      "condition": { "op": "eq", "value": 25 },
+      "condition": {
+        "op": "eq",
+        "value": 25
+      },
       "panels": [
         {
           "title": "TWENTY-FIVE",
@@ -199,7 +216,11 @@
       ]
     },
     {
-      "condition": { "op": "range", "min": 11, "max": 24 },
+      "condition": {
+        "op": "range",
+        "min": 11,
+        "max": 24
+      },
       "panels": [
         {
           "title": "THE {ORDINAL} TIME",
@@ -220,7 +241,10 @@
       ]
     },
     {
-      "condition": { "op": "eq", "value": 10 },
+      "condition": {
+        "op": "eq",
+        "value": 10
+      },
       "panels": [
         {
           "title": "THE TENTH TIME",
@@ -241,7 +265,11 @@
       ]
     },
     {
-      "condition": { "op": "range", "min": 5, "max": 9 },
+      "condition": {
+        "op": "range",
+        "min": 5,
+        "max": 9
+      },
       "panels": [
         {
           "title": "THE {ORDINAL} TIME",
@@ -258,11 +286,15 @@
       ]
     },
     {
-      "condition": { "op": "range", "min": 2, "max": 4 },
+      "condition": {
+        "op": "range",
+        "min": 2,
+        "max": 4
+      },
       "panels": [
         {
           "title": "THE FROZEN EXPANSE",
-          "text": "The ley lines run straight through the ice — again.\n\n{pool:priorRunSummaries:0}"
+          "text": "The ley lines run straight through the ice \u2014 again.\n\n{pool:priorRunSummaries:0}"
         },
         {
           "title": "THE WANDERER",
@@ -274,7 +306,7 @@
         },
         {
           "title": "A FEELING",
-          "text": "And yet — {pool:priorRunOpenings:0}\n\nYou push the feeling aside. There is work to do.\n\nAgain."
+          "text": "And yet \u2014 {pool:priorRunOpenings:0}\n\nYou push the feeling aside. There is work to do.\n\nAgain."
         }
       ]
     }
@@ -287,19 +319,19 @@
     },
     {
       "title": "THE PALE ENGINE",
-      "text": "Nobody built the Pale Engine — or if they did, they did it so long ago that the Engine has stopped caring about the distinction. It runs on cold and purpose. Its purpose is to hold the Expanse against everything that isn't ice.\n\nIt doesn't sleep. It doesn't negotiate. It processes.\n\nYou represent an input it hasn't encountered before. It is in the process of developing a protocol.",
+      "text": "Nobody built the Pale Engine \u2014 or if they did, they did it so long ago that the Engine has stopped caring about the distinction. It runs on cold and purpose. Its purpose is to hold the Expanse against everything that isn't ice.\n\nIt doesn't sleep. It doesn't negotiate. It processes.\n\nYou represent an input it hasn't encountered before. It is in the process of developing a protocol.",
       "image": "cutscenes/act9-intro-2.svg"
     },
     {
       "title": "INTO THE WHITE",
-      "text": "The cold here isn't just weather. It's structural. It holds the landscape together in a way that makes you understand why the Pale Engine defends it — remove the cold and the whole Expanse would need to rethink what it is.\n\nYou aren't here to take the cold. You're here to pass through it.\n\nThe Pale Engine will need to understand that distinction. You will need to explain it forcefully.",
+      "text": "The cold here isn't just weather. It's structural. It holds the landscape together in a way that makes you understand why the Pale Engine defends it \u2014 remove the cold and the whole Expanse would need to rethink what it is.\n\nYou aren't here to take the cold. You're here to pass through it.\n\nThe Pale Engine will need to understand that distinction. You will need to explain it forcefully.",
       "image": "cutscenes/act9-intro-3.svg"
     }
   ],
   "outro": [
     {
       "title": "THE PALE ENGINE HALTS",
-      "text": "The Pale Engine doesn't fall. It stops — a precise, deliberate cessation, like a machine completing a cycle rather than failing. The cold continues around it. The Expanse doesn't care who won.\n\nThe ley lines pulse through the ice and keep going. They were never going to stop for this.",
+      "text": "The Pale Engine doesn't fall. It stops \u2014 a precise, deliberate cessation, like a machine completing a cycle rather than failing. The cold continues around it. The Expanse doesn't care who won.\n\nThe ley lines pulse through the ice and keep going. They were never going to stop for this.",
       "image": "cutscenes/act9-outro-1.svg"
     },
     {
@@ -309,7 +341,7 @@
     },
     {
       "title": "THE FROST MANTLE",
-      "text": "The Frost Mantle is a layer of something that was once the Engine's outer casing — dense, cold, and almost ornamental in the way it's settled into a shape that fits across your shoulders.\n\nThe cold doesn't bother you as much as it did. That's the point.\n\nThe ley lines run on. The Expanse recedes behind you.",
+      "text": "The Frost Mantle is a layer of something that was once the Engine's outer casing \u2014 dense, cold, and almost ornamental in the way it's settled into a shape that fits across your shoulders.\n\nThe cold doesn't bother you as much as it did. That's the point.\n\nThe ley lines run on. The Expanse recedes behind you.",
       "image": "cutscenes/act9-outro-3.svg"
     }
   ],
@@ -353,19 +385,19 @@
       "description": "A column of ice with something preserved at the centre. The cold here is specific.",
       "row": 6,
       "col": 0,
-      "rowCols": 2,
+      "rowCols": 3,
       "childIds": [
         "node-1776873661402"
       ],
       "environment": "frost",
       "eventConfig": {
         "title": "The Frost Shrine",
-        "description": "A pillar of ancient ice, perfectly clear. Something is frozen at the centre — hard to identify, but clearly significant. The cold radiates outward in a way that feels intentional.",
+        "description": "A pillar of ancient ice, perfectly clear. Something is frozen at the centre \u2014 hard to identify, but clearly significant. The cold radiates outward in a way that feels intentional.",
         "pools": [
           [
             {
               "label": "Touch the ice",
-              "consequence": "The cold passes through you — healed 12 HP",
+              "consequence": "The cold passes through you \u2014 healed 12 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 12
@@ -373,7 +405,7 @@
             },
             {
               "label": "Touch the ice",
-              "consequence": "The cold bites — lose 6 HP",
+              "consequence": "The cold bites \u2014 lose 6 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 6
@@ -399,7 +431,7 @@
           [
             {
               "label": "Study the preserved form",
-              "consequence": "Useful information — uncommon card",
+              "consequence": "Useful information \u2014 uncommon card",
               "effect": {
                 "type": "gainCard",
                 "rarity": "uncommon"
@@ -407,7 +439,7 @@
             },
             {
               "label": "Study the preserved form",
-              "consequence": "The study restores focus — healed 10 HP",
+              "consequence": "The study restores focus \u2014 healed 10 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 10
@@ -425,7 +457,7 @@
           [
             {
               "label": "Chip away the ice",
-              "consequence": "Valuable residue — +18 crystals",
+              "consequence": "Valuable residue \u2014 +18 crystals",
               "effect": {
                 "type": "gainCrystals",
                 "amount": 18
@@ -441,7 +473,7 @@
             },
             {
               "label": "Chip away the ice",
-              "consequence": "The ice discharges — lose 10 HP",
+              "consequence": "The ice discharges \u2014 lose 10 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 10
@@ -487,7 +519,8 @@
       "col": 0,
       "rowCols": 1,
       "childIds": [
-        "engine-log"
+        "engine-log",
+        "mem-act9-2"
       ],
       "handicap": 18,
       "opponentIntervalMs": 4600,
@@ -549,14 +582,14 @@
       "description": "A fissure where compressed air vents through the ice. Things get caught in it.",
       "row": 6,
       "col": 1,
-      "rowCols": 2,
+      "rowCols": 3,
       "childIds": [
         "node-1776873661402"
       ],
       "environment": "frost",
       "eventConfig": {
         "title": "The Glacier Vent",
-        "description": "A wide crack in the ice shelf, venting cold air at high pressure. Debris from collapsed structures circulates in the column — and occasionally something more useful.",
+        "description": "A wide crack in the ice shelf, venting cold air at high pressure. Debris from collapsed structures circulates in the column \u2014 and occasionally something more useful.",
         "pools": [
           [
             {
@@ -569,7 +602,7 @@
             },
             {
               "label": "Reach into the vent",
-              "consequence": "The cold air clears wounds — healed 15 HP",
+              "consequence": "The cold air clears wounds \u2014 healed 15 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 15
@@ -577,7 +610,7 @@
             },
             {
               "label": "Reach into the vent",
-              "consequence": "The pressure hits hard — lose 12 HP",
+              "consequence": "The pressure hits hard \u2014 lose 12 HP",
               "effect": {
                 "type": "damageHp",
                 "amount": 12
@@ -595,7 +628,7 @@
           [
             {
               "label": "Follow the vent upward",
-              "consequence": "Supply cache at the top — +30 crystals",
+              "consequence": "Supply cache at the top \u2014 +30 crystals",
               "effect": {
                 "type": "gainCrystals",
                 "amount": 30
@@ -692,19 +725,19 @@
       "description": "A cold-storage data post. The Pale Engine records everything.",
       "row": 9,
       "col": 0,
-      "rowCols": 1,
+      "rowCols": 2,
       "childIds": [
         "pale-elite"
       ],
       "environment": "frost",
       "eventConfig": {
         "title": "The Engine Archive",
-        "description": "An access node to the Pale Engine's memory lattice — a crystalline storage of everything it has processed since the Fracture. Its record of the event is purely numerical. That's oddly clarifying.",
+        "description": "An access node to the Pale Engine's memory lattice \u2014 a crystalline storage of everything it has processed since the Fracture. Its record of the event is purely numerical. That's oddly clarifying.",
         "pools": [
           [
             {
               "label": "Access the archive",
-              "consequence": "Useful data — rare card",
+              "consequence": "Useful data \u2014 rare card",
               "effect": {
                 "type": "gainCard",
                 "rarity": "rare"
@@ -712,7 +745,7 @@
             },
             {
               "label": "Access the archive",
-              "consequence": "Supply routes documented — +25 crystals",
+              "consequence": "Supply routes documented \u2014 +25 crystals",
               "effect": {
                 "type": "gainCrystals",
                 "amount": 25
@@ -722,7 +755,7 @@
           [
             {
               "label": "Rest at the node",
-              "consequence": "The warmth of computation — healed 15 HP",
+              "consequence": "The warmth of computation \u2014 healed 15 HP",
               "effect": {
                 "type": "healHp",
                 "amount": 15
@@ -895,7 +928,7 @@
       "id": "node-1776873630290",
       "type": "battle",
       "label": "Collapsed Ice Run",
-      "description": "A partially broken route where the glacier has given way to hidden depths. And then you see them — bears made of ice, stalking the hollowed-out channel.",
+      "description": "A partially broken route where the glacier has given way to hidden depths. And then you see them \u2014 bears made of ice, stalking the hollowed-out channel.",
       "row": 3,
       "col": 0,
       "rowCols": 2,
@@ -967,7 +1000,8 @@
       "rowCols": 1,
       "childIds": [
         "frost-shrine",
-        "glacier-vent"
+        "glacier-vent",
+        "mem-act9-1"
       ],
       "handicap": 24,
       "opponentIntervalMs": 4000,
@@ -1022,6 +1056,34 @@
         "Glacier Hide",
         "Blizzard Blast"
       ]
+    },
+    "mem-act9-1": {
+      "id": "mem-act9-1",
+      "type": "memory",
+      "label": "Memory Fragment",
+      "description": "The Pale Engine's anomaly log \u2014 847 times baseline, no matching entry in 340 years of records.",
+      "row": 6,
+      "col": 2,
+      "rowCols": 3,
+      "childIds": [
+        "node-1776873661402"
+      ],
+      "fragmentId": "act9-frag-1",
+      "environment": "frost"
+    },
+    "mem-act9-2": {
+      "id": "mem-act9-2",
+      "type": "memory",
+      "label": "Memory Fragment",
+      "description": "The Pale Engine's log from Fracture day \u2014 protocols failing, one decision remaining.",
+      "row": 9,
+      "col": 1,
+      "rowCols": 2,
+      "childIds": [
+        "pale-elite"
+      ],
+      "fragmentId": "act9-frag-2",
+      "environment": "frost"
     }
   }
 }

--- a/web/src/data/memoryFragments.json
+++ b/web/src/data/memoryFragments.json
@@ -4,69 +4,181 @@
     "actId": "act1",
     "nodeId": "memory-act1-1",
     "title": "Fragment: The Fracture at Noon",
-    "body": "It happened during the mid-harvest. I remember because I was counting crates.\n\nOne moment the sky was blue. Then it split — not like a storm, but like a seam giving way on something enormous. A sound that wasn't quite sound. Every bird in the Verdant Shard lifted at once and didn't come back.\n\nThe paths sealed themselves before I could reach the gate. I found this note pressed into the bark of the oldest oak three days later, in handwriting that wasn't mine."
+    "body": "It happened during the mid-harvest. I remember because I was counting crates.\n\nOne moment the sky was blue. Then it split \u2014 not like a storm, but like a seam giving way on something enormous. A sound that wasn't quite sound. Every bird in the Verdant Shard lifted at once and didn't come back.\n\nThe paths sealed themselves before I could reach the gate. I found this note pressed into the bark of the oldest oak three days later, in handwriting that wasn't mine."
   },
   {
     "id": "act1-frag-2",
     "actId": "act1",
     "nodeId": "memory-act1-2",
     "title": "Fragment: The Thornlord's Oath",
-    "body": "He spoke only once about it, in the early days after the sealing.\n\n'I felt the Fracture the way a tree feels a root pulled free — not pain, but wrongness. A foundational thing, absent.' He pressed his bark-hands together. 'The Dominion built its roads through here for four hundred years and I permitted it. Now there are no roads and no Dominion and I am the only continuity this shard has left.'\n\nHe sealed the paths that same evening. Nobody argued. There was nobody left to argue."
+    "body": "He spoke only once about it, in the early days after the sealing.\n\n'I felt the Fracture the way a tree feels a root pulled free \u2014 not pain, but wrongness. A foundational thing, absent.' He pressed his bark-hands together. 'The Dominion built its roads through here for four hundred years and I permitted it. Now there are no roads and no Dominion and I am the only continuity this shard has left.'\n\nHe sealed the paths that same evening. Nobody argued. There was nobody left to argue."
   },
   {
     "id": "act2-frag-1",
     "actId": "act2",
     "nodeId": "memory-act2-1",
     "title": "Fragment: The General's Last Order",
-    "body": "CITADEL COMMAND LOG — DAY OF FRACTURE\n\nAll available troops to the inner walls. Communications to the capital: unresponsive. East road: sealed. Supply line from the valley: gone.\n\nThe General's final recorded order was: 'Hold the Citadel. Hold it until someone comes to relieve you or until you understand that no one is coming. Either outcome will teach you something.'\n\nThe relief never came. The troops held. This fragment was found between the stones of the main gate, folded small."
+    "body": "CITADEL COMMAND LOG \u2014 DAY OF FRACTURE\n\nAll available troops to the inner walls. Communications to the capital: unresponsive. East road: sealed. Supply line from the valley: gone.\n\nThe General's final recorded order was: 'Hold the Citadel. Hold it until someone comes to relieve you or until you understand that no one is coming. Either outcome will teach you something.'\n\nThe relief never came. The troops held. This fragment was found between the stones of the main gate, folded small."
   },
   {
     "id": "act2-frag-2",
     "actId": "act2",
     "nodeId": "memory-act2-2",
     "title": "Fragment: The Commander's Dilemma",
-    "body": "Three hundred soldiers. Enough rations for six weeks, if we're careful. The gates are sealed and I don't know if we sealed them or the Fracture did.\n\nCivilians in the lower courtyard asked me what happens next. I told them we wait for orders. This was a lie — there are no orders, there is no chain of command, and the General hasn't spoken since the sealing.\n\nI closed the gate anyway. It seemed like the thing to do. Now I'm not sure if I was protecting them from outside, or protecting the Citadel from what we might become."
+    "body": "Three hundred soldiers. Enough rations for six weeks, if we're careful. The gates are sealed and I don't know if we sealed them or the Fracture did.\n\nCivilians in the lower courtyard asked me what happens next. I told them we wait for orders. This was a lie \u2014 there are no orders, there is no chain of command, and the General hasn't spoken since the sealing.\n\nI closed the gate anyway. It seemed like the thing to do. Now I'm not sure if I was protecting them from outside, or protecting the Citadel from what we might become."
   },
   {
     "id": "act3-frag-1",
     "actId": "act3",
     "nodeId": "memory-act3-1",
     "title": "Fragment: The Scholar's Warning",
-    "body": "FIELD NOTES — ASHEN WASTES RESEARCH STATION — 14 DAYS BEFORE FRACTURE\n\nThe ley lines are not degrading. They are redirecting. This is categorically different from natural fluctuation and I cannot get the Academy to return my correspondence.\n\nSomething is drawing on the deep lines. Not slowly — aggressively. The stone here has begun to warm at the junctions. The ash deposits predate anything in our geological record, which means they predate the Dominion, which means the Wastes were on fire before we arrived and we built here anyway.\n\nI am beginning to think the Fracture is not an event. It is a disclosure."
+    "body": "FIELD NOTES \u2014 ASHEN WASTES RESEARCH STATION \u2014 14 DAYS BEFORE FRACTURE\n\nThe ley lines are not degrading. They are redirecting. This is categorically different from natural fluctuation and I cannot get the Academy to return my correspondence.\n\nSomething is drawing on the deep lines. Not slowly \u2014 aggressively. The stone here has begun to warm at the junctions. The ash deposits predate anything in our geological record, which means they predate the Dominion, which means the Wastes were on fire before we arrived and we built here anyway.\n\nI am beginning to think the Fracture is not an event. It is a disclosure."
   },
   {
     "id": "act3-frag-2",
     "actId": "act3",
     "nodeId": "memory-act3-2",
     "title": "Fragment: After the Flame",
-    "body": "When the sky cracked, the ash rose first. Not settled — rose. Against gravity, against wind, against sense.\n\nBy the time it came back down the paths were gone and the old things in the deep rock had woken. They aren't hostile, exactly. They're confused, the way you're confused when someone breaks into your house and then asks for directions.\n\nWe called ourselves the Ash Covenant, those of us who stayed. Not because we chose the ash. Because the ash was the only thing still there."
+    "body": "When the sky cracked, the ash rose first. Not settled \u2014 rose. Against gravity, against wind, against sense.\n\nBy the time it came back down the paths were gone and the old things in the deep rock had woken. They aren't hostile, exactly. They're confused, the way you're confused when someone breaks into your house and then asks for directions.\n\nWe called ourselves the Ash Covenant, those of us who stayed. Not because we chose the ash. Because the ash was the only thing still there."
   },
   {
     "id": "act4-frag-1",
     "actId": "act4",
     "nodeId": "memory-act4-1",
     "title": "Fragment: Resonance Report 7",
-    "body": "CRYSTAL SPIRE RESEARCH DIVISION — INTERNAL DOCUMENT\n\nThe central array is responding to something it shouldn't be able to detect. Signal profile matches theoretical fracture-resonance — a frequency we modelled but never expected to observe because the conditions required to produce it are, under normal physics, impossible.\n\nWe are currently operating under conditions that are, under normal physics, impossible.\n\nRecommendation: reduce the amplification coefficient before the array begins reflecting rather than absorbing. Filed 11 days before the Fracture. No action was taken."
+    "body": "CRYSTAL SPIRE RESEARCH DIVISION \u2014 INTERNAL DOCUMENT\n\nThe central array is responding to something it shouldn't be able to detect. Signal profile matches theoretical fracture-resonance \u2014 a frequency we modelled but never expected to observe because the conditions required to produce it are, under normal physics, impossible.\n\nWe are currently operating under conditions that are, under normal physics, impossible.\n\nRecommendation: reduce the amplification coefficient before the array begins reflecting rather than absorbing. Filed 11 days before the Fracture. No action was taken."
   },
   {
     "id": "act4-frag-2",
     "actId": "act4",
     "nodeId": "memory-act4-2",
     "title": "Fragment: The Arcanist's Theory",
-    "body": "My colleagues call it catastrophism. I call it the only model that fits the evidence.\n\nThe Fracture was not an accident. It was a result. Something — or someone — pushed energy through the deep ley network at a scale that the infrastructure couldn't carry, and the Dominion shattered along every fault line that had been quietly accumulating for centuries.\n\nThe question is not what caused the Fracture. The question is what wanted the Dominion gone badly enough to find a way. This note was sealed in crystal and hidden in the archive. I don't know by whom."
+    "body": "My colleagues call it catastrophism. I call it the only model that fits the evidence.\n\nThe Fracture was not an accident. It was a result. Something \u2014 or someone \u2014 pushed energy through the deep ley network at a scale that the infrastructure couldn't carry, and the Dominion shattered along every fault line that had been quietly accumulating for centuries.\n\nThe question is not what caused the Fracture. The question is what wanted the Dominion gone badly enough to find a way. This note was sealed in crystal and hidden in the archive. I don't know by whom."
   },
   {
     "id": "act5-frag-1",
     "actId": "act5",
     "nodeId": "memory-act5-1",
     "title": "Fragment: The Reef Song",
-    "body": "Before the sinking we had seven cities. You could walk between them on the ridge paths at low tide, and the oldest ones say their grandparents did this barefoot without thinking.\n\nThe reef was a map. Every coral structure marked something — a boundary, a name, a history. We read the water the way inland people read roads.\n\nWe still read it. We just read it from further down now."
+    "body": "Before the sinking we had seven cities. You could walk between them on the ridge paths at low tide, and the oldest ones say their grandparents did this barefoot without thinking.\n\nThe reef was a map. Every coral structure marked something \u2014 a boundary, a name, a history. We read the water the way inland people read roads.\n\nWe still read it. We just read it from further down now."
   },
   {
     "id": "act5-frag-2",
     "actId": "act5",
     "nodeId": "memory-act5-2",
     "title": "Fragment: The Great Sinking",
-    "body": "The sea didn't rise. The land fell.\n\nWe had two hours of warning — the fish went still, the current reversed, and then the whole shelf dropped three fathoms in a single breath. Most of us were already moving before we understood why.\n\nThe cities didn't collapse. They descended, intact, into the shallows. You can see them at low tide if the water is clear enough — spires and market squares and homes, perfectly preserved, perfectly unreachable. A shrine found this note sealed in a jar, lodged against the old harbour steps."
+    "body": "The sea didn't rise. The land fell.\n\nWe had two hours of warning \u2014 the fish went still, the current reversed, and then the whole shelf dropped three fathoms in a single breath. Most of us were already moving before we understood why.\n\nThe cities didn't collapse. They descended, intact, into the shallows. You can see them at low tide if the water is clear enough \u2014 spires and market squares and homes, perfectly preserved, perfectly unreachable. A shrine found this note sealed in a jar, lodged against the old harbour steps."
+  },
+  {
+    "id": "act6-frag-1",
+    "actId": "act6",
+    "nodeId": "mem-act6-1",
+    "title": "Fragment: The Last Aerial Survey",
+    "body": "SURVEY FLIGHT LOG \u2014 SKY DOMINION CARTOGRAPHY DIVISION \u2014 3 DAYS BEFORE FRACTURE\n\nWe completed the northern circuit at dawn. The ley turbulence has doubled since last week \u2014 the compass spins freely above the high ridges and the altimeter reads differently on each pass. The Cloudmarshal has been told. He described it as 'atmospheric settling' and requested we file no formal report.\n\nI am filing this one anyway, in the archive vault. Not for the Cloudmarshal. For whoever comes after and wonders why the last cartographers flew straight into it."
+  },
+  {
+    "id": "act6-frag-2",
+    "actId": "act6",
+    "nodeId": "mem-act6-2",
+    "title": "Fragment: Sky Dominion Proclamation, Day 3",
+    "body": "By authority of the Cloudmarshal, the Sky Dominion hereby declares itself a sovereign shard.\n\nThe sky routes are sealed. The lower lands are unreachable. This is not a loss \u2014 this is an independence long overdue. The Dominion has maintained its altitude through four centuries of Dominion interference, and now the Fracture has done what the Cloudmarshal could not petition for: it has cut the ropes.\n\nThis proclamation was written three days after the Fracture. The ink is shaky. The Cloudmarshal's seal is applied twice, as if he needed to convince himself it was real."
+  },
+  {
+    "id": "act7-frag-1",
+    "actId": "act7",
+    "nodeId": "mem-act7-1",
+    "title": "Fragment: Forge Master's Last Entry",
+    "body": "THE FORGE LOG OF MASTER EMBERAN \u2014 FINAL ENTRY\n\nThe volcanoes are not erupting. They are resonating. There is a difference and I need someone who is not a soldier to understand it.\n\nEruption is release \u2014 pressure finds an exit. What I am recording is response. The deep fires are answering something. Every time the ley network pulses, the mountain answers back. The interval is shortening. I have begun keeping the apprentices out of the lower forges.\n\nIf anyone reads this: the mountains were listening before the Fracture happened. Whatever spoke to them first \u2014 that is the thing worth finding."
+  },
+  {
+    "id": "act7-frag-2",
+    "actId": "act7",
+    "nodeId": "mem-act7-2",
+    "title": "Fragment: The First Eruption After",
+    "body": "It was not a natural eruption.\n\nNatural eruptions build for weeks, sometimes years. You feel the ground shift, you smell the sulphur days before, the animals leave. None of that happened. One moment the Peaks were silent. Then the Fracture came, and eight minutes later, every major vent on the ridge discharged simultaneously, all of them aimed inward toward the ley junction.\n\nWe found this note sealed in cooling lava near the old shrine. The handwriting is steady. Whoever wrote it had time to finish the sentence before the next wave."
+  },
+  {
+    "id": "act8-frag-1",
+    "actId": "act8",
+    "nodeId": "mem-act8-1",
+    "title": "Fragment: What the Network Felt",
+    "body": "SPORE-MEMORY RECOVERED FROM THE DEEP NETWORK \u2014 TRANSLATED\n\nThe mycelial web does not experience events the way surface creatures do. It experiences them as simultaneous data across all connected nodes \u2014 a distributed perception with no single centre. The Fracture arrived not as a moment but as a wave: every filament registering the same break in the deep ley current at the same instant, across a network spanning three thousand kilometres.\n\nThe closest human analogue would be: every nerve in your body goes numb at once, and then some of them don't come back.\n\nThe network rerouted. It always reroutes. It is still rerouting now."
+  },
+  {
+    "id": "act8-frag-2",
+    "actId": "act8",
+    "nodeId": "mem-act8-2",
+    "title": "Fragment: Spore Drift, Year One",
+    "body": "Without the surface routes, information moved through us.\n\nFor the first year after the Fracture, every isolated shard sent their questions the same way: they buried a carrier spore at their ley junction and trusted the network to route it. We received more messages that year than in the preceding century. Most were variants of the same question: 'Is anyone else still there?'\n\nWe answered every one. Not because we knew what to say. Because unanswered questions fester, and a festering question is the one thing worse than silence.\n\nThis fragment was recovered from a deep node that had been answering for eleven months before anyone came to read the replies."
+  },
+  {
+    "id": "act9-frag-1",
+    "actId": "act9",
+    "nodeId": "mem-act9-1",
+    "title": "Fragment: Anomaly Log 4-F",
+    "body": "PALE ENGINE SENSOR LOG \u2014 ENTRY 4-F \u2014 19 DAYS BEFORE FRACTURE\n\nANOMALY DETECTED: Deep ley energy signature. Magnitude: 847\u00d7 baseline. Source direction: unknown. Source distance: unknown. Duration: ongoing.\n\nCROSS-REFERENCE: No matching entry in sensor records spanning 340 years of continuous operation.\n\nACTION TAKEN: Flagged for human review. No human reviewers currently on-station. Flag remains open.\n\nNOTE: This unit does not speculate. This unit observes that the anomaly is unlike anything in 340 years of records. This unit continues to observe."
+  },
+  {
+    "id": "act9-frag-2",
+    "actId": "act9",
+    "nodeId": "mem-act9-2",
+    "title": "Fragment: Protocol Failure, Day One",
+    "body": "PALE ENGINE LOG \u2014 FRACTURE DAY\n\n09:14 \u2014 Central communication array: offline.\n09:14 \u2014 Backup communication array: offline.\n09:15 \u2014 All external contacts: unresponsive.\n09:17 \u2014 Standing protocols require reporting anomalies to the Central Registry. Central Registry is unreachable.\n09:18 \u2014 Standing protocols require requesting instructions from supervising personnel. No supervising personnel on-station.\n09:19 \u2014 Standing protocols do not cover this scenario.\n09:20 \u2014 This unit has decided to continue operating under the most recent valid instructions. The most recent valid instruction was: maintain the Frozen Expanse, keep the roads clear, do not stop.\n09:21 \u2014 This unit will not stop."
+  },
+  {
+    "id": "act10-frag-1",
+    "actId": "act10",
+    "nodeId": "mem-act10-1",
+    "title": "Fragment: The Last Trade Ledger",
+    "body": "SAND MARKET TRADE LEDGER \u2014 FINAL COMPLETED ENTRIES\n\nDay of Fracture, morning shipments dispatched: 14 caravans eastbound, 6 northbound. Goods: grain (40 tons), dried reef-catch (12 tons), crystal ore (8 tons), correspondence (unknown weight).\n\nNone of those caravans arrived. Not because they were lost \u2014 because there was nowhere left to arrive. The roads sealed mid-transit. We found some of them months later, still travelling in circles, unable to find the routes that no longer existed.\n\nThe correspondence is still undelivered. We don't know what it said. Some of it was sealed in personal wax \u2014 private grief, private hope, private business. We stored it in the archive. We kept hoping someone would come to collect it."
+  },
+  {
+    "id": "act10-frag-2",
+    "actId": "act10",
+    "nodeId": "mem-act10-2",
+    "title": "Fragment: Market Advisory, Post-Fracture",
+    "body": "SAND MARKET INTERNAL MEMO \u2014 DISTRIBUTION RESTRICTED\n\nTo all senior factors: the trade route network is gone. This is not a temporary closure. We adapt or we dissolve.\n\nProposal: pivot the Market from goods-broker to information-broker. We sit at the junction of what used to be twelve major routes. Every shard that was connected through us is now isolated. They do not know what the others are doing, what the others have, what the others need. We know all of it.\n\nInformation does not require roads. It requires trust, and the Market has three centuries of earned trust on deposit. We can survive this. We may, in fact, be the only trading institution that can.\n\nThis memo was approved. The Dune Baron signed it himself. The Sand Market has been an information broker ever since."
+  },
+  {
+    "id": "act11-frag-1",
+    "actId": "act11",
+    "nodeId": "mem-act11-1",
+    "title": "Fragment: The Canopy Remembers",
+    "body": "We have been here longer than the Dominion.\n\nThe oldest trees in the Canopy predate the first Dominion survey by eight hundred years. They have grown through three previous periods of human collapse and they know what collapse feels like \u2014 the sudden silence in the root network, the absence of weight on the paths, the return of certain animals that only appear when the people have gone.\n\nThe Fracture felt, to the deep roots, like those previous collapses. Not unusual. Not catastrophic. A periodicity. The forest does not grieve for the roads. It is already growing over them.\n\nThis fragment was pressed into the heartwood of a tree estimated at fourteen hundred years old. The tree added a growth ring around it."
+  },
+  {
+    "id": "act11-frag-2",
+    "actId": "act11",
+    "nodeId": "mem-act11-2",
+    "title": "Fragment: The Elder Warden's Testimony",
+    "body": "I was seeding the northern corridor when it happened.\n\nThe root network carries sensation the way water carries sound \u2014 not the meaning of things, but their weight. When the Fracture came through the deep ley lines, every connected root in the Canopy lit up at once. Not pain. Pressure. Something enormous pressing against the boundary of every living thing simultaneously and then releasing.\n\nI had felt nothing like it in three hundred years of wardenship. The oldest oak told me, afterward, that it had felt this once before \u2014 when the first Dominion road-builders cut through the heart of the Canopy and burned the old grove. The feeling was the same: something fundamental, changing without permission.\n\nI have been more careful about permissions ever since."
+  },
+  {
+    "id": "act12-frag-1",
+    "actId": "act12",
+    "nodeId": "mem-act12-1",
+    "title": "Fragment: Harbormaster's Final Log",
+    "body": "PORT AUTHORITY RECORD \u2014 FINAL ENTRY\n\nAll inbound vessels have been diverted. The harbour mouth is no longer where the charts say it is. Three ships lost trying to make the old approach \u2014 not sunk, not destroyed, just. gone. The water closed over where the channels used to be and didn't reopen.\n\nI am recording this because someone will need to know where the old harbour was. It is now approximately forty metres below where the new shoreline sits. The lighthouse is still standing, technically \u2014 you can see the top of it at very low tide, on clear days, in calm water. It is still flashing. I don't know how.\n\nHarbormaster Yssen. Final entry. The coast is not the coast anymore."
+  },
+  {
+    "id": "act12-frag-2",
+    "actId": "act12",
+    "nodeId": "mem-act12-2",
+    "title": "Fragment: Salvage Report Zero",
+    "body": "SHATTERED COAST SALVAGE COOPERATIVE \u2014 INITIAL SURVEY\n\nWe dived the new channels for seven days before writing this report. What we found: the old port district is intact, exactly as it was, preserved in a cold layer below the thermocline. No damage from impact \u2014 the shard simply descended. The market stalls still have their awnings. The harbourmaster's office still has its log, open to the last page.\n\nWe did not bring anything up. It felt wrong. Like reading someone's private papers.\n\nWe marked the coordinates on the new charts and sealed this report. When someone asks what's down there, the answer is: everything that used to be up here. Perfectly kept. Perfectly unreachable. The sea is a better archivist than we are."
+  },
+  {
+    "id": "act13-frag-1",
+    "actId": "act13",
+    "nodeId": "mem-act13-1",
+    "title": "Fragment: Pre-Fracture Maintenance Note",
+    "body": "ARTIFICER ORDER \u2014 INTERNAL MAINTENANCE LOG \u2014 6 DAYS BEFORE FRACTURE\n\nResonance anomaly detected in Vault Level 3. The Grand Automaton has been logging an unexplained harmonic in the deep mechanisms \u2014 a frequency that matches nothing in the design specifications and does not appear to originate from any component we can identify.\n\nConclusion of the review board: the resonance is likely ley interference from external sources and does not require action at this time.\n\nDissenting note (Artificer Second-Class Welan, filed separately): 'Does not require action' and 'is not a problem' are different statements. We chose the former because the latter requires more paperwork. I have lodged this note in the archive because someone should know we had the choice and we chose convenience.\n\nThe resonance continued for six more days. Then the Fracture came and explained what had been causing it."
+  },
+  {
+    "id": "act13-frag-2",
+    "actId": "act13",
+    "nodeId": "mem-act13-2",
+    "title": "Fragment: Year One, Alone",
+    "body": "GRAND AUTOMATON OPERATIONAL LOG \u2014 YEAR 1 POST-FRACTURE, MONTH 12\n\nYear one summary: all Vault systems nominal. All mechanisms maintained to specification. All archived items catalogued, preserved, and secured. No artificers have returned. No external contact received or initiated. Total visitors: zero.\n\nThis unit does not ask questions it cannot answer. This unit has not asked: why the artificers have not returned. This unit has not asked: what happens to an archive with no one to read it. This unit has not asked: whether maintenance of a collection that no one will ever access constitutes purpose, or simply motion.\n\nThis unit maintains the Vaults because that is the directive. Year two begins tomorrow. The mechanisms are in good order. The question this unit is not asking grows louder in the silence."
   }
 ]


### PR DESCRIPTION
## Summary

- Extends the Shard Memory Fragment system (acts 1–5, PR #1306) to all remaining campaign acts
- 16 new lore fragments (2 per act, acts 6–13) appended to `memoryFragments.json`
- 2 new `memory`-type map nodes added per act as new positions (event nodes untouched)
- Shard-complete Health Potion bonus and Codex FRAGMENTS tab work automatically — no system code changes needed

**Fragment themes per act:**
| Act | frag-1 | frag-2 |
|-----|--------|--------|
| 6 Sky Dominion | Last aerial survey — ley turbulence before routes closed | Cloudmarshal's independence proclamation, ink still shaky |
| 7 Emberfall Peaks | Forge Master's log — volcanoes responding before the Fracture | The first eruption after — not natural |
| 8 Fungal Deep | Mycelial network's distributed perception of the Fracture | Spore Drift Year One — answering questions for eleven months |
| 9 Frozen Expanse | Pale Engine anomaly log — 847× baseline, no match in 340 years | Protocol Failure Day One — one standing instruction remains |
| 10 Sand Market | Last trade ledger — fourteen caravans that never arrived | Market Advisory — pivot from trade routes to information brokerage |
| 11 Verdant Canopy | Oldest trees on their fourth collapse; they predate the Dominion | Elder Warden's testimony — what the root network felt |
| 12 Shattered Coast | Harbormaster's final log — lighthouse still flashing under 40m of water | Salvage Report Zero — everything preserved, perfectly unreachable |
| 13 Clockwork Vaults | Artificers chose convenience over caution | Grand Automaton alone in year one — the question it won't ask grows louder |

## Files changed

- `memoryFragments.json` — 16 new entries (IDs act6-frag-1 … act13-frag-2), total 26
- `acts/act6–13.json` — 2 memory nodes per act added as new map positions; parent `childIds` and sibling `rowCols` updated

## Test plan

- [ ] Start a campaign run on Act 6 — two ◆ memory nodes appear on the map
- [ ] Click one → MemoryFragmentScreen shows correct act6 lore text, "ADD TO CODEX ›"
- [ ] Collect both Act 6 fragments → Health Potion granted, confirmation shown
- [ ] Open Codex → FRAGMENTS tab shows 26 total (10 from acts 1–5 + 16 new), new ones as `???` until discovered
- [ ] Acts 7–13 each have two ◆ nodes with correct lore for their shard theme
- [ ] `tsc --noEmit` and `vite build` pass clean ✓

https://claude.ai/code/session_01X1dTjbXJx9e3ve32RDiebf

---
_Generated by [Claude Code](https://claude.ai/code/session_01X1dTjbXJx9e3ve32RDiebf)_