### PR TITLE
feat: recurring characters — Lyra, Kael, and Mira the Chronicler

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -43,6 +43,8 @@ import { MerchantScreen, MerchantItem, cardMerchantItem } from './components/cam
 import { MysteryScreen } from './components/campaign/MysteryScreen'
 import { MemoryFragmentScreen } from './components/campaign/MemoryFragmentScreen'
 import { MemoryFragment, isFragmentDiscovered, markFragmentDiscovered } from './game/codex'
+import { CharacterEncounterScreen } from './components/campaign/CharacterEncounterScreen'
+import { CharacterChoice, recordCharacterEncounter } from './game/characters'
 import memoryFragmentsData from './data/memoryFragments.json'
 import { ItemFoundScreen }    from './components/modals/ItemFoundScreen'
 import { CharacterScreen }    from './components/screens/CharacterScreen'
@@ -204,6 +206,7 @@ type Screen =
   | 'camp'
   | 'codex'
   | 'memory'
+  | 'characterEncounter'
 
 
 const STANCE_RULES_BY_NODE_TYPE: Partial<Record<string, StanceRules>> = {
@@ -369,6 +372,7 @@ export default function App() {
   const merchantBoughtRef = useRef(0)
   const [mysteryReward, setMysteryReward] = useState<RewardDef | null>(null)
   const [activeMemoryFragment, setActiveMemoryFragment] = useState<{ fragment: MemoryFragment; alreadyFound: boolean; shardBonus: boolean } | null>(null)
+  const [activeCharacterEncounter, setActiveCharacterEncounter] = useState<{ nodeId: string; characterId: string } | null>(null)
   const [campNode, setCampNode] = useState<QuestNode | null>(null)
   const [campResult, setCampResult] = useState<string | null>(null)
   // Replay briefing state — stored so onBegin can proceed with the correct context
@@ -959,6 +963,12 @@ export default function App() {
     saveRun(updatedRun)
     setRun(updatedRun)
 
+    if (node.characterEncounter) {
+      setActiveCharacterEncounter({ nodeId: node.id, characterId: node.characterEncounter })
+      setScreen('characterEncounter')
+      return
+    }
+
     if (node.type === 'rest') {
       setCampNode(node)
       setScreen('camp')
@@ -1241,6 +1251,51 @@ export default function App() {
     setScreen('nodemap')
   }, [run, mysteryReward])
 
+  const handleCharacterDone = useCallback((choice?: CharacterChoice) => {
+    const currentRun = run
+    if (!currentRun || !activeCharacterEncounter) { setScreen('nodemap'); return }
+    const act = ACTS[currentRun.actId]
+    if (!act) { setScreen('nodemap'); return }
+
+    recordCharacterEncounter(activeCharacterEncounter.characterId, choice?.label)
+
+    // Apply choice effect (crystals, HP, lives)
+    if (choice?.effect) {
+      const eff = choice.effect
+      if (eff.type === 'gainCrystals' && eff.amount) {
+        const next = loadCrystals() + eff.amount
+        saveCrystals(next)
+        setCrystals(next)
+      } else if (eff.type === 'healHp' && eff.amount) {
+        const healed = Math.min(currentRun.maxHp, currentRun.playerHp + eff.amount)
+        const updated = { ...currentRun, playerHp: healed }
+        saveRun(updated)
+        setRun(updated)
+      } else if (eff.type === 'gainLife' && eff.amount) {
+        const newMax   = Math.min(LIVES_MAX, currentRun.maxLives + eff.amount)
+        const newLives = Math.min(newMax, currentRun.livesRemaining + eff.amount)
+        const updated  = { ...currentRun, livesRemaining: newLives, maxLives: newMax }
+        saveRun(updated)
+        setRun(updated)
+      }
+    }
+
+    const node = act.nodes[activeCharacterEncounter.nodeId]
+    setActiveCharacterEncounter(null)
+
+    // Continue to normal node resolution
+    if (node?.type === 'rest') {
+      setCampNode(node)
+      setScreen('camp')
+    } else if (node?.type === 'event' && node.eventConfig) {
+      const eventData = generateEventFromConfig(node.id, node.eventConfig)
+      if (eventData) { setActiveEvent(eventData); setScreen('event') }
+      else setScreen('nodemap')
+    } else {
+      setScreen('nodemap')
+    }
+  }, [run, activeCharacterEncounter])
+
   const handleMemoryCollect = useCallback(() => {
     const currentRun = run
     if (!currentRun || !activeMemoryFragment) { setScreen('nodemap'); return }
@@ -1271,6 +1326,12 @@ export default function App() {
       return
     }
     setActiveMemoryFragment(null)
+    // Mira appears after every first-time fragment discovery
+    if (!alreadyFound) {
+      setActiveCharacterEncounter({ nodeId: activeMemoryFragment.fragment.nodeId, characterId: 'mira' })
+      setScreen('characterEncounter')
+      return
+    }
     setScreen('nodemap')
   }, [run, activeMemoryFragment])
 
@@ -2450,6 +2511,13 @@ export default function App() {
           onCollect={activeMemoryFragment.shardBonus
             ? () => { setActiveMemoryFragment(null); setScreen('nodemap') }
             : handleMemoryCollect}
+        />
+      )}
+
+      {screen === 'characterEncounter' && activeCharacterEncounter && (
+        <CharacterEncounterScreen
+          characterId={activeCharacterEncounter.characterId}
+          onDone={handleCharacterDone}
         />
       )}
 

--- a/web/src/components/campaign/CharacterEncounterScreen.tsx
+++ b/web/src/components/campaign/CharacterEncounterScreen.tsx
@@ -1,0 +1,66 @@
+import React, { useState } from 'react'
+import { getCharacterDef, getCharacterStage, CharacterChoice } from '../../game/characters'
+
+interface Props {
+  characterId: string
+  onDone: (choice?: CharacterChoice) => void
+}
+
+export function CharacterEncounterScreen({ characterId, onDone }: Props) {
+  const def   = getCharacterDef(characterId)
+  const stage = getCharacterStage(characterId)
+  const [response, setResponse] = useState<string | null>(null)
+  const [chosen,   setChosen]   = useState<CharacterChoice | null>(null)
+
+  if (!def) return null
+
+  function handleChoice(choice: CharacterChoice) {
+    setResponse(choice.response)
+    setChosen(choice)
+  }
+
+  return (
+    <div className="char-screen u-col u-items-c u-gap-6 u-grow">
+      <div className="char-header u-col u-items-c u-gap-2">
+        <span className="char-icon">{def.icon}</span>
+        <div className="char-name">{def.name}</div>
+        <div className="char-title">{def.title}</div>
+      </div>
+
+      <div className="char-body">
+        {stage.greeting.split('\n\n').map((para, i) => (
+          <p key={i} className="char-para">{para}</p>
+        ))}
+      </div>
+
+      {!response && stage.choices && stage.choices.length > 0 && (
+        <div className="char-choices u-col u-gap-3">
+          {stage.choices.map((c, i) => (
+            <button
+              key={i}
+              className="action-btn char-choice-btn"
+              onClick={() => handleChoice(c)}
+            >
+              {c.label}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {response && (
+        <div className="char-response u-col u-items-c u-gap-4">
+          <p className="char-para char-para--response">{response}</p>
+          <button className="action-btn" onClick={() => onDone(chosen ?? undefined)}>
+            Continue
+          </button>
+        </div>
+      )}
+
+      {!response && (!stage.choices || stage.choices.length === 0) && (
+        <button className="action-btn" onClick={() => onDone()}>
+          Continue
+        </button>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/campaign/MerchantScreen.tsx
+++ b/web/src/components/campaign/MerchantScreen.tsx
@@ -1,10 +1,11 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { emitSound } from '../../game/sound'
 import { Card } from '../../game/types'
 import { UselessItem } from '../../game/dailyLogin'
 import { MERCHANT_PRICES, ConsumableDef } from '../../game/questline'
 import { CardTile } from '../cards/CardTile'
 import { OverlayScreen } from '../ui/OverlayScreen'
+import { getCharacterDef, getCharacterStage, recordCharacterEncounter } from '../../game/characters'
 
 export type MerchantItem =
   | { kind: 'card'; card: Card; price: number }
@@ -33,6 +34,11 @@ export function MerchantScreen({ items, crystals, onBuy, onDone }: Props) {
   const [balance, setBalance]     = useState(crystals)
   const [purchased, setPurchased] = useState<Set<string>>(new Set())
 
+  const lyra      = getCharacterDef('lyra')!
+  const lyraStage = getCharacterStage('lyra')
+
+  useEffect(() => { recordCharacterEncounter('lyra') }, [])
+
   function handleBuy(item: MerchantItem) {
     const key = itemKey(item)
     // Consumables can be bought multiple times
@@ -51,8 +57,13 @@ export function MerchantScreen({ items, crystals, onBuy, onDone }: Props) {
     <OverlayScreen title="MERCHANT" onBack={onDone} right={<span className="crystal-count">💎 {balance.toLocaleString()}</span>}>
       <div className="shop-wrapper">
 
-        <div className="merchant-tagline">
-          "Everything has a price. Today, at least these have <em>reasonable</em> ones."
+        <div className="merchant-character-banner">
+          <span className="char-icon">{lyra.icon}</span>
+          <div className="char-banner-text">
+            <span className="char-name">{lyra.name}</span>
+            <span className="char-title">{lyra.title}</span>
+            <span className="char-banner-greeting">{lyraStage.greeting}</span>
+          </div>
         </div>
 
         {balance === 0 && (

--- a/web/src/data/acts/act1.json
+++ b/web/src/data/acts/act1.json
@@ -598,7 +598,8 @@
             }
           ]
         ]
-      }
+      },
+      "characterEncounter": "mira"
     },
     "ambush": {
       "id": "ambush",
@@ -1170,7 +1171,8 @@
         "deep-woods"
       ],
       "restHeal": 15,
-      "environment": "farmland"
+      "environment": "farmland",
+      "characterEncounter": "kael"
     },
     "mem-act1-1": {
       "id": "mem-act1-1",

--- a/web/src/data/acts/act10.json
+++ b/web/src/data/acts/act10.json
@@ -482,7 +482,8 @@
             }
           ]
         ]
-      }
+      },
+      "characterEncounter": "mira"
     },
     "the-outer-ring": {
       "id": "the-outer-ring",
@@ -510,7 +511,8 @@
         "desert-spire"
       ],
       "environment": "sand",
-      "restHeal": 10
+      "restHeal": 10,
+      "characterEncounter": "kael"
     },
     "outer-bazaar": {
       "id": "outer-bazaar",

--- a/web/src/data/acts/act11.json
+++ b/web/src/data/acts/act11.json
@@ -443,7 +443,8 @@
             }
           ]
         ]
-      }
+      },
+      "characterEncounter": "mira"
     },
     "canopy-hollow": {
       "id": "canopy-hollow",
@@ -457,7 +458,8 @@
       "childIds": [
         "warden-vigil",
         "vine-market"
-      ]
+      ],
+      "characterEncounter": "kael"
     },
     "vine-market": {
       "id": "vine-market",

--- a/web/src/data/acts/act12.json
+++ b/web/src/data/acts/act12.json
@@ -435,7 +435,8 @@
             }
           ]
         ]
