### PR TITLE
fix(citybuilder): fast offline catch-up + don't drain happiness while away

### DIFF
--- a/web/src/game/cityBuilder.ts
+++ b/web/src/game/cityBuilder.ts
@@ -1445,12 +1445,20 @@ export function tickCity(state: CityState, nowMs?: number, offline = false): Cit
 
   // For long offline periods, sub-step so carriers complete trips between steps.
   // Without this, a windmill sitting empty for 30 minutes produces zero bread.
+  //
+  // Cap the offline window at MAX_OFFLINE_MINUTES before computing steps.
+  // Using raw elapsed causes stepMs > OFFLINE_STEP_MS when offline for months,
+  // which triggers nested sub-stepping in every recursive call — O(n²/n³) total
+  // ticks. With the cap, stepMs is always exactly OFFLINE_STEP_MS (5 min) so
+  // inner calls never re-enter this branch. Total calls ≤ MAX_OFFLINE_MINUTES/5 = 96.
   if (elapsed > OFFLINE_STEP_MS * 1.5) {
-    const steps   = Math.min(Math.ceil(elapsed / OFFLINE_STEP_MS), MAX_OFFLINE_MINUTES / 5)
-    const stepMs  = elapsed / steps
-    let current   = state
+    const cappedElapsed = Math.min(elapsed, MAX_OFFLINE_MINUTES * 60_000)
+    const steps   = Math.ceil(cappedElapsed / OFFLINE_STEP_MS)   // ≤ 96
+    const stepMs  = cappedElapsed / steps                        // exactly OFFLINE_STEP_MS
+    const startTick = now - cappedElapsed
+    let current = { ...state, lastTick: startTick }
     for (let i = 0; i < steps; i++) {
-      current = tickCity(current, state.lastTick + stepMs * (i + 1), true)
+      current = tickCity(current, startTick + stepMs * (i + 1), true)
     }
     return current
   }
@@ -1718,7 +1726,9 @@ export function tickCity(state: CityState, nowMs?: number, offline = false): Cit
     const seasonRegen = HAPPINESS_REGEN * (1 + si.regen)
     if (current < cellTarget) {
       newHappy[i] = Math.min(cellTarget, current + seasonRegen * minutes)
-    } else if (current > cellTarget) {
+    } else if (current > cellTarget && !offline) {
+      // Don't drain happiness during offline catch-up — returning players
+      // aren't penalised for time away (same principle as skipping food consumption).
       newHappy[i] = Math.max(0, current - HAPPINESS_DRAIN * minutes)
     }
   }


### PR DESCRIPTION
Closes #1555

## Summary

- **Slow load fixed**: The offline sub-stepping loop was O(n²) / O(n³) for long absences. It capped the *number* of steps at 96 but divided raw `elapsed` to compute `stepMs` — for a 1-month absence `stepMs` was 450 min, which caused every recursive `tickCity` call to also trigger sub-stepping. Result: ~8,640 calls for 1 month, ~55,000 for 6 months (~2 minutes on device). Fix: cap the offline window at `MAX_OFFLINE_MINUTES` (8 h) before computing step size, so `stepMs` is always exactly 5 min and inner calls never re-enter the branch. Total calls are now bounded at ≤ 96 regardless of how long the player was away.

- **Uneasy citizens fixed**: Happiness was allowed to drain during offline catch-up (when `current > cellTarget`). The same "don't punish players for being away" principle that already skips food consumption now also applies to happiness — offline ticks only recover happiness, never reduce it. Players return to find their citizens in at least as good a mood as when they left.

## Test plan
- [ ] Open city builder after a long absence — should load in under 1 second
- [ ] Citizens should not appear uneasy immediately on load
- [ ] Normal happiness drain still works during active play (online ticks unaffected)
- [ ] Resources and gold still accumulate correctly during offline catch-up
- [ ] CI passes

https://claude.ai/code/session_01P8nXfryP3BH5kWAWPfsQ1N

---
_Generated by [Claude Code](https://claude.ai/code/session_01P8nXfryP3BH5kWAWPfsQ1N)_