### PR TITLE
Hub world: toggle, building interiors, NPC fix, avatar animation

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -43,7 +43,7 @@ import { EventScreen }          from './components/campaign/EventScreen'
 import { MerchantScreen, MerchantItem, cardMerchantItem } from './components/campaign/MerchantScreen'
 import { MysteryScreen } from './components/campaign/MysteryScreen'
 import { MemoryFragmentScreen } from './components/campaign/MemoryFragmentScreen'
-import { MemoryFragment, isFragmentDiscovered, markFragmentDiscovered, isHubWorldUnlocked, unlockHubWorld, areAllCampaignFragmentsDiscovered } from './game/codex'
+import { MemoryFragment, isFragmentDiscovered, markFragmentDiscovered, isHubWorldUnlocked, unlockHubWorld, areAllCampaignFragmentsDiscovered, loadHubDefault } from './game/codex'
 import { CharacterEncounterScreen } from './components/campaign/CharacterEncounterScreen'
 import { CharacterChoice, recordCharacterEncounter } from './game/characters'
 import memoryFragmentsData from './data/memoryFragments.json'
@@ -320,7 +320,7 @@ export default function App() {
     if (savedRun && savedAct && isActComplete(savedAct, savedRun)) {
       return { screen: 'actcomplete' as Screen, gameState: null as GameState | null, run: savedRun, isCampaign: false }
     }
-    if (isHubWorldUnlocked()) return { screen: 'hubworld' as Screen, gameState: null as GameState | null, run: savedRun as RunState | null, isCampaign: false }
+    if (isHubWorldUnlocked() && loadHubDefault() !== 'title') return { screen: 'hubworld' as Screen, gameState: null as GameState | null, run: savedRun as RunState | null, isCampaign: false }
     return { screen: (loadSkipIntro() ? 'title' : 'intro') as Screen, gameState: null as GameState | null, run: savedRun as RunState | null, isCampaign: false }
   })
 

