### PR TITLE
World map: avatar walk, path tiles, NodeMap-style peek modal

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2632,10 +2632,11 @@ export default function App() {
       {screen === 'worldmap' && (
         <HubWorldMap
           onSelectNode={(node) => {
-            setCurrentWorldLocation(node.id)
             if (node.id === 'ravenwatch') {
+              setCurrentWorldLocation(node.id)
               setScreen('hubworld')
             } else if (node.locationKey && LOCATION_REGISTRY[node.locationKey]) {
+              setCurrentWorldLocation(node.id)
               setCurrentLocationKey(node.locationKey)
               setScreen('location')
             } else if (node.type === 'battle') {

--- a/web/src/components/hub/HubWorldMap.tsx
+++ b/web/src/components/hub/HubWorldMap.tsx
@@ -1,11 +1,15 @@
-import React, { useRef, useState, useEffect, useMemo } from 'react'
+import React, { useRef, useState, useMemo, useEffect } from 'react'
 import * as PIXI from 'pixi.js'
 import { usePixiApp } from '../../hooks/usePixiApp'
 import { WORLD_MAP_NODES, WorldNodeDef } from '../../data/world/worldMapDef'
 import { WORLD_DECOR_FILE, WORLD_ENV_TILES } from '../../data/tiles/worldTileIndex'
-import { loadTileTexture, makeClickable } from '../../utils/pixiHelpers'
-import { buildTerrainGfx, buildBorderGfx } from '../../utils/terrainLayer'
+import { TILE_SIZE } from '../../data/tiles/tileIndex'
+import { loadTileTexture, makeClickable, loadAnimFrames, loadSpriteTexture, tweenTo } from '../../utils/pixiHelpers'
+import { buildTerrainGfx, buildBorderGfx, buildBgTileGfx } from '../../utils/terrainLayer'
+import { renderPathTiles } from '../../utils/tileLookup'
 import { getCurrentWorldLocation, isNodeCleared } from '../../game/world/worldState'
+import { loadPlayerAvatar, loadPlayerName } from '../../game/questline'
+import { emitSound } from '../../game/sound'
 import { OverlayScreen } from '../ui/OverlayScreen'
 import { Toolbar } from '../ui/Toolbar/Toolbar'
 import { ToolbarButton } from '../ui/Toolbar/ToolbarButton'
@@ -21,12 +25,13 @@ import { HUB_QUEST_DEFS } from '../../data/hub/questDefs'
 import { unmarkPickedUp } from '../../game/hub/pickups'
 import { resetQuest } from '../../game/hub/quests'
 import { LoginButton } from '../ui/LoginButton'
-import { loadPlayerName } from '../../game/questline'
 import type { User } from 'firebase/auth'
 
-const MAP_W = 700
-const MAP_H = 520
+const MAP_W      = 700
+const MAP_H      = 520
 const DECOR_COLS = 8
+const AVATAR_SIZE   = 36
+const WALK_DURATION = 700
 
 function isNodeAvailable(node: WorldNodeDef): boolean {
   if (!node.requiredClears || node.requiredClears.length === 0) return true
@@ -34,6 +39,41 @@ function isNodeAvailable(node: WorldNodeDef): boolean {
     if (req.includes('|')) return req.split('|').some(id => isNodeCleared(id))
     return isNodeCleared(req)
   })
+}
+
+// Build L-shaped tile-grid paths between connected world nodes.
+async function buildWorldPathTiles(container: PIXI.Container): Promise<void> {
+  const T = TILE_SIZE
+  const pathSet = new Set<string>()
+  const key = (tx: number, ty: number) => `${tx},${ty}`
+  const seen = new Set<string>()
+
+  for (const node of WORLD_MAP_NODES) {
+    for (const connId of node.connections) {
+      const connKey = [node.id, connId].sort().join('|')
+      if (seen.has(connKey)) continue
+      seen.add(connKey)
+
+      const target = WORLD_MAP_NODES.find(n => n.id === connId)
+      if (!target) continue
+
+      const aTx = Math.floor(node.x   / T), aTy = Math.floor(node.y   / T)
+      const bTx = Math.floor(target.x / T), bTy = Math.floor(target.y / T)
+      const midTx = Math.floor((node.x + target.x) / 2 / T)
+
+      // Horizontal leg: node → midpoint column (at node's row)
+      for (let tx = Math.min(aTx, midTx); tx <= Math.max(aTx, midTx); tx++)
+        pathSet.add(key(tx, aTy))
+      // Vertical leg: midpoint column, node row → target row
+      for (let ty = Math.min(aTy, bTy); ty <= Math.max(aTy, bTy); ty++)
+        pathSet.add(key(midTx, ty))
+      // Horizontal leg: midpoint column → target node (at target's row)
+      for (let tx = Math.min(midTx, bTx); tx <= Math.max(midTx, bTx); tx++)
+        pathSet.add(key(tx, bTy))
+    }
+  }
+
+  await renderPathTiles(container, pathSet, 'farmland', undefined, undefined, WORLD_ENV_TILES.farmland)
 }
 
 interface Props {
@@ -47,15 +87,21 @@ interface Props {
 }
 
 export function HubWorldMap({ onSelectNode, onBack, user, onSignIn, onSignOut, onPlayerTap, onFeedback }: Props) {
-  const containerRef = useRef<HTMLDivElement>(null)
-  const deadRef      = useRef(false)
-  const [selected, setSelected]   = useState<WorldNodeDef | null>(null)
+  const containerRef  = useRef<HTMLDivElement>(null)
+  const deadRef       = useRef(false)
+  const appRef        = useRef<PIXI.Application | null>(null)
+  const avatarRef     = useRef<PIXI.AnimatedSprite | null>(null)
+  const isWalkingRef  = useRef(false)
+
+  const [peekNode, setPeekNode] = useState<WorldNodeDef | null>(null)
   const [questsOpen, setQuestsOpen] = useState(false)
   const [wrongSave, setWrongSave]   = useState<{ cards: number; crystals: number; deck: number } | null>(null)
+
   const currentLocation = getCurrentWorldLocation()
   const { isNight: isGameNight } = useHubClock()
   const playerName = loadPlayerName()
-  const crystals = loadCrystals()
+  const crystals   = loadCrystals()
+
   const { collectionCount, catalogTotal } = useMemo(() => {
     const catalog    = getCardCatalog()
     const collection = loadCollection()
@@ -63,15 +109,6 @@ export function HubWorldMap({ onSelectNode, onBack, user, onSignIn, onSignOut, o
       collectionCount: collection.filter(e => e.count > 0 && catalog.some(c => c.name === e.cardName)).length,
       catalogTotal: catalog.length,
     }
-  }, [])
-
-  useEffect(() => {
-    if (Math.random() > 0.02) return
-    const fake = { cards: Math.floor(Math.random() * catalogTotal), crystals: Math.floor(Math.random() * 9999), deck: Math.floor(Math.random() * 10) }
-    setWrongSave(fake)
-    const id = setTimeout(() => setWrongSave(null), 1800)
-    return () => clearTimeout(id)
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   const handleQuestAbandon = (questId: string) => {
@@ -83,36 +120,53 @@ export function HubWorldMap({ onSelectNode, onBack, user, onSignIn, onSignOut, o
 
   useEffect(() => () => { deadRef.current = true }, [])
 
+  useEffect(() => {
+    if (Math.random() > 0.02) return
+    const fake = { cards: Math.floor(Math.random() * catalogTotal), crystals: Math.floor(Math.random() * 9999), deck: Math.floor(Math.random() * 10) }
+    setWrongSave(fake)
+    const id = setTimeout(() => setWrongSave(null), 1800)
+    return () => clearTimeout(id)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  function handleWalk(node: WorldNodeDef) {
+    const app    = appRef.current
+    const avatar = avatarRef.current
+    if (!app || !avatar || isWalkingRef.current) return
+    isWalkingRef.current = true
+    avatar.play()
+    emitSound('mapFootstep')
+    tweenTo(avatar, node.x, node.y, WALK_DURATION, app).then(() => {
+      avatar.stop()
+      isWalkingRef.current = false
+      setPeekNode(node)
+    })
+  }
+
   usePixiApp(containerRef, MAP_W, MAP_H, async (app) => {
     deadRef.current = false
+    appRef.current  = app
 
-    // Layered ground
+    // Layers: base terrain → path tiles → node decor → avatar
     const baseContainer  = new PIXI.Container()
     const riverContainer = new PIXI.Container()
+    const bgContainer    = new PIXI.Container()
+    const pathContainer  = new PIXI.Container()
     const worldLayer     = new PIXI.Container()
-    app.stage.addChild(baseContainer, riverContainer, worldLayer)
+    app.stage.addChild(baseContainer, riverContainer, bgContainer, pathContainer, worldLayer)
 
     buildTerrainGfx(baseContainer, riverContainer, worldLayer,
       { environment: 'farmland', envDef: WORLD_ENV_TILES.farmland, terrainItems: [], rivers: [] },
       MAP_W, MAP_H)
     buildBorderGfx(worldLayer, { envDef: WORLD_ENV_TILES.farmland }, MAP_W, MAP_H)
 
-    // Connection lines
-    const pathGfx = new PIXI.Graphics()
-    worldLayer.addChild(pathGfx)
-    for (const node of WORLD_MAP_NODES) {
-      for (const connId of node.connections) {
-        const target = WORLD_MAP_NODES.find(n => n.id === connId)
-        if (!target) continue
-        const lit = isNodeAvailable(node) && isNodeAvailable(target)
-        pathGfx
-          .moveTo(node.x, node.y)
-          .lineTo(target.x, target.y)
-          .stroke({ color: lit ? 0xb08040 : 0x3a3a28, width: 6, alpha: lit ? 0.8 : 0.3 })
-      }
-    }
+    buildBgTileGfx(bgContainer, { environment: 'farmland', envDef: WORLD_ENV_TILES.farmland }, MAP_W, MAP_H)
+      .catch(e => console.error('[HubWorldMap] bg tiles failed', e))
 
-    const base = (import.meta as { env: { BASE_URL: string } }).env.BASE_URL
+    buildWorldPathTiles(pathContainer)
+      .catch(e => console.error('[HubWorldMap] path tiles failed', e))
+
+    const base     = (import.meta as { env: { BASE_URL: string } }).env.BASE_URL
     const decorUrl = `${base}${WORLD_DECOR_FILE.slice(1)}`
 
     for (const node of WORLD_MAP_NODES) {
@@ -160,7 +214,10 @@ export function HubWorldMap({ onSelectNode, onBack, user, onSignIn, onSignOut, o
       container.addChild(label)
 
       if (available || isCurrent) {
-        makeClickable(container, () => setSelected(node))
+        makeClickable(container, () => {
+          if (isWalkingRef.current) return
+          handleWalk(node)
+        })
       }
 
       worldLayer.addChild(container)
@@ -180,82 +237,119 @@ export function HubWorldMap({ onSelectNode, onBack, user, onSignIn, onSignOut, o
           .stroke({ color: 0x55ff55, width: 2, alpha: 0.4 + Math.sin(t) * 0.25 })
       })
     }
+
+    // Player avatar at current location
+    const avatarName = loadPlayerAvatar()
+    let avatarTextures: PIXI.Texture[]
+    try {
+      avatarTextures = await loadAnimFrames(avatarName, 3)
+    } catch {
+      try { avatarTextures = [await loadSpriteTexture(avatarName)] } catch { return }
+    }
+    if (deadRef.current) return
+
+    const avatar = new PIXI.AnimatedSprite(avatarTextures)
+    avatar.animationSpeed = 0.12
+    avatar.anchor.set(0.5, 1)
+    avatar.width = avatar.height = AVATAR_SIZE
+
+    const startNode = curNode ?? WORLD_MAP_NODES[0]
+    avatar.position.set(startNode.x, startNode.y)
+    avatar.stop()
+    worldLayer.addChild(avatar)
+    avatarRef.current = avatar
   })
 
-  const isCurrent = selected?.id === currentLocation
-  const canTravel = selected && isNodeAvailable(selected) && !isCurrent
+  const isCurrent = peekNode?.id === currentLocation
+  const isCleared = peekNode ? isNodeCleared(peekNode.id) : false
+  const canTravel  = peekNode && isNodeAvailable(peekNode) && !isCurrent
 
   return (
     <OverlayScreen title="🗺 World Map">
       <Toolbar>
-          <ToolbarLabel className={`title-deck-info${wrongSave ? ' title-deck-info--glitch' : ''}`}>💎 {wrongSave ? wrongSave.crystals.toLocaleString() : crystals.toLocaleString()}</ToolbarLabel>
-          <ToolbarLabel className={`title-deck-info${wrongSave ? ' title-deck-info--glitch' : ''}`}>🃏 {wrongSave ? wrongSave.cards : collectionCount}/{catalogTotal}</ToolbarLabel>
-          <ToolbarLabel className="title-deck-info">{isGameNight ? '🌙' : '☀️'} {formatGameTime()}</ToolbarLabel>
+        <ToolbarLabel className={`title-deck-info${wrongSave ? ' title-deck-info--glitch' : ''}`}>💎 {wrongSave ? wrongSave.crystals.toLocaleString() : crystals.toLocaleString()}</ToolbarLabel>
+        <ToolbarLabel className={`title-deck-info${wrongSave ? ' title-deck-info--glitch' : ''}`}>🃏 {wrongSave ? wrongSave.cards : collectionCount}/{catalogTotal}</ToolbarLabel>
+        <ToolbarLabel className="title-deck-info">{isGameNight ? '🌙' : '☀️'} {formatGameTime()}</ToolbarLabel>
         <ToolbarButton icon="📜" title="Quests" onClick={() => setQuestsOpen(true)} />
-        <ToolbarButton icon="🏠" title="Back to Town" onClick={onBack} />          
+        <ToolbarButton icon="🏠" title="Back to Town" onClick={onBack} />
         <ToolbarSpacer />
 
-
-
         <div className="toolbar-overflow-inline">
-                  <LoginButton onSignIn={() => onSignIn?.()} onSignOut={() => onSignOut?.()} onPlayerTap={onPlayerTap} user={user} playerName={playerName} />
-        <ToolbarButton
-          className="title-auth-btn"
-          onClick={onFeedback}
-          title="Send feedback or report a bug"
-          icon={'🗣️'}
-        />
-        <ToolbarButton className="action-btn hub-hud__btn" onClick={onBack} icon={'⚙'}/>
+          <LoginButton onSignIn={() => onSignIn?.()} onSignOut={() => onSignOut?.()} onPlayerTap={onPlayerTap} user={user} playerName={playerName} />
+          <ToolbarButton
+            className="title-auth-btn"
+            onClick={onFeedback}
+            title="Send feedback or report a bug"
+            icon={'🗣️'}
+          />
+          <ToolbarButton className="action-btn hub-hud__btn" onClick={onBack} icon={'⚙'}/>
         </div>
         <div className="toolbar-overflow-dropdown">
           <ToolbarDropdown label="📊" align="right">
-        <LoginButton onSignIn={() => onSignIn?.()} onSignOut={() => onSignOut?.()} onPlayerTap={onPlayerTap} user={user} playerName={playerName} />
-        <ToolbarButton
-          className="title-auth-btn"
-          onClick={onFeedback}
-          title="Send feedback or report a bug"
-          icon={'🗣️'}
-        />
-        <ToolbarButton className="action-btn hub-hud__btn" onClick={onBack} icon={'⚙'}/>          </ToolbarDropdown>
+            <LoginButton onSignIn={() => onSignIn?.()} onSignOut={() => onSignOut?.()} onPlayerTap={onPlayerTap} user={user} playerName={playerName} />
+            <ToolbarButton
+              className="title-auth-btn"
+              onClick={onFeedback}
+              title="Send feedback or report a bug"
+              icon={'🗣️'}
+            />
+            <ToolbarButton className="action-btn hub-hud__btn" onClick={onBack} icon={'⚙'}/>
+          </ToolbarDropdown>
         </div>
-
       </Toolbar>
+
       {questsOpen && <QuestsModal onClose={() => setQuestsOpen(false)} onAbandon={handleQuestAbandon} />}
+
       <div style={{ flex: 1, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', overflow: 'hidden' }}>
         <div ref={containerRef} style={{ cursor: 'crosshair' }} />
-        {selected && (
-          <div className="nm-peek-backdrop" onClick={() => setSelected(null)}>
+
+        {peekNode && (
+          <div className="nm-peek-backdrop" onClick={() => setPeekNode(null)}>
             <div className="nm-peek-panel" onClick={e => e.stopPropagation()}>
               <div className="nm-peek-header u-col u-items-c u-gap-1">
-                <span className={`nm-peek-type nm-node-type-badge--${selected.type}`}>
-                  {selected.type.toUpperCase()}
+                <span className={`nm-peek-type nm-node-type-badge--${peekNode.type}`}>
+                  {peekNode.type.toUpperCase()}
                 </span>
               </div>
               <div style={{ fontWeight: 'bold', margin: '6px 0 2px', textAlign: 'center' }}>
-                {selected.name}
+                {peekNode.name}
               </div>
               {isCurrent && (
                 <div style={{ color: '#88ee88', fontSize: 12, textAlign: 'center', marginTop: 4 }}>
                   Current location
                 </div>
               )}
-              {!isCurrent && !canTravel && (
+              {peekNode.type === 'battle' && isCleared && (
+                <div style={{ color: '#aaaaaa', fontSize: 12, textAlign: 'center', marginTop: 4 }}>
+                  ✓ Cleared
+                </div>
+              )}
+              {!isCurrent && !canTravel && !isCleared && (
                 <div style={{ color: '#888', fontSize: 12, textAlign: 'center', marginTop: 4 }}>
                   🔒 Not yet accessible
                 </div>
               )}
-              {canTravel && (
+              {canTravel && peekNode.type === 'battle' && !isCleared && (
                 <button
                   className="action-btn"
                   style={{ marginTop: 8, display: 'block', width: '100%' }}
-                  onClick={() => { setSelected(null); onSelectNode(selected) }}
+                  onClick={() => { setPeekNode(null); onSelectNode(peekNode) }}
+                >
+                  Enter Battle ⚔
+                </button>
+              )}
+              {canTravel && peekNode.type !== 'battle' && (
+                <button
+                  className="action-btn"
+                  style={{ marginTop: 8, display: 'block', width: '100%' }}
+                  onClick={() => { setPeekNode(null); onSelectNode(peekNode) }}
                 >
                   Travel ➤
                 </button>
               )}
               <button
                 style={{ marginTop: 6, background: 'transparent', border: '1px solid #555', color: '#aaa', cursor: 'pointer', padding: '2px 10px', fontSize: 12, width: '100%' }}
-                onClick={() => setSelected(null)}
+                onClick={() => setPeekNode(null)}
               >
                 Close
               </button>

--- a/web/src/data/world/worldMapDef.ts
+++ b/web/src/data/world/worldMapDef.ts
@@ -38,7 +38,7 @@ export const WORLD_MAP_NODES: WorldNodeDef[] = [
     y:             360,
     connections:   ['ironhold-keep'],
     requiredClears:[], // available from start
-    battleConfig:  { actId: 'act1', nodeId: 'n1' },
+    battleConfig:  { actId: 'act1', nodeId: 'goblin-raid' },
     decorTiles:    [WORLD_DECOR.groupOfTrees],
   },
   {
@@ -49,7 +49,7 @@ export const WORLD_MAP_NODES: WorldNodeDef[] = [
     y:             360,
     connections:   ['ironhold-keep'],
     requiredClears:[], // available from start
-    battleConfig:  { actId: 'act1', nodeId: 'n2' },
+    battleConfig:  { actId: 'act1', nodeId: 'shrine' },
     decorTiles:    [WORLD_DECOR.stoneBridgeHTop],
   },
   {
@@ -84,7 +84,7 @@ export const WORLD_MAP_NODES: WorldNodeDef[] = [
     y:             105,
     connections:   ['millhaven'],
     requiredClears:['thornwood-camp'],
-    battleConfig:  { actId: 'act2', nodeId: 'n1' },
+    battleConfig:  { actId: 'act2', nodeId: 'iron-gate' },
     decorTiles:    [WORLD_DECOR.woodenBridgeHTop],
   },
   {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Avatar walk**: Player sprite spawns at the current world location and walks to any clicked node via `tweenTo` + animated frames, matching the `NodeMap.tsx` pattern. Peek modal only opens after the walk animation completes.
- **Path tiles**: Replaced plain line graphics with L-shaped tile-grid paths rendered by `buildWorldPathTiles` + `renderPathTiles('farmland')`, plus a `buildBgTileGfx` ground layer for proper farmland tile coverage.
- **Peek modal improvements**: Battle nodes show "Enter Battle ⚔" button; town/castle nodes show "Travel ➤"; cleared battle nodes show "✓ Cleared" with no action button.
- **Bug fixes (from earlier commits)**: Fixed `battleConfig` node IDs in `worldMapDef.ts` (`n1`/`n2` → real IDs `goblin-raid`, `shrine`, `iron-gate`); fixed `setCurrentWorldLocation` being called unconditionally for all node types including battles.

## Test plan

- [ ] Open world map → avatar appears at Ravenwatch
- [ ] Click Forest Path → avatar walks to it, peek modal appears with "Enter Battle ⚔"
- [ ] Click Enter Battle → battle launches (Goblin Raiders)
- [ ] Win battle → returns to world map; Forest Path shows "✓ Cleared" in peek
- [ ] Clearing both Forest Path and Bridge Battle → Ironhold Keep becomes available
- [ ] Click Ironhold Keep → avatar walks, peek shows "Travel ➤"
- [ ] Path tiles render as farmland dirt paths between all connected nodes
- [ ] Pulsing ring stays on Ravenwatch during all battle node interactions

https://claude.ai/code/session_01SrUwTS4spH6aiAti7nsTDo
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SrUwTS4spH6aiAti7nsTDo)_