### PR TITLE
Hub: branching NPC dialogue trees (#1611)

### DIFF
--- a/docs/hubworld.md
+++ b/docs/hubworld.md
@@ -11,12 +11,13 @@
 | File | Owns | TypeScript exports |
 |---|---|---|
 | `web/src/data/hub/config.json` | Map geometry, buildings, doors, NPCs, exterior decor, interiors, windows, interactables | parsed by `loader.ts` |
-| `web/src/data/hub/questDefs.json` | Quests, pickup items, blocked paths, inn rumours, friendship dialogue | parsed by `loader.ts` and `questDefs.ts` |
+| `web/src/data/hub/questDefs.json` | Quests, pickup items, blocked paths, inn rumours, friendship dialogue, dialogue trees | parsed by `loader.ts` and `questDefs.ts` |
 | `web/src/data/hub/loader.ts` | Parses both JSON files; exports all map/NPC/item/path data | `MAP_W`, `MAP_H`, `AVATAR_START`, `HUB_AREAS`, `HUB_STREET_TILES`, `HUB_BUILDINGS`, `HUB_DOORS`, `HUB_INTERIORS`, `EXTERIOR_DECOR`, `HUB_NPCS`, `EXTERIOR_NPCS`, `INTERIOR_NPCS`, `HUB_PICKUP_ITEMS`, `HUB_BLOCKED_PATHS`, `HUB_LOCKED_DOORS`, … |
 | `web/src/data/hub/questDefs.ts` | Parses `questDefs.json`; exports quest definitions and dialogue | `HUB_QUEST_DEFS`, `INN_RUMOURS`, `FRIENDSHIP_DIALOGUE` |
 | `web/src/game/hub/quests.ts` | Quest progress/status persistence (localStorage) | `getQuestState`, `setQuestStatus`, `incrementQuestProgress`, `getQuestProgress`, `resetQuest` |
 | `web/src/game/hub/pickups.ts` | Pickup state persistence (localStorage) | `getPickedUpIds`, `markPickedUp`, `isPickedUp`, `unmarkPickedUp` |
 | `web/src/game/hub/friendship.ts` | NPC friendship XP/level persistence (localStorage) | `getFriendshipLevel`, `addFriendshipXp`, `getFriendshipData` |
+| `web/src/game/hub/dialogueFlags.ts` | Branching-dialogue flag + "seen" branch persistence (localStorage) — see §7b | `setDialogueFlag`, `hasDialogueFlag`, `getDialogueFlags`, `markNodeSeen`, `hasNodeSeen` |
 | `web/src/game/hub/innConvos.ts` | Inn conversation tracking (localStorage) | `getHeardConvoIds`, `markConvoHeard`, `isConvoHeard` |
 | `web/src/game/hub/interactables.ts` | Interactable grant + moved-position persistence (localStorage) | `interactableStoreKey`, `isInteractableGranted`, `markInteractableGranted`, `getInteractableMoves`, `setInteractableMove` |
 | `web/src/game/hub/animals.ts` | Pure animal logic — `ANIMAL_SPECS` registry (per-type data), spawn maths, tint resolution | `ANIMAL_SPECS`, `computeProceduralCounts`, `resolveVariantTint`, `ANIMAL_CAPS`, `TINT_PALETTES` |
@@ -308,6 +309,101 @@ localStorage keys, entries keyed `<townName>:<interactableId>`:
 4. For `quest` reactions, set the quest's `giverNpcId` to the interactable id.
 5. Run `npm run test` (loader tests parse all configs) and `npm run build`.
 6. Verify in-game: tap fires the reactions, tap does not also walk the avatar, indicator shows/clears, moves persist after reload.
+
+---
+
+## §7b — Branching Dialogue Trees
+
+Reusable multi-choice NPC conversations that branch to different endings.
+Authored in `questDefs.json` under a top-level `dialogues` array and attached to
+an NPC via `dialogueTree` (the id of the tree). When such an NPC is tapped and has
+no higher-priority interaction (quest offer/completion, screen, friendship-tier
+line), `HubWorld.tsx` walks the tree instead of the linear `dialogue` cycle.
+
+Types live in `web/src/data/hub/questDefs.ts`; the walker (`runDialogueNode` /
+`applyChoice`) lives in `web/src/components/hub/HubWorld.tsx`. Reuses the existing
+`HubDialogue` UI (renders `choices`), `tryOfferQuest`, and `addFriendshipXp`.
+
+### Full schema
+
+```jsonc
+// questDefs.json (top level, alongside "quests")
+"dialogues": [
+  {
+    "id": "scholar-chat",          // referenced by HubNpc.dialogueTree
+    "npcId": "scholar",            // documentation only
+    "start": "greet",              // id of the first node in `nodes`
+    "nodes": {
+      "greet": {
+        "text": "What's on your mind?",
+        "choices": [
+          { "label": "Tell me about the Fracture.", "next": "lore" },
+          { "label": "Help nearby?",  "next": "errand" },
+          { "label": "Just saying hi.",
+            "effects": [{ "type": "friendship", "npcId": "scholar", "xp": 5 },
+                        { "type": "flag", "flag": "scholar-greeted" }],
+            "next": "hello" }
+        ]
+      },
+      "lore":   { "text": "…", "choices": [ { "label": "Thanks.", "effects": [{ "type": "end" }] } ] },
+      "errand": { "text": "…", "choices": [ { "label": "I'll help.", "effects": [{ "type": "quest", "questId": "feed-the-stray" }] } ] },
+      "hello":  { "text": "…", "choices": [
+                    { "label": "A question…", "requireFlag": "scholar-greeted", "next": "greet" },
+                    { "label": "Farewell.",   "effects": [{ "type": "end" }] } ] }
+    }
+  }
+]
+```
+
+Then on the NPC (in `config.json`): `"dialogueTree": "scholar-chat"` (keep a
+`dialogue` array as a fallback line).
+
+### Field reference
+
+#### `DialogueNode`
+| Field | Type | Notes |
+|---|---|---|
+| `text` | string | The line shown. |
+| `speakerName` | string? | Overrides the NPC name for this node. |
+| `choices` | `DialogueChoiceDef[]`? | Absent/empty → a single **OK** button closes. |
+
+#### `DialogueChoiceDef`
+| Field | Type | Notes |
+|---|---|---|
+| `label` | string | Button text. |
+| `next` | string? | Node id to advance to **after** effects run. |
+| `effects` | `DialogueEffect[]`? | Run in order before navigation. |
+| `requireFlag` | string? | Choice only shown if the flag is set. |
+| `hideIfFlag` | string? | Choice hidden once the flag is set. |
+
+#### `DialogueEffect` types
+| `type` | Fields | Behaviour |
+|---|---|---|
+| `flag` | `flag` | Persist a named dialogue flag. |
+| `friendship` | `npcId?`, `xp` | Grant friendship XP (defaults to the speaking NPC). |
+| `quest` | `questId` | Offer that quest (Accept / Not now). Resolves the quest's real `giverNpcId`. **Terminates** the walk. |
+| `end` | — | End the conversation. |
+
+If a choice has neither a terminating effect (`quest`/`end`) nor `next`, the
+conversation closes.
+
+### Persistence
+
+`web/src/game/hub/dialogueFlags.ts` (localStorage key `jarv_hub_dialogue_flags`):
+
+| Export | Purpose |
+|---|---|
+| `setDialogueFlag` / `hasDialogueFlag` / `getDialogueFlags` | Named flags set by `flag` effects and read by `requireFlag` / `hideIfFlag`. |
+| `markNodeSeen` / `hasNodeSeen` | "Seen" branch tracking — every visited node is recorded as `seen:<treeId>:<nodeId>`, usable as a flag. |
+
+### Authoring checklist
+
+1. Add a tree to the location's `questDefs.json` `dialogues` array with a unique `id` and a `start` node.
+2. Give each branch a clear ending (`end`, a `quest` offer, or a node with an OK button).
+3. For a `quest` effect, ensure the `questId` exists (its real giver is resolved automatically).
+4. Attach `"dialogueTree": "<id>"` to the NPC in `config.json`; keep a `dialogue` fallback line.
+5. Run `npm run test` (loader tests parse all configs) and `npm run build`.
+6. Verify in-game: tapping the NPC branches to different endings, friendship XP / quest offers fire, and flag-gated choices reflect persisted state after reload.
 
 ---
 

--- a/web/src/components/hub/HubDialogue.stories.tsx
+++ b/web/src/components/hub/HubDialogue.stories.tsx
@@ -27,3 +27,51 @@ export const Closed: Story = {
     onClose: fn(),
   },
 }
