### PR TITLE
Shop: Max pack buy button + purchase confirmation modal

### DIFF
--- a/web/src/components/screens/ShopScreen.tsx
+++ b/web/src/components/screens/ShopScreen.tsx
@@ -88,7 +88,9 @@ const PACK_QUANTITIES = [1, 3, 5, 10]
 
 export function ShopScreen({ crystals, onBuyCrystalPack, onCrystalsChange, onBack }: Props) {
   const [packQty, setPackQty] = useState(1)
+  const maxPackQty = Math.max(0, Math.floor((crystals - 100) / CRYSTAL_PACK_COST))
   const canBuyPack = crystals >= CRYSTAL_PACK_COST * packQty
+  const [pendingPackBuy, setPendingPackBuy] = useState(false)
 
   const [npc, setNpc] = useState(() => getDailyShopNPC())
   const [dailyCards, setDailyCards] = useState(() => getDailyShopCards())
@@ -164,11 +166,16 @@ export function ShopScreen({ crystals, onBuyCrystalPack, onCrystalsChange, onBac
 
   function handleBuyPackClick() {
     if (canBuyPack) {
-      emitSound('shopPurchase')
-      onBuyCrystalPack(packQty)
+      setPendingPackBuy(true)
     } else {
       incrementAchievementProgress('misc:shop_broke_click')
     }
+  }
+
+  function handleConfirmPackBuy() {
+    emitSound('shopPurchase')
+    onBuyCrystalPack(packQty)
+    setPendingPackBuy(false)
   }
 
   function handleBuyCard(deal: ShopCardDeal) {
@@ -345,12 +352,20 @@ export function ShopScreen({ crystals, onBuyCrystalPack, onCrystalsChange, onBac
             {PACK_QUANTITIES.map(q => (
               <button
                 key={q}
-                className={`filter-btn${packQty === q ? ' filter-btn--active' : ''}`}
+                className={`filter-btn${packQty === q && packQty !== maxPackQty ? ' filter-btn--active' : ''}`}
                 onClick={() => setPackQty(q)}
               >
                 ×{q}
               </button>
             ))}
+            <button
+              className={`filter-btn filter-btn--gold${packQty === maxPackQty && maxPackQty > 0 ? ' filter-btn--active' : ''}`}
+              onClick={() => setPackQty(maxPackQty)}
+              disabled={maxPackQty === 0}
+              title={maxPackQty === 0 ? 'Not enough crystals' : `Buy ${maxPackQty} packs`}
+            >
+              MAX{maxPackQty > 0 ? ` ×${maxPackQty}` : ''}
+            </button>
           </div>
           <button
             className="action-btn action-btn--gold"
@@ -361,6 +376,22 @@ export function ShopScreen({ crystals, onBuyCrystalPack, onCrystalsChange, onBac
               ? `Buy ${packQty > 1 ? `${packQty}× ` : ''}— ${CRYSTAL_PACK_COST * packQty} 💎`
               : `Need ${CRYSTAL_PACK_COST * packQty - crystals} more 💎`}
           </button>
+
+          {/* Max buy confirmation modal */}
+          {pendingPackBuy && (
+            <div className="shop-confirm-backdrop" onClick={() => setPendingPackBuy(false)}>
+              <div className="shop-confirm-modal" onClick={e => e.stopPropagation()}>
+                <div className="shop-confirm-title">🎁 Card Packs</div>
+                <div className="shop-confirm-body">
+                  This will buy <strong>{packQty} card pack{packQty !== 1 ? 's' : ''}</strong> for <strong>{CRYSTAL_PACK_COST * packQty} 💎</strong>
+                </div>
+                <div className="shop-confirm-actions">
+                  <button className="action-btn" onClick={() => setPendingPackBuy(false)}>Oh no</button>
+                  <button className="action-btn action-btn--gold" onClick={handleConfirmPackBuy}>Oh yes!</button>
+                </div>
+              </div>
+            </div>
+          )}
         </div>
 
         {/* ── Sell slots ── */}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2186,6 +2186,14 @@ body {
 .filter-btn--wide   { min-width: 64px; }
 .filter-btn--fit    { flex: 1; }
 
+.filter-btn--gold {
+  border-color: rgba(255, 215, 0, 0.4);
+  color: var(--color-gold);
+}
+.filter-btn--gold:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
 .filter-btn--gold.filter-btn--active {
   border-color: var(--color-gold);
   color: var(--color-gold);
@@ -13942,4 +13950,47 @@ html.light-mode .action-btn {
   overflow-y: auto;
   display: flex;
   flex-direction: column;
+}
+
+/* ── Shop pack confirmation modal ── */
+.shop-confirm-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 500;
+}
+
+.shop-confirm-modal {
+  background: var(--game-bg-raised);
+  border: 1px solid var(--color-gold);
+  border-radius: 6px;
+  padding: 24px 28px;
+  max-width: 340px;
+  width: 90%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
+  text-align: center;
+}
+
+.shop-confirm-title {
+  font-size: var(--font-lg);
+  color: var(--color-gold);
+  font-weight: bold;
+}
+
+.shop-confirm-body {
+  font-size: var(--font-sm);
+  color: var(--game-text-color);
+  line-height: 1.5;
+}
+
+.shop-confirm-actions {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
 }


### PR DESCRIPTION
## Summary

- Adds a **MAX** button to the card pack quantity selector that calculates how many packs can be bought while leaving 100💎 minimum (`Math.floor((crystals - 100) / packCost)`). Shown in gold, disabled if the player can't afford any packs with the buffer.
- All pack purchases now show a **confirmation modal** before completing — displays pack count and total cost, with "Oh no" (cancel) and "Oh yes!" (confirm) buttons.

## Test plan

- [ ] Open shop with enough crystals for multiple packs — MAX button shows correct quantity
- [ ] With exactly 100 crystals or less — MAX button is disabled/greyed
- [ ] Select any quantity and click Buy — confirmation modal appears with correct count and cost
- [ ] "Oh no" dismisses the modal, no purchase made
- [ ] "Oh yes!" completes the purchase, crystals deducted correctly
- [ ] MAX button stays highlighted (active) after selecting it

https://claude.ai/code/session_01W2CiV4oCEsK3TWzQSQ26xb

---
_Generated by [Claude Code](https://claude.ai/code/session_01W2CiV4oCEsK3TWzQSQ26xb)_