### PR TITLE
Hub animals: lazy cats, cat/dog interactions, and building dens

### DIFF
--- a/docs/hubworld.md
+++ b/docs/hubworld.md
@@ -333,13 +333,32 @@ automatically; fish appear only where `pondTiles` exist.
 
 ### Behaviours
 
-- **Cat** — `wander / sit / sleep / follow-player`, plus event states `flee`
-  (runs from an approaching player) and `chase-bird` (sends the bird fleeing).
-- **Dog** — picks a named-NPC `owner`; `follow-owner / roam`, and reacts to
-  *new* NPCs it meets by rolling like/dislike → wag (♥) or bark ("Woof!").
+- **Cat** — lazy: mostly `sleep`/`sit`, only rousing for a stimulus — a dog to
+  flee, a bird to chase, another cat to play with (♪), or an NPC who might feed
+  them (?). Cats roam **off the paths onto grass**, stepping one tile at a time
+  around solid tiles (buildings/ponds) toward a `goal` beacon (greedy nav, not
+  the street pathfinder), and pad to a quiet grass spot to curl up.
+- **Dog** — picks a named-NPC `owner`; `follow-owner / roam`, chases wandering
+  cats, and reacts to *new* NPCs it meets by rolling like/dislike → wag (♥) or
+  bark ("Woof!").
 - **Bird** — `perched` on roof ridges or empty path tiles; flees everything by
   flying off-screen and re-pitching at a new empty spot.
 - **Fish** — gentle swim constrained to pond tiles, with a sine bob.
+
+### Den schedule & building interiors
+
+Roughly **half** of the procedural cats & dogs are assigned a **home building**
+(a random building door) at spawn. They follow a **night-in / day-out** cycle
+(`getGameHour`): at night (hour ≥ 20 or < 6) they path to their home door and
+**go inside** (the exterior sprite hides, `insideBuilding` is set); in the
+morning they re-emerge at the door. While denned they are excluded from the
+exterior tick.
+
+When the player **enters a building**, `HubTownCanvas` calls
+`animalSystem.getAnimalsInBuilding(buildingId)` and renders any denned cats/dogs
+as **present & idle** sprites (cat = sleep pose, dog = sitting), tinted with
+their variant, at free interior tiles. Cats navigate to their door with the
+grass-capable greedy stepper; dogs use the street pathfinder.
 
 Placed animals with `roam !== true` are **stationary**: they do not wander or
 flee, so the player can always reach them to tap (important for quest givers,

--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -1271,6 +1271,10 @@ export function HubTownCanvas({
       }
     }
 
+    // Provider set once the animal system is created (below). Lets the interior
+    // renderer show cats/dogs that are denned inside the building being entered.
+    let getAnimalsInBuildingFn: (buildingId: string) => { type: string; tint: number }[] = () => []
+
     // ── Interior enter ─────────────────────────────────────────────────────────
     const doEnterInterior = (buildingId: string, entryTx?: number, entryTy?: number) => {
       try {
@@ -1603,6 +1607,26 @@ export function HubTownCanvas({
           })
           interiorLayer.addChild(s)
         }).catch(() => {})
+      }
+
+      // Denned animals — cats/dogs that are home inside this building (#1592)
+      {
+        const denned = getAnimalsInBuildingFn(buildingId)
+        const freeTiles = Array.from(interiorWalkable).map(k => k.split(',').map(Number) as [number, number])
+        denned.forEach((da, i) => {
+          const slug = da.type === 'cat' ? 'animal-cat-sleep' : `animal-${da.type}`
+          const spot = freeTiles[(i * 5 + 2) % Math.max(1, freeTiles.length)] ?? [1, 1]
+          loadTextureUrl(`${base}sprites/${slug}.svg`).then(tex => {
+            if (!interiorActive || currentInteriorId !== buildingId) return
+            const s = new PIXI.Sprite(tex)
+            const px = SPRITE_SIZE * (da.type === 'cat' ? 0.62 : 0.72)
+            s.width = px; s.height = px
+            s.anchor.set(0.5, 1)
+            s.tint = da.tint
+            s.position.set(spot[0] * T + T / 2, spot[1] * T + T)
+            interiorLayer.addChild(s)
+          }).catch(() => {})
+        })
       }
 
       // Quest indicators for interior NPCs
