### PR TITLE
Fix challenge screen clipping its action button off-screen on small phones

### DIFF
--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -8269,7 +8269,15 @@ html.eightbit-mode .lane-layer {
   gap: 14px;
   padding: 24px 16px;
   max-width: 440px;
+  width: 100%;
   margin: 0 auto;
+  /* Allow the screen to scroll inside the fixed-height .game-container (which is
+     overflow:hidden). Without this, tall variants — e.g. the weekly challenge
+     with its lore, leaderboard and 20-card deck — clip the bottom action button
+     off-screen on small phones with no way to reach it. */
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
   font-family: var(--game-font);
   color: var(--game-text-color);
 }


### PR DESCRIPTION
## Problem

A player on a small phone reported that after opening the **Weekly Challenge** screen he couldn't scroll down to reach the retry button — it was off the bottom of the screen.

## Root cause

`.dc-screen` — shared by **both** the daily and weekly challenge screens — is a direct flex child of `.game-container`, which is `height: 100vh; overflow: hidden`. `.dc-screen` had no `overflow-y`, `flex`, or `min-height: 0`, so when its content was taller than the viewport it simply overflowed and got clipped by the container, with no way to scroll to the bottom.

The **weekly** screen is taller than the daily one — it adds a lore paragraph, the "this week's constraint" box, a fragments/shards line, the leaderboard, **and** a 20-card deck list — so it overflows on small screens where the daily screen still fits.

## Fix

Make `.dc-screen` a scrollable flex item (`flex: 1 1 auto; min-height: 0; overflow-y: auto;`, plus `width: 100%`). Tall variants now scroll instead of clipping the bottom action button. No change for screens that already fit.

https://claude.ai/code/session_013LyuKtSLP86mUNdUe3TY4j

---
_Generated by [Claude Code](https://claude.ai/code/session_013LyuKtSLP86mUNdUe3TY4j)_