### PR TITLE
Pin battlefield size so bar content can't resize the play area

### DIFF
--- a/web/src/components/battle/Battlefield.tsx
+++ b/web/src/components/battle/Battlefield.tsx
@@ -716,7 +716,7 @@ export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPaus
 
   return (
     <div
-      className={`battlefield u-col u-grow${actTheme ? ` battlefield--${actTheme}` : ''}${paused ? ' battlefield--paused' : ''}`}
+      className={`battlefield u-grow${actTheme ? ` battlefield--${actTheme}` : ''}${paused ? ' battlefield--paused' : ''}`}
       onClick={paused && !inspectedUnit ? () => doPause(false) : undefined}
     >
 
@@ -751,6 +751,8 @@ export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPaus
         </div>
       )}
 
+      {/* Top cluster: floats above the lane in the reserved top band */}
+      <div className="bf-top-cluster">
       {/* Top bar: clock, scores */}
       <div className={`top-bar${state.suddenDeath ? ' top-bar--sudden-death' : ''}`}>
         <button className="bf-pause-btn" onClick={() => doPause(true)} title="Menu">MENU</button>
@@ -809,6 +811,7 @@ export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPaus
             <span className="strategy-label">{STRATEGY_LABELS[state.opponentStrategy]}</span>
           )}
         </span>
+      </div>
       </div>
 
       {/* The Lane — vertical, fills remaining space */}
@@ -1012,6 +1015,8 @@ export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPaus
         )
       })()}
 
+      {/* Bottom cluster: floats below the lane in the reserved bottom band */}
+      <div className="bf-bottom-cluster">
       {/* Player base */}
       <div className="base-bar base-bar--player">
         <img
@@ -1116,6 +1121,7 @@ export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPaus
       </div>
         )
       })()}
+      </div>
 
       {cardDetailNode}
 

