### PR TITLE
feat(hub): living world — clock, multi-room interiors, NPC schedules

### DIFF
--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -70,6 +70,8 @@ interface Props {
   completedQuestIdsRef?: React.MutableRefObject<Set<string>>
   collectedTreasureIds?: Set<string>
   onTreasureStep?:       (id: string) => void
+  gameHour?:             number
+  isNight?:              boolean
 }
 
 export function HubTownCanvas({
@@ -78,6 +80,7 @@ export function HubTownCanvas({
   interiorEnterRef, interiorExitRef, onExitInterior, onTileTap,
   pickedUpIds, onItemPickup, doorKeys, onDoorLocked, questNpcState, activeQuestIdsRef,
   completedQuestIdsRef, collectedTreasureIds, onTreasureStep,
+  gameHour, isNight,
 }: Props) {
   const containerRef      = useRef<HTMLDivElement>(null)
   const onAreaRef         = useRef(onAreaEnter)
@@ -105,6 +108,8 @@ export function HubTownCanvas({
   const collectedTreasureRef  = useRef<Set<string>>(new Set(collectedTreasureIds))
   const onTreasureStepRef     = useRef(onTreasureStep)
   onTreasureStepRef.current   = onTreasureStep
+  const isNightRef            = useRef(isNight ?? false)
+  isNightRef.current          = isNight ?? false
 
   usePixiApp(containerRef, MAP_W, MAP_H, (app) => {
     app.canvas.style.touchAction = 'pan-x pan-y'
@@ -731,7 +736,7 @@ export function HubTownCanvas({
 
       texPromise.then(tex => {
         if (app.renderer == null) return
-        const isGhost = Math.random() < 0.01  // 1% chance to spawn as a ghost
+        const isGhost = Math.random() < (isNightRef.current ? 0.10 : 0.01)
         const s = new PIXI.Sprite(tex)
         s.width = SPRITE_SIZE; s.height = SPRITE_SIZE
         s.anchor.set(0.5, 1)
@@ -836,7 +841,7 @@ export function HubTownCanvas({
         : loadTextureUrl(`${base}sprites/${slug}.svg`).catch(() => loadTextureUrl(`${base}sprites/hub-avatar.svg`))
       texPromise.then(tex => {
         if (app.renderer == null) return
-        const isGhost = Math.random() < 0.01
+        const isGhost = Math.random() < (isNightRef.current ? 0.10 : 0.01)
         const s = new PIXI.Sprite(tex)
         s.width = SPRITE_SIZE; s.height = SPRITE_SIZE
         s.anchor.set(0.5, 1)

--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -8,6 +8,7 @@ import { PATH_TILE, TILESET_IMAGE, TILESET_COLUMNS } from '../../data/tiles/tile
 import { findPath, nearestWalkable } from '../../utils/hubPathfinder'
 import { MAP_W, MAP_H, HUB_AREAS, HUB_STREET_TILES, HUB_STREET_GROUPS, HUB_BUILDINGS, AVATAR_START, NPC_SPAWN_TILES, AMBIENT_NPC_SPRITES, EXTERIOR_NPCS, INTERIOR_NPCS, HUB_DOORS, HUB_INTERIORS, EXTERIOR_DECOR, HUB_WINDOWS, HUB_POND_TILES, HUB_PICKUP_ITEMS, HUB_LOCKED_DOORS, HUB_BLOCKED_PATHS, HUB_TREASURES } from '../../data/hub/loader'
 import type { HubInteriorExit } from '../../data/hub/loader'
+import { isBuildingOpen } from '../../game/hub/hubNpcSchedule'
 import { getWallTile, ROOF_TILES, WALL_TILES, ROOF_ROWS } from '../../data/tiles/buildingMaterials'
 import type { WallMaterial, RoofMaterial } from '../../data/tiles/buildingMaterials'
 import { loadPlayerAvatar } from '../../game/questline'
@@ -111,6 +112,8 @@ export function HubTownCanvas({
   onTreasureStepRef.current   = onTreasureStep
   const isNightRef            = useRef(isNight ?? false)
   isNightRef.current          = isNight ?? false
+  const gameHourRef           = useRef(gameHour ?? 12)
+  gameHourRef.current         = gameHour ?? 12
 
   usePixiApp(containerRef, MAP_W, MAP_H, (app) => {
     app.canvas.style.touchAction = 'pan-x pan-y'
@@ -963,6 +966,12 @@ export function HubTownCanvas({
       const interior = HUB_INTERIORS[buildingId]
       if (!interior) return
 
+      // Building hours check — block entry if closed
+      if (!isBuildingOpen(interior, gameHourRef.current)) {
+        onDoorLockedRef.current?.(buildingId, 'closed')
+        return
+      }
+
       const intW = interior.width * T
       const intH = interior.height * T
       intOffX = Math.floor((MAP_W - intW) / 2)
@@ -1333,7 +1342,7 @@ export function HubTownCanvas({
             return
           }
           if (roomExit.requiredQuest && !completedQuestIdsRef.current?.has(roomExit.requiredQuest)) {
-            onDoorLockedRef.current?.(roomExit.toInteriorId, roomExit.requiredQuest)
+            onDoorLockedRef.current?.(roomExit.toInteriorId, `quest:${roomExit.requiredQuest}`)
             processInteriorWalkQueue()
             return
           }

--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -7,6 +7,7 @@ import { loadSpriteTexture, loadTextureUrl, loadAnimFrames, loadTileTexture } fr
 import { PATH_TILE, TILESET_IMAGE, TILESET_COLUMNS } from '../../data/tiles/tileIndex'
 import { findPath, nearestWalkable } from '../../utils/hubPathfinder'
 import { MAP_W, MAP_H, HUB_AREAS, HUB_STREET_TILES, HUB_STREET_GROUPS, HUB_BUILDINGS, AVATAR_START, NPC_SPAWN_TILES, AMBIENT_NPC_SPRITES, EXTERIOR_NPCS, INTERIOR_NPCS, HUB_DOORS, HUB_INTERIORS, EXTERIOR_DECOR, HUB_WINDOWS, HUB_POND_TILES, HUB_PICKUP_ITEMS, HUB_LOCKED_DOORS, HUB_BLOCKED_PATHS, HUB_TREASURES } from '../../data/hub/loader'
+import type { HubInteriorExit } from '../../data/hub/loader'
 import { getWallTile, ROOF_TILES, WALL_TILES, ROOF_ROWS } from '../../data/tiles/buildingMaterials'
 import type { WallMaterial, RoofMaterial } from '../../data/tiles/buildingMaterials'
 import { loadPlayerAvatar } from '../../game/questline'
@@ -883,6 +884,7 @@ export function HubTownCanvas({
     let interiorWalkQueue:  [number, number][] = []
     let interiorIsWalking   = false
     let interiorExitTile:   [number, number] = [0, 0]
+    let exitByTile = new Map<string, HubInteriorExit>()
     let intOffX = 0
     let intOffY = 0
 
@@ -949,7 +951,7 @@ export function HubTownCanvas({
     }
 
     // ── Interior enter ─────────────────────────────────────────────────────────
-    const doEnterInterior = (buildingId: string) => {
+    const doEnterInterior = (buildingId: string, entryTx?: number, entryTy?: number) => {
       try {
       // Locked door check — block entry if key not in inventory
       const lock = HUB_LOCKED_DOORS.find(l => l.buildingId === buildingId)
@@ -997,22 +999,29 @@ export function HubTownCanvas({
 
       // Set interior state
       const exitTx: number = Math.floor(interior.width / 2)
-      const entryTile: [number, number] = [exitTx, interior.height - 2]
-      interiorCurrentTile = entryTile
+      const isSubRoom = entryTx !== undefined || entryTy !== undefined
+      const defaultEntryTile: [number, number] = [entryTx ?? exitTx, entryTy ?? (interior.height - 2)]
+      interiorCurrentTile = defaultEntryTile
       currentInteriorId   = buildingId
-      interiorExitTile    = [exitTx, interior.height - 1]
+      interiorExitTile    = isSubRoom ? [-1, -1] : [exitTx, interior.height - 1]
       interiorActive      = true
       interiorIsWalking   = false
       interiorWalkQueue   = []
+      exitByTile          = new Map<string, HubInteriorExit>()
 
       // Build walkable set
       interiorWalkable = new Set<string>()
       for (let tx = 1; tx < interior.width - 1; tx++)
         for (let ty = 1; ty < interior.height - 1; ty++)
           interiorWalkable.add(`${tx},${ty}`)
-      interiorWalkable.add(`${exitTx},${interior.height - 1}`)
+      if (!isSubRoom) interiorWalkable.add(`${exitTx},${interior.height - 1}`)
       for (const d of interior.decor) {
         if (!d.zlayer || d.zlayer === 'solid') interiorWalkable.delete(`${d.tx},${d.ty}`)
+      }
+      // Register inter-room exit tiles
+      for (const exit of interior.exits ?? []) {
+        interiorWalkable.add(`${exit.tx},${exit.ty}`)
+        exitByTile.set(`${exit.tx},${exit.ty}`, exit)
       }
 
       // Floor tile set (all inner tiles + exit door tile)
@@ -1020,9 +1029,9 @@ export function HubTownCanvas({
       for (let tx = 1; tx < interior.width - 1; tx++)
         for (let ty = 1; ty < interior.height - 1; ty++)
           floorSet.add(`${tx},${ty}`)
-      floorSet.add(`${exitTx},${interior.height - 1}`)  // exit door opening
+      if (!isSubRoom) floorSet.add(`${exitTx},${interior.height - 1}`)  // exit door opening
 
-      // Wall tile set (border, minus exit door opening)
+      // Wall tile set (border, minus exit door opening for ground-level rooms)
       const wallSet = new Set<string>()
       for (let tx = 0; tx < interior.width; tx++) {
         wallSet.add(`${tx},0`)
@@ -1032,7 +1041,7 @@ export function HubTownCanvas({
         wallSet.add(`0,${ty}`)
         wallSet.add(`${interior.width - 1},${ty}`)
       }
-      wallSet.delete(`${exitTx},${interior.height - 1}`)  // open door gap
+      if (!isSubRoom) wallSet.delete(`${exitTx},${interior.height - 1}`)  // open door gap
 
       // Render tile layers (async — tiles appear as they load)
       const floorContainer = new PIXI.Container()
@@ -1051,10 +1060,12 @@ export function HubTownCanvas({
             floorContainer.addChild(s)
           }
         }
-        // Exit door tile also gets floor
-        const exitFloor = new PIXI.Sprite(floorTex)
-        exitFloor.position.set(exitTx * T, (interior.height - 1) * T)
-        floorContainer.addChild(exitFloor)
+        // Exit door tile also gets floor (only for ground-level rooms with a bottom door)
+        if (!isSubRoom) {
+          const exitFloor = new PIXI.Sprite(floorTex)
+          exitFloor.position.set(exitTx * T, (interior.height - 1) * T)
+          floorContainer.addChild(exitFloor)
+        }
       }).catch(() => {
         renderPathTiles(floorContainer, floorSet, undefined, PATH_TILE.dirt1).catch(() => {})
       })
@@ -1227,8 +1238,8 @@ export function HubTownCanvas({
       // Move avatar into interior (on top of solid/below decor)
       if (avatar) {
         if (!avatarInInterior) avatarLayer.removeChild(avatar)
-        avatar.x = entryTile[0] * T + T / 2
-        avatar.y = entryTile[1] * T + T
+        avatar.x = defaultEntryTile[0] * T + T / 2
+        avatar.y = defaultEntryTile[1] * T + T
         interiorLayer.addChild(avatar)
         avatarInInterior = true
       }
@@ -1267,7 +1278,7 @@ export function HubTownCanvas({
       }
 
       // Scroll viewport to center on interior
-      onAvatarMoveRef.current(intOffX + entryTile[0] * T + T / 2, intOffY + entryTile[1] * T + T / 2)
+      onAvatarMoveRef.current(intOffX + defaultEntryTile[0] * T + T / 2, intOffY + defaultEntryTile[1] * T + T / 2)
       } catch (e) {
         rollbar.error('[HubTownCanvas] doEnterInterior error', { buildingId, error: String(e) })
       }
@@ -1310,6 +1321,23 @@ export function HubTownCanvas({
         if (ntx === interiorExitTile[0] && nty === interiorExitTile[1]) {
           interiorIsWalking = false
           doExitInterior()
+          return
+        }
+        const roomExit = exitByTile.get(`${ntx},${nty}`)
+        if (roomExit) {
+          interiorIsWalking = false
+          // Lock checks
+          if (roomExit.lockedBy && !doorKeysRef.current?.has(roomExit.lockedBy)) {
+            onDoorLockedRef.current?.(roomExit.toInteriorId, roomExit.lockedBy)
+            processInteriorWalkQueue()
+            return
+          }
+          if (roomExit.requiredQuest && !completedQuestIdsRef.current?.has(roomExit.requiredQuest)) {
+            onDoorLockedRef.current?.(roomExit.toInteriorId, roomExit.requiredQuest)
+            processInteriorWalkQueue()
+            return
+          }
+          doEnterInterior(roomExit.toInteriorId, roomExit.entryTx, roomExit.entryTy)
           return
         }
         processInteriorWalkQueue()

--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -8,7 +8,7 @@ import { PATH_TILE, TILESET_IMAGE, TILESET_COLUMNS } from '../../data/tiles/tile
 import { findPath, nearestWalkable } from '../../utils/hubPathfinder'
 import { MAP_W, MAP_H, HUB_AREAS, HUB_STREET_TILES, HUB_STREET_GROUPS, HUB_BUILDINGS, AVATAR_START, NPC_SPAWN_TILES, AMBIENT_NPC_SPRITES, EXTERIOR_NPCS, INTERIOR_NPCS, HUB_DOORS, HUB_INTERIORS, EXTERIOR_DECOR, HUB_WINDOWS, HUB_POND_TILES, HUB_PICKUP_ITEMS, HUB_LOCKED_DOORS, HUB_BLOCKED_PATHS, HUB_TREASURES } from '../../data/hub/loader'
 import type { HubInteriorExit } from '../../data/hub/loader'
-import { isBuildingOpen } from '../../game/hub/hubNpcSchedule'
+import { isBuildingOpen, getNpcLocation } from '../../game/hub/hubNpcSchedule'
 import { getWallTile, ROOF_TILES, WALL_TILES, ROOF_ROWS } from '../../data/tiles/buildingMaterials'
 import type { WallMaterial, RoofMaterial } from '../../data/tiles/buildingMaterials'
 import { loadPlayerAvatar } from '../../game/questline'
@@ -618,6 +618,8 @@ export function HubTownCanvas({
     // Quest indicators: keyed by npcId, updated imperatively in the ticker
     const questIndicators     = new Map<string, PIXI.Text>()
     const questIndicatorBaseY = new Map<string, number>()
+    // Named NPC containers: keyed by npcId for schedule-driven visibility
+    const namedNpcContainers  = new Map<string, PIXI.Container>()
     // Interior quest indicators: rebuilt each time we enter a building
     const interiorQuestIndicators     = new Map<string, PIXI.Text>()
     const interiorIndicatorBaseY      = new Map<string, number>()
@@ -641,6 +643,7 @@ export function HubTownCanvas({
         }
       })
       npcLayer.addChild(npcContainer)
+      namedNpcContainers.set(npc.id, npcContainer)
       if (npc.dialogue.length > 0) npcBubbleTargets.push({ npc, cx, cy })
 
       if (npc.questGive || npc.questReceive) {
@@ -1212,6 +1215,34 @@ export function HubTownCanvas({
         }).catch(() => {})
       }
 
+      // Scheduled exterior NPCs — render inside this building when their schedule says so
+      const scheduledVisitors = EXTERIOR_NPCS.filter(npc => {
+        if (!npc.schedule) return false
+        const loc = getNpcLocation(npc, gameHourRef.current)
+        return loc?.type === 'interior' && loc.buildingId === buildingId
+      })
+      for (const npc of scheduledVisitors) {
+        const loc = getNpcLocation(npc, gameHourRef.current) as { type: 'interior'; buildingId: string; tx: number; ty: number }
+        loadTextureUrl(`${base}sprites/${npc.sprite}.svg`).then(tex => {
+          if (!interiorActive || currentInteriorId !== buildingId) return
+          const s = new PIXI.Sprite(tex)
+          s.width = SPRITE_SIZE; s.height = SPRITE_SIZE
+          s.anchor.set(0.5, 1)
+          s.position.set(loc.tx * T + T / 2, loc.ty * T + T)
+          s.eventMode = 'static'
+          s.cursor    = 'pointer'
+          s.on('pointerdown', (e: PIXI.FederatedPointerEvent) => {
+            e.stopPropagation()
+            if (npc.dialogue.length > 0 || npc.questGive || npc.questReceive) {
+              const idx = npcDialogueIndex.get(npc.id) ?? 0
+              onNpcTapRef.current?.(npc.dialogue[idx % npc.dialogue.length] ?? '', npc.id)
+              npcDialogueIndex.set(npc.id, idx + 1)
+            }
+          })
+          interiorLayer.addChild(s)
+        }).catch(() => {})
+      }
+
       // Quest indicators for interior NPCs
       interiorQuestIndicators.clear()
       interiorIndicatorBaseY.clear()
@@ -1235,14 +1266,27 @@ export function HubTownCanvas({
       nameLabel.position.set(T + 4, 4)
       interiorLayer.addChild(nameLabel)
 
-      // Exit marker
-      const exitMarker = new PIXI.Text({
-        text: '▼ EXIT',
-        style: { fontSize: 8, fill: '#88ff88', fontFamily: 'monospace', fontWeight: 'bold' },
-      })
-      exitMarker.anchor.set(0.5, 0)
-      exitMarker.position.set(exitTx * T + T / 2, (interior.height - 1) * T + 2)
-      interiorLayer.addChild(exitMarker)
+      // Exit marker (standard "leave building" exit, only for ground-level rooms)
+      if (!isSubRoom) {
+        const exitMarker = new PIXI.Text({
+          text: '▼ EXIT',
+          style: { fontSize: 8, fill: '#88ff88', fontFamily: 'monospace', fontWeight: 'bold' },
+        })
+        exitMarker.anchor.set(0.5, 0)
+        exitMarker.position.set(exitTx * T + T / 2, (interior.height - 1) * T + 2)
+        interiorLayer.addChild(exitMarker)
+      }
+      // Room-exit direction markers (stairs, passages)
+      for (const exit of interior.exits ?? []) {
+        const arrow = exit.direction === 'up' ? '▲' : exit.direction === 'down' ? '▼' : '→'
+        const marker = new PIXI.Text({
+          text: arrow,
+          style: { fontSize: 10, fill: '#aaddff', fontFamily: 'monospace', fontWeight: 'bold' },
+        })
+        marker.anchor.set(0.5, 1)
+        marker.position.set(exit.tx * T + T / 2, exit.ty * T)
+        interiorLayer.addChild(marker)
+      }
 
       // Move avatar into interior (on top of solid/below decor)
       if (avatar) {
@@ -1665,6 +1709,16 @@ export function HubTownCanvas({
         if (state !== null) {
           const baseY = activeBaseY.get(npcId) ?? ind.y
           ind.y = baseY + Math.sin(performance.now() / 400) * 3
+        }
+      }
+
+      // Named NPC visibility — hide when schedule says they're inside a building
+      if (!interiorActive) {
+        for (const [npcId, container] of namedNpcContainers) {
+          const npc = EXTERIOR_NPCS.find(n => n.id === npcId)
+          if (!npc?.schedule) continue
+          const loc = getNpcLocation(npc, gameHourRef.current)
+          container.visible = !loc || loc.type === 'exterior'
         }
       }
 

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -30,7 +30,7 @@ import { QuestsModal } from './QuestsModal'
 import { TreasureModal } from './TreasureModal'
 import { getCollectedTreasureIds, markTreasureCollected } from '../../game/hub/treasures'
 import { useHubClock } from '../../hooks/useHubClock'
-import { formatGameTime } from '../../game/hub/hubClock'
+import { formatGameTime, hourInRange } from '../../game/hub/hubClock'
 
 const T = 32
 const INITIAL_SCROLL = {
@@ -113,6 +113,8 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onPlayerTap, crystals
   const [_tick, setTick] = useState(0)
   const refreshState = useCallback(() => setTick(t => t + 1), [])
 
+  const { gameHour, isNight: isGameNight } = useHubClock()
+
   // Quest NPC state: maps npcId → 'offer' | 'ready' | null, read imperatively by PixiJS ticker
   const questNpcStateRef = useRef(new Map<string, 'offer' | 'ready' | null>())
   {
@@ -123,7 +125,8 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onPlayerTap, crystals
       const state = getQuestState(quest.id)
       if (state.status === 'available') {
         const prereqMet = !quest.prerequisite || checkPrerequisite(quest.prerequisite)
-        if (prereqMet && !atCap) m.set(quest.giverNpcId, 'offer')
+        const hoursMet  = !quest.availableHours || hourInRange(gameHour, quest.availableHours.start, quest.availableHours.end)
+        if (prereqMet && hoursMet && !atCap) m.set(quest.giverNpcId, 'offer')
       } else if (state.status === 'active') {
         if (isQuestReadyToComplete(quest)) m.set(quest.receiverNpcId, 'ready')
       }
@@ -191,8 +194,6 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onPlayerTap, crystals
       catalogTotal: catalog.length,
     }
   }, [])
-
-  const { gameHour, isNight: isGameNight } = useHubClock()
 
   // Keys the player currently holds (determines locked door access)
   const doorKeys = useMemo(() => {
@@ -350,9 +351,15 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onPlayerTap, crystals
     }
   }, [refreshState])
 
-  const handleDoorLocked = useCallback((buildingId: string, requiredItem: string) => {
-    const itemName = requiredItem.replace(/-/g, ' ')
-    setDialogueLine(`This door is locked. You need a ${itemName} to enter.`)
+  const handleDoorLocked = useCallback((_buildingId: string, requiredItem: string) => {
+    if (requiredItem === 'closed') {
+      setDialogueLine('This building is closed right now. Come back later.')
+    } else if (requiredItem.startsWith('quest:')) {
+      setDialogueLine("This passage is sealed. You'll need to discover it first.")
+    } else {
+      const itemName = requiredItem.replace(/-/g, ' ')
+      setDialogueLine(`This door is locked. You need a ${itemName} to enter.`)
+    }
   }, [])
 
   const handleNpcTap = useCallback((line: string, npcId: string) => {

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -29,6 +29,8 @@ import { addCollectible, addConsumable, getCollectibles } from '../../game/itemS
 import { QuestsModal } from './QuestsModal'
 import { TreasureModal } from './TreasureModal'
 import { getCollectedTreasureIds, markTreasureCollected } from '../../game/hub/treasures'
+import { useHubClock } from '../../hooks/useHubClock'
+import { formatGameTime } from '../../game/hub/hubClock'
 
 const T = 32
 const INITIAL_SCROLL = {
@@ -189,6 +191,8 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onPlayerTap, crystals
       catalogTotal: catalog.length,
     }
   }, [])
+
+  const { gameHour, isNight: isGameNight } = useHubClock()
 
   // Keys the player currently holds (determines locked door access)
   const doorKeys = useMemo(() => {
@@ -491,6 +495,7 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onPlayerTap, crystals
       <Toolbar>
         <ToolbarLabel className={`title-deck-info${wrongSave ? ' title-deck-info--glitch' : ''}`}>💎 {wrongSave ? wrongSave.crystals.toLocaleString() : crystals.toLocaleString()}</ToolbarLabel>
         <ToolbarLabel className={`title-deck-info${wrongSave ? ' title-deck-info--glitch' : ''}`}>🃏 {wrongSave ? wrongSave.cards : collectionCount}/{catalogTotal}</ToolbarLabel>
+        <ToolbarLabel className="title-deck-info">{isGameNight ? '🌙' : '☀️'} {formatGameTime()}</ToolbarLabel>
         <ToolbarButton icon="📜" title="Quests" onClick={() => setQuestsOpen(true)} />
         <ToolbarSpacer/>
         <LoginButton onSignIn={() => onLoginToggle?.()} onSignOut={() => onSignOut?.()} onPlayerTap={onPlayerTap} user={user} playerName={playerName} />
@@ -532,6 +537,8 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onPlayerTap, crystals
             completedQuestIdsRef={completedQuestIdsRef}
             collectedTreasureIds={collectedTreasureIds}
             onTreasureStep={handleTreasureStep}
+            gameHour={gameHour}
+            isNight={isGameNight}
           />
         </div>
         <AreaNameBadge name={currentArea} />

--- a/web/src/data/hub/config.json
+++ b/web/src/data/hub/config.json
@@ -1,10 +1,12 @@
 {
   "mapW": 2400,
   "mapH": 1600,
-  "avatarStart": [37, 29],
-
+  "avatarStart": [
+    37,
+    29
+  ],
   "areas": [
-        {
+    {
       "id": "townhall",
       "name": "The Townhall",
       "tx": 30,
@@ -78,484 +80,2253 @@
     }
   ],
   "streets": [
-    { "rect": [0, 23, 35, 25] },
-    { "rect": [39, 23, 74, 25] },
-    { "rect": [36,7, 38, 23] },
-    { "rect": [36, 26, 38, 39] },
-
-    { "rect": [33, 21, 35, 28] },
-    { "rect": [39, 21, 41, 28] },
-
-
-
-
-    { "rect": [35, 39, 41, 39] },
-    { "rect": [55, 5, 57, 23] },
-    { "rect": [55, 8, 74, 10] },
-    { "rect": [14, 26, 16, 45] },
-    { "rect": [0, 35, 16, 36] },
-    { "rect": [18, 2, 19, 23] },
-    { "rect": [18, 11, 38, 12] },
-    { "rect": [0, 12, 20, 13] },
-    { "tile": [6, 11] },
-    { "tile": [7, 11] },
-    { "rect": [14, 11, 14, 13] },
-    { "tile": [8, 14] },
-    { "rect": [25, 20, 26,23] },
-    { "rect": [25, 10, 26,10] },    
-    { "tile": [56, 11] },
-
-    { "tile": [8,  22] },
-    { "tile": [10, 34] },
-    { "rect": [47, 7, 65, 7] },
-    { "rect": [47, 20, 65, 20] },
-    { "rect": [14, 46, 14, 48] },
-    { "rect": [6, 48, 25, 48] },
-    { "rect": [17, 34, 25, 34] },
-    { "rect": [38, 35, 48, 35] },
-    { "rect": [42, 48, 48, 48] },
-    { "rect": [57, 26, 57, 48] },
-    { "rect": [58, 35, 65, 35] },
-    {"rect":[42, 39,42, 48]},
-    { "rect": [58, 48, 65, 48] },
-    {"tile":[66, 48]},
-    {"tile":[67, 48]},
-    {"tile":[68, 48]},
-    {"tile":[69, 48]},
-    {"tile":[70, 48]},
-    {"tile":[71, 48]},
-    {"tile":[72, 48]},
-     {"tile":[65, 47]},
-     {"tile":[72, 47]},
-              {"rect": [0,27, 6, 32], "pathType": "longGrass"},
-         {"tile": [3, 33]},
-         {"tile": [3, 34]},
-
-    {"rect": [30, 34, 35, 34], "pathType": "longGrass"},
-    {"rect": [30, 31, 33, 36], "pathType": "longGrass"}
+    {
+      "rect": [
+        0,
+        23,
+        35,
+        25
+      ]
+    },
+    {
+      "rect": [
+        39,
+        23,
+        74,
+        25
+      ]
+    },
+    {
+      "rect": [
+        36,
+        7,
+        38,
+        23
+      ]
+    },
+    {
+      "rect": [
+        36,
+        26,
+        38,
+        39
+      ]
+    },
+    {
+      "rect": [
+        33,
+        21,
+        35,
+        28
+      ]
+    },
+    {
+      "rect": [
+        39,
+        21,
+        41,
+        28
+      ]
+    },
+    {
+      "rect": [
+        35,
+        39,
+        41,
+        39
+      ]
+    },
+    {
+      "rect": [
+        55,
+        5,
+        57,
+        23
+      ]
+    },
+    {
+      "rect": [
+        55,
+        8,
+        74,
+        10
+      ]
+    },
+    {
+      "rect": [
+        14,
+        26,
+        16,
+        45
+      ]
+    },
+    {
+      "rect": [
+        0,
+        35,
+        16,
+        36
+      ]
+    },
+    {
+      "rect": [
+        18,
+        2,
+        19,
+        23
+      ]
+    },
+    {
+      "rect": [
+        18,
+        11,
+        38,
+        12
+      ]
+    },
+    {
+      "rect": [
+        0,
+        12,
+        20,
+        13
+      ]
+    },
+    {
+      "tile": [
+        6,
+        11
+      ]
+    },
+    {
+      "tile": [
+        7,
+        11
+      ]
+    },
+    {
+      "rect": [
+        14,
+        11,
+        14,
+        13
+      ]
+    },
+    {
+      "tile": [
+        8,
+        14
+      ]
+    },
+    {
+      "rect": [
+        25,
+        20,
+        26,
+        23
+      ]
+    },
+    {
+      "rect": [
+        25,
+        10,
+        26,
+        10
+      ]
+    },
+    {
+      "tile": [
+        56,
+        11
+      ]
+    },
+    {
+      "tile": [
+        8,
+        22
+      ]
+    },
+    {
+      "tile": [
+        10,
+        34
+      ]
+    },
+    {
+      "rect": [
+        47,
+        7,
+        65,
+        7
+      ]
+    },
+    {
+      "rect": [
+        47,
+        20,
+        65,
+        20
+      ]
+    },
+    {
+      "rect": [
+        14,
+        46,
+        14,
+        48
+      ]
+    },
+    {
+      "rect": [
+        6,
+        48,
+        25,
+        48
+      ]
+    },
+    {
+      "rect": [
+        17,
+        34,
+        25,
+        34
+      ]
+    },
+    {
+      "rect": [
+        38,
+        35,
+        48,
+        35
+      ]
+    },
+    {
+      "rect": [
+        42,
+        48,
+        48,
+        48
+      ]
+    },
+    {
+      "rect": [
+        57,
+        26,
+        57,
+        48
+      ]
+    },
+    {
+      "rect": [
+        58,
+        35,
+        65,
+        35
+      ]
+    },
+    {
+      "rect": [
+        42,
+        39,
+        42,
+        48
+      ]
+    },
+    {
+      "rect": [
+        58,
+        48,
+        65,
+        48
+      ]
+    },
+    {
+      "tile": [
+        66,
+        48
+      ]
+    },
+    {
+      "tile": [
+        67,
+        48
+      ]
+    },
+    {
+      "tile": [
+        68,
+        48
+      ]
+    },
+    {
+      "tile": [
+        69,
+        48
+      ]
+    },
+    {
+      "tile": [
+        70,
+        48
+      ]
+    },
+    {
+      "tile": [
+        71,
+        48
+      ]
+    },
+    {
+      "tile": [
+        72,
+        48
+      ]
+    },
+    {
+      "tile": [
+        65,
+        47
+      ]
+    },
+    {
+      "tile": [
+        72,
+        47
+      ]
+    },
+    {
+      "rect": [
+        0,
+        27,
+        6,
+        32
+      ],
+      "pathType": "longGrass"
+    },
+    {
+      "tile": [
+        3,
+        33
+      ]
+    },
+    {
+      "tile": [
+        3,
+        34
+      ]
+    },
+    {
+      "rect": [
+        30,
+        34,
+        35,
+        34
+      ],
+      "pathType": "longGrass"
+    },
+    {
+      "rect": [
+        30,
+        31,
+        33,
+        36
+      ],
+      "pathType": "longGrass"
+    }
   ],
   "buildings": [
     {
-      "rect": [2, 4, 9, 10], "id": "card-shop-bldg", "wall": "brick", "roof": "woodRoof",
-      "doors":   [{ "tx": 4, "ty": 1, "buildingId": "card-shop" }],
-      "windows": [{ "tx": 2, "ty": -2, "tileId": "windowTop" }, { "tx": 2, "ty": -1, "tileId": "windowBottom" },
-                  { "tx": 5, "ty": -2, "tileId": "windowTop"  }, { "tx": 5, "ty": -1, "tileId": "windowBottom" }]
+      "rect": [
+        2,
+        4,
+        9,
+        10
+      ],
+      "id": "card-shop-bldg",
+      "wall": "brick",
+      "roof": "woodRoof",
+      "doors": [
+        {
+          "tx": 4,
+          "ty": 1,
+          "buildingId": "card-shop"
+        }
+      ],
+      "windows": [
+        {
+          "tx": 2,
+          "ty": -2,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 2,
+          "ty": -1,
+          "tileId": "windowBottom"
+        },
+        {
+          "tx": 5,
+          "ty": -2,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 5,
+          "ty": -1,
+          "tileId": "windowBottom"
+        }
+      ]
     },
     {
-      "rect": [11, 4, 17, 10], "id": "augment-shop-bldg", "wall": "woodenSlats", "roof": "redSlateRoof",
-      "doors":   [{ "tx": 3, "ty": 1, "buildingId": "augment-shop" }],
-      "windows": [{ "tx": 1, "ty": -2, "tileId": "windowTop2" }, { "tx": 1, "ty": -1, "tileId": "windowBottom2" },
-                  { "tx": 4, "ty": -2, "tileId": "windowTop2"  }, { "tx": 4, "ty": -1, "tileId": "windowBottom2" }]
+      "rect": [
+        11,
+        4,
+        17,
+        10
+      ],
+      "id": "augment-shop-bldg",
+      "wall": "woodenSlats",
+      "roof": "redSlateRoof",
+      "doors": [
+        {
+          "tx": 3,
+          "ty": 1,
+          "buildingId": "augment-shop"
+        }
+      ],
+      "windows": [
+        {
+          "tx": 1,
+          "ty": -2,
+          "tileId": "windowTop2"
+        },
+        {
+          "tx": 1,
+          "ty": -1,
+          "tileId": "windowBottom2"
+        },
+        {
+          "tx": 4,
+          "ty": -2,
+          "tileId": "windowTop2"
+        },
+        {
+          "tx": 4,
+          "ty": -1,
+          "tileId": "windowBottom2"
+        }
+      ]
     },
     {
-      "rect": [4, 15, 11, 21], "id": "south-building", "wall": "woodenSlats", "roof": "redSlateRoof",
-      "doors":   [{ "tx": 4, "ty": 1, "buildingId": "supply-shop" }],
-      "windows": [{ "tx": 1, "ty": -2, "tileId": "windowTop3" }, { "tx": 1, "ty": -1, "tileId": "windowBottom3" }]
+      "rect": [
+        4,
+        15,
+        11,
+        21
+      ],
+      "id": "south-building",
+      "wall": "woodenSlats",
+      "roof": "redSlateRoof",
+      "doors": [
+        {
+          "tx": 4,
+          "ty": 1,
+          "buildingId": "supply-shop"
+        }
+      ],
+      "windows": [
+        {
+          "tx": 1,
+          "ty": -2,
+          "tileId": "windowTop3"
+        },
+        {
+          "tx": 1,
+          "ty": -1,
+          "tileId": "windowBottom3"
+        }
+      ]
     },
     {
-      "rect": [22, 3, 29, 9], "id": "home-building", "wall": "woodWall", "roof": "yellowSlateRoof",
-      "doors":   [{ "tx": 4, "ty": 1, "buildingId": "home" }],
-      "windows": [{ "tx": 1, "ty": -2, "tileId": "windowTop4" }, { "tx": 1, "ty": -1, "tileId": "windowBottom4" }]
+      "rect": [
+        22,
+        3,
+        29,
+        9
+      ],
+      "id": "home-building",
+      "wall": "woodWall",
+      "roof": "yellowSlateRoof",
+      "doors": [
+        {
+          "tx": 4,
+          "ty": 1,
+          "buildingId": "home"
+        }
+      ],
+      "windows": [
+        {
+          "tx": 1,
+          "ty": -2,
+          "tileId": "windowTop4"
+        },
+        {
+          "tx": 1,
+          "ty": -1,
+          "tileId": "windowBottom4"
+        }
+      ]
     },
     {
-      "rect": [45, 0, 52, 6], "id": "scholars-north-w", "wall": "castleStone", "roof": "blueSlateRoof",
-      "doors":   [{ "tx": 4, "ty": 1, "buildingId": "scholars-north-w" }],
-      "windows": [{ "tx": 1, "ty": -2, "tileId": "windowTop"  }, { "tx": 1, "ty": -1, "tileId": "windowBottom"  }]
+      "rect": [
+        45,
+        0,
+        52,
+        6
+      ],
+      "id": "scholars-north-w",
+      "wall": "castleStone",
+      "roof": "blueSlateRoof",
+      "doors": [
+        {
+          "tx": 4,
+          "ty": 1,
+          "buildingId": "scholars-north-w"
+        }
+      ],
+      "windows": [
+        {
+          "tx": 1,
+          "ty": -2,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 1,
+          "ty": -1,
+          "tileId": "windowBottom"
+        }
+      ]
     },
     {
-      "rect": [61, 0, 68, 6], "id": "scholars-north-e", "wall": "castleStone", "roof": "blueSlateRoof",
-      "doors":   [{ "tx": 4, "ty": 1, "buildingId": "scholars-north-e" }],
-      "windows": [{ "tx": 1, "ty": -2, "tileId": "windowTop2" }, { "tx": 1, "ty": -1, "tileId": "windowBottom2" }]
+      "rect": [
+        61,
+        0,
+        68,
+        6
+      ],
+      "id": "scholars-north-e",
+      "wall": "castleStone",
+      "roof": "blueSlateRoof",
+      "doors": [
+        {
+          "tx": 4,
+          "ty": 1,
+          "buildingId": "scholars-north-e"
+        }
+      ],
+      "windows": [
+        {
+          "tx": 1,
+          "ty": -2,
+          "tileId": "windowTop2"
+        },
+        {
+          "tx": 1,
+          "ty": -1,
+          "tileId": "windowBottom2"
+        }
+      ]
     },
     {
-      "rect": [43, 13, 50, 19], "id": "scholars-hall-w", "wall": "ornateStone", "roof": "blueSlateRoof",
-      "doors":   [{ "tx": 4, "ty": 1, "buildingId": "scholars-hall-w" }],
-      "windows": [{ "tx": 1, "ty": -2, "tileId": "windowTop3" }, { "tx": 1, "ty": -1, "tileId": "windowBottom3" }]
+      "rect": [
+        43,
+        13,
+        50,
+        19
+      ],
+      "id": "scholars-hall-w",
+      "wall": "ornateStone",
+      "roof": "blueSlateRoof",
+      "doors": [
+        {
+          "tx": 4,
+          "ty": 1,
+          "buildingId": "scholars-hall-w"
+        }
+      ],
+      "windows": [
+        {
+          "tx": 1,
+          "ty": -2,
+          "tileId": "windowTop3"
+        },
+        {
+          "tx": 1,
+          "ty": -1,
+          "tileId": "windowBottom3"
+        }
+      ]
     },
     {
-      "rect": [61, 13, 68, 19], "id": "scholars-hall-e", "wall": "ornateStone", "roof": "blueSlateRoof",
-      "doors":   [{ "tx": 4, "ty": 1, "buildingId": "scholars-hall" }],
-      "windows": [{ "tx": 1, "ty": -2, "tileId": "windowTop4" }, { "tx": 1, "ty": -1, "tileId": "windowBottom4" }]
+      "rect": [
+        61,
+        13,
+        68,
+        19
+      ],
+      "id": "scholars-hall-e",
+      "wall": "ornateStone",
+      "roof": "blueSlateRoof",
+      "doors": [
+        {
+          "tx": 4,
+          "ty": 1,
+          "buildingId": "scholars-hall"
+        }
+      ],
+      "windows": [
+        {
+          "tx": 1,
+          "ty": -2,
+          "tileId": "windowTop4"
+        },
+        {
+          "tx": 1,
+          "ty": -1,
+          "tileId": "windowBottom4"
+        }
+      ]
     },
     {
       "comment": "junk traders den",
-      "rect": [7, 27, 13, 33], "id": "sw-building-a", "wall": "darkStone", "roof": "greySlateRoof",
-      "doors":   [{ "tx": 3, "ty": 1, "buildingId": "trader-den" }],
+      "rect": [
+        7,
+        27,
+        13,
+        33
+      ],
+      "id": "sw-building-a",
+      "wall": "darkStone",
+      "roof": "greySlateRoof",
+      "doors": [
+        {
+          "tx": 3,
+          "ty": 1,
+          "buildingId": "trader-den"
+        }
+      ],
       "windows": [
-        { "tx": 1, "ty": -2, "tileId": "windowTop"  }, { "tx": 1, "ty": -1, "tileId": "windowBottom"  },
-        { "tx": 5, "ty": -2, "tileId": "windowTop"  }, { "tx": 5, "ty": -1, "tileId": "windowBottom"  }
+        {
+          "tx": 1,
+          "ty": -2,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 1,
+          "ty": -1,
+          "tileId": "windowBottom"
+        },
+        {
+          "tx": 5,
+          "ty": -2,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 5,
+          "ty": -1,
+          "tileId": "windowBottom"
+        }
       ]
     },
     {
       "comment": "inn",
-      "rect": [22,13, 29, 19], "id": "sw-building-b", "wall": "renderedBrick", "roof": "strawRoof",
-      "doors":   [{ "tx": 4, "ty": 1, "buildingId": "sw-building-b" }],
+      "rect": [
+        22,
+        13,
+        29,
+        19
+      ],
+      "id": "sw-building-b",
+      "wall": "renderedBrick",
+      "roof": "strawRoof",
+      "doors": [
+        {
+          "tx": 4,
+          "ty": 1,
+          "buildingId": "sw-building-b"
+        }
+      ],
       "windows": [
-        { "tx": 1, "ty": -2, "tileId": "windowTop2" }, { "tx": 1, "ty": -1, "tileId": "windowBottom2" },
-        { "tx": 6, "ty": -2, "tileId": "windowTop2" }, { "tx": 6, "ty": -1, "tileId": "windowBottom2" }
+        {
+          "tx": 1,
+          "ty": -2,
+          "tileId": "windowTop2"
+        },
+        {
+          "tx": 1,
+          "ty": -1,
+          "tileId": "windowBottom2"
+        },
+        {
+          "tx": 6,
+          "ty": -2,
+          "tileId": "windowTop2"
+        },
+        {
+          "tx": 6,
+          "ty": -1,
+          "tileId": "windowBottom2"
+        }
       ]
     },
     {
-      "rect": [21, 27, 28, 33], "id": "traders-building", "wall": "tudorFrame", "roof": "metalRoof",
-      "doors":   [{ "tx": 3, "ty": 1, "buildingId": "traders-building" }],
-      "windows": [{ "tx": 1, "ty": -2, "tileId": "windowTop3" }, { "tx": 1, "ty": -1, "tileId": "windowBottom3" }]
+      "rect": [
+        21,
+        27,
+        28,
+        33
+      ],
+      "id": "traders-building",
+      "wall": "tudorFrame",
+      "roof": "metalRoof",
+      "doors": [
+        {
+          "tx": 3,
+          "ty": 1,
+          "buildingId": "traders-building"
+        }
+      ],
+      "windows": [
+        {
+          "tx": 1,
+          "ty": -2,
+          "tileId": "windowTop3"
+        },
+        {
+          "tx": 1,
+          "ty": -1,
+          "tileId": "windowBottom3"
+        }
+      ]
     },
     {
-      "rect": [21, 41, 28, 47], "id": "market-building", "wall": "renderedBrick", "roof": "greySlateRoof",
-      "doors":   [{ "tx": 4, "ty": 1, "buildingId": "market-building" }],
-      "windows": [{ "tx": 1, "ty": -2, "tileId": "windowTop4" }, { "tx": 1, "ty": -1, "tileId": "windowBottom4" }]
+      "rect": [
+        21,
+        41,
+        28,
+        47
+      ],
+      "id": "market-building",
+      "wall": "renderedBrick",
+      "roof": "greySlateRoof",
+      "doors": [
+        {
+          "tx": 4,
+          "ty": 1,
+          "buildingId": "market-building"
+        }
+      ],
+      "windows": [
+        {
+          "tx": 1,
+          "ty": -2,
+          "tileId": "windowTop4"
+        },
+        {
+          "tx": 1,
+          "ty": -1,
+          "tileId": "windowBottom4"
+        }
+      ]
     },
     {
-      "rect": [44, 28, 51, 34], "id": "arcade-building-e", "wall": "whiteStone", "roof": "yellowSlateRoof",
-      "doors":   [{ "tx": 4, "ty": 1, "buildingId": "arcade-building-e" }],
-      "windows": [{ "tx": 1, "ty": -2, "tileId": "windowTop"  }, { "tx": 1, "ty": -1, "tileId": "windowBottom"  }]
+      "rect": [
+        44,
+        28,
+        51,
+        34
+      ],
+      "id": "arcade-building-e",
+      "wall": "whiteStone",
+      "roof": "yellowSlateRoof",
+      "doors": [
+        {
+          "tx": 4,
+          "ty": 1,
+          "buildingId": "arcade-building-e"
+        }
+      ],
+      "windows": [
+        {
+          "tx": 1,
+          "ty": -2,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 1,
+          "ty": -1,
+          "tileId": "windowBottom"
+        }
+      ]
     },
     {
-      "rect": [44, 41, 51, 47], "id": "arcade-building-w", "wall": "tudorFrame", "roof": "strawRoof",
-      "doors":   [{ "tx": 4, "ty": 1, "buildingId": "arcade-building-w" }],
-      "windows": [{ "tx": 1, "ty": -2, "tileId": "windowTop2" }, { "tx": 1, "ty": -1, "tileId": "windowBottom2" }]
+      "rect": [
+        44,
+        41,
+        51,
+        47
+      ],
+      "id": "arcade-building-w",
+      "wall": "tudorFrame",
+      "roof": "strawRoof",
+      "doors": [
+        {
+          "tx": 4,
+          "ty": 1,
+          "buildingId": "arcade-building-w"
+        }
+      ],
+      "windows": [
+        {
+          "tx": 1,
+          "ty": -2,
+          "tileId": "windowTop2"
+        },
+        {
+          "tx": 1,
+          "ty": -1,
+          "tileId": "windowBottom2"
+        }
+      ]
     },
     {
-      "rect": [61, 28, 68, 34], "id": "barracks-north", "wall": "reinforcedStone", "roof": "greySlateRoof",
-      "doors":   [{ "tx": 4, "ty": 1, "buildingId": "barracks-north" }],
-      "windows": [{ "tx": 1, "ty": -2, "tileId": "windowTop3" }, { "tx": 1, "ty": -1, "tileId": "windowBottom3" }]
+      "rect": [
+        61,
+        28,
+        68,
+        34
+      ],
+      "id": "barracks-north",
+      "wall": "reinforcedStone",
+      "roof": "greySlateRoof",
+      "doors": [
+        {
+          "tx": 4,
+          "ty": 1,
+          "buildingId": "barracks-north"
+        }
+      ],
+      "windows": [
+        {
+          "tx": 1,
+          "ty": -2,
+          "tileId": "windowTop3"
+        },
+        {
+          "tx": 1,
+          "ty": -1,
+          "tileId": "windowBottom3"
+        }
+      ]
     },
     {
-      "rect": [61, 40, 68, 46], "id": "barracks-south", "wall": "reinforcedStone", "roof": "greySlateRoof",
-      "doors":   [{ "tx": 4, "ty": 1, "buildingId": "barracks-south" }],
-      "windows": [{ "tx": 1, "ty": -2, "tileId": "windowTop4" }, { "tx": 1, "ty": -1, "tileId": "windowBottom4" }]
+      "rect": [
+        61,
+        40,
+        68,
+        46
+      ],
+      "id": "barracks-south",
+      "wall": "reinforcedStone",
+      "roof": "greySlateRoof",
+      "doors": [
+        {
+          "tx": 4,
+          "ty": 1,
+          "buildingId": "barracks-south"
+        }
+      ],
+      "windows": [
+        {
+          "tx": 1,
+          "ty": -2,
+          "tileId": "windowTop4"
+        },
+        {
+          "tx": 1,
+          "ty": -1,
+          "tileId": "windowBottom4"
+        }
+      ]
     },
     {
-      "rect": [70, 41, 74, 46], "id": "barracks-vault", "wall": "reinforcedStone", "roof": "greySlateRoof",
-      "doors":   [{ "tx": 2, "ty": 1, "buildingId": "barracks-vault" }]
+      "rect": [
+        70,
+        41,
+        74,
+        46
+      ],
+      "id": "barracks-vault",
+      "wall": "reinforcedStone",
+      "roof": "greySlateRoof",
+      "doors": [
+        {
+          "tx": 2,
+          "ty": 1,
+          "buildingId": "barracks-vault"
+        }
+      ]
     },
-
-    { "comment": "Town Hall" },
     {
-      "rects": [[31,0,32,9],[42,0,43,9],[33,2,41,8]],
-      "id": "townhall", "wall": "ornateStone", "roof": "greySlateRoof",
-      "doors":   [{ "tx": 6, "ty": -1, "buildingId": "town-hall" }],
-      "windows": [{ "tx": 1, "ty": -2, "tileId": "windowTop4" }, { "tx": 1, "ty": -1, "tileId": "windowBottom4" }],
+      "comment": "Town Hall"
+    },
+    {
+      "rects": [
+        [
+          31,
+          0,
+          32,
+          9
+        ],
+        [
+          42,
+          0,
+          43,
+          9
+        ],
+        [
+          33,
+          2,
+          41,
+          8
+        ]
+      ],
+      "id": "townhall",
+      "wall": "ornateStone",
+      "roof": "greySlateRoof",
+      "doors": [
+        {
+          "tx": 6,
+          "ty": -1,
+          "buildingId": "town-hall"
+        }
+      ],
+      "windows": [
+        {
+          "tx": 1,
+          "ty": -2,
+          "tileId": "windowTop4"
+        },
+        {
+          "tx": 1,
+          "ty": -1,
+          "tileId": "windowBottom4"
+        }
+      ],
       "decor": [
-          { "comment": "town hall steps - [36, 9]" },
-          { "tx": 5, "ty": -2, "tileId": "stoneStairsUpLeftTop", "zlayer": "below-avatar" },
-          { "tx": 7, "ty": -2, "tileId": "stoneStairsUpRightTop", "zlayer": "below-avatar"  },
-          { "tx": 5, "ty": -1, "tileId": "stoneStairsUpLeftMiddle", "zlayer": "below-avatar"  },
-          { "tx": 6, "ty": -1, "tileId": "stoneStairsUpMiddleMiddle", "zlayer": "below-avatar"  },
-          { "tx": 7, "ty": -1, "tileId": "stoneStairsUpRightMiddle", "zlayer": "below-avatar"  },        
-          { "tx": 5, "ty": 0, "tileId": "stoneStairsUpLeftBottom", "zlayer": "below-avatar"  },
-          { "tx": 6, "ty": 0, "tileId": "stoneStairsUpMiddleBottom", "zlayer": "below-avatar"  },
-          { "tx": 7, "ty": 0, "tileId": "stoneStairsUpRightBottom", "zlayer": "below-avatar"  },
-
-          { "tx": 2, "ty": 0, "tileId": "yellowFlower" },
-          { "tx": 3, "ty": 0, "tileId": "blueFlower" },
-          { "tx": 4, "ty": 0, "tileId": "whiteFlower" },
-
-          { "tx": 10, "ty": 0, "tileId": "yellowFlower" },
-          { "tx": 9, "ty": 0, "tileId": "blueFlower" },
-          { "tx": 8, "ty": 0, "tileId": "whiteFlower" }
-
+        {
+          "comment": "town hall steps - [36, 9]"
+        },
+        {
+          "tx": 5,
+          "ty": -2,
+          "tileId": "stoneStairsUpLeftTop",
+          "zlayer": "below-avatar"
+        },
+        {
+          "tx": 7,
+          "ty": -2,
+          "tileId": "stoneStairsUpRightTop",
+          "zlayer": "below-avatar"
+        },
+        {
+          "tx": 5,
+          "ty": -1,
+          "tileId": "stoneStairsUpLeftMiddle",
+          "zlayer": "below-avatar"
+        },
+        {
+          "tx": 6,
+          "ty": -1,
+          "tileId": "stoneStairsUpMiddleMiddle",
+          "zlayer": "below-avatar"
+        },
+        {
+          "tx": 7,
+          "ty": -1,
+          "tileId": "stoneStairsUpRightMiddle",
+          "zlayer": "below-avatar"
+        },
+        {
+          "tx": 5,
+          "ty": 0,
+          "tileId": "stoneStairsUpLeftBottom",
+          "zlayer": "below-avatar"
+        },
+        {
+          "tx": 6,
+          "ty": 0,
+          "tileId": "stoneStairsUpMiddleBottom",
+          "zlayer": "below-avatar"
+        },
+        {
+          "tx": 7,
+          "ty": 0,
+          "tileId": "stoneStairsUpRightBottom",
+          "zlayer": "below-avatar"
+        },
+        {
+          "tx": 2,
+          "ty": 0,
+          "tileId": "yellowFlower"
+        },
+        {
+          "tx": 3,
+          "ty": 0,
+          "tileId": "blueFlower"
+        },
+        {
+          "tx": 4,
+          "ty": 0,
+          "tileId": "whiteFlower"
+        },
+        {
+          "tx": 10,
+          "ty": 0,
+          "tileId": "yellowFlower"
+        },
+        {
+          "tx": 9,
+          "ty": 0,
+          "tileId": "blueFlower"
+        },
+        {
+          "tx": 8,
+          "ty": 0,
+          "tileId": "whiteFlower"
+        }
       ]
     }
   ],
   "exteriorDecor": [
-    { "tx": 21, "ty": 21, "tileId": "stoneWell" },
-    { "tx":  2, "ty": 11, "tileId": "barrel" },
-    { "tx":  3, "ty": 11, "tileId": "barrel" },
-    { "tx": 11, "ty": 11, "tileId": "crate" },
-    { "tx": 24, "ty": 20, "tileId": "mailBox" },
-
-
-    { "comment": "farm"},
-    { "tx": 0, "ty": 33, "tileId": "fenceLeftRight" },
-    { "tx": 1, "ty": 33, "tileId": "fenceLeftRight" },
-    {"tx": 2, "ty": 33, "tileId": "fenceLeft"},
-    { "tx": 4, "ty": 33, "tileId": "fenceRight" },
-    { "tx": 5, "ty": 33, "tileId": "fenceLeftRight" },
-    {"tx": 6, "ty": 33, "tileId": "fenceLeftRight"},
-    {"tx":5, "ty":29, "tileId": "scarecrowTop"},
-      {"tx":5, "ty":30, "tileId": "scarecrowBottom"},
-
-
-    { "comment": "courtyard fountain" },
-    { "tx":  36, "ty":  23, "tileId": "fountainTopLeft" },
-    { "tx":  37, "ty":  23, "tileId": "fountainTopMiddle" },
-    { "tx":  38, "ty":  23, "tileId": "fountainTopRight" },
-    { "tx":  36, "ty":  24, "tileId": "fountainMidLeft" },
-    { "tx":  37, "ty":  24, "tileId": "fountainMidMiddle" },
-    { "tx":  38, "ty":  24, "tileId": "fountainMidRight" },
-    { "tx":  36, "ty":  25, "tileId": "fountainBotLeft" },
-    { "tx":  37, "ty":  25, "tileId": "fountainBotMiddle" },
-    { "tx":  38, "ty":  25, "tileId": "fountainBotRight" },
-
-
-
-    { "comment": "pond decor"},
-    { "tx":  35, "ty": 43, "tileId": "smallLilypad" },
-    { "tx":  39, "ty": 44, "tileId": "largeLilypad" },
-    { "tx":  1, "ty": 36, "tileId": "smallRock" },
-    { "tx":  34, "ty": 45, "tileId": "smallRock" },
-
-    { "tx":  0, "ty":  0, "tileId": "darkTreeTopLeft" },
-    { "tx":  1, "ty":  0, "tileId": "darkTreeTopRight" },
-    { "tx":  0, "ty":  1, "tileId": "darkTreeBottomLeft" },
-    { "tx":  1, "ty":  1, "tileId": "darkTreeBottomRight" },
-
-    { "tx":  0, "ty":  3, "tileId": "darkTreeTopLeft" },
-    { "tx":  1, "ty":  3, "tileId": "darkTreeTopRight" },
-    { "tx":  0, "ty":  4, "tileId": "darkTreeBottomLeft" },
-    { "tx":  1, "ty":  4, "tileId": "darkTreeBottomRight" },
-
-    { "tx":  0, "ty":  6, "tileId": "darkTreeTopLeft" },
-    { "tx":  1, "ty":  6, "tileId": "darkTreeTopRight" },
-    { "tx":  0, "ty":  7, "tileId": "darkTreeBottomLeft" },
-    { "tx":  1, "ty":  7, "tileId": "darkTreeBottomRight" },
-
-    { "tx":  0, "ty":  9, "tileId": "darkTreeTopLeft" },
-    { "tx":  1, "ty":  9, "tileId": "darkTreeTopRight" },
-    { "tx":  0, "ty": 10, "tileId": "darkTreeBottomLeft" },
-    { "tx":  1, "ty": 10, "tileId": "darkTreeBottomRight" },
-
-    { "tx": 12, "ty":  0, "tileId": "darkTreeTopLeft" },
-    { "tx": 13, "ty":  0, "tileId": "darkTreeTopRight" },
-    { "tx": 12, "ty":  1, "tileId": "darkTreeBottomLeft" },
-    { "tx": 13, "ty":  1, "tileId": "darkTreeBottomRight" },
-
-    { "tx": 20, "ty":  0, "tileId": "darkTreeTopLeft" },
-    { "tx": 21, "ty":  0, "tileId": "darkTreeTopRight" },
-    { "tx": 20, "ty":  1, "tileId": "darkTreeBottomLeft" },
-    { "tx": 21, "ty":  1, "tileId": "darkTreeBottomRight" },
-
-    { "tx": 20, "ty":  3, "tileId": "darkTreeTopLeft" },
-    { "tx": 21, "ty":  3, "tileId": "darkTreeTopRight" },
-    { "tx": 20, "ty":  4, "tileId": "darkTreeBottomLeft" },
-    { "tx": 21, "ty":  4, "tileId": "darkTreeBottomRight" },
-
-    { "tx": 29, "ty":  0, "tileId": "darkTreeTopLeft" },
-    { "tx": 30, "ty":  0, "tileId": "darkTreeTopRight" },
-    { "tx": 29, "ty":  1, "tileId": "darkTreeBottomLeft" },
-    { "tx": 30, "ty":  1, "tileId": "darkTreeBottomRight" },
-
-    { "tx": 39, "ty":  0, "tileId": "darkTreeTopLeft" },
-    { "tx": 40, "ty":  0, "tileId": "darkTreeTopRight" },
-    { "tx": 39, "ty":  1, "tileId": "darkTreeBottomLeft" },
-    { "tx": 40, "ty":  1, "tileId": "darkTreeBottomRight" },
-
-    { "tx": 51, "ty":  0, "tileId": "darkTreeTopLeft" },
-    { "tx": 52, "ty":  0, "tileId": "darkTreeTopRight" },
-    { "tx": 51, "ty":  1, "tileId": "darkTreeBottomLeft" },
-    { "tx": 52, "ty":  1, "tileId": "darkTreeBottomRight" },
-
-    { "tx": 58, "ty":  0, "tileId": "darkTreeTopLeft" },
-    { "tx": 59, "ty":  0, "tileId": "darkTreeTopRight" },
-    { "tx": 58, "ty":  1, "tileId": "darkTreeBottomLeft" },
-    { "tx": 59, "ty":  1, "tileId": "darkTreeBottomRight" },
-
-    { "tx": 69, "ty":  0, "tileId": "darkTreeTopLeft" },
-    { "tx": 70, "ty":  0, "tileId": "darkTreeTopRight" },
-    { "tx": 69, "ty":  1, "tileId": "darkTreeBottomLeft" },
-    { "tx": 70, "ty":  1, "tileId": "darkTreeBottomRight" },
-
-    { "tx": 72, "ty":  0, "tileId": "darkTreeTopLeft" },
-    { "tx": 73, "ty":  0, "tileId": "darkTreeTopRight" },
-    { "tx": 72, "ty":  1, "tileId": "darkTreeBottomLeft" },
-    { "tx": 73, "ty":  1, "tileId": "darkTreeBottomRight" },
-
-    { "tx": 72, "ty":  3, "tileId": "darkTreeTopLeft" },
-    { "tx": 73, "ty":  3, "tileId": "darkTreeTopRight" },
-    { "tx": 72, "ty":  4, "tileId": "darkTreeBottomLeft" },
-    { "tx": 73, "ty":  4, "tileId": "darkTreeBottomRight" },
-
-    { "tx": 51, "ty":  8, "tileId": "darkTreeTopLeft" },
-    { "tx": 52, "ty":  8, "tileId": "darkTreeTopRight" },
-    { "tx": 51, "ty":  9, "tileId": "darkTreeBottomLeft" },
-    { "tx": 52, "ty":  9, "tileId": "darkTreeBottomRight" },
-
-    { "tx": 58, "ty":  8, "tileId": "darkTreeTopLeft" },
-    { "tx": 59, "ty":  8, "tileId": "darkTreeTopRight" },
-    { "tx": 58, "ty":  9, "tileId": "darkTreeBottomLeft" },
-    { "tx": 59, "ty":  9, "tileId": "darkTreeBottomRight" },
-
-    { "tx": 72, "ty":  8, "tileId": "darkTreeTopLeft" },
-    { "tx": 73, "ty":  8, "tileId": "darkTreeTopRight" },
-    { "tx": 72, "ty":  9, "tileId": "darkTreeBottomLeft" },
-    { "tx": 73, "ty":  9, "tileId": "darkTreeBottomRight" },
-
-
-    { "tx": 30, "ty":  29, "tileId": "darkTreeTopLeft" },
-    { "tx": 31, "ty":  29, "tileId": "darkTreeTopRight" },
-    { "tx": 30, "ty":  30, "tileId": "darkTreeBottomLeft" },
-    { "tx": 31, "ty":  30, "tileId": "darkTreeBottomRight" },
-    { "tx": 32, "ty":  29, "tileId": "darkTreeTopLeft" },
-    { "tx": 33, "ty":  29, "tileId": "darkTreeTopRight" },
-    { "tx": 32, "ty":  30, "tileId": "darkTreeBottomLeft" },
-    { "tx": 33, "ty":  30, "tileId": "darkTreeBottomRight" },
-
-    { "comment": "" },
-    { "tx": 34, "ty": 29, "tileId": "darkTreeTopLeft" },
-    { "tx": 35, "ty": 29, "tileId": "darkTreeTopRight" },
-    { "tx": 34, "ty": 30, "tileId": "darkTreeColumnLeft" },
-    { "tx": 35, "ty": 30, "tileId": "darkTreeColumnRight" },
-    { "tx": 34, "ty": 31, "tileId": "darkTreeColumnLeft" },
-    { "tx": 35, "ty": 31, "tileId": "darkTreeColumnRight" },
-    { "tx": 34, "ty": 32, "tileId": "darkTreeColumnLeft" },
-    { "tx": 35, "ty": 32, "tileId": "darkTreeColumnRight" },
-    { "tx": 34, "ty": 33, "tileId": "darkTreeBottomLeft" },
-    { "tx": 35, "ty": 33, "tileId": "darkTreeBottomRight" },
-
-    { "tx": 34, "ty": 34, "tileId": "darkTreeTopLeft" },
-    { "tx": 35, "ty": 34, "tileId": "darkTreeTopRight" },
-    { "tx": 34, "ty": 35, "tileId": "darkTreeColumnLeft" },
-    { "tx": 35, "ty": 35, "tileId": "darkTreeColumnRight" },
-    { "tx": 34, "ty": 36, "tileId": "darkTreeColumnLeft" },
-    { "tx": 35, "ty": 36, "tileId": "darkTreeColumnRight" },
-
-    { "tx": 34, "ty": 37, "tileId": "darkTreeColumnLeft" },
-    { "tx": 35, "ty": 37, "tileId": "darkTreeColumnRight" },
-    { "tx": 34, "ty": 38, "tileId": "darkTreeColumnRightStaggered" },
-    { "tx": 35, "ty": 38, "tileId": "darkTreeBottomRight" },    
-
-    { "tx": 32, "ty": 37, "tileId": "darkTreeTopLeft" },
-    { "tx": 33, "ty": 37, "tileId": "darkTreeTopRight" },
-    { "tx": 32, "ty": 38, "tileId": "darkTreeColumnRightStaggered" },
-    { "tx": 33, "ty": 38, "tileId": "darkTreeColumnLeftStaggered" },
-
-
-    { "tx": 30, "ty": 37, "tileId": "darkTreeTopLeft" },
-        { "tx": 30, "ty": 38, "tileId": "darkTreeBottomLeft" },
-    { "tx": 31, "ty": 37, "tileId": "darkTreeTopRight" },
-    { "tx": 31, "ty": 38, "tileId": "darkTreeColumnLeftStaggered" },
-
-    { "tx": 31, "ty": 39, "tileId": "darkTreeBottomLeft" },
-    { "tx": 32, "ty": 39, "tileId": "darkTreeBottomRight" },
-    { "tx": 33, "ty": 39, "tileId": "darkTreeBottomLeft" },    
-    { "tx": 34, "ty": 39, "tileId": "darkTreeBottomRight" },
-    { "tx": 33, "ty": 39, "tileId": "darkTreeBottomLeft" },
-
-
-
-    { "tx": 39, "ty": 29, "tileId": "darkTreeTopLeft" },
-    { "tx": 40, "ty": 29, "tileId": "darkTreeTopRight" },
-    { "tx": 39, "ty": 30, "tileId": "darkTreeColumnLeft" },
-    { "tx": 40, "ty": 30, "tileId": "darkTreeColumnRight" },
-    { "tx": 39, "ty": 31, "tileId": "darkTreeColumnLeft" },
-    { "tx": 40, "ty": 31, "tileId": "darkTreeColumnRight" },
-    { "tx": 39, "ty": 32, "tileId": "darkTreeColumnLeft" },
-    { "tx": 40, "ty": 32, "tileId": "darkTreeColumnRight" },
-    { "tx": 39, "ty": 33, "tileId": "darkTreeColumnLeft" },
-    { "tx": 40, "ty": 33, "tileId": "darkTreeColumnRight" },
-    { "tx": 39, "ty": 34, "tileId": "darkTreeBottomLeft" },
-    { "tx": 40, "ty": 34, "tileId": "darkTreeBottomRight" },
-
-    { "tx": 39, "ty": 35, "tileId": "darkTreeTopLeft" },
-    { "tx": 40, "ty": 35, "tileId": "darkTreeTopRight" },
-    { "tx": 39, "ty": 36, "tileId": "darkTreeColumnLeft" },
-    { "tx": 40, "ty": 36, "tileId": "darkTreeColumnRight" },
-    { "tx": 39, "ty": 37, "tileId": "darkTreeColumnLeft" },
-    { "tx": 40, "ty": 37, "tileId": "darkTreeColumnRight" },
-    { "tx": 39, "ty": 38, "tileId": "darkTreeBottomLeft" },
-    { "tx": 40, "ty": 38, "tileId": "darkTreeBottomRight" },    
-
-
-
-    { "tx": 53, "ty": 21, "tileId": "darkTreeTopLeft" },
-    { "tx": 54, "ty": 21, "tileId": "darkTreeTopRight" },
-    { "tx": 53, "ty": 22, "tileId": "darkTreeBottomLeft" },
-    { "tx": 54, "ty": 22, "tileId": "darkTreeBottomRight" },
-
-    { "tx": 53, "ty": 27, "tileId": "darkTreeTopLeft" },
-    { "tx": 54, "ty": 27, "tileId": "darkTreeTopRight" },
-    { "tx": 53, "ty": 28, "tileId": "darkTreeBottomLeft" },
-    { "tx": 54, "ty": 28, "tileId": "darkTreeBottomRight" },
-
-    { "tx": 53, "ty": 43, "tileId": "darkTreeTopLeft" },
-    { "tx": 54, "ty": 43, "tileId": "darkTreeTopRight" },
-    { "tx": 53, "ty": 44, "tileId": "darkTreeBottomLeft" },
-    { "tx": 54, "ty": 44, "tileId": "darkTreeBottomRight" },
-
-    { "tx": 69, "ty": 21, "tileId": "darkTreeTopLeft" },
-    { "tx": 70, "ty": 21, "tileId": "darkTreeTopRight" },
-    { "tx": 69, "ty": 22, "tileId": "darkTreeBottomLeft" },
-    { "tx": 70, "ty": 22, "tileId": "darkTreeBottomRight" },
-
-    { "tx": 69, "ty": 39, "tileId": "darkTreeTopLeft" },
-    { "tx": 70, "ty": 39, "tileId": "darkTreeTopRight" },
-    { "tx": 69, "ty": 40, "tileId": "darkTreeBottomLeft" },
-    { "tx": 70, "ty": 40, "tileId": "darkTreeBottomRight" },
-
-    { "tx": 72, "ty": 21, "tileId": "darkTreeTopLeft" },
-    { "tx": 73, "ty": 21, "tileId": "darkTreeTopRight" },
-    { "tx": 72, "ty": 22, "tileId": "darkTreeBottomLeft" },
-    { "tx": 73, "ty": 22, "tileId": "darkTreeBottomRight" },
-
-    { "tx": 72, "ty": 27, "tileId": "darkTreeTopLeft" },
-    { "tx": 73, "ty": 27, "tileId": "darkTreeTopRight" },
-    { "tx": 72, "ty": 28, "tileId": "darkTreeBottomLeft" },
-    { "tx": 73, "ty": 28, "tileId": "darkTreeBottomRight" },
-
-    { "tx": 72, "ty": 39, "tileId": "darkTreeTopLeft" },
-    { "tx": 73, "ty": 39, "tileId": "darkTreeTopRight" },
-    { "tx": 72, "ty": 40, "tileId": "darkTreeBottomLeft" },
-    { "tx": 73, "ty": 40, "tileId": "darkTreeBottomRight" },
-
-    { "tx":  0, "ty": 16, "tileId": "darkBush" },
-    { "tx":  0, "ty": 17, "tileId": "lightBush" },
-    { "tx":  0, "ty": 20, "tileId": "darkBush" },
-    { "tx": 12, "ty": 15, "tileId": "lightBush" },
-    { "tx": 12, "ty": 22, "tileId": "darkBush" },
-    { "tx": 29, "ty": 29, "tileId": "lightBush" },
-    { "tx": 28, "ty": 13, "tileId": "darkBush" },
-    { "tx": 28, "ty": 20, "tileId": "darkBush" },
-    { "tx": 51, "ty": 13, "tileId": "lightBush" },
-    { "tx": 52, "ty": 13, "tileId": "darkBush" },
-    { "tx": 69, "ty": 11, "tileId": "darkBush" },
-    { "tx": 70, "ty": 11, "tileId": "lightBush" },
-    { "tx": 42, "ty": 27, "tileId": "darkBush" },
-    { "tx": 42, "ty": 34, "tileId": "lightBush" },
-    { "tx": 41, "ty": 41, "tileId": "darkBush" },
-    { "tx": 29, "ty": 37, "tileId": "lightBush" },
-    { "tx": 29, "ty": 43, "tileId": "darkBush" },
-    { "tx": 13, "ty": 37, "tileId": "darkBush" },
-    { "tx": 17, "ty": 43, "tileId": "lightBush" },
-    { "tx":  0, "ty": 27, "tileId": "darkBush" },
-    { "tx":  0, "ty": 38, "tileId": "darkBush" },
-    { "tx":  0, "ty": 49, "tileId": "lightBush" },
-    { "tx": 10, "ty": 49, "tileId": "darkBush" },
-    { "tx": 20, "ty": 49, "tileId": "darkBush" },
-    { "tx": 30, "ty": 49, "tileId": "lightBush" },
-
-    { "tx": 33, "ty": 18, "tileId": "whiteFlower" },
-    { "tx": 34, "ty": 18, "tileId": "pinkFlower" },
-    { "tx": 40, "ty": 18, "tileId": "blueFlower" },
-    { "tx": 41, "ty": 18, "tileId": "yellowFlower" },
-    { "tx": 34, "ty": 20, "tileId": "whiteFlower" },
-    { "tx": 40, "ty": 20, "tileId": "pinkFlower" },
-    { "tx": 17, "ty": 26, "tileId": "yellowFlower" },
-    { "tx": 30, "ty": 26, "tileId": "blueFlower" },
-    { "tx": 43, "ty": 26, "tileId": "whiteFlower" },
-    { "tx": 60, "ty": 26, "tileId": "pinkFlower" },
-
-    { "tx": 20, "ty": 11, "tileId": "smallRock" },
-    { "tx":  2, "ty": 22, "tileId": "smallRock" },
-    { "tx": 13, "ty": 26, "tileId": "smallRock" },
-    { "tx": 29, "ty": 26, "tileId": "smallRock" },
-    { "tx": 42, "ty": 26, "tileId": "smallRock" },
-    { "tx": 60, "ty": 26, "tileId": "smallRock" },
-
-    { "tx":  2, "ty":  3, "tileId": "grassTuft" },
-    { "tx": 14, "ty":  3, "tileId": "grassTuft" },
-    { "tx": 24, "ty":  8, "tileId": "grassTuft" },
-    { "tx": 30, "ty":  5, "tileId": "grassTuft" },
-    { "tx": 40, "ty":  12, "tileId": "grassTuft" },
-    { "tx": 59, "ty":  5, "tileId": "grassTuft" },
-    { "tx": 71, "ty":  5, "tileId": "grassTuft" },
-    { "tx": 29, "ty": 40, "tileId": "grassTuft" },
-    { "tx": 41, "ty": 48, "tileId": "grassTuft" },
-    { "tx": 60, "ty": 36, "tileId": "grassTuft" }
+    {
+      "tx": 21,
+      "ty": 21,
+      "tileId": "stoneWell"
+    },
+    {
+      "tx": 2,
+      "ty": 11,
+      "tileId": "barrel"
+    },
+    {
+      "tx": 3,
+      "ty": 11,
+      "tileId": "barrel"
+    },
+    {
+      "tx": 11,
+      "ty": 11,
+      "tileId": "crate"
+    },
+    {
+      "tx": 24,
+      "ty": 20,
+      "tileId": "mailBox"
+    },
+    {
+      "comment": "farm"
+    },
+    {
+      "tx": 0,
+      "ty": 33,
+      "tileId": "fenceLeftRight"
+    },
+    {
+      "tx": 1,
+      "ty": 33,
+      "tileId": "fenceLeftRight"
+    },
+    {
+      "tx": 2,
+      "ty": 33,
+      "tileId": "fenceLeft"
+    },
+    {
+      "tx": 4,
+      "ty": 33,
+      "tileId": "fenceRight"
+    },
+    {
+      "tx": 5,
+      "ty": 33,
+      "tileId": "fenceLeftRight"
+    },
+    {
+      "tx": 6,
+      "ty": 33,
+      "tileId": "fenceLeftRight"
+    },
+    {
+      "tx": 5,
+      "ty": 29,
+      "tileId": "scarecrowTop"
+    },
+    {
+      "tx": 5,
+      "ty": 30,
+      "tileId": "scarecrowBottom"
+    },
+    {
+      "comment": "courtyard fountain"
+    },
+    {
+      "tx": 36,
+      "ty": 23,
+      "tileId": "fountainTopLeft"
+    },
+    {
+      "tx": 37,
+      "ty": 23,
+      "tileId": "fountainTopMiddle"
+    },
+    {
+      "tx": 38,
+      "ty": 23,
+      "tileId": "fountainTopRight"
+    },
+    {
+      "tx": 36,
+      "ty": 24,
+      "tileId": "fountainMidLeft"
+    },
+    {
+      "tx": 37,
+      "ty": 24,
+      "tileId": "fountainMidMiddle"
+    },
+    {
+      "tx": 38,
+      "ty": 24,
+      "tileId": "fountainMidRight"
+    },
+    {
+      "tx": 36,
+      "ty": 25,
+      "tileId": "fountainBotLeft"
+    },
+    {
+      "tx": 37,
+      "ty": 25,
+      "tileId": "fountainBotMiddle"
+    },
+    {
+      "tx": 38,
+      "ty": 25,
+      "tileId": "fountainBotRight"
+    },
+    {
+      "comment": "pond decor"
+    },
+    {
+      "tx": 35,
+      "ty": 43,
+      "tileId": "smallLilypad"
+    },
+    {
+      "tx": 39,
+      "ty": 44,
+      "tileId": "largeLilypad"
+    },
+    {
+      "tx": 1,
+      "ty": 36,
+      "tileId": "smallRock"
+    },
+    {
+      "tx": 34,
+      "ty": 45,
+      "tileId": "smallRock"
+    },
+    {
+      "tx": 0,
+      "ty": 0,
+      "tileId": "darkTreeTopLeft"
+    },
+    {
+      "tx": 1,
+      "ty": 0,
+      "tileId": "darkTreeTopRight"
+    },
+    {
+      "tx": 0,
+      "ty": 1,
+      "tileId": "darkTreeBottomLeft"
+    },
+    {
+      "tx": 1,
+      "ty": 1,
+      "tileId": "darkTreeBottomRight"
+    },
+    {
+      "tx": 0,
+      "ty": 3,
+      "tileId": "darkTreeTopLeft"
+    },
+    {
+      "tx": 1,
+      "ty": 3,
+      "tileId": "darkTreeTopRight"
+    },
+    {
+      "tx": 0,
+      "ty": 4,
+      "tileId": "darkTreeBottomLeft"
+    },
+    {
+      "tx": 1,
+      "ty": 4,
+      "tileId": "darkTreeBottomRight"
+    },
+    {
+      "tx": 0,
+      "ty": 6,
+      "tileId": "darkTreeTopLeft"
+    },
+    {
+      "tx": 1,
+      "ty": 6,
+      "tileId": "darkTreeTopRight"
+    },
+    {
+      "tx": 0,
+      "ty": 7,
+      "tileId": "darkTreeBottomLeft"
+    },
+    {
+      "tx": 1,
+      "ty": 7,
+      "tileId": "darkTreeBottomRight"
+    },
+    {
+      "tx": 0,
+      "ty": 9,
+      "tileId": "darkTreeTopLeft"
+    },
+    {
+      "tx": 1,
+      "ty": 9,
+      "tileId": "darkTreeTopRight"
+    },
+    {
+      "tx": 0,
+      "ty": 10,
+      "tileId": "darkTreeBottomLeft"
+    },
+    {
+      "tx": 1,
+      "ty": 10,
+      "tileId": "darkTreeBottomRight"
+    },
+    {
+      "tx": 12,
+      "ty": 0,
+      "tileId": "darkTreeTopLeft"
+    },
+    {
+      "tx": 13,
+      "ty": 0,
+      "tileId": "darkTreeTopRight"
+    },
+    {
+      "tx": 12,
+      "ty": 1,
+      "tileId": "darkTreeBottomLeft"
+    },
+    {
+      "tx": 13,
+      "ty": 1,
+      "tileId": "darkTreeBottomRight"
+    },
+    {
+      "tx": 20,
+      "ty": 0,
+      "tileId": "darkTreeTopLeft"
+    },
+    {
+      "tx": 21,
+      "ty": 0,
+      "tileId": "darkTreeTopRight"
+    },
+    {
+      "tx": 20,
+      "ty": 1,
+      "tileId": "darkTreeBottomLeft"
+    },
+    {
+      "tx": 21,
+      "ty": 1,
+      "tileId": "darkTreeBottomRight"
+    },
+    {
+      "tx": 20,
+      "ty": 3,
+      "tileId": "darkTreeTopLeft"
+    },
+    {
+      "tx": 21,
+      "ty": 3,
+      "tileId": "darkTreeTopRight"
+    },
+    {
+      "tx": 20,
+      "ty": 4,
+      "tileId": "darkTreeBottomLeft"
+    },
+    {
+      "tx": 21,
+      "ty": 4,
+      "tileId": "darkTreeBottomRight"
+    },
+    {
+      "tx": 29,
+      "ty": 0,
+      "tileId": "darkTreeTopLeft"
+    },
+    {
+      "tx": 30,
+      "ty": 0,
+      "tileId": "darkTreeTopRight"
+    },
+    {
+      "tx": 29,
+      "ty": 1,
+      "tileId": "darkTreeBottomLeft"
+    },
+    {
+      "tx": 30,
+      "ty": 1,
+      "tileId": "darkTreeBottomRight"
+    },
+    {
+      "tx": 39,
+      "ty": 0,
+      "tileId": "darkTreeTopLeft"
+    },
+    {
+      "tx": 40,
+      "ty": 0,
+      "tileId": "darkTreeTopRight"
+    },
+    {
+      "tx": 39,
+      "ty": 1,
+      "tileId": "darkTreeBottomLeft"
+    },
+    {
+      "tx": 40,
+      "ty": 1,
+      "tileId": "darkTreeBottomRight"
+    },
+    {
+      "tx": 51,
+      "ty": 0,
+      "tileId": "darkTreeTopLeft"
+    },
+    {
+      "tx": 52,
+      "ty": 0,
+      "tileId": "darkTreeTopRight"
+    },
+    {
+      "tx": 51,
+      "ty": 1,
+      "tileId": "darkTreeBottomLeft"
+    },
+    {
+      "tx": 52,
+      "ty": 1,
+      "tileId": "darkTreeBottomRight"
+    },
+    {
+      "tx": 58,
+      "ty": 0,
+      "tileId": "darkTreeTopLeft"
+    },
+    {
+      "tx": 59,
+      "ty": 0,
+      "tileId": "darkTreeTopRight"
+    },
+    {
+      "tx": 58,
+      "ty": 1,
+      "tileId": "darkTreeBottomLeft"
+    },
+    {
+      "tx": 59,
+      "ty": 1,
+      "tileId": "darkTreeBottomRight"
+    },
+    {
+      "tx": 69,
+      "ty": 0,
+      "tileId": "darkTreeTopLeft"
+    },
+    {
+      "tx": 70,
+      "ty": 0,
+      "tileId": "darkTreeTopRight"
+    },
+    {
+      "tx": 69,
+      "ty": 1,
+      "tileId": "darkTreeBottomLeft"
+    },
+    {
+      "tx": 70,
+      "ty": 1,
+      "tileId": "darkTreeBottomRight"
+    },
+    {
+      "tx": 72,
+      "ty": 0,
+      "tileId": "darkTreeTopLeft"
+    },
+    {
+      "tx": 73,
+      "ty": 0,
+      "tileId": "darkTreeTopRight"
+    },
+    {
+      "tx": 72,
+      "ty": 1,
+      "tileId": "darkTreeBottomLeft"
+    },
+    {
+      "tx": 73,
+      "ty": 1,
+      "tileId": "darkTreeBottomRight"
+    },
+    {
+      "tx": 72,
+      "ty": 3,
+      "tileId": "darkTreeTopLeft"
+    },
+    {
+      "tx": 73,
+      "ty": 3,
+      "tileId": "darkTreeTopRight"
+    },
+    {
+      "tx": 72,
+      "ty": 4,
+      "tileId": "darkTreeBottomLeft"
+    },
+    {
+      "tx": 73,
+      "ty": 4,
+      "tileId": "darkTreeBottomRight"
+    },
+    {
+      "tx": 51,
+      "ty": 8,
+      "tileId": "darkTreeTopLeft"
+    },
+    {
+      "tx": 52,
+      "ty": 8,
+      "tileId": "darkTreeTopRight"
+    },
+    {
+      "tx": 51,
+      "ty": 9,
+      "tileId": "darkTreeBottomLeft"
+    },
+    {
+      "tx": 52,
+      "ty": 9,
+      "tileId": "darkTreeBottomRight"
+    },
+    {
+      "tx": 58,
+      "ty": 8,
+      "tileId": "darkTreeTopLeft"
+    },
+    {
+      "tx": 59,
+      "ty": 8,
+      "tileId": "darkTreeTopRight"
+    },
+    {
+      "tx": 58,
+      "ty": 9,
+      "tileId": "darkTreeBottomLeft"
+    },
+    {
+      "tx": 59,
+      "ty": 9,
+      "tileId": "darkTreeBottomRight"
+    },
+    {
+      "tx": 72,
+      "ty": 8,
+      "tileId": "darkTreeTopLeft"
+    },
+    {
+      "tx": 73,
+      "ty": 8,
+      "tileId": "darkTreeTopRight"
+    },
+    {
+      "tx": 72,
+      "ty": 9,
+      "tileId": "darkTreeBottomLeft"
+    },
+    {
+      "tx": 73,
+      "ty": 9,
+      "tileId": "darkTreeBottomRight"
+    },
+    {
+      "tx": 30,
+      "ty": 29,
+      "tileId": "darkTreeTopLeft"
+    },
+    {
+      "tx": 31,
+      "ty": 29,
+      "tileId": "darkTreeTopRight"
+    },
+    {
+      "tx": 30,
+      "ty": 30,
+      "tileId": "darkTreeBottomLeft"
+    },
+    {
+      "tx": 31,
+      "ty": 30,
+      "tileId": "darkTreeBottomRight"
+    },
+    {
+      "tx": 32,
+      "ty": 29,
+      "tileId": "darkTreeTopLeft"
+    },
+    {
+      "tx": 33,
+      "ty": 29,
+      "tileId": "darkTreeTopRight"
+    },
+    {
+      "tx": 32,
+      "ty": 30,
+      "tileId": "darkTreeBottomLeft"
+    },
+    {
+      "tx": 33,
+      "ty": 30,
+      "tileId": "darkTreeBottomRight"
+    },
+    {
+      "comment": ""
+    },
+    {
+      "tx": 34,
+      "ty": 29,
+      "tileId": "darkTreeTopLeft"
+    },
+    {
+      "tx": 35,
+      "ty": 29,
+      "tileId": "darkTreeTopRight"
+    },
+    {
+      "tx": 34,
+      "ty": 30,
+      "tileId": "darkTreeColumnLeft"
+    },
+    {
+      "tx": 35,
+      "ty": 30,
+      "tileId": "darkTreeColumnRight"
+    },
+    {
+      "tx": 34,
+      "ty": 31,
+      "tileId": "darkTreeColumnLeft"
+    },
+    {
+      "tx": 35,
+      "ty": 31,
+      "tileId": "darkTreeColumnRight"
+    },
+    {
+      "tx": 34,
+      "ty": 32,
+      "tileId": "darkTreeColumnLeft"
+    },
+    {
+      "tx": 35,
+      "ty": 32,
+      "tileId": "darkTreeColumnRight"
+    },
+    {
+      "tx": 34,
+      "ty": 33,
+      "tileId": "darkTreeBottomLeft"
+    },
+    {
+      "tx": 35,
+      "ty": 33,
+      "tileId": "darkTreeBottomRight"
+    },
+    {
+      "tx": 34,
+      "ty": 34,
+      "tileId": "darkTreeTopLeft"
+    },
+    {
+      "tx": 35,
+      "ty": 34,
+      "tileId": "darkTreeTopRight"
+    },
+    {
+      "tx": 34,
+      "ty": 35,
+      "tileId": "darkTreeColumnLeft"
+    },
+    {
+      "tx": 35,
+      "ty": 35,
+      "tileId": "darkTreeColumnRight"
+    },
+    {
+      "tx": 34,
+      "ty": 36,
+      "tileId": "darkTreeColumnLeft"
+    },
+    {
+      "tx": 35,
+      "ty": 36,
+      "tileId": "darkTreeColumnRight"
+    },
+    {
+      "tx": 34,
+      "ty": 37,
+      "tileId": "darkTreeColumnLeft"
+    },
+    {
+      "tx": 35,
+      "ty": 37,
+      "tileId": "darkTreeColumnRight"
+    },
+    {
+      "tx": 34,
+      "ty": 38,
+      "tileId": "darkTreeColumnRightStaggered"
+    },
+    {
+      "tx": 35,
+      "ty": 38,
+      "tileId": "darkTreeBottomRight"
+    },
+    {
+      "tx": 32,
+      "ty": 37,
+      "tileId": "darkTreeTopLeft"
+    },
+    {
+      "tx": 33,
+      "ty": 37,
+      "tileId": "darkTreeTopRight"
+    },
+    {
+      "tx": 32,
+      "ty": 38,
+      "tileId": "darkTreeColumnRightStaggered"
+    },
+    {
+      "tx": 33,
+      "ty": 38,
+      "tileId": "darkTreeColumnLeftStaggered"
+    },
+    {
+      "tx": 30,
+      "ty": 37,
+      "tileId": "darkTreeTopLeft"
+    },
+    {
+      "tx": 30,
+      "ty": 38,
+      "tileId": "darkTreeBottomLeft"
+    },
+    {
+      "tx": 31,
+      "ty": 37,
+      "tileId": "darkTreeTopRight"
+    },
+    {
+      "tx": 31,
+      "ty": 38,
+      "tileId": "darkTreeColumnLeftStaggered"
+    },
+    {
+      "tx": 31,
+      "ty": 39,
+      "tileId": "darkTreeBottomLeft"
+    },
+    {
+      "tx": 32,
+      "ty": 39,
+      "tileId": "darkTreeBottomRight"
+    },
+    {
+      "tx": 33,
+      "ty": 39,
+      "tileId": "darkTreeBottomLeft"
+    },
+    {
+      "tx": 34,
+      "ty": 39,
+      "tileId": "darkTreeBottomRight"
+    },
+    {
+      "tx": 33,
+      "ty": 39,
+      "tileId": "darkTreeBottomLeft"
+    },
+    {
+      "tx": 39,
+      "ty": 29,
+      "tileId": "darkTreeTopLeft"
+    },
+    {
+      "tx": 40,
+      "ty": 29,
+      "tileId": "darkTreeTopRight"
+    },
+    {
+      "tx": 39,
+      "ty": 30,
+      "tileId": "darkTreeColumnLeft"
+    },
+    {
+      "tx": 40,
+      "ty": 30,
+      "tileId": "darkTreeColumnRight"
+    },
+    {
+      "tx": 39,
+      "ty": 31,
+      "tileId": "darkTreeColumnLeft"
+    },
+    {
+      "tx": 40,
+      "ty": 31,
+      "tileId": "darkTreeColumnRight"
+    },
+    {
+      "tx": 39,
+      "ty": 32,
+      "tileId": "darkTreeColumnLeft"
+    },
+    {
+      "tx": 40,
+      "ty": 32,
+      "tileId": "darkTreeColumnRight"
+    },
+    {
+      "tx": 39,
+      "ty": 33,
+      "tileId": "darkTreeColumnLeft"
+    },
+    {
+      "tx": 40,
+      "ty": 33,
+      "tileId": "darkTreeColumnRight"
+    },
+    {
+      "tx": 39,
+      "ty": 34,
+      "tileId": "darkTreeBottomLeft"
+    },
+    {
+      "tx": 40,
+      "ty": 34,
+      "tileId": "darkTreeBottomRight"
+    },
+    {
+      "tx": 39,
+      "ty": 35,
+      "tileId": "darkTreeTopLeft"
+    },
+    {
+      "tx": 40,
+      "ty": 35,
+      "tileId": "darkTreeTopRight"
+    },
+    {
+      "tx": 39,
+      "ty": 36,
+      "tileId": "darkTreeColumnLeft"
+    },
+    {
+      "tx": 40,
+      "ty": 36,
+      "tileId": "darkTreeColumnRight"
+    },
+    {
+      "tx": 39,
+      "ty": 37,
+      "tileId": "darkTreeColumnLeft"
+    },
+    {
+      "tx": 40,
+      "ty": 37,
+      "tileId": "darkTreeColumnRight"
+    },
+    {
+      "tx": 39,
+      "ty": 38,
+      "tileId": "darkTreeBottomLeft"
+    },
+    {
+      "tx": 40,
+      "ty": 38,
+      "tileId": "darkTreeBottomRight"
+    },
+    {
+      "tx": 53,
+      "ty": 21,
+      "tileId": "darkTreeTopLeft"
+    },
+    {
+      "tx": 54,
+      "ty": 21,
+      "tileId": "darkTreeTopRight"
+    },
+    {
+      "tx": 53,
+      "ty": 22,
+      "tileId": "darkTreeBottomLeft"
+    },
+    {
+      "tx": 54,
+      "ty": 22,
+      "tileId": "darkTreeBottomRight"
+    },
+    {
+      "tx": 53,
+      "ty": 27,
+      "tileId": "darkTreeTopLeft"
+    },
+    {
+      "tx": 54,
+      "ty": 27,
+      "tileId": "darkTreeTopRight"
+    },
+    {
+      "tx": 53,
+      "ty": 28,
+      "tileId": "darkTreeBottomLeft"
+    },
+    {
+      "tx": 54,
+      "ty": 28,
+      "tileId": "darkTreeBottomRight"
+    },
+    {
+      "tx": 53,
+      "ty": 43,
+      "tileId": "darkTreeTopLeft"
+    },
+    {
+      "tx": 54,
+      "ty": 43,
+      "tileId": "darkTreeTopRight"
+    },
+    {
+      "tx": 53,
+      "ty": 44,
+      "tileId": "darkTreeBottomLeft"
+    },
+    {
+      "tx": 54,
+      "ty": 44,
+      "tileId": "darkTreeBottomRight"
+    },
+    {
+      "tx": 69,
+      "ty": 21,
+      "tileId": "darkTreeTopLeft"
+    },
+    {
+      "tx": 70,
+      "ty": 21,
+      "tileId": "darkTreeTopRight"
+    },
+    {
+      "tx": 69,
+      "ty": 22,
+      "tileId": "darkTreeBottomLeft"
+    },
+    {
+      "tx": 70,
+      "ty": 22,
+      "tileId": "darkTreeBottomRight"
+    },
+    {
+      "tx": 69,
+      "ty": 39,
+      "tileId": "darkTreeTopLeft"
+    },
+    {
+      "tx": 70,
+      "ty": 39,
+      "tileId": "darkTreeTopRight"
+    },
+    {
+      "tx": 69,
+      "ty": 40,
+      "tileId": "darkTreeBottomLeft"
+    },
+    {
+      "tx": 70,
+      "ty": 40,
+      "tileId": "darkTreeBottomRight"
+    },
+    {
+      "tx": 72,
+      "ty": 21,
+      "tileId": "darkTreeTopLeft"
+    },
+    {
+      "tx": 73,
+      "ty": 21,
+      "tileId": "darkTreeTopRight"
+    },
+    {
+      "tx": 72,
+      "ty": 22,
+      "tileId": "darkTreeBottomLeft"
+    },
+    {
+      "tx": 73,
+      "ty": 22,
+      "tileId": "darkTreeBottomRight"
+    },
+    {
+      "tx": 72,
+      "ty": 27,
+      "tileId": "darkTreeTopLeft"
+    },
+    {
+      "tx": 73,
+      "ty": 27,
+      "tileId": "darkTreeTopRight"
+    },
+    {
+      "tx": 72,
+      "ty": 28,
+      "tileId": "darkTreeBottomLeft"
+    },
+    {
+      "tx": 73,
+      "ty": 28,
+      "tileId": "darkTreeBottomRight"
+    },
+    {
+      "tx": 72,
+      "ty": 39,
+      "tileId": "darkTreeTopLeft"
+    },
+    {
+      "tx": 73,
+      "ty": 39,
+      "tileId": "darkTreeTopRight"
+    },
+    {
+      "tx": 72,
+      "ty": 40,
+      "tileId": "darkTreeBottomLeft"
+    },
+    {
+      "tx": 73,
+      "ty": 40,
+      "tileId": "darkTreeBottomRight"
+    },
+    {
+      "tx": 0,
+      "ty": 16,
+      "tileId": "darkBush"
+    },
+    {
+      "tx": 0,
+      "ty": 17,
+      "tileId": "lightBush"
+    },
+    {
+      "tx": 0,
+      "ty": 20,
+      "tileId": "darkBush"
+    },
+    {
+      "tx": 12,
+      "ty": 15,
+      "tileId": "lightBush"
+    },
+    {
+      "tx": 12,
+      "ty": 22,
+      "tileId": "darkBush"
+    },
+    {
+      "tx": 29,
+      "ty": 29,
+      "tileId": "lightBush"
+    },
+    {
+      "tx": 28,
+      "ty": 13,
+      "tileId": "darkBush"
+    },
+    {
+      "tx": 28,
+      "ty": 20,
+      "tileId": "darkBush"
+    },
+    {
+      "tx": 51,
+      "ty": 13,
+      "tileId": "lightBush"
+    },
+    {
+      "tx": 52,
+      "ty": 13,
+      "tileId": "darkBush"
+    },
+    {
+      "tx": 69,
+      "ty": 11,
+      "tileId": "darkBush"
+    },
+    {
+      "tx": 70,
+      "ty": 11,
+      "tileId": "lightBush"
+    },
+    {
+      "tx": 42,
+      "ty": 27,
+      "tileId": "darkBush"
+    },
+    {
+      "tx": 42,
+      "ty": 34,
+      "tileId": "lightBush"
+    },
+    {
+      "tx": 41,
+      "ty": 41,
+      "tileId": "darkBush"
+    },
+    {
+      "tx": 29,
+      "ty": 37,
+      "tileId": "lightBush"
+    },
+    {
+      "tx": 29,
+      "ty": 43,
+      "tileId": "darkBush"
+    },
+    {
+      "tx": 13,
+      "ty": 37,
+      "tileId": "darkBush"
+    },
+    {
+      "tx": 17,
+      "ty": 43,
+      "tileId": "lightBush"
+    },
+    {
+      "tx": 0,
+      "ty": 27,
+      "tileId": "darkBush"
+    },
+    {
+      "tx": 0,
+      "ty": 38,
+      "tileId": "darkBush"
+    },
+    {
+      "tx": 0,
+      "ty": 49,
+      "tileId": "lightBush"
+    },
+    {
+      "tx": 10,
+      "ty": 49,
+      "tileId": "darkBush"
+    },
+    {
+      "tx": 20,
+      "ty": 49,
+      "tileId": "darkBush"
+    },
+    {
+      "tx": 30,
+      "ty": 49,
+      "tileId": "lightBush"
+    },
+    {
+      "tx": 33,
+      "ty": 18,
+      "tileId": "whiteFlower"
+    },
+    {
+      "tx": 34,
+      "ty": 18,
+      "tileId": "pinkFlower"
+    },
+    {
+      "tx": 40,
+      "ty": 18,
+      "tileId": "blueFlower"
+    },
+    {
+      "tx": 41,
+      "ty": 18,
+      "tileId": "yellowFlower"
+    },
+    {
+      "tx": 34,
+      "ty": 20,
+      "tileId": "whiteFlower"
+    },
+    {
+      "tx": 40,
+      "ty": 20,
+      "tileId": "pinkFlower"
+    },
+    {
+      "tx": 17,
+      "ty": 26,
+      "tileId": "yellowFlower"
+    },
+    {
+      "tx": 30,
+      "ty": 26,
+      "tileId": "blueFlower"
+    },
+    {
+      "tx": 43,
+      "ty": 26,
+      "tileId": "whiteFlower"
+    },
+    {
+      "tx": 60,
+      "ty": 26,
+      "tileId": "pinkFlower"
+    },
+    {
+      "tx": 20,
+      "ty": 11,
+      "tileId": "smallRock"
+    },
+    {
+      "tx": 2,
+      "ty": 22,
+      "tileId": "smallRock"
+    },
+    {
+      "tx": 13,
+      "ty": 26,
+      "tileId": "smallRock"
+    },
+    {
+      "tx": 29,
+      "ty": 26,
+      "tileId": "smallRock"
+    },
+    {
+      "tx": 42,
+      "ty": 26,
+      "tileId": "smallRock"
+    },
+    {
+      "tx": 60,
+      "ty": 26,
+      "tileId": "smallRock"
+    },
+    {
+      "tx": 2,
+      "ty": 3,
+      "tileId": "grassTuft"
+    },
+    {
+      "tx": 14,
+      "ty": 3,
+      "tileId": "grassTuft"
+    },
+    {
+      "tx": 24,
+      "ty": 8,
+      "tileId": "grassTuft"
+    },
+    {
+      "tx": 30,
+      "ty": 5,
+      "tileId": "grassTuft"
+    },
+    {
+      "tx": 40,
+      "ty": 12,
+      "tileId": "grassTuft"
+    },
+    {
+      "tx": 59,
+      "ty": 5,
+      "tileId": "grassTuft"
+    },
+    {
+      "tx": 71,
+      "ty": 5,
+      "tileId": "grassTuft"
+    },
+    {
+      "tx": 29,
+      "ty": 40,
+      "tileId": "grassTuft"
+    },
+    {
+      "tx": 41,
+      "ty": 48,
+      "tileId": "grassTuft"
+    },
+    {
+      "tx": 60,
+      "ty": 36,
+      "tileId": "grassTuft"
+    }
   ],
   "pondTiles": [
-    { "rect": [32, 42, 41, 46] },
-    { "rect": [35, 40, 39, 46] }
+    {
+      "rect": [
+        32,
+        42,
+        41,
+        46
+      ]
+    },
+    {
+      "rect": [
+        35,
+        40,
+        39,
+        46
+      ]
+    }
   ],
   "interiors": {
     "card-shop": {
@@ -633,7 +2404,6 @@
       "wallTileId": "interiorWallWhite",
       "floorTileId": "darkStoneFloor",
       "decor": [
-
         {
           "tx": 1,
           "ty": 2,
@@ -663,18 +2433,17 @@
           "tx": 6,
           "ty": 2,
           "tileId": "counterTopHorizontalMiddle"
-        },              
+        },
         {
           "tx": 7,
           "ty": 2,
           "tileId": "counterTopHorizontalRight"
-        },                    
-        
+        },
         {
           "tx": 1,
           "ty": 7,
           "tileId": "summoningCircle"
-        },        
+        },
         {
           "tx": 10,
           "ty": 7,
@@ -699,18 +2468,17 @@
           "tx": 1,
           "ty": 1,
           "tileId": "candlestickLitTop"
-        },        
+        },
         {
           "tx": 1,
           "ty": 2,
           "tileId": "candlestickLitBottom"
         },
-
         {
           "tx": 10,
           "ty": 6,
           "tileId": "candlestickLitTop"
-        },               
+        },
         {
           "tx": 10,
           "ty": 7,
@@ -721,7 +2489,6 @@
           "ty": 6,
           "tileId": "barrel"
         },
-
         {
           "tx": 9,
           "ty": 4,
@@ -732,7 +2499,6 @@
           "ty": 5,
           "tileId": "suitOfArmourBottom"
         },
-
         {
           "tx": 2,
           "ty": -1,
@@ -742,8 +2508,7 @@
           "tx": 3,
           "ty": -1,
           "tileId": "rapierMountedRight"
-        }, 
-
+        },
         {
           "tx": 5,
           "ty": -1,
@@ -753,8 +2518,7 @@
           "tx": 6,
           "ty": -1,
           "tileId": "swordMountedRight"
-        }, 
-
+        },
         {
           "tx": 5,
           "ty": 1,
@@ -764,7 +2528,7 @@
           "tx": 5,
           "ty": 2,
           "tileId": "helmetBottom"
-        },        
+        },
         {
           "tx": 7,
           "ty": 1,
@@ -970,7 +2734,6 @@
           "tileId": "simpleBedFoot",
           "zLayer": "below"
         },
-
         {
           "tx": 2,
           "ty": 1,
@@ -994,7 +2757,7 @@
           "ty": 2,
           "tileId": "simpleBedFootOverlay",
           "zLayer": "above"
-        },        
+        },
         {
           "tx": 8,
           "ty": 0,
@@ -1004,7 +2767,7 @@
           "tx": 8,
           "ty": 1,
           "tileId": "fireplaceBottomLeft"
-        },        
+        },
         {
           "tx": 9,
           "ty": 0,
@@ -1025,7 +2788,6 @@
           "ty": 1,
           "tileId": "fireplaceBottomRight"
         },
-
         {
           "tx": 5,
           "ty": 4,
@@ -1062,6 +2824,17 @@
           "tx": 9,
           "ty": 7,
           "tileId": "bookshelfBottom"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 10,
+          "ty": 4,
+          "toInteriorId": "home-barracks-passage",
+          "entryTx": 1,
+          "entryTy": 1,
+          "requiredQuest": "aldous-hidden-passage",
+          "label": "Hidden passage (blocked)"
         }
       ]
     },
@@ -1344,6 +3117,12 @@
       "floorTileId": "darkWoodFloor",
       "decor": [
         {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "ladderIntoFloor",
+          "zlayer": "below"
+        },
+        {
           "tx": 2,
           "ty": 2,
           "tileId": "counterTop"
@@ -1399,6 +3178,17 @@
           "tx": 10,
           "ty": 6,
           "tileId": "barrel"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 1,
+          "ty": 1,
+          "toInteriorId": "sw-building-b-upstairs",
+          "entryTx": 1,
+          "entryTy": 6,
+          "direction": "up",
+          "label": "Go upstairs"
         }
       ]
     },
@@ -1711,7 +3501,7 @@
         {
           "tx": 2,
           "ty": 2,
-          "tileId": "simpleBedHead"          ,
+          "tileId": "simpleBedHead",
           "zlayer": "below"
         },
         {
@@ -1729,7 +3519,7 @@
         {
           "tx": 4,
           "ty": 3,
-          "tileId": "simpleBedFoot"          ,
+          "tileId": "simpleBedFoot",
           "zlayer": "below"
         },
         {
@@ -1756,11 +3546,10 @@
           "tileId": "simpleBedFoot",
           "zlayer": "below"
         },
-
-                {
+        {
           "tx": 2,
           "ty": 2,
-          "tileId": "simpleBedHeadOverlay"          ,
+          "tileId": "simpleBedHeadOverlay",
           "zlayer": "above"
         },
         {
@@ -1778,7 +3567,7 @@
         {
           "tx": 4,
           "ty": 3,
-          "tileId": "simpleBedFootOverlay"          ,
+          "tileId": "simpleBedFootOverlay",
           "zlayer": "above"
         },
         {
@@ -1805,8 +3594,6 @@
           "tileId": "simpleBedFootOverlay",
           "zlayer": "above"
         },
-
-
         {
           "tx": 7,
           "ty": 4,
@@ -1831,6 +3618,17 @@
           "tx": 8,
           "ty": 5,
           "tileId": "barrel"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 1,
+          "ty": 4,
+          "toInteriorId": "home-barracks-passage",
+          "entryTx": 10,
+          "entryTy": 1,
+          "requiredQuest": "aldous-hidden-passage",
+          "label": "Hidden passage"
         }
       ]
     },
@@ -1966,52 +3764,378 @@
       "height": 10,
       "floorTileId": "blueOrnateFloor",
       "decor": [
-        { "tx":  1, "ty": 1, "tileId": "bookshelfTop" },
-        { "tx":  2, "ty": 1, "tileId": "bookshelfTop" },
-        { "tx":  1, "ty": 2, "tileId": "bookshelfBottom" },
-        { "tx":  2, "ty": 2, "tileId": "bookshelfBottom" },
-
-        { "tx":  7, "ty": 1, "tileId": "deskTop" },
-        { "tx":  8, "ty": 1, "tileId": "deskTop" },
-
-        { "tx": 13, "ty": 1, "tileId": "bookshelfTop" },
-        { "tx": 14, "ty": 1, "tileId": "bookshelfTop" },
-        { "tx": 13, "ty": 2, "tileId": "bookshelfBottom" },
-        { "tx": 14, "ty": 2, "tileId": "bookshelfBottom" },
-
-        { "tx":  3, "ty": 2, "tileId": "ornateStonePillarTop" },
-        { "tx":  3, "ty": 3, "tileId": "ornateStonePillarBottom" },
-        { "tx": 12, "ty": 2, "tileId": "ornateStonePillarTop" },
-        { "tx": 12, "ty": 3, "tileId": "ornateStonePillarBottom" },
-
-        { "tx":  4, "ty": 4, "tileId": "smallTableTopLeft" },
-        { "tx":  5, "ty": 4, "tileId": "smallTableTopMiddle" },
-        { "tx":  6, "ty": 4, "tileId": "smallTableTopMiddle" },
-        { "tx":  7, "ty": 4, "tileId": "smallTableTopMiddle" },
-        { "tx":  8, "ty": 4, "tileId": "smallTableTopMiddle" },
-        { "tx":  9, "ty": 4, "tileId": "smallTableTopMiddle" },
-        { "tx": 10, "ty": 4, "tileId": "smallTableTopMiddle" },
-        { "tx": 11, "ty": 4, "tileId": "smallTableTopRight" },
-        { "tx":  4, "ty": 5, "tileId": "smallTableBottomLeft" },
-        { "tx":  5, "ty": 5, "tileId": "smallTableBottomMiddle" },
-        { "tx":  6, "ty": 5, "tileId": "smallTableBottomMiddle" },
-        { "tx":  7, "ty": 5, "tileId": "smallTableBottomMiddle" },
-        { "tx":  8, "ty": 5, "tileId": "smallTableBottomMiddle" },
-        { "tx":  9, "ty": 5, "tileId": "smallTableBottomMiddle" },
-        { "tx": 10, "ty": 5, "tileId": "smallTableBottomMiddle" },
-        { "tx": 11, "ty": 5, "tileId": "smallTableBottomRight" },
-
-        { "tx":  3, "ty": 6, "tileId": "ornateStonePillarTop" },
-        { "tx":  3, "ty": 7, "tileId": "ornateStonePillarBottom" },
-        { "tx": 12, "ty": 6, "tileId": "ornateStonePillarTop" },
-        { "tx": 12, "ty": 7, "tileId": "ornateStonePillarBottom" },
-
-        { "tx":  4, "ty": 7, "tileId": "benchLeft" },
-        { "tx":  5, "ty": 7, "tileId": "benchMiddle" },
-        { "tx":  6, "ty": 7, "tileId": "benchRight" },
-        { "tx":  9, "ty": 7, "tileId": "benchLeft" },
-        { "tx": 10, "ty": 7, "tileId": "benchMiddle" },
-        { "tx": 11, "ty": 7, "tileId": "benchRight" }
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "bookshelfTop"
+        },
+        {
+          "tx": 2,
+          "ty": 1,
+          "tileId": "bookshelfTop"
+        },
+        {
+          "tx": 1,
+          "ty": 2,
+          "tileId": "bookshelfBottom"
+        },
+        {
+          "tx": 2,
+          "ty": 2,
+          "tileId": "bookshelfBottom"
+        },
+        {
+          "tx": 7,
+          "ty": 1,
+          "tileId": "deskTop"
+        },
+        {
+          "tx": 8,
+          "ty": 1,
+          "tileId": "deskTop"
+        },
+        {
+          "tx": 13,
+          "ty": 1,
+          "tileId": "bookshelfTop"
+        },
+        {
+          "tx": 14,
+          "ty": 1,
+          "tileId": "bookshelfTop"
+        },
+        {
+          "tx": 13,
+          "ty": 2,
+          "tileId": "bookshelfBottom"
+        },
+        {
+          "tx": 14,
+          "ty": 2,
+          "tileId": "bookshelfBottom"
+        },
+        {
+          "tx": 3,
+          "ty": 2,
+          "tileId": "ornateStonePillarTop"
+        },
+        {
+          "tx": 3,
+          "ty": 3,
+          "tileId": "ornateStonePillarBottom"
+        },
+        {
+          "tx": 12,
+          "ty": 2,
+          "tileId": "ornateStonePillarTop"
+        },
+        {
+          "tx": 12,
+          "ty": 3,
+          "tileId": "ornateStonePillarBottom"
+        },
+        {
+          "tx": 4,
+          "ty": 4,
+          "tileId": "smallTableTopLeft"
+        },
+        {
+          "tx": 5,
+          "ty": 4,
+          "tileId": "smallTableTopMiddle"
+        },
+        {
+          "tx": 6,
+          "ty": 4,
+          "tileId": "smallTableTopMiddle"
+        },
+        {
+          "tx": 7,
+          "ty": 4,
+          "tileId": "smallTableTopMiddle"
+        },
+        {
+          "tx": 8,
+          "ty": 4,
+          "tileId": "smallTableTopMiddle"
+        },
+        {
+          "tx": 9,
+          "ty": 4,
+          "tileId": "smallTableTopMiddle"
+        },
+        {
+          "tx": 10,
+          "ty": 4,
+          "tileId": "smallTableTopMiddle"
+        },
+        {
+          "tx": 11,
+          "ty": 4,
+          "tileId": "smallTableTopRight"
+        },
+        {
+          "tx": 4,
+          "ty": 5,
+          "tileId": "smallTableBottomLeft"
+        },
+        {
+          "tx": 5,
+          "ty": 5,
+          "tileId": "smallTableBottomMiddle"
+        },
+        {
+          "tx": 6,
+          "ty": 5,
+          "tileId": "smallTableBottomMiddle"
+        },
+        {
+          "tx": 7,
+          "ty": 5,
+          "tileId": "smallTableBottomMiddle"
+        },
+        {
+          "tx": 8,
+          "ty": 5,
+          "tileId": "smallTableBottomMiddle"
+        },
+        {
+          "tx": 9,
+          "ty": 5,
+          "tileId": "smallTableBottomMiddle"
+        },
+        {
+          "tx": 10,
+          "ty": 5,
+          "tileId": "smallTableBottomMiddle"
+        },
+        {
+          "tx": 11,
+          "ty": 5,
+          "tileId": "smallTableBottomRight"
+        },
+        {
+          "tx": 3,
+          "ty": 6,
+          "tileId": "ornateStonePillarTop"
+        },
+        {
+          "tx": 3,
+          "ty": 7,
+          "tileId": "ornateStonePillarBottom"
+        },
+        {
+          "tx": 12,
+          "ty": 6,
+          "tileId": "ornateStonePillarTop"
+        },
+        {
+          "tx": 12,
+          "ty": 7,
+          "tileId": "ornateStonePillarBottom"
+        },
+        {
+          "tx": 4,
+          "ty": 7,
+          "tileId": "benchLeft"
+        },
+        {
+          "tx": 5,
+          "ty": 7,
+          "tileId": "benchMiddle"
+        },
+        {
+          "tx": 6,
+          "ty": 7,
+          "tileId": "benchRight"
+        },
+        {
+          "tx": 9,
+          "ty": 7,
+          "tileId": "benchLeft"
+        },
+        {
+          "tx": 10,
+          "ty": 7,
+          "tileId": "benchMiddle"
+        },
+        {
+          "tx": 11,
+          "ty": 7,
+          "tileId": "benchRight"
+        }
+      ]
+    },
+    "sw-building-b-upstairs": {
+      "name": "The Wanderer's Rest (Upstairs)",
+      "width": 12,
+      "height": 9,
+      "floorTileId": "darkWoodFloor",
+      "wallMaterial": "tudor",
+      "decor": [
+        {
+          "tx": 2,
+          "ty": 1,
+          "tileId": "simpleBedHead",
+          "zlayer": "below"
+        },
+        {
+          "tx": 2,
+          "ty": 2,
+          "tileId": "simpleBedFoot",
+          "zlayer": "below"
+        },
+        {
+          "tx": 2,
+          "ty": 1,
+          "tileId": "simpleBedHeadOverlay",
+          "zlayer": "above"
+        },
+        {
+          "tx": 2,
+          "ty": 2,
+          "tileId": "simpleBedFootOverlay",
+          "zlayer": "above"
+        },
+        {
+          "tx": 4,
+          "ty": 1,
+          "tileId": "simpleBedHead",
+          "zlayer": "below"
+        },
+        {
+          "tx": 4,
+          "ty": 2,
+          "tileId": "simpleBedFoot",
+          "zlayer": "below"
+        },
+        {
+          "tx": 4,
+          "ty": 1,
+          "tileId": "simpleBedHeadOverlay",
+          "zlayer": "above"
+        },
+        {
+          "tx": 4,
+          "ty": 2,
+          "tileId": "simpleBedFootOverlay",
+          "zlayer": "above"
+        },
+        {
+          "tx": 7,
+          "ty": 1,
+          "tileId": "simpleBedHead",
+          "zlayer": "below"
+        },
+        {
+          "tx": 7,
+          "ty": 2,
+          "tileId": "simpleBedFoot",
+          "zlayer": "below"
+        },
+        {
+          "tx": 7,
+          "ty": 1,
+          "tileId": "simpleBedHeadOverlay",
+          "zlayer": "above"
+        },
+        {
+          "tx": 7,
+          "ty": 2,
+          "tileId": "simpleBedFootOverlay",
+          "zlayer": "above"
+        },
+        {
+          "tx": 9,
+          "ty": 1,
+          "tileId": "simpleBedHead",
+          "zlayer": "below"
+        },
+        {
+          "tx": 9,
+          "ty": 2,
+          "tileId": "simpleBedFoot",
+          "zlayer": "below"
+        },
+        {
+          "tx": 9,
+          "ty": 1,
+          "tileId": "simpleBedHeadOverlay",
+          "zlayer": "above"
+        },
+        {
+          "tx": 9,
+          "ty": 2,
+          "tileId": "simpleBedFootOverlay",
+          "zlayer": "above"
+        },
+        {
+          "tx": 5,
+          "ty": 5,
+          "tileId": "roundTable"
+        },
+        {
+          "tx": 6,
+          "ty": 5,
+          "tileId": "roundTable"
+        },
+        {
+          "tx": 1,
+          "ty": 7,
+          "tileId": "ladderIntoFloor",
+          "zlayer": "below"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 1,
+          "ty": 7,
+          "toInteriorId": "sw-building-b",
+          "entryTx": 1,
+          "entryTy": 2,
+          "direction": "down",
+          "label": "Go downstairs"
+        }
+      ]
+    },
+    "home-barracks-passage": {
+      "name": "Hidden Passage",
+      "width": 12,
+      "height": 3,
+      "floorTileId": "cobblestone",
+      "decor": [
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "ladderIntoFloor",
+          "zlayer": "below"
+        },
+        {
+          "tx": 10,
+          "ty": 1,
+          "tileId": "ladderIntoFloor",
+          "zlayer": "below"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 1,
+          "ty": 1,
+          "toInteriorId": "home",
+          "entryTx": 9,
+          "entryTy": 4,
+          "requiredQuest": "aldous-hidden-passage",
+          "label": "Back to quarters"
+        },
+        {
+          "tx": 10,
+          "ty": 1,
+          "toInteriorId": "barracks-north",
+          "entryTx": 2,
+          "entryTy": 4,
+          "requiredQuest": "aldous-hidden-passage",
+          "label": "Into barracks"
+        }
       ]
     }
   },
@@ -2028,7 +4152,14 @@
         "There is strength in preparation. Make sure your deck is ready before you venture out."
       ],
       "questGive": "lost-pendant",
-      "questReceive": ["aldous-family-heirloom", "mira-anti-fracture-charms", "alric-heartstone-analysis", "orin-champions-stand", "aldous-the-hearthstone", "thorin-the-last-watch"]
+      "questReceive": [
+        "aldous-family-heirloom",
+        "mira-anti-fracture-charms",
+        "alric-heartstone-analysis",
+        "orin-champions-stand",
+        "aldous-the-hearthstone",
+        "thorin-the-last-watch"
+      ]
     },
     {
       "id": "merchant",
@@ -2060,14 +4191,19 @@
       "id": "fisherman",
       "name": "Old Greyfish",
       "sprite": "hub-npc-fisherman",
-      "tx": 40, "ty": 40,
+      "tx": 40,
+      "ty": 40,
       "dialogue": [
         "Been sitting at this pond since before the Fracture. The water's gone quiet lately \u2014 something's stirring beneath.",
         "I pulled out a strange glowing fish last week. Threw it back \u2014 some things are better left undisturbed.",
         "Patience, wanderer. The best things in life take time."
       ],
       "questGive": "greyfishs-bait",
-      "questReceive": ["fisherman-fracture-depths", "elder-rallying-the-hub", "thorin-the-last-watch"]
+      "questReceive": [
+        "fisherman-fracture-depths",
+        "elder-rallying-the-hub",
+        "thorin-the-last-watch"
+      ]
     },
     {
       "id": "dealer",
@@ -2082,13 +4218,17 @@
         "One spin, one chance. What do you say, friend?"
       ],
       "questGive": "dealer-lucky-charm",
-      "questReceive": ["elder-rallying-the-hub", "dealer-echo-final-bet"]
+      "questReceive": [
+        "elder-rallying-the-hub",
+        "dealer-echo-final-bet"
+      ]
     },
     {
       "id": "campaign-gate",
       "name": "War Herald Davos",
       "sprite": "hub-npc-herald",
-      "tx": 33, "ty": 21,
+      "tx": 33,
+      "ty": 21,
       "screen": "campaign",
       "questGive": "the-password-part-3",
       "questReceive": "the-password-part-2",
@@ -2155,7 +4295,8 @@
       "id": "commander-post",
       "name": "Commander's Post",
       "sprite": "hub-npc-elder",
-      "tx": 32, "ty": 27,
+      "tx": 32,
+      "ty": 27,
       "screen": "commander",
       "dialogue": [
         "Your forces await your orders, Commander."
@@ -2238,13 +4379,25 @@
         "The Fracture left many mysteries. Perhaps you can solve them."
       ],
       "questGive": "scholars-anthology",
-      "questReceive": ["elder-old-codex", "gildwyn-stolen-card-plans", "lyss-cipher-key", "elder-absolution", "mira-anti-fracture-charms", "alric-heartstone-analysis", "lyss-the-final-cipher", "fisherman-depths-secret", "vex-final-trade", "thorin-the-last-watch"]
+      "questReceive": [
+        "elder-old-codex",
+        "gildwyn-stolen-card-plans",
+        "lyss-cipher-key",
+        "elder-absolution",
+        "mira-anti-fracture-charms",
+        "alric-heartstone-analysis",
+        "lyss-the-final-cipher",
+        "fisherman-depths-secret",
+        "vex-final-trade",
+        "thorin-the-last-watch"
+      ]
     },
     {
       "id": "achievements-keeper",
       "name": "The Chronicler",
       "sprite": "hub-npc-elder",
-      "tx": 35, "ty": 28,
+      "tx": 35,
+      "ty": 28,
       "screen": "hall-of-achievements",
       "dialogue": [
         "Your deeds are recorded here, Commander. Come see your legacy."
@@ -2255,16 +4408,19 @@
       "name": "The Chronicler",
       "sprite": "hub-npc-elder",
       "building": "arcade-building-e",
-      "tx": 6, "ty": 3,
+      "tx": 6,
+      "ty": 3,
       "screen": "hall-of-achievements",
-      "dialogue": ["Your deeds are recorded here, Commander. Come see your legacy."]
+      "dialogue": [
+        "Your deeds are recorded here, Commander. Come see your legacy."
+      ]
     },
-    
     {
       "id": "home-shelf",
       "name": "Steward Maren",
       "sprite": "hub-npc-elder",
-      "tx": 27, "ty": 10,
+      "tx": 27,
+      "ty": 10,
       "screen": "home-shelf",
       "dialogue": [
         "Your quarters are just inside, Commander. I keep your things in order.",
@@ -2276,105 +4432,156 @@
       "id": "fishing-hole",
       "name": "Rod",
       "sprite": "hub-npc-fisherman",
-      "tx": 35, "ty": 39,
+      "tx": 35,
+      "ty": 39,
       "screen": "fishing",
-      "dialogue": ["Nothings biting today. Maybe try again later?", "The fish are shy around here. Patience is key."]
+      "dialogue": [
+        "Nothings biting today. Maybe try again later?",
+        "The fish are shy around here. Patience is key."
+      ]
     },
     {
       "id": "fishing-hole-2",
       "name": "Captain Dan",
       "sprite": "hub-npc-fisherman",
-      "tx": 34, "ty": 41,
+      "tx": 34,
+      "ty": 41,
       "screen": "fishing",
-      "dialogue": ["The pond is calm today. Care to fish?"]
+      "dialogue": [
+        "The pond is calm today. Care to fish?"
+      ]
     },
     {
       "id": "marble-master",
       "name": "Marble Master",
       "sprite": "hub-npc-dealer",
-      "tx": 46, "ty": 22,
+      "tx": 46,
+      "ty": 22,
       "screen": "marble",
-      "dialogue": ["Steady hands and a keen eye — care to roll?", "Every marble tells a story. Shall we write yours?"]
+      "dialogue": [
+        "Steady hands and a keen eye \u2014 care to roll?",
+        "Every marble tells a story. Shall we write yours?"
+      ]
     },
     {
       "id": "the-flipper",
       "name": "The Flipper",
       "sprite": "hub-npc-merchant",
-      "tx": 48, "ty": 22,
+      "tx": 48,
+      "ty": 22,
       "screen": "tileflip",
-      "dialogue": ["Flip a tile, reveal your fate.", "Memory is a weapon. How sharp is yours?"]
+      "dialogue": [
+        "Flip a tile, reveal your fate.",
+        "Memory is a weapon. How sharp is yours?"
+      ]
     },
     {
       "id": "crystal-keeper",
       "name": "Crystal Keeper",
       "sprite": "hub-npc-scholar",
-      "tx": 52, "ty": 22,
+      "tx": 52,
+      "ty": 22,
       "screen": "crystalcatch",
-      "dialogue": ["Crystals falling fast — catch them before they shatter!", "Speed and focus. That is all you need."]
+      "dialogue": [
+        "Crystals falling fast \u2014 catch them before they shatter!",
+        "Speed and focus. That is all you need."
+      ]
     },
     {
       "id": "spinner-sal",
       "name": "Spinner Sal",
       "sprite": "hub-npc-dealer",
-      "tx": 54, "ty": 22,
+      "tx": 54,
+      "ty": 22,
       "screen": "spinner",
-      "dialogue": ["Give it a spin — luck favours the bold.", "The wheel knows no favourites. Try your luck!"]
+      "dialogue": [
+        "Give it a spin \u2014 luck favours the bold.",
+        "The wheel knows no favourites. Try your luck!"
+      ]
     },
     {
       "id": "race-marshal",
       "name": "Race Marshal",
       "sprite": "hub-npc-arena",
-      "tx": 56, "ty": 22,
+      "tx": 56,
+      "ty": 22,
       "screen": "marblerace",
-      "dialogue": ["On your marks — the race is about to begin!", "Place your bets and pick your marble. May the fastest win."]
+      "dialogue": [
+        "On your marks \u2014 the race is about to begin!",
+        "Place your bets and pick your marble. May the fastest win."
+      ]
     },
     {
       "id": "card-sharp",
       "name": "Card Sharp",
       "sprite": "hub-npc-merchant",
-      "tx": 56, "ty": 24,
+      "tx": 56,
+      "ty": 24,
       "screen": "higherOrLower",
-      "dialogue": ["Higher or lower? Simple question, nerves of steel.", "Read the deck — or trust your gut."]
+      "dialogue": [
+        "Higher or lower? Simple question, nerves of steel.",
+        "Read the deck \u2014 or trust your gut."
+      ]
     },
     {
       "id": "reels-remy",
       "name": "Reels Remy",
       "sprite": "hub-npc-dealer",
-      "tx": 54, "ty": 26,
+      "tx": 54,
+      "ty": 26,
       "screen": "fruitMachine",
-      "dialogue": ["Pull the lever and watch the reels spin!", "Three in a row and the jackpot is yours."]
+      "dialogue": [
+        "Pull the lever and watch the reels spin!",
+        "Three in a row and the jackpot is yours."
+      ]
     },
     {
       "id": "poker-pete",
       "name": "Poker Pete",
       "sprite": "hub-npc-dealer",
-      "tx": 52, "ty": 26,
+      "tx": 52,
+      "ty": 26,
       "screen": "videoPoker",
-      "dialogue": ["Best hand wins. Know when to hold, know when to fold.", "Poker face optional. Skill is not."]
+      "dialogue": [
+        "Best hand wins. Know when to hold, know when to fold.",
+        "Poker face optional. Skill is not."
+      ]
     },
     {
       "id": "prize-keeper",
       "name": "Prize Keeper",
       "sprite": "hub-npc-merchant",
-      "tx": 38, "ty": 27,
+      "tx": 38,
+      "ty": 27,
       "screen": "prizes",
-      "dialogue": ["Got tickets? I've got prizes. Let's make a deal.", "Trade in your winning tickets for something special."]
+      "dialogue": [
+        "Got tickets? I've got prizes. Let's make a deal.",
+        "Trade in your winning tickets for something special."
+      ]
     },
     {
       "id": "siege-master",
       "name": "Siege Master",
       "sprite": "hub-npc-soldier",
-      "tx": 41, "ty": 26,
+      "tx": 41,
+      "ty": 26,
       "screen": "towerDefence",
-      "dialogue": ["The enemy approaches. Build your defences and hold the line!", "Every tower placed is a life saved. Choose wisely."]
+      "dialogue": [
+        "The enemy approaches. Build your defences and hold the line!",
+        "Every tower placed is a life saved. Choose wisely."
+      ]
     },
     {
       "id": "town-planner",
       "name": "Town Planner",
       "sprite": "hub-npc-elder",
-      "tx": 39, "ty": 10,
+      "tx": 39,
+      "ty": 10,
       "screen": "citybuilder",
-      "dialogue": ["A great city starts with a single road. Shall we begin?", "Lay the streets, raise the buildings — this town is yours to shape."]
+      "dialogue": [
+        "A great city starts with a single road. Shall we begin?",
+        "Lay the streets, raise the buildings \u2014 this town is yours to shape."
+      ]
     },
     {
       "id": "home-steward",
@@ -2446,7 +4653,10 @@
         "Rooms are cheap, ale is cheaper. Stay as long as you need."
       ],
       "questGive": "innkeepers-package",
-      "questReceive": ["elder-rallying-the-hub", "thorin-the-last-watch"],
+      "questReceive": [
+        "elder-rallying-the-hub",
+        "thorin-the-last-watch"
+      ],
       "innRumours": [
         {
           "id": "rumour-barracks",
@@ -2478,7 +4688,14 @@
       "tx": 7,
       "ty": 4,
       "questGive": "ferryn-ledger",
-      "questReceive": ["vex-trade-ledger", "dealer-echo-bookie", "vex-supply-chain-rebuilt", "elder-rallying-the-hub", "zev-games-hall-stands", "thorin-the-last-watch"],
+      "questReceive": [
+        "vex-trade-ledger",
+        "dealer-echo-bookie",
+        "vex-supply-chain-rebuilt",
+        "elder-rallying-the-hub",
+        "zev-games-hall-stands",
+        "thorin-the-last-watch"
+      ],
       "dialogue": [
         "The Merchant's Guild has connections across every shard. We can help.",
         "Trade is the lifeblood of any civilisation. Even one in pieces.",
@@ -2504,7 +4721,8 @@
       "name": "Trophy Keeper Orin",
       "sprite": "hub-npc-elder",
       "building": "arcade-building-e",
-      "tx": 3, "ty": 3,
+      "tx": 3,
+      "ty": 3,
       "dialogue": [
         "Every trophy here represents a hard-won victory.",
         "Champions come and go, but their deeds are recorded forever.",
@@ -2540,7 +4758,20 @@
         "Need security? My men are at your service."
       ],
       "questGive": "thorin-security-report",
-      "questReceive": ["innkeepers-package", "rosie-spy-in-the-inn", "bram-echo-territory-map", "aldous-hidden-passage", "elder-confession", "varn-traitor-confronted", "elder-absolution", "bramble-fortified-supplies", "dealer-echo-final-bet", "mira-anti-fracture-charms", "zev-games-hall-stands", "orin-champions-stand"]
+      "questReceive": [
+        "innkeepers-package",
+        "rosie-spy-in-the-inn",
+        "bram-echo-territory-map",
+        "aldous-hidden-passage",
+        "elder-confession",
+        "varn-traitor-confronted",
+        "elder-absolution",
+        "bramble-fortified-supplies",
+        "dealer-echo-final-bet",
+        "mira-anti-fracture-charms",
+        "zev-games-hall-stands",
+        "orin-champions-stand"
+      ]
     },
     {
       "id": "drill-sergeant-varn",
@@ -2562,81 +4793,117 @@
       "name": "Marble Master",
       "sprite": "hub-npc-dealer",
       "building": "arcade-building-e",
-      "tx": 8, "ty": 3,
+      "tx": 8,
+      "ty": 3,
       "screen": "marble",
-      "dialogue": ["Steady hands and a keen eye — care to roll?", "Every marble tells a story. Shall we write yours?"]
+      "dialogue": [
+        "Steady hands and a keen eye \u2014 care to roll?",
+        "Every marble tells a story. Shall we write yours?"
+      ]
     },
     {
       "id": "the-flipper-int",
       "name": "The Flipper",
       "sprite": "hub-npc-merchant",
       "building": "arcade-building-e",
-      "tx": 4, "ty": 3,
+      "tx": 4,
+      "ty": 3,
       "screen": "tileflip",
-      "dialogue": ["Flip a tile, reveal your fate.", "Memory is a weapon. How sharp is yours?"]
+      "dialogue": [
+        "Flip a tile, reveal your fate.",
+        "Memory is a weapon. How sharp is yours?"
+      ]
     },
     {
       "id": "crystal-keeper-int",
       "name": "Crystal Keeper",
       "sprite": "hub-npc-scholar",
       "building": "arcade-building-e",
-      "tx": 6, "ty": 5,
+      "tx": 6,
+      "ty": 5,
       "screen": "crystalcatch",
-      "dialogue": ["Crystals falling fast — catch them before they shatter!", "Speed and focus. That is all you need."]
+      "dialogue": [
+        "Crystals falling fast \u2014 catch them before they shatter!",
+        "Speed and focus. That is all you need."
+      ]
     },
     {
       "id": "prize-keeper-int",
       "name": "Prize Keeper",
       "sprite": "hub-npc-merchant",
       "building": "arcade-building-e",
-      "tx": 2, "ty": 4,
+      "tx": 2,
+      "ty": 4,
       "screen": "prizes",
-      "dialogue": ["Got tickets? I've got prizes. Let's make a deal.", "Trade in your winning tickets for something special."]
+      "dialogue": [
+        "Got tickets? I've got prizes. Let's make a deal.",
+        "Trade in your winning tickets for something special."
+      ]
     },
     {
       "id": "spinner-sal-int",
       "name": "Spinner Sal",
       "sprite": "hub-npc-dealer",
       "building": "arcade-building-w",
-      "tx": 2, "ty": 2,
+      "tx": 2,
+      "ty": 2,
       "screen": "spinner",
-      "dialogue": ["Give it a spin — luck favours the bold.", "The wheel knows no favourites. Try your luck!"]
+      "dialogue": [
+        "Give it a spin \u2014 luck favours the bold.",
+        "The wheel knows no favourites. Try your luck!"
+      ]
     },
     {
       "id": "race-marshal-int",
       "name": "Race Marshal",
       "sprite": "hub-npc-arena",
       "building": "arcade-building-w",
-      "tx": 10, "ty": 2,
+      "tx": 10,
+      "ty": 2,
       "screen": "marblerace",
-      "dialogue": ["On your marks — the race is about to begin!", "Place your bets and pick your marble. May the fastest win."]
+      "dialogue": [
+        "On your marks \u2014 the race is about to begin!",
+        "Place your bets and pick your marble. May the fastest win."
+      ]
     },
     {
       "id": "card-sharp-int",
       "name": "Card Sharp",
       "sprite": "hub-npc-merchant",
       "building": "arcade-building-w",
-      "tx": 5, "ty": 5,
+      "tx": 5,
+      "ty": 5,
       "screen": "higherOrLower",
-      "dialogue": ["Higher or lower? Simple question, nerves of steel.", "Read the deck — or trust your gut."]
+      "dialogue": [
+        "Higher or lower? Simple question, nerves of steel.",
+        "Read the deck \u2014 or trust your gut."
+      ]
     },
     {
       "id": "reels-remy-int",
       "name": "Reels Remy",
       "sprite": "hub-npc-dealer",
       "building": "arcade-building-w",
-      "tx": 2, "ty": 8,
+      "tx": 2,
+      "ty": 8,
       "screen": "fruitMachine",
-      "dialogue": ["Pull the lever and watch the reels spin!", "Three in a row and the jackpot is yours."]
+      "dialogue": [
+        "Pull the lever and watch the reels spin!",
+        "Three in a row and the jackpot is yours."
+      ]
     },
     {
       "id": "poker-pete-int",
       "name": "Poker Pete",
       "sprite": "hub-npc-dealer",
       "building": "arcade-building-w",
-      "tx": 9, "ty": 8,
+      "tx": 9,
+      "ty": 8,
       "screen": "videoPoker",
-      "dialogue": ["Best hand wins. Know when to hold, know when to fold.", "Poker face optional. Skill is not."]
+      "dialogue": [
+        "Best hand wins. Know when to hold, know when to fold.",
+        "Poker face optional. Skill is not."
+      ]
     }
   ],
   "ambientNpcSprites": [
@@ -2645,7 +4912,7 @@
     "hub-npc-scholar",
     "hub-npc-fisherman"
   ],
-  "npcSpawnTiles": [ ],
+  "npcSpawnTiles": [],
   "lockedDoors": [
     {
       "buildingId": "barracks-vault",
@@ -2655,20 +4922,31 @@
   "treasures": [
     {
       "id": "forest-chest-1",
-      "tx": 31, "ty": 32,
+      "tx": 31,
+      "ty": 32,
       "tileId": "chest",
       "collectedTileId": "openChest",
       "title": "A moss-covered chest hidden in the forest",
-      "reward": { "crystals": 30 }
+      "reward": {
+        "crystals": 30
+      }
     },
     {
       "id": "augment-shop-chest",
       "buildingId": "augment-shop",
-      "tx": 9, "ty": 1,
+      "tx": 9,
+      "ty": 1,
       "tileId": "chest",
       "collectedTileId": "openChest",
       "title": "A dusty chest in Mira's studio",
-      "reward": { "consumables": [{ "id": "health_potion", "quantity": 3 }] }
+      "reward": {
+        "consumables": [
+          {
+            "id": "health_potion",
+            "quantity": 3
+          }
+        ]
+      }
     }
   ]
 }

--- a/web/src/data/hub/config.json
+++ b/web/src/data/hub/config.json
@@ -2395,7 +2395,11 @@
           "ty": 6,
           "tileId": "chest"
         }
-      ]
+      ],
+      "hours": {
+        "open": 8,
+        "close": 20
+      }
     },
     "augment-shop": {
       "name": "Mira's Enchantment Studio",
@@ -2539,7 +2543,11 @@
           "ty": 2,
           "tileId": "wizardHatBottom"
         }
-      ]
+      ],
+      "hours": {
+        "open": 8,
+        "close": 20
+      }
     },
     "supply-shop": {
       "name": "Bramble's Supplies",
@@ -2602,7 +2610,11 @@
           "ty": 7,
           "tileId": "bookshelfBottom"
         }
-      ]
+      ],
+      "hours": {
+        "open": 8,
+        "close": 20
+      }
     },
     "scholars-hall": {
       "name": "The Scholar's Hall",
@@ -2702,7 +2714,11 @@
           "ty": 7,
           "tileId": "chest"
         }
-      ]
+      ],
+      "hours": {
+        "open": 7,
+        "close": 22
+      }
     },
     "home": {
       "name": "Your Quarters",
@@ -2894,7 +2910,11 @@
           "ty": 6,
           "tileId": "pileOfSacks"
         }
-      ]
+      ],
+      "hours": {
+        "open": 8,
+        "close": 20
+      }
     },
     "scholars-north-w": {
       "name": "Northern Library Wing",
@@ -2967,7 +2987,11 @@
           "ty": 5,
           "tileId": "chest"
         }
-      ]
+      ],
+      "hours": {
+        "open": 7,
+        "close": 22
+      }
     },
     "scholars-north-e": {
       "name": "Cartography Room",
@@ -3020,7 +3044,11 @@
           "ty": 5,
           "tileId": "barrel"
         }
-      ]
+      ],
+      "hours": {
+        "open": 7,
+        "close": 22
+      }
     },
     "scholars-hall-w": {
       "name": "The Lecture Hall",
@@ -3108,7 +3136,11 @@
           "ty": 7,
           "tileId": "chest"
         }
-      ]
+      ],
+      "hours": {
+        "open": 7,
+        "close": 22
+      }
     },
     "sw-building-b": {
       "name": "The Wanderer's Rest",
@@ -3190,7 +3222,8 @@
           "direction": "up",
           "label": "Go upstairs"
         }
-      ]
+      ],
+      "hours": "always"
     },
     "traders-building": {
       "name": "Merchant's Guild Hall",
@@ -3630,7 +3663,8 @@
           "requiredQuest": "aldous-hidden-passage",
           "label": "Hidden passage"
         }
-      ]
+      ],
+      "hours": "always"
     },
     "barracks-south": {
       "name": "South Training Hall",
@@ -3718,7 +3752,8 @@
           "ty": 7,
           "tileId": "barrel"
         }
-      ]
+      ],
+      "hours": "always"
     },
     "barracks-vault": {
       "name": "Barracks Vault",
@@ -3756,7 +3791,8 @@
           "ty": 3,
           "tileId": "barrel"
         }
