### PR TITLE
Per-level building exterior & interior editing in the map editor (#1641)

### DIFF
--- a/docs/hubworld.md
+++ b/docs/hubworld.md
@@ -791,6 +791,43 @@ kinds: `shop`, `inn`, `tavern`, `cottage`, `workshop`, `shrine`, `default`.
 Reputation tiers/names live in `buildingUpgrades.ts` (`REPUTATION_TIERS`,
 `REPUTATION_TIER_NAMES`, `getReputationTier`).
 
+### Per-building level variants (map editor)
+
+The shared `decor` track above applies to *every* building of a kind. To author
+how **one specific building** looks and behaves at each upgrade level, use the
+map editor's **level selector** (shown on the Building inspector and inside an
+interior). Stepping the level previews that level (higher-level content is
+dimmed) and tags anything you place with the selected level. Levels are
+**cumulative**: an item with `minLevel: 2` appears once the building reaches
+level 2 and stays for all higher levels.
+
+This is stored directly in `config.json` via three optional fields:
+
+| Field | Where | Effect |
+|---|---|---|
+| `levelDecor` | on a building | Per-building exterior decor (absolute `tx`/`ty`). Each item carries `minLevel`. When present it **replaces** the shared kind-track decor for that building. |
+| `minLevel` | on an interior `decor` item | Interior decor that only appears at/above this upgrade level. |
+| `minLevel` | on an interior `exits[]` entry | The room behind the doorway is **unavailable** (door closed, not walkable) until the level is reached. |
+| `minLevel` | on an NPC | The NPC (and the quests it gives/receives) is **absent** until the level is reached. |
+
+```jsonc
+{
+  "id": "cider-house", "upgradeKind": "tavern", "maxLevel": 3,
+  "rect": [4, 2, 11, 8],
+  "levelDecor": [
+    { "tx": 3, "ty": 9, "tileId": "barrel" },                 // base — always shown
+    { "tx": 12, "ty": 9, "tileId": "drinkSign", "minLevel": 2 } // appears at level 2+
+  ]
+}
+```
+
+At runtime `HubTownCanvas` resolves the building's current level
+(`getUpgradeLevel`) and filters interior decor / exits / NPCs and per-building
+`levelDecor` by `minLevel`. Sub-rooms (interiors with no exterior door) inherit
+the level of the parent building whose id prefixes the interior id. `maxLevel`
+(optional) caps how many levels the editor offers; it defaults to the
+`upgradeKind` track length.
+
 ### Services
 
 Each unlocked `service` id is readable via `getUnlockedServices(town)` /

