### PR TITLE
fix(hub): three NPC interaction bugs — commander crash, deck builder screen, quest+screen routing

### DIFF
--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -476,11 +476,11 @@ export function HubTownCanvas({
       npcContainer.cursor    = 'pointer'
       npcContainer.on('pointerdown', (e: PIXI.FederatedPointerEvent) => {
         e.stopPropagation()
-        if (npc.screen) {
+        if (npc.screen && !npc.questGive && !npc.questReceive) {
           onNodeInteractRef.current(npc.screen)
-        } else if (npc.dialogue.length > 0) {
+        } else if (npc.dialogue.length > 0 || npc.questGive || npc.questReceive) {
           const idx = npcDialogueIndex.get(npc.id) ?? 0
-          onNpcTapRef.current?.(npc.dialogue[idx % npc.dialogue.length], npc.id)
+          onNpcTapRef.current?.(npc.dialogue[idx % npc.dialogue.length] ?? '', npc.id)
           npcDialogueIndex.set(npc.id, idx + 1)
         }
       })
@@ -875,11 +875,11 @@ export function HubTownCanvas({
           s.cursor    = 'pointer'
           s.on('pointerdown', (e: PIXI.FederatedPointerEvent) => {
             e.stopPropagation()
-            if (npc.screen) {
+            if (npc.screen && !npc.questGive && !npc.questReceive) {
               onNodeInteractRef.current(npc.screen)
-            } else if (npc.dialogue.length > 0) {
+            } else if (npc.dialogue.length > 0 || npc.questGive || npc.questReceive) {
               const idx = npcDialogueIndex.get(npc.id) ?? 0
-              onNpcTapRef.current?.(npc.dialogue[idx % npc.dialogue.length], npc.id)
+              onNpcTapRef.current?.(npc.dialogue[idx % npc.dialogue.length] ?? '', npc.id)
               npcDialogueIndex.set(npc.id, idx + 1)
             }
           })

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -220,8 +220,12 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onPlayerTap, crystals
       return
     }
     if (screen === 'campaign') { onCampaign?.(); return }
+    if (screen === 'commander' && !commander) {
+      setDialogueEvent({ speakerName: "Commander's Post", text: "No commander has been assigned yet. Visit the title screen to choose one." })
+      return
+    }
     onNavigate?.(screen)
-  }, [onNavigate, onCampaign])
+  }, [onNavigate, onCampaign, commander])
 
   const handleReturn = useCallback(() => {
     returnRef.current?.()
@@ -363,9 +367,15 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onPlayerTap, crystals
         }
 
         if (state.status === 'completed') {
-          // Fall through to friendship/default dialogue
+          // Fall through to screen navigation or friendship/default dialogue
         }
       }
+    }
+
+    // ── Screen navigation fallthrough (quest done or no active quest) ────────
+    if (npcDef?.screen) {
+      handleNodeInteract(npcDef.screen)
+      return
     }
 
     // ── Friendship tier dialogue override ───────────────────────────────────
@@ -384,7 +394,7 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onPlayerTap, crystals
 
     // ── Default dialogue ─────────────────────────────────────────────────────
     setDialogueEvent({ speakerName, text: line })
-  }, [refreshState])
+  }, [refreshState, handleNodeInteract])
 
   return (
     <OverlayScreen title="JARVS AMAZING WEB GAME">

--- a/web/src/data/hubConfig.json
+++ b/web/src/data/hubConfig.json
@@ -1863,7 +1863,7 @@
       "sprite": "hub-npc-arena",
       "tx": 40,
       "ty": 18,
-      "screen": "deck-builder",
+      "screen": "deckbuilder",
       "dialogue": [
         "Let's plan our strategy for the next battle.",
         "A strong army wins wars!"


### PR DESCRIPTION
- Commander's Post: guard null commander in handleNodeInteract; shows dialogue
  instead of navigating to a blank screen when no commander is set
- Deck Builder Dave: fix screen name mismatch ("deck-builder" → "deckbuilder")
  so the NPC correctly opens the Deck Builder UI
- Screen+quest NPCs: route NPCs with questGive/questReceive through handleNpcTap
  instead of immediate screen navigation, so quest offers/active dialogue are
  shown first; once the quest is completed the tap falls through to the screen

https://claude.ai/code/session_01B7jiiKLsnETnMnAUENRAss