### PR TITLE
Hub NPC activities: pose sprite only (no emote) + map editor support

### DIFF
--- a/docs/hubworld.md
+++ b/docs/hubworld.md
@@ -482,10 +482,12 @@ A `!`/`?` quest indicator floats above placed animals that have
 Named NPCs (`config.json` → `npcs`) can follow a **time-of-day schedule**: a list
 of entries that relocate the NPC between exterior tiles and building interiors as
 the hub clock advances (30 real minutes = 1 game day, see `hubClock.ts`). At each
-scheduled stop an NPC may also perform a visible **activity** — rendered as a
-bobbing emote bubble plus an optional pose-swap sprite — so the town feels
-lived-in. Parsed straight through by `loader.ts`; logic lives in
-`web/src/game/hub/hubNpcSchedule.ts`, rendering in `HubTownCanvas.tsx`.
+scheduled stop an NPC may also perform a visible **activity** — rendered by
+swapping to an activity **pose sprite** — so the town feels lived-in. Parsed
+straight through by `loader.ts`; logic lives in
+`web/src/game/hub/hubNpcSchedule.ts`, rendering in `HubTownCanvas.tsx`. NPC
+schedules and activities are also editable in the in-app map editor
+(`components/mapEditor/npcQuestDrawer/NpcEditor.tsx`).
 
 ### Schema (`HubNpc.schedule`)
 
@@ -513,29 +515,29 @@ lived-in. Parsed straight through by `loader.ts`; logic lives in
 | Field | Type | Required | Description |
 |---|---|---|---|
 | `startHour` / `endHour` | `number` (0–23) | ✓ | Half-open `[start, end)` game-hour window. **Wraps midnight** when `start > end` (e.g. `20 → 0`). The first matching entry wins; cover all 24 hours to avoid gaps. |
-| `activity` | `NpcActivity` | | Visible activity at this stop (see table below). Omit for "just stand there". |
+| `activity` | `NpcActivity` | | Visible activity at this stop (see list below). Omit for "just stand there". |
 | `location.type` | `"exterior"` \| `"interior"` | ✓ | Where the NPC is during this window. |
 | `location.tx` / `ty` | `number` | ✓ | Exterior: absolute hub coords. Interior: coords within that building's room grid. |
-| `location.buildingId` | `string` | interior only | Building `id` the NPC waits inside. The exterior sprite hides; if the player enters that building the NPC renders inside (its activity emote/pose shows there too). |
+| `location.buildingId` | `string` | interior only | Building `id` the NPC waits inside. The exterior sprite hides; if the player enters that building the NPC renders inside (its activity pose shows there too). |
 | `homeBed` | `{ buildingId, tx, ty }` | | Reserved sleeping spot reference (used by night logic). |
 
 On a game-hour boundary the NPC pathfinds to the new location (emerging at / walking
-to the relevant door for interior transitions). The activity emote and pose only
-show while the NPC is **standing at its post** — they clear while it walks.
+to the relevant door for interior transitions). The activity pose only shows while
+the NPC is **standing at its post** — it reverts to the base sprite while it walks.
 
-### Activities & emotes (`ACTIVITY_EMOTES` in `hubNpcSchedule.ts`)
+### Activities (`NPC_ACTIVITIES` in `hubNpcSchedule.ts`)
 
-| Activity | Emote | Typical use |
-|---|---|---|
-| `work` | 🔨 | Manning a stall, smithing, labouring |
-| `sweep` | 🧹 | Tidying a doorway / square |
-| `fish` | 🎣 | Fishing at the pond edge |
-| `idle-chat` | 💬 | Chatting / gossiping in the open |
-| `eat` | 🍲 | Eating at the inn |
-| `sleep` | 💤 | Resting in a bedroom |
+| Activity | Typical use |
+|---|---|
+| `work` | Manning a stall, smithing, labouring |
+| `sweep` | Tidying a doorway / square |
+| `fish` | Fishing at the pond edge |
+| `idle-chat` | Chatting / gossiping in the open |
+| `eat` | Eating at the inn |
+| `sleep` | Resting in a bedroom |
 
-`ACTIVITY_EMOTES` is the single source of truth — add a key there (and to the
-`NpcActivity` union in `loader.ts`) to introduce a new activity.
+`NPC_ACTIVITIES` is the single source of truth for editor dropdowns — add an entry
+there **and** to the `NpcActivity` union in `loader.ts` to introduce a new activity.
 
 ### Pose-swap sprites (optional art)
 
