### PR TITLE
feat(hub): #1408 fishing pond node and fisherman NPC

### DIFF
--- a/web/public/sprites/hub-npc-fisherman.svg
+++ b/web/public/sprites/hub-npc-fisherman.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Body -->
+  <rect x="11" y="14" width="10" height="11" rx="2" fill="#4a6a3a"/>
+  <!-- Head -->
+  <circle cx="16" cy="10" r="5" fill="#c8a07a"/>
+  <!-- Wide-brim fishing hat -->
+  <ellipse cx="16" cy="6" rx="8" ry="2.5" fill="#6a5a2a"/>
+  <rect x="13" y="4" width="6" height="4" rx="1.5" fill="#7a6a30"/>
+  <!-- Eyes -->
+  <circle cx="14" cy="10" r="1" fill="#3a2a1a"/>
+  <circle cx="18" cy="10" r="1" fill="#3a2a1a"/>
+  <!-- Beard -->
+  <ellipse cx="16" cy="14" rx="3.5" ry="2" fill="#c8c8b0"/>
+  <!-- Fishing rod (right hand) -->
+  <line x1="21" y1="15" x2="30" y2="4" stroke="#8a6a3a" stroke-width="1.5"/>
+  <line x1="30" y1="4" x2="30" y2="10" stroke="#88bbdd" stroke-width="1"/>
+  <circle cx="30" cy="10" r="1.5" fill="#88bbdd"/>
+  <!-- Legs -->
+  <rect x="12" y="24" width="4" height="6" rx="1" fill="#3a4a2a"/>
+  <rect x="17" y="24" width="4" height="6" rx="1" fill="#3a4a2a"/>
+  <!-- Boots -->
+  <rect x="11" y="28" width="5" height="3" rx="1" fill="#2a1a0a"/>
+  <rect x="16" y="28" width="5" height="3" rx="1" fill="#2a1a0a"/>
+</svg>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -226,6 +226,7 @@ type Screen =
   | 'collection-tabs'
   | 'home-shelf'
   | 'hubworld'
+  | 'hub-fishing'
 
 
 const STANCE_RULES_BY_NODE_TYPE: Partial<Record<string, StanceRules>> = {
@@ -2931,6 +2932,17 @@ export default function App() {
           characterName={loadPlayerName()}
           onBack={() => { setMiniGamesEntry('menu'); setScreen('title') }}
           initialSubScreen={miniGamesEntry}
+        />
+      )}
+
+      {screen === 'hub-fishing' && (
+        <MiniGamesMenu
+          crystals={crystals}
+          onCrystalsChange={(n) => { saveCrystals(n); setCrystals(n) }}
+          user={user}
+          characterName={loadPlayerName()}
+          onBack={() => setScreen('hubworld')}
+          initialSubScreen="fishing"
         />
       )}
 

