### PR TITLE
feat(tilemap): world-scale tile terrain canvas for Battlefield lane

### DIFF
--- a/web/src/components/battle/Battlefield.tsx
+++ b/web/src/components/battle/Battlefield.tsx
@@ -1,4 +1,5 @@
 import React, { useRef, useEffect, useState } from 'react'
+import { BattlefieldTerrainCanvas } from './battlefield/BattlefieldTerrainCanvas'
 import battlefieldConfig from '../../data/battlefield.json'
 import { GameState, Unit, LANE_WIDTH, Card, TerrainObstacle, TerrainType, BuffTag, TERRAIN_AVOID_SHAPE } from '../../game/types'
 import { CardTile } from '../cards/CardTile'
@@ -1092,7 +1093,7 @@ export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPaus
         onContextMenu={pendingAoeCard ? (e) => { e.preventDefault(); setPendingAoeCard(null); setAoeHoverPos(null) } : undefined}
       >
         <div className="lane-ground" />
-        <LaneBackground env={state.environment} />
+        <BattlefieldTerrainCanvas environment={state.environment} id={state.environment} />
         <ForestBorder theme={actTheme} />
         {(state.terrain ?? []).map(obs => <TerrainTile key={obs.id} obs={obs} />)}
         {isDebugMode() && (state.terrain ?? []).map(obs => {

--- a/web/src/components/battle/battlefield/BattlefieldTerrainCanvas.stories.tsx
+++ b/web/src/components/battle/battlefield/BattlefieldTerrainCanvas.stories.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { BattlefieldTerrainCanvas } from './BattlefieldTerrainCanvas'
+
+const meta = {
+  component: BattlefieldTerrainCanvas,
+  parameters: { layout: 'centered' },
+  decorators: [
+    (Story: React.ComponentType) => (
+      // Battlefield lane proportions: tall and narrow (rotated vertical combat area)
+      <div style={{ width: 320, height: 560, position: 'relative', border: '1px solid #333' }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof BattlefieldTerrainCanvas>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Forest:   Story = { args: { environment: 'forest',   id: 'forest-test'   } }
+export const Farmland: Story = { args: { environment: 'farmland', id: 'farmland-test' } }
+export const Ruins:    Story = { args: { environment: 'ruins',    id: 'ruins-test'    } }
+export const Ashen:    Story = { args: { environment: 'ashen',    id: 'ashen-test'    } }
+export const Sand:     Story = { args: { environment: 'sand',     id: 'sand-test'     } }
+export const Volcano:  Story = { args: { environment: 'volcano',  id: 'volcano-test'  } }
+export const Citadel:  Story = { args: { environment: 'citadel',  id: 'citadel-test'  } }
+export const Coast:    Story = { args: { environment: 'coast',    id: 'coast-test'    } }
+export const Frost:    Story = { args: { environment: 'frost',    id: 'frost-test'    } }

--- a/web/src/components/battle/battlefield/BattlefieldTerrainCanvas.tsx
+++ b/web/src/components/battle/battlefield/BattlefieldTerrainCanvas.tsx
@@ -1,0 +1,66 @@
+import React, { useRef, useEffect, useState } from 'react'
+import * as PIXI from 'pixi.js'
+import { usePixiApp } from '../../../hooks/usePixiApp'
+import { buildTerrainGfx, buildBgTileGfx, buildDecorGfx } from '../../../utils/terrainLayer'
+import { WORLD_ENV_TILES } from '../../../data/tiles/worldTileIndex'
+import { ENV_TILES } from '../../../data/tiles/tileIndex'
+
+export interface Props {
+  environment?: string
+  /** Stable ID used as terrain scatter seed — use node/act ID for deterministic decoration */
+  id?: string
+}
+
+// Inner component — only mounts once dimensions are known so usePixiApp gets the right size.
+function TerrainPixi({ environment, id, w, h }: Props & { w: number; h: number }) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const envDef = WORLD_ENV_TILES[environment ?? ''] ?? ENV_TILES[environment ?? '']
+
+  usePixiApp(containerRef, w, h, (app) => {
+    const base  = new PIXI.Container()
+    const river = new PIXI.Container() // not added to stage — rivers suppressed on battlefield
+    const world = new PIXI.Container()
+    const bg    = new PIXI.Container()
+    const decor = new PIXI.Container()
+    app.stage.addChild(base, bg, decor, world)
+    buildTerrainGfx(base, river, world,
+      { environment, envDef, id, rivers: [] },
+      w, h)
+    buildBgTileGfx(bg, { environment, envDef }, w, h)
+    buildDecorGfx(decor, { environment, envDef, id }, w, h)
+  })
+
+  return <div ref={containerRef} style={{ width: w, height: h }} />
+}
+
+/**
+ * World-scale tile terrain background for the Battlefield lane.
+ * Measures its container after mount, then renders a PixiJS tile scene.
+ * Replaces the SVG layer approach of BattlefieldBackground.
+ */
+export function BattlefieldTerrainCanvas({ environment, id }: Props) {
+  const wrapRef = useRef<HTMLDivElement>(null)
+  const [dims, setDims] = useState<{ w: number; h: number } | null>(null)
+
+  useEffect(() => {
+    const el = wrapRef.current
+    if (!el) return
+    const measure = () => {
+      const { width, height } = el.getBoundingClientRect()
+      if (width > 0 && height > 0) setDims({ w: Math.ceil(width), h: Math.ceil(height) })
+    }
+    measure()
+    // Retry after paint in case layout hasn't settled yet
+    const raf = requestAnimationFrame(measure)
+    return () => cancelAnimationFrame(raf)
+  }, [])
+
+  return (
+    <div
+      ref={wrapRef}
+      style={{ position: 'absolute', inset: 0, overflow: 'hidden', zIndex: 0, pointerEvents: 'none' }}
+    >
+      {dims && <TerrainPixi environment={environment} id={id} w={dims.w} h={dims.h} />}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- **`battlefield/BattlefieldTerrainCanvas.tsx`** (new): self-contained sub-component that measures its container after mount (via `requestAnimationFrame`), then renders a PixiJS scene using `buildTerrainGfx` (rivers suppressed — they'd look odd on a battle field), `buildBgTileGfx`, and `buildDecorGfx` with `WORLD_ENV_TILES`; falls back to town-scale `ENV_TILES` for any unmapped environment
- **`battlefield/BattlefieldTerrainCanvas.stories.tsx`** (new): 9 environment stories at battlefield lane proportions (320×560 px)
- **`Battlefield.tsx`**: replaces `<LaneBackground>` (SVG image stack) with `<BattlefieldTerrainCanvas environment={state.environment} />` — the battle lane now renders world-scale tile terrain

`LaneBackground`/`BattlefieldBackground` remain in `Battlefield.tsx` but are no longer called; they can be cleaned up in a follow-up if the tile background proves stable.

## Test plan

- [ ] `npm run build` passes ✅ (verified locally)
- [ ] Open `BattlefieldTerrainCanvas` stories in Storybook → all 9 environments render correctly
- [ ] Start a battle in game → lane background renders tiled terrain instead of SVG layers
- [ ] Verify terrain scatter (trees/rocks) and decor appear behind units and terrain obstacles
- [ ] No pointer-events leakage from canvas (background has `pointerEvents: none`)

https://claude.ai/code/session_01MBDpW8x7FL9TbT6E8j1Nkn

---
_Generated by [Claude Code](https://claude.ai/code/session_01MBDpW8x7FL9TbT6E8j1Nkn)_