### PR TITLE
Combine SCENERY ring + WORLD_DECOR center tile per terrain obstacle

### DIFF
--- a/web/src/components/battle/battlefield/BattlefieldTerrainCanvas.tsx
+++ b/web/src/components/battle/battlefield/BattlefieldTerrainCanvas.tsx
@@ -1,7 +1,7 @@
 import React, { useRef, useEffect, useState } from 'react'
 import * as PIXI from 'pixi.js'
 import { usePixiApp } from '../../../hooks/usePixiApp'
-import { buildTerrainGfx, buildBgTileGfx, buildDecorGfx, buildBorderGfx, buildTerrainDecorGfx } from '../../../utils/terrainLayer'
+import { buildTerrainGfx, buildBgTileGfx, buildBorderGfx, buildTerrainDecorGfx } from '../../../utils/terrainLayer'
 import { WORLD_ENV_TILES } from '../../../data/tiles/worldTileIndex'
 import { ENV_TILES } from '../../../data/tiles/tileIndex'
 import type { TerrainObstacle } from '../../../game/engine/terrain'
@@ -23,16 +23,14 @@ function TerrainPixi({ environment, id, terrain, w, h }: Props & { w: number; h:
     const river          = new PIXI.Container() // not added to stage — rivers suppressed on battlefield
     const world          = new PIXI.Container()
     const bg             = new PIXI.Container()
-    const decor          = new PIXI.Container()
     const border         = new PIXI.Container()
     const decorObstacles = new PIXI.Container()
-    app.stage.addChild(base, bg, border, decor, decorObstacles, world)
+    app.stage.addChild(base, bg, border, decorObstacles, world)
     buildTerrainGfx(base, river, world,
       { environment, envDef, id, rivers: [], terrainItems: [] },
       w, h)
     buildBgTileGfx(bg, { environment, envDef }, w, h)
     buildBorderGfx(border, { environment, envDef }, w, h)
-    buildDecorGfx(decor, { environment, envDef, id }, w, h)
     buildTerrainDecorGfx(decorObstacles, terrain ?? [], { environment, envDef }, w, h)
   })
 

--- a/web/src/components/battle/battlefield/BattlefieldTerrainCanvas.tsx
+++ b/web/src/components/battle/battlefield/BattlefieldTerrainCanvas.tsx
@@ -1,7 +1,7 @@
 import React, { useRef, useEffect, useState } from 'react'
 import * as PIXI from 'pixi.js'
 import { usePixiApp } from '../../../hooks/usePixiApp'
-import { buildTerrainGfx, buildBgTileGfx, buildBorderGfx, buildTerrainDecorGfx } from '../../../utils/terrainLayer'
+import { buildTerrainGfx, buildBgTileGfx, buildDecorGfx, buildBorderGfx, buildTerrainDecorGfx } from '../../../utils/terrainLayer'
 import { WORLD_ENV_TILES } from '../../../data/tiles/worldTileIndex'
 import { ENV_TILES } from '../../../data/tiles/tileIndex'
 import type { TerrainObstacle } from '../../../game/engine/terrain'
@@ -23,14 +23,16 @@ function TerrainPixi({ environment, id, terrain, w, h }: Props & { w: number; h:
     const river          = new PIXI.Container() // not added to stage — rivers suppressed on battlefield
     const world          = new PIXI.Container()
     const bg             = new PIXI.Container()
+    const decor          = new PIXI.Container()
     const border         = new PIXI.Container()
     const decorObstacles = new PIXI.Container()
-    app.stage.addChild(base, bg, border, decorObstacles, world)
+    app.stage.addChild(base, bg, border, decor, decorObstacles, world)
     buildTerrainGfx(base, river, world,
       { environment, envDef, id, rivers: [], terrainItems: [] },
       w, h)
     buildBgTileGfx(bg, { environment, envDef }, w, h)
     buildBorderGfx(border, { environment, envDef }, w, h)
+    buildDecorGfx(decor, { environment, envDef, id }, w, h)
     buildTerrainDecorGfx(decorObstacles, terrain ?? [], { environment, envDef }, w, h)
   })
 

