### PR TITLE
fix(tiles): fill diagonal corner cells at canal bends

### DIFF
--- a/web/src/components/campaign/NodeMap.tsx
+++ b/web/src/components/campaign/NodeMap.tsx
@@ -404,6 +404,10 @@ async function buildPathTileGfx(
       const hasV = original.has(key(tx, ty + 1)) || original.has(key(tx, ty - 1))
       if (hasH) for (let d = 1; d <= half; d++) { extra.add(key(tx, ty - d)); extra.add(key(tx, ty + d)) }
       if (hasV) for (let d = 1; d <= half; d++) { extra.add(key(tx - d, ty)); extra.add(key(tx + d, ty)) }
+      if (hasH && hasV) for (let dx = 1; dx <= half; dx++) for (let dy = 1; dy <= half; dy++) {
+        extra.add(key(tx + dx, ty + dy)); extra.add(key(tx + dx, ty - dy))
+        extra.add(key(tx - dx, ty + dy)); extra.add(key(tx - dx, ty - dy))
+      }
     }
     for (const k of extra) pathSet.add(k)
   }


### PR DESCRIPTION
## Problem

At canal bends, the expansion logic added perpendicular cells independently per direction:
- Horizontal cells → expand N/S
- Vertical cells → expand E/W

This left the diagonal corner cells (e.g. the tile NE of a turn) unpopulated, producing a staircase step at every bend instead of a smooth rectangular corner.

## Fix

When a cell has **both** horizontal and vertical neighbours (a turn/junction), also add the 4 diagonal corner cells. For `half=1` (width=3) this fills a 3×3 block at every bend rather than a `+` shape.

```
Before (+ shape):   After (filled block):
  .X.                 XXX
  XXX                 XXX
  .X.                 XXX
```

## Test plan

- [ ] Open act V (reef) — canal bends should now have smooth rectangular corners with no staircase steps
- [ ] Straight canal segments unchanged
- [ ] Other environments (non-wide paths) unaffected

https://claude.ai/code/session_01VfPqhNQoRRARbL6Q9kBiHz

---
_Generated by [Claude Code](https://claude.ai/code/session_01VfPqhNQoRRARbL6Q9kBiHz)_