### PR TITLE
feat(bundles): simple-bed, fireplace, fountain bundles; convert hub config

### DIFF
--- a/web/src/components/hub/HubWorldMap.stories.tsx
+++ b/web/src/components/hub/HubWorldMap.stories.tsx
@@ -1,0 +1,27 @@
+import { fn } from 'storybook/test'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { HubWorldMap } from './HubWorldMap'
+
+const meta = {
+  component: HubWorldMap,
+  parameters: { layout: 'fullscreen' },
+  decorators: [
+    (Story) => (
+      <div className="game-container">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof HubWorldMap>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    onSelectNode: fn(),
+    onBack:       fn(),
+    onFeedback:   fn(),
+    user:         null,
+  },
+}

--- a/web/src/components/hub/QuestsModal.stories.tsx
+++ b/web/src/components/hub/QuestsModal.stories.tsx
@@ -1,0 +1,77 @@
+import { fn } from 'storybook/test'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { QuestsModal } from './QuestsModal'
+import type { HubQuestDef } from '../../data/hub/questDefs'
+
+const meta = {
+  component: QuestsModal,
+  parameters: { layout: 'fullscreen' },
+  decorators: [
+    (Story) => (
+      <div className="game-container">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof QuestsModal>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+const sampleQuests: HubQuestDef[] = [
+  {
+    id: 'q-sample-1',
+    type: 'fetch',
+    title: 'The Missing Shipment',
+    giverNpcId:      'merchant-npc',
+    receiverNpcId:   'merchant-npc',
+    offerDialogue:   'My crates never arrived from the docks. Can you help?',
+    activeDialogue:  { find: 'Check the dockside warehouse for the missing crates.' },
+    completeDialogue: 'Wonderful — thank you!',
+    reward: { crystals: 50 },
+    steps: [
+      { key: 'find', type: 'collect', required: 1, pickupIds: ['crate-1'] },
+    ],
+  },
+  {
+    id: 'q-sample-2',
+    type: 'chain',
+    title: 'Supply Run',
+    giverNpcId:      'alchemist-npc',
+    receiverNpcId:   'alchemist-npc',
+    offerDialogue:   'I need ingredients urgently.',
+    activeDialogue: {
+      herbs:    'Gather herbs from the market district.',
+      crystals: 'Bring back the crystals from the vault.',
+    },
+    completeDialogue: 'Perfect, just what I needed.',
+    reward: { crystals: 120 },
+    steps: [
+      { key: 'herbs',    type: 'collect', required: 3, pickupIds: ['herb-1', 'herb-2', 'herb-3'] },
+      { key: 'crystals', type: 'collect', required: 2, pickupIds: ['crystal-1', 'crystal-2'] },
+    ],
+  },
+]
+
+export const NoActiveQuests: Story = {
+  args: {
+    onClose:   fn(),
+    onAbandon: fn(),
+    questDefs: [],
+  },
+}
+
+export const WithQuests: Story = {
+  args: {
+    onClose:   fn(),
+    onAbandon: fn(),
+    questDefs: sampleQuests,
+  },
+}
+
+export const Default: Story = {
+  args: {
+    onClose:   fn(),
+    onAbandon: fn(),
+  },
+}

--- a/web/src/components/hub/TreasureModal.stories.tsx
+++ b/web/src/components/hub/TreasureModal.stories.tsx
@@ -1,0 +1,68 @@
+import { fn } from 'storybook/test'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { TreasureModal } from './TreasureModal'
+import type { HubTreasure } from '../../data/hub/loader'
+
+const meta = {
+  component: TreasureModal,
+  parameters: { layout: 'fullscreen' },
+  decorators: [
+    (Story) => (
+      <div className="game-container">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof TreasureModal>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+const base: Omit<HubTreasure, 'reward'> = {
+  id: 'chest-1',
+  tx: 5,
+  ty: 5,
+  tileId: 888,
+  title: 'Forgotten Chest',
+}
+
+export const CrystalReward: Story = {
+  args: {
+    treasure: { ...base, reward: { crystals: 250 } },
+    onClose: fn(),
+  },
+}
+
+export const CollectibleReward: Story = {
+  args: {
+    treasure: {
+      ...base,
+      title: 'Ancient Relic',
+      reward: {
+        collectible: { id: 'ancient-crown', name: 'Ancient Crown', icon: '👑', desc: 'A crown worn by forgotten kings.' },
+      },
+    },
+    onClose: fn(),
+  },
+}
+
+export const MixedReward: Story = {
+  args: {
+    treasure: {
+      ...base,
+      title: 'Merchant\'s Stash',
+      reward: {
+        crystals: 100,
+        consumables: [{ id: 'health_potion', quantity: 2 }],
+      },
+    },
+    onClose: fn(),
+  },
+}
+
+export const EmptyTreasure: Story = {
+  args: {
+    treasure: { ...base, title: 'Empty Box', reward: {} },
+    onClose: fn(),
+  },
+}

--- a/web/src/data/bundles/BundleBrowser.stories.tsx
+++ b/web/src/data/bundles/BundleBrowser.stories.tsx
@@ -1,0 +1,192 @@
+import React, { useRef, useState } from 'react'
+import * as PIXI from 'pixi.js'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { getAllBundles, getBundleById, type BundleDef } from './bundleLoader'
+import { usePixiApp } from '../../hooks/usePixiApp'
+import { loadTileTexture } from '../../utils/pixiHelpers'
+import { TILESET_IMAGE, TILESET_COLUMNS } from '../tiles/tileIndex'
+
+const T     = 32
+const PAD   = 1  // padding tiles around the bundle grid
+
+// ── Canvas that renders one bundle ────────────────────────────────────────────
+
+function BundleCanvas({ bundle, scale }: { bundle: BundleDef; scale: number }) {
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  const tilesWithPos = bundle.tiles.filter(t => t.type !== 'door' || true)
+  const maxX  = tilesWithPos.length > 0 ? Math.max(...tilesWithPos.map(t => t.x)) : 0
+  const maxY  = tilesWithPos.length > 0 ? Math.max(...tilesWithPos.map(t => t.y)) : 0
+  const cols  = maxX + 1 + PAD * 2
+  const rows  = maxY + 1 + PAD * 2
+
+  usePixiApp(containerRef, cols * T * scale, rows * T * scale, (app) => {
+    app.stage.scale.set(scale)
+
+    // Checkerboard background
+    const bg = new PIXI.Graphics()
+    for (let cx = 0; cx < cols; cx++)
+      for (let cy = 0; cy < rows; cy++)
+        bg.rect(cx * T, cy * T, T, T).fill({ color: (cx + cy) % 2 === 0 ? 0x1e1e2e : 0x16161f })
+    app.stage.addChild(bg)
+
+    // Origin marker — the (0,0) bundle tile maps to (PAD, PAD + maxY) in canvas space
+    const originG = new PIXI.Graphics()
+    originG.rect(PAD * T, (PAD + maxY) * T, T, T).fill({ color: 0x004400 })
+    app.stage.addChild(originG)
+
+    const base        = (import.meta as { env: { BASE_URL: string } }).env.BASE_URL
+    const baseChipUrl = `${base}${TILESET_IMAGE.baseChip.slice(1)}`
+
+    for (const tile of bundle.tiles) {
+      // canvas y: flip bundle-y so y=0 appears at the bottom of the grid
+      const canvasX = (PAD + tile.x) * T
+      const canvasY = (PAD + maxY - tile.y) * T
+
+      if (tile.type === 'door') {
+        const g = new PIXI.Graphics()
+        g.rect(canvasX, canvasY, T, T).fill({ color: 0x663300 })
+        const label = new PIXI.Text({ text: 'D', style: { fontSize: 10, fill: 0xffcc88, fontFamily: 'monospace' } })
+        label.position.set(canvasX + 4, canvasY + 4)
+        app.stage.addChild(g, label)
+        continue
+      }
+
+      if (!tile.tileId) continue
+
+      loadTileTexture(baseChipUrl, tile.tileId, TILESET_COLUMNS.baseChip).then(tex => {
+        if (!app.renderer) return
+        const s = new PIXI.Sprite(tex)
+        s.position.set(canvasX, canvasY)
+        s.width = T; s.height = T
+        if (tile.zlayer === 'above') s.alpha = 0.65
+        app.stage.addChild(s)
+      }).catch(() => {})
+    }
+
+    // Grid lines
+    const grid = new PIXI.Graphics()
+    grid.setStrokeStyle({ width: 0.5, color: 0x333355, alpha: 0.6 })
+    for (let cx = 0; cx <= cols; cx++) grid.moveTo(cx * T, 0).lineTo(cx * T, rows * T)
+    for (let cy = 0; cy <= rows; cy++) grid.moveTo(0, cy * T).lineTo(cols * T, cy * T)
+    grid.stroke()
+    app.stage.addChild(grid)
+  })
+
+  return <div ref={containerRef} />
+}
+
+// ── Placeholder component (required by Storybook meta) ────────────────────────
+
+function BundleBrowserPlaceholder() { return null }
+
+// ── Meta ──────────────────────────────────────────────────────────────────────
+
+const meta = {
+  component: BundleBrowserPlaceholder,
+  parameters: { layout: 'fullscreen' },
+} satisfies Meta<typeof BundleBrowserPlaceholder>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+// ── Browser story ─────────────────────────────────────────────────────────────
+
+export const Browser: Story = {
+  render: () => {
+    const allBundles = getAllBundles()
+    const [selectedId, setSelectedId] = useState(allBundles[0]?.bundleID ?? '')
+    const [scale, setScale]           = useState(4)
+    const bundle = getBundleById(selectedId)
+
+    const tileStyle: React.CSSProperties = {
+      fontFamily: 'monospace', fontSize: 11,
+      background: '#111122', border: '1px solid #334',
+      padding: '2px 6px', borderRadius: 2,
+    }
+
+    return (
+      <div style={{ background: '#0a0a18', minHeight: '100vh', color: '#aabbcc', fontFamily: 'monospace', padding: 20 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 16, marginBottom: 16, flexWrap: 'wrap' }}>
+          <strong style={{ fontSize: 13, color: '#88ccff' }}>Bundle Browser</strong>
+
+          <select
+            value={selectedId}
+            onChange={e => setSelectedId(e.target.value)}
+            style={{ background: '#111', color: '#88ccff', border: '1px solid #336', padding: '4px 10px', fontFamily: 'monospace', fontSize: 12 }}
+          >
+            {allBundles.map(b => (
+              <option key={b.bundleID} value={b.bundleID}>{b.bundleID}</option>
+            ))}
+          </select>
+
+          <label style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 12 }}>
+            Scale
+            <input
+              type="range" min={2} max={6} step={1} value={scale}
+              onChange={e => setScale(Number(e.target.value))}
+              style={{ width: 80 }}
+            />
+            {scale}×
+          </label>
+
+          {bundle && (
+            <span style={{ color: '#446688', fontSize: 11 }}>
+              {bundle.tiles.length} tiles
+            </span>
+          )}
+        </div>
+
+        {bundle ? (
+          <div style={{ display: 'flex', gap: 32, alignItems: 'flex-start', flexWrap: 'wrap' }}>
+            {/* Canvas — key forces remount so PixiJS reinitialises */}
+            <div style={{ background: '#111122', border: '1px solid #334', display: 'inline-block' }}>
+              <BundleCanvas key={`${selectedId}-${scale}`} bundle={bundle} scale={scale} />
+            </div>
+
+            {/* Tile table */}
+            <div>
+              <div style={{ marginBottom: 8, fontSize: 12, color: '#668888' }}>
+                Origin (0,0) = <span style={{ color: '#44ff88' }}>■</span> green = bottom-left tile
+                &nbsp;·&nbsp;
+                <span style={{ opacity: 0.6 }}>above-layer tiles at 65% opacity</span>
+              </div>
+              <table style={{ borderCollapse: 'collapse', fontSize: 11 }}>
+                <thead>
+                  <tr style={{ color: '#6688aa', borderBottom: '1px solid #334' }}>
+                    {['type', 'x', 'y', 'tileId', 'zlayer'].map(h => (
+                      <th key={h} style={{ padding: '2px 12px 4px 0', textAlign: 'left', fontWeight: 'normal' }}>{h}</th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {bundle.tiles.map((t, i) => (
+                    <tr key={i} style={{ borderBottom: '1px solid #1a1a2e', lineHeight: '1.8' }}>
+                      <td style={{ ...tileStyle, color: t.type === 'door' ? '#ffcc88' : t.type === 'window' ? '#88aaff' : '#aaccaa' }}>{t.type}</td>
+                      <td style={{ padding: '0 12px 0 8px' }}>{t.x}</td>
+                      <td style={{ padding: '0 12px 0 0' }}>{t.y}</td>
+                      <td style={{ padding: '0 12px 0 0', color: '#556677' }}>{t.tileId || '—'}</td>
+                      <td style={{ padding: '0 0 0 0', color: t.zlayer === 'above' ? '#ffaaff' : t.zlayer === 'below' ? '#aaffaa' : '#556677' }}>
+                        {t.zlayer ?? '—'}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+
+              <div style={{ marginTop: 16, fontSize: 11, color: '#446', lineHeight: 1.7 }}>
+                <div>Usage in JSON:</div>
+                <pre style={{ background: '#0d0d1a', border: '1px solid #334', padding: '8px 12px', margin: '6px 0 0', color: '#88ccaa', borderRadius: 3 }}>
+{`{ "tx": X, "ty": Y, "bundleID": "${selectedId}" }`}
+                </pre>
+                <div style={{ color: '#446688', marginTop: 4 }}>where (X, Y) is the bottom-left tile position</div>
+              </div>
+            </div>
+          </div>
+        ) : (
+          <div style={{ color: '#664444', padding: 20 }}>No bundles registered.</div>
+        )}
+      </div>
+    )
+  },
+}

--- a/web/src/data/bundles/bundleLoader.ts
+++ b/web/src/data/bundles/bundleLoader.ts
@@ -44,6 +44,10 @@ export function getBundleById(id: string): BundleDef | undefined {
   return BUNDLE_REGISTRY.get(id)
 }
 
+export function getAllBundles(): BundleDef[] {
+  return Array.from(BUNDLE_REGISTRY.values())
+}
+
 /** Expand decor tiles from a bundle at the given bottom-left origin. */
 export function expandBundleDecor(
   bundleID: string,

--- a/web/src/data/bundles/bundles.json
+++ b/web/src/data/bundles/bundles.json
@@ -9,6 +9,40 @@
     ]
   },
   {
+    "bundleID": "simple-bed",
+    "tiles": [
+      { "tileID": "simpleBedHead",        "x": 0, "y": 1, "zlayer": "below" },
+      { "tileID": "simpleBedFoot",        "x": 0, "y": 0, "zlayer": "below" },
+      { "tileID": "simpleBedHeadOverlay", "x": 0, "y": 1, "zlayer": "above" },
+      { "tileID": "simpleBedFootOverlay", "x": 0, "y": 0, "zlayer": "above" }
+    ]
+  },
+  {
+    "bundleID": "fireplace",
+    "tiles": [
+      { "tileID": "fireplaceTopLeft",     "x": 0, "y": 1 },
+      { "tileID": "fireplaceTopMiddle",   "x": 1, "y": 1 },
+      { "tileID": "fireplaceTopRight",    "x": 2, "y": 1 },
+      { "tileID": "fireplaceBottomLeft",  "x": 0, "y": 0 },
+      { "tileID": "fireplaceBottomMiddle","x": 1, "y": 0 },
+      { "tileID": "fireplaceBottomRight", "x": 2, "y": 0 }
+    ]
+  },
+  {
+    "bundleID": "fountain",
+    "tiles": [
+      { "tileID": "fountainTopLeft",   "x": 0, "y": 2 },
+      { "tileID": "fountainTopMiddle", "x": 1, "y": 2 },
+      { "tileID": "fountainTopRight",  "x": 2, "y": 2 },
+      { "tileID": "fountainMidLeft",   "x": 0, "y": 1 },
+      { "tileID": "fountainMidMiddle", "x": 1, "y": 1 },
+      { "tileID": "fountainMidRight",  "x": 2, "y": 1 },
+      { "tileID": "fountainBotLeft",   "x": 0, "y": 0 },
+      { "tileID": "fountainBotMiddle", "x": 1, "y": 0 },
+      { "tileID": "fountainBotRight",  "x": 2, "y": 0 }
+    ]
+  },
+  {
     "bundleID": "shop-front",
     "tiles": [
       { "type": "window", "tileID": "windowTop",    "x": 2, "y": 3 },

--- a/web/src/data/hub/config.json
+++ b/web/src/data/hub/config.json
@@ -1521,54 +1521,8 @@
     { "tx":11, "ty":48, "tileId":"bottomPlough","zlayer": "below-avatar"},
     { "tx":12, "ty":48, "tileId":"bottomRightPlough","zlayer": "below-avatar"  },
 
-    {
-      "comment": "courtyard fountain"
-    },
-    {
-      "tx": 36,
-      "ty": 23,
-      "tileId": "fountainTopLeft"
-    },
-    {
-      "tx": 37,
-      "ty": 23,
-      "tileId": "fountainTopMiddle"
-    },
-    {
-      "tx": 38,
-      "ty": 23,
-      "tileId": "fountainTopRight"
-    },
-    {
-      "tx": 36,
-      "ty": 24,
-      "tileId": "fountainMidLeft"
-    },
-    {
-      "tx": 37,
-      "ty": 24,
-      "tileId": "fountainMidMiddle"
-    },
-    {
-      "tx": 38,
-      "ty": 24,
-      "tileId": "fountainMidRight"
-    },
-    {
-      "tx": 36,
-      "ty": 25,
-      "tileId": "fountainBotLeft"
-    },
-    {
-      "tx": 37,
-      "ty": 25,
-      "tileId": "fountainBotMiddle"
-    },
-    {
-      "tx": 38,
-      "ty": 25,
-      "tileId": "fountainBotRight"
-    },
+    { "comment": "courtyard fountain" },
+    { "tx": 36, "ty": 25, "bundleID": "fountain" },
     {
       "comment": "pond decor"
     },
@@ -3734,84 +3688,9 @@
       "height": 9,
       "floorTileId": "parquetFloor",
       "decor": [
-        {
-          "tx": 2,
-          "ty": 1,
-          "tileId": "simpleBedHead",
-          "zLayer": "below"
-        },
-        {
-          "tx": 3,
-          "ty": 1,
-          "tileId": "simpleBedHead",
-          "zLayer": "below"
-        },
-        {
-          "tx": 2,
-          "ty": 2,
-          "tileId": "simpleBedFoot",
-          "zLayer": "below"
-        },
-        {
-          "tx": 3,
-          "ty": 2,
-          "tileId": "simpleBedFoot",
-          "zLayer": "below"
-        },
-        {
-          "tx": 2,
-          "ty": 1,
-          "tileId": "simpleBedHeadOverlay",
-          "zLayer": "above"
-        },
-        {
-          "tx": 3,
-          "ty": 1,
-          "tileId": "simpleBedHeadOverlay",
-          "zLayer": "above"
-        },
-        {
-          "tx": 2,
-          "ty": 2,
-          "tileId": "simpleBedFootOverlay",
-          "zLayer": "above"
-        },
-        {
-          "tx": 3,
-          "ty": 2,
-          "tileId": "simpleBedFootOverlay",
-          "zLayer": "above"
-        },
-        {
-          "tx": 8,
-          "ty": 0,
-          "tileId": "fireplaceTopLeft"
-        },
-        {
-          "tx": 8,
-          "ty": 1,
-          "tileId": "fireplaceBottomLeft"
-        },
-        {
-          "tx": 9,
-          "ty": 0,
-          "tileId": "fireplaceTopMiddle"
-        },
-        {
-          "tx": 9,
-          "ty": 1,
-          "tileId": "fireplaceBottomMiddle"
-        },
-        {
-          "tx": 10,
-          "ty": 0,
-          "tileId": "fireplaceTopRight"
-        },
-        {
-          "tx": 10,
-          "ty": 1,
-          "tileId": "fireplaceBottomRight"
-        },
+        { "tx": 2, "ty": 2, "bundleID": "simple-bed" },
+        { "tx": 3, "ty": 2, "bundleID": "simple-bed" },
+        { "tx": 8, "ty": 1, "bundleID": "fireplace" },
         {
           "tx": 5,
           "ty": 4,
@@ -4549,102 +4428,10 @@
       "height": 8,
       "floorTileId": "darkStoneFloor",
       "decor": [
-        {
-          "tx": 2,
-          "ty": 2,
-          "tileId": "simpleBedHead",
-          "zlayer": "below"
-        },
-        {
-          "tx": 2,
-          "ty": 3,
-          "tileId": "simpleBedFoot",
-          "zlayer": "below"
-        },
-        {
-          "tx": 4,
-          "ty": 2,
-          "tileId": "simpleBedHead",
-          "zlayer": "below"
-        },
-        {
-          "tx": 4,
-          "ty": 3,
-          "tileId": "simpleBedFoot",
-          "zlayer": "below"
-        },
-        {
-          "tx": 10,
-          "ty": 2,
-          "tileId": "simpleBedHead",
-          "zlayer": "below"
-        },
-        {
-          "tx": 10,
-          "ty": 3,
-          "tileId": "simpleBedFoot",
-          "zlayer": "below"
-        },
-        {
-          "tx": 12,
-          "ty": 2,
-          "tileId": "simpleBedHead",
-          "zlayer": "below"
-        },
-        {
-          "tx": 12,
-          "ty": 3,
-          "tileId": "simpleBedFoot",
-          "zlayer": "below"
-        },
-        {
-          "tx": 2,
-          "ty": 2,
-          "tileId": "simpleBedHeadOverlay",
-          "zlayer": "above"
-        },
-        {
-          "tx": 2,
-          "ty": 3,
-          "tileId": "simpleBedFootOverlay",
-          "zlayer": "above"
-        },
-        {
-          "tx": 4,
-          "ty": 2,
-          "tileId": "simpleBedHeadOverlay",
-          "zlayer": "above"
-        },
-        {
-          "tx": 4,
-          "ty": 3,
-          "tileId": "simpleBedFootOverlay",
-          "zlayer": "above"
-        },
-        {
-          "tx": 10,
-          "ty": 2,
-          "tileId": "simpleBedHeadOverlay",
-          "zlayer": "above"
-        },
-        {
-          "tx": 10,
-          "ty": 3,
-          "tileId": "simpleBedFootOverlay",
-          "zlayer": "above"
-        },
-        {
-          "tx": 12,
-          "ty": 2,
-          "tileId": "simpleBedHeadOverlay",
-          "zlayer": "above"
-        },
-        {
-          "tx": 12,
-          "ty": 3,
-          "tileId": "simpleBedFootOverlay",
-          "zlayer": "above"
-        },
+        { "tx": 2,  "ty": 3, "bundleID": "simple-bed" },
+        { "tx": 4,  "ty": 3, "bundleID": "simple-bed" },
+        { "tx": 10, "ty": 3, "bundleID": "simple-bed" },
+        { "tx": 12, "ty": 3, "bundleID": "simple-bed" },
         {
           "tx": 7,
           "ty": 4,
@@ -5035,102 +4822,10 @@
       "floorTileId": "darkWoodFloor",
       "wallMaterial": "tudor",
       "decor": [
-        {
-          "tx": 2,
-          "ty": 1,
-          "tileId": "simpleBedHead",
-          "zlayer": "below"
-        },
-        {
-          "tx": 2,
-          "ty": 2,
-          "tileId": "simpleBedFoot",
-          "zlayer": "below"
-        },
-        {
-          "tx": 2,
-          "ty": 1,
-          "tileId": "simpleBedHeadOverlay",
-          "zlayer": "above"
-        },
-        {
-          "tx": 2,
-          "ty": 2,
-          "tileId": "simpleBedFootOverlay",
-          "zlayer": "above"
-        },
-        {
-          "tx": 4,
-          "ty": 1,
-          "tileId": "simpleBedHead",
-          "zlayer": "below"
-        },
-        {
-          "tx": 4,
-          "ty": 2,
-          "tileId": "simpleBedFoot",
-          "zlayer": "below"
-        },
-        {
-          "tx": 4,
-          "ty": 1,
-          "tileId": "simpleBedHeadOverlay",
-          "zlayer": "above"
-        },
-        {
-          "tx": 4,
-          "ty": 2,
-          "tileId": "simpleBedFootOverlay",
-          "zlayer": "above"
-        },
-        {
-          "tx": 7,
-          "ty": 1,
-          "tileId": "simpleBedHead",
-          "zlayer": "below"
-        },
-        {
-          "tx": 7,
-          "ty": 2,
-          "tileId": "simpleBedFoot",
-          "zlayer": "below"
-        },
-        {
-          "tx": 7,
-          "ty": 1,
-          "tileId": "simpleBedHeadOverlay",
-          "zlayer": "above"
-        },
-        {
-          "tx": 7,
-          "ty": 2,
-          "tileId": "simpleBedFootOverlay",
-          "zlayer": "above"
-        },
-        {
-          "tx": 9,
-          "ty": 1,
-          "tileId": "simpleBedHead",
-          "zlayer": "below"
-        },
-        {
-          "tx": 9,
-          "ty": 2,
-          "tileId": "simpleBedFoot",
-          "zlayer": "below"
-        },
-        {
-          "tx": 9,
-          "ty": 1,
-          "tileId": "simpleBedHeadOverlay",
-          "zlayer": "above"
-        },
-        {
-          "tx": 9,
-          "ty": 2,
-          "tileId": "simpleBedFootOverlay",
-          "zlayer": "above"
-        },
+        { "tx": 2, "ty": 2, "bundleID": "simple-bed" },
+        { "tx": 4, "ty": 2, "bundleID": "simple-bed" },
+        { "tx": 7, "ty": 2, "bundleID": "simple-bed" },
+        { "tx": 9, "ty": 2, "bundleID": "simple-bed" },
         {
           "tx": 5,
           "ty": 5,


### PR DESCRIPTION
## Summary

Follow-on to #1543 — adds three real-world bundles and converts existing hub decor to use them.

**New bundles in `bundles.json`:**
- `simple-bed` — 4 tiles: head+foot at `below` layer, head+foot overlay at `above` layer. Place at the foot tile position.
- `fireplace` — 6 tiles (3-wide × 2-tall). Place at the bottom-left corner.
- `fountain` — 9 tiles (3-wide × 3-tall). Place at the bottom-left corner.

**Conversions in `hub/config.json`** (318 lines → 47 lines for these blocks):
- `exteriorDecor`: 9 individual fountain tiles → `{ "tx": 36, "ty": 25, "bundleID": "fountain" }`
- `home` interior: 8 bed tiles + 6 fireplace tiles → 2 × `simple-bed` + 1 × `fireplace`
- `barracks-north` interior: 16 bed tiles → 4 × `simple-bed`
- `sw-building-b-upstairs` interior: 16 bed tiles → 4 × `simple-bed`

## Test plan

- [ ] `npm run build` passes clean ✅ verified
- [ ] Dev server: courtyard fountain renders at (36,23)–(38,25)
- [ ] Dev server: home interior — double bed at tx 2–3 and fireplace at tx 8–10 render correctly
- [ ] Dev server: barracks-north interior — 4 beds at tx 2, 4, 10, 12 render correctly
- [ ] Dev server: Wanderer's Rest upstairs — 4 beds at tx 2, 4, 7, 9 render correctly

https://claude.ai/code/session_01Ao9b7Mx37z5NeH75c46dVR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ao9b7Mx37z5NeH75c46dVR)_