### PR TITLE
Fix Codex relic persistence and deck selector resting badges

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -413,6 +413,7 @@ export default function App() {
 
   // Deck selector modal (shown before quick battle / endless when Deck B has cards)
   const [pendingBattleFn, setPendingBattleFn] = useState<null | (() => void)>(null)
+  const [pendingBattleIsCampaign, setPendingBattleIsCampaign] = useState(false)
   const campaignPlayCountsRef = useRef<Record<string, number>>({})  // per-battle play tracking
   const gameStateRef = useRef<GameState | null>(null)  // always-current snapshot for callbacks
 
@@ -679,6 +680,7 @@ export default function App() {
 
   const handlePlay = useCallback((mode: QuickBattleMode) => {
     if (loadDeckSlot('b').length > 0) {
+      setPendingBattleIsCampaign(false)
       setPendingBattleFn(() => () => launchQuickBattle(mode))
     } else {
       launchQuickBattle(mode)
@@ -701,6 +703,7 @@ export default function App() {
 
   const handleEndless = useCallback(() => {
     if (loadDeckSlot('b').length > 0) {
+      setPendingBattleIsCampaign(false)
       setPendingBattleFn(() => launchEndless)
     } else {
       launchEndless()
@@ -959,6 +962,7 @@ export default function App() {
     } // end doLaunch
 
     if (loadDeckSlot('b').length > 0) {
+      setPendingBattleIsCampaign(true)
       setPendingBattleFn(() => doLaunch)
     } else {
       doLaunch()
@@ -3060,7 +3064,7 @@ export default function App() {
       {/* Deck selector — shown before quick battle / endless when Deck B has content */}
       {pendingBattleFn && (
         <DeckSelectorModal
-          fatiguedCards={fatiguedCards}
+          fatiguedCards={pendingBattleIsCampaign ? fatiguedCards : []}
           onConfirm={() => {
             const fn = pendingBattleFn
             setPendingBattleFn(null)

--- a/web/src/game/codex.ts
+++ b/web/src/game/codex.ts
@@ -1,6 +1,6 @@
 import { getCardCatalog } from './cards'
 import { loadCollection } from './collection'
-import { getRelics } from './itemStore'
+import { getEverAcquiredRelics } from './itemStore'
 import { loadActCount } from './questline'
 import { getCharacterDef, getCharacterState, getCharacterIds } from './characters'
 import relicsData from '../data/relics.json'
@@ -156,13 +156,13 @@ export function getCodexCards(): CodexCardEntry[] {
 }
 
 export function getCodexRelics(): CodexRelicEntry[] {
-  const earned = new Set(getRelics())
+  const everAcquired = new Set(getEverAcquiredRelics())
   return (relicsData as Array<{ name: string; icon: string; desc: string; lore?: string; effects: unknown[] }>).map(r => ({
     name: r.name,
     icon: r.icon,
     desc: r.desc,
     lore: r.lore ?? '',
-    unlocked: earned.has(r.name),
+    unlocked: everAcquired.has(r.name),
   }))
 }
 

--- a/web/src/game/itemStore.ts
+++ b/web/src/game/itemStore.ts
@@ -345,14 +345,48 @@ export function spendTickets(n: number): boolean {
 // runs and are unique — adding the same relic twice is a no-op.
 // Display data and broken-relic logic live in relics.ts.
 
-/** Return the names of all relics the player has earned. */
+const CODEX_RELICS_KEY = 'jarv_codex_relics'
+
+function getCodexRelicSet(): Set<string> {
+  try {
+    const raw = localStorage.getItem(CODEX_RELICS_KEY)
+    if (!raw) return new Set()
+    return new Set(JSON.parse(raw) as string[])
+  } catch { return new Set() }
+}
+
+/** Return the names of all relics the player currently holds. */
 export function getRelics(): string[] {
   return getItemsOfType('relic').map(e => e.id)
+}
+
+/**
+ * Return the names of all relics the player has ever acquired.
+ * This set only grows — broken/removed relics remain here so the Codex
+ * can show them as unlocked permanently.
+ */
+export function getEverAcquiredRelics(): string[] {
+  const ever = getCodexRelicSet()
+  if (ever.size === 0) {
+    // Migrate: seed from currently-held relics on first call after this change
+    const current = getRelics()
+    if (current.length > 0) {
+      try { localStorage.setItem(CODEX_RELICS_KEY, JSON.stringify(current)) } catch { /* ignore */ }
+      return current
+    }
+  }
+  return [...ever]
 }
 
 /** Add a relic to the player's permanent collection (no-op if already owned). */
 export function addRelic(name: string): void {
   addItem('relic', name)
+  // Persist to codex set (survives relic removal/breaking)
+  const ever = getCodexRelicSet()
+  if (!ever.has(name)) {
+    ever.add(name)
+    try { localStorage.setItem(CODEX_RELICS_KEY, JSON.stringify([...ever])) } catch { /* ignore */ }
+  }
 }
 
 /** Remove a relic from the player's permanent collection (e.g. when it breaks). */


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **#1373 (Codex)**: Relics now stay unlocked in the Codex after they break. Added `getEverAcquiredRelics()` in `itemStore.ts` tracking a separate `jarv_codex_relics` localStorage key that only grows — `removeRelic()` no longer affects Codex visibility. Existing players' current relics are migrated on first call.
- **#1369 (Deck selector)**: The "zzz" resting badges no longer appear in Quick Battle or Endless deck selector — `fatiguedCards` is only passed when launching from the Campaign.

## Changes

- `web/src/game/itemStore.ts` — added `CODEX_RELICS_KEY`, `getCodexRelicSet()`, `getEverAcquiredRelics()`; updated `addRelic()` to persist to the codex set
- `web/src/game/codex.ts` — `getCodexRelics()` now uses `getEverAcquiredRelics()` instead of `getRelics()`
- `web/src/App.tsx` — added `pendingBattleIsCampaign` state; set to `false` for Quick Battle/Endless, `true` for Campaign; passed conditionally to `DeckSelectorModal`

## Test plan

- [ ] Acquire a relic in campaign, then reach a node that breaks it — confirm it still shows as unlocked in the Codex
- [ ] Open deck selector from Quick Battle or Endless with fatigued cards — confirm no zzz badges shown
- [ ] Open deck selector from Campaign with fatigued cards — confirm zzz badges still shown

https://claude.ai/code/session_01W2CiV4oCEsK3TWzQSQ26xb
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01W2CiV4oCEsK3TWzQSQ26xb)_