### PR TITLE
feat(hub): minigame NPCs for every game + correct return flow from hub

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -127,7 +127,7 @@ import { DailyChallengeScreen } from './components/screens/DailyChallengeScreen'
 import { ConfirmModal }          from './components/modals/ConfirmModal'
 import { StreakBrokenModal }     from './components/modals/StreakBrokenModal'
 import { EndlessLeaderboardScreen } from './components/screens/EndlessLeaderboardScreen'
-import { MiniGamesMenu }           from './components/screens/MiniGamesMenu'
+import { MiniGamesMenu, SubScreen } from './components/screens/MiniGamesMenu'
 import { AugmentCollectionScreen } from './components/screens/AugmentCollectionScreen'
 import { PlayerScreen }            from './components/screens/PlayerScreen'
 import { CollectionTabScreen }     from './components/screens/CollectionTabScreen'
@@ -227,7 +227,7 @@ type Screen =
   | 'collection-tabs'
   | 'home-shelf'
   | 'hubworld'
-  | 'hub-fishing'
+  | 'hub-minigame'
   | 'casino'
 
 
@@ -330,6 +330,7 @@ export default function App() {
   const [screen, setScreen]             = useState<Screen>(_startup.screen)
   const [returnScreen, setReturnScreen]  = useState<Screen>('title')
   const [miniGamesEntry, setMiniGamesEntry] = useState<'menu' | 'citybuilder'>('menu')
+  const [hubMiniGameEntry, setHubMiniGameEntry] = useState<SubScreen>('menu')
   const [showTitleLoginModal, setShowTitleLoginModal] = useState(false)
   const [feedbackOpen, setFeedbackOpen] = useState(false)
   // ── Battle state (all ephemeral state that exists only during a battle) ──────
@@ -2513,7 +2514,16 @@ export default function App() {
       {screen === 'hubworld' && (
         <HubWorld
           onBack={() => setScreen('settings')}
-          onNavigate={(s) => { setReturnScreen('hubworld'); setScreen(s as Screen) }}
+          onNavigate={(s) => {
+            setReturnScreen('hubworld')
+            const HUB_MINIGAME_IDS: SubScreen[] = ['marble', 'tileflip', 'crystalcatch', 'spinner', 'marblerace', 'higherOrLower', 'fruitMachine', 'videoPoker', 'fishing', 'towerDefence', 'citybuilder', 'prizes']
+            if (HUB_MINIGAME_IDS.includes(s as SubScreen)) {
+              setHubMiniGameEntry(s as SubScreen)
+              setScreen('hub-minigame')
+            } else {
+              setScreen(s as Screen)
+            }
+          }}
           onCampaign={() => { setReturnScreen('hubworld'); handleCampaign() }}
           onPlayerTap={() => { setReturnScreen('hubworld'); setScreen('player') }}
           crystals={crystals}
@@ -2975,14 +2985,15 @@ export default function App() {
         />
       )}
 
-      {screen === 'hub-fishing' && (
+      {screen === 'hub-minigame' && (
         <MiniGamesMenu
           crystals={crystals}
           onCrystalsChange={(n) => { saveCrystals(n); setCrystals(n) }}
           user={user}
           characterName={loadPlayerName()}
           onBack={() => setScreen('hubworld')}
-          initialSubScreen="fishing"
+          onGameDone={() => setScreen('hubworld')}
+          initialSubScreen={hubMiniGameEntry}
         />
       )}
 

--- a/web/src/components/screens/MiniGamesMenu.tsx
+++ b/web/src/components/screens/MiniGamesMenu.tsx
@@ -28,7 +28,7 @@ import { TowerDefence, TowerPool } from '../minigames/TowerDefence'
 import { PageHeader } from '../ui/PageHeader'
 import { OverlayScreen } from '../ui/OverlayScreen'
 
-type SubScreen = 'menu' | MiniGameId | 'prizes' | 'leaderboard' | 'citybuilder' | 'fishing' | 'towerDefence'
+export type SubScreen = 'menu' | MiniGameId | 'prizes' | 'leaderboard' | 'citybuilder' | 'fishing' | 'towerDefence'
 
 interface Props {
   crystals: number
@@ -36,6 +36,7 @@ interface Props {
   user: User | null
   characterName: string
   onBack: () => void
+  onGameDone?: () => void
   initialSubScreen?: SubScreen
 }
 
@@ -67,7 +68,7 @@ function pickRandomCards(count: number, rarity?: 'uncommon' | 'rare' | 'legendar
   return results
 }
 
-export function MiniGamesMenu({ crystals, onCrystalsChange, user, characterName, onBack, initialSubScreen }: Props) {
+export function MiniGamesMenu({ crystals, onCrystalsChange, user, characterName, onBack, onGameDone, initialSubScreen }: Props) {
   const [subScreen, setSubScreen] = useState<SubScreen>(initialSubScreen ?? 'menu')
   const [tickets, setTickets] = useState(() => loadTickets())
   const [toast, setToast] = useState<string | null>(null)
@@ -153,8 +154,8 @@ export function MiniGamesMenu({ crystals, onCrystalsChange, user, characterName,
       }).catch(() => { /* offline — ignore */ })
     }
 
-    setSubScreen('menu')
-  }, [user, characterName])
+    if (onGameDone) { onGameDone() } else { setSubScreen('menu') }
+  }, [user, characterName, onGameDone])
 
   // ── Prize redemption ──────────────────────────────────────────────────────────
 

--- a/web/src/data/hubConfig.json
+++ b/web/src/data/hubConfig.json
@@ -904,7 +904,7 @@
       "id": "achievements-keeper",
       "name": "The Chronicler",
       "sprite": "hub-npc-elder",
-      "tx": 56, "ty": 19,
+      "tx": 33, "ty": 22,
       "screen": "hall-of-achievements",
       "dialogue": ["Your deeds are recorded here, Commander. Come see your legacy."]
     },
@@ -912,7 +912,7 @@
       "id": "home-shelf",
       "name": "Steward Maren",
       "sprite": "hub-npc-elder",
-      "tx": 19, "ty": 18,
+      "tx": 33, "ty": 24,
       "screen": "home-shelf",
       "dialogue": [
         "Your quarters are just inside, Commander. I keep your things in order.",
@@ -925,7 +925,7 @@
       "name": "Fishing Hole",
       "sprite": "hub-npc-fisherman",
       "tx": 35, "ty": 39,
-      "screen": "hub-fishing",
+      "screen": "fishing",
       "dialogue": ["The pond is calm today. Care to fish?"]
     },
     {
@@ -933,9 +933,97 @@
       "name": "Fishing Hole",
       "sprite": "hub-npc-fisherman",
       "tx": 34, "ty": 41,
-      "screen": "hub-fishing",
+      "screen": "fishing",
       "dialogue": ["The pond is calm today. Care to fish?"]
-    },    
+    },
+    {
+      "id": "marble-master",
+      "name": "Marble Master",
+      "sprite": "hub-npc-dealer",
+      "tx": 46, "ty": 22,
+      "screen": "marble",
+      "dialogue": ["Steady hands and a keen eye — care to roll?", "Every marble tells a story. Shall we write yours?"]
+    },
+    {
+      "id": "the-flipper",
+      "name": "The Flipper",
+      "sprite": "hub-npc-merchant",
+      "tx": 48, "ty": 22,
+      "screen": "tileflip",
+      "dialogue": ["Flip a tile, reveal your fate.", "Memory is a weapon. How sharp is yours?"]
+    },
+    {
+      "id": "crystal-keeper",
+      "name": "Crystal Keeper",
+      "sprite": "hub-npc-scholar",
+      "tx": 52, "ty": 22,
+      "screen": "crystalcatch",
+      "dialogue": ["Crystals falling fast — catch them before they shatter!", "Speed and focus. That is all you need."]
+    },
+    {
+      "id": "spinner-sal",
+      "name": "Spinner Sal",
+      "sprite": "hub-npc-dealer",
+      "tx": 54, "ty": 22,
+      "screen": "spinner",
+      "dialogue": ["Give it a spin — luck favours the bold.", "The wheel knows no favourites. Try your luck!"]
+    },
+    {
+      "id": "race-marshal",
+      "name": "Race Marshal",
+      "sprite": "hub-npc-arena",
+      "tx": 56, "ty": 22,
+      "screen": "marblerace",
+      "dialogue": ["On your marks — the race is about to begin!", "Place your bets and pick your marble. May the fastest win."]
+    },
+    {
+      "id": "card-sharp",
+      "name": "Card Sharp",
+      "sprite": "hub-npc-merchant",
+      "tx": 56, "ty": 24,
+      "screen": "higherOrLower",
+      "dialogue": ["Higher or lower? Simple question, nerves of steel.", "Read the deck — or trust your gut."]
+    },
+    {
+      "id": "reels-remy",
+      "name": "Reels Remy",
+      "sprite": "hub-npc-dealer",
+      "tx": 54, "ty": 26,
+      "screen": "fruitMachine",
+      "dialogue": ["Pull the lever and watch the reels spin!", "Three in a row and the jackpot is yours."]
+    },
+    {
+      "id": "poker-pete",
+      "name": "Poker Pete",
+      "sprite": "hub-npc-dealer",
+      "tx": 52, "ty": 26,
+      "screen": "videoPoker",
+      "dialogue": ["Best hand wins. Know when to hold, know when to fold.", "Poker face optional. Skill is not."]
+    },
+    {
+      "id": "prize-keeper",
+      "name": "Prize Keeper",
+      "sprite": "hub-npc-merchant",
+      "tx": 38, "ty": 27,
+      "screen": "prizes",
+      "dialogue": ["Got tickets? I've got prizes. Let's make a deal.", "Trade in your winning tickets for something special."]
+    },
+    {
+      "id": "siege-master",
+      "name": "Siege Master",
+      "sprite": "hub-npc-soldier",
+      "tx": 41, "ty": 26,
+      "screen": "towerDefence",
+      "dialogue": ["The enemy approaches. Build your defences and hold the line!", "Every tower placed is a life saved. Choose wisely."]
+    },
+    {
+      "id": "town-planner",
+      "name": "Town Planner",
+      "sprite": "hub-npc-elder",
+      "tx": 37, "ty": 26,
+      "screen": "citybuilder",
+      "dialogue": ["A great city starts with a single road. Shall we begin?", "Lay the streets, raise the buildings — this town is yours to shape."]
+    },
     {
       "id": "home-steward",
       "name": "Steward Aldous",


### PR DESCRIPTION
## Summary

### Return flow fix
- **`MiniGamesMenu`**: new `onGameDone?` prop — when provided, game end calls it directly instead of returning to the arcade menu. Used by hub-launched games so finishing a game goes straight back to hubworld.
- **`App.tsx`**: replaces the one-off `hub-fishing` screen with a general `hub-minigame` screen that works for any game. `onNavigate` in `<HubWorld>` now intercepts all minigame IDs (and `prizes`) and routes to `hub-minigame` with the correct `initialSubScreen`.

### Hub NPC coverage (`hubConfig.json`)
| NPC | Game | Position |
|---|---|---|
| Marble Master | marble | tx:46, ty:22 |
| The Flipper | tileflip | tx:48, ty:22 |
| Crystal Keeper | crystalcatch | tx:52, ty:22 |
| Spinner Sal | spinner | tx:54, ty:22 |
| Race Marshal | marblerace | tx:56, ty:22 |
| Card Sharp | higherOrLower | tx:56, ty:24 |
| Reels Remy | fruitMachine | tx:54, ty:26 |
| Poker Pete | videoPoker | tx:52, ty:26 |
| Siege Master | towerDefence | tx:41, ty:26 |
| Town Planner | cityBuilder | tx:37, ty:26 |
| **Prize Keeper** | prizes (ticket exchange) | tx:38, ty:27 |

- **Fishing-hole NPCs** updated from `hub-fishing` → `fishing` screen value.
- **achievements-keeper** moved to tx:33, ty:22 (courtyard entrance) — was in the scholars area and hard to find.
- **home-shelf** moved to tx:33, ty:24 (courtyard) — was above market lane and hard to find.

## Test plan
- [ ] Hub → tap any game NPC → correct game launches → game ends → returns directly to hubworld ✓
- [ ] Hub → tap Prize Keeper → ticket exchange screen opens → back → hubworld ✓
- [ ] Hub → tap The Chronicler (hall of achievements) → achievements screen → back → hubworld ✓
- [ ] Hub → tap Steward Maren (home shelf) → shelf screen → back → hubworld ✓
- [ ] Title → minigames menu → play a game → game ends → returns to arcade menu (unchanged) ✓
- [ ] Build: `npm run build` — no TypeScript errors ✓

https://claude.ai/code/session_01KsbTPR9gf6bfxY6rk2jQzu

---
_Generated by [Claude Code](https://claude.ai/code/session_01KsbTPR9gf6bfxY6rk2jQzu)_