### PR TITLE
fix(hub): prevent iOS Safari page kills from oversized hub WebGL buffers

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useCallback, useEffect, useRef, useMemo, useReducer } from 'react'
 import { resolvedNodeOpts, loadHandicap, HANDICAP_KEY, buildQuickBattleOpts, loadCurrentDeckInfo } from './game/campaignHelpers'
 import { usePlaytime } from './hooks/usePlaytime'
+import { recordScreen } from './utils/crashSentinel'
 import { useStartupData } from './hooks/useStartupData'
 import { useCloudSync } from './hooks/useCloudSync'
 import { useRegisterSW } from 'virtual:pwa-register/react'
@@ -514,6 +515,12 @@ export default function App() {
   // Keep gameStateRef in sync so callbacks can read current state without stale closures
   gameStateRef.current = gameState
   runRef.current = run
+
+  // ── Crash sentinel: record screen transitions so unclean exits (iOS page
+  // kills) report where the player was when the page died ──
+  useEffect(() => {
+    recordScreen(screen, currentLocationKey)
+  }, [screen, currentLocationKey])
 
   // ── Page visibility: pause game loop when tab is hidden ──
   const [isTabHidden, setIsTabHidden] = useState(() => document.hidden)

--- a/web/src/components/ErrorBoundary.tsx
+++ b/web/src/components/ErrorBoundary.tsx
@@ -1,0 +1,42 @@
+import React from 'react'
+import rollbar from '../rollbar'
+
+interface Props {
+  children: React.ReactNode
+}
+
+interface State {
+  hasError: boolean
+}
+
+/**
+ * Top-level error boundary: reports render errors to Rollbar (with component
+ * stack) and shows a reload fallback instead of silently unmounting the app.
+ */
+export class ErrorBoundary extends React.Component<Props, State> {
+  state: State = { hasError: false }
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true }
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo): void {
+    rollbar?.error(error, { componentStack: info.componentStack })
+  }
+
+  render(): React.ReactNode {
+    if (!this.state.hasError) return this.props.children
+    return (
+      <div style={{
+        display: 'flex', flexDirection: 'column', alignItems: 'center',
+        justifyContent: 'center', height: '100vh', gap: 16, textAlign: 'center',
+      }}>
+        <div className="title-logo">JARV'S</div>
+        <p>Something went wrong. The error has been reported.</p>
+        <button className="action-btn" onClick={() => window.location.reload()}>
+          RELOAD
+        </button>
+      </div>
+    )
+  }
+}

--- a/web/src/hooks/usePixiApp.test.ts
+++ b/web/src/hooks/usePixiApp.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from 'vitest'
+
+// usePixiApp imports rollbar, which reads window.Rollbar at module load.
+vi.stubGlobal('window', { Rollbar: undefined, devicePixelRatio: 3 })
+vi.stubGlobal('localStorage', { getItem: () => null, setItem: () => {}, removeItem: () => {} })
+
+const { computeCappedResolution, RENDERER_PIXEL_BUDGET } = await import('./usePixiApp')
+
+describe('computeCappedResolution', () => {
+  it('clamps dpr 3 to 2 for typical town maps', () => {
+    expect(computeCappedResolution(1200, 900, 3)).toBe(2)
+  })
+
+  it('caps the Ravenwatch map (2400×2240) below dpr 2 via the pixel budget', () => {
+    const res = computeCappedResolution(2400, 2240, 3)
+    expect(res).toBeCloseTo(1.766, 2)
+    // Resulting drawing buffer must fit the budget
+    expect(2400 * res * 2240 * res).toBeLessThanOrEqual(RENDERER_PIXEL_BUDGET + 1)
+  })
+
+  it('never upscales a dpr-1 device', () => {
+    expect(computeCappedResolution(2400, 2240, 1)).toBe(1)
+  })
+
+  it('leaves small canvases at full dpr (up to the clamp)', () => {
+    expect(computeCappedResolution(400, 700, 2)).toBe(2)
+  })
+
+  it('falls back to 1 for a zero/NaN dpr', () => {
+    expect(computeCappedResolution(800, 600, 0)).toBe(1)
+    expect(computeCappedResolution(800, 600, NaN)).toBe(1)
+  })
+
+  it('respects a custom budget', () => {
+    expect(computeCappedResolution(1000, 1000, 3, 1000 * 1000)).toBe(1)
+  })
+})

