### PR TITLE
Hub audio: nighttime crickets + animal vocalisations

### DIFF
--- a/docs/hubworld.md
+++ b/docs/hubworld.md
@@ -855,6 +855,21 @@ Wired through `emitSound(id)` (ids documented in `web/src/data/sounds.json`):
 `hubFootstep` (throttled, per walk tile), `pickup` (item collect), `treasure`
 (chest), and `dayNightChime` (dawn/dusk transition). All honour mute/volume.
 
+### Night crickets
+An outdoor night ambiance bed (`CRICKETS_AMBIANCE`, id `amb-crickets`) plays while
+the hub is **at night and outdoors**. `HubTownCanvas` calls `setNightAmbiance(on)`
+from its ticker with `on = isNight && !interiorActive` (idempotent), so crickets
+start/stop on the day↔night flip and on building enter/exit; `useMusic` clears
+them when leaving the hub screen.
+
+### Animal vocalisations
+Hub critters make sounds via `emitSound`: `dogBark`, `catMeow`, `birdChirp`,
+`henCluck` (mapped per type in `ANIMAL_SFX`, `hubAnimals.ts`). They fire when an
+animal is tapped, when a dog spontaneously barks, and ambiently — every 5–10 s a
+random visible critter near the avatar vocalises. A single global throttle
+(`_lastAnimalSfxMs`, 250 ms) prevents overlap into a cacophony. Add a new vocal
+type by adding its `SoundId` to `ANIMAL_SFX`.
+
 ---
 
 ## §12 — Weather

--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -8,7 +8,7 @@ import { PATH_TILE } from '../../data/tiles/tileIndex'
 import { findPath, nearestWalkable } from '../../utils/hubPathfinder'
 import { isBuildingOpen, getNpcLocation, getNpcActivity } from '../../game/hub/hubNpcSchedule'
 import { getGameHour, getGameMinute } from '../../game/hub/hubClock'
-import { emitSound, startInteriorAudio, stopInteriorAudio } from '../../game/sound'
+import { emitSound, startInteriorAudio, stopInteriorAudio, setNightAmbiance } from '../../game/sound'
 import { getWallTile, ROOF_TILES, WALL_TILES, ROOF_ROWS } from '../../data/tiles/buildingMaterials'
 import type { WallMaterial, RoofMaterial } from '../../data/tiles/buildingMaterials'
 import { loadPlayerAvatar } from '../../game/questline'
