### PR TITLE
feat(battlefield): TYPE3 adjacency-tiled terrain obstacle patches

### DIFF
--- a/web/src/data/tiles/worldTileIndex.ts
+++ b/web/src/data/tiles/worldTileIndex.ts
@@ -86,25 +86,34 @@ export const WORLD_DECOR = {
   fantasyCastleBottomRight: 62,    
 } as const
 
-// ── Terrain obstacle → decor tile mapping (for battlefield rendering) ─────────
-// Maps environment name + TerrainType to an array of WORLD_DECOR tile IDs.
-// _default entries are used when no environment-specific override exists.
+// ── Terrain obstacle → decor tile mapping (ruins only) ────────────────────────
+// Maps environment name + TerrainType 'ruin' to WORLD_DECOR tile IDs.
 // Multiple IDs → pick one deterministically via idNum % length.
 export const TERRAIN_DECOR_MAP: Record<string, Partial<Record<string, number[]>>> = {
   _default: {
-    tree:  [WORLD_DECOR.singleTree, WORLD_DECOR.groupOfTrees],
-    rock:  [WORLD_DECOR.pileOfRocks, WORLD_DECOR.rock],
-    water: [WORLD_DECOR.pond],
-    ruin:  [WORLD_DECOR.graveStone, WORLD_DECOR.signpost],
+    ruin: [WORLD_DECOR.graveStone, WORLD_DECOR.signpost],
   },
-  forest:  { tree: [WORLD_DECOR.groupOfTrees, WORLD_DECOR.bigTree] },
-  ashen:   { tree: [WORLD_DECOR.bigTree], water: [WORLD_DECOR.hole], ruin: [WORLD_DECOR.graveStone] },
-  sand:    { water: [WORLD_DECOR.sandSinkhole], rock: [WORLD_DECOR.rock] },
-  volcano: { rock: [WORLD_DECOR.mountainTopLeft], water: [WORLD_DECOR.waterWhirlpool], ruin: [WORLD_DECOR.volcanoCaveBottomLeft] },
-  citadel: { ruin: [WORLD_DECOR.house], rock: [WORLD_DECOR.pileOfRocks] },
-  fungal:  { tree: [WORLD_DECOR.groupOfTrees, WORLD_DECOR.bigTree] },
-  frost:   { water: [WORLD_DECOR.pond], rock: [WORLD_DECOR.pileOfRocks] },
-  coast:   { water: [WORLD_DECOR.pond] },
+  ashen:   { ruin: [WORLD_DECOR.graveStone] },
+  volcano: { ruin: [WORLD_DECOR.volcanoCaveBottomLeft] },
+  citadel: { ruin: [WORLD_DECOR.house] },
+  sand:    { ruin: [WORLD_DECOR.signpost] },
+}
+
+// ── Terrain obstacle → TYPE3 patch tileset (for battlefield rendering) ────────
+// Maps environment name + TerrainType to a WORLD_SCENERY_TILE or WORLD_PATH_TILE
+// file. renderPathTiles uses 8-bit adjacency bitmask to create organic shapes.
+// Ruin type is intentionally absent — ruins use a single TERRAIN_DECOR_MAP tile.
+export const TERRAIN_PATCH_MAP: Record<string, Partial<Record<string, string>>> = {
+  _default: {
+    tree:  WORLD_SCENERY_TILE.forest1,
+    rock:  WORLD_SCENERY_TILE.rocks1,
+    water: WORLD_PATH_TILE.grass1Water1,
+  },
+  ashen:   { tree: WORLD_SCENERY_TILE.rocks1 },
+  volcano: { rock: WORLD_SCENERY_TILE.mountains1 },
+  frost:   { rock: WORLD_SCENERY_TILE.mountains1 },
+  farmland: { rock: WORLD_SCENERY_TILE.hills1 },
+  coast:   { rock: WORLD_SCENERY_TILE.hills1 },
 }
 
 // ── Per-environment tile config for world-scale (campaign) rendering ──────────

--- a/web/src/utils/terrainLayer.ts
+++ b/web/src/utils/terrainLayer.ts
@@ -1,6 +1,6 @@
 import * as PIXI from 'pixi.js'
 import { ENV_TILES, BASE_GROUND, TILESET_IMAGE, TILESET_COLUMNS, TILE_SIZE, EnvTileDef, SCENERY } from '../data/tiles/tileIndex'
