### PR TITLE
Hub world: interactive items and scenery

### DIFF
--- a/docs/hubworld.md
+++ b/docs/hubworld.md
@@ -10,7 +10,7 @@
 
 | File | Owns | TypeScript exports |
 |---|---|---|
-| `web/src/data/hub/config.json` | Map geometry, buildings, doors, NPCs, exterior decor, interiors, windows | parsed by `loader.ts` |
+| `web/src/data/hub/config.json` | Map geometry, buildings, doors, NPCs, exterior decor, interiors, windows, interactables | parsed by `loader.ts` |
 | `web/src/data/hub/questDefs.json` | Quests, pickup items, blocked paths, inn rumours, friendship dialogue | parsed by `loader.ts` and `questDefs.ts` |
 | `web/src/data/hub/loader.ts` | Parses both JSON files; exports all map/NPC/item/path data | `MAP_W`, `MAP_H`, `AVATAR_START`, `HUB_AREAS`, `HUB_STREET_TILES`, `HUB_BUILDINGS`, `HUB_DOORS`, `HUB_INTERIORS`, `EXTERIOR_DECOR`, `HUB_NPCS`, `EXTERIOR_NPCS`, `INTERIOR_NPCS`, `HUB_PICKUP_ITEMS`, `HUB_BLOCKED_PATHS`, `HUB_LOCKED_DOORS`, … |
 | `web/src/data/hub/questDefs.ts` | Parses `questDefs.json`; exports quest definitions and dialogue | `HUB_QUEST_DEFS`, `INN_RUMOURS`, `FRIENDSHIP_DIALOGUE` |
@@ -18,6 +18,7 @@
 | `web/src/game/hub/pickups.ts` | Pickup state persistence (localStorage) | `getPickedUpIds`, `markPickedUp`, `isPickedUp`, `unmarkPickedUp` |
 | `web/src/game/hub/friendship.ts` | NPC friendship XP/level persistence (localStorage) | `getFriendshipLevel`, `addFriendshipXp`, `getFriendshipData` |
 | `web/src/game/hub/innConvos.ts` | Inn conversation tracking (localStorage) | `getHeardConvoIds`, `markConvoHeard`, `isConvoHeard` |
+| `web/src/game/hub/interactables.ts` | Interactable grant + moved-position persistence (localStorage) | `interactableStoreKey`, `isInteractableGranted`, `markInteractableGranted`, `getInteractableMoves`, `setInteractableMove` |
 | `web/src/components/hub/HubTownCanvas.tsx` | PixiJS canvas — rendering, pathfinding, walk, interactions | — |
 | `web/src/components/hub/HubWorld.tsx` | React orchestrator — quest flow, dialogue, state | — |
 
@@ -222,3 +223,86 @@ Existing hub NPC sprites: `hub-npc-elder`, `hub-npc-merchant`, `hub-npc-scholar`
 6. **Add the entry** to `blockedPaths` in `questDefs.json`.
 7. **Run `npm run build`** from `web/` — TypeScript will catch any malformed tile ID or missing field.
 8. **Verify in-game**: confirm the avatar cannot path through the blocked tiles, the NPC speech bubbles appear at the right distances, and tapping the NPC shows the tap dialogue.
