### PR TITLE
Hub: minimap + quest objective markers

### DIFF
--- a/web/src/components/hub/HubMinimap.stories.tsx
+++ b/web/src/components/hub/HubMinimap.stories.tsx
@@ -1,0 +1,69 @@
+import { useRef } from 'react'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { HubMinimap, MinimapObjective } from './HubMinimap'
+import { RAVENWATCH } from '../../data/hub/hubWorldFactory'
+
+// Story-friendly wrapper: HubMinimap reads the player position and viewport
+// imperatively via refs, so we set those up here and feed it static demo data.
+interface DemoProps {
+  objectives: MinimapObjective[]
+  player:     { x: number; y: number }
+  viewport:   { width: number; height: number }
+}
+
+function MinimapDemo({ objectives, player, viewport }: DemoProps) {
+  const playerRef   = useRef(player)
+  const viewportRef = useRef<HTMLDivElement | null>(null)
+  return (
+    <div style={{ position: 'relative', width: 460, height: 340, background: '#16241a', overflow: 'hidden' }}>
+      <div
+        ref={viewportRef}
+        style={{ width: viewport.width, height: viewport.height, overflow: 'hidden' }}
+      >
+        <div style={{ width: RAVENWATCH.MAP_W, height: RAVENWATCH.MAP_H }} />
+      </div>
+      <HubMinimap
+        locationData={RAVENWATCH}
+        objectives={objectives}
+        playerRef={playerRef}
+        viewportRef={viewportRef}
+      />
+    </div>
+  )
+}
+
+const meta = {
+  component: MinimapDemo,
+  parameters: { layout: 'centered' },
+} satisfies Meta<typeof MinimapDemo>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    player:   { x: 200, y: 150 },
+    viewport: { width: 460, height: 340 },
+    objectives: [
+      { x: 300, y: 200, kind: 'pickup' },
+      { x: 150, y: 260, kind: 'npc' },
+    ],
+  },
+}
+
+export const OffscreenObjective: Story = {
+  args: {
+    player:   { x: 200, y: 150 },
+    viewport: { width: 460, height: 340 },
+    // Far outside the visible window → triggers the off-screen edge arrow.
+    objectives: [{ x: 1700, y: 1300, kind: 'npc' }],
+  },
+}
+
+export const NoObjectives: Story = {
+  args: {
+    player:     { x: 400, y: 400 },
+    viewport:   { width: 460, height: 340 },
+    objectives: [],
+  },
+}

