### PR TITLE
feat: Tactician Archetypes — Siege Commander, Swarm Tactician, Arcane Scholar (#1297)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4,7 +4,7 @@ import { usePlaytime } from './hooks/usePlaytime'
 import { useStartupData } from './hooks/useStartupData'
 import { useCloudSync } from './hooks/useCloudSync'
 import { useRegisterSW } from 'virtual:pwa-register/react'
-import { GameState, Card, StanceRules } from './game/types'
+import { GameState, Card, StanceRules, Archetype } from './game/types'
 import { newGame, MAX_HANDICAP } from './game/engine'
 import { playCard, playAoeCard } from './game/engine/cards'
 import { makeNodeDeck } from './game/cards'
@@ -35,6 +35,7 @@ import {
   ALL_CONSUMABLES, addToConsumableStash, useConsumable,
   getModifiersByCount, getModifierMax,
   setLastRunFailed, loadLastRunFailed, clearLastRunFailed,
+  ARCHETYPE_STARTER_PACK,
 } from './game/questline'
 import { CardRestSelect }       from './components/cards/CardRestSelect'
 import { CampScreen, CampChoice } from './components/campaign/CampScreen'
@@ -857,6 +858,7 @@ export default function App() {
           const state = newGame({ playerCards, ...resolvedNodeOpts(node, act, loadRunCount(), mods) })
           state.playerBase = { hp: activeRun.playerHp, maxHp: activeRun.maxHp }
           if (activeRun.activeRelic) getRelicDef(activeRun.activeRelic)?.applyToGame(state)
+          if (activeRun.archetype) state.archetypePassive = activeRun.archetype
           state.stanceRules = STANCE_RULES_BY_NODE_TYPE[node.type]
           startBattle(state)
           rollRareEvent()
@@ -2634,6 +2636,7 @@ export default function App() {
           onPick={handleStarterPackPick}
           fatiguedCards={fatiguedCards}
           bonusCards={bonusPackCards}
+          recommendedPackId={run?.archetype ? ARCHETYPE_STARTER_PACK[run.archetype as Archetype] : undefined}
         />
       )}
 

--- a/web/src/components/campaign/NodeMap.tsx
+++ b/web/src/components/campaign/NodeMap.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useRef, useEffect, useState } from 'react'
 import { emitSound } from '../../game/sound'
 import { getDiscoveredFragmentIds } from '../../game/codex'
-import { Act, QuestNode, RunState, ReplayModifier, getAvailableNodeIds, loadNodeHistory, getModifiersByCount, ALL_CONSUMABLES, loadPlayerAvatar } from '../../game/questline'
+import { Act, QuestNode, RunState, ReplayModifier, getAvailableNodeIds, loadNodeHistory, getModifiersByCount, ALL_CONSUMABLES, loadPlayerAvatar, ARCHETYPE_DEFS } from '../../game/questline'
 import { spriteSlug } from '../../game/sprites'
 import { StatRow } from '../ui/StatRow'
 import { AnimatedSpriteImg } from '../ui/SpriteImg'