@@ -2151,6 +2151,7 @@ export function HubTownCanvas({
     let _lastNightAvatarX = -Infinity, _lastNightAvatarY = -Infinity
     let _lastReportX = -Infinity, _lastReportY = -Infinity
     let _lastIsNight = isNightRef.current  // for the day↔night transition chime
+    let _lastCrickets = false              // crickets-ambiance desired state (night && outdoors)
     // ── Animals (cats, dogs, birds, fish) ──────────────────────────────────────
     // Building roof ridges (top row of each building) are bird perch candidates.
     const animalRoofTiles: [number, number][] = []
@@ -2449,6 +2450,13 @@ export function HubTownCanvas({
       if (isNightRef.current !== _lastIsNight) {
         _lastIsNight = isNightRef.current
         if (!interiorActive) emitSound('dayNightChime')
+      }
+
+      // Crickets: outdoor night bed. Tracks night + indoor/outdoor in one place.
+      const _wantCrickets = isNightRef.current && !interiorActive
+      if (_wantCrickets !== _lastCrickets) {
+        _lastCrickets = _wantCrickets
+        setNightAmbiance(_wantCrickets)
       }
 
       // Night dimming — canvas 2D destination-out digs transparent torch-light holes.

--- a/web/src/components/hub/hubAnimals.ts
+++ b/web/src/components/hub/hubAnimals.ts
@@ -9,6 +9,7 @@
 import * as PIXI from 'pixi.js'
 import { findPath } from '../../utils/hubPathfinder'
 import { loadAnimFrames, loadTextureUrl } from '../../utils/pixiHelpers'
+import { emitSound, SoundId } from '../../game/sound'
 import type { HubAnimal } from '../../data/hub/loader'
 import {
   AnimalType,
@@ -126,6 +127,13 @@ const FLAVOUR: Record<AnimalType, string> = {
   butterfly: '~', rabbit: '!', chicken: 'Cluck', frog: 'Ribbit',
   firefly: '✦', bat: 'eek!',
 }
+
+// Vocal critters → their procedural SFX id (see sound.ts). Others are silent.
+const ANIMAL_SFX: Partial<Record<AnimalType, SoundId>> = {
+  cat: 'catMeow', dog: 'dogBark', bird: 'birdChirp', chicken: 'henCluck',
+}
+// Global throttle so overlapping animals never produce a cacophony.
+let _lastAnimalSfxMs = 0
 
 // Floating types are centre-anchored and hover; the rest are bottom-anchored.
 const isFloating = (t: AnimalType) => t === 'fish' || t === 'butterfly' || t === 'firefly' || t === 'bat'
@@ -253,6 +261,18 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
   function positionBubble(a: Animal) {
     if (a.bubble) a.bubble.position.set(a.sprite.x, a.sprite.y - spriteSize * a.baseScale - 4)
   }
+  // Play an animal's vocalisation (throttled globally); optionally show its bubble.
+  function vocalize(a: Animal, withBubble = false): void {
+    const id = ANIMAL_SFX[a.type]
+    if (!id) return
+    const t = Date.now()
+    if (t - _lastAnimalSfxMs < 250) return
+    _lastAnimalSfxMs = t
+    emitSound(id)
+    if (withBubble) speak(a, FLAVOUR[a.type], 1200)
+  }
+  // Occasional ambient vocalisation from a critter near the avatar.
+  let _ambientVocalTimer = 4000
 
   // ── shared relations & navigation ─────────────────────────────────────────────
   function nearestAnimal(a: Animal, pred: (o: Animal) => boolean, radiusPx: number): Animal | null {
@@ -406,7 +426,7 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
     if (!a.seen.has(near.id)) { a.seen.add(near.id); a.opinion.set(near.id, Math.random() < 0.5) }
     a.reactCooldown = 5000
     if (a.opinion.get(near.id)) { speak(a, '♥'); a.wagTimer = 1300 }
-    else speak(a, 'Woof!')
+    else { speak(a, 'Woof!'); vocalize(a) }
   }
 
   // Dogs spot a wandering cat or rabbit and give chase — they leave the path
@@ -689,6 +709,18 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
     const hour = opts.getGameHour()
     const night = isNightHour(hour)
 
+    // Ambient critter sounds: every few seconds a nearby, visible, vocal animal
+    // chirps/barks/etc. so the town feels alive without the player tapping.
+    _ambientVocalTimer -= dt
+    if (_ambientVocalTimer <= 0) {
+      _ambientVocalTimer = 5000 + Math.random() * 5000
+      const nearby = animals.filter(a =>
+        ANIMAL_SFX[a.type] && a.sprite.visible && !a.insideBuilding &&
+        Math.hypot(a.sprite.x - avatar.x, a.sprite.y - avatar.y) < 320)
+      const pick = randOf(nearby)
+      if (pick) vocalize(pick, true)
+    }
+
     for (const a of animals) {
       // Day/night fliers: birds & butterflies vanish at night; fireflies & bats
       // only appear after dark.
@@ -848,6 +880,7 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
       e.stopPropagation()
       if (a.id) { opts.onAnimalTap(a.id); return }
       speak(a, FLAVOUR[type])
+      vocalize(a)
       if (type === 'bird' || type === 'butterfly') a.fleeRequested = true
       if (type === 'cat' && a.state !== 'flee') { a.state = 'sit'; a.stateTimer = 200 }
     })

--- a/web/src/data/sounds.json
+++ b/web/src/data/sounds.json
@@ -149,6 +149,30 @@
       "name": "Day/Night Chime",
       "category": "hub",
       "description": "Gentle transition sting when the hub flips between day and night"
+    },
+    {
+      "id": "dogBark",
+      "name": "Dog Bark",
+      "category": "hub",
+      "description": "Two gruff bursts — hub dogs, on tap and ambiently"
+    },
+    {
+      "id": "catMeow",
+      "name": "Cat Meow",
+      "category": "hub",
+      "description": "Rising-falling meow — hub cats, on tap and ambiently"
+    },
+    {
+      "id": "birdChirp",
+      "name": "Bird Chirp",
+      "category": "hub",
+      "description": "Two quick high tweets — hub birds, on tap and ambiently"
+    },
+    {
+      "id": "henCluck",
+      "name": "Hen Cluck",
+      "category": "hub",
+      "description": "Low clipped clucks — hub chickens, on tap and ambiently"
     }
   ]
 }

--- a/web/src/game/sound.ts
+++ b/web/src/game/sound.ts
@@ -268,6 +268,37 @@ export function playDayNightChime() {
   node(784, 'sine',     t + 0.12, 0.40, 0.13)
 }
 
+// ─── Animal vocalisations (hub critters) ──────────────────────────────────────
+export function playDogBark() {
+  const t = now()
+  // Two short gruff bursts
+  node(190, 'square',   t,        0.07, 0.26)
+  node(140, 'sawtooth', t + 0.01, 0.08, 0.20)
+  node(200, 'square',   t + 0.16, 0.06, 0.22)
+  node(150, 'sawtooth', t + 0.17, 0.07, 0.16)
+}
+
+export function playCatMeow() {
+  const t = now()
+  // Rising-then-falling glide ≈ "me-ow"
+  node(640, 'sine',     t,        0.13, 0.16)
+  node(540, 'sine',     t + 0.11, 0.17, 0.14)
+}
+
+export function playBirdChirp() {
+  const t = now()
+  // Two quick high tweets
+  node(2400, 'sine', t,        0.04, 0.10)
+  node(3100, 'sine', t + 0.05, 0.05, 0.09)
+}
+
+export function playHenCluck() {
+  const t = now()
+  // Low clipped clucks
+  node(440, 'square', t,        0.05, 0.13)
+  node(300, 'square', t + 0.08, 0.06, 0.12)
+}
+
 
 // ─── Music Engine ─────────────────────────────────────────────────────────────
 // Look-ahead scheduler pattern — runs a setInterval every SCHEDULE_MS and
@@ -861,11 +892,40 @@ function scheduleMarket(track: MusicTrack, vol: number, beatSec: number, upTo: n
 }
 export const MARKET_AMBIANCE: MusicTrackConfig = { id: 'amb-market', bpm: 120, vol: 0.5, schedule: scheduleMarket }
 
+// Crickets — outdoor night bed: rhythmic high-frequency chirp trills with gaps.
+function scheduleCrickets(track: MusicTrack, vol: number, beatSec: number, upTo: number): void {
+  while (track.nextBeatTime < upTo) {
+    const t = track.nextBeatTime
+    // A trill = a few rapid high pulses; not every beat, so it breathes.
+    if (Math.random() < 0.7) {
+      const base = 4200 + Math.random() * 600
+      const pulses = 2 + ((Math.random() * 3) | 0)
+      for (let i = 0; i < pulses; i++) {
+        musicNote(track, vol, base, 'sine', t + i * 0.03, 0.02, 0.05)
+      }
+    }
+    track.nextBeatTime += beatSec
+    track.beatIndex++
+  }
+}
+export const CRICKETS_AMBIANCE: MusicTrackConfig = { id: 'amb-crickets', bpm: 140, vol: 0.4, schedule: scheduleCrickets }
+
 /** Ambiance beds, keyed by the `ambianceId` set on an interior. */
 export const AMBIANCE_TRACKS: Record<string, MusicTrackConfig> = {
   hearth: HEARTH_AMBIANCE,
   sacred: SACRED_AMBIANCE,
   market: MARKET_AMBIANCE,
+}
+
+// ─── Outdoor night ambiance (crickets) ───────────────────────────────────────
+// Driven by HubTownCanvas: on at night while outdoors, off by day / indoors /
+// when leaving the hub. Idempotent.
+let _nightAmbianceOn = false
+export function setNightAmbiance(on: boolean): void {
+  if (on === _nightAmbianceOn) return
+  _nightAmbianceOn = on
+  if (on) startMusicTrack(CRICKETS_AMBIANCE)
+  else stopMusicTrack(CRICKETS_AMBIANCE.id)
 }
 export const AMBIANCE_IDS = Object.keys(AMBIANCE_TRACKS)
 
@@ -942,6 +1002,7 @@ export type SoundId =
   | 'shopPurchase' | 'fruitMachineSpin' | 'fruitMachineWin' | 'fruitMachineLose'
   | 'mapFootstep'
   | 'hubFootstep' | 'pickup' | 'treasure' | 'dayNightChime'
+  | 'dogBark' | 'catMeow' | 'birdChirp' | 'henCluck'
 
 const SOUND_MAP: Record<SoundId, () => void> = {
   cardPlay:          playCardPlay,
@@ -969,6 +1030,10 @@ const SOUND_MAP: Record<SoundId, () => void> = {
   pickup:            playPickup,
   treasure:          playTreasure,
   dayNightChime:     playDayNightChime,
+  dogBark:           playDogBark,
+  catMeow:           playCatMeow,
+  birdChirp:         playBirdChirp,
+  henCluck:          playHenCluck,
 }
 
 export function emitSound(id: SoundId): void {

--- a/web/src/hooks/useMusic.ts
+++ b/web/src/hooks/useMusic.ts
@@ -7,6 +7,7 @@ import {
   startGameOverMusic, stopGameOverMusic,
   startMapMusic, stopMapMusic,
   startHubMusic, stopHubMusic,
+  setNightAmbiance,
   setBattleIntensity, startMusicTrack, MUSIC_TRACKS,
 } from '../game/sound'
 
@@ -22,6 +23,7 @@ export function useMusic(screen: Screen, gameState: GameState | null, run: RunSt
     stopGameOverMusic()
     stopMapMusic()
     stopHubMusic()
+    if (screen !== 'hubworld' && screen !== 'location') setNightAmbiance(false)  // crickets are hub-only
 
     const act = run ? ACTS[run.actId] : undefined
 
@@ -44,7 +46,7 @@ export function useMusic(screen: Screen, gameState: GameState | null, run: RunSt
         startGameOverMusic(phase.winner)
       }
     }
-    return () => { stopBattleMusic(); stopTitleMusic(); stopGameOverMusic(); stopMapMusic(); stopHubMusic() }
+    return () => { stopBattleMusic(); stopTitleMusic(); stopGameOverMusic(); stopMapMusic(); stopHubMusic(); setNightAmbiance(false) }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [screen, gameState?.phase.type])
 


### PR DESCRIPTION
Adds the two audio features you asked for: nighttime crickets and animal vocalisations. All procedural (no asset files), routed through the existing `sound.ts` synthesis and honouring the global mute/volume.

## Nighttime crickets
- `CRICKETS_AMBIANCE` (id `amb-crickets`) — a rhythmic high-frequency chirp-trill bed, layered like the existing interior ambiances.
- `setNightAmbiance(on)` (idempotent) toggles it. `HubTownCanvas` drives it from its ticker with `on = isNight && !interiorActive`, so crickets start/stop on the day↔night flip and on building enter/exit. `useMusic` clears them when you leave the hub.

## Animal vocalisations
- Procedural one-shots: `dogBark`, `catMeow`, `birdChirp`, `henCluck` (new `emitSound` ids).
- `hubAnimals.ts` maps vocal types in `ANIMAL_SFX` and plays them: **on tap**, when a **dog spontaneously barks**, and **ambiently** — every 5–10 s a random *visible, nearby* critter sounds off so the town feels alive without interaction.
- A single global 250 ms throttle (`_lastAnimalSfxMs`) keeps overlapping animals from turning into a cacophony.

## Files
`game/sound.ts` (sounds + crickets + `setNightAmbiance`), `components/hub/hubAnimals.ts` (vocalize + wiring), `components/hub/HubTownCanvas.tsx` (crickets ticker hook), `hooks/useMusic.ts` (stop on leave), `data/sounds.json` (+4 ids), `docs/hubworld.md` §11.

## Verification
- `npm run build` clean.
- In-game (Ravenwatch): crickets fade in at night outdoors and stop indoors / by day / on leaving the hub; tapping a cat/dog/bird/hen plays its sound, and nearby critters chirp/bark on their own periodically. Muting silences all of it.

Note: this is the hub-audio follow-up referenced in the weather PR (#1712). Rain SFX can layer onto `setNightAmbiance`-style hooks later if desired.

https://claude.ai/code/session_01NrvfVAXqwHRtawwxQKgXmL

---
_Generated by [Claude Code](https://claude.ai/code/session_01NrvfVAXqwHRtawwxQKgXmL)_