### PR TITLE
Add hub NPCs for the Chronicle and Weekly Challenge screens

### DIFF
--- a/web/src/components/minigames/towerdefence/GameGrid.tsx
+++ b/web/src/components/minigames/towerdefence/GameGrid.tsx
@@ -7,7 +7,7 @@ import {
   TDAttackEvent, TDGameState, TDTower, TDUnit, xpToUpgrade,
 } from '../../../game/towerDefence'
 import { usePixiApp } from '../../../hooks/usePixiApp'
-import { loadAnimFrames, loadSpriteTexture, loadTileRef } from '../../../utils/pixiHelpers'
+import { loadAnimFrames, loadSpriteTexture, loadTileRef, loadTileTexture } from '../../../utils/pixiHelpers'
 import { PATH_TILE_LOOKUP } from '../../../utils/tileLookup'
 import { TILE_SIZE } from '../../../data/tiles/tileIndex'
 import { WORLD_ENV_TILES } from '../../../data/tiles/worldTileIndex'
@@ -427,6 +427,7 @@ export function GameGrid({
 
       // Path: cell-space 8-neighbor variant lookup, sprites scaled to CELL_PX
       if (!worldDef?.pathFile) return
+      const baseUrl = (import.meta as { env: { BASE_URL: string } }).env.BASE_URL
       const pathUrl = `${baseUrl}${worldDef.pathFile.slice(1)}`
       const hasPath = (col: number, row: number) => PATH_SET.has(`${col},${row}`)
       const cellVariant = (col: number, row: number): number => {

--- a/web/src/data/hub/ravenwatch/config.json
+++ b/web/src/data/hub/ravenwatch/config.json
@@ -7026,6 +7026,19 @@
       ]
     },
     {
+      "id": "weekly-herald",
+      "name": "Trials Herald Lyra",
+      "sprite": "hub-npc-herald",
+      "tx": 31,
+      "ty": 28,
+      "screen": "weeklychallenge",
+      "dialogue": [
+        "This week's trial carries a story, Commander. The realm remembers those who answer.",
+        "Three fragments forge a relic shard. The Chronicle rewards the persistent.",
+        "A new trial begins each Monday at dawn. Every commander faces the same fate."
+      ]
+    },
+    {
       "id": "quickbattle-gate",
       "name": "Pit Master Gorr",
       "sprite": "hub-npc-arena",
@@ -7150,6 +7163,19 @@
         "One person's junk is another's treasure. Have a rummage!",
         "I found this stuff all over the Fracture zones. Don't ask how.",
         "Make me an offer — I'm always looking to deal."
+      ]
+    },
+    {
+      "id": "chronicler",
+      "name": "Chronicler Maeve",
+      "sprite": "hub-npc-scholar",
+      "tx": 60,
+      "ty": 14,
+      "screen": "chronicle",
+      "dialogue": [
+        "I keep the Fracture Chronicle, Commander. Each chapter brings us closer to the truth.",
+        "The story of what shattered our world unfolds piece by piece. Come, read with me.",
+        "A new chapter surfaces when the time is right. The Chronicle does not rush its telling."
       ]
     },
     {


### PR DESCRIPTION
## Summary

Follow-up to #1588: the Fracture Chronicle and Weekly Challenge screens were only reachable from the title screen. This adds two NPCs to the Ravenwatch hub so hub-first players can discover them, using the existing NPC `screen` navigation (no code changes needed — pure config authoring):

- **Chronicler Maeve** (`hub-npc-scholar`) stands in the courtyard between the Scholars' Hall wings at (60, 14) and opens the **Chronicle** screen. Thematically she keeps the record of the Fracture, complementing Archivist Naia inside the hall (who opens the Codex, where the Chronicle archive tab lives).
- **Trials Herald Lyra** (`hub-npc-herald`) stands beside Challenge Herald Vex in the herald plaza at (31, 28) and opens the **Weekly Challenge** screen, mirroring how the daily challenge is surfaced.

Both tiles were verified free against building footprints, decor, pond tiles, and existing NPC positions.

## Also included

Fixes two pre-existing typecheck errors on `main` from the tower defence merge (#1589): `GameGrid.tsx` referenced `loadTileTexture` without importing it and used an undefined `baseUrl` when building the path tileset URL. Without this, `tsc --noEmit` fails on every PR.

## Testing

- `python3 -m json.tool` validates the config JSON
- `npx tsc --noEmit` passes (was failing on main before the GameGrid fix)
- All 119 tests pass (`npx vitest run`)

https://claude.ai/code/session_01FW5mXq7ipnbvp9UR97jYkj

---
_Generated by [Claude Code](https://claude.ai/code/session_01FW5mXq7ipnbvp9UR97jYkj)_