### PR TITLE
feat(hubworld): tile bundles — bundleID for decor and building definitions

### DIFF
--- a/web/src/data/bundles/bundleLoader.ts
+++ b/web/src/data/bundles/bundleLoader.ts
@@ -1,0 +1,85 @@
+import rawBundles from './bundles.json'
+import { BASE_CHIP_TILES } from '../tiles/baseChipIndex'
+
+export type BundleTileType = 'decor' | 'window' | 'door'
+
+export interface BundleTileEntry {
+  type:        BundleTileType
+  tileId:      number          // resolved at load time; 0 for door entries
+  x:           number
+  y:           number
+  zlayer?:     string
+  buildingId?: string          // for type="door" entries
+}
+
+export interface BundleDef {
+  bundleID: string
+  tiles:    BundleTileEntry[]
+}
+
+function resolveTileId(key: string): number {
+  return (BASE_CHIP_TILES as Record<string, number>)[key] ?? 666
+}
+
+const BUNDLE_REGISTRY = new Map<string, BundleDef>()
+
+for (const raw of rawBundles as Array<Record<string, unknown>>) {
+  const id = raw['bundleID'] as string | undefined
+  if (!id || !Array.isArray(raw['tiles'])) {
+    console.warn('[bundles] Skipping malformed bundle:', raw)
+    continue
+  }
+  const tiles: BundleTileEntry[] = (raw['tiles'] as Array<Record<string, unknown>>).map(t => ({
+    type:       (t['type'] as BundleTileType | undefined) ?? 'decor',
+    tileId:     t['tileID'] ? resolveTileId(t['tileID'] as string) : 0,
+    x:          (t['x'] as number) ?? 0,
+    y:          (t['y'] as number) ?? 0,
+    zlayer:     t['zlayer'] as string | undefined,
+    buildingId: t['buildingId'] as string | undefined,
+  }))
+  BUNDLE_REGISTRY.set(id, { bundleID: id, tiles })
+}
+
+export function getBundleById(id: string): BundleDef | undefined {
+  return BUNDLE_REGISTRY.get(id)
+}
+
+/** Expand decor tiles from a bundle at the given bottom-left origin. */
+export function expandBundleDecor(
+  bundleID: string,
+  originTx: number,
+  originTy: number,
+): { tx: number; ty: number; tileId: number; zlayer?: string }[] {
+  const bundle = BUNDLE_REGISTRY.get(bundleID)
+  if (!bundle) { console.warn(`[bundles] Unknown bundleID: "${bundleID}"`); return [] }
+  return bundle.tiles
+    .filter(t => t.type === 'decor')
+    .map(t => ({ tx: originTx + t.x, ty: originTy - t.y, tileId: t.tileId, zlayer: t.zlayer }))
+}
+
+/** Expand window tiles from a bundle at the given bottom-left origin. */
+export function expandBundleWindows(
+  bundleID: string,
+  originTx: number,
+  originTy: number,
+): { tx: number; ty: number; tileId: number }[] {
+  const bundle = BUNDLE_REGISTRY.get(bundleID)
+  if (!bundle) { console.warn(`[bundles] Unknown bundleID: "${bundleID}"`); return [] }
+  return bundle.tiles
+    .filter(t => t.type === 'window')
+    .map(t => ({ tx: originTx + t.x, ty: originTy - t.y, tileId: t.tileId }))
+}
+
+/** Expand door entries from a bundle at the given bottom-left origin. */
+export function expandBundleDoors(
+  bundleID: string,
+  defaultBuildingId: string,
+  originTx: number,
+  originTy: number,
+): { buildingId: string; tx: number; ty: number }[] {
+  const bundle = BUNDLE_REGISTRY.get(bundleID)
+  if (!bundle) { console.warn(`[bundles] Unknown bundleID: "${bundleID}"`); return [] }
+  return bundle.tiles
+    .filter(t => t.type === 'door')
+    .map(t => ({ buildingId: t.buildingId ?? defaultBuildingId, tx: originTx + t.x, ty: originTy - t.y }))
+}

