### PR TITLE
Fix quick battle replay mode and reward packs

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -790,9 +790,15 @@ export default function App() {
         : handicap
     try { localStorage.setItem(HANDICAP_KEY, String(nextHandicap)) } catch { /* ignore */ }
     setHandicap(nextHandicap)
-    const { playerCards, deckBonus } = loadCurrentDeckInfo()
-    battleAllLegendaryRef.current = playerCards.length > 0 && playerCards.every(c => c.rarity === 'legendary')
-    startBattle(newGame(playerCards, Math.min(MAX_HANDICAP, nextHandicap + deckBonus)))
+    if (gameState.endlessMode) {
+      const { playerCards, deckBonus } = loadCurrentDeckInfo()
+      battleAllLegendaryRef.current = playerCards.length > 0 && playerCards.every(c => c.rarity === 'legendary')
+      startBattle(newGame({ playerCards, opponentHandicap: Math.min(MAX_HANDICAP, nextHandicap + deckBonus), endlessMode: true }))
+    } else {
+      const { opts, playerCards } = buildQuickBattleOpts(quickBattleModeRef.current, nextHandicap)
+      battleAllLegendaryRef.current = playerCards.length > 0 && playerCards.every(c => c.rarity === 'legendary')
+      startBattle(newGame(opts))
+    }
     rollRareEvent()
   }, [gameState, handicap])
 
@@ -2165,20 +2171,53 @@ export default function App() {
 
   const handleOpenPack = useCallback(() => {
     packBackScreenRef.current = 'title'
-    var pack = generatePack()
+    let pack: string[]
 
     switch(quickBattleModeRef.current) {
-      case  'easy':
-        // Easy mode: 2 cards per pack, no duplicates
-        pack = [...new Set(pack)].slice(0, 2)
+      case 'easy':
+        pack = [...new Set(generatePack())].slice(0, 2)
         break
       case 'normal':
-        case 'mirror':
-        // Normal mode: 5 cards per pack, no duplicates
+      case 'mirror':
         pack = generatePack()
         break
       case 'unlimited':
-        pack = generateSeededPack(3, "rare")
+        pack = generateSeededPack(3, 'rare')
+        break
+      case 'hero-only':
+        pack = generateSeededPack(5, 'legendary')
+        break
+      case 'chaos':
+        pack = generateSeededPack(2, 'legendary')
+        break
+      case 'only-units': {
+        const pool = getCardCatalog().filter(c => c.cardType.includes('unit'))
+        pack = Array.from({ length: 3 }, () => pool[Math.floor(Math.random() * pool.length)].name)
+        break
+      }
+      case 'only-spells': {
+        const pool = getCardCatalog().filter(c => c.cardType.includes('upgrade'))
+        pack = Array.from({ length: 3 }, () => pool[Math.floor(Math.random() * pool.length)].name)
+        break
+      }
+      case 'only-buildings': {
+        const pool = getCardCatalog().filter(c => c.cardType.includes('structure'))
+        pack = Array.from({ length: 3 }, () => pool[Math.floor(Math.random() * pool.length)].name)
+        break
+      }
+      case 'common-only': {
+        const pool = getCardCatalog().filter(c => c.rarity === 'common')
+        pack = Array.from({ length: 5 }, () => pool[Math.floor(Math.random() * pool.length)].name)
+        break
+      }
+      case 'uncommon-only':
+        pack = generateSeededPack(5, 'uncommon')
+        break
+      case 'rare-only':
+        pack = generateSeededPack(5, 'rare')
+        break
+      case 'legendary-only':
+        pack = generateSeededPack(5, 'legendary')
         break
       default:
         pack = generatePack()


### PR DESCRIPTION
## Summary

- **#1375 (Quick Battle Replay)**: Replaying a battle now re-uses the same mode. `handlePlayAgain` was using a generic `newGame(playerCards, handicap)` call that discarded the quick battle mode. It now calls `buildQuickBattleOpts(quickBattleModeRef.current, nextHandicap)` so a Chaos replay stays Chaos, etc. Endless replay also correctly passes `endlessMode: true` again.

- **#1376 (Quick Battle Rewards)**: Pack rewards now match what the screen advertises. `handleOpenPack` had no cases for `hero-only`, `chaos`, `only-units`, `only-spells`, `only-buildings`, `common-only`, `uncommon-only`, `rare-only`, or `legendary-only` — all fell through to a standard pack. Now each mode gives its advertised reward.

## Reward mapping

| Mode | Reward |
|------|--------|
| `easy` | 2-card standard pack |
| `normal` / `mirror` | 5-card standard pack |
| `unlimited` | 3-card rare pack |
| `hero-only` / `legendary-only` | 5-card legendary pack |
| `chaos` | 2-card legendary pack |
| `only-units` / `only-spells` / `only-buildings` | 3 type-filtered cards |
| `common-only` | 5 common cards |
| `uncommon-only` | 5 uncommon cards |
| `rare-only` | 5 rare cards |

## Test plan

- [ ] Start a Chaos battle, lose, hit replay — confirm it's Chaos again (not standard)
- [ ] Win a Chaos battle — confirm reward is 2 legendary cards, not a standard pack
- [ ] Win a Units Only battle — confirm reward is 3 unit cards
- [ ] Win a Rare Only battle — confirm reward is 5 rare cards

https://claude.ai/code/session_01W2CiV4oCEsK3TWzQSQ26xb

---
_Generated by [Claude Code](https://claude.ai/code/session_01W2CiV4oCEsK3TWzQSQ26xb)_