### PR TITLE
fix: apply archetype cost reduction to card affordability and display

### DIFF
--- a/web/src/components/battle/Battlefield.tsx
+++ b/web/src/components/battle/Battlefield.tsx
@@ -7,7 +7,7 @@ import { SpriteImg, AnimatedSpriteImg } from '../ui/SpriteImg'
 import { spriteSlug } from '../../game/sprites'
 import { BattleEventOverlay } from './BattleEventOverlay'
 import { isNoDamageMode, isDebugMode } from '../../game/debug'
-import { MAX_UPGRADE_LEVEL } from '../../game/engine/cards'
+import { MAX_UPGRADE_LEVEL, getEffectiveCardCost } from '../../game/engine/cards'
 import { SUDDEN_DEATH_FORCE_MS } from '../../game/engine/suddenDeath'
 import { getRelicDef } from '../../game/relics'
 import { getUnitLore, getCardCatalog } from '../../game/cards'
@@ -1352,7 +1352,8 @@ export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPaus
               <div key={card.id} className="hand-card-wrap u-relative u-col" title={isMaxUpgrade ? 'Already at max level' : undefined}>
                 <CardTile
                   card={card}
-                  canAfford={!isMaxUpgrade && state.mana >= card.cost}
+                  canAfford={!isMaxUpgrade && state.mana >= getEffectiveCardCost(card, state)}
+                  displayCost={getEffectiveCardCost(card, state)}
                   onClick={() => {
                     if (truceLocked) return
                     if (onPlayAoeCard && card.cardType === 'upgrade' && card.upgradeEffect?.type === 'aoe') {

--- a/web/src/components/cards/CardTile.tsx
+++ b/web/src/components/cards/CardTile.tsx
@@ -137,10 +137,11 @@ interface Props {
   onClick?: () => void
   lockedSecs?: number   // hero cards: seconds remaining until playable (0 = unlocked)
   upgradeable?: boolean // collection: show UPGRADE badge
+  displayCost?: number  // override displayed cost (e.g. after archetype discounts)
   showDetails?: boolean  // collection: show details button
 }
 
-export function CardTile({ card, canAfford = true, disabled = false, onClick, lockedSecs = 0, upgradeable = false , showDetails = false }: Props) {
+export function CardTile({ card, canAfford = true, disabled = false, onClick, lockedSecs = 0, upgradeable = false , showDetails = false, displayCost }: Props) {
   const heroLocked = card.isHero && lockedSecs > 0
   const clickable = canAfford && !disabled && !heroLocked
   const { openDetail, cardDetailNode } = useCardDetail()
@@ -198,7 +199,7 @@ export function CardTile({ card, canAfford = true, disabled = false, onClick, lo
 
 
 
-      <div className="card-cost">{card.cost}</div>
+      <div className="card-cost">{displayCost ?? card.cost}</div>
       {upgradeable && <div className="card-upgrade-badge">UPGRADE</div>}
       <div className="card-title">{card.name}</div>
       <div className="card-art u-flex u-items-c u-just-c">


### PR DESCRIPTION
## Summary

- **Root cause:** `getEffectiveCardCost()` was already correctly used when deducting mana in `playCard()`, but the hand UI referenced `card.cost` (base cost) directly in two places, so archetype discounts were invisible to players.
- Fixed the `canAfford` check in `Battlefield.tsx` to use `getEffectiveCardCost(card, state)` — cards are now clickable when the player can afford the discounted cost.
- Added a `displayCost` prop to `CardTile` and passed the effective cost from the Battlefield, so the card in hand shows the discounted mana value.

Fixes #1332

## Test plan

- [ ] Start a new campaign with the **Siege Commander** archetype selected
- [ ] Confirm structure cards in hand show their cost reduced by 1 (e.g. a 3-cost Farm shows "2")
- [ ] With exactly the discounted amount of mana, confirm the card is clickable (not greyed out)
- [ ] Play a structure card and confirm mana drops by the discounted cost, not the base cost
- [ ] Verify non-structure cards are unaffected
- [ ] Verify a run without an archetype shows normal costs

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fp68s1sf53j4Yf4fKtiFjX)_