--- a/web/src/data/bundles/bundles.json
+++ b/web/src/data/bundles/bundles.json
@@ -1,0 +1,23 @@
+[
+  {
+    "bundleID": "royal-bed",
+    "tiles": [
+      { "tileID": "bed-tl", "x": 0, "y": 1, "zlayer": "below" },
+      { "tileID": "bed-tr", "x": 1, "y": 1, "zlayer": "below" },
+      { "tileID": "bed-bl", "x": 0, "y": 0, "zlayer": "above" },
+      { "tileID": "bed-br", "x": 1, "y": 0, "zlayer": "above" }
+    ]
+  },
+  {
+    "bundleID": "shop-front",
+    "tiles": [
+      { "type": "window", "tileID": "windowTop",    "x": 2, "y": 3 },
+      { "type": "window", "tileID": "windowBottom", "x": 2, "y": 2 },
+      { "type": "window", "tileID": "windowTop",    "x": 4, "y": 3 },
+      { "type": "window", "tileID": "windowBottom", "x": 4, "y": 2 },
+      { "type": "door",   "x": 3, "y": 0 },
+      { "type": "decor",  "tileID": "lampPostTop",    "x": 0, "y": 0, "zlayer": "solid" },
+      { "type": "decor",  "tileID": "lampPostBottom", "x": 0, "y": 1, "zlayer": "solid" }
+    ]
+  }
+]

--- a/web/src/data/castle/loader.ts
+++ b/web/src/data/castle/loader.ts
@@ -10,6 +10,7 @@ import type {
 } from '../hub/loader'
 import type { HubLocationData, HubExitTile } from '../hub/locationTypes'
 import type { HubQuestDef } from '../hub/questDefs'
+import { expandBundleDecor, expandBundleWindows, expandBundleDoors } from '../bundles/bundleLoader'
 
 const WALL_MATERIAL_NAMES = new Set<string>(Object.keys(WALL_TILES))
 const T = 32
