### PR TITLE
Hub: daily town tribute — first wired upgrade service (#1619)

### DIFF
--- a/docs/hubworld.md
+++ b/docs/hubworld.md
@@ -793,11 +793,19 @@ Reputation tiers/names live in `buildingUpgrades.ts` (`REPUTATION_TIERS`,
 
 ### Services
 
-`service` ids are **data only** today: nothing consumes them yet, but the unlocked
-benefit text is shown in the panel and other systems can read the unlocked set via
-`getUnlockedServices(town)` / `hasTownService(town, id)`. `HubWorld` registers the
-`upgradeKind` resolver with `setUpgradeKindResolver` so these reads work without
-importing the loader. The guaranteed visible change on purchase is the **decor**.
+Each unlocked `service` id is readable via `getUnlockedServices(town)` /
+`hasTownService(town, id)`; `HubWorld` registers the `upgradeKind` resolver with
+`setUpgradeKindResolver` so these reads work without importing the loader. The
+benefit text is shown in the panel, and the guaranteed visible change on purchase
+is the **decor**.
+
+The first concrete payoff wired to services is the **daily town tribute**: the
+town pays a small crystal stipend scaled by how many services its buildings have
+unlocked (`tributeAmount` = `10 + services × 8`), claimable once per real day from
+the panel header (`tributeAmount` / `tributeAvailable` / `collectTribute` in
+`reputation.ts`). This turns every unlocked service into a tangible daily return on
+the crystals invested. Additional service-specific effects can hook the same
+`getUnlockedServices`/`hasTownService` reads.
 
 ### Authoring checklist: new upgrade track / upgradeable building
 

--- a/web/src/components/hub/HubTownUpgrades.stories.tsx
+++ b/web/src/components/hub/HubTownUpgrades.stories.tsx
@@ -41,6 +41,9 @@ export const Default: Story = {
     crystals:   500,
     rows,
     onUpgrade:  fn(),
+    tributeAmount:    34,
+    tributeAvailable: true,
+    onCollectTribute: fn(),
   },
 }
 
@@ -52,5 +55,8 @@ export const Broke: Story = {
     crystals:   10,
     rows,
     onUpgrade:  fn(),
+    tributeAmount:    34,
+    tributeAvailable: true,
+    onCollectTribute: fn(),
   },
 }