--- a/web/src/hooks/usePixiApp.test.ts
+++ b/web/src/hooks/usePixiApp.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect, vi } from 'vitest'
 
-// usePixiApp imports rollbar, which reads window.Rollbar at module load.
+// usePixiApp imports rollbar, which reads window.Rollbar at module load, and
+// pixi.js, which reads navigator.userAgent at module load (absent in Node 20).
 vi.stubGlobal('window', { Rollbar: undefined, devicePixelRatio: 3 })
+vi.stubGlobal('navigator', { userAgent: 'node' })
 vi.stubGlobal('localStorage', { getItem: () => null, setItem: () => {}, removeItem: () => {} })
 
 const { computeCappedResolution, RENDERER_PIXEL_BUDGET } = await import('./usePixiApp')

--- a/web/src/hooks/usePixiApp.ts
+++ b/web/src/hooks/usePixiApp.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react'
 import * as PIXI from 'pixi.js'
 import rollbar from '../rollbar'
+import { noteContextCreated, noteContextDestroyed, getGlStats } from '../utils/pixiTelemetry'
 
 /**
  * Initialises a PixiJS v8 Application and mounts its canvas into the given container.
@@ -25,6 +26,38 @@ function suppressContextLostOnce(canvas: HTMLCanvasElement) {
   canvas.addEventListener('webglcontextlost', handler, { capture: true, once: true })
 }
 
+// Cap on the drawing-buffer size (device pixels). Large hub maps (Ravenwatch is
+// 2400×2240 CSS px) at devicePixelRatio 3 would otherwise allocate a 7200×6720
+// buffer ≈ 185 MB of GPU memory — enough for iOS Safari to kill the page when
+// the buffer is transiently doubled while navigating away and back.
+export const RENDERER_PIXEL_BUDGET = 4096 * 4096
+
+/**
+ * Resolution for a canvas of width×height CSS px: the devicePixelRatio, clamped
+ * to 2 (indistinguishable from 3 for 32px pixel art, halves GPU memory) and to
+ * whatever keeps the drawing buffer within RENDERER_PIXEL_BUDGET.
+ */
+export function computeCappedResolution(
+  width: number,
+  height: number,
+  dpr: number,
+  budget: number = RENDERER_PIXEL_BUDGET,
+): number {
+  const area = Math.max(1, width * height)
+  return Math.min(dpr || 1, 2, Math.sqrt(budget / area))
+}
+
+// Shrink the drawing buffer so iOS Safari frees its GPU memory immediately
+// instead of when the canvas is garbage collected. Pixi's destroy() already
+// loses the WebGL context, but a lost context keeps its backing store until GC
+// — long enough for a remount's new buffer to transiently double GPU memory.
+function releaseCanvasBackingStore(canvas: HTMLCanvasElement) {
+  try {
+    canvas.width = 1
+    canvas.height = 1
+  } catch { /* best effort */ }
+}
+
 export function usePixiApp(
   containerRef: React.RefObject<HTMLElement | null>,
   width: number,
@@ -40,33 +73,52 @@ export function usePixiApp(
     const app = new PIXI.Application()
     appRef.current = app
 
+    const resolution = computeCappedResolution(width, height, window.devicePixelRatio || 1)
+    const contextInfo = { width, height, resolution }
+    const onContextLost = () => {
+      rollbar?.error('[usePixiApp] webglcontextlost during app lifetime', { ...contextInfo, ...getGlStats() })
+    }
+    const destroyApp = () => {
+      const canvas = app.canvas as HTMLCanvasElement  // capture before destroy — destroy(true) detaches it
+      canvas.removeEventListener('webglcontextlost', onContextLost)
+      suppressContextLostOnce(canvas)
+      app.destroy(true, { children: true, texture: false })
+      releaseCanvasBackingStore(canvas)
+      noteContextDestroyed(contextInfo)
+    }
+
     let initialized = false
     app.init({
       width,
       height,
       backgroundAlpha: 0,
       antialias: false,
-      resolution: window.devicePixelRatio || 1,
+      resolution,
       autoDensity: true,
     }).then(() => {
       initialized = true
+      noteContextCreated(contextInfo)
       if (destroyed) {
         // Cleanup ran before init resolved — destroy properly to release the WebGL context.
         rollbar?.warn('[usePixiApp] init resolved after unmount — destroying orphan app')
-        suppressContextLostOnce(app.canvas as HTMLCanvasElement)
-        app.destroy(true, { children: true, texture: false })
+        destroyApp()
         return
       }
+      // Report unexpected context loss while the app is live. Intentional loss
+      // during teardown never reaches this listener: suppressContextLostOnce
+      // registers in capture phase and stops immediate propagation.
+      ;(app.canvas as HTMLCanvasElement).addEventListener('webglcontextlost', onContextLost)
       container.appendChild(app.canvas)
       onReady(app)
     }).catch(e => {
       console.error('[usePixiApp] app.init failed', e)
-      rollbar?.error('[usePixiApp] app.init failed', { message: (e as Error)?.message })
+      rollbar?.error('[usePixiApp] app.init failed', { message: (e as Error)?.message, ...contextInfo, ...getGlStats() })
       // Release any partial WebGL context created before the failure to prevent
       // context accumulation that crashes the browser after repeated navigations.
       try {
         suppressContextLostOnce(app.canvas as HTMLCanvasElement)
         app.destroy(true, { children: true, texture: false })
+        releaseCanvasBackingStore(app.canvas as HTMLCanvasElement)
       } catch { /* partial init — best effort */ }
       appRef.current = null
     })
@@ -74,8 +126,7 @@ export function usePixiApp(
     return () => {
       destroyed = true
       if (initialized) {
-        suppressContextLostOnce(app.canvas as HTMLCanvasElement)
-        app.destroy(true, { children: true, texture: false })
+        destroyApp()
       }
       appRef.current = null
     }

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -2,9 +2,16 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import rollbar from './rollbar'
 import { setErrorLogger } from './logger'
+import { initCrashSentinel } from './utils/crashSentinel'
+import { ErrorBoundary } from './components/ErrorBoundary'
 import App from './App'
 
 setErrorLogger((msg, ctx) => rollbar.error(msg, ctx as object))
+
+// Report if the previous session died without a clean exit (e.g. iOS Safari
+// killing the page under memory pressure) — before React renders, so crash
+// loops are reported even when rendering itself dies.
+initCrashSentinel()
 
 // Unlock any achievements whose progress target was already met before the
 // achievement was added (e.g. after a game update adds new achievements).
@@ -31,6 +38,8 @@ window.addEventListener('unhandledrejection', (event) => {
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <App />
+    <ErrorBoundary>
+      <App />
+    </ErrorBoundary>
   </React.StrictMode>,
 )

--- a/web/src/utils/crashSentinel.test.ts
+++ b/web/src/utils/crashSentinel.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+// crashSentinel needs window/document/localStorage at module load (via
+// rollbar.ts) and call time — stub them before importing the module under test.
+const rollbarSpy = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), configure: vi.fn() }
+
+let store = new Map<string, string>()
+let storageThrows = false
+const localStorageStub = {
+  getItem: (k: string) => { if (storageThrows) throw new Error('quota'); return store.get(k) ?? null },
+  setItem: (k: string, v: string) => { if (storageThrows) throw new Error('quota'); store.set(k, v) },
+  removeItem: (k: string) => { if (storageThrows) throw new Error('quota'); store.delete(k) },
+}
+
+const windowListeners = new Map<string, () => void>()
+const documentListeners = new Map<string, () => void>()
+vi.stubGlobal('window', {
+  Rollbar: rollbarSpy,
+  devicePixelRatio: 2,
+  addEventListener: (type: string, fn: () => void) => windowListeners.set(type, fn),
+})
+vi.stubGlobal('document', {
+  visibilityState: 'visible',
+  addEventListener: (type: string, fn: () => void) => documentListeners.set(type, fn),
+})
+vi.stubGlobal('localStorage', localStorageStub)
+
+const { initCrashSentinel, recordScreen, _resetCrashSentinelForTest } = await import('./crashSentinel')
+
+const KEY = 'jarv_crash_sentinel'
+const readRecord = () => JSON.parse(store.get(KEY)!)
+
+describe('crashSentinel', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    store = new Map()
+    storageThrows = false
+    windowListeners.clear()
+    documentListeners.clear()
+    rollbarSpy.warn.mockClear()
+    _resetCrashSentinelForTest()
+  })
+
+  it('does not report on first boot (no previous record)', () => {
+    initCrashSentinel()
+    expect(rollbarSpy.warn).not.toHaveBeenCalled()
+    expect(readRecord()).toMatchObject({ screen: 'boot', cleanExit: false })
+  })
+
+  it('reports an unclean exit with the last known screen', () => {
+    store.set(KEY, JSON.stringify({
+      ts: Date.now() - 30_000, screen: 'hubworld', location: 'ravenwatch',
+      visibility: 'visible', cleanExit: false, largestCanvasMB: 185,
+    }))
+    initCrashSentinel()
+    expect(rollbarSpy.warn).toHaveBeenCalledWith(
+      '[sentinel] unclean exit — probable page kill',
+      expect.objectContaining({
+        lastScreen: 'hubworld',
+        lastLocation: 'ravenwatch',
+        visibility: 'visible',
+        largestCanvasMB: 185,
+        secondsAgo: 30,
+      }),
+    )
+  })
+
+  it('does not report after a clean exit', () => {
+    store.set(KEY, JSON.stringify({
+      ts: Date.now(), screen: 'hubworld', visibility: 'hidden', cleanExit: true,
+    }))
+    initCrashSentinel()
+    expect(rollbarSpy.warn).not.toHaveBeenCalled()
+  })
+
+  it('marks the record clean on pagehide and dirty again on pageshow', () => {
+    initCrashSentinel()
+    windowListeners.get('pagehide')!()
+    expect(readRecord().cleanExit).toBe(true)
+    windowListeners.get('pageshow')!()
+    expect(readRecord().cleanExit).toBe(false)
+  })
+
+  it('records screen transitions with WebGL stats', () => {
+    initCrashSentinel()
+    recordScreen('hubworld', 'ravenwatch')
+    expect(readRecord()).toMatchObject({
+      screen: 'hubworld',
+      location: 'ravenwatch',
+      cleanExit: false,
+      liveContexts: expect.any(Number),
+    })
+  })
+
+  it('survives a throwing localStorage', () => {
+    storageThrows = true
+    expect(() => {
+      initCrashSentinel()
+      recordScreen('hubworld')
+    }).not.toThrow()
+  })
+})

