### PR TITLE
Hub world: animals (cats, dogs, birds, fish)

### DIFF
--- a/docs/hubworld.md
+++ b/docs/hubworld.md
@@ -19,6 +19,8 @@
 | `web/src/game/hub/friendship.ts` | NPC friendship XP/level persistence (localStorage) | `getFriendshipLevel`, `addFriendshipXp`, `getFriendshipData` |
 | `web/src/game/hub/innConvos.ts` | Inn conversation tracking (localStorage) | `getHeardConvoIds`, `markConvoHeard`, `isConvoHeard` |
 | `web/src/game/hub/interactables.ts` | Interactable grant + moved-position persistence (localStorage) | `interactableStoreKey`, `isInteractableGranted`, `markInteractableGranted`, `getInteractableMoves`, `setInteractableMove` |
+| `web/src/game/hub/animals.ts` | Pure animal logic (spawn ratios/caps, tint palettes, behaviour tables) | `computeProceduralCounts`, `resolveVariantTint`, `pickWeighted`, `ANIMAL_RATIOS`, `ANIMAL_CAPS` |
+| `web/src/components/hub/hubAnimals.ts` | PixiJS animal manager — spawns & ticks cats/dogs/birds/fish | `createAnimalSystem` |
 | `web/src/components/hub/HubTownCanvas.tsx` | PixiJS canvas — rendering, pathfinding, walk, interactions | — |
 | `web/src/components/hub/HubWorld.tsx` | React orchestrator — quest flow, dialogue, state | — |
 
@@ -306,3 +308,94 @@ localStorage keys, entries keyed `<townName>:<interactableId>`:
 4. For `quest` reactions, set the quest's `giverNpcId` to the interactable id.
 5. Run `npm run test` (loader tests parse all configs) and `npm run build`.
 6. Verify in-game: tap fires the reactions, tap does not also walk the avatar, indicator shows/clears, moves persist after reload.
