### PR TITLE
feat(nodemap): add terrainSeed, terrainItems and rivers overrides to Act

### DIFF
--- a/web/src/components/admin/CampaignAdminScreen.tsx
+++ b/web/src/components/admin/CampaignAdminScreen.tsx
@@ -4,6 +4,7 @@ import { Section } from '../ui/Section'
 import { ACTS, Act, QuestNode, NodeType } from '../../game/questline'
 import { getCardCatalog } from '../../game/cards'
 import battlefieldData from '../../data/battlefield.json'
+import { TerrainEditorPanel, TerrainItemDef, RiverDef } from './TerrainEditorPanel'
 
 interface Props {
   onBack: () => void
@@ -278,6 +279,7 @@ function NodeIdPicker({
 // ─── Main component ───────────────────────────────────────────────────────────
 
 export function CampaignAdminScreen({ onBack }: Props) {
+  const [tab, setTab] = useState<'nodes' | 'terrain'>('nodes')
   const [actId, setActId] = useState('act1')
   const [act, setAct] = useState<Act>(() => JSON.parse(JSON.stringify(ACTS['act1'])))
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null)
@@ -331,6 +333,14 @@ export function CampaignAdminScreen({ onBack }: Props) {
     setAct(JSON.parse(JSON.stringify(ACTS[newId])))
     setSelectedNodeId(null)
     setDeckSearch('')
+  }
+
+  function handleTerrainUpdate(terrainItems: TerrainItemDef[], rivers: RiverDef[]) {
+    setAct(prev => ({
+      ...prev,
+      terrainItems: terrainItems.length > 0 ? terrainItems : undefined,
+      rivers:       rivers.length > 0       ? rivers       : undefined,
+    }))
   }
 
   function updateActField<K extends keyof Act>(field: K, value: Act[K]) {
@@ -492,6 +502,35 @@ export function CampaignAdminScreen({ onBack }: Props) {
             ))}
           </select>
         </div>
+
+        {/* Tab bar */}
+        <div className="u-flex u-gap-3">
+          <button
+            className={`action-btn${tab === 'nodes' ? ' action-btn--gold' : ''}`}
+            onClick={() => setTab('nodes')}
+          >
+            NODES
+          </button>
+          <button
+            className={`action-btn${tab === 'terrain' ? ' action-btn--gold' : ''}`}
+            onClick={() => setTab('terrain')}
+          >
+            TERRAIN
+          </button>
+        </div>
+
+        {/* Terrain editor tab */}
+        {tab === 'terrain' && (
+          <Section bordered title="TERRAIN EDITOR">
+            <div className="settings-sublabel" style={{ marginBottom: 8 }}>
+              Place, move, and resize terrain items on the map. Copy the JSON and paste into the act file under <code>terrainItems</code> / <code>rivers</code>.
+            </div>
+            <TerrainEditorPanel act={act} onUpdate={handleTerrainUpdate} />
+          </Section>
+        )}
+
+        {/* Nodes tab sections */}
+        {tab === 'nodes' && <>
 
         {/* Act info */}
         <Section bordered title="ACT INFO">
@@ -864,6 +903,8 @@ export function CampaignAdminScreen({ onBack }: Props) {
 
           </Section>
         )}
+
+        </> /* end nodes tab */}
 
         {/* Export */}
         <Section bordered title="EXPORT">

--- a/web/src/components/admin/TerrainEditorPanel.tsx
+++ b/web/src/components/admin/TerrainEditorPanel.tsx
@@ -1,0 +1,447 @@
+import React, { useRef, useState, useEffect } from 'react'
+import * as PIXI from 'pixi.js'
+import { Act } from '../../game/questline'
+import { usePixiApp } from '../../hooks/usePixiApp'
+import { drawTerrainItem } from '../../utils/terrainGfx'
+
+// ── Types (mirror the Act field shapes) ────────────────────────────────────────
+
+export interface TerrainItemDef { kind: string; x: number; y: number; scale: number }
+export interface RiverDef {
+  x1: number; y1: number; x2: number; y2: number
+  cx1: number; cy1: number; cx2: number; cy2: number
+}
+
+// ── Constants ──────────────────────────────────────────────────────────────────
+
+const TERRAIN_KINDS = [
+  'mountain', 'tree', 'deadtree', 'crystal', 'mushroom',
+  'lava', 'wave', 'cloud', 'tower', 'pillar', 'dune',
+]
+const KIND_ICONS: Record<string, string> = {
+  mountain: '⛰', tree: '🌲', deadtree: '🪵', crystal: '💎', mushroom: '🍄',
+  lava: '🌋', wave: '🌊', cloud: '☁', tower: '🏰', pillar: '🗿', dune: '🏜',
+}
+
+const COL_WIDTH = 112, ROW_HEIGHT = 112, AVATAR_PADDING = 72, CONN_W = 44
+
+// ── River colour helpers (mirrors NodeMap.tsx) ─────────────────────────────────
+
+function riverColors(env: string | undefined) {
+  const base = env === 'volcano' ? 0xcc4400 : env === 'fungal' ? 0x6633aa : env === 'frost' ? 0x88ddff : 0x2255aa
+  const r = (base >> 16) & 0xff, g = (base >> 8) & 0xff, b = base & 0xff
+  return {
+    base,
+    dark:  (Math.round(r * 0.55) << 16) | (Math.round(g * 0.55) << 8) | Math.round(b * 0.55),
+    light: (Math.min(255, Math.round(r * 1.45)) << 16) | (Math.min(255, Math.round(g * 1.45)) << 8) | Math.min(255, Math.round(b * 1.45)),
+  }
+}
+
+function drawRiverOnGfx(
+  gfx: PIXI.Graphics,
+  r: RiverDef,
+  colors: ReturnType<typeof riverColors>,
+  alpha = 1,
+) {
+  const { x1, y1, cx1, cy1, cx2, cy2, x2, y2 } = r
+  gfx.moveTo(x1, y1).bezierCurveTo(cx1, cy1, cx2, cy2, x2, y2).stroke({ color: colors.dark,  width: 20, alpha: 0.65 * alpha, cap: 'round' })
+  gfx.moveTo(x1, y1).bezierCurveTo(cx1, cy1, cx2, cy2, x2, y2).stroke({ color: colors.base,  width: 13, alpha: 0.75 * alpha, cap: 'round' })
+  gfx.moveTo(x1, y1).bezierCurveTo(cx1, cy1, cx2, cy2, x2, y2).stroke({ color: colors.light, width: 7,  alpha: 0.55 * alpha, cap: 'round' })
+  gfx.moveTo(x1, y1).bezierCurveTo(cx1, cy1, cx2, cy2, x2, y2).stroke({ color: 0xffffff,     width: 2,  alpha: 0.38 * alpha, cap: 'round' })
+}
+
+// ── Node background preview ────────────────────────────────────────────────────
+
+function drawNodeBg(
+  container: PIXI.Container,
+  act: Act,
+  rowNums: number[],
+  maxRowCols: number,
+  mapWidth: number,
+  mapHeight: number,
+) {
+  const g = new PIXI.Graphics()
+  // Faint background
+  g.rect(0, 0, mapWidth, mapHeight).fill({ color: 0x000000, alpha: 0.55 })
+
+  const NODE_COLORS: Record<string, number> = {
+    battle: 0xdd5050, elite: 0xddbb30, boss: 0xff2222,
+    rest: 0x33cc55, event: 0x5588ff, merchant: 0xccaa30,
+  }
+
+  for (const node of Object.values(act.nodes)) {
+    const rowIndex = rowNums.indexOf(node.row)
+    const rowCols = node.rowCols ?? 1
+    const x = AVATAR_PADDING + rowIndex * (COL_WIDTH + CONN_W) + COL_WIDTH / 2
+    const y = ((maxRowCols - rowCols) / 2 + node.col + 0.5) * ROW_HEIGHT
+    const col = NODE_COLORS[node.type] ?? 0x888888
+    g.circle(x, y, 14).fill({ color: col, alpha: 0.22 })
+    g.circle(x, y, 14).stroke({ color: col, alpha: 0.45, width: 1.5 })
+  }
+  container.addChild(g)
+}
+
+// ── Component ──────────────────────────────────────────────────────────────────
+
+interface Props {
+  act: Act
+  onUpdate: (terrainItems: TerrainItemDef[], rivers: RiverDef[]) => void
+}
+
+export function TerrainEditorPanel({ act, onUpdate }: Props) {
+  // Map dimensions
+  const allNodes = Object.values(act.nodes)
+  const rowNums = [...new Set(allNodes.map(n => n.row))].sort((a, b) => a - b)
+  const maxRowCols = Math.max(1, ...allNodes.map(n => n.rowCols ?? 1))
+  const mapHeight = maxRowCols * ROW_HEIGHT
+  const mapWidth  = AVATAR_PADDING + rowNums.length * COL_WIDTH + Math.max(0, rowNums.length - 1) * CONN_W
+
+  // Editor state
+  const [toolMode,      setToolMode]      = useState<string>('select')
+  const [items,         setItems]         = useState<TerrainItemDef[]>(() => act.terrainItems ?? [])
+  const [rivers,        setRivers]        = useState<RiverDef[]>(() => act.rivers ?? [])
+  const [selectedItem,  setSelectedItem]  = useState<number | null>(null)
+  const [selectedRiver, setSelectedRiver] = useState<number | null>(null)
+  const [riverPoints,   setRiverPoints]   = useState<{ x: number; y: number }[]>([])
+
+  // Reset when act changes
+  useEffect(() => {
+    setItems(act.terrainItems ?? [])
+    setRivers(act.rivers ?? [])
+    setSelectedItem(null)
+    setSelectedRiver(null)
+    setRiverPoints([])
+    setToolMode('select')
+  }, [act.id]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Notify parent whenever editor state changes
+  useEffect(() => {
+    onUpdate(items, rivers)
+  }, [items, rivers]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // PixiJS layer refs
+  const canvasRef     = useRef<HTMLCanvasElement>(null)
+  const itemsLayerRef = useRef<PIXI.Container | null>(null)
+  const riverLayerRef = useRef<PIXI.Container | null>(null)
+  const overlayLayerRef = useRef<PIXI.Container | null>(null)
+
+  // Drag state
+  const dragRef = useRef<{
+    idx: number
+    startItemPos: { x: number; y: number }
+    startPtrPos:  { x: number; y: number }
+  } | null>(null)
+  const isDraggingRef = useRef(false)
+
+  // Always-current state accessible from PixiJS handlers
+  const stateRef = useRef({ toolMode, items, selectedItem, selectedRiver, riverPoints })
+  stateRef.current = { toolMode, items, selectedItem, selectedRiver, riverPoints }
+
+  // ── PixiJS init (once) ────────────────────────────────────────────────────────
+  usePixiApp(canvasRef, mapWidth, mapHeight, (app) => {
+    app.canvas.style.touchAction = 'pan-x pan-y'
+
+    const bgLayer      = new PIXI.Container()
+    const riverLayer   = new PIXI.Container()
+    const itemsLayer   = new PIXI.Container()
+    itemsLayer.sortableChildren = true
+    const overlayLayer = new PIXI.Container()
+
+    app.stage.addChild(bgLayer, riverLayer, itemsLayer, overlayLayer)
+    riverLayerRef.current   = riverLayer
+    itemsLayerRef.current   = itemsLayer
+    overlayLayerRef.current = overlayLayer
+
+    drawNodeBg(bgLayer, act, rowNums, maxRowCols, mapWidth, mapHeight)
+
+    // Stage hit area
+    app.stage.eventMode = 'static'
+    app.stage.hitArea = new PIXI.Rectangle(0, 0, mapWidth, mapHeight)
+
+    app.stage.on('pointerdown', (e: PIXI.FederatedPointerEvent) => {
+      const { toolMode: mode } = stateRef.current
+      if (mode === 'select') {
+        setSelectedItem(null)
+        setSelectedRiver(null)
+        return
+      }
+      const pt = { x: Math.round(e.global.x), y: Math.round(e.global.y) }
+      if (mode === 'river') {
+        setRiverPoints(prev => {
+          const next = [...prev, pt]
+          if (next.length === 4) {
+            setRivers(r => [...r, {
+              x1: next[0].x, y1: next[0].y,
+              cx1: next[1].x, cy1: next[1].y,
+              cx2: next[2].x, cy2: next[2].y,
+              x2: next[3].x, y2: next[3].y,
+            }])
+            return []
+          }
+          return next
+        })
+        return
+      }
+      // Place mode — add item
+      setItems(prev => [...prev, { kind: mode, x: pt.x, y: pt.y, scale: 1.0 }])
+    })
+
+    // Drag move
+    app.stage.on('pointermove', (e: PIXI.FederatedPointerEvent) => {
+      const drag = dragRef.current
+      if (!drag) return
+      const il = itemsLayerRef.current
+      if (!il) return
+      const dx = e.global.x - drag.startPtrPos.x
+      const dy = e.global.y - drag.startPtrPos.y
+      const c = il.children[drag.idx] as PIXI.Container | undefined
+      if (c) c.position.set(drag.startItemPos.x + dx, drag.startItemPos.y + dy)
+    })
+
+    // Drag commit
+    app.stage.on('pointerup', (e: PIXI.FederatedPointerEvent) => {
+      const drag = dragRef.current
+      if (!drag) return
+      const dx = e.global.x - drag.startPtrPos.x
+      const dy = e.global.y - drag.startPtrPos.y
+      dragRef.current = null
+      isDraggingRef.current = false
+      setItems(prev => prev.map((it, i) => i === drag.idx
+        ? { ...it, x: Math.round(drag.startItemPos.x + dx), y: Math.round(drag.startItemPos.y + dy) }
+        : it
+      ))
+    })
+
+    app.stage.on('pointerupoutside', () => {
+      if (!dragRef.current) return
+      dragRef.current = null
+      isDraggingRef.current = false
+    })
+
+    app.ticker.add(() => { itemsLayer.sortChildren() })
+  })
+
+  // ── Rebuild items layer ────────────────────────────────────────────────────────
+  useEffect(() => {
+    if (isDraggingRef.current) return
+    const il = itemsLayerRef.current
+    if (!il) return
+    il.removeChildren()
+
+    for (let i = 0; i < items.length; i++) {
+      const item = items[i]
+      const container = new PIXI.Container()
+      container.position.set(item.x, item.y)
+      container.zIndex   = item.y
+      container.eventMode = 'static'
+      container.cursor   = 'pointer'
+      container.hitArea  = new PIXI.Circle(0, 0, Math.max(20, item.scale * 28))
+
+      const g = new PIXI.Graphics()
+      drawTerrainItem(g, item.kind, item.scale, act.environment, i)
+      container.addChild(g)
+
+      if (i === selectedItem) {
+        const ring = new PIXI.Graphics()
+        ring.circle(0, 0, Math.max(22, item.scale * 28)).stroke({ color: 0x44ff44, width: 2.5, alpha: 0.9 })
+        container.addChild(ring)
+      }
+
+      const idx = i
+      container.on('pointerdown', (e: PIXI.FederatedPointerEvent) => {
+        if (stateRef.current.toolMode !== 'select') return
+        e.stopPropagation()
+        setSelectedItem(idx)
+        setSelectedRiver(null)
+        isDraggingRef.current = true
+        dragRef.current = {
+          idx,
+          startItemPos: { x: item.x, y: item.y },
+          startPtrPos:  { x: e.global.x, y: e.global.y },
+        }
+      })
+
+      il.addChild(container)
+    }
+  }, [items, selectedItem, act.environment]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // ── Rebuild river layer ────────────────────────────────────────────────────────
+  useEffect(() => {
+    const rl = riverLayerRef.current
+    const ol = overlayLayerRef.current
+    if (!rl || !ol) return
+    rl.removeChildren()
+    ol.removeChildren()
+
+    const colors = riverColors(act.environment)
+
+    for (let i = 0; i < rivers.length; i++) {
+      const g = new PIXI.Graphics()
+      drawRiverOnGfx(g, rivers[i], colors)
+
+      if (i === selectedRiver) {
+        const { x1, y1, x2, y2 } = rivers[i]
+        g.circle((x1 + x2) / 2, (y1 + y2) / 2, 10).stroke({ color: 0x44ff44, width: 2.5, alpha: 0.9 })
+      }
+
+      g.eventMode = 'static'
+      const riv = rivers[i]
+      g.hitArea = new PIXI.Rectangle(
+        Math.min(riv.x1, riv.x2) - 12, Math.min(riv.y1, riv.y2) - 12,
+        Math.abs(riv.x2 - riv.x1) + 24, Math.abs(riv.y2 - riv.y1) + 24,
+      )
+      const ri = i
+      g.on('pointerdown', (e: PIXI.FederatedPointerEvent) => {
+        if (stateRef.current.toolMode !== 'select') return
+        e.stopPropagation()
+        setSelectedRiver(ri)
+        setSelectedItem(null)
+      })
+      rl.addChild(g)
+    }
+
+    // In-progress river overlay
+    if (riverPoints.length > 0) {
+      const og = new PIXI.Graphics()
+      for (const pt of riverPoints) {
+        og.circle(pt.x, pt.y, 6).fill({ color: 0xffaa00, alpha: 0.9 })
+      }
+      for (let i = 1; i < riverPoints.length; i++) {
+        og.moveTo(riverPoints[i-1].x, riverPoints[i-1].y)
+          .lineTo(riverPoints[i].x, riverPoints[i].y)
+          .stroke({ color: 0xffaa00, width: 1.5, alpha: 0.55, cap: 'round' })
+      }
+      ol.addChild(og)
+    }
+  }, [rivers, selectedRiver, riverPoints, act.environment]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // ── Keyboard shortcuts ────────────────────────────────────────────────────────
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Delete' || e.key === 'Backspace') {
+        if (selectedItem !== null) {
+          setItems(prev => prev.filter((_, i) => i !== selectedItem))
+          setSelectedItem(null)
+        } else if (selectedRiver !== null) {
+          setRivers(prev => prev.filter((_, i) => i !== selectedRiver))
+          setSelectedRiver(null)
+        }
+      }
+      if (e.key === 'Escape') {
+        setRiverPoints([])
+        if (toolMode === 'river') setToolMode('select')
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [selectedItem, selectedRiver, toolMode])
+
+  // ── JSON output ───────────────────────────────────────────────────────────────
+  const selectedItemDef = selectedItem !== null ? items[selectedItem] ?? null : null
+
+  const jsonOutput = JSON.stringify({
+    ...(items.length  > 0 ? { terrainItems: items }  : {}),
+    ...(rivers.length > 0 ? { rivers }               : {}),
+  }, null, 2)
+
+  // ── Render ────────────────────────────────────────────────────────────────────
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+
+      {/* Mode toolbar */}
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+        <button
+          className={`action-btn${toolMode === 'select' ? ' action-btn--gold' : ''}`}
+          onClick={() => setToolMode('select')}
+        >
+          SELECT
+        </button>
+        <button
+          className={`action-btn${toolMode === 'river' ? ' action-btn--gold' : ''}`}
+          onClick={() => { setToolMode('river'); setRiverPoints([]) }}
+        >
+          RIVER{riverPoints.length > 0 ? ` (${riverPoints.length}/4)` : ''}
+        </button>
+        {TERRAIN_KINDS.map(k => (
+          <button
+            key={k}
+            className={`action-btn${toolMode === k ? ' action-btn--gold' : ''}`}
+            onClick={() => setToolMode(k)}
+          >
+            {KIND_ICONS[k]} {k.toUpperCase()}
+          </button>
+        ))}
+      </div>
+
+      {/* Instruction line */}
+      <div className="settings-sublabel" style={{ fontSize: 11 }}>
+        {toolMode === 'select'
+          ? 'Click item to select • Drag to move • Delete key or button to remove'
+          : toolMode === 'river'
+          ? `Click 4 points: start → control1 → control2 → end  (${riverPoints.length}/4)  •  ESC to cancel`
+          : `Click map to place ${toolMode}  •  switch to SELECT to move/delete`}
+      </div>
+
+      {/* Scale / delete for selected item */}
+      {selectedItemDef && (
+        <div className="settings-row u-flex u-items-c u-gap-4">
+          <div className="settings-label" style={{ minWidth: 50 }}>Scale</div>
+          <input
+            type="range" min="0.3" max="2.5" step="0.05"
+            value={selectedItemDef.scale}
+            onChange={e => {
+              const s = parseFloat(e.target.value)
+              setItems(prev => prev.map((it, i) => i === selectedItem ? { ...it, scale: s } : it))
+            }}
+            style={{ flex: 1 }}
+          />
+          <div className="settings-sublabel" style={{ minWidth: 36 }}>{selectedItemDef.scale.toFixed(2)}</div>
+          <button className="action-btn" onClick={() => { setItems(p => p.filter((_, i) => i !== selectedItem)); setSelectedItem(null) }}>
+            DELETE
+          </button>
+        </div>
+      )}
+
+      {/* Delete selected river */}
+      {selectedRiver !== null && (
+        <div className="settings-row u-flex u-items-c u-gap-4">
+          <div className="settings-label">River {selectedRiver + 1} selected</div>
+          <button className="action-btn" onClick={() => { setRivers(p => p.filter((_, i) => i !== selectedRiver)); setSelectedRiver(null) }}>
+            DELETE
+          </button>
+        </div>
+      )}
+
+      {/* Canvas */}
+      <div style={{ overflowX: 'auto' }}>
+        <canvas ref={canvasRef} style={{ display: 'block', width: mapWidth, height: mapHeight }} />
+      </div>
+
+      {/* Actions + JSON */}
+      <div className="u-flex u-gap-4 u-items-c" style={{ flexWrap: 'wrap' }}>
+        <button className="action-btn" onClick={() => { setItems([]); setRivers([]); setSelectedItem(null); setSelectedRiver(null) }}>
+          CLEAR ALL
+        </button>
+        <button
+          className="action-btn action-btn--gold"
+          onClick={() => navigator.clipboard?.writeText(jsonOutput).catch(() => undefined)}
+        >
+          COPY JSON
+        </button>
+        <div className="settings-sublabel">{items.length} item{items.length !== 1 ? 's' : ''}, {rivers.length} river{rivers.length !== 1 ? 's' : ''}</div>
+      </div>
+
+      <textarea
+        readOnly
+        value={jsonOutput || '(empty — place items to generate JSON)'}
+        style={{
+          width: '100%', height: 130,
+          background: '#0a0a0a', color: '#aaa',
+          fontSize: 11, fontFamily: 'monospace',
+          border: '1px solid rgba(255,255,255,0.15)',
+          borderRadius: 4, padding: 8, resize: 'vertical',
+        }}
+      />
+    </div>
+  )
+}

--- a/web/src/components/campaign/NodeMap.tsx
+++ b/web/src/components/campaign/NodeMap.tsx
@@ -15,6 +15,7 @@ import { ToolbarSpacer } from '../ui/Toolbar/ToolbarSpacer'
 import { ToolbarLabel } from '../ui/Toolbar/ToolbarLabel'
 import { usePixiApp } from '../../hooks/usePixiApp'
 import { loadSpriteTexture, loadAnimFrames, loadTextureUrl, makeClickable, tweenTo } from '../../utils/pixiHelpers'
+import { drawTerrainItem } from '../../utils/terrainGfx'
 
 interface Props {
   act: Act
@@ -220,121 +221,10 @@ function buildTerrainGfx(
   const terrainItems = items.filter(i => i.kind !== 'river')
   for (let i = 0; i < terrainItems.length; i++) {
     const { x, y, scale, kind } = terrainItems[i]
-    const k = `${kind}-${i}`
     const g = new PIXI.Graphics()
     g.position.set(x, y)
-
-    switch (kind) {
-      case 'mountain': {
-        const w = scale * 44, h = scale * 32
-        const col = environment === 'frost' ? 0x8ab8cc : environment === 'volcano' ? 0x6a3020 : environment === 'sand' ? 0xa08040 : 0x5a6050
-        g.ellipse(w * 0.5, 3, w * 0.5, 5).fill({ color: 0x000000, alpha: 0.30 })
-        g.poly([0,0, w*0.45,-h, w,0]).fill({ color: col, alpha: 0.82 })
-        g.poly([w*0.3,0, w*0.72,-h*0.75, w*1.1,0]).fill({ color: col, alpha: 0.82 })
-        g.poly([w*0.45,-h, w*0.15,-h*0.4, w*0.45,-h*0.05]).fill({ color: 0xffffff, alpha: 0.12 })
-        if (environment === 'frost')
-          g.poly([w*0.2,-h*0.55, w*0.45,-h, w*0.7,-h*0.55]).fill({ color: 0xffffff, alpha: 0.50 })
-        g.zIndex = y
-        break
-      }
-      case 'tree': {
-        const h = scale * 28, tw = scale * 14
-        const col = environment === 'farmland' ? 0x4a7a28 : environment === 'ruins' ? 0x3a6028 : 0x2a7020
-        g.ellipse(0, 2, tw * 0.8, 4).fill({ color: 0x000000, alpha: 0.28 })
-        g.rect(-scale*2, -scale*8, scale*4, scale*9).fill({ color: 0x6b4226, alpha: 0.85 })
-        g.poly([0,-h, -tw,-scale*6, tw,-scale*6]).fill({ color: col, alpha: 0.82 })
-        g.poly([0,-h*0.62, -tw*1.1,-scale*2, tw*1.1,-scale*2]).fill({ color: col, alpha: 0.82 })
-        g.poly([0,-h, -tw,-scale*6, tw,-scale*6]).stroke({ color: 0x1a4012, width: 1, alpha: 0.50 })
-        g.poly([0,-h*0.62, -tw*1.1,-scale*2, tw*1.1,-scale*2]).stroke({ color: 0x1a4012, width: 1, alpha: 0.50 })
-        g.zIndex = y
-        break
-      }
-      case 'deadtree': {
-        const h = scale * 28
-        g.ellipse(0, 2, scale * 5, 3).fill({ color: 0x000000, alpha: 0.25 })
-        g.moveTo(0,0).lineTo(0,-h).stroke({ color: 0x5a4030, width: scale*3, alpha: 0.82, cap: 'round' })
-        g.moveTo(0,-h*0.6).lineTo(-scale*12,-h*0.85).stroke({ color: 0x5a4030, width: scale*2, alpha: 0.82, cap: 'round' })
-        g.moveTo(0,-h*0.5).lineTo(scale*10,-h*0.72).stroke({ color: 0x5a4030, width: scale*1.5, alpha: 0.82, cap: 'round' })
-        g.zIndex = y
-        break
-      }
-      case 'crystal': {
-        const h = scale * 26
-        g.ellipse(0, 3, scale * 7, 4).fill({ color: 0x000000, alpha: 0.25 })
-        g.poly([0,-h, -scale*5,0, scale*5,0]).fill({ color: 0x88ddff, alpha: 0.85 })
-        g.poly([0,-h*0.7, -scale*7,h*0.3, scale*7,h*0.3]).fill({ color: 0xaaeeff, alpha: 0.85 })
-        g.moveTo(0,-h).lineTo(0,h*0.3).stroke({ color: 0xffffff, width: scale*1.5, alpha: 0.55 })
-        g.zIndex = y
-        break
-      }
-      case 'mushroom': {
-        const h = scale * 22, rw = scale * 12
-        g.ellipse(0, 3, rw * 0.7, 4).fill({ color: 0x000000, alpha: 0.25 })
-        g.rect(-scale*2.5,-h, scale*5, h).fill({ color: 0x8a7060, alpha: 0.80 })
-        g.ellipse(0,-h, rw, scale*8).fill({ color: 0x9a40ee, alpha: 0.82 })
-        g.ellipse(-scale*3,-h-scale*2, scale*4, scale*3).fill({ color: 0xffffff, alpha: 0.35 })
-        g.zIndex = y
-        break
-      }
-      case 'lava': {
-        g.ellipse(0, 2, scale * 22, 6).fill({ color: 0x000000, alpha: 0.28 })
-        g.ellipse(0,0, scale*20, scale*10).fill({ color: 0xcc3300, alpha: 0.82 })
-        g.ellipse(0,0, scale*12, scale*6).fill({ color: 0xff6600, alpha: 0.82 })
-        g.ellipse(scale*4,-scale*2, scale*5, scale*3).fill({ color: 0xffaa00, alpha: 0.75 })
-        g.zIndex = y
-        break
-      }
-      case 'wave': {
-        const ww = scale * 50
-        g.moveTo(0,0).quadraticCurveTo(ww*0.25,-scale*9, ww*0.5,0).quadraticCurveTo(ww*0.75,scale*9, ww,0)
-          .stroke({ color: 0x4499cc, width: scale*4, alpha: 0.78, cap: 'round' })
-        g.moveTo(scale*5,scale*7).quadraticCurveTo(ww*0.3,-scale*5, ww*0.6,scale*7)
-          .stroke({ color: 0x88ccee, width: scale*2.5, alpha: 0.65, cap: 'round' })
-        g.moveTo(scale*2,scale*3).quadraticCurveTo(ww*0.25,-scale*4, ww*0.5,scale*3)
-          .stroke({ color: 0xffffff, width: scale*1.5, alpha: 0.45, cap: 'round' })
-        g.zIndex = y
-        break
-      }
-      case 'cloud': {
-        g.ellipse(0,0, scale*22, scale*13).fill({ color: 0xf0f8ff, alpha: 0.78 })
-        g.ellipse(scale*14,scale*4, scale*18, scale*11).fill({ color: 0xe8f4ff, alpha: 0.78 })
-        g.ellipse(-scale*12,scale*5, scale*16, scale*10).fill({ color: 0xf0f8ff, alpha: 0.78 })
-        g.ellipse(scale*2,-scale*5, scale*14, scale*9).fill({ color: 0xffffff, alpha: 0.85 })
-        g.zIndex = y
-        break
-      }
-      case 'tower': {
-        const h = scale * 30, tw = scale * 10
-        g.ellipse(0, 3, tw * 0.7, 4).fill({ color: 0x000000, alpha: 0.28 })
-        g.rect(-tw/2,-h, tw, h).fill({ color: 0x6a6a7a, alpha: 0.82 })
-        g.rect(-tw/2,-h, tw, h).stroke({ color: 0x3a3a4a, width: 1, alpha: 0.60 })
-        g.rect(-tw/2-scale*2,-h, tw+scale*4, scale*5).fill({ color: 0x8a8a9a, alpha: 0.82 })
-        g.rect(-scale*2,-h-scale*6, scale*4, scale*6).fill({ color: 0x6a6a7a, alpha: 0.82 })
-        g.rect(-tw/2-scale*2,-h-scale*6, tw+scale*4, scale*3).fill({ color: 0x7a7a8a, alpha: 0.82 })
-        g.zIndex = y
-        break
-      }
-      case 'pillar': {
-        const h = scale * (16 + hashStr(`${k}${x}`) % 18), pw = scale * 7
-        g.ellipse(0, 3, pw * 0.7, 4).fill({ color: 0x000000, alpha: 0.25 })
-        g.rect(-pw/2,-h, pw, h).fill({ color: 0x888888, alpha: 0.80 })
-        g.rect(-pw/2,-h, pw, h).stroke({ color: 0x444444, width: 1, alpha: 0.55 })
-        g.rect(-pw/2-scale*2,-h, pw+scale*4, scale*4).fill({ color: 0xaaaaaa, alpha: 0.80 })
-        g.rect(-pw/2-scale*2,-scale*4, pw+scale*4, scale*4).fill({ color: 0xaaaaaa, alpha: 0.80 })
-        g.zIndex = y
-        break
-      }
-      case 'dune': {
-        const dw = scale * 55
-        g.ellipse(0, 4, dw * 0.45, 6).fill({ color: 0x000000, alpha: 0.22 })
-        g.ellipse(0,0, dw*0.5, scale*10).fill({ color: 0xc8a040, alpha: 0.80 })
-        g.ellipse(dw*0.35,scale*4, dw*0.35, scale*8).fill({ color: 0xb89030, alpha: 0.80 })
-        g.moveTo(-dw*0.3,-scale*7).quadraticCurveTo(0,-scale*11, dw*0.25,-scale*6)
-          .stroke({ color: 0xffe090, width: scale*2, alpha: 0.50, cap: 'round' })
-        g.zIndex = y
-        break
-      }
-    }
+    drawTerrainItem(g, kind, scale, environment, hashStr(`${kind}-${i}${x}`) % 18)
+    g.zIndex = y
     worldLayer.addChild(g)
   }
 }

--- a/web/src/components/campaign/NodeMap.tsx
+++ b/web/src/components/campaign/NodeMap.tsx
@@ -174,12 +174,13 @@ function getTerrainItems(env: string | undefined, seed: number, w: number, h: nu
 function buildTerrainGfx(
   groundLayer: PIXI.Container,
   worldLayer: PIXI.Container,
-  environment: string | undefined,
-  actId: string,
+  act: Act,
   mapWidth: number,
   mapHeight: number,
 ): void {
-  const items = getTerrainItems(environment, hashStr(actId), mapWidth, mapHeight)
+  const { environment, terrainSeed, terrainItems: explicitItems, rivers: explicitRivers } = act
+  const seed = terrainSeed ?? hashStr(act.id)
+  const items = explicitItems ?? getTerrainItems(environment, seed, mapWidth, mapHeight)
 
   const riverColor = environment === 'volcano' ? 0xcc4400
                    : environment === 'fungal'  ? 0x6633aa
@@ -189,16 +190,21 @@ function buildTerrainGfx(
   const riverDark  = (Math.round(rc * 0.55) << 16) | (Math.round(gc * 0.55) << 8) | Math.round(bc * 0.55)
   const riverLight = (Math.min(255, Math.round(rc * 1.45)) << 16) | (Math.min(255, Math.round(gc * 1.45)) << 8) | Math.min(255, Math.round(bc * 1.45))
 
-  const rseed = hashStr(actId + 'river')
-  const rr = seededRand(rseed)
-  const rrf = (lo: number, hi: number) => lo + rr() * (hi - lo)
+  // Explicit rivers override the random scatter; fall back to seeded random
+  const riversToDraw: Array<{ x1: number; y1: number; x2: number; y2: number; cx1: number; cy1: number; cx2: number; cy2: number }> =
+    explicitRivers ?? (() => {
+      const rseed = hashStr(act.id + 'river')
+      const rr = seededRand(rseed)
+      const rrf = (lo: number, hi: number) => lo + rr() * (hi - lo)
+      return items.filter(i => i.kind === 'river').map(() => ({
+        x1: rrf(0, mapWidth * 0.25),   y1: rrf(0, mapHeight),
+        x2: rrf(mapWidth * 0.75, mapWidth), y2: rrf(0, mapHeight),
+        cx1: rrf(mapWidth * 0.2, mapWidth * 0.5), cy1: rrf(0, mapHeight),
+        cx2: rrf(mapWidth * 0.5, mapWidth * 0.8), cy2: rrf(0, mapHeight),
+      }))
+    })()
 
-  for (const it of items.filter(i => i.kind === 'river')) {
-    void it
-    const x1 = rrf(0, mapWidth * 0.25), y1 = rrf(0, mapHeight)
-    const x2 = rrf(mapWidth * 0.75, mapWidth), y2 = rrf(0, mapHeight)
-    const cx1 = rrf(mapWidth * 0.2, mapWidth * 0.5), cy1 = rrf(0, mapHeight)
-    const cx2 = rrf(mapWidth * 0.5, mapWidth * 0.8), cy2 = rrf(0, mapHeight)
+  for (const { x1, y1, x2, y2, cx1, cy1, cx2, cy2 } of riversToDraw) {
     const g = new PIXI.Graphics()
     g.moveTo(x1, y1).bezierCurveTo(cx1, cy1, cx2, cy2, x2, y2)
       .stroke({ color: riverDark, width: 20, alpha: 0.65, cap: 'round' })
@@ -798,7 +804,7 @@ export function NodeMap({ act, run, onSelectNode, onUseConsumable, onBack }: Pro
     worldRef.current  = worldLayer
 
     // Terrain
-    buildTerrainGfx(groundLayer, worldLayer, act.environment, act.id, mapWidth, mapHeight)
+    buildTerrainGfx(groundLayer, worldLayer, act, mapWidth, mapHeight)
 
     // Campfire at start position
     try {

--- a/web/src/game/questline.ts
+++ b/web/src/game/questline.ts
@@ -309,6 +309,30 @@ export interface Act {
    * All modifiers up to the current replay index stack additively.
    */
   replayModifiers?: ReplayModifier[]
+
+  /**
+   * Override the random seed used for terrain scatter on this act's node map.
+   * Useful for tuning layouts without pinning exact positions.
+   * If omitted, the seed is derived from the act id.
+   */
+  terrainSeed?: number
+
+  /**
+   * Explicit terrain item placements. When present, replaces the random scatter
+   * for this act entirely. Each item needs x/y (pixels, relative to map size),
+   * scale (1 = default), and kind (mountain | tree | deadtree | crystal |
+   * mushroom | lava | wave | cloud | tower | pillar | dune).
+   * A kind of "river" here is ignored — use the `rivers` field instead.
+   */
+  terrainItems?: Array<{ kind: string; x: number; y: number; scale: number }>
+
+  /**
+   * Explicit river paths. When present, these bezier curves are drawn instead
+   * of the auto-generated river. Each entry specifies the start point (x1,y1),
+   * end point (x2,y2), and two bezier control points (cx1,cy1) and (cx2,cy2).
+   * All values are pixel coordinates relative to the map canvas size.
+   */
+  rivers?: Array<{ x1: number; y1: number; x2: number; y2: number; cx1: number; cy1: number; cx2: number; cy2: number }>
 }
 
 // ─── Run counter ──────────────────────────────────────────

--- a/web/src/utils/terrainGfx.ts
+++ b/web/src/utils/terrainGfx.ts
@@ -1,0 +1,117 @@
+import * as PIXI from 'pixi.js'
+
+/**
+ * Draws a single terrain item shape onto `g` centred at (0, 0).
+ * The caller is responsible for positioning `g` and setting `zIndex`.
+ *
+ * @param pillarVariant  0–17 integer used to vary pillar height; callers
+ *   should derive this from a hash of the item's position/index.
+ */
+export function drawTerrainItem(
+  g: PIXI.Graphics,
+  kind: string,
+  scale: number,
+  environment: string | undefined,
+  pillarVariant = 0,
+): void {
+  switch (kind) {
+    case 'mountain': {
+      const w = scale * 44, h = scale * 32
+      const col = environment === 'frost' ? 0x8ab8cc : environment === 'volcano' ? 0x6a3020 : environment === 'sand' ? 0xa08040 : 0x5a6050
+      g.ellipse(w * 0.5, 3, w * 0.5, 5).fill({ color: 0x000000, alpha: 0.30 })
+      g.poly([0,0, w*0.45,-h, w,0]).fill({ color: col, alpha: 0.82 })
+      g.poly([w*0.3,0, w*0.72,-h*0.75, w*1.1,0]).fill({ color: col, alpha: 0.82 })
+      g.poly([w*0.45,-h, w*0.15,-h*0.4, w*0.45,-h*0.05]).fill({ color: 0xffffff, alpha: 0.12 })
+      if (environment === 'frost')
+        g.poly([w*0.2,-h*0.55, w*0.45,-h, w*0.7,-h*0.55]).fill({ color: 0xffffff, alpha: 0.50 })
+      break
+    }
+    case 'tree': {
+      const h = scale * 28, tw = scale * 14
+      const col = environment === 'farmland' ? 0x4a7a28 : environment === 'ruins' ? 0x3a6028 : 0x2a7020
+      g.ellipse(0, 2, tw * 0.8, 4).fill({ color: 0x000000, alpha: 0.28 })
+      g.rect(-scale*2, -scale*8, scale*4, scale*9).fill({ color: 0x6b4226, alpha: 0.85 })
+      g.poly([0,-h, -tw,-scale*6, tw,-scale*6]).fill({ color: col, alpha: 0.82 })
+      g.poly([0,-h*0.62, -tw*1.1,-scale*2, tw*1.1,-scale*2]).fill({ color: col, alpha: 0.82 })
+      g.poly([0,-h, -tw,-scale*6, tw,-scale*6]).stroke({ color: 0x1a4012, width: 1, alpha: 0.50 })
+      g.poly([0,-h*0.62, -tw*1.1,-scale*2, tw*1.1,-scale*2]).stroke({ color: 0x1a4012, width: 1, alpha: 0.50 })
+      break
+    }
+    case 'deadtree': {
+      const h = scale * 28
+      g.ellipse(0, 2, scale * 5, 3).fill({ color: 0x000000, alpha: 0.25 })
+      g.moveTo(0,0).lineTo(0,-h).stroke({ color: 0x5a4030, width: scale*3, alpha: 0.82, cap: 'round' })
+      g.moveTo(0,-h*0.6).lineTo(-scale*12,-h*0.85).stroke({ color: 0x5a4030, width: scale*2, alpha: 0.82, cap: 'round' })
+      g.moveTo(0,-h*0.5).lineTo(scale*10,-h*0.72).stroke({ color: 0x5a4030, width: scale*1.5, alpha: 0.82, cap: 'round' })
+      break
+    }
+    case 'crystal': {
+      const h = scale * 26
+      g.ellipse(0, 3, scale * 7, 4).fill({ color: 0x000000, alpha: 0.25 })
+      g.poly([0,-h, -scale*5,0, scale*5,0]).fill({ color: 0x88ddff, alpha: 0.85 })
+      g.poly([0,-h*0.7, -scale*7,h*0.3, scale*7,h*0.3]).fill({ color: 0xaaeeff, alpha: 0.85 })
+      g.moveTo(0,-h).lineTo(0,h*0.3).stroke({ color: 0xffffff, width: scale*1.5, alpha: 0.55 })
+      break
+    }
+    case 'mushroom': {
+      const h = scale * 22, rw = scale * 12
+      g.ellipse(0, 3, rw * 0.7, 4).fill({ color: 0x000000, alpha: 0.25 })
+      g.rect(-scale*2.5,-h, scale*5, h).fill({ color: 0x8a7060, alpha: 0.80 })
+      g.ellipse(0,-h, rw, scale*8).fill({ color: 0x9a40ee, alpha: 0.82 })
+      g.ellipse(-scale*3,-h-scale*2, scale*4, scale*3).fill({ color: 0xffffff, alpha: 0.35 })
+      break
+    }
+    case 'lava': {
+      g.ellipse(0, 2, scale * 22, 6).fill({ color: 0x000000, alpha: 0.28 })
+      g.ellipse(0,0, scale*20, scale*10).fill({ color: 0xcc3300, alpha: 0.82 })
+      g.ellipse(0,0, scale*12, scale*6).fill({ color: 0xff6600, alpha: 0.82 })
+      g.ellipse(scale*4,-scale*2, scale*5, scale*3).fill({ color: 0xffaa00, alpha: 0.75 })
+      break
+    }
+    case 'wave': {
+      const ww = scale * 50
+      g.moveTo(0,0).quadraticCurveTo(ww*0.25,-scale*9, ww*0.5,0).quadraticCurveTo(ww*0.75,scale*9, ww,0)
+        .stroke({ color: 0x4499cc, width: scale*4, alpha: 0.78, cap: 'round' })
+      g.moveTo(scale*5,scale*7).quadraticCurveTo(ww*0.3,-scale*5, ww*0.6,scale*7)
+        .stroke({ color: 0x88ccee, width: scale*2.5, alpha: 0.65, cap: 'round' })
+      g.moveTo(scale*2,scale*3).quadraticCurveTo(ww*0.25,-scale*4, ww*0.5,scale*3)
+        .stroke({ color: 0xffffff, width: scale*1.5, alpha: 0.45, cap: 'round' })
+      break
+    }
+    case 'cloud': {
+      g.ellipse(0,0, scale*22, scale*13).fill({ color: 0xf0f8ff, alpha: 0.78 })
+      g.ellipse(scale*14,scale*4, scale*18, scale*11).fill({ color: 0xe8f4ff, alpha: 0.78 })
+      g.ellipse(-scale*12,scale*5, scale*16, scale*10).fill({ color: 0xf0f8ff, alpha: 0.78 })
+      g.ellipse(scale*2,-scale*5, scale*14, scale*9).fill({ color: 0xffffff, alpha: 0.85 })
+      break
+    }
+    case 'tower': {
+      const h = scale * 30, tw = scale * 10
+      g.ellipse(0, 3, tw * 0.7, 4).fill({ color: 0x000000, alpha: 0.28 })
+      g.rect(-tw/2,-h, tw, h).fill({ color: 0x6a6a7a, alpha: 0.82 })
+      g.rect(-tw/2,-h, tw, h).stroke({ color: 0x3a3a4a, width: 1, alpha: 0.60 })
+      g.rect(-tw/2-scale*2,-h, tw+scale*4, scale*5).fill({ color: 0x8a8a9a, alpha: 0.82 })
+      g.rect(-scale*2,-h-scale*6, scale*4, scale*6).fill({ color: 0x6a6a7a, alpha: 0.82 })
+      g.rect(-tw/2-scale*2,-h-scale*6, tw+scale*4, scale*3).fill({ color: 0x7a7a8a, alpha: 0.82 })
+      break
+    }
+    case 'pillar': {
+      const h = scale * (16 + (pillarVariant % 18)), pw = scale * 7
+      g.ellipse(0, 3, pw * 0.7, 4).fill({ color: 0x000000, alpha: 0.25 })
+      g.rect(-pw/2,-h, pw, h).fill({ color: 0x888888, alpha: 0.80 })
+      g.rect(-pw/2,-h, pw, h).stroke({ color: 0x444444, width: 1, alpha: 0.55 })
+      g.rect(-pw/2-scale*2,-h, pw+scale*4, scale*4).fill({ color: 0xaaaaaa, alpha: 0.80 })
+      g.rect(-pw/2-scale*2,-scale*4, pw+scale*4, scale*4).fill({ color: 0xaaaaaa, alpha: 0.80 })
+      break
+    }
+    case 'dune': {
+      const dw = scale * 55
+      g.ellipse(0, 4, dw * 0.45, 6).fill({ color: 0x000000, alpha: 0.22 })
+      g.ellipse(0,0, dw*0.5, scale*10).fill({ color: 0xc8a040, alpha: 0.80 })
+      g.ellipse(dw*0.35,scale*4, dw*0.35, scale*8).fill({ color: 0xb89030, alpha: 0.80 })
+      g.moveTo(-dw*0.3,-scale*7).quadraticCurveTo(0,-scale*11, dw*0.25,-scale*6)
+        .stroke({ color: 0xffe090, width: scale*2, alpha: 0.50, cap: 'round' })
+      break
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds three optional fields to the `Act` type that give per-act control over node map terrain placement, without touching any act that doesn't opt in.

- **`terrainSeed?: number`** — override the seed used for random terrain scatter. Try different integers until the layout looks right. Acts without this field continue using `hashStr(actId)` as before.
- **`terrainItems?: [{kind, x, y, scale}]`** — explicit list of terrain objects. When present, fully replaces the random scatter for that act. Supports all terrain kinds: `mountain`, `tree`, `deadtree`, `crystal`, `mushroom`, `lava`, `wave`, `cloud`, `tower`, `pillar`, `dune`.
- **`rivers?: [{x1,y1,x2,y2,cx1,cy1,cx2,cy2}]`** — explicit bezier river paths. When present, replaces the auto-generated river. All coordinates are pixels relative to the map canvas size.

### Example usage in an act JSON

```json
"terrainSeed": 42,
"terrainItems": [
  { "kind": "tree",     "x": 120, "y":  80, "scale": 1.2 },
  { "kind": "mountain", "x": 300, "y": 200, "scale": 1.0 }
],
"rivers": [
  { "x1": 0, "y1": 150, "x2": 600, "y2": 300,
    "cx1": 150, "cy1": 100, "cx2": 450, "cy2": 350 }
]
```

All three fields are independent — you can use just `terrainSeed`, or pin only items while leaving rivers random, etc.

## Test plan

- [ ] `npm run build` — no TypeScript errors
- [ ] Act without any new fields: terrain renders as before (no regression)
- [ ] Act with `terrainSeed`: terrain layout changes to match the seed
- [ ] Act with `terrainItems`: only those items appear, random scatter suppressed
- [ ] Act with `rivers`: exact bezier paths drawn, auto-river suppressed

https://claude.ai/code/session_0178FWDGT2AnsK7r6hmFJU1R

---
_Generated by [Claude Code](https://claude.ai/code/session_0178FWDGT2AnsK7r6hmFJU1R)_