--- a/web/src/utils/crashSentinel.ts
+++ b/web/src/utils/crashSentinel.ts
@@ -1,0 +1,114 @@
+import rollbar from '../rollbar'
+import { getGlStats } from './pixiTelemetry'
+
+// ── Unclean-exit (page-kill) detector ─────────────────────────────────────────
+// iOS Safari kills pages under memory pressure with no JS-visible signal: the
+// page simply reloads (landing on the title screen) and, when it happens
+// repeatedly, Safari shows "A problem repeatedly occurred". This sentinel keeps
+// a heartbeat record in localStorage and marks it clean on pagehide; if the app
+// boots and finds a record that was never marked clean, the previous session
+// died without a normal exit and we report it to Rollbar with the last known
+// screen + WebGL context stats so crashes can be located.
+
+const SENTINEL_KEY = 'jarv_crash_sentinel'
+const HEARTBEAT_MS = 20_000
+
+interface SentinelRecord {
+  ts: number
+  screen: string
+  location?: string
+  visibility: string
+  cleanExit: boolean
+  contextsCreatedTotal?: number
+  contextsDestroyedTotal?: number
+  liveContexts?: number
+  liveCanvasMB?: number
+  largestCanvasMB?: number
+}
+
+function readRecord(): SentinelRecord | null {
+  try {
+    const raw = localStorage.getItem(SENTINEL_KEY)
+    return raw ? JSON.parse(raw) as SentinelRecord : null
+  } catch {
+    return null
+  }
+}
+
+function writeRecord(patch: Partial<SentinelRecord>): void {
+  try {
+    const prev = readRecord()
+    const next: SentinelRecord = {
+      ts: Date.now(),
+      screen: prev?.screen ?? 'unknown',
+      visibility: document.visibilityState,
+      cleanExit: false,
+      ...prev,
+      ...patch,
+    }
+    localStorage.setItem(SENTINEL_KEY, JSON.stringify(next))
+  } catch (e) {
+    // localStorage unavailable/full — sentinel is diagnostics-only, never fatal
+    rollbar?.warn('[sentinel] localStorage write failed', { message: (e as Error)?.message })
+  }
+}
+
+let _initialized = false
+let _heartbeatStarted = false
+
+/** Call once at boot, before React renders, so crash loops are reported even
+ *  if rendering itself dies. */
+export function initCrashSentinel(): void {
+  if (_initialized) return
+  _initialized = true
+
+  const prev = readRecord()
+  if (prev && prev.cleanExit !== true) {
+    rollbar?.warn('[sentinel] unclean exit — probable page kill', {
+      lastScreen: prev.screen,
+      lastLocation: prev.location,
+      secondsAgo: Math.round((Date.now() - prev.ts) / 1000),
+      visibility: prev.visibility,
+      contextsCreatedTotal: prev.contextsCreatedTotal,
+      contextsDestroyedTotal: prev.contextsDestroyedTotal,
+      liveContexts: prev.liveContexts,
+      liveCanvasMB: prev.liveCanvasMB,
+      largestCanvasMB: prev.largestCanvasMB,
+    })
+  }
+  try { localStorage.removeItem(SENTINEL_KEY) } catch { /* best effort */ }
+  writeRecord({ screen: 'boot', ts: Date.now(), cleanExit: false, visibility: document.visibilityState })
+
+  // Real navigations and tab closes are clean exits. pagehide fires on iOS
+  // where unload does not.
+  window.addEventListener('pagehide', () => {
+    writeRecord({ cleanExit: true })
+  })
+  // Returning from bfcache / foregrounding means the session is live again.
+  window.addEventListener('pageshow', () => {
+    writeRecord({ cleanExit: false, visibility: document.visibilityState })
+  })
+  // Track visibility so dashboards can split foreground jetsam kills (our
+  // crash: visibility 'visible') from routine background tab eviction.
+  document.addEventListener('visibilitychange', () => {
+    writeRecord({ visibility: document.visibilityState, cleanExit: false })
+  })
+}
+
+/** Record the active screen (and hub location) plus current WebGL stats.
+ *  Call on every screen change — crashes cluster around screen transitions. */
+export function recordScreen(screen: string, location?: string): void {
+  writeRecord({ screen, location, ts: Date.now(), cleanExit: false, ...getGlStats() })
+  if (!_heartbeatStarted) {
+    _heartbeatStarted = true
+    setInterval(() => {
+      writeRecord({ ts: Date.now(), ...getGlStats() })
+    }, HEARTBEAT_MS)
+  }
+}
+
+/** Test-only: reset module state between cases. */
+export function _resetCrashSentinelForTest(): void {
+  _initialized = false
+  _heartbeatStarted = false
+}