@@ -79,9 +80,10 @@ const HUB_STREET_TILES: [number, number][] = HUB_STREET_GROUPS.flatMap(g => g.ti
 type RawBuilding = {
   rect?: number[]; rects?: number[][];
   id?: string; wall?: string; roof?: string;
+  bundleID?: string;
   doors?:   Array<{ tx: number; ty: number; buildingId?: string }>
   windows?: Array<{ tx: number; ty: number; tileId: string }>
-  decor?:   Array<{ tx: number; ty: number; tileId: string; zlayer?: string }>
+  decor?:   Array<{ tx: number; ty: number; tileId?: string; bundleID?: string; zlayer?: string }>
 }
 
 const HUB_BUILDINGS: HubBuilding[] = (rawConfig.buildings as RawBuilding[]).flatMap(b => {
@@ -111,6 +113,12 @@ for (const b of rawConfig.buildings as RawBuilding[]) {
   const rectList = b.rects ?? (b.rect ? [b.rect] : [])
   if (rectList.length === 0) continue
   const [ox, oy] = buildingOrigin(rectList)
+  if (b.bundleID) {
+    _nestedWindows.push(...expandBundleWindows(b.bundleID, ox, oy))
+    _nestedDecor.push(...expandBundleDecor(b.bundleID, ox, oy))
+    _nestedDoors.push(...expandBundleDoors(b.bundleID, b.id ?? '', ox, oy))
+    continue
+  }
   for (const d of b.doors ?? []) {
     const absTy = oy + d.ty
     let storeTy  = absTy
@@ -126,15 +134,22 @@ for (const b of rawConfig.buildings as RawBuilding[]) {
   }
   for (const w of b.windows ?? [])
     _nestedWindows.push({ tx: ox + w.tx, ty: oy + w.ty, tileId: resolveTileId(w.tileId) })
-  for (const d of b.decor ?? [])
-    _nestedDecor.push({ tx: ox + d.tx, ty: oy + d.ty, tileId: resolveTileId(d.tileId), zlayer: d.zlayer })
+  for (const d of b.decor ?? []) {
+    if (d.bundleID)
+      _nestedDecor.push(...expandBundleDecor(d.bundleID, ox + d.tx, oy + d.ty))
+    else if (d.tileId)
+      _nestedDecor.push({ tx: ox + d.tx, ty: oy + d.ty, tileId: resolveTileId(d.tileId), zlayer: d.zlayer })
+  }
 }
 
-type RawDecorEntry = { tx?: number; ty?: number; tileId?: string; comment?: string; zlayer?: string }
+type RawDecorEntry = { tx?: number; ty?: number; tileId?: string; bundleID?: string; comment?: string; zlayer?: string }
 const EXTERIOR_DECOR = [
-  ...(rawConfig.exteriorDecor as RawDecorEntry[])
-    .filter((d): d is { tx: number; ty: number; tileId: string; zlayer?: string } => d.tx != null && d.ty != null && d.tileId != null)
-    .map(d => ({ tx: d.tx, ty: d.ty, tileId: resolveTileId(d.tileId), zlayer: d.zlayer })),
+  ...(rawConfig.exteriorDecor as RawDecorEntry[]).flatMap(d => {
+    if (d.tx == null || d.ty == null) return []
+    if (d.bundleID) return expandBundleDecor(d.bundleID, d.tx, d.ty)
+    if (d.tileId) return [{ tx: d.tx, ty: d.ty, tileId: resolveTileId(d.tileId), zlayer: d.zlayer }]
+    return []
+  }),
   ..._nestedDecor,
 ]
 
@@ -157,12 +172,11 @@ const HUB_INTERIORS: Record<string, HubInterior> = Object.fromEntries(
         height:       raw.height,
         floorTileId:  resolveTileId(raw.floorTileId),
         wallMaterial: wallTileIdStr && WALL_MATERIAL_NAMES.has(wallTileIdStr) ? wallTileIdStr as WallMaterial : undefined,
-        decor:        (raw.decor as Array<{ tx: number; ty: number; tileId: string; zlayer?: string }>).map(d => ({
-          tx:     d.tx,
-          ty:     d.ty,
-          tileId: resolveTileId(d.tileId),
-          zlayer: d.zlayer as InteriorDecor['zlayer'],
-        })),
+        decor:        (raw.decor as Array<{ tx: number; ty: number; tileId?: string; bundleID?: string; zlayer?: string }>).flatMap(d => {
+          if (d.bundleID)
+            return expandBundleDecor(d.bundleID, d.tx, d.ty).map(e => ({ ...e, zlayer: e.zlayer as InteriorDecor['zlayer'] }))
+          return [{ tx: d.tx, ty: d.ty, tileId: resolveTileId(d.tileId ?? ''), zlayer: d.zlayer as InteriorDecor['zlayer'] }]
+        }),
         exits: ((rawAny.exits ?? []) as HubInteriorExit[]),
         hours: rawAny.hours as HubInterior['hours'],
       } satisfies HubInterior,

--- a/web/src/data/hub/loader.ts
+++ b/web/src/data/hub/loader.ts
@@ -4,6 +4,7 @@ import { BASE_CHIP_TILES } from '../tiles/baseChipIndex'
 import { WALL_TILES } from '../tiles/buildingMaterials'
 import type { WallMaterial, RoofMaterial } from '../tiles/buildingMaterials'
 import type { HubLocationData, HubExitTile } from './locationTypes'
+import { expandBundleDecor, expandBundleWindows, expandBundleDoors } from '../bundles/bundleLoader'
 
 const WALL_MATERIAL_NAMES = new Set<string>(Object.keys(WALL_TILES))
 
@@ -203,9 +204,10 @@ export const HUB_STREET_TILES:  [number, number][] = HUB_STREET_GROUPS.flatMap(g
 type RawBuilding = {
   rect?: number[]; rects?: number[][];
   id?: string; wall?: string; roof?: string;
+  bundleID?: string;
   doors?:   Array<{ tx: number; ty: number; buildingId?: string }>
   windows?: Array<{ tx: number; ty: number; tileId: string }>
-  decor?:   Array<{ tx: number; ty: number; tileId: string; zlayer?: string }>
+  decor?:   Array<{ tx: number; ty: number; tileId?: string; bundleID?: string; zlayer?: string }>
 }
 export const HUB_BUILDINGS: HubBuilding[] = (rawConfig.buildings as RawBuilding[]).flatMap(b => {
   const rectList = b.rects ?? (b.rect ? [b.rect] : [])
@@ -234,6 +236,12 @@ for (const b of rawConfig.buildings as RawBuilding[]) {
   const rectList = b.rects ?? (b.rect ? [b.rect] : [])
   if (rectList.length === 0) continue
   const [ox, oy] = buildingOrigin(rectList)
+  if (b.bundleID) {
+    _nestedWindows.push(...expandBundleWindows(b.bundleID, ox, oy))
+    _nestedDecor.push(...expandBundleDecor(b.bundleID, ox, oy))
+    _nestedDoors.push(...expandBundleDoors(b.bundleID, b.id ?? '', ox, oy))
+    continue
+  }
   for (const d of b.doors ?? []) {
     const absTy = oy + d.ty
     // Find the rect whose south face (ty2+1) the door will match against.
@@ -252,15 +260,22 @@ for (const b of rawConfig.buildings as RawBuilding[]) {
   }
   for (const w of b.windows ?? [])
     _nestedWindows.push({ tx: ox + w.tx, ty: oy + w.ty, tileId: resolveTileId(w.tileId) })
-  for (const d of b.decor ?? [])
-    _nestedDecor.push({ tx: ox + d.tx, ty: oy + d.ty, tileId: resolveTileId(d.tileId), zlayer: d.zlayer })
+  for (const d of b.decor ?? []) {
+    if (d.bundleID)
+      _nestedDecor.push(...expandBundleDecor(d.bundleID, ox + d.tx, oy + d.ty))
+    else if (d.tileId)
+      _nestedDecor.push({ tx: ox + d.tx, ty: oy + d.ty, tileId: resolveTileId(d.tileId), zlayer: d.zlayer })
+  }
 }
 
-type RawDecorEntry = { tx?: number; ty?: number; tileId?: string; comment?: string; zlayer?: string }
+type RawDecorEntry = { tx?: number; ty?: number; tileId?: string; bundleID?: string; comment?: string; zlayer?: string }
 export const EXTERIOR_DECOR = [
-  ...(rawConfig.exteriorDecor as RawDecorEntry[])
-    .filter((d): d is { tx: number; ty: number; tileId: string; zlayer?: string } => d.tx != null && d.ty != null && d.tileId != null)
-    .map(d => ({ tx: d.tx, ty: d.ty, tileId: resolveTileId(d.tileId), zlayer: d.zlayer })),
+  ...(rawConfig.exteriorDecor as RawDecorEntry[]).flatMap(d => {
+    if (d.tx == null || d.ty == null) return []
+    if (d.bundleID) return expandBundleDecor(d.bundleID, d.tx, d.ty)
+    if (d.tileId) return [{ tx: d.tx, ty: d.ty, tileId: resolveTileId(d.tileId), zlayer: d.zlayer }]
+    return []
+  }),
   ..._nestedDecor,
 ]
 
@@ -292,12 +307,11 @@ export const HUB_INTERIORS: Record<string, HubInterior> = Object.fromEntries(
         height:       raw.height,
         floorTileId:  resolveTileId(raw.floorTileId),
         wallMaterial: wallTileIdStr && WALL_MATERIAL_NAMES.has(wallTileIdStr) ? wallTileIdStr as WallMaterial : undefined,
-        decor:        (raw.decor as Array<{ tx: number; ty: number; tileId: string; zlayer?: string }>).map(d => ({
-          tx:     d.tx,
-          ty:     d.ty,
-          tileId: resolveTileId(d.tileId),
-          zlayer: d.zlayer as InteriorDecor['zlayer'],
-        })),
+        decor:        (raw.decor as Array<{ tx: number; ty: number; tileId?: string; bundleID?: string; zlayer?: string }>).flatMap(d => {
+          if (d.bundleID)
+            return expandBundleDecor(d.bundleID, d.tx, d.ty).map(e => ({ ...e, zlayer: e.zlayer as InteriorDecor['zlayer'] }))
+          return [{ tx: d.tx, ty: d.ty, tileId: resolveTileId(d.tileId ?? ''), zlayer: d.zlayer as InteriorDecor['zlayer'] }]
+        }),
         exits: ((rawAny.exits ?? []) as HubInteriorExit[]),
         hours: rawAny.hours as HubInterior['hours'],
       } satisfies HubInterior,
@@ -340,13 +354,16 @@ export const HUB_PICKUP_ITEMS: HubPickupItem[] = (
 }))
 
 type RawBlockedPathNpc = { id: string; sprite: string; tx: number; ty: number; proximityDialogue?: { atDistance: number; text: string }[]; tapDialogue?: string }
-type RawBlockedPathState = { decor?: Array<{ tx: number; ty: number; tileId: string; zlayer?: string }>; npcs?: RawBlockedPathNpc[] }
+type RawBlockedPathState = { decor?: Array<{ tx: number; ty: number; tileId?: string; bundleID?: string; zlayer?: string }>; npcs?: RawBlockedPathNpc[] }
 type RawBlockedPath = { id: string; blockedTiles: [number, number][]; questId: string; blocked: RawBlockedPathState; cleared: RawBlockedPathState }
 
 function resolveBlockedPathState(raw: RawBlockedPathState): BlockedPathState {
   return {
-    decor: (raw.decor ?? []).map(d => ({ tx: d.tx, ty: d.ty, tileId: resolveTileId(d.tileId), zlayer: d.zlayer })),
-    npcs:  raw.npcs ?? [],
+    decor: (raw.decor ?? []).flatMap(d => {
+      if (d.bundleID) return expandBundleDecor(d.bundleID, d.tx, d.ty)
+      return [{ tx: d.tx, ty: d.ty, tileId: resolveTileId(d.tileId ?? ''), zlayer: d.zlayer }]
+    }),
+    npcs: raw.npcs ?? [],
   }
 }
 

--- a/web/src/data/town2/loader.ts
+++ b/web/src/data/town2/loader.ts
@@ -10,6 +10,7 @@ import type {
 } from '../hub/loader'
 import type { HubLocationData, HubExitTile } from '../hub/locationTypes'
 import type { HubQuestDef } from '../hub/questDefs'
+import { expandBundleDecor, expandBundleWindows, expandBundleDoors } from '../bundles/bundleLoader'
 
 const WALL_MATERIAL_NAMES = new Set<string>(Object.keys(WALL_TILES))
 const T = 32
@@ -79,9 +80,10 @@ const HUB_STREET_TILES: [number, number][] = HUB_STREET_GROUPS.flatMap(g => g.ti
 type RawBuilding = {
   rect?: number[]; rects?: number[][];
   id?: string; wall?: string; roof?: string;
+  bundleID?: string;
   doors?:   Array<{ tx: number; ty: number; buildingId?: string }>
   windows?: Array<{ tx: number; ty: number; tileId: string }>
-  decor?:   Array<{ tx: number; ty: number; tileId: string; zlayer?: string }>
+  decor?:   Array<{ tx: number; ty: number; tileId?: string; bundleID?: string; zlayer?: string }>
 }
 
 const HUB_BUILDINGS: HubBuilding[] = (rawConfig.buildings as RawBuilding[]).flatMap(b => {
@@ -111,6 +113,12 @@ for (const b of rawConfig.buildings as RawBuilding[]) {
   const rectList = b.rects ?? (b.rect ? [b.rect] : [])
   if (rectList.length === 0) continue
   const [ox, oy] = buildingOrigin(rectList)
+  if (b.bundleID) {
+    _nestedWindows.push(...expandBundleWindows(b.bundleID, ox, oy))
+    _nestedDecor.push(...expandBundleDecor(b.bundleID, ox, oy))
+    _nestedDoors.push(...expandBundleDoors(b.bundleID, b.id ?? '', ox, oy))
+    continue
+  }
   for (const d of b.doors ?? []) {
     const absTy = oy + d.ty
     let storeTy  = absTy
@@ -126,15 +134,22 @@ for (const b of rawConfig.buildings as RawBuilding[]) {
   }
   for (const w of b.windows ?? [])
     _nestedWindows.push({ tx: ox + w.tx, ty: oy + w.ty, tileId: resolveTileId(w.tileId) })
-  for (const d of b.decor ?? [])
-    _nestedDecor.push({ tx: ox + d.tx, ty: oy + d.ty, tileId: resolveTileId(d.tileId), zlayer: d.zlayer })
+  for (const d of b.decor ?? []) {
+    if (d.bundleID)
+      _nestedDecor.push(...expandBundleDecor(d.bundleID, ox + d.tx, oy + d.ty))
+    else if (d.tileId)
+      _nestedDecor.push({ tx: ox + d.tx, ty: oy + d.ty, tileId: resolveTileId(d.tileId), zlayer: d.zlayer })
+  }
 }
 
-type RawDecorEntry = { tx?: number; ty?: number; tileId?: string; comment?: string; zlayer?: string }
+type RawDecorEntry = { tx?: number; ty?: number; tileId?: string; bundleID?: string; comment?: string; zlayer?: string }
 const EXTERIOR_DECOR = [
-  ...(rawConfig.exteriorDecor as RawDecorEntry[])
-    .filter((d): d is { tx: number; ty: number; tileId: string; zlayer?: string } => d.tx != null && d.ty != null && d.tileId != null)
-    .map(d => ({ tx: d.tx, ty: d.ty, tileId: resolveTileId(d.tileId), zlayer: d.zlayer })),
+  ...(rawConfig.exteriorDecor as RawDecorEntry[]).flatMap(d => {
+    if (d.tx == null || d.ty == null) return []
+    if (d.bundleID) return expandBundleDecor(d.bundleID, d.tx, d.ty)
+    if (d.tileId) return [{ tx: d.tx, ty: d.ty, tileId: resolveTileId(d.tileId), zlayer: d.zlayer }]
+    return []
+  }),
   ..._nestedDecor,
 ]
 
@@ -155,12 +170,11 @@ const HUB_INTERIORS: Record<string, HubInterior> = Object.fromEntries(
         height:       raw.height,
         floorTileId:  resolveTileId(raw.floorTileId),
         wallMaterial: wallTileIdStr && WALL_MATERIAL_NAMES.has(wallTileIdStr) ? wallTileIdStr as WallMaterial : undefined,
-        decor:        (raw.decor as Array<{ tx: number; ty: number; tileId: string; zlayer?: string }>).map(d => ({
-          tx:     d.tx,
-          ty:     d.ty,
-          tileId: resolveTileId(d.tileId),
-          zlayer: d.zlayer as InteriorDecor['zlayer'],
-        })),
+        decor:        (raw.decor as Array<{ tx: number; ty: number; tileId?: string; bundleID?: string; zlayer?: string }>).flatMap(d => {
+          if (d.bundleID)
+            return expandBundleDecor(d.bundleID, d.tx, d.ty).map(e => ({ ...e, zlayer: e.zlayer as InteriorDecor['zlayer'] }))
+          return [{ tx: d.tx, ty: d.ty, tileId: resolveTileId(d.tileId ?? ''), zlayer: d.zlayer as InteriorDecor['zlayer'] }]
+        }),
         exits: ((rawAny.exits ?? []) as HubInteriorExit[]),
         hours: rawAny.hours as HubInterior['hours'],
       } satisfies HubInterior,


### PR DESCRIPTION
## Summary

Implements [#1519](https://github.com/Jarvichi/jarvs-amazing-web-game/issues/1519) and all three sub-tasks (#1529, #1530, #1531).

- **`web/src/data/bundles/bundles.json`** — bundle definitions file with two example bundles: `royal-bed` (4 decor tiles with per-tile `zlayer`) and `shop-front` (windows + door + decor tiles)
- **`web/src/data/bundles/bundleLoader.ts`** — registry loaded at startup; exports `getBundleById`, `expandBundleDecor`, `expandBundleWindows`, `expandBundleDoors`; malformed bundles log a warning and are skipped
- **`hub/loader.ts`, `town2/loader.ts`, `castle/loader.ts`** — `bundleID` now accepted as an alternative to `tileID` in: exterior decor, building-level decor/windows/doors, interior decor, and blocked-path decor

## Coordinate system

Bundle tiles use a y-up origin (`x=0, y=0` = bottom-left tile). The expansion formula maps to the loaders' y-down screen coordinates:
```
absolute_tx = origin_tx + bundle_tile.x
absolute_ty = origin_ty - bundle_tile.y
```

## Usage examples

**Exterior decor:**
```json
{ "tx": 10, "ty": 15, "bundleID": "royal-bed" }
```

**Building with bundleID (replaces windows/doors/decor):**
```json
{ "rect": [5, 10, 12, 16], "id": "shop", "wall": "brick", "roof": "woodRoof", "bundleID": "shop-front" }
```

**Building decor entry using bundleID (inline bundle at offset):**
```json
{ "tx": 2, "ty": -1, "bundleID": "royal-bed" }
```

## Test plan

- [ ] `npm run build` passes clean (TypeScript + Vite) ✅ verified
- [ ] Add a `bundleID: "royal-bed"` entry to `hub/config.json` `exteriorDecor` and confirm tiles render at the expected position in the dev server
- [ ] Add `"bundleID": "shop-front"` to a building in `hub/config.json` and confirm windows/door/decor appear correctly
- [ ] Set an invalid `bundleID` and confirm a console warning is logged with no crash

https://claude.ai/code/session_01Ao9b7Mx37z5NeH75c46dVR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ao9b7Mx37z5NeH75c46dVR)_