### PR TITLE
NodeMap visual polish: colour match, seam fix, node border, avatar layer, tombstone, animated icons

### DIFF
--- a/web/public/sprites/campfire-1.svg
+++ b/web/public/sprites/campfire-1.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect x="6" y="23" width="14" height="4" rx="2" transform="rotate(-20,13,25)" fill="#6b3a1f"/>
+  <rect x="12" y="23" width="14" height="4" rx="2" transform="rotate(20,19,25)" fill="#7a4422"/>
+  <ellipse cx="16" cy="26" rx="7" ry="3" fill="#ff6600" opacity="0.35"/>
+  <polygon points="16,10 9,26 23,26" fill="#ff6600" opacity="0.85"/>
+  <polygon points="16,13 11,26 21,26" fill="#ff9900"/>
+  <polygon points="16,16 13,26 19,26" fill="#ffcc00"/>
+  <polygon points="16,11 14.5,18 17.5,18" fill="#fff8c0" opacity="0.8"/>
+  <polygon points="11,19 8,26 14,25" fill="#ff4400" opacity="0.55"/>
+  <polygon points="21,19 18,25 24,26" fill="#ff4400" opacity="0.55"/>
+</svg>

--- a/web/public/sprites/campfire-2.svg
+++ b/web/public/sprites/campfire-2.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect x="6" y="23" width="14" height="4" rx="2" transform="rotate(-20,13,25)" fill="#6b3a1f"/>
+  <rect x="12" y="23" width="14" height="4" rx="2" transform="rotate(20,19,25)" fill="#7a4422"/>
+  <ellipse cx="16" cy="26" rx="8" ry="3" fill="#ff6600" opacity="0.45"/>
+  <polygon points="16,7 8,26 24,26" fill="#ff6600" opacity="0.90"/>
+  <polygon points="16,11 10,26 22,26" fill="#ff9900"/>
+  <polygon points="16,14 13,26 19,26" fill="#ffdd00"/>
+  <polygon points="16,8 14,16 18,16" fill="#fff8c0" opacity="0.9"/>
+  <polygon points="10,17 7,26 13,25" fill="#ff4400" opacity="0.65"/>
+  <polygon points="22,17 19,25 25,26" fill="#ff4400" opacity="0.65"/>
+</svg>

--- a/web/public/sprites/campfire-3.svg
+++ b/web/public/sprites/campfire-3.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect x="6" y="23" width="14" height="4" rx="2" transform="rotate(-20,13,25)" fill="#6b3a1f"/>
+  <rect x="12" y="23" width="14" height="4" rx="2" transform="rotate(20,19,25)" fill="#7a4422"/>
+  <ellipse cx="15" cy="26" rx="7" ry="3" fill="#ff6600" opacity="0.38"/>
+  <polygon points="14,10 7,26 21,26" fill="#ff6600" opacity="0.85"/>
+  <polygon points="14,13 9,26 19,26" fill="#ff9900"/>
+  <polygon points="15,16 12,26 18,26" fill="#ffcc00"/>
+  <polygon points="14,11 12.5,18 15.5,18" fill="#fff8c0" opacity="0.8"/>
+  <polygon points="9,18 6,26 12,25" fill="#ff4400" opacity="0.70"/>
+  <polygon points="20,20 17,25 23,26" fill="#ff4400" opacity="0.45"/>
+</svg>

--- a/web/public/sprites/event-1.svg
+++ b/web/public/sprites/event-1.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect x="7" y="6" width="18" height="22" rx="2" fill="#e8d59a"/>
+  <ellipse cx="16" cy="6" rx="9" ry="3" fill="#d4b870"/>
+  <ellipse cx="16" cy="6" rx="7" ry="2" fill="#e8d59a"/>
+  <ellipse cx="16" cy="28" rx="9" ry="3" fill="#d4b870"/>
+  <ellipse cx="16" cy="28" rx="7" ry="2" fill="#e8d59a"/>
+  <path d="M13,11 Q13,9 16,9 Q19,9 19,12 Q19,14 16,15 L16,18" fill="none" stroke="#6a3a10" stroke-width="2" stroke-linecap="round"/>
+  <circle cx="16" cy="21" r="1.3" fill="#6a3a10"/>
+  <line x1="10" y1="24" x2="22" y2="24" stroke="#c4a050" stroke-width="0.8" opacity="0.6"/>
+  <line x1="10" y1="26" x2="18" y2="26" stroke="#c4a050" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="22" cy="8" r="2.5" fill="#cc2222" opacity="0.7"/>
+  <circle cx="22" cy="8" r="1.5" fill="#ee4444" opacity="0.6"/>
+</svg>

