### PR TITLE
fix(pwa): close race condition and handle already-waiting SW in update flow

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -255,12 +255,6 @@ export default function App() {
   const { needRefresh: [needRefresh], updateServiceWorker } = useRegisterSW({
     onRegisteredSW(_url, r) {
       swRegRef.current = r ?? null
-      // Register the controllerchange listener immediately so we never race
-      // with skipWaiting: the new SW may activate before onNeedRefresh fires.
-      let reloading = false
-      navigator.serviceWorker.addEventListener('controllerchange', () => {
-        if (!reloading) { reloading = true; window.location.reload() }
-      })
       // In standalone (home screen) mode the browser doesn't trigger SW update
       // checks on each launch the way a normal tab does, so we kick one off
       // immediately and then repeat every hour.
@@ -273,9 +267,16 @@ export default function App() {
       updateServiceWorker(true)
     },
   })
+  // Attached at mount (synchronously, before any async SW lifecycle callbacks)
+  // so we never miss the controllerchange event when skipWaiting activates a
+  // new service worker before onRegisteredSW has run.
   useEffect(() => {
-    if (needRefresh) updateServiceWorker(true)
-  }, [needRefresh, updateServiceWorker])
+    if (!navigator.serviceWorker) return
+    let reloading = false
+    const handler = () => { if (!reloading) { reloading = true; window.location.reload() } }
+    navigator.serviceWorker.addEventListener('controllerchange', handler)
+    return () => navigator.serviceWorker.removeEventListener('controllerchange', handler)
+  }, [])
 
   // ── Startup: auto-resume a pending campaign battle on page refresh ──────────
   // If the player refreshed mid-battle, pendingNodeId is still set. We build the
@@ -2499,7 +2500,13 @@ export default function App() {
           onFeedbackAdmin={() => setScreen('feedbackAdmin')}
           onHubWorld={() => setScreen('hubworld')}
           onTitleScreen={() => setScreen('title')}
-          onCheckForUpdates={() => swRegRef.current?.update().catch(() => {})}
+          onCheckForUpdates={async () => {
+            if (needRefresh) {
+              updateServiceWorker(true)
+            } else {
+              await swRegRef.current?.update().catch(() => {})
+            }
+          }}
         />
       )}
 

--- a/web/src/components/screens/SettingsScreen.tsx
+++ b/web/src/components/screens/SettingsScreen.tsx
@@ -28,7 +28,7 @@ interface Props {
   onFeedbackAdmin?: () => void
   onHubWorld?: () => void
   onTitleScreen?: () => void
-  onCheckForUpdates?: () => void
+  onCheckForUpdates?: () => Promise<void>
 }
 
 const TEXT_SIZE_KEY      = 'jarv_text_size'
@@ -339,10 +339,10 @@ export function SettingsScreen({ onBack, onResetGame, user, authLoading, onDevCr
     }
   }
 
-  function handleCheckForUpdates() {
+  async function handleCheckForUpdates() {
     setUpdateStatus('checking')
-    onCheckForUpdates?.()
-    setTimeout(() => setUpdateStatus('done'), 3000)
+    await onCheckForUpdates?.()
+    setUpdateStatus('done')
   }
 
   return (


### PR DESCRIPTION
## Summary

- **Race condition closed**: The `controllerchange` listener was previously registered inside the async `onRegisteredSW` callback, meaning a `skipWaiting` activation that fired before that callback ran would be silently missed. The listener is now attached in a mount-time `useEffect` with `[]` deps, guaranteeing it's in place before any SW lifecycle events fire.
- **Force-update now handles already-waiting SWs**: "Check for Updates" was calling `registration.update()` even when a SW was already installed but not yet activated (`needRefresh === true`). In that state, `update()` does nothing useful. The callback now calls `updateServiceWorker(true)` directly when a SW is waiting, activating it immediately.
- **Removed redundant effect**: Both `onNeedRefresh` and a `useEffect` watching `needRefresh` were calling `updateServiceWorker(true)` — the effect is removed since `onNeedRefresh` already handles it.
- **"Done" status tied to real completion**: The 3-second `setTimeout` in `handleCheckForUpdates` is replaced with an `await` on the actual `update()` promise, so the status reflects when the network check actually finishes.

## Test plan

- [ ] Deploy a new version while a tab is open — page should auto-reload reliably
- [ ] Open Settings → About → click "Check for Updates" — "Done" appears after the real network check completes (typically ~1–2 s), not after a fixed 3 s
- [ ] If a new version exists when the button is clicked, the page reloads automatically after "Done"
- [ ] Standalone (home screen) mode: hourly polling interval is still present in `onRegisteredSW`

https://claude.ai/code/session_01KsbTPR9gf6bfxY6rk2jQzu

---
_Generated by [Claude Code](https://claude.ai/code/session_01KsbTPR9gf6bfxY6rk2jQzu)_