-      ]
+      ],
+      "hours": "always"
     },
     "town-hall": {
       "name": "The Town Hall",
@@ -3964,7 +4000,11 @@
           "ty": 7,
           "tileId": "benchRight"
         }
-      ]
+      ],
+      "hours": {
+        "open": 8,
+        "close": 18
+      }
     },
     "sw-building-b-upstairs": {
       "name": "The Wanderer's Rest (Upstairs)",
@@ -4096,7 +4136,8 @@
           "direction": "down",
           "label": "Go downstairs"
         }
-      ]
+      ],
+      "hours": "always"
     },
     "home-barracks-passage": {
       "name": "Hidden Passage",
@@ -4159,7 +4200,43 @@
         "orin-champions-stand",
         "aldous-the-hearthstone",
         "thorin-the-last-watch"
-      ]
+      ],
+      "schedule": [
+        {
+          "startHour": 0,
+          "endHour": 6,
+          "location": {
+            "type": "interior",
+            "buildingId": "sw-building-b-upstairs",
+            "tx": 2,
+            "ty": 1
+          }
+        },
+        {
+          "startHour": 6,
+          "endHour": 20,
+          "location": {
+            "type": "exterior",
+            "tx": 19,
+            "ty": 12
+          }
+        },
+        {
+          "startHour": 20,
+          "endHour": 0,
+          "location": {
+            "type": "interior",
+            "buildingId": "sw-building-b",
+            "tx": 5,
+            "ty": 5
+          }
+        }
+      ],
+      "homeBed": {
+        "buildingId": "sw-building-b-upstairs",
+        "tx": 2,
+        "ty": 1
+      }
     },
     {
       "id": "merchant",
@@ -4173,7 +4250,43 @@
         "Keep your coin close, wanderer. Not everyone in this town has honest intentions."
       ],
       "questGive": "merchants-herb",
