### PR TITLE
Give Ravenwatch duplicate-named NPCs unique names

### DIFF
--- a/web/src/data/hub/ravenwatch/config.json
+++ b/web/src/data/hub/ravenwatch/config.json
@@ -6848,7 +6848,7 @@
     },
     {
       "id": "scholar",
-      "name": "Archivist Naia",
+      "name": "Loremaster Caelen",
       "sprite": "hub-npc-scholar",
       "tx": 58,
       "ty": 8,
@@ -7206,8 +7206,8 @@
       ]
     },
     {
-      "id": "achievements-keeper",
-      "name": "The Chronicler",
+      "id": "achievements-keeper-int",
+      "name": "Hall Keeper Mabon",
       "sprite": "hub-npc-elder",
       "building": "arcade-building-e",
       "tx": 6,
@@ -7592,7 +7592,7 @@
     },
     {
       "id": "marble-master-int",
-      "name": "Marble Master",
+      "name": "Aggie the Roller",
       "sprite": "hub-npc-dealer",
       "building": "arcade-building-e",
       "tx": 8,
@@ -7605,7 +7605,7 @@
     },
     {
       "id": "the-flipper-int",
-      "name": "The Flipper",
+      "name": "Tilt Tomas",
       "sprite": "hub-npc-merchant",
       "building": "arcade-building-e",
       "tx": 4,
@@ -7618,7 +7618,7 @@
     },
     {
       "id": "crystal-keeper-int",
-      "name": "Crystal Keeper",
+      "name": "Geode Greta",
       "sprite": "hub-npc-scholar",
       "building": "arcade-building-e",
       "tx": 6,
@@ -7631,7 +7631,7 @@
     },
     {
       "id": "prize-keeper-int",
-      "name": "Prize Keeper",
+      "name": "Token Tess",
       "sprite": "hub-npc-merchant",
       "building": "arcade-building-e",
       "tx": 2,
@@ -7644,7 +7644,7 @@
     },
     {
       "id": "spinner-sal-int",
-      "name": "Spinner Sal",
+      "name": "Wheelwright Wyn",
       "sprite": "hub-npc-dealer",
       "building": "arcade-building-w",
       "tx": 2,
@@ -7657,7 +7657,7 @@
     },
     {
       "id": "race-marshal-int",
-      "name": "Race Marshal",
+      "name": "Lap Judge Lorn",
       "sprite": "hub-npc-arena",
       "building": "arcade-building-w",
       "tx": 10,
@@ -7670,7 +7670,7 @@
     },
     {
       "id": "card-sharp-int",
-      "name": "Card Sharp",
+      "name": "Dealer Dax",
       "sprite": "hub-npc-merchant",
       "building": "arcade-building-w",
       "tx": 5,
@@ -7683,7 +7683,7 @@
     },
     {
       "id": "reels-remy-int",
-      "name": "Reels Remy",
+      "name": "Jackpot Juno",
       "sprite": "hub-npc-dealer",
       "building": "arcade-building-w",
       "tx": 2,
@@ -7696,7 +7696,7 @@
     },
     {
       "id": "poker-pete-int",
-      "name": "Poker Pete",
+      "name": "Bluff Bessa",
       "sprite": "hub-npc-dealer",
       "building": "arcade-building-w",
       "tx": 9,

--- a/web/src/data/hub/ravenwatch/questDefs.json
+++ b/web/src/data/hub/ravenwatch/questDefs.json
@@ -5624,7 +5624,7 @@
           ]
         },
         "intro": {
-          "text": "Archivist Naia. I keep Ravenwatch's records — and its secrets, when they will hold still long enough to be written down.",
+          "text": "Loremaster Caelen. I tend the gate-side archives — and keep half an eye on who passes through, when the ledgers will hold still long enough to be written.",
           "choices": [
             { "label": "Good to know.", "next": "greet" }
           ]


### PR DESCRIPTION
## What

Fixes the confusion where a quest sends you to a named NPC but the one you walk up to isn't the right one — caused by two *different* NPCs sharing a display name.

Only **Ravenwatch** had within-town duplicate names. After triage:

### The real culprit — Archivist Naia
Two different NPCs were both "Archivist Naia":
- `naia-interior` (scholars' hall) — the actual quest NPC (gives/receives ~12 quests, delivery target for many).
- `scholar` (the gate) — gives no quests.

A quest saying "take this to Archivist Naia" wouldn't progress if you approached the gate NPC. Renamed the gate NPC to **Loremaster Caelen** (and updated its dialogue-tree intro line); `naia-interior` stays the canonical "Archivist Naia."

### Arcade/casino copies
Each minigame host appeared twice (plaza + inside the arcade) under one name. Per request, these are now distinct characters rather than duplicates:

| Original | Interior copy renamed to |
|---|---|
| Marble Master | Aggie the Roller |
| The Flipper | Tilt Tomas |
| Crystal Keeper | Geode Greta |
| Prize Keeper | Token Tess |
| Spinner Sal | Wheelwright Wyn |
| Race Marshal | Lap Judge Lorn |
| Card Sharp | Dealer Dax |
| Reels Remy | Jackpot Juno |
| Poker Pete | Bluff Bessa |
| The Chronicler (`achievements-keeper`) | Hall Keeper Mabon |

The exterior originals keep their canonical names. The two `achievements-keeper` entries also shared the **same id** — the interior copy now has a unique id (`achievements-keeper-int`), fixing a latent collision.

No quest data, NPC ids (other than the achievements fix), screens, or dialogue logic changed — only display names (and one intro line). Friendship/quest wiring keys off ids, which are untouched.

## Testing
- `npm test` — loader tests pass
- `npm run build` — clean
- Verified: zero duplicate NPC names and zero duplicate ids remain in Ravenwatch.

https://claude.ai/code/session_01JmQvMcKSgxrhSUmMkpAzYJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01JmQvMcKSgxrhSUmMkpAzYJ)_