--- a/web/src/data/tiles/worldTileIndex.ts
+++ b/web/src/data/tiles/worldTileIndex.ts
@@ -86,17 +86,25 @@ export const WORLD_DECOR = {
   fantasyCastleBottomRight: 62,    
 } as const
 
-// ── Terrain obstacle → decor tile mapping (ruins only) ────────────────────────
-// Maps environment name + TerrainType 'ruin' to WORLD_DECOR tile IDs.
+// ── Terrain obstacle → WORLD_DECOR center tile mapping ───────────────────────
+// Each obstacle renders a SCENERY/PATH tile ring (via TERRAIN_PATCH_MAP) with a
+// single WORLD_DECOR tile placed in the center cell — they must not share a cell.
 // Multiple IDs → pick one deterministically via idNum % length.
 export const TERRAIN_DECOR_MAP: Record<string, Partial<Record<string, number[]>>> = {
   _default: {
-    ruin: [WORLD_DECOR.graveStone, WORLD_DECOR.signpost],
+    tree:  [WORLD_DECOR.groupOfTrees, WORLD_DECOR.bigTree, WORLD_DECOR.singleTree],
+    rock:  [WORLD_DECOR.pileOfRocks, WORLD_DECOR.rock],
+    water: [WORLD_DECOR.pond],
+    ruin:  [WORLD_DECOR.graveStone, WORLD_DECOR.signpost],
   },
-  ashen:   { ruin: [WORLD_DECOR.graveStone] },
-  volcano: { ruin: [WORLD_DECOR.volcanoCaveBottomLeft] },
-  citadel: { ruin: [WORLD_DECOR.house] },
-  sand:    { ruin: [WORLD_DECOR.signpost] },
+  forest:  { tree: [WORLD_DECOR.bigTree, WORLD_DECOR.groupOfTrees] },
+  ashen:   { tree: [WORLD_DECOR.rock], ruin: [WORLD_DECOR.graveStone] },
+  sand:    { water: [WORLD_DECOR.sandSinkhole], rock: [WORLD_DECOR.rock], ruin: [WORLD_DECOR.signpost] },
+  volcano: { rock: [WORLD_DECOR.pileOfRocks], water: [WORLD_DECOR.waterWhirlpool], ruin: [WORLD_DECOR.volcanoCaveBottomLeft] },
+  citadel: { ruin: [WORLD_DECOR.house], rock: [WORLD_DECOR.pileOfRocks] },
+  frost:   { water: [WORLD_DECOR.pond], rock: [WORLD_DECOR.pileOfRocks] },
+  coast:   { water: [WORLD_DECOR.pond] },
+  fungal:  { tree: [WORLD_DECOR.groupOfTrees, WORLD_DECOR.bigTree] },
 }
 
 // ── Terrain obstacle → TYPE3 patch tileset (for battlefield rendering) ────────

--- a/web/src/utils/terrainLayer.ts
+++ b/web/src/utils/terrainLayer.ts
@@ -1,6 +1,6 @@
 import * as PIXI from 'pixi.js'
 import { ENV_TILES, BASE_GROUND, TILESET_IMAGE, TILESET_COLUMNS, TILE_SIZE, EnvTileDef, SCENERY } from '../data/tiles/tileIndex'
-import { WORLD_DECOR_FILE, TERRAIN_DECOR_MAP, TERRAIN_PATCH_MAP } from '../data/tiles/worldTileIndex'
+import { WORLD_DECOR_FILE, WORLD_DECOR, TERRAIN_DECOR_MAP, TERRAIN_PATCH_MAP } from '../data/tiles/worldTileIndex'
 import { loadTileTexture } from './pixiHelpers'
 import { drawTerrainItem } from './terrainGfx'
 import { seededRand, hashStr, getTerrainItems, type TerrainItem } from './mapUtils'
@@ -292,6 +292,7 @@ export async function buildTerrainDecorGfx(
     const idNum = parseInt(obs.id.replace('t', ''), 10)
 
     // ── TYPE3 adjacency-tiled patch (tree / rock / water) ───────────────────
+    // SCENERY/PATH tiles fill the ring; center cell is reserved for WORLD_DECOR.
     const patchFile = envPatchMap[obs.type] ?? TERRAIN_PATCH_MAP._default?.[obs.type]
     if (patchFile) {
       const tileRadius = Math.max(1, Math.round(obs.radius * h / (500 * TILE_SIZE)))
@@ -305,28 +306,44 @@ export async function buildTerrainDecorGfx(
           }
         }
       }
