### PR TITLE
Expose save data export/import via ?debug URL param

### DIFF
--- a/web/src/components/screens/SettingsScreen.tsx
+++ b/web/src/components/screens/SettingsScreen.tsx
@@ -635,9 +635,8 @@ export function SettingsScreen({ onBack, onResetGame, user, authLoading, onDevCr
           </Section>
         )}
 
-        {user?.uid === GIFT_OWNER_UID && (onGiftAdmin || onNewsAdmin || onFeedbackAdmin) && (
-<>
-      <Section bordered title="DEBUG">
+        {(isDebugMode || user?.uid === GIFT_OWNER_UID) && (
+          <Section bordered title="DEBUG">
             <div className="settings-row u-flex u-items-c u-just-sb u-gap-7">
               <div>
                 <div className="settings-label">Export save data</div>
@@ -682,6 +681,9 @@ export function SettingsScreen({ onBack, onResetGame, user, authLoading, onDevCr
               </div>
             )}
           </Section>
+        )}
+
+        {user?.uid === GIFT_OWNER_UID && (onGiftAdmin || onNewsAdmin || onFeedbackAdmin) && (
           <Section bordered title="ADMIN">
             {onGiftAdmin && (
               <div className="settings-row u-flex u-items-c u-just-sb u-gap-7">
@@ -727,7 +729,6 @@ export function SettingsScreen({ onBack, onResetGame, user, authLoading, onDevCr
               <button className="action-btn action-btn--danger" onClick={handleResetHubData}>RESET</button>
             </div>
           </Section>
-</>
         )}
 
         {isDevMode() && onDevCrystalsChanged && onDevHandicapChanged && (


### PR DESCRIPTION
## What

Make the **Export / Import save data** controls on the Settings screen reachable via a `?debug` URL parameter, so a player (e.g. for diagnosis) can self-serve a save export without being signed in as the owner account.

## Why

The Export/Import buttons lived in a `DEBUG` section gated solely behind `user?.uid === GIFT_OWNER_UID`. A `?debug` query param already existed in the file (`const isDebugMode = new URLSearchParams(window.location.search).has('debug')`) but was **dead code** — defined and never used.

## Change

Split the previously combined owner-only block into two:

- **DEBUG** section (Export / Import save data + Rollbar test buttons) — now shows when `?debug` is present **or** the owner is signed in.
- **ADMIN** section (gift / news / campaign / feedback management, hub reset) — unchanged, stays **strictly owner-only**.

So `https://jawg.uk/?debug` now reveals the export/import controls to anyone, but admin tooling remains locked to the owner account.

## Footgun note

This intentionally exposes a full `localStorage` export/import to anyone who knows the `?debug` param. Export is read-only; Import overwrites local save data but only via an explicit file picker, so the risk is low — but worth being aware of.

## Verification

- `npm run build` passes (`tsc` + vite).

https://claude.ai/code/session_013LyuKtSLP86mUNdUe3TY4j

---
_Generated by [Claude Code](https://claude.ai/code/session_013LyuKtSLP86mUNdUe3TY4j)_