-      "questReceive": "thorin-the-last-watch"
+      "questReceive": "thorin-the-last-watch",
+      "schedule": [
+        {
+          "startHour": 0,
+          "endHour": 6,
+          "location": {
+            "type": "interior",
+            "buildingId": "sw-building-b-upstairs",
+            "tx": 4,
+            "ty": 1
+          }
+        },
+        {
+          "startHour": 6,
+          "endHour": 20,
+          "location": {
+            "type": "exterior",
+            "tx": 22,
+            "ty": 24
+          }
+        },
+        {
+          "startHour": 20,
+          "endHour": 0,
+          "location": {
+            "type": "interior",
+            "buildingId": "sw-building-b",
+            "tx": 7,
+            "ty": 5
+          }
+        }
+      ],
+      "homeBed": {
+        "buildingId": "sw-building-b-upstairs",
+        "tx": 4,
+        "ty": 1
+      }
     },
     {
       "id": "scholar",
@@ -4185,7 +4298,43 @@
         "I have been cataloguing the Fracture shards. The answers are within your reach \u2014 if you dare.",
         "The archives hold centuries of knowledge. Most of it was lost in the Fracture. What remains is precious.",
         "Do not underestimate the power of knowing your enemy, Commander."
-      ]
+      ],
+      "schedule": [
+        {
+          "startHour": 0,
+          "endHour": 6,
+          "location": {
+            "type": "interior",
+            "buildingId": "sw-building-b-upstairs",
+            "tx": 9,
+            "ty": 1
+          }
+        },
+        {
+          "startHour": 6,
+          "endHour": 20,
+          "location": {
+            "type": "exterior",
+            "tx": 56,
+            "ty": 9
+          }
+        },
+        {
+          "startHour": 20,
+          "endHour": 0,
+          "location": {
+            "type": "interior",
+            "buildingId": "sw-building-b",
+            "tx": 8,
+            "ty": 4
+          }
+        }
+      ],
+      "homeBed": {
+        "buildingId": "sw-building-b-upstairs",
+        "tx": 9,
+        "ty": 1
+      }
     },
     {
       "id": "fisherman",
@@ -4203,7 +4352,43 @@
         "fisherman-fracture-depths",
         "elder-rallying-the-hub",
         "thorin-the-last-watch"
-      ]
+      ],
+      "schedule": [
+        {
+          "startHour": 0,
+          "endHour": 6,
+          "location": {
+            "type": "interior",
+            "buildingId": "sw-building-b-upstairs",
+            "tx": 7,
+            "ty": 1
+          }
+        },
+        {
+          "startHour": 6,
+          "endHour": 20,
+          "location": {
+            "type": "exterior",
+            "tx": 40,
+            "ty": 40
+          }
+        },
+        {
+          "startHour": 20,
+          "endHour": 0,
+          "location": {
+            "type": "interior",
+            "buildingId": "sw-building-b",
+            "tx": 4,
+            "ty": 4
+          }
+        }
+      ],
+      "homeBed": {
+        "buildingId": "sw-building-b-upstairs",
+        "tx": 7,
+        "ty": 1
+      }
     },
     {
       "id": "dealer",

--- a/web/src/data/hub/loader.ts
+++ b/web/src/data/hub/loader.ts
@@ -64,6 +64,15 @@ export interface HubInterior {
   floorTileId?: number
   wallMaterial?: WallMaterial
   exits?: HubInteriorExit[]
+  hours?: { open: number; close: number } | 'always'
+}
+
+export interface NpcScheduleEntry {
+  startHour: number
+  endHour: number
+  location:
+    | { type: 'exterior'; tx: number; ty: number }
+    | { type: 'interior'; buildingId: string; tx: number; ty: number }
 }
 
 export interface HubNpc {
@@ -79,6 +88,8 @@ export interface HubNpc {
   questReceive?: string | string[]
   innRumours?: Array<{ id: string; text: string }>
   isGhost?: boolean
+  schedule?: NpcScheduleEntry[]
+  homeBed?: { buildingId: string; tx: number; ty: number }
 }
 
 export interface HubPickupItem {
@@ -287,6 +298,7 @@ export const HUB_INTERIORS: Record<string, HubInterior> = Object.fromEntries(
           zlayer: d.zlayer as InteriorDecor['zlayer'],
         })),
         exits: ((rawAny.exits ?? []) as HubInteriorExit[]),
+        hours: rawAny.hours as HubInterior['hours'],
       } satisfies HubInterior,
     ]
   })

