### PR TITLE
Fix forest flower decor using wrong tile ID

### DIFF
--- a/web/src/data/tiles/tileIndex.ts
+++ b/web/src/data/tiles/tileIndex.ts
@@ -140,7 +140,7 @@ export interface EnvTileDef {
 }
 
 export const ENV_TILES: Record<string, EnvTileDef> = {
-  forest:   { ground: BASE_GROUND.lightGrass,  pathFile: PATH_TILE.grass1Dirt1,  decorFile: PATH_TILE.flower1,  decorTileIds: [PATH.allSidesNoGrass] },
+  forest:   { ground: BASE_GROUND.lightGrass,  pathFile: PATH_TILE.grass1Dirt1,  decorFile: PATH_TILE.flower1,  decorTileIds: [PATH.isolated] },
   farmland: { ground: BASE_GROUND.mediumGrass, pathFile: PATH_TILE.grass1Dirt1  },
   ruins:    { ground: BASE_GROUND.darkGrass,   pathFile: PATH_TILE.grass1Grass3 },
   ashen:    { ground: BASE_GROUND.dyingGrass,  pathFile: PATH_TILE.grass1Grass4 },


### PR DESCRIPTION
## Summary

- `decorTileIds` for the forest environment was set to `[PATH.allSidesNoGrass]` (tile 14) instead of `[PATH.isolated]` (tile 0)
- Tile 14 is a fully-connected path fill tile; tile 0 is the standalone isolated sprite — the correct choice for scattered flower decor

https://claude.ai/code/session_01VfPqhNQoRRARbL6Q9kBiHz

---
_Generated by [Claude Code](https://claude.ai/code/session_01VfPqhNQoRRARbL6Q9kBiHz)_