### PR TITLE
debug: nodemap Copy Debug State button

### DIFF
--- a/web/src/components/campaign/NodeMap.tsx
+++ b/web/src/components/campaign/NodeMap.tsx
@@ -874,6 +874,29 @@ export function NodeMap({ act, run, onSelectNode, onUseConsumable, onBack }: Pro
           )
         })}
 
+        <ToolbarSpacer />
+        <ToolbarButton
+          label="Copy Debug State"
+          icon="🐞"
+          onClick={() => {
+            const nodeStatuses: Record<string, string> = {}
+            for (const node of Object.values(act.nodes)) {
+              nodeStatuses[node.id] = `${node.type} → ${statusOf(node.id)}`
+            }
+            const state = {
+              actId:            run.actId,
+              pendingNodeId:    run.pendingNodeId,
+              completedNodeIds: run.completedNodeIds,
+              skippedNodeIds:   run.skippedNodeIds,
+              availableIds,
+              nodeStatuses,
+            }
+            const text = JSON.stringify(state, null, 2)
+            console.log('[NodeMap debug]', state)
+            navigator.clipboard?.writeText(text).catch(() => undefined)
+            alert('Debug state copied to clipboard (also logged to console).')
+          }}
+        />
       </Toolbar>
 
 


### PR DESCRIPTION
## Summary

Adds a temporary **🐞 Copy Debug State** button to the nodemap toolbar to diagnose a reported stuck/dimmed nodemap issue.

Pressing the button:
- Copies a JSON snapshot to the clipboard containing `actId`, `pendingNodeId`, `completedNodeIds`, `skippedNodeIds`, `availableIds`, and the status of every node
- Logs the same object to the browser console under `[NodeMap debug]`
- Shows a brief alert confirming the copy

This can be removed once the root cause is confirmed and fixed.

## Test plan

- [ ] Open nodemap — verify 🐞 button appears in toolbar
- [ ] Press button — confirm clipboard contains valid JSON with node state
- [ ] Confirm console logs `[NodeMap debug]` object

https://claude.ai/code/session_0157Nc2LsuyreG7bzzzaYxdk

---
_Generated by [Claude Code](https://claude.ai/code/session_0157Nc2LsuyreG7bzzzaYxdk)_