### PR TITLE
Add visual map editor Storybook story

### DIFF
--- a/web/.storybook/main.ts
+++ b/web/.storybook/main.ts
@@ -1,17 +1,71 @@
-import type { StorybookConfig } from '@storybook/react-vite';
+import type { StorybookConfig } from '@storybook/react-vite'
+import { writeFileSync } from 'fs'
+import { resolve, dirname } from 'path'
+import { fileURLToPath } from 'url'
+import type { IncomingMessage, ServerResponse } from 'http'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname  = dirname(__filename)
+
+const MAP_PATHS: Record<string, string> = {
+  hub:    resolve(__dirname, '../src/data/hub/config.json'),
+  town2:  resolve(__dirname, '../src/data/town2/config.json'),
+  castle: resolve(__dirname, '../src/data/castle/config.json'),
+}
 
 const config: StorybookConfig = {
-  "stories": [
-    "../src/**/*.mdx",
-    "../src/**/*.stories.@(js|jsx|mjs|ts|tsx)"
+  stories: [
+    '../src/**/*.mdx',
+    '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)',
   ],
-  "addons": [
-    "@chromatic-com/storybook",
-    "@storybook/addon-vitest",
-    "@storybook/addon-a11y",
-    "@storybook/addon-onboarding",
-    "@storybook/addon-docs"
+  addons: [
+    '@chromatic-com/storybook',
+    '@storybook/addon-vitest',
+    '@storybook/addon-a11y',
+    '@storybook/addon-onboarding',
+    '@storybook/addon-docs',
   ],
-  "framework": "@storybook/react-vite"
-};
-export default config;
+  framework: '@storybook/react-vite',
+
+  viteFinal: async (viteConfig) => {
+    viteConfig.plugins = viteConfig.plugins ?? []
+    viteConfig.plugins.push({
+      name: 'map-editor-save',
+      apply: 'serve',
+      configureServer(server) {
+        server.middlewares.use(
+          '/api/map-editor/save',
+          (req: IncomingMessage, res: ServerResponse) => {
+            if (req.method !== 'POST') {
+              res.statusCode = 405
+              res.end('Method Not Allowed')
+              return
+            }
+            let body = ''
+            req.on('data', (chunk: Buffer) => { body += chunk.toString() })
+            req.on('end', () => {
+              try {
+                const { mapId, data } = JSON.parse(body) as { mapId: string; data: unknown }
+                const filePath = MAP_PATHS[mapId]
+                if (!filePath) {
+                  res.statusCode = 400
+                  res.end(JSON.stringify({ error: `Unknown mapId: ${mapId}` }))
+                  return
+                }
+                writeFileSync(filePath, JSON.stringify(data, null, 2))
+                res.setHeader('Content-Type', 'application/json')
+                res.end(JSON.stringify({ ok: true }))
+              } catch (e) {
+                res.statusCode = 500
+                res.end(JSON.stringify({ error: String(e) }))
+              }
+            })
+          },
+        )
+      },
+    })
+    return viteConfig
+  },
+}
+
+export default config

--- a/web/src/components/mapEditor/EntityInspector.tsx
+++ b/web/src/components/mapEditor/EntityInspector.tsx
@@ -1,0 +1,378 @@
+import React from 'react'
+import type { SelectedEntity, RawMapConfig, Zlayer, RawDecorItem, RawNpc, RawBuilding } from './mapEditorTypes'
+import { BASE_CHIP_TILES } from '../../data/tiles/baseChipIndex'
+
+const SHEET_URL = '/world/SampleMap/[Base]BaseChip_pipo.png'
+const COLS = 8
+const T = 32
+
+interface Props {
+  selectedEntity:   SelectedEntity | null
+  configData:       RawMapConfig
+  activeInteriorId: string | null
+  onDelete:         (entity: SelectedEntity) => void
+  onMoveEntity:     (entity: SelectedEntity, tx: number, ty: number) => void
+  onZlayerChange:   (entity: SelectedEntity, z: Zlayer) => void
+  onDialogueChange: (index: number, dialogue: string[]) => void
+  onOpenInterior:   (id: string) => void
+  onCloseInterior:  () => void
+  viewMode:         'exterior' | 'interior'
+}
+
+function TilePreview({ tileId }: { tileId: string }) {
+  const id = (BASE_CHIP_TILES as Record<string, number>)[tileId]
+  if (id === undefined) return <span style={{ color: '#888' }}>{tileId}</span>
+  const col = id % COLS
+  const row = Math.floor(id / COLS)
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+      <div
+        style={{
+          width: T, height: T, flexShrink: 0,
+          backgroundImage: `url("${SHEET_URL}")`,
+          backgroundPosition: `-${col * T}px -${row * T}px`,
+          backgroundRepeat: 'no-repeat',
+          imageRendering: 'pixelated',
+          border: '1px solid #444',
+        }}
+      />
+      <span style={{ fontFamily: 'monospace', fontSize: 11, color: '#aaa' }}>{tileId}</span>
+    </div>
+  )
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div style={{ marginBottom: 10 }}>
+      <div style={{ color: '#888', fontSize: 10, marginBottom: 3, textTransform: 'uppercase', letterSpacing: 1 }}>{label}</div>
+      {children}
+    </div>
+  )
+}
+
+function numInput(value: number, onChange: (v: number) => void) {
+  return (
+    <input
+      type="number"
+      value={value}
+      onChange={e => onChange(Number(e.target.value))}
+      style={{
+        width: 60, padding: '3px 5px', background: '#111', border: '1px solid #444',
+        color: '#eee', borderRadius: 3, fontSize: 12,
+      }}
+    />
+  )
+}
+
+function DecorInspector({
+  item, entity, onMove, onZlayer, onDelete,
+}: {
+  item: RawDecorItem
+  entity: SelectedEntity
+  onMove: (tx: number, ty: number) => void
+  onZlayer: (z: Zlayer) => void
+  onDelete: () => void
+}) {
+  return (
+    <div>
+      <Field label="Tile">
+        {item.tileId ? <TilePreview tileId={item.tileId} /> : <span style={{ color: '#aaa' }}>{item.bundleID ?? '—'}</span>}
+      </Field>
+      <Field label="Position">
+        <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+          <label style={{ fontSize: 11, color: '#888' }}>X</label>
+          {numInput(item.tx ?? 0, tx => onMove(tx, item.ty ?? 0))}
+          <label style={{ fontSize: 11, color: '#888' }}>Y</label>
+          {numInput(item.ty ?? 0, ty => onMove(item.tx ?? 0, ty))}
+        </div>
+      </Field>
+      <Field label="Z-Layer">
+        <div style={{ display: 'flex', gap: 4 }}>
+          {(['solid', 'below', 'above'] as Zlayer[]).map(z => (
+            <button
+              key={z}
+              onClick={() => onZlayer(z)}
+              style={{
+                padding: '3px 8px', fontSize: 11, cursor: 'pointer',
+                background: (item.zlayer ?? 'solid') === z ? '#f0c040' : '#333',
+                color: (item.zlayer ?? 'solid') === z ? '#1a1a2e' : '#aaa',
+                border: 'none', borderRadius: 3,
+              }}
+            >
+              {z}
+            </button>
+          ))}
+        </div>
+      </Field>
+      <button
+        onClick={onDelete}
+        style={{
+          width: '100%', padding: '6px 0', background: '#5a1a1a', border: '1px solid #922',
+          color: '#f88', cursor: 'pointer', borderRadius: 3, fontSize: 12, marginTop: 4,
+        }}
+      >
+        Delete
+      </button>
+    </div>
+  )
+}
+
+function NpcInspector({
+  npc, entity, onMove, onDelete, onDialogueChange,
+}: {
+  npc: RawNpc
+  entity: SelectedEntity & { type: 'npc' }
+  onMove: (tx: number, ty: number) => void
+  onDelete: () => void
+  onDialogueChange: (d: string[]) => void
+}) {
+  return (
+    <div>
+      <Field label="ID">
+        <span style={{ fontFamily: 'monospace', fontSize: 11, color: '#aaa' }}>{npc.id}</span>
+      </Field>
+      <Field label="Name">
+        <span style={{ fontSize: 12 }}>{npc.name}</span>
+      </Field>
+      <Field label="Sprite">
+        <span style={{ fontFamily: 'monospace', fontSize: 11, color: '#aaa' }}>{npc.sprite}</span>
+      </Field>
+      <Field label="Position">
+        <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+          <label style={{ fontSize: 11, color: '#888' }}>X</label>
+          {numInput(npc.tx, tx => onMove(tx, npc.ty))}
+          <label style={{ fontSize: 11, color: '#888' }}>Y</label>
+          {numInput(npc.ty, ty => onMove(npc.tx, ty))}
+        </div>
+      </Field>
+      <Field label="Dialogue">
+        <textarea
+          value={npc.dialogue.join('\n')}
+          onChange={e => onDialogueChange(e.target.value.split('\n'))}
+          rows={4}
+          style={{
+            width: '100%', background: '#111', border: '1px solid #444',
+            color: '#eee', borderRadius: 3, fontSize: 11, padding: 4,
+            boxSizing: 'border-box', resize: 'vertical', fontFamily: 'inherit',
+          }}
+        />
+        <div style={{ color: '#666', fontSize: 10, marginTop: 2 }}>One line = one dialogue entry</div>
+      </Field>
+      <button
+        onClick={onDelete}
+        style={{
+          width: '100%', padding: '6px 0', background: '#5a1a1a', border: '1px solid #922',
+          color: '#f88', cursor: 'pointer', borderRadius: 3, fontSize: 12,
+        }}
+      >
+        Delete NPC
+      </button>
+    </div>
+  )
+}
+
+function BuildingInspector({
+  building, onOpenInterior, interiorIds,
+}: {
+  building: RawBuilding
+  onOpenInterior: (id: string) => void
+  interiorIds: string[]
+}) {
+  const [tx1, ty1, tx2, ty2] = building.rect ?? [0, 0, 0, 0]
+  return (
+    <div>
+      {building.id && (
+        <Field label="ID">
+          <span style={{ fontFamily: 'monospace', fontSize: 11, color: '#aaa' }}>{building.id}</span>
+        </Field>
+      )}
+      <Field label="Rect">
+        <span style={{ fontFamily: 'monospace', fontSize: 11, color: '#aaa' }}>
+          ({tx1},{ty1}) → ({tx2},{ty2}) — {tx2 - tx1 + 1}×{ty2 - ty1 + 1} tiles
+        </span>
+      </Field>
+      {building.wall && (
+        <Field label="Wall">
+          <span style={{ fontFamily: 'monospace', fontSize: 11, color: '#aaa' }}>{building.wall}</span>
+        </Field>
+      )}
+      {building.roof && (
+        <Field label="Roof">
+          <span style={{ fontFamily: 'monospace', fontSize: 11, color: '#aaa' }}>{building.roof}</span>
+        </Field>
+      )}
+      {interiorIds.length > 0 && (
+        <Field label="Interiors">
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+            {interiorIds.map(id => (
+              <button
+                key={id}
+                onClick={() => onOpenInterior(id)}
+                style={{
+                  padding: '5px 8px', background: '#1e2a4e', border: '1px solid #3a4a8e',
+                  color: '#8af', cursor: 'pointer', borderRadius: 3, fontSize: 11, textAlign: 'left',
+                }}
+              >
+                Edit interior: {id}
+              </button>
+            ))}
+          </div>
+        </Field>
+      )}
+    </div>
+  )
+}
+
+export function EntityInspector({
+  selectedEntity, configData, activeInteriorId, viewMode,
+  onDelete, onMoveEntity, onZlayerChange, onDialogueChange, onOpenInterior, onCloseInterior,
+}: Props) {
+  const panelStyle: React.CSSProperties = {
+    display: 'flex', flexDirection: 'column', height: '100%',
+    background: '#1a1a2e', color: '#ccc', fontSize: 12,
+  }
+
+  const headerStyle: React.CSSProperties = {
+    padding: '8px 10px', borderBottom: '1px solid #333',
+    fontWeight: 'bold', fontSize: 12, color: '#ddd', background: '#252540',
+    display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+  }
+
+  const bodyStyle: React.CSSProperties = {
+    flex: 1, overflowY: 'auto', padding: 10,
+  }
+
+  if (viewMode === 'interior' && activeInteriorId) {
+    const interior = configData.interiors?.[activeInteriorId]
+    return (
+      <div style={panelStyle}>
+        <div style={headerStyle}>
+          <span>Interior: {interior?.name ?? activeInteriorId}</span>
+          <button
+            onClick={onCloseInterior}
+            style={{
+              padding: '3px 8px', background: '#333', border: '1px solid #555',
+              color: '#aaa', cursor: 'pointer', borderRadius: 3, fontSize: 11,
+            }}
+          >
+            ← Back
+          </button>
+        </div>
+        <div style={bodyStyle}>
+          {interior && (
+            <>
+              <Field label="Size">{interior.width} × {interior.height} tiles</Field>
+              <Field label="Floor">{interior.floorTileId && <TilePreview tileId={interior.floorTileId} />}</Field>
+              {interior.wallTileId && <Field label="Wall">{interior.wallTileId}</Field>}
+              <Field label="Decor items">
+                <span style={{ color: '#aaa' }}>{interior.decor.length} items</span>
+              </Field>
+              <div style={{ color: '#666', fontSize: 10, marginTop: 8 }}>
+                Click an item on the canvas to select it, or use the Place tool to add new decor.
+              </div>
+            </>
+          )}
+          {selectedEntity?.type === 'interiorDecor' && selectedEntity.interiorId === activeInteriorId && interior && (
+            <>
+              <div style={{ borderTop: '1px solid #333', marginTop: 12, paddingTop: 12 }}>
+                <div style={{ color: '#f0c040', marginBottom: 8, fontWeight: 'bold' }}>Selected Decor</div>
+                <DecorInspector
+                  item={interior.decor[selectedEntity.index]}
+                  entity={selectedEntity}
+                  onMove={(tx, ty) => onMoveEntity(selectedEntity, tx, ty)}
+                  onZlayer={z => onZlayerChange(selectedEntity, z)}
+                  onDelete={() => onDelete(selectedEntity)}
+                />
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    )
+  }
+
+  if (!selectedEntity) {
+    return (
+      <div style={panelStyle}>
+        <div style={headerStyle}>Inspector</div>
+        <div style={bodyStyle}>
+          <div style={{ color: '#555', fontSize: 11, marginTop: 20, textAlign: 'center' }}>
+            Click an entity to inspect it.<br /><br />
+            Use the Select tool to move entities.<br />
+            Use the Place tool to add decor.
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  if (selectedEntity.type === 'exteriorDecor') {
+    const items = configData.exteriorDecor ?? []
+    const item = items[selectedEntity.index]
+    if (!item) return null
+    return (
+      <div style={panelStyle}>
+        <div style={headerStyle}>Exterior Decor #{selectedEntity.index}</div>
+        <div style={bodyStyle}>
+          <DecorInspector
+            item={item}
+            entity={selectedEntity}
+            onMove={(tx, ty) => onMoveEntity(selectedEntity, tx, ty)}
+            onZlayer={z => onZlayerChange(selectedEntity, z)}
+            onDelete={() => onDelete(selectedEntity)}
+          />
+        </div>
+      </div>
+    )
+  }
+
+  if (selectedEntity.type === 'npc') {
+    const npcs = configData.npcs ?? []
+    const npc = npcs[selectedEntity.index]
+    if (!npc) return null
+    return (
+      <div style={panelStyle}>
+        <div style={headerStyle}>NPC</div>
+        <div style={bodyStyle}>
+          <NpcInspector
+            npc={npc}
+            entity={selectedEntity}
+            onMove={(tx, ty) => onMoveEntity(selectedEntity, tx, ty)}
+            onDelete={() => onDelete(selectedEntity)}
+            onDialogueChange={d => onDialogueChange(selectedEntity.index, d)}
+          />
+        </div>
+      </div>
+    )
+  }
+
+  if (selectedEntity.type === 'building') {
+    const buildings = configData.buildings ?? []
+    const building = buildings[selectedEntity.index]
+    if (!building) return null
+
+    // Find which interiors are linked to this building
+    const buildingId = building.id
+    const interiorIds: string[] = buildingId
+      ? Object.keys(configData.interiors ?? {}).filter(id => {
+          const doors = building.doors ?? []
+          return doors.some(d => d.buildingId === id) || id.startsWith(buildingId)
+        })
+      : []
+
+    return (
+      <div style={panelStyle}>
+        <div style={headerStyle}>Building</div>
+        <div style={bodyStyle}>
+          <BuildingInspector
+            building={building}
+            onOpenInterior={onOpenInterior}
+            interiorIds={interiorIds}
+          />
+        </div>
+      </div>
+    )
+  }
+
+  return null
+}

--- a/web/src/components/mapEditor/MapEditor.stories.tsx
+++ b/web/src/components/mapEditor/MapEditor.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { MapEditor } from './MapEditor'
+
+const meta = {
+  title:      'Map Editor/MapEditor',
+  component:  MapEditor,
+  parameters: {
+    layout: 'fullscreen',
+    docs:   { description: { component: 'Visual map editor for hub towns, castles and interiors. Dev-only — requires Storybook dev server for file saves.' } },
+  },
+} satisfies Meta<typeof MapEditor>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Hub: Story = {
+  args: { initialMapId: 'hub' },
+}
+
+export const Town2: Story = {
+  args: { initialMapId: 'town2' },
+}
+
+export const Castle: Story = {
+  args: { initialMapId: 'castle' },
+}

--- a/web/src/components/mapEditor/MapEditor.tsx
+++ b/web/src/components/mapEditor/MapEditor.tsx
@@ -1,0 +1,108 @@
+import React, { useState, useEffect } from 'react'
+import { MapEditorToolbar } from './MapEditorToolbar'
+import { TilePalette } from './TilePalette'
+import { EntityInspector } from './EntityInspector'
+import { MapEditorCanvas } from './MapEditorCanvas'
+import { useMapEditorState } from './useMapEditorState'
+import type { MapId } from './mapEditorTypes'
+
+interface Props {
+  initialMapId?: MapId
+}
+
+export function MapEditor({ initialMapId = 'hub' }: Props) {
+  const [showGrid, setShowGrid] = useState(true)
+
+  const {
+    state, setMapId, setTool, setActiveTile, setZlayer,
+    openInterior, closeInterior, selectEntity,
+    placeDecor, moveEntity, deleteEntity,
+    updateDecorZlayer, updateNpcDialogue,
+    undo, redo, markSaved,
+  } = useMapEditorState(initialMapId)
+
+  // Keyboard shortcuts
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return
+      if ((e.ctrlKey || e.metaKey) && e.key === 'z') { e.preventDefault(); undo() }
+      if ((e.ctrlKey || e.metaKey) && (e.key === 'y' || (e.shiftKey && e.key === 'z'))) { e.preventDefault(); redo() }
+      if (e.key === 's' && !e.ctrlKey && !e.metaKey) setTool('select')
+      if (e.key === 'p') setTool('place')
+      if (e.key === 'd' && !e.ctrlKey && !e.metaKey) setTool('delete')
+      if (e.key === 'Delete' || e.key === 'Backspace') {
+        if (state.selectedEntity) deleteEntity(state.selectedEntity)
+      }
+    }
+    window.addEventListener('keydown', handleKey)
+    return () => window.removeEventListener('keydown', handleKey)
+  }, [undo, redo, setTool, deleteEntity, state.selectedEntity])
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100vh', fontFamily: 'sans-serif', background: '#0f0f22' }}>
+      <MapEditorToolbar
+        mapId={state.mapId}
+        tool={state.tool}
+        canUndo={state.undoStack.length > 0}
+        canRedo={state.redoStack.length > 0}
+        isDirty={state.isDirty}
+        showGrid={showGrid}
+        configData={state.configData}
+        onMapChange={setMapId}
+        onToolChange={setTool}
+        onUndo={undo}
+        onRedo={redo}
+        onGridToggle={() => setShowGrid(g => !g)}
+        onSaved={markSaved}
+      />
+
+      <div style={{ display: 'flex', flex: 1, overflow: 'hidden' }}>
+        {/* Left: Tile palette */}
+        <div style={{ width: 192, flexShrink: 0, borderRight: '1px solid #333', overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
+          <TilePalette
+            activeTileId={state.activeTileId}
+            activeBundleId={state.activeBundleId}
+            activeZlayer={state.activeZlayer}
+            onSelectTile={tileId => setActiveTile(tileId)}
+            onSelectBundle={bundleId => setActiveTile(null, bundleId)}
+            onZlayerChange={setZlayer}
+          />
+        </div>
+
+        {/* Center: Map canvas — key forces remount when canvas dimensions change */}
+        <MapEditorCanvas
+          key={`${state.mapId}-${state.viewMode}-${state.activeInteriorId ?? ''}`}
+          configData={state.configData}
+          tool={state.tool}
+          showGrid={showGrid}
+          selectedEntity={state.selectedEntity}
+          viewMode={state.viewMode}
+          activeInteriorId={state.activeInteriorId}
+          activeTileId={state.activeTileId}
+          activeBundleId={state.activeBundleId}
+          activeZlayer={state.activeZlayer}
+          onSelectEntity={selectEntity}
+          onPlaceDecor={placeDecor}
+          onMoveEntity={moveEntity}
+          onDeleteEntity={deleteEntity}
+        />
+
+        {/* Right: Inspector */}
+        <div style={{ width: 220, flexShrink: 0, borderLeft: '1px solid #333', overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
+          <EntityInspector
+            selectedEntity={state.selectedEntity}
+            configData={state.configData}
+            activeInteriorId={state.activeInteriorId}
+            viewMode={state.viewMode}
+            onDelete={deleteEntity}
+            onMoveEntity={moveEntity}
+            onZlayerChange={updateDecorZlayer}
+            onDialogueChange={updateNpcDialogue}
+            onOpenInterior={openInterior}
+            onCloseInterior={closeInterior}
+          />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/mapEditor/MapEditorCanvas.tsx
+++ b/web/src/components/mapEditor/MapEditorCanvas.tsx
@@ -1,0 +1,457 @@
+import React, { useRef, useEffect, useCallback } from 'react'
+import * as PIXI from 'pixi.js'
+import { usePixiApp } from '../../hooks/usePixiApp'
+import { loadTileTexture, loadSpriteTexture } from '../../utils/pixiHelpers'
+import { BASE_CHIP_TILES } from '../../data/tiles/baseChipIndex'
+import { TILESET_IMAGE, TILESET_COLUMNS } from '../../data/tiles/tileIndex'
+import type { RawMapConfig, RawDecorItem, SelectedEntity, ToolMode, Zlayer } from './mapEditorTypes'
+import { expandBundleDecor } from '../../data/bundles/bundleLoader'
+
+const T         = 32
+const BASE_URL  = TILESET_IMAGE.baseChip
+const BASE_COLS = TILESET_COLUMNS.baseChip
+
+const WALL_COLORS: Record<string, number> = {
+  brick:               0x8b5e4a,
+  woodWall:            0x7a5c38,
+  tudorFrame:          0x6a4e2a,
+  renderedBrick:       0xaa8866,
+  whiteStone:          0xc8c0b0,
+  darkStone:           0x4a4a5a,
+  castleStone:         0x5a5a6a,
+  ornateStone:         0x6a7a6a,
+  reinforcedStone:     0x4a5a4a,
+  woodenSlats:         0x8a6a4a,
+  interiorWallStriped: 0x7a7a8a,
+  interiorWallWhite:   0xc0c0c0,
+  prisonRailings:      0x444444,
+}
+
+const STREET_COLOR = 0x8a7a5a
+const POND_COLOR   = 0x3a6aaa
+const GROUND_COLOR = 0x3a5a3a
+
+function tileNumericId(tileId: string): number {
+  return (BASE_CHIP_TILES as Record<string, number>)[tileId] ?? 0
+}
+
+function expandEntries(entries: Array<{ rect?: number[]; tile?: number[] }>): [number, number][] {
+  const out: [number, number][] = []
+  for (const e of entries) {
+    if (e.rect) {
+      const [tx1, ty1, tx2, ty2] = e.rect
+      for (let tx = tx1; tx <= tx2; tx++)
+        for (let ty = ty1; ty <= ty2; ty++)
+          out.push([tx, ty])
+    } else if (e.tile) {
+      out.push([e.tile[0], e.tile[1]])
+    }
+  }
+  return out
+}
+
+type FlatDecorItem = { tx: number; ty: number; tileId: string; zlayer: Zlayer; sourceIndex: number }
+
+function flattenDecor(items: RawDecorItem[]): FlatDecorItem[] {
+  const out: FlatDecorItem[] = []
+  items.forEach((item, sourceIndex) => {
+    if (item.tx === undefined) return // comment-only entry
+    if (item.bundleID) {
+      const expanded = expandBundleDecor(item.bundleID, item.tx, item.ty ?? 0)
+      expanded.forEach(e => {
+        const tileKey = Object.keys(BASE_CHIP_TILES as Record<string, number>)
+          .find(k => (BASE_CHIP_TILES as Record<string, number>)[k] === e.tileId) ?? ''
+        if (tileKey) out.push({ tx: e.tx, ty: e.ty, tileId: tileKey, zlayer: (e.zlayer as Zlayer) ?? 'solid', sourceIndex })
+      })
+    } else if (item.tileId) {
+      out.push({ tx: item.tx, ty: item.ty ?? 0, tileId: item.tileId, zlayer: item.zlayer ?? 'solid', sourceIndex })
+    }
+  })
+  return out
+}
+
+interface Props {
+  configData:       RawMapConfig
+  tool:             ToolMode
+  showGrid:         boolean
+  selectedEntity:   SelectedEntity | null
+  viewMode:         'exterior' | 'interior'
+  activeInteriorId: string | null
+  activeTileId:     string | null
+  activeBundleId:   string | null
+  activeZlayer:     Zlayer
+  onSelectEntity:   (e: SelectedEntity | null) => void
+  onPlaceDecor:     (tx: number, ty: number) => void
+  onMoveEntity:     (entity: SelectedEntity, tx: number, ty: number) => void
+  onDeleteEntity:   (entity: SelectedEntity) => void
+}
+
+export function MapEditorCanvas(props: Props) {
+  const {
+    configData, tool, showGrid, selectedEntity, viewMode, activeInteriorId,
+    activeTileId, activeBundleId, activeZlayer,
+    onSelectEntity, onPlaceDecor, onMoveEntity, onDeleteEntity,
+  } = props
+
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  // Refs that event handlers read so they always get the latest values
+  const propsRef = useRef(props)
+  propsRef.current = props
+
+  // Drag state
+  const dragRef = useRef<{ entity: SelectedEntity; lastTx: number; lastTy: number } | null>(null)
+
+  // Render version counter — incremented on each render, so async sprite loads can detect staleness
+  const renderVersionRef = useRef(0)
+
+  // Compute canvas dimensions
+  const isInterior = viewMode === 'interior' && activeInteriorId
+  const interior   = isInterior ? configData.interiors?.[activeInteriorId!] : null
+  const mapW = isInterior ? (interior?.width  ?? 12) * T : configData.mapW
+  const mapH = isInterior ? (interior?.height ?? 9)  * T : configData.mapH
+
+  const appRef = usePixiApp(containerRef, mapW, mapH, useCallback((app: PIXI.Application) => {
+    const stage = app.stage
+    stage.eventMode = 'static'
+    stage.hitArea   = new PIXI.Rectangle(0, 0, mapW, mapH)
+
+    stage.on('pointerdown', (e: PIXI.FederatedPointerEvent) => {
+      const { tool: t, activeTileId: tid, activeBundleId: bid, viewMode: vm,
+               activeInteriorId: iid, configData: cfg } = propsRef.current
+      const pos = e.getLocalPosition(stage)
+      const tx  = Math.floor(pos.x / T)
+      const ty  = Math.floor(pos.y / T)
+
+      if (t === 'select') {
+        const entity = hitTest(cfg, tx, ty, vm, iid)
+        propsRef.current.onSelectEntity(entity)
+        if (entity) {
+          const etx = getEntityTx(cfg, entity)
+          const ety = getEntityTy(cfg, entity)
+          dragRef.current = { entity, lastTx: etx, lastTy: ety }
+        }
+      } else if (t === 'place' && (tid || bid)) {
+        propsRef.current.onPlaceDecor(tx, ty)
+      } else if (t === 'delete') {
+        const entity = hitTest(cfg, tx, ty, vm, iid)
+        if (entity) {
+          propsRef.current.onDeleteEntity(entity)
+          propsRef.current.onSelectEntity(null)
+        }
+      }
+    })
+
+    stage.on('pointermove', (e: PIXI.FederatedPointerEvent) => {
+      if (!dragRef.current) return
+      const { configData: cfg } = propsRef.current
+      const pos = e.getLocalPosition(stage)
+      const tx  = Math.floor(pos.x / T)
+      const ty  = Math.floor(pos.y / T)
+      const { entity, lastTx, lastTy } = dragRef.current
+      if (tx !== lastTx || ty !== lastTy) {
+        dragRef.current.lastTx = tx
+        dragRef.current.lastTy = ty
+        propsRef.current.onMoveEntity(entity, tx, ty)
+        void cfg // suppress lint
+      }
+    })
+
+    stage.on('pointerup',        () => { dragRef.current = null })
+    stage.on('pointerupoutside', () => { dragRef.current = null })
+  }, [mapW, mapH])) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Rebuild PixiJS scene on every render (configData / showGrid / selectedEntity changes)
+  useEffect(() => {
+    const app = appRef.current
+    if (!app) return
+    const stage = app.stage
+    const version = ++renderVersionRef.current
+
+    // Remove old scene children (keep stage itself)
+    const toRemove: PIXI.ContainerChild[] = []
+    for (let i = 0; i < stage.children.length; i++) toRemove.push(stage.children[i])
+    toRemove.forEach(c => stage.removeChild(c))
+
+    const groundLayer   = new PIXI.Container()
+    const streetLayer   = new PIXI.Container()
+    const buildingLayer = new PIXI.Container()
+    const decorBLayer   = new PIXI.Container()
+    const decorLayer    = new PIXI.Container()
+    const npcLayer      = new PIXI.Container()
+    const decorALayer   = new PIXI.Container()
+    const selLayer      = new PIXI.Graphics()
+    const gridLayer     = new PIXI.Graphics()
+
+    stage.addChild(groundLayer, streetLayer, buildingLayer,
+                   decorBLayer, decorLayer, npcLayer, decorALayer,
+                   selLayer, gridLayer)
+
+    if (isInterior && interior) {
+      renderInterior(version, groundLayer, decorBLayer, decorLayer, decorALayer, selLayer)
+    } else {
+      renderExterior(version, groundLayer, streetLayer, buildingLayer,
+                     decorBLayer, decorLayer, npcLayer, decorALayer, selLayer)
+    }
+
+    if (showGrid) drawGrid(gridLayer)
+    drawSelection(selLayer)
+  })
+
+  // ── Exterior rendering ─────────────────────────────────────────────────────────
+  function renderExterior(
+    version: number,
+    groundLayer: PIXI.Container, streetLayer: PIXI.Container, buildingLayer: PIXI.Container,
+    decorBLayer: PIXI.Container, decorLayer: PIXI.Container,
+    npcLayer: PIXI.Container, decorALayer: PIXI.Container,
+    selLayer: PIXI.Graphics,
+  ) {
+    const W = Math.ceil(configData.mapW / T)
+    const H = Math.ceil(configData.mapH / T)
+
+    // Ground
+    const gndGfx = new PIXI.Graphics()
+    gndGfx.rect(0, 0, W * T, H * T).fill(GROUND_COLOR)
+    groundLayer.addChild(gndGfx)
+
+    // Streets
+    const sGfx = new PIXI.Graphics()
+    for (const s of configData.streets ?? [])
+      for (const [tx, ty] of expandEntries([s]))
+        sGfx.rect(tx * T, ty * T, T, T).fill(STREET_COLOR)
+    streetLayer.addChild(sGfx)
+
+    // Ponds
+    const pGfx = new PIXI.Graphics()
+    for (const p of configData.pondTiles ?? [])
+      for (const [tx, ty] of expandEntries([p]))
+        pGfx.rect(tx * T, ty * T, T, T).fill(POND_COLOR)
+    streetLayer.addChild(pGfx)
+
+    // Buildings
+    const buildings = configData.buildings ?? []
+    buildings.forEach((b, bIdx) => {
+      const rects = b.rects ?? (b.rect ? [b.rect] : [])
+      const col   = WALL_COLORS[b.wall ?? ''] ?? 0x556677
+      const isSel = selectedEntity?.type === 'building' && selectedEntity.index === bIdx
+      const gfx   = new PIXI.Graphics()
+      for (const [tx1, ty1, tx2, ty2] of rects) {
+        gfx.rect(tx1 * T, ty1 * T, (tx2 - tx1 + 1) * T, (ty2 - ty1 + 1) * T).fill(col)
+        if (isSel)
+          gfx.rect(tx1 * T, ty1 * T, (tx2 - tx1 + 1) * T, (ty2 - ty1 + 1) * T)
+            .stroke({ color: 0xf0c040, width: 2 })
+      }
+      buildingLayer.addChild(gfx)
+      if (b.id && rects[0]) {
+        const [tx1, ty1, tx2, ty2] = rects[0]
+        const lbl = new PIXI.Text({ text: b.id, style: { fontSize: 9, fill: 0xeeeecc } })
+        lbl.x = (tx1 + (tx2 - tx1 + 1) / 2) * T - lbl.width / 2
+        lbl.y = (ty1 + (ty2 - ty1 + 1) / 2) * T - lbl.height / 2
+        buildingLayer.addChild(lbl)
+      }
+    })
+
+    // Exterior decor tiles
+    renderDecorItems(version, flattenDecor(configData.exteriorDecor ?? []),
+                     decorBLayer, decorLayer, decorALayer, 'exteriorDecor', '', selLayer)
+
+    // NPCs
+    const npcs = configData.npcs ?? []
+    npcs.forEach((npc, nIdx) => {
+      if (npc.building) return
+      const isSel = selectedEntity?.type === 'npc' && selectedEntity.index === nIdx
+      loadSpriteTexture(npc.sprite).then(tex => {
+        if (renderVersionRef.current !== version) return
+        const sp = new PIXI.Sprite(tex)
+        sp.width  = T * 1.5; sp.height = T * 1.5
+        sp.x      = npc.tx * T - T * 0.25
+        sp.y      = npc.ty * T - T * 0.5
+        sp.eventMode = 'static'; sp.cursor = 'pointer'
+        sp.on('pointerdown', (e: PIXI.FederatedPointerEvent) => {
+          e.stopPropagation()
+          propsRef.current.onSelectEntity({ type: 'npc', index: nIdx })
+        })
+        if (isSel) {
+          selLayer.rect(sp.x - 2, sp.y - 2, sp.width + 4, sp.height + 4)
+            .stroke({ color: 0xf0c040, width: 2 })
+        }
+        npcLayer.addChild(sp)
+      }).catch(() => {
+        if (renderVersionRef.current !== version) return
+        const g = new PIXI.Graphics()
+        g.circle(npc.tx * T + T / 2, npc.ty * T + T / 2, T / 3).fill(0xff88aa)
+        npcLayer.addChild(g)
+      })
+    })
+  }
+
+  // ── Interior rendering ─────────────────────────────────────────────────────────
+  function renderInterior(
+    version: number,
+    groundLayer: PIXI.Container,
+    decorBLayer: PIXI.Container, decorLayer: PIXI.Container, decorALayer: PIXI.Container,
+    selLayer: PIXI.Graphics,
+  ) {
+    if (!interior) return
+    const { width, height } = interior
+
+    const floorGfx = new PIXI.Graphics()
+    floorGfx.rect(0, 0, width * T, height * T).fill(0x5a4a3a)
+    groundLayer.addChild(floorGfx)
+
+    // Floor tiles
+    if (interior.floorTileId) {
+      const fid = tileNumericId(interior.floorTileId)
+      loadTileTexture(BASE_URL, fid, BASE_COLS).then(tex => {
+        if (renderVersionRef.current !== version) return
+        for (let tx = 0; tx < width; tx++) {
+          for (let ty = 0; ty < height; ty++) {
+            const sp = new PIXI.Sprite(tex)
+            sp.x = tx * T; sp.y = ty * T
+            groundLayer.addChild(sp)
+          }
+        }
+      }).catch(() => {})
+    }
+
+    // Walls
+    const wallGfx = new PIXI.Graphics()
+    wallGfx.rect(0, 0, width * T, T * 2).fill(0x3a3a4a)
+    wallGfx.rect(0, (height - 1) * T, width * T, T).fill(0x3a3a4a)
+    wallGfx.rect(0, 0, T, height * T).fill(0x3a3a4a)
+    wallGfx.rect((width - 1) * T, 0, T, height * T).fill(0x3a3a4a)
+    groundLayer.addChild(wallGfx)
+
+    const iid = activeInteriorId ?? ''
+    renderDecorItems(version, flattenDecor(interior.decor),
+                     decorBLayer, decorLayer, decorALayer, 'interiorDecor', iid, selLayer)
+  }
+
+  // ── Decor tile rendering ───────────────────────────────────────────────────────
+  function renderDecorItems(
+    version: number,
+    items: FlatDecorItem[],
+    decorBLayer: PIXI.Container, decorLayer: PIXI.Container, decorALayer: PIXI.Container,
+    entityType: 'exteriorDecor' | 'interiorDecor',
+    interiorId: string,
+    selLayer: PIXI.Graphics,
+  ) {
+    items.forEach(({ tx, ty, tileId, zlayer, sourceIndex }) => {
+      const numId = tileNumericId(tileId)
+      const layer = zlayer === 'below' ? decorBLayer : zlayer === 'above' ? decorALayer : decorLayer
+      const isSel = selectedEntity?.type === entityType &&
+        (entityType === 'exteriorDecor'
+          ? (selectedEntity as { index: number }).index === sourceIndex
+          : (selectedEntity as { index: number; interiorId: string }).index === sourceIndex &&
+            (selectedEntity as { interiorId: string }).interiorId === interiorId)
+
+      loadTileTexture(BASE_URL, numId, BASE_COLS).then(tex => {
+        if (renderVersionRef.current !== version) return
+        const sp = new PIXI.Sprite(tex)
+        sp.x = tx * T; sp.y = ty * T
+        sp.eventMode = 'static'; sp.cursor = 'pointer'
+        sp.on('pointerdown', (e: PIXI.FederatedPointerEvent) => {
+          e.stopPropagation()
+          const entity: SelectedEntity = entityType === 'exteriorDecor'
+            ? { type: 'exteriorDecor', index: sourceIndex }
+            : { type: 'interiorDecor', index: sourceIndex, interiorId }
+          propsRef.current.onSelectEntity(entity)
+        })
+        if (isSel) {
+          selLayer.rect(tx * T - 1, ty * T - 1, T + 2, T + 2)
+            .stroke({ color: 0xf0c040, width: 2 })
+        }
+        layer.addChild(sp)
+      }).catch(() => {
+        if (renderVersionRef.current !== version) return
+        const g = new PIXI.Graphics()
+        g.rect(tx * T + 4, ty * T + 4, T - 8, T - 8).fill(0x884422)
+        layer.addChild(g)
+      })
+    })
+  }
+
+  // ── Grid overlay ───────────────────────────────────────────────────────────────
+  function drawGrid(gfx: PIXI.Graphics) {
+    const wTiles = Math.ceil(mapW / T)
+    const hTiles = Math.ceil(mapH / T)
+    for (let x = 0; x <= wTiles; x++)
+      gfx.moveTo(x * T, 0).lineTo(x * T, hTiles * T).stroke({ color: 0x333355, width: 0.5, alpha: 0.4 })
+    for (let y = 0; y <= hTiles; y++)
+      gfx.moveTo(0, y * T).lineTo(wTiles * T, y * T).stroke({ color: 0x333355, width: 0.5, alpha: 0.4 })
+  }
+
+  // ── Selection highlight ────────────────────────────────────────────────────────
+  function drawSelection(gfx: PIXI.Graphics) {
+    if (!selectedEntity) return
+    let tx = -1, ty = -1
+    if (selectedEntity.type === 'exteriorDecor') {
+      const item = configData.exteriorDecor?.[selectedEntity.index]
+      if (item?.tx !== undefined) { tx = item.tx; ty = item.ty ?? 0 }
+    } else if (selectedEntity.type === 'npc') {
+      const npc = configData.npcs?.[selectedEntity.index]
+      if (npc) { tx = npc.tx; ty = npc.ty }
+    } else if (selectedEntity.type === 'interiorDecor' && selectedEntity.interiorId === activeInteriorId) {
+      const item = configData.interiors?.[selectedEntity.interiorId]?.decor[selectedEntity.index]
+      if (item?.tx !== undefined) { tx = item.tx; ty = item.ty ?? 0 }
+    }
+    if (tx >= 0) {
+      gfx.rect(tx * T - 2, ty * T - 2, T + 4, T + 4).stroke({ color: 0xf0c040, width: 2 })
+    }
+  }
+
+  return (
+    <div style={{ flex: 1, overflow: 'auto', background: '#0a0a1a', position: 'relative' }}>
+      <div ref={containerRef} style={{ display: 'inline-block' }} />
+    </div>
+  )
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function hitTest(
+  cfg: RawMapConfig, tx: number, ty: number,
+  viewMode: string, activeInteriorId: string | null,
+): SelectedEntity | null {
+  if (viewMode === 'interior' && activeInteriorId) {
+    const decor = cfg.interiors?.[activeInteriorId]?.decor ?? []
+    for (let i = decor.length - 1; i >= 0; i--) {
+      if (decor[i].tx === tx && decor[i].ty === ty)
+        return { type: 'interiorDecor', index: i, interiorId: activeInteriorId }
+    }
+    return null
+  }
+  const extDecor = cfg.exteriorDecor ?? []
+  for (let i = extDecor.length - 1; i >= 0; i--) {
+    if (extDecor[i].tx === tx && extDecor[i].ty === ty)
+      return { type: 'exteriorDecor', index: i }
+  }
+  const npcs = cfg.npcs ?? []
+  for (let i = npcs.length - 1; i >= 0; i--) {
+    if (!npcs[i].building && npcs[i].tx === tx && npcs[i].ty === ty)
+      return { type: 'npc', index: i }
+  }
+  const buildings = cfg.buildings ?? []
+  for (let i = buildings.length - 1; i >= 0; i--) {
+    const rects = buildings[i].rects ?? (buildings[i].rect ? [buildings[i].rect!] : [])
+    for (const [tx1, ty1, tx2, ty2] of rects) {
+      if (tx >= tx1 && tx <= tx2 && ty >= ty1 && ty <= ty2)
+        return { type: 'building', index: i }
+    }
+  }
+  return null
+}
+
+function getEntityTx(cfg: RawMapConfig, entity: SelectedEntity): number {
+  if (entity.type === 'exteriorDecor') return cfg.exteriorDecor?.[entity.index]?.tx ?? 0
+  if (entity.type === 'npc') return cfg.npcs?.[entity.index]?.tx ?? 0
+  if (entity.type === 'interiorDecor') return cfg.interiors?.[entity.interiorId]?.decor[entity.index]?.tx ?? 0
+  return 0
+}
+
+function getEntityTy(cfg: RawMapConfig, entity: SelectedEntity): number {
+  if (entity.type === 'exteriorDecor') return cfg.exteriorDecor?.[entity.index]?.ty ?? 0
+  if (entity.type === 'npc') return cfg.npcs?.[entity.index]?.ty ?? 0
+  if (entity.type === 'interiorDecor') return cfg.interiors?.[entity.interiorId]?.decor[entity.index]?.ty ?? 0
+  return 0
+}

--- a/web/src/components/mapEditor/MapEditorToolbar.tsx
+++ b/web/src/components/mapEditor/MapEditorToolbar.tsx
@@ -1,0 +1,166 @@
+import React, { useState } from 'react'
+import type { MapId, ToolMode } from './mapEditorTypes'
+import { saveMap } from './mapEditorApi'
+import type { RawMapConfig } from './mapEditorTypes'
+
+const MAP_OPTIONS: { id: MapId; label: string }[] = [
+  { id: 'hub',    label: 'Hub — Ravenwatch' },
+  { id: 'town2',  label: 'Town — Millhaven' },
+  { id: 'castle', label: 'Castle — Ironhold Keep' },
+]
+
+interface Props {
+  mapId:       MapId
+  tool:        ToolMode
+  canUndo:     boolean
+  canRedo:     boolean
+  isDirty:     boolean
+  showGrid:    boolean
+  configData:  RawMapConfig
+  onMapChange: (id: MapId) => void
+  onToolChange:(t: ToolMode) => void
+  onUndo:      () => void
+  onRedo:      () => void
+  onGridToggle:() => void
+  onSaved:     () => void
+}
+
+const TOOLS: { mode: ToolMode; label: string; title: string }[] = [
+  { mode: 'select', label: '↖', title: 'Select / Move (S)' },
+  { mode: 'place',  label: '✎', title: 'Place tile (P)' },
+  { mode: 'delete', label: '✕', title: 'Delete (D)' },
+]
+
+export function MapEditorToolbar({
+  mapId, tool, canUndo, canRedo, isDirty, showGrid,
+  configData, onMapChange, onToolChange, onUndo, onRedo, onGridToggle, onSaved,
+}: Props) {
+  const [saveState, setSaveState] = useState<'idle' | 'saving' | 'ok' | 'error'>('idle')
+  const [saveError, setSaveError] = useState('')
+
+  const handleSave = async () => {
+    setSaveState('saving')
+    setSaveError('')
+    try {
+      await saveMap(mapId, configData)
+      setSaveState('ok')
+      onSaved()
+      setTimeout(() => setSaveState('idle'), 2000)
+    } catch (e) {
+      setSaveState('error')
+      setSaveError(e instanceof Error ? e.message : String(e))
+      setTimeout(() => setSaveState('idle'), 4000)
+    }
+  }
+
+  const btnBase: React.CSSProperties = {
+    padding: '4px 10px', border: '1px solid #444', cursor: 'pointer',
+    borderRadius: 3, fontSize: 12, lineHeight: '1.4',
+  }
+
+  return (
+    <div style={{
+      display: 'flex', alignItems: 'center', gap: 8, padding: '0 12px',
+      background: '#12122a', borderBottom: '1px solid #333', height: 42, flexShrink: 0,
+    }}>
+      {/* Map selector */}
+      <select
+        value={mapId}
+        onChange={e => onMapChange(e.target.value as MapId)}
+        style={{
+          padding: '4px 6px', background: '#1e1e3e', border: '1px solid #444',
+          color: '#eee', borderRadius: 3, fontSize: 12, cursor: 'pointer',
+        }}
+      >
+        {MAP_OPTIONS.map(o => (
+          <option key={o.id} value={o.id}>{o.label}</option>
+        ))}
+      </select>
+
+      <div style={{ width: 1, height: 24, background: '#333' }} />
+
+      {/* Tool buttons */}
+      {TOOLS.map(t => (
+        <button
+          key={t.mode}
+          title={t.title}
+          onClick={() => onToolChange(t.mode)}
+          style={{
+            ...btnBase,
+            background: tool === t.mode ? '#2a3a7e' : '#1e1e3e',
+            color:      tool === t.mode ? '#8af' : '#888',
+            borderColor: tool === t.mode ? '#4a5aae' : '#444',
+            fontWeight: tool === t.mode ? 'bold' : 'normal',
+          }}
+        >
+          {t.label}
+        </button>
+      ))}
+
+      <div style={{ width: 1, height: 24, background: '#333' }} />
+
+      {/* Undo/Redo */}
+      <button
+        title="Undo (Ctrl+Z)"
+        onClick={onUndo}
+        disabled={!canUndo}
+        style={{ ...btnBase, background: '#1e1e3e', color: canUndo ? '#aaa' : '#444', borderColor: '#444' }}
+      >
+        ↩
+      </button>
+      <button
+        title="Redo (Ctrl+Y)"
+        onClick={onRedo}
+        disabled={!canRedo}
+        style={{ ...btnBase, background: '#1e1e3e', color: canRedo ? '#aaa' : '#444', borderColor: '#444' }}
+      >
+        ↪
+      </button>
+
+      <div style={{ width: 1, height: 24, background: '#333' }} />
+
+      {/* Grid toggle */}
+      <button
+        title="Toggle grid"
+        onClick={onGridToggle}
+        style={{
+          ...btnBase,
+          background: showGrid ? '#1e2e1e' : '#1e1e3e',
+          color:      showGrid ? '#6f6' : '#666',
+          borderColor: showGrid ? '#4a7a4a' : '#444',
+        }}
+      >
+        ⊞
+      </button>
+
+      <div style={{ flex: 1 }} />
+
+      {/* Save */}
+      {saveState === 'error' && (
+        <span style={{ color: '#f66', fontSize: 11 }}>{saveError}</span>
+      )}
+      <button
+        onClick={handleSave}
+        disabled={saveState === 'saving'}
+        style={{
+          ...btnBase,
+          background: saveState === 'ok'    ? '#1e4e1e'
+                    : saveState === 'error' ? '#4e1e1e'
+                    : isDirty               ? '#2a4e2a'
+                    : '#1e1e3e',
+          color: saveState === 'ok'    ? '#6f6'
+               : saveState === 'error' ? '#f66'
+               : isDirty               ? '#8d8'
+               : '#666',
+          borderColor: saveState === 'ok'    ? '#3a7a3a'
+                     : saveState === 'error' ? '#7a3a3a'
+                     : isDirty               ? '#3a6a3a'
+                     : '#444',
+          fontWeight: 'bold', minWidth: 60,
+        }}
+      >
+        {saveState === 'saving' ? '…' : saveState === 'ok' ? '✓ Saved' : 'Save'}
+      </button>
+    </div>
+  )
+}

--- a/web/src/components/mapEditor/TilePalette.tsx
+++ b/web/src/components/mapEditor/TilePalette.tsx
@@ -1,0 +1,368 @@
+import React, { useState, useMemo } from 'react'
+import { BASE_CHIP_TILES } from '../../data/tiles/baseChipIndex'
+import { getAllBundles } from '../../data/bundles/bundleLoader'
+import type { Zlayer } from './mapEditorTypes'
+
+const SHEET_URL = '/world/SampleMap/[Base]BaseChip_pipo.png'
+const COLS = 8
+const T = 32
+
+// Tile categories: ordered groups of tile keys shown in the palette
+const TILE_CATEGORIES: Record<string, string[]> = {
+  'Ground': [
+    'lightGrass', 'mediumGrass', 'darkGrass', 'dyingGrass',
+    'sand', 'lightDirt', 'mediumDirt', 'darkDirt',
+  ],
+  'Flooring': [
+    'woodFloor', 'darkWoodFloor', 'parquetFloor', 'darkParquetFloor',
+    'stoneFloor', 'cobblestoneFloor', 'smallStoneFloor', 'darkStoneFloor',
+    'darkCobblestoneFloor', 'checkeredFloor', 'darkCheckeredFloor',
+    'quarteredFloor', 'darkQuarteredFloor', 'diagonalFloor', 'darkDiagonalFloor',
+    'fourByFourTileFloor', 'darkFourByFourTileFloor',
+    'ornateFloor', 'blueOrnateFloor', 'meshFloor', 'lightMeshFloor',
+    'goldSmallTileFloor', 'redCarpetFloor', 'yellowCarpetFloor',
+    'fullLadderTop', 'halfLadderTop', 'ladderBottom', 'ladderIntoFloor',
+    'stepsUpFromLeft', 'stepsUpFromRight',
+  ],
+  'Plants & Nature': [
+    'lightBush', 'darkBush', 'autumnBush', 'deadBush',
+    'grassTuft', 'smallGrass', 'deadGrassTuft', 'deadSmallGrass',
+    'whiteFlower', 'pinkFlower', 'blueFlower', 'yellowFlower',
+    'brownMushroom', 'purpleMushroom',
+    'smallLilypad', 'largeLilypad',
+    'lightPuddle', 'darkPuddle', 'greenPuddle',
+    'tallBushTop', 'tallBushPot', 'spikyPlantTop', 'spikyPlantBottom',
+    'potOfFlowers', 'emptyPotOfFlowers', 'flowerPotLeft',
+  ],
+  'Trees': [
+    'lightTreeTopLeft', 'lightTreeTopRight',
+    'lightTreeBottomLeft', 'lightTreeBottomRight',
+    'lightTreeColumnLeft', 'lightTreeColumnRight',
+    'darkTreeTopLeft', 'darkTreeTopRight',
+    'darkTreeBottomLeft', 'darkTreeBottomRight',
+    'autumnTreeTopLeft', 'autumnTreeTopRight',
+    'autumnTreeBottomLeft', 'autumnTreeBottomRight',
+    'deadTreeTopLeft', 'deadTreeTopRight',
+    'deadTreeBottomLeft', 'deadTreeBottomRight',
+    'smallStump', 'largeStump',
+    'logLeft', 'logRight', 'logTop', 'logBottom',
+  ],
+  'Rocks & Natural': [
+    'smallRock', 'largeRock', 'hole',
+    'graveStone', 'graveWoodenCross',
+    'campfireUnlit', 'summoningCircle',
+    'goldenCross', 'stoneCross',
+  ],
+  'Fences': [
+    'fenceIsolated', 'fenceLeft', 'fenceRight', 'fenceTop', 'fenceTopBottom',
+    'fenceLeftRight', 'fenceTopRight', 'fenceLeftTop',
+    'fenceTopRightBottom', 'fenceLeftTopBottom', 'fenceRightBottom', 'fenceLeftBottom',
+    'fenceLeftRightTop', 'fenceLeftRightBottom', 'fenceLeftRightTopBottom',
+    'ironFenceIsolated', 'ironFenceLeft', 'ironFenceRight', 'ironFenceTop',
+    'ironFenceLeftRight', 'ironFenceTopRight', 'ironFenceLeftTop',
+    'ironFenceTopRightBottom', 'ironFenceLeftTopBottom',
+    'stoneWallIsolated', 'stoneWallLeft', 'stoneWallRight', 'stoneWallTop',
+    'stoneWallLeftRight', 'stoneWallTopRight', 'stoneWallLeftTop',
+  ],
+  'Furniture': [
+    'roundTable', 'roundTableWithCloth', 'deskTop',
+    'smallTableTopLeft', 'smallTableTopMiddle', 'smallTableTopRight',
+    'smallTableMiddleLeft', 'smallTableMiddleMiddle', 'smallTableMiddleRight',
+    'smallTableBottomLeft', 'smallTableBottomMiddle', 'smallTableBottomRight',
+    'bookshelfTop', 'bookshelfBottom',
+    'stool', 'stoolDark', 'stoolWithCover', 'stoolWithPurpleCushion',
+    'rugTopLeft', 'rugTopRight', 'rugBottomLeft', 'rugBottomRight',
+    'simpleBedHead', 'simpleBedFoot', 'simpleBedHeadOverlay', 'simpleBedFootOverlay',
+    'normalBedHead', 'normalBedFoot', 'normalBedHeadOverlay', 'normalBedFootOverlay',
+    'royalBedTopLeft', 'royalBedTopRight', 'royalBedBottonLeft', 'royalBedBottomRight',
+    'royalBedTopLeftOverlay', 'royalBedTopRightOverlay',
+    'royalBedBottonLeftOverlay', 'royalBedBottomRightOverlay',
+    'cauldren',
+  ],
+  'Storage & Items': [
+    'barrel', 'crate', 'openCrate', 'sack', 'pileOfSacks',
+    'chest', 'openChest', 'strongChest', 'openStrongChest', 'goldChest', 'openGoldChest',
+    'lightPotWithLid', 'lightPotWithoutLid', 'darkPotWithLid', 'darkPotWithoutLid',
+    'fullBucket', 'emptyBucket', 'logPile', 'choppingBlock',
+    'hayStack', 'emptyBasket', 'appleBasket', 'leafBasket', 'mushroomBasket',
+    'smallChest', 'gift', 'pileOfCoins',
+    'mugOfCoffee', 'teapot', 'cupOfTea', 'rolledMap', 'note', 'pileOfPapers',
+    'quilAndInk', 'smallSack', 'bunchOfHerbs',
+    'closedBook', 'openBook', 'blueclosedBook', 'blueopenBook',
+    'blackclosedBook', 'blackopenBook', 'greenclosedBook', 'greenopenBook',
+    'plateEmpty', 'bottlesOfLiquor', 'potions', 'pendant',
+    'sword', 'axe', 'skull', 'key', 'shieldMounted',
+    'wallClock', 'wallClock2', 'mirrorTop', 'mirrorBottom', 'painting',
+    'candlestickLitTop', 'candlestickLitBottom', 'candlestickUnlit',
+    'wallNotes', 'wallNotesTop', 'wallNotesBottom', 'wantedPosterTop', 'wantedPosterBottom',
+    'crownOfCushon', 'teddy', 'doll', 'toy',
+  ],
+  'Exterior Decor': [
+    'stoneWell', 'bucketAndRope', 'mailBox',
+    'roadSignTop', 'roadSignBottom', 'smallSign', 'mediumSign', 'largeSign',
+    'messageBoardTopLeft', 'messageBoardTopRight',
+    'messageBoardBottomLeft', 'messageBoardBottomRight',
+    'lampPostTop', 'lampPostBottom',
+    'benchLeft', 'benchMiddle', 'benchRight',
+    'darkPillarTop', 'darkPillarMiddle', 'darkPillarBottom',
+    'lightPillarTop', 'lightPillarMiddle', 'lightPillarBottom',
+    'birdBathTop', 'birdBathMiddle', 'birdBathBottom',
+    'brazierTop', 'brazierBottom',
+    'knightTop', 'knightBottom',
+    'angelStatueTop', 'angelStatueBottom',
+    'gargoyleTop', 'gargoyleBottom',
+    'memorialTopLeft', 'memorialTopRight', 'memorialBotLeft', 'memorialBotRight',
+    'stripedShopAwningTop', 'stripedShopAwningMiddle', 'stripedShopAwningBottom',
+    'stripedShopAwningWithSupport', 'stripedShopAwningSupportPillar', 'stripedShopAwningSupportPillarBot',
+    'plainShowAwningTop', 'plainShowAwningMiddle', 'plainShowAwningBottom',
+    'fountainTopLeft', 'fountainTopMiddle', 'fountainTopRight',
+    'fountainMidLeft', 'fountainMidMiddle', 'fountainMidRight',
+    'fountainBotLeft', 'fountainBotMiddle', 'fountainBotRight',
+    'boardwalkVertical', 'boardwalkHorizontal',
+    'boardwalkVerticalSupport', 'boardwalkHorizontalSupport',
+    'chimneyTop', 'chimneyMiddle', 'chimneyBottom', 'chimneyShort',
+    'portcullisTopLeft', 'portcullisTopRight', 'portcullisBottomLeft', 'portcullisBottomRight',
+    'bellTowerTop', 'bellTowerBottom',
+    'worldMapTopLeft', 'worldMapTopRight', 'worldMapBottomLeft', 'worldMapBottomRight',
+  ],
+  'Signs': [
+    'weaponsSign', 'armourSign', 'bagSign', 'foodSign', 'drinkSign',
+    'teaSign', 'magicSign', 'ringSign', 'innSign', 'healthSign',
+    'appleSign', 'bookSign', 'goldSign', 'wolfSign', 'skullSign', 'blankSign',
+  ],
+  'Windows & Doors': [
+    'windowTop', 'windowBottom', 'windowTop2', 'windowBottom2',
+    'windowTop3', 'windowBottom3', 'windowTop4', 'windowBottom4',
+    'doorTop', 'doorBottom',
+    'strongDoorTopLeft', 'strongDoorTopRight',
+    'strongDoorBottomLeft', 'strongDoorBottomRight',
+  ],
+  'Farming': [
+    'topLeftPlough', 'topPlough', 'topRightPlough',
+    'leftPlough', 'centerPlough', 'rightPlough',
+    'bottomLeftPlough', 'bottomPlough', 'bottomRightPlough', 'isolatedPlough',
+    'scarecrowTop', 'scarecrowBottom',
+    'cropShoot', 'cropWheatTop', 'cropWheatMiddle', 'cropWheatBottom',
+    'cropCarrot', 'cropSpinach', 'cropDead',
+    'cropPumkin', 'cropLettuce', 'cropRose', 'cropBeans', 'cropBerries',
+  ],
+  'Washing & Misc': [
+    'washingLineEmptyTopLeft', 'washingLineEmptyTopRight',
+    'washingLineEmptyBottomLeft', 'washingLineEmptyBottomRight',
+    'washingLineTopLeft', 'washingLineTopRight',
+    'washingLineBottomLeft', 'washingLineBottomRight',
+    'washingLineClothesTopLeft', 'washingLineClothesTopRight',
+    'washingLineClothesBottomLeft', 'washingLineClothesBottomRight',
+    'stoneStairsUpLeftTop', 'stoneStairsUpRightTop',
+    'stoneStairsUpLeftMiddle', 'stoneStairsUpMiddleMiddle', 'stoneStairsUpRightMiddle',
+    'stoneStairsUpLeftBottom', 'stoneStairsUpMiddleBottom', 'stoneStairsUpRightBottom',
+  ],
+}
+
+type PaletteTab = 'tiles' | 'bundles'
+
+interface Props {
+  activeTileId:   string | null
+  activeBundleId: string | null
+  activeZlayer:   Zlayer
+  onSelectTile:   (tileId: string) => void
+  onSelectBundle: (bundleId: string) => void
+  onZlayerChange: (z: Zlayer) => void
+}
+
+function TileCell({
+  tileKey,
+  numericId,
+  isSelected,
+  onClick,
+}: {
+  tileKey: string
+  numericId: number
+  isSelected: boolean
+  onClick: () => void
+}) {
+  const col = numericId % COLS
+  const row = Math.floor(numericId / COLS)
+  return (
+    <div
+      title={tileKey}
+      onClick={onClick}
+      style={{
+        width:            T,
+        height:           T,
+        backgroundImage:  `url("${SHEET_URL}")`,
+        backgroundPosition: `-${col * T}px -${row * T}px`,
+        backgroundRepeat: 'no-repeat',
+        imageRendering:   'pixelated',
+        cursor:           'pointer',
+        outline:          isSelected ? '2px solid #f0c040' : '1px solid transparent',
+        outlineOffset:    '-1px',
+        flexShrink:       0,
+      }}
+    />
+  )
+}
+
+export function TilePalette({ activeTileId, activeBundleId, activeZlayer, onSelectTile, onSelectBundle, onZlayerChange }: Props) {
+  const [tab, setTab]         = useState<PaletteTab>('tiles')
+  const [search, setSearch]   = useState('')
+  const [openCats, setOpenCats] = useState<Set<string>>(() => new Set(['Exterior Decor', 'Furniture', 'Storage & Items']))
+
+  const bundles = useMemo(() => getAllBundles(), [])
+
+  const toggleCat = (cat: string) => {
+    setOpenCats(prev => {
+      const next = new Set(prev)
+      if (next.has(cat)) next.delete(cat)
+      else next.add(cat)
+      return next
+    })
+  }
+
+  const filteredCategories = useMemo(() => {
+    if (!search.trim()) return TILE_CATEGORIES
+    const q = search.toLowerCase()
+    const result: Record<string, string[]> = {}
+    for (const [cat, keys] of Object.entries(TILE_CATEGORIES)) {
+      const matched = keys.filter(k => k.toLowerCase().includes(q))
+      if (matched.length > 0) result[cat] = matched
+    }
+    return result
+  }, [search])
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%', background: '#1a1a2e', color: '#ccc', fontSize: 12 }}>
+      {/* Tabs */}
+      <div style={{ display: 'flex', borderBottom: '1px solid #333' }}>
+        {(['tiles', 'bundles'] as PaletteTab[]).map(t => (
+          <button
+            key={t}
+            onClick={() => setTab(t)}
+            style={{
+              flex: 1, padding: '6px 0', background: tab === t ? '#2a2a4e' : 'transparent',
+              border: 'none', color: tab === t ? '#f0c040' : '#888', cursor: 'pointer',
+              fontWeight: tab === t ? 'bold' : 'normal', fontSize: 12,
+            }}
+          >
+            {t.charAt(0).toUpperCase() + t.slice(1)}
+          </button>
+        ))}
+      </div>
+
+      {tab === 'tiles' && (
+        <>
+          {/* Z-layer selector */}
+          <div style={{ padding: '6px 8px', borderBottom: '1px solid #333', display: 'flex', gap: 4, alignItems: 'center' }}>
+            <span style={{ color: '#888', marginRight: 4 }}>Z:</span>
+            {(['solid', 'below', 'above'] as Zlayer[]).map(z => (
+              <button
+                key={z}
+                onClick={() => onZlayerChange(z)}
+                style={{
+                  padding: '2px 6px', fontSize: 11, cursor: 'pointer',
+                  background: activeZlayer === z ? '#f0c040' : '#333',
+                  color: activeZlayer === z ? '#1a1a2e' : '#aaa',
+                  border: 'none', borderRadius: 3,
+                }}
+              >
+                {z}
+              </button>
+            ))}
+          </div>
+
+          {/* Search */}
+          <div style={{ padding: '6px 8px', borderBottom: '1px solid #333' }}>
+            <input
+              type="text"
+              placeholder="Search tiles…"
+              value={search}
+              onChange={e => setSearch(e.target.value)}
+              style={{
+                width: '100%', padding: '4px 6px', background: '#111', border: '1px solid #444',
+                color: '#ccc', borderRadius: 3, fontSize: 12, boxSizing: 'border-box',
+              }}
+            />
+          </div>
+
+          {/* Tile categories */}
+          <div style={{ flex: 1, overflowY: 'auto' }}>
+            {Object.entries(filteredCategories).map(([cat, keys]) => (
+              <div key={cat}>
+                <button
+                  onClick={() => toggleCat(cat)}
+                  style={{
+                    width: '100%', padding: '5px 8px', background: '#252540',
+                    border: 'none', borderBottom: '1px solid #333', color: '#bbb',
+                    textAlign: 'left', cursor: 'pointer', fontSize: 11, fontWeight: 'bold',
+                    display: 'flex', justifyContent: 'space-between',
+                  }}
+                >
+                  <span>{cat}</span>
+                  <span style={{ color: '#666' }}>{openCats.has(cat) || search ? '▼' : '▶'}</span>
+                </button>
+                {(openCats.has(cat) || !!search.trim()) && (
+                  <div style={{ display: 'flex', flexWrap: 'wrap', padding: 4, gap: 2, background: '#111' }}>
+                    {keys.map(key => {
+                      const id = (BASE_CHIP_TILES as Record<string, number>)[key]
+                      if (id === undefined) return null
+                      return (
+                        <TileCell
+                          key={key}
+                          tileKey={key}
+                          numericId={id}
+                          isSelected={activeTileId === key}
+                          onClick={() => onSelectTile(key)}
+                        />
+                      )
+                    })}
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+
+      {tab === 'bundles' && (
+        <div style={{ flex: 1, overflowY: 'auto', padding: 8 }}>
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+            {bundles.map(bundle => {
+              const firstDecor = bundle.tiles.find(t => t.type === 'decor')
+              const previewId = firstDecor?.tileId ?? 0
+              const col = previewId % COLS
+              const row = Math.floor(previewId / COLS)
+              const isSelected = activeBundleId === bundle.bundleID
+              return (
+                <div
+                  key={bundle.bundleID}
+                  title={bundle.bundleID}
+                  onClick={() => onSelectBundle(bundle.bundleID)}
+                  style={{
+                    display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 2,
+                    cursor: 'pointer', padding: 4,
+                    background: isSelected ? '#2a2a4e' : '#1a1a2e',
+                    border: isSelected ? '1px solid #f0c040' : '1px solid #333',
+                    borderRadius: 4, minWidth: 56,
+                  }}
+                >
+                  <div
+                    style={{
+                      width: T, height: T,
+                      backgroundImage: `url("${SHEET_URL}")`,
+                      backgroundPosition: `-${col * T}px -${row * T}px`,
+                      backgroundRepeat: 'no-repeat',
+                      imageRendering: 'pixelated',
+                    }}
+                  />
+                  <span style={{ fontSize: 10, color: '#aaa', textAlign: 'center', wordBreak: 'break-all', maxWidth: 64 }}>
+                    {bundle.bundleID}
+                  </span>
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/mapEditor/mapEditorApi.ts
+++ b/web/src/components/mapEditor/mapEditorApi.ts
@@ -1,0 +1,11 @@
+export async function saveMap(mapId: string, data: unknown): Promise<void> {
+  const res = await fetch('/api/map-editor/save', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ mapId, data }),
+  })
+  if (!res.ok) {
+    const text = await res.text().catch(() => res.statusText)
+    throw new Error(`Save failed: ${text}`)
+  }
+}

--- a/web/src/components/mapEditor/mapEditorTypes.ts
+++ b/web/src/components/mapEditor/mapEditorTypes.ts
@@ -1,0 +1,145 @@
+import type { WallMaterial, RoofMaterial } from '../../data/tiles/buildingMaterials'
+
+export type MapId = 'hub' | 'town2' | 'castle'
+export type ToolMode = 'select' | 'place' | 'delete'
+export type Zlayer = 'solid' | 'below' | 'above'
+export type ViewMode = 'exterior' | 'interior'
+
+// Raw JSON shapes — matches what config.json actually stores
+export interface RawDecorItem {
+  tx?: number
+  ty?: number
+  tileId?: string
+  zlayer?: Zlayer
+  bundleID?: string
+  comment?: string
+}
+
+export interface RawBuildingDoor {
+  tx: number
+  ty: number
+  buildingId?: string
+}
+
+export interface RawBuildingWindow {
+  tx: number
+  ty: number
+  tileId: string
+}
+
+export interface RawBuilding {
+  rect?: [number, number, number, number]
+  rects?: [number, number, number, number][]
+  id?: string
+  wall?: WallMaterial
+  roof?: RoofMaterial
+  bundleID?: string
+  doors?: RawBuildingDoor[]
+  windows?: RawBuildingWindow[]
+  decor?: RawDecorItem[]
+}
+
+export interface RawNpc {
+  id: string
+  name: string
+  sprite: string
+  tx: number
+  ty: number
+  dialogue: string[]
+  building?: string
+  questGive?: string
+  questReceive?: string | string[]
+  isGhost?: boolean
+  schedule?: Array<{
+    startHour: number
+    endHour: number
+    location:
+      | { type: 'exterior'; tx: number; ty: number }
+      | { type: 'interior'; buildingId: string; tx: number; ty: number }
+  }>
+  homeBed?: { buildingId: string; tx: number; ty: number }
+  innRumours?: Array<{ id: string; text: string }>
+}
+
+export interface RawInterior {
+  name: string
+  width: number
+  height: number
+  floorTileId: string
+  wallTileId?: string
+  wallMaterial?: string
+  decor: RawDecorItem[]
+  hours?: { open: number; close: number } | 'always'
+  exits?: Array<{
+    tx: number
+    ty: number
+    toInteriorId: string
+    entryTx?: number
+    entryTy?: number
+    direction?: 'up' | 'down'
+    lockedBy?: string
+    requiredQuest?: string
+    label?: string
+  }>
+}
+
+export interface RawMapConfig {
+  mapW: number
+  mapH: number
+  townName: string
+  avatarStart: [number, number]
+  exitTiles?: Array<{ tx: number; ty: number; screen: string }>
+  areas?: Array<{ id: string; name: string; tx: number; ty: number; tw: number; th: number }>
+  streets?: Array<{ rect?: number[]; tile?: number[]; pathType?: string }>
+  buildings?: RawBuilding[]
+  exteriorDecor?: RawDecorItem[]
+  pondTiles?: Array<{ rect?: number[]; tile?: number[] }>
+  interiors?: Record<string, RawInterior>
+  npcs?: RawNpc[]
+  doors?: Array<{ buildingId: string; tx: number; ty: number; tyAdjust?: number }>
+  npcSpawnTiles?: [number, number][]
+  ambientNpcSprites?: string[]
+  treasures?: Array<{
+    id: string
+    tx: number
+    ty: number
+    tileId: string
+    title: string
+    buildingId?: string
+    collectedTileId?: string
+    reward: Record<string, unknown>
+  }>
+  pickupItems?: Array<{
+    id: string
+    tx: number
+    ty: number
+    tileId: string
+    building?: string
+    questId?: string
+    chain?: string
+    requireTouch?: boolean
+  }>
+  blockedPaths?: unknown[]
+  lockedDoors?: unknown[]
+}
+
+export type SelectedEntity =
+  | { type: 'exteriorDecor'; index: number }
+  | { type: 'npc'; index: number }
+  | { type: 'building'; index: number }
+  | { type: 'interiorDecor'; interiorId: string; index: number }
+
+export interface MapEditorState {
+  mapId: MapId
+  configData: RawMapConfig
+  tool: ToolMode
+  activeTileId: string | null
+  activeBundleId: string | null
+  activeZlayer: Zlayer
+  viewMode: ViewMode
+  activeInteriorId: string | null
+  selectedEntity: SelectedEntity | null
+  undoStack: RawMapConfig[]
+  redoStack: RawMapConfig[]
+  isDirty: boolean
+}

--- a/web/src/components/mapEditor/useMapEditorState.ts
+++ b/web/src/components/mapEditor/useMapEditorState.ts
@@ -1,0 +1,279 @@
+import { useState, useCallback } from 'react'
+import type { MapId, RawMapConfig, SelectedEntity, ToolMode, Zlayer, MapEditorState } from './mapEditorTypes'
+import hubConfig from '../../data/hub/config.json'
+import town2Config from '../../data/town2/config.json'
+import castleConfig from '../../data/castle/config.json'
+
+const RAW_CONFIGS: Record<MapId, RawMapConfig> = {
+  hub:    hubConfig    as unknown as RawMapConfig,
+  town2:  town2Config  as unknown as RawMapConfig,
+  castle: castleConfig as unknown as RawMapConfig,
+}
+
+const MAX_UNDO = 50
+
+export function useMapEditorState(initialMapId: MapId = 'hub') {
+  const [state, setState] = useState<MapEditorState>(() => ({
+    mapId:            initialMapId,
+    configData:       structuredClone(RAW_CONFIGS[initialMapId]),
+    tool:             'select',
+    activeTileId:     null,
+    activeBundleId:   null,
+    activeZlayer:     'solid',
+    viewMode:         'exterior',
+    activeInteriorId: null,
+    selectedEntity:   null,
+    undoStack:        [],
+    redoStack:        [],
+    isDirty:          false,
+  }))
+
+  const setMapId = useCallback((mapId: MapId) => {
+    setState(s => ({
+      ...s,
+      mapId,
+      configData:       structuredClone(RAW_CONFIGS[mapId]),
+      selectedEntity:   null,
+      viewMode:         'exterior',
+      activeInteriorId: null,
+      undoStack:        [],
+      redoStack:        [],
+      isDirty:          false,
+    }))
+  }, [])
+
+  const setTool = useCallback((tool: ToolMode) => {
+    setState(s => ({ ...s, tool }))
+  }, [])
+
+  const setActiveTile = useCallback((tileId: string | null, bundleId?: string) => {
+    setState(s => ({
+      ...s,
+      activeTileId:   tileId,
+      activeBundleId: bundleId ?? null,
+      tool:           (tileId || bundleId) ? 'place' : s.tool,
+    }))
+  }, [])
+
+  const setZlayer = useCallback((zlayer: Zlayer) => {
+    setState(s => ({ ...s, activeZlayer: zlayer }))
+  }, [])
+
+  const openInterior = useCallback((interiorId: string) => {
+    setState(s => ({ ...s, viewMode: 'interior', activeInteriorId: interiorId, selectedEntity: null }))
+  }, [])
+
+  const closeInterior = useCallback(() => {
+    setState(s => ({ ...s, viewMode: 'exterior', activeInteriorId: null, selectedEntity: null }))
+  }, [])
+
+  const selectEntity = useCallback((entity: SelectedEntity | null) => {
+    setState(s => ({ ...s, selectedEntity: entity }))
+  }, [])
+
+  const placeDecor = useCallback((tx: number, ty: number) => {
+    setState(s => {
+      if (!s.activeTileId && !s.activeBundleId) return s
+      const prevConfig = s.configData
+      const newItem = s.activeBundleId
+        ? { tx, ty, bundleID: s.activeBundleId, zlayer: s.activeZlayer }
+        : { tx, ty, tileId: s.activeTileId!, zlayer: s.activeZlayer }
+
+      let newConfig: RawMapConfig
+      if (s.viewMode === 'exterior') {
+        newConfig = { ...prevConfig, exteriorDecor: [...(prevConfig.exteriorDecor ?? []), newItem] }
+      } else if (s.viewMode === 'interior' && s.activeInteriorId) {
+        const interior = prevConfig.interiors?.[s.activeInteriorId]
+        if (!interior) return s
+        newConfig = {
+          ...prevConfig,
+          interiors: {
+            ...prevConfig.interiors,
+            [s.activeInteriorId]: { ...interior, decor: [...interior.decor, newItem] },
+          },
+        }
+      } else {
+        return s
+      }
+
+      return {
+        ...s,
+        configData: newConfig,
+        undoStack:  [...s.undoStack, prevConfig].slice(-MAX_UNDO),
+        redoStack:  [],
+        isDirty:    true,
+      }
+    })
+  }, [])
+
+  const moveEntity = useCallback((entity: SelectedEntity, tx: number, ty: number) => {
+    setState(s => {
+      const prevConfig = s.configData
+      let newConfig = prevConfig
+
+      if (entity.type === 'exteriorDecor') {
+        const decor = [...(prevConfig.exteriorDecor ?? [])]
+        if (!decor[entity.index]) return s
+        decor[entity.index] = { ...decor[entity.index], tx, ty }
+        newConfig = { ...prevConfig, exteriorDecor: decor }
+      } else if (entity.type === 'npc') {
+        const npcs = [...(prevConfig.npcs ?? [])]
+        if (!npcs[entity.index]) return s
+        npcs[entity.index] = { ...npcs[entity.index], tx, ty }
+        newConfig = { ...prevConfig, npcs }
+      } else if (entity.type === 'interiorDecor' && prevConfig.interiors?.[entity.interiorId]) {
+        const interior = prevConfig.interiors[entity.interiorId]
+        const decor = [...interior.decor]
+        if (!decor[entity.index]) return s
+        decor[entity.index] = { ...decor[entity.index], tx, ty }
+        newConfig = {
+          ...prevConfig,
+          interiors: { ...prevConfig.interiors, [entity.interiorId]: { ...interior, decor } },
+        }
+      }
+
+      if (newConfig === prevConfig) return s
+      return {
+        ...s,
+        configData: newConfig,
+        undoStack:  [...s.undoStack, prevConfig].slice(-MAX_UNDO),
+        redoStack:  [],
+        isDirty:    true,
+      }
+    })
+  }, [])
+
+  const deleteEntity = useCallback((entity: SelectedEntity) => {
+    setState(s => {
+      const prevConfig = s.configData
+      let newConfig = prevConfig
+
+      if (entity.type === 'exteriorDecor') {
+        newConfig = { ...prevConfig, exteriorDecor: (prevConfig.exteriorDecor ?? []).filter((_, i) => i !== entity.index) }
+      } else if (entity.type === 'npc') {
+        newConfig = { ...prevConfig, npcs: (prevConfig.npcs ?? []).filter((_, i) => i !== entity.index) }
+      } else if (entity.type === 'interiorDecor' && prevConfig.interiors?.[entity.interiorId]) {
+        const interior = prevConfig.interiors[entity.interiorId]
+        newConfig = {
+          ...prevConfig,
+          interiors: {
+            ...prevConfig.interiors,
+            [entity.interiorId]: { ...interior, decor: interior.decor.filter((_, i) => i !== entity.index) },
+          },
+        }
+      }
+
+      if (newConfig === prevConfig) return s
+      return {
+        ...s,
+        configData:     newConfig,
+        selectedEntity: null,
+        undoStack:      [...s.undoStack, prevConfig].slice(-MAX_UNDO),
+        redoStack:      [],
+        isDirty:        true,
+      }
+    })
+  }, [])
+
+  const updateDecorZlayer = useCallback((entity: SelectedEntity, zlayer: Zlayer) => {
+    setState(s => {
+      const prevConfig = s.configData
+      let newConfig = prevConfig
+
+      if (entity.type === 'exteriorDecor') {
+        const decor = [...(prevConfig.exteriorDecor ?? [])]
+        if (!decor[entity.index]) return s
+        decor[entity.index] = { ...decor[entity.index], zlayer }
+        newConfig = { ...prevConfig, exteriorDecor: decor }
+      } else if (entity.type === 'interiorDecor' && prevConfig.interiors?.[entity.interiorId]) {
+        const interior = prevConfig.interiors[entity.interiorId]
+        const decor = [...interior.decor]
+        if (!decor[entity.index]) return s
+        decor[entity.index] = { ...decor[entity.index], zlayer }
+        newConfig = {
+          ...prevConfig,
+          interiors: { ...prevConfig.interiors, [entity.interiorId]: { ...interior, decor } },
+        }
+      }
+
+      if (newConfig === prevConfig) return s
+      return {
+        ...s,
+        configData: newConfig,
+        undoStack:  [...s.undoStack, prevConfig].slice(-MAX_UNDO),
+        redoStack:  [],
+        isDirty:    true,
+      }
+    })
+  }, [])
+
+  const updateNpcDialogue = useCallback((index: number, dialogue: string[]) => {
+    setState(s => {
+      const prevConfig = s.configData
+      const npcs = [...(prevConfig.npcs ?? [])]
+      if (!npcs[index]) return s
+      npcs[index] = { ...npcs[index], dialogue }
+      return {
+        ...s,
+        configData: { ...prevConfig, npcs },
+        undoStack:  [...s.undoStack, prevConfig].slice(-MAX_UNDO),
+        redoStack:  [],
+        isDirty:    true,
+      }
+    })
+  }, [])
+
+  const undo = useCallback(() => {
+    setState(s => {
+      if (s.undoStack.length === 0) return s
+      const undoStack = [...s.undoStack]
+      const prevConfig = undoStack.pop()!
+      return {
+        ...s,
+        configData:     prevConfig,
+        undoStack,
+        redoStack:      [s.configData, ...s.redoStack],
+        selectedEntity: null,
+        isDirty:        undoStack.length > 0,
+      }
+    })
+  }, [])
+
+  const redo = useCallback(() => {
+    setState(s => {
+      if (s.redoStack.length === 0) return s
+      const redoStack = [...s.redoStack]
+      const nextConfig = redoStack.shift()!
+      return {
+        ...s,
+        configData: nextConfig,
+        undoStack:  [...s.undoStack, s.configData],
+        redoStack,
+        isDirty:    true,
+      }
+    })
+  }, [])
+
+  const markSaved = useCallback(() => {
+    setState(s => ({ ...s, isDirty: false }))
+  }, [])
+
+  return {
+    state,
+    setMapId,
+    setTool,
+    setActiveTile,
+    setZlayer,
+    openInterior,
+    closeInterior,
+    selectEntity,
+    placeDecor,
+    moveEntity,
+    deleteEntity,
+    updateDecorZlayer,
+    updateNpcDialogue,
+    undo,
+    redo,
+    markSaved,
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a dev-only visual map editor accessible in Storybook under **Map Editor / MapEditor** with three stories: Hub (Ravenwatch), Town2 (Millhaven), Castle (Ironhold Keep)
- PixiJS canvas previews building footprints, streets, ponds, exterior decor as actual tile sprites, and NPC sprites
- Tile palette with 800+ tiles grouped into 12 categories (Ground, Flooring, Plants, Trees, Fences, Furniture, Storage, Exterior Decor, Signs, Windows/Doors, Farming) + a Bundles tab for multi-tile furniture
- Entity inspector with position editing, z-layer selector (solid/below/above), NPC dialogue editing, and building→interior drill-in
- Interior editing mode: click "Edit Interior" to switch to an interior view with the same decor editing tools
- Save button POSTs to `/api/map-editor/save` — a dev-only Vite middleware added to `.storybook/main.ts` (via `viteFinal`) that writes directly back to the source `config.json` files

## Tools & Interactions

| Tool | Key | Action |
|------|-----|--------|
| Select/Move | `S` | Click to select; drag to reposition on grid |
| Place | `P` | Select a tile from palette, click canvas to place |
| Delete | `D` | Click an entity to remove it |
| Undo/Redo | `Ctrl+Z` / `Ctrl+Y` | Up to 50 steps |
| Delete selected | `Delete` / `Backspace` | Remove currently selected entity |

## Architecture

```
web/src/components/mapEditor/
├── MapEditor.tsx              # Three-pane layout (palette | canvas | inspector)
├── MapEditor.stories.tsx      # Storybook stories (Hub / Town2 / Castle)
├── MapEditorCanvas.tsx        # PixiJS rendering + pointer interaction
├── TilePalette.tsx            # CSS background-image tile grid + bundles tab
├── EntityInspector.tsx        # Properties panel for selected entity
├── MapEditorToolbar.tsx       # Map picker, tools, undo/redo, save
├── useMapEditorState.ts       # All editing state + undo/redo history
├── mapEditorTypes.ts          # TypeScript types for raw config + editor state
└── mapEditorApi.ts            # POST /api/map-editor/save
web/.storybook/main.ts         # +viteFinal plugin with save middleware
```

## Test plan

- [ ] `npm run storybook` in `web/` → open "Map Editor / MapEditor → Hub"
- [ ] Verify map renders: green ground, brown building footprints with IDs, tan streets, decor tile sprites appear as textures load
- [ ] Tile palette: verify categories expand/collapse, search narrows results, tiles show as thumbnails
- [ ] Select tool: click a decor item → inspector shows tile, position, z-layer controls
- [ ] Drag: drag a decor item to a new position → it moves
- [ ] Place tool: select a tile from palette → click canvas → new decor appears
- [ ] Z-layer: change a decor item's zlayer → inspector reflects change
- [ ] Delete: switch to delete tool, click an entity → it's removed
- [ ] Interior: click a building → "Edit Interior" → canvas shows floor tiles + interior decor
- [ ] Undo/Redo: place tiles, Ctrl+Z undoes them
- [ ] Save: click Save → check `git diff web/src/data/hub/config.json` shows changes
- [ ] Map switch: switch to Town2/Castle → canvas resizes to match map dimensions

---
_Generated by [Claude Code](https://claude.ai/code/session_01KmN48EipsbwTGAsrkJsEVW)_