-      }
+      },
+      "characterEncounter": "mira"
     },
     "wreck-camp": {
       "id": "wreck-camp",
@@ -449,7 +450,8 @@
         "gale-watch",
         "salvage-market"
       ],
-      "healAmount": 8
+      "healAmount": 8,
+      "characterEncounter": "kael"
     },
     "salvage-market": {
       "id": "salvage-market",

--- a/web/src/data/acts/act13.json
+++ b/web/src/data/acts/act13.json
@@ -435,7 +435,8 @@
             }
           ]
         ]
-      }
+      },
+      "characterEncounter": "mira"
     },
     "assembly-rest": {
       "id": "assembly-rest",
@@ -449,7 +450,8 @@
         "automaton-watch",
         "cog-market"
       ],
-      "healAmount": 8
+      "healAmount": 8,
+      "characterEncounter": "kael"
     },
     "cog-market": {
       "id": "cog-market",

--- a/web/src/data/acts/act2.json
+++ b/web/src/data/acts/act2.json
@@ -394,7 +394,8 @@
         "siege-captain"
       ],
       "environment": "camp",
-      "restHeal": 10
+      "restHeal": 10,
+      "characterEncounter": "kael"
     },
     "supply-cache": {
       "id": "supply-cache",
@@ -463,7 +464,8 @@
             }
           ]
         ]
