### PR TITLE
feat(hub): #1409 casino building with PixiJS roulette table

### DIFF
--- a/web/public/sprites/hub-npc-dealer.svg
+++ b/web/public/sprites/hub-npc-dealer.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Body — formal black jacket -->
+  <rect x="10" y="14" width="12" height="12" rx="2" fill="#1a1a2a"/>
+  <!-- White shirt / bow-tie area -->
+  <rect x="13" y="14" width="6" height="7" rx="1" fill="#e8e8f0"/>
+  <circle cx="16" cy="17" r="1.5" fill="#2a1a4a"/>
+  <!-- Head -->
+  <circle cx="16" cy="10" r="5" fill="#c8a07a"/>
+  <!-- Slicked hair -->
+  <ellipse cx="16" cy="6" rx="5" ry="2.5" fill="#2a1a0a"/>
+  <rect x="11" y="5" width="10" height="4" rx="1" fill="#2a1a0a"/>
+  <!-- Eyes — sharp gaze -->
+  <rect x="13" y="9" width="2" height="2" rx="0.5" fill="#1a1a2a"/>
+  <rect x="17" y="9" width="2" height="2" rx="0.5" fill="#1a1a2a"/>
+  <!-- Thin moustache -->
+  <rect x="13" y="13" width="6" height="1" rx="0.5" fill="#2a1a0a"/>
+  <!-- Arms / cuffs -->
+  <rect x="6"  y="15" width="5" height="3" rx="1" fill="#1a1a2a"/>
+  <rect x="21" y="15" width="5" height="3" rx="1" fill="#1a1a2a"/>
+  <rect x="5"  y="16" width="3" height="2" rx="1" fill="#e8e8f0"/>
+  <rect x="24" y="16" width="3" height="2" rx="1" fill="#e8e8f0"/>
+  <!-- Legs -->
+  <rect x="11" y="25" width="4" height="6" rx="1" fill="#1a1a2a"/>
+  <rect x="17" y="25" width="4" height="6" rx="1" fill="#1a1a2a"/>
+  <!-- Shoes -->
+  <rect x="10" y="29" width="5" height="3" rx="1" fill="#0a0a0a"/>
+  <rect x="17" y="29" width="5" height="3" rx="1" fill="#0a0a0a"/>
+</svg>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -60,6 +60,7 @@ import { DeckBuilder }        from './components/cards/DeckBuilder'
 import { PackOpening }        from './components/cards/PackOpening'
 import { NodeMap }            from './components/campaign/NodeMap'
 import { HubWorld }           from './components/hub/HubWorld'
+import { CasinoScreen }       from './components/hub/CasinoScreen'
 import { PostBattleReward }   from './components/battle/PostBattleReward'
 import { ActComplete }        from './components/battle/ActComplete'
 import { RelicSelectScreen }  from './components/campaign/RelicSelectScreen'
@@ -227,6 +228,7 @@ type Screen =
   | 'home-shelf'
   | 'hubworld'
   | 'hub-fishing'
+  | 'casino'
 
 
 const STANCE_RULES_BY_NODE_TYPE: Partial<Record<string, StanceRules>> = {
@@ -2495,6 +2497,14 @@ export default function App() {
         <HubWorld
           onBack={() => setScreen('settings')}
           onNavigate={(s) => setScreen(s as Screen)}
+        />
+      )}
+
+      {screen === 'casino' && (
+        <CasinoScreen
+          crystals={crystals}
+          onCrystalsChange={(n) => { saveCrystals(n); setCrystals(n) }}
+          onBack={() => setScreen('hubworld')}
         />
       )}
 

