### PR TITLE
fix: apply archetype passive to resumed runs that predate archetype selection

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -35,7 +35,7 @@ import {
   ALL_CONSUMABLES, addToConsumableStash, useConsumable,
   getModifiersByCount, getModifierMax,
   setLastRunFailed, loadLastRunFailed, clearLastRunFailed,
-  ARCHETYPE_STARTER_PACK,
+  ARCHETYPE_STARTER_PACK, loadPlayerArchetype,
 } from './game/questline'
 import { CardRestSelect }       from './components/cards/CardRestSelect'
 import { CampScreen, CampChoice } from './components/campaign/CampScreen'
@@ -858,7 +858,8 @@ export default function App() {
           const state = newGame({ playerCards, ...resolvedNodeOpts(node, act, loadRunCount(), mods) })
           state.playerBase = { hp: activeRun.playerHp, maxHp: activeRun.maxHp }
           if (activeRun.activeRelic) getRelicDef(activeRun.activeRelic)?.applyToGame(state)
-          if (activeRun.archetype) state.archetypePassive = activeRun.archetype
+          const archetype = activeRun.archetype ?? loadPlayerArchetype() ?? undefined
+          if (archetype) state.archetypePassive = archetype
           state.stanceRules = STANCE_RULES_BY_NODE_TYPE[node.type]
           startBattle(state)
           rollRareEvent()


### PR DESCRIPTION
## Summary

Follow-up to #1334. The UI fix in that PR correctly called `getEffectiveCardCost`, but the function returns base cost when `state.archetypePassive` is unset — which is always the case when resuming a run that was saved before the archetype was chosen.

**Root cause:** `activeRun.archetype` is `undefined` on old/resumed runs, so the `if (activeRun.archetype)` guard in `App.tsx` never sets `archetypePassive`. The fix falls back to `loadPlayerArchetype()` so the current player archetype is always applied when entering a battle.

Closes #1332

## Test plan

- [ ] Start a campaign, enter a battle — verify structure cards show reduced cost with Siege Commander
- [ ] Abandon the run, re-enter the campaign (resume flow) — verify archetype still applies
- [ ] Test with no archetype selected — verify no cost change

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fp68s1sf53j4Yf4fKtiFjX)_