### PR TITLE
Fix: Town Directory pin/arrow for NPCs inside buildings

### DIFF
--- a/web/src/game/hub/npcLocator.test.ts
+++ b/web/src/game/hub/npcLocator.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest'
+import { resolveNpcPlace, buildingWorldTile, areaNameForTile } from './npcLocator'
+import type { HubLocationBundle, HubNpc } from '../../data/hub/loader'
+
+// Minimal bundle with only the fields the locator reads.
+const loc = {
+  HUB_TOWN_NAME: 'Testville',
+  HUB_AREAS: [{ id: 'sq', name: 'Town Square', x: 0, y: 0, w: 32 * 10, h: 32 * 10 }],
+  HUB_DOORS: [{ buildingId: 'inn', tx: 10, ty: 12 }],
+  HUB_BUILDINGS: [
+    { rect: [8, 8, 12, 12], id: 'inn' },
+    { rect: [20, 20, 24, 24], id: 'smithy' }, // no door → footprint centre
+  ],
+  HUB_INTERIORS: {
+    inn:    { id: 'inn',    name: 'The Sleepy Inn', width: 6, height: 6, decor: [] },
+    smithy: { id: 'smithy', name: "Smith's Forge",  width: 6, height: 6, decor: [] },
+  },
+} as unknown as HubLocationBundle
+
+const base: HubNpc = { id: 'x', name: 'X', sprite: 's', tx: 3, ty: 3, dialogue: [] }
+
+describe('buildingWorldTile', () => {
+  it('uses the door entrance when available', () => {
+    expect(buildingWorldTile('inn', loc)).toEqual({ tx: 10, ty: 12 })
+  })
+  it('falls back to the footprint centre when there is no door', () => {
+    expect(buildingWorldTile('smithy', loc)).toEqual({ tx: 22, ty: 22 })
+  })
+  it('returns null for an unknown building', () => {
+    expect(buildingWorldTile('nope', loc)).toBeNull()
+  })
+})
+
+describe('areaNameForTile', () => {
+  it('names the area containing the tile centre', () => {
+    expect(areaNameForTile(3, 3, loc.HUB_AREAS)).toBe('Town Square')
+  })
+  it('returns null outside any area', () => {
+    expect(areaNameForTile(50, 50, loc.HUB_AREAS)).toBeNull()
+  })
+})
+
+describe('resolveNpcPlace', () => {
+  it('maps a scheduled interior NPC to the building world door, not interior-local coords', () => {
+    const npc: HubNpc = { ...base, schedule: [{ startHour: 6, endHour: 20, location: { type: 'interior', buildingId: 'inn', tx: 1, ty: 1 } }] }
+    expect(resolveNpcPlace(npc, 12, loc)).toEqual({ name: 'The Sleepy Inn', tx: 10, ty: 12, interiorId: 'inn' })
+  })
+
+  it('maps a building NPC with no schedule to the building world position', () => {
+    const npc: HubNpc = { ...base, building: 'smithy', tx: 1, ty: 1 }
+    expect(resolveNpcPlace(npc, 9, loc)).toEqual({ name: "Smith's Forge", tx: 22, ty: 22, interiorId: 'smithy' })
+  })
+
+  it('resolves a scheduled exterior NPC to its area and tile', () => {
+    const npc: HubNpc = { ...base, schedule: [{ startHour: 6, endHour: 20, location: { type: 'exterior', tx: 3, ty: 3 } }] }
+    expect(resolveNpcPlace(npc, 12, loc)).toEqual({ name: 'Town Square', tx: 3, ty: 3 })
+  })
+
+  it('uses the town name when an exterior tile is in no named area', () => {
+    const npc: HubNpc = { ...base, tx: 50, ty: 50 }
+    expect(resolveNpcPlace(npc, 12, loc)).toEqual({ name: 'Testville', tx: 50, ty: 50 })
+  })
+})

