### PR TITLE
Fix terrain patch tiles to use 4-bit SCENERY_LOOKUP

### DIFF
--- a/web/src/utils/terrainLayer.ts
+++ b/web/src/utils/terrainLayer.ts
@@ -227,6 +227,41 @@ export async function buildDecorGfx(
   }
 }
 
+// Renders a scenery-sheet patch using 4-bit diagonal SCENERY_LOOKUP.
+// WORLD_SCENERY_TILE files (forest1, rocks1, mountains1, hills1) use this lookup —
+// NOT the 8-bit PATH_TILE_LOOKUP used by renderPathTiles.
+async function renderSceneryPatch(
+  container: PIXI.Container,
+  pathSet: Set<string>,
+  tileFile: string,
+): Promise<void> {
+  const base = (import.meta as { env: { BASE_URL: string } }).env.BASE_URL
+  const url = base + tileFile.replace(/^\//, '')
+  const tex = await PIXI.Assets.load(url) as PIXI.Texture
+  if (container.destroyed) return
+  const tileW = tex.width / 8
+  const tileH = tileW
+  for (const key of pathSet) {
+    const [c, r] = key.split(',').map(Number)
+    const nw = pathSet.has(`${c - 1},${r - 1}`) ? 8 : 0
+    const ne = pathSet.has(`${c + 1},${r - 1}`) ? 4 : 0
+    const se = pathSet.has(`${c + 1},${r + 1}`) ? 2 : 0
+    const sw = pathSet.has(`${c - 1},${r + 1}`) ? 1 : 0
+    const frame    = SCENERY_LOOKUP[nw | ne | se | sw]
+    const frameCol = frame % 8
+    const frameRow = Math.floor(frame / 8)
+    const frameTex = new PIXI.Texture({
+      source: tex.source,
+      frame:  new PIXI.Rectangle(frameCol * tileW, frameRow * tileH, tileW, tileH),
+    })
+    const sprite = new PIXI.Sprite(frameTex)
+    sprite.position.set(c * TILE_SIZE, r * TILE_SIZE)
+    sprite.width  = TILE_SIZE
+    sprite.height = TILE_SIZE
+    container.addChild(sprite)
+  }
+}
+
 /**
  * Renders battlefield terrain obstacles using TYPE3 adjacency-tiled patches
  * (tree → forest1, rock → rocks1/mountains1, water → grass1Water1) so shapes
@@ -272,7 +307,11 @@ export async function buildTerrainDecorGfx(
       }
       const patchContainer = new PIXI.Container()
       container.addChild(patchContainer)
-      await renderPathTiles(patchContainer, pathSet, undefined, patchFile)
+      if (obs.type === 'water') {
+        await renderPathTiles(patchContainer, pathSet, undefined, patchFile)
+      } else {
+        await renderSceneryPatch(patchContainer, pathSet, patchFile)
+      }
       if (container.destroyed) return
       continue
     }


### PR DESCRIPTION
## Summary

- Adds `renderSceneryPatch()` to `terrainLayer.ts` — uses the 4-bit diagonal `SCENERY_LOOKUP` (NW/NE/SE/SW corners) that WORLD_SCENERY_TILE sheets (`forest1.png`, `rocks1.png`, `mountains1.png`, `hills1.png`) are designed for
- Routes tree and rock terrain obstacle patches through `renderSceneryPatch` instead of `renderPathTiles` (which uses the 8-bit cardinal+diagonal PATH_TILE_LOOKUP and was selecting wrong variants)
- Water obstacles continue using `renderPathTiles` — `grass1_water1.png` is a WORLD_PATH_TILE (8-bit) sheet and was already correct

The pattern mirrors `buildBorderGfx` which already uses `SCENERY_LOOKUP` correctly for border fills.

## Test plan

- [ ] `npm run build` passes with no TypeScript errors
- [ ] In a `forest` environment battle, tree patches show correctly shaped forest clusters with proper corner/edge tile variants from the scenery sheet
- [ ] In `volcano`/`frost` environments, rock patches render mountain scenery with correct organic edge shapes
- [ ] Water obstacles still render as tiled pools (unchanged path)
- [ ] Ruins still render as single WORLD_DECOR tiles (unchanged)
- [ ] Unit avoidance ellipses still align with obstacle positions (engine unchanged)

https://claude.ai/code/session_01MBDpW8x7FL9TbT6E8j1Nkn

---
_Generated by [Claude Code](https://claude.ai/code/session_01MBDpW8x7FL9TbT6E8j1Nkn)_