--- a/web/src/components/battle/battlefield/BattlefieldTerrainCanvas.tsx
+++ b/web/src/components/battle/battlefield/BattlefieldTerrainCanvas.tsx
@@ -51,14 +51,26 @@ export function BattlefieldTerrainCanvas({ environment, id, terrain }: Props) {
   useEffect(() => {
     const el = wrapRef.current
     if (!el) return
+    let raf = 0
     const measure = () => {
       const { width, height } = el.getBoundingClientRect()
-      if (width > 0 && height > 0) setDims({ w: Math.ceil(width), h: Math.ceil(height) })
+      if (width > 0 && height > 0) {
+        const w = Math.ceil(width)
+        const h = Math.ceil(height)
+        // Only update when the rounded size actually changes — avoids needless remounts.
+        setDims(prev => (prev && prev.w === w && prev.h === h) ? prev : { w, h })
+      }
     }
+    // Re-measure whenever the container resizes (viewport/orientation change).
+    // rAF-debounced so a burst of resize callbacks collapses into a single remount
+    // at the final size. The lane no longer resizes during battle, so this is rare.
+    const ro = new ResizeObserver(() => {
+      cancelAnimationFrame(raf)
+      raf = requestAnimationFrame(measure)
+    })
+    ro.observe(el)
     measure()
-    // Retry after paint in case layout hasn't settled yet
-    const raf = requestAnimationFrame(measure)
-    return () => cancelAnimationFrame(raf)
+    return () => { cancelAnimationFrame(raf); ro.disconnect() }
   }, [])
 
   return (
@@ -66,7 +78,8 @@ export function BattlefieldTerrainCanvas({ environment, id, terrain }: Props) {
       ref={wrapRef}
       style={{ position: 'absolute', inset: 0, overflow: 'hidden', zIndex: 0, pointerEvents: 'none' }}
     >
-      {dims && <TerrainPixi environment={environment} id={id} terrain={terrain} w={dims.w} h={dims.h} />}
+      {/* Re-key on size so the Pixi scene remounts and rebuilds at the new dimensions. */}
+      {dims && <TerrainPixi key={`${dims.w}x${dims.h}`} environment={environment} id={id} terrain={terrain} w={dims.w} h={dims.h} />}
     </div>
   )
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -209,9 +209,29 @@ body {
 /* ─── Battlefield ────────────────────────────────────── */
 
 .battlefield {
-  gap: 5px;
+  position: relative;
   min-height: 0;
+  /* Fixed bands reserved for the floating bar clusters. The lane fills the space
+     between them, so the play area's size depends only on the viewport — never on
+     bar content (long scores, wave status, event tags, card-bar height changes). */
+  --bf-top-buffer: 80px;
+  --bf-bottom-buffer: 230px;
 }
+
+/* Floating bar clusters: absolutely positioned in the reserved bands above/below
+   the lane. Their content can grow/wrap without ever resizing or reflowing the lane. */
+.bf-top-cluster,
+.bf-bottom-cluster {
+  position: absolute;
+  left: 0;
+  right: 0;
+  z-index: 5;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+.bf-top-cluster { top: 0; }
+.bf-bottom-cluster { bottom: 0; }
 
 /* ─── Top Bar (clock + scores + sudden death) ─────────── */
 
@@ -220,6 +240,9 @@ body {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  flex-wrap: nowrap;
+  white-space: nowrap;
+  overflow: hidden;
   padding: 3px 8px;
   border: 1px solid var(--game-border);
   border-radius: 3px;
@@ -431,9 +454,13 @@ body {
 /* ─── The Lane (vertical — fills remaining space) ────── */
 
 .lane {
-  position: relative;
-  flex: 1;
-  min-height: 160px;
+  /* Absolute fill between the reserved buffer bands — size is viewport-driven only.
+     Still establishes the positioning context + rect source for %-placed units. */
+  position: absolute;
+  top: var(--bf-top-buffer);
+  bottom: var(--bf-bottom-buffer);
+  left: 0;
+  right: 0;
   border: 2px solid var(--game-border);
   border-radius: 3px;
   background:
@@ -1349,6 +1376,8 @@ body {
   .game-container { padding: 4px 6px; }
   .game-title { font-size: var(--font-base); letter-spacing: 1px; }
 
+  .battlefield { --bf-top-buffer: 74px; --bf-bottom-buffer: 200px; }
+
   .hand-cards { gap: 4px; padding-bottom: 4px; }
   .card-tile { width: 78px; padding: 6px 8px; }
   .card-title { font-size: var(--font-xxs); }
@@ -1374,7 +1403,7 @@ body {
   .card-title { font-size: 0.571rem; }
 
   .lane { min-height: 90px; }
-  .battlefield { gap: 3px; }
+  .battlefield { --bf-top-buffer: 68px; --bf-bottom-buffer: 182px; }
 }
 
 /* ─── Intro Screen ───────────────────────────────────── */


### PR DESCRIPTION
## Problem

The battlefield visibly resized **during** a battle whenever the surrounding bars changed height — a long score, between-wave status, or event tags wrapping the **top bar**, or the **card bar** changing height (truce banner / slightly different card sizes). These resizes caused graphic glitches and broke pointer interactions.

**Root cause:** the battle screen (`Battlefield.tsx`) is a flex column where `.lane` (the play area) is the only `flex:1` child; every other row is content-height `flex-shrink:0`. So any sibling height change was absorbed by the lane. That, in turn:
- left the Pixi **terrain canvas** stale/misaligned — it measured its size **once on mount** with no `ResizeObserver`; and
- shifted the pointer→game-coord mapping (which reads the live lane rect) mid-gesture, breaking taps.

## Fix (overlay bars + fixed play area)

Make the lane's size depend **only on the viewport**, never on bar content, and float the bars above it — the approach requested in planning.

- `.battlefield` is now `position: relative`. The top bar + opponent HP bar are wrapped in `.bf-top-cluster`, and the player HP bar + stance bar + hand in `.bf-bottom-cluster`. Both are absolutely positioned in fixed top/bottom **buffer bands** (CSS vars `--bf-top-buffer` / `--bf-bottom-buffer`), so their content can grow/wrap without ever reflowing the lane.
- `.lane` is absolutely pinned between the buffer bands. It **remains the positioning context and `getBoundingClientRect` source**, so the existing percentage-based unit placement (`topPct`/`hPct`) and the AoE tap mapping are deliberately left untouched — they now just run on a stable rect.
- `.top-bar` gets `nowrap`; buffer sizes have responsive overrides at the ≤480px / ≤380px breakpoints.
- `BattlefieldTerrainCanvas` now uses a rAF-debounced `ResizeObserver` and re-keys the Pixi scene, so the terrain re-renders aligned after a genuine viewport/orientation resize instead of going stale.

Cluster `z-index: 5` sits above the lane and below every modal overlay (all ≥ 40 — important-msg, sudden-death, boss-splash, battle-event, AoE banner/reticle), so banners and splashes still paint on top. Units at the extreme top (enemy base) and bottom (player commander) render at the lane edges, beside the floating bars rather than under them.

## Testing

- `tsc --noEmit` clean; `vite build` succeeds; `vitest run` 58/58 unit tests pass.
- **Needs a visual pass in-app** (I couldn't run a browser here): start a battle and confirm the lane's borders don't move while the score grows, an endless truce banner shows, event tags appear, and the hand updates; confirm AoE taps still land where expected; resize/rotate the window and confirm the terrain stays aligned; confirm the commander (bottom) and enemy units (top) aren't hidden behind the bars.

> Note: the buffer pixel values (`--bf-*-buffer`) are sized generously with slack; they may want minor tuning once viewed on real devices. The correctness property (the lane never resizes from bar content) holds regardless of the exact values.

https://claude.ai/code/session_01VNRdkgwiYXd6GBzwXi5XbZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01VNRdkgwiYXd6GBzwXi5XbZ)_