### PR TITLE
Fix quest tracker showing internal ids instead of NPC names for deliver steps

### DIFF
--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -142,7 +142,9 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onEndless, onWorldMap
   const { gameHour, isNight: isGameNight } = useHubClock()
 
   function getNpcDisplayName(npcId: string): string {
-    return locationData.HUB_NPCS.find(n => n.id === npcId)?.name ?? npcId
+    return locationData.HUB_NPCS.find(n => n.id === npcId)?.name
+      ?? locationData.HUB_ANIMALS.find(a => a.id === npcId)?.name
+      ?? npcId
   }
 
 
@@ -925,7 +927,7 @@ function tryOfferQuest(giverId: string, speakerName: string, onlyQuestId?: strin
           />
         )}
 
-        {questsOpen && <QuestsModal onClose={() => setQuestsOpen(false)} onAbandon={handleQuestAbandon} questDefs={questDefs}/>}
+        {questsOpen && <QuestsModal onClose={() => setQuestsOpen(false)} onAbandon={handleQuestAbandon} questDefs={questDefs} resolveNpcName={getNpcDisplayName}/>}
         {directoryOpen && <TownDirectory onClose={() => setDirectoryOpen(false)} locationData={locationData} pinnedNpcId={pinnedNpcId} onTogglePin={togglePinnedNpc} onShowRelationship={setRelationshipNpcId} />}
         {relationshipNpcId && <RelationshipView npcName={getNpcDisplayName(relationshipNpcId)} entry={getRelationship(relationshipNpcId)} onClose={() => setRelationshipNpcId(null)} />}
         {openTreasure && <TreasureModal treasure={openTreasure} onClose={() => setOpenTreasure(null)} />}

--- a/web/src/components/hub/QuestsModal.tsx
+++ b/web/src/components/hub/QuestsModal.tsx
@@ -7,11 +7,23 @@ interface Props {
   onClose: () => void
   onAbandon: (questId: string) => void
   questDefs: HubQuestDef[]
+  /** Resolve an NPC/animal id to its display name (for deliver-step labels). */
+  resolveNpcName?: (id: string) => string
 }
 
 function progressDots(current: number, required: number): string {
   const filled = Math.min(current, required)
   return '●'.repeat(filled) + '○'.repeat(Math.max(0, required - filled))
+}
+
+/** Human-readable label for a quest objective. Deliver steps name their target
+ *  NPC so it matches the character you actually see in the world; other steps
+ *  fall back to a title-cased version of the step key. */
+function stepLabel(step: HubQuestDef['steps'][number], resolveNpcName: (id: string) => string): string {
+  if (step.type === 'deliver' && step.targetNpcId) {
+    return `Deliver to ${resolveNpcName(step.targetNpcId)}`
+  }
+  return step.key.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase())
 }
 
 function getActiveHint(quest: HubQuestDef): string {
@@ -25,7 +37,7 @@ function getActiveHint(quest: HubQuestDef): string {
   return Object.values(activeDialogue)[Object.values(activeDialogue).length - 1] || "Hello"
 }
 
-export function QuestsModal({ onClose, onAbandon, questDefs }: Props) {
+export function QuestsModal({ onClose, onAbandon, questDefs, resolveNpcName = (id) => id }: Props) {
   const [confirmingId, setConfirmingId] = useState<string | null>(null)
 
   const active    = questDefs.filter(q => getQuestState(q.id).status === 'active')
@@ -63,7 +75,7 @@ export function QuestsModal({ onClose, onAbandon, questDefs }: Props) {
                 </div>
                 {quest.steps.map(step => {
                   const current = getQuestProgress(quest.id, step.key)
-                  const label   = step.key.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase())
+                  const label   = stepLabel(step, resolveNpcName)
                   return (
                     <div key={step.key} className="quests-modal__step">
                       <span>{label}</span>


### PR DESCRIPTION
## Problem

Doing **"Rallying the town"**, the quest tracker lists delivery objectives whose names don't match any NPC you can find — e.g. "Deliver Fisherman" and "Deliver Dealer", when the NPCs in the world are **Old Greyfish** and **Vince the Dealer**.

## Cause

`QuestsModal` built every objective label from the raw `step.key` (`step.key.replace(/-/g,' ')…`). For deliver steps the keys are `deliver-fisherman`, `deliver-dealer`, etc., so the tracker showed the internal id fragment instead of the NPC's display name. This affected **all** deliver-step quests, not just this one.

## Fix

Deliver steps now render **"Deliver to &lt;NPC display name&gt;"**, resolved from `step.targetNpcId`:
- `QuestsModal` takes an optional `resolveNpcName` prop (identity fallback, so the Storybook story is unaffected).
- `HubWorld` passes `getNpcDisplayName`, now extended to resolve animals as well as NPCs (some deliver targets are animals).

For "Rallying the town" the tracker now reads:
- Collect Messages
- Deliver to Guild Master Ferryn
- Deliver to Innkeeper Rosie
- Deliver to Vince the Dealer
- Deliver to Old Greyfish

…which match the characters you actually visit. The quest *data* was already correct; only the tracker's display label changed.

## Testing
- `npm run build` — clean
- `tsc --noEmit` — clean
- Verified the four Ravenwatch deliver targets resolve to the expected display names.

https://claude.ai/code/session_01JmQvMcKSgxrhSUmMkpAzYJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01JmQvMcKSgxrhSUmMkpAzYJ)_