### PR TITLE
Hub animals: day/night fliers (fireflies + bats) and roosting chickens

### DIFF
--- a/docs/hubworld.md
+++ b/docs/hubworld.md
@@ -341,9 +341,21 @@ data-driven from these specs. **Adding a type** = a spec entry + sprites +
 | Rabbits | 4 per town (where grass exists) | grass tiles | 4 |
 | Chickens | 1 per 6 pen tiles | `chickenZones` | 8 |
 | Frogs | 1 per 8 pond tiles | `HUB_POND_TILES` | 4 |
+| Fireflies | 10 per town (fixed, **night only**) | — | 10 |
+| Bats | 5 per town (fixed, **night only**) | — | 5 |
 
 Fish/frogs need ponds; butterflies need flower decor; rabbits need grass;
 chickens need a `chickenZones` pen — otherwise that type is simply absent.
+
+### Day / night
+
+A spec's optional `active: 'day' | 'night'` gates the sprite by time of day
+(`isNightHour` = hour ≥ 20 or < 6). **Birds & butterflies** are `'day'` (they
+vanish after dark); **fireflies & bats** are `'night'` (hidden by day). All four
+are spawned once and shown/hidden by the tick. Cats & dogs **den** in buildings
+at night (see below); **chickens roost** at night — they head to their pen's
+roost tile (`chickenZones[].roost`, default the pen centre) and huddle until
+morning.
 
 ### Navigation modes
 
@@ -368,9 +380,12 @@ free overlay movement) · `pond` (fish) · `pond-edge` (frogs) · `zone` (chicke
   fluttery bob; darts away when a cat is near.
 - **Rabbit** — hops on **grass only**; freezes, then bolts from dogs/the player.
 - **Chicken** — confined to a fenced **pen** (`chickenZones`); pecks and hops
-  within it and scatters to the far corner when a dog or the player enters.
+  within it and scatters to the far corner when a dog or the player enters; at
+  night it **roosts** at the pen's roost tile and huddles until morning.
 - **Frog** — sits on **pond-edge** tiles, hops between them, and **plops** into
   the water (alpha dip) when something comes near, re-emerging at an edge.
+- **Firefly** (night) — drifts slowly anywhere with a pulsing alpha **glow**.
+- **Bat** (night) — swoops erratically across the night sky (overlay layer).
 
 ### Den schedule & building interiors
 
@@ -405,12 +420,13 @@ random palette colour.
 ### Chicken pens (`config.json` → top-level `chickenZones`)
 
 ```json
-{ "chickenZones": [ { "rect": [tx, ty, w, h], "count": 3 } ] }
+{ "chickenZones": [ { "rect": [tx, ty, w, h], "count": 3, "roost": [tx, ty] } ] }
 ```
 
 Each `rect` is a fenced area (draw it over existing fence decor). Chickens spawn
 and stay inside; `count` is optional (defaults to the 1-per-6-tiles rule, capped
-at 8). No zones ⇒ no chickens. Parsed into `HUB_CHICKEN_ZONES` by `loader.ts`.
+at 8); `roost` (optional, defaults to the pen centre) is where they huddle at
+night. No zones ⇒ no chickens. Parsed into `HUB_CHICKEN_ZONES` by `loader.ts`.
 
 ### Placed-animal config schema (`config.json` → top-level `animals`)
 

--- a/web/public/sprites/animal-bat-1.svg
+++ b/web/public/sprites/animal-bat-1.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- wings up -->
+  <ellipse cx="16" cy="16" rx="2.5" ry="3.5" fill="#eeeeee"/>
+  <path d="M16 15 Q9 6 4 9 Q9 13 13 16 Z" fill="#eeeeee"/>
+  <path d="M16 15 Q23 6 28 9 Q23 13 19 16 Z" fill="#eeeeee"/>
+  <path d="M14 13 l-1 -3 l2 2 Z" fill="#eeeeee"/>
+  <path d="M18 13 l1 -3 l-2 2 Z" fill="#eeeeee"/>
+</svg>

