### PR TITLE
feat(hub): viewport-sized canvas with scroll-driven camera (#1570)

### DIFF
--- a/web/src/components/hub/HubTownCanvas.stories.tsx
+++ b/web/src/components/hub/HubTownCanvas.stories.tsx
@@ -36,6 +36,18 @@ function PannableCanvas(args: React.ComponentProps<typeof HubTownCanvas>) {
   )
 }
 
+// Exercises the production path: viewport-sized canvas with the camera driven
+// by a native scroll container (HubWorld does the same with its scrollRef).
+function ViewportCanvas(args: React.ComponentProps<typeof HubTownCanvas>) {
+  const returnRef = useRef<(() => void) | null>(null)
+  const scrollRef = useRef<HTMLDivElement>(null)
+  return (
+    <div ref={scrollRef} style={{ overflow: 'auto', width: '100vw', height: '100vh' }}>
+      <HubTownCanvas {...args} returnRef={returnRef} viewportRef={scrollRef} />
+    </div>
+  )
+}
+
 const meta = {
   component: HubTownCanvas,
   parameters: {
@@ -62,6 +74,17 @@ export const Ravenwatch: Story = {
     locationData: RAVENWATCH,
     questData: RAVENWATCH_QUESTS,
   },
+}
+
+export const RavenwatchViewportCamera: Story = {
+  args: {
+    onAreaEnter:    fn(),
+    onNodeInteract: fn(),
+    onAvatarMove:   fn(),
+    locationData: RAVENWATCH,
+    questData: RAVENWATCH_QUESTS,
+  },
+  render: (args) => <ViewportCanvas {...args} />,
 }
 
 export const IronholdKeep: Story = {

--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -81,6 +81,9 @@ interface Props {
   npcProximityDialogue?: React.MutableRefObject<Map<string, { atDistance: number; text: string }[]>>
   locationData:         HubLocationBundle
   questData: HubQuestBundle
+  /** Scroll container whose scroll position drives the camera. When set, the
+   *  canvas is viewport-sized; without it (e.g. Storybook) it spans the map. */
+  viewportRef?:          React.RefObject<HTMLDivElement | null>
 }
 
 export function HubTownCanvas({
@@ -91,7 +94,8 @@ export function HubTownCanvas({
   completedQuestIdsRef, collectedTreasureIds, onTreasureStep,
   gameHour, isNight, npcProximityDialogue,
   locationData,
-  questData
+  questData,
+  viewportRef
 }: Props) {
   const {
     MAP_W, MAP_H, AVATAR_START,
@@ -146,6 +150,17 @@ export function HubTownCanvas({
   usePixiApp(containerRef, MAP_W, MAP_H, (app) => {
     app.canvas.style.touchAction = 'pan-x pan-y'
 
+    // ── Camera ─────────────────────────────────────────────────────────────────
+    // All world content lives in worldRoot so the canvas can stay viewport-sized
+    // while the parent scroll container provides the camera position (#1570).
+    // Without viewportRef the canvas spans the whole map and the camera is fixed.
+    const worldRoot = new PIXI.Container()
+    app.stage.addChild(worldRoot)
+    const syncCamera = () => {
+      const vp = viewportRef?.current
+      if (vp) worldRoot.position.set(-vp.scrollLeft, -vp.scrollTop)
+    }
+
     // ── Layer hierarchy ────────────────────────────────────────────────────────
     const groundLayer   = new PIXI.Container()
     const streetLayer   = new PIXI.Container()
@@ -181,7 +196,7 @@ export function HubTownCanvas({
     const npcLayer    = spriteLayer
     const avatarLayer = spriteLayer
     const exteriorDecorLayer = spriteLayer
-    app.stage.addChild(groundLayer, streetLayer, pondLayer, buildingLayer, windowLayer, belowAvatarLayer, spriteLayer, aboveAvatarLayer, pickupLayer, nodeLayer, worldLayer, nightSprite, interiorLayer, bubbleLayer, highlightGfx)
+    worldRoot.addChild(groundLayer, streetLayer, pondLayer, buildingLayer, windowLayer, belowAvatarLayer, spriteLayer, aboveAvatarLayer, pickupLayer, nodeLayer, worldLayer, nightSprite, interiorLayer, bubbleLayer, highlightGfx)
 
     // Keyed by pickupId; used to imperatively show/hide sprites when items are collected
     const pickupSprites  = new Map<string, PIXI.Sprite>()
@@ -1735,7 +1750,10 @@ export function HubTownCanvas({
 
     // ── Input ──────────────────────────────────────────────────────────────────
     app.stage.eventMode = 'static'
-    app.stage.hitArea   = new PIXI.Rectangle(0, 0, MAP_W, MAP_H)
+    // Stage-local coords equal screen coords (the camera transform lives on
+    // worldRoot), so the hit area is the screen rect — app.screen is updated
+    // in place by renderer resizes.
+    app.stage.hitArea   = app.screen
 
     function drawTileHighlight(stageX: number, stageY: number) {
       highlightGfx.clear()
@@ -1764,7 +1782,8 @@ export function HubTownCanvas({
         interiorWalkQueue = path.slice(1)
         if (!interiorIsWalking) processInteriorWalkQueue()
       } else {
-        const { x, y } = e.getLocalPosition(app.stage)
+        const { x, y } = e.getLocalPosition(worldRoot)
+        if (x < 0 || y < 0 || x >= MAP_W || y >= MAP_H) return  // off the map edge
         const tapTx = Math.floor(x / T)
         const tapTy = Math.floor(y / T)
         if (onTileTapRef.current) {
@@ -1793,7 +1812,7 @@ export function HubTownCanvas({
 
     app.stage.on('pointermove', (e: PIXI.FederatedPointerEvent) => {
       if (interiorActive) return
-      const { x, y } = e.getLocalPosition(app.stage)
+      const { x, y } = e.getLocalPosition(worldRoot)
       const area = HUB_AREAS.find(
         a => x >= a.x && x < a.x + a.w && y >= a.y && y < a.y + a.h,
       )
@@ -1814,12 +1833,17 @@ export function HubTownCanvas({
     }
 
     // ── Per-frame ──────────────────────────────────────────────────────────────
+    syncCamera()  // position the camera before the first rendered frame
     let _tickerErrorTs = 0
     let _lastNightAlpha = -1
     let _lastNightAvatarX = -Infinity, _lastNightAvatarY = -Infinity
     let _lastReportX = -Infinity, _lastReportY = -Infinity
     app.ticker.add((ticker) => {
       try {
+      // Follow the scroll container every frame — scroll events are async on
+      // iOS momentum scrolling, but only the camera is visible motion, so
+      // reading the live scroll position here can never show a stale frame.
+      syncCamera()
       // Avatar animation + position report
       if (avatar) {
         // Report stage-space position (accounts for interior layer offset)
@@ -2149,12 +2173,18 @@ export function HubTownCanvas({
         }
       }
     })
-  })
+  }, { resizeTo: viewportRef })
 
   return (
-    <div
-      ref={containerRef}
-      style={{ display: 'block', flexShrink: 0, width: MAP_W, height: MAP_H }}
-    />
+    // The map-sized spacer preserves the parent scroll range; the sticky inner
+    // div pins the viewport-sized canvas to the scrollport while scrolling
+    // moves the camera. Without viewportRef the canvas is map-sized and fills
+    // the spacer, matching the old layout.
+    <div style={{ position: 'relative', flexShrink: 0, width: MAP_W, height: MAP_H }}>
+      <div
+        ref={containerRef}
+        style={{ position: 'sticky', top: 0, left: 0, width: 'fit-content', height: 'fit-content' }}
+      />
+    </div>
   )
 }

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -625,6 +625,7 @@ function grantQuestReward(quest: HubQuestDef): void {
             npcProximityDialogue={npcProximityDialogueRef}
             locationData={locationData}
             questData={ALL_QUESTS}
+            viewportRef={scrollRef}
           />
         </div>
         <AreaNameBadge name={currentArea} />

--- a/web/src/hooks/usePixiApp.ts
+++ b/web/src/hooks/usePixiApp.ts
@@ -13,6 +13,10 @@ import { noteContextCreated, noteContextDestroyed, getGlStats } from '../utils/p
  *   usePixiApp(containerRef, width, height, app => { ... build scene ... })
  *   return <div ref={containerRef} />
  *
+ * When opts.resizeTo is given, the renderer is sized to that element (and tracks
+ * window resizes via Pixi's ResizePlugin) instead of the fixed width/height,
+ * which then only serve as a fallback when the element has no size yet.
+ *
  * Note: PixiJS creates its own canvas element and appends it to the container.
  * This avoids the React Strict Mode double-invoke issue where two apps would share
  * the same pre-existing canvas element and fight over its WebGL context.
@@ -63,6 +67,7 @@ export function usePixiApp(
   width: number,
   height: number,
   onReady: (app: PIXI.Application) => void,
+  opts?: { resizeTo?: React.RefObject<HTMLElement | null> },
 ) {
   const appRef = useRef<PIXI.Application | null>(null)
 
@@ -73,8 +78,11 @@ export function usePixiApp(
     const app = new PIXI.Application()
     appRef.current = app
 
-    const resolution = computeCappedResolution(width, height, window.devicePixelRatio || 1)
-    const contextInfo = { width, height, resolution }
+    const resizeEl = opts?.resizeTo?.current ?? undefined
+    const initW = resizeEl?.clientWidth  || width
+    const initH = resizeEl?.clientHeight || height
+    const resolution = computeCappedResolution(initW, initH, window.devicePixelRatio || 1)
+    const contextInfo = { width: initW, height: initH, resolution }
     const onContextLost = () => {
       rollbar?.error('[usePixiApp] webglcontextlost during app lifetime', { ...contextInfo, ...getGlStats() })
     }
@@ -89,8 +97,9 @@ export function usePixiApp(
 
     let initialized = false
     app.init({
-      width,
-      height,
+      width: initW,
+      height: initH,
+      resizeTo: resizeEl,
       backgroundAlpha: 0,
       antialias: false,
       resolution,


### PR DESCRIPTION
Implements Phase A of #1570 (plan: [issue comment](https://github.com/Jarvichi/jarvs-amazing-web-game/issues/1570#issuecomment-4667710349)). Should also resolve #1572 (fuzzy avatar) since the hub renders at full `min(dpr, 2)` again.

## What changed

The hub canvas previously spanned the entire map — 2400×2240 CSS px for Ravenwatch, ~64 MB of GPU memory even after the #1569 resolution cap, with sub-dpr rendering that blurred sprites. It is now **viewport-sized** (~4 MB at dpr 2) with a camera:

- **DOM:** `HubTownCanvas` renders a map-sized spacer (preserving the parent scroll range) containing a `position: sticky` div that pins the canvas to the scrollport. `HubWorld` passes its existing `scrollRef` down as `viewportRef`.
- **Pixi:** all 15 world layers moved into a single `worldRoot` container; each ticker frame sets `worldRoot.position = (-scrollLeft, -scrollTop)`. Reading the live scroll position per frame sidesteps iOS's async scroll events — the canvas itself never moves, so no jitter is possible.
- **Unchanged by design:** avatar-follow (`scrollLeft/scrollTop` math), saved-position restore, interiors, night overlay, speech bubbles, tile highlights — all map-coordinate code lives under `worldRoot` and Pixi resolves the transform.
- **Pointer input:** taps/moves resolve via `getLocalPosition(worldRoot)` (2 call sites); the stage hit area is now `app.screen` (live-updated on resize) with an off-map-edge guard, since on large screens a small town can be smaller than the viewport.
- **`usePixiApp`:** new optional `{ resizeTo }` element — sizes the renderer to it via Pixi's ResizePlugin (handles window resize/rotation); all fixed-size callers unaffected.
- **Storybook:** existing stories keep working via the no-`viewportRef` fallback (map-sized canvas, as before); new `RavenwatchViewportCamera` story exercises the production camera path.

## Verification

- Playwright against the new story (chromium, 390×700 @ dpr 2):
  - canvas attrs **780×1384** (viewport × dpr 2, full sharpness) instead of 4240×3957; scroll range still 2400×2240 via the spacer.
  - after scrolling to (800, 600) the canvas stays pinned while the world pans — screenshots show two different town districts rendering correctly (tiles, buildings, NPCs, name tags).
  - the only console errors are pre-existing Storybook sprite 404s, identical on the old story.
- `npm run build` (tsc + vite) green; unit suite 78/78 green.
- **Still needs a real-device iOS pass** per the #1570 regression checklist (tap-to-walk at various scroll positions, interiors, night overlay, rotation) before this is fully signed off.

## Expected telemetry shift

`[pixi] webgl context created` events for the hub should drop from `estimatedMB ≈ 64` to ~4 (below the report threshold, so hub canvases largely disappear from Rollbar info events — that silence is the success signal).

Phase B (tile chunk culling) to follow separately per the plan.

Closes #1572.

https://claude.ai/code/session_01AEkb3G3PxVJRi4Fkhq56v7

---
_Generated by [Claude Code](https://claude.ai/code/session_01AEkb3G3PxVJRi4Fkhq56v7)_