### PR TITLE
Expand world map: 20 new battles, 9 new visitable locations, fractal layout

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2740,6 +2740,7 @@ export default function App() {
           onSelectNode={(node) => {
             if (node.id === 'ravenwatch') {
               setCurrentWorldLocation(node.id)
+              setCurrentLocationKey('ravenwatch')
               setScreen('hubworld')
             } else if (node.locationKey && LOCATION_REGISTRY[node.locationKey]) {
               setCurrentWorldLocation(node.id)

--- a/web/src/components/admin/DevMenu.tsx
+++ b/web/src/components/admin/DevMenu.tsx
@@ -199,7 +199,7 @@ export function DevMenu({ onCrystalsChanged, onHandicapChanged }: Props) {
           onChange={e => handleSkipToAct(e.target.value)}
         >
           <option value="">— choose —</option>
-          {Object.entries(ACTS).map(([id, act]) => (
+          {Object.entries(ACTS).filter(([id]) => id !== 'world').map(([id, act]) => (
             <option key={id} value={id}>{act.title ?? id}</option>
           ))}
         </select>

--- a/web/src/components/hub/HubWorldMap.tsx
+++ b/web/src/components/hub/HubWorldMap.tsx
@@ -106,13 +106,13 @@ export function HubWorldMap({ onSelectNode, onBack, user, onSignIn, onSignOut, o
 
       {questsOpen && <QuestsModal onClose={() => setQuestsOpen(false)} onAbandon={handleQuestAbandon} questDefs={ALL_QUEST_DEFS} />}
 
-      <div style={{ flex: 1, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', overflow: 'hidden' }}>
+      <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden', minHeight: 0 }}>
         <NodeMapRederer
           id="hub-world"
           worldMap={WORLD_MAP}
           clearedNodeIds={clearedNodeIds}
-          mapWidth={700}
-          mapHeight={520}
+          mapWidth={1600}
+          mapHeight={1400}
           setPeekNode={setPeekNode}
           showPaths={false}
         />

--- a/web/src/components/mapEditor/useMapEditorState.ts
+++ b/web/src/components/mapEditor/useMapEditorState.ts
@@ -5,12 +5,32 @@ type InteriorExit = NonNullable<RawInterior['exits']>[number]
 import hubConfig from '../../data/hub/ravenwatch/config.json'
 import town2Config from '../../data/hub/millhaven/config.json'
 import castleConfig from '../../data/hub/ironholdkeep/config.json'
+import thornwoodcampConfig from '../../data/hub/thornwoodcamp/config.json'
+import capitalcityConfig from '../../data/hub/capitalcity/config.json'
+import royalpalaceConfig from '../../data/hub/royalpalace/config.json'
+import saltmereportConfig from '../../data/hub/saltmereport/config.json'
+import gearfordConfig from '../../data/hub/gearford/config.json'
+import harrowfieldConfig from '../../data/hub/harrowfield/config.json'
+import applefordConfig from '../../data/hub/appleford/config.json'
+import gravemoorConfig from '../../data/hub/gravemoor/config.json'
+import hollowmereConfig from '../../data/hub/hollowmere/config.json'
+import dreadspirecitadelConfig from '../../data/hub/dreadspirecitadel/config.json'
 import { MapId } from '../../data/hub/hubWorldFactory'
 
 const RAW_CONFIGS: Record<MapId, RawMapConfig> = {
   ravenwatch:    hubConfig    as unknown as RawMapConfig,
   millhaven:  town2Config  as unknown as RawMapConfig,
   ironholdkeep: castleConfig as unknown as RawMapConfig,
+  thornwoodcamp: thornwoodcampConfig as unknown as RawMapConfig,
+  capitalcity: capitalcityConfig as unknown as RawMapConfig,
+  royalpalace: royalpalaceConfig as unknown as RawMapConfig,
+  saltmereport: saltmereportConfig as unknown as RawMapConfig,
+  gearford: gearfordConfig as unknown as RawMapConfig,
+  harrowfield: harrowfieldConfig as unknown as RawMapConfig,
+  appleford: applefordConfig as unknown as RawMapConfig,
+  gravemoor: gravemoorConfig as unknown as RawMapConfig,
+  hollowmere: hollowmereConfig as unknown as RawMapConfig,
+  dreadspirecitadel: dreadspirecitadelConfig as unknown as RawMapConfig,
 }
 
 const MAX_UNDO = 50

--- a/web/src/components/ui/NodeMap/NodeMapRederer.tsx
+++ b/web/src/components/ui/NodeMap/NodeMapRederer.tsx
@@ -910,6 +910,17 @@ export function NodeMapRederer({ id, run, worldMap, clearedNodeIds, mapWidth: ma
     mapEl.scrollLeft = pos.x - mapEl.clientWidth / 2
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
+  // Scroll to the player's current world location on mount (freeform world map)
+  useEffect(() => {
+    if (!isFreeform) return
+    const mapEl = mapRef.current
+    if (!mapEl) return
+    const node = worldMap.nodes[getCurrentWorldLocation()]
+    if (!node || node.x === undefined || node.y === undefined) return
+    mapEl.scrollLeft = node.x - mapEl.clientWidth / 2
+    mapEl.scrollTop  = node.y - mapEl.clientHeight / 2
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+
   function handleWalk(node: QuestNode, pos: { x: number; y: number }) {
     const app    = appRef.current
     const avatar = avatarRef.current
@@ -943,7 +954,7 @@ export function NodeMapRederer({ id, run, worldMap, clearedNodeIds, mapWidth: ma
           className={`nm-map u-flex u-grow u-items-c${worldMap.environment ? ` nm-map--${worldMap.environment}` : ''}`}
           ref={mapRef}
         >
-          <div ref={canvasRef} style={{ display: 'block', flexShrink: 0, width: mapWidth, height: mapHeight }} />
+          <div ref={canvasRef} style={{ display: 'block', flexShrink: 0, width: mapWidth, height: mapHeight, margin: 'auto' }} />
         </div>
 
   )

--- a/web/src/data/acts/worldbattles.json
+++ b/web/src/data/acts/worldbattles.json
@@ -1,0 +1,312 @@
+{
+  "id": "world",
+  "title": "WORLD",
+  "subtitle": "Free Battles",
+  "rewardRelic": "",
+  "rewardRelicDesc": "",
+  "environment": "farmland",
+  "rewardTags": [],
+  "startNodeIds": ["b-east-road"],
+  "nodes": {
+    "b-east-road": {
+      "id": "b-east-road",
+      "type": "battle",
+      "label": "Toll Road Ambush",
+      "description": "Bandits have set up an illegal toll on the east road. They take coin, goods and sometimes boots.",
+      "row": 0, "col": 0, "rowCols": 1, "childIds": [],
+      "handicap": 5,
+      "opponentBaseHp": 150,
+      "opponentIntervalMs": 6500,
+      "environment": "farmland",
+      "enemyDeck": [
+        "Bandit", "Goblin", "Rogue", "Bandit", "Archer",
+        "Bandit Camp", "Goblin", "Rogue", "Crossbow", "Goblin Warrens"
+      ]
+    },
+    "b-south-road": {
+      "id": "b-south-road",
+      "type": "battle",
+      "label": "Old King's Road",
+      "description": "Deserters from the royal army hold the old highway south. They still fight in formation.",
+      "row": 1, "col": 0, "rowCols": 1, "childIds": [],
+      "handicap": 5,
+      "opponentBaseHp": 155,
+      "opponentIntervalMs": 6500,
+      "environment": "farmland",
+      "enemyDeck": [
+        "Knight", "Archer", "Shield Guard", "Bandit", "Crossbow",
+        "Guard Post", "Archer", "Knight", "Shield Wall Soldier", "Bandit"
+      ]
+    },
+    "b-west-road": {
+      "id": "b-west-road",
+      "type": "battle",
+      "label": "Quarry Road",
+      "description": "Goblins have moved into the old quarry and they are not paying rent.",
+      "row": 2, "col": 0, "rowCols": 1, "childIds": [],
+      "handicap": 6,
+      "opponentBaseHp": 160,
+      "opponentIntervalMs": 6000,
+      "environment": "farmland",
+      "enemyDeck": [
+        "Goblin", "Goblin Warrens", "Bandit", "Goblin", "Troll",
+        "Rogue", "Goblin", "Bandit Camp", "Goblin", "Archer"
+      ]
+    },
+    "b-mine-trouble": {
+      "id": "b-mine-trouble",
+      "type": "battle",
+      "label": "Collapsed Mine",
+      "description": "Something mechanical woke up in the collapsed shafts. The miners did not stay to ask questions.",
+      "row": 3, "col": 0, "rowCols": 1, "childIds": [],
+      "handicap": 10,
+      "opponentBaseHp": 185,
+      "opponentIntervalMs": 5200,
+      "environment": "vault",
+      "enemyDeck": [
+        "Gear Scout", "Golem", "Clockwork Archer", "Siege Engineer", "Gear Wall",
+        "Steam Walker", "Golem Forge", "Gear Scout", "Ballista Crew", "Iron Forge", "Golem"
+      ]
+    },
+    "b-salt-marsh": {
+      "id": "b-salt-marsh",
+      "type": "battle",
+      "label": "Salt Marsh Crossing",
+      "description": "The marsh between Ravenwatch and the coast is full of things that bite, sting and drag you under.",
+      "row": 4, "col": 0, "rowCols": 1, "childIds": [],
+      "handicap": 10,
+      "opponentBaseHp": 185,
+      "opponentIntervalMs": 5000,
+      "environment": "coast",
+      "enemyDeck": [
+        "Wave Brawler", "Tide Runner", "Reef Shark", "Tide Sprite", "Crab Shielder",
+        "Tide Caller", "Tide Barracks", "Wave Brawler", "Jellyfish Drifter", "Tide Runner", "Sea Witch"
+      ]
+    },
+    "b-orchard-raid": {
+      "id": "b-orchard-raid",
+      "type": "battle",
+      "label": "Orchard Raid",
+      "description": "Raiders are stripping Appleford's orchards bare — and worse things prowl between the rows at night.",
+      "row": 5, "col": 0, "rowCols": 1, "childIds": [],
+      "handicap": 11,
+      "opponentBaseHp": 190,
+      "opponentIntervalMs": 5000,
+      "environment": "forest",
+      "enemyDeck": [
+        "Bandit", "Rogue", "Harpy", "Bandit Hideout", "Rogue Den",
+        "Werewolf", "Bandit", "Archer", "Harpy Roost", "Rogue", "Mercenary Captain"
+      ]
+    },
+    "b-river-ford": {
+      "id": "b-river-ford",
+      "type": "battle",
+      "label": "Southford Crossing",
+      "description": "A mercenary company holds the only ford on the south river. Their rates are unreasonable.",
+      "row": 6, "col": 0, "rowCols": 1, "childIds": [],
+      "handicap": 11,
+      "opponentBaseHp": 190,
+      "opponentIntervalMs": 5000,
+      "environment": "farmland",
+      "enemyDeck": [
+        "Mercenary Captain", "Bandit", "Knight", "Crossbow", "Shield Guard",
+        "Bandit Camp", "Rogue", "Cavalry Scout", "Archer's Keep", "Knight"
+      ]
+    },
+    "b-scarecrow-fields": {
+      "id": "b-scarecrow-fields",
+      "type": "battle",
+      "label": "Scarecrow Fields",
+      "description": "The scarecrows of Harrowfield keep the crows away. Lately they keep the farmers away too.",
+      "row": 7, "col": 0, "rowCols": 1, "childIds": [],
+      "handicap": 12,
+      "opponentBaseHp": 195,
+      "opponentIntervalMs": 4800,
+      "environment": "farmland",
+      "enemyDeck": [
+        "Thornbeast", "Werewolf", "Harpy", "Wolfpack Den", "Goblin",
+        "Thornbeast", "Spike Pit", "Bandit", "Harpy Roost", "Werewolf"
+      ]
+    },
+    "b-bandit-toll": {
+      "id": "b-bandit-toll",
+      "type": "battle",
+      "label": "Bandit Toll",
+      "description": "The Gearford bandits learned bookkeeping. Now they call their robbery a 'transit fee'.",
+      "row": 8, "col": 0, "rowCols": 1, "childIds": [],
+      "handicap": 14,
+      "opponentBaseHp": 205,
+      "opponentIntervalMs": 4600,
+      "environment": "farmland",
+      "enemyDeck": [
+        "Bandit", "Bandit", "Rogue", "Bandit Camp", "Mercenary Captain",
+        "Bandit Hideout", "Rogue's Guild", "Cavalry Scout", "Bandit", "Rogue", "Crossbow"
+      ]
+    },
+    "b-smoke-fields": {
+      "id": "b-smoke-fields",
+      "type": "battle",
+      "label": "Smokefield Patrol",
+      "description": "Rogue constructs from the Gearford foundries patrol the smoke fields, attacking anything that moves.",
+      "row": 9, "col": 0, "rowCols": 1, "childIds": [],
+      "handicap": 14,
+      "opponentBaseHp": 205,
+      "opponentIntervalMs": 4600,
+      "environment": "vault",
+      "enemyDeck": [
+        "Steam Walker", "Clockwork Archer", "Gear Scout", "Iron Barracks", "Catapult",
+        "Golem", "Siege Engineer", "Steam Works", "Gear Wall", "Clockwork Titan", "Ballista"
+      ]
+    },
+    "b-smugglers-landing": {
+      "id": "b-smugglers-landing",
+      "type": "battle",
+      "label": "Smuggler's Landing",
+      "description": "Half the contraband on the coast moves through this hidden cove. The smugglers protect their margins fiercely.",
+      "row": 10, "col": 0, "rowCols": 1, "childIds": [],
+      "handicap": 15,
+      "opponentBaseHp": 210,
+      "opponentIntervalMs": 4500,
+      "environment": "coast",
+      "enemyDeck": [
+        "Rogue", "Bandit", "Tide Runner", "Rogue's Guild", "Wave Brawler",
+        "Bandit Hideout", "Sea Witch", "Reef Shark", "Mercenary Captain", "Tide Stalker", "Rogue Den"
+      ]
+    },
+    "b-royal-checkpoint": {
+      "id": "b-royal-checkpoint",
+      "type": "battle",
+      "label": "Royal Checkpoint",
+      "description": "The crown's border guard does not recognise your travel papers. Mostly because you don't have any.",
+      "row": 11, "col": 0, "rowCols": 1, "childIds": [],
+      "handicap": 16,
+      "opponentBaseHp": 215,
+      "opponentIntervalMs": 4400,
+      "environment": "citadel",
+      "enemyDeck": [
+        "Knight", "Paladin", "Shield Wall Soldier", "Crossbow Tower", "Knight Barracks",
+        "Cavalry Scout", "Archer", "Paladin's Chapel", "Shield Guard", "Ballista", "Knight", "Mercenary Captain"
+      ]
+    },
+    "b-pirate-cove": {
+      "id": "b-pirate-cove",
+      "type": "battle",
+      "label": "Pirate Cove",
+      "description": "The pirates of the eastern reef answer to no crown, no port authority, and certainly not to you.",
+      "row": 12, "col": 0, "rowCols": 1, "childIds": [],
+      "handicap": 17,
+      "opponentBaseHp": 215,
+      "opponentIntervalMs": 4300,
+      "environment": "reef",
+      "enemyDeck": [
+        "Wave Brawler", "Tide Stalker", "Sea Witch", "Reef Shark", "Kraken Beacon",
+        "Tide Caller", "Tide Barracks", "Rogue", "Tide Dragon", "Wave Pit", "Tide Runner", "Anglerfish Lurker"
+      ]
+    },
+    "b-foundry-gate": {
+      "id": "b-foundry-gate",
+      "type": "battle",
+      "label": "Foundry Gate",
+      "description": "The great foundry west of Gearford sealed its gates years ago. Its guardians never stopped working.",
+      "row": 13, "col": 0, "rowCols": 1, "childIds": [],
+      "handicap": 18,
+      "opponentBaseHp": 220,
+      "opponentIntervalMs": 4200,
+      "environment": "vault",
+      "enemyDeck": [
+        "Golem", "Iron Colossus", "Clockwork Titan", "Gear Wall", "Golem Foundry",
+        "Steam Walker", "Ballista Tower", "Siege Engineer", "Clockwork Archer", "Iron Forge", "Arcane Turret", "Golem"
+      ]
+    },
+    "b-tournament": {
+      "id": "b-tournament",
+      "type": "battle",
+      "label": "Tournament Grounds",
+      "description": "The kingdom's finest knights compete here for glory. You are the novelty act — prove them wrong.",
+      "row": 14, "col": 0, "rowCols": 1, "childIds": [],
+      "handicap": 19,
+      "opponentBaseHp": 225,
+      "opponentIntervalMs": 4100,
+      "environment": "citadel",
+      "enemyDeck": [
+        "Knight", "Paladin", "Rune Knight", "Cavalry Scout", "Knight Barracks",
+        "Shield Wall Soldier", "Paladin", "Archer's Keep", "Crossbow Tower", "Mercenary Captain", "Rune Knight"
+      ]
+    },
+    "b-blight-fields": {
+      "id": "b-blight-fields",
+      "type": "battle",
+      "label": "Blighted Fields",
+      "description": "North of Millhaven the crops stopped growing and the farmers stopped staying buried.",
+      "row": 15, "col": 0, "rowCols": 1, "childIds": [],
+      "handicap": 20,
+      "opponentBaseHp": 225,
+      "opponentIntervalMs": 4400,
+      "environment": "ashen",
+      "enemyDeck": [
+        "Skeleton", "Bone Archer", "Wight Knight", "Bone Wall", "Skeleton",
+        "Necromancer", "Crypt", "Bone Archer", "Wraith", "Wight Barracks", "Skeleton", "Bat"
+      ]
+    },
+    "b-crypt-road": {
+      "id": "b-crypt-road",
+      "type": "battle",
+      "label": "Crypt Road",
+      "description": "The old road to Hollowmere runs past a hundred crypts. None of the doors are closed any more.",
+      "row": 16, "col": 0, "rowCols": 1, "childIds": [],
+      "handicap": 20,
+      "opponentBaseHp": 225,
+      "opponentIntervalMs": 4400,
+      "environment": "ashen",
+      "enemyDeck": [
+        "Bat", "Cave Bat", "Skeleton", "Crypt", "Bone Tower",
+        "Wight Knight", "Necromancer", "Bone Archer", "Wraith Shrine", "Revenant", "Bat Cave", "Skeleton"
+      ]
+    },
+    "b-grave-mists": {
+      "id": "b-grave-mists",
+      "type": "battle",
+      "label": "Grave Mists",
+      "description": "The mists west of Dreadspire are made of the things that did not get to say goodbye.",
+      "row": 17, "col": 0, "rowCols": 1, "childIds": [],
+      "handicap": 24,
+      "opponentBaseHp": 240,
+      "opponentIntervalMs": 4000,
+      "environment": "ashen",
+      "enemyDeck": [
+        "Wraith", "Ice Wraith", "Revenant", "Wraith Hollow", "Necromancer",
+        "Wight Knight", "Bone Colossus", "Wraith Shrine", "Lich Apprentice", "Skeleton", "Revenant Gate"
+      ]
+    },
+    "b-howling-dark": {
+      "id": "b-howling-dark",
+      "type": "battle",
+      "label": "The Howling Dark",
+      "description": "The forest east of Dreadspire howls all night. Whatever howls back is bigger.",
+      "row": 18, "col": 0, "rowCols": 1, "childIds": [],
+      "handicap": 24,
+      "opponentBaseHp": 240,
+      "opponentIntervalMs": 4000,
+      "environment": "ruins",
+      "enemyDeck": [
+        "Werewolf", "Troll", "Ogre", "Wolfpack Den", "Harpy",
+        "Wyvern", "Troll Den", "Werewolf", "Ogre Den", "Giant", "Harpy Roost", "Wyvern Roost"
+      ]
+    },
+    "b-dread-gate": {
+      "id": "b-dread-gate",
+      "type": "battle",
+      "label": "Dreadspire Gate",
+      "description": "The gate of Dreadspire Citadel is guarded by the castle's finest. Death did not end their watch.",
+      "row": 19, "col": 0, "rowCols": 1, "childIds": [],
+      "handicap": 28,
+      "opponentBaseHp": 260,
+      "opponentIntervalMs": 3600,
+      "environment": "ruins",
+      "enemyDeck": [
+        "Wight Knight", "Bone Colossus", "Lich Apprentice", "Necromancer", "Vampire",
+        "Lich Spire", "Bone Tower", "Revenant", "Wight Barracks", "Ash Revenant", "Necropolis", "Wraith", "Graveblight Tower"
+      ]
+    }
+  }
+}

--- a/web/src/data/hub/appleford/config.json
+++ b/web/src/data/hub/appleford/config.json
@@ -1,0 +1,121 @@
+{
+  "mapW": 896,
+  "mapH": 640,
+  "townName": "Appleford",
+  "environment": "farmland",
+  "avatarStart": { "tx": 14, "ty": 18 },
+  "exitTiles": [
+    { "tx": 13, "ty": 19, "screen": "worldmap" },
+    { "tx": 14, "ty": 19, "screen": "worldmap" }
+  ],
+  "areas": [
+    { "id": "appleford-orchard", "name": "The Orchards", "tx": 3, "ty": 12, "tw": 22, "th": 6 }
+  ],
+  "streets": [
+    { "rect": [13, 2, 14, 19] },
+    { "rect": [3, 10, 25, 11] }
+  ],
+  "buildings": [
+    {
+      "id": "cider-house",
+      "rect": [4, 2, 11, 8],
+      "wall": "woodWall",
+      "roof": "redSlateRoof",
+      "doors": [
+        { "tx": 4, "ty": 1, "hideSign": true, "buildingId": "cider-house" }
+      ]
+    },
+    {
+      "id": "keepers-cottage",
+      "rect": [17, 3, 23, 8],
+      "wall": "woodWall",
+      "roof": "strawRoof",
+      "doors": [
+        { "tx": 3, "ty": 1, "hideSign": true, "buildingId": "keepers-cottage" }
+      ]
+    }
+  ],
+  "exteriorDecor": [
+    { "comment": "orchard rows" },
+    { "tx": 4, "ty": 13, "bundleID": "light-tree", "zlayer": "solid" },
+    { "tx": 8, "ty": 13, "bundleID": "light-tree", "zlayer": "solid" },
+    { "tx": 16, "ty": 13, "bundleID": "light-tree", "zlayer": "solid" },
+    { "tx": 20, "ty": 13, "bundleID": "light-tree", "zlayer": "solid" },
+    { "tx": 24, "ty": 13, "bundleID": "light-tree", "zlayer": "solid" },
+    { "tx": 4, "ty": 17, "bundleID": "autumn-tree", "zlayer": "solid" },
+    { "tx": 8, "ty": 17, "bundleID": "autumn-tree", "zlayer": "solid" },
+    { "tx": 18, "ty": 17, "bundleID": "autumn-tree", "zlayer": "solid" },
+    { "tx": 22, "ty": 17, "bundleID": "autumn-tree", "zlayer": "solid" },
+    { "comment": "cider house front" },
+    { "tx": 3, "ty": 9, "tileId": "appleSign", "zlayer": "above" },
+    { "tx": 12, "ty": 9, "tileId": "barrel" },
+    { "tx": 12, "ty": 8, "tileId": "barrel" },
+    { "tx": 6, "ty": 9, "tileId": "appleBasket" },
+    { "comment": "village green" },
+    { "tx": 15, "ty": 9, "tileId": "stoneWell" },
+    { "tx": 25, "ty": 9, "tileId": "logPile" },
+    { "tx": 16, "ty": 12, "tileId": "whiteFlower" },
+    { "tx": 12, "ty": 16, "tileId": "whiteFlower" }
+  ],
+  "npcSpawnTiles": [],
+  "ambientNpcSprites": ["hub-npc-merchant"],
+  "npcs": [
+    {
+      "id": "orchard-keeper-bess",
+      "name": "Keeper Bess",
+      "sprite": "hub-npc-elder",
+      "tx": 16,
+      "ty": 11,
+      "dialogue": [
+        "Every tree in this orchard has a name. Don't ask me to introduce all of them.",
+        "Raiders hit the east rows last week. Took apples, baskets, and my best ladder.",
+        "An orchard is patience you can eat. Remember that."
+      ],
+      "building": "keepers-cottage",
+      "questGive": "appleford-scattered-harvest",
+      "questReceive": "appleford-scattered-harvest"
+    },
+    {
+      "id": "cider-brewer-tom",
+      "name": "Brewer Tom",
+      "sprite": "hub-npc-merchant",
+      "tx": 8,
+      "ty": 10,
+      "dialogue": [
+        "Appleford cider — pressed here, drunk everywhere, remembered fondly nowhere near here.",
+        "The toll road's made deliveries a nightmare. Bandits drink my profits, literally.",
+        "First mug's full price. So's the second. I'm a brewer, not a charity."
+      ],
+      "building": "cider-house"
+    }
+  ],
+  "interiors": {
+    "cider-house": {
+      "name": "The Cider House",
+      "width": 8,
+      "height": 5,
+      "floorTileId": "woodFloor",
+      "wallTileId": "woodWall",
+      "decor": [
+        { "tx": 1, "ty": 1, "tileId": "barrel" },
+        { "tx": 2, "ty": 1, "tileId": "barrel" },
+        { "tx": 3, "ty": 1, "tileId": "barrel" },
+        { "tx": 6, "ty": 1, "tileId": "bottlesOfLiquor" }
+      ],
+      "exits": []
+    },
+    "keepers-cottage": {
+      "name": "The Keeper's Cottage",
+      "width": 7,
+      "height": 4,
+      "floorTileId": "woodFloor",
+      "wallTileId": "woodWall",
+      "decor": [
+        { "tx": 1, "ty": 1, "tileId": "appleBasket" },
+        { "tx": 4, "ty": 1, "tileId": "roundTable" },
+        { "tx": 5, "ty": 2, "tileId": "stool" }
+      ],
+      "exits": []
+    }
+  }
+}

--- a/web/src/data/hub/appleford/questDefs.json
+++ b/web/src/data/hub/appleford/questDefs.json
@@ -1,0 +1,37 @@
+{
+  "quests": [
+    {
+      "id": "appleford-scattered-harvest",
+      "title": "The Scattered Harvest",
+      "type": "fetch",
+      "giverNpcId": "orchard-keeper-bess",
+      "receiverNpcId": "orchard-keeper-bess",
+      "offerDialogue": "The raiders dropped half of what they stole running from the village dogs. Three baskets of good apples, scattered through the orchard rows. Bring them in before the wasps claim them, would you? My knees have retired from bending.",
+      "activeDialogue": "Three apple baskets, somewhere among the orchard rows. Follow the wasps if you're stuck.",
+      "completeDialogue": "Barely a bruise on them! The pressing's saved. You've a friend in Appleford, traveller — and a discount Tom doesn't know he's offering.",
+      "steps": [
+        {
+          "key": "apples",
+          "type": "collect",
+          "pickupIds": ["apple-basket-1", "apple-basket-2", "apple-basket-3"],
+          "required": 3
+        }
+      ],
+      "reward": {
+        "crystals": 45,
+        "collectible": {
+          "id": "appleford-apple",
+          "name": "Perfect Apple",
+          "icon": "🍎",
+          "desc": "A flawless apple from the oldest tree in Appleford. Bess named the tree Gerald."
+        }
+      }
+    }
+  ],
+  "pickupItems": [
+    { "id": "apple-basket-1", "tx": 6, "ty": 15, "tileId": "appleBasket", "questId": "appleford-scattered-harvest" },
+    { "id": "apple-basket-2", "tx": 14, "ty": 14, "tileId": "appleBasket", "questId": "appleford-scattered-harvest" },
+    { "id": "apple-basket-3", "tx": 21, "ty": 16, "tileId": "appleBasket", "questId": "appleford-scattered-harvest" }
+  ],
+  "blockedPaths": []
+}

--- a/web/src/data/hub/capitalcity/config.json
+++ b/web/src/data/hub/capitalcity/config.json
@@ -1,0 +1,205 @@
+{
+  "mapW": 1280,
+  "mapH": 1088,
+  "townName": "Crownhaven",
+  "environment": "citadel",
+  "avatarStart": { "tx": 19, "ty": 30 },
+  "exitTiles": [
+    { "tx": 19, "ty": 31, "screen": "worldmap" },
+    { "tx": 20, "ty": 31, "screen": "worldmap" }
+  ],
+  "areas": [
+    { "id": "crownhaven-plaza", "name": "Coronation Plaza", "tx": 14, "ty": 10, "tw": 12, "th": 8 },
+    { "id": "crownhaven-market", "name": "The Grand Market", "tx": 26, "ty": 2, "tw": 12, "th": 14 }
+  ],
+  "streets": [
+    { "rect": [18, 2, 21, 31] },
+    { "rect": [2, 14, 37, 17] },
+    { "rect": [14, 10, 25, 13] },
+    { "rect": [6, 18, 7, 22] },
+    { "rect": [32, 18, 33, 22] }
+  ],
+  "buildings": [
+    {
+      "id": "grand-inn",
+      "rect": [3, 2, 12, 9],
+      "wall": "whiteStone",
+      "roof": "blueSlateRoof",
+      "doors": [
+        { "tx": 5, "ty": 1, "hideSign": true, "buildingId": "grand-inn" }
+      ]
+    },
+    {
+      "id": "market-hall-crownhaven",
+      "rect": [27, 2, 36, 9],
+      "wall": "brick",
+      "roof": "redSlateRoof",
+      "doors": [
+        { "tx": 4, "ty": 1, "hideSign": true, "buildingId": "market-hall-crownhaven" }
+      ]
+    },
+    {
+      "id": "guardhouse",
+      "rect": [3, 20, 10, 26],
+      "wall": "castleStone",
+      "roof": "greySlateRoof",
+      "doors": [
+        { "tx": 3, "ty": 1, "hideSign": true, "buildingId": "guardhouse" }
+      ]
+    },
+    {
+      "id": "chapel",
+      "rect": [29, 20, 36, 27],
+      "wall": "ornateStone",
+      "roof": "blueSlateRoof",
+      "doors": [
+        { "tx": 3, "ty": 1, "hideSign": true, "buildingId": "chapel" }
+      ]
+    }
+  ],
+  "exteriorDecor": [
+    { "comment": "plaza fountain" },
+    { "tx": 18, "ty": 11, "bundleID": "fountain", "zlayer": "solid" },
+    { "comment": "market clutter" },
+    { "tx": 26, "ty": 11, "tileId": "crate" },
+    { "tx": 27, "ty": 11, "tileId": "openCrate" },
+    { "tx": 35, "ty": 11, "tileId": "barrel" },
+    { "tx": 36, "ty": 12, "tileId": "sack" },
+    { "comment": "guardhouse braziers" },
+    { "tx": 4, "ty": 28, "tileId": "brazierBottom" },
+    { "tx": 4, "ty": 27, "tileId": "brazierTop", "zlayer": "above" },
+    { "tx": 9, "ty": 28, "tileId": "brazierBottom" },
+    { "tx": 9, "ty": 27, "tileId": "brazierTop", "zlayer": "above" },
+    { "comment": "city greenery" },
+    { "tx": 13, "ty": 19, "bundleID": "mixed-tree-cluster-V", "zlayer": "solid" },
+    { "tx": 24, "ty": 19, "bundleID": "mixed-tree-cluster-V", "zlayer": "solid" },
+    { "tx": 2, "ty": 11, "bundleID": "light-tree", "zlayer": "solid" },
+    { "tx": 36, "ty": 17, "bundleID": "light-tree", "zlayer": "solid" },
+    { "tx": 14, "ty": 9, "tileId": "whiteFlower" },
+    { "tx": 25, "ty": 9, "tileId": "whiteFlower" },
+    { "comment": "road sign at the south gate" },
+    { "tx": 16, "ty": 29, "tileId": "roadSignTop", "zlayer": "above" },
+    { "tx": 16, "ty": 30, "tileId": "roadSignBottom", "zlayer": "above" }
+  ],
+  "npcSpawnTiles": [],
+  "ambientNpcSprites": ["hub-npc-merchant", "hub-npc-scholar"],
+  "npcs": [
+    {
+      "id": "innkeeper-crownhaven",
+      "name": "Innkeep Rosalind",
+      "sprite": "hub-npc-merchant",
+      "tx": 8,
+      "ty": 11,
+      "dialogue": [
+        "Welcome to The Gilded Goose, finest beds in the capital.",
+        "Half my guests are here for the tournament. The other half are avoiding it.",
+        "If Captain Hale sends you with anything, I'll see it gets where it's going."
+      ],
+      "building": "grand-inn",
+      "questReceive": "crownhaven-gate-key"
+    },
+    {
+      "id": "watch-captain-hale",
+      "name": "Captain Hale",
+      "sprite": "hub-npc-soldier",
+      "tx": 12,
+      "ty": 19,
+      "dialogue": [
+        "Crownhaven watch. State your business — or don't, you look harmless enough.",
+        "The old postern gate key went missing on patrol. If it falls into the wrong hands, the palace will have my head.",
+        "Keep your nose clean in my city, traveller."
+      ],
+      "building": "guardhouse",
+      "questGive": "crownhaven-gate-key"
+    },
+    {
+      "id": "royal-archivist",
+      "name": "Archivist Quill",
+      "sprite": "hub-npc-scholar",
+      "tx": 24,
+      "ty": 12,
+      "dialogue": [
+        "The royal survey of the outer provinces is three scrolls short. Three!",
+        "The couriers dropped them somewhere between here and the gates, I'm certain of it.",
+        "History is just paperwork that survived, you know."
+      ],
+      "questGive": "crownhaven-census",
+      "questReceive": "crownhaven-census"
+    },
+    {
+      "id": "market-matron",
+      "name": "Matron Goldie",
+      "sprite": "hub-npc-elder",
+      "tx": 31,
+      "ty": 12,
+      "dialogue": [
+        "Forty years I've run this market. Kings come and go; turnips are forever.",
+        "You want gossip, try the inn. You want a fair price, you talk to me.",
+        "Mind the fountain — the pigeons have opinions."
+      ],
+      "building": "market-hall-crownhaven"
+    }
+  ],
+  "interiors": {
+    "grand-inn": {
+      "name": "The Gilded Goose",
+      "width": 10,
+      "height": 6,
+      "floorTileId": "woodFloor",
+      "wallTileId": "whiteStone",
+      "decor": [
+        { "tx": 1, "ty": 1, "tileId": "barrel" },
+        { "tx": 2, "ty": 1, "tileId": "barrel" },
+        { "tx": 7, "ty": 1, "tileId": "roundTableWithCloth" },
+        { "tx": 8, "ty": 2, "tileId": "stool" },
+        { "tx": 6, "ty": 2, "tileId": "stool" }
+      ],
+      "exits": []
+    },
+    "market-hall-crownhaven": {
+      "name": "The Grand Market Hall",
+      "width": 10,
+      "height": 5,
+      "floorTileId": "woodFloor",
+      "wallTileId": "brick",
+      "decor": [
+        { "tx": 1, "ty": 1, "tileId": "crate" },
+        { "tx": 2, "ty": 1, "tileId": "openCrate" },
+        { "tx": 7, "ty": 1, "tileId": "sack" },
+        { "tx": 8, "ty": 1, "tileId": "crate" }
+      ],
+      "exits": []
+    },
+    "guardhouse": {
+      "name": "The Watch House",
+      "width": 8,
+      "height": 5,
+      "floorTileId": "stoneFloor",
+      "wallTileId": "castleStone",
+      "decor": [
+        { "tx": 1, "ty": 1, "tileId": "suitOfArmourTop" },
+        { "tx": 1, "ty": 2, "tileId": "suitOfArmourBottom" },
+        { "tx": 6, "ty": 1, "tileId": "suitOfArmourTop" },
+        { "tx": 6, "ty": 2, "tileId": "suitOfArmourBottom" },
+        { "tx": 3, "ty": 1, "tileId": "swordMountedLeft" },
+        { "tx": 4, "ty": 1, "tileId": "shieldMounted" }
+      ],
+      "exits": []
+    },
+    "chapel": {
+      "name": "Chapel of the Dawn",
+      "width": 8,
+      "height": 6,
+      "floorTileId": "cobblestoneFloor",
+      "wallTileId": "ornateStone",
+      "decor": [
+        { "tx": 1, "ty": 1, "tileId": "bookshelfTop" },
+        { "tx": 1, "ty": 2, "tileId": "bookshelfBottom" },
+        { "tx": 6, "ty": 1, "tileId": "bookshelfTop" },
+        { "tx": 6, "ty": 2, "tileId": "bookshelfBottom" },
+        { "tx": 3, "ty": 1, "tileId": "roundTableWithCloth" }
+      ],
+      "exits": []
+    }
+  }
+}

--- a/web/src/data/hub/capitalcity/questDefs.json
+++ b/web/src/data/hub/capitalcity/questDefs.json
@@ -1,0 +1,66 @@
+{
+  "quests": [
+    {
+      "id": "crownhaven-census",
+      "title": "The Royal Census",
+      "type": "fetch",
+      "giverNpcId": "royal-archivist",
+      "receiverNpcId": "royal-archivist",
+      "offerDialogue": "The survey of the outer provinces is missing three scrolls — dropped by careless couriers somewhere in the city. Without them, the census is a work of fiction. Find them, please. The crown's records depend on it.",
+      "activeDialogue": "Three survey scrolls, somewhere in the streets. Check near the gates and the market.",
+      "completeDialogue": "All three, and barely smudged! The census lives. You have done the kingdom's paperwork a great service — which is to say, the kingdom itself.",
+      "steps": [
+        {
+          "key": "scrolls",
+          "type": "collect",
+          "pickupIds": ["survey-scroll-1", "survey-scroll-2", "survey-scroll-3"],
+          "required": 3
+        }
+      ],
+      "reward": {
+        "crystals": 70
+      }
+    },
+    {
+      "id": "crownhaven-gate-key",
+      "title": "The Postern Key",
+      "type": "chain",
+      "giverNpcId": "watch-captain-hale",
+      "receiverNpcId": "innkeeper-crownhaven",
+      "offerDialogue": "One of my watchmen dropped the old postern gate key on patrol last night. Find it before someone less honest does, and leave it with Rosalind at The Gilded Goose — I'll collect it at end of shift, and the fewer hands it passes through, the better.",
+      "activeDialogue": {
+        "key": "The key went missing somewhere along the east wall, near the chapel. Look sharp.",
+        "deliver": "You found it? Good. Now get it to Rosalind at the inn, quiet-like."
+      },
+      "completeDialogue": "From Captain Hale? Say no more. It'll be under the counter until shift change. You've done the watch a favour — here, for your discretion.",
+      "steps": [
+        {
+          "key": "key",
+          "type": "collect",
+          "pickupIds": ["postern-key"],
+          "required": 1
+        },
+        {
+          "key": "deliver",
+          "type": "deliver",
+          "targetNpcId": "innkeeper-crownhaven",
+          "required": 1
+        }
+      ],
+      "reward": {
+        "crystals": 80,
+        "friendship": {
+          "watch-captain-hale": 15,
+          "innkeeper-crownhaven": 10
+        }
+      }
+    }
+  ],
+  "pickupItems": [
+    { "id": "survey-scroll-1", "tx": 4, "ty": 13, "tileId": "rolledMap", "questId": "crownhaven-census" },
+    { "id": "survey-scroll-2", "tx": 33, "ty": 18, "tileId": "rolledMap", "questId": "crownhaven-census" },
+    { "id": "survey-scroll-3", "tx": 25, "ty": 28, "tileId": "rolledMap", "questId": "crownhaven-census" },
+    { "id": "postern-key", "tx": 27, "ty": 19, "tileId": "key", "questId": "crownhaven-gate-key" }
+  ],
+  "blockedPaths": []
+}

--- a/web/src/data/hub/dreadspirecitadel/config.json
+++ b/web/src/data/hub/dreadspirecitadel/config.json
@@ -1,0 +1,117 @@
+{
+  "mapW": 832,
+  "mapH": 640,
+  "townName": "Dreadspire Citadel",
+  "environment": "ashen",
+  "avatarStart": { "tx": 12, "ty": 17 },
+  "exitTiles": [
+    { "tx": 12, "ty": 18, "screen": "worldmap" },
+    { "tx": 13, "ty": 18, "screen": "worldmap" }
+  ],
+  "areas": [
+    { "id": "dreadspire-court", "name": "The Ashen Court", "tx": 8, "ty": 11, "tw": 10, "th": 5 }
+  ],
+  "streets": [
+    { "rect": [11, 2, 14, 18] },
+    { "rect": [5, 12, 20, 13] }
+  ],
+  "buildings": [
+    {
+      "id": "dread-keep",
+      "rect": [7, 2, 18, 10],
+      "wall": "darkStone",
+      "roof": "greySlateRoof",
+      "doors": [
+        { "tx": 5, "ty": 1, "hideSign": true, "buildingId": "dread-keep" },
+        { "tx": 6, "ty": 1, "hideSign": true, "buildingId": "dread-keep" }
+      ]
+    }
+  ],
+  "exteriorDecor": [
+    { "comment": "gate braziers burning cold" },
+    { "tx": 10, "ty": 12, "tileId": "brazierBottom" },
+    { "tx": 10, "ty": 11, "tileId": "brazierTop", "zlayer": "above" },
+    { "tx": 15, "ty": 12, "tileId": "brazierBottom" },
+    { "tx": 15, "ty": 11, "tileId": "brazierTop", "zlayer": "above" },
+    { "comment": "dark crystals growing through the courtyard" },
+    { "tx": 5, "ty": 14, "tileId": "dark_red_crystal1" },
+    { "tx": 19, "ty": 15, "tileId": "dark_red_crystal1" },
+    { "tx": 8, "ty": 16, "tileId": "skull" },
+    { "tx": 17, "ty": 16, "tileId": "smallRock" },
+    { "comment": "iron fence along the court, gap at the gate" },
+    { "tx": 5, "ty": 16, "tileId": "ironFenceLeftRight", "zlayer": "above" },
+    { "tx": 6, "ty": 16, "tileId": "ironFenceLeftRight", "zlayer": "above" },
+    { "tx": 7, "ty": 16, "tileId": "ironFenceLeftRight", "zlayer": "above" },
+    { "tx": 8, "ty": 16, "tileId": "ironFenceLeftRight", "zlayer": "above" },
+    { "tx": 9, "ty": 16, "tileId": "ironFenceLeftRight", "zlayer": "above" },
+    { "tx": 10, "ty": 16, "tileId": "ironFenceLeft", "zlayer": "above" },
+    { "tx": 15, "ty": 16, "tileId": "ironFenceRight", "zlayer": "above" },
+    { "tx": 16, "ty": 16, "tileId": "ironFenceLeftRight", "zlayer": "above" },
+    { "tx": 17, "ty": 16, "tileId": "ironFenceLeftRight", "zlayer": "above" },
+    { "tx": 18, "ty": 16, "tileId": "ironFenceLeftRight", "zlayer": "above" },
+    { "tx": 19, "ty": 16, "tileId": "ironFenceLeftRight", "zlayer": "above" },
+    { "tx": 20, "ty": 16, "tileId": "ironFenceLeftRight", "zlayer": "above" },
+    { "comment": "nothing alive grows here" },
+    { "tx": 2, "ty": 5, "bundleID": "dead-tree", "zlayer": "solid" },
+    { "tx": 21, "ty": 5, "bundleID": "dead-tree", "zlayer": "solid" },
+    { "tx": 3, "ty": 11, "bundleID": "dead-tree", "zlayer": "solid" },
+    { "tx": 22, "ty": 12, "bundleID": "dead-tree", "zlayer": "solid" },
+    { "tx": 18, "ty": 18, "bundleID": "dead-tree", "zlayer": "solid" },
+    { "tx": 4, "ty": 18, "bundleID": "dead-tree", "zlayer": "solid" }
+  ],
+  "npcSpawnTiles": [],
+  "ambientNpcSprites": [],
+  "npcs": [
+    {
+      "id": "the-castellan",
+      "name": "The Castellan",
+      "sprite": "hub-npc-scholar",
+      "isGhost": true,
+      "tx": 12,
+      "ty": 14,
+      "dialogue": [
+        "Welcome to Dreadspire. The master is out. The master has been out for four hundred years.",
+        "I maintain the citadel. The dust maintains itself — it's quite industrious.",
+        "The dark crystals in the courtyard keep the walls standing. They've been... wandering off lately."
+      ],
+      "questGive": "dreadspire-dark-harvest",
+      "questReceive": "dreadspire-dark-harvest"
+    },
+    {
+      "id": "bound-knight",
+      "name": "The Bound Knight",
+      "sprite": "hub-npc-soldier",
+      "tx": 14,
+      "ty": 14,
+      "dialogue": [
+        "I swore to guard this gate until my lord returns. He has not returned. I am very good at my job.",
+        "You defeated the garrison at the gate. They'll re-form by morning — death is a poor excuse for missing a shift here.",
+        "If you mean the citadel harm, I must stop you. If you mean it well, I must watch you suspiciously. Those are the rules."
+      ]
+    }
+  ],
+  "interiors": {
+    "dread-keep": {
+      "name": "The Dread Throne",
+      "width": 12,
+      "height": 8,
+      "floorTileId": "stoneFloor",
+      "wallTileId": "darkStone",
+      "decor": [
+        { "comment": "the summoning circle before the empty throne" },
+        { "tx": 5, "ty": 3, "tileId": "summoningCircle" },
+        { "tx": 2, "ty": 1, "tileId": "brazierTop" },
+        { "tx": 2, "ty": 2, "tileId": "brazierBottom" },
+        { "tx": 9, "ty": 1, "tileId": "brazierTop" },
+        { "tx": 9, "ty": 2, "tileId": "brazierBottom" },
+        { "tx": 5, "ty": 1, "tileId": "suitOfArmourTop" },
+        { "tx": 5, "ty": 2, "tileId": "suitOfArmourBottom" },
+        { "tx": 6, "ty": 1, "tileId": "suitOfArmourTop" },
+        { "tx": 6, "ty": 2, "tileId": "suitOfArmourBottom" },
+        { "tx": 1, "ty": 5, "tileId": "skull" },
+        { "tx": 10, "ty": 5, "tileId": "dark_red_crystal1" }
+      ],
+      "exits": []
+    }
+  }
+}

--- a/web/src/data/hub/dreadspirecitadel/questDefs.json
+++ b/web/src/data/hub/dreadspirecitadel/questDefs.json
@@ -1,0 +1,37 @@
+{
+  "quests": [
+    {
+      "id": "dreadspire-dark-harvest",
+      "title": "The Dark Harvest",
+      "type": "fetch",
+      "giverNpcId": "the-castellan",
+      "receiverNpcId": "the-castellan",
+      "offerDialogue": "The dark crystals anchor the citadel's foundations — without them, four centuries of deferred maintenance arrive all at once. Three have broken loose and crept off around the grounds. Crystals shouldn't creep. Retrieve them before the east wing notices it's unsupported.",
+      "activeDialogue": "Three dark crystals, loose somewhere on the grounds. They glow. They hum. Occasionally they sulk.",
+      "completeDialogue": "All three, returned and re-anchored. The citadel stands another century. The master would thank you, were he here, which he is not, which is the usual arrangement. Take this from the treasury — the dust won't miss it.",
+      "steps": [
+        {
+          "key": "crystals",
+          "type": "collect",
+          "pickupIds": ["dark-crystal-1", "dark-crystal-2", "dark-crystal-3"],
+          "required": 3
+        }
+      ],
+      "reward": {
+        "crystals": 100,
+        "collectible": {
+          "id": "dreadspire-shard",
+          "name": "Dreadspire Shard",
+          "icon": "🔮",
+          "desc": "A sliver of dark crystal from the citadel's foundations. It hums when it thinks no one is listening."
+        }
+      }
+    }
+  ],
+  "pickupItems": [
+    { "id": "dark-crystal-1", "tx": 3, "ty": 14, "tileId": "dark_red_crystal1", "questId": "dreadspire-dark-harvest" },
+    { "id": "dark-crystal-2", "tx": 21, "ty": 17, "tileId": "dark_red_crystal1", "questId": "dreadspire-dark-harvest" },
+    { "id": "dark-crystal-3", "tx": 16, "ty": 18, "tileId": "dark_red_crystal1", "questId": "dreadspire-dark-harvest" }
+  ],
+  "blockedPaths": []
+}

--- a/web/src/data/hub/gearford/config.json
+++ b/web/src/data/hub/gearford/config.json
@@ -1,0 +1,167 @@
+{
+  "mapW": 1088,
+  "mapH": 832,
+  "townName": "Gearford",
+  "environment": "vault",
+  "avatarStart": { "tx": 16, "ty": 24 },
+  "exitTiles": [
+    { "tx": 16, "ty": 25, "screen": "worldmap" },
+    { "tx": 17, "ty": 25, "screen": "worldmap" }
+  ],
+  "areas": [
+    { "id": "gearford-foundry-yard", "name": "Foundry Yard", "tx": 3, "ty": 2, "tw": 14, "th": 12 },
+    { "id": "gearford-works", "name": "The Works", "tx": 19, "ty": 2, "tw": 12, "th": 10 }
+  ],
+  "streets": [
+    { "rect": [2, 12, 31, 13] },
+    { "rect": [16, 2, 17, 25] },
+    { "rect": [24, 14, 25, 16] },
+    { "rect": [8, 10, 9, 11] }
+  ],
+  "buildings": [
+    {
+      "id": "foundry",
+      "rect": [4, 2, 15, 9],
+      "wall": "brick",
+      "roof": "metalRoof",
+      "doors": [
+        { "tx": 5, "ty": 1, "hideSign": true, "buildingId": "foundry" }
+      ]
+    },
+    {
+      "id": "workshop",
+      "rect": [20, 3, 27, 9],
+      "wall": "woodenSlats",
+      "roof": "greySlateRoof",
+      "doors": [
+        { "tx": 4, "ty": 1, "hideSign": true, "buildingId": "workshop" }
+      ]
+    },
+    {
+      "id": "miners-inn",
+      "rect": [21, 15, 29, 21],
+      "wall": "tudorFrame",
+      "roof": "strawRoof",
+      "doors": [
+        { "tx": 3, "ty": 1, "hideSign": true, "buildingId": "miners-inn" }
+      ]
+    }
+  ],
+  "exteriorDecor": [
+    { "comment": "foundry yard braziers" },
+    { "tx": 3, "ty": 11, "tileId": "brazierBottom" },
+    { "tx": 3, "ty": 10, "tileId": "brazierTop", "zlayer": "above" },
+    { "tx": 14, "ty": 11, "tileId": "brazierBottom" },
+    { "tx": 14, "ty": 10, "tileId": "brazierTop", "zlayer": "above" },
+    { "comment": "industrial clutter" },
+    { "tx": 2, "ty": 14, "tileId": "crate" },
+    { "tx": 2, "ty": 15, "tileId": "openCrate" },
+    { "tx": 18, "ty": 10, "tileId": "barrel" },
+    { "tx": 19, "ty": 11, "tileId": "barrel" },
+    { "tx": 29, "ty": 10, "tileId": "logPile" },
+    { "tx": 30, "ty": 11, "tileId": "logPile" },
+    { "tx": 28, "ty": 14, "tileId": "pileOfSacks" },
+    { "tx": 5, "ty": 16, "tileId": "smallRock" },
+    { "tx": 12, "ty": 18, "tileId": "smallRock" },
+    { "comment": "what little grows here" },
+    { "tx": 3, "ty": 20, "bundleID": "dead-tree", "zlayer": "solid" },
+    { "tx": 9, "ty": 21, "bundleID": "dead-tree", "zlayer": "solid" },
+    { "tx": 30, "ty": 22, "bundleID": "dark-tree", "zlayer": "solid" },
+    { "tx": 19, "ty": 19, "bundleID": "dark-tree", "zlayer": "solid" },
+    { "comment": "well by the inn" },
+    { "tx": 19, "ty": 16, "tileId": "stoneWell" }
+  ],
+  "npcSpawnTiles": [],
+  "ambientNpcSprites": ["hub-npc-supplies"],
+  "npcs": [
+    {
+      "id": "forgemaster-brunn",
+      "name": "Forgemaster Brunn",
+      "sprite": "hub-npc-supplies",
+      "tx": 10,
+      "ty": 11,
+      "dialogue": [
+        "Gearford runs on three things: coal, iron, and complaints.",
+        "Somebody's been lifting tools from the yard. A foundry without tools is just a very warm room.",
+        "Hear that hammering? That's the sound of nothing being wrong. I like that sound."
+      ],
+      "building": "foundry",
+      "questGive": "gearford-stolen-tools",
+      "questReceive": "gearford-stolen-tools"
+    },
+    {
+      "id": "engineer-vela",
+      "name": "Engineer Vela",
+      "sprite": "hub-npc-merchant",
+      "tx": 23,
+      "ty": 11,
+      "dialogue": [
+        "The constructs that went rogue out in the smoke fields? Not mine. Mostly not mine.",
+        "Every machine wants to work. You just have to convince it the work is yours.",
+        "The forge eats coal like a dragon eats... well, everything. We're always short."
+      ],
+      "building": "workshop",
+      "questGive": "gearford-coal-run",
+      "questReceive": "gearford-coal-run"
+    },
+    {
+      "id": "foreman-dask",
+      "name": "Foreman Dask",
+      "sprite": "hub-npc-soldier",
+      "tx": 18,
+      "ty": 14,
+      "dialogue": [
+        "Shift starts at dawn, ends when Brunn stops shouting.",
+        "Between the bandits on the toll road and the mine collapse, half my crew won't travel.",
+        "You look sturdy. Ever considered honest work? No? Smart."
+      ],
+      "building": "miners-inn"
+    }
+  ],
+  "interiors": {
+    "foundry": {
+      "name": "The Great Foundry",
+      "width": 12,
+      "height": 6,
+      "floorTileId": "stoneFloor",
+      "wallTileId": "brick",
+      "decor": [
+        { "tx": 2, "ty": 1, "tileId": "brazierTop" },
+        { "tx": 2, "ty": 2, "tileId": "brazierBottom" },
+        { "tx": 9, "ty": 1, "tileId": "brazierTop" },
+        { "tx": 9, "ty": 2, "tileId": "brazierBottom" },
+        { "tx": 5, "ty": 1, "tileId": "crate" },
+        { "tx": 6, "ty": 1, "tileId": "barrel" }
+      ],
+      "exits": []
+    },
+    "workshop": {
+      "name": "Vela's Workshop",
+      "width": 8,
+      "height": 5,
+      "floorTileId": "woodFloor",
+      "wallTileId": "woodenSlats",
+      "decor": [
+        { "tx": 1, "ty": 1, "tileId": "crate" },
+        { "tx": 2, "ty": 1, "tileId": "openCrate" },
+        { "tx": 5, "ty": 1, "tileId": "bookshelfTop" },
+        { "tx": 5, "ty": 2, "tileId": "bookshelfBottom" }
+      ],
+      "exits": []
+    },
+    "miners-inn": {
+      "name": "The Pickaxe Rest",
+      "width": 9,
+      "height": 5,
+      "floorTileId": "woodFloor",
+      "wallTileId": "woodWall",
+      "decor": [
+        { "tx": 1, "ty": 1, "tileId": "barrel" },
+        { "tx": 2, "ty": 1, "tileId": "bottlesOfLiquor" },
+        { "tx": 6, "ty": 2, "tileId": "roundTable" },
+        { "tx": 7, "ty": 3, "tileId": "stool" }
+      ],
+      "exits": []
+    }
+  }
+}

--- a/web/src/data/hub/gearford/questDefs.json
+++ b/web/src/data/hub/gearford/questDefs.json
@@ -1,0 +1,58 @@
+{
+  "quests": [
+    {
+      "id": "gearford-stolen-tools",
+      "title": "Tools of the Trade",
+      "type": "fetch",
+      "giverNpcId": "forgemaster-brunn",
+      "receiverNpcId": "forgemaster-brunn",
+      "offerDialogue": "Three toolboxes lifted from the yard in one week. The whole foundry grinds to a halt without them. Whoever took them stashed them around town — find the crates and bring them back before the furnace goes cold.",
+      "activeDialogue": "Three toolbox crates, stashed somewhere around town. Thieves are lazy — check the quiet corners.",
+      "completeDialogue": "Every wrench accounted for. The furnace stays lit and so does my temper — barely. You've earned this, traveller.",
+      "steps": [
+        {
+          "key": "tools",
+          "type": "collect",
+          "pickupIds": ["toolbox-1", "toolbox-2", "toolbox-3"],
+          "required": 3
+        }
+      ],
+      "reward": {
+        "crystals": 65
+      }
+    },
+    {
+      "id": "gearford-coal-run",
+      "title": "Feeding the Forge",
+      "type": "fetch",
+      "giverNpcId": "engineer-vela",
+      "receiverNpcId": "engineer-vela",
+      "prerequisite": "quest:gearford-stolen-tools",
+      "offerDialogue": "The forge is down to its last scuttle of coal and the next caravan is a week out. Two sacks from the old depot would keep us running. The depot's abandoned — the coal isn't doing anyone any good sitting there.",
+      "activeDialogue": "Two coal sacks from the old depot, south side of town. Heavy, but you look like you lift.",
+      "completeDialogue": "Coal! Beautiful, filthy coal. The forge eats tonight. You've kept Gearford working, friend — that's worth more here than gold. Have some gold anyway.",
+      "steps": [
+        {
+          "key": "coal",
+          "type": "collect",
+          "pickupIds": ["coal-sack-1", "coal-sack-2"],
+          "required": 2
+        }
+      ],
+      "reward": {
+        "crystals": 55,
+        "friendship": {
+          "engineer-vela": 15
+        }
+      }
+    }
+  ],
+  "pickupItems": [
+    { "id": "toolbox-1", "tx": 2, "ty": 17, "tileId": "crate", "questId": "gearford-stolen-tools" },
+    { "id": "toolbox-2", "tx": 30, "ty": 4, "tileId": "crate", "questId": "gearford-stolen-tools" },
+    { "id": "toolbox-3", "tx": 12, "ty": 21, "tileId": "crate", "questId": "gearford-stolen-tools" },
+    { "id": "coal-sack-1", "tx": 6, "ty": 23, "tileId": "sack", "questId": "gearford-coal-run" },
+    { "id": "coal-sack-2", "tx": 28, "ty": 23, "tileId": "sack", "questId": "gearford-coal-run" }
+  ],
+  "blockedPaths": []
+}

--- a/web/src/data/hub/gravemoor/config.json
+++ b/web/src/data/hub/gravemoor/config.json
@@ -1,0 +1,148 @@
+{
+  "mapW": 960,
+  "mapH": 704,
+  "townName": "Gravemoor",
+  "environment": "ashen",
+  "avatarStart": { "tx": 15, "ty": 20 },
+  "exitTiles": [
+    { "tx": 14, "ty": 21, "screen": "worldmap" },
+    { "tx": 15, "ty": 21, "screen": "worldmap" }
+  ],
+  "areas": [
+    { "id": "gravemoor-cemetery", "name": "The Old Cemetery", "tx": 3, "ty": 12, "tw": 11, "th": 7 },
+    { "id": "gravemoor-square", "name": "The Quiet Square", "tx": 13, "ty": 10, "tw": 6, "th": 4 }
+  ],
+  "streets": [
+    { "rect": [14, 2, 16, 21] },
+    { "rect": [4, 10, 26, 11] },
+    { "rect": [21, 12, 22, 14] }
+  ],
+  "buildings": [
+    {
+      "id": "mourning-hall",
+      "rect": [4, 2, 12, 9],
+      "wall": "darkStone",
+      "roof": "greySlateRoof",
+      "doors": [
+        { "tx": 4, "ty": 1, "hideSign": true, "buildingId": "mourning-hall" }
+      ]
+    },
+    {
+      "id": "crypt-keep",
+      "rect": [19, 2, 26, 8],
+      "wall": "darkStone",
+      "roof": "greySlateRoof",
+      "doors": [
+        { "tx": 3, "ty": 1, "hideSign": true, "buildingId": "crypt-keep" }
+      ]
+    }
+  ],
+  "exteriorDecor": [
+    { "comment": "the old cemetery" },
+    { "tx": 4, "ty": 13, "tileId": "graveStone" },
+    { "tx": 7, "ty": 13, "tileId": "graveWoodenCross" },
+    { "tx": 10, "ty": 13, "tileId": "graveStone" },
+    { "tx": 5, "ty": 15, "tileId": "graveWoodenCross" },
+    { "tx": 8, "ty": 15, "tileId": "graveStone" },
+    { "tx": 11, "ty": 15, "tileId": "graveWoodenCross" },
+    { "tx": 4, "ty": 17, "tileId": "graveStone" },
+    { "tx": 9, "ty": 17, "tileId": "graveStone" },
+    { "tx": 12, "ty": 17, "tileId": "graveWoodenCross" },
+    { "comment": "dead trees ring the town" },
+    { "tx": 2, "ty": 4, "bundleID": "dead-tree", "zlayer": "solid" },
+    { "tx": 16, "ty": 4, "bundleID": "dead-tree", "zlayer": "solid" },
+    { "tx": 27, "ty": 12, "bundleID": "dead-tree", "zlayer": "solid" },
+    { "tx": 20, "ty": 17, "bundleID": "dead-tree", "zlayer": "solid" },
+    { "tx": 2, "ty": 19, "bundleID": "dead-tree", "zlayer": "solid" },
+    { "tx": 25, "ty": 19, "bundleID": "dead-tree", "zlayer": "solid" },
+    { "comment": "remains of the living town" },
+    { "tx": 17, "ty": 12, "tileId": "stoneWell" },
+    { "tx": 13, "ty": 9, "tileId": "skull" },
+    { "tx": 24, "ty": 15, "tileId": "smallRock" },
+    { "tx": 18, "ty": 9, "tileId": "barrel" },
+    { "comment": "braziers that no one remembers lighting" },
+    { "tx": 13, "ty": 11, "tileId": "brazierBottom" },
+    { "tx": 13, "ty": 10, "tileId": "brazierTop", "zlayer": "above" },
+    { "tx": 18, "ty": 11, "tileId": "brazierBottom" },
+    { "tx": 18, "ty": 10, "tileId": "brazierTop", "zlayer": "above" }
+  ],
+  "npcSpawnTiles": [],
+  "ambientNpcSprites": [],
+  "npcs": [
+    {
+      "id": "ghost-mayor-aldous",
+      "name": "Mayor Aldous",
+      "sprite": "hub-npc-elder",
+      "isGhost": true,
+      "tx": 15,
+      "ty": 12,
+      "dialogue": [
+        "Welcome to Gravemoor! Population: technically zero. Spiritually: thriving.",
+        "I was mayor when I died and nobody's run against me since. Democracy at its finest.",
+        "We're dead, not rude. Wipe your feet and you're welcome anywhere in town."
+      ]
+    },
+    {
+      "id": "restless-merchant-mora",
+      "name": "Merchant Mora",
+      "sprite": "hub-npc-merchant",
+      "isGhost": true,
+      "tx": 19,
+      "ty": 13,
+      "dialogue": [
+        "Two hundred years of stock and not a single customer. Until you.",
+        "Money means little to the dead, but haggling? Haggling is eternal.",
+        "The blight took the town, but it couldn't take the market spirit. Literally, in my case."
+      ],
+      "building": "mourning-hall"
+    },
+    {
+      "id": "grave-keeper-finch",
+      "name": "Keeper Finch",
+      "sprite": "hub-npc-scholar",
+      "isGhost": true,
+      "tx": 22,
+      "ty": 10,
+      "dialogue": [
+        "I kept the graves in life. Now I keep them in death. Job security, of a sort.",
+        "Some of my neighbours' remains have been... borrowed. Scattered. It's terribly undignified.",
+        "The dead sleep better when everything's where it should be. So would I."
+      ],
+      "building": "crypt-keep",
+      "questGive": "gravemoor-restless-remains",
+      "questReceive": "gravemoor-restless-remains"
+    }
+  ],
+  "interiors": {
+    "mourning-hall": {
+      "name": "The Mourning Hall",
+      "width": 9,
+      "height": 6,
+      "floorTileId": "cobblestoneFloor",
+      "wallTileId": "darkStone",
+      "decor": [
+        { "tx": 1, "ty": 1, "tileId": "candlestickUnlit" },
+        { "tx": 7, "ty": 1, "tileId": "candlestickUnlit" },
+        { "tx": 4, "ty": 1, "tileId": "bookshelfTop" },
+        { "tx": 4, "ty": 2, "tileId": "bookshelfBottom" },
+        { "tx": 2, "ty": 3, "tileId": "roundTableWithCloth" }
+      ],
+      "exits": []
+    },
+    "crypt-keep": {
+      "name": "The Crypt Keep",
+      "width": 8,
+      "height": 5,
+      "floorTileId": "stoneFloor",
+      "wallTileId": "darkStone",
+      "decor": [
+        { "tx": 1, "ty": 1, "tileId": "skull" },
+        { "tx": 6, "ty": 1, "tileId": "skull" },
+        { "tx": 3, "ty": 1, "tileId": "bookshelfTop" },
+        { "tx": 3, "ty": 2, "tileId": "bookshelfBottom" },
+        { "tx": 5, "ty": 3, "tileId": "chest" }
+      ],
+      "exits": []
+    }
+  }
+}

--- a/web/src/data/hub/gravemoor/questDefs.json
+++ b/web/src/data/hub/gravemoor/questDefs.json
@@ -1,0 +1,37 @@
+{
+  "quests": [
+    {
+      "id": "gravemoor-restless-remains",
+      "title": "The Restless Remains",
+      "type": "fetch",
+      "giverNpcId": "grave-keeper-finch",
+      "receiverNpcId": "grave-keeper-finch",
+      "offerDialogue": "Something has been digging in the cemetery — scattering the remains of three of my oldest residents about the town. They cannot rest like this, and frankly their complaints are constant. Gather them up and bring them home, won't you?",
+      "activeDialogue": "Three sets of remains, scattered around town. They'll be the suspiciously chatty skulls.",
+      "completeDialogue": "Home at last, all three. Listen... silence. Blessed, dignified silence. The dead of Gravemoor thank you — and unlike most, they mean it eternally.",
+      "steps": [
+        {
+          "key": "remains",
+          "type": "collect",
+          "pickupIds": ["remains-1", "remains-2", "remains-3"],
+          "required": 3
+        }
+      ],
+      "reward": {
+        "crystals": 70,
+        "collectible": {
+          "id": "gravemoor-lantern",
+          "name": "Mourner's Lantern",
+          "icon": "🏮",
+          "desc": "A small lantern that burns with a cold blue flame. The dead find it comforting."
+        }
+      }
+    }
+  ],
+  "pickupItems": [
+    { "id": "remains-1", "tx": 3, "ty": 9, "tileId": "skull", "questId": "gravemoor-restless-remains" },
+    { "id": "remains-2", "tx": 26, "ty": 16, "tileId": "skull", "questId": "gravemoor-restless-remains" },
+    { "id": "remains-3", "tx": 10, "ty": 19, "tileId": "skull", "questId": "gravemoor-restless-remains" }
+  ],
+  "blockedPaths": []
+}

--- a/web/src/data/hub/harrowfield/config.json
+++ b/web/src/data/hub/harrowfield/config.json
@@ -1,0 +1,157 @@
+{
+  "mapW": 960,
+  "mapH": 704,
+  "townName": "Harrowfield",
+  "environment": "farmland",
+  "avatarStart": { "tx": 15, "ty": 20 },
+  "exitTiles": [
+    { "tx": 15, "ty": 21, "screen": "worldmap" },
+    { "tx": 16, "ty": 21, "screen": "worldmap" }
+  ],
+  "areas": [
+    { "id": "harrowfield-fields", "name": "The Fields", "tx": 2, "ty": 11, "tw": 10, "th": 9 },
+    { "id": "harrowfield-green", "name": "Village Green", "tx": 10, "ty": 9, "tw": 9, "th": 4 }
+  ],
+  "streets": [
+    { "rect": [15, 2, 16, 21] },
+    { "rect": [3, 10, 27, 11] },
+    { "rect": [22, 12, 23, 14] }
+  ],
+  "buildings": [
+    {
+      "id": "farmhouse",
+      "rect": [3, 2, 9, 8],
+      "wall": "woodWall",
+      "roof": "strawRoof",
+      "doors": [
+        { "tx": 3, "ty": 1, "hideSign": true, "buildingId": "farmhouse" }
+      ]
+    },
+    {
+      "id": "barn",
+      "rect": [20, 2, 27, 9],
+      "wall": "woodenSlats",
+      "roof": "strawRoof",
+      "doors": [
+        { "tx": 3, "ty": 1, "hideSign": true, "buildingId": "barn" }
+      ]
+    },
+    {
+      "id": "mill-cottage",
+      "rect": [19, 14, 25, 19],
+      "wall": "woodWall",
+      "roof": "strawRoof",
+      "doors": [
+        { "tx": 3, "ty": 1, "hideSign": true, "buildingId": "mill-cottage" }
+      ]
+    }
+  ],
+  "exteriorDecor": [
+    { "comment": "ploughed fields west of the lane" },
+    { "tx": 3, "ty": 13, "bundleID": "ploughed-field-6x5", "zlayer": "below" },
+    { "comment": "scarecrow watching the field" },
+    { "tx": 10, "ty": 14, "tileId": "scarecrowBottom" },
+    { "tx": 10, "ty": 13, "tileId": "scarecrowTop", "zlayer": "above" },
+    { "comment": "hay and farm clutter" },
+    { "tx": 11, "ty": 16, "tileId": "hayStack" },
+    { "tx": 12, "ty": 18, "tileId": "hayStack" },
+    { "tx": 19, "ty": 12, "tileId": "hayStack" },
+    { "tx": 28, "ty": 8, "tileId": "logPile" },
+    { "tx": 18, "ty": 9, "tileId": "barrel" },
+    { "tx": 12, "ty": 9, "tileId": "stoneWell" },
+    { "comment": "hedgerow trees" },
+    { "tx": 1, "ty": 4, "bundleID": "mixed-tree-cluster-V", "zlayer": "solid" },
+    { "tx": 12, "ty": 3, "bundleID": "light-tree", "zlayer": "solid" },
+    { "tx": 27, "ty": 16, "bundleID": "mixed-tree-cluster-V", "zlayer": "solid" },
+    { "tx": 2, "ty": 19, "bundleID": "light-tree", "zlayer": "solid" },
+    { "tx": 17, "ty": 13, "tileId": "whiteFlower" },
+    { "tx": 13, "ty": 12, "tileId": "whiteFlower" }
+  ],
+  "npcSpawnTiles": [],
+  "ambientNpcSprites": ["hub-npc-supplies"],
+  "npcs": [
+    {
+      "id": "elder-maeve",
+      "name": "Elder Maeve",
+      "sprite": "hub-npc-elder",
+      "tx": 13,
+      "ty": 9,
+      "dialogue": [
+        "Harrowfield feeds half the kingdom and gets thanked by none of it.",
+        "The scarecrows have been... moving. Pip says I imagine it. Pip didn't grow up here.",
+        "Stay for the harvest supper if you can. We owe travellers more kindness than we used to show."
+      ],
+      "building": "farmhouse"
+    },
+    {
+      "id": "farmhand-pip",
+      "name": "Farmhand Pip",
+      "sprite": "hub-npc-supplies",
+      "tx": 6,
+      "ty": 11,
+      "dialogue": [
+        "Sowing, hoeing, mowing. The fields don't care what day it is.",
+        "Three seed-grain sacks have gone missing. Maeve will have my ears if they're not found.",
+        "The scarecrow moved again last night. I'm not paid enough to ask it why."
+      ],
+      "questGive": "harrowfield-seed-grain",
+      "questReceive": "harrowfield-seed-grain"
+    },
+    {
+      "id": "miller-rook",
+      "name": "Miller Rook",
+      "sprite": "hub-npc-merchant",
+      "tx": 18,
+      "ty": 13,
+      "dialogue": [
+        "Flour, meal, and gossip — ground fresh daily.",
+        "The road south to the capital used to be safe. Now even the king's road has tolls of the unofficial kind.",
+        "Bread prices in Crownhaven would make you weep. My prices will merely sting."
+      ],
+      "building": "mill-cottage"
+    }
+  ],
+  "interiors": {
+    "farmhouse": {
+      "name": "Maeve's Farmhouse",
+      "width": 8,
+      "height": 5,
+      "floorTileId": "woodFloor",
+      "wallTileId": "woodWall",
+      "decor": [
+        { "tx": 1, "ty": 1, "tileId": "sack" },
+        { "tx": 2, "ty": 1, "tileId": "barrel" },
+        { "tx": 5, "ty": 2, "tileId": "roundTable" },
+        { "tx": 6, "ty": 3, "tileId": "stool" }
+      ],
+      "exits": []
+    },
+    "barn": {
+      "name": "The Great Barn",
+      "width": 9,
+      "height": 6,
+      "floorTileId": "woodFloor",
+      "wallTileId": "woodenSlats",
+      "decor": [
+        { "tx": 1, "ty": 1, "tileId": "hayStack" },
+        { "tx": 2, "ty": 1, "tileId": "hayStack" },
+        { "tx": 6, "ty": 1, "tileId": "pileOfSacks" },
+        { "tx": 7, "ty": 1, "tileId": "crate" }
+      ],
+      "exits": []
+    },
+    "mill-cottage": {
+      "name": "Rook's Mill",
+      "width": 8,
+      "height": 4,
+      "floorTileId": "woodFloor",
+      "wallTileId": "woodWall",
+      "decor": [
+        { "tx": 1, "ty": 1, "tileId": "pileOfSacks" },
+        { "tx": 2, "ty": 1, "tileId": "sack" },
+        { "tx": 5, "ty": 1, "tileId": "barrel" }
+      ],
+      "exits": []
+    }
+  }
+}

--- a/web/src/data/hub/harrowfield/questDefs.json
+++ b/web/src/data/hub/harrowfield/questDefs.json
@@ -1,0 +1,31 @@
+{
+  "quests": [
+    {
+      "id": "harrowfield-seed-grain",
+      "title": "The Seed Grain",
+      "type": "fetch",
+      "giverNpcId": "farmhand-pip",
+      "receiverNpcId": "farmhand-pip",
+      "offerDialogue": "Three sacks of next season's seed grain have vanished from the barn. If they're not found before sowing, there's no harvest, and if there's no harvest, Elder Maeve gets creative with chores. Please. Help me.",
+      "activeDialogue": "Three seed sacks, scattered somewhere around the village. Whoever took them didn't carry them far.",
+      "completeDialogue": "All three! The sowing's saved and so are my ears. Maeve never needs to know — here, your share of my enormous relief.",
+      "steps": [
+        {
+          "key": "grain",
+          "type": "collect",
+          "pickupIds": ["seed-sack-1", "seed-sack-2", "seed-sack-3"],
+          "required": 3
+        }
+      ],
+      "reward": {
+        "crystals": 50
+      }
+    }
+  ],
+  "pickupItems": [
+    { "id": "seed-sack-1", "tx": 2, "ty": 9, "tileId": "sack", "questId": "harrowfield-seed-grain" },
+    { "id": "seed-sack-2", "tx": 26, "ty": 12, "tileId": "sack", "questId": "harrowfield-seed-grain" },
+    { "id": "seed-sack-3", "tx": 13, "ty": 19, "tileId": "sack", "questId": "harrowfield-seed-grain" }
+  ],
+  "blockedPaths": []
+}

--- a/web/src/data/hub/hollowmere/config.json
+++ b/web/src/data/hub/hollowmere/config.json
@@ -1,0 +1,132 @@
+{
+  "mapW": 896,
+  "mapH": 640,
+  "townName": "Hollowmere",
+  "environment": "ruins",
+  "avatarStart": { "tx": 13, "ty": 17 },
+  "exitTiles": [
+    { "tx": 12, "ty": 18, "screen": "worldmap" },
+    { "tx": 13, "ty": 18, "screen": "worldmap" }
+  ],
+  "areas": [
+    { "id": "hollowmere-hollow", "name": "The Hollow", "tx": 10, "ty": 10, "tw": 8, "th": 5 }
+  ],
+  "streets": [
+    { "rect": [12, 2, 14, 18] },
+    { "rect": [4, 10, 24, 11] },
+    { "rect": [6, 12, 7, 14] }
+  ],
+  "buildings": [
+    {
+      "id": "broken-hall",
+      "rect": [4, 2, 11, 8],
+      "wall": "woodenSlats",
+      "roof": "strawRoof",
+      "doors": [
+        { "tx": 4, "ty": 1, "hideSign": true, "buildingId": "broken-hall" }
+      ]
+    },
+    {
+      "id": "fang-den",
+      "rect": [17, 3, 24, 9],
+      "wall": "darkStone",
+      "roof": "greySlateRoof",
+      "doors": [
+        { "tx": 3, "ty": 1, "hideSign": true, "buildingId": "fang-den" }
+      ]
+    }
+  ],
+  "exteriorDecor": [
+    { "comment": "the witch's corner" },
+    { "tx": 8, "ty": 13, "tileId": "cauldren" },
+    { "tx": 9, "ty": 14, "tileId": "bottlesOfLiquor" },
+    { "tx": 7, "ty": 15, "tileId": "bunchOfHerbs" },
+    { "comment": "monster-town clutter" },
+    { "tx": 16, "ty": 12, "tileId": "skull" },
+    { "tx": 20, "ty": 13, "tileId": "barrel" },
+    { "tx": 21, "ty": 12, "tileId": "openCrate" },
+    { "tx": 4, "ty": 9, "tileId": "logPile" },
+    { "tx": 23, "ty": 16, "tileId": "smallRock" },
+    { "tx": 16, "ty": 16, "tileId": "largeStump" },
+    { "comment": "the dark wood presses close" },
+    { "tx": 2, "ty": 4, "bundleID": "dark-tree-cluster-V", "zlayer": "solid" },
+    { "tx": 14, "ty": 4, "bundleID": "dark-tree", "zlayer": "solid" },
+    { "tx": 25, "ty": 12, "bundleID": "dark-tree-cluster-V", "zlayer": "solid" },
+    { "tx": 2, "ty": 14, "bundleID": "dark-tree", "zlayer": "solid" },
+    { "tx": 19, "ty": 17, "bundleID": "dead-tree", "zlayer": "solid" },
+    { "tx": 0, "ty": 9, "bundleID": "dark-tree-column-4", "zlayer": "solid" }
+  ],
+  "npcSpawnTiles": [],
+  "ambientNpcSprites": [],
+  "npcs": [
+    {
+      "id": "ogrim-the-bouncer",
+      "name": "Ogrim the Bouncer",
+      "sprite": "hub-npc-soldier",
+      "tx": 15,
+      "ty": 11,
+      "dialogue": [
+        "Rules of Hollowmere: no biting before sundown, no howling indoors, no heroes.",
+        "You smell like a hero. Lucky for you, I'm off duty.",
+        "We're monsters, not animals. The animals live in the nice town down south."
+      ],
+      "building": "fang-den"
+    },
+    {
+      "id": "fang-the-fence",
+      "name": "Fang the Fence",
+      "sprite": "hub-npc-merchant",
+      "tx": 19,
+      "ty": 11,
+      "dialogue": [
+        "Buying, selling, no questions. Especially no questions about the inventory.",
+        "The undead up at Gravemoor are lovely neighbours. Quiet. Very quiet.",
+        "Everything here fell off a cart. A very specific, very unlucky cart."
+      ]
+    },
+    {
+      "id": "hedge-witch-morwen",
+      "name": "Hedge-Witch Morwen",
+      "sprite": "hub-npc-scholar",
+      "tx": 8,
+      "ty": 12,
+      "dialogue": [
+        "The cauldron's gone cold and my joints know it. I need moonherb, and plenty of it.",
+        "Hollowmere takes in what other towns turn away. Werewolves, ogres, tax dodgers.",
+        "Don't touch the bottles. Some of them are potions. Some of them are relatives."
+      ],
+      "questGive": "hollowmere-witch-brew",
+      "questReceive": "hollowmere-witch-brew"
+    }
+  ],
+  "interiors": {
+    "broken-hall": {
+      "name": "The Broken Hall",
+      "width": 8,
+      "height": 5,
+      "floorTileId": "woodFloor",
+      "wallTileId": "woodenSlats",
+      "decor": [
+        { "tx": 1, "ty": 1, "tileId": "barrel" },
+        { "tx": 2, "ty": 1, "tileId": "skull" },
+        { "tx": 5, "ty": 2, "tileId": "roundTable" },
+        { "tx": 6, "ty": 3, "tileId": "stool" }
+      ],
+      "exits": []
+    },
+    "fang-den": {
+      "name": "The Fang & Flagon",
+      "width": 8,
+      "height": 5,
+      "floorTileId": "woodFloor",
+      "wallTileId": "darkStone",
+      "decor": [
+        { "tx": 1, "ty": 1, "tileId": "bottlesOfLiquor" },
+        { "tx": 2, "ty": 1, "tileId": "barrel" },
+        { "tx": 5, "ty": 1, "tileId": "skull" },
+        { "tx": 4, "ty": 2, "tileId": "roundTable" }
+      ],
+      "exits": []
+    }
+  }
+}

--- a/web/src/data/hub/hollowmere/questDefs.json
+++ b/web/src/data/hub/hollowmere/questDefs.json
@@ -1,0 +1,34 @@
+{
+  "quests": [
+    {
+      "id": "hollowmere-witch-brew",
+      "title": "The Cold Cauldron",
+      "type": "fetch",
+      "giverNpcId": "hedge-witch-morwen",
+      "receiverNpcId": "hedge-witch-morwen",
+      "offerDialogue": "My joint-ease brew needs moonherb — three good bunches of it. It grows wild around the hollow, wherever the dark trees thin out. Fetch it for me and half of Hollowmere walks easier this winter. The other half slithers, but they appreciate the gesture.",
+      "activeDialogue": "Three bunches of moonherb, growing around the edges of town. It glows faintly. Or hums. Sometimes both.",
+      "completeDialogue": "Fresh moonherb! The cauldron bubbles tonight. Here — your cut, and some free advice: if Ogrim offers you a drink, ask what's in it FIRST.",
+      "steps": [
+        {
+          "key": "herbs",
+          "type": "collect",
+          "pickupIds": ["moonherb-1", "moonherb-2", "moonherb-3"],
+          "required": 3
+        }
+      ],
+      "reward": {
+        "crystals": 65,
+        "friendship": {
+          "hedge-witch-morwen": 15
+        }
+      }
+    }
+  ],
+  "pickupItems": [
+    { "id": "moonherb-1", "tx": 3, "ty": 12, "tileId": "bunchOfHerbs", "questId": "hollowmere-witch-brew" },
+    { "id": "moonherb-2", "tx": 16, "ty": 14, "tileId": "bunchOfHerbs", "questId": "hollowmere-witch-brew" },
+    { "id": "moonherb-3", "tx": 24, "ty": 17, "tileId": "bunchOfHerbs", "questId": "hollowmere-witch-brew" }
+  ],
+  "blockedPaths": []
+}

--- a/web/src/data/hub/hubWorldFactory.ts
+++ b/web/src/data/hub/hubWorldFactory.ts
@@ -1,5 +1,5 @@
 import { createHubLocationData, createHubQuestData, HubLocationBundle, HubQuestBundle } from "./loader";
-import ravenwatch_config from './ravenwatch/config.json' 
+import ravenwatch_config from './ravenwatch/config.json'
 import rawQuestConfig from './ravenwatch/questDefs.json'
 
 import ironholdkeep_config from './ironholdkeep/config.json'
@@ -7,6 +7,37 @@ import ironholdkeep_quests from './ironholdkeep/questDefs.json'
 
 import millhaven_config from './millhaven/config.json'
 import millhaven_quests from './millhaven/questDefs.json'
+
+import thornwoodcamp_config from './thornwoodcamp/config.json'
+import thornwoodcamp_quests from './thornwoodcamp/questDefs.json'
+
+import capitalcity_config from './capitalcity/config.json'
+import capitalcity_quests from './capitalcity/questDefs.json'
+
+import royalpalace_config from './royalpalace/config.json'
+import royalpalace_quests from './royalpalace/questDefs.json'
+
+import saltmereport_config from './saltmereport/config.json'
+import saltmereport_quests from './saltmereport/questDefs.json'
+
+import gearford_config from './gearford/config.json'
+import gearford_quests from './gearford/questDefs.json'
+
+import harrowfield_config from './harrowfield/config.json'
+import harrowfield_quests from './harrowfield/questDefs.json'
+
+import appleford_config from './appleford/config.json'
+import appleford_quests from './appleford/questDefs.json'
+
+import gravemoor_config from './gravemoor/config.json'
+import gravemoor_quests from './gravemoor/questDefs.json'
+
+import hollowmere_config from './hollowmere/config.json'
+import hollowmere_quests from './hollowmere/questDefs.json'
+
+import dreadspirecitadel_config from './dreadspirecitadel/config.json'
+import dreadspirecitadel_quests from './dreadspirecitadel/questDefs.json'
+
 import { HubQuestDef } from "./questDefs";
 
 
@@ -20,51 +51,88 @@ export interface RawQuestPickupItem {
   chain?: string
   requireTouch?: boolean
 }
-export type MapId = 'ravenwatch' | 'ironholdkeep' | 'millhaven'
+export type MapId =
+  | 'ravenwatch'
+  | 'ironholdkeep'
+  | 'millhaven'
+  | 'thornwoodcamp'
+  | 'capitalcity'
+  | 'royalpalace'
+  | 'saltmereport'
+  | 'gearford'
+  | 'harrowfield'
+  | 'appleford'
+  | 'gravemoor'
+  | 'hollowmere'
+  | 'dreadspirecitadel'
 export type QuestDefsJson = { pickupItems?: RawQuestPickupItem[]; [key: string]: unknown }
 export const QUEST_DEFS_BY_MAP: Record<MapId, QuestDefsJson> = {
   ravenwatch: rawQuestConfig as QuestDefsJson,
   millhaven: millhaven_quests as  QuestDefsJson,
-    ironholdkeep: ironholdkeep_quests as QuestDefsJson,
-
+  ironholdkeep: ironholdkeep_quests as QuestDefsJson,
+  thornwoodcamp: thornwoodcamp_quests as QuestDefsJson,
+  capitalcity: capitalcity_quests as QuestDefsJson,
+  royalpalace: royalpalace_quests as QuestDefsJson,
+  saltmereport: saltmereport_quests as QuestDefsJson,
+  gearford: gearford_quests as QuestDefsJson,
+  harrowfield: harrowfield_quests as QuestDefsJson,
+  appleford: appleford_quests as QuestDefsJson,
+  gravemoor: gravemoor_quests as QuestDefsJson,
+  hollowmere: hollowmere_quests as QuestDefsJson,
+  dreadspirecitadel: dreadspirecitadel_quests as QuestDefsJson,
 }
 
 
 export const RAVENWATCH = createHubLocationData(ravenwatch_config)
 export const IRONHOLDKEEP = createHubLocationData(ironholdkeep_config)
 export const MILLHAVE = createHubLocationData(millhaven_config)
+export const THORNWOODCAMP = createHubLocationData(thornwoodcamp_config)
+export const CAPITALCITY = createHubLocationData(capitalcity_config)
+export const ROYALPALACE = createHubLocationData(royalpalace_config)
+export const SALTMEREPORT = createHubLocationData(saltmereport_config)
+export const GEARFORD = createHubLocationData(gearford_config)
+export const HARROWFIELD = createHubLocationData(harrowfield_config)
+export const APPLEFORD = createHubLocationData(appleford_config)
+export const GRAVEMOOR = createHubLocationData(gravemoor_config)
+export const HOLLOWMERE = createHubLocationData(hollowmere_config)
+export const DREADSPIRECITADEL = createHubLocationData(dreadspirecitadel_config)
 
 export const RAVENWATCH_QUESTS = createHubQuestData(rawQuestConfig)
 export const IRONHOLDKEEP_QUESTS  = createHubQuestData(ironholdkeep_quests)
 export const MILLHAVE_QUESTS  = createHubQuestData(millhaven_quests)
+export const THORNWOODCAMP_QUESTS = createHubQuestData(thornwoodcamp_quests)
+export const CAPITALCITY_QUESTS = createHubQuestData(capitalcity_quests)
+export const ROYALPALACE_QUESTS = createHubQuestData(royalpalace_quests)
+export const SALTMEREPORT_QUESTS = createHubQuestData(saltmereport_quests)
+export const GEARFORD_QUESTS = createHubQuestData(gearford_quests)
+export const HARROWFIELD_QUESTS = createHubQuestData(harrowfield_quests)
+export const APPLEFORD_QUESTS = createHubQuestData(appleford_quests)
+export const GRAVEMOOR_QUESTS = createHubQuestData(gravemoor_quests)
+export const HOLLOWMERE_QUESTS = createHubQuestData(hollowmere_quests)
+export const DREADSPIRECITADEL_QUESTS = createHubQuestData(dreadspirecitadel_quests)
 
+const ALL_QUEST_BUNDLES: HubQuestBundle[] = [
+  RAVENWATCH_QUESTS,
+  IRONHOLDKEEP_QUESTS,
+  MILLHAVE_QUESTS,
+  THORNWOODCAMP_QUESTS,
+  CAPITALCITY_QUESTS,
+  ROYALPALACE_QUESTS,
+  SALTMEREPORT_QUESTS,
+  GEARFORD_QUESTS,
+  HARROWFIELD_QUESTS,
+  APPLEFORD_QUESTS,
+  GRAVEMOOR_QUESTS,
+  HOLLOWMERE_QUESTS,
+  DREADSPIRECITADEL_QUESTS,
+]
 
 export const ALL_QUESTS : HubQuestBundle = {
-    HUB_QUEST_DEFS: [  
-          ... RAVENWATCH_QUESTS.HUB_QUEST_DEFS,
-    ... IRONHOLDKEEP_QUESTS.HUB_QUEST_DEFS,
-    ... MILLHAVE_QUESTS.HUB_QUEST_DEFS,
-    ],
-  INN_RUMOURS: [  
-      ... RAVENWATCH_QUESTS.INN_RUMOURS ?? [],
-    ... IRONHOLDKEEP_QUESTS.INN_RUMOURS ?? [],
-    ... MILLHAVE_QUESTS.INN_RUMOURS ?? [],
-  ],
-  FRIENDSHIP_DIALOGUE:{ 
-       ... RAVENWATCH_QUESTS.FRIENDSHIP_DIALOGUE,
-    ... IRONHOLDKEEP_QUESTS.FRIENDSHIP_DIALOGUE,
-    ... MILLHAVE_QUESTS.FRIENDSHIP_DIALOGUE,
- },
-  HUB_PICKUP_ITEMS:[  
-       ... RAVENWATCH_QUESTS.HUB_PICKUP_ITEMS,
-    ... IRONHOLDKEEP_QUESTS.HUB_PICKUP_ITEMS,
-    ... MILLHAVE_QUESTS.HUB_PICKUP_ITEMS,
-  ],
-  HUB_BLOCKED_PATHS:[ 
-       ... RAVENWATCH_QUESTS.HUB_BLOCKED_PATHS,
-    ...IRONHOLDKEEP_QUESTS.HUB_BLOCKED_PATHS,
-    ...MILLHAVE_QUESTS.HUB_BLOCKED_PATHS,
-  ],
+  HUB_QUEST_DEFS:    ALL_QUEST_BUNDLES.flatMap(b => b.HUB_QUEST_DEFS),
+  INN_RUMOURS:       ALL_QUEST_BUNDLES.flatMap(b => b.INN_RUMOURS ?? []),
+  FRIENDSHIP_DIALOGUE: Object.assign({}, ...ALL_QUEST_BUNDLES.map(b => b.FRIENDSHIP_DIALOGUE)),
+  HUB_PICKUP_ITEMS:  ALL_QUEST_BUNDLES.flatMap(b => b.HUB_PICKUP_ITEMS),
+  HUB_BLOCKED_PATHS: ALL_QUEST_BUNDLES.flatMap(b => b.HUB_BLOCKED_PATHS),
 }
 
 export const ALL_QUEST_DEFS = [
@@ -73,9 +141,7 @@ export const ALL_QUEST_DEFS = [
 
 
 export const FRIENDSHIP_DIALOGUE = {
-  ...RAVENWATCH_QUESTS.FRIENDSHIP_DIALOGUE,
-  ...IRONHOLDKEEP_QUESTS.FRIENDSHIP_DIALOGUE,
-  ...MILLHAVE_QUESTS.FRIENDSHIP_DIALOGUE,
+  ...ALL_QUESTS.FRIENDSHIP_DIALOGUE,
 }
 
 export interface LocationEntry {
@@ -91,4 +157,14 @@ export const LOCATION_REGISTRY: Record<string, LocationEntry> = {
   'ravenwatch':    { locationData: RAVENWATCH,  locationQuests: RAVENWATCH_QUESTS,  questDefs: RAVENWATCH_QUESTS.HUB_QUEST_DEFS },
   'ironhold-keep': { locationData: IRONHOLDKEEP, locationQuests:IRONHOLDKEEP_QUESTS, questDefs: IRONHOLDKEEP_QUESTS.HUB_QUEST_DEFS },
   'millhaven':     { locationData: MILLHAVE, locationQuests:MILLHAVE_QUESTS, questDefs: MILLHAVE_QUESTS.HUB_QUEST_DEFS },
+  'thornwood-camp':     { locationData: THORNWOODCAMP, locationQuests: THORNWOODCAMP_QUESTS, questDefs: THORNWOODCAMP_QUESTS.HUB_QUEST_DEFS },
+  'capital-city':       { locationData: CAPITALCITY, locationQuests: CAPITALCITY_QUESTS, questDefs: CAPITALCITY_QUESTS.HUB_QUEST_DEFS },
+  'royal-palace':       { locationData: ROYALPALACE, locationQuests: ROYALPALACE_QUESTS, questDefs: ROYALPALACE_QUESTS.HUB_QUEST_DEFS },
+  'saltmere-port':      { locationData: SALTMEREPORT, locationQuests: SALTMEREPORT_QUESTS, questDefs: SALTMEREPORT_QUESTS.HUB_QUEST_DEFS },
+  'gearford':           { locationData: GEARFORD, locationQuests: GEARFORD_QUESTS, questDefs: GEARFORD_QUESTS.HUB_QUEST_DEFS },
+  'harrowfield':        { locationData: HARROWFIELD, locationQuests: HARROWFIELD_QUESTS, questDefs: HARROWFIELD_QUESTS.HUB_QUEST_DEFS },
+  'appleford':          { locationData: APPLEFORD, locationQuests: APPLEFORD_QUESTS, questDefs: APPLEFORD_QUESTS.HUB_QUEST_DEFS },
+  'gravemoor':          { locationData: GRAVEMOOR, locationQuests: GRAVEMOOR_QUESTS, questDefs: GRAVEMOOR_QUESTS.HUB_QUEST_DEFS },
+  'hollowmere':         { locationData: HOLLOWMERE, locationQuests: HOLLOWMERE_QUESTS, questDefs: HOLLOWMERE_QUESTS.HUB_QUEST_DEFS },
+  'dreadspire-citadel': { locationData: DREADSPIRECITADEL, locationQuests: DREADSPIRECITADEL_QUESTS, questDefs: DREADSPIRECITADEL_QUESTS.HUB_QUEST_DEFS },
 }

--- a/web/src/data/hub/royalpalace/config.json
+++ b/web/src/data/hub/royalpalace/config.json
@@ -1,0 +1,121 @@
+{
+  "mapW": 896,
+  "mapH": 768,
+  "townName": "Royal Palace",
+  "environment": "citadel",
+  "avatarStart": { "tx": 13, "ty": 21 },
+  "exitTiles": [
+    { "tx": 13, "ty": 22, "screen": "worldmap" },
+    { "tx": 14, "ty": 22, "screen": "worldmap" }
+  ],
+  "areas": [
+    { "id": "palace-gardens", "name": "The Royal Gardens", "tx": 4, "ty": 13, "tw": 20, "th": 8 }
+  ],
+  "streets": [
+    { "rect": [12, 13, 15, 22] },
+    { "rect": [4, 14, 23, 15] },
+    { "rect": [12, 18, 15, 19] }
+  ],
+  "buildings": [
+    {
+      "id": "palace",
+      "rect": [6, 2, 21, 12],
+      "wall": "ornateStone",
+      "roof": "blueSlateRoof",
+      "doors": [
+        { "tx": 7, "ty": 1, "hideSign": true, "buildingId": "palace" },
+        { "tx": 8, "ty": 1, "hideSign": true, "buildingId": "palace" }
+      ]
+    }
+  ],
+  "exteriorDecor": [
+    { "comment": "garden fountain" },
+    { "tx": 17, "ty": 16, "bundleID": "fountain", "zlayer": "solid" },
+    { "comment": "garden trees and flowers" },
+    { "tx": 4, "ty": 17, "bundleID": "light-tree", "zlayer": "solid" },
+    { "tx": 8, "ty": 17, "bundleID": "light-tree", "zlayer": "solid" },
+    { "tx": 22, "ty": 13, "bundleID": "light-tree", "zlayer": "solid" },
+    { "tx": 2, "ty": 13, "bundleID": "light-tree", "zlayer": "solid" },
+    { "tx": 6, "ty": 16, "tileId": "whiteFlower" },
+    { "tx": 10, "ty": 16, "tileId": "whiteFlower" },
+    { "tx": 16, "ty": 20, "tileId": "whiteFlower" },
+    { "tx": 20, "ty": 16, "tileId": "whiteFlower" },
+    { "comment": "fences along the south garden wall, gap at the gate" },
+    { "tx": 9, "ty": 21, "tileId": "ironFenceLeftRight", "zlayer": "above" },
+    { "tx": 10, "ty": 21, "tileId": "ironFenceLeftRight", "zlayer": "above" },
+    { "tx": 11, "ty": 21, "tileId": "ironFenceLeft", "zlayer": "above" },
+    { "tx": 16, "ty": 21, "tileId": "ironFenceRight", "zlayer": "above" },
+    { "tx": 17, "ty": 21, "tileId": "ironFenceLeftRight", "zlayer": "above" },
+    { "tx": 18, "ty": 21, "tileId": "ironFenceLeftRight", "zlayer": "above" },
+    { "comment": "entrance braziers" },
+    { "tx": 12, "ty": 13, "tileId": "brazierBottom" },
+    { "tx": 12, "ty": 12, "tileId": "brazierTop", "zlayer": "above" },
+    { "tx": 15, "ty": 13, "tileId": "brazierBottom" },
+    { "tx": 15, "ty": 12, "tileId": "brazierTop", "zlayer": "above" }
+  ],
+  "npcSpawnTiles": [],
+  "ambientNpcSprites": ["hub-npc-soldier"],
+  "npcs": [
+    {
+      "id": "royal-herald",
+      "name": "Herald Fanshawe",
+      "sprite": "hub-npc-scholar",
+      "tx": 10,
+      "ty": 14,
+      "dialogue": [
+        "Presenting: you. To no one in particular. It's been a slow morning.",
+        "Their Majesties are in session. The gardens, however, receive all visitors.",
+        "Protocol is the art of standing in the right place while important things happen elsewhere."
+      ]
+    },
+    {
+      "id": "palace-guard",
+      "name": "Guardsman Brick",
+      "sprite": "hub-npc-soldier",
+      "tx": 16,
+      "ty": 14,
+      "dialogue": [
+        "Move along. Or stand there. You're not technically breaking any rules.",
+        "Nobody enters the throne room without an appointment. Or a mop. The mop people go everywhere.",
+        "Quietest post in the kingdom, this. I've counted the fence railings twice."
+      ]
+    },
+    {
+      "id": "royal-steward",
+      "name": "Steward Marigold",
+      "sprite": "hub-npc-elder",
+      "tx": 8,
+      "ty": 18,
+      "dialogue": [
+        "Oh dear, oh dear. The coronation regalia — misplaced! Again!",
+        "The ceremonial pendant, the jubilee gift, and the vault key. Scattered about the gardens by that dreadful wind.",
+        "If the regalia isn't recovered before the next audience, I shall simply expire."
+      ],
+      "questGive": "palace-lost-regalia",
+      "questReceive": "palace-lost-regalia"
+    }
+  ],
+  "interiors": {
+    "palace": {
+      "name": "The Throne Hall",
+      "width": 16,
+      "height": 9,
+      "floorTileId": "cobblestoneFloor",
+      "wallTileId": "ornateStone",
+      "decor": [
+        { "comment": "honour guard armour flanking the hall" },
+        { "tx": 2, "ty": 1, "tileId": "suitOfArmourTop" },
+        { "tx": 2, "ty": 2, "tileId": "suitOfArmourBottom" },
+        { "tx": 13, "ty": 1, "tileId": "suitOfArmourTop" },
+        { "tx": 13, "ty": 2, "tileId": "suitOfArmourBottom" },
+        { "tx": 6, "ty": 1, "tileId": "shieldMounted" },
+        { "tx": 9, "ty": 1, "tileId": "shieldMounted" },
+        { "tx": 7, "ty": 1, "tileId": "swordMountedLeft" },
+        { "tx": 8, "ty": 1, "tileId": "swordMountedRight" },
+        { "tx": 4, "ty": 3, "tileId": "roundTableWithCloth" },
+        { "tx": 11, "ty": 3, "tileId": "roundTableWithCloth" }
+      ],
+      "exits": []
+    }
+  }
+}

--- a/web/src/data/hub/royalpalace/questDefs.json
+++ b/web/src/data/hub/royalpalace/questDefs.json
@@ -1,0 +1,37 @@
+{
+  "quests": [
+    {
+      "id": "palace-lost-regalia",
+      "title": "The Lost Regalia",
+      "type": "fetch",
+      "giverNpcId": "royal-steward",
+      "receiverNpcId": "royal-steward",
+      "offerDialogue": "The coronation regalia has been scattered across the gardens — the ceremonial pendant, the jubilee gift, and the vault key. The next royal audience is in mere hours. Recover all three and you will have the palace's eternal, slightly flustered gratitude.",
+      "activeDialogue": "The pendant, the gift, and the key — somewhere in the gardens. Do hurry, but mind the flowerbeds.",
+      "completeDialogue": "The pendant! The gift! The key! All accounted for. The audience is saved, and so am I. The crown rewards competence — here, with my compliments.",
+      "steps": [
+        {
+          "key": "regalia",
+          "type": "collect",
+          "pickupIds": ["regalia-pendant", "regalia-gift", "regalia-key"],
+          "required": 3
+        }
+      ],
+      "reward": {
+        "crystals": 90,
+        "collectible": {
+          "id": "royal-seal",
+          "name": "Royal Seal",
+          "icon": "👑",
+          "desc": "A wax seal bearing the crown's sigil, given for service to the palace."
+        }
+      }
+    }
+  ],
+  "pickupItems": [
+    { "id": "regalia-pendant", "tx": 5, "ty": 19, "tileId": "pendant", "questId": "palace-lost-regalia" },
+    { "id": "regalia-gift", "tx": 21, "ty": 19, "tileId": "gift", "questId": "palace-lost-regalia" },
+    { "id": "regalia-key", "tx": 24, "ty": 16, "tileId": "key", "questId": "palace-lost-regalia" }
+  ],
+  "blockedPaths": []
+}

--- a/web/src/data/hub/saltmereport/config.json
+++ b/web/src/data/hub/saltmereport/config.json
@@ -1,0 +1,179 @@
+{
+  "mapW": 1152,
+  "mapH": 896,
+  "townName": "Saltmere Port",
+  "environment": "coast",
+  "avatarStart": { "tx": 2, "ty": 14 },
+  "exitTiles": [
+    { "tx": 1, "ty": 14, "screen": "worldmap" },
+    { "tx": 1, "ty": 15, "screen": "worldmap" }
+  ],
+  "areas": [
+    { "id": "saltmere-docks", "name": "The Docks", "tx": 28, "ty": 2, "tw": 8, "th": 24 },
+    { "id": "saltmere-quay", "name": "Quayside Market", "tx": 4, "ty": 11, "tw": 22, "th": 7 }
+  ],
+  "streets": [
+    { "rect": [33, 0, 35, 27], "pathType": "water1" },
+    { "rect": [32, 6, 32, 22], "pathType": "water1" },
+    { "rect": [30, 2, 31, 25] },
+    { "rect": [2, 13, 30, 15] },
+    { "rect": [13, 16, 15, 23] },
+    { "rect": [24, 5, 25, 12] },
+    { "rect": [7, 5, 8, 12] }
+  ],
+  "buildings": [
+    {
+      "id": "harbourmaster",
+      "rect": [21, 4, 28, 10],
+      "wall": "woodenSlats",
+      "roof": "strawRoof",
+      "doors": [
+        { "tx": 3, "ty": 1, "hideSign": true, "buildingId": "harbourmaster" }
+      ]
+    },
+    {
+      "id": "fish-market",
+      "rect": [3, 4, 11, 10],
+      "wall": "woodenSlats",
+      "roof": "yellowSlateRoof",
+      "doors": [
+        { "tx": 4, "ty": 1, "hideSign": true, "buildingId": "fish-market" }
+      ]
+    },
+    {
+      "id": "sailors-inn",
+      "rect": [9, 17, 18, 24],
+      "wall": "tudorFrame",
+      "roof": "redSlateRoof",
+      "doors": [
+        { "tx": 5, "ty": 1, "hideSign": true, "buildingId": "sailors-inn" }
+      ]
+    }
+  ],
+  "exteriorDecor": [
+    { "comment": "dock clutter along the waterfront" },
+    { "tx": 30, "ty": 4, "tileId": "barrel" },
+    { "tx": 31, "ty": 4, "tileId": "barrel" },
+    { "tx": 30, "ty": 10, "tileId": "crate" },
+    { "tx": 31, "ty": 17, "tileId": "pileOfSacks" },
+    { "tx": 30, "ty": 22, "tileId": "crate" },
+    { "tx": 31, "ty": 23, "tileId": "openCrate" },
+    { "tx": 29, "ty": 7, "tileId": "sack" },
+    { "comment": "lilypads and rocks in the shallows" },
+    { "tx": 33, "ty": 5, "tileId": "smallLilypad" },
+    { "tx": 34, "ty": 13, "tileId": "largeLilypad" },
+    { "tx": 33, "ty": 21, "tileId": "smallLilypad" },
+    { "tx": 32, "ty": 3, "tileId": "smallRock" },
+    { "comment": "quayside market" },
+    { "tx": 19, "ty": 12, "tileId": "stoneWell" },
+    { "tx": 4, "ty": 12, "tileId": "mushroomBasket" },
+    { "tx": 26, "ty": 12, "tileId": "barrel" },
+    { "comment": "greenery on the landward side" },
+    { "tx": 3, "ty": 20, "bundleID": "mixed-tree-cluster-V", "zlayer": "solid" },
+    { "tx": 21, "ty": 19, "bundleID": "mixed-tree-cluster-V", "zlayer": "solid" },
+    { "tx": 2, "ty": 2, "bundleID": "light-tree", "zlayer": "solid" },
+    { "tx": 16, "ty": 2, "bundleID": "light-tree", "zlayer": "solid" }
+  ],
+  "npcSpawnTiles": [],
+  "ambientNpcSprites": ["hub-npc-fisherman", "hub-npc-merchant"],
+  "npcs": [
+    {
+      "id": "harbourmaster-vane",
+      "name": "Harbourmaster Vane",
+      "sprite": "hub-npc-merchant",
+      "tx": 26,
+      "ty": 12,
+      "dialogue": [
+        "Every crate, every barrel, every gull on this dock answers to me.",
+        "Cargo's been going missing off the quay. The manifest doesn't lie — people do.",
+        "Pirates to the north, smugglers to the south, and paperwork in every direction."
+      ],
+      "building": "harbourmaster",
+      "questGive": "saltmere-lost-cargo",
+      "questReceive": "saltmere-rum-run"
+    },
+    {
+      "id": "fishwife-pearl",
+      "name": "Fishwife Pearl",
+      "sprite": "hub-npc-fisherman",
+      "tx": 9,
+      "ty": 12,
+      "dialogue": [
+        "Fresh off the morning tide! Mostly fresh. Define fresh.",
+        "The reef's been restless. Old Salt says it's the kraken. Old Salt says a lot of things.",
+        "You buy, or you're blocking the stall."
+      ],
+      "building": "fish-market"
+    },
+    {
+      "id": "dockhand-tam",
+      "name": "Dockhand Tam",
+      "sprite": "hub-npc-supplies",
+      "tx": 29,
+      "ty": 16,
+      "dialogue": [
+        "Lift with the knees. That's the whole job, really.",
+        "Found a barrel of navy rum washed up under the south pier. Above my pay grade, that.",
+        "Vane counts the cargo twice. I count my fingers after every shift."
+      ],
+      "questGive": "saltmere-rum-run"
+    },
+    {
+      "id": "old-salt",
+      "name": "Old Salt",
+      "sprite": "hub-npc-elder",
+      "tx": 17,
+      "ty": 16,
+      "dialogue": [
+        "Forty years before the mast, and the sea still won't tell me her secrets.",
+        "There's a cove east of here no chart will show you. The pirates make sure of that.",
+        "The tide takes and the tide gives back. Rarely the same things, mind."
+      ]
+    }
+  ],
+  "interiors": {
+    "harbourmaster": {
+      "name": "The Harbour Office",
+      "width": 8,
+      "height": 5,
+      "floorTileId": "woodFloor",
+      "wallTileId": "woodWall",
+      "decor": [
+        { "tx": 1, "ty": 1, "tileId": "bookshelfTop" },
+        { "tx": 1, "ty": 2, "tileId": "bookshelfBottom" },
+        { "tx": 5, "ty": 1, "tileId": "chest" },
+        { "tx": 6, "ty": 1, "tileId": "crate" }
+      ],
+      "exits": []
+    },
+    "fish-market": {
+      "name": "The Fish Market",
+      "width": 9,
+      "height": 5,
+      "floorTileId": "woodFloor",
+      "wallTileId": "woodenSlats",
+      "decor": [
+        { "tx": 1, "ty": 1, "tileId": "barrel" },
+        { "tx": 2, "ty": 1, "tileId": "barrel" },
+        { "tx": 6, "ty": 1, "tileId": "openCrate" },
+        { "tx": 7, "ty": 1, "tileId": "crate" }
+      ],
+      "exits": []
+    },
+    "sailors-inn": {
+      "name": "The Brined Anchor",
+      "width": 10,
+      "height": 6,
+      "floorTileId": "woodFloor",
+      "wallTileId": "woodWall",
+      "decor": [
+        { "tx": 1, "ty": 1, "tileId": "barrel" },
+        { "tx": 2, "ty": 1, "tileId": "bottlesOfLiquor" },
+        { "tx": 6, "ty": 2, "tileId": "roundTable" },
+        { "tx": 7, "ty": 3, "tileId": "stool" },
+        { "tx": 5, "ty": 3, "tileId": "stool" }
+      ],
+      "exits": []
+    }
+  }
+}

--- a/web/src/data/hub/saltmereport/questDefs.json
+++ b/web/src/data/hub/saltmereport/questDefs.json
@@ -1,0 +1,66 @@
+{
+  "quests": [
+    {
+      "id": "saltmere-lost-cargo",
+      "title": "The Missing Manifest",
+      "type": "fetch",
+      "giverNpcId": "harbourmaster-vane",
+      "receiverNpcId": "harbourmaster-vane",
+      "offerDialogue": "Three crates walked off my quay this week. Crates don't walk — so either I have thieves or very ambitious crabs. They can't have gone far. Find them and the port owes you a favour.",
+      "activeDialogue": "Three crates, stamped with the port seal. Check along the waterfront and behind the inn.",
+      "completeDialogue": "All three, seals intact. So — lazy thieves, not clever ones. Good. The manifest balances and so do my nerves. Here's your finder's fee.",
+      "steps": [
+        {
+          "key": "crates",
+          "type": "collect",
+          "pickupIds": ["port-crate-1", "port-crate-2", "port-crate-3"],
+          "required": 3
+        }
+      ],
+      "reward": {
+        "crystals": 60
+      }
+    },
+    {
+      "id": "saltmere-rum-run",
+      "title": "Barrel of Trouble",
+      "type": "chain",
+      "giverNpcId": "dockhand-tam",
+      "receiverNpcId": "harbourmaster-vane",
+      "offerDialogue": "There's a barrel of navy rum washed up under the south pier. If the watch finds it first, someone hangs for smuggling, and I've got the only ladder down there. Fish it out and hand it to Vane official-like, would you? Keeps everyone's neck the right length.",
+      "activeDialogue": {
+        "barrel": "The barrel's under the south pier, past the inn. Can't miss it — it's the only barrel acting suspicious.",
+        "deliver": "Got it? Straight to Harbourmaster Vane. Walk natural."
+      },
+      "completeDialogue": "Salvaged cargo, declared properly? You may be the first honest soul on this dock in a decade. The navy pays recovery rates — your share, as the law requires.",
+      "steps": [
+        {
+          "key": "barrel",
+          "type": "collect",
+          "pickupIds": ["navy-rum-barrel"],
+          "required": 1
+        },
+        {
+          "key": "deliver",
+          "type": "deliver",
+          "targetNpcId": "harbourmaster-vane",
+          "required": 1
+        }
+      ],
+      "reward": {
+        "crystals": 75,
+        "friendship": {
+          "dockhand-tam": 15,
+          "harbourmaster-vane": 10
+        }
+      }
+    }
+  ],
+  "pickupItems": [
+    { "id": "port-crate-1", "tx": 28, "ty": 25, "tileId": "crate", "questId": "saltmere-lost-cargo" },
+    { "id": "port-crate-2", "tx": 20, "ty": 16, "tileId": "crate", "questId": "saltmere-lost-cargo" },
+    { "id": "port-crate-3", "tx": 2, "ty": 11, "tileId": "crate", "questId": "saltmere-lost-cargo" },
+    { "id": "navy-rum-barrel", "tx": 6, "ty": 25, "tileId": "barrel", "questId": "saltmere-rum-run" }
+  ],
+  "blockedPaths": []
+}

--- a/web/src/data/hub/thornwoodcamp/config.json
+++ b/web/src/data/hub/thornwoodcamp/config.json
@@ -1,0 +1,59 @@
+{
+  "mapW": 640,
+  "mapH": 640,
+  "townName": "Thornwood Camp",
+  "environment": "camp",
+  "avatarStart": { "tx": 10, "ty": 13 },
+  "exitTiles": [
+    { "tx": 9, "ty": 14, "screen": "worldmap" },
+    { "tx": 10, "ty": 14, "screen": "worldmap" }
+  ],
+  "areas": [
+    { "id": "thornwood-fire", "name": "The Campfire", "tx": 6, "ty": 6, "tw": 9, "th": 9 }
+  ],
+  "streets": [
+    { "rect": [9, 11, 10, 14] },
+    { "rect": [8, 8, 12, 12] }
+  ],
+  "buildings": [],
+  "exteriorDecor": [
+    { "comment": "the campfire at the heart of the camp" },
+    { "tx": 10, "ty": 10, "tileId": "campfireUnlit" },
+    { "comment": "supplies ring around the fire" },
+    { "tx": 8, "ty": 9, "tileId": "logPile" },
+    { "tx": 8, "ty": 10, "tileId": "logPile" },
+    { "tx": 12, "ty": 9, "tileId": "crate" },
+    { "tx": 12, "ty": 11, "tileId": "barrel" },
+    { "tx": 9, "ty": 8, "tileId": "sack" },
+    { "tx": 11, "ty": 8, "tileId": "smallRock" },
+    { "tx": 13, "ty": 13, "tileId": "largeStump" },
+    { "tx": 6, "ty": 12, "tileId": "largeStump" },
+    { "comment": "thornwood treeline" },
+    { "tx": 2, "ty": 4, "bundleID": "dark-tree-cluster-V", "zlayer": "solid" },
+    { "tx": 15, "ty": 4, "bundleID": "dark-tree-cluster-V", "zlayer": "solid" },
+    { "tx": 3, "ty": 15, "bundleID": "dark-tree-cluster-V", "zlayer": "solid" },
+    { "tx": 14, "ty": 15, "bundleID": "mixed-tree-cluster-V", "zlayer": "solid" },
+    { "tx": 7, "ty": 2, "bundleID": "mixed-tree-cluster-V", "zlayer": "solid" },
+    { "tx": 0, "ty": 9, "bundleID": "dark-tree-column-4", "zlayer": "solid" },
+    { "tx": 17, "ty": 9, "bundleID": "dark-tree-column-4", "zlayer": "solid" }
+  ],
+  "npcSpawnTiles": [],
+  "ambientNpcSprites": [],
+  "npcs": [
+    {
+      "id": "warden-rell",
+      "name": "Warden Rell",
+      "sprite": "hub-npc-soldier",
+      "tx": 11,
+      "ty": 10,
+      "dialogue": [
+        "Thornwood Camp. Last warm fire between Ironhold and the river.",
+        "I keep the fire and the fire keeps the wolves honest. Simple arrangement.",
+        "Firewood's running low again. The forest gives, but only if you go and fetch."
+      ],
+      "questGive": "thornwood-embers-low",
+      "questReceive": "thornwood-embers-low"
+    }
+  ],
+  "interiors": {}
+}

--- a/web/src/data/hub/thornwoodcamp/questDefs.json
+++ b/web/src/data/hub/thornwoodcamp/questDefs.json
@@ -1,0 +1,31 @@
+{
+  "quests": [
+    {
+      "id": "thornwood-embers-low",
+      "title": "Embers Low",
+      "type": "fetch",
+      "giverNpcId": "warden-rell",
+      "receiverNpcId": "warden-rell",
+      "offerDialogue": "The fire's down to embers and my knees are too old for hauling. There are three piles of cut wood out by the treeline — bring them in and the camp stays warm another week.",
+      "activeDialogue": "Three wood piles, out by the treeline. Mind the brambles.",
+      "completeDialogue": "Good haul. The fire will see out the week now. Sit a while if you like — the camp's yours as much as mine.",
+      "steps": [
+        {
+          "key": "firewood",
+          "type": "collect",
+          "pickupIds": ["thornwood-firewood-1", "thornwood-firewood-2", "thornwood-firewood-3"],
+          "required": 3
+        }
+      ],
+      "reward": {
+        "crystals": 25
+      }
+    }
+  ],
+  "pickupItems": [
+    { "id": "thornwood-firewood-1", "tx": 4, "ty": 7, "tileId": "logPile", "questId": "thornwood-embers-low" },
+    { "id": "thornwood-firewood-2", "tx": 16, "ty": 13, "tileId": "logPile", "questId": "thornwood-embers-low" },
+    { "id": "thornwood-firewood-3", "tx": 12, "ty": 17, "tileId": "logPile", "questId": "thornwood-embers-low" }
+  ],
+  "blockedPaths": []
+}

--- a/web/src/data/world/worldMap.json
+++ b/web/src/data/world/worldMap.json
@@ -5,16 +5,17 @@
     "ravenwatch": {
       "id": "ravenwatch", "type": "town", "label": "Ravenwatch", "description": "",
       "row": 0, "col": 0, "rowCols": 1, "childIds": [],
-      "x": 350, "y": 450,
-      "connections": ["forest-path", "bridge-battle"],
+      "x": 800, "y": 700,
+      "connections": ["forest-path", "bridge-battle", "b-east-road", "b-south-road", "b-west-road"],
       "locationKey": "ravenwatch",
       "decorTiles": [49, 50],
       "decorOffsets": [[-32, -16], [0, -16]]
     },
+
     "forest-path": {
       "id": "forest-path", "type": "battle", "label": "Forest Path", "description": "",
       "row": 1, "col": 0, "rowCols": 2, "childIds": [],
-      "x": 210, "y": 360,
+      "x": 700, "y": 612,
       "connections": ["ironhold-keep"],
       "requiredClears": [],
       "battleConfig": { "actId": "act1", "nodeId": "goblin-raid" },
@@ -23,7 +24,7 @@
     "bridge-battle": {
       "id": "bridge-battle", "type": "battle", "label": "Bridge Battle", "description": "",
       "row": 1, "col": 1, "rowCols": 2, "childIds": [],
-      "x": 490, "y": 360,
+      "x": 900, "y": 612,
       "connections": ["ironhold-keep"],
       "requiredClears": [],
       "battleConfig": { "actId": "act1", "nodeId": "shrine" },
@@ -32,7 +33,7 @@
     "ironhold-keep": {
       "id": "ironhold-keep", "type": "castle", "label": "Ironhold Keep", "description": "",
       "row": 2, "col": 0, "rowCols": 1, "childIds": [],
-      "x": 350, "y": 270,
+      "x": 800, "y": 535,
       "connections": ["thornwood-camp"],
       "requiredClears": ["forest-path|bridge-battle"],
       "locationKey": "ironhold-keep",
@@ -42,16 +43,17 @@
     "thornwood-camp": {
       "id": "thornwood-camp", "type": "camp", "label": "Thornwood Camp", "description": "",
       "row": 3, "col": 0, "rowCols": 1, "childIds": [],
-      "x": 350, "y": 185,
+      "x": 800, "y": 455,
       "connections": ["river-battle"],
       "requiredClears": ["forest-path|bridge-battle"],
+      "locationKey": "thornwood-camp",
       "decorTiles": [8, 11],
       "decorOffsets": [[-20, -16], [8, -8]]
     },
     "river-battle": {
       "id": "river-battle", "type": "battle", "label": "River Crossing", "description": "",
       "row": 4, "col": 0, "rowCols": 1, "childIds": [],
-      "x": 350, "y": 105,
+      "x": 800, "y": 375,
       "connections": ["millhaven"],
       "requiredClears": ["forest-path|bridge-battle"],
       "battleConfig": { "actId": "act2", "nodeId": "iron-gate" },
@@ -60,12 +62,284 @@
     "millhaven": {
       "id": "millhaven", "type": "town", "label": "Millhaven", "description": "",
       "row": 5, "col": 0, "rowCols": 1, "childIds": [],
-      "x": 350, "y": 30,
-      "connections": [],
+      "x": 800, "y": 295,
+      "connections": ["b-blight-fields", "b-crypt-road", "b-dread-gate"],
       "requiredClears": ["river-battle"],
       "locationKey": "millhaven",
       "decorTiles": [57, 58],
       "decorOffsets": [[-32, -16], [0, -16]]
+    },
+
+    "b-blight-fields": {
+      "id": "b-blight-fields", "type": "battle", "label": "Blighted Fields", "description": "",
+      "row": 6, "col": 0, "rowCols": 1, "childIds": [],
+      "x": 655, "y": 235,
+      "connections": ["gravemoor"],
+      "requiredClears": ["river-battle"],
+      "battleConfig": { "actId": "world", "nodeId": "b-blight-fields" },
+      "decorTiles": [29]
+    },
+    "gravemoor": {
+      "id": "gravemoor", "type": "town", "label": "Gravemoor", "description": "",
+      "row": 6, "col": 1, "rowCols": 1, "childIds": [],
+      "x": 545, "y": 180,
+      "connections": ["b-grave-mists"],
+      "requiredClears": ["b-blight-fields"],
+      "locationKey": "gravemoor",
+      "decorTiles": [49, 50],
+      "decorOffsets": [[-32, -16], [0, -16]]
+    },
+    "b-grave-mists": {
+      "id": "b-grave-mists", "type": "battle", "label": "Grave Mists", "description": "",
+      "row": 6, "col": 2, "rowCols": 1, "childIds": [],
+      "x": 600, "y": 95,
+      "connections": ["dreadspire-citadel"],
+      "requiredClears": ["b-blight-fields"],
+      "battleConfig": { "actId": "world", "nodeId": "b-grave-mists" },
+      "decorTiles": [29]
+    },
+    "b-crypt-road": {
+      "id": "b-crypt-road", "type": "battle", "label": "Crypt Road", "description": "",
+      "row": 7, "col": 0, "rowCols": 1, "childIds": [],
+      "x": 945, "y": 235,
+      "connections": ["hollowmere"],
+      "requiredClears": ["river-battle"],
+      "battleConfig": { "actId": "world", "nodeId": "b-crypt-road" },
+      "decorTiles": [29]
+    },
+    "hollowmere": {
+      "id": "hollowmere", "type": "town", "label": "Hollowmere", "description": "",
+      "row": 7, "col": 1, "rowCols": 1, "childIds": [],
+      "x": 1055, "y": 180,
+      "connections": ["b-howling-dark"],
+      "requiredClears": ["b-crypt-road"],
+      "locationKey": "hollowmere",
+      "decorTiles": [49, 50],
+      "decorOffsets": [[-32, -16], [0, -16]]
+    },
+    "b-howling-dark": {
+      "id": "b-howling-dark", "type": "battle", "label": "The Howling Dark", "description": "",
+      "row": 7, "col": 2, "rowCols": 1, "childIds": [],
+      "x": 1000, "y": 95,
+      "connections": ["dreadspire-citadel"],
+      "requiredClears": ["b-crypt-road"],
+      "battleConfig": { "actId": "world", "nodeId": "b-howling-dark" },
+      "decorTiles": [10]
+    },
+    "b-dread-gate": {
+      "id": "b-dread-gate", "type": "battle", "label": "Dreadspire Gate", "description": "",
+      "row": 8, "col": 0, "rowCols": 1, "childIds": [],
+      "x": 800, "y": 180,
+      "connections": ["dreadspire-citadel"],
+      "requiredClears": ["b-blight-fields|b-crypt-road"],
+      "battleConfig": { "actId": "world", "nodeId": "b-dread-gate" },
+      "decorTiles": [29]
+    },
+    "dreadspire-citadel": {
+      "id": "dreadspire-citadel", "type": "castle", "label": "Dreadspire Citadel", "description": "",
+      "row": 8, "col": 1, "rowCols": 1, "childIds": [],
+      "x": 800, "y": 75,
+      "connections": [],
+      "requiredClears": ["b-dread-gate|b-grave-mists|b-howling-dark"],
+      "locationKey": "dreadspire-citadel",
+      "decorTiles": [53, 54, 61, 62],
+      "decorOffsets": [[-32, -32], [0, -32], [-32, 0], [0, 0]]
+    },
+
+    "b-east-road": {
+      "id": "b-east-road", "type": "battle", "label": "Toll Road Ambush", "description": "",
+      "row": 9, "col": 0, "rowCols": 1, "childIds": [],
+      "x": 950, "y": 720,
+      "connections": ["appleford", "b-salt-marsh"],
+      "requiredClears": [],
+      "battleConfig": { "actId": "world", "nodeId": "b-east-road" },
+      "decorTiles": [28]
+    },
+    "appleford": {
+      "id": "appleford", "type": "town", "label": "Appleford", "description": "",
+      "row": 9, "col": 1, "rowCols": 1, "childIds": [],
+      "x": 1075, "y": 640,
+      "connections": ["b-orchard-raid"],
+      "requiredClears": ["b-east-road"],
+      "locationKey": "appleford",
+      "decorTiles": [56]
+    },
+    "b-orchard-raid": {
+      "id": "b-orchard-raid", "type": "battle", "label": "Orchard Raid", "description": "",
+      "row": 9, "col": 2, "rowCols": 1, "childIds": [],
+      "x": 1200, "y": 620,
+      "connections": ["saltmere-port"],
+      "requiredClears": ["b-east-road"],
+      "battleConfig": { "actId": "world", "nodeId": "b-orchard-raid" },
+      "decorTiles": [9]
+    },
+    "b-salt-marsh": {
+      "id": "b-salt-marsh", "type": "battle", "label": "Salt Marsh Crossing", "description": "",
+      "row": 10, "col": 0, "rowCols": 1, "childIds": [],
+      "x": 1090, "y": 780,
+      "connections": ["saltmere-port"],
+      "requiredClears": ["b-east-road"],
+      "battleConfig": { "actId": "world", "nodeId": "b-salt-marsh" },
+      "decorTiles": [16]
+    },
+    "saltmere-port": {
+      "id": "saltmere-port", "type": "port", "label": "Saltmere Port", "description": "",
+      "row": 10, "col": 1, "rowCols": 1, "childIds": [],
+      "x": 1320, "y": 700,
+      "connections": ["b-pirate-cove", "b-smugglers-landing"],
+      "requiredClears": ["b-salt-marsh|b-orchard-raid"],
+      "locationKey": "saltmere-port",
+      "decorTiles": [49, 50],
+      "decorOffsets": [[-32, -16], [0, -16]]
+    },
+    "b-pirate-cove": {
+      "id": "b-pirate-cove", "type": "battle", "label": "Pirate Cove", "description": "",
+      "row": 10, "col": 2, "rowCols": 1, "childIds": [],
+      "x": 1450, "y": 640,
+      "connections": [],
+      "requiredClears": ["b-salt-marsh|b-orchard-raid"],
+      "battleConfig": { "actId": "world", "nodeId": "b-pirate-cove" },
+      "decorTiles": [20]
+    },
+    "b-smugglers-landing": {
+      "id": "b-smugglers-landing", "type": "battle", "label": "Smuggler's Landing", "description": "",
+      "row": 11, "col": 0, "rowCols": 1, "childIds": [],
+      "x": 1300, "y": 930,
+      "connections": ["capital-city"],
+      "requiredClears": ["b-salt-marsh|b-orchard-raid|b-royal-checkpoint"],
+      "battleConfig": { "actId": "world", "nodeId": "b-smugglers-landing" },
+      "decorTiles": [16]
+    },
+
+    "b-south-road": {
+      "id": "b-south-road", "type": "battle", "label": "Old King's Road", "description": "",
+      "row": 12, "col": 0, "rowCols": 1, "childIds": [],
+      "x": 800, "y": 830,
+      "connections": ["harrowfield", "b-river-ford"],
+      "requiredClears": [],
+      "battleConfig": { "actId": "world", "nodeId": "b-south-road" },
+      "decorTiles": [28]
+    },
+    "harrowfield": {
+      "id": "harrowfield", "type": "town", "label": "Harrowfield", "description": "",
+      "row": 12, "col": 1, "rowCols": 1, "childIds": [],
+      "x": 665, "y": 905,
+      "connections": ["b-scarecrow-fields"],
+      "requiredClears": ["b-south-road"],
+      "locationKey": "harrowfield",
+      "decorTiles": [56]
+    },
+    "b-scarecrow-fields": {
+      "id": "b-scarecrow-fields", "type": "battle", "label": "Scarecrow Fields", "description": "",
+      "row": 12, "col": 2, "rowCols": 1, "childIds": [],
+      "x": 640, "y": 1020,
+      "connections": ["capital-city"],
+      "requiredClears": ["b-south-road"],
+      "battleConfig": { "actId": "world", "nodeId": "b-scarecrow-fields" },
+      "decorTiles": [9]
+    },
+    "b-river-ford": {
+      "id": "b-river-ford", "type": "battle", "label": "Southford Crossing", "description": "",
+      "row": 13, "col": 0, "rowCols": 1, "childIds": [],
+      "x": 900, "y": 920,
+      "connections": ["b-royal-checkpoint"],
+      "requiredClears": ["b-south-road"],
+      "battleConfig": { "actId": "world", "nodeId": "b-river-ford" },
+      "decorTiles": [18]
+    },
+    "b-royal-checkpoint": {
+      "id": "b-royal-checkpoint", "type": "battle", "label": "Royal Checkpoint", "description": "",
+      "row": 13, "col": 1, "rowCols": 1, "childIds": [],
+      "x": 870, "y": 1030,
+      "connections": ["capital-city"],
+      "requiredClears": ["b-river-ford"],
+      "battleConfig": { "actId": "world", "nodeId": "b-royal-checkpoint" },
+      "decorTiles": [18]
+    },
+    "capital-city": {
+      "id": "capital-city", "type": "town", "label": "Crownhaven", "description": "",
+      "row": 14, "col": 0, "rowCols": 1, "childIds": [],
+      "x": 800, "y": 1140,
+      "connections": ["royal-palace", "b-tournament"],
+      "requiredClears": ["b-royal-checkpoint|b-scarecrow-fields|b-smugglers-landing"],
+      "locationKey": "capital-city",
+      "decorTiles": [57, 58],
+      "decorOffsets": [[-32, -16], [0, -16]]
+    },
+    "royal-palace": {
+      "id": "royal-palace", "type": "castle", "label": "Royal Palace", "description": "",
+      "row": 14, "col": 1, "rowCols": 1, "childIds": [],
+      "x": 800, "y": 1255,
+      "connections": [],
+      "requiredClears": ["b-royal-checkpoint|b-scarecrow-fields|b-smugglers-landing"],
+      "locationKey": "royal-palace",
+      "decorTiles": [53, 54, 61, 62],
+      "decorOffsets": [[-32, -32], [0, -32], [-32, 0], [0, 0]]
+    },
+    "b-tournament": {
+      "id": "b-tournament", "type": "battle", "label": "Tournament Grounds", "description": "",
+      "row": 14, "col": 2, "rowCols": 1, "childIds": [],
+      "x": 950, "y": 1180,
+      "connections": [],
+      "requiredClears": ["b-royal-checkpoint|b-scarecrow-fields|b-smugglers-landing"],
+      "battleConfig": { "actId": "world", "nodeId": "b-tournament" },
+      "decorTiles": [28]
+    },
+
+    "b-west-road": {
+      "id": "b-west-road", "type": "battle", "label": "Quarry Road", "description": "",
+      "row": 15, "col": 0, "rowCols": 1, "childIds": [],
+      "x": 650, "y": 720,
+      "connections": ["b-mine-trouble"],
+      "requiredClears": [],
+      "battleConfig": { "actId": "world", "nodeId": "b-west-road" },
+      "decorTiles": [12]
+    },
+    "b-mine-trouble": {
+      "id": "b-mine-trouble", "type": "battle", "label": "Collapsed Mine", "description": "",
+      "row": 15, "col": 1, "rowCols": 1, "childIds": [],
+      "x": 530, "y": 660,
+      "connections": ["gearford"],
+      "requiredClears": ["b-west-road"],
+      "battleConfig": { "actId": "world", "nodeId": "b-mine-trouble" },
+      "decorTiles": [30]
+    },
+    "gearford": {
+      "id": "gearford", "type": "town", "label": "Gearford", "description": "",
+      "row": 15, "col": 2, "rowCols": 1, "childIds": [],
+      "x": 410, "y": 710,
+      "connections": ["b-smoke-fields", "b-foundry-gate", "b-bandit-toll"],
+      "requiredClears": ["b-mine-trouble"],
+      "locationKey": "gearford",
+      "decorTiles": [49, 50],
+      "decorOffsets": [[-32, -16], [0, -16]]
+    },
+    "b-smoke-fields": {
+      "id": "b-smoke-fields", "type": "battle", "label": "Smokefield Patrol", "description": "",
+      "row": 16, "col": 0, "rowCols": 1, "childIds": [],
+      "x": 300, "y": 640,
+      "connections": [],
+      "requiredClears": ["b-mine-trouble"],
+      "battleConfig": { "actId": "world", "nodeId": "b-smoke-fields" },
+      "decorTiles": [12]
+    },
+    "b-foundry-gate": {
+      "id": "b-foundry-gate", "type": "battle", "label": "Foundry Gate", "description": "",
+      "row": 16, "col": 1, "rowCols": 1, "childIds": [],
+      "x": 290, "y": 790,
+      "connections": [],
+      "requiredClears": ["b-mine-trouble"],
+      "battleConfig": { "actId": "world", "nodeId": "b-foundry-gate" },
+      "decorTiles": [12]
+    },
+    "b-bandit-toll": {
+      "id": "b-bandit-toll", "type": "battle", "label": "Bandit Toll", "description": "",
+      "row": 16, "col": 2, "rowCols": 1, "childIds": [],
+      "x": 520, "y": 860,
+      "connections": ["harrowfield"],
+      "requiredClears": ["b-mine-trouble|b-south-road"],
+      "battleConfig": { "actId": "world", "nodeId": "b-bandit-toll" },
+      "decorTiles": [28]
     }
   }
 }

--- a/web/src/game/questline.ts
+++ b/web/src/game/questline.ts
@@ -17,6 +17,7 @@ import act11Data from '../data/acts/act11.json'
 import act12Data from '../data/acts/act12.json'
 import act13Data    from '../data/acts/act13.json'
 import actFinaleData from '../data/acts/actfinale.json'
+import worldBattlesData from '../data/acts/worldbattles.json'
 import consumablesData from '../data/consumables.json'
 
 // ─── Consumables ──────────────────────────────────────────
@@ -895,6 +896,8 @@ export const ACT_11: Act = act11Data as Act
 export const ACT_12: Act = act12Data as Act
 export const ACT_13:     Act = act13Data    as Act
 export const ACT_FINALE: Act = actFinaleData as Act
+/** Standalone battles launched from the world map — never part of campaign progression. */
+export const ACT_WORLD: Act = worldBattlesData as Act
 
 export const ACTS: Record<string, Act> = {
   act1:  ACT_1,
@@ -911,6 +914,7 @@ export const ACTS: Record<string, Act> = {
   act12: ACT_12,
   act13:     ACT_13,
   actfinale: ACT_FINALE,
+  world:     ACT_WORLD,
 }
 
 // ─── Node history (persistent across runs) ───────────────


### PR DESCRIPTION
## Summary

Expands the overworld from 7 nodes in a line to a 36-node fractal/radial world centred on Ravenwatch, with 20 new battles and 9 new visitable locations (every named location now has its own hub).

### World map (`web/src/data/world/worldMap.json`)
- Radial layout on a 1600×1400 canvas, Ravenwatch at the centre, roads (`connections`) linking every node, difficulty ramping with distance.
- **North** (hardest): Blighted Fields / Crypt Road gate the undead towns **Gravemoor** and **Hollowmere**, converging on the evil castle **Dreadspire Citadel**.
- **East**: farming village **Appleford** and the port town **Saltmere Port**, with Pirate Cove and a Smuggler's Landing shortcut to the capital.
- **South**: farming hamlet **Harrowfield**, then the capital **Crownhaven** with the **Royal Palace** immediately beside it at the far south.
- **West**: industrial **Gearford** behind the Collapsed Mine, with foundry/smoke-field battles beyond.
- Existing node ids, locationKeys and `requiredClears` are unchanged (only positions/connections), so existing saves keep working.

### Battles (`web/src/data/acts/worldbattles.json`)
- New standalone `world` act with 20 battle definitions referenced via `battleConfig` — themed enemy decks (undead, monsters, pirates, royal knights, constructs, bandits), stats calibrated to the existing act difficulty curve (h5/HP150/6500ms → h28/HP260/3600ms). All card names validated against `cards.json`.
- The world act is excluded from the dev Skip-to-act menu and never enters campaign progression.

### Hubs (`web/src/data/hub/*`)
- 10 new hub folders (config + questDefs), each registered in `LOCATION_REGISTRY` / `MapId` / map editor: thornwoodcamp, capitalcity, royalpalace, saltmereport, gearford, harrowfield, appleford, gravemoor, hollowmere, dreadspirecitadel.
- Thornwood Camp is now visitable: 20×20 tiles with a campfire, Warden Rell, and a firewood fetch quest.
- Every location has NPCs (ghosts in the undead towns via `isGhost`) and 1–2 quests with pickups.

### Rendering / fixes
- World map scrolls to the player's current location on open; oversized maps stay fully scrollable (`margin: auto` + wrapper overflow fix).
- Bug fix: selecting Ravenwatch on the world map now resets `currentLocationKey`, so returning home after visiting another town renders Ravenwatch instead of the last-visited hub.

## Testing
- `tsc --noEmit`: clean except two pre-existing `GameGrid.tsx` errors already present on `main`.
- `vite build`: passes.
- `vitest run`: 164 files / 606 tests pass.
- Data validation: all 36 nodes' connections, `requiredClears`, and `battleConfig` references cross-checked; all enemy-deck card names exist in `cards.json`; all tile/bundle/material ids verified against the tile indexes.

https://claude.ai/code/session_014wnDahtPsmj6QRbufR1WAt

---
_Generated by [Claude Code](https://claude.ai/code/session_014wnDahtPsmj6QRbufR1WAt)_