--- a/web/src/components/hub/HubInteriorCanvas.tsx
+++ b/web/src/components/hub/HubInteriorCanvas.tsx
@@ -1,0 +1,248 @@
+import React, { useRef } from 'react'
+import * as PIXI from 'pixi.js'
+import { usePixiApp } from '../../hooks/usePixiApp'
+import { HUB_INTERIORS, InteriorDecor } from '../../data/hubInteriors'
+import { loadPlayerAvatar } from '../../game/questline'
+import { loadTextureUrl, loadAnimFrames } from '../../utils/pixiHelpers'
+
+const T             = 32
+const WALK_PX_PER_S = 128
+
+interface Props {
+  buildingId: string
+  onExit: () => void
+}
+
+function drawDecorPiece(g: PIXI.Graphics, decor: InteriorDecor): void {
+  const x = decor.tx * T
+  const y = decor.ty * T
+  const col = decor.color
+  switch (decor.type) {
+    case 'shelf':
+      g.rect(x + 2, y + 4, T - 4, T - 12).fill(col ?? 0x8b5e3c)
+      g.rect(x + 2, y + 4, T - 4, 4).fill(col !== undefined ? Math.min(col + 0x222222, 0xffffff) : 0xaa7744)
+      break
+    case 'table':
+      g.rect(x + 4, y + 8, T - 8, T - 16).fill(col ?? 0x9b6f4a)
+      g.rect(x + 4, y + 8, T - 8, 3).fill(col !== undefined ? Math.min(col + 0x111111, 0xffffff) : 0xbb8855)
+      break
+    case 'counter':
+      g.rect(x + 2, y + 10, T - 4, T - 14).fill(col ?? 0x7a5c38)
+      g.rect(x + 2, y + 10, T - 4, 4).fill(col !== undefined ? Math.min(col + 0x222222, 0xffffff) : 0xaa8855)
+      break
+    case 'barrel':
+      g.ellipse(x + T / 2, y + T / 2, 10, 13).fill(col ?? 0x6b4c2a)
+      g.ellipse(x + T / 2, y + T / 2, 10, 13).stroke({ color: 0x3d2b15, width: 1.5 })
+      g.rect(x + T / 2 - 10, y + T / 2 - 2, 20, 2).fill(0x3d2b15)
+      break
+    case 'chest':
+      g.rect(x + 3, y + 8, T - 6, T - 14).fill(col ?? 0x7a5c38)
+      g.rect(x + 3, y + 8, T - 6, 5).fill(col !== undefined ? Math.min(col + 0x111111, 0xffffff) : 0xaa8040)
+      g.rect(x + T / 2 - 3, y + 10, 6, 6).fill(0xddaa22)
+      break
+    case 'desk':
+      g.rect(x + 2, y + 6, T - 4, T - 10).fill(col ?? 0x6b8b3c)
+      g.rect(x + 2, y + 6, T - 4, 3).fill(col !== undefined ? Math.min(col + 0x111111, 0xffffff) : 0x88aa55)
+      g.rect(x + 4, y + 9, T - 8, T - 16).fill(0x111a0a)
+      break
+    case 'bed':
+      g.rect(x + 2, y + 4, T - 4, T - 8).fill(col ?? 0x335588)
+      g.rect(x + 2, y + 4, T - 4, 8).fill(col !== undefined ? Math.min(col + 0x222222, 0xffffff) : 0x556688)
+      g.rect(x + 4, y + 6, T - 8, 4).fill(0xeeeeff)
+      break
+    case 'fireplace':
+      g.rect(x + 4, y + 4, T - 8, T - 8).fill(0x3a2010)
+      g.rect(x + 6, y + 12, T - 12, T - 18).fill(col ?? 0xcc4400)
+      g.rect(x + 8, y + 14, 4, 6).fill(0xffaa22)
+      g.rect(x + 14, y + 15, 4, 5).fill(0xff8800)
+      break
+  }
+}
+
+export function HubInteriorCanvas({ buildingId, onExit }: Props) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const interior = HUB_INTERIORS[buildingId]
+  const W = interior ? interior.width * T : T
+  const H = interior ? interior.height * T : T
+
+  usePixiApp(containerRef, W, H, (app) => {
+    if (!interior) { onExit(); return }
+
+    // ── Floor ──────────────────────────────────────────────────────────────────
+    const floor = new PIXI.Graphics()
+    for (let tx = 1; tx < interior.width - 1; tx++) {
+      for (let ty = 1; ty < interior.height - 1; ty++) {
+        const shade = ((tx + ty) % 2 === 0) ? 0x7c6e4a : 0x6e6040
+        floor.rect(tx * T, ty * T, T, T).fill(shade)
+      }
+    }
+    app.stage.addChild(floor)
+
+    // ── Walls ──────────────────────────────────────────────────────────────────
+    const walls = new PIXI.Graphics()
+    for (let tx = 0; tx < interior.width; tx++) {
+      walls.rect(tx * T, 0, T, T).fill(0x3a2e1e)
+      walls.rect(tx * T, (interior.height - 1) * T, T, T).fill(0x3a2e1e)
+    }
+    for (let ty = 1; ty < interior.height - 1; ty++) {
+      walls.rect(0, ty * T, T, T).fill(0x3a2e1e)
+      walls.rect((interior.width - 1) * T, ty * T, T, T).fill(0x3a2e1e)
+    }
+    // Exit door — opening in south wall
+    const exitTx = Math.floor(interior.width / 2)
+    walls.rect(exitTx * T, (interior.height - 1) * T, T, T).fill(0x5a4a2a)
+    app.stage.addChild(walls)
+
+    // ── Decor ──────────────────────────────────────────────────────────────────
+    const decorGfx = new PIXI.Graphics()
+    for (const d of interior.decor) drawDecorPiece(decorGfx, d)
+    app.stage.addChild(decorGfx)
+
+    // ── Labels ─────────────────────────────────────────────────────────────────
+    const nameLabel = new PIXI.Text({
+      text: interior.name,
+      style: { fontSize: 10, fill: '#c8e8c8', fontFamily: 'monospace' },
+    })
+    nameLabel.position.set(T + 4, 4)
+    app.stage.addChild(nameLabel)
+
+    const exitMarker = new PIXI.Text({
+      text: '▼ EXIT',
+      style: { fontSize: 8, fill: '#88ff88', fontFamily: 'monospace', fontWeight: 'bold' },
+    })
+    exitMarker.anchor.set(0.5, 0)
+    exitMarker.position.set(exitTx * T + T / 2, (interior.height - 1) * T + 2)
+    app.stage.addChild(exitMarker)
+
+    // ── Walkable set ───────────────────────────────────────────────────────────
+    const walkable = new Set<string>()
+    for (let tx = 1; tx < interior.width - 1; tx++)
+      for (let ty = 1; ty < interior.height - 1; ty++)
+        walkable.add(`${tx},${ty}`)
+    walkable.add(`${exitTx},${interior.height - 1}`)
+    for (const d of interior.decor) walkable.delete(`${d.tx},${d.ty}`)
+
+    // BFS pathfinder
+    function findPath(from: [number, number], to: [number, number]): [number, number][] {
+      const key = (t: [number, number]) => `${t[0]},${t[1]}`
+      const queue: [number, number][][] = [[from]]
+      const visited = new Set([key(from)])
+      while (queue.length > 0) {
+        const path = queue.shift()!
+        const cur = path[path.length - 1]
+        if (cur[0] === to[0] && cur[1] === to[1]) return path
+        for (const [dx, dy] of [[0, -1], [1, 0], [0, 1], [-1, 0]]) {
+          const next: [number, number] = [cur[0] + dx, cur[1] + dy]
+          if (walkable.has(key(next)) && !visited.has(key(next))) {
+            visited.add(key(next))
+            queue.push([...path, next])
+          }
+        }
+      }
+      return [from]
+    }
+
+    // ── Avatar ─────────────────────────────────────────────────────────────────
+    const base = (import.meta as { env: { BASE_URL: string } }).env.BASE_URL
+    const slug = loadPlayerAvatar()
+    let avatar: PIXI.Sprite | null = null
+    let avatarFrames: PIXI.Texture[] = []
+    let avatarBaseTexture: PIXI.Texture | null = null
+    let avatarAnimTimer = 0
+    let avatarAnimFrame = 0
+    let currentTile: [number, number] = [exitTx, interior.height - 2]
+    let walkQueue: [number, number][] = []
+    let isWalking = false
+
+    Promise.all([
+      loadTextureUrl(`${base}sprites/${slug}.svg`),
+      loadAnimFrames(slug, 3).catch(() => [] as PIXI.Texture[]),
+    ]).then(([baseTex, frames]) => {
+      if (app.renderer == null) return
+      avatarBaseTexture = baseTex
+      avatarFrames = frames
+      const s = new PIXI.Sprite(baseTex)
+      s.width = T; s.height = T
+      s.anchor.set(0.5, 0.5)
+      s.position.set(currentTile[0] * T + T / 2, currentTile[1] * T + T / 2)
+      app.stage.addChild(s)
+      avatar = s
+    }).catch(() => { /* avatar optional */ })
+
+    function tweenLinear(obj: PIXI.Container, tx: number, ty: number, ms: number): Promise<void> {
+      return new Promise(resolve => {
+        if (ms <= 0) { obj.x = tx; obj.y = ty; resolve(); return }
+        const sx = obj.x, sy = obj.y
+        let elapsed = 0
+        const tick = (ticker: PIXI.Ticker) => {
+          elapsed += ticker.deltaMS
+          const t = Math.min(elapsed / ms, 1)
+          obj.x = sx + (tx - sx) * t
+          obj.y = sy + (ty - sy) * t
+          if (t >= 1) { app.ticker.remove(tick); resolve() }
+        }
+        app.ticker.add(tick)
+      })
+    }
+
+    async function processWalkQueue() {
+      if (walkQueue.length === 0) { isWalking = false; return }
+      isWalking = true
+      const [ntx, nty] = walkQueue.shift()!
+      const px = ntx * T + T / 2
+      const py = nty * T + T / 2
+      const av = avatar
+      if (!av) { currentTile = [ntx, nty]; processWalkQueue(); return }
+      if (px < av.x - 1) av.scale.x = -1
+      else if (px > av.x + 1) av.scale.x = 1
+      const dist = Math.hypot(px - av.x, py - av.y)
+      await tweenLinear(av, px, py, (dist / WALK_PX_PER_S) * 1000)
+      currentTile = [ntx, nty]
+      if (ntx === exitTx && nty === interior.height - 1) {
+        isWalking = false
+        onExit()
+        return
+      }
+      processWalkQueue()
+    }
+
+    // ── Input ──────────────────────────────────────────────────────────────────
+    app.stage.eventMode = 'static'
+    app.stage.hitArea   = new PIXI.Rectangle(0, 0, W, H)
+    app.stage.on('pointerdown', (e: PIXI.FederatedPointerEvent) => {
+      const { x, y } = e.getLocalPosition(app.stage)
+      const tapTx = Math.max(1, Math.min(interior.width - 1, Math.floor(x / T)))
+      const tapTy = Math.max(1, Math.min(interior.height - 1, Math.floor(y / T)))
+      const target: [number, number] = [tapTx, tapTy]
+      if (!walkable.has(`${tapTx},${tapTy}`) && !(tapTx === exitTx && tapTy === interior.height - 1)) return
+      const path = findPath(currentTile, target)
+      walkQueue = path.slice(1)
+      if (!isWalking) processWalkQueue()
+    })
+
+    // ── Per-frame ──────────────────────────────────────────────────────────────
+    app.ticker.add((ticker) => {
+      if (avatar && isWalking && avatarFrames.length > 0) {
+        avatarAnimTimer -= ticker.deltaMS
+        if (avatarAnimTimer <= 0) {
+          avatarAnimTimer = 200
+          avatarAnimFrame = (avatarAnimFrame + 1) % avatarFrames.length
+          avatar.texture = avatarFrames[avatarAnimFrame]
+        }
+      } else if (avatar && !isWalking && avatarBaseTexture) {
+        if (avatar.texture !== avatarBaseTexture) {
+          avatar.texture = avatarBaseTexture
+          avatarAnimTimer = 0
+          avatarAnimFrame = 0
+        }
+      }
+    })
+  })
+
+  return (
+    <div
+      ref={containerRef}
+      style={{ display: 'block', flexShrink: 0 }}
+    />
+  )
+}

