### PR TITLE
feat: route intro screen to hubworld when hub is enabled

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2438,7 +2438,7 @@ export default function App() {
       })()}
 
       {screen === 'intro' && (
-        <IntroScreen onDone={() => setScreen('title')} />
+        <IntroScreen onDone={() => setScreen(isHubWorldUnlocked() && loadHubDefault() !== 'title' ? 'hubworld' : 'title')} />
       )}
 
       {screen === 'title' && (

--- a/web/src/data/hubConfigLoader.ts
+++ b/web/src/data/hubConfigLoader.ts
@@ -127,11 +127,14 @@ export const HUB_BUILDINGS: HubBuilding[] = (rawConfig.buildings as RawBuilding[
   roof: b.roof as RoofMaterial | undefined,
 }))
 
-export const EXTERIOR_DECOR = rawConfig.exteriorDecor.map(d => ({
-  tx:     d.tx,
-  ty:     d.ty,
-  tileId: resolveTileId(d.tileId),
-}))
+type RawDecorEntry = { tx?: number; ty?: number; tileId?: string; comment?: string }
+export const EXTERIOR_DECOR = (rawConfig.exteriorDecor as RawDecorEntry[])
+  .filter((d): d is { tx: number; ty: number; tileId: string } => d.tx != null && d.ty != null && d.tileId != null)
+  .map(d => ({
+    tx:     d.tx,
+    ty:     d.ty,
+    tileId: resolveTileId(d.tileId),
+  }))
 
 type RawWindowEntry = { tx: number; ty: number; tileId: string }
 export const HUB_WINDOWS = (rawConfig as unknown as { windows?: RawWindowEntry[] }).windows?.map(w => ({


### PR DESCRIPTION
## Summary

- After the intro screen completes, navigate to hubworld instead of title if `isHubWorldUnlocked()` is true and the player's default screen is not `'title'` — matching the existing startup routing logic at App.tsx line 326.
- Also includes the `hubConfigLoader.ts` TS fix from #1454 (comment-only `exteriorDecor` entries filtered via type predicate) so CI passes cleanly regardless of merge order.

## Test plan
- [ ] New player (hub not unlocked): intro → title ✓
- [ ] Player with hub unlocked and default = hubworld: intro → hubworld ✓  
- [ ] Player with hub unlocked but default = title: intro → title ✓
- [ ] Build passes with no TypeScript errors

https://claude.ai/code/session_01KsbTPR9gf6bfxY6rk2jQzu

---
_Generated by [Claude Code](https://claude.ai/code/session_01KsbTPR9gf6bfxY6rk2jQzu)_