### PR TITLE
fix: persist archetype immediately on selection

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1066,6 +1066,8 @@ export default function App() {
     const state = newGame({ playerCards, ...resolvedNodeOpts(node, act, loadRunCount(), mods733) })
     state.playerBase = { hp: updatedRun.playerHp, maxHp: updatedRun.maxHp }
     if (updatedRun.activeRelic) getRelicDef(updatedRun.activeRelic)?.applyToGame(state)
+    const archetypeA = updatedRun.archetype ?? loadPlayerArchetype() ?? undefined
+    if (archetypeA) state.archetypePassive = archetypeA
     state.stanceRules = STANCE_RULES_BY_NODE_TYPE[node.type]
     startBattle(state)
     rollRareEvent()
@@ -1096,6 +1098,8 @@ export default function App() {
     const state = newGame({ playerCards, ...resolvedNodeOpts(node, act, loadRunCount(), mods761) })
     state.playerBase = { hp: run.playerHp, maxHp: run.maxHp }
     if (run.activeRelic) getRelicDef(run.activeRelic)?.applyToGame(state)
+    const archetypeB = run.archetype ?? loadPlayerArchetype() ?? undefined
+    if (archetypeB) state.archetypePassive = archetypeB
     state.stanceRules = STANCE_RULES_BY_NODE_TYPE[node.type]
     startBattle(state)
     rollRareEvent()
@@ -1784,6 +1788,8 @@ export default function App() {
     const state = newGame({ playerCards, ...resolvedNodeOpts(node, act, loadRunCount(), modsRetry) })
     state.playerBase = { hp: withFail.playerHp, maxHp: withFail.maxHp }
     if (withFail.activeRelic) getRelicDef(withFail.activeRelic)?.applyToGame(state)
+    const archetypeC = withFail.archetype ?? loadPlayerArchetype() ?? undefined
+    if (archetypeC) state.archetypePassive = archetypeC
     state.stanceRules = STANCE_RULES_BY_NODE_TYPE[node.type]
     startBattle(state)
     rollRareEvent()

--- a/web/src/components/screens/CharacterScreen.tsx
+++ b/web/src/components/screens/CharacterScreen.tsx
@@ -191,7 +191,7 @@ export function CharacterScreen({ onDone }: Props) {
               <button
                 key={def.id}
                 className={`character-archetype-btn${archetype === def.id ? ' character-archetype-btn--chosen' : ''}${def.locked ? ' character-archetype-btn--locked' : ''}`}
-                onClick={def.locked ? undefined : () => setArchetype(def.id)}
+                onClick={def.locked ? undefined : () => { setArchetype(def.id); savePlayerArchetype(def.id) }}
                 title={def.locked ? `${def.name} — complete the campaign to unlock` : def.name}
               >
                 {archetype === def.id && (


### PR DESCRIPTION
## Summary

Follow-up to #1334 and #1342. The root cause of #1332.

`CharacterScreen` has a Back button (`onBack={onDone}`) that returns to the title screen without calling `handleSave()`. If the user clicked an archetype and then pressed Back instead of Save, the selection was held only in React state and was silently discarded — `savePlayerArchetype` was never called, so `localStorage` had no archetype, and `archetypePassive` was never set at battle start.

**Fix:** Call `savePlayerArchetype(def.id)` immediately when an archetype button is clicked, alongside `setArchetype`. The choice is now persisted to `localStorage` the moment it's selected, regardless of whether the user exits via Save or Back.

Closes #1332

## Test plan

- [ ] Open Character screen, click Siege Commander, press Back (don't click Save)
- [ ] Start a new campaign and enter a battle — structures should show reduced cost
- [ ] Verify switching archetypes updates localStorage immediately (second selection overrides first)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fp68s1sf53j4Yf4fKtiFjX)_