### PR TITLE
Fix endless mode false "base destroyed" deaths at high game speed

### DIFF
--- a/web/src/game/battleReducer.test.ts
+++ b/web/src/game/battleReducer.test.ts
@@ -146,6 +146,47 @@ describe('battleReducer', () => {
       expect(next).toBe(INITIAL_BATTLE_STATE)
     })
 
+    it('runs one fixed-size engine sub-tick per speed multiple', async () => {
+      const { tick } = await import('./engine')
+      const state = withGameState(makeGameState({ gameTime: 0 }), { speedMultiplier: 8 })
+
+      const next = battleReducer(state, { type: 'TICK' })
+
+      expect(tick).toHaveBeenCalledTimes(8)
+      expect(vi.mocked(tick).mock.calls.every(call => call[1] === TICK_MS)).toBe(true)
+      expect(next.gameState?.gameTime).toBe(8 * TICK_MS)
+    })
+
+    it('stops sub-ticking as soon as the player base takes damage', async () => {
+      const { tick } = await import('./engine')
+      vi.mocked(tick).mockImplementationOnce((state: GameState, deltaMs: number) => ({
+        ...state,
+        gameTime: state.gameTime + deltaMs,
+        playerBase: { ...state.playerBase, hp: state.playerBase.hp - 5 },
+      }))
+      const state = withGameState(makeGameState({ gameTime: 0 }), { speedMultiplier: 8 })
+
+      const next = battleReducer(state, { type: 'TICK' })
+
+      expect(tick).toHaveBeenCalledTimes(1)
+      expect(next.gameState?.playerBase.hp).toBe(95)
+    })
+
+    it('stops sub-ticking when the game leaves the playing phase', async () => {
+      const { tick } = await import('./engine')
+      vi.mocked(tick).mockImplementationOnce((state: GameState, deltaMs: number) => ({
+        ...state,
+        gameTime: state.gameTime + deltaMs,
+        phase: { type: 'gameOver' as const, winner: 'opponent' as const },
+      }))
+      const state = withGameState(makeGameState({ gameTime: 0 }), { speedMultiplier: 8 })
+
+      const next = battleReducer(state, { type: 'TICK' })
+
+      expect(tick).toHaveBeenCalledTimes(1)
+      expect(next.gameState?.phase.type).toBe('gameOver')
+    })
+
     it('does not mutate other battle state fields', () => {
       const state = withGameState(makeGameState(), { showBossShockwave: true, fingerSmashNames: ['X'] })
       const next = battleReducer(state, { type: 'TICK' })

--- a/web/src/game/battleReducer.ts
+++ b/web/src/game/battleReducer.ts
@@ -111,7 +111,21 @@ export function battleReducer(state: BattleState, action: BattleAction): BattleS
 
     case 'TICK': {
       if (!state.gameState) return state
-      return { ...state, gameState: engineTick(state.gameState, TICK_MS * state.speedMultiplier) }
+      // Run fixed TICK_MS sub-ticks rather than one large delta. A single 800ms tick
+      // at 8× distorts the simulation (movement tunneling, attack cadence, whole-tick
+      // damage bursts landing between game-over checks) and can kill the commander
+      // within one render — before the "drop to 1× on commander damage" effect in
+      // App.tsx ever gets a chance to fire.
+      let gs = state.gameState
+      for (let i = 0; i < state.speedMultiplier; i++) {
+        const hpBefore = gs.playerBase.hp
+        gs = engineTick(gs, TICK_MS)
+        if (gs.phase.type !== 'playing') break
+        // Stop early when the player takes damage so the UI can render (and
+        // auto-drop the speed) before further sub-ticks compound the damage.
+        if (gs.playerBase.hp < hpBefore) break
+      }
+      return { ...state, gameState: gs }
     }
 
     case 'SET_GAME_STATE':

--- a/web/src/game/battleState.ts
+++ b/web/src/game/battleState.ts
@@ -1,5 +1,6 @@
 import { GameState } from './types'
 import { logError } from '../logger'
+import { syncUnitIdCounter } from './engine/helpers'
 
 const KEY = 'jarv_battle_state'
 
@@ -40,6 +41,9 @@ export function loadBattleState(): GameState | null {
       localStorage.removeItem(KEY)
       return null
     }
+    // Units in the restored field keep their original ids while the module-level id
+    // counter restarts at 0 after a reload — bump it so new spawns can't collide.
+    syncUnitIdCounter(parsed.field)
     return parsed
   } catch { return null }
 }

