### PR TITLE
Save tower defence runs so tab discards don't lose progress

### DIFF
--- a/web/src/components/minigames/TowerDefence.tsx
+++ b/web/src/components/minigames/TowerDefence.tsx
@@ -8,7 +8,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
   ENEMY_TEMPLATES,
   MilestoneUpgrade,
-  TDGameState, TDTargetingMode, TDTower,
+  TDGameState, TDLoadedSave, TDTargetingMode, TDTower,
   TDUpgradeType,
   TD_CELL_PX,
   TD_COLS,
@@ -22,10 +22,14 @@ import {
   calcGoldReward,
   calcTicketReward,
   chooseMilestoneUpgrade,
+  clearTDSave,
   createTDGame,
   generateWave,
+  loadTDSave,
   moveTower,
   placeTower, removeTower,
+  resumeTDGame,
+  saveTDGame,
   sellRefund,
   setTowerTargetingMode,
   startWave, tickTD, tickUnitsHomeOnly,
@@ -78,6 +82,10 @@ export function TowerDefence({ pool, mode, onDone, environment }: Props) {
   const [game, setGame] = useState<TDGameState>(() =>
     createTDGame(pool.map(p => p.template), mode, initialPlacements)
   )
+  // A run saved mid-game survives tab discards/reloads; the pool is saved with
+  // it so the resumed run keeps the exact roster it started with.
+  const [pendingResume, setPendingResume] = useState<TDLoadedSave | null>(() => loadTDSave(mode))
+  const [activePool, setActivePool] = useState<TowerPool[]>(pool)
   const [selected, setSelected] = useState<UnitTemplate | null>(null)
   const [hoveredTower, setHoveredTower] = useState<TDTower | null>(null)
   const [selectedTowerId, setSelectedTowerId] = useState<number | null>(null)
@@ -131,6 +139,42 @@ export function TowerDefence({ pool, mode, onDone, environment }: Props) {
       setGame(prev => startWave(prev))
     }
   }, [autoStart, game.phase, game.milestoneChoices])
+
+  // ── Save / resume ───────────────────────────────────────────────────────────
+  // Autosave so a tab discard (e.g. browser memory savers) or reload doesn't
+  // lose the run. Saves on every phase change and at most every 3s in between.
+  const lastSaveRef = useRef<{ at: number; phase: TDGameState['phase'] | null }>({ at: 0, phase: null })
+  useEffect(() => {
+    if (pendingResume) return
+    if (game.phase === 'victory' || game.phase === 'defeat') {
+      clearTDSave(mode)
+      return
+    }
+    if (game.phase === 'prep' && game.towers.length === 0) return
+    const now = Date.now()
+    if (lastSaveRef.current.phase === game.phase && now - lastSaveRef.current.at < 3000) return
+    lastSaveRef.current = { at: now, phase: game.phase }
+    saveTDGame(mode, game, activePool)
+  }, [game, mode, activePool, pendingResume])
+
+  function handleResume() {
+    if (!pendingResume) return
+    const restored = resumeTDGame(pendingResume.game)
+    setActivePool(pendingResume.pool)
+    prevLivesRef.current = restored.lives
+    setGame(restored)
+    setPendingResume(null)
+  }
+
+  function handleStartFresh() {
+    clearTDSave(mode)
+    setPendingResume(null)
+  }
+
+  function handleQuit() {
+    clearTDSave(mode)
+    onDone(reward)
+  }
 
   // ── Game loop ───────────────────────────────────────────────────────────────
 
@@ -211,7 +255,7 @@ export function TowerDefence({ pool, mode, onDone, environment }: Props) {
     // No tower selected, no tower at cell: place if a unit chip is chosen
     if (!selected || isOnPath(col, row)) return
     if (g.phase !== 'prep' && g.phase !== 'between' && g.phase !== 'wave' && g.phase !== 'milestone') return
-    const entry = pool.find(p => p.template.name === selected.name)
+    const entry = activePool.find(p => p.template.name === selected.name)
     if (!entry) return
     const next = placeTower(g, selected, entry.buildingName, col, row)
     if (next) setGame(next)
@@ -291,6 +335,31 @@ export function TowerDefence({ pool, mode, onDone, environment }: Props) {
     return cells
   }, [selectedTower, hoveredTower, selected, hoveredCell])
 
