### PR TITLE
fix(hub): NPC interaction bugs — commander crash, deck builder screen, quest dialogue routing

### DIFF
--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -317,58 +317,54 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onPlayerTap, crystals
     }
 
     // ── Quest give/active dialogue ──────────────────────────────────────────
-    if (npcDef?.questGive) {
-      const quest = HUB_QUEST_DEFS.find(q => q.id === npcDef.questGive)
-      if (quest) {
-        const state = getQuestState(quest.id)
+    // Scan ALL quests this NPC gives — not just the first one — so later
+    // quests in the chain are offered once earlier ones are completed.
+    const giveQuests = HUB_QUEST_DEFS.filter(q => q.giverNpcId === npcId)
 
-        if (state.status === 'available') {
-          const prereqMet = !quest.prerequisite || checkPrerequisite(quest.prerequisite)
-          if (prereqMet) {
-            setDialogueEvent({
-              speakerName,
-              text: quest.offerDialogue,
-              choices: [
-                {
-                  label: 'Accept',
-                  primary: true,
-                  onClick: () => {
-                    setQuestStatus(quest.id, 'active')
-                    refreshState()
-                    setDialogueEvent(null)
-                  },
-                },
-                {
-                  label: 'Not now',
-                  onClick: () => setDialogueEvent(null),
-                },
-              ],
-            })
-            return
-          }
-        }
+    // First pass: active quest (takes priority — show progress or complete)
+    for (const quest of giveQuests) {
+      if (getQuestState(quest.id).status !== 'active') continue
+      if (quest.receiverNpcId === npcId && isQuestReadyToComplete(quest)) {
+        setQuestStatus(quest.id, 'completed')
+        grantQuestReward(quest)
+        refreshState()
+        const rewardText = formatQuestReward(quest.reward)
+        setDialogueEvent({
+          speakerName,
+          text: quest.completeDialogue,
+          ...(rewardText ? { onClose: () => setDialogueEvent({ speakerName: '', text: rewardText }) } : {}),
+        })
+        return
+      }
+      setDialogueEvent({ speakerName, text: getActiveDialogue(quest) })
+      return
+    }
 
-        if (state.status === 'active') {
-          // Also check if this NPC is the receiver and quest is ready
-          if (quest.receiverNpcId === npcId && isQuestReadyToComplete(quest)) {
-            setQuestStatus(quest.id, 'completed')
-            grantQuestReward(quest)
-            refreshState()
-            const rewardText = formatQuestReward(quest.reward)
-            setDialogueEvent({
-              speakerName,
-              text: quest.completeDialogue,
-              ...(rewardText ? { onClose: () => setDialogueEvent({ speakerName: '', text: rewardText }) } : {}),
-            })
-            return
-          }
-          setDialogueEvent({ speakerName, text: getActiveDialogue(quest) })
-          return
-        }
-
-        if (state.status === 'completed') {
-          // Fall through to screen navigation or friendship/default dialogue
-        }
+    // Second pass: first available quest whose prerequisites are met
+    for (const quest of giveQuests) {
+      if (getQuestState(quest.id).status !== 'available') continue
+      const prereqMet = !quest.prerequisite || checkPrerequisite(quest.prerequisite)
+      if (prereqMet) {
+        setDialogueEvent({
+          speakerName,
+          text: quest.offerDialogue,
+          choices: [
+            {
+              label: 'Accept',
+              primary: true,
+              onClick: () => {
+                setQuestStatus(quest.id, 'active')
+                refreshState()
+                setDialogueEvent(null)
+              },
+            },
+            {
+              label: 'Not now',
+              onClick: () => setDialogueEvent(null),
+            },
+          ],
+        })
+        return
       }
     }
 


### PR DESCRIPTION
## Summary

- **Commander's Post crash**: Guard null `commander` in `handleNodeInteract` — shows a dialogue instead of navigating to a blank screen when no commander is set
- **Deck Builder Dave black screen**: Fix screen name mismatch (`"deck-builder"` → `"deckbuilder"`) so the NPC correctly opens the Deck Builder UI
- **Screen+quest NPCs**: Route NPCs with `questGive`/`questReceive` through `handleNpcTap` instead of immediate screen navigation, so quest offers/active dialogue appear first; tapping after quest completion falls through to the screen
- **Quest chain NPCs show normal dialogue**: `handleNpcTap` was only checking `npcDef.questGive` (the NPC's first quest). Once that quest was complete, later quests in the chain showed the `!` indicator but tapping fell through to default dialogue. Fixed by scanning all `HUB_QUEST_DEFS` entries where `giverNpcId === npcId`, matching the indicator logic exactly.

## Test plan

- [ ] Tap Commander's Post with no commander set → dialogue shown, no black screen
- [ ] Tap Deck Builder Dave → Deck Builder opens with back button
- [ ] Tap a quest NPC (e.g. The Elder) before accepting quest → quest offer with Accept/Not Now
- [ ] Accept quest, tap again → active dialogue shown
- [ ] Complete first quest, tap same NPC again → next quest in chain is offered (not normal dialogue)
- [ ] Complete all quests for an NPC → normal/friendship dialogue shown

https://claude.ai/code/session_01B7jiiKLsnETnMnAUENRAss

---
_Generated by [Claude Code](https://claude.ai/code/session_01B7jiiKLsnETnMnAUENRAss)_