+
+// A self-contained branching conversation: root node offers three choices that
+// lead to two different endings, demonstrating the choice-branch rendering.
+const BRANCH_TREE: Record<string, { text: string; choices: { label: string; next?: string }[] }> = {
+  root: {
+    text: 'You again, wanderer. The watch could use sharp eyes tonight — or perhaps you only came to talk?',
+    choices: [
+      { label: 'I can stand watch with you', next: 'accept' },
+      { label: "Tell me about Ravenwatch", next: 'lore' },
+      { label: 'Just passing through', next: 'leave' },
+    ],
+  },
+  accept: {
+    text: 'Good. Keep to the wall and call out anything that moves. We hold the line together.',
+    choices: [{ label: 'Understood', next: undefined }],
+  },
+  lore: {
+    text: 'These walls have weathered three sieges. The ravens stayed through every one — that is how we earned the name.',
+    choices: [
+      { label: "That's reassuring", next: 'leave' },
+      { label: 'Back', next: 'root' },
+    ],
+  },
+  leave: {
+    text: 'Safe roads, then. The gate closes at dusk.',
+    choices: [{ label: 'Farewell', next: undefined }],
+  },
+}
+
+export const Branching: Story = {
+  args: { line: BRANCH_TREE.root.text, onClose: fn() },
+  render: () => {
+    const [nodeId, setNodeId] = useState<string | null>('root')
+    const node = nodeId ? BRANCH_TREE[nodeId] : null
+    return (
+      <HubDialogue
+        line={node?.text ?? null}
+        speakerName="Watch Captain Vane"
+        onClose={() => setNodeId(null)}
+        choices={node?.choices.map((c, i) => ({
+          label:   c.label,
+          primary: i === 0,
+          onClick: () => setNodeId(c.next ?? null),
+        }))}
+      />
+    )
+  },
+}

