### PR TITLE
fix: hub world card-unit NPCs visible on mobile

### DIFF
--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -189,7 +189,7 @@ export function HubTownCanvas({ onAreaEnter, onNodeInteract, onAvatarMove, retur
             currentTile: [tx, ty],
             walkQueue:   [],
             isWalking:   false,
-            wanderTimer: 3000 + Math.random() * 7000,  // initial delay 3–10 s
+            wanderTimer: 500 + Math.random() * 1500,   // initial delay 0.5–2 s
           }
           unitNpcs.push(state)
         }).catch(() => {/* silently skip missing sprites */})

--- a/web/src/data/hubNpcs.ts
+++ b/web/src/data/hubNpcs.ts
@@ -78,7 +78,15 @@ export const QUEST_GIVER_NPCS: QuestGiverNpc[] = [
 ]
 
 // Preset positions for card-unit NPC spawning — all on street tiles, spread across the map.
+// Courtyard tiles (tx≈33-41, ty≈21-28) are always in the initial mobile viewport so NPCs
+// are visible immediately without scrolling.
 export const NPC_SPAWN_TILES: [number, number][] = [
+  // ── Courtyard — always visible on mobile ─────────────────────────────────
+  [35, 23],   // courtyard NW
+  [39, 23],   // courtyard NE
+  [35, 26],   // courtyard SW
+  [39, 26],   // courtyard SE
+  // ── Rest of the map ───────────────────────────────────────────────────────
   [19,  8],   // NW alley upper
   [19, 15],   // NW alley mid
   [10, 24],   // Market Lane west


### PR DESCRIPTION
## Summary

- Added 4 courtyard spawn tiles to `NPC_SPAWN_TILES` so at least 4 NPCs always land inside the initial mobile viewport (the courtyard is centered in view on load)
- Reduced initial wander delay from 3–10 s → 0.5–2 s so NPCs start walking almost immediately instead of several seconds after the hub opens

## Root cause

All previous spawn tiles were in outlying streets (NW alley, Market Lane, NE spur, etc.) — all outside the ~12-tile-wide mobile viewport that appears on first load. On a PC the map is wide enough that the player can see further out, but on a phone the courtyard area is the only thing visible without scrolling.

## Test plan

- [ ] Open hub world on a mobile device — at least 4 NPCs should be visible wandering in the courtyard immediately
- [ ] NPCs in outlying areas still appear when scrolling to those streets
- [ ] PC rendering unchanged

https://claude.ai/code/session_013AyvzYXfUBE58v7YcFBnne

---
_Generated by [Claude Code](https://claude.ai/code/session_013AyvzYXfUBE58v7YcFBnne)_