### PR TITLE
fix(tiles): use edge/quad tiles for canal outer rows

### DIFF
--- a/web/src/components/campaign/NodeMap.tsx
+++ b/web/src/components/campaign/NodeMap.tsx
@@ -394,14 +394,14 @@ async function buildPathTileGfx(
 
   // Expand pathSet perpendicular to path direction for wide paths (e.g. canals)
   const pathWidth = ENV_TILES[act.environment ?? '']?.pathWidth ?? 1
+  const originalPath = new Set(pathSet)
   if (pathWidth > 1) {
     const half = Math.floor(pathWidth / 2)
-    const original = new Set(pathSet)
     const extra = new Set<string>()
-    for (const k of original) {
+    for (const k of originalPath) {
       const [tx, ty] = k.split(',').map(Number)
-      const hasH = original.has(key(tx + 1, ty)) || original.has(key(tx - 1, ty))
-      const hasV = original.has(key(tx, ty + 1)) || original.has(key(tx, ty - 1))
+      const hasH = originalPath.has(key(tx + 1, ty)) || originalPath.has(key(tx - 1, ty))
+      const hasV = originalPath.has(key(tx, ty + 1)) || originalPath.has(key(tx, ty - 1))
       if (hasH) for (let d = 1; d <= half; d++) { extra.add(key(tx, ty - d)); extra.add(key(tx, ty + d)) }
       if (hasV) for (let d = 1; d <= half; d++) { extra.add(key(tx - d, ty)); extra.add(key(tx + d, ty)) }
       if (hasH && hasV) for (let dx = 1; dx <= half; dx++) for (let dy = 1; dy <= half; dy++) {
@@ -435,12 +435,34 @@ async function buildPathTileGfx(
     if (!N &&  S && !E && !W) return PATH.bottomOnly
     return PATH.isolated
   }
+  // Edge variant: used for expanded cells — swaps turn/tJunc tiles for the
+  // edge-border and quad-corner tiles that suit canal outer rows.
+  const edgeVariant = (tx: number, ty: number): number => {
+    const N = has(tx, ty - 1), S = has(tx, ty + 1)
+    const E = has(tx + 1, ty), W = has(tx - 1, ty)
+    if ( N &&  S &&  E &&  W) return PATH.allSidesNoGrass
+    if ( N &&  S &&  E && !W) return PATH.tJuncRight
+    if ( N &&  S && !E &&  W) return PATH.tJuncLeft2
+    if ( N && !S &&  E &&  W) return PATH.edgeBottom
+    if (!N &&  S &&  E &&  W) return PATH.edgeTop
+    if ( N &&  S && !E && !W) return PATH.vertical
+    if (!N && !S &&  E &&  W) return PATH.horizontal
+    if ( N && !S &&  E && !W) return PATH.quadTopRight
+    if ( N && !S && !E &&  W) return PATH.quadTopLeft
+    if (!N &&  S &&  E && !W) return PATH.quadBottomRight
+    if (!N &&  S && !E &&  W) return PATH.quadBottomLeft
+    if (!N && !S &&  E && !W) return PATH.rightOnly
+    if (!N && !S && !E &&  W) return PATH.leftOnly
+    if ( N && !S && !E && !W) return PATH.topOnly
+    if (!N &&  S && !E && !W) return PATH.bottomOnly
+    return PATH.isolated
+  }
 
   // Group cells by variant to batch the texture loads
   const byVariant = new Map<number, Array<{ tx: number; ty: number }>>()
   for (const k of pathSet) {
     const [tx, ty] = k.split(',').map(Number)
-    const v = variant(tx, ty)
+    const v = (noGrass && !originalPath.has(k)) ? edgeVariant(tx, ty) : variant(tx, ty)
     if (!byVariant.has(v)) byVariant.set(v, [])
     byVariant.get(v)!.push({ tx, ty })
   }

--- a/web/src/components/campaign/NodeMap.tsx
+++ b/web/src/components/campaign/NodeMap.tsx
@@ -404,6 +404,10 @@ async function buildPathTileGfx(
       const hasV = original.has(key(tx, ty + 1)) || original.has(key(tx, ty - 1))
       if (hasH) for (let d = 1; d <= half; d++) { extra.add(key(tx, ty - d)); extra.add(key(tx, ty + d)) }
       if (hasV) for (let d = 1; d <= half; d++) { extra.add(key(tx - d, ty)); extra.add(key(tx + d, ty)) }
+      if (hasH && hasV) for (let dx = 1; dx <= half; dx++) for (let dy = 1; dy <= half; dy++) {
+        extra.add(key(tx + dx, ty + dy)); extra.add(key(tx + dx, ty - dy))
+        extra.add(key(tx - dx, ty + dy)); extra.add(key(tx - dx, ty - dy))
+      }
     }
     for (const k of extra) pathSet.add(k)
   }

--- a/web/src/components/campaign/NodeMap.tsx
+++ b/web/src/components/campaign/NodeMap.tsx
@@ -447,10 +447,10 @@ async function buildPathTileGfx(
     if (!N &&  S &&  E &&  W) return PATH.edgeTop
     if ( N &&  S && !E && !W) return PATH.vertical
     if (!N && !S &&  E &&  W) return PATH.horizontal
-    if ( N && !S &&  E && !W) return PATH.quadTopRight
-    if ( N && !S && !E &&  W) return PATH.quadTopLeft
-    if (!N &&  S &&  E && !W) return PATH.quadBottomRight
-    if (!N &&  S && !E &&  W) return PATH.quadBottomLeft
+    if ( N && !S &&  E && !W) return PATH.grassCornerBL
+    if ( N && !S && !E &&  W) return PATH.grassCornerBR
+    if (!N &&  S &&  E && !W) return PATH.grassCornerTL
+    if (!N &&  S && !E &&  W) return PATH.grassCornerTR
     if (!N && !S &&  E && !W) return PATH.rightOnly
     if (!N && !S && !E &&  W) return PATH.leftOnly
     if ( N && !S && !E && !W) return PATH.topOnly

--- a/web/src/data/tiles/tileIndex.ts
+++ b/web/src/data/tiles/tileIndex.ts
@@ -46,6 +46,11 @@ export const PATH = {
   edgeBottom:       22,  // l + t + r  (grass border along bottom edge)
   quadTopLeft:      23,  // l + t  (grass bottom + right)
   allSides:         46,  // l + r + t + b (with grass corners — use near grass)
+  // Tiles 24–45: corner-grass variations (mostly filled, grass only in one corner)
+  grassCornerBR:    28,  // grass bottom-right corner
+  grassCornerBL:    29,  // grass bottom-left corner
+  grassCornerTR:    36,  // grass top-right corner
+  grassCornerTL:    37,  // grass top-left corner
 } as const
 
 // ── [A]Grass_pipo — path set base tile IDs (SampleMap big sheet, used by TileBrowser) ──


### PR DESCRIPTION
## Problem

The `variant()` function has ambiguous exit-pattern mappings. For example `l+b+r` (no north neighbour) maps to `tJuncTop` (11), but `edgeTop` (6) has identical exits and is the correct tile for a canal top edge. Similarly all four `turn*` tiles share exits with their `quad*` counterparts.

The previous implementation always picked `tJunc*`/`turn*` tiles for the expanded canal rows, so the outer edges looked like road junctions rather than water-to-land borders.

## Fix

- Hoist `originalPath` snapshot before expansion so it's available during variant selection
- Add `edgeVariant()` closure — identical to `variant()` except it maps the 6 affected patterns to the correct border/corner tiles:

| Exit pattern | `variant()` | `edgeVariant()` |
|---|---|---|
| `!N S E W` | `tJuncTop` (11) | `edgeTop` (6) |
| `N !S E W` | `tJuncBottom` (18) | `edgeBottom` (22) |
| `!N S E !W` | `turnBottomRight` (8) | `quadBottomRight` (5) |
| `!N S !E W` | `turnBottomLeft` (9) | `quadBottomLeft` (7) |
| `N !S E !W` | `turnTopRight` (16) | `quadTopRight` (21) |
| `N !S !E W` | `turnTopLeft` (17) | `quadTopLeft` (23) |

- Expanded cells (`!originalPath.has(k)`) use `edgeVariant`; original path cells use `variant` unchanged

## Test plan

- [ ] Act V (reef) — top and bottom canal rows should show the decorative land-border edge tiles, not T-junction tiles
- [ ] Canal corners should show quarter-circle quad tiles, not curved road turns
- [ ] Original 1-tile-wide paths (all other environments) are unaffected

https://claude.ai/code/session_01VfPqhNQoRRARbL6Q9kBiHz

---
_Generated by [Claude Code](https://claude.ai/code/session_01VfPqhNQoRRARbL6Q9kBiHz)_