### PR TITLE
Fix bugs #1566, #1565, #1315, #1426, #1556

### DIFF
--- a/web/src/components/minigames/towerdefence/GameGrid.tsx
+++ b/web/src/components/minigames/towerdefence/GameGrid.tsx
@@ -78,6 +78,7 @@ function drawCells(
   selected: boolean,
   towers: TDTower[],
 ) {
+  if (!g || g.destroyed) return
   g.clear()
   const towerByCell = new Map(towers.map(t => [`${t.col},${t.row}`, t]))
 
@@ -230,6 +231,7 @@ function drawHpBars(
   enemies:  TDGameState['enemies'],
   units:    TDGameState['units'],
 ) {
+  if (!g || g.destroyed) return
   g.clear()
   const BAR = 20
 
@@ -288,6 +290,7 @@ function drawAnimatedEffects(
   startTimes: Map<number, number>,
   nowMs: number,
 ) {
+  if (!g || g.destroyed) return
   g.clear()
   for (const ev of events) {
     const startMs = startTimes.get(ev.id) ?? nowMs
@@ -343,6 +346,7 @@ function drawAnimatedEffects(
 // ── Draw hazard clouds ────────────────────────────────────────────────────────
 
 function drawHazards(g: PIXI.Graphics, hazards: TDGameState['hazards']) {
+  if (!g || g.destroyed) return
   g.clear()
   for (const h of hazards) {
     // Three concentric fills approximate a radial gradient: opaque core fading to
@@ -464,16 +468,6 @@ export function GameGrid({
       }))
     }).catch(() => { /* terrain tiles optional — solid fallback from cellGfx */ })
 
-    // Cell labels for start/end
-    const startLabel = new PIXI.Text({ text: 'IN',   style: { fontSize: 9, fill: 0xffffff, fontWeight: 'bold' } })
-    const endLabel   = new PIXI.Text({ text: 'BASE', style: { fontSize: 8, fill: 0xffffff, fontWeight: 'bold' } })
-    startLabel.x = cellCx(TD_PATH[0].col) - 8
-    startLabel.y = cellCy(TD_PATH[0].row) - 5
-    endLabel.x   = cellCx(TD_PATH[TD_PATH.length - 1].col) - 10
-    endLabel.y   = cellCy(TD_PATH[TD_PATH.length - 1].row) - 5
-    app.stage.addChild(startLabel)
-    app.stage.addChild(endLabel)
-
     // Click/hover detection on the cell layer background
     const hitArea = new PIXI.Graphics()
     hitArea.rect(0, 0, W, H).fill({ color: 0x000000, alpha: 0 })
@@ -536,6 +530,12 @@ export function GameGrid({
     })
   })
 
+  // Clear the scene ref on unmount so the update effect below never runs against
+  // a stale scene whose Graphics objects were already destroyed by usePixiApp cleanup.
+  useEffect(() => {
+    return () => { sceneRef.current = null }
+  }, [])
+
   // ── Update scene when game state changes ───────────────────────────────────
   useEffect(() => {
     if (!sceneRef.current) return
@@ -593,6 +593,8 @@ export function GameGrid({
             style={{ display: 'block', width: W, height: H }}
             onMouseLeave={handleMouseLeave}
           />
+          <div className="td-cell-label" style={{ left: cellCx(TD_PATH[0].col) - 8, top: cellCy(TD_PATH[0].row) - 5 }}>IN</div>
+          <div className="td-cell-label" style={{ left: cellCx(TD_PATH[TD_PATH.length - 1].col) - 10, top: cellCy(TD_PATH[TD_PATH.length - 1].row) - 5 }}>BASE</div>
           {tooltip}
         </div>
       </div>

--- a/web/src/components/screens/ShopScreen.tsx
+++ b/web/src/components/screens/ShopScreen.tsx
@@ -256,11 +256,7 @@ export function ShopScreen({ crystals, onBuyCrystalPack, onCrystalsChange, onBac
 
         {/* ── Daily card deals ── */}
         {show('cards') && <div className="shop-section">
-          <div className="shop-section-header">Current Stock
-        🕐 refreshes in <span className="shop-countdown-time">{formatCountdown(countdown)}</span>
-      
-
-</div>
+          <div className="shop-section-header">Current Stock 🕐 refreshes in <span className="shop-countdown-time">{formatCountdown(countdown)}</span></div>
           <div className="shop-daily-cards u-flex u-gap-6 u-wrap u-just-c">
             {dailyCards.map(deal => {
               const bought = shopState.boughtCardNames.includes(deal.cardName)

--- a/web/src/game/engine.ts
+++ b/web/src/game/engine.ts
@@ -1,4 +1,5 @@
 import { GameState, Card, Unit, UnitTemplate, CardRarity, LANE_WIDTH } from './types'
+import { logError } from '../logger'
 import { makeDeck, makeNodeDeck, HERO_CARDS, getCardUnit, getCardCatalog, flushCardValidationErrors } from './cards'
 import { loadPlayerStats } from './playerStats'
 
@@ -240,8 +241,12 @@ export function newGame(
         `Enemy strategy: ${STRATEGY_LABELS[strategy]}`,
       ]
 
+  if (isDailyChallenge) {
+    const badCards = playerDeck.filter(c => c.cost == null).map(c => c.name)
+    if (badCards.length > 0) logError('Daily challenge deck has cards with null cost', { badCards })
+  }
   const rawDeckMaxMana = isDailyChallenge && playerDeck.length > 0
-    ? playerDeck.reduce((m, c) => Math.max(m, c.cost), 0)
+    ? playerDeck.reduce((m, c) => Math.max(m, c.cost ?? 0), 0)
     : 0
   // Include playerStats.maxMana so regenerateMana() (which reads s.deckMaxMana) respects stat upgrades
   const deckMaxMana = Math.max(rawDeckMaxMana, loadPlayerStats().maxMana)

--- a/web/src/game/engine/cards.ts
+++ b/web/src/game/engine/cards.ts
@@ -142,11 +142,11 @@ export function deployCard(s: GameState, card: Card, owner: 'player' | 'opponent
     } else {
       log.push(`${who} ${verb} ${unit.name}.`);
     }
-    // Glass cards: chance to shatter immediately after deployment
+    // Glass cards: chance to crack on deployment — half HP but double damage
     if (card.glassBreakChance && Math.random() < card.glassBreakChance) {
-      unit.hp = 0;
-      unit.dyingTimer = 400;
-      log.push(`💎 ${unit.name} shattered!`);
+      unit.hp = Math.max(1, Math.ceil(unit.maxHp / 2));
+      unit.attack = unit.attack * 2;
+      log.push(`💎 ${unit.name} cracked — half HP, double damage!`);
       s.glassShatterCount = (s.glassShatterCount ?? 0) + 1;
     }
   } else if (card.cardType === 'upgrade' && card.upgradeEffect) {

--- a/web/src/game/secretRarities.ts
+++ b/web/src/game/secretRarities.ts
@@ -45,7 +45,7 @@ export function makeHolofoilVariant(card: Card): Card {
 export function makeGlassVariant(card: Card): Card {
   const boostedUnit = card.unit ? {
     ...card.unit,
-    attack: Math.round(card.unit.attack * 1.6),
+    attack: Math.round(card.unit.attack * 2.0),
     maxHp: Math.round(card.unit.maxHp * 1.4),
     cardVariant: 'glass' as const,
   } : undefined

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1905,6 +1905,7 @@ body {
 
 /* Section headers */
 .shop-section { display: flex; flex-direction: column; gap: 12px; align-items: center; width: 100%; }
+.shop-daily-cards { width: 100%; display: flex; flex-wrap: wrap; justify-content: center; gap: 6px; box-sizing: border-box; }
 .shop-section-header {
   display: flex;
   align-items: center;
@@ -13570,6 +13571,16 @@ html.light-mode .action-btn {
 .td-unit-sprite { width: 100%; height: 100%; display: block; image-rendering: pixelated; }
 .td-unit--walking { opacity: 0.85; }
 .td-unit--stationed { filter: drop-shadow(0 0 3px var(--color-green-bright)); }
+
+/* IN / BASE cell labels (DOM overlay replacing PIXI.Text to avoid TexturePool crash on unmount) */
+.td-cell-label {
+  position: absolute;
+  font-size: 9px;
+  color: #fff;
+  font-weight: bold;
+  pointer-events: none;
+  z-index: 2;
+}
 
 /* Tower tooltip (positioned inside grid) */
 .td-tower-tooltip {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **#1566** — `TypeError: null 'clear'` in Tower Defense: added `sceneRef.current = null` cleanup effect so the scene is cleared before `usePixiApp` destroys the PixiJS app; guarded all `drawCells`/`drawHpBars`/`drawHazards`/`drawAnimatedEffects` functions with `if (!g || g.destroyed) return` as defence in depth.
- **#1565** — `TypeError: undefined 'push'` in PixiJS TexturePool: removed the two `PIXI.Text` start/end labels from the canvas (they triggered a PixiJS v8 internal bug during `app.destroy`); replaced with lightweight DOM overlays (`.td-cell-label`) that render identically and have no cleanup risk.
- **#1315** — Daily challenge max mana inconsistency: guarded the mana reduce with `c.cost ?? 0` to prevent `NaN` propagation when a card has an undefined cost; added a `logError` call to surface the root-cause card if it ever fires.
- **#1426** — Shop CSS layout broken: added the missing `.shop-daily-cards` flex container class to `styles.css`; cleaned up stray whitespace in the section header JSX.
- **#1556** — Glass card behaviour change: cracking now sets the unit to half HP + double damage instead of killing it (`unit.hp = 0` → `Math.ceil(unit.maxHp / 2)`, `unit.attack *= 2`); base attack multiplier in `makeGlassVariant` raised from 1.6× to 2.0× so the cracked unit still hits hard.

## Test plan

- [ ] Open Tower Defense, play a wave, then navigate away — no `TypeError` in console
- [ ] Repeat with React Strict Mode active (double-invoke cycle)
- [ ] Start today's daily challenge — confirm max mana matches the highest-cost card in the deck
- [ ] Open the Shop screen at 375 px width — cards should be aligned, no overflow
- [ ] Deploy a Glass card in Quick Battle — unit should spawn (sometimes cracked at half HP / double damage), never instantly dead

https://claude.ai/code/session_01A6kZrcU1ikZY5o8HhaceDC
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A6kZrcU1ikZY5o8HhaceDC)_