### PR TITLE
fix: register controllerchange listener early to prevent missed SW updates

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -237,6 +237,12 @@ export default function App() {
   const { needRefresh: [needRefresh], updateServiceWorker } = useRegisterSW({
     onRegisteredSW(_url, r) {
       swRegRef.current = r ?? null
+      // Register the controllerchange listener immediately so we never race
+      // with skipWaiting: the new SW may activate before onNeedRefresh fires.
+      let reloading = false
+      navigator.serviceWorker.addEventListener('controllerchange', () => {
+        if (!reloading) { reloading = true; window.location.reload() }
+      })
       // In standalone (home screen) mode the browser doesn't trigger SW update
       // checks on each launch the way a normal tab does, so we kick one off
       // immediately and then repeat every hour.


### PR DESCRIPTION
## Summary

With `skipWaiting: true` in the workbox config, the new service worker calls `skipWaiting()` itself during install and can activate — firing `controllerchange` — **before** `onNeedRefresh` runs and tries to add its own `controllerchange` listener inside `updateServiceWorker(true)`. The listener was registered too late, so the page never reloaded and users had to refresh manually.

**Fix:** register a `controllerchange` → `window.location.reload()` listener eagerly inside `onRegisteredSW`, so it is always in place before any new SW can take effect. A `reloading` flag prevents infinite reload loops. The existing `onNeedRefresh` / `needRefresh` effect are kept as a secondary safety net.

## Test plan

- [ ] Deploy a new version while the app is open — page should reload automatically within a few seconds
- [ ] Reload should not loop (only fires once)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fp68s1sf53j4Yf4fKtiFjX)_