--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -73,6 +73,21 @@ export function HubTownCanvas({ onAreaEnter, onNodeInteract, onAvatarMove, retur
     buildDecorGfx(groundLayer, { environment: HUB_ENV, id: 'hubworld' }, MAP_W, MAP_H)
       .catch(e => console.error('[HubTownCanvas] decor tiles failed', e))
 
+    // ── Pond (Greyfish Pond — SW district, between building blocks) ───────────
+    {
+      const g = new PIXI.Graphics()
+      const px = 5 * T, py = 34 * T + T / 2
+      // Deep water fill
+      g.ellipse(px, py, 112, 56).fill({ color: 0x1a3a6a, alpha: 0.92 })
+      // Mid-water shimmer
+      g.ellipse(px, py, 96, 44).fill({ color: 0x1e5090, alpha: 0.7 })
+      // Highlight
+      g.ellipse(px - 24, py - 12, 32, 14).fill({ color: 0x5ab4e8, alpha: 0.22 })
+      // Shore fringe
+      g.ellipse(px, py, 112, 56).stroke({ color: 0x2a6aaa, width: 2.5, alpha: 0.8 })
+      groundLayer.addChild(g)
+    }
+
     // ── Streets ────────────────────────────────────────────────────────────────
     const pathSet = new Set(HUB_STREET_TILES.map(([tx, ty]) => `${tx},${ty}`))
     renderPathTiles(streetLayer, pathSet, HUB_ENV)

--- a/web/src/data/hubLayout.ts
+++ b/web/src/data/hubLayout.ts
@@ -31,6 +31,7 @@ export const HUB_AREAS: HubArea[] = [
   { id: 'market',    name: 'Market Lane',             x:  0,     y: 23 * T, w: 33 * T, h: 3 * T  },
   { id: 'arcade',    name: 'The Arcade Quarter',      x: 42 * T, y: 23 * T, w: 33 * T, h: 3 * T  },
   { id: 'scholars',  name: "The Scholar's Hall",      x: 42 * T, y:  0,     w: 33 * T, h: 23 * T },
+  { id: 'pond',      name: 'Greyfish Pond',           x:  1 * T, y: 33 * T, w: 9 * T,  h: 5 * T  },
 ]
 
 // Tappable location nodes — all placed on street tiles.
@@ -45,6 +46,7 @@ export const HUB_NODES: HubNode[] = [
   { id: 'commander',    label: 'Commander',     tx: 37, ty: 24, screen: 'commander'      },
   { id: 'achievements', label: 'Achievements',  tx: 56, ty: 19, screen: 'hall-of-achievements' },
   { id: 'home',         label: 'Home',          tx: 19, ty: 18, screen: 'home-shelf'     },
+  { id: 'fishing',      label: 'Fishing Hole',  tx:  5, ty: 35, screen: 'hub-fishing'    },
 ]
 
 // Generate tile positions for a filled rectangular region (inclusive).

--- a/web/src/data/hubNpcs.ts
+++ b/web/src/data/hubNpcs.ts
@@ -75,6 +75,14 @@ export const QUEST_GIVER_NPCS: QuestGiverNpc[] = [
     dialogue: '',
     screen:   'shop-supplies',
   },
+  {
+    id:      'fisherman',
+    name:    'Old Greyfish',
+    sprite:  'hub-npc-fisherman',
+    tx:       3,
+    ty:      35,
+    dialogue: "Been sitting at this pond since before the Fracture. The water's gone quiet lately — something's stirring beneath.",
+  },
 ]
 
 // Preset positions for card-unit NPC spawning — all on street tiles, spread across the map.


### PR DESCRIPTION
Closes #1408. Part of #1331.

## Summary

- **Pond visual**: PixiJS ellipse drawn in the SW district between the two building blocks (tx≈1–9, ty≈33–37) — layered above terrain, below street tiles. Deep blue fill with a shimmer highlight and a shore stroke.
- **Greyfish Pond** HubArea added for area name badge on hover/move
- **Fishing Hole** HubNode at tx=5, ty=35 (on the SW cross-spur path) navigates to `hub-fishing`
- **Old Greyfish** quest-giver NPC with fishing-rod sprite at tx=3, ty=35 — tapping shows flavour dialogue
- **`hub-fishing` Screen** added to App.tsx: renders MiniGamesMenu with `initialSubScreen="fishing"`, back goes to hub world

## Test plan

- [ ] Hub world: pond blue ellipse visible in the SW district
- [ ] Moving into the pond area shows "Greyfish Pond" name badge
- [ ] Tapping the Fishing Hole node opens the fishing mini-game
- [ ] Returning from the fishing game returns to hub world
- [ ] Tapping Old Greyfish shows the dialogue panel
- [ ] No regressions in other hub nodes or mini-games

https://claude.ai/code/session_013AyvzYXfUBE58v7YcFBnne

---
_Generated by [Claude Code](https://claude.ai/code/session_013AyvzYXfUBE58v7YcFBnne)_