### PR TITLE
Hub animals: halve butterfly size and speed

### DIFF
--- a/web/src/game/hub/animals.ts
+++ b/web/src/game/hub/animals.ts
@@ -68,7 +68,7 @@ export const ANIMAL_SPECS: Record<AnimalType, AnimalSpec> = {
     spawn: { source: 'pondTiles', per: 6, cap: 12 },
   },
   butterfly: {
-    speed: 90, scale: 0.45, layer: 'overlay', nav: 'fly',
+    speed: 45, scale: 0.225, layer: 'overlay', nav: 'fly',
     palette: { orange: 0xe8923c, blue: 0x6db4ff, white: 0xf5f5f0, purple: 0xb07cd6, yellow: 0xf0d24a },
     spawn: { source: 'flowers', per: 2, cap: 5 },
     fleesFrom: ['cat'],


### PR DESCRIPTION
Tiny tuning tweak (#1592): butterflies are now **half the size** and move at **half the speed** for a daintier flutter.

`ANIMAL_SPECS.butterfly`: `scale` 0.45 → 0.225, `speed` 90 → 45 px/s.

Typecheck + tests pass.

https://claude.ai/code/session_01AJ8fw6nbRq6kDss3frrmwq

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJ8fw6nbRq6kDss3frrmwq)_