--- a/web/src/components/hub/CasinoScreen.tsx
+++ b/web/src/components/hub/CasinoScreen.tsx
@@ -1,0 +1,285 @@
+// ─── Casino Screen — The Lucky Draw ──────────────────────────────────────────
+// PixiJS roulette table with a spinning ball. Same prize segments and crystal
+// cost as the Lucky Spinner mini-game.
+
+import React, { useRef, useState, useCallback } from 'react'
+import * as PIXI from 'pixi.js'
+import { usePixiApp } from '../../hooks/usePixiApp'
+import { addTickets, loadLocalHighScore, saveLocalHighScore } from '../../game/miniGames'
+import { loadCrystals, saveCrystals } from '../../game/collection'
+import { incrementAchievementProgress, setAchievementProgress } from '../../game/achievements'
+import { OverlayScreen } from '../ui/OverlayScreen'
+
+const SPIN_COST     = 10
+const SEGMENTS      = [2, 5, 10, 20, 5, 10, 50, 2]
+const SEG_COLORS    = [0x4a3060, 0x3a5a40, 0x6a2a2a, 0x2a4a6a, 0x3a5a40, 0x6a2a2a, 0xc8a000, 0x4a3060]
+const SEG_COUNT     = SEGMENTS.length
+const JACKPOT       = 50
+const WHEEL_R       = 108
+const BALL_ORBIT_R  = WHEEL_R + 18  // outer orbit before drop
+const BALL_LAND_R   = WHEEL_R * 0.82 // resting position on wheel surface
+const SPIN_DURATION = 4200  // ms
+const CW = 280, CH = 280
+const CX = CW / 2, CY = CH / 2
+
+interface Props {
+  crystals:          number
+  onCrystalsChange:  (n: number) => void
+  onBack:            () => void
+}
+
+interface SpinState {
+  startTime:    number
+  wheelStartR:  number
+  wheelEndR:    number
+  ballStartA:   number
+  ballEndA:     number
+  tickets:      number
+}
+
+export function CasinoScreen({ crystals, onCrystalsChange, onBack }: Props) {
+  const canvasRef    = useRef<HTMLDivElement>(null)
+  const spinStateRef = useRef<SpinState | null>(null)
+  const wheelRef     = useRef<PIXI.Container | null>(null)
+  const ballRef      = useRef<PIXI.Graphics | null>(null)
+
+  const [phase,    setPhase]   = useState<'ready' | 'spinning' | 'result'>('ready')
+  const [result,   setResult]  = useState<number | null>(null)
+  const [balance,  setBalance] = useState(crystals)
+
+  usePixiApp(canvasRef, CW, CH, app => {
+    const toRad = (deg: number) => (deg - 90) * Math.PI / 180
+
+    // ── Green felt background ────────────────────────────────────────────────
+    const bg = new PIXI.Graphics()
+    bg.rect(0, 0, CW, CH).fill({ color: 0x082010 })
+    app.stage.addChild(bg)
+
+    // ── Wheel container (rotates) ────────────────────────────────────────────
+    const wheel = new PIXI.Container()
+    wheel.position.set(CX, CY)
+    wheelRef.current = wheel
+
+    const gfx = new PIXI.Graphics()
+
+    // Gold outer rim
+    gfx.circle(0, 0, WHEEL_R + 7).fill({ color: 0x8a6a00 })
+
+    // Segments
+    for (let i = 0; i < SEG_COUNT; i++) {
+      const sA = toRad(i * (360 / SEG_COUNT))
+      const eA = toRad((i + 1) * (360 / SEG_COUNT))
+      gfx.moveTo(0, 0)
+        .arc(0, 0, WHEEL_R, sA, eA)
+        .closePath()
+        .fill({ color: SEG_COLORS[i] })
+    }
+
+    // Dividing spokes
+    for (let i = 0; i < SEG_COUNT; i++) {
+      const a = toRad(i * (360 / SEG_COUNT))
+      gfx.moveTo(0, 0)
+        .lineTo(WHEEL_R * Math.cos(a), WHEEL_R * Math.sin(a))
+        .stroke({ color: 0xffd700, width: 1.5 })
+    }
+
+    // Center hub
+    gfx.circle(0, 0, 15).fill({ color: 0x1a0800 }).stroke({ color: 0xffd700, width: 2 })
+    wheel.addChild(gfx)
+
+    // Segment labels
+    for (let i = 0; i < SEG_COUNT; i++) {
+      const midDeg = (i + 0.5) * (360 / SEG_COUNT)
+      const a = (midDeg - 90) * Math.PI / 180
+      const r = WHEEL_R * 0.64
+      const val = SEGMENTS[i]
+      const lbl = new PIXI.Text({
+        text: String(val),
+        style: {
+          fontSize:   val === JACKPOT ? 14 : 11,
+          fill:       val === JACKPOT ? '#ffd700' : '#e8e8e8',
+          fontFamily: 'monospace',
+          fontWeight: 'bold',
+        },
+      })
+      lbl.anchor.set(0.5, 0.5)
+      lbl.position.set(r * Math.cos(a), r * Math.sin(a))
+      lbl.rotation = a + Math.PI / 2
+      wheel.addChild(lbl)
+    }
+
+    app.stage.addChild(wheel)
+
+    // ── Ball ─────────────────────────────────────────────────────────────────
+    const ball = new PIXI.Graphics()
+    ball.circle(0, 0, 7).fill({ color: 0xfafafa }).stroke({ color: 0xaaaaaa, width: 1.5 })
+    ball.position.set(CX + BALL_ORBIT_R, CY)
+    ballRef.current = ball
+    app.stage.addChild(ball)
+
+    // ── Pointer ───────────────────────────────────────────────────────────────
+    const ptr = new PIXI.Graphics()
+    ptr.moveTo(0, 0).lineTo(-7, -16).lineTo(7, -16).closePath()
+      .fill({ color: 0xffd700 })
+      .stroke({ color: 0xffa500, width: 1 })
+    ptr.position.set(CX, CY - WHEEL_R - 8)
+    app.stage.addChild(ptr)
+
+    // ── Ticker: drives both wheel rotation and ball orbit ─────────────────────
+    app.ticker.add(() => {
+      const state = spinStateRef.current
+      if (!state) return
+
+      const elapsed = Date.now() - state.startTime
+      const t = Math.min(elapsed / SPIN_DURATION, 1)
+
+      // Ease-out cubic
+      const e = 1 - Math.pow(1 - t, 3)
+
+      // Wheel rotates to final angle
+      wheel.rotation = state.wheelStartR + (state.wheelEndR - state.wheelStartR) * e
+
+      // Ball starts at outer orbit and drops inward as it slows
+      const orbitR = BALL_ORBIT_R - (BALL_ORBIT_R - BALL_LAND_R) * e
+      const ballA  = state.ballStartA + (state.ballEndA - state.ballStartA) * e
+      ball.x = CX + orbitR * Math.cos(ballA)
+      ball.y = CY + orbitR * Math.sin(ballA)
+
+      if (t >= 1) {
+        spinStateRef.current = null
+        // Notify React — state setter is safe to call from a ticker
+        setResult(state.tickets)
+        setPhase('result')
+      }
+    })
+  })
+
+  const spin = useCallback(() => {
+    if (phase !== 'ready') return
+    const current = loadCrystals()
+    if (current < SPIN_COST) return
+
+    // Deduct crystals
+    const next = current - SPIN_COST
+    saveCrystals(next)
+    setBalance(next)
+    onCrystalsChange(next)
+
+    // Pick winning segment
+    const winSeg  = Math.floor(Math.random() * SEG_COUNT)
+    const tickets = SEGMENTS[winSeg]
+
+    // Calculate wheel target: 5-8 full rotations + land winning segment at pointer (top)
+    const fullSpins  = 5 + Math.floor(Math.random() * 4)
+    const segMidDeg  = (winSeg + 0.5) * (360 / SEG_COUNT)
+    const wheelEnd   = (wheelRef.current?.rotation ?? 0) + fullSpins * Math.PI * 2 + (360 - segMidDeg) * Math.PI / 180
+
+    // Ball target angle: pointer is at top (−π/2); winning seg mid mapped to that angle on fixed canvas
+    const ballStartA = ballRef.current
+      ? Math.atan2(ballRef.current.y - CY, ballRef.current.x - CX)
+      : -Math.PI / 2
+    // Ball orbits clockwise; add enough rounds to look like it's spinning then landing
+    const ballRounds = 4 + Math.floor(Math.random() * 3)
+    const ballEndA   = ballStartA + ballRounds * Math.PI * 2 + (-Math.PI / 2 - ballStartA)
+
+    spinStateRef.current = {
+      startTime:   Date.now(),
+      wheelStartR: wheelRef.current?.rotation ?? 0,
+      wheelEndR:   wheelEnd,
+      ballStartA,
+      ballEndA,
+      tickets,
+    }
+
+    setPhase('spinning')
+
+    // Update achievements on completion (handled when phase → 'result')
+    // Store tickets so the effect can read them
+    pendingTicketsRef.current = tickets
+  }, [phase, onCrystalsChange])
+
+  const pendingTicketsRef = useRef(0)
+
+  // When result arrives, record achievements
+  const handleResultShown = useCallback((tickets: number) => {
+    addTickets(tickets)
+    incrementAchievementProgress('miniGame:gamesPlayed')
+    incrementAchievementProgress('miniGame:ticketsEarned', tickets)
+    const best = loadLocalHighScore('spinner')
+    const newBest = Math.max(best, tickets)
+    saveLocalHighScore('spinner', newBest)
+    setAchievementProgress('miniGame:spinner:bestScore', newBest)
+    if (tickets === JACKPOT) incrementAchievementProgress('miniGame:spinner:jackpots')
+  }, [])
+
+  // Fire achievements once when result is first shown
+  const achievementsFiredRef = useRef(false)
+  if (phase === 'result' && result !== null && !achievementsFiredRef.current) {
+    achievementsFiredRef.current = true
+    handleResultShown(result)
+  }
+
+  const handlePlayAgain = () => {
+    achievementsFiredRef.current = false
+    setResult(null)
+    setPhase('ready')
+  }
+
+  const canSpin = balance >= SPIN_COST && phase === 'ready'
+  const isJackpot = result === JACKPOT
+
+  return (
+    <OverlayScreen title="THE LUCKY DRAW" onBack={onBack}>
+      <div className="casino-screen">
+        {/* Dealer */}
+        <div className="casino-dealer-row">
+          <img
+            className="casino-dealer-img"
+            src={`${(import.meta as { env: { BASE_URL: string } }).env.BASE_URL}sprites/hub-npc-dealer.svg`}
+            alt="Vince the Dealer"
+          />
+          <div className="casino-dealer-speech">
+            {phase === 'ready'   && 'Place your crystals and spin the wheel!'}
+            {phase === 'spinning' && "Round and round she goes..."}
+            {phase === 'result' && isJackpot && '⭐ JACKPOT! You\'re a legend!'}
+            {phase === 'result' && !isJackpot && `${result} tickets! Not bad.`}
+          </div>
+        </div>
+
+        {/* Roulette canvas */}
+        <div className="casino-table-wrap">
+          <div ref={canvasRef} className="casino-canvas" />
+        </div>
+
+        {/* Crystal balance */}
+        <div className="casino-currency">💎 {balance.toLocaleString()} crystals</div>
+
+        {/* Controls */}
+        {phase === 'ready' && (
+          <button
+            className={`action-btn${canSpin ? ' action-btn--gold' : ''} casino-spin-btn`}
+            onClick={spin}
+            disabled={!canSpin}
+          >
+            {canSpin ? `SPIN — ${SPIN_COST} 💎` : `NEED ${SPIN_COST} 💎`}
+          </button>
+        )}
+
+        {phase === 'spinning' && (
+          <div className="casino-spinning-label">Spinning...</div>
+        )}
+
+        {phase === 'result' && result !== null && (
+          <div className="casino-result u-col u-items-c u-gap-4">
+            {isJackpot && <div className="casino-jackpot">⭐ JACKPOT! ⭐</div>}
+            <div className="casino-result-headline">You won <strong>{result}</strong> 🎫</div>
+            <div className="u-flex u-gap-4">
+              <button className="action-btn action-btn--gold" onClick={handlePlayAgain}>SPIN AGAIN</button>
+              <button className="action-btn" onClick={onBack}>LEAVE TABLE</button>
+            </div>
+          </div>
+        )}
+      </div>
+    </OverlayScreen>
+  )
+}

