### PR TITLE
feat(tiles): add background and decor tile layers to NodeMap

### DIFF
--- a/web/src/components/campaign/NodeMap.tsx
+++ b/web/src/components/campaign/NodeMap.tsx
@@ -177,7 +177,8 @@ function getTerrainItems(env: string | undefined, seed: number, w: number, h: nu
 // Rivers go into groundLayer; all other items go into worldLayer for Y-sorting.
 
 function buildTerrainGfx(
-  groundLayer: PIXI.Container,
+  baseContainer: PIXI.Container,
+  riverContainer: PIXI.Container,
   worldLayer: PIXI.Container,
   act: Act,
   mapWidth: number,
@@ -190,7 +191,7 @@ function buildTerrainGfx(
   const groundTileId = ENV_TILES[environment ?? '']?.ground ?? BASE_GROUND.mediumGrass
   const tileUrl = `${base}${TILESET_IMAGE.baseChip.slice(1)}`
   loadTileTexture(tileUrl, groundTileId, TILESET_COLUMNS.baseChip).then(groundTex => {
-    if (groundLayer.destroyed) return
+    if (baseContainer.destroyed) return
     const tileCols = Math.ceil(mapWidth / 32)
     const tileRows = Math.ceil(mapHeight / 32)
     const bg = new PIXI.Container()
@@ -201,7 +202,7 @@ function buildTerrainGfx(
         bg.addChild(s)
       }
     }
-    groundLayer.addChildAt(bg, 0)
+    baseContainer.addChild(bg)
   }).catch(e => console.error('[NodeMap] ground tile load failed', tileUrl, e))
 
   const seed = terrainSeed ?? hashStr(act.id)
@@ -239,7 +240,7 @@ function buildTerrainGfx(
       .stroke({ color: riverLight, width: 7, alpha: 0.55, cap: 'round' })
     g.moveTo(x1, y1).bezierCurveTo(cx1, cy1, cx2, cy2, x2, y2)
       .stroke({ color: 0xffffff, width: 2, alpha: 0.38, cap: 'round' })
-    groundLayer.addChild(g)
+    riverContainer.addChild(g)
   }
 
   const terrainItems = items.filter(i => i.kind !== 'river')
@@ -253,13 +254,68 @@ function buildTerrainGfx(
   }
 }
 
+// ── Background tile layer ─────────────────────────────────────────────────────
+// Tiles the fully-filled variant of the pathFile across the whole map, giving
+// a rich textured fill that shows behind the path-transition edges.
+async function buildBgTileGfx(
+  container: PIXI.Container,
+  act: Act,
+  mapWidth: number,
+  mapHeight: number,
+): Promise<void> {
+  const def = ENV_TILES[act.environment ?? '']
+  if (def?.bgTileId === undefined) return
+  const base = (import.meta as { env: { BASE_URL: string } }).env.BASE_URL
+  const tileUrl = `${base}${def.pathFile.slice(1)}`
+  const tex = await loadTileTexture(tileUrl, def.bgTileId, 8)
+  if (container.destroyed) return
+  const cols = Math.ceil(mapWidth / TILE_SIZE)
+  const rows = Math.ceil(mapHeight / TILE_SIZE)
+  for (let r = 0; r < rows; r++) {
+    for (let c = 0; c < cols; c++) {
+      const s = new PIXI.Sprite(tex)
+      s.position.set(c * TILE_SIZE, r * TILE_SIZE)
+      container.addChild(s)
+    }
+  }
+}
+
+// ── Decor tile layer ──────────────────────────────────────────────────────────
+// Scatters tiles from the environment's decorFile across the map at ~15% density.
+async function buildDecorGfx(
+  container: PIXI.Container,
+  act: Act,
+  mapWidth: number,
+  mapHeight: number,
+): Promise<void> {
+  const def = ENV_TILES[act.environment ?? '']
+  if (!def?.decorFile || !def.decorTileIds?.length) return
+  const base = (import.meta as { env: { BASE_URL: string } }).env.BASE_URL
+  const tileUrl = `${base}${def.decorFile.slice(1)}`
+  const tileIds = def.decorTileIds
+  const rand = seededRand(hashStr(act.id + 'decor'))
+  const cols = Math.ceil(mapWidth / TILE_SIZE)
+  const rows = Math.ceil(mapHeight / TILE_SIZE)
+  for (let r = 0; r < rows; r++) {
+    for (let c = 0; c < cols; c++) {
+      if (rand() > 0.15) continue
+      const tileId = tileIds[Math.floor(rand() * tileIds.length)]
+      const tex = await loadTileTexture(tileUrl, tileId, 8)
+      if (container.destroyed) return
+      const s = new PIXI.Sprite(tex)
+      s.position.set(c * TILE_SIZE, r * TILE_SIZE)
+      container.addChild(s)
+    }
+  }
+}
+
 // ── Path tile renderer ────────────────────────────────────────────────────────
 // Lays PATH tiles from [A]Grass_pipo along each connector route.
 // Routes are L-shaped (horizontal → vertical → horizontal) snapped to the 32px
 // tile grid; neighbors are checked to pick the right PATH variant at each cell.
 
 async function buildPathTileGfx(
-  groundLayer: PIXI.Container,
+  container: PIXI.Container,
   act: Act,
   rows: QuestNode[][],
   maxRowCols: number,
@@ -371,11 +427,11 @@ async function buildPathTileGfx(
   await Promise.all(
     Array.from(byVariant.entries()).map(async ([v, tiles]) => {
       const tex = await loadTileTexture(tileUrl, v, 8)
-      if (groundLayer.destroyed) return
+      if (container.destroyed) return
       for (const { tx, ty } of tiles) {
         const s = new PIXI.Sprite(tex)
         s.position.set(tx * T, ty * T)
-        groundLayer.addChild(s)
+        container.addChild(s)
       }
     })
   )
@@ -893,10 +949,21 @@ export function NodeMap({ act, run, onSelectNode, onUseConsumable, onBack, user 
     worldRef.current  = worldLayer
     nodeLRef.current  = nodeLayer
 
-    // Terrain + path tiles (both fire-and-forget async)
-    buildTerrainGfx(groundLayer, worldLayer, act, mapWidth, mapHeight)
-    buildPathTileGfx(groundLayer, act, rows, maxRowCols, mapHeight)
+    // Sub-containers within groundLayer — z-order: base → bg → rivers → path → decor
+    const baseContainer  = new PIXI.Container()
+    const bgContainer    = new PIXI.Container()
+    const riverContainer = new PIXI.Container()
+    const pathContainer  = new PIXI.Container()
+    const decorContainer = new PIXI.Container()
+    groundLayer.addChild(baseContainer, bgContainer, riverContainer, pathContainer, decorContainer)
+
+    buildTerrainGfx(baseContainer, riverContainer, worldLayer, act, mapWidth, mapHeight)
+    buildBgTileGfx(bgContainer, act, mapWidth, mapHeight)
+      .catch(e => console.error('[NodeMap] bg tiles failed', e))
+    buildPathTileGfx(pathContainer, act, rows, maxRowCols, mapHeight)
       .catch(e => console.error('[NodeMap] path tiles failed', e))
+    buildDecorGfx(decorContainer, act, mapWidth, mapHeight)
+      .catch(e => console.error('[NodeMap] decor tiles failed', e))
 
     // Campfire at start position
     try {

--- a/web/src/data/tiles/tileIndex.ts
+++ b/web/src/data/tiles/tileIndex.ts
@@ -86,6 +86,8 @@ export const PATH_TILE = {
   water5:       '/world/[A]_type3/[A]Water5_pipo.png',
   water6:       '/world/[A]_type3/[A]Water6_pipo.png',
   water7:       '/world/[A]_type3/[A]Water7_pipo.png',
+  flower1:      '/world/[A]_type3/[A]Flower_pipo.png',
+  longGrass:    '/world/[A]_type3/[A]LongGrass_pipo.png',
 } as const
 
 // ── Tileset image paths (relative to /public) ─────────────────────────────────
@@ -122,18 +124,26 @@ export function tileFrame(id: number, cols: number): { x: number; y: number; w: 
   }
 }
 
-// ── Per-environment defaults ───────────────────────────────────────────────────
-export const ENV_TILES: Record<string, { ground: number; pathFile: string }> = {
-  forest:   { ground: BASE_GROUND.lightGrass, pathFile: PATH_TILE.grass1Dirt1  },
+// ── Per-environment tile config ───────────────────────────────────────────────
+export interface EnvTileDef {
+  ground: number          // BaseChip tile id — solid colour fallback fill
+  pathFile: string        // per-combination 8-col transition sheet
+  bgTileId?: number       // tile in pathFile to repeat as textured background fill
+  decorFile?: string      // decor scatter sheet (same 8-col format)
+  decorTileIds?: number[] // tile ids to randomly scatter as decor
+}
+
+export const ENV_TILES: Record<string, EnvTileDef> = {
+  forest:   { ground: BASE_GROUND.lightGrass,  pathFile: PATH_TILE.grass1Dirt1,  decorFile: PATH_TILE.flower1,  decorTileIds: [PATH.allSidesNoGrass] },
   farmland: { ground: BASE_GROUND.mediumGrass, pathFile: PATH_TILE.grass1Dirt1  },
   ruins:    { ground: BASE_GROUND.darkGrass,   pathFile: PATH_TILE.grass1Grass3 },
   ashen:    { ground: BASE_GROUND.dyingGrass,  pathFile: PATH_TILE.grass1Grass4 },
   sand:     { ground: BASE_GROUND.sand,        pathFile: PATH_TILE.grass1Dirt2  },
   frost:    { ground: BASE_GROUND.lightGrass,  pathFile: PATH_TILE.grass1Grass2 },
   volcano:  { ground: BASE_GROUND.darkDirt,    pathFile: PATH_TILE.dirt4        },
-  citadel:  { ground: BASE_GROUND.darkGrass,   pathFile: PATH_TILE.wall2 },
-  coast:    { ground: BASE_GROUND.sand,        pathFile: PATH_TILE.water2       },
-  reef:     { ground: BASE_GROUND.sand,        pathFile: PATH_TILE.water1       },
+  citadel:  { ground: BASE_GROUND.darkGrass,   pathFile: PATH_TILE.wall2        },
+  coast:    { ground: BASE_GROUND.sand,        pathFile: PATH_TILE.water2,       bgTileId: PATH.allSidesNoGrass },
+  reef:     { ground: BASE_GROUND.sand,        pathFile: PATH_TILE.water1,       bgTileId: PATH.allSidesNoGrass },
   sky:      { ground: BASE_GROUND.lightGrass,  pathFile: PATH_TILE.grass1Grass2 },
   fungal:   { ground: BASE_GROUND.darkGrass,   pathFile: PATH_TILE.grass1Grass3 },
   vault:    { ground: BASE_GROUND.darkGrass,   pathFile: PATH_TILE.wall1        },


### PR DESCRIPTION
## Summary

- Splits the single `groundLayer` container into 5 ordered sub-containers: `base → bg → river → path → decor`
- Adds `buildBgTileGfx` — tiles the fully-filled variant of an env's `pathFile` across the whole map as a textured background behind the transition edges
- Adds `buildDecorGfx` — seeded-random scatter (~15% density) of tiles from an env's `decorFile`
- Extends `EnvTileDef` in `tileIndex.ts` with optional `bgTileId`, `decorFile`, `decorTileIds`
- **reef / coast** → `bgTileId: PATH.allSidesNoGrass` (solid water tile fills the background)
- **forest** → `decorFile: flower1`, `decorTileIds: [PATH.allSidesNoGrass]` (flower patches scattered across the map)
- Adds `flower1` and `longGrass` to `PATH_TILE` for use as decor sources

## Test plan

- [ ] Open act V (reef) in the campaign map — background should now show the textured water tile rather than the plain sand BaseChip fill
- [ ] Open act I (forest) — flower patches should be scattered lightly across the terrain
- [ ] Verify path transition tiles still render correctly on top of the new background layer
- [ ] Check that rivers (volcano, fungal, etc.) still draw above the background layer
- [ ] Other environments (volcano, ruins, etc.) should be unchanged

https://claude.ai/code/session_01VfPqhNQoRRARbL6Q9kBiHz

---
_Generated by [Claude Code](https://claude.ai/code/session_01VfPqhNQoRRARbL6Q9kBiHz)_