--- a/web/src/components/hub/HubTownUpgrades.tsx
+++ b/web/src/components/hub/HubTownUpgrades.tsx
@@ -25,6 +25,11 @@ interface Props {
   crystals:   number
   rows:       UpgradeRow[]
   onUpgrade:  (buildingId: string) => void
+  /** Daily tribute crystals the town offers (0 = nothing unlocked yet). */
+  tributeAmount:    number
+  /** Whether today's tribute can still be collected. */
+  tributeAvailable: boolean
+  onCollectTribute: () => void
 }
 
 function reputationToNextTier(rep: number): { tier: number; label: string; progress: string } {
@@ -37,7 +42,10 @@ function reputationToNextTier(rep: number): { tier: number; label: string; progr
   return { tier, label, progress }
 }
 
-export function HubTownUpgrades({ onClose, townName, reputation, crystals, rows, onUpgrade }: Props) {
+export function HubTownUpgrades({
+  onClose, townName, reputation, crystals, rows, onUpgrade,
+  tributeAmount, tributeAvailable, onCollectTribute,
+}: Props) {
   const rep = reputationToNextTier(reputation)
 
   return (
@@ -55,6 +63,21 @@ export function HubTownUpgrades({ onClose, townName, reputation, crystals, rows,
           <span className="town-upgrades__rep-tier">⭐ {rep.label}</span>
           <span className="town-upgrades__rep-prog">{rep.progress}</span>
         </div>
+
+        {tributeAmount > 0 && (
+          <div className="town-upgrades__tribute">
+            <span className="town-upgrades__tribute-text">
+              🎁 Daily tribute from grateful townsfolk: <strong>💎 {tributeAmount}</strong>
+            </span>
+            <button
+              className="action-btn action-btn--gold town-upgrades__btn"
+              disabled={!tributeAvailable}
+              onClick={onCollectTribute}
+            >
+              {tributeAvailable ? 'Collect' : 'Collected today'}
+            </button>
+          </div>
+        )}
 
         {rows.length === 0 ? (
           <div className="town-directory__empty">No upgradeable buildings here yet.</div>

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -31,7 +31,7 @@ import { addCollectible, addConsumable, getCollectibles } from '../../game/itemS
 import { QuestsModal } from './QuestsModal'
 import { TownDirectory } from './TownDirectory'
 import { HubTownUpgrades, type UpgradeRow } from './HubTownUpgrades'
-import { nextUpgrade, purchaseUpgrade, getTownReputation, getUpgradeLevel, setUpgradeKindResolver } from '../../game/hub/reputation'
+import { nextUpgrade, purchaseUpgrade, getTownReputation, getUpgradeLevel, setUpgradeKindResolver, tributeAmount, tributeAvailable, collectTribute } from '../../game/hub/reputation'
 import { RelationshipView } from './RelationshipView'
 import { resolveNpcPlace } from '../../game/hub/npcLocator'
 import { TreasureModal } from './TreasureModal'
@@ -187,6 +187,15 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onEndless, onWorldMap
       setDialogueEvent({ speakerName: 'Town Steward', text: msg })
     }
   }, [locationData, town, onCrystalsChange, refreshState])
+
+  const handleCollectTribute = useCallback(() => {
+    const amount = collectTribute(town)
+    if (amount > 0) {
+      onCrystalsChange?.(loadCrystals())
+      refreshState()
+      setDialogueEvent({ speakerName: 'Town Steward', text: `The town thanks you for your patronage. 💎 ${amount} crystals!` })
+    }
+  }, [town, onCrystalsChange, refreshState])
 
   const { gameHour, isNight: isGameNight } = useHubClock()
 
@@ -995,7 +1004,7 @@ function tryOfferQuest(giverId: string, speakerName: string, onlyQuestId?: strin
 
         {questsOpen && <QuestsModal onClose={() => setQuestsOpen(false)} onAbandon={handleQuestAbandon} questDefs={questDefs} resolveNpcName={getNpcDisplayName}/>}
         {directoryOpen && <TownDirectory onClose={() => setDirectoryOpen(false)} locationData={locationData} pinnedNpcId={pinnedNpcId} onTogglePin={togglePinnedNpc} onShowRelationship={setRelationshipNpcId} />}
-        {upgradesOpen && <HubTownUpgrades onClose={() => setUpgradesOpen(false)} townName={town} reputation={getTownReputation(town)} crystals={loadCrystals()} rows={upgradeRows} onUpgrade={handleUpgrade} />}
+        {upgradesOpen && <HubTownUpgrades onClose={() => setUpgradesOpen(false)} townName={town} reputation={getTownReputation(town)} crystals={loadCrystals()} rows={upgradeRows} onUpgrade={handleUpgrade} tributeAmount={tributeAmount(town)} tributeAvailable={tributeAvailable(town)} onCollectTribute={handleCollectTribute} />}
         {relationshipNpcId && <RelationshipView npcName={getNpcDisplayName(relationshipNpcId)} entry={getRelationship(relationshipNpcId)} onClose={() => setRelationshipNpcId(null)} />}
         {openTreasure && <TreasureModal treasure={openTreasure} onClose={() => setOpenTreasure(null)} />}
 

--- a/web/src/game/hub/reputation.test.ts
+++ b/web/src/game/hub/reputation.test.ts
@@ -8,6 +8,9 @@ import {
   getUnlockedServices,
   hasTownService,
   setUpgradeKindResolver,
+  tributeAmount,
+  tributeAvailable,
+  collectTribute,
 } from './reputation'
 import { saveCrystals, loadCrystals } from '../collection'
 import { getUpgradeTrack } from '../../data/hub/buildingUpgrades'
@@ -126,5 +129,31 @@ describe('unlocked services', () => {
     saveCrystals(1000)
     purchaseUpgrade(TOWN, 'cider-house', 'shop')
     expect(getUnlockedServices(TOWN)).toEqual([])
+  })
+})
+
+describe('daily tribute', () => {
+  it('offers nothing until a service is unlocked', () => {
+    setUpgradeKindResolver((_t, id) => (id === 'cider-house' ? 'shop' : undefined))
+    expect(tributeAmount(TOWN)).toBe(0)
+    expect(tributeAvailable(TOWN)).toBe(false)
+  })
+
+  it('scales with unlocked services and credits crystals once per day', () => {
+    setUpgradeKindResolver((_t, id) => (id === 'cider-house' ? 'shop' : undefined))
+    saveCrystals(100000)
+    purchaseUpgrade(TOWN, 'cider-house', 'shop')   // unlocks 1 service
+    const amount = tributeAmount(TOWN)
+    expect(amount).toBeGreaterThan(0)
+
+    expect(tributeAvailable(TOWN)).toBe(true)
+    const before = loadCrystals()
+    expect(collectTribute(TOWN)).toBe(amount)
+    expect(loadCrystals()).toBe(before + amount)
+
+    // Second collection the same day is a no-op.
+    expect(tributeAvailable(TOWN)).toBe(false)
+    expect(collectTribute(TOWN)).toBe(0)
+    expect(loadCrystals()).toBe(before + amount)
   })
 })

--- a/web/src/game/hub/reputation.ts
+++ b/web/src/game/hub/reputation.ts
@@ -23,6 +23,8 @@ interface TownState {
   rep: number
   /** buildingId → purchased upgrade level (1-based count of bought levels). */
   levels: Record<string, number>
+  /** YYYY-MM-DD of the last collected daily tribute. */
+  tributeDay?: string
 }
 
 type Store = Record<string, TownState>
@@ -175,4 +177,46 @@ export function getUnlockedServices(town: string): string[] {
 /** True when a given service id is unlocked anywhere in the town. */
 export function hasTownService(town: string, serviceId: string): boolean {
   return getUnlockedServices(town).includes(serviceId)
+}
+
+// ── Daily town tribute ───────────────────────────────────────────────────────
+//
+// The first concrete service payoff: a town pays a small daily crystal stipend
+// scaled by the services its buildings have unlocked, claimable once per day.
+// This makes every catalog `service` worth something and gives reputation a
+// tangible return on the crystals invested.
+
+const TRIBUTE_BASE = 10
+const TRIBUTE_PER_SERVICE = 8
+
+function today(): string {
+  return new Date().toISOString().slice(0, 10)
+}
+
+/** Crystals the town would pay today (0 when nothing is unlocked). */
+export function tributeAmount(town: string): number {
+  const services = getUnlockedServices(town).length
+  if (services === 0) return 0
+  return TRIBUTE_BASE + services * TRIBUTE_PER_SERVICE
+}
+
+/** True when today's tribute has not yet been collected and is non-zero. */
+export function tributeAvailable(town: string): boolean {
+  if (tributeAmount(town) <= 0) return false
+  return townState(load(), town).tributeDay !== today()
+}
+
+/**
+ * Collect today's tribute: credits crystals (shared wallet), marks the day, and
+ * returns the amount. Returns 0 if already collected or nothing is unlocked.
+ */
+export function collectTribute(town: string): number {
+  if (!tributeAvailable(town)) return 0
+  const amount = tributeAmount(town)
+  saveCrystals(loadCrystals() + amount)
+  const data = load()
+  const state = townState(data, town)
+  data[town] = { ...state, tributeDay: today() }
+  save(data)
+  return amount
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -15270,6 +15270,19 @@ html.light-mode .action-btn {
 }
 .town-upgrades__rep-tier { font-size: 12px; font-weight: bold; color: #eedd88; letter-spacing: 0.04em; }
 .town-upgrades__rep-prog { font-size: 10px; color: #bbaa77; }
+.town-upgrades__tribute {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 10px;
+  padding: 6px 10px;
+  border: 1px solid #3a5a2a;
+  border-radius: 2px;
+  background: rgba(20, 40, 14, 0.4);
+}
+.town-upgrades__tribute-text { font-size: 11px; color: #bcd8a0; }
+.town-upgrades__tribute-text strong { color: #eedd88; }
 .town-upgrades__lvl    { font-size: 10px; color: #88aa88; font-weight: normal; }
 .town-upgrades__next   { font-size: 10px; color: #aac8dd; }
 .town-upgrades__next strong { color: #cfe6f2; }


### PR DESCRIPTION
Follow-up to #1700 (issue #1619): wires the **first concrete town-scoped effect** to the upgrade `service` system, so unlocked services do something real rather than just display text.

## Daily town tribute
A town pays a small **daily crystal stipend scaled by how many services its buildings have unlocked** — `10 + services × 8` — claimable **once per real day** from the Town Upgrades panel header.

This turns every unlocked `service` into a tangible daily return on the crystals invested, giving reputation/upgrades a payoff loop while staying net-negative overall (you invest far more than the trickle back).

## Changes
- **`game/hub/reputation.ts`** — `tributeAmount`, `tributeAvailable`, `collectTribute`; tracks `tributeDay` (YYYY-MM-DD) in the per-town store; credits the shared crystal wallet.
- **`components/hub/HubTownUpgrades.tsx`** (+ story) — tribute row with a Collect button (disabled once collected today; hidden until a service is unlocked).
- **`HubWorld.tsx`** — collect handler credits crystals, updates the wallet, and confirms via the Town Steward.
- **`reputation.test.ts`** — scaling with unlocked services + once-per-day behaviour.
- **`docs/hubworld.md`** — documented under §10 Services.

## Why tribute (vs. the inn-rest example)
There's no existing rest mechanic or per-town shop in the hub to hook into (the daily Shop is global), so a tribute is the cleanest genuinely town-scoped effect that ties directly to the catalog `service` ids without touching fragile global systems. Other service-specific effects can hook the same `getUnlockedServices`/`hasTownService` reads later.

## Verification
- `npm run build` passes; `reputation.test.ts` 12/12 green (unit suite unaffected). Storybook browser project can't launch Chromium in this sandbox (environmental).
- In-game: upgrade a building → a tribute row appears in 🏗️ Town Upgrades; Collect credits crystals and disables until tomorrow; persists across reload.

https://claude.ai/code/session_01CSjZieb74WwKBH5qjxyDEC

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSjZieb74WwKBH5qjxyDEC)_