### PR TITLE
Don't burn campaign lives when losing a non-campaign battle

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2529,7 +2529,11 @@ export default function App() {
     const currentRun = run
 
     const isLoss = gameState?.phase.type === 'gameOver' && gameState.phase.winner !== 'player'
-    if (currentRun && isLoss) {
+    // Only campaign-battle losses cost a life / record a node failure. Without the
+    // wasInCampaign guard, losing a non-campaign battle (weekly/daily challenge,
+    // quick battle, endless) while a campaign run exists would wrongly burn a life
+    // and fail the node, silently corrupting the saved run.
+    if (wasInCampaign && currentRun && isLoss) {
       // Decrement a life and record the node failure
       const nodeId = currentRun.pendingNodeId
       const prevCount = nodeId ? (currentRun.nodeFailCounts[nodeId] ?? 0) : 0


### PR DESCRIPTION
## Problem

A player reported that **"Continue Campaign" stopped working after he kept losing the new weekly challenge** — and that Quick Battle / Endless also seemed off. The weekly challenge itself isn't the culprit; it just got him losing repeatedly while a campaign run was active.

## Root cause

In `handleMainMenu` (the GameOver **Main Menu** button), the campaign-loss penalty was gated only on `currentRun && isLoss`:

```js
const isLoss = gameState?.phase.type === 'gameOver' && gameState.phase.winner !== 'player'
if (currentRun && isLoss) {
  // decrement a campaign life + record a node failure, saveRun(withFail)...
```

It never checked whether the lost battle was actually a **campaign** battle. So losing a **weekly/daily challenge, quick battle, or endless run** while a saved campaign run existed would:

- decrement `livesRemaining` on the campaign run, and
- record a `nodeFailCounts` failure for the run's `pendingNodeId`.

The existing `wasInCampaign` guard only protected the *clear-the-run / campaign-failed* branch — so instead of cleanly failing, the run was silently corrupted (lives driven toward 0, node marked failed), which is why **Continue Run** misbehaved afterwards.

This bug predates the weekly feature; the new (taller) weekly screen simply made it easy to hit by losing repeatedly.

## Fix

Gate the penalty block on `wasInCampaign` so only genuine campaign-battle losses affect the saved run. Non-campaign losses now fall through to the normal "return to title" path and leave the run untouched.

```js
if (wasInCampaign && currentRun && isLoss) {
```

## Notes

- Build passes (`npm run build`).
- This prevents *future* corruption. A save already mangled by this bug (lives at 0 on a still-present run) isn't repaired by this change.

https://claude.ai/code/session_013LyuKtSLP86mUNdUe3TY4j

---
_Generated by [Claude Code](https://claude.ai/code/session_013LyuKtSLP86mUNdUe3TY4j)_