### PR TITLE
feat(hub): show quest progress dialogue on item pickup

### DIFF
--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -260,13 +260,39 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onPlayerTap, crystals
     if (state.status !== 'active') return
 
     // Find which step this pickup belongs to and increment progress
+    let pickedStep: typeof quest.steps[0] | undefined
     for (const step of quest.steps) {
       if (step.type === 'collect' && step.pickupIds?.includes(id)) {
         incrementQuestProgress(questId, step.key)
+        pickedStep = step
         break
       }
     }
     refreshState()
+    if (!pickedStep) return
+
+    // Check if every collect step is now complete
+    const allCollectDone = quest.steps
+      .filter(s => s.type === 'collect')
+      .every(s => getQuestProgress(questId, s.key) >= s.required)
+
+    const speakerName = quest.title
+
+    if (allCollectDone) {
+      const receiverNpc = HUB_NPCS.find(n => n.id === quest.receiverNpcId)
+      const npcName = receiverNpc?.name ?? 'the quest giver'
+      setDialogueEvent({
+        speakerName,
+        text: `All items found! Return to ${npcName} to complete the quest.`,
+      })
+    } else {
+      const progress = getQuestProgress(questId, pickedStep.key)
+      const countSuffix = pickedStep.required > 1 ? ` (${progress}/${pickedStep.required})` : ''
+      setDialogueEvent({
+        speakerName,
+        text: `Item collected${countSuffix}. ${getActiveDialogue(quest)}`,
+      })
+    }
   }, [refreshState])
 
   const handleDoorLocked = useCallback((buildingId: string, requiredItem: string) => {


### PR DESCRIPTION
## Summary

- Picking up a quest item now immediately shows a dialogue with progress feedback — no more silent disappearing sprites
- **In progress (multi-item steps):** "Item collected (2/3). [step hint text]"
- **Chain quests:** hint automatically advances to the next step via `getActiveDialogue`, so the player always knows what to find next
- **All collect steps done:** "All items found! Return to [NPC name] to complete the quest." — looks up the receiver NPC's display name from `HUB_NPCS`
- Non-quest pickups are unchanged (no dialogue shown)

## Test plan

- [ ] Accept a multi-item quest (e.g. Lost Pendant — 3 items) → pick up item 1 → dialogue shows "(1/3)" with hint
- [ ] Pick up item 2 → "(2/3)"
- [ ] Pick up item 3 (last) → "All items found! Return to [NPC name]..."
- [ ] Chain quest (e.g. Ancient Tomes) → each pickup advances the hint to the next tome's location
- [ ] Pick up a non-quest item (no questId) → no dialogue shown

https://claude.ai/code/session_01RoGW51T9EFcoYLKY5AoXRN

---
_Generated by [Claude Code](https://claude.ai/code/session_01RoGW51T9EFcoYLKY5AoXRN)_