### PR TITLE
#1406 Hall of Achievements — trophy grid with claim modal

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -107,7 +107,8 @@ import {
   incrementAchievementProgress, setAchievementProgress, AchievementDef,
 } from './game/achievements'
 import { incrementAugmentSouls } from './game/collection'
-import { AchievementsScreen } from './components/screens/AchievementsScreen'
+import { AchievementsScreen }  from './components/screens/AchievementsScreen'
+import { HallOfAchievements }   from './components/hub/HallOfAchievements'
 import { HeroCardsScreen }   from './components/screens/HeroCardsScreen'
 import FingerSmash from './components/battle/FingerSmash'
 import BossShockwave from './components/battle/BossShockwave'
@@ -190,6 +191,7 @@ type Screen =
   | 'relicselect'
   | 'inventory'
   | 'achievements'
+  | 'hall-of-achievements'
   | 'campaignfailed'
   | 'heroCards'
   | 'battlesummary'
@@ -2823,6 +2825,13 @@ export default function App() {
       {screen === 'achievements' && (
         <AchievementsScreen
           onBack={() => setScreen('title')}
+          onCrystalsChanged={handleCrystalsChanged}
+        />
+      )}
+
+      {screen === 'hall-of-achievements' && (
+        <HallOfAchievements
+          onBack={() => setScreen('hubworld')}
           onCrystalsChanged={handleCrystalsChanged}
         />
       )}

--- a/web/src/components/hub/HallOfAchievements.stories.tsx
+++ b/web/src/components/hub/HallOfAchievements.stories.tsx
@@ -1,0 +1,17 @@
+import { fn } from 'storybook/test'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { HallOfAchievements } from './HallOfAchievements'
+
+const meta = {
+  component: HallOfAchievements,
+} satisfies Meta<typeof HallOfAchievements>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    onBack:            fn(),
+    onCrystalsChanged: fn(),
+  },
+}