--- a/web/src/utils/pixiTelemetry.test.ts
+++ b/web/src/utils/pixiTelemetry.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+// pixiTelemetry (via rollbar.ts) reads window.Rollbar at module load — stub
+// the browser globals before importing the module under test.
+const rollbarSpy = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), configure: vi.fn() }
+vi.stubGlobal('window', { Rollbar: rollbarSpy, devicePixelRatio: 3 })
+vi.stubGlobal('localStorage', { getItem: () => null, setItem: () => {}, removeItem: () => {} })
+
+const { estimateCanvasMB, getGlStats, noteContextCreated, noteContextDestroyed, _resetGlStatsForTest } =
+  await import('./pixiTelemetry')
+
+describe('estimateCanvasMB', () => {
+  it('estimates the Ravenwatch map at dpr 3 as ~185 MB', () => {
+    expect(estimateCanvasMB(2400, 2240, 3)).toBeCloseTo(184.6, 0)
+  })
+
+  it('estimates the Ravenwatch map at the capped resolution as ~64 MB', () => {
+    expect(estimateCanvasMB(2400, 2240, 1.766)).toBeCloseTo(64, 0)
+  })
+
+  it('estimates a small battle canvas as well under the info threshold', () => {
+    expect(estimateCanvasMB(400, 700, 2)).toBeLessThan(48)
+  })
+})
+
+describe('context counters', () => {
+  beforeEach(() => {
+    _resetGlStatsForTest()
+    rollbarSpy.info.mockClear()
+    rollbarSpy.warn.mockClear()
+  })
+
+  it('pairs created/destroyed and never goes negative', () => {
+    const info = { width: 400, height: 700, resolution: 2 }
+    noteContextCreated(info)
+    expect(getGlStats().liveContexts).toBe(1)
+    noteContextDestroyed(info)
+    noteContextDestroyed(info)  // double-destroy must not underflow
+    const stats = getGlStats()
+    expect(stats.liveContexts).toBe(0)
+    expect(stats.liveCanvasMB).toBe(0)
+    expect(stats.contextsCreatedTotal).toBe(1)
+    expect(stats.contextsDestroyedTotal).toBe(2)
+  })
+
+  it('tracks the largest canvas seen', () => {
+    noteContextCreated({ width: 400, height: 700, resolution: 2 })
+    noteContextCreated({ width: 2400, height: 2240, resolution: 3 })
+    noteContextDestroyed({ width: 2400, height: 2240, resolution: 3 })
+    expect(getGlStats().largestCanvasMB).toBe(185)
+  })
+
+  it('stays silent for small single canvases', () => {
+    noteContextCreated({ width: 400, height: 700, resolution: 2 })
+    expect(rollbarSpy.info).not.toHaveBeenCalled()
+    expect(rollbarSpy.warn).not.toHaveBeenCalled()
+  })
+
+  it('warns on a high-memory canvas', () => {
+    noteContextCreated({ width: 2400, height: 2240, resolution: 3 })
+    expect(rollbarSpy.warn).toHaveBeenCalledWith(
+      '[pixi] high GPU canvas memory',
+      expect.objectContaining({ estimatedMB: 185, liveContexts: 1 }),
+    )
+  })
+
+  it('reports when a second live context appears', () => {
+    noteContextCreated({ width: 400, height: 700, resolution: 2 })
+    noteContextCreated({ width: 400, height: 700, resolution: 2 })
+    expect(rollbarSpy.info).toHaveBeenCalledWith(
+      '[pixi] webgl context created',
+      expect.objectContaining({ liveContexts: 2 }),
+    )
+  })
+})