+      // Remove center cell so SCENERY/PATH tiles don't occupy it
+      const centerKey = `${tcx},${tcy}`
+      const ringSet = new Set(pathSet)
+      ringSet.delete(centerKey)
+
       const patchContainer = new PIXI.Container()
       container.addChild(patchContainer)
       if (obs.type === 'water') {
-        await renderPathTiles(patchContainer, pathSet, undefined, patchFile)
+        await renderPathTiles(patchContainer, ringSet, undefined, patchFile)
       } else {
-        await renderSceneryPatch(patchContainer, pathSet, patchFile)
+        await renderSceneryPatch(patchContainer, ringSet, patchFile)
       }
       if (container.destroyed) return
+
+      // Place WORLD_DECOR tile in the center cell (separate from SCENERY/PATH ring)
+      const tileIds = (envDecorMap[obs.type] ?? TERRAIN_DECOR_MAP._default?.[obs.type]) as number[] | undefined
+      if (tileIds?.length) {
+        const tileId = tileIds[idNum % tileIds.length]
+        const decorUrl = `${base}${WORLD_DECOR_FILE.slice(1)}`
+        const tex = await loadTileTexture(decorUrl, tileId, 8)
+        if (container.destroyed) return
+        const s = new PIXI.Sprite(tex)
+        s.position.set(tcx * TILE_SIZE, tcy * TILE_SIZE)
+        container.addChild(s)
+      }
       continue
     }
 
     // ── Ruin: single WORLD_DECOR tile (gravestone, house, …) ────────────────
     if (obs.type === 'ruin') {
-      const tileIds = envDecorMap['ruin'] ?? TERRAIN_DECOR_MAP._default?.['ruin'] ?? []
+      const tileIds = (envDecorMap['ruin'] ?? TERRAIN_DECOR_MAP._default?.['ruin']) as number[] | undefined ?? []
       if (tileIds.length === 0) continue
       const tileId = tileIds[idNum % tileIds.length]
       const decorUrl = `${base}${WORLD_DECOR_FILE.slice(1)}`
       const tex = await loadTileTexture(decorUrl, tileId, 8)
       if (container.destroyed) return
       const s = new PIXI.Sprite(tex)
-      s.anchor.set(0.5)
-      s.position.set(cx, cy)
+      s.position.set(Math.round(cx / TILE_SIZE) * TILE_SIZE, Math.round(cy / TILE_SIZE) * TILE_SIZE)
       container.addChild(s)
     }
   }


### PR DESCRIPTION
## Summary

- Each terrain obstacle now renders two layers in **separate grid cells** — SCENERY/PATH tiles never share a cell with WORLD_DECOR tiles
- **Outer ring**: SCENERY (tree/rock) or PATH (water) adjacency-tiled patch with the center cell excluded
- **Center cell**: a single WORLD_DECOR tile identifying the obstacle — `pond` for water, `bigTree`/`groupOfTrees` for trees, `pileOfRocks`/`rock` for rocks, graves/houses/signposts for ruins
- `TERRAIN_DECOR_MAP` expanded from ruins-only to all four terrain types (`tree`, `rock`, `water`, `ruin`) with per-environment overrides
- Background `buildDecorGfx` scatter restored for ambient visual richness
- `WORLD_DECOR` import added to `terrainLayer.ts`

## Test plan

- [ ] Forest environment battle: tree obstacles show a forest SCENERY ring with a tree WORLD_DECOR tile at the center; units steer around them
- [ ] Water obstacle shows a water PATH ring with a pond tile at the center
- [ ] Rock obstacle shows a rocks SCENERY ring with a pileOfRocks tile at the center
- [ ] Ruin obstacle shows a single gravestone/signpost WORLD_DECOR tile (no ring — ruins have no TERRAIN_PATCH_MAP entry)
- [ ] No two tile types occupy the same grid cell

https://claude.ai/code/session_01MBDpW8x7FL9TbT6E8j1Nkn