--- a/web/src/components/hub/HubMinimap.tsx
+++ b/web/src/components/hub/HubMinimap.tsx
@@ -1,0 +1,256 @@
+import React, { useEffect, useRef, useState } from 'react'
+import type { HubLocationBundle } from '../../data/hub/loader'
+
+const T = 32
+
+const MM_W = 140
+const MM_H = 120
+const PAD  = 6          // inner padding inside the minimap canvas
+
+const STORE_KEY = 'jarv_hub_minimap_on'
+
+export interface MinimapObjective {
+  x:    number              // world pixel coords (centre of the target tile)
+  y:    number
+  kind: 'pickup' | 'npc'
+}
+
+interface Props {
+  locationData: HubLocationBundle
+  objectives:   MinimapObjective[]
+  playerRef:    React.RefObject<{ x: number; y: number }>
+  viewportRef:  React.RefObject<HTMLDivElement | null>
+}
+
+function loadVisible(): boolean {
+  try {
+    return localStorage.getItem(STORE_KEY) !== 'off'
+  } catch {
+    return true
+  }
+}
+
+function saveVisible(on: boolean): void {
+  try {
+    localStorage.setItem(STORE_KEY, on ? 'on' : 'off')
+  } catch { /* ignore */ }
+}
+
+export function HubMinimap({ locationData, objectives, playerRef, viewportRef }: Props) {
+  const { MAP_W, MAP_H, HUB_BUILDINGS } = locationData
+
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const [visible, setVisible] = useState(loadVisible)
+  // Off-screen edge arrow, in screen-fraction coords (0..1) + angle, or null when on-screen.
+  const [arrow, setArrow] = useState<{ fx: number; fy: number; angle: number } | null>(null)
+
+  // World → minimap scale (letterboxed to preserve aspect ratio).
+  const innerW = MM_W - PAD * 2
+  const innerH = MM_H - PAD * 2
+  const scale  = Math.min(innerW / MAP_W, innerH / MAP_H)
+  const drawW  = MAP_W * scale
+  const drawH  = MAP_H * scale
+  const offX   = PAD + (innerW - drawW) / 2
+  const offY   = PAD + (innerH - drawH) / 2
+  const toMmX  = (wx: number) => offX + wx * scale
+  const toMmY  = (wy: number) => offY + wy * scale
+
+  // Redraw loop — runs only while the minimap is visible. Repaints when the
+  // player tile, objectives, or viewport window change (keeps work minimal).
+  useEffect(() => {
+    if (!visible) { setArrow(null); return }
+    const canvas = canvasRef.current
+    if (!canvas) return
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+
+    // Hi-DPI crispness.
+    const dpr = Math.min(window.devicePixelRatio || 1, 2)
+    canvas.width  = MM_W * dpr
+    canvas.height = MM_H * dpr
+    ctx.scale(dpr, dpr)
+
+    let raf = 0
+    let lastSig = ''
+
+    const objSig = objectives.map(o => `${o.kind}:${Math.round(o.x)},${Math.round(o.y)}`).join('|')
+
+    const frame = () => {
+      const p  = playerRef.current ?? { x: 0, y: 0 }
+      const vp = viewportRef.current
+
+      // Visible world window (for the edge-arrow on-screen test).
+      const vx = vp?.scrollLeft ?? 0
+      const vy = vp?.scrollTop  ?? 0
+      const vw = vp?.clientWidth  ?? MAP_W
+      const vh = vp?.clientHeight ?? MAP_H
+
+      const sig = `${Math.round(p.x)},${Math.round(p.y)}|${objSig}|${Math.round(vx)},${Math.round(vy)},${vw},${vh}`
+      if (sig !== lastSig) {
+        lastSig = sig
+        draw(ctx, p, { vx, vy, vw, vh })
+      }
+      raf = requestAnimationFrame(frame)
+    }
+
+    const draw = (
+      c: CanvasRenderingContext2D,
+      player: { x: number; y: number },
+      view: { vx: number; vy: number; vw: number; vh: number },
+    ) => {
+      c.clearRect(0, 0, MM_W, MM_H)
+
+      // Map outline.
+      c.fillStyle   = 'rgba(20,34,20,0.9)'
+      c.strokeStyle = '#446644'
+      c.lineWidth   = 1
+      c.fillRect(offX, offY, drawW, drawH)
+
+      // Buildings.
+      c.fillStyle = 'rgba(120,150,120,0.55)'
+      for (const b of HUB_BUILDINGS) {
+        const [tx1, ty1, tx2, ty2] = b.rect
+        const bx = toMmX(tx1 * T)
+        const by = toMmY(ty1 * T)
+        const bw = (tx2 - tx1 + 1) * T * scale
+        const bh = (ty2 - ty1 + 1) * T * scale
+        c.fillRect(bx, by, bw, bh)
+      }
+
+      c.strokeRect(offX, offY, drawW, drawH)
+
+      // Viewport window indicator.
+      c.strokeStyle = 'rgba(212,234,212,0.35)'
+      c.strokeRect(
+        toMmX(view.vx), toMmY(view.vy),
+        view.vw * scale, view.vh * scale,
+      )
+
+      // Objective pins.
+      for (const o of objectives) {
+        c.beginPath()
+        c.arc(toMmX(o.x), toMmY(o.y), 3, 0, Math.PI * 2)
+        c.fillStyle = o.kind === 'pickup' ? '#e0b050' : '#66cc66'
+        c.fill()
+        c.lineWidth   = 1
+        c.strokeStyle = 'rgba(8,14,8,0.9)'
+        c.stroke()
+      }
+
+      // Player marker.
+      c.beginPath()
+      c.arc(toMmX(player.x), toMmY(player.y), 3.2, 0, Math.PI * 2)
+      c.fillStyle = '#ffffff'
+      c.fill()
+      c.lineWidth   = 1.2
+      c.strokeStyle = '#88cc88'
+      c.stroke()
+
+      // ── Off-screen edge arrow: nearest objective outside the viewport ──────
+      let nearest: MinimapObjective | null = null
+      let nearestD = Infinity
+      for (const o of objectives) {
+        const d = (o.x - player.x) ** 2 + (o.y - player.y) ** 2
+        if (d < nearestD) { nearestD = d; nearest = o }
+      }
+      if (nearest) {
+        const onScreen =
+          nearest.x >= view.vx && nearest.x <= view.vx + view.vw &&
+          nearest.y >= view.vy && nearest.y <= view.vy + view.vh
+        if (!onScreen) {
+          // Direction from the viewport centre to the objective.
+          const cx = view.vx + view.vw / 2
+          const cy = view.vy + view.vh / 2
+          const angle = Math.atan2(nearest.y - cy, nearest.x - cx)
+          // Project onto the edge of a centred unit box → screen fraction.
+          const dx = Math.cos(angle)
+          const dy = Math.sin(angle)
+          const m = Math.max(Math.abs(dx), Math.abs(dy)) || 1
+          const fx = 0.5 + (dx / m) * 0.45
+          const fy = 0.5 + (dy / m) * 0.45
+          setArrow({ fx, fy, angle })
+        } else {
+          setArrow(null)
+        }
+      } else {
+        setArrow(null)
+      }
+    }
+
+    raf = requestAnimationFrame(frame)
+    return () => cancelAnimationFrame(raf)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [visible, objectives, locationData])
+
+  const toggle = () => {
+    setVisible(v => { saveVisible(!v); return !v })
+  }
+
+  return (
+    <>
+      {/* Off-screen objective edge arrow */}
+      {visible && arrow && (
+        <div
+          style={{
+            position:      'absolute',
+            left:          `${arrow.fx * 100}%`,
+            top:           `${arrow.fy * 100}%`,
+            transform:     `translate(-50%, -50%) rotate(${arrow.angle}rad)`,
+            pointerEvents: 'none',
+            zIndex:        19,
+            fontSize:      22,
+            color:         '#e0b050',
+            textShadow:    '0 0 6px rgba(0,0,0,0.8)',
+            lineHeight:    1,
+          }}
+          aria-hidden
+        >
+          ➤
+        </div>
+      )}
+
+      {/* Corner minimap */}
+      <div
+        style={{
+          position:      'absolute',
+          top:           48,
+          right:         12,
+          zIndex:        20,
+          pointerEvents: 'none',
+        }}
+      >
+        {visible && (
+          <canvas
+            ref={canvasRef}
+            style={{
+              display:    'block',
+              width:      MM_W,
+              height:     MM_H,
+              border:     '1px solid #446644',
+              background: 'rgba(8,14,8,0.85)',
+            }}
+          />
+        )}
+        <button
+          onClick={toggle}
+          title={visible ? 'Hide minimap' : 'Show minimap'}
+          style={{
+            position:      'absolute',
+            top:           4,
+            right:         4,
+            pointerEvents: 'auto',
+            background:    'rgba(8,14,8,0.85)',
+            border:        '1px solid #446644',
+            color:         '#88cc88',
+            fontSize:      12,
+            lineHeight:    1,
+            padding:       '2px 4px',
+            cursor:        'pointer',
+          }}
+        >
+          🗺
+        </button>
+      </div>
+    </>
+  )
+}

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -2,6 +2,8 @@ import React, { useState, useCallback, useEffect, useMemo, useRef } from 'react'
 import { OverlayScreen } from '../ui/OverlayScreen'
 import { HubTownCanvas } from './HubTownCanvas'
 import { AreaNameBadge } from './AreaNameBadge'
+import { HubMinimap } from './HubMinimap'
+import type { MinimapObjective } from './HubMinimap'
 import { HubReturnButton } from './HubReturnButton'
 import { HubDialogue } from './HubDialogue'
 import type { DialogueChoice } from './HubDialogue'
@@ -249,6 +251,38 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onEndless, onWorldMap
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [_tick])
 
