### PR TITLE
fix: make archetype selection state visually clear

### DIFF
--- a/web/src/components/screens/CharacterScreen.tsx
+++ b/web/src/components/screens/CharacterScreen.tsx
@@ -194,6 +194,9 @@ export function CharacterScreen({ onDone }: Props) {
                 onClick={def.locked ? undefined : () => setArchetype(def.id)}
                 title={def.locked ? `${def.name} — complete the campaign to unlock` : def.name}
               >
+                {archetype === def.id && (
+                  <span className="character-archetype-selected-badge">✓ SELECTED</span>
+                )}
                 <span className="character-archetype-icon">{def.locked ? '🔒' : def.icon}</span>
                 <span className="character-archetype-name">{def.locked ? '???' : def.name}</span>
                 {!def.locked && <span className="character-archetype-identity">{def.identity}</span>}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -7458,6 +7458,78 @@ html.eightbit-mode .lane-layer {
   text-align: center;
 }
 
+/* ── Archetype Selection ─────────────────────────────────────────────────── */
+
+.character-archetype-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  width: 100%;
+}
+
+.character-archetype-btn {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.15rem;
+  width: 100%;
+  padding: 0.65rem 0.85rem;
+  background: #0a1a0a;
+  border: 1px solid #1e3a1e;
+  color: #aaffaa;
+  cursor: pointer;
+  text-align: left;
+  transition: border-color 0.15s, background 0.15s;
+  position: relative;
+}
+.character-archetype-btn:hover:not(.character-archetype-btn--locked) {
+  border-color: #33ff33;
+  background: #0d1a0d;
+}
+.character-archetype-btn--chosen {
+  border-color: #33ff33;
+  background: #0d2a0d;
+  box-shadow: 0 0 8px rgba(51, 255, 51, 0.25);
+}
+.character-archetype-btn--locked {
+  opacity: 0.45;
+  cursor: default;
+}
+
+.character-archetype-selected-badge {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.65rem;
+  font-size: 0.65rem;
+  color: #33ff33;
+  font-weight: bold;
+  letter-spacing: 0.05em;
+}
+
+.character-archetype-icon {
+  font-size: 1.3rem;
+  line-height: 1;
+  margin-bottom: 0.1rem;
+}
+.character-archetype-name {
+  font-size: 0.85rem;
+  font-weight: bold;
+  color: #eeffee;
+}
+.character-archetype-btn--chosen .character-archetype-name {
+  color: #33ff33;
+}
+.character-archetype-identity {
+  font-size: 0.7rem;
+  color: #88bb88;
+  font-style: italic;
+}
+.character-archetype-passive {
+  font-size: 0.68rem;
+  color: #aaa;
+  margin-top: 0.15rem;
+}
+
 /* ── Daily Challenge Screen ─────────────────────────────────────────────── */
 
 .dc-screen {


### PR DESCRIPTION
## Summary

- Add complete CSS for the archetype grid and buttons (the `character-archetype-*` classes were entirely absent, so the chosen state had no visual effect)
- Add a `✓ SELECTED` badge (absolute-positioned top-right) on the active archetype card so the current selection is unambiguous at a glance
- Chosen card also gets a green name, brighter border, and a subtle glow — matching the avatar selection style

## Test plan

- [ ] Open Character Screen → archetype cards render with borders, icons, name, identity, and passive text
- [ ] Click an archetype → `✓ SELECTED` badge appears top-right, card name turns green, border glows
- [ ] Click a different archetype → badge moves to the new selection immediately
- [ ] Locked archetype (Arcane Scholar pre-completion) remains visually dimmed and unclickable

https://claude.ai/code/session_01X1B6HWaK4thLbDnfFNPPKb

---
_Generated by [Claude Code](https://claude.ai/code/session_01X1B6HWaK4thLbDnfFNPPKb)_