### PR TITLE
Fix: hub toolbar dropdown renders under the minimap

### DIFF
--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -10078,6 +10078,10 @@ html.light-mode .action-btn {
   row-gap: 0;
   container-type: inline-size;
   container-name: toolbar;
+  /* Keep the toolbar (and its overflow dropdown) above positioned map overlays
+     such as the hub minimap; modals portal to <body> at z-index 200 and stay above. */
+  position: relative;
+  z-index: 50;
 }
 .toolbar > .filter-btn {
   align-self: stretch;


### PR DESCRIPTION
## Problem
The hub `📊` toolbar overflow dropdown opened **underneath** the corner minimap.

## Root cause
`.toolbar` sets `container-type: inline-size`, which applies layout containment and makes the toolbar a **stacking context**. The dropdown panel (`.toolbar-dropdown-panel`, z-index 20) is trapped inside that context. Since the toolbar is non-positioned it paints early, while the sibling map container (`.nm-map`, `position: relative`) is positioned and paints later — so every positioned child of `.nm-map` (the minimap, z-index 20) paints above the entire toolbar regardless of the dropdown's own z-index. Lowering the minimap's z-index can't fix this; the toolbar itself has to paint above the map region.

## Fix
Give `.toolbar` `position: relative; z-index: 50`. This lifts the toolbar (and its dropdown) above the map overlays (minimap 20, edge arrow 19, dialogue 10) while staying below modals — `ModalBackdrop` portals to `document.body` with `.modal-backdrop { z-index: 200 }`, so quests/treasure modals still cover everything. `position: relative` doesn't change layout (the toolbar is a flex child).

The rule is shared by other screens (HubWorldMap, CityBuilder, NodeMap, …); a toolbar painting above its own screen's content is the expected behavior, and modals/tooltips (z-index ≥ 200) remain above it.

## Testing
- `cd web && npm run build` passes.

Relates to the minimap added in #1685.

https://claude.ai/code/session_014q6YieiapPX2CH8GpTGV6h

---
_Generated by [Claude Code](https://claude.ai/code/session_014q6YieiapPX2CH8GpTGV6h)_