### PR TITLE
#1404 Hub NPC avatars — quest-givers + wandering card-unit NPCs

### DIFF
--- a/web/public/sprites/hub-npc-elder.svg
+++ b/web/public/sprites/hub-npc-elder.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- shadow -->
+  <ellipse cx="16" cy="29" rx="5" ry="2" fill="rgba(0,0,0,0.2)"/>
+  <!-- robe -->
+  <rect x="10" y="13" width="12" height="15" rx="3" fill="#8b5e3c"/>
+  <!-- arms -->
+  <rect x="8"  y="14" width="3" height="8" rx="1" fill="#8b5e3c"/>
+  <rect x="21" y="14" width="3" height="8" rx="1" fill="#8b5e3c"/>
+  <!-- staff -->
+  <rect x="22" y="8" width="2" height="18" rx="1" fill="#6b4020"/>
+  <circle cx="23" cy="7" r="2" fill="#d4a847"/>
+  <!-- beard -->
+  <rect x="12" y="11" width="8" height="5" rx="2" fill="#c8c0b0"/>
+  <!-- head -->
+  <circle cx="16" cy="9" r="5" fill="#d4b090"/>
+  <!-- white hair -->
+  <rect x="11" y="4" width="10" height="4" rx="2" fill="#e8e0d8"/>
+  <!-- eyes -->
+  <rect x="13" y="8" width="2" height="2" rx="1" fill="#2a1a0a"/>
+  <rect x="17" y="8" width="2" height="2" rx="1" fill="#2a1a0a"/>
+</svg>

--- a/web/public/sprites/hub-npc-merchant.svg
+++ b/web/public/sprites/hub-npc-merchant.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- shadow -->
+  <ellipse cx="16" cy="29" rx="6" ry="2" fill="rgba(0,0,0,0.2)"/>
+  <!-- boots -->
+  <rect x="11" y="26" width="4" height="2" rx="1" fill="#1a0a00"/>
+  <rect x="17" y="26" width="4" height="2" rx="1" fill="#1a0a00"/>
+  <!-- legs -->
+  <rect x="12" y="21" width="3" height="6" rx="1" fill="#4a2a10"/>
+  <rect x="17" y="21" width="3" height="6" rx="1" fill="#4a2a10"/>
+  <!-- tunic -->
+  <rect x="10" y="12" width="12" height="10" rx="2" fill="#aa2a2a"/>
+  <!-- gold trim -->
+  <rect x="10" y="12" width="12" height="2" rx="1" fill="#d4a020"/>
+  <rect x="10" y="20" width="12" height="2" rx="1" fill="#d4a020"/>
+  <!-- arms -->
+  <rect x="8"  y="13" width="3" height="7" rx="1" fill="#c8a070"/>
+  <rect x="21" y="13" width="3" height="7" rx="1" fill="#c8a070"/>
+  <!-- coin pouch -->
+  <circle cx="9" cy="22" r="3" fill="#d4a020"/>
+  <!-- head -->
+  <circle cx="16" cy="8" r="5" fill="#c8a070"/>
+  <!-- merchant hat -->
+  <rect x="11" y="3" width="10" height="4" rx="2" fill="#2a1a00"/>
+  <rect x="9"  y="5" width="14" height="2" rx="1" fill="#2a1a00"/>
+  <!-- eyes -->
+  <rect x="13" y="8" width="2" height="2" rx="1" fill="#1a0a00"/>
+  <rect x="17" y="8" width="2" height="2" rx="1" fill="#1a0a00"/>
+</svg>

--- a/web/public/sprites/hub-npc-scholar.svg
+++ b/web/public/sprites/hub-npc-scholar.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- shadow -->
+  <ellipse cx="16" cy="29" rx="5" ry="2" fill="rgba(0,0,0,0.2)"/>
+  <!-- robes -->
+  <rect x="10" y="13" width="12" height="15" rx="3" fill="#2a4a8a"/>
+  <!-- rune/sigil on robe -->
+  <rect x="14" y="17" width="4" height="4" rx="1" fill="#7a9ade" opacity="0.7"/>
+  <!-- arms -->
+  <rect x="8"  y="14" width="3" height="8" rx="1" fill="#2a4a8a"/>
+  <rect x="21" y="14" width="3" height="8" rx="1" fill="#2a4a8a"/>
+  <!-- book in left hand -->
+  <rect x="7" y="16" width="5" height="6" rx="1" fill="#c8a070"/>
+  <rect x="9" y="16" width="1" height="6" fill="#8b6040"/>
+  <!-- head -->
+  <circle cx="16" cy="9" r="5" fill="#d4b090"/>
+  <!-- dark hood -->
+  <rect x="11" y="4" width="10" height="5" rx="2" fill="#1a2a6a"/>
+  <!-- spectacles -->
+  <rect x="12" y="8" width="3" height="2" rx="1" fill="none" stroke="#aaa" stroke-width="0.7"/>
+  <rect x="17" y="8" width="3" height="2" rx="1" fill="none" stroke="#aaa" stroke-width="0.7"/>
+  <line x1="15" y1="9" x2="17" y2="9" stroke="#aaa" stroke-width="0.7"/>
+  <!-- eyes -->
+  <rect x="13" y="8" width="2" height="2" rx="1" fill="#1a0a2a"/>
+  <rect x="17" y="8" width="2" height="2" rx="1" fill="#1a0a2a"/>
+</svg>

