### PR TITLE
fix(endless): restore in-progress endless run after page reload

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -324,6 +324,13 @@ export default function App() {
       return { screen: 'actcomplete' as Screen, gameState: null as GameState | null, run: savedRun, isCampaign: false }
     }
     if (isHubWorldUnlocked() && loadHubDefault() !== 'title' && loadSkipIntro()) return { screen: 'hubworld' as Screen, gameState: null as GameState | null, run: savedRun as RunState | null, isCampaign: false }
+    // Restore an in-progress endless run interrupted by a page reload (e.g. SW auto-update)
+    const savedEndless = loadBattleState()
+    if (savedEndless?.endlessMode && savedEndless.phase?.type !== 'gameOver') {
+      const endlessArch = loadPlayerArchetype()
+      if (endlessArch) savedEndless.archetypePassive = endlessArch
+      return { screen: 'playing' as Screen, gameState: savedEndless, run: null as RunState | null, isCampaign: false }
+    }
     return { screen: (loadSkipIntro() ? 'title' : 'intro') as Screen, gameState: null as GameState | null, run: savedRun as RunState | null, isCampaign: false }
   })
 
@@ -724,6 +731,7 @@ export default function App() {
   }, [launchQuickBattle])
 
   const launchEndless = useCallback(() => {
+    clearBattleState()
     isCampaignRef.current = false
     isDailyChallengeRef.current = false
     battleFlawlessRef.current = true
@@ -1938,6 +1946,7 @@ export default function App() {
         saveDailyChallengeResult(false)
       }
       isDailyChallengeRef.current = false
+      clearBattleState()
       dispatch({ type: 'END' })
       setScreen('title')
     }


### PR DESCRIPTION
## Summary

- **Root cause:** The service worker `controllerchange` event triggers `window.location.reload()` when a new SW activates. The startup code only restored mid-battle state for campaign mode (guarded by `savedRun?.pendingNodeId`). Endless mode had no equivalent restore path, so all progress was wiped.
- `saveBattleState()` already writes the full `GameState` to localStorage on every card play (wave number, survival time, HP, hand, deck — everything). The data was there; the startup code just never read it back for endless sessions.
- Three targeted changes to `App.tsx`:
  1. **Startup restore:** detect `endlessMode === true` in `loadBattleState()` and drop the player straight back into the `playing` screen — mirrors the existing campaign battle restore path.
  2. **`launchEndless`:** call `clearBattleState()` before starting so a fresh run never accidentally picks up a stale previous save.
  3. **`handleGiveUp` (non-campaign branch):** call `clearBattleState()` so giving up cleans the saved state rather than leaving it around for the next startup.

## Test plan

- [ ] Start an endless run, play several cards to advance a wave or two, then hard-refresh the page — should land back in the battle at the last card-play state
- [ ] Start an endless run, hit Give Up, then hard-refresh — should go to title screen (not restore the abandoned run)
- [ ] Start a fresh endless run after a previous one — should start fresh, not restore an old save
- [ ] Campaign battle restore still works after refresh (regression check)

https://claude.ai/code/session_01AHdyHfqNo8F7pQ6y33tiEf

---
_Generated by [Claude Code](https://claude.ai/code/session_01AHdyHfqNo8F7pQ6y33tiEf)_