-      }
+      },
+      "characterEncounter": "mira"
     },
     "outer-wall": {
       "id": "outer-wall",

--- a/web/src/data/acts/act3.json
+++ b/web/src/data/acts/act3.json
@@ -526,7 +526,8 @@
             }
           ]
         ]
-      }
+      },
+      "characterEncounter": "mira"
     },
     "bone-fire": {
       "id": "bone-fire",
@@ -540,7 +541,8 @@
         "revenant-witch"
       ],
       "environment": "ashen",
-      "restHeal": 10
+      "restHeal": 10,
+      "characterEncounter": "kael"
     },
     "plague-front": {
       "id": "plague-front",

--- a/web/src/data/acts/act4.json
+++ b/web/src/data/acts/act4.json
@@ -579,7 +579,8 @@
             }
           ]
         ]
-      }
+      },
+      "characterEncounter": "mira"
     },
     "echo-halls": {
       "id": "echo-halls",
@@ -761,7 +762,8 @@
         "spire-gate"
       ],
       "restHeal": 12,
-      "environment": "citadel"
+      "environment": "citadel",
+      "characterEncounter": "kael"
     },
     "void-bridge": {
       "id": "void-bridge",

--- a/web/src/data/acts/act5.json
+++ b/web/src/data/acts/act5.json
@@ -518,7 +518,8 @@
             }
           ]
         ]
