### PR TITLE
Make hub building upgrades visibly change the building

### DIFF
--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -701,8 +701,13 @@ export function HubTownCanvas({
     {
       for (const b of HUB_BUILDINGS) {
         if (!b.id || !b.upgradeKind) continue
-        const door = HUB_DOORS.find(d => d.buildingId === b.id)
-        if (!door) continue
+        // Anchor decor at the building's primary door; fall back to the front
+        // centre of its footprint when the door comes from a bundle/elsewhere.
+        const foundDoor = HUB_DOORS.find(d => d.buildingId === b.id)
+        const door = foundDoor ?? {
+          tx: Math.floor((b.rect[0] + b.rect[2]) / 2),
+          ty: b.rect[3] + 1,
+        }
         const track = getUpgradeTrack(b.upgradeKind)
         const currentLevel = buildingUpgradeLevelsRef?.current[b.id] ?? 0
         track.forEach((lvl, levelIndex) => {

--- a/web/src/data/hub/buildingUpgrades.json
+++ b/web/src/data/hub/buildingUpgrades.json
@@ -2,78 +2,78 @@
   "shop": [
     { "label": "Stocked Shelves", "cost": 120, "repReward": 40, "repRequired": 0,
       "benefit": "Wider, deeper shop stock.", "service": "shop-stock",
-      "decor": [{ "dx": -1, "dy": 0, "tileId": "crate" }] },
+      "decor": [{ "dx": -1, "dy": 0, "tileId": "crate" }, { "dx": 1, "dy": 0, "tileId": "barrel" }] },
     { "label": "Trade Counter", "cost": 280, "repReward": 80, "repRequired": 150,
       "benefit": "A standing daily discount on purchases.", "service": "shop-discount",
-      "decor": [{ "dx": 1, "dy": 0, "tileId": "pileOfSacks" }] },
+      "decor": [{ "dx": -2, "dy": 0, "tileId": "pileOfSacks" }, { "dx": 2, "dy": 0, "tileId": "crate" }] },
     { "label": "Guild Charter", "cost": 600, "repReward": 160, "repRequired": 350,
       "benefit": "Premium rare stock and the best prices in the shard.", "service": "shop-premium",
-      "decor": [{ "dx": -2, "dy": 0, "tileId": "goldSign" }] }
+      "decor": [{ "dx": 0, "dy": 2, "tileId": "goldSign" }, { "dx": -1, "dy": 1, "tileId": "goldChest" }] }
   ],
   "inn": [
     { "label": "Fresh Linens", "cost": 110, "repReward": 40, "repRequired": 0,
       "benefit": "A more comfortable common room.", "service": "inn-rest",
-      "decor": [{ "dx": -1, "dy": 0, "tileId": "barrel" }] },
+      "decor": [{ "dx": -1, "dy": 0, "tileId": "barrel" }, { "dx": 1, "dy": 0, "tileId": "barrel" }] },
     { "label": "Hearth & Bench", "cost": 260, "repReward": 80, "repRequired": 150,
       "benefit": "More rumours and traveller gossip.", "service": "inn-rumours",
-      "decor": [{ "dx": 1, "dy": 0, "tileId": "benchMiddle" }] },
+      "decor": [{ "dx": -2, "dy": 0, "tileId": "floorLantern" }, { "dx": 2, "dy": 0, "tileId": "potOfFlowers" }] },
     { "label": "Grand Sign", "cost": 560, "repReward": 160, "repRequired": 350,
       "benefit": "A renowned inn that draws notable guests.", "service": "inn-guests",
-      "decor": [{ "dx": -2, "dy": 0, "tileId": "innSign" }] }
+      "decor": [{ "dx": 0, "dy": 2, "tileId": "innSign" }, { "dx": -1, "dy": 1, "tileId": "floorLantern" }] }
   ],
   "tavern": [
     { "label": "Full Cellar", "cost": 110, "repReward": 40, "repRequired": 0,
       "benefit": "Better brews on tap.", "service": "tavern-brews",
-      "decor": [{ "dx": -1, "dy": 0, "tileId": "barrel" }] },
+      "decor": [{ "dx": -1, "dy": 0, "tileId": "barrel" }, { "dx": 1, "dy": 0, "tileId": "bottlesOfLiquor" }] },
     { "label": "Bottle Rack", "cost": 250, "repReward": 80, "repRequired": 150,
       "benefit": "Rare vintages and louder revelry.", "service": "tavern-rare",
-      "decor": [{ "dx": 1, "dy": 0, "tileId": "bottlesOfLiquor" }] },
+      "decor": [{ "dx": -2, "dy": 0, "tileId": "barrel" }, { "dx": 2, "dy": 0, "tileId": "barrel" }] },
     { "label": "Tavern Sign", "cost": 540, "repReward": 160, "repRequired": 350,
       "benefit": "A landmark tavern known across the shard.", "service": "tavern-landmark",
-      "decor": [{ "dx": -2, "dy": 0, "tileId": "drinkSign" }] }
+      "decor": [{ "dx": 0, "dy": 2, "tileId": "drinkSign" }, { "dx": -1, "dy": 1, "tileId": "bottlesOfLiquor" }] }
   ],
   "cottage": [
     { "label": "Window Box", "cost": 90, "repReward": 35, "repRequired": 0,
       "benefit": "A cheerier, well-kept home.", "service": "cottage-decor",
-      "decor": [{ "dx": -1, "dy": 0, "tileId": "pinkFlower" }] },
+      "decor": [{ "dx": -1, "dy": 0, "tileId": "pinkFlower" }, { "dx": 1, "dy": 0, "tileId": "blueFlower" }] },
     { "label": "Flower Pots", "cost": 220, "repReward": 70, "repRequired": 120,
       "benefit": "A blooming garden the whole street admires.", "service": "cottage-garden",
-      "decor": [{ "dx": 1, "dy": 0, "tileId": "potOfFlowers" }] },
+      "decor": [{ "dx": -2, "dy": 0, "tileId": "potOfFlowers" }, { "dx": 2, "dy": 0, "tileId": "potOfFlowers" }] },
     { "label": "Lantern Post", "cost": 480, "repReward": 140, "repRequired": 300,
       "benefit": "Warm lantern-light that keeps the lane lively after dark.", "service": "cottage-lantern",
-      "decor": [{ "dx": -2, "dy": 0, "tileId": "floorLantern" }] }
+      "decor": [{ "dx": 0, "dy": 2, "tileId": "floorLantern" }, { "dx": 1, "dy": 1, "tileId": "potOfFlowers" }] }
   ],
   "workshop": [
     { "label": "Tool Crates", "cost": 130, "repReward": 40, "repRequired": 0,
       "benefit": "Faster, sturdier craftwork.", "service": "workshop-craft",
-      "decor": [{ "dx": -1, "dy": 0, "tileId": "crate" }] },
+      "decor": [{ "dx": -1, "dy": 0, "tileId": "crate" }, { "dx": 1, "dy": 0, "tileId": "crate" }] },
     { "label": "Strongbox", "cost": 300, "repReward": 80, "repRequired": 150,
       "benefit": "Commissions completed more quickly.", "service": "workshop-speed",
-      "decor": [{ "dx": 1, "dy": 0, "tileId": "chest" }] },
+      "decor": [{ "dx": -2, "dy": 0, "tileId": "chest" }, { "dx": 2, "dy": 0, "tileId": "barrel" }] },
     { "label": "Master's Mark", "cost": 620, "repReward": 160, "repRequired": 350,
       "benefit": "Masterwork goods bearing the guild mark.", "service": "workshop-master",
-      "decor": [{ "dx": -2, "dy": 0, "tileId": "armourSign" }] }
+      "decor": [{ "dx": 0, "dy": 2, "tileId": "armourSign" }, { "dx": -1, "dy": 1, "tileId": "chest" }] }
   ],
   "shrine": [
     { "label": "Votive Candles", "cost": 100, "repReward": 40, "repRequired": 0,
       "benefit": "A tended, welcoming shrine.", "service": "shrine-blessing",
-      "decor": [{ "dx": -1, "dy": 0, "tileId": "candlestickLitTop" }] },
+      "decor": [{ "dx": -1, "dy": 0, "tileId": "floorLantern" }, { "dx": 1, "dy": 0, "tileId": "floorLantern" }] },
     { "label": "Sacred Brazier", "cost": 240, "repReward": 80, "repRequired": 150,
       "benefit": "Stronger blessings for travellers.", "service": "shrine-ward",
-      "decor": [{ "dx": 1, "dy": 0, "tileId": "brazierTop" }] },
+      "decor": [{ "dx": -2, "dy": 0, "tileId": "potOfFlowers" }, { "dx": 2, "dy": 0, "tileId": "potOfFlowers" }] },
     { "label": "Reliquary", "cost": 520, "repReward": 160, "repRequired": 350,
       "benefit": "A hallowed reliquary that draws pilgrims.", "service": "shrine-relic",
-      "decor": [{ "dx": -2, "dy": 0, "tileId": "goldChest" }] }
+      "decor": [{ "dx": 0, "dy": 2, "tileId": "largeSign" }, { "dx": -1, "dy": 1, "tileId": "goldChest" }] }
   ],
   "default": [
     { "label": "Tidy Frontage", "cost": 100, "repReward": 35, "repRequired": 0,
       "benefit": "A cared-for building the town is proud of.", "service": "decor",
-      "decor": [{ "dx": -1, "dy": 0, "tileId": "lightBush" }] },
+      "decor": [{ "dx": -1, "dy": 0, "tileId": "lightBush" }, { "dx": 1, "dy": 0, "tileId": "lightBush" }] },
     { "label": "Planters", "cost": 240, "repReward": 70, "repRequired": 120,
       "benefit": "Greenery that brightens the whole street.", "service": "decor",
-      "decor": [{ "dx": 1, "dy": 0, "tileId": "potOfFlowers" }] },
+      "decor": [{ "dx": -2, "dy": 0, "tileId": "potOfFlowers" }, { "dx": 2, "dy": 0, "tileId": "potOfFlowers" }] },
     { "label": "Proud Sign", "cost": 500, "repReward": 140, "repRequired": 300,
       "benefit": "A landmark frontage known across town.", "service": "decor",
-      "decor": [{ "dx": -2, "dy": 0, "tileId": "largeSign" }] }
+      "decor": [{ "dx": 0, "dy": 2, "tileId": "largeSign" }, { "dx": -1, "dy": 1, "tileId": "potOfFlowers" }] }
   ]
 }

