### PR TITLE
Fix hub world navigation crash and WebGL context leak

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2962,7 +2962,7 @@ export default function App() {
         <CollectionTabScreen
           crystals={crystals}
           onCrystalsChanged={handleCrystalsChanged}
-          onBack={() => setScreen('title')}
+          onBack={() => setScreen(returnScreen)}
           commanderName={commander?.cardName ?? null}
           onPromoteCommander={(cardName) => {
             const ok = promoteCommander(cardName)
@@ -3035,7 +3035,7 @@ export default function App() {
       )}
 
       {screen === 'deckbuilder' && (
-        <DeckBuilder onBack={() => setScreen('title')} fatiguedCards={run ? fatiguedCards : []}/>
+        <DeckBuilder onBack={() => setScreen(returnScreen)} fatiguedCards={run ? fatiguedCards : []}/>
       )}
 
       {screen === 'pack' && (
@@ -3101,7 +3101,7 @@ export default function App() {
       )}
 
       {screen === 'dailychallenge' && (
-        <DailyChallengeScreen onStart={handleStartDailyChallenge} onBack={() => setScreen('title')} />
+        <DailyChallengeScreen onStart={handleStartDailyChallenge} onBack={() => setScreen(returnScreen)} />
       )}
 
       {screen === 'endlessleaderboard' && (

--- a/web/src/hooks/usePixiApp.ts
+++ b/web/src/hooks/usePixiApp.ts
@@ -41,9 +41,8 @@ export function usePixiApp(
     }).then(() => {
       initialized = true
       if (destroyed) {
-        // Strict Mode cleanup ran before init resolved — canvas was never inserted.
-        // Stop the ticker so this inert app consumes no CPU; it will be GC'd.
-        app.ticker.stop()
+        // Cleanup ran before init resolved — destroy properly to release the WebGL context.
+        app.destroy(true, { children: true, texture: false })
         return
       }
       container.appendChild(app.canvas)


### PR DESCRIPTION
Fixes #1558

## Summary

Two root causes found for hub world crashing/restarting on back navigation:

- **WebGL context leak** (`usePixiApp.ts`): When the user navigates away from hub before PixiJS finishes initialising, cleanup fires `destroyed = true` but the app was not yet destroyed (only the ticker was stopped). Each cycle leaked a WebGL context. Browsers cap simultaneous contexts (~16); after enough rapid navigations the canvas fails to initialise and the hub goes blank. Fixed by calling `app.destroy()` instead of `app.ticker.stop()` in the late-init branch.

- **Wrong back navigation** (`App.tsx`): Three screens accessible from hub had `onBack` hardcoded to `setScreen('title')` — `collection-tabs`, `deckbuilder`, and `dailychallenge`. Pressing back from any of these when entered from hub sent the player to the title screen (which then auto-redirected back to hub for players with hub-as-default, causing a jarring double-remount). Changed all three to use `setScreen(returnScreen)`, which is `'hubworld'` when entered from hub and `'title'` when entered from the title screen.

## Test plan
- [ ] Ravenwatch → Prize Keeper → back → returns to hub world (not title)
- [ ] Hub → Collection → back → returns to hub world
- [ ] Hub → Deck Builder → back → returns to hub world
- [ ] Hub → Daily Challenge → back → returns to hub world
- [ ] Title → Daily Challenge → back → returns to title (not hub)
- [ ] Navigate hub → prizes → hub → prizes → hub several times rapidly — canvas should remain functional throughout

https://claude.ai/code/session_01P8nXfryP3BH5kWAWPfsQ1N

---
_Generated by [Claude Code](https://claude.ai/code/session_01P8nXfryP3BH5kWAWPfsQ1N)_