### PR TITLE
Render hub minimap behind the dialogue overlay

### DIFF
--- a/web/src/components/hub/HubMinimap.tsx
+++ b/web/src/components/hub/HubMinimap.tsx
@@ -206,7 +206,7 @@ export function HubMinimap({ locationData, objectives, playerRef, viewportRef }:
             top:           `${arrow.fy * 100}%`,
             transform:     `translate(-50%, -50%) rotate(${arrow.angle}rad)`,
             pointerEvents: 'none',
-            zIndex:        19,
+            zIndex:        8,
             fontSize:      22,
             color:         '#e0b050',
             textShadow:    '0 0 6px rgba(0,0,0,0.8)',
@@ -224,7 +224,7 @@ export function HubMinimap({ locationData, objectives, playerRef, viewportRef }:
           position:      'absolute',
           bottom:        12,
           left:          12,
-          zIndex:        20,
+          zIndex:        9,        // below the dialogue overlay (z-index 10) so it doesn't cover it
           pointerEvents: 'none',
         }}
       >


### PR DESCRIPTION
## What
The bottom-left minimap shares space with the dialogue overlay (bottom-centre) and was covering it. This lowers the minimap below the dialogue.

The dialogue overlay (`HubDialogue`) sits at `z-index: 10`. The minimap container was at `z-index: 20` and its off-screen edge arrow at `19`, so both painted over the dialogue. Now the minimap is `z-index: 9` and the arrow `8` — both still above the map canvas (non-positioned), but below the dialogue, so the dialogue is never covered.

## Testing
- `cd web && npm run build` passes.

https://claude.ai/code/session_014q6YieiapPX2CH8GpTGV6h

---
_Generated by [Claude Code](https://claude.ai/code/session_014q6YieiapPX2CH8GpTGV6h)_