### PR TITLE
fix(hub): fix TS18048 build error — completedQuestIdsRef optional chain

### DIFF
--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -1385,7 +1385,7 @@ export function HubTownCanvas({
             processInteriorWalkQueue()
             return
           }
-          if (roomExit.requiredQuest && !completedQuestIdsRef.current?.has(roomExit.requiredQuest)) {
+          if (roomExit.requiredQuest && !completedQuestIdsRef?.current.has(roomExit.requiredQuest)) {
             onDoorLockedRef.current?.(roomExit.toInteriorId, `quest:${roomExit.requiredQuest}`)
             processInteriorWalkQueue()
             return


### PR DESCRIPTION
## Summary

- Fixes the build failure introduced by PR #1499 where `completedQuestIdsRef` (an optional prop) was accessed as `completedQuestIdsRef.current?.has(...)` — TypeScript correctly flags this as TS18048 since the ref itself can be `undefined`.
- Corrected to `completedQuestIdsRef?.current.has(...)` to match the pattern used everywhere else in the file.

## Test plan
- [ ] `tsc && vite build` passes without TS18048 error

https://claude.ai/code/session_01DVUtQ8n5zmGawj5yLHsY1m

---
_Generated by [Claude Code](https://claude.ai/code/session_01DVUtQ8n5zmGawj5yLHsY1m)_