### PR TITLE
Hub animals: pluggable registry + butterflies, rabbits, chickens, frogs

### DIFF
--- a/docs/hubworld.md
+++ b/docs/hubworld.md
@@ -19,8 +19,8 @@
 | `web/src/game/hub/friendship.ts` | NPC friendship XP/level persistence (localStorage) | `getFriendshipLevel`, `addFriendshipXp`, `getFriendshipData` |
 | `web/src/game/hub/innConvos.ts` | Inn conversation tracking (localStorage) | `getHeardConvoIds`, `markConvoHeard`, `isConvoHeard` |
 | `web/src/game/hub/interactables.ts` | Interactable grant + moved-position persistence (localStorage) | `interactableStoreKey`, `isInteractableGranted`, `markInteractableGranted`, `getInteractableMoves`, `setInteractableMove` |
-| `web/src/game/hub/animals.ts` | Pure animal logic (spawn ratios/caps, tint palettes, behaviour tables) | `computeProceduralCounts`, `resolveVariantTint`, `pickWeighted`, `ANIMAL_RATIOS`, `ANIMAL_CAPS` |
-| `web/src/components/hub/hubAnimals.ts` | PixiJS animal manager — spawns & ticks cats/dogs/birds/fish | `createAnimalSystem` |
+| `web/src/game/hub/animals.ts` | Pure animal logic — `ANIMAL_SPECS` registry (per-type data), spawn maths, tint resolution | `ANIMAL_SPECS`, `computeProceduralCounts`, `resolveVariantTint`, `ANIMAL_CAPS`, `TINT_PALETTES` |
+| `web/src/components/hub/hubAnimals.ts` | PixiJS animal manager — spawns & ticks all animal types | `createAnimalSystem` |
 | `web/src/components/hub/HubTownCanvas.tsx` | PixiJS canvas — rendering, pathfinding, walk, interactions | — |
 | `web/src/components/hub/HubWorld.tsx` | React orchestrator — quest flow, dialogue, state | — |
 
@@ -311,39 +311,66 @@ localStorage keys, entries keyed `<townName>:<interactableId>`:
 
 ---
 
-## §8 — Animals (cats, dogs, birds, fish)
+## §8 — Animals
 
 Living town ambience. Two kinds: **procedural** animals (spawned from town
 geometry, anonymous, flavour-only) and **placed** animals (defined in
 `config.json`, stable `id`, can give/receive quests). The PixiJS manager is
-`createAnimalSystem` in `web/src/components/hub/hubAnimals.ts`; the pure maths
-and behaviour tables live in `web/src/game/hub/animals.ts`.
+`createAnimalSystem` in `web/src/components/hub/hubAnimals.ts`; per-type data and
+the pure maths live in `web/src/game/hub/animals.ts`.
 
-### Procedural spawn ratios & caps
+### Registry — `ANIMAL_SPECS`
+
+Every type is one entry in the `ANIMAL_SPECS` registry (the single source of
+truth): `speed`, `scale`, tint `palette`, render `layer` (`sprite`/`overlay`/
+`pond`), `nav` mode, a `spawn` rule, optional `fleesFrom`/`chases` relations,
+and `dens` (uses the night schedule). `computeProceduralCounts(sources)` is
+data-driven from these specs. **Adding a type** = a spec entry + sprites +
+(usually) a thin `…Tick` hook in `hubAnimals.ts` reusing the shared primitives
+(`stepToward`, `nearestThreat`/`nearestPrey`, `fleeBeacon`, `advance`, `speak`).
+
+### Procedural spawn rules & caps
 
 | Animal | Count | Source | Cap |
 |---|---|---|---|
-| Cats | 1 per 4 buildings | `HUB_BUILDINGS.length` | 6 |
-| Dogs | 1 per 4 NPCs | exterior NPC count | 8 |
+| Cats | 1 per 4 buildings | building count | 6 |
+| Dogs | 1 per 4 NPCs | exterior NPC count | 4 |
 | Birds | 8 per town (fixed) | — | 8 |
-| Fish | 1 per 6 pond tiles | `HUB_POND_TILES.length` | 12 |
+| Fish | 1 per 6 pond tiles | `HUB_POND_TILES` | 12 |
+| Butterflies | 1 per 2 flower-decor tiles | flower decor in `EXTERIOR_DECOR` | 5 |
+| Rabbits | 4 per town (where grass exists) | grass tiles | 4 |
+| Chickens | 1 per 6 pen tiles | `chickenZones` | 8 |
+| Frogs | 1 per 8 pond tiles | `HUB_POND_TILES` | 4 |
 
-Counts come from `computeProceduralCounts`. All towns get cats/dogs/birds
-automatically; fish appear only where `pondTiles` exist.
+Fish/frogs need ponds; butterflies need flower decor; rabbits need grass;
+chickens need a `chickenZones` pen — otherwise that type is simply absent.
+
+### Navigation modes
+
+`grass` (cats — greedy step avoiding solids, streets allowed) · `grass-only`
+(rabbits — never streets) · `street` (dogs — street pathfinding, but they
+**leave the path** via a grass step to chase prey) · `fly` (birds, butterflies —
+free overlay movement) · `pond` (fish) · `pond-edge` (frogs) · `zone` (chickens
+— clamped to a pen rect).
 
 ### Behaviours
 
 - **Cat** — lazy: mostly `sleep`/`sit`, only rousing for a stimulus — a dog to
-  flee, a bird to chase, another cat to play with (♪), or an NPC who might feed
-  them (?). Cats roam **off the paths onto grass**, stepping one tile at a time
-  around solid tiles (buildings/ponds) toward a `goal` beacon (greedy nav, not
-  the street pathfinder), and pad to a quiet grass spot to curl up.
-- **Dog** — picks a named-NPC `owner`; `follow-owner / roam`, chases wandering
-  cats, and reacts to *new* NPCs it meets by rolling like/dislike → wag (♥) or
-  bark ("Woof!").
+  flee, a **bird or butterfly** to chase, another cat to play with (♪), or an
+  NPC who might feed them (?). Roams off the paths onto grass.
+- **Dog** — picks a named-NPC `owner`; `follow-owner / roam` on the streets,
+  **chases cats and rabbits** (leaving the path onto grass to pursue), and reacts
+  to *new* NPCs by rolling like/dislike → wag (♥) or bark.
 - **Bird** — `perched` on roof ridges or empty path tiles; flees everything by
-  flying off-screen and re-pitching at a new empty spot.
-- **Fish** — gentle swim constrained to pond tiles, with a sine bob.
+  flying off-screen and re-pitching.
+- **Fish** — gentle swim within pond tiles, with a sine bob.
+- **Butterfly** — flits **flower-to-flower** over an overlay layer with a
+  fluttery bob; darts away when a cat is near.
+- **Rabbit** — hops on **grass only**; freezes, then bolts from dogs/the player.
+- **Chicken** — confined to a fenced **pen** (`chickenZones`); pecks and hops
+  within it and scatters to the far corner when a dog or the player enters.
+- **Frog** — sits on **pond-edge** tiles, hops between them, and **plops** into
+  the water (alpha dip) when something comes near, re-emerging at an edge.
 
 ### Den schedule & building interiors
 
@@ -368,11 +395,21 @@ especially birds, which otherwise flee on approach).
 
 ### Colour variants
 
-One neutral-grey base SVG per type (`animal-cat`, `animal-dog`, `animal-bird`,
-`animal-fish`, with `-1/-2/-3` walk/fly frames and `animal-cat-sleep`),
-recoloured at spawn via `sprite.tint`. `variant` may be a palette key
-(`TINT_PALETTES`, e.g. `"orange"`, `"brown"`, `"grey"`) or a hex string
-(`"#e8923c"`); omit it for a random palette colour.
+One neutral-grey base SVG per type (`animal-<type>.svg`, with `-1/-2/-3`
+walk/fly frames for animated types and `animal-cat-sleep`), recoloured at spawn
+via `sprite.tint`. `variant` may be a palette key (each spec's `palette`, e.g.
+`"orange"`, `"brown"`, `"grey"`) or a hex string (`"#e8923c"`); omit it for a
+random palette colour.
+
+### Chicken pens (`config.json` → top-level `chickenZones`)
+
+```json
+{ "chickenZones": [ { "rect": [tx, ty, w, h], "count": 3 } ] }
+```
+
+Each `rect` is a fenced area (draw it over existing fence decor). Chickens spawn
+and stay inside; `count` is optional (defaults to the 1-per-6-tiles rule, capped
+at 8). No zones ⇒ no chickens. Parsed into `HUB_CHICKEN_ZONES` by `loader.ts`.
 
 ### Placed-animal config schema (`config.json` → top-level `animals`)
 

--- a/web/public/sprites/animal-butterfly-1.svg
+++ b/web/public/sprites/animal-butterfly-1.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- wings up -->
+  <ellipse cx="13" cy="11" rx="4" ry="6" fill="#eeeeee"/>
+  <ellipse cx="19" cy="11" rx="4" ry="6" fill="#eeeeee"/>
+  <ellipse cx="13" cy="19" rx="3" ry="4" fill="#e2e2e2"/>
+  <ellipse cx="19" cy="19" rx="3" ry="4" fill="#e2e2e2"/>
+  <ellipse cx="16" cy="16" rx="1.4" ry="7" fill="#3a3a3a"/>
+  <path d="M16 9 Q14 5 12 5" stroke="#3a3a3a" stroke-width="0.8" fill="none"/>
+  <path d="M16 9 Q18 5 20 5" stroke="#3a3a3a" stroke-width="0.8" fill="none"/>
+</svg>

--- a/web/public/sprites/animal-butterfly-2.svg
+++ b/web/public/sprites/animal-butterfly-2.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- wings level (same as base) -->
+  <ellipse cx="10" cy="13" rx="6" ry="5" fill="#eeeeee"/>
+  <ellipse cx="22" cy="13" rx="6" ry="5" fill="#eeeeee"/>
+  <ellipse cx="11" cy="20" rx="4.5" ry="4" fill="#e2e2e2"/>
+  <ellipse cx="21" cy="20" rx="4.5" ry="4" fill="#e2e2e2"/>
+  <ellipse cx="16" cy="16" rx="1.4" ry="7" fill="#3a3a3a"/>
+  <path d="M16 9 Q14 5 12 5" stroke="#3a3a3a" stroke-width="0.8" fill="none"/>
+  <path d="M16 9 Q18 5 20 5" stroke="#3a3a3a" stroke-width="0.8" fill="none"/>
+</svg>

--- a/web/public/sprites/animal-butterfly-3.svg
+++ b/web/public/sprites/animal-butterfly-3.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- wings spread wide / down -->
+  <ellipse cx="8" cy="15" rx="7" ry="4" fill="#eeeeee"/>
+  <ellipse cx="24" cy="15" rx="7" ry="4" fill="#eeeeee"/>
+  <ellipse cx="10" cy="21" rx="5" ry="3.5" fill="#e2e2e2"/>
+  <ellipse cx="22" cy="21" rx="5" ry="3.5" fill="#e2e2e2"/>
+  <ellipse cx="16" cy="16" rx="1.4" ry="7" fill="#3a3a3a"/>
+  <path d="M16 9 Q14 5 12 5" stroke="#3a3a3a" stroke-width="0.8" fill="none"/>
+  <path d="M16 9 Q18 5 20 5" stroke="#3a3a3a" stroke-width="0.8" fill="none"/>
+</svg>

