### PR TITLE
feat(augments): fallback sprites for all 7 augment slot types

### DIFF
--- a/web/public/sprites/augment-amulet.svg
+++ b/web/public/sprites/augment-amulet.svg
@@ -1,0 +1,17 @@
+<svg width="40" height="36" viewBox="0 0 40 36" xmlns="http://www.w3.org/2000/svg">
+  <!-- Chain left -->
+  <path d="M 6 4 Q 13 9 20 6" stroke="#aaaaaa" stroke-width="2" fill="none" stroke-linecap="round"/>
+  <!-- Chain right -->
+  <path d="M 20 6 Q 27 9 34 4" stroke="#aaaaaa" stroke-width="2" fill="none" stroke-linecap="round"/>
+  <!-- Pendant backing -->
+  <circle cx="20" cy="20" r="10" fill="#5522aa"/>
+  <!-- Outer gem ring -->
+  <circle cx="20" cy="20" r="10" fill="none" stroke="#9966dd" stroke-width="2"/>
+  <!-- Gem facets -->
+  <polygon points="20,12 26,20 20,28 14,20" fill="#aa77ff" opacity="0.85"/>
+  <polygon points="20,12 27,16 26,20" fill="#cc99ff" opacity="0.5"/>
+  <polygon points="20,12 13,16 14,20" fill="#cc99ff" opacity="0.3"/>
+  <!-- Center sparkle -->
+  <circle cx="20" cy="20" r="3.5" fill="#ffffff" opacity="0.55"/>
+  <circle cx="18" cy="18" r="1.2" fill="#ffffff" opacity="0.7"/>
+</svg>

--- a/web/public/sprites/augment-arms.svg
+++ b/web/public/sprites/augment-arms.svg
@@ -1,0 +1,15 @@
+<svg width="40" height="36" viewBox="0 0 40 36" xmlns="http://www.w3.org/2000/svg">
+  <!-- Gauntlet body -->
+  <rect x="11" y="6" width="18" height="16" rx="3" fill="#cc9922"/>
+  <!-- Wrist band -->
+  <rect x="10" y="4" width="20" height="5" rx="2" fill="#ddaa33"/>
+  <!-- Knuckle plate -->
+  <rect x="9" y="20" width="22" height="5" rx="1.5" fill="#ddaa33"/>
+  <!-- Fingers -->
+  <rect x="10" y="24" width="4" height="10" rx="2" fill="#cc9922"/>
+  <rect x="15" y="24" width="4" height="11" rx="2" fill="#cc9922"/>
+  <rect x="21" y="24" width="4" height="11" rx="2" fill="#cc9922"/>
+  <rect x="26" y="24" width="4" height="10" rx="2" fill="#cc9922"/>
+  <!-- Highlight -->
+  <path d="M 14 6 Q 20 4 26 6" stroke="#ffcc55" stroke-width="1.5" fill="none" stroke-linecap="round" opacity="0.6"/>
+</svg>

--- a/web/public/sprites/augment-chest.svg
+++ b/web/public/sprites/augment-chest.svg
@@ -1,0 +1,14 @@
+<svg width="40" height="36" viewBox="0 0 40 36" xmlns="http://www.w3.org/2000/svg">
+  <!-- Shoulder pauldrons -->
+  <rect x="4" y="4" width="8" height="7" rx="3" fill="#ddaa33"/>
+  <rect x="28" y="4" width="8" height="7" rx="3" fill="#ddaa33"/>
+  <!-- Main breastplate -->
+  <rect x="9" y="7" width="22" height="25" rx="3" fill="#cc9922"/>
+  <!-- Center ridge -->
+  <line x1="20" y1="8" x2="20" y2="31" stroke="#aa7711" stroke-width="2" opacity="0.7"/>
+  <!-- Horizontal bands -->
+  <line x1="10" y1="15" x2="30" y2="15" stroke="#aa7711" stroke-width="1.5" opacity="0.7"/>
+  <line x1="10" y1="23" x2="30" y2="23" stroke="#aa7711" stroke-width="1.5" opacity="0.7"/>
+  <!-- Highlight -->
+  <path d="M 12 9 Q 16 7 20 9" stroke="#ffcc55" stroke-width="1.5" fill="none" stroke-linecap="round" opacity="0.7"/>
+</svg>