-import { WORLD_DECOR_FILE, WORLD_DECOR, TERRAIN_DECOR_MAP, WORLD_PATH_TILE } from '../data/tiles/worldTileIndex'
+import { WORLD_DECOR_FILE, TERRAIN_DECOR_MAP, TERRAIN_PATCH_MAP } from '../data/tiles/worldTileIndex'
 import { loadTileTexture } from './pixiHelpers'
 import { drawTerrainItem } from './terrainGfx'
 import { seededRand, hashStr, getTerrainItems, type TerrainItem } from './mapUtils'
@@ -228,8 +228,11 @@ export async function buildDecorGfx(
 }
 
 /**
- * Renders battlefield terrain obstacles (trees, rocks, water, ruins) as
- * WORLD_DECOR tile sprites instead of SVG line-art.
+ * Renders battlefield terrain obstacles using TYPE3 adjacency-tiled patches
+ * (tree → forest1, rock → rocks1/mountains1, water → grass1Water1) so shapes
+ * are organic rather than single scaled tiles. Ruins fall back to a single
+ * WORLD_DECOR tile (gravestone, house, etc.).
+ *
  * Game coords → canvas px:
  *   cx = (0.5 + (obs.y / 80) * 0.36) * w
  *   cy = (1 - obs.x / 500) * h
@@ -243,9 +246,9 @@ export async function buildTerrainDecorGfx(
 ): Promise<void> {
   if (terrain.length === 0) return
   const base = (import.meta as { env: { BASE_URL: string } }).env.BASE_URL
-  const decorUrl = `${base}${WORLD_DECOR_FILE.slice(1)}`
   const env = opts.environment ?? ''
-  const envMap = TERRAIN_DECOR_MAP[env] ?? {}
+  const envPatchMap = TERRAIN_PATCH_MAP[env] ?? {}
+  const envDecorMap = TERRAIN_DECOR_MAP[env] ?? {}
 
   for (const obs of terrain) {
     if (container.destroyed) return
@@ -253,50 +256,9 @@ export async function buildTerrainDecorGfx(
     const cy = (1 - obs.x / 500) * h
     const idNum = parseInt(obs.id.replace('t', ''), 10)
 
-    const tileIds: number[] = (envMap[obs.type] ?? TERRAIN_DECOR_MAP._default[obs.type]) ?? []
-    if (tileIds.length === 0) continue
-    const tileId = tileIds[idNum % tileIds.length]
-
-    // ── 2×2 mountain block (volcano rocks) ──────────────────────────────────
-    if (tileId === WORLD_DECOR.mountainTopLeft) {
-      const tiles = [
-        { id: WORLD_DECOR.mountainTopLeft,     dx: -TILE_SIZE, dy: -TILE_SIZE },
-        { id: WORLD_DECOR.mountainTopRight,    dx: 0,          dy: -TILE_SIZE },
-        { id: WORLD_DECOR.mountainBottomLeft,  dx: -TILE_SIZE, dy: 0 },
-        { id: WORLD_DECOR.mountainBottomRight, dx: 0,          dy: 0 },
-      ]
-      for (const t of tiles) {
-        if (container.destroyed) return
-        const tex = await loadTileTexture(decorUrl, t.id, 8)
-        if (container.destroyed) return
-        const s = new PIXI.Sprite(tex)
-        s.position.set(cx + t.dx, cy + t.dy)
-        s.width = TILE_SIZE
-        s.height = TILE_SIZE
-        container.addChild(s)
-      }
-      continue
-    }
-
-    // ── Bridge over large water obstacles ────────────────────────────────────
-    if (obs.type === 'water' && obs.radius > 26) {
-      for (const { id, yOff } of [
-        { id: WORLD_DECOR.stoneBridgeVTop,    yOff: -TILE_SIZE * 0.5 },
-        { id: WORLD_DECOR.stoneBridgeVBottom, yOff:  TILE_SIZE * 0.5 },
-      ]) {
-        if (container.destroyed) return
-        const tex = await loadTileTexture(decorUrl, id, 8)
-        if (container.destroyed) return
-        const s = new PIXI.Sprite(tex)
-        s.anchor.set(0.5)
-        s.position.set(cx, cy + yOff)
-        container.addChild(s)
-      }
-      continue
-    }
-
-    // ── Water pool (tiled area + overlay decor) ──────────────────────────────
-    if (obs.type === 'water') {
+    // ── TYPE3 adjacency-tiled patch (tree / rock / water) ───────────────────
+    const patchFile = envPatchMap[obs.type] ?? TERRAIN_PATCH_MAP._default?.[obs.type]
+    if (patchFile) {
       const tileRadius = Math.max(1, Math.round(obs.radius * h / (500 * TILE_SIZE)))
       const tcx = Math.round(cx / TILE_SIZE)
       const tcy = Math.round(cy / TILE_SIZE)
@@ -308,27 +270,25 @@ export async function buildTerrainDecorGfx(
           }
         }
       }
-      const waterContainer = new PIXI.Container()
-      container.addChild(waterContainer)
-      await renderPathTiles(waterContainer, pathSet, undefined, WORLD_PATH_TILE.grass1Water1)
+      const patchContainer = new PIXI.Container()
+      container.addChild(patchContainer)
+      await renderPathTiles(patchContainer, pathSet, undefined, patchFile)
       if (container.destroyed) return
+      continue
+    }
 
-      // Overlay decor tile (pond/hole/whirlpool/sinkhole) at natural pixel scale
+    // ── Ruin: single WORLD_DECOR tile (gravestone, house, …) ────────────────
+    if (obs.type === 'ruin') {
+      const tileIds = envDecorMap['ruin'] ?? TERRAIN_DECOR_MAP._default?.['ruin'] ?? []
+      if (tileIds.length === 0) continue
+      const tileId = tileIds[idNum % tileIds.length]
+      const decorUrl = `${base}${WORLD_DECOR_FILE.slice(1)}`
       const tex = await loadTileTexture(decorUrl, tileId, 8)
       if (container.destroyed) return
       const s = new PIXI.Sprite(tex)
       s.anchor.set(0.5)
       s.position.set(cx, cy)
       container.addChild(s)
-      continue
     }
-
-    // ── Single decor tile (tree, rock, ruin) at natural pixel scale ──────────
-    const tex = await loadTileTexture(decorUrl, tileId, 8)
-    if (container.destroyed) return
-    const s = new PIXI.Sprite(tex)
-    s.anchor.set(0.5)
-    s.position.set(cx, cy)
-    container.addChild(s)
   }
 }


### PR DESCRIPTION
## Summary

Replaces single stretched decor tiles (and the ad-hoc 2×2 mountain block) with `renderPathTiles()` calls using the WORLD_SCENERY_TILE sets. The 8-bit adjacency bitmask produces organic irregular-shaped patches at natural pixel scale.

### New `TERRAIN_PATCH_MAP` (worldTileIndex.ts)

| Type | Default | Environment overrides |
|---|---|---|
| `tree` | `forest1.png` | `rocks1` in ashen |
| `rock` | `rocks1.png` | `mountains1` in volcano/frost; `hills1` in farmland/coast |
| `water` | `grass1_water1.png` | — |
| `ruin` | *(no patch)* | single WORLD_DECOR tile (gravestone, house, cave…) |

### What was removed
- 2×2 mountain block sentinel hack
- Bridge tiles over large water
- Water pool decor overlay
- `TERRAIN_DECOR_MAP` tree/rock/water entries (now in `TERRAIN_PATCH_MAP`)
- Radius-based `scale` factor that was distorting tiles

## Test plan

- [ ] `npm run build` passes
- [ ] Forest environment: tree obstacles render as organic `forest1` patches
- [ ] Volcano environment: rock obstacles render as `mountains1` patches
- [ ] Water obstacles render as `grass1_water1` patches
- [ ] Ruin obstacles render as a single gravestone/house tile
- [ ] All tiles at natural pixel scale — no stretching

https://claude.ai/code/session_01MBDpW8x7FL9TbT6E8j1Nkn

---
_Generated by [Claude Code](https://claude.ai/code/session_01MBDpW8x7FL9TbT6E8j1Nkn)_