### PR TITLE
Act VI: black sky background, dirt paths, denser clouds on node map

### DIFF
--- a/web/src/data/tiles/tileIndex.ts
+++ b/web/src/data/tiles/tileIndex.ts
@@ -133,6 +133,7 @@ export function tileFrame(id: number, cols: number): { x: number; y: number; w: 
 export interface EnvTileDef {
   ground: number          // BaseChip tile id — solid colour fallback fill
   pathFile: string        // per-combination 8-col transition sheet
+  solidColor?: number     // when set, fill background with this solid hex color instead of tiles
   bgTileId?: number       // tile in pathFile to repeat as textured background fill
   pathWidth?: number      // path tile width (odd; default 1); >1 expands perpendicular to path direction
   decorFile?: string      // decor scatter sheet (same 8-col format)
@@ -150,7 +151,7 @@ export const ENV_TILES: Record<string, EnvTileDef> = {
   citadel:  { ground: BASE_GROUND.darkGrass,   pathFile: PATH_TILE.wall2        },
   coast:    { ground: BASE_GROUND.sand,        pathFile: PATH_TILE.water2,       pathWidth: 3 },
   reef:     { ground: BASE_GROUND.sand,        pathFile: PATH_TILE.water1,       pathWidth: 3 },
-  sky:      { ground: BASE_GROUND.lightGrass,  pathFile: PATH_TILE.grass1Grass2 },
+  sky:      { ground: BASE_GROUND.lightGrass,  solidColor: 0x000000, pathFile: PATH_TILE.dirt4 },
   fungal:   { ground: BASE_GROUND.darkGrass,   pathFile: PATH_TILE.grass1Grass3 },
   vault:    { ground: BASE_GROUND.darkGrass,   pathFile: PATH_TILE.wall1        },
   camp:     { ground: BASE_GROUND.mediumGrass, pathFile: PATH_TILE.grass1Dirt1  },

--- a/web/src/utils/mapUtils.ts
+++ b/web/src/utils/mapUtils.ts
@@ -36,7 +36,7 @@ export function getTerrainItems(env: string | undefined, seed: number, w: number
     case 'sand':     scatter('dune', 10, 0.7, 1.3); scatter('mountain', 4, 0.5, 0.9); break
     case 'reef':
     case 'coast':    scatter('wave', 10, 0.8, 1.4); scatter('mountain', 4, 0.5, 0.9); scatter('river', 1, 1, 1); break
-    case 'sky':      scatter('cloud', 12, 0.8, 1.5); scatter('mountain', 4, 0.4, 0.8); break
+    case 'sky':      scatter('cloud', 20, 0.7, 2.0); break
     case 'fungal':   scatter('mushroom', 12, 0.8, 1.5); scatter('deadtree', 4, 0.5, 0.9); scatter('river', 1, 1, 1); break
     case 'vault':
     case 'camp':     scatter('pillar', 8, 0.7, 1.2); scatter('mountain', 4, 0.5, 0.9); break

--- a/web/src/utils/terrainLayer.ts
+++ b/web/src/utils/terrainLayer.ts
@@ -23,22 +23,29 @@ export function buildTerrainGfx(
   const base = (import.meta as { env: { BASE_URL: string } }).env.BASE_URL
   const { environment, terrainSeed, terrainItems: explicitItems, rivers: explicitRivers, id = '' } = opts
 
-  const groundTileId = ENV_TILES[environment ?? '']?.ground ?? BASE_GROUND.mediumGrass
-  const tileUrl = `${base}${TILESET_IMAGE.baseChip.slice(1)}`
-  loadTileTexture(tileUrl, groundTileId, TILESET_COLUMNS.baseChip).then(groundTex => {
-    if (baseContainer.destroyed) return
-    const tileCols = Math.ceil(mapWidth / 32)
-    const tileRows = Math.ceil(mapHeight / 32)
-    const bg = new PIXI.Container()
-    for (let r = 0; r < tileRows; r++) {
-      for (let c = 0; c < tileCols; c++) {
-        const s = new PIXI.Sprite(groundTex)
-        s.position.set(c * 32, r * 32)
-        bg.addChild(s)
+  const def = ENV_TILES[environment ?? '']
+  if (def?.solidColor !== undefined) {
+    const g = new PIXI.Graphics()
+    g.rect(0, 0, mapWidth, mapHeight).fill({ color: def.solidColor })
+    baseContainer.addChild(g)
+  } else {
+    const groundTileId = def?.ground ?? BASE_GROUND.mediumGrass
+    const tileUrl = `${base}${TILESET_IMAGE.baseChip.slice(1)}`
+    loadTileTexture(tileUrl, groundTileId, TILESET_COLUMNS.baseChip).then(groundTex => {
+      if (baseContainer.destroyed) return
+      const tileCols = Math.ceil(mapWidth / 32)
+      const tileRows = Math.ceil(mapHeight / 32)
+      const bg = new PIXI.Container()
+      for (let r = 0; r < tileRows; r++) {
+        for (let c = 0; c < tileCols; c++) {
+          const s = new PIXI.Sprite(groundTex)
+          s.position.set(c * 32, r * 32)
+          bg.addChild(s)
+        }
       }
-    }
-    baseContainer.addChild(bg)
-  }).catch(e => console.error('[terrainLayer] ground tile load failed', tileUrl, e))
+      baseContainer.addChild(bg)
+    }).catch(e => console.error('[terrainLayer] ground tile load failed', tileUrl, e))
+  }
 
   const seed = terrainSeed ?? hashStr(id)
   const items = explicitItems ?? getTerrainItems(environment, seed, mapWidth, mapHeight)


### PR DESCRIPTION
## Summary

- **Black background** — adds a `solidColor` field to `EnvTileDef`; when set, `buildTerrainGfx` fills the base layer with a solid colour instead of repeating ground tiles. `sky` is set to `0x000000`.
- **Floating dirt paths** — switches the `sky` path tileset from `grass1Grass2` to `dirt4`, which renders only the path shape with no surrounding ground texture, so paths appear to float over the black.
- **Denser cloud scatter** — sky terrain items go from 12 clouds (scale 0.8–1.5) + 4 mountains to 20 clouds (scale 0.7–2.0). Mountains removed (they read oddly in a pure black void; floating-island treatment deferred for a future pass).

## Test plan

- [ ] Open Act VI node map — background should be solid black
- [ ] Clouds (soft blue/white ellipse clusters) scattered in varied sizes across the canvas
- [ ] Path tiles between nodes use dirt styling with no surrounding grass/ground
- [ ] Sky-blue connector line colours unchanged
- [ ] Act I (forest) and other acts unaffected

https://claude.ai/code/session_01SoE4qqEXPFqc1Jq2yyYTqf

---
_Generated by [Claude Code](https://claude.ai/code/session_01SoE4qqEXPFqc1Jq2yyYTqf)_