### PR TITLE
Fix canal corner tiles: turn when diagonal is water, grassCorner when not

### DIFF
--- a/web/src/components/campaign/NodeMap.tsx
+++ b/web/src/components/campaign/NodeMap.tsx
@@ -212,10 +212,10 @@ function buildTileLookup(canal: boolean): number[] {
     else if (N && E && W)        t[mask] = canal ? PATH.edgeBottom : PATH.tJuncBottom
     else if (N && S)             t[mask] = PATH.vertical
     else if (E && W)             t[mask] = PATH.horizontal
-    else if (N && E)             t[mask] = canal ? PATH.grassCornerBL : PATH.turnTopRight
-    else if (N && W)             t[mask] = canal ? PATH.grassCornerBR : PATH.turnTopLeft
-    else if (S && E)             t[mask] = canal ? PATH.grassCornerTL : PATH.turnBottomRight
-    else if (S && W)             t[mask] = canal ? PATH.grassCornerTR : PATH.turnBottomLeft
+    else if (N && E)             t[mask] = canal ? (NE ? PATH.turnTopRight    : PATH.grassCornerBL) : PATH.turnTopRight
+    else if (N && W)             t[mask] = canal ? (NW ? PATH.turnTopLeft     : PATH.grassCornerBR) : PATH.turnTopLeft
+    else if (S && E)             t[mask] = canal ? (SE ? PATH.turnBottomRight : PATH.grassCornerTL) : PATH.turnBottomRight
+    else if (S && W)             t[mask] = canal ? (SW ? PATH.turnBottomLeft  : PATH.grassCornerTR) : PATH.turnBottomLeft
     else if (N)                  t[mask] = PATH.topOnly
     else if (E)                  t[mask] = PATH.rightOnly
     else if (S)                  t[mask] = PATH.bottomOnly


### PR DESCRIPTION
## Summary

- For 2-adjacent cardinal cases in canal mode, the inner diagonal now determines which tile is used
- Inner diagonal = water → turn tile (`turnBottomLeft` etc.) — the canal curves through this cell
- Inner diagonal = land → grassCorner tile — end of an arm where two land sides meet

## Example

Cell with S+W+SW (water to south, west, and SW diagonal): previously got `grassCornerTR`, now correctly gets `turnBottomLeft` which shows the water curving from the W arm into the S arm.

## Test plan

- [ ] Open Act V (reef/coast) and confirm canal bends show smooth curved turns at outer corners
- [ ] Confirm straight canal arm ends (where inner diagonal is land) still show grassCorner tiles

https://claude.ai/code/session_01VfPqhNQoRRARbL6Q9kBiHz

---
_Generated by [Claude Code](https://claude.ai/code/session_01VfPqhNQoRRARbL6Q9kBiHz)_