### PR TITLE
feat(augments): card-tile grid, sort/group, detail modal, title button

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2370,6 +2370,7 @@ export default function App() {
             onCityBuilder={() => { setMiniGamesEntry('citybuilder'); setScreen('minigames') }}
             onPlayerStats={() => setScreen('playerstats')}
             onCodex={() => setScreen('codex')}
+            onAugments={() => setScreen('augments')}
             user={user}
             onSignOut={() => { import('firebase/auth').then(({ signOut }) => signOut(auth)) }}
             onSignIn={() => setShowTitleLoginModal(true)}

--- a/web/src/components/cards/CardDetailModal.tsx
+++ b/web/src/components/cards/CardDetailModal.tsx
@@ -7,7 +7,9 @@ import {
   getMasteryXp,
   masteryProgress,
   getCardStats,
+  AUGMENT_UPGRADE_COST,
 } from '../../game/collection'
+import { augmentSlotLabel } from '../../game/augments'
 import { CardTile } from './CardTile'
 import { ModalBackdrop } from '../ui/ModalBackdrop'
 import { MasteryBar } from '../ui/MasteryBar'
@@ -25,6 +27,11 @@ interface Props {
   commanderName?: string | null
   promotionsLeft?: number
   onPromote?: () => void
+  // Augment-instance specific (optional)
+  augmentLevel?: number
+  augmentEquippedTo?: string | null
+  canUpgrade?: boolean
+  onUpgrade?: () => void
 }
 
 const RARITY_COLOUR: Record<string, string> = {
@@ -48,7 +55,7 @@ function affinityEffectText(effectType: string, effectAmount: number): string {
   return `×${effectAmount} ${effectType}`
 }
 
-export function CardDetailModal({ card, collection, deckEntries, onClose, extras = 0, disenchantValue = 0, onDisenchant, onMasterCard, commanderName, promotionsLeft = 0, onPromote }: Props) {
+export function CardDetailModal({ card, collection, deckEntries, onClose, extras = 0, disenchantValue = 0, onDisenchant, onMasterCard, commanderName, promotionsLeft = 0, onPromote, augmentLevel, augmentEquippedTo, canUpgrade, onUpgrade }: Props) {
   const owned  = getOwnedCount(collection, card.name)
   const inDeck = deckEntries?.find(e => e.cardName === card.name)?.count ?? 0
   const xp     = getMasteryXp(collection, card.name)
@@ -145,6 +152,29 @@ export function CardDetailModal({ card, collection, deckEntries, onClose, extras
               </div>
             )}
 
+            {/* Augment stats (augment cards only) */}
+            {card.augmentEffect && (
+              <div className="cdm-augment-block u-col u-gap-2">
+                <div className="cdm-stats-block u-flex u-wrap">
+                  {card.augmentEffect.maxHp       && <StatRow compact label="HP"  value={`+${card.augmentEffect.maxHp}`} />}
+                  {card.augmentEffect.attack      && <StatRow compact label="ATK" value={`+${card.augmentEffect.attack}`} />}
+                  {card.augmentEffect.attackRange && <StatRow compact label="RNG" value={`+${card.augmentEffect.attackRange}`} />}
+                  {card.augmentEffect.moveSpeed   && <StatRow compact label="SPD" value={`+${card.augmentEffect.moveSpeed}`} />}
+                </div>
+                {card.setName && card.augmentSlot && (
+                  <div className="cdm-augment-meta">{card.setName} Set · {augmentSlotLabel(card.augmentSlot)}</div>
+                )}
+                {augmentLevel != null && (
+                  <div className="cdm-augment-meta">Level {augmentLevel}</div>
+                )}
+                {augmentEquippedTo != null && (
+                  <div className="cdm-augment-meta">
+                    {augmentEquippedTo ? `Equipped on: ${augmentEquippedTo}` : 'Unequipped'}
+                  </div>
+                )}
+              </div>
+            )}
+
             {/* Traits */}
             {traits.length > 0 && (
               <div className="cdm-traits u-flex u-wrap u-gap-2">
@@ -210,8 +240,8 @@ export function CardDetailModal({ card, collection, deckEntries, onClose, extras
               </div>
             ) : null}
 
-            {/* Mastery */}
-            <div className="cdm-mastery-block">
+            {/* Mastery (not shown for augments) */}
+            {card.cardType !== 'augment' && <div className="cdm-mastery-block">
               <div className="cdm-mastery-header">
                 <span style={{ color: masteryLvl >= 5 ? '#ff9900' : '#ffd700' }}>
                   {masteryLvl >= 5 ? '⚡' : '★'} Mastery {masteryLvl}{masteryLvl >= 5 ? ' — ELITE' : ''}
@@ -261,19 +291,34 @@ export function CardDetailModal({ card, collection, deckEntries, onClose, extras
                   </div>
                 )
               })()}
-            </div>
+            </div>}
 
-            {/* Battle stats */}
-            <div className="cdm-battle-stats u-col u-gap-1">
-              <StatRow compact label="Times played" value={statsPlayed.played} />
-              {statsUnit && <StatRow compact label="Units lost" value={statsUnit.died} />}
-            </div>
+            {/* Battle stats (not shown for augments) */}
+            {card.cardType !== 'augment' && (
+              <div className="cdm-battle-stats u-col u-gap-1">
+                <StatRow compact label="Times played" value={statsPlayed.played} />
+                {statsUnit && <StatRow compact label="Units lost" value={statsUnit.died} />}
+              </div>
+            )}
           </div>
         </div>
 
         {/* Lore */}
         {card.lore && (
           <div className="cdm-lore">"{card.lore}"</div>
+        )}
+
+        {/* Augment upgrade action */}
+        {onUpgrade && (
+          <div className="cdm-actions">
+            <button
+              className={`action-btn action-btn--gold${canUpgrade ? '' : ' action-btn--disabled'}`}
+              onClick={onUpgrade}
+              title={`Costs ${AUGMENT_UPGRADE_COST} souls`}
+            >
+              ↑ Upgrade ({AUGMENT_UPGRADE_COST} souls)
+            </button>
+          </div>
         )}
 
         {/* Sell / Upgrade actions (collection only) */}

--- a/web/src/components/screens/AugmentCollectionScreen.tsx
+++ b/web/src/components/screens/AugmentCollectionScreen.tsx
@@ -1,50 +1,69 @@
-import React, { useState } from 'react'
-import { AugmentInstance } from '../../game/types'
+import React, { memo, useRef, useState, useEffect } from 'react'
+import { AugmentInstance, Card } from '../../game/types'
 import {
   loadAugmentInstances,
   loadAugmentSouls,
-  loadCollection,
   upgradeAugment,
   AUGMENT_UPGRADE_COST,
 } from '../../game/collection'
-import { getAugmentCard, augmentSlotLabel, scaledAugmentEffect } from '../../game/augments'
+import {
+  getAugmentCard,
+  augmentSlotLabel,
+  scaledAugmentEffect,
+  ALL_AUGMENT_SLOTS,
+} from '../../game/augments'
 import { OverlayScreen } from '../ui/OverlayScreen'
+import { CardTile } from '../cards/CardTile'
+import { CardDetailModal } from '../cards/CardDetailModal'
 import { CardAugmentScreen } from '../cards/CardAugmentScreen'
 import { getCardCatalog } from '../../game/cards'
+import { loadCollection } from '../../game/collection'
+
+// ─── Lazy cell (same pattern as CollectionScreen) ──────────
+
+const LazyCell = memo(function LazyCell({ children, className }: { children: React.ReactNode; className: string }) {
+  const ref  = useRef<HTMLDivElement>(null)
+  const [vis, setVis] = useState(false)
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+    const obs = new IntersectionObserver(([e]) => { if (e.isIntersecting) { setVis(true); obs.disconnect() } }, { rootMargin: '200px' })
+    obs.observe(el)
+    return () => obs.disconnect()
+  }, [])
+  return <div ref={ref} className={className}>{vis ? children : null}</div>
+})
+
+// ─── Sort / group types ────────────────────────────────────
+
+type AugSortKey  = 'default' | 'az' | 'za' | 'rarity' | 'level-desc' | 'level-asc' | 'slot'
+type AugGroupKey = 'none' | 'slot' | 'set' | 'rarity' | 'status'
+
+const RARITY_ORDER: Record<string, number> = {
+  common: 0, uncommon: 1, rare: 2, epic: 3, legendary: 4, mythic: 5,
+  shiny: 4, holofoil: 4, glass: 4,
+}
 
 interface Props {
   onBack: () => void
 }
 
-const RARITY_COLOUR: Record<string, string> = {
-  common:    '#55cc55',
-  uncommon:  '#4499ff',
-  rare:      '#bb66ff',
-  epic:      '#ff8800',
-  legendary: '#ffcc00',
-  mythic:    '#e040fb',
-}
-
-function effectSummary(effect: { attack?: number; attackRange?: number; maxHp?: number; moveSpeed?: number }): string {
-  const parts: string[] = []
-  if (effect.maxHp)       parts.push(`+${effect.maxHp} HP`)
-  if (effect.attack)      parts.push(`+${effect.attack} ATK`)
-  if (effect.attackRange) parts.push(`+${effect.attackRange} RNG`)
-  if (effect.moveSpeed)   parts.push(`+${effect.moveSpeed} SPD`)
-  return parts.join(', ')
-}
-
 export function AugmentCollectionScreen({ onBack }: Props) {
-  const [refresh, setRefresh] = useState(0)
-  const [detailCardName, setDetailCardName] = useState<string | null>(null)
+  const [refresh,    setRefresh]    = useState(0)
+  const [sortKey,    setSortKey]    = useState<AugSortKey>('default')
+  const [groupKey,   setGroupKey]   = useState<AugGroupKey>('none')
+  const [sortOpen,   setSortOpen]   = useState(false)
+  const [groupOpen,  setGroupOpen]  = useState(false)
+  const [detailInst, setDetailInst] = useState<{ card: Card; inst: AugmentInstance } | null>(null)
   const [upgradeError, setUpgradeError] = useState<string | null>(null)
+  const [detailCardName, setDetailCardName] = useState<string | null>(null)
 
-  const forceRefresh = () => setRefresh((r: number) => r + 1)
+  const forceRefresh = () => setRefresh(r => r + 1)
 
-  const instances   = loadAugmentInstances()
-  const souls       = loadAugmentSouls()
-  const collection  = loadCollection()
-  const catalog     = getCardCatalog()
+  const instances  = loadAugmentInstances()
+  const souls      = loadAugmentSouls()
+  const collection = loadCollection()
+  const catalog    = getCardCatalog()
 
   function handleUpgrade(inst: AugmentInstance) {
     const err = upgradeAugment(inst.instanceId)
@@ -53,8 +72,20 @@ export function AugmentCollectionScreen({ onBack }: Props) {
       setTimeout(() => setUpgradeError(null), 2500)
     }
     forceRefresh()
+    // refresh detail modal to show updated level
+    if (detailInst?.inst.instanceId === inst.instanceId) {
+      const updated = loadAugmentInstances().find(i => i.instanceId === inst.instanceId)
+      if (updated) {
+        const augCard = getAugmentCard(updated.cardId)
+        if (augCard) {
+          const displayCard = { ...augCard, augmentEffect: scaledAugmentEffect(augCard.augmentEffect ?? {}, updated.level) }
+          setDetailInst({ card: displayCard, inst: updated })
+        }
+      }
+    }
   }
 
+  // Navigate to unit card's augment screen
   if (detailCardName) {
     const card = catalog.find(c => c.name === detailCardName)
     if (card) {
@@ -68,12 +99,134 @@ export function AugmentCollectionScreen({ onBack }: Props) {
     }
   }
 
+  // ─── Build display items ───────────────────────────────
+
+  type DisplayItem = { inst: AugmentInstance; card: Card; displayCard: Card }
+
+  const items: DisplayItem[] = instances.flatMap(inst => {
+    const augCard = getAugmentCard(inst.cardId)
+    if (!augCard) return []
+    const displayCard = { ...augCard, augmentEffect: scaledAugmentEffect(augCard.augmentEffect ?? {}, inst.level) }
+    return [{ inst, card: augCard, displayCard }]
+  })
+
+  // ─── Sort ─────────────────────────────────────────────
+
+  const sorted = [...items].sort((a, b) => {
+    switch (sortKey) {
+      case 'az':         return a.card.name.localeCompare(b.card.name)
+      case 'za':         return b.card.name.localeCompare(a.card.name)
+      case 'rarity':     return (RARITY_ORDER[b.card.rarity] ?? 0) - (RARITY_ORDER[a.card.rarity] ?? 0)
+      case 'level-desc': return b.inst.level - a.inst.level
+      case 'level-asc':  return a.inst.level - b.inst.level
+      case 'slot':       return ALL_AUGMENT_SLOTS.indexOf(a.card.augmentSlot!) - ALL_AUGMENT_SLOTS.indexOf(b.card.augmentSlot!)
+      default:           return 0
+    }
+  })
+
+  // ─── Group ────────────────────────────────────────────
+
+  function groupLabel(item: DisplayItem): string {
+    switch (groupKey) {
+      case 'slot':   return augmentSlotLabel(item.card.augmentSlot!)
+      case 'set':    return item.card.setName ?? 'Unknown Set'
+      case 'rarity': return item.card.rarity.charAt(0).toUpperCase() + item.card.rarity.slice(1)
+      case 'status': return item.inst.equippedToCardName ? 'Equipped' : 'Unequipped'
+      default:       return ''
+    }
+  }
+
+  const groups: { label: string; items: DisplayItem[] }[] = []
+  if (groupKey === 'none') {
+    groups.push({ label: '', items: sorted })
+  } else {
+    for (const item of sorted) {
+      const label = groupLabel(item)
+      const existing = groups.find(g => g.label === label)
+      if (existing) existing.items.push(item)
+      else groups.push({ label, items: [item] })
+    }
+  }
+
+  // Count total instances per cardId for the modal "owned" display
+  const instanceCounts: Record<string, number> = {}
+  for (const inst of instances) {
+    instanceCounts[inst.cardId] = (instanceCounts[inst.cardId] ?? 0) + 1
+  }
+
+  const currentSouls = loadAugmentSouls()
+
   return (
-    <OverlayScreen title="AUGMENTS" onBack={onBack} right={
-      <span style={{ color: '#cc88ff', fontWeight: 700 }}>{souls.toLocaleString()} 👻 souls</span>
-    }>
+    <OverlayScreen
+      title="AUGMENTS"
+      onBack={onBack}
+      right={<span style={{ color: '#cc88ff', fontWeight: 700 }}>{souls.toLocaleString()} 👻 souls</span>}
+    >
+      {/* Filter bar */}
+      <div className="filter-bar">
+        {/* SORT */}
+        <div className="filter-popup-wrap">
+          <button
+            className={`filter-btn${sortKey !== 'default' ? ' filter-btn--active' : ''}`}
+            onClick={() => { setSortOpen(o => !o); setGroupOpen(false) }}
+          >
+            SORT {sortOpen ? '▲' : '▼'}
+          </button>
+          {sortOpen && (
+            <div className="filter-popup">
+              {([
+                ['default',    'Default'],
+                ['az',         'A → Z'],
+                ['za',         'Z → A'],
+                ['rarity',     'Rarity'],
+                ['level-desc', 'Level ↓'],
+                ['level-asc',  'Level ↑'],
+                ['slot',       'Slot'],
+              ] as [AugSortKey, string][]).map(([key, label]) => (
+                <button
+                  key={key}
+                  className={`filter-btn filter-btn--sm${sortKey === key ? ' filter-btn--active' : ''}`}
+                  onClick={() => { setSortKey(key); setSortOpen(false) }}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* GROUP */}
+        <div className="filter-popup-wrap">
+          <button
+            className={`filter-btn${groupKey !== 'none' ? ' filter-btn--active' : ''}`}
+            onClick={() => { setGroupOpen(o => !o); setSortOpen(false) }}
+          >
+            GROUP {groupOpen ? '▲' : '▼'}
+          </button>
+          {groupOpen && (
+            <div className="filter-popup">
+              {([
+                ['none',   'None'],
+                ['slot',   'Slot'],
+                ['set',    'Set'],
+                ['rarity', 'Rarity'],
+                ['status', 'Equipped / Unequipped'],
+              ] as [AugGroupKey, string][]).map(([key, label]) => (
+                <button
+                  key={key}
+                  className={`filter-btn filter-btn--sm${groupKey === key ? ' filter-btn--active' : ''}`}
+                  onClick={() => { setGroupKey(key); setGroupOpen(false) }}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
       {upgradeError && (
-        <div style={{ color: '#ff6666', textAlign: 'center', fontSize: 12, marginBottom: 8 }}>{upgradeError}</div>
+        <div style={{ color: '#ff6666', textAlign: 'center', fontSize: 12, padding: '4px 0' }}>{upgradeError}</div>
       )}
 
       {instances.length === 0 ? (
@@ -81,47 +234,52 @@ export function AugmentCollectionScreen({ onBack }: Props) {
           No augments owned yet. Earn augments from packs to equip them to your units.
         </div>
       ) : (
-        <div className="aug-list">
-          {instances.map(inst => {
-            const augCard = getAugmentCard(inst.cardId)
-            if (!augCard) return null
-            const scaled = scaledAugmentEffect(augCard.augmentEffect ?? {}, inst.level)
-
-            return (
-              <div key={inst.instanceId} className="aug-list-item">
-                <div className="aug-list-item-info">
-                  <span className="aug-list-name" style={{ color: RARITY_COLOUR[augCard.rarity] ?? '#fff' }}>
-                    {augCard.name}
-                  </span>
-                  <span style={{ opacity: 0.6, fontSize: 11 }}>
-                    {augCard.setName} set · {augmentSlotLabel(augCard.augmentSlot!)} · Lv{inst.level}
-                  </span>
-                  <span style={{ fontSize: 12, color: '#aaddff' }}>{effectSummary(scaled)}</span>
-                  {inst.equippedToCardName ? (
+        <div className="collection-grid u-flex u-wrap u-just-c u-gap-4 u-grow">
+          {groups.map(group => (
+            <React.Fragment key={group.label}>
+              {group.label && (
+                <div className="collection-group-header">{group.label}</div>
+              )}
+              {group.items.map(({ inst, displayCard }) => (
+                <LazyCell key={inst.instanceId} className="collection-cell u-col">
+                  <CardTile
+                    card={displayCard}
+                    onClick={() => setDetailInst({ card: displayCard, inst })}
+                  />
+                  <div className="cell-footer">
+                    <span>Lv{inst.level}</span>
+                    {inst.equippedToCardName && (
+                      <span
+                        title={inst.equippedToCardName}
+                        style={{ cursor: 'pointer', color: '#88ccff' }}
+                        onClick={e => { e.stopPropagation(); setDetailCardName(inst.equippedToCardName!) }}
+                      >↗</span>
+                    )}
                     <button
-                      className="aug-equipped-link"
-                      onClick={() => setDetailCardName(inst.equippedToCardName!)}
-                    >
-                      Equipped on: {inst.equippedToCardName} →
-                    </button>
-                  ) : (
-                    <span style={{ opacity: 0.5, fontSize: 11 }}>Unequipped</span>
-                  )}
-                </div>
-
-                <div className="aug-list-item-actions">
-                  <button
-                    className={`action-btn action-btn--gold${souls < AUGMENT_UPGRADE_COST ? ' action-btn--disabled' : ''}`}
-                    onClick={() => handleUpgrade(inst)}
-                    title={`Costs ${AUGMENT_UPGRADE_COST} souls`}
-                  >
-                    ↑ Upgrade
-                  </button>
-                </div>
-              </div>
-            )
-          })}
+                      className={`action-btn action-btn--gold${currentSouls < AUGMENT_UPGRADE_COST ? ' action-btn--disabled' : ''}`}
+                      onClick={e => { e.stopPropagation(); handleUpgrade(inst) }}
+                      title={`Upgrade · ${AUGMENT_UPGRADE_COST} souls`}
+                      style={{ padding: '1px 6px', fontSize: 11 }}
+                    >↑</button>
+                  </div>
+                </LazyCell>
+              ))}
+            </React.Fragment>
+          ))}
         </div>
+      )}
+
+      {/* Detail modal */}
+      {detailInst && (
+        <CardDetailModal
+          card={detailInst.card}
+          collection={[{ cardName: detailInst.inst.cardId, count: instanceCounts[detailInst.inst.cardId] ?? 1 }]}
+          augmentLevel={detailInst.inst.level}
+          augmentEquippedTo={detailInst.inst.equippedToCardName}
+          canUpgrade={currentSouls >= AUGMENT_UPGRADE_COST}
+          onUpgrade={() => handleUpgrade(detailInst.inst)}
+          onClose={() => setDetailInst(null)}
+        />
       )}
     </OverlayScreen>
   )

--- a/web/src/components/title/TitleScreen.tsx
+++ b/web/src/components/title/TitleScreen.tsx
@@ -55,9 +55,10 @@ export interface Props {
   onSignOut: () => void
   onSignIn: () => void
   onFeedback: () => void
+  onAugments?: () => void
 }
 
-export function TitleScreen({ crystals, onPlay, onEndless, onCampaign, onCollection, onShop, onDeckBuilder, onSettings, onInventory, onAchievements, onHeroCards, onCharacter, on8bitUnlocked, onDailyChallenge, onEndlessLeaderboard, onCommander, commanderName, onTraining, onNews, hasUnreadNews, onMiniGames, onCityBuilder, onPlayerStats, onCodex, user, onSignOut, onSignIn, onFeedback }: Props) {
+export function TitleScreen({ crystals, onPlay, onEndless, onCampaign, onCollection, onShop, onDeckBuilder, onSettings, onInventory, onAchievements, onHeroCards, onCharacter, on8bitUnlocked, onDailyChallenge, onEndlessLeaderboard, onCommander, commanderName, onTraining, onNews, hasUnreadNews, onMiniGames, onCityBuilder, onPlayerStats, onCodex, user, onSignOut, onSignIn, onFeedback, onAugments }: Props) {
   const deck             = loadDeck()
   const count            = deckTotalCards(deck)
   const valid            = isDeckValid(deck)
@@ -254,6 +255,7 @@ export function TitleScreen({ crystals, onPlay, onEndless, onCampaign, onCollect
         <div className="title-nav-grid">
           <TitleButton onClick={onDeckBuilder}>DECK BUILDER</TitleButton>
           <TitleButton onClick={onCollection} badge={collectionAlert}>COLLECTION</TitleButton>
+          <TitleButton onClick={onAugments}>⚔ AUGMENTS</TitleButton>
           <TitleButton onClick={onShop} badge={shopAlert}>🛒 SHOP</TitleButton>
           <TitleButton onClick={onHeroCards}>🦸 HEROES</TitleButton>
           <TitleButton onClick={onInventory}>🎒 INVENTORY</TitleButton>


### PR DESCRIPTION
## Summary

- **Augment screen grid** — replaced the plain list with a `CardTile` grid matching the Collection screen style; each tile shows the augment's slot sprite, rarity colour, name, and description
- **Sort & group** — filter bar with SORT (default / A→Z / Z→A / rarity / level ↓ / level ↑ / slot) and GROUP (none / slot / set / rarity / equipped status) dropdowns; uses the same `.filter-bar` / `.filter-popup` CSS as the Collection screen
- **Per-tile footer** — shows `Lv{N}`, an equipped indicator (↗, tappable to jump to the unit's augment screen), and a quick-upgrade button
- **Detail modal** — tapping a tile opens `CardDetailModal` with the augment's stats scaled to the instance's level, set name, slot label, level, equipped-on info, and an upgrade button; mastery and battle-stats sections are hidden for augment cards
- **Title screen button** — ⚔ AUGMENTS added to the secondary nav row, navigates directly to the augments screen

## Test plan

- [ ] Title screen → tap ⚔ AUGMENTS → augments screen opens
- [ ] Augments screen shows tiles in a grid with slot sprites and rarity borders
- [ ] Sort by "Level ↓" → highest-level instances first
- [ ] Group by "Set" → tiles grouped under set name headers
- [ ] Group by "Equipped / Unequipped" → two groups shown
- [ ] Tap a tile → `CardDetailModal` shows scaled stats (e.g. Lv2 augment shows 40% higher effect than Lv0)
- [ ] Upgrade button in modal: greyed out with < 500 souls; functional with ≥ 500 souls
- [ ] Quick-upgrade ↑ in tile footer works and refreshes the tile level
- [ ] ↗ link in footer jumps to the unit's `CardAugmentScreen`
- [ ] Existing unit/upgrade cards in Collection screen unaffected (no mastery/battle-stat regression)

https://claude.ai/code/session_015RkrsCkAGirZEhQBjPLgfq

---
_Generated by [Claude Code](https://claude.ai/code/session_015RkrsCkAGirZEhQBjPLgfq)_