### PR TITLE
Fix missing loadBestStreak import causing build failure

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -15,7 +15,7 @@ import {
   recordCardPlayed, recordUnitDied, addCardsToCollection,
   getOwnedCount, DECK_MAX, CRYSTAL_PACK_COST, DeckEntry,
   deckTotalCards, STARTER_DECK,
-  loadWinStreak, incrementWinStreak, resetWinStreak, incrementTotalWins,
+  loadWinStreak, loadBestStreak, incrementWinStreak, resetWinStreak, incrementTotalWins,
   generateSeededPack,
 } from './game/collection'
 import { getCardCatalog } from './game/cards'


### PR DESCRIPTION
## Summary
- `loadBestStreak` was used in the `handleStreakReset` helper (added in #1380) but not included in the import from `./game/collection`, causing a TypeScript build error

## Test plan
- [ ] Build passes without `TS2304: Cannot find name 'loadBestStreak'`
- [ ] Streak broken modal still appears correctly when campaign streak ends

https://claude.ai/code/session_01W2CiV4oCEsK3TWzQSQ26xb

---
_Generated by [Claude Code](https://claude.ai/code/session_01W2CiV4oCEsK3TWzQSQ26xb)_