--- a/web/src/utils/pixiTelemetry.ts
+++ b/web/src/utils/pixiTelemetry.ts
@@ -1,0 +1,91 @@
+import rollbar from '../rollbar'
+
+// ── WebGL context lifecycle telemetry ─────────────────────────────────────────
+// Tracks how many PixiJS WebGL contexts are alive and how much GPU memory their
+// canvas backing stores consume. iOS Safari kills the page (jetsam) when canvas
+// memory spikes — e.g. a 2400×2240 hub map at devicePixelRatio 3 is a ~185 MB
+// drawing buffer, transiently doubled while navigating away and back. These
+// counters feed Rollbar so crashes can be correlated with canvas churn.
+
+export interface GlStats {
+  contextsCreatedTotal: number
+  contextsDestroyedTotal: number
+  liveContexts: number
+  liveCanvasMB: number
+  largestCanvasMB: number
+}
+
+interface ContextInfo {
+  width: number
+  height: number
+  resolution: number
+}
+
+// Rollbar only hears about creations at or above these sizes — small canvases
+// (battles, minigames, node map) would otherwise spam the quota.
+const INFO_MB_THRESHOLD = 48
+const WARN_MB_THRESHOLD = 100
+
+let _createdTotal = 0
+let _destroyedTotal = 0
+let _liveMB: number[] = []
+let _largestMB = 0
+
+/** Estimated single-buffer size of a canvas drawing buffer, in MiB (RGBA).
+ *  Real GPU cost is ~2× with double buffering; thresholds account for that. */
+export function estimateCanvasMB(width: number, height: number, resolution: number): number {
+  return (width * resolution) * (height * resolution) * 4 / (1024 * 1024)
+}
+
+export function getGlStats(): GlStats {
+  return {
+    contextsCreatedTotal: _createdTotal,
+    contextsDestroyedTotal: _destroyedTotal,
+    liveContexts: _liveMB.length,
+    liveCanvasMB: Math.round(_liveMB.reduce((a, b) => a + b, 0)),
+    largestCanvasMB: Math.round(_largestMB),
+  }
+}
+
+export function noteContextCreated(info: ContextInfo): void {
+  const estimatedMB = estimateCanvasMB(info.width, info.height, info.resolution)
+  _createdTotal++
+  _liveMB.push(estimatedMB)
+  _largestMB = Math.max(_largestMB, estimatedMB)
+  const stats = getGlStats()
+  const payload = {
+    width: info.width,
+    height: info.height,
+    resolution: info.resolution,
+    dpr: window.devicePixelRatio || 1,
+    estimatedMB: Math.round(estimatedMB),
+    ...stats,
+  }
+  if (estimatedMB >= WARN_MB_THRESHOLD || (stats.liveContexts >= 2 && stats.liveCanvasMB >= WARN_MB_THRESHOLD)) {
+    rollbar?.warn('[pixi] high GPU canvas memory', payload)
+  } else if (estimatedMB >= INFO_MB_THRESHOLD || stats.liveContexts >= 2) {
+    rollbar?.info('[pixi] webgl context created', payload)
+  }
+}
+
+export function noteContextDestroyed(info: ContextInfo): void {
+  const estimatedMB = estimateCanvasMB(info.width, info.height, info.resolution)
+  _destroyedTotal++
+  // Remove one live entry matching this size (closest match is fine — sizes are
+  // only used in aggregate).
+  let bestIdx = -1
+  let bestDelta = Infinity
+  for (let i = 0; i < _liveMB.length; i++) {
+    const delta = Math.abs(_liveMB[i] - estimatedMB)
+    if (delta < bestDelta) { bestDelta = delta; bestIdx = i }
+  }
+  if (bestIdx >= 0) _liveMB.splice(bestIdx, 1)
+}
+
+/** Test-only: reset module counters between cases. */
+export function _resetGlStatsForTest(): void {
+  _createdTotal = 0
+  _destroyedTotal = 0
+  _liveMB = []
+  _largestMB = 0
+}


