### PR TITLE
feat(codex): add NPC conversations tab (issue #1326)

### DIFF
--- a/web/src/components/screens/CodexScreen.tsx
+++ b/web/src/components/screens/CodexScreen.tsx
@@ -1,11 +1,11 @@
 import React, { useState, useMemo } from 'react'
 import { OverlayScreen } from '../ui/OverlayScreen'
 import {
-  getCodexCards, getCodexRelics, getCodexWorld, getCodexFragments,
-  CodexCardEntry, CodexRelicEntry, CodexWorldEntry, CodexFragmentEntry,
+  getCodexCards, getCodexRelics, getCodexWorld, getCodexFragments, getCodexConversations,
+  CodexCardEntry, CodexRelicEntry, CodexWorldEntry, CodexFragmentEntry, CodexConversationEntry,
 } from '../../game/codex'
 
-type CodexTab = 'cards' | 'relics' | 'world' | 'fragments'
+type CodexTab = 'cards' | 'relics' | 'world' | 'fragments' | 'conversations'
 type CardTypeFilter = 'all' | 'unit' | 'structure' | 'upgrade'
 
 const RARITY_ORDER: Record<string, number> = {
@@ -23,6 +23,45 @@ const RARITY_COLORS: Record<string, string> = {
   shiny:     '#ffe066',
   holofoil:  '#40e0d0',
   glass:     '#a0d8ef',
+}
+
+function ConversationLorePanel({ entry }: { entry: CodexConversationEntry }) {
+  return (
+    <div className="codex-entry">
+      <div className="codex-entry-header">
+        <span className="codex-entry-name">{entry.icon} {entry.name}</span>
+        <span className="codex-entry-tag">{entry.title.toUpperCase()}</span>
+        <span className="codex-entry-tag">{entry.seenCount} / {entry.stages.length} ENCOUNTERS</span>
+      </div>
+      <div className="codex-conversation-stages">
+        {entry.stages.map((stage) => (
+          stage.seen ? (
+            <div key={stage.index} className="codex-conversation-stage">
+              <div className="codex-conversation-stage-label">ENCOUNTER {stage.index + 1}</div>
+              {stage.greeting.split('\n\n').map((para, i) => (
+                <div key={i} className="codex-entry-desc">{para}</div>
+              ))}
+              {stage.choices && (
+                <div className="codex-conversation-choices">
+                  {stage.choices.map((choice, j) => (
+                    <div key={j} className="codex-conversation-choice">
+                      <div className="codex-conversation-choice-label">› {choice.label}</div>
+                      <div className="codex-conversation-choice-response">{choice.response}</div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          ) : (
+            <div key={stage.index} className="codex-conversation-stage codex-conversation-stage--locked">
+              <div className="codex-conversation-stage-label">ENCOUNTER {stage.index + 1}</div>
+              <div className="codex-entry-locked-hint">Meet {entry.name} again to unlock this encounter.</div>
+            </div>
+          )
+        ))}
+      </div>
+    </div>
+  )
 }
 
 function FragmentLorePanel({ entry }: { entry: CodexFragmentEntry }) {
@@ -130,10 +169,11 @@ export function CodexScreen({ onDone }: Props) {
   const [search, setSearch] = useState('')
   const [showLocked, setShowLocked] = useState(true)
 
-  const cards     = useMemo(() => getCodexCards(),     [])
-  const relics    = useMemo(() => getCodexRelics(),    [])
-  const world     = useMemo(() => getCodexWorld(),     [])
-  const fragments = useMemo(() => getCodexFragments(), [])
+  const cards         = useMemo(() => getCodexCards(),         [])
+  const relics        = useMemo(() => getCodexRelics(),        [])
+  const world         = useMemo(() => getCodexWorld(),         [])
+  const fragments     = useMemo(() => getCodexFragments(),     [])
+  const conversations = useMemo(() => getCodexConversations(), [])
 
   const filteredCards = useMemo<CodexCardEntry[]>(() => {
     let list = cards
@@ -152,6 +192,7 @@ export function CodexScreen({ onDone }: Props) {
   const unlockedRelicCount    = relics.filter(r => r.unlocked).length
   const unlockedWorldCount    = world.filter(w => w.unlocked).length
   const discoveredFragCount   = fragments.filter(f => f.discovered).length
+  const metNpcCount           = conversations.filter(c => c.seenCount > 0).length
 
   const subtitle = tab === 'cards'
     ? `${unlockedCardCount} / ${cards.length} discovered`
@@ -159,23 +200,26 @@ export function CodexScreen({ onDone }: Props) {
     ? `${unlockedRelicCount} / ${relics.length} earned`
     : tab === 'world'
     ? `${unlockedWorldCount} / ${world.length} shards explored`
-    : `${discoveredFragCount} / ${fragments.length} fragments recovered`
+    : tab === 'fragments'
+    ? `${discoveredFragCount} / ${fragments.length} fragments recovered`
+    : `${metNpcCount} / ${conversations.length} characters met`
 
   return (
     <OverlayScreen title="CODEX" subtitle={subtitle} onBack={onDone}>
       <div className="codex-screen">
         {/* Tab bar */}
         <div className="codex-tabs">
-          {(['cards', 'relics', 'world', 'fragments'] as CodexTab[]).map(t => (
+          {(['cards', 'relics', 'world', 'fragments', 'conversations'] as CodexTab[]).map(t => (
             <button
               key={t}
               className={`filter-btn${tab === t ? ' filter-btn--active' : ''}`}
               onClick={() => setTab(t)}
             >
-              {t === 'cards'     ? `CARDS (${unlockedCardCount})` :
-               t === 'relics'    ? `RELICS (${unlockedRelicCount})` :
-               t === 'world'     ? `WORLD (${unlockedWorldCount})` :
-               `FRAGMENTS (${discoveredFragCount})`}
+              {t === 'cards'          ? `CARDS (${unlockedCardCount})` :
+               t === 'relics'         ? `RELICS (${unlockedRelicCount})` :
+               t === 'world'          ? `WORLD (${unlockedWorldCount})` :
+               t === 'fragments'      ? `FRAGMENTS (${discoveredFragCount})` :
+               `NPCS (${metNpcCount})`}
             </button>
           ))}
         </div>
@@ -226,6 +270,10 @@ export function CodexScreen({ onDone }: Props) {
 
           {tab === 'fragments' && fragments.map(entry => (
             <FragmentLorePanel key={entry.id} entry={entry} />
+          ))}
+
+          {tab === 'conversations' && conversations.map(entry => (
+            <ConversationLorePanel key={entry.id} entry={entry} />
           ))}
 
           {tab === 'cards' && filteredCards.length === 0 && (

--- a/web/src/game/characters.ts
+++ b/web/src/game/characters.ts
@@ -64,3 +64,7 @@ export function getCharacterStage(id: string): CharacterStage {
   const idx = Math.min(count, def.encounters.length - 1)
   return def.encounters[idx]
 }
+
+export function getCharacterIds(): string[] {
+  return Object.keys(catalog)
+}

--- a/web/src/game/codex.ts
+++ b/web/src/game/codex.ts
@@ -2,6 +2,7 @@ import { getCardCatalog } from './cards'
 import { loadCollection } from './collection'
 import { getRelics } from './itemStore'
 import { loadActCount } from './questline'
+import { getCharacterDef, getCharacterState, getCharacterIds } from './characters'
 import relicsData from '../data/relics.json'
 import memoryFragmentsData from '../data/memoryFragments.json'
 
@@ -100,6 +101,43 @@ export interface CodexWorldEntry {
   bossDescription: string
   shardLore: string
   unlocked: boolean
+}
+
+export interface CodexConversationStage {
+  index: number
+  greeting: string
+  choices?: Array<{ label: string; response: string }>
+  seen: boolean
+}
+
+export interface CodexConversationEntry {
+  id: string
+  name: string
+  title: string
+  icon: string
+  stages: CodexConversationStage[]
+  seenCount: number
+}
+
+export function getCodexConversations(): CodexConversationEntry[] {
+  return getCharacterIds().map(id => {
+    const def = getCharacterDef(id)!
+    const { count } = getCharacterState(id)
+    const stages: CodexConversationStage[] = def.encounters.map((enc, i) => ({
+      index: i,
+      greeting: enc.greeting,
+      choices: enc.choices?.map(c => ({ label: c.label, response: c.response })),
+      seen: count > i,
+    }))
+    return {
+      id,
+      name: def.name,
+      title: def.title,
+      icon: def.icon,
+      stages,
+      seenCount: Math.min(count, def.encounters.length),
+    }
+  })
 }
 
 export function getCodexCards(): CodexCardEntry[] {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -7351,6 +7351,54 @@ html.eightbit-mode .lane-layer {
   padding: 2rem;
 }
 
+.codex-conversation-stages {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  margin-top: 0.4rem;
+}
+
+.codex-conversation-stage {
+  border-left: 2px solid #2a5a2a;
+  padding-left: 0.6rem;
+}
+
+.codex-conversation-stage--locked {
+  border-left-color: #1a3a1a;
+  opacity: 0.5;
+}
+
+.codex-conversation-stage-label {
+  font-size: 0.62rem;
+  color: #557755;
+  letter-spacing: 0.05em;
+  margin-bottom: 0.25rem;
+}
+
+.codex-conversation-choices {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  margin-top: 0.3rem;
+}
+
+.codex-conversation-choice {
+  padding-left: 0.5rem;
+  border-left: 1px solid #1a3a1a;
+}
+
+.codex-conversation-choice-label {
+  font-size: 0.72rem;
+  color: #aaddaa;
+  margin-bottom: 0.15rem;
+}
+
+.codex-conversation-choice-response {
+  font-size: 0.7rem;
+  color: #778877;
+  font-style: italic;
+}
+
 /* ── Character Screen ─────────────────────────────────── */
 .character-screen-scroll {
   flex: 1;


### PR DESCRIPTION
## Summary

- Adds a **NPCS** tab to the Codex screen showing dialogue history for Lyra, Kael, and Mira
- Each character entry shows their encounter stages in order — unlocked ones display the full greeting text and any player choices with NPC responses; unmet stages show a locked hint
- Tab count shows how many NPCs the player has met (e.g. `NPCS (2)`)
- Subtitle updates to `X / 3 characters met` when on the conversations tab

## Changes

- `characters.ts`: export `getCharacterIds()` to enumerate NPCs without hardcoding
- `codex.ts`: add `CodexConversationEntry`, `CodexConversationStage` interfaces and `getCodexConversations()` that reads encounter state from `getCharacterState()`
- `CodexScreen.tsx`: add `ConversationLorePanel` component and `'conversations'` tab
- `styles.css`: add `codex-conversation-*` CSS for stage list, locked stages, choice labels, and response text

## Test plan

- [ ] Open the Codex and confirm a NPCS tab is present
- [ ] With no NPC encounters recorded, all three character entries show locked stages
- [ ] After meeting Lyra once, her ENCOUNTER 1 entry shows the full greeting
- [ ] After meeting Kael twice, ENCOUNTER 1 and 2 are visible with choices and responses shown
- [ ] Locked stages show a hint like "Meet Mira again to unlock this encounter."
- [ ] Tab button shows correct met count (e.g. `NPCS (1)`)
- [ ] Subtitle reads `X / 3 characters met`

https://claude.ai/code/session_01X1B6HWaK4thLbDnfFNPPKb

---
_Generated by [Claude Code](https://claude.ai/code/session_01X1B6HWaK4thLbDnfFNPPKb)_