### PR TITLE
Guard against soft-locks: invalid active deck + zombie 0-life run

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -301,6 +301,18 @@ export default function App() {
   // game state immediately so they land straight back in the battle.
   const [_startup] = useState(() => {
     const savedRun = loadRun()
+    // Guard: a run drained to 0 lives is unplayable. Normally hitting 0 lives clears
+    // the run via the campaign-failed flow, so a *persisted* 0-life run is a corrupted
+    // /zombie state (e.g. from the pre-#1702 bug where losing a non-campaign battle
+    // drained campaign lives). Treat it as a failed run — record the failure so the
+    // next run gets mercy tiers, clear it, and show the campaign-failed screen —
+    // rather than leaving a soft-locked "Continue Run".
+    if (savedRun && savedRun.livesRemaining <= 0) {
+      rollbar.error('Campaign run loaded at 0 lives — auto-failing', { actId: savedRun.actId })
+      setLastRunFailed()
+      clearRun()
+      return { screen: 'campaignfailed' as Screen, gameState: null as GameState | null, run: null as RunState | null, isCampaign: false }
+    }
     if (savedRun?.pendingNodeId) {
       const act  = ACTS[savedRun.actId]
       const node = act?.nodes[savedRun.pendingNodeId]

--- a/web/src/components/title/TitleScreen.tsx
+++ b/web/src/components/title/TitleScreen.tsx
@@ -213,12 +213,11 @@ export function TitleScreen({ crystals, onPlay, onEndless, onCampaign, onCollect
         </TitleButton>
 
         <TitleButton
-          onClick={onPlay}
+          onClick={valid ? onPlay : onDeckBuilder}
           extraClass="title-primary-btn"
-          disabled={!valid}
-          title={valid ? undefined : `Deck needs ${10 - count} more cards`}
+          title={valid ? undefined : `Deck needs ${10 - count} more cards — tap to fix in the deck builder`}
         >
-          {valid ? '▶  QUICK BATTLE' : `⚠ DECK (${count}/10)`}
+          {valid ? '▶  QUICK BATTLE' : `⚠ FIX DECK (${count}/10)`}
         </TitleButton>
 
         <TitleButton


### PR DESCRIPTION
## Why

Diagnosing a player's stuck save revealed two *silent soft-locks* (neither gave the player a way out):

1. **Invalid active deck** — his active deck slot held only 9 cards (<10 min). `isDeckValid` failed, so Quick Battle / Endless / Continue all disabled, and the disabled `⚠ DECK` button did nothing when tapped. No obvious recovery path.
2. **Zombie 0-life run** — his campaign run was stuck at `livesRemaining: 0` (a corrupted state, e.g. from the pre-#1702 bug where losing a non-campaign battle drained campaign lives). Normally hitting 0 lives clears the run, but a *persisted* 0-life run just sat there unplayable.

## Changes

**Guard A — `TitleScreen.tsx`:** When the active deck is invalid, the QUICK BATTLE button is no longer a disabled dead end. It becomes an enabled shortcut to the deck builder, labelled `⚠ FIX DECK (n/10)` with a "tap to fix" tooltip — so an invalid active deck is self-recoverable in one tap.

**Guard B — `App.tsx` (`_startup`):** If a campaign run loads with `livesRemaining <= 0`, treat it as a failed run: log it (rollbar), record the failure so the next run gets mercy tiers (`setLastRunFailed`), `clearRun()`, and route to the campaign-failed screen — instead of leaving a soft-locked "Continue Run". (Per the earlier decision: auto-fail & clear, rather than restore lives.)

## Notes

- These are defense-in-depth; #1702 already removed the main *source* of 0-life corruption. Guard B catches saves already corrupted before that fix deployed.
- `npm run build` passes (`tsc` + vite).

https://claude.ai/code/session_013LyuKtSLP86mUNdUe3TY4j

---
_Generated by [Claude Code](https://claude.ai/code/session_013LyuKtSLP86mUNdUe3TY4j)_