### PR TITLE
Move hub minimap to the bottom-left corner

### DIFF
--- a/web/src/components/hub/HubMinimap.tsx
+++ b/web/src/components/hub/HubMinimap.tsx
@@ -222,8 +222,8 @@ export function HubMinimap({ locationData, objectives, playerRef, viewportRef }:
       <div
         style={{
           position:      'absolute',
-          top:           48,
-          right:         12,
+          bottom:        12,
+          left:          12,
           zIndex:        20,
           pointerEvents: 'none',
         }}


### PR DESCRIPTION
## What
Moves the hub minimap overlay from the **top-right** to the **bottom-left** corner, as requested.

Single change in `HubMinimap.tsx`: the corner container's positioning goes from `top: 48; right: 12` to `bottom: 12; left: 12`. The off-screen edge arrow and toggle button are unaffected (the arrow positions relative to the whole map; the toggle stays in the minimap's corner). Bottom-left is clear of the bottom-right area-name badge and the bottom-centre dialogue.

## Testing
- `cd web && npm run build` passes.

https://claude.ai/code/session_014q6YieiapPX2CH8GpTGV6h

---
_Generated by [Claude Code](https://claude.ai/code/session_014q6YieiapPX2CH8GpTGV6h)_