### PR TITLE
fix: mana stat upgrades persist in battle; augments apply to structure-spawned units

### DIFF
--- a/web/src/game/collection.ts
+++ b/web/src/game/collection.ts
@@ -683,13 +683,17 @@ export function buildDeckCards(entries: DeckEntry[], collection?: CollectionEntr
       if (!se.unitTemplate) continue
       const spawnXp = getMasteryXp(collection, se.unitTemplate.name)
       const spawnLvl = masteryLevel(spawnXp)
+      let ut = { ...se.unitTemplate }
       if (spawnLvl > 0) {
-        const ut = { ...se.unitTemplate }
         ut.attack  = ut.attack  + spawnLvl
         ut.maxHp   = ut.maxHp   + spawnLvl * 2
         ut.masteryLevel = spawnLvl
-        withSpawnMastery = { ...boosted, unit: { ...boosted.unit, structureEffect: { ...se, unitTemplate: ut } } }
       }
+      // Apply augment bonuses to the spawn template using the spawned unit's name
+      const spawnProxy = { ...boosted, name: se.unitTemplate.name, cardType: 'unit' as const, unit: ut }
+      const augmentedSpawn = applyAugmentBonuses(spawnProxy, se.unitTemplate.name)
+      if (augmentedSpawn.unit) ut = augmentedSpawn.unit
+      withSpawnMastery = { ...boosted, unit: { ...boosted.unit, structureEffect: { ...se, unitTemplate: ut } } }
     }
 
     const withLevel: Card = withSpawnMastery.unit

--- a/web/src/game/engine.ts
+++ b/web/src/game/engine.ts
@@ -238,10 +238,12 @@ export function newGame(
         `Enemy strategy: ${STRATEGY_LABELS[strategy]}`,
       ]
 
-  const deckMaxMana = isDailyChallenge && playerDeck.length > 0
+  const rawDeckMaxMana = isDailyChallenge && playerDeck.length > 0
     ? playerDeck.reduce((m, c) => Math.max(m, c.cost), 0)
-    : undefined
-  const maxMana = forgiveManaLimit ? 9 : Math.max(BASE_MAX_MANA, deckMaxMana ?? 0, loadPlayerStats().maxMana)
+    : 0
+  // Include playerStats.maxMana so regenerateMana() (which reads s.deckMaxMana) respects stat upgrades
+  const deckMaxMana = Math.max(rawDeckMaxMana, loadPlayerStats().maxMana)
+  const maxMana = forgiveManaLimit ? 9 : Math.max(BASE_MAX_MANA, deckMaxMana)
 
   const baseOpponentHp = hpOverride ?? (boss ? 95 : 82)
   const initialField: import('./types').Unit[] = []


### PR DESCRIPTION
## Summary

- **Fixes #1338** — "More mana" campaign reward now correctly applies in battle. `regenerateMana()` was recalculating `s.maxMana` every tick using only `BASE_MAX_MANA` and `s.deckMaxMana`, ignoring `playerStats.maxMana`. Fixed by baking `playerStats.maxMana` into `deckMaxMana` at `newGame()` time so the per-tick floor is always correct.

- **Fixes #1333** — Augment bonuses now apply to units spawned by structures (e.g. Barracks → Goblin). `buildDeckCards` was calling `applyAugmentBonuses` on player unit cards but not on the `unitTemplate` embedded in spawn-type structures. Goblins/other units spawned mid-battle by structures now inherit augment bonuses keyed to the spawned unit's name.

## Test plan

- [ ] Earn "more mana" stat upgrade, start a new campaign, enter battle — verify max mana HUD shows upgraded value and stays correct throughout play (doesn't reset to 5 on first tick)
- [ ] Equip Iron armour augments to Goblin card, include Barracks in deck, start battle — verify Barracks-spawned goblins have augmented HP rather than base 10 HP
- [ ] `npm run build` passes with no TypeScript errors ✓

https://claude.ai/code/session_0157Nc2LsuyreG7bzzzaYxdk

---
_Generated by [Claude Code](https://claude.ai/code/session_0157Nc2LsuyreG7bzzzaYxdk)_