### PR TITLE
fix(city): restore warehouse global cap contribution, fix per-producer cap floor

### DIFF
--- a/web/src/game/cityBuilder.ts
+++ b/web/src/game/cityBuilder.ts
@@ -524,21 +524,23 @@ export function distributeIncomingResources(
 }
 
 export function calculateStorageCaps(state: CityState): ResourceStock {
-  const caps: ResourceStock = { wheat: 0, wood: 0, ore: 0, bread: 0, planks: 0, metal: 0 }
+  const caps = { ...STORAGE_BASE_CAPS }
   for (const cell of state.grid) {
     if (!cell || cell.spawnedUnitName) continue
     const cellCap = cellStockCap(cell)
     if (WAREHOUSE_PATTERN.test(cell.cardName)) {
-      for (const k of Object.keys(caps) as ResourceType[]) caps[k] += cellCap
+      // Warehouses boost all resource caps; scale with mastery but never below original flat bonus
+      const contrib = Math.max(STORAGE_PER_WAREHOUSE, cellCap)
+      for (const k of Object.keys(caps) as ResourceType[]) caps[k] += contrib
     } else {
+      // Production buildings contribute their per-cell cap to the resources they produce,
+      // preventing high-mastery producers from stalling when the global pool is too small
       const produces = getBuildingProduces(cell.cardName)
       for (const [res, rate] of Object.entries(produces)) {
-        if ((rate as number) > 0) caps[res as ResourceType] = (caps[res as ResourceType] ?? 0) + cellCap
+        if ((rate as number) > 0)
+          caps[res as ResourceType] = (caps[res as ResourceType] ?? 0) + cellCap
       }
     }
-  }
-  for (const k of Object.keys(STORAGE_BASE_CAPS) as ResourceType[]) {
-    caps[k] = Math.max(STORAGE_BASE_CAPS[k] as number, caps[k] ?? 0)
   }
   return caps
 }


### PR DESCRIPTION
## Problem

PR #1284's `calculateStorageCaps` change introduced two regressions:

1. **Warehouse nerf**: Level-0 warehouses now contribute `cellStockCap = 50` per resource to global caps instead of the original flat `STORAGE_PER_WAREHOUSE = 200`. Players with unupgraded warehouses got 4× less global storage.

2. **Farm-screen resources excluded**: Resources produced on the farm screen (`FarmState.plots`) are not in `CityState.grid`. The new formula only aggregated city-grid buildings, so wheat/bread produced by farm-screen buildings wasn't factored into global caps. A player with 1 level-4 city warehouse and farm-screen wheat farms saw a wheat cap of only 800 (not 1300).

## Fix

Hybrid formula in `calculateStorageCaps`:

- **Warehouses**: `Math.max(STORAGE_PER_WAREHOUSE, cellStockCap(cell))` contributed to all resource caps — never worse than before, but warehouse upgrades now pay off at higher mastery levels.
- **Production city buildings**: their `cellStockCap` is added to the global cap for the resources they produce — prevents high-mastery producers from filling per-cell bins and stalling carriers.

| Scenario | Pre-#1283 | #1284 (broken) | This fix |
|---|---|---|---|
| 4 level-0 warehouses, no city producers | wheat = 1300 | wheat = 500 ❌ | wheat = 1300 ✓ |
| 1 level-4 warehouse, farm-screen wheat | wheat = 700 | wheat = 800 | wheat = 1300 ✓ |
| 4 level-4 lumber camps + 4 level-0 warehouses | wood = 1100 ❌ | wood = 3200 ✓ | wood = 4300 ✓ |

## Test plan

- [ ] 4 unupgraded warehouses: all resource caps ≥ 500 + 4×200 (same as pre-PR-1283).
- [ ] 1 level-4 warehouse + farm-screen wheat farms: wheat cap = 1300, not 800.
- [ ] 4 level-4 lumber camps: wood cap ≥ 3200 (carriers can unload, no bottleneck).
- [ ] Build clean, 58 tests pass.

https://claude.ai/code/session_01E1zKpS7dddS5eQtuNani5E

---
_Generated by [Claude Code](https://claude.ai/code/session_01E1zKpS7dddS5eQtuNani5E)_