### PR TITLE
feat(hubworld): add Olgrim (endless) and Vex (daily challenge) NPCs near Davos

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2543,6 +2543,7 @@ export default function App() {
             }
           }}
           onCampaign={() => { setReturnScreen('hubworld'); handleCampaign() }}
+          onEndless={() => { setReturnScreen('hubworld'); handleEndless() }}
           onPlayerTap={() => { setReturnScreen('hubworld'); setScreen('player') }}
           crystals={crystals}
           user={user}

--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -80,6 +80,7 @@ interface Props {
   onTreasureStep?:       (id: string) => void
   gameHour?:             number
   isNight?:              boolean
+  npcProximityDialogue?: React.MutableRefObject<Map<string, { atDistance: number; text: string }[]>>
 }
 
 export function HubTownCanvas({
@@ -88,7 +89,7 @@ export function HubTownCanvas({
   interiorEnterRef, interiorExitRef, onEnterInterior, onExitInterior, onTileTap,
   pickedUpIds, onItemPickup, doorKeys, onDoorLocked, questNpcState, activeQuestIdsRef,
   completedQuestIdsRef, collectedTreasureIds, onTreasureStep,
-  gameHour, isNight,
+  gameHour, isNight, npcProximityDialogue,
 }: Props) {
   const containerRef      = useRef<HTMLDivElement>(null)
   const onAreaRef         = useRef(onAreaEnter)
@@ -653,6 +654,8 @@ export function HubTownCanvas({
       currentBuildingId: string | null
     }
     const namedNpcWalkStates = new Map<string, NamedNpcWalkState>()
+    // Proximity bubbles for named NPCs driven by npcProximityDialogue ref
+    const namedNpcProximityBubbles = new Map<string, { bubble: PIXI.Container | null; lastText: string | null }>()
     // Interior quest indicators: rebuilt each time we enter a building
     const interiorQuestIndicators     = new Map<string, PIXI.Text>()
     const interiorIndicatorBaseY      = new Map<string, number>()
@@ -1839,6 +1842,32 @@ export function HubTownCanvas({
               }
               n.lastBubbleText = newText
             }
+          }
+        }
+      }
+
+      // Named NPC proximity bubbles (dynamic content from npcProximityDialogue ref)
+      if (!interiorActive && npcProximityDialogue) {
+        const [atx, aty] = currentTile
+        for (const [npcId, dialogues] of npcProximityDialogue.current) {
+          const ws = namedNpcWalkStates.get(npcId)
+          if (!ws || ws.isInside) { continue }
+          const dist = Math.max(Math.abs(ws.currentTx - atx), Math.abs(ws.currentTy - aty))
+          const match = dialogues
+            .filter(p => dist <= p.atDistance)
+            .sort((a, b) => a.atDistance - b.atDistance)[0]
+          const newText = match ? match.text : null
+          const entry = namedNpcProximityBubbles.get(npcId) ?? { bubble: null, lastText: null }
+          if (newText !== entry.lastText) {
+            if (entry.bubble) { bubbleLayer.removeChild(entry.bubble); entry.bubble = null }
+            if (newText !== null) {
+              const cx = ws.currentTx * T + T / 2
+              const cy = ws.currentTy * T + T
+              entry.bubble = createSpeechBubble(newText, cx, cy)
+              bubbleLayer.addChild(entry.bubble)
+            }
+            entry.lastText = newText
+            namedNpcProximityBubbles.set(npcId, entry)
           }
         }
       }

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -31,6 +31,7 @@ import { TreasureModal } from './TreasureModal'
 import { getCollectedTreasureIds, markTreasureCollected } from '../../game/hub/treasures'
 import { useHubClock } from '../../hooks/useHubClock'
 import { formatGameTime, hourInRange } from '../../game/hub/hubClock'
+import { getDailyChallengeState } from '../../game/dailyChallenge'
 
 const T = 32
 const INITIAL_SCROLL = {
@@ -86,6 +87,7 @@ interface Props {
   onBack:             () => void
   onNavigate?:        (screen: string) => void
   onCampaign?:        () => void
+  onEndless?:         () => void
   onPlayerTap?:       () => void
   crystals?:          number
   isSignedIn?:        boolean
@@ -98,7 +100,7 @@ interface Props {
   onTileTap?:         (tx: number, ty: number) => void
 }
 
-export function HubWorld({ onBack, onNavigate, onCampaign, onPlayerTap, crystals = 0, isSignedIn = false, commander, user, onSignIn: onLoginToggle, onSignOut, onFeedback, onCrystalsChange, onTileTap }: Props) {
+export function HubWorld({ onBack, onNavigate, onCampaign, onEndless, onPlayerTap, crystals = 0, isSignedIn = false, commander, user, onSignIn: onLoginToggle, onSignOut, onFeedback, onCrystalsChange, onTileTap }: Props) {
   const [splashVisible, setSplashVisible] = useState(() => !_hubSplashShown && !loadSkipIntro())
   const [splashFading,  setSplashFading]  = useState(false)
   const [currentArea,    setCurrentArea]    = useState<string | null>(null)
@@ -142,6 +144,23 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onPlayerTap, crystals
       if (getQuestState(quest.id).status === 'active') s.add(quest.id)
     }
     activeQuestIdsRef.current = s
+  }
+
+  // Proximity dialogue for named NPCs: dynamic text shown as speech bubbles on approach
+  const npcProximityDialogueRef = useRef(new Map<string, { atDistance: number; text: string }[]>())
+  {
+    const dc = getDailyChallengeState()
+    let dcText: string
+    if (dc.won === true) {
+      dcText = "Today's challenge: complete!"
+    } else if (dc.attempts > 0) {
+      dcText = `Daily challenge: attempt ${dc.attempts}`
+    } else {
+      dcText = 'Daily challenge awaits!'
+    }
+    npcProximityDialogueRef.current = new Map([
+      ['challenge-herald', [{ atDistance: 5, text: dcText }]],
+    ])
   }
 
   // Completed quest IDs: read imperatively by PixiJS ticker to gate blocked path state
@@ -255,6 +274,7 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onPlayerTap, crystals
       return
     }
     if (screen === 'campaign') { onCampaign?.(); return }
+    if (screen === 'endless') { onEndless?.(); return }
     if (screen === 'commander' && !commander) {
       setDialogueEvent({ speakerName: "Commander's Post", text: "No commander has been assigned yet. Visit the title screen to choose one." })
       return
@@ -550,6 +570,7 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onPlayerTap, crystals
             onTreasureStep={handleTreasureStep}
             gameHour={gameHour}
             isNight={isGameNight}
+            npcProximityDialogue={npcProximityDialogueRef}
           />
         </div>
         <AreaNameBadge name={currentArea} />

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -31,7 +31,7 @@ import { TreasureModal } from './TreasureModal'
 import { getCollectedTreasureIds, markTreasureCollected } from '../../game/hub/treasures'
 import { useHubClock } from '../../hooks/useHubClock'
 import { formatGameTime, hourInRange } from '../../game/hub/hubClock'
-import { getDailyChallengeState } from '../../game/dailyChallenge'
+import { getDailyChallengeNPCDialogue } from '../../game/hub/npcDialogue'
 
 const T = 32
 const INITIAL_SCROLL = {
@@ -148,20 +148,9 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onEndless, onPlayerTa
 
   // Proximity dialogue for named NPCs: dynamic text shown as speech bubbles on approach
   const npcProximityDialogueRef = useRef(new Map<string, { atDistance: number; text: string }[]>())
-  {
-    const dc = getDailyChallengeState()
-    let dcText: string
-    if (dc.won === true) {
-      dcText = "Today's challenge: complete!"
-    } else if (dc.attempts > 0) {
-      dcText = `Daily challenge: attempt ${dc.attempts}`
-    } else {
-      dcText = 'Daily challenge awaits!'
-    }
-    npcProximityDialogueRef.current = new Map([
-      ['challenge-herald', [{ atDistance: 5, text: dcText }]],
-    ])
-  }
+  npcProximityDialogueRef.current = new Map([
+    ['challenge-herald', getDailyChallengeNPCDialogue()],
+  ])
 
   // Completed quest IDs: read imperatively by PixiJS ticker to gate blocked path state
   const completedQuestIdsRef = useRef(new Set<string>())

--- a/web/src/data/hub/config.json
+++ b/web/src/data/hub/config.json
@@ -5458,6 +5458,32 @@
       ]
     },
     {
+      "id": "endless-herald",
+      "name": "Warchief Olgrim",
+      "sprite": "hub-npc-soldier",
+      "tx": 31,
+      "ty": 21,
+      "screen": "endless",
+      "dialogue": [
+        "The endless pits never close, Commander. How long can you last?",
+        "Wave after wave. Only the strongest endure.",
+        "Glory awaits those who survive the endless onslaught."
+      ]
+    },
+    {
+      "id": "challenge-herald",
+      "name": "Challenge Herald Vex",
+      "sprite": "hub-npc-herald",
+      "tx": 35,
+      "ty": 21,
+      "screen": "dailychallenge",
+      "dialogue": [
+        "Today's challenge is set. Every commander faces the same deck.",
+        "The daily trial resets at dawn. Will you answer the call?",
+        "One challenge, one day. Prove your worth, Commander."
+      ]
+    },
+    {
       "id": "quickbattle-gate",
       "name": "Pit Master Gorr",
       "sprite": "hub-npc-arena",

--- a/web/src/game/hub/npcDialogue.ts
+++ b/web/src/game/hub/npcDialogue.ts
@@ -1,0 +1,15 @@
+import { getDailyChallengeState } from '../dailyChallenge'
+
+/** Returns proximity dialogue entries for the daily challenge herald NPC. */
+export function getDailyChallengeNPCDialogue(): { atDistance: number; text: string }[] {
+  const dc = getDailyChallengeState()
+  let text: string
+  if (dc.won === true) {
+    text = "Today's challenge: complete!"
+  } else if (dc.attempts > 0) {
+    text = `Daily challenge: attempt ${dc.attempts}`
+  } else {
+    text = 'Daily challenge awaits!'
+  }
+  return [{ atDistance: 5, text }]
+}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Warchief Olgrim** placed at (31, 21) — 2 tiles left of Davos, launches endless mode
- **Challenge Herald Vex** placed at (35, 21) — 2 tiles right of Davos, launches daily challenge
- Vex shows a proximity speech bubble (within 5 tiles) with live daily challenge state: `"Today's challenge: complete!"`, `"Daily challenge: attempt N"`, or `"Daily challenge awaits!"`

## Changes

- `config.json`: two new NPC entries flanking War Herald Davos
- `HubWorld.tsx`: `onEndless` prop; `screen === 'endless'` handler; `npcProximityDialogueRef` computed from `getDailyChallengeState()` each render
- `HubTownCanvas.tsx`: new `npcProximityDialogue` ref prop; ticker shows/hides speech bubbles for named NPCs based on Chebyshev distance
- `App.tsx`: passes `onEndless={handleEndless}` to `<HubWorld>` (reuses existing deck-selector flow)

## Test plan

- [ ] Walk up to Warchief Olgrim — tap launches endless mode (deck selector shown if Deck B has cards)
- [ ] Walk up to Challenge Herald Vex — tap navigates to daily challenge screen
- [ ] Approach Vex within 5 tiles — speech bubble appears with correct state text
- [ ] Complete daily challenge, return to hub — Vex bubble updates to "complete!"
- [ ] Existing Davos / Gorr behaviour unchanged

https://claude.ai/code/session_01BJKCr7DSeuiNrjsdA1jRUe
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BJKCr7DSeuiNrjsdA1jRUe)_