### PR TITLE
fix: augment cards now drop from card packs

### DIFF
--- a/web/src/game/collection.ts
+++ b/web/src/game/collection.ts
@@ -1,6 +1,6 @@
 import { AugmentEffect, AugmentInstance, Card, CardRarity } from './types'
 import { getCardCatalog } from './cards'
-import { getAugmentCard, getAugmentSetDef, scaledAugmentEffect, ALL_AUGMENT_SLOTS } from './augments'
+import { getAugmentCard, getAugmentCatalog, getAugmentSetDef, scaledAugmentEffect, ALL_AUGMENT_SLOTS } from './augments'
 import { logError } from '../logger'
 import { validateIntegrity, updateChecksum } from './integrity'
 
@@ -529,12 +529,17 @@ export function saveCollection(c: CollectionEntry[]): void {
 
 export function addCardsToCollection(newCards: CollectionEntry[]): CollectionEntry[] {
   const collection = loadCollection()
+  const augNames = new Set(getAugmentCatalog().map(c => c.name))
   for (const entry of newCards) {
-    const existing = collection.find(e => e.cardName === entry.cardName)
-    if (existing) {
-      existing.count += entry.count
+    if (augNames.has(entry.cardName)) {
+      for (let i = 0; i < entry.count; i++) addAugmentInstance(entry.cardName)
     } else {
-      collection.push({ ...entry })
+      const existing = collection.find(e => e.cardName === entry.cardName)
+      if (existing) {
+        existing.count += entry.count
+      } else {
+        collection.push({ ...entry })
+      }
     }
   }
   saveCollection(collection)
@@ -777,10 +782,18 @@ export function generatePack(): string[] {
     picks.push(pickRandom(uncommons).name)
   }
 
+  // Add one augment card (same rarity weights as the bonus slot)
+  const augCatalog = getAugmentCatalog()
+  const augR = Math.random()
+  const augRarity = augR < 0.10 ? 'rare' : augR < 0.30 ? 'uncommon' : 'common'
+  const augPool = augCatalog.filter(c => c.rarity === augRarity)
+  if (augPool.length > 0) picks.push(pickRandom(augPool).name)
+
   const rarityOrder: Record<string, number> = { common: 0, uncommon: 1, rare: 2, legendary: 3 }
+  const allCards = [...catalog, ...augCatalog]
   picks.sort((a, b) => {
-    const ar = catalog.find(c => c.name === a)?.rarity ?? 'common'
-    const br = catalog.find(c => c.name === b)?.rarity ?? 'common'
+    const ar = allCards.find(c => c.name === a)?.rarity ?? 'common'
+    const br = allCards.find(c => c.name === b)?.rarity ?? 'common'
     return (rarityOrder[ar] ?? 0) - (rarityOrder[br] ?? 0)
   })
 


### PR DESCRIPTION
## Summary

- `generatePack()` never drew from the augment catalog — packs now always include 1 augment card per pack (70% common / 20% uncommon / 10% rare, matching the existing bonus-slot weights)
- `addCardsToCollection()` would have silently counted augment card names as regular `CollectionEntry` counts — it now detects augment card names and routes them to `addAugmentInstance()` so received augments appear as individual equippable instances in the Augments screen

## Test plan

- [ ] Open a card pack → 6 cards revealed, the last one has an augment name (e.g. "Thunder Helm")
- [ ] Navigate to Augments screen → the new augment instance appears in the list
- [ ] Open ~10 packs → augments appear across rarities, mostly common/uncommon

Fixes #1312 (augments not earnable from packs)

https://claude.ai/code/session_015RkrsCkAGirZEhQBjPLgfq

---
_Generated by [Claude Code](https://claude.ai/code/session_015RkrsCkAGirZEhQBjPLgfq)_