### PR TITLE
feat(hub): show quest reward after completion dialogue

### DIFF
--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -123,7 +123,7 @@ export function HubTownCanvas({
     const npcLayer    = spriteLayer
     const avatarLayer = spriteLayer
     const exteriorDecorLayer = spriteLayer
-    app.stage.addChild(groundLayer, streetLayer, pondLayer, pickupLayer, buildingLayer, windowLayer, spriteLayer, nodeLayer, worldLayer, interiorLayer, bubbleLayer, highlightGfx)
+    app.stage.addChild(groundLayer, streetLayer, pondLayer, buildingLayer, windowLayer, spriteLayer, pickupLayer, nodeLayer, worldLayer, interiorLayer, bubbleLayer, highlightGfx)
 
     // Keyed by pickupId; used to imperatively show/hide sprites when items are collected
     const pickupSprites = new Map<string, PIXI.Sprite>()

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -41,6 +41,7 @@ interface QuestEvent {
   speakerName: string
   text: string
   choices?: DialogueChoice[]
+  onClose?: () => void
 }
 
 function checkPrerequisite(prereq: string): boolean {
@@ -272,9 +273,11 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onPlayerTap, crystals
           setQuestStatus(quest.id, 'completed')
           grantQuestReward(quest)
           refreshState()
+          const rewardText = formatQuestReward(quest.reward)
           setDialogueEvent({
             speakerName,
             text: quest.completeDialogue,
+            ...(rewardText ? { onClose: () => setDialogueEvent({ speakerName: '', text: rewardText }) } : {}),
           })
           return
         }
@@ -319,7 +322,12 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onPlayerTap, crystals
             setQuestStatus(quest.id, 'completed')
             grantQuestReward(quest)
             refreshState()
-            setDialogueEvent({ speakerName, text: quest.completeDialogue })
+            const rewardText = formatQuestReward(quest.reward)
+            setDialogueEvent({
+              speakerName,
+              text: quest.completeDialogue,
+              ...(rewardText ? { onClose: () => setDialogueEvent({ speakerName: '', text: rewardText }) } : {}),
+            })
             return
           }
           setDialogueEvent({ speakerName, text: getActiveDialogue(quest) })
@@ -403,8 +411,10 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onPlayerTap, crystals
           speakerName={dialogueEvent?.speakerName}
           choices={dialogueEvent?.choices}
           onClose={() => {
+            const after = dialogueEvent?.onClose
             setDialogueEvent(null)
             setDialogueLine(null)
+            after?.()
           }}
         />
 
@@ -435,7 +445,19 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onPlayerTap, crystals
   )
 }
 
-// ── Quest reward helper ────────────────────────────────────────────────────────
+// ── Quest reward helpers ───────────────────────────────────────────────────────
+
+function formatQuestReward(reward: HubQuestDef['reward']): string {
+  const parts: string[] = []
+  if (reward.crystals)    parts.push(`+${reward.crystals} 💎`)
+  if (reward.collectible) parts.push(`${reward.collectible.icon} ${reward.collectible.name}`)
+  if (reward.friendship) {
+    for (const [npcId, xp] of Object.entries(reward.friendship)) {
+      parts.push(`+${xp} friendship with ${getNpcDisplayName(npcId)}`)
+    }
+  }
+  return parts.length > 0 ? `You received: ${parts.join('  ·  ')}` : ''
+}
 
 function grantQuestReward(quest: HubQuestDef): void {
   const { reward } = quest

--- a/web/src/components/screens/SettingsScreen.tsx
+++ b/web/src/components/screens/SettingsScreen.tsx
@@ -339,6 +339,11 @@ export function SettingsScreen({ onBack, onResetGame, user, authLoading, onDevCr
     }
   }
 
+  function handleResetHubData() {
+    try { localStorage.removeItem('jarv_hub_quests') } catch { /* ignore */ }
+    try { localStorage.removeItem('jarv_hub_pickups') } catch { /* ignore */ }
+  }
+
   async function handleCheckForUpdates() {
     setUpdateStatus('checking')
     await onCheckForUpdates?.()
@@ -714,6 +719,13 @@ export function SettingsScreen({ onBack, onResetGame, user, authLoading, onDevCr
                 <button className="action-btn action-btn--gold" onClick={onFeedbackAdmin}>OPEN</button>
               </div>
             )}
+            <div className="settings-row u-flex u-items-c u-just-sb u-gap-7">
+              <div>
+                <div className="settings-label">Reset hub quests &amp; pickups</div>
+                <div className="settings-sublabel">Clears all quest progress and collected pickup state</div>
+              </div>
+              <button className="action-btn action-btn--danger" onClick={handleResetHubData}>RESET</button>
+            </div>
           </Section>
 </>
         )}

