### PR TITLE
feat: full PixiJS NodeMap — Y-sorted world layer, PixiJS markers, avatar walk

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - web/src/**
+      - .github/workflows/test.yml
 
 jobs:
   test:
@@ -23,6 +24,9 @@ jobs:
         run: npm install
         working-directory: web
 
+      - name: Set Playwright browsers path
+        run: echo "PLAYWRIGHT_BROWSERS_PATH=$HOME/.cache/ms-playwright" >> $GITHUB_ENV
+
       - name: Cache Playwright browsers
         uses: actions/cache@v4
         with:
@@ -32,14 +36,11 @@ jobs:
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
         working-directory: web
-        env:
-          PLAYWRIGHT_BROWSERS_PATH: 0
 
       - name: Test
         run: npm test
         working-directory: web
         env:
-          PLAYWRIGHT_BROWSERS_PATH: 0
           VITE_FIREBASE_API_KEY: ${{ secrets.VITE_FIREBASE_API_KEY }}
           VITE_FIREBASE_AUTH_DOMAIN: ${{ secrets.VITE_FIREBASE_AUTH_DOMAIN }}
           VITE_FIREBASE_PROJECT_ID: ${{ secrets.VITE_FIREBASE_PROJECT_ID }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,11 +32,14 @@ jobs:
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
         working-directory: web
+        env:
+          PLAYWRIGHT_BROWSERS_PATH: 0
 
       - name: Test
         run: npm test
         working-directory: web
         env:
+          PLAYWRIGHT_BROWSERS_PATH: 0
           VITE_FIREBASE_API_KEY: ${{ secrets.VITE_FIREBASE_API_KEY }}
           VITE_FIREBASE_AUTH_DOMAIN: ${{ secrets.VITE_FIREBASE_AUTH_DOMAIN }}
           VITE_FIREBASE_PROJECT_ID: ${{ secrets.VITE_FIREBASE_PROJECT_ID }}

--- a/web/src/components/campaign/NodeMap.tsx
+++ b/web/src/components/campaign/NodeMap.tsx
@@ -1,19 +1,20 @@
 import React, { useMemo, useRef, useEffect, useState } from 'react'
+import * as PIXI from 'pixi.js'
 import { emitSound } from '../../game/sound'
 import { getDiscoveredFragmentIds } from '../../game/codex'
 import { Act, QuestNode, RunState, ReplayModifier, getAvailableNodeIds, loadNodeHistory, getModifiersByCount, ALL_CONSUMABLES, loadPlayerAvatar, ARCHETYPE_DEFS } from '../../game/questline'
 import { spriteSlug } from '../../game/sprites'
 import { StatRow } from '../ui/StatRow'
-import { AnimatedSpriteImg } from '../ui/SpriteImg'
 import { getCardUnit } from '../../game/cards'
 import { Lives } from '../ui/Lives/Lives'
 import { OverlayScreen } from '../ui/OverlayScreen'
 import { Toolbar } from '../ui/Toolbar/Toolbar'
 import { ToolbarButton } from '../ui/Toolbar/ToolbarButton'
 import { NodeMapHpBar } from './NodeMapHpBar'
-import { ToolbarSubComponent } from '../ui/Toolbar/ToolbarSubComponent'
 import { ToolbarSpacer } from '../ui/Toolbar/ToolbarSpacer'
 import { ToolbarLabel } from '../ui/Toolbar/ToolbarLabel'
+import { usePixiApp } from '../../hooks/usePixiApp'
+import { loadSpriteTexture, loadAnimFrames, loadTextureUrl, makeClickable, tweenTo } from '../../utils/pixiHelpers'
 
 interface Props {
   act: Act
@@ -24,32 +25,76 @@ interface Props {
 }
 
 const NODE_ICON: Record<string, string> = {
-  battle:   '⚔',
-  elite:    '★',
-  boss:     '☠',
-  rest:     '⛺',
-  event:    '?',
-  merchant: '⚖',
-  memory:   '◆',
+  battle: '⚔', elite: '★', boss: '☠', rest: '⛺',
+  event: '?', merchant: '⚖', memory: '◆',
 }
 
-const COL_WIDTH      = 112 // fixed pixel width per map column slot
-const ROW_HEIGHT     = 112 // fixed pixel height per vertical node slot within a column
-const AVATAR_PADDING = 72  // left space in nm-map-inner for the "node 0" start position
-const AVATAR_SIZE    = 36  // px avatar width/height
-const WALK_DURATION  = 700 // ms for the walk animation
-
-function startPosition(mapHeight: number): { x: number; y: number } {
-  return { x: AVATAR_PADDING / 2, y: mapHeight / 2 }
+const NODE_LABEL: Record<string, string> = {
+  battle: 'BATTLE', elite: 'ELITE', boss: 'BOSS', rest: 'REST',
+  event: 'EVENT', merchant: 'SHOP', memory: 'MEMORY',
 }
 
-function getRelativeCenter(el: HTMLElement, container: HTMLElement): { x: number; y: number } {
-  const er = el.getBoundingClientRect()
-  const cr = container.getBoundingClientRect()
-  return {
-    x: er.left - cr.left + er.width  / 2,
-    y: er.top  - cr.top  + er.height / 2,
+const COL_WIDTH      = 112
+const ROW_HEIGHT     = 112
+const AVATAR_PADDING = 72
+const CONN_W         = 44
+const AVATAR_SIZE    = 36
+const WALK_DURATION  = 700
+const NODE_RADIUS    = 22
+
+// ── Game logic helpers ────────────────────────────────────────────────────────
+
+type NodeStatus = 'completed' | 'available' | 'skipped' | 'locked' | 'pending'
+
+function getNodeStatus(nodeId: string, availableIds: string[], run: RunState): NodeStatus {
+  if (run.pendingNodeId === nodeId)          return 'pending'
+  if (run.completedNodeIds.includes(nodeId)) return 'completed'
+  if (run.skippedNodeIds.includes(nodeId))   return 'skipped'
+  if (availableIds.includes(nodeId))         return 'available'
+  return 'locked'
+}
+
+function computeReachableIds(act: Act, run: RunState): Set<string> {
+  const skipped = new Set(run.skippedNodeIds)
+  const reachable = new Set<string>()
+  function visit(id: string) {
+    if (reachable.has(id) || skipped.has(id)) return
+    reachable.add(id)
+    const node = act.nodes[id]
+    if (!node) return
+    for (const childId of node.childIds) visit(childId)
   }
+  const hasParent = new Set<string>()
+  for (const node of Object.values(act.nodes))
+    for (const cid of node.childIds) hasParent.add(cid)
+  for (const [id] of Object.entries(act.nodes))
+    if (!hasParent.has(id) && !skipped.has(id)) visit(id)
+  return reachable
+}
+
+function buildRows(act: Act): QuestNode[][] {
+  const byRow: Record<number, QuestNode[]> = {}
+  for (const node of Object.values(act.nodes)) {
+    if (!byRow[node.row]) byRow[node.row] = []
+    byRow[node.row].push(node)
+  }
+  return Object.keys(byRow).map(Number).sort((a, b) => a - b)
+    .map(r => byRow[r].sort((a, b) => a.col - b.col))
+}
+
+function computeHiddenNodeIds(act: Act, run: RunState, discoveredFragIds: Set<string>): Set<string> {
+  const ids = new Set<string>()
+  for (const node of Object.values(act.nodes)) {
+    if (node.type !== 'memory' || !node.fragmentId) continue
+    const alreadyFound   = discoveredFragIds.has(node.fragmentId)
+    const visitedThisRun = run.completedNodeIds.includes(node.id)
+    if (alreadyFound && !visitedThisRun) {
+      ids.add(node.id)
+    } else if (!alreadyFound && !visitedThisRun) {
+      if (hashStr(node.id + String(run.runSeed)) % 100 >= 20) ids.add(node.id)
+    }
+  }
+  return ids
 }
 
 function lastCompletedNode(act: Act, run: RunState): QuestNode | null {
@@ -63,87 +108,18 @@ function lastCompletedNode(act: Act, run: RunState): QuestNode | null {
   return act.nodes[run.completedNodeIds[run.completedNodeIds.length - 1]] ?? null
 }
 
-const NODE_LABEL: Record<string, string> = {
-  battle:   'BATTLE',
-  elite:    'ELITE',
-  boss:     'BOSS',
-  rest:     'REST',
-  event:    'EVENT',
-  merchant: 'SHOP',
-  memory:   'MEMORY',
-}
-
-function nodeSprite(node: QuestNode): string | null {
-  if (node.type === 'rest')     return '/sprites/campfire.svg'
-  if (node.type === 'merchant') return '/sprites/merchant.svg'
-  if (node.type === 'event')    return '/sprites/event.svg'
-  if (node.type === 'memory')   return '/sprites/event.svg'
-  if (node.type === 'boss' && node.bossAI)
-    return `/sprites/boss-${node.bossAI}.svg`
-  if ((node.type === 'battle' || node.type === 'elite') && node.enemyDeck?.length)
-    return `/sprites/${spriteSlug(node.enemyDeck[0])}.svg`
-  return null
-}
-
-type NodeStatus = 'completed' | 'available' | 'skipped' | 'locked' | 'pending'
-
-function getNodeStatus(
-  nodeId: string,
-  availableIds: string[],
-  run: RunState,
-): NodeStatus {
-  if (run.pendingNodeId === nodeId)          return 'pending'
-  if (run.completedNodeIds.includes(nodeId)) return 'completed'
-  if (run.skippedNodeIds.includes(nodeId))   return 'skipped'
-  if (availableIds.includes(nodeId))         return 'available'
-  return 'locked'
-}
-
-/**
- * BFS from start nodes (parentIds === []) following non-skipped edges.
- * Returns the set of node IDs that can still be reached in the current run.
- * Completed, available, and future-path nodes are all included; skipped and
- * their descendants that have no other parent are excluded.
- */
-function computeReachableIds(act: Act, run: RunState): Set<string> {
-  const skipped = new Set(run.skippedNodeIds)
-  const reachable = new Set<string>()
-
-  function visit(id: string) {
-    if (reachable.has(id) || skipped.has(id)) return
-    reachable.add(id)
-    const node = act.nodes[id]
-    if (!node) return
-    for (const childId of node.childIds) {
-      visit(childId)
-    }
+function nodePosition(
+  rowIndex: number, node: QuestNode, rowCols: number, maxRowCols: number,
+): { x: number; y: number } {
+  return {
+    x: AVATAR_PADDING + rowIndex * (COL_WIDTH + CONN_W) + COL_WIDTH / 2,
+    y: ((maxRowCols - rowCols) / 2 + node.col + 0.5) * ROW_HEIGHT,
   }
-
-  // Build reverse map to find start nodes (those with no parents)
-  const hasParent = new Set<string>()
-  for (const node of Object.values(act.nodes)) {
-    for (const cid of node.childIds) hasParent.add(cid)
-  }
-  for (const [id] of Object.entries(act.nodes)) {
-    if (!hasParent.has(id) && !skipped.has(id)) visit(id)
-  }
-  return reachable
 }
 
-// Rows sorted top→bottom (row 0 first; boss last)
-function buildRows(act: Act): QuestNode[][] {
-  const byRow: Record<number, QuestNode[]> = {}
-  for (const node of Object.values(act.nodes)) {
-    if (!byRow[node.row]) byRow[node.row] = []
-    byRow[node.row].push(node)
-  }
-  return Object.keys(byRow)
-    .map(Number)
-    .sort((a, b) => a - b)
-    .map(r => byRow[r].sort((a, b) => a.col - b.col))
-}
+function startPos(mapHeight: number) { return { x: AVATAR_PADDING / 2, y: mapHeight / 2 } }
 
-// ── Terrain decoration layer ─────────────────────────────────────────────────
+// ── Terrain helpers ────────────────────────────────────────────────────────────
 
 function seededRand(seed: number) {
   let s = seed | 0
@@ -164,284 +140,173 @@ function hashStr(str: string): number {
 interface TerrainItem { x: number; y: number; scale: number; kind: string }
 
 function getTerrainItems(env: string | undefined, seed: number, w: number, h: number): TerrainItem[] {
-  const r   = seededRand(seed)
-  const rf  = (lo: number, hi: number) => lo + r() * (hi - lo)
+  const r = seededRand(seed)
+  const rf = (lo: number, hi: number) => lo + r() * (hi - lo)
   const pad = 30
   const items: TerrainItem[] = []
-
   const scatter = (kind: string, count: number, minS: number, maxS: number) => {
     for (let i = 0; i < count; i++)
       items.push({ kind, x: rf(pad, w - pad), y: rf(pad, h - pad), scale: rf(minS, maxS) })
   }
-
   switch (env) {
-    case 'forest':
-      scatter('tree',     14, 0.8, 1.5)
-      scatter('mountain',  4, 0.5, 0.9)
-      scatter('river',     1, 1,   1  )
-      break
-    case 'citadel':
-      scatter('tower',    10, 0.8, 1.4)
-      scatter('mountain',  5, 0.5, 1.0)
-      break
-    case 'ruins':
-      scatter('pillar',    9, 0.8, 1.3)
-      scatter('tree',      4, 0.5, 0.9)
-      scatter('river',     1, 1,   1  )
-      break
-    case 'ashen':
-      scatter('mountain', 10, 0.7, 1.4)
-      scatter('deadtree',  6, 0.8, 1.3)
-      break
-    case 'farmland':
-      scatter('tree',      8, 0.7, 1.1)
-      scatter('mountain',  4, 0.4, 0.7)
-      scatter('river',     1, 1,   1  )
-      break
-    case 'frost':
-      scatter('crystal',  12, 0.8, 1.4)
-      scatter('mountain',  6, 0.7, 1.2)
-      scatter('river',     1, 1,   1  )
-      break
-    case 'volcano':
-      scatter('mountain', 10, 0.8, 1.5)
-      scatter('lava',      5, 0.7, 1.2)
-      break
-    case 'sand':
-      scatter('dune',     10, 0.7, 1.3)
-      scatter('mountain',  4, 0.5, 0.9)
-      break
+    case 'forest':   scatter('tree', 14, 0.8, 1.5); scatter('mountain', 4, 0.5, 0.9); scatter('river', 1, 1, 1); break
+    case 'citadel':  scatter('tower', 10, 0.8, 1.4); scatter('mountain', 5, 0.5, 1.0); break
+    case 'ruins':    scatter('pillar', 9, 0.8, 1.3); scatter('tree', 4, 0.5, 0.9); scatter('river', 1, 1, 1); break
+    case 'ashen':    scatter('mountain', 10, 0.7, 1.4); scatter('deadtree', 6, 0.8, 1.3); break
+    case 'farmland': scatter('tree', 8, 0.7, 1.1); scatter('mountain', 4, 0.4, 0.7); scatter('river', 1, 1, 1); break
+    case 'frost':    scatter('crystal', 12, 0.8, 1.4); scatter('mountain', 6, 0.7, 1.2); scatter('river', 1, 1, 1); break
+    case 'volcano':  scatter('mountain', 10, 0.8, 1.5); scatter('lava', 5, 0.7, 1.2); break
+    case 'sand':     scatter('dune', 10, 0.7, 1.3); scatter('mountain', 4, 0.5, 0.9); break
     case 'reef':
-    case 'coast':
-      scatter('wave',     10, 0.8, 1.4)
-      scatter('mountain',  4, 0.5, 0.9)
-      scatter('river',     1, 1,   1  )
-      break
-    case 'sky':
-      scatter('cloud',    12, 0.8, 1.5)
-      scatter('mountain',  4, 0.4, 0.8)
-      break
-    case 'fungal':
-      scatter('mushroom', 12, 0.8, 1.5)
-      scatter('deadtree',  4, 0.5, 0.9)
-      scatter('river',     1, 1,   1  )
-      break
+    case 'coast':    scatter('wave', 10, 0.8, 1.4); scatter('mountain', 4, 0.5, 0.9); scatter('river', 1, 1, 1); break
+    case 'sky':      scatter('cloud', 12, 0.8, 1.5); scatter('mountain', 4, 0.4, 0.8); break
+    case 'fungal':   scatter('mushroom', 12, 0.8, 1.5); scatter('deadtree', 4, 0.5, 0.9); scatter('river', 1, 1, 1); break
     case 'vault':
-    case 'camp':
-      scatter('pillar',    8, 0.7, 1.2)
-      scatter('mountain',  4, 0.5, 0.9)
-      break
-    default:
-      scatter('mountain', 10, 0.6, 1.2)
-      scatter('tree',      4, 0.6, 1.0)
+    case 'camp':     scatter('pillar', 8, 0.7, 1.2); scatter('mountain', 4, 0.5, 0.9); break
+    default:         scatter('mountain', 10, 0.6, 1.2); scatter('tree', 4, 0.6, 1.0)
   }
-
   return items
 }
 
-interface TerrainProps { environment?: string; actId: string; width: number; height: number }
+// ── PixiJS terrain builder ─────────────────────────────────────────────────────
+// Rivers go into groundLayer; all other items go into worldLayer for Y-sorting.
 
-function MapTerrain({ environment, actId, width, height }: TerrainProps) {
-  const items = useMemo(
-    () => getTerrainItems(environment, hashStr(actId), width, height),
-    [environment, actId, width, height],
-  )
+function buildTerrainGfx(
+  groundLayer: PIXI.Container,
+  worldLayer: PIXI.Container,
+  environment: string | undefined,
+  actId: string,
+  mapWidth: number,
+  mapHeight: number,
+): void {
+  const items = getTerrainItems(environment, hashStr(actId), mapWidth, mapHeight)
 
-  const riverColor = (() => {
-    switch (environment) {
-      case 'volcano': return '#cc4400'
-      case 'fungal':  return '#6633aa'
-      case 'frost':   return '#88ddff'
-      default:        return '#2255aa'
-    }
-  })()
+  const riverColor = environment === 'volcano' ? 0xcc4400
+                   : environment === 'fungal'  ? 0x6633aa
+                   : environment === 'frost'   ? 0x88ddff : 0x2255aa
 
-  const riverItems   = items.filter(it => it.kind === 'river')
-  const terrainItems = items.filter(it => it.kind !== 'river')
-
-  // Seed river control points off actId hash
   const rseed = hashStr(actId + 'river')
-  const rr    = seededRand(rseed)
-  const rrf   = (lo: number, hi: number) => lo + rr() * (hi - lo)
+  const rr = seededRand(rseed)
+  const rrf = (lo: number, hi: number) => lo + rr() * (hi - lo)
 
-  return (
-    <svg
-      viewBox={`0 0 ${width} ${height}`}
-      preserveAspectRatio="xMidYMid meet"
-      style={{ position: 'absolute', inset: 0, width: '100%', height: '100%', pointerEvents: 'none', zIndex: 0 }}
-    >
-      {/* Rivers */}
-      {riverItems.map((_, i) => {
-        const x1 = rrf(0, width * 0.25),  y1 = rrf(0, height)
-        const x2 = rrf(width * 0.75, width), y2 = rrf(0, height)
-        const cx1 = rrf(width * 0.2, width * 0.5), cy1 = rrf(0, height)
-        const cx2 = rrf(width * 0.5, width * 0.8), cy2 = rrf(0, height)
-        return (
-          <g key={`river-${i}`} opacity={0.28}>
-            <path d={`M ${x1},${y1} C ${cx1},${cy1} ${cx2},${cy2} ${x2},${y2}`}
-              fill="none" stroke={riverColor} strokeWidth={6} strokeLinecap="round" />
-            <path d={`M ${x1},${y1} C ${cx1},${cy1} ${cx2},${cy2} ${x2},${y2}`}
-              fill="none" stroke="rgba(255,255,255,0.25)" strokeWidth={2} strokeLinecap="round" />
-          </g>
-        )
-      })}
+  for (const it of items.filter(i => i.kind === 'river')) {
+    void it
+    const x1 = rrf(0, mapWidth * 0.25), y1 = rrf(0, mapHeight)
+    const x2 = rrf(mapWidth * 0.75, mapWidth), y2 = rrf(0, mapHeight)
+    const cx1 = rrf(mapWidth * 0.2, mapWidth * 0.5), cy1 = rrf(0, mapHeight)
+    const cx2 = rrf(mapWidth * 0.5, mapWidth * 0.8), cy2 = rrf(0, mapHeight)
+    const g = new PIXI.Graphics()
+    g.moveTo(x1, y1).bezierCurveTo(cx1, cy1, cx2, cy2, x2, y2)
+      .stroke({ color: riverColor, width: 6, alpha: 0.28, cap: 'round' })
+    g.moveTo(x1, y1).bezierCurveTo(cx1, cy1, cx2, cy2, x2, y2)
+      .stroke({ color: 0xffffff, width: 2, alpha: 0.28 * 0.25, cap: 'round' })
+    groundLayer.addChild(g)
+  }
 
-      {/* Terrain features */}
-      {terrainItems.map((it, i) => {
-        const { x, y, scale, kind } = it
-        const k = `${kind}-${i}`
-        switch (kind) {
+  const terrainItems = items.filter(i => i.kind !== 'river')
+  for (let i = 0; i < terrainItems.length; i++) {
+    const { x, y, scale, kind } = terrainItems[i]
+    const k = `${kind}-${i}`
+    const g = new PIXI.Graphics()
+    g.position.set(x, y)
 
-          case 'mountain': {
-            const w = scale * 44, h = scale * 32
-            const col = environment === 'frost'   ? '#8ab8cc'
-                      : environment === 'volcano' ? '#6a3020'
-                      : environment === 'sand'    ? '#a08040'
-                      : '#5a6050'
-            return (
-              <g key={k} opacity={0.22}>
-                <polygon points={`${x},${y} ${x+w*0.45},${y-h} ${x+w},${y}`} fill={col} />
-                <polygon points={`${x+w*0.3},${y} ${x+w*0.72},${y-h*0.75} ${x+w*1.1},${y}`} fill={col} />
-                {environment === 'frost' && (
-                  <polygon points={`${x+w*0.2},${y-h*0.55} ${x+w*0.45},${y-h} ${x+w*0.7},${y-h*0.55}`} fill="rgba(255,255,255,0.55)" />
-                )}
-              </g>
-            )
-          }
-
-          case 'tree': {
-            const h = scale * 28, tw = scale * 14
-            const col = environment === 'farmland' ? '#4a7a28'
-                      : environment === 'ruins'    ? '#3a6028'
-                      : '#2a7020'
-            return (
-              <g key={k} opacity={0.24}>
-                <rect x={x - scale*2} y={y - scale*8} width={scale*4} height={scale*9} fill="#6b4226" />
-                <polygon points={`${x},${y-h} ${x-tw},${y-scale*6} ${x+tw},${y-scale*6}`} fill={col} />
-                <polygon points={`${x},${y-h*0.62} ${x-tw*1.1},${y-scale*2} ${x+tw*1.1},${y-scale*2}`} fill={col} />
-              </g>
-            )
-          }
-
-          case 'deadtree': {
-            const h = scale * 28
-            return (
-              <g key={k} opacity={0.2}>
-                <line x1={x} y1={y} x2={x} y2={y - h} stroke="#5a4030" strokeWidth={scale * 3} strokeLinecap="round" />
-                <line x1={x} y1={y - h * 0.6} x2={x - scale*12} y2={y - h * 0.85} stroke="#5a4030" strokeWidth={scale * 2} strokeLinecap="round" />
-                <line x1={x} y1={y - h * 0.5} x2={x + scale*10} y2={y - h * 0.72} stroke="#5a4030" strokeWidth={scale * 1.5} strokeLinecap="round" />
-              </g>
-            )
-          }
-
-          case 'crystal': {
-            const h = scale * 26
-            return (
-              <g key={k} opacity={0.28}>
-                <polygon points={`${x},${y-h} ${x-scale*5},${y} ${x+scale*5},${y}`} fill="#88ddff" />
-                <polygon points={`${x},${y-h*0.7} ${x-scale*7},${y+h*0.3} ${x+scale*7},${y+h*0.3}`} fill="#aaeeff" />
-                <line x1={x} y1={y-h} x2={x} y2={y+h*0.3} stroke="rgba(255,255,255,0.4)" strokeWidth={scale*1.5} />
-              </g>
-            )
-          }
-
-          case 'mushroom': {
-            const h = scale * 22, rw = scale * 12
-            return (
-              <g key={k} opacity={0.24}>
-                <rect x={x - scale*2.5} y={y - h} width={scale*5} height={h} fill="#8a7060" />
-                <ellipse cx={x} cy={y - h} rx={rw} ry={scale * 8} fill="#9a40ee" />
-                <ellipse cx={x - scale*3} cy={y - h - scale*2} rx={scale*4} ry={scale*3} fill="rgba(255,255,255,0.3)" />
-              </g>
-            )
-          }
-
-          case 'lava': {
-            return (
-              <g key={k} opacity={0.22}>
-                <ellipse cx={x} cy={y} rx={scale*20} ry={scale*10} fill="#cc3300" />
-                <ellipse cx={x} cy={y} rx={scale*12} ry={scale*6}  fill="#ff6600" />
-                <ellipse cx={x + scale*4} cy={y - scale*2} rx={scale*5} ry={scale*3} fill="#ffaa00" opacity={0.7} />
-              </g>
-            )
-          }
-
-          case 'wave': {
-            const ww = scale * 50
-            return (
-              <g key={k} opacity={0.22}>
-                <path d={`M ${x},${y} Q ${x+ww*0.25},${y-scale*9} ${x+ww*0.5},${y} Q ${x+ww*0.75},${y+scale*9} ${x+ww},${y}`}
-                  fill="none" stroke="#4499cc" strokeWidth={scale*3} strokeLinecap="round" />
-                <path d={`M ${x+scale*5},${y+scale*7} Q ${x+ww*0.3},${y-scale*5} ${x+ww*0.6},${y+scale*7}`}
-                  fill="none" stroke="#66bbee" strokeWidth={scale*2} strokeLinecap="round" opacity={0.6} />
-              </g>
-            )
-          }
-
-          case 'cloud': {
-            return (
-              <g key={k} opacity={0.15}>
-                <ellipse cx={x}              cy={y}            rx={scale*22} ry={scale*13} fill="white" />
-                <ellipse cx={x + scale*14}   cy={y + scale*4}  rx={scale*18} ry={scale*11} fill="white" />
-                <ellipse cx={x - scale*12}   cy={y + scale*5}  rx={scale*16} ry={scale*10} fill="white" />
-              </g>
-            )
-          }
-
-          case 'tower': {
-            const h = scale * 30, tw = scale * 10
-            return (
-              <g key={k} opacity={0.2}>
-                <rect x={x - tw/2} y={y - h} width={tw} height={h} fill="#6a6a7a" />
-                <rect x={x - tw/2 - scale*2} y={y - h} width={tw + scale*4} height={scale*5} fill="#8a8a9a" />
-                <rect x={x - scale*2} y={y - h - scale*6} width={scale*4} height={scale*6} fill="#6a6a7a" />
-                <rect x={x - tw/2 - scale*2} y={y - h - scale*6} width={tw + scale*4} height={scale*3} fill="#7a7a8a" />
-              </g>
-            )
-          }
-
-          case 'pillar': {
-            const h = scale * (16 + hashStr(`${k}${x}`) % 18), pw = scale * 7
-            return (
-              <g key={k} opacity={0.18}>
-                <rect x={x - pw/2} y={y - h} width={pw} height={h} fill="#888" />
-                <rect x={x - pw/2 - scale*2} y={y - h}          width={pw + scale*4} height={scale*4} fill="#aaa" />
-                <rect x={x - pw/2 - scale*2} y={y - scale*4}    width={pw + scale*4} height={scale*4} fill="#aaa" />
-              </g>
-            )
-          }
-
-          case 'dune': {
-            const dw = scale * 55
-            return (
-              <g key={k} opacity={0.2}>
-                <ellipse cx={x} cy={y} rx={dw * 0.5} ry={scale * 10} fill="#c8a040" />
-                <ellipse cx={x + dw*0.35} cy={y + scale*4} rx={dw * 0.35} ry={scale * 8} fill="#b89030" />
-              </g>
-            )
-          }
-
-          default: return null
-        }
-      })}
-    </svg>
-  )
+    switch (kind) {
+      case 'mountain': {
+        const w = scale * 44, h = scale * 32
+        const col = environment === 'frost' ? 0x8ab8cc : environment === 'volcano' ? 0x6a3020 : environment === 'sand' ? 0xa08040 : 0x5a6050
+        g.poly([0,0, w*0.45,-h, w,0]).fill({ color: col, alpha: 0.22 })
+        g.poly([w*0.3,0, w*0.72,-h*0.75, w*1.1,0]).fill({ color: col, alpha: 0.22 })
+        if (environment === 'frost')
+          g.poly([w*0.2,-h*0.55, w*0.45,-h, w*0.7,-h*0.55]).fill({ color: 0xffffff, alpha: 0.55*0.22 })
+        g.zIndex = y
+        break
+      }
+      case 'tree': {
+        const h = scale * 28, tw = scale * 14
+        const col = environment === 'farmland' ? 0x4a7a28 : environment === 'ruins' ? 0x3a6028 : 0x2a7020
+        g.rect(-scale*2, -scale*8, scale*4, scale*9).fill({ color: 0x6b4226, alpha: 0.24 })
+        g.poly([0,-h, -tw,-scale*6, tw,-scale*6]).fill({ color: col, alpha: 0.24 })
+        g.poly([0,-h*0.62, -tw*1.1,-scale*2, tw*1.1,-scale*2]).fill({ color: col, alpha: 0.24 })
+        g.zIndex = y
+        break
+      }
+      case 'deadtree': {
+        const h = scale * 28
+        g.moveTo(0,0).lineTo(0,-h).stroke({ color: 0x5a4030, width: scale*3, alpha: 0.2, cap: 'round' })
+        g.moveTo(0,-h*0.6).lineTo(-scale*12,-h*0.85).stroke({ color: 0x5a4030, width: scale*2, alpha: 0.2, cap: 'round' })
+        g.moveTo(0,-h*0.5).lineTo(scale*10,-h*0.72).stroke({ color: 0x5a4030, width: scale*1.5, alpha: 0.2, cap: 'round' })
+        g.zIndex = y
+        break
+      }
+      case 'crystal': {
+        const h = scale * 26
+        g.poly([0,-h, -scale*5,0, scale*5,0]).fill({ color: 0x88ddff, alpha: 0.28 })
+        g.poly([0,-h*0.7, -scale*7,h*0.3, scale*7,h*0.3]).fill({ color: 0xaaeeff, alpha: 0.28 })
+        g.moveTo(0,-h).lineTo(0,h*0.3).stroke({ color: 0xffffff, width: scale*1.5, alpha: 0.4*0.28 })
+        g.zIndex = y
+        break
+      }
+      case 'mushroom': {
+        const h = scale * 22, rw = scale * 12
+        g.rect(-scale*2.5,-h, scale*5, h).fill({ color: 0x8a7060, alpha: 0.24 })
+        g.ellipse(0,-h, rw, scale*8).fill({ color: 0x9a40ee, alpha: 0.24 })
+        g.ellipse(-scale*3,-h-scale*2, scale*4, scale*3).fill({ color: 0xffffff, alpha: 0.3*0.24 })
+        g.zIndex = y
+        break
+      }
+      case 'lava': {
+        g.ellipse(0,0, scale*20, scale*10).fill({ color: 0xcc3300, alpha: 0.22 })
+        g.ellipse(0,0, scale*12, scale*6).fill({ color: 0xff6600, alpha: 0.22 })
+        g.ellipse(scale*4,-scale*2, scale*5, scale*3).fill({ color: 0xffaa00, alpha: 0.22*0.7 })
+        g.zIndex = y
+        break
+      }
+      case 'wave': {
+        const ww = scale * 50
+        g.moveTo(0,0).quadraticCurveTo(ww*0.25,-scale*9, ww*0.5,0).quadraticCurveTo(ww*0.75,scale*9, ww,0)
+          .stroke({ color: 0x4499cc, width: scale*3, alpha: 0.22, cap: 'round' })
+        g.moveTo(scale*5,scale*7).quadraticCurveTo(ww*0.3,-scale*5, ww*0.6,scale*7)
+          .stroke({ color: 0x66bbee, width: scale*2, alpha: 0.22*0.6, cap: 'round' })
+        g.zIndex = y
+        break
+      }
+      case 'cloud': {
+        g.ellipse(0,0, scale*22, scale*13).fill({ color: 0xffffff, alpha: 0.15 })
+        g.ellipse(scale*14,scale*4, scale*18, scale*11).fill({ color: 0xffffff, alpha: 0.15 })
+        g.ellipse(-scale*12,scale*5, scale*16, scale*10).fill({ color: 0xffffff, alpha: 0.15 })
+        g.zIndex = y
+        break
+      }
+      case 'tower': {
+        const h = scale * 30, tw = scale * 10
+        g.rect(-tw/2,-h, tw, h).fill({ color: 0x6a6a7a, alpha: 0.2 })
+        g.rect(-tw/2-scale*2,-h, tw+scale*4, scale*5).fill({ color: 0x8a8a9a, alpha: 0.2 })
+        g.rect(-scale*2,-h-scale*6, scale*4, scale*6).fill({ color: 0x6a6a7a, alpha: 0.2 })
+        g.rect(-tw/2-scale*2,-h-scale*6, tw+scale*4, scale*3).fill({ color: 0x7a7a8a, alpha: 0.2 })
+        g.zIndex = y
+        break
+      }
+      case 'pillar': {
+        const h = scale * (16 + hashStr(`${k}${x}`) % 18), pw = scale * 7
+        g.rect(-pw/2,-h, pw, h).fill({ color: 0x888888, alpha: 0.18 })
+        g.rect(-pw/2-scale*2,-h, pw+scale*4, scale*4).fill({ color: 0xaaaaaa, alpha: 0.18 })
+        g.rect(-pw/2-scale*2,-scale*4, pw+scale*4, scale*4).fill({ color: 0xaaaaaa, alpha: 0.18 })
+        g.zIndex = y
+        break
+      }
+      case 'dune': {
+        const dw = scale * 55
+        g.ellipse(0,0, dw*0.5, scale*10).fill({ color: 0xc8a040, alpha: 0.2 })
+        g.ellipse(dw*0.35,scale*4, dw*0.35, scale*8).fill({ color: 0xb89030, alpha: 0.2 })
+        g.zIndex = y
+        break
+      }
+    }
+    worldLayer.addChild(g)
+  }
 }
 
-// ── SVG connector ────────────────────────────────────────────────────────────
-// Renders cubic-bezier curves between adjacent columns (L→R layout).
-// viewBox is 1×maxRows; row centres at row+0.5, matching the CSS grid.
-// Each path is coloured by the status of its parent→child pair.
-
-interface ConnProps {
-  prevRow:       QuestNode[]
-  nextRow:       QuestNode[]
-  maxRows:       number
-  statusOf:      (id: string) => NodeStatus
-  reachableIds:  Set<string>
-  hiddenNodeIds: Set<string>
-  environment?:  string
-}
+// ── Connector helpers ──────────────────────────────────────────────────────────
 
 type LineVariant = 'trail' | 'frontier' | 'future' | 'dead'
 
@@ -450,8 +315,7 @@ function lineVariant(
   statusOf: (id: string) => NodeStatus,
   reachableIds: Set<string>,
 ): LineVariant {
-  const ps = statusOf(parentId)
-  const cs = statusOf(childId)
+  const ps = statusOf(parentId), cs = statusOf(childId)
   if (!reachableIds.has(parentId) || !reachableIds.has(childId)) return 'dead'
   if (ps === 'completed' && (cs === 'completed' || cs === 'pending')) return 'trail'
   if (ps === 'completed' && cs === 'available')                       return 'frontier'
@@ -460,108 +324,189 @@ function lineVariant(
 
 function envColors(env?: string): { trail: string; frontier: string } {
   switch (env) {
-    case 'forest':   return { trail: 'rgba(80,140,60,0.6)',   frontier: 'rgba(100,220,80,0.9)'  }
+    case 'forest':   return { trail: 'rgba(80,140,60,0.6)',    frontier: 'rgba(100,220,80,0.9)'   }
     case 'citadel':
-    case 'ruins':    return { trail: 'rgba(120,120,140,0.55)', frontier: 'rgba(180,180,210,0.9)' }
-    case 'ashen':    return { trail: 'rgba(160,80,40,0.55)',   frontier: 'rgba(240,120,60,0.9)'  }
-    case 'farmland': return { trail: 'rgba(140,160,60,0.55)',  frontier: 'rgba(200,220,80,0.9)'  }
-    case 'frost':    return { trail: 'rgba(80,160,200,0.55)',  frontier: 'rgba(120,220,255,0.9)' }
-    case 'volcano':  return { trail: 'rgba(200,80,20,0.6)',    frontier: 'rgba(255,120,30,0.95)' }
-    case 'sand':     return { trail: 'rgba(200,160,60,0.55)',  frontier: 'rgba(240,200,80,0.9)'  }
+    case 'ruins':    return { trail: 'rgba(120,120,140,0.55)', frontier: 'rgba(180,180,210,0.9)'  }
+    case 'ashen':    return { trail: 'rgba(160,80,40,0.55)',   frontier: 'rgba(240,120,60,0.9)'   }
+    case 'farmland': return { trail: 'rgba(140,160,60,0.55)',  frontier: 'rgba(200,220,80,0.9)'   }
+    case 'frost':    return { trail: 'rgba(80,160,200,0.55)',  frontier: 'rgba(120,220,255,0.9)'  }
+    case 'volcano':  return { trail: 'rgba(200,80,20,0.6)',    frontier: 'rgba(255,120,30,0.95)'  }
+    case 'sand':     return { trail: 'rgba(200,160,60,0.55)',  frontier: 'rgba(240,200,80,0.9)'   }
     case 'reef':
-    case 'coast':    return { trail: 'rgba(40,140,180,0.55)',  frontier: 'rgba(60,200,240,0.9)'  }
-    case 'sky':      return { trail: 'rgba(100,140,200,0.55)', frontier: 'rgba(140,190,255,0.9)' }
-    case 'fungal':   return { trail: 'rgba(120,60,160,0.55)',  frontier: 'rgba(180,80,240,0.9)'  }
+    case 'coast':    return { trail: 'rgba(40,140,180,0.55)',  frontier: 'rgba(60,200,240,0.9)'   }
+    case 'sky':      return { trail: 'rgba(100,140,200,0.55)', frontier: 'rgba(140,190,255,0.9)'  }
+    case 'fungal':   return { trail: 'rgba(120,60,160,0.55)',  frontier: 'rgba(180,80,240,0.9)'   }
     case 'vault':
-    case 'camp':     return { trail: 'rgba(140,120,80,0.55)',  frontier: 'rgba(200,180,100,0.9)' }
-    default:         return { trail: 'rgba(120,120,120,0.45)', frontier: 'rgba(51,255,51,0.85)'  }
+    case 'camp':     return { trail: 'rgba(140,120,80,0.55)',  frontier: 'rgba(200,180,100,0.9)'  }
+    default:         return { trail: 'rgba(120,120,120,0.45)', frontier: 'rgba(51,255,51,0.85)'   }
   }
 }
 
-function SVGConnector({ prevRow, nextRow, maxRows, statusOf, reachableIds, hiddenNodeIds, environment }: ConnProps) {
-  const prevRowCols = prevRow[0]?.rowCols ?? prevRow.length
-  const nextRowCols = nextRow[0]?.rowCols ?? nextRow.length
+function parseRgba(s: string): { color: number; alpha: number } {
+  const m = /rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*([\d.]+))?\)/.exec(s)
+  if (!m) return { color: 0xffffff, alpha: 1 }
+  return {
+    color: (parseInt(m[1]) << 16) | (parseInt(m[2]) << 8) | parseInt(m[3]),
+    alpha: m[4] ? parseFloat(m[4]) : 1,
+  }
+}
 
-  // Absolute row position within the maxRows-tall container
-  const visualRow = (node: QuestNode, rowCols: number) =>
-    (maxRows - rowCols) / 2 + node.col
+function drawConnectorsGfx(
+  gfx: PIXI.Graphics,
+  rows: QuestNode[][],
+  maxRowCols: number,
+  mapHeight: number,
+  statusOf: (id: string) => NodeStatus,
+  reachableIds: Set<string>,
+  hiddenNodeIds: Set<string>,
+  environment: string | undefined,
+): void {
+  const cols = envColors(environment)
+  const trail    = parseRgba(cols.trail)
+  const frontier = parseRgba(cols.frontier)
+  const priority: Record<LineVariant, number> = { frontier: 3, trail: 2, future: 1, dead: 0 }
 
-  const nextById = new Map(nextRow.map(n => [n.id, n]))
+  for (let ri = 0; ri < rows.length - 1; ri++) {
+    const prevRow = rows[ri], nextRow = rows[ri + 1]
+    const prevRowCols = prevRow[0]?.rowCols ?? prevRow.length
+    const nextRowCols = nextRow[0]?.rowCols ?? nextRow.length
+    const vrow = (node: QuestNode, rc: number) => (maxRowCols - rc) / 2 + node.col
+    const nextById = new Map(nextRow.map(n => [n.id, n]))
+    const best = new Map<string, { variant: LineVariant; pr: number; cr: number }>()
 
-  // Build connections from parent.childIds, skipping collected memory nodes
-  const connections: [string, string, number, number][] = []
-  for (const parent of prevRow) {
-    if (hiddenNodeIds.has(parent.id)) continue
-    for (const childId of parent.childIds) {
-      if (hiddenNodeIds.has(childId)) continue
-      const child = nextById.get(childId)
-      if (child) {
-        connections.push([parent.id, child.id, visualRow(parent, prevRowCols), visualRow(child, nextRowCols)])
+    for (const parent of prevRow) {
+      if (hiddenNodeIds.has(parent.id)) continue
+      for (const childId of parent.childIds) {
+        if (hiddenNodeIds.has(childId)) continue
+        const child = nextById.get(childId)
+        if (!child) continue
+        const pr = vrow(parent, prevRowCols), cr = vrow(child, nextRowCols)
+        const key = `${pr}:${cr}`
+        const v = lineVariant(parent.id, childId, statusOf, reachableIds)
+        const ex = best.get(key)
+        if (!ex || priority[v] > priority[ex.variant]) best.set(key, { variant: v, pr, cr })
+      }
+    }
+
+    const xStart = AVATAR_PADDING + (ri + 1) * COL_WIDTH + ri * CONN_W
+    const xMid   = xStart + CONN_W / 2
+    const xEnd   = xStart + CONN_W
+
+    for (const { variant, pr, cr } of best.values()) {
+      const y1 = (pr + 0.5) / maxRowCols * mapHeight
+      const y2 = (cr + 0.5) / maxRowCols * mapHeight
+
+      if (variant === 'future') {
+        gfx.moveTo(xStart, y1).bezierCurveTo(xMid, y1, xMid, y2, xEnd, y2)
+          .stroke({ color: 0xffffff, width: 2, alpha: 0.13, cap: 'round' })
+      } else if (variant === 'dead') {
+        gfx.moveTo(xStart, y1).bezierCurveTo(xMid, y1, xMid, y2, xEnd, y2)
+          .stroke({ color: 0xffffff, width: 1, alpha: 0.04 })
+      } else {
+        const c     = variant === 'frontier' ? frontier : trail
+        const outer = variant === 'frontier' ? 18 : 14
+        const inner = variant === 'frontier' ? 11 : 8
+        gfx.moveTo(xStart, y1).bezierCurveTo(xMid, y1, xMid, y2, xEnd, y2)
+          .stroke({ color: 0x000000, width: outer, alpha: variant === 'frontier' ? 0.65 : 0.5, cap: 'round' })
+        gfx.moveTo(xStart, y1).bezierCurveTo(xMid, y1, xMid, y2, xEnd, y2)
+          .stroke({ color: c.color, width: inner, alpha: c.alpha, cap: 'round' })
       }
     }
   }
-
-  if (connections.length === 0) return null
-
-  // Row i centre in viewBox units (viewBox is 1 wide, maxRows tall)
-  const cy = (vr: number) => vr + 0.5
-
-  // Deduplicate by visual row pair (keep highest-priority variant)
-  const variantPriority: Record<LineVariant, number> = { frontier: 3, trail: 2, future: 1, dead: 0 }
-  const best = new Map<string, { variant: LineVariant; pr: number; cr: number }>()
-  for (const [pid, cid, pr, cr] of connections) {
-    const key = `${pr}:${cr}`
-    const v = lineVariant(pid, cid, statusOf, reachableIds)
-    const existing = best.get(key)
-    if (!existing || variantPriority[v] > variantPriority[existing.variant]) {
-      best.set(key, { variant: v, pr, cr })
-    }
-  }
-
-  const colors = envColors(environment)
-
-  return (
-    <svg
-      viewBox={`0 0 1 ${maxRows}`}
-      preserveAspectRatio="none"
-      style={{ width: '44px', height: '100%', display: 'block', overflow: 'visible', alignSelf: 'stretch', flexShrink: 0, position: 'relative', zIndex: 1 }}
-    >
-      {Array.from(best.values()).map(({ variant, pr, cr }, i) => {
-        const y1 = cy(pr), y2 = cy(cr)
-        const d = `M 0,${y1} C 0.5,${y1} 0.5,${y2} 1,${y2}`
-
-        if (variant === 'future') {
-          return (
-            <path key={i} d={d} fill="none"
-              stroke="rgba(255,255,255,0.13)" strokeWidth={2}
-              strokeDasharray="0.04 0.06" strokeLinecap="round"
-              vectorEffect="non-scaling-stroke" />
-          )
-        }
-        if (variant === 'dead') {
-          return (
-            <path key={i} d={d} fill="none"
-              stroke="rgba(255,255,255,0.04)" strokeWidth={1}
-              vectorEffect="non-scaling-stroke" />
-          )
-        }
-        // trail / frontier — two-layer road look
-        const surfaceColor = variant === 'frontier' ? colors.frontier : colors.trail
-        const edgeColor    = variant === 'frontier' ? 'rgba(0,0,0,0.65)' : 'rgba(0,0,0,0.5)'
-        const outerWidth   = variant === 'frontier' ? 18 : 14
-        const innerWidth   = variant === 'frontier' ? 11 : 8
-        return (
-          <React.Fragment key={i}>
-            <path d={d} fill="none" stroke={edgeColor}    strokeWidth={outerWidth} strokeLinecap="round" vectorEffect="non-scaling-stroke" />
-            <path d={d} fill="none" stroke={surfaceColor} strokeWidth={innerWidth} strokeLinecap="round" vectorEffect="non-scaling-stroke" />
-          </React.Fragment>
-        )
-      })}
-    </svg>
-  )
 }
 
-// ── Reward summary ───────────────────────────────────────────────────────────
+// ── Node markers ──────────────────────────────────────────────────────────────
+
+const NODE_BG: Record<string, number> = {
+  battle: 0x1a2a3a, elite: 0x2a1a3a, boss: 0x3a0a0a,
+  rest: 0x0a2a1a, event: 0x2a2a0a, merchant: 0x0a2a2a, memory: 0x1a1a3a,
+}
+const NODE_ACCENT: Record<string, number> = {
+  battle: 0x3388bb, elite: 0xaa44cc, boss: 0xff2222,
+  rest: 0x33cc55, event: 0xddcc33, merchant: 0x33cccc, memory: 0x4444cc,
+}
+
+function markerAlpha(status: NodeStatus, inReachable: boolean): number {
+  if (status === 'available' || status === 'pending') return 1
+  if (!inReachable || status === 'skipped') return 0.25
+  if (status === 'completed') return 0.55
+  return 0.4
+}
+
+async function loadNodeIcon(node: QuestNode): Promise<PIXI.Texture | null> {
+  const base = (import.meta as { env: { BASE_URL: string } }).env.BASE_URL
+  try {
+    if (node.type === 'rest')     return await loadTextureUrl(`${base}sprites/campfire.svg`)
+    if (node.type === 'merchant') return await loadTextureUrl(`${base}sprites/merchant.svg`)
+    if (node.type === 'event' || node.type === 'memory')
+      return await loadTextureUrl(`${base}sprites/event.svg`)
+    if (node.type === 'boss' && node.bossAI)
+      return await loadTextureUrl(`${base}sprites/boss-${node.bossAI}.svg`)
+    if ((node.type === 'battle' || node.type === 'elite') && node.enemyDeck?.length)
+      return await loadSpriteTexture(node.enemyDeck[0])
+  } catch { /* fall through to text icon */ }
+  return null
+}
+
+async function buildNodeMarker(
+  node: QuestNode, status: NodeStatus, inReachable: boolean,
+): Promise<PIXI.Container> {
+  const container = new PIXI.Container()
+  const bg = new PIXI.Graphics()
+  const bgColor     = NODE_BG[node.type]     ?? 0x1a1a2a
+  const accentColor = NODE_ACCENT[node.type] ?? 0x44cc44
+  const borderAlpha = status === 'available' ? 1 : 0.35
+  const borderWidth = status === 'available' ? 3 : 1.5
+  bg.circle(0, 0, NODE_RADIUS).fill({ color: bgColor, alpha: 0.88 })
+  bg.circle(0, 0, NODE_RADIUS).stroke({ color: accentColor, width: borderWidth, alpha: borderAlpha })
+  container.addChild(bg)
+
+  const texture = await loadNodeIcon(node)
+  if (texture) {
+    const sprite = new PIXI.Sprite(texture)
+    sprite.width = sprite.height = NODE_RADIUS * 1.1
+    sprite.anchor.set(0.5)
+    container.addChild(sprite)
+  } else {
+    const t = new PIXI.Text({ text: NODE_ICON[node.type] ?? '?',
+      style: { fontSize: 14, fill: '#ffffff', fontFamily: 'monospace' } })
+    t.anchor.set(0.5)
+    container.addChild(t)
+  }
+
+  const badge = new PIXI.Text({ text: NODE_LABEL[node.type] ?? node.type.toUpperCase(),
+    style: { fontSize: 8, fill: '#999999', fontFamily: 'monospace', fontWeight: 'bold' } })
+  badge.anchor.set(0.5, 1)
+  badge.y = -NODE_RADIUS - 3
+  container.addChild(badge)
+
+  const nameLabel = new PIXI.Text({ text: node.label ?? '',
+    style: { fontSize: 9, fill: '#dddddd', fontFamily: 'monospace' } })
+  nameLabel.anchor.set(0.5, 0)
+  nameLabel.y = NODE_RADIUS + 4
+  container.addChild(nameLabel)
+
+  if (status === 'completed') {
+    const st = new PIXI.Text({ text: '✓', style: { fontSize: 11, fill: '#44cc44' } })
+    st.anchor.set(1, 1); st.position.set(NODE_RADIUS - 1, NODE_RADIUS - 1)
+    container.addChild(st)
+  } else if (status === 'skipped') {
+    const st = new PIXI.Text({ text: '╳', style: { fontSize: 11, fill: '#884444' } })
+    st.anchor.set(1, 1); st.position.set(NODE_RADIUS - 1, NODE_RADIUS - 1)
+    container.addChild(st)
+  }
+
+  container.alpha = markerAlpha(status, inReachable)
+  return container
+}
+
+function updateMarkerStyle(
+  marker: PIXI.Container, status: NodeStatus, inReachable: boolean,
+): void {
+  marker.alpha = markerAlpha(status, inReachable)
+}
+
+// ── Reward / difficulty helpers ───────────────────────────────────────────────
 
 function rewardSummary(node: QuestNode): string {
   switch (node.type) {
@@ -576,101 +521,49 @@ function rewardSummary(node: QuestNode): string {
 }
 
 const DIFFICULTY_LABELS = ['Easy', 'Easy', 'Medium', 'Medium', 'Hard', 'Hard', 'Very Hard', 'Brutal']
-
 function difficultyLabel(handicap: number | undefined): string {
-  const h = handicap ?? 0
-  return DIFFICULTY_LABELS[Math.min(h, DIFFICULTY_LABELS.length - 1)]
+  return DIFFICULTY_LABELS[Math.min(handicap ?? 0, DIFFICULTY_LABELS.length - 1)]
 }
-
 function difficultyColor(handicap: number | undefined): string {
   const h = handicap ?? 0
-  if (h <= 1) return '#33ff33'
-  if (h <= 3) return '#ffcc00'
-  if (h <= 5) return '#ff8844'
-  return '#ff4444'
+  return h <= 1 ? '#33ff33' : h <= 3 ? '#ffcc00' : h <= 5 ? '#ff8844' : '#ff4444'
 }
 
 const BOSS_AI_DESCRIPTIONS: Record<string, string> = {
   thornlord: 'Builds walls every turn — floods the field with structures and outlasts you.',
 }
-
 function playstyleDescription(node: QuestNode): string {
-  if (node.bossAI && BOSS_AI_DESCRIPTIONS[node.bossAI]) {
-    return BOSS_AI_DESCRIPTIONS[node.bossAI]
-  }
-  if (node.enemyDeck && node.enemyDeck.length > 0) {
-    return `Deck: ${node.enemyDeck.join(', ')}`
-  }
+  if (node.bossAI && BOSS_AI_DESCRIPTIONS[node.bossAI]) return BOSS_AI_DESCRIPTIONS[node.bossAI]
+  if (node.enemyDeck?.length) return `Deck: ${node.enemyDeck.join(', ')}`
   return 'Plays a standard shuffled deck.'
 }
 
-/** Collapse multiple modifiers of the same type into one row with summed values. */
 function collapseModifiers(modifiers: ReplayModifier[]): ReplayModifier[] {
   const byType = new Map<string, number>()
-  for (const m of modifiers) {
-    byType.set(m.type, (byType.get(m.type) ?? 0) + m.value)
-  }
+  for (const m of modifiers) byType.set(m.type, (byType.get(m.type) ?? 0) + m.value)
   return Array.from(byType.entries()).map(([type, total]) => {
     switch (type) {
-      case 'enemyHpPercent':         return { type: type as ReplayModifier['type'], value: total, label: `+${total}% enemy HP` }
-      case 'crystalBonus':           return { type: type as ReplayModifier['type'], value: total, label: `+${total} crystals per battle` }
-      case 'enemyHandBonus':         return { type: type as ReplayModifier['type'], value: total, label: `Enemies start +${total} card${total !== 1 ? 's' : ''}` }
-      case 'enemyIntervalReduction': return modifiers.find(m => m.type === type)!
-      default:                       return modifiers.find(m => m.type === type)!
+      case 'enemyHpPercent':  return { type: type as ReplayModifier['type'], value: total, label: `+${total}% enemy HP` }
+      case 'crystalBonus':    return { type: type as ReplayModifier['type'], value: total, label: `+${total} crystals per battle` }
+      case 'enemyHandBonus':  return { type: type as ReplayModifier['type'], value: total, label: `Enemies start +${total} card${total !== 1 ? 's' : ''}` }
+      default:                return modifiers.find(m => m.type === type)!
     }
   })
 }
 
-// ── Wandering sprite ─────────────────────────────────────────────────────────
-
-const WANDER_RANGE = 10 // px radius from centre
-
-function WanderingSprite({ name }: { name: string }) {
-  const [pos, setPos] = useState({ x: 0, y: 0 })
-  const [dur, setDur] = useState(1200)
-
-  useEffect(() => {
-    let timer: ReturnType<typeof setTimeout>
-    function step() {
-      const x = (Math.random() * 2 - 1) * WANDER_RANGE
-      const y = (Math.random() * 2 - 1) * WANDER_RANGE
-      const d = 600 + Math.random() * 1200
-      setPos({ x, y })
-      setDur(d)
-      timer = setTimeout(step, d + 80)
-    }
-    // Stagger startup so sprites don't all move in sync
-    timer = setTimeout(step, Math.random() * 1200)
-    return () => clearTimeout(timer)
-  }, [])
-
-  return (
-    <div style={{ transform: `translate(${pos.x}px,${pos.y}px)`, transition: `transform ${dur}ms ease-in-out` }}>
-      <AnimatedSpriteImg name={name} frameCount={3} fps={6} className="nm-node-sprite" />
-    </div>
-  )
-}
-
-// ── Node Peek Modal ──────────────────────────────────────────────────────────
+// ── Node Peek Modal ────────────────────────────────────────────────────────────
 
 interface PeekModalProps {
-  node: QuestNode
-  actId: string
-  nodeHistory: Set<string>
-  activeModifiers: ReplayModifier[]
-  onEnter: () => void
-  onClose: () => void
+  node: QuestNode; actId: string; nodeHistory: Set<string>
+  activeModifiers: ReplayModifier[]; onEnter: () => void; onClose: () => void
 }
 
 function NodePeekModal({ node, actId, nodeHistory, activeModifiers, onEnter, onClose }: PeekModalProps) {
   const hasPreviouslyCompleted = nodeHistory.has(`${actId}:${node.id}`)
   const isBattle = node.type === 'battle' || node.type === 'elite' || node.type === 'boss'
-
   return (
     <div className="nm-peek-backdrop" onClick={onClose}>
       <div className="nm-peek-panel" onClick={e => e.stopPropagation()}>
-
-        {/* Header */}
         <div className="nm-peek-header u-col u-items-c u-gap-1">
           <span className={`nm-peek-type nm-node-type-badge--${node.type}`}>
             {NODE_LABEL[node.type] ?? node.type.toUpperCase()}
@@ -678,32 +571,18 @@ function NodePeekModal({ node, actId, nodeHistory, activeModifiers, onEnter, onC
           <span className="nm-peek-icon">{NODE_ICON[node.type] ?? '?'}</span>
           <span className="nm-peek-name">{node.label}</span>
         </div>
-
-        {/* Description */}
-        {node.description && (
-          <div className="nm-peek-desc">{node.description}</div>
-        )}
-
-        {/* Reward */}
+        {node.description && <div className="nm-peek-desc">{node.description}</div>}
         <StatRow label="REWARD" value={<span className="nm-peek-reward">{rewardSummary(node)}</span>} />
-
-        {/* Difficulty (battle nodes only) */}
         {isBattle && (
-          <StatRow
-            label="DIFFICULTY"
-            value={<span style={{ color: difficultyColor(node.handicap) }}>{difficultyLabel(node.handicap)}</span>}
-          />
+          <StatRow label="DIFFICULTY"
+            value={<span style={{ color: difficultyColor(node.handicap) }}>{difficultyLabel(node.handicap)}</span>} />
         )}
-
-        {/* Previously completed — reveal opponent deck */}
         {hasPreviouslyCompleted && isBattle && (
           <div className="nm-peek-history u-col u-gap-2">
             <div className="nm-peek-history-label">— INTEL (from previous run) —</div>
             <div className="nm-peek-history-body">{playstyleDescription(node)}</div>
           </div>
         )}
-
-        {/* Active modifiers (battle nodes only) — same-type entries are summed */}
         {isBattle && activeModifiers.length > 0 && (
           <div className="nm-peek-modifiers">
             <div className="nm-peek-modifiers-label">— REPLAY MODIFIERS —</div>
@@ -715,123 +594,198 @@ function NodePeekModal({ node, actId, nodeHistory, activeModifiers, onEnter, onC
             ))}
           </div>
         )}
-
-        {/* Actions */}
         <div className="nm-peek-actions u-flex u-gap-4">
           {(isBattle || node.type === 'event' || node.type === 'merchant') ? (
             <button className="action-btn nm-peek-enter-btn u-grow" onClick={onEnter}>
-              {node.type === 'rest' ? 'REST' : node.type === 'merchant' ? 'ENTER SHOP' : node.type === 'event' ? 'APPROACH' : 'ENTER BATTLE'}
+              {node.type === 'merchant' ? 'ENTER SHOP' : node.type === 'event' ? 'APPROACH' : 'ENTER BATTLE'}
             </button>
           ) : (
             <button className="action-btn nm-peek-enter-btn u-grow" onClick={onEnter}>
               {node.type === 'rest' ? 'REST HERE' : 'PROCEED'}
             </button>
           )}
-          <button className="action-btn nm-peek-back-btn" onClick={onClose}>
-            BACK
-          </button>
+          <button className="action-btn nm-peek-back-btn" onClick={onClose}>BACK</button>
         </div>
-
       </div>
     </div>
   )
 }
 
-// ── Main component ──────────────────────────────────────────────────────────
+// ── Main component ─────────────────────────────────────────────────────────────
 
 export function NodeMap({ act, run, onSelectNode, onUseConsumable, onBack }: Props) {
-  const availableIds       = getAvailableNodeIds(act, run)
-  const rows               = useMemo(() => buildRows(act), [act])
-  const maxRowCols         = useMemo(() => Math.max(...rows.map(r => r[0]?.rowCols ?? r.length)), [rows])
-  const reachableIds       = useMemo(() => computeReachableIds(act, run), [act, run])
-  const discoveredFragIds  = useMemo(() => getDiscoveredFragmentIds(), [])
-  const hiddenNodeIds      = useMemo(() => {
-    const ids = new Set<string>()
-    for (const node of Object.values(act.nodes)) {
-      if (node.type !== 'memory' || !node.fragmentId) continue
-      const alreadyFound = discoveredFragIds.has(node.fragmentId)
-      const visitedThisRun = run.completedNodeIds.includes(node.id)
-      if (alreadyFound && !visitedThisRun) {
-        // Collected in a previous run — always hide
-        ids.add(node.id)
-      } else if (!alreadyFound && !visitedThisRun) {
-        // Not yet collected — 20% chance to appear this run
-        const roll = hashStr(node.id + String(run.runSeed)) % 100
-        if (roll >= 20) ids.add(node.id)
-      }
-    }
-    return ids
-  }, [act, discoveredFragIds, run])
+  const availableIds      = useMemo(() => getAvailableNodeIds(act, run), [act, run])
+  const rows              = useMemo(() => buildRows(act), [act])
+  const maxRowCols        = useMemo(() => Math.max(...rows.map(r => r[0]?.rowCols ?? r.length)), [rows])
+  const reachableIds      = useMemo(() => computeReachableIds(act, run), [act, run])
+  const discoveredFragIds = useMemo(() => getDiscoveredFragmentIds(), [])
+  const hiddenNodeIds     = useMemo(
+    () => computeHiddenNodeIds(act, run, discoveredFragIds),
+    [act, run, discoveredFragIds],
+  )
 
   const mapHeight = maxRowCols * ROW_HEIGHT
-  const mapWidth  = AVATAR_PADDING + rows.length * COL_WIDTH + Math.max(0, rows.length - 1) * 44
+  const mapWidth  = AVATAR_PADDING + rows.length * COL_WIDTH + Math.max(0, rows.length - 1) * CONN_W
 
-  const statusOf = (id: string): NodeStatus => getNodeStatus(id, availableIds, run)
-
-  // Node peek state
   const [peekNode, setPeekNode] = useState<QuestNode | null>(null)
   const nodeHistory = useMemo(() => loadNodeHistory(), [])
 
-  // Avatar state
-  const [avatarPos, setAvatarPos] = useState<{ x: number; y: number } | null>(null)
-  const [isWalking, setIsWalking] = useState(false)
-  const [walkFrame, setWalkFrame] = useState(0)
+  const canvasRef    = useRef<HTMLCanvasElement>(null)
+  const mapRef       = useRef<HTMLDivElement>(null)
+  const appRef       = useRef<PIXI.Application | null>(null)
+  const connGfxRef   = useRef<PIXI.Graphics | null>(null)
+  const groundRef    = useRef<PIXI.Container | null>(null)
+  const worldRef     = useRef<PIXI.Container | null>(null)
+  const markersRef   = useRef<Map<string, PIXI.Container>>(new Map())
+  const avatarRef    = useRef<PIXI.AnimatedSprite | null>(null)
+  const isWalkingRef = useRef(false)
+  const deadRef      = useRef(false)
 
-  const mapRef         = useRef<HTMLDivElement>(null)
-  const mapInnerRef    = useRef<HTMLDivElement>(null)
-  const currentRef     = useRef<HTMLDivElement>(null)
-  const nodeButtonRefs = useRef<Record<string, HTMLButtonElement | null>>({})
+  // Always-current state for use inside async PixiJS callbacks
+  const stateRef = useRef({ availableIds, reachableIds, hiddenNodeIds, run })
+  stateRef.current = { availableIds, reachableIds, hiddenNodeIds, run }
 
-  const currentNodeId = run.pendingNodeId
-    ?? rows.flatMap(r => r).find(n => availableIds.includes(n.id))?.id
+  useEffect(() => () => { deadRef.current = true }, [])
 
-  // On mount: scroll to current node, then place avatar using DOM measurement
-  useEffect(() => {
-    const mapEl      = mapRef.current
-    const mapInnerEl = mapInnerRef.current
-    const scrollToEl = currentRef.current
+  usePixiApp(canvasRef, mapWidth, mapHeight, async (app) => {
+    appRef.current = app
 
-    if (mapEl && scrollToEl) {
-      const mapRect  = mapEl.getBoundingClientRect()
-      const nodeRect = scrollToEl.getBoundingClientRect()
-      mapEl.scrollLeft += nodeRect.left - mapRect.left - (mapRect.width - nodeRect.width) / 2
-    }
+    const groundLayer = new PIXI.Container()
+    const worldLayer  = new PIXI.Container()
+    worldLayer.sortableChildren = true
+    app.stage.addChild(groundLayer, worldLayer)
+    groundRef.current = groundLayer
+    worldRef.current  = worldLayer
 
-    if (!mapInnerEl) {
-      setAvatarPos(startPosition(mapHeight))
-      return
-    }
-    const lastNode = lastCompletedNode(act, run)
-    if (lastNode) {
-      const nodeBtn = nodeButtonRefs.current[lastNode.id]
-      if (nodeBtn) {
-        setAvatarPos(getRelativeCenter(nodeBtn, mapInnerEl))
-        return
+    // Terrain
+    buildTerrainGfx(groundLayer, worldLayer, act.environment, act.id, mapWidth, mapHeight)
+
+    // Campfire at start position
+    try {
+      const base = (import.meta as { env: { BASE_URL: string } }).env.BASE_URL
+      const cfTex = await loadTextureUrl(`${base}sprites/campfire.svg`)
+      if (!deadRef.current) {
+        const cf = new PIXI.Sprite(cfTex)
+        cf.width = cf.height = 32
+        cf.anchor.set(0.5)
+        const sp = startPos(mapHeight)
+        cf.position.set(sp.x, sp.y)
+        cf.alpha = 0.75
+        cf.zIndex = sp.y
+        worldLayer.addChild(cf)
+      }
+    } catch { /* no campfire sprite */ }
+
+    // Connectors
+    const connGfx = new PIXI.Graphics()
+    groundLayer.addChild(connGfx)
+    connGfxRef.current = connGfx
+    const { availableIds: aids, reachableIds: rids, hiddenNodeIds: hids, run: r } = stateRef.current
+    drawConnectorsGfx(connGfx, rows, maxRowCols, mapHeight,
+      id => getNodeStatus(id, aids, r), rids, hids, act.environment)
+
+    // Node markers
+    for (let ri = 0; ri < rows.length; ri++) {
+      const rowNodes = rows[ri]
+      const rowCols  = rowNodes[0]?.rowCols ?? rowNodes.length
+      for (const node of rowNodes) {
+        if (hids.has(node.id)) continue
+        if (deadRef.current) return
+        const pos    = nodePosition(ri, node, rowCols, maxRowCols)
+        const status = getNodeStatus(node.id, aids, r)
+        const marker = await buildNodeMarker(node, status, rids.has(node.id))
+        if (deadRef.current) return
+        makeClickable(marker, () => {
+          if (isWalkingRef.current) return
+          const { availableIds: a, run: rr } = stateRef.current
+          if (getNodeStatus(node.id, a, rr) !== 'available') return
+          handleWalk(node, pos)
+        })
+        marker.position.set(pos.x, pos.y)
+        marker.zIndex = pos.y + NODE_RADIUS
+        worldLayer.addChild(marker)
+        markersRef.current.set(node.id, marker)
       }
     }
-    setAvatarPos(startPosition(mapHeight))
+
+    // Avatar
+    const avatarName = loadPlayerAvatar()
+    let avatarTextures: PIXI.Texture[]
+    try {
+      avatarTextures = await loadAnimFrames(avatarName, 3)
+    } catch {
+      try { avatarTextures = [await loadSpriteTexture(avatarName)] } catch { return }
+    }
+    if (deadRef.current) return
+
+    const avatar = new PIXI.AnimatedSprite(avatarTextures)
+    avatar.animationSpeed = 0.12
+    avatar.anchor.set(0.5, 1)
+    avatar.width = avatar.height = AVATAR_SIZE
+
+    const sp = startPos(mapHeight)
+    avatar.position.set(sp.x, sp.y)
+    avatar.zIndex = sp.y
+
+    const lastNode = lastCompletedNode(act, stateRef.current.run)
+    if (lastNode) {
+      const ri = rows.findIndex(row => row.some(n => n.id === lastNode.id))
+      if (ri >= 0) {
+        const rowNodes = rows[ri]
+        const pos = nodePosition(ri, lastNode, rowNodes[0]?.rowCols ?? rowNodes.length, maxRowCols)
+        avatar.position.set(pos.x, pos.y)
+        avatar.zIndex = pos.y
+      }
+    }
+
+    avatar.stop()
+    worldLayer.addChild(avatar)
+    avatarRef.current = avatar
+
+    app.ticker.add(() => { worldLayer.sortChildren() })
+  })
+
+  // Redraw connectors + update marker styles when run state changes
+  useEffect(() => {
+    const connGfx = connGfxRef.current
+    if (!connGfx) return
+    connGfx.clear()
+    drawConnectorsGfx(connGfx, rows, maxRowCols, mapHeight,
+      id => getNodeStatus(id, availableIds, run), reachableIds, hiddenNodeIds, act.environment)
+    for (const [nodeId, marker] of markersRef.current) {
+      const status = getNodeStatus(nodeId, availableIds, run)
+      updateMarkerStyle(marker, status, reachableIds.has(nodeId))
+    }
+  }, [run, availableIds, reachableIds, hiddenNodeIds]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Scroll to current node on mount
+  useEffect(() => {
+    const mapEl = mapRef.current
+    const currentNodeId = run.pendingNodeId
+      ?? rows.flatMap(r => r).find(n => availableIds.includes(n.id))?.id
+    if (!mapEl || !currentNodeId) return
+    const node = act.nodes[currentNodeId]
+    if (!node) return
+    const ri = rows.findIndex(row => row.some(n => n.id === node.id))
+    if (ri < 0) return
+    const rowNodes = rows[ri]
+    const pos = nodePosition(ri, node, rowNodes[0]?.rowCols ?? rowNodes.length, maxRowCols)
+    mapEl.scrollLeft = pos.x - mapEl.clientWidth / 2
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
-  const handleNodeClick = (node: QuestNode) => {
-    if (isWalking) return
-    const mapInnerEl = mapInnerRef.current
-    const nodeBtn    = nodeButtonRefs.current[node.id]
-    if (!mapInnerEl || !nodeBtn) return
-    const target = getRelativeCenter(nodeBtn, mapInnerEl)
-
-    setIsWalking(true)
-    setAvatarPos(target)  // CSS transition animates the move
-    const frameTimer = setInterval(() => setWalkFrame(f => (f % 3) + 1), 175)
+  function handleWalk(node: QuestNode, pos: { x: number; y: number }) {
+    const app    = appRef.current
+    const avatar = avatarRef.current
+    if (!app || !avatar || isWalkingRef.current) return
+    isWalkingRef.current = true
+    avatar.play()
     emitSound('mapFootstep')
-    const stepTimer  = setInterval(() => emitSound('mapFootstep'), 350)
-
-    setTimeout(() => {
-      clearInterval(frameTimer)
-      clearInterval(stepTimer)
-      setWalkFrame(0)
-      setIsWalking(false)
+    tweenTo(avatar, pos.x, pos.y, WALK_DURATION, app).then(() => {
+      avatar.zIndex = pos.y
+      avatar.stop()
+      isWalkingRef.current = false
       setPeekNode(node)
-    }, WALK_DURATION)
+    })
   }
 
   const handlePeekEnter = () => {
@@ -840,231 +794,80 @@ export function NodeMap({ act, run, onSelectNode, onUseConsumable, onBack }: Pro
     onSelectNode(peekNode)
   }
 
+  const statusOf = (id: string) => getNodeStatus(id, availableIds, run)
+
   return (
-    <OverlayScreen 
-    onBack={onBack}
-     title={act.title} 
-     subtitle={act.subtitle}
-     >
+    <OverlayScreen onBack={onBack} title={act.title} subtitle={act.subtitle}>
+      <div className="nodemap u-col u-grow">
 
-
-    <div className="nodemap u-col u-grow">
-
-      {/* Consumables bar */}
-      <Toolbar>
-        {run.archetype && (() => {
-          const def = ARCHETYPE_DEFS.find(d => d.id === run.archetype)
-          return def ? <ToolbarLabel>{def.icon} {def.name}</ToolbarLabel> : null
-        })()}
-        <ToolbarLabel>Items</ToolbarLabel>
-
-      
-        {ALL_CONSUMABLES.map(def => {
-          const rc = run.consumables?.find(c => c.id === def.id)
-          const count = rc?.count ?? 0
-          return (
-            <>
-            <ToolbarButton key={def.id}
-            label={`${def.name} ×${count}`}
-            icon={def.icon}
-            disabled={count === 0} 
-            onClick={() => onUseConsumable(def.id)}
-            />
-            </>
-          )
-        })}
-
-        <ToolbarSpacer />
-        <ToolbarButton
-          label="Copy Debug State"
-          icon="🐞"
-          onClick={() => {
-            const nodeStatuses: Record<string, string> = {}
-            for (const node of Object.values(act.nodes)) {
-              nodeStatuses[node.id] = `${node.type} → ${statusOf(node.id)}`
-            }
-            const state = {
-              actId:            run.actId,
-              pendingNodeId:    run.pendingNodeId,
-              completedNodeIds: run.completedNodeIds,
-              skippedNodeIds:   run.skippedNodeIds,
-              availableIds,
-              nodeStatuses,
-            }
-            const text = JSON.stringify(state, null, 2)
-            console.log('[NodeMap debug]', state)
-            navigator.clipboard?.writeText(text).catch(() => undefined)
-            alert('Debug state copied to clipboard (also logged to console).')
-          }}
-        />
-      </Toolbar>
-
-
-      {/* Map — left-to-right: each act row renders as a vertical column */}
-      <div className={`nm-map u-flex u-grow u-items-c${act.environment ? ` nm-map--${act.environment}` : ''}`} ref={mapRef}>
-        <div className="nm-map-inner u-row u-items-c" ref={mapInnerRef} style={{ height: `${mapHeight}px`, paddingLeft: `${AVATAR_PADDING}px`, position: 'relative' }}>
-          <MapTerrain
-            environment={act.environment}
-            actId={act.id}
-            width={mapWidth}
-            height={mapHeight}
-          />
-          {/* Node-0 campfire marker */}
-          <img
-            src="/sprites/campfire.svg"
-            alt=""
-            style={{
-              position: 'absolute',
-              left: startPosition(mapHeight).x - 18,
-              top:  startPosition(mapHeight).y - 18,
-              width: 36, height: 36,
-              opacity: 0.75,
-              pointerEvents: 'none',
-              zIndex: 1,
-            }}
-          />
-          {/* Player avatar */}
-          {avatarPos && (
-            <div
-              className={isWalking ? 'nm-avatar nm-avatar--walking' : 'nm-avatar'}
-              style={{
-                left: avatarPos.x - AVATAR_SIZE / 2,
-                top:  avatarPos.y - AVATAR_SIZE / 2,
-                transition: isWalking
-                  ? `left ${WALK_DURATION}ms ease-in-out, top ${WALK_DURATION}ms ease-in-out`
-                  : undefined,
-              }}
-            >
-              <img
-                src={`/sprites/${loadPlayerAvatar()}.svg`}
-                alt="Jarv"
-                style={{ width: AVATAR_SIZE, height: AVATAR_SIZE, imageRendering: 'pixelated' }}
-              />
-            </div>
-          )}
-          {rows.map((rowNodes, rowIndex) => {
-            const rowCols = rowNodes[0]?.rowCols ?? rowNodes.length
+        <Toolbar>
+          {run.archetype && (() => {
+            const def = ARCHETYPE_DEFS.find(d => d.id === run.archetype)
+            return def ? <ToolbarLabel>{def.icon} {def.name}</ToolbarLabel> : null
+          })()}
+          <ToolbarLabel>Items</ToolbarLabel>
+          {ALL_CONSUMABLES.map(def => {
+            const rc    = run.consumables?.find(c => c.id === def.id)
+            const count = rc?.count ?? 0
             return (
-              <React.Fragment key={rowIndex}>
-                {/* Column of nodes — fixed-height rows, centred in the container */}
-                <div
-                  className="nm-col"
-                  style={{
-                    gridTemplateRows: `repeat(${rowCols}, ${ROW_HEIGHT}px)`,
-                    height: `${rowCols * ROW_HEIGHT}px`,
-                    width: `${COL_WIDTH}px`,
-                    margin: 'auto 0',
-                    position: 'relative',
-                    zIndex: 1,
-                  }}
-                >
-                  {rowNodes.map((node) => {
-                    if (hiddenNodeIds.has(node.id)) {
-                      return <div key={node.id} style={{ gridRow: node.col + 1 }} />
-                    }
-
-                    const status    = getNodeStatus(node.id, availableIds, run)
-                    const clickable = status === 'available'
-                    const dim = status === 'completed'
-                             || status === 'skipped'
-                             || (status === 'locked' && !reachableIds.has(node.id))
-                    const isCurrent = node.id === currentNodeId
-
-                    return (
-                      <div
-                        key={node.id}
-                        ref={isCurrent ? currentRef : undefined}
-                        style={{ gridRow: node.col + 1, display: 'flex', justifyContent: 'center', alignItems: 'center' }}
-                      >
-                        <button
-                          ref={el => { nodeButtonRefs.current[node.id] = el }}
-                          className={[
-                            'nm-node',
-                            `nm-node--${node.type}`,
-                            `nm-node--${status}`,
-                            dim ? 'nm-node--dim' : '',
-                          ].filter(Boolean).join(' ')}
-                          onClick={clickable && !isWalking ? () => handleNodeClick(node) : undefined}
-                          disabled={!clickable}
-                          title={node.description}
-                        >
-                          <span className={`nm-node-type-badge nm-node-type-badge--${node.type}`}>
-                            {NODE_LABEL[node.type] ?? node.type.toUpperCase()}
-                          </span>
-                          {(() => {
-                            if ((node.type === 'battle' || node.type === 'elite') && node.enemyDeck?.length) {
-                              const unitName = node.enemyDeck[0]
-                              if (status === 'completed') {
-                                return <span className="nm-node-icon">🪦</span>
-                              }
-                              const isBuilding = (getCardUnit(unitName)?.moveSpeed ?? 1) === 0
-                              if (isBuilding) {
-                                const slug = spriteSlug(unitName)
-                                return <img src={`/sprites/${slug}.svg`} alt="" className="nm-node-sprite"
-                                  onError={e => { (e.currentTarget as HTMLImageElement).style.display = 'none' }} />
-                              }
-                              return <WanderingSprite name={unitName} />
-                            }
-                            const sprite = nodeSprite(node)
-                            return sprite
-                              ? <img src={sprite} alt="" className="nm-node-sprite"
-                                  onError={e => { (e.currentTarget as HTMLImageElement).style.display = 'none' }} />
-                              : <span className="nm-node-icon">{NODE_ICON[node.type] ?? '?'}</span>
-                          })()}
-                          <span className="nm-node-name">{node.label}</span>
-                          <span className="nm-node-status">
-                            {status === 'completed' && '✓'}
-                            {status === 'pending'   && '…'}
-                            {status === 'skipped'   && '╳'}
-                            {status === 'available' && node.type === 'rest'
-                              ? `+${node.restHeal} HP`
-                              : status === 'available' ? '' : ''}
-                          </span>
-                        </button>
-                      </div>
-                    )
-                  })}
-                </div>
-
-                {/* Connector to the right of this column */}
-                {rowIndex < rows.length - 1 && (
-                  <SVGConnector
-                    prevRow={rowNodes}
-                    nextRow={rows[rowIndex + 1]}
-                    maxRows={maxRowCols}
-                    statusOf={statusOf}
-                    reachableIds={reachableIds}
-                    hiddenNodeIds={hiddenNodeIds}
-                    environment={act.environment}
-                  />
-                )}
+              <React.Fragment key={def.id}>
+                <ToolbarButton
+                  label={`${def.name} ×${count}`}
+                  icon={def.icon}
+                  disabled={count === 0}
+                  onClick={() => onUseConsumable(def.id)}
+                />
               </React.Fragment>
             )
           })}
+          <ToolbarSpacer />
+          <ToolbarButton
+            label="Copy Debug State"
+            icon="🐞"
+            onClick={() => {
+              const nodeStatuses: Record<string, string> = {}
+              for (const node of Object.values(act.nodes))
+                nodeStatuses[node.id] = `${node.type} → ${statusOf(node.id)}`
+              const state = {
+                actId: run.actId, pendingNodeId: run.pendingNodeId,
+                completedNodeIds: run.completedNodeIds, skippedNodeIds: run.skippedNodeIds,
+                availableIds, nodeStatuses,
+              }
+              console.log('[NodeMap debug]', state)
+              navigator.clipboard?.writeText(JSON.stringify(state, null, 2)).catch(() => undefined)
+              alert('Debug state copied to clipboard (also logged to console).')
+            }}
+          />
+        </Toolbar>
+
+        <div
+          className={`nm-map u-flex u-grow u-items-c${act.environment ? ` nm-map--${act.environment}` : ''}`}
+          ref={mapRef}
+        >
+          <canvas ref={canvasRef} style={{ display: 'block', flexShrink: 0 }} />
         </div>
+
+        {peekNode && (
+          <NodePeekModal
+            node={peekNode}
+            actId={act.id}
+            nodeHistory={nodeHistory}
+            activeModifiers={getModifiersByCount(act, run.activeModifierCount)}
+            onEnter={handlePeekEnter}
+            onClose={() => setPeekNode(null)}
+          />
+        )}
       </div>
 
-
-      {/* Node peek modal */}
-      {peekNode && (
-        <NodePeekModal
-          node={peekNode}
-          actId={act.id}
-          nodeHistory={nodeHistory}
-          activeModifiers={getModifiersByCount(act, run.activeModifierCount)}
-          onEnter={handlePeekEnter}
-          onClose={() => setPeekNode(null)}
-        />
-      )}
-    </div>
       <Toolbar>
         <ToolbarSpacer />
-      <div className="u-col u-gap-1 u-mg-t-lg u-mg-b-md">
-        <NodeMapHpBar hp={run.playerHp} maxHp={run.maxHp} />
-        <div className="nm-lives-area u-flex u-items-end u-just-end u-gap-1 " title="Lives remaining — lose them all and the campaign ends">
-          <Lives maxLives={run.maxLives ?? 3} currentLives={run.livesRemaining ?? 3} />
+        <div className="u-col u-gap-1 u-mg-t-lg u-mg-b-md">
+          <NodeMapHpBar hp={run.playerHp} maxHp={run.maxHp} />
+          <div className="nm-lives-area u-flex u-items-end u-just-end u-gap-1"
+            title="Lives remaining — lose them all and the campaign ends">
+            <Lives maxLives={run.maxLives ?? 3} currentLives={run.livesRemaining ?? 3} />
+          </div>
         </div>
-      </div>
       </Toolbar>
     </OverlayScreen>
   )

--- a/web/src/components/minigames/towerdefence/GameGrid.tsx
+++ b/web/src/components/minigames/towerdefence/GameGrid.tsx
@@ -1,162 +1,488 @@
-import { buildingUnitCount, TD_CELL_PX as CELL_PX, TD_COLS, TD_MAX_UPGRADES, TD_PATH, TD_ROWS, TDGameState, TDTower, TDUnit, xpToUpgrade } from "../../../game/towerDefence";
-import { SpriteImg } from "../../ui/SpriteImg";
-import { AttackEffect } from "./AttackEffect";
-import { EnemyToken } from "./EnemyToken";
-import { HazardCloud } from "./HazardCloud";
-import { UnitGroupToken } from "./UnitGroupToken";
+import { useRef, useEffect, useCallback } from 'react'
+import * as PIXI from 'pixi.js'
+import {
+  buildingUnitCount, hpBarColor,
+  TD_CELL_PX as CELL_PX, TD_COLS, TD_MAX_UPGRADES, TD_PATH, TD_ROWS,
+  PATH_SET,
+  TDGameState, TDTower, TDUnit, xpToUpgrade,
+} from '../../../game/towerDefence'
+import { usePixiApp } from '../../../hooks/usePixiApp'
+import { loadAnimFrames, loadSpriteTexture } from '../../../utils/pixiHelpers'
 
+// ── Cell colours ─────────────────────────────────────────────────────────────
+const C_GRASS          = 0x2d4a1e
+const C_PATH           = 0x8b6b3d
+const C_START          = 0x1a5c0e
+const C_END            = 0x5c0e0e
+const C_IN_RANGE       = 0x224488
+const C_DROPPABLE      = 0x1a3d1a
+const C_TOWER_SELECTED = 0x7a5500
+const C_BORDER_DARK    = 0x111111
 
 export interface Props {
-boardWrapRef: React.RefObject<HTMLDivElement>;
-game: TDGameState;
-selectedTowerId: number | null;
-rangeHighlight: Set<string>;
-canPlaceTowers: boolean;
-selected: boolean;
-setHoveredTower: (tower: TDTower | null) => void;
-setHoveredCell: (cell: { col: number; row: number } | null) => void;
-handleCellClick: (col: number, row: number) => void;
-gridScale: number
-isOnPath(col: number, row: number): boolean
-selectedTower: TDTower | null
-hoveredTower: TDTower | null
+  boardWrapRef: React.RefObject<HTMLDivElement>
+  game: TDGameState
+  selectedTowerId: number | null
+  rangeHighlight: Set<string>
+  canPlaceTowers: boolean
+  selected: boolean
+  setHoveredTower: (tower: TDTower | null) => void
+  setHoveredCell: (cell: { col: number; row: number } | null) => void
+  handleCellClick: (col: number, row: number) => void
+  gridScale: number
+  isOnPath(col: number, row: number): boolean
+  selectedTower: TDTower | null
+  hoveredTower: TDTower | null
 }
 
+// ── Scene object refs ─────────────────────────────────────────────────────────
+
+interface Scene {
+  cellGfx:    PIXI.Graphics
+  towerLayer: PIXI.Container
+  unitLayer:  PIXI.Container
+  enemyLayer: PIXI.Container
+  effectGfx:  PIXI.Graphics
+  hazardGfx:  PIXI.Graphics
+  hpGfx:      PIXI.Graphics
+  // Sprite pools keyed by id
+  enemySprites: Map<number, PIXI.AnimatedSprite>
+  unitSprites:  Map<number, PIXI.AnimatedSprite>  // keyed by towerId
+  towerSprites: Map<number, PIXI.Container>
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function cellLeft(col: number) { return col * CELL_PX }
+function cellTop (row: number) { return row * CELL_PX }
+function cellCx  (col: number) { return col * CELL_PX + CELL_PX / 2 }
+function cellCy  (row: number) { return row * CELL_PX + CELL_PX / 2 }
+
+function hpBarColorHex(frac: number): number {
+  return parseInt(hpBarColor(frac).slice(1), 16)
+}
+
+// ── Draw cells ────────────────────────────────────────────────────────────────
+
+function drawCells(
+  g: PIXI.Graphics,
+  rangeHighlight: Set<string>,
+  selectedTowerId: number | null,
+  canPlaceTowers: boolean,
+  selected: boolean,
+  towers: TDTower[],
+) {
+  g.clear()
+  const towerByCell = new Map(towers.map(t => [`${t.col},${t.row}`, t]))
+
+  for (let row = 0; row < TD_ROWS; row++) {
+    for (let col = 0; col < TD_COLS; col++) {
+      const key    = `${col},${row}`
+      const onPath = PATH_SET.has(key)
+      const isStart = col === TD_PATH[0].col          && row === TD_PATH[0].row
+      const isEnd   = col === TD_PATH[TD_PATH.length - 1].col && row === TD_PATH[TD_PATH.length - 1].row
+      const tower   = towerByCell.get(key)
+      const inRange = rangeHighlight.has(key)
+      const isTowerSelected = tower?.id === selectedTowerId
+      const canDrop = !onPath && !tower && ((selected && canPlaceTowers) || selectedTowerId !== null)
+
+      const base = isStart ? C_START : isEnd ? C_END : onPath ? C_PATH : C_GRASS
+      const fill = isTowerSelected ? C_TOWER_SELECTED
+                 : inRange         ? C_IN_RANGE
+                 : canDrop         ? C_DROPPABLE
+                 : base
+
+      const x = cellLeft(col)
+      const y = cellTop(row)
+      g.rect(x, y, CELL_PX, CELL_PX).fill(fill)
+      g.rect(x, y, CELL_PX, CELL_PX).stroke({ width: 1, color: C_BORDER_DARK, alpha: 0.5 })
+
+      // IN / BASE labels
+      if (isStart || isEnd) {
+        // Drawn via PIXI.Text in a separate pass for legibility
+      }
+    }
+  }
+}
+
+// ── Sync tower sprites ────────────────────────────────────────────────────────
+
+async function syncTowers(
+  layer: PIXI.Container,
+  towerSprites: Map<number, PIXI.Container>,
+  towers: TDTower[],
+) {
+  const liveIds = new Set(towers.map(t => t.id))
+
+  // Remove stale
+  for (const [id, c] of towerSprites) {
+    if (!liveIds.has(id)) { layer.removeChild(c); c.destroy({ children: true }); towerSprites.delete(id) }
+  }
+
+  // Add/update
+  for (const tower of towers) {
+    let ctr = towerSprites.get(tower.id)
+    if (!ctr) {
+      ctr = new PIXI.Container()
+      try {
+        const tex = await loadSpriteTexture(tower.buildingName)
+        const spr = new PIXI.Sprite(tex)
+        spr.width = CELL_PX - 8
+        spr.height = CELL_PX - 8
+        spr.x = 4; spr.y = 4
+        ctr.addChild(spr)
+      } catch {
+        // sprite missing — render a placeholder square
+        const g = new PIXI.Graphics()
+        g.rect(4, 4, CELL_PX - 8, CELL_PX - 8).fill(0x886600)
+        ctr.addChild(g)
+      }
+      layer.addChild(ctr)
+      towerSprites.set(tower.id, ctr)
+    }
+    ctr.x = cellLeft(tower.col)
+    ctr.y = cellTop(tower.row)
+
+    // Badge text (tier, ready)
+    const existingBadge = ctr.getChildByLabel('badge') as PIXI.Text | null
+    existingBadge?.destroy()
+
+    if (tower.upgrades > 0) {
+      const t = new PIXI.Text({ text: `★${tower.upgrades}`, style: { fontSize: 8, fill: 0xffdd00 } })
+      t.label = 'badge'
+      t.x = 1; t.y = 1
+      ctr.addChild(t)
+    }
+
+    // Upgrade-ready indicator
+    const xpNeeded = xpToUpgrade(tower)
+    const existingReady = ctr.getChildByLabel('ready') as PIXI.Text | null
+    existingReady?.destroy()
+    if (tower.upgrades < TD_MAX_UPGRADES && tower.xp >= xpNeeded) {
+      const t = new PIXI.Text({ text: '⬆', style: { fontSize: 9, fill: 0x44ff44 } })
+      t.label = 'ready'
+      t.x = CELL_PX - 11; t.y = 1
+      ctr.addChild(t)
+    }
+  }
+}
+
+// ── Sync animated entity sprites ──────────────────────────────────────────────
+
+async function syncEntitySprites(
+  layer: PIXI.Container,
+  sprites: Map<number, PIXI.AnimatedSprite>,
+  entities: Array<{ id: number; x: number; y: number; spriteName: string }>,
+  size: number,
+  fps: number,
+) {
+  const liveIds = new Set(entities.map(e => e.id))
+
+  for (const [id, spr] of sprites) {
+    if (!liveIds.has(id)) { layer.removeChild(spr); spr.destroy(); sprites.delete(id) }
+  }
+
+  for (const ent of entities) {
+    let spr = sprites.get(ent.id)
+    if (!spr) {
+      try {
+        const frames = await loadAnimFrames(ent.spriteName, 3)
+        spr = new PIXI.AnimatedSprite(frames)
+        spr.animationSpeed = fps / 60
+        spr.play()
+      } catch {
+        // fallback: static sprite
+        try {
+          const tex = await loadSpriteTexture(ent.spriteName)
+          spr = new PIXI.AnimatedSprite([tex])
+        } catch {
+          spr = new PIXI.AnimatedSprite([PIXI.Texture.EMPTY])
+        }
+      }
+      spr.width = size
+      spr.height = size
+      layer.addChild(spr)
+      sprites.set(ent.id, spr)
+    }
+    spr.x = ent.x - size / 2
+    spr.y = ent.y - size / 2
+  }
+}
+
+// ── Draw HP bars ──────────────────────────────────────────────────────────────
+
+function drawHpBars(
+  g: PIXI.Graphics,
+  enemies:  TDGameState['enemies'],
+  units:    TDGameState['units'],
+) {
+  g.clear()
+  const BAR = 20
+
+  for (const e of enemies) {
+    const frac = e.hp / e.maxHp
+    const col  = parseInt(hpBarColor(frac).slice(1), 16)
+    const x = e.x - BAR / 2
+    const y = e.y + 9
+    g.rect(x, y, BAR, 3).fill(0x111111)
+    if (frac > 0) g.rect(x, y, Math.round(BAR * frac), 3).fill(col)
+  }
+
+  // Units: group by tower, show at lead unit position
+  const byTower = new Map<number, TDUnit[]>()
+  for (const u of units) {
+    const g2 = byTower.get(u.towerId) ?? []; g2.push(u); byTower.set(u.towerId, g2)
+  }
+  for (const group of byTower.values()) {
+    if (group.length === 0) continue
+    const lead     = group[0]
+    const minFrac  = Math.min(...group.map(u => u.hp / u.maxHp))
+    const col      = parseInt(hpBarColor(minFrac).slice(1), 16)
+    const x = lead.x - BAR / 2
+    const y = lead.y + 7
+    g.rect(x, y, BAR, 3).fill(0x111111)
+    if (minFrac > 0) g.rect(x, y, Math.round(BAR * minFrac), 3).fill(col)
+  }
+
+}
+
+// ── Draw attack effects ───────────────────────────────────────────────────────
+
+function drawEffects(g: PIXI.Graphics, attackEvents: TDGameState['attackEvents']) {
+  g.clear()
+  for (const ev of attackEvents) {
+    const pType = ev.projectileType ?? 'magic'
+    const dx = ev.toX - ev.fromX
+    const dy = ev.toY - ev.fromY
+    const len = Math.hypot(dx, dy)
+
+    if (pType === 'aoe' || (ev.aoeRadius && len < 2)) {
+      const r = ev.aoeRadius ?? 48
+      g.circle(ev.toX, ev.toY, r).stroke({ width: 2, color: 0xff8800, alpha: 0.7 })
+      g.circle(ev.toX, ev.toY, r * 0.6).fill({ color: 0xff4400, alpha: 0.3 })
+    } else {
+      const col = pType === 'lightning' ? 0xaabbff
+               : pType === 'icebolt'   ? 0x88eeff
+               : pType === 'fireball'  ? 0xff6600
+               : pType === 'poisonblob'? 0x88ff44
+               : pType === 'arrow'     ? 0xccaa44
+               : 0xcc44ff // magic default
+      g.moveTo(ev.fromX, ev.fromY).lineTo(ev.toX, ev.toY)
+        .stroke({ width: 2, color: col, alpha: 0.85 })
+      // Hit burst
+      g.circle(ev.toX, ev.toY, 5).fill({ color: col, alpha: 0.6 })
+    }
+  }
+}
+
+// ── Draw hazard clouds ────────────────────────────────────────────────────────
+
+function drawHazards(g: PIXI.Graphics, hazards: TDGameState['hazards']) {
+  g.clear()
+  for (const h of hazards) {
+    g.circle(h.x, h.y, h.radius).fill({ color: 0x44bb44, alpha: 0.35 })
+    g.circle(h.x, h.y, h.radius).stroke({ width: 1, color: 0x88ff88, alpha: 0.5 })
+  }
+}
+
+// ── Main component ────────────────────────────────────────────────────────────
+
 export function GameGrid({
-boardWrapRef, game, selectedTowerId, rangeHighlight, canPlaceTowers, selected,
-gridScale,
-isOnPath,setHoveredTower, setHoveredCell, handleCellClick,
-selectedTower, hoveredTower,
+  boardWrapRef, game, selectedTowerId, rangeHighlight, canPlaceTowers, selected,
+  gridScale, isOnPath, setHoveredTower, setHoveredCell, handleCellClick,
+  selectedTower, hoveredTower,
 }: Props) {
-    const towerByCell = new Map(game.towers.map(t => [`${t.col},${t.row}`, t]))
-    return <div className="td-board-wrap" ref={boardWrapRef}>
+  const W = TD_COLS * CELL_PX
+  const H = TD_ROWS * CELL_PX
+
+  const canvasRef  = useRef<HTMLCanvasElement>(null)
+  const sceneRef   = useRef<Scene | null>(null)
+
+  // Stable callback ref so the scene-update effect doesn't re-run on each render
+  const propsRef = useRef({
+    game, selectedTowerId, rangeHighlight, canPlaceTowers, selected,
+    isOnPath, selectedTower, hoveredTower,
+    handleCellClick, setHoveredTower, setHoveredCell,
+  })
+  propsRef.current = {
+    game, selectedTowerId, rangeHighlight, canPlaceTowers, selected,
+    isOnPath, selectedTower, hoveredTower,
+    handleCellClick, setHoveredTower, setHoveredCell,
+  }
+
+  // ── Initialise PixiJS once ─────────────────────────────────────────────────
+  usePixiApp(canvasRef, W, H, (app) => {
+    const cellGfx    = new PIXI.Graphics()
+    const towerLayer = new PIXI.Container()
+    const unitLayer  = new PIXI.Container()
+    const enemyLayer = new PIXI.Container()
+    const effectGfx  = new PIXI.Graphics()
+    const hazardGfx  = new PIXI.Graphics()
+    const hpGfx      = new PIXI.Graphics()
+
+    app.stage.addChild(cellGfx)
+    app.stage.addChild(towerLayer)
+    app.stage.addChild(unitLayer)
+    app.stage.addChild(enemyLayer)
+    app.stage.addChild(hazardGfx)
+    app.stage.addChild(effectGfx)
+    app.stage.addChild(hpGfx)
+
+    // Cell labels for start/end
+    const startLabel = new PIXI.Text({ text: 'IN',   style: { fontSize: 9, fill: 0xffffff, fontWeight: 'bold' } })
+    const endLabel   = new PIXI.Text({ text: 'BASE', style: { fontSize: 8, fill: 0xffffff, fontWeight: 'bold' } })
+    startLabel.x = cellCx(TD_PATH[0].col) - 8
+    startLabel.y = cellCy(TD_PATH[0].row) - 5
+    endLabel.x   = cellCx(TD_PATH[TD_PATH.length - 1].col) - 10
+    endLabel.y   = cellCy(TD_PATH[TD_PATH.length - 1].row) - 5
+    app.stage.addChild(startLabel)
+    app.stage.addChild(endLabel)
+
+    // Click/hover detection on the cell layer background
+    const hitArea = new PIXI.Graphics()
+    hitArea.rect(0, 0, W, H).fill({ color: 0x000000, alpha: 0 })
+    hitArea.eventMode = 'static'
+    hitArea.on('pointerdown', (e: PIXI.FederatedPointerEvent) => {
+      const local = e.getLocalPosition(hitArea)
+      const col = Math.floor(local.x / CELL_PX)
+      const row = Math.floor(local.y / CELL_PX)
+      if (col >= 0 && col < TD_COLS && row >= 0 && row < TD_ROWS) {
+        propsRef.current.handleCellClick(col, row)
+      }
+    })
+    hitArea.on('pointermove', (e: PIXI.FederatedPointerEvent) => {
+      const local = e.getLocalPosition(hitArea)
+      const col = Math.floor(local.x / CELL_PX)
+      const row = Math.floor(local.y / CELL_PX)
+      if (col >= 0 && col < TD_COLS && row >= 0 && row < TD_ROWS) {
+        const towerByCell = new Map(propsRef.current.game.towers.map(t => [`${t.col},${t.row}`, t]))
+        const tower = towerByCell.get(`${col},${row}`) ?? null
+        propsRef.current.setHoveredTower(tower)
+        propsRef.current.setHoveredCell({ col, row })
+      } else {
+        propsRef.current.setHoveredTower(null)
+        propsRef.current.setHoveredCell(null)
+      }
+    })
+    hitArea.on('pointerout', () => {
+      propsRef.current.setHoveredTower(null)
+      propsRef.current.setHoveredCell(null)
+    })
+    app.stage.addChild(hitArea)
+
+    sceneRef.current = {
+      cellGfx, towerLayer, unitLayer, enemyLayer,
+      effectGfx, hazardGfx, hpGfx,
+      enemySprites: new Map(),
+      unitSprites:  new Map(),
+      towerSprites: new Map(),
+    }
+
+    // Initial draw
+    renderScene(sceneRef.current, propsRef.current)
+  })
+
+  // ── Update scene when game state changes ───────────────────────────────────
+  useEffect(() => {
+    if (!sceneRef.current) return
+    renderScene(sceneRef.current, propsRef.current)
+  }) // run on every render to keep scene in sync
+
+  // ── Canvas click/hover forwarding ──────────────────────────────────────────
+  const handleMouseLeave = useCallback(() => {
+    setHoveredTower(null)
+    setHoveredCell(null)
+  }, [setHoveredTower, setHoveredCell])
+
+  // ── Tooltip (DOM overlay) ─────────────────────────────────────────────────
+  const t = selectedTower ?? hoveredTower
+  const tooltip = t ? (() => {
+    const unitCount  = buildingUnitCount(t)
+    const activeUnits = game.units.filter(u => u.towerId === t.id)
+    const xpNeeded   = xpToUpgrade(t)
+    const xpReady    = t.upgrades < TD_MAX_UPGRADES && t.xp >= xpNeeded
+    return (
+      <div
+        className="td-tower-tooltip"
+        style={{ left: t.col * CELL_PX, top: Math.max(0, t.row * CELL_PX - 56) }}
+      >
+        <strong>{t.buildingName}</strong>
+        {t.upgrades > 0 && <span className="td-tower-tier-label u-text-gold"> {'★'.repeat(t.upgrades)}</span>}
+        <div>{t.template.name} · {activeUnits.length}/{unitCount} active</div>
+        {t.upgrades < TD_MAX_UPGRADES && (
+          <div className={xpReady ? 'td-tooltip-xp-ready' : 'td-tooltip-xp'}>
+            {xpReady ? '⬆ Upgrade ready!' : `XP ${t.xp}/${xpNeeded} kills`}
+          </div>
+        )}
+        {t.id !== selectedTowerId && <div className="td-tooltip-hint">Tap to select</div>}
+      </div>
+    )
+  })() : null
+
+  return (
+    <div className="td-board-wrap" ref={boardWrapRef}>
       <div
         className="td-grid-scaler"
-        style={{
-          width: TD_COLS * CELL_PX * gridScale,
-          height: TD_ROWS * CELL_PX * gridScale,
-        }}
+        style={{ width: W * gridScale, height: H * gridScale }}
       >
         <div
-          className="td-grid"
           style={{
-            width: TD_COLS * CELL_PX,
-            height: TD_ROWS * CELL_PX,
+            width: W,
+            height: H,
             transform: `scale(${gridScale})`,
             transformOrigin: 'top left',
+            position: 'relative',
           }}
         >
-          {/* Cells */}
-          {Array.from({ length: TD_ROWS }, (_, row) => Array.from({ length: TD_COLS }, (_, col) => {
-            const onPath = isOnPath(col, row)
-            const isStart = col === TD_PATH[0].col && row === TD_PATH[0].row
-            const isEnd = col === TD_PATH[TD_PATH.length - 1].col && row === TD_PATH[TD_PATH.length - 1].row
-            const tower = towerByCell.get(`${col},${row}`)
-            const isTowerSelected = tower?.id === selectedTowerId
-            // canDrop: valid placement cell, or valid move destination for selected tower
-            const canDrop = !onPath && !tower && (
-              (selected && canPlaceTowers) ||
-              (selectedTowerId !== null)
-            )
-            const inRange = rangeHighlight.has(`${col},${row}`)
-
-            return (
-              <div
-                key={`${col},${row}`}
-                className={[
-                  'td-cell u-absolute u-pointer u-flex u-items-c u-just-c u-no-select',
-                  onPath ? 'td-cell--path' : 'td-cell--grass',
-                  isStart ? 'td-cell--start' : '',
-                  isEnd ? 'td-cell--end' : '',
-                  canDrop ? 'td-cell--droppable' : '',
-                  tower ? 'td-cell--occupied' : '',
-                  inRange ? 'td-cell--in-range' : '',
-                  isTowerSelected ? 'td-cell--tower-selected' : '',
-                ].filter(Boolean).join(' ')}
-                style={{ left: col * CELL_PX, top: row * CELL_PX, width: CELL_PX, height: CELL_PX }}
-                onClick={() => handleCellClick(col, row)}
-                onMouseEnter={() => {
-                  if (tower) setHoveredTower(tower)
-                  setHoveredCell({ col, row })
-                } }
-                onMouseLeave={() => {
-                  setHoveredTower(null)
-                  setHoveredCell(null)
-                } }
-              >
-                {isStart && <span className="td-cell-label">IN</span>}
-                {isEnd && <span className="td-cell-label">BASE</span>}
-                {tower && (
-                  <div className="td-tower-inner u-col u-items-c">
-                    <SpriteImg name={tower.buildingName} />
-                    {tower.upgrades > 0 && (
-                      <div className="td-tower-tier">★{tower.upgrades}</div>
-                    )}
-                    {tower.respawnTimers.length > 0 && (
-                      <div className="td-tower-respawn">⏳</div>
-                    )}
-                    {tower.upgrades < TD_MAX_UPGRADES && tower.xp >= xpToUpgrade(tower) && (
-                      <div className="td-tower-upgrade-ready">⬆</div>
-                    )}
-                  </div>
-                )}
-              </div>
-            )
-          })
-          )}
-
-          {/* Player units — grouped per building, one cell per group */}
-          {Array.from(
-            game.units.reduce((map, u) => {
-              const g = map.get(u.towerId) ?? []
-              g.push(u)
-              map.set(u.towerId, g)
-              return map
-            }, new Map<number, TDUnit[]>())
-          ).map(([towerId, units]) => (
-            <UnitGroupToken key={towerId} units={units} />
-          ))}
-
-          {/* Enemies */}
-          {game.enemies.map(enemy => (
-            <EnemyToken key={enemy.id} enemy={enemy} />
-          ))}
-
-          {/* Gas cloud hazards */}
-          {game.hazards.map(h => (
-            <HazardCloud key={h.id} hazard={h} />
-          ))}
-
-          {/* Attack effects */}
-          {game.attackEvents.map(ev => (
-            <AttackEffect key={ev.id} ev={ev} />
-          ))}
-
-          {/* Building tooltip */}
-          {(selectedTower || hoveredTower) && (() => {
-            const t = selectedTower ?? hoveredTower!
-            const unitCount = buildingUnitCount(t)
-            const activeUnits = game.units.filter(u => u.towerId === t.id)
-            const xpNeeded = xpToUpgrade(t)
-            const xpReady = t.upgrades < TD_MAX_UPGRADES && t.xp >= xpNeeded
-            return (
-              <div
-                className="td-tower-tooltip"
-                style={{ left: t.col * CELL_PX, top: Math.max(0, t.row * CELL_PX - 56) }}
-              >
-                <strong>{t.buildingName}</strong>
-                {t.upgrades > 0 && <span className="td-tower-tier-label u-text-gold"> {'★'.repeat(t.upgrades)}</span>}
-                <div>{t.template.name} · {activeUnits.length}/{unitCount} active</div>
-                {t.upgrades < TD_MAX_UPGRADES && (
-                  <div className={xpReady ? 'td-tooltip-xp-ready' : 'td-tooltip-xp'}>
-                    {xpReady ? '⬆ Upgrade ready!' : `XP ${t.xp}/${xpNeeded} kills`}
-                  </div>
-                )}
-                {t.id !== selectedTowerId && <div className="td-tooltip-hint">Tap to select</div>}
-              </div>
-            )
-          })()}
+          <canvas
+            ref={canvasRef}
+            width={W}
+            height={H}
+            style={{ display: 'block', width: W, height: H }}
+            onMouseLeave={handleMouseLeave}
+          />
+          {tooltip}
         </div>
-      </div>{/* td-grid-scaler */}
+      </div>
     </div>
+  )
+}
+
+// ── Scene render (called on every React render) ───────────────────────────────
+
+function renderScene(
+  scene: Scene,
+  props: {
+    game: TDGameState
+    selectedTowerId: number | null
+    rangeHighlight: Set<string>
+    canPlaceTowers: boolean
+    selected: boolean
+    isOnPath: (col: number, row: number) => boolean
+    selectedTower: TDTower | null
+    hoveredTower: TDTower | null
+  },
+) {
+  const { game, selectedTowerId, rangeHighlight, canPlaceTowers, selected } = props
+
+  drawCells(scene.cellGfx, rangeHighlight, selectedTowerId, canPlaceTowers, selected, game.towers)
+  drawEffects(scene.effectGfx, game.attackEvents)
+  drawHazards(scene.hazardGfx, game.hazards)
+  drawHpBars(scene.hpGfx, game.enemies, game.units)
+
+  // Async sprite sync (fire and forget — sprites appear as textures load)
+  syncTowers(scene.towerLayer, scene.towerSprites, game.towers)
+
+  const enemies = game.enemies.map(e => ({ id: e.id, x: e.x, y: e.y, spriteName: e.template.spriteName }))
+  syncEntitySprites(scene.enemyLayer, scene.enemySprites, enemies, 15, 6)
+
+  // Units: one sprite per tower-group at lead unit position
+  const unitGroups = new Map<number, TDUnit[]>()
+  for (const u of game.units) {
+    const g = unitGroups.get(u.towerId) ?? []; g.push(u); unitGroups.set(u.towerId, g)
   }
+  const unitEntities = Array.from(unitGroups.values())
+    .filter(g => g.length > 0)
+    .map(g => ({ id: g[0].towerId, x: g[0].x, y: g[0].y, spriteName: g[0].template.name }))
+  syncEntitySprites(scene.unitLayer, scene.unitSprites, unitEntities, 11, 8)
+}

--- a/web/src/hooks/usePixiApp.ts
+++ b/web/src/hooks/usePixiApp.ts
@@ -26,6 +26,7 @@ export function usePixiApp(
     const app = new PIXI.Application()
     appRef.current = app
 
+    let initialized = false
     app.init({
       canvas,
       width,
@@ -35,13 +36,19 @@ export function usePixiApp(
       resolution: window.devicePixelRatio || 1,
       autoDensity: true,
     }).then(() => {
-      if (destroyed) return
+      initialized = true
+      if (destroyed) {
+        app.destroy(false, { children: true, texture: false })
+        return
+      }
       onReady(app)
     })
 
     return () => {
       destroyed = true
-      app.destroy(false, { children: true, texture: false })
+      if (initialized) {
+        app.destroy(false, { children: true, texture: false })
+      }
       appRef.current = null
     }
   }, []) // eslint-disable-line react-hooks/exhaustive-deps

--- a/web/src/utils/pixiHelpers.ts
+++ b/web/src/utils/pixiHelpers.ts
@@ -57,3 +57,37 @@ export function makeClickable(
   container.cursor    = 'pointer'
   container.on('pointerdown', onClick)
 }
+
+/**
+ * Load a texture directly from an arbitrary URL (with caching).
+ * Use this for sprite URLs that aren't derived from a unit name.
+ */
+export function loadTextureUrl(url: string): Promise<PIXI.Texture> {
+  return _load(url)
+}
+
+/**
+ * Tween a Container's (x, y) position to the target over durationMs milliseconds.
+ * Uses an ease-in-out curve. Returns a Promise that resolves when the tween completes.
+ */
+export function tweenTo(
+  obj: PIXI.Container,
+  targetX: number,
+  targetY: number,
+  durationMs: number,
+  app: PIXI.Application,
+): Promise<void> {
+  return new Promise(resolve => {
+    const startX = obj.x, startY = obj.y
+    let elapsed = 0
+    const tick = (ticker: PIXI.Ticker) => {
+      elapsed += ticker.deltaMS
+      const t = Math.min(elapsed / durationMs, 1)
+      const e = t < 0.5 ? 2 * t * t : -1 + (4 - 2 * t) * t
+      obj.x = startX + (targetX - startX) * e
+      obj.y = startY + (targetY - startY) * e
+      if (t >= 1) { app.ticker.remove(tick); resolve() }
+    }
+    app.ticker.add(tick)
+  })
+}


### PR DESCRIPTION
## Summary

- Rewrites `NodeMap.tsx` from a hybrid SVG/DOM layout to a single PixiJS canvas with a proper 2D scene graph
- **WorldLayer** (`sortableChildren = true`) Y-sorts all world objects — terrain decorations, node markers, and the avatar depth-sort correctly against each other with no CSS hacks
- **Node markers** are `PIXI.Container` objects with `eventMode = 'static'`; clicking an available node tweens the avatar to it before opening the peek modal
- **DOM** retains only the peek modal, toolbar, HP bar, and lives — no DOM node buttons
- Adds `loadTextureUrl` and `tweenTo` helpers to `pixiHelpers.ts`

## Architecture

```
PixiJS Application (fills nm-map canvas)
├── GroundLayer  — terrain rivers, bezier connector paths
└── WorldLayer   — terrain objects, node markers, avatar (sortableChildren=true; zIndex=y)
```

## Test plan

- [ ] Campaign map renders with terrain decorations, connector paths between columns
- [ ] Node markers visible with correct icons/labels; styled by status (available/locked/completed/skipped)
- [ ] Clicking an available node: avatar walks to it, peek modal opens
- [ ] Avatar Y-sorts against terrain objects (appears behind tall terrain when positioned behind it)
- [ ] No DOM node buttons in devtools — only canvas + peek modal
- [ ] Toolbar, consumables, debug button, HP bar, lives all functional
- [ ] `npm run build` passes with no TypeScript errors

https://claude.ai/code/session_0178FWDGT2AnsK7r6hmFJU1R

---
_Generated by [Claude Code](https://claude.ai/code/session_0178FWDGT2AnsK7r6hmFJU1R)_