### PR TITLE
fix: apply archetype passive in all campaign battle-start paths

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1066,6 +1066,8 @@ export default function App() {
     const state = newGame({ playerCards, ...resolvedNodeOpts(node, act, loadRunCount(), mods733) })
     state.playerBase = { hp: updatedRun.playerHp, maxHp: updatedRun.maxHp }
     if (updatedRun.activeRelic) getRelicDef(updatedRun.activeRelic)?.applyToGame(state)
+    const archetypeA = updatedRun.archetype ?? loadPlayerArchetype() ?? undefined
+    if (archetypeA) state.archetypePassive = archetypeA
     state.stanceRules = STANCE_RULES_BY_NODE_TYPE[node.type]
     startBattle(state)
     rollRareEvent()
@@ -1096,6 +1098,8 @@ export default function App() {
     const state = newGame({ playerCards, ...resolvedNodeOpts(node, act, loadRunCount(), mods761) })
     state.playerBase = { hp: run.playerHp, maxHp: run.maxHp }
     if (run.activeRelic) getRelicDef(run.activeRelic)?.applyToGame(state)
+    const archetypeB = run.archetype ?? loadPlayerArchetype() ?? undefined
+    if (archetypeB) state.archetypePassive = archetypeB
     state.stanceRules = STANCE_RULES_BY_NODE_TYPE[node.type]
     startBattle(state)
     rollRareEvent()
@@ -1784,6 +1788,8 @@ export default function App() {
     const state = newGame({ playerCards, ...resolvedNodeOpts(node, act, loadRunCount(), modsRetry) })
     state.playerBase = { hp: withFail.playerHp, maxHp: withFail.maxHp }
     if (withFail.activeRelic) getRelicDef(withFail.activeRelic)?.applyToGame(state)
+    const archetypeC = withFail.archetype ?? loadPlayerArchetype() ?? undefined
+    if (archetypeC) state.archetypePassive = archetypeC
     state.stanceRules = STANCE_RULES_BY_NODE_TYPE[node.type]
     startBattle(state)
     rollRareEvent()

--- a/web/src/components/screens/CharacterScreen.tsx
+++ b/web/src/components/screens/CharacterScreen.tsx
@@ -191,7 +191,7 @@ export function CharacterScreen({ onDone }: Props) {
               <button
                 key={def.id}
                 className={`character-archetype-btn${archetype === def.id ? ' character-archetype-btn--chosen' : ''}${def.locked ? ' character-archetype-btn--locked' : ''}`}
-                onClick={def.locked ? undefined : () => setArchetype(def.id)}
+                onClick={def.locked ? undefined : () => { setArchetype(def.id); savePlayerArchetype(def.id) }}
                 title={def.locked ? `${def.name} — complete the campaign to unlock` : def.name}
               >
                 {archetype === def.id && (


### PR DESCRIPTION
## Summary

Three separate bugs all contributing to #1332:

1. **`CharacterScreen`** — archetype selection was only persisted in `handleSave()`. Clicking Back discarded the selection silently. Fix: call `savePlayerArchetype` immediately on click.

2. **`App.tsx` — `handleCampaign`** — `activeRun.archetype` was undefined for runs created before the archetype was saved. Fix: fall back to `loadPlayerArchetype()`.

3. **`App.tsx` — three additional `startBattle` call sites** (node select, post-boss-dialogue, retry-after-defeat) — `archetypePassive` was never set in these paths at all. The normal "tap a node on the map" flow goes through one of these, so the archetype *never* applied during regular campaign play.

Closes #1332

## Test plan

- [ ] Select Siege Commander on the Character screen and click Save
- [ ] Start a new campaign, tap a battle node — structures should show cost reduced by 1
- [ ] Retry a lost battle — archetype should still apply
- [ ] Complete a boss dialogue then enter the boss fight — archetype should still apply
- [ ] Verify no archetype selected → no cost change

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fp68s1sf53j4Yf4fKtiFjX)_