--- a/web/src/game/engine.test.ts
+++ b/web/src/game/engine.test.ts
@@ -25,6 +25,8 @@ vi.mock('./debug', () => ({
 
 import { newGame, tick, MAX_HANDICAP } from './engine'
 import { playCard } from './engine/cards'
+import { triggerNextEndlessWave } from './engine/endlessMode'
+import { syncUnitIdCounter, uid } from './engine/helpers'
 import { makeDeck } from './cards'
 
 // ─── newGame ──────────────────────────────────────────────────────────────────
@@ -148,5 +150,38 @@ describe('tick', () => {
     const full = { ...state, mana: state.maxMana, manaAccum: 0 }
     const next = tick(full, 100000)
     expect(next.mana).toBeLessThanOrEqual(next.maxMana)
+  })
+})
+
+// ─── Endless mode wave transition ────────────────────────────────────────────
+
+describe('triggerNextEndlessWave', () => {
+  it('finger smash never removes the player commander, even when unit ids collide', () => {
+    const state = newGame({ endlessMode: true })
+    const commander = state.field.find(u => u.isCommander && u.owner === 'player')
+    expect(commander).toBeDefined()
+
+    // Simulate a restored save where the id counter reset and a later spawn
+    // re-used the commander's id (issue: instant "base destroyed" on wave clear).
+    state.field = state.field.filter(u => u.isCommander)
+    const dupe = { ...commander!, isCommander: false, commanderHomeX: undefined, name: 'Dupe', moveSpeed: 5 }
+    state.field.push(dupe)
+
+    triggerNextEndlessWave(state)
+
+    // The duplicate-id unit is the only smash candidate and is always removed;
+    // the commander must survive the removal despite sharing its id.
+    expect(state.field).toContain(commander)
+    expect(state.field).not.toContain(dupe)
+  })
+})
+
+// ─── Unit id counter restore ─────────────────────────────────────────────────
+
+describe('syncUnitIdCounter', () => {
+  it('bumps the uid counter past restored unit ids so new spawns cannot collide', () => {
+    syncUnitIdCounter([{ id: 'unit-9000' }, { id: 'rc-5' }, { id: undefined }])
+    const next = parseInt(uid().replace('unit-', ''), 10)
+    expect(next).toBeGreaterThan(9000)
   })
 })

--- a/web/src/game/engine.ts
+++ b/web/src/game/engine.ts
@@ -444,8 +444,9 @@ function checkGameOver(s: GameState): boolean {
       killCount = Math.min(killCount, Math.max(0, shockwavePool.length - MIN_SURVIVORS))
       if (killCount > 0) {
         const victims = shuffle(shockwavePool).slice(0, killCount)
-        const victimIds = new Set(victims.map(u => u.id))
-        s.field = s.field.filter(u => !victimIds.has(u.id))
+        // Remove by identity, not id — restored saves can contain duplicate unit ids
+        const victimSet = new Set(victims)
+        s.field = s.field.filter(u => !victimSet.has(u))
         s.log.push(`💥 The shockwave obliterates ${victims.map(u => u.name).join(', ')}!`)
       }
 

--- a/web/src/game/engine/combat.ts
+++ b/web/src/game/engine/combat.ts
@@ -108,6 +108,9 @@ export function processAttacks(s: GameState, deltaMs: number, log: string[]): vo
             for (const e of aoeTargets) {
               e.hp = Math.max(0, e.hp - dmg)
               e.damageFlashTimer = DAMAGE_FLASH_MS
+              // Mark mobile kills as dying so they linger for the death animation and
+              // aren't silently purged before the commander/base HP sync sees them.
+              if (e.hp <= 0 && e.moveSpeed > 0 && !e.isWall && !e.dyingTimer) e.dyingTimer = DEATH_LINGER_MS
               if (isPlayer) s.playerScore += Math.min(dmg, prevHp)
               else          s.opponentScore += Math.min(dmg, prevHp)
             }
@@ -161,6 +164,9 @@ export function processAttacks(s: GameState, deltaMs: number, log: string[]): vo
           for (const e of enemies) {
             e.hp -= aoeDmg
             e.damageFlashTimer = DAMAGE_FLASH_MS
+            // Mark mobile kills as dying so they linger for the death animation and
+            // aren't silently purged before the commander/base HP sync sees them.
+            if (e.hp <= 0 && e.moveSpeed > 0 && !e.isWall && !e.dyingTimer) e.dyingTimer = DEATH_LINGER_MS
           }
           log.push(`!!💥 ${target.name} erupts! AOE blast hits ${enemies.length} enemy unit${enemies.length !== 1 ? 's' : ''}!`)
         }
@@ -174,6 +180,9 @@ export function processAttacks(s: GameState, deltaMs: number, log: string[]): vo
             for (const e of blastTargets) {
               e.hp = Math.max(0, e.hp - aoeDmg)
               e.damageFlashTimer = DAMAGE_FLASH_MS
+              // Mark mobile kills as dying so they linger for the death animation and
+              // aren't silently purged before the commander/base HP sync sees them.
+              if (e.hp <= 0 && e.moveSpeed > 0 && !e.isWall && !e.dyingTimer) e.dyingTimer = DEATH_LINGER_MS
             }
             log.push(`!!💥 ${target.name} explodes! ${blastTargets.length} unit${blastTargets.length !== 1 ? 's' : ''} caught in the blast!`)
           }

