### PR TITLE
Hub world: restore avatar position and scroll when returning from sub-screens

### DIFF
--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -18,6 +18,9 @@ const T             = 32
 const WALK_PX_PER_S = 160
 const COURTYARD_PX  = { x: AVATAR_START[0] * T + T / 2, y: AVATAR_START[1] * T + T / 2 }
 
+let _savedTile: [number, number] | null = null
+export function getSavedHubTile(): [number, number] | null { return _savedTile }
+
 // ── Interior BFS pathfinder ────────────────────────────────────────────────────
 function findInteriorPath(
   from: [number, number],
@@ -171,7 +174,9 @@ export function HubTownCanvas({
         interiorLayer.addChild(s)
         avatarInInterior = true
       } else {
-        s.position.set(COURTYARD_PX.x, COURTYARD_PX.y)
+        const startTile: [number, number] = _savedTile ? [..._savedTile] : [...AVATAR_START]
+        currentTile = startTile
+        s.position.set(startTile[0] * T + T / 2, startTile[1] * T + T / 2)
         avatarLayer.addChild(s)
       }
       avatar = s
@@ -601,6 +606,7 @@ export function HubTownCanvas({
 
       await tweenLinear(av, targetX, targetY, duration)
       currentTile = [tx, ty]
+      _savedTile  = [tx, ty]
 
       // Update area name on each tile step (works on mobile where pointermove doesn't fire)
       const tilePixX = tx * T + T / 2
@@ -687,6 +693,7 @@ export function HubTownCanvas({
       pendingScreen = null
       isWalking     = false
       currentTile   = [...AVATAR_START]
+      _savedTile    = null
       if (avatar) { avatar.x = COURTYARD_PX.x; avatar.y = COURTYARD_PX.y }
       onAvatarMoveRef.current(COURTYARD_PX.x, COURTYARD_PX.y)
     }

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -8,6 +8,7 @@ import { AVATAR_START, MAP_W, MAP_H } from '../../data/hubLayout'
 import { loadDeck } from '../../game/collection'
 import { getCardCatalog } from '../../game/cards'
 import { loadSkipIntro } from '../screens/SettingsScreen'
+import { getSavedHubTile } from './HubTownCanvas'
 const T = 32
 const INITIAL_SCROLL = {
   x: AVATAR_START[0] * T + T / 2,
@@ -72,8 +73,11 @@ export function HubWorld({ onBack, onNavigate, crystals = 0, isSignedIn = false,
   useEffect(() => {
     const el = scrollRef.current
     if (!el) return
-    el.scrollLeft = INITIAL_SCROLL.x - el.clientWidth  / 2
-    el.scrollTop  = INITIAL_SCROLL.y - el.clientHeight / 2
+    const saved = getSavedHubTile()
+    const px = saved ? saved[0] * T + T / 2 : INITIAL_SCROLL.x
+    const py = saved ? saved[1] * T + T / 2 : INITIAL_SCROLL.y
+    el.scrollLeft = px - el.clientWidth  / 2
+    el.scrollTop  = py - el.clientHeight / 2
   }, [])
 
   const handleNodeInteract = useCallback((screen: string) => {


### PR DESCRIPTION
## Summary

- When navigating from hub world to a shop/sub-screen and pressing back, the avatar now reappears at the tile they were standing on — not back at the courtyard spawn
- Scroll is also restored to centre on that tile
- Tapping the "return" button still resets to the courtyard as before

## How it works

`HubWorld` is conditionally mounted in `App.tsx`, so it is destroyed and rebuilt on every navigation round-trip. A module-level `_savedTile` variable in `HubTownCanvas` survives unmounts and stores the last exterior tile the avatar completed a walk step on. On remount, the avatar sprite starts at that tile and `HubWorld` scrolls the viewport to centre there.

## Test plan

- [ ] Walk to a shopkeeper → enter shop → press back → avatar is at the shop door, viewport centred there
- [ ] Walk to a distant area → navigate to quickbattle → press back → avatar is where you left it
- [ ] Tap the "return" button → avatar resets to courtyard → navigate away and back → spawns at courtyard ✓
- [ ] Fresh page load → avatar spawns at courtyard ✓

https://claude.ai/code/session_013AyvzYXfUBE58v7YcFBnne

---
_Generated by [Claude Code](https://claude.ai/code/session_013AyvzYXfUBE58v7YcFBnne)_