### PR TITLE
Hub: town directory / "Where is…?" NPC locator

### DIFF
--- a/web/src/components/hub/HubMinimap.tsx
+++ b/web/src/components/hub/HubMinimap.tsx
@@ -12,7 +12,7 @@ const STORE_KEY = 'jarv_hub_minimap_on'
 export interface MinimapObjective {
   x:    number              // world pixel coords (centre of the target tile)
   y:    number
-  kind: 'pickup' | 'npc'
+  kind: 'pickup' | 'npc' | 'directory'
 }
 
 interface Props {
@@ -126,11 +126,20 @@ export function HubMinimap({ locationData, objectives, playerRef, viewportRef }:
         view.vw * scale, view.vh * scale,
       )
 
-      // Objective pins.
+      // Objective pins. Directory pins (user "show on map") are larger + cyan with
+      // a halo ring so they stand out from quest pins.
       for (const o of objectives) {
+        const directory = o.kind === 'directory'
+        if (directory) {
+          c.beginPath()
+          c.arc(toMmX(o.x), toMmY(o.y), 6, 0, Math.PI * 2)
+          c.strokeStyle = 'rgba(85,221,238,0.6)'
+          c.lineWidth   = 1.5
+          c.stroke()
+        }
         c.beginPath()
-        c.arc(toMmX(o.x), toMmY(o.y), 3, 0, Math.PI * 2)
-        c.fillStyle = o.kind === 'pickup' ? '#e0b050' : '#66cc66'
+        c.arc(toMmX(o.x), toMmY(o.y), directory ? 3.6 : 3, 0, Math.PI * 2)
+        c.fillStyle = directory ? '#55ddee' : o.kind === 'pickup' ? '#e0b050' : '#66cc66'
         c.fill()
         c.lineWidth   = 1
         c.strokeStyle = 'rgba(8,14,8,0.9)'

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -27,6 +27,8 @@ import { loadPlayerName } from '../../game/questline'
 import { LoginButton } from '../ui/LoginButton'
 import { addCollectible, addConsumable, getCollectibles } from '../../game/itemStore'
 import { QuestsModal } from './QuestsModal'
+import { TownDirectory } from './TownDirectory'
+import { resolveNpcPlace } from '../../game/hub/npcLocator'
 import { TreasureModal } from './TreasureModal'
 import { getCollectedTreasureIds, markTreasureCollected } from '../../game/hub/treasures'
 import { useHubClock } from '../../hooks/useHubClock'
@@ -119,6 +121,8 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onEndless, onWorldMap
   const [interiorActive, setInteriorActive] = useState(false)
   const [pickedUpIds,    setPickedUpIds]    = useState<Set<string>>(() => getPickedUpIds())
   const [questsOpen,          setQuestsOpen]          = useState(false)
+  const [directoryOpen,       setDirectoryOpen]       = useState(false)
+  const [pinnedNpcId,         setPinnedNpcId]         = useState<string | null>(null)
   const [openTreasure,        setOpenTreasure]        = useState<HubTreasure | null>(null)
   const [collectedTreasureIds] = useState<Set<string>>(() => getCollectedTreasureIds())
   // Refresh friendship/quest state after interactions (lightweight — just reads localStorage)
@@ -279,9 +283,21 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onEndless, onWorldMap
         pushNpc(incomplete.targetNpcId)
       }
     }