--- a/web/src/components/hub/HubDialogue.stories.tsx
+++ b/web/src/components/hub/HubDialogue.stories.tsx
@@ -1,0 +1,29 @@
+import { fn } from 'storybook/test'
+import { useState } from 'react'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { HubDialogue } from './HubDialogue'
+
+const meta = {
+  component: HubDialogue,
+  render: (args) => {
+    const [line, setLine] = useState(args.line)
+    return <HubDialogue line={line} onClose={() => setLine(null)} />
+  },
+} satisfies Meta<typeof HubDialogue>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Open: Story = {
+  args: {
+    line: 'The roads beyond the outer walls grow darker by the day. Tread carefully, wanderer.',
+    onClose: fn(),
+  },
+}
+
+export const Closed: Story = {
+  args: {
+    line: null,
+    onClose: fn(),
+  },
+}

--- a/web/src/components/hub/HubDialogue.tsx
+++ b/web/src/components/hub/HubDialogue.tsx
@@ -1,0 +1,60 @@
+import React from 'react'
+
+interface Props {
+  line:    string | null
+  onClose: () => void
+}
+
+export function HubDialogue({ line, onClose }: Props) {
+  return (
+    <div
+      style={{
+        position:       'absolute',
+        bottom:          56,
+        left:           '50%',
+        transform:      'translateX(-50%)',
+        width:          'calc(100% - 40px)',
+        maxWidth:        440,
+        pointerEvents:  line ? 'auto' : 'none',
+        opacity:        line ? 1 : 0,
+        transition:     'opacity 0.25s ease',
+        zIndex:          10,
+      }}
+    >
+      <div style={{
+        background:   'rgba(8,14,8,0.93)',
+        border:       '1px solid #446644',
+        padding:      '10px 14px',
+        display:      'flex',
+        alignItems:   'flex-start',
+        gap:           12,
+      }}>
+        <div style={{
+          flex:          1,
+          fontSize:      13,
+          color:         '#c8e8c8',
+          letterSpacing: '0.03em',
+          lineHeight:     1.55,
+        }}>
+          {line ?? ''}
+        </div>
+        <button
+          onClick={onClose}
+          style={{
+            background:    'none',
+            border:        '1px solid #446644',
+            color:         '#88cc88',
+            fontSize:       10,
+            padding:       '3px 10px',
+            cursor:        'pointer',
+            letterSpacing: '0.12em',
+            flexShrink:     0,
+            marginTop:      1,
+          }}
+        >
+          OK
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -3,7 +3,7 @@ import * as PIXI from 'pixi.js'
 import { usePixiApp } from '../../hooks/usePixiApp'
 import { buildTerrainGfx, buildBgTileGfx, buildDecorGfx } from '../../utils/terrainLayer'
 import { renderPathTiles } from '../../utils/tileLookup'
-import { loadTextureUrl } from '../../utils/pixiHelpers'
+import { loadSpriteTexture, loadTextureUrl } from '../../utils/pixiHelpers'
 import { PATH_TILE } from '../../data/tiles/tileIndex'
 import { findPath, nearestWalkable } from '../../utils/hubPathfinder'
 import {
@@ -14,6 +14,7 @@ import {
   HUB_STREET_TILES,
   AVATAR_START,
 } from '../../data/hubLayout'
+import { QUEST_GIVER_NPCS, NPC_SPAWN_TILES } from '../../data/hubNpcs'
 
 const HUB_ENV       = 'camp'
 const T             = 32
@@ -29,9 +30,11 @@ interface Props {
   onNodeInteract: (screen: string) => void
   onAvatarMove:   (px: number, py: number) => void
   returnRef?:     React.MutableRefObject<(() => void) | null>
+  unitCards?:     string[]
+  onNpcTap?:      (dialogue: string) => void
 }
 
-export function HubTownCanvas({ onAreaEnter, onNodeInteract, onAvatarMove, returnRef }: Props) {
+export function HubTownCanvas({ onAreaEnter, onNodeInteract, onAvatarMove, returnRef, unitCards, onNpcTap }: Props) {
   const containerRef      = useRef<HTMLDivElement>(null)
   const onAreaRef         = useRef(onAreaEnter)
   onAreaRef.current       = onAreaEnter
@@ -39,6 +42,10 @@ export function HubTownCanvas({ onAreaEnter, onNodeInteract, onAvatarMove, retur
   onNodeInteractRef.current = onNodeInteract
   const onAvatarMoveRef   = useRef(onAvatarMove)
   onAvatarMoveRef.current = onAvatarMove
+  const onNpcTapRef       = useRef(onNpcTap)
+  onNpcTapRef.current     = onNpcTap
+  const unitCardsRef      = useRef(unitCards)
+  unitCardsRef.current    = unitCards
 
   usePixiApp(containerRef, MAP_W, MAP_H, (app) => {
     app.canvas.style.touchAction = 'pan-x pan-y'
@@ -48,10 +55,11 @@ export function HubTownCanvas({ onAreaEnter, onNodeInteract, onAvatarMove, retur
     const streetLayer   = new PIXI.Container()
     const buildingLayer = new PIXI.Container()
     const nodeLayer     = new PIXI.Container()
+    const npcLayer      = new PIXI.Container()
     const avatarLayer   = new PIXI.Container()
     const worldLayer    = new PIXI.Container()
     worldLayer.sortableChildren = true
-    app.stage.addChild(groundLayer, streetLayer, buildingLayer, nodeLayer, avatarLayer, worldLayer)
+    app.stage.addChild(groundLayer, streetLayer, buildingLayer, nodeLayer, npcLayer, avatarLayer, worldLayer)
 
     // ── Terrain ────────────────────────────────────────────────────────────────
     const baseContainer  = new PIXI.Container()
@@ -108,6 +116,104 @@ export function HubTownCanvas({ onAreaEnter, onNodeInteract, onAvatarMove, retur
       avatarLayer.addChild(s)
       avatar = s
     }).catch(e => console.error('[HubTownCanvas] avatar load failed', e))
+
+    // ── Quest-giver NPCs ───────────────────────────────────────────────────────
+    for (const npc of QUEST_GIVER_NPCS) {
+      const cx = npc.tx * T + T / 2
+      const cy = npc.ty * T + T / 2
+
+      const npcContainer = new PIXI.Container()
+      npcContainer.eventMode = 'static'
+      npcContainer.cursor    = 'pointer'
+      npcContainer.on('pointerdown', (e: PIXI.FederatedPointerEvent) => {
+        e.stopPropagation()
+        onNpcTapRef.current?.(npc.dialogue)
+      })
+      npcLayer.addChild(npcContainer)
+
+      loadTextureUrl(`${base}sprites/${npc.sprite}.svg`).then(tex => {
+        if (app.renderer == null) return
+        const s = new PIXI.Sprite(tex)
+        s.width = T; s.height = T
+        s.anchor.set(0.5, 0.5)
+        s.position.set(cx, cy)
+        npcContainer.addChild(s)
+      }).catch(e => console.error(`[HubTownCanvas] NPC sprite failed: ${npc.sprite}`, e))
+
+      // "!" indicator
+      const exclaim = new PIXI.Text({ text: '!', style: { fontSize: 11, fill: '#ffdd44', fontFamily: 'monospace', fontWeight: 'bold' } })
+      exclaim.anchor.set(0.5, 1)
+      exclaim.position.set(cx, cy - T / 2 - 2)
+      npcLayer.addChild(exclaim)
+    }
+
+    // ── Card-unit NPCs ─────────────────────────────────────────────────────────
+    interface UnitNpcState {
+      sprite:      PIXI.Sprite
+      currentTile: [number, number]
+      walkQueue:   [number, number][]
+      isWalking:   boolean
+      wanderTimer: number
+    }
+
+    const unitNpcs: UnitNpcState[] = []
+    const cards = unitCardsRef.current ?? []
+
+    if (cards.length > 0) {
+      const spawnCount = Math.min(NPC_SPAWN_TILES.length, cards.length * 3)  // allow repeats up to 3x
+      const slots = NPC_SPAWN_TILES.slice(0, Math.min(spawnCount, NPC_SPAWN_TILES.length))
+
+      slots.forEach(([tx, ty], i) => {
+        const cardName = cards[i % cards.length]
+        const cx = tx * T + T / 2
+        const cy = ty * T + T / 2
+
+        loadSpriteTexture(cardName).then(tex => {
+          if (app.renderer == null) return
+          const s = new PIXI.Sprite(tex)
+          s.width = T; s.height = T
+          s.anchor.set(0.5, 0.5)
+          s.position.set(cx, cy)
+          s.alpha = 0.85
+          npcLayer.addChild(s)
+
+          const state: UnitNpcState = {
+            sprite:      s,
+            currentTile: [tx, ty],
+            walkQueue:   [],
+            isWalking:   false,
+            wanderTimer: 3000 + Math.random() * 7000,  // initial delay 3–10 s
+          }
+          unitNpcs.push(state)
+        }).catch(() => {/* silently skip missing sprites */})
+      })
+    }
+
+    async function processNpcWalkQueue(npc: UnitNpcState) {
+      if (npc.walkQueue.length === 0) { npc.isWalking = false; return }
+      npc.isWalking = true
+      const [tx, ty] = npc.walkQueue.shift()!
+      const targetX  = tx * T + T / 2
+      const targetY  = ty * T + T / 2
+      const dist     = Math.hypot(targetX - npc.sprite.x, targetY - npc.sprite.y)
+      const duration = (dist / WALK_PX_PER_S) * 1000
+      if (targetX < npc.sprite.x - 1) npc.sprite.scale.x = -Math.abs(npc.sprite.scale.x)
+      else if (targetX > npc.sprite.x + 1) npc.sprite.scale.x = Math.abs(npc.sprite.scale.x)
+      await tweenLinear(npc.sprite, targetX, targetY, duration)
+      npc.currentTile = [tx, ty]
+      processNpcWalkQueue(npc)
+    }
+
+    function wanderNpc(npc: UnitNpcState) {
+      const options = NPC_SPAWN_TILES.filter(
+        ([tx, ty]) => tx !== npc.currentTile[0] || ty !== npc.currentTile[1],
+      ) as [number, number][]
+      if (options.length === 0) return
+      const target = options[Math.floor(Math.random() * options.length)]
+      const path   = findPath(npc.currentTile, target, pathSet)
+      npc.walkQueue = path.slice(1)
+      if (!npc.isWalking) processNpcWalkQueue(npc)
+    }
 
     // ── Walk state ─────────────────────────────────────────────────────────────
     let currentTile: [number, number] = [...AVATAR_START]
@@ -207,9 +313,19 @@ export function HubTownCanvas({ onAreaEnter, onNodeInteract, onAvatarMove, retur
     }
 
     // ── Per-frame ──────────────────────────────────────────────────────────────
-    app.ticker.add(() => {
+    app.ticker.add((ticker) => {
       if (avatar) onAvatarMoveRef.current(avatar.x, avatar.y)
       worldLayer.sortChildren()
+
+      for (const npc of unitNpcs) {
+        if (!npc.isWalking) {
+          npc.wanderTimer -= ticker.deltaMS
+          if (npc.wanderTimer <= 0) {
+            npc.wanderTimer = 10000 + Math.random() * 20000
+            wanderNpc(npc)
+          }
+        }
+      }
     })
   })
 

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -1,9 +1,12 @@
-import React, { useState, useCallback, useEffect, useRef } from 'react'
+import React, { useState, useCallback, useEffect, useMemo, useRef } from 'react'
 import { OverlayScreen } from '../ui/OverlayScreen'
 import { HubTownCanvas } from './HubTownCanvas'
 import { AreaNameBadge } from './AreaNameBadge'
 import { HubReturnButton } from './HubReturnButton'
+import { HubDialogue } from './HubDialogue'
 import { AVATAR_START, MAP_W, MAP_H } from '../../data/hubLayout'
+import { loadDeck } from '../../game/collection'
+import { getCardCatalog } from '../../game/cards'
 
 const T = 32
 const INITIAL_SCROLL = {
@@ -17,9 +20,19 @@ interface Props {
 }
 
 export function HubWorld({ onBack, onNavigate }: Props) {
-  const [currentArea, setCurrentArea] = useState<string | null>(null)
+  const [currentArea,  setCurrentArea]  = useState<string | null>(null)
+  const [dialogueLine, setDialogueLine] = useState<string | null>(null)
   const scrollRef = useRef<HTMLDivElement>(null)
   const returnRef = useRef(null) as React.MutableRefObject<(() => void) | null>
+
+  const unitCards = useMemo(() => {
+    const deck    = loadDeck()
+    const catalog = getCardCatalog()
+    const names   = new Set(deck.map(e => e.cardName))
+    return catalog
+      .filter(c => c.cardType === 'unit' && names.has(c.name))
+      .map(c => c.name)
+  }, [])
 
   // Centre viewport on avatar's pixel position.
   const handleAvatarMove = useCallback((px: number, py: number) => {
@@ -60,10 +73,13 @@ export function HubWorld({ onBack, onNavigate }: Props) {
             onNodeInteract={handleNodeInteract}
             onAvatarMove={handleAvatarMove}
             returnRef={returnRef}
+            unitCards={unitCards}
+            onNpcTap={setDialogueLine}
           />
         </div>
         <AreaNameBadge name={currentArea} />
         <HubReturnButton onClick={handleReturn} />
+        <HubDialogue line={dialogueLine} onClose={() => setDialogueLine(null)} />
       </div>
     </OverlayScreen>
   )

--- a/web/src/data/hubNpcs.ts
+++ b/web/src/data/hubNpcs.ts
@@ -1,0 +1,52 @@
+// Hub World NPC definitions — quest-givers and card-unit spawn positions.
+
+export interface QuestGiverNpc {
+  id:       string
+  name:     string
+  sprite:   string   // filename slug (looked up via /sprites/{sprite}.svg)
+  tx:       number
+  ty:       number
+  dialogue: string
+}
+
+// Fixed-position quest-giver NPCs (tappable, placeholder dialogue).
+export const QUEST_GIVER_NPCS: QuestGiverNpc[] = [
+  {
+    id:       'elder',
+    name:     'The Elder',
+    sprite:   'hub-npc-elder',
+    tx:       19,
+    ty:       12,
+    dialogue: 'The roads beyond the outer walls grow darker by the day. Tread carefully, wanderer.',
+  },
+  {
+    id:       'merchant',
+    name:     'Vex the Merchant',
+    sprite:   'hub-npc-merchant',
+    tx:       22,
+    ty:       24,
+    dialogue: "Business has been slow since the Fracture. Come back when the trade routes are safe again.",
+  },
+  {
+    id:       'scholar',
+    name:     'Archivist Naia',
+    sprite:   'hub-npc-scholar',
+    tx:       56,
+    ty:        9,
+    dialogue: 'I have been cataloguing the Fracture shards. The answers are within your reach — if you dare.',
+  },
+]
+
+// Preset positions for card-unit NPC spawning — all on street tiles, spread across the map.
+export const NPC_SPAWN_TILES: [number, number][] = [
+  [19,  8],   // NW alley upper
+  [19, 15],   // NW alley mid
+  [ 8, 24],   // Market Lane west
+  [60, 24],   // Arcade east
+  [56, 11],   // NE alley mid
+  [37,  7],   // North corridor
+  [37, 40],   // South corridor
+  [15, 35],   // SW cross-spur
+  [ 5, 35],   // SW spur far end
+  [65,  9],   // NE spur far east
+]


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds three quest-giver NPCs (The Elder, Vex the Merchant, Archivist Naia) with distinct 32×32 SVG sprites placed at fixed hub map positions
- Each quest-giver shows a "!" indicator and opens a dialogue panel (`HubDialogue`) when tapped — click does not propagate to the walk handler
- Card-unit NPCs from the player's active deck spawn at 10 preset street tiles and wander autonomously via A* pathfinding on a 10–30 s randomised timer, reusing the same tile-by-tile linear-walk pattern as the player avatar
- `HubWorld` computes `unitCards` via `useMemo` over `loadDeck()` + `getCardCatalog()` (unit cards only) and manages `dialogueLine` state for the dialogue panel

## New files
- `web/public/sprites/hub-npc-elder.svg`
- `web/public/sprites/hub-npc-merchant.svg`
- `web/public/sprites/hub-npc-scholar.svg`
- `web/src/data/hubNpcs.ts` — NPC definitions + spawn tile positions
- `web/src/components/hub/HubDialogue.tsx` — fade-in dialogue panel with OK dismiss
- `web/src/components/hub/HubDialogue.stories.tsx`

## Test plan
- [ ] Open Hub World via Settings (`?debug`) → three named NPCs visible with "!" above them
- [ ] Tap a quest-giver NPC → dialogue panel appears at bottom of screen; player does not move
- [ ] Click OK → dialogue dismisses
- [ ] Wait ~5 s → card-unit NPCs begin wandering between spawn tiles
- [ ] Player walk unaffected while NPCs are moving
- [ ] `npm run build` passes with zero TypeScript errors

https://claude.ai/code/session_013AyvzYXfUBE58v7YcFBnne
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_013AyvzYXfUBE58v7YcFBnne)_