+  // ── Resume prompt ───────────────────────────────────────────────────────────
+
+  if (pendingResume) {
+    const saved = pendingResume.game
+    const minsAgo = Math.max(0, Math.round((Date.now() - pendingResume.savedAt) / 60000))
+    return (
+      <div className="td-root">
+        <div className="td-resume-prompt">
+          <div className="td-resume-title">⚔ DEFENCE IN PROGRESS</div>
+          <div className="td-resume-info">
+            Wave {saved.wavesCompleted + 1}/{TD_TOTAL_WAVES} · ❤️ {saved.lives} · 💧 {saved.mana} · ⭐ {saved.score}
+          </div>
+          <div className="td-resume-time">
+            saved {minsAgo < 1 ? 'moments' : `${minsAgo} min`} ago
+          </div>
+          <div className="td-resume-actions u-flex u-gap-4">
+            <button className="action-btn action-btn--gold" onClick={handleResume}>▶ RESUME</button>
+            <button className="action-btn action-btn--danger" onClick={handleStartFresh}>START FRESH</button>
+          </div>
+          <div className="td-resume-hint">Starting fresh abandons the saved run — no rewards are paid out for it.</div>
+        </div>
+      </div>
+    )
+  }
+
   // ── End screen ──────────────────────────────────────────────────────────────
 
   if (game.phase === 'victory' || game.phase === 'defeat') {
@@ -354,7 +423,7 @@ export function TowerDefence({ pool, mode, onDone, environment }: Props) {
           >⚡Auto</button>
         </div>
 
-        <button className="action-btn action-btn--danger td-header-btn" onClick={() => onDone(reward)}>
+        <button className="action-btn action-btn--danger td-header-btn" onClick={handleQuit}>
           ✕
         </button>
       </div>
@@ -530,7 +599,7 @@ export function TowerDefence({ pool, mode, onDone, environment }: Props) {
       })()}
 
       {/* ── Bottom panel ── */}
-      <BottomPanel lastLog={lastLog} canPlaceTowers={canPlaceTowers} selected={selected} selectedTower={selectedTower} pool={pool} game={game} towerCost={towerCost} handleSelectUnit={handleSelectUnit} />
+      <BottomPanel lastLog={lastLog} canPlaceTowers={canPlaceTowers} selected={selected} selectedTower={selectedTower} pool={activePool} game={game} towerCost={towerCost} handleSelectUnit={handleSelectUnit} />
     </div>
   )
 

