### PR TITLE
feat(tilemap): wire world-scale tiles into NodeMap campaign map

### DIFF
--- a/web/src/components/campaign/NodeMap.tsx
+++ b/web/src/components/campaign/NodeMap.tsx
@@ -17,6 +17,7 @@ import { ToolbarLabel } from '../ui/Toolbar/ToolbarLabel'
 import { usePixiApp } from '../../hooks/usePixiApp'
 import { loadSpriteTexture, loadAnimFrames, loadTextureUrl, makeClickable, tweenTo } from '../../utils/pixiHelpers'
 import { ENV_TILES, TILE_SIZE } from '../../data/tiles/tileIndex'
+import { WORLD_ENV_TILES } from '../../data/tiles/worldTileIndex'
 import { GIFT_OWNER_UID } from '../../game/gifts'
 import { hashStr, envColors, parseRgba, sampleBezier, bezierBand } from '../../utils/mapUtils'
 import { renderPathTiles } from '../../utils/tileLookup'
@@ -207,7 +208,8 @@ async function buildPathTileGfx(
   }
 
   // Expand pathSet perpendicular to path direction for wide paths (e.g. canals)
-  const pathWidth = ENV_TILES[act.environment ?? '']?.pathWidth ?? 1
+  const worldEnvDef = WORLD_ENV_TILES[act.environment ?? ''] ?? ENV_TILES[act.environment ?? '']
+  const pathWidth = worldEnvDef?.pathWidth ?? 1
   if (pathWidth > 1) {
     const half = Math.floor(pathWidth / 2)
     const original = new Set(pathSet)
@@ -226,7 +228,7 @@ async function buildPathTileGfx(
     for (const k of extra) pathSet.add(k)
   }
 
-  await renderPathTiles(container, pathSet, act.environment)
+  await renderPathTiles(container, pathSet, act.environment, undefined, undefined, worldEnvDef)
 }
 
 // ── Connector helpers ──────────────────────────────────────────────────────────