+
+---
+
+## §8 — Animals (cats, dogs, birds, fish)
+
+Living town ambience. Two kinds: **procedural** animals (spawned from town
+geometry, anonymous, flavour-only) and **placed** animals (defined in
+`config.json`, stable `id`, can give/receive quests). The PixiJS manager is
+`createAnimalSystem` in `web/src/components/hub/hubAnimals.ts`; the pure maths
+and behaviour tables live in `web/src/game/hub/animals.ts`.
+
+### Procedural spawn ratios & caps
+
+| Animal | Count | Source | Cap |
+|---|---|---|---|
+| Cats | 1 per 4 buildings | `HUB_BUILDINGS.length` | 6 |
+| Dogs | 1 per 4 NPCs | exterior NPC count | 8 |
+| Birds | 4 per town (fixed) | — | 4 |
+| Fish | 1 per 6 pond tiles | `HUB_POND_TILES.length` | 12 |
+
+Counts come from `computeProceduralCounts`. All towns get cats/dogs/birds
+automatically; fish appear only where `pondTiles` exist.
+
+### Behaviours
+
+- **Cat** — `wander / sit / sleep / follow-player`, plus event states `flee`
+  (runs from an approaching player) and `chase-bird` (sends the bird fleeing).
+- **Dog** — picks a named-NPC `owner`; `follow-owner / roam`, and reacts to
+  *new* NPCs it meets by rolling like/dislike → wag (♥) or bark ("Woof!").
+- **Bird** — `perched` on roof ridges or empty path tiles; flees everything by
+  flying off-screen and re-pitching at a new empty spot.
+- **Fish** — gentle swim constrained to pond tiles, with a sine bob.
+
+Placed animals with `roam !== true` are **stationary**: they do not wander or
+flee, so the player can always reach them to tap (important for quest givers,
+especially birds, which otherwise flee on approach).
+
+### Colour variants
+
+One neutral-grey base SVG per type (`animal-cat`, `animal-dog`, `animal-bird`,
+`animal-fish`, with `-1/-2/-3` walk/fly frames and `animal-cat-sleep`),
+recoloured at spawn via `sprite.tint`. `variant` may be a palette key
+(`TINT_PALETTES`, e.g. `"orange"`, `"brown"`, `"grey"`) or a hex string
+(`"#e8923c"`); omit it for a random palette colour.
+
+### Placed-animal config schema (`config.json` → top-level `animals`)
+
+```jsonc
+{
+  "animals": [
+    {
+      "id": "rover",                  // unique; shares NPC quest id space
+      "type": "dog",                  // cat | dog | bird | fish
+      "variant": "brown",             // palette key or hex; optional
+      "tx": 33, "ty": 32,
+      "name": "Rover",                // shown as the dialogue speaker
+      "dialogue": ["*woof!*"],        // first line used on tap (flavour / fallback)
+      "questGive": "wheres-rover",    // optional — quest this animal offers
+      "questReceive": "feed-the-stray", // optional — quest(s) it completes/receives
+      "roam": false,                  // default false (stationary); true = wanders
+      "areaRect": [tx, ty, w, h]      // optional roam bounds (reserved)
+    }
+  ]
+}
+```
+
+### Quests with animals
+
+Placed animals route taps through `handleNpcTap` (in `HubWorld.tsx`) by `id`,
+so quests reference them exactly like NPCs:
+
+- **Animal as giver:** set the animal's `questGive` and the quest's
+  `giverNpcId` to the animal `id` (giver==receiver works for a self-contained
+  collect quest, e.g. *Where's Rover?*).
+- **Animal as quest step / receiver:** set a `deliver` step's `targetNpcId`
+  (and `receiverNpcId`) to the animal `id`, and give the animal
+  `questReceive` (e.g. *Feed the Stray* delivers fish to a cat).
+
+A `!`/`?` quest indicator floats above placed animals that have
+`questGive`/`questReceive`, driven by the same `questNpcState` map as NPCs.
+
+### Authoring checklist: new animal quest
+
+1. Add the animal to the town's `config.json` `animals` array with a stable
+   `id`, a `name`, `dialogue`, and `questGive`/`questReceive`. Use `roam:false`
+   (default) for quest givers/receivers so they stay tappable.
+2. Author the quest in `questDefs.json` `quests`, pointing `giverNpcId` /
+   `receiverNpcId` / `targetNpcId` at the animal `id`.
+3. Add any `collect`-step `pickupItems` (tile constants from `baseChipIndex.ts`).
+4. Run `npm run test` and `npm run build`; verify the `!` shows, the quest
+   offers, pickups collect, and tapping the animal completes it.

--- a/web/public/sprites/animal-bird-1.svg
+++ b/web/public/sprites/animal-bird-1.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- flying — wings up -->
+  <ellipse cx="16" cy="20" rx="4.5" ry="3.2" fill="#eeeeee"/>
+  <!-- wings raised -->
+  <path d="M16 18 Q9 8 4 12 Q9 16 14 19 Z" fill="#eeeeee"/>
+  <path d="M16 18 Q23 8 28 12 Q23 16 18 19 Z" fill="#eeeeee"/>
+  <!-- head -->
+  <circle cx="19" cy="18" r="2.8" fill="#eeeeee"/>
+  <path d="M21.5 18 L24 18.5 L21.5 19.4 Z" fill="#e0a838"/>
+  <circle cx="20" cy="17.4" r="0.8" fill="#2a2a2a"/>
+</svg>

--- a/web/public/sprites/animal-bird-2.svg
+++ b/web/public/sprites/animal-bird-2.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- flying — wings level -->
+  <ellipse cx="16" cy="20" rx="4.5" ry="3.2" fill="#eeeeee"/>
+  <!-- wings out -->
+  <path d="M16 19 Q9 17 3 18 Q9 21 14 20.5 Z" fill="#eeeeee"/>
+  <path d="M16 19 Q23 17 29 18 Q23 21 18 20.5 Z" fill="#eeeeee"/>
+  <circle cx="19" cy="18.5" r="2.8" fill="#eeeeee"/>
+  <path d="M21.5 18.5 L24 19 L21.5 19.9 Z" fill="#e0a838"/>
+  <circle cx="20" cy="17.9" r="0.8" fill="#2a2a2a"/>
+</svg>

--- a/web/public/sprites/animal-bird-3.svg
+++ b/web/public/sprites/animal-bird-3.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- flying — wings down -->
+  <ellipse cx="16" cy="20" rx="4.5" ry="3.2" fill="#eeeeee"/>
+  <!-- wings lowered -->
+  <path d="M16 20 Q9 28 4 25 Q9 22 14 20.5 Z" fill="#eeeeee"/>
+  <path d="M16 20 Q23 28 28 25 Q23 22 18 20.5 Z" fill="#eeeeee"/>
+  <circle cx="19" cy="19" r="2.8" fill="#eeeeee"/>
+  <path d="M21.5 19 L24 19.5 L21.5 20.4 Z" fill="#e0a838"/>
+  <circle cx="20" cy="18.4" r="0.8" fill="#2a2a2a"/>
+</svg>

--- a/web/public/sprites/animal-bird.svg
+++ b/web/public/sprites/animal-bird.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- perched bird, neutral base for PIXI tint -->
+  <ellipse cx="16" cy="27" rx="5" ry="1.5" fill="rgba(0,0,0,0.2)"/>
+  <!-- legs -->
+  <rect x="14" y="23" width="1" height="3" fill="#caa24a"/>
+  <rect x="17" y="23" width="1" height="3" fill="#caa24a"/>
+  <!-- body -->
+  <ellipse cx="16" cy="20" rx="5.5" ry="4" fill="#eeeeee"/>
+  <!-- folded wing -->
+  <ellipse cx="14" cy="20" rx="3.5" ry="2.6" fill="#dddddd"/>
+  <!-- tail -->
+  <path d="M11 21 L6 23 L11 19 Z" fill="#eeeeee"/>
+  <!-- head -->
+  <circle cx="20" cy="16" r="3.4" fill="#eeeeee"/>
+  <!-- beak -->
+  <path d="M23 16 L26 16.6 L23 17.6 Z" fill="#e0a838"/>
+  <!-- eye -->
+  <circle cx="21" cy="15.4" r="0.9" fill="#2a2a2a"/>
+</svg>

--- a/web/public/sprites/animal-cat-1.svg
+++ b/web/public/sprites/animal-cat-1.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- walk frame 1 — stride A -->
+  <ellipse cx="16" cy="29" rx="8" ry="2" fill="rgba(0,0,0,0.22)"/>
+  <path d="M7 23 Q2 19 6 14" stroke="#eeeeee" stroke-width="2.6" fill="none" stroke-linecap="round"/>
+  <rect x="7" y="23" width="2.6" height="5" rx="1" fill="#eeeeee"/>
+  <rect x="21" y="23" width="2.6" height="5" rx="1" fill="#eeeeee"/>
+  <ellipse cx="14" cy="20" rx="9" ry="5" fill="#eeeeee"/>
+  <circle cx="23" cy="16" r="4.6" fill="#eeeeee"/>
+  <path d="M19.5 12.5 L20.5 8 L23 12.5 Z" fill="#eeeeee"/>
+  <path d="M24 12.5 L26.5 8 L27.5 12.5 Z" fill="#eeeeee"/>
+  <circle cx="24" cy="15.5" r="1" fill="#2a2a2a"/>
+  <circle cx="27.2" cy="17.2" r="0.9" fill="#777777"/>
+</svg>

--- a/web/public/sprites/animal-cat-2.svg
+++ b/web/public/sprites/animal-cat-2.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- walk frame 2 — mid stride, body 1px higher -->
+  <ellipse cx="16" cy="29" rx="8" ry="2" fill="rgba(0,0,0,0.22)"/>
+  <path d="M7 22 Q2 19 5 13" stroke="#eeeeee" stroke-width="2.6" fill="none" stroke-linecap="round"/>
+  <rect x="9" y="22" width="2.6" height="6" rx="1" fill="#eeeeee"/>
+  <rect x="19" y="22" width="2.6" height="6" rx="1" fill="#eeeeee"/>
+  <ellipse cx="14" cy="19" rx="9" ry="5" fill="#eeeeee"/>
+  <circle cx="23" cy="15" r="4.6" fill="#eeeeee"/>
+  <path d="M19.5 11.5 L20.5 7 L23 11.5 Z" fill="#eeeeee"/>
+  <path d="M24 11.5 L26.5 7 L27.5 11.5 Z" fill="#eeeeee"/>
+  <circle cx="24" cy="14.5" r="1" fill="#2a2a2a"/>
+  <circle cx="27.2" cy="16.2" r="0.9" fill="#777777"/>
+</svg>

--- a/web/public/sprites/animal-cat-3.svg
+++ b/web/public/sprites/animal-cat-3.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- walk frame 3 — stride B (opposite of frame 1) -->
+  <ellipse cx="16" cy="29" rx="8" ry="2" fill="rgba(0,0,0,0.22)"/>
+  <path d="M7 23 Q2 20 4 15" stroke="#eeeeee" stroke-width="2.6" fill="none" stroke-linecap="round"/>
+  <rect x="11" y="23" width="2.6" height="5" rx="1" fill="#eeeeee"/>
+  <rect x="17" y="23" width="2.6" height="5" rx="1" fill="#eeeeee"/>
+  <ellipse cx="14" cy="20" rx="9" ry="5" fill="#eeeeee"/>
+  <circle cx="23" cy="16" r="4.6" fill="#eeeeee"/>
+  <path d="M19.5 12.5 L20.5 8 L23 12.5 Z" fill="#eeeeee"/>
+  <path d="M24 12.5 L26.5 8 L27.5 12.5 Z" fill="#eeeeee"/>
+  <circle cx="24" cy="15.5" r="1" fill="#2a2a2a"/>
+  <circle cx="27.2" cy="17.2" r="0.9" fill="#777777"/>
+</svg>

--- a/web/public/sprites/animal-cat-sleep.svg
+++ b/web/public/sprites/animal-cat-sleep.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- curled, sleeping -->
+  <ellipse cx="16" cy="28" rx="10" ry="2.5" fill="rgba(0,0,0,0.22)"/>
+  <!-- curled body -->
+  <ellipse cx="16" cy="24" rx="10" ry="5.5" fill="#eeeeee"/>
+  <!-- tail wrapped round the front -->
+  <path d="M7 24 Q9 30 20 27" stroke="#eeeeee" stroke-width="3" fill="none" stroke-linecap="round"/>
+  <!-- head tucked -->
+  <circle cx="9" cy="22" r="4.4" fill="#eeeeee"/>
+  <path d="M6 19 L6.5 15.5 L9 19 Z" fill="#eeeeee"/>
+  <path d="M9.5 19 L12 15.5 L12.5 19 Z" fill="#eeeeee"/>
+  <!-- closed eye -->
+  <path d="M7 22 q2 1.4 4 0" stroke="#2a2a2a" stroke-width="0.9" fill="none" stroke-linecap="round"/>
+  <!-- zzz -->
+  <text x="20" y="14" font-family="monospace" font-size="6" fill="#9a9aa6">z</text>
+  <text x="24" y="10" font-family="monospace" font-size="5" fill="#9a9aa6">z</text>
+</svg>

--- a/web/public/sprites/animal-cat.svg
+++ b/web/public/sprites/animal-cat.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- neutral light base so PIXI tint colours the whole cat -->
+  <ellipse cx="16" cy="29" rx="8" ry="2" fill="rgba(0,0,0,0.22)"/>
+  <!-- tail -->
+  <path d="M7 23 Q2 20 5 14" stroke="#eeeeee" stroke-width="2.6" fill="none" stroke-linecap="round"/>
+  <!-- back legs -->
+  <rect x="9" y="23" width="2.6" height="5" rx="1" fill="#eeeeee"/>
+  <!-- front legs -->
+  <rect x="19" y="23" width="2.6" height="5" rx="1" fill="#eeeeee"/>
+  <!-- body -->
+  <ellipse cx="14" cy="20" rx="9" ry="5" fill="#eeeeee"/>
+  <!-- head -->
+  <circle cx="23" cy="16" r="4.6" fill="#eeeeee"/>
+  <!-- ears -->
+  <path d="M19.5 12.5 L20.5 8 L23 12.5 Z" fill="#eeeeee"/>
+  <path d="M24 12.5 L26.5 8 L27.5 12.5 Z" fill="#eeeeee"/>
+  <!-- eye + nose -->
+  <circle cx="24" cy="15.5" r="1" fill="#2a2a2a"/>
+  <circle cx="27.2" cy="17.2" r="0.9" fill="#777777"/>
+</svg>

--- a/web/public/sprites/animal-dog-1.svg
+++ b/web/public/sprites/animal-dog-1.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- walk frame 1 — stride A -->
+  <ellipse cx="16" cy="29" rx="9" ry="2" fill="rgba(0,0,0,0.22)"/>
+  <path d="M6 21 Q1 17 5 12" stroke="#eeeeee" stroke-width="3" fill="none" stroke-linecap="round"/>
+  <rect x="6" y="22" width="3" height="6" rx="1" fill="#eeeeee"/>
+  <rect x="22" y="22" width="3" height="6" rx="1" fill="#eeeeee"/>
+  <ellipse cx="15" cy="19" rx="10" ry="6" fill="#eeeeee"/>
+  <circle cx="24" cy="15" r="5.2" fill="#eeeeee"/>
+  <path d="M21 11 Q19 11 19.5 16 Q22 15 22.5 12 Z" fill="#dddddd"/>
+  <rect x="27" y="15" width="4" height="3.5" rx="1.5" fill="#eeeeee"/>
+  <circle cx="30.5" cy="16.2" r="1" fill="#444444"/>
+  <circle cx="25" cy="14" r="1" fill="#2a2a2a"/>
+</svg>

--- a/web/public/sprites/animal-dog-2.svg
+++ b/web/public/sprites/animal-dog-2.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- walk frame 2 — mid stride, body 1px higher -->
+  <ellipse cx="16" cy="29" rx="9" ry="2" fill="rgba(0,0,0,0.22)"/>
+  <path d="M6 20 Q1 17 4 11" stroke="#eeeeee" stroke-width="3" fill="none" stroke-linecap="round"/>
+  <rect x="8" y="21" width="3" height="7" rx="1" fill="#eeeeee"/>
+  <rect x="20" y="21" width="3" height="7" rx="1" fill="#eeeeee"/>
+  <ellipse cx="15" cy="18" rx="10" ry="6" fill="#eeeeee"/>
+  <circle cx="24" cy="14" r="5.2" fill="#eeeeee"/>
+  <path d="M21 10 Q19 10 19.5 15 Q22 14 22.5 11 Z" fill="#dddddd"/>
+  <rect x="27" y="14" width="4" height="3.5" rx="1.5" fill="#eeeeee"/>
+  <circle cx="30.5" cy="15.2" r="1" fill="#444444"/>
+  <circle cx="25" cy="13" r="1" fill="#2a2a2a"/>
+</svg>

--- a/web/public/sprites/animal-dog-3.svg
+++ b/web/public/sprites/animal-dog-3.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- walk frame 3 — stride B (opposite of frame 1) -->
+  <ellipse cx="16" cy="29" rx="9" ry="2" fill="rgba(0,0,0,0.22)"/>
+  <path d="M6 21 Q1 18 3 13" stroke="#eeeeee" stroke-width="3" fill="none" stroke-linecap="round"/>
+  <rect x="10" y="22" width="3" height="6" rx="1" fill="#eeeeee"/>
+  <rect x="18" y="22" width="3" height="6" rx="1" fill="#eeeeee"/>
+  <ellipse cx="15" cy="19" rx="10" ry="6" fill="#eeeeee"/>
+  <circle cx="24" cy="15" r="5.2" fill="#eeeeee"/>
+  <path d="M21 11 Q19 11 19.5 16 Q22 15 22.5 12 Z" fill="#dddddd"/>
+  <rect x="27" y="15" width="4" height="3.5" rx="1.5" fill="#eeeeee"/>
+  <circle cx="30.5" cy="16.2" r="1" fill="#444444"/>
+  <circle cx="25" cy="14" r="1" fill="#2a2a2a"/>
+</svg>

--- a/web/public/sprites/animal-dog.svg
+++ b/web/public/sprites/animal-dog.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- neutral light base so PIXI tint colours the whole dog -->
+  <ellipse cx="16" cy="29" rx="9" ry="2" fill="rgba(0,0,0,0.22)"/>
+  <!-- tail -->
+  <path d="M6 21 Q1 18 4 13" stroke="#eeeeee" stroke-width="3" fill="none" stroke-linecap="round"/>
+  <!-- back legs -->
+  <rect x="8" y="22" width="3" height="6" rx="1" fill="#eeeeee"/>
+  <!-- front legs -->
+  <rect x="20" y="22" width="3" height="6" rx="1" fill="#eeeeee"/>
+  <!-- body -->
+  <ellipse cx="15" cy="19" rx="10" ry="6" fill="#eeeeee"/>
+  <!-- head -->
+  <circle cx="24" cy="15" r="5.2" fill="#eeeeee"/>
+  <!-- floppy ear -->
+  <path d="M21 11 Q19 11 19.5 16 Q22 15 22.5 12 Z" fill="#dddddd"/>
+  <!-- snout -->
+  <rect x="27" y="15" width="4" height="3.5" rx="1.5" fill="#eeeeee"/>
+  <circle cx="30.5" cy="16.2" r="1" fill="#444444"/>
+  <!-- eye -->
+  <circle cx="25" cy="14" r="1" fill="#2a2a2a"/>
+</svg>

--- a/web/public/sprites/animal-fish.svg
+++ b/web/public/sprites/animal-fish.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- top-down-ish fish, neutral base for PIXI tint -->
+  <!-- tail -->
+  <path d="M7 16 L2 12 L3 16 L2 20 Z" fill="#eeeeee"/>
+  <!-- body -->
+  <ellipse cx="17" cy="16" rx="9" ry="5" fill="#eeeeee"/>
+  <!-- top fin -->
+  <path d="M14 11 L18 7 L20 11 Z" fill="#dddddd"/>
+  <!-- gill line -->
+  <path d="M21 12 Q23 16 21 20" stroke="#cfcfcf" stroke-width="0.8" fill="none"/>
+  <!-- eye -->
+  <circle cx="23" cy="15" r="1.1" fill="#2a2a2a"/>
+</svg>

--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -2058,6 +2058,7 @@ export function HubTownCanvas({
         return out
       },
       onAnimalTap: (id) => onAnimalTapRef.current?.(id),
+      getQuestIndicator: (id) => questNpcState?.current.get(id) ?? null,
       isInteriorActive: () => interiorActive,
     })
 

