### PR TITLE
fix: bundle scheduler into vendor-react chunk (#1348)

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -66,7 +66,7 @@ export default defineConfig({
     rollupOptions: {
       output: {
         manualChunks(id) {
-          if (id.includes('node_modules/react') || id.includes('node_modules/react-dom')) {
+          if (id.includes('node_modules/react') || id.includes('node_modules/react-dom') || id.includes('node_modules/scheduler')) {
             return 'vendor-react';
           }
           if (id.includes('node_modules/firebase')) {


### PR DESCRIPTION
Fixes #1348.

## Root cause

When PixiJS was added, Vite's chunk splitter moved the `scheduler` package (a React internal) out of the `vendor-react` chunk into the generic `vendor` chunk. Because `vendor-react` loads first, `react-dom` tried to call `scheduler.unstable_scheduleCallback` before the scheduler module was initialised, producing:

```
TypeError: undefined is not an object (evaluating 'ce.unstable_scheduleCallback')
```

## Fix

One-line change to `vite.config.ts` — add `scheduler` to the `vendor-react` `manualChunks` condition so it's always co-bundled with React and React DOM:

```ts
if (id.includes('node_modules/react') || id.includes('node_modules/react-dom') || id.includes('node_modules/scheduler')) {
  return 'vendor-react'
}
```

## Test plan

- [ ] `npm run build` passes clean
- [ ] `vendor-react` chunk contains scheduler (confirmed by build output — chunk size includes it)
- [ ] No runtime crash on https://jawg.uk after deploy

https://claude.ai/code/session_0178FWDGT2AnsK7r6hmFJU1R

---
_Generated by [Claude Code](https://claude.ai/code/session_0178FWDGT2AnsK7r6hmFJU1R)_