--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -709,7 +709,30 @@ export function HubTownCanvas({
     const upgradeDecorSprites: { buildingId: string; levelIndex: number; sprite: PIXI.Sprite }[] = []
     {
       for (const b of HUB_BUILDINGS) {
-        if (!b.id || !b.upgradeKind) continue
+        if (!b.id) continue
+        const buildingLevel = buildingUpgradeLevelsRef?.current[b.id] ?? 0
+
+        // Per-building level decor (absolute tile positions, authored in the map
+        // editor). When present it replaces the shared kind-track visuals for
+        // this building. Each item carries minLevel and reveals cumulatively.
+        if (b.levelDecor?.length) {
+          for (const d of b.levelDecor) {
+            const min = d.minLevel ?? 0
+            const layer = d.zlayer === 'above' ? aboveAvatarLayer : belowAvatarLayer
+            loadTileRef(d.tileId).then(tex => {
+              if (app.renderer == null) return
+              const s = new PIXI.Sprite(tex)
+              s.position.set(d.tx * T, d.ty * T)
+              s.width = T; s.height = T
+              s.visible = buildingLevel >= min
+              layer.addChild(s)
+              upgradeDecorSprites.push({ buildingId: b.id as string, levelIndex: min - 1, sprite: s })
+            }).catch(() => {})
+          }
+          continue
+        }
+
+        if (!b.upgradeKind) continue
         // Anchor decor at the building's primary door; fall back to the front
         // centre of its footprint when the door comes from a bundle/elsewhere.
         const foundDoor = HUB_DOORS.find(d => d.buildingId === b.id)
@@ -718,7 +741,6 @@ export function HubTownCanvas({
           ty: b.rect[3] + 1,
         }
         const track = getUpgradeTrack(b.upgradeKind)
-        const currentLevel = buildingUpgradeLevelsRef?.current[b.id] ?? 0
         track.forEach((lvl, levelIndex) => {
           for (const d of lvl.decor ?? []) {
             const tileId = (BASE_CHIP_TILES as Record<string, number>)[d.tileId]
@@ -731,7 +753,7 @@ export function HubTownCanvas({
               const s = new PIXI.Sprite(tex)
               s.position.set(tx * T, ty * T)
               s.width = T; s.height = T
-              s.visible = currentLevel >= levelIndex + 1
+              s.visible = buildingLevel >= levelIndex + 1
               belowAvatarLayer.addChild(s)
               upgradeDecorSprites.push({ buildingId, levelIndex, sprite: s })
             }).catch(() => {})
@@ -1379,6 +1401,16 @@ export function HubTownCanvas({
       const interior = HUB_INTERIORS[buildingId]
       if (!interior) return
 
+      // ── Upgrade-level gating ───────────────────────────────────────────────
+      // Interior decor, rooms (exits) and NPCs can be tagged with a minLevel so
+      // they only appear once the building has been upgraded that far. Sub-rooms
+      // (no exterior door) inherit the level of the parent building whose id
+      // prefixes this interior's id.
+      const levelKey = HUB_BUILDINGS.find(b => b.id && buildingId.startsWith(b.id) && b.upgradeKind)?.id ?? buildingId
+      const currentLevel = buildingUpgradeLevelsRef?.current[levelKey] ?? 0
+      const visibleDecor   = interior.decor.filter(d => (d.minLevel ?? 0) <= currentLevel)
+      const availableExits = (interior.exits ?? []).filter(e => (e.minLevel ?? 0) <= currentLevel)
+
       // Building hours check — block entry if closed
       if (!isBuildingOpen(interior, gameHourRef.current)) {
         const openHour = interior.hours !== 'always' && interior.hours ? interior.hours.open : null
@@ -1451,7 +1483,7 @@ export function HubTownCanvas({
         for (let ty = 1; ty < interior.height - 1; ty++)
           interiorWalkable.add(`${tx},${ty}`)
       if (!isSubRoom) interiorWalkable.add(`${exitTx},${interior.height - 1}`)
-      for (const d of interior.decor) {
+      for (const d of visibleDecor) {
         if (!d.zlayer || d.zlayer === 'solid') interiorWalkable.delete(`${d.tx},${d.ty}`)
       }
       // Interactables' owned solid decor blocks walking (at moved position if persisted)
@@ -1462,7 +1494,7 @@ export function HubTownCanvas({
         }
       }
       // Register inter-room exit tiles
-      for (const exit of interior.exits ?? []) {
+      for (const exit of availableExits) {
         interiorWalkable.add(`${exit.tx},${exit.ty}`)
         exitByTile.set(`${exit.tx},${exit.ty}`, exit)
       }
@@ -1473,7 +1505,7 @@ export function HubTownCanvas({
         for (let ty = 1; ty < interior.height - 1; ty++)
           floorSet.add(`${tx},${ty}`)
       if (!isSubRoom) floorSet.add(`${exitTx},${interior.height - 1}`)  // exit door opening
-      for (const exit of interior.exits ?? []) {
+      for (const exit of availableExits) {
         if (exit.direction === 'left' || exit.direction === 'right' ||
             exit.direction === 'front' || exit.direction === 'back') floorSet.add(`${exit.tx},${exit.ty}`)
       }
@@ -1489,7 +1521,7 @@ export function HubTownCanvas({
         wallSet.add(`${interior.width - 1},${ty}`)
       }
       if (!isSubRoom) wallSet.delete(`${exitTx},${interior.height - 1}`)  // open bottom door gap
-      for (const exit of interior.exits ?? []) {
+      for (const exit of availableExits) {
         if (exit.direction === 'left' || exit.direction === 'right' ||
             exit.direction === 'front' || exit.direction === 'back') wallSet.delete(`${exit.tx},${exit.ty}`)
       }
@@ -1517,7 +1549,7 @@ export function HubTownCanvas({
           floorContainer.addChild(exitFloor)
         }
         // Wall-gap exits need explicit floor tiles (they're outside the inner loop)
-        for (const exit of interior.exits ?? []) {
+        for (const exit of availableExits) {
           if (exit.direction === 'left' || exit.direction === 'right' ||
               exit.direction === 'front' || exit.direction === 'back') {
             const s = new PIXI.Sprite(floorTex)
@@ -1538,7 +1570,7 @@ export function HubTownCanvas({
         else {sideWallSet.add(`${wx},${wy-1}`); sideWallSet.add(`${wx},${wy}`)}
       }
       // The tile below a left/right exit contributes the exit position to sideWallSet; remove it explicitly
-      for (const exit of interior.exits ?? []) {
+      for (const exit of availableExits) {
         if (exit.direction === 'left' || exit.direction === 'right') sideWallSet.delete(`${exit.tx},${exit.ty}`)
         // back exits are at ty=0; the sideWallSet formula adds (wx, -1) and (wx, 0) for ty=0 wall tiles,
         // but since we deleted (tx, 0) from wallSet before building sideWallSet, nothing to clean up here.
@@ -1598,7 +1630,7 @@ export function HubTownCanvas({
         }
       }
 
-      renderDecorItems(interior.decor.filter(d => d.zlayer !== 'above'), decorBelowContainer)
+      renderDecorItems(visibleDecor.filter(d => d.zlayer !== 'above'), decorBelowContainer)
       // above decor rendered after avatar is added (below)
 
       // Interior pickup items — rendered in room, disappear when tapped
@@ -1654,7 +1686,7 @@ export function HubTownCanvas({
       }
 
       // Interior NPCs — rendered inside the room, tappable
-      const interiorNpcList: HubNpc[] = INTERIOR_NPCS[buildingId] ?? []
+      const interiorNpcList: HubNpc[] = (INTERIOR_NPCS[buildingId] ?? []).filter(n => (n.minLevel ?? 0) <= currentLevel)
       for (const npc of interiorNpcList) {
         loadTextureUrl(`${base}sprites/${npc.sprite}.svg`).then(tex => {
           if (!interiorActive || currentInteriorId !== buildingId) return
@@ -1780,7 +1812,7 @@ export function HubTownCanvas({
         interiorLayer.addChild(exitMarker)
       }
       // Room-exit direction markers (stairs, passages)
-      for (const exit of interior.exits ?? []) {
+      for (const exit of availableExits) {
         const arrow = exit.direction === 'up' ? '▲' : exit.direction === 'down' ? '▼' : exit.direction === 'left' ? '◄' : exit.direction === 'back' ? '▲' : exit.direction === 'front' ? '▼' : '►'
         const marker = new PIXI.Text({
           text: arrow,
@@ -1802,7 +1834,7 @@ export function HubTownCanvas({
 
       // above decor — added after avatar so it renders on top
       interiorLayer.addChild(decorAboveContainer)
-      renderDecorItems(interior.decor.filter(d => d.zlayer === 'above'), decorAboveContainer)
+      renderDecorItems(visibleDecor.filter(d => d.zlayer === 'above'), decorAboveContainer)
 
       // Interior treasures — chests defined in the treasures array with a matching buildingId
       for (const t of HUB_TREASURES.filter(tr => tr.buildingId === buildingId)) {

--- a/web/src/components/mapEditor/EntityInspector.tsx
+++ b/web/src/components/mapEditor/EntityInspector.tsx
@@ -8,6 +8,12 @@ import { NpcSpritePicker, AnimalTypePicker } from './SpritePicker'
 import { ANIMAL_SPECS } from '../../game/hub/animals'
 import type { AnimalType } from '../../game/hub/animals'
 import { BUILDING_MUSIC_IDS, AMBIANCE_IDS } from '../../game/sound'
+import { getUpgradeTrack } from '../../data/hub/buildingUpgrades'
+
+/** Highest upgrade level a building can reach: explicit maxLevel, else its kind track length. */
+function buildingMaxLevel(building: RawBuilding): number {
+  return building.maxLevel ?? getUpgradeTrack(building.upgradeKind).length
+}
 
 const FLOOR_TILES = [
   'woodFloor', 'stoneFloor', 'cobblestoneFloor', 'quarteredFloor', 'checkeredFloor',
@@ -36,6 +42,10 @@ interface Props {
   selectedEntity:   SelectedEntity | null
   configData:       RawMapConfig
   activeInteriorId: string | null
+  activeLevel:      number
+  onSetActiveLevel:      (level: number) => void
+  onUpdateBuilding:      (index: number, patch: Partial<RawBuilding>) => void
+  onUpdateDecorMinLevel: (entity: SelectedEntity, minLevel: number | undefined) => void
   onDelete:              (entity: SelectedEntity) => void
   onMoveEntity:          (entity: SelectedEntity, tx: number, ty: number) => void
   onZlayerChange:        (entity: SelectedEntity, z: Zlayer) => void
@@ -205,6 +215,25 @@ function Field({ label, children }: { label: string; children: React.ReactNode }
   )
 }
 
+// Upgrade-level selector. Stepping it changes which level the canvas previews
+// and which level newly-placed decor is tagged with.
+function LevelStepper({ level, max, onChange }: { level: number; max: number; onChange: (n: number) => void }) {
+  const btn: React.CSSProperties = {
+    padding: '2px 9px', fontSize: 13, cursor: 'pointer', borderRadius: 3,
+    background: '#1a2030', border: '1px solid #2a3050', color: '#88aaee', lineHeight: 1.2,
+  }
+  const disabled: React.CSSProperties = { ...btn, opacity: 0.35, cursor: 'default' }
+  return (
+    <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+      <button style={level <= 0 ? disabled : btn} disabled={level <= 0} onClick={() => onChange(level - 1)}>−</button>
+      <span style={{ fontFamily: 'monospace', fontSize: 12, color: level > 0 ? '#f0c040' : '#aaa', minWidth: 54, textAlign: 'center' }}>
+        {level === 0 ? 'base' : `level ${level}`} / {max}
+      </span>
+      <button style={level >= max ? disabled : btn} disabled={level >= max} onClick={() => onChange(level + 1)}>+</button>
+    </div>
+  )
+}
+
 function numInput(value: number, onChange: (v: number) => void) {
   return (
     <input
@@ -253,7 +282,7 @@ function GlowControls({ glow, glowRadius, pulse, onChange }: {
 }
 
 function DecorInspector({
-  item, entity, onMove, onZlayer, onGlow, onDelete,
+  item, entity, onMove, onZlayer, onGlow, onDelete, onMinLevel, maxLevel,
 }: {
   item: RawDecorItem
   entity: SelectedEntity
@@ -261,12 +290,27 @@ function DecorInspector({
   onZlayer: (z: Zlayer) => void
   onGlow?: (patch: GlowPatch) => void
   onDelete: () => void
+  onMinLevel?: (minLevel: number | undefined) => void
+  maxLevel?: number
 }) {
   return (
     <div>
       <Field label="Tile">
         {item.tileId ? <TilePreview tileId={item.tileId} /> : <span style={{ color: '#aaa' }}>{item.bundleID ?? '—'}</span>}
       </Field>
+      {onMinLevel && (
+        <Field label="Appears at level">
+          <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+            <input
+              type="number" min={0} max={maxLevel ?? 9}
+              value={item.minLevel ?? 0}
+              onChange={e => onMinLevel(Number(e.target.value))}
+              style={{ width: 56, padding: '3px 5px', background: '#111', border: '1px solid #444', color: '#eee', borderRadius: 3, fontSize: 12 }}
+            />
+            <span style={{ fontSize: 10, color: '#666' }}>0 = always visible</span>
+          </div>
+        </Field>
+      )}
       <Field label="Position">
         <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
           <label style={{ fontSize: 11, color: '#888' }}>X</label>
@@ -348,6 +392,25 @@ function NpcInspector({
           }}
         />
         <div style={{ color: '#666', fontSize: 10, marginTop: 2 }}>One line = one dialogue entry</div>
+      </Field>
+      <Field label="Min Building Level">
+        <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+          <input
+            type="number" min={0}
+            value={npc.minLevel ?? 0}
+            onChange={e => {
+              const v = Math.max(0, Number(e.target.value))
+              onUpdate({ minLevel: v > 0 ? v : undefined })
+            }}
+            style={{ width: 56, padding: '3px 5px', background: '#111', border: '1px solid #444', color: '#eee', borderRadius: 3, fontSize: 12 }}
+          />
+          <span style={{ fontSize: 10, color: '#666' }}>0 = always present</span>
+        </div>
+        {npc.building && (npc.questGive || npc.questReceive) && (npc.minLevel ?? 0) > 0 && (
+          <div style={{ color: '#c97', fontSize: 10, marginTop: 3 }}>
+            Quests on this NPC are only obtainable once the building reaches level {npc.minLevel}.
+          </div>
+        )}
       </Field>
       <button
         onClick={onDelete}
@@ -612,9 +675,14 @@ function StreetInspector({
 }
 
 function BuildingInspector({
-  building, onOpenInterior, interiorIds, existingInteriorIds, onAddInterior,
+  building, buildingIndex, activeLevel, onSetActiveLevel, onUpdateBuilding,
+  onOpenInterior, interiorIds, existingInteriorIds, onAddInterior,
 }: {
   building: RawBuilding
+  buildingIndex: number
+  activeLevel: number
+  onSetActiveLevel: (level: number) => void
+  onUpdateBuilding: (index: number, patch: Partial<RawBuilding>) => void
   onOpenInterior: (id: string) => void
   interiorIds: string[]
   existingInteriorIds: string[]
@@ -692,6 +760,34 @@ function BuildingInspector({
           <span style={{ fontFamily: 'monospace', fontSize: 11, color: '#aaa' }}>{building.roof}</span>
         </Field>
       )}
+
+      {/* ── Upgrade levels ─────────────────────────────────────────────── */}
+      <div style={{ borderTop: '1px solid #333', marginTop: 4, paddingTop: 10 }}>
+        <Field label="Upgrade Kind">
+          <input
+            value={building.upgradeKind ?? ''}
+            onChange={e => onUpdateBuilding(buildingIndex, { upgradeKind: e.target.value || undefined })}
+            placeholder="shop / inn / tavern / …"
+            style={inputStyle}
+          />
+        </Field>
+        <Field label="Max Level">
+          <input
+            type="number" min={0}
+            value={building.maxLevel ?? buildingMaxLevel(building)}
+            onChange={e => onUpdateBuilding(buildingIndex, { maxLevel: Math.max(0, Number(e.target.value)) })}
+            style={numStyle}
+          />
+        </Field>
+        <Field label="Editing Level">
+          <LevelStepper level={activeLevel} max={buildingMaxLevel(building)} onChange={onSetActiveLevel} />
+        </Field>
+        <div style={{ color: '#777', fontSize: 10, marginBottom: 8 }}>
+          {(building.levelDecor ?? []).filter(d => (d.minLevel ?? 0) === activeLevel).length} decor item(s) added at {activeLevel === 0 ? 'base' : `level ${activeLevel}`}.
+          {' '}Pick a tile and use the Place tool to add decor for this level. Items from lower levels stay visible; higher-level items are dimmed.
+        </div>
+      </div>
+
       <Field label="Interiors">
         <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
           {interiorIds.map(id => (
@@ -762,6 +858,7 @@ function BuildingInspector({
 
 function InteriorInspector({
   interiorId, interior, selectedEntity, allInteriors,
+  activeLevel, levelMax, onSetActiveLevel, onUpdateDecorMinLevel,
   panelStyle, headerStyle, bodyStyle,
   onCloseInterior, onOpenInterior, onResizeInterior,
   onAddInteriorExit, onUpdateInteriorProps, onUpdateInteriorExit, onRemoveInteriorExit,
@@ -771,6 +868,10 @@ function InteriorInspector({
   interior: RawInterior | undefined
   selectedEntity: SelectedEntity | null
   allInteriors: Record<string, RawInterior>
+  activeLevel: number
+  levelMax: number
+  onSetActiveLevel: (level: number) => void
+  onUpdateDecorMinLevel: (entity: SelectedEntity, minLevel: number | undefined) => void
   panelStyle: React.CSSProperties
   headerStyle: React.CSSProperties
   bodyStyle: React.CSSProperties
@@ -910,6 +1011,12 @@ function InteriorInspector({
                 {AMBIANCE_IDS.map(id => <option key={id} value={id}>{id}</option>)}
               </select>
             </Field>
+            <Field label="Editing Level">
+              <LevelStepper level={activeLevel} max={levelMax} onChange={onSetActiveLevel} />
+              <div style={{ color: '#777', fontSize: 10, marginTop: 4 }}>
+                Decor, rooms & NPCs tagged above this level are dimmed. New decor placed now is tagged with {activeLevel === 0 ? 'base' : `level ${activeLevel}`}.
+              </div>
+            </Field>
             <Field label="Decor items"><span style={{ color: '#aaa' }}>{interior.decor.length} items</span></Field>
 
             {/* Exits */}
@@ -938,6 +1045,21 @@ function InteriorInspector({
                           <label style={{ color: '#888', fontSize: 9 }}>Y</label>
                           <input type="number" value={exit.ty} min={0} onChange={e => onUpdateInteriorExit(interiorId, i, { ty: Number(e.target.value) })} style={{ ...numSm, width: 36 }} />
                         </div>
+                      )}
+                      <div style={{ display: 'flex', gap: 6, alignItems: 'center', marginTop: 3, paddingLeft: 2 }}>
+                        <label style={{ color: '#888', fontSize: 9 }} title="Room unavailable below this upgrade level">Min level</label>
+                        <input
+                          type="number" min={0} max={levelMax}
+                          value={exit.minLevel ?? 0}
+                          onChange={e => {
+                            const v = Math.max(0, Number(e.target.value))
+                            onUpdateInteriorExit(interiorId, i, { minLevel: v > 0 ? v : undefined })
+                          }}
+                          style={{ ...numSm, width: 36 }}
+                        />
+                      </div>
+                      {(exit.minLevel ?? 0) > activeLevel && (
+                        <div style={{ color: '#c97', fontSize: 9, paddingLeft: 2, marginTop: 2 }}>locked at current level</div>
                       )}
                     </div>
                   )
@@ -1019,6 +1141,8 @@ function InteriorInspector({
             <DecorInspector
               item={interior.decor[selectedEntity.index]}
               entity={selectedEntity}
+              maxLevel={levelMax}
+              onMinLevel={ml => onUpdateDecorMinLevel(selectedEntity, ml)}
               onMove={(tx, ty) => onMoveEntity(selectedEntity, tx, ty)}
               onZlayer={z => onZlayerChange(selectedEntity, z)}
               onDelete={() => onDelete(selectedEntity)}
@@ -1230,7 +1354,8 @@ function TownInspector({
 }
 
 export function EntityInspector({
-  selectedEntity, configData, activeInteriorId, viewMode,
+  selectedEntity, configData, activeInteriorId, activeLevel, viewMode,
+  onSetActiveLevel, onUpdateBuilding, onUpdateDecorMinLevel,
   onDelete, onMoveEntity, onZlayerChange, onUpdateGlow, onUpdatePickupGlow, onDialogueChange,
   onOpenInterior, onCloseInterior, onUpdateStreetEntry,
   onResizeInterior, onAddInterior, onAddInteriorExit, onUpdateInteriorProps, onUpdateInteriorExit,
@@ -1263,6 +1388,13 @@ export function EntityInspector({
 
   if (viewMode === 'interior' && activeInteriorId && !isQuestItemSelected) {
     const interior = configData.interiors?.[activeInteriorId]
+    // Resolve the owning building so the level stepper matches what's reachable in-game.
+    const ownerBuilding = (configData.buildings ?? []).find(b => {
+      if (!b.id) return false
+      if (activeInteriorId === b.id || activeInteriorId.startsWith(b.id)) return true
+      return (b.doors ?? []).some(d => d.buildingId === activeInteriorId)
+    })
+    const levelMax = ownerBuilding ? buildingMaxLevel(ownerBuilding) : 3
     return (
       <InteriorInspector
         key={activeInteriorId}
@@ -1270,6 +1402,10 @@ export function EntityInspector({
         interior={interior}
         selectedEntity={selectedEntity}
         allInteriors={configData.interiors ?? {}}
+        activeLevel={activeLevel}
+        levelMax={levelMax}
+        onSetActiveLevel={onSetActiveLevel}
+        onUpdateDecorMinLevel={onUpdateDecorMinLevel}
         panelStyle={panelStyle}
         headerStyle={headerStyle}
         bodyStyle={bodyStyle}
@@ -1319,6 +1455,29 @@ export function EntityInspector({
           <DecorInspector
             item={item}
             entity={selectedEntity}
+            onMove={(tx, ty) => onMoveEntity(selectedEntity, tx, ty)}
+            onZlayer={z => onZlayerChange(selectedEntity, z)}
+            onGlow={onUpdateGlow ? patch => onUpdateGlow(selectedEntity, patch) : undefined}
+            onDelete={() => onDelete(selectedEntity)}
+          />
+        </div>
+      </div>
+    )
+  }
+
+  if (selectedEntity.type === 'buildingLevelDecor') {
+    const building = (configData.buildings ?? [])[selectedEntity.buildingIndex]
+    const item = building?.levelDecor?.[selectedEntity.index]
+    if (!item) return null
+    return (
+      <div style={panelStyle}>
+        <div style={headerStyle}>Level Decor — {building?.id ?? `#${selectedEntity.buildingIndex}`}</div>
+        <div style={bodyStyle}>
+          <DecorInspector
+            item={item}
+            entity={selectedEntity}
+            maxLevel={building ? buildingMaxLevel(building) : undefined}
+            onMinLevel={ml => onUpdateDecorMinLevel(selectedEntity, ml)}
             onMove={(tx, ty) => onMoveEntity(selectedEntity, tx, ty)}
             onZlayer={z => onZlayerChange(selectedEntity, z)}
             onGlow={onUpdateGlow ? patch => onUpdateGlow(selectedEntity, patch) : undefined}
@@ -1457,6 +1616,10 @@ export function EntityInspector({
         <div style={bodyStyle}>
           <BuildingInspector
             building={building}
+            buildingIndex={selectedEntity.index}
+            activeLevel={activeLevel}
+            onSetActiveLevel={onSetActiveLevel}
+            onUpdateBuilding={onUpdateBuilding}
             onOpenInterior={onOpenInterior}
             interiorIds={interiorIds}
             existingInteriorIds={Object.keys(configData.interiors ?? {})}

--- a/web/src/components/mapEditor/MapEditor.tsx
+++ b/web/src/components/mapEditor/MapEditor.tsx
@@ -32,10 +32,10 @@ export function MapEditor({ initialMapId = 'ravenwatch' }: Props) {
   const drawerDragRef = useRef<{ startY: number; startH: number } | null>(null)
 
   const {
-    state, setMapId, setTool, setActiveTile, setZlayer,
+    state, setMapId, setTool, setActiveTile, setZlayer, setActiveLevel,
     openInterior, closeInterior, selectEntity,
     placeDecor, moveEntity, deleteEntity,
-    updateDecorZlayer, updateGlow, addNpc, updateNpcDialogue, updateNpc,
+    updateDecorZlayer, updateGlow, updateDecorMinLevel, updateBuilding, addNpc, updateNpcDialogue, updateNpc,
     addAnimal, updateAnimal,
     updateTreasure,
     updateArea, updateMapProps, resizeMap,
@@ -207,6 +207,7 @@ export function MapEditor({ initialMapId = 'ravenwatch' }: Props) {
             selectedEntity={state.selectedEntity}
             viewMode={state.viewMode}
             activeInteriorId={state.activeInteriorId}
+            activeLevel={state.activeLevel}
             activeTileId={state.activeTileId}
             activeBundleId={state.activeBundleId}
             activeZlayer={state.activeZlayer}
@@ -224,7 +225,11 @@ export function MapEditor({ initialMapId = 'ravenwatch' }: Props) {
               selectedEntity={state.selectedEntity}
               configData={state.configData}
               activeInteriorId={state.activeInteriorId}
+              activeLevel={state.activeLevel}
               viewMode={state.viewMode}
+              onSetActiveLevel={setActiveLevel}
+              onUpdateBuilding={updateBuilding}
+              onUpdateDecorMinLevel={updateDecorMinLevel}
               onDelete={handleDeleteEntity}
               onMoveEntity={handleMoveEntity}
               onZlayerChange={updateDecorZlayer}

--- a/web/src/components/mapEditor/MapEditorCanvas.tsx
+++ b/web/src/components/mapEditor/MapEditorCanvas.tsx
@@ -52,21 +52,22 @@ function expandEntries(entries: Array<{ rect?: number[]; tile?: number[] }>): [n
   return out
 }
 
-type FlatDecorItem = { tx: number; ty: number; tileId: string; zlayer: Zlayer; sourceIndex: number }
+type FlatDecorItem = { tx: number; ty: number; tileId: string; zlayer: Zlayer; sourceIndex: number; minLevel: number }
 
 function flattenDecor(items: RawDecorItem[]): FlatDecorItem[] {
   const out: FlatDecorItem[] = []
   items.forEach((item, sourceIndex) => {
     if (item.tx === undefined) return // comment-only entry
+    const minLevel = item.minLevel ?? 0
     if (item.bundleID) {
       const expanded = expandBundleDecor(item.bundleID, item.tx, item.ty ?? 0)
       expanded.forEach(e => {
         const tileKey = Object.keys(BASE_CHIP_TILES as Record<string, number>)
           .find(k => (BASE_CHIP_TILES as Record<string, number>)[k] === e.tileId) ?? ''
-        if (tileKey) out.push({ tx: e.tx, ty: e.ty, tileId: tileKey, zlayer: (e.zlayer as Zlayer) ?? 'solid', sourceIndex })
+        if (tileKey) out.push({ tx: e.tx, ty: e.ty, tileId: tileKey, zlayer: (e.zlayer as Zlayer) ?? 'solid', sourceIndex, minLevel })
       })
     } else if (item.tileId) {
-      out.push({ tx: item.tx, ty: item.ty ?? 0, tileId: item.tileId, zlayer: item.zlayer ?? 'solid', sourceIndex })
+      out.push({ tx: item.tx, ty: item.ty ?? 0, tileId: item.tileId, zlayer: item.zlayer ?? 'solid', sourceIndex, minLevel })
     }
   })
   return out
@@ -79,6 +80,7 @@ interface Props {
   selectedEntity:   SelectedEntity | null
   viewMode:         'exterior' | 'interior'
   activeInteriorId: string | null
+  activeLevel:      number
   activeTileId:     string | null
   activeBundleId:   string | null
   activeZlayer:     Zlayer
@@ -96,7 +98,7 @@ interface Props {
 
 export function MapEditorCanvas(props: Props) {
   const {
-    configData, tool, showGrid, selectedEntity, viewMode, activeInteriorId,
+    configData, tool, showGrid, selectedEntity, viewMode, activeInteriorId, activeLevel,
     activeTileId, activeBundleId, activeZlayer, showQuestItems, showBlockedPaths, showAreas, blockedPaths, questPickupItems,
     onSelectEntity, onPlaceDecor, onMoveEntity, onDeleteEntity, onAddStreet,
   } = props
@@ -344,6 +346,12 @@ export function MapEditorCanvas(props: Props) {
     // Exterior decor tiles
     renderDecorItems(version, flattenDecor(configData.exteriorDecor ?? []),
                      decorBLayer, decorLayer, decorALayer, 'exteriorDecor', '', selLayer)
+
+    // Per-building level decor (revealed by upgrade level; dimmed above active level)
+    buildings.forEach((b, bIdx) => {
+      renderBuildingLevelDecor(version, bIdx, flattenDecor(b.levelDecor ?? []),
+                               decorBLayer, decorLayer, decorALayer, selLayer)
+    })
 
     // NPCs
     const npcs = configData.npcs ?? []
@@ -604,12 +612,22 @@ export function MapEditorCanvas(props: Props) {
     ;(configData.npcs ?? []).forEach((npc, nIdx) => {
       if (npc.building !== iid) return
       const isSel = selectedEntity?.type === 'npc' && selectedEntity.index === nIdx
+      const dimmed = (npc.minLevel ?? 0) > activeLevel  // NPC only present at a higher upgrade level
       loadSpriteTexture(npc.sprite).then(tex => {
         if (renderVersionRef.current !== version) return
         const sp = new PIXI.Sprite(tex)
         sp.width = T * 1.5; sp.height = T * 1.5
         sp.x = npc.tx * T - T * 0.25
         sp.y = npc.ty * T - T * 0.5
+        if (dimmed) sp.alpha = 0.3
+        sp.eventMode = 'static'; sp.cursor = 'pointer'
+        sp.on('pointerdown', (e: PIXI.FederatedPointerEvent) => {
+          e.stopPropagation()
+          const entity: SelectedEntity = { type: 'npc', index: nIdx }
+          propsRef.current.onSelectEntity(entity)
+          if (propsRef.current.tool === 'select')
+            dragRef.current = { entity, lastTx: npc.tx, lastTy: npc.ty, offsetX: 0, offsetY: 0 }
+        })
         if (isSel) selLayer.rect(sp.x - 2, sp.y - 2, sp.width + 4, sp.height + 4).stroke({ color: 0xf0c040, width: 2 })
         npcLayer.addChild(sp)
       }).catch(() => {
@@ -701,9 +719,10 @@ export function MapEditorCanvas(props: Props) {
     interiorId: string,
     selLayer: PIXI.Graphics,
   ) {
-    items.forEach(({ tx, ty, tileId, zlayer, sourceIndex }) => {
+    items.forEach(({ tx, ty, tileId, zlayer, sourceIndex, minLevel }) => {
       const numId = tileNumericId(tileId)
       const layer = zlayer === 'below' ? decorBLayer : zlayer === 'above' ? decorALayer : decorLayer
+      const dimmed = minLevel > activeLevel  // decor that only appears at a higher upgrade level
       const isSel = selectedEntity?.type === entityType &&
         (entityType === 'exteriorDecor'
           ? (selectedEntity as { index: number }).index === sourceIndex
@@ -714,6 +733,7 @@ export function MapEditorCanvas(props: Props) {
         if (renderVersionRef.current !== version) return
         const sp = new PIXI.Sprite(tex)
         sp.x = tx * T; sp.y = ty * T
+        if (dimmed) sp.alpha = 0.3
         sp.eventMode = 'static'; sp.cursor = 'pointer'
         sp.on('pointerdown', (e: PIXI.FederatedPointerEvent) => {
           e.stopPropagation()
@@ -733,6 +753,48 @@ export function MapEditorCanvas(props: Props) {
         if (renderVersionRef.current !== version) return
         const g = new PIXI.Graphics()
         g.rect(tx * T + 4, ty * T + 4, T - 8, T - 8).fill(0x884422)
+        layer.addChild(g)
+      })
+    })
+  }
+
+  // ── Building level-decor rendering (exterior, per-building, level-gated) ───────
+  function renderBuildingLevelDecor(
+    version: number,
+    buildingIndex: number,
+    items: FlatDecorItem[],
+    decorBLayer: PIXI.Container, decorLayer: PIXI.Container, decorALayer: PIXI.Container,
+    selLayer: PIXI.Graphics,
+  ) {
+    items.forEach(({ tx, ty, tileId, zlayer, sourceIndex, minLevel }) => {
+      const numId = tileNumericId(tileId)
+      const layer = zlayer === 'below' ? decorBLayer : zlayer === 'above' ? decorALayer : decorLayer
+      const dimmed = minLevel > activeLevel
+      const isSel = selectedEntity?.type === 'buildingLevelDecor'
+        && selectedEntity.buildingIndex === buildingIndex && selectedEntity.index === sourceIndex
+      const entity: SelectedEntity = { type: 'buildingLevelDecor', buildingIndex, index: sourceIndex }
+
+      loadTileRef(numId).then(tex => {
+        if (renderVersionRef.current !== version) return
+        const sp = new PIXI.Sprite(tex)
+        sp.x = tx * T; sp.y = ty * T
+        if (dimmed) sp.alpha = 0.3
+        sp.eventMode = 'static'; sp.cursor = 'pointer'
+        sp.on('pointerdown', (e: PIXI.FederatedPointerEvent) => {
+          e.stopPropagation()
+          propsRef.current.onSelectEntity(entity)
+          if (propsRef.current.tool === 'select')
+            dragRef.current = { entity, lastTx: tx, lastTy: ty, offsetX: 0, offsetY: 0 }
+        })
+        if (isSel) {
+          selLayer.rect(tx * T - 1, ty * T - 1, T + 2, T + 2).stroke({ color: 0xf0c040, width: 2 })
+        }
+        layer.addChild(sp)
+      }).catch(() => {
+        if (renderVersionRef.current !== version) return
+        const g = new PIXI.Graphics()
+        g.rect(tx * T + 4, ty * T + 4, T - 8, T - 8).fill(0x884422)
+        if (dimmed) g.alpha = 0.3
         layer.addChild(g)
       })
     })

--- a/web/src/components/mapEditor/mapEditorTypes.ts
+++ b/web/src/components/mapEditor/mapEditorTypes.ts
@@ -19,6 +19,7 @@ export interface RawDecorItem {
   glow?: boolean        // emit a night light glow
   glowRadius?: number   // glow radius in tiles
   pulse?: boolean       // animate the glow radius
+  minLevel?: number     // building upgrade level at which this decor first appears (0/undefined = base)
 }
 
 export interface RawBuildingDoor {
@@ -43,6 +44,9 @@ export interface RawBuilding {
   doors?: RawBuildingDoor[]
   windows?: RawBuildingWindow[]
   decor?: RawDecorItem[]
+  upgradeKind?: string         // shared upgrade track key (shop/inn/…) — drives costs & default decor
+  maxLevel?: number            // highest upgrade level this building can reach (defaults to its track length)
+  levelDecor?: RawDecorItem[]  // per-building exterior decor revealed by upgrade level (each item carries minLevel)
 }
 
 export interface RawAnimal {
@@ -71,6 +75,7 @@ export interface RawNpc {
   questGive?: string
   questReceive?: string | string[]
   isGhost?: boolean
+  minLevel?: number   // building upgrade level at which this NPC first appears (0/undefined = always)
   schedule?: Array<{
     startHour: number
     endHour: number
@@ -103,6 +108,7 @@ export interface RawInterior {
     direction?: 'up' | 'down' | 'left' | 'right' | 'front' | 'back'
     lockedBy?: string
     requiredQuest?: string
+    minLevel?: number   // building upgrade level required before this room/exit is available (0/undefined = always)
     label?: string
   }>
 }
@@ -170,6 +176,7 @@ export type SelectedEntity =
   | { type: 'exteriorDecor'; index: number }
   | { type: 'npc'; index: number }
   | { type: 'building'; index: number }
+  | { type: 'buildingLevelDecor'; buildingIndex: number; index: number }
   | { type: 'street'; index: number }
   | { type: 'treasure'; index: number }
   | { type: 'pickupItem'; index: number }
@@ -188,6 +195,7 @@ export interface MapEditorState {
   activeZlayer: Zlayer
   viewMode: ViewMode
   activeInteriorId: string | null
+  activeLevel: number
   selectedEntity: SelectedEntity | null
   undoStack: RawMapConfig[]
   redoStack: RawMapConfig[]

--- a/web/src/components/mapEditor/useMapEditorState.ts
+++ b/web/src/components/mapEditor/useMapEditorState.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback } from 'react'
-import type { RawMapConfig, RawNpc, RawAnimal, RawInterior, RawLockedDoor, SelectedEntity, ToolMode, Zlayer, MapEditorState } from './mapEditorTypes'
+import type { RawMapConfig, RawNpc, RawAnimal, RawInterior, RawBuilding, RawDecorItem, RawLockedDoor, SelectedEntity, ToolMode, Zlayer, MapEditorState } from './mapEditorTypes'
 
 type InteriorExit = NonNullable<RawInterior['exits']>[number]
 import hubConfig from '../../data/hub/ravenwatch/config.json'
@@ -45,6 +45,7 @@ export function useMapEditorState(initialMapId: MapId = 'ravenwatch') {
     activeZlayer:     'solid',
     viewMode:         'exterior',
     activeInteriorId: null,
+    activeLevel:      0,
     selectedEntity:   null,
     undoStack:        [],
     redoStack:        [],
@@ -59,10 +60,15 @@ export function useMapEditorState(initialMapId: MapId = 'ravenwatch') {
       selectedEntity:   null,
       viewMode:         'exterior',
       activeInteriorId: null,
+      activeLevel:      0,
       undoStack:        [],
       redoStack:        [],
       isDirty:          false,
     }))
+  }, [])
+
+  const setActiveLevel = useCallback((activeLevel: number) => {
+    setState(s => ({ ...s, activeLevel: Math.max(0, activeLevel) }))
   }, [])
 
   const setTool = useCallback((tool: ToolMode) => {
@@ -83,11 +89,11 @@ export function useMapEditorState(initialMapId: MapId = 'ravenwatch') {
   }, [])
 
   const openInterior = useCallback((interiorId: string) => {
-    setState(s => ({ ...s, viewMode: 'interior', activeInteriorId: interiorId, selectedEntity: null }))
+    setState(s => ({ ...s, viewMode: 'interior', activeInteriorId: interiorId, activeLevel: 0, selectedEntity: null }))
   }, [])
 
   const closeInterior = useCallback(() => {
-    setState(s => ({ ...s, viewMode: 'exterior', activeInteriorId: null, selectedEntity: null }))
+    setState(s => ({ ...s, viewMode: 'exterior', activeInteriorId: null, activeLevel: 0, selectedEntity: null }))
   }, [])
 
   const selectEntity = useCallback((entity: SelectedEntity | null) => {
@@ -98,13 +104,26 @@ export function useMapEditorState(initialMapId: MapId = 'ravenwatch') {
     setState(s => {
       if (!s.activeTileId && !s.activeBundleId) return s
       const prevConfig = s.configData
+      // Tag the item with the active level (cumulative reveal). Level 0 = base.
+      const levelTag = s.activeLevel > 0 ? { minLevel: s.activeLevel } : {}
       const newItem = s.activeBundleId
-        ? { tx, ty, bundleID: s.activeBundleId, zlayer: s.activeZlayer }
-        : { tx, ty, tileId: s.activeTileId!, zlayer: s.activeZlayer }
+        ? { tx, ty, bundleID: s.activeBundleId, zlayer: s.activeZlayer, ...levelTag }
+        : { tx, ty, tileId: s.activeTileId!, zlayer: s.activeZlayer, ...levelTag }
 
       let newConfig: RawMapConfig
       if (s.viewMode === 'exterior') {
-        newConfig = { ...prevConfig, exteriorDecor: [...(prevConfig.exteriorDecor ?? []), newItem] }
+        // When a building is selected, exterior decor belongs to that building's
+        // per-level decor (revealed by upgrade level). Otherwise it is ambient
+        // exterior decor with no level association.
+        if (s.selectedEntity?.type === 'building') {
+          const buildings = [...(prevConfig.buildings ?? [])]
+          const b = buildings[s.selectedEntity.index]
+          if (!b) return s
+          buildings[s.selectedEntity.index] = { ...b, levelDecor: [...(b.levelDecor ?? []), newItem] }
+          newConfig = { ...prevConfig, buildings }
+        } else {
+          newConfig = { ...prevConfig, exteriorDecor: [...(prevConfig.exteriorDecor ?? []), newItem] }
+        }
       } else if (s.viewMode === 'interior' && s.activeInteriorId) {
         const interior = prevConfig.interiors?.[s.activeInteriorId]
         if (!interior) return s
@@ -197,6 +216,14 @@ export function useMapEditorState(initialMapId: MapId = 'ravenwatch') {
         if (!areas[entity.index]) return s
         areas[entity.index] = { ...areas[entity.index], tx, ty }
         newConfig = { ...prevConfig, areas }
+      } else if (entity.type === 'buildingLevelDecor') {
+        const buildings = [...(prevConfig.buildings ?? [])]
+        const b = buildings[entity.buildingIndex]
+        if (!b?.levelDecor?.[entity.index]) return s
+        const levelDecor = [...b.levelDecor]
+        levelDecor[entity.index] = { ...levelDecor[entity.index], tx, ty }
+        buildings[entity.buildingIndex] = { ...b, levelDecor }
+        newConfig = { ...prevConfig, buildings }
       } else if (entity.type === 'interiorDecor' && prevConfig.interiors?.[entity.interiorId]) {
         const interior = prevConfig.interiors[entity.interiorId]
         const decor = [...interior.decor]
@@ -238,6 +265,11 @@ export function useMapEditorState(initialMapId: MapId = 'ravenwatch') {
         newConfig = { ...prevConfig, treasures: (prevConfig.treasures ?? []).filter((_, i) => i !== entity.index) }
       } else if (entity.type === 'pickupItem') {
         newConfig = { ...prevConfig, pickupItems: (prevConfig.pickupItems ?? []).filter((_, i) => i !== entity.index) }
+      } else if (entity.type === 'buildingLevelDecor' && prevConfig.buildings?.[entity.buildingIndex]?.levelDecor) {
+        const buildings = [...prevConfig.buildings]
+        const b = buildings[entity.buildingIndex]
+        buildings[entity.buildingIndex] = { ...b, levelDecor: (b.levelDecor ?? []).filter((_, i) => i !== entity.index) }
+        newConfig = { ...prevConfig, buildings }
       } else if (entity.type === 'interiorDecor' && prevConfig.interiors?.[entity.interiorId]) {
         const interior = prevConfig.interiors[entity.interiorId]
         newConfig = {
@@ -271,6 +303,14 @@ export function useMapEditorState(initialMapId: MapId = 'ravenwatch') {
         if (!decor[entity.index]) return s
         decor[entity.index] = { ...decor[entity.index], zlayer }
         newConfig = { ...prevConfig, exteriorDecor: decor }
+      } else if (entity.type === 'buildingLevelDecor' && prevConfig.buildings?.[entity.buildingIndex]?.levelDecor) {
+        const buildings = [...prevConfig.buildings]
+        const b = buildings[entity.buildingIndex]
+        const levelDecor = [...(b.levelDecor ?? [])]
+        if (!levelDecor[entity.index]) return s
+        levelDecor[entity.index] = { ...levelDecor[entity.index], zlayer }
+        buildings[entity.buildingIndex] = { ...b, levelDecor }
+        newConfig = { ...prevConfig, buildings }
       } else if (entity.type === 'interiorDecor' && prevConfig.interiors?.[entity.interiorId]) {
         const interior = prevConfig.interiors[entity.interiorId]
         const decor = [...interior.decor]
@@ -304,6 +344,14 @@ export function useMapEditorState(initialMapId: MapId = 'ravenwatch') {
         if (!decor[entity.index]) return s
         decor[entity.index] = { ...decor[entity.index], ...patch }
         newConfig = { ...prevConfig, exteriorDecor: decor }
+      } else if (entity.type === 'buildingLevelDecor' && prevConfig.buildings?.[entity.buildingIndex]?.levelDecor) {
+        const buildings = [...prevConfig.buildings]
+        const b = buildings[entity.buildingIndex]
+        const levelDecor = [...(b.levelDecor ?? [])]
+        if (!levelDecor[entity.index]) return s
+        levelDecor[entity.index] = { ...levelDecor[entity.index], ...patch }
+        buildings[entity.buildingIndex] = { ...b, levelDecor }
+        newConfig = { ...prevConfig, buildings }
       } else if (entity.type === 'interiorDecor' && prevConfig.interiors?.[entity.interiorId]) {
         const interior = prevConfig.interiors[entity.interiorId]
         const decor = [...interior.decor]
@@ -319,6 +367,64 @@ export function useMapEditorState(initialMapId: MapId = 'ravenwatch') {
       return {
         ...s,
         configData: newConfig,
+        undoStack:  [...s.undoStack, prevConfig].slice(-MAX_UNDO),
+        redoStack:  [],
+        isDirty:    true,
+      }
+    })
+  }, [])
+
+  // Patch the minLevel of a level-aware decor item (building level-decor or interior decor).
+  const updateDecorMinLevel = useCallback((entity: SelectedEntity, minLevel: number | undefined) => {
+    setState(s => {
+      const prevConfig = s.configData
+      let newConfig = prevConfig
+      const clean = (item: RawDecorItem): RawDecorItem => {
+        const next = { ...item, minLevel }
+        if (minLevel === undefined || minLevel <= 0) delete next.minLevel
+        return next
+      }
+
+      if (entity.type === 'buildingLevelDecor' && prevConfig.buildings?.[entity.buildingIndex]?.levelDecor) {
+        const buildings = [...prevConfig.buildings]
+        const b = buildings[entity.buildingIndex]
+        const levelDecor = [...(b.levelDecor ?? [])]
+        if (!levelDecor[entity.index]) return s
+        levelDecor[entity.index] = clean(levelDecor[entity.index])
+        buildings[entity.buildingIndex] = { ...b, levelDecor }
+        newConfig = { ...prevConfig, buildings }
+      } else if (entity.type === 'interiorDecor' && prevConfig.interiors?.[entity.interiorId]) {
+        const interior = prevConfig.interiors[entity.interiorId]
+        const decor = [...interior.decor]
+        if (!decor[entity.index]) return s
+        decor[entity.index] = clean(decor[entity.index])
+        newConfig = {
+          ...prevConfig,
+          interiors: { ...prevConfig.interiors, [entity.interiorId]: { ...interior, decor } },
+        }
+      }
+
+      if (newConfig === prevConfig) return s
+      return {
+        ...s,
+        configData: newConfig,
+        undoStack:  [...s.undoStack, prevConfig].slice(-MAX_UNDO),
+        redoStack:  [],
+        isDirty:    true,
+      }
+    })
+  }, [])
+
+  // Patch building-level fields (upgradeKind / maxLevel) on a building.
+  const updateBuilding = useCallback((index: number, patch: Partial<RawBuilding>) => {
+    setState(s => {
+      const prevConfig = s.configData
+      const buildings = [...(prevConfig.buildings ?? [])]
+      if (!buildings[index]) return s
+      buildings[index] = { ...buildings[index], ...patch }
+      return {
+        ...s,
+        configData: { ...prevConfig, buildings },
         undoStack:  [...s.undoStack, prevConfig].slice(-MAX_UNDO),
         redoStack:  [],
         isDirty:    true,
@@ -848,6 +954,7 @@ export function useMapEditorState(initialMapId: MapId = 'ravenwatch') {
     setTool,
     setActiveTile,
     setZlayer,
+    setActiveLevel,
     openInterior,
     closeInterior,
     selectEntity,
@@ -856,6 +963,8 @@ export function useMapEditorState(initialMapId: MapId = 'ravenwatch') {
     deleteEntity,
     updateDecorZlayer,
     updateGlow,
+    updateDecorMinLevel,
+    updateBuilding,
     addNpc,
     updateNpcDialogue,
     updateNpc,

--- a/web/src/data/hub/loader.ts
+++ b/web/src/data/hub/loader.ts
@@ -27,6 +27,8 @@ export interface HubBuilding {
   roof?: RoofMaterial
   /** Upgrade track key (buildingUpgrades.json); set = building is upgradeable. */
   upgradeKind?: string
+  /** Per-building exterior decor revealed by upgrade level (absolute tx/ty, each carries minLevel). */
+  levelDecor?: Array<{ tx: number; ty: number; tileId: number; zlayer?: 'solid' | 'below' | 'above'; minLevel?: number }>
 }
 
 export interface HubDoor {
@@ -47,6 +49,7 @@ export interface InteriorDecor extends DecorGlow {
   tx:      number
   ty:      number
   tileId:  number
+  minLevel?: number   // building upgrade level at which this decor first appears (0/undefined = base)
   zlayer?: 'solid' | 'below' | 'above'
   // solid (default): not walkable, renders below avatar
   // below: walkable, renders below avatar (rugs, floor markings)
@@ -62,6 +65,7 @@ export interface HubInteriorExit {
   direction?: 'up' | 'down' | 'left' | 'right' | 'front' | 'back'
   lockedBy?: string
   requiredQuest?: string
+  minLevel?: number   // building upgrade level required before this room/exit is available
   label?: string
 }
 
@@ -107,6 +111,7 @@ export interface HubNpc {
   questReceive?: string | string[]
   innRumours?: Array<{ id: string; text: string }>
   isGhost?: boolean
+  minLevel?: number   // building upgrade level at which this NPC first appears (0/undefined = always)
   schedule?: NpcScheduleEntry[]
   homeBed?: { buildingId: string; tx: number; ty: number }
   /** Id of a branching dialogue tree (questDefs.json `dialogues`) to run on tap. */
@@ -355,15 +360,24 @@ type RawBuilding = {
   doors?:   Array<{ tx: number; ty: number; buildingId?: string, hideSign?: boolean }>
   windows?: Array<{ tx: number; ty: number; tileId: string }>
   decor?:   Array<{ tx: number; ty: number; tileId?: string; bundleID?: string; zlayer?: string }>
+  levelDecor?: Array<{ tx?: number; ty?: number; tileId?: string; zlayer?: string; minLevel?: number }>
 }
 const HUB_BUILDINGS: HubBuilding[] = (rawConfig.buildings as RawBuilding[]).flatMap(b => {
   const rectList = b.rects ?? (b.rect ? [b.rect] : [])
-  return rectList.map(rect => ({
+  // Resolve per-building level decor once (attach to the first rect only so a
+  // multi-rect building does not render duplicates).
+  const levelDecor = (b.levelDecor ?? []).flatMap(d =>
+    d.tx == null || d.ty == null || !d.tileId
+      ? []
+      : [{ tx: d.tx, ty: d.ty, tileId: resolveTileId(d.tileId), zlayer: d.zlayer as 'solid' | 'below' | 'above' | undefined, minLevel: d.minLevel }],
+  )
+  return rectList.map((rect, i) => ({
     rect: rect as [number, number, number, number],
     id:   b.id,
     wall: b.wall as WallMaterial | undefined,
     roof: b.roof as RoofMaterial | undefined,
     upgradeKind: b.upgradeKind,
+    ...(i === 0 && levelDecor.length ? { levelDecor } : {}),
   }))
 })
 
@@ -455,10 +469,10 @@ const HUB_INTERIORS: Record<string, HubInterior> = Object.fromEntries(
         height:       raw.height,
         floorTileId:  resolveTileId(raw.floorTileId),
         wallMaterial: wallTileIdStr && WALL_MATERIAL_NAMES.has(wallTileIdStr) ? wallTileIdStr as WallMaterial : undefined,
-        decor:        (raw.decor as Array<{ tx: number; ty: number; tileId?: string; bundleID?: string; zlayer?: string }>).flatMap(d => {
+        decor:        (raw.decor as Array<{ tx: number; ty: number; tileId?: string; bundleID?: string; zlayer?: string; minLevel?: number }>).flatMap(d => {
           if (d.bundleID)
-            return expandBundleDecor(d.bundleID, d.tx, d.ty).map(e => ({ ...e, zlayer: e.zlayer as InteriorDecor['zlayer'] }))
-          return [{ tx: d.tx, ty: d.ty, tileId: resolveTileId(d.tileId ?? ''), zlayer: d.zlayer as InteriorDecor['zlayer'] }]
+            return expandBundleDecor(d.bundleID, d.tx, d.ty).map(e => ({ ...e, zlayer: e.zlayer as InteriorDecor['zlayer'], minLevel: d.minLevel }))
+          return [{ tx: d.tx, ty: d.ty, tileId: resolveTileId(d.tileId ?? ''), zlayer: d.zlayer as InteriorDecor['zlayer'], minLevel: d.minLevel }]
         }),
         exits: ((rawAny.exits ?? []) as HubInteriorExit[]),
         hours: rawAny.hours as HubInterior['hours'],


### PR DESCRIPTION
Closes #1641.

Adds a **level axis** to the map editor so a building's exterior decor and interior layout can be authored per upgrade level, and makes the live game honour it.

## What you can do now
- Click a building (or open its interior) → a **Level selector** appears in the inspector.
- Step the level (`base / level 1 / level 2 / …`). Content tagged above the current level is **dimmed**; placing decor tags it with the selected level.
- **Exterior:** decor placed while a building is selected is stored on that building's own `levelDecor` (per-building, not shared across the whole type). The shared `buildingUpgrades.json` track remains the default for buildings without `levelDecor`, and still drives costs / services / reputation.
- **Interior:** interior decor, **room doorways** (`exits[].minLevel`) and **NPCs** (`minLevel`) can be gated by level — so some rooms are unavailable until level 2/3 and some NPCs (and the quests they give) only appear once the building is upgraded.

Levels are **cumulative** (`minLevel: 2` = appears at level 2 and stays), matching the existing exterior reveal mechanic. The editor level reuses the in-game purchased upgrade level (`reputation.ts`).

## Runtime
`HubTownCanvas` resolves each building's current level (`getUpgradeLevel`) and filters interior decor / exits / NPCs and per-building `levelDecor` by `minLevel`. Sub-rooms inherit the parent building's level. Existing towns are unaffected — `levelDecor`/`minLevel` are opt-in.

## Design decisions (confirmed with the issue author)
1. **Per-building** exterior decor (shared type-track stays as the fallback).
2. **Cumulative `minLevel` tagging** (no duplicated full layouts).
3. **Reuse the existing upgrade level** as the editor's level source.

## Files
- `mapEditor/`: `mapEditorTypes`, `useMapEditorState`, `MapEditor`, `MapEditorCanvas`, `EntityInspector`
- `data/hub/loader.ts`, `components/hub/HubTownCanvas.tsx`
- `docs/hubworld.md` (§10)

## Verification
- `npm run build` passes (tsc + vite).
- Manual: in the map editor, select a building, step the level, place decor at level 2, mark a room exit / NPC `minLevel: 2`; in-game, upgrade the building and confirm the new exterior decor, unlocked room, and level-2 NPC/quest appear only at the matching level.

No live town JSON was mutated — authoring happens through the editor, so existing saves and quests are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011f8gD7RAP6taye8wz8GfFs)_