### PR TITLE
Hub: ambient music + SFX, with per-building music & ambiance

### DIFF
--- a/docs/hubworld.md
+++ b/docs/hubworld.md
@@ -819,3 +819,38 @@ the crystals invested. Additional service-specific effects can hook the same
 4. Verify in-game: open 🏗️ Town Upgrades, buy a level → crystals drop, standing
    rises, the new decor appears on the building immediately, a rep-locked tier
    stays blocked until standing is high enough, and everything survives a reload.
+
+---
+
+## §11 — Hub Audio (music, ambiance & SFX)
+
+The hub world has its own procedural audio (no external files — everything is
+synthesised in `web/src/game/sound.ts`, respecting the global mute/volume).
+
+### Town music
+A calm town theme (`HUB_MUSIC`, id `hub`) starts whenever the hub screen is
+active, routed by `web/src/hooks/useMusic.ts` (one track at a time, same contract
+as battle/map music).
+
+### Per-building music & ambiance
+Each interior in `config.json` may set two optional fields:
+
+| Field | Type | Description |
+|---|---|---|
+| `musicId` | `string` | Swaps the town theme for a building track while the player is inside. Keys: see `BUILDING_MUSIC_TRACKS` (`inn`, `church`, `shop`). Omit to keep the town theme. |
+| `ambianceId` | `string` | A low-volume looping bed layered **under** the music. Keys: see `AMBIANCE_TRACKS` (`hearth`, `sacred`, `market`). Omit for silence. |
+
+On entering a building `HubTownCanvas` calls `startInteriorAudio(musicId, ambianceId)`;
+on exit `stopInteriorAudio()` restores the town theme and drops the ambiance.
+Both id lists are exported (`BUILDING_MUSIC_IDS`, `AMBIANCE_IDS`) and surfaced as
+dropdowns on the interior in the **map editor** (`EntityInspector` → Music /
+Ambiance). Example (Ravenwatch): the inn uses `inn` + `hearth`, the church uses
+`church` + `sacred`, the market hall uses `shop` + `market`.
+
+To add a new track: define a `MusicTrackConfig` in `sound.ts`, add it to
+`BUILDING_MUSIC_TRACKS` or `AMBIANCE_TRACKS`, and it appears in the editor.
+
+### Ambient SFX
+Wired through `emitSound(id)` (ids documented in `web/src/data/sounds.json`):
+`hubFootstep` (throttled, per walk tile), `pickup` (item collect), `treasure`
+(chest), and `dayNightChime` (dawn/dusk transition). All honour mute/volume.

--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -8,6 +8,7 @@ import { PATH_TILE } from '../../data/tiles/tileIndex'
 import { findPath, nearestWalkable } from '../../utils/hubPathfinder'
 import { isBuildingOpen, getNpcLocation, getNpcActivity } from '../../game/hub/hubNpcSchedule'
 import { getGameHour, getGameMinute } from '../../game/hub/hubClock'
+import { emitSound, startInteriorAudio, stopInteriorAudio } from '../../game/sound'
 import { getWallTile, ROOF_TILES, WALL_TILES, ROOF_ROWS } from '../../data/tiles/buildingMaterials'
 import type { WallMaterial, RoofMaterial } from '../../data/tiles/buildingMaterials'
 import { loadPlayerAvatar } from '../../game/questline'
