### PR TITLE
fix: auto-repair stuck nodemap saves (convergence-node skip bug)

### DIFF
--- a/web/src/game/questline.ts
+++ b/web/src/game/questline.ts
@@ -553,6 +553,26 @@ export function loadRun(): RunState | null {
       parsed.pendingNodeId = null
     }
 
+    // Repair saves corrupted by the convergence-node skip bug (fixed in skipSiblings):
+    // A node Y was incorrectly skipped if any of its completed parents has no other completed child.
+    // Such a node is still reachable and must be un-skipped so the map isn't deadlocked.
+    {
+      const completedSet = new Set(parsed.completedNodeIds)
+      const parentMap = buildParentMap(act)
+      const toUnSkip = parsed.skippedNodeIds.filter(nodeId => {
+        const parents = parentMap[nodeId] ?? []
+        return parents.some(pid => {
+          if (!completedSet.has(pid)) return false
+          return !act.nodes[pid].childIds.some(cid => cid !== nodeId && completedSet.has(cid))
+        })
+      })
+      if (toUnSkip.length > 0) {
+        const unSkipSet = new Set(toUnSkip)
+        parsed.skippedNodeIds = parsed.skippedNodeIds.filter(id => !unSkipSet.has(id))
+        saveRun(parsed)
+      }
+    }
+
     // If act is already complete with no pendingNode, clear run so a fresh one starts —
     // unless pendingActComplete is set (player is on the act-complete screen) or
     // pendingRelicSelect is set (player exited mid relic-select between acts).


### PR DESCRIPTION
## Summary

- Adds a save-repair migration to `loadRun()` in `questline.ts` that automatically un-skips nodes that were incorrectly added to `skippedNodeIds` due to the convergence-node bug (fixed in PR #1350).
- The repair runs on every `loadRun()` call: for each skipped node, if any of its completed parents has no other completed child, the node could not have been a legitimate skipped branch alternative and is removed from `skippedNodeIds`.
- Repaired saves are immediately written back via `saveRun()` so the fix persists.

### Why this is safe
The rule only un-skips a node when a completed parent has **no other completed child** — meaning no branch was chosen via that parent, so the skip could only have come from the bug. Legitimate skips (where a sibling branch was taken) are never touched.

This directly unblocks the player save described in the bug report: `war-camp` was incorrectly skipped after navigating through `mem-act1-1` (a memory fragment node), leaving `availableIds` empty and the nodemap unnavigable.

## Test plan
- [ ] Load a save with `war-camp` in `skippedNodeIds` (user's corrupt save) — verify nodemap becomes navigable after page load
- [ ] Normal play through a forked path — verify legitimate skips are not affected
- [ ] `npm run build` passes (only pre-existing pixi.js type errors, unrelated to this change)

https://claude.ai/code/session_0157Nc2LsuyreG7bzzzaYxdk

---
_Generated by [Claude Code](https://claude.ai/code/session_0157Nc2LsuyreG7bzzzaYxdk)_