### PR TITLE
feat: replace battlefield SVG blob border with world-scale scenery tiles

### DIFF
--- a/web/src/components/battle/Battlefield.tsx
+++ b/web/src/components/battle/Battlefield.tsx
@@ -629,130 +629,6 @@ const CURRENT_SEASON = getCurrentSeason()
 const SEASON_LAYERS = (battlefieldConfig.seasonLayers as Record<string, string[]>)[CURRENT_SEASON] ?? []
 const SEASON_TERRAIN = (battlefieldConfig.seasonTerrain as Record<string, Record<string, string[]>>)[CURRENT_SEASON] ?? {}
 
-// ─── Forest border ────────────────────────────────────────────────────────────
-// Purely decorative tree line along the left edge, right edge, and top of the
-// battlefield. Uses deterministic (sin-based) offsets so the layout is stable
-// across re-renders without needing game state.
-
-// ── Themed border blob SVGs ──────────────────────────────────────────────────
-
-// act1 / default — green tree canopy
-function BlobSvg({ size, shade }: { size: number; shade: number }) {
-  const base = Math.round(30 + shade * 20)
-  const fill = `rgb(${18 + Math.round(shade * 8)},${base + 60},${18 + Math.round(shade * 8)})`
-  const hi   = `rgb(${30 + Math.round(shade * 10)},${base + 90},${30 + Math.round(shade * 10)})`
-  return (
-    <svg width={size} height={size} viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-      <ellipse cx="10" cy="11" rx="10" ry="9"  fill={fill}/>
-      <ellipse cx="10" cy="8"  rx="8"  ry="7"  fill={hi}/>
-      <ellipse cx="8"  cy="6"  rx="4"  ry="3"  fill={hi} opacity="0.5"/>
-    </svg>
-  )
-}
-
-// act2 — rocky cliff / fortress stone
-function RockBorderBlob({ size, shade }: { size: number; shade: number }) {
-  const g    = Math.round(80 + shade * 30)
-  const fill = `rgb(${g - 10},${g},${g + 5})`
-  const hi   = `rgb(${g + 20},${g + 22},${g + 28})`
-  return (
-    <svg width={size} height={Math.round(size * 0.85)} viewBox="0 0 22 19" xmlns="http://www.w3.org/2000/svg">
-      <ellipse cx="11" cy="18" rx="10" ry="3" fill="#1a1a1a" opacity="0.35"/>
-      <polygon points="1,17 5,7 11,2 17,7 21,17" fill={fill}/>
-      <polygon points="5,17 9,6 12,1 15,7 18,17" fill={hi} opacity="0.65"/>
-      <line x1="11" y1="2" x2="10" y2="8" stroke="white" strokeWidth="0.5" opacity="0.3"/>
-    </svg>
-  )
-}
-
-// act3 — dead trees / ashen mounds
-function AshBorderBlob({ size, shade }: { size: number; shade: number }) {
-  const g    = Math.round(28 + shade * 18)
-  const dark = `rgb(${g + 8},${g},${g - 4})`
-  return (
-    <svg width={size} height={size} viewBox="0 0 20 22" xmlns="http://www.w3.org/2000/svg">
-      <rect x="8" y="12" width="4" height="10" fill="#2a2010" rx="1"/>
-      <line x1="10" y1="14" x2="3"  y2="8"  stroke={dark} strokeWidth="1.6"/>
-      <line x1="10" y1="13" x2="17" y2="7"  stroke={dark} strokeWidth="1.6"/>
-      <line x1="3"  y1="8"  x2="1"  y2="4"  stroke={dark} strokeWidth="1"/>
-      <line x1="3"  y1="8"  x2="6"  y2="4"  stroke={dark} strokeWidth="1"/>
-      <line x1="17" y1="7"  x2="19" y2="3"  stroke={dark} strokeWidth="1"/>
-      <ellipse cx="10" cy="21" rx="7" ry="2.5" fill="#4a3a28" opacity="0.7"/>
-    </svg>
-  )
-}
-
-// act4 — crystal / ice shards
-function CrystalBorderBlob({ size, shade }: { size: number; shade: number }) {
-  const b    = Math.round(150 + shade * 50)
-  const fill = `rgb(15,${Math.round(b * 0.6)},${b})`
-  const hi   = `rgb(60,${Math.round(b * 0.78)},${b})`
-  return (
-    <svg width={size} height={size} viewBox="0 0 20 24" xmlns="http://www.w3.org/2000/svg">
-      <polygon points="5,22  3,12  6,3   8,12  7,22"  fill={fill} opacity="0.88"/>
-      <polygon points="10,22 8,9  12,1  15,9  13,22"  fill={hi}   opacity="0.95"/>
-      <polygon points="14,22 13,14 16,7  18,14 17,22"  fill={fill} opacity="0.82"/>
-      <line x1="12" y1="2" x2="11" y2="8" stroke="white" strokeWidth="0.7" opacity="0.55"/>
-    </svg>
-  )
-}
-
-type BorderTheme = 'act1' | 'act2' | 'act3' | 'act4' | undefined
-
-function BorderBlob({ size, shade, theme }: { size: number; shade: number; theme: BorderTheme }) {
-  if (theme === 'act2') return <RockBorderBlob   size={size} shade={shade} />
-  if (theme === 'act3') return <AshBorderBlob    size={size} shade={shade} />
-  if (theme === 'act4') return <CrystalBorderBlob size={size} shade={shade} />
-  return <BlobSvg size={size} shade={shade} />
-}
-
-// TODO: replace with tiles for the border. use web\src\data\tiles\worldTileIndex.ts forest1/hills1/mountains1/rocks1
-// Use the SCENERY key from web\src\data\tiles\tileIndex.ts to determine which tile variants to use for the border based on the battlefield environment, and add some variation within the theme (e.g. different tree shapes, rock formations, etc). For now just use the same blobs as the act1 forest theme since they work decently as generic foliage/rocks.
-const ForestBorder = React.memo(function ForestBorder({ theme }: { theme?: string }) {
-  const blobs: { key: string; top: number; left: number; size: number; shade: number }[] = []
-
-  // Left (y≈-95) and right (y≈+95) — tight wall just outside the playable field
-  for (const side of [-95, 95] as const) {
-    for (let ex = 5; ex <= 500; ex += 16) {
-      const yOff  = Math.sin(ex * 0.19 + side) * 2      // ±2 units jitter
-      const topPct  = (1 - ex / LANE_WIDTH) * 100
-      const leftPct = 50 + ((side + yOff) / 80) * 36
-      const size    = 20 + Math.round(Math.abs(Math.sin(ex * 0.37 + side)) * 8)
-      const shade   = (Math.sin(ex * 0.53 + side * 0.1) + 1) / 2
-      blobs.push({ key: `fe-${side}-${ex}`, top: topPct, left: leftPct, size, shade })
-    }
-  }
-
-  // Top edge (opponent side)
-  for (let ey = -95; ey <= 95; ey += 16) {
-    const xOff  = Math.sin(ey * 0.23) * 3
-    const topPct  = (1 - (495 + xOff) / LANE_WIDTH) * 100
-    const leftPct = 50 + (ey / 80) * 36
-    const size    = 20 + Math.round(Math.abs(Math.sin(ey * 0.41)) * 8)
-    const shade   = (Math.sin(ey * 0.57) + 1) / 2
-    blobs.push({ key: `fe-top-${ey}`, top: topPct, left: leftPct, size, shade })
-  }
-
-  return (
-    <div className="forest-border" style={{ position: 'absolute', inset: 0, pointerEvents: 'none', zIndex: 1 }}>
-      {blobs.map(b => (
-        <div
-          key={b.key}
-          style={{
-            position: 'absolute',
-            top: `${b.top}%`,
-            left: `${b.left}%`,
-            transform: 'translateX(-50%) translateY(-50%)',
-            pointerEvents: 'none',
-            userSelect: 'none',
-          }}
-        >
-          <BorderBlob size={b.size} shade={b.shade} theme={theme as BorderTheme} />
-        </div>
-      ))}
-    </div>
-  )
-})
 
 // Bridge shown over large water obstacles — runs top-to-bottom (unit travel direction)
 function BridgeSvg({ size }: { size: number }) {
@@ -1120,7 +996,6 @@ export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPaus
       >
         <div className="lane-ground" />
         <BattlefieldTerrainCanvas environment={state.environment} id={state.environment} />
-        <ForestBorder theme={actTheme} />
         {(state.terrain ?? []).map(obs => <TerrainTile key={obs.id} obs={obs} />)}
         {isDebugMode() && (state.terrain ?? []).map(obs => {
           // Avoidance ellipse matching TERRAIN_AVOID_SHAPE used by the engine.

--- a/web/src/components/battle/battlefield/BattlefieldTerrainCanvas.tsx
+++ b/web/src/components/battle/battlefield/BattlefieldTerrainCanvas.tsx
@@ -1,7 +1,7 @@
 import React, { useRef, useEffect, useState } from 'react'
 import * as PIXI from 'pixi.js'
 import { usePixiApp } from '../../../hooks/usePixiApp'
-import { buildTerrainGfx, buildBgTileGfx, buildDecorGfx } from '../../../utils/terrainLayer'
+import { buildTerrainGfx, buildBgTileGfx, buildDecorGfx, buildBorderGfx } from '../../../utils/terrainLayer'
 import { WORLD_ENV_TILES } from '../../../data/tiles/worldTileIndex'
 import { ENV_TILES } from '../../../data/tiles/tileIndex'
 
@@ -17,16 +17,18 @@ function TerrainPixi({ environment, id, w, h }: Props & { w: number; h: number }
   const envDef = WORLD_ENV_TILES[environment ?? ''] ?? ENV_TILES[environment ?? '']
 
   usePixiApp(containerRef, w, h, (app) => {
-    const base  = new PIXI.Container()
-    const river = new PIXI.Container() // not added to stage — rivers suppressed on battlefield
-    const world = new PIXI.Container()
-    const bg    = new PIXI.Container()
-    const decor = new PIXI.Container()
-    app.stage.addChild(base, bg, decor, world)
+    const base   = new PIXI.Container()
+    const river  = new PIXI.Container() // not added to stage — rivers suppressed on battlefield
+    const world  = new PIXI.Container()
+    const bg     = new PIXI.Container()
+    const decor  = new PIXI.Container()
+    const border = new PIXI.Container()
+    app.stage.addChild(base, bg, border, decor, world)
     buildTerrainGfx(base, river, world,
       { environment, envDef, id, rivers: [] },
       w, h)
     buildBgTileGfx(bg, { environment, envDef }, w, h)
+    buildBorderGfx(border, { environment, envDef }, w, h)
     buildDecorGfx(decor, { environment, envDef, id }, w, h)
   })
 

--- a/web/src/data/tiles/worldTileIndex.ts
+++ b/web/src/data/tiles/worldTileIndex.ts
@@ -11,12 +11,12 @@ export const WORLD_PATH_TILE = {
 } as const
 
 // ── World-scale scenery tile files (web/public/nodemap/32x32/scenery/) ───────
-// 8-col × 47-variant TYPE3 format - different from path tiles.
+// 8-col × 47-variant TYPE3 format — used as border fills on battlefield/map edges.
 export const WORLD_SCENERY_TILE = {
-  forest1:      '/nodemap/32x32/environment/forest1.png',
-  hills1:       '/nodemap/32x32/environment/hills1.png',
-  mountains1:   '/nodemap/32x32/environment/mountains1.png',
-  rocks1:       '/nodemap/32x32/environment/rocks1.png',
+  forest1:    '/nodemap/32x32/scenery/forest1.png',
+  hills1:     '/nodemap/32x32/scenery/hills1.png',
+  mountains1: '/nodemap/32x32/scenery/mountains1.png',
+  rocks1:     '/nodemap/32x32/scenery/rocks1.png',
 } as const
 
 // ── World-scale decor sheet (web/public/nodemap/32x32/decor.png) ─────────────
@@ -90,18 +90,18 @@ export const WORLD_DECOR = {
 // Mirrors ENV_TILES in tileIndex.ts; used by NodeMap.tsx via envDef override.
 // ground IDs still reference BASE_GROUND (BaseChip sheet) for background fills.
 export const WORLD_ENV_TILES: Record<string, EnvTileDef> = {
-  forest:   { ground: BASE_GROUND.lightGrass,  pathFile: WORLD_PATH_TILE.grass1Dirt1,  borderFile:WORLD_SCENERY_TILE.forest1,    decorFile: WORLD_DECOR_FILE, decorTileIds: [WORLD_DECOR.singleTree, WORLD_DECOR.groupOfTrees] },
-  farmland: { ground: BASE_GROUND.mediumGrass, pathFile: WORLD_PATH_TILE.grass1Dirt1, borderFile: WORLD_SCENERY_TILE.hills1,      decorFile: WORLD_DECOR_FILE, decorTileIds: [WORLD_DECOR.singleTree, WORLD_DECOR.groupOfTrees] },
-  ruins:    { ground: BASE_GROUND.darkGrass,   pathFile: WORLD_PATH_TILE.grass1Grass2 },
-  ashen:    { ground: BASE_GROUND.dyingGrass,  pathFile: WORLD_PATH_TILE.grass1Dirt2 },
-  sand:     { ground: BASE_GROUND.sand,        pathFile: WORLD_PATH_TILE.grass1Dirt2 },
-  frost:    { ground: BASE_GROUND.lightGrass, solidColor: 0xDDFDFD, pathFile: WORLD_PATH_TILE.grass1Grass2 },
-  volcano:  { ground: BASE_GROUND.darkDirt,    pathFile: WORLD_SCENERY_TILE.mountains1 },
-  citadel:  { ground: BASE_GROUND.darkGrass,   pathFile: WORLD_PATH_TILE.gravel1 },
-  coast:    { ground: BASE_GROUND.sand,        pathFile: WORLD_PATH_TILE.grass1Water1,  pathWidth: 3 },
-  reef:     { ground: BASE_GROUND.sand,        pathFile: WORLD_PATH_TILE.grass1Water1,  pathWidth: 3 },
+  forest:   { ground: BASE_GROUND.lightGrass,  pathFile: WORLD_PATH_TILE.grass1Dirt1,  borderFile: WORLD_SCENERY_TILE.forest1,    decorFile: WORLD_DECOR_FILE, decorTileIds: [WORLD_DECOR.singleTree, WORLD_DECOR.groupOfTrees] },
+  farmland: { ground: BASE_GROUND.mediumGrass, pathFile: WORLD_PATH_TILE.grass1Dirt1,  borderFile: WORLD_SCENERY_TILE.hills1,     decorFile: WORLD_DECOR_FILE, decorTileIds: [WORLD_DECOR.singleTree, WORLD_DECOR.groupOfTrees] },
+  ruins:    { ground: BASE_GROUND.darkGrass,   pathFile: WORLD_PATH_TILE.grass1Grass2, borderFile: WORLD_SCENERY_TILE.rocks1 },
+  ashen:    { ground: BASE_GROUND.dyingGrass,  pathFile: WORLD_PATH_TILE.grass1Dirt2,  borderFile: WORLD_SCENERY_TILE.rocks1 },
+  sand:     { ground: BASE_GROUND.sand,        pathFile: WORLD_PATH_TILE.grass1Dirt2,  borderFile: WORLD_SCENERY_TILE.rocks1 },
+  frost:    { ground: BASE_GROUND.lightGrass,  solidColor: 0xDDFDFD, pathFile: WORLD_PATH_TILE.grass1Grass2, borderFile: WORLD_SCENERY_TILE.mountains1 },
+  volcano:  { ground: BASE_GROUND.darkDirt,    pathFile: WORLD_PATH_TILE.gravel1,      borderFile: WORLD_SCENERY_TILE.mountains1 },
+  citadel:  { ground: BASE_GROUND.darkGrass,   pathFile: WORLD_PATH_TILE.gravel1,      borderFile: WORLD_SCENERY_TILE.rocks1 },
+  coast:    { ground: BASE_GROUND.sand,        pathFile: WORLD_PATH_TILE.grass1Water1, borderFile: WORLD_SCENERY_TILE.hills1,     pathWidth: 3 },
+  reef:     { ground: BASE_GROUND.sand,        pathFile: WORLD_PATH_TILE.grass1Water1, borderFile: WORLD_SCENERY_TILE.hills1,     pathWidth: 3 },
   sky:      { ground: BASE_GROUND.lightGrass,  solidColor: 0x000000, pathFile: PATH_TILE.dirt1 },
-  fungal:   { ground: BASE_GROUND.darkGrass,   pathFile: WORLD_PATH_TILE.grass1Grass2 },
-  vault:    { ground: BASE_GROUND.darkGrass,   pathFile: WORLD_PATH_TILE.gravel1 },
-  camp:     { ground: BASE_GROUND.mediumGrass, pathFile: WORLD_PATH_TILE.grass1Dirt1 },
+  fungal:   { ground: BASE_GROUND.darkGrass,   pathFile: WORLD_PATH_TILE.grass1Grass2, borderFile: WORLD_SCENERY_TILE.forest1 },
+  vault:    { ground: BASE_GROUND.darkGrass,   pathFile: WORLD_PATH_TILE.gravel1,      borderFile: WORLD_SCENERY_TILE.rocks1 },
+  camp:     { ground: BASE_GROUND.mediumGrass, pathFile: WORLD_PATH_TILE.grass1Dirt1,  borderFile: WORLD_SCENERY_TILE.forest1 },
 }

--- a/web/src/utils/terrainLayer.ts
+++ b/web/src/utils/terrainLayer.ts
@@ -1,5 +1,5 @@
 import * as PIXI from 'pixi.js'
-import { ENV_TILES, BASE_GROUND, TILESET_IMAGE, TILESET_COLUMNS, TILE_SIZE, EnvTileDef } from '../data/tiles/tileIndex'
+import { ENV_TILES, BASE_GROUND, TILESET_IMAGE, TILESET_COLUMNS, TILE_SIZE, EnvTileDef, SCENERY } from '../data/tiles/tileIndex'
 import { loadTileTexture } from './pixiHelpers'
 import { drawTerrainItem } from './terrainGfx'
 import { seededRand, hashStr, getTerrainItems, type TerrainItem } from './mapUtils'
@@ -117,6 +117,84 @@ export async function buildBgTileGfx(
       container.addChild(s)
     }
   }
+}
+
+// Maps 4-bit diagonal-adjacency bitmask (NW=8 NE=4 SE=2 SW=1) → SCENERY tile frame number.
+// Derived from the SCENERY constants in tileIndex.ts.
+const SCENERY_LOOKUP: number[] = [
+  SCENERY.single,           // 0000
+  SCENERY.singleAndSW,      // 0001
+  SCENERY.singleAndSE,      // 0010
+  SCENERY.singleAndSESW,    // 0011
+  SCENERY.singleAndNE,      // 0100
+  SCENERY.singleAndNESW,    // 0101
+  SCENERY.singleAndNESE,    // 0110
+  SCENERY.singleAndNESESW,  // 0111
+  SCENERY.singleAndNW,      // 1000
+  SCENERY.singleAndNWSW,    // 1001
+  SCENERY.singleAndNWSE,    // 1010
+  SCENERY.singleAndNWSESW,  // 1011
+  SCENERY.singleAndNWNE,    // 1100
+  SCENERY.singleAndNWNESW,  // 1101
+  SCENERY.singleAndNWNESE,  // 1110
+  SCENERY.singleAndNWNESESW,// 1111
+]
+
+/**
+ * Renders a scenery tile border strip along the left, right, and top edges of the canvas.
+ * Uses envDef.borderFile as the 8-col scenery sheet and SCENERY_LOOKUP for diagonal adjacency.
+ * No-ops when borderFile is absent (e.g. sky environment).
+ */
+export function buildBorderGfx(
+  container: PIXI.Container,
+  opts: { envDef?: EnvTileDef; environment?: string },
+  w: number,
+  h: number,
+): void {
+  const def = opts.envDef ?? ENV_TILES[opts.environment ?? '']
+  const borderFile = def?.borderFile
+  if (!borderFile) return
+
+  const base = (import.meta as { env: { BASE_URL: string } }).env.BASE_URL
+  const url  = base + borderFile.replace(/^\//, '')
+
+  const BORDER_COLS = 2
+  const BORDER_ROWS = 1
+  const totalCols   = Math.ceil(w / TILE_SIZE)
+  const totalRows   = Math.ceil(h / TILE_SIZE)
+
+  function isBorder(c: number, r: number): boolean {
+    if (c < 0 || r < 0 || c >= totalCols || r >= totalRows) return true
+    return c < BORDER_COLS || c >= totalCols - BORDER_COLS || r < BORDER_ROWS
+  }
+
+  PIXI.Assets.load(url).then((tex: PIXI.Texture) => {
+    if (container.destroyed) return
+    const tileW = tex.width / 8
+    const tileH = tileW
+
+    for (let r = 0; r < totalRows; r++) {
+      for (let c = 0; c < totalCols; c++) {
+        if (!isBorder(c, r)) continue
+        const nw = isBorder(c - 1, r - 1) ? 8 : 0
+        const ne = isBorder(c + 1, r - 1) ? 4 : 0
+        const se = isBorder(c + 1, r + 1) ? 2 : 0
+        const sw = isBorder(c - 1, r + 1) ? 1 : 0
+        const frame    = SCENERY_LOOKUP[nw | ne | se | sw]
+        const frameCol = frame % 8
+        const frameRow = Math.floor(frame / 8)
+        const frameTex = new PIXI.Texture({
+          source: tex.source,
+          frame:  new PIXI.Rectangle(frameCol * tileW, frameRow * tileH, tileW, tileH),
+        })
+        const sprite = new PIXI.Sprite(frameTex)
+        sprite.position.set(c * TILE_SIZE, r * TILE_SIZE)
+        sprite.width  = TILE_SIZE
+        sprite.height = TILE_SIZE
+        container.addChild(sprite)
+      }
+    }
+  }).catch(e => console.error('[terrainLayer] border tile load failed', url, e))
 }
 
 export async function buildDecorGfx(


### PR DESCRIPTION
## Summary

- Fixes `WORLD_SCENERY_TILE` paths to use the new `scenery/` subdirectory (split from `environment/`)
- Adds `borderFile` to all 14 environments in `WORLD_ENV_TILES` (`sky` intentionally has none — open sky, no border)
- Fixes a bug where `volcano` was using a scenery file as its `pathFile`
- Adds `buildBorderGfx()` to `terrainLayer.ts`: loads the `borderFile` sheet and tiles a 2-column strip on left/right edges + 1-row strip at the top, using the `SCENERY` diagonal-adjacency bitmask lookup from `tileIndex.ts`
- Wires `buildBorderGfx` into `BattlefieldTerrainCanvas` as a new `border` container layer
- Removes the `ForestBorder` React component and all its SVG blob helpers (`BlobSvg`, `RockBorderBlob`, `AshBorderBlob`, `CrystalBorderBlob`) from `Battlefield.tsx`

## Test plan

- [ ] Open `BattlefieldTerrainCanvas` Storybook stories — forest/farmland/ruins/volcano etc. should show world-scale tile border strips on left, right, and top edges
- [ ] `sky` environment story should show no border
- [ ] Play a battle — confirm the tile border replaces the old SVG blobs, lane centre is not covered
- [ ] `npm run build` passes cleanly

https://claude.ai/code/session_01MBDpW8x7FL9TbT6E8j1Nkn

---
_Generated by [Claude Code](https://claude.ai/code/session_01MBDpW8x7FL9TbT6E8j1Nkn)_