### PR TITLE
Hub animals: double birds per town (4 → 8)

### DIFF
--- a/docs/hubworld.md
+++ b/docs/hubworld.md
@@ -325,7 +325,7 @@ and behaviour tables live in `web/src/game/hub/animals.ts`.
 |---|---|---|---|
 | Cats | 1 per 4 buildings | `HUB_BUILDINGS.length` | 6 |
 | Dogs | 1 per 4 NPCs | exterior NPC count | 8 |
-| Birds | 4 per town (fixed) | — | 4 |
+| Birds | 8 per town (fixed) | — | 8 |
 | Fish | 1 per 6 pond tiles | `HUB_POND_TILES.length` | 12 |
 
 Counts come from `computeProceduralCounts`. All towns get cats/dogs/birds

--- a/web/src/game/hub/animals.test.ts
+++ b/web/src/game/hub/animals.test.ts
@@ -10,16 +10,16 @@ import {
 
 describe('computeProceduralCounts', () => {
   it('applies the issue ratios', () => {
-    // 8 buildings → 2 cats, 8 npcs → 2 dogs, birds fixed 4, 12 pond tiles → 2 fish
-    expect(computeProceduralCounts(8, 8, 12)).toEqual({ cat: 2, dog: 2, bird: 4, fish: 2 })
+    // 8 buildings → 2 cats, 8 npcs → 2 dogs, birds fixed 8, 12 pond tiles → 2 fish
+    expect(computeProceduralCounts(8, 8, 12)).toEqual({ cat: 2, dog: 2, bird: 8, fish: 2 })
   })
 
   it('floors fractional counts', () => {
-    expect(computeProceduralCounts(7, 7, 11)).toEqual({ cat: 1, dog: 1, bird: 4, fish: 1 })
+    expect(computeProceduralCounts(7, 7, 11)).toEqual({ cat: 1, dog: 1, bird: 8, fish: 1 })
   })
 
   it('returns zero when there is no source data (and birds stay fixed)', () => {
-    expect(computeProceduralCounts(0, 0, 0)).toEqual({ cat: 0, dog: 0, bird: 4, fish: 0 })
+    expect(computeProceduralCounts(0, 0, 0)).toEqual({ cat: 0, dog: 0, bird: 8, fish: 0 })
   })
 
   it('clamps to the per-type caps for a large town', () => {
@@ -28,7 +28,7 @@ describe('computeProceduralCounts', () => {
     expect(counts.cat).toBe(5)                 // 22/4=5, below cap 6
     expect(counts.dog).toBe(ANIMAL_CAPS.dog)   // 56/4=14 → capped to dog cap
     expect(counts.fish).toBe(ANIMAL_CAPS.fish) // 85/6=14 → capped to 12
-    expect(counts.bird).toBe(4)
+    expect(counts.bird).toBe(8)
   })
 })
 

--- a/web/src/game/hub/animals.ts
+++ b/web/src/game/hub/animals.ts
@@ -8,12 +8,12 @@
 export type AnimalType = 'cat' | 'dog' | 'bird' | 'fish'
 
 // ── Procedural spawn ratios ─────────────────────────────────────────────────
-// Cats: 1 per 4 buildings · Dogs: 1 per 4 NPCs · Birds: 4 per town ·
+// Cats: 1 per 4 buildings · Dogs: 1 per 4 NPCs · Birds: 8 per town ·
 // Fish: 1 per 6 pond tiles.
 export const ANIMAL_RATIOS = {
   buildingsPerCat: 4,
   npcsPerDog:      4,
-  birdsPerTown:    4,
+  birdsPerTown:    8,
   pondTilesPerFish: 6,
 } as const
 
@@ -21,7 +21,7 @@ export const ANIMAL_RATIOS = {
 export const ANIMAL_CAPS: Record<AnimalType, number> = {
   cat:  6,
   dog:  4,
-  bird: 4,
+  bird: 8,
   fish: 12,
 }
 


### PR DESCRIPTION
Small tweak (#1592): doubles the number of birds per hub town from **4 → 8** (both the fixed count and the cap), so towns feel busier.

## Verification
- `npm run test` passes (counts tests updated).
- `npm run build` clean.
- `docs/hubworld.md §8` table updated.

https://claude.ai/code/session_01AJ8fw6nbRq6kDss3frrmwq

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJ8fw6nbRq6kDss3frrmwq)_