--- a/web/public/sprites/animal-butterfly.svg
+++ b/web/public/sprites/animal-butterfly.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- neutral light wings so PIXI tint colours the butterfly -->
+  <ellipse cx="10" cy="13" rx="6" ry="5" fill="#eeeeee"/>
+  <ellipse cx="22" cy="13" rx="6" ry="5" fill="#eeeeee"/>
+  <ellipse cx="11" cy="20" rx="4.5" ry="4" fill="#e2e2e2"/>
+  <ellipse cx="21" cy="20" rx="4.5" ry="4" fill="#e2e2e2"/>
+  <ellipse cx="16" cy="16" rx="1.4" ry="7" fill="#3a3a3a"/>
+  <path d="M16 9 Q14 5 12 5" stroke="#3a3a3a" stroke-width="0.8" fill="none"/>
+  <path d="M16 9 Q18 5 20 5" stroke="#3a3a3a" stroke-width="0.8" fill="none"/>
+</svg>

--- a/web/public/sprites/animal-chicken-1.svg
+++ b/web/public/sprites/animal-chicken-1.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- stride A: legs apart -->
+  <ellipse cx="16" cy="29" rx="6" ry="1.6" fill="rgba(0,0,0,0.2)"/>
+  <rect x="12" y="24" width="1.2" height="4" fill="#d8a23a"/>
+  <rect x="19" y="24" width="1.2" height="4" fill="#d8a23a"/>
+  <path d="M8 18 L4 13 L9 17 Z" fill="#eeeeee"/>
+  <ellipse cx="15" cy="20" rx="7" ry="6" fill="#eeeeee"/>
+  <circle cx="21" cy="14" r="3.5" fill="#eeeeee"/>
+  <path d="M19 11 q1 -2 2 0 q1 -2 2 0 l0 1.5 l-4 0 Z" fill="#d64545"/>
+  <path d="M24 14 l3 0.6 l-3 1.2 Z" fill="#e8a838"/>
+  <ellipse cx="22.5" cy="17.2" rx="1" ry="1.6" fill="#d64545"/>
+  <circle cx="21.5" cy="13.5" r="0.8" fill="#2a2a2a"/>
+</svg>

--- a/web/public/sprites/animal-chicken-2.svg
+++ b/web/public/sprites/animal-chicken-2.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- mid stride: legs together (same as base) -->
+  <ellipse cx="16" cy="29" rx="6" ry="1.6" fill="rgba(0,0,0,0.2)"/>
+  <rect x="14" y="24" width="1.2" height="4" fill="#d8a23a"/>
+  <rect x="18" y="24" width="1.2" height="4" fill="#d8a23a"/>
+  <path d="M8 18 L4 13 L9 17 Z" fill="#eeeeee"/>
+  <ellipse cx="15" cy="19" rx="7" ry="6" fill="#eeeeee"/>
+  <circle cx="21" cy="13" r="3.5" fill="#eeeeee"/>
+  <path d="M19 10 q1 -2 2 0 q1 -2 2 0 l0 1.5 l-4 0 Z" fill="#d64545"/>
+  <path d="M24 13 l3 0.6 l-3 1.2 Z" fill="#e8a838"/>
+  <ellipse cx="22.5" cy="16.2" rx="1" ry="1.6" fill="#d64545"/>
+  <circle cx="21.5" cy="12.5" r="0.8" fill="#2a2a2a"/>
+</svg>

--- a/web/public/sprites/animal-chicken-3.svg
+++ b/web/public/sprites/animal-chicken-3.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- peck: head lowered to the ground -->
+  <ellipse cx="16" cy="29" rx="6" ry="1.6" fill="rgba(0,0,0,0.2)"/>
+  <rect x="14" y="24" width="1.2" height="4" fill="#d8a23a"/>
+  <rect x="18" y="24" width="1.2" height="4" fill="#d8a23a"/>
+  <path d="M8 17 L4 12 L9 16 Z" fill="#eeeeee"/>
+  <ellipse cx="15" cy="20" rx="7" ry="6" fill="#eeeeee"/>
+  <circle cx="23" cy="19" r="3.3" fill="#eeeeee"/>
+  <path d="M21.5 16 q1 -2 2 0 q1 -2 2 0 l0 1.5 l-4 0 Z" fill="#d64545"/>
+  <path d="M25 21 l3 0.6 l-3 1.2 Z" fill="#e8a838"/>
+  <circle cx="23.5" cy="18.5" r="0.8" fill="#2a2a2a"/>
+</svg>

--- a/web/public/sprites/animal-chicken.svg
+++ b/web/public/sprites/animal-chicken.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <ellipse cx="16" cy="29" rx="6" ry="1.6" fill="rgba(0,0,0,0.2)"/>
+  <rect x="14" y="24" width="1.2" height="4" fill="#d8a23a"/>
+  <rect x="18" y="24" width="1.2" height="4" fill="#d8a23a"/>
+  <path d="M8 18 L4 13 L9 17 Z" fill="#eeeeee"/>
+  <ellipse cx="15" cy="20" rx="7" ry="6" fill="#eeeeee"/>
+  <circle cx="21" cy="14" r="3.5" fill="#eeeeee"/>
+  <path d="M19 11 q1 -2 2 0 q1 -2 2 0 l0 1.5 l-4 0 Z" fill="#d64545"/>
+  <path d="M24 14 l3 0.6 l-3 1.2 Z" fill="#e8a838"/>
+  <ellipse cx="22.5" cy="17.2" rx="1" ry="1.6" fill="#d64545"/>
+  <circle cx="21.5" cy="13.5" r="0.8" fill="#2a2a2a"/>
+</svg>

--- a/web/public/sprites/animal-frog.svg
+++ b/web/public/sprites/animal-frog.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <ellipse cx="16" cy="29" rx="7" ry="1.8" fill="rgba(0,0,0,0.2)"/>
+  <ellipse cx="8" cy="25" rx="3" ry="2" fill="#dddddd"/>
+  <ellipse cx="24" cy="25" rx="3" ry="2" fill="#dddddd"/>
+  <ellipse cx="16" cy="22" rx="8" ry="6" fill="#eeeeee"/>
+  <circle cx="12" cy="15" r="3" fill="#eeeeee"/>
+  <circle cx="20" cy="15" r="3" fill="#eeeeee"/>
+  <circle cx="12" cy="14.5" r="1.3" fill="#2a2a2a"/>
+  <circle cx="20" cy="14.5" r="1.3" fill="#2a2a2a"/>
+  <path d="M10 22 q6 4 12 0" stroke="#9a9a9a" stroke-width="1" fill="none"/>
+</svg>

--- a/web/public/sprites/animal-rabbit-1.svg
+++ b/web/public/sprites/animal-rabbit-1.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- crouched -->
+  <ellipse cx="16" cy="29" rx="7" ry="1.8" fill="rgba(0,0,0,0.2)"/>
+  <circle cx="8" cy="25" r="2.2" fill="#f6f6f6"/>
+  <ellipse cx="13" cy="28" rx="5" ry="1.6" fill="#eeeeee"/>
+  <ellipse cx="15" cy="24" rx="7.5" ry="5" fill="#eeeeee"/>
+  <circle cx="22" cy="20" r="4" fill="#eeeeee"/>
+  <ellipse cx="21" cy="14" rx="1.5" ry="4.5" fill="#eeeeee"/>
+  <ellipse cx="24" cy="14.5" rx="1.5" ry="4.5" fill="#eeeeee"/>
+  <circle cx="23" cy="19.5" r="0.9" fill="#2a2a2a"/>
+</svg>

--- a/web/public/sprites/animal-rabbit-2.svg
+++ b/web/public/sprites/animal-rabbit-2.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- mid leap (body raised, legs stretched) -->
+  <ellipse cx="16" cy="29" rx="6" ry="1.5" fill="rgba(0,0,0,0.18)"/>
+  <circle cx="7" cy="20" r="2.2" fill="#f6f6f6"/>
+  <ellipse cx="10" cy="24" rx="4.5" ry="1.5" fill="#eeeeee"/>
+  <ellipse cx="15" cy="18" rx="8" ry="4.5" fill="#eeeeee"/>
+  <circle cx="23" cy="15" r="4" fill="#eeeeee"/>
+  <ellipse cx="22" cy="8.5" rx="1.5" ry="5" fill="#eeeeee"/>
+  <ellipse cx="25" cy="9" rx="1.5" ry="5" fill="#eeeeee"/>
+  <circle cx="24" cy="14.5" r="0.9" fill="#2a2a2a"/>
+  <ellipse cx="20" cy="22" rx="4" ry="1.4" fill="#eeeeee"/>
+</svg>

--- a/web/public/sprites/animal-rabbit-3.svg
+++ b/web/public/sprites/animal-rabbit-3.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- landing (low, legs forward) -->
+  <ellipse cx="16" cy="29" rx="7" ry="1.8" fill="rgba(0,0,0,0.2)"/>
+  <circle cx="8" cy="24" r="2.2" fill="#f6f6f6"/>
+  <ellipse cx="20" cy="28" rx="5" ry="1.6" fill="#eeeeee"/>
+  <ellipse cx="15" cy="23" rx="7.5" ry="5" fill="#eeeeee"/>
+  <circle cx="22" cy="19" r="4" fill="#eeeeee"/>
+  <ellipse cx="21" cy="12.5" rx="1.5" ry="5" fill="#eeeeee"/>
+  <ellipse cx="24" cy="13" rx="1.5" ry="5" fill="#eeeeee"/>
+  <circle cx="23" cy="18.5" r="0.9" fill="#2a2a2a"/>
+  <circle cx="25.5" cy="20" r="0.7" fill="#cc9988"/>
+</svg>

--- a/web/public/sprites/animal-rabbit.svg
+++ b/web/public/sprites/animal-rabbit.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <ellipse cx="16" cy="29" rx="7" ry="1.8" fill="rgba(0,0,0,0.2)"/>
+  <circle cx="8" cy="24" r="2.2" fill="#f6f6f6"/>
+  <ellipse cx="12" cy="27" rx="4" ry="1.6" fill="#eeeeee"/>
+  <ellipse cx="15" cy="22" rx="7" ry="5.5" fill="#eeeeee"/>
+  <circle cx="22" cy="18" r="4" fill="#eeeeee"/>
+  <ellipse cx="21" cy="11" rx="1.5" ry="5" fill="#eeeeee"/>
+  <ellipse cx="24" cy="11.5" rx="1.5" ry="5" fill="#eeeeee"/>
+  <circle cx="23" cy="17.5" r="0.9" fill="#2a2a2a"/>
+  <circle cx="25.5" cy="19" r="0.7" fill="#cc9988"/>
+</svg>

