### PR TITLE
feat(hub): #1410 hub world unlock condition

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -43,7 +43,7 @@ import { EventScreen }          from './components/campaign/EventScreen'
 import { MerchantScreen, MerchantItem, cardMerchantItem } from './components/campaign/MerchantScreen'
 import { MysteryScreen } from './components/campaign/MysteryScreen'
 import { MemoryFragmentScreen } from './components/campaign/MemoryFragmentScreen'
-import { MemoryFragment, isFragmentDiscovered, markFragmentDiscovered } from './game/codex'
+import { MemoryFragment, isFragmentDiscovered, markFragmentDiscovered, isHubWorldUnlocked, unlockHubWorld, areAllCampaignFragmentsDiscovered } from './game/codex'
 import { CharacterEncounterScreen } from './components/campaign/CharacterEncounterScreen'
 import { CharacterChoice, recordCharacterEncounter } from './game/characters'
 import memoryFragmentsData from './data/memoryFragments.json'
@@ -319,6 +319,7 @@ export default function App() {
     if (savedRun && savedAct && isActComplete(savedAct, savedRun)) {
       return { screen: 'actcomplete' as Screen, gameState: null as GameState | null, run: savedRun, isCampaign: false }
     }
+    if (isHubWorldUnlocked()) return { screen: 'hubworld' as Screen, gameState: null as GameState | null, run: savedRun as RunState | null, isCampaign: false }
     return { screen: (loadSkipIntro() ? 'title' : 'intro') as Screen, gameState: null as GameState | null, run: savedRun as RunState | null, isCampaign: false }
   })
 