+
+---
+
+## §7 — Interactables (tap-reactive decor & scenery)
+
+Interactables make decor react to a click/tap: show dialogue, open a screen,
+give an inventory item (once), offer a quest, or move to another tile. They
+are defined in the top-level `interactables` array of a location's
+`config.json` and work in both the exterior world and building interiors.
+
+### Full schema
+
+```jsonc
+{
+  "interactables": [
+    {
+      "id": "notice-board",            // unique per location
+      "tx": 49, "ty": 21,              // anchor tile (top-left of footprint)
+      "building": "inn-building",      // optional — interior id; omit for exterior
+      "decor": [                       // optional — OWNED tiles (rendered + movable)
+        { "dx": 0, "dy": 0, "tileId": "messageBoardTopLeft", "zlayer": "solid" }
+      ],
+      "hitRect": { "w": 2, "h": 2 },   // optional — invisible tap area at the anchor
+      "indicator": { "condition": "unread-news", "dx": 0, "dy": 0 },  // optional '!'
+      "reactions": [                   // ordered; executed sequentially per tap
+        { "type": "screen", "screen": "news" }
+      ]
+    }
+  ]
+}
+```
+
+An interactable either **owns its decor** (`decor`, offsets relative to the
+anchor — required for `move` reactions, since the canvas repositions those
+sprites as a unit) or is a **pure hit area** (`hitRect`) laid invisibly over
+existing static `exteriorDecor`/interior decor. When converting existing
+scenery to owned decor, **remove the duplicate tiles** from `exteriorDecor`.
+If neither `hitRect` nor `decor` is given, the hit area defaults to the decor
+bounds, else a single tile.
+
+### Reaction types
+
+| Type | Fields | Behaviour |
+|---|---|---|
+| `dialogue` | `speakerName?`, `text` (string or string[]) | Shows the dialogue modal. A string[] cycles one entry per tap. |
+| `screen` | `screen` | Opens a screen via the same routing as NPC `screen` (e.g. `news`, `shop`, `interior:<id>`, minigame ids). |
+| `giveItem` | `collectible?`, `consumables?`, `crystals?`, `message?`, `alreadyGrantedText?` | One-time grant (persisted). Re-taps show `alreadyGrantedText` if set. Reward shapes match treasure rewards. |
+| `quest` | `questId`, `speakerName?` | Offers the quest with Accept / Not now. The quest's `giverNpcId` in `questDefs.json` **must equal the interactable's id**. Honours prerequisites and the 2-active-quest cap. |
+| `move` | `to: {tx, ty}`, `message?` | Moves the owned decor to the target tile, live and persisted across reloads. Requires owned `decor`. |
+
+Reactions run in order; `dialogue` (and `message`-bearing reactions) chain the
+remainder through the dialogue's close. Conventions: at most one `screen` or
+`quest` reaction per interactable, placed last; don't overlap two
+interactables' solid interior decor on the same tile.
+
+### Indicator conditions
+
+`indicator.condition` names a boolean computed by `HubWorld`:
+
+| Condition | True when |
+|---|---|
+| `unread-news` | `getUnreadCount()` (news store) is > 0 at hub load |
+
+The indicator is a bobbing yellow `!` above the footprint (offset by
+`dx`/`dy` tiles), identical in style to NPC quest indicators.
+
+### Persistence
+
+localStorage keys, entries keyed `<townName>:<interactableId>`:
+
+| Key | Holds |
+|---|---|
+| `jarv_hub_interactable_grants` | ids whose `giveItem` already fired |
+| `jarv_hub_interactable_moves` | persisted `{tx, ty}` position overrides |
+
+### Authoring checklist
+
+1. Pick a unique `id` within the location.
+2. Owned decor or hit area? Owned if it should ever move; hit area to make existing static scenery tappable.
+3. Look up `tileId` constants in `baseChipIndex.ts`; set `building` for interiors.
+4. For `quest` reactions, set the quest's `giverNpcId` to the interactable id.
+5. Run `npm run test` (loader tests parse all configs) and `npm run build`.
+6. Verify in-game: tap fires the reactions, tap does not also walk the avatar, indicator shows/clears, moves persist after reload.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2864,7 +2864,7 @@ export default function App() {
       )}
 
       {screen === 'news' && (
-        <NewsScreen onBack={() => { setNewsUnreadCount(0); setScreen('title') }} />
+        <NewsScreen onBack={() => { setNewsUnreadCount(0); setScreen(returnScreen) }} />
       )}
 
       {screen === 'newsAdmin' && (

--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -14,7 +14,7 @@ import { loadPlayerAvatar } from '../../game/questline'
 import { createChunkCuller } from '../../utils/chunkCull'
 import { CommanderState } from '../../game/commander'
 import rollbar from '../../rollbar'
-import { HubInteriorExit, HubLocationBundle, HubNpc, HubQuestBundle, HubStreetGroup, NpcScheduleEntry } from '../../data/hub/loader'
+import { HubInteractable, HubInteriorExit, HubLocationBundle, HubNpc, HubQuestBundle, HubStreetGroup, NpcScheduleEntry } from '../../data/hub/loader'
 
 
 const T                 = 32
@@ -80,6 +80,13 @@ interface Props {
   gameHour?:             number
   isNight?:              boolean
   npcProximityDialogue?: React.MutableRefObject<Map<string, { atDistance: number; text: string }[]>>
+  onInteractableTap?:         (id: string) => void
+  /** Indicator condition id → visible (e.g. 'unread-news' → true) */
+  interactableIndicatorsRef?: React.MutableRefObject<Map<string, boolean>>
+  /** Interactable id → persisted position override */
+  interactableMovesRef?:      React.MutableRefObject<Map<string, { tx: number; ty: number }>>
+  /** Receives a callback to reposition an interactable's sprites live */
+  moveInteractableRef?:       React.MutableRefObject<((id: string, tx: number, ty: number) => void) | null>
   locationData:         HubLocationBundle
   questData: HubQuestBundle
   /** Scroll container whose scroll position drives the camera. When set, the
@@ -94,6 +101,7 @@ export function HubTownCanvas({
   pickedUpIds, onItemPickup, doorKeys, onDoorLocked, questNpcState, activeQuestIdsRef,
   completedQuestIdsRef, collectedTreasureIds, onTreasureStep,
   gameHour, isNight, npcProximityDialogue,
+  onInteractableTap, interactableIndicatorsRef, interactableMovesRef, moveInteractableRef,
   locationData,
   questData,
   viewportRef
@@ -106,7 +114,7 @@ export function HubTownCanvas({
     EXTERIOR_DECOR, HUB_WINDOWS, HUB_POND_TILES,
     HUB_DOORS, HUB_INTERIORS, EXTERIOR_NPCS, INTERIOR_NPCS,
     NPC_SPAWN_TILES, AMBIENT_NPC_SPRITES,
-   HUB_LOCKED_DOORS, HUB_TREASURES,
+   HUB_LOCKED_DOORS, HUB_TREASURES, HUB_INTERACTABLES,
     EXIT_TILES: exitTilesData,
     HUB_TOWN_NAME: locationKey,
   } = locationData
@@ -141,6 +149,8 @@ export function HubTownCanvas({
   const collectedTreasureRef  = useRef<Set<string>>(new Set(collectedTreasureIds))
   const onTreasureStepRef     = useRef(onTreasureStep)
   onTreasureStepRef.current   = onTreasureStep
+  const onInteractableTapRef     = useRef(onInteractableTap)
+  onInteractableTapRef.current   = onInteractableTap
   const isNightRef            = useRef(isNight ?? false)
   isNightRef.current          = isNight ?? false
   const gameHourRef           = useRef(gameHour ?? 12)
@@ -449,8 +459,130 @@ export function HubTownCanvas({
             aboveAvatarLayer.addChild(s)
           }
         }).catch(() => {})
-      }      
+      }
     }
+
+    // ── Interactables (tap-reactive decor / scenery) ───────────────────────────
+    // Each interactable is a tappable container that either renders its own
+    // decor tiles (movable as a unit) or is an invisible hit area over static
+    // decor. Containers live in spriteLayer / interiorLayer — never in chunk-
+    // culled layers, whose children must not move after adoption.
+    interface InteractableEntry {
+      def:            HubInteractable
+      root:           PIXI.Container
+      above:          PIXI.Container | null   // paired container for 'above' zlayer tiles
+      indicator:      PIXI.Text | null
+      indicatorBaseY: number
+    }
+    const exteriorInteractables = new Map<string, InteractableEntry>()
+    const interiorInteractables = new Map<string, InteractableEntry>()
+
+    function interactableZIndex(def: HubInteractable, ty: number): number {
+      return (ty + def.hitRect.h - 1) * T + T + 1  // y-sort on the bottom tile row, like decor
+    }
+
+    function interactableIndicatorPos(def: HubInteractable, tx: number, ty: number): { x: number; y: number } {
+      const ind = def.indicator!
+      return { x: tx * T + (def.hitRect.w * T) / 2 + ind.dx * T, y: ty * T - 6 + ind.dy * T }
+    }
+
+    function buildInteractable(
+      def: HubInteractable,
+      target: PIXI.Container,
+      aboveTarget: PIXI.Container,
+      indicatorTarget: PIXI.Container,
+      registry: Map<string, InteractableEntry>,
+      stillCurrent: () => boolean,
+    ): void {
+      const pos = interactableMovesRef?.current.get(def.id) ?? { tx: def.tx, ty: def.ty }
+      const root = new PIXI.Container()
+      root.position.set(pos.tx * T, pos.ty * T)
+      root.zIndex = interactableZIndex(def, pos.ty)
+      root.eventMode = 'static'
+      root.cursor    = 'pointer'
+      root.on('pointerdown', (e: PIXI.FederatedPointerEvent) => {
+        e.stopPropagation()
+        onInteractableTapRef.current?.(def.id)
+      })
+      target.addChild(root)
+
+      let above: PIXI.Container | null = null
+      const decor = (def.decor ?? []).filter(d => d.tileId !== 666)
+      if (decor.length > 0) {
+        if (decor.some(d => d.zlayer === 'above')) {
+          above = new PIXI.Container()
+          above.position.set(pos.tx * T, pos.ty * T)
+          above.zIndex = MAP_H * 2 + pos.ty * T  // above all y-sorted sprites
+          aboveTarget.addChild(above)
+        }
+        for (const d of decor) {
+          const parent = d.zlayer === 'above' ? above! : root
+          loadTileRef(d.tileId).then(tex => {
+            if (app.renderer == null || !stillCurrent()) return
+            const s = new PIXI.Sprite(tex)
+            s.position.set(d.dx * T, d.dy * T)
+            s.width = T; s.height = T
+            parent.addChild(s)
+          }).catch(() => {})
+        }
+      } else {
+        // Pure hit area over independently-rendered decor
+        root.hitArea = new PIXI.Rectangle(0, 0, def.hitRect.w * T, def.hitRect.h * T)
+      }
+
+      let indicator: PIXI.Text | null = null
+      let indicatorBaseY = 0
+      if (def.indicator) {
+        const { x, y } = interactableIndicatorPos(def, pos.tx, pos.ty)
+        indicator = new PIXI.Text({ text: '!', style: { fontSize: 16, fill: '#ffdd44', fontWeight: 'bold', fontFamily: 'monospace', stroke: { color: '#1a1a1a', width: 3 } } })
+        indicator.anchor.set(0.5, 1)
+        indicator.position.set(x, y)
+        indicator.visible = false
+        indicatorTarget.addChild(indicator)
+        indicatorBaseY = y
+      }
+
+      registry.set(def.id, { def, root, above, indicator, indicatorBaseY })
+    }
+
+    for (const def of HUB_INTERACTABLES.filter(i => !i.building)) {
+      buildInteractable(def, spriteLayer, spriteLayer, bubbleLayer, exteriorInteractables, () => true)
+    }
+
+    // Live repositioning (move reactions) — registered into moveInteractableRef below
+    const doMoveInteractable = (id: string, tx: number, ty: number): void => {
+      try {
+        const entry = interiorInteractables.get(id) ?? exteriorInteractables.get(id)
+        if (!entry) return
+        const { def, root } = entry
+        const isInteriorEntry = interiorInteractables.has(id)
+        // Re-carve interior walkability: free the old footprint, block the new
+        if (isInteriorEntry) {
+          const oldTx = Math.round(root.x / T)
+          const oldTy = Math.round(root.y / T)
+          for (const d of def.decor ?? []) {
+            if (!d.zlayer || d.zlayer === 'solid') interiorWalkable.add(`${oldTx + d.dx},${oldTy + d.dy}`)
+          }
+          for (const d of def.decor ?? []) {
+            if (!d.zlayer || d.zlayer === 'solid') interiorWalkable.delete(`${tx + d.dx},${ty + d.dy}`)
+          }
+        }
+        root.position.set(tx * T, ty * T)
+        root.zIndex = interactableZIndex(def, ty)
+        if (entry.above) {
+          entry.above.position.set(tx * T, ty * T)
+          if (!isInteriorEntry) entry.above.zIndex = MAP_H * 2 + ty * T
+        }
+        if (entry.indicator && def.indicator) {
+          const { x, y } = interactableIndicatorPos(def, tx, ty)
+          entry.indicator.position.x = x
+          entry.indicatorBaseY = y
+        }
+      } catch (e) {
+        rollbar.error('[HubTownCanvas] moveInteractable failed', { id, error: String(e) })
+      }
+    }
+    if (moveInteractableRef) moveInteractableRef.current = doMoveInteractable
 
     // ── Blocked paths (quest-gated obstructions) ──────────────────────────────
     interface BlockedNpcEntry {
@@ -1207,6 +1339,7 @@ export function HubTownCanvas({
 
       // Hide exterior overlays so they don't bleed into the interior view
       for (const ind of questIndicators.values()) ind.visible = false
+      for (const entry of exteriorInteractables.values()) { if (entry.indicator) entry.indicator.visible = false }
       for (const { tag } of npcNameTags) tag.visible = false
 
       // Build walkable set
@@ -1217,6 +1350,13 @@ export function HubTownCanvas({
       if (!isSubRoom) interiorWalkable.add(`${exitTx},${interior.height - 1}`)
       for (const d of interior.decor) {
         if (!d.zlayer || d.zlayer === 'solid') interiorWalkable.delete(`${d.tx},${d.ty}`)
+      }
+      // Interactables' owned solid decor blocks walking (at moved position if persisted)
+      for (const i of HUB_INTERACTABLES.filter(i => i.building === buildingId)) {
+        const pos = interactableMovesRef?.current.get(i.id) ?? { tx: i.tx, ty: i.ty }
+        for (const d of i.decor ?? []) {
+          if (!d.zlayer || d.zlayer === 'solid') interiorWalkable.delete(`${pos.tx + d.dx},${pos.ty + d.dy}`)
+        }
       }
       // Register inter-room exit tiles
       for (const exit of interior.exits ?? []) {
@@ -1399,6 +1539,15 @@ export function HubTownCanvas({
             }
           }).catch(() => {})
         }
+      }
+
+      // Interior interactables — tappable decor / hit areas inside the room
+      interiorInteractables.clear()
+      for (const def of HUB_INTERACTABLES.filter(i => i.building === buildingId)) {
+        buildInteractable(
+          def, interiorLayer, decorAboveContainer, interiorLayer, interiorInteractables,
+          () => interiorActive && currentInteriorId === buildingId,
+        )
       }
 
       // Interior NPCs — rendered inside the room, tappable
@@ -1986,6 +2135,15 @@ export function HubTownCanvas({
           const baseY = activeBaseY.get(npcId) ?? ind.y
           ind.y = baseY + Math.sin(performance.now() / 400) * 3
         }
+      }
+
+      // Interactable indicators — visibility driven by condition flags (e.g. unread news)
+      const activeInteractables = interiorActive ? interiorInteractables : exteriorInteractables
+      for (const entry of activeInteractables.values()) {
+        if (!entry.indicator || !entry.def.indicator) continue
+        const on = interactableIndicatorsRef?.current.get(entry.def.indicator.condition) ?? false
+        entry.indicator.visible = on
+        if (on) entry.indicator.y = entry.indicatorBaseY + Math.sin(performance.now() / 400) * 3
       }
 
       // Named NPC schedule walk — fire walks when game hour changes

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -31,7 +31,10 @@ import { useHubClock } from '../../hooks/useHubClock'
 import { formatGameTime, hourInRange } from '../../game/hub/hubClock'
 import { getDailyChallengeNPCDialogue } from '../../game/hub/npcDialogue'
 import {  ALL_QUESTS, FRIENDSHIP_DIALOGUE, RAVENWATCH } from '../../data/hub/hubWorldFactory'
-import { HubLocationBundle, HubQuestBundle, HubTreasure } from '../../data/hub/loader'
+import { HubInteractable, HubLocationBundle, HubQuestBundle, HubTreasure } from '../../data/hub/loader'
+import { getUnreadCount } from '../../game/news'
+import { interactableStoreKey, isInteractableGranted, markInteractableGranted, getInteractableMoves, setInteractableMove } from '../../game/hub/interactables'
+import rollbar from '../../rollbar'
 interface QuestEvent {
   speakerName: string
   text: string
@@ -161,6 +164,30 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onEndless, onWorldMap
   npcProximityDialogueRef.current = new Map([
     ['challenge-herald', getDailyChallengeNPCDialogue()],
   ])
+
+  // Interactable indicator conditions (e.g. 'unread-news'): read imperatively by PixiJS ticker
+  const indicatorConditionsRef = useRef(new Map<string, boolean>())
+  useEffect(() => {
+    getUnreadCount()
+      .then(n => { indicatorConditionsRef.current.set('unread-news', n > 0) })
+      .catch(e => rollbar.error('[HubWorld] getUnreadCount failed', { error: String(e) }))
+  }, [])
+
+  // Persisted interactable position overrides for this location (id → tile)
+  const interactableMovesRef = useRef(new Map<string, { tx: number; ty: number }>())
+  {
+    const m = new Map<string, { tx: number; ty: number }>()
+    const stored = getInteractableMoves()
+    for (const i of locationData.HUB_INTERACTABLES) {
+      const v = stored[interactableStoreKey(locationData.HUB_TOWN_NAME, i.id)]
+      if (v) m.set(i.id, v)
+    }
+    interactableMovesRef.current = m
+  }
+  // Receives the canvas's live-reposition callback
+  const moveInteractableRef = useRef<((id: string, tx: number, ty: number) => void) | null>(null)
+  // Per-interactable tap counts so dialogue arrays cycle
+  const interactableTapCounts = useRef(new Map<string, number>())
 
   // Completed quest IDs: read imperatively by PixiJS ticker to gate blocked path state
   const completedQuestIdsRef = useRef(new Set<string>())
@@ -419,6 +446,48 @@ function grantQuestReward(quest: HubQuestDef): void {
   }
 }
 
+// Offer the first available quest given by `giverId` (an NPC or interactable id).
+// Returns true if an offer dialogue was shown; false if there is nothing to
+// offer (caller falls through to screens / default dialogue).
+function tryOfferQuest(giverId: string, speakerName: string, onlyQuestId?: string): boolean {
+  const giveQuests = questDefs.filter(q => q.giverNpcId === giverId && (!onlyQuestId || q.id === onlyQuestId))
+  const atOfferCap = questDefs.filter(q => getQuestState(q.id).status === 'active').length >= 2
+  for (const quest of giveQuests) {
+    if (getQuestState(quest.id).status !== 'available') continue
+    const prereqMet = !quest.prerequisite || checkPrerequisite(quest.prerequisite)
+    if (prereqMet) {
+      if (atOfferCap) return false  // at cap — skip offer, fall through to screen or default dialogue
+      setDialogueEvent({
+        speakerName,
+        text: quest.offerDialogue,
+        choices: [
+          {
+            label: 'Accept',
+            primary: true,
+            onClick: () => {
+              const count = questDefs.filter(q => getQuestState(q.id).status === 'active').length
+              if (count >= 2) {
+                setDialogueEvent({ speakerName, text: "You're already working on 2 quests. Finish one first." })
+                return
+              }
+              setQuestStatus(quest.id, 'active')
+              activeQuestIdsRef.current.add(quest.id)
+              refreshState()
+              setDialogueEvent(null)
+            },
+          },
+          {
+            label: 'Not now',
+            onClick: () => setDialogueEvent(null),
+          },
+        ],
+      })
+      return true
+    }
+  }
+  return false
+}
+
 
   const handleNpcTap = useCallback((line: string, npcId: string) => {
     const npcDef = locationData.HUB_NPCS.find(n => n.id === npcId)
@@ -496,40 +565,7 @@ function grantQuestReward(quest: HubQuestDef): void {
     }
 
     // Second pass: first available quest whose prerequisites are met
-    const atOfferCap = questDefs.filter(q => getQuestState(q.id).status === 'active').length >= 2
-    for (const quest of giveQuests) {
-      if (getQuestState(quest.id).status !== 'available') continue
-      const prereqMet = !quest.prerequisite || checkPrerequisite(quest.prerequisite)
-      if (prereqMet) {
-        if (atOfferCap) break  // at cap — skip offer, fall through to screen or default dialogue
-        setDialogueEvent({
-          speakerName,
-          text: quest.offerDialogue,
-          choices: [
-            {
-              label: 'Accept',
-              primary: true,
-              onClick: () => {
-                const count = questDefs.filter(q => getQuestState(q.id).status === 'active').length
-                if (count >= 2) {
-                  setDialogueEvent({ speakerName, text: "You're already working on 2 quests. Finish one first." })
-                  return
-                }
-                setQuestStatus(quest.id, 'active')
-                activeQuestIdsRef.current.add(quest.id)
-                refreshState()
-                setDialogueEvent(null)
-              },
-            },
-            {
-              label: 'Not now',
-              onClick: () => setDialogueEvent(null),
-            },
-          ],
-        })
-        return
-      }
-    }
+    if (tryOfferQuest(npcId, speakerName)) return
 
     // ── Screen navigation fallthrough (quest done or no active quest) ────────
     if (npcDef?.screen) {
@@ -554,6 +590,72 @@ function grantQuestReward(quest: HubQuestDef): void {
     // ── Default dialogue ─────────────────────────────────────────────────────
     setDialogueEvent({ speakerName, text: line })
   }, [refreshState, handleNodeInteract])
+
+  // ── Interactable reactions ─────────────────────────────────────────────────
+  // Reactions run in order; dialogue-style reactions chain the remainder
+  // through the dialogue's onClose (manual close or 15 s auto-dismiss).
+  function runReactions(def: HubInteractable, idx: number): void {
+    const r = def.reactions[idx]
+    if (!r) return
+    const next = () => runReactions(def, idx + 1)
+    const storeKey = interactableStoreKey(locationData.HUB_TOWN_NAME, def.id)
+    switch (r.type) {
+      case 'dialogue': {
+        let text: string
+        if (Array.isArray(r.text)) {
+          const count = interactableTapCounts.current.get(def.id) ?? 0
+          interactableTapCounts.current.set(def.id, count + 1)
+          text = r.text[count % r.text.length]
+        } else {
+          text = r.text
+        }
+        setDialogueEvent({ speakerName: r.speakerName ?? '', text, onClose: next })
+        return
+      }
+      case 'screen':
+        handleNodeInteract(r.screen)
+        return
+      case 'quest':
+        if (!tryOfferQuest(def.id, r.speakerName ?? '', r.questId)) next()
+        return
+      case 'giveItem': {
+        if (isInteractableGranted(storeKey)) {
+          if (r.alreadyGrantedText) setDialogueEvent({ speakerName: '', text: r.alreadyGrantedText, onClose: next })
+          else next()
+          return
+        }
+        markInteractableGranted(storeKey)
+        if (r.collectible) {
+          const { id, name, icon, desc } = r.collectible
+          addCollectible(id, { name, icon, desc })
+        }
+        if (r.consumables) {
+          for (const { id, quantity } of r.consumables) addConsumable(id, quantity)
+        }
+        if (r.crystals) {
+          saveCrystals(loadCrystals() + r.crystals)
+          onCrystalsChange?.(loadCrystals())
+        }
+        refreshState()
+        if (r.message) setDialogueEvent({ speakerName: '', text: r.message, onClose: next })
+        else next()
+        return
+      }
+      case 'move': {
+        setInteractableMove(storeKey, r.to)
+        interactableMovesRef.current.set(def.id, r.to)
+        moveInteractableRef.current?.(def.id, r.to.tx, r.to.ty)
+        if (r.message) setDialogueEvent({ speakerName: '', text: r.message, onClose: next })
+        else next()
+        return
+      }
+    }
+  }
+
+  function handleInteractableTap(id: string): void {
+    const def = locationData.HUB_INTERACTABLES.find(i => i.id === id)
+    if (def) runReactions(def, 0)
+  }
 
   return (
     <OverlayScreen title={`🏠 ${locationData.HUB_TOWN_NAME}`}>
@@ -623,6 +725,10 @@ function grantQuestReward(quest: HubQuestDef): void {
             gameHour={gameHour}
             isNight={isGameNight}
             npcProximityDialogue={npcProximityDialogueRef}
+            onInteractableTap={handleInteractableTap}
+            interactableIndicatorsRef={indicatorConditionsRef}
+            interactableMovesRef={interactableMovesRef}
+            moveInteractableRef={moveInteractableRef}
             locationData={locationData}
             questData={ALL_QUESTS}
             viewportRef={scrollRef}

--- a/web/src/components/minigames/towerdefence/GameGrid.tsx
+++ b/web/src/components/minigames/towerdefence/GameGrid.tsx
@@ -7,7 +7,7 @@ import {
   TDAttackEvent, TDGameState, TDTower, TDUnit, xpToUpgrade,
 } from '../../../game/towerDefence'
 import { usePixiApp } from '../../../hooks/usePixiApp'
-import { loadAnimFrames, loadSpriteTexture, loadTileRef } from '../../../utils/pixiHelpers'
+import { loadAnimFrames, loadSpriteTexture, loadTileRef, loadTileTexture } from '../../../utils/pixiHelpers'
 import { PATH_TILE_LOOKUP } from '../../../utils/tileLookup'
 import { TILE_SIZE } from '../../../data/tiles/tileIndex'
 import { WORLD_ENV_TILES } from '../../../data/tiles/worldTileIndex'
@@ -427,6 +427,7 @@ export function GameGrid({
 
       // Path: cell-space 8-neighbor variant lookup, sprites scaled to CELL_PX
       if (!worldDef?.pathFile) return
+      const baseUrl = (import.meta as { env: { BASE_URL: string } }).env.BASE_URL
       const pathUrl = `${baseUrl}${worldDef.pathFile.slice(1)}`
       const hasPath = (col: number, row: number) => PATH_SET.has(`${col},${row}`)
       const cellVariant = (col: number, row: number): number => {

--- a/web/src/data/hub/config.ts
+++ b/web/src/data/hub/config.ts
@@ -201,6 +201,65 @@ export interface RawTreasure {
   buildingId?: string
 }
 
+export interface RawInteractableDecor {
+  dx: number
+  dy: number
+  tileId: string
+  zlayer?: string
+}
+
+export interface RawInteractableReaction {
+  type: 'dialogue' | 'screen' | 'giveItem' | 'quest' | 'move'
+
+  // dialogue
+  speakerName?: string
+  text?: string | string[]
+
+  // screen
+  screen?: string
+
+  // giveItem
+  collectible?: {
+    id: string
+    name: string
+    icon: string
+    desc: string
+  }
+  consumables?: Array<{
+    id: string
+    quantity: number
+  }>
+  crystals?: number
+  message?: string
+  alreadyGrantedText?: string
+
+  // quest
+  questId?: string
+
+  // move
+  to?: RawCoordinate
+}
+
+export interface RawInteractable {
+  id: string
+
+  tx: number
+  ty: number
+
+  building?: string
+
+  decor?: RawInteractableDecor[]
+  hitRect?: { w: number; h: number }
+
+  indicator?: {
+    condition: string
+    dx?: number
+    dy?: number
+  }
+
+  reactions: RawInteractableReaction[]
+}
+
 export interface RawConfig {
   mapW: number
   mapH: number
@@ -237,4 +296,6 @@ export interface RawConfig {
   lockedDoors?: RawLockedDoor[]
 
   treasures?: RawTreasure[]
+
+  interactables?: RawInteractable[]
 }

--- a/web/src/data/hub/config.ts
+++ b/web/src/data/hub/config.ts
@@ -209,7 +209,9 @@ export interface RawInteractableDecor {
 }
 
 export interface RawInteractableReaction {
-  type: 'dialogue' | 'screen' | 'giveItem' | 'quest' | 'move'
+  // 'dialogue' | 'screen' | 'giveItem' | 'quest' | 'move' — plain string so
+  // JSON imports don't widen-fail; loader.ts casts to the parsed union
+  type: string
 
   // dialogue
   speakerName?: string

--- a/web/src/data/hub/loader.test.ts
+++ b/web/src/data/hub/loader.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest'
+import { createHubLocationData } from './loader'
+import { RawConfig } from './config'
+import { BASE_CHIP_TILES } from '../tiles/baseChipIndex'
+import ravenwatchConfig from './ravenwatch/config.json'
+
+function minimalConfig(extra: Partial<RawConfig>): RawConfig {
+  return {
+    mapW: 320,
+    mapH: 320,
+    avatarStart: { tx: 1, ty: 1 },
+    areas: [],
+    streets: [],
+    buildings: [],
+    exteriorDecor: [],
+    interiors: {},
+    npcs: [],
+    npcSpawnTiles: [],
+    ...extra,
+  } as RawConfig
+}
+
+describe('interactables parsing', () => {
+  it('returns [] when the key is absent', () => {
+    const bundle = createHubLocationData(minimalConfig({}))
+    expect(bundle.HUB_INTERACTABLES).toEqual([])
+  })
+
+  it('parses an owned-decor interactable: tile resolution and hitRect from decor bounds', () => {
+    const bundle = createHubLocationData(minimalConfig({
+      interactables: [{
+        id: 'board',
+        tx: 49, ty: 21,
+        decor: [
+          { dx: 0, dy: 0, tileId: 'messageBoardTopLeft' },
+          { dx: 1, dy: 0, tileId: 'messageBoardTopRight' },
+          { dx: 0, dy: 1, tileId: 'messageBoardBottomLeft' },
+          { dx: 1, dy: 1, tileId: 'messageBoardBottomRight' },
+        ],
+        indicator: { condition: 'unread-news' },
+        reactions: [{ type: 'screen', screen: 'news' }],
+      }],
+    }))
+    expect(bundle.HUB_INTERACTABLES).toHaveLength(1)
+    const i = bundle.HUB_INTERACTABLES[0]
+    expect(i.id).toBe('board')
+    expect(i.hitRect).toEqual({ w: 2, h: 2 })
+    expect(i.decor?.[0].tileId).toBe(BASE_CHIP_TILES.messageBoardTopLeft)
+    expect(i.decor?.map(d => d.tileId).every(t => t > 0)).toBe(true)
+    expect(i.indicator).toEqual({ condition: 'unread-news', dx: 0, dy: 0 })
+    expect(i.reactions).toEqual([{ type: 'screen', screen: 'news' }])
+  })
+
+  it('defaults hitRect to 1x1 when there is no decor, keeps explicit hitRect, passes building through', () => {
+    const bundle = createHubLocationData(minimalConfig({
+      interactables: [
+        { id: 'plain', tx: 3, ty: 4, reactions: [{ type: 'dialogue', text: 'Hi' }] },
+        { id: 'wide', tx: 5, ty: 6, building: 'inn-building', hitRect: { w: 3, h: 1 }, reactions: [] },
+      ],
+    }))
+    expect(bundle.HUB_INTERACTABLES[0].hitRect).toEqual({ w: 1, h: 1 })
+    expect(bundle.HUB_INTERACTABLES[0].building).toBeUndefined()
+    expect(bundle.HUB_INTERACTABLES[1].hitRect).toEqual({ w: 3, h: 1 })
+    expect(bundle.HUB_INTERACTABLES[1].building).toBe('inn-building')
+  })
+})
+
+describe('ravenwatch config', () => {
+  it('contains the notice-board interactable with 4 resolved decor tiles', () => {
+    const bundle = createHubLocationData(ravenwatchConfig as unknown as RawConfig)
+    const board = bundle.HUB_INTERACTABLES.find(i => i.id === 'notice-board')
+    expect(board).toBeDefined()
+    expect(board!.decor).toHaveLength(4)
+    expect(board!.decor!.every(d => d.tileId > 0)).toBe(true)
+    expect(board!.hitRect).toEqual({ w: 2, h: 2 })
+    expect(board!.indicator?.condition).toBe('unread-news')
+    expect(board!.reactions).toEqual([{ type: 'screen', screen: 'news' }])
+  })
+
+  it('no longer renders the message board as plain exterior decor', () => {
+    const bundle = createHubLocationData(ravenwatchConfig as unknown as RawConfig)
+    const boardTiles = [
+      BASE_CHIP_TILES.messageBoardTopLeft,
+      BASE_CHIP_TILES.messageBoardTopRight,
+      BASE_CHIP_TILES.messageBoardBottomLeft,
+      BASE_CHIP_TILES.messageBoardBottomRight,
+    ]
+    expect(bundle.EXTERIOR_DECOR.some(d => boardTiles.includes(d.tileId))).toBe(false)
+  })
+})

--- a/web/src/data/hub/loader.ts
+++ b/web/src/data/hub/loader.ts
@@ -165,7 +165,7 @@ export type HubInteractableReaction =
       crystals?: number
       message?: string
       alreadyGrantedText?: string }
-  | { type: 'quest'; questId: string }
+  | { type: 'quest'; questId: string; speakerName?: string }
   | { type: 'move'; to: HubCoordinate; message?: string }
 
 export interface HubInteractable {

--- a/web/src/data/hub/loader.ts
+++ b/web/src/data/hub/loader.ts
@@ -3,7 +3,7 @@ import { WALL_TILES } from '../tiles/buildingMaterials'
 import type { WallMaterial, RoofMaterial } from '../tiles/buildingMaterials'
 import { expandBundleDecor, expandBundleWindows, expandBundleDoors } from '../bundles/bundleLoader'
 import { FriendshipDialogue, HubQuestDef, QuestInnRumour, RawQuestConfig } from './questDefs'
-import { RawConfig } from './config'
+import { RawConfig, RawInteractable } from './config'
 
 const WALL_MATERIAL_NAMES = new Set<string>(Object.keys(WALL_TILES))
 
@@ -149,6 +149,36 @@ export interface HubTreasure {
   buildingId?:      string   // if set, this treasure lives inside the named interior
 }
 
+export interface HubInteractableDecor {
+  dx: number
+  dy: number
+  tileId: number
+  zlayer?: 'solid' | 'below' | 'above'
+}
+
+export type HubInteractableReaction =
+  | { type: 'dialogue'; speakerName?: string; text: string | string[] }
+  | { type: 'screen'; screen: string }
+  | { type: 'giveItem'
+      collectible?: { id: string; name: string; icon: string; desc: string }
+      consumables?: Array<{ id: string; quantity: number }>
+      crystals?: number
+      message?: string
+      alreadyGrantedText?: string }
+  | { type: 'quest'; questId: string }
+  | { type: 'move'; to: HubCoordinate; message?: string }
+
+export interface HubInteractable {
+  id: string
+  tx: number
+  ty: number
+  building?: string
+  decor?: HubInteractableDecor[]
+  hitRect: { w: number; h: number }   // resolved: explicit → decor bounds → 1×1
+  indicator?: { condition: string; dx: number; dy: number }
+  reactions: HubInteractableReaction[]
+}
+
 // ── Helpers ────────────────────────────────────────────────────────────────────
 
 type TileEntry = { rect: number[]; pathType?: string } | { tile: number[]; pathType?: string }
@@ -200,6 +230,7 @@ export interface HubLocationBundle {
   AMBIENT_NPC_SPRITES: string[]
   HUB_LOCKED_DOORS: HubLockedDoor[]
   HUB_TREASURES: HubTreasure[]
+  HUB_INTERACTABLES: HubInteractable[]
   EXIT_TILES: HubExitTile[]
 
 
@@ -434,6 +465,31 @@ type RawTreasure = { id: string; tx: number; ty: number; tileId: string; collect
   collectedTileId:  t.collectedTileId ? resolveTileId(t.collectedTileId) : undefined,
 }))
 
+const HUB_INTERACTABLES: HubInteractable[] = (
+  (rawConfig as unknown as { interactables?: RawInteractable[] }).interactables ?? []
+).map(i => {
+  const decor: HubInteractableDecor[] | undefined = i.decor?.map(d => ({
+    dx:     d.dx,
+    dy:     d.dy,
+    tileId: resolveTileId(d.tileId),
+    zlayer: d.zlayer as HubInteractableDecor['zlayer'],
+  }))
+  // Hit area: explicit rect → owned-decor bounds → single tile
+  const hitRect = i.hitRect ?? (decor && decor.length > 0
+    ? { w: Math.max(...decor.map(d => d.dx)) + 1, h: Math.max(...decor.map(d => d.dy)) + 1 }
+    : { w: 1, h: 1 })
+  return {
+    id:        i.id,
+    tx:        i.tx,
+    ty:        i.ty,
+    building:  i.building,
+    decor,
+    hitRect,
+    indicator: i.indicator ? { condition: i.indicator.condition, dx: i.indicator.dx ?? 0, dy: i.indicator.dy ?? 0 } : undefined,
+    reactions: i.reactions as unknown as HubInteractableReaction[],
+  }
+})
+
  const HUB_TOWN_NAME: string = (rawConfig as unknown as { townName?: string }).townName ?? 'Town'
 const ENVIRONMENT: string = (rawConfig as unknown as { environment?: string }).environment ?? 'camp'
 
@@ -503,6 +559,7 @@ type RawExitTile = { tx: number; ty: number; screen: string }
 
     HUB_LOCKED_DOORS,
     HUB_TREASURES,
+    HUB_INTERACTABLES,
     EXIT_TILES: HUB_EXIT_TILES,
 
   }

--- a/web/src/data/hub/ravenwatch/config.json
+++ b/web/src/data/hub/ravenwatch/config.json
@@ -4097,30 +4097,6 @@
       "zlayer": "solid"
     },
     {
-      "tx": 49,
-      "ty": 22,
-      "tileId": "messageBoardBottomLeft",
-      "zlayer": "solid"
-    },
-    {
-      "tx": 50,
-      "ty": 22,
-      "tileId": "messageBoardBottomRight",
-      "zlayer": "solid"
-    },
-    {
-      "tx": 49,
-      "ty": 21,
-      "tileId": "messageBoardTopLeft",
-      "zlayer": "solid"
-    },
-    {
-      "tx": 50,
-      "ty": 21,
-      "tileId": "messageBoardTopRight",
-      "zlayer": "solid"
-    },
-    {
       "tx": 35,
       "ty": 20,
       "tileId": "largeSign",
@@ -7779,6 +7755,23 @@
       "reward": {
         "crystals": 30
       }
+    }
+  ],
+  "interactables": [
+    {
+      "id": "notice-board",
+      "tx": 49,
+      "ty": 21,
+      "decor": [
+        { "dx": 0, "dy": 0, "tileId": "messageBoardTopLeft" },
+        { "dx": 1, "dy": 0, "tileId": "messageBoardTopRight" },
+        { "dx": 0, "dy": 1, "tileId": "messageBoardBottomLeft" },
+        { "dx": 1, "dy": 1, "tileId": "messageBoardBottomRight" }
+      ],
+      "indicator": { "condition": "unread-news" },
+      "reactions": [
+        { "type": "screen", "screen": "news" }
+      ]
     }
   ]
 }

--- a/web/src/game/hub/interactables.test.ts
+++ b/web/src/game/hub/interactables.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  interactableStoreKey,
+  isInteractableGranted,
+  markInteractableGranted,
+  getInteractableMoves,
+  setInteractableMove,
+} from './interactables'
+
+// In-memory localStorage mock (tests run in node environment)
+const store = new Map<string, string>()
+beforeEach(() => {
+  store.clear()
+  globalThis.localStorage = {
+    getItem:    (k: string) => store.get(k) ?? null,
+    setItem:    (k: string, v: string) => { store.set(k, v) },
+    removeItem: (k: string) => { store.delete(k) },
+    clear:      () => { store.clear() },
+    key:        (i: number) => [...store.keys()][i] ?? null,
+    get length() { return store.size },
+  } as Storage
+})
+
+describe('interactableStoreKey', () => {
+  it('scopes ids by town name', () => {
+    expect(interactableStoreKey('Ravenwatch', 'notice-board')).toBe('Ravenwatch:notice-board')
+  })
+})
+
+describe('grants', () => {
+  it('roundtrips a grant', () => {
+    const key = interactableStoreKey('Ravenwatch', 'barrel')
+    expect(isInteractableGranted(key)).toBe(false)
+    markInteractableGranted(key)
+    expect(isInteractableGranted(key)).toBe(true)
+  })
+
+  it('keeps grants for other keys separate', () => {
+    markInteractableGranted('Ravenwatch:a')
+    expect(isInteractableGranted('Ravenwatch:b')).toBe(false)
+    expect(isInteractableGranted('Millhaven:a')).toBe(false)
+  })
+
+  it('falls back to empty on corrupted JSON', () => {
+    store.set('jarv_hub_interactable_grants', '{not json')
+    expect(isInteractableGranted('Ravenwatch:a')).toBe(false)
+    markInteractableGranted('Ravenwatch:a')
+    expect(isInteractableGranted('Ravenwatch:a')).toBe(true)
+  })
+})
+
+describe('moves', () => {
+  it('roundtrips a moved position', () => {
+    expect(getInteractableMoves()).toEqual({})
+    setInteractableMove('Ravenwatch:cat', { tx: 12, ty: 30 })
+    expect(getInteractableMoves()).toEqual({ 'Ravenwatch:cat': { tx: 12, ty: 30 } })
+  })
+
+  it('overwrites an existing position', () => {
+    setInteractableMove('Ravenwatch:cat', { tx: 12, ty: 30 })
+    setInteractableMove('Ravenwatch:cat', { tx: 5, ty: 6 })
+    expect(getInteractableMoves()['Ravenwatch:cat']).toEqual({ tx: 5, ty: 6 })
+  })
+
+  it('falls back to empty on corrupted JSON', () => {
+    store.set('jarv_hub_interactable_moves', '][')
+    expect(getInteractableMoves()).toEqual({})
+    setInteractableMove('Ravenwatch:cat', { tx: 1, ty: 2 })
+    expect(getInteractableMoves()['Ravenwatch:cat']).toEqual({ tx: 1, ty: 2 })
+  })
+})

--- a/web/src/game/hub/interactables.ts
+++ b/web/src/game/hub/interactables.ts
@@ -1,0 +1,54 @@
+import { logError } from '../../logger'
+
+const GRANTS_KEY = 'jarv_hub_interactable_grants'
+const MOVES_KEY  = 'jarv_hub_interactable_moves'
+
+export interface InteractablePosition { tx: number; ty: number }
+
+// Grants and moves are keyed "<townName>:<interactableId>" so interactable ids
+// only need to be unique within a single location.
+export function interactableStoreKey(townName: string, id: string): string {
+  return `${townName}:${id}`
+}
+
+function loadGrants(): Set<string> {
+  try {
+    const raw = localStorage.getItem(GRANTS_KEY)
+    return raw ? new Set(JSON.parse(raw) as string[]) : new Set()
+  } catch {
+    return new Set()
+  }
+}
+
+export function isInteractableGranted(key: string): boolean {
+  return loadGrants().has(key)
+}
+
+export function markInteractableGranted(key: string): void {
+  const grants = loadGrants()
+  grants.add(key)
+  try {
+    localStorage.setItem(GRANTS_KEY, JSON.stringify([...grants]))
+  } catch (e) {
+    logError('markInteractableGranted failed', { key, error: String(e) })
+  }
+}
+
+export function getInteractableMoves(): Record<string, InteractablePosition> {
+  try {
+    const raw = localStorage.getItem(MOVES_KEY)
+    return raw ? JSON.parse(raw) as Record<string, InteractablePosition> : {}
+  } catch {
+    return {}
+  }
+}
+
+export function setInteractableMove(key: string, pos: InteractablePosition): void {
+  const moves = getInteractableMoves()
+  moves[key] = pos
+  try {
+    localStorage.setItem(MOVES_KEY, JSON.stringify(moves))
+  } catch (e) {
+    logError('setInteractableMove failed', { key, error: String(e) })
+  }
+}


### PR DESCRIPTION
## Summary

Adds a config-driven **interactables** system so hub-world decor can react to click/tap, and wires the Raven Watch notice board to open the messages (News) screen with an unread `!` indicator.

### New `interactables` config section (per location `config.json`)

An interactable either **owns its decor tiles** (rendered by the canvas and movable as a unit) or is an **invisible hit area** over existing static decor. `reactions` run in order on each tap:

| Reaction | Behaviour |
|---|---|
| `dialogue` | Shows the dialogue modal (string[] cycles per tap); chains the rest via close |
| `screen` | Opens any screen via the existing NPC `screen` routing (`news`, `shop`, `interior:*`, minigames…) |
| `giveItem` | One-time grant (collectible / consumables / crystals), persisted in localStorage |
| `quest` | Offers a quest through the existing offer flow (quest's `giverNpcId` = interactable id; honours prerequisites and the 2-quest cap) |
| `move` | Moves the decor to another tile, live and persisted across reloads |

Optional `indicator: { condition }` shows a bobbing `!` (same style as NPC quest indicators) driven by a generic condition map — first condition is `unread-news`. Works in exteriors **and** building interiors (owned solid decor blocks interior walking, re-carved on move).

### Shipped example
The Ravenwatch notice board (4 `messageBoard*` tiles) is now an interactable: tap → News screen, `!` when there are unread news items. The News screen's back button now returns to the originating screen (hub or title) instead of always going to title.

### Other changes
- `tryOfferQuest` extracted from `handleNpcTap` (behaviour unchanged) and shared with interactables
- New localStorage store `web/src/game/hub/interactables.ts` (grants + moved positions, keyed `<townName>:<id>`)
- Docs: `docs/hubworld.md` §7 with full schema + authoring checklist
- Fixes pre-existing `tsc` build breakage on main in `towerdefence/GameGrid.tsx` (missing `baseUrl` / `loadTileTexture` import)

## Testing
- `npm run build` passes (was failing on main before the GameGrid fix)
- `npm run test`: 171 files / 643 tests pass, including new unit tests for loader parsing (interactables schema, ravenwatch config regression-pin) and the persistence store

### Known limitations
- `unread-news` is computed once per hub load (no live refresh while idling in the hub)
- A `move` reaction requires owned `decor`; don't overlap two interactables' solid interior decor on the same tile

https://claude.ai/code/session_01E3nixsK4ZbzhdBiT5f3ZXW

---
_Generated by [Claude Code](https://claude.ai/code/session_01E3nixsK4ZbzhdBiT5f3ZXW)_