### PR TITLE
Finish epics #1290 & #1291: boss epilogues, exotic relics, build identity HUD, exotic quest chains

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -96,6 +96,7 @@ import { DeckSelectorModal } from './components/cards/DeckSelectorModal'
 import { loadDeckSlot } from './game/collection'
 import { getDailyPlayerDeck, getDailyOpponentDeck, getDailyChallengeState, saveDailyChallengeResult, recordDailyWin, publishDailyResult, publishEndlessResult, DailyChallengeState } from './game/dailyChallenge'
 import { getRelicDef, addEarnedRelic, removeEarnedRelic, loadEarnedRelics, addBrokenRelic, rollExoticDrop } from './game/relics'
+import { recordQuestKills, recordQuestWin, recordQuestCardPlayed, recordQuestBossDefeat, QuestChainDef } from './game/quests'
 import { playCardPlay, playButtonClick, playBattleEvent, playCardFlip, playRestHeal, playBattleStart, playVictory, playDefeat, stopBattleMusic, stopGameOverMusic } from './game/sound'
 import { useMusic } from './hooks/useMusic'
 import { getIntegrityViolations, clearIntegrityViolations } from './game/integrity'
@@ -440,6 +441,7 @@ export default function App() {
   } | null>(null)
   const [foundItem, setFoundItem] = useState<Omit<import('./game/dailyLogin').UselessItem, 'acquiredDate'> | null>(null)
   const [exoticDrop, setExoticDrop] = useState<string | null>(null)
+  const [questCompletes, setQuestCompletes] = useState<QuestChainDef[]>([])
 
   // Card fatigue
   const [fatiguedCards, setFatiguedCards]       = useState<string[]>(loadFatigued)
@@ -1521,6 +1523,12 @@ export default function App() {
       }
     }
 
+    // Exotic quest chains: defeat-boss steps
+    if (node.type === 'boss') {
+      const questDone = recordQuestBossDefeat(act.id)
+      if (questDone.length > 0) setQuestCompletes(prev => [...prev, ...questDone])
+    }
+
     // Check act complete
     if (isActComplete(act, updatedRun)) {
       // Track act completion achievement + per-act replay count
@@ -2093,6 +2101,9 @@ export default function App() {
       newToasts.push(...totalUnlocked)
       // Award augment souls (1 per kill)
       incrementAugmentSouls(newKills.length)
+      // Exotic quest chains: tagged-kill steps
+      const questDone = recordQuestKills(newKills)
+      if (questDone.length > 0) setQuestCompletes(prev => [...prev, ...questDone])
       if (newToasts.length > 0) {
         setAchievementToasts(prev => [...prev, ...newToasts])
       }
@@ -2167,6 +2178,11 @@ export default function App() {
     }
     if (card.cardType === 'structure') battleUsedStructure.current = true
     if (card.cardType === 'unit') battleUsedMobileUnit.current = true
+    // Exotic quest chains: play-card-type steps
+    if (!isTrainingModeRef.current) {
+      const questDone = recordQuestCardPlayed(card.cardType)
+      if (questDone.length > 0) setQuestCompletes(prev => [...prev, ...questDone])
+    }
     if (isCampaignRef.current) {
       campaignPlayCountsRef.current[card.name] =
         (campaignPlayCountsRef.current[card.name] ?? 0) + 1
@@ -2240,6 +2256,10 @@ export default function App() {
       toasts.push(...incrementAchievementProgress('misc:one_card_win'))
     }
     if (toasts.length > 0) setAchievementToasts(prev => [...prev, ...toasts])
+
+    // Exotic quest chains: win-battle steps (any mode except training)
+    const questDone = recordQuestWin()
+    if (questDone.length > 0) setQuestCompletes(prev => [...prev, ...questDone])
 
     // Secret 10 — Wins Celebration: fires at every 100-win milestone, scales with tier
     const totalWins = incrementTotalWins()
@@ -3490,6 +3510,21 @@ export default function App() {
           </div>
         )
       })()}
