### PR TITLE
feat(tiles): 3-wide canal paths for reef/coast environments

### DIFF
--- a/web/src/components/campaign/NodeMap.tsx
+++ b/web/src/components/campaign/NodeMap.tsx
@@ -392,12 +392,29 @@ async function buildPathTileGfx(
     }
   }
 
+  // Expand pathSet perpendicular to path direction for wide paths (e.g. canals)
+  const pathWidth = ENV_TILES[act.environment ?? '']?.pathWidth ?? 1
+  if (pathWidth > 1) {
+    const half = Math.floor(pathWidth / 2)
+    const original = new Set(pathSet)
+    const extra = new Set<string>()
+    for (const k of original) {
+      const [tx, ty] = k.split(',').map(Number)
+      const hasH = original.has(key(tx + 1, ty)) || original.has(key(tx - 1, ty))
+      const hasV = original.has(key(tx, ty + 1)) || original.has(key(tx, ty - 1))
+      if (hasH) for (let d = 1; d <= half; d++) { extra.add(key(tx, ty - d)); extra.add(key(tx, ty + d)) }
+      if (hasV) for (let d = 1; d <= half; d++) { extra.add(key(tx - d, ty)); extra.add(key(tx + d, ty)) }
+    }
+    for (const k of extra) pathSet.add(k)
+  }
+  const noGrass = pathWidth > 1
+
   // Pick the correct PATH variant for each cell based on which neighbors are also path
   const has = (tx: number, ty: number) => pathSet.has(key(tx, ty))
   const variant = (tx: number, ty: number): number => {
     const N = has(tx, ty - 1), S = has(tx, ty + 1)
     const E = has(tx + 1, ty), W = has(tx - 1, ty)
-    if ( N &&  S &&  E &&  W) return PATH.allSides
+    if ( N &&  S &&  E &&  W) return noGrass ? PATH.allSidesNoGrass : PATH.allSides
     if ( N &&  S &&  E && !W) return PATH.tJuncRight
     if ( N &&  S && !E &&  W) return PATH.tJuncLeft2
     if ( N && !S &&  E &&  W) return PATH.tJuncBottom

--- a/web/src/data/tiles/tileIndex.ts
+++ b/web/src/data/tiles/tileIndex.ts
@@ -129,6 +129,7 @@ export interface EnvTileDef {
   ground: number          // BaseChip tile id — solid colour fallback fill
   pathFile: string        // per-combination 8-col transition sheet
   bgTileId?: number       // tile in pathFile to repeat as textured background fill
+  pathWidth?: number      // path tile width (odd; default 1); >1 expands perpendicular to path direction
   decorFile?: string      // decor scatter sheet (same 8-col format)
   decorTileIds?: number[] // tile ids to randomly scatter as decor
 }
@@ -142,8 +143,8 @@ export const ENV_TILES: Record<string, EnvTileDef> = {
   frost:    { ground: BASE_GROUND.lightGrass,  pathFile: PATH_TILE.grass1Grass2 },
   volcano:  { ground: BASE_GROUND.darkDirt,    pathFile: PATH_TILE.dirt4        },
   citadel:  { ground: BASE_GROUND.darkGrass,   pathFile: PATH_TILE.wall2        },
-  coast:    { ground: BASE_GROUND.sand,        pathFile: PATH_TILE.water2,       bgTileId: PATH.allSidesNoGrass },
-  reef:     { ground: BASE_GROUND.sand,        pathFile: PATH_TILE.water1,       bgTileId: PATH.allSidesNoGrass },
+  coast:    { ground: BASE_GROUND.sand,        pathFile: PATH_TILE.water2,       pathWidth: 3 },
+  reef:     { ground: BASE_GROUND.sand,        pathFile: PATH_TILE.water1,       pathWidth: 3 },
   sky:      { ground: BASE_GROUND.lightGrass,  pathFile: PATH_TILE.grass1Grass2 },
   fungal:   { ground: BASE_GROUND.darkGrass,   pathFile: PATH_TILE.grass1Grass3 },
   vault:    { ground: BASE_GROUND.darkGrass,   pathFile: PATH_TILE.wall1        },


### PR DESCRIPTION
## Summary

- Adds `pathWidth` to `EnvTileDef` (odd integer, default 1)
- `reef` and `coast` set `pathWidth: 3` — paths expand to 3 tiles wide, reading as water canals over a sand background
- Removes `bgTileId` from reef/coast (sand BaseChip fill is the background; the canal effect comes from the path tiles alone)
- In `buildPathTileGfx`: after the 1-tile-wide `pathSet` is built, each cell is expanded ±1 tile perpendicular to its path direction (horizontal cells expand N/S, vertical cells expand E/W). The expansion uses a snapshot of the original set so direction detection is clean
- `variant()` uses `PATH.allSidesNoGrass` (14) instead of `PATH.allSides` (46) for fully-surrounded interior cells when `pathWidth > 1`, preventing land-corner artefacts inside the canal

## How the canal edge tiles work

The existing `variant()` closure naturally picks the right border tiles once the extra rows are in `pathSet`:

| Row | Example position | Neighbours → tile |
|-----|-----------------|-------------------|
| ty-1 | top-left end | S+E → `turnBottomRight` |
| ty-1 | top middle | S+E+W → `edgeTop` (land border on north) |
| ty | centre | N+S+E+W → `allSidesNoGrass` (full water) |
| ty+1 | bottom middle | N+E+W → `edgeBottom` (land border on south) |
| ty+1 | bottom-right end | N+W → `turnTopLeft` |

L-bend corners expand in both dimensions, producing a wider rounded corner.

## Test plan

- [ ] Open act V (reef environment) — paths should be 3 tiles wide with land-edge borders top and bottom, background is sand
- [ ] Straight horizontal segments show `edgeTop` / `edgeBottom` border rows flanking a solid-water centre
- [ ] L-bend corners produce a wider smooth turn
- [ ] Act I (forest) paths are unchanged — still 1 tile wide

https://claude.ai/code/session_01VfPqhNQoRRARbL6Q9kBiHz

---
_Generated by [Claude Code](https://claude.ai/code/session_01VfPqhNQoRRARbL6Q9kBiHz)_