### PR TITLE
perf(tower-defence): fix 4 performance issues causing stutter (#1317)

### DIFF
--- a/web/src/components/minigames/TowerDefence.tsx
+++ b/web/src/components/minigames/TowerDefence.tsx
@@ -283,7 +283,7 @@ export function TowerDefence({ pool, mode, onDone }: Props) {
       }
     }
     return cells
-  }, [selectedTower, hoveredTower, selected, hoveredCell, game.units])
+  }, [selectedTower, hoveredTower, selected, hoveredCell])
 
   // ── End screen ──────────────────────────────────────────────────────────────
 

--- a/web/src/components/minigames/towerdefence/GameGrid.tsx
+++ b/web/src/components/minigames/towerdefence/GameGrid.tsx
@@ -28,6 +28,7 @@ gridScale,
 isOnPath,setHoveredTower, setHoveredCell, handleCellClick,
 selectedTower, hoveredTower,
 }: Props) {
+    const towerByCell = new Map(game.towers.map(t => [`${t.col},${t.row}`, t]))
     return <div className="td-board-wrap" ref={boardWrapRef}>
       <div
         className="td-grid-scaler"
@@ -50,7 +51,7 @@ selectedTower, hoveredTower,
             const onPath = isOnPath(col, row)
             const isStart = col === TD_PATH[0].col && row === TD_PATH[0].row
             const isEnd = col === TD_PATH[TD_PATH.length - 1].col && row === TD_PATH[TD_PATH.length - 1].row
-            const tower = game.towers.find(t => t.col === col && t.row === row)
+            const tower = towerByCell.get(`${col},${row}`)
             const isTowerSelected = tower?.id === selectedTowerId
             // canDrop: valid placement cell, or valid move destination for selected tower
             const canDrop = !onPath && !tower && (

--- a/web/src/components/ui/SpriteImg.tsx
+++ b/web/src/components/ui/SpriteImg.tsx
@@ -1,6 +1,28 @@
 /// <reference types="vite/client" />
-import React, { useState, useEffect, useRef } from 'react'
+import React, { useState, useEffect, useRef, useSyncExternalStore } from 'react'
 import { spriteSlug } from '../../game/sprites'
+
+// ── Shared animation ticker ────────────────────────────────────────────────────
+// One interval drives all AnimatedSpriteImg instances. React 18 batches all
+// subscriber setState calls that fire synchronously in the same tick, so N
+// components re-render in a single pass rather than N separate passes.
+let _animTick = 0
+const _animSubs = new Set<() => void>()
+let _animTimer: ReturnType<typeof setInterval> | null = null
+
+function _startAnimTicker() {
+  if (_animTimer) return
+  _animTimer = setInterval(() => { _animTick++; _animSubs.forEach(fn => fn()) }, 125) // 8 fps max
+}
+function _stopAnimTicker() {
+  if (_animTimer) { clearInterval(_animTimer); _animTimer = null }
+}
+function subscribeAnimTick(fn: () => void) {
+  _animSubs.add(fn)
+  _startAnimTicker()
+  return () => { _animSubs.delete(fn); if (_animSubs.size === 0) _stopAnimTicker() }
+}
+function getAnimTick() { return _animTick }
 
 const BASE = import.meta.env.BASE_URL
 
@@ -188,11 +210,14 @@ interface AnimatedProps {
  */
 export function AnimatedSpriteImg({ name, frameCount, fps, className, style }: AnimatedProps) {
   const slug = spriteSlug(name)
-  const [frame,       setFrame]       = useState(1)
   const [useFallback, setUseFallback] = useState(false)
   const [eightbit,    setEightbit]    = useState(is8bitMode)
   const [monochrome, setMonochrome]    = useState(isMonochromeMode)
-  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  // Shared global ticker — all instances update together in one React render pass
+  const tick = useSyncExternalStore(subscribeAnimTick, getAnimTick)
+  // Derive frame from global 8-fps tick; lower-fps sprites skip ticks via integer division
+  const frame = useFallback ? 1 : (Math.floor(tick * fps / 8) % frameCount) + 1
 
   useEffect(() => {
     const handler = () => setEightbit(is8bitMode())
@@ -205,16 +230,6 @@ export function AnimatedSpriteImg({ name, frameCount, fps, className, style }: A
     return () => window.removeEventListener('monochrome-change', handler)
   }, [])
 
-  useEffect(() => {
-    if (useFallback) return
-    intervalRef.current = setInterval(() => {
-      setFrame(f => (f % frameCount) + 1)
-    }, 1000 / fps)
-    return () => {
-      if (intervalRef.current) clearInterval(intervalRef.current)
-    }
-  }, [frameCount, fps, useFallback])
-
   if (useFallback) {
     return <SpriteImg name={name} className={className} style={style} />
   }
@@ -222,7 +237,6 @@ export function AnimatedSpriteImg({ name, frameCount, fps, className, style }: A
   const src = `${BASE}sprites/${slug}-${frame}.svg`
 
   const handleFrameError = () => {
-    if (intervalRef.current) clearInterval(intervalRef.current)
     setUseFallback(true)
   }
 
@@ -241,7 +255,6 @@ export function AnimatedSpriteImg({ name, frameCount, fps, className, style }: A
       className={className}
       style={style}
       onError={() => {
-        if (intervalRef.current) clearInterval(intervalRef.current)
         setUseFallback(true)
       }}
     />

--- a/web/src/game/towerDefence.ts
+++ b/web/src/game/towerDefence.ts
@@ -1029,6 +1029,10 @@ export function tickTD(state: TDGameState, dtMs: number): TDGameState {
   // Pre-build a map of tower targeting modes for O(1) lookup per unit
   const towerTargetingModes = new Map<number, TDTargetingMode>(s.towers.map(t => [t.id, t.targetingMode]))
 
+  // Accumulate enemy mutations — applied in one pass after the units loop to avoid
+  // O(units × enemies) array copies (was up to 4 full enemy-array maps per attacking unit).
+  const enemyMutations = new Map<number, Partial<TDEnemy>>()
+
   s.units = s.units.map(unit => {
     let cd = Math.max(0, unit.attackCooldownRemaining - dtMs)
     if (cd <= 0 && s.enemies.length > 0) {
@@ -1046,33 +1050,42 @@ export function tickTD(state: TDGameState, dtMs: number): TDGameState {
         if (target.shielded) {
           // Shield absorbs the hit — break it and skip damage
           shieldedEnemyIds.add(target.id)
-          s.enemies = s.enemies.map(e => e.id === target.id ? { ...e, shielded: false } : e)
+          const cur = enemyMutations.get(target.id) ?? {}
+          enemyMutations.set(target.id, { ...cur, shielded: false })
         } else {
           const dmg = Math.round(unitDamageDealt(unit, target) * damageMult * unit.damageMult)
-          const newHp = target.hp - dmg
+          // Use pending hp so multiple units hitting the same enemy in one tick is correct
+          const effHp = enemyMutations.get(target.id)?.hp ?? target.hp
+          const newHp = effHp - dmg
           // Apply elemental on-hit effect
           const eff = unit.template.attackEffect
           if (eff && Math.random() < eff.chance) {
             if (eff.type === 'burn' || eff.type === 'freeze' || eff.type === 'poison' || eff.type === 'shock') {
               if (newHp > 0 && !target.template.immunities?.includes(eff.type)) {
-                s.enemies = s.enemies.map(e => {
-                  if (e.id !== target.id) return e
-                  if (eff.type === 'burn')   return { ...e, burnTimer:   eff.durationMs, burnDps:   eff.dps ?? 8 }
-                  if (eff.type === 'freeze') return { ...e, freezeTimer: eff.durationMs, freezeSlow: eff.slowFactor ?? 0.35 }
-                  if (eff.type === 'poison') return { ...e, poisonTimer: eff.durationMs, poisonDps: eff.dps ?? 5 }
-                  if (eff.type === 'shock')  return { ...e, freezeTimer: eff.durationMs, freezeSlow: 0 }
-                  return e
-                })
+                const cur = enemyMutations.get(target.id) ?? {}
+                if (eff.type === 'burn')   enemyMutations.set(target.id, { ...cur, burnTimer:   eff.durationMs, burnDps:   eff.dps ?? 8 })
+                if (eff.type === 'freeze') enemyMutations.set(target.id, { ...cur, freezeTimer: eff.durationMs, freezeSlow: eff.slowFactor ?? 0.35 })
+                if (eff.type === 'poison') enemyMutations.set(target.id, { ...cur, poisonTimer: eff.durationMs, poisonDps: eff.dps ?? 5 })
+                if (eff.type === 'shock')  enemyMutations.set(target.id, { ...cur, freezeTimer: eff.durationMs, freezeSlow: 0 })
               }
             } else if (eff.type === 'aoe' && eff.aoeRadius) {
               // AOE burst: deal same damage to all enemies in radius
-              s.enemies = s.enemies.map(e => {
-                if (e.id === target.id || deadEnemyIds.has(e.id) || e.hp <= 0) return e
-                if (dist(e.x, e.y, target.x, target.y) > eff.aoeRadius!) return e
-                const splashHp = e.hp - dmg
-                if (splashHp <= 0) { deadEnemyIds.add(e.id); s.score += e.template.reward; s.mana += e.template.reward; s.enemyKills++; towerXpGains[unit.towerId] = (towerXpGains[unit.towerId] ?? 0) + 1 }
-                return { ...e, hp: Math.max(0, splashHp) }
-              })
+              for (const e of s.enemies) {
+                if (e.id === target.id || deadEnemyIds.has(e.id)) continue
+                if (dist(e.x, e.y, target.x, target.y) > eff.aoeRadius!) continue
+                const splashEffHp = enemyMutations.get(e.id)?.hp ?? e.hp
+                const splashHp = splashEffHp - dmg
+                if (splashHp <= 0) {
+                  deadEnemyIds.add(e.id)
+                  s.score += e.template.reward
+                  s.mana += e.template.reward
+                  s.enemyKills++
+                  towerXpGains[unit.towerId] = (towerXpGains[unit.towerId] ?? 0) + 1
+                } else {
+                  const cur = enemyMutations.get(e.id) ?? {}
+                  enemyMutations.set(e.id, { ...cur, hp: splashHp })
+                }
+              }
               // AOE ring visual
               newAttackEvents.push({ id: nextId(), fromX: target.x, fromY: target.y, toX: target.x, toY: target.y, expiresAt: s.gameTimeMs + 500, aoeRadius: eff.aoeRadius })
             } else if (eff.type === 'gascloud' && eff.aoeRadius) {
@@ -1093,7 +1106,8 @@ export function tickTD(state: TDGameState, dtMs: number): TDGameState {
             s.enemyKills++
             towerXpGains[unit.towerId] = (towerXpGains[unit.towerId] ?? 0) + 1
           } else {
-            s.enemies = s.enemies.map(e => e.id === target.id ? { ...e, hp: newHp } : e)
+            const cur = enemyMutations.get(target.id) ?? {}
+            enemyMutations.set(target.id, { ...cur, hp: newHp })
           }
         }
         newAttackEvents.push({
@@ -1111,6 +1125,14 @@ export function tickTD(state: TDGameState, dtMs: number): TDGameState {
     return { ...unit, attackCooldownRemaining: cd }
   })
   s.attackEvents = newAttackEvents
+
+  // Single-pass application of all accumulated enemy mutations
+  if (enemyMutations.size > 0) {
+    s.enemies = s.enemies.map(e => {
+      const mut = enemyMutations.get(e.id)
+      return mut ? { ...e, ...mut } : e
+    })
+  }
 
   // Split-on-death: collect offspring before removing dead enemies
   const splitOffspring: TDEnemy[] = []


### PR DESCRIPTION
## Summary

Addresses stutter and high CPU usage in the Tower Defence minigame (issue #1317). Four distinct performance problems were found and fixed:

- **`rangeHighlight` wrong dep** (`TowerDefence.tsx`): `game.units` was listed as a dependency of the range-circle `useMemo`, but `game.units` is a new array reference every tick (state is spread-copied in `tickTD`). This caused an unnecessary O(91 cells × sqrt) recalculation every 100 ms even when selection/hover hadn't changed. Removed the stale dep — one-line fix, zero behaviour change.

- **Tower lookup O(n) per cell** (`GameGrid.tsx`): The cell render loop called `game.towers.find()` for each of the 91 grid cells on every render — O(towers × cells) comparisons. Pre-computing a `Map<"col,row", TDTower>` reduces each lookup to O(1).

- **N independent animation intervals** (`SpriteImg.tsx`): Each `AnimatedSpriteImg` instance had its own `setInterval` calling `setState`, which React processes as separate reconciliation passes. During a busy wave (20+ enemies + unit groups) this was 20+ independent render passes per animation frame. Replaced with a shared module-level ticker via `useSyncExternalStore` — all sprite instances now update together in a single React render pass.

- **Repeated `s.enemies.map()` inside unit attack loop** (`towerDefence.ts`): For each attacking unit, the tick function called `s.enemies.map()` up to 4 times (shield break, elemental effect, AOE splash, HP update), creating O(units × enemies) enemy object copies per tick. At 20 units / 30 enemies / 10 ticks per second = ~24 000 enemy object allocations/second; worse at 8× speed. Replaced with a `Map<enemyId, Partial<TDEnemy>>` mutation accumulator applied in one `s.enemies.map()` pass after the unit loop. Multi-unit kills on the same enemy are still handled correctly via pending-hp tracking.

## Test plan

- [ ] `npm run build` passes with zero TypeScript errors ✅
- [ ] Start a wave — enemies move smoothly at 1× speed with no visible stutter
- [ ] 2×, 4×, 8× speed all work correctly (game logic progresses, not just visuals)
- [ ] Elemental effects (burn/freeze/poison/shock) still appear on enemies
- [ ] AOE attacks still damage all enemies in radius
- [ ] Shield absorption still works on armored enemies (wave 30+)
- [ ] Sprite walk animations still cycle correctly for enemies and player units
- [ ] Range highlight appears when hovering/selecting a tower and disappears correctly

https://claude.ai/code/session_01XmMaruguZppeHy4CDAhKrD

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmMaruguZppeHy4CDAhKrD)_