--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -3,7 +3,7 @@ import * as PIXI from 'pixi.js'
 import { usePixiApp } from '../../hooks/usePixiApp'
 import { buildTerrainGfx, buildBgTileGfx, buildDecorGfx } from '../../utils/terrainLayer'
 import { renderPathTiles } from '../../utils/tileLookup'
-import { loadSpriteTexture, loadTextureUrl } from '../../utils/pixiHelpers'
+import { loadSpriteTexture, loadTextureUrl, loadAnimFrames } from '../../utils/pixiHelpers'
 import { PATH_TILE } from '../../data/tiles/tileIndex'
 import { findPath, nearestWalkable } from '../../utils/hubPathfinder'
 import {
@@ -15,6 +15,8 @@ import {
   AVATAR_START,
 } from '../../data/hubLayout'
 import { QUEST_GIVER_NPCS, NPC_SPAWN_TILES } from '../../data/hubNpcs'
+import { HUB_DOORS } from '../../data/hubInteriors'
+import { loadPlayerAvatar } from '../../game/questline'
 
 const HUB_ENV       = 'camp'
 const T             = 32
@@ -121,10 +123,20 @@ export function HubTownCanvas({ onAreaEnter, onNodeInteract, onAvatarMove, retur
 
     // ── Avatar ─────────────────────────────────────────────────────────────────
     let avatar: PIXI.Sprite | null = null
+    let avatarFrames: PIXI.Texture[] = []
+    let avatarBaseTexture: PIXI.Texture | null = null
+    let avatarAnimTimer = 0
+    let avatarAnimFrame = 0
     const base = (import.meta as { env: { BASE_URL: string } }).env.BASE_URL
-    loadTextureUrl(`${base}sprites/hub-avatar.svg`).then(tex => {
+    const avatarSlug = loadPlayerAvatar()
+    Promise.all([
+      loadTextureUrl(`${base}sprites/${avatarSlug}.svg`),
+      loadAnimFrames(avatarSlug, 3).catch(() => [] as PIXI.Texture[]),
+    ]).then(([baseTex, frames]) => {
       if (app.renderer == null) return
-      const s = new PIXI.Sprite(tex)
+      avatarBaseTexture = baseTex
+      avatarFrames = frames
+      const s = new PIXI.Sprite(baseTex)
       s.width = T; s.height = T
       s.anchor.set(0.5, 0.5)
       s.position.set(COURTYARD_PX.x, COURTYARD_PX.y)
@@ -176,6 +188,9 @@ export function HubTownCanvas({ onAreaEnter, onNodeInteract, onAvatarMove, retur
       walkQueue:   [number, number][]
       isWalking:   boolean
       wanderTimer: number
+      animFrames:  PIXI.Texture[]
+      animTimer:   number
+      animFrame:   number
     }
 
     const unitNpcs: UnitNpcState[] = []
@@ -190,24 +205,33 @@ export function HubTownCanvas({ onAreaEnter, onNodeInteract, onAvatarMove, retur
         const cx = tx * T + T / 2
         const cy = ty * T + T / 2
 
-        loadSpriteTexture(cardName).then(tex => {
-          if (app.renderer == null) return
-          const s = new PIXI.Sprite(tex)
-          s.width = T; s.height = T
-          s.anchor.set(0.5, 0.5)
-          s.position.set(cx, cy)
-          s.alpha = 0.85
-          npcLayer.addChild(s)
+        loadSpriteTexture(cardName)
+          .catch(() => loadTextureUrl(`${base}sprites/hub-avatar.svg`))
+          .then(tex => {
+            if (app.renderer == null) return
+            const s = new PIXI.Sprite(tex)
+            s.width = T; s.height = T
+            s.anchor.set(0.5, 0.5)
+            s.position.set(cx, cy)
+            s.alpha = 0.85
+            npcLayer.addChild(s)
 
-          const state: UnitNpcState = {
-            sprite:      s,
-            currentTile: [tx, ty],
-            walkQueue:   [],
-            isWalking:   false,
-            wanderTimer: 500 + Math.random() * 1500,   // initial delay 0.5–2 s
-          }
-          unitNpcs.push(state)
-        }).catch(() => {/* silently skip missing sprites */})
+            const state: UnitNpcState = {
+              sprite:      s,
+              currentTile: [tx, ty],
+              walkQueue:   [],
+              isWalking:   false,
+              wanderTimer: 500 + Math.random() * 500,   // initial delay 0.5–1 s
+              animFrames:  [],
+              animTimer:   0,
+              animFrame:   0,
+            }
+            unitNpcs.push(state)
+
+            loadAnimFrames(cardName, 3)
+              .then(frames => { state.animFrames = frames })
+              .catch(() => { /* no walk animation */ })
+          })
       })
     }
 
@@ -291,6 +315,17 @@ export function HubTownCanvas({ onAreaEnter, onNodeInteract, onAvatarMove, retur
 
       await tweenLinear(av, targetX, targetY, duration)
       currentTile = [tx, ty]
+
+      // Door detection — entering a building triggers interior view
+      const door = HUB_DOORS.find(d => d.tx === currentTile[0] && d.ty === currentTile[1])
+      if (door) {
+        isWalking = false
+        walkQueue = []
+        pendingScreen = null
+        onNodeInteractRef.current(`interior:${door.buildingId}`)
+        return
+      }
+
       processWalkQueue()
     }
 
@@ -336,14 +371,44 @@ export function HubTownCanvas({ onAreaEnter, onNodeInteract, onAvatarMove, retur
 
     // ── Per-frame ──────────────────────────────────────────────────────────────
     app.ticker.add((ticker) => {
-      if (avatar) onAvatarMoveRef.current(avatar.x, avatar.y)
+      // Avatar animation + position report
+      if (avatar) {
+        onAvatarMoveRef.current(avatar.x, avatar.y)
+        if (isWalking && avatarFrames.length > 0) {
+          avatarAnimTimer -= ticker.deltaMS
+          if (avatarAnimTimer <= 0) {
+            avatarAnimTimer = 200
+            avatarAnimFrame = (avatarAnimFrame + 1) % avatarFrames.length
+            avatar.texture = avatarFrames[avatarAnimFrame]
+          }
+        } else if (!isWalking && avatarBaseTexture && avatar.texture !== avatarBaseTexture) {
+          avatar.texture = avatarBaseTexture
+          avatarAnimTimer = 0
+          avatarAnimFrame = 0
+        }
+      }
+
       worldLayer.sortChildren()
 
       for (const npc of unitNpcs) {
+        // Walk animation
+        if (npc.isWalking && npc.animFrames.length > 0) {
+          npc.animTimer -= ticker.deltaMS
+          if (npc.animTimer <= 0) {
+            npc.animTimer = 200
+            npc.animFrame = (npc.animFrame + 1) % npc.animFrames.length
+            npc.sprite.texture = npc.animFrames[npc.animFrame]
+          }
+        } else if (!npc.isWalking && npc.animFrames.length > 0 && npc.animFrame !== 0) {
+          npc.sprite.texture = npc.animFrames[0]
+          npc.animFrame = 0
+          npc.animTimer = 0
+        }
+        // Wander
         if (!npc.isWalking) {
           npc.wanderTimer -= ticker.deltaMS
           if (npc.wanderTimer <= 0) {
-            npc.wanderTimer = 10000 + Math.random() * 20000
+            npc.wanderTimer = 2000 + Math.random() * 3000
             wanderNpc(npc)
           }
         }

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useCallback, useEffect, useMemo, useRef } from 'react'
 import { OverlayScreen } from '../ui/OverlayScreen'
 import { HubTownCanvas } from './HubTownCanvas'
+import { HubInteriorCanvas } from './HubInteriorCanvas'
 import { AreaNameBadge } from './AreaNameBadge'
 import { HubReturnButton } from './HubReturnButton'
 import { HubDialogue } from './HubDialogue'
@@ -22,6 +23,7 @@ interface Props {
 export function HubWorld({ onBack, onNavigate }: Props) {
   const [currentArea,  setCurrentArea]  = useState<string | null>(null)
   const [dialogueLine, setDialogueLine] = useState<string | null>(null)
+  const [interiorId,   setInteriorId]   = useState<string | null>(null)
   const scrollRef = useRef<HTMLDivElement>(null)
   const returnRef = useRef(null) as React.MutableRefObject<(() => void) | null>
 
@@ -51,6 +53,10 @@ export function HubWorld({ onBack, onNavigate }: Props) {
   }, [])
 
   const handleNodeInteract = useCallback((screen: string) => {
+    if (screen.startsWith('interior:')) {
+      setInteriorId(screen.slice(9))
+      return
+    }
     onNavigate?.(screen)
   }, [onNavigate])
 
@@ -80,6 +86,24 @@ export function HubWorld({ onBack, onNavigate }: Props) {
         <AreaNameBadge name={currentArea} />
         <HubReturnButton onClick={handleReturn} />
         <HubDialogue line={dialogueLine} onClose={() => setDialogueLine(null)} />
+        {interiorId && (
+          <div style={{
+            position: 'absolute', inset: 0,
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            background: 'rgba(0,0,0,0.80)', zIndex: 10,
+          }}>
+            <div style={{ position: 'relative' }}>
+              <button
+                className="action-btn"
+                style={{ position: 'absolute', top: -36, right: 0, zIndex: 1 }}
+                onClick={() => setInteriorId(null)}
+              >
+                LEAVE
+              </button>
+              <HubInteriorCanvas buildingId={interiorId} onExit={() => setInteriorId(null)} />
+            </div>
+          </div>
+        )}
       </div>
     </OverlayScreen>
   )

--- a/web/src/components/screens/SettingsScreen.tsx
+++ b/web/src/components/screens/SettingsScreen.tsx
@@ -13,7 +13,7 @@ import { isDevMode } from '../../game/debug'
 import { DevMenu } from '../admin/DevMenu'
 import { GIFT_OWNER_UID } from '../../game/gifts'
 import { loadPlaytime, formatPlaytime } from '../../game/playtime'
-import { isHubWorldUnlocked, unlockHubWorld } from '../../game/codex'
+import { isHubWorldUnlocked, unlockHubWorld, loadHubDefault, saveHubDefault } from '../../game/codex'
 
 interface Props {
   onBack: () => void
@@ -172,6 +172,7 @@ export function SettingsScreen({ onBack, onResetGame, user, authLoading, onDevCr
   const [monochromeOn,   setMonochromeOn]   = useState(loadMonochromeEnabled)
   const [lightModeOn,   setLightModeOn]   = useState(loadLightMode)
   const [battlePopups,  setBattlePopups]  = useState(loadBattlePopups)
+  const [hubDefault,    setHubDefault]    = useState(loadHubDefault)
   const [confirmReset,  setConfirmReset]  = useState(false)
   const [importMsg,     setImportMsg]     = useState<string | null>(null)
   const [rollbarMsg,    setRollbarMsg]    = useState<string | null>(null)
@@ -575,14 +576,27 @@ export function SettingsScreen({ onBack, onResetGame, user, authLoading, onDevCr
           </div>
         </Section>
 
-        {isHubWorldUnlocked() && onTitleScreen && (
+        {isHubWorldUnlocked() && (
           <Section bordered title="NAVIGATION">
             <div className="settings-row u-flex u-items-c u-just-sb u-gap-7">
               <div>
-                <div className="settings-label">Classic Title Screen</div>
-                <div className="settings-sublabel">Return to the original title screen</div>
+                <div className="settings-label">Default startup screen</div>
+                <div className="settings-sublabel">Which screen opens when the game launches</div>
               </div>
-              <button className="action-btn" onClick={onTitleScreen}>GO</button>
+              <div style={{ display: 'flex', gap: '8px' }}>
+                <button
+                  className={`action-btn${hubDefault === 'hub' ? ' action-btn--gold' : ''}`}
+                  onClick={() => { saveHubDefault('hub'); setHubDefault('hub') }}
+                >
+                  HUB WORLD
+                </button>
+                <button
+                  className={`action-btn${hubDefault === 'title' ? ' action-btn--gold' : ''}`}
+                  onClick={() => { saveHubDefault('title'); setHubDefault('title') }}
+                >
+                  TITLE SCREEN
+                </button>
+              </div>
             </div>
           </Section>
         )}

--- a/web/src/data/hubInteriors.ts
+++ b/web/src/data/hubInteriors.ts
@@ -1,0 +1,129 @@
+// Hub World building interiors — door positions and interior layouts.
+
+export interface HubDoor {
+  buildingId: string
+  tx: number
+  ty: number
+}
+
+export interface InteriorDecor {
+  tx: number
+  ty: number
+  type: 'table' | 'shelf' | 'barrel' | 'chest' | 'desk' | 'bed' | 'counter' | 'fireplace'
+  color?: number
+}
+
+export interface HubInterior {
+  id: string
+  name: string
+  width: number
+  height: number
+  decor: InteriorDecor[]
+}
+
+// Exterior door tiles — walking onto these triggers an interior transition.
+export const HUB_DOORS: HubDoor[] = [
+  { buildingId: 'card-shop',     tx:  6, ty: 11 },
+  { buildingId: 'augment-shop',  tx: 14, ty: 11 },
+  { buildingId: 'supply-shop',   tx:  8, ty: 14 },
+  { buildingId: 'scholars-hall', tx: 56, ty: 11 },
+  { buildingId: 'home',          tx: 21, ty: 20 },
+  { buildingId: 'trader-den',    tx: 11, ty: 26 },
+]
+
+export const HUB_INTERIORS: Record<string, HubInterior> = {
+  'card-shop': {
+    id: 'card-shop',
+    name: "Gildwyn's Card Emporium",
+    width: 12,
+    height: 9,
+    decor: [
+      { tx: 2, ty: 2, type: 'shelf' },
+      { tx: 3, ty: 2, type: 'shelf' },
+      { tx: 8, ty: 2, type: 'shelf' },
+      { tx: 9, ty: 2, type: 'shelf' },
+      { tx: 5, ty: 4, type: 'counter' },
+      { tx: 6, ty: 4, type: 'counter' },
+      { tx: 3, ty: 6, type: 'table' },
+      { tx: 8, ty: 6, type: 'chest' },
+    ],
+  },
+  'augment-shop': {
+    id: 'augment-shop',
+    name: "Mira's Enchantment Studio",
+    width: 12,
+    height: 9,
+    decor: [
+      { tx: 2, ty: 2, type: 'desk', color: 0x6633aa },
+      { tx: 5, ty: 3, type: 'table', color: 0x4422cc },
+      { tx: 9, ty: 2, type: 'shelf' },
+      { tx: 9, ty: 3, type: 'shelf' },
+      { tx: 2, ty: 6, type: 'barrel' },
+      { tx: 8, ty: 6, type: 'chest', color: 0xaa44cc },
+    ],
+  },
+  'supply-shop': {
+    id: 'supply-shop',
+    name: "Bramble's Supplies",
+    width: 12,
+    height: 9,
+    decor: [
+      { tx: 2, ty: 2, type: 'barrel' },
+      { tx: 3, ty: 2, type: 'barrel' },
+      { tx: 4, ty: 2, type: 'barrel' },
+      { tx: 8, ty: 2, type: 'chest' },
+      { tx: 9, ty: 2, type: 'chest' },
+      { tx: 5, ty: 5, type: 'table' },
+      { tx: 2, ty: 6, type: 'shelf' },
+      { tx: 9, ty: 6, type: 'shelf' },
+    ],
+  },
+  'scholars-hall': {
+    id: 'scholars-hall',
+    name: "The Scholar's Hall",
+    width: 14,
+    height: 10,
+    decor: [
+      { tx: 2, ty: 2, type: 'shelf' },
+      { tx: 3, ty: 2, type: 'shelf' },
+      { tx: 4, ty: 2, type: 'shelf' },
+      { tx: 9, ty: 2, type: 'shelf' },
+      { tx: 10, ty: 2, type: 'shelf' },
+      { tx: 11, ty: 2, type: 'shelf' },
+      { tx: 5, ty: 5, type: 'desk' },
+      { tx: 7, ty: 5, type: 'desk' },
+      { tx: 3, ty: 7, type: 'table' },
+      { tx: 10, ty: 7, type: 'chest' },
+    ],
+  },
+  'home': {
+    id: 'home',
+    name: 'Your Quarters',
+    width: 12,
+    height: 9,
+    decor: [
+      { tx: 2, ty: 2, type: 'bed' },
+      { tx: 9, ty: 2, type: 'fireplace', color: 0xcc4400 },
+      { tx: 5, ty: 4, type: 'table' },
+      { tx: 6, ty: 4, type: 'table' },
+      { tx: 2, ty: 6, type: 'chest' },
+      { tx: 9, ty: 6, type: 'shelf' },
+    ],
+  },
+  'trader-den': {
+    id: 'trader-den',
+    name: "The Junk Trader's Den",
+    width: 12,
+    height: 9,
+    decor: [
+      { tx: 2, ty: 2, type: 'barrel' },
+      { tx: 3, ty: 2, type: 'barrel' },
+      { tx: 4, ty: 2, type: 'barrel' },
+      { tx: 8, ty: 2, type: 'chest' },
+      { tx: 9, ty: 2, type: 'chest' },
+      { tx: 10, ty: 2, type: 'chest' },
+      { tx: 5, ty: 5, type: 'counter' },
+      { tx: 6, ty: 5, type: 'counter' },
+    ],
+  },
+}

--- a/web/src/data/hubLayout.ts
+++ b/web/src/data/hubLayout.ts
@@ -81,9 +81,19 @@ export const HUB_STREET_TILES: [number, number][] = [
   // NW cross-spur — Market Lane internal street
   ...tileRect(0, 12, 20, 13),
 
-  // Building entrances — rendered with wall tiles via renderPathTiles.
+  // Building door tiles — each connects a building facade to the adjacent street.
+  // card-shop door (tx=6, ty=11) + approach from NW cross-spur (ty=12-13)
   ...tileRect(6, 11, 7, 11),
-  ...tileRect(7, 22, 10, 22),
+  // augment-shop door (tx=14, ty=11) + approach connector to NW alley
+  ...tileRect(14, 11, 14, 13),
+  // supply-shop door (tx=8, ty=14) — approach via NW cross-spur already covers ty=12-13
+  ...tileRect(8, 14, 8, 14),
+  // home door (tx=21, ty=20) — NW center building south face, connects to NW alley at tx=18-19
+  ...tileRect(19, 20, 21, 20),
+  // scholars-hall door (tx=56, ty=11) — NE building south face, connects to NE alley at tx=55-57
+  ...tileRect(56, 11, 56, 11),
+  // trader-den door (tx=11, ty=26) — SW dock building north face, connects to main horizontal
+  ...tileRect(11, 25, 11, 26),
 ]
 
 // Building tile positions — rendered with wall tiles via renderPathTiles.

--- a/web/src/game/codex.ts
+++ b/web/src/game/codex.ts
@@ -30,6 +30,7 @@ const ALL_ACTS: any[] = [
 
 const FRAGMENT_KEY        = 'jarv_memory_fragments'
 const HUB_WORLD_UNLOCK_KEY = 'jarv_hub_world_unlocked'
+const HUB_DEFAULT_KEY      = 'jarv_hub_default'
 
 export interface MemoryFragment {
   id: string
@@ -61,6 +62,14 @@ export function isHubWorldUnlocked(): boolean {
 
 export function unlockHubWorld(): void {
   try { localStorage.setItem(HUB_WORLD_UNLOCK_KEY, 'true') } catch { /* ignore */ }
+}
+
+export function loadHubDefault(): 'hub' | 'title' {
+  try { const v = localStorage.getItem(HUB_DEFAULT_KEY); return v === 'title' ? 'title' : 'hub' } catch { return 'hub' }
+}
+
+export function saveHubDefault(val: 'hub' | 'title'): void {
+  try { localStorage.setItem(HUB_DEFAULT_KEY, val) } catch { /* ignore */ }
 }
 
 export function areAllCampaignFragmentsDiscovered(): boolean {


### PR DESCRIPTION
## Summary

- **Hub world toggle** — Settings NAVIGATION section (visible when hub is unlocked) now shows a two-button selector: **HUB WORLD** / **TITLE SCREEN**. The choice is persisted in `localStorage` as `jarv_hub_default` and respected on startup. Replaces the old one-way "Classic Title Screen" button.

- **Building interiors** — Six buildings have walkable interiors: Card Shop, Augment Shop, Supply Shop, Scholar's Hall, Home, Trader's Den. Walking onto a door tile (added to `HUB_STREET_TILES`) opens a PixiJS interior canvas with checkered floor, dark walls, and hand-drawn decor (shelves, tables, barrels, chests, desks, beds, fireplaces). The player avatar navigates inside via tap + BFS pathfinding. Stepping on the exit tile (or pressing LEAVE) returns to the hub map.

- **NPC walking fix** — Wander timer reduced from 10–30s to 2–5s; initial spawn delay reduced to 0.5–1s. Fallback sprite (`hub-avatar.svg`) added so NPCs always appear even if the card sprite fails. Walk animation cycles through `slug-1/2/3.svg` frames at 200ms intervals.

- **Player avatar animation** — Avatar now uses `loadPlayerAvatar()` to load the player's chosen avatar sprite instead of the generic `hub-avatar.svg`. Walk frames animate at 200ms while moving; returns to base pose when standing.

## Test plan

- [ ] Unlock hub world (EXPERIMENTS → UNLOCK in Settings)
- [ ] Settings → NAVIGATION shows HUB WORLD / TITLE SCREEN toggle; switching to TITLE SCREEN boots to title on next reload
- [ ] Hub world: player avatar matches the chosen avatar (default: jarv.svg) and legs animate while walking
- [ ] Hub world: card-unit NPCs appear in the courtyard within 1 second and visibly wander every 2–5 seconds with walk animation
- [ ] Walk to a building door tile (e.g. tx=6, ty=11 for Card Shop) — interior overlay opens with floor, walls, and decor
- [ ] Tap around inside the interior — avatar walks to tap target using BFS
- [ ] Walk to the exit tile (bottom-center, labeled ▼ EXIT) — returns to hub map
- [ ] LEAVE button also closes the interior
- [ ] `cd web && npm run build` passes with zero TypeScript errors

https://claude.ai/code/session_013AyvzYXfUBE58v7YcFBnne

---
_Generated by [Claude Code](https://claude.ai/code/session_013AyvzYXfUBE58v7YcFBnne)_