### PR DESCRIPTION
## Problem

In Ravenwatch, tapping an NPC with a non-canvas screen (e.g. Field Marshall Fred → `collection-tabs`) and tapping back to the hub sometimes hard-resets the game to the title screen on iOS Safari; repeated occurrences trigger Safari's **"A problem repeatedly occurred"** page. That message means iOS repeatedly killed the page process under memory pressure — a memory crash, not a JS error, so it never reached Rollbar.

## Root cause

- `usePixiApp` creates the Pixi canvas at **full map size** with `resolution: window.devicePixelRatio`. Ravenwatch's map is **2400×2240** CSS px (`web/src/data/hub/ravenwatch/config.json`) vs ~1200×900 for the other towns.
- On a dpr-3 iPhone that's a **7200×6720 drawing buffer ≈ 185 MB of GPU memory**.
- Fred's tap unmounts HubWorld (`app.destroy`); tapping back remounts it and allocates a **new** ~185 MB buffer while the old one is only freed at GC time (Pixi v8's destroy loses the WebGL context but a lost context keeps its backing store until the canvas is collected) → transient ~370 MB spike → iOS jetsam kills the page.
- On reload, startup can land straight back on `hubworld`, immediately re-allocating → crash loop → "A problem repeatedly occurred". When startup picks `title` instead, the player sees "reset to title screen".

