### PR TITLE
feat(hub): cap active quests at 2 and unblock screen NPCs

### DIFF
--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -110,11 +110,13 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onPlayerTap, crystals
   const questNpcStateRef = useRef(new Map<string, 'offer' | 'ready' | null>())
   {
     const m = new Map<string, 'offer' | 'ready' | null>()
+    const activeCount = HUB_QUEST_DEFS.filter(q => getQuestState(q.id).status === 'active').length
+    const atCap = activeCount >= 2
     for (const quest of HUB_QUEST_DEFS) {
       const state = getQuestState(quest.id)
       if (state.status === 'available') {
         const prereqMet = !quest.prerequisite || checkPrerequisite(quest.prerequisite)
-        if (prereqMet) m.set(quest.giverNpcId, 'offer')
+        if (prereqMet && !atCap) m.set(quest.giverNpcId, 'offer')
       } else if (state.status === 'active') {
         if (isQuestReadyToComplete(quest)) m.set(quest.receiverNpcId, 'ready')
       }
@@ -336,15 +338,22 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onPlayerTap, crystals
         })
         return
       }
+      // Quest in progress but not completable — if NPC has a screen, open it directly
+      if (npcDef?.screen) {
+        handleNodeInteract(npcDef.screen)
+        return
+      }
       setDialogueEvent({ speakerName, text: getActiveDialogue(quest) })
       return
     }
 
     // Second pass: first available quest whose prerequisites are met
+    const atOfferCap = HUB_QUEST_DEFS.filter(q => getQuestState(q.id).status === 'active').length >= 2
     for (const quest of giveQuests) {
       if (getQuestState(quest.id).status !== 'available') continue
       const prereqMet = !quest.prerequisite || checkPrerequisite(quest.prerequisite)
       if (prereqMet) {
+        if (atOfferCap) break  // at cap — skip offer, fall through to screen or default dialogue
         setDialogueEvent({
           speakerName,
           text: quest.offerDialogue,
@@ -353,6 +362,11 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onPlayerTap, crystals
               label: 'Accept',
               primary: true,
               onClick: () => {
+                const count = HUB_QUEST_DEFS.filter(q => getQuestState(q.id).status === 'active').length
+                if (count >= 2) {
+                  setDialogueEvent({ speakerName, text: "You're already working on 2 quests. Finish one first." })
+                  return
+                }
                 setQuestStatus(quest.id, 'active')
                 activeQuestIdsRef.current.add(quest.id)
                 refreshState()


### PR DESCRIPTION
## Summary

- **2-quest cap**: `questNpcStateRef` now suppresses `'offer'` state when 2 quests are already active, so `!` indicators stop appearing. `handleNpcTap` also skips the offer dialogue at cap, falling through to the NPC's screen or default dialogue instead
- **Safety guard on Accept**: even if the offer is somehow visible at cap, clicking Accept shows a friendly message rather than starting a 3rd quest
- **Screen NPCs unblocked**: NPCs with both a `screen` and an in-progress quest now open their screen on tap instead of showing a progress hint — players aren't locked out of shops while doing a fetch quest. Quest completion still takes priority (quest ready → completion dialogue first)

## Test plan

- [ ] Accept 2 quests → `!` disappears from all remaining quest NPCs
- [ ] Tap a quest NPC while at cap → no offer shown; screen NPCs open their screen, dialogue-only NPCs show default dialogue
- [ ] Tap a screen NPC (e.g. shop) after accepting their quest → shop opens directly, not a progress hint
- [ ] Complete a quest to drop to 1 active → `!` reappears on remaining available quest NPCs
- [ ] Quest completion still works: when a quest is ready to turn in, tapping the NPC shows the completion dialogue (not the screen)

https://claude.ai/code/session_01RoGW51T9EFcoYLKY5AoXRN

---
_Generated by [Claude Code](https://claude.ai/code/session_01RoGW51T9EFcoYLKY5AoXRN)_