### PR TITLE
feat(hub): speech bubble polish, name tags + arcade interior NPCs

### DIFF
--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -439,6 +439,15 @@ export function HubTownCanvas({
       }).catch(e => console.error(`[HubTownCanvas] NPC sprite failed: ${npcSpriteSlug}`, e))
     }
 
+    // ── NPC name tags (show within 5 tiles of avatar) ─────────────────────────
+    const npcNameTags: { tx: number; ty: number; tag: PIXI.Container }[] = []
+    for (const { npc, cx, cy } of npcBubbleTargets) {
+      const tag = createNameTag(npc.name, cx, cy)
+      tag.visible = false
+      bubbleLayer.addChild(tag)
+      npcNameTags.push({ tx: npc.tx, ty: npc.ty, tag })
+    }
+
     // ── Card-unit NPCs ─────────────────────────────────────────────────────────
     interface UnitNpcState {
       sprite:      PIXI.Sprite
@@ -794,30 +803,51 @@ export function HubTownCanvas({
 
     // ── Idle speech bubble state ───────────────────────────────────────────────
     const IDLE_THRESHOLD_MS = 5000
-    const BUBBLE_SHOW_MS    = 5000
+    const BUBBLE_SHOW_MS    = 10_000
     const BUBBLE_FADE_MS    = 500
+    const SLOT_STAGGER_MS   = 4_000
+    const MAX_BUBBLES       = 3
 
+    interface BubbleSlot { container: PIXI.Container; timer: number; phase: 'showing' | 'fading' }
+    const activeBubbles: BubbleSlot[] = []
     let lastMovedMs    = performance.now()
-    let bubblePhase:     'waiting' | 'showing' | 'fading' = 'waiting'
-    let bubbleTimer    = 0
-    let activeBubble:  PIXI.Container | null = null
+    let nextSpawnTimer = 0
     let lastBubbleIdx  = -1
 
     function createSpeechBubble(text: string, cx: number, cy: number): PIXI.Container {
       const c   = new PIXI.Container()
       const lbl = new PIXI.Text({
         text,
-        style: { fontSize: 11, fill: '#e8ffe8', fontFamily: 'monospace', wordWrap: true, wordWrapWidth: 160 },
+        style: { fontSize: 11, fill: '#111111', fontFamily: 'monospace', wordWrap: true, wordWrapWidth: 160 },
       })
-      lbl.anchor.set(0.5, 1)
+      lbl.anchor.set(0.5, 0.5)
       const pad = 6
       const bw  = lbl.width  + pad * 2
       const bh  = lbl.height + pad * 2
+      lbl.position.set(0, -bh / 2)
       const bg  = new PIXI.Graphics()
-      bg.roundRect(-bw / 2, -bh, bw, bh, 6).fill({ color: 0x1a2a1a, alpha: 0.92 })
-      bg.roundRect(-bw / 2, -bh, bw, bh, 6).stroke({ color: 0x44ff88, width: 1.5 })
-      bg.moveTo(-6, 0).lineTo(6, 0).lineTo(0, 8).closePath().fill({ color: 0x1a2a1a })
-      bg.moveTo(-6, 0).lineTo(6, 0).lineTo(0, 8).closePath().stroke({ color: 0x44ff88, width: 1.5 })
+      bg.roundRect(-bw / 2, -bh, bw, bh, 6).fill({ color: 0xffffff, alpha: 1 })
+      bg.roundRect(-bw / 2, -bh, bw, bh, 6).stroke({ color: 0x000000, width: 1.5 })
+      bg.moveTo(-6, 0).lineTo(6, 0).lineTo(0, 8).closePath().fill({ color: 0xffffff })
+      bg.moveTo(-6, 0).lineTo(6, 0).lineTo(0, 8).closePath().stroke({ color: 0x000000, width: 1.5 })
+      c.addChild(bg, lbl)
+      c.position.set(cx, cy - SPRITE_SIZE - 4)
+      return c
+    }
+
+    function createNameTag(name: string, cx: number, cy: number): PIXI.Container {
+      const c   = new PIXI.Container()
+      const lbl = new PIXI.Text({
+        text: name,
+        style: { fontSize: 9, fill: '#111111', fontFamily: 'monospace', fontWeight: 'bold' },
+      })
+      lbl.anchor.set(0.5, 0.5)
+      const pad = 3
+      const bw  = lbl.width  + pad * 2
+      const bh  = lbl.height + pad * 2
+      const bg  = new PIXI.Graphics()
+      bg.roundRect(-bw / 2, -bh / 2, bw, bh, 3).fill({ color: 0xffffff, alpha: 0.9 })
+      bg.roundRect(-bw / 2, -bh / 2, bw, bh, 3).stroke({ color: 0x000000, width: 1 })
       c.addChild(bg, lbl)
       c.position.set(cx, cy - SPRITE_SIZE - 4)
       return c
@@ -873,8 +903,9 @@ export function HubTownCanvas({
     }
 
     function startWalk(target: [number, number], nodeScreen?: string) {
-      if (activeBubble) { bubbleLayer.removeChild(activeBubble); activeBubble = null }
-      bubblePhase = 'waiting'
+      for (const s of activeBubbles) bubbleLayer.removeChild(s.container)
+      activeBubbles.length = 0
+      nextSpawnTimer = 0
       lastMovedMs = performance.now()
       const path = findPath(currentTile, target, pathSet)
       walkQueue = path.slice(1)
@@ -991,6 +1022,14 @@ export function HubTownCanvas({
       spriteLayer.sortChildren()
       worldLayer.sortChildren()
 
+      // NPC name tag proximity (exterior only)
+      if (!interiorActive) {
+        const [atx, aty] = currentTile
+        for (const { tx, ty, tag } of npcNameTags) {
+          tag.visible = Math.max(Math.abs(tx - atx), Math.abs(ty - aty)) <= 5
+        }
+      }
+
       for (const npc of unitNpcs) {
         if (npc.isWalking && npc.animFrames.length > 0) {
           npc.animTimer -= ticker.deltaMS
@@ -1018,30 +1057,31 @@ export function HubTownCanvas({
         const now = performance.now()
         if (isWalking) lastMovedMs = now
 
-        if (bubblePhase === 'waiting') {
-          if (now - lastMovedMs >= IDLE_THRESHOLD_MS) {
+        if (now - lastMovedMs >= IDLE_THRESHOLD_MS && activeBubbles.length < MAX_BUBBLES) {
+          nextSpawnTimer -= ticker.deltaMS
+          if (nextSpawnTimer <= 0) {
             lastBubbleIdx = (lastBubbleIdx + 1) % npcBubbleTargets.length
             const { npc, cx, cy } = npcBubbleTargets[lastBubbleIdx]
             const didx = npcDialogueIndex.get(npc.id) ?? 0
             const line = npc.dialogue[didx % npc.dialogue.length]
-            activeBubble = createSpeechBubble(line, cx, cy)
-            bubbleLayer.addChild(activeBubble)
-            bubbleTimer = BUBBLE_SHOW_MS
-            bubblePhase = 'showing'
+            const container = createSpeechBubble(line, cx, cy)
+            bubbleLayer.addChild(container)
+            activeBubbles.push({ container, timer: BUBBLE_SHOW_MS, phase: 'showing' })
+            nextSpawnTimer = SLOT_STAGGER_MS
           }
-        } else if (bubblePhase === 'showing') {
-          bubbleTimer -= ticker.deltaMS
-          if (bubbleTimer <= 0) {
-            bubblePhase = 'fading'
-            bubbleTimer = BUBBLE_FADE_MS
-          }
-        } else if (bubblePhase === 'fading') {
-          bubbleTimer -= ticker.deltaMS
-          if (activeBubble) activeBubble.alpha = Math.max(0, bubbleTimer / BUBBLE_FADE_MS)
-          if (bubbleTimer <= 0) {
-            if (activeBubble) { bubbleLayer.removeChild(activeBubble); activeBubble = null }
-            lastMovedMs = now
-            bubblePhase = 'waiting'
+        }
+
+        for (let i = activeBubbles.length - 1; i >= 0; i--) {
+          const slot = activeBubbles[i]
+          slot.timer -= ticker.deltaMS
+          if (slot.phase === 'showing' && slot.timer <= 0) {
+            slot.phase = 'fading'; slot.timer = BUBBLE_FADE_MS
+          } else if (slot.phase === 'fading') {
+            slot.container.alpha = Math.max(0, slot.timer / BUBBLE_FADE_MS)
+            if (slot.timer <= 0) {
+              bubbleLayer.removeChild(slot.container)
+              activeBubbles.splice(i, 1)
+            }
           }
         }
       }

--- a/web/src/data/hubConfig.json
+++ b/web/src/data/hubConfig.json
@@ -1165,6 +1165,87 @@
         "This hall forges soldiers from raw recruits. No exceptions.",
         "Training is the difference between victory and defeat. Remember that."
       ]
+    },
+    {
+      "id": "marble-master-int",
+      "name": "Marble Master",
+      "sprite": "hub-npc-dealer",
+      "building": "arcade-building-e",
+      "tx": 8, "ty": 3,
+      "screen": "marble",
+      "dialogue": ["Steady hands and a keen eye — care to roll?", "Every marble tells a story. Shall we write yours?"]
+    },
+    {
+      "id": "the-flipper-int",
+      "name": "The Flipper",
+      "sprite": "hub-npc-merchant",
+      "building": "arcade-building-e",
+      "tx": 4, "ty": 3,
+      "screen": "tileflip",
+      "dialogue": ["Flip a tile, reveal your fate.", "Memory is a weapon. How sharp is yours?"]
+    },
+    {
+      "id": "crystal-keeper-int",
+      "name": "Crystal Keeper",
+      "sprite": "hub-npc-scholar",
+      "building": "arcade-building-e",
+      "tx": 6, "ty": 5,
+      "screen": "crystalcatch",
+      "dialogue": ["Crystals falling fast — catch them before they shatter!", "Speed and focus. That is all you need."]
+    },
+    {
+      "id": "prize-keeper-int",
+      "name": "Prize Keeper",
+      "sprite": "hub-npc-merchant",
+      "building": "arcade-building-e",
+      "tx": 2, "ty": 4,
+      "screen": "prizes",
+      "dialogue": ["Got tickets? I've got prizes. Let's make a deal.", "Trade in your winning tickets for something special."]
+    },
+    {
+      "id": "spinner-sal-int",
+      "name": "Spinner Sal",
+      "sprite": "hub-npc-dealer",
+      "building": "arcade-building-w",
+      "tx": 2, "ty": 2,
+      "screen": "spinner",
+      "dialogue": ["Give it a spin — luck favours the bold.", "The wheel knows no favourites. Try your luck!"]
+    },
+    {
+      "id": "race-marshal-int",
+      "name": "Race Marshal",
+      "sprite": "hub-npc-arena",
+      "building": "arcade-building-w",
+      "tx": 10, "ty": 2,
+      "screen": "marblerace",
+      "dialogue": ["On your marks — the race is about to begin!", "Place your bets and pick your marble. May the fastest win."]
+    },
+    {
+      "id": "card-sharp-int",
+      "name": "Card Sharp",
+      "sprite": "hub-npc-merchant",
+      "building": "arcade-building-w",
+      "tx": 5, "ty": 5,
+      "screen": "higherOrLower",
+      "dialogue": ["Higher or lower? Simple question, nerves of steel.", "Read the deck — or trust your gut."]
+    },
+    {
+      "id": "reels-remy-int",
+      "name": "Reels Remy",
+      "sprite": "hub-npc-dealer",
+      "building": "arcade-building-w",
+      "tx": 2, "ty": 8,
+      "screen": "fruitMachine",
+      "dialogue": ["Pull the lever and watch the reels spin!", "Three in a row and the jackpot is yours."]
+    },
+    {
+      "id": "poker-pete-int",
+      "name": "Poker Pete",
+      "sprite": "hub-npc-dealer",
+      "building": "arcade-building-w",
+      "tx": 9, "ty": 8,
+      "screen": "videoPoker",
+      "dialogue": ["Best hand wins. Know when to hold, know when to fold.", "Poker face optional. Skill is not."]
     }
   ],
 


### PR DESCRIPTION
## Summary

- **Bubble styling**: white fill, black border, text properly centered (was flushed to the bottom)
- **Multiple concurrent bubbles**: up to 3 NPCs show bubbles simultaneously, staggered 4s apart, each lasting 10s; moving clears all immediately
- **Name tags**: when the player is within 5 tiles (Chebyshev) of any NPC with dialogue, a small white name tag appears above their head
- **Arcade interior NPCs**: all minigame NPCs duplicated inside the arcade buildings so every game is accessible from inside too

## Interior NPC placements

**Trophy Hall (arcade-building-e):** Marble Master (8,3), The Flipper (4,3), Crystal Keeper (6,5), Prize Keeper (2,4)

**Games Hall (arcade-building-w):** Spinner Sal (2,2), Race Marshal (10,2), Card Sharp (5,5), Reels Remy (2,8), Poker Pete (9,8)

Positions verified against decor tile map — no collisions.

## Test plan

- [ ] Stand idle 5s → first bubble appears (white bg, black border, text centered)
- [ ] Stand idle 4s more → second bubble appears on a different NPC (both visible)
- [ ] Stand idle 4s more → third bubble (3 simultaneous max)
- [ ] Move → all bubbles dismiss instantly
- [ ] Walk within 5 tiles of an NPC → name tag appears; walk away → disappears
- [ ] Enter Trophy Hall → can tap Marble Master, Flipper, Crystal Keeper, Prize Keeper → games launch → return to hub
- [ ] Enter Games Hall → can tap Spinner Sal, Race Marshal, Card Sharp, Reels Remy, Poker Pete → games launch → return to hub

https://claude.ai/code/session_01KsbTPR9gf6bfxY6rk2jQzu

---
_Generated by [Claude Code](https://claude.ai/code/session_01KsbTPR9gf6bfxY6rk2jQzu)_