### PR TITLE
feat(hub): campaign NPC launches campaign directly instead of title screen

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2338,7 +2338,7 @@ export default function App() {
         setRun(cleared)
       }
       clearBattleState()
-      setScreen('title')
+      setScreen(returnScreen === 'hubworld' && isHubWorldUnlocked() ? 'hubworld' : 'title')
       dispatch({ type: 'END' })
       return
     }
@@ -2351,9 +2351,9 @@ export default function App() {
       setRun(cleared)
     }
     clearBattleState()
-    setScreen('title')
+    setScreen(returnScreen === 'hubworld' && isHubWorldUnlocked() ? 'hubworld' : 'title')
     dispatch({ type: 'END' })
-  }, [run, gameState])
+  }, [run, gameState, returnScreen])
 
   // ── Game over routing ────────────────────────────────────
 
@@ -2514,6 +2514,7 @@ export default function App() {
         <HubWorld
           onBack={() => setScreen('settings')}
           onNavigate={(s) => { setReturnScreen('hubworld'); setScreen(s as Screen) }}
+          onCampaign={() => { setReturnScreen('hubworld'); handleCampaign() }}
           onPlayerTap={() => { setReturnScreen('hubworld'); setScreen('player') }}
           crystals={crystals}
           user={user}

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -30,6 +30,7 @@ let _hubSplashShown = false
 interface Props {
   onBack:          () => void
   onNavigate?:     (screen: string) => void
+  onCampaign?:     () => void
   onPlayerTap?:    () => void
   crystals?:       number
   isSignedIn?:     boolean
@@ -41,7 +42,7 @@ interface Props {
   onTileTap?:      (tx: number, ty: number) => void
 }
 
-export function HubWorld({ onBack, onNavigate, onPlayerTap, crystals = 0, isSignedIn = false, commander, user, onSignIn: onLoginToggle, onSignOut, onFeedback, onTileTap }: Props) {
+export function HubWorld({ onBack, onNavigate, onCampaign, onPlayerTap, crystals = 0, isSignedIn = false, commander, user, onSignIn: onLoginToggle, onSignOut, onFeedback, onTileTap }: Props) {
   const [splashVisible, setSplashVisible] = useState(() => !_hubSplashShown && !loadSkipIntro())
   const [splashFading,  setSplashFading]  = useState(false)
   const [currentArea,    setCurrentArea]    = useState<string | null>(null)
@@ -126,8 +127,9 @@ export function HubWorld({ onBack, onNavigate, onPlayerTap, crystals = 0, isSign
       interiorEnterRef.current?.(buildingId)
       return
     }
+    if (screen === 'campaign') { onCampaign?.(); return }
     onNavigate?.(screen)
-  }, [onNavigate])
+  }, [onNavigate, onCampaign])
 
   const handleReturn = useCallback(() => {
     returnRef.current?.()

--- a/web/src/data/hubConfig.json
+++ b/web/src/data/hubConfig.json
@@ -800,7 +800,7 @@
       "name": "War Herald Davos",
       "sprite": "hub-npc-herald",
       "tx": 35, "ty": 22,
-      "screen": "title",
+      "screen": "campaign",
       "dialogue": [
         "The campaign banners are raised, Commander. Your forces await your orders.",
         "Every great victory began with a single step forward. Ready when you are.",


### PR DESCRIPTION
## Summary

- Tapping **War Herald Davos** in the hub now shows the deck selection modal and enters the campaign node map directly, bypassing the title screen.
- Backing out of the node map returns to **hubworld** (if hub is enabled) or **title** (if not).

## Changes

- **`hubConfig.json`**: Campaign NPC `screen` changed from `"title"` to `"campaign"` — a sentinel value handled specially in HubWorld rather than treated as a screen name.
- **`HubWorld.tsx`**: New `onCampaign?` prop. `handleNodeInteract` intercepts `"campaign"` and calls it (instead of falling through to `onNavigate`).
- **`App.tsx`**:
  - `<HubWorld onCampaign>` calls `setReturnScreen('hubworld')` then `handleCampaign()`, so the back destination is recorded before the campaign flow begins.
  - `handleMainMenu` (nodemap back/quit) now returns to hubworld when `returnScreen === 'hubworld'` and hub is unlocked, rather than always returning to title. Both exit paths (normal back and lives=0 loss) are updated.

## Test plan

- [ ] Hub unlocked: tap War Herald Davos → deck selector appears → confirm → node map loads → back button → returns to **hubworld** ✓
- [ ] Hub unlocked: tap War Herald Davos → deck selector → cancel → stays in hubworld ✓  
- [ ] Hub unlocked: play campaign from hub → lose all lives → returns to **hubworld** ✓
- [ ] Title screen Campaign button: unchanged behaviour — node map back → returns to **title** ✓ (returnScreen resets to `'title'` whenever the title screen is shown)
- [ ] Build: `npm run build` passes with no TypeScript errors ✓

https://claude.ai/code/session_01KsbTPR9gf6bfxY6rk2jQzu

---
_Generated by [Claude Code](https://claude.ai/code/session_01KsbTPR9gf6bfxY6rk2jQzu)_