--- a/web/src/game/hub/npcLocator.ts
+++ b/web/src/game/hub/npcLocator.ts
@@ -22,6 +22,23 @@ export function areaNameForTile(tx: number, ty: number, areas: HubArea[]): strin
 }
 
 /**
+ * World-map tile to point at for a building interior. Interior schedule/base
+ * coordinates are local to the interior grid, not the town map, so for map pins we
+ * use the building's exterior position: its door (entrance) if known, otherwise the
+ * footprint centre. Returns null if the building can't be located on the map.
+ */
+export function buildingWorldTile(buildingId: string, loc: HubLocationBundle): { tx: number; ty: number } | null {
+  const door = loc.HUB_DOORS.find(d => d.buildingId === buildingId)
+  if (door) return { tx: door.tx, ty: door.ty }
+  const building = loc.HUB_BUILDINGS.find(b => b.id === buildingId)
+  if (building) {
+    const [tx1, ty1, tx2, ty2] = building.rect
+    return { tx: Math.round((tx1 + tx2) / 2), ty: Math.round((ty1 + ty2) / 2) }
+  }
+  return null
+}
+
+/**
  * Resolve where an NPC is *right now* (for the given game hour), returning both a
  * display name and tile coordinates. Falls back to the NPC's base position/building
  * when no schedule entry applies.
@@ -29,16 +46,24 @@ export function areaNameForTile(tx: number, ty: number, areas: HubArea[]): strin
 export function resolveNpcPlace(npc: HubNpc, gameHour: number, loc: HubLocationBundle): NpcPlace {
   const sched = getNpcLocation(npc, gameHour)
 
-  if (sched?.type === 'interior') {
-    return { name: loc.HUB_INTERIORS[sched.buildingId]?.name ?? 'a building', tx: sched.tx, ty: sched.ty, interiorId: sched.buildingId }
+  const interior = (buildingId: string, localTx: number, localTy: number): NpcPlace => {
+    // Map to the building's exterior position; fall back to local coords only if the
+    // building isn't placed on the map (shouldn't normally happen).
+    const world = buildingWorldTile(buildingId, loc)
+    return {
+      name: loc.HUB_INTERIORS[buildingId]?.name ?? 'a building',
+      tx: world?.tx ?? localTx,
+      ty: world?.ty ?? localTy,
+      interiorId: buildingId,
+    }
   }
+
+  if (sched?.type === 'interior') return interior(sched.buildingId, sched.tx, sched.ty)
   if (sched?.type === 'exterior') {
     return { name: areaNameForTile(sched.tx, sched.ty, loc.HUB_AREAS) ?? loc.HUB_TOWN_NAME, tx: sched.tx, ty: sched.ty }
   }
 
   // No schedule entry for this hour — use the NPC's base placement.
-  if (npc.building) {
-    return { name: loc.HUB_INTERIORS[npc.building]?.name ?? 'a building', tx: npc.tx, ty: npc.ty, interiorId: npc.building }
-  }
+  if (npc.building) return interior(npc.building, npc.tx, npc.ty)
   return { name: areaNameForTile(npc.tx, npc.ty, loc.HUB_AREAS) ?? loc.HUB_TOWN_NAME, tx: npc.tx, ty: npc.ty }
 }


### PR DESCRIPTION
## Problem
In the Town Directory ("Where is…?"), when an NPC is inside a building the **minimap pin and edge arrow point to the wrong place** (near the map origin) instead of the building.

## Root cause
`getNpcLocation` returns **interior-local** `tx/ty` for an NPC in a building — coordinates within that building's interior grid, not the town map. The directory pin was placing those local coordinates directly on the world map. (The same applied to a building-dwelling NPC's base `tx/ty` when it has no schedule.)

## Fix
`resolveNpcPlace` now maps interior NPCs to the **building's exterior position** via a new `buildingWorldTile(buildingId, loc)` helper:
- prefer the building's **door** (entrance) from `HUB_DOORS` — the natural "go here" target;
- otherwise the **footprint centre** from `HUB_BUILDINGS`;
- fall back to the local coords only if the building isn't placed on the map (shouldn't normally happen).

The display name (the interior name) is unchanged. Now the pin sits on the building and the off-screen arrow points toward it.

## Tests
Adds `npcLocator.test.ts` (9 cases): door-vs-footprint resolution, unknown building, area naming, and `resolveNpcPlace` for scheduled-interior, no-schedule-building, exterior, and unnamed-area NPCs.
- `npx vitest run src/game/hub/npcLocator.test.ts` → 9 passed
- `cd web && npm run build` passes

Follow-up to #1689.

https://claude.ai/code/session_014q6YieiapPX2CH8GpTGV6h

---
_Generated by [Claude Code](https://claude.ai/code/session_014q6YieiapPX2CH8GpTGV6h)_