### PR TITLE
fix: prevent nodemap deadlock after selecting memory fragment node

### DIFF
--- a/web/src/game/questline.ts
+++ b/web/src/game/questline.ts
@@ -702,11 +702,13 @@ export function getAvailableNodeIds(act: Act, run: RunState): string[] {
 export function skipSiblings(act: Act, chosenId: string, run: RunState): RunState {
   const parentMap = buildParentMap(act)
   const parents = parentMap[chosenId] ?? []
+  // Never skip a node that is also a child of the chosen node — it's still reachable.
+  const chosenChildren = new Set(act.nodes[chosenId]?.childIds ?? [])
   const siblings: string[] = []
   for (const pid of parents) {
     const parent = act.nodes[pid]
     for (const cid of parent.childIds) {
-      if (cid !== chosenId && !run.completedNodeIds.includes(cid) && !run.skippedNodeIds.includes(cid)) {
+      if (cid !== chosenId && !run.completedNodeIds.includes(cid) && !run.skippedNodeIds.includes(cid) && !chosenChildren.has(cid)) {
         siblings.push(cid)
       }
     }


### PR DESCRIPTION
## Summary

Fixes a softlock where the campaign nodemap becomes fully dimmed and unnavigable after visiting a memory fragment node.

**Root cause:** Several acts (1, 2, 10, 11, 12) have "convergence" nodes that are reachable via two paths: directly from an earlier battle node, OR through a memory fragment node. For example in act1:

```
captain (battle) ──┬──> mem-act1-1 (memory) ──> war-camp
                   └──> war-camp  (also a direct child of captain)
```

`war-camp` is both a *sibling* of `mem-act1-1` (shared parent `captain`) and a *child* of `mem-act1-1`.

When the player selected `mem-act1-1`, `skipSiblings()` marked `war-camp` as skipped (treating it purely as an unchosen branch). After collecting the fragment, `war-camp` was still flagged skipped, so `getAvailableNodeIds()` excluded it — leaving the entire nodemap with nothing selectable.

**Fix:** `skipSiblings()` now exempts any sibling that is also a direct child of the chosen node, since that node remains reachable via the chosen path.

## Test plan

- [ ] Act 1: complete the first battle (`captain`), choose the memory fragment branch (`mem-act1-1`), collect the fragment — verify `war-camp` becomes available on the nodemap
- [ ] Act 2: same test with `mem-act2-1` → `supply-cache`
- [ ] Verify non-memory branch choices still correctly skip the unchosen sibling branches
- [ ] `npm run build` passes ✓

https://claude.ai/code/session_0157Nc2LsuyreG7bzzzaYxdk

---
_Generated by [Claude Code](https://claude.ai/code/session_0157Nc2LsuyreG7bzzzaYxdk)_