--- a/web/public/sprites/animal-bat-2.svg
+++ b/web/public/sprites/animal-bat-2.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- wings level (same as base) -->
+  <ellipse cx="16" cy="16" rx="2.5" ry="3.5" fill="#eeeeee"/>
+  <path d="M16 15 Q8 11 3 15 Q8 17 13 17 Z" fill="#eeeeee"/>
+  <path d="M16 15 Q24 11 29 15 Q24 17 19 17 Z" fill="#eeeeee"/>
+  <path d="M14 13 l-1 -3 l2 2 Z" fill="#eeeeee"/>
+  <path d="M18 13 l1 -3 l-2 2 Z" fill="#eeeeee"/>
+</svg>

--- a/web/public/sprites/animal-bat-3.svg
+++ b/web/public/sprites/animal-bat-3.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- wings down -->
+  <ellipse cx="16" cy="16" rx="2.5" ry="3.5" fill="#eeeeee"/>
+  <path d="M16 16 Q9 24 4 21 Q9 18 13 16 Z" fill="#eeeeee"/>
+  <path d="M16 16 Q23 24 28 21 Q23 18 19 16 Z" fill="#eeeeee"/>
+  <path d="M14 13 l-1 -3 l2 2 Z" fill="#eeeeee"/>
+  <path d="M18 13 l1 -3 l-2 2 Z" fill="#eeeeee"/>
+</svg>

--- a/web/public/sprites/animal-bat.svg
+++ b/web/public/sprites/animal-bat.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- wings level -->
+  <ellipse cx="16" cy="16" rx="2.5" ry="3.5" fill="#eeeeee"/>
+  <path d="M16 15 Q8 11 3 15 Q8 17 13 17 Z" fill="#eeeeee"/>
+  <path d="M16 15 Q24 11 29 15 Q24 17 19 17 Z" fill="#eeeeee"/>
+  <path d="M14 13 l-1 -3 l2 2 Z" fill="#eeeeee"/>
+  <path d="M18 13 l1 -3 l-2 2 Z" fill="#eeeeee"/>
+</svg>

--- a/web/public/sprites/animal-firefly.svg
+++ b/web/public/sprites/animal-firefly.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- glow halo + body; neutral light so PIXI tint sets the glow colour -->
+  <circle cx="16" cy="16" r="7" fill="#ffffff" opacity="0.4"/>
+  <circle cx="16" cy="16" r="4" fill="#f8f8f8" opacity="0.7"/>
+  <circle cx="16" cy="16" r="2.4" fill="#eeeeee"/>
+</svg>

