### PR TITLE
#1407 Home — inventory and relics on wooden shelves

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -109,6 +109,7 @@ import {
 import { incrementAugmentSouls } from './game/collection'
 import { AchievementsScreen }  from './components/screens/AchievementsScreen'
 import { HallOfAchievements }   from './components/hub/HallOfAchievements'
+import { HomeShelf }             from './components/hub/HomeShelf'
 import { HeroCardsScreen }   from './components/screens/HeroCardsScreen'
 import FingerSmash from './components/battle/FingerSmash'
 import BossShockwave from './components/battle/BossShockwave'
@@ -223,6 +224,7 @@ type Screen =
   | 'augments'
   | 'player'
   | 'collection-tabs'
+  | 'home-shelf'
   | 'hubworld'
 
 
@@ -2834,6 +2836,10 @@ export default function App() {
           onBack={() => setScreen('hubworld')}
           onCrystalsChanged={handleCrystalsChanged}
         />
+      )}
+
+      {screen === 'home-shelf' && (
+        <HomeShelf onBack={() => setScreen('hubworld')} />
       )}
 
       {screen === 'heroCards' && (

--- a/web/src/components/hub/HomeShelf.stories.tsx
+++ b/web/src/components/hub/HomeShelf.stories.tsx
@@ -1,0 +1,16 @@
+import { fn } from 'storybook/test'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { HomeShelf } from './HomeShelf'
+
+const meta = {
+  component: HomeShelf,
+} satisfies Meta<typeof HomeShelf>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    onBack: fn(),
+  },
+}

--- a/web/src/components/hub/HomeShelf.tsx
+++ b/web/src/components/hub/HomeShelf.tsx
@@ -1,0 +1,107 @@
+import React, { useState } from 'react'
+import { UselessItem, loadInventory } from '../../game/dailyLogin'
+import { loadEarnedRelics, getRelicDef, RelicDef } from '../../game/relics'
+import { OverlayScreen } from '../ui/OverlayScreen'
+
+interface Props {
+  onBack: () => void
+}
+
+type ShelfEntry =
+  | { kind: 'item';  item: UselessItem }
+  | { kind: 'relic'; relic: RelicDef }
+
+const SLOTS_PER_ROW = 6
+
+export function HomeShelf({ onBack }: Props) {
+  const items  = loadInventory()
+  const relics = loadEarnedRelics()
+    .map(name => getRelicDef(name))
+    .filter((r): r is RelicDef => !!r)
+
+  const entries: ShelfEntry[] = [
+    ...relics.map(r => ({ kind: 'relic' as const, relic: r })),
+    ...items.map(i => ({ kind: 'item'  as const, item:  i })),
+  ]
+
+  // Pad to a full number of rows (at least 3 rows shown)
+  const minSlots   = Math.max(SLOTS_PER_ROW * 3, Math.ceil(entries.length / SLOTS_PER_ROW) * SLOTS_PER_ROW)
+  const slots: Array<ShelfEntry | null> = [
+    ...entries,
+    ...Array(minSlots - entries.length).fill(null),
+  ]
+
+  const rows: Array<Array<ShelfEntry | null>> = []
+  for (let i = 0; i < slots.length; i += SLOTS_PER_ROW)
+    rows.push(slots.slice(i, i + SLOTS_PER_ROW))
+
+  const [detail, setDetail] = useState<ShelfEntry | null>(null)
+
+  return (
+    <OverlayScreen title="HOME" onBack={onBack}>
+      <div className="shelf-room">
+        {entries.length === 0 && (
+          <div className="shelf-empty-msg">Your shelves are bare. Collect items to fill them.</div>
+        )}
+        {rows.map((row, ri) => (
+          <div key={ri} className="shelf-row">
+            <div className="shelf-items">
+              {row.map((entry, si) => (
+                <button
+                  key={si}
+                  className={`shelf-slot${entry ? ' shelf-slot--filled' : ' shelf-slot--empty'}`}
+                  onClick={() => entry && setDetail(entry)}
+                  disabled={!entry}
+                  aria-label={entry ? (entry.kind === 'item' ? entry.item.name : entry.relic.name) : 'Empty slot'}
+                >
+                  {entry ? (
+                    <>
+                      <span className="shelf-slot-icon">
+                        {entry.kind === 'item' ? entry.item.icon : entry.relic.icon}
+                      </span>
+                      <span className="shelf-slot-name">
+                        {entry.kind === 'item' ? entry.item.name : entry.relic.name}
+                      </span>
+                    </>
+                  ) : (
+                    <span className="shelf-slot-dust" />
+                  )}
+                </button>
+              ))}
+            </div>
+            <div className="shelf-plank" />
+          </div>
+        ))}
+      </div>
+
+      {detail && (
+        <div className="shelf-modal-backdrop" onClick={() => setDetail(null)}>
+          <div className="shelf-modal" onClick={e => e.stopPropagation()}>
+            <div className="shelf-modal-icon">
+              {detail.kind === 'item' ? detail.item.icon : detail.relic.icon}
+            </div>
+            <div className="shelf-modal-name">
+              {detail.kind === 'item' ? detail.item.name : detail.relic.name}
+            </div>
+            {detail.kind === 'relic' && (
+              <div className="shelf-modal-tag">RELIC</div>
+            )}
+            {detail.kind === 'item' && detail.item.id.startsWith('broken-relic-') && (
+              <div className="shelf-modal-tag shelf-modal-tag--broken">BROKEN RELIC</div>
+            )}
+            <div className="shelf-modal-desc">
+              {detail.kind === 'item' ? detail.item.desc : detail.relic.desc}
+            </div>
+            {detail.kind === 'item' && detail.item.lore && (
+              <div className="shelf-modal-lore">"{detail.item.lore}"</div>
+            )}
+            {detail.kind === 'item' && detail.item.acquiredDate && (
+              <div className="shelf-modal-date">Acquired: {detail.item.acquiredDate}</div>
+            )}
+            <button className="action-btn" onClick={() => setDetail(null)}>CLOSE</button>
+          </div>
+        </div>
+      )}
+    </OverlayScreen>
+  )
+}