--- a/web/public/sprites/augment-helmet.svg
+++ b/web/public/sprites/augment-helmet.svg
@@ -1,0 +1,15 @@
+<svg width="40" height="36" viewBox="0 0 40 36" xmlns="http://www.w3.org/2000/svg">
+  <!-- Helm dome -->
+  <path d="M 8 22 Q 8 4 20 4 Q 32 4 32 22 Z" fill="#cc9922"/>
+  <!-- Visor slit -->
+  <rect x="13" y="17" width="14" height="4" rx="2" fill="#1a1a2e"/>
+  <!-- Nasal guard -->
+  <rect x="19" y="12" width="2" height="9" rx="1" fill="#aa7711"/>
+  <!-- Cheek guards -->
+  <rect x="7" y="20" width="5" height="9" rx="2" fill="#bb8811"/>
+  <rect x="28" y="20" width="5" height="9" rx="2" fill="#bb8811"/>
+  <!-- Brim -->
+  <rect x="5" y="24" width="30" height="3" rx="1.5" fill="#ddaa33"/>
+  <!-- Crest highlight -->
+  <path d="M 14 4 Q 20 2 26 4" stroke="#ffcc55" stroke-width="1.5" fill="none" stroke-linecap="round"/>
+</svg>

--- a/web/public/sprites/augment-legs.svg
+++ b/web/public/sprites/augment-legs.svg
@@ -1,0 +1,16 @@
+<svg width="40" height="36" viewBox="0 0 40 36" xmlns="http://www.w3.org/2000/svg">
+  <!-- Left greave -->
+  <rect x="6" y="2" width="11" height="20" rx="3" fill="#cc9922"/>
+  <line x1="6" y1="9"  x2="17" y2="9"  stroke="#aa7711" stroke-width="1.5" opacity="0.7"/>
+  <line x1="6" y1="16" x2="17" y2="16" stroke="#aa7711" stroke-width="1.5" opacity="0.7"/>
+  <!-- Left boot -->
+  <rect x="5" y="22" width="13" height="10" rx="2" fill="#bb8811"/>
+  <rect x="4" y="29" width="16" height="4" rx="2" fill="#aa7700"/>
+  <!-- Right greave -->
+  <rect x="23" y="2" width="11" height="20" rx="3" fill="#cc9922"/>
+  <line x1="23" y1="9"  x2="34" y2="9"  stroke="#aa7711" stroke-width="1.5" opacity="0.7"/>
+  <line x1="23" y1="16" x2="34" y2="16" stroke="#aa7711" stroke-width="1.5" opacity="0.7"/>
+  <!-- Right boot -->
+  <rect x="22" y="22" width="13" height="10" rx="2" fill="#bb8811"/>
+  <rect x="20" y="29" width="16" height="4" rx="2" fill="#aa7700"/>
+</svg>

--- a/web/public/sprites/augment-melee.svg
+++ b/web/public/sprites/augment-melee.svg
@@ -1,0 +1,12 @@
+<svg width="40" height="36" viewBox="0 0 40 36" xmlns="http://www.w3.org/2000/svg">
+  <!-- Blade -->
+  <line x1="11" y1="31" x2="31" y2="5" stroke="#ccddee" stroke-width="4" stroke-linecap="round"/>
+  <!-- Blade edge highlight -->
+  <line x1="13" y1="30" x2="32" y2="7" stroke="#eef4ff" stroke-width="1.5" stroke-linecap="round" opacity="0.6"/>
+  <!-- Crossguard -->
+  <line x1="13" y1="24" x2="25" y2="30" stroke="#99aa88" stroke-width="3" stroke-linecap="round"/>
+  <!-- Handle -->
+  <line x1="10" y1="31" x2="7" y2="35" stroke="#886644" stroke-width="3" stroke-linecap="round"/>
+  <!-- Pommel -->
+  <circle cx="6" cy="34" r="2.5" fill="#99aa88"/>
+</svg>

