### PR TITLE
perf(hub): cull off-screen static tile chunks (#1570 Phase B)

### DIFF
--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -11,6 +11,7 @@ import { getGameHour, getGameMinute } from '../../game/hub/hubClock'
 import { getWallTile, ROOF_TILES, WALL_TILES, ROOF_ROWS } from '../../data/tiles/buildingMaterials'
 import type { WallMaterial, RoofMaterial } from '../../data/tiles/buildingMaterials'
 import { loadPlayerAvatar } from '../../game/questline'
+import { createChunkCuller } from '../../utils/chunkCull'
 import { CommanderState } from '../../game/commander'
 import rollbar from '../../rollbar'
 import { HubInteriorExit, HubLocationBundle, HubNpc, HubQuestBundle, HubStreetGroup, NpcScheduleEntry } from '../../data/hub/loader'
@@ -207,14 +208,23 @@ export function HubTownCanvas({
     // ── Terrain ────────────────────────────────────────────────────────────────
     const baseContainer  = new PIXI.Container()
     const riverContainer = new PIXI.Container()
-    groundLayer.addChild(baseContainer, riverContainer)
+    const decorContainer = new PIXI.Container()
+    groundLayer.addChild(baseContainer, riverContainer, decorContainer)
 
     buildTerrainGfx(baseContainer, riverContainer, worldLayer,
       { environment: HUB_ENV, id: 'hubworld', terrainItems: [] }, MAP_W, MAP_H)
     buildBgTileGfx(baseContainer, { environment: HUB_ENV }, MAP_W, MAP_H)
       .catch(e => rollbar.error('[HubTownCanvas] bg tiles failed', { error: String(e) }))
-    buildDecorGfx(groundLayer, { environment: HUB_ENV, id: 'hubworld' }, MAP_W, MAP_H)
+    buildDecorGfx(decorContainer, { environment: HUB_ENV, id: 'hubworld' }, MAP_W, MAP_H)
       .catch(e => rollbar.error('[HubTownCanvas] decor tiles failed', { error: String(e) }))
+
+    // Cull off-screen chunks of the static tile layers each frame (#1570 Phase
+    // B). Dynamic layers (sprites, pickups, bubbles, interior) stay unculled.
+    const chunkCuller = createChunkCuller([
+      baseContainer, riverContainer, decorContainer,
+      streetLayer, pondLayer, buildingLayer, windowLayer,
+      belowAvatarLayer, aboveAvatarLayer, nodeLayer,
+    ])
 
     // ── Pond (Greyfish Pond) — water path tiles ───────────────────────────────
     {
@@ -1844,6 +1854,10 @@ export function HubTownCanvas({
       // iOS momentum scrolling, but only the camera is visible motion, so
       // reading the live scroll position here can never show a stale frame.
       syncCamera()
+      // Hide static-layer chunks outside the camera view. Only in viewport
+      // mode — the map-sized fallback canvas (Storybook) shows everything.
+      const vp = viewportRef?.current
+      if (vp) chunkCuller.update(ticker.deltaMS, vp.scrollLeft, vp.scrollTop, app.screen.width, app.screen.height)
       // Avatar animation + position report
       if (avatar) {
         // Report stage-space position (accounts for interior layer offset)

--- a/web/src/utils/chunkCull.test.ts
+++ b/web/src/utils/chunkCull.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi } from 'vitest'
+
+// pixi.js reads navigator/window at module load (absent in Node 20 CI).
+vi.stubGlobal('window', { devicePixelRatio: 2 })
+vi.stubGlobal('navigator', { userAgent: 'node' })
+
+const PIXI = await import('pixi.js')
+const { createChunkCuller } = await import('./chunkCull')
+
+function tileAt(x: number, y: number, size = 32): InstanceType<typeof PIXI.Graphics> {
+  const g = new PIXI.Graphics()
+  g.rect(0, 0, size, size).fill(0xffffff)
+  g.x = x
+  g.y = y
+  return g
+}
+
+describe('createChunkCuller', () => {
+  it('adopts children into grid chunks and leaves only chunk containers on the layer', () => {
+    const layer = new PIXI.Container()
+    layer.addChild(tileAt(0, 0), tileAt(64, 64), tileAt(600, 0), tileAt(600, 600))
+    const culler = createChunkCuller([layer], { chunkPx: 512 })
+    culler.rechunk()
+    // (0,0)+(64,64) share chunk 0,0; (600,0) → 1,0; (600,600) → 1,1
+    expect(culler.stats().chunks).toBe(3)
+    expect(layer.children).toHaveLength(3)
+  })
+
+  it('culls chunks outside the view and keeps those inside', () => {
+    const layer = new PIXI.Container()
+    const near = tileAt(0, 0)
+    const far = tileAt(2000, 2000)
+    layer.addChild(near, far)
+    const culler = createChunkCuller([layer], { chunkPx: 512 })
+    culler.update(0, 0, 0, 400, 700)
+    expect(near.parent!.visible).toBe(true)
+    expect(far.parent!.visible).toBe(false)
+    expect(culler.stats()).toEqual({ chunks: 2, visibleChunks: 1 })
+
+    // Move the view onto the far chunk
+    culler.update(0, 1900, 1900, 400, 700)
+    expect(near.parent!.visible).toBe(false)
+    expect(far.parent!.visible).toBe(true)
+  })
+
+  it('adopts late-added children on the next periodic sweep', () => {
+    const layer = new PIXI.Container()
+    const culler = createChunkCuller([layer], { chunkPx: 512, rechunkMs: 1000 })
+    culler.update(0, 0, 0, 400, 700)  // first update always sweeps
+    const late = tileAt(1500, 0)
+    layer.addChild(late)
+    culler.update(100, 0, 0, 400, 700)  // 100ms — not yet swept, still at layer level
+    expect(late.parent).toBe(layer)
+    expect(late.visible).toBe(true)     // un-adopted children render normally
+    culler.update(1000, 0, 0, 400, 700)
+    expect(late.parent).not.toBe(layer)
+    expect(late.parent!.visible).toBe(false)  // off-view once adopted
+  })
+
+  it('never culls a chunk containing an oversized child', () => {
+    const layer = new PIXI.Container()
+    const mapWide = new PIXI.Graphics()
+    mapWide.rect(0, 0, 2400, 2240).fill(0x00ff00)  // anchored at chunk 0,0 but spans the map
+    layer.addChild(mapWide)
+    const culler = createChunkCuller([layer], { chunkPx: 512 })
+    culler.update(0, 1800, 1800, 400, 700)  // view far from the child's origin
+    expect(mapWide.parent!.visible).toBe(true)
+  })
+
+  it('accounts for child scale when measuring bounds', () => {
+    const layer = new PIXI.Container()
+    const scaled = tileAt(480, 0)
+    scaled.scale.set(4)  // 32px rect → 128px, reaching x=608 into the next chunk's area
+    layer.addChild(scaled)
+    const culler = createChunkCuller([layer], { chunkPx: 512 })
+    culler.update(0, 560, 0, 400, 700)  // view starts past the unscaled extent
+    expect(scaled.parent!.visible).toBe(true)
+  })
+})

--- a/web/src/utils/chunkCull.ts
+++ b/web/src/utils/chunkCull.ts
@@ -1,0 +1,125 @@
+import * as PIXI from 'pixi.js'
+
+// ── Chunked culling for static world layers ───────────────────────────────────
+// The hub map renders thousands of tile/decor sprites; with a viewport-sized
+// camera (#1570) most are off-screen every frame, but Pixi still processes
+// them. This groups a layer's children into grid-cell chunk containers and
+// toggles chunk visibility against the camera view, so per-frame work scales
+// with the viewport instead of the map.
+//
+// Constraints:
+// - Only pass layers whose children do NOT move after being added (their
+//   bounds are captured when a sweep adopts them into a chunk). Toggling
+//   `visible`/`alpha`/textures on children is fine.
+// - Children are assigned to a chunk by their (x, y), but culling tests the
+//   chunk's exact bounds union, so oversized children (multi-tile buildings,
+//   map-wide backgrounds) are never culled incorrectly — a map-wide child
+//   simply makes its chunk permanently visible.
+// - Children added asynchronously (texture loads) are adopted by the periodic
+//   sweep; until then they sit at the layer level and render normally.
+
+const DEFAULT_CHUNK_PX   = 512   // 16 tiles of 32px
+const DEFAULT_RECHUNK_MS = 1000
+
+interface Chunk {
+  container: PIXI.Container
+  minX: number
+  minY: number
+  maxX: number
+  maxY: number
+}
+
+interface LayerState {
+  layer: PIXI.Container
+  chunks: Map<string, Chunk>
+}
+
+export interface ChunkCuller {
+  /** Adopt any new layer children into chunks, then cull against the view
+   *  (world-space rect). Call once per frame after the camera is positioned. */
+  update(deltaMS: number, viewX: number, viewY: number, viewW: number, viewH: number): void
+  /** Force an adoption sweep now (also runs every rechunkMs via update). */
+  rechunk(): void
+  /** Visible/total chunk counts from the last update — for tests/telemetry. */
+  stats(): { chunks: number; visibleChunks: number }
+}
+
+const CHUNK_FLAG = Symbol('hubChunk')
+
+function isChunk(c: PIXI.Container): boolean {
+  return CHUNK_FLAG in (c as unknown as Record<symbol, unknown>)
+}
+
+// Child bounds in layer space: local bounds mapped through position + scale
+// (rotation is not used by hub scene content).
+function childBox(c: PIXI.Container): { minX: number; minY: number; maxX: number; maxY: number } {
+  const lb = c.getLocalBounds()
+  const sx = c.scale.x, sy = c.scale.y
+  const x0 = c.x + lb.x * sx, y0 = c.y + lb.y * sy
+  const x1 = c.x + (lb.x + lb.width) * sx, y1 = c.y + (lb.y + lb.height) * sy
+  return { minX: Math.min(x0, x1), minY: Math.min(y0, y1), maxX: Math.max(x0, x1), maxY: Math.max(y0, y1) }
+}
+
+export function createChunkCuller(
+  layers: PIXI.Container[],
+  opts?: { chunkPx?: number; rechunkMs?: number },
+): ChunkCuller {
+  const chunkPx   = opts?.chunkPx   ?? DEFAULT_CHUNK_PX
+  const rechunkMs = opts?.rechunkMs ?? DEFAULT_RECHUNK_MS
+  const states: LayerState[] = layers.map(layer => ({ layer, chunks: new Map() }))
+  let sinceRechunk = Infinity  // first update() always sweeps
+  let visibleChunks = 0
+
+  function rechunk(): void {
+    for (const st of states) {
+      const pending = st.layer.children.filter(c => !isChunk(c))
+      for (const child of pending) {
+        const box = childBox(child)
+        const key = `${Math.floor(child.x / chunkPx)},${Math.floor(child.y / chunkPx)}`
+        let chunk = st.chunks.get(key)
+        if (!chunk) {
+          const container = new PIXI.Container()
+          ;(container as unknown as Record<symbol, unknown>)[CHUNK_FLAG] = true
+          st.layer.addChild(container)
+          chunk = { container, minX: Infinity, minY: Infinity, maxX: -Infinity, maxY: -Infinity }
+          st.chunks.set(key, chunk)
+        }
+        chunk.container.addChild(child)  // re-parents; layer-space coords are unchanged
+        chunk.minX = Math.min(chunk.minX, box.minX)
+        chunk.minY = Math.min(chunk.minY, box.minY)
+        chunk.maxX = Math.max(chunk.maxX, box.maxX)
+        chunk.maxY = Math.max(chunk.maxY, box.maxY)
+      }
+    }
+  }
+
+  function cull(viewX: number, viewY: number, viewW: number, viewH: number): void {
+    visibleChunks = 0
+    for (const st of states) {
+      for (const chunk of st.chunks.values()) {
+        const visible =
+          chunk.maxX >= viewX && chunk.minX <= viewX + viewW &&
+          chunk.maxY >= viewY && chunk.minY <= viewY + viewH
+        chunk.container.visible = visible
+        if (visible) visibleChunks++
+      }
+    }
+  }
+
+  return {
+    rechunk,
+    update(deltaMS, viewX, viewY, viewW, viewH) {
+      sinceRechunk += deltaMS
+      if (sinceRechunk >= rechunkMs) {
+        sinceRechunk = 0
+        rechunk()
+      }
+      cull(viewX, viewY, viewW, viewH)
+    },
+    stats() {
+      let chunks = 0
+      for (const st of states) chunks += st.chunks.size
+      return { chunks, visibleChunks }
+    },
+  }
+}


### PR DESCRIPTION
Phase B of #1570 (Phase A landed in #1573). Completes the issue.

## What changed

With the viewport camera in place, most of the hub's ~10–20k static tile/decor sprites are off-screen every frame, but Pixi still walked and batched all of them. This adds `web/src/utils/chunkCull.ts`:

- The static layers' children (terrain, bg tiles, decor, streets, pond, buildings, windows, below/above-avatar decor, door signs) are adopted into **512px grid-cell chunk containers** by a periodic sweep (handles the async texture-load `.then()` additions — children render normally at layer level until adopted).
- Each ticker frame, after the camera sync, chunk visibility is toggled against the camera's world rect — **~250 rectangle tests instead of thousands of sprite traversals**.
- **Correctness guard:** chunks are assigned by child position but culled against the chunk's exact bounds union (position + scaled local bounds), so multi-tile buildings or map-wide background graphics can never be culled while visible — a map-wide child just makes its chunk permanently visible.
- Dynamic layers (avatar/NPCs, pickups, bubbles, interior, night overlay, highlight) stay unculled; the map-sized Storybook fallback (no `viewportRef`) skips culling entirely.
- Decor now builds into its own sub-container so the terrain sub-containers aren't swept into chunks.

## Verification

- 5 new unit tests (`chunkCull.test.ts`, real Pixi containers): chunk adoption, late adoption via periodic sweep, view culling + stats, the oversized-child guard, and scale-aware bounds.
- Playwright against the `RavenwatchViewportCamera` story at four scroll positions including the far map corner (2010, 1540): **no holes, no missing tiles, no page errors** — screenshots show full ground/street/building/decor/NPC rendering everywhere.
- `npm run build` green; full unit suite green.

https://claude.ai/code/session_01AEkb3G3PxVJRi4Fkhq56v7

---
_Generated by [Claude Code](https://claude.ai/code/session_01AEkb3G3PxVJRi4Fkhq56v7)_