### PR TITLE
feat(hubworld): world node map, Ironhold Keep & Millhaven

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -60,6 +60,8 @@ import { DeckBuilder }        from './components/cards/DeckBuilder'
 import { PackOpening }        from './components/cards/PackOpening'
 import { NodeMap }            from './components/campaign/NodeMap'
 import { HubWorld }           from './components/hub/HubWorld'
+import { HubWorldMap }        from './components/hub/HubWorldMap'
+import { HubLocationWorld }   from './components/hub/HubLocationWorld'
 import { CasinoScreen }       from './components/hub/CasinoScreen'
 import { PostBattleReward }   from './components/battle/PostBattleReward'
 import { ActComplete }        from './components/battle/ActComplete'
@@ -102,6 +104,9 @@ import { useAchievements } from './hooks/useAchievements'
 import { isNoDamageMode } from './game/debug'
 import { saveBattleState, loadBattleState, clearBattleState } from './game/battleState'
 import { loadCommander, promoteCommander, CommanderState } from './game/commander'
+import { LOCATION_REGISTRY } from './data/world/locationRegistry'
+import { WORLD_MAP_NODES } from './data/world/worldMapDef'
+import { setCurrentWorldLocation, markNodeCleared, isNodeCleared } from './game/world/worldState'
 import { CommanderScreen } from './components/screens/CommanderScreen'
 import { TrainingScreen }  from './components/screens/TrainingScreen'
 import {
@@ -229,6 +234,8 @@ type Screen =
   | 'hubworld'
   | 'hub-minigame'
   | 'casino'
+  | 'worldmap'
+  | 'location'
 
 
 const STANCE_RULES_BY_NODE_TYPE: Partial<Record<string, StanceRules>> = {
@@ -336,6 +343,7 @@ export default function App() {
 
   const [screen, setScreen]             = useState<Screen>(_startup.screen)
   const [returnScreen, setReturnScreen]  = useState<Screen>('title')
+  const [currentLocationKey, setCurrentLocationKey] = useState<string>('ravenwatch')
   const [miniGamesEntry, setMiniGamesEntry] = useState<'menu' | 'citybuilder'>('menu')
   const [hubMiniGameEntry, setHubMiniGameEntry] = useState<SubScreen>('menu')
   const [showTitleLoginModal, setShowTitleLoginModal] = useState(false)
@@ -381,6 +389,10 @@ export default function App() {
   const [packs, setPacks]         = useState<string[][]>([])
   const [handicap, setHandicap]   = useState<number>(loadHandicap)
   const [crystals, setCrystals]   = useState<number>(loadCrystals)
+  const allQuestDefs = useMemo(
+    () => Object.values(LOCATION_REGISTRY).flatMap(e => e.questDefs),
+    []
+  )
   const [quickPlayRewardClaimed, setQuickPlayRewardClaimed] = useState(false)
 
   // Campaign run state
@@ -2544,6 +2556,7 @@ export default function App() {
           }}
           onCampaign={() => { setReturnScreen('hubworld'); handleCampaign() }}
           onEndless={() => { setReturnScreen('hubworld'); handleEndless() }}
+          onWorldMap={() => setScreen('worldmap')}
           onPlayerTap={() => { setReturnScreen('hubworld'); setScreen('player') }}
           crystals={crystals}
           user={user}
@@ -2561,6 +2574,40 @@ export default function App() {
           crystals={crystals}
           onCrystalsChange={(n) => { saveCrystals(n); setCrystals(n) }}
           onBack={() => setScreen('hubworld')}
+        />
+      )}
+
+      {screen === 'worldmap' && (
+        <HubWorldMap
+          onSelectNode={(node) => {
+            setCurrentWorldLocation(node.id)
+            if (node.id === 'ravenwatch') {
+              setScreen('hubworld')
+            } else if (node.locationKey && LOCATION_REGISTRY[node.locationKey]) {
+              setCurrentLocationKey(node.locationKey)
+              setScreen('location')
+            } else if (node.type === 'battle') {
+              if (!isNodeCleared(node.id)) {
+                setReturnScreen('worldmap')
+                handleCampaign()
+              }
+            }
+          }}
+          onBack={() => setScreen('hubworld')}
+        />
+      )}
+
+      {screen === 'location' && LOCATION_REGISTRY[currentLocationKey] && (
+        <HubLocationWorld
+          locationData={LOCATION_REGISTRY[currentLocationKey].locationData}
+          questDefs={LOCATION_REGISTRY[currentLocationKey].questDefs}
+          allQuestDefs={allQuestDefs}
+          user={user}
+          crystals={crystals}
+          commander={commander ?? undefined}
+          onBack={() => setScreen('worldmap')}
+          onCrystalsChange={(n) => { saveCrystals(n); setCrystals(n) }}
+          onFeedback={() => setFeedbackOpen(true)}
         />
       )}
 

--- a/web/src/components/hub/HubLocationWorld.tsx
+++ b/web/src/components/hub/HubLocationWorld.tsx
@@ -1,0 +1,455 @@
+import React, { useState, useCallback, useEffect, useMemo, useRef } from 'react'
+import { User } from 'firebase/auth'
+import { OverlayScreen } from '../ui/OverlayScreen'
+import { HubTownCanvas, getSavedHubTile } from './HubTownCanvas'
+import { AreaNameBadge } from './AreaNameBadge'
+import { HubReturnButton } from './HubReturnButton'
+import { HubDialogue } from './HubDialogue'
+import type { DialogueChoice } from './HubDialogue'
+import { QuestsModal } from './QuestsModal'
+import { TreasureModal } from './TreasureModal'
+import { Toolbar } from '../ui/Toolbar/Toolbar'
+import { ToolbarButton } from '../ui/Toolbar/ToolbarButton'
+import { ToolbarLabel } from '../ui/Toolbar/ToolbarLabel'
+import { ToolbarSpacer } from '../ui/Toolbar/ToolbarSpacer'
+import type { HubLocationData } from '../../data/hub/locationTypes'
+import type { HubQuestDef } from '../../data/hub/questDefs'
+import type { HubTreasure } from '../../data/hub/loader'
+import { getPickedUpIds, markPickedUp, unmarkPickedUp } from '../../game/hub/pickups'
+import { getQuestState, setQuestStatus, incrementQuestProgress, getQuestProgress, resetQuest } from '../../game/hub/quests'
+import { loadCrystals, saveCrystals, addCardsToCollection, loadDeck } from '../../game/collection'
+import { getCardCatalog } from '../../game/cards'
+import { getCollectibles, addCollectible } from '../../game/itemStore'
+import { getCollectedTreasureIds, markTreasureCollected } from '../../game/hub/treasures'
+import { getFriendshipLevel, addFriendshipXp } from '../../game/hub/friendship'
+import { useHubClock } from '../../hooks/useHubClock'
+import { CommanderState } from '../../game/commander'
+
+const T = 32
+
+interface QuestEvent {
+  speakerName: string
+  text: string
+  choices?: DialogueChoice[]
+  onClose?: () => void
+}
+
+function checkPrerequisite(prereq: string): boolean {
+  return prereq.split('|').every(p => {
+    const part = p.trim()
+    if (part.startsWith('friendship:')) {
+      const parts = part.split(':')
+      return getFriendshipLevel(parts[1]) >= parseInt(parts[2] ?? '1')
+    }
+    if (part.startsWith('quest:')) {
+      return getQuestState(part.slice(6)).status === 'completed'
+    }
+    return true
+  })
+}
+
+function isQuestReadyToComplete(quest: HubQuestDef): boolean {
+  return quest.steps.every(step => getQuestProgress(quest.id, step.key) >= step.required)
+}
+
+function getActiveDialogue(quest: HubQuestDef): string {
+  const { activeDialogue } = quest
+  if (typeof activeDialogue === 'string') return activeDialogue
+  for (const step of quest.steps) {
+    if (getQuestProgress(quest.id, step.key) < step.required) {
+      return activeDialogue[step.key] ?? Object.values(activeDialogue)[0]
+    }
+  }
+  return Object.values(activeDialogue)[Object.values(activeDialogue).length - 1]
+}
+
+function formatQuestReward(reward: HubQuestDef['reward']): string {
+  const parts: string[] = []
+  if (reward.crystals)    parts.push(`+${reward.crystals} 💎`)
+  if (reward.collectible) parts.push(`${reward.collectible.icon} ${reward.collectible.name}`)
+  if (reward.card)        parts.push(`🃏 ${reward.card.name} (card)`)
+  return parts.length > 0 ? `You received: ${parts.join('  ·  ')}` : ''
+}
+
+function grantQuestReward(quest: HubQuestDef): void {
+  const { reward } = quest
+  if (reward.crystals) saveCrystals(loadCrystals() + reward.crystals)
+  if (reward.collectible) {
+    const { id, name, icon, desc } = reward.collectible
+    addCollectible(id, { name, icon, desc })
+  }
+  if (reward.card) {
+    addCardsToCollection([{ cardName: reward.card.name, count: reward.card.count ?? 1 }])
+  }
+  if (reward.friendship) {
+    for (const [npcId, xp] of Object.entries(reward.friendship)) {
+      addFriendshipXp(npcId, xp)
+    }
+  }
+}
+
+interface Props {
+  locationData:    HubLocationData
+  questDefs:       HubQuestDef[]
+  allQuestDefs:    HubQuestDef[]
+  user:            User | null
+  crystals?:       number
+  commander?:      CommanderState
+  onBack:          () => void
+  onCrystalsChange?: (n: number) => void
+  onFeedback?:     () => void
+}
+
+export function HubLocationWorld({
+  locationData, questDefs, allQuestDefs, crystals = 0, commander,
+  onBack, onCrystalsChange, onFeedback,
+}: Props) {
+  const allNpcs = locationData.HUB_NPCS
+
+  const [currentArea,    setCurrentArea]    = useState<string | null>(null)
+  const [dialogueLine,   setDialogueLine]   = useState<string | null>(null)
+  const [dialogueEvent,  setDialogueEvent]  = useState<QuestEvent | null>(null)
+  const [interiorActive, setInteriorActive] = useState(false)
+  const [pickedUpIds,    setPickedUpIds]    = useState<Set<string>>(() => getPickedUpIds())
+  const [questsOpen,     setQuestsOpen]     = useState(false)
+  const [openTreasure,   setOpenTreasure]   = useState<HubTreasure | null>(null)
+  const [collectedTreasureIds] = useState<Set<string>>(() => getCollectedTreasureIds())
+  const [_tick,          setTick]           = useState(0)
+  const refreshState = useCallback(() => setTick(t => t + 1), [])
+
+  const { gameHour } = useHubClock()
+
+  // Quest NPC state: read imperatively by PixiJS ticker
+  const questNpcStateRef = useRef(new Map<string, 'offer' | 'ready' | null>())
+  {
+    const m = new Map<string, 'offer' | 'ready' | null>()
+    const activeCount = questDefs.filter(q => getQuestState(q.id).status === 'active').length
+    const atCap = activeCount >= 2
+    for (const quest of questDefs) {
+      const state = getQuestState(quest.id)
+      if (state.status === 'available') {
+        const prereqMet = !quest.prerequisite || checkPrerequisite(quest.prerequisite)
+        if (prereqMet && !atCap) m.set(quest.giverNpcId, 'offer')
+      } else if (state.status === 'active') {
+        if (isQuestReadyToComplete(quest)) m.set(quest.receiverNpcId, 'ready')
+      }
+    }
+    // Cross-location: mark receiver NPCs that are in this location
+    for (const quest of allQuestDefs) {
+      if (questDefs.some(q => q.id === quest.id)) continue
+      if (getQuestState(quest.id).status === 'active' && isQuestReadyToComplete(quest)) {
+        if (allNpcs.some(n => n.id === quest.receiverNpcId)) m.set(quest.receiverNpcId, 'ready')
+      }
+    }
+    questNpcStateRef.current = m
+  }
+
+  const activeQuestIdsRef = useRef(new Set<string>())
+  {
+    const s = new Set<string>()
+    for (const quest of questDefs) {
+      if (getQuestState(quest.id).status === 'active') s.add(quest.id)
+    }
+    activeQuestIdsRef.current = s
+  }
+
+  const completedQuestIdsRef = useRef(new Set<string>())
+  {
+    const s = new Set<string>()
+    for (const quest of questDefs) {
+      if (getQuestState(quest.id).status === 'completed') s.add(quest.id)
+    }
+    completedQuestIdsRef.current = s
+  }
+
+  const scrollRef        = useRef<HTMLDivElement>(null)
+  const returnRef        = useRef<(() => void) | null>(null)
+  const interiorEnterRef = useRef<((buildingId: string) => void) | null>(null)
+  const interiorExitRef  = useRef<(() => void) | null>(null)
+
+  const unitCards = useMemo(() => {
+    const deck    = loadDeck()
+    const catalog = getCardCatalog()
+    const names   = new Set(deck.map(e => e.cardName))
+    return catalog.filter(c => c.cardType === 'unit' && names.has(c.name)).map(c => c.name)
+  }, [])
+
+  const doorKeys = useMemo(() => {
+    const keys = new Set<string>()
+    for (const c of getCollectibles()) keys.add(c.id)
+    return keys
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [_tick])
+
+  // Auto-dismiss non-choice dialogues after 15 s
+  useEffect(() => {
+    const hasContent = !!(dialogueEvent?.text ?? dialogueLine)
+    const hasChoices = !!(dialogueEvent?.choices?.length)
+    if (!hasContent || hasChoices) return
+    const after = dialogueEvent?.onClose
+    const id = setTimeout(() => { setDialogueEvent(null); setDialogueLine(null); after?.() }, 15_000)
+    return () => clearTimeout(id)
+  }, [dialogueEvent, dialogueLine])
+
+  const handleAvatarMove = useCallback((px: number, py: number) => {
+    const el = scrollRef.current
+    if (!el) return
+    el.scrollLeft = px - el.clientWidth  / 2
+    el.scrollTop  = py - el.clientHeight / 2
+  }, [])
+
+  useEffect(() => {
+    const el = scrollRef.current
+    if (!el) return
+    const saved = getSavedHubTile(locationData.TOWN_NAME)
+    const px = saved ? saved[0] * T + T / 2 : locationData.AVATAR_START[0] * T + T / 2
+    const py = saved ? saved[1] * T + T / 2 : locationData.AVATAR_START[1] * T + T / 2
+    el.scrollLeft = px - el.clientWidth  / 2
+    el.scrollTop  = py - el.clientHeight / 2
+  }, [locationData])
+
+  const handleNodeInteract = useCallback((screen: string) => {
+    if (screen.startsWith('interior:')) {
+      interiorEnterRef.current?.(screen.slice(9))
+      return
+    }
+    if (screen === 'worldmap') { onBack(); return }
+  }, [onBack])
+
+  const handleQuestAbandon = useCallback((questId: string) => {
+    const quest = questDefs.find(q => q.id === questId)
+    if (!quest) return
+    const pickupIds = quest.steps.flatMap(s => s.pickupIds ?? [])
+    unmarkPickedUp(pickupIds)
+    resetQuest(questId)
+    setPickedUpIds(getPickedUpIds())
+    refreshState()
+  }, [questDefs, refreshState])
+
+  const handleTreasureStep = useCallback((id: string) => {
+    const treasure = locationData.HUB_TREASURES.find(t => t.id === id)
+    if (!treasure) return
+    markTreasureCollected(id)
+    const { reward } = treasure
+    if (reward.crystals) { saveCrystals(loadCrystals() + reward.crystals); onCrystalsChange?.(loadCrystals()) }
+    if (reward.collectible) {
+      const { id: cid, name, icon, desc } = reward.collectible
+      addCollectible(cid, { name, icon, desc })
+    }
+    setOpenTreasure(treasure)
+    refreshState()
+  }, [locationData, onCrystalsChange, refreshState])
+
+  const handleItemPickup = useCallback((id: string, questId?: string) => {
+    markPickedUp(id)
+    setPickedUpIds(getPickedUpIds())
+    if (!questId) return
+    const quest = [...questDefs, ...allQuestDefs].find(q => q.id === questId)
+    if (!quest || getQuestState(questId).status !== 'active') return
+    let pickedStep: typeof quest.steps[0] | undefined
+    for (const step of quest.steps) {
+      if (step.type === 'collect' && step.pickupIds?.includes(id)) {
+        incrementQuestProgress(questId, step.key)
+        pickedStep = step
+        break
+      }
+    }
+    refreshState()
+    if (!pickedStep) return
+    const allCollectDone = quest.steps.filter(s => s.type === 'collect')
+      .every(s => getQuestProgress(questId, s.key) >= s.required)
+    const speakerName = quest.title
+    if (allCollectDone) {
+      const receiverNpc = allNpcs.find(n => n.id === quest.receiverNpcId)
+      const npcName = receiverNpc?.name ?? 'the quest giver'
+      setDialogueEvent({ speakerName, text: `All items found! Return to ${npcName} to complete the quest.` })
+    } else {
+      const progress = getQuestProgress(questId, pickedStep.key)
+      const countSuffix = pickedStep.required > 1 ? ` (${progress}/${pickedStep.required})` : ''
+      setDialogueEvent({ speakerName, text: `Item collected${countSuffix}. ${getActiveDialogue(quest)}` })
+    }
+  }, [questDefs, allQuestDefs, allNpcs, refreshState])
+
+  const handleDoorLocked = useCallback((_buildingId: string, requiredItem: string) => {
+    if (requiredItem.startsWith('closed:')) {
+      const h = parseInt(requiredItem.slice(7))
+      setDialogueLine(`This building is closed right now. Opens at ${String(h).padStart(2, '0')}:00.`)
+    } else if (requiredItem === 'closed') {
+      setDialogueLine('This building is closed right now. Come back later.')
+    } else if (requiredItem.startsWith('quest:')) {
+      setDialogueLine("This passage is sealed. You'll need to discover it first.")
+    } else {
+      setDialogueLine(`This door is locked. You need a ${requiredItem.replace(/-/g, ' ')} to enter.`)
+    }
+  }, [])
+
+  const handleNpcTap = useCallback((line: string, npcId: string) => {
+    const npcDef = allNpcs.find(n => n.id === npcId)
+    const speakerName = npcDef?.name ?? ''
+
+    // Cross-location & local quest completion (active quests with this NPC as receiver)
+    const receiveQuestIds = npcDef?.questReceive
+      ? (Array.isArray(npcDef.questReceive) ? npcDef.questReceive : [npcDef.questReceive])
+      : []
+    const allCandidates = allQuestDefs.filter(q =>
+      receiveQuestIds.includes(q.id) || q.receiverNpcId === npcId
+    )
+    for (const quest of allCandidates) {
+      if (getQuestState(quest.id).status !== 'active') continue
+      for (const step of quest.steps) {
+        if (step.type === 'deliver' && step.targetNpcId === npcId) {
+          incrementQuestProgress(quest.id, step.key)
+          break
+        }
+      }
+      if (isQuestReadyToComplete(quest)) {
+        setQuestStatus(quest.id, 'completed')
+        grantQuestReward(quest)
+        if (quest.reward.crystals) onCrystalsChange?.(loadCrystals())
+        refreshState()
+        const rewardText = formatQuestReward(quest.reward)
+        setDialogueEvent({
+          speakerName,
+          text: quest.completeDialogue,
+          ...(rewardText ? { onClose: () => setDialogueEvent({ speakerName: '', text: rewardText }) } : {}),
+        })
+        return
+      }
+    }
+
+    // Active local quest from this giver
+    const giveQuests = questDefs.filter(q => q.giverNpcId === npcId)
+    for (const quest of giveQuests) {
+      if (getQuestState(quest.id).status !== 'active') continue
+      if (quest.receiverNpcId === npcId && isQuestReadyToComplete(quest)) {
+        setQuestStatus(quest.id, 'completed')
+        grantQuestReward(quest)
+        if (quest.reward.crystals) onCrystalsChange?.(loadCrystals())
+        refreshState()
+        const rewardText = formatQuestReward(quest.reward)
+        setDialogueEvent({
+          speakerName,
+          text: quest.completeDialogue,
+          ...(rewardText ? { onClose: () => setDialogueEvent({ speakerName: '', text: rewardText }) } : {}),
+        })
+        return
+      }
+      setDialogueEvent({ speakerName, text: getActiveDialogue(quest) })
+      return
+    }
+
+    // Offer an available quest
+    const atCap = questDefs.filter(q => getQuestState(q.id).status === 'active').length >= 2
+    for (const quest of giveQuests) {
+      if (getQuestState(quest.id).status !== 'available') continue
+      if (!quest.prerequisite || checkPrerequisite(quest.prerequisite)) {
+        if (atCap) break
+        setDialogueEvent({
+          speakerName,
+          text: quest.offerDialogue,
+          choices: [
+            {
+              label: 'Accept',
+              primary: true,
+              onClick: () => {
+                const count = questDefs.filter(q => getQuestState(q.id).status === 'active').length
+                if (count >= 2) {
+                  setDialogueEvent({ speakerName, text: "You're working on 2 quests. Finish one first." })
+                  return
+                }
+                setQuestStatus(quest.id, 'active')
+                activeQuestIdsRef.current.add(quest.id)
+                refreshState()
+                setDialogueEvent(null)
+              },
+            },
+            { label: 'Not now', onClick: () => setDialogueEvent(null) },
+          ],
+        })
+        return
+      }
+    }
+
+    // Default dialogue line from NPC def
+    setDialogueEvent({ speakerName, text: line })
+  }, [allNpcs, questDefs, allQuestDefs, onCrystalsChange, refreshState])
+
+  return (
+    <OverlayScreen title="JARVS AMAZING WEB GAME">
+      <Toolbar>
+        <ToolbarLabel className="title-deck-info">⚔ {locationData.TOWN_NAME}</ToolbarLabel>
+        <ToolbarLabel className="title-deck-info">💎 {crystals.toLocaleString()}</ToolbarLabel>
+        <ToolbarButton icon="📜" title="Quests" onClick={() => setQuestsOpen(true)} />
+        <ToolbarSpacer />
+        <ToolbarButton icon="🗺" title="World Map" onClick={onBack} />
+        {onFeedback && (
+          <ToolbarButton icon="🗣️" title="Send feedback" onClick={onFeedback} />
+        )}
+      </Toolbar>
+
+      <div className="nm-map nm-map--camp" style={{ position: 'relative', flex: 1, overflow: 'hidden' }}>
+        <div ref={scrollRef} style={{ overflowX: 'auto', overflowY: 'auto', width: '100%', height: '100%' }}>
+          <HubTownCanvas
+            onAreaEnter={setCurrentArea}
+            onNodeInteract={handleNodeInteract}
+            onAvatarMove={handleAvatarMove}
+            returnRef={returnRef}
+            unitCards={unitCards}
+            commander={commander}
+            onNpcTap={handleNpcTap}
+            interiorEnterRef={interiorEnterRef}
+            interiorExitRef={interiorExitRef}
+            onEnterInterior={() => setInteriorActive(true)}
+            onExitInterior={() => setInteriorActive(false)}
+            pickedUpIds={pickedUpIds}
+            onItemPickup={handleItemPickup}
+            doorKeys={doorKeys}
+            onDoorLocked={handleDoorLocked}
+            questNpcState={questNpcStateRef}
+            activeQuestIdsRef={activeQuestIdsRef}
+            completedQuestIdsRef={completedQuestIdsRef}
+            collectedTreasureIds={collectedTreasureIds}
+            onTreasureStep={handleTreasureStep}
+            gameHour={gameHour}
+            isNight={false}
+            locationData={locationData}
+          />
+        </div>
+
+        {currentArea && !interiorActive && !dialogueLine && !dialogueEvent && (
+          <AreaNameBadge name={currentArea} />
+        )}
+        {interiorActive && (
+          <HubReturnButton onClick={() => { interiorExitRef.current?.(); setInteriorActive(false) }} />
+        )}
+        {(dialogueLine || dialogueEvent) && (
+          <HubDialogue
+            line={dialogueLine ?? dialogueEvent?.text ?? ''}
+            speakerName={dialogueEvent?.speakerName}
+            choices={dialogueEvent?.choices}
+            onClose={() => {
+              const after = dialogueEvent?.onClose
+              setDialogueEvent(null)
+              setDialogueLine(null)
+              after?.()
+            }}
+          />
+        )}
+      </div>
+
+      {questsOpen && (
+        <QuestsModal
+          questDefs={questDefs}
+          onAbandon={handleQuestAbandon}
+          onClose={() => setQuestsOpen(false)}
+        />
+      )}
+      {openTreasure && (
+        <TreasureModal
+          treasure={openTreasure}
+          onClose={() => setOpenTreasure(null)}
+        />
+      )}
+    </OverlayScreen>
+  )
+}

--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -6,8 +6,9 @@ import { renderPathTiles } from '../../utils/tileLookup'
 import { loadSpriteTexture, loadTextureUrl, loadAnimFrames, loadTileTexture } from '../../utils/pixiHelpers'
 import { PATH_TILE, TILESET_IMAGE, TILESET_COLUMNS } from '../../data/tiles/tileIndex'
 import { findPath, nearestWalkable } from '../../utils/hubPathfinder'
-import { MAP_W, MAP_H, HUB_AREAS, HUB_STREET_TILES, HUB_STREET_GROUPS, HUB_BUILDINGS, AVATAR_START, NPC_SPAWN_TILES, AMBIENT_NPC_SPRITES, EXTERIOR_NPCS, INTERIOR_NPCS, HUB_DOORS, HUB_INTERIORS, EXTERIOR_DECOR, HUB_WINDOWS, HUB_POND_TILES, HUB_PICKUP_ITEMS, HUB_LOCKED_DOORS, HUB_BLOCKED_PATHS, HUB_TREASURES } from '../../data/hub/loader'
+import { HUB_LOCATION_DATA } from '../../data/hub/loader'
 import type { HubInteriorExit, NpcScheduleEntry } from '../../data/hub/loader'
+import type { HubLocationData } from '../../data/hub/locationTypes'
 import { isBuildingOpen, getNpcLocation } from '../../game/hub/hubNpcSchedule'
 import { getGameHour, getGameMinute } from '../../game/hub/hubClock'
 import { getWallTile, ROOF_TILES, WALL_TILES, ROOF_ROWS } from '../../data/tiles/buildingMaterials'
@@ -18,19 +19,19 @@ import { CommanderState } from '../../game/commander'
 import rollbar from '../../rollbar'
 
 
-const HUB_ENV           = 'camp'
 const T                 = 32
 const SPRITE_SIZE       = T * 1.5
 const WALK_PX_PER_S     = 160
 const NPC_WALK_PX_PER_S = 80
-const COURTYARD_PX  = { x: AVATAR_START[0] * T + T / 2, y: AVATAR_START[1] * T + T }
 
 const NIGHT_LIGHT_INNER  = 4 * T   // fully lit within this radius of avatar
 const NIGHT_LIGHT_OUTER  = 7 * T   // fully dark beyond this radius
 const NIGHT_NPC_LIGHT_R  = 2 * T   // small glow radius around each NPC
 
-let _savedTile: [number, number] | null = null
-export function getSavedHubTile(): [number, number] | null { return _savedTile }
+const _savedTiles = new Map<string, [number, number]>()
+export function getSavedHubTile(locationKey?: string): [number, number] | null {
+  return _savedTiles.get(locationKey ?? 'ravenwatch') ?? null
+}
 
 // ── Interior BFS pathfinder ────────────────────────────────────────────────────
 function findInteriorPath(
@@ -81,6 +82,7 @@ interface Props {
   gameHour?:             number
   isNight?:              boolean
   npcProximityDialogue?: React.MutableRefObject<Map<string, { atDistance: number; text: string }[]>>
+  locationData?:         HubLocationData
 }
 
 export function HubTownCanvas({
@@ -90,7 +92,24 @@ export function HubTownCanvas({
   pickedUpIds, onItemPickup, doorKeys, onDoorLocked, questNpcState, activeQuestIdsRef,
   completedQuestIdsRef, collectedTreasureIds, onTreasureStep,
   gameHour, isNight, npcProximityDialogue,
+  locationData: locationDataProp,
 }: Props) {
+  const loc = locationDataProp ?? HUB_LOCATION_DATA
+  const {
+    MAP_W, MAP_H, AVATAR_START,
+    HUB_AREAS, HUB_BUILDINGS,
+    HUB_STREET_GROUPS, HUB_STREET_TILES,
+    EXTERIOR_DECOR, HUB_WINDOWS, HUB_POND_TILES,
+    HUB_DOORS, HUB_INTERIORS, EXTERIOR_NPCS, INTERIOR_NPCS,
+    NPC_SPAWN_TILES, AMBIENT_NPC_SPRITES, HUB_PICKUP_ITEMS,
+    HUB_BLOCKED_PATHS, HUB_LOCKED_DOORS, HUB_TREASURES,
+    EXIT_TILES: exitTilesData,
+    TOWN_NAME: locationKey,
+  } = loc
+  const HUB_ENV = locationDataProp?.TOWN_NAME === 'Ironhold Keep' ? 'citadel'
+               : locationDataProp?.TOWN_NAME === 'Millhaven'      ? 'coast'
+               : 'camp'
+  const COURTYARD_PX = { x: AVATAR_START[0] * T + T / 2, y: AVATAR_START[1] * T + T }
   const containerRef      = useRef<HTMLDivElement>(null)
   const onAreaRef         = useRef(onAreaEnter)
   onAreaRef.current       = onAreaEnter
@@ -627,7 +646,7 @@ export function HubTownCanvas({
         interiorLayer.addChild(s)
         avatarInInterior = true
       } else {
-        const startTile: [number, number] = _savedTile ? [..._savedTile] : [...AVATAR_START]
+        const startTile: [number, number] = _savedTiles.has(locationKey) ? [..._savedTiles.get(locationKey)!] : [...AVATAR_START]
         currentTile = startTile
         s.position.set(startTile[0] * T + T / 2, startTile[1] * T + T)
         avatarLayer.addChild(s)
@@ -1617,7 +1636,7 @@ export function HubTownCanvas({
 
         await tweenLinear(av, targetX, targetY, duration)
         currentTile = [tx, ty]
-        _savedTile  = [tx, ty]
+        _savedTiles.set(locationKey, [tx, ty])
 
         // Touch-pickup: collect requireTouch items when avatar walks onto their tile
         for (const [pid, sprite] of pickupSprites) {
@@ -1663,6 +1682,16 @@ export function HubTownCanvas({
           walkQueue     = []
           pendingScreen = null
           onNodeInteractRef.current(`interior:${door.buildingId}`)
+          return
+        }
+
+        // Exit tile detection — walking onto an exit tile fires a screen transition
+        const exitTile = exitTilesData.find(e => e.tx === currentTile[0] && e.ty === currentTile[1])
+        if (exitTile) {
+          isWalking     = false
+          walkQueue     = []
+          pendingScreen = null
+          onNodeInteractRef.current(exitTile.screen)
           return
         }
 
@@ -1765,7 +1794,7 @@ export function HubTownCanvas({
       pendingScreen = null
       isWalking     = false
       currentTile   = [...AVATAR_START]
-      _savedTile    = null
+      _savedTiles.delete(locationKey)
       if (avatar) { avatar.x = COURTYARD_PX.x; avatar.y = COURTYARD_PX.y }
       onAvatarMoveRef.current(COURTYARD_PX.x, COURTYARD_PX.y)
     }

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -5,7 +5,7 @@ import { AreaNameBadge } from './AreaNameBadge'
 import { HubReturnButton } from './HubReturnButton'
 import { HubDialogue } from './HubDialogue'
 import type { DialogueChoice } from './HubDialogue'
-import { AVATAR_START, MAP_W, MAP_H, HUB_NPCS, HUB_TREASURES } from '../../data/hub/loader'
+import { AVATAR_START, MAP_W, MAP_H, HUB_NPCS, HUB_TREASURES, HUB_TOWN_NAME } from '../../data/hub/loader'
 import type { HubTreasure } from '../../data/hub/loader'
 import { HUB_QUEST_DEFS, INN_RUMOURS, FRIENDSHIP_DIALOGUE } from '../../data/hub/questDefs'
 import type { HubQuestDef } from '../../data/hub/questDefs'
@@ -88,6 +88,7 @@ interface Props {
   onNavigate?:        (screen: string) => void
   onCampaign?:        () => void
   onEndless?:         () => void
+  onWorldMap?:        () => void
   onPlayerTap?:       () => void
   crystals?:          number
   isSignedIn?:        boolean
@@ -100,7 +101,7 @@ interface Props {
   onTileTap?:         (tx: number, ty: number) => void
 }
 
-export function HubWorld({ onBack, onNavigate, onCampaign, onEndless, onPlayerTap, crystals = 0, isSignedIn = false, commander, user, onSignIn: onLoginToggle, onSignOut, onFeedback, onCrystalsChange, onTileTap }: Props) {
+export function HubWorld({ onBack, onNavigate, onCampaign, onEndless, onWorldMap, onPlayerTap, crystals = 0, isSignedIn = false, commander, user, onSignIn: onLoginToggle, onSignOut, onFeedback, onCrystalsChange, onTileTap }: Props) {
   const [splashVisible, setSplashVisible] = useState(() => !_hubSplashShown && !loadSkipIntro())
   const [splashFading,  setSplashFading]  = useState(false)
   const [currentArea,    setCurrentArea]    = useState<string | null>(null)
@@ -262,6 +263,7 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onEndless, onPlayerTa
       interiorEnterRef.current?.(buildingId)
       return
     }
+    if (screen === 'worldmap') { onWorldMap?.(); return }
     if (screen === 'campaign') { onCampaign?.(); return }
     if (screen === 'endless') { onEndless?.(); return }
     if (screen === 'commander' && !commander) {
@@ -269,7 +271,7 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onEndless, onPlayerTa
       return
     }
     onNavigate?.(screen)
-  }, [onNavigate, onCampaign, commander])
+  }, [onNavigate, onCampaign, onWorldMap, commander])
 
   const handleReturn = useCallback(() => {
     returnRef.current?.()
@@ -512,6 +514,7 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onEndless, onPlayerTa
   return (
     <OverlayScreen title="JARVS AMAZING WEB GAME">
       <Toolbar>
+        <ToolbarLabel className="title-deck-info">⚔ {HUB_TOWN_NAME}</ToolbarLabel>
         <ToolbarLabel className={`title-deck-info${wrongSave ? ' title-deck-info--glitch' : ''}`}>💎 {wrongSave ? wrongSave.crystals.toLocaleString() : crystals.toLocaleString()}</ToolbarLabel>
         <ToolbarLabel className={`title-deck-info${wrongSave ? ' title-deck-info--glitch' : ''}`}>🃏 {wrongSave ? wrongSave.cards : collectionCount}/{catalogTotal}</ToolbarLabel>
         <ToolbarLabel className="title-deck-info">{isGameNight ? '🌙' : '☀️'} {formatGameTime()}</ToolbarLabel>

--- a/web/src/components/hub/HubWorldMap.tsx
+++ b/web/src/components/hub/HubWorldMap.tsx
@@ -1,0 +1,193 @@
+import React, { useRef, useState, useEffect } from 'react'
+import * as PIXI from 'pixi.js'
+import { usePixiApp } from '../../hooks/usePixiApp'
+import { WORLD_MAP_NODES, WorldNodeDef } from '../../data/world/worldMapDef'
+import { WORLD_DECOR_FILE, WORLD_ENV_TILES } from '../../data/tiles/worldTileIndex'
+import { loadTileTexture, makeClickable } from '../../utils/pixiHelpers'
+import { buildTerrainGfx, buildBorderGfx } from '../../utils/terrainLayer'
+import { getCurrentWorldLocation, isNodeCleared } from '../../game/world/worldState'
+import { OverlayScreen } from '../ui/OverlayScreen'
+import { Toolbar } from '../ui/Toolbar/Toolbar'
+import { ToolbarButton } from '../ui/Toolbar/ToolbarButton'
+import { ToolbarLabel } from '../ui/Toolbar/ToolbarLabel'
+import { ToolbarSpacer } from '../ui/Toolbar/ToolbarSpacer'
+
+const MAP_W = 700
+const MAP_H = 520
+const DECOR_COLS = 8
+
+function isNodeAvailable(node: WorldNodeDef): boolean {
+  if (!node.requiredClears || node.requiredClears.length === 0) return true
+  return node.requiredClears.every(req => {
+    if (req.includes('|')) return req.split('|').some(id => isNodeCleared(id))
+    return isNodeCleared(req)
+  })
+}
+
+interface Props {
+  onSelectNode: (node: WorldNodeDef) => void
+  onBack: () => void
+}
+
+export function HubWorldMap({ onSelectNode, onBack }: Props) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const deadRef      = useRef(false)
+  const [selected, setSelected] = useState<WorldNodeDef | null>(null)
+  const currentLocation = getCurrentWorldLocation()
+
+  useEffect(() => () => { deadRef.current = true }, [])
+
+  usePixiApp(containerRef, MAP_W, MAP_H, async (app) => {
+    deadRef.current = false
+
+    // Layered ground
+    const baseContainer  = new PIXI.Container()
+    const riverContainer = new PIXI.Container()
+    const worldLayer     = new PIXI.Container()
+    app.stage.addChild(baseContainer, riverContainer, worldLayer)
+
+    buildTerrainGfx(baseContainer, riverContainer, worldLayer,
+      { environment: 'farmland', envDef: WORLD_ENV_TILES.farmland, terrainItems: [], rivers: [] },
+      MAP_W, MAP_H)
+    buildBorderGfx(worldLayer, { envDef: WORLD_ENV_TILES.farmland }, MAP_W, MAP_H)
+
+    // Connection lines
+    const pathGfx = new PIXI.Graphics()
+    worldLayer.addChild(pathGfx)
+    for (const node of WORLD_MAP_NODES) {
+      for (const connId of node.connections) {
+        const target = WORLD_MAP_NODES.find(n => n.id === connId)
+        if (!target) continue
+        const lit = isNodeAvailable(node) && isNodeAvailable(target)
+        pathGfx
+          .moveTo(node.x, node.y)
+          .lineTo(target.x, target.y)
+          .stroke({ color: lit ? 0xb08040 : 0x3a3a28, width: 6, alpha: lit ? 0.8 : 0.3 })
+      }
+    }
+
+    const base = (import.meta as { env: { BASE_URL: string } }).env.BASE_URL
+    const decorUrl = `${base}${WORLD_DECOR_FILE.slice(1)}`
+
+    for (const node of WORLD_MAP_NODES) {
+      if (deadRef.current) return
+      const available = isNodeAvailable(node)
+      const isCurrent = node.id === currentLocation
+      const container = new PIXI.Container()
+      container.position.set(node.x, node.y)
+
+      // Node background circle
+      const circle = new PIXI.Graphics()
+      circle.circle(0, 0, 22)
+        .fill({ color: isCurrent ? 0x1a6b1a : available ? 0x3a3a20 : 0x222218, alpha: 0.9 })
+        .stroke({ color: isCurrent ? 0x66ff66 : available ? 0xccaa44 : 0x444430, width: 2 })
+      container.addChild(circle)
+
+      // WORLD_DECOR sprites
+      for (let i = 0; i < node.decorTiles.length; i++) {
+        try {
+          const tex = await loadTileTexture(decorUrl, node.decorTiles[i], DECOR_COLS)
+          if (deadRef.current) return
+          const sprite = new PIXI.Sprite(tex)
+          const off = node.decorOffsets?.[i] ?? [-16, -16]
+          sprite.position.set(off[0], off[1])
+          container.addChild(sprite)
+        } catch { /* sprite unavailable */ }
+      }
+
+      // Lock badge for unavailable nodes
+      if (!available && !isCurrent) {
+        container.alpha = 0.38
+        const lockLabel = new PIXI.Text({ text: '🔒',
+          style: { fontSize: 13, fontFamily: 'monospace' } })
+        lockLabel.anchor.set(0.5, 1)
+        lockLabel.position.set(0, -25)
+        container.addChild(lockLabel)
+      }
+
+      // Name label below node
+      const label = new PIXI.Text({ text: node.name,
+        style: { fontSize: 11, fill: '#ffffff', fontFamily: 'monospace',
+          dropShadow: { alpha: 1, blur: 3, distance: 1, color: '#000000' } } })
+      label.anchor.set(0.5, 0)
+      label.position.set(0, 26)
+      container.addChild(label)
+
+      if (available || isCurrent) {
+        makeClickable(container, () => setSelected(node))
+      }
+
+      worldLayer.addChild(container)
+    }
+
+    // Pulsing ring on current location node
+    const curNode = WORLD_MAP_NODES.find(n => n.id === currentLocation)
+    if (curNode) {
+      const ring = new PIXI.Graphics()
+      ring.position.set(curNode.x, curNode.y)
+      worldLayer.addChild(ring)
+      let t = 0
+      app.ticker.add(() => {
+        t += 0.04
+        ring.clear()
+        ring.circle(0, 0, 25 + Math.sin(t) * 5)
+          .stroke({ color: 0x55ff55, width: 2, alpha: 0.4 + Math.sin(t) * 0.25 })
+      })
+    }
+  })
+
+  const isCurrent = selected?.id === currentLocation
+  const canTravel = selected && isNodeAvailable(selected) && !isCurrent
+
+  return (
+    <OverlayScreen title="WORLD MAP">
+      <Toolbar>
+        <ToolbarLabel className="title-deck-info">🗺 World Map</ToolbarLabel>
+        <ToolbarSpacer />
+        <ToolbarButton icon="🏠" title="Back to Town" onClick={onBack} />
+      </Toolbar>
+      <div style={{ flex: 1, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', overflow: 'hidden' }}>
+        <div ref={containerRef} style={{ cursor: 'crosshair' }} />
+        {selected && (
+          <div className="nm-peek-backdrop" onClick={() => setSelected(null)}>
+            <div className="nm-peek-panel" onClick={e => e.stopPropagation()}>
+              <div className="nm-peek-header u-col u-items-c u-gap-1">
+                <span className={`nm-peek-type nm-node-type-badge--${selected.type}`}>
+                  {selected.type.toUpperCase()}
+                </span>
+              </div>
+              <div style={{ fontWeight: 'bold', margin: '6px 0 2px', textAlign: 'center' }}>
+                {selected.name}
+              </div>
+              {isCurrent && (
+                <div style={{ color: '#88ee88', fontSize: 12, textAlign: 'center', marginTop: 4 }}>
+                  Current location
+                </div>
+              )}
+              {!isCurrent && !canTravel && (
+                <div style={{ color: '#888', fontSize: 12, textAlign: 'center', marginTop: 4 }}>
+                  🔒 Not yet accessible
+                </div>
+              )}
+              {canTravel && (
+                <button
+                  className="action-btn"
+                  style={{ marginTop: 8, display: 'block', width: '100%' }}
+                  onClick={() => { setSelected(null); onSelectNode(selected) }}
+                >
+                  Travel ➤
+                </button>
+              )}
+              <button
+                style={{ marginTop: 6, background: 'transparent', border: '1px solid #555', color: '#aaa', cursor: 'pointer', padding: '2px 10px', fontSize: 12, width: '100%' }}
+                onClick={() => setSelected(null)}
+              >
+                Close
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </OverlayScreen>
+  )
+}

--- a/web/src/components/hub/QuestsModal.tsx
+++ b/web/src/components/hub/QuestsModal.tsx
@@ -7,6 +7,7 @@ import { getQuestState, getQuestProgress } from '../../game/hub/quests'
 interface Props {
   onClose: () => void
   onAbandon: (questId: string) => void
+  questDefs?: HubQuestDef[]
 }
 
 function progressDots(current: number, required: number): string {
@@ -25,13 +26,14 @@ function getActiveHint(quest: HubQuestDef): string {
   return Object.values(activeDialogue)[Object.values(activeDialogue).length - 1]
 }
 
-export function QuestsModal({ onClose, onAbandon }: Props) {
+export function QuestsModal({ onClose, onAbandon, questDefs: questDefsProp }: Props) {
   const [confirmingId, setConfirmingId] = useState<string | null>(null)
+  const defs = questDefsProp ?? HUB_QUEST_DEFS
 
-  const active    = HUB_QUEST_DEFS.filter(q => getQuestState(q.id).status === 'active')
-  const completed = HUB_QUEST_DEFS.filter(q => getQuestState(q.id).status === 'completed')
+  const active    = defs.filter(q => getQuestState(q.id).status === 'active')
+  const completed = defs.filter(q => getQuestState(q.id).status === 'completed')
   const discovered = active.length + completed.length
-  const total      = HUB_QUEST_DEFS.length
+  const total      = defs.length
 
   return (
     <ModalBackdrop onClose={onClose}>

--- a/web/src/data/castle/config.json
+++ b/web/src/data/castle/config.json
@@ -1,0 +1,244 @@
+{
+  "mapW": 704,
+  "mapH": 640,
+  "townName": "Ironhold Keep",
+  "avatarStart": [10, 16],
+  "exitTiles": [
+    { "tx": 9,  "ty": 18, "screen": "worldmap" },
+    { "tx": 10, "ty": 18, "screen": "worldmap" },
+    { "tx": 11, "ty": 18, "screen": "worldmap" },
+    { "tx": 12, "ty": 18, "screen": "worldmap" }
+  ],
+  "areas": [
+    {
+      "id": "castle-outer",
+      "name": "Outer Courtyard",
+      "tx": 4,
+      "ty": 7,
+      "tw": 14,
+      "th": 12
+    },
+    {
+      "id": "castle-keep",
+      "name": "The Inner Keep",
+      "tx": 4,
+      "ty": 0,
+      "tw": 14,
+      "th": 7
+    },
+    {
+      "id": "castle-armory",
+      "name": "The Armory",
+      "tx": 0,
+      "ty": 8,
+      "tw": 6,
+      "th": 6
+    },
+    {
+      "id": "castle-barracks",
+      "name": "The Barracks",
+      "tx": 16,
+      "ty": 8,
+      "tw": 6,
+      "th": 6
+    }
+  ],
+  "streets": [
+    { "rect": [4, 7, 17, 19] },
+    { "rect": [0, 14, 3, 19] },
+    { "rect": [18, 14, 21, 19] }
+  ],
+  "buildings": [
+    {
+      "id": "commanders-hall",
+      "rect": [4, 0, 17, 6],
+      "wall": "castleStone",
+      "roof": "greySlateRoof",
+      "doors": [
+        { "tx": 5, "ty": 1 }
+      ]
+    },
+    {
+      "id": "armory",
+      "rect": [0, 8, 5, 13],
+      "wall": "reinforcedStone",
+      "roof": "metalRoof",
+      "doors": [
+        { "tx": 2, "ty": 1 }
+      ]
+    },
+    {
+      "id": "barracks",
+      "rect": [16, 8, 21, 13],
+      "wall": "castleStone",
+      "roof": "greySlateRoof",
+      "doors": [
+        { "tx": 2, "ty": 1 }
+      ]
+    }
+  ],
+  "exteriorDecor": [
+    { "comment": "stone wells" },
+    { "tx": 6,  "ty": 9,  "tileId": "stoneWell" },
+    { "tx": 15, "ty": 9,  "tileId": "stoneWell" },
+    { "comment": "iron fence border south" },
+    { "tx": 0,  "ty": 19, "tileId": "ironFenceLeftRight" },
+    { "tx": 1,  "ty": 19, "tileId": "ironFenceLeftRight" },
+    { "tx": 2,  "ty": 19, "tileId": "ironFenceLeftRight" },
+    { "tx": 3,  "ty": 19, "tileId": "ironFenceLeftRight" },
+    { "tx": 4,  "ty": 19, "tileId": "ironFenceLeftRight" },
+    { "tx": 5,  "ty": 19, "tileId": "ironFenceLeftRight" },
+    { "tx": 6,  "ty": 19, "tileId": "ironFenceLeftRight" },
+    { "tx": 7,  "ty": 19, "tileId": "ironFenceLeftRight" },
+    { "tx": 8,  "ty": 19, "tileId": "ironFenceLeftRight" },
+    { "comment": "gap at tx 9-12 for exit" },
+    { "tx": 13, "ty": 19, "tileId": "ironFenceLeftRight" },
+    { "tx": 14, "ty": 19, "tileId": "ironFenceLeftRight" },
+    { "tx": 15, "ty": 19, "tileId": "ironFenceLeftRight" },
+    { "tx": 16, "ty": 19, "tileId": "ironFenceLeftRight" },
+    { "tx": 17, "ty": 19, "tileId": "ironFenceLeftRight" },
+    { "tx": 18, "ty": 19, "tileId": "ironFenceLeftRight" },
+    { "tx": 19, "ty": 19, "tileId": "ironFenceLeftRight" },
+    { "tx": 20, "ty": 19, "tileId": "ironFenceLeftRight" },
+    { "tx": 21, "ty": 19, "tileId": "ironFenceLeftRight" },
+    { "comment": "pillars flanking the gate entrance" },
+    { "tx": 8,  "ty": 19, "tileId": "darkPillarBottom" },
+    { "tx": 13, "ty": 19, "tileId": "darkPillarBottom" },
+    { "comment": "barrels near armory" },
+    { "tx": 1,  "ty": 14, "tileId": "barrel" },
+    { "tx": 2,  "ty": 14, "tileId": "barrel" },
+    { "comment": "crates near barracks" },
+    { "tx": 19, "ty": 14, "tileId": "crate" },
+    { "tx": 20, "ty": 14, "tileId": "crate" },
+    { "comment": "campfire in courtyard" },
+    { "tx": 10, "ty": 11, "tileId": "campfireUnlit" },
+    { "comment": "small rocks border corners" },
+    { "tx": 3,  "ty": 7,  "tileId": "smallRock" },
+    { "tx": 18, "ty": 7,  "tileId": "smallRock" }
+  ],
+  "npcSpawnTiles": [],
+  "ambientNpcSprites": [],
+  "npcs": [
+    {
+      "id": "castle-commander",
+      "name": "Commander Varek",
+      "sprite": "hub-npc-arena",
+      "tx": 10,
+      "ty": 9,
+      "dialogue": [
+        "Ironhold Keep has stood for three centuries. I intend to see it stand for three more.",
+        "The patrol routes have been compromised. We need those reports.",
+        "You fight well, traveller. Ravenwatch is lucky to have you."
+      ],
+      "building": "commanders-hall",
+      "questGive": "castle-missing-patrol",
+      "questReceive": "castle-missing-patrol"
+    },
+    {
+      "id": "castle-blacksmith",
+      "name": "Blacksmith Kern",
+      "sprite": "hub-npc-supplies",
+      "tx": 3,
+      "ty": 9,
+      "dialogue": [
+        "Every blade that leaves my anvil could save a soldier's life.",
+        "The weapon crates haven't been accounted for since the last resupply.",
+        "Iron doesn't lie — only men do."
+      ],
+      "building": "armory",
+      "questGive": "castle-weapon-cache",
+      "questReceive": "castle-weapon-cache"
+    },
+    {
+      "id": "castle-archivist",
+      "name": "Archivist Elwyn",
+      "sprite": "hub-npc-scholar",
+      "tx": 18,
+      "ty": 9,
+      "dialogue": [
+        "The keep's records go back to the founding. Most of them, anyway.",
+        "A siege chronicle was separated from the archives. It belongs here.",
+        "History is the only weapon that never dulls."
+      ],
+      "building": "barracks",
+      "questGive": "castle-siege-memory",
+      "questReceive": "castle-siege-memory"
+    },
+    {
+      "id": "castle-guard-1",
+      "name": "Guard Bren",
+      "sprite": "hub-npc-soldier",
+      "tx": 7,
+      "ty": 12,
+      "dialogue": [
+        "Patrol routes are memorised, not written. Or they used to be.",
+        "Three of us dropped our patrol papers during the last drill. Embarrassing.",
+        "The south gate is yours to use, traveller."
+      ],
+      "questReceive": "castle-missing-patrol"
+    },
+    {
+      "id": "castle-guard-2",
+      "name": "Guard Holt",
+      "sprite": "hub-npc-soldier",
+      "tx": 14,
+      "ty": 12,
+      "dialogue": [
+        "All quiet on the eastern wall.",
+        "I lost my patrol report somewhere out in the courtyard. The Commander will have my head.",
+        "Ironhold has never fallen. Long may that last."
+      ],
+      "questReceive": "castle-missing-patrol"
+    }
+  ],
+  "interiors": {
+    "commanders-hall": {
+      "name": "Commander's Hall",
+      "width": 12,
+      "height": 5,
+      "floorTileId": "cobblestoneFloor",
+      "wallTileId": "castleStone",
+      "decor": [
+        { "tx": 2,  "ty": 1, "tileId": "bookshelfTop" },
+        { "tx": 3,  "ty": 1, "tileId": "bookshelfTop" },
+        { "tx": 2,  "ty": 2, "tileId": "bookshelfBottom" },
+        { "tx": 3,  "ty": 2, "tileId": "bookshelfBottom" },
+        { "tx": 8,  "ty": 1, "tileId": "bookshelfTop" },
+        { "tx": 9,  "ty": 1, "tileId": "bookshelfTop" },
+        { "tx": 8,  "ty": 2, "tileId": "bookshelfBottom" },
+        { "tx": 9,  "ty": 2, "tileId": "bookshelfBottom" },
+        { "tx": 5,  "ty": 1, "tileId": "chest" },
+        { "tx": 6,  "ty": 1, "tileId": "chest" }
+      ],
+      "exits": []
+    },
+    "armory": {
+      "name": "The Armory",
+      "width": 5,
+      "height": 5,
+      "floorTileId": "stoneFloor",
+      "wallTileId": "reinforcedStone",
+      "decor": [
+        { "tx": 1, "ty": 1, "tileId": "crate" },
+        { "tx": 2, "ty": 1, "tileId": "crate" },
+        { "tx": 3, "ty": 1, "tileId": "openCrate" },
+        { "tx": 1, "ty": 3, "tileId": "barrel" },
+        { "tx": 3, "ty": 3, "tileId": "barrel" }
+      ],
+      "exits": []
+    },
+    "barracks": {
+      "name": "The Barracks",
+      "width": 5,
+      "height": 5,
+      "floorTileId": "woodFloor",
+      "wallTileId": "castleStone",
+      "decor": [
+        { "tx": 1, "ty": 1, "tileId": "chest" },
+        { "tx": 3, "ty": 1, "tileId": "chest" },
+        { "tx": 2, "ty": 3, "tileId": "barrel" }
+      ],
+      "exits": []
+    }
+  }
+}

--- a/web/src/data/castle/loader.ts
+++ b/web/src/data/castle/loader.ts
@@ -1,0 +1,234 @@
+import rawConfig from './config.json'
+import rawQuestConfig from './questDefs.json'
+import { BASE_CHIP_TILES } from '../tiles/baseChipIndex'
+import { WALL_TILES } from '../tiles/buildingMaterials'
+import type { WallMaterial, RoofMaterial } from '../tiles/buildingMaterials'
+import type {
+  HubArea, HubBuilding, HubDoor, InteriorDecor, HubInterior,
+  HubInteriorExit, HubNpc, HubPickupItem, BlockedPath, BlockedPathState,
+  HubLockedDoor, HubTreasure, HubTreasureReward, HubStreetGroup,
+} from '../hub/loader'
+import type { HubLocationData, HubExitTile } from '../hub/locationTypes'
+import type { HubQuestDef } from '../hub/questDefs'
+
+const WALL_MATERIAL_NAMES = new Set<string>(Object.keys(WALL_TILES))
+const T = 32
+
+function resolveTileId(key: string): number {
+  return (BASE_CHIP_TILES as Record<string, number>)[key] ?? 666
+}
+
+type TileEntry = { rect: number[]; pathType?: string } | { tile: number[]; pathType?: string }
+
+function expandTiles(entries: TileEntry[]): [number, number][] {
+  const out: [number, number][] = []
+  for (const e of entries) {
+    if ('rect' in e) {
+      const [tx1, ty1, tx2, ty2] = e.rect
+      for (let tx = tx1; tx <= tx2; tx++)
+        for (let ty = ty1; ty <= ty2; ty++)
+          out.push([tx, ty])
+    } else {
+      out.push(e.tile as [number, number])
+    }
+  }
+  return out
+}
+
+function groupStreets(entries: TileEntry[]): HubStreetGroup[] {
+  const map = new Map<string, [number, number][]>()
+  for (const e of entries) {
+    const key = e.pathType ?? ''
+    if (!map.has(key)) map.set(key, [])
+    const tiles = map.get(key)!
+    if ('rect' in e) {
+      const [tx1, ty1, tx2, ty2] = e.rect
+      for (let tx = tx1; tx <= tx2; tx++)
+        for (let ty = ty1; ty <= ty2; ty++)
+          tiles.push([tx, ty])
+    } else {
+      tiles.push(e.tile as [number, number])
+    }
+  }
+  return Array.from(map.entries()).map(([key, tiles]) => ({ pathType: key || undefined, tiles }))
+}
+
+function buildingOrigin(rectList: number[][]): [number, number] {
+  const tx1 = Math.min(...rectList.map(r => r[0]))
+  const ty2 = Math.max(...rectList.map(r => r[3]))
+  return [tx1, ty2]
+}
+
+const MAP_W = rawConfig.mapW
+const MAP_H = rawConfig.mapH
+const AVATAR_START = rawConfig.avatarStart as [number, number]
+const TOWN_NAME: string = (rawConfig as unknown as { townName?: string }).townName ?? 'Castle'
+
+const HUB_AREAS: HubArea[] = rawConfig.areas.map(a => ({
+  id:   a.id,
+  name: a.name,
+  x:    a.tx * T,
+  y:    a.ty * T,
+  w:    a.tw * T,
+  h:    a.th * T,
+}))
+
+const HUB_STREET_GROUPS: HubStreetGroup[] = groupStreets(rawConfig.streets as TileEntry[])
+const HUB_STREET_TILES: [number, number][] = HUB_STREET_GROUPS.flatMap(g => g.tiles)
+
+type RawBuilding = {
+  rect?: number[]; rects?: number[][];
+  id?: string; wall?: string; roof?: string;
+  doors?:   Array<{ tx: number; ty: number; buildingId?: string }>
+  windows?: Array<{ tx: number; ty: number; tileId: string }>
+  decor?:   Array<{ tx: number; ty: number; tileId: string; zlayer?: string }>
+}
+
+const HUB_BUILDINGS: HubBuilding[] = (rawConfig.buildings as RawBuilding[]).flatMap(b => {
+  const rectList = b.rects ?? (b.rect ? [b.rect] : [])
+  return rectList.map(rect => ({
+    rect: rect as [number, number, number, number],
+    id:   b.id,
+    wall: b.wall as WallMaterial | undefined,
+    roof: b.roof as RoofMaterial | undefined,
+  }))
+})
+
+const HUB_BUILDING_TILES: [number, number][] = HUB_BUILDINGS.flatMap(b => {
+  const [tx1, ty1, tx2, ty2] = b.rect
+  const tiles: [number, number][] = []
+  for (let tx = tx1; tx <= tx2; tx++)
+    for (let ty = ty1; ty <= ty2; ty++)
+      tiles.push([tx, ty])
+  return tiles
+})
+
+const _nestedDoors:   HubDoor[] = []
+const _nestedWindows: { tx: number; ty: number; tileId: number }[] = []
+const _nestedDecor:   { tx: number; ty: number; tileId: number; zlayer?: string }[] = []
+
+for (const b of rawConfig.buildings as RawBuilding[]) {
+  const rectList = b.rects ?? (b.rect ? [b.rect] : [])
+  if (rectList.length === 0) continue
+  const [ox, oy] = buildingOrigin(rectList)
+  for (const d of b.doors ?? []) {
+    const absTy = oy + d.ty
+    let storeTy  = absTy
+    let tyAdjust = 0
+    if (!rectList.some(r => r[3] + 1 === absTy)) {
+      const candidate = rectList
+        .map(r => r[3] + 1)
+        .filter(ty2p1 => ty2p1 > absTy)
+        .sort((a, b) => a - b)[0]
+      if (candidate !== undefined) { storeTy = candidate; tyAdjust = candidate - absTy }
+    }
+    _nestedDoors.push({ buildingId: d.buildingId ?? b.id ?? '', tx: ox + d.tx, ty: storeTy, ...(tyAdjust ? { tyAdjust } : {}) })
+  }
+  for (const w of b.windows ?? [])
+    _nestedWindows.push({ tx: ox + w.tx, ty: oy + w.ty, tileId: resolveTileId(w.tileId) })
+  for (const d of b.decor ?? [])
+    _nestedDecor.push({ tx: ox + d.tx, ty: oy + d.ty, tileId: resolveTileId(d.tileId), zlayer: d.zlayer })
+}
+
+type RawDecorEntry = { tx?: number; ty?: number; tileId?: string; comment?: string; zlayer?: string }
+const EXTERIOR_DECOR = [
+  ...(rawConfig.exteriorDecor as RawDecorEntry[])
+    .filter((d): d is { tx: number; ty: number; tileId: string; zlayer?: string } => d.tx != null && d.ty != null && d.tileId != null)
+    .map(d => ({ tx: d.tx, ty: d.ty, tileId: resolveTileId(d.tileId), zlayer: d.zlayer })),
+  ..._nestedDecor,
+]
+
+const HUB_WINDOWS = [..._nestedWindows]
+const HUB_POND_TILES: [number, number][] = []
+const HUB_DOORS: HubDoor[] = _nestedDoors
+
+const HUB_INTERIORS: Record<string, HubInterior> = Object.fromEntries(
+  Object.entries(rawConfig.interiors).map(([id, raw]) => {
+    const rawAny = raw as Record<string, unknown>
+    const wallTileIdStr = rawAny.wallTileId as string | undefined
+    return [
+      id,
+      {
+        id,
+        name:         raw.name,
+        width:        raw.width,
+        height:       raw.height,
+        floorTileId:  resolveTileId(raw.floorTileId),
+        wallMaterial: wallTileIdStr && WALL_MATERIAL_NAMES.has(wallTileIdStr) ? wallTileIdStr as WallMaterial : undefined,
+        decor:        (raw.decor as Array<{ tx: number; ty: number; tileId: string; zlayer?: string }>).map(d => ({
+          tx:     d.tx,
+          ty:     d.ty,
+          tileId: resolveTileId(d.tileId),
+          zlayer: d.zlayer as InteriorDecor['zlayer'],
+        })),
+        exits: ((rawAny.exits ?? []) as HubInteriorExit[]),
+        hours: rawAny.hours as HubInterior['hours'],
+      } satisfies HubInterior,
+    ]
+  })
+)
+
+const HUB_NPCS: HubNpc[] = rawConfig.npcs as HubNpc[]
+const EXTERIOR_NPCS = HUB_NPCS.filter(n => !n.building)
+const INTERIOR_NPCS: Record<string, HubNpc[]> = HUB_NPCS
+  .filter(n => !!n.building)
+  .reduce<Record<string, HubNpc[]>>((acc, n) => {
+    const key = n.building!
+    ;(acc[key] ??= []).push(n)
+    return acc
+  }, {})
+
+const NPC_SPAWN_TILES: [number, number][] = HUB_DOORS.map(d => [d.tx, d.ty] as [number, number])
+const AMBIENT_NPC_SPRITES: string[] = []
+
+type RawPickup = { id: string; tx: number; ty: number; tileId: string; building?: string; questId?: string; chain?: string; requireTouch?: boolean }
+const HUB_PICKUP_ITEMS: HubPickupItem[] = (
+  (rawQuestConfig as unknown as { pickupItems?: RawPickup[] }).pickupItems ?? []
+).map(p => ({
+  id:           p.id,
+  tx:           p.tx,
+  ty:           p.ty,
+  tileId:       resolveTileId(p.tileId),
+  building:     p.building,
+  questId:      p.questId,
+  chain:        p.chain,
+  requireTouch: p.requireTouch,
+}))
+
+const HUB_BLOCKED_PATHS: BlockedPath[] = []
+const HUB_LOCKED_DOORS: HubLockedDoor[] = []
+const HUB_TREASURES: HubTreasure[] = []
+
+type RawExitTile = { tx: number; ty: number; screen: string }
+const EXIT_TILES: HubExitTile[] = (
+  (rawConfig as unknown as { exitTiles?: RawExitTile[] }).exitTiles ?? []
+)
+
+export const CASTLE_QUEST_DEFS: HubQuestDef[] = (rawQuestConfig as unknown as { quests: HubQuestDef[] }).quests
+
+export const CASTLE_LOCATION_DATA: HubLocationData = {
+  MAP_W,
+  MAP_H,
+  AVATAR_START,
+  TOWN_NAME,
+  HUB_AREAS,
+  HUB_STREET_GROUPS,
+  HUB_STREET_TILES,
+  HUB_BUILDINGS,
+  HUB_BUILDING_TILES,
+  EXTERIOR_DECOR,
+  HUB_WINDOWS,
+  HUB_POND_TILES,
+  HUB_DOORS,
+  HUB_INTERIORS,
+  HUB_NPCS,
+  EXTERIOR_NPCS,
+  INTERIOR_NPCS,
+  NPC_SPAWN_TILES,
+  AMBIENT_NPC_SPRITES,
+  HUB_PICKUP_ITEMS,
+  HUB_BLOCKED_PATHS,
+  HUB_LOCKED_DOORS,
+  HUB_TREASURES,
+  EXIT_TILES,
+}

--- a/web/src/data/castle/questDefs.json
+++ b/web/src/data/castle/questDefs.json
@@ -1,0 +1,91 @@
+{
+  "quests": [
+    {
+      "id": "castle-missing-patrol",
+      "title": "Missing Patrol Reports",
+      "type": "fetch",
+      "giverNpcId": "castle-commander",
+      "receiverNpcId": "castle-commander",
+      "offerDialogue": "Three of my guards lost their patrol reports during yesterday's drill. I need those papers recovered before the weekly briefing. Search the courtyard.",
+      "activeDialogue": "The patrol reports should be somewhere in the outer courtyard. Guard Bren and Guard Holt lost theirs too — ask them if you spot anything.",
+      "completeDialogue": "All three reports accounted for. You have my thanks, traveller. The keep runs on discipline — I can't have its records scattered in the dirt.",
+      "steps": [
+        { "key": "reports", "type": "collect", "pickupIds": ["patrol-report-1", "patrol-report-2", "patrol-report-3"], "required": 3 }
+      ],
+      "reward": {
+        "crystals": 60
+      }
+    },
+    {
+      "id": "castle-weapon-cache",
+      "title": "The Weapon Cache",
+      "type": "fetch",
+      "giverNpcId": "castle-blacksmith",
+      "receiverNpcId": "castle-blacksmith",
+      "prerequisite": "quest:castle-missing-patrol",
+      "offerDialogue": "Three weapon crates went missing during the last resupply. My tallies don't add up. They can't have gone far — check around the courtyard and the side passages.",
+      "activeDialogue": "Three crates, somewhere in the keep grounds. If someone's been pilfering supplies, I want proof.",
+      "completeDialogue": "All three. No damage, no pilfering — just poor organisation. I'll have a word with the quartermasters. Here, take this in thanks.",
+      "steps": [
+        { "key": "crates", "type": "collect", "pickupIds": ["weapon-crate-1", "weapon-crate-2", "weapon-crate-3"], "required": 3 }
+      ],
+      "reward": {
+        "crystals": 50,
+        "collectible": { "id": "castle-seal", "name": "Castle Seal", "icon": "🔰", "desc": "The iron seal of Ironhold Keep. A mark of trust." }
+      }
+    },
+    {
+      "id": "castle-siege-memory",
+      "title": "The Siege Chronicle",
+      "type": "chain",
+      "giverNpcId": "castle-archivist",
+      "receiverNpcId": "castle-archivist",
+      "offerDialogue": "A chronicle of the great siege was separated from our archives years ago. Three pages were found and distributed around the keep. If you recover them, our history will be whole again.",
+      "activeDialogue": {
+        "page-1": "The first page was last seen in the commanders' hall. Worth checking the shelves.",
+        "page-2": "Good, one page found. The second was tucked away in the armory, of all places.",
+        "page-3": "Two pages now — remarkable. The final page was stored in the barracks. Nearly done."
+      },
+      "completeDialogue": "The chronicle is complete. This account of the siege is irreplaceable. You have done the keep a great service, traveller.",
+      "steps": [
+        { "key": "page-1", "type": "collect", "pickupIds": ["chronicle-page-1"], "required": 1 },
+        { "key": "page-2", "type": "collect", "pickupIds": ["chronicle-page-2"], "required": 1, "chain": "chronicle-page-1" },
+        { "key": "page-3", "type": "collect", "pickupIds": ["chronicle-page-3"], "required": 1, "chain": "chronicle-page-2" }
+      ],
+      "reward": {
+        "crystals": 40,
+        "collectible": { "id": "siege-chronicle", "name": "Siege Chronicle", "icon": "📖", "desc": "A complete account of the fall and recapture of Ironhold Keep." },
+        "friendship": { "castle-archivist": 30 }
+      }
+    },
+    {
+      "id": "castle-message-ravenwatch",
+      "title": "Message for the Captain",
+      "type": "fetch",
+      "giverNpcId": "castle-commander",
+      "receiverNpcId": "guard-captain-thorin",
+      "prerequisite": "quest:castle-weapon-cache",
+      "offerDialogue": "I have intelligence that must reach Guard Captain Thorin in Ravenwatch immediately. The south gate will take you back. Deliver this message personally — no intermediaries.",
+      "activeDialogue": "Guard Captain Thorin in Ravenwatch is waiting for this message. Return through the south gate and find him in the barracks.",
+      "completeDialogue": "From Commander Varek? I've been expecting this. Thank you, traveller — this changes our defensive arrangements considerably. Take this for your trouble.",
+      "steps": [
+        { "key": "deliver", "type": "deliver", "targetNpcId": "guard-captain-thorin", "required": 1 }
+      ],
+      "reward": {
+        "crystals": 80
+      }
+    }
+  ],
+  "pickupItems": [
+    { "id": "patrol-report-1", "tx": 5,  "ty": 10, "tileId": "smallSign",   "questId": "castle-missing-patrol" },
+    { "id": "patrol-report-2", "tx": 12, "ty": 13, "tileId": "smallSign",   "questId": "castle-missing-patrol" },
+    { "id": "patrol-report-3", "tx": 16, "ty": 11, "tileId": "smallSign",   "questId": "castle-missing-patrol" },
+    { "id": "weapon-crate-1",  "tx": 1,  "ty": 16, "tileId": "crate",       "questId": "castle-weapon-cache" },
+    { "id": "weapon-crate-2",  "tx": 20, "ty": 17, "tileId": "crate",       "questId": "castle-weapon-cache" },
+    { "id": "weapon-crate-3",  "tx": 7,  "ty": 17, "tileId": "openCrate",   "questId": "castle-weapon-cache" },
+    { "id": "chronicle-page-1","tx": 5,  "ty": 2,  "tileId": "smallSign",   "questId": "castle-siege-memory", "building": "commanders-hall" },
+    { "id": "chronicle-page-2","tx": 2,  "ty": 2,  "tileId": "smallSign",   "questId": "castle-siege-memory", "building": "armory", "chain": "chronicle-page-1" },
+    { "id": "chronicle-page-3","tx": 2,  "ty": 2,  "tileId": "smallSign",   "questId": "castle-siege-memory", "building": "barracks", "chain": "chronicle-page-2" }
+  ],
+  "blockedPaths": []
+}

--- a/web/src/data/hub/config.json
+++ b/web/src/data/hub/config.json
@@ -1,9 +1,16 @@
 {
   "mapW": 2400,
   "mapH": 2240,
+  "townName": "Ravenwatch",
   "avatarStart": [
     37,
     29
+  ],
+  "exitTiles": [
+    { "tx": 36, "ty": 67, "screen": "worldmap" },
+    { "tx": 37, "ty": 67, "screen": "worldmap" },
+    { "tx": 38, "ty": 67, "screen": "worldmap" },
+    { "tx": 39, "ty": 67, "screen": "worldmap" }
   ],
   "areas": [
     {
@@ -77,6 +84,14 @@
       "ty": 27,
       "tw": 15,
       "th": 8
+    },
+    {
+      "id": "southgate",
+      "name": "Ravenwatch South Gate",
+      "tx": 28,
+      "ty": 57,
+      "tw": 20,
+      "th": 13
     }
   ],
   "streets": [

--- a/web/src/data/hub/loader.ts
+++ b/web/src/data/hub/loader.ts
@@ -3,6 +3,7 @@ import rawQuestConfig from './questDefs.json'
 import { BASE_CHIP_TILES } from '../tiles/baseChipIndex'
 import { WALL_TILES } from '../tiles/buildingMaterials'
 import type { WallMaterial, RoofMaterial } from '../tiles/buildingMaterials'
+import type { HubLocationData, HubExitTile } from './locationTypes'
 
 const WALL_MATERIAL_NAMES = new Set<string>(Object.keys(WALL_TILES))
 
@@ -388,3 +389,37 @@ export const HUB_TREASURES: HubTreasure[] = (
   tileId:           resolveTileId(t.tileId),
   collectedTileId:  t.collectedTileId ? resolveTileId(t.collectedTileId) : undefined,
 }))
+
+export const HUB_TOWN_NAME: string = (rawConfig as unknown as { townName?: string }).townName ?? 'Town'
+
+type RawExitTile = { tx: number; ty: number; screen: string }
+export const HUB_EXIT_TILES: HubExitTile[] = (
+  (rawConfig as unknown as { exitTiles?: RawExitTile[] }).exitTiles ?? []
+)
+
+export const HUB_LOCATION_DATA: HubLocationData = {
+  MAP_W,
+  MAP_H,
+  AVATAR_START,
+  TOWN_NAME:          HUB_TOWN_NAME,
+  HUB_AREAS,
+  HUB_STREET_GROUPS,
+  HUB_STREET_TILES,
+  HUB_BUILDINGS,
+  HUB_BUILDING_TILES,
+  EXTERIOR_DECOR,
+  HUB_WINDOWS,
+  HUB_POND_TILES,
+  HUB_DOORS,
+  HUB_INTERIORS,
+  HUB_NPCS,
+  EXTERIOR_NPCS,
+  INTERIOR_NPCS,
+  NPC_SPAWN_TILES,
+  AMBIENT_NPC_SPRITES,
+  HUB_PICKUP_ITEMS,
+  HUB_BLOCKED_PATHS,
+  HUB_LOCKED_DOORS,
+  HUB_TREASURES,
+  EXIT_TILES:         HUB_EXIT_TILES,
+}

--- a/web/src/data/hub/locationTypes.ts
+++ b/web/src/data/hub/locationTypes.ts
@@ -1,0 +1,37 @@
+import type {
+  HubArea, HubBuilding, HubStreetGroup, HubDoor, HubInterior,
+  HubNpc, HubPickupItem, BlockedPath, HubLockedDoor, HubTreasure,
+} from './loader'
+
+export interface HubExitTile {
+  tx: number
+  ty: number
+  screen: string
+}
+
+export interface HubLocationData {
+  MAP_W:              number
+  MAP_H:              number
+  AVATAR_START:       [number, number]
+  TOWN_NAME:          string
+  HUB_AREAS:          HubArea[]
+  HUB_STREET_GROUPS:  HubStreetGroup[]
+  HUB_STREET_TILES:   [number, number][]
+  HUB_BUILDINGS:      HubBuilding[]
+  HUB_BUILDING_TILES: [number, number][]
+  EXTERIOR_DECOR:     { tx: number; ty: number; tileId: number; zlayer?: string }[]
+  HUB_WINDOWS:        { tx: number; ty: number; tileId: number }[]
+  HUB_POND_TILES:     [number, number][]
+  HUB_DOORS:          HubDoor[]
+  HUB_INTERIORS:      Record<string, HubInterior>
+  HUB_NPCS:           HubNpc[]
+  EXTERIOR_NPCS:      HubNpc[]
+  INTERIOR_NPCS:      Record<string, HubNpc[]>
+  NPC_SPAWN_TILES:    [number, number][]
+  AMBIENT_NPC_SPRITES: string[]
+  HUB_PICKUP_ITEMS:   HubPickupItem[]
+  HUB_BLOCKED_PATHS:  BlockedPath[]
+  HUB_LOCKED_DOORS:   HubLockedDoor[]
+  HUB_TREASURES:      HubTreasure[]
+  EXIT_TILES:         HubExitTile[]
+}

--- a/web/src/data/town2/config.json
+++ b/web/src/data/town2/config.json
@@ -1,0 +1,256 @@
+{
+  "mapW": 896,
+  "mapH": 640,
+  "townName": "Millhaven",
+  "avatarStart": [13, 15],
+  "exitTiles": [
+    { "tx": 11, "ty": 19, "screen": "worldmap" },
+    { "tx": 12, "ty": 19, "screen": "worldmap" },
+    { "tx": 13, "ty": 19, "screen": "worldmap" },
+    { "tx": 14, "ty": 19, "screen": "worldmap" },
+    { "tx": 15, "ty": 19, "screen": "worldmap" }
+  ],
+  "areas": [
+    {
+      "id": "millhaven-harbour",
+      "name": "The Harbour",
+      "tx": 0,
+      "ty": 8,
+      "tw": 28,
+      "th": 4
+    },
+    {
+      "id": "millhaven-market",
+      "name": "Market Square",
+      "tx": 7,
+      "ty": 10,
+      "tw": 14,
+      "th": 4
+    },
+    {
+      "id": "millhaven-centre",
+      "name": "Town Square",
+      "tx": 9,
+      "ty": 12,
+      "tw": 10,
+      "th": 8
+    }
+  ],
+  "streets": [
+    { "rect": [0, 8, 27, 8] },
+    { "rect": [9, 9, 18, 19] },
+    { "rect": [0, 8, 6, 9] },
+    { "rect": [21, 8, 27, 9] }
+  ],
+  "buildings": [
+    {
+      "id": "mill",
+      "rect": [1, 1, 5, 7],
+      "wall": "woodenSlats",
+      "roof": "strawRoof",
+      "doors": [
+        { "tx": 2, "ty": 1 }
+      ]
+    },
+    {
+      "id": "fishmonger",
+      "rect": [21, 1, 27, 6],
+      "wall": "woodenSlats",
+      "roof": "yellowSlateRoof",
+      "doors": [
+        { "tx": 3, "ty": 2 }
+      ]
+    },
+    {
+      "id": "inn-millhaven",
+      "rect": [9, 1, 18, 6],
+      "wall": "tudorFrame",
+      "roof": "redSlateRoof",
+      "doors": [
+        { "tx": 5, "ty": 2 }
+      ]
+    },
+    {
+      "id": "market-hall",
+      "rect": [7, 10, 20, 12],
+      "wall": "woodenSlats",
+      "roof": "strawRoof",
+      "doors": [
+        { "tx": 5, "ty": 1 }
+      ]
+    },
+    {
+      "id": "town-hall-millhaven",
+      "rect": [9, 13, 18, 17],
+      "wall": "renderedBrick",
+      "roof": "blueSlateRoof",
+      "doors": [
+        { "tx": 4, "ty": 1 }
+      ]
+    }
+  ],
+  "exteriorDecor": [
+    { "comment": "dock and harbour decor" },
+    { "tx": 0, "ty": 8, "tileId": "smallRock" },
+    { "tx": 27, "ty": 8, "tileId": "smallRock" },
+    { "tx": 3,  "ty": 9, "tileId": "barrel" },
+    { "tx": 4,  "ty": 9, "tileId": "barrel" },
+    { "tx": 23, "ty": 9, "tileId": "barrel" },
+    { "tx": 24, "ty": 9, "tileId": "barrel" },
+    { "comment": "lilypads in front of mill pond" },
+    { "tx": 0, "ty": 3, "tileId": "largeLilypad" },
+    { "tx": 0, "ty": 5, "tileId": "smallLilypad" },
+    { "comment": "market stall crates" },
+    { "tx": 8,  "ty": 9, "tileId": "crate" },
+    { "tx": 19, "ty": 9, "tileId": "crate" },
+    { "comment": "town square features" },
+    { "tx": 10, "ty": 13, "tileId": "stoneWell" },
+    { "tx": 16, "ty": 13, "tileId": "stoneWell" },
+    { "comment": "south exit fencing with gap" },
+    { "tx": 9,  "ty": 19, "tileId": "ironFenceLeftRight" },
+    { "tx": 10, "ty": 19, "tileId": "ironFenceLeftRight" },
+    { "comment": "gap at tx 11-15 for exit" },
+    { "tx": 16, "ty": 19, "tileId": "ironFenceLeftRight" },
+    { "tx": 17, "ty": 19, "tileId": "ironFenceLeftRight" },
+    { "tx": 18, "ty": 19, "tileId": "ironFenceLeftRight" }
+  ],
+  "npcSpawnTiles": [],
+  "ambientNpcSprites": ["hub-npc-fisherman", "hub-npc-merchant"],
+  "npcs": [
+    {
+      "id": "mill-owner",
+      "name": "Miller Oswin",
+      "sprite": "hub-npc-supplies",
+      "tx": 3,
+      "ty": 8,
+      "dialogue": [
+        "Millhaven's mill has ground grain for this coast for sixty years.",
+        "Three grain sacks went missing from the store. Someone's been helping themselves.",
+        "If you find those sacks, I'll remember the favour."
+      ],
+      "questGive": "millhaven-mill-grain",
+      "questReceive": "millhaven-mill-grain"
+    },
+    {
+      "id": "fishmonger-marta",
+      "name": "Fishwife Marta",
+      "sprite": "hub-npc-fisherman",
+      "tx": 24,
+      "ty": 8,
+      "dialogue": [
+        "The catch has been thin lately. Strange currents, says Sailor Finn.",
+        "I've got fish baskets missing somewhere around the docks.",
+        "Fresh catch, get your fresh catch! Don't let the gulls beat you to it."
+      ],
+      "questGive": "millhaven-missing-catch",
+      "questReceive": "millhaven-missing-catch"
+    },
+    {
+      "id": "innkeeper-millhaven",
+      "name": "Innkeeper Cobb",
+      "sprite": "hub-npc-merchant",
+      "tx": 14,
+      "ty": 8,
+      "dialogue": [
+        "Welcome to The Anchor, best beds on the Millhaven coast.",
+        "A merchant from Ravenwatch left a letter here. Meant for someone called Elder Elara.",
+        "You look like someone who travels. That letter's been sitting here long enough."
+      ],
+      "building": "inn-millhaven",
+      "questGive": "millhaven-message-to-ravenwatch",
+      "questReceive": "millhaven-message-to-ravenwatch"
+    },
+    {
+      "id": "town-elder-millhaven",
+      "name": "Elder Bramwell",
+      "sprite": "hub-npc-elder",
+      "tx": 13,
+      "ty": 16,
+      "dialogue": [
+        "Millhaven was founded by fisherfolk. We've kept it that way.",
+        "The castle to the south needs resupply. We've been meaning to send a courier.",
+        "If you're heading to Ironhold Keep, perhaps you could take our supply manifest to Commander Varek?"
+      ],
+      "building": "town-hall-millhaven",
+      "questGive": "millhaven-supplies-for-keep",
+      "questReceive": "millhaven-supplies-for-keep"
+    },
+    {
+      "id": "sailor-finn",
+      "name": "Sailor Finn",
+      "sprite": "hub-npc-fisherman",
+      "tx": 5,
+      "ty": 8,
+      "dialogue": [
+        "The tides have been off all week. Something in the currents.",
+        "I've seen three ships go dark past the reef. No word from them.",
+        "Marta thinks I'm superstitious. Maybe I am."
+      ],
+      "questGive": "millhaven-lost-at-sea",
+      "questReceive": "millhaven-missing-catch"
+    },
+    {
+      "id": "market-trader",
+      "name": "Trader Nessa",
+      "sprite": "hub-npc-merchant",
+      "tx": 13,
+      "ty": 11,
+      "dialogue": [
+        "Everything from rope to ribbon, if you've got coin.",
+        "Trade's been slow. Travellers don't stop here like they used to.",
+        "Nice to see a fresh face in Millhaven."
+      ],
+      "building": "market-hall",
+      "questGive": "millhaven-festival-prep",
+      "questReceive": "millhaven-festival-prep"
+    }
+  ],
+  "interiors": {
+    "inn-millhaven": {
+      "name": "The Anchor Inn",
+      "width": 9,
+      "height": 5,
+      "floorTileId": "woodFloor",
+      "wallTileId": "woodWall",
+      "decor": [
+        { "tx": 1, "ty": 1, "tileId": "barrel" },
+        { "tx": 2, "ty": 1, "tileId": "barrel" },
+        { "tx": 6, "ty": 1, "tileId": "chest" },
+        { "tx": 7, "ty": 1, "tileId": "chest" }
+      ],
+      "exits": []
+    },
+    "market-hall": {
+      "name": "Market Hall",
+      "width": 12,
+      "height": 3,
+      "floorTileId": "woodFloor",
+      "wallTileId": "woodenSlats",
+      "decor": [
+        { "tx": 1,  "ty": 1, "tileId": "crate" },
+        { "tx": 2,  "ty": 1, "tileId": "openCrate" },
+        { "tx": 9,  "ty": 1, "tileId": "crate" },
+        { "tx": 10, "ty": 1, "tileId": "openCrate" }
+      ],
+      "exits": []
+    },
+    "town-hall-millhaven": {
+      "name": "Millhaven Town Hall",
+      "width": 8,
+      "height": 4,
+      "floorTileId": "cobblestoneFloor",
+      "wallTileId": "renderedBrick",
+      "decor": [
+        { "tx": 1, "ty": 1, "tileId": "bookshelfTop" },
+        { "tx": 2, "ty": 1, "tileId": "bookshelfTop" },
+        { "tx": 1, "ty": 2, "tileId": "bookshelfBottom" },
+        { "tx": 2, "ty": 2, "tileId": "bookshelfBottom" },
+        { "tx": 5, "ty": 1, "tileId": "bookshelfTop" },
+        { "tx": 6, "ty": 1, "tileId": "bookshelfTop" },
+        { "tx": 5, "ty": 2, "tileId": "bookshelfBottom" },
+        { "tx": 6, "ty": 2, "tileId": "bookshelfBottom" }
+      ],
+      "exits": []
+    }
+  }
+}

--- a/web/src/data/town2/loader.ts
+++ b/web/src/data/town2/loader.ts
@@ -1,0 +1,234 @@
+import rawConfig from './config.json'
+import rawQuestConfig from './questDefs.json'
+import { BASE_CHIP_TILES } from '../tiles/baseChipIndex'
+import { WALL_TILES } from '../tiles/buildingMaterials'
+import type { WallMaterial, RoofMaterial } from '../tiles/buildingMaterials'
+import type {
+  HubArea, HubBuilding, HubDoor, InteriorDecor, HubInterior,
+  HubInteriorExit, HubNpc, HubPickupItem, BlockedPath, BlockedPathState,
+  HubLockedDoor, HubTreasure, HubTreasureReward, HubStreetGroup,
+} from '../hub/loader'
+import type { HubLocationData, HubExitTile } from '../hub/locationTypes'
+import type { HubQuestDef } from '../hub/questDefs'
+
+const WALL_MATERIAL_NAMES = new Set<string>(Object.keys(WALL_TILES))
+const T = 32
+
+function resolveTileId(key: string): number {
+  return (BASE_CHIP_TILES as Record<string, number>)[key] ?? 666
+}
+
+type TileEntry = { rect: number[]; pathType?: string } | { tile: number[]; pathType?: string }
+
+function expandTiles(entries: TileEntry[]): [number, number][] {
+  const out: [number, number][] = []
+  for (const e of entries) {
+    if ('rect' in e) {
+      const [tx1, ty1, tx2, ty2] = e.rect
+      for (let tx = tx1; tx <= tx2; tx++)
+        for (let ty = ty1; ty <= ty2; ty++)
+          out.push([tx, ty])
+    } else {
+      out.push(e.tile as [number, number])
+    }
+  }
+  return out
+}
+
+function groupStreets(entries: TileEntry[]): HubStreetGroup[] {
+  const map = new Map<string, [number, number][]>()
+  for (const e of entries) {
+    const key = e.pathType ?? ''
+    if (!map.has(key)) map.set(key, [])
+    const tiles = map.get(key)!
+    if ('rect' in e) {
+      const [tx1, ty1, tx2, ty2] = e.rect
+      for (let tx = tx1; tx <= tx2; tx++)
+        for (let ty = ty1; ty <= ty2; ty++)
+          tiles.push([tx, ty])
+    } else {
+      tiles.push(e.tile as [number, number])
+    }
+  }
+  return Array.from(map.entries()).map(([key, tiles]) => ({ pathType: key || undefined, tiles }))
+}
+
+function buildingOrigin(rectList: number[][]): [number, number] {
+  const tx1 = Math.min(...rectList.map(r => r[0]))
+  const ty2 = Math.max(...rectList.map(r => r[3]))
+  return [tx1, ty2]
+}
+
+const MAP_W = rawConfig.mapW
+const MAP_H = rawConfig.mapH
+const AVATAR_START = rawConfig.avatarStart as [number, number]
+const TOWN_NAME: string = (rawConfig as unknown as { townName?: string }).townName ?? 'Town'
+
+const HUB_AREAS: HubArea[] = rawConfig.areas.map(a => ({
+  id:   a.id,
+  name: a.name,
+  x:    a.tx * T,
+  y:    a.ty * T,
+  w:    a.tw * T,
+  h:    a.th * T,
+}))
+
+const HUB_STREET_GROUPS: HubStreetGroup[] = groupStreets(rawConfig.streets as TileEntry[])
+const HUB_STREET_TILES: [number, number][] = HUB_STREET_GROUPS.flatMap(g => g.tiles)
+
+type RawBuilding = {
+  rect?: number[]; rects?: number[][];
+  id?: string; wall?: string; roof?: string;
+  doors?:   Array<{ tx: number; ty: number; buildingId?: string }>
+  windows?: Array<{ tx: number; ty: number; tileId: string }>
+  decor?:   Array<{ tx: number; ty: number; tileId: string; zlayer?: string }>
+}
+
+const HUB_BUILDINGS: HubBuilding[] = (rawConfig.buildings as RawBuilding[]).flatMap(b => {
+  const rectList = b.rects ?? (b.rect ? [b.rect] : [])
+  return rectList.map(rect => ({
+    rect: rect as [number, number, number, number],
+    id:   b.id,
+    wall: b.wall as WallMaterial | undefined,
+    roof: b.roof as RoofMaterial | undefined,
+  }))
+})
+
+const HUB_BUILDING_TILES: [number, number][] = HUB_BUILDINGS.flatMap(b => {
+  const [tx1, ty1, tx2, ty2] = b.rect
+  const tiles: [number, number][] = []
+  for (let tx = tx1; tx <= tx2; tx++)
+    for (let ty = ty1; ty <= ty2; ty++)
+      tiles.push([tx, ty])
+  return tiles
+})
+
+const _nestedDoors:   HubDoor[] = []
+const _nestedWindows: { tx: number; ty: number; tileId: number }[] = []
+const _nestedDecor:   { tx: number; ty: number; tileId: number; zlayer?: string }[] = []
+
+for (const b of rawConfig.buildings as RawBuilding[]) {
+  const rectList = b.rects ?? (b.rect ? [b.rect] : [])
+  if (rectList.length === 0) continue
+  const [ox, oy] = buildingOrigin(rectList)
+  for (const d of b.doors ?? []) {
+    const absTy = oy + d.ty
+    let storeTy  = absTy
+    let tyAdjust = 0
+    if (!rectList.some(r => r[3] + 1 === absTy)) {
+      const candidate = rectList
+        .map(r => r[3] + 1)
+        .filter(ty2p1 => ty2p1 > absTy)
+        .sort((a, b) => a - b)[0]
+      if (candidate !== undefined) { storeTy = candidate; tyAdjust = candidate - absTy }
+    }
+    _nestedDoors.push({ buildingId: d.buildingId ?? b.id ?? '', tx: ox + d.tx, ty: storeTy, ...(tyAdjust ? { tyAdjust } : {}) })
+  }
+  for (const w of b.windows ?? [])
+    _nestedWindows.push({ tx: ox + w.tx, ty: oy + w.ty, tileId: resolveTileId(w.tileId) })
+  for (const d of b.decor ?? [])
+    _nestedDecor.push({ tx: ox + d.tx, ty: oy + d.ty, tileId: resolveTileId(d.tileId), zlayer: d.zlayer })
+}
+
+type RawDecorEntry = { tx?: number; ty?: number; tileId?: string; comment?: string; zlayer?: string }
+const EXTERIOR_DECOR = [
+  ...(rawConfig.exteriorDecor as RawDecorEntry[])
+    .filter((d): d is { tx: number; ty: number; tileId: string; zlayer?: string } => d.tx != null && d.ty != null && d.tileId != null)
+    .map(d => ({ tx: d.tx, ty: d.ty, tileId: resolveTileId(d.tileId), zlayer: d.zlayer })),
+  ..._nestedDecor,
+]
+
+const HUB_WINDOWS = [..._nestedWindows]
+const HUB_POND_TILES: [number, number][] = []
+const HUB_DOORS: HubDoor[] = _nestedDoors
+
+const HUB_INTERIORS: Record<string, HubInterior> = Object.fromEntries(
+  Object.entries(rawConfig.interiors).map(([id, raw]) => {
+    const rawAny = raw as Record<string, unknown>
+    const wallTileIdStr = rawAny.wallTileId as string | undefined
+    return [
+      id,
+      {
+        id,
+        name:         raw.name,
+        width:        raw.width,
+        height:       raw.height,
+        floorTileId:  resolveTileId(raw.floorTileId),
+        wallMaterial: wallTileIdStr && WALL_MATERIAL_NAMES.has(wallTileIdStr) ? wallTileIdStr as WallMaterial : undefined,
+        decor:        (raw.decor as Array<{ tx: number; ty: number; tileId: string; zlayer?: string }>).map(d => ({
+          tx:     d.tx,
+          ty:     d.ty,
+          tileId: resolveTileId(d.tileId),
+          zlayer: d.zlayer as InteriorDecor['zlayer'],
+        })),
+        exits: ((rawAny.exits ?? []) as HubInteriorExit[]),
+        hours: rawAny.hours as HubInterior['hours'],
+      } satisfies HubInterior,
+    ]
+  })
+)
+
+const HUB_NPCS: HubNpc[] = rawConfig.npcs as HubNpc[]
+const EXTERIOR_NPCS = HUB_NPCS.filter(n => !n.building)
+const INTERIOR_NPCS: Record<string, HubNpc[]> = HUB_NPCS
+  .filter(n => !!n.building)
+  .reduce<Record<string, HubNpc[]>>((acc, n) => {
+    const key = n.building!
+    ;(acc[key] ??= []).push(n)
+    return acc
+  }, {})
+
+const NPC_SPAWN_TILES: [number, number][] = HUB_DOORS.map(d => [d.tx, d.ty] as [number, number])
+const AMBIENT_NPC_SPRITES: string[] = []
+
+type RawPickup = { id: string; tx: number; ty: number; tileId: string; building?: string; questId?: string; chain?: string; requireTouch?: boolean }
+const HUB_PICKUP_ITEMS: HubPickupItem[] = (
+  (rawQuestConfig as unknown as { pickupItems?: RawPickup[] }).pickupItems ?? []
+).map(p => ({
+  id:           p.id,
+  tx:           p.tx,
+  ty:           p.ty,
+  tileId:       resolveTileId(p.tileId),
+  building:     p.building,
+  questId:      p.questId,
+  chain:        p.chain,
+  requireTouch: p.requireTouch,
+}))
+
+const HUB_BLOCKED_PATHS: BlockedPath[] = []
+const HUB_LOCKED_DOORS: HubLockedDoor[] = []
+const HUB_TREASURES: HubTreasure[] = []
+
+type RawExitTile = { tx: number; ty: number; screen: string }
+const EXIT_TILES: HubExitTile[] = (
+  (rawConfig as unknown as { exitTiles?: RawExitTile[] }).exitTiles ?? []
+)
+
+export const TOWN2_QUEST_DEFS: HubQuestDef[] = (rawQuestConfig as unknown as { quests: HubQuestDef[] }).quests
+
+export const TOWN2_LOCATION_DATA: HubLocationData = {
+  MAP_W,
+  MAP_H,
+  AVATAR_START,
+  TOWN_NAME,
+  HUB_AREAS,
+  HUB_STREET_GROUPS,
+  HUB_STREET_TILES,
+  HUB_BUILDINGS,
+  HUB_BUILDING_TILES,
+  EXTERIOR_DECOR,
+  HUB_WINDOWS,
+  HUB_POND_TILES,
+  HUB_DOORS,
+  HUB_INTERIORS,
+  HUB_NPCS,
+  EXTERIOR_NPCS,
+  INTERIOR_NPCS,
+  NPC_SPAWN_TILES,
+  AMBIENT_NPC_SPRITES,
+  HUB_PICKUP_ITEMS,
+  HUB_BLOCKED_PATHS,
+  HUB_LOCKED_DOORS,
+  HUB_TREASURES,
+  EXIT_TILES,
+}

--- a/web/src/data/town2/questDefs.json
+++ b/web/src/data/town2/questDefs.json
@@ -1,0 +1,131 @@
+{
+  "quests": [
+    {
+      "id": "millhaven-mill-grain",
+      "title": "The Missing Grain",
+      "type": "fetch",
+      "giverNpcId": "mill-owner",
+      "receiverNpcId": "mill-owner",
+      "offerDialogue": "Three grain sacks have gone missing from my store. I suspect someone's been helping themselves in the night. Check around the harbour and docks — they can't have gone far.",
+      "activeDialogue": "Three grain sacks, somewhere around the harbour area. Keep your eyes open.",
+      "completeDialogue": "All three! Someone had been stacking them near the dock behind the barrels. Thank you kindly — a mill without grain is just a fancy windbreak.",
+      "steps": [
+        { "key": "grain", "type": "collect", "pickupIds": ["grain-sack-1", "grain-sack-2", "grain-sack-3"], "required": 3 }
+      ],
+      "reward": {
+        "crystals": 40
+      }
+    },
+    {
+      "id": "millhaven-missing-catch",
+      "title": "The Missing Catch",
+      "type": "chain",
+      "giverNpcId": "fishmonger-marta",
+      "receiverNpcId": "sailor-finn",
+      "offerDialogue": "Two fish baskets went overboard during the morning haul. I saw them drift toward the east dock. Bring them back and take them to Sailor Finn on the west dock — he's sorting the morning catch.",
+      "activeDialogue": {
+        "baskets": "The fish baskets were near the east dock, last I saw. Have a look.",
+        "deliver": "Good, both baskets found! Take them to Sailor Finn on the west dock."
+      },
+      "completeDialogue": "Marta's baskets? Excellent — I was wondering where these went. Here, keep a bit for your trouble.",
+      "steps": [
+        { "key": "baskets", "type": "collect", "pickupIds": ["fish-basket-1", "fish-basket-2"], "required": 2 },
+        { "key": "deliver", "type": "deliver", "targetNpcId": "sailor-finn", "required": 1 }
+      ],
+      "reward": {
+        "crystals": 50,
+        "collectible": { "id": "smoked-herring", "name": "Smoked Herring", "icon": "🐟", "desc": "A freshly smoked herring from Millhaven's famous catch." },
+        "friendship": { "fishmonger-marta": 20, "sailor-finn": 15 }
+      }
+    },
+    {
+      "id": "millhaven-lost-at-sea",
+      "title": "Lost at Sea",
+      "type": "fetch",
+      "giverNpcId": "sailor-finn",
+      "receiverNpcId": "sailor-finn",
+      "prerequisite": "quest:millhaven-missing-catch",
+      "offerDialogue": "A shipmate of mine went missing two weeks ago. His last known position is on a chart I dropped somewhere near the warehouse. If you find it, maybe I can work out what happened.",
+      "activeDialogue": "The nautical chart should be somewhere near the market warehouse area. Look carefully.",
+      "completeDialogue": "This is it! The course he was sailing — past the dark reef. No wonder we lost him. I can file a proper report now, at least. Take this as thanks.",
+      "steps": [
+        { "key": "chart", "type": "collect", "pickupIds": ["nautical-chart"], "required": 1 }
+      ],
+      "reward": {
+        "crystals": 40,
+        "card": { "name": "Sea Raider", "count": 1 },
+        "collectible": { "id": "sea-chart", "name": "Navigator's Chart", "icon": "🗺️", "desc": "A detailed chart of the coastal reef. Marks a mysterious dark spot." }
+      }
+    },
+    {
+      "id": "millhaven-supplies-for-keep",
+      "title": "Supplies for Ironhold",
+      "type": "fetch",
+      "giverNpcId": "town-elder-millhaven",
+      "receiverNpcId": "castle-commander",
+      "prerequisite": "quest:millhaven-mill-grain",
+      "offerDialogue": "Ironhold Keep has been short on supplies since the last resupply convoy was delayed. I have a manifest ready — would you take it to Commander Varek at the keep? The south road will take you there.",
+      "activeDialogue": "Commander Varek at Ironhold Keep is expecting this supply manifest. Travel south through the town gate.",
+      "completeDialogue": "From Elder Bramwell? This is exactly what we needed. The supply chain can resume. You have the keep's gratitude, traveller.",
+      "steps": [
+        { "key": "deliver", "type": "deliver", "targetNpcId": "castle-commander", "required": 1 }
+      ],
+      "reward": {
+        "crystals": 100
+      }
+    },
+    {
+      "id": "millhaven-message-to-ravenwatch",
+      "title": "A Letter for the Elder",
+      "type": "fetch",
+      "giverNpcId": "innkeeper-millhaven",
+      "receiverNpcId": "elder",
+      "prerequisite": "quest:millhaven-mill-grain",
+      "offerDialogue": "A merchant from Ravenwatch was staying here last month. He left a sealed letter meant for someone called Elder Elara in Ravenwatch. Would you take it if you're heading that way? It's been sitting on my shelf too long.",
+      "activeDialogue": "Elder Elara in Ravenwatch is waiting for this letter. Find her when you're back in Ravenwatch.",
+      "completeDialogue": "Oh! This is from the coast? I've been expecting word from there for weeks. Thank you so much, traveller — you've put my mind at ease.",
+      "steps": [
+        { "key": "deliver", "type": "deliver", "targetNpcId": "elder", "required": 1 }
+      ],
+      "reward": {
+        "crystals": 60,
+        "friendship": { "innkeeper-millhaven": 20 }
+      }
+    },
+    {
+      "id": "millhaven-festival-prep",
+      "title": "Festival Preparations",
+      "type": "chain",
+      "giverNpcId": "market-trader",
+      "receiverNpcId": "market-trader",
+      "offerDialogue": "Millhaven's harvest festival is in three days and I'm short on supplies. A ribbon from the inn, a candle from the mill, and a flower from the town square would complete the decoration. Help me gather them?",
+      "activeDialogue": {
+        "ribbon": "The decorative ribbon should be at the inn. They always have one around this time of year.",
+        "candle": "Good, one item found. The mill keeps a stock of candles — check near the entrance.",
+        "flower": "Almost there. There should be a fresh flower near the town square wells."
+      },
+      "completeDialogue": "All three! The festival stall is going to look wonderful. Here — take a festival ribbon as a memento of your visit to Millhaven.",
+      "steps": [
+        { "key": "ribbon",  "type": "collect", "pickupIds": ["festival-ribbon"],  "required": 1 },
+        { "key": "candle",  "type": "collect", "pickupIds": ["festival-candle"],  "required": 1, "chain": "festival-ribbon" },
+        { "key": "flower",  "type": "collect", "pickupIds": ["festival-flower"],  "required": 1, "chain": "festival-candle" }
+      ],
+      "reward": {
+        "crystals": 70,
+        "collectible": { "id": "festival-ribbon", "name": "Festival Ribbon", "icon": "🎀", "desc": "A bright ribbon from the Millhaven harvest festival." }
+      }
+    }
+  ],
+  "pickupItems": [
+    { "id": "grain-sack-1",     "tx": 2,  "ty": 9,  "tileId": "hayStack",   "questId": "millhaven-mill-grain" },
+    { "id": "grain-sack-2",     "tx": 25, "ty": 9,  "tileId": "hayStack",   "questId": "millhaven-mill-grain" },
+    { "id": "grain-sack-3",     "tx": 6,  "ty": 8,  "tileId": "hayStack",   "questId": "millhaven-mill-grain" },
+    { "id": "fish-basket-1",    "tx": 22, "ty": 8,  "tileId": "openCrate",  "questId": "millhaven-missing-catch" },
+    { "id": "fish-basket-2",    "tx": 26, "ty": 8,  "tileId": "openCrate",  "questId": "millhaven-missing-catch" },
+    { "id": "nautical-chart",   "tx": 8,  "ty": 11, "tileId": "smallSign",  "questId": "millhaven-lost-at-sea" },
+    { "id": "festival-ribbon",  "tx": 12, "ty": 5,  "tileId": "smallSign",  "questId": "millhaven-festival-prep", "building": "inn-millhaven" },
+    { "id": "festival-candle",  "tx": 1,  "ty": 7,  "tileId": "smallSign",  "questId": "millhaven-festival-prep", "chain": "festival-ribbon" },
+    { "id": "festival-flower",  "tx": 11, "ty": 13, "tileId": "whiteFlower","questId": "millhaven-festival-prep", "chain": "festival-candle" }
+  ],
+  "blockedPaths": []
+}

--- a/web/src/data/world/locationRegistry.ts
+++ b/web/src/data/world/locationRegistry.ts
@@ -1,0 +1,20 @@
+import type { HubLocationData } from '../hub/locationTypes'
+import type { HubQuestDef } from '../hub/questDefs'
+import { HUB_LOCATION_DATA } from '../hub/loader'
+import { HUB_QUEST_DEFS } from '../hub/questDefs'
+import { CASTLE_LOCATION_DATA, CASTLE_QUEST_DEFS } from '../castle/loader'
+import { TOWN2_LOCATION_DATA, TOWN2_QUEST_DEFS } from '../town2/loader'
+
+export interface LocationEntry {
+  locationData: HubLocationData
+  questDefs:    HubQuestDef[]
+}
+
+// Maps locationKey → data bundle.
+// To add a new location: create web/src/data/<key>/ with config.json + questDefs.json + loader.ts,
+// then add one entry here.
+export const LOCATION_REGISTRY: Record<string, LocationEntry> = {
+  'ravenwatch':    { locationData: HUB_LOCATION_DATA,    questDefs: HUB_QUEST_DEFS },
+  'ironhold-keep': { locationData: CASTLE_LOCATION_DATA, questDefs: CASTLE_QUEST_DEFS },
+  'millhaven':     { locationData: TOWN2_LOCATION_DATA,  questDefs: TOWN2_QUEST_DEFS },
+}

--- a/web/src/data/world/worldMapDef.ts
+++ b/web/src/data/world/worldMapDef.ts
@@ -1,0 +1,102 @@
+import { WORLD_DECOR } from '../tiles/worldTileIndex'
+
+export type WorldNodeType = 'town' | 'castle' | 'battle' | 'camp' | 'cave' | 'port'
+
+export interface WorldNodeDef {
+  id:              string
+  type:            WorldNodeType
+  name:            string
+  x:               number
+  y:               number
+  connections:     string[]
+  requiredClears?: string[]
+  locationKey?:    string
+  battleConfig?:   { actId: string; nodeId: string }
+  decorTiles:      number[]
+  decorOffsets?:   [number, number][]
+}
+
+// World map canvas: 700×520 px
+// Ravenwatch is at the bottom-centre; new nodes can be added anywhere.
+export const WORLD_MAP_NODES: WorldNodeDef[] = [
+  {
+    id:          'ravenwatch',
+    type:        'town',
+    name:        'Ravenwatch',
+    x:           350,
+    y:           450,
+    connections: ['forest-path', 'bridge-battle'],
+    locationKey: 'ravenwatch',
+    decorTiles:  [WORLD_DECOR.villageLeft, WORLD_DECOR.villageRight],
+    decorOffsets:[[-32, -16], [0, -16]],
+  },
+  {
+    id:            'forest-path',
+    type:          'battle',
+    name:          'Forest Path',
+    x:             210,
+    y:             360,
+    connections:   ['ironhold-keep'],
+    requiredClears:[], // available from start
+    battleConfig:  { actId: 'act1', nodeId: 'n1' },
+    decorTiles:    [WORLD_DECOR.groupOfTrees],
+  },
+  {
+    id:            'bridge-battle',
+    type:          'battle',
+    name:          'Bridge Battle',
+    x:             490,
+    y:             360,
+    connections:   ['ironhold-keep'],
+    requiredClears:[], // available from start
+    battleConfig:  { actId: 'act1', nodeId: 'n2' },
+    decorTiles:    [WORLD_DECOR.stoneBridgeHTop],
+  },
+  {
+    id:            'ironhold-keep',
+    type:          'castle',
+    name:          'Ironhold Keep',
+    x:             350,
+    y:             270,
+    connections:   ['thornwood-camp'],
+    requiredClears:['forest-path|bridge-battle'],
+    locationKey:   'ironhold-keep',
+    decorTiles:    [WORLD_DECOR.squareCastleTopLeft, WORLD_DECOR.squareCastleTopRight,
+                    WORLD_DECOR.squareCastleBottomLeft, WORLD_DECOR.squareCastleBottomRight],
+    decorOffsets:  [[-32, -32], [0, -32], [-32, 0], [0, 0]],
+  },
+  {
+    id:            'thornwood-camp',
+    type:          'camp',
+    name:          'Thornwood Camp',
+    x:             350,
+    y:             185,
+    connections:   ['river-battle'],
+    requiredClears:['ironhold-keep'],
+    decorTiles:    [WORLD_DECOR.singleTree, WORLD_DECOR.rock],
+    decorOffsets:  [[-20, -16], [8, -8]],
+  },
+  {
+    id:            'river-battle',
+    type:          'battle',
+    name:          'River Crossing',
+    x:             350,
+    y:             105,
+    connections:   ['millhaven'],
+    requiredClears:['thornwood-camp'],
+    battleConfig:  { actId: 'act2', nodeId: 'n1' },
+    decorTiles:    [WORLD_DECOR.woodenBridgeHTop],
+  },
+  {
+    id:            'millhaven',
+    type:          'town',
+    name:          'Millhaven',
+    x:             350,
+    y:             30,
+    connections:   [],
+    requiredClears:['river-battle'],
+    locationKey:   'millhaven',
+    decorTiles:    [WORLD_DECOR.walledTownLeft, WORLD_DECOR.walledTownRight],
+    decorOffsets:  [[-32, -16], [0, -16]],
+  },
+]

--- a/web/src/game/world/worldState.ts
+++ b/web/src/game/world/worldState.ts
@@ -1,0 +1,60 @@
+const KEY = 'jarv_world_state'
+
+interface StoredState {
+  currentLocationId: string
+  nodes: Record<string, { visited: boolean; cleared: boolean }>
+}
+
+function load(): StoredState {
+  try {
+    const raw = localStorage.getItem(KEY)
+    return raw ? JSON.parse(raw) : { currentLocationId: 'ravenwatch', nodes: {} }
+  } catch {
+    return { currentLocationId: 'ravenwatch', nodes: {} }
+  }
+}
+
+function save(state: StoredState): void {
+  try { localStorage.setItem(KEY, JSON.stringify(state)) } catch { /* ignore */ }
+}
+
+export function getCurrentWorldLocation(): string {
+  return load().currentLocationId
+}
+
+export function setCurrentWorldLocation(id: string): void {
+  const state = load()
+  state.currentLocationId = id
+  save(state)
+}
+
+export function setWorldNodeVisited(id: string): void {
+  const state = load()
+  state.nodes[id] = { ...state.nodes[id] ?? { cleared: false }, visited: true }
+  save(state)
+}
+
+export function markNodeCleared(id: string): void {
+  const state = load()
+  state.nodes[id] = { visited: true, cleared: true }
+  save(state)
+}
+
+export function isNodeCleared(id: string): boolean {
+  return load().nodes[id]?.cleared ?? false
+}
+
+export function isNodeVisited(id: string): boolean {
+  return load().nodes[id]?.visited ?? false
+}
+
+export function getAllClearedNodeIds(): string[] {
+  const state = load()
+  return Object.entries(state.nodes)
+    .filter(([, v]) => v.cleared)
+    .map(([k]) => k)
+}
+
+export function resetWorldState(): void {
+  localStorage.removeItem(KEY)
+}


### PR DESCRIPTION
## Summary

- **Ravenwatch** — hub town is now named; portcullis gate exit tiles (row 67) transition to the world map
- **World node map** — PIXI.js 700×520 canvas with farmland terrain, WORLD_DECOR sprites, animated pulsing ring on current location, path lines between nodes, click-to-travel info panel. 7 nodes: Ravenwatch → Forest Path / Bridge Battle → Ironhold Keep → Thornwood Camp → River Crossing → Millhaven. Node types include `cave` and `port` for future use.
- **Ironhold Keep** — castle location (22×20 tiles) with 3 buildings, 5 NPCs, 4 quests (including cross-location delivery back to Ravenwatch)
- **Millhaven** — coastal town (28×20 tiles) with 5 buildings, 6 NPCs, 6 quests (including cross-location deliveries to the castle and Ravenwatch)
- **Extensible architecture** — adding a new location only requires a `data/<key>/` directory + one entry in `LOCATION_REGISTRY` + one `WorldNodeDef` in `worldMapDef.ts`. No component code changes needed. `WorldNodeType` already includes `cave` and `port`.
- **Cross-location quests** — `HubLocationWorld` checks `allQuestDefs` (all registered locations) when handling NPC interactions, so deliver steps work regardless of which location defined the quest
- **`HubTownCanvas`** — now accepts optional `locationData` prop; per-location saved avatar position via `_savedTiles` Map
- **`QuestsModal`** — now accepts optional `questDefs` prop (backwards-compatible, defaults to hub quests)

## Test plan

- [ ] Walk avatar south through Ravenwatch portcullis gate → world map appears
- [ ] Toolbar shows "⚔ Ravenwatch" in hub
- [ ] Ravenwatch is highlighted with pulsing ring on world map
- [ ] Forest Path and Bridge Battle nodes are clickable; locked nodes (Ironhold Keep, etc.) show 🔒 and 40% alpha
- [ ] Click available node → info panel with "Travel ➤" button appears
- [ ] Click "Travel ➤" on Forest Path / Bridge Battle → campaign battle launches
- [ ] After clearing a battle node, Ironhold Keep becomes available
- [ ] Travel to Ironhold Keep → HubLocationWorld renders castle map, toolbar shows "⚔ Ironhold Keep"
- [ ] Talk to NPCs in castle, accept/complete quests, collect items
- [ ] Walk south to exit tiles at castle bottom → returns to world map
- [ ] Travel to Millhaven → same flow with fishing town layout
- [ ] Cross-location quest: accept "Supplies for Ironhold" in Millhaven → deliver to castle-commander in Ironhold Keep
- [ ] Back button on world map returns to Ravenwatch hub

https://claude.ai/code/session_01SrUwTS4spH6aiAti7nsTDo

---
_Generated by [Claude Code](https://claude.ai/code/session_01SrUwTS4spH6aiAti7nsTDo)_