### PR TITLE
Night glow system: fireflies + configurable decor/quest-item glow

### DIFF
--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -16,7 +16,7 @@ import { createChunkCuller } from '../../utils/chunkCull'
 import { CommanderState } from '../../game/commander'
 import rollbar from '../../rollbar'
 import { HubInteractable, HubInteriorExit, HubLocationBundle, HubNpc, HubQuestBundle, HubStreetGroup, NpcScheduleEntry } from '../../data/hub/loader'
-import { createAnimalSystem, AnimalSystem } from './hubAnimals'
+import { createAnimalSystem, AnimalSystem, GlowSource } from './hubAnimals'
 import { createWeatherSystem } from './hubWeather'
 import { resolveWeather } from '../../game/hub/weather'
 import { BASE_CHIP_TILES } from '../../data/tiles/baseChipIndex'
@@ -225,6 +225,10 @@ export function HubTownCanvas({
     // Keyed by pickupId; used to imperatively show/hide sprites when items are collected
     const pickupSprites  = new Map<string, PIXI.Sprite>()
     const pickupQuestIds = new Map<string, string>()  // pickupId → questId, for ticker gating
+
+    // Night-glow sources flagged on decor / quest items (carved by the night overlay).
+    const decorGlows:  GlowSource[] = []                                       // static world positions
+    const pickupGlows: { id: string; radius: number; pulse: boolean }[] = []   // looked up live (skip collected)
 
     const base = (import.meta as { env: { BASE_URL: string } }).env.BASE_URL
 
@@ -438,6 +442,7 @@ export function HubTownCanvas({
         const list = map.get(d.tileId) ?? []
         list.push([d.tx, d.ty])
         map.set(d.tileId, list)
+        if (d.glow) decorGlows.push({ x: d.tx * T + T / 2, y: d.ty * T + T / 2, radius: (d.glowRadius ?? 2) * T, pulse: !!d.pulse })
       }
       for (const [tileId, positions] of extNormal) {
         loadTileRef(tileId).then(tex => {
@@ -811,6 +816,7 @@ export function HubTownCanvas({
             }
             pickupLayer.addChild(s)
             pickupSprites.set(pickup.id, s)
+            if (pickup.glow) pickupGlows.push({ id: pickup.id, radius: (pickup.glowRadius ?? 2) * T, pulse: !!pickup.pulse })
           }
         }).catch(() => {})
       }
@@ -2489,10 +2495,16 @@ export function HubTownCanvas({
       if (nightAlpha > 0 && !interiorActive && avatar) {
         nightSprite.visible = true
         const _anyNpcWalking = unitNpcs.some(n => n.isWalking)
+        // Fireflies and pulsing decor/item glows animate, so they must force a
+        // redraw every frame (fireflies also drift). Computed once, reused below.
+        const _fireflyGlows = animalSystem.getGlowSources()
+        const _hasDynamicGlow = _fireflyGlows.length > 0
+          || decorGlows.some(g => g.pulse) || pickupGlows.some(p => p.pulse)
         const _nightDirty = nightAlpha !== _lastNightAlpha
           || Math.abs(avatar.x - _lastNightAvatarX) > 0.5
           || Math.abs(avatar.y - _lastNightAvatarY) > 0.5
           || _anyNpcWalking
+          || _hasDynamicGlow
         if (!_nightDirty) { /* skip canvas redraw — nothing visible changed */ } else {
         _lastNightAlpha = nightAlpha
         _lastNightAvatarX = avatar.x
@@ -2536,6 +2548,25 @@ export function HubTownCanvas({
           nightCtx.fillStyle = grad
           nightCtx.beginPath()
           nightCtx.arc(npc.sprite.x * cs, npc.sprite.y * cs, NIGHT_NPC_LIGHT_R * 0.6 * cs, 0, Math.PI * 2)
+          nightCtx.fill()
+        }
+        // Extra night lights: fireflies + glow-flagged decor / quest items.
+        const _glowMs = performance.now()
+        const _pulse  = (seed: number) => 0.8 + 0.2 * Math.sin(_glowMs / 500 + seed)
+        const _extraGlows: GlowSource[] = [..._fireflyGlows, ...decorGlows]
+        for (const pg of pickupGlows) {
+          const ps = pickupSprites.get(pg.id)
+          if (ps && ps.visible) _extraGlows.push({ x: ps.x + T / 2, y: ps.y + T / 2, radius: pg.radius, pulse: pg.pulse })
+        }
+        for (const g of _extraGlows) {
+          const gx = g.x * cs, gy = g.y * cs
+          const gr = (g.pulse ? g.radius * _pulse(g.x + g.y) : g.radius) * cs
+          const grad = nightCtx.createRadialGradient(gx, gy, 0, gx, gy, gr)
+          grad.addColorStop(0, 'rgba(0,0,0,1)')
+          grad.addColorStop(1, 'rgba(0,0,0,0)')
+          nightCtx.fillStyle = grad
+          nightCtx.beginPath()
+          nightCtx.arc(gx, gy, gr, 0, Math.PI * 2)
           nightCtx.fill()
         }
         nightCtx.globalCompositeOperation = 'source-over'

--- a/web/src/components/hub/hubAnimals.ts
+++ b/web/src/components/hub/hubAnimals.ts
@@ -27,6 +27,7 @@ const T_PX = 32
 // placed bird has hysteresis and doesn't instantly re-flee.
 const BIRD_FLEE_R = 4.5 * T_PX
 const BIRD_PERCH_CLEAR = 6 * T_PX
+const FIREFLY_GLOW_R = 1.2 * T_PX   // small night light pool each firefly casts
 
 type Rect = [number, number, number, number]   // tx, ty, w, h
 interface Pt { x: number; y: number }
@@ -119,10 +120,15 @@ export interface AnimalSystemOptions {
   getViewportRect: () => { x: number; y: number; w: number; h: number } | null
 }
 
+/** A point light the night overlay should carve into the darkness. */
+export interface GlowSource { x: number; y: number; radius: number; pulse: boolean }
+
 export interface AnimalSystem {
   tick: (deltaMS: number) => void
   /** Animals currently denned inside the given building (for interior render). */
   getAnimalsInBuilding: (buildingId: string) => { type: AnimalType; tint: number }[]
+  /** Night light sources from animals (fireflies) for the night overlay. */
+  getGlowSources: () => GlowSource[]
   destroy: () => void
 }
 
@@ -995,6 +1001,18 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
     return animals.filter(a => a.insideBuilding === buildingId).map(a => ({ type: a.type, tint: a.tint }))
   }
 
+  // Fireflies glow at night — hand their positions to the night overlay so it can
+  // carve a small pool of light around each visible one.
+  function getGlowSources(): GlowSource[] {
+    const out: GlowSource[] = []
+    for (const a of animals) {
+      if (a.type === 'firefly' && a.sprite.visible) {
+        out.push({ x: a.sprite.x, y: a.sprite.y, radius: FIREFLY_GLOW_R, pulse: true })
+      }
+    }
+    return out
+  }
+
   function destroy() {
     for (const a of animals) {
       if (a.bubble) opts.bubbleLayer.removeChild(a.bubble)
@@ -1006,5 +1024,5 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
     fishLayer.destroy({ children: true })
   }
 
-  return { tick, getAnimalsInBuilding, destroy }
+  return { tick, getAnimalsInBuilding, getGlowSources, destroy }
 }

--- a/web/src/components/mapEditor/EntityInspector.tsx
+++ b/web/src/components/mapEditor/EntityInspector.tsx
@@ -30,6 +30,8 @@ const T = 32
 
 type InteriorExit = NonNullable<RawInterior['exits']>[number]
 
+export type GlowPatch = Partial<{ glow: boolean; glowRadius: number; pulse: boolean }>
+
 interface Props {
   selectedEntity:   SelectedEntity | null
   configData:       RawMapConfig
@@ -37,6 +39,8 @@ interface Props {
   onDelete:              (entity: SelectedEntity) => void
   onMoveEntity:          (entity: SelectedEntity, tx: number, ty: number) => void
   onZlayerChange:        (entity: SelectedEntity, z: Zlayer) => void
+  onUpdateGlow?:         (entity: SelectedEntity, patch: GlowPatch) => void
+  onUpdatePickupGlow?:   (index: number, patch: GlowPatch) => void
   onDialogueChange:      (index: number, dialogue: string[]) => void
   onOpenInterior:        (id: string) => void
   onCloseInterior:       () => void
@@ -215,13 +219,47 @@ function numInput(value: number, onChange: (v: number) => void) {
   )
 }
 
+// Night-glow controls shared by decor and pickup-item inspectors.
+function GlowControls({ glow, glowRadius, pulse, onChange }: {
+  glow?: boolean; glowRadius?: number; pulse?: boolean; onChange: (patch: GlowPatch) => void
+}) {
+  const checkbox = (label: string, checked: boolean, on: (v: boolean) => void) => (
+    <label style={{ display: 'flex', alignItems: 'center', gap: 6, cursor: 'pointer', fontSize: 11 }}>
+      <input type="checkbox" checked={checked} onChange={e => on(e.target.checked)} />
+      {label}
+    </label>
+  )
+  return (
+    <>
+      <Field label="Glow">{checkbox('night light', !!glow, v => onChange({ glow: v }))}</Field>
+      {glow && (
+        <>
+          <Field label="Glow radius">
+            <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+              <input
+                type="range" min={1} max={8} step={0.5}
+                value={glowRadius ?? 2}
+                onChange={e => onChange({ glowRadius: Number(e.target.value) })}
+                style={{ flex: 1 }}
+              />
+              <span style={{ fontSize: 11, color: '#aaa', width: 34, textAlign: 'right' }}>{glowRadius ?? 2}t</span>
+            </div>
+          </Field>
+          <Field label="Pulse">{checkbox('animate radius', !!pulse, v => onChange({ pulse: v }))}</Field>
+        </>
+      )}
+    </>
+  )
+}
+
 function DecorInspector({
-  item, entity, onMove, onZlayer, onDelete,
+  item, entity, onMove, onZlayer, onGlow, onDelete,
 }: {
   item: RawDecorItem
   entity: SelectedEntity
   onMove: (tx: number, ty: number) => void
   onZlayer: (z: Zlayer) => void
+  onGlow?: (patch: GlowPatch) => void
   onDelete: () => void
 }) {
   return (
@@ -255,6 +293,7 @@ function DecorInspector({
           ))}
         </div>
       </Field>
+      {onGlow && <GlowControls glow={item.glow} glowRadius={item.glowRadius} pulse={item.pulse} onChange={onGlow} />}
       <button
         onClick={onDelete}
         style={{
@@ -1192,7 +1231,7 @@ function TownInspector({
 
 export function EntityInspector({
   selectedEntity, configData, activeInteriorId, viewMode,
-  onDelete, onMoveEntity, onZlayerChange, onDialogueChange,
+  onDelete, onMoveEntity, onZlayerChange, onUpdateGlow, onUpdatePickupGlow, onDialogueChange,
   onOpenInterior, onCloseInterior, onUpdateStreetEntry,
   onResizeInterior, onAddInterior, onAddInteriorExit, onUpdateInteriorProps, onUpdateInteriorExit,
   onRemoveInteriorExit,
@@ -1282,6 +1321,7 @@ export function EntityInspector({
             entity={selectedEntity}
             onMove={(tx, ty) => onMoveEntity(selectedEntity, tx, ty)}
             onZlayer={z => onZlayerChange(selectedEntity, z)}
+            onGlow={onUpdateGlow ? patch => onUpdateGlow(selectedEntity, patch) : undefined}
             onDelete={() => onDelete(selectedEntity)}
           />
         </div>
@@ -1369,6 +1409,12 @@ export function EntityInspector({
             onDelete={() => onDelete(selectedEntity)}
             onTileChange={onUpdatePickupItemTile ? tileId => onUpdatePickupItemTile(selectedEntity.index, tileId) : undefined}
           />
+          {onUpdatePickupGlow && (
+            <GlowControls
+              glow={p.glow} glowRadius={p.glowRadius} pulse={p.pulse}
+              onChange={patch => onUpdatePickupGlow(selectedEntity.index, patch)}
+            />
+          )}
         </div>
       </div>
     )

--- a/web/src/components/mapEditor/MapEditor.tsx
+++ b/web/src/components/mapEditor/MapEditor.tsx
@@ -35,7 +35,7 @@ export function MapEditor({ initialMapId = 'ravenwatch' }: Props) {
     state, setMapId, setTool, setActiveTile, setZlayer,
     openInterior, closeInterior, selectEntity,
     placeDecor, moveEntity, deleteEntity,
-    updateDecorZlayer, addNpc, updateNpcDialogue, updateNpc,
+    updateDecorZlayer, updateGlow, addNpc, updateNpcDialogue, updateNpc,
     addAnimal, updateAnimal,
     updateTreasure,
     updateArea, updateMapProps, resizeMap,
@@ -228,6 +228,14 @@ export function MapEditor({ initialMapId = 'ravenwatch' }: Props) {
               onDelete={handleDeleteEntity}
               onMoveEntity={handleMoveEntity}
               onZlayerChange={updateDecorZlayer}
+              onUpdateGlow={updateGlow}
+              onUpdatePickupGlow={(index, patch) => setQuestDefsData(prev => {
+                if (!prev) return prev
+                const items = [...(prev.pickupItems ?? [])]
+                if (!items[index]) return prev
+                items[index] = { ...items[index], ...patch }
+                return { ...prev, pickupItems: items }
+              })}
               onDialogueChange={updateNpcDialogue}
               onOpenInterior={openInterior}
               onCloseInterior={closeInterior}

--- a/web/src/components/mapEditor/mapEditorTypes.ts
+++ b/web/src/components/mapEditor/mapEditorTypes.ts
@@ -16,6 +16,9 @@ export interface RawDecorItem {
   zlayer?: Zlayer
   bundleID?: string
   comment?: string
+  glow?: boolean        // emit a night light glow
+  glowRadius?: number   // glow radius in tiles
+  pulse?: boolean       // animate the glow radius
 }
 
 export interface RawBuildingDoor {
@@ -155,6 +158,9 @@ export interface RawMapConfig {
     questId?: string
     chain?: string
     requireTouch?: boolean
+    glow?: boolean
+    glowRadius?: number
+    pulse?: boolean
   }>
   blockedPaths?: unknown[]
   lockedDoors?: RawLockedDoor[]

--- a/web/src/components/mapEditor/useMapEditorState.ts
+++ b/web/src/components/mapEditor/useMapEditorState.ts
@@ -293,6 +293,39 @@ export function useMapEditorState(initialMapId: MapId = 'ravenwatch') {
     })
   }, [])
 
+  // Merge glow fields (glow/glowRadius/pulse) into the selected decor item.
+  const updateGlow = useCallback((entity: SelectedEntity, patch: Partial<{ glow: boolean; glowRadius: number; pulse: boolean }>) => {
+    setState(s => {
+      const prevConfig = s.configData
+      let newConfig = prevConfig
+
+      if (entity.type === 'exteriorDecor') {
+        const decor = [...(prevConfig.exteriorDecor ?? [])]
+        if (!decor[entity.index]) return s
+        decor[entity.index] = { ...decor[entity.index], ...patch }
+        newConfig = { ...prevConfig, exteriorDecor: decor }
+      } else if (entity.type === 'interiorDecor' && prevConfig.interiors?.[entity.interiorId]) {
+        const interior = prevConfig.interiors[entity.interiorId]
+        const decor = [...interior.decor]
+        if (!decor[entity.index]) return s
+        decor[entity.index] = { ...decor[entity.index], ...patch }
+        newConfig = {
+          ...prevConfig,
+          interiors: { ...prevConfig.interiors, [entity.interiorId]: { ...interior, decor } },
+        }
+      }
+
+      if (newConfig === prevConfig) return s
+      return {
+        ...s,
+        configData: newConfig,
+        undoStack:  [...s.undoStack, prevConfig].slice(-MAX_UNDO),
+        redoStack:  [],
+        isDirty:    true,
+      }
+    })
+  }, [])
+
   const updateNpcDialogue = useCallback((index: number, dialogue: string[]) => {
     setState(s => {
       const prevConfig = s.configData
@@ -822,6 +855,7 @@ export function useMapEditorState(initialMapId: MapId = 'ravenwatch') {
     moveEntity,
     deleteEntity,
     updateDecorZlayer,
+    updateGlow,
     addNpc,
     updateNpcDialogue,
     updateNpc,

--- a/web/src/data/hub/config.ts
+++ b/web/src/data/hub/config.ts
@@ -42,6 +42,9 @@ export interface RawDecor {
   bundleID?: string
   zlayer?: string
   comment?: string
+  glow?: boolean        // emit a night light glow (reuses the night overlay)
+  glowRadius?: number   // glow radius in tiles
+  pulse?: boolean       // animate the glow radius
 }
 
 export interface RawCoordinate {  tx: number

--- a/web/src/data/hub/hubWorldFactory.ts
+++ b/web/src/data/hub/hubWorldFactory.ts
@@ -50,6 +50,9 @@ export interface RawQuestPickupItem {
   building?: string
   chain?: string
   requireTouch?: boolean
+  glow?: boolean
+  glowRadius?: number
+  pulse?: boolean
 }
 export type MapId =
   | 'ravenwatch'

--- a/web/src/data/hub/loader.ts
+++ b/web/src/data/hub/loader.ts
@@ -37,7 +37,13 @@ export interface HubDoor {
   tyAdjust?: number  // tiles to shift the render position upward (0 = standard south-face)
 }
 
-export interface InteriorDecor {
+export interface DecorGlow {
+  glow?:       boolean   // emit a night light glow (reuses the night overlay)
+  glowRadius?: number    // glow radius in tiles
+  pulse?:      boolean   // animate the glow radius
+}
+
+export interface InteriorDecor extends DecorGlow {
   tx:      number
   ty:      number
   tileId:  number
@@ -125,7 +131,7 @@ export interface HubAnimal {
   areaRect?: number[]
 }
 
-export interface HubPickupItem {
+export interface HubPickupItem extends DecorGlow {
   id: string
   tx: number
   ty: number
@@ -410,12 +416,12 @@ for (const b of rawConfig.buildings as RawBuilding[]) {
   }
 }
 
-type RawDecorEntry = { tx?: number; ty?: number; tileId?: string; bundleID?: string; comment?: string; zlayer?: string }
+type RawDecorEntry = { tx?: number; ty?: number; tileId?: string; bundleID?: string; comment?: string; zlayer?: string; glow?: boolean; glowRadius?: number; pulse?: boolean }
 const EXTERIOR_DECOR = [
   ...(rawConfig.exteriorDecor as RawDecorEntry[]).flatMap(d => {
     if (d.tx == null || d.ty == null) return []
     if (d.bundleID) return expandBundleDecor(d.bundleID, d.tx, d.ty)
-    if (d.tileId) return [{ tx: d.tx, ty: d.ty, tileId: resolveTileId(d.tileId), zlayer: d.zlayer }]
+    if (d.tileId) return [{ tx: d.tx, ty: d.ty, tileId: resolveTileId(d.tileId), zlayer: d.zlayer, glow: d.glow, glowRadius: d.glowRadius, pulse: d.pulse }]
     return []
   }),
   ..._nestedDecor,
@@ -672,7 +678,7 @@ const HUB_BLOCKED_PATHS: BlockedPath[] = (
   cleared:      resolveBlockedPathState(bp.cleared),
 }))
 
-type RawPickup = { id: string; tx: number; ty: number; tileId: string; building?: string; questId?: string; chain?: string; requireTouch?: boolean }
+type RawPickup = { id: string; tx: number; ty: number; tileId: string; building?: string; questId?: string; chain?: string; requireTouch?: boolean; glow?: boolean; glowRadius?: number; pulse?: boolean }
 const HUB_PICKUP_ITEMS: HubPickupItem[] = (
   (rawQuestConfig as unknown as { pickupItems?: RawPickup[] }).pickupItems ?? []
 ).map(p => ({
@@ -684,6 +690,9 @@ const HUB_PICKUP_ITEMS: HubPickupItem[] = (
   questId:      p.questId,
   chain:        p.chain,
   requireTouch: p.requireTouch,
+  glow:         p.glow,
+  glowRadius:   p.glowRadius,
+  pulse:        p.pulse,
 }))
 
 const HUB_DIALOGUES: Record<string, DialogueTree> = Object.fromEntries(


### PR DESCRIPTION
Adds a night-time glow system: fireflies cast a small pulsing light, and decor / quest items can be flagged to glow. Reuses the existing night-overlay "light-hole" reveal (the same colourless effect that already lights the avatar and NPCs at night) — so glow is only visible at night/dusk-dawn.

## What's included
- **Fireflies glow.** The animal system exposes `getGlowSources()` (visible fireflies → a small pulsing pool of light). `hubAnimals.ts`
- **Decor & quest-item glow.** New optional fields `glow` / `glowRadius` (tiles) / `pulse` are threaded through the data model (`RawDecor`, `InteriorDecor`/`HubPickupItem` via a shared `DecorGlow`, `RawQuestPickupItem`, editor types) and the loader. Flagged items carve a radial light hole at night; collected pickups stop glowing. `config.ts`, `loader.ts`, `hubWorldFactory.ts`, `HubTownCanvas.tsx`
- **Night-pass rendering.** After the avatar/NPC carving, fireflies + decor + visible pickup glows are carved with the same `destination-out` gradient. Pulsing/moving glows extend the `_nightDirty` flag so they animate each frame (cheap — the night canvas is low-res, MAP/8).
- **Map-editor controls.** The exterior-decor and pickup-item inspectors get a glow checkbox, a glow-radius slider (1–8 tiles), and a pulse checkbox, with write-back via a new `updateGlow` handler (decor) and `setQuestDefsData` (pickups). `EntityInspector.tsx`, `MapEditor.tsx`, `useMapEditorState.ts`

## Notes
- Glow is intentionally **night-only** (the overlay only renders at night) and colourless — it reveals the lit map beneath, matching the NPC lights. Interior decor is excluded from the editor since the night overlay is exterior-only.
- Branched after PR #1721 (birds) merged; rebased onto the latest `main`.

## Verification
- `npx tsc --noEmit` — clean.
- `npx vitest run` — 190 tests pass (Playwright browser tests don't run in this container; pre-existing environmental limitation).

Manual: at night, fireflies cast a small pulsing light; flag a decor item's `glow` (radius/pulse) in the editor → it lights its surroundings at night and is dark by day; a glowing quest item lights up until collected; toggling `pulse` animates the radius.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HpbzdgJPNvowxMUAKsCvss)_