### PR TITLE
Memory fragment node visibility — hide collected, 20% chance per run

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1520,6 +1520,7 @@ export default function App() {
             crystalBonus: 0,
             consumables: currentRun.consumables,
             activeModifierCount: 0,  // each new act starts fresh; modifiers are act-specific
+            runSeed: Math.random() * 0xffffffff | 0,
           }
           saveRun(nextRun)
           setRun(nextRun)

--- a/web/src/components/campaign/NodeMap.tsx
+++ b/web/src/components/campaign/NodeMap.tsx
@@ -748,13 +748,16 @@ export function NodeMap({ act, run, onSelectNode, onUseConsumable, onBack }: Pro
   const hiddenNodeIds      = useMemo(() => {
     const ids = new Set<string>()
     for (const node of Object.values(act.nodes)) {
-      if (
-        node.type === 'memory' &&
-        node.fragmentId &&
-        discoveredFragIds.has(node.fragmentId) &&
-        !run.completedNodeIds.includes(node.id)
-      ) {
+      if (node.type !== 'memory' || !node.fragmentId) continue
+      const alreadyFound = discoveredFragIds.has(node.fragmentId)
+      const visitedThisRun = run.completedNodeIds.includes(node.id)
+      if (alreadyFound && !visitedThisRun) {
+        // Collected in a previous run — always hide
         ids.add(node.id)
+      } else if (!alreadyFound && !visitedThisRun) {
+        // Not yet collected — 20% chance to appear this run
+        const roll = hashStr(node.id + String(run.runSeed)) % 100
+        if (roll >= 20) ids.add(node.id)
       }
     }
     return ids

--- a/web/src/components/campaign/NodeMap.tsx
+++ b/web/src/components/campaign/NodeMap.tsx
@@ -748,12 +748,17 @@ export function NodeMap({ act, run, onSelectNode, onUseConsumable, onBack }: Pro
   const hiddenNodeIds      = useMemo(() => {
     const ids = new Set<string>()
     for (const node of Object.values(act.nodes)) {
-      if (node.type === 'memory' && node.fragmentId && discoveredFragIds.has(node.fragmentId)) {
+      if (
+        node.type === 'memory' &&
+        node.fragmentId &&
+        discoveredFragIds.has(node.fragmentId) &&
+        !run.completedNodeIds.includes(node.id)
+      ) {
         ids.add(node.id)
       }
     }
     return ids
-  }, [act, discoveredFragIds])
+  }, [act, discoveredFragIds, run])
 
   const mapHeight = maxRowCols * ROW_HEIGHT
   const mapWidth  = AVATAR_PADDING + rows.length * COL_WIDTH + Math.max(0, rows.length - 1) * 44

--- a/web/src/components/campaign/NodeMap.tsx
+++ b/web/src/components/campaign/NodeMap.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useRef, useEffect, useState } from 'react'
 import { emitSound } from '../../game/sound'
+import { getDiscoveredFragmentIds } from '../../game/codex'
 import { Act, QuestNode, RunState, ReplayModifier, getAvailableNodeIds, loadNodeHistory, getModifiersByCount, ALL_CONSUMABLES, loadPlayerAvatar } from '../../game/questline'
 import { spriteSlug } from '../../game/sprites'
 import { StatRow } from '../ui/StatRow'
@@ -433,12 +434,13 @@ function MapTerrain({ environment, actId, width, height }: TerrainProps) {
 // Each path is coloured by the status of its parent→child pair.
 
 interface ConnProps {
-  prevRow:      QuestNode[]
-  nextRow:      QuestNode[]
-  maxRows:      number
-  statusOf:     (id: string) => NodeStatus
-  reachableIds: Set<string>
-  environment?: string
+  prevRow:       QuestNode[]
+  nextRow:       QuestNode[]
+  maxRows:       number
+  statusOf:      (id: string) => NodeStatus
+  reachableIds:  Set<string>
+  hiddenNodeIds: Set<string>
+  environment?:  string
 }
 
 type LineVariant = 'trail' | 'frontier' | 'future' | 'dead'
@@ -476,7 +478,7 @@ function envColors(env?: string): { trail: string; frontier: string } {
   }
 }
 
-function SVGConnector({ prevRow, nextRow, maxRows, statusOf, reachableIds, environment }: ConnProps) {
+function SVGConnector({ prevRow, nextRow, maxRows, statusOf, reachableIds, hiddenNodeIds, environment }: ConnProps) {
   const prevRowCols = prevRow[0]?.rowCols ?? prevRow.length
   const nextRowCols = nextRow[0]?.rowCols ?? nextRow.length
 
@@ -486,10 +488,12 @@ function SVGConnector({ prevRow, nextRow, maxRows, statusOf, reachableIds, envir
 
   const nextById = new Map(nextRow.map(n => [n.id, n]))
 
-  // Build connections from parent.childIds
+  // Build connections from parent.childIds, skipping collected memory nodes
   const connections: [string, string, number, number][] = []
   for (const parent of prevRow) {
+    if (hiddenNodeIds.has(parent.id)) continue
     for (const childId of parent.childIds) {
+      if (hiddenNodeIds.has(childId)) continue
       const child = nextById.get(childId)
       if (child) {
         connections.push([parent.id, child.id, visualRow(parent, prevRowCols), visualRow(child, nextRowCols)])
@@ -736,10 +740,20 @@ function NodePeekModal({ node, actId, nodeHistory, activeModifiers, onEnter, onC
 // ── Main component ──────────────────────────────────────────────────────────
 
 export function NodeMap({ act, run, onSelectNode, onUseConsumable, onBack }: Props) {
-  const availableIds  = getAvailableNodeIds(act, run)
-  const rows          = useMemo(() => buildRows(act), [act])
-  const maxRowCols    = useMemo(() => Math.max(...rows.map(r => r[0]?.rowCols ?? r.length)), [rows])
-  const reachableIds  = useMemo(() => computeReachableIds(act, run), [act, run])
+  const availableIds       = getAvailableNodeIds(act, run)
+  const rows               = useMemo(() => buildRows(act), [act])
+  const maxRowCols         = useMemo(() => Math.max(...rows.map(r => r[0]?.rowCols ?? r.length)), [rows])
+  const reachableIds       = useMemo(() => computeReachableIds(act, run), [act, run])
+  const discoveredFragIds  = useMemo(() => getDiscoveredFragmentIds(), [])
+  const hiddenNodeIds      = useMemo(() => {
+    const ids = new Set<string>()
+    for (const node of Object.values(act.nodes)) {
+      if (node.type === 'memory' && node.fragmentId && discoveredFragIds.has(node.fragmentId)) {
+        ids.add(node.id)
+      }
+    }
+    return ids
+  }, [act, discoveredFragIds])
 
   const mapHeight = maxRowCols * ROW_HEIGHT
   const mapWidth  = AVATAR_PADDING + rows.length * COL_WIDTH + Math.max(0, rows.length - 1) * 44
@@ -910,6 +924,10 @@ export function NodeMap({ act, run, onSelectNode, onUseConsumable, onBack }: Pro
                   }}
                 >
                   {rowNodes.map((node) => {
+                    if (hiddenNodeIds.has(node.id)) {
+                      return <div key={node.id} style={{ gridRow: node.col + 1 }} />
+                    }
+
                     const status    = getNodeStatus(node.id, availableIds, run)
                     const clickable = status === 'available'
                     const dim = status === 'completed'
@@ -981,6 +999,7 @@ export function NodeMap({ act, run, onSelectNode, onUseConsumable, onBack }: Pro
                     maxRows={maxRowCols}
                     statusOf={statusOf}
                     reachableIds={reachableIds}
+                    hiddenNodeIds={hiddenNodeIds}
                     environment={act.environment}
                   />
                 )}

--- a/web/src/game/questline.ts
+++ b/web/src/game/questline.ts
@@ -501,6 +501,7 @@ export interface RunState {
   crystalBonus: number         // extra crystals awarded after each battle (from replay modifiers)
   consumables: RunConsumable[] // consumable items held during this run
   activeModifierCount: number  // how many replay modifiers from the act's list are active this run
+  runSeed: number              // stable random seed for this run (used for per-run node visibility rolls)
 }
 
 const RUN_KEY = 'jarv_run'
@@ -529,6 +530,7 @@ export function loadRun(): RunState | null {
     parsed.consumables = drainStashIntoRun(parsed.consumables)
     if (stashBeforeDrain.length > 0) saveRun(parsed)
     if (typeof parsed.activeModifierCount !== 'number') parsed.activeModifierCount = 0
+    if (typeof parsed.runSeed !== 'number') parsed.runSeed = Math.random() * 0xffffffff | 0
     if (typeof parsed.maxLives !== 'number' || parsed.maxLives < 1) parsed.maxLives = 3
     if (typeof parsed.livesRemaining !== 'number') parsed.livesRemaining = parsed.maxLives
     parsed.livesRemaining = Math.max(0, Math.min(parsed.maxLives, parsed.livesRemaining))
@@ -623,6 +625,7 @@ export function newRun(actId: string, activeModifierCount = 0): RunState {
     crystalBonus: 0,
     consumables: drainStashIntoRun([]),
     activeModifierCount,
+    runSeed: Math.random() * 0xffffffff | 0,
   }
 }
 

--- a/web/src/game/types.sample.ts
+++ b/web/src/game/types.sample.ts
@@ -129,6 +129,7 @@ export const exampleRunState: RunState = {
   crystalBonus: 0,
   consumables: [],
   activeModifierCount: 0,
+  runSeed: 12345678,
 };
 
 export const exampleGameState: GameState = {


### PR DESCRIPTION
## Summary

- **Hide on subsequent runs:** Memory nodes for already-collected fragments are hidden from the act map on all future runs. If you collected it this run (it's in `completedNodeIds`), it stays visible until the run ends.
- **20% appearance chance:** Undiscovered memory nodes have a 20% chance to appear each run, rolled deterministically from a new `runSeed` field on `RunState`. The same nodes show/hide consistently for the entire run, re-rolled on each new run or act.

## Changes

- `questline.ts` — adds `runSeed: number` to `RunState`; generated in `newRun()`, re-generated when advancing acts, migrated in `loadRun()` for old saves
- `NodeMap.tsx` — `hiddenNodeIds` now uses `runSeed + nodeId` hash for the 20% roll; already-collected nodes (previous runs only) always hidden
- `App.tsx` — adds `runSeed` to the inline `nextRun` object when advancing acts
- `types.sample.ts` — adds `runSeed` to the sample fixture

## Test plan

- [ ] Start a fresh run on an act with memory nodes — some (≈20%) appear, others don't
- [ ] Abandon and restart the same act — different nodes may appear (different roll)
- [ ] Collect a fragment; complete the act; start the next run on the same act — that node is gone
- [ ] Nodes visited this run remain visible for the rest of that run
- [ ] `tsc --noEmit` passes clean

https://claude.ai/code/session_01X1dTjbXJx9e3ve32RDiebf

---
_Generated by [Claude Code](https://claude.ai/code/session_01X1dTjbXJx9e3ve32RDiebf)_