### PR TITLE
fix(augments): guard onAugments to resolve TS2322 build error

### DIFF
--- a/web/src/components/title/TitleScreen.tsx
+++ b/web/src/components/title/TitleScreen.tsx
@@ -255,7 +255,7 @@ export function TitleScreen({ crystals, onPlay, onEndless, onCampaign, onCollect
         <div className="title-nav-grid">
           <TitleButton onClick={onDeckBuilder}>DECK BUILDER</TitleButton>
           <TitleButton onClick={onCollection} badge={collectionAlert}>COLLECTION</TitleButton>
-          <TitleButton onClick={onAugments}>⚔ AUGMENTS</TitleButton>
+          {onAugments && <TitleButton onClick={onAugments}>⚔ AUGMENTS</TitleButton>}
           <TitleButton onClick={onShop} badge={shopAlert}>🛒 SHOP</TitleButton>
           <TitleButton onClick={onHeroCards}>🦸 HEROES</TitleButton>
           <TitleButton onClick={onInventory}>🎒 INVENTORY</TitleButton>


### PR DESCRIPTION
## Summary

`TitleButton.onClick` is typed as `() => void` (non-optional), but `onAugments` is `(() => void) | undefined`. This caused a `TS2322` type error that failed the CI build.

Fix: wrap the button in a conditional `{onAugments && <TitleButton ...>}`, matching the same pattern used for `onCommander`.

## Test plan

- [ ] CI build passes
- [ ] ⚔ AUGMENTS button still appears on the title screen (since `App.tsx` always passes `onAugments`)

https://claude.ai/code/session_015RkrsCkAGirZEhQBjPLgfq

---
_Generated by [Claude Code](https://claude.ai/code/session_015RkrsCkAGirZEhQBjPLgfq)_