@@ -2029,6 +2053,11 @@ export function HubTownCanvas({
       }
       return s
     }
+    // Tiles cats may not pad across when roaming off the paths.
+    const animalPondSet = new Set(HUB_POND_TILES.map(([tx, ty]) => `${tx},${ty}`))
+    const animalIsSolid = (tx: number, ty: number): boolean =>
+      tx < 0 || ty < 0 || tx >= MAP_W / T || ty >= MAP_H / T ||
+      buildingSet.has(`${tx},${ty}`) || animalPondSet.has(`${tx},${ty}`)
     const animalSystem: AnimalSystem = createAnimalSystem({
       app,
       spriteLayer,
@@ -2041,6 +2070,9 @@ export function HubTownCanvas({
       mapW: MAP_W,
       mapH: MAP_H,
       getWalkable: animalGetWalkable,
+      isSolidTile: animalIsSolid,
+      getGameHour: () => gameHourRef.current,
+      homes: HUB_DOORS.filter(d => d.buildingId).map(d => ({ buildingId: d.buildingId, tx: d.tx, ty: d.ty })),
       pondTiles: HUB_POND_TILES,
       roofTiles: animalRoofTiles,
       placedAnimals: HUB_ANIMALS,
@@ -2061,6 +2093,7 @@ export function HubTownCanvas({
       getQuestIndicator: (id) => questNpcState?.current.get(id) ?? null,
       isInteriorActive: () => interiorActive,
     })
+    getAnimalsInBuildingFn = animalSystem.getAnimalsInBuilding
 
     app.ticker.add((ticker) => {
       try {

--- a/web/src/components/hub/hubAnimals.ts
+++ b/web/src/components/hub/hubAnimals.ts
@@ -11,7 +11,6 @@ import { loadAnimFrames, loadTextureUrl } from '../../utils/pixiHelpers'
 import type { HubAnimal } from '../../data/hub/loader'
 import {
   AnimalType,
-  CAT_IDLE_WEIGHTS,
   DOG_IDLE_WEIGHTS,
   computeProceduralCounts,
   pickWeighted,
@@ -46,6 +45,7 @@ interface Animal {
   path: [number, number][]
   movingTo: [number, number] | null
   target: Pt | null
+  goal: [number, number] | null   // cats: beacon tile they walk toward (grass-capable)
   staticTex: PIXI.Texture | null
   sleepTex: PIXI.Texture | null
   frames: PIXI.Texture[]
@@ -85,6 +85,8 @@ export interface AnimalSystemOptions {
   mapH: number
   /** Current walkable street tiles ("tx,ty"), recomputed each call. */
   getWalkable: () => Set<string>
+  /** True if a tile is impassable for off-path roamers (building/pond/out-of-bounds). */
+  isSolidTile: (tx: number, ty: number) => boolean
   pondTiles: [number, number][]
   roofTiles: [number, number][]
   placedAnimals: HubAnimal[]
@@ -217,48 +219,16 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
     if (a.bubble) a.bubble.position.set(a.sprite.x, a.sprite.y - spriteSize * a.baseScale - 4)
   }
 
-  // ── behaviour: cats ──────────────────────────────────────────────────────────
-  function catIdle(a: Animal, walkable: Set<string>, avatar: Pt) {
-    const choice = a.stationary ? (Math.random() < 0.5 ? 'sit' : 'sleep') : pickWeighted(CAT_IDLE_WEIGHTS)
-    a.state = choice
-    a.stateTimer = randomDuration(choice)
-    if (choice === 'sit') showStatic(a)
-    else if (choice === 'sleep') showSleep(a)
-    else if (choice === 'wander') {
-      const dest = randOf(tilesWithin(walkable, a.tx, a.ty, 5))
-      if (dest) setPath(a, [a.tx, a.ty], dest, walkable)
-      showStatic(a)
-    } else if (choice === 'follow-player') {
-      showStatic(a)
-      followToward(a, avatar, walkable)
+  // Nearest other animal matching `pred` within `radiusPx`, else null.
+  function nearestAnimal(a: Animal, pred: (o: Animal) => boolean, radiusPx: number): Animal | null {
+    let best: Animal | null = null
+    let bd = radiusPx
+    for (const o of animals) {
+      if (o === a || !pred(o)) continue
+      const d = Math.hypot(o.sprite.x - a.sprite.x, o.sprite.y - a.sprite.y)
+      if (d < bd) { bd = d; best = o }
     }
-  }
-
-  function catEvents(a: Animal, dt: number, walkable: Set<string>, avatar: Pt, perchedBirds: Animal[]) {
-    if (a.stationary) return  // placed quest cats stay put so they can be tapped
-    if (a.state === 'flee' || a.state === 'chase-bird') return
-    const dAv = Math.hypot(avatar.x - a.sprite.x, avatar.y - a.sprite.y)
-    if (dAv < 3 * T && Math.random() < (dt / 1000) * 0.6) {
-      // run away
-      a.state = 'flee'; a.stateTimer = 2400
-      const avTile: [number, number] = [Math.floor(avatar.x / T), Math.floor(avatar.y / T)]
-      const opt = tilesWithin(walkable, a.tx, a.ty, 6)
-      let best: [number, number] | null = null, bestD = -1
-      for (const t of opt) {
-        const d = Math.abs(t[0] - avTile[0]) + Math.abs(t[1] - avTile[1])
-        if (d > bestD) { bestD = d; best = t }
-      }
-      if (best) setPath(a, [a.tx, a.ty], best, walkable)
-      return
-    }
-    if (!a.stationary) {
-      const bird = perchedBirds.find(b => Math.hypot(b.sprite.x - a.sprite.x, b.sprite.y - a.sprite.y) < 5 * T)
-      if (bird && Math.random() < (dt / 1000) * 0.4) {
-        a.state = 'chase-bird'; a.stateTimer = 3000
-        bird.fleeRequested = true
-        setPath(a, [a.tx, a.ty], [bird.tx, bird.ty], walkable)
-      }
-    }
+    return best
   }
 
   function followToward(a: Animal, target: Pt, walkable: Set<string>) {
@@ -267,6 +237,104 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
     const near = tilesWithin(walkable, tt[0], tt[1], 2)
     const dest = randOf(near) ?? (walkable.has(key(tt[0], tt[1])) ? tt : null)
     if (dest) setPath(a, [a.tx, a.ty], dest, walkable)
+  }
+
+  // ── behaviour: cats ──────────────────────────────────────────────────────────
+  // Cats are lazy: they sleep most of the day and only rouse for something that
+  // interests a feline soul — a dog to flee, a bird to chase, another cat to
+  // play with, or an NPC who might feed them. They roam off the paths (onto
+  // grass) toward a `goal` beacon, stepping around solid tiles (#1592).
+  const cols = Math.floor(opts.mapW / T)
+  const rows = Math.floor(opts.mapH / T)
+  const DIRS8: [number, number][] = [[0, -1], [1, -1], [1, 0], [1, 1], [0, 1], [-1, 1], [-1, 0], [-1, -1]]
+  const clampN = (n: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, n))
+
+  // Greedy one-tile step toward a.goal, avoiding solids (lets cats cross grass).
+  function catStep(a: Animal) {
+    if (!a.goal) return
+    const [gx, gy] = a.goal
+    if (Math.abs(a.tx - gx) <= 1 && Math.abs(a.ty - gy) <= 1) { a.goal = null; return }
+    let best: [number, number] | null = null, bd = Infinity
+    for (const [dx, dy] of DIRS8) {
+      const nx = a.tx + dx, ny = a.ty + dy
+      if (nx < 0 || ny < 0 || nx >= cols || ny >= rows) continue
+      if (opts.isSolidTile(nx, ny)) continue
+      const d = Math.hypot(nx - gx, ny - gy)
+      if (d < bd) { bd = d; best = [nx, ny] }
+    }
+    if (best) { a.movingTo = best; a.target = center(a, best[0], best[1]); a.path = [] }
+    else a.goal = null
+  }
+
+  function catFleeFrom(a: Animal, fromPx: Pt, durationMs: number) {
+    a.state = 'flee'; a.stateTimer = durationMs
+    const dx = a.tx - fromPx.x / T, dy = a.ty - fromPx.y / T
+    const len = Math.hypot(dx, dy) || 1
+    a.goal = [clampN(Math.round(a.tx + (dx / len) * 6), 0, cols - 1),
+              clampN(Math.round(a.ty + (dy / len) * 6), 0, rows - 1)]
+  }
+
+  // A quiet grass tile (off the path) within a short radius, else null.
+  function comfyTile(a: Animal, walkable: Set<string>): [number, number] | null {
+    const out: [number, number][] = []
+    for (let dx = -3; dx <= 3; dx++) for (let dy = -3; dy <= 3; dy++) {
+      const tx = a.tx + dx, ty = a.ty + dy
+      if ((dx || dy) && tx >= 0 && ty >= 0 && tx < cols && ty < rows
+          && !opts.isSolidTile(tx, ty) && !walkable.has(key(tx, ty))) out.push([tx, ty])
+    }
+    return randOf(out)
+  }
+
+  function catRest(a: Animal, walkable: Set<string>) {
+    const sleeping = Math.random() < 0.85
+    a.state = sleeping ? 'sleep' : 'sit'
+    a.stateTimer = sleeping ? 12000 + Math.random() * 30000 : 4000 + Math.random() * 6000
+    // Sometimes pad off the path to a comfy grass spot, then settle there.
+    a.goal = Math.random() < 0.4 ? comfyTile(a, walkable) : null
+  }
+
+  // While at rest, look for a reason to wake. Returns true if one was found.
+  function catWake(a: Animal, dt: number, npcs: { x: number; y: number }[], perchedBirds: Animal[]): boolean {
+    const bird = perchedBirds.find(b => Math.hypot(b.sprite.x - a.sprite.x, b.sprite.y - a.sprite.y) < 5 * T)
+    if (bird && Math.random() < (dt / 1000) * 0.5) {
+      a.state = 'chase-bird'; a.stateTimer = 3500; bird.fleeRequested = true; a.goal = [bird.tx, bird.ty]; return true
+    }
+    const cat = nearestAnimal(a, o => o.type === 'cat' && !o.stationary, 4 * T)
+    if (cat && Math.random() < (dt / 1000) * 0.12) {
+      a.state = 'play'; a.stateTimer = 4000; a.goal = [cat.tx, cat.ty]; return true
+    }
+    let npc: { x: number; y: number } | null = null, nd = 3 * T
+    for (const n of npcs) { const d = Math.hypot(n.x - a.sprite.x, n.y - a.sprite.y); if (d < nd) { nd = d; npc = n } }
+    if (npc && Math.random() < (dt / 1000) * 0.1) {
+      a.state = 'approach-npc'; a.stateTimer = 5000; a.goal = [Math.floor(npc.x / T), Math.floor(npc.y / T)]; return true
+    }
+    return false
+  }
+
+  function catTick(a: Animal, dt: number, walkable: Set<string>, npcs: { x: number; y: number }[], perchedBirds: Animal[]) {
+    if (a.stationary) {
+      if (!isMoving(a) && a.stateTimer <= 0) {
+        a.state = Math.random() < 0.6 ? 'sleep' : 'sit'
+        a.stateTimer = 5000 + Math.random() * 8000
+      }
+      return
+    }
+    // A dog always interrupts whatever the cat was doing.
+    if (a.state !== 'flee') {
+      const dog = nearestAnimal(a, o => o.type === 'dog', 3.5 * T)
+      if (dog) catFleeFrom(a, { x: dog.sprite.x, y: dog.sprite.y }, 2600)
+    }
+    // Other stimuli only rouse a resting cat.
+    if (a.state === 'sleep' || a.state === 'sit') catWake(a, dt, npcs, perchedBirds)
+    // Progress toward the current goal one tile at a time.
+    if (a.goal && !isMoving(a)) catStep(a)
+    // Reached a play/feed goal — react, then settle.
+    if (!a.goal && !isMoving(a) && (a.state === 'play' || a.state === 'approach-npc')) {
+      speak(a, a.state === 'play' ? '♪' : '?', 1400)
+      a.state = 'sit'; a.stateTimer = 1500
+    }
+    // Finished an active state → back to a long rest.
+    if (!isMoving(a) && !a.goal && a.stateTimer <= 0) catRest(a, walkable)
   }
 
   // ── behaviour: dogs ──────────────────────────────────────────────────────────
@@ -310,6 +378,19 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
     a.reactCooldown = 5000
     if (likes) { speak(a, '♥'); a.wagTimer = 1300 }
     else speak(a, 'Woof!')
+  }
+
+  // Dogs occasionally spot a wandering cat and give chase (the cat flees via its
+  // own dog-avoidance). Returns true if a chase started.
+  function dogChaseCat(a: Animal, dt: number, walkable: Set<string>): boolean {
+    if (a.stationary || a.state === 'chase-cat') return false
+    const cat = nearestAnimal(a, o => o.type === 'cat' && !o.stationary, 5 * T)
+    if (cat && Math.random() < (dt / 1000) * 0.5) {
+      a.state = 'chase-cat'; a.stateTimer = 3000
+      setPath(a, [a.tx, a.ty], [cat.tx, cat.ty], walkable)
+      return true
+    }
+    return false
   }
 
   // ── behaviour: birds ─────────────────────────────────────────────────────────
@@ -438,18 +519,22 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
       // cats & dogs
       advance(a, dt)
       if (isMoving(a)) animateWalk(a, dt)
-      else if (a.state !== 'sleep') showStatic(a)
+      else if (a.state === 'sleep') showSleep(a)
+      else showStatic(a)
 
       a.stateTimer -= dt
       if (a.type === 'cat') {
-        catEvents(a, dt, walkable, avatar, perchedBirds)
-        if (a.state === 'follow-player' && !isMoving(a) && a.stateTimer > 0) followToward(a, avatar, walkable)
-        if (!isMoving(a) && a.stateTimer <= 0) catIdle(a, walkable, avatar)
+        catTick(a, dt, walkable, npcs, perchedBirds)
       } else {
         dogSocial(a, dt, npcs)
+        dogChaseCat(a, dt, walkable)
         if (a.state === 'follow-owner' && !isMoving(a) && a.stateTimer > 0) {
           const owner = npcs.find(n => n.id === a.ownerId)
           if (owner) followToward(a, owner, walkable)
+        }
+        if (a.state === 'chase-cat' && !isMoving(a) && a.stateTimer > 0) {
+          const cat = nearestAnimal(a, o => o.type === 'cat' && !o.stationary, 6 * T)
+          if (cat) setPath(a, [a.tx, a.ty], [cat.tx, cat.ty], walkable)
         }
         if (!isMoving(a) && a.stateTimer <= 0) dogIdle(a, walkable, npcs)
       }
@@ -480,9 +565,9 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
     const a: Animal = {
       type, id: placed?.id, stationary: !!placed && placed.roam !== true,
       homeTile: [tx, ty], sprite, bottomAnchored, baseScale,
-      tx, ty, path: [], movingTo: null, target: null,
+      tx, ty, path: [], movingTo: null, target: null, goal: null,
       staticTex, sleepTex: null, frames: [], frameIdx: 0, frameTimer: FRAME_MS,
-      state: type === 'bird' ? 'perched' : type === 'fish' ? 'swim' : 'sit',
+      state: type === 'bird' ? 'perched' : type === 'fish' ? 'swim' : type === 'cat' ? 'sleep' : 'sit',
       stateTimer: 500 + Math.random() * 1500,
       bubble: null, bubbleTimer: 0,
       seen: new Set(), opinion: new Map(), reactCooldown: 0, wagTimer: 0,

--- a/web/src/components/hub/hubAnimals.ts
+++ b/web/src/components/hub/hubAnimals.ts
@@ -38,8 +38,12 @@ interface Animal {
   stationary: boolean         // placed animal with roam !== true
   homeTile: [number, number]
   sprite: PIXI.Sprite
+  tint: number
   bottomAnchored: boolean
   baseScale: number
+  homeBuildingId?: string         // building this animal dens in at night
+  homeDoor?: [number, number]     // its door tile
+  insideBuilding: string | null   // currently denned inside this building
   tx: number
   ty: number
   path: [number, number][]
@@ -87,6 +91,10 @@ export interface AnimalSystemOptions {
   getWalkable: () => Set<string>
   /** True if a tile is impassable for off-path roamers (building/pond/out-of-bounds). */
   isSolidTile: (tx: number, ty: number) => boolean
+  /** Current in-game hour (0–23) for the day/night den schedule. */
+  getGameHour: () => number
+  /** Buildings (with door tiles) cats/dogs can call home. */
+  homes: { buildingId: string; tx: number; ty: number }[]
   pondTiles: [number, number][]
   roofTiles: [number, number][]
   placedAnimals: HubAnimal[]
@@ -104,6 +112,8 @@ export interface AnimalSystemOptions {
 
 export interface AnimalSystem {
   tick: (deltaMS: number) => void
+  /** Animals currently denned inside the given building (for interior render). */
+  getAnimalsInBuilding: (buildingId: string) => { type: AnimalType; tint: number }[]
   destroy: () => void
 }
 
@@ -483,6 +493,56 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
     a.sprite.y = a.baseY + Math.sin(a.bobPhase) * 1.5
   }
 
+  // ── day/night den schedule (cats & dogs with a home) ────────────────────────
+  const isNightHour = (hour: number) => hour >= 20 || hour < 6
+
+  function enterHome(a: Animal) {
+    a.insideBuilding = a.homeBuildingId ?? null
+    a.sprite.visible = false
+    a.state = 'inside'
+    a.goal = null; a.target = null; a.movingTo = null; a.path = []
+    if (a.bubble) { opts.bubbleLayer.removeChild(a.bubble); a.bubble = null }
+  }
+
+  function exitHome(a: Animal) {
+    const door = a.homeDoor
+    if (door) {
+      a.tx = door[0]; a.ty = door[1]
+      const c = center(a, a.tx, a.ty)
+      a.sprite.x = c.x; a.sprite.y = c.y; a.baseY = c.y
+      a.sprite.zIndex = c.y
+    }
+    a.insideBuilding = null
+    a.sprite.visible = true
+    a.state = a.type === 'cat' ? 'sleep' : 'sit'
+    a.stateTimer = 1000 + Math.random() * 2000
+  }
+
+  const atTile = (a: Animal, tile: [number, number]) =>
+    Math.abs(a.tx - tile[0]) <= 1 && Math.abs(a.ty - tile[1]) <= 1
+
+  // Returns true if the animal is (or is heading) inside and needs no exterior tick.
+  function runDenSchedule(a: Animal, walkable: Set<string>, hour: number): boolean {
+    if (!a.homeBuildingId || !a.homeDoor) return false
+    const wantInside = isNightHour(hour)
+    if (a.insideBuilding) {
+      if (!wantInside) exitHome(a)   // morning — come back out
+      return !!a.insideBuilding
+    }
+    if (wantInside) {
+      if (a.state !== 'go-home') {
+        a.state = 'go-home'
+        if (a.type === 'cat') a.goal = a.homeDoor
+        else setPath(a, [a.tx, a.ty], a.homeDoor, walkable)
+      }
+      if (a.type === 'cat' && a.goal && !isMoving(a)) catStep(a)
+      if (!isMoving(a) && atTile(a, a.homeDoor)) enterHome(a)
+      return true   // travelling home — skip normal behaviour
+    }
+    if (a.state === 'go-home') { a.state = a.type === 'cat' ? 'sleep' : 'sit'; a.goal = null }
+    return false
+  }
+
   // ── per-frame tick ───────────────────────────────────────────────────────────
   function tick(deltaMS: number) {
     if (opts.isInteriorActive()) { birdLayer.visible = false; fishLayer.visible = false; return }
@@ -491,6 +551,7 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
     const walkable = opts.getWalkable()
     const avatar = opts.getAvatarPx()
     const npcs = opts.getNpcPositions()
+    const hour = opts.getGameHour()
     const perchedBirds = animals.filter(a => a.type === 'bird' && a.state === 'perched')
 
     for (const a of animals) {
@@ -510,6 +571,17 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
           a.indicator.tint = st === 'ready' ? 0x66ddff : 0xffdd44
           const bob = Math.sin(performance.now() / 300) * 2
           a.indicator.position.set(a.sprite.x, a.sprite.y - spriteSize * a.baseScale - 6 + bob)
+        }
+      }
+
+      // Day/night den schedule (cats & dogs with a home building).
+      if (a.type === 'cat' || a.type === 'dog') {
+        const busy = runDenSchedule(a, walkable, hour)
+        if (a.insideBuilding) continue          // denned inside — hidden, no exterior update
+        if (busy) {                              // travelling home
+          advance(a, dt)
+          if (isMoving(a)) animateWalk(a, dt); else showStatic(a)
+          continue
         }
       }
 
@@ -553,7 +625,8 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
     sprite.width = px; sprite.height = px
     const bottomAnchored = type !== 'fish'
     sprite.anchor.set(0.5, bottomAnchored ? 1 : 0.5)
-    sprite.tint = resolveVariantTint(type, placed?.variant)
+    const tint = resolveVariantTint(type, placed?.variant)
+    sprite.tint = tint
     const baseScale = sprite.scale.x
 
     const layer = type === 'bird' ? birdLayer : type === 'fish' ? fishLayer : opts.spriteLayer
@@ -564,7 +637,8 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
 
     const a: Animal = {
       type, id: placed?.id, stationary: !!placed && placed.roam !== true,
-      homeTile: [tx, ty], sprite, bottomAnchored, baseScale,
+      homeTile: [tx, ty], sprite, tint, bottomAnchored, baseScale,
+      insideBuilding: null,
       tx, ty, path: [], movingTo: null, target: null, goal: null,
       staticTex, sleepTex: null, frames: [], frameIdx: 0, frameTimer: FRAME_MS,
       state: type === 'bird' ? 'perched' : type === 'fish' ? 'swim' : type === 'cat' ? 'sleep' : 'sit',
@@ -573,6 +647,13 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
       seen: new Set(), opinion: new Map(), reactCooldown: 0, wagTimer: 0,
       fleeRequested: false, bobPhase: Math.random() * Math.PI * 2, baseY: c.y,
       indicator: null,
+    }
+    // Give roughly half of the procedural cats & dogs a home building they den
+    // in at night.
+    if (!placed && (type === 'cat' || type === 'dog') && opts.homes.length > 0 && Math.random() < 0.5) {
+      const home = opts.homes[(Math.random() * opts.homes.length) | 0]
+      a.homeBuildingId = home.buildingId
+      a.homeDoor = [home.tx, home.ty]
     }
     animals.push(a)
 
@@ -628,6 +709,10 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
   // Placed/quest animals (always rendered)
   for (const pa of opts.placedAnimals) void makeAnimal(pa.type, pa.tx, pa.ty, pa)
 
+  function getAnimalsInBuilding(buildingId: string): { type: AnimalType; tint: number }[] {
+    return animals.filter(a => a.insideBuilding === buildingId).map(a => ({ type: a.type, tint: a.tint }))
+  }
+
   function destroy() {
     for (const a of animals) {
       if (a.bubble) opts.bubbleLayer.removeChild(a.bubble)
@@ -639,5 +724,5 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
     fishLayer.destroy({ children: true })
   }
 
-  return { tick, destroy }
+  return { tick, getAnimalsInBuilding, destroy }
 }


### PR DESCRIPTION
More hub-animal behaviour from playtest feedback (#1592).

## Changes

**Cats are now lazy and reactive** (real cats sleep ~20h/day!):
- Cats mostly **sleep/rest** and only rouse for something that interests them:
  - a **dog** nearby → flee
  - a **bird** nearby → chase (sends the bird fleeing)
  - **another cat** nearby → wander over to play (♪)
  - an **NPC** nearby who might feed them → approach hopefully (?)
- Cats **roam off the paths onto grass**, stepping one tile at a time around solid tiles (buildings/ponds) toward a goal beacon — no longer confined to the street navmesh.
- When settling, cats pad to a quiet grass spot and curl up to sleep.

**Cat ↔ dog interactions:**
- Cats **avoid/flee dogs**.
- Dogs **chase wandering cats**, or fall back to following their owner NPC / roaming.

**Animals den in buildings (day/night schedule):**
- ~half of procedural cats & dogs get a **home building** (a random door) and follow a **night-in / day-out** cycle: at night they path to their door and go inside; in the morning they re-emerge.
- When you **enter a building**, any denned cats/dogs render inside as **present & idle** sprites (cat sleeping, dog sitting), tinted by variant.

## Implementation
- New cat state machine + grass-capable greedy navigation (`isSolidTile` predicate from the canvas).
- Den schedule (`getGameHour`, home assignment, enter/exit) and `getAnimalsInBuilding` exposed to the interior renderer in `HubTownCanvas`.
- `docs/hubworld.md §8` updated (behaviours, den schedule, interior rendering).

## Verification
- `npm run build` clean; `npm run test` passes.

https://claude.ai/code/session_01AJ8fw6nbRq6kDss3frrmwq