### PR TITLE
Fix delivering to a screen NPC opening its minigame instead of registering the quest step

### DIFF
--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -650,31 +650,45 @@ function tryOfferQuest(giverId: string, speakerName: string, onlyQuestId?: strin
       }
     }
 
-    // ── Quest completion (receiver NPC tapped) ──────────────────────────────
+    // ── Quest delivery / completion (receiver NPC tapped) ───────────────────
     if (npcDef?.questReceive) {
       const receiveIds = Array.isArray(npcDef.questReceive) ? npcDef.questReceive : [npcDef.questReceive]
       for (const questId of receiveIds) {
         const quest = questDefs.find(q => q.id === questId)
-        if (quest && getQuestState(quest.id).status === 'active') {
-          for (const step of quest.steps) {
-            if (step.type === 'deliver' && step.targetNpcId === npcId) {
-              incrementQuestProgress(quest.id, step.key)
-              break
-            }
-          }
-          if (isQuestReadyToComplete(quest)) {
-            setQuestStatus(quest.id, 'completed')
-            grantQuestReward(quest)
-            if (quest.reward.crystals) onCrystalsChange?.(loadCrystals())
-            refreshState()
-            const rewardText = formatQuestReward(quest.reward)
-            setDialogueEvent({
-              speakerName,
-              text: quest.completeDialogue,
-              ...(rewardText ? { onClose: () => setDialogueEvent({ speakerName: '', text: rewardText }) } : {}),
-            })
-            return
-          }
+        if (!quest || getQuestState(quest.id).status !== 'active') continue
+
+        const completeQuest = () => {
+          setQuestStatus(quest.id, 'completed')
+          grantQuestReward(quest)
+          if (quest.reward.crystals) onCrystalsChange?.(loadCrystals())
+          refreshState()
+          const rewardText = formatQuestReward(quest.reward)
+          setDialogueEvent({
+            speakerName,
+            text: quest.completeDialogue,
+            ...(rewardText ? { onClose: () => setDialogueEvent({ speakerName: '', text: rewardText }) } : {}),
+          })
+        }
+
+        // Register a pending delivery addressed to this NPC (guarded so repeat
+        // taps don't over-count).
+        const pending = quest.steps.find(s =>
+          s.type === 'deliver' && s.targetNpcId === npcId &&
+          getQuestProgress(quest.id, s.key) < s.required)
+        if (pending) {
+          incrementQuestProgress(quest.id, pending.key)
+          refreshState()
+          if (isQuestReadyToComplete(quest)) completeQuest()
+          // Delivered but the quest still needs more — acknowledge so the player
+          // sees feedback instead of (e.g.) the NPC's screen opening silently.
+          else setDialogueEvent({ speakerName, text: getActiveDialogue(quest) })
+          return
+        }
+
+        // Nothing to deliver here, but the quest may be ready to hand in.
+        if (isQuestReadyToComplete(quest)) {
+          completeQuest()
+          return
         }
       }
     }

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -142,7 +142,9 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onEndless, onWorldMap
   const { gameHour, isNight: isGameNight } = useHubClock()
 
   function getNpcDisplayName(npcId: string): string {
-    return locationData.HUB_NPCS.find(n => n.id === npcId)?.name ?? npcId
+    return locationData.HUB_NPCS.find(n => n.id === npcId)?.name
+      ?? locationData.HUB_ANIMALS.find(a => a.id === npcId)?.name
+      ?? npcId
   }
 
 
@@ -925,7 +927,7 @@ function tryOfferQuest(giverId: string, speakerName: string, onlyQuestId?: strin
           />
         )}
 
