### PR TITLE
World-scale tile terrain: battlefield decor, quick battle environments

### DIFF
--- a/web/src/components/battle/Battlefield.tsx
+++ b/web/src/components/battle/Battlefield.tsx
@@ -1,8 +1,7 @@
 import React, { useRef, useEffect, useState } from 'react'
 import * as PIXI from 'pixi.js'
 import { BattlefieldTerrainCanvas } from './battlefield/BattlefieldTerrainCanvas'
-import battlefieldConfig from '../../data/battlefield.json'
-import { GameState, Unit, LANE_WIDTH, Card, TerrainObstacle, TerrainType, BuffTag, TERRAIN_AVOID_SHAPE } from '../../game/types'
+import { GameState, Unit, LANE_WIDTH, Card, TerrainObstacle, BuffTag, TERRAIN_AVOID_SHAPE } from '../../game/types'
 import { CardTile } from '../cards/CardTile'
 import { useCardDetail } from '../cards/useCardDetail'
 import { SpriteImg, AnimatedSpriteImg } from '../ui/SpriteImg'
@@ -544,164 +543,6 @@ const LaneUnit = React.memo(function LaneUnit({ unit, stackIndex = 0, wallStack,
   )
 })
 
-// ─── Lane background ──────────────────────────────────────────────────────────
-// Full-size SVG rendered as the ground layer: grass, dirt path, crop rows,
-// sandy patches. Uses preserveAspectRatio="none" so it always fills the lane.
-
-const BATTLEFIELD_SPRITE_PATH = '/sprites/battlefield/'
-
-const BattlefieldBackground = React.memo(function BattlefieldBackground({ env }: { env?: string }) {
-  const key = (env && env in battlefieldConfig.environments)
-    ? env as keyof typeof battlefieldConfig.environments
-    : 'forest'
-  const layers = [...battlefieldConfig.environments[key], ...SEASON_LAYERS]
-  return (
-    <div style={{ position: 'absolute', inset: 0, width: '100%', height: '100%', zIndex: 0 }}>
-      {layers.map(layer => (
-        <img
-          key={layer}
-          className="lane-layer"
-          src={`${BATTLEFIELD_SPRITE_PATH}${layer}.svg`}
-          style={{ position: 'absolute', inset: 0, width: '100%', height: '100%', display: 'block' }}
-          alt=""
-          draggable={false}
-        />
-      ))}
-    </div>
-  )
-})
-
-// Alias for callers that still use the old name
-const LaneBackground = BattlefieldBackground
-
-// ─── Terrain obstacle rendering ───────────────────────────────────────────────
-// Shapes are loaded as <img> from sprites/battlefield/terrain-*.svg.
-// Dimension ratios (wr/hr) mirror the original per-variant aspect ratios.
-
-type TerrainVariant = { file: string; wr: number; hr: number }
-const TERRAIN_CONFIG = battlefieldConfig.terrain as Record<string, TerrainVariant[]>
-
-// ─── Season detection ─────────────────────────────────────────────────────────
-
-type Season = 'spring' | 'summer' | 'autumn' | 'winter'
-
-// IANA timezone prefixes/names that are in the southern hemisphere
-const SOUTHERN_TZ_PREFIXES = ['Australia/', 'Antarctica/']
-const SOUTHERN_TZ_NAMES = new Set([
-  'Pacific/Auckland', 'Pacific/Chatham', 'Pacific/Norfolk',
-  'America/Argentina/Buenos_Aires', 'America/Argentina/Cordoba',
-  'America/Argentina/Salta', 'America/Argentina/Jujuy',
-  'America/Argentina/Tucuman', 'America/Argentina/Catamarca',
-  'America/Argentina/La_Rioja', 'America/Argentina/San_Juan',
-  'America/Argentina/Mendoza', 'America/Argentina/San_Luis',
-  'America/Argentina/Rio_Gallegos', 'America/Argentina/Ushuaia',
-  'America/Sao_Paulo', 'America/Santiago', 'America/Montevideo',
-  'America/Asuncion', 'America/Punta_Arenas', 'America/Lima',
-  'America/Bogota', 'America/Guayaquil',
-  'Africa/Johannesburg', 'Africa/Harare', 'Africa/Lusaka',
-  'Africa/Maputo', 'Africa/Windhoek', 'Africa/Maseru', 'Africa/Mbabane',
-  'Africa/Nairobi', 'Africa/Dar_es_Salaam', 'Africa/Luanda',
-  'Indian/Mauritius', 'Indian/Reunion', 'Indian/Maldives',
-])
-
-function isSouthernHemisphere(): boolean {
-  try {
-    const tz = Intl.DateTimeFormat().resolvedOptions().timeZone
-    if (SOUTHERN_TZ_PREFIXES.some(p => tz.startsWith(p))) return true
-    if (SOUTHERN_TZ_NAMES.has(tz)) return true
-  } catch { /* ignore */ }
-  return false
-}
-
-function getCurrentSeason(): Season {
-  const m = new Date().getMonth() // 0-based
-  const northern: Season =
-    m >= 2 && m <= 4 ? 'spring' :
-    m >= 5 && m <= 7 ? 'summer' :
-    m >= 8 && m <= 10 ? 'autumn' : 'winter'
-  if (!isSouthernHemisphere()) return northern
-  // Flip season for southern hemisphere
-  const flip: Record<Season, Season> = { spring: 'autumn', autumn: 'spring', summer: 'winter', winter: 'summer' }
-  return flip[northern]
-}
-
-const CURRENT_SEASON = getCurrentSeason()
-const SEASON_LAYERS = (battlefieldConfig.seasonLayers as Record<string, string[]>)[CURRENT_SEASON] ?? []
-const SEASON_TERRAIN = (battlefieldConfig.seasonTerrain as Record<string, Record<string, string[]>>)[CURRENT_SEASON] ?? {}
-
-
-// Bridge shown over large water obstacles — runs top-to-bottom (unit travel direction)
-function BridgeSvg({ size }: { size: number }) {
-  const bw = Math.round(size * 0.42)   // narrow bridge deck
-  return (
-    <svg
-      width={bw} height={size}
-      viewBox="0 0 12 30"
-      style={{ position: 'absolute', top: 0, left: '50%', transform: 'translateX(-50%)', pointerEvents: 'none' }}
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      {/* Bridge deck */}
-      <rect x="2" y="0" width="8" height="30" fill="#8a6a3a"/>
-      {/* Horizontal planks (perpendicular to travel) */}
-      {[3, 8, 13, 18, 23, 28].map(y => (
-        <line key={y} x1="2" y1={y} x2="10" y2={y} stroke="#6a4a22" strokeWidth="1.2"/>
-      ))}
-      {/* Left and right railings */}
-      <line x1="1"  y1="0" x2="1"  y2="30" stroke="#c8a060" strokeWidth="1.5"/>
-      <line x1="11" y1="0" x2="11" y2="30" stroke="#c8a060" strokeWidth="1.5"/>
-      {/* Cross-support posts */}
-      {[0, 8, 16, 24].map(y => (
-        <line key={y} x1="0" y1={y} x2="12" y2={y} stroke="#c8a060" strokeWidth="1"/>
-      ))}
-    </svg>
-  )
-}
-
-function TerrainTile({ obs }: { obs: TerrainObstacle }) {
-  const topPct  = (1 - obs.x / LANE_WIDTH) * 100
-  const leftPct = 50 + (obs.y / 80) * 36
-  // Visual size tracks the physical radius so the obstacle looks as large as it blocks
-  const size    = Math.round(obs.radius * 2.8)   // radius 20–32 → 56–90 px
-  const hasBridge = obs.type === 'water' && obs.radius > 26
-
-  // Deterministic variant from obstacle id (0, 1, 2)
-  const variant = parseInt(obs.id.replace('t', ''), 10) % 3
-
-  const baseVariants = TERRAIN_CONFIG[obs.type] ?? []
-  const variantCfg = baseVariants[variant % Math.max(1, baseVariants.length)]
-  // Apply seasonal terrain file override if one exists for this type and variant index
-  const seasonFiles = SEASON_TERRAIN[obs.type]
-  const seasonFile = seasonFiles?.[variant % Math.max(1, baseVariants.length)]
-  const terrainFile = seasonFile ?? variantCfg?.file
-  const shape = variantCfg && terrainFile
-    ? <img
-        className="lane-layer"
-        src={`${BATTLEFIELD_SPRITE_PATH}${terrainFile}`}
-        width={Math.round(size * variantCfg.wr)}
-        height={Math.round(size * variantCfg.hr)}
-        alt=""
-        draggable={false}
-      />
-    : null
-
-  return (
-    <div
-      className={`terrain-obstacle u-absolute u-no-select u-flex u-items-c u-just-c terrain-obstacle--${obs.type}`}
-      style={{
-        top:       `${topPct}%`,
-        left:      `${leftPct}%`,
-        transform: 'translateX(-50%) translateY(-50%)',
-        overflow:  'visible',
-        position:  'absolute',
-        zIndex:    2,
-      }}
-      title={obs.type}
-    >
-      {shape}
-      {hasBridge && <BridgeSvg size={size} />}
-    </div>
-  )
-}
 
 function ManaBar({ mana, maxMana, manaAccum }: { mana: number; maxMana: number; manaAccum: number }) {
   const pips = Array.from({ length: maxMana }, (_, i) => {
@@ -995,8 +836,7 @@ export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPaus
         onContextMenu={pendingAoeCard ? (e) => { e.preventDefault(); setPendingAoeCard(null); setAoeHoverPos(null) } : undefined}
       >
         <div className="lane-ground" />
-        <BattlefieldTerrainCanvas environment={state.environment} id={state.environment} />
-        {(state.terrain ?? []).map(obs => <TerrainTile key={obs.id} obs={obs} />)}
+        <BattlefieldTerrainCanvas environment={state.environment} id={state.environment} terrain={state.terrain} />
         {isDebugMode() && (state.terrain ?? []).map(obs => {
           // Avoidance ellipse matching TERRAIN_AVOID_SHAPE used by the engine.
           // x-axis (forward/vertical on screen): 500 units → 100% field height → 0.2% per unit

--- a/web/src/components/battle/battlefield/BattlefieldTerrainCanvas.tsx
+++ b/web/src/components/battle/battlefield/BattlefieldTerrainCanvas.tsx
@@ -1,35 +1,39 @@
 import React, { useRef, useEffect, useState } from 'react'
 import * as PIXI from 'pixi.js'
 import { usePixiApp } from '../../../hooks/usePixiApp'
-import { buildTerrainGfx, buildBgTileGfx, buildDecorGfx, buildBorderGfx } from '../../../utils/terrainLayer'
+import { buildTerrainGfx, buildBgTileGfx, buildDecorGfx, buildBorderGfx, buildTerrainDecorGfx } from '../../../utils/terrainLayer'
 import { WORLD_ENV_TILES } from '../../../data/tiles/worldTileIndex'
 import { ENV_TILES } from '../../../data/tiles/tileIndex'
+import type { TerrainObstacle } from '../../../game/engine/terrain'
 
 export interface Props {
   environment?: string
   /** Stable ID used as terrain scatter seed — use node/act ID for deterministic decoration */
   id?: string
+  terrain?: TerrainObstacle[]
 }
 
 // Inner component — only mounts once dimensions are known so usePixiApp gets the right size.
-function TerrainPixi({ environment, id, w, h }: Props & { w: number; h: number }) {
+function TerrainPixi({ environment, id, terrain, w, h }: Props & { w: number; h: number }) {
   const containerRef = useRef<HTMLDivElement>(null)
   const envDef = WORLD_ENV_TILES[environment ?? ''] ?? ENV_TILES[environment ?? '']
 
   usePixiApp(containerRef, w, h, (app) => {
-    const base   = new PIXI.Container()
-    const river  = new PIXI.Container() // not added to stage — rivers suppressed on battlefield
-    const world  = new PIXI.Container()
-    const bg     = new PIXI.Container()
-    const decor  = new PIXI.Container()
-    const border = new PIXI.Container()
-    app.stage.addChild(base, bg, border, decor, world)
+    const base           = new PIXI.Container()
+    const river          = new PIXI.Container() // not added to stage — rivers suppressed on battlefield
+    const world          = new PIXI.Container()
+    const bg             = new PIXI.Container()
+    const decor          = new PIXI.Container()
+    const border         = new PIXI.Container()
+    const decorObstacles = new PIXI.Container()
+    app.stage.addChild(base, bg, border, decor, decorObstacles, world)
     buildTerrainGfx(base, river, world,
       { environment, envDef, id, rivers: [] },
       w, h)
     buildBgTileGfx(bg, { environment, envDef }, w, h)
     buildBorderGfx(border, { environment, envDef }, w, h)
     buildDecorGfx(decor, { environment, envDef, id }, w, h)
+    buildTerrainDecorGfx(decorObstacles, terrain ?? [], { environment, envDef }, w, h)
   })
 
   return <div ref={containerRef} style={{ width: w, height: h }} />
@@ -40,7 +44,7 @@ function TerrainPixi({ environment, id, w, h }: Props & { w: number; h: number }
  * Measures its container after mount, then renders a PixiJS tile scene.
  * Replaces the SVG layer approach of BattlefieldBackground.
  */
-export function BattlefieldTerrainCanvas({ environment, id }: Props) {
+export function BattlefieldTerrainCanvas({ environment, id, terrain }: Props) {
   const wrapRef = useRef<HTMLDivElement>(null)
   const [dims, setDims] = useState<{ w: number; h: number } | null>(null)
 
@@ -62,7 +66,7 @@ export function BattlefieldTerrainCanvas({ environment, id }: Props) {
       ref={wrapRef}
       style={{ position: 'absolute', inset: 0, overflow: 'hidden', zIndex: 0, pointerEvents: 'none' }}
     >
-      {dims && <TerrainPixi environment={environment} id={id} w={dims.w} h={dims.h} />}
+      {dims && <TerrainPixi environment={environment} id={id} terrain={terrain} w={dims.w} h={dims.h} />}
     </div>
   )
 }

--- a/web/src/data/tiles/worldTileIndex.ts
+++ b/web/src/data/tiles/worldTileIndex.ts
@@ -86,6 +86,27 @@ export const WORLD_DECOR = {
   fantasyCastleBottomRight: 62,    
 } as const
 
+// ── Terrain obstacle → decor tile mapping (for battlefield rendering) ─────────
+// Maps environment name + TerrainType to an array of WORLD_DECOR tile IDs.
+// _default entries are used when no environment-specific override exists.
+// Multiple IDs → pick one deterministically via idNum % length.
+export const TERRAIN_DECOR_MAP: Record<string, Partial<Record<string, number[]>>> = {
+  _default: {
+    tree:  [WORLD_DECOR.singleTree, WORLD_DECOR.groupOfTrees],
+    rock:  [WORLD_DECOR.pileOfRocks, WORLD_DECOR.rock],
+    water: [WORLD_DECOR.pond],
+    ruin:  [WORLD_DECOR.graveStone, WORLD_DECOR.signpost],
+  },
+  forest:  { tree: [WORLD_DECOR.groupOfTrees, WORLD_DECOR.bigTree] },
+  ashen:   { tree: [WORLD_DECOR.bigTree], water: [WORLD_DECOR.hole], ruin: [WORLD_DECOR.graveStone] },
+  sand:    { water: [WORLD_DECOR.sandSinkhole], rock: [WORLD_DECOR.rock] },
+  volcano: { rock: [WORLD_DECOR.mountainTopLeft], water: [WORLD_DECOR.waterWhirlpool], ruin: [WORLD_DECOR.volcanoCaveBottomLeft] },
+  citadel: { ruin: [WORLD_DECOR.house], rock: [WORLD_DECOR.pileOfRocks] },
+  fungal:  { tree: [WORLD_DECOR.groupOfTrees, WORLD_DECOR.bigTree] },
+  frost:   { water: [WORLD_DECOR.pond], rock: [WORLD_DECOR.pileOfRocks] },
+  coast:   { water: [WORLD_DECOR.pond] },
+}
+
 // ── Per-environment tile config for world-scale (campaign) rendering ──────────
 // Mirrors ENV_TILES in tileIndex.ts; used by NodeMap.tsx via envDef override.
 // ground IDs still reference BASE_GROUND (BaseChip sheet) for background fills.

--- a/web/src/game/campaignHelpers.ts
+++ b/web/src/game/campaignHelpers.ts
@@ -3,6 +3,11 @@ import { NewGameOptions, MAX_HANDICAP } from './engine'
 import { Card, SECRET_RARITIES } from './types'
 import { shuffle } from './engine/helpers'
 import { HERO_CARDS, makeNodeDeck, getCardCatalog } from './cards'
+
+const QB_ENVIRONMENTS = ['forest', 'farmland', 'ruins', 'ashen', 'sand', 'volcano', 'citadel', 'coast', 'frost', 'fungal', 'vault', 'camp'] as const
+function pickQBEnvironment(): string {
+  return QB_ENVIRONMENTS[Math.floor(Math.random() * QB_ENVIRONMENTS.length)]
+}
 import {
   buildDeckCards, DECK_MAX, STARTER_DECK, deckTotalCards,
   generateSeededPack, loadCollection, loadDeck,
@@ -35,30 +40,32 @@ export function buildQuickBattleOpts(
   const deckBonus     = Math.round(Math.max(0, DECK_MAX - deckCount) / DECK_MAX * 10)
   const adjustedHandicap = Math.min(MAX_HANDICAP, handicap + deckBonus)
 
+  const environment = pickQBEnvironment()
+
   if (mode === 'mirror') {
-    return { playerCards, opts: { playerCards, opponentHandicap: MAX_HANDICAP, prebuiltOpponentDeck: shuffle([...playerCards]) } }
+    return { playerCards, opts: { playerCards, opponentHandicap: MAX_HANDICAP, prebuiltOpponentDeck: shuffle([...playerCards]), environment } }
   }
   if (mode === 'easy') {
-    return { playerCards, opts: { playerCards, opponentHandicap: adjustedHandicap } }
+    return { playerCards, opts: { playerCards, opponentHandicap: adjustedHandicap, environment } }
   }
   if (mode === 'normal') {
     const ownedNames       = new Set(collection.filter(e => e.count > 0).map(e => e.cardName))
     const collectionPool   = getCardCatalog().filter(c => ownedNames.has(c.name))
     const opponentCardPool = collectionPool.length >= 20 ? collectionPool : undefined
-    return { playerCards, opts: { playerCards, opponentHandicap: adjustedHandicap, opponentCardPool } }
+    return { playerCards, opts: { playerCards, opponentHandicap: adjustedHandicap, opponentCardPool, environment } }
   }
   if (mode === 'chaos') {
     const collectionPool   = makeNodeDeck(generateSeededPack(20, 'legendary'))
     const opponentCardPool = collectionPool.length >= 20 ? collectionPool : undefined
-    return { playerCards, opts: { playerCards: opponentCardPool, opponentHandicap: 0, opponentCardPool, forgiveManaLimit: true } }
+    return { playerCards, opts: { playerCards: opponentCardPool, opponentHandicap: 0, opponentCardPool, forgiveManaLimit: true, environment } }
   }
   if (mode === 'unlimited') {
     const collectionPool   = getCardCatalog().filter(c => !SECRET_RARITIES.has(c.rarity))
     const opponentCardPool = collectionPool.length >= 20 ? collectionPool : undefined
-    return { playerCards, opts: { playerCards, opponentHandicap: 0, opponentCardPool } }
+    return { playerCards, opts: { playerCards, opponentHandicap: 0, opponentCardPool, environment } }
   }
   if (mode === 'hero-only') {
-    return { playerCards, opts: { playerCards, opponentHandicap: 0, opponentCardPool: [...HERO_CARDS, ...HERO_CARDS, ...HERO_CARDS], forgiveManaLimit: true } }
+    return { playerCards, opts: { playerCards, opponentHandicap: 0, opponentCardPool: [...HERO_CARDS, ...HERO_CARDS, ...HERO_CARDS], forgiveManaLimit: true, environment } }
   }
   // Rarity / type filter modes
   const filterMap: Record<string, (c: Card) => boolean> = {
@@ -74,10 +81,10 @@ export function buildQuickBattleOpts(
   if (filter) {
     const collectionPool   = getCardCatalog().filter(c => filter(c) && !SECRET_RARITIES.has(c.rarity))
     const opponentCardPool = collectionPool.length >= 20 ? collectionPool : undefined
-    return { playerCards, opts: { playerCards, opponentHandicap: 0, opponentCardPool } }
+    return { playerCards, opts: { playerCards, opponentHandicap: 0, opponentCardPool, environment } }
   }
   // Fallback: easy
-  return { playerCards, opts: { playerCards, opponentHandicap: adjustedHandicap } }
+  return { playerCards, opts: { playerCards, opponentHandicap: adjustedHandicap, environment } }
 }
 
 export const HANDICAP_KEY = 'jarvs_handicap'

--- a/web/src/utils/terrainLayer.ts
+++ b/web/src/utils/terrainLayer.ts
@@ -1,8 +1,11 @@
 import * as PIXI from 'pixi.js'
 import { ENV_TILES, BASE_GROUND, TILESET_IMAGE, TILESET_COLUMNS, TILE_SIZE, EnvTileDef, SCENERY } from '../data/tiles/tileIndex'
+import { WORLD_DECOR_FILE, WORLD_DECOR, TERRAIN_DECOR_MAP, WORLD_PATH_TILE } from '../data/tiles/worldTileIndex'
 import { loadTileTexture } from './pixiHelpers'
 import { drawTerrainItem } from './terrainGfx'
 import { seededRand, hashStr, getTerrainItems, type TerrainItem } from './mapUtils'
+import { renderPathTiles } from './tileLookup'
+import type { TerrainObstacle } from '../game/engine/terrain'
 
 export interface TerrainLayerOptions {
   environment?: string
@@ -221,5 +224,119 @@ export async function buildDecorGfx(
       s.position.set(c * TILE_SIZE, r * TILE_SIZE)
       container.addChild(s)
     }
+  }
+}
+
+/**
+ * Renders battlefield terrain obstacles (trees, rocks, water, ruins) as
+ * WORLD_DECOR tile sprites instead of SVG line-art.
+ * Game coords → canvas px:
+ *   cx = (0.5 + (obs.y / 80) * 0.36) * w
+ *   cy = (1 - obs.x / 500) * h
+ */
+export async function buildTerrainDecorGfx(
+  container: PIXI.Container,
+  terrain: TerrainObstacle[],
+  opts: { environment?: string; envDef?: EnvTileDef },
+  w: number,
+  h: number,
+): Promise<void> {
+  if (terrain.length === 0) return
+  const base = (import.meta as { env: { BASE_URL: string } }).env.BASE_URL
+  const decorUrl = `${base}${WORLD_DECOR_FILE.slice(1)}`
+  const env = opts.environment ?? ''
+  const envMap = TERRAIN_DECOR_MAP[env] ?? {}
+
+  for (const obs of terrain) {
+    if (container.destroyed) return
+    const cx = (0.5 + (obs.y / 80) * 0.36) * w
+    const cy = (1 - obs.x / 500) * h
+    const idNum = parseInt(obs.id.replace('t', ''), 10)
+
+    const tileIds: number[] = (envMap[obs.type] ?? TERRAIN_DECOR_MAP._default[obs.type]) ?? []
+    if (tileIds.length === 0) continue
+    const tileId = tileIds[idNum % tileIds.length]
+
+    // ── 2×2 mountain block (volcano rocks) ──────────────────────────────────
+    if (tileId === WORLD_DECOR.mountainTopLeft) {
+      const tiles = [
+        { id: WORLD_DECOR.mountainTopLeft,     dx: -TILE_SIZE, dy: -TILE_SIZE },
+        { id: WORLD_DECOR.mountainTopRight,    dx: 0,          dy: -TILE_SIZE },
+        { id: WORLD_DECOR.mountainBottomLeft,  dx: -TILE_SIZE, dy: 0 },
+        { id: WORLD_DECOR.mountainBottomRight, dx: 0,          dy: 0 },
+      ]
+      for (const t of tiles) {
+        if (container.destroyed) return
+        const tex = await loadTileTexture(decorUrl, t.id, 8)
+        if (container.destroyed) return
+        const s = new PIXI.Sprite(tex)
+        s.position.set(cx + t.dx, cy + t.dy)
+        s.width = TILE_SIZE
+        s.height = TILE_SIZE
+        container.addChild(s)
+      }
+      continue
+    }
+
+    // ── Bridge over large water obstacles ────────────────────────────────────
+    if (obs.type === 'water' && obs.radius > 26) {
+      const bridgeW = obs.radius * 2.8
+      for (const { id, yOff } of [
+        { id: WORLD_DECOR.stoneBridgeVTop,    yOff: -TILE_SIZE * 0.5 },
+        { id: WORLD_DECOR.stoneBridgeVBottom, yOff:  TILE_SIZE * 0.5 },
+      ]) {
+        if (container.destroyed) return
+        const tex = await loadTileTexture(decorUrl, id, 8)
+        if (container.destroyed) return
+        const s = new PIXI.Sprite(tex)
+        const aspect = tex.height / tex.width
+        s.width  = bridgeW
+        s.height = bridgeW * aspect
+        s.anchor.set(0.5)
+        s.position.set(cx, cy + yOff)
+        container.addChild(s)
+      }
+      continue
+    }
+
+    // ── Water pool (tiled area + overlay decor) ──────────────────────────────
+    if (obs.type === 'water') {
+      const tileRadius = Math.max(1, Math.round(obs.radius * h / (500 * TILE_SIZE)))
+      const tcx = Math.round(cx / TILE_SIZE)
+      const tcy = Math.round(cy / TILE_SIZE)
+      const pathSet = new Set<string>()
+      for (let dr = -tileRadius; dr <= tileRadius; dr++) {
+        for (let dc = -tileRadius; dc <= tileRadius; dc++) {
+          if (dr * dr + dc * dc <= tileRadius * tileRadius) {
+            pathSet.add(`${tcx + dc},${tcy + dr}`)
+          }
+        }
+      }
+      const waterContainer = new PIXI.Container()
+      container.addChild(waterContainer)
+      await renderPathTiles(waterContainer, pathSet, undefined, WORLD_PATH_TILE.grass1Water1)
+      if (container.destroyed) return
+
+      // Overlay decor tile (pond/hole/whirlpool/sinkhole) centred on the pool
+      const scale = (obs.radius * 2.8) / TILE_SIZE
+      const tex = await loadTileTexture(decorUrl, tileId, 8)
+      if (container.destroyed) return
+      const s = new PIXI.Sprite(tex)
+      s.anchor.set(0.5)
+      s.scale.set(scale)
+      s.position.set(cx, cy)
+      container.addChild(s)
+      continue
+    }
+
+    // ── Single decor tile (tree, rock, ruin) ─────────────────────────────────
+    const scale = (obs.radius * 2.8) / TILE_SIZE
+    const tex = await loadTileTexture(decorUrl, tileId, 8)
+    if (container.destroyed) return
+    const s = new PIXI.Sprite(tex)
+    s.anchor.set(0.5)
+    s.scale.set(scale)
+    s.position.set(cx, cy)
+    container.addChild(s)
   }
 }


### PR DESCRIPTION
## Summary

- Quick Battle now picks a random environment from 12 options so the tile border and themed ground always render
- Battlefield terrain obstacles (trees, rocks, water, ruins) are now rendered as `WORLD_DECOR` tile sprites via PixiJS — replacing the SVG line-art `<img>` approach
- Water obstacles render as a tiled pool (`WORLD_PATH_TILE.grass1Water1`) with a decor overlay; large water gets stone bridge tiles; volcano rocks render as a 2×2 mountain tile block
- Environment-specific tile mappings defined in new `TERRAIN_DECOR_MAP` export in `worldTileIndex.ts`
- Unit avoidance logic (`TERRAIN_AVOID_SHAPE`) is unchanged — units still walk around obstacles
- Season detection, `BridgeSvg`, `TerrainTile`, and all related dead code removed from `Battlefield.tsx`

## Test plan

- [ ] `npm run build` passes cleanly
- [ ] Campaign battle — terrain obstacles appear as WORLD_DECOR tiles (trees, rocks, ruins, water pools) matching the environment
- [ ] Quick Battle — environment varies per run; tile border displays on left, right, and top edges
- [ ] Volcano environment — rock obstacles render as 2×2 mountain tile blocks
- [ ] Large water obstacle — stone bridge tiles appear over the pool
- [ ] Debug mode — avoidance ellipses still align with obstacle positions

https://claude.ai/code/session_01MBDpW8x7FL9TbT6E8j1Nkn