@@ -1350,6 +1351,7 @@ export default function App() {
     let updatedConsumables = currentRun.consumables
     if (!alreadyFound) {
       shardBonus = markFragmentDiscovered(fragment.id)
+      if (areAllCampaignFragmentsDiscovered()) unlockHubWorld()
       if (shardBonus) {
         const existing = updatedConsumables.find(c => c.id === 'health_potion')
         updatedConsumables = existing
@@ -2484,6 +2486,7 @@ export default function App() {
           onCampaignAdmin={() => setScreen('campaignAdmin')}
           onFeedbackAdmin={() => setScreen('feedbackAdmin')}
           onHubWorld={() => setScreen('hubworld')}
+          onTitleScreen={() => setScreen('title')}
         />
       )}
 

--- a/web/src/components/screens/SettingsScreen.tsx
+++ b/web/src/components/screens/SettingsScreen.tsx
@@ -13,6 +13,7 @@ import { isDevMode } from '../../game/debug'
 import { DevMenu } from '../admin/DevMenu'
 import { GIFT_OWNER_UID } from '../../game/gifts'
 import { loadPlaytime, formatPlaytime } from '../../game/playtime'
+import { isHubWorldUnlocked, unlockHubWorld } from '../../game/codex'
 
 interface Props {
   onBack: () => void
@@ -26,6 +27,7 @@ interface Props {
   onCampaignAdmin?: () => void
   onFeedbackAdmin?: () => void
   onHubWorld?: () => void
+  onTitleScreen?: () => void
 }
 
 const TEXT_SIZE_KEY      = 'jarv_text_size'
@@ -158,7 +160,7 @@ function exportLocalStorage(): void {
   URL.revokeObjectURL(url)
 }
 
-export function SettingsScreen({ onBack, onResetGame, user, authLoading, onDevCrystalsChanged, onDevHandicapChanged, onGiftAdmin, onNewsAdmin, onCampaignAdmin, onFeedbackAdmin, onHubWorld }: Props) {
+export function SettingsScreen({ onBack, onResetGame, user, authLoading, onDevCrystalsChanged, onDevHandicapChanged, onGiftAdmin, onNewsAdmin, onCampaignAdmin, onFeedbackAdmin, onHubWorld, onTitleScreen }: Props) {
   const [soundOn,       setSoundOn]       = useState(isSoundEnabled)
   const [soundVolume,   setSoundVolumeState]   = useState(getSoundVolume)
   const [musicVolume,   setMusicVolumeState]   = useState(getMusicVolume)
@@ -573,14 +575,35 @@ export function SettingsScreen({ onBack, onResetGame, user, authLoading, onDevCr
           </div>
         </Section>
 
-        {user?.uid === GIFT_OWNER_UID && onHubWorld && (
-          <Section bordered title="EXPERIMENTS">
+        {isHubWorldUnlocked() && onTitleScreen && (
+          <Section bordered title="NAVIGATION">
             <div className="settings-row u-flex u-items-c u-just-sb u-gap-7">
               <div>
-                <div className="settings-label">Hub World</div>
-                <div className="settings-sublabel">Prototype terrain canvas</div>
+                <div className="settings-label">Classic Title Screen</div>
+                <div className="settings-sublabel">Return to the original title screen</div>
               </div>
-              <button className="action-btn" onClick={onHubWorld}>OPEN</button>
+              <button className="action-btn" onClick={onTitleScreen}>GO</button>
+            </div>
+          </Section>
+        )}
+
+        {user?.uid === GIFT_OWNER_UID && (onHubWorld || onTitleScreen) && (
+          <Section bordered title="EXPERIMENTS">
+            {onHubWorld && (
+              <div className="settings-row u-flex u-items-c u-just-sb u-gap-7">
+                <div>
+                  <div className="settings-label">Hub World</div>
+                  <div className="settings-sublabel">Prototype terrain canvas</div>
+                </div>
+                <button className="action-btn" onClick={onHubWorld}>OPEN</button>
+              </div>
+            )}
+            <div className="settings-row u-flex u-items-c u-just-sb u-gap-7">
+              <div>
+                <div className="settings-label">Unlock Hub World</div>
+                <div className="settings-sublabel">Dev cheat — sets the hub world unlock flag</div>
+              </div>
+              <button className="action-btn" onClick={() => { unlockHubWorld(); window.location.reload() }}>UNLOCK</button>
             </div>
           </Section>
         )}

--- a/web/src/game/codex.ts
+++ b/web/src/game/codex.ts
@@ -28,7 +28,8 @@ const ALL_ACTS: any[] = [
   act11Data, act12Data, act13Data, actFinaleData,
 ]
 
-const FRAGMENT_KEY = 'jarv_memory_fragments'
+const FRAGMENT_KEY        = 'jarv_memory_fragments'
+const HUB_WORLD_UNLOCK_KEY = 'jarv_hub_world_unlocked'
 
 export interface MemoryFragment {
   id: string
@@ -52,6 +53,19 @@ export function getDiscoveredFragmentIds(): Set<string> {
 
 export function isFragmentDiscovered(id: string): boolean {
   return getDiscoveredFragmentIds().has(id)
+}
+
+export function isHubWorldUnlocked(): boolean {
+  try { return localStorage.getItem(HUB_WORLD_UNLOCK_KEY) === 'true' } catch { return false }
+}
+
+export function unlockHubWorld(): void {
+  try { localStorage.setItem(HUB_WORLD_UNLOCK_KEY, 'true') } catch { /* ignore */ }
+}
+
+export function areAllCampaignFragmentsDiscovered(): boolean {
+  const discovered = getDiscoveredFragmentIds()
+  return (memoryFragmentsData as MemoryFragment[]).every(f => discovered.has(f.id))
 }
 
 /** Returns true if this discovery completed all fragments for the act (bonus trigger). */


### PR DESCRIPTION
Closes #1410. Part of #1331.

## Summary

- `codex.ts` adds `isHubWorldUnlocked()`, `unlockHubWorld()`, and `areAllCampaignFragmentsDiscovered()` helpers
- When the last memory fragment is collected, `unlockHubWorld()` is called automatically — `jarv_hub_world_unlocked` is set in localStorage
- App startup checks the flag: boots to hub world instead of the title/intro screen
- Settings screen shows a **NAVIGATION** section with a "Classic Title Screen" button when the hub world is unlocked (lets players return to the original title)
- Owner UID settings **EXPERIMENTS** section gains an "Unlock Hub World" dev cheat button

## Test plan

- [ ] Collect all 26 memory fragments → `jarv_hub_world_unlocked` appears in localStorage
- [ ] Reload app → boots directly to hub world
- [ ] Settings → NAVIGATION → "Classic Title Screen" → navigates to title screen
- [ ] Owner UID dev cheat button sets flag and reloads to hub world

https://claude.ai/code/session_013AyvzYXfUBE58v7YcFBnne

---
_Generated by [Claude Code](https://claude.ai/code/session_013AyvzYXfUBE58v7YcFBnne)_