-        {questsOpen && <QuestsModal onClose={() => setQuestsOpen(false)} onAbandon={handleQuestAbandon} questDefs={questDefs}/>}
+        {questsOpen && <QuestsModal onClose={() => setQuestsOpen(false)} onAbandon={handleQuestAbandon} questDefs={questDefs} resolveNpcName={getNpcDisplayName}/>}
         {directoryOpen && <TownDirectory onClose={() => setDirectoryOpen(false)} locationData={locationData} pinnedNpcId={pinnedNpcId} onTogglePin={togglePinnedNpc} onShowRelationship={setRelationshipNpcId} />}
         {relationshipNpcId && <RelationshipView npcName={getNpcDisplayName(relationshipNpcId)} entry={getRelationship(relationshipNpcId)} onClose={() => setRelationshipNpcId(null)} />}
         {openTreasure && <TreasureModal treasure={openTreasure} onClose={() => setOpenTreasure(null)} />}

--- a/web/src/components/hub/QuestsModal.tsx
+++ b/web/src/components/hub/QuestsModal.tsx
@@ -7,11 +7,23 @@ interface Props {
   onClose: () => void
   onAbandon: (questId: string) => void
   questDefs: HubQuestDef[]
+  /** Resolve an NPC/animal id to its display name (for deliver-step labels). */
+  resolveNpcName?: (id: string) => string
 }
 
 function progressDots(current: number, required: number): string {
   const filled = Math.min(current, required)
   return '●'.repeat(filled) + '○'.repeat(Math.max(0, required - filled))
+}
+
+/** Human-readable label for a quest objective. Deliver steps name their target
+ *  NPC so it matches the character you actually see in the world; other steps
+ *  fall back to a title-cased version of the step key. */
+function stepLabel(step: HubQuestDef['steps'][number], resolveNpcName: (id: string) => string): string {
+  if (step.type === 'deliver' && step.targetNpcId) {
+    return `Deliver to ${resolveNpcName(step.targetNpcId)}`
+  }
+  return step.key.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase())
 }
 
 function getActiveHint(quest: HubQuestDef): string {
@@ -25,7 +37,7 @@ function getActiveHint(quest: HubQuestDef): string {
   return Object.values(activeDialogue)[Object.values(activeDialogue).length - 1] || "Hello"
 }
 
-export function QuestsModal({ onClose, onAbandon, questDefs }: Props) {
+export function QuestsModal({ onClose, onAbandon, questDefs, resolveNpcName = (id) => id }: Props) {
   const [confirmingId, setConfirmingId] = useState<string | null>(null)
 
   const active    = questDefs.filter(q => getQuestState(q.id).status === 'active')
@@ -63,7 +75,7 @@ export function QuestsModal({ onClose, onAbandon, questDefs }: Props) {
                 </div>
                 {quest.steps.map(step => {
                   const current = getQuestProgress(quest.id, step.key)
-                  const label   = step.key.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase())
+                  const label   = stepLabel(step, resolveNpcName)
                   return (
                     <div key={step.key} className="quests-modal__step">
                       <span>{label}</span>


### PR DESCRIPTION
## Problem

During "Rallying the town", tapping **Vince the Dealer** (a delivery target) opens the casino minigame and appears not to progress the quest.

## Cause

`handleNpcTap` registered the delivery correctly, but in the `questReceive` block the `return`/completion only happened when the **whole quest** was ready. If the delivery didn't finish the quest, the handler fell through to the screen-navigation fallthrough — so the dealer's `screen: casino` opened, masking the fact that the step had progressed. Two issues:

1. **Screen fallthrough** — a mid-quest delivery to a screen NPC opened the screen instead of giving feedback.
2. **No progress guard** — every tap re-incremented the deliver step (`incrementQuestProgress` with no `progress < required` check).

## Fix

In the delivery/completion block:
- Only register a delivery when the step is still pending (`progress < required`) — repeat taps no longer over-count.
- After a delivery that *doesn't* complete the quest, show the active hint as acknowledgement and `return`, so a screen NPC no longer opens its screen.
- Still completes the quest when the final step lands, and still hands in at the receiver when all steps are already satisfied.

Net effect: tapping the dealer (or any screen NPC that's a delivery target) registers the message and gives feedback; once you've delivered, tapping again opens the casino as normal.

## Testing
- `tsc --noEmit` — clean
- `npm run build` — clean

https://claude.ai/code/session_01JmQvMcKSgxrhSUmMkpAzYJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01JmQvMcKSgxrhSUmMkpAzYJ)_