--- a/web/src/data/hub/config.ts
+++ b/web/src/data/hub/config.ts
@@ -278,7 +278,7 @@ export interface RawAnimal {
   questGive?: string
   questReceive?: string | string[]
   roam?: boolean                     // default false for placed animals
-  areaRect?: [number, number, number, number]  // [tx, ty, w, h] roam bounds
+  areaRect?: number[]  // [tx, ty, w, h] roam bounds (JSON infers number[])
 }
 
 export interface RawConfig {

--- a/web/src/data/hub/loader.ts
+++ b/web/src/data/hub/loader.ts
@@ -118,7 +118,7 @@ export interface HubAnimal {
   questGive?: string
   questReceive?: string | string[]
   roam?: boolean
-  areaRect?: [number, number, number, number]
+  areaRect?: number[]
 }
 
 export interface HubPickupItem {


### PR DESCRIPTION
You reported upgrading the inn but seeing no visible change. Investigation: the decor system worked, but each level only placed **a single small tile** one square from the door (e.g. one barrel for the inn), which is very easy to miss — and any building whose door comes from a bundle (not in `HUB_DOORS`) was skipped entirely.

## Fixes
- **Bolder, unmistakable decor** — every upgrade level now places **two prominent flanking items in front of the building** instead of one. Upgrading visibly develops the frontage (e.g. the inn gains barrels → a lantern + flowers → a grand sign + lantern across its three levels).
- **Door-less fallback** — `HubTownCanvas` now falls back to the building footprint's front-centre when a building has no `HUB_DOORS` entry, so **every** tagged building shows its decor.

## Also (unrelated, pre-existing build break)
`npm run build` (`tsc && vite build`) was **already red on `main`** — a recently merged config added an animal with an `areaRect`, which JSON infers as `number[]` and no longer matched the `[number,number,number,number]` tuple type. Loosened the `areaRect` type in `config.ts` + `loader.ts` to `number[]` (the field is reserved/unused), which unblocks the build for the whole repo. Called out separately so it's easy to review.

## Verification
- `npm run build` now passes (was failing on main before this PR).
- `reputation.test.ts` 12/12 green; all catalog `tileId`s verified to exist in `baseChipIndex.ts`.
- In-game: upgrade a building → two bold decor items appear in front immediately; each further level adds more; persists across reload.

Note: if you were testing the live site, a hard refresh (or clearing the PWA cache) ensures you're on the latest build.

https://claude.ai/code/session_01CSjZieb74WwKBH5qjxyDEC

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSjZieb74WwKBH5qjxyDEC)_