--- a/web/src/game/engine/endlessMode.ts
+++ b/web/src/game/engine/endlessMode.ts
@@ -86,7 +86,9 @@ export function triggerNextEndlessWave(s: GameState): false {
     const idx = Math.floor(Math.random() * smashPool.length)
     const [victim] = smashPool.splice(idx, 1)
     smashedNames.push(victim.name)
-    s.field = s.field.filter(u => u.id !== victim.id)
+    // Remove by identity, not id — restored saves can contain duplicate unit ids,
+    // and an id match would also delete an innocent unit (even the commander).
+    s.field = s.field.filter(u => u !== victim)
     if (victim.moveSpeed > 0 && !victim.flying) {
       s.bloodPools.push({ id: `smash-${victim.id}`, x: victim.x, y: victim.y ?? 0 })
       const active = s.bloodPools.filter(p => p.fadingAt === undefined)

--- a/web/src/game/engine/helpers.ts
+++ b/web/src/game/engine/helpers.ts
@@ -7,6 +7,18 @@ import { PLAYER_SPAWN_X, OPPONENT_SPAWN_X, COMMANDER_HOME_X } from './constants'
 // ─── Helpers ─────────────────────────────────────────────
 let _unitId = 0;
 export function uid(): string { return `unit-${++_unitId}`; }
+/**
+ * Advance the unit-id counter past every id in a restored field. The counter lives in
+ * module state and resets to 0 on page reload, so without this a restored battle's
+ * units collide with freshly spawned ones — and any removal-by-id (e.g. the endless
+ * finger smash) then deletes the restored unit too, including the player commander.
+ */
+export function syncUnitIdCounter(field: { id?: string }[]): void {
+  for (const u of field) {
+    const m = /^unit-(\d+)$/.exec(u.id ?? '');
+    if (m) _unitId = Math.max(_unitId, parseInt(m[1], 10));
+  }
+}
 let _recycleId = 0;
 export function recycleCardId(): string { return `rc-${++_recycleId}`; }
 let _animId = 0;


### PR DESCRIPTION
## Problem

Players occasionally get the **"Your base was destroyed"** screen in endless mode without having taken any damage, typically while running at 8x speed.

## Root cause

Unit ids come from a module-level counter (`engine/helpers.ts`) that resets to 0 on page reload, but `loadBattleState()` restores an in-progress endless run with its **original** unit ids. After resuming a run, newly spawned units silently reuse existing ids — including the player commander's (it's one of the first units spawned, so its id is reused almost immediately).

The endless finger-smash wave transition then removes its victims **by id** (`endlessMode.ts`). Smashing a duplicate-id unit also deleted the commander, and the per-tick HP sync (`engine.ts`) treats a missing commander as base HP 0 → instant defeat on a wave clear, with zero damage taken.

The "8x speed" detail in the reports is a tell: the game auto-drops to 1x the moment the commander takes damage (`App.tsx`), so anyone still at 8x on the death screen by definition never saw damage land.

## Fixes

- **Restore-safe ids:** `loadBattleState()` now bumps the unit-id counter past every restored id (`syncUnitIdCounter`), so new spawns can't collide.
- **Removal by identity:** the finger smash and the boss-phase-2 shockwave now remove victims by object identity instead of id, so a duplicate id can never take an innocent unit (or the commander) with it.
- **No more silent purges:** AOE-burst, on-death-blast, and half-health-eruption kills now set `dyingTimer` (matching the existing fix for player AOE cards in `engine/cards.ts`), so mobile units — including commanders — are never purged in the same tick with no death animation before the HP sync / game-over check.
- **Fixed-timestep speed multiplier:** `TICK` now runs N fixed 100ms engine sub-ticks instead of one N×100ms mega-tick. Large deltas distorted the simulation at 8x (movement tunneling, attack cadence, whole-tick damage bursts landing between game-over checks). The loop also stops early when the player base takes damage, so the auto-drop-to-1x effect gets a render to react before further sub-ticks compound the damage.

## Tests

- Regression test: finger smash with a duplicate-id unit must not remove the commander (fails on the old id-based removal).
- `syncUnitIdCounter` bumps the uid counter past restored ids.
- Reducer sub-ticks: 8x runs 8×100ms ticks; stops early on player damage and on phase change.

All 63 tests pass; `tsc --noEmit` is clean.

https://claude.ai/code/session_012NPLJ5EtnX2rwfMWr6UJhM

---
_Generated by [Claude Code](https://claude.ai/code/session_012NPLJ5EtnX2rwfMWr6UJhM)_