@@ -551,5 +553,5 @@ workflow in `AGENTS.md` (32×32 SVG, create/commit/push one at a time).
    on the relevant entries (use the activity keys above).
 2. (Optional) Author `{sprite}-{activity}.svg` pose sprites for a richer look.
 3. Run `npm run test` (loader + schedule tests) and `npm run build`.
-4. Verify in-game: at the relevant hours the NPC is at its post showing the emote
-   (and pose); the emote clears while it walks at an hour boundary.
+4. Verify in-game: at the relevant hours the NPC is at its post in its activity
+   pose; the pose reverts to the base sprite while it walks at an hour boundary.

--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -6,7 +6,7 @@ import { renderPathTiles } from '../../utils/tileLookup'
 import { loadSpriteTexture, loadTextureUrl, loadAnimFrames, loadTileRef } from '../../utils/pixiHelpers'
 import { PATH_TILE } from '../../data/tiles/tileIndex'
 import { findPath, nearestWalkable } from '../../utils/hubPathfinder'
-import { isBuildingOpen, getNpcLocation, getNpcActivity, getActivityEmote } from '../../game/hub/hubNpcSchedule'
+import { isBuildingOpen, getNpcLocation, getNpcActivity } from '../../game/hub/hubNpcSchedule'
 import { getGameHour, getGameMinute } from '../../game/hub/hubClock'
 import { getWallTile, ROOF_TILES, WALL_TILES, ROOF_ROWS } from '../../data/tiles/buildingMaterials'
 import type { WallMaterial, RoofMaterial } from '../../data/tiles/buildingMaterials'