--- a/web/public/sprites/augment-ranged.svg
+++ b/web/public/sprites/augment-ranged.svg
@@ -1,0 +1,13 @@
+<svg width="40" height="36" viewBox="0 0 40 36" xmlns="http://www.w3.org/2000/svg">
+  <!-- Bow arc -->
+  <path d="M 9 4 Q 26 18 9 32" stroke="#66ccff" stroke-width="3" fill="none" stroke-linecap="round"/>
+  <!-- Bowstring -->
+  <line x1="9" y1="4" x2="9" y2="32" stroke="#aaddff" stroke-width="1.5" opacity="0.6"/>
+  <!-- Arrow shaft -->
+  <line x1="11" y1="18" x2="33" y2="18" stroke="#ffcc66" stroke-width="2.5" stroke-linecap="round"/>
+  <!-- Arrowhead -->
+  <polygon points="33,18 27,15 27,21" fill="#ffcc66"/>
+  <!-- Fletching -->
+  <line x1="13" y1="18" x2="11" y2="14" stroke="#ff8866" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="13" y1="18" x2="11" y2="22" stroke="#ff8866" stroke-width="1.5" stroke-linecap="round"/>
+</svg>

--- a/web/src/components/cards/CardTile.tsx
+++ b/web/src/components/cards/CardTile.tsx
@@ -12,6 +12,16 @@ const UPGRADE_SPRITE: Record<string, string> = {
   buffRange:  'upgrade-range',
 }
 
+const AUGMENT_SPRITE: Record<string, string> = {
+  primaryRanged: 'augment-ranged',
+  heavyMelee:    'augment-melee',
+  helmet:        'augment-helmet',
+  chest:         'augment-chest',
+  arms:          'augment-arms',
+  legs:          'augment-legs',
+  amulet:        'augment-amulet',
+}
+
 // ─── Card type category ───────────────────────────────────
 
 type CardCategory = 'unit' | 'hero' | 'spawner' | 'defensive' | 'support' | 'buff'
@@ -196,7 +206,9 @@ export function CardTile({ card, canAfford = true, disabled = false, onClick, lo
           ? <SpriteImg name={card.unit.name} className="card-sprite" />
           : card.upgradeEffect
             ? <SpriteImg name={card.name} fallbackName={UPGRADE_SPRITE[card.upgradeEffect.type] ?? 'upgrade'} className="card-sprite" />
-            : null
+            : card.augmentSlot
+              ? <SpriteImg name={card.name} fallbackName={AUGMENT_SPRITE[card.augmentSlot] ?? 'augment-amulet'} className="card-sprite" />
+              : null
         }
       </div>
 


### PR DESCRIPTION
## Summary

Augment cards showed a blank art area in `CardTile` because neither `card.unit` nor `card.upgradeEffect` is set on augment cards — the sprite render branch simply fell through to `null`.

- Added 7 SVG sprites (one per slot type) to `web/public/sprites/`
- Added `AUGMENT_SPRITE` map in `CardTile.tsx` keyed by `AugmentSlot`, mirroring the existing `UPGRADE_SPRITE` pattern
- Augment cards now resolve their sprite via `card.augmentSlot`, with `augment-amulet` as the final fallback

| Slot | Sprite file | Visual |
|------|-------------|--------|
| `primaryRanged` | `augment-ranged.svg` | Bow + arrow (blue/gold) |
| `heavyMelee` | `augment-melee.svg` | Sword (silver) |
| `helmet` | `augment-helmet.svg` | Full helm (gold) |
| `chest` | `augment-chest.svg` | Breastplate + pauldrons (gold) |
| `arms` | `augment-arms.svg` | Gauntlet (gold) |
| `legs` | `augment-legs.svg` | Greaves + boots (gold) |
| `amulet` | `augment-amulet.svg` | Faceted gem on chain (purple) |

## Test plan

- [ ] Open a card pack containing an augment → augment card shows its slot sprite in the art area
- [ ] Visit Augments screen → each augment instance tile shows the correct slot icon
- [ ] Augment with no matching sprite (edge case) → falls back to `augment-amulet`
- [ ] Existing unit and upgrade cards unaffected

https://claude.ai/code/session_015RkrsCkAGirZEhQBjPLgfq

---
_Generated by [Claude Code](https://claude.ai/code/session_015RkrsCkAGirZEhQBjPLgfq)_