### PR TITLE
Hub: relationship tracks (ally / rival / romance) (#1613)

### DIFF
--- a/docs/hubworld.md
+++ b/docs/hubworld.md
@@ -11,12 +11,13 @@
 | File | Owns | TypeScript exports |
 |---|---|---|
 | `web/src/data/hub/config.json` | Map geometry, buildings, doors, NPCs, exterior decor, interiors, windows, interactables | parsed by `loader.ts` |
-| `web/src/data/hub/questDefs.json` | Quests, pickup items, blocked paths, inn rumours, friendship dialogue, dialogue trees | parsed by `loader.ts` and `questDefs.ts` |
+| `web/src/data/hub/questDefs.json` | Quests, pickup items, blocked paths, inn rumours, friendship dialogue, dialogue trees, relationship dialogue | parsed by `loader.ts` and `questDefs.ts` |
 | `web/src/data/hub/loader.ts` | Parses both JSON files; exports all map/NPC/item/path data | `MAP_W`, `MAP_H`, `AVATAR_START`, `HUB_AREAS`, `HUB_STREET_TILES`, `HUB_BUILDINGS`, `HUB_DOORS`, `HUB_INTERIORS`, `EXTERIOR_DECOR`, `HUB_NPCS`, `EXTERIOR_NPCS`, `INTERIOR_NPCS`, `HUB_PICKUP_ITEMS`, `HUB_BLOCKED_PATHS`, `HUB_LOCKED_DOORS`, … |
 | `web/src/data/hub/questDefs.ts` | Parses `questDefs.json`; exports quest definitions and dialogue | `HUB_QUEST_DEFS`, `INN_RUMOURS`, `FRIENDSHIP_DIALOGUE` |
 | `web/src/game/hub/quests.ts` | Quest progress/status persistence (localStorage) | `getQuestState`, `setQuestStatus`, `incrementQuestProgress`, `getQuestProgress`, `resetQuest` |
 | `web/src/game/hub/pickups.ts` | Pickup state persistence (localStorage) | `getPickedUpIds`, `markPickedUp`, `isPickedUp`, `unmarkPickedUp` |
 | `web/src/game/hub/friendship.ts` | NPC friendship XP/level persistence (localStorage) | `getFriendshipLevel`, `addFriendshipXp`, `getFriendshipData` |
+| `web/src/game/hub/relationships.ts` | NPC relationship-track (ally/rival/romance) persistence (localStorage) — see §7c | `getRelationship`, `getRelationshipTrack`, `getRelationshipLevel`, `addRelationshipPoints`, `relationshipProgress` |
 | `web/src/game/hub/dialogueFlags.ts` | Branching-dialogue flag + "seen" branch persistence (localStorage) — see §7b | `setDialogueFlag`, `hasDialogueFlag`, `getDialogueFlags`, `markNodeSeen`, `hasNodeSeen` |
 | `web/src/game/hub/innConvos.ts` | Inn conversation tracking (localStorage) | `getHeardConvoIds`, `markConvoHeard`, `isConvoHeard` |
 | `web/src/game/hub/interactables.ts` | Interactable grant + moved-position persistence (localStorage) | `interactableStoreKey`, `isInteractableGranted`, `markInteractableGranted`, `getInteractableMoves`, `setInteractableMove` |
@@ -381,6 +382,7 @@ Then on the NPC (in `config.json`): `"dialogueTree": "scholar-chat"` (keep a
 |---|---|---|
 | `flag` | `flag` | Persist a named dialogue flag. |
 | `friendship` | `npcId?`, `xp` | Grant friendship XP (defaults to the speaking NPC). |
+| `relationship` | `npcId?`, `track`, `points` | Add points to a relationship track (`ally`/`rival`/`romance`) — defaults to the speaking NPC. See §7c. |
 | `quest` | `questId` | Offer that quest (Accept / Not now). Resolves the quest's real `giverNpcId`. **Terminates** the walk. |
 | `end` | — | End the conversation. |
 
@@ -404,6 +406,85 @@ conversation closes.
 4. Attach `"dialogueTree": "<id>"` to the NPC in `config.json`; keep a `dialogue` fallback line.
 5. Run `npm run test` (loader tests parse all configs) and `npm run build`.
 6. Verify in-game: tapping the NPC branches to different endings, friendship XP / quest offers fire, and flag-gated choices reflect persisted state after reload.
+
+---
+
+## §7c — Relationship Tracks (ally / rival / romance)
+
+A second relationship layer **on top of** flat friendship (§7b friendship is
+untouched). Each NPC accumulates points on three independent tracks — `ally`,
+`rival`, `romance` — and the track with the most points becomes the NPC's
+**dominant track**, whose point total maps to a 0–4 level via the same ladder as
+friendship (`[0, 10, 25, 50, 100]`). State persists in `localStorage`.
+
+Logic: `web/src/game/hub/relationships.ts`. UI: per-NPC `RelationshipView` modal
+opened from the Town Directory ("Where is…?") row buttons.
+
+### Persistence — `web/src/game/hub/relationships.ts` (key `jarv_hub_relationships`)
+
+| Export | Purpose |
+|---|---|
+| `getRelationship(npcId)` | `{ track, level, points }` entry (default empty). |
+| `getRelationshipTrack(npcId)` / `getRelationshipLevel(npcId)` | Dominant track / its level. |
+| `addRelationshipPoints(npcId, track, points)` | Add points, recompute dominant track + level, persist. |
+| `relationshipProgress(entry)` / `MAX_RELATIONSHIP_LEVEL` | Pure helpers for the view UI. |
+
+### Advancing a track
+
+1. **Dialogue choices** — a `relationship` `DialogueEffect` in a dialogue tree
+   (§7b). This is the primary way the player *steers* an NPC:
+   ```jsonc
+   { "label": "As a worthy rival.",
+     "effects": [{ "type": "relationship", "npcId": "scholar", "track": "rival", "points": 4 }] }
+   ```
+2. **Quest / gift rewards** — a `relationship` block on a quest `reward`
+   (parallels `friendship`):
+   ```jsonc
+   "reward": { "crystals": 60, "relationship": { "scholar": { "track": "ally", "points": 10 } } }
+   ```
+
+### Track-gated content
+
+A quest `prerequisite` (or interactable quest gate) may require a track + level:
+
+```
+"prerequisite": "relationship:<npcId>:<track>:<level>"   // e.g. relationship:scholar:ally:2
+```
+
+True only when the NPC's **dominant** track equals `<track>` and its level
+`>= <level>`. Combine with `|` like other prerequisites (e.g.
+`quest:foo|relationship:scholar:rival:2`).
+
+### Track-specific greeting — `relationshipDialogue`
+
+A top-level block in `questDefs.json` (parallels `friendshipDialogue`), keyed
+`npcId → track → levelString → line`. Shown when that NPC's dominant track is
+active at/under the current level, taking precedence over the friendship-tier
+greeting:
+
+```jsonc
+"relationshipDialogue": {
+  "merchant": {
+    "ally":  { "2": "For a trusted ally, the best stock comes out from under the counter." },
+    "rival": { "2": "Every bargain with you is a duel. I won't blink first." }
+  }
+}
+```
+
+> **Do not** author `relationshipDialogue` for an NPC that also has a
+> `dialogueTree` — the greeting would shadow the tree (the player's steering
+> path). `HubWorld.tsx` guards against this, so steer tree-NPCs via tree choices
+> and use `relationshipDialogue` only on linear-dialogue NPCs.
+
+### Authoring checklist
+
+1. To let the player steer an NPC: add `relationship` effects to its dialogue
+   tree choices (§7b), or grant points via quest `reward.relationship`.
+2. Gate follow-up quests with `prerequisite: "relationship:<npc>:<track>:<level>"`.
+3. Optionally add `relationshipDialogue` for **linear-dialogue** NPCs only.
+4. Run `npm run test` + `npm run build`; verify in-game that steering changes the
+   track in the Town Directory → Relationship view, gated quests appear, and
+   state survives a reload.
 
 ---
 

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -10,6 +10,7 @@ import type { DialogueChoice } from './HubDialogue'
 import type { HubQuestDef, DialogueTree, DialogueChoiceDef } from '../../data/hub/questDefs'
 import { getPickedUpIds, markPickedUp, unmarkPickedUp } from '../../game/hub/pickups'
 import { getFriendshipLevel, addFriendshipXp, getFriendshipData } from '../../game/hub/friendship'
+import { addRelationshipPoints, getRelationship } from '../../game/hub/relationships'
 import { setDialogueFlag, hasDialogueFlag, markNodeSeen } from '../../game/hub/dialogueFlags'
 import { getQuestState, setQuestStatus, incrementQuestProgress, getQuestProgress, resetQuest } from '../../game/hub/quests'
 import { getHeardConvoIds, markConvoHeard } from '../../game/hub/innConvos'
@@ -35,7 +36,7 @@ import { getCollectedTreasureIds, markTreasureCollected } from '../../game/hub/t
 import { useHubClock } from '../../hooks/useHubClock'
 import { formatGameTime, hourInRange } from '../../game/hub/hubClock'
 import { getDailyChallengeNPCDialogue } from '../../game/hub/npcDialogue'
-import {  ALL_QUESTS, FRIENDSHIP_DIALOGUE, RAVENWATCH } from '../../data/hub/hubWorldFactory'
+import {  ALL_QUESTS, FRIENDSHIP_DIALOGUE, RELATIONSHIP_DIALOGUE, RAVENWATCH } from '../../data/hub/hubWorldFactory'
 import { HubInteractable, HubLocationBundle, HubQuestBundle, HubTreasure } from '../../data/hub/loader'
 import { getUnreadCount } from '../../game/news'
 import { interactableStoreKey, isInteractableGranted, markInteractableGranted, getInteractableMoves, setInteractableMove } from '../../game/hub/interactables'
@@ -61,6 +62,12 @@ function checkPrerequisite(prereq: string): boolean {
     if (part.startsWith('friendship:')) {
       const parts = part.split(':')
       return getFriendshipLevel(parts[1]) >= parseInt(parts[2] ?? '1')
+    }
+    if (part.startsWith('relationship:')) {
+      // relationship:<npcId>:<track>:<level>
+      const [, npcId, track, lvl] = part.split(':')
+      const rel = getRelationship(npcId)
+      return rel.track === track && rel.level >= parseInt(lvl ?? '1')
     }
     if (part.startsWith('quest:')) {
       return getQuestState(part.slice(6)).status === 'completed'
@@ -483,6 +490,11 @@ function formatQuestReward(reward: HubQuestDef['reward']): string {
       parts.push(`+${xp} friendship with ${getNpcDisplayName(npcId)}`)
     }
   }
+  if (reward.relationship) {
+    for (const [npcId, grant] of Object.entries(reward.relationship)) {
+      parts.push(`+${grant.points} ${grant.track} with ${getNpcDisplayName(npcId)}`)
+    }
+  }
   return parts.length > 0 ? `You received: ${parts.join('  ·  ')}` : ''
 }
 
@@ -501,6 +513,11 @@ function grantQuestReward(quest: HubQuestDef): void {
   if (reward.friendship) {
     for (const [npcId, xp] of Object.entries(reward.friendship)) {
       addFriendshipXp(npcId, xp)
+    }
+  }
+  if (reward.relationship) {
+    for (const [npcId, grant] of Object.entries(reward.relationship)) {
+      addRelationshipPoints(npcId, grant.track, grant.points)
     }
   }
 }
@@ -579,6 +596,10 @@ function tryOfferQuest(giverId: string, speakerName: string, onlyQuestId?: strin
           break
         case 'friendship':
           addFriendshipXp(eff.npcId ?? npcId, eff.xp)
+          refreshState()
+          break
+        case 'relationship':
+          addRelationshipPoints(eff.npcId ?? npcId, eff.track, eff.points)
           refreshState()
           break
         case 'quest': {
@@ -713,6 +734,22 @@ function tryOfferQuest(giverId: string, speakerName: string, onlyQuestId?: strin
       const tree = ALL_QUESTS.HUB_DIALOGUES[treeId]
       if (tree) {
         runDialogueNode(tree, tree.start, npcId, speakerName)
+        return
+      }
+    }
+
+    // ── Relationship-track dialogue override ────────────────────────────────
+    // Fires only for NPCs without a dialogue tree (the tree is how the player
+    // steers), so an active track flavours the greeting at the matching level.
+    const relTracks = RELATIONSHIP_DIALOGUE[npcId]
+    const rel = getRelationship(npcId)
+    if (relTracks && rel.track && relTracks[rel.track]) {
+      const lines = Object.entries(relTracks[rel.track]!)
+        .map(([k, v]) => ({ minLevel: parseInt(k), text: v }))
+        .filter(t => rel.level >= t.minLevel)
+        .sort((a, b) => b.minLevel - a.minLevel)
+      if (lines.length > 0) {
+        setDialogueEvent({ speakerName, text: lines[0].text })
         return
       }
     }

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -716,6 +716,24 @@ function tryOfferQuest(giverId: string, speakerName: string, onlyQuestId?: strin
       return
     }
 
+    // ── Relationship-track dialogue override ────────────────────────────────
+    // Takes precedence over the generic friendship greeting: once a track is
+    // active, it flavours the greeting at the matching level. NPCs steered via a
+    // dialogue tree should not author relationshipDialogue (the tree below is how
+    // the player steers — a greeting here would shadow it).
+    const relTracks = RELATIONSHIP_DIALOGUE[npcId]
+    const rel = getRelationship(npcId)
+    if (!npcDef?.dialogueTree && relTracks && rel.track && relTracks[rel.track]) {
+      const lines = Object.entries(relTracks[rel.track]!)
+        .map(([k, v]) => ({ minLevel: parseInt(k), text: v }))
+        .filter(t => rel.level >= t.minLevel)
+        .sort((a, b) => b.minLevel - a.minLevel)
+      if (lines.length > 0) {
+        setDialogueEvent({ speakerName, text: lines[0].text })
+        return
+      }
+    }
+
     // ── Friendship tier dialogue override ───────────────────────────────────
     const friendTiers = FRIENDSHIP_DIALOGUE[npcId]
     if (friendTiers) {
@@ -736,22 +754,6 @@ function tryOfferQuest(giverId: string, speakerName: string, onlyQuestId?: strin
       const tree = ALL_QUESTS.HUB_DIALOGUES[treeId]
       if (tree) {
         runDialogueNode(tree, tree.start, npcId, speakerName)
-        return
-      }
-    }
-
-    // ── Relationship-track dialogue override ────────────────────────────────
-    // Fires only for NPCs without a dialogue tree (the tree is how the player
-    // steers), so an active track flavours the greeting at the matching level.
-    const relTracks = RELATIONSHIP_DIALOGUE[npcId]
-    const rel = getRelationship(npcId)
-    if (relTracks && rel.track && relTracks[rel.track]) {
-      const lines = Object.entries(relTracks[rel.track]!)
-        .map(([k, v]) => ({ minLevel: parseInt(k), text: v }))
-        .filter(t => rel.level >= t.minLevel)
-        .sort((a, b) => b.minLevel - a.minLevel)
-      if (lines.length > 0) {
-        setDialogueEvent({ speakerName, text: lines[0].text })
         return
       }
     }

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -30,6 +30,7 @@ import { LoginButton } from '../ui/LoginButton'
 import { addCollectible, addConsumable, getCollectibles } from '../../game/itemStore'
 import { QuestsModal } from './QuestsModal'
 import { TownDirectory } from './TownDirectory'
+import { RelationshipView } from './RelationshipView'
 import { resolveNpcPlace } from '../../game/hub/npcLocator'
 import { TreasureModal } from './TreasureModal'
 import { getCollectedTreasureIds, markTreasureCollected } from '../../game/hub/treasures'
@@ -130,6 +131,7 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onEndless, onWorldMap
   const [pickedUpIds,    setPickedUpIds]    = useState<Set<string>>(() => getPickedUpIds())
   const [questsOpen,          setQuestsOpen]          = useState(false)
   const [directoryOpen,       setDirectoryOpen]       = useState(false)
+  const [relationshipNpcId,   setRelationshipNpcId]   = useState<string | null>(null)
   const [pinnedNpcId,         setPinnedNpcId]         = useState<string | null>(null)
   const [openTreasure,        setOpenTreasure]        = useState<HubTreasure | null>(null)
   const [collectedTreasureIds] = useState<Set<string>>(() => getCollectedTreasureIds())
@@ -922,7 +924,8 @@ function tryOfferQuest(giverId: string, speakerName: string, onlyQuestId?: strin
         )}
 
         {questsOpen && <QuestsModal onClose={() => setQuestsOpen(false)} onAbandon={handleQuestAbandon} questDefs={questDefs}/>}
-        {directoryOpen && <TownDirectory onClose={() => setDirectoryOpen(false)} locationData={locationData} pinnedNpcId={pinnedNpcId} onTogglePin={togglePinnedNpc} />}
+        {directoryOpen && <TownDirectory onClose={() => setDirectoryOpen(false)} locationData={locationData} pinnedNpcId={pinnedNpcId} onTogglePin={togglePinnedNpc} onShowRelationship={setRelationshipNpcId} />}
+        {relationshipNpcId && <RelationshipView npcName={getNpcDisplayName(relationshipNpcId)} entry={getRelationship(relationshipNpcId)} onClose={() => setRelationshipNpcId(null)} />}
         {openTreasure && <TreasureModal treasure={openTreasure} onClose={() => setOpenTreasure(null)} />}
 
         <HubDialogue

--- a/web/src/components/hub/RelationshipView.stories.tsx
+++ b/web/src/components/hub/RelationshipView.stories.tsx
@@ -1,0 +1,49 @@
+import { fn } from 'storybook/test'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { RelationshipView } from './RelationshipView'
+import type { RelationshipEntry } from '../../game/hub/relationships'
+
+const meta = {
+  component: RelationshipView,
+  parameters: { layout: 'fullscreen' },
+  decorators: [
+    (Story) => (
+      <div className="game-container">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof RelationshipView>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+const entry = (
+  track: RelationshipEntry['track'],
+  level: number,
+  points: Partial<RelationshipEntry['points']> = {},
+): RelationshipEntry => ({
+  track,
+  level,
+  points: { ally: 0, rival: 0, romance: 0, ...points },
+})
+
+export const Acquaintance: Story = {
+  args: { npcName: 'Elder Maeve', entry: entry(null, 0), onClose: fn() },
+}
+
+export const Ally: Story = {
+  args: { npcName: 'Elder Maeve', entry: entry('ally', 2, { ally: 14 }), onClose: fn() },
+}
+
+export const Rival: Story = {
+  args: { npcName: 'Captain Roth', entry: entry('rival', 3, { rival: 32 }), onClose: fn() },
+}
+
+export const Romance: Story = {
+  args: { npcName: 'Naia', entry: entry('romance', 4, { romance: 60 }), onClose: fn() },
+}
+
+export const Maxed: Story = {
+  args: { npcName: 'Naia', entry: entry('romance', 5, { romance: 120 }), onClose: fn() },
+}

--- a/web/src/components/hub/RelationshipView.tsx
+++ b/web/src/components/hub/RelationshipView.tsx
@@ -1,0 +1,61 @@
+import React from 'react'
+import { ModalBackdrop } from '../ui/ModalBackdrop'
+import {
+  MAX_RELATIONSHIP_LEVEL,
+  relationshipProgress,
+  type RelationshipEntry,
+  type RelationshipTrack,
+} from '../../game/hub/relationships'
+
+interface Props {
+  npcName: string
+  entry:   RelationshipEntry
+  onClose: () => void
+}
+
+const TRACK_META: Record<RelationshipTrack, { icon: string; label: string; hint: string }> = {
+  ally:    { icon: '🤝', label: 'Ally',    hint: 'Keep helping out — loyal allies open up unique requests.' },
+  rival:   { icon: '⚔️', label: 'Rival',   hint: 'A heated rivalry — push back to unlock their challenges.' },
+  romance: { icon: '💗', label: 'Romance', hint: 'Warm words are noticed — keep flirting to grow closer.' },
+}
+
+export function RelationshipView({ npcName, entry, onClose }: Props) {
+  const meta = entry.track ? TRACK_META[entry.track] : null
+  const { points, nextThreshold } = relationshipProgress(entry)
+
+  return (
+    <ModalBackdrop onClose={onClose}>
+      <div className="town-directory">
+        <div className="town-directory__header">
+          <span>{meta ? meta.icon : '🙂'} {npcName}</span>
+          <button className="town-directory__close" onClick={onClose}>✕</button>
+        </div>
+
+        <div className="town-directory__list">
+          <div className="town-directory__row">
+            <div className="town-directory__info">
+              <span className="town-directory__name">
+                {meta ? `${meta.label} · Level ${entry.level}` : 'Acquaintance'}
+              </span>
+              <span className="town-directory__place">
+                {meta
+                  ? (nextThreshold !== null
+                      ? `${points} / ${nextThreshold} pts to next level`
+                      : `Maxed out (level ${MAX_RELATIONSHIP_LEVEL})`)
+                  : 'You haven’t formed a bond yet — talk to them to begin.'}
+              </span>
+            </div>
+          </div>
+
+          {meta && (
+            <div className="town-directory__row">
+              <div className="town-directory__info">
+                <span className="town-directory__place">💡 {meta.hint}</span>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </ModalBackdrop>
+  )
+}

--- a/web/src/components/hub/TownDirectory.stories.tsx
+++ b/web/src/components/hub/TownDirectory.stories.tsx
@@ -24,6 +24,7 @@ export const Default: Story = {
     locationData: RAVENWATCH,
     pinnedNpcId:  null,
     onTogglePin:  fn(),
+    onShowRelationship: fn(),
   },
 }
 
@@ -33,5 +34,6 @@ export const WithPinned: Story = {
     locationData: RAVENWATCH,
     pinnedNpcId:  RAVENWATCH.HUB_NPCS.find(n => n.name?.trim())?.id ?? null,
     onTogglePin:  fn(),
+    onShowRelationship: fn(),
   },
 }

--- a/web/src/components/hub/TownDirectory.tsx
+++ b/web/src/components/hub/TownDirectory.tsx
@@ -4,15 +4,19 @@ import type { HubLocationBundle } from '../../data/hub/loader'
 import { useHubClock } from '../../hooks/useHubClock'
 import { resolveNpcPlace } from '../../game/hub/npcLocator'
 import { getFriendshipLevel } from '../../game/hub/friendship'
+import { getRelationship } from '../../game/hub/relationships'
+
+const TRACK_ICON: Record<string, string> = { ally: '🤝', rival: '⚔️', romance: '💗' }
 
 interface Props {
-  onClose:      () => void
-  locationData: HubLocationBundle
-  pinnedNpcId:  string | null
-  onTogglePin:  (npcId: string) => void
+  onClose:            () => void
+  locationData:       HubLocationBundle
+  pinnedNpcId:        string | null
+  onTogglePin:        (npcId: string) => void
+  onShowRelationship: (npcId: string) => void
 }
 
-export function TownDirectory({ onClose, locationData, pinnedNpcId, onTogglePin }: Props) {
+export function TownDirectory({ onClose, locationData, pinnedNpcId, onTogglePin, onShowRelationship }: Props) {
   const { gameHour } = useHubClock()
   const [onlyMet, setOnlyMet] = useState(false)
 
@@ -55,19 +59,31 @@ export function TownDirectory({ onClose, locationData, pinnedNpcId, onTogglePin 
             {visible.map(npc => {
               const place  = resolveNpcPlace(npc, gameHour, locationData)
               const pinned = pinnedNpcId === npc.id
+              const track  = getRelationship(npc.id).track
               return (
                 <div key={npc.id} className="town-directory__row">
                   <div className="town-directory__info">
-                    <span className="town-directory__name">{npc.name}</span>
+                    <span className="town-directory__name">
+                      {npc.name}{track ? ` ${TRACK_ICON[track]}` : ''}
+                    </span>
                     <span className="town-directory__place">📍 {place.name}</span>
                   </div>
-                  <button
-                    className={`town-directory__pin-btn${pinned ? ' town-directory__pin-btn--on' : ''}`}
-                    onClick={() => onTogglePin(npc.id)}
-                    title={pinned ? 'Hide on minimap' : 'Show on minimap'}
-                  >
-                    {pinned ? '📌 Pinned' : '📍 Show on map'}
-                  </button>
+                  <div style={{ display: 'flex', gap: 6 }}>
+                    <button
+                      className="town-directory__pin-btn"
+                      onClick={() => onShowRelationship(npc.id)}
+                      title="View relationship"
+                    >
+                      💗 Relationship
+                    </button>
+                    <button
+                      className={`town-directory__pin-btn${pinned ? ' town-directory__pin-btn--on' : ''}`}
+                      onClick={() => onTogglePin(npc.id)}
+                      title={pinned ? 'Hide on minimap' : 'Show on minimap'}
+                    >
+                      {pinned ? '📌 Pinned' : '📍 Show on map'}
+                    </button>
+                  </div>
                 </div>
               )
             })}

--- a/web/src/data/hub/hubWorldFactory.ts
+++ b/web/src/data/hub/hubWorldFactory.ts
@@ -131,6 +131,7 @@ export const ALL_QUESTS : HubQuestBundle = {
   HUB_QUEST_DEFS:    ALL_QUEST_BUNDLES.flatMap(b => b.HUB_QUEST_DEFS),
   INN_RUMOURS:       ALL_QUEST_BUNDLES.flatMap(b => b.INN_RUMOURS ?? []),
   FRIENDSHIP_DIALOGUE: Object.assign({}, ...ALL_QUEST_BUNDLES.map(b => b.FRIENDSHIP_DIALOGUE)),
+  RELATIONSHIP_DIALOGUE: Object.assign({}, ...ALL_QUEST_BUNDLES.map(b => b.RELATIONSHIP_DIALOGUE)),
   HUB_PICKUP_ITEMS:  ALL_QUEST_BUNDLES.flatMap(b => b.HUB_PICKUP_ITEMS),
   HUB_BLOCKED_PATHS: ALL_QUEST_BUNDLES.flatMap(b => b.HUB_BLOCKED_PATHS),
   HUB_DIALOGUES:     Object.assign({}, ...ALL_QUEST_BUNDLES.map(b => b.HUB_DIALOGUES)),
@@ -143,6 +144,10 @@ export const ALL_QUEST_DEFS = [
 
 export const FRIENDSHIP_DIALOGUE = {
   ...ALL_QUESTS.FRIENDSHIP_DIALOGUE,
+}
+
+export const RELATIONSHIP_DIALOGUE = {
+  ...ALL_QUESTS.RELATIONSHIP_DIALOGUE,
 }
 
 export interface LocationEntry {

--- a/web/src/data/hub/loader.ts
+++ b/web/src/data/hub/loader.ts
@@ -2,7 +2,7 @@ import { BASE_CHIP_TILES } from '../tiles/baseChipIndex'
 import { WALL_TILES } from '../tiles/buildingMaterials'
 import type { WallMaterial, RoofMaterial } from '../tiles/buildingMaterials'
 import { expandBundleDecor, expandBundleWindows, expandBundleDoors } from '../bundles/bundleLoader'
-import { DialogueTree, FriendshipDialogue, HubQuestDef, QuestInnRumour, RawQuestConfig } from './questDefs'
+import { DialogueTree, FriendshipDialogue, HubQuestDef, QuestInnRumour, RawQuestConfig, RelationshipDialogue } from './questDefs'
 import { RawAnimal, RawConfig, RawInteractable } from './config'
 
 const WALL_MATERIAL_NAMES = new Set<string>(Object.keys(WALL_TILES))
@@ -267,6 +267,7 @@ export interface HubQuestBundle {
   HUB_QUEST_DEFS: HubQuestDef[]
   INN_RUMOURS?: QuestInnRumour[]
   FRIENDSHIP_DIALOGUE: FriendshipDialogue
+  RELATIONSHIP_DIALOGUE: RelationshipDialogue
   HUB_PICKUP_ITEMS: HubPickupItem[]
   HUB_BLOCKED_PATHS: BlockedPath[]
   HUB_DIALOGUES: Record<string, DialogueTree>
@@ -630,6 +631,8 @@ const INN_RUMOURS = rawQuestConfig.innRumours || []
 
 const FRIENDSHIP_DIALOGUE = rawQuestConfig.friendshipDialogue || {}
 
+const RELATIONSHIP_DIALOGUE: RelationshipDialogue = rawQuestConfig.relationshipDialogue || {}
+
 type RawBlockedPathNpc = { id: string; sprite: string; tx: number; ty: number; proximityDialogue?: { atDistance: number; text: string }[]; tapDialogue?: string }
 type RawBlockedPathState = { decor?: Array<{ tx: number; ty: number; tileId?: string; bundleID?: string; zlayer?: string }>; npcs?: RawBlockedPathNpc[] }
 
@@ -680,6 +683,7 @@ const HUB_DIALOGUES: Record<string, DialogueTree> = Object.fromEntries(
     HUB_QUEST_DEFS,
     INN_RUMOURS,
     FRIENDSHIP_DIALOGUE,
+    RELATIONSHIP_DIALOGUE,
     HUB_BLOCKED_PATHS,
     HUB_PICKUP_ITEMS,
     HUB_DIALOGUES,

--- a/web/src/data/hub/questDefs.ts
+++ b/web/src/data/hub/questDefs.ts
@@ -1,3 +1,4 @@
+import type { RelationshipTrack } from '../../game/hub/relationships'
 
 export interface HubQuestStep {
   key: string
@@ -8,13 +9,26 @@ export interface HubQuestStep {
   chain?: string
 }
 
+export interface RelationshipGrant {
+  track: RelationshipTrack
+  points: number
+}
+
 export interface HubQuestReward {
   crystals?: number
   collectible?: { id: string; name: string; icon: string; desc: string }
   card?: { name: string; count?: number }
   friendship?: Record<string, number>
+  /** Per-NPC relationship-track points granted on quest completion. */
+  relationship?: Record<string, RelationshipGrant>
   unlock?: string
 }
+
+/** npcId -> track -> levelString -> line shown when that track is active. */
+export type RelationshipDialogue = Record<
+  string,
+  Partial<Record<RelationshipTrack, Record<string, string>>>
+>
 
 export interface HubQuestDef {
   id: string
@@ -87,6 +101,8 @@ export interface QuestReward {
   crystals?: number
 
   friendship?: FriendShip | undefined
+
+  relationship?: Record<string, RelationshipGrant>
 
   collectible?: {
     id: string
@@ -167,6 +183,7 @@ export interface QuestBlockedPaths {
 export type DialogueEffect =
   | { type: 'flag'; flag: string }              // persist a named dialogue flag
   | { type: 'friendship'; npcId?: string; xp: number }  // grant friendship XP (defaults to the speaking NPC)
+  | { type: 'relationship'; npcId?: string; track: RelationshipTrack; points: number }  // advance a relationship track (defaults to the speaking NPC)
   | { type: 'quest'; questId: string }          // offer a quest (Accept / Not now)
   | { type: 'end' }                             // end the conversation
 
@@ -196,6 +213,7 @@ export interface RawQuestConfig {
   pickupItems?: QuestPickupItem[]
   innRumours?: QuestInnRumour[]
   friendshipDialogue?: FriendshipDialogue
+  relationshipDialogue?: RelationshipDialogue
   blockedPaths?: QuestBlockedPaths[]
   // `dialogues` (DialogueTree[]) is read in loader.ts via an `as unknown` cast —
   // it is intentionally not declared here so the raw JSON (whose effect `type`

--- a/web/src/data/hub/questDefs.ts
+++ b/web/src/data/hub/questDefs.ts
@@ -102,7 +102,10 @@ export interface QuestReward {
 
   friendship?: FriendShip | undefined
 
-  relationship?: Record<string, RelationshipGrant>
+  // Raw JSON boundary: `track` stays `string` here so the literal config assigns
+  // without a union mismatch. The runtime `HubQuestReward.relationship` (read via
+  // an `as unknown` cast in loader.ts) narrows it back to `RelationshipGrant`.
+  relationship?: Record<string, { track: string; points: number } | undefined>
 
   collectible?: {
     id: string

--- a/web/src/data/hub/ravenwatch/questDefs.json
+++ b/web/src/data/hub/ravenwatch/questDefs.json
@@ -16,6 +16,36 @@
       "reward": { "crystals": 40, "friendship": { "fisherman": 15 } }
     },
     {
+      "id": "naia-allys-tome",
+      "title": "Naia's Trusted Errand",
+      "type": "fetch",
+      "giverNpcId": "scholar",
+      "receiverNpcId": "scholar",
+      "prerequisite": "relationship:scholar:ally:2",
+      "offerDialogue": "You have earned my trust, friend. A rare tome slipped from my satchel near the pond — only someone I rely on could fetch it discreetly. Will you?",
+      "activeDialogue": "The tome should be down by the pond's edge. I would be grateful to have it back.",
+      "completeDialogue": "You found it! I knew I could count on you. Allies like you are rarer than any book.",
+      "steps": [
+        { "key": "tome", "type": "collect", "pickupIds": ["naia-rare-tome"], "required": 1 }
+      ],
+      "reward": { "crystals": 60, "relationship": { "scholar": { "track": "ally", "points": 10 } } }
+    },
+    {
+      "id": "naia-rivals-gauntlet",
+      "title": "Naia's Gauntlet",
+      "type": "fetch",
+      "giverNpcId": "scholar",
+      "receiverNpcId": "scholar",
+      "prerequisite": "relationship:scholar:rival:2",
+      "offerDialogue": "So you fancy yourself my better? Prove it. My contested research glyph is hidden by the pond — retrieve it before I do, if you can keep up.",
+      "activeDialogue": "Still chasing my glyph by the pond? Tick tock, rival. I won't make this easy.",
+      "completeDialogue": "Hmph. You actually managed it. Do not let it go to your head — this rivalry is far from over.",
+      "steps": [
+        { "key": "glyph", "type": "collect", "pickupIds": ["naia-research-glyph"], "required": 1 }
+      ],
+      "reward": { "crystals": 60, "relationship": { "scholar": { "track": "rival", "points": 10 } } }
+    },
+    {
       "id": "wheres-rover",
       "title": "Where's Rover?",
       "type": "fetch",
@@ -101,6 +131,9 @@
         },
         "friendship": {
           "merchant": 20
+        },
+        "relationship": {
+          "merchant": { "track": "ally", "points": 12 }
         }
       }
     },
@@ -3427,6 +3460,8 @@
     }
   ],
   "pickupItems": [
+    { "id": "naia-rare-tome", "tx": 47, "ty": 56, "tileId": "pendant", "questId": "naia-allys-tome" },
+    { "id": "naia-research-glyph", "tx": 43, "ty": 52, "tileId": "yellow_crystal1", "questId": "naia-rivals-gauntlet" },
     { "id": "stray-fish-1", "tx": 48, "ty": 57, "tileId": "appleBasket", "questId": "feed-the-stray" },
     { "id": "stray-fish-2", "tx": 41, "ty": 51, "tileId": "appleBasket", "questId": "feed-the-stray" },
     { "id": "stray-fish-3", "tx": 46, "ty": 49, "tileId": "appleBasket", "questId": "feed-the-stray" },
@@ -5135,6 +5170,17 @@
       "2": "I do not forget those who help me. You have my respect, traveller."
     }
   },
+  "relationshipDialogue": {
+    "merchant": {
+      "ally": {
+        "2": "For a trusted ally like you, my friend, the best stock comes out from under the counter. Always.",
+        "3": "We have been through enough together that I'd vouch for you to any caravan on the road."
+      },
+      "rival": {
+        "2": "Back again? Every bargain with you is a duel. Do not expect me to blink first."
+      }
+    }
+  },
   "blockedPaths": [
     {
       "id": "forest-path-block",
@@ -5620,7 +5666,37 @@
             { "label": "Remind me — who are you?", "hideIfFlag": "scholar-greeted", "effects": [{ "type": "flag", "flag": "scholar-greeted" }], "next": "intro" },
             { "label": "Tell me about the Fracture.", "next": "lore" },
             { "label": "Anything I can help with nearby?", "next": "errand" },
+            { "label": "Where do we stand, you and I?", "next": "regard" },
             { "label": "Just saying hello.", "effects": [{ "type": "friendship", "npcId": "scholar", "xp": 5 }, { "type": "flag", "flag": "scholar-greeted" }], "next": "hello" }
+          ]
+        },
+        "regard": {
+          "text": "An interesting question. How do you mean to treat me, wanderer?",
+          "choices": [
+            { "label": "As a trusted friend.", "effects": [{ "type": "relationship", "npcId": "scholar", "track": "ally", "points": 4 }], "next": "regard-ally" },
+            { "label": "As a worthy rival.", "effects": [{ "type": "relationship", "npcId": "scholar", "track": "rival", "points": 4 }], "next": "regard-rival" },
+            { "label": "As someone I admire.", "effects": [{ "type": "relationship", "npcId": "scholar", "track": "romance", "points": 4 }], "next": "regard-romance" }
+          ]
+        },
+        "regard-ally": {
+          "text": "Then a friend you shall be. Loyalty is worth more than any relic — keep it up and I may trust you with the work I share with no one else.",
+          "choices": [
+            { "label": "Again.", "next": "regard" },
+            { "label": "Farewell.", "effects": [{ "type": "end" }] }
+          ]
+        },
+        "regard-rival": {
+          "text": "A rival, is it? Good. Nothing sharpens the mind like someone snapping at its heels. Press me hard enough and I'll set you a real challenge.",
+          "choices": [
+            { "label": "Again.", "next": "regard" },
+            { "label": "Farewell.", "effects": [{ "type": "end" }] }
+          ]
+        },
+        "regard-romance": {
+          "text": "Admiration? You'll make an archivist blush. Keep talking like that and who knows where the evening reading might lead.",
+          "choices": [
+            { "label": "Again.", "next": "regard" },
+            { "label": "Farewell.", "effects": [{ "type": "end" }] }
           ]
         },
         "intro": {

--- a/web/src/game/hub/relationships.test.ts
+++ b/web/src/game/hub/relationships.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  addRelationshipPoints,
+  getRelationship,
+  getRelationshipLevel,
+  getRelationshipTrack,
+} from './relationships'
+
+// In-memory localStorage mock (tests run in node environment)
+const store = new Map<string, string>()
+beforeEach(() => {
+  store.clear()
+  globalThis.localStorage = {
+    getItem:    (k: string) => store.get(k) ?? null,
+    setItem:    (k: string, v: string) => { store.set(k, v) },
+    removeItem: (k: string) => { store.delete(k) },
+    clear:      () => { store.clear() },
+    key:        (i: number) => [...store.keys()][i] ?? null,
+    get length() { return store.size },
+  } as Storage
+})
+
+describe('relationships default state', () => {
+  it('returns an empty entry for an unknown npc', () => {
+    const rel = getRelationship('nobody')
+    expect(rel.track).toBeNull()
+    expect(rel.level).toBe(0)
+    expect(rel.points).toEqual({ ally: 0, rival: 0, romance: 0 })
+  })
+})
+
+describe('addRelationshipPoints', () => {
+  it('accumulates points and sets the dominant track', () => {
+    addRelationshipPoints('elder', 'ally', 4)
+    expect(getRelationshipTrack('elder')).toBe('ally')
+    expect(getRelationship('elder').points.ally).toBe(4)
+  })
+
+  it('derives level from the dominant track total (mirrors friendship ladder)', () => {
+    addRelationshipPoints('elder', 'ally', 4)
+    expect(getRelationshipLevel('elder')).toBe(1) // any points => level 1 ("met")
+    addRelationshipPoints('elder', 'ally', 6)      // total 10 => level 2
+    expect(getRelationshipLevel('elder')).toBe(2)
+    addRelationshipPoints('elder', 'ally', 15)     // total 25 => level 3
+    expect(getRelationshipLevel('elder')).toBe(3)
+  })
+
+  it('switches the dominant track when another overtakes it', () => {
+    addRelationshipPoints('merchant', 'ally', 10)
+    expect(getRelationshipTrack('merchant')).toBe('ally')
+    addRelationshipPoints('merchant', 'rival', 12)
+    expect(getRelationshipTrack('merchant')).toBe('rival')
+    expect(getRelationshipLevel('merchant')).toBe(2) // 12 pts => level 2
+  })
+
+  it('keeps the current track on a tie (stable steering)', () => {
+    addRelationshipPoints('rosie', 'ally', 10)
+    addRelationshipPoints('rosie', 'romance', 10)
+    expect(getRelationshipTrack('rosie')).toBe('ally')
+  })
+
+  it('persists across loads', () => {
+    addRelationshipPoints('naia', 'romance', 30)
+    expect(getRelationshipTrack('naia')).toBe('romance')
+    expect(getRelationshipLevel('naia')).toBe(3) // 30 pts => level 3
+  })
+})

--- a/web/src/game/hub/relationships.ts
+++ b/web/src/game/hub/relationships.ts
@@ -1,0 +1,96 @@
+const KEY = 'jarv_hub_relationships'
+
+// Same ladder as friendship (see friendship.ts) — points needed to reach levels 1-4.
+const POINT_THRESHOLDS = [0, 10, 25, 50, 100]
+
+export type RelationshipTrack = 'ally' | 'rival' | 'romance'
+
+export const RELATIONSHIP_TRACKS: RelationshipTrack[] = ['ally', 'rival', 'romance']
+
+export interface RelationshipEntry {
+  /** Dominant track — the one with the most points (null until any points earned). */
+  track: RelationshipTrack | null
+  /** 0-4, derived from the dominant track's point total. */
+  level: number
+  /** Accumulated points per track. */
+  points: Record<RelationshipTrack, number>
+}
+
+type RelationshipStore = Record<string, RelationshipEntry>
+
+function emptyEntry(): RelationshipEntry {
+  return { track: null, level: 0, points: { ally: 0, rival: 0, romance: 0 } }
+}
+
+function load(): RelationshipStore {
+  try {
+    const raw = localStorage.getItem(KEY)
+    return raw ? (JSON.parse(raw) as RelationshipStore) : {}
+  } catch {
+    return {}
+  }
+}
+
+function save(store: RelationshipStore): void {
+  try {
+    localStorage.setItem(KEY, JSON.stringify(store))
+  } catch { /* ignore */ }
+}
+
+function levelForPoints(points: number): number {
+  let level = 0
+  while (level < POINT_THRESHOLDS.length && points >= POINT_THRESHOLDS[level]) {
+    level += 1
+  }
+  return level
+}
+
+/** Recompute the dominant track + level from the per-track point totals. */
+function recompute(entry: RelationshipEntry): RelationshipEntry {
+  let dominant: RelationshipTrack | null = entry.track
+  let best = dominant ? entry.points[dominant] : 0
+  for (const track of RELATIONSHIP_TRACKS) {
+    // Strictly greater so ties keep the current dominant track (stable steering).
+    if (entry.points[track] > best) {
+      best = entry.points[track]
+      dominant = track
+    }
+  }
+  entry.track = best > 0 ? dominant : null
+  entry.level = entry.track ? levelForPoints(entry.points[entry.track]) : 0
+  return entry
+}
+
+export function getRelationshipData(): Record<string, RelationshipEntry> {
+  return load()
+}
+
+export function getRelationship(npcId: string): RelationshipEntry {
+  return load()[npcId] ?? emptyEntry()
+}
+
+export function getRelationshipTrack(npcId: string): RelationshipTrack | null {
+  return load()[npcId]?.track ?? null
+}
+
+export function getRelationshipLevel(npcId: string): number {
+  return load()[npcId]?.level ?? 0
+}
+
+/**
+ * Add points to one of an NPC's relationship tracks, recompute the dominant
+ * track + level, and persist. Returns the updated entry.
+ */
+export function addRelationshipPoints(
+  npcId: string,
+  track: RelationshipTrack,
+  points: number,
+): RelationshipEntry {
+  const store = load()
+  const entry = store[npcId] ?? emptyEntry()
+  entry.points[track] = (entry.points[track] ?? 0) + points
+  recompute(entry)
+  store[npcId] = entry
+  save(store)
+  return entry
+}

--- a/web/src/game/hub/relationships.ts
+++ b/web/src/game/hub/relationships.ts
@@ -61,6 +61,21 @@ function recompute(entry: RelationshipEntry): RelationshipEntry {
   return entry
 }
 
+/** Max level reachable (length of the threshold ladder). */
+export const MAX_RELATIONSHIP_LEVEL = POINT_THRESHOLDS.length
+
+/**
+ * Progress of the dominant track toward the next level. `nextThreshold` is null
+ * once the max level is reached. Pure — safe to call from view components.
+ */
+export function relationshipProgress(
+  entry: RelationshipEntry,
+): { points: number; nextThreshold: number | null } {
+  const points = entry.track ? entry.points[entry.track] : 0
+  const nextThreshold = POINT_THRESHOLDS[entry.level] ?? null
+  return { points, nextThreshold }
+}
+
 export function getRelationshipData(): Record<string, RelationshipEntry> {
   return load()
 }


### PR DESCRIPTION
Implements the Hub relationship-tracks epic (#1613) and its three sub-issues:

- **#1658** — `relationships.ts`: per-NPC ally / rival / romance tracks with points, dominant track, and level, persisted to localStorage. Additive — existing `friendship.ts` tiers are untouched.
- **#1662** — track advancement via per-tap dialogue choices **and** quest/gift rewards; track-gated dialogue/quests via a new `relationship:<npc>:<track>:<level>` prerequisite.
- **#1665** — a per-NPC relationship view modal (reachable from the Town Directory rows) showing track, level, and hints, with Storybook stories.

Example content authored in Ravenwatch: one NPC steerable down two tracks, each unlocking distinct track-gated quests/dialogue.

## Acceptance criteria
- [x] An NPC can be steered down at least two different tracks, unlocking track-specific dialogue/quests
- [x] State persists; existing friendship tiers remain intact
- [ ] `npm run build` + tests pass (verified before merge)

Work in progress — pushing in small steps.

https://claude.ai/code/session_0153KfAwoUYnvtA9mWM3rWxQ

---
_Generated by [Claude Code](https://claude.ai/code/session_0153KfAwoUYnvtA9mWM3rWxQ)_