### PR TITLE
fix(worldmap): fix double-tap Enter Battle and node-unlock bugs

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -400,6 +400,7 @@ export default function App() {
   const runRef                          = useRef<RunState | null>(_startup.run)
   const [rewardChoices,  setRewardChoices]  = useState<string[]>([])
   const [rewardCrystals, setRewardCrystals] = useState(0)
+  const [worldMapKey,    setWorldMapKey]    = useState(0)
   const isCampaignRef       = useRef(_startup.isCampaign)   // true while playing a campaign battle
   const isDailyChallengeRef = useRef(false)                  // true while playing the daily challenge
   const isTrainingModeRef   = useRef(false)                  // true while playing a training battle
@@ -1061,7 +1062,7 @@ export default function App() {
     battleAllLegendaryRef.current = playerCards.length > 0 && playerCards.every(c => c.rarity === 'legendary')
     const state = newGame({ playerCards, ...resolvedNodeOpts(node, act, loadRunCount(), []) })
     startBattle(state)
-    rollRareEvent()
+    if (isCampaignRef.current) rollRareEvent()
   }, [startBattle, rollRareEvent])
 
   const handleSelectNode = useCallback((node: QuestNode) => {
@@ -2438,6 +2439,7 @@ export default function App() {
       if (gameState.phase.winner === 'player') markNodeCleared(nodeId)
       clearBattleState()
       dispatch({ type: 'END' })
+      setWorldMapKey(k => k + 1)
       setScreen('worldmap')
       return
     }
@@ -2631,6 +2633,7 @@ export default function App() {
 
       {screen === 'worldmap' && (
         <HubWorldMap
+          key={worldMapKey}
           onSelectNode={(node) => {
             if (node.id === 'ravenwatch') {
               setCurrentWorldLocation(node.id)

--- a/web/src/components/hub/HubWorldMap.tsx
+++ b/web/src/components/hub/HubWorldMap.tsx
@@ -92,6 +92,7 @@ export function HubWorldMap({ onSelectNode, onBack, user, onSignIn, onSignOut, o
   const appRef        = useRef<PIXI.Application | null>(null)
   const avatarRef     = useRef<PIXI.AnimatedSprite | null>(null)
   const isWalkingRef  = useRef(false)
+  const peekNodeRef   = useRef<WorldNodeDef | null>(null)
 
   const [peekNode, setPeekNode] = useState<WorldNodeDef | null>(null)
   const [questsOpen, setQuestsOpen] = useState(false)
@@ -132,13 +133,14 @@ export function HubWorldMap({ onSelectNode, onBack, user, onSignIn, onSignOut, o
   function handleWalk(node: WorldNodeDef) {
     const app    = appRef.current
     const avatar = avatarRef.current
-    if (!app || !avatar || isWalkingRef.current) return
+    if (!app || !avatar || isWalkingRef.current || peekNodeRef.current) return
     isWalkingRef.current = true
     avatar.play()
     emitSound('mapFootstep')
     tweenTo(avatar, node.x, node.y, WALK_DURATION, app).then(() => {
       avatar.stop()
       isWalkingRef.current = false
+      peekNodeRef.current = node
       setPeekNode(node)
     })
   }
@@ -304,8 +306,8 @@ export function HubWorldMap({ onSelectNode, onBack, user, onSignIn, onSignOut, o
         <div ref={containerRef} style={{ cursor: 'crosshair' }} />
 
         {peekNode && (
-          <div className="nm-peek-backdrop" onClick={() => setPeekNode(null)}>
-            <div className="nm-peek-panel" onClick={e => e.stopPropagation()}>
+          <div className="nm-peek-backdrop" onClick={() => { peekNodeRef.current = null; setPeekNode(null) }}>
+            <div className="nm-peek-panel" onClick={e => e.stopPropagation()} onPointerDown={e => e.stopPropagation()}>
               <div className="nm-peek-header u-col u-items-c u-gap-1">
                 <span className={`nm-peek-type nm-node-type-badge--${peekNode.type}`}>
                   {peekNode.type.toUpperCase()}
@@ -333,7 +335,7 @@ export function HubWorldMap({ onSelectNode, onBack, user, onSignIn, onSignOut, o
                 <button
                   className="action-btn"
                   style={{ marginTop: 8, display: 'block', width: '100%' }}
-                  onClick={() => { setPeekNode(null); onSelectNode(peekNode) }}
+                  onClick={() => { peekNodeRef.current = null; setPeekNode(null); onSelectNode(peekNode) }}
                 >
                   Enter Battle ⚔
                 </button>
@@ -342,14 +344,14 @@ export function HubWorldMap({ onSelectNode, onBack, user, onSignIn, onSignOut, o
                 <button
                   className="action-btn"
                   style={{ marginTop: 8, display: 'block', width: '100%' }}
-                  onClick={() => { setPeekNode(null); onSelectNode(peekNode) }}
+                  onClick={() => { peekNodeRef.current = null; setPeekNode(null); onSelectNode(peekNode) }}
                 >
                   Travel ➤
                 </button>
               )}
               <button
                 style={{ marginTop: 6, background: 'transparent', border: '1px solid #555', color: '#aaa', cursor: 'pointer', padding: '2px 10px', fontSize: 12, width: '100%' }}
-                onClick={() => setPeekNode(null)}
+                onClick={() => { peekNodeRef.current = null; setPeekNode(null) }}
               >
                 Close
               </button>


### PR DESCRIPTION
## Summary

- **Double-tap bug**: First tap on "Enter Battle" did nothing; second tap launched the battle. Root cause: `rollRareEvent()` was called unconditionally in `handleWorldBattle` even for world battles — if a hub rare event was overdue it fired on the first frame and hijacked the screen. Also, `nm-peek-panel` only blocked `click` propagation, not `pointerdown`, so PIXI's `makeClickable` (which uses `pointerdown`) could fire again through the modal.
- **Node unlock bug**: After winning, the next node stayed locked. Root cause: the world map component read node state at mount time, so `markNodeCleared` written to localStorage after the battle wasn't picked up. Forcing a remount via `key={worldMapKey}` after every world battle ensures fresh reads.

## Changes

- `App.tsx`: Guard `rollRareEvent()` — only call for campaign battles (`if (isCampaignRef.current) rollRareEvent()`)
- `App.tsx`: Add `worldMapKey` state; increment it in `handleGameOverPrimary`'s world-battle block before `setScreen('worldmap')`; pass `key={worldMapKey}` to `<HubWorldMap>` to force remount
- `HubWorldMap.tsx`: Add `peekNodeRef` guard in `handleWalk` — blocks re-triggering walk while peek modal is open
- `HubWorldMap.tsx`: Add `onPointerDown={e => e.stopPropagation()}` to `nm-peek-panel` — prevents PIXI canvas receiving `pointerdown` events through the modal overlay

## Test plan

- [ ] Walk to a battle node, tap "Enter Battle" once → battle launches immediately (no double-tap needed)
- [ ] Win the battle → world map reopens → next node (e.g. Ironhold Keep) is now available/unlocked
- [ ] Pulsing ring stays on Ravenwatch throughout battle nodes (current location unchanged)
- [ ] Clicking backdrop or Close button dismisses the peek panel correctly

https://claude.ai/code/session_01SrUwTS4spH6aiAti7nsTDo

---
_Generated by [Claude Code](https://claude.ai/code/session_01SrUwTS4spH6aiAti7nsTDo)_