### PR TITLE
feat(augments): stack complete sets in augment screen (#1382)

### DIFF
--- a/web/src/components/cards/CardAugmentScreen.tsx
+++ b/web/src/components/cards/CardAugmentScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useMemo } from 'react'
 import { Card, AugmentSlot, AugmentEffect, AugmentInstance } from '../../game/types'
 import {
   CollectionEntry,
@@ -10,6 +10,7 @@ import {
   getEquippedAugments,
   getSetBonus,
   upgradeAugment,
+  mergeAugmentEffects,
   AUGMENT_UPGRADE_COST,
 } from '../../game/collection'
 import {
@@ -21,7 +22,6 @@ import {
   getAugmentSetDef,
 } from '../../game/augments'
 import { CardTile } from './CardTile'
-import { StatRow } from '../ui/StatRow'
 import { MasteryBar } from '../ui/MasteryBar'
 import { AugmentPickerModal } from './AugmentPickerModal'
 
@@ -42,6 +42,19 @@ const RARITY_COLOUR: Record<string, string> = {
   shiny:     '#ffe066',
   holofoil:  '#40e0d0',
   glass:     '#a0d8ef',
+}
+
+function AugStatRow({ label, base, delta }: { label: string; base: number; delta?: number }) {
+  const hasDelta = delta != null && delta !== 0
+  return (
+    <div style={{ display: 'flex', alignItems: 'baseline', gap: 4, minWidth: 64 }}>
+      <span style={{ fontSize: 10, opacity: 0.6, textTransform: 'uppercase' }}>{label}</span>
+      <span style={{ fontWeight: 700 }}>{hasDelta ? base + delta! : base}</span>
+      {hasDelta && (
+        <span style={{ fontSize: 10, color: '#aaddff' }}>(+{delta})</span>
+      )}
+    </div>
+  )
 }
 
 function effectSummary(effect: AugmentEffect): string {
@@ -71,6 +84,20 @@ export function CardAugmentScreen({ card, collection, deckEntries, onClose }: Pr
   const souls       = loadAugmentSouls()
 
   const u = card.unit
+
+  // Compute total augment effect for live stat display
+  const totalAugmentEffect = useMemo(() => {
+    let effect: AugmentEffect = {}
+    for (const inst of Object.values(equippedMap)) {
+      const augCard = getAugmentCard(inst.cardId)
+      if (!augCard?.augmentEffect) continue
+      const scaled = scaledAugmentEffect(augCard.augmentEffect, inst.level)
+      effect = mergeAugmentEffects(effect, scaled)
+    }
+    if (setBonus) effect = mergeAugmentEffects(effect, setBonus.effect)
+    return effect
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [refresh])
 
   function handleUpgrade(inst: AugmentInstance) {
     const err = upgradeAugment(inst.instanceId)
@@ -112,15 +139,15 @@ export function CardAugmentScreen({ card, collection, deckEntries, onClose }: Pr
               {/* Unit stats */}
               {u && u.moveSpeed > 0 && (
                 <div className="cdm-stats-block u-flex u-wrap">
-                  <StatRow compact label="ATK" value={u.attack} />
-                  <StatRow compact label="HP"  value={u.maxHp} />
-                  <StatRow compact label="SPD" value={u.moveSpeed} />
-                  {u.attackRange > 0 && <StatRow compact label="RNG" value={u.attackRange} />}
+                  <AugStatRow label="ATK" base={u.attack}      delta={totalAugmentEffect.attack} />
+                  <AugStatRow label="HP"  base={u.maxHp}       delta={totalAugmentEffect.maxHp} />
+                  <AugStatRow label="SPD" base={u.moveSpeed}   delta={totalAugmentEffect.moveSpeed} />
+                  {u.attackRange > 0 && <AugStatRow label="RNG" base={u.attackRange} delta={totalAugmentEffect.attackRange} />}
                 </div>
               )}
               {u && u.moveSpeed === 0 && (
                 <div className="cdm-stats-block u-flex u-wrap">
-                  <StatRow compact label="HP" value={u.maxHp} />
+                  <AugStatRow label="HP" base={u.maxHp} delta={totalAugmentEffect.maxHp} />
                 </div>
               )}
 

--- a/web/src/components/screens/AugmentCollectionScreen.tsx
+++ b/web/src/components/screens/AugmentCollectionScreen.tsx
@@ -4,22 +4,27 @@ import {
   loadAugmentInstances,
   loadAugmentSouls,
   upgradeAugment,
+  upgradeAugmentStack,
+  equipAugmentSet,
   AUGMENT_UPGRADE_COST,
+  loadCollection,
 } from '../../game/collection'
 import {
   getAugmentCard,
   augmentSlotLabel,
   scaledAugmentEffect,
   ALL_AUGMENT_SLOTS,
+  getAugmentSetDef,
+  AugmentSetDef,
 } from '../../game/augments'
 import { OverlayScreen } from '../ui/OverlayScreen'
 import { CardTile } from '../cards/CardTile'
 import { CardDetailModal } from '../cards/CardDetailModal'
 import { CardAugmentScreen } from '../cards/CardAugmentScreen'
+import { ModalBackdrop } from '../ui/ModalBackdrop'
 import { getCardCatalog } from '../../game/cards'
-import { loadCollection } from '../../game/collection'
 
-// ─── Lazy cell (same pattern as CollectionScreen) ──────────
+// ─── Lazy cell ────────────────────────────────────────────
 
 const LazyCell = memo(function LazyCell({ children, className }: { children: React.ReactNode; className: string }) {
   const ref  = useRef<HTMLDivElement>(null)
@@ -34,7 +39,7 @@ const LazyCell = memo(function LazyCell({ children, className }: { children: Rea
   return <div ref={ref} className={className}>{vis ? children : null}</div>
 })
 
-// ─── Sort / group types ────────────────────────────────────
+// ─── Sort / group types ───────────────────────────────────
 
 type AugSortKey  = 'default' | 'az' | 'za' | 'rarity' | 'level-desc' | 'level-asc' | 'slot'
 type AugGroupKey = 'none' | 'slot' | 'set' | 'rarity' | 'status'
@@ -44,20 +49,214 @@ const RARITY_ORDER: Record<string, number> = {
   shiny: 4, holofoil: 4, glass: 4,
 }
 
+const RARITY_COLOUR: Record<string, string> = {
+  common:    '#55cc55',
+  uncommon:  '#4499ff',
+  rare:      '#bb66ff',
+  epic:      '#ff8800',
+  legendary: '#ffcc00',
+  mythic:    '#e040fb',
+}
+
+// ─── Stack type and computation ───────────────────────────
+
+interface AugStack {
+  setName: string
+  setDef: AugmentSetDef | undefined
+  instances: AugmentInstance[]   // exactly 7, one per slot
+}
+
+function computeStacks(instances: AugmentInstance[]): { stacks: AugStack[]; individuals: AugmentInstance[] } {
+  const stacks: AugStack[] = []
+  const individuals: AugmentInstance[] = []
+
+  const bySet = new Map<string, AugmentInstance[]>()
+  for (const inst of instances) {
+    const card = getAugmentCard(inst.cardId)
+    const setName = card?.setName
+    if (!setName) { individuals.push(inst); continue }
+    if (!bySet.has(setName)) bySet.set(setName, [])
+    bySet.get(setName)!.push(inst)
+  }
+
+  for (const [setName, setInsts] of bySet) {
+    const bySlot = new Map<string, AugmentInstance[]>()
+    for (const inst of setInsts) {
+      const card = getAugmentCard(inst.cardId)
+      if (!card?.augmentSlot) { individuals.push(inst); continue }
+      if (!bySlot.has(card.augmentSlot)) bySlot.set(card.augmentSlot, [])
+      bySlot.get(card.augmentSlot)!.push(inst)
+    }
+
+    const allPresent = ALL_AUGMENT_SLOTS.every(s => (bySlot.get(s)?.length ?? 0) > 0)
+    if (!allPresent) {
+      for (const inst of setInsts) individuals.push(inst)
+      continue
+    }
+
+    const queues = new Map(ALL_AUGMENT_SLOTS.map(s => [s, [...(bySlot.get(s) ?? [])]]))
+
+    while (ALL_AUGMENT_SLOTS.every(s => (queues.get(s)?.length ?? 0) > 0)) {
+      const stackInsts: AugmentInstance[] = []
+      for (const slot of ALL_AUGMENT_SLOTS) stackInsts.push(queues.get(slot)!.shift()!)
+      stacks.push({ setName, setDef: getAugmentSetDef(setName), instances: stackInsts })
+    }
+
+    for (const slot of ALL_AUGMENT_SLOTS) {
+      for (const inst of queues.get(slot) ?? []) individuals.push(inst)
+    }
+  }
+
+  return { stacks, individuals }
+}
+
+function stackLevelSummary(stack: AugStack): string {
+  const levels = stack.instances.map(i => i.level)
+  const min = Math.min(...levels)
+  const max = Math.max(...levels)
+  return min === max ? `Lv${min}` : `Lv${min}–${max}`
+}
+
+function stackUpgradeCost(stack: AugStack): number {
+  const minLevel = Math.min(...stack.instances.map(i => i.level))
+  const count = stack.instances.filter(i => i.level === minLevel).length
+  return count * AUGMENT_UPGRADE_COST
+}
+
+// ─── Unit Picker Modal ────────────────────────────────────
+
+interface UnitPickerProps {
+  stack: AugStack
+  onEquip: (cardName: string) => void
+  onClose: () => void
+}
+
+function UnitPickerModal({ stack, onEquip, onClose }: UnitPickerProps) {
+  const collection = loadCollection()
+  const catalog    = getCardCatalog()
+  const unitCards  = catalog.filter(c =>
+    c.cardType === 'unit' && c.unit && c.unit.moveSpeed > 0 &&
+    collection.some(e => e.cardName === c.name && e.count > 0)
+  )
+
+  return (
+    <ModalBackdrop onClose={onClose} zIndex={400}>
+      <div className="apm-panel">
+        <div className="apm-header">
+          Equip {stack.setName} Set to Unit
+          <button className="cdm-close" onClick={onClose}>✕</button>
+        </div>
+        {unitCards.length === 0 ? (
+          <div className="apm-empty">No unit cards owned.</div>
+        ) : (
+          <div className="apm-list">
+            {unitCards.map(card => (
+              <div key={card.name} className="apm-item">
+                <div className="apm-item-info">
+                  <span className="apm-item-name">{card.name}</span>
+                  <span className="apm-item-set" style={{ opacity: 0.6, fontSize: 11 }}>
+                    {card.rarity.toUpperCase()}
+                  </span>
+                </div>
+                <div className="apm-item-actions">
+                  <button
+                    className="action-btn action-btn--gold"
+                    onClick={() => { onEquip(card.name); onClose() }}
+                  >
+                    Equip Set
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </ModalBackdrop>
+  )
+}
+
+// ─── Stack Tile ───────────────────────────────────────────
+
+interface StackTileProps {
+  stack: AugStack
+  souls: number
+  onView: () => void
+  onUpgrade: () => void
+  onEquipToUnit: () => void
+  upgradeError?: string | null
+}
+
+function StackTile({ stack, souls, onView, onUpgrade, onEquipToUnit, upgradeError }: StackTileProps) {
+  const cost      = stackUpgradeCost(stack)
+  const canUpgrade = souls >= cost
+  const col       = RARITY_COLOUR[stack.setDef?.rarity ?? 'common'] ?? '#55cc55'
+  const levels    = stack.instances.map(i => i.level)
+  const minLevel  = Math.min(...levels)
+  const atMin     = levels.filter(l => l === minLevel).length
+
+  return (
+    <div className="aug-stack-tile">
+      <div className="aug-stack-header">
+        <span className="aug-stack-name" style={{ color: col }}>{stack.setName} Set</span>
+        <span className="aug-stack-levels">{stackLevelSummary(stack)}</span>
+      </div>
+      <div className="aug-stack-slots">
+        {stack.instances.map(inst => {
+          const card = getAugmentCard(inst.cardId)
+          return (
+            <span key={inst.instanceId} className="aug-stack-slot-chip" style={{ color: col }}>
+              {augmentSlotLabel(card?.augmentSlot ?? 'helmet').slice(0, 4)} Lv{inst.level}
+            </span>
+          )
+        })}
+      </div>
+      {atMin < 7 && (
+        <div className="aug-stack-upgrade-note">
+          {atMin} item{atMin !== 1 ? 's' : ''} at Lv{minLevel} · next upgrade: {cost.toLocaleString()} souls
+        </div>
+      )}
+      {upgradeError && <div style={{ color: '#ff6666', fontSize: 11 }}>{upgradeError}</div>}
+      <div className="aug-stack-actions">
+        <button className="filter-btn" onClick={onView}>View Stack</button>
+        <button
+          className={`action-btn action-btn--gold${canUpgrade ? '' : ' action-btn--disabled'}`}
+          onClick={onUpgrade}
+          title={`Upgrade stack · ${cost.toLocaleString()} souls`}
+          style={{ fontSize: 11, padding: '2px 8px' }}
+        >
+          ↑ Upgrade · {cost.toLocaleString()}
+        </button>
+        <button
+          className="action-btn"
+          onClick={onEquipToUnit}
+          style={{ fontSize: 11, padding: '2px 8px' }}
+        >
+          Equip to Unit
+        </button>
+      </div>
+    </div>
+  )
+}
+
+// ─── Main screen ──────────────────────────────────────────
+
 interface Props {
   onBack: () => void
   embedded?: boolean
 }
 
 export function AugmentCollectionScreen({ onBack, embedded }: Props) {
-  const [refresh,    setRefresh]    = useState(0)
-  const [sortKey,    setSortKey]    = useState<AugSortKey>('default')
-  const [groupKey,   setGroupKey]   = useState<AugGroupKey>('none')
-  const [sortOpen,   setSortOpen]   = useState(false)
-  const [groupOpen,  setGroupOpen]  = useState(false)
-  const [detailInst, setDetailInst] = useState<{ card: Card; inst: AugmentInstance } | null>(null)
-  const [upgradeError, setUpgradeError] = useState<string | null>(null)
+  const [refresh,       setRefresh]       = useState(0)
+  const [sortKey,       setSortKey]       = useState<AugSortKey>('default')
+  const [groupKey,      setGroupKey]      = useState<AugGroupKey>('none')
+  const [sortOpen,      setSortOpen]      = useState(false)
+  const [groupOpen,     setGroupOpen]     = useState(false)
+  const [detailInst,    setDetailInst]    = useState<{ card: Card; inst: AugmentInstance } | null>(null)
+  const [upgradeError,  setUpgradeError]  = useState<string | null>(null)
+  const [stackErrors,   setStackErrors]   = useState<Record<string, string | null>>({})
   const [detailCardName, setDetailCardName] = useState<string | null>(null)
+  const [activeStack,   setActiveStack]   = useState<AugStack | null>(null)
+  const [equipTarget,   setEquipTarget]   = useState<AugStack | null>(null)
 
   const forceRefresh = () => setRefresh(r => r + 1)
 
@@ -66,6 +265,8 @@ export function AugmentCollectionScreen({ onBack, embedded }: Props) {
   const collection = loadCollection()
   const catalog    = getCardCatalog()
 
+  const { stacks, individuals } = computeStacks(instances)
+
   function handleUpgrade(inst: AugmentInstance) {
     const err = upgradeAugment(inst.instanceId)
     if (err) {
@@ -73,7 +274,6 @@ export function AugmentCollectionScreen({ onBack, embedded }: Props) {
       setTimeout(() => setUpgradeError(null), 2500)
     }
     forceRefresh()
-    // refresh detail modal to show updated level
     if (detailInst?.inst.instanceId === inst.instanceId) {
       const updated = loadAugmentInstances().find(i => i.instanceId === inst.instanceId)
       if (updated) {
@@ -86,7 +286,27 @@ export function AugmentCollectionScreen({ onBack, embedded }: Props) {
     }
   }
 
-  // Navigate to unit card's augment screen
+  function handleUpgradeStack(stack: AugStack) {
+    const key = stack.instances[0].instanceId
+    const err = upgradeAugmentStack(stack.instances.map(i => i.instanceId))
+    if (err) {
+      setStackErrors(prev => ({ ...prev, [key]: err }))
+      setTimeout(() => setStackErrors(prev => ({ ...prev, [key]: null })), 2500)
+    }
+    forceRefresh()
+    // keep activeStack in sync if we're in drill-down
+    if (activeStack) {
+      const updated = loadAugmentInstances()
+      const refreshed = activeStack.instances.map(old => updated.find(i => i.instanceId === old.instanceId) ?? old)
+      setActiveStack({ ...activeStack, instances: refreshed })
+    }
+  }
+
+  function handleEquipSet(stack: AugStack, cardName: string) {
+    equipAugmentSet(stack.instances.map(i => i.instanceId), cardName)
+    forceRefresh()
+  }
+
   if (detailCardName) {
     const card = catalog.find(c => c.name === detailCardName)
     if (card) {
@@ -100,20 +320,22 @@ export function AugmentCollectionScreen({ onBack, embedded }: Props) {
     }
   }
 
-  // ─── Build display items ───────────────────────────────
+  // ─── Build display items for individual grid ──────────
 
   type DisplayItem = { inst: AugmentInstance; card: Card; displayCard: Card }
 
-  const items: DisplayItem[] = instances.flatMap(inst => {
+  const sourceInstances = activeStack ? activeStack.instances : individuals
+
+  const items: DisplayItem[] = sourceInstances.flatMap(inst => {
     const augCard = getAugmentCard(inst.cardId)
     if (!augCard) return []
     const displayCard = { ...augCard, augmentEffect: scaledAugmentEffect(augCard.augmentEffect ?? {}, inst.level) }
     return [{ inst, card: augCard, displayCard }]
   })
 
-  // ─── Sort ─────────────────────────────────────────────
+  // ─── Sort (only applies to individuals list, not stack drill-down) ───
 
-  const sorted = [...items].sort((a, b) => {
+  const sorted = activeStack ? items : [...items].sort((a, b) => {
     switch (sortKey) {
       case 'az':         return a.card.name.localeCompare(b.card.name)
       case 'za':         return b.card.name.localeCompare(a.card.name)
@@ -125,7 +347,7 @@ export function AugmentCollectionScreen({ onBack, embedded }: Props) {
     }
   })
 
-  // ─── Group ────────────────────────────────────────────
+  // ─── Group (only for individuals) ─────────────────────
 
   function groupLabel(item: DisplayItem): string {
     switch (groupKey) {
@@ -138,7 +360,7 @@ export function AugmentCollectionScreen({ onBack, embedded }: Props) {
   }
 
   const groups: { label: string; items: DisplayItem[] }[] = []
-  if (groupKey === 'none') {
+  if (groupKey === 'none' || activeStack) {
     groups.push({ label: '', items: sorted })
   } else {
     for (const item of sorted) {
@@ -149,78 +371,90 @@ export function AugmentCollectionScreen({ onBack, embedded }: Props) {
     }
   }
 
-  // Count total instances per cardId for the modal "owned" display
   const instanceCounts: Record<string, number> = {}
   for (const inst of instances) {
     instanceCounts[inst.cardId] = (instanceCounts[inst.cardId] ?? 0) + 1
   }
 
-  const currentSouls = loadAugmentSouls()
-
   const inner = (
     <>
-      {/* Filter bar */}
-      <div className="filter-bar">
-        {/* SORT */}
-        <div className="filter-popup-wrap">
+      {/* Drill-down header */}
+      {activeStack ? (
+        <div className="aug-stack-drill-header">
+          <button className="filter-btn" onClick={() => setActiveStack(null)}>← Back to All</button>
+          <span className="aug-stack-drill-title">
+            {activeStack.setName} Set
+          </span>
           <button
-            className={`filter-btn${sortKey !== 'default' ? ' filter-btn--active' : ''}`}
-            onClick={() => { setSortOpen(o => !o); setGroupOpen(false) }}
+            className="action-btn"
+            onClick={() => setEquipTarget(activeStack)}
+            style={{ fontSize: 11, padding: '2px 8px' }}
           >
-            SORT {sortOpen ? '▲' : '▼'}
+            Equip to Unit
           </button>
-          {sortOpen && (
-            <div className="filter-popup">
-              {([
-                ['default',    'Default'],
-                ['az',         'A → Z'],
-                ['za',         'Z → A'],
-                ['rarity',     'Rarity'],
-                ['level-desc', 'Level ↓'],
-                ['level-asc',  'Level ↑'],
-                ['slot',       'Slot'],
-              ] as [AugSortKey, string][]).map(([key, label]) => (
-                <button
-                  key={key}
-                  className={`filter-btn filter-btn--sm${sortKey === key ? ' filter-btn--active' : ''}`}
-                  onClick={() => { setSortKey(key); setSortOpen(false) }}
-                >
-                  {label}
-                </button>
-              ))}
-            </div>
-          )}
         </div>
+      ) : (
+        /* Filter bar — only shown when not in drill-down */
+        <div className="filter-bar">
+          <div className="filter-popup-wrap">
+            <button
+              className={`filter-btn${sortKey !== 'default' ? ' filter-btn--active' : ''}`}
+              onClick={() => { setSortOpen(o => !o); setGroupOpen(false) }}
+            >
+              SORT {sortOpen ? '▲' : '▼'}
+            </button>
+            {sortOpen && (
+              <div className="filter-popup">
+                {([
+                  ['default',    'Default'],
+                  ['az',         'A → Z'],
+                  ['za',         'Z → A'],
+                  ['rarity',     'Rarity'],
+                  ['level-desc', 'Level ↓'],
+                  ['level-asc',  'Level ↑'],
+                  ['slot',       'Slot'],
+                ] as [AugSortKey, string][]).map(([key, label]) => (
+                  <button
+                    key={key}
+                    className={`filter-btn filter-btn--sm${sortKey === key ? ' filter-btn--active' : ''}`}
+                    onClick={() => { setSortKey(key); setSortOpen(false) }}
+                  >
+                    {label}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
 
-        {/* GROUP */}
-        <div className="filter-popup-wrap">
-          <button
-            className={`filter-btn${groupKey !== 'none' ? ' filter-btn--active' : ''}`}
-            onClick={() => { setGroupOpen(o => !o); setSortOpen(false) }}
-          >
-            GROUP {groupOpen ? '▲' : '▼'}
-          </button>
-          {groupOpen && (
-            <div className="filter-popup">
-              {([
-                ['none',   'None'],
-                ['slot',   'Slot'],
-                ['set',    'Set'],
-                ['rarity', 'Rarity'],
-                ['status', 'Equipped / Unequipped'],
-              ] as [AugGroupKey, string][]).map(([key, label]) => (
-                <button
-                  key={key}
-                  className={`filter-btn filter-btn--sm${groupKey === key ? ' filter-btn--active' : ''}`}
-                  onClick={() => { setGroupKey(key); setGroupOpen(false) }}
-                >
-                  {label}
-                </button>
-              ))}
-            </div>
-          )}
+          <div className="filter-popup-wrap">
+            <button
+              className={`filter-btn${groupKey !== 'none' ? ' filter-btn--active' : ''}`}
+              onClick={() => { setGroupOpen(o => !o); setSortOpen(false) }}
+            >
+              GROUP {groupOpen ? '▲' : '▼'}
+            </button>
+            {groupOpen && (
+              <div className="filter-popup">
+                {([
+                  ['none',   'None'],
+                  ['slot',   'Slot'],
+                  ['set',    'Set'],
+                  ['rarity', 'Rarity'],
+                  ['status', 'Equipped / Unequipped'],
+                ] as [AugGroupKey, string][]).map(([key, label]) => (
+                  <button
+                    key={key}
+                    className={`filter-btn filter-btn--sm${groupKey === key ? ' filter-btn--active' : ''}`}
+                    onClick={() => { setGroupKey(key); setGroupOpen(false) }}
+                  >
+                    {label}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
         </div>
-      </div>
+      )}
 
       {upgradeError && (
         <div style={{ color: '#ff6666', textAlign: 'center', fontSize: 12, padding: '4px 0' }}>{upgradeError}</div>
@@ -231,38 +465,83 @@ export function AugmentCollectionScreen({ onBack, embedded }: Props) {
           No augments owned yet. Earn augments from packs to equip them to your units.
         </div>
       ) : (
-        <div className="collection-grid u-flex u-wrap u-just-c u-gap-4 u-grow">
-          {groups.map(group => (
-            <React.Fragment key={group.label}>
-              {group.label && (
-                <div className="collection-group-header">{group.label}</div>
-              )}
-              {group.items.map(({ inst, displayCard }) => (
-                <LazyCell key={inst.instanceId} className="collection-cell u-col">
-                  <CardTile
-                    card={displayCard}
-                    onClick={() => setDetailInst({ card: displayCard, inst })}
-                  />
-                  <div className="cell-footer">
-                    <span>Lv{inst.level}</span>
-                    {inst.equippedToCardName && (
-                      <span
-                        title={inst.equippedToCardName}
-                        style={{ cursor: 'pointer', color: '#88ccff' }}
-                        onClick={e => { e.stopPropagation(); setDetailCardName(inst.equippedToCardName!) }}
-                      >↗</span>
-                    )}
-                    <button
-                      className={`action-btn action-btn--gold${currentSouls < AUGMENT_UPGRADE_COST ? ' action-btn--disabled' : ''}`}
-                      onClick={e => { e.stopPropagation(); handleUpgrade(inst) }}
-                      title={`Upgrade · ${AUGMENT_UPGRADE_COST} souls`}
-                      style={{ padding: '1px 6px', fontSize: 11 }}
-                    >↑</button>
-                  </div>
-                </LazyCell>
+        <div className="u-col u-gap-4 u-grow">
+
+          {/* Complete set stacks — only shown when not in drill-down */}
+          {!activeStack && stacks.length > 0 && (
+            <div className="aug-stacks-section">
+              <div className="collection-group-header">Complete Sets ({stacks.length})</div>
+              {stacks.map((stack, i) => (
+                <StackTile
+                  key={`${stack.setName}-${i}`}
+                  stack={stack}
+                  souls={souls}
+                  onView={() => setActiveStack(stack)}
+                  onUpgrade={() => handleUpgradeStack(stack)}
+                  onEquipToUnit={() => setEquipTarget(stack)}
+                  upgradeError={stackErrors[stack.instances[0].instanceId]}
+                />
               ))}
-            </React.Fragment>
-          ))}
+            </div>
+          )}
+
+          {/* Drill-down upgrade bar */}
+          {activeStack && (
+            <div className="aug-stack-drill-upgrade">
+              <span style={{ fontSize: 12, opacity: 0.8 }}>
+                Stack: {stackLevelSummary(activeStack)}
+              </span>
+              <button
+                className={`action-btn action-btn--gold${souls >= stackUpgradeCost(activeStack) ? '' : ' action-btn--disabled'}`}
+                onClick={() => handleUpgradeStack(activeStack)}
+                style={{ fontSize: 11, padding: '2px 8px' }}
+              >
+                ↑ Upgrade Stack · {stackUpgradeCost(activeStack).toLocaleString()} souls
+              </button>
+            </div>
+          )}
+
+          {/* Individuals / drill-down items grid */}
+          {(!activeStack && individuals.length > 0) || activeStack ? (
+            <>
+              {!activeStack && individuals.length > 0 && stacks.length > 0 && (
+                <div className="collection-group-header">Individual Augments ({individuals.length})</div>
+              )}
+              <div className="collection-grid u-flex u-wrap u-just-c u-gap-4">
+                {groups.map(group => (
+                  <React.Fragment key={group.label}>
+                    {group.label && (
+                      <div className="collection-group-header">{group.label}</div>
+                    )}
+                    {group.items.map(({ inst, displayCard }) => (
+                      <LazyCell key={inst.instanceId} className="collection-cell u-col">
+                        <CardTile
+                          card={displayCard}
+                          onClick={() => setDetailInst({ card: displayCard, inst })}
+                        />
+                        <div className="cell-footer">
+                          <span>Lv{inst.level}</span>
+                          {inst.equippedToCardName && (
+                            <span
+                              title={inst.equippedToCardName}
+                              style={{ cursor: 'pointer', color: '#88ccff' }}
+                              onClick={e => { e.stopPropagation(); setDetailCardName(inst.equippedToCardName!) }}
+                            >↗</span>
+                          )}
+                          <button
+                            className={`action-btn action-btn--gold${souls < AUGMENT_UPGRADE_COST ? ' action-btn--disabled' : ''}`}
+                            onClick={e => { e.stopPropagation(); handleUpgrade(inst) }}
+                            title={`Upgrade · ${AUGMENT_UPGRADE_COST} souls`}
+                            style={{ padding: '1px 6px', fontSize: 11 }}
+                          >↑</button>
+                        </div>
+                      </LazyCell>
+                    ))}
+                  </React.Fragment>
+                ))}
+              </div>
+            </>
+          ) : null}
         </div>
       )}
 
@@ -273,9 +552,18 @@ export function AugmentCollectionScreen({ onBack, embedded }: Props) {
           collection={[{ cardName: detailInst.inst.cardId, count: instanceCounts[detailInst.inst.cardId] ?? 1 }]}
           augmentLevel={detailInst.inst.level}
           augmentEquippedTo={detailInst.inst.equippedToCardName}
-          canUpgrade={currentSouls >= AUGMENT_UPGRADE_COST}
+          canUpgrade={souls >= AUGMENT_UPGRADE_COST}
           onUpgrade={() => handleUpgrade(detailInst.inst)}
           onClose={() => setDetailInst(null)}
+        />
+      )}
+
+      {/* Unit picker for equipping a complete set */}
+      {equipTarget && (
+        <UnitPickerModal
+          stack={equipTarget}
+          onEquip={cardName => handleEquipSet(equipTarget, cardName)}
+          onClose={() => setEquipTarget(null)}
         />
       )}
     </>

--- a/web/src/game/collection.ts
+++ b/web/src/game/collection.ts
@@ -334,6 +334,50 @@ export function upgradeAugment(instanceId: string): string | null {
   return null
 }
 
+/** Upgrade a group of augment instances as a stack.
+ *  Finds the minimum level across all instances, upgrades only those at that minimum.
+ *  Cost = (count at minimum level) × AUGMENT_UPGRADE_COST souls.
+ *  Returns null on success, or an error string on failure. */
+export function upgradeAugmentStack(instanceIds: string[]): string | null {
+  const souls = loadAugmentSouls()
+  const instances = loadAugmentInstances()
+  const targets = instanceIds.map(id => instances.find(i => i.instanceId === id)).filter(Boolean) as AugmentInstance[]
+  if (targets.length === 0) return 'No instances found'
+
+  const minLevel = Math.min(...targets.map(t => t.level))
+  const toUpgrade = targets.filter(t => t.level === minLevel)
+  const cost = toUpgrade.length * AUGMENT_UPGRADE_COST
+
+  if (souls < cost) return `Not enough souls (need ${cost.toLocaleString()}, have ${souls.toLocaleString()})`
+
+  for (const t of toUpgrade) t.level += 1
+  saveAugmentInstances(instances)
+  saveAugmentSouls(souls - cost)
+  return null
+}
+
+/** Equip all instances in the given list to a unit card, one per slot.
+ *  Any existing augment in the same slot on that card is unequipped first. */
+export function equipAugmentSet(instanceIds: string[], cardName: string): void {
+  const instances = loadAugmentInstances()
+  const targets = instanceIds.map(id => instances.find(i => i.instanceId === id)).filter(Boolean) as AugmentInstance[]
+
+  for (const target of targets) {
+    const card = getAugmentCard(target.cardId)
+    if (!card?.augmentSlot) continue
+
+    for (const inst of instances) {
+      if (inst.equippedToCardName !== cardName) continue
+      const iCard = getAugmentCard(inst.cardId)
+      if (iCard?.augmentSlot === card.augmentSlot) inst.equippedToCardName = null
+    }
+
+    target.equippedToCardName = cardName
+  }
+
+  saveAugmentInstances(instances)
+}
+
 /** Return the set bonus effect if all 7 slots of the same set are equipped to the given unit.
  *  Returns undefined if the set is incomplete. */
 export function getSetBonus(cardName: string): { setName: string; effect: AugmentEffect; description: string } | undefined {
@@ -740,7 +784,7 @@ function applyAugmentBonuses(card: Card, cardName: string): Card {
   return { ...card, unit: u }
 }
 
-function mergeAugmentEffects(a: AugmentEffect, b: AugmentEffect): AugmentEffect {
+export function mergeAugmentEffects(a: AugmentEffect, b: AugmentEffect): AugmentEffect {
   const sum = (x: number | undefined, y: number | undefined): number | undefined => {
     const total = (x ?? 0) + (y ?? 0)
     return total !== 0 ? total : undefined

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -13876,6 +13876,80 @@ html.light-mode .action-btn {
 .apm-item-actions { flex-shrink: 0; }
 
 /* ── Augment Collection Screen ───────────────────────────────────────────────── */
+
+.aug-stacks-section { display: flex; flex-direction: column; gap: 8px; width: 100%; }
+
+.aug-stack-tile {
+  border: 1px solid #333;
+  border-radius: 6px;
+  padding: 10px 12px;
+  background: rgba(80,50,120,0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.aug-stack-header {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.aug-stack-name   { font-size: var(--font-sm); font-weight: bold; }
+.aug-stack-levels { font-size: var(--font-xxs); color: #aaa; }
+
+.aug-stack-slots {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.aug-stack-slot-chip {
+  font-size: 10px;
+  background: rgba(255,255,255,0.05);
+  border: 1px solid rgba(255,255,255,0.12);
+  border-radius: 3px;
+  padding: 1px 5px;
+}
+
+.aug-stack-upgrade-note {
+  font-size: 11px;
+  color: var(--game-text-color-dim);
+}
+
+.aug-stack-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 2px;
+}
+
+.aug-stack-drill-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 0 4px;
+  border-bottom: 1px solid #2a2a2a;
+  margin-bottom: 4px;
+}
+
+.aug-stack-drill-title {
+  flex: 1;
+  font-weight: bold;
+  font-size: var(--font-sm);
+}
+
+.aug-stack-drill-upgrade {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 6px 8px;
+  background: rgba(255,200,0,0.05);
+  border: 1px solid rgba(255,200,0,0.15);
+  border-radius: 4px;
+}
+
 .aug-list { display: flex; flex-direction: column; gap: 6px; }
 .aug-list-item {
   display: flex;


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Implements the augment stacking UI from issue #1382.

- **Complete-set stacks**: augment instances are grouped into stacks when you own one of each slot (helmet/chest/arms/legs/amulet/ranged weapon/melee weapon) all from the same named set. Multiple complete stacks of the same set are shown separately.
- **Stack tile**: each complete stack is displayed as a card above the individual items grid, showing set name, level range, per-slot level chips, upgrade cost, and two action buttons.
- **Drill-down view**: tapping "View Stack" filters the screen to show only the 7 items in that stack, with a "← Back to All" header and an "Equip to Unit" button.
- **Stack upgrade**: upgrades all items at the minimum level to min+1 in one click. Cost = (count at min level) × 500 souls, displayed on the button.
- **Equip to Unit**: opens a unit picker modal; selecting a unit equips all 7 augments from the stack to that unit in one action.
- **Effective stats in CardAugmentScreen**: after equipping/upgrading, the stat block now shows the post-augment value with a `(+N)` delta for each boosted stat (including set bonus).

## Test plan

- [ ] Open Augments screen with a complete Iron set → single StackTile appears above individuals
- [ ] With 9+ items covering all 7 Iron slots → two StackTiles, remainder as individuals
- [ ] Tap "View Stack" → drill-down shows 7 items, "← Back to All" returns to full view
- [ ] Tap "Upgrade Stack" with enough souls → items at minimum level advance; cost label updates
- [ ] Tap "Upgrade Stack" without enough souls → error message shown
- [ ] Tap "Equip to Unit" → unit picker lists owned unit cards; selecting one equips all 7 slots
- [ ] Open CardAugmentScreen for an equipped unit → stats show base + `(+N)` deltas; set bonus included if full set active
- [ ] Augments without a complete set (missing any slot) still show as individual items

https://claude.ai/code/session_017PQ2k3dmuNct72a7kQzX6u
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_017PQ2k3dmuNct72a7kQzX6u)_