+  // Active-quest objective pins for the minimap (world-pixel coords).
+  // Lost-item quests show no item pins until everything is found, then point to
+  // the NPC who finishes the quest (see issue #1663).
+  const minimapObjectives = useMemo<MinimapObjective[]>(() => {
+    const out: MinimapObjective[] = []
+    const pushNpc = (npcId: string | undefined) => {
+      const npc = locationData.HUB_NPCS.find(n => n.id === npcId)
+      if (npc) out.push({ x: npc.tx * T + T / 2, y: npc.ty * T + T / 2, kind: 'npc' })
+    }
+    for (const quest of questDefs) {
+      if (getQuestState(quest.id).status !== 'active') continue
+      const incomplete = quest.steps.find(s => getQuestProgress(quest.id, s.key) < s.required)
+      if (!incomplete) {
+        // All steps done but quest still active → return to the receiver NPC.
+        pushNpc(quest.receiverNpcId)
+        continue
+      }
+      if (incomplete.type === 'collect') {
+        if (quest.type === 'lost-items') continue  // no item pins for lost-item quests
+        for (const pid of incomplete.pickupIds ?? []) {
+          if (pickedUpIds.has(pid)) continue
+          const item = locationQuests.HUB_PICKUP_ITEMS.find(p => p.id === pid)
+          if (item) out.push({ x: item.tx * T + T / 2, y: item.ty * T + T / 2, kind: 'pickup' })
+        }
+      } else {
+        pushNpc(incomplete.targetNpcId)
+      }
+    }
+    return out
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [questDefs, pickedUpIds, _tick, locationData, locationQuests])
+
   const dismissSplash = useCallback(() => {
     _hubSplashShown = true
     setSplashFading(true)
@@ -276,7 +310,14 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onEndless, onWorldMap
     return () => clearTimeout(id)
   }, [dialogueEvent, dialogueLine])
 
+  // Live player world-pixel position, read imperatively by the minimap's rAF loop.
+  const playerPixelRef = useRef({
+    x: locationData.AVATAR_START.tx * T + T / 2,
+    y: locationData.AVATAR_START.ty * T + T / 2,
+  })
+
   const handleAvatarMove = useCallback((px: number, py: number) => {
+    playerPixelRef.current = { x: px, y: py }
     const el = scrollRef.current
     if (!el) return
     el.scrollLeft = px - el.clientWidth  / 2
@@ -289,6 +330,7 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onEndless, onWorldMap
     const saved = getSavedHubTile(locationData.HUB_TOWN_NAME)
     const px = saved ? saved[0] * T + T / 2 : locationData.AVATAR_START.tx * T + T / 2
     const py = saved ? saved[1] * T + T / 2 : locationData.AVATAR_START.ty * T + T / 2
+    playerPixelRef.current = { x: px, y: py }
     el.scrollLeft = px - el.clientWidth  / 2
     el.scrollTop  = py - el.clientHeight / 2
   }, [locationData])
@@ -751,6 +793,15 @@ function tryOfferQuest(giverId: string, speakerName: string, onlyQuestId?: strin
           />
         </div>
         <AreaNameBadge name={currentArea} />
+
+        {!interiorActive && (
+          <HubMinimap
+            locationData={locationData}
+            objectives={minimapObjectives}
+            playerRef={playerPixelRef}
+            viewportRef={scrollRef}
+          />
+        )}
 
         {questsOpen && <QuestsModal onClose={() => setQuestsOpen(false)} onAbandon={handleQuestAbandon} questDefs={questDefs}/>}
         {openTreasure && <TreasureModal treasure={openTreasure} onClose={() => setOpenTreasure(null)} />}


### PR DESCRIPTION
## Why
The hub maps are large (Ravenwatch is 75×70 tiles) and there's no on-screen guidance, so players can get lost or miss active-quest objectives.

## What's in this PR
A corner **minimap** overlay for the Hub World plus an off-screen **edge arrow** to the nearest objective. Implements issue #1607 and its sub-tasks #1659, #1663, #1666.

### `HubMinimap.tsx` (new)
- Lightweight 2D `<canvas>` HUD (no second PixiJS app) drawn in a `requestAnimationFrame` loop that only repaints when the player tile, objectives, or viewport window change.
- Renders the **map outline**, **buildings** (`HUB_BUILDINGS`), the current **viewport window**, **objective pins** (amber = pickup, green = NPC), and the **player marker**.
- Reads live player position and the scroll viewport imperatively via refs, matching the existing "ref read by ticker" pattern in `HubWorld`.
- **Off-screen edge arrow**: points to the nearest active objective when it's outside the visible window.
- **Toggleable** via a small 🗺 button (state persisted in `localStorage`); all layers use `pointer-events: none` except the toggle, so the minimap never blocks gameplay taps.

### `HubWorld.tsx`
- Tracks the player's world-pixel position in a ref (updated from the existing `onAvatarMove` callback).
- Computes objective pins from quest state:
  - **Lost-item quests** show **no item pins** until everything is found, then point to the NPC who completes the quest (per #1663).
  - **Fetch/chain quests** show pickup pins, switching to the delivery/return NPC as steps complete.
- Mounts `<HubMinimap>` (hidden while inside building interiors).

### `HubMinimap.stories.tsx` (new)
Storybook story covering the default pins, the off-screen edge arrow, and the no-objectives state.

## Acceptance criteria
- [x] Minimap renders player + buildings + active-quest pins and updates as the player moves
- [x] Toggleable; does not block gameplay taps (`pointer-events: none`)
- [x] Storybook story added
- [x] `npm run build` passes

## Testing
- `cd web && npm run build` passes (the `tsc` step typechecks the new component and story).
- Vitest could not run in CI here because it's configured for Playwright browser mode and the browsers aren't downloaded in the container — unrelated to this change.

Closes #1607

https://claude.ai/code/session_014q6YieiapPX2CH8GpTGV6h

---
_Generated by [Claude Code](https://claude.ai/code/session_014q6YieiapPX2CH8GpTGV6h)_