### PR TITLE
Hub: weather system (rain / snow / fog)

### DIFF
--- a/docs/hubworld.md
+++ b/docs/hubworld.md
@@ -854,3 +854,38 @@ To add a new track: define a `MusicTrackConfig` in `sound.ts`, add it to
 Wired through `emitSound(id)` (ids documented in `web/src/data/sounds.json`):
 `hubFootstep` (throttled, per walk tile), `pickup` (item collect), `treasure`
 (chest), and `dayNightChime` (dawn/dusk transition). All honour mute/volume.
+
+---
+
+## §12 — Weather
+
+A screen-space PixiJS overlay renders rain / snow / fog above the world (and
+above the night-dimming layer), hidden while inside a building. The pure
+selection logic is `resolveWeather` in `web/src/game/hub/weather.ts`; the
+renderer is `createWeatherSystem` in `web/src/components/hub/hubWeather.ts`
+(particle pools are capped — ≤240 rain, ≤200 snow — and recycled as they leave
+the viewport, so cost is independent of map size). A standalone
+`HubWeather.tsx` wrapper + `HubWeather.stories.tsx` show each type in Storybook.
+
+### Config (`config.json` → optional top-level `weather`)
+
+```jsonc
+{
+  "weather": {
+    "type": "fog",                 // force one type (overrides everything)
+    "bySeason": {                  // OR pick by current season
+      "spring": "rain", "summer": "rain", "autumn": "fog", "winter": "snow"
+    }
+  }
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `type` | `"clear" \| "rain" \| "snow" \| "fog"` | Forces a single weather type. Highest precedence. |
+| `bySeason` | `Partial<Record<Season, WeatherType>>` | Maps the current real-date season (`seasonForDate`) to a weather type. Used when `type` is absent. |
+
+**Resolution precedence:** `type` → `bySeason[currentSeason]` → per-`environment`
+default (`snow`/`ice`/`tundra` → snow; `swamp`/`marsh`/`graveyard`/`ashen` → fog;
+`forest` → rain; others → clear) → `clear`. Omit `weather` entirely to use the
+environment default. `WEATHER_TYPES` in `weather.ts` is the canonical type list.

--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -17,6 +17,8 @@ import { CommanderState } from '../../game/commander'
 import rollbar from '../../rollbar'
 import { HubInteractable, HubInteriorExit, HubLocationBundle, HubNpc, HubQuestBundle, HubStreetGroup, NpcScheduleEntry } from '../../data/hub/loader'
 import { createAnimalSystem, AnimalSystem } from './hubAnimals'
+import { createWeatherSystem } from './hubWeather'
+import { resolveWeather } from '../../game/hub/weather'
 import { BASE_CHIP_TILES } from '../../data/tiles/baseChipIndex'
 import { getUpgradeTrack } from '../../data/hub/buildingUpgrades'
 
@@ -128,6 +130,7 @@ export function HubTownCanvas({
   } = locationData
   const {HUB_QUEST_DEFS,INN_RUMOURS,FRIENDSHIP_DIALOGUE,HUB_PICKUP_ITEMS,HUB_BLOCKED_PATHS} = questData
   const HUB_ENV = locationData?.ENVIRONMENT || 'camp'
+  const HUB_WEATHER = locationData?.WEATHER
   const COURTYARD_PX = { x: AVATAR_START.tx * T + T / 2, y: AVATAR_START.ty * T + T }
   const containerRef      = useRef<HTMLDivElement>(null)
   const onAreaRef         = useRef(onAreaEnter)
@@ -2212,9 +2215,21 @@ export function HubTownCanvas({
     })
     getAnimalsInBuildingFn = animalSystem.getAnimalsInBuilding
 
+    // ── Weather overlay (screen-space, above the world incl. night dimming) ────
+    const weatherLayer = new PIXI.Container()
+    weatherLayer.eventMode = 'none'   // never block pointer events
+    app.stage.addChild(weatherLayer)  // added after worldRoot ⇒ renders on top
+    const weatherSystem = createWeatherSystem({
+      layer: weatherLayer,
+      getScreen: () => ({ width: app.screen.width, height: app.screen.height }),
+      isPaused: () => interiorActive,
+    })
+    weatherSystem.setWeather(resolveWeather(HUB_WEATHER, HUB_ENV))
+
     app.ticker.add((ticker) => {
       try {
       animalSystem.tick(ticker.deltaMS)
+      weatherSystem.tick(ticker.deltaMS)
 
       // Denned cats/dogs wandering the interior room (random 1-tile hops).
       if (interiorActive && interiorAnimals.length > 0) {

--- a/web/src/components/hub/HubWeather.stories.tsx
+++ b/web/src/components/hub/HubWeather.stories.tsx
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { HubWeather } from './HubWeather';
+
+const meta = {
+  component: HubWeather,
+  parameters: { layout: 'centered' },
+} satisfies Meta<typeof HubWeather>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Rain: Story = { args: { type: 'rain' } };
+export const Snow: Story = { args: { type: 'snow' } };
+export const Fog: Story = { args: { type: 'fog' } };
+export const Clear: Story = { args: { type: 'clear' } };

--- a/web/src/components/hub/HubWeather.tsx
+++ b/web/src/components/hub/HubWeather.tsx
@@ -1,0 +1,43 @@
+import { useRef, useEffect } from 'react'
+import * as PIXI from 'pixi.js'
+import { usePixiApp } from '../../hooks/usePixiApp'
+import { createWeatherSystem, WeatherSystem } from './hubWeather'
+import type { WeatherType } from '../../game/hub/weather'
+
+interface Props {
+  type: WeatherType
+  width?: number
+  height?: number
+}
+
+/**
+ * Standalone canvas that renders one weather type — used for Storybook
+ * inspection of the weather overlay. In-game weather is driven directly by
+ * `createWeatherSystem` inside `HubTownCanvas`; this wrapper is purely visual.
+ */
+export function HubWeather({ type, width = 480, height = 320 }: Props) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const systemRef = useRef<WeatherSystem | null>(null)
+
+  usePixiApp(containerRef, width, height, (app) => {
+    // Dark backdrop so light particles (rain/snow/fog) are visible.
+    const bg = new PIXI.Graphics()
+    bg.rect(0, 0, app.screen.width, app.screen.height).fill({ color: 0x223044 })
+    app.stage.addChild(bg)
+
+    const layer = new PIXI.Container()
+    app.stage.addChild(layer)
+    const system = createWeatherSystem({
+      layer,
+      getScreen: () => ({ width: app.screen.width, height: app.screen.height }),
+    })
+    system.setWeather(type)
+    systemRef.current = system
+    app.ticker.add((ticker) => system.tick(ticker.deltaMS))
+  })
+
+  // Update weather when the story arg changes (app persists across re-renders).
+  useEffect(() => { systemRef.current?.setWeather(type) }, [type])
+
+  return <div ref={containerRef} style={{ width, height }} />
+}

--- a/web/src/components/hub/hubWeather.ts
+++ b/web/src/components/hub/hubWeather.ts
@@ -1,0 +1,176 @@
+// Imperative PixiJS manager for hub-world weather (issue #1604).
+//
+// Renders a screen-space overlay (rain streaks, drifting snow, layered fog) that
+// always covers the viewport, so no world-space culling is needed. Particle
+// pools are capped and recycled as they leave the viewport. Weather selection is
+// data-driven per town — the pure logic lives in `web/src/game/hub/weather.ts`;
+// this file owns the sprites and the per-frame loop.
+
+import * as PIXI from 'pixi.js'
+import type { WeatherType } from '../../game/hub/weather'
+
+export interface WeatherSystemOptions {
+  /** Screen-space container (added to the stage, not the scrolling world root). */
+  layer: PIXI.Container
+  /** Current viewport size in CSS pixels. */
+  getScreen: () => { width: number; height: number }
+  /** Weather pauses (hides) while this returns true — e.g. inside a building. */
+  isPaused?: () => boolean
+}
+
+export interface WeatherSystem {
+  setWeather: (type: WeatherType) => void
+  getWeather: () => WeatherType
+  tick: (deltaMS: number) => void
+  destroy: () => void
+}
+
+// Hard caps keep the overlay cheap regardless of viewport size.
+const MAX_RAIN = 240
+const MAX_SNOW = 200
+const FOG_BANDS = 3
+
+interface Particle {
+  gfx: PIXI.Graphics
+  x: number
+  y: number
+  vx: number
+  vy: number
+  /** snow phase for gentle sway */
+  phase: number
+}
+
+export function createWeatherSystem(opts: WeatherSystemOptions): WeatherSystem {
+  const { layer, getScreen, isPaused } = opts
+
+  let weather: WeatherType = 'clear'
+  let wind = 0                 // horizontal drift shared by all particle kinds
+  let windTarget = 0
+  let windTimer = 0
+
+  const rain: Particle[] = []
+  const snow: Particle[] = []
+  const fogBands: { gfx: PIXI.Graphics; x: number; speed: number }[] = []
+  let lastW = 0
+  let lastH = 0
+
+  // ── Particle factories ─────────────────────────────────────────────────────
+  function makeRainDrop(): Particle {
+    const g = new PIXI.Graphics()
+    g.moveTo(0, 0).lineTo(0, 8).stroke({ color: 0x99bbdd, width: 1, alpha: 0.5 })
+    layer.addChild(g)
+    return { gfx: g, x: 0, y: 0, vx: 0, vy: 0, phase: 0 }
+  }
+  function makeSnowFlake(): Particle {
+    const g = new PIXI.Graphics()
+    const r = 1 + Math.random() * 1.5
+    g.circle(0, 0, r).fill({ color: 0xffffff, alpha: 0.85 })
+    layer.addChild(g)
+    return { gfx: g, x: 0, y: 0, vx: 0, vy: 0, phase: Math.random() * Math.PI * 2 }
+  }
+
+  function resetRain(p: Particle, screen: { width: number; height: number }, fromTop: boolean) {
+    p.x = Math.random() * (screen.width + 200) - 100
+    p.y = fromTop ? -10 : Math.random() * screen.height
+    p.vy = 9 + Math.random() * 4       // px per frame (~60fps baseline)
+    p.vx = 1.2
+  }
+  function resetSnow(p: Particle, screen: { width: number; height: number }, fromTop: boolean) {
+    p.x = Math.random() * (screen.width + 100) - 50
+    p.y = fromTop ? -10 : Math.random() * screen.height
+    p.vy = 1.0 + Math.random() * 1.2
+    p.vx = 0.3
+    p.phase = Math.random() * Math.PI * 2
+  }
+
+  // ── Pool sizing per weather type ────────────────────────────────────────────
+  function ensurePools() {
+    const screen = getScreen()
+    if (weather === 'rain') {
+      while (rain.length < MAX_RAIN) { const p = makeRainDrop(); resetRain(p, screen, false); rain.push(p) }
+    }
+    if (weather === 'snow') {
+      while (snow.length < MAX_SNOW) { const p = makeSnowFlake(); resetSnow(p, screen, false); snow.push(p) }
+    }
+    if (weather === 'fog') {
+      while (fogBands.length < FOG_BANDS) {
+        const g = new PIXI.Graphics()
+        layer.addChild(g)
+        fogBands.push({ gfx: g, x: Math.random() * screen.width, speed: 0.15 + fogBands.length * 0.1 })
+      }
+      drawFog()
+    }
+  }
+
+  function drawFog() {
+    const screen = getScreen()
+    fogBands.forEach((band, i) => {
+      band.gfx.clear()
+      const h = screen.height * (0.5 + i * 0.18)
+      const y = screen.height - h
+      band.gfx.rect(0, y, screen.width, h).fill({ color: 0xc8d0d8, alpha: 0.06 + i * 0.03 })
+    })
+  }
+
+  function clearKind(arr: { gfx: PIXI.Graphics }[]) {
+    for (const p of arr) { layer.removeChild(p.gfx); p.gfx.destroy() }
+    arr.length = 0
+  }
+
+  function setWeather(type: WeatherType) {
+    if (type === weather) return
+    weather = type
+    clearKind(rain); clearKind(snow); clearKind(fogBands)
+    ensurePools()
+  }
+
+  // ── Per-frame loop ──────────────────────────────────────────────────────────
+  function tick(deltaMS: number) {
+    const paused = isPaused?.() ?? false
+    layer.visible = !paused && weather !== 'clear'
+    if (paused || weather === 'clear') return
+
+    const screen = getScreen()
+    // Redraw fog bands when the viewport size changes (cheap; 3 rects).
+    if (weather === 'fog' && (screen.width !== lastW || screen.height !== lastH)) drawFog()
+    lastW = screen.width; lastH = screen.height
+    // dt in 60fps-frame units, clamped so a stutter doesn't teleport particles.
+    const dt = Math.min(deltaMS, 50) / 16.667
+
+    // Wind drifts slowly toward a new random target every few seconds.
+    windTimer -= deltaMS
+    if (windTimer <= 0) { windTimer = 3000 + Math.random() * 4000; windTarget = (Math.random() * 2 - 1) * 2.5 }
+    wind += (windTarget - wind) * 0.02 * dt
+
+    if (weather === 'rain') {
+      for (const p of rain) {
+        p.y += p.vy * dt
+        p.x += (p.vx + wind * 1.5) * dt
+        if (p.y > screen.height || p.x < -120 || p.x > screen.width + 120) resetRain(p, screen, true)
+        p.gfx.position.set(p.x, p.y)
+        p.gfx.rotation = Math.atan2(p.vy, p.vx + wind * 1.5) - Math.PI / 2
+      }
+    } else if (weather === 'snow') {
+      for (const p of snow) {
+        p.phase += 0.04 * dt
+        p.y += p.vy * dt
+        p.x += (p.vx + wind + Math.sin(p.phase) * 0.6) * dt
+        if (p.y > screen.height || p.x < -60 || p.x > screen.width + 60) resetSnow(p, screen, true)
+        p.gfx.position.set(p.x, p.y)
+      }
+    } else if (weather === 'fog') {
+      for (const band of fogBands) {
+        band.x += (band.speed + wind * 0.3) * dt
+        if (band.x > screen.width) band.x = 0
+        // Subtle horizontal shimmer via container offset (re-draw only on resize).
+        band.gfx.x = (band.x % screen.width) * 0.05
+      }
+    }
+  }
+
+  function destroy() {
+    clearKind(rain); clearKind(snow); clearKind(fogBands)
+  }
+
+  return { setWeather, getWeather: () => weather, tick, destroy }
+}

--- a/web/src/data/hub/config.ts
+++ b/web/src/data/hub/config.ts
@@ -293,6 +293,9 @@ export interface RawConfig {
   townName?: string
   environment?: string
 
+  /** Optional per-town weather (loose raw shape; typed `WeatherConfig` at the loader output). */
+  weather?: { type?: string; bySeason?: Record<string, string> }
+
   avatarStart:RawCoordinate
 
   exitTiles?: RawExitTile[]

--- a/web/src/data/hub/loader.ts
+++ b/web/src/data/hub/loader.ts
@@ -238,6 +238,7 @@ export interface HubLocationBundle {
   MAP_H: number
   HUB_TOWN_NAME: string
   ENVIRONMENT: string
+  WEATHER?: import('../../game/hub/weather').WeatherConfig
 
   AVATAR_START: HubCoordinate
 
@@ -555,6 +556,7 @@ const HUB_CHICKEN_ZONES = (
 
  const HUB_TOWN_NAME: string = (rawConfig as unknown as { townName?: string }).townName ?? 'Town'
 const ENVIRONMENT: string = (rawConfig as unknown as { environment?: string }).environment ?? 'camp'
+const WEATHER = (rawConfig as unknown as { weather?: import('../../game/hub/weather').WeatherConfig }).weather
 
 type RawExitTile = { tx: number; ty: number; screen: string }
  const HUB_EXIT_TILES: HubExitTile[] = (
@@ -603,6 +605,7 @@ type RawExitTile = { tx: number; ty: number; screen: string }
     AVATAR_START,
     HUB_TOWN_NAME,
     ENVIRONMENT,
+    WEATHER,
     HUB_AREAS,
     HUB_STREET_GROUPS,
     HUB_STREET_TILES: HUB_STREET_TILES,

--- a/web/src/data/hub/ravenwatch/config.json
+++ b/web/src/data/hub/ravenwatch/config.json
@@ -3,6 +3,14 @@
   "mapH": 2240,
   "townName": "Ravenwatch",
   "environment": "farmland",
+  "weather": {
+    "bySeason": {
+      "spring": "rain",
+      "summer": "rain",
+      "autumn": "fog",
+      "winter": "snow"
+    }
+  },
   "avatarStart": {
     "tx": 37,
     "ty": 29

--- a/web/src/game/hub/weather.test.ts
+++ b/web/src/game/hub/weather.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest'
+import { resolveWeather, seasonForDate, WEATHER_TYPES } from './weather'
+
+const d = (month: number) => new Date(2026, month, 15)
+
+describe('seasonForDate', () => {
+  it('maps months to northern-hemisphere seasons', () => {
+    expect(seasonForDate(d(0))).toBe('winter')   // Jan
+    expect(seasonForDate(d(3))).toBe('spring')    // Apr
+    expect(seasonForDate(d(6))).toBe('summer')    // Jul
+    expect(seasonForDate(d(9))).toBe('autumn')    // Oct
+    expect(seasonForDate(d(11))).toBe('winter')   // Dec
+  })
+})
+
+describe('resolveWeather', () => {
+  it('explicit type overrides everything', () => {
+    expect(resolveWeather({ type: 'snow' }, 'forest', d(6))).toBe('snow')
+  })
+
+  it('seasonal mapping wins over environment default', () => {
+    const cfg = { bySeason: { winter: 'snow' as const, summer: 'rain' as const } }
+    expect(resolveWeather(cfg, 'desert', d(0))).toBe('snow')   // winter
+    expect(resolveWeather(cfg, 'desert', d(6))).toBe('rain')   // summer
+  })
+
+  it('falls back to the season-less environment default', () => {
+    expect(resolveWeather({ bySeason: { winter: 'snow' } }, 'swamp', d(6))).toBe('fog') // summer not mapped → env default
+    expect(resolveWeather(undefined, 'snow', d(6))).toBe('snow')
+  })
+
+  it('defaults to clear for unknown environments / no config', () => {
+    expect(resolveWeather(undefined, 'farmland', d(6))).toBe('clear')
+    expect(resolveWeather(undefined, undefined, d(6))).toBe('clear')
+  })
+
+  it('only returns known weather types', () => {
+    const r = resolveWeather(undefined, 'forest', d(6))
+    expect(WEATHER_TYPES).toContain(r)
+  })
+})

--- a/web/src/game/hub/weather.ts
+++ b/web/src/game/hub/weather.ts
@@ -1,0 +1,61 @@
+// Hub weather — pure logic. Resolves which weather a town shows, data-driven
+// per town with sensible per-environment defaults and a date-driven season
+// hook (for the seasonal-events tie-in, #1605). No PixiJS / DOM here.
+
+export type WeatherType = 'clear' | 'rain' | 'snow' | 'fog'
+
+export const WEATHER_TYPES: WeatherType[] = ['clear', 'rain', 'snow', 'fog']
+
+export type Season = 'spring' | 'summer' | 'autumn' | 'winter'
+
+/**
+ * Per-town weather config (optional `weather` field in config.json).
+ * - `type`: force a single weather type (overrides everything).
+ * - `bySeason`: pick weather from the current season.
+ * - omitted entirely ⇒ environment default.
+ */
+export interface WeatherConfig {
+  type?: WeatherType
+  bySeason?: Partial<Record<Season, WeatherType>>
+}
+
+/** Northern-hemisphere season from a calendar month (0–11). */
+export function seasonForDate(date: Date = new Date()): Season {
+  const m = date.getMonth()
+  if (m <= 1 || m === 11) return 'winter'
+  if (m <= 4) return 'spring'
+  if (m <= 7) return 'summer'
+  return 'autumn'
+}
+
+// Default weather per town environment when no explicit config is given.
+const ENVIRONMENT_DEFAULTS: Record<string, WeatherType> = {
+  snow: 'snow',
+  ice: 'snow',
+  tundra: 'snow',
+  swamp: 'fog',
+  marsh: 'fog',
+  graveyard: 'fog',
+  ashen: 'fog',
+  forest: 'rain',
+  camp: 'clear',
+  desert: 'clear',
+}
+
+/**
+ * Resolve the active weather for a town.
+ * Precedence: explicit `type` → seasonal mapping → environment default → clear.
+ */
+export function resolveWeather(
+  cfg: WeatherConfig | undefined,
+  environment: string | undefined,
+  date: Date = new Date(),
+): WeatherType {
+  if (cfg?.type) return cfg.type
+  if (cfg?.bySeason) {
+    const seasonal = cfg.bySeason[seasonForDate(date)]
+    if (seasonal) return seasonal
+  }
+  if (environment && ENVIRONMENT_DEFAULTS[environment]) return ENVIRONMENT_DEFAULTS[environment]
+  return 'clear'
+}


### PR DESCRIPTION
Implements **#1604 — Hub weather system** (covering sub-issues #1630, #1634, #1637).

## What
A screen-space PixiJS weather overlay (rain / snow / fog) above the world and the night-dimming layer, hidden while indoors. Data-driven per town with a season hook.

- **Pure logic — `game/hub/weather.ts`**: `resolveWeather(cfg, environment, date)` with precedence `type → bySeason[season] → environment default → clear`; `seasonForDate`, `WeatherType`/`WEATHER_TYPES`. Fully unit-tested.
- **Renderer — `components/hub/hubWeather.ts`**: `createWeatherSystem` (mirrors `createAnimalSystem`). Screen-space layer on `app.stage`, so particles always cover the viewport — no world culling. Rain streaks, drifting snow, layered fog, shared wind. Particle pools **capped** (≤240 rain / ≤200 snow) and recycled as they exit the viewport, so cost is independent of map size.
- **Wiring — `HubTownCanvas.tsx`**: weather layer added above `worldRoot`, ticked in the existing loop, paused (hidden) while `interiorActive`; type resolved from the town's config.
- **Storybook — `HubWeather.tsx` + `HubWeather.stories.tsx`**: standalone canvas per type (Rain / Snow / Fog / Clear).
- **Data + docs**: optional `weather` field on `RawConfig` → `WEATHER` bundle export; Ravenwatch gets a seasonal demo; new **§12** in `docs/hubworld.md`.

## Acceptance criteria
- ✅ Rain + snow + fog render and are performant (capped, recycled pools; viewport-only).
- ✅ Data-driven per town; `clear`/default state exists.
- ✅ Storybook story per weather type; `npm run build` passes; loader + new `weather.ts` tests green (17 tests).

## Verification
- `npm run build` clean; `npx vitest run src/game/hub/weather.test.ts src/data/hub/loader.test.ts` → 17 passed.
- In-game (Ravenwatch): weather follows the season (`bySeason`); it covers the viewport, sits above night dimming, and disappears on entering a building.
- Storybook: the four `HubWeather` stories show each type.

## Deferred
The optional **rain SFX hook** is intentionally deferred to a dedicated hub-audio follow-up (alongside requested nighttime crickets + per-animal sounds) so `sound.ts` is touched once, cohesively.

https://claude.ai/code/session_01NrvfVAXqwHRtawwxQKgXmL

---
_Generated by [Claude Code](https://claude.ai/code/session_01NrvfVAXqwHRtawwxQKgXmL)_