--- a/web/src/data/hub/loader.ts
+++ b/web/src/data/hub/loader.ts
@@ -43,6 +43,18 @@ export interface InteriorDecor {
   // above: walkable, renders above avatar (hanging items, backdrop shelves)
 }
 
+export interface HubInteriorExit {
+  tx: number
+  ty: number
+  toInteriorId: string
+  entryTx?: number
+  entryTy?: number
+  direction?: 'up' | 'down'
+  lockedBy?: string
+  requiredQuest?: string
+  label?: string
+}
+
 export interface HubInterior {
   id: string
   name: string
@@ -51,6 +63,7 @@ export interface HubInterior {
   decor: InteriorDecor[]
   floorTileId?: number
   wallMaterial?: WallMaterial
+  exits?: HubInteriorExit[]
 }
 
 export interface HubNpc {
@@ -273,6 +286,7 @@ export const HUB_INTERIORS: Record<string, HubInterior> = Object.fromEntries(
           tileId: resolveTileId(d.tileId),
           zlayer: d.zlayer as InteriorDecor['zlayer'],
         })),
+        exits: ((rawAny.exits ?? []) as HubInteriorExit[]),
       } satisfies HubInterior,
     ]
   })

--- a/web/src/data/hub/questDefs.ts
+++ b/web/src/data/hub/questDefs.ts
@@ -29,6 +29,7 @@ export interface HubQuestDef {
   completeDialogue: string
   steps: HubQuestStep[]
   reward: HubQuestReward
+  availableHours?: { start: number; end: number }
 }
 
 export const HUB_QUEST_DEFS: HubQuestDef[] = data.quests as unknown as HubQuestDef[]

