### PR TITLE
fix(nodemap): fix bezierBand connector polygon — reverse coordinate pairs not flat elements

### DIFF
--- a/web/src/components/campaign/NodeMap.tsx
+++ b/web/src/components/campaign/NodeMap.tsx
@@ -393,16 +393,17 @@ function sampleBezier(
 }
 
 function bezierBand(pts: Array<{ x: number; y: number }>, halfW: number): number[] {
-  const left: number[] = [], right: number[] = []
+  const left: number[] = [], right: Array<{ x: number; y: number }> = []
   for (let i = 0; i < pts.length; i++) {
     const prev = pts[Math.max(0, i - 1)], next = pts[Math.min(pts.length - 1, i + 1)]
     const tx = next.x - prev.x, ty = next.y - prev.y
     const len = Math.sqrt(tx * tx + ty * ty) || 1
     const nx = -ty / len, ny = tx / len
     left.push(pts[i].x + nx * halfW, pts[i].y + ny * halfW)
-    right.push(pts[i].x - nx * halfW, pts[i].y - ny * halfW)
+    right.push({ x: pts[i].x - nx * halfW, y: pts[i].y - ny * halfW })
   }
-  return [...left, ...right.reverse()]
+  const rightFlat = right.reverse().flatMap(p => [p.x, p.y])
+  return [...left, ...rightFlat]
 }
 
 function drawConnectorsGfx(


### PR DESCRIPTION
## Summary

Fixes the trail/frontier connector road polygons introduced in the NodeMap visual improvements.

`bezierBand()` built the right edge of the road as a flat `number[]` array `[x0, y0, x1, y1, ...]` then called `.reverse()` on it. `Array.reverse()` reverses individual elements, swapping every x with its y — so the polygon vertices were completely wrong, producing the large diagonal green fills visible on the map.

**Fix:** store the right edge as `{x, y}` objects, reverse the object array, then flatten — so coordinate pairs stay intact.

## Test plan

- [ ] Campaign map renders with trail/frontier connectors as narrow road bands (~14px wide), not large diagonal fills
- [ ] Dashed centre lane markings visible on trail/frontier connectors
- [ ] Future (unvisited) connectors show as dashed lines
- [ ] All existing tests pass

https://claude.ai/code/session_0178FWDGT2AnsK7r6hmFJU1R

---
_Generated by [Claude Code](https://claude.ai/code/session_0178FWDGT2AnsK7r6hmFJU1R)_