--- a/web/src/data/hubLayout.ts
+++ b/web/src/data/hubLayout.ts
@@ -32,6 +32,7 @@ export const HUB_AREAS: HubArea[] = [
   { id: 'arcade',    name: 'The Arcade Quarter',      x: 42 * T, y: 23 * T, w: 33 * T, h: 3 * T  },
   { id: 'scholars',  name: "The Scholar's Hall",      x: 42 * T, y:  0,     w: 33 * T, h: 23 * T },
   { id: 'pond',      name: 'Greyfish Pond',           x:  1 * T, y: 33 * T, w: 9 * T,  h: 5 * T  },
+  { id: 'casino',    name: 'The Lucky Draw',          x: 58 * T, y: 27 * T, w: 15 * T, h: 8 * T  },
 ]
 
 // Tappable location nodes — all placed on street tiles.
@@ -47,6 +48,7 @@ export const HUB_NODES: HubNode[] = [
   { id: 'achievements', label: 'Achievements',  tx: 56, ty: 19, screen: 'hall-of-achievements' },
   { id: 'home',         label: 'Home',          tx: 19, ty: 18, screen: 'home-shelf'     },
   { id: 'fishing',      label: 'Fishing Hole',  tx:  5, ty: 35, screen: 'hub-fishing'    },
+  { id: 'casino',       label: 'Lucky Draw',    tx: 64, ty: 24, screen: 'casino'          },
 ]
 
 // Generate tile positions for a filled rectangular region (inclusive).