--- a/web/src/game/hub/hubClock.ts
+++ b/web/src/game/hub/hubClock.ts
@@ -1,0 +1,48 @@
+// Hub world clock — 30 real minutes = 1 full game day.
+// Game hour is derived from device time modulo 30 minutes so that all
+// players on the same device see the same time, and it advances smoothly.
+
+/** Returns the current game hour (0–23). */
+export function getGameHour(): number {
+  const now = new Date()
+  const realMinutes = now.getHours() * 60 + now.getMinutes() + now.getSeconds() / 60
+  return Math.floor((realMinutes % 30) / 30 * 24)
+}
+
+/** Returns the current game minute within the hour (0–59). */
+export function getGameMinute(): number {
+  const now = new Date()
+  const realMinutes = now.getHours() * 60 + now.getMinutes() + now.getSeconds() / 60
+  const gameFraction = (realMinutes % 30) / 30  // 0–1 through the day
+  const totalGameMinutes = gameFraction * 24 * 60
+  return Math.floor(totalGameMinutes % 60)
+}
+
+/** Returns a display string like "14:30". */
+export function formatGameTime(): string {
+  const h = getGameHour()
+  const m = getGameMinute()
+  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`
+}
+
+/** Night: 20:00–05:59. */
+export function isNight(hour = getGameHour()): boolean {
+  return hour >= 20 || hour < 6
+}
+
+/** Dawn: 06:00–07:59. */
+export function isDawn(hour = getGameHour()): boolean {
+  return hour >= 6 && hour < 8
+}
+
+/** Inn gathering hours: 20:00–23:59. */
+export function isInnHours(hour = getGameHour()): boolean {
+  return hour >= 20 && hour < 24
+}
+
+/** Returns true if the given hour range contains `hour` (wraps midnight). */
+export function hourInRange(hour: number, start: number, end: number): boolean {
+  if (start <= end) return hour >= start && hour < end
+  // wraps midnight, e.g. start=22 end=6
+  return hour >= start || hour < end
+}

--- a/web/src/game/hub/hubNpcSchedule.ts
+++ b/web/src/game/hub/hubNpcSchedule.ts
@@ -1,0 +1,21 @@
+import { hourInRange } from './hubClock'
+import type { HubNpc, HubInterior, NpcScheduleEntry } from '../../data/hub/loader'
+
+export function getNpcLocation(npc: HubNpc, gameHour: number): NpcScheduleEntry['location'] | null {
+  if (!npc.schedule?.length) return null
+  for (const entry of npc.schedule) {
+    if (hourInRange(gameHour, entry.startHour, entry.endHour)) return entry.location
+  }
+  return null
+}
+
+export function isNpcInBuilding(npc: HubNpc, buildingId: string, gameHour: number): boolean {
+  const loc = getNpcLocation(npc, gameHour)
+  return loc?.type === 'interior' && loc.buildingId === buildingId
+}
+
+export function isBuildingOpen(interior: HubInterior, gameHour: number): boolean {
+  if (!interior.hours || interior.hours === 'always') return true
+  const { open, close } = interior.hours as { open: number; close: number }
+  return hourInRange(gameHour, open, close)
+}

--- a/web/src/hooks/useHubClock.ts
+++ b/web/src/hooks/useHubClock.ts
@@ -1,0 +1,28 @@
+import { useState, useEffect } from 'react'
+import { getGameHour, getGameMinute, isNight } from '../game/hub/hubClock'
+
+export interface HubClockState {
+  gameHour:   number
+  gameMinute: number
+  isNight:    boolean
+}
+
+function snapshot(): HubClockState {
+  const h = getGameHour()
+  return { gameHour: h, gameMinute: getGameMinute(), isNight: isNight(h) }
+}
+
+/**
+ * Returns the current hub game time, refreshing every `updateMs` milliseconds.
+ * Default 10 s is fine-grained enough for schedule checks without being wasteful.
+ */
+export function useHubClock(updateMs = 10_000): HubClockState {
+  const [state, setState] = useState<HubClockState>(snapshot)
+
+  useEffect(() => {
+    const id = setInterval(() => setState(snapshot()), updateMs)
+    return () => clearInterval(id)
+  }, [updateMs])
+
+  return state
+}


### PR DESCRIPTION
## Summary

Implements the hub living-world feature set across four phases. Phase 1 is complete in this commit; Phases 2–4 will be added in subsequent commits.

### Phase 1 — Hub Clock ✅
- New `hubClock.ts`: 30 real minutes = 1 full game day, derived from device time modulo 30 min. Exports `getGameHour`, `getGameMinute`, `formatGameTime`, `isNight`, `isDawn`, `isInnHours`, `hourInRange`.
- New `useHubClock` React hook: returns `{ gameHour, gameMinute, isNight }`, refreshes every 10 s.
- HUD toolbar now shows a moon/sun icon + current game time (e.g. `🌙 22:15`).
- Ghost spawn probability raised from 1 % → 10 % during night game hours.

### Phase 2 — Multi-Room Interiors & Cross-Building Passages (upcoming)
### Phase 3 — NPC Schedules & Building Hours (upcoming)
### Phase 4 — NPC Walking & Interior Persistence (upcoming)

## Test plan
- [ ] HUD toolbar displays a game time that advances — complete a 30-minute real cycle and confirm it runs 00:00 → 23:59
- [ ] Moon icon appears during game hours 20–05; sun otherwise
- [ ] At night hours, noticeably more ghost NPCs spawn on the hub map

https://claude.ai/code/session_01DVUtQ8n5zmGawj5yLHsY1m

---
_Generated by [Claude Code](https://claude.ai/code/session_01DVUtQ8n5zmGawj5yLHsY1m)_