@@ -1345,6 +1346,7 @@ export function HubTownCanvas({
         interiorAnimals.length = 0
         currentInteriorId = null
         highlightGfx.clear()
+        stopInteriorAudio()  // resume town theme + drop ambiance
         onExitInteriorRef.current?.()
       } catch (e) {
         rollbar.error('[HubTownCanvas] doExitInterior error', { error: String(e) })
@@ -1382,6 +1384,9 @@ export function HubTownCanvas({
 
       // Notify HubWorld that entry succeeded (must happen after all guard returns)
       onEnterInteriorRef.current?.()
+
+      // Per-building audio: swap to the interior's music / ambiance (if authored)
+      startInteriorAudio(interior.musicId, interior.ambianceId)
 
       // Hide exterior layers
       groundLayer.visible   = false
@@ -1969,6 +1974,7 @@ export function HubTownCanvas({
         await tweenLinear(av, targetX, targetY, duration)
         currentTile = [tx, ty]
         _savedTiles.set(locationKey, [tx, ty])
+        emitSound('hubFootstep')  // throttled internally
 
         // Touch-pickup: collect requireTouch items when avatar walks onto their tile
         for (const [pid, sprite] of pickupSprites) {
@@ -2141,6 +2147,7 @@ export function HubTownCanvas({
     let _lastNightAlpha = -1
     let _lastNightAvatarX = -Infinity, _lastNightAvatarY = -Infinity
     let _lastReportX = -Infinity, _lastReportY = -Infinity
+    let _lastIsNight = isNightRef.current  // for the day↔night transition chime
     // ── Animals (cats, dogs, birds, fish) ──────────────────────────────────────
     // Building roof ridges (top row of each building) are bird perch candidates.
     const animalRoofTiles: [number, number][] = []
@@ -2421,6 +2428,12 @@ export function HubTownCanvas({
           const newLoc = getNpcLocation(npc, gameHourRef.current)
           walkNamedNpc(npc, ws, container, newLoc)
         }
+      }
+
+      // Day↔night transition chime — fires once when the day phase flips.
+      if (isNightRef.current !== _lastIsNight) {
+        _lastIsNight = isNightRef.current
+        if (!interiorActive) emitSound('dayNightChime')
       }
 
       // Night dimming — canvas 2D destination-out digs transparent torch-light holes.

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -8,6 +8,7 @@ import { HubReturnButton } from './HubReturnButton'
 import { HubDialogue } from './HubDialogue'
 import type { DialogueChoice } from './HubDialogue'
 import type { HubQuestDef, DialogueTree, DialogueChoiceDef } from '../../data/hub/questDefs'
+import { emitSound } from '../../game/sound'
 import { getPickedUpIds, markPickedUp, unmarkPickedUp } from '../../game/hub/pickups'
 import { getFriendshipLevel, addFriendshipXp, getFriendshipData } from '../../game/hub/friendship'
 import { addRelationshipPoints, getRelationship } from '../../game/hub/relationships'
@@ -463,6 +464,7 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onEndless, onWorldMap
   const handleTreasureStep = useCallback((id: string) => {
     const treasure = locationData.HUB_TREASURES.find(t => t.id === id)
     if (!treasure) return
+    emitSound('treasure')
     markTreasureCollected(id)
     const { reward } = treasure
     if (reward.crystals) {
@@ -483,6 +485,7 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onEndless, onWorldMap
   }, [refreshState])
 
   const handleItemPickup = useCallback((id: string, questId?: string) => {
+    emitSound('pickup')
     markPickedUp(id)
     setPickedUpIds(getPickedUpIds())
 

--- a/web/src/components/mapEditor/EntityInspector.tsx
+++ b/web/src/components/mapEditor/EntityInspector.tsx
@@ -7,6 +7,7 @@ import { RawQuestPickupItem } from '../../data/hub/hubWorldFactory'
 import { NpcSpritePicker, AnimalTypePicker } from './SpritePicker'
 import { ANIMAL_SPECS } from '../../game/hub/animals'
 import type { AnimalType } from '../../game/hub/animals'
+import { BUILDING_MUSIC_IDS, AMBIANCE_IDS } from '../../game/sound'
 
 const FLOOR_TILES = [
   'woodFloor', 'stoneFloor', 'cobblestoneFloor', 'quarteredFloor', 'checkeredFloor',
@@ -737,6 +738,26 @@ function InteriorInspector({
               >
                 <option value="">— none —</option>
                 {WALL_MATERIALS.map(m => <option key={m} value={m}>{m}</option>)}
+              </select>
+            </Field>
+            <Field label="Music">
+              <select
+                value={interior.musicId ?? ''}
+                onChange={e => onUpdateInteriorProps(interiorId, { musicId: e.target.value || undefined })}
+                style={{ width: '100%', padding: '3px 5px', background: '#111', border: '1px solid #444', color: '#eee', borderRadius: 3, fontSize: 11 }}
+              >
+                <option value="">— town theme —</option>
+                {BUILDING_MUSIC_IDS.map(id => <option key={id} value={id}>{id}</option>)}
+              </select>
+            </Field>
+            <Field label="Ambiance">
+              <select
+                value={interior.ambianceId ?? ''}
+                onChange={e => onUpdateInteriorProps(interiorId, { ambianceId: e.target.value || undefined })}
+                style={{ width: '100%', padding: '3px 5px', background: '#111', border: '1px solid #444', color: '#eee', borderRadius: 3, fontSize: 11 }}
+              >
+                <option value="">— none —</option>
+                {AMBIANCE_IDS.map(id => <option key={id} value={id}>{id}</option>)}
               </select>
             </Field>
             <Field label="Decor items"><span style={{ color: '#aaa' }}>{interior.decor.length} items</span></Field>

--- a/web/src/components/mapEditor/mapEditorTypes.ts
+++ b/web/src/components/mapEditor/mapEditorTypes.ts
@@ -89,6 +89,8 @@ export interface RawInterior {
   wallMaterial?: string
   decor: RawDecorItem[]
   hours?: { open: number; close: number } | 'always'
+  musicId?: string
+  ambianceId?: string
   exits?: Array<{
     tx: number
     ty: number

--- a/web/src/data/hub/config.ts
+++ b/web/src/data/hub/config.ts
@@ -111,6 +111,11 @@ export interface RawInterior {
   }>
 
   hours?: string | OpenAndCloseTime
+
+  /** Interior music track id (see BUILDING_MUSIC_TRACKS in sound.ts). */
+  musicId?: string
+  /** Ambiance bed id (see AMBIANCE_TRACKS in sound.ts). */
+  ambianceId?: string
 }
 
 

--- a/web/src/data/hub/loader.ts
+++ b/web/src/data/hub/loader.ts
@@ -69,6 +69,10 @@ export interface HubInterior {
   wallMaterial?: WallMaterial
   exits?: HubInteriorExit[]
   hours?: { open: number; close: number } | 'always'
+  /** Interior music track id (BUILDING_MUSIC_TRACKS) — swaps town theme while inside. */
+  musicId?: string
+  /** Ambiance bed id (AMBIANCE_TRACKS) — layered under the music while inside. */
+  ambianceId?: string
 }
 
 /** Visible activity an NPC performs while at a scheduled location. */
@@ -451,6 +455,8 @@ const HUB_INTERIORS: Record<string, HubInterior> = Object.fromEntries(
         }),
         exits: ((rawAny.exits ?? []) as HubInteriorExit[]),
         hours: rawAny.hours as HubInterior['hours'],
+        musicId:    rawAny.musicId as string | undefined,
+        ambianceId: rawAny.ambianceId as string | undefined,
       } satisfies HubInterior,
     ]
   })

--- a/web/src/data/hub/ravenwatch/config.json
+++ b/web/src/data/hub/ravenwatch/config.json
@@ -5463,6 +5463,8 @@
     },
     "inn-building": {
       "name": "The Wanderer's Rest",
+      "musicId": "inn",
+      "ambianceId": "hearth",
       "width": 12,
       "height": 9,
       "floorTileId": "darkWoodFloor",
@@ -5621,6 +5623,8 @@
     },
     "market-building": {
       "name": "The Market Hall",
+      "musicId": "shop",
+      "ambianceId": "market",
       "width": 14,
       "height": 10,
       "floorTileId": "cobblestoneFloor",
@@ -6395,6 +6399,8 @@
     },
     "church": {
       "name": "Church",
+      "musicId": "church",
+      "ambianceId": "sacred",
       "width": 14,
       "height": 10,
       "wallTileId": "interiorWallWhite",

--- a/web/src/data/sounds.json
+++ b/web/src/data/sounds.json
@@ -125,6 +125,30 @@
       "name": "Map Footstep",
       "category": "ui",
       "description": "Soft thud when the player avatar begins walking to a new node"
+    },
+    {
+      "id": "hubFootstep",
+      "name": "Hub Footstep",
+      "category": "hub",
+      "description": "Soft, throttled footstep as the avatar walks each tile in the hub world"
+    },
+    {
+      "id": "pickup",
+      "name": "Item Pickup",
+      "category": "hub",
+      "description": "Light two-note chime when collecting a hub pickup item"
+    },
+    {
+      "id": "treasure",
+      "name": "Treasure Collect",
+      "category": "hub",
+      "description": "Rewarding ascending sparkle when opening a hub treasure chest"
+    },
+    {
+      "id": "dayNightChime",
+      "name": "Day/Night Chime",
+      "category": "hub",
+      "description": "Gentle transition sting when the hub flips between day and night"
     }
   ]
 }

--- a/web/src/game/sound.ts
+++ b/web/src/game/sound.ts
@@ -234,6 +234,41 @@ export function playMapFootstep() {
   node(80,  'sawtooth', t + 0.02, 0.04, 0.14)
 }
 
+// Hub footstep — softer/quieter than the map version and throttled so the
+// per-tile walk in the hub world does not flood the channel.
+let _lastHubStepMs = 0
+export function playHubFootstep() {
+  const now2 = Date.now()
+  if (now2 - _lastHubStepMs < 180) return
+  _lastHubStepMs = now2
+  const t = now()
+  node(150, 'sine', t,        0.04, 0.12)
+  node(90,  'sine', t + 0.02, 0.03, 0.08)
+}
+
+export function playPickup() {
+  const t = now()
+  // Light two-note pleasant chime when collecting an item
+  node(880,  'sine', t,        0.06, 0.20)
+  node(1320, 'sine', t + 0.06, 0.10, 0.18)
+}
+
+export function playTreasure() {
+  const t = now()
+  // Rewarding ascending sparkle (richer than pickup) for treasure chests
+  const melody = [659, 880, 1175, 1568]
+  melody.forEach((f, i) => node(f, 'sine', t + i * 0.08, 0.16, 0.24))
+  node(330, 'triangle', t, 0.30, 0.16)  // warm low body
+}
+
+export function playDayNightChime() {
+  const t = now()
+  // Gentle two-note transition sting marking dawn/dusk
+  node(523, 'triangle', t,        0.45, 0.16)
+  node(784, 'sine',     t + 0.12, 0.40, 0.13)
+}
+
+
 // ─── Music Engine ─────────────────────────────────────────────────────────────
 // Look-ahead scheduler pattern — runs a setInterval every SCHEDULE_MS and
 // pre-schedules Web Audio notes up to LOOKAHEAD_SEC ahead of playback.
@@ -635,6 +670,239 @@ export const MAP_MUSIC: MusicTrackConfig = { id: 'map', bpm: MAP_BPM, vol: MAP_V
 export function startMapMusic(): void { startMusicTrack(MAP_MUSIC) }
 export function stopMapMusic(): void  { stopMusicTrack('map') }
 
+// ─── Hub Music (G major, calm & towny, 66 BPM) ───────────────────────────────
+// Gentle, unhurried village theme: soft bass, warm triangle pads and a light
+// pluck melody. 3 phrases × 8 beats = 24-beat cycle (~21.8 s).
+
+const HUB_BPM = 66
+const HUB_VOL = 0.09
+
+// G major pentatonic: G2, D3, G3, A3, B3, D4, E4, G4
+const HP = [98.0, 146.8, 196.0, 220.0, 246.9, 293.7, 329.6, 392.0]
+const HB = [49.0, 73.4, 65.4]  // bass roots: G1, D2, C2
+
+const H_PAD: (number|null)[][] = [
+  [2, null, 4, null, 5,    null, 4, null],   // G centre — settled
+  [3, null, 5, null, 6,    null, 5, null],   // A/D — lifts
+  [1, null, 4, null, 3,    null, 5, null],   // gentle resolve
+]
+const H_TOP: (number|null)[][] = [
+  [null, 5, null, 7, null, 6,    null, 5],
+  [null, 6, null, 7, null, 5,    null, 4],
+  [null, 7, null, 5, null, 4,    null, 6],
+]
+const H_BASS = [[0, 1], [1, 2], [2, 0]]  // bass root indices per phrase [beat0, beat4]
+
+function scheduleHub(track: MusicTrack, vol: number, beatSec: number, upTo: number): void {
+  while (track.nextBeatTime < upTo) {
+    const phrase = Math.floor(track.beatIndex / 8) % 3
+    const beat   = track.beatIndex % 8
+    const t      = track.nextBeatTime
+    const n      = (f: number, type: OscillatorType, off: number, dur: number, v: number) =>
+                     musicNote(track, vol, f, type, t + off, dur, v)
+
+    // Soft bass on beats 0 and 4
+    if (beat === 0 || beat === 4) {
+      const bIdx = beat === 0 ? H_BASS[phrase][0] : H_BASS[phrase][1]
+      n(HB[bIdx], 'sine', 0, beatSec * 1.9, 0.40)
+      n(HB[bIdx] * 2, 'sine', 0, beatSec * 1.6, 0.14)
+    }
+
+    // Warm pad
+    const padIdx = H_PAD[phrase][beat]
+    if (padIdx !== null) n(HP[padIdx], 'triangle', 0, beatSec * 1.4, 0.26)
+
+    // Light pluck melody up an octave
+    const topIdx = H_TOP[phrase][beat]
+    if (topIdx !== null) n(HP[topIdx] * 2, 'sine', beatSec * 0.1, beatSec * 0.55, 0.16)
+
+    track.nextBeatTime += beatSec
+    track.beatIndex++
+  }
+}
+
+export const HUB_MUSIC: MusicTrackConfig = { id: 'hub', bpm: HUB_BPM, vol: HUB_VOL, schedule: scheduleHub }
+
+export function startHubMusic(): void { startMusicTrack(HUB_MUSIC) }
+export function stopHubMusic(): void  { stopMusicTrack('hub') }
+
+// ─── Building interior music ─────────────────────────────────────────────────
+// Each interior can pick a `musicId` (see BUILDING_MUSIC_TRACKS). When the player
+// enters such a building the town theme is swapped for the building's track and
+// restored on exit. Authored per-building in the map editor.
+
+// Inn — lively D-major tavern jig (108 BPM): bouncy bass + jaunty melody.
+const INN_NOTES = [146.8, 220.0, 293.7, 329.6, 392.0, 440.0, 587.3]  // D3,A3,D4,E4,G4,A4,D5
+const INN_BASS  = [73.4, 110.0, 98.0]  // D2, A2, G2
+const INN_MEL: (number|null)[][] = [
+  [2, 3, 4, 3, 2, 4, 3, 2],
+  [4, 5, 4, 3, 2, 3, 4, 5],
+  [2, 4, 6, 4, 3, 5, 4, 2],
+]
+function scheduleInn(track: MusicTrack, vol: number, beatSec: number, upTo: number): void {
+  while (track.nextBeatTime < upTo) {
+    const phrase = Math.floor(track.beatIndex / 8) % 3
+    const beat   = track.beatIndex % 8
+    const t      = track.nextBeatTime
+    const n = (f: number, ty: OscillatorType, off: number, dur: number, v: number) =>
+                musicNote(track, vol, f, ty, t + off, dur, v)
+    // Oom-pah bass: root on the beat, fifth on the off-beat
+    const root = INN_BASS[[0, 1, 2][phrase]]
+    n(root, 'triangle', 0, beatSec * 0.45, 0.4)
+    n(root * 1.5, 'triangle', beatSec * 0.5, beatSec * 0.4, 0.26)
+    const mIdx = INN_MEL[phrase][beat]
+    if (mIdx !== null) n(INN_NOTES[mIdx], 'square', beatSec * 0.05, beatSec * 0.5, 0.12)
+    track.nextBeatTime += beatSec
+    track.beatIndex++
+  }
+}
+export const INN_MUSIC: MusicTrackConfig = { id: 'music-inn', bpm: 108, vol: 0.085, schedule: scheduleInn }
+
+// Church/temple — solemn, slow sustained chords (50 BPM), A minor / modal.
+const CH_CHORD = [
+  [110.0, 164.8, 220.0],  // A2 E3 A3
+  [98.0,  146.8, 196.0],  // G2 D3 G3
+  [130.8, 196.0, 261.6],  // C3 G3 C4
+]
+function scheduleChurch(track: MusicTrack, vol: number, beatSec: number, upTo: number): void {
+  while (track.nextBeatTime < upTo) {
+    const phrase = Math.floor(track.beatIndex / 4) % 3
+    const beat   = track.beatIndex % 4
+    const t      = track.nextBeatTime
+    const n = (f: number, ty: OscillatorType, off: number, dur: number, v: number) =>
+                musicNote(track, vol, f, ty, t + off, dur, v)
+    if (beat === 0) {
+      // Sustained organ chord held across the whole bar
+      for (const f of CH_CHORD[phrase]) n(f, 'sine', 0, beatSec * 3.8, 0.18)
+      n(CH_CHORD[phrase][0] / 2, 'sine', 0, beatSec * 3.8, 0.12)  // sub octave
+    }
+    // Sparse high shimmer on beat 2
+    if (beat === 2) n(CH_CHORD[phrase][2] * 2, 'triangle', 0, beatSec * 1.5, 0.07)
+    track.nextBeatTime += beatSec
+    track.beatIndex++
+  }
+}
+export const CHURCH_MUSIC: MusicTrackConfig = { id: 'music-church', bpm: 50, vol: 0.09, schedule: scheduleChurch }
+
+// Shop — light, pleasant, busy little tune (92 BPM), C major.
+const SHOP_N = [261.6, 329.6, 392.0, 523.2, 659.3]  // C4 E4 G4 C5 E5
+const SHOP_MEL: (number|null)[][] = [
+  [0, 2, 1, 3, 2, 4, 3, 2],
+  [3, 2, 4, 3, 1, 2, 0, 2],
+]
+function scheduleShop(track: MusicTrack, vol: number, beatSec: number, upTo: number): void {
+  while (track.nextBeatTime < upTo) {
+    const phrase = Math.floor(track.beatIndex / 8) % 2
+    const beat   = track.beatIndex % 8
+    const t      = track.nextBeatTime
+    const n = (f: number, ty: OscillatorType, off: number, dur: number, v: number) =>
+                musicNote(track, vol, f, ty, t + off, dur, v)
+    if (beat % 2 === 0) n(130.8, 'sine', 0, beatSec * 0.9, 0.3)  // soft C3 pulse
+    const mIdx = SHOP_MEL[phrase][beat]
+    if (mIdx !== null) n(SHOP_N[mIdx], 'triangle', beatSec * 0.04, beatSec * 0.45, 0.14)
+    track.nextBeatTime += beatSec
+    track.beatIndex++
+  }
+}
+export const SHOP_MUSIC: MusicTrackConfig = { id: 'music-shop', bpm: 92, vol: 0.08, schedule: scheduleShop }
+
+/** Building interior music tracks, keyed by the `musicId` set on an interior. */
+export const BUILDING_MUSIC_TRACKS: Record<string, MusicTrackConfig> = {
+  inn:    INN_MUSIC,
+  church: CHURCH_MUSIC,
+  shop:   SHOP_MUSIC,
+}
+export const BUILDING_MUSIC_IDS = Object.keys(BUILDING_MUSIC_TRACKS)
+
+// ─── Ambiance beds ───────────────────────────────────────────────────────────
+// Low-volume looping textures that layer *under* the music while inside a
+// building. Picked via an interior's `ambianceId`.
+
+// Hearth — random soft fire crackles/pops.
+function scheduleHearth(track: MusicTrack, vol: number, beatSec: number, upTo: number): void {
+  while (track.nextBeatTime < upTo) {
+    const t = track.nextBeatTime
+    if (Math.random() < 0.6) {
+      const f = 1800 + Math.random() * 2200
+      musicNote(track, vol, f, 'square', t + Math.random() * beatSec, 0.02 + Math.random() * 0.03, 0.05 + Math.random() * 0.05)
+    }
+    if (Math.random() < 0.25) musicNote(track, vol, 90 + Math.random() * 40, 'sine', t, 0.18, 0.06)  // low whoosh
+    track.nextBeatTime += beatSec
+    track.beatIndex++
+  }
+}
+export const HEARTH_AMBIANCE: MusicTrackConfig = { id: 'amb-hearth', bpm: 150, vol: 0.5, schedule: scheduleHearth }
+
+// Sacred — sustained low drone + sparse high bell shimmer (reverberant).
+function scheduleSacred(track: MusicTrack, vol: number, beatSec: number, upTo: number): void {
+  while (track.nextBeatTime < upTo) {
+    const t = track.nextBeatTime
+    const beat = track.beatIndex % 8
+    if (beat === 0) musicNote(track, vol, 65.4, 'sine', 0, beatSec * 7.5, 0.18)  // C2 drone
+    if (beat === 4) musicNote(track, vol, 98.0, 'sine', 0, beatSec * 3.5, 0.12)
+    if (Math.random() < 0.3) musicNote(track, vol, 1046 + Math.random() * 400, 'sine', t + Math.random() * beatSec, 0.8, 0.04)
+    track.nextBeatTime += beatSec
+    track.beatIndex++
+  }
+}
+export const SACRED_AMBIANCE: MusicTrackConfig = { id: 'amb-sacred', bpm: 40, vol: 0.6, schedule: scheduleSacred }
+
+// Market — gentle random mid-range chatter taps.
+function scheduleMarket(track: MusicTrack, vol: number, beatSec: number, upTo: number): void {
+  while (track.nextBeatTime < upTo) {
+    const t = track.nextBeatTime
+    if (Math.random() < 0.5) {
+      const f = 300 + Math.random() * 500
+      musicNote(track, vol, f, 'triangle', t + Math.random() * beatSec, 0.05 + Math.random() * 0.06, 0.04 + Math.random() * 0.04)
+    }
+    track.nextBeatTime += beatSec
+    track.beatIndex++
+  }
+}
+export const MARKET_AMBIANCE: MusicTrackConfig = { id: 'amb-market', bpm: 120, vol: 0.5, schedule: scheduleMarket }
+
+/** Ambiance beds, keyed by the `ambianceId` set on an interior. */
+export const AMBIANCE_TRACKS: Record<string, MusicTrackConfig> = {
+  hearth: HEARTH_AMBIANCE,
+  sacred: SACRED_AMBIANCE,
+  market: MARKET_AMBIANCE,
+}
+export const AMBIANCE_IDS = Object.keys(AMBIANCE_TRACKS)
+
+// ─── Interior audio control ──────────────────────────────────────────────────
+// Imperatively driven by HubWorld on building enter/exit. A building may set a
+// `musicId` (swaps the town theme) and/or an `ambianceId` (layered bed).
+
+let _interiorMusicId: string | null = null
+let _ambianceId:      string | null = null
+
+/** Enter a building: swap to its music (if any) and start its ambiance (if any). */
+export function startInteriorAudio(musicId?: string, ambianceId?: string): void {
+  stopInteriorAudio()
+  if (musicId && BUILDING_MUSIC_TRACKS[musicId]) {
+    stopHubMusic()
+    startMusicTrack(BUILDING_MUSIC_TRACKS[musicId])
+    _interiorMusicId = musicId
+  }
+  if (ambianceId && AMBIANCE_TRACKS[ambianceId]) {
+    startMusicTrack(AMBIANCE_TRACKS[ambianceId])
+    _ambianceId = ambianceId
+  }
+}
+
+/** Exit a building: stop its music/ambiance and resume the town theme. */
+export function stopInteriorAudio(): void {
+  if (_interiorMusicId) {
+    stopMusicTrack(BUILDING_MUSIC_TRACKS[_interiorMusicId].id)
+    _interiorMusicId = null
+    startHubMusic()
+  }
+  if (_ambianceId) {
+    stopMusicTrack(AMBIANCE_TRACKS[_ambianceId].id)
+    _ambianceId = null
+  }
+}
+
 // ─── Adaptive Battle Music ────────────────────────────────────────────────────
 // The battle track can be "instructed" to shift its intensity and phrase
 // selection based on game state. Call setBattleIntensity() from App.tsx.
@@ -656,6 +924,7 @@ export const MUSIC_TRACKS: Record<string, MusicTrackConfig> = {
   battle:  BATTLE_MUSIC,
   title:   TITLE_MUSIC,
   map:     MAP_MUSIC,
+  hub:     HUB_MUSIC,
   gameover: GAME_OVER_MUSIC_VICTORY,
 }
 
@@ -672,6 +941,7 @@ export type SoundId =
   | 'minigameCorrect' | 'minigameWrong'
   | 'shopPurchase' | 'fruitMachineSpin' | 'fruitMachineWin' | 'fruitMachineLose'
   | 'mapFootstep'
+  | 'hubFootstep' | 'pickup' | 'treasure' | 'dayNightChime'
 
 const SOUND_MAP: Record<SoundId, () => void> = {
   cardPlay:          playCardPlay,
@@ -695,6 +965,10 @@ const SOUND_MAP: Record<SoundId, () => void> = {
   fruitMachineWin:   playFruitMachineWin,
   fruitMachineLose:  playFruitMachineLose,
   mapFootstep:       playMapFootstep,
+  hubFootstep:       playHubFootstep,
+  pickup:            playPickup,
+  treasure:          playTreasure,
+  dayNightChime:     playDayNightChime,
 }
 
 export function emitSound(id: SoundId): void {

--- a/web/src/hooks/useMusic.ts
+++ b/web/src/hooks/useMusic.ts
@@ -6,6 +6,7 @@ import {
   startTitleMusic, stopTitleMusic,
   startGameOverMusic, stopGameOverMusic,
   startMapMusic, stopMapMusic,
+  startHubMusic, stopHubMusic,
   setBattleIntensity, startMusicTrack, MUSIC_TRACKS,
 } from '../game/sound'
 
@@ -20,11 +21,14 @@ export function useMusic(screen: Screen, gameState: GameState | null, run: RunSt
     stopTitleMusic()
     stopGameOverMusic()
     stopMapMusic()
+    stopHubMusic()
 
     const act = run ? ACTS[run.actId] : undefined
 
     if (screen === 'title' || screen === 'settings' || screen === 'deckbuilder' || screen === 'collection') {
       startTitleMusic()
+    } else if (screen === 'hubworld' || screen === 'location') {
+      startHubMusic()
     } else if (screen === 'nodemap') {
       const mapTrackId = act?.mapMusicId
       const mapTrack = mapTrackId ? MUSIC_TRACKS[mapTrackId] : undefined
@@ -40,7 +44,7 @@ export function useMusic(screen: Screen, gameState: GameState | null, run: RunSt
         startGameOverMusic(phase.winner)
       }
     }
-    return () => { stopBattleMusic(); stopTitleMusic(); stopGameOverMusic(); stopMapMusic() }
+    return () => { stopBattleMusic(); stopTitleMusic(); stopGameOverMusic(); stopMapMusic(); stopHubMusic() }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [screen, gameState?.phase.type])
 


### PR DESCRIPTION
Closes #1603 (and its sub-tasks #1624, #1625, #1627). Item 1 of the Hub World epic #1602.

The hub world was silent. This adds procedural music + SFX (no audio files — everything is synthesised in `sound.ts`, respecting the existing mute/volume), **and** per-building music/ambiance that's authorable in the map editor.

## Town audio
- **`HUB_MUSIC`** — a calm G-major town theme (registered as `hub`), started on the `hubworld`/`location` screens via a new `useMusic` branch (one-track-at-a-time contract preserved).
- **SFX** (`emitSound`): `hubFootstep` (throttled, per walk tile), `pickup` (item collect), `treasure` (chest), `dayNightChime` (dawn/dusk flip).

## Per-building music & ambiance (per the follow-up request)
Different buildings now sound different — e.g. the **inn** vs the **church**:
- Interiors gain optional `musicId` (swaps the town theme while inside — `inn`/`church`/`shop`) and `ambianceId` (a low-volume bed layered under the music — `hearth`/`sacred`/`market`).
- `HubTownCanvas` calls `startInteriorAudio()` on enter and `stopInteriorAudio()` on exit (restores the town theme).
- **Map editor**: the interior inspector (`EntityInspector`) now has **Music** and **Ambiance** dropdowns, populated from the exported `BUILDING_MUSIC_IDS` / `AMBIANCE_IDS`.
- Ravenwatch wired as a demo: inn = `inn`+`hearth`, church = `church`+`sacred`, market hall = `shop`+`market`.

Adding a new track = define a `MusicTrackConfig` in `sound.ts`, add it to `BUILDING_MUSIC_TRACKS`/`AMBIANCE_TRACKS`, and it appears in the editor automatically.

## Files
`sound.ts`, `useMusic.ts`, `HubTownCanvas.tsx`, `HubWorld.tsx`, `EntityInspector.tsx`, `mapEditorTypes.ts`, `loader.ts`, `config.ts`, `ravenwatch/config.json`, `sounds.json`, `docs/hubworld.md` (§11).

## Acceptance criteria
- ✅ Entering the hub starts hub music; leaving stops it (one track at a time).
- ✅ Footstep + pickup/treasure SFX fire; all respect mute/volume.
- ✅ Distinct per-building audio (inn ≠ church), data-driven and editor-selectable.
- ✅ `npm run build` clean; loader tests pass.

## Verification
`cd web && npm run dev` → enter Ravenwatch (town theme plays, footsteps on walk, chime at dawn/dusk, pickup/treasure SFX). Enter the inn → lively tavern jig + hearth crackle; enter the church → solemn organ + sacred drone; exit → town theme resumes. In the map editor, an interior shows Music/Ambiance dropdowns that persist into the config.

> Note: the Storybook/Playwright browser test needs a chromium binary not present in some sandboxes — unrelated to this change; it runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NrvfVAXqwHRtawwxQKgXmL

---
_Generated by [Claude Code](https://claude.ai/code/session_01NrvfVAXqwHRtawwxQKgXmL)_