### PR TITLE
Hub: town reputation &amp; building upgrades (#1619)

### DIFF
--- a/docs/hubworld.md
+++ b/docs/hubworld.md
@@ -17,6 +17,8 @@
 | `web/src/game/hub/quests.ts` | Quest progress/status persistence (localStorage) | `getQuestState`, `setQuestStatus`, `incrementQuestProgress`, `getQuestProgress`, `resetQuest` |
 | `web/src/game/hub/pickups.ts` | Pickup state persistence (localStorage) | `getPickedUpIds`, `markPickedUp`, `isPickedUp`, `unmarkPickedUp` |
 | `web/src/game/hub/friendship.ts` | NPC friendship XP/level persistence (localStorage) | `getFriendshipLevel`, `addFriendshipXp`, `getFriendshipData` |
+| `web/src/game/hub/reputation.ts` | Per-town reputation + per-building upgrade levels (localStorage) — see §10 | `getTownReputation`, `getUpgradeLevel`, `nextUpgrade`, `purchaseUpgrade`, `getUnlockedServices`, `hasTownService` |
+| `web/src/data/hub/buildingUpgrades.json` / `.ts` | Shared upgrade tracks keyed by building *kind* (costs, benefits, services, decor) — see §10 | `getUpgradeTrack`, `getReputationTier`, `REPUTATION_TIERS` |
 | `web/src/game/hub/relationships.ts` | NPC relationship-track (ally/rival/romance) persistence (localStorage) — see §7c | `getRelationship`, `getRelationshipTrack`, `getRelationshipLevel`, `addRelationshipPoints`, `relationshipProgress` |
 | `web/src/game/hub/dialogueFlags.ts` | Branching-dialogue flag + "seen" branch persistence (localStorage) — see §7b | `setDialogueFlag`, `hasDialogueFlag`, `getDialogueFlags`, `markNodeSeen`, `hasNodeSeen` |
 | `web/src/game/hub/innConvos.ts` | Inn conversation tracking (localStorage) | `getHeardConvoIds`, `markConvoHeard`, `isConvoHeard` |
@@ -732,3 +734,80 @@ workflow in `AGENTS.md` (32×32 SVG, create/commit/push one at a time).
 3. Run `npm run test` (loader + schedule tests) and `npm run build`.
 4. Verify in-game: at the relevant hours the NPC is at its post in its activity
    pose; the pose reverts to the base sprite while it walks at an hour boundary.
+
+---
+
+## §10 — Town Reputation & Building Upgrades
+
+Towns gain a **reputation** (standing) value and their buildings gain **upgrade
+levels**. Reputation is *earned by investing crystals*: each upgrade purchase
+spends crystals, raises the town's reputation, and reputation in turn **gates the
+higher upgrade tiers**. Buying an upgrade reveals a **visible decor change** at the
+building and unlocks a labelled **service/benefit**. All state persists in
+localStorage.
+
+- Store: `web/src/game/hub/reputation.ts` (key `jarv_hub_reputation`).
+- Catalog: `web/src/data/hub/buildingUpgrades.json` (+ typed `.ts`).
+- UI: `web/src/components/hub/HubTownUpgrades.tsx`, opened from the 🏗️ toolbar
+  button in `HubWorld.tsx` or the `town-upgrades` screen route (so an interactable
+  with `{ "type": "screen", "screen": "town-upgrades" }` also opens it).
+- Decor rendering: `HubTownCanvas.tsx` (toggled per-frame against
+  `buildingUpgradeLevelsRef`, mirroring the §2 blocked-path decor pattern).
+
+### Making a building upgradeable
+
+Tag the building in its town `config.json` with an `upgradeKind` — the key of an
+upgrade track in `buildingUpgrades.json`:
+
+```jsonc
+{
+  "id": "cider-house",
+  "upgradeKind": "tavern",
+  "rect": [4, 2, 11, 8],
+  "wall": "woodWall", "roof": "redSlateRoof",
+  "doors": [ { "tx": 4, "ty": 1, "buildingId": "cider-house" } ]
+}
+```
+
+The building **must have a door** (decor is placed relative to its primary door
+tile). The display name in the panel comes from the building's interior `name`,
+falling back to a title-cased id.
+
+### Upgrade catalog schema (`buildingUpgrades.json`)
+
+Keyed by `kind`; each value is an ordered list of levels (level 1 first). Built-in
+kinds: `shop`, `inn`, `tavern`, `cottage`, `workshop`, `shrine`, `default`.
+
+| Field | Type | Description |
+|---|---|---|
+| `label` | string | Level title shown in the panel. |
+| `cost` | number | Crystals to purchase this level. |
+| `repReward` | number | Town reputation granted on purchase. |
+| `repRequired` | number | Town reputation needed before this level can be bought (the tier gate). |
+| `benefit` | string | One-line description of what the level unlocks. |
+| `service` | string? | Service id readable via `getUnlockedServices`/`hasTownService`. |
+| `decor` | `{dx,dy,tileId}[]`? | Decor revealed at this level, offset from the building's primary door. `tileId` is a `baseChipIndex.ts` constant name. |
+
+Reputation tiers/names live in `buildingUpgrades.ts` (`REPUTATION_TIERS`,
+`REPUTATION_TIER_NAMES`, `getReputationTier`).
+
+### Services
+
+`service` ids are **data only** today: nothing consumes them yet, but the unlocked
+benefit text is shown in the panel and other systems can read the unlocked set via
+`getUnlockedServices(town)` / `hasTownService(town, id)`. `HubWorld` registers the
+`upgradeKind` resolver with `setUpgradeKindResolver` so these reads work without
+importing the loader. The guaranteed visible change on purchase is the **decor**.
+
+### Authoring checklist: new upgrade track / upgradeable building
+
+1. (New kind only) Add a `kind` entry to `buildingUpgrades.json` with ordered
+   levels — escalating `cost`/`repRequired`, a `benefit`, and `decor` whose
+   `tileId`s exist in `baseChipIndex.ts`.
+2. Add `"upgradeKind": "<kind>"` to the building in its town `config.json`; ensure
+   the building has a `door`.
+3. Run `npm run test` (loader tests parse every config; `reputation.test.ts` covers
+   the store) and `npm run build`.
+4. Verify in-game: open 🏗️ Town Upgrades, buy a level → crystals drop, standing
+   rises, the new decor appears on the building immediately, a rep-locked tier
+   stays blocked until standing is high enough, and everything survives a reload.

--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -16,6 +16,8 @@ import { CommanderState } from '../../game/commander'
 import rollbar from '../../rollbar'
 import { HubInteractable, HubInteriorExit, HubLocationBundle, HubNpc, HubQuestBundle, HubStreetGroup, NpcScheduleEntry } from '../../data/hub/loader'
 import { createAnimalSystem, AnimalSystem } from './hubAnimals'
+import { BASE_CHIP_TILES } from '../../data/tiles/baseChipIndex'
+import { getUpgradeTrack } from '../../data/hub/buildingUpgrades'
 
 
 const T                 = 32
@@ -89,6 +91,8 @@ interface Props {
   interactableMovesRef?:      React.MutableRefObject<Map<string, { tx: number; ty: number }>>
   /** Receives a callback to reposition an interactable's sprites live */
   moveInteractableRef?:       React.MutableRefObject<((id: string, tx: number, ty: number) => void) | null>
+  /** buildingId → purchased upgrade level; reveals unlocked decor live */
+  buildingUpgradeLevelsRef?:  React.MutableRefObject<Record<string, number>>
   locationData:         HubLocationBundle
   questData: HubQuestBundle
   /** Scroll container whose scroll position drives the camera. When set, the
@@ -104,6 +108,7 @@ export function HubTownCanvas({
   completedQuestIdsRef, collectedTreasureIds, onTreasureStep,
   gameHour, isNight, npcProximityDialogue,
   onInteractableTap, interactableIndicatorsRef, interactableMovesRef, moveInteractableRef,
+  buildingUpgradeLevelsRef,
   locationData,
   questData,
   viewportRef
@@ -685,6 +690,39 @@ export function HubTownCanvas({
         }
 
         blockedPathEntries.set(bp.id, entry)
+      }
+    }
+
+    // ── Building upgrade decor (revealed as the player upgrades buildings) ─────
+    // Each upgrade level may add decor at offsets relative to the building's
+    // primary door tile. Sprites are created once and toggled each frame against
+    // buildingUpgradeLevelsRef (mirrors the blocked-path visibility pattern).
+    const upgradeDecorSprites: { buildingId: string; levelIndex: number; sprite: PIXI.Sprite }[] = []
+    {
+      for (const b of HUB_BUILDINGS) {
+        if (!b.id || !b.upgradeKind) continue
+        const door = HUB_DOORS.find(d => d.buildingId === b.id)
+        if (!door) continue
+        const track = getUpgradeTrack(b.upgradeKind)
+        const currentLevel = buildingUpgradeLevelsRef?.current[b.id] ?? 0
+        track.forEach((lvl, levelIndex) => {
+          for (const d of lvl.decor ?? []) {
+            const tileId = (BASE_CHIP_TILES as Record<string, number>)[d.tileId]
+            if (tileId == null) continue
+            const tx = door.tx + d.dx
+            const ty = door.ty + d.dy
+            const buildingId = b.id as string
+            loadTileRef(tileId).then(tex => {
+              if (app.renderer == null) return
+              const s = new PIXI.Sprite(tex)
+              s.position.set(tx * T, ty * T)
+              s.width = T; s.height = T
+              s.visible = currentLevel >= levelIndex + 1
+              belowAvatarLayer.addChild(s)
+              upgradeDecorSprites.push({ buildingId, levelIndex, sprite: s })
+            }).catch(() => {})
+          }
+        })
       }
     }
 
@@ -2305,6 +2343,14 @@ export function HubTownCanvas({
               }
               n.lastBubbleText = newText
             }
+          }
+        }
+
+        // Building upgrade decor visibility (reveals on purchase)
+        if (upgradeDecorSprites.length > 0) {
+          const levels = buildingUpgradeLevelsRef?.current ?? {}
+          for (const u of upgradeDecorSprites) {
+            u.sprite.visible = (levels[u.buildingId] ?? 0) >= u.levelIndex + 1
           }
         }
       }

--- a/web/src/components/hub/HubTownUpgrades.stories.tsx
+++ b/web/src/components/hub/HubTownUpgrades.stories.tsx
@@ -1,0 +1,56 @@
+import { fn } from 'storybook/test'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { HubTownUpgrades, type UpgradeRow } from './HubTownUpgrades'
+import { getUpgradeTrack } from '../../data/hub/buildingUpgrades'
+
+const shop = getUpgradeTrack('shop')
+const inn = getUpgradeTrack('inn')
+
+const rows: UpgradeRow[] = [
+  // Affordable next level.
+  {
+    buildingId: 'card-shop', name: 'The Card Emporium', kind: 'shop', level: 1, total: shop.length,
+    next: { def: shop[1], level: 1, total: shop.length, cost: shop[1].cost, repRequired: shop[1].repRequired, repLocked: false, maxed: false },
+  },
+  // Reputation-locked next level.
+  {
+    buildingId: 'inn', name: 'The Wayfarer Inn', kind: 'inn', level: 1, total: inn.length,
+    next: { def: inn[1], level: 1, total: inn.length, cost: inn[1].cost, repRequired: inn[1].repRequired, repLocked: true, maxed: false },
+  },
+  // Fully upgraded.
+  {
+    buildingId: 'shrine', name: 'The Old Shrine', kind: 'shrine', level: 3, total: 3,
+    next: { def: null, level: 3, total: 3, cost: 0, repRequired: 0, repLocked: false, maxed: true },
+  },
+]
+
+const meta = {
+  component: HubTownUpgrades,
+  parameters: { layout: 'fullscreen' },
+  decorators: [(Story) => (<div className="game-container"><Story /></div>)],
+} satisfies Meta<typeof HubTownUpgrades>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    onClose:    fn(),
+    townName:   'Ravenwatch',
+    reputation: 80,
+    crystals:   500,
+    rows,
+    onUpgrade:  fn(),
+  },
+}
+
+export const Broke: Story = {
+  args: {
+    onClose:    fn(),
+    townName:   'Ravenwatch',
+    reputation: 80,
+    crystals:   10,
+    rows,
+    onUpgrade:  fn(),
+  },
+}

--- a/web/src/components/hub/HubTownUpgrades.tsx
+++ b/web/src/components/hub/HubTownUpgrades.tsx
@@ -1,0 +1,115 @@
+import React from 'react'
+import { ModalBackdrop } from '../ui/ModalBackdrop'
+import {
+  REPUTATION_TIERS,
+  REPUTATION_TIER_NAMES,
+  getReputationTier,
+  getUpgradeTrack,
+} from '../../data/hub/buildingUpgrades'
+import type { NextUpgrade } from '../../game/hub/reputation'
+
+/** One upgradeable building, pre-resolved by HubWorld. Pure-visual: props only. */
+export interface UpgradeRow {
+  buildingId: string
+  name: string
+  kind: string
+  level: number
+  total: number
+  next: NextUpgrade
+}
+
+interface Props {
+  onClose:    () => void
+  townName:   string
+  reputation: number
+  crystals:   number
+  rows:       UpgradeRow[]
+  onUpgrade:  (buildingId: string) => void
+}
+
+function reputationToNextTier(rep: number): { tier: number; label: string; progress: string } {
+  const tier = getReputationTier(rep)
+  const nextThreshold = REPUTATION_TIERS[tier + 1]
+  const label = REPUTATION_TIER_NAMES[tier]
+  const progress = nextThreshold !== undefined
+    ? `${rep} / ${nextThreshold} to ${REPUTATION_TIER_NAMES[tier + 1]}`
+    : `${rep} (max standing)`
+  return { tier, label, progress }
+}
+
+export function HubTownUpgrades({ onClose, townName, reputation, crystals, rows, onUpgrade }: Props) {
+  const rep = reputationToNextTier(reputation)
+
+  return (
+    <ModalBackdrop onClose={onClose}>
+      <div className="town-directory town-upgrades">
+        <div className="town-directory__header">
+          <span>🏗️ {townName} — Standing &amp; Upgrades</span>
+          <span className="town-directory__meta">
+            💎 {crystals.toLocaleString()}
+            <button className="town-directory__close" onClick={onClose}>✕</button>
+          </span>
+        </div>
+
+        <div className="town-upgrades__rep">
+          <span className="town-upgrades__rep-tier">⭐ {rep.label}</span>
+          <span className="town-upgrades__rep-prog">{rep.progress}</span>
+        </div>
+
+        {rows.length === 0 ? (
+          <div className="town-directory__empty">No upgradeable buildings here yet.</div>
+        ) : (
+          <div className="town-directory__list">
+            {rows.map(row => {
+              const { next } = row
+              const track = getUpgradeTrack(row.kind)
+              const currentBenefit = row.level > 0 ? track[row.level - 1]?.benefit : null
+
+              let btnLabel = 'Upgrade'
+              let disabled = false
+              let reason: string | null = null
+              if (next.maxed || !next.def) {
+                btnLabel = 'Fully upgraded'; disabled = true
+              } else if (next.repLocked) {
+                btnLabel = `🔒 Needs ${next.repRequired} standing`; disabled = true
+                reason = `Raise the town's standing to ${next.repRequired}.`
+              } else if (crystals < next.cost) {
+                btnLabel = `💎 ${next.cost}`; disabled = true
+                reason = 'Not enough crystals.'
+              } else {
+                btnLabel = `Upgrade · 💎 ${next.cost}`
+              }
+
+              return (
+                <div key={row.buildingId} className="town-directory__row">
+                  <div className="town-directory__info">
+                    <span className="town-directory__name">
+                      {row.name} <span className="town-upgrades__lvl">Lv {row.level}/{row.total}</span>
+                    </span>
+                    {currentBenefit && (
+                      <span className="town-directory__place">✓ {currentBenefit}</span>
+                    )}
+                    {next.def && (
+                      <span className="town-upgrades__next">
+                        → <strong>{next.def.label}</strong>: {next.def.benefit}
+                      </span>
+                    )}
+                    {reason && <span className="town-upgrades__reason">{reason}</span>}
+                  </div>
+                  <button
+                    className="action-btn action-btn--gold town-upgrades__btn"
+                    disabled={disabled}
+                    onClick={() => onUpgrade(row.buildingId)}
+                    title={next.def?.label ?? 'Fully upgraded'}
+                  >
+                    {btnLabel}
+                  </button>
+                </div>
+              )
+            })}
+          </div>
+        )}
+      </div>
+    </ModalBackdrop>
+  )
+}

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -976,6 +976,7 @@ function tryOfferQuest(giverId: string, speakerName: string, onlyQuestId?: strin
             interactableIndicatorsRef={indicatorConditionsRef}
             interactableMovesRef={interactableMovesRef}
             moveInteractableRef={moveInteractableRef}
+            buildingUpgradeLevelsRef={buildingUpgradeLevelsRef}
             locationData={locationData}
             questData={ALL_QUESTS}
             viewportRef={scrollRef}

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -30,6 +30,8 @@ import { LoginButton } from '../ui/LoginButton'
 import { addCollectible, addConsumable, getCollectibles } from '../../game/itemStore'
 import { QuestsModal } from './QuestsModal'
 import { TownDirectory } from './TownDirectory'
+import { HubTownUpgrades, type UpgradeRow } from './HubTownUpgrades'
+import { nextUpgrade, purchaseUpgrade, getTownReputation, getUpgradeLevel, setUpgradeKindResolver } from '../../game/hub/reputation'
 import { RelationshipView } from './RelationshipView'
 import { resolveNpcPlace } from '../../game/hub/npcLocator'
 import { TreasureModal } from './TreasureModal'
@@ -131,6 +133,10 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onEndless, onWorldMap
   const [pickedUpIds,    setPickedUpIds]    = useState<Set<string>>(() => getPickedUpIds())
   const [questsOpen,          setQuestsOpen]          = useState(false)
   const [directoryOpen,       setDirectoryOpen]       = useState(false)
+  const [upgradesOpen,        setUpgradesOpen]        = useState(false)
+  // buildingId → purchased upgrade level; read each frame by the canvas to
+  // reveal unlocked decor live, and updated on purchase.
+  const buildingUpgradeLevelsRef = useRef<Record<string, number>>({})
   const [relationshipNpcId,   setRelationshipNpcId]   = useState<string | null>(null)
   const [pinnedNpcId,         setPinnedNpcId]         = useState<string | null>(null)
   const [openTreasure,        setOpenTreasure]        = useState<HubTreasure | null>(null)
@@ -138,6 +144,49 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onEndless, onWorldMap
   // Refresh friendship/quest state after interactions (lightweight — just reads localStorage)
   const [_tick, setTick] = useState(0)
   const refreshState = useCallback(() => setTick(t => t + 1), [])
+
+  // ── Town reputation & building upgrades ───────────────────────────────────
+  const town = locationData.HUB_TOWN_NAME
+  // Register how the reputation store resolves a building's upgrade kind, and
+  // seed the canvas decor ref with each building's current upgrade level.
+  useEffect(() => {
+    setUpgradeKindResolver((_t, buildingId) =>
+      locationData.HUB_BUILDINGS.find(b => b.id === buildingId)?.upgradeKind)
+    const levels: Record<string, number> = {}
+    for (const b of locationData.HUB_BUILDINGS) {
+      if (b.id && b.upgradeKind) levels[b.id] = getUpgradeLevel(town, b.id)
+    }
+    buildingUpgradeLevelsRef.current = levels
+    return () => setUpgradeKindResolver(null)
+  }, [locationData, town])
+
+  // Upgradeable buildings, resolved fresh each render (cheap — a handful).
+  const upgradeRows: UpgradeRow[] = locationData.HUB_BUILDINGS
+    .filter(b => b.id && b.upgradeKind)
+    .map(b => {
+      const id = b.id as string
+      const name = locationData.HUB_INTERIORS[id]?.name
+        ?? id.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase())
+      const next = nextUpgrade(town, id, b.upgradeKind)
+      return { buildingId: id, name, kind: b.upgradeKind as string, level: next.level, total: next.total, next }
+    })
+
+  const handleUpgrade = useCallback((buildingId: string) => {
+    const b = locationData.HUB_BUILDINGS.find(x => x.id === buildingId)
+    const res = purchaseUpgrade(town, buildingId, b?.upgradeKind)
+    if (res.ok) {
+      onCrystalsChange?.(loadCrystals())
+      buildingUpgradeLevelsRef.current[buildingId] = res.newLevel
+      refreshState()
+    } else {
+      const msg = res.reason === 'insufficient-crystals'
+        ? "You don't have enough crystals for that upgrade."
+        : res.reason === 'rep-locked'
+          ? "The town's standing isn't high enough yet — upgrade more first."
+          : 'That building is already fully upgraded.'
+      setDialogueEvent({ speakerName: 'Town Steward', text: msg })
+    }
+  }, [locationData, town, onCrystalsChange, refreshState])
 
   const { gameHour, isNight: isGameNight } = useHubClock()
 
@@ -369,6 +418,7 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onEndless, onWorldMap
       interiorEnterRef.current?.(buildingId)
       return
     }
+    if (screen === 'town-upgrades') { setUpgradesOpen(true); return }
     if (screen === 'worldmap') { onWorldMap?.(); return }
     if (screen === 'campaign') { onCampaign?.(); return }
     if (screen === 'endless') { onEndless?.(); return }
@@ -859,6 +909,7 @@ function tryOfferQuest(giverId: string, speakerName: string, onlyQuestId?: strin
           <ToolbarLabel className="title-deck-info">{isGameNight ? '🌙' : '☀️'} {formatGameTime()}</ToolbarLabel>
         <ToolbarButton icon="📜" title="Quests" onClick={() => setQuestsOpen(true)} />
         <ToolbarButton icon="🧭" title="Where is…?" onClick={() => setDirectoryOpen(true)} />
+        <ToolbarButton icon="🏗️" title="Town Upgrades" onClick={() => setUpgradesOpen(true)} />
         <ToolbarButton icon="🗺" title="World Map" onClick={() => onWorldMap?.()}  disabled={getQuestState('thorin-the-last-watch').status !== 'completed'} />
 
         <ToolbarSpacer/>
@@ -943,6 +994,7 @@ function tryOfferQuest(giverId: string, speakerName: string, onlyQuestId?: strin
 
         {questsOpen && <QuestsModal onClose={() => setQuestsOpen(false)} onAbandon={handleQuestAbandon} questDefs={questDefs} resolveNpcName={getNpcDisplayName}/>}
         {directoryOpen && <TownDirectory onClose={() => setDirectoryOpen(false)} locationData={locationData} pinnedNpcId={pinnedNpcId} onTogglePin={togglePinnedNpc} onShowRelationship={setRelationshipNpcId} />}
+        {upgradesOpen && <HubTownUpgrades onClose={() => setUpgradesOpen(false)} townName={town} reputation={getTownReputation(town)} crystals={loadCrystals()} rows={upgradeRows} onUpgrade={handleUpgrade} />}
         {relationshipNpcId && <RelationshipView npcName={getNpcDisplayName(relationshipNpcId)} entry={getRelationship(relationshipNpcId)} onClose={() => setRelationshipNpcId(null)} />}
         {openTreasure && <TreasureModal treasure={openTreasure} onClose={() => setOpenTreasure(null)} />}
 

--- a/web/src/data/hub/appleford/config.json
+++ b/web/src/data/hub/appleford/config.json
@@ -18,6 +18,7 @@
   "buildings": [
     {
       "id": "cider-house",
+      "upgradeKind": "tavern",
       "rect": [4, 2, 11, 8],
       "wall": "woodWall",
       "roof": "redSlateRoof",
@@ -27,6 +28,7 @@
     },
     {
       "id": "keepers-cottage",
+      "upgradeKind": "cottage",
       "rect": [17, 3, 23, 8],
       "wall": "woodWall",
       "roof": "strawRoof",

--- a/web/src/data/hub/buildingUpgrades.json
+++ b/web/src/data/hub/buildingUpgrades.json
@@ -1,0 +1,79 @@
+{
+  "shop": [
+    { "label": "Stocked Shelves", "cost": 120, "repReward": 40, "repRequired": 0,
+      "benefit": "Wider, deeper shop stock.", "service": "shop-stock",
+      "decor": [{ "dx": -1, "dy": 0, "tileId": "crate" }] },
+    { "label": "Trade Counter", "cost": 280, "repReward": 80, "repRequired": 150,
+      "benefit": "A standing daily discount on purchases.", "service": "shop-discount",
+      "decor": [{ "dx": 1, "dy": 0, "tileId": "pileOfSacks" }] },
+    { "label": "Guild Charter", "cost": 600, "repReward": 160, "repRequired": 350,
+      "benefit": "Premium rare stock and the best prices in the shard.", "service": "shop-premium",
+      "decor": [{ "dx": -2, "dy": 0, "tileId": "goldSign" }] }
+  ],
+  "inn": [
+    { "label": "Fresh Linens", "cost": 110, "repReward": 40, "repRequired": 0,
+      "benefit": "A more comfortable common room.", "service": "inn-rest",
+      "decor": [{ "dx": -1, "dy": 0, "tileId": "barrel" }] },
+    { "label": "Hearth & Bench", "cost": 260, "repReward": 80, "repRequired": 150,
+      "benefit": "More rumours and traveller gossip.", "service": "inn-rumours",
+      "decor": [{ "dx": 1, "dy": 0, "tileId": "benchMiddle" }] },
+    { "label": "Grand Sign", "cost": 560, "repReward": 160, "repRequired": 350,
+      "benefit": "A renowned inn that draws notable guests.", "service": "inn-guests",
+      "decor": [{ "dx": -2, "dy": 0, "tileId": "innSign" }] }
+  ],
+  "tavern": [
+    { "label": "Full Cellar", "cost": 110, "repReward": 40, "repRequired": 0,
+      "benefit": "Better brews on tap.", "service": "tavern-brews",
+      "decor": [{ "dx": -1, "dy": 0, "tileId": "barrel" }] },
+    { "label": "Bottle Rack", "cost": 250, "repReward": 80, "repRequired": 150,
+      "benefit": "Rare vintages and louder revelry.", "service": "tavern-rare",
+      "decor": [{ "dx": 1, "dy": 0, "tileId": "bottlesOfLiquor" }] },
+    { "label": "Tavern Sign", "cost": 540, "repReward": 160, "repRequired": 350,
+      "benefit": "A landmark tavern known across the shard.", "service": "tavern-landmark",
+      "decor": [{ "dx": -2, "dy": 0, "tileId": "drinkSign" }] }
+  ],
+  "cottage": [
+    { "label": "Window Box", "cost": 90, "repReward": 35, "repRequired": 0,
+      "benefit": "A cheerier, well-kept home.", "service": "cottage-decor",
+      "decor": [{ "dx": -1, "dy": 0, "tileId": "pinkFlower" }] },
+    { "label": "Flower Pots", "cost": 220, "repReward": 70, "repRequired": 120,
+      "benefit": "A blooming garden the whole street admires.", "service": "cottage-garden",
+      "decor": [{ "dx": 1, "dy": 0, "tileId": "potOfFlowers" }] },
+    { "label": "Lantern Post", "cost": 480, "repReward": 140, "repRequired": 300,
+      "benefit": "Warm lantern-light that keeps the lane lively after dark.", "service": "cottage-lantern",
+      "decor": [{ "dx": -2, "dy": 0, "tileId": "floorLantern" }] }
+  ],
+  "workshop": [
+    { "label": "Tool Crates", "cost": 130, "repReward": 40, "repRequired": 0,
+      "benefit": "Faster, sturdier craftwork.", "service": "workshop-craft",
+      "decor": [{ "dx": -1, "dy": 0, "tileId": "crate" }] },
+    { "label": "Strongbox", "cost": 300, "repReward": 80, "repRequired": 150,
+      "benefit": "Commissions completed more quickly.", "service": "workshop-speed",
+      "decor": [{ "dx": 1, "dy": 0, "tileId": "chest" }] },
+    { "label": "Master's Mark", "cost": 620, "repReward": 160, "repRequired": 350,
+      "benefit": "Masterwork goods bearing the guild mark.", "service": "workshop-master",
+      "decor": [{ "dx": -2, "dy": 0, "tileId": "armourSign" }] }
+  ],
+  "shrine": [
+    { "label": "Votive Candles", "cost": 100, "repReward": 40, "repRequired": 0,
+      "benefit": "A tended, welcoming shrine.", "service": "shrine-blessing",
+      "decor": [{ "dx": -1, "dy": 0, "tileId": "candlestickLitTop" }] },
+    { "label": "Sacred Brazier", "cost": 240, "repReward": 80, "repRequired": 150,
+      "benefit": "Stronger blessings for travellers.", "service": "shrine-ward",
+      "decor": [{ "dx": 1, "dy": 0, "tileId": "brazierTop" }] },
+    { "label": "Reliquary", "cost": 520, "repReward": 160, "repRequired": 350,
+      "benefit": "A hallowed reliquary that draws pilgrims.", "service": "shrine-relic",
+      "decor": [{ "dx": -2, "dy": 0, "tileId": "goldChest" }] }
+  ],
+  "default": [
+    { "label": "Tidy Frontage", "cost": 100, "repReward": 35, "repRequired": 0,
+      "benefit": "A cared-for building the town is proud of.", "service": "decor",
+      "decor": [{ "dx": -1, "dy": 0, "tileId": "lightBush" }] },
+    { "label": "Planters", "cost": 240, "repReward": 70, "repRequired": 120,
+      "benefit": "Greenery that brightens the whole street.", "service": "decor",
+      "decor": [{ "dx": 1, "dy": 0, "tileId": "potOfFlowers" }] },
+    { "label": "Proud Sign", "cost": 500, "repReward": 140, "repRequired": 300,
+      "benefit": "A landmark frontage known across town.", "service": "decor",
+      "decor": [{ "dx": -2, "dy": 0, "tileId": "largeSign" }] }
+  ]
+}

--- a/web/src/data/hub/buildingUpgrades.ts
+++ b/web/src/data/hub/buildingUpgrades.ts
@@ -1,0 +1,63 @@
+// ─── Building Upgrade Catalog ───────────────────────────────────────────────
+//
+// Shared, data-driven upgrade tracks keyed by building *kind* (shop, inn,
+// cottage, workshop, shrine, tavern, default…). Each town building is tagged
+// with an `upgradeKind` in its config.json; the reputation store reads the
+// matching track here. Decor offsets (`dx`/`dy`) are relative to the building's
+// primary door tile and are revealed once that upgrade level is reached.
+//
+// Authored data lives in ./buildingUpgrades.json — edit costs/benefits there.
+
+import raw from './buildingUpgrades.json'
+
+export interface UpgradeDecor {
+  dx: number
+  dy: number
+  /** Constant name from baseChipIndex.ts (resolved by the canvas, not here). */
+  tileId: string
+}
+
+export interface BuildingUpgradeLevel {
+  /** Short title for this level (shown in the upgrade panel). */
+  label: string
+  /** Crystal cost to purchase this level. */
+  cost: number
+  /** Town reputation granted on purchase. */
+  repReward: number
+  /** Town reputation required before this level can be purchased. */
+  repRequired: number
+  /** One-line description of what this level unlocks. */
+  benefit: string
+  /** Optional service id other systems can read via getTownServiceLevel. */
+  service?: string
+  /** Decor revealed at the building's door when this level is reached. */
+  decor?: UpgradeDecor[]
+}
+
+export type UpgradeCatalog = Record<string, BuildingUpgradeLevel[]>
+
+export const UPGRADE_CATALOG: UpgradeCatalog = raw as UpgradeCatalog
+
+/** Returns the ordered upgrade track for a building kind (falls back to `default`). */
+export function getUpgradeTrack(kind: string | undefined): BuildingUpgradeLevel[] {
+  if (!kind) return []
+  return UPGRADE_CATALOG[kind] ?? UPGRADE_CATALOG.default ?? []
+}
+
+// ── Reputation tiers ─────────────────────────────────────────────────────────
+
+/** Cumulative reputation needed to reach tiers 0–4. */
+export const REPUTATION_TIERS: readonly number[] = [0, 50, 150, 350, 700]
+
+export const REPUTATION_TIER_NAMES: readonly string[] = [
+  'Unknown', 'Recognised', 'Respected', 'Honoured', 'Revered',
+]
+
+/** Maps a reputation total to its tier index (0–4). */
+export function getReputationTier(rep: number): number {
+  let tier = 0
+  for (let i = 0; i < REPUTATION_TIERS.length; i++) {
+    if (rep >= REPUTATION_TIERS[i]) tier = i
+  }
+  return tier
+}

--- a/web/src/data/hub/capitalcity/config.json
+++ b/web/src/data/hub/capitalcity/config.json
@@ -22,6 +22,7 @@
   "buildings": [
     {
       "id": "grand-inn",
+      "upgradeKind": "inn",
       "rect": [3, 2, 12, 9],
       "wall": "whiteStone",
       "roof": "blueSlateRoof",
@@ -31,6 +32,7 @@
     },
     {
       "id": "market-hall-crownhaven",
+      "upgradeKind": "shop",
       "rect": [27, 2, 36, 9],
       "wall": "brick",
       "roof": "redSlateRoof",
@@ -40,6 +42,7 @@
     },
     {
       "id": "guardhouse",
+      "upgradeKind": "workshop",
       "rect": [3, 20, 10, 26],
       "wall": "castleStone",
       "roof": "greySlateRoof",
@@ -49,6 +52,7 @@
     },
     {
       "id": "chapel",
+      "upgradeKind": "shrine",
       "rect": [29, 20, 36, 27],
       "wall": "ornateStone",
       "roof": "blueSlateRoof",

--- a/web/src/data/hub/config.ts
+++ b/web/src/data/hub/config.ts
@@ -55,6 +55,9 @@ export interface BaseBuilding {
   bundleID?: string
   comment?: string
 
+  /** Upgrade track key (buildingUpgrades.json). Tags the building as upgradeable. */
+  upgradeKind?: string
+
   doors?: RawDoor[]
   windows?: RawWindow[]
   decor?: RawDecor[]

--- a/web/src/data/hub/dreadspirecitadel/config.json
+++ b/web/src/data/hub/dreadspirecitadel/config.json
@@ -18,6 +18,7 @@
   "buildings": [
     {
       "id": "dread-keep",
+      "upgradeKind": "default",
       "rect": [7, 2, 18, 10],
       "wall": "darkStone",
       "roof": "greySlateRoof",

--- a/web/src/data/hub/gearford/config.json
+++ b/web/src/data/hub/gearford/config.json
@@ -21,6 +21,7 @@
   "buildings": [
     {
       "id": "foundry",
+      "upgradeKind": "workshop",
       "rect": [4, 2, 15, 9],
       "wall": "brick",
       "roof": "metalRoof",
@@ -30,6 +31,7 @@
     },
     {
       "id": "workshop",
+      "upgradeKind": "workshop",
       "rect": [20, 3, 27, 9],
       "wall": "woodenSlats",
       "roof": "greySlateRoof",
@@ -39,6 +41,7 @@
     },
     {
       "id": "miners-inn",
+      "upgradeKind": "inn",
       "rect": [21, 15, 29, 21],
       "wall": "tudorFrame",
       "roof": "strawRoof",

--- a/web/src/data/hub/gravemoor/config.json
+++ b/web/src/data/hub/gravemoor/config.json
@@ -20,6 +20,7 @@
   "buildings": [
     {
       "id": "mourning-hall",
+      "upgradeKind": "shrine",
       "rect": [4, 2, 12, 9],
       "wall": "darkStone",
       "roof": "greySlateRoof",
@@ -29,6 +30,7 @@
     },
     {
       "id": "crypt-keep",
+      "upgradeKind": "default",
       "rect": [19, 2, 26, 8],
       "wall": "darkStone",
       "roof": "greySlateRoof",

--- a/web/src/data/hub/harrowfield/config.json
+++ b/web/src/data/hub/harrowfield/config.json
@@ -20,6 +20,7 @@
   "buildings": [
     {
       "id": "farmhouse",
+      "upgradeKind": "cottage",
       "rect": [3, 2, 9, 8],
       "wall": "woodWall",
       "roof": "strawRoof",
@@ -29,6 +30,7 @@
     },
     {
       "id": "barn",
+      "upgradeKind": "workshop",
       "rect": [20, 2, 27, 9],
       "wall": "woodenSlats",
       "roof": "strawRoof",
@@ -38,6 +40,7 @@
     },
     {
       "id": "mill-cottage",
+      "upgradeKind": "cottage",
       "rect": [19, 14, 25, 19],
       "wall": "woodWall",
       "roof": "strawRoof",

--- a/web/src/data/hub/hollowmere/config.json
+++ b/web/src/data/hub/hollowmere/config.json
@@ -19,6 +19,7 @@
   "buildings": [
     {
       "id": "broken-hall",
+      "upgradeKind": "default",
       "rect": [4, 2, 11, 8],
       "wall": "woodenSlats",
       "roof": "strawRoof",
@@ -28,6 +29,7 @@
     },
     {
       "id": "fang-den",
+      "upgradeKind": "default",
       "rect": [17, 3, 24, 9],
       "wall": "darkStone",
       "roof": "greySlateRoof",

--- a/web/src/data/hub/ironholdkeep/config.json
+++ b/web/src/data/hub/ironholdkeep/config.json
@@ -160,6 +160,7 @@
     },
     {
       "id": "keep",
+      "upgradeKind": "default",
       "rect": [
         12,
         -1,
@@ -181,6 +182,7 @@
     },
     {
       "id": "armoury",
+      "upgradeKind": "workshop",
       "rect": [
         8,
         14,
@@ -198,6 +200,7 @@
     },
     {
       "id": "barracks",
+      "upgradeKind": "default",
       "rect": [
         21,
         14,

--- a/web/src/data/hub/loader.ts
+++ b/web/src/data/hub/loader.ts
@@ -25,6 +25,8 @@ export interface HubBuilding {
   id?: string
   wall?: WallMaterial
   roof?: RoofMaterial
+  /** Upgrade track key (buildingUpgrades.json); set = building is upgradeable. */
+  upgradeKind?: string
 }
 
 export interface HubDoor {
@@ -338,6 +340,7 @@ type RawBuilding = {
   rect?: number[]; rects?: number[][];
   id?: string; wall?: string; roof?: string;
   bundleID?: string;
+  upgradeKind?: string;
   doors?:   Array<{ tx: number; ty: number; buildingId?: string, hideSign?: boolean }>
   windows?: Array<{ tx: number; ty: number; tileId: string }>
   decor?:   Array<{ tx: number; ty: number; tileId?: string; bundleID?: string; zlayer?: string }>
@@ -349,6 +352,7 @@ const HUB_BUILDINGS: HubBuilding[] = (rawConfig.buildings as RawBuilding[]).flat
     id:   b.id,
     wall: b.wall as WallMaterial | undefined,
     roof: b.roof as RoofMaterial | undefined,
+    upgradeKind: b.upgradeKind,
   }))
 })
 

--- a/web/src/data/hub/millhaven/config.json
+++ b/web/src/data/hub/millhaven/config.json
@@ -270,6 +270,7 @@
   "buildings": [
     {
       "id": "mill",
+      "upgradeKind": "workshop",
       "rect": [
         1,
         0,
@@ -289,6 +290,7 @@
     },
     {
       "id": "fishmonger",
+      "upgradeKind": "shop",
       "rect": [
         24,
         6,
@@ -308,6 +310,7 @@
     },
     {
       "id": "inn-millhaven",
+      "upgradeKind": "inn",
       "rect": [
         13,
         2,
@@ -327,6 +330,7 @@
     },
     {
       "id": "market-hall",
+      "upgradeKind": "shop",
       "rect": [
         23,
         16,
@@ -346,6 +350,7 @@
     },
     {
       "id": "town-hall-millhaven",
+      "upgradeKind": "default",
       "rect": [
         6,
         16,

--- a/web/src/data/hub/ravenwatch/config.json
+++ b/web/src/data/hub/ravenwatch/config.json
@@ -32,6 +32,7 @@
   "areas": [
     {
       "id": "townhall",
+      "upgradeKind": "default",
       "name": "The Townhall",
       "tx": 30,
       "ty": 1,
@@ -801,6 +802,7 @@
         10
       ],
       "id": "card-shop-bldg",
+      "upgradeKind": "shop",
       "wall": "brick",
       "roof": "woodRoof",
       "doors": [
@@ -841,6 +843,7 @@
         10
       ],
       "id": "augment-shop-bldg",
+      "upgradeKind": "shop",
       "wall": "woodenSlats",
       "roof": "redSlateRoof",
       "doors": [
@@ -1103,6 +1106,7 @@
         20
       ],
       "id": "inn-building",
+      "upgradeKind": "inn",
       "wall": "renderedBrick",
       "roof": "strawRoof",
       "doors": [
@@ -1143,6 +1147,7 @@
         33
       ],
       "id": "traders-building",
+      "upgradeKind": "shop",
       "wall": "tudorFrame",
       "roof": "metalRoof",
       "doors": [
@@ -1174,6 +1179,7 @@
         43
       ],
       "id": "market-building",
+      "upgradeKind": "shop",
       "wall": "renderedBrick",
       "roof": "greySlateRoof",
       "doors": [
@@ -1510,6 +1516,7 @@
         ]
       ],
       "id": "church-building",
+      "upgradeKind": "shrine",
       "wall": "castleStone",
       "roof": "greySlateRoof",
       "decor": [

--- a/web/src/data/hub/royalpalace/config.json
+++ b/web/src/data/hub/royalpalace/config.json
@@ -19,6 +19,7 @@
   "buildings": [
     {
       "id": "palace",
+      "upgradeKind": "default",
       "rect": [6, 2, 21, 12],
       "wall": "ornateStone",
       "roof": "blueSlateRoof",

--- a/web/src/data/hub/saltmereport/config.json
+++ b/web/src/data/hub/saltmereport/config.json
@@ -24,6 +24,7 @@
   "buildings": [
     {
       "id": "harbourmaster",
+      "upgradeKind": "default",
       "rect": [21, 4, 28, 10],
       "wall": "woodenSlats",
       "roof": "strawRoof",
@@ -33,6 +34,7 @@
     },
     {
       "id": "fish-market",
+      "upgradeKind": "shop",
       "rect": [3, 4, 11, 10],
       "wall": "woodenSlats",
       "roof": "yellowSlateRoof",
@@ -42,6 +44,7 @@
     },
     {
       "id": "sailors-inn",
+      "upgradeKind": "inn",
       "rect": [9, 17, 18, 24],
       "wall": "tudorFrame",
       "roof": "redSlateRoof",

--- a/web/src/game/hub/reputation.test.ts
+++ b/web/src/game/hub/reputation.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  getTownReputation,
+  getTownReputationTier,
+  getUpgradeLevel,
+  nextUpgrade,
+  purchaseUpgrade,
+  getUnlockedServices,
+  hasTownService,
+  setUpgradeKindResolver,
+} from './reputation'
+import { saveCrystals, loadCrystals } from '../collection'
+import { getUpgradeTrack } from '../../data/hub/buildingUpgrades'
+
+// In-memory localStorage mock (tests run in node environment)
+const store = new Map<string, string>()
+beforeEach(() => {
+  store.clear()
+  globalThis.localStorage = {
+    getItem:    (k: string) => store.get(k) ?? null,
+    setItem:    (k: string, v: string) => { store.set(k, v) },
+    removeItem: (k: string) => { store.delete(k) },
+    clear:      () => { store.clear() },
+    key:        (i: number) => [...store.keys()][i] ?? null,
+    get length() { return store.size },
+  } as Storage
+  setUpgradeKindResolver(null)
+})
+
+const TOWN = 'Appleford'
+const shop = getUpgradeTrack('shop')
+
+describe('reputation default state', () => {
+  it('returns zero reputation and level for an unknown town/building', () => {
+    expect(getTownReputation(TOWN)).toBe(0)
+    expect(getTownReputationTier(TOWN)).toBe(0)
+    expect(getUpgradeLevel(TOWN, 'cider-house')).toBe(0)
+  })
+
+  it('reports the first level as the next upgrade', () => {
+    const n = nextUpgrade(TOWN, 'cider-house', 'shop')
+    expect(n.level).toBe(0)
+    expect(n.total).toBe(shop.length)
+    expect(n.cost).toBe(shop[0].cost)
+    expect(n.repLocked).toBe(false)
+    expect(n.maxed).toBe(false)
+  })
+})
+
+describe('purchaseUpgrade', () => {
+  it('spends crystals, raises the level and grants reputation', () => {
+    saveCrystals(1000)
+    const res = purchaseUpgrade(TOWN, 'cider-house', 'shop')
+    expect(res.ok).toBe(true)
+    expect(loadCrystals()).toBe(1000 - shop[0].cost)
+    expect(getUpgradeLevel(TOWN, 'cider-house')).toBe(1)
+    expect(getTownReputation(TOWN)).toBe(shop[0].repReward)
+  })
+
+  it('refuses when the player cannot afford it', () => {
+    saveCrystals(shop[0].cost - 1)
+    const res = purchaseUpgrade(TOWN, 'cider-house', 'shop')
+    expect(res).toEqual({ ok: false, reason: 'insufficient-crystals' })
+    expect(loadCrystals()).toBe(shop[0].cost - 1)
+    expect(getUpgradeLevel(TOWN, 'cider-house')).toBe(0)
+  })
+
+  it('blocks higher tiers behind a town reputation gate', () => {
+    saveCrystals(100000)
+    // Level 1 is ungated.
+    expect(purchaseUpgrade(TOWN, 'cider-house', 'shop').ok).toBe(true)
+    // Level 2 requires more reputation than a single building can provide.
+    const gated = nextUpgrade(TOWN, 'cider-house', 'shop')
+    if (gated.repRequired > getTownReputation(TOWN)) {
+      const res = purchaseUpgrade(TOWN, 'cider-house', 'shop')
+      expect(res).toEqual({ ok: false, reason: 'rep-locked' })
+      expect(getUpgradeLevel(TOWN, 'cider-house')).toBe(1)
+    }
+  })
+
+  it('unlocks gated tiers once enough reputation is earned town-wide', () => {
+    saveCrystals(100000)
+    // Invest across several buildings to accumulate town reputation.
+    purchaseUpgrade(TOWN, 'b1', 'shop')
+    purchaseUpgrade(TOWN, 'b2', 'shop')
+    purchaseUpgrade(TOWN, 'b3', 'shop')
+    purchaseUpgrade(TOWN, 'b4', 'shop')
+    // With enough rep, b1 can now reach level 2.
+    const n = nextUpgrade(TOWN, 'b1', 'shop')
+    if (getTownReputation(TOWN) >= n.repRequired) {
+      expect(purchaseUpgrade(TOWN, 'b1', 'shop').ok).toBe(true)
+      expect(getUpgradeLevel(TOWN, 'b1')).toBe(2)
+    }
+  })
+
+  it('reports maxed once every level is purchased', () => {
+    saveCrystals(1000000)
+    // Build up enough town reputation (via other buildings) to clear the gates.
+    for (let i = 0; i < 12; i++) purchaseUpgrade(TOWN, `dummy-${i}`, 'shop')
+    for (let i = 0; i < shop.length; i++) purchaseUpgrade(TOWN, 'cider-house', 'shop')
+    const n = nextUpgrade(TOWN, 'cider-house', 'shop')
+    expect(n.maxed).toBe(true)
+    expect(n.def).toBeNull()
+    expect(purchaseUpgrade(TOWN, 'cider-house', 'shop')).toEqual({ ok: false, reason: 'maxed' })
+  })
+
+  it('persists across reloads', () => {
+    saveCrystals(1000)
+    purchaseUpgrade(TOWN, 'cider-house', 'shop')
+    // A fresh read goes through localStorage again.
+    expect(getUpgradeLevel(TOWN, 'cider-house')).toBe(1)
+    expect(getTownReputation(TOWN)).toBe(shop[0].repReward)
+  })
+})
+
+describe('unlocked services', () => {
+  it('resolves services from purchased levels via the kind resolver', () => {
+    saveCrystals(100000)
+    setUpgradeKindResolver((_town, id) => (id === 'cider-house' ? 'shop' : undefined))
+    expect(getUnlockedServices(TOWN)).toEqual([])
+    purchaseUpgrade(TOWN, 'cider-house', 'shop')
+    expect(hasTownService(TOWN, shop[0].service!)).toBe(true)
+  })
+
+  it('returns nothing when no resolver is registered', () => {
+    saveCrystals(1000)
+    purchaseUpgrade(TOWN, 'cider-house', 'shop')
+    expect(getUnlockedServices(TOWN)).toEqual([])
+  })
+})

--- a/web/src/game/hub/reputation.ts
+++ b/web/src/game/hub/reputation.ts
@@ -1,0 +1,178 @@
+// ─── Hub town reputation & building upgrades ────────────────────────────────
+//
+// Per-town reputation plus per-building upgrade levels, persisted to
+// localStorage. Reputation is *earned by investing crystals*: each upgrade
+// purchase spends crystals (the shared wallet in ../collection) and grants the
+// town reputation, which in turn gates the higher upgrade tiers. Upgrade tracks
+// and costs live in ../../data/hub/buildingUpgrades.json (keyed by building kind).
+//
+// Mirrors the store shape of friendship.ts / relationships.ts.
+
+import { loadCrystals, saveCrystals } from '../collection'
+import { logError } from '../../logger'
+import {
+  getUpgradeTrack,
+  getReputationTier,
+  type BuildingUpgradeLevel,
+} from '../../data/hub/buildingUpgrades'
+
+const KEY = 'jarv_hub_reputation'
+
+interface TownState {
+  /** Cumulative town reputation. */
+  rep: number
+  /** buildingId → purchased upgrade level (1-based count of bought levels). */
+  levels: Record<string, number>
+}
+
+type Store = Record<string, TownState>
+
+function load(): Store {
+  try {
+    const raw = localStorage.getItem(KEY)
+    return raw ? (JSON.parse(raw) as Store) : {}
+  } catch {
+    return {}
+  }
+}
+
+function save(data: Store): void {
+  try {
+    localStorage.setItem(KEY, JSON.stringify(data))
+  } catch (e) {
+    logError('saveReputation failed', { error: String(e) })
+  }
+}
+
+function townState(data: Store, town: string): TownState {
+  return data[town] ?? { rep: 0, levels: {} }
+}
+
+// ── Reads ──────────────────────────────────────────────────────────────────
+
+export function getTownReputation(town: string): number {
+  return townState(load(), town).rep
+}
+
+export function getTownReputationTier(town: string): number {
+  return getReputationTier(getTownReputation(town))
+}
+
+/** Map of buildingId → purchased upgrade level for a town. */
+export function getTownUpgradeLevels(town: string): Record<string, number> {
+  return { ...townState(load(), town).levels }
+}
+
+/** Purchased upgrade level for one building (0 = not upgraded). */
+export function getUpgradeLevel(town: string, buildingId: string): number {
+  return townState(load(), town).levels[buildingId] ?? 0
+}
+
+// ── Next-upgrade query ───────────────────────────────────────────────────────
+
+export interface NextUpgrade {
+  /** The next level definition, or null when the track is maxed/empty. */
+  def: BuildingUpgradeLevel | null
+  /** Current purchased level. */
+  level: number
+  /** Total levels in this building's track. */
+  total: number
+  /** Crystal cost of the next level (0 when none). */
+  cost: number
+  /** Reputation required for the next level. */
+  repRequired: number
+  /** True when the next level is blocked by insufficient town reputation. */
+  repLocked: boolean
+  /** True when every level has been purchased. */
+  maxed: boolean
+}
+
+export function nextUpgrade(town: string, buildingId: string, kind: string | undefined): NextUpgrade {
+  const track = getUpgradeTrack(kind)
+  const data = load()
+  const state = townState(data, town)
+  const level = state.levels[buildingId] ?? 0
+  const total = track.length
+
+  if (level >= total || total === 0) {
+    return { def: null, level, total, cost: 0, repRequired: 0, repLocked: false, maxed: total > 0 }
+  }
+
+  const def = track[level]
+  return {
+    def,
+    level,
+    total,
+    cost: def.cost,
+    repRequired: def.repRequired,
+    repLocked: state.rep < def.repRequired,
+    maxed: false,
+  }
+}
+
+// ── Purchase ─────────────────────────────────────────────────────────────────
+
+export type PurchaseResult =
+  | { ok: true; newLevel: number; newRep: number; spent: number; def: BuildingUpgradeLevel }
+  | { ok: false; reason: 'maxed' | 'rep-locked' | 'insufficient-crystals' }
+
+/**
+ * Attempt to buy the next upgrade level for a building. Validates the town
+ * reputation gate and the crystal balance, then deducts crystals, increments
+ * the level, and grants reputation. All-or-nothing.
+ */
+export function purchaseUpgrade(town: string, buildingId: string, kind: string | undefined): PurchaseResult {
+  const next = nextUpgrade(town, buildingId, kind)
+  if (next.maxed || !next.def) return { ok: false, reason: 'maxed' }
+  if (next.repLocked) return { ok: false, reason: 'rep-locked' }
+
+  const balance = loadCrystals()
+  if (balance < next.cost) return { ok: false, reason: 'insufficient-crystals' }
+
+  // Deduct crystals first, then persist the new level + reputation.
+  saveCrystals(balance - next.cost)
+
+  const data = load()
+  const state = townState(data, town)
+  const newLevel = (state.levels[buildingId] ?? 0) + 1
+  const newRep = state.rep + next.def.repReward
+  data[town] = { rep: newRep, levels: { ...state.levels, [buildingId]: newLevel } }
+  save(data)
+
+  return { ok: true, newLevel, newRep, spent: next.cost, def: next.def }
+}
+
+// ── Services ─────────────────────────────────────────────────────────────────
+//
+// A building's `upgradeKind` lives in the town config (not in this store), so to
+// resolve which catalog services are unlocked we need a buildingId→kind lookup.
+// HubWorld registers one from the active location bundle; other systems then
+// read services without importing the loader.
+
+let _kindResolver: ((town: string, buildingId: string) => string | undefined) | null = null
+
+/** Register how to resolve a building's `upgradeKind` (set by HubWorld on load). */
+export function setUpgradeKindResolver(
+  fn: ((town: string, buildingId: string) => string | undefined) | null,
+): void {
+  _kindResolver = fn
+}
+
+/** All service ids unlocked across a town's purchased upgrade levels. */
+export function getUnlockedServices(town: string): string[] {
+  if (!_kindResolver) return []
+  const state = townState(load(), town)
+  const out: string[] = []
+  for (const [buildingId, level] of Object.entries(state.levels)) {
+    const track = getUpgradeTrack(_kindResolver(town, buildingId))
+    for (let i = 0; i < Math.min(level, track.length); i++) {
+      if (track[i].service) out.push(track[i].service!)
+    }
+  }
+  return out
+}
+
+/** True when a given service id is unlocked anywhere in the town. */
+export function hasTownService(town: string, serviceId: string): boolean {
+  return getUnlockedServices(town).includes(serviceId)
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -15248,6 +15248,32 @@ html.light-mode .action-btn {
 .town-directory__pin-btn--on { border-color: #55ddee; color: #55ddee; }
 .town-directory__pin-btn:hover { opacity: 0.85; }
 
+/* ── Town Upgrades panel (reuses .town-directory layout) ───────────────────── */
+.town-upgrades__rep {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 10px;
+  margin-bottom: 10px;
+  padding: 6px 10px;
+  border: 1px solid #5a4a22;
+  border-radius: 2px;
+  background: rgba(40, 32, 10, 0.4);
+}
+.town-upgrades__rep-tier { font-size: 12px; font-weight: bold; color: #eedd88; letter-spacing: 0.04em; }
+.town-upgrades__rep-prog { font-size: 10px; color: #bbaa77; }
+.town-upgrades__lvl    { font-size: 10px; color: #88aa88; font-weight: normal; }
+.town-upgrades__next   { font-size: 10px; color: #aac8dd; }
+.town-upgrades__next strong { color: #cfe6f2; }
+.town-upgrades__reason { font-size: 10px; color: #cc8866; }
+.town-upgrades__btn {
+  flex-shrink: 0;
+  font-size: 10px;
+  padding: 6px 10px;
+  white-space: nowrap;
+}
+.town-upgrades__btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
 /* ── Treasure Modal ────────────────────────────────────────────────────────── */
 .treasure-modal {
   background: rgba(8, 14, 8, 0.97);


### PR DESCRIPTION
Implements #1619 (and sub-issues #1636, #1638, #1641): a per-town **reputation** value plus per-building **upgrade levels** that give the hub a sense of progression and a crystal sink.

## How it works
- **Reputation is earned by investing crystals.** Each upgrade purchase spends crystals (the shared wallet), raises the town's standing, and reputation **gates the higher upgrade tiers**.
- Buying an upgrade **reveals decor** at the building immediately and unlocks a labelled benefit/service.
- All state (reputation + per-building levels) persists in `localStorage`.
- **Rolled out to all 13 towns** via a shared catalog keyed by building *kind* — each building is just tagged with an `upgradeKind`, so no bespoke per-building data.

## What's included
- **`game/hub/reputation.ts`** (+ `reputation.test.ts`) — store: `getTownReputation`, `getUpgradeLevel`, `nextUpgrade`, `purchaseUpgrade`, `getUnlockedServices`/`hasTownService`. Validates the rep gate and crystal balance, all-or-nothing.
- **`data/hub/buildingUpgrades.json` / `.ts`** — upgrade tracks by kind (shop, inn, tavern, cottage, workshop, shrine, default) with escalating cost/rep-gate, benefits, services, and door-relative decor; reputation tiers.
- **`data/hub/config.ts` + `loader.ts`** — optional `upgradeKind` on the building schema; principal buildings tagged across all 12 towns with buildings.
- **`components/hub/HubTownUpgrades.tsx`** (+ story) — pure-visual panel: reputation tier, per-building current/next benefit, cost, and an Upgrade button disabled with a reason when locked/unaffordable.
- **`HubWorld.tsx`** — 🏗️ toolbar button + `town-upgrades` screen route open the panel; purchase wiring; registers the `upgradeKind` resolver.
- **`HubTownCanvas.tsx`** — builds upgrade decor sprites at door offsets and toggles them per-frame against a levels ref (mirrors the blocked-path decor pattern), so decor appears the moment you buy.
- **`docs/hubworld.md`** — new §10 (schema, tagging, services, authoring checklist).

## Acceptance criteria
- ✅ Spending crystals upgrades a building and unlocks a visible decor change.
- ✅ Reputation + upgrade levels persist (localStorage).
- ✅ `npm run build` passes; `npm run test` — 182/182 unit tests pass (incl. new `reputation.test.ts`). The Storybook browser project can't launch Chromium in this sandbox; that's environmental, not from these changes.

## Notes / scope
- Access is via a 🏗️ toolbar button (consistent across all towns, zero placement risk) plus the `town-upgrades` route for optional in-world stewards.
- `service` ids are **data-only** for now: the unlocked benefit is shown in the panel and readable via `getUnlockedServices`, but nothing consumes them yet (the daily Shop is global, not town-scoped). The guaranteed visible change is the decor.

## Verify
Open a town → 🏗️ Town Upgrades → buy a level: crystals drop, standing rises, new decor appears on the building immediately; a rep-locked tier stays blocked until standing is high enough; reload preserves everything.

https://claude.ai/code/session_01CSjZieb74WwKBH5qjxyDEC

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSjZieb74WwKBH5qjxyDEC)_