### PR TITLE
Fix milestone effects lingering + soft gas cloud rendering

### DIFF
--- a/web/src/components/minigames/towerdefence/GameGrid.tsx
+++ b/web/src/components/minigames/towerdefence/GameGrid.tsx
@@ -342,8 +342,11 @@ function drawAnimatedEffects(
 function drawHazards(g: PIXI.Graphics, hazards: TDGameState['hazards']) {
   g.clear()
   for (const h of hazards) {
-    g.circle(h.x, h.y, h.radius).fill({ color: 0x44bb44, alpha: 0.35 })
-    g.circle(h.x, h.y, h.radius).stroke({ width: 1, color: 0x88ff88, alpha: 0.5 })
+    // Three concentric fills approximate a radial gradient: opaque core fading to
+    // transparent at the edge — no hard outline stroke.
+    g.circle(h.x, h.y, h.radius).fill({ color: 0x44bb44, alpha: 0.06 })
+    g.circle(h.x, h.y, h.radius * 0.70).fill({ color: 0x44bb44, alpha: 0.14 })
+    g.circle(h.x, h.y, h.radius * 0.40).fill({ color: 0x66cc66, alpha: 0.22 })
   }
 }
 

--- a/web/src/game/towerDefence.ts
+++ b/web/src/game/towerDefence.ts
@@ -1274,7 +1274,7 @@ export function tickUnitsHomeOnly(state: TDGameState, dtMs: number): TDGameState
     if (d < 2) return unit
     return { ...unit, x: unit.x + dx / d * Math.min(step, d), y: unit.y + dy / d * Math.min(step, d), stationed: false }
   })
-  return { ...state, units }
+  return { ...state, units, attackEvents: [], hazards: [] }
 }
 
 /** Compute ticket reward for arcade mode based on waves cleared. */


### PR DESCRIPTION
Follow-up to #1562.

## Summary

- **Effects lingering during milestone**: `tickUnitsHomeOnly` now sets `attackEvents: []` and `hazards: []` on every call, so any projectile animations and gas clouds that were active at the end of a wave are cleared immediately when the milestone reward screen opens.

- **Gas cloud soft rendering**: `drawHazards` previously drew a uniform-alpha filled circle with a hard 1px stroke. Replaced with three concentric filled circles (radii 100%/70%/40% of cloud radius, alphas 0.06/0.14/0.22) that composite into a soft radial gradient — opaque at the centre, fading to fully transparent at the edge, no visible outline.

## Test plan
- [ ] Complete a milestone wave — attack projectiles and gas clouds should disappear immediately when the reward screen opens
- [ ] Gas tower clouds during a wave should render as a soft semi-transparent blob with no hard edge
- [ ] CI passes

https://claude.ai/code/session_01P8nXfryP3BH5kWAWPfsQ1N

---
_Generated by [Claude Code](https://claude.ai/code/session_01P8nXfryP3BH5kWAWPfsQ1N)_