### PR TITLE
fix(hub): add required args to Browser story to fix TS2322 build error

### DIFF
--- a/web/src/components/hub/HubInteriorViewer.stories.tsx
+++ b/web/src/components/hub/HubInteriorViewer.stories.tsx
@@ -16,6 +16,7 @@ const INTERIOR_IDS = Object.keys(HUB_INTERIORS)
 // ── Browser: pick any interior from a dropdown ─────────────────────────────
 
 export const Browser: Story = {
+  args: { interiorId: INTERIOR_IDS[0] ?? '' },
   render: () => {
     const [selected, setSelected] = useState(INTERIOR_IDS[0])
     const interior = HUB_INTERIORS[selected]


### PR DESCRIPTION
## Summary

- The `Browser` story in `HubInteriorViewer.stories.tsx` was missing the required `args` field
- TypeScript's `StoryAnnotations` type requires `args: { interiorId: string }` because `interiorId` is a required prop on `HubInteriorViewer`
- The `render` function manages its own state (ignoring args), so `args` just needs a valid placeholder value
- Added `args: { interiorId: INTERIOR_IDS[0] ?? '' }` to satisfy the type constraint without changing runtime behaviour

## Test plan

- [ ] `npm run build` completes with no TypeScript errors
- [ ] Storybook Browser story still shows the interior dropdown as before

https://claude.ai/code/session_01AgAJ4h3SoTA4pyHUw4agEy

---
_Generated by [Claude Code](https://claude.ai/code/session_01AgAJ4h3SoTA4pyHUw4agEy)_