@@ -692,14 +694,15 @@ export function NodeMap({ act, run, onSelectNode, onUseConsumable, onBack, user 
     const decorContainer = new PIXI.Container()
     groundLayer.addChild(baseContainer, bgContainer, riverContainer, pathContainer, decorContainer)
 
+    const actEnvDef = WORLD_ENV_TILES[act.environment ?? ''] ?? ENV_TILES[act.environment ?? '']
     buildTerrainGfx(baseContainer, riverContainer, worldLayer,
-      { environment: act.environment, terrainSeed: act.terrainSeed, terrainItems: act.terrainItems, rivers: act.rivers, id: act.id },
+      { environment: act.environment, envDef: actEnvDef, terrainSeed: act.terrainSeed, terrainItems: act.terrainItems, rivers: act.rivers, id: act.id },
       mapWidth, mapHeight)
-    buildBgTileGfx(bgContainer, { environment: act.environment }, mapWidth, mapHeight)
+    buildBgTileGfx(bgContainer, { environment: act.environment, envDef: actEnvDef }, mapWidth, mapHeight)
       .catch(e => console.error('[NodeMap] bg tiles failed', e))
     buildPathTileGfx(pathContainer, act, rows, maxRowCols, mapHeight)
       .catch(e => console.error('[NodeMap] path tiles failed', e))
-    buildDecorGfx(decorContainer, { environment: act.environment, id: act.id }, mapWidth, mapHeight)
+    buildDecorGfx(decorContainer, { environment: act.environment, envDef: actEnvDef, id: act.id }, mapWidth, mapHeight)
       .catch(e => console.error('[NodeMap] decor tiles failed', e))
 
     // Campfire at start position

--- a/web/src/data/tiles/worldTileIndex.ts
+++ b/web/src/data/tiles/worldTileIndex.ts
@@ -1,0 +1,51 @@
+import { EnvTileDef, BASE_GROUND } from './tileIndex'
+
+// ── World-scale path tile files (web/public/nodemap/32x32/environment/) ───────
+// Same 8-col × 47-variant TYPE3 format as the town-scale [A]_type3 sheets.
+export const WORLD_PATH_TILE = {
+  forest1:      '/nodemap/32x32/environment/forest1.png',
+  grass1Dirt1:  '/nodemap/32x32/environment/grass1_dirt1.png',
+  grass1Dirt2:  '/nodemap/32x32/environment/grass1_dirt2.png',
+  grass1Grass2: '/nodemap/32x32/environment/grass1_grass2.png',
+  grass1Water1: '/nodemap/32x32/environment/grass1_water1.png',
+  gravel1:      '/nodemap/32x32/environment/gravel1.png',
+  hills1:       '/nodemap/32x32/environment/hills1.png',
+  mountains1:   '/nodemap/32x32/environment/mountains1.png',
+  rocks1:       '/nodemap/32x32/environment/rocks1.png',
+} as const
+
+// ── World-scale decor sheet (web/public/nodemap/32x32/decor.png) ─────────────
+// Tiles 0–7 are ground fills. Named decor starts at tile 8.
+// Additional entries (towns, castles, mountains, volcanoes…) to be added after
+// reviewing the NM_Decor Storybook story.
+export const WORLD_DECOR_FILE = '/nodemap/32x32/decor.png'
+
+export const WORLD_DECOR = {
+  singleTree:      8,
+  groupOfTrees:    9,
+  woodenBridgeH:  16,
+  woodenBridgeV:  17,
+  stoneBridgeH:   18,
+  stoneBridgeV:   19,
+  waterWhirlpool: 20,
+} as const
+
+// ── Per-environment tile config for world-scale (campaign) rendering ──────────
+// Mirrors ENV_TILES in tileIndex.ts; used by NodeMap.tsx via envDef override.
+// ground IDs still reference BASE_GROUND (BaseChip sheet) for background fills.
+export const WORLD_ENV_TILES: Record<string, EnvTileDef> = {
+  forest:   { ground: BASE_GROUND.lightGrass,  pathFile: WORLD_PATH_TILE.forest1,      decorFile: WORLD_DECOR_FILE, decorTileIds: [WORLD_DECOR.singleTree, WORLD_DECOR.groupOfTrees] },
+  farmland: { ground: BASE_GROUND.mediumGrass, pathFile: WORLD_PATH_TILE.grass1Dirt1 },
+  ruins:    { ground: BASE_GROUND.darkGrass,   pathFile: WORLD_PATH_TILE.grass1Grass2 },
+  ashen:    { ground: BASE_GROUND.dyingGrass,  pathFile: WORLD_PATH_TILE.grass1Dirt2 },
+  sand:     { ground: BASE_GROUND.sand,        pathFile: WORLD_PATH_TILE.grass1Dirt2 },
+  frost:    { ground: BASE_GROUND.lightGrass,  pathFile: WORLD_PATH_TILE.grass1Grass2 },
+  volcano:  { ground: BASE_GROUND.darkDirt,    pathFile: WORLD_PATH_TILE.mountains1 },
+  citadel:  { ground: BASE_GROUND.darkGrass,   pathFile: WORLD_PATH_TILE.gravel1 },
+  coast:    { ground: BASE_GROUND.sand,        pathFile: WORLD_PATH_TILE.grass1Water1,  pathWidth: 3 },
+  reef:     { ground: BASE_GROUND.sand,        pathFile: WORLD_PATH_TILE.grass1Water1,  pathWidth: 3 },
+  sky:      { ground: BASE_GROUND.lightGrass,  solidColor: 0x000000, pathFile: WORLD_PATH_TILE.grass1Grass2 },
+  fungal:   { ground: BASE_GROUND.darkGrass,   pathFile: WORLD_PATH_TILE.grass1Grass2 },
+  vault:    { ground: BASE_GROUND.darkGrass,   pathFile: WORLD_PATH_TILE.gravel1 },
+  camp:     { ground: BASE_GROUND.mediumGrass, pathFile: WORLD_PATH_TILE.grass1Dirt1 },
+}

--- a/web/src/utils/terrainLayer.ts
+++ b/web/src/utils/terrainLayer.ts
@@ -1,11 +1,12 @@
 import * as PIXI from 'pixi.js'
-import { ENV_TILES, BASE_GROUND, TILESET_IMAGE, TILESET_COLUMNS, TILE_SIZE } from '../data/tiles/tileIndex'
+import { ENV_TILES, BASE_GROUND, TILESET_IMAGE, TILESET_COLUMNS, TILE_SIZE, EnvTileDef } from '../data/tiles/tileIndex'
 import { loadTileTexture } from './pixiHelpers'
 import { drawTerrainItem } from './terrainGfx'
 import { seededRand, hashStr, getTerrainItems, type TerrainItem } from './mapUtils'
 
 export interface TerrainLayerOptions {
   environment?: string
+  envDef?: EnvTileDef
   terrainSeed?: number
   terrainItems?: TerrainItem[]
   rivers?: Array<{ x1: number; y1: number; x2: number; y2: number; cx1: number; cy1: number; cx2: number; cy2: number }>
@@ -21,9 +22,9 @@ export function buildTerrainGfx(
   mapHeight: number,
 ): void {
   const base = (import.meta as { env: { BASE_URL: string } }).env.BASE_URL
-  const { environment, terrainSeed, terrainItems: explicitItems, rivers: explicitRivers, id = '' } = opts
+  const { environment, envDef: envDefOverride, terrainSeed, terrainItems: explicitItems, rivers: explicitRivers, id = '' } = opts
 
-  const def = ENV_TILES[environment ?? '']
+  const def = envDefOverride ?? ENV_TILES[environment ?? '']
   if (def?.solidColor !== undefined) {
     const g = new PIXI.Graphics()
     g.rect(0, 0, mapWidth, mapHeight).fill({ color: def.solidColor })
@@ -97,11 +98,11 @@ export function buildTerrainGfx(
 
 export async function buildBgTileGfx(
   container: PIXI.Container,
-  opts: { environment?: string },
+  opts: { environment?: string; envDef?: EnvTileDef },
   mapWidth: number,
   mapHeight: number,
 ): Promise<void> {
-  const def = ENV_TILES[opts.environment ?? '']
+  const def = opts.envDef ?? ENV_TILES[opts.environment ?? '']
   if (def?.bgTileId === undefined) return
   const base = (import.meta as { env: { BASE_URL: string } }).env.BASE_URL
   const tileUrl = `${base}${def.pathFile.slice(1)}`
@@ -120,11 +121,11 @@ export async function buildBgTileGfx(
 
 export async function buildDecorGfx(
   container: PIXI.Container,
-  opts: { environment?: string; id?: string },
+  opts: { environment?: string; envDef?: EnvTileDef; id?: string },
   mapWidth: number,
   mapHeight: number,
 ): Promise<void> {
-  const def = ENV_TILES[opts.environment ?? '']
+  const def = opts.envDef ?? ENV_TILES[opts.environment ?? '']
   if (!def?.decorFile || !def.decorTileIds?.length) return
   const base = (import.meta as { env: { BASE_URL: string } }).env.BASE_URL
   const tileUrl = `${base}${def.decorFile.slice(1)}`

--- a/web/src/utils/tileLookup.ts
+++ b/web/src/utils/tileLookup.ts
@@ -1,5 +1,5 @@
 import * as PIXI from 'pixi.js'
-import { ENV_TILES, PATH, TILE_SIZE, PATH_TILE } from '../data/tiles/tileIndex'
+import { ENV_TILES, PATH, TILE_SIZE, PATH_TILE, EnvTileDef } from '../data/tiles/tileIndex'
 import { loadTileTexture } from './pixiHelpers'
 
 // ── 8-neighbor tile lookup tables ─────────────────────────────────────────────
@@ -64,12 +64,14 @@ export async function renderPathTiles(
   environment?: string,
   tileFileOverride?: string,
   useCanal?: boolean,
+  envDef?: EnvTileDef,
 ): Promise<void> {
   const T = TILE_SIZE
-  const pathFile = tileFileOverride ?? ENV_TILES[environment ?? '']?.pathFile ?? PATH_TILE.grass1Dirt1
+  const def = envDef ?? ENV_TILES[environment ?? '']
+  const pathFile = tileFileOverride ?? def?.pathFile ?? PATH_TILE.grass1Dirt1
   const base = (import.meta as { env: { BASE_URL: string } }).env.BASE_URL
   const tileUrl = `${base}${pathFile.slice(1)}`
-  const pathWidth = tileFileOverride ? 1 : (ENV_TILES[environment ?? '']?.pathWidth ?? 1)
+  const pathWidth = tileFileOverride ? 1 : (def?.pathWidth ?? 1)
   const lookup = (useCanal || pathWidth > 1) ? CANAL_TILE_LOOKUP : PATH_TILE_LOOKUP
 
   const key = (tx: number, ty: number) => `${tx},${ty}`


### PR DESCRIPTION
## Summary

- **`worldTileIndex.ts`** (new): `WORLD_PATH_TILE` paths to all 9 `nodemap/32x32/environment/` sheets, `WORLD_DECOR` tile IDs (single tree=8, group=9, bridges=16–19, whirlpool=20), and `WORLD_ENV_TILES` config mapping all 14 act environments to world-scale tiles
- **`terrainLayer.ts`**: adds optional `envDef?: EnvTileDef` to `TerrainLayerOptions` and the `buildBgTileGfx`/`buildDecorGfx` opts — callers can now bypass the `ENV_TILES` lookup without touching `environment` routing
- **`tileLookup.ts`**: adds optional 6th param `envDef?: EnvTileDef` to `renderPathTiles`; resolves `pathFile` and `pathWidth` from it when provided (backward-compatible — all existing `HubTownCanvas` calls unaffected)
- **`NodeMap.tsx`**: imports `WORLD_ENV_TILES`; resolves `actEnvDef` (world-scale first, town-scale fallback) and passes it as `envDef` to all four terrain layer calls — the campaign map now renders world-scale tiles

## How it works

NodeMap always prefers world-scale tiles. If an act's environment has no entry in `WORLD_ENV_TILES`, it falls back to `ENV_TILES` (town-scale). HubTownCanvas is unchanged — it never passes `envDef` so it continues using the original town-scale lookup.

## Still to come

- Remaining `WORLD_DECOR` tile IDs (towns, castles, mountains, volcanoes) — to be added once user reviews the `NM_Decor` Storybook story
- Battlefield.tsx terrain layer (deferred pending PixiJS migration)
- Minigames (deferred)

## Test plan

- [ ] `npm run build` passes ✅ (verified locally)
- [ ] Open Storybook → NodeMap Default story → confirm world-scale path tiles render on the campaign map
- [ ] Confirm HubTownCanvas still renders town-scale tiles (no visual regression)
- [ ] Test coast/reef environments — wide path (pathWidth: 3) should still expand correctly

https://claude.ai/code/session_01MBDpW8x7FL9TbT6E8j1Nkn

---
_Generated by [Claude Code](https://claude.ai/code/session_01MBDpW8x7FL9TbT6E8j1Nkn)_