## Prevention

- **`usePixiApp` caps renderer resolution** to `min(dpr, 2, sqrt(4096² / (w·h)))` (`computeCappedResolution`, exported + unit-tested). Ravenwatch's buffer drops **185 MB → ~64 MB**; the dpr-2 clamp halves memory on dpr-3 iPhones game-wide (imperceptible for 32px pixel art with antialias off). `autoDensity` keeps the CSS size at MAP_W×MAP_H, so the native-scroll camera, hit-testing, and all other `usePixiApp` callers (battles, casino, node map, interiors, editors — all far below the budget) are coordinate-unchanged.
- **Deterministic backing-store release**: on every destroy path the canvas is shrunk to 1×1 after `app.destroy`, so iOS frees the buffer immediately instead of at GC time — eliminating the double-allocation window.

## Diagnostics (Rollbar)

- **`web/src/utils/pixiTelemetry.ts`** — WebGL context lifecycle counters; `[pixi] webgl context created` (info) for canvases ≥48 MB or a 2nd live context, `[pixi] high GPU canvas memory` (warn) at ≥100 MB. Payload: width/height/resolution/dpr/estimatedMB/live counts.
- **`web/src/utils/crashSentinel.ts`** — `jarv_crash_sentinel` localStorage heartbeat, marked clean on `pagehide`. On boot, a dirty record ⇒ `[sentinel] unclean exit — probable page kill` (warn) with last screen/hub location, visibility (separates foreground jetsam kills from background tab eviction), and the WebGL stats at the time. App.tsx records every screen transition.
- **Real `webglcontextlost` reporting** during app lifetime (the teardown-time suppression still works — it stops propagation in capture phase).
- **`web/src/components/ErrorBoundary.tsx`** wrapping `<App/>`: render errors now reach Rollbar with component stack and show a reload fallback instead of a silent blank screen.

### Expected Rollbar signals post-deploy
- Hub context-created `estimatedMB` drops ~185 → ~64.
- `[sentinel] unclean exit` with `visibility: visible` + `lastScreen: hubworld` should trend to ~0; any residual events carry session replay for diagnosis.

## Testing

- 20 new vitest tests (resolution cap maths, MB estimation, counter invariants, sentinel boot/pagehide/throwing-storage behavior) — all pass; full unit suite 78/78 green.
- `npm run build` (tsc + vite) passes.
- Storybook/playwright browser project doesn't run in this environment (chromium not installed) — pre-existing limitation, unrelated.
- Worth a real-device check: iPhone → Ravenwatch → Fred round-trip ×15; canvas attrs should now be ≈4238×3956.

## Deferred follow-ups (raised as issues)

- Viewport-sized canvas + camera transform (long-term fix; renders ~5 MB instead of ~64 MB).
- Texture cache eviction policy, if telemetry shows residual memory pressure.

https://claude.ai/code/session_01AEkb3G3PxVJRi4Fkhq56v7

---
_Generated by [Claude Code](https://claude.ai/code/session_01AEkb3G3PxVJRi4Fkhq56v7)_