### PR TITLE
feat: card augments system (#1312)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -104,6 +104,7 @@ import { TrainingScreen }  from './components/screens/TrainingScreen'
 import {
   incrementAchievementProgress, setAchievementProgress, AchievementDef,
 } from './game/achievements'
+import { incrementAugmentSouls } from './game/collection'
 import { AchievementsScreen } from './components/screens/AchievementsScreen'
 import { HeroCardsScreen }   from './components/screens/HeroCardsScreen'
 import FingerSmash from './components/battle/FingerSmash'
@@ -121,6 +122,7 @@ import { DailyChallengeScreen } from './components/screens/DailyChallengeScreen'
 import { ConfirmModal }          from './components/modals/ConfirmModal'
 import { EndlessLeaderboardScreen } from './components/screens/EndlessLeaderboardScreen'
 import { MiniGamesMenu }           from './components/screens/MiniGamesMenu'
+import { AugmentCollectionScreen } from './components/screens/AugmentCollectionScreen'
 import './styles.css'
 import brokenRelicsData from './data/broken-relics.json'
 import rollbar, { updateRollbarPerson } from './rollbar'
@@ -207,6 +209,7 @@ type Screen =
   | 'codex'
   | 'memory'
   | 'characterEncounter'
+  | 'augments'
 
 
 const STANCE_RULES_BY_NODE_TYPE: Partial<Record<string, StanceRules>> = {
@@ -1933,6 +1936,8 @@ export default function App() {
       // Track total kills
       const totalUnlocked = incrementAchievementProgress('misc:total_kills', newKills.length)
       newToasts.push(...totalUnlocked)
+      // Award augment souls (1 per kill)
+      incrementAugmentSouls(newKills.length)
       if (newToasts.length > 0) {
         setAchievementToasts(prev => [...prev, ...newToasts])
       }
@@ -2637,6 +2642,7 @@ export default function App() {
           onCrystalsChanged={handleCrystalsChanged}
           onBack={() => setScreen('title')}
           commanderName={commander?.cardName ?? null}
+          onViewAugments={() => setScreen('augments')}
           onPromoteCommander={(cardName) => {
             const ok = promoteCommander(cardName)
             if (ok) {
@@ -2645,6 +2651,10 @@ export default function App() {
             }
           }}
         />
+      )}
+
+      {screen === 'augments' && (
+        <AugmentCollectionScreen onBack={() => setScreen('collection')} />
       )}
 
       {screen === 'shop' && (

--- a/web/src/components/cards/AugmentPickerModal.tsx
+++ b/web/src/components/cards/AugmentPickerModal.tsx
@@ -1,0 +1,103 @@
+import React from 'react'
+import { AugmentSlot, AugmentInstance } from '../../game/types'
+import {
+  loadAugmentInstances,
+  equipAugment,
+  unequipAugment,
+} from '../../game/collection'
+import { getAugmentCard, augmentSlotLabel } from '../../game/augments'
+import { ModalBackdrop } from '../ui/ModalBackdrop'
+
+interface Props {
+  slot: AugmentSlot
+  cardName: string
+  onClose: () => void
+}
+
+const RARITY_COLOUR: Record<string, string> = {
+  common:    '#55cc55',
+  uncommon:  '#4499ff',
+  rare:      '#bb66ff',
+  epic:      '#ff8800',
+  legendary: '#ffcc00',
+  mythic:    '#e040fb',
+}
+
+export function AugmentPickerModal({ slot, cardName, onClose }: Props) {
+  const allInstances = loadAugmentInstances()
+
+  // Filter to instances of the correct slot type
+  const matching: AugmentInstance[] = allInstances.filter(inst => {
+    const augCard = getAugmentCard(inst.cardId)
+    return augCard?.augmentSlot === slot
+  })
+
+  function handleEquip(inst: AugmentInstance) {
+    equipAugment(inst.instanceId, cardName)
+    onClose()
+  }
+
+  function handleUnequip(inst: AugmentInstance) {
+    unequipAugment(inst.instanceId)
+    onClose()
+  }
+
+  return (
+    <ModalBackdrop onClose={onClose} zIndex={400}>
+      <div className="apm-panel">
+        <div className="apm-header">
+          Equip {augmentSlotLabel(slot)}
+          <button className="cdm-close" onClick={onClose}>✕</button>
+        </div>
+
+        {matching.length === 0 ? (
+          <div className="apm-empty">
+            No {augmentSlotLabel(slot)} augments owned.
+          </div>
+        ) : (
+          <div className="apm-list">
+            {matching.map(inst => {
+              const augCard = getAugmentCard(inst.cardId)
+              if (!augCard) return null
+              const isEquippedHere = inst.equippedToCardName === cardName
+              const isEquippedElsewhere = inst.equippedToCardName && inst.equippedToCardName !== cardName
+
+              return (
+                <div key={inst.instanceId} className={`apm-item${isEquippedHere ? ' apm-item--active' : ''}`}>
+                  <div className="apm-item-info">
+                    <span
+                      className="apm-item-name"
+                      style={{ color: RARITY_COLOUR[augCard.rarity] ?? '#fff' }}
+                    >
+                      {augCard.name}
+                    </span>
+                    <span className="apm-item-set" style={{ opacity: 0.6, fontSize: 11 }}>
+                      {augCard.setName} set · Lv{inst.level}
+                    </span>
+                    {isEquippedElsewhere && (
+                      <span className="apm-item-equipped-other" style={{ color: '#ffaa44', fontSize: 11 }}>
+                        Equipped on: {inst.equippedToCardName}
+                      </span>
+                    )}
+                  </div>
+
+                  <div className="apm-item-actions">
+                    {isEquippedHere ? (
+                      <button className="action-btn action-btn--danger" onClick={() => handleUnequip(inst)}>
+                        Unequip
+                      </button>
+                    ) : (
+                      <button className="action-btn action-btn--gold" onClick={() => handleEquip(inst)}>
+                        {isEquippedElsewhere ? 'Move Here' : 'Equip'}
+                      </button>
+                    )}
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        )}
+      </div>
+    </ModalBackdrop>
+  )
+}

--- a/web/src/components/cards/CardAugmentScreen.tsx
+++ b/web/src/components/cards/CardAugmentScreen.tsx
@@ -1,0 +1,230 @@
+import React, { useState } from 'react'
+import { Card, AugmentSlot, AugmentEffect, AugmentInstance } from '../../game/types'
+import {
+  CollectionEntry,
+  DeckEntry,
+  getOwnedCount,
+  getMasteryXp,
+  masteryProgress,
+  loadAugmentSouls,
+  getEquippedAugments,
+  getSetBonus,
+  upgradeAugment,
+  AUGMENT_UPGRADE_COST,
+} from '../../game/collection'
+import {
+  getAugmentCard,
+  scaledAugmentEffect,
+  augmentSlotLabel,
+  ALL_AUGMENT_SLOTS,
+  AugmentSetDef,
+  getAugmentSetDef,
+} from '../../game/augments'
+import { CardTile } from './CardTile'
+import { StatRow } from '../ui/StatRow'
+import { MasteryBar } from '../ui/MasteryBar'
+import { AugmentPickerModal } from './AugmentPickerModal'
+
+interface Props {
+  card: Card
+  collection: CollectionEntry[]
+  deckEntries?: DeckEntry[]
+  onClose: () => void
+}
+
+const RARITY_COLOUR: Record<string, string> = {
+  common:    '#55cc55',
+  uncommon:  '#4499ff',
+  rare:      '#bb66ff',
+  epic:      '#ff8800',
+  legendary: '#ffcc00',
+  mythic:    '#e040fb',
+  shiny:     '#ffe066',
+  holofoil:  '#40e0d0',
+  glass:     '#a0d8ef',
+}
+
+function effectSummary(effect: AugmentEffect): string {
+  const parts: string[] = []
+  if (effect.maxHp)       parts.push(`+${effect.maxHp} HP`)
+  if (effect.attack)      parts.push(`+${effect.attack} ATK`)
+  if (effect.attackRange) parts.push(`+${effect.attackRange} RNG`)
+  if (effect.moveSpeed)   parts.push(`+${effect.moveSpeed} SPD`)
+  return parts.join(', ')
+}
+
+export function CardAugmentScreen({ card, collection, deckEntries, onClose }: Props) {
+  const [refresh, setRefresh] = useState(0)
+  const [pickerSlot, setPickerSlot] = useState<AugmentSlot | null>(null)
+  const [upgradeError, setUpgradeError] = useState<string | null>(null)
+
+  const forceRefresh = () => setRefresh((r: number) => r + 1)
+
+  const owned  = getOwnedCount(collection, card.name)
+  const inDeck = deckEntries?.find(e => e.cardName === card.name)?.count ?? 0
+  const xp     = getMasteryXp(collection, card.name)
+  const { level: masteryLvl, current: xpCur, needed: xpNeeded } = masteryProgress(xp)
+  const rarityCol = RARITY_COLOUR[card.rarity] ?? 'var(--game-text-color-dim)'
+
+  const equippedMap = getEquippedAugments(card.name)
+  const setBonus    = getSetBonus(card.name)
+  const souls       = loadAugmentSouls()
+
+  const u = card.unit
+
+  function handleUpgrade(inst: AugmentInstance) {
+    const err = upgradeAugment(inst.instanceId)
+    if (err) {
+      setUpgradeError(err)
+      setTimeout(() => setUpgradeError(null), 2500)
+    }
+    forceRefresh()
+  }
+
+  return (
+    <div className="cas-backdrop" onClick={onClose}>
+      <div className="cas-panel" onClick={(e: React.MouseEvent) => e.stopPropagation()}>
+
+        {/* Header */}
+        <div className="cas-header">
+          <span className="cas-name" style={{ color: rarityCol }}>{card.name}</span>
+          <span className="cas-rarity" style={{ color: rarityCol }}>
+            {'★'.repeat(({ common: 1, uncommon: 2, rare: 3, epic: 4, legendary: 5, mythic: 6, shiny: 4, holofoil: 4, glass: 4 } as Record<string,number>)[card.rarity] ?? 1)}
+            {' '}{card.rarity.toUpperCase()}
+          </span>
+          <button className="cdm-close" onClick={onClose}>✕</button>
+        </div>
+
+        <div className="cas-body">
+
+          {/* Card tile + base stats */}
+          <div className="cas-top u-flex u-gap-4">
+            <div className="cas-card-col u-col u-items-c u-gap-2">
+              <CardTile card={card} canAfford={true} />
+              <div className="cdm-owned">×{owned} owned{inDeck > 0 ? ` · ×${inDeck} in deck` : ''}</div>
+              {xp > 0 && <MasteryBar xp={xp} />}
+            </div>
+
+            <div className="cas-info-col u-grow u-col u-gap-3">
+              <div className="cdm-desc">{card.description}</div>
+              {card.lore && <div className="cdm-lore" style={{ fontStyle: 'italic', opacity: 0.7, fontSize: 11 }}>{card.lore}</div>}
+
+              {/* Unit stats */}
+              {u && u.moveSpeed > 0 && (
+                <div className="cdm-stats-block u-flex u-wrap">
+                  <StatRow compact label="ATK" value={u.attack} />
+                  <StatRow compact label="HP"  value={u.maxHp} />
+                  <StatRow compact label="SPD" value={u.moveSpeed} />
+                  {u.attackRange > 0 && <StatRow compact label="RNG" value={u.attackRange} />}
+                </div>
+              )}
+              {u && u.moveSpeed === 0 && (
+                <div className="cdm-stats-block u-flex u-wrap">
+                  <StatRow compact label="HP" value={u.maxHp} />
+                </div>
+              )}
+
+              {masteryLvl > 0 && (
+                <div style={{ fontSize: 11, color: '#ffcc55' }}>Mastery ★{masteryLvl} · {xpCur}/{xpNeeded} XP</div>
+              )}
+            </div>
+          </div>
+
+          {/* Souls balance */}
+          <div className="cas-souls-bar">
+            <span style={{ opacity: 0.7, fontSize: 12 }}>Augment Souls:</span>
+            <span style={{ color: '#cc88ff', fontWeight: 700 }}>{souls.toLocaleString()} 👻</span>
+            {upgradeError && <span style={{ color: '#ff6666', fontSize: 11 }}>{upgradeError}</span>}
+          </div>
+
+          {/* Augment slots */}
+          <div className="cas-slots-title">Equipment Slots</div>
+
+          <div className="cas-slots-grid">
+            {ALL_AUGMENT_SLOTS.map(slot => {
+              const inst = equippedMap[slot]
+              const augCard = inst ? getAugmentCard(inst.cardId) : undefined
+              const scaled = (augCard?.augmentEffect && inst)
+                ? scaledAugmentEffect(augCard.augmentEffect, inst.level)
+                : undefined
+
+              return (
+                <div key={slot} className={`cas-slot${inst ? ' cas-slot--filled' : ''}`}>
+                  <div className="cas-slot-label">{augmentSlotLabel(slot)}</div>
+                  {inst && augCard ? (
+                    <>
+                      <div className="cas-slot-name" style={{ color: RARITY_COLOUR[augCard.rarity] ?? '#fff' }}>
+                        {augCard.name}
+                      </div>
+                      <div className="cas-slot-level">Lv{inst.level}</div>
+                      {scaled && (
+                        <div className="cas-slot-effect">{effectSummary(scaled)}</div>
+                      )}
+                      <div className="cas-slot-actions">
+                        <button
+                          className="action-btn action-btn--gold cas-slot-btn"
+                          disabled={souls < AUGMENT_UPGRADE_COST}
+                          onClick={() => handleUpgrade(inst)}
+                          title={`Upgrade (costs ${AUGMENT_UPGRADE_COST} souls)`}
+                        >
+                          ↑ Upgrade
+                        </button>
+                        <button
+                          className="action-btn cas-slot-btn"
+                          onClick={() => { setPickerSlot(slot); }}
+                        >
+                          Swap
+                        </button>
+                      </div>
+                    </>
+                  ) : (
+                    <button
+                      className="action-btn cas-slot-btn"
+                      onClick={() => setPickerSlot(slot)}
+                    >
+                      + Equip
+                    </button>
+                  )}
+                </div>
+              )
+            })}
+          </div>
+
+          {/* Set bonus */}
+          {(() => {
+            const equipped = Object.values(equippedMap)
+            if (equipped.length === 0) return null
+            const firstAug = getAugmentCard(equipped[0]?.cardId ?? '')
+            const setName  = firstAug?.setName
+            const setDef: AugmentSetDef | undefined = setName ? getAugmentSetDef(setName) : undefined
+            if (!setDef) return null
+            const hasFullSet = !!setBonus
+            const slotsFilledSameSet = equipped.filter(i => getAugmentCard(i.cardId)?.setName === setName).length
+            return (
+              <div className={`cas-set-bonus${hasFullSet ? ' cas-set-bonus--active' : ''}`}>
+                <span className="cas-set-bonus-name" style={{ color: RARITY_COLOUR[setDef.rarity] ?? '#fff' }}>
+                  {setName} Set Bonus ({slotsFilledSameSet}/7)
+                </span>
+                <span className="cas-set-bonus-desc">{setDef.setBonusDescription}</span>
+                {hasFullSet && (
+                  <span className="cas-set-bonus-effect" style={{ color: '#ffcc00' }}>
+                    {effectSummary(setDef.setBonus)} ACTIVE
+                  </span>
+                )}
+              </div>
+            )
+          })()}
+
+        </div>
+      </div>
+
+      {pickerSlot && (
+        <AugmentPickerModal
+          slot={pickerSlot}
+          cardName={card.name}
+          onClose={() => { setPickerSlot(null); forceRefresh() }}
+        />
+      )}
+    </div>
+  )
+}

--- a/web/src/components/cards/DeckBuilder.tsx
+++ b/web/src/components/cards/DeckBuilder.tsx
@@ -255,7 +255,7 @@ export function DeckBuilder({ onBack, fatiguedCards = [] }: Props) {
   }, [catalog])
 
   const RARITY_ORDER: Record<CardRarity, number> = { common: 0, uncommon: 1, rare: 2, epic: 3, legendary: 4, mythic: 5, shiny: 6, holofoil: 7, glass: 8 }
-  const TYPE_ORDER: Record<CardType, number>     = { unit: 0, structure: 1, upgrade: 2 }
+  const TYPE_ORDER: Record<CardType, number>     = { unit: 0, structure: 1, upgrade: 2, augment: 3 }
 
   const catalogPos = useMemo(() => new Map<string, number>(catalog.map((c, i) => [c.name, i])), [catalog])
 

--- a/web/src/components/minigames/TowerDefence.tsx
+++ b/web/src/components/minigames/TowerDefence.tsx
@@ -34,6 +34,7 @@ import {
   xpToUpgrade
 } from '../../game/towerDefence'
 import { UnitTemplate } from '../../game/types'
+import { incrementAugmentSouls } from '../../game/collection'
 import { Lives } from '../ui/Lives/Lives'
 import { BottomPanel } from './towerdefence/BottomPanel'
 import { TowerDefenceEndScreen } from './towerdefence/EndScreen'
@@ -113,6 +114,15 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
     }
     prevLivesRef.current = game.lives
   }, [game.lives])
+
+  // Award augment souls when the game ends (1 per enemy killed)
+  const soulsAwardedRef = useRef(false)
+  useEffect(() => {
+    if ((game.phase === 'victory' || game.phase === 'defeat') && !soulsAwardedRef.current) {
+      soulsAwardedRef.current = true
+      if (game.enemyKills > 0) incrementAugmentSouls(game.enemyKills)
+    }
+  }, [game.phase, game.enemyKills])
 
   // Auto-start next wave when the toggle is on
   useEffect(() => {

--- a/web/src/components/screens/AugmentCollectionScreen.tsx
+++ b/web/src/components/screens/AugmentCollectionScreen.tsx
@@ -1,0 +1,129 @@
+import React, { useState } from 'react'
+import { AugmentInstance } from '../../game/types'
+import {
+  loadAugmentInstances,
+  loadAugmentSouls,
+  loadCollection,
+  upgradeAugment,
+  AUGMENT_UPGRADE_COST,
+} from '../../game/collection'
+import { getAugmentCard, augmentSlotLabel, scaledAugmentEffect } from '../../game/augments'
+import { OverlayScreen } from '../ui/OverlayScreen'
+import { CardAugmentScreen } from '../cards/CardAugmentScreen'
+import { getCardCatalog } from '../../game/cards'
+
+interface Props {
+  onBack: () => void
+}
+
+const RARITY_COLOUR: Record<string, string> = {
+  common:    '#55cc55',
+  uncommon:  '#4499ff',
+  rare:      '#bb66ff',
+  epic:      '#ff8800',
+  legendary: '#ffcc00',
+  mythic:    '#e040fb',
+}
+
+function effectSummary(effect: { attack?: number; attackRange?: number; maxHp?: number; moveSpeed?: number }): string {
+  const parts: string[] = []
+  if (effect.maxHp)       parts.push(`+${effect.maxHp} HP`)
+  if (effect.attack)      parts.push(`+${effect.attack} ATK`)
+  if (effect.attackRange) parts.push(`+${effect.attackRange} RNG`)
+  if (effect.moveSpeed)   parts.push(`+${effect.moveSpeed} SPD`)
+  return parts.join(', ')
+}
+
+export function AugmentCollectionScreen({ onBack }: Props) {
+  const [refresh, setRefresh] = useState(0)
+  const [detailCardName, setDetailCardName] = useState<string | null>(null)
+  const [upgradeError, setUpgradeError] = useState<string | null>(null)
+
+  const forceRefresh = () => setRefresh((r: number) => r + 1)
+
+  const instances   = loadAugmentInstances()
+  const souls       = loadAugmentSouls()
+  const collection  = loadCollection()
+  const catalog     = getCardCatalog()
+
+  function handleUpgrade(inst: AugmentInstance) {
+    const err = upgradeAugment(inst.instanceId)
+    if (err) {
+      setUpgradeError(err)
+      setTimeout(() => setUpgradeError(null), 2500)
+    }
+    forceRefresh()
+  }
+
+  if (detailCardName) {
+    const card = catalog.find(c => c.name === detailCardName)
+    if (card) {
+      return (
+        <CardAugmentScreen
+          card={card}
+          collection={collection}
+          onClose={() => setDetailCardName(null)}
+        />
+      )
+    }
+  }
+
+  return (
+    <OverlayScreen title="AUGMENTS" onBack={onBack} right={
+      <span style={{ color: '#cc88ff', fontWeight: 700 }}>{souls.toLocaleString()} 👻 souls</span>
+    }>
+      {upgradeError && (
+        <div style={{ color: '#ff6666', textAlign: 'center', fontSize: 12, marginBottom: 8 }}>{upgradeError}</div>
+      )}
+
+      {instances.length === 0 ? (
+        <div style={{ textAlign: 'center', opacity: 0.6, marginTop: 48 }}>
+          No augments owned yet. Earn augments from packs to equip them to your units.
+        </div>
+      ) : (
+        <div className="aug-list">
+          {instances.map(inst => {
+            const augCard = getAugmentCard(inst.cardId)
+            if (!augCard) return null
+            const scaled = scaledAugmentEffect(augCard.augmentEffect ?? {}, inst.level)
+
+            return (
+              <div key={inst.instanceId} className="aug-list-item">
+                <div className="aug-list-item-info">
+                  <span className="aug-list-name" style={{ color: RARITY_COLOUR[augCard.rarity] ?? '#fff' }}>
+                    {augCard.name}
+                  </span>
+                  <span style={{ opacity: 0.6, fontSize: 11 }}>
+                    {augCard.setName} set · {augmentSlotLabel(augCard.augmentSlot!)} · Lv{inst.level}
+                  </span>
+                  <span style={{ fontSize: 12, color: '#aaddff' }}>{effectSummary(scaled)}</span>
+                  {inst.equippedToCardName ? (
+                    <button
+                      className="aug-equipped-link"
+                      onClick={() => setDetailCardName(inst.equippedToCardName!)}
+                    >
+                      Equipped on: {inst.equippedToCardName} →
+                    </button>
+                  ) : (
+                    <span style={{ opacity: 0.5, fontSize: 11 }}>Unequipped</span>
+                  )}
+                </div>
+
+                <div className="aug-list-item-actions">
+                  <button
+                    className="action-btn action-btn--gold"
+                    disabled={souls < AUGMENT_UPGRADE_COST}
+                    onClick={() => handleUpgrade(inst)}
+                    title={`Costs ${AUGMENT_UPGRADE_COST} souls`}
+                  >
+                    ↑ Upgrade
+                  </button>
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </OverlayScreen>
+  )
+}

--- a/web/src/components/screens/CollectionScreen.tsx
+++ b/web/src/components/screens/CollectionScreen.tsx
@@ -20,6 +20,7 @@ import { promotionsRemainingToday } from '../../game/commander'
 import { incrementAchievementProgress } from '../../game/achievements'
 import { CardTile } from '../cards/CardTile'
 import { CardDetailModal } from '../cards/CardDetailModal'
+import { CardAugmentScreen } from '../cards/CardAugmentScreen'
 import { OverlayScreen } from '../ui/OverlayScreen'
 import { MasteryBar } from '../ui/MasteryBar'
 import { ModalBackdrop } from '../ui/ModalBackdrop'
@@ -31,6 +32,7 @@ interface Props {
   onBack: () => void
   commanderName?: string | null
   onPromoteCommander?: (cardName: string) => void
+  onViewAugments?: () => void
 }
 
 type RarityFilter = 'all' | CardRarity
@@ -67,7 +69,7 @@ const LazyCell = memo(function LazyCell({ children, className }: { children: Rea
   )
 })
 
-export function CollectionScreen({ crystals, onCrystalsChanged, onBack, commanderName, onPromoteCommander }: Props) {
+export function CollectionScreen({ crystals, onCrystalsChanged, onBack, commanderName, onPromoteCommander, onViewAugments }: Props) {
   const catalog = getCardCatalog()
   const allAffinityLabels = Array.from(
     new Set(catalog.flatMap(c => c.unit?.affinity?.label ? [c.unit.affinity.label] : []))
@@ -97,6 +99,7 @@ export function CollectionScreen({ crystals, onCrystalsChanged, onBack, commande
   const [upgradeModal, setUpgradeModal] = useState<Array<{cardName: string, xpGained: number}> | null>(null)
   const [disenchantModal, setDisenchantModal] = useState<Array<{cardName: string, crystals: number}> | null>(null)
   const [detailCard, setDetailCard] = useState<import('../../game/types').Card | null>(null)
+  const [augmentCard, setAugmentCard] = useState<import('../../game/types').Card | null>(null)
   const [levelUpCard, setLevelUpCard] = useState<string | null>(null)
   const [secretToast, setSecretToast] = useState<string | null>(null)
   const legendaryViewCount = useRef(0)
@@ -162,7 +165,7 @@ export function CollectionScreen({ crystals, onCrystalsChanged, onBack, commande
   })
 
   const RARITY_ORDER: Record<CardRarity, number> = { common: 0, uncommon: 1, rare: 2, epic: 3, legendary: 4, mythic: 5, shiny: 6, holofoil: 7, glass: 8 }
-  const TYPE_ORDER: Record<CardType, number>     = { unit: 0, structure: 1, upgrade: 2 }
+  const TYPE_ORDER: Record<CardType, number>     = { unit: 0, structure: 1, upgrade: 2, augment: 3 }
 
   // Default sort: spawn buildings appear immediately after the unit they spawn.
   const catalogPos = new Map<string, number>(catalog.map((c, i) => [c.name, i]))
@@ -310,7 +313,16 @@ export function CollectionScreen({ crystals, onCrystalsChanged, onBack, commande
   }
 
   return (
-    <OverlayScreen title="COLLECTION" onBack={onBack} right={<span className="crystal-count">💎 {crystals.toLocaleString()}</span>}>
+    <OverlayScreen title="COLLECTION" onBack={onBack} right={
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        {onViewAugments && (
+          <button className="action-btn" style={{ fontSize: 12, padding: '3px 10px' }} onClick={onViewAugments}>
+            Augments 👻
+          </button>
+        )}
+        <span className="crystal-count">💎 {crystals.toLocaleString()}</span>
+      </div>
+    }>
 
       {/* Action row */}
       <div className="collection-action-row u-flex u-items-c u-gap-4 u-wrap">
@@ -556,7 +568,11 @@ export function CollectionScreen({ crystals, onCrystalsChanged, onBack, commande
                     canAfford={true}
                     upgradeable={extras > 0}
                     onClick={() => {
-                      setDetailCard(card)
+                      if (card.cardType === 'unit' && card.unit && card.unit.moveSpeed > 0) {
+                        setAugmentCard(card)
+                      } else {
+                        setDetailCard(card)
+                      }
                       if (card.rarity === 'legendary') {
                         legendaryViewCount.current += 1
                         if (legendaryViewCount.current === 10) {
@@ -581,6 +597,14 @@ export function CollectionScreen({ crystals, onCrystalsChanged, onBack, commande
           })
         })()}
       </div>
+
+      {augmentCard && (
+        <CardAugmentScreen
+          card={augmentCard}
+          collection={collection}
+          onClose={() => setAugmentCard(null)}
+        />
+      )}
 
       {detailCard && (() => {
         const dOwned   = getOwnedCount(collection, detailCard.name)

--- a/web/src/data/augments.json
+++ b/web/src/data/augments.json
@@ -1,0 +1,330 @@
+{
+  "sets": [
+    {
+      "name": "Thunder", "rarity": "common",
+      "setBonusDescription": "Lightning crackling through every strike — +8 attack range, +2 damage",
+      "setBonus": { "attackRange": 8, "attack": 2 }
+    },
+    {
+      "name": "Frost", "rarity": "common",
+      "setBonusDescription": "The cold that never leaves — +15 max HP, +5 move speed",
+      "setBonus": { "maxHp": 15, "moveSpeed": 5 }
+    },
+    {
+      "name": "Ember", "rarity": "common",
+      "setBonusDescription": "Smouldering fury ignites — +5 attack",
+      "setBonus": { "attack": 5 }
+    },
+    {
+      "name": "Iron", "rarity": "common",
+      "setBonusDescription": "Unyielding iron will — +20 max HP",
+      "setBonus": { "maxHp": 20 }
+    },
+    {
+      "name": "Verdant", "rarity": "common",
+      "setBonusDescription": "Nature breathes through the wearer — +12 max HP, +8 move speed",
+      "setBonus": { "maxHp": 12, "moveSpeed": 8 }
+    },
+    {
+      "name": "Shadow", "rarity": "uncommon",
+      "setBonusDescription": "Darkness gifts speed and precision — +15 move speed, +4 attack",
+      "setBonus": { "moveSpeed": 15, "attack": 4 }
+    },
+    {
+      "name": "Storm", "rarity": "uncommon",
+      "setBonusDescription": "The storm answers — +18 attack range, +5 attack",
+      "setBonus": { "attackRange": 18, "attack": 5 }
+    },
+    {
+      "name": "Crimson", "rarity": "uncommon",
+      "setBonusDescription": "Crimson tide rises — +8 attack, +15 max HP",
+      "setBonus": { "attack": 8, "maxHp": 15 }
+    },
+    {
+      "name": "Obsidian", "rarity": "uncommon",
+      "setBonusDescription": "Volcanic glass, unbreakable — +35 max HP",
+      "setBonus": { "maxHp": 35 }
+    },
+    {
+      "name": "Aurora", "rarity": "uncommon",
+      "setBonusDescription": "Aurora's blessing extends far — +25 attack range, +5 attack",
+      "setBonus": { "attackRange": 25, "attack": 5 }
+    },
+    {
+      "name": "Venom", "rarity": "rare",
+      "setBonusDescription": "Poison flows freely — +10 attack, +15 attack range",
+      "setBonus": { "attack": 10, "attackRange": 15 }
+    },
+    {
+      "name": "Tide", "rarity": "rare",
+      "setBonusDescription": "The tide grants swiftness — +20 move speed, +30 max HP",
+      "setBonus": { "moveSpeed": 20, "maxHp": 30 }
+    },
+    {
+      "name": "Ash", "rarity": "rare",
+      "setBonusDescription": "From the ashes, power — +12 attack, +8 attack range",
+      "setBonus": { "attack": 12, "attackRange": 8 }
+    },
+    {
+      "name": "Steel", "rarity": "rare",
+      "setBonusDescription": "Steel forged in fury — +55 max HP",
+      "setBonus": { "maxHp": 55 }
+    },
+    {
+      "name": "Midnight", "rarity": "rare",
+      "setBonusDescription": "Midnight empowers the blade — +15 attack, +20 move speed",
+      "setBonus": { "attack": 15, "moveSpeed": 20 }
+    },
+    {
+      "name": "Dragon", "rarity": "epic",
+      "setBonusDescription": "Draconic power unleashed — +25 attack, +30 attack range",
+      "setBonus": { "attack": 25, "attackRange": 30 }
+    },
+    {
+      "name": "Elder", "rarity": "epic",
+      "setBonusDescription": "Ancient wisdom endures — +80 max HP, +12 attack",
+      "setBonus": { "maxHp": 80, "attack": 12 }
+    },
+    {
+      "name": "Jade", "rarity": "epic",
+      "setBonusDescription": "Jade vitality — +65 max HP, +25 move speed",
+      "setBonus": { "maxHp": 65, "moveSpeed": 25 }
+    },
+    {
+      "name": "Blood", "rarity": "epic",
+      "setBonusDescription": "Blood feeds the hunger — +20 attack, +40 max HP",
+      "setBonus": { "attack": 20, "maxHp": 40 }
+    },
+    {
+      "name": "Crystal", "rarity": "epic",
+      "setBonusDescription": "Crystal clarity extends sight — +45 attack range, +15 attack",
+      "setBonus": { "attackRange": 45, "attack": 15 }
+    },
+    {
+      "name": "Bone", "rarity": "legendary",
+      "setBonusDescription": "The dead do not tire — +100 max HP, +20 attack",
+      "setBonus": { "maxHp": 100, "attack": 20 }
+    },
+    {
+      "name": "Tempest", "rarity": "legendary",
+      "setBonusDescription": "The tempest howls through — +30 attack, +45 attack range",
+      "setBonus": { "attack": 30, "attackRange": 45 }
+    },
+    {
+      "name": "Solar", "rarity": "legendary",
+      "setBonusDescription": "Solar radiance endures — +130 max HP, +25 attack",
+      "setBonus": { "maxHp": 130, "attack": 25 }
+    },
+    {
+      "name": "Void", "rarity": "legendary",
+      "setBonusDescription": "The void reaches all — +25 attack, +65 attack range",
+      "setBonus": { "attack": 25, "attackRange": 65 }
+    },
+    {
+      "name": "Granite", "rarity": "legendary",
+      "setBonusDescription": "Granite endurance — +150 max HP, +25 move speed",
+      "setBonus": { "maxHp": 150, "moveSpeed": 25 }
+    }
+  ],
+  "cards": [
+    { "id": "aug-thunder-helm",      "name": "Thunder Helm",      "rarity": "common",    "setName": "Thunder",  "slot": "helmet",       "effect": { "maxHp": 3 },            "description": "Helmet charged with lightning. +3 HP.", "lore": "Static dances across the visor in a storm." },
+    { "id": "aug-thunder-cuirass",   "name": "Thunder Cuirass",   "rarity": "common",    "setName": "Thunder",  "slot": "chest",        "effect": { "maxHp": 5 },            "description": "Chest piece crackling with power. +5 HP.", "lore": "The metal smells of ozone after a long march." },
+    { "id": "aug-thunder-gauntlets", "name": "Thunder Gauntlets", "rarity": "common",    "setName": "Thunder",  "slot": "arms",         "effect": { "attack": 1 },           "description": "Gauntlets that amplify each blow. +1 attack.", "lore": "Each punch echoes like distant thunder." },
+    { "id": "aug-thunder-cuisses",   "name": "Thunder Cuisses",   "rarity": "common",    "setName": "Thunder",  "slot": "legs",         "effect": { "moveSpeed": 5 },        "description": "Leg armour crackles with kinetic energy. +5 speed.", "lore": "The wearer's steps leave scorched ground." },
+    { "id": "aug-thunder-amulet",    "name": "Thunder Amulet",    "rarity": "common",    "setName": "Thunder",  "slot": "amulet",       "effect": { "maxHp": 2, "attack": 1 }, "description": "Amulet humming with stored lightning. +2 HP, +1 attack.", "lore": "A storm in a pendant." },
+    { "id": "aug-thunder-bow",       "name": "Thunder Bow",       "rarity": "common",    "setName": "Thunder",  "slot": "primaryRanged","effect": { "attackRange": 5 },      "description": "Bow that fires crackling bolts. +5 attack range.", "lore": "The string is woven from lightning rods." },
+    { "id": "aug-thunder-blade",     "name": "Thunder Blade",     "rarity": "common",    "setName": "Thunder",  "slot": "heavyMelee",   "effect": { "attack": 2 },           "description": "Blade wreathed in electrical arcs. +2 attack.", "lore": "Cuts through both armour and air resistance." },
+
+    { "id": "aug-frost-hood",        "name": "Frost Hood",        "rarity": "common",    "setName": "Frost",    "slot": "helmet",       "effect": { "maxHp": 3 },            "description": "Hood lined with frost crystals. +3 HP.", "lore": "Keeps the head clear and cold in the heat of battle." },
+    { "id": "aug-frost-breastplate", "name": "Frost Breastplate", "rarity": "common",    "setName": "Frost",    "slot": "chest",        "effect": { "maxHp": 5 },            "description": "Chest plate radiating cold. +5 HP.", "lore": "Enemies hesitate before striking frozen armour." },
+    { "id": "aug-frost-bracers",     "name": "Frost Bracers",     "rarity": "common",    "setName": "Frost",    "slot": "arms",         "effect": { "attack": 1 },           "description": "Bracers that freeze what they touch. +1 attack.", "lore": "The ice in the veins focuses the strike." },
+    { "id": "aug-frost-leggings",    "name": "Frost Leggings",    "rarity": "common",    "setName": "Frost",    "slot": "legs",         "effect": { "moveSpeed": 5 },        "description": "Leggings that glide like ice. +5 speed.", "lore": "Friction is an afterthought on these boots." },
+    { "id": "aug-frost-pendant",     "name": "Frost Pendant",     "rarity": "common",    "setName": "Frost",    "slot": "amulet",       "effect": { "maxHp": 2, "attack": 1 }, "description": "Pendant encasing a frozen spark. +2 HP, +1 attack.", "lore": "The gem never melts, not even in volcanos." },
+    { "id": "aug-frost-wand",        "name": "Frost Wand",        "rarity": "common",    "setName": "Frost",    "slot": "primaryRanged","effect": { "attackRange": 5 },      "description": "Wand that extends icy bolts further. +5 attack range.", "lore": "Aims best in the cold." },
+    { "id": "aug-frost-axe",         "name": "Frost Axe",         "rarity": "common",    "setName": "Frost",    "slot": "heavyMelee",   "effect": { "attack": 2 },           "description": "Axe that bites like winter cold. +2 attack.", "lore": "The edge never dulls — ice reforms it each morning." },
+
+    { "id": "aug-ember-crown",       "name": "Ember Crown",       "rarity": "common",    "setName": "Ember",    "slot": "helmet",       "effect": { "maxHp": 3 },            "description": "Crown forged in volcanic embers. +3 HP.", "lore": "A ring of perpetual fire circles the brow." },
+    { "id": "aug-ember-coat",        "name": "Ember Coat",        "rarity": "common",    "setName": "Ember",    "slot": "chest",        "effect": { "maxHp": 5 },            "description": "Coat woven from fire-resistant fibres. +5 HP.", "lore": "It smells of campfire and old battles." },
+    { "id": "aug-ember-vambraces",   "name": "Ember Vambraces",   "rarity": "common",    "setName": "Ember",    "slot": "arms",         "effect": { "attack": 1 },           "description": "Vambraces that heat up with every swing. +1 attack.", "lore": "After a long fight they glow cherry red." },
+    { "id": "aug-ember-greaves",     "name": "Ember Greaves",     "rarity": "common",    "setName": "Ember",    "slot": "legs",         "effect": { "moveSpeed": 5 },        "description": "Greaves powered by thermal vents. +5 speed.", "lore": "The exhaust leaves small scorched circles in the earth." },
+    { "id": "aug-ember-locket",      "name": "Ember Locket",      "rarity": "common",    "setName": "Ember",    "slot": "amulet",       "effect": { "maxHp": 2, "attack": 1 }, "description": "Locket containing a piece of the first fire. +2 HP, +1 attack.", "lore": "It opens to reveal only flame." },
+    { "id": "aug-ember-staff",       "name": "Ember Staff",       "rarity": "common",    "setName": "Ember",    "slot": "primaryRanged","effect": { "attackRange": 5 },      "description": "Staff channelling combustive force far. +5 attack range.", "lore": "The tip glows orange even on moonless nights." },
+    { "id": "aug-ember-sword",       "name": "Ember Sword",       "rarity": "common",    "setName": "Ember",    "slot": "heavyMelee",   "effect": { "attack": 2 },           "description": "Sword that smoulders between strikes. +2 attack.", "lore": "Quenching it only makes it angrier." },
+
+    { "id": "aug-iron-helm",         "name": "Iron Helm",         "rarity": "common",    "setName": "Iron",     "slot": "helmet",       "effect": { "maxHp": 3 },            "description": "Plain iron helm, sturdy as a rock. +3 HP.", "lore": "Dented in every war it has survived." },
+    { "id": "aug-iron-plate",        "name": "Iron Plate",        "rarity": "common",    "setName": "Iron",     "slot": "chest",        "effect": { "maxHp": 5 },            "description": "Solid iron plate armour. +5 HP.", "lore": "Heavy, but the enemy always hits it first." },
+    { "id": "aug-iron-bracers",      "name": "Iron Bracers",      "rarity": "common",    "setName": "Iron",     "slot": "arms",         "effect": { "attack": 1 },           "description": "Iron bracers that add weight to each blow. +1 attack.", "lore": "Blacksmiths make these in their sleep." },
+    { "id": "aug-iron-greaves",      "name": "Iron Greaves",      "rarity": "common",    "setName": "Iron",     "slot": "legs",         "effect": { "moveSpeed": 5 },        "description": "Iron greaves surprisingly swift for their weight. +5 speed.", "lore": "Good ankles help." },
+    { "id": "aug-iron-talisman",     "name": "Iron Talisman",     "rarity": "common",    "setName": "Iron",     "slot": "amulet",       "effect": { "maxHp": 2, "attack": 1 }, "description": "Iron talisman shaped like an anvil. +2 HP, +1 attack.", "lore": "The smith who forged it never lost a duel." },
+    { "id": "aug-iron-crossbow",     "name": "Iron Crossbow",     "rarity": "common",    "setName": "Iron",     "slot": "primaryRanged","effect": { "attackRange": 5 },      "description": "Reliable iron crossbow with extended draw. +5 attack range.", "lore": "Cheaper than a wand, deadlier than most." },
+    { "id": "aug-iron-maul",         "name": "Iron Maul",         "rarity": "common",    "setName": "Iron",     "slot": "heavyMelee",   "effect": { "attack": 2 },           "description": "Iron maul that leaves a lasting impression. +2 attack.", "lore": "Not subtle, but effective." },
+
+    { "id": "aug-verdant-hood",      "name": "Verdant Hood",      "rarity": "common",    "setName": "Verdant",  "slot": "helmet",       "effect": { "maxHp": 3 },            "description": "Hood woven from living vines. +3 HP.", "lore": "Flowers bloom on it in spring." },
+    { "id": "aug-verdant-vest",      "name": "Verdant Vest",      "rarity": "common",    "setName": "Verdant",  "slot": "chest",        "effect": { "maxHp": 5 },            "description": "Vest of layered bark and leaf. +5 HP.", "lore": "The forest itself lends its protection." },
+    { "id": "aug-verdant-bracers",   "name": "Verdant Bracers",   "rarity": "common",    "setName": "Verdant",  "slot": "arms",         "effect": { "attack": 1 },           "description": "Bracers of ironwood. +1 attack.", "lore": "The oldest trees give the strongest wood." },
+    { "id": "aug-verdant-boots",     "name": "Verdant Boots",     "rarity": "common",    "setName": "Verdant",  "slot": "legs",         "effect": { "moveSpeed": 5 },        "description": "Boots that grip any terrain. +5 speed.", "lore": "You can hear roots shifting to make way." },
+    { "id": "aug-verdant-seed",      "name": "Verdant Seed",      "rarity": "common",    "setName": "Verdant",  "slot": "amulet",       "effect": { "maxHp": 2, "attack": 1 }, "description": "Seed of an ancient guardian tree. +2 HP, +1 attack.", "lore": "It pulses warmly against the skin." },
+    { "id": "aug-verdant-shortbow",  "name": "Verdant Shortbow",  "rarity": "common",    "setName": "Verdant",  "slot": "primaryRanged","effect": { "attackRange": 5 },      "description": "Shortbow carved from a living branch. +5 attack range.", "lore": "The wood has never been cut — it grew this way." },
+    { "id": "aug-verdant-club",      "name": "Verdant Club",      "rarity": "common",    "setName": "Verdant",  "slot": "heavyMelee",   "effect": { "attack": 2 },           "description": "Club grown dense with nature's resilience. +2 attack.", "lore": "It gets heavier with each fight." },
+
+    { "id": "aug-shadow-hood",       "name": "Shadow Hood",       "rarity": "uncommon",  "setName": "Shadow",   "slot": "helmet",       "effect": { "maxHp": 6 },            "description": "Hood that blurs the wearer's outline. +6 HP.", "lore": "Enemies strike where you were, not where you are." },
+    { "id": "aug-shadow-cloak",      "name": "Shadow Cloak",      "rarity": "uncommon",  "setName": "Shadow",   "slot": "chest",        "effect": { "maxHp": 10 },           "description": "Cloak woven from solidified shadow. +10 HP.", "lore": "In dim light it seems to swallow the wearer whole." },
+    { "id": "aug-shadow-gloves",     "name": "Shadow Gloves",     "rarity": "uncommon",  "setName": "Shadow",   "slot": "arms",         "effect": { "attack": 2 },           "description": "Gloves that darken every strike. +2 attack.", "lore": "Silent strikes land harder." },
+    { "id": "aug-shadow-wraps",      "name": "Shadow Wraps",      "rarity": "uncommon",  "setName": "Shadow",   "slot": "legs",         "effect": { "moveSpeed": 10 },       "description": "Leg wraps that dampen sound and friction. +10 speed.", "lore": "Running through shadow requires no effort at all." },
+    { "id": "aug-shadow-gem",        "name": "Shadow Gem",        "rarity": "uncommon",  "setName": "Shadow",   "slot": "amulet",       "effect": { "maxHp": 4, "attack": 2 }, "description": "Gem that pulses with absorbed darkness. +4 HP, +2 attack.", "lore": "Darker than any stone should be." },
+    { "id": "aug-shadow-sling",      "name": "Shadow Sling",      "rarity": "uncommon",  "setName": "Shadow",   "slot": "primaryRanged","effect": { "attackRange": 10 },     "description": "Sling that launches from the shadows. +10 attack range.", "lore": "The stone disappears before it hits." },
+    { "id": "aug-shadow-dagger",     "name": "Shadow Dagger",     "rarity": "uncommon",  "setName": "Shadow",   "slot": "heavyMelee",   "effect": { "attack": 4 },           "description": "Dagger forged in the penumbra. +4 attack.", "lore": "It cuts shadow and bone equally." },
+
+    { "id": "aug-storm-helm",        "name": "Storm Helm",        "rarity": "uncommon",  "setName": "Storm",    "slot": "helmet",       "effect": { "maxHp": 6 },            "description": "Helm forged in a tempest's eye. +6 HP.", "lore": "The cheeks are pitted by a million tiny hailstones." },
+    { "id": "aug-storm-mail",        "name": "Storm Mail",        "rarity": "uncommon",  "setName": "Storm",    "slot": "chest",        "effect": { "maxHp": 10 },           "description": "Chain mail woven from storm-iron. +10 HP.", "lore": "It hums in anticipation of the next storm." },
+    { "id": "aug-storm-gauntlets",   "name": "Storm Gauntlets",   "rarity": "uncommon",  "setName": "Storm",    "slot": "arms",         "effect": { "attack": 2 },           "description": "Gauntlets that channel storm force. +2 attack.", "lore": "Punching with these feels like punching lightning." },
+    { "id": "aug-storm-greaves",     "name": "Storm Greaves",     "rarity": "uncommon",  "setName": "Storm",    "slot": "legs",         "effect": { "moveSpeed": 10 },       "description": "Greaves propelled by air pressure. +10 speed.", "lore": "The wearer leaves small tornadoes in their wake." },
+    { "id": "aug-storm-amulet",      "name": "Storm Amulet",      "rarity": "uncommon",  "setName": "Storm",    "slot": "amulet",       "effect": { "maxHp": 4, "attack": 2 }, "description": "Amulet containing a bottled hurricane. +4 HP, +2 attack.", "lore": "Listen closely and hear the howling inside." },
+    { "id": "aug-storm-bow",         "name": "Storm Bow",         "rarity": "uncommon",  "setName": "Storm",    "slot": "primaryRanged","effect": { "attackRange": 10 },     "description": "Bow riding gale-force winds. +10 attack range.", "lore": "Arrows from this bow have been found three towns over." },
+    { "id": "aug-storm-hammer",      "name": "Storm Hammer",      "rarity": "uncommon",  "setName": "Storm",    "slot": "heavyMelee",   "effect": { "attack": 4 },           "description": "Hammer that brings thunder with every swing. +4 attack.", "lore": "You can hear the boom before impact." },
+
+    { "id": "aug-crimson-helm",      "name": "Crimson Helm",      "rarity": "uncommon",  "setName": "Crimson",  "slot": "helmet",       "effect": { "maxHp": 6 },            "description": "Helm stained with battlefield victory. +6 HP.", "lore": "The red never washes out." },
+    { "id": "aug-crimson-plate",     "name": "Crimson Plate",     "rarity": "uncommon",  "setName": "Crimson",  "slot": "chest",        "effect": { "maxHp": 10 },           "description": "Deep crimson plate for veterans. +10 HP.", "lore": "Earned not bought. Each dent tells a story." },
+    { "id": "aug-crimson-gauntlets", "name": "Crimson Gauntlets", "rarity": "uncommon",  "setName": "Crimson",  "slot": "arms",         "effect": { "attack": 2 },           "description": "Gauntlets soaked in battle fervour. +2 attack.", "lore": "The knuckles have seen a thousand faces." },
+    { "id": "aug-crimson-cuisses",   "name": "Crimson Cuisses",   "rarity": "uncommon",  "setName": "Crimson",  "slot": "legs",         "effect": { "moveSpeed": 10 },       "description": "Cuisses that drive the wearer forward. +10 speed.", "lore": "Retreat is not in their vocabulary." },
+    { "id": "aug-crimson-token",     "name": "Crimson Token",     "rarity": "uncommon",  "setName": "Crimson",  "slot": "amulet",       "effect": { "maxHp": 4, "attack": 2 }, "description": "Blood-red token of a warrior's pact. +4 HP, +2 attack.", "lore": "An oath sworn in crimson cannot be broken." },
+    { "id": "aug-crimson-crossbow",  "name": "Crimson Crossbow",  "rarity": "uncommon",  "setName": "Crimson",  "slot": "primaryRanged","effect": { "attackRange": 10 },     "description": "Crossbow with a crimson stock. +10 attack range.", "lore": "The red sight never misses the mark." },
+    { "id": "aug-crimson-cleaver",   "name": "Crimson Cleaver",   "rarity": "uncommon",  "setName": "Crimson",  "slot": "heavyMelee",   "effect": { "attack": 4 },           "description": "Cleaver that grows sharper with each use. +4 attack.", "lore": "It has never been sharpened — only used." },
+
+    { "id": "aug-obsidian-helm",     "name": "Obsidian Helm",     "rarity": "uncommon",  "setName": "Obsidian", "slot": "helmet",       "effect": { "maxHp": 6 },            "description": "Helm of volcanic glass. +6 HP.", "lore": "Harder than steel, lighter than iron." },
+    { "id": "aug-obsidian-cuirass",  "name": "Obsidian Cuirass",  "rarity": "uncommon",  "setName": "Obsidian", "slot": "chest",        "effect": { "maxHp": 10 },           "description": "Cuirass of layered obsidian plates. +10 HP.", "lore": "The volcano it came from has been silent since." },
+    { "id": "aug-obsidian-bracers",  "name": "Obsidian Bracers",  "rarity": "uncommon",  "setName": "Obsidian", "slot": "arms",         "effect": { "attack": 2 },           "description": "Bracers that cut on impact. +2 attack.", "lore": "Obsidian edges are sharper than any forged blade." },
+    { "id": "aug-obsidian-greaves",  "name": "Obsidian Greaves",  "rarity": "uncommon",  "setName": "Obsidian", "slot": "legs",         "effect": { "moveSpeed": 10 },       "description": "Greaves smoothed to near frictionlessness. +10 speed.", "lore": "The surface reflects the sky perfectly." },
+    { "id": "aug-obsidian-shard",    "name": "Obsidian Shard",    "rarity": "uncommon",  "setName": "Obsidian", "slot": "amulet",       "effect": { "maxHp": 4, "attack": 2 }, "description": "Shard of a shattered obsidian idol. +4 HP, +2 attack.", "lore": "The idol it belonged to was never identified." },
+    { "id": "aug-obsidian-sling",    "name": "Obsidian Sling",    "rarity": "uncommon",  "setName": "Obsidian", "slot": "primaryRanged","effect": { "attackRange": 10 },     "description": "Sling that hurls razor-edged chips. +10 attack range.", "lore": "The projectiles shatter on impact for bonus damage." },
+    { "id": "aug-obsidian-blade",    "name": "Obsidian Blade",    "rarity": "uncommon",  "setName": "Obsidian", "slot": "heavyMelee",   "effect": { "attack": 4 },           "description": "Blade of pure volcanic glass. +4 attack.", "lore": "The sharpest natural edge ever found." },
+
+    { "id": "aug-aurora-crown",      "name": "Aurora Crown",      "rarity": "uncommon",  "setName": "Aurora",   "slot": "helmet",       "effect": { "maxHp": 6 },            "description": "Crown that shimmers with aurora light. +6 HP.", "lore": "The colours shift with the wearer's mood." },
+    { "id": "aug-aurora-vestment",   "name": "Aurora Vestment",   "rarity": "uncommon",  "setName": "Aurora",   "slot": "chest",        "effect": { "maxHp": 10 },           "description": "Vestment woven from captured northern light. +10 HP.", "lore": "In total darkness it still shimmers faintly." },
+    { "id": "aug-aurora-gloves",     "name": "Aurora Gloves",     "rarity": "uncommon",  "setName": "Aurora",   "slot": "arms",         "effect": { "attack": 2 },           "description": "Gloves that channel magical aurora energy. +2 attack.", "lore": "Spells cast with these glow in three colours." },
+    { "id": "aug-aurora-boots",      "name": "Aurora Boots",      "rarity": "uncommon",  "setName": "Aurora",   "slot": "legs",         "effect": { "moveSpeed": 10 },       "description": "Boots blessed by the northern lights. +10 speed.", "lore": "The wearer leaves fading aurora trails." },
+    { "id": "aug-aurora-jewel",      "name": "Aurora Jewel",      "rarity": "uncommon",  "setName": "Aurora",   "slot": "amulet",       "effect": { "maxHp": 4, "attack": 2 }, "description": "Jewel capturing a frozen aurora. +4 HP, +2 attack.", "lore": "The light inside moves on its own." },
+    { "id": "aug-aurora-wand",       "name": "Aurora Wand",       "rarity": "uncommon",  "setName": "Aurora",   "slot": "primaryRanged","effect": { "attackRange": 10 },     "description": "Wand firing arcing beams of colour. +10 attack range.", "lore": "Even enemies pause to admire the shot." },
+    { "id": "aug-aurora-sword",      "name": "Aurora Sword",      "rarity": "uncommon",  "setName": "Aurora",   "slot": "heavyMelee",   "effect": { "attack": 4 },           "description": "Sword shimmering with prismatic energy. +4 attack.", "lore": "A blade that inspires and intimidates in equal measure." },
+
+    { "id": "aug-venom-mask",        "name": "Venom Mask",        "rarity": "rare",      "setName": "Venom",    "slot": "helmet",       "effect": { "maxHp": 12 },           "description": "Mask soaked in potent venom. +12 HP.", "lore": "The wearer grows immune to most poisons — eventually." },
+    { "id": "aug-venom-mantle",      "name": "Venom Mantle",      "rarity": "rare",      "setName": "Venom",    "slot": "chest",        "effect": { "maxHp": 18 },           "description": "Mantle secreting a toxic aura. +18 HP.", "lore": "Insects avoid a three-metre radius around it." },
+    { "id": "aug-venom-gauntlets",   "name": "Venom Gauntlets",   "rarity": "rare",      "setName": "Venom",    "slot": "arms",         "effect": { "attack": 3 },           "description": "Gauntlets coating strikes in toxin. +3 attack.", "lore": "The outer layer never fully dries." },
+    { "id": "aug-venom-leggings",    "name": "Venom Leggings",    "rarity": "rare",      "setName": "Venom",    "slot": "legs",         "effect": { "moveSpeed": 15 },       "description": "Leggings infused with serpent essence. +15 speed.", "lore": "Strikes with the speed of a viper." },
+    { "id": "aug-venom-fang",        "name": "Venom Fang",        "rarity": "rare",      "setName": "Venom",    "slot": "amulet",       "effect": { "maxHp": 8, "attack": 3 }, "description": "Fang of the great serpent. +8 HP, +3 attack.", "lore": "The serpent it came from isn't looking for it." },
+    { "id": "aug-venom-blowgun",     "name": "Venom Blowgun",     "rarity": "rare",      "setName": "Venom",    "slot": "primaryRanged","effect": { "attackRange": 20 },     "description": "Blowgun firing envenomed darts. +20 attack range.", "lore": "Silent, accurate, and deeply unpleasant." },
+    { "id": "aug-venom-blade",       "name": "Venom Blade",       "rarity": "rare",      "setName": "Venom",    "slot": "heavyMelee",   "effect": { "attack": 7 },           "description": "Blade with a venom-filled fuller. +7 attack.", "lore": "Even a scratch is enough." },
+
+    { "id": "aug-tide-helm",         "name": "Tide Helm",         "rarity": "rare",      "setName": "Tide",     "slot": "helmet",       "effect": { "maxHp": 12 },           "description": "Helm from the deep ocean floor. +12 HP.", "lore": "Salt crystals form on the visor after every fight." },
+    { "id": "aug-tide-scale",        "name": "Tide Scale",        "rarity": "rare",      "setName": "Tide",     "slot": "chest",        "effect": { "maxHp": 18 },           "description": "Scale armour from a tide leviathan. +18 HP.", "lore": "Repairs itself overnight in seawater." },
+    { "id": "aug-tide-bracers",      "name": "Tide Bracers",      "rarity": "rare",      "setName": "Tide",     "slot": "arms",         "effect": { "attack": 3 },           "description": "Bracers with crushing tidal force. +3 attack.", "lore": "Designed to break hull-plating barehanded." },
+    { "id": "aug-tide-fins",         "name": "Tide Fins",         "rarity": "rare",      "setName": "Tide",     "slot": "legs",         "effect": { "moveSpeed": 15 },       "description": "Fins that work on land and sea. +15 speed.", "lore": "Strangely effective on solid ground." },
+    { "id": "aug-tide-pearl",        "name": "Tide Pearl",        "rarity": "rare",      "setName": "Tide",     "slot": "amulet",       "effect": { "maxHp": 8, "attack": 3 }, "description": "Perfect pearl from the world's deepest oyster. +8 HP, +3 attack.", "lore": "The oyster was reportedly the size of a boat." },
+    { "id": "aug-tide-rod",          "name": "Tide Rod",          "rarity": "rare",      "setName": "Tide",     "slot": "primaryRanged","effect": { "attackRange": 20 },     "description": "Rod conducting water pressure waves. +20 attack range.", "lore": "The impact feels like standing in a riptide." },
+    { "id": "aug-tide-trident",      "name": "Tide Trident",      "rarity": "rare",      "setName": "Tide",     "slot": "heavyMelee",   "effect": { "attack": 7 },           "description": "Trident channelling the ocean's wrath. +7 attack.", "lore": "Three prongs, three promises of pain." },
+
+    { "id": "aug-ash-hood",          "name": "Ash Hood",          "rarity": "rare",      "setName": "Ash",      "slot": "helmet",       "effect": { "maxHp": 12 },           "description": "Hood from the aftermath of a great fire. +12 HP.", "lore": "It cannot burn. It already has." },
+    { "id": "aug-ash-cloak",         "name": "Ash Cloak",         "rarity": "rare",      "setName": "Ash",      "slot": "chest",        "effect": { "maxHp": 18 },           "description": "Cloak woven from compressed ash. +18 HP.", "lore": "Impossibly light yet absurdly durable." },
+    { "id": "aug-ash-wraps",         "name": "Ash Wraps",         "rarity": "rare",      "setName": "Ash",      "slot": "arms",         "effect": { "attack": 3 },           "description": "Wraps binding ember-hot knuckles. +3 attack.", "lore": "Each fight leaves fresh scorch marks on the canvas." },
+    { "id": "aug-ash-treads",        "name": "Ash Treads",        "rarity": "rare",      "setName": "Ash",      "slot": "legs",         "effect": { "moveSpeed": 15 },       "description": "Treads leaving ash prints at speed. +15 speed.", "lore": "After the fire, only the fastest survived." },
+    { "id": "aug-ash-cinder",        "name": "Ash Cinder",        "rarity": "rare",      "setName": "Ash",      "slot": "amulet",       "effect": { "maxHp": 8, "attack": 3 }, "description": "Cinder from the last great pyre. +8 HP, +3 attack.", "lore": "It still radiates warmth after centuries." },
+    { "id": "aug-ash-bow",           "name": "Ash Bow",           "rarity": "rare",      "setName": "Ash",      "slot": "primaryRanged","effect": { "attackRange": 20 },     "description": "Bow that fires smouldering arrows. +20 attack range.", "lore": "The trail of smoke makes it easy to dodge — by then it's too late." },
+    { "id": "aug-ash-sword",         "name": "Ash Sword",         "rarity": "rare",      "setName": "Ash",      "slot": "heavyMelee",   "effect": { "attack": 7 },           "description": "Sword reforged from the ashes of another. +7 attack.", "lore": "Destroyed twice. Improved each time." },
+
+    { "id": "aug-steel-helm",        "name": "Steel Helm",        "rarity": "rare",      "setName": "Steel",    "slot": "helmet",       "effect": { "maxHp": 12 },           "description": "Premium steel helm, perfected over centuries. +12 HP.", "lore": "The metallurgist took thirty years to get the alloy right." },
+    { "id": "aug-steel-plate",       "name": "Steel Plate",       "rarity": "rare",      "setName": "Steel",    "slot": "chest",        "effect": { "maxHp": 18 },           "description": "Steel plate of impeccable quality. +18 HP.", "lore": "Arrowheads shatter against it like pottery." },
+    { "id": "aug-steel-gauntlets",   "name": "Steel Gauntlets",   "rarity": "rare",      "setName": "Steel",    "slot": "arms",         "effect": { "attack": 3 },           "description": "Steel gauntlets with reinforced knuckles. +3 attack.", "lore": "The fingerprints of a hundred previous owners remain." },
+    { "id": "aug-steel-greaves",     "name": "Steel Greaves",     "rarity": "rare",      "setName": "Steel",    "slot": "legs",         "effect": { "moveSpeed": 15 },       "description": "Steel greaves with spring-loaded joints. +15 speed.", "lore": "Engineering marvel. The inventor went mad trying to explain it." },
+    { "id": "aug-steel-sigil",       "name": "Steel Sigil",       "rarity": "rare",      "setName": "Steel",    "slot": "amulet",       "effect": { "maxHp": 8, "attack": 3 }, "description": "Sigil stamped from refined steel. +8 HP, +3 attack.", "lore": "The mark of the Iron Guild, earned never given." },
+    { "id": "aug-steel-crossbow",    "name": "Steel Crossbow",    "rarity": "rare",      "setName": "Steel",    "slot": "primaryRanged","effect": { "attackRange": 20 },     "description": "Precision steel crossbow. +20 attack range.", "lore": "Competition winning at three hundred paces." },
+    { "id": "aug-steel-maul",        "name": "Steel Maul",        "rarity": "rare",      "setName": "Steel",    "slot": "heavyMelee",   "effect": { "attack": 7 },           "description": "Steel maul of staggering weight. +7 attack.", "lore": "Most warriors can't lift it. The rest become champions." },
+
+    { "id": "aug-midnight-cowl",     "name": "Midnight Cowl",     "rarity": "rare",      "setName": "Midnight", "slot": "helmet",       "effect": { "maxHp": 12 },           "description": "Cowl as dark as a moonless night. +12 HP.", "lore": "The wearer's eyes are the only visible thing in the dark." },
+    { "id": "aug-midnight-shroud",   "name": "Midnight Shroud",   "rarity": "rare",      "setName": "Midnight", "slot": "chest",        "effect": { "maxHp": 18 },           "description": "Shroud that absorbs moonlight into HP. +18 HP.", "lore": "Thickest at midnight. Lightest at noon." },
+    { "id": "aug-midnight-wraps",    "name": "Midnight Wraps",    "rarity": "rare",      "setName": "Midnight", "slot": "arms",         "effect": { "attack": 3 },           "description": "Wraps saturated with the strength of darkness. +3 attack.", "lore": "Everything is weaker at midnight except these." },
+    { "id": "aug-midnight-boots",    "name": "Midnight Boots",    "rarity": "rare",      "setName": "Midnight", "slot": "legs",         "effect": { "moveSpeed": 15 },       "description": "Boots swift as a shadow at midnight. +15 speed.", "lore": "They don't make a sound, no matter the surface." },
+    { "id": "aug-midnight-stone",    "name": "Midnight Stone",    "rarity": "rare",      "setName": "Midnight", "slot": "amulet",       "effect": { "maxHp": 8, "attack": 3 }, "description": "Stone that glows at the darkest hour. +8 HP, +3 attack.", "lore": "Found at midnight, glowing alone in a frozen field." },
+    { "id": "aug-midnight-bow",      "name": "Midnight Bow",      "rarity": "rare",      "setName": "Midnight", "slot": "primaryRanged","effect": { "attackRange": 20 },     "description": "Bow that fires in perfect silence. +20 attack range.", "lore": "The string makes no sound. Neither does the enemy after." },
+    { "id": "aug-midnight-dagger",   "name": "Midnight Dagger",   "rarity": "rare",      "setName": "Midnight", "slot": "heavyMelee",   "effect": { "attack": 7 },           "description": "Dagger sharp enough to cut the dark. +7 attack.", "lore": "Invisible until it's too late." },
+
+    { "id": "aug-dragon-helm",       "name": "Dragon Helm",       "rarity": "epic",      "setName": "Dragon",   "slot": "helmet",       "effect": { "maxHp": 20 },           "description": "Helm fashioned from a dragon's skull. +20 HP.", "lore": "The dragon lost, but not by much." },
+    { "id": "aug-dragon-scale",      "name": "Dragon Scale",      "rarity": "epic",      "setName": "Dragon",   "slot": "chest",        "effect": { "maxHp": 30 },           "description": "Breastplate from a great wyrm's hide. +30 HP.", "lore": "It still smells faintly of brimstone." },
+    { "id": "aug-dragon-claws",      "name": "Dragon Claws",      "rarity": "epic",      "setName": "Dragon",   "slot": "arms",         "effect": { "attack": 5 },           "description": "Gauntlets with grafted dragon claws. +5 attack.", "lore": "Still sharp a hundred years after harvest." },
+    { "id": "aug-dragon-boots",      "name": "Dragon Boots",      "rarity": "epic",      "setName": "Dragon",   "slot": "legs",         "effect": { "moveSpeed": 20 },       "description": "Boots with dragon-tendon spring. +20 speed.", "lore": "Each step is a near-leap." },
+    { "id": "aug-dragon-heart",      "name": "Dragon Heart",      "rarity": "epic",      "setName": "Dragon",   "slot": "amulet",       "effect": { "maxHp": 15, "attack": 5 }, "description": "Crystallised dragon heart. +15 HP, +5 attack.", "lore": "It pulses with its own rhythm, separate from the wearer's." },
+    { "id": "aug-dragon-fang",       "name": "Dragon Fang",       "rarity": "epic",      "setName": "Dragon",   "slot": "primaryRanged","effect": { "attackRange": 35 },     "description": "Fang used as a projectile launcher. +35 attack range.", "lore": "Dragon breath has range. So does this." },
+    { "id": "aug-dragon-sword",      "name": "Dragon Sword",      "rarity": "epic",      "setName": "Dragon",   "slot": "heavyMelee",   "effect": { "attack": 12 },          "description": "Sword forged in dragonfire. +12 attack.", "lore": "The fire is still in the blade, waiting." },
+
+    { "id": "aug-elder-crown",       "name": "Elder Crown",       "rarity": "epic",      "setName": "Elder",    "slot": "helmet",       "effect": { "maxHp": 20 },           "description": "Crown of the elder council, millennia old. +20 HP.", "lore": "Each ruler adds a gem. It runs out of room every century." },
+    { "id": "aug-elder-vestment",    "name": "Elder Vestment",    "rarity": "epic",      "setName": "Elder",    "slot": "chest",        "effect": { "maxHp": 30 },           "description": "Vestment woven by elder hands. +30 HP.", "lore": "The pattern encodes the history of a civilization." },
+    { "id": "aug-elder-bracers",     "name": "Elder Bracers",     "rarity": "epic",      "setName": "Elder",    "slot": "arms",         "effect": { "attack": 5 },           "description": "Bracers of the elder champions. +5 attack.", "lore": "Worn by warriors who ended wars." },
+    { "id": "aug-elder-sandals",     "name": "Elder Sandals",     "rarity": "epic",      "setName": "Elder",    "slot": "legs",         "effect": { "moveSpeed": 20 },       "description": "Sandals blessing the wearer with elder swiftness. +20 speed.", "lore": "The elder council never hurried. They didn't need to." },
+    { "id": "aug-elder-relic",       "name": "Elder Relic",       "rarity": "epic",      "setName": "Elder",    "slot": "amulet",       "effect": { "maxHp": 15, "attack": 5 }, "description": "Relic of the founding elder. +15 HP, +5 attack.", "lore": "The first elder's name is inscribed inside. It's unpronounceable." },
+    { "id": "aug-elder-staff",       "name": "Elder Staff",       "rarity": "epic",      "setName": "Elder",    "slot": "primaryRanged","effect": { "attackRange": 35 },     "description": "Staff extending the elder's reach through time. +35 attack range.", "lore": "The crystal tip predates the staff itself." },
+    { "id": "aug-elder-blade",       "name": "Elder Blade",       "rarity": "epic",      "setName": "Elder",    "slot": "heavyMelee",   "effect": { "attack": 12 },          "description": "Blade that has outlasted every hand that held it. +12 attack.", "lore": "The blade is older than the kingdom." },
+
+    { "id": "aug-jade-helm",         "name": "Jade Helm",         "rarity": "epic",      "setName": "Jade",     "slot": "helmet",       "effect": { "maxHp": 20 },           "description": "Jade helm carved by temple artisans. +20 HP.", "lore": "The emperor who ordered it never wore it in battle." },
+    { "id": "aug-jade-cuirass",      "name": "Jade Cuirass",      "rarity": "epic",      "setName": "Jade",     "slot": "chest",        "effect": { "maxHp": 30 },           "description": "Jade cuirass polished to perfection. +30 HP.", "lore": "Monks spent forty years on the inlay work." },
+    { "id": "aug-jade-gauntlets",    "name": "Jade Gauntlets",    "rarity": "epic",      "setName": "Jade",     "slot": "arms",         "effect": { "attack": 5 },           "description": "Jade gauntlets channelling earth strength. +5 attack.", "lore": "They ring like a bell when two jade-clad warriors meet." },
+    { "id": "aug-jade-greaves",      "name": "Jade Greaves",      "rarity": "epic",      "setName": "Jade",     "slot": "legs",         "effect": { "moveSpeed": 20 },       "description": "Jade greaves flowing like water. +20 speed.", "lore": "Hard as stone, graceful as water." },
+    { "id": "aug-jade-lotus",        "name": "Jade Lotus",        "rarity": "epic",      "setName": "Jade",     "slot": "amulet",       "effect": { "maxHp": 15, "attack": 5 }, "description": "Jade lotus blossom of ancient provenance. +15 HP, +5 attack.", "lore": "Blooms once per century in the presence of a great warrior." },
+    { "id": "aug-jade-bow",          "name": "Jade Bow",          "rarity": "epic",      "setName": "Jade",     "slot": "primaryRanged","effect": { "attackRange": 35 },     "description": "Jade bow that flexes without cracking. +35 attack range.", "lore": "No one understands how it bends." },
+    { "id": "aug-jade-mace",         "name": "Jade Mace",         "rarity": "epic",      "setName": "Jade",     "slot": "heavyMelee",   "effect": { "attack": 12 },          "description": "Jade mace of the mountain guardian. +12 attack.", "lore": "Its weight shifts depending on the wielder's conviction." },
+
+    { "id": "aug-blood-crown",       "name": "Blood Crown",       "rarity": "epic",      "setName": "Blood",    "slot": "helmet",       "effect": { "maxHp": 20 },           "description": "Crown of the blood sovereign. +20 HP.", "lore": "It was never coronated — it was claimed." },
+    { "id": "aug-blood-plate",       "name": "Blood Plate",       "rarity": "epic",      "setName": "Blood",    "slot": "chest",        "effect": { "maxHp": 30 },           "description": "Plate that feeds on spilled blood. +30 HP.", "lore": "After battle it is heavier than before." },
+    { "id": "aug-blood-gauntlets",   "name": "Blood Gauntlets",   "rarity": "epic",      "setName": "Blood",    "slot": "arms",         "effect": { "attack": 5 },           "description": "Gauntlets soaked in millennia of battle. +5 attack.", "lore": "They have never been cleaned." },
+    { "id": "aug-blood-greaves",     "name": "Blood Greaves",     "rarity": "epic",      "setName": "Blood",    "slot": "legs",         "effect": { "moveSpeed": 20 },       "description": "Greaves that surge in battle heat. +20 speed.", "lore": "Faster when the situation is most desperate." },
+    { "id": "aug-blood-pendant",     "name": "Blood Pendant",     "rarity": "epic",      "setName": "Blood",    "slot": "amulet",       "effect": { "maxHp": 15, "attack": 5 }, "description": "Pendant of the blood covenant. +15 HP, +5 attack.", "lore": "An oath sealed in blood literally." },
+    { "id": "aug-blood-crossbow",    "name": "Blood Crossbow",    "rarity": "epic",      "setName": "Blood",    "slot": "primaryRanged","effect": { "attackRange": 35 },     "description": "Crossbow powered by blood pressure. +35 attack range.", "lore": "Technically a medical device. A lethal one." },
+    { "id": "aug-blood-sword",       "name": "Blood Sword",       "rarity": "epic",      "setName": "Blood",    "slot": "heavyMelee",   "effect": { "attack": 12 },          "description": "Blade that grows sharper with each kill. +12 attack.", "lore": "It has no edge when new. The owner provides one." },
+
+    { "id": "aug-crystal-helm",      "name": "Crystal Helm",      "rarity": "epic",      "setName": "Crystal",  "slot": "helmet",       "effect": { "maxHp": 20 },           "description": "Helm of perfect crystal clarity. +20 HP.", "lore": "You can see through it and into the mind of your foe." },
+    { "id": "aug-crystal-breastplate","name": "Crystal Breastplate","rarity": "epic",    "setName": "Crystal",  "slot": "chest",        "effect": { "maxHp": 30 },           "description": "Breastplate that resonates with magical force. +30 HP.", "lore": "It hums when magic is near." },
+    { "id": "aug-crystal-bracers",   "name": "Crystal Bracers",   "rarity": "epic",      "setName": "Crystal",  "slot": "arms",         "effect": { "attack": 5 },           "description": "Bracers that focus magical energy. +5 attack.", "lore": "The sharp edges are a bonus feature." },
+    { "id": "aug-crystal-boots",     "name": "Crystal Boots",     "rarity": "epic",      "setName": "Crystal",  "slot": "legs",         "effect": { "moveSpeed": 20 },       "description": "Boots that refract light and speed. +20 speed.", "lore": "The wearer leaves a prismatic trail." },
+    { "id": "aug-crystal-shard",     "name": "Crystal Shard",     "rarity": "epic",      "setName": "Crystal",  "slot": "amulet",       "effect": { "maxHp": 15, "attack": 5 }, "description": "Shard of the crystal monolith. +15 HP, +5 attack.", "lore": "The monolith cracked in the last great war. The shards scattered across the world." },
+    { "id": "aug-crystal-wand",      "name": "Crystal Wand",      "rarity": "epic",      "setName": "Crystal",  "slot": "primaryRanged","effect": { "attackRange": 35 },     "description": "Wand amplifying magical range greatly. +35 attack range.", "lore": "Crystal lenses inside multiply the effective distance." },
+    { "id": "aug-crystal-blade",     "name": "Crystal Blade",     "rarity": "epic",      "setName": "Crystal",  "slot": "heavyMelee",   "effect": { "attack": 12 },          "description": "Blade of solid conjured crystal. +12 attack.", "lore": "Grows back if chipped. Takes about a week." },
+
+    { "id": "aug-bone-crown",        "name": "Bone Crown",        "rarity": "legendary", "setName": "Bone",     "slot": "helmet",       "effect": { "maxHp": 35 },           "description": "Crown of the death sovereign. +35 HP.", "lore": "Assembled from warriors who dared to challenge the lich." },
+    { "id": "aug-bone-plate",        "name": "Bone Plate",        "rarity": "legendary", "setName": "Bone",     "slot": "chest",        "effect": { "maxHp": 50 },           "description": "Bone plate — lighter than steel, harder than pride. +50 HP.", "lore": "The bones fused themselves into armour. No one is sure when." },
+    { "id": "aug-bone-gauntlets",    "name": "Bone Gauntlets",    "rarity": "legendary", "setName": "Bone",     "slot": "arms",         "effect": { "attack": 8 },           "description": "Gauntlets of the risen champion. +8 attack.", "lore": "They belonged to someone great. Now they belong to you." },
+    { "id": "aug-bone-greaves",      "name": "Bone Greaves",      "rarity": "legendary", "setName": "Bone",     "slot": "legs",         "effect": { "moveSpeed": 30 },       "description": "Bone greaves of the death runner. +30 speed.", "lore": "Death moves faster than you think." },
+    { "id": "aug-bone-token",        "name": "Bone Token",        "rarity": "legendary", "setName": "Bone",     "slot": "amulet",       "effect": { "maxHp": 25, "attack": 8 }, "description": "Token of the undying pact. +25 HP, +8 attack.", "lore": "The pact predates living memory." },
+    { "id": "aug-bone-bow",          "name": "Bone Bow",          "rarity": "legendary", "setName": "Bone",     "slot": "primaryRanged","effect": { "attackRange": 55 },     "description": "Bone bow that fires at impossible range. +55 attack range.", "lore": "The arrows never stop until they hit something." },
+    { "id": "aug-bone-cleaver",      "name": "Bone Cleaver",      "rarity": "legendary", "setName": "Bone",     "slot": "heavyMelee",   "effect": { "attack": 20 },          "description": "Cleaver that parts armour like paper. +20 attack.", "lore": "Nothing has ever resisted this blade successfully." },
+
+    { "id": "aug-tempest-helm",      "name": "Tempest Helm",      "rarity": "legendary", "setName": "Tempest",  "slot": "helmet",       "effect": { "maxHp": 35 },           "description": "Helm of the storm lord. +35 HP.", "lore": "The visor shows a permanent storm rather than the real sky." },
+    { "id": "aug-tempest-mail",      "name": "Tempest Mail",      "rarity": "legendary", "setName": "Tempest",  "slot": "chest",        "effect": { "maxHp": 50 },           "description": "Mail that deflects tempest forces. +50 HP.", "lore": "Every ring was struck during a hurricane." },
+    { "id": "aug-tempest-gauntlets", "name": "Tempest Gauntlets", "rarity": "legendary", "setName": "Tempest",  "slot": "arms",         "effect": { "attack": 8 },           "description": "Gauntlets charged with tempest force. +8 attack.", "lore": "The wind follows every punch." },
+    { "id": "aug-tempest-greaves",   "name": "Tempest Greaves",   "rarity": "legendary", "setName": "Tempest",  "slot": "legs",         "effect": { "moveSpeed": 30 },       "description": "Greaves riding the tempest wind. +30 speed.", "lore": "The wearer runs faster than the storm itself." },
+    { "id": "aug-tempest-eye",       "name": "Tempest Eye",       "rarity": "legendary", "setName": "Tempest",  "slot": "amulet",       "effect": { "maxHp": 25, "attack": 8 }, "description": "Eye of the storm, captured at its peak. +25 HP, +8 attack.", "lore": "Calm only in the wearer's presence." },
+    { "id": "aug-tempest-bow",       "name": "Tempest Bow",       "rarity": "legendary", "setName": "Tempest",  "slot": "primaryRanged","effect": { "attackRange": 55 },     "description": "Bow that hurls arrows on hurricane winds. +55 attack range.", "lore": "Aim downwind for best results. Or upwind. Results vary." },
+    { "id": "aug-tempest-maul",      "name": "Tempest Maul",      "rarity": "legendary", "setName": "Tempest",  "slot": "heavyMelee",   "effect": { "attack": 20 },          "description": "Maul that makes its own weather on impact. +20 attack.", "lore": "The crater it leaves smokes for a week." },
+
+    { "id": "aug-solar-crown",       "name": "Solar Crown",       "rarity": "legendary", "setName": "Solar",    "slot": "helmet",       "effect": { "maxHp": 35 },           "description": "Crown forged in the sun's corona. +35 HP.", "lore": "Even gods squint to look at it." },
+    { "id": "aug-solar-plate",       "name": "Solar Plate",       "rarity": "legendary", "setName": "Solar",    "slot": "chest",        "effect": { "maxHp": 50 },           "description": "Solar-tempered plate of divine radiance. +50 HP.", "lore": "Blinding to enemies. Warm to the wearer." },
+    { "id": "aug-solar-gauntlets",   "name": "Solar Gauntlets",   "rarity": "legendary", "setName": "Solar",    "slot": "arms",         "effect": { "attack": 8 },           "description": "Gauntlets that strike like sunlight. +8 attack.", "lore": "The impact leaves a sunburst mark." },
+    { "id": "aug-solar-greaves",     "name": "Solar Greaves",     "rarity": "legendary", "setName": "Solar",    "slot": "legs",         "effect": { "moveSpeed": 30 },       "description": "Greaves moving at the speed of light. +30 speed.", "lore": "The wearer's passage is marked by light trails." },
+    { "id": "aug-solar-disc",        "name": "Solar Disc",        "rarity": "legendary", "setName": "Solar",    "slot": "amulet",       "effect": { "maxHp": 25, "attack": 8 }, "description": "Disc containing a fragment of the sun. +25 HP, +8 attack.", "lore": "Do not look directly at the bearer." },
+    { "id": "aug-solar-bow",         "name": "Solar Bow",         "rarity": "legendary", "setName": "Solar",    "slot": "primaryRanged","effect": { "attackRange": 55 },     "description": "Bow firing arrows of pure light. +55 attack range.", "lore": "The arrows are visible from the other side of the world." },
+    { "id": "aug-solar-sword",       "name": "Solar Sword",       "rarity": "legendary", "setName": "Solar",    "slot": "heavyMelee",   "effect": { "attack": 20 },          "description": "Sword that burns with solar fire. +20 attack.", "lore": "It has no handle. Sunbeams hold it in place." },
+
+    { "id": "aug-void-mask",         "name": "Void Mask",         "rarity": "legendary", "setName": "Void",     "slot": "helmet",       "effect": { "maxHp": 35 },           "description": "Mask that absorbs incoming force into the void. +35 HP.", "lore": "Damage becomes nothing. Nothing becomes armour." },
+    { "id": "aug-void-shroud",       "name": "Void Shroud",       "rarity": "legendary", "setName": "Void",     "slot": "chest",        "effect": { "maxHp": 50 },           "description": "Shroud of void matter — absorbs punishment. +50 HP.", "lore": "Scientists argue about whether it actually exists." },
+    { "id": "aug-void-wraps",        "name": "Void Wraps",        "rarity": "legendary", "setName": "Void",     "slot": "arms",         "effect": { "attack": 8 },           "description": "Wraps pulling strength from the void. +8 attack.", "lore": "They punch through dimensions. Literal ones." },
+    { "id": "aug-void-boots",        "name": "Void Boots",        "rarity": "legendary", "setName": "Void",     "slot": "legs",         "effect": { "moveSpeed": 30 },       "description": "Boots stepping through void space. +30 speed.", "lore": "Each step skips a metre of intervening reality." },
+    { "id": "aug-void-gem",          "name": "Void Gem",          "rarity": "legendary", "setName": "Void",     "slot": "amulet",       "effect": { "maxHp": 25, "attack": 8 }, "description": "Gem containing a pinhole to the void. +25 HP, +8 attack.", "lore": "If you look inside it long enough, it looks back." },
+    { "id": "aug-void-sling",        "name": "Void Sling",        "rarity": "legendary", "setName": "Void",     "slot": "primaryRanged","effect": { "attackRange": 55 },     "description": "Sling launching projectiles through void shortcuts. +55 attack range.", "lore": "The stone disappears and reappears at the target." },
+    { "id": "aug-void-blade",        "name": "Void Blade",        "rarity": "legendary", "setName": "Void",     "slot": "heavyMelee",   "effect": { "attack": 20 },          "description": "Blade that exists and doesn't. +20 attack.", "lore": "Armour is irrelevant to something that is simultaneously everywhere and nowhere." },
+
+    { "id": "aug-granite-helm",      "name": "Granite Helm",      "rarity": "legendary", "setName": "Granite",  "slot": "helmet",       "effect": { "maxHp": 35 },           "description": "Helm carved from mountain granite. +35 HP.", "lore": "The mountain it came from collapsed without it." },
+    { "id": "aug-granite-plate",     "name": "Granite Plate",     "rarity": "legendary", "setName": "Granite",  "slot": "chest",        "effect": { "maxHp": 50 },           "description": "Granite plate of the earth's endurance. +50 HP.", "lore": "Geologists weep when they see it used as armour." },
+    { "id": "aug-granite-gauntlets", "name": "Granite Gauntlets", "rarity": "legendary", "setName": "Granite",  "slot": "arms",         "effect": { "attack": 8 },           "description": "Gauntlets of sheer geological force. +8 attack.", "lore": "Impact craters are a common result." },
+    { "id": "aug-granite-boots",     "name": "Granite Boots",     "rarity": "legendary", "setName": "Granite",  "slot": "legs",         "effect": { "moveSpeed": 30 },       "description": "Granite boots with inexplicable spring. +30 speed.", "lore": "The wearer should not be this fast. Yet here we are." },
+    { "id": "aug-granite-talisman",  "name": "Granite Talisman",  "rarity": "legendary", "setName": "Granite",  "slot": "amulet",       "effect": { "maxHp": 25, "attack": 8 }, "description": "Talisman of the mountain spirit. +25 HP, +8 attack.", "lore": "The mountain spirit gave this up reluctantly." },
+    { "id": "aug-granite-crossbow",  "name": "Granite Crossbow",  "rarity": "legendary", "setName": "Granite",  "slot": "primaryRanged","effect": { "attackRange": 55 },     "description": "Crossbow that fires granite bolts at ludicrous range. +55 attack range.", "lore": "Loading it requires a small crane." },
+    { "id": "aug-granite-maul",      "name": "Granite Maul",      "rarity": "legendary", "setName": "Granite",  "slot": "heavyMelee",   "effect": { "attack": 20 },          "description": "Maul as heavy as a mountain. +20 attack.", "lore": "The impact registers on seismographs." }
+  ]
+}

--- a/web/src/game/augments.ts
+++ b/web/src/game/augments.ts
@@ -1,0 +1,114 @@
+import { AugmentEffect, AugmentSlot, Card, CardRarity } from './types'
+import augmentsData from '../data/augments.json'
+
+// ─── Raw JSON types ───────────────────────────────────────
+
+interface RawAugmentCard {
+  id: string
+  name: string
+  rarity: string
+  setName: string
+  slot: string
+  effect: { attack?: number; attackRange?: number; maxHp?: number; moveSpeed?: number }
+  description: string
+  lore: string
+}
+
+interface RawAugmentSet {
+  name: string
+  rarity: string
+  setBonusDescription: string
+  setBonus: { attack?: number; attackRange?: number; maxHp?: number; moveSpeed?: number }
+}
+
+// ─── Public types ─────────────────────────────────────────
+
+export interface AugmentSetDef {
+  name: string
+  rarity: CardRarity
+  setBonusDescription: string
+  setBonus: AugmentEffect
+}
+
+// ─── Parsed data ──────────────────────────────────────────
+
+const _sets: AugmentSetDef[] = (augmentsData.sets as RawAugmentSet[]).map(s => ({
+  name: s.name,
+  rarity: s.rarity as CardRarity,
+  setBonusDescription: s.setBonusDescription,
+  setBonus: s.setBonus as AugmentEffect,
+}))
+
+const SET_MAP = new Map<string, AugmentSetDef>(_sets.map(s => [s.name, s]))
+
+const _cards: Card[] = (augmentsData.cards as RawAugmentCard[]).map(raw => ({
+  id: raw.id,
+  name: raw.name,
+  rarity: raw.rarity as CardRarity,
+  cost: 0,
+  cardType: 'augment' as const,
+  description: raw.description,
+  lore: raw.lore,
+  augmentSlot: raw.slot as AugmentSlot,
+  augmentEffect: raw.effect as AugmentEffect,
+  setName: raw.setName,
+}))
+
+const AUGMENT_MAP = new Map<string, Card>(_cards.map(c => [c.name, c]))
+
+// ─── Public API ───────────────────────────────────────────
+
+/** All augment card definitions (one per type). */
+export function getAugmentCatalog(): Card[] {
+  return _cards
+}
+
+/** Look up a single augment card by name. */
+export function getAugmentCard(name: string): Card | undefined {
+  return AUGMENT_MAP.get(name)
+}
+
+/** All 25 set definitions. */
+export function getAllAugmentSets(): AugmentSetDef[] {
+  return _sets
+}
+
+/** Look up a set definition by name, or undefined if not found. */
+export function getAugmentSetDef(setName: string): AugmentSetDef | undefined {
+  return SET_MAP.get(setName)
+}
+
+/** Compute scaled effect for a given augment at a given level.
+ *  Each level adds 20% of the base effect: effectValue * (1 + 0.2 * level). */
+export function scaledAugmentEffect(baseEffect: AugmentEffect, level: number): AugmentEffect {
+  const mult = 1 + 0.2 * level
+  return {
+    attack:      baseEffect.attack      != null ? Math.round(baseEffect.attack      * mult) : undefined,
+    attackRange: baseEffect.attackRange != null ? Math.round(baseEffect.attackRange * mult) : undefined,
+    maxHp:       baseEffect.maxHp       != null ? Math.round(baseEffect.maxHp       * mult) : undefined,
+    moveSpeed:   baseEffect.moveSpeed   != null ? Math.round(baseEffect.moveSpeed   * mult) : undefined,
+  }
+}
+
+/** Human-readable label for a slot type. */
+export function augmentSlotLabel(slot: AugmentSlot): string {
+  const labels: Record<AugmentSlot, string> = {
+    helmet:       'Helmet',
+    chest:        'Chest',
+    arms:         'Arms',
+    legs:         'Legs',
+    amulet:       'Amulet',
+    primaryRanged:'Ranged Weapon',
+    heavyMelee:   'Melee Weapon',
+  }
+  return labels[slot]
+}
+
+/** Slot category — 'weapon' or 'armour'. */
+export function augmentSlotCategory(slot: AugmentSlot): 'weapon' | 'armour' {
+  return slot === 'primaryRanged' || slot === 'heavyMelee' ? 'weapon' : 'armour'
+}
+
+export const ALL_AUGMENT_SLOTS: AugmentSlot[] = [
+  'helmet', 'chest', 'arms', 'legs', 'amulet', 'primaryRanged', 'heavyMelee',
+]

--- a/web/src/game/collection.ts
+++ b/web/src/game/collection.ts
@@ -1,5 +1,6 @@
-import { Card, CardRarity } from './types'
+import { AugmentEffect, AugmentInstance, Card, CardRarity } from './types'
 import { getCardCatalog } from './cards'
+import { getAugmentCard, getAugmentSetDef, scaledAugmentEffect, ALL_AUGMENT_SLOTS } from './augments'
 import { logError } from '../logger'
 import { validateIntegrity, updateChecksum } from './integrity'
 
@@ -80,6 +81,10 @@ const WIN_STREAK_KEY      = 'jarv_win_streak'
 const BEST_STREAK_KEY     = 'jarv_best_streak'
 const TOTAL_WINS_KEY      = 'jarv_total_wins'
 const SAVED_DECKS_KEY     = 'jarv_saved_decks'
+const AUGMENT_INSTANCES_KEY = 'jarv_augment_instances'
+const AUGMENT_SOULS_KEY     = 'jarv_augment_souls'
+
+export const AUGMENT_UPGRADE_COST = 500   // augment souls per upgrade
 
 export const DECK_MIN  = 10
 export const DECK_MAX  = 30
@@ -218,6 +223,135 @@ export function loadCrystals(): number {
 export function saveCrystals(n: number): void {
   try { localStorage.setItem(CRYSTALS_KEY, String(Math.max(0, n))) }
   catch (e) { logError('saveCrystals failed', { error: String(e) }) }
+}
+
+// ─── Augment Souls ────────────────────────────────────────
+
+export function loadAugmentSouls(): number {
+  try {
+    const v = localStorage.getItem(AUGMENT_SOULS_KEY)
+    if (v !== null) return Math.max(0, parseInt(v, 10) || 0)
+  } catch { /* ignore */ }
+  return 0
+}
+
+export function saveAugmentSouls(n: number): void {
+  try { localStorage.setItem(AUGMENT_SOULS_KEY, String(Math.max(0, n))) }
+  catch (e) { logError('saveAugmentSouls failed', { error: String(e) }) }
+}
+
+/** Add `n` augment souls to the persistent total. Call at end of battle/TD session. */
+export function incrementAugmentSouls(n: number): void {
+  if (n <= 0) return
+  saveAugmentSouls(loadAugmentSouls() + n)
+}
+
+// ─── Augment Instances ────────────────────────────────────
+
+export function loadAugmentInstances(): AugmentInstance[] {
+  try {
+    const raw = localStorage.getItem(AUGMENT_INSTANCES_KEY)
+    if (raw) return JSON.parse(raw) as AugmentInstance[]
+  } catch { /* ignore */ }
+  return []
+}
+
+export function saveAugmentInstances(instances: AugmentInstance[]): void {
+  try { localStorage.setItem(AUGMENT_INSTANCES_KEY, JSON.stringify(instances)) }
+  catch (e) { logError('saveAugmentInstances failed', { error: String(e) }) }
+}
+
+let _augInstanceCounter = Date.now()
+
+/** Create and persist a new augment instance for the given augment card name. */
+export function addAugmentInstance(cardId: string): AugmentInstance {
+  const instance: AugmentInstance = {
+    instanceId: `aug-inst-${++_augInstanceCounter}`,
+    cardId,
+    level: 0,
+    equippedToCardName: null,
+  }
+  const instances = loadAugmentInstances()
+  instances.push(instance)
+  saveAugmentInstances(instances)
+  return instance
+}
+
+/** Return all augment instances equipped to the given unit card name, keyed by slot. */
+export function getEquippedAugments(cardName: string): Record<string, AugmentInstance> {
+  const instances = loadAugmentInstances()
+  const result: Record<string, AugmentInstance> = {}
+  for (const inst of instances) {
+    if (inst.equippedToCardName !== cardName) continue
+    const card = getAugmentCard(inst.cardId)
+    if (!card?.augmentSlot) continue
+    result[card.augmentSlot] = inst
+  }
+  return result
+}
+
+/** Equip an augment instance to a unit card name. A slot can only hold one instance at a time. */
+export function equipAugment(instanceId: string, cardName: string): void {
+  const instances = loadAugmentInstances()
+  const target = instances.find(i => i.instanceId === instanceId)
+  if (!target) return
+  const card = getAugmentCard(target.cardId)
+  if (!card?.augmentSlot) return
+
+  // Unequip any existing instance in the same slot on the same card
+  for (const inst of instances) {
+    if (inst.equippedToCardName !== cardName) continue
+    const iCard = getAugmentCard(inst.cardId)
+    if (iCard?.augmentSlot === card.augmentSlot) inst.equippedToCardName = null
+  }
+
+  target.equippedToCardName = cardName
+  saveAugmentInstances(instances)
+}
+
+/** Unequip an augment instance from whichever unit it is on. */
+export function unequipAugment(instanceId: string): void {
+  const instances = loadAugmentInstances()
+  const target = instances.find(i => i.instanceId === instanceId)
+  if (!target) return
+  target.equippedToCardName = null
+  saveAugmentInstances(instances)
+}
+
+/** Upgrade an augment instance by 1 level. Costs AUGMENT_UPGRADE_COST souls.
+ *  Returns null on success, or an error string if insufficient souls. */
+export function upgradeAugment(instanceId: string): string | null {
+  const souls = loadAugmentSouls()
+  if (souls < AUGMENT_UPGRADE_COST) {
+    return `Not enough souls (need ${AUGMENT_UPGRADE_COST}, have ${souls})`
+  }
+  const instances = loadAugmentInstances()
+  const target = instances.find(i => i.instanceId === instanceId)
+  if (!target) return 'Augment not found'
+  target.level += 1
+  saveAugmentInstances(instances)
+  saveAugmentSouls(souls - AUGMENT_UPGRADE_COST)
+  return null
+}
+
+/** Return the set bonus effect if all 7 slots of the same set are equipped to the given unit.
+ *  Returns undefined if the set is incomplete. */
+export function getSetBonus(cardName: string): { setName: string; effect: AugmentEffect; description: string } | undefined {
+  const instances = loadAugmentInstances()
+  const equipped = instances.filter(i => i.equippedToCardName === cardName)
+  if (equipped.length < ALL_AUGMENT_SLOTS.length) return undefined
+
+  // Collect set names for all equipped instances
+  const setNames = equipped.map(i => getAugmentCard(i.cardId)?.setName).filter(Boolean) as string[]
+  if (setNames.length < ALL_AUGMENT_SLOTS.length) return undefined
+
+  // All must belong to the same set
+  const first = setNames[0]
+  if (!setNames.every(s => s === first)) return undefined
+
+  const def = getAugmentSetDef(first)
+  if (!def) return undefined
+  return { setName: first, effect: def.setBonus, description: def.setBonusDescription }
 }
 
 // ─── Mastery math ─────────────────────────────────────────
@@ -556,11 +690,58 @@ export function buildDeckCards(entries: DeckEntry[], collection?: CollectionEntr
     const withLevel: Card = withSpawnMastery.unit
       ? { ...withSpawnMastery, unit: { ...withSpawnMastery.unit, masteryLevel: lvl } }
       : withSpawnMastery
+
+    // Apply augment bonuses (only for unit cards with a unit template)
+    const withAugments = applyAugmentBonuses(withLevel, entry.cardName)
+
     for (let i = 0; i < entry.count; i++) {
-      result.push({ ...withLevel, id: `deck-${entry.cardName}-${++_deckCardId}` })
+      result.push({ ...withAugments, id: `deck-${entry.cardName}-${++_deckCardId}` })
     }
   }
   return result
+}
+
+function applyAugmentBonuses(card: Card, cardName: string): Card {
+  if (!card.unit || card.unit.moveSpeed === 0) return card   // structures don't get augments
+  const equipped = getEquippedAugments(cardName)
+  const slotKeys = Object.keys(equipped)
+  if (slotKeys.length === 0) return card
+
+  const u = { ...card.unit }
+  let totalEffect: AugmentEffect = {}
+
+  for (const instanceId of Object.values(equipped)) {
+    const augCard = getAugmentCard(instanceId.cardId)
+    if (!augCard?.augmentEffect) continue
+    const scaled = scaledAugmentEffect(augCard.augmentEffect, instanceId.level)
+    totalEffect = mergeAugmentEffects(totalEffect, scaled)
+  }
+
+  // Apply set bonus if all 7 slots are filled with the same set
+  const setBonus = getSetBonus(cardName)
+  if (setBonus) {
+    totalEffect = mergeAugmentEffects(totalEffect, setBonus.effect)
+  }
+
+  if (totalEffect.attack      != null) u.attack      = Math.max(0, u.attack      + totalEffect.attack)
+  if (totalEffect.attackRange != null) u.attackRange = Math.max(0, u.attackRange + totalEffect.attackRange)
+  if (totalEffect.maxHp       != null) u.maxHp       = Math.max(1, u.maxHp       + totalEffect.maxHp)
+  if (totalEffect.moveSpeed   != null) u.moveSpeed   = Math.max(1, u.moveSpeed   + totalEffect.moveSpeed)
+
+  return { ...card, unit: u }
+}
+
+function mergeAugmentEffects(a: AugmentEffect, b: AugmentEffect): AugmentEffect {
+  const sum = (x: number | undefined, y: number | undefined): number | undefined => {
+    const total = (x ?? 0) + (y ?? 0)
+    return total !== 0 ? total : undefined
+  }
+  return {
+    attack:      sum(a.attack,      b.attack),
+    attackRange: sum(a.attackRange, b.attackRange),
+    maxHp:       sum(a.maxHp,       b.maxHp),
+    moveSpeed:   sum(a.moveSpeed,   b.moveSpeed),
+  }
 }
 
 // ─── Pack Generation ──────────────────────────────────────

--- a/web/src/game/towerDefence.ts
+++ b/web/src/game/towerDefence.ts
@@ -434,6 +434,7 @@ export interface TDGameState {
   mode: 'collection' | 'city'
   passives: TDPassives
   milestoneChoices: MilestoneUpgrade[] | null
+  enemyKills: number   // total enemies killed this session (for augment souls)
 }
 
 // ── Constants ─────────────────────────────────────────────────────────────────
@@ -682,6 +683,7 @@ export function createTDGame(
     mode,
     passives: { attackSpeedMult: 1, rangeBonus: 0, damageMult: 1, respawnMult: 1 },
     milestoneChoices: null,
+    enemyKills: 0,
   }
 }
 
@@ -1068,7 +1070,7 @@ export function tickTD(state: TDGameState, dtMs: number): TDGameState {
                 if (e.id === target.id || deadEnemyIds.has(e.id) || e.hp <= 0) return e
                 if (dist(e.x, e.y, target.x, target.y) > eff.aoeRadius!) return e
                 const splashHp = e.hp - dmg
-                if (splashHp <= 0) { deadEnemyIds.add(e.id); s.score += e.template.reward; s.mana += e.template.reward; towerXpGains[unit.towerId] = (towerXpGains[unit.towerId] ?? 0) + 1 }
+                if (splashHp <= 0) { deadEnemyIds.add(e.id); s.score += e.template.reward; s.mana += e.template.reward; s.enemyKills++; towerXpGains[unit.towerId] = (towerXpGains[unit.towerId] ?? 0) + 1 }
                 return { ...e, hp: Math.max(0, splashHp) }
               })
               // AOE ring visual
@@ -1088,6 +1090,7 @@ export function tickTD(state: TDGameState, dtMs: number): TDGameState {
             deadEnemyIds.add(target.id)
             s.score += target.template.reward
             s.mana += target.template.reward
+            s.enemyKills++
             towerXpGains[unit.towerId] = (towerXpGains[unit.towerId] ?? 0) + 1
           } else {
             s.enemies = s.enemies.map(e => e.id === target.id ? { ...e, hp: newHp } : e)

--- a/web/src/game/types.ts
+++ b/web/src/game/types.ts
@@ -40,7 +40,28 @@ export type UpgradeEffect =
 export type CardRarity = 'common' | 'uncommon' | 'rare' | 'epic' | 'legendary' | 'mythic' | 'shiny' | 'holofoil' | 'glass'
 /** Rarities that are secret — hidden in collections until obtained. */
 export const SECRET_RARITIES: ReadonlySet<CardRarity> = new Set(['mythic', 'shiny', 'holofoil', 'glass'])
-export type CardType = 'unit' | 'structure' | 'upgrade'
+export type CardType = 'unit' | 'structure' | 'upgrade' | 'augment'
+
+// ─── Augment System ───────────────────────────────────────
+
+/** Which equipment slot an augment card occupies. */
+export type AugmentSlot = 'primaryRanged' | 'heavyMelee' | 'helmet' | 'chest' | 'arms' | 'legs' | 'amulet'
+
+/** Flat stat deltas granted by an equipped augment (scaled by upgrade level). */
+export interface AugmentEffect {
+  attack?: number
+  attackRange?: number
+  maxHp?: number
+  moveSpeed?: number
+}
+
+/** One owned copy of an augment card — each instance is independently levelled and equippable. */
+export interface AugmentInstance {
+  instanceId: string
+  cardId: string            // augment card name (e.g. "Thunder Helm")
+  level: number             // 0 = base; each upgrade adds +1
+  equippedToCardName: string | null   // unit card name this is equipped on, or null
+}
 
 export interface UnitTemplate {
   name: string
@@ -277,6 +298,12 @@ export interface Card {
   variant?: 'shiny' | 'holofoil' | 'glass'
   /** Glass cards: probability (0–1) the card shatters when played (unit instantly dies). */
   glassBreakChance?: number
+  /** Augment cards: which equipment slot this occupies. */
+  augmentSlot?: AugmentSlot
+  /** Augment cards: base stat bonuses (scaled by instance level when equipped). */
+  augmentEffect?: AugmentEffect
+  /** Augment cards: which named set this belongs to. */
+  setName?: string
 }
 
 // ─── Boss Trait State ─────────────────────────────────────

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -13563,3 +13563,157 @@ html.light-mode .action-btn {
 .city-expand-lvl   { color: #c0e8a0; font-weight: bold; min-width: 90px; }
 .city-expand-cost  { color: #a0c080; font-size: 10px; flex: 1; }
 .city-expand-status { color: #80b060; font-size: 10px; flex: 1; }
+
+
+/* ── Card Augment Screen ──────────────────────────────────────────────────────── */
+.cas-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.75);
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  z-index: 250;
+  overflow-y: auto;
+  padding: 12px 0;
+}
+.cas-panel {
+  background: var(--game-bg);
+  border: 1px solid var(--game-border);
+  border-radius: 4px;
+  width: min(560px, 98vw);
+  max-height: 95vh;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+}
+.cas-header {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  padding: 10px 12px 8px;
+  border-bottom: 1px solid #222;
+  position: sticky;
+  top: 0;
+  background: var(--game-bg);
+  z-index: 1;
+}
+.cas-name   { font-size: 1.071rem; font-weight: bold; flex: 1; }
+.cas-rarity { font-size: var(--font-xs); letter-spacing: 1px; }
+.cas-body   { padding: 12px; display: flex; flex-direction: column; gap: 12px; }
+.cas-top    { align-items: flex-start; }
+.cas-card-col { flex-shrink: 0; }
+.cas-info-col { min-width: 0; }
+.cas-souls-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  background: rgba(100,50,180,0.15);
+  border-radius: 4px;
+  border: 1px solid rgba(150,80,255,0.3);
+  font-size: 13px;
+}
+.cas-slots-title {
+  font-size: var(--font-xs);
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  color: var(--game-text-color-dim);
+  padding-bottom: 4px;
+  border-bottom: 1px solid #222;
+}
+.cas-slots-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+.cas-slot {
+  border: 1px solid #333;
+  border-radius: 4px;
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-height: 70px;
+}
+.cas-slot--filled {
+  border-color: rgba(150,80,255,0.5);
+  background: rgba(100,50,180,0.08);
+}
+.cas-slot-label { font-size: var(--font-xxs); text-transform: uppercase; letter-spacing: 1px; color: var(--game-text-color-dim); }
+.cas-slot-name  { font-size: var(--font-sm); font-weight: bold; }
+.cas-slot-level { font-size: var(--font-xxs); color: #aaa; }
+.cas-slot-effect { font-size: var(--font-xs); color: #aaddff; }
+.cas-slot-actions { display: flex; gap: 4px; flex-wrap: wrap; margin-top: 4px; }
+.cas-slot-btn { font-size: 11px; padding: 2px 8px; }
+.cas-set-bonus {
+  border: 1px solid #333;
+  border-radius: 4px;
+  padding: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  opacity: 0.5;
+}
+.cas-set-bonus--active { opacity: 1; border-color: #ffcc00; background: rgba(255,200,0,0.06); }
+.cas-set-bonus-name { font-size: var(--font-sm); font-weight: bold; }
+.cas-set-bonus-desc { font-size: var(--font-xs); color: var(--game-text-color-muted); }
+.cas-set-bonus-effect { font-size: var(--font-xs); }
+
+/* ── Augment Picker Modal ─────────────────────────────────────────────────────── */
+.apm-panel {
+  background: var(--game-bg);
+  border: 1px solid var(--game-border);
+  border-radius: 4px;
+  width: min(400px, 96vw);
+  max-height: 80vh;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+}
+.apm-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 12px;
+  border-bottom: 1px solid #222;
+  font-weight: bold;
+}
+.apm-empty { padding: 24px; text-align: center; opacity: 0.6; font-size: var(--font-sm); }
+.apm-list  { display: flex; flex-direction: column; }
+.apm-item  {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  border-bottom: 1px solid #1a1a1a;
+}
+.apm-item--active { background: rgba(100,50,180,0.12); }
+.apm-item-info    { display: flex; flex-direction: column; gap: 2px; flex: 1; min-width: 0; }
+.apm-item-name    { font-size: var(--font-sm); font-weight: bold; }
+.apm-item-actions { flex-shrink: 0; }
+
+/* ── Augment Collection Screen ───────────────────────────────────────────────── */
+.aug-list { display: flex; flex-direction: column; gap: 6px; }
+.aug-list-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border: 1px solid #2a2a2a;
+  border-radius: 4px;
+}
+.aug-list-item-info { display: flex; flex-direction: column; gap: 3px; flex: 1; min-width: 0; }
+.aug-list-name      { font-size: var(--font-sm); font-weight: bold; }
+.aug-list-item-actions { flex-shrink: 0; }
+.aug-equipped-link {
+  background: none;
+  border: none;
+  color: #88bbff;
+  font-size: 11px;
+  cursor: pointer;
+  padding: 0;
+  font-family: inherit;
+  text-align: left;
+  text-decoration: underline;
+}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds full **Card Augments** system: 25 named sets (common → legendary), 7 equippable slots per unit card (2 weapon: `primaryRanged`/`heavyMelee`; 5 armour: `helmet`/`chest`/`arms`/`legs`/`amulet`)
- New **Augment Souls** currency: 1 soul per enemy kill in battlefield and tower defence modes, 500 souls per augment upgrade
- **Set bonus** activates when all 7 slots are filled with augments from the same named set
- Augment stat bonuses (`attack`, `attackRange`, `maxHp`, `moveSpeed`) scale per level: `baseEffect × (1 + 0.2 × level)` and are applied at deck-build time
- New UI screens: `CardAugmentScreen` (7-slot panel per unit), `AugmentPickerModal` (equip/swap/unequip), `AugmentCollectionScreen` (browse all owned augment instances)
- Augment Collection Screen accessible via "Augments 👻" button in the Collection screen header

## Test plan

- [ ] Tap a unit card in Collection → `CardAugmentScreen` opens with 7 empty slots and base stats
- [ ] Tap a slot → `AugmentPickerModal` opens; select an augment → slot shows name + stats
- [ ] Equip all 7 pieces of the same set → set bonus panel activates
- [ ] Kill enemies in battlefield/TD → augment souls balance increases
- [ ] With 500+ souls, tap Upgrade on an equipped augment → level increments, souls decrease
- [ ] Deploy a unit with augments → verify stats are higher than base (attack range, HP)
- [ ] Navigate to Augments screen via Collection header → see owned augment instances; tap one equipped to a unit → navigate to that unit's `CardAugmentScreen`

Closes #1312

https://claude.ai/code/session_015RkrsCkAGirZEhQBjPLgfq
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_015RkrsCkAGirZEhQBjPLgfq)_