-      }
+      },
+      "characterEncounter": "mira"
     },
     "wreck-camp": {
       "id": "wreck-camp",
@@ -533,7 +534,8 @@
         "mem-act5-1"
       ],
       "environment": "reef",
-      "restHeal": 10
+      "restHeal": 10,
+      "characterEncounter": "kael"
     },
     "reef-bazaar": {
       "id": "reef-bazaar",

--- a/web/src/data/acts/act6.json
+++ b/web/src/data/acts/act6.json
@@ -481,7 +481,8 @@
             }
           ]
         ]
-      }
+      },
+      "characterEncounter": "mira"
     },
     "skyport-camp": {
       "id": "skyport-camp",
@@ -495,7 +496,8 @@
         "storm-battery"
       ],
       "environment": "sky",
-      "restHeal": 10
+      "restHeal": 10,
+      "characterEncounter": "kael"
     },
     "sky-bazaar": {
       "id": "sky-bazaar",

--- a/web/src/data/acts/act7.json
+++ b/web/src/data/acts/act7.json
@@ -483,7 +483,8 @@
             }
           ]
         ]
-      }
+      },
+      "characterEncounter": "mira"
     },
     "lava-camp": {
       "id": "lava-camp",
@@ -497,7 +498,8 @@
         "summit-elite"
       ],
       "environment": "volcano",
-      "restHeal": 10
+      "restHeal": 10,
+      "characterEncounter": "kael"
     },
     "ember-bazaar": {
       "id": "ember-bazaar",

--- a/web/src/data/acts/act8.json
+++ b/web/src/data/acts/act8.json
@@ -484,7 +484,8 @@
             }
           ]
         ]
-      }
+      },
+      "characterEncounter": "mira"
     },
     "root-hollow": {
       "id": "root-hollow",
@@ -499,7 +500,8 @@
         "node-1776871965007"
       ],
       "environment": "fungal",
-      "restHeal": 10
+      "restHeal": 10,
+      "characterEncounter": "kael"
     },
     "deep-trader": {
       "id": "deep-trader",

--- a/web/src/data/acts/act9.json
+++ b/web/src/data/acts/act9.json
@@ -481,7 +481,8 @@
             }
           ]
         ]
-      }
+      },
+      "characterEncounter": "mira"
     },
     "ice-hollow": {
       "id": "ice-hollow",
@@ -495,7 +496,8 @@
         "node-1776873646236"
       ],
       "environment": "frost",