--- a/web/public/sprites/event-2.svg
+++ b/web/public/sprites/event-2.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect x="7" y="6" width="18" height="22" rx="2" fill="#eedfa8"/>
+  <ellipse cx="16" cy="6" rx="9" ry="3" fill="#d4b870"/>
+  <ellipse cx="16" cy="6" rx="7" ry="2" fill="#eedfa8"/>
+  <ellipse cx="16" cy="28" rx="9" ry="3" fill="#d4b870"/>
+  <ellipse cx="16" cy="28" rx="7" ry="2" fill="#eedfa8"/>
+  <path d="M13,11 Q13,9 16,9 Q19,9 19,12 Q19,14 16,15 L16,18" fill="none" stroke="#4a2a08" stroke-width="2" stroke-linecap="round"/>
+  <circle cx="16" cy="21" r="1.3" fill="#4a2a08"/>
+  <line x1="10" y1="24" x2="22" y2="24" stroke="#c4a050" stroke-width="0.8" opacity="0.7"/>
+  <line x1="10" y1="26" x2="18" y2="26" stroke="#c4a050" stroke-width="0.8" opacity="0.5"/>
+  <circle cx="22" cy="8" r="3" fill="#dd1111" opacity="1.0"/>
+  <circle cx="22" cy="8" r="1.8" fill="#ff5555" opacity="0.9"/>
+</svg>

--- a/web/public/sprites/event-3.svg
+++ b/web/public/sprites/event-3.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect x="7" y="6" width="18" height="22" rx="2" fill="#f0e0aa"/>
+  <ellipse cx="16" cy="6" rx="9" ry="3" fill="#d8c078"/>
+  <ellipse cx="16" cy="6" rx="7" ry="2" fill="#f0e0aa"/>
+  <ellipse cx="16" cy="28" rx="9" ry="3" fill="#d8c078"/>
+  <ellipse cx="16" cy="28" rx="7" ry="2" fill="#f0e0aa"/>
+  <path d="M13,11 Q13,9 16,9 Q19,9 19,12 Q19,14 16,15 L16,18" fill="none" stroke="#6a3a10" stroke-width="2" stroke-linecap="round"/>
+  <circle cx="16" cy="21" r="1.3" fill="#6a3a10"/>
+  <line x1="10" y1="24" x2="22" y2="24" stroke="#c4a050" stroke-width="0.8" opacity="0.6"/>
+  <line x1="10" y1="26" x2="18" y2="26" stroke="#c4a050" stroke-width="0.8" opacity="0.4"/>
+  <circle cx="22" cy="8" r="2" fill="#aa1818" opacity="0.5"/>
+  <circle cx="22" cy="8" r="1.2" fill="#cc3333" opacity="0.4"/>
+</svg>

--- a/web/public/sprites/tombstone.svg
+++ b/web/public/sprites/tombstone.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- base slab -->
+  <rect x="8" y="26" width="16" height="3" rx="1" fill="#666677"/>
+  <!-- stone body -->
+  <rect x="11" y="10" width="10" height="17" fill="#555566"/>
+  <!-- arched top -->
+  <path d="M11,16 Q11,6 16,6 Q21,6 21,16" fill="#555566"/>
+  <!-- cross -->
+  <line x1="16" y1="13" x2="16" y2="23" stroke="#444455" stroke-width="1.2"/>
+  <line x1="13" y1="17" x2="19" y2="17" stroke="#444455" stroke-width="1.2"/>
+  <!-- stone highlight -->
+  <path d="M12,16 Q12,7 16,7 Q19,7 19.5,11" fill="none" stroke="#8888aa" stroke-width="0.8" opacity="0.5"/>
+</svg>

