### PR TITLE
fix(hub): prizes/citybuilder back button returns to hub when opened from hub world

### DIFF
--- a/web/src/components/screens/MiniGamesMenu.tsx
+++ b/web/src/components/screens/MiniGamesMenu.tsx
@@ -264,7 +264,7 @@ export function MiniGamesMenu({ crystals, onCrystalsChange, user, characterName,
     )
   }
   if (subScreen === 'citybuilder') {
-    return <CityBuilder onBack={() => setSubScreen('menu')} />
+    return <CityBuilder onBack={() => initialSubScreen === 'citybuilder' ? onBack() : setSubScreen('menu')} />
   }
 
   return (
@@ -338,7 +338,7 @@ export function MiniGamesMenu({ crystals, onCrystalsChange, user, characterName,
         {subScreen === 'prizes' && (
           <div className="prize-screen u-col">
             <div className="overlay-header u-flex u-items-c u-gap-6">
-              <button className="action-btn" onClick={() => setSubScreen('menu')}>← BACK</button>
+              <button className="action-btn" onClick={() => initialSubScreen === 'prizes' ? onBack() : setSubScreen('menu')}>← BACK</button>
               <span className="overlay-title">🎁 PRIZE SHOP</span>
               <div className="ticket-balance">🎫 {tickets}</div>
             </div>
@@ -374,7 +374,7 @@ export function MiniGamesMenu({ crystals, onCrystalsChange, user, characterName,
         {subScreen === 'leaderboard' && (
           <div className="lb-screen u-col">
             <div className="overlay-header u-flex u-items-c u-gap-6">
-              <button className="action-btn" onClick={() => setSubScreen('menu')}>← BACK</button>
+              <button className="action-btn" onClick={() => initialSubScreen === 'leaderboard' ? onBack() : setSubScreen('menu')}>← BACK</button>
               <span className="overlay-title">🏆 LEADERBOARDS</span>
             </div>
 

--- a/web/src/hooks/usePixiApp.ts
+++ b/web/src/hooks/usePixiApp.ts
@@ -52,6 +52,10 @@ export function usePixiApp(
     }).catch(e => {
       console.error('[usePixiApp] app.init failed', e)
       rollbar.error('[usePixiApp] app.init failed', { message: (e as Error)?.message })
+      // Release any partial WebGL context created before the failure to prevent
+      // context accumulation that crashes the browser after repeated navigations.
+      try { app.destroy(true, { children: true, texture: false }) } catch { /* partial init — best effort */ }
+      appRef.current = null
     })
 
     return () => {

--- a/web/src/hooks/usePixiApp.ts
+++ b/web/src/hooks/usePixiApp.ts
@@ -43,7 +43,7 @@ export function usePixiApp(
       initialized = true
       if (destroyed) {
         // Cleanup ran before init resolved — destroy properly to release the WebGL context.
-        rollbar.warn('[usePixiApp] init resolved after unmount — destroying orphan app')
+        rollbar?.warn('[usePixiApp] init resolved after unmount — destroying orphan app')
         app.destroy(true, { children: true, texture: false })
         return
       }
@@ -51,7 +51,7 @@ export function usePixiApp(
       onReady(app)
     }).catch(e => {
       console.error('[usePixiApp] app.init failed', e)
-      rollbar.error('[usePixiApp] app.init failed', { message: (e as Error)?.message })
+      rollbar?.error('[usePixiApp] app.init failed', { message: (e as Error)?.message })
       // Release any partial WebGL context created before the failure to prevent
       // context accumulation that crashes the browser after repeated navigations.
       try { app.destroy(true, { children: true, texture: false }) } catch { /* partial init — best effort */ }

--- a/web/src/hooks/usePixiApp.ts
+++ b/web/src/hooks/usePixiApp.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react'
 import * as PIXI from 'pixi.js'
+import rollbar from '../rollbar'
 
 /**
  * Initialises a PixiJS v8 Application and mounts its canvas into the given container.
@@ -42,12 +43,16 @@ export function usePixiApp(
       initialized = true
       if (destroyed) {
         // Cleanup ran before init resolved — destroy properly to release the WebGL context.
+        rollbar.warn('[usePixiApp] init resolved after unmount — destroying orphan app')
         app.destroy(true, { children: true, texture: false })
         return
       }
       container.appendChild(app.canvas)
       onReady(app)
-    }).catch(e => console.error('[usePixiApp] app.init failed', e))
+    }).catch(e => {
+      console.error('[usePixiApp] app.init failed', e)
+      rollbar.error('[usePixiApp] app.init failed', { message: (e as Error)?.message })
+    })
 
     return () => {
       destroyed = true


### PR DESCRIPTION
## Summary

- When prize keeper NPC opens the prizes screen directly (`hub-minigame` with `initialSubScreen='prizes'`), the prizes section's internal "← BACK" button was calling `setSubScreen('menu')` — dropping the player at the arcade menu they never visited, which felt like a crash
- Same issue affected the citybuilder and leaderboard subscreens when opened directly from hub
- Fixed by routing back via `onBack()` (→ hub world) when `initialSubScreen` matches the current subscreen; otherwise routes to arcade menu as before

## Test plan

- [ ] Tap prize keeper in Ravenwatch → prizes screen opens → press "← BACK" → returns directly to hub world (not arcade menu)
- [ ] Tap citybuilder node in hub → citybuilder opens → press back → returns to hub world
- [ ] Open arcade from hub (`minigames` screen) → navigate to prizes → press "← BACK" → returns to arcade menu (existing behaviour preserved)
- [ ] Same for leaderboard path

https://claude.ai/code/session_01P8nXfryP3BH5kWAWPfsQ1N

---
_Generated by [Claude Code](https://claude.ai/code/session_01P8nXfryP3BH5kWAWPfsQ1N)_