-      "restHeal": 10
+      "restHeal": 10,
+      "characterEncounter": "kael"
     },
     "cold-trader": {
       "id": "cold-trader",

--- a/web/src/data/characters.json
+++ b/web/src/data/characters.json
@@ -1,0 +1,131 @@
+{
+  "lyra": {
+    "name": "Lyra",
+    "title": "Travelling Merchant",
+    "icon": "⚖",
+    "encounters": [
+      {
+        "greeting": "First time through here? You've got the look of someone who didn't expect to make it this far. I sell cards, consumables, whatever I can carry. Name's Lyra. Don't let the prices put you off — everything here kept me alive long enough to reach you."
+      },
+      {
+        "greeting": "You again. I wasn't sure you'd make it past that last stretch. Most don't. What are you building — I can tell by what people keep buying."
+      },
+      {
+        "greeting": "I heard something interesting from the last traveller through here. They said the ley lines near the core have been... singing. Not a sound exactly. More like a pressure behind the eyes. They didn't last the week. Anyway — what do you need?"
+      },
+      {
+        "greeting": "I'll tell you something I don't usually say. I left my shard three days before the Fracture. I didn't know anything was coming — I just had a contract dispute with a very insistent buyer. Sometimes the most mundane reasons save your life. I've been on the road ever since. It suits me better than home did. Here — I've set aside something I thought you might want."
+      },
+      {
+        "greeting": "At this point I'm starting to route my circuits around where you might be. That's either good business or a problem. Possibly both. Take a look — I've got a few things I pulled specifically because I thought 'yes, that's exactly the kind of stupid plan they'd have.'"
+      }
+    ]
+  },
+  "kael": {
+    "name": "Kael",
+    "title": "Wandering Soldier",
+    "icon": "⚔",
+    "encounters": [
+      {
+        "greeting": "He looks up from the fire when you approach. His armour is campaign-worn, one pauldron cracked down the middle. He doesn't reach for his weapon.\n\n\"Didn't hear you coming. That's — that's good, actually, I've been sitting here for a while.\" He looks back at the fire. \"My unit got separated in the Fracture. I stayed at the last marked waypoint for four days. Nobody came. I don't know if that means something or nothing.\"",
+        "choices": [
+          {
+            "label": "Share what you know about the roads ahead",
+            "response": "He listens carefully, asks two sharp questions, then nods. \"That helps. I can work with that.\" He rummages in his pack and hands you a small purse. \"Supplies I was saving. You need them more than I do right now.\"",
+            "effect": { "type": "gainCrystals", "amount": 15 }
+          },
+          {
+            "label": "Leave him to it",
+            "response": "You nod and move on. He goes back to watching the fire.",
+            "effect": { "type": "nothing" }
+          }
+        ]
+      },
+      {
+        "greeting": "He's on his feet when you find him this time, studying a rough map scratched into bark.\n\n\"I found a trail. Boot print, military issue, heading northeast — I know that tread, that's Sergeant Veska's kit.\" He looks at you. \"I'm going to follow it. Thought I should mention that to someone before I go.\" A pause. \"You haven't seen anyone else out here, have you? Unit markings, a blue chevron on the shoulder?\"",
+        "choices": [
+          {
+            "label": "Help him dress his wounds before he sets out",
+            "response": "He protests once, then lets you. \"Didn't realise how bad it had gotten,\" he admits. The rest does both of you good.",
+            "effect": { "type": "healHp", "amount": 8 }
+          },
+          {
+            "label": "Wish him luck",
+            "response": "\"Right. Thanks.\" He folds the map carefully and tucks it into his coat. \"If you find Veska before I do — just tell her Kael is looking.\"",
+            "effect": { "type": "nothing" }
+          }
+        ]
+      },
+      {
+        "greeting": "He's sitting against a collapsed wall, a small book open in his hands. He looks up when he hears you.\n\n\"The trail ended at a bridge that isn't there anymore. But I found this — Veska's field journal. She made it further than I thought.\" He holds it out. \"The last entry describes a way through the passes. I could use it to keep looking.\" He closes the book slowly. \"Or I could leave it where I found it. For whoever comes after.\"",
+        "choices": [
+          {
+            "label": "Keep looking — the information is yours",
+            "response": "He nods, grips the journal tighter. \"Yeah. Yeah, you're right. I'll find her.\" Something settles in him. He hands you a few coins he'd been holding, a nervous habit. \"For the road.\"",
+            "effect": { "type": "gainCrystals", "amount": 20 }
+          },
+          {
+            "label": "Leave it — let others find their way too",
+            "response": "He thinks about it for a long time. Then he sets the journal on the wall, visible from the path. \"Good call,\" he says quietly. \"She'd have said the same thing.\"",
+            "effect": { "type": "nothing" }
+          }
+        ]
+      },
+      {
+        "greeting": "He's built a small shelter this time. Two walls and a roof, badly constructed but enthusiastic.\n\n\"I'm not going to find her,\" he says, before you can speak. \"I know that now. The passes she described — they're sealed. Whatever Veska did to get through, I can't follow.\" He sits down heavily. \"But I found two other survivors from the eastern units. We're going to try to reach the Verdant Canopy — there's a settlement there.\" He looks at you steadily. \"I wouldn't have got this far without — well. You know.\"",
+        "choices": [
+          {
+            "label": "Tell him Veska would be proud",
+            "response": "He's quiet for a moment. Then he exhales slowly, like something he'd been holding for a very long time finally releasing. \"Maybe she would be. Yeah.\" He presses his hand briefly to your shoulder. \"Travel well.\"",
+            "effect": { "type": "gainLife", "amount": 1 }
+          },
+          {
+            "label": "Nod and let him have the moment",
+            "response": "Some things don't need words. He seems to understand that.",
+            "effect": { "type": "nothing" }
+          }
+        ]
+      },
+      {
+        "greeting": "He catches you on your way through, looking better than the last time — cleaner kit, steadier eyes.\n\n\"We made it to the Canopy. The settlement is small but it's real.\" He grins briefly. \"I'm heading back to help with the northern route. Apparently I'm good at finding paths that aren't there.\" He presses something into your hand — a worn compass, cracked face, needle still true. \"You need this more than I do. I know where I'm going now.\"",
+        "choices": [
+          {
+            "label": "Accept the compass",
+            "response": "The compass is old but the needle holds steady wherever you point it.",
+            "effect": { "type": "gainCrystals", "amount": 25 }
+          },
+          {
+            "label": "Tell him to keep it",
+            "response": "He looks like he's going to argue, then pockets it. \"Fair enough. I'll find you again and give it to you then.\"",
+            "effect": { "type": "nothing" }
+          }
+        ]
+      },
+      {
+        "greeting": "He's passing through, not resting — just long enough to raise a hand in greeting.\n\n\"Still going? Good. So am I.\" He looks like he means it."
+      }
+    ]
+  },
+  "mira": {
+    "name": "Mira",
+    "title": "The Chronicler",
+    "icon": "✦",
+    "encounters": [
+      {
+        "greeting": "A woman in a grey coat steps out of the shadows near the path. She's carrying too many notebooks.\n\n\"You found one.\" She nods at the fragment. \"I'm Mira — I was an archivist for the Dominion before the Fracture scattered everything. I've been collecting evidence ever since. Testimonies, sensor logs, what the trees remember.\" She studies you. \"You're going further in, aren't you? Towards the Core?\" A pause. \"Would you share what you find? I'm trying to understand what happened to all of us.\""
+      },
+      {
+        "greeting": "She has a new notebook since last time, already half-full.\n\n\"I've been mapping the timing,\" she says without preamble. \"The Fracture wasn't simultaneous. The reef shards went first — three minutes before the central collapse. Then the sky routes. Then everything else.\" She turns a page. \"That's not how a natural event works. That's a sequence. Someone — or something — initiated it in a specific order.\" She looks up. \"Whatever you're finding out there, keep finding it.\""
+      },
+      {
+        "greeting": "She looks tired in a way that isn't about sleep.\n\n\"I have a theory and I don't like it.\" She sits down on a nearby rock without asking. \"The deep ley network has a regulating architecture — built long before the Dominion, possibly before recorded history. The Fracture matches the signature of a forced draw on that architecture. Something pulled more energy through it than it was designed to carry.\" She looks at you directly. \"Not an accident. Not a natural event. A miscalculation. Somebody tried to do something with the ley network and it broke.\" She closes the notebook. \"I just need to confirm the source.\""
+      },
+      {
+        "greeting": "She finds you before you find her.\n\n\"I know what it was.\" She's shaking slightly, which she seems annoyed by. \"There was a structure — the Dominion called it the Resonance Engine. Pre-Dominion construction, repurposed. It was designed to stabilise the ley network during high-output periods.\" She steadies herself. \"Someone activated it at full capacity. They were trying to prevent something. The Engine miscalculated and caused the exact catastrophe it was built to prevent.\" A long pause. \"The Engine is still active. Somewhere near the Fractured Core. And it doesn't know it failed.\""
+      },
+      {
+        "greeting": "She looks calmer now. Resolved.\n\n\"I've published the findings. Sent copies to every settlement I can reach.\" She adjusts her notebooks. \"Most people won't believe it. Some will. That's enough.\" She meets your eyes. \"Be careful near the Core. The Engine responds to ley disturbances — and you're heading straight into the largest one remaining. It may notice you.\" A pause. \"I'll be here when you come back. Assuming you do.\""
+      }
+    ]
+  }
+}

--- a/web/src/game/characters.ts
+++ b/web/src/game/characters.ts
@@ -1,0 +1,66 @@
+import charactersData from '../data/characters.json'
+
+const CHARACTERS_KEY = 'jarv_characters'
+
+interface CharacterState {
+  count: number
+  lastChoice: string | null
+}
+
+type CharacterStore = Record<string, CharacterState>
+
+function loadStore(): CharacterStore {
+  try {
+    const raw = localStorage.getItem(CHARACTERS_KEY)
+    return raw ? JSON.parse(raw) : {}
+  } catch {
+    return {}
+  }
+}
+
+function saveStore(store: CharacterStore): void {
+  try { localStorage.setItem(CHARACTERS_KEY, JSON.stringify(store)) } catch { /* ignore */ }
+}
+
+export function getCharacterState(id: string): CharacterState {
+  return loadStore()[id] ?? { count: 0, lastChoice: null }
+}
+
+export function recordCharacterEncounter(id: string, choiceKey?: string): void {
+  const store = loadStore()
+  const current = store[id] ?? { count: 0, lastChoice: null }
+  store[id] = { count: current.count + 1, lastChoice: choiceKey ?? current.lastChoice }
+  saveStore(store)
+}
+
+export interface CharacterChoice {
+  label:    string
+  response: string
+  effect:   { type: string; amount?: number; rarity?: string; itemId?: string }
+}
+
+export interface CharacterStage {
+  greeting: string
+  choices?: CharacterChoice[]
+}
+
+type CharacterDef = {
+  name: string
+  title: string
+  icon: string
+  encounters: CharacterStage[]
+}
+
+const catalog = charactersData as Record<string, CharacterDef>
+
+export function getCharacterDef(id: string): CharacterDef | null {
+  return catalog[id] ?? null
+}
+
+export function getCharacterStage(id: string): CharacterStage {
+  const def = catalog[id]
+  if (!def) return { greeting: '' }
+  const { count } = getCharacterState(id)
+  const idx = Math.min(count, def.encounters.length - 1)
+  return def.encounters[idx]
+}

--- a/web/src/game/questline.ts
+++ b/web/src/game/questline.ts
@@ -146,6 +146,7 @@ export interface QuestNode {
   bossHpMultiplier?: number  // multiplier applied to boss card unit's HP (default 10)
   eventConfig?: NodeEventConfig
   fragmentId?: string
+  characterEncounter?: string
   bossDialogue?: string[]  // lines the boss speaks before the fight
   bossIntro?: CutscenePanel[]  // cutscene panels shown before boss dialogue
   /** Preset enemy deck — card names in order. Makes each node deterministic and learnable. */

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -5424,6 +5424,79 @@ body {
 }
 .mystery-collect-btn { margin-top: 8px; }
 
+/* ─── Character Encounter Screen ────────────────────── */
+.char-screen {
+  padding: 32px 16px;
+  max-width: 560px;
+  margin: 0 auto;
+  text-align: center;
+}
+.char-header { margin-bottom: 8px; }
+.char-icon {
+  font-size: 2.4rem;
+  display: block;
+  margin-bottom: 4px;
+}
+.char-name {
+  font-size: 1.2rem;
+  font-weight: bold;
+  letter-spacing: 0.12em;
+  color: #aaddff;
+}
+.char-title {
+  font-size: 0.75rem;
+  color: var(--muted);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  margin-top: 2px;
+}
+.char-body {
+  text-align: left;
+  max-width: 480px;
+  width: 100%;
+}
+.char-para {
+  font-size: 0.9rem;
+  line-height: 1.65;
+  color: var(--fg);
+  margin: 0 0 12px;
+}
+.char-para--response {
+  color: #aaddff;
+  font-style: italic;
+}
+.char-choices { width: 100%; max-width: 420px; }
+.char-choice-btn {
+  width: 100%;
+  text-align: left;
+  font-size: 0.85rem;
+}
+
+/* ─── Merchant character banner ──────────────────────── */
+.merchant-character-banner {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 12px 16px;
+  background: rgba(100,160,255,0.07);
+  border: 1px solid rgba(100,160,255,0.18);
+  border-radius: 6px;
+  margin-bottom: 16px;
+}
+.char-banner-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1;
+}
+.char-banner-greeting {
+  font-size: 0.82rem;
+  color: var(--fg);
+  line-height: 1.5;
+  margin-top: 4px;
+  font-style: italic;
+}
+
 /* ─── Memory Fragment Screen ─────────────────────────── */
 .memory-screen {
   padding: 32px 16px;


### PR DESCRIPTION
## Summary

Adds three named characters who persist across all campaign acts with evolving, staged dialogue — bringing Destiny-style world continuity to Shattered Dominion.

- **Lyra** (Travelling Merchant) — appears at every merchant node via a banner inside `MerchantScreen`. Her dialogue advances each time you visit a shop, building from a wary stranger to a trusted trade partner with lore about pre-Fracture trade routes.
- **Kael** (Wandering Soldier) — appears at one rest node per act (acts 1–13) before the heal fires. Has a full 5-stage personal arc (lost unit → difficult truth → resolution), then collapses to a warm post-arc greeting. Choices grant crystals, HP, or bonus lives.
- **Mira the Chronicler** — appears automatically after every *first-time* memory fragment collection, and at one event node per act (acts 1–13) as a fallback. Her arc mirrors the player's Codex progress: she assembles the Fracture backstory from the same fragments you find.

## New files

- `web/src/data/characters.json` — full authored dialogue for all 3 characters, 5+ stages each
- `web/src/game/characters.ts` — localStorage persistence (`jarv_characters`), encounter counting, stage selection
- `web/src/components/campaign/CharacterEncounterScreen.tsx` — shared encounter UI (icon, name, title, dialogue, choices, response)

## Modified files

- `questline.ts` — added `characterEncounter?: string` to `QuestNode`
- `App.tsx` — `'characterEncounter'` screen state, `handleCharacterDone` (applies choice effects, routes to rest/event/nodemap), Mira trigger in `handleMemoryCollect`
- `MerchantScreen.tsx` — Lyra banner with evolving greeting, encounter recorded on mount
- `styles.css` — character screen, banner, choice, and response styles
- `act1.json`–`act13.json` — `characterEncounter: "kael"` on one rest node and `characterEncounter: "mira"` on one event node per act

## Test plan

- [ ] Visit 3 merchant nodes — Lyra's dialogue advances (verify `jarv_characters` in localStorage)
- [ ] Visit rest node in Act 1 — Kael appears before the heal; choice is applied (crystals/HP)
- [ ] Visit same rest node in a new run — Kael is one stage later
- [ ] Collect a new memory fragment — Mira appears after the lore screen, not before
- [ ] Collect an already-known fragment — Mira does NOT appear
- [ ] Visit an event node with `characterEncounter: "mira"` — Mira appears, then the event fires
- [ ] `tsc --noEmit` passes clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01X1dTjbXJx9e3ve32RDiebf)_