--- a/web/src/data/hubNpcs.ts
+++ b/web/src/data/hubNpcs.ts
@@ -83,6 +83,15 @@ export const QUEST_GIVER_NPCS: QuestGiverNpc[] = [
     ty:      35,
     dialogue: "Been sitting at this pond since before the Fracture. The water's gone quiet lately — something's stirring beneath.",
   },
+  {
+    id:      'dealer',
+    name:    'Vince the Dealer',
+    sprite:  'hub-npc-dealer',
+    tx:      64,
+    ty:      26,
+    dialogue: 'The wheel never lies. Step right up — fortune favours the bold.',
+    screen:   'casino',
+  },
 ]
 
 // Preset positions for card-unit NPC spawning — all on street tiles, spread across the map.

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -14451,3 +14451,94 @@ html.light-mode .action-btn {
   gap: 12px;
   justify-content: center;
 }
+
+/* ── Casino / Roulette screen ──────────────────────────────────────────────── */
+.casino-screen {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
+  padding: 12px 8px 20px;
+}
+
+.casino-dealer-row {
+  display: flex;
+  align-items: flex-end;
+  gap: 12px;
+  width: 100%;
+  max-width: 320px;
+}
+
+.casino-dealer-img {
+  width: 52px;
+  height: 52px;
+  flex-shrink: 0;
+}
+
+.casino-dealer-speech {
+  background: rgba(255,255,255,0.06);
+  border: 1px solid rgba(255,255,255,0.15);
+  border-radius: 8px;
+  padding: 8px 12px;
+  font-size: 12px;
+  color: #c8e8c8;
+  font-family: monospace;
+  line-height: 1.4;
+}
+
+.casino-table-wrap {
+  display: flex;
+  justify-content: center;
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 4px 24px rgba(0,0,0,0.6);
+}
+
+.casino-canvas canvas {
+  display: block;
+}
+
+.casino-currency {
+  font-size: 14px;
+  color: #88ddff;
+  font-family: monospace;
+}
+
+.casino-spin-btn {
+  min-width: 160px;
+  font-size: 15px;
+}
+
+.casino-spinning-label {
+  font-size: 14px;
+  color: #aaa;
+  font-family: monospace;
+  animation: casino-pulse 1s ease-in-out infinite;
+}
+
+@keyframes casino-pulse {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0.4; }
+}
+
+.casino-jackpot {
+  font-size: 22px;
+  color: #ffd700;
+  font-family: monospace;
+  font-weight: bold;
+  text-shadow: 0 0 12px #ffd700;
+  animation: casino-jackpot-flash 0.5s ease-in-out 4;
+}
+
+@keyframes casino-jackpot-flash {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50%       { opacity: 0.6; transform: scale(1.12); }
+}
+
+.casino-result { width: 100%; align-items: center; }
+
+.casino-result-headline {
+  font-size: 18px;
+  color: #e8e8e8;
+  font-family: monospace;
+}