@@ -842,8 +842,7 @@ export function HubTownCanvas({
     const namedNpcWalkStates = new Map<string, NamedNpcWalkState>()
     // Proximity bubbles for named NPCs driven by npcProximityDialogue ref
     const namedNpcProximityBubbles = new Map<string, { bubble: PIXI.Container | null; lastText: string | null }>()
-    // Schedule-driven activities: emote glyphs, current activity, and pose textures
-    const namedNpcActivityEmotes = new Map<string, PIXI.Text>()
+    // Schedule-driven activities: current activity + pose textures (swap sprite while active)
     const namedNpcActivity       = new Map<string, ReturnType<typeof getNpcActivity>>()
     const namedNpcBaseTex        = new Map<string, PIXI.Texture>()
     const namedNpcPoseTex        = new Map<string, PIXI.Texture>()  // keyed `${npcId}:${activity}`
@@ -897,15 +896,6 @@ export function HubTownCanvas({
         bubbleLayer.addChild(ind)
         questIndicators.set(npc.id, ind)
         questIndicatorBaseY.set(npc.id, indBaseY)
-      }
-
-      // Activity emote (schedule-driven) — bobs above the NPC while it works/eats/etc.
-      if (npc.schedule?.some(e => e.activity)) {
-        const emote = new PIXI.Text({ text: '', style: { fontSize: 15, fontFamily: 'sans-serif' } })
-        emote.anchor.set(0.5, 1)
-        emote.visible = false
-        bubbleLayer.addChild(emote)
-        namedNpcActivityEmotes.set(npc.id, emote)
       }
 
       const npcSpriteSlug = isCommanderNpc ? (commander !== undefined ? commander.cardName : avatarSlug) : npc.sprite
@@ -2281,25 +2271,17 @@ export function HubTownCanvas({
           }
         }
 
-        // Activity emote + pose swap — active while the NPC is at its post (not walking)
-        for (const [npcId, emote] of namedNpcActivityEmotes) {
+        // Activity pose swap — use the activity pose sprite while the NPC is at its
+        // post (not walking/indoors), the base sprite otherwise.
+        for (const [npcId, baseTex] of namedNpcBaseTex) {
           const ws = namedNpcWalkStates.get(npcId)
           const container = namedNpcContainers.get(npcId)
           const s = container?.children[0] as PIXI.Sprite | undefined
+          if (!s) continue
           const activity = (ws && !ws.isWalking && !ws.isInside) ? namedNpcActivity.get(npcId) ?? null : null
-          const glyph = getActivityEmote(activity)
-          emote.visible = glyph !== null && (container?.visible ?? false)
-          if (emote.visible && s) {
-            if (emote.text !== glyph) emote.text = glyph as string
-            emote.position.set(s.x, s.y - SPRITE_SIZE - 18 + Math.sin(performance.now() / 400) * 2)
-          }
-          // Pose swap: use the activity pose texture while active, base texture otherwise.
-          if (s) {
-            const poseTex = activity ? namedNpcPoseTex.get(`${npcId}:${activity}`) : undefined
-            const baseTex = namedNpcBaseTex.get(npcId)
-            const wantTex = poseTex ?? baseTex
-            if (wantTex && s.texture !== wantTex) s.texture = wantTex
-          }
+          const poseTex = activity ? namedNpcPoseTex.get(`${npcId}:${activity}`) : undefined
+          const wantTex = poseTex ?? baseTex
+          if (s.texture !== wantTex) s.texture = wantTex
         }
 
         // Blocked path visibility and proximity speech bubbles

--- a/web/src/components/mapEditor/mapEditorTypes.ts
+++ b/web/src/components/mapEditor/mapEditorTypes.ts
@@ -1,5 +1,6 @@
 import { MapId } from '../../data/hub/hubWorldFactory'
 import type { WallMaterial, RoofMaterial } from '../../data/tiles/buildingMaterials'
+import type { NpcActivity } from '../../data/hub/loader'
 
 
 export type ToolMode = 'select' | 'place' | 'delete' | 'street'
@@ -55,6 +56,7 @@ export interface RawNpc {
   schedule?: Array<{
     startHour: number
     endHour: number
+    activity?: NpcActivity
     location:
       | { type: 'exterior'; tx: number; ty: number }
       | { type: 'interior'; buildingId: string; tx: number; ty: number }

--- a/web/src/components/mapEditor/npcQuestDrawer/NpcEditor.tsx
+++ b/web/src/components/mapEditor/npcQuestDrawer/NpcEditor.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react'
 import type { RawMapConfig, RawNpc } from '../mapEditorTypes'
 import type { QuestDefsJson } from '../../../data/hub/hubWorldFactory'
+import { NPC_ACTIVITIES } from '../../../game/hub/hubNpcSchedule'
 
 interface Props {
   configData: RawMapConfig
@@ -94,6 +95,15 @@ function ScheduleEditor({ schedule, onChange }: {
             <input type="number" value={row.location.ty}
               onChange={e => setLocation(i, { ...row.location, ty: Number(e.target.value) })}
               style={{ ...NUM, width: 44 }} />
+            <label style={{ color: '#888', fontSize: 10 }}>Activity</label>
+            <select
+              value={row.activity ?? ''}
+              onChange={e => update(i, { activity: e.target.value ? (e.target.value as ScheduleRow['activity']) : undefined })}
+              style={{ padding: '2px 5px', background: '#111', border: '1px solid #444', color: '#eee', borderRadius: 3, fontSize: 10 }}
+            >
+              <option value="">none</option>
+              {NPC_ACTIVITIES.map(a => <option key={a} value={a}>{a}</option>)}
+            </select>
           </div>
         </div>
       ))}

--- a/web/src/data/hub/config.ts
+++ b/web/src/data/hub/config.ts
@@ -129,6 +129,8 @@ export interface RawInteriorNPCLocation {
 export interface RawNpcScheduleEntry {
   startHour: number
   endHour: number
+  /** Loose raw type; the typed `NpcActivity` union lives in loader.ts. */
+  activity?: string
 
   location: RawExteriorNPCLocation | RawInteriorNPCLocation
 }

--- a/web/src/data/hub/loader.ts
+++ b/web/src/data/hub/loader.ts
@@ -75,7 +75,7 @@ export type NpcActivity = 'work' | 'eat' | 'idle-chat' | 'sleep' | 'sweep' | 'fi
 export interface NpcScheduleEntry {
   startHour: number
   endHour: number
-  /** Optional activity shown via an emote bubble + pose swap while at this location. */
+  /** Optional activity shown via a pose-swap sprite while at this location. */
   activity?: NpcActivity
   location:
     | { type: 'exterior'; tx: number; ty: number }

--- a/web/src/game/hub/hubNpcSchedule.test.ts
+++ b/web/src/game/hub/hubNpcSchedule.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { getNpcActivity, getActivityEmote, ACTIVITY_EMOTES } from './hubNpcSchedule'
+import { getNpcActivity, NPC_ACTIVITIES } from './hubNpcSchedule'
 import type { HubNpc } from '../../data/hub/loader'
 
 const npc: HubNpc = {
@@ -26,14 +26,9 @@ describe('getNpcActivity', () => {
   })
 })
 
-describe('getActivityEmote', () => {
-  it('maps every activity to a glyph', () => {
-    expect(getActivityEmote('fish')).toBe(ACTIVITY_EMOTES.fish)
-    expect(getActivityEmote('work')).toBe(ACTIVITY_EMOTES.work)
-  })
-
-  it('returns null for null/undefined', () => {
-    expect(getActivityEmote(null)).toBeNull()
-    expect(getActivityEmote(undefined)).toBeNull()
+describe('NPC_ACTIVITIES', () => {
+  it('lists the activity used in the fixture schedule', () => {
+    expect(NPC_ACTIVITIES).toContain('work')
+    expect(NPC_ACTIVITIES).toContain('fish')
   })
 })

--- a/web/src/game/hub/hubNpcSchedule.ts
+++ b/web/src/game/hub/hubNpcSchedule.ts
@@ -2,18 +2,11 @@ import { hourInRange } from './hubClock'
 import type { HubNpc, HubInterior, NpcScheduleEntry, NpcActivity } from '../../data/hub/loader'
 
 /**
- * Single source of truth for activity → emote glyph shown above an NPC while it
- * performs the activity at its scheduled location. Adding an activity = an entry
- * here + (optionally) a `{sprite}-{activity}.svg` pose sprite.
+ * Canonical list of NPC activities (single source of truth for editor dropdowns
+ * and validation). Each activity optionally renders a `{sprite}-{activity}.svg`
+ * pose sprite while the NPC performs it at its scheduled location.
  */
-export const ACTIVITY_EMOTES: Record<NpcActivity, string> = {
-  work: '🔨',
-  eat: '🍲',
-  'idle-chat': '💬',
-  sleep: '💤',
-  sweep: '🧹',
-  fish: '🎣',
-}
+export const NPC_ACTIVITIES: NpcActivity[] = ['work', 'eat', 'idle-chat', 'sleep', 'sweep', 'fish']
 
 export function getNpcLocation(npc: HubNpc, gameHour: number): NpcScheduleEntry['location'] | null {
   if (!npc.schedule?.length) return null
@@ -30,11 +23,6 @@ export function getNpcActivity(npc: HubNpc, gameHour: number): NpcActivity | nul
     if (hourInRange(gameHour, entry.startHour, entry.endHour)) return entry.activity ?? null
   }
   return null
-}
-
-/** Emote glyph for an activity, or null. */
-export function getActivityEmote(activity: NpcActivity | null | undefined): string | null {
-  return activity ? ACTIVITY_EMOTES[activity] ?? null : null
 }
 
 export function isNpcInBuilding(npc: HubNpc, buildingId: string, gameHour: number): boolean {


### PR DESCRIPTION
Follow-up to #1686 (Hub NPC daily-life activities), addressing two pieces of feedback.

## 1. Drop the emote bubble — the pose sprite is enough
The activity emoji that floated above an NPC's head is removed. The activity **pose sprite** (`{sprite}-{activity}.svg`) is now the sole visual indicator — it swaps in while the NPC is at its post and reverts to the base sprite while it walks. Less visual noise, same "lived-in" effect.

- `HubTownCanvas.tsx`: removed the emote `PIXI.Text` creation and per-frame emote logic; kept the pose-swap loop.
- `hubNpcSchedule.ts`: replaced `ACTIVITY_EMOTES` / `getActivityEmote()` with a canonical `NPC_ACTIVITIES` list (single source of truth for editor dropdowns + validation).
- `docs/hubworld.md` §9: updated to describe pose-only activities.

## 2. Map editor now covers the new feature
The in-app NPC editor's schedule rows had no way to set an activity. Added it:

- `npcQuestDrawer/NpcEditor.tsx`: an **Activity** `<select>` per schedule slot (`none` + the six activities from `NPC_ACTIVITIES`).
- `mapEditorTypes.ts`: added `activity?: NpcActivity` to the editor's schedule type.
- `config.ts`: added the (loose) `activity?` field to the raw schedule type so the raw-config contract is complete.

## Verification
- `npm run build` — clean.
- Loader + schedule tests pass (`loader.test.ts`, `hubNpcSchedule.test.ts`).
- In the map editor, opening an NPC with a schedule shows the Activity dropdown per slot; selecting one persists into the config; clearing to `none` drops the field.
- In-game (Ravenwatch, daytime): the fisherman/merchant/scholar/elder show their activity poses with no emoji overhead.

https://claude.ai/code/session_01NrvfVAXqwHRtawwxQKgXmL

---
_Generated by [Claude Code](https://claude.ai/code/session_01NrvfVAXqwHRtawwxQKgXmL)_