### PR TITLE
Hub world: title screen splash styling, persistent HUD, splash shows only once

### DIFF
--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -7,12 +7,16 @@ import { HubDialogue } from './HubDialogue'
 import { AVATAR_START, MAP_W, MAP_H } from '../../data/hubLayout'
 import { loadDeck } from '../../game/collection'
 import { getCardCatalog } from '../../game/cards'
+import { loadSkipIntro } from '../screens/SettingsScreen'
 const T = 32
 const INITIAL_SCROLL = {
   x: AVATAR_START[0] * T + T / 2,
   y: AVATAR_START[1] * T + T / 2,
 }
 const SPLASH_MS = 10_000
+
+// Module-level flag: once dismissed in this session, never re-show
+let _hubSplashShown = false
 
 interface Props {
   onBack:          () => void
@@ -24,7 +28,7 @@ interface Props {
 }
 
 export function HubWorld({ onBack, onNavigate, crystals = 0, isSignedIn = false, onLoginToggle, onSignOut }: Props) {
-  const [splashVisible, setSplashVisible] = useState(true)
+  const [splashVisible, setSplashVisible] = useState(() => !_hubSplashShown && !loadSkipIntro())
   const [splashFading,  setSplashFading]  = useState(false)
   const [currentArea,    setCurrentArea]    = useState<string | null>(null)
   const [dialogueLine,   setDialogueLine]   = useState<string | null>(null)
@@ -46,11 +50,13 @@ export function HubWorld({ onBack, onNavigate, crystals = 0, isSignedIn = false,
   const deckCount = useMemo(() => loadDeck().length, [])
 
   const dismissSplash = useCallback(() => {
+    _hubSplashShown = true
     setSplashFading(true)
     setTimeout(() => setSplashVisible(false), 500)
   }, [])
 
   useEffect(() => {
+    if (!splashVisible) return
     const t = setTimeout(dismissSplash, SPLASH_MS)
     return () => clearTimeout(t)
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -123,25 +129,33 @@ export function HubWorld({ onBack, onNavigate, crystals = 0, isSignedIn = false,
             LEAVE
           </button>
         )}
+
+        {/* Persistent HUD — always visible */}
+        <div className="hub-hud">
+          <div className="hub-hud__stats">
+            <span>💎 {crystals}</span>
+            <span>🃏 {deckCount}</span>
+          </div>
+          <div className="hub-hud__actions">
+            <button className="action-btn hub-hud__btn" onClick={onBack}>⚙</button>
+            <button
+              className="action-btn hub-hud__btn"
+              onClick={() => isSignedIn ? onSignOut?.() : onLoginToggle?.()}
+            >
+              {isSignedIn ? 'OUT' : 'IN'}
+            </button>
+          </div>
+        </div>
+
         {splashVisible && (
           <div
             className={`hub-splash${splashFading ? ' hub-splash--fading' : ''}`}
             onClick={dismissSplash}
           >
-            <h1 className="hub-splash__title">Jarv's Amazing<br />Web Game</h1>
-            <div className="hub-splash__stats">
-              <span>⚡ {crystals}</span>
-              <span>🃏 {deckCount}</span>
-            </div>
-            <div className="hub-splash__actions" onClick={e => e.stopPropagation()}>
-              <button className="action-btn" onClick={onBack}>SETTINGS</button>
-              <button
-                className="action-btn"
-                onClick={() => { dismissSplash(); isSignedIn ? onSignOut?.() : onLoginToggle?.() }}
-              >
-                {isSignedIn ? 'SIGN OUT' : 'SIGN IN'}
-              </button>
-            </div>
+            <div className="title-logo">JARV'S</div>
+            <div className="title-subtitle">AMAZING WEB GAME</div>
+            <div className="title-logo-ornament">· · · · ·</div>
+            <div className="title-deck-info">{deckCount} cards &nbsp;·&nbsp; 💎 {crystals}</div>
             <p className="hub-splash__hint">tap to continue</p>
           </div>
         )}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -14543,6 +14543,43 @@ html.light-mode .action-btn {
   font-family: monospace;
 }
 
+/* ── Hub World Persistent HUD ──────────────────────────────────────────── */
+.hub-hud {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  z-index: 20;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  pointer-events: none;
+}
+
+.hub-hud__stats {
+  display: flex;
+  gap: 10px;
+  font-family: monospace;
+  font-size: 0.75rem;
+  color: var(--color-gold-alt);
+  background: rgba(14, 10, 8, 0.72);
+  border: 1px solid rgba(255, 204, 0, 0.2);
+  border-radius: 4px;
+  padding: 4px 8px;
+  letter-spacing: 0.04em;
+}
+
+.hub-hud__actions {
+  display: flex;
+  gap: 4px;
+  pointer-events: all;
+}
+
+.hub-hud__btn {
+  font-size: 0.7rem;
+  padding: 3px 8px;
+  min-width: 0;
+}
+
 /* ── Hub World Splash Intro ────────────────────────────────────────────── */
 .hub-splash {
   position: absolute;
@@ -14564,27 +14601,6 @@ html.light-mode .action-btn {
 .hub-splash--fading {
   opacity: 0;
   pointer-events: none;
-}
-
-.hub-splash__title {
-  font-size: clamp(2rem, 6vw, 4rem);
-  color: #f0d080;
-  text-align: center;
-  font-family: monospace;
-  font-weight: bold;
-  line-height: 1.2;
-  text-shadow: 0 0 32px rgba(240, 208, 128, 0.45), 0 2px 6px rgba(0, 0, 0, 0.9);
-  letter-spacing: 0.02em;
-  margin: 0;
-}
-
-.hub-splash__stats {
-  display: flex;
-  gap: 28px;
-  font-size: 1.1rem;
-  color: #c8b060;
-  font-family: monospace;
-  letter-spacing: 0.04em;
 }
 
 .hub-splash__actions {


### PR DESCRIPTION
## Summary

- Splash screen now uses the exact same `title-logo` / `title-subtitle` / `title-logo-ornament` CSS classes as the title screen — same gold font, letter spacing, and pulse animation
- Splash only shows once per session (`_hubSplashShown` module flag); navigating to a sub-screen and back no longer re-shows it
- Splash is suppressed when the "skip intro" setting is active, making it consistent with the title screen behaviour
- Persistent HUD (top-left corner) always shows crystal count, card count, a settings button (⚙), and a sign in/out button while in hub world

## Test plan

- [ ] Open hub world for the first time in a session → splash appears with gold `JARV'S` / `AMAZING WEB GAME` title matching title screen style
- [ ] Tap a sub-screen (shop, quickbattle, etc.), press back → returns to hub world with **no** splash
- [ ] Enable "skip intro" in settings → hub world loads with no splash at all
- [ ] Persistent HUD visible in top-left at all times (crystals, cards, ⚙, IN/OUT)
- [ ] ⚙ button opens settings; IN/OUT button triggers login/logout

https://claude.ai/code/session_013AyvzYXfUBE58v7YcFBnne

---
_Generated by [Claude Code](https://claude.ai/code/session_013AyvzYXfUBE58v7YcFBnne)_