### PR TITLE
feat(map-editor): drag to move buildings and street/path entries

### DIFF
--- a/web/.storybook/main.ts
+++ b/web/.storybook/main.ts
@@ -1,17 +1,7 @@
 import type { StorybookConfig } from '@storybook/react-vite'
 import { writeFileSync } from 'fs'
-import { resolve, dirname } from 'path'
-import { fileURLToPath } from 'url'
+import { resolve } from 'path'
 import type { IncomingMessage, ServerResponse } from 'http'
-
-const __filename = fileURLToPath(import.meta.url)
-const __dirname  = dirname(__filename)
-
-const MAP_PATHS: Record<string, string> = {
-  hub:    resolve(__dirname, '../src/data/hub/config.json'),
-  town2:  resolve(__dirname, '../src/data/town2/config.json'),
-  castle: resolve(__dirname, '../src/data/castle/config.json'),
-}
 
 const config: StorybookConfig = {
   stories: [
@@ -28,17 +18,23 @@ const config: StorybookConfig = {
   framework: '@storybook/react-vite',
 
   viteFinal: async (viteConfig) => {
+    const root = viteConfig.root ?? process.cwd()
+    const MAP_PATHS: Record<string, string> = {
+      hub:    resolve(root, 'src/data/hub/config.json'),
+      town2:  resolve(root, 'src/data/town2/config.json'),
+      castle: resolve(root, 'src/data/castle/config.json'),
+    }
+
     viteConfig.plugins = viteConfig.plugins ?? []
-    viteConfig.plugins.push({
+    viteConfig.plugins.unshift({
       name: 'map-editor-save',
+      enforce: 'pre',
       apply: 'serve',
       configureServer(server) {
         server.middlewares.use(
-          '/api/map-editor/save',
-          (req: IncomingMessage, res: ServerResponse) => {
-            if (req.method !== 'POST') {
-              res.statusCode = 405
-              res.end('Method Not Allowed')
+          (req: IncomingMessage, res: ServerResponse, next: () => void) => {
+            if (req.url !== '/api/map-editor/save' || req.method !== 'POST') {
+              next()
               return
             }
             let body = ''
@@ -49,6 +45,7 @@ const config: StorybookConfig = {
                 const filePath = MAP_PATHS[mapId]
                 if (!filePath) {
                   res.statusCode = 400
+                  res.setHeader('Content-Type', 'application/json')
                   res.end(JSON.stringify({ error: `Unknown mapId: ${mapId}` }))
                   return
                 }
@@ -57,6 +54,7 @@ const config: StorybookConfig = {
                 res.end(JSON.stringify({ ok: true }))
               } catch (e) {
                 res.statusCode = 500
+                res.setHeader('Content-Type', 'application/json')
                 res.end(JSON.stringify({ error: String(e) }))
               }
             })

--- a/web/src/components/mapEditor/EntityInspector.tsx
+++ b/web/src/components/mapEditor/EntityInspector.tsx
@@ -10,13 +10,14 @@ interface Props {
   selectedEntity:   SelectedEntity | null
   configData:       RawMapConfig
   activeInteriorId: string | null
-  onDelete:         (entity: SelectedEntity) => void
-  onMoveEntity:     (entity: SelectedEntity, tx: number, ty: number) => void
-  onZlayerChange:   (entity: SelectedEntity, z: Zlayer) => void
-  onDialogueChange: (index: number, dialogue: string[]) => void
-  onOpenInterior:   (id: string) => void
-  onCloseInterior:  () => void
-  viewMode:         'exterior' | 'interior'
+  onDelete:              (entity: SelectedEntity) => void
+  onMoveEntity:          (entity: SelectedEntity, tx: number, ty: number) => void
+  onZlayerChange:        (entity: SelectedEntity, z: Zlayer) => void
+  onDialogueChange:      (index: number, dialogue: string[]) => void
+  onOpenInterior:        (id: string) => void
+  onCloseInterior:       () => void
+  onUpdateStreetEntry:   (index: number, data: { rect?: number[]; tile?: number[] }) => void
+  viewMode:              'exterior' | 'interior'
 }
 
 function TilePreview({ tileId }: { tileId: string }) {
@@ -172,11 +173,14 @@ function NpcInspector({
 }
 
 function StreetInspector({
-  entry, onDelete,
+  entry, onUpdate, onDelete,
 }: {
   entry: { rect?: number[]; tile?: number[]; pathType?: string }
+  onUpdate: (data: { rect?: number[]; tile?: number[] }) => void
   onDelete: () => void
 }) {
+  const r = entry.rect
+  const t = entry.tile
   return (
     <div>
       {entry.pathType && (
@@ -184,27 +188,45 @@ function StreetInspector({
           <span style={{ fontFamily: 'monospace', fontSize: 11, color: '#aaa' }}>{entry.pathType}</span>
         </Field>
       )}
-      {entry.rect ? (
-        <Field label="Rect">
-          <span style={{ fontFamily: 'monospace', fontSize: 11, color: '#aaa' }}>
-            ({entry.rect[0]},{entry.rect[1]}) → ({entry.rect[2]},{entry.rect[3]}) — {entry.rect[2]-entry.rect[0]+1}×{entry.rect[3]-entry.rect[1]+1} tiles
-          </span>
-        </Field>
-      ) : entry.tile ? (
-        <Field label="Tile">
-          <span style={{ fontFamily: 'monospace', fontSize: 11, color: '#aaa' }}>
-            ({entry.tile[0]},{entry.tile[1]})
-          </span>
+      {r ? (
+        <>
+          <Field label="Top-left">
+            <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+              <label style={{ fontSize: 11, color: '#888' }}>X</label>
+              {numInput(r[0], v => onUpdate({ rect: [v, r[1], r[2], r[3]] }))}
+              <label style={{ fontSize: 11, color: '#888' }}>Y</label>
+              {numInput(r[1], v => onUpdate({ rect: [r[0], v, r[2], r[3]] }))}
+            </div>
+          </Field>
+          <Field label="Bottom-right">
+            <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+              <label style={{ fontSize: 11, color: '#888' }}>X</label>
+              {numInput(r[2], v => onUpdate({ rect: [r[0], r[1], v, r[3]] }))}
+              <label style={{ fontSize: 11, color: '#888' }}>Y</label>
+              {numInput(r[3], v => onUpdate({ rect: [r[0], r[1], r[2], v] }))}
+            </div>
+          </Field>
+          <Field label="Size">
+            <span style={{ fontFamily: 'monospace', fontSize: 11, color: '#666' }}>
+              {r[2]-r[0]+1} × {r[3]-r[1]+1} tiles
+            </span>
+          </Field>
+        </>
+      ) : t ? (
+        <Field label="Position">
+          <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+            <label style={{ fontSize: 11, color: '#888' }}>X</label>
+            {numInput(t[0], v => onUpdate({ tile: [v, t[1]] }))}
+            <label style={{ fontSize: 11, color: '#888' }}>Y</label>
+            {numInput(t[1], v => onUpdate({ tile: [t[0], v] }))}
+          </div>
         </Field>
       ) : null}
-      <div style={{ color: '#666', fontSize: 10, marginTop: 4, marginBottom: 8 }}>
-        Drag to reposition. Deleting a rect removes all its tiles.
-      </div>
       <button
         onClick={onDelete}
         style={{
           width: '100%', padding: '6px 0', background: '#5a1a1a', border: '1px solid #922',
-          color: '#f88', cursor: 'pointer', borderRadius: 3, fontSize: 12,
+          color: '#f88', cursor: 'pointer', borderRadius: 3, fontSize: 12, marginTop: 8,
         }}
       >
         Delete Street Entry
@@ -267,7 +289,8 @@ function BuildingInspector({
 
 export function EntityInspector({
   selectedEntity, configData, activeInteriorId, viewMode,
-  onDelete, onMoveEntity, onZlayerChange, onDialogueChange, onOpenInterior, onCloseInterior,
+  onDelete, onMoveEntity, onZlayerChange, onDialogueChange,
+  onOpenInterior, onCloseInterior, onUpdateStreetEntry,
 }: Props) {
   const panelStyle: React.CSSProperties = {
     display: 'flex', flexDirection: 'column', height: '100%',
@@ -397,6 +420,7 @@ export function EntityInspector({
         <div style={bodyStyle}>
           <StreetInspector
             entry={entry}
+            onUpdate={data => onUpdateStreetEntry(selectedEntity.index, data)}
             onDelete={() => onDelete(selectedEntity)}
           />
         </div>

--- a/web/src/components/mapEditor/EntityInspector.tsx
+++ b/web/src/components/mapEditor/EntityInspector.tsx
@@ -16,7 +16,7 @@ interface Props {
   onDialogueChange:      (index: number, dialogue: string[]) => void
   onOpenInterior:        (id: string) => void
   onCloseInterior:       () => void
-  onUpdateStreetEntry:   (index: number, data: { rect?: number[]; tile?: number[] }) => void
+  onUpdateStreetEntry:   (index: number, data: { rect?: number[]; tile?: number[]; pathType?: string }) => void
   viewMode:              'exterior' | 'interior'
 }
 
@@ -176,18 +176,25 @@ function StreetInspector({
   entry, onUpdate, onDelete,
 }: {
   entry: { rect?: number[]; tile?: number[]; pathType?: string }
-  onUpdate: (data: { rect?: number[]; tile?: number[] }) => void
+  onUpdate: (data: { rect?: number[]; tile?: number[]; pathType?: string }) => void
   onDelete: () => void
 }) {
   const r = entry.rect
   const t = entry.tile
   return (
     <div>
-      {entry.pathType && (
-        <Field label="Path Type">
-          <span style={{ fontFamily: 'monospace', fontSize: 11, color: '#aaa' }}>{entry.pathType}</span>
-        </Field>
-      )}
+      <Field label="Path Type">
+        <input
+          type="text"
+          value={entry.pathType ?? ''}
+          onChange={e => onUpdate({ pathType: e.target.value || undefined })}
+          placeholder="e.g. cobblestone (optional)"
+          style={{
+            width: '100%', padding: '3px 5px', background: '#111', border: '1px solid #444',
+            color: '#eee', borderRadius: 3, fontSize: 11, boxSizing: 'border-box',
+          }}
+        />
+      </Field>
       {r ? (
         <>
           <Field label="Top-left">

--- a/web/src/components/mapEditor/EntityInspector.tsx
+++ b/web/src/components/mapEditor/EntityInspector.tsx
@@ -171,6 +171,48 @@ function NpcInspector({
   )
 }
 
+function StreetInspector({
+  entry, onDelete,
+}: {
+  entry: { rect?: number[]; tile?: number[]; pathType?: string }
+  onDelete: () => void
+}) {
+  return (
+    <div>
+      {entry.pathType && (
+        <Field label="Path Type">
+          <span style={{ fontFamily: 'monospace', fontSize: 11, color: '#aaa' }}>{entry.pathType}</span>
+        </Field>
+      )}
+      {entry.rect ? (
+        <Field label="Rect">
+          <span style={{ fontFamily: 'monospace', fontSize: 11, color: '#aaa' }}>
+            ({entry.rect[0]},{entry.rect[1]}) → ({entry.rect[2]},{entry.rect[3]}) — {entry.rect[2]-entry.rect[0]+1}×{entry.rect[3]-entry.rect[1]+1} tiles
+          </span>
+        </Field>
+      ) : entry.tile ? (
+        <Field label="Tile">
+          <span style={{ fontFamily: 'monospace', fontSize: 11, color: '#aaa' }}>
+            ({entry.tile[0]},{entry.tile[1]})
+          </span>
+        </Field>
+      ) : null}
+      <div style={{ color: '#666', fontSize: 10, marginTop: 4, marginBottom: 8 }}>
+        Drag to reposition. Deleting a rect removes all its tiles.
+      </div>
+      <button
+        onClick={onDelete}
+        style={{
+          width: '100%', padding: '6px 0', background: '#5a1a1a', border: '1px solid #922',
+          color: '#f88', cursor: 'pointer', borderRadius: 3, fontSize: 12,
+        }}
+      >
+        Delete Street Entry
+      </button>
+    </div>
+  )
+}
+
 function BuildingInspector({
   building, onOpenInterior, interiorIds,
 }: {
@@ -340,6 +382,22 @@ export function EntityInspector({
             onMove={(tx, ty) => onMoveEntity(selectedEntity, tx, ty)}
             onDelete={() => onDelete(selectedEntity)}
             onDialogueChange={d => onDialogueChange(selectedEntity.index, d)}
+          />
+        </div>
+      </div>
+    )
+  }
+
+  if (selectedEntity.type === 'street') {
+    const entry = (configData.streets ?? [])[selectedEntity.index]
+    if (!entry) return null
+    return (
+      <div style={panelStyle}>
+        <div style={headerStyle}>Street / Path #{selectedEntity.index}</div>
+        <div style={bodyStyle}>
+          <StreetInspector
+            entry={entry}
+            onDelete={() => onDelete(selectedEntity)}
           />
         </div>
       </div>

--- a/web/src/components/mapEditor/MapEditor.tsx
+++ b/web/src/components/mapEditor/MapEditor.tsx
@@ -18,6 +18,7 @@ export function MapEditor({ initialMapId = 'hub' }: Props) {
     openInterior, closeInterior, selectEntity,
     placeDecor, moveEntity, deleteEntity,
     updateDecorZlayer, updateNpcDialogue,
+    addStreet, updateStreetEntry,
     undo, redo, markSaved,
   } = useMapEditorState(initialMapId)
 
@@ -30,6 +31,7 @@ export function MapEditor({ initialMapId = 'hub' }: Props) {
       if (e.key === 's' && !e.ctrlKey && !e.metaKey) setTool('select')
       if (e.key === 'p') setTool('place')
       if (e.key === 'd' && !e.ctrlKey && !e.metaKey) setTool('delete')
+      if (e.key === 'r') setTool('street')
       if (e.key === 'Delete' || e.key === 'Backspace') {
         if (state.selectedEntity) deleteEntity(state.selectedEntity)
       }
@@ -85,6 +87,7 @@ export function MapEditor({ initialMapId = 'hub' }: Props) {
           onPlaceDecor={placeDecor}
           onMoveEntity={moveEntity}
           onDeleteEntity={deleteEntity}
+          onAddStreet={addStreet}
         />
 
         {/* Right: Inspector */}
@@ -100,6 +103,7 @@ export function MapEditor({ initialMapId = 'hub' }: Props) {
             onDialogueChange={updateNpcDialogue}
             onOpenInterior={openInterior}
             onCloseInterior={closeInterior}
+            onUpdateStreetEntry={updateStreetEntry}
           />
         </div>
       </div>

--- a/web/src/components/mapEditor/MapEditorCanvas.tsx
+++ b/web/src/components/mapEditor/MapEditorCanvas.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect, useCallback } from 'react'
+import React, { useRef, useEffect, useCallback, useState } from 'react'
 import * as PIXI from 'pixi.js'
 import { usePixiApp } from '../../hooks/usePixiApp'
 import { loadTileTexture, loadSpriteTexture } from '../../utils/pixiHelpers'
@@ -84,6 +84,7 @@ interface Props {
   onPlaceDecor:     (tx: number, ty: number) => void
   onMoveEntity:     (entity: SelectedEntity, tx: number, ty: number) => void
   onDeleteEntity:   (entity: SelectedEntity) => void
+  onAddStreet:      (tx1: number, ty1: number, tx2: number, ty2: number) => void
 }
 
 export function MapEditorCanvas(props: Props) {
@@ -101,6 +102,21 @@ export function MapEditorCanvas(props: Props) {
 
   // Drag state — offsetX/Y = click position minus entity anchor, for non-point entities like buildings
   const dragRef = useRef<{ entity: SelectedEntity; lastTx: number; lastTy: number; offsetX: number; offsetY: number } | null>(null)
+
+  // Street draw state
+  type StreetPreview = { sx: number; sy: number; ex: number; ey: number }
+  const [streetPreview, setStreetPreview] = useState<StreetPreview | null>(null)
+  const setStreetPreviewRef = useRef(setStreetPreview)
+  setStreetPreviewRef.current = setStreetPreview
+  const streetDrawRef = useRef<{ startTx: number; startTy: number; lastTx: number; lastTy: number } | null>(null)
+
+  // Clear street draw when tool switches away
+  useEffect(() => {
+    if (tool !== 'street') {
+      streetDrawRef.current = null
+      setStreetPreview(null)
+    }
+  }, [tool])
 
   // Render version counter — incremented on each render, so async sprite loads can detect staleness
   const renderVersionRef = useRef(0)
@@ -139,24 +155,61 @@ export function MapEditorCanvas(props: Props) {
           propsRef.current.onDeleteEntity(entity)
           propsRef.current.onSelectEntity(null)
         }
+      } else if (t === 'street') {
+        streetDrawRef.current = { startTx: tx, startTy: ty, lastTx: tx, lastTy: ty }
+        setStreetPreviewRef.current({ sx: tx, sy: ty, ex: tx, ey: ty })
       }
     })
 
     stage.on('pointermove', (e: PIXI.FederatedPointerEvent) => {
-      if (!dragRef.current) return
       const pos = e.getLocalPosition(stage)
       const tx  = Math.floor(pos.x / T)
       const ty  = Math.floor(pos.y / T)
-      const { entity, lastTx, lastTy, offsetX, offsetY } = dragRef.current
-      if (tx !== lastTx || ty !== lastTy) {
-        dragRef.current.lastTx = tx
-        dragRef.current.lastTy = ty
-        propsRef.current.onMoveEntity(entity, tx - offsetX, ty - offsetY)
+
+      if (dragRef.current) {
+        const { entity, lastTx, lastTy, offsetX, offsetY } = dragRef.current
+        if (tx !== lastTx || ty !== lastTy) {
+          dragRef.current.lastTx = tx
+          dragRef.current.lastTy = ty
+          propsRef.current.onMoveEntity(entity, tx - offsetX, ty - offsetY)
+        }
+      }
+
+      if (streetDrawRef.current) {
+        const { startTx, startTy, lastTx, lastTy } = streetDrawRef.current
+        if (tx !== lastTx || ty !== lastTy) {
+          streetDrawRef.current.lastTx = tx
+          streetDrawRef.current.lastTy = ty
+          setStreetPreviewRef.current({
+            sx: Math.min(tx, startTx), sy: Math.min(ty, startTy),
+            ex: Math.max(tx, startTx), ey: Math.max(ty, startTy),
+          })
+        }
       }
     })
 
-    stage.on('pointerup',        () => { dragRef.current = null })
-    stage.on('pointerupoutside', () => { dragRef.current = null })
+    stage.on('pointerup', (e: PIXI.FederatedPointerEvent) => {
+      dragRef.current = null
+      if (streetDrawRef.current) {
+        const pos = e.getLocalPosition(stage)
+        const tx = Math.floor(pos.x / T)
+        const ty = Math.floor(pos.y / T)
+        const { startTx, startTy } = streetDrawRef.current
+        propsRef.current.onAddStreet(
+          Math.min(tx, startTx), Math.min(ty, startTy),
+          Math.max(tx, startTx), Math.max(ty, startTy),
+        )
+        streetDrawRef.current = null
+        setStreetPreviewRef.current(null)
+      }
+    })
+    stage.on('pointerupoutside', () => {
+      dragRef.current = null
+      if (streetDrawRef.current) {
+        streetDrawRef.current = null
+        setStreetPreviewRef.current(null)
+      }
+    })
   }, [mapW, mapH])) // eslint-disable-line react-hooks/exhaustive-deps
 
   // Rebuild PixiJS scene on every render (configData / showGrid / selectedEntity changes)
@@ -194,6 +247,16 @@ export function MapEditorCanvas(props: Props) {
 
     if (showGrid) drawGrid(gridLayer)
     drawSelection(selLayer)
+
+    // Street draw preview — drawn above all other layers
+    if (!isInterior && streetPreview) {
+      const { sx, sy, ex, ey } = streetPreview
+      const pvGfx = new PIXI.Graphics()
+      pvGfx.rect(sx * T, sy * T, (ex - sx + 1) * T, (ey - sy + 1) * T)
+        .fill({ color: STREET_COLOR, alpha: 0.4 })
+        .stroke({ color: 0xf0c040, width: 2 })
+      stage.addChild(pvGfx)
+    }
   })
 
   // ── Exterior rendering ─────────────────────────────────────────────────────────

--- a/web/src/components/mapEditor/MapEditorCanvas.tsx
+++ b/web/src/components/mapEditor/MapEditorCanvas.tsx
@@ -330,7 +330,10 @@ export function MapEditorCanvas(props: Props) {
         sp.eventMode = 'static'; sp.cursor = 'pointer'
         sp.on('pointerdown', (e: PIXI.FederatedPointerEvent) => {
           e.stopPropagation()
-          propsRef.current.onSelectEntity({ type: 'npc', index: nIdx })
+          const entity: SelectedEntity = { type: 'npc', index: nIdx }
+          propsRef.current.onSelectEntity(entity)
+          if (propsRef.current.tool === 'select')
+            dragRef.current = { entity, lastTx: npc.tx, lastTy: npc.ty, offsetX: 0, offsetY: 0 }
         })
         if (isSel) {
           selLayer.rect(sp.x - 2, sp.y - 2, sp.width + 4, sp.height + 4)
@@ -417,6 +420,8 @@ export function MapEditorCanvas(props: Props) {
             ? { type: 'exteriorDecor', index: sourceIndex }
             : { type: 'interiorDecor', index: sourceIndex, interiorId }
           propsRef.current.onSelectEntity(entity)
+          if (propsRef.current.tool === 'select')
+            dragRef.current = { entity, lastTx: tx, lastTy: ty, offsetX: 0, offsetY: 0 }
         })
         if (isSel) {
           selLayer.rect(tx * T - 1, ty * T - 1, T + 2, T + 2)

--- a/web/src/components/mapEditor/MapEditorCanvas.tsx
+++ b/web/src/components/mapEditor/MapEditorCanvas.tsx
@@ -99,8 +99,8 @@ export function MapEditorCanvas(props: Props) {
   const propsRef = useRef(props)
   propsRef.current = props
 
-  // Drag state
-  const dragRef = useRef<{ entity: SelectedEntity; lastTx: number; lastTy: number } | null>(null)
+  // Drag state — offsetX/Y = click position minus entity anchor, for non-point entities like buildings
+  const dragRef = useRef<{ entity: SelectedEntity; lastTx: number; lastTy: number; offsetX: number; offsetY: number } | null>(null)
 
   // Render version counter — incremented on each render, so async sprite loads can detect staleness
   const renderVersionRef = useRef(0)
@@ -129,7 +129,7 @@ export function MapEditorCanvas(props: Props) {
         if (entity) {
           const etx = getEntityTx(cfg, entity)
           const ety = getEntityTy(cfg, entity)
-          dragRef.current = { entity, lastTx: etx, lastTy: ety }
+          dragRef.current = { entity, lastTx: tx, lastTy: ty, offsetX: tx - etx, offsetY: ty - ety }
         }
       } else if (t === 'place' && (tid || bid)) {
         propsRef.current.onPlaceDecor(tx, ty)
@@ -144,16 +144,14 @@ export function MapEditorCanvas(props: Props) {
 
     stage.on('pointermove', (e: PIXI.FederatedPointerEvent) => {
       if (!dragRef.current) return
-      const { configData: cfg } = propsRef.current
       const pos = e.getLocalPosition(stage)
       const tx  = Math.floor(pos.x / T)
       const ty  = Math.floor(pos.y / T)
-      const { entity, lastTx, lastTy } = dragRef.current
+      const { entity, lastTx, lastTy, offsetX, offsetY } = dragRef.current
       if (tx !== lastTx || ty !== lastTy) {
         dragRef.current.lastTx = tx
         dragRef.current.lastTy = ty
-        propsRef.current.onMoveEntity(entity, tx, ty)
-        void cfg // suppress lint
+        propsRef.current.onMoveEntity(entity, tx - offsetX, ty - offsetY)
       }
     })
 
@@ -384,6 +382,18 @@ export function MapEditorCanvas(props: Props) {
   // ── Selection highlight ────────────────────────────────────────────────────────
   function drawSelection(gfx: PIXI.Graphics) {
     if (!selectedEntity) return
+    if (selectedEntity.type === 'street') {
+      const entry = configData.streets?.[selectedEntity.index]
+      if (entry?.rect) {
+        const [tx1, ty1, tx2, ty2] = entry.rect
+        gfx.rect(tx1 * T - 2, ty1 * T - 2, (tx2 - tx1 + 1) * T + 4, (ty2 - ty1 + 1) * T + 4)
+          .stroke({ color: 0xf0c040, width: 2 })
+      } else if (entry?.tile) {
+        gfx.rect(entry.tile[0] * T - 2, entry.tile[1] * T - 2, T + 4, T + 4)
+          .stroke({ color: 0xf0c040, width: 2 })
+      }
+      return
+    }
     let tx = -1, ty = -1
     if (selectedEntity.type === 'exteriorDecor') {
       const item = configData.exteriorDecor?.[selectedEntity.index]
@@ -439,6 +449,17 @@ function hitTest(
         return { type: 'building', index: i }
     }
   }
+  const streets = cfg.streets ?? []
+  for (let i = streets.length - 1; i >= 0; i--) {
+    const entry = streets[i]
+    if (entry.rect) {
+      const [tx1, ty1, tx2, ty2] = entry.rect
+      if (tx >= tx1 && tx <= tx2 && ty >= ty1 && ty <= ty2)
+        return { type: 'street', index: i }
+    } else if (entry.tile && entry.tile[0] === tx && entry.tile[1] === ty) {
+      return { type: 'street', index: i }
+    }
+  }
   return null
 }
 
@@ -446,6 +467,15 @@ function getEntityTx(cfg: RawMapConfig, entity: SelectedEntity): number {
   if (entity.type === 'exteriorDecor') return cfg.exteriorDecor?.[entity.index]?.tx ?? 0
   if (entity.type === 'npc') return cfg.npcs?.[entity.index]?.tx ?? 0
   if (entity.type === 'interiorDecor') return cfg.interiors?.[entity.interiorId]?.decor[entity.index]?.tx ?? 0
+  if (entity.type === 'building') {
+    const b = cfg.buildings?.[entity.index]
+    const rects = b?.rects ?? (b?.rect ? [b.rect] : [])
+    return rects[0]?.[0] ?? 0
+  }
+  if (entity.type === 'street') {
+    const e = cfg.streets?.[entity.index]
+    return e?.rect?.[0] ?? e?.tile?.[0] ?? 0
+  }
   return 0
 }
 
@@ -453,5 +483,14 @@ function getEntityTy(cfg: RawMapConfig, entity: SelectedEntity): number {
   if (entity.type === 'exteriorDecor') return cfg.exteriorDecor?.[entity.index]?.ty ?? 0
   if (entity.type === 'npc') return cfg.npcs?.[entity.index]?.ty ?? 0
   if (entity.type === 'interiorDecor') return cfg.interiors?.[entity.interiorId]?.decor[entity.index]?.ty ?? 0
+  if (entity.type === 'building') {
+    const b = cfg.buildings?.[entity.index]
+    const rects = b?.rects ?? (b?.rect ? [b.rect] : [])
+    return rects[0]?.[1] ?? 0
+  }
+  if (entity.type === 'street') {
+    const e = cfg.streets?.[entity.index]
+    return e?.rect?.[1] ?? e?.tile?.[1] ?? 0
+  }
   return 0
 }

--- a/web/src/components/mapEditor/MapEditorToolbar.tsx
+++ b/web/src/components/mapEditor/MapEditorToolbar.tsx
@@ -29,6 +29,7 @@ const TOOLS: { mode: ToolMode; label: string; title: string }[] = [
   { mode: 'select', label: '↖', title: 'Select / Move (S)' },
   { mode: 'place',  label: '✎', title: 'Place tile (P)' },
   { mode: 'delete', label: '✕', title: 'Delete (D)' },
+  { mode: 'street', label: '⊟', title: 'Draw Street / Path (R)' },
 ]
 
 export function MapEditorToolbar({

--- a/web/src/components/mapEditor/mapEditorTypes.ts
+++ b/web/src/components/mapEditor/mapEditorTypes.ts
@@ -1,7 +1,7 @@
 import type { WallMaterial, RoofMaterial } from '../../data/tiles/buildingMaterials'
 
 export type MapId = 'hub' | 'town2' | 'castle'
-export type ToolMode = 'select' | 'place' | 'delete'
+export type ToolMode = 'select' | 'place' | 'delete' | 'street'
 export type Zlayer = 'solid' | 'below' | 'above'
 export type ViewMode = 'exterior' | 'interior'
 

--- a/web/src/components/mapEditor/mapEditorTypes.ts
+++ b/web/src/components/mapEditor/mapEditorTypes.ts
@@ -127,6 +127,7 @@ export type SelectedEntity =
   | { type: 'exteriorDecor'; index: number }
   | { type: 'npc'; index: number }
   | { type: 'building'; index: number }
+  | { type: 'street'; index: number }
   | { type: 'interiorDecor'; interiorId: string; index: number }
 
 export interface MapEditorState {

--- a/web/src/components/mapEditor/useMapEditorState.ts
+++ b/web/src/components/mapEditor/useMapEditorState.ts
@@ -121,6 +121,39 @@ export function useMapEditorState(initialMapId: MapId = 'hub') {
         if (!npcs[entity.index]) return s
         npcs[entity.index] = { ...npcs[entity.index], tx, ty }
         newConfig = { ...prevConfig, npcs }
+      } else if (entity.type === 'building') {
+        const buildings = [...(prevConfig.buildings ?? [])]
+        if (!buildings[entity.index]) return s
+        const b = buildings[entity.index]
+        const rects = b.rects ?? (b.rect ? [b.rect] : [])
+        const oldTx1 = rects[0]?.[0] ?? 0
+        const oldTy1 = rects[0]?.[1] ?? 0
+        const dx = tx - oldTx1
+        const dy = ty - oldTy1
+        if (dx === 0 && dy === 0) return s
+        const newRects = rects.map(([rx1, ry1, rx2, ry2]) =>
+          [rx1 + dx, ry1 + dy, rx2 + dx, ry2 + dy] as [number, number, number, number],
+        )
+        buildings[entity.index] = b.rects
+          ? { ...b, rects: newRects }
+          : { ...b, rect: newRects[0] }
+        newConfig = { ...prevConfig, buildings }
+      } else if (entity.type === 'street') {
+        const streets = [...(prevConfig.streets ?? [])]
+        if (!streets[entity.index]) return s
+        const entry = streets[entity.index]
+        if (entry.rect) {
+          const [tx1, ty1, tx2, ty2] = entry.rect
+          const dx = tx - tx1
+          const dy = ty - ty1
+          if (dx === 0 && dy === 0) return s
+          streets[entity.index] = { ...entry, rect: [tx1 + dx, ty1 + dy, tx2 + dx, ty2 + dy] }
+        } else if (entry.tile) {
+          streets[entity.index] = { ...entry, tile: [tx, ty] }
+        } else {
+          return s
+        }
+        newConfig = { ...prevConfig, streets }
       } else if (entity.type === 'interiorDecor' && prevConfig.interiors?.[entity.interiorId]) {
         const interior = prevConfig.interiors[entity.interiorId]
         const decor = [...interior.decor]
@@ -152,6 +185,10 @@ export function useMapEditorState(initialMapId: MapId = 'hub') {
         newConfig = { ...prevConfig, exteriorDecor: (prevConfig.exteriorDecor ?? []).filter((_, i) => i !== entity.index) }
       } else if (entity.type === 'npc') {
         newConfig = { ...prevConfig, npcs: (prevConfig.npcs ?? []).filter((_, i) => i !== entity.index) }
+      } else if (entity.type === 'building') {
+        newConfig = { ...prevConfig, buildings: (prevConfig.buildings ?? []).filter((_, i) => i !== entity.index) }
+      } else if (entity.type === 'street') {
+        newConfig = { ...prevConfig, streets: (prevConfig.streets ?? []).filter((_, i) => i !== entity.index) }
       } else if (entity.type === 'interiorDecor' && prevConfig.interiors?.[entity.interiorId]) {
         const interior = prevConfig.interiors[entity.interiorId]
         newConfig = {

--- a/web/src/components/mapEditor/useMapEditorState.ts
+++ b/web/src/components/mapEditor/useMapEditorState.ts
@@ -291,6 +291,41 @@ export function useMapEditorState(initialMapId: MapId = 'hub') {
     })
   }, [])
 
+  const addStreet = useCallback((tx1: number, ty1: number, tx2: number, ty2: number) => {
+    setState(s => {
+      const prevConfig = s.configData
+      const newEntry = tx1 === tx2 && ty1 === ty2
+        ? { tile: [tx1, ty1] }
+        : { rect: [tx1, ty1, tx2, ty2] }
+      const streets = [...(prevConfig.streets ?? []), newEntry]
+      const newIndex = streets.length - 1
+      return {
+        ...s,
+        configData: { ...prevConfig, streets },
+        selectedEntity: { type: 'street' as const, index: newIndex },
+        undoStack: [...s.undoStack, prevConfig].slice(-MAX_UNDO),
+        redoStack: [],
+        isDirty: true,
+      }
+    })
+  }, [])
+
+  const updateStreetEntry = useCallback((index: number, data: { rect?: number[]; tile?: number[] }) => {
+    setState(s => {
+      const prevConfig = s.configData
+      const streets = [...(prevConfig.streets ?? [])]
+      if (!streets[index]) return s
+      streets[index] = { ...streets[index], ...data }
+      return {
+        ...s,
+        configData: { ...prevConfig, streets },
+        undoStack: [...s.undoStack, prevConfig].slice(-MAX_UNDO),
+        redoStack: [],
+        isDirty: true,
+      }
+    })
+  }, [])
+
   const markSaved = useCallback(() => {
     setState(s => ({ ...s, isDirty: false }))
   }, [])
@@ -311,6 +346,8 @@ export function useMapEditorState(initialMapId: MapId = 'hub') {
     updateNpcDialogue,
     undo,
     redo,
+    addStreet,
+    updateStreetEntry,
     markSaved,
   }
 }

--- a/web/src/components/mapEditor/useMapEditorState.ts
+++ b/web/src/components/mapEditor/useMapEditorState.ts
@@ -310,7 +310,7 @@ export function useMapEditorState(initialMapId: MapId = 'hub') {
     })
   }, [])
 
-  const updateStreetEntry = useCallback((index: number, data: { rect?: number[]; tile?: number[] }) => {
+  const updateStreetEntry = useCallback((index: number, data: { rect?: number[]; tile?: number[]; pathType?: string }) => {
     setState(s => {
       const prevConfig = s.configData
       const streets = [...(prevConfig.streets ?? [])]

--- a/web/src/data/bundles/bundles.json
+++ b/web/src/data/bundles/bundles.json
@@ -1,11 +1,52 @@
 [
   {
+    "bundleID": "light-tree",
+    "tiles": [
+      { "tileID": "lightTreeTopLeft", "x": 0, "y": 1, "zlayer": "above" },
+      { "tileID": "lightTreeTopRight", "x": 1, "y": 1, "zlayer": "above" },
+      { "tileID": "lightTreeBottomLeft", "x": 0, "y": 0, "zlayer": "solid" },
+      { "tileID": "lightTreeBottomRight", "x": 1, "y": 0, "zlayer": "solid" }
+    ]
+  },
+  {
+    "bundleID": "dark-tree",
+    "tiles": [
+      { "tileID": "darkTreeTopLeft", "x": 0, "y": 1, "zlayer": "above" },
+      { "tileID": "darkTreeTopRight", "x": 1, "y": 1, "zlayer": "above" },
+      { "tileID": "darkTreeBottomLeft", "x": 0, "y": 0, "zlayer": "solid" },
+      { "tileID": "darkTreeBottomRight", "x": 1, "y": 0, "zlayer": "solid" }
+    ]
+  },
+  {
+    "bundleID": "autumn-tree",
+    "tiles": [
+      { "tileID": "autumnTreeTopLeft", "x": 0, "y": 1, "zlayer": "above" },
+      { "tileID": "autumnTreeTopRight", "x": 1, "y": 1, "zlayer": "above" },
+      { "tileID": "autumnTreeBottomLeft", "x": 0, "y": 0, "zlayer": "solid" },
+      { "tileID": "autumnTreeBottomRight", "x": 1, "y": 0, "zlayer": "solid" }
+    ]
+  },    
+  {
+    "bundleID": "dead-tree",
+    "tiles": [
+      { "tileID": "deadTreeTopLeft", "x": 0, "y": 1, "zlayer": "above" },
+      { "tileID": "deadTreeTopRight", "x": 1, "y": 1, "zlayer": "above" },
+      { "tileID": "deadTreeBottomLeft", "x": 0, "y": 0, "zlayer": "solid" },
+      { "tileID": "deadTreeBottomRight", "x": 1, "y": 0, "zlayer": "solid" }
+    ]
+  },
+  
+  {
     "bundleID": "royal-bed",
     "tiles": [
-      { "tileID": "bed-tl", "x": 0, "y": 1, "zlayer": "below" },
-      { "tileID": "bed-tr", "x": 1, "y": 1, "zlayer": "below" },
-      { "tileID": "bed-bl", "x": 0, "y": 0, "zlayer": "above" },
-      { "tileID": "bed-br", "x": 1, "y": 0, "zlayer": "above" }
+      { "tileID": "royalBedTopLeft", "x": 0, "y": 1, "zlayer": "below" },
+      { "tileID": "royalBedTopRight", "x": 1, "y": 1, "zlayer": "below" },
+      { "tileID": "royalBedBottonLeft", "x": 0, "y": 0, "zlayer": "below" },
+      { "tileID": "royalBedBottomRight", "x": 1, "y": 0, "zlayer": "below" },
+      { "tileID": "royalBedTopLeftOverlay", "x": 0, "y": 1, "zlayer": "above" },
+      { "tileID": "royalBedTopRightOverlay", "x": 1, "y": 1, "zlayer": "above" },
+      { "tileID": "royalBedBottonLeftOverlay", "x": 0, "y": 0, "zlayer": "above" },
+      { "tileID": "royalBedBottomRightOverlay", "x": 1, "y": 0, "zlayer": "above" }
     ]
   },
   {

--- a/web/src/data/hub/config.json
+++ b/web/src/data/hub/config.json
@@ -7,10 +7,26 @@
     29
   ],
   "exitTiles": [
-    { "tx": 36, "ty": 67, "screen": "worldmap" },
-    { "tx": 37, "ty": 67, "screen": "worldmap" },
-    { "tx": 38, "ty": 67, "screen": "worldmap" },
-    { "tx": 39, "ty": 67, "screen": "worldmap" }
+    {
+      "tx": 36,
+      "ty": 67,
+      "screen": "worldmap"
+    },
+    {
+      "tx": 37,
+      "ty": 67,
+      "screen": "worldmap"
+    },
+    {
+      "tx": 38,
+      "ty": 67,
+      "screen": "worldmap"
+    },
+    {
+      "tx": 39,
+      "ty": 67,
+      "screen": "worldmap"
+    }
   ],
   "areas": [
     {
@@ -97,7 +113,7 @@
   "streets": [
     {
       "rect": [
-        0,
+        4,
         23,
         35,
         25
@@ -107,7 +123,7 @@
       "rect": [
         39,
         23,
-        74,
+        61,
         25
       ]
     },
@@ -153,18 +169,18 @@
     },
     {
       "rect": [
-        55,
-        5,
-        57,
-        23
+        59,
+        9,
+        61,
+        22
       ]
     },
     {
       "rect": [
-        55,
-        8,
-        74,
-        10
+        62,
+        9,
+        65,
+        9
       ]
     },
     {
@@ -186,9 +202,9 @@
     {
       "rect": [
         18,
-        2,
+        11,
         19,
-        23
+        22
       ]
     },
     {
@@ -201,9 +217,9 @@
     },
     {
       "rect": [
-        0,
+        6,
         12,
-        20,
+        17,
         13
       ]
     },
@@ -228,12 +244,6 @@
       ]
     },
     {
-      "tile": [
-        8,
-        14
-      ]
-    },
-    {
       "rect": [
         25,
         20,
@@ -251,36 +261,24 @@
     },
     {
       "tile": [
-        56,
-        11
-      ]
-    },
-    {
-      "tile": [
-        8,
-        22
-      ]
-    },
-    {
-      "tile": [
         10,
         34
       ]
     },
     {
       "rect": [
-        47,
-        7,
-        65,
-        7
+        55,
+        9,
+        58,
+        9
       ]
     },
     {
       "rect": [
-        47,
-        20,
-        65,
-        20
+        53,
+        19,
+        58,
+        19
       ]
     },
     {
@@ -489,7 +487,7 @@
         60
       ]
     },
-        {
+    {
       "tile": [
         13,
         58
@@ -503,10 +501,117 @@
         60
       ]
     },
-    { "tile": [35,65] },    
-    { "rect": [13,61,14,61] },
-    { "rect": [5,62,23,68], "pathType": "grass1Grass4" },
-    { "rect": [35,69,39,70] }
+    {
+      "tile": [
+        35,
+        65
+      ]
+    },
+    {
+      "rect": [
+        13,
+        61,
+        14,
+        61
+      ]
+    },
+    {
+      "rect": [
+        5,
+        62,
+        23,
+        68
+      ],
+      "pathType": "grass1Grass4"
+    },
+    {
+      "rect": [
+        35,
+        69,
+        39,
+        70
+      ]
+    },
+    {
+      "rect": [
+        64,
+        8,
+        65,
+        8
+      ]
+    },
+    {
+      "rect": [
+        55,
+        8,
+        56,
+        8
+      ]
+    },
+    {
+      "rect": [
+        53,
+        18,
+        54,
+        18
+      ]
+    },
+    {
+      "rect": [
+        62,
+        19,
+        67,
+        19
+      ]
+    },
+    {
+      "rect": [
+        66,
+        18,
+        67,
+        18
+      ]
+    },
+    {
+      "rect": [
+        44,
+        18,
+        45,
+        22
+      ]
+    },
+    {
+      "rect": [
+        46,
+        9,
+        54,
+        9
+      ]
+    },
+    {
+      "rect": [
+        45,
+        1,
+        45,
+        9
+      ]
+    },
+    {
+      "rect": [
+        46,
+        1,
+        48,
+        1
+      ]
+    },
+    {
+      "rect": [
+        4,
+        22,
+        5,
+        22
+      ]
+    }
   ],
   "buildings": [
     {
@@ -591,9 +696,9 @@
     },
     {
       "rect": [
-        4,
+        1,
         15,
-        11,
+        8,
         21
       ],
       "id": "south-building",
@@ -651,10 +756,10 @@
     },
     {
       "rect": [
-        45,
-        0,
         52,
-        6
+        1,
+        59,
+        7
       ],
       "id": "scholars-north-w",
       "wall": "castleStone",
@@ -682,9 +787,9 @@
     {
       "rect": [
         61,
-        0,
+        1,
         68,
-        6
+        7
       ],
       "id": "scholars-north-e",
       "wall": "castleStone",
@@ -711,10 +816,10 @@
     },
     {
       "rect": [
-        43,
-        13,
         50,
-        19
+        11,
+        57,
+        17
       ],
       "id": "scholars-hall-w",
       "wall": "ornateStone",
@@ -741,10 +846,10 @@
     },
     {
       "rect": [
-        61,
-        13,
-        68,
-        19
+        63,
+        11,
+        70,
+        17
       ],
       "id": "scholars-hall-e",
       "wall": "ornateStone",
@@ -913,10 +1018,10 @@
     },
     {
       "rect": [
-        44,
-        28,
-        51,
-        34
+        41,
+        11,
+        48,
+        17
       ],
       "id": "arcade-building-e",
       "wall": "whiteStone",
@@ -944,9 +1049,9 @@
     {
       "rect": [
         44,
-        40,
+        27,
         51,
-        46
+        33
       ],
       "id": "arcade-building-w",
       "wall": "tudorFrame",
@@ -1084,7 +1189,7 @@
         }
       ],
       "windows": [
-               {
+        {
           "tx": 2,
           "ty": -4,
           "tileId": "windowTop4"
@@ -1104,7 +1209,7 @@
           "ty": -3,
           "tileId": "windowBottom4"
         },
-                {
+        {
           "tx": 8,
           "ty": -4,
           "tileId": "windowTop4"
@@ -1114,7 +1219,7 @@
           "ty": -3,
           "tileId": "windowBottom4"
         },
-                {
+        {
           "tx": 10,
           "ty": -4,
           "tileId": "windowTop4"
@@ -1124,7 +1229,6 @@
           "ty": -3,
           "tileId": "windowBottom4"
         }
-
       ],
       "decor": [
         {
@@ -1211,42 +1315,44 @@
       ]
     },
     {
-      "rects":[ [
-        3,
-        47,
-        5,
-        57
-      ],[
-        6,
-        50,
-        17,
-        57
-      ]],
+      "rects": [
+        [
+          3,
+          47,
+          5,
+          57
+        ],
+        [
+          6,
+          50,
+          17,
+          57
+        ]
+      ],
       "id": "church-building",
       "wall": "castleStone",
       "roof": "greySlateRoof",
-      "decor":[
-    {
-      "tx": 6,
-      "ty": -6,
-      "tileId": "stoneCross"
-    },
-    {
-      "tx": 13,
-      "ty": -6,
-      "tileId": "stoneCross"
-    },
-    {
-      "tx": 1,
-      "ty": -6,
-      "tileId": "bellTowerTop"
-    },
-    {
-      "tx": 1,
-      "ty": -5,
-      "tileId": "bellTowerBottom"
-    }    
-
+      "decor": [
+        {
+          "tx": 6,
+          "ty": -6,
+          "tileId": "stoneCross"
+        },
+        {
+          "tx": 13,
+          "ty": -6,
+          "tileId": "stoneCross"
+        },
+        {
+          "tx": 1,
+          "ty": -6,
+          "tileId": "bellTowerTop"
+        },
+        {
+          "tx": 1,
+          "ty": -5,
+          "tileId": "bellTowerBottom"
+        }
       ],
       "doors": [
         {
@@ -1370,159 +1476,855 @@
       "ty": 30,
       "tileId": "scarecrowBottom"
     },
-
-    {      "comment": "garden"    },
-    {      "tx": 1,      "ty": 38,      "tileId": "fenceLeft"    },
-    {      "tx": 1,      "ty": 38,      "tileId": "fenceLeftRight"    },
-    {      "tx": 2,      "ty": 38,      "tileId": "fenceLeftRight"    },
-    {      "tx": 3,      "ty": 38,      "tileId": "fenceLeftRight"    },
-    {      "tx": 4,      "ty": 38,      "tileId": "fenceLeftRight"    },
-    {      "tx": 5,      "ty": 38,      "tileId": "fenceLeftRight"    },
-    {      "tx": 6,      "ty": 38,      "tileId": "fenceLeft"    },
-   {      "tx": 8,      "ty": 38,      "tileId": "fenceRight"    },
-    {      "tx": 9,      "ty": 38,      "tileId": "fenceLeftRight"    },
-    {      "tx": 10,      "ty": 38,      "tileId": "fenceLeftRight"    },
-    {      "tx": 11,      "ty": 38,      "tileId": "fenceLeftRight"    },
-    {      "tx": 12,      "ty": 38,      "tileId": "fenceLeftRight"    },
-    {      "tx": 13,      "ty": 38,      "tileId": "fenceLeftBottom"    },
-    {      "tx": 13,      "ty": 39,      "tileId": "fenceTopBottom"    },
-    {      "tx": 13,      "ty": 40,      "tileId": "fenceTopBottom"    },
-    {      "tx": 13,      "ty": 41,      "tileId": "fenceTopBottom"    },
-    {      "tx": 13,      "ty": 42,      "tileId": "fenceTopBottom"    },
-    {      "tx": 13,      "ty": 43,      "tileId": "fenceTopBottom"    },
-    {      "tx": 13,      "ty": 44,      "tileId": "fenceTopBottom"    },
-    {      "tx": 13,      "ty": 45,      "tileId": "fenceTopBottom"    },
-    {      "tx": 13,      "ty": 46,      "tileId": "fenceTopBottom"    },
-    {      "tx": 13,      "ty": 47,      "tileId": "fenceTop"    },
-    {      "tx": 13,      "ty": 49,      "tileId": "fenceIsolated"    },
-
-    {"comment": "crops"},
-    { "tx":1, "ty":39, "tileId":"topLeftPlough","zlayer": "below-avatar"},
-    { "tx":2, "ty":39, "tileId":"topPlough","zlayer": "below-avatar"},
-    { "tx":3, "ty":39, "tileId":"topPlough","zlayer": "below-avatar"},
-    { "tx":4, "ty":39, "tileId":"topPlough","zlayer": "below-avatar"},
-    { "tx":5, "ty":39, "tileId":"topPlough","zlayer": "below-avatar"},
-    { "tx":6, "ty":39, "tileId":"topRightPlough","zlayer": "below-avatar"},
-    { "tx":1, "ty":40, "tileId":"leftPlough","zlayer": "below-avatar"},
-    { "tx":2, "ty":40, "tileId":"centerPlough","zlayer": "below-avatar"},
-    { "tx":3, "ty":40, "tileId":"centerPlough","zlayer": "below-avatar"},
-    { "tx":4, "ty":40, "tileId":"centerPlough","zlayer": "below-avatar"},
-    { "tx":5, "ty":40, "tileId":"centerPlough","zlayer": "below-avatar"},
-    { "tx":6, "ty":40, "tileId":"rightPlough","zlayer": "below-avatar"},
-    { "tx":1, "ty":41, "tileId":"leftPlough","zlayer": "below-avatar"},
-    { "tx":2, "ty":41, "tileId":"centerPlough","zlayer": "below-avatar"},
-    { "tx":3, "ty":41, "tileId":"centerPlough","zlayer": "below-avatar"},
-    { "tx":4, "ty":41, "tileId":"centerPlough","zlayer": "below-avatar"},
-    { "tx":5, "ty":41, "tileId":"centerPlough","zlayer": "below-avatar"},
-    { "tx":6, "ty":41, "tileId":"rightPlough","zlayer": "below-avatar"},
-    { "tx":1, "ty":42, "tileId":"leftPlough","zlayer": "below-avatar"},
-    { "tx":2, "ty":42, "tileId":"centerPlough","zlayer": "below-avatar"},
-    { "tx":3, "ty":42, "tileId":"centerPlough","zlayer": "below-avatar"},
-    { "tx":4, "ty":42, "tileId":"centerPlough","zlayer": "below-avatar"},
-    { "tx":5, "ty":42, "tileId":"centerPlough","zlayer": "below-avatar"},
-    { "tx":6, "ty":42, "tileId":"rightPlough","zlayer": "below-avatar"},
-    { "tx":1, "ty":43, "tileId":"bottomLeftPlough","zlayer": "below-avatar"},
-    { "tx":2, "ty":43, "tileId":"bottomPlough","zlayer": "below-avatar"},
-    { "tx":3, "ty":43, "tileId":"bottomPlough","zlayer": "below-avatar"},
-    { "tx":4, "ty":43, "tileId":"bottomPlough","zlayer": "below-avatar"},
-    { "tx":5, "ty":43, "tileId":"bottomPlough","zlayer": "below-avatar"},
-    { "tx":6, "ty":43, "tileId":"bottomRightPlough","zlayer": "below-avatar"},
-
-    { "tx":1, "ty":44, "tileId":"topLeftPlough","zlayer": "below-avatar"},
-    { "tx":2, "ty":44, "tileId":"topPlough","zlayer": "below-avatar"},
-    { "tx":3, "ty":44, "tileId":"topPlough","zlayer": "below-avatar"},
-    { "tx":4, "ty":44, "tileId":"topPlough","zlayer": "below-avatar"},
-    { "tx":5, "ty":44, "tileId":"topPlough","zlayer": "below-avatar"},
-    { "tx":6, "ty":44, "tileId":"topRightPlough","zlayer": "below-avatar"},
-    { "tx":1, "ty":45, "tileId":"leftPlough","zlayer": "below-avatar"},
-    { "tx":2, "ty":45, "tileId":"centerPlough","zlayer": "below-avatar"},
-    { "tx":3, "ty":45, "tileId":"centerPlough","zlayer": "below-avatar"},
-    { "tx":4, "ty":45, "tileId":"centerPlough","zlayer": "below-avatar"},
-    { "tx":5, "ty":45, "tileId":"centerPlough","zlayer": "below-avatar"},
-    { "tx":6, "ty":45, "tileId":"rightPlough","zlayer": "below-avatar"},
-    { "tx":1, "ty":46, "tileId":"leftPlough","zlayer": "below-avatar"},
-    { "tx":2, "ty":46, "tileId":"centerPlough","zlayer": "below-avatar"},
-    { "tx":3, "ty":46, "tileId":"centerPlough","zlayer": "below-avatar"},
-    { "tx":4, "ty":46, "tileId":"centerPlough","zlayer": "below-avatar"},
-    { "tx":5, "ty":46, "tileId":"centerPlough","zlayer": "below-avatar"},
-    { "tx":6, "ty":46, "tileId":"rightPlough","zlayer": "below-avatar"},
-    { "tx":1, "ty":47, "tileId":"leftPlough","zlayer": "below-avatar"},
-    { "tx":2, "ty":47, "tileId":"centerPlough","zlayer": "below-avatar"},
-    { "tx":3, "ty":47, "tileId":"centerPlough","zlayer": "below-avatar"},
-    { "tx":4, "ty":47, "tileId":"centerPlough","zlayer": "below-avatar"},
-    { "tx":5, "ty":47, "tileId":"centerPlough","zlayer": "below-avatar"},
-    { "tx":6, "ty":47, "tileId":"rightPlough"  ,"zlayer": "below-avatar"},
-    { "tx":1, "ty":48, "tileId":"bottomLeftPlough","zlayer": "below-avatar"},
-    { "tx":2, "ty":48, "tileId":"bottomPlough","zlayer": "below-avatar"},
-    { "tx":3, "ty":48, "tileId":"bottomPlough","zlayer": "below-avatar"},
-    { "tx":4, "ty":48, "tileId":"bottomPlough","zlayer": "below-avatar"},
-    { "tx":5, "ty":48, "tileId":"bottomPlough","zlayer": "below-avatar"},
-    { "tx":6, "ty":48, "tileId":"bottomRightPlough"  ,"zlayer": "below-avatar"},
-
-    { "tx":7, "ty":39, "tileId":"topLeftPlough","zlayer": "below-avatar"},
-    { "tx":8, "ty":39, "tileId":"topPlough","zlayer": "below-avatar"},
-    { "tx":9, "ty":39, "tileId":"topPlough","zlayer": "below-avatar"},
-    { "tx":10, "ty":39, "tileId":"topPlough","zlayer": "below-avatar"},
-    { "tx":11, "ty":39, "tileId":"topPlough","zlayer": "below-avatar"},
-    { "tx":12, "ty":39, "tileId":"topRightPlough","zlayer": "below-avatar"},
-    { "tx":7, "ty":40, "tileId":"leftPlough","zlayer": "below-avatar"},
-    { "tx":8, "ty":40, "tileId":"centerPlough","zlayer": "below-avatar"},
-    { "tx":9, "ty":40, "tileId":"centerPlough","zlayer": "below-avatar"},
-    { "tx":10, "ty":40, "tileId":"centerPlough","zlayer": "below-avatar"},
-    { "tx":11, "ty":40, "tileId":"centerPlough","zlayer": "below-avatar"},
-    { "tx":12, "ty":40, "tileId":"rightPlough","zlayer": "below-avatar"},
-    { "tx":7, "ty":41, "tileId":"leftPlough","zlayer": "below-avatar"},
-    { "tx":8, "ty":41, "tileId":"centerPlough","zlayer": "below-avatar"},
-    { "tx":9, "ty":41, "tileId":"centerPlough","zlayer": "below-avatar"},
-    { "tx":10, "ty":41, "tileId":"centerPlough","zlayer": "below-avatar"},
-    { "tx":11, "ty":41, "tileId":"centerPlough","zlayer": "below-avatar"},
-    { "tx":12, "ty":41, "tileId":"rightPlough","zlayer": "below-avatar"},
-    { "tx":7, "ty":42, "tileId":"leftPlough","zlayer": "below-avatar"},
-    { "tx":8, "ty":42, "tileId":"centerPlough","zlayer": "below-avatar"},
-    { "tx":9, "ty":42, "tileId":"centerPlough","zlayer": "below-avatar"},
-    { "tx":10, "ty":42, "tileId":"centerPlough","zlayer": "below-avatar"},
-    { "tx":11, "ty":42, "tileId":"centerPlough","zlayer": "below-avatar"},
-    { "tx":12, "ty":42, "tileId":"rightPlough","zlayer": "below-avatar"  },
-    { "tx":7, "ty":43, "tileId":"bottomLeftPlough","zlayer": "below-avatar"},
-    { "tx":8, "ty":43, "tileId":"bottomPlough","zlayer": "below-avatar"},
-    { "tx":9, "ty":43, "tileId":"bottomPlough","zlayer": "below-avatar"},
-    { "tx":10, "ty":43, "tileId":"bottomPlough","zlayer": "below-avatar"},
-    { "tx":11, "ty":43, "tileId":"bottomPlough","zlayer": "below-avatar"},
-    { "tx":12, "ty":43, "tileId":"bottomRightPlough","zlayer": "below-avatar"},
-
-    { "tx":7, "ty":44, "tileId":"topLeftPlough","zlayer": "below-avatar"},
-    { "tx":8, "ty":44, "tileId":"topPlough","zlayer": "below-avatar"},
-    { "tx":9, "ty":44, "tileId":"topPlough","zlayer": "below-avatar"},
-    { "tx":10, "ty":44, "tileId":"topPlough","zlayer": "below-avatar"},
-    { "tx":11, "ty":44, "tileId":"topPlough","zlayer": "below-avatar"},
-    { "tx":12, "ty":44, "tileId":"topRightPlough","zlayer": "below-avatar"},
-    { "tx":7, "ty":45, "tileId":"leftPlough","zlayer": "below-avatar"},
-    { "tx":8, "ty":45, "tileId":"centerPlough","zlayer": "below-avatar"},
-    { "tx":9, "ty":45, "tileId":"centerPlough","zlayer": "below-avatar"},
-    { "tx":10, "ty":45, "tileId":"centerPlough","zlayer": "below-avatar"},
-    { "tx":11, "ty":45, "tileId":"centerPlough","zlayer": "below-avatar"},
-    { "tx":12, "ty":45, "tileId":"rightPlough","zlayer": "below-avatar"},
-    { "tx":7, "ty":46, "tileId":"leftPlough","zlayer": "below-avatar"},
-    { "tx":8, "ty":46, "tileId":"centerPlough","zlayer": "below-avatar"},
-    { "tx":9, "ty":46, "tileId":"centerPlough","zlayer": "below-avatar"},
-    { "tx":10, "ty":46, "tileId":"centerPlough","zlayer": "below-avatar"},
-    { "tx":11, "ty":46, "tileId":"centerPlough","zlayer": "below-avatar"},
-    { "tx":12, "ty":46, "tileId":"rightPlough","zlayer": "below-avatar"},
-    { "tx":7, "ty":47, "tileId":"leftPlough","zlayer": "below-avatar"},
-    { "tx":8, "ty":47, "tileId":"centerPlough","zlayer": "below-avatar"},
-    { "tx":9, "ty":47, "tileId":"centerPlough","zlayer": "below-avatar"},
-    { "tx":10, "ty":47, "tileId":"centerPlough","zlayer": "below-avatar"},
-    { "tx":11, "ty":47, "tileId":"centerPlough","zlayer": "below-avatar"},
-    { "tx":12, "ty":47, "tileId":"rightPlough","zlayer": "below-avatar"  },
-    { "tx":7, "ty":48, "tileId":"bottomLeftPlough","zlayer": "below-avatar"},
-    { "tx":8, "ty":48, "tileId":"bottomPlough","zlayer": "below-avatar"},
-    { "tx":9, "ty":48, "tileId":"bottomPlough","zlayer": "below-avatar"},
-    { "tx":10, "ty":48, "tileId":"bottomPlough","zlayer": "below-avatar"},
-    { "tx":11, "ty":48, "tileId":"bottomPlough","zlayer": "below-avatar"},
-    { "tx":12, "ty":48, "tileId":"bottomRightPlough","zlayer": "below-avatar"  },
-
-    { "comment": "courtyard fountain" },
-    { "tx": 36, "ty": 25, "bundleID": "fountain" },
+    {
+      "comment": "garden"
+    },
+    {
+      "tx": 1,
+      "ty": 38,
+      "tileId": "fenceLeft"
+    },
+    {
+      "tx": 1,
+      "ty": 38,
+      "tileId": "fenceLeftRight"
+    },
+    {
+      "tx": 2,
+      "ty": 38,
+      "tileId": "fenceLeftRight"
+    },
+    {
+      "tx": 3,
+      "ty": 38,
+      "tileId": "fenceLeftRight"
+    },
+    {
+      "tx": 4,
+      "ty": 38,
+      "tileId": "fenceLeftRight"
+    },
+    {
+      "tx": 5,
+      "ty": 38,
+      "tileId": "fenceLeftRight"
+    },
+    {
+      "tx": 6,
+      "ty": 38,
+      "tileId": "fenceLeft"
+    },
+    {
+      "tx": 8,
+      "ty": 38,
+      "tileId": "fenceRight"
+    },
+    {
+      "tx": 9,
+      "ty": 38,
+      "tileId": "fenceLeftRight"
+    },
+    {
+      "tx": 10,
+      "ty": 38,
+      "tileId": "fenceLeftRight"
+    },
+    {
+      "tx": 11,
+      "ty": 38,
+      "tileId": "fenceLeftRight"
+    },
+    {
+      "tx": 12,
+      "ty": 38,
+      "tileId": "fenceLeftRight"
+    },
+    {
+      "tx": 13,
+      "ty": 38,
+      "tileId": "fenceLeftBottom"
+    },
+    {
+      "tx": 13,
+      "ty": 39,
+      "tileId": "fenceTopBottom"
+    },
+    {
+      "tx": 13,
+      "ty": 40,
+      "tileId": "fenceTopBottom"
+    },
+    {
+      "tx": 13,
+      "ty": 41,
+      "tileId": "fenceTopBottom"
+    },
+    {
+      "tx": 13,
+      "ty": 42,
+      "tileId": "fenceTopBottom"
+    },
+    {
+      "tx": 13,
+      "ty": 43,
+      "tileId": "fenceTopBottom"
+    },
+    {
+      "tx": 13,
+      "ty": 44,
+      "tileId": "fenceTopBottom"
+    },
+    {
+      "tx": 13,
+      "ty": 45,
+      "tileId": "fenceTopBottom"
+    },
+    {
+      "tx": 13,
+      "ty": 46,
+      "tileId": "fenceTopBottom"
+    },
+    {
+      "tx": 13,
+      "ty": 47,
+      "tileId": "fenceTop"
+    },
+    {
+      "tx": 13,
+      "ty": 49,
+      "tileId": "fenceIsolated"
+    },
+    {
+      "comment": "crops"
+    },
+    {
+      "tx": 1,
+      "ty": 39,
+      "tileId": "topLeftPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 2,
+      "ty": 39,
+      "tileId": "topPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 3,
+      "ty": 39,
+      "tileId": "topPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 4,
+      "ty": 39,
+      "tileId": "topPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 5,
+      "ty": 39,
+      "tileId": "topPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 6,
+      "ty": 39,
+      "tileId": "topRightPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 1,
+      "ty": 40,
+      "tileId": "leftPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 2,
+      "ty": 40,
+      "tileId": "centerPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 3,
+      "ty": 40,
+      "tileId": "centerPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 4,
+      "ty": 40,
+      "tileId": "centerPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 5,
+      "ty": 40,
+      "tileId": "centerPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 6,
+      "ty": 40,
+      "tileId": "rightPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 1,
+      "ty": 41,
+      "tileId": "leftPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 2,
+      "ty": 41,
+      "tileId": "centerPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 3,
+      "ty": 41,
+      "tileId": "centerPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 4,
+      "ty": 41,
+      "tileId": "centerPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 5,
+      "ty": 41,
+      "tileId": "centerPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 6,
+      "ty": 41,
+      "tileId": "rightPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 1,
+      "ty": 42,
+      "tileId": "leftPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 2,
+      "ty": 42,
+      "tileId": "centerPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 3,
+      "ty": 42,
+      "tileId": "centerPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 4,
+      "ty": 42,
+      "tileId": "centerPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 5,
+      "ty": 42,
+      "tileId": "centerPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 6,
+      "ty": 42,
+      "tileId": "rightPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 1,
+      "ty": 43,
+      "tileId": "bottomLeftPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 2,
+      "ty": 43,
+      "tileId": "bottomPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 3,
+      "ty": 43,
+      "tileId": "bottomPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 4,
+      "ty": 43,
+      "tileId": "bottomPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 5,
+      "ty": 43,
+      "tileId": "bottomPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 6,
+      "ty": 43,
+      "tileId": "bottomRightPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 1,
+      "ty": 44,
+      "tileId": "topLeftPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 2,
+      "ty": 44,
+      "tileId": "topPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 3,
+      "ty": 44,
+      "tileId": "topPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 4,
+      "ty": 44,
+      "tileId": "topPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 5,
+      "ty": 44,
+      "tileId": "topPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 6,
+      "ty": 44,
+      "tileId": "topRightPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 1,
+      "ty": 45,
+      "tileId": "leftPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 2,
+      "ty": 45,
+      "tileId": "centerPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 3,
+      "ty": 45,
+      "tileId": "centerPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 4,
+      "ty": 45,
+      "tileId": "centerPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 5,
+      "ty": 45,
+      "tileId": "centerPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 6,
+      "ty": 45,
+      "tileId": "rightPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 1,
+      "ty": 46,
+      "tileId": "leftPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 2,
+      "ty": 46,
+      "tileId": "centerPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 3,
+      "ty": 46,
+      "tileId": "centerPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 4,
+      "ty": 46,
+      "tileId": "centerPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 5,
+      "ty": 46,
+      "tileId": "centerPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 6,
+      "ty": 46,
+      "tileId": "rightPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 1,
+      "ty": 47,
+      "tileId": "leftPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 2,
+      "ty": 47,
+      "tileId": "centerPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 3,
+      "ty": 47,
+      "tileId": "centerPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 4,
+      "ty": 47,
+      "tileId": "centerPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 5,
+      "ty": 47,
+      "tileId": "centerPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 6,
+      "ty": 47,
+      "tileId": "rightPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 1,
+      "ty": 48,
+      "tileId": "bottomLeftPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 2,
+      "ty": 48,
+      "tileId": "bottomPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 3,
+      "ty": 48,
+      "tileId": "bottomPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 4,
+      "ty": 48,
+      "tileId": "bottomPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 5,
+      "ty": 48,
+      "tileId": "bottomPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 6,
+      "ty": 48,
+      "tileId": "bottomRightPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 7,
+      "ty": 39,
+      "tileId": "topLeftPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 8,
+      "ty": 39,
+      "tileId": "topPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 9,
+      "ty": 39,
+      "tileId": "topPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 10,
+      "ty": 39,
+      "tileId": "topPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 11,
+      "ty": 39,
+      "tileId": "topPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 12,
+      "ty": 39,
+      "tileId": "topRightPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 7,
+      "ty": 40,
+      "tileId": "leftPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 8,
+      "ty": 40,
+      "tileId": "centerPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 9,
+      "ty": 40,
+      "tileId": "centerPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 10,
+      "ty": 40,
+      "tileId": "centerPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 11,
+      "ty": 40,
+      "tileId": "centerPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 12,
+      "ty": 40,
+      "tileId": "rightPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 7,
+      "ty": 41,
+      "tileId": "leftPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 8,
+      "ty": 41,
+      "tileId": "centerPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 9,
+      "ty": 41,
+      "tileId": "centerPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 10,
+      "ty": 41,
+      "tileId": "centerPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 11,
+      "ty": 41,
+      "tileId": "centerPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 12,
+      "ty": 41,
+      "tileId": "rightPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 7,
+      "ty": 42,
+      "tileId": "leftPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 8,
+      "ty": 42,
+      "tileId": "centerPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 9,
+      "ty": 42,
+      "tileId": "centerPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 10,
+      "ty": 42,
+      "tileId": "centerPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 11,
+      "ty": 42,
+      "tileId": "centerPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 12,
+      "ty": 42,
+      "tileId": "rightPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 7,
+      "ty": 43,
+      "tileId": "bottomLeftPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 8,
+      "ty": 43,
+      "tileId": "bottomPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 9,
+      "ty": 43,
+      "tileId": "bottomPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 10,
+      "ty": 43,
+      "tileId": "bottomPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 11,
+      "ty": 43,
+      "tileId": "bottomPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 12,
+      "ty": 43,
+      "tileId": "bottomRightPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 7,
+      "ty": 44,
+      "tileId": "topLeftPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 8,
+      "ty": 44,
+      "tileId": "topPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 9,
+      "ty": 44,
+      "tileId": "topPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 10,
+      "ty": 44,
+      "tileId": "topPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 11,
+      "ty": 44,
+      "tileId": "topPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 12,
+      "ty": 44,
+      "tileId": "topRightPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 7,
+      "ty": 45,
+      "tileId": "leftPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 8,
+      "ty": 45,
+      "tileId": "centerPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 9,
+      "ty": 45,
+      "tileId": "centerPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 10,
+      "ty": 45,
+      "tileId": "centerPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 11,
+      "ty": 45,
+      "tileId": "centerPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 12,
+      "ty": 45,
+      "tileId": "rightPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 7,
+      "ty": 46,
+      "tileId": "leftPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 8,
+      "ty": 46,
+      "tileId": "centerPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 9,
+      "ty": 46,
+      "tileId": "centerPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 10,
+      "ty": 46,
+      "tileId": "centerPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 11,
+      "ty": 46,
+      "tileId": "centerPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 12,
+      "ty": 46,
+      "tileId": "rightPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 7,
+      "ty": 47,
+      "tileId": "leftPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 8,
+      "ty": 47,
+      "tileId": "centerPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 9,
+      "ty": 47,
+      "tileId": "centerPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 10,
+      "ty": 47,
+      "tileId": "centerPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 11,
+      "ty": 47,
+      "tileId": "centerPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 12,
+      "ty": 47,
+      "tileId": "rightPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 7,
+      "ty": 48,
+      "tileId": "bottomLeftPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 8,
+      "ty": 48,
+      "tileId": "bottomPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 9,
+      "ty": 48,
+      "tileId": "bottomPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 10,
+      "ty": 48,
+      "tileId": "bottomPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 11,
+      "ty": 48,
+      "tileId": "bottomPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "tx": 12,
+      "ty": 48,
+      "tileId": "bottomRightPlough",
+      "zlayer": "below-avatar"
+    },
+    {
+      "comment": "courtyard fountain"
+    },
+    {
+      "tx": 36,
+      "ty": 25,
+      "bundleID": "fountain"
+    },
     {
       "comment": "pond decor"
     },
@@ -1548,383 +2350,98 @@
     },
     {
       "tx": 0,
-      "ty": 0,
-      "tileId": "darkTreeTopLeft"
-    },
-    {
-      "tx": 1,
-      "ty": 0,
-      "tileId": "darkTreeTopRight"
-    },
-    {
-      "tx": 0,
       "ty": 1,
-      "tileId": "darkTreeBottomLeft"
-    },
-    {
-      "tx": 1,
-      "ty": 1,
-      "tileId": "darkTreeBottomRight"
-    },
-    {
-      "tx": 0,
-      "ty": 3,
-      "tileId": "darkTreeTopLeft"
-    },
-    {
-      "tx": 1,
-      "ty": 3,
-      "tileId": "darkTreeTopRight"
+      "bundleID": "dark-tree"
     },
     {
       "tx": 0,
       "ty": 4,
-      "tileId": "darkTreeBottomLeft"
-    },
-    {
-      "tx": 1,
-      "ty": 4,
-      "tileId": "darkTreeBottomRight"
-    },
-    {
-      "tx": 0,
-      "ty": 6,
-      "tileId": "darkTreeTopLeft"
-    },
-    {
-      "tx": 1,
-      "ty": 6,
-      "tileId": "darkTreeTopRight"
+      "bundleID": "dark-tree"
     },
     {
       "tx": 0,
       "ty": 7,
-      "tileId": "darkTreeBottomLeft"
-    },
-    {
-      "tx": 1,
-      "ty": 7,
-      "tileId": "darkTreeBottomRight"
-    },
-    {
-      "tx": 0,
-      "ty": 9,
-      "tileId": "darkTreeTopLeft"
-    },
-    {
-      "tx": 1,
-      "ty": 9,
-      "tileId": "darkTreeTopRight"
+      "bundleID": "dark-tree"
     },
     {
       "tx": 0,
       "ty": 10,
-      "tileId": "darkTreeBottomLeft"
+      "bundleID": "dark-tree"
     },
     {
-      "tx": 1,
+      "tx": 12,
+      "ty": 1,
+      "bundleID": "dark-tree"
+    },
+    {
+      "tx": 20,
+      "ty": 1,
+      "bundleID": "dark-tree"
+    },
+    {
+      "tx": 20,
+      "ty": 4,
+      "bundleID": "dark-tree"
+    },
+    {
+      "tx": 29,
+      "ty": 1,
+      "bundleID": "dark-tree"
+    },
+    {
+      "tx": 39,
+      "ty": 1,
+      "bundleID": "dark-tree"
+    },
+    {
+      "tx": 46,
+      "ty": 2,
+      "bundleID": "dark-tree"
+    },
+    {
+      "tx": 65,
+      "ty": 2,
+      "bundleID": "dark-tree"
+    },
+    {
+      "tx": 66,
+      "ty": 1,
+      "bundleID": "dark-tree"
+    },
+    {
+      "tx": 68,
+      "ty": 1,
+      "bundleID": "dark-tree"
+    },
+    {
+      "tx": 69,
+      "ty": 4,
+      "bundleID": "dark-tree"
+    },
+    {
+      "tx": 50,
       "ty": 10,
-      "tileId": "darkTreeBottomRight"
+      "bundleID": "dark-tree"
     },
     {
-      "tx": 12,
-      "ty": 0,
-      "tileId": "darkTreeTopLeft"
-    },
-    {
-      "tx": 13,
-      "ty": 0,
-      "tileId": "darkTreeTopRight"
-    },
-    {
-      "tx": 12,
-      "ty": 1,
-      "tileId": "darkTreeBottomLeft"
-    },
-    {
-      "tx": 13,
-      "ty": 1,
-      "tileId": "darkTreeBottomRight"
-    },
-    {
-      "tx": 20,
-      "ty": 0,
-      "tileId": "darkTreeTopLeft"
-    },
-    {
-      "tx": 21,
-      "ty": 0,
-      "tileId": "darkTreeTopRight"
-    },
-    {
-      "tx": 20,
-      "ty": 1,
-      "tileId": "darkTreeBottomLeft"
-    },
-    {
-      "tx": 21,
-      "ty": 1,
-      "tileId": "darkTreeBottomRight"
-    },
-    {
-      "tx": 20,
-      "ty": 3,
-      "tileId": "darkTreeTopLeft"
-    },
-    {
-      "tx": 21,
-      "ty": 3,
-      "tileId": "darkTreeTopRight"
-    },
-    {
-      "tx": 20,
-      "ty": 4,
-      "tileId": "darkTreeBottomLeft"
-    },
-    {
-      "tx": 21,
-      "ty": 4,
-      "tileId": "darkTreeBottomRight"
-    },
-    {
-      "tx": 29,
-      "ty": 0,
-      "tileId": "darkTreeTopLeft"
-    },
-    {
-      "tx": 30,
-      "ty": 0,
-      "tileId": "darkTreeTopRight"
-    },
-    {
-      "tx": 29,
-      "ty": 1,
-      "tileId": "darkTreeBottomLeft"
-    },
-    {
-      "tx": 30,
-      "ty": 1,
-      "tileId": "darkTreeBottomRight"
-    },
-    {
-      "tx": 39,
-      "ty": 0,
-      "tileId": "darkTreeTopLeft"
-    },
-    {
-      "tx": 40,
-      "ty": 0,
-      "tileId": "darkTreeTopRight"
-    },
-    {
-      "tx": 39,
-      "ty": 1,
-      "tileId": "darkTreeBottomLeft"
-    },
-    {
-      "tx": 40,
-      "ty": 1,
-      "tileId": "darkTreeBottomRight"
-    },
-    {
-      "tx": 51,
-      "ty": 0,
-      "tileId": "darkTreeTopLeft"
-    },
-    {
-      "tx": 52,
-      "ty": 0,
-      "tileId": "darkTreeTopRight"
-    },
-    {
-      "tx": 51,
-      "ty": 1,
-      "tileId": "darkTreeBottomLeft"
-    },
-    {
-      "tx": 52,
-      "ty": 1,
-      "tileId": "darkTreeBottomRight"
-    },
-    {
-      "tx": 58,
-      "ty": 0,
-      "tileId": "darkTreeTopLeft"
-    },
-    {
-      "tx": 59,
-      "ty": 0,
-      "tileId": "darkTreeTopRight"
-    },
-    {
-      "tx": 58,
-      "ty": 1,
-      "tileId": "darkTreeBottomLeft"
-    },
-    {
-      "tx": 59,
-      "ty": 1,
-      "tileId": "darkTreeBottomRight"
-    },
-    {
-      "tx": 69,
-      "ty": 0,
-      "tileId": "darkTreeTopLeft"
-    },
-    {
-      "tx": 70,
-      "ty": 0,
-      "tileId": "darkTreeTopRight"
-    },
-    {
-      "tx": 69,
-      "ty": 1,
-      "tileId": "darkTreeBottomLeft"
-    },
-    {
-      "tx": 70,
-      "ty": 1,
-      "tileId": "darkTreeBottomRight"
+      "tx": 61,
+      "ty": 10,
+      "bundleID": "dark-tree"
     },
     {
       "tx": 72,
-      "ty": 0,
-      "tileId": "darkTreeTopLeft"
-    },
-    {
-      "tx": 73,
-      "ty": 0,
-      "tileId": "darkTreeTopRight"
-    },
-    {
-      "tx": 72,
-      "ty": 1,
-      "tileId": "darkTreeBottomLeft"
-    },
-    {
-      "tx": 73,
-      "ty": 1,
-      "tileId": "darkTreeBottomRight"
-    },
-    {
-      "tx": 72,
-      "ty": 3,
-      "tileId": "darkTreeTopLeft"
-    },
-    {
-      "tx": 73,
-      "ty": 3,
-      "tileId": "darkTreeTopRight"
-    },
-    {
-      "tx": 72,
-      "ty": 4,
-      "tileId": "darkTreeBottomLeft"
-    },
-    {
-      "tx": 73,
-      "ty": 4,
-      "tileId": "darkTreeBottomRight"
-    },
-    {
-      "tx": 51,
-      "ty": 8,
-      "tileId": "darkTreeTopLeft"
-    },
-    {
-      "tx": 52,
-      "ty": 8,
-      "tileId": "darkTreeTopRight"
-    },
-    {
-      "tx": 51,
-      "ty": 9,
-      "tileId": "darkTreeBottomLeft"
-    },
-    {
-      "tx": 52,
-      "ty": 9,
-      "tileId": "darkTreeBottomRight"
-    },
-    {
-      "tx": 58,
-      "ty": 8,
-      "tileId": "darkTreeTopLeft"
-    },
-    {
-      "tx": 59,
-      "ty": 8,
-      "tileId": "darkTreeTopRight"
-    },
-    {
-      "tx": 58,
-      "ty": 9,
-      "tileId": "darkTreeBottomLeft"
-    },
-    {
-      "tx": 59,
-      "ty": 9,
-      "tileId": "darkTreeBottomRight"
-    },
-    {
-      "tx": 72,
-      "ty": 8,
-      "tileId": "darkTreeTopLeft"
-    },
-    {
-      "tx": 73,
-      "ty": 8,
-      "tileId": "darkTreeTopRight"
-    },
-    {
-      "tx": 72,
-      "ty": 9,
-      "tileId": "darkTreeBottomLeft"
-    },
-    {
-      "tx": 73,
-      "ty": 9,
-      "tileId": "darkTreeBottomRight"
-    },
-    {
-      "tx": 30,
-      "ty": 29,
-      "tileId": "darkTreeTopLeft"
-    },
-    {
-      "tx": 31,
-      "ty": 29,
-      "tileId": "darkTreeTopRight"
+      "ty": 12,
+      "bundleID": "dark-tree"
     },
     {
       "tx": 30,
       "ty": 30,
-      "tileId": "darkTreeBottomLeft"
-    },
-    {
-      "tx": 31,
-      "ty": 30,
-      "tileId": "darkTreeBottomRight"
-    },
-    {
-      "tx": 32,
-      "ty": 29,
-      "tileId": "darkTreeTopLeft"
-    },
-    {
-      "tx": 33,
-      "ty": 29,
-      "tileId": "darkTreeTopRight"
+      "bundleID": "dark-tree"
     },
     {
       "tx": 32,
       "ty": 30,
-      "tileId": "darkTreeBottomLeft"
-    },
-    {
-      "tx": 33,
-      "ty": 30,
-      "tileId": "darkTreeBottomRight"
+      "bundleID": "dark-tree"
     },
     {
       "comment": ""
@@ -1972,7 +2489,7 @@
     {
       "tx": 34,
       "ty": 33,
-      "tileId": "darkTreeBottomLeft"
+      "bundleID": "dark-tree"
     },
     {
       "tx": 35,
@@ -2057,7 +2574,7 @@
     {
       "tx": 30,
       "ty": 38,
-      "tileId": "darkTreeBottomLeft"
+      "bundleID": "dark-tree"
     },
     {
       "tx": 31,
@@ -2072,7 +2589,7 @@
     {
       "tx": 31,
       "ty": 39,
-      "tileId": "darkTreeBottomLeft"
+      "bundleID": "dark-tree"
     },
     {
       "tx": 32,
@@ -2082,7 +2599,7 @@
     {
       "tx": 33,
       "ty": 39,
-      "tileId": "darkTreeBottomLeft"
+      "bundleID": "dark-tree"
     },
     {
       "tx": 34,
@@ -2092,7 +2609,7 @@
     {
       "tx": 33,
       "ty": 39,
-      "tileId": "darkTreeBottomLeft"
+      "bundleID": "dark-tree"
     },
     {
       "tx": 39,
@@ -2147,7 +2664,7 @@
     {
       "tx": 39,
       "ty": 34,
-      "tileId": "darkTreeBottomLeft"
+      "bundleID": "dark-tree"
     },
     {
       "tx": 40,
@@ -2187,7 +2704,7 @@
     {
       "tx": 39,
       "ty": 38,
-      "tileId": "darkTreeBottomLeft"
+      "bundleID": "dark-tree"
     },
     {
       "tx": 40,
@@ -2207,7 +2724,7 @@
     {
       "tx": 53,
       "ty": 22,
-      "tileId": "darkTreeBottomLeft"
+      "bundleID": "dark-tree"
     },
     {
       "tx": 54,
@@ -2227,7 +2744,7 @@
     {
       "tx": 53,
       "ty": 28,
-      "tileId": "darkTreeBottomLeft"
+      "bundleID": "dark-tree"
     },
     {
       "tx": 54,
@@ -2247,7 +2764,7 @@
     {
       "tx": 53,
       "ty": 44,
-      "tileId": "darkTreeBottomLeft"
+      "bundleID": "dark-tree"
     },
     {
       "tx": 54,
@@ -2267,7 +2784,7 @@
     {
       "tx": 69,
       "ty": 22,
-      "tileId": "darkTreeBottomLeft"
+      "bundleID": "dark-tree"
     },
     {
       "tx": 70,
@@ -2287,7 +2804,7 @@
     {
       "tx": 69,
       "ty": 40,
-      "tileId": "darkTreeBottomLeft"
+      "bundleID": "dark-tree"
     },
     {
       "tx": 70,
@@ -2307,7 +2824,7 @@
     {
       "tx": 72,
       "ty": 22,
-      "tileId": "darkTreeBottomLeft"
+      "bundleID": "dark-tree"
     },
     {
       "tx": 73,
@@ -2327,7 +2844,7 @@
     {
       "tx": 72,
       "ty": 28,
-      "tileId": "darkTreeBottomLeft"
+      "bundleID": "dark-tree"
     },
     {
       "tx": 73,
@@ -2347,7 +2864,7 @@
     {
       "tx": 72,
       "ty": 40,
-      "tileId": "darkTreeBottomLeft"
+      "bundleID": "dark-tree"
     },
     {
       "tx": 73,
@@ -2531,7 +3048,7 @@
     },
     {
       "tx": 20,
-      "ty": 11,
+      "ty": 10,
       "tileId": "smallRock"
     },
     {
@@ -2555,7 +3072,7 @@
       "tileId": "smallRock"
     },
     {
-      "tx": 60,
+      "tx": 59,
       "ty": 26,
       "tileId": "smallRock"
     },
@@ -2585,12 +3102,12 @@
       "tileId": "grassTuft"
     },
     {
-      "tx": 59,
+      "tx": 56,
       "ty": 5,
       "tileId": "grassTuft"
     },
     {
-      "tx": 71,
+      "tx": 69,
       "ty": 5,
       "tileId": "grassTuft"
     },
@@ -2612,7 +3129,6 @@
     {
       "comment": "church exterior decor"
     },
-
     {
       "tx": 5,
       "ty": 59,
@@ -2971,43 +3487,13 @@
     },
     {
       "tx": 7,
-      "ty": 62,
-      "tileId": "deadTreeTopLeft"
-    },
-    {
-      "tx": 8,
-      "ty": 62,
-      "tileId": "deadTreeTopRight"
-    },
-    {
-      "tx": 7,
       "ty": 63,
-      "tileId": "deadTreeBottomLeft"
-    },
-    {
-      "tx": 8,
-      "ty": 63,
-      "tileId": "deadTreeBottomRight"
-    },
-    {
-      "tx": 20,
-      "ty": 66,
-      "tileId": "deadTreeTopLeft"
-    },
-    {
-      "tx": 21,
-      "ty": 66,
-      "tileId": "deadTreeTopRight"
+      "bundleID": "dead-tree"
     },
     {
       "tx": 20,
       "ty": 67,
-      "tileId": "deadTreeBottomLeft"
-    },
-    {
-      "tx": 21,
-      "ty": 67,
-      "tileId": "deadTreeBottomRight"
+      "bundleID": "dead-tree"
     },
     {
       "tx": 10,
@@ -3062,45 +3548,122 @@
     {
       "comment": "portcullis in gatehouse road gap"
     },
-    { "tx": 35, "ty": 58, "tileId": "greySlateRoofRow2", "zlayer": "above" },    
-    { "tx": 36, "ty": 58, "tileId": "greySlateRoofRow2", "zlayer": "above" },
-    { "tx": 37, "ty": 58, "tileId": "greySlateRoofRow2", "zlayer": "above" },
-    { "tx": 38, "ty": 58, "tileId": "greySlateRoofRow2", "zlayer": "above" },
-    { "tx": 39, "ty": 58, "tileId": "greySlateRoofRow2", "zlayer": "above" },
-
-    { "tx": 35, "ty": 59, "tileId": "greySlateRoofRow3", "zlayer": "above" },    
-    { "tx": 36, "ty": 59, "tileId": "greySlateRoofRow3", "zlayer": "above" },
-    { "tx": 37, "ty": 59, "tileId": "greySlateRoofRow3", "zlayer": "above" },
-    { "tx": 38, "ty": 59, "tileId": "greySlateRoofRow3", "zlayer": "above" },
-    { "tx": 39, "ty": 59, "tileId": "greySlateRoofRow3", "zlayer": "above" },    
-
-    { "tx": 35, "ty": 60, "tileId": "greySlateRoofRow4", "zlayer": "above" },    
-    { "tx": 36, "ty": 60, "tileId": "greySlateRoofRow4", "zlayer": "above" },
-    { "tx": 37, "ty": 60, "tileId": "greySlateRoofRow4", "zlayer": "above" },
-    { "tx": 38, "ty": 60, "tileId": "greySlateRoofRow4", "zlayer": "above" },
-    { "tx": 39, "ty": 60, "tileId": "greySlateRoofRow4", "zlayer": "above" },
-
-    { "tx": 35,
+    {
+      "tx": 35,
+      "ty": 58,
+      "tileId": "greySlateRoofRow2",
+      "zlayer": "above"
+    },
+    {
+      "tx": 36,
+      "ty": 58,
+      "tileId": "greySlateRoofRow2",
+      "zlayer": "above"
+    },
+    {
+      "tx": 37,
+      "ty": 58,
+      "tileId": "greySlateRoofRow2",
+      "zlayer": "above"
+    },
+    {
+      "tx": 38,
+      "ty": 58,
+      "tileId": "greySlateRoofRow2",
+      "zlayer": "above"
+    },
+    {
+      "tx": 39,
+      "ty": 58,
+      "tileId": "greySlateRoofRow2",
+      "zlayer": "above"
+    },
+    {
+      "tx": 35,
+      "ty": 59,
+      "tileId": "greySlateRoofRow3",
+      "zlayer": "above"
+    },
+    {
+      "tx": 36,
+      "ty": 59,
+      "tileId": "greySlateRoofRow3",
+      "zlayer": "above"
+    },
+    {
+      "tx": 37,
+      "ty": 59,
+      "tileId": "greySlateRoofRow3",
+      "zlayer": "above"
+    },
+    {
+      "tx": 38,
+      "ty": 59,
+      "tileId": "greySlateRoofRow3",
+      "zlayer": "above"
+    },
+    {
+      "tx": 39,
+      "ty": 59,
+      "tileId": "greySlateRoofRow3",
+      "zlayer": "above"
+    },
+    {
+      "tx": 35,
+      "ty": 60,
+      "tileId": "greySlateRoofRow4",
+      "zlayer": "above"
+    },
+    {
+      "tx": 36,
+      "ty": 60,
+      "tileId": "greySlateRoofRow4",
+      "zlayer": "above"
+    },
+    {
+      "tx": 37,
+      "ty": 60,
+      "tileId": "greySlateRoofRow4",
+      "zlayer": "above"
+    },
+    {
+      "tx": 38,
+      "ty": 60,
+      "tileId": "greySlateRoofRow4",
+      "zlayer": "above"
+    },
+    {
+      "tx": 39,
+      "ty": 60,
+      "tileId": "greySlateRoofRow4",
+      "zlayer": "above"
+    },
+    {
+      "tx": 35,
       "ty": 61,
       "tileId": "portcullisTopLeft",
       "zlayer": "above"
     },
-    { "tx": 36,
+    {
+      "tx": 36,
       "ty": 61,
       "tileId": "portcullisTopLeft",
       "zlayer": "above"
     },
-    { "tx": 37,
+    {
+      "tx": 37,
       "ty": 61,
       "tileId": "portcullisTopLeft",
       "zlayer": "above"
     },
-    { "tx": 38,
+    {
+      "tx": 38,
       "ty": 61,
       "tileId": "portcullisTopLeft",
       "zlayer": "above"
     },
-    { "tx": 39,
+    {
+      "tx": 39,
       "ty": 61,
       "tileId": "portcullisTopLeft",
       "zlayer": "above"
@@ -3135,88 +3698,208 @@
       "tileId": "portcullisBottomLeft",
       "zlayer": "above"
     },
-
-    { "tx": 35, "ty": 61, "tileId": "wallArchTopLeft", "zlayer": "above" },    
-    { "tx": 36, "ty": 61, "tileId": "wallArchTopMiddle", "zlayer": "above" },    
-    { "tx": 37, "ty": 61, "tileId": "wallArchTopMiddle", "zlayer": "above" },    
-    { "tx": 38, "ty": 61, "tileId": "wallArchTopMiddle", "zlayer": "above" },    
-    { "tx": 39, "ty": 61, "tileId": "wallArchTopRight", "zlayer": "above" },        
-
-    { "tx": 35, "ty": 62, "tileId": "wallArchLeft", "zlayer": "above" },    
-    { "tx": 36, "ty": 62, "tileId": "wallArchFill", "zlayer": "above" },    
-    { "tx": 37, "ty": 62, "tileId": "wallArchFill", "zlayer": "above" },    
-    { "tx": 38, "ty": 62, "tileId": "wallArchFill", "zlayer": "above" },    
-    { "tx": 39, "ty": 62, "tileId": "wallArchRight", "zlayer": "above" },    
-
-    { "tx": 35, "ty": 63, "tileId": "wallArchLeft", "zlayer": "above" },    
-    { "tx": 36, "ty": 63, "tileId": "wallArchFill", "zlayer": "above" },    
-    { "tx": 37, "ty": 63, "tileId": "wallArchFill", "zlayer": "above" },    
-    { "tx": 38, "ty": 63, "tileId": "wallArchFill", "zlayer": "above" },    
-    { "tx": 39, "ty": 63, "tileId": "wallArchRight", "zlayer": "above" },    
-
-    { "tx": 35, "ty": 64, "tileId": "wallArchLeft", "zlayer": "above" },    
-    { "tx": 36, "ty": 64, "tileId": "wallArchFill", "zlayer": "above" },    
-    { "tx": 37, "ty": 64, "tileId": "wallArchFill", "zlayer": "above" },    
-    { "tx": 38, "ty": 64, "tileId": "wallArchFill", "zlayer": "above" },    
-    { "tx": 39, "ty": 64, "tileId": "wallArchRight", "zlayer": "above" },    
-
-    { "tx": 35, "ty": 65, "tileId": "wallArchLeft", "zlayer": "above" },    
-    { "tx": 36, "ty": 65, "tileId": "wallArchFill", "zlayer": "above" },    
-    { "tx": 37, "ty": 65, "tileId": "wallArchFill", "zlayer": "above" },    
-    { "tx": 38, "ty": 65, "tileId": "wallArchFill", "zlayer": "above" },    
-    { "tx": 39, "ty": 65, "tileId": "wallArchRight", "zlayer": "above" },    
-
-    { "tx": 35, "ty": 66, "tileId": "wallArchLeft", "zlayer": "above" },    
-    { "tx": 36, "ty": 66, "tileId": "wallArchFill", "zlayer": "above" },    
-    { "tx": 37, "ty": 66, "tileId": "wallArchFill", "zlayer": "above" },    
-    { "tx": 38, "ty": 66, "tileId": "wallArchFill", "zlayer": "above" },    
-    { "tx": 39, "ty": 66, "tileId": "wallArchRight", "zlayer": "above" },    
-
-    { "tx": 40, "ty": 68, "tileId": "roadSignTop" },
-    { "tx": 40, "ty": 69, "tileId": "roadSignBottom" },    
-
+    {
+      "tx": 35,
+      "ty": 61,
+      "tileId": "wallArchTopLeft",
+      "zlayer": "above"
+    },
+    {
+      "tx": 36,
+      "ty": 61,
+      "tileId": "wallArchTopMiddle",
+      "zlayer": "above"
+    },
+    {
+      "tx": 37,
+      "ty": 61,
+      "tileId": "wallArchTopMiddle",
+      "zlayer": "above"
+    },
+    {
+      "tx": 38,
+      "ty": 61,
+      "tileId": "wallArchTopMiddle",
+      "zlayer": "above"
+    },
+    {
+      "tx": 39,
+      "ty": 61,
+      "tileId": "wallArchTopRight",
+      "zlayer": "above"
+    },
+    {
+      "tx": 35,
+      "ty": 62,
+      "tileId": "wallArchLeft",
+      "zlayer": "above"
+    },
+    {
+      "tx": 36,
+      "ty": 62,
+      "tileId": "wallArchFill",
+      "zlayer": "above"
+    },
+    {
+      "tx": 37,
+      "ty": 62,
+      "tileId": "wallArchFill",
+      "zlayer": "above"
+    },
+    {
+      "tx": 38,
+      "ty": 62,
+      "tileId": "wallArchFill",
+      "zlayer": "above"
+    },
+    {
+      "tx": 39,
+      "ty": 62,
+      "tileId": "wallArchRight",
+      "zlayer": "above"
+    },
+    {
+      "tx": 35,
+      "ty": 63,
+      "tileId": "wallArchLeft",
+      "zlayer": "above"
+    },
+    {
+      "tx": 36,
+      "ty": 63,
+      "tileId": "wallArchFill",
+      "zlayer": "above"
+    },
+    {
+      "tx": 37,
+      "ty": 63,
+      "tileId": "wallArchFill",
+      "zlayer": "above"
+    },
+    {
+      "tx": 38,
+      "ty": 63,
+      "tileId": "wallArchFill",
+      "zlayer": "above"
+    },
+    {
+      "tx": 39,
+      "ty": 63,
+      "tileId": "wallArchRight",
+      "zlayer": "above"
+    },
+    {
+      "tx": 35,
+      "ty": 64,
+      "tileId": "wallArchLeft",
+      "zlayer": "above"
+    },
+    {
+      "tx": 36,
+      "ty": 64,
+      "tileId": "wallArchFill",
+      "zlayer": "above"
+    },
+    {
+      "tx": 37,
+      "ty": 64,
+      "tileId": "wallArchFill",
+      "zlayer": "above"
+    },
+    {
+      "tx": 38,
+      "ty": 64,
+      "tileId": "wallArchFill",
+      "zlayer": "above"
+    },
+    {
+      "tx": 39,
+      "ty": 64,
+      "tileId": "wallArchRight",
+      "zlayer": "above"
+    },
+    {
+      "tx": 35,
+      "ty": 65,
+      "tileId": "wallArchLeft",
+      "zlayer": "above"
+    },
+    {
+      "tx": 36,
+      "ty": 65,
+      "tileId": "wallArchFill",
+      "zlayer": "above"
+    },
+    {
+      "tx": 37,
+      "ty": 65,
+      "tileId": "wallArchFill",
+      "zlayer": "above"
+    },
+    {
+      "tx": 38,
+      "ty": 65,
+      "tileId": "wallArchFill",
+      "zlayer": "above"
+    },
+    {
+      "tx": 39,
+      "ty": 65,
+      "tileId": "wallArchRight",
+      "zlayer": "above"
+    },
+    {
+      "tx": 35,
+      "ty": 66,
+      "tileId": "wallArchLeft",
+      "zlayer": "above"
+    },
+    {
+      "tx": 36,
+      "ty": 66,
+      "tileId": "wallArchFill",
+      "zlayer": "above"
+    },
+    {
+      "tx": 37,
+      "ty": 66,
+      "tileId": "wallArchFill",
+      "zlayer": "above"
+    },
+    {
+      "tx": 38,
+      "ty": 66,
+      "tileId": "wallArchFill",
+      "zlayer": "above"
+    },
+    {
+      "tx": 39,
+      "ty": 66,
+      "tileId": "wallArchRight",
+      "zlayer": "above"
+    },
+    {
+      "tx": 40,
+      "ty": 68,
+      "tileId": "roadSignTop"
+    },
+    {
+      "tx": 40,
+      "ty": 69,
+      "tileId": "roadSignBottom"
+    },
     {
       "comment": "south expansion atmosphere"
     },
     {
       "tx": 25,
-      "ty": 51,
-      "tileId": "autumnTreeTopLeft"
-    },
-    {
-      "tx": 26,
-      "ty": 51,
-      "tileId": "autumnTreeTopRight"
-    },
-    {
-      "tx": 25,
       "ty": 52,
-      "tileId": "autumnTreeBottomLeft"
-    },
-    {
-      "tx": 26,
-      "ty": 52,
-      "tileId": "autumnTreeBottomRight"
-    },
-    {
-      "tx": 27,
-      "ty": 54,
-      "tileId": "autumnTreeTopLeft"
-    },
-    {
-      "tx": 28,
-      "ty": 54,
-      "tileId": "autumnTreeTopRight"
+      "bundleID": "autumn-tree"
     },
     {
       "tx": 27,
       "ty": 55,
-      "tileId": "autumnTreeBottomLeft"
-    },
-    {
-      "tx": 28,
-      "ty": 55,
-      "tileId": "autumnTreeBottomRight"
+      "bundleID": "autumn-tree"
     },
     {
       "tx": 42,
@@ -3688,9 +4371,21 @@
       "height": 9,
       "floorTileId": "parquetFloor",
       "decor": [
-        { "tx": 2, "ty": 2, "bundleID": "simple-bed" },
-        { "tx": 3, "ty": 2, "bundleID": "simple-bed" },
-        { "tx": 8, "ty": 1, "bundleID": "fireplace" },
+        {
+          "tx": 2,
+          "ty": 2,
+          "bundleID": "simple-bed"
+        },
+        {
+          "tx": 3,
+          "ty": 2,
+          "bundleID": "simple-bed"
+        },
+        {
+          "tx": 8,
+          "ty": 1,
+          "bundleID": "fireplace"
+        },
         {
           "tx": 5,
           "ty": 4,
@@ -4428,10 +5123,26 @@
       "height": 8,
       "floorTileId": "darkStoneFloor",
       "decor": [
-        { "tx": 2,  "ty": 3, "bundleID": "simple-bed" },
-        { "tx": 4,  "ty": 3, "bundleID": "simple-bed" },
-        { "tx": 10, "ty": 3, "bundleID": "simple-bed" },
-        { "tx": 12, "ty": 3, "bundleID": "simple-bed" },
+        {
+          "tx": 2,
+          "ty": 3,
+          "bundleID": "simple-bed"
+        },
+        {
+          "tx": 4,
+          "ty": 3,
+          "bundleID": "simple-bed"
+        },
+        {
+          "tx": 10,
+          "ty": 3,
+          "bundleID": "simple-bed"
+        },
+        {
+          "tx": 12,
+          "ty": 3,
+          "bundleID": "simple-bed"
+        },
         {
           "tx": 7,
           "ty": 4,
@@ -4822,10 +5533,26 @@
       "floorTileId": "darkWoodFloor",
       "wallMaterial": "tudor",
       "decor": [
-        { "tx": 2, "ty": 2, "bundleID": "simple-bed" },
-        { "tx": 4, "ty": 2, "bundleID": "simple-bed" },
-        { "tx": 7, "ty": 2, "bundleID": "simple-bed" },
-        { "tx": 9, "ty": 2, "bundleID": "simple-bed" },
+        {
+          "tx": 2,
+          "ty": 2,
+          "bundleID": "simple-bed"
+        },
+        {
+          "tx": 4,
+          "ty": 2,
+          "bundleID": "simple-bed"
+        },
+        {
+          "tx": 7,
+          "ty": 2,
+          "bundleID": "simple-bed"
+        },
+        {
+          "tx": 9,
+          "ty": 2,
+          "bundleID": "simple-bed"
+        },
         {
           "tx": 5,
           "ty": 5,
@@ -4874,7 +5601,7 @@
           "ty": -1,
           "tileId": "ladderBottom",
           "zlayer": "below"
-        }  ,          
+        },
         {
           "tx": 1,
           "ty": 0,
@@ -4886,7 +5613,7 @@
           "ty": 0,
           "tileId": "ladderBottom",
           "zlayer": "below"
-        }  ,      
+        },
         {
           "tx": 1,
           "ty": 1,
@@ -5014,7 +5741,7 @@
       "name": "The Elder",
       "sprite": "hub-npc-elder",
       "tx": 19,
-      "ty": 12,
+      "ty": 10,
       "dialogue": [
         "The roads beyond the outer walls grow darker by the day. Tread carefully, wanderer.",
         "I remember when this courtyard was full of laughter. The Fracture changed everything.",
@@ -5123,7 +5850,7 @@
       "tx": 56,
       "ty": 9,
       "dialogue": [
-        "I have been cataloguing the Fracture shards. The answers are within your reach \u2014 if you dare.",
+        "I have been cataloguing the Fracture shards. The answers are within your reach — if you dare.",
         "The archives hold centuries of knowledge. Most of it was lost in the Fracture. What remains is precious.",
         "Do not underestimate the power of knowing your enemy, Commander."
       ],
@@ -5171,8 +5898,8 @@
       "tx": 50,
       "ty": 50,
       "dialogue": [
-        "Been sitting at this pond since before the Fracture. The water's gone quiet lately \u2014 something's stirring beneath.",
-        "I pulled out a strange glowing fish last week. Threw it back \u2014 some things are better left undisturbed.",
+        "Been sitting at this pond since before the Fracture. The water's gone quiet lately — something's stirring beneath.",
+        "I pulled out a strange glowing fish last week. Threw it back — some things are better left undisturbed.",
         "Patience, wanderer. The best things in life take time."
       ],
       "questGive": "greyfishs-bait",
@@ -5226,7 +5953,7 @@
       "ty": 26,
       "screen": "casino",
       "dialogue": [
-        "The wheel never lies. Step right up \u2014 fortune favours the bold.",
+        "The wheel never lies. Step right up — fortune favours the bold.",
         "I've seen a thousand players. The ones who win? They trust their instincts.",
         "One spin, one chance. What do you say, friend?"
       ],
@@ -5383,7 +6110,7 @@
       "screen": "shop-supplies",
       "dialogue": [
         "Got everything you need right here. Reliable gear, fair prices.",
-        "Stock up before you head out \u2014 the roads aren't safe.",
+        "Stock up before you head out — the roads aren't safe.",
         "I've been supplying adventurers for thirty years. I know what keeps folks alive."
       ],
       "questGive": "brambles-first-delivery",
@@ -5401,7 +6128,7 @@
       "dialogue": [
         "One person's junk is another's treasure. Have a rummage!",
         "I found this stuff all over the Fracture zones. Don't ask how.",
-        "Make me an offer \u2014 I'm always looking to deal."
+        "Make me an offer — I'm always looking to deal."
       ]
     },
     {
@@ -5498,7 +6225,7 @@
       "ty": 22,
       "screen": "marble",
       "dialogue": [
-        "Steady hands and a keen eye \u2014 care to roll?",
+        "Steady hands and a keen eye — care to roll?",
         "Every marble tells a story. Shall we write yours?"
       ]
     },
@@ -5522,7 +6249,7 @@
       "ty": 22,
       "screen": "crystalcatch",
       "dialogue": [
-        "Crystals falling fast \u2014 catch them before they shatter!",
+        "Crystals falling fast — catch them before they shatter!",
         "Speed and focus. That is all you need."
       ]
     },
@@ -5534,7 +6261,7 @@
       "ty": 22,
       "screen": "spinner",
       "dialogue": [
-        "Give it a spin \u2014 luck favours the bold.",
+        "Give it a spin — luck favours the bold.",
         "The wheel knows no favourites. Try your luck!"
       ]
     },
@@ -5546,7 +6273,7 @@
       "ty": 22,
       "screen": "marblerace",
       "dialogue": [
-        "On your marks \u2014 the race is about to begin!",
+        "On your marks — the race is about to begin!",
         "Place your bets and pick your marble. May the fastest win."
       ]
     },
@@ -5559,7 +6286,7 @@
       "screen": "higherOrLower",
       "dialogue": [
         "Higher or lower? Simple question, nerves of steel.",
-        "Read the deck \u2014 or trust your gut."
+        "Read the deck — or trust your gut."
       ]
     },
     {
@@ -5619,7 +6346,7 @@
       "screen": "citybuilder",
       "dialogue": [
         "A great city starts with a single road. Shall we begin?",
-        "Lay the streets, raise the buildings \u2014 this town is yours to shape."
+        "Lay the streets, raise the buildings — this town is yours to shape."
       ]
     },
     {
@@ -5647,7 +6374,7 @@
       "dialogue": [
         "I am cataloguing every tome in this wing. It may take years.",
         "The northern library holds records predating the Fracture. Fascinating.",
-        "Please keep your voice down \u2014 scholars are studying."
+        "Please keep your voice down — scholars are studying."
       ]
     },
     {
@@ -5699,7 +6426,7 @@
       "innRumours": [
         {
           "id": "rumour-barracks",
-          "text": "The south barracks wing has been sealed for years. Captain Thorin keeps to himself about it\u2026"
+          "text": "The south barracks wing has been sealed for years. Captain Thorin keeps to himself about it…"
         },
         {
           "id": "rumour-elder",
@@ -5715,7 +6442,7 @@
         },
         {
           "id": "rumour-pond",
-          "text": "Old Greyfish says the pond shimmers at night. Strange glimmers beneath the water, he says\u2026"
+          "text": "Old Greyfish says the pond shimmers at night. Strange glimmers beneath the water, he says…"
         }
       ]
     },
@@ -5780,7 +6507,7 @@
       "questGive": "zev-game-prize-restock",
       "dialogue": [
         "Step right up! The games never stop here.",
-        "Skill, luck, or cunning \u2014 what'll it be, Commander?",
+        "Skill, luck, or cunning — what'll it be, Commander?",
         "Every game is a battle. You look like you enjoy battles."
       ]
     },
@@ -5836,7 +6563,7 @@
       "ty": 3,
       "screen": "marble",
       "dialogue": [
-        "Steady hands and a keen eye \u2014 care to roll?",
+        "Steady hands and a keen eye — care to roll?",
         "Every marble tells a story. Shall we write yours?"
       ]
     },
@@ -5862,7 +6589,7 @@
       "ty": 5,
       "screen": "crystalcatch",
       "dialogue": [
-        "Crystals falling fast \u2014 catch them before they shatter!",
+        "Crystals falling fast — catch them before they shatter!",
         "Speed and focus. That is all you need."
       ]
     },
@@ -5888,7 +6615,7 @@
       "ty": 2,
       "screen": "spinner",
       "dialogue": [
-        "Give it a spin \u2014 luck favours the bold.",
+        "Give it a spin — luck favours the bold.",
         "The wheel knows no favourites. Try your luck!"
       ]
     },
@@ -5901,7 +6628,7 @@
       "ty": 2,
       "screen": "marblerace",
       "dialogue": [
-        "On your marks \u2014 the race is about to begin!",
+        "On your marks — the race is about to begin!",
         "Place your bets and pick your marble. May the fastest win."
       ]
     },
@@ -5915,7 +6642,7 @@
       "screen": "higherOrLower",
       "dialogue": [
         "Higher or lower? Simple question, nerves of steel.",
-        "Read the deck \u2014 or trust your gut."
+        "Read the deck — or trust your gut."
       ]
     },
     {


### PR DESCRIPTION
## Summary

- **Buildings**: click to select, drag to reposition — all \`rect\`/\`rects\` shift by the drag delta. Nested \`doors\`, \`windows\`, and \`decor\` are stored as relative coords so they follow automatically.
- **Streets / paths**: click any tile within a \`rect\` or \`tile\` entry to select it, drag to reposition the entire entry.
- **Drag offset fix**: stores \`clickTx − entityAnchorTx\` on mouse-down so large entities don't jump when you click anywhere other than their top-left corner.
- **Delete**: building and street deletion now wired up in \`deleteEntity\`.
- **Inspector**: \`StreetInspector\` shows rect/tile coords, path type, and delete button.
- **Save fix** (also in this commit): \`main.ts\` middleware now uses \`viteConfig.root\` instead of \`import.meta.url\`/\`__dirname\`, and the plugin is \`unshift\`ed with \`enforce: 'pre'\` so it intercepts before Storybook's catch-all.

## Test plan

- [ ] Restart Storybook — Save button now works
- [ ] Click a building → yellow outline, inspector shows Building panel
- [ ] Drag the building → it moves, inspector rect updates
- [ ] Click a street tile → yellow outline around the full rect
- [ ] Drag the street entry → entire rect repositions
- [ ] Undo/Redo a building move → reverts correctly
- [ ] Delete a building via inspector → building removed
- [ ] Save → \`git diff src/data/hub/config.json\` shows updated coords

🤖 Generated with [Claude Code](https://claude.ai/code)