### PR TITLE
fix: SyntaxError Unexpected token ? — replace ES2021 ??= with ES2020 code

### DIFF
--- a/web/src/data/castle/loader.ts
+++ b/web/src/data/castle/loader.ts
@@ -174,7 +174,8 @@ const INTERIOR_NPCS: Record<string, HubNpc[]> = HUB_NPCS
   .filter(n => !!n.building)
   .reduce<Record<string, HubNpc[]>>((acc, n) => {
     const key = n.building!
-    ;(acc[key] ??= []).push(n)
+    if (!acc[key]) acc[key] = []
+    acc[key].push(n)
     return acc
   }, {})
 

--- a/web/src/data/hub/loader.ts
+++ b/web/src/data/hub/loader.ts
@@ -313,7 +313,8 @@ export const INTERIOR_NPCS: Record<string, HubNpc[]> = HUB_NPCS
   .filter(n => !!n.building)
   .reduce<Record<string, HubNpc[]>>((acc, n) => {
     const key = n.building!
-    ;(acc[key] ??= []).push(n)
+    if (!acc[key]) acc[key] = []
+    acc[key].push(n)
     return acc
   }, {})
 

--- a/web/src/data/town2/loader.ts
+++ b/web/src/data/town2/loader.ts
@@ -174,7 +174,8 @@ const INTERIOR_NPCS: Record<string, HubNpc[]> = HUB_NPCS
   .filter(n => !!n.building)
   .reduce<Record<string, HubNpc[]>>((acc, n) => {
     const key = n.building!
-    ;(acc[key] ??= []).push(n)
+    if (!acc[key]) acc[key] = []
+    acc[key].push(n)
     return acc
   }, {})
 

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -62,6 +62,7 @@ export default defineConfig({
   })],
   base: '/',
   build: {
+    target: 'es2020',
     sourcemap: true,
     rollupOptions: {
       output: {


### PR DESCRIPTION
## Summary

- **Root cause:** Three `loader.ts` files used `??=` (nullish coalescing assignment, ES2021), but the project declares `target: "ES2020"` in `tsconfig.json` and had no explicit `build.target` in `vite.config.ts`. Without an explicit target, Vite's esbuild defaulted to the `'modules'` browser set, which includes `firefox78` — a browser that does *not* support `??=` (added in Firefox 79). This left the operator untranspiled in the output bundle, causing `SyntaxError: Unexpected token ?` in affected browsers and service-worker contexts.
- **Fix 1:** Add `build.target: 'es2020'` to `vite.config.ts` so the target is explicit and any ES2021+ syntax is always transpiled down, regardless of future Vite default changes.
- **Fix 2:** Replace `(acc[key] ??= []).push(n)` with an explicit if-guard + push in all three loader files, eliminating the ES2021 syntax entirely and aligning with the ES2020 target.

## Files changed

| File | Change |
|---|---|
| `web/vite.config.ts` | Added `build.target: 'es2020'` |
| `web/src/data/hub/loader.ts` | Replaced `??=` with ES2020 equivalent |
| `web/src/data/castle/loader.ts` | Replaced `??=` with ES2020 equivalent |
| `web/src/data/town2/loader.ts` | Replaced `??=` with ES2020 equivalent |

## Test plan

- [ ] `npm run build` passes cleanly (verified locally)
- [ ] Confirm no `??=` or other ES2021+ syntax remains in source: `grep -r '??=' web/src`
- [ ] Deploy to staging and confirm the Rollbar error no longer recurs

https://claude.ai/code/session_23a1231ac20980e8a64d2c48d0288801

---
_Generated by [Claude Code](https://claude.ai/code/session_017rCAf52wrXiuxBngWSJjke)_