### PR TITLE
Fix AOE that kills a commander not ending the game (forward-port of #1515)

### DIFF
--- a/web/src/game/engine.ts
+++ b/web/src/game/engine.ts
@@ -545,16 +545,19 @@ export function tick(state: GameState, deltaMs: number): GameState {
   processAttacks(s, deltaMs, log)
 
   // 4a. Sync commander/boss HP → base HP so game-over check and UI bars are accurate.
-  // find() matches a dying commander (hp 0, dyingTimer running) too, so Math.max(0, hp) already
-  // yields 0 in that case — no separate "is dying" branch is needed.
+  // find() matches a dying commander (hp 0, dyingTimer running). If the commander is gone
+  // entirely — e.g. an AOE dropped it to 0 with no dyingTimer and it was purged from the field —
+  // force base HP to 0 so the game-over check still fires (otherwise it keeps a stale value).
   const playerCmd = s.field.find(u => u.isCommander && u.owner === 'player')
   if (playerCmd) s.playerBase.hp = Math.max(0, playerCmd.hp)
+  else s.playerBase.hp = 0
   if (s.bossCard && !s.endlessMode) {
     const bossUnit = s.field.find(u => u.owner === 'opponent' && u.name === s.bossCard && u.hp > 0)
     if (bossUnit) s.opponentBase.hp = bossUnit.hp
   } else {
     const opCmd = s.field.find(u => u.isCommander && u.owner === 'opponent')
     if (opCmd) s.opponentBase.hp = Math.max(0, opCmd.hp)
+    else s.opponentBase.hp = 0
   }
 
   // 4b. Check for game over before processing timers, so player still gets credit for killing a boss in the same tick that it kills them

--- a/web/src/game/engine/cards.ts
+++ b/web/src/game/engine/cards.ts
@@ -9,6 +9,7 @@ import {
   ARCH_SWARM_UNIT_THRESHOLD, ARCH_SWARM_COST_REDUCTION,
   ARCH_SCHOLAR_UPGRADE_MULT,
 } from './constants';
+import { DEATH_LINGER_MS } from './combat';
 
 /** Returns the mana cost the player actually pays for a card, after archetype passives. */
 export function getEffectiveCardCost(card: Card, state: GameState): number {
@@ -252,6 +253,9 @@ export function playAoeCard(state: GameState, cardId: string, cx: number, cy: nu
   for (const u of targets) {
     u.hp -= dmg
     u.damageFlashTimer = 200
+    // Mark mobile kills as dying so they linger for the death animation and aren't
+    // silently purged before the commander/base HP sync + game-over check can see them.
+    if (u.hp <= 0 && u.moveSpeed > 0 && !u.isWall) u.dyingTimer = DEATH_LINGER_MS
   }
   s.log.push(`Your AOE! ${targets.length} enem${targets.length === 1 ? 'y' : 'ies'} hit for ${dmg} damage.`)
 
@@ -298,6 +302,9 @@ export function applyUpgrade(s: GameState, effect: UpgradeEffect, owner: 'player
     for (const u of targets) {
       u.hp -= dmg
       u.damageFlashTimer = 200
+      // Mark mobile kills as dying so they linger for the death animation and aren't
+      // silently purged before the commander/base HP sync + game-over check can see them.
+      if (u.hp <= 0 && u.moveSpeed > 0 && !u.isWall) u.dyingTimer = DEATH_LINGER_MS
     }
     log.push(`${label} AOE! ${targets.length} enem${targets.length === 1 ? 'y' : 'ies'} hit for ${dmg} damage.`)
   } else if (effect.type === 'buffHp') {


### PR DESCRIPTION
Re-applies the still-needed half of #1515 on top of current `main`, since that PR's branch predates the engine refactor in #1516 and no longer merges cleanly. The DoT-rounding half described in #1515 already landed separately via **#1513**, so only the AOE-commander-wipe fix remains.

## The bug (live on `main`)

`combat.ts` purges any unit that isn't alive, a moat, or actively dying:
```ts
s.field = s.field.filter(u => u.hp > 0 || u.isMoat || (u.dyingTimer != null && u.dyingTimer > 0))
```
AOE upgrade cards (World's End, Root Surge, …) reduced a unit's HP to 0 **without setting `dyingTimer`**. So when an AOE killed a commander, it was removed from the field entirely. The HP-sync's `find(commander)` then returned `undefined`, base HP kept its stale (full) value, and `checkGameOver` never fired — the commander vanished, the HP bar stayed full, and the game (notably **endless mode**) never ended.

> Note: #1516's cleanup removed the dead `else if` that #1515 intended to convert into a live `else`, so the safety net was gone on `main`; this restores it correctly.

## Fix

- **`cards.ts`** — set `dyingTimer` on mobile units an AOE kills, in **both** AOE paths:
  - `applyUpgrade` (opponent → player commander — the path #1515 fixed), and
  - `playAoeCard` (player → enemy commander — the same bug #1515 missed; without it, a player AOE killing the enemy commander wouldn't register a win).
  
  The unit now lingers on the field so the HP-sync + game-over check see it (and the death animation plays).
- **`engine.ts`** — restore an unconditional `else { base.hp = 0 }` on both HP-sync branches as a safety net for any other silent-removal path.

### Endless-mode safety
Verified the opponent-side `else` is safe: `triggerNextEndlessWave` (called synchronously from `checkGameOver` when `opponentBase.hp <= 0`) resets `opponentBase.hp` and respawns the commander before returning, and the 5s truce runs with that commander present. So `opCmd` is only ever `undefined` on the single tick a wave should advance — which the `else` correctly drives.

## Testing
- `tsc --noEmit` clean; `vite build` succeeds; `vitest run` 58/58 pass.
- Manual checks to run in-app: opponent plays World's End / Root Surge in endless mode → game-over screen fires instead of the commander disappearing silently; a player AOE that finishes the enemy commander registers the win; the AOE death animation plays.

Closes #1515.

https://claude.ai/code/session_01VNRdkgwiYXd6GBzwXi5XbZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01VNRdkgwiYXd6GBzwXi5XbZ)_