--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -15,6 +15,7 @@ import { createChunkCuller } from '../../utils/chunkCull'
 import { CommanderState } from '../../game/commander'
 import rollbar from '../../rollbar'
 import { HubInteractable, HubInteriorExit, HubLocationBundle, HubNpc, HubQuestBundle, HubStreetGroup, NpcScheduleEntry } from '../../data/hub/loader'
+import { createAnimalSystem, AnimalSystem } from './hubAnimals'
 
 
 const T                 = 32
@@ -63,6 +64,7 @@ interface Props {
   unitCards?:       string[]
   commander?:       CommanderState
   onNpcTap?:        (dialogue: string, npcId: string) => void
+  onAnimalTap?:     (animalId: string) => void
   interiorEnterRef?: React.MutableRefObject<((buildingId: string) => void) | null>
   interiorExitRef?:  React.MutableRefObject<(() => void) | null>
   onEnterInterior?:  () => void
@@ -96,7 +98,7 @@ interface Props {
 
 export function HubTownCanvas({
   onAreaEnter, onNodeInteract, onAvatarMove,
-  returnRef, unitCards, commander, onNpcTap,
+  returnRef, unitCards, commander, onNpcTap, onAnimalTap,
   interiorEnterRef, interiorExitRef, onEnterInterior, onExitInterior, onTileTap,
   pickedUpIds, onItemPickup, doorKeys, onDoorLocked, questNpcState, activeQuestIdsRef,
   completedQuestIdsRef, collectedTreasureIds, onTreasureStep,
@@ -114,7 +116,7 @@ export function HubTownCanvas({
     EXTERIOR_DECOR, HUB_WINDOWS, HUB_POND_TILES,
     HUB_DOORS, HUB_INTERIORS, EXTERIOR_NPCS, INTERIOR_NPCS,
     NPC_SPAWN_TILES, AMBIENT_NPC_SPRITES,
-   HUB_LOCKED_DOORS, HUB_TREASURES, HUB_INTERACTABLES,
+   HUB_LOCKED_DOORS, HUB_TREASURES, HUB_INTERACTABLES, HUB_ANIMALS,
     EXIT_TILES: exitTilesData,
     HUB_TOWN_NAME: locationKey,
   } = locationData
@@ -130,6 +132,8 @@ export function HubTownCanvas({
   onAvatarMoveRef.current = onAvatarMove
   const onNpcTapRef       = useRef(onNpcTap)
   onNpcTapRef.current     = onNpcTap
+  const onAnimalTapRef    = useRef(onAnimalTap)
+  onAnimalTapRef.current  = onAnimalTap
   const unitCardsRef      = useRef(unitCards)
   unitCardsRef.current    = unitCards
   const onEnterInteriorRef  = useRef(onEnterInterior)
@@ -2010,8 +2014,56 @@ export function HubTownCanvas({
     let _lastNightAlpha = -1
     let _lastNightAvatarX = -Infinity, _lastNightAvatarY = -Infinity
     let _lastReportX = -Infinity, _lastReportY = -Infinity
+    // ── Animals (cats, dogs, birds, fish) ──────────────────────────────────────
+    // Building roof ridges (top row of each building) are bird perch candidates.
+    const animalRoofTiles: [number, number][] = []
+    for (const b of HUB_BUILDINGS) {
+      const [x1, y1, x2] = b.rect
+      for (let tx = x1; tx <= x2; tx++) animalRoofTiles.push([tx, y1])
+    }
+    const animalGetWalkable = (): Set<string> => {
+      const s = new Set(pathSet)
+      for (const bp of HUB_BLOCKED_PATHS) {
+        if (!(completedQuestIdsRef?.current.has(bp.questId) ?? false))
+          for (const [btx, bty] of bp.blockedTiles) s.delete(`${btx},${bty}`)
+      }
+      return s
+    }
+    const animalSystem: AnimalSystem = createAnimalSystem({
+      app,
+      spriteLayer,
+      overlayLayer: aboveAvatarLayer,
+      pondLayer,
+      bubbleLayer,
+      baseUrl: base,
+      T,
+      spriteSize: SPRITE_SIZE,
+      mapW: MAP_W,
+      mapH: MAP_H,
+      getWalkable: animalGetWalkable,
+      pondTiles: HUB_POND_TILES,
+      roofTiles: animalRoofTiles,
+      placedAnimals: HUB_ANIMALS,
+      buildingCount: HUB_BUILDINGS.length,
+      npcCount: EXTERIOR_NPCS.length,
+      getAvatarPx: () => ({ x: avatar?.x ?? COURTYARD_PX.x, y: avatar?.y ?? COURTYARD_PX.y }),
+      getNpcPositions: () => {
+        const out: { id?: string; x: number; y: number }[] = []
+        for (const [id, container] of namedNpcContainers) {
+          if (!container.visible) continue
+          const s = container.children[0] as PIXI.Sprite | undefined
+          if (s) out.push({ id, x: s.x, y: s.y })
+        }
+        for (const n of unitNpcs) out.push({ x: n.sprite.x, y: n.sprite.y })
+        return out
+      },
+      onAnimalTap: (id) => onAnimalTapRef.current?.(id),
+      isInteriorActive: () => interiorActive,
+    })
+
     app.ticker.add((ticker) => {
       try {
+      animalSystem.tick(ticker.deltaMS)
       // Follow the scroll container every frame — scroll events are async on
       // iOS momentum scrolling, but only the camera is visible motion, so
       // reading the live scroll position here can never show a stale frame.

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -490,7 +490,15 @@ function tryOfferQuest(giverId: string, speakerName: string, onlyQuestId?: strin
 
 
   const handleNpcTap = useCallback((line: string, npcId: string) => {
-    const npcDef = locationData.HUB_NPCS.find(n => n.id === npcId)
+    // Placed animals (HUB_ANIMALS) reuse all NPC quest logic — they share the
+    // same id space as quest giverNpcId / receiverNpcId / targetNpcId.
+    const npcDef: {
+      name?: string; dialogue?: string[]; screen?: string
+      questGive?: string; questReceive?: string | string[]
+      innRumours?: Array<{ id: string; text: string }>
+    } | undefined =
+      locationData.HUB_NPCS.find(n => n.id === npcId) ??
+      locationData.HUB_ANIMALS.find(a => a.id === npcId)
     const speakerName = npcDef?.name ?? ''
 
     // ── Inn rumour handling (Innkeeper Rosie) ───────────────────────────────
@@ -590,6 +598,13 @@ function tryOfferQuest(giverId: string, speakerName: string, onlyQuestId?: strin
     // ── Default dialogue ─────────────────────────────────────────────────────
     setDialogueEvent({ speakerName, text: line })
   }, [refreshState, handleNodeInteract])
+
+  // Placed/quest animals route through the same handler as NPCs.
+  const handleAnimalTap = useCallback((animalId: string) => {
+    const a = locationData.HUB_ANIMALS.find(an => an.id === animalId)
+    const line = a?.dialogue && a.dialogue.length > 0 ? a.dialogue[0] : ''
+    handleNpcTap(line, animalId)
+  }, [handleNpcTap, locationData])
 
   // ── Interactable reactions ─────────────────────────────────────────────────
   // Reactions run in order; dialogue-style reactions chain the remainder
@@ -708,6 +723,7 @@ function tryOfferQuest(giverId: string, speakerName: string, onlyQuestId?: strin
             unitCards={unitCards}
             commander={commander}
             onNpcTap={handleNpcTap}
+            onAnimalTap={handleAnimalTap}
             interiorEnterRef={interiorEnterRef}
             interiorExitRef={interiorExitRef}
             onEnterInterior={() => setInteriorActive(true)}

--- a/web/src/components/hub/hubAnimals.ts
+++ b/web/src/components/hub/hubAnimals.ts
@@ -50,6 +50,7 @@ interface Animal {
   stateTimer: number
   bubble: PIXI.Container | null
   bubbleTimer: number
+  indicator: PIXI.Text | null
   // dog social memory
   ownerId?: string
   seen: Set<string>
@@ -89,6 +90,8 @@ export interface AnimalSystemOptions {
   getNpcPositions: () => { id?: string; x: number; y: number }[]
   /** Routes a placed animal tap to quest handling. */
   onAnimalTap: (animalId: string) => void
+  /** Quest indicator state for a placed animal id ('offer'|'ready'|null). */
+  getQuestIndicator?: (animalId: string) => 'offer' | 'ready' | null
   isInteriorActive: () => boolean
 }
 
@@ -400,6 +403,18 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
         if (a.bubbleTimer <= 0) { opts.bubbleLayer.removeChild(a.bubble); a.bubble = null }
       }
 
+      // quest indicator
+      if (a.indicator && a.id) {
+        const st = opts.getQuestIndicator?.(a.id) ?? null
+        a.indicator.visible = st !== null
+        if (st !== null) {
+          a.indicator.text = st === 'ready' ? '?' : '!'
+          a.indicator.tint = st === 'ready' ? 0x66ddff : 0xffdd44
+          const bob = Math.sin(performance.now() / 300) * 2
+          a.indicator.position.set(a.sprite.x, a.sprite.y - spriteSize * a.baseScale - 6 + bob)
+        }
+      }
+
       if (a.type === 'fish') { fishTick(a, dt); continue }
       if (a.type === 'bird') { birdTick(a, dt, avatar, npcs, walkable); continue }
 
@@ -455,8 +470,18 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
       bubble: null, bubbleTimer: 0,
       seen: new Set(), opinion: new Map(), reactCooldown: 0, wagTimer: 0,
       fleeRequested: false, bobPhase: Math.random() * Math.PI * 2, baseY: c.y,
+      indicator: null,
     }
     animals.push(a)
+
+    // Quest indicator ('!') for placed animals that can give/complete quests.
+    if (placed?.id && (placed.questGive || placed.questReceive)) {
+      const ind = new PIXI.Text({ text: '!', style: { fontSize: 16, fill: '#ffdd44', fontWeight: 'bold', fontFamily: 'monospace', stroke: { color: '#1a1a1a', width: 3 } } })
+      ind.anchor.set(0.5, 1)
+      ind.visible = false
+      opts.bubbleLayer.addChild(ind)
+      a.indicator = ind
+    }
 
     // dogs pick an owner from current named NPCs
     if (type === 'dog' && !a.stationary) {
@@ -501,7 +526,11 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
   for (const pa of opts.placedAnimals) void makeAnimal(pa.type, pa.tx, pa.ty, pa)
 
   function destroy() {
-    for (const a of animals) { if (a.bubble) opts.bubbleLayer.removeChild(a.bubble); a.sprite.destroy() }
+    for (const a of animals) {
+      if (a.bubble) opts.bubbleLayer.removeChild(a.bubble)
+      if (a.indicator) opts.bubbleLayer.removeChild(a.indicator)
+      a.sprite.destroy()
+    }
     animals.length = 0
     birdLayer.destroy({ children: true })
     fishLayer.destroy({ children: true })

--- a/web/src/components/hub/hubAnimals.ts
+++ b/web/src/components/hub/hubAnimals.ts
@@ -225,6 +225,7 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
   }
 
   function catEvents(a: Animal, dt: number, walkable: Set<string>, avatar: Pt, perchedBirds: Animal[]) {
+    if (a.stationary) return  // placed quest cats stay put so they can be tapped
     if (a.state === 'flee' || a.state === 'chase-bird') return
     const dAv = Math.hypot(avatar.x - a.sprite.x, avatar.y - a.sprite.y)
     if (dAv < 3 * T && Math.random() < (dt / 1000) * 0.6) {
@@ -329,7 +330,8 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
 
   function birdTick(a: Animal, dt: number, avatar: Pt, npcs: { x: number; y: number }[], walkable: Set<string>) {
     if (a.state === 'perched') {
-      animateWalk(a, dt) // perched: keep static (no frames cycle since we showStatic), cheap no-op
+      // Placed/tame birds (quest givers) stay put so the player can reach them.
+      if (a.stationary) { a.fleeRequested = false; return }
       const threats = [avatar, ...npcs, ...animals.filter(x => x !== a && (x.type === 'cat' || x.type === 'dog')).map(x => ({ x: x.sprite.x, y: x.sprite.y }))]
       const scared = a.fleeRequested || threats.some(t => Math.hypot(t.x - a.sprite.x, t.y - a.sprite.y) < 4 * T)
       a.stateTimer -= dt

--- a/web/src/components/hub/hubAnimals.ts
+++ b/web/src/components/hub/hubAnimals.ts
@@ -1,0 +1,511 @@
+// Imperative PixiJS manager for hub-world animals (issue #1592).
+//
+// Spawns and ticks cats, dogs, birds, and fish. Procedural animals are derived
+// from town geometry (see `computeProceduralCounts`); placed/quest animals come
+// from `HUB_ANIMALS`. Pure maths/behaviour tables live in
+// `web/src/game/hub/animals.ts`; this file owns sprites and the per-frame loop.
+
+import * as PIXI from 'pixi.js'
+import { findPath } from '../../utils/hubPathfinder'
+import { loadAnimFrames, loadTextureUrl } from '../../utils/pixiHelpers'
+import type { HubAnimal } from '../../data/hub/loader'
+import {
+  AnimalType,
+  CAT_IDLE_WEIGHTS,
+  DOG_IDLE_WEIGHTS,
+  computeProceduralCounts,
+  pickWeighted,
+  randomDuration,
+  resolveVariantTint,
+} from '../../game/hub/animals'
+
+const FRAME_MS = 160
+
+// Movement speeds, px/s.
+const SPEED: Record<AnimalType, number> = { cat: 55, dog: 72, bird: 230, fish: 26 }
+// Sprite size as a fraction of the NPC sprite size.
+const SCALE: Record<AnimalType, number> = { cat: 0.62, dog: 0.72, bird: 0.5, fish: 0.5 }
+
+interface Pt { x: number; y: number }
+
+interface Animal {
+  type: AnimalType
+  id?: string                 // placed/quest animals only
+  stationary: boolean         // placed animal with roam !== true
+  homeTile: [number, number]
+  sprite: PIXI.Sprite
+  bottomAnchored: boolean
+  baseScale: number
+  tx: number
+  ty: number
+  path: [number, number][]
+  movingTo: [number, number] | null
+  target: Pt | null
+  staticTex: PIXI.Texture | null
+  sleepTex: PIXI.Texture | null
+  frames: PIXI.Texture[]
+  frameIdx: number
+  frameTimer: number
+  state: string
+  stateTimer: number
+  bubble: PIXI.Container | null
+  bubbleTimer: number
+  // dog social memory
+  ownerId?: string
+  seen: Set<string>
+  opinion: Map<string, boolean>
+  reactCooldown: number
+  wagTimer: number
+  // bird
+  fleeRequested: boolean
+  // fish bob
+  bobPhase: number
+  baseY: number
+}
+
+export interface AnimalSystemOptions {
+  app: PIXI.Application
+  /** Y-sorted layer shared with the avatar (cats & dogs live here). */
+  spriteLayer: PIXI.Container
+  /** Layer rendered above buildings (birds nest in a child container here). */
+  overlayLayer: PIXI.Container
+  /** Pond/water layer (fish nest in a child container here). */
+  pondLayer: PIXI.Container
+  bubbleLayer: PIXI.Container
+  baseUrl: string
+  T: number
+  spriteSize: number
+  mapW: number
+  mapH: number
+  /** Current walkable street tiles ("tx,ty"), recomputed each call. */
+  getWalkable: () => Set<string>
+  pondTiles: [number, number][]
+  roofTiles: [number, number][]
+  placedAnimals: HubAnimal[]
+  buildingCount: number
+  npcCount: number
+  getAvatarPx: () => Pt
+  /** Pixel positions of named (id'd) + ambient NPCs. */
+  getNpcPositions: () => { id?: string; x: number; y: number }[]
+  /** Routes a placed animal tap to quest handling. */
+  onAnimalTap: (animalId: string) => void
+  isInteriorActive: () => boolean
+}
+
+export interface AnimalSystem {
+  tick: (deltaMS: number) => void
+  destroy: () => void
+}
+
+const FLAVOUR: Record<AnimalType, string> = { cat: 'Meow', dog: 'Woof!', bird: 'Chirp!', fish: 'blub' }
+
+export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
+  const { app, T, spriteSize } = opts
+  const animals: Animal[] = []
+
+  const birdLayer = new PIXI.Container()
+  const fishLayer = new PIXI.Container()
+  opts.overlayLayer.addChild(birdLayer)
+  opts.pondLayer.addChild(fishLayer)
+
+  // ── geometry helpers ───────────────────────────────────────────────────────
+  const key = (tx: number, ty: number) => `${tx},${ty}`
+  const center = (a: Animal, tx: number, ty: number): Pt =>
+    a.bottomAnchored
+      ? { x: tx * T + T / 2, y: ty * T + T }
+      : { x: tx * T + T / 2, y: ty * T + T / 2 }
+
+  function tilesWithin(set: Iterable<string>, tx: number, ty: number, r: number): [number, number][] {
+    const out: [number, number][] = []
+    for (const k of set) {
+      const [x, y] = k.split(',').map(Number)
+      if ((x !== tx || y !== ty) && Math.abs(x - tx) <= r && Math.abs(y - ty) <= r) out.push([x, y])
+    }
+    return out
+  }
+
+  const randOf = <X,>(arr: X[]): X | null => (arr.length ? arr[(Math.random() * arr.length) | 0] : null)
+
+  function setPath(a: Animal, from: [number, number], to: [number, number], walkable: Set<string>) {
+    const path = findPath(from, to, walkable)
+    a.path = path.length > 1 ? path.slice(1) : []
+    beginNextStep(a)
+  }
+
+  function beginNextStep(a: Animal) {
+    const next = a.path.shift()
+    if (!next) { a.target = null; a.movingTo = null; return }
+    a.movingTo = next
+    a.target = center(a, next[0], next[1])
+  }
+
+  // ── movement integration ─────────────────────────────────────────────────────
+  function advance(a: Animal, dt: number) {
+    if (!a.target) return
+    const dx = a.target.x - a.sprite.x
+    const dy = a.target.y - a.sprite.y
+    const dist = Math.hypot(dx, dy)
+    const step = (a.type === 'bird' && a.state === 'fleeing' ? SPEED.bird : SPEED[a.type]) * (dt / 1000)
+    if (dx < -0.5) a.sprite.scale.x = -a.baseScale
+    else if (dx > 0.5) a.sprite.scale.x = a.baseScale
+    if (step >= dist || dist < 0.001) {
+      a.sprite.x = a.target.x
+      a.baseY = a.target.y
+      a.sprite.y = a.target.y
+      if (a.movingTo) { a.tx = a.movingTo[0]; a.ty = a.movingTo[1] }
+      beginNextStep(a)
+    } else {
+      a.sprite.x += (dx / dist) * step
+      a.baseY = a.sprite.y + (dy / dist) * step
+      a.sprite.y = a.baseY
+    }
+    if (a.bottomAnchored) a.sprite.zIndex = a.sprite.y
+  }
+
+  const isMoving = (a: Animal) => a.target !== null
+
+  // ── textures / pose ──────────────────────────────────────────────────────────
+  function showStatic(a: Animal) {
+    if (a.staticTex) a.sprite.texture = a.staticTex
+    a.frameIdx = 0
+  }
+  function showSleep(a: Animal) {
+    a.sprite.texture = a.sleepTex ?? a.staticTex ?? a.sprite.texture
+  }
+
+  function animateWalk(a: Animal, dt: number) {
+    if (a.frames.length === 0) return
+    a.frameTimer -= dt
+    if (a.frameTimer <= 0) {
+      a.frameTimer = FRAME_MS
+      a.frameIdx = (a.frameIdx + 1) % a.frames.length
+      a.sprite.texture = a.frames[a.frameIdx]
+    }
+  }
+
+  // ── bubbles ────────────────────────────────────────────────────────────────
+  function speak(a: Animal, text: string, ms = 1600) {
+    if (a.bubble) { opts.bubbleLayer.removeChild(a.bubble); a.bubble = null }
+    const c = new PIXI.Container()
+    const lbl = new PIXI.Text({ text, style: { fontSize: 10, fill: '#111', fontFamily: 'monospace' } })
+    lbl.anchor.set(0.5, 0.5)
+    const pad = 5, bw = lbl.width + pad * 2, bh = lbl.height + pad * 2
+    lbl.position.set(0, -bh / 2)
+    const bg = new PIXI.Graphics()
+    bg.roundRect(-bw / 2, -bh, bw, bh, 5).fill({ color: 0xffffff }).stroke({ color: 0x000000, width: 1.2 })
+    c.addChild(bg, lbl)
+    c.zIndex = 1e6
+    opts.bubbleLayer.addChild(c)
+    a.bubble = c
+    a.bubbleTimer = ms
+    positionBubble(a)
+  }
+  function positionBubble(a: Animal) {
+    if (a.bubble) a.bubble.position.set(a.sprite.x, a.sprite.y - spriteSize * a.baseScale - 4)
+  }
+
+  // ── behaviour: cats ──────────────────────────────────────────────────────────
+  function catIdle(a: Animal, walkable: Set<string>, avatar: Pt) {
+    const choice = a.stationary ? (Math.random() < 0.5 ? 'sit' : 'sleep') : pickWeighted(CAT_IDLE_WEIGHTS)
+    a.state = choice
+    a.stateTimer = randomDuration(choice)
+    if (choice === 'sit') showStatic(a)
+    else if (choice === 'sleep') showSleep(a)
+    else if (choice === 'wander') {
+      const dest = randOf(tilesWithin(walkable, a.tx, a.ty, 5))
+      if (dest) setPath(a, [a.tx, a.ty], dest, walkable)
+      showStatic(a)
+    } else if (choice === 'follow-player') {
+      showStatic(a)
+      followToward(a, avatar, walkable)
+    }
+  }
+
+  function catEvents(a: Animal, dt: number, walkable: Set<string>, avatar: Pt, perchedBirds: Animal[]) {
+    if (a.state === 'flee' || a.state === 'chase-bird') return
+    const dAv = Math.hypot(avatar.x - a.sprite.x, avatar.y - a.sprite.y)
+    if (dAv < 3 * T && Math.random() < (dt / 1000) * 0.6) {
+      // run away
+      a.state = 'flee'; a.stateTimer = 2400
+      const avTile: [number, number] = [Math.floor(avatar.x / T), Math.floor(avatar.y / T)]
+      const opt = tilesWithin(walkable, a.tx, a.ty, 6)
+      let best: [number, number] | null = null, bestD = -1
+      for (const t of opt) {
+        const d = Math.abs(t[0] - avTile[0]) + Math.abs(t[1] - avTile[1])
+        if (d > bestD) { bestD = d; best = t }
+      }
+      if (best) setPath(a, [a.tx, a.ty], best, walkable)
+      return
+    }
+    if (!a.stationary) {
+      const bird = perchedBirds.find(b => Math.hypot(b.sprite.x - a.sprite.x, b.sprite.y - a.sprite.y) < 5 * T)
+      if (bird && Math.random() < (dt / 1000) * 0.4) {
+        a.state = 'chase-bird'; a.stateTimer = 3000
+        bird.fleeRequested = true
+        setPath(a, [a.tx, a.ty], [bird.tx, bird.ty], walkable)
+      }
+    }
+  }
+
+  function followToward(a: Animal, target: Pt, walkable: Set<string>) {
+    const tt: [number, number] = [Math.floor(target.x / T), Math.floor(target.y / T)]
+    // step toward a walkable tile nearest the target, staying a tile back
+    const near = tilesWithin(walkable, tt[0], tt[1], 2)
+    const dest = randOf(near) ?? (walkable.has(key(tt[0], tt[1])) ? tt : null)
+    if (dest) setPath(a, [a.tx, a.ty], dest, walkable)
+  }
+
+  // ── behaviour: dogs ──────────────────────────────────────────────────────────
+  function dogIdle(a: Animal, walkable: Set<string>, npcs: { id?: string; x: number; y: number }[]) {
+    if (a.stationary) { a.state = 'sit'; a.stateTimer = randomDuration('sit'); showStatic(a); return }
+    const choice = pickWeighted(DOG_IDLE_WEIGHTS)
+    a.state = choice
+    a.stateTimer = randomDuration(choice)
+    showStatic(a)
+    if (choice === 'follow-owner') {
+      const owner = npcs.find(n => n.id === a.ownerId)
+      if (owner) followToward(a, owner, walkable)
+      else { const d = randOf(tilesWithin(walkable, a.tx, a.ty, 5)); if (d) setPath(a, [a.tx, a.ty], d, walkable) }
+    } else {
+      const d = randOf(tilesWithin(walkable, a.tx, a.ty, 5))
+      if (d) setPath(a, [a.tx, a.ty], d, walkable)
+    }
+  }
+
+  function dogSocial(a: Animal, dt: number, npcs: { id?: string; x: number; y: number }[]) {
+    if (a.reactCooldown > 0) a.reactCooldown -= dt
+    if (a.wagTimer > 0) {
+      a.wagTimer -= dt
+      a.sprite.angle = Math.sin(performance.now() / 70) * 6
+      if (a.wagTimer <= 0) a.sprite.angle = 0
+    }
+    if (a.reactCooldown > 0) return
+    let near: { id?: string; x: number; y: number } | null = null
+    let nearD = Infinity
+    for (const n of npcs) {
+      if (!n.id || n.id === a.ownerId) continue
+      const d = Math.hypot(n.x - a.sprite.x, n.y - a.sprite.y)
+      if (d < 2.5 * T && d < nearD) { nearD = d; near = n }
+    }
+    if (!near || !near.id) return
+    if (!a.seen.has(near.id)) {
+      a.seen.add(near.id)
+      a.opinion.set(near.id, Math.random() < 0.5)
+    }
+    const likes = a.opinion.get(near.id)
+    a.reactCooldown = 5000
+    if (likes) { speak(a, '♥'); a.wagTimer = 1300 }
+    else speak(a, 'Woof!')
+  }
+
+  // ── behaviour: birds ─────────────────────────────────────────────────────────
+  function emptyPerch(avatar: Pt, npcs: { x: number; y: number }[], walkable: Set<string>): { tile: [number, number]; kind: 'roof' | 'ground' } | null {
+    const ground = tilesWithin(walkable, Math.floor(opts.mapW / 2 / T), Math.floor(opts.mapH / 2 / T), 999)
+    const candidates: { tile: [number, number]; kind: 'roof' | 'ground' }[] = [
+      ...opts.roofTiles.map(t => ({ tile: t, kind: 'roof' as const })),
+      ...ground.map(t => ({ tile: t, kind: 'ground' as const })),
+    ]
+    const blockers = [avatar, ...npcs, ...animals.filter(a => a.type === 'cat' || a.type === 'dog').map(a => ({ x: a.sprite.x, y: a.sprite.y }))]
+    const free = candidates.filter(c => {
+      const px = c.tile[0] * T + T / 2, py = c.tile[1] * T + T / 2
+      return blockers.every(b => Math.hypot(b.x - px, b.y - py) > 3 * T)
+    })
+    return randOf(free.length ? free : candidates)
+  }
+
+  function placeBirdPerch(a: Animal, perch: { tile: [number, number]; kind: 'roof' | 'ground' }) {
+    a.tx = perch.tile[0]; a.ty = perch.tile[1]
+    const c = center(a, a.tx, a.ty)
+    a.sprite.x = c.x; a.sprite.y = c.y; a.baseY = c.y
+    a.sprite.alpha = 1
+    a.target = null; a.path = []
+    a.state = 'perched'; a.stateTimer = 4000 + Math.random() * 6000
+    a.fleeRequested = false
+    showStatic(a)
+  }
+
+  function birdTick(a: Animal, dt: number, avatar: Pt, npcs: { x: number; y: number }[], walkable: Set<string>) {
+    if (a.state === 'perched') {
+      animateWalk(a, dt) // perched: keep static (no frames cycle since we showStatic), cheap no-op
+      const threats = [avatar, ...npcs, ...animals.filter(x => x !== a && (x.type === 'cat' || x.type === 'dog')).map(x => ({ x: x.sprite.x, y: x.sprite.y }))]
+      const scared = a.fleeRequested || threats.some(t => Math.hypot(t.x - a.sprite.x, t.y - a.sprite.y) < 4 * T)
+      a.stateTimer -= dt
+      if (scared || a.stateTimer <= 0) startBirdFlee(a)
+      return
+    }
+    // fleeing
+    a.frameTimer -= dt
+    if (a.frameTimer <= 0 && a.frames.length) {
+      a.frameTimer = FRAME_MS
+      a.frameIdx = (a.frameIdx + 1) % a.frames.length
+      a.sprite.texture = a.frames[a.frameIdx]
+    }
+    advance(a, dt)
+    a.sprite.alpha = Math.max(0.5, a.sprite.alpha - dt / 1200)
+    const off = a.sprite.x < -T || a.sprite.x > opts.mapW + T || a.sprite.y < -T || a.sprite.y > opts.mapH + T
+    if (off || !a.target) {
+      const perch = emptyPerch(avatar, npcs, walkable)
+      if (perch) placeBirdPerch(a, perch)
+      else { a.state = 'perched'; a.stateTimer = 4000 }
+    }
+  }
+
+  function startBirdFlee(a: Animal) {
+    a.state = 'fleeing'
+    // pick nearest screen edge to fly off
+    const dl = a.sprite.x, dr = opts.mapW - a.sprite.x, dt2 = a.sprite.y, db = opts.mapH - a.sprite.y
+    const m = Math.min(dl, dr, dt2, db)
+    let tx = a.sprite.x, ty = a.sprite.y - 3 * T
+    if (m === dl) { tx = -2 * T; ty = a.sprite.y - 2 * T }
+    else if (m === dr) { tx = opts.mapW + 2 * T; ty = a.sprite.y - 2 * T }
+    else if (m === dt2) { tx = a.sprite.x; ty = -2 * T }
+    else { tx = a.sprite.x; ty = opts.mapH + 2 * T }
+    a.path = []
+    a.target = { x: tx, y: ty }
+  }
+
+  // ── behaviour: fish ──────────────────────────────────────────────────────────
+  const pondSet = new Set(opts.pondTiles.map(([x, y]) => key(x, y)))
+  function fishTick(a: Animal, dt: number) {
+    a.bobPhase += dt / 600
+    if (!isMoving(a)) {
+      a.stateTimer -= dt
+      if (a.stateTimer <= 0) {
+        a.stateTimer = 1500 + Math.random() * 2500
+        const near = tilesWithin(pondSet, a.tx, a.ty, 3)
+        const dest = randOf(near)
+        if (dest) { a.tx = dest[0]; a.ty = dest[1]; const c = center(a, dest[0], dest[1]); a.target = c; a.path = [] }
+      }
+    } else {
+      advance(a, dt)
+    }
+    a.sprite.y = a.baseY + Math.sin(a.bobPhase) * 1.5
+  }
+
+  // ── per-frame tick ───────────────────────────────────────────────────────────
+  function tick(deltaMS: number) {
+    if (opts.isInteriorActive()) { birdLayer.visible = false; fishLayer.visible = false; return }
+    birdLayer.visible = true; fishLayer.visible = true
+    const dt = Math.min(deltaMS, 50)
+    const walkable = opts.getWalkable()
+    const avatar = opts.getAvatarPx()
+    const npcs = opts.getNpcPositions()
+    const perchedBirds = animals.filter(a => a.type === 'bird' && a.state === 'perched')
+
+    for (const a of animals) {
+      // bubble lifetime
+      if (a.bubble) {
+        positionBubble(a)
+        a.bubbleTimer -= dt
+        if (a.bubbleTimer <= 0) { opts.bubbleLayer.removeChild(a.bubble); a.bubble = null }
+      }
+
+      if (a.type === 'fish') { fishTick(a, dt); continue }
+      if (a.type === 'bird') { birdTick(a, dt, avatar, npcs, walkable); continue }
+
+      // cats & dogs
+      advance(a, dt)
+      if (isMoving(a)) animateWalk(a, dt)
+      else if (a.state !== 'sleep') showStatic(a)
+
+      a.stateTimer -= dt
+      if (a.type === 'cat') {
+        catEvents(a, dt, walkable, avatar, perchedBirds)
+        if (a.state === 'follow-player' && !isMoving(a) && a.stateTimer > 0) followToward(a, avatar, walkable)
+        if (!isMoving(a) && a.stateTimer <= 0) catIdle(a, walkable, avatar)
+      } else {
+        dogSocial(a, dt, npcs)
+        if (a.state === 'follow-owner' && !isMoving(a) && a.stateTimer > 0) {
+          const owner = npcs.find(n => n.id === a.ownerId)
+          if (owner) followToward(a, owner, walkable)
+        }
+        if (!isMoving(a) && a.stateTimer <= 0) dogIdle(a, walkable, npcs)
+      }
+    }
+  }
+
+  // ── spawning ──────────────────────────────────────────────────────────────────
+  async function makeAnimal(
+    type: AnimalType, tx: number, ty: number, placed?: HubAnimal,
+  ): Promise<void> {
+    const slug = `animal-${type}`
+    const staticTex = await loadTextureUrl(`${opts.baseUrl}sprites/${slug}.svg`).catch(() => null)
+    if (!staticTex || app.renderer == null) return
+    const sprite = new PIXI.Sprite(staticTex)
+    const px = spriteSize * SCALE[type]
+    sprite.width = px; sprite.height = px
+    const bottomAnchored = type !== 'fish'
+    sprite.anchor.set(0.5, bottomAnchored ? 1 : 0.5)
+    sprite.tint = resolveVariantTint(type, placed?.variant)
+    const baseScale = sprite.scale.x
+
+    const layer = type === 'bird' ? birdLayer : type === 'fish' ? fishLayer : opts.spriteLayer
+    const c = bottomAnchored ? { x: tx * T + T / 2, y: ty * T + T } : { x: tx * T + T / 2, y: ty * T + T / 2 }
+    sprite.position.set(c.x, c.y)
+    if (bottomAnchored) sprite.zIndex = c.y
+    layer.addChild(sprite)
+
+    const a: Animal = {
+      type, id: placed?.id, stationary: !!placed && placed.roam !== true,
+      homeTile: [tx, ty], sprite, bottomAnchored, baseScale,
+      tx, ty, path: [], movingTo: null, target: null,
+      staticTex, sleepTex: null, frames: [], frameIdx: 0, frameTimer: FRAME_MS,
+      state: type === 'bird' ? 'perched' : type === 'fish' ? 'swim' : 'sit',
+      stateTimer: 500 + Math.random() * 1500,
+      bubble: null, bubbleTimer: 0,
+      seen: new Set(), opinion: new Map(), reactCooldown: 0, wagTimer: 0,
+      fleeRequested: false, bobPhase: Math.random() * Math.PI * 2, baseY: c.y,
+    }
+    animals.push(a)
+
+    // dogs pick an owner from current named NPCs
+    if (type === 'dog' && !a.stationary) {
+      const named = opts.getNpcPositions().filter(n => n.id)
+      a.ownerId = randOf(named)?.id
+    }
+
+    // tap handling
+    sprite.eventMode = 'static'
+    sprite.cursor = 'pointer'
+    sprite.on('pointerdown', (e: PIXI.FederatedPointerEvent) => {
+      e.stopPropagation()
+      if (a.id) { opts.onAnimalTap(a.id); return }
+      speak(a, FLAVOUR[type])
+      if (type === 'bird') a.fleeRequested = true
+      if (type === 'cat' && a.state !== 'flee') { a.state = 'sit'; a.stateTimer = 200 }
+    })
+
+    // load walk/fly frames + cat sleep pose
+    if (type !== 'fish') {
+      loadAnimFrames(slug, 3).then(f => { a.frames = f }).catch(() => {})
+    }
+    if (type === 'cat') {
+      loadTextureUrl(`${opts.baseUrl}sprites/animal-cat-sleep.svg`).then(t => { a.sleepTex = t }).catch(() => {})
+    }
+  }
+
+  // Procedural population
+  const counts = computeProceduralCounts(opts.buildingCount, opts.npcCount, opts.pondTiles.length)
+  const walkable0 = opts.getWalkable()
+  const walkTiles = Array.from(walkable0).map(k => k.split(',').map(Number) as [number, number])
+  for (let i = 0; i < counts.cat; i++) { const t = randOf(walkTiles); if (t) void makeAnimal('cat', t[0], t[1]) }
+  for (let i = 0; i < counts.dog; i++) { const t = randOf(walkTiles); if (t) void makeAnimal('dog', t[0], t[1]) }
+  for (let i = 0; i < counts.bird; i++) {
+    const roof = randOf(opts.roofTiles)
+    const t = roof ?? randOf(walkTiles)
+    if (t) void makeAnimal('bird', t[0], t[1])
+  }
+  for (let i = 0; i < counts.fish; i++) { const t = randOf(opts.pondTiles); if (t) void makeAnimal('fish', t[0], t[1]) }
+
+  // Placed/quest animals (always rendered)
+  for (const pa of opts.placedAnimals) void makeAnimal(pa.type, pa.tx, pa.ty, pa)
+
+  function destroy() {
+    for (const a of animals) { if (a.bubble) opts.bubbleLayer.removeChild(a.bubble); a.sprite.destroy() }
+    animals.length = 0
+    birdLayer.destroy({ children: true })
+    fishLayer.destroy({ children: true })
+  }
+
+  return { tick, destroy }
+}

--- a/web/src/data/hub/config.ts
+++ b/web/src/data/hub/config.ts
@@ -262,6 +262,20 @@ export interface RawInteractable {
   reactions: RawInteractableReaction[]
 }
 
+export interface RawAnimal {
+  id: string
+  type: string                       // 'cat' | 'dog' | 'bird' | 'fish'
+  variant?: string                   // palette key (e.g. "orange") or hex ("#e8923c")
+  tx: number
+  ty: number
+  name?: string
+  dialogue?: string[]
+  questGive?: string
+  questReceive?: string | string[]
+  roam?: boolean                     // default false for placed animals
+  areaRect?: [number, number, number, number]  // [tx, ty, w, h] roam bounds
+}
+
 export interface RawConfig {
   mapW: number
   mapH: number
@@ -300,4 +314,6 @@ export interface RawConfig {
   treasures?: RawTreasure[]
 
   interactables?: RawInteractable[]
+
+  animals?: RawAnimal[]
 }

--- a/web/src/data/hub/loader.test.ts
+++ b/web/src/data/hub/loader.test.ts
@@ -65,6 +65,29 @@ describe('interactables parsing', () => {
   })
 })
 
+describe('animals parsing', () => {
+  it('returns [] when the key is absent', () => {
+    const bundle = createHubLocationData(minimalConfig({}))
+    expect(bundle.HUB_ANIMALS).toEqual([])
+  })
+
+  it('passes placed animals through with all quest fields', () => {
+    const bundle = createHubLocationData(minimalConfig({
+      animals: [
+        { id: 'rover', type: 'dog', variant: 'brown', tx: 10, ty: 12, name: 'Rover',
+          dialogue: ['Woof!'], questGive: 'wheres-rover' },
+        { id: 'smudge', type: 'cat', tx: 5, ty: 6, questReceive: ['feed-the-stray'], roam: true },
+      ],
+    }))
+    expect(bundle.HUB_ANIMALS).toHaveLength(2)
+    expect(bundle.HUB_ANIMALS[0]).toMatchObject({
+      id: 'rover', type: 'dog', variant: 'brown', tx: 10, ty: 12, questGive: 'wheres-rover',
+    })
+    expect(bundle.HUB_ANIMALS[1].questReceive).toEqual(['feed-the-stray'])
+    expect(bundle.HUB_ANIMALS[1].roam).toBe(true)
+  })
+})
+
 describe('ravenwatch config', () => {
   it('contains the notice-board interactable with 4 resolved decor tiles', () => {
     const bundle = createHubLocationData(ravenwatchConfig as unknown as RawConfig)

--- a/web/src/data/hub/loader.ts
+++ b/web/src/data/hub/loader.ts
@@ -3,7 +3,7 @@ import { WALL_TILES } from '../tiles/buildingMaterials'
 import type { WallMaterial, RoofMaterial } from '../tiles/buildingMaterials'
 import { expandBundleDecor, expandBundleWindows, expandBundleDoors } from '../bundles/bundleLoader'
 import { FriendshipDialogue, HubQuestDef, QuestInnRumour, RawQuestConfig } from './questDefs'
-import { RawConfig, RawInteractable } from './config'
+import { RawAnimal, RawConfig, RawInteractable } from './config'
 
 const WALL_MATERIAL_NAMES = new Set<string>(Object.keys(WALL_TILES))
 
@@ -92,6 +92,22 @@ export interface HubNpc {
   isGhost?: boolean
   schedule?: NpcScheduleEntry[]
   homeBed?: { buildingId: string; tx: number; ty: number }
+}
+
+export type HubAnimalType = 'cat' | 'dog' | 'bird' | 'fish'
+
+export interface HubAnimal {
+  id: string
+  type: HubAnimalType
+  variant?: string
+  tx: number
+  ty: number
+  name?: string
+  dialogue?: string[]
+  questGive?: string
+  questReceive?: string | string[]
+  roam?: boolean
+  areaRect?: [number, number, number, number]
 }
 
 export interface HubPickupItem {
@@ -231,6 +247,7 @@ export interface HubLocationBundle {
   HUB_LOCKED_DOORS: HubLockedDoor[]
   HUB_TREASURES: HubTreasure[]
   HUB_INTERACTABLES: HubInteractable[]
+  HUB_ANIMALS: HubAnimal[]
   EXIT_TILES: HubExitTile[]
 
 
@@ -490,6 +507,22 @@ const HUB_INTERACTABLES: HubInteractable[] = (
   }
 })
 
+const HUB_ANIMALS: HubAnimal[] = (
+  (rawConfig as unknown as { animals?: RawAnimal[] }).animals ?? []
+).map(a => ({
+  id:           a.id,
+  type:         a.type as HubAnimalType,
+  variant:      a.variant,
+  tx:           a.tx,
+  ty:           a.ty,
+  name:         a.name,
+  dialogue:     a.dialogue,
+  questGive:    a.questGive,
+  questReceive: a.questReceive,
+  roam:         a.roam,
+  areaRect:     a.areaRect,
+}))
+
  const HUB_TOWN_NAME: string = (rawConfig as unknown as { townName?: string }).townName ?? 'Town'
 const ENVIRONMENT: string = (rawConfig as unknown as { environment?: string }).environment ?? 'camp'
 
@@ -560,6 +593,7 @@ type RawExitTile = { tx: number; ty: number; screen: string }
     HUB_LOCKED_DOORS,
     HUB_TREASURES,
     HUB_INTERACTABLES,
+    HUB_ANIMALS,
     EXIT_TILES: HUB_EXIT_TILES,
 
   }

--- a/web/src/data/hub/ravenwatch/config.json
+++ b/web/src/data/hub/ravenwatch/config.json
@@ -7799,5 +7799,37 @@
         { "type": "screen", "screen": "news" }
       ]
     }
+  ],
+  "animals": [
+    {
+      "id": "stray-cat-ravenwatch",
+      "type": "cat",
+      "variant": "orange",
+      "tx": 52,
+      "ty": 54,
+      "name": "Smudge",
+      "dialogue": ["*meow?*", "Smudge the stray blinks up at you, hopeful for a meal."],
+      "questReceive": "feed-the-stray"
+    },
+    {
+      "id": "rover",
+      "type": "dog",
+      "variant": "brown",
+      "tx": 33,
+      "ty": 32,
+      "name": "Rover",
+      "dialogue": ["*woof!*", "Rover wags his tail and looks at you expectantly."],
+      "questGive": "wheres-rover"
+    },
+    {
+      "id": "pip",
+      "type": "bird",
+      "variant": "brown",
+      "tx": 31,
+      "ty": 24,
+      "name": "Pip",
+      "dialogue": ["*caw!*", "Pip the raven tilts its head, eyeing your pockets for something shiny."],
+      "questGive": "pips-treasures"
+    }
   ]
 }

--- a/web/src/data/hub/ravenwatch/questDefs.json
+++ b/web/src/data/hub/ravenwatch/questDefs.json
@@ -1,6 +1,49 @@
 {
   "quests": [
     {
+      "id": "feed-the-stray",
+      "title": "Feed the Stray",
+      "type": "fetch",
+      "giverNpcId": "fisherman",
+      "receiverNpcId": "stray-cat-ravenwatch",
+      "offerDialogue": "There's a little stray that hangs about the pond — poor thing's half-starved. If you can scrounge up three fish from the banks, take them to her, would you?",
+      "activeDialogue": "Three fish from around the pond, then carry them over to that stray cat. She's usually sat by the east bank.",
+      "completeDialogue": "She ate the lot! Look at her purr. You've a good heart, traveller.",
+      "steps": [
+        { "key": "fish", "type": "collect", "pickupIds": ["stray-fish-1", "stray-fish-2", "stray-fish-3"], "required": 3 },
+        { "key": "deliver", "type": "deliver", "targetNpcId": "stray-cat-ravenwatch", "required": 1 }
+      ],
+      "reward": { "crystals": 40, "friendship": { "fisherman": 15 } }
+    },
+    {
+      "id": "wheres-rover",
+      "title": "Where's Rover?",
+      "type": "fetch",
+      "giverNpcId": "rover",
+      "receiverNpcId": "rover",
+      "offerDialogue": "Rover paws at the ground and whines — he's buried his favourite toys all over town and can't dig them up. Help him find his three toys?",
+      "activeDialogue": "Rover is still pining for his three lost toys, scattered around the streets.",
+      "completeDialogue": "Rover bounds in circles, toys in mouth, tail a blur. You've made a friend for life!",
+      "steps": [
+        { "key": "toys", "type": "collect", "pickupIds": ["rover-toy-1", "rover-toy-2", "rover-toy-3"], "required": 3 }
+      ],
+      "reward": { "crystals": 35 }
+    },
+    {
+      "id": "pips-treasures",
+      "title": "Pip's Treasures",
+      "type": "fetch",
+      "giverNpcId": "pip",
+      "receiverNpcId": "pip",
+      "offerDialogue": "The raven cocks its head and caws insistently, pointing its beak at the rooftops. It seems to want three shiny baubles gathered from around town.",
+      "activeDialogue": "Pip is still waiting for its three shiny baubles. Best check the streets and squares.",
+      "completeDialogue": "Pip snatches the last bauble, gives a satisfied caw, and drops a gift at your feet.",
+      "steps": [
+        { "key": "shiny", "type": "collect", "pickupIds": ["pip-shiny-1", "pip-shiny-2", "pip-shiny-3"], "required": 3 }
+      ],
+      "reward": { "crystals": 35 }
+    },
+    {
       "id": "lost-pendant",
       "title": "The Lost Pendants",
       "type": "lost-items",
@@ -3384,6 +3427,15 @@
     }
   ],
   "pickupItems": [
+    { "id": "stray-fish-1", "tx": 48, "ty": 57, "tileId": "appleBasket", "questId": "feed-the-stray" },
+    { "id": "stray-fish-2", "tx": 41, "ty": 51, "tileId": "appleBasket", "questId": "feed-the-stray" },
+    { "id": "stray-fish-3", "tx": 46, "ty": 49, "tileId": "appleBasket", "questId": "feed-the-stray" },
+    { "id": "rover-toy-1", "tx": 30, "ty": 33, "tileId": "gift", "questId": "wheres-rover" },
+    { "id": "rover-toy-2", "tx": 40, "ty": 35, "tileId": "gift", "questId": "wheres-rover" },
+    { "id": "rover-toy-3", "tx": 36, "ty": 45, "tileId": "gift", "questId": "wheres-rover" },
+    { "id": "pip-shiny-1", "tx": 35, "ty": 24, "tileId": "yellow_crystal1", "questId": "pips-treasures" },
+    { "id": "pip-shiny-2", "tx": 45, "ty": 30, "tileId": "yellow_crystal1", "questId": "pips-treasures" },
+    { "id": "pip-shiny-3", "tx": 29, "ty": 32, "tileId": "yellow_crystal1", "questId": "pips-treasures" },
     {
       "id": "pendant-1",
       "tx": 1,

--- a/web/src/data/hub/saltmereport/config.json
+++ b/web/src/data/hub/saltmereport/config.json
@@ -175,5 +175,17 @@
       ],
       "exits": []
     }
-  }
+  },
+  "animals": [
+    {
+      "id": "dockside-cat-saltmere",
+      "type": "cat",
+      "variant": "grey",
+      "tx": 12,
+      "ty": 14,
+      "name": "Barnacle",
+      "dialogue": ["*mrrow*", "Barnacle the dock cat winds around your ankles, eyeing the catch."],
+      "questReceive": "saltmere-dockside-cat"
+    }
+  ]
 }

--- a/web/src/data/hub/saltmereport/questDefs.json
+++ b/web/src/data/hub/saltmereport/questDefs.json
@@ -1,6 +1,21 @@
 {
   "quests": [
     {
+      "id": "saltmere-dockside-cat",
+      "title": "The Dockside Cat",
+      "type": "fetch",
+      "giverNpcId": "fishwife-pearl",
+      "receiverNpcId": "dockside-cat-saltmere",
+      "offerDialogue": "That grey tom haunts my stall day and night, the beggar. Fetch three fish heads from along the wharf and feed him, will you? Maybe then he'll let me work in peace.",
+      "activeDialogue": "Three fish heads off the wharf, then take them to that grey cat by the docks.",
+      "completeDialogue": "Well I never — he's actually content. Take this for your trouble, love.",
+      "steps": [
+        { "key": "scraps", "type": "collect", "pickupIds": ["dock-fish-1", "dock-fish-2", "dock-fish-3"], "required": 3 },
+        { "key": "deliver", "type": "deliver", "targetNpcId": "dockside-cat-saltmere", "required": 1 }
+      ],
+      "reward": { "crystals": 40, "friendship": { "fishwife-pearl": 15 } }
+    },
+    {
       "id": "saltmere-lost-cargo",
       "title": "The Missing Manifest",
       "type": "fetch",
@@ -57,6 +72,9 @@
     }
   ],
   "pickupItems": [
+    { "id": "dock-fish-1", "tx": 8, "ty": 14, "tileId": "appleBasket", "questId": "saltmere-dockside-cat" },
+    { "id": "dock-fish-2", "tx": 18, "ty": 16, "tileId": "appleBasket", "questId": "saltmere-dockside-cat" },
+    { "id": "dock-fish-3", "tx": 24, "ty": 13, "tileId": "appleBasket", "questId": "saltmere-dockside-cat" },
     { "id": "port-crate-1", "tx": 28, "ty": 25, "tileId": "crate", "questId": "saltmere-lost-cargo" },
     { "id": "port-crate-2", "tx": 20, "ty": 16, "tileId": "crate", "questId": "saltmere-lost-cargo" },
     { "id": "port-crate-3", "tx": 2, "ty": 11, "tileId": "crate", "questId": "saltmere-lost-cargo" },

--- a/web/src/game/hub/animals.test.ts
+++ b/web/src/game/hub/animals.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest'
+import {
+  ANIMAL_CAPS,
+  computeProceduralCounts,
+  resolveVariantTint,
+  TINT_PALETTES,
+  pickWeighted,
+  randomDuration,
+} from './animals'
+
+describe('computeProceduralCounts', () => {
+  it('applies the issue ratios', () => {
+    // 8 buildings → 2 cats, 8 npcs → 2 dogs, birds fixed 4, 12 pond tiles → 2 fish
+    expect(computeProceduralCounts(8, 8, 12)).toEqual({ cat: 2, dog: 2, bird: 4, fish: 2 })
+  })
+
+  it('floors fractional counts', () => {
+    expect(computeProceduralCounts(7, 7, 11)).toEqual({ cat: 1, dog: 1, bird: 4, fish: 1 })
+  })
+
+  it('returns zero when there is no source data (and birds stay fixed)', () => {
+    expect(computeProceduralCounts(0, 0, 0)).toEqual({ cat: 0, dog: 0, bird: 4, fish: 0 })
+  })
+
+  it('clamps to the per-type caps for a large town', () => {
+    // Ravenwatch-scale: 22 buildings, 56 npcs, 85 pond tiles
+    const counts = computeProceduralCounts(22, 56, 85)
+    expect(counts.cat).toBe(5)                 // 22/4=5, below cap 6
+    expect(counts.dog).toBe(ANIMAL_CAPS.dog)   // 56/4=14 → capped to 8
+    expect(counts.fish).toBe(ANIMAL_CAPS.fish) // 85/6=14 → capped to 12
+    expect(counts.bird).toBe(4)
+  })
+})
+
+describe('resolveVariantTint', () => {
+  it('resolves a named palette key', () => {
+    expect(resolveVariantTint('cat', 'orange')).toBe(TINT_PALETTES.cat.orange)
+  })
+
+  it('parses hex strings in several forms', () => {
+    expect(resolveVariantTint('dog', '#abcdef')).toBe(0xabcdef)
+    expect(resolveVariantTint('dog', 'abcdef')).toBe(0xabcdef)
+    expect(resolveVariantTint('dog', '0xABCDEF')).toBe(0xabcdef)
+  })
+
+  it('falls back to a palette colour using the supplied rng', () => {
+    const tint = resolveVariantTint('bird', undefined, () => 0)
+    expect(tint).toBe(Object.values(TINT_PALETTES.bird)[0])
+  })
+
+  it('ignores an invalid variant and falls back', () => {
+    const tint = resolveVariantTint('fish', 'not-a-colour', () => 0)
+    expect(tint).toBe(Object.values(TINT_PALETTES.fish)[0])
+  })
+})
+
+describe('pickWeighted', () => {
+  it('selects the first bucket at rng=0', () => {
+    expect(pickWeighted({ a: 1, b: 9 }, () => 0)).toBe('a')
+  })
+
+  it('selects a later bucket as rng approaches 1', () => {
+    expect(pickWeighted({ a: 1, b: 9 }, () => 0.99)).toBe('b')
+  })
+})
+
+describe('randomDuration', () => {
+  it('returns the low bound at rng=0', () => {
+    expect(randomDuration('sit', () => 0)).toBe(3000)
+  })
+
+  it('uses a default range for unknown states', () => {
+    const d = randomDuration('mystery', () => 0)
+    expect(d).toBe(2000)
+  })
+})

--- a/web/src/game/hub/animals.ts
+++ b/web/src/game/hub/animals.ts
@@ -1,0 +1,126 @@
+// Pure logic for hub-world animals (issue #1592).
+//
+// This module is deliberately free of PixiJS and React so the spawn maths,
+// colour-variant resolution, and behaviour-transition tables can be unit
+// tested in isolation. The imperative sprite/rendering layer lives in
+// `web/src/components/hub/hubAnimals.ts`.
+
+export type AnimalType = 'cat' | 'dog' | 'bird' | 'fish'
+
+// ── Procedural spawn ratios ─────────────────────────────────────────────────
+// Cats: 1 per 4 buildings · Dogs: 1 per 4 NPCs · Birds: 4 per town ·
+// Fish: 1 per 6 pond tiles.
+export const ANIMAL_RATIOS = {
+  buildingsPerCat: 4,
+  npcsPerDog:      4,
+  birdsPerTown:    4,
+  pondTilesPerFish: 6,
+} as const
+
+// Per-type caps keep rendering cost bounded in the largest town (Ravenwatch).
+export const ANIMAL_CAPS: Record<AnimalType, number> = {
+  cat:  6,
+  dog:  8,
+  bird: 4,
+  fish: 12,
+}
+
+export interface ProceduralCounts {
+  cat:  number
+  dog:  number
+  bird: number
+  fish: number
+}
+
+/** Derive how many of each procedural animal a town should spawn. */
+export function computeProceduralCounts(
+  buildingCount: number,
+  npcCount:      number,
+  pondTileCount: number,
+): ProceduralCounts {
+  const clamp = (type: AnimalType, n: number) => Math.max(0, Math.min(ANIMAL_CAPS[type], n))
+  return {
+    cat:  clamp('cat',  Math.floor(buildingCount / ANIMAL_RATIOS.buildingsPerCat)),
+    dog:  clamp('dog',  Math.floor(npcCount      / ANIMAL_RATIOS.npcsPerDog)),
+    bird: clamp('bird', ANIMAL_RATIOS.birdsPerTown),
+    fish: clamp('fish', Math.floor(pondTileCount / ANIMAL_RATIOS.pondTilesPerFish)),
+  }
+}
+
+// ── Colour variants (applied via PIXI sprite.tint) ──────────────────────────
+// Base sprites are neutral grey so a flat tint reads cleanly.
+export const TINT_PALETTES: Record<AnimalType, Record<string, number>> = {
+  cat:  { black: 0x3a3a3a, orange: 0xe8923c, grey: 0x9aa0a6, white: 0xf5f5f0, cream: 0xe8d8b0 },
+  dog:  { brown: 0x8b5a2b, black: 0x3a3a3a, golden: 0xe0b050, tan: 0xc9a06a },
+  bird: { red: 0xd64545, blue: 0x4f86d6, brown: 0x9c6b3f, yellow: 0xe8d24a },
+  fish: { orange: 0xe8923c, silver: 0xc8d0d8, teal: 0x46b0a8 },
+}
+
+/**
+ * Resolve a colour-variant for an animal to a PIXI tint (0xRRGGBB).
+ * `variant` may be a palette key (e.g. "orange"), a hex string
+ * ("#e8923c"/"e8923c"/"0xe8923c"), or omitted (random from the type palette).
+ */
+export function resolveVariantTint(
+  type:    AnimalType,
+  variant?: string,
+  rng:     () => number = Math.random,
+): number {
+  const palette = TINT_PALETTES[type]
+  if (variant) {
+    if (variant in palette) return palette[variant]
+    const hex = variant.replace(/^#/, '').replace(/^0x/i, '')
+    if (/^[0-9a-fA-F]{6}$/.test(hex)) return parseInt(hex, 16)
+  }
+  const values = Object.values(palette)
+  return values[Math.floor(rng() * values.length)]
+}
+
+// ── Behaviour transition tables ─────────────────────────────────────────────
+// Only the *idle* transitions are weighted here; event-driven states
+// (cat flee/chase-bird, dog bark/wag) are triggered by the manager.
+export type CatState = 'wander' | 'sit' | 'sleep' | 'follow-player' | 'flee' | 'chase-bird'
+export type DogState = 'follow-owner' | 'roam' | 'bark' | 'wag'
+export type BirdState = 'perched' | 'fleeing'
+
+export const CAT_IDLE_WEIGHTS: Record<string, number> = {
+  wander:          4,
+  sit:             3,
+  sleep:           2,
+  'follow-player': 1,
+}
+
+export const DOG_IDLE_WEIGHTS: Record<string, number> = {
+  'follow-owner': 5,
+  roam:           3,
+}
+
+/** Pick a key from a weight table. Higher weight → more likely. */
+export function pickWeighted(
+  weights: Record<string, number>,
+  rng:     () => number = Math.random,
+): string {
+  const entries = Object.entries(weights)
+  const total = entries.reduce((sum, [, w]) => sum + w, 0)
+  let r = rng() * total
+  for (const [key, w] of entries) {
+    r -= w
+    if (r < 0) return key
+  }
+  return entries[entries.length - 1][0]
+}
+
+// Idle-state durations, in milliseconds: [min, max].
+export const STATE_DURATION_MS: Record<string, [number, number]> = {
+  wander:          [2000, 5000],
+  sit:             [3000, 8000],
+  sleep:           [6000, 14000],
+  'follow-player': [3000, 7000],
+  'follow-owner':  [4000, 9000],
+  roam:            [2000, 5000],
+}
+
+export function randomDuration(state: string, rng: () => number = Math.random): number {
+  const [lo, hi] = STATE_DURATION_MS[state] ?? [2000, 4000]
+  return lo + rng() * (hi - lo)
+}


### PR DESCRIPTION
Closes #1592.

Adds living-town ambience to every hub town: autonomous **cats, dogs, birds, and fish** with colour variants, that are tappable and can give or be steps in quests.

## What's included

### Animals
- **Cats** — wander / sit / sleep / follow the player / flee when approached / chase birds. 1 per 4 buildings (cap 6).
- **Dogs** — pick a named-NPC owner to follow, roam, and react to new NPCs by rolling like/dislike → wag (♥) or bark ("Woof!"). 1 per 4 NPCs (cap 8).
- **Birds** — perch on building roof ridges and empty path tiles, flee everything by flying off-screen and re-pitching elsewhere. 4 per town.
- **Fish** — swim gently within pond tiles with a sine bob. 1 per 6 pond tiles (cap 12); appear only where ponds exist (currently Ravenwatch).

Procedural counts derive from each town's geometry, so **all 13 towns** get animals automatically. Colour variants are produced by `sprite.tint` over neutral-grey base SVGs (one base + walk/fly frames per type, plus a cat sleep pose).

### Interactivity & quests
- Procedural animals show flavour bubbles on tap (meow/woof/chirp).
- **Placed/quest animals** are defined in `config.json` (stable `id`, predictable tile) and route taps through the existing NPC quest logic, so they can give quests, be `deliver` targets, and show `!`/`?` indicators. Stationary placed animals don't flee, so they stay tappable.
- Authored quests: **Feed the Stray**, **Where's Rover?**, **Pip's Treasures** (Ravenwatch) and **The Dockside Cat** (Saltmere Port).

## Architecture
- `web/src/game/hub/animals.ts` — pure logic (ratios/caps, tint palettes, behaviour tables) + unit tests.
- `web/src/components/hub/hubAnimals.ts` — `createAnimalSystem` PixiJS manager (spawns/ticks all animals), reusing `findPath`, `loadAnimFrames`, and the canvas layers.
- `HubTownCanvas.tsx` instantiates the system and ticks it; `HubWorld.tsx` adds `handleAnimalTap` and extends the quest lookup to `HUB_ANIMALS`.
- New `animals` config schema parsed in `loader.ts` (`HUB_ANIMALS`).
- Docs: new **§8 — Animals** in `docs/hubworld.md` with schema and authoring checklist.

## Verification
- `npm run test` — 145 tests pass (incl. new animal-logic + loader-parsing tests).
- `npm run build` — clean TypeScript build.

Manual QA suggestion: open Ravenwatch and confirm cats/dogs/birds behave as described, fish swim in the pond, and the four animal quests can be completed end-to-end.

https://claude.ai/code/session_01AJ8fw6nbRq6kDss3frrmwq

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJ8fw6nbRq6kDss3frrmwq)_