### PR TITLE
fix: add enemyKills to TDGameState sample to fix build

### DIFF
--- a/web/src/game/types.sample.ts
+++ b/web/src/game/types.sample.ts
@@ -236,7 +236,8 @@ export const exampleTDGameState: TDGameState = {
   phase: "prep",
   mana: 0,
   log: [],
-  hazards: []
+  hazards: [],
+  enemyKills: 0
 }
 
 export const exampleTowerPool: TowerPool[] = [


### PR DESCRIPTION
## Summary

- `types.sample.ts` was missing the `enemyKills` field added to `TDGameState` in #1313, causing a `TS2741` build failure on CI
- Adds `enemyKills: 0` to the `exampleTDGameState` sample object

## Test plan

- [ ] CI build passes (`tsc && vite build` no longer errors on `types.sample.ts`)

https://claude.ai/code/session_015RkrsCkAGirZEhQBjPLgfq

---
_Generated by [Claude Code](https://claude.ai/code/session_015RkrsCkAGirZEhQBjPLgfq)_