--- a/web/src/data/hubLayout.ts
+++ b/web/src/data/hubLayout.ts
@@ -44,7 +44,7 @@ export const HUB_NODES: HubNode[] = [
   { id: 'codex',        label: 'Codex',         tx: 56, ty: 15, screen: 'codex'          },
   { id: 'commander',    label: 'Commander',     tx: 37, ty: 24, screen: 'commander'      },
   { id: 'achievements', label: 'Achievements',  tx: 56, ty: 19, screen: 'hall-of-achievements' },
-  { id: 'home',         label: 'Home',          tx: 19, ty: 18, screen: 'collection-tabs'},
+  { id: 'home',         label: 'Home',          tx: 19, ty: 18, screen: 'home-shelf'     },
 ]
 
 // Generate tile positions for a filled rectangular region (inclusive).

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -7310,6 +7310,165 @@ body {
 
 .hoa-modal-close { margin-top: 4px; }
 
+/* ── Home Shelf ─────────────────────────────────────────────────────────── */
+
+.shelf-room {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  padding: 12px 12px 0;
+  overflow-y: auto;
+  flex: 1;
+}
+
+.shelf-empty-msg {
+  font-size: 13px;
+  color: #5a7a5a;
+  font-family: monospace;
+  text-align: center;
+  padding: 24px 0 8px;
+  letter-spacing: 0.04em;
+}
+
+.shelf-row {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 16px;
+}
+
+.shelf-items {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 4px;
+  padding-bottom: 6px;
+}
+
+/* Wooden plank */
+.shelf-plank {
+  height: 10px;
+  background: linear-gradient(to bottom, #7a4a20 0%, #5a3010 60%, #3a1a00 100%);
+  border-top: 2px solid #aa7040;
+  box-shadow: 0 3px 6px rgba(0,0,0,0.5);
+  border-radius: 1px;
+}
+
+.shelf-slot {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 3px;
+  min-height: 72px;
+  padding: 6px 4px 4px;
+  background: none;
+  border: 1px solid transparent;
+  cursor: default;
+}
+
+.shelf-slot--filled {
+  cursor: pointer;
+  border-color: transparent;
+  transition: border-color 0.15s, background 0.15s;
+}
+.shelf-slot--filled:hover {
+  border-color: #446644;
+  background: rgba(20,36,20,0.5);
+}
+
+.shelf-slot--empty { opacity: 0.3; cursor: default; }
+
+.shelf-slot-icon {
+  font-size: 32px;
+  line-height: 1;
+  display: block;
+  filter: drop-shadow(0 2px 3px rgba(0,0,0,0.6));
+}
+
+.shelf-slot-name {
+  font-size: 9px;
+  color: #9ab89a;
+  font-family: monospace;
+  text-align: center;
+  line-height: 1.2;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.shelf-slot-dust {
+  display: block;
+  width: 28px;
+  height: 4px;
+  background: rgba(120,90,60,0.2);
+  border-radius: 2px;
+  margin-bottom: 8px;
+}
+
+/* ── Shelf item detail modal ── */
+
+.shelf-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.72);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 200;
+}
+
+.shelf-modal {
+  background: rgba(8,14,8,0.97);
+  border: 1px solid #446644;
+  padding: 20px 24px;
+  max-width: 300px;
+  width: calc(100% - 32px);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  text-align: center;
+}
+
+.shelf-modal-icon { font-size: 48px; line-height: 1; }
+
+.shelf-modal-name {
+  font-size: 15px;
+  color: #c8e8c8;
+  font-family: monospace;
+  letter-spacing: 0.06em;
+  font-weight: bold;
+}
+
+.shelf-modal-tag {
+  font-size: 10px;
+  color: #88cc88;
+  border: 1px solid #446644;
+  padding: 1px 8px;
+  letter-spacing: 0.1em;
+  font-family: monospace;
+}
+.shelf-modal-tag--broken { color: #cc8844; border-color: #664422; }
+
+.shelf-modal-desc {
+  font-size: 12px;
+  color: #9ab89a;
+  line-height: 1.5;
+}
+
+.shelf-modal-lore {
+  font-size: 11px;
+  color: #6a8a6a;
+  font-style: italic;
+  line-height: 1.4;
+}
+
+.shelf-modal-date {
+  font-size: 10px;
+  color: #4a6a4a;
+  font-family: monospace;
+}
+
 /* ── Battery / reduced-motion optimisations ────────────────────────────── */
 /* Disable infinite decorative animations for users who prefer reduced motion
    or on any device where the browser opts in via the media query. This also


### PR DESCRIPTION
## Summary

- New `HomeShelf` screen accessible from the hub Home node (tx=19,ty=18)
- Displays the player's earned relics and useless items as large emoji icons sitting on wooden shelf rows
- 6 slots per shelf row; empty slots show a faint dust mark; remaining space padded to at least 3 full rows
- Tapping any item opens a detail modal with name, description, lore, acquired date, and a relic/broken-relic tag where applicable
- CSS wooden plank effect via gradient + box-shadow for the shelf surfaces
- Old `collection-tabs` route from the title screen is unchanged; `home-shelf` routes back to hubworld

## Test plan
- [ ] Open Hub World → walk to Home node (NW district) → HomeShelf opens
- [ ] Items displayed as emoji icons on shelf rows with name label below
- [ ] Relics appear first, then useless items
- [ ] Empty slots show faint dust placeholder, not clickable
- [ ] Tapping a filled slot opens detail modal with correct info
- [ ] CLOSE button dismisses the modal
- [ ] Empty inventory shows "Your shelves are bare" message
- [ ] Back button returns to Hub World
- [ ] `npm run build` passes with zero TypeScript errors

https://claude.ai/code/session_013AyvzYXfUBE58v7YcFBnne

---
_Generated by [Claude Code](https://claude.ai/code/session_013AyvzYXfUBE58v7YcFBnne)_