@@ -852,6 +852,10 @@ export function NodeMap({ act, run, onSelectNode, onUseConsumable, onBack }: Pro
 
       {/* Consumables bar */}
       <Toolbar>
+        {run.archetype && (() => {
+          const def = ARCHETYPE_DEFS.find(d => d.id === run.archetype)
+          return def ? <ToolbarLabel>{def.icon} {def.name}</ToolbarLabel> : null
+        })()}
         <ToolbarLabel>Items</ToolbarLabel>
 
       

--- a/web/src/components/cards/StarterPackSelect.tsx
+++ b/web/src/components/cards/StarterPackSelect.tsx
@@ -4,11 +4,12 @@ import { getCardCatalog } from '../../game/cards'
 
 interface Props {
   onPick: (cards: DeckEntry[]) => void
-  fatiguedCards?: string[]   // card names currently resting — shown with a badge
-  bonusCards?: string[]      // card names auto-added to collection as a top-up bonus
+  fatiguedCards?: string[]      // card names currently resting — shown with a badge
+  bonusCards?: string[]         // card names auto-added to collection as a top-up bonus
+  recommendedPackId?: string    // pack ID matching the player's current archetype
 }
 
-export function StarterPackSelect({ onPick, fatiguedCards = [], bonusCards = [] }: Props) {
+export function StarterPackSelect({ onPick, fatiguedCards = [], bonusCards = [], recommendedPackId }: Props) {
   const catalog = getCardCatalog()
 
   return (
@@ -34,8 +35,11 @@ export function StarterPackSelect({ onPick, fatiguedCards = [], bonusCards = [] 
       </div>
 
       <div className="starter-packs u-flex u-gap-6 u-just-c u-wrap">
-        {STARTER_PACK_OPTIONS.map(pack => (
-          <div key={pack.id} className="starter-pack u-col u-gap-4 u-grow u-pointer" onClick={() => onPick(pack.cards)}>
+        {STARTER_PACK_OPTIONS.map(pack => {
+          const isRecommended = recommendedPackId === pack.id
+          return (
+          <div key={pack.id} className={`starter-pack u-col u-gap-4 u-grow u-pointer${isRecommended ? ' starter-pack--recommended' : ''}`} onClick={() => onPick(pack.cards)}>
+            {isRecommended && <div className="starter-pack-recommended">⭐ RECOMMENDED</div>}
             <div className="starter-pack-name">{pack.name}</div>
             <div className="starter-pack-desc">{pack.description}</div>
             <ul className="starter-pack-list">
@@ -53,7 +57,8 @@ export function StarterPackSelect({ onPick, fatiguedCards = [], bonusCards = [] 
             </ul>
             <button className="action-btn starter-pack-btn">CHOOSE</button>
           </div>
-        ))}
+          )
+        })}
       </div>
     </div>
   )

--- a/web/src/components/screens/CharacterScreen.tsx
+++ b/web/src/components/screens/CharacterScreen.tsx
@@ -5,7 +5,9 @@ import {
   loadPlayerName, savePlayerName,
   loadPlayerAvatar, savePlayerAvatar,
   isAvatarUnlocked,
+  getArchetypeDefs, loadPlayerArchetype, savePlayerArchetype, loadActCount,
 } from '../../game/questline'
+import type { Archetype } from '../../game/types'
 import { auth } from '../../firebase'
 import { claimPlayerName } from '../../game/playerName'
 import { OverlayScreen } from '../ui/OverlayScreen'
@@ -58,6 +60,8 @@ export function CharacterScreen({ onDone }: Props) {
   const [saving,    setSaving]    = useState(false)
   const [nameError, setNameError] = useState<string | null>(null)
   const [activeTab, setActiveTab] = useState<AvatarTab>('base')
+  const [archetype, setArchetype] = useState<Archetype | null>(loadPlayerArchetype())
+  const archetypeDefs = getArchetypeDefs(loadActCount('actfinale'))
 
   async function handleSave() {
 
@@ -77,6 +81,7 @@ export function CharacterScreen({ onDone }: Props) {
     savePlayerName(finalName)
   }
     savePlayerAvatar(avatar)
+    if (archetype) savePlayerArchetype(archetype)
     onDone()
   }
 
@@ -177,6 +182,25 @@ export function CharacterScreen({ onDone }: Props) {
               ))}
             </div>
           )}
+        </div>
+
+        <div style={{ margin: '1.2rem 0 0.5rem', width: '100%' }}>
+          <div style={{ color: '#aaffaa', fontSize: '0.8rem', marginBottom: '0.6rem' }}>ARCHETYPE</div>
+          <div className="character-archetype-grid">
+            {archetypeDefs.map(def => (
+              <button
+                key={def.id}
+                className={`character-archetype-btn${archetype === def.id ? ' character-archetype-btn--chosen' : ''}${def.locked ? ' character-archetype-btn--locked' : ''}`}
+                onClick={def.locked ? undefined : () => setArchetype(def.id)}
+                title={def.locked ? `${def.name} — complete the campaign to unlock` : def.name}
+              >
+                <span className="character-archetype-icon">{def.locked ? '🔒' : def.icon}</span>
+                <span className="character-archetype-name">{def.locked ? '???' : def.name}</span>
+                {!def.locked && <span className="character-archetype-identity">{def.identity}</span>}
+                {!def.locked && <span className="character-archetype-passive">{def.passive}</span>}
+              </button>
+            ))}
+          </div>
         </div>
 
         <Button

--- a/web/src/game/engine.ts
+++ b/web/src/game/engine.ts
@@ -4,7 +4,7 @@ import { loadPlayerStats } from './playerStats'
 
 import { moveUnits, processAffinities } from './engine/units'
 import { processAttacks, DEATH_LINGER_MS } from './engine/combat'
-import { BASE_MAX_MANA, BLOOD_POOL_FADE_MS, BASE_STOP_MARGIN, MANA_REGEN_MS, OPPONENT_INTERVAL_MS, PLAYER_SPAWN_X, SPAWN_GROW_MS, COMMANDER_HOME_X } from './engine/constants'
+import { BASE_MAX_MANA, BLOOD_POOL_FADE_MS, BASE_STOP_MARGIN, MANA_REGEN_MS, OPPONENT_INTERVAL_MS, PLAYER_SPAWN_X, SPAWN_GROW_MS, COMMANDER_HOME_X, ARCH_SWARM_ATK_PER_UNIT } from './engine/constants'
 import { genericBossAI, getBossAIDef } from './engine/boss'
 import { tickBossTrait } from './engine/bossTraits'
 import { getManaBonus, getManaSpeedMult } from './engine/bonusEffects'
@@ -496,6 +496,9 @@ export function tick(state: GameState, deltaMs: number): GameState {
   // 1b. apply tick effects (periodic relic buffs)
   applyTickEffects(s, deltaMs)
 
+  // 1c. apply archetype passives
+  applyArchetypePassives(s)
+
   // 2. Move all units
   moveUnits(s, deltaMs)
 
@@ -838,6 +841,21 @@ function performUnitMaintenance(s: GameState, deltaMs: number, log: string[]) {
         unit.spawnTimer = intervalMs
       }
     }
+  }
+}
+
+function applyArchetypePassives(s: GameState) {
+  if (s.archetypePassive !== 'swarm_tactician') return
+  const mobileCount = s.field.filter(u => u.owner === 'player' && !u.isWall && u.moveSpeed > 0).length
+  const newMult = 1 + mobileCount * ARCH_SWARM_ATK_PER_UNIT
+  const prevMult = s.swarmAtkMult ?? 1
+  if (Math.abs(newMult - prevMult) > 0.001) {
+    for (const u of s.field) {
+      if (u.owner === 'player' && !u.isWall && u.moveSpeed > 0) {
+        u.attack = Math.max(1, Math.round(u.attack / prevMult * newMult))
+      }
+    }
+    s.swarmAtkMult = newMult
   }
 }
 

--- a/web/src/game/engine/cards.ts
+++ b/web/src/game/engine/cards.ts
@@ -4,6 +4,26 @@ import { spawnUnit } from './helpers';
 import { drawCard } from './helpers';
 import {  Card, UnitTemplate } from '../types';
 import { playUpgrade } from '../sound';
+import {
+  ARCH_STRUCTURE_COST_REDUCTION, ARCH_STRUCTURE_HP_MULT,
+  ARCH_SWARM_UNIT_THRESHOLD, ARCH_SWARM_COST_REDUCTION,
+  ARCH_SCHOLAR_UPGRADE_MULT,
+} from './constants';
+
+/** Returns the mana cost the player actually pays for a card, after archetype passives. */
+export function getEffectiveCardCost(card: Card, state: GameState): number {
+  const archetype = state.archetypePassive
+  if (archetype === 'siege_commander' && card.cardType === 'structure') {
+    return Math.max(0, card.cost - ARCH_STRUCTURE_COST_REDUCTION)
+  }
+  if (archetype === 'swarm_tactician' && card.cardType === 'unit') {
+    const mobileCount = state.field.filter(u => u.owner === 'player' && !u.isWall && u.moveSpeed > 0).length
+    if (mobileCount >= ARCH_SWARM_UNIT_THRESHOLD) {
+      return Math.max(0, card.cost - ARCH_SWARM_COST_REDUCTION)
+    }
+  }
+  return card.cost
+}
 
 // ─── Deploy a card onto the field ────────────────────────
 export function deployCard(s: GameState, card: Card, owner: 'player' | 'opponent', log: string[]): void {
@@ -89,6 +109,11 @@ export function deployCard(s: GameState, card: Card, owner: 'player' | 'opponent
         if (e.attackBonus) unit.attack = Math.max(0, unit.attack + e.attackBonus)
       }
     }
+    // Siege Commander: new structures get +20% max HP
+    if (owner === 'player' && card.cardType === 'structure' && s.archetypePassive === 'siege_commander') {
+      unit.maxHp = Math.round(unit.maxHp * ARCH_STRUCTURE_HP_MULT)
+      unit.hp    = unit.maxHp
+    }
     if (card.lore) unit.lore = card.lore;
     // Hero units use the card's display name but keep the base unit sprite
     if (card.isHero) {
@@ -137,7 +162,8 @@ export function playCard(state: GameState, cardId: string): GameState {
   if (cardIdx === -1) return state
 
   const card = state.playerHand[cardIdx]
-  if (state.mana < card.cost) return state
+  const effectiveCost = getEffectiveCardCost(card, state)
+  if (state.mana < effectiveCost) return state
 
   // For structures: if there's no upgradeable copy below max level, a new building will be placed.
   // In endless mode, block that new placement once the 3-row limit is reached.
@@ -158,12 +184,45 @@ export function playCard(state: GameState, cardId: string): GameState {
 
   const s = structuredClone(state)
   s.playerHand.splice(cardIdx, 1)
-  s.mana -= card.cost
+  s.mana -= effectiveCost
 
-  deployCard(s, card, 'player', s.log)
+  // Arcane Scholar: double upgrade effect amounts before applying
+  const isScholarUpgrade =
+    s.archetypePassive === 'arcane_scholar' &&
+    card.cardType === 'upgrade' &&
+    card.upgradeEffect != null
+  const cardToPlay: Card = isScholarUpgrade
+    ? { ...card, upgradeEffect: scaleUpgradeEffect(card.upgradeEffect!, ARCH_SCHOLAR_UPGRADE_MULT) }
+    : card
+
+  deployCard(s, cardToPlay, 'player', s.log)
   if (!s.secretRaresObtained) s.secretRaresObtained = []
   drawCard(s.playerDeck, s.playerHand, s.secretRaresObtained)
+  // Arcane Scholar: draw an extra card after each upgrade
+  if (isScholarUpgrade) {
+    drawCard(s.playerDeck, s.playerHand, s.secretRaresObtained)
+  }
   return s
+}
+
+/** Scale all numeric amount fields on an UpgradeEffect by a multiplier. */
+function scaleUpgradeEffect(effect: UpgradeEffect, mult: number): UpgradeEffect {
+  switch (effect.type) {
+    case 'buffAttack':        return { ...effect, amount: Math.round(effect.amount * mult) }
+    case 'healUnits':         return { ...effect, amount: Math.round(effect.amount * mult) }
+    case 'buffSpeed':         return { ...effect, amount: Math.round(effect.amount * mult) }
+    case 'buffMaxHp':         return { ...effect, amount: Math.round(effect.amount * mult) }
+    case 'buffRange':         return { ...effect, amount: Math.round(effect.amount * mult) }
+    case 'buffHp':            return { ...effect, amount: Math.round(effect.amount * mult) }
+    case 'buffHeal':          return { ...effect, amount: Math.round(effect.amount * mult) }
+    case 'buffAttackCooldown': return { ...effect, amount: Math.round(effect.amount * mult) }
+    case 'aoe': return {
+      ...effect,
+      damage: effect.damage != null ? Math.round(effect.damage * mult) : undefined,
+      amount: effect.amount != null ? Math.round(effect.amount * mult) : undefined,
+    }
+    default: return effect
+  }
 }
 /** Play an AoE upgrade card with a player-chosen target point (cx, cy in game units). */
 
@@ -172,15 +231,19 @@ export function playAoeCard(state: GameState, cardId: string, cx: number, cy: nu
   const cardIdx = state.playerHand.findIndex(c => c.id === cardId)
   if (cardIdx === -1) return state
   const card = state.playerHand[cardIdx]
-  if (state.mana < card.cost) return state
+  const effectiveCost = getEffectiveCardCost(card, state)
+  if (state.mana < effectiveCost) return state
   if (card.cardType !== 'upgrade' || !card.upgradeEffect || card.upgradeEffect.type !== 'aoe') return state
   if (card.isHero && state.gameTime < 30000) return state
 
   const s = structuredClone(state)
   s.playerHand.splice(cardIdx, 1)
-  s.mana -= card.cost
+  s.mana -= effectiveCost
 
-  const effect = card.upgradeEffect
+  const rawEffect = card.upgradeEffect
+  const effect = s.archetypePassive === 'arcane_scholar'
+    ? scaleUpgradeEffect(rawEffect, ARCH_SCHOLAR_UPGRADE_MULT) as typeof rawEffect & { type: 'aoe' }
+    : rawEffect
   const dmg = effect.damage ?? effect.amount ?? 0
   const enemies = s.field.filter(u => u.owner !== 'player' && !u.isWall)
   const targets = effect.range != null
@@ -194,6 +257,10 @@ export function playAoeCard(state: GameState, cardId: string, cx: number, cy: nu
 
   if (!s.secretRaresObtained) s.secretRaresObtained = []
   drawCard(s.playerDeck, s.playerHand, s.secretRaresObtained)
+  // Arcane Scholar: draw an extra card after each upgrade
+  if (s.archetypePassive === 'arcane_scholar') {
+    drawCard(s.playerDeck, s.playerHand, s.secretRaresObtained)
+  }
   return s
 }
 // ─── Apply Upgrade ────────────────────────────────────────

--- a/web/src/game/engine/constants.ts
+++ b/web/src/game/engine/constants.ts
@@ -17,3 +17,11 @@ export const OPPONENT_SPAWN_X    = LANE_WIDTH - 30  // where opponent units appe
 export const BASE_STOP_MARGIN    = 0                // units may reach the base character position exactly
 export const COMMANDER_HOME_X    = 15               // player commander's home position
 export const COMMANDER_LEASH_PX  = 40              // max px a commander can stray from home
+
+// ─── Archetype Passive Multipliers ────────────────────────
+export const ARCH_STRUCTURE_COST_REDUCTION = 1     // Siege Commander: structures cost 1 less
+export const ARCH_STRUCTURE_HP_MULT        = 1.2   // Siege Commander: +20% structure max HP
+export const ARCH_SWARM_UNIT_THRESHOLD     = 4     // Swarm Tactician: activate when ≥4 mobile units on field
+export const ARCH_SWARM_COST_REDUCTION     = 1     // Swarm Tactician: unit cards cost 1 less when active
+export const ARCH_SWARM_ATK_PER_UNIT       = 0.05  // Swarm Tactician: +5% ATK per mobile unit alive
+export const ARCH_SCHOLAR_UPGRADE_MULT     = 2     // Arcane Scholar: upgrade effect amounts doubled

--- a/web/src/game/questline.ts
+++ b/web/src/game/questline.ts
@@ -1,4 +1,4 @@
-import { CardRarity } from './types'
+import { CardRarity, Archetype } from './types'
 import { loadPlayerStats } from './playerStats'
 import { logError } from '../logger'
 import { getCardCatalog } from './cards'
@@ -503,6 +503,7 @@ export interface RunState {
   consumables: RunConsumable[] // consumable items held during this run
   activeModifierCount: number  // how many replay modifiers from the act's list are active this run
   runSeed: number              // stable random seed for this run (used for per-run node visibility rolls)
+  archetype?: Archetype        // playstyle chosen on the character screen; set at run creation
 }
 
 const RUN_KEY = 'jarv_run'
@@ -627,6 +628,7 @@ export function newRun(actId: string, activeModifierCount = 0): RunState {
     consumables: drainStashIntoRun([]),
     activeModifierCount,
     runSeed: Math.random() * 0xffffffff | 0,
+    archetype: loadPlayerArchetype() ?? undefined,
   }
 }
 
@@ -969,4 +971,70 @@ export function applyPlayerName(panels: CutscenePanel[]): CutscenePanel[] {
   const name = loadPlayerName()
   if (name === 'Jarv') return panels
   return panels.map(p => ({ ...p, text: p.text.replace(/\bJarv\b/g, name) }))
+}
+
+// ─── Archetypes ───────────────────────────────────────────
+
+export interface ArchetypeDef {
+  id: Archetype
+  name: string
+  icon: string
+  identity: string
+  passive: string
+}
+
+export const ARCHETYPE_DEFS: ArchetypeDef[] = [
+  {
+    id:       'siege_commander',
+    name:     'Siege Commander',
+    icon:     '🏰',
+    identity: 'Structures win wars',
+    passive:  'Structures cost 1 less mana. Structure HP +20%.',
+  },
+  {
+    id:       'swarm_tactician',
+    name:     'Swarm Tactician',
+    icon:     '🐝',
+    identity: 'Quantity is quality',
+    passive:  'Units cost 1 less when 4+ are on the field. +5% ATK per unit alive.',
+  },
+  {
+    id:       'arcane_scholar',
+    name:     'Arcane Scholar',
+    icon:     '📜',
+    identity: 'Upgrades shape reality',
+    passive:  'Upgrade cards have double effect. Draw +1 card after each upgrade played.',
+  },
+]
+
+/** Archetype IDs that are always available (no unlock required). */
+const ALWAYS_UNLOCKED: Archetype[] = ['siege_commander', 'swarm_tactician']
+
+export function getArchetypeDefs(campaignCompletions: number): (ArchetypeDef & { locked: boolean })[] {
+  return ARCHETYPE_DEFS.map(def => ({
+    ...def,
+    locked: !ALWAYS_UNLOCKED.includes(def.id) && campaignCompletions === 0,
+  }))
+}
+
+/** Maps each archetype to the starter pack ID that best fits its playstyle. */
+export const ARCHETYPE_STARTER_PACK: Record<Archetype, string> = {
+  siege_commander: 'fortress',
+  swarm_tactician: 'swarm',
+  arcane_scholar:  'balanced',
+}
+
+const PLAYER_ARCHETYPE_KEY = 'jarv_archetype'
+const VALID_ARCHETYPES: Archetype[] = ['siege_commander', 'swarm_tactician', 'arcane_scholar']
+
+export function loadPlayerArchetype(): Archetype | null {
+  try {
+    const v = localStorage.getItem(PLAYER_ARCHETYPE_KEY)
+    if (v && (VALID_ARCHETYPES as string[]).includes(v)) return v as Archetype
+  } catch { /* ignore */ }
+  return null
+}
+
+export function savePlayerArchetype(a: Archetype): void {
+  try { localStorage.setItem(PLAYER_ARCHETYPE_KEY, a) } catch { /* ignore */ }
 }

--- a/web/src/game/types.ts
+++ b/web/src/game/types.ts
@@ -1,3 +1,7 @@
+// ─── Archetypes ───────────────────────────────────────────
+
+export type Archetype = 'siege_commander' | 'swarm_tactician' | 'arcane_scholar'
+
 // ─── Relic Engine Hook Effects ────────────────────────────
 
 /** Periodic effect applied each engine tick (e.g. heal all player units every N ms). */
@@ -453,6 +457,10 @@ export interface GameState {
   secretRaresObtained?: string[]
   /** Count of glass cards that shattered on play this session. */
   glassShatterCount?: number
+  /** Archetype passive applied for this battle (copied from RunState at battle start). */
+  archetypePassive?: Archetype
+  /** Current ATK multiplier applied to player mobile units by the Swarm Tactician passive. */
+  swarmAtkMult?: number
 }
 
 export interface StanceRules {


### PR DESCRIPTION
## Summary

Closes #1297

Adds the Tactician Archetype system. Players choose an archetype on the Character Screen — it persists as a player preference and is snapshotted into `RunState` when a new run begins, applying passives for that entire campaign.

**Siege Commander** 🏰 — Structures win wars
- Structure cards cost 1 less mana
- Newly deployed structures have +20% max HP

**Swarm Tactician** 🐝 — Quantity is quality
- Unit cards cost 1 less when 4+ mobile units are alive on the field
- All player mobile units gain +5% ATK per alive unit (updates dynamically each tick)

**Arcane Scholar** 📜 — Upgrades shape reality *(locked until first campaign completion)*
- Upgrade card effects are doubled
- Draw +1 card after each upgrade played (including AoE upgrades)

## Changes

- `types.ts` — adds `Archetype` type, `archetypePassive` and `swarmAtkMult` to `GameState`
- `questline.ts` — adds `ARCHETYPE_DEFS`, `getArchetypeDefs()`, `ARCHETYPE_STARTER_PACK`, `loadPlayerArchetype()`, `savePlayerArchetype()`, and `archetype` field in `RunState` / `newRun()`
- `engine/constants.ts` — archetype multiplier constants
- `engine/cards.ts` — `getEffectiveCardCost()`, structure HP bonus in `deployCard()`, Scholar upgrade scaling + extra draw in `playCard()` / `playAoeCard()`
- `engine.ts` — `applyArchetypePassives()` called each tick for Swarm ATK scaling
- `App.tsx` — sets `state.archetypePassive` at battle launch; passes recommended pack to `StarterPackSelect`
- `CharacterScreen.tsx` — new ARCHETYPE section with lock indicator for Arcane Scholar
- `NodeMap.tsx` — archetype badge shown in the campaign toolbar
- `StarterPackSelect.tsx` — ⭐ RECOMMENDED badge on the archetype-matching pack

## Test plan

- [ ] Character Screen shows all three archetypes; Arcane Scholar shows locked until `actfinale` is completed
- [ ] Selecting an archetype and saving persists it (reopen Character Screen to verify)
- [ ] Start a run as **Siege Commander** → structure cards show 1 mana discount; placed structures have visibly higher HP
- [ ] Start a run as **Swarm Tactician** → deploy 4 units → unit card cost drops by 1; ATK values update as units die
- [ ] Start a run as **Arcane Scholar** → play an upgrade → effect is doubled; hand gains a card after playing it
- [ ] `run.archetype` is set in localStorage `jarv_run` after starting a run
- [ ] NodeMap toolbar shows archetype icon and name
- [ ] StarterPack screen shows ⭐ RECOMMENDED on the matching pack
- [ ] Old save without `archetype` field loads without errors and battles normally (no passive)
- [ ] All 58 unit tests pass (`npm test`)

https://claude.ai/code/session_01X1B6HWaK4thLbDnfFNPPKb

---
_Generated by [Claude Code](https://claude.ai/code/session_01X1B6HWaK4thLbDnfFNPPKb)_