--- a/web/src/components/campaign/NodeMap.tsx
+++ b/web/src/components/campaign/NodeMap.tsx
@@ -362,17 +362,21 @@ function drawConnectorsGfx(
           .stroke({ color: 0xffffff, width: 1, alpha: 0.04 })
       } else if (variant === 'future') {
         const pts = [
-          { x: parentCenterX, y: y1 },
+          { x: parentCenterX,                y: y1 },
+          { x: (parentCenterX + xStart) / 2, y: y1 },
           ...sampleBezier(xStart, y1, xMid, y1, xMid, y2, xEnd, y2),
-          { x: childCenterX,  y: y2 },
+          { x: (xEnd + childCenterX) / 2,    y: y2 },
+          { x: childCenterX,                 y: y2 },
         ]
         gfx.poly(bezierBand(pts, 5)).fill({ color: 0x000000, alpha: 0.25 })
         gfx.poly(bezierBand(pts, 3)).fill({ color: trail.color, alpha: trail.alpha * 0.35 })
       } else {
         const pts = [
-          { x: parentCenterX, y: y1 },
+          { x: parentCenterX,                y: y1 },
+          { x: (parentCenterX + xStart) / 2, y: y1 },
           ...sampleBezier(xStart, y1, xMid, y1, xMid, y2, xEnd, y2),
-          { x: childCenterX,  y: y2 },
+          { x: (xEnd + childCenterX) / 2,    y: y2 },
+          { x: childCenterX,                 y: y2 },
         ]
         const isFront = variant === 'frontier'
         const halfOuter = isFront ? 9 : 7
@@ -405,11 +409,12 @@ function markerAlpha(status: NodeStatus, inReachable: boolean): number {
   return 0.4
 }
 
-function nodeRoadColor(status: NodeStatus, environment: string | undefined): number {
+function nodeRoadFill(status: NodeStatus, environment: string | undefined): { color: number; alpha: number } {
   const { trail, frontier } = envColors(environment)
-  if (status === 'completed' || status === 'pending') return parseRgba(trail).color
-  if (status === 'available')                         return parseRgba(frontier).color
-  return 0x2a2a2a
+  const t = parseRgba(trail), f = parseRgba(frontier)
+  if (status === 'completed' || status === 'pending') return { color: t.color, alpha: Math.min(t.alpha, 0.85) }
+  if (status === 'available')                         return { color: f.color, alpha: Math.min(f.alpha, 0.85) }
+  return { color: 0x2a2a2a, alpha: 0.5 }
 }
 
 async function loadNodeIcon(node: QuestNode): Promise<PIXI.Texture | null> {
@@ -433,10 +438,12 @@ async function buildNodeMarker(
 ): Promise<PIXI.Container> {
   const container = new PIXI.Container()
 
-  // bg: always fully opaque, road-colored, no outline — hides road end beneath node
+  // bg: two-layer ellipse matching road cross-section (dark outer + coloured inner)
   const bg = new PIXI.Graphics()
   const ry = NODE_RADIUS / 2
-  bg.ellipse(0, 0, NODE_RADIUS, ry).fill({ color: nodeRoadColor(status, environment), alpha: 1.0 })
+  const fill = nodeRoadFill(status, environment)
+  bg.ellipse(0, 0, NODE_RADIUS + 2, ry + 2).fill({ color: 0x000000, alpha: 0.55 })
+  bg.ellipse(0, 0, NODE_RADIUS, ry).fill({ color: fill.color, alpha: fill.alpha })
   container.addChild(bg)
 
   // iconLayer: icons + labels, dimmed by status independently of the bg
@@ -445,10 +452,12 @@ async function buildNodeMarker(
 
   // Battle/elite nodes show the first enemy unit as icon.
   // Mobile units get animated frames + sine-wave wander; buildings are static.
+  const isBattleType = node.type === 'battle' || node.type === 'elite' || node.type === 'boss'
   const isBattleNode = node.type === 'battle' || node.type === 'elite'
   const unitName = isBattleNode && node.enemyDeck?.length ? node.enemyDeck[0] : null
   const isBuilding = unitName ? (getCardUnit(unitName)?.moveSpeed ?? 1) === 0 : false
   const shouldWander = !!unitName && !isBuilding
+  const base = (import.meta as { env: { BASE_URL: string } }).env.BASE_URL
 
   let iconAdded = false
 
@@ -496,6 +505,36 @@ async function buildNodeMarker(
     }
   }
 
+  if (isBattleType && status === 'completed' && !iconAdded) {
+    try {
+      const tomb = new PIXI.Sprite(await loadTextureUrl(`${base}sprites/tombstone.svg`))
+      tomb.width = tomb.height = NODE_RADIUS * 1.1
+      tomb.anchor.set(0.5)
+      iconLayer.addChild(tomb)
+      iconAdded = true
+    } catch { /* fall through */ }
+  }
+
+  if (node.type === 'rest' && !iconAdded) {
+    try {
+      const frames = await loadAnimFrames('campfire', 3)
+      const anim = new PIXI.AnimatedSprite(frames)
+      anim.animationSpeed = 0.06; anim.play()
+      anim.width = anim.height = NODE_RADIUS * 1.3; anim.anchor.set(0.5)
+      iconLayer.addChild(anim); iconAdded = true
+    } catch { /* fall through */ }
+  }
+
+  if ((node.type === 'event' || node.type === 'memory') && !iconAdded) {
+    try {
+      const frames = await loadAnimFrames('event', 3)
+      const anim = new PIXI.AnimatedSprite(frames)
+      anim.animationSpeed = 0.04; anim.play()
+      anim.width = anim.height = NODE_RADIUS * 1.1; anim.anchor.set(0.5)
+      iconLayer.addChild(anim); iconAdded = true
+    } catch { /* fall through */ }
+  }
+
   if (!iconAdded) {
     const texture = await loadNodeIcon(node)
     if (texture) {
@@ -523,7 +562,7 @@ async function buildNodeMarker(
   nameLabel.y = ry + 4
   iconLayer.addChild(nameLabel)
 
-  if (status === 'completed') {
+  if (status === 'completed' && !isBattleType) {
     const st = new PIXI.Text({ text: '✓', style: { fontSize: 11, fill: '#44cc44' } })
     st.anchor.set(1, 1); st.position.set(NODE_RADIUS - 1, ry - 1)
     iconLayer.addChild(st)
@@ -767,7 +806,6 @@ export function NodeMap({ act, run, onSelectNode, onUseConsumable, onBack, user 
 
     const sp = startPos(mapHeight)
     avatar.position.set(sp.x, sp.y)
-    avatar.zIndex = sp.y
 
     const lastNode = lastCompletedNode(act, stateRef.current.run)
     if (lastNode) {
@@ -776,12 +814,12 @@ export function NodeMap({ act, run, onSelectNode, onUseConsumable, onBack, user 
         const rowNodes = rows[ri]
         const pos = nodePosition(ri, lastNode, rowNodes[0]?.rowCols ?? rowNodes.length, maxRowCols)
         avatar.position.set(pos.x, pos.y)
-        avatar.zIndex = pos.y
       }
     }
 
     avatar.stop()
-    worldLayer.addChild(avatar)
+    avatar.zIndex = 100000
+    nodeLayer.addChild(avatar)
     avatarRef.current = avatar
 
     app.ticker.add(() => { worldLayer.sortChildren(); nodeLayer.sortChildren() })
@@ -823,7 +861,6 @@ export function NodeMap({ act, run, onSelectNode, onUseConsumable, onBack, user 
     avatar.play()
     emitSound('mapFootstep')
     tweenTo(avatar, pos.x, pos.y, WALK_DURATION, app).then(() => {
-      avatar.zIndex = pos.y
       avatar.stop()
       isWalkingRef.current = false
       setPeekNode(node)


### PR DESCRIPTION
## Summary

- **Node/road colour match** — replaced `nodeRoadColor` with `nodeRoadFill` returning `{color, alpha}`, so the node disc uses the same alpha as the road inner fill (no more brightness mismatch over the dark background)
- **Road seam fix** — added a midpoint to each horizontal leg of the road path so `bezierBand` normals are computed over two horizontal neighbours, eliminating the visible kink at the horizontal-to-curve junction
- **Consistent node border** — node bg is now two ellipses: outer dark (`0x000000 @ 0.55`) + inner coloured, mirroring the road's dark outer band + coloured inner fill
- **Avatar above nodes** — moved avatar from `worldLayer` to `nodeLayer` with `zIndex = 100000`; walking animation is now visible when traversing the map
- **Tombstone on completed battles** — completed battle/elite/boss nodes show `tombstone.svg` instead of a ✓ checkmark; new sprite created
- **Animated campfire** — rest nodes animate over 3 campfire frames (speed 0.06); frames vary flame height and lean
- **Animated event scroll** — event/memory nodes animate over 3 scroll frames (speed 0.04); frames pulse the wax seal brightness

## New sprites
`tombstone.svg`, `campfire-1/2/3.svg`, `event-1/2/3.svg`

## Test plan
- [ ] Node fill colour is visually indistinguishable from the road colour it connects to
- [ ] No visible kink/seam where horizontal road meets the bezier curve
- [ ] Node discs have a dark outer ring matching the road's outer band
- [ ] Player avatar renders above node discs; walking animation plays during traversal
- [ ] Completed battle/elite/boss nodes show a tombstone, not a ✓
- [ ] Rest nodes show a flickering campfire animation
- [ ] Event/memory nodes show a pulsing scroll animation; static scroll as fallback if frames fail to load

https://claude.ai/code/session_0178FWDGT2AnsK7r6hmFJU1R

---
_Generated by [Claude Code](https://claude.ai/code/session_0178FWDGT2AnsK7r6hmFJU1R)_