### PR TITLE
Hub world lock/unlock preference toggle

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2523,7 +2523,6 @@ export default function App() {
       {screen === 'hubworld' && (
         <HubWorld
           onBack={() => setScreen('settings')}
-          onUseTitleScreen={() => { saveHubDefault('title'); setScreen('title') }}
           onNavigate={(s) => {
             setReturnScreen('hubworld')
             const HUB_MINIGAME_IDS: SubScreen[] = ['marble', 'tileflip', 'crystalcatch', 'spinner', 'marblerace', 'higherOrLower', 'fruitMachine', 'videoPoker', 'fishing', 'towerDefence', 'citybuilder', 'prizes']

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -43,7 +43,7 @@ import { EventScreen }          from './components/campaign/EventScreen'
 import { MerchantScreen, MerchantItem, cardMerchantItem } from './components/campaign/MerchantScreen'
 import { MysteryScreen } from './components/campaign/MysteryScreen'
 import { MemoryFragmentScreen } from './components/campaign/MemoryFragmentScreen'
-import { MemoryFragment, isFragmentDiscovered, markFragmentDiscovered, isHubWorldUnlocked, unlockHubWorld, areAllCampaignFragmentsDiscovered, loadHubDefault } from './game/codex'
+import { MemoryFragment, isFragmentDiscovered, markFragmentDiscovered, isHubWorldUnlocked, unlockHubWorld, areAllCampaignFragmentsDiscovered, loadHubDefault, saveHubDefault } from './game/codex'
 import { CharacterEncounterScreen } from './components/campaign/CharacterEncounterScreen'
 import { CharacterChoice, recordCharacterEncounter } from './game/characters'
 import memoryFragmentsData from './data/memoryFragments.json'
@@ -481,6 +481,13 @@ export default function App() {
   // affect screens reached later via the title screen's own navigation.
   useEffect(() => {
     if (screen === 'title') setReturnScreen('title')
+  }, [screen])
+  // When hub is unlocked and set as default, redirect title→hub automatically.
+  // saveHubDefault('title') must be called before setScreen('title') to bypass this.
+  useEffect(() => {
+    if (screen === 'title' && isHubWorldUnlocked() && loadHubDefault() !== 'title') {
+      setScreen('hubworld')
+    }
   }, [screen])
   const { activeRareEvent, isGamePaused: isRareEventPaused, rollRareEvent, handleRareEventDone } = useRareEvents({
     gameState, screen, setGameState, setCrystals, setAchievementToasts,
@@ -2469,6 +2476,8 @@ export default function App() {
             onSignOut={() => { import('firebase/auth').then(({ signOut }) => signOut(auth)) }}
             onSignIn={() => setShowTitleLoginModal(true)}
             onFeedback={() => setFeedbackOpen(true)}
+            hubUnlocked={isHubWorldUnlocked() && loadHubDefault() === 'title'}
+            onHub={() => { saveHubDefault('hub'); setScreen('hubworld') }}
           />
           {feedbackOpen && (
             <FeedbackModal user={user} onClose={() => setFeedbackOpen(false)} />
@@ -2514,6 +2523,7 @@ export default function App() {
       {screen === 'hubworld' && (
         <HubWorld
           onBack={() => setScreen('settings')}
+          onUseTitleScreen={() => { saveHubDefault('title'); setScreen('title') }}
           onNavigate={(s) => {
             setReturnScreen('hubworld')
             const HUB_MINIGAME_IDS: SubScreen[] = ['marble', 'tileflip', 'crystalcatch', 'spinner', 'marblerace', 'higherOrLower', 'fruitMachine', 'videoPoker', 'fishing', 'towerDefence', 'citybuilder', 'prizes']

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -29,7 +29,6 @@ let _hubSplashShown = false
 
 interface Props {
   onBack:             () => void
-  onUseTitleScreen?:  () => void
   onNavigate?:        (screen: string) => void
   onCampaign?:        () => void
   onPlayerTap?:       () => void
@@ -43,7 +42,7 @@ interface Props {
   onTileTap?:         (tx: number, ty: number) => void
 }
 
-export function HubWorld({ onBack, onUseTitleScreen, onNavigate, onCampaign, onPlayerTap, crystals = 0, isSignedIn = false, commander, user, onSignIn: onLoginToggle, onSignOut, onFeedback, onTileTap }: Props) {
+export function HubWorld({ onBack, onNavigate, onCampaign, onPlayerTap, crystals = 0, isSignedIn = false, commander, user, onSignIn: onLoginToggle, onSignOut, onFeedback, onTileTap }: Props) {
   const [splashVisible, setSplashVisible] = useState(() => !_hubSplashShown && !loadSkipIntro())
   const [splashFading,  setSplashFading]  = useState(false)
   const [currentArea,    setCurrentArea]    = useState<string | null>(null)
@@ -157,9 +156,6 @@ export function HubWorld({ onBack, onUseTitleScreen, onNavigate, onCampaign, onP
             icon={'🗣️'}
           />
           
-          {onUseTitleScreen && (
-            <ToolbarButton className="action-btn hub-hud__btn" onClick={onUseTitleScreen} icon={'⌂'} title="Use Title Screen as home" />
-          )}
                       <ToolbarButton className="action-btn hub-hud__btn" onClick={onBack} icon={'⚙'}/>
 
           </Toolbar>

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -28,21 +28,22 @@ const SPLASH_MS = 10_000
 let _hubSplashShown = false
 
 interface Props {
-  onBack:          () => void
-  onNavigate?:     (screen: string) => void
-  onCampaign?:     () => void
-  onPlayerTap?:    () => void
-  crystals?:       number
-  isSignedIn?:     boolean
+  onBack:             () => void
+  onUseTitleScreen?:  () => void
+  onNavigate?:        (screen: string) => void
+  onCampaign?:        () => void
+  onPlayerTap?:       () => void
+  crystals?:          number
+  isSignedIn?:        boolean
   commander?: CommanderState
   user: User | null
-  onSignIn?:  () => void
-  onSignOut?:      () => void
+  onSignIn?:   () => void
+  onSignOut?:         () => void
   onFeedback: () => void
-  onTileTap?:      (tx: number, ty: number) => void
+  onTileTap?:         (tx: number, ty: number) => void
 }
 
-export function HubWorld({ onBack, onNavigate, onCampaign, onPlayerTap, crystals = 0, isSignedIn = false, commander, user, onSignIn: onLoginToggle, onSignOut, onFeedback, onTileTap }: Props) {
+export function HubWorld({ onBack, onUseTitleScreen, onNavigate, onCampaign, onPlayerTap, crystals = 0, isSignedIn = false, commander, user, onSignIn: onLoginToggle, onSignOut, onFeedback, onTileTap }: Props) {
   const [splashVisible, setSplashVisible] = useState(() => !_hubSplashShown && !loadSkipIntro())
   const [splashFading,  setSplashFading]  = useState(false)
   const [currentArea,    setCurrentArea]    = useState<string | null>(null)
@@ -156,6 +157,9 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onPlayerTap, crystals
             icon={'🗣️'}
           />
           
+          {onUseTitleScreen && (
+            <ToolbarButton className="action-btn hub-hud__btn" onClick={onUseTitleScreen} icon={'⌂'} title="Use Title Screen as home" />
+          )}
                       <ToolbarButton className="action-btn hub-hud__btn" onClick={onBack} icon={'⚙'}/>
 
           </Toolbar>

--- a/web/src/components/title/TitleScreen.tsx
+++ b/web/src/components/title/TitleScreen.tsx
@@ -51,9 +51,11 @@ export interface Props {
   onSignOut: () => void
   onSignIn: () => void
   onFeedback: () => void
+  hubUnlocked?: boolean
+  onHub?: () => void
 }
 
-export function TitleScreen({ crystals, onPlay, onEndless, onCampaign, onCollection, onShop, onDeckBuilder, onSettings, onPlayer, on8bitUnlocked, onDailyChallenge, onEndlessLeaderboard, onCommander, commanderName, onTraining, onNews, hasUnreadNews, onMiniGames, onCityBuilder, onCodex, user, onSignOut, onSignIn, onFeedback }: Props) {
+export function TitleScreen({ crystals, onPlay, onEndless, onCampaign, onCollection, onShop, onDeckBuilder, onSettings, onPlayer, on8bitUnlocked, onDailyChallenge, onEndlessLeaderboard, onCommander, commanderName, onTraining, onNews, hasUnreadNews, onMiniGames, onCityBuilder, onCodex, user, onSignOut, onSignIn, onFeedback, hubUnlocked, onHub }: Props) {
   const deck             = loadDeck()
   const count            = deckTotalCards(deck)
   const valid            = isDeckValid(deck)
@@ -234,6 +236,11 @@ export function TitleScreen({ crystals, onPlay, onEndless, onCampaign, onCollect
         {cityAttackAlert && (
           <TitleButton variant="large" onClick={onCityBuilder} extraClass="title-campaign-btn title-minigames-btn title-btn--alert title-alert-badge">
             ⚔ CITY ALERT
+          </TitleButton>
+        )}
+        {hubUnlocked && onHub && (
+          <TitleButton variant="large" onClick={onHub} extraClass="title-campaign-btn">
+            🌆  HUB WORLD
           </TitleButton>
         )}
       </div>


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- When all memory fragments are collected, navigating to the title screen now automatically redirects to hub world in-session (previously only worked on the next page load)
- Added a ⌂ toolbar button in hub world to switch back to the title screen as your home — `saveHubDefault('title')` is called before navigating so the redirect useEffect won't fire
- Added a **🌆 HUB WORLD** button on the title screen (only visible when hub is unlocked and player has opted into title screen mode) — clicking it restores hub as the default home

## How it works

- `loadHubDefault()` already returned `'hub'` by default, so no changes needed to `codex.ts`
- A new `useEffect` in `App.tsx` watches `screen` — when it becomes `'title'` and hub is unlocked with hub as the default, it redirects to `'hubworld'` automatically
- `saveHubDefault()` (which was defined but never called) is now wired up via the toggle buttons

## Test plan

- [ ] Collect all fragments in campaign, navigate back to title — should auto-redirect to hub world
- [ ] From hub world, click ⌂ button — should land on title screen with **HUB WORLD** button visible
- [ ] Click **HUB WORLD** on title — should navigate to hub and restore hub as home (no HUB WORLD button next time)
- [ ] Refresh page with hub unlocked and pref=hub → lands on hub; with pref=title → lands on title
- [ ] Existing navigation (settings, campaign, etc.) still works correctly

https://claude.ai/code/session_01R3HTXGSHTbCP9or9bSi1Qk
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01R3HTXGSHTbCP9or9bSi1Qk)_