### PR DESCRIPTION
Closes #1409. Part of #1331.

## Summary

- **The Lucky Draw** HubArea in the SE Arcade district — area name badge shows on move
- **Lucky Draw** HubNode at tx=64, ty=24 (main horizontal thoroughfare) navigates to `casino`
- **Vince the Dealer** NPC at the entrance (tx=64, ty=26) — tapping opens the casino directly or shows flavour dialogue
- **CasinoScreen** (`CasinoScreen.tsx`):
  - PixiJS roulette wheel: 8 coloured wedges, gold rim, per-segment labels
  - Ball animation: orbits at outer radius, decelerates with ease-out cubic, drops inward to land on the winning segment
  - Dealer speech bubble reacts to each phase (ready / spinning / jackpot / result)
  - Crystal cost 10 💎, same prize segments as Lucky Spinner: `[2, 5, 10, 20, 5, 10, 50, 2]`
  - Tracks `miniGame:spinner:bestScore`, `miniGame:spinner:jackpots`, `miniGame:gamesPlayed`, `miniGame:ticketsEarned` achievements
  - "SPIN AGAIN" resets for another go; "LEAVE TABLE" returns to hub world

## Test plan

- [ ] Tap Lucky Draw node or Vince the Dealer → casino screen opens
- [ ] Roulette wheel renders with 8 coloured segments and labels
- [ ] SPIN deducts 10 crystals and starts the wheel + ball animation
- [ ] Ball slows and stops on the winning segment; result matches tickets
- [ ] Jackpot (50 tickets) triggers golden flash
- [ ] SPIN AGAIN allows another round; LEAVE TABLE returns to hub world
- [ ] Achievements updated correctly after spin
- [ ] Not enough crystals → button disabled

https://claude.ai/code/session_013AyvzYXfUBE58v7YcFBnne

---
_Generated by [Claude Code](https://claude.ai/code/session_013AyvzYXfUBE58v7YcFBnne)_