### PR TITLE
Fix win streak reset bug and add streak broken notification

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -121,6 +121,7 @@ import { PlayerStatsScreen }     from './components/screens/PlayerStatsScreen'
 import { CodexScreen }          from './components/screens/CodexScreen'
 import { DailyChallengeScreen } from './components/screens/DailyChallengeScreen'
 import { ConfirmModal }          from './components/modals/ConfirmModal'
+import { StreakBrokenModal }     from './components/modals/StreakBrokenModal'
 import { EndlessLeaderboardScreen } from './components/screens/EndlessLeaderboardScreen'
 import { MiniGamesMenu }           from './components/screens/MiniGamesMenu'
 import { AugmentCollectionScreen } from './components/screens/AugmentCollectionScreen'
@@ -410,6 +411,7 @@ export default function App() {
   const [cardRestPlayCounts, setCardRestPlayCounts] = useState<Record<string, number>>({})
   const [bonusPackCards, setBonusPackCards]     = useState<string[]>([])
   const [campaignRestingAlert, setCampaignRestingAlert] = useState(false)
+  const [streakBrokenData, setStreakBrokenData] = useState<{ streak: number; bestStreak: number } | null>(null)
   // Secret 5 — Time Capsule on 100th battle
   const [timeCapsuleVisible, setTimeCapsuleVisible] = useState(false)
   // Secret 10 — 100 Wins Celebration
@@ -769,6 +771,12 @@ export default function App() {
     rollRareEvent()
   }, [])
 
+  function handleStreakReset() {
+    const current = loadWinStreak()
+    if (current > 0) setStreakBrokenData({ streak: current, bestStreak: loadBestStreak() })
+    resetWinStreak()
+  }
+
   const handlePlayAgain = useCallback(() => {
     if (!gameState || gameState.phase.type !== 'gameOver') return
     // Training mode: send back to training setup screen
@@ -787,7 +795,6 @@ export default function App() {
     prevOpponentUnitsRef.current = new Map()
     prevPlayerUnitsRef.current = new Map()
     const winner = gameState.phase.winner
-    if (winner === 'player') { incrementWinStreak() } else { resetWinStreak() }
     const nextHandicap = winner === 'player'
       ? Math.max(0, handicap - 1)
       : winner === 'opponent'
@@ -1778,7 +1785,7 @@ export default function App() {
       setCrystals(next)
       const failUnlocked = incrementAchievementProgress('misc:campaign_failed')
       if (failUnlocked.length > 0) setAchievementToasts(prev => [...prev, ...failUnlocked])
-      resetWinStreak()
+      handleStreakReset()
       setLastRunFailed()
       clearRun()
       setRun(null)
@@ -1857,7 +1864,7 @@ export default function App() {
         setCrystals(next)
         const failUnlocked = incrementAchievementProgress('misc:campaign_failed')
         if (failUnlocked.length > 0) setAchievementToasts(prev => [...prev, ...failUnlocked])
-        resetWinStreak()
+        handleStreakReset()
         setLastRunFailed()
         clearRun()
         setRun(null)
@@ -2287,7 +2294,7 @@ export default function App() {
         setCrystals(next)
         const failUnlocked = incrementAchievementProgress('misc:campaign_failed')
         if (failUnlocked.length > 0) setAchievementToasts(prev => [...prev, ...failUnlocked])
-        resetWinStreak()
+        handleStreakReset()
         setLastRunFailed()
         clearRun()
         setRun(null)
@@ -3107,6 +3114,14 @@ export default function App() {
           </div>
         )
       })()}
+
+      {streakBrokenData && (
+        <StreakBrokenModal
+          streak={streakBrokenData.streak}
+          bestStreak={streakBrokenData.bestStreak}
+          onClose={() => setStreakBrokenData(null)}
+        />
+      )}
 
       {/* Secret 5 — Time Capsule: 100th battle milestone overlay */}
       {timeCapsuleVisible && (

--- a/web/src/components/modals/StreakBrokenModal.tsx
+++ b/web/src/components/modals/StreakBrokenModal.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import { ModalBackdrop } from '../ui/ModalBackdrop'
+
+interface Props {
+  streak: number
+  bestStreak: number
+  onClose: () => void
+}
+
+export function StreakBrokenModal({ streak, bestStreak, onClose }: Props) {
+  const wasPersonalBest = streak >= bestStreak
+
+  return (
+    <ModalBackdrop onClose={onClose} zIndex={600}>
+      <div className="streak-broken-modal">
+        <div className="streak-broken-icon">💔</div>
+        <div className="streak-broken-heading">STREAK OVER</div>
+        <div className="streak-broken-count">{streak}</div>
+        <div className="streak-broken-label">
+          win streak{streak === 1 ? '' : 's'} ended
+        </div>
+        {wasPersonalBest && (
+          <div className="streak-broken-pb">That was your best ever.</div>
+        )}
+        <button className="action-btn streak-broken-btn" onClick={onClose}>
+          Oof.
+        </button>
+      </div>
+    </ModalBackdrop>
+  )
+}

--- a/web/src/game/achievements.ts
+++ b/web/src/game/achievements.ts
@@ -80,7 +80,7 @@ export function incrementAchievementProgress(progressKey: string, by = 1): Achie
 /** Set a progress counter to a specific value (for tracking maximums like streaks). Returns newly unlocked defs. */
 export function setAchievementProgress(progressKey: string, value: number): AchievementDef[] {
   const save = loadAchievementSave()
-  save.progress[progressKey] = value
+  save.progress[progressKey] = Math.max(value, save.progress[progressKey] ?? 0)
 
   const newlyUnlocked: AchievementDef[] = []
   for (const def of ACHIEVEMENT_DEFS) {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -13952,6 +13952,57 @@ html.light-mode .action-btn {
   flex-direction: column;
 }
 
+/* ── Streak broken modal ── */
+.streak-broken-modal {
+  background: var(--game-bg-raised);
+  border: 2px solid var(--color-red, #cc3333);
+  border-radius: 6px;
+  padding: 32px 40px;
+  max-width: 320px;
+  width: 90%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  text-align: center;
+}
+
+.streak-broken-icon {
+  font-size: 40px;
+  line-height: 1;
+}
+
+.streak-broken-heading {
+  font-size: var(--font-lg);
+  font-weight: bold;
+  color: var(--color-red, #cc3333);
+  letter-spacing: 0.1em;
+  margin-top: 4px;
+}
+
+.streak-broken-count {
+  font-size: 56px;
+  font-weight: bold;
+  color: var(--game-text-color);
+  line-height: 1;
+  margin: 4px 0;
+}
+
+.streak-broken-label {
+  font-size: var(--font-sm);
+  color: var(--game-text-color-dim);
+}
+
+.streak-broken-pb {
+  font-size: var(--font-xs);
+  color: var(--color-gold);
+  margin-top: 4px;
+}
+
+.streak-broken-btn {
+  margin-top: 16px;
+}
+
 /* ── Shop pack confirmation modal ── */
 .shop-confirm-backdrop {
   position: fixed;


### PR DESCRIPTION
- Remove incrementWinStreak/resetWinStreak from handlePlayAgain — streak is campaign-only, not affected by Quick Battle or Endless
- Guard setAchievementProgress against regressing stored progress (Math.max)
- Add StreakBrokenModal shown when a campaign run ends a streak > 0, with "Oof." dismiss button and personal best callout

https://claude.ai/code/session_01W2CiV4oCEsK3TWzQSQ26xb