### PR TITLE
fix(hub): hide quest indicators when scheduled NPC moves inside

### DIFF
--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -693,12 +693,12 @@ export function HubTownCanvas({
     }
 
     // ── NPC name tags (show within 5 tiles of avatar) ─────────────────────────
-    const npcNameTags: { tx: number; ty: number; tag: PIXI.Container }[] = []
+    const npcNameTags: { npcId: string; tx: number; ty: number; tag: PIXI.Container }[] = []
     for (const { npc, cx, cy } of npcBubbleTargets) {
       const tag = createNameTag(npc.name, cx, cy)
       tag.visible = false
       bubbleLayer.addChild(tag)
-      npcNameTags.push({ tx: npc.tx, ty: npc.ty, tag })
+      npcNameTags.push({ npcId: npc.id, tx: npc.tx, ty: npc.ty, tag })
     }
 
     // ── Card-unit NPCs ─────────────────────────────────────────────────────────
@@ -971,7 +971,8 @@ export function HubTownCanvas({
 
       // Building hours check — block entry if closed
       if (!isBuildingOpen(interior, gameHourRef.current)) {
-        onDoorLockedRef.current?.(buildingId, 'closed')
+        const openHour = interior.hours !== 'always' && interior.hours ? interior.hours.open : null
+        onDoorLockedRef.current?.(buildingId, openHour !== null ? `closed:${openHour}` : 'closed')
         return
       }
 
@@ -1666,8 +1667,9 @@ export function HubTownCanvas({
       // NPC name tag proximity (exterior only)
       if (!interiorActive) {
         const [atx, aty] = currentTile
-        for (const { tx, ty, tag } of npcNameTags) {
-          tag.visible = Math.max(Math.abs(tx - atx), Math.abs(ty - aty)) <= 5
+        for (const { npcId, tx, ty, tag } of npcNameTags) {
+          const npcOnExterior = namedNpcContainers.get(npcId)?.visible ?? true
+          tag.visible = npcOnExterior && Math.max(Math.abs(tx - atx), Math.abs(ty - aty)) <= 5
         }
 
         // Blocked path visibility and proximity speech bubbles

--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -1704,7 +1704,9 @@ export function HubTownCanvas({
       const activeBaseY      = interiorActive ? interiorIndicatorBaseY  : questIndicatorBaseY
       for (const [npcId, ind] of activeIndicators) {
         const state = questNpcState?.current.get(npcId) ?? null
-        ind.visible = state !== null
+        // Also hide the indicator when the NPC has moved inside a building
+        const npcOnExterior = namedNpcContainers.get(npcId)?.visible ?? true
+        ind.visible = state !== null && (interiorActive || npcOnExterior)
         ind.text    = state === 'ready' ? '?' : '!'
         if (state !== null) {
           const baseY = activeBaseY.get(npcId) ?? ind.y

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -352,7 +352,11 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onPlayerTap, crystals
   }, [refreshState])
 
   const handleDoorLocked = useCallback((_buildingId: string, requiredItem: string) => {
-    if (requiredItem === 'closed') {
+    if (requiredItem.startsWith('closed:')) {
+      const openHour = parseInt(requiredItem.slice(7))
+      const openStr  = `${String(openHour).padStart(2, '0')}:00`
+      setDialogueLine(`This building is closed right now. Opens at ${openStr}.`)
+    } else if (requiredItem === 'closed') {
       setDialogueLine('This building is closed right now. Come back later.')
     } else if (requiredItem.startsWith('quest:')) {
       setDialogueLine("This passage is sealed. You'll need to discover it first.")


### PR DESCRIPTION
## Summary

- Quest `!`/`?` indicators were positioned at the NPC's fixed exterior tile and only hidden based on `questNpcState`. When a scheduled NPC moved inside a building (container hidden), the floating indicator stayed behind at their daytime spot.
- Fix: in the ticker indicator loop, also check `namedNpcContainers.get(npcId)?.visible`. If the NPC container is hidden (they're inside), the indicator is suppressed too. Interior indicators are unaffected (`interiorActive` guard).

## Test plan
- [ ] At game hour 20, elder/merchant disappear from exterior — their `!`/`?` badge disappears with them
- [ ] Entering the inn shows them at their table; their indicator appears above them there if they have an active quest state

https://claude.ai/code/session_01DVUtQ8n5zmGawj5yLHsY1m

---
_Generated by [Claude Code](https://claude.ai/code/session_01DVUtQ8n5zmGawj5yLHsY1m)_