### PR TITLE
fix(rollbar): no-op safely when window.Rollbar is unavailable (fixes CI test failures)

### DIFF
--- a/web/src/rollbar.ts
+++ b/web/src/rollbar.ts
@@ -1,19 +1,37 @@
 // Rollbar is loaded via CDN snippet in index.html.
 // This module re-exports the global so existing imports keep working.
+//
+// In environments where the CDN snippet isn't present — Storybook, the
+// Vitest/Storybook test runner, SSR — `window.Rollbar` is undefined. Reading
+// `.error`/`.configure` off the bare global would then throw
+// "Cannot read properties of undefined". To stay safe everywhere, we expose a
+// thin wrapper that resolves `window.Rollbar` at call time and no-ops when it
+// isn't available.
+
+interface RollbarClient {
+  info: (msg: string | Error, extra?: object) => void
+  error: (msg: string | Error, extra?: object) => void
+  warn: (msg: string | Error, extra?: object) => void
+  debug: (msg: string | Error, extra?: object) => void
+  configure: (options: object) => void
+}
 
 declare global {
   interface Window {
-    Rollbar: {
-      info: (msg: string | Error, extra?: object) => void
-      error: (msg: string | Error, extra?: object) => void
-      warn: (msg: string | Error, extra?: object) => void
-      debug: (msg: string | Error, extra?: object) => void
-      configure: (options: object) => void
-    }
+    Rollbar?: RollbarClient
   }
 }
 
-const rollbar = window.Rollbar
+const client = (): RollbarClient | undefined =>
+  typeof window !== 'undefined' ? window.Rollbar : undefined
+
+const rollbar: RollbarClient = {
+  info: (msg, extra) => client()?.info(msg, extra),
+  error: (msg, extra) => client()?.error(msg, extra),
+  warn: (msg, extra) => client()?.warn(msg, extra),
+  debug: (msg, extra) => client()?.debug(msg, extra),
+  configure: (options) => client()?.configure(options),
+}
 
 export default rollbar
 


### PR DESCRIPTION
Superseded — the rollbar fix has been applied directly onto PR #1718's branch (`feat/editor-areas-town-inspector`), so this standalone PR to `main` is redundant. Closing.