--- a/web/src/components/hub/HallOfAchievements.tsx
+++ b/web/src/components/hub/HallOfAchievements.tsx
@@ -1,0 +1,229 @@
+import React, { useState, useCallback } from 'react'
+import {
+  ACHIEVEMENT_DEFS, AchievementDef, AchievementCategory,
+  loadAchievementSave, claimAchievementReward, claimAllAchievementRewards,
+} from '../../game/achievements'
+import { OverlayScreen } from '../ui/OverlayScreen'
+import { addCardsToCollection, loadCrystals, saveCrystals } from '../../game/collection'
+import { addToInventory, ALL_ITEMS } from '../../game/dailyLogin'
+import { addUnlockedAvatar } from '../../game/questline'
+
+interface Props {
+  onBack:              () => void
+  onCrystalsChanged:   (n: number) => void
+}
+
+const CATEGORY_ORDER: AchievementCategory[] = [
+  'campaign', 'daily', 'playtime', 'misc', 'events', 'kills', 'structures',
+]
+const CATEGORY_LABELS: Record<AchievementCategory, string> = {
+  campaign:   'Campaign',
+  daily:      'Daily',
+  playtime:   'Playtime',
+  misc:       'Misc',
+  events:     'Events',
+  kills:      'Kills',
+  structures: 'Structures',
+}
+
+function TrophyIcon() {
+  return (
+    <svg viewBox="0 0 32 32" width="40" height="40" aria-hidden="true">
+      <rect x="11" y="27" width="10" height="2" rx="1" fill="#8a6000"/>
+      <rect x="9"  y="24" width="14" height="4" rx="1" fill="#aa7800"/>
+      <rect x="14" y="18" width="4"  height="7" fill="#aa7800"/>
+      <path d="M8 6 Q8 19 16 19 Q24 19 24 6 Z" fill="#ffcc00"/>
+      <rect x="8"  y="5"  width="16" height="3" rx="1" fill="#ffe040"/>
+      <path d="M8 8 Q3 8 3 13 Q3 17 8 16"  fill="none" stroke="#ffcc00" strokeWidth="2.5"/>
+      <path d="M24 8 Q29 8 29 13 Q29 17 24 16" fill="none" stroke="#ffcc00" strokeWidth="2.5"/>
+    </svg>
+  )
+}
+
+function PlinthIcon() {
+  return (
+    <svg viewBox="0 0 32 32" width="40" height="40" aria-hidden="true">
+      <rect x="7"  y="27" width="18" height="3" rx="1" fill="#3a3a4a"/>
+      <rect x="10" y="13" width="12" height="15" rx="2" fill="#2a2a3a"/>
+      <rect x="12" y="15" width="8"  height="11" rx="1" fill="#1e1e2a"/>
+      <text x="16" y="24" textAnchor="middle" fontSize="9" fill="#4a4a6a" fontFamily="monospace">?</text>
+    </svg>
+  )
+}
+
+function formatRewardLine(def: AchievementDef): string {
+  const r = def.reward
+  const parts: string[] = []
+  if (r.type === 'avatar' && r.avatarSlug)  parts.push('New avatar')
+  if (r.type === 'crystals' && r.crystals)  parts.push(`💎 ${r.crystals}`)
+  if (r.type === 'cards' && r.cardName)     parts.push(`${r.count}× ${r.cardName}`)
+  if (r.type === 'item' && r.item)          parts.push(`${r.item.icon} ${r.item.name}`)
+  if (r.bonusCrystals)                      parts.push(`💎 ${r.bonusCrystals}`)
+  if (r.bonusCards)  parts.push(r.bonusCards.map(c => `${c.count}× ${c.cardName}`).join(', '))
+  return parts.join(' + ') || '—'
+}
+
+export function HallOfAchievements({ onBack, onCrystalsChanged }: Props) {
+  const [save, setSave]               = useState(() => loadAchievementSave())
+  const [activeCategory, setCategory] = useState<AchievementCategory>('campaign')
+  const [selected, setSelected]       = useState<AchievementDef | null>(null)
+  const [justClaimed, setJustClaimed] = useState<string | null>(null)
+
+  const handleClaim = useCallback((def: AchievementDef) => {
+    const reward = claimAchievementReward(def.id)
+    if (!reward) return
+    let crystalDelta = 0
+    if (reward.type === 'crystals' && reward.crystals)  crystalDelta += reward.crystals
+    if (reward.bonusCrystals)                           crystalDelta += reward.bonusCrystals
+    if (crystalDelta > 0) {
+      const next = loadCrystals() + crystalDelta
+      saveCrystals(next)
+      onCrystalsChanged(next)
+    }
+    if (reward.type === 'cards' && reward.cardName && reward.count)
+      addCardsToCollection([{ cardName: reward.cardName, count: reward.count }])
+    if (reward.bonusCards) addCardsToCollection(reward.bonusCards)
+    if (reward.type === 'item' && reward.item) {
+      const full = ALL_ITEMS.find(i => i.id === reward.item!.id) ?? { ...reward.item, lore: '', weight: 1 }
+      addToInventory(full)
+    }
+    if (reward.avatarSlug) addUnlockedAvatar(reward.avatarSlug)
+    setSave(loadAchievementSave())
+    setJustClaimed(def.id)
+    setTimeout(() => setJustClaimed(null), 1800)
+  }, [onCrystalsChanged])
+
+  const handleClaimAll = useCallback(() => {
+    const results = claimAllAchievementRewards()
+    if (results.length === 0) return
+    let crystalDelta = 0
+    for (const { reward } of results) {
+      if (reward.type === 'crystals' && reward.crystals) crystalDelta += reward.crystals
+      if (reward.bonusCrystals) crystalDelta += reward.bonusCrystals
+      if (reward.type === 'cards' && reward.cardName && reward.count)
+        addCardsToCollection([{ cardName: reward.cardName, count: reward.count }])
+      if (reward.bonusCards) addCardsToCollection(reward.bonusCards)
+      if (reward.type === 'item' && reward.item) {
+        const full = ALL_ITEMS.find(i => i.id === reward.item!.id) ?? { ...reward.item, lore: '', weight: 1 }
+        addToInventory(full)
+      }
+      if (reward.avatarSlug) addUnlockedAvatar(reward.avatarSlug)
+    }
+    if (crystalDelta > 0) {
+      const next = loadCrystals() + crystalDelta
+      saveCrystals(next)
+      onCrystalsChanged(next)
+    }
+    setSave(loadAchievementSave())
+  }, [onCrystalsChanged])
+
+  const defs = ACHIEVEMENT_DEFS.filter(d => d.category === activeCategory)
+
+  const claimableInCategory = (cat: AchievementCategory) =>
+    ACHIEVEMENT_DEFS.filter(d => d.category === cat && save.unlocked[d.id] && !save.claimed[d.id]).length
+
+  const totalClaimable = ACHIEVEMENT_DEFS.filter(d => save.unlocked[d.id] && !save.claimed[d.id]).length
+
+  const selectedUnlocked = selected ? !!save.unlocked[selected.id]  : false
+  const selectedClaimed  = selected ? !!save.claimed[selected.id]   : false
+  const selectedProgress = selected ? (save.progress[selected.progressKey] ?? 0) : 0
+
+  return (
+    <OverlayScreen title="HALL OF ACHIEVEMENTS" onBack={onBack}>
+      {/* Category tabs */}
+      <div className="hoa-tabs">
+        {CATEGORY_ORDER.map(cat => {
+          const badge = claimableInCategory(cat)
+          return (
+            <button
+              key={cat}
+              className={`hoa-tab${cat === activeCategory ? ' hoa-tab--active' : ''}`}
+              onClick={() => setCategory(cat)}
+            >
+              {CATEGORY_LABELS[cat]}
+              {badge > 0 && <span className="hoa-badge">{badge}</span>}
+            </button>
+          )
+        })}
+      </div>
+
+      {/* Claim all bar */}
+      {totalClaimable > 0 && (
+        <div className="hoa-claim-bar">
+          <span className="hoa-claim-bar-label">{totalClaimable} reward{totalClaimable !== 1 ? 's' : ''} ready</span>
+          <button className="action-btn action-btn--gold action-btn--sm" onClick={handleClaimAll}>
+            Claim All
+          </button>
+        </div>
+      )}
+
+      {/* Trophy grid */}
+      <div className="hoa-grid">
+        {defs.map(def => {
+          const unlocked = !!save.unlocked[def.id]
+          const claimed  = !!save.claimed[def.id]
+          const canClaim = unlocked && !claimed
+          return (
+            <button
+              key={def.id}
+              className={`hoa-tile${unlocked ? ' hoa-tile--unlocked' : ''}${canClaim ? ' hoa-tile--claimable' : ''}`}
+              onClick={() => setSelected(def)}
+              title={unlocked ? def.name : '???'}
+            >
+              <div className="hoa-tile-icon">
+                {unlocked ? <TrophyIcon /> : <PlinthIcon />}
+              </div>
+              <div className="hoa-tile-name">
+                {unlocked ? def.name : '???'}
+              </div>
+              {canClaim && <div className="hoa-tile-dot" />}
+            </button>
+          )
+        })}
+      </div>
+
+      {/* Detail modal */}
+      {selected && (
+        <div className="hoa-backdrop" onClick={() => setSelected(null)}>
+          <div className="hoa-modal" onClick={e => e.stopPropagation()}>
+            <div className="hoa-modal-icon">
+              {selectedUnlocked ? <TrophyIcon /> : <PlinthIcon />}
+            </div>
+            <div className="hoa-modal-name">
+              {selectedUnlocked ? selected.name : '???'}
+            </div>
+            {selectedUnlocked && (
+              <div className="hoa-modal-desc">{selected.description}</div>
+            )}
+            <div className="hoa-modal-criteria">
+              {selectedUnlocked
+                ? `Criteria: ${selectedProgress.toLocaleString()} / ${selected.target.toLocaleString()}`
+                : `Progress: ${selectedProgress.toLocaleString()} / ${selected.target.toLocaleString()}`}
+            </div>
+            <div className="hoa-modal-reward">
+              Reward: {formatRewardLine(selected)}
+            </div>
+            {selectedUnlocked && (
+              <div className="hoa-modal-unlocked">UNLOCKED ✓</div>
+            )}
+            {selectedUnlocked && !selectedClaimed && (
+              <button
+                className={`action-btn action-btn--gold${justClaimed === selected.id ? ' action-btn--dim' : ''}`}
+                onClick={() => handleClaim(selected)}
+                disabled={justClaimed === selected.id}
+              >
+                {justClaimed === selected.id ? 'Claimed!' : 'Claim Reward'}
+              </button>
+            )}
+            {selectedClaimed && (
+              <div className="hoa-modal-claimed">Reward Collected</div>
+            )}
+            <button className="action-btn hoa-modal-close" onClick={() => setSelected(null)}>
+              Close
+            </button>
+          </div>
+        </div>
+      )}
+    </OverlayScreen>
+  )
+}

