### PR TITLE
Hub animals: make interior animals tappable

### DIFF
--- a/docs/hubworld.md
+++ b/docs/hubworld.md
@@ -359,8 +359,9 @@ When the player **enters a building**, `HubTownCanvas` calls
 inside as `InteriorAnimal`s, tinted with their variant. They **wander the room**
 with random one-tile hops across `interiorWalkable` (cats occasionally curl up
 to sleep), ticked in the main loop while `interiorActive`, and are cleared on
-exit. Cats navigate to their door outside with the grass-capable greedy stepper;
-dogs use the street pathfinder.
+exit. They are **tappable indoors** too (flavour bubble, like outside). Cats
+navigate to their door outside with the grass-capable greedy stepper; dogs use
+the street pathfinder.
 
 Placed animals with `roam !== true` are **stationary**: they do not wander or
 flee, so the player can always reach them to tap (important for quest givers,

--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -1223,6 +1223,8 @@ export function HubTownCanvas({
       frameIdx: number
       frameTimer: number
       baseScale: number
+      bubble: PIXI.Container | null
+      bubbleTimer: number
     }
     const interiorAnimals: InteriorAnimal[] = []
 
@@ -1650,7 +1652,19 @@ export function HubTownCanvas({
               type: da.type as 'cat' | 'dog', sprite: s, tx: spot[0], ty: spot[1],
               targetX: s.x, targetY: s.y, moving: false, timer: 1000 + Math.random() * 2500,
               frames: [], staticTex: tex, sleepTex: null, frameIdx: 0, frameTimer: 160, baseScale: s.scale.x,
+              bubble: null, bubbleTimer: 0,
             }
+            // Tappable indoors too — show a flavour bubble (#1592).
+            s.eventMode = 'static'
+            s.cursor = 'pointer'
+            s.on('pointerdown', (e: PIXI.FederatedPointerEvent) => {
+              e.stopPropagation()
+              if (ia.bubble) interiorLayer.removeChild(ia.bubble)
+              const b = createSpeechBubble(ia.type === 'cat' ? 'Meow' : 'Woof!', ia.sprite.x, ia.sprite.y)
+              interiorLayer.addChild(b)
+              ia.bubble = b
+              ia.bubbleTimer = 1500
+            })
             interiorAnimals.push(ia)
             loadAnimFrames(baseSlug, 3).then(f => { ia.frames = f }).catch(() => {})
             if (da.type === 'cat') loadTextureUrl(`${base}sprites/animal-cat-sleep.svg`).then(t => { ia.sleepTex = t }).catch(() => {})
@@ -2132,6 +2146,11 @@ export function HubTownCanvas({
       if (interiorActive && interiorAnimals.length > 0) {
         const adt = Math.min(ticker.deltaMS, 50)
         for (const ia of interiorAnimals) {
+          if (ia.bubble) {
+            ia.bubble.position.set(ia.sprite.x, ia.sprite.y - SPRITE_SIZE * ia.baseScale - 4)
+            ia.bubbleTimer -= adt
+            if (ia.bubbleTimer <= 0) { interiorLayer.removeChild(ia.bubble); ia.bubble = null }
+          }
           if (ia.moving) {
             const dx = ia.targetX - ia.sprite.x, dy = ia.targetY - ia.sprite.y
             const dist = Math.hypot(dx, dy), step = 40 * (adt / 1000)


### PR DESCRIPTION
Fixes the gap you spotted (#1592): you could tap animals outside but not the ones denned **inside** buildings.

- Denned cats/dogs rendered indoors now have a tap handler and show a flavour bubble (Meow / Woof!), just like outdoors.
- The bubble follows the animal and is aged/cleared by the existing interior tick (and on exit).

## Verification
- `npm run build` clean; `npm run test` passes.
- `docs/hubworld.md §8` updated.

https://claude.ai/code/session_01AJ8fw6nbRq6kDss3frrmwq

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJ8fw6nbRq6kDss3frrmwq)_