--- a/web/src/data/hubConfig.json
+++ b/web/src/data/hubConfig.json
@@ -2303,7 +2303,7 @@
     {
       "id": "pendant-3",
       "tx": 66,
-      "ty": 50,
+      "ty": 49,
       "tileId": "chest",
       "questId": "lost-pendant"
     },

--- a/web/src/data/hubConfig.json
+++ b/web/src/data/hubConfig.json
@@ -2290,35 +2290,35 @@
       "id": "pendant-1",
       "tx": 4,
       "ty": 39,
-      "tileId": "goldChest",
+      "tileId": "pendant",
       "questId": "lost-pendant"
     },
     {
       "id": "pendant-2",
       "tx": 24,
       "ty": 49,
-      "tileId": "chest",
+      "tileId": "pendant",
       "questId": "lost-pendant"
     },
     {
       "id": "pendant-3",
       "tx": 66,
       "ty": 49,
-      "tileId": "chest",
+      "tileId": "pendant",
       "questId": "lost-pendant"
     },
     {
       "id": "moonleaf-herb",
       "tx": 52,
       "ty": 2,
-      "tileId": "sack",
+      "tileId": "bunchOfHerbs",
       "questId": "merchants-herb"
     },
     {
       "id": "ancient-tome-1",
       "tx": 3,
       "ty": 5,
-      "tileId": "bookshelfBottom",
+      "tileId": "blackclosedBook",
       "questId": "scholars-anthology",
       "building": "card-shop"
     },
@@ -2326,7 +2326,7 @@
       "id": "ancient-tome-2",
       "tx": 4,
       "ty": 3,
-      "tileId": "bookshelfBottom",
+      "tileId": "blueclosedBook",
       "questId": "scholars-anthology",
       "building": "traders-building",
       "chain": "ancient-tome-1"
@@ -2335,7 +2335,7 @@
       "id": "ancient-tome-3",
       "tx": 3,
       "ty": 40,
-      "tileId": "bookshelfBottom",
+      "tileId": "greenclosedBook",
       "questId": "scholars-anthology"
     },
     {

--- a/web/src/data/tiles/baseChipIndex.ts
+++ b/web/src/data/tiles/baseChipIndex.ts
@@ -477,6 +477,13 @@ export const BASE_CHIP_TILES = {
     greenclosedBook: 958,
     greenopenBook: 959,
 
+    bunchOfHerbs: 984,
+
+    gift:992,
+    smallChest:993,
+    pileOfCoins:994,
+    pendant: 1008,
+
 
     // Exterior Walls
 


### PR DESCRIPTION
## Summary
- After an NPC says their quest completion line, dismissing it now triggers a second dialogue showing what the player received (e.g. `You received: +50 💎  ·  +25 friendship with Elder`)
- Reward summary is skipped if the quest has no reward
- Adds a **Reset hub quests & pickups** danger button to the admin-only section of Settings for dev testing

## Test plan
- [ ] Complete **Lost Pendants** (collect 3 pendants, talk to Elder) — NPC completion line → OK → reward summary → OK
- [ ] Complete **Innkeeper's Package** (deliver to Guard Captain) — reward box shows Barracks Key + friendship for both NPCs
- [ ] Talk to an in-progress quest NPC mid-quest — no reward box appears
- [ ] In Settings (admin account) → ADMIN section → RESET hub quests & pickups — quest and pickup state clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)