--- a/web/src/data/hubLayout.ts
+++ b/web/src/data/hubLayout.ts
@@ -43,7 +43,7 @@ export const HUB_NODES: HubNode[] = [
   { id: 'supply-shop',  label: 'Supplies',      tx:  8, ty: 24, screen: 'shop-supplies' },
   { id: 'codex',        label: 'Codex',         tx: 56, ty: 15, screen: 'codex'          },
   { id: 'commander',    label: 'Commander',     tx: 37, ty: 24, screen: 'commander'      },
-  { id: 'achievements', label: 'Achievements',  tx: 56, ty: 19, screen: 'achievements'   },
+  { id: 'achievements', label: 'Achievements',  tx: 56, ty: 19, screen: 'hall-of-achievements' },
   { id: 'home',         label: 'Home',          tx: 19, ty: 18, screen: 'collection-tabs'},
 ]
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -7137,6 +7137,179 @@ body {
   to   { opacity: 1; transform: translateX(0); }
 }
 
+/* ── Hall of Achievements ───────────────────────────────────────────────── */
+
+.hoa-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  padding: 10px 12px 0;
+  border-bottom: 1px solid #2a3a2a;
+}
+
+.hoa-tab {
+  background: none;
+  border: 1px solid transparent;
+  color: #7a9a7a;
+  font-family: monospace;
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  padding: 4px 10px;
+  cursor: pointer;
+  position: relative;
+  border-radius: 2px 2px 0 0;
+}
+.hoa-tab:hover { color: #c8e8c8; border-color: #446644; }
+.hoa-tab--active {
+  color: #c8e8c8;
+  border-color: #446644;
+  border-bottom-color: #0a120a;
+  background: #0a120a;
+}
+
+.hoa-badge {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  background: #ffcc00;
+  color: #1a1000;
+  font-size: 9px;
+  font-weight: bold;
+  min-width: 14px;
+  height: 14px;
+  line-height: 14px;
+  text-align: center;
+  border-radius: 7px;
+  padding: 0 3px;
+}
+
+.hoa-claim-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 12px;
+  background: rgba(255,204,0,0.07);
+  border-bottom: 1px solid #3a3a1a;
+  font-size: 12px;
+  color: #c8c880;
+}
+
+.hoa-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(80px, 1fr));
+  gap: 8px;
+  padding: 12px;
+  overflow-y: auto;
+  flex: 1;
+}
+
+.hoa-tile {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  background: rgba(10,18,10,0.6);
+  border: 1px solid #1a2a1a;
+  padding: 8px 4px 6px;
+  cursor: pointer;
+  border-radius: 2px;
+  position: relative;
+  transition: border-color 0.15s, background 0.15s;
+}
+.hoa-tile:hover { border-color: #446644; background: rgba(20,36,20,0.8); }
+.hoa-tile--claimable { border-color: #aa8800; }
+.hoa-tile--claimable:hover { border-color: #ffcc00; }
+
+.hoa-tile-icon { line-height: 0; }
+
+.hoa-tile-name {
+  font-size: 9px;
+  color: #7a9a7a;
+  font-family: monospace;
+  text-align: center;
+  line-height: 1.3;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  max-height: 2.6em;
+}
+.hoa-tile--unlocked .hoa-tile-name { color: #c8e8c8; }
+
+.hoa-tile-dot {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #ffcc00;
+}
+
+/* ── Detail modal ── */
+
+.hoa-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.72);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 200;
+}
+
+.hoa-modal {
+  background: rgba(8,14,8,0.97);
+  border: 1px solid #446644;
+  padding: 20px 24px;
+  max-width: 320px;
+  width: calc(100% - 32px);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  text-align: center;
+}
+
+.hoa-modal-icon { line-height: 0; }
+
+.hoa-modal-name {
+  font-size: 15px;
+  color: #c8e8c8;
+  font-family: monospace;
+  letter-spacing: 0.06em;
+  font-weight: bold;
+}
+
+.hoa-modal-desc {
+  font-size: 12px;
+  color: #9ab89a;
+  line-height: 1.5;
+}
+
+.hoa-modal-criteria,
+.hoa-modal-reward {
+  font-size: 11px;
+  color: #7a9a7a;
+  font-family: monospace;
+}
+
+.hoa-modal-unlocked {
+  font-size: 12px;
+  color: #88cc88;
+  letter-spacing: 0.12em;
+  font-family: monospace;
+}
+
+.hoa-modal-claimed {
+  font-size: 11px;
+  color: #557755;
+  font-family: monospace;
+  letter-spacing: 0.08em;
+}
+
+.hoa-modal-close { margin-top: 4px; }
+
 /* ── Battery / reduced-motion optimisations ────────────────────────────── */
 /* Disable infinite decorative animations for users who prefer reduced motion
    or on any device where the browser opts in via the media query. This also


### PR DESCRIPTION
## Summary

- New `HallOfAchievements` screen accessible from the hub map achievements node (tx=56,ty=19)
- Responsive grid of trophy/plinth tiles — gold trophy SVG for unlocked achievements, grey stone plinth for locked
- Category tabs (Campaign, Daily, Playtime, Misc, Events, Kills, Structures) with claimable-reward badge counts
- Tap any tile → detail modal with name, description, progress criteria, reward line, and Claim Reward button
- "Claim All" bar appears whenever any unclaimed rewards are ready
- Old `achievements` screen (title screen path) unchanged; new `hall-of-achievements` Screen type routes back to hubworld
- CSS-only styling via new `.hoa-*` classes in styles.css

## Test plan
- [ ] Open Hub World → walk to Achievements node (NE district) → Hall opens
- [ ] Category tabs switch grid correctly
- [ ] Locked achievements show grey plinth + "???" name
- [ ] Unlocked achievements show gold trophy + real name + gold border
- [ ] Claimable achievements show gold dot indicator; "Claim All" bar appears
- [ ] Tapping any tile opens detail modal with correct info
- [ ] Claim Reward button claims reward and updates the tile
- [ ] Back button returns to Hub World
- [ ] Old achievements route from title screen still works
- [ ] `npm run build` passes with zero TypeScript errors

https://claude.ai/code/session_013AyvzYXfUBE58v7YcFBnne

---
_Generated by [Claude Code](https://claude.ai/code/session_013AyvzYXfUBE58v7YcFBnne)_