### PR TITLE
Victory screen: single "Claim Reward" button before navigation options

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -372,6 +372,7 @@ export default function App() {
   const [packs, setPacks]         = useState<string[][]>([])
   const [handicap, setHandicap]   = useState<number>(loadHandicap)
   const [crystals, setCrystals]   = useState<number>(loadCrystals)
+  const [quickPlayRewardClaimed, setQuickPlayRewardClaimed] = useState(false)
 
   // Campaign run state
   const [run, setRun]                   = useState<RunState | null>(_startup.run)
@@ -807,6 +808,7 @@ export default function App() {
     }
     isCampaignRef.current       = false
     isDailyChallengeRef.current = false
+    setQuickPlayRewardClaimed(false)
     battleFlawlessRef.current = true
     battleUsedStructure.current = false
     battleUsedMobileUnit.current = false
@@ -2208,7 +2210,8 @@ export default function App() {
   const packBackScreenRef = useRef<Screen>('title')
 
   const handleOpenPack = useCallback(() => {
-    packBackScreenRef.current = 'title'
+    packBackScreenRef.current = 'playing'
+    setQuickPlayRewardClaimed(true)
     let pack: string[]
 
     switch(quickBattleModeRef.current) {
@@ -3076,6 +3079,7 @@ export default function App() {
             winner={gameState.phase.winner}
             handicap={handicap}
             onOpenPack={!isCampaignRef.current && gameState.phase.winner === 'player' ? handleOpenPack : undefined}
+            rewardClaimed={quickPlayRewardClaimed}
             onPlayAgain={isCampaignRef.current
               ? (gameState.phase.winner === 'player' ? handleCampaignWin : handleCampaignRetry)
               : isDailyChallengeRef.current

--- a/web/src/components/battle/GameOver.stories.tsx
+++ b/web/src/components/battle/GameOver.stories.tsx
@@ -20,6 +20,19 @@ export const Victory: Story = {
     state: exampleGameState,
     winner: 'player',
     handicap: 1,
+    onOpenPack: fn(),
+    onPlayAgain: fn(),
+    onMainMenu: fn(),
+  },
+};
+
+export const VictoryRewardClaimed: Story = {
+  args: {
+    state: exampleGameState,
+    winner: 'player',
+    handicap: 1,
+    onOpenPack: fn(),
+    rewardClaimed: true,
     onPlayAgain: fn(),
     onMainMenu: fn(),
   },

--- a/web/src/components/battle/GameOver.tsx
+++ b/web/src/components/battle/GameOver.tsx
@@ -18,6 +18,8 @@ interface Props {
   /** Current opponent deck handicap (cards removed from enemy deck). */
   handicap: number
   onOpenPack?: () => void
+  /** True after the player has opened their reward pack (free play only). */
+  rewardClaimed?: boolean
   onPlayAgain: () => void
   onMainMenu: () => void
   /** If set, show an Abandon Run button (campaign mode only). */
@@ -51,7 +53,7 @@ const DRAW_ART = `  =====
   =====
   DRAW!`
 
-export function GameOver({ state, winner, handicap, onOpenPack, onPlayAgain, onMainMenu, campaignAbandon, quickPlayHint, showStreak, dailyChallengeState }: Props) {
+export function GameOver({ state, winner, handicap, onOpenPack, rewardClaimed, onPlayAgain, onMainMenu, campaignAbandon, quickPlayHint, showStreak, dailyChallengeState }: Props) {
   const won  = winner === 'player'
   const draw = winner === 'draw'
   const isEndlessDefeat = !!state.endlessMode && !won && !draw
@@ -184,22 +186,32 @@ export function GameOver({ state, winner, handicap, onOpenPack, onPlayAgain, onM
       )}
 
       <div className="gameover-actions u-col u-items-c u-gap-5">
-        {won && onOpenPack && (
-          <button className="action-btn action-btn--large action-btn--gold" onClick={onOpenPack}>
-            ✦ OPEN PACK ✦
-          </button>
+        {won && onOpenPack ? (
+          rewardClaimed ? (
+            <>
+              <button className="action-btn" onClick={onPlayAgain}>[ Play Again ]</button>
+              <button className="action-btn" onClick={onMainMenu}>[ I'm Done ]</button>
+            </>
+          ) : (
+            <button className="action-btn action-btn--large action-btn--gold" onClick={onOpenPack}>
+              ✦ CLAIM REWARD ✦
+            </button>
+          )
+        ) : (
+          <>
+            <button className="action-btn" onClick={onPlayAgain}>
+              {campaignAbandon ? (won ? '[ Claim Reward ]' : '[ Retry Node ]') : '[ Play Again ]'}
+            </button>
+            {campaignAbandon && (
+              <button className="action-btn action-btn--danger gameover-abandon-btn u-text-sm" onClick={() => setConfirmAbandon(true)}>
+                [ Abandon Run ]
+              </button>
+            )}
+            <button className="action-btn" onClick={onMainMenu}>
+              [ Main Menu ]
+            </button>
+          </>
         )}
-        <button className="action-btn" onClick={onPlayAgain}>
-          {campaignAbandon ? (won ? '[ Claim Reward ]' : '[ Retry Node ]') : '[ Play Again ]'}
-        </button>
-        {campaignAbandon && (
-          <button className="action-btn action-btn--danger gameover-abandon-btn u-text-sm" onClick={() => setConfirmAbandon(true)}>
-            [ Abandon Run ]
-          </button>
-        )}
-        <button className="action-btn" onClick={onMainMenu}>
-          [ Main Menu ]
-        </button>
       </div>
       {confirmAbandon && campaignAbandon && (
         <ConfirmModal


### PR DESCRIPTION
## Summary

- Quick battle victory screen now shows a single **"✦ CLAIM REWARD ✦"** button instead of "Open Pack" alongside "Play Again" / "Main Menu"
- After opening the pack, the player is returned to the victory screen showing **"Play Again"** and **"I'm Done"** — no reward can be accidentally skipped
- Campaign, daily challenge, and defeat flows are unchanged (they never receive `onOpenPack`)

## Test plan

- [ ] Win a quick battle → only "CLAIM REWARD" button appears (no navigation buttons)
- [ ] Click "CLAIM REWARD" → pack opening screen appears
- [ ] After opening pack → returned to victory screen showing "Play Again" and "I'm Done"
- [ ] "Play Again" starts a new battle; "I'm Done" goes to main menu
- [ ] Lose a quick battle → normal "Play Again" / "Main Menu" buttons still appear
- [ ] Win a campaign battle → "Claim Reward" / "Retry Node" / "Main Menu" layout unchanged

https://claude.ai/code/session_01PCwjqTXXQ3czvGg9rqwpMm

---
_Generated by [Claude Code](https://claude.ai/code/session_01PCwjqTXXQ3czvGg9rqwpMm)_