### PR TITLE
fix(worldmap): launch battle on first tap & unlock nodes on win

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1076,6 +1076,16 @@ export default function App() {
     if (isCampaignRef.current) rollRareEvent()
   }, [startBattle, rollRareEvent])
 
+  // Re-run the current world-map battle after a loss ("Try Again").
+  const handleWorldBattleRetry = useCallback(() => {
+    const nodeId = worldBattleNodeIdRef.current
+    const worldNode = nodeId ? WORLD_MAP_NODES.find(n => n.id === nodeId) : undefined
+    if (!worldNode) { handleMainMenu(); return }
+    dispatch({ type: 'END' })
+    handleWorldBattle(worldNode)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [handleWorldBattle])
+
   const handleSelectNode = useCallback((node: QuestNode) => {
     const currentRun = run
     if (!currentRun) return
@@ -2367,9 +2377,15 @@ export default function App() {
 
   const handleMainMenu = useCallback(() => {
     if (worldBattleNodeIdRef.current !== null) {
+      const nodeId = worldBattleNodeIdRef.current
       worldBattleNodeIdRef.current = null
+      if (gameState?.phase.type === 'gameOver' && gameState.phase.winner === 'player') {
+        markNodeCleared(nodeId)
+        setCurrentWorldLocation(nodeId)
+      }
       clearBattleState()
       dispatch({ type: 'END' })
+      setWorldMapKey(k => k + 1)
       setScreen('worldmap')
       return
     }
@@ -2660,8 +2676,11 @@ export default function App() {
             }
           }}
           onBack={() => setScreen('hubworld')}
-                    user={user}
-                    
+          user={user}
+          onSignIn={() => setShowTitleLoginModal(true)}
+          onSignOut={() => { import('firebase/auth').then(({ signOut }) => signOut(auth)) }}
+          onPlayerTap={() => { setReturnScreen('hubworld'); setScreen('player') }}
+          onFeedback={() => setFeedbackOpen(true)}
         />
       )}
 
@@ -3232,19 +3251,22 @@ export default function App() {
             state={gameState}
             winner={gameState.phase.winner}
             handicap={handicap}
-            onOpenPack={!isCampaignRef.current && gameState.phase.winner === 'player' ? handleOpenPack : undefined}
+            onOpenPack={!isCampaignRef.current && worldBattleNodeIdRef.current === null && gameState.phase.winner === 'player' ? handleOpenPack : undefined}
             rewardClaimed={quickPlayRewardClaimed}
-            onPlayAgain={isCampaignRef.current
-              ? (gameState.phase.winner === 'player' ? handleCampaignWin : handleCampaignRetry)
-              : isDailyChallengeRef.current
-                ? handleDailyChallengeRetry
-                : handlePlayAgain
+            onPlayAgain={worldBattleNodeIdRef.current !== null
+              ? handleWorldBattleRetry
+              : isCampaignRef.current
+                ? (gameState.phase.winner === 'player' ? handleCampaignWin : handleCampaignRetry)
+                : isDailyChallengeRef.current
+                  ? handleDailyChallengeRetry
+                  : handlePlayAgain
             }
             onMainMenu={handleMainMenu}
             campaignAbandon={isCampaignRef.current ? handleAbandonRun : undefined}
             quickPlayHint={quickPlayHint}
-            showStreak={!isCampaignRef.current && !isDailyChallengeRef.current}
+            showStreak={!isCampaignRef.current && worldBattleNodeIdRef.current === null && !isDailyChallengeRef.current}
             dailyChallengeState={isDailyChallengeRef.current ? dcGameOverState : undefined}
+            worldBattle={worldBattleNodeIdRef.current !== null}
           />
         ) : (
           <>

--- a/web/src/components/battle/GameOver.tsx
+++ b/web/src/components/battle/GameOver.tsx
@@ -30,6 +30,8 @@ interface Props {
   showStreak?: boolean
   /** If set, show daily challenge result banner. */
   dailyChallengeState?: DailyChallengeState
+  /** World-map battle: show a single "Return to Map" action instead of the play-again flow. */
+  worldBattle?: boolean
 }
 
 const VICTORY_ART = `   \\o/
@@ -53,7 +55,7 @@ const DRAW_ART = `  =====
   =====
   DRAW!`
 
-export function GameOver({ state, winner, handicap, onOpenPack, rewardClaimed, onPlayAgain, onMainMenu, campaignAbandon, quickPlayHint, showStreak, dailyChallengeState }: Props) {
+export function GameOver({ state, winner, handicap, onOpenPack, rewardClaimed, onPlayAgain, onMainMenu, campaignAbandon, quickPlayHint, showStreak, dailyChallengeState, worldBattle }: Props) {
   const won  = winner === 'player'
   const draw = winner === 'draw'
   const isEndlessDefeat = !!state.endlessMode && !won && !draw
@@ -157,7 +159,7 @@ export function GameOver({ state, winner, handicap, onOpenPack, rewardClaimed, o
           )}
         </div>
       )}
-      {handicapNote && !dailyChallengeState && <div className="gameover-handicap">{handicapNote}</div>}
+      {handicapNote && !dailyChallengeState && !worldBattle && <div className="gameover-handicap">{handicapNote}</div>}
 
       {dailyChallengeState && (
         <div className={`gameover-daily ${winner === 'player' ? 'gameover-daily--win' : 'gameover-daily--lose'}`}>
@@ -186,7 +188,16 @@ export function GameOver({ state, winner, handicap, onOpenPack, rewardClaimed, o
       )}
 
       <div className="gameover-actions u-col u-items-c u-gap-5">
-        {won && onOpenPack ? (
+        {worldBattle ? (
+          <>
+            {!won && (
+              <button className="action-btn" onClick={onPlayAgain}>[ Try Again ]</button>
+            )}
+            <button className="action-btn" onClick={onMainMenu}>
+              {won ? '[ Return to Map ]' : '[ Back to Map ]'}
+            </button>
+          </>
+        ) : won && onOpenPack ? (
           rewardClaimed ? (
             <>
               <button className="action-btn" onClick={onPlayAgain}>[ Play Again ]</button>

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -18,7 +18,6 @@ import { getCardCatalog } from '../../game/cards'
 import { CommanderState } from '../../game/commander'
 import { loadSkipIntro } from '../screens/SettingsScreen'
 import { getSavedHubTile } from './HubTownCanvas'
-import { HubWorldMap } from './HubWorldMap'
 import { Toolbar } from '../ui/Toolbar/Toolbar'
 import { ToolbarLabel } from '../ui/Toolbar/ToolbarLabel'
 import { ToolbarButton } from '../ui/Toolbar/ToolbarButton'
@@ -106,7 +105,6 @@ interface Props {
 export function HubWorld({ onBack, onNavigate, onCampaign, onEndless, onWorldMap, onPlayerTap, crystals = 0, isSignedIn = false, commander, user, onSignIn: onLoginToggle, onSignOut, onFeedback, onCrystalsChange, onTileTap }: Props) {
   const [splashVisible, setSplashVisible] = useState(() => !_hubSplashShown && !loadSkipIntro())
   const [splashFading,  setSplashFading]  = useState(false)
-  const [worldMapOpen,  setWorldMapOpen]  = useState(false)
   const [currentArea,    setCurrentArea]    = useState<string | null>(null)
   const [dialogueLine,   setDialogueLine]   = useState<string | null>(null)
   const [dialogueEvent,  setDialogueEvent]  = useState<QuestEvent | null>(null)
@@ -266,7 +264,7 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onEndless, onWorldMap
       interiorEnterRef.current?.(buildingId)
       return
     }
-    if (screen === 'worldmap') { setWorldMapOpen(true); return }
+    if (screen === 'worldmap') { onWorldMap?.(); return }
     if (screen === 'campaign') { onCampaign?.(); return }
     if (screen === 'endless') { onEndless?.(); return }
     if (screen === 'commander' && !commander) {
@@ -514,20 +512,6 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onEndless, onWorldMap
     setDialogueEvent({ speakerName, text: line })
   }, [refreshState, handleNodeInteract])
 
-  if (worldMapOpen) {
-    return (
-      <HubWorldMap
-        onBack={() => setWorldMapOpen(false)}
-        onSelectNode={(node) => { setWorldMapOpen(false); onWorldMap?.() }}
-        user={user}
-        onSignIn={onLoginToggle}
-        onSignOut={onSignOut}
-        onPlayerTap={onPlayerTap}
-        onFeedback={onFeedback}
-      />
-    )
-  }
-
   return (
     <OverlayScreen title={`🏠 ${HUB_TOWN_NAME}`}>
       <Toolbar>
@@ -535,7 +519,7 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onEndless, onWorldMap
           <ToolbarLabel className={`title-deck-info${wrongSave ? ' title-deck-info--glitch' : ''}`}>🃏 {wrongSave ? wrongSave.cards : collectionCount}/{catalogTotal}</ToolbarLabel>
           <ToolbarLabel className="title-deck-info">{isGameNight ? '🌙' : '☀️'} {formatGameTime()}</ToolbarLabel>
         <ToolbarButton icon="📜" title="Quests" onClick={() => setQuestsOpen(true)} />
-        <ToolbarButton icon="🗺" title="World Map" onClick={() => setWorldMapOpen(true)} />
+        <ToolbarButton icon="🗺" title="World Map" onClick={() => onWorldMap?.()} />
 
         <ToolbarSpacer/>
         <div className="toolbar-overflow-inline">


### PR DESCRIPTION
## Problem

Three issues with world-map battle nodes:

1. **Needed two taps to enter a battle.** Tapping **Enter Battle** closed the peek modal, the avatar snapped back to the previous node, and only a second attempt launched the fight.
2. **Winning didn't unlock the next node(s).** Returning to the map after a victory left the chain locked.
3. **"Play Again" was offered even on a win.** After winning you got the free-play reward/play-again flow instead of returning to the map.

## Root causes

- **`HubWorld.tsx` rendered its own embedded copy of `HubWorldMap`** whose `onSelectNode` just did `setWorldMapOpen(false); onWorldMap()` — i.e. it navigated to the *real* world-map screen instead of starting the battle. So the first tap threw the selection away and re-mounted a fresh map (avatar reset); only the second tap, now on the App-level map with real battle logic, started the fight.
- A world battle isn't a campaign battle, so it fell through to the **free-play `GameOver` flow** (claim-pack → Play Again / I'm Done). Only `handlePlayAgain` marked the node cleared and re-mounted the map; the `I'm Done` (`handleMainMenu`) path returned **without** clearing, so nodes never unlocked.

## Changes

- **`HubWorld.tsx`** — removed the embedded duplicate map; the hub's 🗺 World Map button (and the `worldmap` tile interaction) now go straight to the real worldmap screen via `onWorldMap`.
- **`GameOver.tsx`** — added a `worldBattle` prop; in that mode it shows a single **`[ Return to Map ]`** action on a win (and **`[ Try Again ]`** + **`[ Back to Map ]`** on a loss), with the free-play pack / play-again / handicap note suppressed.
- **`App.tsx`** — passes `worldBattle`, disables the free-play pack/streak for world battles, marks the node cleared + advances the avatar's current location + remounts the map on a win (so the next node(s) unlock), adds a `Try Again` retry handler, and wires the login/feedback toolbar callbacks on the world-map screen.

## Testing

- `npm run build` passes (tsc + Vite).
- `npm test` — all 58 unit tests pass.

https://claude.ai/code/session_01YJ7bevy2PbbTt5ZUtboFLw

---
_Generated by [Claude Code](https://claude.ai/code/session_01YJ7bevy2PbbTt5ZUtboFLw)_