--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -116,7 +116,7 @@ export function HubTownCanvas({
     EXTERIOR_DECOR, HUB_WINDOWS, HUB_POND_TILES,
     HUB_DOORS, HUB_INTERIORS, EXTERIOR_NPCS, INTERIOR_NPCS,
     NPC_SPAWN_TILES, AMBIENT_NPC_SPRITES,
-   HUB_LOCKED_DOORS, HUB_TREASURES, HUB_INTERACTABLES, HUB_ANIMALS,
+   HUB_LOCKED_DOORS, HUB_TREASURES, HUB_INTERACTABLES, HUB_ANIMALS, HUB_CHICKEN_ZONES,
     EXIT_TILES: exitTilesData,
     HUB_TOWN_NAME: locationKey,
   } = locationData
@@ -2087,6 +2087,11 @@ export function HubTownCanvas({
     const animalIsSolid = (tx: number, ty: number): boolean =>
       tx < 0 || ty < 0 || tx >= MAP_W / T || ty >= MAP_H / T ||
       buildingSet.has(`${tx},${ty}`) || animalPondSet.has(`${tx},${ty}`)
+    // Flower-decor tiles — butterflies route between them.
+    const FLOWER_TILE_IDS = new Set([52, 53, 54, 55, 943])  // white/pink/blue/yellow flower, potOfFlowers
+    const animalFlowerTiles: [number, number][] = EXTERIOR_DECOR
+      .filter((d: { tileId: number }) => FLOWER_TILE_IDS.has(d.tileId))
+      .map((d: { tx: number; ty: number }) => [d.tx, d.ty] as [number, number])
     const animalSystem: AnimalSystem = createAnimalSystem({
       app,
       spriteLayer,
@@ -2104,6 +2109,8 @@ export function HubTownCanvas({
       homes: HUB_DOORS.filter(d => d.buildingId).map(d => ({ buildingId: d.buildingId, tx: d.tx, ty: d.ty })),
       pondTiles: HUB_POND_TILES,
       roofTiles: animalRoofTiles,
+      flowerTiles: animalFlowerTiles,
+      chickenZones: HUB_CHICKEN_ZONES,
       placedAnimals: HUB_ANIMALS,
       buildingCount: HUB_BUILDINGS.length,
       npcCount: EXTERIOR_NPCS.length,

--- a/web/src/components/hub/hubAnimals.ts
+++ b/web/src/components/hub/hubAnimals.ts
@@ -1,9 +1,10 @@
 // Imperative PixiJS manager for hub-world animals (issue #1592).
 //
-// Spawns and ticks cats, dogs, birds, and fish. Procedural animals are derived
-// from town geometry (see `computeProceduralCounts`); placed/quest animals come
-// from `HUB_ANIMALS`. Pure maths/behaviour tables live in
-// `web/src/game/hub/animals.ts`; this file owns sprites and the per-frame loop.
+// Spawns and ticks all animal types. Per-type data (speed, scale, tints, render
+// layer, navigation mode, spawn rule, predator/prey relations) lives in the
+// `ANIMAL_SPECS` registry in `web/src/game/hub/animals.ts`; this file owns
+// sprites, movement primitives, and the per-frame loop. New types are mostly a
+// spec entry + sprites + a thin behaviour hook that reuses the shared helpers.
 
 import * as PIXI from 'pixi.js'
 import { findPath } from '../../utils/hubPathfinder'
@@ -11,6 +12,7 @@ import { loadAnimFrames, loadTextureUrl } from '../../utils/pixiHelpers'
 import type { HubAnimal } from '../../data/hub/loader'
 import {
   AnimalType,
+  ANIMAL_SPECS,
   DOG_IDLE_WEIGHTS,
   computeProceduralCounts,
   pickWeighted,
@@ -25,11 +27,7 @@ const T_PX = 32
 const BIRD_FLEE_R = 4.5 * T_PX
 const BIRD_PERCH_CLEAR = 6 * T_PX
 
-// Movement speeds, px/s.
-const SPEED: Record<AnimalType, number> = { cat: 55, dog: 72, bird: 230, fish: 26 }
-// Sprite size as a fraction of the NPC sprite size.
-const SCALE: Record<AnimalType, number> = { cat: 0.62, dog: 0.72, bird: 0.5, fish: 0.5 }
-
+type Rect = [number, number, number, number]   // tx, ty, w, h
 interface Pt { x: number; y: number }
 
 interface Animal {
@@ -44,12 +42,13 @@ interface Animal {
   homeBuildingId?: string         // building this animal dens in at night
   homeDoor?: [number, number]     // its door tile
   insideBuilding: string | null   // currently denned inside this building
+  zoneRect?: Rect                 // chickens: pen they're confined to
   tx: number
   ty: number
   path: [number, number][]
   movingTo: [number, number] | null
   target: Pt | null
-  goal: [number, number] | null   // cats: beacon tile they walk toward (grass-capable)
+  goal: [number, number] | null   // beacon tile for grass-capable steppers
   staticTex: PIXI.Texture | null
   sleepTex: PIXI.Texture | null
   frames: PIXI.Texture[]
@@ -68,18 +67,18 @@ interface Animal {
   wagTimer: number
   // bird
   fleeRequested: boolean
-  // fish bob
+  // fish/butterfly bob
   bobPhase: number
   baseY: number
 }
 
 export interface AnimalSystemOptions {
   app: PIXI.Application
-  /** Y-sorted layer shared with the avatar (cats & dogs live here). */
+  /** Y-sorted layer shared with the avatar (ground walkers live here). */
   spriteLayer: PIXI.Container
-  /** Layer rendered above buildings (birds nest in a child container here). */
+  /** Layer rendered above buildings (birds & butterflies nest here). */
   overlayLayer: PIXI.Container
-  /** Pond/water layer (fish nest in a child container here). */
+  /** Pond/water layer (fish nest here). */
   pondLayer: PIXI.Container
   bubbleLayer: PIXI.Container
   baseUrl: string
@@ -97,6 +96,10 @@ export interface AnimalSystemOptions {
   homes: { buildingId: string; tx: number; ty: number }[]
   pondTiles: [number, number][]
   roofTiles: [number, number][]
+  /** Flower-decor tiles — butterflies route between these. */
+  flowerTiles: [number, number][]
+  /** Fenced pens chickens are confined to. */
+  chickenZones: { rect: Rect; count?: number }[]
   placedAnimals: HubAnimal[]
   buildingCount: number
   npcCount: number
@@ -117,21 +120,32 @@ export interface AnimalSystem {
   destroy: () => void
 }
 
-const FLAVOUR: Record<AnimalType, string> = { cat: 'Meow', dog: 'Woof!', bird: 'Chirp!', fish: 'blub' }
+const FLAVOUR: Record<AnimalType, string> = {
+  cat: 'Meow', dog: 'Woof!', bird: 'Chirp!', fish: 'blub',
+  butterfly: '~', rabbit: '!', chicken: 'Cluck', frog: 'Ribbit',
+}
+
+// Floating types are centre-anchored and hover; the rest are bottom-anchored.
+const isFloating = (t: AnimalType) => t === 'fish' || t === 'butterfly'
 
 export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
   const { app, T, spriteSize } = opts
   const animals: Animal[] = []
 
-  const birdLayer = new PIXI.Container()
+  const overlayAnimLayer = new PIXI.Container()   // birds + butterflies (above buildings)
   const fishLayer = new PIXI.Container()
-  opts.overlayLayer.addChild(birdLayer)
+  opts.overlayLayer.addChild(overlayAnimLayer)
   // Pond water tiles are rendered into pondLayer asynchronously, so they can be
   // added AFTER fishLayer and would otherwise draw on top of the fish. Sort by
   // zIndex (tiles default to 0) and keep fish above them.
   opts.pondLayer.sortableChildren = true
   fishLayer.zIndex = 1000
   opts.pondLayer.addChild(fishLayer)
+
+  const cols = Math.floor(opts.mapW / T)
+  const rows = Math.floor(opts.mapH / T)
+  const DIRS8: [number, number][] = [[0, -1], [1, -1], [1, 0], [1, 1], [0, 1], [-1, 1], [-1, 0], [-1, -1]]
+  const clampN = (n: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, n))
 
   // ── geometry helpers ───────────────────────────────────────────────────────
   const key = (tx: number, ty: number) => `${tx},${ty}`
@@ -151,6 +165,8 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
 
   const randOf = <X,>(arr: X[]): X | null => (arr.length ? arr[(Math.random() * arr.length) | 0] : null)
 
+  const pondSet = new Set(opts.pondTiles.map(([x, y]) => key(x, y)))
+
   function setPath(a: Animal, from: [number, number], to: [number, number], walkable: Set<string>) {
     const path = findPath(from, to, walkable)
     a.path = path.length > 1 ? path.slice(1) : []
@@ -164,13 +180,20 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
     a.target = center(a, next[0], next[1])
   }
 
+  // Move the sprite directly to a tile (one straight segment; used by flyers/froggers).
+  function hopTo(a: Animal, tile: [number, number]) {
+    a.movingTo = tile
+    a.target = center(a, tile[0], tile[1])
+    a.path = []
+  }
+
   // ── movement integration ─────────────────────────────────────────────────────
   function advance(a: Animal, dt: number) {
     if (!a.target) return
     const dx = a.target.x - a.sprite.x
     const dy = a.target.y - a.sprite.y
     const dist = Math.hypot(dx, dy)
-    const step = (a.type === 'bird' && a.state === 'fleeing' ? SPEED.bird : SPEED[a.type]) * (dt / 1000)
+    const step = ANIMAL_SPECS[a.type].speed * (dt / 1000)
     if (dx < -0.5) a.sprite.scale.x = -a.baseScale
     else if (dx > 0.5) a.sprite.scale.x = a.baseScale
     if (step >= dist || dist < 0.001) {
@@ -229,38 +252,31 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
     if (a.bubble) a.bubble.position.set(a.sprite.x, a.sprite.y - spriteSize * a.baseScale - 4)
   }
 
-  // Nearest other animal matching `pred` within `radiusPx`, else null.
+  // ── shared relations & navigation ─────────────────────────────────────────────
   function nearestAnimal(a: Animal, pred: (o: Animal) => boolean, radiusPx: number): Animal | null {
     let best: Animal | null = null
     let bd = radiusPx
     for (const o of animals) {
-      if (o === a || !pred(o)) continue
+      if (o === a || o.insideBuilding || !pred(o)) continue
       const d = Math.hypot(o.sprite.x - a.sprite.x, o.sprite.y - a.sprite.y)
       if (d < bd) { bd = d; best = o }
     }
     return best
   }
-
-  function followToward(a: Animal, target: Pt, walkable: Set<string>) {
-    const tt: [number, number] = [Math.floor(target.x / T), Math.floor(target.y / T)]
-    // step toward a walkable tile nearest the target, staying a tile back
-    const near = tilesWithin(walkable, tt[0], tt[1], 2)
-    const dest = randOf(near) ?? (walkable.has(key(tt[0], tt[1])) ? tt : null)
-    if (dest) setPath(a, [a.tx, a.ty], dest, walkable)
+  // Nearest animal this type flees from / chases, per the registry.
+  function nearestThreat(a: Animal, r: number): Animal | null {
+    const f = ANIMAL_SPECS[a.type].fleesFrom
+    return f ? nearestAnimal(a, o => f.includes(o.type), r) : null
+  }
+  function nearestPrey(a: Animal, r: number): Animal | null {
+    const c = ANIMAL_SPECS[a.type].chases
+    return c ? nearestAnimal(a, o => c.includes(o.type) && !o.stationary, r) : null
   }
 
-  // ── behaviour: cats ──────────────────────────────────────────────────────────
-  // Cats are lazy: they sleep most of the day and only rouse for something that
-  // interests a feline soul — a dog to flee, a bird to chase, another cat to
-  // play with, or an NPC who might feed them. They roam off the paths (onto
-  // grass) toward a `goal` beacon, stepping around solid tiles (#1592).
-  const cols = Math.floor(opts.mapW / T)
-  const rows = Math.floor(opts.mapH / T)
-  const DIRS8: [number, number][] = [[0, -1], [1, -1], [1, 0], [1, 1], [0, 1], [-1, 1], [-1, 0], [-1, -1]]
-  const clampN = (n: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, n))
-
-  // Greedy one-tile step toward a.goal, avoiding solids (lets cats cross grass).
-  function catStep(a: Animal) {
+  type StepMode = 'grass' | 'grass-only' | 'zone'
+  // Greedy one-tile step toward a.goal, avoiding solids. `grass-only` also avoids
+  // streets; `zone` clamps candidates to a rect.
+  function stepToward(a: Animal, walkable: Set<string>, mode: StepMode = 'grass', zone?: Rect) {
     if (!a.goal) return
     const [gx, gy] = a.goal
     if (Math.abs(a.tx - gx) <= 1 && Math.abs(a.ty - gy) <= 1) { a.goal = null; return }
@@ -269,6 +285,8 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
       const nx = a.tx + dx, ny = a.ty + dy
       if (nx < 0 || ny < 0 || nx >= cols || ny >= rows) continue
       if (opts.isSolidTile(nx, ny)) continue
+      if (mode === 'grass-only' && walkable.has(key(nx, ny))) continue
+      if (mode === 'zone' && zone && (nx < zone[0] || ny < zone[1] || nx >= zone[0] + zone[2] || ny >= zone[1] + zone[3])) continue
       const d = Math.hypot(nx - gx, ny - gy)
       if (d < bd) { bd = d; best = [nx, ny] }
     }
@@ -276,7 +294,7 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
     else a.goal = null
   }
 
-  function catFleeFrom(a: Animal, fromPx: Pt, durationMs: number) {
+  function fleeBeacon(a: Animal, fromPx: Pt, durationMs: number) {
     a.state = 'flee'; a.stateTimer = durationMs
     const dx = a.tx - fromPx.x / T, dy = a.ty - fromPx.y / T
     const len = Math.hypot(dx, dy) || 1
@@ -284,10 +302,17 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
               clampN(Math.round(a.ty + (dy / len) * 6), 0, rows - 1)]
   }
 
+  function followToward(a: Animal, target: Pt, walkable: Set<string>) {
+    const tt: [number, number] = [Math.floor(target.x / T), Math.floor(target.y / T)]
+    const near = tilesWithin(walkable, tt[0], tt[1], 2)
+    const dest = randOf(near) ?? (walkable.has(key(tt[0], tt[1])) ? tt : null)
+    if (dest) setPath(a, [a.tx, a.ty], dest, walkable)
+  }
+
   // A quiet grass tile (off the path) within a short radius, else null.
-  function comfyTile(a: Animal, walkable: Set<string>): [number, number] | null {
+  function grassTileNear(a: Animal, walkable: Set<string>, r = 3): [number, number] | null {
     const out: [number, number][] = []
-    for (let dx = -3; dx <= 3; dx++) for (let dy = -3; dy <= 3; dy++) {
+    for (let dx = -r; dx <= r; dx++) for (let dy = -r; dy <= r; dy++) {
       const tx = a.tx + dx, ty = a.ty + dy
       if ((dx || dy) && tx >= 0 && ty >= 0 && tx < cols && ty < rows
           && !opts.isSolidTile(tx, ty) && !walkable.has(key(tx, ty))) out.push([tx, ty])
@@ -295,19 +320,20 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
     return randOf(out)
   }
 
+  // ── behaviour: cats ──────────────────────────────────────────────────────────
   function catRest(a: Animal, walkable: Set<string>) {
     const sleeping = Math.random() < 0.85
     a.state = sleeping ? 'sleep' : 'sit'
     a.stateTimer = sleeping ? 12000 + Math.random() * 30000 : 4000 + Math.random() * 6000
-    // Sometimes pad off the path to a comfy grass spot, then settle there.
-    a.goal = Math.random() < 0.4 ? comfyTile(a, walkable) : null
+    a.goal = Math.random() < 0.4 ? grassTileNear(a, walkable) : null
   }
 
-  // While at rest, look for a reason to wake. Returns true if one was found.
-  function catWake(a: Animal, dt: number, npcs: { x: number; y: number }[], perchedBirds: Animal[]): boolean {
-    const bird = perchedBirds.find(b => Math.hypot(b.sprite.x - a.sprite.x, b.sprite.y - a.sprite.y) < 5 * T)
-    if (bird && Math.random() < (dt / 1000) * 0.5) {
-      a.state = 'chase-bird'; a.stateTimer = 3500; bird.fleeRequested = true; a.goal = [bird.tx, bird.ty]; return true
+  function catWake(a: Animal, dt: number, npcs: { x: number; y: number }[]): boolean {
+    const prey = nearestPrey(a, 5 * T)
+    if (prey && Math.random() < (dt / 1000) * 0.5) {
+      a.state = 'chase'; a.stateTimer = 3500
+      if (prey.type === 'bird') prey.fleeRequested = true
+      a.goal = [prey.tx, prey.ty]; return true
     }
     const cat = nearestAnimal(a, o => o.type === 'cat' && !o.stationary, 4 * T)
     if (cat && Math.random() < (dt / 1000) * 0.12) {
@@ -321,7 +347,7 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
     return false
   }
 
-  function catTick(a: Animal, dt: number, walkable: Set<string>, npcs: { x: number; y: number }[], perchedBirds: Animal[]) {
+  function catTick(a: Animal, dt: number, walkable: Set<string>, npcs: { x: number; y: number }[]) {
     if (a.stationary) {
       if (!isMoving(a) && a.stateTimer <= 0) {
         a.state = Math.random() < 0.6 ? 'sleep' : 'sit'
@@ -329,21 +355,16 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
       }
       return
     }
-    // A dog always interrupts whatever the cat was doing.
     if (a.state !== 'flee') {
-      const dog = nearestAnimal(a, o => o.type === 'dog', 3.5 * T)
-      if (dog) catFleeFrom(a, { x: dog.sprite.x, y: dog.sprite.y }, 2600)
+      const dog = nearestThreat(a, 3.5 * T)   // dogs
+      if (dog) fleeBeacon(a, { x: dog.sprite.x, y: dog.sprite.y }, 2600)
     }
-    // Other stimuli only rouse a resting cat.
-    if (a.state === 'sleep' || a.state === 'sit') catWake(a, dt, npcs, perchedBirds)
-    // Progress toward the current goal one tile at a time.
-    if (a.goal && !isMoving(a)) catStep(a)
-    // Reached a play/feed goal — react, then settle.
+    if (a.state === 'sleep' || a.state === 'sit') catWake(a, dt, npcs)
+    if (a.goal && !isMoving(a)) stepToward(a, walkable, 'grass')
     if (!a.goal && !isMoving(a) && (a.state === 'play' || a.state === 'approach-npc')) {
       speak(a, a.state === 'play' ? '♪' : '?', 1400)
       a.state = 'sit'; a.stateTimer = 1500
     }
-    // Finished an active state → back to a long rest.
     if (!isMoving(a) && !a.goal && a.stateTimer <= 0) catRest(a, walkable)
   }
 
@@ -380,51 +401,41 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
       if (d < 2.5 * T && d < nearD) { nearD = d; near = n }
     }
     if (!near || !near.id) return
-    if (!a.seen.has(near.id)) {
-      a.seen.add(near.id)
-      a.opinion.set(near.id, Math.random() < 0.5)
-    }
-    const likes = a.opinion.get(near.id)
+    if (!a.seen.has(near.id)) { a.seen.add(near.id); a.opinion.set(near.id, Math.random() < 0.5) }
     a.reactCooldown = 5000
-    if (likes) { speak(a, '♥'); a.wagTimer = 1300 }
+    if (a.opinion.get(near.id)) { speak(a, '♥'); a.wagTimer = 1300 }
     else speak(a, 'Woof!')
   }
 
-  // Dogs occasionally spot a wandering cat and give chase (the cat flees via its
-  // own dog-avoidance). Returns true if a chase started.
-  function dogChaseCat(a: Animal, dt: number, walkable: Set<string>): boolean {
-    if (a.stationary || a.state === 'chase-cat') return false
-    const cat = nearestAnimal(a, o => o.type === 'cat' && !o.stationary, 5 * T)
-    if (cat && Math.random() < (dt / 1000) * 0.5) {
-      a.state = 'chase-cat'; a.stateTimer = 3000
-      setPath(a, [a.tx, a.ty], [cat.tx, cat.ty], walkable)
-      return true
+  // Dogs spot a wandering cat or rabbit and give chase — they leave the path
+  // (grass step) to pursue, returning to street roaming afterwards.
+  function dogChasePrey(a: Animal, dt: number): boolean {
+    if (a.stationary || a.state === 'chase') return false
+    const prey = nearestPrey(a, 5 * T)
+    if (prey && Math.random() < (dt / 1000) * 0.5) {
+      a.state = 'chase'; a.stateTimer = 3000; a.goal = [prey.tx, prey.ty]; return true
     }
     return false
   }
 
   // ── behaviour: birds ─────────────────────────────────────────────────────────
-  function emptyPerch(avatar: Pt, npcs: { x: number; y: number }[], walkable: Set<string>): { tile: [number, number]; kind: 'roof' | 'ground' } | null {
+  function emptyPerch(avatar: Pt, npcs: { x: number; y: number }[], walkable: Set<string>): { tile: [number, number] } | null {
     const ground = Array.from(walkable).map(k => k.split(',').map(Number) as [number, number])
     const blockers = [avatar, ...npcs, ...animals.filter(a => a.type === 'cat' || a.type === 'dog').map(a => ({ x: a.sprite.x, y: a.sprite.y }))]
-    // Clearance must exceed the flee radius (BIRD_FLEE_R) so a freshly-placed
-    // bird doesn't instantly re-flee.
     const isFree = (t: [number, number]) => {
       const px = t[0] * T + T / 2, py = t[1] * T + T / 2
       return blockers.every(b => Math.hypot(b.x - px, b.y - py) > BIRD_PERCH_CLEAR)
     }
-    const freeGround = ground.filter(isFree).map(t => ({ tile: t, kind: 'ground' as const }))
-    const freeRoof = opts.roofTiles.filter(isFree).map(t => ({ tile: t, kind: 'roof' as const }))
-    // Prefer ground/path perches (where the player & pets roam, so fleeing is
-    // visible); fall back to roofs, then to any tile.
+    const freeGround = ground.filter(isFree).map(t => ({ tile: t }))
+    const freeRoof = opts.roofTiles.filter(isFree).map(t => ({ tile: t }))
     if (freeGround.length && (Math.random() < 0.6 || freeRoof.length === 0)) return randOf(freeGround)
     if (freeRoof.length) return randOf(freeRoof)
     if (freeGround.length) return randOf(freeGround)
-    return randOf([...opts.roofTiles.map(t => ({ tile: t, kind: 'roof' as const })), ...ground.map(t => ({ tile: t, kind: 'ground' as const }))])
+    return randOf([...opts.roofTiles.map(t => ({ tile: t })), ...ground.map(t => ({ tile: t }))])
   }
 
-  function placeBirdPerch(a: Animal, perch: { tile: [number, number]; kind: 'roof' | 'ground' }) {
-    a.tx = perch.tile[0]; a.ty = perch.tile[1]
+  function placeBirdPerch(a: Animal, tile: [number, number]) {
+    a.tx = tile[0]; a.ty = tile[1]
     const c = center(a, a.tx, a.ty)
     a.sprite.x = c.x; a.sprite.y = c.y; a.baseY = c.y
     a.sprite.alpha = 1
@@ -436,7 +447,6 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
 
   function birdTick(a: Animal, dt: number, avatar: Pt, npcs: { x: number; y: number }[], walkable: Set<string>) {
     if (a.state === 'perched') {
-      // Placed/tame birds (quest givers) stay put so the player can reach them.
       if (a.stationary) { a.fleeRequested = false; return }
       const threats = [avatar, ...npcs, ...animals.filter(x => x !== a && (x.type === 'cat' || x.type === 'dog')).map(x => ({ x: x.sprite.x, y: x.sprite.y }))]
       const scared = a.fleeRequested || threats.some(t => Math.hypot(t.x - a.sprite.x, t.y - a.sprite.y) < BIRD_FLEE_R)
@@ -444,53 +454,135 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
       if (scared || a.stateTimer <= 0) startBirdFlee(a)
       return
     }
-    // fleeing
-    a.frameTimer -= dt
-    if (a.frameTimer <= 0 && a.frames.length) {
-      a.frameTimer = FRAME_MS
-      a.frameIdx = (a.frameIdx + 1) % a.frames.length
-      a.sprite.texture = a.frames[a.frameIdx]
-    }
+    animateWalk(a, dt)
     advance(a, dt)
     a.sprite.alpha = Math.max(0.5, a.sprite.alpha - dt / 1200)
     const off = a.sprite.x < -T || a.sprite.x > opts.mapW + T || a.sprite.y < -T || a.sprite.y > opts.mapH + T
     if (off || !a.target) {
       const perch = emptyPerch(avatar, npcs, walkable)
-      if (perch) placeBirdPerch(a, perch)
+      if (perch) placeBirdPerch(a, perch.tile)
       else { a.state = 'perched'; a.stateTimer = 4000 }
     }
   }
 
   function startBirdFlee(a: Animal) {
     a.state = 'fleeing'
-    // pick nearest screen edge to fly off
-    const dl = a.sprite.x, dr = opts.mapW - a.sprite.x, dt2 = a.sprite.y, db = opts.mapH - a.sprite.y
-    const m = Math.min(dl, dr, dt2, db)
+    const dl = a.sprite.x, dr = opts.mapW - a.sprite.x, dtop = a.sprite.y, db = opts.mapH - a.sprite.y
+    const m = Math.min(dl, dr, dtop, db)
     let tx = a.sprite.x, ty = a.sprite.y - 3 * T
     if (m === dl) { tx = -2 * T; ty = a.sprite.y - 2 * T }
     else if (m === dr) { tx = opts.mapW + 2 * T; ty = a.sprite.y - 2 * T }
-    else if (m === dt2) { tx = a.sprite.x; ty = -2 * T }
+    else if (m === dtop) { tx = a.sprite.x; ty = -2 * T }
     else { tx = a.sprite.x; ty = opts.mapH + 2 * T }
     a.path = []
     a.target = { x: tx, y: ty }
   }
 
-  // ── behaviour: fish ──────────────────────────────────────────────────────────
-  const pondSet = new Set(opts.pondTiles.map(([x, y]) => key(x, y)))
-  function fishTick(a: Animal, dt: number) {
-    a.bobPhase += dt / 600
-    if (!isMoving(a)) {
+  // ── behaviour: butterflies ─────────────────────────────────────────────────────
+  function flowerNear(a: Animal): [number, number] | null {
+    const close = opts.flowerTiles.filter(([fx, fy]) => Math.abs(fx - a.tx) <= 8 && Math.abs(fy - a.ty) <= 8 && (fx !== a.tx || fy !== a.ty))
+    return randOf(close.length ? close : opts.flowerTiles)
+  }
+  function butterflyTick(a: Animal, dt: number) {
+    a.bobPhase += dt / 200
+    const cat = nearestThreat(a, 3.5 * T)   // cats
+    if (cat) {
+      const dx = a.sprite.x - cat.sprite.x, dy = a.sprite.y - cat.sprite.y
+      const len = Math.hypot(dx, dy) || 1
+      a.movingTo = null
+      a.target = { x: clampN(a.sprite.x + (dx / len) * 4 * T, 0, opts.mapW), y: clampN(a.sprite.y + (dy / len) * 4 * T - T, 0, opts.mapH) }
+      a.path = []
+      a.state = 'flee'; a.stateTimer = 1000
+    } else if (!isMoving(a)) {
       a.stateTimer -= dt
-      if (a.stateTimer <= 0) {
-        a.stateTimer = 1500 + Math.random() * 2500
-        const near = tilesWithin(pondSet, a.tx, a.ty, 3)
-        const dest = randOf(near)
-        if (dest) { a.tx = dest[0]; a.ty = dest[1]; const c = center(a, dest[0], dest[1]); a.target = c; a.path = [] }
+      if (a.stateTimer <= 0 || a.state === 'flee') {
+        const f = flowerNear(a)
+        if (f) { hopTo(a, f); a.state = 'flit'; a.stateTimer = 1200 + Math.random() * 2500 }
+        else a.stateTimer = 1500
       }
-    } else {
-      advance(a, dt)
     }
-    a.sprite.y = a.baseY + Math.sin(a.bobPhase) * 1.5
+    animateWalk(a, dt)
+    advance(a, dt)
+    a.sprite.y = a.baseY + Math.sin(a.bobPhase) * 3
+  }
+
+  // ── behaviour: rabbits ─────────────────────────────────────────────────────────
+  function rabbitTick(a: Animal, dt: number, avatar: Pt, walkable: Set<string>) {
+    if (a.stationary) return
+    const dog = nearestThreat(a, 4 * T)     // dogs
+    const playerNear = Math.hypot(avatar.x - a.sprite.x, avatar.y - a.sprite.y) < 2.5 * T
+    if (a.state !== 'flee' && (dog || playerNear)) {
+      fleeBeacon(a, dog ? { x: dog.sprite.x, y: dog.sprite.y } : avatar, 2200)
+    }
+    if (a.goal && !isMoving(a)) stepToward(a, walkable, 'grass-only')
+    if (!isMoving(a) && !a.goal && a.stateTimer <= 0) {
+      if (Math.random() < 0.45) { const g = grassTileNear(a, walkable, 3); if (g) a.goal = g; a.state = 'hop'; a.stateTimer = 1500 + Math.random() * 2500 }
+      else { a.state = 'freeze'; a.stateTimer = 2000 + Math.random() * 3000 }
+    }
+  }
+
+  // ── behaviour: chickens ─────────────────────────────────────────────────────────
+  function chickenTick(a: Animal, dt: number, avatar: Pt, walkable: Set<string>) {
+    const z = a.zoneRect
+    if (!z) return
+    const dog = nearestThreat(a, 3 * T)     // dogs
+    const playerNear = Math.hypot(avatar.x - a.sprite.x, avatar.y - a.sprite.y) < 3 * T
+    if (a.state !== 'scatter' && (dog || playerNear)) {
+      // bolt to the far corner of the pen
+      const cx = a.tx < z[0] + z[2] / 2 ? z[0] + z[2] - 1 : z[0]
+      const cy = a.ty < z[1] + z[3] / 2 ? z[1] + z[3] - 1 : z[1]
+      a.goal = [cx, cy]; a.state = 'scatter'; a.stateTimer = 2000
+    }
+    if (a.goal && !isMoving(a)) stepToward(a, walkable, 'zone', z)
+    if (!isMoving(a) && !a.goal && a.stateTimer <= 0) {
+      if (Math.random() < 0.6) { a.state = 'peck'; a.stateTimer = 1800 + Math.random() * 3000 }
+      else {
+        const tx = z[0] + (Math.random() * z[2] | 0), ty = z[1] + (Math.random() * z[3] | 0)
+        if (!opts.isSolidTile(tx, ty)) { a.goal = [tx, ty]; a.state = 'walk'; a.stateTimer = 1500 }
+        else { a.state = 'peck'; a.stateTimer = 1500 }
+      }
+    }
+  }
+
+  // ── behaviour: frogs ─────────────────────────────────────────────────────────
+  const pondEdgeTiles: [number, number][] = []
+  {
+    const seen = new Set<string>()
+    for (const [px, py] of opts.pondTiles) for (const [dx, dy] of [[0, -1], [1, 0], [0, 1], [-1, 0]]) {
+      const nx = px + dx, ny = py + dy, k = key(nx, ny)
+      if (nx < 0 || ny < 0 || nx >= cols || ny >= rows) continue
+      if (!seen.has(k) && !opts.isSolidTile(nx, ny) && !pondSet.has(k)) { seen.add(k); pondEdgeTiles.push([nx, ny]) }
+    }
+  }
+  const edgeNear = (a: Animal): [number, number] | null =>
+    randOf(pondEdgeTiles.filter(([x, y]) => Math.abs(x - a.tx) <= 3 && Math.abs(y - a.ty) <= 3 && (x !== a.tx || y !== a.ty)))
+  const nearestPond = (a: Animal): [number, number] | null => {
+    let best: [number, number] | null = null, bd = Infinity
+    for (const [x, y] of opts.pondTiles) { const d = Math.hypot(x - a.tx, y - a.ty); if (d < bd) { bd = d; best = [x, y] } }
+    return best
+  }
+  function frogTick(a: Animal, dt: number, avatar: Pt) {
+    a.stateTimer -= dt
+    advance(a, dt)
+    if (a.state === 'plop') {
+      if (!isMoving(a) && a.stateTimer <= 0) {
+        const e = edgeNear(a) ?? a.homeTile
+        hopTo(a, e); a.sprite.alpha = 1; a.state = 'idle'; a.stateTimer = 2000 + Math.random() * 3000
+      }
+      return
+    }
+    const threat = Math.hypot(avatar.x - a.sprite.x, avatar.y - a.sprite.y) < 2.5 * T
+      || nearestAnimal(a, o => o.type === 'cat' || o.type === 'dog', 2.5 * T) != null
+    if (threat && !isMoving(a)) {
+      const p = nearestPond(a)
+      if (p) { hopTo(a, p); a.sprite.alpha = 0.5; a.state = 'plop'; a.stateTimer = 1500 }
+      return
+    }
+    if (!isMoving(a) && a.stateTimer <= 0) {
+      const e = edgeNear(a)
+      if (e) hopTo(a, e)
+      a.state = 'idle'; a.stateTimer = 2000 + Math.random() * 3000
+    }
   }
 
   // ── day/night den schedule (cats & dogs with a home) ────────────────────────
@@ -521,12 +613,11 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
   const atTile = (a: Animal, tile: [number, number]) =>
     Math.abs(a.tx - tile[0]) <= 1 && Math.abs(a.ty - tile[1]) <= 1
 
-  // Returns true if the animal is (or is heading) inside and needs no exterior tick.
   function runDenSchedule(a: Animal, walkable: Set<string>, hour: number): boolean {
     if (!a.homeBuildingId || !a.homeDoor) return false
     const wantInside = isNightHour(hour)
     if (a.insideBuilding) {
-      if (!wantInside) exitHome(a)   // morning — come back out
+      if (!wantInside) exitHome(a)
       return !!a.insideBuilding
     }
     if (wantInside) {
@@ -535,9 +626,9 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
         if (a.type === 'cat') a.goal = a.homeDoor
         else setPath(a, [a.tx, a.ty], a.homeDoor, walkable)
       }
-      if (a.type === 'cat' && a.goal && !isMoving(a)) catStep(a)
+      if (a.type === 'cat' && a.goal && !isMoving(a)) stepToward(a, walkable, 'grass')
       if (!isMoving(a) && atTile(a, a.homeDoor)) enterHome(a)
-      return true   // travelling home — skip normal behaviour
+      return true
     }
     if (a.state === 'go-home') { a.state = a.type === 'cat' ? 'sleep' : 'sit'; a.goal = null }
     return false
@@ -545,24 +636,21 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
 
   // ── per-frame tick ───────────────────────────────────────────────────────────
   function tick(deltaMS: number) {
-    if (opts.isInteriorActive()) { birdLayer.visible = false; fishLayer.visible = false; return }
-    birdLayer.visible = true; fishLayer.visible = true
+    if (opts.isInteriorActive()) { overlayAnimLayer.visible = false; fishLayer.visible = false; return }
+    overlayAnimLayer.visible = true; fishLayer.visible = true
     const dt = Math.min(deltaMS, 50)
     const walkable = opts.getWalkable()
     const avatar = opts.getAvatarPx()
     const npcs = opts.getNpcPositions()
     const hour = opts.getGameHour()
-    const perchedBirds = animals.filter(a => a.type === 'bird' && a.state === 'perched')
 
     for (const a of animals) {
-      // bubble lifetime
       if (a.bubble) {
         positionBubble(a)
         a.bubbleTimer -= dt
         if (a.bubbleTimer <= 0) { opts.bubbleLayer.removeChild(a.bubble); a.bubble = null }
       }
 
-      // quest indicator
       if (a.indicator && a.id) {
         const st = opts.getQuestIndicator?.(a.id) ?? null
         a.indicator.visible = st !== null
@@ -575,20 +663,23 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
       }
 
       // Day/night den schedule (cats & dogs with a home building).
-      if (a.type === 'cat' || a.type === 'dog') {
+      if (ANIMAL_SPECS[a.type].dens) {
         const busy = runDenSchedule(a, walkable, hour)
-        if (a.insideBuilding) continue          // denned inside — hidden, no exterior update
-        if (busy) {                              // travelling home
+        if (a.insideBuilding) continue
+        if (busy) {
           advance(a, dt)
           if (isMoving(a)) animateWalk(a, dt); else showStatic(a)
           continue
         }
       }
 
+      // Custom-movement types own their advance() call.
       if (a.type === 'fish') { fishTick(a, dt); continue }
       if (a.type === 'bird') { birdTick(a, dt, avatar, npcs, walkable); continue }
+      if (a.type === 'butterfly') { butterflyTick(a, dt); continue }
+      if (a.type === 'frog') { frogTick(a, dt, avatar); continue }
 
-      // cats & dogs
+      // Ground walkers: cat, dog, rabbit, chicken — shared advance + animation.
       advance(a, dt)
       if (isMoving(a)) animateWalk(a, dt)
       else if (a.state === 'sleep') showSleep(a)
@@ -596,68 +687,91 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
 
       a.stateTimer -= dt
       if (a.type === 'cat') {
-        catTick(a, dt, walkable, npcs, perchedBirds)
+        catTick(a, dt, walkable, npcs)
+      } else if (a.type === 'rabbit') {
+        rabbitTick(a, dt, avatar, walkable)
+      } else if (a.type === 'chicken') {
+        chickenTick(a, dt, avatar, walkable)
       } else {
         dogSocial(a, dt, npcs)
-        dogChaseCat(a, dt, walkable)
+        dogChasePrey(a, dt)
         if (a.state === 'follow-owner' && !isMoving(a) && a.stateTimer > 0) {
           const owner = npcs.find(n => n.id === a.ownerId)
           if (owner) followToward(a, owner, walkable)
         }
-        if (a.state === 'chase-cat' && !isMoving(a) && a.stateTimer > 0) {
-          const cat = nearestAnimal(a, o => o.type === 'cat' && !o.stationary, 6 * T)
-          if (cat) setPath(a, [a.tx, a.ty], [cat.tx, cat.ty], walkable)
+        if (a.state === 'chase' && !isMoving(a) && a.stateTimer > 0) {
+          const prey = nearestPrey(a, 6 * T)
+          if (prey) { a.goal = [prey.tx, prey.ty]; stepToward(a, walkable, 'grass') }
+          else a.stateTimer = 0
         }
         if (!isMoving(a) && a.stateTimer <= 0) dogIdle(a, walkable, npcs)
       }
     }
   }
 
+  // ── fish ───────────────────────────────────────────────────────────────────
+  function fishTick(a: Animal, dt: number) {
+    a.bobPhase += dt / 600
+    if (!isMoving(a)) {
+      a.stateTimer -= dt
+      if (a.stateTimer <= 0) {
+        a.stateTimer = 1500 + Math.random() * 2500
+        const near = tilesWithin(pondSet, a.tx, a.ty, 3)
+        const dest = randOf(near)
+        if (dest) { a.tx = dest[0]; a.ty = dest[1]; a.target = center(a, dest[0], dest[1]); a.path = [] }
+      }
+    } else {
+      advance(a, dt)
+    }
+    a.sprite.y = a.baseY + Math.sin(a.bobPhase) * 1.5
+  }
+
   // ── spawning ──────────────────────────────────────────────────────────────────
-  async function makeAnimal(
-    type: AnimalType, tx: number, ty: number, placed?: HubAnimal,
-  ): Promise<void> {
+  async function makeAnimal(type: AnimalType, tx: number, ty: number, placed?: HubAnimal, zoneRect?: Rect): Promise<void> {
+    const spec = ANIMAL_SPECS[type]
     const slug = `animal-${type}`
     const staticTex = await loadTextureUrl(`${opts.baseUrl}sprites/${slug}.svg`).catch(() => null)
     if (!staticTex || app.renderer == null) return
     const sprite = new PIXI.Sprite(staticTex)
-    const px = spriteSize * SCALE[type]
+    const px = spriteSize * spec.scale
     sprite.width = px; sprite.height = px
-    const bottomAnchored = type !== 'fish'
+    const bottomAnchored = !isFloating(type)
     sprite.anchor.set(0.5, bottomAnchored ? 1 : 0.5)
     const tint = resolveVariantTint(type, placed?.variant)
     sprite.tint = tint
     const baseScale = sprite.scale.x
 
-    const layer = type === 'bird' ? birdLayer : type === 'fish' ? fishLayer : opts.spriteLayer
+    const layer = spec.layer === 'overlay' ? overlayAnimLayer : spec.layer === 'pond' ? fishLayer : opts.spriteLayer
     const c = bottomAnchored ? { x: tx * T + T / 2, y: ty * T + T } : { x: tx * T + T / 2, y: ty * T + T / 2 }
     sprite.position.set(c.x, c.y)
     if (bottomAnchored) sprite.zIndex = c.y
     layer.addChild(sprite)
 
+    const initState =
+      type === 'bird' ? 'perched' : type === 'fish' ? 'swim' : type === 'butterfly' ? 'flit'
+      : type === 'frog' ? 'idle' : type === 'cat' ? 'sleep' : type === 'rabbit' ? 'freeze'
+      : type === 'chicken' ? 'peck' : 'sit'
+
     const a: Animal = {
       type, id: placed?.id, stationary: !!placed && placed.roam !== true,
       homeTile: [tx, ty], sprite, tint, bottomAnchored, baseScale,
-      insideBuilding: null,
+      insideBuilding: null, zoneRect,
       tx, ty, path: [], movingTo: null, target: null, goal: null,
       staticTex, sleepTex: null, frames: [], frameIdx: 0, frameTimer: FRAME_MS,
-      state: type === 'bird' ? 'perched' : type === 'fish' ? 'swim' : type === 'cat' ? 'sleep' : 'sit',
-      stateTimer: 500 + Math.random() * 1500,
+      state: initState, stateTimer: 500 + Math.random() * 1500,
       bubble: null, bubbleTimer: 0,
       seen: new Set(), opinion: new Map(), reactCooldown: 0, wagTimer: 0,
       fleeRequested: false, bobPhase: Math.random() * Math.PI * 2, baseY: c.y,
       indicator: null,
     }
-    // Give roughly half of the procedural cats & dogs a home building they den
-    // in at night.
-    if (!placed && (type === 'cat' || type === 'dog') && opts.homes.length > 0 && Math.random() < 0.5) {
+    // Half of the procedural cats & dogs den in a home building at night.
+    if (!placed && spec.dens && opts.homes.length > 0 && Math.random() < 0.5) {
       const home = opts.homes[(Math.random() * opts.homes.length) | 0]
       a.homeBuildingId = home.buildingId
       a.homeDoor = [home.tx, home.ty]
     }
     animals.push(a)
 
-    // Quest indicator ('!') for placed animals that can give/complete quests.
     if (placed?.id && (placed.questGive || placed.questReceive)) {
       const ind = new PIXI.Text({ text: '!', style: { fontSize: 16, fill: '#ffdd44', fontWeight: 'bold', fontFamily: 'monospace', stroke: { color: '#1a1a1a', width: 3 } } })
       ind.anchor.set(0.5, 1)
@@ -666,25 +780,23 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
       a.indicator = ind
     }
 
-    // dogs pick an owner from current named NPCs
     if (type === 'dog' && !a.stationary) {
       const named = opts.getNpcPositions().filter(n => n.id)
       a.ownerId = randOf(named)?.id
     }
 
-    // tap handling
     sprite.eventMode = 'static'
     sprite.cursor = 'pointer'
     sprite.on('pointerdown', (e: PIXI.FederatedPointerEvent) => {
       e.stopPropagation()
       if (a.id) { opts.onAnimalTap(a.id); return }
       speak(a, FLAVOUR[type])
-      if (type === 'bird') a.fleeRequested = true
+      if (type === 'bird' || type === 'butterfly') a.fleeRequested = true
       if (type === 'cat' && a.state !== 'flee') { a.state = 'sit'; a.stateTimer = 200 }
     })
 
-    // load walk/fly frames + cat sleep pose
-    if (type !== 'fish') {
+    // Walk/fly frames for the animated types; cat also gets a sleep pose.
+    if (type !== 'fish' && type !== 'frog') {
       loadAnimFrames(slug, 3).then(f => { a.frames = f }).catch(() => {})
     }
     if (type === 'cat') {
@@ -692,19 +804,46 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
     }
   }
 
-  // Procedural population
-  const counts = computeProceduralCounts(opts.buildingCount, opts.npcCount, opts.pondTiles.length)
+  // ── procedural population ──────────────────────────────────────────────────────
   const walkable0 = opts.getWalkable()
   const walkTiles = Array.from(walkable0).map(k => k.split(',').map(Number) as [number, number])
+  const grassTiles: [number, number][] = []
+  for (let y = 0; y < rows; y++) for (let x = 0; x < cols; x++) {
+    if (!opts.isSolidTile(x, y) && !walkable0.has(key(x, y))) grassTiles.push([x, y])
+  }
+  const zoneTileCount = opts.chickenZones.reduce((s, z) => s + z.rect[2] * z.rect[3], 0)
+
+  const counts = computeProceduralCounts({
+    buildings: opts.buildingCount,
+    npcs:      opts.npcCount,
+    flowers:   opts.flowerTiles.length,
+    pondTiles: opts.pondTiles.length,
+    grass:     grassTiles.length,
+    zones:     zoneTileCount,
+  })
+
   for (let i = 0; i < counts.cat; i++) { const t = randOf(walkTiles); if (t) void makeAnimal('cat', t[0], t[1]) }
   for (let i = 0; i < counts.dog; i++) { const t = randOf(walkTiles); if (t) void makeAnimal('dog', t[0], t[1]) }
   for (let i = 0; i < counts.bird; i++) {
-    // Mix of ground/path and roof perches so birds are reachable and visibly flee.
     const perch = emptyPerch(opts.getAvatarPx(), opts.getNpcPositions(), walkable0)
     const t = perch?.tile ?? randOf(opts.roofTiles) ?? randOf(walkTiles)
     if (t) void makeAnimal('bird', t[0], t[1])
   }
   for (let i = 0; i < counts.fish; i++) { const t = randOf(opts.pondTiles); if (t) void makeAnimal('fish', t[0], t[1]) }
+  for (let i = 0; i < counts.butterfly; i++) { const t = randOf(opts.flowerTiles); if (t) void makeAnimal('butterfly', t[0], t[1]) }
+  for (let i = 0; i < counts.rabbit; i++) { const t = randOf(grassTiles); if (t) void makeAnimal('rabbit', t[0], t[1]) }
+  for (let i = 0; i < counts.frog; i++) { const t = randOf(pondEdgeTiles); if (t) void makeAnimal('frog', t[0], t[1]) }
+  // Chickens distributed across their pens.
+  if (counts.chicken > 0 && opts.chickenZones.length > 0) {
+    for (let i = 0; i < counts.chicken; i++) {
+      const z = opts.chickenZones[i % opts.chickenZones.length].rect
+      let placed = false
+      for (let tries = 0; tries < 8 && !placed; tries++) {
+        const tx = z[0] + (Math.random() * z[2] | 0), ty = z[1] + (Math.random() * z[3] | 0)
+        if (!opts.isSolidTile(tx, ty)) { void makeAnimal('chicken', tx, ty, undefined, z); placed = true }
+      }
+    }
+  }
 
   // Placed/quest animals (always rendered)
   for (const pa of opts.placedAnimals) void makeAnimal(pa.type, pa.tx, pa.ty, pa)
@@ -720,7 +859,7 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
       a.sprite.destroy()
     }
     animals.length = 0
-    birdLayer.destroy({ children: true })
+    overlayAnimLayer.destroy({ children: true })
     fishLayer.destroy({ children: true })
   }
 

--- a/web/src/data/hub/config.ts
+++ b/web/src/data/hub/config.ts
@@ -316,4 +316,7 @@ export interface RawConfig {
   interactables?: RawInteractable[]
 
   animals?: RawAnimal[]
+
+  /** Fenced pens that chickens are confined to. */
+  chickenZones?: { rect: number[]; count?: number }[]
 }

--- a/web/src/data/hub/loader.ts
+++ b/web/src/data/hub/loader.ts
@@ -94,7 +94,9 @@ export interface HubNpc {
   homeBed?: { buildingId: string; tx: number; ty: number }
 }
 
-export type HubAnimalType = 'cat' | 'dog' | 'bird' | 'fish'
+export type HubAnimalType =
+  | 'cat' | 'dog' | 'bird' | 'fish'
+  | 'butterfly' | 'rabbit' | 'chicken' | 'frog'
 
 export interface HubAnimal {
   id: string
@@ -248,6 +250,7 @@ export interface HubLocationBundle {
   HUB_TREASURES: HubTreasure[]
   HUB_INTERACTABLES: HubInteractable[]
   HUB_ANIMALS: HubAnimal[]
+  HUB_CHICKEN_ZONES: { rect: [number, number, number, number]; count?: number }[]
   EXIT_TILES: HubExitTile[]
 
 
@@ -523,6 +526,10 @@ const HUB_ANIMALS: HubAnimal[] = (
   areaRect:     a.areaRect,
 }))
 
+const HUB_CHICKEN_ZONES = (
+  (rawConfig as unknown as { chickenZones?: { rect: number[]; count?: number }[] }).chickenZones ?? []
+).map(z => ({ rect: z.rect as [number, number, number, number], count: z.count }))
+
  const HUB_TOWN_NAME: string = (rawConfig as unknown as { townName?: string }).townName ?? 'Town'
 const ENVIRONMENT: string = (rawConfig as unknown as { environment?: string }).environment ?? 'camp'
 
@@ -594,6 +601,7 @@ type RawExitTile = { tx: number; ty: number; screen: string }
     HUB_TREASURES,
     HUB_INTERACTABLES,
     HUB_ANIMALS,
+    HUB_CHICKEN_ZONES,
     EXIT_TILES: HUB_EXIT_TILES,
 
   }

--- a/web/src/data/hub/ravenwatch/config.json
+++ b/web/src/data/hub/ravenwatch/config.json
@@ -7831,5 +7831,8 @@
       "dialogue": ["*caw!*", "Pip the raven tilts its head, eyeing your pockets for something shiny."],
       "questGive": "pips-treasures"
     }
+  ],
+  "chickenZones": [
+    { "rect": [1, 27, 6, 5] }
   ]
 }

--- a/web/src/game/hub/animals.test.ts
+++ b/web/src/game/hub/animals.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect } from 'vitest'
 import {
   ANIMAL_CAPS,
+  ANIMAL_SPECS,
+  ANIMAL_TYPES,
+  SpawnSources,
   computeProceduralCounts,
   resolveVariantTint,
   TINT_PALETTES,
@@ -8,27 +11,58 @@ import {
   randomDuration,
 } from './animals'
 
+function sources(p: Partial<SpawnSources>): SpawnSources {
+  return { buildings: 0, npcs: 0, flowers: 0, pondTiles: 0, grass: 0, zones: 0, ...p }
+}
+
 describe('computeProceduralCounts', () => {
-  it('applies the issue ratios', () => {
-    // 8 buildings → 2 cats, 8 npcs → 2 dogs, birds fixed 8, 12 pond tiles → 2 fish
-    expect(computeProceduralCounts(8, 8, 12)).toEqual({ cat: 2, dog: 2, bird: 8, fish: 2 })
+  it('applies each spec spawn rule', () => {
+    // 8 buildings → 2 cats, 8 npcs → 2 dogs, birds fixed 8, 12 pond → 2 fish + 1 frog
+    expect(computeProceduralCounts(sources({ buildings: 8, npcs: 8, pondTiles: 12 }))).toEqual({
+      cat: 2, dog: 2, bird: 8, fish: 2, butterfly: 0, rabbit: 0, chicken: 0, frog: 1,
+    })
   })
 
-  it('floors fractional counts', () => {
-    expect(computeProceduralCounts(7, 7, 11)).toEqual({ cat: 1, dog: 1, bird: 8, fish: 1 })
+  it('butterflies: 1 per 2 flowers, capped at 5', () => {
+    expect(computeProceduralCounts(sources({ flowers: 4 })).butterfly).toBe(2)
+    expect(computeProceduralCounts(sources({ flowers: 16 })).butterfly).toBe(5)
   })
 
-  it('returns zero when there is no source data (and birds stay fixed)', () => {
-    expect(computeProceduralCounts(0, 0, 0)).toEqual({ cat: 0, dog: 0, bird: 8, fish: 0 })
+  it('rabbits: fixed 4 when grass exists, else 0', () => {
+    expect(computeProceduralCounts(sources({ grass: 0 })).rabbit).toBe(0)
+    expect(computeProceduralCounts(sources({ grass: 1 })).rabbit).toBe(4)
+    expect(computeProceduralCounts(sources({ grass: 9999 })).rabbit).toBe(4)
   })
 
-  it('clamps to the per-type caps for a large town', () => {
-    // Ravenwatch-scale: 22 buildings, 56 npcs, 85 pond tiles
-    const counts = computeProceduralCounts(22, 56, 85)
-    expect(counts.cat).toBe(5)                 // 22/4=5, below cap 6
-    expect(counts.dog).toBe(ANIMAL_CAPS.dog)   // 56/4=14 → capped to dog cap
-    expect(counts.fish).toBe(ANIMAL_CAPS.fish) // 85/6=14 → capped to 12
-    expect(counts.bird).toBe(8)
+  it('chickens: 1 per 6 zone tiles, capped at 8', () => {
+    expect(computeProceduralCounts(sources({ zones: 18 })).chicken).toBe(3)
+    expect(computeProceduralCounts(sources({ zones: 999 })).chicken).toBe(8)
+    expect(computeProceduralCounts(sources({ zones: 0 })).chicken).toBe(0)
+  })
+
+  it('clamps to caps for a large town', () => {
+    const c = computeProceduralCounts(sources({ buildings: 22, npcs: 56, pondTiles: 85, flowers: 16, grass: 500, zones: 30 }))
+    expect(c.cat).toBe(5)                  // 22/4
+    expect(c.dog).toBe(ANIMAL_CAPS.dog)    // 56/4=14 → cap 4
+    expect(c.fish).toBe(ANIMAL_CAPS.fish)  // 85/6=14 → cap 12
+    expect(c.frog).toBe(ANIMAL_CAPS.frog)  // 85/8=10 → cap 4
+    expect(c.bird).toBe(8)
+  })
+})
+
+describe('registry', () => {
+  it('every type has a palette and a cap', () => {
+    for (const t of ANIMAL_TYPES) {
+      expect(Object.keys(ANIMAL_SPECS[t].palette).length).toBeGreaterThan(0)
+      expect(ANIMAL_SPECS[t].spawn.cap).toBeGreaterThan(0)
+    }
+  })
+
+  it('predator/prey relations are symmetric where expected', () => {
+    expect(ANIMAL_SPECS.cat.chases).toContain('butterfly')
+    expect(ANIMAL_SPECS.butterfly.fleesFrom).toContain('cat')
+    expect(ANIMAL_SPECS.dog.chases).toContain('rabbit')
+    expect(ANIMAL_SPECS.rabbit.fleesFrom).toContain('dog')
   })
 })
 
@@ -44,33 +78,20 @@ describe('resolveVariantTint', () => {
   })
 
   it('falls back to a palette colour using the supplied rng', () => {
-    const tint = resolveVariantTint('bird', undefined, () => 0)
-    expect(tint).toBe(Object.values(TINT_PALETTES.bird)[0])
-  })
-
-  it('ignores an invalid variant and falls back', () => {
-    const tint = resolveVariantTint('fish', 'not-a-colour', () => 0)
-    expect(tint).toBe(Object.values(TINT_PALETTES.fish)[0])
+    expect(resolveVariantTint('frog', undefined, () => 0)).toBe(Object.values(TINT_PALETTES.frog)[0])
   })
 })
 
 describe('pickWeighted', () => {
-  it('selects the first bucket at rng=0', () => {
+  it('selects the first bucket at rng=0 and a later one near 1', () => {
     expect(pickWeighted({ a: 1, b: 9 }, () => 0)).toBe('a')
-  })
-
-  it('selects a later bucket as rng approaches 1', () => {
     expect(pickWeighted({ a: 1, b: 9 }, () => 0.99)).toBe('b')
   })
 })
 
 describe('randomDuration', () => {
-  it('returns the low bound at rng=0', () => {
+  it('returns the low bound at rng=0; default range for unknown states', () => {
     expect(randomDuration('sit', () => 0)).toBe(3000)
-  })
-
-  it('uses a default range for unknown states', () => {
-    const d = randomDuration('mystery', () => 0)
-    expect(d).toBe(2000)
+    expect(randomDuration('mystery', () => 0)).toBe(2000)
   })
 })

--- a/web/src/game/hub/animals.ts
+++ b/web/src/game/hub/animals.ts
@@ -4,57 +4,135 @@
 // colour-variant resolution, and behaviour-transition tables can be unit
 // tested in isolation. The imperative sprite/rendering layer lives in
 // `web/src/components/hub/hubAnimals.ts`.
+//
+// Adding a new animal type is mostly a matter of adding an `AnimalSpec` entry
+// to ANIMAL_SPECS below (data: speed, scale, tint palette, render layer,
+// navigation mode, spawn rule, predator/prey relations) plus its sprites and a
+// thin behaviour hook in hubAnimals.ts that reuses the shared primitives.
 
-export type AnimalType = 'cat' | 'dog' | 'bird' | 'fish'
+export type AnimalType =
+  | 'cat' | 'dog' | 'bird' | 'fish'
+  | 'butterfly' | 'rabbit' | 'chicken' | 'frog'
 
-// ── Procedural spawn ratios ─────────────────────────────────────────────────
-// Cats: 1 per 4 buildings · Dogs: 1 per 4 NPCs · Birds: 8 per town ·
-// Fish: 1 per 6 pond tiles.
-export const ANIMAL_RATIOS = {
-  buildingsPerCat: 4,
-  npcsPerDog:      4,
-  birdsPerTown:    8,
-  pondTilesPerFish: 6,
-} as const
+// How an animal moves around the map.
+export type NavMode =
+  | 'street'      // street pathfinding (dogs — but they may leave paths to chase)
+  | 'grass'       // greedy step avoiding solids; streets allowed (cats)
+  | 'grass-only'  // greedy step on grass only, never streets (rabbits)
+  | 'fly'         // free movement over an overlay layer to a target (birds, butterflies)
+  | 'pond'        // within pond tiles (fish)
+  | 'pond-edge'   // hops along pond-adjacent tiles, plops into water (frogs)
+  | 'zone'        // clamped to a rectangular pen (chickens)
 
-// Per-type caps keep rendering cost bounded in the largest town (Ravenwatch).
-export const ANIMAL_CAPS: Record<AnimalType, number> = {
-  cat:  6,
-  dog:  4,
-  bird: 8,
-  fish: 12,
+export type SpawnSource =
+  | 'buildings' | 'npcs' | 'flowers' | 'pondTiles' | 'grass' | 'zones' | 'fixed'
+
+export type RenderLayer = 'sprite' | 'overlay' | 'pond'
+
+export interface AnimalSpec {
+  speed: number                       // px/s
+  scale: number                       // fraction of the NPC sprite size
+  palette: Record<string, number>     // colour-variant tints (applied via sprite.tint)
+  layer: RenderLayer                  // overlay = above buildings (flying)
+  nav: NavMode
+  /** Procedural spawn rule. `fixed` (with a source) means "that many if the
+   *  source exists, else 0"; otherwise count = floor(sourceCount / per). */
+  spawn: { source: SpawnSource; per?: number; fixed?: number; cap: number }
+  fleesFrom?: AnimalType[]            // generic predator/prey
+  chases?: AnimalType[]
+  dens?: boolean                      // follows the night-in / day-out building schedule
 }
 
-export interface ProceduralCounts {
-  cat:  number
-  dog:  number
-  bird: number
-  fish: number
+// ── Per-type registry — the single source of truth for animal data ──────────
+export const ANIMAL_SPECS: Record<AnimalType, AnimalSpec> = {
+  cat: {
+    speed: 55, scale: 0.62, layer: 'sprite', nav: 'grass',
+    palette: { black: 0x3a3a3a, orange: 0xe8923c, grey: 0x9aa0a6, white: 0xf5f5f0, cream: 0xe8d8b0 },
+    spawn: { source: 'buildings', per: 4, cap: 6 },
+    fleesFrom: ['dog'], chases: ['bird', 'butterfly'], dens: true,
+  },
+  dog: {
+    speed: 72, scale: 0.72, layer: 'sprite', nav: 'street',
+    palette: { brown: 0x8b5a2b, black: 0x3a3a3a, golden: 0xe0b050, tan: 0xc9a06a },
+    spawn: { source: 'npcs', per: 4, cap: 4 },
+    chases: ['cat', 'rabbit'], dens: true,
+  },
+  bird: {
+    speed: 230, scale: 0.5, layer: 'overlay', nav: 'fly',
+    palette: { red: 0xd64545, blue: 0x4f86d6, brown: 0x9c6b3f, yellow: 0xe8d24a },
+    spawn: { source: 'fixed', fixed: 8, cap: 8 },
+  },
+  fish: {
+    speed: 26, scale: 0.5, layer: 'pond', nav: 'pond',
+    palette: { orange: 0xe8923c, silver: 0xc8d0d8, teal: 0x46b0a8 },
+    spawn: { source: 'pondTiles', per: 6, cap: 12 },
+  },
+  butterfly: {
+    speed: 90, scale: 0.45, layer: 'overlay', nav: 'fly',
+    palette: { orange: 0xe8923c, blue: 0x6db4ff, white: 0xf5f5f0, purple: 0xb07cd6, yellow: 0xf0d24a },
+    spawn: { source: 'flowers', per: 2, cap: 5 },
+    fleesFrom: ['cat'],
+  },
+  rabbit: {
+    speed: 95, scale: 0.5, layer: 'sprite', nav: 'grass-only',
+    palette: { brown: 0x9c6b3f, grey: 0x9aa0a6, white: 0xf5f5f0, sandy: 0xd8c090 },
+    spawn: { source: 'grass', fixed: 4, cap: 4 },
+    fleesFrom: ['dog'],
+  },
+  chicken: {
+    speed: 45, scale: 0.55, layer: 'sprite', nav: 'zone',
+    palette: { white: 0xf5f5f0, brown: 0xb87a3c, speckled: 0xcbb89a, black: 0x3a3a3a },
+    spawn: { source: 'zones', per: 6, cap: 8 },
+    fleesFrom: ['dog'],
+  },
+  frog: {
+    speed: 60, scale: 0.45, layer: 'sprite', nav: 'pond-edge',
+    palette: { green: 0x5bbf52, darkgreen: 0x3a8f46, brown: 0x8b7a3c, spotted: 0x7fae5a },
+    spawn: { source: 'pondTiles', per: 8, cap: 4 },
+  },
 }
 
-/** Derive how many of each procedural animal a town should spawn. */
-export function computeProceduralCounts(
-  buildingCount: number,
-  npcCount:      number,
-  pondTileCount: number,
-): ProceduralCounts {
-  const clamp = (type: AnimalType, n: number) => Math.max(0, Math.min(ANIMAL_CAPS[type], n))
-  return {
-    cat:  clamp('cat',  Math.floor(buildingCount / ANIMAL_RATIOS.buildingsPerCat)),
-    dog:  clamp('dog',  Math.floor(npcCount      / ANIMAL_RATIOS.npcsPerDog)),
-    bird: clamp('bird', ANIMAL_RATIOS.birdsPerTown),
-    fish: clamp('fish', Math.floor(pondTileCount / ANIMAL_RATIOS.pondTilesPerFish)),
+export const ANIMAL_TYPES = Object.keys(ANIMAL_SPECS) as AnimalType[]
+
+// Back-compat derived maps (still referenced by tests / docs).
+export const TINT_PALETTES = Object.fromEntries(
+  ANIMAL_TYPES.map(t => [t, ANIMAL_SPECS[t].palette]),
+) as Record<AnimalType, Record<string, number>>
+
+export const ANIMAL_CAPS = Object.fromEntries(
+  ANIMAL_TYPES.map(t => [t, ANIMAL_SPECS[t].spawn.cap]),
+) as Record<AnimalType, number>
+
+// ── Procedural spawn counts ─────────────────────────────────────────────────
+export interface SpawnSources {
+  buildings: number
+  npcs:      number
+  flowers:   number
+  pondTiles: number
+  grass:     number
+  zones:     number
+}
+
+/** Derive how many of each procedural animal a town should spawn, by reading
+ *  each spec's `spawn` rule against the available `sources`. */
+export function computeProceduralCounts(sources: SpawnSources): Record<AnimalType, number> {
+  const out = {} as Record<AnimalType, number>
+  for (const type of ANIMAL_TYPES) {
+    const sp = ANIMAL_SPECS[type].spawn
+    let n = 0
+    if (sp.source === 'fixed') {
+      n = sp.fixed ?? 0
+    } else {
+      const avail = (sources as unknown as Record<string, number>)[sp.source] ?? 0
+      n = sp.fixed != null ? (avail > 0 ? sp.fixed : 0) : Math.floor(avail / (sp.per ?? 1))
+    }
+    out[type] = Math.max(0, Math.min(sp.cap, n))
   }
+  return out
 }
 
 // ── Colour variants (applied via PIXI sprite.tint) ──────────────────────────
 // Base sprites are neutral grey so a flat tint reads cleanly.
-export const TINT_PALETTES: Record<AnimalType, Record<string, number>> = {
-  cat:  { black: 0x3a3a3a, orange: 0xe8923c, grey: 0x9aa0a6, white: 0xf5f5f0, cream: 0xe8d8b0 },
-  dog:  { brown: 0x8b5a2b, black: 0x3a3a3a, golden: 0xe0b050, tan: 0xc9a06a },
-  bird: { red: 0xd64545, blue: 0x4f86d6, brown: 0x9c6b3f, yellow: 0xe8d24a },
-  fish: { orange: 0xe8923c, silver: 0xc8d0d8, teal: 0x46b0a8 },
-}
 
 /**
  * Resolve a colour-variant for an animal to a PIXI tint (0xRRGGBB).
@@ -77,18 +155,8 @@ export function resolveVariantTint(
 }
 
 // ── Behaviour transition tables ─────────────────────────────────────────────
-// Only the *idle* transitions are weighted here; event-driven states
-// (cat flee/chase-bird, dog bark/wag) are triggered by the manager.
-export type CatState = 'wander' | 'sit' | 'sleep' | 'follow-player' | 'flee' | 'chase-bird'
-export type DogState = 'follow-owner' | 'roam' | 'bark' | 'wag'
-export type BirdState = 'perched' | 'fleeing'
-
-export const CAT_IDLE_WEIGHTS: Record<string, number> = {
-  wander:          4,
-  sit:             3,
-  sleep:           2,
-  'follow-player': 1,
-}
+export type CatState = 'sleep' | 'sit' | 'flee' | 'chase-bird' | 'play' | 'approach-npc' | 'go-home' | 'inside'
+export type DogState = 'follow-owner' | 'roam' | 'bark' | 'wag' | 'chase-cat'
 
 export const DOG_IDLE_WEIGHTS: Record<string, number> = {
   'follow-owner': 5,
@@ -112,10 +180,8 @@ export function pickWeighted(
 
 // Idle-state durations, in milliseconds: [min, max].
 export const STATE_DURATION_MS: Record<string, [number, number]> = {
-  wander:          [2000, 5000],
   sit:             [3000, 8000],
   sleep:           [6000, 14000],
-  'follow-player': [3000, 7000],
   'follow-owner':  [4000, 9000],
   roam:            [2000, 5000],
 }


### PR DESCRIPTION
Makes hub animals pluggable and adds **four new critters** (#1592), reusing the existing behaviour primitives.

## Pluggable registry
Introduces `ANIMAL_SPECS` in `game/hub/animals.ts` — one entry per type holding all the data (speed, scale, tint palette, render layer, nav mode, spawn rule, predator/prey relations, dens). `computeProceduralCounts` is now data-driven. **Adding a type** is mostly a spec entry + sprites + a thin behaviour hook. Shared primitives generalised: generic `nearestThreat`/`nearestPrey` (from `fleesFrom`/`chases`), `stepToward` with `grass`/`grass-only`/`zone` modes, `fleeBeacon`.

## New animals (per your specs)
- **Butterfly** — 1 per 2 flower-decor tiles (cap 5). Flits flower-to-flower over the overlay layer; **cats chase them, they flee cats**.
- **Rabbit** — **grass-only** movement (cap 4). Freezes then bolts; **dogs chase rabbits**.
- **Chicken** — confined to a fenced **pen** (`chickenZones` in config); pecks/hops within it and scatters to the far corner when a dog or the player enters. Demo pen added to Ravenwatch's western fenced field.
- **Frog** — sits on **pond-edge** tiles, hops between them, and **plops into the water** when startled, re-emerging at an edge.
- **Dogs** now leave the path (grass step) to chase cats/rabbits, but otherwise prefer street roaming.

## Wiring
- `chickenZones` config field + `HUB_CHICKEN_ZONES` loader parsing; `HubAnimalType` extended; `flowerTiles` derived from `EXTERIOR_DECOR` in `HubTownCanvas`.
- New sprites: `animal-{butterfly,rabbit,chicken,frog}*.svg` (neutral grey for tint).

## Verification
- `npm run test` — registry/count tests for all 8 types pass (145 total).
- `npm run build` — clean.
- `docs/hubworld.md §8` rewritten: registry, spawn table, nav modes, behaviours, `chickenZones` schema.

> Based on `main` before #1598 (interior-tap) merged — no file overlap; will rebase if needed.

https://claude.ai/code/session_01AJ8fw6nbRq6kDss3frrmwq

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJ8fw6nbRq6kDss3frrmwq)_