### PR TITLE
Hub World: town map layout — streets, buildings, named areas (#1402)

### DIFF
--- a/web/src/components/hub/AreaNameBadge.stories.tsx
+++ b/web/src/components/hub/AreaNameBadge.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { AreaNameBadge } from './AreaNameBadge'
+
+const meta = {
+  component: AreaNameBadge,
+  decorators: [
+    (Story) => (
+      <div style={{ position: 'relative', width: 400, height: 200, background: '#1a2a1a' }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof AreaNameBadge>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Visible: Story = {
+  args: { name: 'The Courtyard' },
+}
+
+export const Hidden: Story = {
+  args: { name: null },
+}
+
+export const LongName: Story = {
+  args: { name: "The Fisherman's Dock" },
+}

--- a/web/src/components/hub/AreaNameBadge.tsx
+++ b/web/src/components/hub/AreaNameBadge.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+
+interface Props {
+  name: string | null
+}
+
+export function AreaNameBadge({ name }: Props) {
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        bottom: 16,
+        right: 20,
+        pointerEvents: 'none',
+        opacity: name ? 1 : 0,
+        transition: 'opacity 0.35s ease',
+        textAlign: 'right',
+      }}
+    >
+      <div style={{
+        fontSize: 11,
+        letterSpacing: '0.15em',
+        color: 'rgba(200,220,200,0.6)',
+        textTransform: 'uppercase',
+        marginBottom: 2,
+      }}>
+        area
+      </div>
+      <div style={{
+        fontSize: 16,
+        letterSpacing: '0.08em',
+        color: '#d4ead4',
+        textShadow: '0 0 8px rgba(100,200,100,0.6)',
+        textTransform: 'uppercase',
+      }}>
+        {name ?? ''}
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/hub/HubTownCanvas.stories.tsx
+++ b/web/src/components/hub/HubTownCanvas.stories.tsx
@@ -1,0 +1,16 @@
+import { fn } from 'storybook/test'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { HubTownCanvas } from './HubTownCanvas'
+
+const meta = {
+  component: HubTownCanvas,
+} satisfies Meta<typeof HubTownCanvas>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    onAreaEnter: fn(),
+  },
+}

--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -1,0 +1,110 @@
+import React, { useRef } from 'react'
+import * as PIXI from 'pixi.js'
+import { usePixiApp } from '../../hooks/usePixiApp'
+import { buildTerrainGfx, buildBgTileGfx, buildDecorGfx } from '../../utils/terrainLayer'
+import { renderPathTiles } from '../../utils/tileLookup'
+import {
+  MAP_W, MAP_H,
+  HUB_AREAS,
+  HUB_BUILDINGS,
+  HUB_INTERACTION_POINTS,
+  HUB_STREET_TILES,
+} from '../../data/hubLayout'
+
+const HUB_ENV = 'camp'
+
+// Building fill colour — dark stone, slightly warm
+const BUILDING_COLOR  = 0x1a1810
+const BUILDING_BORDER = 0x4a4030
+// Interaction-point ellipse colours (matches NodeMap node style)
+const MARKER_FILL     = 0x2a3a2a
+const MARKER_STROKE   = 0x88cc88
+const MARKER_GLOW     = 0x44aa44
+
+interface Props {
+  onAreaEnter: (areaName: string | null) => void
+}
+
+export function HubTownCanvas({ onAreaEnter }: Props) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const onAreaRef    = useRef(onAreaEnter)
+  onAreaRef.current  = onAreaEnter
+
+  usePixiApp(containerRef, MAP_W, MAP_H, (app) => {
+    app.canvas.style.touchAction = 'pan-x pan-y'
+
+    // ── Layer hierarchy ────────────────────────────────────────────────────────
+    const groundLayer  = new PIXI.Container()
+    const streetLayer  = new PIXI.Container()
+    const buildingLayer = new PIXI.Container()
+    const markerLayer  = new PIXI.Container()
+    const worldLayer   = new PIXI.Container()
+    worldLayer.sortableChildren = true
+    app.stage.addChild(groundLayer, streetLayer, buildingLayer, markerLayer, worldLayer)
+
+    // ── Terrain (camp environment) ─────────────────────────────────────────────
+    const baseContainer  = new PIXI.Container()
+    const riverContainer = new PIXI.Container()
+    groundLayer.addChild(baseContainer, riverContainer)
+
+    buildTerrainGfx(baseContainer, riverContainer, worldLayer,
+      { environment: HUB_ENV, id: 'hubworld' }, MAP_W, MAP_H)
+    buildBgTileGfx(baseContainer, { environment: HUB_ENV }, MAP_W, MAP_H)
+      .catch(e => console.error('[HubTownCanvas] bg tiles failed', e))
+    buildDecorGfx(groundLayer, { environment: HUB_ENV, id: 'hubworld' }, MAP_W, MAP_H)
+      .catch(e => console.error('[HubTownCanvas] decor tiles failed', e))
+
+    // ── Streets ───────────────────────────────────────────────────────────────
+    const pathSet = new Set(HUB_STREET_TILES.map(([tx, ty]) => `${tx},${ty}`))
+    renderPathTiles(streetLayer, pathSet, HUB_ENV)
+      .catch(e => console.error('[HubTownCanvas] street tiles failed', e))
+
+    // ── Buildings ─────────────────────────────────────────────────────────────
+    const bldGfx = new PIXI.Graphics()
+    for (const b of HUB_BUILDINGS) {
+      bldGfx
+        .rect(b.x, b.y, b.w, b.h)
+        .fill({ color: BUILDING_COLOR })
+        .rect(b.x, b.y, b.w, b.h)
+        .stroke({ color: BUILDING_BORDER, width: 1 })
+    }
+    buildingLayer.addChild(bldGfx)
+
+    // ── Interaction-point ellipses (district entrances) ────────────────────────
+    const T = 32
+    for (const pt of HUB_INTERACTION_POINTS) {
+      const g   = new PIXI.Graphics()
+      const cx  = pt.tx * T + T / 2
+      const cy  = pt.ty * T + T / 2
+      // glow ring
+      g.ellipse(cx, cy, 14, 8).fill({ color: MARKER_GLOW, alpha: 0.25 })
+      // body
+      g.ellipse(cx, cy, 10, 6).fill({ color: MARKER_FILL })
+      g.ellipse(cx, cy, 10, 6).stroke({ color: MARKER_STROKE, width: 1.5 })
+      // highlight
+      g.ellipse(cx - 2, cy - 2, 5, 3).fill({ color: MARKER_STROKE, alpha: 0.4 })
+      markerLayer.addChild(g)
+    }
+
+    // ── Area name on pointer move ──────────────────────────────────────────────
+    app.stage.eventMode = 'static'
+    app.stage.hitArea   = new PIXI.Rectangle(0, 0, MAP_W, MAP_H)
+    app.stage.on('pointermove', (e: PIXI.FederatedPointerEvent) => {
+      const { x, y } = e.getLocalPosition(app.stage)
+      const area = HUB_AREAS.find(
+        a => x >= a.x && x < a.x + a.w && y >= a.y && y < a.y + a.h,
+      )
+      onAreaRef.current(area?.name ?? null)
+    })
+    app.stage.on('pointerleave', () => { onAreaRef.current(null) })
+
+    app.ticker.add(() => { worldLayer.sortChildren() })
+  })
+
+  return (
+    <div
+      ref={containerRef}
+      style={{ display: 'block', flexShrink: 0, width: MAP_W, height: MAP_H }}
+    />
+  )
+}

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -1,47 +1,26 @@
-import React, { useRef } from 'react'
-import * as PIXI from 'pixi.js'
-import { usePixiApp } from '../../hooks/usePixiApp'
-import { buildTerrainGfx, buildBgTileGfx, buildDecorGfx } from '../../utils/terrainLayer'
+import React, { useState, useCallback } from 'react'
 import { OverlayScreen } from '../ui/OverlayScreen'
+import { HubTownCanvas } from './HubTownCanvas'
+import { AreaNameBadge } from './AreaNameBadge'
 
 interface Props {
   onBack: () => void
 }
 
-const MAP_WIDTH  = 1200
-const MAP_HEIGHT = 800
-const HUB_ENV   = 'camp'
-
 export function HubWorld({ onBack }: Props) {
-  const containerRef = useRef<HTMLDivElement>(null)
-
-  usePixiApp(containerRef, MAP_WIDTH, MAP_HEIGHT, (app) => {
-    app.canvas.style.touchAction = 'pan-x pan-y'
-
-    const groundLayer = new PIXI.Container()
-    const worldLayer  = new PIXI.Container()
-    worldLayer.sortableChildren = true
-    app.stage.addChild(groundLayer, worldLayer)
-
-    const baseContainer  = new PIXI.Container()
-    const riverContainer = new PIXI.Container()
-    groundLayer.addChild(baseContainer, riverContainer)
-
-    buildTerrainGfx(baseContainer, riverContainer, worldLayer,
-      { environment: HUB_ENV, id: 'hubworld' },
-      MAP_WIDTH, MAP_HEIGHT)
-    buildBgTileGfx(baseContainer, { environment: HUB_ENV }, MAP_WIDTH, MAP_HEIGHT)
-      .catch(e => console.error('[HubWorld] bg tiles failed', e))
-    buildDecorGfx(groundLayer, { environment: HUB_ENV, id: 'hubworld' }, MAP_WIDTH, MAP_HEIGHT)
-      .catch(e => console.error('[HubWorld] decor tiles failed', e))
-
-    app.ticker.add(() => { worldLayer.sortChildren() })
-  })
+  const [currentArea, setCurrentArea] = useState<string | null>(null)
+  const handleAreaEnter = useCallback((name: string | null) => { setCurrentArea(name) }, [])
 
   return (
     <OverlayScreen onBack={onBack} title="HUB WORLD" subtitle="Coming soon">
-      <div className="nm-map u-flex u-grow u-items-c nm-map--camp" style={{ overflowX: 'auto', overflowY: 'auto' }}>
-        <div ref={containerRef} style={{ display: 'block', flexShrink: 0, width: MAP_WIDTH, height: MAP_HEIGHT }} />
+      <div
+        className="nm-map nm-map--camp"
+        style={{ position: 'relative', flex: 1, overflow: 'hidden' }}
+      >
+        <div style={{ overflowX: 'auto', overflowY: 'auto', width: '100%', height: '100%' }}>
+          <HubTownCanvas onAreaEnter={handleAreaEnter} />
+        </div>
+        <AreaNameBadge name={currentArea} />
       </div>
     </OverlayScreen>
   )

--- a/web/src/data/hubLayout.ts
+++ b/web/src/data/hubLayout.ts
@@ -1,0 +1,106 @@
+// Hub World town map layout — areas, streets, buildings, interaction points.
+// All coordinates use pixel space (1 tile = 32 px) unless noted.
+
+export const MAP_W = 2400
+export const MAP_H = 1600
+const T = 32
+
+export interface HubArea {
+  id: string
+  name: string
+  x: number
+  y: number
+  w: number
+  h: number
+}
+
+export interface HubBuilding {
+  x: number
+  y: number
+  w: number
+  h: number
+}
+
+export interface HubInteractionPoint {
+  tx: number
+  ty: number
+  label: string
+}
+
+// Named zones — hit-tested on pointer move (first match wins).
+export const HUB_AREAS: HubArea[] = [
+  { id: 'courtyard', name: 'The Courtyard',          x: 33 * T, y: 21 * T, w: 9 * T,  h: 8 * T  },
+  { id: 'barracks',  name: 'The Barracks Gate',      x: 36 * T, y:  0,     w: 3 * T,  h: 21 * T },
+  { id: 'dock',      name: "The Fisherman's Dock",   x: 36 * T, y: 29 * T, w: 3 * T,  h: 21 * T },
+  { id: 'market',    name: 'Market Lane',             x:  0,     y: 23 * T, w: 33 * T, h: 3 * T  },
+  { id: 'arcade',    name: 'The Arcade Quarter',      x: 42 * T, y: 23 * T, w: 33 * T, h: 3 * T  },
+  { id: 'scholars',  name: "The Scholar's Hall",      x: 42 * T, y:  0,     w: 33 * T, h: 23 * T },
+]
+
+// Generate tile positions for a rectangular street block (inclusive).
+function streetRect(tx1: number, ty1: number, tx2: number, ty2: number): [number, number][] {
+  const out: [number, number][] = []
+  for (let tx = tx1; tx <= tx2; tx++)
+    for (let ty = ty1; ty <= ty2; ty++)
+      out.push([tx, ty])
+  return out
+}
+
+// All path-tile positions that form the town's streets and alleyways.
+// Duplicates are harmless — callers should deduplicate via Set if needed.
+export const HUB_STREET_TILES: [number, number][] = [
+  // Main horizontal thoroughfare
+  ...streetRect(0, 23, 74, 25),
+  // Main vertical thoroughfare
+  ...streetRect(36, 0, 38, 49),
+  // Central courtyard opening (widens the crossing into a plaza)
+  ...streetRect(33, 21, 41, 28),
+  // NE alley — Barracks Gate ↔ Scholar's Hall
+  ...streetRect(55, 5, 57, 23),
+  // NE cross-spur — Scholar's Hall internal street
+  ...streetRect(55, 8, 74, 10),
+  // SW alley — Arcade Quarter ↔ Fisherman's Dock
+  ...streetRect(14, 26, 16, 45),
+  // SW cross-spur — Dock district internal street
+  ...streetRect(0, 35, 16, 37),
+  // NW alley — Market Lane internal alley
+  ...streetRect(18, 5, 20, 23),
+  // NW cross-spur — Market Lane internal street
+  ...streetRect(0, 12, 20, 14),
+]
+
+// Dark filled blocks representing buildings (inaccessible regions).
+// Positions chosen to avoid all street tile columns/rows defined above.
+export const HUB_BUILDINGS: HubBuilding[] = [
+  // ── NW quadrant — Market district ───────────────────────────────────────────
+  { x:  1 * T, y:  1 * T, w: 16 * T, h: 10 * T },   // Grand Market Hall
+  { x:  1 * T, y: 15 * T, w: 16 * T, h:  7 * T },   // Market Stalls
+  { x: 21 * T, y:  1 * T, w: 11 * T, h: 19 * T },   // Merchant Quarter
+
+  // ── NE quadrant — Scholar's district ────────────────────────────────────────
+  { x: 41 * T, y:  1 * T, w: 13 * T, h:  6 * T },   // Library
+  { x: 58 * T, y:  1 * T, w: 15 * T, h:  6 * T },   // Scholar's Hall
+  { x: 41 * T, y: 11 * T, w: 13 * T, h:  9 * T },   // Archives
+  { x: 58 * T, y: 11 * T, w: 15 * T, h:  9 * T },   // Observatory
+
+  // ── SW quadrant — Dock district ──────────────────────────────────────────────
+  { x:  1 * T, y: 27 * T, w: 12 * T, h:  7 * T },   // Warehouse A
+  { x:  1 * T, y: 38 * T, w: 12 * T, h: 10 * T },   // Fishing Hut
+  { x: 17 * T, y: 27 * T, w: 18 * T, h:  7 * T },   // Dock Hall
+  { x: 17 * T, y: 38 * T, w: 18 * T, h: 10 * T },   // Harbor Market
+
+  // ── SE quadrant — Arcade district ────────────────────────────────────────────
+  { x: 41 * T, y: 27 * T, w: 13 * T, h:  8 * T },   // Arcade Hall
+  { x: 41 * T, y: 38 * T, w: 13 * T, h: 10 * T },   // Casino
+  { x: 58 * T, y: 27 * T, w: 15 * T, h:  8 * T },   // Showroom
+  { x: 58 * T, y: 38 * T, w: 15 * T, h: 10 * T },   // Gallery
+]
+
+// Interaction-point ellipses at district entrances (visual only for now).
+export const HUB_INTERACTION_POINTS: HubInteractionPoint[] = [
+  { tx: 37, ty: 18, label: 'Barracks Gate' },
+  { tx: 37, ty: 30, label: "Fisherman's Dock" },
+  { tx: 28, ty: 24, label: 'Market Lane' },
+  { tx: 46, ty: 24, label: 'Arcade Quarter' },
+  { tx: 56, ty: 20, label: "Scholar's Hall" },
+]


### PR DESCRIPTION
## Summary

- **`web/src/data/hubLayout.ts`** — map data: 2400×1600 px canvas; 6 named areas (The Courtyard, Market Lane, The Arcade Quarter, The Barracks Gate, The Fisherman's Dock, The Scholar's Hall); 9 street/alley blocks as tile-coord rects fed to `renderPathTiles`; 15 building blocks as tile-coord sets; 5 district-entrance interaction points
- **`web/src/utils/tileLookup.ts`** — `renderPathTiles` gains optional `tileFileOverride` param so any tile sheet can be used without needing an `ENV_TILES` entry
- **`HubTownCanvas.tsx`** — PixiJS sub-component: terrain (camp env) + street path tiles + building wall tiles (`[A]Wall-Up2_pipo.png` with correct 8-neighbor edge/corner joins) + entry-point ellipses + stage `pointermove` → area hit-test → `onAreaEnter` callback
- **`AreaNameBadge.tsx`** — pure React label that fades in at the lower-right when the pointer enters a named zone; fades out on leave
- **`HubWorld.tsx`** — refactored to orchestrate `HubTownCanvas` + `AreaNameBadge`; tracks `currentArea` state
- Stories added for `HubTownCanvas`, `AreaNameBadge`, and `HubWorld`

Closes #1402.

## Test plan

- [ ] Open Settings with `?debug`, tap **Open Hub World**
- [ ] Map is larger than viewport; scrolls horizontally and vertically
- [ ] Camp-environment terrain tiles render (grass, decor)
- [ ] Streets/alleyways render with correct tile-neighbor joins (8-neighbour bitmask)
- [ ] Building blocks render with `Wall-Up2` tiles — correct edge/corner transitions at building perimeters
- [ ] Interaction-point ellipses visible at 5 district entrances
- [ ] Moving pointer over a street/courtyard shows area name in lower-right (fades in)
- [ ] Moving pointer off the street clears the label (fades out)
- [ ] No console errors

https://github.com/Jarvichi/jarvs-amazing-web-game/issues/1402