--- a/web/src/components/minigames/TowerDefence.tsx
+++ b/web/src/components/minigames/TowerDefence.tsx
@@ -79,13 +79,17 @@ export function TowerDefence({ pool, mode, onDone, environment }: Props) {
   const initialPlacements: Record<string, number> = {}
   for (const entry of pool) initialPlacements[entry.template.name] = entry.total
 
+  // A run saved mid-game survives tab discards/reloads and is resumed
+  // automatically; the pool is saved with it so the resumed run keeps the
+  // exact roster it started with. Quitting (✕) clears the save.
+  const initialSave = useMemo<TDLoadedSave | null>(() => loadTDSave(mode), [mode])
+
   const [game, setGame] = useState<TDGameState>(() =>
-    createTDGame(pool.map(p => p.template), mode, initialPlacements)
+    initialSave
+      ? { ...resumeTDGame(initialSave.game), log: [...initialSave.game.log.slice(-9), '⟳ Resumed saved defence.'] }
+      : createTDGame(pool.map(p => p.template), mode, initialPlacements)
   )
-  // A run saved mid-game survives tab discards/reloads; the pool is saved with
-  // it so the resumed run keeps the exact roster it started with.
-  const [pendingResume, setPendingResume] = useState<TDLoadedSave | null>(() => loadTDSave(mode))
-  const [activePool, setActivePool] = useState<TowerPool[]>(pool)
+  const [activePool] = useState<TowerPool[]>(() => initialSave?.pool ?? pool)
   const [selected, setSelected] = useState<UnitTemplate | null>(null)
   const [hoveredTower, setHoveredTower] = useState<TDTower | null>(null)
   const [selectedTowerId, setSelectedTowerId] = useState<number | null>(null)
@@ -145,7 +149,6 @@ export function TowerDefence({ pool, mode, onDone, environment }: Props) {
   // lose the run. Saves on every phase change and at most every 3s in between.
   const lastSaveRef = useRef<{ at: number; phase: TDGameState['phase'] | null }>({ at: 0, phase: null })
   useEffect(() => {
-    if (pendingResume) return
     if (game.phase === 'victory' || game.phase === 'defeat') {
       clearTDSave(mode)
       return
@@ -155,21 +158,7 @@ export function TowerDefence({ pool, mode, onDone, environment }: Props) {
     if (lastSaveRef.current.phase === game.phase && now - lastSaveRef.current.at < 3000) return
     lastSaveRef.current = { at: now, phase: game.phase }
     saveTDGame(mode, game, activePool)
-  }, [game, mode, activePool, pendingResume])
-
-  function handleResume() {
-    if (!pendingResume) return
-    const restored = resumeTDGame(pendingResume.game)
-    setActivePool(pendingResume.pool)
-    prevLivesRef.current = restored.lives
-    setGame(restored)
-    setPendingResume(null)
-  }
-
-  function handleStartFresh() {
-    clearTDSave(mode)
-    setPendingResume(null)
-  }
+  }, [game, mode, activePool])
 
   function handleQuit() {
     clearTDSave(mode)
@@ -334,31 +323,6 @@ export function TowerDefence({ pool, mode, onDone, environment }: Props) {
     }
     return cells
   }, [selectedTower, hoveredTower, selected, hoveredCell])
-
-  // ── Resume prompt ───────────────────────────────────────────────────────────
-
-  if (pendingResume) {
-    const saved = pendingResume.game
-    const minsAgo = Math.max(0, Math.round((Date.now() - pendingResume.savedAt) / 60000))
-    return (
-      <div className="td-root">
-        <div className="td-resume-prompt">
-          <div className="td-resume-title">⚔ DEFENCE IN PROGRESS</div>
-          <div className="td-resume-info">
-            Wave {saved.wavesCompleted + 1}/{TD_TOTAL_WAVES} · ❤️ {saved.lives} · 💧 {saved.mana} · ⭐ {saved.score}
-          </div>
-          <div className="td-resume-time">
-            saved {minsAgo < 1 ? 'moments' : `${minsAgo} min`} ago
-          </div>
-          <div className="td-resume-actions u-flex u-gap-4">
-            <button className="action-btn action-btn--gold" onClick={handleResume}>▶ RESUME</button>
-            <button className="action-btn action-btn--danger" onClick={handleStartFresh}>START FRESH</button>
-          </div>
-          <div className="td-resume-hint">Starting fresh abandons the saved run — no rewards are paid out for it.</div>
-        </div>
-      </div>
-    )
-  }
 
   // ── End screen ──────────────────────────────────────────────────────────────
 

--- a/web/src/game/towerDefence.save.test.ts
+++ b/web/src/game/towerDefence.save.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+// towerDefence save helpers need localStorage — stub it before importing.
+let store = new Map<string, string>()
+let storageThrows = false
+const localStorageStub = {
+  getItem: (k: string) => { if (storageThrows) throw new Error('quota'); return store.get(k) ?? null },
+  setItem: (k: string, v: string) => { if (storageThrows) throw new Error('quota'); store.set(k, v) },
+  removeItem: (k: string) => { if (storageThrows) throw new Error('quota'); store.delete(k) },
+}
+vi.stubGlobal('localStorage', localStorageStub)
+
+const {
+  createTDGame, placeTower, saveTDGame, loadTDSave, clearTDSave, resumeTDGame,
+} = await import('./towerDefence')
+
+import type { UnitTemplate } from './types'
+import type { TDSavedPoolEntry } from './towerDefence'
+
+const TEMPLATE: UnitTemplate = {
+  name: 'Test Knight',
+  attack: 10,
+  maxHp: 100,
+  isWall: false,
+  bypassWall: false,
+  moveSpeed: 50,
+  attackRange: 60,
+  attackCooldownMs: 1000,
+}
+
+const POOL: TDSavedPoolEntry[] = [{ template: TEMPLATE, total: 3, buildingName: 'Barracks' }]
+
+function makeGame() {
+  return createTDGame([TEMPLATE], 'city', { [TEMPLATE.name]: 3 })
+}
+
+describe('tower defence save/resume', () => {
+  beforeEach(() => {
+    store = new Map()
+    storageThrows = false
+  })
+
+  it('round-trips an in-progress game, preserving Infinity nextWaveAt', () => {
+    let game = makeGame()
+    game = placeTower(game, TEMPLATE, 'Barracks', 0, 1)!
+    game = { ...game, wavesCompleted: 12, currentWaveIndex: 12, mana: 345, lives: 2, phase: 'wave' }
+    expect(game.nextWaveAt).toBe(Infinity)
+
+    saveTDGame('city', game, POOL)
+    const loaded = loadTDSave('city')
+
+    expect(loaded).not.toBeNull()
+    expect(loaded!.game).toEqual(game)
+    expect(loaded!.game.nextWaveAt).toBe(Infinity)
+    expect(loaded!.pool).toEqual(POOL)
+  })
+
+  it('round-trips a finite nextWaveAt', () => {
+    const game = { ...makeGame(), phase: 'between' as const, nextWaveAt: 9876 }
+    saveTDGame('city', game, POOL)
+    expect(loadTDSave('city')!.game.nextWaveAt).toBe(9876)
+  })
+
+  it('keeps city and collection saves in separate slots', () => {
+    saveTDGame('city', { ...makeGame(), mana: 111 }, POOL)
+    saveTDGame('collection', { ...makeGame(), mana: 222 }, POOL)
+    expect(loadTDSave('city')!.game.mana).toBe(111)
+    expect(loadTDSave('collection')!.game.mana).toBe(222)
+  })
+
+  it('does not offer finished games for resume', () => {
+    saveTDGame('city', { ...makeGame(), phase: 'victory' }, POOL)
+    expect(loadTDSave('city')).toBeNull()
+    saveTDGame('city', { ...makeGame(), phase: 'defeat' }, POOL)
+    expect(loadTDSave('city')).toBeNull()
+  })
+
+  it('returns null for missing, corrupt, or empty-pool saves', () => {
+    expect(loadTDSave('city')).toBeNull()
+    store.set('jarv_td_save_city', '{not json')
+    expect(loadTDSave('city')).toBeNull()
+    saveTDGame('city', makeGame(), [])
+    expect(loadTDSave('city')).toBeNull()
+  })
+
+  it('clearTDSave removes the save', () => {
+    saveTDGame('city', { ...makeGame(), phase: 'wave' }, POOL)
+    expect(loadTDSave('city')).not.toBeNull()
+    clearTDSave('city')
+    expect(loadTDSave('city')).toBeNull()
+  })
+
+  it('survives a throwing localStorage without crashing', () => {
+    storageThrows = true
+    expect(() => saveTDGame('city', makeGame(), POOL)).not.toThrow()
+    expect(loadTDSave('city')).toBeNull()
+    expect(() => clearTDSave('city')).not.toThrow()
+  })
+
+  it('resumeTDGame fast-forwards the ID counter past saved entities', () => {
+    let game = makeGame()
+    game = placeTower(game, TEMPLATE, 'Barracks', 0, 1)!
+    // Simulate a save whose IDs are far ahead of the fresh counter
+    const savedTower = { ...game.towers[0], id: 50 }
+    const saved = { ...game, towers: [savedTower], units: game.units.map(u => ({ ...u, towerId: 50 })) }
+
+    const resumed = resumeTDGame(saved)
+    const next = placeTower(resumed, TEMPLATE, 'Barracks', 2, 1)!
+    const newTower = next.towers.find(t => t.col === 2 && t.row === 1)!
+    expect(newTower.id).toBeGreaterThan(50)
+  })
+})

--- a/web/src/game/towerDefence.ts
+++ b/web/src/game/towerDefence.ts
@@ -1,6 +1,7 @@
 // ─── Tower Defence — pure game logic ──────────────────────────────────────────
 // No React imports. All state is plain objects; tick() returns a new state.
 
+import { logError } from '../logger'
 import { UnitTemplate, UnitTag, ProjectileType, getProjectileType } from './types'
 
 // ── Grid ──────────────────────────────────────────────────────────────────────
@@ -1285,6 +1286,93 @@ export function calcTicketReward(wavesCompleted: number): number {
 /** Compute city gold reward for city mode based on waves cleared. */
 export function calcGoldReward(wavesCompleted: number): number {
   return wavesCompleted * 2500
+}
+
+// ── Save / resume ─────────────────────────────────────────────────────────────
+// Persists an in-progress run to localStorage so a tab discard (e.g. browser
+// memory savers) or accidental reload doesn't lose the defence.
+
+export interface TDSavedPoolEntry {
+  template: UnitTemplate
+  total: number
+  buildingName: string
+}
+
+// nextWaveAt may be Infinity, which JSON cannot represent — stored as null
+type TDSavedGame = Omit<TDGameState, 'nextWaveAt'> & { nextWaveAt: number | null }
+
+interface TDSaveFile {
+  version: number
+  savedAt: number
+  pool: TDSavedPoolEntry[]
+  game: TDSavedGame
+}
+
+export interface TDLoadedSave {
+  game: TDGameState
+  pool: TDSavedPoolEntry[]
+  savedAt: number
+}
+
+const TD_SAVE_VERSION = 1
+function tdSaveKey(mode: 'collection' | 'city'): string {
+  return `jarv_td_save_${mode}`
+}
+
+export function saveTDGame(mode: 'collection' | 'city', game: TDGameState, pool: TDSavedPoolEntry[]): void {
+  try {
+    const file: TDSaveFile = {
+      version: TD_SAVE_VERSION,
+      savedAt: Date.now(),
+      pool,
+      game: { ...game, nextWaveAt: Number.isFinite(game.nextWaveAt) ? game.nextWaveAt : null },
+    }
+    localStorage.setItem(tdSaveKey(mode), JSON.stringify(file))
+  } catch (err) {
+    logError('saveTDGame failed', err as Record<string, unknown>)
+  }
+}
+
+export function loadTDSave(mode: 'collection' | 'city'): TDLoadedSave | null {
+  try {
+    const raw = localStorage.getItem(tdSaveKey(mode))
+    if (!raw) return null
+    const file = JSON.parse(raw) as TDSaveFile
+    if (file.version !== TD_SAVE_VERSION) return null
+    const g = file.game
+    if (!g || !Array.isArray(g.towers) || !Array.isArray(g.units) || !Array.isArray(g.enemies)) return null
+    if (g.phase === 'victory' || g.phase === 'defeat') return null
+    if (!Array.isArray(file.pool) || file.pool.length === 0) return null
+    return {
+      game: { ...g, nextWaveAt: g.nextWaveAt ?? Infinity },
+      pool: file.pool,
+      savedAt: file.savedAt,
+    }
+  } catch (err) {
+    logError('loadTDSave failed', err as Record<string, unknown>)
+    return null
+  }
+}
+
+export function clearTDSave(mode: 'collection' | 'city'): void {
+  try {
+    localStorage.removeItem(tdSaveKey(mode))
+  } catch {
+    // ignore — worst case a stale save lingers and the resume prompt reappears
+  }
+}
+
+/** Prepare a loaded save for play: fast-forward the module ID counter past
+ *  every ID in the save so newly spawned entities don't collide. */
+export function resumeTDGame(game: TDGameState): TDGameState {
+  let maxId = 0
+  for (const t of game.towers) maxId = Math.max(maxId, t.id)
+  for (const u of game.units) maxId = Math.max(maxId, u.id)
+  for (const e of game.enemies) maxId = Math.max(maxId, e.id)
+  for (const a of game.attackEvents) maxId = Math.max(maxId, a.id)
+  for (const h of game.hazards) maxId = Math.max(maxId, h.id)
+  if (maxId >= _nextId) _nextId = maxId + 1
+  return game
 }
 
 export { ENEMY_TEMPLATES }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -13680,6 +13680,24 @@ html.light-mode .action-btn {
 }
 .td-root--life-lost { animation: td-life-lost-flash 0.7s ease-out forwards; }
 
+/* ── Resume prompt ── */
+.td-resume-prompt {
+  margin: auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  padding: 24px;
+  border: 1px solid #333;
+  background: #111;
+  text-align: center;
+  max-width: 320px;
+}
+.td-resume-title { font-size: 16px; font-weight: bold; color: var(--color-gold); }
+.td-resume-info { font-size: 13px; color: #e0e0e0; }
+.td-resume-time { font-size: 10px; color: #888; }
+.td-resume-hint { font-size: 10px; color: #888; }
+
 /* ── Wave preview ── */
 .td-wave-preview {
   padding: 4px 10px;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -13680,24 +13680,6 @@ html.light-mode .action-btn {
 }
 .td-root--life-lost { animation: td-life-lost-flash 0.7s ease-out forwards; }
 
-/* ── Resume prompt ── */
-.td-resume-prompt {
-  margin: auto;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 12px;
-  padding: 24px;
-  border: 1px solid #333;
-  background: #111;
-  text-align: center;
-  max-width: 320px;
-}
-.td-resume-title { font-size: 16px; font-weight: bold; color: var(--color-gold); }
-.td-resume-info { font-size: 13px; color: #e0e0e0; }
-.td-resume-time { font-size: 10px; color: #888; }
-.td-resume-hint { font-size: 10px; color: #888; }
-
 /* ── Wave preview ── */
 .td-wave-preview {
   padding: 4px 10px;


### PR DESCRIPTION
## Problem

Browser memory savers (Edge's "this tab was put to sleep to save memory") can discard the tab mid-defence. Restoring the tab reloads the app to the main menu, losing the entire run — reported after losing a 40-minute city defence.

## Fix

The tower defence minigame (City Builder DEFEND + arcade mode) now autosaves to localStorage and resumes automatically:

- **Autosave** on every phase change and at most every 3s while the simulation is ticking. Separate save slots per mode (`jarv_td_save_city` / `jarv_td_save_collection`).
- **Auto-resume**: re-entering the game with a save present restores it silently (with a "⟳ Resumed saved defence." log line). Speed resets to 1× on resume.
- The save stores the **tower pool alongside the game state**, so a resumed run keeps the exact roster it started with even if city residents changed in the meantime.
- Serialisation gotchas handled: `nextWaveAt: Infinity` is encoded as `null` (JSON can't represent Infinity), and the module-level entity ID counter is fast-forwarded past all saved IDs on restore so new entities don't collide.
- Save is **cleared** on victory/defeat and on quitting via the ✕ button (both paths already pay out rewards), so finished runs can't be re-farmed. Quitting is also how you start fresh.

## Testing

- New `towerDefence.save.test.ts`: 8 tests covering round-trip (incl. Infinity), per-mode slots, finished/corrupt/empty saves, throwing localStorage, and ID-counter fast-forward.
- Full suite: 104 tests pass. `tsc` introduces no new errors (the two existing `GameGrid.tsx` errors are pre-existing on main).

https://claude.ai/code/session_012wfNKgkKA4gYzL7k2KHRvn