### PR TITLE
fix(hub): don't show LEAVE button when closed-building entry is blocked

### DIFF
--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -65,6 +65,7 @@ interface Props {
   onNpcTap?:        (dialogue: string, npcId: string) => void
   interiorEnterRef?: React.MutableRefObject<((buildingId: string) => void) | null>
   interiorExitRef?:  React.MutableRefObject<(() => void) | null>
+  onEnterInterior?:  () => void
   onExitInterior?:   () => void
   onTileTap?:        (tx: number, ty: number) => void
   pickedUpIds?:      Set<string>
@@ -83,7 +84,7 @@ interface Props {
 export function HubTownCanvas({
   onAreaEnter, onNodeInteract, onAvatarMove,
   returnRef, unitCards, commander, onNpcTap,
-  interiorEnterRef, interiorExitRef, onExitInterior, onTileTap,
+  interiorEnterRef, interiorExitRef, onEnterInterior, onExitInterior, onTileTap,
   pickedUpIds, onItemPickup, doorKeys, onDoorLocked, questNpcState, activeQuestIdsRef,
   completedQuestIdsRef, collectedTreasureIds, onTreasureStep,
   gameHour, isNight,
@@ -99,6 +100,8 @@ export function HubTownCanvas({
   onNpcTapRef.current     = onNpcTap
   const unitCardsRef      = useRef(unitCards)
   unitCardsRef.current    = unitCards
+  const onEnterInteriorRef  = useRef(onEnterInterior)
+  onEnterInteriorRef.current = onEnterInterior
   const onExitInteriorRef   = useRef(onExitInterior)
   onExitInteriorRef.current = onExitInterior
   const onTileTapRef        = useRef(onTileTap)
@@ -997,6 +1000,9 @@ export function HubTownCanvas({
       const intH = interior.height * T
       intOffX = Math.floor((MAP_W - intW) / 2)
       intOffY = Math.floor((MAP_H - intH) / 2)
+
+      // Notify HubWorld that entry succeeded (must happen after all guard returns)
+      onEnterInteriorRef.current?.()
 
       // Hide exterior layers
       groundLayer.visible   = false

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -251,7 +251,6 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onPlayerTap, crystals
   const handleNodeInteract = useCallback((screen: string) => {
     if (screen.startsWith('interior:')) {
       const buildingId = screen.slice(9)
-      setInteriorActive(true)
       interiorEnterRef.current?.(buildingId)
       return
     }
@@ -537,6 +536,7 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onPlayerTap, crystals
             onNpcTap={handleNpcTap}
             interiorEnterRef={interiorEnterRef}
             interiorExitRef={interiorExitRef}
+            onEnterInterior={() => setInteriorActive(true)}
             onExitInterior={() => setInteriorActive(false)}
             onTileTap={onTileTap}
             pickedUpIds={pickedUpIds}


### PR DESCRIPTION
## Problem

`handleNodeInteract` in `HubWorld.tsx` called `setInteriorActive(true)` before invoking `doEnterInterior`. If the building was closed (or locked), `doEnterInterior` returned early — but React state was already set to active, so the LEAVE button appeared even though the player never entered.

## Fix

- Remove `setInteriorActive(true)` from `handleNodeInteract`
- Add `onEnterInterior?: () => void` prop to `HubTownCanvas`
- `doEnterInterior` calls `onEnterInteriorRef.current?.()` after all guard-return checks (closed, locked, missing interior) pass — i.e. only on successful entry
- `HubWorld` wires `onEnterInterior={() => setInteriorActive(true)}`

## Test plan

- [ ] Walk to a closed shop — "closed" dialogue appears, no LEAVE button
- [ ] Walk to an open shop and enter — LEAVE button appears as expected
- [ ] Walk to a locked door — locked dialogue, no LEAVE button
- [ ] Interior-to-interior transitions still work (LEAVE button stays visible)

https://claude.ai/code/session_01DVUtQ8n5zmGawj5yLHsY1m

---
_Generated by [Claude Code](https://claude.ai/code/session_01DVUtQ8n5zmGawj5yLHsY1m)_