+    // Town Directory "show on map" pin — the chosen NPC's current location.
+    if (pinnedNpcId) {
+      const npc = locationData.HUB_NPCS.find(n => n.id === pinnedNpcId)
+      if (npc) {
+        const place = resolveNpcPlace(npc, gameHour, locationData)
+        out.push({ x: place.tx * T + T / 2, y: place.ty * T + T / 2, kind: 'directory' })
+      }
+    }
     return out
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [questDefs, pickedUpIds, _tick, locationData, locationQuests])
+  }, [questDefs, pickedUpIds, _tick, locationData, locationQuests, pinnedNpcId, gameHour])
+
+  const togglePinnedNpc = useCallback((npcId: string) => {
+    setPinnedNpcId(prev => (prev === npcId ? null : npcId))
+  }, [])
 
   const dismissSplash = useCallback(() => {
     _hubSplashShown = true
@@ -721,6 +737,7 @@ function tryOfferQuest(giverId: string, speakerName: string, onlyQuestId?: strin
           <ToolbarLabel className={`title-deck-info${wrongSave ? ' title-deck-info--glitch' : ''}`}>🃏 {wrongSave ? wrongSave.cards : collectionCount}/{catalogTotal}</ToolbarLabel>
           <ToolbarLabel className="title-deck-info">{isGameNight ? '🌙' : '☀️'} {formatGameTime()}</ToolbarLabel>
         <ToolbarButton icon="📜" title="Quests" onClick={() => setQuestsOpen(true)} />
+        <ToolbarButton icon="🧭" title="Where is…?" onClick={() => setDirectoryOpen(true)} />
         <ToolbarButton icon="🗺" title="World Map" onClick={() => onWorldMap?.()}  disabled={getQuestState('thorin-the-last-watch').status !== 'completed'} />
 
         <ToolbarSpacer/>
@@ -804,6 +821,7 @@ function tryOfferQuest(giverId: string, speakerName: string, onlyQuestId?: strin
         )}
 
         {questsOpen && <QuestsModal onClose={() => setQuestsOpen(false)} onAbandon={handleQuestAbandon} questDefs={questDefs}/>}
+        {directoryOpen && <TownDirectory onClose={() => setDirectoryOpen(false)} locationData={locationData} pinnedNpcId={pinnedNpcId} onTogglePin={togglePinnedNpc} />}
         {openTreasure && <TreasureModal treasure={openTreasure} onClose={() => setOpenTreasure(null)} />}
 
         <HubDialogue

--- a/web/src/components/hub/TownDirectory.stories.tsx
+++ b/web/src/components/hub/TownDirectory.stories.tsx
@@ -1,0 +1,37 @@
+import { fn } from 'storybook/test'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { TownDirectory } from './TownDirectory'
+import { RAVENWATCH } from '../../data/hub/hubWorldFactory'
+
+const meta = {
+  component: TownDirectory,
+  parameters: { layout: 'fullscreen' },
+  decorators: [
+    (Story) => (
+      <div className="game-container">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof TownDirectory>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    onClose:     fn(),
+    locationData: RAVENWATCH,
+    pinnedNpcId:  null,
+    onTogglePin:  fn(),
+  },
+}
+
+export const WithPinned: Story = {
+  args: {
+    onClose:     fn(),
+    locationData: RAVENWATCH,
+    pinnedNpcId:  RAVENWATCH.HUB_NPCS.find(n => n.name?.trim())?.id ?? null,
+    onTogglePin:  fn(),
+  },
+}

--- a/web/src/components/hub/TownDirectory.tsx
+++ b/web/src/components/hub/TownDirectory.tsx
@@ -1,0 +1,79 @@
+import React, { useState } from 'react'
+import { ModalBackdrop } from '../ui/ModalBackdrop'
+import type { HubLocationBundle } from '../../data/hub/loader'
+import { useHubClock } from '../../hooks/useHubClock'
+import { resolveNpcPlace } from '../../game/hub/npcLocator'
+import { getFriendshipLevel } from '../../game/hub/friendship'
+
+interface Props {
+  onClose:      () => void
+  locationData: HubLocationBundle
+  pinnedNpcId:  string | null
+  onTogglePin:  (npcId: string) => void
+}
+
+export function TownDirectory({ onClose, locationData, pinnedNpcId, onTogglePin }: Props) {
+  const { gameHour } = useHubClock()
+  const [onlyMet, setOnlyMet] = useState(false)
+
+  // Named NPCs only (skip ambient/unnamed). De-dupe by id for safety.
+  const seen = new Set<string>()
+  const named = locationData.HUB_NPCS.filter(n => {
+    if (!n.name?.trim() || seen.has(n.id)) return false
+    seen.add(n.id)
+    return true
+  })
+
+  const visible = (onlyMet ? named.filter(n => getFriendshipLevel(n.id) > 0) : named)
+    .slice()
+    .sort((a, b) => a.name.localeCompare(b.name))
+
+  return (
+    <ModalBackdrop onClose={onClose}>
+      <div className="town-directory">
+        <div className="town-directory__header">
+          <span>🧭 Where is…?</span>
+          <span className="town-directory__meta">
+            {visible.length} {visible.length === 1 ? 'person' : 'people'}
+            <button className="town-directory__close" onClick={onClose}>✕</button>
+          </span>
+        </div>
+
+        <button
+          className={`town-directory__filter${onlyMet ? ' town-directory__filter--on' : ''}`}
+          onClick={() => setOnlyMet(v => !v)}
+        >
+          {onlyMet ? '☑' : '☐'} Only people I've met
+        </button>
+
+        {visible.length === 0 ? (
+          <div className="town-directory__empty">
+            {onlyMet ? "You haven't met anyone yet — explore the town." : 'No one is around right now.'}
+          </div>
+        ) : (
+          <div className="town-directory__list">
+            {visible.map(npc => {
+              const place  = resolveNpcPlace(npc, gameHour, locationData)
+              const pinned = pinnedNpcId === npc.id
+              return (
+                <div key={npc.id} className="town-directory__row">
+                  <div className="town-directory__info">
+                    <span className="town-directory__name">{npc.name}</span>
+                    <span className="town-directory__place">📍 {place.name}</span>
+                  </div>
+                  <button
+                    className={`town-directory__pin-btn${pinned ? ' town-directory__pin-btn--on' : ''}`}
+                    onClick={() => onTogglePin(npc.id)}
+                    title={pinned ? 'Hide on minimap' : 'Show on minimap'}
+                  >
+                    {pinned ? '📌 Pinned' : '📍 Show on map'}
+                  </button>
+                </div>
+              )
+            })}
+          </div>
+        )}
+      </div>
+    </ModalBackdrop>
+  )
+}

--- a/web/src/game/hub/npcLocator.ts
+++ b/web/src/game/hub/npcLocator.ts
@@ -1,0 +1,44 @@
+import type { HubArea, HubLocationBundle, HubNpc } from '../../data/hub/loader'
+import { getNpcLocation } from './hubNpcSchedule'
+
+const T = 32
+
+export interface NpcPlace {
+  /** Human-readable current location (area or building name). */
+  name: string
+  /** Current tile position. */
+  tx: number
+  ty: number
+  /** Set when the NPC is currently inside a building interior. */
+  interiorId?: string
+}
+
+/** Name of the area whose rect contains the centre of tile (tx, ty), or null. */
+export function areaNameForTile(tx: number, ty: number, areas: HubArea[]): string | null {
+  const px = tx * T + T / 2
+  const py = ty * T + T / 2
+  const area = areas.find(a => px >= a.x && px < a.x + a.w && py >= a.y && py < a.y + a.h)
+  return area?.name ?? null
+}
+
+/**
+ * Resolve where an NPC is *right now* (for the given game hour), returning both a
+ * display name and tile coordinates. Falls back to the NPC's base position/building
+ * when no schedule entry applies.
+ */
+export function resolveNpcPlace(npc: HubNpc, gameHour: number, loc: HubLocationBundle): NpcPlace {
+  const sched = getNpcLocation(npc, gameHour)
+
+  if (sched?.type === 'interior') {
+    return { name: loc.HUB_INTERIORS[sched.buildingId]?.name ?? 'a building', tx: sched.tx, ty: sched.ty, interiorId: sched.buildingId }
+  }
+  if (sched?.type === 'exterior') {
+    return { name: areaNameForTile(sched.tx, sched.ty, loc.HUB_AREAS) ?? loc.HUB_TOWN_NAME, tx: sched.tx, ty: sched.ty }
+  }
+
+  // No schedule entry for this hour — use the NPC's base placement.
+  if (npc.building) {
+    return { name: loc.HUB_INTERIORS[npc.building]?.name ?? 'a building', tx: npc.tx, ty: npc.ty, interiorId: npc.building }
+  }
+  return { name: areaNameForTile(npc.tx, npc.ty, loc.HUB_AREAS) ?? loc.HUB_TOWN_NAME, tx: npc.tx, ty: npc.ty }
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -15153,6 +15153,94 @@ html.light-mode .action-btn {
 .quests-modal__confirm-btns button:first-child { border-color: #cc5544; color: #cc5544; }
 .quests-modal__confirm-btns button:hover { opacity: 0.8; }
 
+/* ── Town Directory ("Where is…?") ─────────────────────────────────────────── */
+.town-directory {
+  background: rgba(8, 14, 8, 0.97);
+  border: 1px solid #446644;
+  color: #c8e8c8;
+  padding: 20px;
+  width: min(420px, 92vw);
+  max-height: 80vh;
+  overflow-y: auto;
+  border-radius: 4px;
+  font-family: monospace;
+}
+.town-directory__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+  font-size: 14px;
+  letter-spacing: 0.1em;
+  color: #88cc88;
+  text-transform: uppercase;
+}
+.town-directory__meta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 10px;
+  color: #557755;
+}
+.town-directory__close {
+  background: none;
+  border: none;
+  color: #557755;
+  cursor: pointer;
+  font-size: 12px;
+  padding: 0 2px;
+  line-height: 1;
+}
+.town-directory__close:hover { color: #88cc88; }
+.town-directory__filter {
+  background: none;
+  border: 1px solid #2a4a2a;
+  color: #557755;
+  font-family: monospace;
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  padding: 4px 10px;
+  margin-bottom: 12px;
+  cursor: pointer;
+  border-radius: 2px;
+}
+.town-directory__filter--on { border-color: #668844; color: #88cc88; }
+.town-directory__filter:hover { color: #88cc88; }
+.town-directory__empty {
+  font-size: 11px;
+  color: #557755;
+  text-align: center;
+  padding: 20px 0;
+}
+.town-directory__list { display: flex; flex-direction: column; gap: 6px; }
+.town-directory__row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+  border: 1px solid #2a4a2a;
+  padding: 8px 12px;
+  border-radius: 2px;
+}
+.town-directory__info { display: flex; flex-direction: column; gap: 3px; min-width: 0; }
+.town-directory__name { font-size: 12px; font-weight: bold; color: #c8e8c8; }
+.town-directory__place { font-size: 10px; color: #88aa88; }
+.town-directory__pin-btn {
+  flex-shrink: 0;
+  background: none;
+  border: 1px solid #446644;
+  color: #88cc88;
+  font-family: monospace;
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  padding: 4px 8px;
+  cursor: pointer;
+  border-radius: 2px;
+  white-space: nowrap;
+}
+.town-directory__pin-btn--on { border-color: #55ddee; color: #55ddee; }
+.town-directory__pin-btn:hover { opacity: 0.85; }
+
 /* ── Treasure Modal ────────────────────────────────────────────────────────── */
 .treasure-modal {
   background: rgba(8, 14, 8, 0.97);


### PR DESCRIPTION
## Why
NPCs move on schedules (`hubNpcSchedule.ts`), so a quest-giver may not be where the player expects. This adds a directory panel to make finding them painless. Implements #1609, including both optional extras (show-on-minimap pin + only-met filter).

## What's in this PR

### `npcLocator.ts` (new)
Single source of truth for "where is this NPC right now":
- `resolveNpcPlace(npc, gameHour, loc)` → current display name + tile coords, using `getNpcLocation` (schedule) and falling back to the NPC's base position/building when no schedule entry applies.
- `areaNameForTile(tx, ty, areas)` resolves a tile to its containing area name (tile-centre inside the area rect).

### `TownDirectory.tsx` (+ story)
- Opened from the hub toolbar via a new 🧭 **"Where is…?"** button.
- Lists named NPCs (`HUB_NPCS` with a real name) and their **current** area/building.
- Calls `useHubClock()`, so locations **update with game time** (refreshes ~every 10s).
- **"Only people I've met"** filter — gates to `getFriendshipLevel(id) > 0`.
- **"Show on map"** per NPC — pins their current location on the minimap; toggles off when clicked again.
- Mirrors `QuestsModal` / `ModalBackdrop` structure and the dark-green `.quests-modal` styling (new `.town-directory` BEM block).

### `HubMinimap.tsx`
- Adds a `'directory'` pin kind, drawn as a distinct **cyan marker with a halo ring** so it stands out from quest pins. The existing off-screen edge arrow automatically points to it.

### `HubWorld.tsx`
- New `directoryOpen` / `pinnedNpcId` state + toolbar button + panel mount.
- Appends the pinned NPC's current location to the `minimapObjectives` memo (keyed on `gameHour` + `pinnedNpcId`), so the pin tracks the NPC as time advances.

## Acceptance criteria
- [x] Directory shows each named NPC and the area/building they're currently in, updating with game time
- [x] Storybook story added
- [x] `npm run build` passes

## Testing
- `cd web && npm run build` passes (tsc covers the new component, story, and util).

Closes #1609

https://claude.ai/code/session_014q6YieiapPX2CH8GpTGV6h

---
_Generated by [Claude Code](https://claude.ai/code/session_014q6YieiapPX2CH8GpTGV6h)_