### PR TITLE
fix: restore tap-progress dots display in pack opening (#1318)

### DIFF
--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2772,9 +2772,12 @@ body {
   line-height: 1;
 }
 
-.pack-hidden-dots,
-.city-fort-sort,
-.city-level-stars,
+.pack-hidden-dots {
+  display: flex;
+  gap: 4px;
+  align-items: center;
+  justify-content: center;
+}
 
 .pack-dot {
   width: 7px;
@@ -10384,6 +10387,7 @@ html.light-mode .action-btn {
   padding: 6px 0 4px;
 }
 .city-fort-filter { display: flex; gap: 4px; flex-wrap: wrap; }
+.city-fort-sort   { display: flex; gap: 4px; }
 .city-fort-filter-btn, .city-fort-sort-btn {
   font-family: inherit;
   font-size: 10px;


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Fixes a CSS selector bug introduced in the augments PR where `.pack-hidden-dots` was accidentally grouped into the same rule as `.pack-dot`, giving the dots *container* the same 7×7px / 50% border-radius styling as the individual dot elements — collapsing it into a tiny circle (the reported visual glitch).
- Gives `.pack-hidden-dots` its own proper rule: `display: flex; gap: 4px; align-items: center; justify-content: center;` so tap-progress dots render as a row again.
- Also fixes `.city-fort-sort` which was caught in the same bad selector group and had no layout styles; it now gets `display: flex; gap: 4px;` matching its sibling `.city-fort-filter`.

## Root cause

In `styles.css` around line 2775, the selector block looked like:

```css
.pack-hidden-dots,
.city-fort-sort,
.city-level-stars,

.pack-dot {
  width: 7px;
  height: 7px;
  border-radius: 50%;
  ...
}
```

The trailing commas accidentally included the container classes in the `.pack-dot` rule.

## Test plan

- [ ] Open a pack containing a rare or legendary card
- [ ] Verify the tap-progress dots appear as a horizontal row of circles (not a glitched blob)
- [ ] Verify tapping fills dots left-to-right until the card flips
- [ ] Check the Fortifications sort buttons still render correctly

Fixes #1318

https://claude.ai/code/session_015RY9JztG5S7SEkRTh3MGc5
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_015RY9JztG5S7SEkRTh3MGc5)_