--- a/web/src/components/hub/hubAnimals.ts
+++ b/web/src/components/hub/hubAnimals.ts
@@ -43,6 +43,7 @@ interface Animal {
   homeDoor?: [number, number]     // its door tile
   insideBuilding: string | null   // currently denned inside this building
   zoneRect?: Rect                 // chickens: pen they're confined to
+  roostTile?: [number, number]    // chickens: where they roost at night
   tx: number
   ty: number
   path: [number, number][]
@@ -98,8 +99,8 @@ export interface AnimalSystemOptions {
   roofTiles: [number, number][]
   /** Flower-decor tiles — butterflies route between these. */
   flowerTiles: [number, number][]
-  /** Fenced pens chickens are confined to. */
-  chickenZones: { rect: Rect; count?: number }[]
+  /** Fenced pens chickens are confined to (with an optional night roost tile). */
+  chickenZones: { rect: Rect; count?: number; roost?: [number, number] }[]
   placedAnimals: HubAnimal[]
   buildingCount: number
   npcCount: number
@@ -123,10 +124,11 @@ export interface AnimalSystem {
 const FLAVOUR: Record<AnimalType, string> = {
   cat: 'Meow', dog: 'Woof!', bird: 'Chirp!', fish: 'blub',
   butterfly: '~', rabbit: '!', chicken: 'Cluck', frog: 'Ribbit',
+  firefly: '✦', bat: 'eek!',
 }
 
 // Floating types are centre-anchored and hover; the rest are bottom-anchored.
-const isFloating = (t: AnimalType) => t === 'fish' || t === 'butterfly'
+const isFloating = (t: AnimalType) => t === 'fish' || t === 'butterfly' || t === 'firefly' || t === 'bat'
 
 export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
   const { app, T, spriteSize } = opts
@@ -522,9 +524,17 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
   }
 
   // ── behaviour: chickens ─────────────────────────────────────────────────────────
-  function chickenTick(a: Animal, dt: number, avatar: Pt, walkable: Set<string>) {
+  function chickenTick(a: Animal, dt: number, avatar: Pt, walkable: Set<string>, night: boolean) {
     const z = a.zoneRect
     if (!z) return
+    // At night, chickens roost: head to the roost spot and settle there.
+    if (night) {
+      const roost = a.roostTile ?? [z[0] + (z[2] >> 1), z[1] + (z[3] >> 1)]
+      if (a.state !== 'roost') { a.goal = roost.slice() as [number, number]; a.state = 'roost' }
+      if (a.goal && !isMoving(a)) stepToward(a, walkable, 'zone', z)
+      return   // huddled — no pecking or scattering
+    }
+    if (a.state === 'roost') { a.state = 'peck'; a.stateTimer = 500; a.goal = null }
     const dog = nearestThreat(a, 3 * T)     // dogs
     const playerNear = Math.hypot(avatar.x - a.sprite.x, avatar.y - a.sprite.y) < 3 * T
     if (a.state !== 'scatter' && (dog || playerNear)) {
@@ -585,6 +595,40 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
     }
   }
 
+  // ── behaviour: fireflies (glow flies) — drift slowly with a pulsing glow ──────
+  function fireflyTick(a: Animal, dt: number) {
+    a.bobPhase += dt / 320
+    if (!isMoving(a)) {
+      a.stateTimer -= dt
+      if (a.stateTimer <= 0) {
+        const tx = clampN(a.tx + (Math.random() * 9 | 0) - 4, 0, cols - 1)
+        const ty = clampN(a.ty + (Math.random() * 9 | 0) - 4, 0, rows - 1)
+        if (!opts.isSolidTile(tx, ty)) hopTo(a, [tx, ty])
+        a.stateTimer = 1200 + Math.random() * 2500
+      }
+    }
+    advance(a, dt)
+    a.sprite.y = a.baseY + Math.sin(a.bobPhase) * 2
+    a.sprite.alpha = 0.4 + 0.6 * (0.5 + 0.5 * Math.sin(performance.now() / 450 + a.bobPhase))
+  }
+
+  // ── behaviour: bats — erratic swooping across the night sky ──────────────────
+  function batTick(a: Animal, dt: number) {
+    a.bobPhase += dt / 120
+    if (!isMoving(a)) {
+      a.stateTimer -= dt
+      if (a.stateTimer <= 0) {
+        a.movingTo = null
+        a.target = { x: Math.random() * opts.mapW, y: Math.random() * (opts.mapH * 0.7) }
+        a.path = []
+        a.stateTimer = 700 + Math.random() * 1400
+      }
+    }
+    animateWalk(a, dt)
+    advance(a, dt)
+    a.sprite.y = a.baseY + Math.sin(a.bobPhase) * 4   // jittery flight
+  }
+
   // ── day/night den schedule (cats & dogs with a home) ────────────────────────
   const isNightHour = (hour: number) => hour >= 20 || hour < 6
 
@@ -643,8 +687,19 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
     const avatar = opts.getAvatarPx()
     const npcs = opts.getNpcPositions()
     const hour = opts.getGameHour()
+    const night = isNightHour(hour)
 
     for (const a of animals) {
+      // Day/night fliers: birds & butterflies vanish at night; fireflies & bats
+      // only appear after dark.
+      const active = ANIMAL_SPECS[a.type].active
+      if (active && (active === 'night') !== night) {
+        if (a.sprite.visible) a.sprite.visible = false
+        if (a.bubble) { opts.bubbleLayer.removeChild(a.bubble); a.bubble = null }
+        continue
+      }
+      if (active && !a.sprite.visible) a.sprite.visible = true
+
       if (a.bubble) {
         positionBubble(a)
         a.bubbleTimer -= dt
@@ -678,6 +733,8 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
       if (a.type === 'bird') { birdTick(a, dt, avatar, npcs, walkable); continue }
       if (a.type === 'butterfly') { butterflyTick(a, dt); continue }
       if (a.type === 'frog') { frogTick(a, dt, avatar); continue }
+      if (a.type === 'firefly') { fireflyTick(a, dt); continue }
+      if (a.type === 'bat') { batTick(a, dt); continue }
 
       // Ground walkers: cat, dog, rabbit, chicken — shared advance + animation.
       advance(a, dt)
@@ -691,7 +748,7 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
       } else if (a.type === 'rabbit') {
         rabbitTick(a, dt, avatar, walkable)
       } else if (a.type === 'chicken') {
-        chickenTick(a, dt, avatar, walkable)
+        chickenTick(a, dt, avatar, walkable, night)
       } else {
         dogSocial(a, dt, npcs)
         dogChasePrey(a, dt)
@@ -727,7 +784,7 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
   }
 
   // ── spawning ──────────────────────────────────────────────────────────────────
-  async function makeAnimal(type: AnimalType, tx: number, ty: number, placed?: HubAnimal, zoneRect?: Rect): Promise<void> {
+  async function makeAnimal(type: AnimalType, tx: number, ty: number, placed?: HubAnimal, zoneRect?: Rect, roostTile?: [number, number]): Promise<void> {
     const spec = ANIMAL_SPECS[type]
     const slug = `animal-${type}`
     const staticTex = await loadTextureUrl(`${opts.baseUrl}sprites/${slug}.svg`).catch(() => null)
@@ -750,12 +807,12 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
     const initState =
       type === 'bird' ? 'perched' : type === 'fish' ? 'swim' : type === 'butterfly' ? 'flit'
       : type === 'frog' ? 'idle' : type === 'cat' ? 'sleep' : type === 'rabbit' ? 'freeze'
-      : type === 'chicken' ? 'peck' : 'sit'
+      : type === 'chicken' ? 'peck' : type === 'firefly' ? 'drift' : type === 'bat' ? 'swoop' : 'sit'
 
     const a: Animal = {
       type, id: placed?.id, stationary: !!placed && placed.roam !== true,
       homeTile: [tx, ty], sprite, tint, bottomAnchored, baseScale,
-      insideBuilding: null, zoneRect,
+      insideBuilding: null, zoneRect, roostTile,
       tx, ty, path: [], movingTo: null, target: null, goal: null,
       staticTex, sleepTex: null, frames: [], frameIdx: 0, frameTimer: FRAME_MS,
       state: initState, stateTimer: 500 + Math.random() * 1500,
@@ -796,7 +853,7 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
     })
 
     // Walk/fly frames for the animated types; cat also gets a sleep pose.
-    if (type !== 'fish' && type !== 'frog') {
+    if (type !== 'fish' && type !== 'frog' && type !== 'firefly') {
       loadAnimFrames(slug, 3).then(f => { a.frames = f }).catch(() => {})
     }
     if (type === 'cat') {
@@ -833,14 +890,20 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
   for (let i = 0; i < counts.butterfly; i++) { const t = randOf(opts.flowerTiles); if (t) void makeAnimal('butterfly', t[0], t[1]) }
   for (let i = 0; i < counts.rabbit; i++) { const t = randOf(grassTiles); if (t) void makeAnimal('rabbit', t[0], t[1]) }
   for (let i = 0; i < counts.frog; i++) { const t = randOf(pondEdgeTiles); if (t) void makeAnimal('frog', t[0], t[1]) }
-  // Chickens distributed across their pens.
+  // Nocturnal fliers — spawned now but hidden until night by the active gate.
+  const skyTiles = grassTiles.length ? grassTiles : walkTiles
+  for (let i = 0; i < counts.firefly; i++) { const t = randOf(skyTiles); if (t) void makeAnimal('firefly', t[0], t[1]) }
+  for (let i = 0; i < counts.bat; i++) { void makeAnimal('bat', (Math.random() * cols) | 0, (Math.random() * rows * 0.6) | 0) }
+  // Chickens distributed across their pens (with the pen's roost tile).
   if (counts.chicken > 0 && opts.chickenZones.length > 0) {
     for (let i = 0; i < counts.chicken; i++) {
-      const z = opts.chickenZones[i % opts.chickenZones.length].rect
+      const zone = opts.chickenZones[i % opts.chickenZones.length]
+      const z = zone.rect
+      const roost = zone.roost ?? [z[0] + (z[2] >> 1), z[1] + (z[3] >> 1)] as [number, number]
       let placed = false
       for (let tries = 0; tries < 8 && !placed; tries++) {
         const tx = z[0] + (Math.random() * z[2] | 0), ty = z[1] + (Math.random() * z[3] | 0)
-        if (!opts.isSolidTile(tx, ty)) { void makeAnimal('chicken', tx, ty, undefined, z); placed = true }
+        if (!opts.isSolidTile(tx, ty)) { void makeAnimal('chicken', tx, ty, undefined, z, roost); placed = true }
       }
     }
   }

--- a/web/src/data/hub/config.ts
+++ b/web/src/data/hub/config.ts
@@ -318,5 +318,5 @@ export interface RawConfig {
   animals?: RawAnimal[]
 
   /** Fenced pens that chickens are confined to. */
-  chickenZones?: { rect: number[]; count?: number }[]
+  chickenZones?: { rect: number[]; count?: number; roost?: number[] }[]
 }

--- a/web/src/data/hub/loader.ts
+++ b/web/src/data/hub/loader.ts
@@ -250,7 +250,7 @@ export interface HubLocationBundle {
   HUB_TREASURES: HubTreasure[]
   HUB_INTERACTABLES: HubInteractable[]
   HUB_ANIMALS: HubAnimal[]
-  HUB_CHICKEN_ZONES: { rect: [number, number, number, number]; count?: number }[]
+  HUB_CHICKEN_ZONES: { rect: [number, number, number, number]; count?: number; roost?: [number, number] }[]
   EXIT_TILES: HubExitTile[]
 
 
@@ -527,8 +527,12 @@ const HUB_ANIMALS: HubAnimal[] = (
 }))
 
 const HUB_CHICKEN_ZONES = (
-  (rawConfig as unknown as { chickenZones?: { rect: number[]; count?: number }[] }).chickenZones ?? []
-).map(z => ({ rect: z.rect as [number, number, number, number], count: z.count }))
+  (rawConfig as unknown as { chickenZones?: { rect: number[]; count?: number; roost?: number[] }[] }).chickenZones ?? []
+).map(z => ({
+  rect: z.rect as [number, number, number, number],
+  count: z.count,
+  roost: z.roost ? (z.roost as [number, number]) : undefined,
+}))
 
  const HUB_TOWN_NAME: string = (rawConfig as unknown as { townName?: string }).townName ?? 'Town'
 const ENVIRONMENT: string = (rawConfig as unknown as { environment?: string }).environment ?? 'camp'

--- a/web/src/game/hub/animals.test.ts
+++ b/web/src/game/hub/animals.test.ts
@@ -20,6 +20,7 @@ describe('computeProceduralCounts', () => {
     // 8 buildings → 2 cats, 8 npcs → 2 dogs, birds fixed 8, 12 pond → 2 fish + 1 frog
     expect(computeProceduralCounts(sources({ buildings: 8, npcs: 8, pondTiles: 12 }))).toEqual({
       cat: 2, dog: 2, bird: 8, fish: 2, butterfly: 0, rabbit: 0, chicken: 0, frog: 1,
+      firefly: 10, bat: 5,
     })
   })
 
@@ -63,6 +64,13 @@ describe('registry', () => {
     expect(ANIMAL_SPECS.butterfly.fleesFrom).toContain('cat')
     expect(ANIMAL_SPECS.dog.chases).toContain('rabbit')
     expect(ANIMAL_SPECS.rabbit.fleesFrom).toContain('dog')
+  })
+
+  it('fliers are gated to day or night', () => {
+    expect(ANIMAL_SPECS.bird.active).toBe('day')
+    expect(ANIMAL_SPECS.butterfly.active).toBe('day')
+    expect(ANIMAL_SPECS.firefly.active).toBe('night')
+    expect(ANIMAL_SPECS.bat.active).toBe('night')
   })
 })
 

--- a/web/src/game/hub/animals.ts
+++ b/web/src/game/hub/animals.ts
@@ -13,6 +13,7 @@
 export type AnimalType =
   | 'cat' | 'dog' | 'bird' | 'fish'
   | 'butterfly' | 'rabbit' | 'chicken' | 'frog'
+  | 'firefly' | 'bat'
 
 // How an animal moves around the map.
 export type NavMode =
@@ -41,6 +42,7 @@ export interface AnimalSpec {
   fleesFrom?: AnimalType[]            // generic predator/prey
   chases?: AnimalType[]
   dens?: boolean                      // follows the night-in / day-out building schedule
+  active?: 'day' | 'night'            // only present during this phase (omit = always)
 }
 
 // ── Per-type registry — the single source of truth for animal data ──────────
@@ -61,6 +63,7 @@ export const ANIMAL_SPECS: Record<AnimalType, AnimalSpec> = {
     speed: 230, scale: 0.5, layer: 'overlay', nav: 'fly',
     palette: { red: 0xd64545, blue: 0x4f86d6, brown: 0x9c6b3f, yellow: 0xe8d24a },
     spawn: { source: 'fixed', fixed: 8, cap: 8 },
+    active: 'day',
   },
   fish: {
     speed: 26, scale: 0.5, layer: 'pond', nav: 'pond',
@@ -71,7 +74,7 @@ export const ANIMAL_SPECS: Record<AnimalType, AnimalSpec> = {
     speed: 90, scale: 0.45, layer: 'overlay', nav: 'fly',
     palette: { orange: 0xe8923c, blue: 0x6db4ff, white: 0xf5f5f0, purple: 0xb07cd6, yellow: 0xf0d24a },
     spawn: { source: 'flowers', per: 2, cap: 5 },
-    fleesFrom: ['cat'],
+    fleesFrom: ['cat'], active: 'day',
   },
   rabbit: {
     speed: 95, scale: 0.5, layer: 'sprite', nav: 'grass-only',
@@ -89,6 +92,19 @@ export const ANIMAL_SPECS: Record<AnimalType, AnimalSpec> = {
     speed: 60, scale: 0.45, layer: 'sprite', nav: 'pond-edge',
     palette: { green: 0x5bbf52, darkgreen: 0x3a8f46, brown: 0x8b7a3c, spotted: 0x7fae5a },
     spawn: { source: 'pondTiles', per: 8, cap: 4 },
+  },
+  // Nocturnal fliers — replace the birds & butterflies after dark.
+  firefly: {
+    speed: 28, scale: 0.2, layer: 'overlay', nav: 'fly',
+    palette: { yellow: 0xfff07a, green: 0xc8ff88, warm: 0xffd86a },
+    spawn: { source: 'fixed', fixed: 10, cap: 10 },
+    active: 'night',
+  },
+  bat: {
+    speed: 170, scale: 0.42, layer: 'overlay', nav: 'fly',
+    palette: { black: 0x3a3a4a, brown: 0x5a4a3a, grey: 0x6a6a72 },
+    spawn: { source: 'fixed', fixed: 5, cap: 5 },
+    active: 'night',
   },
 }
 


### PR DESCRIPTION
Day/night life for the hub (#1592), built on the new registry.

## Day ↔ night fliers
A spec's optional `active: 'day' | 'night'` gates a type by time of day (`isNightHour` = hour ≥ 20 or < 6). Animals spawn once and the tick shows/hides them.
- **Birds & butterflies** are now `'day'` — they vanish after dark.
- **Fireflies** (new, glow flies) — drift slowly with a pulsing alpha **glow**; 10/town, night only.
- **Bats** (new) — swoop erratically across the night sky; 5/town, night only.

## Chickens roost at night
At night chickens head to their pen's **roost tile** (`chickenZones[].roost`, default the pen centre) and huddle until morning, then resume pecking by day.

## Wiring
- New `firefly`/`bat` specs + behaviours (`fireflyTick`/`batTick`) and sprites (`animal-firefly.svg`, `animal-bat*.svg`).
- `chickenZones[].roost` config field threaded through `config.ts`/`loader.ts`/the manager; `HubAnimalType` extended.
- `docs/hubworld.md §8` updated: day/night mechanic, fireflies/bats, roost.

## Verification
- `npm run test` — 146 pass (new active-gating + count assertions).
- `npm run build` — clean.

> Independent of #1600 (butterfly size/speed tweak) — they touch different lines of the butterfly spec, so both merge cleanly in either order.

https://claude.ai/code/session_01AJ8fw6nbRq6kDss3frrmwq

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJ8fw6nbRq6kDss3frrmwq)_