+
+      {/* Exotic quest chain completed — guaranteed card reveal */}
+      {questCompletes.length > 0 && (
+        <div className="exotic-drop-overlay" onClick={() => setQuestCompletes(prev => prev.slice(1))}>
+          <div className="exotic-drop-modal" onClick={e => e.stopPropagation()}>
+            <div className="exotic-drop-title">✦ QUEST COMPLETE ✦</div>
+            <div className="exotic-drop-icon">{questCompletes[0].icon}</div>
+            <div className="exotic-drop-name">{questCompletes[0].name}</div>
+            <div className="exotic-drop-desc">
+              <strong>{questCompletes[0].targetCard}</strong> has been added to your collection. Earned, not lucky.
+            </div>
+            <button className="action-btn" onClick={() => setQuestCompletes(prev => prev.slice(1))}>CLAIM</button>
+          </div>
+        </div>
+      )}
 
       {/* Daily login reward modal — shown as overlay on first visit each day */}
       {dailyReward && (

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -95,7 +95,7 @@ import { FeedbackAdminScreen } from './components/admin/FeedbackAdminScreen'
 import { DeckSelectorModal } from './components/cards/DeckSelectorModal'
 import { loadDeckSlot } from './game/collection'
 import { getDailyPlayerDeck, getDailyOpponentDeck, getDailyChallengeState, saveDailyChallengeResult, recordDailyWin, publishDailyResult, publishEndlessResult, DailyChallengeState } from './game/dailyChallenge'
-import { getRelicDef, addEarnedRelic, removeEarnedRelic, loadEarnedRelics, addBrokenRelic } from './game/relics'
+import { getRelicDef, addEarnedRelic, removeEarnedRelic, loadEarnedRelics, addBrokenRelic, rollExoticDrop } from './game/relics'
 import { playCardPlay, playButtonClick, playBattleEvent, playCardFlip, playRestHeal, playBattleStart, playVictory, playDefeat, stopBattleMusic, stopGameOverMusic } from './game/sound'
 import { useMusic } from './hooks/useMusic'
 import { getIntegrityViolations, clearIntegrityViolations } from './game/integrity'
@@ -439,6 +439,7 @@ export default function App() {
     proceed: (chosenCount: number) => void
   } | null>(null)
   const [foundItem, setFoundItem] = useState<Omit<import('./game/dailyLogin').UselessItem, 'acquiredDate'> | null>(null)
+  const [exoticDrop, setExoticDrop] = useState<string | null>(null)
 
   // Card fatigue
   const [fatiguedCards, setFatiguedCards]       = useState<string[]>(loadFatigued)
@@ -1510,6 +1511,15 @@ export default function App() {
     recordNodeComplete(updatedRun.actId, nodeId)
     saveRun(updatedRun)
     setRun(updatedRun)
+
+    // Exotic relics drop from bosses and elites at low probability
+    if (node.type === 'boss' || node.type === 'elite') {
+      const dropped = rollExoticDrop(node.type)
+      if (dropped) {
+        addEarnedRelic(dropped)
+        setExoticDrop(dropped)
+      }
+    }
 
     // Check act complete
     if (isActComplete(act, updatedRun)) {
@@ -3464,6 +3474,22 @@ export default function App() {
           onCancel={() => setPendingBattleFn(null)}
         />
       )}
+
+      {/* Exotic relic drop — gold reveal overlay, shown over whatever screen follows the battle */}
+      {exoticDrop && (() => {
+        const def = getRelicDef(exoticDrop)
+        return (
+          <div className="exotic-drop-overlay" onClick={() => setExoticDrop(null)}>
+            <div className="exotic-drop-modal" onClick={e => e.stopPropagation()}>
+              <div className="exotic-drop-title">✦ EXOTIC RELIC ACQUIRED ✦</div>
+              <div className="exotic-drop-icon">{def?.icon ?? '✨'}</div>
+              <div className="exotic-drop-name">{exoticDrop}</div>
+              <div className="exotic-drop-desc">{def?.desc}</div>
+              <button className="action-btn" onClick={() => setExoticDrop(null)}>TAKE IT</button>
+            </div>
+          </div>
+        )
+      })()}
 
       {/* Daily login reward modal — shown as overlay on first visit each day */}
       {dailyReward && (

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -97,6 +97,8 @@ import { loadDeckSlot } from './game/collection'
 import { getDailyPlayerDeck, getDailyOpponentDeck, getDailyChallengeState, saveDailyChallengeResult, recordDailyWin, publishDailyResult, publishEndlessResult, DailyChallengeState } from './game/dailyChallenge'
 import { getRelicDef, addEarnedRelic, removeEarnedRelic, loadEarnedRelics, addBrokenRelic, rollExoticDrop } from './game/relics'
 import { recordQuestKills, recordQuestWin, recordQuestCardPlayed, recordQuestBossDefeat, QuestChainDef } from './game/quests'
+import { BossEpilogueScreen } from './components/campaign/BossEpilogueScreen'
+import bossEpiloguesData from './data/bossEpilogues.json'
 import { playCardPlay, playButtonClick, playBattleEvent, playCardFlip, playRestHeal, playBattleStart, playVictory, playDefeat, stopBattleMusic, stopGameOverMusic } from './game/sound'
 import { useMusic } from './hooks/useMusic'
 import { getIntegrityViolations, clearIntegrityViolations } from './game/integrity'
@@ -189,6 +191,7 @@ type Screen =
   | 'pack'
   | 'nodemap'
   | 'cutscene'
+  | 'bossEpilogue'
   | 'bossdialogue'
   | 'event'
   | 'merchant'
@@ -408,6 +411,7 @@ export default function App() {
   // Cutscenes & boss dialogue
   const [cutscenePanels, setCutscenePanels]   = useState<CutscenePanel[]>([])
   const cutsceneDoneRef     = useRef<() => void>(() => {})
+  const epilogueDoneRef     = useRef<(() => void) | null>(null)
   const summaryDoneRef      = useRef<() => void>(() => {})
   const relicSelectDoneRef  = useRef<(relicName: string | null) => void>(() => {})
   const cardRestActDoneRef  = useRef<(() => void) | null>(null)           // set during mid-act card rest; null at campaign end
@@ -442,6 +446,7 @@ export default function App() {
   const [foundItem, setFoundItem] = useState<Omit<import('./game/dailyLogin').UselessItem, 'acquiredDate'> | null>(null)
   const [exoticDrop, setExoticDrop] = useState<string | null>(null)
   const [questCompletes, setQuestCompletes] = useState<QuestChainDef[]>([])
+  const [epiloguePanels, setEpiloguePanels] = useState<CutscenePanel[]>([])
 
   // Card fatigue
   const [fatiguedCards, setFatiguedCards]       = useState<string[]>(loadFatigued)
@@ -581,6 +586,9 @@ export default function App() {
         pendingActComplete: run?.pendingActComplete,
       })
       setScreen(fallback)
+    } else if (screen === 'bossEpilogue' && epiloguePanels.length === 0) {
+      rollbar.error('bossEpilogue screen reached with no panels', { runActId: run?.actId })
+      setScreen(run?.pendingActComplete ? 'actcomplete' : fallback)
     } else if (screen === 'actcomplete' && (!run || !ACTS[run.actId])) {
       rollbar.error('actcomplete screen reached without valid run/actData', { runActId: run?.actId })
       clearRun()
@@ -607,7 +615,7 @@ export default function App() {
       setRun(null)
       setScreen('title')
     }
-  }, [screen, cutscenePanels, run, bossDialogueNode, activeEvent, merchantItems, mysteryReward, foundItem])
+  }, [screen, cutscenePanels, epiloguePanels, run, bossDialogueNode, activeEvent, merchantItems, mysteryReward, foundItem])
 
   // Show boss fight splash when phase 2 triggers.
   useEffect(() => {
@@ -1546,16 +1554,28 @@ export default function App() {
         actId: currentRun.actId,
         hasOutro: (act.outro?.length ?? 0) > 0,
       })
-      if (act.outro && act.outro.length > 0) {
-        setCutscenePanels(applyPlayerName(act.outro))
-        cutsceneDoneRef.current = () => {
-          rollbar.info('cutsceneDone (outro): navigating to actcomplete', { actId: currentRun.actId })
-          setCutscenePanels([])
+      const showOutroThenComplete = () => {
+        if (act.outro && act.outro.length > 0) {
+          setCutscenePanels(applyPlayerName(act.outro))
+          cutsceneDoneRef.current = () => {
+            rollbar.info('cutsceneDone (outro): navigating to actcomplete', { actId: currentRun.actId })
+            setCutscenePanels([])
+            setScreen('actcomplete')
+          }
+          setScreen('cutscene')
+        } else {
           setScreen('actcomplete')
         }
-        setScreen('cutscene')
+      }
+      // Boss epilogue: a short skippable scene revealing what the boss was
+      // protecting, shown between the victory and the act-complete rewards.
+      const epilogue = (bossEpiloguesData as Record<string, CutscenePanel[]>)[currentRun.actId]
+      if (epilogue && epilogue.length > 0) {
+        setEpiloguePanels(applyPlayerName(epilogue))
+        epilogueDoneRef.current = showOutroThenComplete
+        setScreen('bossEpilogue')
       } else {
-        setScreen('actcomplete')
+        showOutroThenComplete()
       }
       return
     }
@@ -2821,6 +2841,16 @@ export default function App() {
         <CutsceneScreen panels={cutscenePanels} onDone={() => {
           rollbar.info('CutsceneScreen.onDone fired', { panelCount: cutscenePanels.length, runActId: run?.actId })
           cutsceneDoneRef.current()
+        }} />
+      )}
+
+      {screen === 'bossEpilogue' && epiloguePanels.length > 0 && (
+        <BossEpilogueScreen panels={epiloguePanels} onDone={() => {
+          setEpiloguePanels([])
+          const done = epilogueDoneRef.current
+          epilogueDoneRef.current = null
+          if (done) done()
+          else setScreen('actcomplete')
         }} />
       )}
 

--- a/web/src/components/campaign/BossEpilogueScreen.tsx
+++ b/web/src/components/campaign/BossEpilogueScreen.tsx
@@ -1,0 +1,72 @@
+import React, { useState, useEffect } from 'react'
+import { CutscenePanel } from '../../game/questline'
+
+interface Props {
+  panels: CutscenePanel[]
+  onDone: () => void
+}
+
+/**
+ * Boss epilogue — a short, skippable cutscene shown after an act boss falls,
+ * revealing what the boss was protecting. Same presentation as CutsceneScreen
+ * plus an always-visible SKIP control.
+ */
+export function BossEpilogueScreen({ panels, onDone }: Props) {
+  const [index, setIndex] = useState(0)
+  const [visible, setVisible] = useState(true)
+
+  const panel = panels[index]
+  const isLast = index === panels.length - 1
+
+  function advance() {
+    if (isLast) {
+      onDone()
+      return
+    }
+    setVisible(false)
+    setTimeout(() => {
+      setIndex(i => i + 1)
+      setVisible(true)
+    }, 200)
+  }
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); advance() }
+      if (e.key === 'Escape') { e.preventDefault(); onDone() }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [index, isLast])
+
+  if (!panel) return null
+
+  const paragraphs = panel.text.split('\n\n').filter(Boolean)
+
+  return (
+    <div className="cutscene-screen u-col u-just-sb u-pointer u-no-select" onClick={advance}>
+      <div className={`cutscene-content${visible ? ' cutscene-content--visible' : ''}`}>
+        <div className="cutscene-act-label">// {panel.title}</div>
+        {panel.image && (
+          <img src={`${import.meta.env.BASE_URL}${panel.image}`} alt="" className="cutscene-image" />
+        )}
+        <div className="cutscene-body u-col u-gap-7">
+          {paragraphs.map((p, i) => (
+            <p key={i} className="cutscene-paragraph">{p}</p>
+          ))}
+        </div>
+      </div>
+
+      <div className="cutscene-footer u-flex u-just-sb u-items-c">
+        <span className="cutscene-progress">{index + 1} / {panels.length}</span>
+        <button
+          className="cutscene-skip-btn"
+          onClick={e => { e.stopPropagation(); onDone() }}
+        >
+          SKIP ›
+        </button>
+        <span className="cutscene-continue">{isLast ? 'PRESS ENTER TO CONTINUE' : 'CLICK TO CONTINUE ›'}</span>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/campaign/BuildIdentityPanel.tsx
+++ b/web/src/components/campaign/BuildIdentityPanel.tsx
@@ -1,0 +1,42 @@
+import React, { useMemo, useState } from 'react'
+import { RunState } from '../../game/questline'
+import { deriveBuildIdentity } from '../../game/buildIdentity'
+
+/**
+ * Read-only Build Identity display for the campaign node map.
+ * Collapsed by default — a single themed line; expands to show the
+ * archetype, equipped relic, and any synergy note.
+ */
+export function BuildIdentityPanel({ run }: { run: RunState }) {
+  const [expanded, setExpanded] = useState(false)
+  const identity = useMemo(() => deriveBuildIdentity(run), [run])
+
+  if (!identity.archetypeName && !identity.relicName) return null
+
+  return (
+    <div className={`build-identity${expanded ? ' build-identity--expanded' : ''}`}>
+      <button className="build-identity-toggle" onClick={() => setExpanded(v => !v)}>
+        <span className="build-identity-theme">⚒ {identity.themeLabel}</span>
+        <span className="build-identity-chevron">{expanded ? '▾' : '▸'}</span>
+      </button>
+
+      {expanded && (
+        <div className="build-identity-body">
+          {identity.archetypeName && (
+            <div className="build-identity-row">
+              {identity.archetypeIcon} {identity.archetypeName}
+            </div>
+          )}
+          <div className="build-identity-row">
+            {identity.relicName
+              ? <>{identity.relicIcon} {identity.relicName}{identity.relicIsExotic && <span className="relic-exotic-tag" style={{ position: 'static', marginLeft: 6 }}>EXOTIC</span>}</>
+              : <span className="build-identity-muted">No relic equipped</span>}
+          </div>
+          {identity.synergyNote && (
+            <div className="build-identity-note">{identity.synergyNote}</div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/campaign/NodeMap.tsx
+++ b/web/src/components/campaign/NodeMap.tsx
@@ -11,6 +11,7 @@ import { ToolbarButton } from '../ui/Toolbar/ToolbarButton'
 import { ToolbarLabel } from '../ui/Toolbar/ToolbarLabel'
 import { ToolbarSpacer } from '../ui/Toolbar/ToolbarSpacer'
 import { NodeMapHpBar } from './NodeMapHpBar'
+import { BuildIdentityPanel } from './BuildIdentityPanel'
 
 interface Props {
   act: Act
@@ -86,6 +87,8 @@ export function NodeMap({ act, run, onSelectNode, onUseConsumable, onBack, user 
             />
           )}
         </Toolbar>
+
+        <BuildIdentityPanel run={run} />
 
         <NodeMapRederer id={act.id} run={run} worldMap={act} setPeekNode={setPeekNode} showPaths={showPaths} />
 

--- a/web/src/components/campaign/RelicSelectScreen.tsx
+++ b/web/src/components/campaign/RelicSelectScreen.tsx
@@ -38,9 +38,10 @@ export function RelicSelectScreen({ earnedRelics, currentRelic, brokenRelic, onS
         {defs.map(({ name, def }) => (
           <button
             key={name}
-            className={`relic-select-card${picked === name ? ' relic-select-card--chosen' : ''}`}
+            className={`relic-select-card${def!.exotic ? ' relic-select-card--exotic' : ''}${picked === name ? ' relic-select-card--chosen' : ''}`}
             onClick={() => setPicked(name)}
           >
+            {def!.exotic && <div className="relic-exotic-tag">EXOTIC</div>}
             <div className="relic-select-icon">{def!.icon}</div>
             <div className="relic-select-name">{def!.name}</div>
             <div className="relic-select-desc">{def!.desc}</div>

--- a/web/src/components/screens/CodexScreen.tsx
+++ b/web/src/components/screens/CodexScreen.tsx
@@ -127,6 +127,7 @@ function RelicLorePanel({ relic }: { relic: CodexRelicEntry }) {
     <div className="codex-entry">
       <div className="codex-entry-header">
         <span className="codex-entry-name">{relic.icon} {relic.name}</span>
+        {relic.exotic && <span className="relic-exotic-tag" style={{ position: 'static', marginLeft: 8 }}>EXOTIC</span>}
       </div>
       <div className="codex-entry-desc">{relic.desc}</div>
       {relic.lore && <div className="codex-entry-lore">"{relic.lore}"</div>}

--- a/web/src/components/screens/CollectionScreen.tsx
+++ b/web/src/components/screens/CollectionScreen.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef, useEffect, useCallback, memo } from 'react'
 import { Card, CardRarity, CardType, UnitTag, SECRET_RARITIES } from '../../game/types'
 import { getCardCatalog, getCardThemeTags } from '../../game/cards'
+import { getQuestTargetCards } from '../../game/quests'
 import {
   loadCollection,
   saveCollection,
@@ -72,6 +73,7 @@ const LazyCell = memo(function LazyCell({ children, className }: { children: Rea
 
 export function CollectionScreen({ crystals, onCrystalsChanged, onBack, commanderName, onPromoteCommander, onViewAugments, embedded }: Props) {
   const catalog = getCardCatalog()
+  const questTargetCards = getQuestTargetCards()
   const allAffinityLabels = Array.from(
     new Set(catalog.flatMap(c => c.unit?.affinity?.label ? [c.unit.affinity.label] : []))
   ).sort()
@@ -146,8 +148,9 @@ export function CollectionScreen({ crystals, onCrystalsChanged, onBack, commande
   const totalUpgradeable = collection.reduce((s, e) => s + (Math.max(0, e.count - COPIES_MAX) > 0 ? 1 : 0), 0)
 
   const filtered = catalog.filter(c => {
-    // Secret rarities are hidden until the player has obtained at least one copy
-    if (SECRET_RARITIES.has(c.rarity) && getOwnedCount(collection, c.name) === 0) return false
+    // Secret rarities are hidden until the player has obtained at least one copy —
+    // except quest-chain rewards, which are shown with an "Earn via Quest" badge
+    if (SECRET_RARITIES.has(c.rarity) && getOwnedCount(collection, c.name) === 0 && !questTargetCards.has(c.name)) return false
     if (typeFilter   !== 'all' && c.cardType !== typeFilter)   return false
     if (rarityFilter !== 'all' && c.rarity   !== rarityFilter) return false
     if (specialFilter === 'upgradeable') {
@@ -577,9 +580,11 @@ export function CollectionScreen({ crystals, onCrystalsChanged, onBack, commande
                   />
 
                   <div className="cell-footer">
-                    <span className="cell-count">
-                      ×{owned}{lvl > 0 && <span className="cell-mastery-badge">★{lvl}</span>}
-                    </span>
+                    {owned === 0 && questTargetCards.has(card.name)
+                      ? <span className="earn-via-quest-badge">EARN VIA QUEST</span>
+                      : <span className="cell-count">
+                          ×{owned}{lvl > 0 && <span className="cell-mastery-badge">★{lvl}</span>}
+                        </span>}
                   </div>
 
                   {xp > 0 && <MasteryBar xp={xp} />}

--- a/web/src/components/screens/PlayerScreen.tsx
+++ b/web/src/components/screens/PlayerScreen.tsx
@@ -5,8 +5,9 @@ import { PlayerStatsScreen } from './PlayerStatsScreen'
 import { CharacterScreen } from './CharacterScreen'
 import { AchievementsScreen } from './AchievementsScreen'
 import { InventoryScreen } from './InventoryScreen'
+import { QuestsScreen } from './QuestsScreen'
 
-type PlayerTab = 'stats' | 'character' | 'achievements' | 'inventory'
+type PlayerTab = 'stats' | 'character' | 'achievements' | 'inventory' | 'quests'
 
 interface Props {
   crystals: number
@@ -22,6 +23,7 @@ export function PlayerScreen({ crystals, onCrystalsChanged, onBack, onSignOut }:
   const tabs: { id: PlayerTab; label: string; badge?: boolean }[] = [
     { id: 'character',    label: 'Character' },
     { id: 'inventory',    label: 'Inventory' },
+    { id: 'quests',       label: 'Quests' },
     { id: 'achievements', label: 'Achievements', badge: achievementAlert },
     { id: 'stats',        label: 'Stats' },
   ]
@@ -43,6 +45,7 @@ export function PlayerScreen({ crystals, onCrystalsChanged, onBack, onSignOut }:
         </div>
         <div className="player-tab-content">
           {tab === 'character'    && <CharacterScreen onDone={() => setTab('stats')} embedded />}
+          {tab === 'quests'       && <QuestsScreen onBack={() => setTab('stats')} embedded />}
           {tab === 'achievements' && <AchievementsScreen onBack={() => setTab('stats')} onCrystalsChanged={onCrystalsChanged} embedded />}
           {tab === 'stats'        && <PlayerStatsScreen onBack={() => setTab('stats')} embedded />}
           {tab === 'inventory'    && <InventoryScreen onBack={() => setTab('stats')} onCrystalsChanged={onCrystalsChanged} embedded />}

--- a/web/src/components/screens/QuestsScreen.tsx
+++ b/web/src/components/screens/QuestsScreen.tsx
@@ -1,0 +1,76 @@
+import React, { useMemo } from 'react'
+import { OverlayScreen } from '../ui/OverlayScreen'
+import { getQuestStatuses, QuestChainStatus } from '../../game/quests'
+import { getCardCatalog } from '../../game/cards'
+
+interface Props {
+  onBack: () => void
+  embedded?: boolean
+}
+
+function QuestChainCard({ status }: { status: QuestChainStatus }) {
+  const { def, stepProgress, activeStep, completed } = status
+  const targetRarity = useMemo(
+    () => getCardCatalog().find(c => c.name === def.targetCard)?.rarity ?? 'legendary',
+    [def.targetCard]
+  )
+
+  return (
+    <div className={`quest-chain${completed ? ' quest-chain--completed' : ''}`}>
+      <div className="quest-chain-header">
+        <span className="quest-chain-icon">{def.icon}</span>
+        <span className="quest-chain-name">{def.name}</span>
+        <span className="quest-chain-reward">
+          {completed ? '✓ EARNED' : `REWARD: ${targetRarity.toUpperCase()}`}
+        </span>
+      </div>
+      <div className="quest-chain-intro">{def.intro}</div>
+      <div className="quest-chain-target">
+        {completed
+          ? <>🏆 {def.targetCard} has been added to your collection.</>
+          : <>🏆 Completing all steps guarantees: <strong>{def.targetCard}</strong></>}
+      </div>
+
+      <div className="quest-steps">
+        {def.steps.map((step, i) => {
+          const target = step.condition.type === 'defeat_boss' ? 1 : step.condition.count
+          const progress = stepProgress[i]
+          const done = progress >= target
+          const locked = !completed && i > activeStep
+          return (
+            <div key={i} className={`quest-step${done ? ' quest-step--done' : ''}${locked ? ' quest-step--locked' : ''}`}>
+              <span className="quest-step-status">{done ? '✓' : locked ? '🔒' : '▸'}</span>
+              <span className="quest-step-label">{step.label}</span>
+              {!locked && target > 1 && (
+                <span className="quest-step-progress">[{progress}/{target}]</span>
+              )}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+export function QuestsScreen({ onBack, embedded }: Props) {
+  const statuses = useMemo(() => getQuestStatuses(), [])
+  const earned = statuses.filter(s => s.completed).length
+
+  const content = (
+    <div className="quests-screen">
+      <div className="quests-blurb">
+        Multi-step hunts for cards that cannot be won by luck. Steps complete in
+        order, and progress carries across every run and battle mode.
+        {' '}({earned}/{statuses.length} earned)
+      </div>
+      {statuses.map(s => <QuestChainCard key={s.def.id} status={s} />)}
+    </div>
+  )
+
+  if (embedded) return content
+  return (
+    <OverlayScreen title="EXOTIC QUESTS" subtitle={`${earned}/${statuses.length} cards earned`} onBack={onBack}>
+      {content}
+    </OverlayScreen>
+  )
+}

--- a/web/src/data/bossEpilogues.json
+++ b/web/src/data/bossEpilogues.json
@@ -1,0 +1,136 @@
+{
+  "act1": [
+    {
+      "title": "EPILOGUE — THE THORNLORD FALLS",
+      "text": "The thorns loosen their grip on the Verdant Shard, and for the first time in three hundred years the old groves stand unguarded.\n\nThe Thornlord did not grow the briar to conquer. He grew it the day the world shattered, a wall of living thorn around the last unbroken forest in existence — and then he never learned how to stop."
+    },
+    {
+      "title": "WHAT HE PROTECTED",
+      "text": "Beneath the briar you find what he was keeping: seedlings. Thousands of them, one for every species the Fracture burned away, each wrapped in bark like the shield he wore as a badge of office.\n\nThe forest will remember him as a tyrant. The seedlings will remember him as a gardener. Both will be right."
+    }
+  ],
+  "act2": [
+    {
+      "title": "EPILOGUE — THE WARLORD'S SILENCE",
+      "text": "Kragg's banners come down without ceremony. His army — what's left of it — simply stops, as if the noise that drove them forward has finally run out.\n\nThe Iron Citadel was never meant to be a fortress. Before the Fracture it was a foundry-city, the Dominion's beating industrial heart. Kragg just kept the furnaces lit the only way he knew: by feeding them a war."
+    },
+    {
+      "title": "WHAT HE PROTECTED",
+      "text": "In the citadel's vault you find the muster rolls. Every soldier who ever followed the iron standard, every name recorded in the Warlord's own crabbed hand, going back three centuries.\n\nHe never lost a single name. Armies were the only thing he knew how to keep alive."
+    }
+  ],
+  "act3": [
+    {
+      "title": "EPILOGUE — THE LAST EMBER",
+      "text": "The Ashwalker comes apart gently, like a fire settling at the end of a long night. The Wastes are quiet in a way they have not been since they burned.\n\nThis shard was the Fracture's first wound — the place where the breaking began. The Ashwalker has been pacing its perimeter ever since, stamping out every spark that threatened to start the burning again."
+    },
+    {
+      "title": "WHAT IT PROTECTED",
+      "text": "At the centre of the Wastes lies a soulstone, warm in the cold ash — twin to the one you carry. The Ashwalker never said what its stone contained, and now you understand why you never pressed the matter.\n\nIt holds the voices of everyone the first fire took. The Ashwalker wasn't a guardian of the dead. It was their pallbearer, still mid-procession."
+    }
+  ],
+  "act4": [
+    {
+      "title": "EPILOGUE — THE FINAL ENTRY",
+      "text": "The Archivist sets down his pen before he falls — recording, with perfect penmanship, the time and manner of his own defeat. The Crystal Spire dims to a respectful hush.\n\nThe Spire holds the Dominion's complete record: every law, every song, every census of a civilisation that no longer exists. He catalogued the apocalypse while it happened, and never once fell behind."
+    },
+    {
+      "title": "WHAT HE PROTECTED",
+      "text": "His final ledger lies open. The last line reads: 'Collection passes to the bearer of the Prism Lens. See entry: Jarv. Misappropriation forgiven — retroactively reclassified as inheritance.'\n\nSomewhere in the stacks, a librarian's lamp clicks off for the first time in three hundred years."
+    }
+  ],
+  "act5": [
+    {
+      "title": "EPILOGUE — THE TIDE TURNS",
+      "text": "The Tidal Sovereign sinks back into the deep court without anger, robes of reef-thread unravelling into the current. The Sunken Reef exhales.\n\nWhen the Fracture came, this shard fell into the sea — cities, fields, and all. The Sovereign drowned with its people, and then refused to let the drowning be the end of them."
+    },
+    {
+      "title": "WHAT THEY PROTECTED",
+      "text": "Below the throne you find the drowned cities, lit by patient coral lanterns. The Sovereign's deep-court attendants have spent three centuries weaving the reef through every street, holding the ruins together against the currents.\n\nNot a tomb. A preservation. The Reef was never their kingdom — it was their mantle, wrapped around what remained."
+    }
+  ],
+  "act6": [
+    {
+      "title": "EPILOGUE — GROUNDED",
+      "text": "The Cloudmarshal's command platform lists, loses altitude, and settles into the cloud sea with surprising grace — a six-badge general executing one final, flawless landing.\n\nThe Sky Dominion was the shard that refused to fall when the world broke. The Cloudmarshal kept it aloft through three hundred years of impossible odds, one won engagement at a time."
+    },
+    {
+      "title": "WHAT SHE PROTECTED",
+      "text": "Aboard the flagship you find the passenger manifests. The Sky Dominion's fleet wasn't military — it was an evacuation, still in progress. Every floating bastion is a lifeboat that never found a shore to land on.\n\nYour stormcaller's badge marks you as one of her generals now. The refugees of the sky will follow it anywhere. Try to deserve that."
+    }
+  ],
+  "act7": [
+    {
+      "title": "EPILOGUE — THE FORGE GOES COLD",
+      "text": "The Cinderwarlord kneels into the caldera and does not rise. Across the Emberfall Peaks, the war-forges bank their fires one by one, like candles at the end of a vigil.\n\nThe Peaks held the Dominion's great forges — and when the world shattered, the Cinderwarlord sealed every one of them rather than let the breaking be armed."
+    },
+    {
+      "title": "WHAT HE PROTECTED",
+      "text": "In the deepest forge you find the moulds: not for weapons, but for cornerstones, bridge-pins, keystone arches. The tools a civilisation uses to rebuild itself.\n\nThe magma core you carry stays cold until danger arrives. Now you know where it learned that patience — from a warlord who spent three hundred years refusing to strike first."
+    }
+  ],
+  "act8": [
+    {
+      "title": "EPILOGUE — THE QUEEN'S GIFT",
+      "text": "The Root Queen sighs, and the sigh becomes spores, and the spores drift down through the Fungal Deep like slow snow. She is everywhere now, which is to say she is exactly where she always was.\n\nThe Deep grew in the Fracture's cracks — the only shard that was born from the breaking instead of broken by it."
+    },
+    {
+      "title": "WHAT SHE PROTECTED",
+      "text": "The mycelium runs deeper than you mapped, down into the fault lines of the shattered world itself — stitching, knitting, holding the broken edges together. The Deep isn't a kingdom in the cracks. It is a suture.\n\n'A gift freely given,' she said of the spore bloom you carry. She was smiling because she knew you'd eventually understand what the gift was for."
+    }
+  ],
+  "act9": [
+    {
+      "title": "EPILOGUE — THE ENGINE STOPS",
+      "text": "The Pale Engine winds down by degrees, frost flowering across its hull. Its vanguard units halt mid-stride across the Frozen Expanse, statues in an army-shaped garden.\n\nIt was built in the Dominion's final hour — a machine to outlast the cold that followed the Fracture, and to keep something warm at its core until spring came."
+    },
+    {
+      "title": "WHAT IT PROTECTED",
+      "text": "Inside the Engine's hull, behind doctrine-plates of frost-glass, you find the vault it was keeping warm: seedstock, libraries, cradles. A spring that has been postponed for three hundred years.\n\nThe Engine's last act is to transfer the vault's heating duty to its frost mantles — including the one you're wearing. Congratulations. You are now load-bearing."
+    }
+  ],
+  "act10": [
+    {
+      "title": "EPILOGUE — THE FINAL SALE",
+      "text": "The Dune Baron concedes with the practised grace of a merchant closing a hard bargain, signing over the Sand Market with a flourish of his last working pen.\n\nThe Market was the only shard that kept trading after the world broke — the one place where survivors of every other shard could still meet without drawing blades."
+    },
+    {
+      "title": "WHAT HE PROTECTED",
+      "text": "His ledgers tell the real story: three centuries of unprofitable loans, forgiven debts, and caravans dispatched to shards that could never pay. The Baron ran the Market at a loss the entire time, and cooked the books so nobody would know it was charity.\n\nThe neutral ground stays neutral. That was always the only deal that mattered."
+    }
+  ],
+  "act11": [
+    {
+      "title": "EPILOGUE — THE WARDEN RESTS",
+      "text": "The Elder Warden lowers its great limbs and takes root one final time, crown spreading into the high green of the Verdant Canopy. It does not die. Trees this old simply change jobs.\n\nThe Canopy is the Verdant Shard's elder sibling — the seed-vault from which the Thornlord's seedlings were cut, tended by a warden older than the Dominion itself."
+    },
+    {
+      "title": "WHAT IT PROTECTED",
+      "text": "In the Warden's shade, saplings are already rising through the leaf-litter — the same species you found sleeping under the Thornlord's briar, awake now and growing like they have three hundred years to make up for.\n\nThe living bark you carry has added another ring. It seems to approve of how this ended."
+    }
+  ],
+  "act12": [
+    {
+      "title": "EPILOGUE — THE COAST CALMS",
+      "text": "The Grand Serpent uncoils from around the Shattered Coast and sounds, one last time, into water finally still enough to hold a reflection.\n\nThe Coast is where the Fracture's debris washed ashore — three hundred years of wrecks, salvage, and stranded sailors. The Serpent circled it all like a dragon on a hoard."
+    },
+    {
+      "title": "WHAT IT PROTECTED",
+      "text": "From the cliffs you finally see the pattern in the wrecks: the Serpent herded every drifting hull into the same sheltered bay. The Coast wasn't its hunting ground. It was its harbour — every castaway in three centuries delivered to the one shore where the others would find them.\n\nThe harbourmaster's bell rings itself once, and is quiet."
+    }
+  ],
+  "act13": [
+    {
+      "title": "EPILOGUE — THE VAULTS OPEN",
+      "text": "The Grand Automaton powers down section by section, and as it does, every lock in the Clockwork Vaults releases in sequence — a three-hundred-year security protocol completing its final instruction.\n\nThe Vaults were the Dominion's deep archive: every machine, every blueprint, every backup of a civilisation that believed in redundancy."
+    },
+    {
+      "title": "WHAT IT PROTECTED",
+      "text": "The Automaton's last transmission is an inventory manifest, addressed to no one, marked simply: RELEASED TO SUCCESSOR.\n\nIts secondary core still beats in your pack — the gear heart that never knew it left the Vaults. There seems no kind way to tell it that it is now the most important machine in the world. Perhaps it always was."
+    },
+    {
+      "title": "THE DOMINION REMEMBERS",
+      "text": "Thirteen guardians. Thirteen vigils, all of them kept.\n\nThe Shattered Dominion was never leaderless after the Fracture. It was simply waiting for someone to visit every shard, defeat every keeper, and inherit every burden — and discover, too late to refuse, that the burdens were the point."
+    }
+  ]
+}

--- a/web/src/data/quests.json
+++ b/web/src/data/quests.json
@@ -1,0 +1,112 @@
+[
+  {
+    "id": "ashen_bargain",
+    "name": "The Ashen Bargain",
+    "icon": "💀",
+    "theme": "undead",
+    "intro": "The Ashen Wastes remember every army that burned there. Walk with the dead long enough, and something older than the Ashwalker will notice you.",
+    "targetCard": "Void Titan",
+    "steps": [
+      {
+        "label": "Win 3 battles with a deck that is at least 30% undead or ashen cards",
+        "condition": { "type": "win_battles", "count": 3, "deckTags": ["undead", "ashen"], "deckTagPct": 0.3 }
+      },
+      {
+        "label": "Destroy 40 undead or ashen units",
+        "condition": { "type": "kill_tagged", "tags": ["undead", "ashen"], "count": 40 }
+      },
+      {
+        "label": "Defeat The Ashwalker (Act III — The Ashen Wastes)",
+        "condition": { "type": "defeat_boss", "actId": "act3" }
+      }
+    ]
+  },
+  {
+    "id": "refracted_codex",
+    "name": "The Refracted Codex",
+    "icon": "🔮",
+    "theme": "arcane",
+    "intro": "Somewhere in the Crystal Spire's misfiled archives is the schematic for a wyrm made of pure refraction. The Archivist insists it does not exist. He is lying.",
+    "targetCard": "Prism Wyrm",
+    "steps": [
+      {
+        "label": "Play 25 upgrade cards",
+        "condition": { "type": "play_card_type", "cardType": "upgrade", "count": 25 }
+      },
+      {
+        "label": "Destroy 40 magic or arcane units",
+        "condition": { "type": "kill_tagged", "tags": ["magic", "arcane"], "count": 40 }
+      },
+      {
+        "label": "Defeat The Archivist (Act IV — The Crystal Spire)",
+        "condition": { "type": "defeat_boss", "actId": "act4" }
+      }
+    ]
+  },
+  {
+    "id": "doctrine_of_iron",
+    "name": "Doctrine of Iron",
+    "icon": "⚙️",
+    "theme": "military",
+    "intro": "Warlord Kragg's engineers began one final war machine before the Iron Citadel fell. The blueprints survived. The discipline to finish it is the real test.",
+    "targetCard": "Dreadnought",
+    "steps": [
+      {
+        "label": "Build 25 structures",
+        "condition": { "type": "play_card_type", "cardType": "structure", "count": 25 }
+      },
+      {
+        "label": "Win 5 battles",
+        "condition": { "type": "win_battles", "count": 5 }
+      },
+      {
+        "label": "Defeat Warlord Kragg (Act II — The Iron Citadel)",
+        "condition": { "type": "defeat_boss", "actId": "act2" }
+      }
+    ]
+  },
+  {
+    "id": "verdant_oath",
+    "name": "The Verdant Oath",
+    "icon": "🌳",
+    "theme": "forest",
+    "intro": "The oldest tree in the Verdant Shard predates the Dominion itself. Prove the forest can trust you with an army, and it will lend you something that walks.",
+    "targetCard": "Elder Treant",
+    "steps": [
+      {
+        "label": "Win 3 battles with a deck that is at least 30% forest or canopy cards",
+        "condition": { "type": "win_battles", "count": 3, "deckTags": ["forest", "canopy"], "deckTagPct": 0.3 }
+      },
+      {
+        "label": "Destroy 40 beast or forest units",
+        "condition": { "type": "kill_tagged", "tags": ["beast", "forest"], "count": 40 }
+      },
+      {
+        "label": "Defeat The Thornlord (Act I — The Verdant Shard)",
+        "condition": { "type": "defeat_boss", "actId": "act1" }
+      }
+    ]
+  },
+  {
+    "id": "tides_of_the_deep",
+    "name": "Tides of the Deep",
+    "icon": "🌊",
+    "theme": "aquatic",
+    "intro": "The Sunken Reef's deep-court keeps a leviathan chained beneath the throne. The Tidal Sovereign will not free it. You can take the matter up with the Sovereign directly.",
+    "targetCard": "Leviathan",
+    "steps": [
+      {
+        "label": "Win 4 battles",
+        "condition": { "type": "win_battles", "count": 4 }
+      },
+      {
+        "label": "Destroy 40 reef or tidal units",
+        "condition": { "type": "kill_tagged", "tags": ["reef", "tidal"], "count": 40 }
+      },
+      {
+        "label": "Defeat The Tidal Sovereign (Act V — The Sunken Reef)",
+        "condition": { "type": "defeat_boss", "actId": "act5" }
+      }
+    ]
+  }
+]

--- a/web/src/data/relics.json
+++ b/web/src/data/relics.json
@@ -196,5 +196,72 @@
         "amount": 2
       }
     ]
+  },
+  {
+    "name": "The Last Farm",
+    "icon": "🌾",
+    "desc": "EXOTIC — Every Farm you build also musters a Goblin, ready to fight.",
+    "lore": "When the Fracture tore the Verdant Shard apart, one farmstead refused to fall with it. Its fields still grow. Its workers still report for duty. Nobody has told them the war for their valley ended three hundred years ago — and looking at their pitchforks, nobody is going to.",
+    "exotic": true,
+    "effects": [
+      {
+        "type": "farmSpawn"
+      }
+    ]
+  },
+  {
+    "name": "Phantom Legion",
+    "icon": "👻",
+    "desc": "EXOTIC — Your units that die have a 33% chance to instantly revive at 50% HP.",
+    "lore": "An entire battalion of the old Dominion was caught mid-march when the world shattered. They never noticed. They are still marching, still following their last order, and death is simply no longer an obstacle they recognise. Carry their standard and some of that stubbornness rubs off.",
+    "exotic": true,
+    "effects": [
+      {
+        "type": "phantomRevive",
+        "chance": 0.33
+      }
+    ]
+  },
+  {
+    "name": "Mana Surge",
+    "icon": "🌀",
+    "desc": "EXOTIC — Your mana keeps charging past its cap, storing up to 3 overflow mana while you hold back.",
+    "lore": "A bottled fragment of the Fracture itself, still discharging. The Archivist's notes call containment 'theoretically inadvisable'. The scholars who built it believed mana should pool like floodwater behind a dam. The dam, notably, is you.",
+    "exotic": true,
+    "effects": [
+      {
+        "type": "manaOverflow",
+        "amount": 3
+      }
+    ]
+  },
+  {
+    "name": "Glass Cannon Protocol",
+    "icon": "💥",
+    "desc": "EXOTIC — Your base HP becomes 10. All your units gain +100% ATK.",
+    "lore": "The Pale Engine's forbidden combat doctrine, etched on a plate of frost-glass thin enough to read through. Its final theorem is unambiguous: armour is the admission that you intend to be hit. The Engine's vanguard adopted it for exactly one battle. It was a very short, very decisive battle.",
+    "exotic": true,
+    "effects": [
+      {
+        "type": "baseHpSet",
+        "amount": 10
+      },
+      {
+        "type": "atkMult",
+        "mult": 2
+      }
+    ]
+  },
+  {
+    "name": "The Architect's Eye",
+    "icon": "👁️",
+    "desc": "EXOTIC — Building any structure draws 1 card.",
+    "lore": "The Grand Automaton's master surveyor lens, salvaged from the Vaults. It was designed to see every flaw in a blueprint before the first stone was laid. Hold it long enough and you start seeing what it sees: every building is just the opening move of the next one.",
+    "exotic": true,
+    "effects": [
+      {
+        "type": "structureDraw"
+      }
+    ]
   }
 ]

--- a/web/src/game/buildIdentity.ts
+++ b/web/src/game/buildIdentity.ts
@@ -1,0 +1,82 @@
+/**
+ * Build Identity — derives a named "build theme" from the player's archetype +
+ * equipped relic so the HUD can surface what the combination means.
+ * Read-only: no game logic, just labelling existing run state.
+ */
+
+import type { Archetype } from './types'
+import { ARCHETYPE_DEFS, RunState } from './questline'
+import { getRelicDef, isExoticRelic } from './relics'
+
+export interface BuildIdentity {
+  archetypeName: string | null
+  archetypeIcon: string | null
+  relicName: string | null
+  relicIcon: string | null
+  relicIsExotic: boolean
+  /** Short evocative label for the combination, e.g. "Structure Engine". */
+  themeLabel: string
+  /** One-line synergy note when the combination has a known interaction. */
+  synergyNote: string | null
+}
+
+interface ThemeRule {
+  archetype?: Archetype          // omit = any archetype
+  relic?: string                 // omit = any relic
+  label: string
+  note?: string
+}
+
+/** First matching rule wins — most specific (archetype + relic) pairs first. */
+const THEME_RULES: ThemeRule[] = [
+  // Named archetype + exotic pairings
+  { archetype: 'siege_commander', relic: "The Architect's Eye", label: 'Structure Engine',
+    note: "Cheap structures that each draw a card — every wall is also a cantrip." },
+  { archetype: 'siege_commander', relic: 'The Last Farm', label: 'Fortified Homestead',
+    note: 'Discounted Farms that muster free Goblins — the economy fights back.' },
+  { archetype: 'swarm_tactician', relic: 'Phantom Legion', label: 'Undying Swarm',
+    note: 'A wide board that refuses to stay dead — every revive re-feeds the swarm ATK bonus.' },
+  { archetype: 'swarm_tactician', relic: 'The Last Farm', label: 'Goblin Tide',
+    note: 'Farms add free bodies that count toward your swarm discount and ATK stacks.' },
+  { archetype: 'arcane_scholar', relic: 'Mana Surge', label: 'Tempo Scholar',
+    note: 'Banked overflow mana turns every double-effect upgrade into a burst turn.' },
+  { archetype: 'arcane_scholar', relic: 'Prism Lens', label: 'Deep Reservoir' },
+  // Exotic-defined themes (any archetype)
+  { relic: 'Glass Cannon Protocol', label: 'Glass Cannon',
+    note: 'Ten base HP. Double-strength units. End it before they reach you.' },
+  { relic: 'Phantom Legion', label: 'Ghost March' },
+  { relic: 'Mana Surge', label: 'Stored Lightning' },
+  { relic: "The Architect's Eye", label: 'Master Builder' },
+  { relic: 'The Last Farm', label: 'Harvest War' },
+  // Notable standard-relic synergies
+  { archetype: 'siege_commander', relic: 'Bark Shield', label: 'Living Bastion' },
+  { archetype: 'siege_commander', relic: 'Living Bark', label: 'Living Bastion' },
+  { archetype: 'swarm_tactician', relic: 'Spore Bloom', label: 'Regenerating Horde' },
+  { archetype: 'swarm_tactician', relic: 'Iron Standard', label: 'Sharpened Swarm' },
+  { archetype: 'arcane_scholar', relic: 'Golden Compass', label: 'Opening Gambit' },
+  // Archetype-only fallbacks
+  { archetype: 'siege_commander', label: 'Siege Doctrine' },
+  { archetype: 'swarm_tactician', label: 'Swarm Blitz' },
+  { archetype: 'arcane_scholar', label: 'Late Game Control' },
+]
+
+/** Derives the player's current build identity from run state. Pure + cheap. */
+export function deriveBuildIdentity(run: RunState): BuildIdentity {
+  const archDef = run.archetype ? ARCHETYPE_DEFS.find(d => d.id === run.archetype) : undefined
+  const relicDef = run.activeRelic ? getRelicDef(run.activeRelic) : undefined
+
+  const rule = THEME_RULES.find(r =>
+    (r.archetype === undefined || r.archetype === run.archetype) &&
+    (r.relic === undefined || r.relic === run.activeRelic)
+  )
+
+  return {
+    archetypeName: archDef?.name ?? null,
+    archetypeIcon: archDef?.icon ?? null,
+    relicName: relicDef?.name ?? null,
+    relicIcon: relicDef?.icon ?? null,
+    relicIsExotic: run.activeRelic ? isExoticRelic(run.activeRelic) : false,
+    themeLabel: rule?.label ?? 'Free Agent',
+    synergyNote: rule?.note ?? null,
+  }
+}

--- a/web/src/game/codex.ts
+++ b/web/src/game/codex.ts
@@ -112,6 +112,7 @@ export interface CodexRelicEntry {
   icon: string
   desc: string
   lore: string
+  exotic: boolean
   unlocked: boolean
 }
 
@@ -180,11 +181,12 @@ export function getCodexCards(): CodexCardEntry[] {
 
 export function getCodexRelics(): CodexRelicEntry[] {
   const everAcquired = new Set(getEverAcquiredRelics())
-  return (relicsData as Array<{ name: string; icon: string; desc: string; lore?: string; effects: unknown[] }>).map(r => ({
+  return (relicsData as Array<{ name: string; icon: string; desc: string; lore?: string; exotic?: boolean; effects: unknown[] }>).map(r => ({
     name: r.name,
     icon: r.icon,
     desc: r.desc,
     lore: r.lore ?? '',
+    exotic: r.exotic === true,
     unlocked: everAcquired.has(r.name),
   }))
 }

--- a/web/src/game/engine.ts
+++ b/web/src/game/engine.ts
@@ -843,6 +843,10 @@ function performUnitMaintenance(s: GameState, deltaMs: number, log: string[]) {
       if (sEffect.type === 'spawn') {
         const effect = sEffect as { type: 'spawn'; unitTemplate: UnitTemplate; intervalMs: number} 
         const spawned = spawnUnit(effect.unitTemplate, unit.owner)
+        // Glass Cannon Protocol exotic: spawner-bred units also hit harder
+        if (unit.owner === 'player' && s.playerAtkMult && s.playerAtkMult !== 1) {
+          spawned.attack = Math.round(spawned.attack * s.playerAtkMult)
+        }
         spawned.x = unit.x
         spawned.y = unit.y
         spawned.spawnGrowTimer = SPAWN_GROW_MS
@@ -911,14 +915,16 @@ function regenerateMana(s: GameState, deltaMs: number) {
   const manaBonus = getManaBonus(s.field, 'player')
   s.maxMana = clampMaxMana(s.deckMaxMana ?? 0, manaBonus, s.relicManaBonus ?? 0, !!s.forgiveManaLimit)
 
-  if (s.mana < s.maxMana) {
+  // Mana Surge exotic: mana keeps charging past the cap, up to maxMana + overflow
+  const manaCap = s.maxMana + (s.manaOverflowCap ?? 0)
+  if (s.mana < manaCap) {
     const speedMult = 1 + getManaSpeedMult(s.field, 'player')
     s.manaAccum += (deltaMs / (s.playerManaRegenMs ?? MANA_REGEN_MS)) * speedMult
-    while (s.manaAccum >= 1 && s.mana < s.maxMana) {
+    while (s.manaAccum >= 1 && s.mana < manaCap) {
       s.mana++
       s.manaAccum -= 1
     }
-    if (s.mana >= s.maxMana) s.manaAccum = 0
+    if (s.mana >= manaCap) s.manaAccum = 0
   }
 }
 

--- a/web/src/game/engine/cards.ts
+++ b/web/src/game/engine/cards.ts
@@ -2,6 +2,7 @@ import { logError } from '../../logger';
 import { GameState, UpgradeEffect, Unit, BuffTag, LANE_WIDTH } from '../types';
 import { spawnUnit } from './helpers';
 import { drawCard } from './helpers';
+import { getCardCatalog } from '../cards';
 import {  Card, UnitTemplate } from '../types';
 import { playUpgrade } from '../sound';
 import {
@@ -110,6 +111,10 @@ export function deployCard(s: GameState, card: Card, owner: 'player' | 'opponent
         if (e.attackBonus) unit.attack = Math.max(0, unit.attack + e.attackBonus)
       }
     }
+    // Glass Cannon Protocol exotic: every player unit hits harder
+    if (owner === 'player' && s.playerAtkMult && s.playerAtkMult !== 1) {
+      unit.attack = Math.round(unit.attack * s.playerAtkMult)
+    }
     // Siege Commander: new structures get +20% max HP
     if (owner === 'player' && card.cardType === 'structure' && s.archetypePassive === 'siege_commander') {
       unit.maxHp = Math.round(unit.maxHp * ARCH_STRUCTURE_HP_MULT)
@@ -141,6 +146,18 @@ export function deployCard(s: GameState, card: Card, owner: 'player' | 'opponent
       applyUpgrade(s, card.heroEffect, owner, log);
     } else {
       log.push(`${who} ${verb} ${unit.name}.`);
+    }
+    // The Last Farm exotic: building a Farm also musters a Goblin
+    if (owner === 'player' && s.farmSpawnsGoblin && card.cardType === 'structure' && unit.name === 'Farm') {
+      const goblinCard = getCardCatalog().find(c => c.name === 'Goblin')
+      if (goblinCard?.unit) {
+        const goblin = spawnUnit(goblinCard.unit, owner)
+        goblin.x = unit.x
+        goblin.y = unit.y
+        if (s.playerAtkMult && s.playerAtkMult !== 1) goblin.attack = Math.round(goblin.attack * s.playerAtkMult)
+        s.field.push(goblin)
+        log.push(`🌾 The Last Farm stirs — a Goblin reports for duty!`)
+      }
     }
     // Glass cards: chance to crack on deployment — half HP but double damage
     if (card.glassBreakChance && Math.random() < card.glassBreakChance) {
@@ -202,6 +219,11 @@ export function playCard(state: GameState, cardId: string): GameState {
   // Arcane Scholar: draw an extra card after each upgrade
   if (isScholarUpgrade) {
     drawCard(s.playerDeck, s.playerHand, s.secretRaresObtained)
+  }
+  // The Architect's Eye exotic: building any structure draws an extra card
+  if (s.structureDrawsCard && card.cardType === 'structure') {
+    drawCard(s.playerDeck, s.playerHand, s.secretRaresObtained)
+    s.log.push(`👁️ The Architect's Eye opens — you draw a card.`)
   }
   return s
 }

--- a/web/src/game/engine/combat.ts
+++ b/web/src/game/engine/combat.ts
@@ -209,6 +209,21 @@ export function processAttacks(s: GameState, deltaMs: number, log: string[]): vo
     }
   }
 
+  // Phantom Legion exotic: each dying player unit rolls once for an instant revive
+  if (s.phantomReviveChance) {
+    for (const u of s.field) {
+      if (u.owner === 'player' && u.hp <= 0 && u.moveSpeed > 0 && !u.isWall && !u.reviveRolled) {
+        u.reviveRolled = true
+        if (Math.random() < s.phantomReviveChance) {
+          u.hp = Math.ceil(u.maxHp / 2)
+          u.dyingTimer = undefined
+          u.reviveRolled = false   // a future death gets a fresh roll
+          log.push(`👻 ${u.name} refuses to fall — the Phantom Legion marches on!`)
+        }
+      }
+    }
+  }
+
   // Auto-revive: once per battle, restore the first dead player unit
   if (s.unitReviveHp !== undefined) {
     const dead = s.field.find(u => u.owner === 'player' && u.hp <= 0 && u.moveSpeed > 0)

--- a/web/src/game/quests.ts
+++ b/web/src/game/quests.ts
@@ -1,0 +1,213 @@
+/**
+ * Exotic Quest Chains — multi-step quests that guarantee a specific
+ * mythic/legendary card on completion. Like Destiny exotic quests:
+ * the card is earned, not lucky.
+ *
+ * Quest definitions live in src/data/quests.json. Progress persists in
+ * localStorage across runs. Steps complete strictly in order — only the
+ * chain's first incomplete step accumulates progress.
+ */
+
+import { getCardCatalog } from './cards'
+import { addCardsToCollection, loadDeck } from './collection'
+import { logError } from '../logger'
+import questsData from '../data/quests.json'
+
+// ─── Types ────────────────────────────────────────────────
+
+export type QuestCondition =
+  | { type: 'win_battles'; count: number; deckTags?: string[]; deckTagPct?: number }
+  | { type: 'kill_tagged'; tags: string[]; count: number }
+  | { type: 'play_card_type'; cardType: 'unit' | 'structure' | 'upgrade'; count: number }
+  | { type: 'defeat_boss'; actId: string }
+
+export interface QuestStepDef {
+  label: string
+  condition: QuestCondition
+}
+
+export interface QuestChainDef {
+  id: string
+  name: string
+  icon: string
+  theme: string
+  intro: string
+  targetCard: string
+  steps: QuestStepDef[]
+}
+
+export const QUEST_CHAINS: QuestChainDef[] = questsData as QuestChainDef[]
+
+/** Card names that are quest rewards — shown as "Earn via Quest" in the collection. */
+export function getQuestTargetCards(): Set<string> {
+  return new Set(QUEST_CHAINS.map(q => q.targetCard))
+}
+
+/** Returns the quest chain whose reward is the given card, if any. */
+export function getQuestForCard(cardName: string): QuestChainDef | undefined {
+  return QUEST_CHAINS.find(q => q.targetCard === cardName)
+}
+
+// ─── Persistence ──────────────────────────────────────────
+
+const QUEST_KEY = 'jarv_quest_progress'
+
+interface QuestSave {
+  /** Progress per step, keyed "{chainId}:{stepIndex}". */
+  steps: Record<string, number>
+  /** Chain IDs whose reward card has been granted. */
+  completed: string[]
+}
+
+function loadSave(): QuestSave {
+  try {
+    const raw = localStorage.getItem(QUEST_KEY)
+    if (raw) {
+      const parsed = JSON.parse(raw) as Partial<QuestSave>
+      return {
+        steps: parsed.steps && typeof parsed.steps === 'object' ? parsed.steps : {},
+        completed: Array.isArray(parsed.completed) ? parsed.completed : [],
+      }
+    }
+  } catch { /* ignore */ }
+  return { steps: {}, completed: [] }
+}
+
+function persist(save: QuestSave): void {
+  try { localStorage.setItem(QUEST_KEY, JSON.stringify(save)) }
+  catch (e) { logError('quest save failed', { error: String(e) }) }
+}
+
+// ─── Status queries ───────────────────────────────────────
+
+function conditionTarget(c: QuestCondition): number {
+  return c.type === 'defeat_boss' ? 1 : c.count
+}
+
+export interface QuestChainStatus {
+  def: QuestChainDef
+  /** Raw progress per step (clamped to target). */
+  stepProgress: number[]
+  /** Index of the first incomplete step; equals steps.length when done. */
+  activeStep: number
+  completed: boolean
+}
+
+export function getQuestStatuses(): QuestChainStatus[] {
+  const save = loadSave()
+  return QUEST_CHAINS.map(def => {
+    const completed = save.completed.includes(def.id)
+    const stepProgress = def.steps.map((s, i) => {
+      const target = conditionTarget(s.condition)
+      return Math.min(target, save.steps[`${def.id}:${i}`] ?? 0)
+    })
+    let activeStep = def.steps.findIndex((s, i) => stepProgress[i] < conditionTarget(s.condition))
+    if (activeStep === -1 || completed) activeStep = def.steps.length
+    return { def, stepProgress, activeStep, completed }
+  })
+}
+
+/** True if any quest has an in-progress (started but unfinished) step. */
+export function hasActiveQuests(): boolean {
+  return getQuestStatuses().some(q => !q.completed)
+}
+
+// ─── Progress events ──────────────────────────────────────
+
+/**
+ * Core progress applicator. For every uncompleted chain, advances the active
+ * step if `matches` applies to its condition. When a chain's final step
+ * completes, the target card is granted and the chain def is returned.
+ */
+function applyProgress(matches: (c: QuestCondition) => number): QuestChainDef[] {
+  const save = loadSave()
+  const newlyCompleted: QuestChainDef[] = []
+  let dirty = false
+
+  for (const def of QUEST_CHAINS) {
+    if (save.completed.includes(def.id)) continue
+
+    // Active step = first step below target
+    let activeIdx = -1
+    for (let i = 0; i < def.steps.length; i++) {
+      const target = conditionTarget(def.steps[i].condition)
+      if ((save.steps[`${def.id}:${i}`] ?? 0) < target) { activeIdx = i; break }
+    }
+    if (activeIdx === -1) continue   // all steps already done (legacy state) — handled below via completion check
+
+    const step = def.steps[activeIdx]
+    const inc = matches(step.condition)
+    if (inc <= 0) continue
+
+    const key = `${def.id}:${activeIdx}`
+    const target = conditionTarget(step.condition)
+    save.steps[key] = Math.min(target, (save.steps[key] ?? 0) + inc)
+    dirty = true
+
+    // Chain complete?
+    const allDone = def.steps.every((s, i) =>
+      (save.steps[`${def.id}:${i}`] ?? 0) >= conditionTarget(s.condition))
+    if (allDone) {
+      save.completed.push(def.id)
+      addCardsToCollection([{ cardName: def.targetCard, count: 1 }])
+      newlyCompleted.push(def)
+    }
+  }
+
+  if (dirty) persist(save)
+  return newlyCompleted
+}
+
+/** Fraction (0–1) of the player's current deck carrying any of the given tags. */
+function deckTagFraction(tags: string[]): number {
+  const deck = loadDeck()
+  if (deck.length === 0) return 0
+  const catalog = getCardCatalog()
+  let total = 0
+  let tagged = 0
+  for (const entry of deck) {
+    const card = catalog.find(c => c.name === entry.cardName)
+    const count = entry.count ?? 1
+    total += count
+    const cardTags: string[] = (card as unknown as { tags?: string[] })?.tags ?? []
+    if (cardTags.some(t => tags.includes(t))) tagged += count
+  }
+  return total === 0 ? 0 : tagged / total
+}
+
+/** Call when the player wins any battle. Returns chains completed by this event. */
+export function recordQuestWin(): QuestChainDef[] {
+  return applyProgress(c => {
+    if (c.type !== 'win_battles') return 0
+    if (c.deckTags && c.deckTagPct && deckTagFraction(c.deckTags) < c.deckTagPct) return 0
+    return 1
+  })
+}
+
+/** Call with the names of enemy units destroyed (per tick batch). */
+export function recordQuestKills(killedNames: string[]): QuestChainDef[] {
+  if (killedNames.length === 0) return []
+  const catalog = getCardCatalog()
+  return applyProgress(c => {
+    if (c.type !== 'kill_tagged') return 0
+    let n = 0
+    for (const name of killedNames) {
+      const card = catalog.find(x => x.name === name)
+      const cardTags: string[] = (card as unknown as { tags?: string[] })?.tags ?? []
+      if (cardTags.some(t => c.tags.includes(t))) n++
+    }
+    return n
+  })
+}
+
+/** Call when the player plays a card. */
+export function recordQuestCardPlayed(cardType: string): QuestChainDef[] {
+  return applyProgress(c =>
+    c.type === 'play_card_type' && c.cardType === cardType ? 1 : 0)
+}
+
+/** Call when a campaign act boss is defeated. */
+export function recordQuestBossDefeat(actId: string): QuestChainDef[] {
+  return applyProgress(c =>
+    c.type === 'defeat_boss' && c.actId === actId ? 1 : 0)
+}

--- a/web/src/game/relics.ts
+++ b/web/src/game/relics.ts
@@ -18,11 +18,19 @@ export type RelicEffect =
   | { type: 'unitRevive'; hp: 'half' | 'full' | number }
   | { type: 'tickHeal';   amount: number; intervalMs: number }
   | { type: 'onPlayAtk';  amount: number }
+  // ── Exotic effects — rule-breaking mechanics, one exotic equippable per run ──
+  | { type: 'baseHpSet';      amount: number }   // base max HP becomes exactly this value
+  | { type: 'atkMult';        mult: number }     // all player units (incl. later deploys) ×mult ATK
+  | { type: 'phantomRevive';  chance: number }   // dying units roll this chance to revive at 50% HP
+  | { type: 'manaOverflow';   amount: number }   // mana keeps regenerating up to maxMana + amount
+  | { type: 'farmSpawn' }                        // building a Farm also spawns a Goblin
+  | { type: 'structureDraw' }                    // building any structure draws 1 card
 
 interface RelicData {
   name: string
   icon: string
   desc: string
+  exotic?: boolean
   effects: RelicEffect[]
 }
 
@@ -32,6 +40,7 @@ export interface RelicDef {
   name: string
   icon: string
   desc: string
+  exotic: boolean
   applyToGame: (state: GameState) => void
 }
 
@@ -71,6 +80,28 @@ function buildApplyToGame(effects: RelicEffect[]): (state: GameState) => void {
         case 'onPlayAtk':
           state.onCardPlayedEffects = [...(state.onCardPlayedEffects ?? []), { attackBonus: effect.amount }]
           break
+        case 'baseHpSet':
+          state.playerBase.maxHp = effect.amount
+          state.playerBase.hp    = Math.min(state.playerBase.hp, effect.amount)
+          break
+        case 'atkMult':
+          state.playerAtkMult = (state.playerAtkMult ?? 1) * effect.mult
+          for (const u of state.field) {
+            if (u.owner === 'player') u.attack = Math.round(u.attack * effect.mult)
+          }
+          break
+        case 'phantomRevive':
+          state.phantomReviveChance = effect.chance
+          break
+        case 'manaOverflow':
+          state.manaOverflowCap = effect.amount
+          break
+        case 'farmSpawn':
+          state.farmSpawnsGoblin = true
+          break
+        case 'structureDraw':
+          state.structureDrawsCard = true
+          break
       }
     }
   }
@@ -82,11 +113,38 @@ const RELIC_CATALOG: RelicDef[] = (relicsCatalog as RelicData[]).map(data => ({
   name: data.name,
   icon: data.icon,
   desc: data.desc,
+  exotic: data.exotic === true,
   applyToGame: buildApplyToGame(data.effects),
 }))
 
 export function getRelicDef(name: string): RelicDef | undefined {
   return RELIC_CATALOG.find(r => r.name === name)
+}
+
+/** True if the named relic is an exotic. */
+export function isExoticRelic(name: string): boolean {
+  return getRelicDef(name)?.exotic === true
+}
+
+/** Names of every exotic relic in the catalog. */
+export function getExoticRelicNames(): string[] {
+  return RELIC_CATALOG.filter(r => r.exotic).map(r => r.name)
+}
+
+/** Drop chance for an exotic relic by node type (boss > elite; others never drop). */
+export const EXOTIC_DROP_CHANCE: Record<string, number> = { boss: 0.15, elite: 0.06 }
+
+/**
+ * Rolls an exotic relic drop for a beaten node. Returns the dropped relic name,
+ * or null if the roll failed or the player already owns every exotic.
+ */
+export function rollExoticDrop(nodeType: string): string | null {
+  const chance = EXOTIC_DROP_CHANCE[nodeType]
+  if (!chance || Math.random() >= chance) return null
+  const owned = new Set(getRelics())
+  const candidates = getExoticRelicNames().filter(n => !owned.has(n))
+  if (candidates.length === 0) return null
+  return candidates[Math.floor(Math.random() * candidates.length)]
 }
 
 // ─── Persistent relic collection (survives act resets) ────────────────────────

--- a/web/src/game/types.ts
+++ b/web/src/game/types.ts
@@ -248,6 +248,8 @@ export interface Unit extends UnitTemplate {
   poisonAccum?: number
   /** ms until the next moat damage pulse — prevents continuous per-frame chip damage. */
   moatDamageTimer?: number
+  /** True once this unit's Phantom Legion revive chance has been rolled (one roll per death). */
+  reviveRolled?: boolean
 }
 
 // ─── Ground Hazards ───────────────────────────────────────
@@ -416,6 +418,11 @@ export interface GameState {
   environment?: string       // battlefield background theme ('forest' | 'ruins' | 'camp' | 'citadel' | 'ashen')
   unitReviveHp?: 'half' | 'full' | number      // pending one-time unit revive at this HP value (set by Soulstone/Salvage Hook relics)
   relicManaBonus?: number             // passive +N to maxMana cap (set by Prism Lens relic)
+  playerAtkMult?: number              // ATK multiplier applied to all player units, incl. later deploys (Glass Cannon Protocol exotic)
+  phantomReviveChance?: number        // 0–1 chance each dying player unit revives at 50% HP (Phantom Legion exotic)
+  manaOverflowCap?: number            // mana keeps regenerating up to maxMana + this (Mana Surge exotic)
+  farmSpawnsGoblin?: boolean          // building a Farm also spawns a Goblin (The Last Farm exotic)
+  structureDrawsCard?: boolean        // building any structure draws 1 extra card (The Architect's Eye exotic)
   playerManaRegenMs?: number          // player's upgraded mana regen interval (default 3000 ms)
   tickEffects?: TickEffect[]          // periodic effects applied each engine tick
   onCardPlayedEffects?: OnCardPlayedEffect[]  // effects applied when the player plays a card

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4924,6 +4924,24 @@ body {
   color: var(--game-text-color-muted);
 }
 
+/* Boss epilogue skip control */
+.cutscene-skip-btn {
+  background: none;
+  border: 1px solid var(--game-border);
+  border-radius: 4px;
+  padding: 4px 12px;
+  font-family: inherit;
+  font-size: var(--font-xxs);
+  letter-spacing: 2px;
+  color: var(--game-text-color-muted);
+  cursor: pointer;
+}
+
+.cutscene-skip-btn:hover {
+  color: var(--game-text-color-dim);
+  border-color: var(--game-text-color-muted);
+}
+
 /* "Earn via Quest" badge in the collection */
 .earn-via-quest-badge {
   display: inline-block;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4757,6 +4757,61 @@ body {
   margin-bottom: 14px;
 }
 
+/* ── Build Identity panel (campaign node map) ── */
+.build-identity {
+  border: 1px solid var(--game-border);
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.03);
+  margin: 4px 0;
+}
+
+.build-identity-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 6px 10px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-family: inherit;
+  color: var(--game-text-color-dim);
+}
+
+.build-identity-theme {
+  font-size: var(--font-xs);
+  font-weight: bold;
+  letter-spacing: 1px;
+}
+
+.build-identity-chevron {
+  font-size: var(--font-xs);
+  color: var(--game-text-color-muted);
+}
+
+.build-identity-body {
+  padding: 2px 10px 8px;
+  border-top: 1px solid var(--game-border);
+}
+
+.build-identity-row {
+  font-size: var(--font-xs);
+  color: var(--game-text-color-dim);
+  padding-top: 6px;
+}
+
+.build-identity-muted {
+  color: var(--game-text-color-muted);
+}
+
+.build-identity-note {
+  font-size: var(--font-xxs);
+  color: var(--game-text-color-muted);
+  font-style: italic;
+  line-height: 1.4;
+  padding-top: 6px;
+}
+
 .relic-select-desc--broken {
   color: var(--game-text-color-muted);
   font-style: italic;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4812,6 +4812,129 @@ body {
   padding-top: 6px;
 }
 
+/* ── Exotic quest chains screen ── */
+.quests-screen {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 12px;
+}
+
+.quests-blurb {
+  font-size: var(--font-xs);
+  color: var(--game-text-color-dim);
+  line-height: 1.5;
+}
+
+.quest-chain {
+  border: 1px solid #d4a017;
+  border-radius: 6px;
+  padding: 12px 14px;
+  background: rgba(90, 70, 10, 0.1);
+}
+
+.quest-chain--completed {
+  border-color: var(--game-border);
+  background: rgba(255, 255, 255, 0.03);
+  opacity: 0.85;
+}
+
+.quest-chain-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.quest-chain-icon {
+  font-size: 1.3rem;
+}
+
+.quest-chain-name {
+  flex: 1;
+  font-weight: bold;
+  font-size: var(--font-base);
+  color: #ffd54a;
+}
+
+.quest-chain--completed .quest-chain-name {
+  color: var(--game-text-color-dim);
+}
+
+.quest-chain-reward {
+  font-size: var(--font-xxs);
+  letter-spacing: 1px;
+  color: var(--game-text-color-muted);
+}
+
+.quest-chain-intro {
+  font-size: var(--font-xs);
+  color: var(--game-text-color-dim);
+  font-style: italic;
+  line-height: 1.5;
+  margin: 8px 0;
+}
+
+.quest-chain-target {
+  font-size: var(--font-xs);
+  color: var(--game-text-color-dim);
+  margin-bottom: 10px;
+}
+
+.quest-steps {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.quest-step {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  font-size: var(--font-xs);
+  color: var(--game-text-color-dim);
+}
+
+.quest-step--done {
+  color: var(--game-text-color-muted);
+  text-decoration: line-through;
+}
+
+.quest-step--locked {
+  color: var(--game-text-color-muted);
+  opacity: 0.6;
+}
+
+.quest-step-status {
+  min-width: 16px;
+  text-align: center;
+}
+
+.quest-step-label {
+  flex: 1;
+  line-height: 1.4;
+}
+
+.quest-step-progress {
+  font-weight: bold;
+  color: #ffd54a;
+  white-space: nowrap;
+}
+
+.quest-step--done .quest-step-progress {
+  color: var(--game-text-color-muted);
+}
+
+/* "Earn via Quest" badge in the collection */
+.earn-via-quest-badge {
+  display: inline-block;
+  font-size: var(--font-xxs);
+  letter-spacing: 1px;
+  color: #ffd54a;
+  border: 1px solid #d4a017;
+  border-radius: 3px;
+  padding: 1px 5px;
+}
+
 .relic-select-desc--broken {
   color: var(--game-text-color-muted);
   font-style: italic;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4674,6 +4674,89 @@ body {
   color: var(--game-text-color-muted);
 }
 
+/* ── Exotic relics: animated gold border treatment ── */
+.relic-select-card--exotic {
+  position: relative;
+  border: 1px solid #d4a017;
+  background: rgba(90, 70, 10, 0.18);
+  animation: exotic-glow 2.2s ease-in-out infinite;
+}
+
+.relic-select-card--exotic:hover {
+  border-color: #ffd54a;
+  background: rgba(110, 85, 15, 0.28);
+}
+
+.relic-select-card--exotic.relic-select-card--chosen {
+  border-color: #ffd54a;
+  background: rgba(120, 95, 20, 0.35);
+  box-shadow: 0 0 12px rgba(255, 200, 60, 0.55);
+}
+
+.relic-exotic-tag {
+  position: absolute;
+  top: 4px;
+  right: 8px;
+  font-size: var(--font-xxs);
+  font-weight: bold;
+  letter-spacing: 2px;
+  color: #ffd54a;
+  text-shadow: 0 0 6px rgba(255, 200, 60, 0.6);
+}
+
+@keyframes exotic-glow {
+  0%, 100% { box-shadow: 0 0 4px rgba(255, 200, 60, 0.25); }
+  50%      { box-shadow: 0 0 14px rgba(255, 200, 60, 0.6); }
+}
+
+/* ── Exotic relic drop modal ── */
+.exotic-drop-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.75);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1200;
+}
+
+.exotic-drop-modal {
+  max-width: 340px;
+  margin: 16px;
+  padding: 20px 18px;
+  text-align: center;
+  background: #181410;
+  border: 1px solid #d4a017;
+  border-radius: 8px;
+  animation: exotic-glow 2.2s ease-in-out infinite;
+}
+
+.exotic-drop-title {
+  font-size: var(--font-xs);
+  letter-spacing: 3px;
+  color: #ffd54a;
+  margin-bottom: 10px;
+}
+
+.exotic-drop-icon {
+  font-size: 3rem;
+  margin-bottom: 8px;
+}
+
+.exotic-drop-name {
+  font-size: var(--font-lg);
+  font-weight: bold;
+  color: #ffd54a;
+  margin-bottom: 8px;
+}
+
+.exotic-drop-desc {
+  font-size: var(--font-xs);
+  color: var(--game-text-color-dim);
+  line-height: 1.5;
+  margin-bottom: 14px;
+}
+
 .relic-select-desc--broken {
   color: var(--game-text-color-muted);
   font-style: italic;


### PR DESCRIPTION
Completes the four remaining sub-tasks of the Story & World Building and Build Crafting & Identity epics. The other sub-tasks (1.1 Codex #1293, 1.2 Memory Fragments #1294, 1.3 Recurring Characters #1295, 2.1 Archetypes #1297, 2.5 Augments #1312) were already done.

## 2.2 — Exotic Relics (#1298)
- 5 exotics in `relics.json` with `exotic: true` + lore: **The Last Farm** (Farms also spawn a Goblin), **Phantom Legion** (33% chance dying units revive at 50% HP), **Mana Surge** (mana charges past cap, +3 overflow), **Glass Cannon Protocol** (base HP becomes 10, units +100% ATK — applies to later deploys and spawner-bred units too), **The Architect's Eye** (building a structure draws a card).
- New relic effect types wired through `relics.ts`, `engine/cards.ts`, `engine/combat.ts`, `engine.ts`.
- Drop from elite (6%) / boss (15%) node wins, never duplicating owned exotics; gold reveal modal.
- Gold animated border + EXOTIC tag on relic select; exotic flag in the Codex. The existing one-relic-per-run rule enforces the single-exotic constraint.

## 2.3 — Build Identity HUD (#1299)
- `game/buildIdentity.ts` derives a named build theme from archetype + equipped relic (Structure Engine, Undying Swarm, Tempo Scholar, Glass Cannon, ...) with synergy notes for known pairings.
- Read-only, collapsed-by-default expandable panel on the campaign node map.

## 2.4 — Exotic Quest Chains (#1300)
- `data/quests.json`: 5 chains (undead / arcane / military / forest / aquatic), 3 ordered steps each, targeting Void Titan, Prism Wyrm, Dreadnought, Elder Treant, Leviathan.
- `game/quests.ts`: data-driven conditions (wins with optional deck-tag share, tagged kills, card-type plays, boss defeats), progress persists across runs, sequential step unlocking, guaranteed card grant on completion.
- App hooks feed progress from kill tracking, battle wins, card plays, and campaign boss defeats; gold QUEST COMPLETE modal.
- New **Quests** tab in the Player screen with per-step `[x/y]` progress.
- Quest reward cards show **EARN VIA QUEST** in the collection; quest-target mythics are now visible (badged) instead of hidden.

## 1.4 — Boss Epilogue Scenes (#1296)
- `data/bossEpilogues.json`: 2–3 panel epilogues for all 13 act bosses revealing what each boss was protecting, cross-referencing relic Codex lore (Soulstone, Prism Lens, Gear Heart, ...).
- `BossEpilogueScreen` plays after a boss victory, before the act outro and act-complete rewards; skippable via button or Escape.

## Verification
- `tsc --noEmit` clean, production build succeeds, unit tests 96/96 passing (browser-mode tests can't run here — no Playwright binaries in the environment).

Closes #1296, closes #1298, closes #1299, closes #1300.
Closes #1290, closes #1291 (all sub-tasks complete).

https://claude.ai/code/session_011P7fgE5T7WpJRijEAXU6Qb

---
_Generated by [Claude Code](https://claude.ai/code/session_011P7fgE5T7WpJRijEAXU6Qb)_