--- a/web/src/components/hub/HubDialogue.tsx
+++ b/web/src/components/hub/HubDialogue.tsx
@@ -54,7 +54,15 @@ export function HubDialogue({ line, onClose, speakerName, choices }: Props) {
         }}>
           {line ?? ''}
         </div>
-        <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end', marginTop: 6 }}>
+        <div
+          style={
+            // Single action stays inline/right-aligned; multiple branch options
+            // stack vertically full-width so 3–4 choices read clearly.
+            choices && choices.length > 1
+              ? { display: 'flex', flexDirection: 'column', gap: 6, marginTop: 6 }
+              : { display: 'flex', gap: 8, justifyContent: 'flex-end', marginTop: 6 }
+          }
+        >
           {choices && choices.length > 0
             ? choices.map(c => (
                 <button
@@ -68,6 +76,8 @@ export function HubDialogue({ line, onClose, speakerName, choices }: Props) {
                     padding:       '4px 12px',
                     cursor:        'pointer',
                     letterSpacing: '0.12em',
+                    textAlign:     choices.length > 1 ? 'left' : 'center',
+                    width:         choices.length > 1 ? '100%' : 'auto',
                   }}
                 >
                   {c.label}

--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -876,7 +876,7 @@ export function HubTownCanvas({
       npcContainer.cursor    = 'pointer'
       npcContainer.on('pointerdown', (e: PIXI.FederatedPointerEvent) => {
         e.stopPropagation()
-        if (npc.dialogue.length > 0 || npc.screen || npc.questGive || npc.questReceive) {
+        if (npc.dialogue.length > 0 || npc.screen || npc.questGive || npc.questReceive || npc.dialogueTree) {
           const idx = npcDialogueIndex.get(npc.id) ?? 0
           onNpcTapRef.current?.(npc.dialogue[idx % npc.dialogue.length] ?? '', npc.id)
           npcDialogueIndex.set(npc.id, idx + 1)
@@ -1609,7 +1609,7 @@ export function HubTownCanvas({
           s.cursor    = 'pointer'
           s.on('pointerdown', (e: PIXI.FederatedPointerEvent) => {
             e.stopPropagation()
-            if (npc.dialogue.length > 0 || npc.screen || npc.questGive || npc.questReceive) {
+            if (npc.dialogue.length > 0 || npc.screen || npc.questGive || npc.questReceive || npc.dialogueTree) {
               const idx = npcDialogueIndex.get(npc.id) ?? 0
               onNpcTapRef.current?.(npc.dialogue[idx % npc.dialogue.length] ?? '', npc.id)
               npcDialogueIndex.set(npc.id, idx + 1)
@@ -1637,7 +1637,7 @@ export function HubTownCanvas({
           s.cursor    = 'pointer'
           s.on('pointerdown', (e: PIXI.FederatedPointerEvent) => {
             e.stopPropagation()
-            if (npc.dialogue.length > 0 || npc.questGive || npc.questReceive) {
+            if (npc.dialogue.length > 0 || npc.questGive || npc.questReceive || npc.dialogueTree) {
               const idx = npcDialogueIndex.get(npc.id) ?? 0
               onNpcTapRef.current?.(npc.dialogue[idx % npc.dialogue.length] ?? '', npc.id)
               npcDialogueIndex.set(npc.id, idx + 1)

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -7,9 +7,10 @@ import type { MinimapObjective } from './HubMinimap'
 import { HubReturnButton } from './HubReturnButton'
 import { HubDialogue } from './HubDialogue'
 import type { DialogueChoice } from './HubDialogue'
-import type { HubQuestDef } from '../../data/hub/questDefs'
+import type { HubQuestDef, DialogueTree, DialogueChoiceDef } from '../../data/hub/questDefs'
 import { getPickedUpIds, markPickedUp, unmarkPickedUp } from '../../game/hub/pickups'
 import { getFriendshipLevel, addFriendshipXp, getFriendshipData } from '../../game/hub/friendship'
+import { setDialogueFlag, hasDialogueFlag, markNodeSeen } from '../../game/hub/dialogueFlags'
 import { getQuestState, setQuestStatus, incrementQuestProgress, getQuestProgress, resetQuest } from '../../game/hub/quests'
 import { getHeardConvoIds, markConvoHeard } from '../../game/hub/innConvos'
 import { loadDeck, loadCollection, loadCrystals, saveCrystals, addCardsToCollection } from '../../game/collection'
@@ -546,6 +547,54 @@ function tryOfferQuest(giverId: string, speakerName: string, onlyQuestId?: strin
   return false
 }
 
+  // ── Branching dialogue-tree walker ──────────────────────────────────────────
+  // Renders a node (text + visible choices) into the shared dialogue UI, then
+  // applies a choice's effects and advances to the next node (or ends).
+  function runDialogueNode(tree: DialogueTree, nodeId: string, npcId: string, speakerName: string): void {
+    const node = tree.nodes[nodeId]
+    if (!node) { setDialogueEvent(null); return }
+    markNodeSeen(tree.id, nodeId)
+    const visible = (node.choices ?? []).filter(c =>
+      (!c.requireFlag || hasDialogueFlag(c.requireFlag)) &&
+      (!c.hideIfFlag  || !hasDialogueFlag(c.hideIfFlag))
+    )
+    const choices: DialogueChoice[] = visible.map((c, i) => ({
+      label:   c.label,
+      primary: i === 0,
+      onClick: () => applyChoice(tree, c, npcId, speakerName),
+    }))
+    setDialogueEvent({
+      speakerName: node.speakerName ?? speakerName,
+      text:        node.text,
+      ...(choices.length > 0 ? { choices } : {}),
+    })
+  }
+
+  function applyChoice(tree: DialogueTree, choice: DialogueChoiceDef, npcId: string, speakerName: string): void {
+    let ended = false
+    for (const eff of choice.effects ?? []) {
+      switch (eff.type) {
+        case 'flag':
+          setDialogueFlag(eff.flag)
+          break
+        case 'friendship':
+          addFriendshipXp(eff.npcId ?? npcId, eff.xp)
+          refreshState()
+          break
+        case 'quest':
+          // tryOfferQuest replaces the dialogue with an Accept / Not now offer.
+          // If nothing can be offered (cap reached / unavailable), just close.
+          if (!tryOfferQuest(npcId, speakerName, eff.questId)) setDialogueEvent(null)
+          return
+        case 'end':
+          ended = true
+          break
+      }
+    }
+    if (!ended && choice.next) runDialogueNode(tree, choice.next, npcId, speakerName)
+    else setDialogueEvent(null)
+  }
+
 
   const handleNpcTap = useCallback((line: string, npcId: string) => {
     // Placed animals (HUB_ANIMALS) reuse all NPC quest logic — they share the
@@ -554,6 +603,7 @@ function tryOfferQuest(giverId: string, speakerName: string, onlyQuestId?: strin
       name?: string; dialogue?: string[]; screen?: string
       questGive?: string; questReceive?: string | string[]
       innRumours?: Array<{ id: string; text: string }>
+      dialogueTree?: string
     } | undefined =
       locationData.HUB_NPCS.find(n => n.id === npcId) ??
       locationData.HUB_ANIMALS.find(a => a.id === npcId)
@@ -649,6 +699,16 @@ function tryOfferQuest(giverId: string, speakerName: string, onlyQuestId?: strin
         .sort((a, b) => b.minLevel - a.minLevel)
       if (tiers.length > 0) {
         setDialogueEvent({ speakerName, text: tiers[0].text })
+        return
+      }
+    }
+
+    // ── Branching dialogue tree (ordinary chat) ─────────────────────────────
+    const treeId = npcDef?.dialogueTree
+    if (treeId) {
+      const tree = ALL_QUESTS.HUB_DIALOGUES[treeId]
+      if (tree) {
+        runDialogueNode(tree, tree.start, npcId, speakerName)
         return
       }
     }

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -581,11 +581,15 @@ function tryOfferQuest(giverId: string, speakerName: string, onlyQuestId?: strin
           addFriendshipXp(eff.npcId ?? npcId, eff.xp)
           refreshState()
           break
-        case 'quest':
+        case 'quest': {
           // tryOfferQuest replaces the dialogue with an Accept / Not now offer.
-          // If nothing can be offered (cap reached / unavailable), just close.
-          if (!tryOfferQuest(npcId, speakerName, eff.questId)) setDialogueEvent(null)
+          // Resolve the quest's real giver so a tree can surface a quest that
+          // belongs to another NPC. If nothing can be offered (cap reached /
+          // unavailable / prerequisite unmet), just close.
+          const giver = questDefs.find(q => q.id === eff.questId)?.giverNpcId ?? npcId
+          if (!tryOfferQuest(giver, speakerName, eff.questId)) setDialogueEvent(null)
           return
+        }
         case 'end':
           ended = true
           break

--- a/web/src/data/hub/hubWorldFactory.ts
+++ b/web/src/data/hub/hubWorldFactory.ts
@@ -133,6 +133,7 @@ export const ALL_QUESTS : HubQuestBundle = {
   FRIENDSHIP_DIALOGUE: Object.assign({}, ...ALL_QUEST_BUNDLES.map(b => b.FRIENDSHIP_DIALOGUE)),
   HUB_PICKUP_ITEMS:  ALL_QUEST_BUNDLES.flatMap(b => b.HUB_PICKUP_ITEMS),
   HUB_BLOCKED_PATHS: ALL_QUEST_BUNDLES.flatMap(b => b.HUB_BLOCKED_PATHS),
+  HUB_DIALOGUES:     Object.assign({}, ...ALL_QUEST_BUNDLES.map(b => b.HUB_DIALOGUES)),
 }
 
 export const ALL_QUEST_DEFS = [

--- a/web/src/data/hub/loader.test.ts
+++ b/web/src/data/hub/loader.test.ts
@@ -115,8 +115,8 @@ describe('npc schedule activities', () => {
   })
 })
 
-function minimalQuestConfig(extra: Partial<RawQuestConfig>): RawQuestConfig {
-  return { quests: [], ...extra } as RawQuestConfig
+function minimalQuestConfig(extra: Record<string, unknown>): RawQuestConfig {
+  return { quests: [], ...extra } as unknown as RawQuestConfig
 }
 
 describe('dialogue trees parsing', () => {

--- a/web/src/data/hub/loader.test.ts
+++ b/web/src/data/hub/loader.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
-import { createHubLocationData } from './loader'
+import { createHubLocationData, createHubQuestData } from './loader'
 import { RawConfig } from './config'
+import { RawQuestConfig } from './questDefs'
 import { BASE_CHIP_TILES } from '../tiles/baseChipIndex'
 import ravenwatchConfig from './ravenwatch/config.json'
 
@@ -111,6 +112,43 @@ describe('npc schedule activities', () => {
     expect(acts('fisherman')).toContain('fish')
     expect(acts('merchant')).toContain('work')
     expect(acts('elder')).toContain('idle-chat')
+  })
+})
+
+function minimalQuestConfig(extra: Partial<RawQuestConfig>): RawQuestConfig {
+  return { quests: [], ...extra } as RawQuestConfig
+}
+
+describe('dialogue trees parsing', () => {
+  it('returns {} when the dialogues key is absent', () => {
+    const bundle = createHubQuestData(minimalQuestConfig({}))
+    expect(bundle.HUB_DIALOGUES).toEqual({})
+  })
+
+  it('parses dialogue trees into a map keyed by id, preserving start + nodes', () => {
+    const bundle = createHubQuestData(minimalQuestConfig({
+      dialogues: [{
+        id: 'elder-chat',
+        npcId: 'elder',
+        start: 'root',
+        nodes: {
+          root: {
+            text: 'What brings you here?',
+            choices: [
+              { label: 'Lore', next: 'lore', effects: [{ type: 'friendship', xp: 5 }] },
+              { label: 'Leave', effects: [{ type: 'end' }] },
+            ],
+          },
+          lore: { text: 'A long story...', choices: [{ label: 'Bye', effects: [{ type: 'end' }] }] },
+        },
+      }],
+    }))
+    expect(Object.keys(bundle.HUB_DIALOGUES)).toEqual(['elder-chat'])
+    const tree = bundle.HUB_DIALOGUES['elder-chat']
+    expect(tree.start).toBe('root')
+    expect(tree.nodes.root.choices?.[0].next).toBe('lore')
+    expect(tree.nodes.root.choices?.[0].effects?.[0]).toEqual({ type: 'friendship', xp: 5 })
+    expect(tree.nodes.lore.text).toBe('A long story...')
   })
 })
 

--- a/web/src/data/hub/loader.ts
+++ b/web/src/data/hub/loader.ts
@@ -2,7 +2,7 @@ import { BASE_CHIP_TILES } from '../tiles/baseChipIndex'
 import { WALL_TILES } from '../tiles/buildingMaterials'
 import type { WallMaterial, RoofMaterial } from '../tiles/buildingMaterials'
 import { expandBundleDecor, expandBundleWindows, expandBundleDoors } from '../bundles/bundleLoader'
-import { FriendshipDialogue, HubQuestDef, QuestInnRumour, RawQuestConfig } from './questDefs'
+import { DialogueTree, FriendshipDialogue, HubQuestDef, QuestInnRumour, RawQuestConfig } from './questDefs'
 import { RawAnimal, RawConfig, RawInteractable } from './config'
 
 const WALL_MATERIAL_NAMES = new Set<string>(Object.keys(WALL_TILES))
@@ -97,6 +97,8 @@ export interface HubNpc {
   isGhost?: boolean
   schedule?: NpcScheduleEntry[]
   homeBed?: { buildingId: string; tx: number; ty: number }
+  /** Id of a branching dialogue tree (questDefs.json `dialogues`) to run on tap. */
+  dialogueTree?: string
 }
 
 export type HubAnimalType =
@@ -267,6 +269,7 @@ export interface HubQuestBundle {
   FRIENDSHIP_DIALOGUE: FriendshipDialogue
   HUB_PICKUP_ITEMS: HubPickupItem[]
   HUB_BLOCKED_PATHS: BlockedPath[]
+  HUB_DIALOGUES: Record<string, DialogueTree>
 }
 
 export function createHubLocationData(
@@ -667,6 +670,10 @@ const HUB_PICKUP_ITEMS: HubPickupItem[] = (
   requireTouch: p.requireTouch,
 }))
 
+const HUB_DIALOGUES: Record<string, DialogueTree> = Object.fromEntries(
+  ((rawQuestConfig as unknown as { dialogues?: DialogueTree[] }).dialogues ?? []).map(d => [d.id, d])
+)
+
   return {
 
 
@@ -675,5 +682,6 @@ const HUB_PICKUP_ITEMS: HubPickupItem[] = (
     FRIENDSHIP_DIALOGUE,
     HUB_BLOCKED_PATHS,
     HUB_PICKUP_ITEMS,
+    HUB_DIALOGUES,
   }
 }

--- a/web/src/data/hub/questDefs.ts
+++ b/web/src/data/hub/questDefs.ts
@@ -159,11 +159,44 @@ export interface QuestBlockedPaths {
 }
 
 
+// ── Branching dialogue trees ────────────────────────────────────────────────
+// A reusable schema for multi-choice NPC conversations that branch to different
+// endings. Authored in a town's questDefs.json `dialogues` block and referenced
+// from an NPC via `dialogueTree`. See docs/hubworld.md for the full reference.
+
+export type DialogueEffect =
+  | { type: 'flag'; flag: string }              // persist a named dialogue flag
+  | { type: 'friendship'; npcId?: string; xp: number }  // grant friendship XP (defaults to the speaking NPC)
+  | { type: 'quest'; questId: string }          // offer a quest (Accept / Not now)
+  | { type: 'end' }                             // end the conversation
+
+export interface DialogueChoiceDef {
+  label: string
+  next?: string            // node id to advance to after effects run
+  effects?: DialogueEffect[]
+  requireFlag?: string     // only show this choice if the flag is set
+  hideIfFlag?: string      // hide this choice once the flag is set
+}
+
+export interface DialogueNode {
+  text: string
+  speakerName?: string     // overrides the NPC name for this node (optional)
+  choices?: DialogueChoiceDef[]  // absent/empty → single OK button closes
+}
+
+export interface DialogueTree {
+  id: string
+  npcId?: string           // documentation only — which NPC this belongs to
+  start: string            // id of the first node in `nodes`
+  nodes: Record<string, DialogueNode>
+}
+
 export interface RawQuestConfig {
   quests: QuestDefinition[]
   pickupItems?: QuestPickupItem[]
   innRumours?: QuestInnRumour[]
   friendshipDialogue?: FriendshipDialogue
   blockedPaths?: QuestBlockedPaths[]
+  dialogues?: DialogueTree[]
 }
 

--- a/web/src/data/hub/questDefs.ts
+++ b/web/src/data/hub/questDefs.ts
@@ -197,6 +197,8 @@ export interface RawQuestConfig {
   innRumours?: QuestInnRumour[]
   friendshipDialogue?: FriendshipDialogue
   blockedPaths?: QuestBlockedPaths[]
-  dialogues?: DialogueTree[]
+  // `dialogues` (DialogueTree[]) is read in loader.ts via an `as unknown` cast —
+  // it is intentionally not declared here so the raw JSON (whose effect `type`
+  // widens to `string`) assigns to RawQuestConfig without a union mismatch.
 }
 

--- a/web/src/data/hub/ravenwatch/config.json
+++ b/web/src/data/hub/ravenwatch/config.json
@@ -6852,6 +6852,7 @@
       "sprite": "hub-npc-scholar",
       "tx": 58,
       "ty": 8,
+      "dialogueTree": "scholar-chat",
       "dialogue": [
         "I have been cataloguing the Fracture shards. The answers are within your reach — if you dare.",
         "The archives hold centuries of knowledge. Most of it was lost in the Fracture. What remains is precious.",

--- a/web/src/data/hub/ravenwatch/questDefs.json
+++ b/web/src/data/hub/ravenwatch/questDefs.json
@@ -5607,5 +5607,56 @@
         ]
       }
     }
+  ],
+  "dialogues": [
+    {
+      "id": "scholar-chat",
+      "npcId": "scholar",
+      "start": "greet",
+      "nodes": {
+        "greet": {
+          "text": "Ah — the wanderer who never sits still. The archives can wait. What's on your mind?",
+          "choices": [
+            { "label": "Remind me — who are you?", "hideIfFlag": "scholar-greeted", "effects": [{ "type": "flag", "flag": "scholar-greeted" }], "next": "intro" },
+            { "label": "Tell me about the Fracture.", "next": "lore" },
+            { "label": "Anything I can help with nearby?", "next": "errand" },
+            { "label": "Just saying hello.", "effects": [{ "type": "friendship", "npcId": "scholar", "xp": 5 }, { "type": "flag", "flag": "scholar-greeted" }], "next": "hello" }
+          ]
+        },
+        "intro": {
+          "text": "Archivist Naia. I keep Ravenwatch's records — and its secrets, when they will hold still long enough to be written down.",
+          "choices": [
+            { "label": "Good to know.", "next": "greet" }
+          ]
+        },
+        "lore": {
+          "text": "The Dominion was whole, once. The Fracture shattered it into drifting shards — and left Echoes in the cracks between. I have spent years cataloguing them.",
+          "choices": [
+            { "label": "What are the Echoes?", "next": "echoes" },
+            { "label": "Fascinating — thank you.", "effects": [{ "type": "friendship", "npcId": "scholar", "xp": 10 }, { "type": "end" }] }
+          ]
+        },
+        "echoes": {
+          "text": "Fragments of what was — memories given shape, sometimes teeth. Tread carefully when the air hums. That is all I will say in the open.",
+          "choices": [
+            { "label": "I'll be careful.", "effects": [{ "type": "end" }] }
+          ]
+        },
+        "errand": {
+          "text": "As it happens — Old Greyfish has been fretting over that half-starved stray by the pond. A kind soul could see her fed.",
+          "choices": [
+            { "label": "I'll help the stray.", "effects": [{ "type": "quest", "questId": "feed-the-stray" }] },
+            { "label": "Maybe later.", "effects": [{ "type": "end" }] }
+          ]
+        },
+        "hello": {
+          "text": "Hello to you, friend. Come back whenever curiosity strikes — I am always here, buried in parchment.",
+          "choices": [
+            { "label": "I have a question, actually...", "requireFlag": "scholar-greeted", "next": "greet" },
+            { "label": "Farewell.", "effects": [{ "type": "end" }] }
+          ]
+        }
+      }
+    }
   ]
 }

--- a/web/src/game/hub/dialogueFlags.test.ts
+++ b/web/src/game/hub/dialogueFlags.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import {
+  setDialogueFlag, hasDialogueFlag, getDialogueFlags,
+  markNodeSeen, hasNodeSeen,
+} from './dialogueFlags'
+
+function installLocalStorageStub(): void {
+  const store = new Map<string, string>()
+  vi.stubGlobal('localStorage', {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => { store.set(k, v) },
+    removeItem: (k: string) => { store.delete(k) },
+    clear: () => { store.clear() },
+  })
+}
+
+describe('dialogueFlags', () => {
+  beforeEach(() => {
+    installLocalStorageStub()
+  })
+
+  it('sets and reads flags, deduplicating', () => {
+    expect(hasDialogueFlag('met-elder')).toBe(false)
+    setDialogueFlag('met-elder')
+    setDialogueFlag('met-elder')
+    expect(hasDialogueFlag('met-elder')).toBe(true)
+    expect(getDialogueFlags()).toEqual(['met-elder'])
+  })
+
+  it('tracks seen nodes via the seen:<tree>:<node> convention', () => {
+    expect(hasNodeSeen('elder-chat', 'root')).toBe(false)
+    markNodeSeen('elder-chat', 'root')
+    expect(hasNodeSeen('elder-chat', 'root')).toBe(true)
+    expect(hasNodeSeen('elder-chat', 'lore')).toBe(false)
+    expect(getDialogueFlags()).toContain('seen:elder-chat:root')
+  })
+
+  it('returns empty + false when localStorage throws', () => {
+    vi.stubGlobal('localStorage', {
+      getItem: () => { throw new Error('blocked') },
+      setItem: () => { throw new Error('blocked') },
+    })
+    expect(() => setDialogueFlag('x')).not.toThrow()
+    expect(hasDialogueFlag('x')).toBe(false)
+    expect(getDialogueFlags()).toEqual([])
+  })
+})

--- a/web/src/game/hub/dialogueFlags.ts
+++ b/web/src/game/hub/dialogueFlags.ts
@@ -1,0 +1,48 @@
+const KEY = 'jarv_hub_dialogue_flags'
+
+function load(): Set<string> {
+  try {
+    const raw = localStorage.getItem(KEY)
+    return new Set(raw ? (JSON.parse(raw) as string[]) : [])
+  } catch {
+    return new Set()
+  }
+}
+
+function save(flags: Set<string>): void {
+  try {
+    localStorage.setItem(KEY, JSON.stringify([...flags]))
+  } catch { /* ignore */ }
+}
+
+/** Persist a named dialogue flag (idempotent). */
+export function setDialogueFlag(flag: string): void {
+  const flags = load()
+  if (flags.has(flag)) return
+  flags.add(flag)
+  save(flags)
+}
+
+export function hasDialogueFlag(flag: string): boolean {
+  return load().has(flag)
+}
+
+export function getDialogueFlags(): string[] {
+  return [...load()]
+}
+
+// ── "Seen" branch tracking ───────────────────────────────────────────────────
+// Visited dialogue nodes are persisted as flags using the `seen:<treeId>:<nodeId>`
+// convention so authors can gate branches on whether the player has been here.
+
+function seenFlag(treeId: string, nodeId: string): string {
+  return `seen:${treeId}:${nodeId}`
+}
+
+export function markNodeSeen(treeId: string, nodeId: string): void {
+  setDialogueFlag(seenFlag(treeId, nodeId))
+}
+
+export function hasNodeSeen(treeId: string, nodeId: string): boolean {
+  return hasDialogueFlag(seenFlag(treeId, nodeId))
+}


### PR DESCRIPTION
Closes #1611 (and sub-issues #1635, #1639, #1642, #1645).

## What

Adds a reusable **branching dialogue-tree** system for ordinary hub NPC chat, so
NPCs can hold multi-choice conversations that branch to different endings — on top
of the existing linear `dialogue: string[]` cycle.

### Schema + parser (#1635)
- `questDefs.ts`: `DialogueTree` / `DialogueNode` / `DialogueChoiceDef` / `DialogueEffect` types; trees authored in a top-level `dialogues` block of `questDefs.json`.
- `loader.ts`: parses `HUB_DIALOGUES` into `HubQuestBundle`; adds `HubNpc.dialogueTree`.
- `hubWorldFactory.ts`: merges `HUB_DIALOGUES` across all locations into `ALL_QUESTS`.

### Choice-branch rendering (#1639)
- `HubDialogue.tsx`: stacks multiple branch choices vertically full-width (single actions stay inline). Reuses the existing `choices` prop — no new UI primitive.

### Choice effects + persistence (#1642)
- New `game/hub/dialogueFlags.ts`: `setDialogueFlag` / `hasDialogueFlag` / `getDialogueFlags` + `markNodeSeen` / `hasNodeSeen` (`seen:<tree>:<node>`), localStorage-backed.
- `HubWorld.tsx`: `runDialogueNode` / `applyChoice` walk the tree, filter choices by `requireFlag` / `hideIfFlag`, and apply effects — **continue / end / set flag / grant friendship XP / offer a quest** (reusing `tryOfferQuest`, resolving the quest's real giver). Runs below quest/screen/friendship-tier overrides in `handleNpcTap`.

### Storybook (#1645)
- `HubDialogue.stories.tsx`: a `Branching` story walking a 3-node tree to two endings.

### Sample conversation (end-to-end)
- Ravenwatch's `scholar` (Archivist Naia) gets a `scholar-chat` tree: branches to multiple endings, grants friendship XP, offers `feed-the-stray`, and gates a branch on a persisted flag.

### Docs
- `docs/hubworld.md` §7b: schema, effect reference, persistence, authoring checklist.

## Testing
- `npm run build` — clean ✅
- `npm test` — all 157 node tests pass, including new `loader.test.ts` (dialogue parsing) and `dialogueFlags.test.ts` cases ✅ (the Storybook browser project needs `npx playwright install`, which only runs in CI here).

## Acceptance criteria
- ✅ An NPC presents a multi-choice conversation that branches to different endings.
- ✅ Choices can grant friendship XP / offer a quest; state persists (localStorage flags + seen branches).
- ✅ Storybook story for a branching conversation; `npm run build` + loader tests pass.

https://claude.ai/code/session_01JmQvMcKSgxrhSUmMkpAzYJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01JmQvMcKSgxrhSUmMkpAzYJ)_