### PR TITLE
Map editor: pick-on-map placement, searchable sprites, default sprite, animals in NPC drawer

### DIFF
--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -4,6 +4,7 @@ import { usePixiApp } from '../../hooks/usePixiApp'
 import { buildTerrainGfx, buildBgTileGfx, buildDecorGfx } from '../../utils/terrainLayer'
 import { renderPathTiles } from '../../utils/tileLookup'
 import { loadSpriteTexture, loadTextureUrl, loadAnimFrames, loadTileRef } from '../../utils/pixiHelpers'
+import { resolveNpcSprite } from '../../game/sprites'
 import { PATH_TILE } from '../../data/tiles/tileIndex'
 import { findPath, nearestWalkable } from '../../utils/hubPathfinder'
 import { isBuildingOpen, getNpcLocation, getNpcActivity } from '../../game/hub/hubNpcSchedule'
@@ -662,7 +663,7 @@ export function HubTownCanvas({
             e.stopPropagation()
             if (npc.tapDialogue) onNpcTapRef.current?.(npc.tapDialogue, npc.id)
           })
-          loadTextureUrl(`${base}sprites/${npc.sprite}.svg`).then(tex => {
+          loadTextureUrl(`${base}sprites/${resolveNpcSprite(npc.sprite)}.svg`).then(tex => {
             if (app.renderer == null) return
             const s = new PIXI.Sprite(tex)
             s.width = SPRITE_SIZE; s.height = SPRITE_SIZE
@@ -686,7 +687,7 @@ export function HubTownCanvas({
             e.stopPropagation()
             if (npc.tapDialogue) onNpcTapRef.current?.(npc.tapDialogue, npc.id)
           })
-          loadTextureUrl(`${base}sprites/${npc.sprite}.svg`).then(tex => {
+          loadTextureUrl(`${base}sprites/${resolveNpcSprite(npc.sprite)}.svg`).then(tex => {
             if (app.renderer == null) return
             const s = new PIXI.Sprite(tex)
             s.width = SPRITE_SIZE; s.height = SPRITE_SIZE
@@ -996,7 +997,7 @@ export function HubTownCanvas({
           namedNpcBaseTex.set(npc.id, tex)
           const activities = new Set(npc.schedule.map(e => e.activity).filter(Boolean) as string[])
           for (const activity of activities) {
-            loadTextureUrl(`${base}sprites/${npc.sprite}-${activity}.svg`)
+            loadTextureUrl(`${base}sprites/${resolveNpcSprite(npc.sprite)}-${activity}.svg`)
               .then(poseTex => { namedNpcPoseTex.set(`${npc.id}:${activity}`, poseTex) })
               .catch(() => { /* no pose art — keep base sprite */ })
           }
@@ -1688,7 +1689,7 @@ export function HubTownCanvas({
       // Interior NPCs — rendered inside the room, tappable
       const interiorNpcList: HubNpc[] = (INTERIOR_NPCS[buildingId] ?? []).filter(n => (n.minLevel ?? 0) <= currentLevel)
       for (const npc of interiorNpcList) {
-        loadTextureUrl(`${base}sprites/${npc.sprite}.svg`).then(tex => {
+        loadTextureUrl(`${base}sprites/${resolveNpcSprite(npc.sprite)}.svg`).then(tex => {
           if (!interiorActive || currentInteriorId !== buildingId) return
           const s = new PIXI.Sprite(tex)
           s.width = SPRITE_SIZE; s.height = SPRITE_SIZE
@@ -1716,7 +1717,7 @@ export function HubTownCanvas({
       })
       for (const npc of scheduledVisitors) {
         const loc = getNpcLocation(npc, gameHourRef.current) as { type: 'interior'; buildingId: string; tx: number; ty: number }
-        loadTextureUrl(`${base}sprites/${npc.sprite}.svg`).then(tex => {
+        loadTextureUrl(`${base}sprites/${resolveNpcSprite(npc.sprite)}.svg`).then(tex => {
           if (!interiorActive || currentInteriorId !== buildingId) return
           const s = new PIXI.Sprite(tex)
           s.width = SPRITE_SIZE; s.height = SPRITE_SIZE

--- a/web/src/components/mapEditor/EntityInspector.tsx
+++ b/web/src/components/mapEditor/EntityInspector.tsx
@@ -4,7 +4,7 @@ import { BASE_CHIP_TILES } from '../../data/tiles/baseChipIndex'
 import { resolveTileRef } from '../../data/tiles/tileIndex'
 import type { WallMaterial } from '../../data/tiles/buildingMaterials'
 import { RawQuestPickupItem } from '../../data/hub/hubWorldFactory'
-import { NpcSpritePicker, AnimalTypePicker } from './SpritePicker'
+import { SpriteSearchPicker, AnimalTypePicker } from './SpritePicker'
 import { ANIMAL_SPECS } from '../../game/hub/animals'
 import type { AnimalType } from '../../game/hub/animals'
 import { BUILDING_MUSIC_IDS, AMBIANCE_IDS } from '../../game/sound'
@@ -76,6 +76,12 @@ interface Props {
   onUpdateArea?:         (index: number, patch: Partial<{ name: string; tw: number; th: number }>) => void
   onResizeMap?:          (dir: 'n' | 's' | 'e' | 'w', grow: boolean) => void
   onUpdateMapProps?:     (patch: { townName?: string; environment?: string }) => void
+  onPickLocation?:       (kind: 'npc' | 'animal', index: number) => void
+}
+
+const BTN_PICK: React.CSSProperties = {
+  padding: '4px 8px', background: '#1e2a4e', border: '1px solid #3a4a8e',
+  color: '#8af', borderRadius: 3, fontSize: 11, cursor: 'pointer', width: '100%', marginTop: 2,
 }
 
 const S = 20  // thumbnail size for tile picker grid
@@ -352,7 +358,7 @@ function DecorInspector({
 }
 
 function NpcInspector({
-  npc, entity, onMove, onDelete, onDialogueChange, onUpdate,
+  npc, entity, onMove, onDelete, onDialogueChange, onUpdate, onPickLocation,
 }: {
   npc: RawNpc
   entity: SelectedEntity & { type: 'npc' }
@@ -360,6 +366,7 @@ function NpcInspector({
   onDelete: () => void
   onDialogueChange: (d: string[]) => void
   onUpdate: (partial: Partial<RawNpc>) => void
+  onPickLocation?: () => void
 }) {
   return (
     <div>
@@ -370,7 +377,7 @@ function NpcInspector({
         <span style={{ fontSize: 12 }}>{npc.name}</span>
       </Field>
       <Field label="Sprite">
-        <NpcSpritePicker value={npc.sprite} onChange={slug => onUpdate({ sprite: slug })} />
+        <SpriteSearchPicker value={npc.sprite} onChange={slug => onUpdate({ sprite: slug })} />
       </Field>
       <Field label="Position">
         <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
@@ -379,6 +386,7 @@ function NpcInspector({
           <label style={{ fontSize: 11, color: '#888' }}>Y</label>
           {numInput(npc.ty, ty => onMove(npc.tx, ty))}
         </div>
+        {onPickLocation && <button style={BTN_PICK} onClick={onPickLocation}>📍 Pick on map</button>}
       </Field>
       <Field label="Dialogue">
         <textarea
@@ -426,12 +434,13 @@ function NpcInspector({
 }
 
 function AnimalInspector({
-  animal, onMove, onDelete, onUpdate,
+  animal, onMove, onDelete, onUpdate, onPickLocation,
 }: {
   animal: RawAnimal
   onMove: (tx: number, ty: number) => void
   onDelete: () => void
   onUpdate: (partial: Partial<RawAnimal>) => void
+  onPickLocation?: () => void
 }) {
   const inputStyle: React.CSSProperties = {
     background: '#252540', border: '1px solid #444', color: '#ccc',
@@ -529,6 +538,7 @@ function AnimalInspector({
           <label style={{ fontSize: 11, color: '#888' }}>Y</label>
           {numInput(animal.ty, ty => onMove(animal.tx, ty))}
         </div>
+        {onPickLocation && <button style={BTN_PICK} onClick={onPickLocation}>📍 Pick on map</button>}
       </Field>
       <button
         onClick={onDelete}
@@ -1365,7 +1375,7 @@ export function EntityInspector({
   onAddLockedDoor, onUpdateLockedDoor, onDeleteLockedDoor,
   onUpdateNpc, onUpdateAnimal,
   onUpdateTreasureTile, onUpdatePickupItemTile,
-  onUpdateArea, onResizeMap, onUpdateMapProps,
+  onUpdateArea, onResizeMap, onUpdateMapProps, onPickLocation,
 }: Props) {
   const panelStyle: React.CSSProperties = {
     display: 'flex', flexDirection: 'column', height: '100%',
@@ -1503,6 +1513,7 @@ export function EntityInspector({
             onDelete={() => onDelete(selectedEntity)}
             onDialogueChange={d => onDialogueChange(selectedEntity.index, d)}
             onUpdate={partial => onUpdateNpc(selectedEntity.index, partial)}
+            onPickLocation={onPickLocation ? () => onPickLocation('npc', selectedEntity.index) : undefined}
           />
         </div>
       </div>
@@ -1521,6 +1532,7 @@ export function EntityInspector({
             onMove={(tx, ty) => onMoveEntity(selectedEntity, tx, ty)}
             onDelete={() => onDelete(selectedEntity)}
             onUpdate={partial => onUpdateAnimal(selectedEntity.index, partial)}
+            onPickLocation={onPickLocation ? () => onPickLocation('animal', selectedEntity.index) : undefined}
           />
         </div>
       </div>

--- a/web/src/components/mapEditor/MapEditor.tsx
+++ b/web/src/components/mapEditor/MapEditor.tsx
@@ -8,7 +8,7 @@ import type { MapId,  QuestDefsJson } from '../../data/hub/hubWorldFactory'
 import  {  QUEST_DEFS_BY_MAP } from '../../data/hub/hubWorldFactory'
 
 import { SelectedEntity } from './mapEditorTypes'
-import type { RawBlockedPath, RawAnimal } from './mapEditorTypes'
+import type { RawBlockedPath } from './mapEditorTypes'
 import { NpcQuestDrawer } from './npcQuestDrawer/NpcQuestDrawer'
 import type { DrawerTab } from './npcQuestDrawer/npcQuestDrawerTypes'
 
@@ -29,6 +29,8 @@ export function MapEditor({ initialMapId = 'ravenwatch' }: Props) {
   const [drawerTab, setDrawerTab] = useState<DrawerTab>('npcs')
   const [drawerHeight, setDrawerHeight] = useState(280)
   const [focusedNpcIndex, setFocusedNpcIndex] = useState<number | null>(null)
+  // When set, the next canvas tile click places this NPC/animal there.
+  const [pick, setPick] = useState<{ kind: 'npc' | 'animal'; index: number } | null>(null)
   const drawerDragRef = useRef<{ startY: number; startH: number } | null>(null)
 
   const {
@@ -115,6 +117,21 @@ export function MapEditor({ initialMapId = 'ravenwatch' }: Props) {
     }
   }, [deleteEntity, selectEntity])
 
+  // Enter "pick a tile" mode for an NPC/animal; the next canvas click sets its location.
+  const handlePickLocation = useCallback((kind: 'npc' | 'animal', index: number) => {
+    setPick({ kind, index })
+  }, [])
+
+  const handlePickTile = useCallback((tx: number, ty: number) => {
+    if (!pick) return
+    // Inside an interior the coords are interior-local and the building is recorded;
+    // in the exterior the building association is cleared.
+    const building = state.viewMode === 'interior' ? (state.activeInteriorId ?? undefined) : undefined
+    if (pick.kind === 'npc') updateNpc(pick.index, { tx, ty, building })
+    else updateAnimal(pick.index, { tx, ty, building })
+    setPick(null)
+  }, [pick, state.viewMode, state.activeInteriorId, updateNpc, updateAnimal])
+
   const handleUpdateBlockedPath = useCallback((index: number, patch: Partial<RawBlockedPath>) => {
     setQuestDefsData(prev => {
       if (!prev) return prev
@@ -180,6 +197,18 @@ export function MapEditor({ initialMapId = 'ravenwatch' }: Props) {
       />
 
       <div style={{ display: 'flex', flexDirection: 'column', flex: 1, overflow: 'hidden' }}>
+        {pick && (
+          <div style={{
+            flexShrink: 0, padding: '5px 12px', background: '#1e2a4e', borderBottom: '1px solid #3a4a8e',
+            color: '#8af', fontSize: 12, display: 'flex', alignItems: 'center', gap: 10,
+          }}>
+            <span>📍 Click a tile on the map to place this {pick.kind}{state.viewMode === 'interior' ? ` (in ${state.activeInteriorId})` : ''}.</span>
+            <button
+              onClick={() => setPick(null)}
+              style={{ marginLeft: 'auto', padding: '2px 10px', background: '#333', border: '1px solid #555', color: '#aaa', borderRadius: 3, fontSize: 11, cursor: 'pointer' }}
+            >Cancel</button>
+          </div>
+        )}
         {/* Canvas row */}
         <div style={{ display: 'flex', flex: 1, overflow: 'hidden', minHeight: 0 }}>
           {/* Left: Tile palette */}
@@ -211,6 +240,8 @@ export function MapEditor({ initialMapId = 'ravenwatch' }: Props) {
             activeTileId={state.activeTileId}
             activeBundleId={state.activeBundleId}
             activeZlayer={state.activeZlayer}
+            pickActive={pick !== null}
+            onPickTile={handlePickTile}
             onSelectEntity={selectEntity}
             onPlaceDecor={placeDecor}
             onMoveEntity={handleMoveEntity}
@@ -230,6 +261,7 @@ export function MapEditor({ initialMapId = 'ravenwatch' }: Props) {
               onSetActiveLevel={setActiveLevel}
               onUpdateBuilding={updateBuilding}
               onUpdateDecorMinLevel={updateDecorMinLevel}
+              onPickLocation={handlePickLocation}
               onDelete={handleDeleteEntity}
               onMoveEntity={handleMoveEntity}
               onZlayerChange={updateDecorZlayer}
@@ -291,25 +323,12 @@ export function MapEditor({ initialMapId = 'ravenwatch' }: Props) {
               onTabChange={setDrawerTab}
               onAddNpc={addNpc}
               onUpdateNpc={updateNpc}
+              onAddAnimal={addAnimal}
+              onUpdateAnimal={updateAnimal}
+              onDeleteAnimal={(index) => handleDeleteEntity({ type: 'animal', index })}
+              onPickLocation={handlePickLocation}
               onQuestDefsChange={handleQuestDefsChange}
             />
-            <div style={{ padding: '6px 10px', borderTop: '1px solid #2a2a4a', flexShrink: 0 }}>
-              <button
-                onClick={() => {
-                  const newAnimal: RawAnimal = {
-                    id: `animal-${Date.now()}`,
-                    type: 'cat',
-                    tx: Math.floor((state.configData.mapW ?? 20) / 2),
-                    ty: Math.floor((state.configData.mapH ?? 20) / 2),
-                  }
-                  addAnimal(newAnimal)
-                  selectEntity({ type: 'animal', index: (state.configData.animals ?? []).length })
-                }}
-                style={{ padding: '4px 10px', background: '#1a2e1a', border: '1px solid #3a6a3a', color: '#88ffaa', borderRadius: 3, fontSize: 11, cursor: 'pointer' }}
-              >
-                + Add Animal
-              </button>
-            </div>
           </div>
         )}
       </div>

--- a/web/src/components/mapEditor/MapEditorCanvas.tsx
+++ b/web/src/components/mapEditor/MapEditorCanvas.tsx
@@ -9,6 +9,7 @@ import { WALL_TILES } from '../../data/tiles/buildingMaterials'
 import type { WallMaterial } from '../../data/tiles/buildingMaterials'
 import { expandBundleDecor } from '../../data/bundles/bundleLoader'
 import { RawQuestPickupItem } from '../../data/hub/hubWorldFactory'
+import { resolveNpcSprite } from './spriteList'
 
 const T           = 32
 const INTERIOR_PAD = 10  // tiles of surrounding space around active room in interior view
@@ -84,6 +85,8 @@ interface Props {
   activeTileId:     string | null
   activeBundleId:   string | null
   activeZlayer:     Zlayer
+  pickActive?:      boolean
+  onPickTile?:      (tx: number, ty: number) => void
   onSelectEntity:   (e: SelectedEntity | null) => void
   onPlaceDecor:     (tx: number, ty: number) => void
   onMoveEntity:     (entity: SelectedEntity, tx: number, ty: number) => void
@@ -99,7 +102,7 @@ interface Props {
 export function MapEditorCanvas(props: Props) {
   const {
     configData, tool, showGrid, selectedEntity, viewMode, activeInteriorId, activeLevel,
-    activeTileId, activeBundleId, activeZlayer, showQuestItems, showBlockedPaths, showAreas, blockedPaths, questPickupItems,
+    activeTileId, activeBundleId, activeZlayer, pickActive, showQuestItems, showBlockedPaths, showAreas, blockedPaths, questPickupItems,
     onSelectEntity, onPlaceDecor, onMoveEntity, onDeleteEntity, onAddStreet,
   } = props
 
@@ -151,6 +154,12 @@ export function MapEditorCanvas(props: Props) {
       const pos = e.getLocalPosition(stage)
       const tx  = Math.floor((pos.x - ox) / T)
       const ty  = Math.floor((pos.y - oy) / T)
+
+      // Pick-location mode overrides all tools: the click sets an entity's tile.
+      if (propsRef.current.pickActive) {
+        propsRef.current.onPickTile?.(tx, ty)
+        return
+      }
 
       if (t === 'select') {
         const entity = hitTest(cfg, tx, ty, vm, iid, sqI, sbp, bps, sareas)
@@ -288,6 +297,22 @@ export function MapEditorCanvas(props: Props) {
         .stroke({ color: 0xf0c040, width: 2 })
       worldContainer.addChild(pvGfx)
     }
+
+    // Pick-location overlay — a transparent full-canvas catcher above every
+    // sprite, so a pick click lands on whatever tile is under the cursor even
+    // when an entity sprite (which stops propagation) sits there.
+    if (pickActive) {
+      const catcher = new PIXI.Graphics()
+      catcher.rect(0, 0, mapW, mapH).fill({ color: 0x000000, alpha: 0.001 })
+      catcher.eventMode = 'static'
+      catcher.cursor = 'crosshair'
+      catcher.on('pointerdown', (e: PIXI.FederatedPointerEvent) => {
+        const { x: ox, y: oy } = worldOriginRef.current
+        const pos = e.getLocalPosition(stage)
+        propsRef.current.onPickTile?.(Math.floor((pos.x - ox) / T), Math.floor((pos.y - oy) / T))
+      })
+      stage.addChild(catcher)
+    }
   })
 
   // ── Exterior rendering ─────────────────────────────────────────────────────────
@@ -358,7 +383,7 @@ export function MapEditorCanvas(props: Props) {
     npcs.forEach((npc, nIdx) => {
       if (npc.building) return
       const isSel = selectedEntity?.type === 'npc' && selectedEntity.index === nIdx
-      loadSpriteTexture(npc.sprite).then(tex => {
+      loadSpriteTexture(resolveNpcSprite(npc.sprite)).then(tex => {
         if (renderVersionRef.current !== version) return
         const sp = new PIXI.Sprite(tex)
         sp.width  = T * 1.5; sp.height = T * 1.5
@@ -613,7 +638,7 @@ export function MapEditorCanvas(props: Props) {
       if (npc.building !== iid) return
       const isSel = selectedEntity?.type === 'npc' && selectedEntity.index === nIdx
       const dimmed = (npc.minLevel ?? 0) > activeLevel  // NPC only present at a higher upgrade level
-      loadSpriteTexture(npc.sprite).then(tex => {
+      loadSpriteTexture(resolveNpcSprite(npc.sprite)).then(tex => {
         if (renderVersionRef.current !== version) return
         const sp = new PIXI.Sprite(tex)
         sp.width = T * 1.5; sp.height = T * 1.5

--- a/web/src/components/mapEditor/SpritePicker.tsx
+++ b/web/src/components/mapEditor/SpritePicker.tsx
@@ -1,5 +1,5 @@
-import React from 'react'
-import { NPC_SPRITE_SLUGS, npcSpriteUrl, animalSpriteUrl, ANIMAL_TYPES, EditorAnimalType } from './spriteList'
+import React, { useState, useMemo } from 'react'
+import { NPC_SPRITE_SLUGS, npcSpriteUrl, animalSpriteUrl, resolveNpcSprite, ANIMAL_TYPES, EditorAnimalType } from './spriteList'
 
 const selectStyle: React.CSSProperties = {
   background: '#252540', border: '1px solid #444', color: '#ccc',
@@ -11,11 +11,80 @@ const imgStyle: React.CSSProperties = {
   border: '1px solid #333', borderRadius: 3, flexShrink: 0,
 }
 
-/** Dropdown + preview for selecting an NPC sprite slug. */
+/**
+ * Searchable sprite picker over every NPC and card/unit sprite
+ * (`NPC_SPRITE_SLUGS`). Shows the current sprite (with default fallback) and,
+ * when focused, a filterable grid of thumbnails. Mirrors the TilePicker pattern.
+ */
+export function SpriteSearchPicker({ value, onChange }: { value: string; onChange: (slug: string) => void }) {
+  const [open, setOpen] = useState(false)
+  const [search, setSearch] = useState('')
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase()
+    const list = q ? NPC_SPRITE_SLUGS.filter(s => s.toLowerCase().includes(q)) : NPC_SPRITE_SLUGS
+    return list.slice(0, 300)
+  }, [search])
+
+  return (
+    <div>
+      <div
+        onClick={() => setOpen(o => !o)}
+        style={{ display: 'flex', gap: 6, alignItems: 'center', cursor: 'pointer' }}
+        title="Click to change sprite"
+      >
+        <img src={npcSpriteUrl(resolveNpcSprite(value))} style={imgStyle} alt="" />
+        <span style={{ flex: 1, fontSize: 11, color: value ? '#ccc' : '#888', fontFamily: 'monospace', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+          {value || `(default: ${resolveNpcSprite(value)})`}
+        </span>
+        <span style={{ fontSize: 10, color: '#666' }}>{open ? '▾' : '✎'}</span>
+      </div>
+      {open && (
+        <div style={{ marginTop: 6, background: '#0e0e1a', border: '1px solid #555', borderRadius: 4, padding: 6 }}>
+          <input
+            autoFocus
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+            placeholder="Search sprites…"
+            style={{ ...selectStyle, marginBottom: 4 }}
+          />
+          <div style={{ maxHeight: 200, overflowY: 'auto', display: 'grid', gridTemplateColumns: 'repeat(auto-fill, 36px)', gap: 4 }}>
+            {filtered.map(slug => (
+              <button
+                key={slug}
+                title={slug}
+                onClick={() => { onChange(slug); setOpen(false); setSearch('') }}
+                style={{
+                  width: 36, height: 36, padding: 2, cursor: 'pointer', display: 'flex',
+                  background: slug === value ? '#2a4a7a' : 'transparent',
+                  border: slug === value ? '1px solid #5a8aee' : '1px solid #2a2a3a',
+                  borderRadius: 3,
+                }}
+              >
+                <img src={npcSpriteUrl(slug)} style={{ width: '100%', height: '100%', objectFit: 'contain' }} alt="" />
+              </button>
+            ))}
+            {filtered.length === 0 && <span style={{ color: '#666', fontSize: 10 }}>No matches</span>}
+          </div>
+          {search.trim() && !NPC_SPRITE_SLUGS.includes(search.trim()) && (
+            <button
+              onClick={() => { onChange(search.trim()); setOpen(false); setSearch('') }}
+              style={{ marginTop: 4, fontSize: 10, color: '#8af', background: 'none', border: 'none', cursor: 'pointer', width: '100%', textAlign: 'left' }}
+            >
+              Use custom slug "{search.trim()}"
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+/** Dropdown + preview for selecting an NPC sprite slug (legacy; prefer SpriteSearchPicker). */
 export function NpcSpritePicker({ value, onChange }: { value: string; onChange: (slug: string) => void }) {
   return (
     <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
-      <img src={npcSpriteUrl(value)} style={imgStyle} alt="" />
+      <img src={npcSpriteUrl(resolveNpcSprite(value))} style={imgStyle} alt="" />
       <select value={value} onChange={e => onChange(e.target.value)} style={selectStyle}>
         {!NPC_SPRITE_SLUGS.includes(value) && (
           <option value={value}>{value} (custom)</option>

--- a/web/src/components/mapEditor/npcQuestDrawer/AnimalEditor.tsx
+++ b/web/src/components/mapEditor/npcQuestDrawer/AnimalEditor.tsx
@@ -1,0 +1,128 @@
+import React from 'react'
+import type { RawAnimal } from '../mapEditorTypes'
+import { AnimalTypePicker } from '../SpritePicker'
+import { ANIMAL_SPECS } from '../../../game/hub/animals'
+import type { AnimalType } from '../../../game/hub/animals'
+
+const INPUT: React.CSSProperties = {
+  width: '100%', padding: '3px 6px', background: '#111', border: '1px solid #444',
+  color: '#eee', borderRadius: 3, fontSize: 11, boxSizing: 'border-box',
+}
+const NUM: React.CSSProperties = {
+  width: 52, padding: '3px 5px', background: '#111', border: '1px solid #444',
+  color: '#eee', borderRadius: 3, fontSize: 11,
+}
+const BTN_DANGER: React.CSSProperties = {
+  padding: '2px 7px', background: '#5a1a1a', border: '1px solid #922',
+  color: '#f88', borderRadius: 3, fontSize: 10, cursor: 'pointer',
+}
+const BTN_PICK: React.CSSProperties = {
+  padding: '3px 8px', background: '#1e2a4e', border: '1px solid #3a4a8e',
+  color: '#8af', borderRadius: 3, fontSize: 10, cursor: 'pointer', marginLeft: 'auto',
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div style={{ marginBottom: 8 }}>
+      <div style={{ color: '#888', fontSize: 10, marginBottom: 3, textTransform: 'uppercase', letterSpacing: 1 }}>{label}</div>
+      {children}
+    </div>
+  )
+}
+
+/** Inline editor for an animal entity in the NPC/animal drawer (mirrors AnimalInspector). */
+export function AnimalEditor({ animal, onUpdate, onDelete, onPickLocation }: {
+  animal: RawAnimal
+  onUpdate: (partial: Partial<RawAnimal>) => void
+  onDelete: () => void
+  onPickLocation?: () => void
+}) {
+  const paletteKeys = ANIMAL_SPECS[animal.type as AnimalType]?.palette
+    ? Object.keys(ANIMAL_SPECS[animal.type as AnimalType].palette)
+    : []
+
+  return (
+    <div style={{ padding: '8px 10px 12px', borderLeft: '3px solid #3a6a3a', marginLeft: 4, marginBottom: 6 }}>
+      <Field label="ID">
+        <span style={{ fontFamily: 'monospace', fontSize: 11, color: '#888' }}>{animal.id}</span>
+      </Field>
+      <Field label="Type">
+        <AnimalTypePicker value={animal.type} onChange={type => onUpdate({ type, variant: undefined })} />
+      </Field>
+      <Field label="Variant">
+        <select value={animal.variant ?? ''} onChange={e => onUpdate({ variant: e.target.value || undefined })} style={INPUT}>
+          <option value="">(none)</option>
+          {paletteKeys.map(k => <option key={k} value={k}>{k}</option>)}
+        </select>
+      </Field>
+      <Field label="Name">
+        <input style={INPUT} value={animal.name ?? ''} onChange={e => onUpdate({ name: e.target.value || undefined })} />
+      </Field>
+      <Field label="Dialogue">
+        <textarea
+          value={(animal.dialogue ?? []).join('\n')}
+          onChange={e => onUpdate({ dialogue: e.target.value ? e.target.value.split('\n') : [] })}
+          rows={2}
+          style={{ ...INPUT, resize: 'vertical', fontFamily: 'inherit' }}
+        />
+        <div style={{ color: '#666', fontSize: 10, marginTop: 2 }}>One line = one dialogue entry</div>
+      </Field>
+      <Field label="Quest Give">
+        <input style={INPUT} value={animal.questGive ?? ''} onChange={e => onUpdate({ questGive: e.target.value || undefined })} />
+      </Field>
+      <Field label="Quest Receive">
+        <input
+          style={INPUT}
+          value={Array.isArray(animal.questReceive) ? animal.questReceive.join(', ') : (animal.questReceive ?? '')}
+          onChange={e => {
+            const val = e.target.value.trim()
+            const parsed: string | string[] | undefined = val.includes(',')
+              ? val.split(',').map(s => s.trim()).filter(Boolean)
+              : val || undefined
+            onUpdate({ questReceive: parsed })
+          }}
+        />
+      </Field>
+      <Field label="Building (interior)">
+        <input style={INPUT} value={animal.building ?? ''} placeholder="building ID (optional)"
+          onChange={e => onUpdate({ building: e.target.value || undefined })} />
+      </Field>
+      <Field label="Roam">
+        <label style={{ display: 'flex', alignItems: 'center', gap: 6, cursor: 'pointer', fontSize: 11 }}>
+          <input type="checkbox" checked={animal.roam ?? false} onChange={e => onUpdate({ roam: e.target.checked || undefined })} />
+          Wanders an area
+        </label>
+      </Field>
+      {animal.roam && (
+        <Field label="Area Rect (x, y, w, h)">
+          <div style={{ display: 'flex', gap: 4 }}>
+            {(['x', 'y', 'w', 'h'] as const).map((k, ki) => (
+              <input
+                key={k}
+                type="number"
+                value={animal.areaRect?.[ki] ?? 0}
+                onChange={e => {
+                  const r: [number, number, number, number] = [...(animal.areaRect ?? [0, 0, 0, 0])] as [number, number, number, number]
+                  r[ki] = Number(e.target.value)
+                  onUpdate({ areaRect: r })
+                }}
+                style={{ ...NUM, width: 44 }}
+                placeholder={k}
+              />
+            ))}
+          </div>
+        </Field>
+      )}
+      <Field label="Location">
+        <div style={{ display: 'flex', gap: 6, alignItems: 'center', flexWrap: 'wrap' }}>
+          <label style={{ color: '#888', fontSize: 10 }}>X</label>
+          <input type="number" style={NUM} value={animal.tx} onChange={e => onUpdate({ tx: Number(e.target.value) })} />
+          <label style={{ color: '#888', fontSize: 10 }}>Y</label>
+          <input type="number" style={NUM} value={animal.ty} onChange={e => onUpdate({ ty: Number(e.target.value) })} />
+          {onPickLocation && <button style={BTN_PICK} onClick={onPickLocation}>📍 Pick on map</button>}
+        </div>
+      </Field>
+      <button style={{ ...BTN_DANGER, width: '100%', padding: '5px 0' }} onClick={onDelete}>Delete Animal</button>
+    </div>
+  )
+}

--- a/web/src/components/mapEditor/npcQuestDrawer/NpcEditor.tsx
+++ b/web/src/components/mapEditor/npcQuestDrawer/NpcEditor.tsx
@@ -1,7 +1,11 @@
 import React, { useState, useEffect, useRef } from 'react'
-import type { RawMapConfig, RawNpc } from '../mapEditorTypes'
+import type { RawMapConfig, RawNpc, RawAnimal } from '../mapEditorTypes'
 import type { QuestDefsJson } from '../../../data/hub/hubWorldFactory'
 import { NPC_ACTIVITIES } from '../../../game/hub/hubNpcSchedule'
+import { SpriteSearchPicker } from '../SpritePicker'
+import { AnimalEditor } from './AnimalEditor'
+
+export type PickKind = 'npc' | 'animal'
 
 interface Props {
   configData: RawMapConfig
@@ -9,6 +13,10 @@ interface Props {
   focusedIndex: number | null
   onAddNpc: (npc: RawNpc) => void
   onUpdateNpc: (index: number, partial: Partial<RawNpc>) => void
+  onAddAnimal: (animal: RawAnimal) => void
+  onUpdateAnimal: (index: number, partial: Partial<RawAnimal>) => void
+  onDeleteAnimal: (index: number) => void
+  onPickLocation: (kind: PickKind, index: number) => void
 }
 
 function Field({ label, children }: { label: string; children: React.ReactNode }) {
@@ -36,6 +44,10 @@ const BTN_DANGER: React.CSSProperties = {
 const BTN_ADD: React.CSSProperties = {
   padding: '3px 10px', background: '#1e2e1e', border: '1px solid #3a5a3a',
   color: '#6d6', borderRadius: 3, fontSize: 11, cursor: 'pointer',
+}
+const BTN_PICK: React.CSSProperties = {
+  padding: '3px 8px', background: '#1e2a4e', border: '1px solid #3a4a8e',
+  color: '#8af', borderRadius: 3, fontSize: 10, cursor: 'pointer', marginLeft: 'auto',
 }
 
 // ── Schedule sub-editor ──────────────────────────────────────────────────────
@@ -172,10 +184,11 @@ function InnRumoursEditor({ rumours, onChange }: {
 
 // ── NpcFullEditor ─────────────────────────────────────────────────────────────
 
-function NpcFullEditor({ npc, questIds, onUpdate }: {
+function NpcFullEditor({ npc, questIds, onUpdate, onPickLocation }: {
   npc: RawNpc
   questIds: string[]
   onUpdate: (partial: Partial<RawNpc>) => void
+  onPickLocation?: () => void
 }) {
   const questOptions = [
     { value: '', label: '— none —' },
@@ -199,7 +212,19 @@ function NpcFullEditor({ npc, questIds, onUpdate }: {
         <input style={INPUT} type="text" value={npc.name} onChange={e => onUpdate({ name: e.target.value })} />
       </Field>
       <Field label="Sprite">
-        <input style={INPUT} type="text" value={npc.sprite} onChange={e => onUpdate({ sprite: e.target.value })} />
+        <SpriteSearchPicker value={npc.sprite} onChange={slug => onUpdate({ sprite: slug })} />
+      </Field>
+      <Field label="Location">
+        <div style={{ display: 'flex', gap: 6, alignItems: 'center', flexWrap: 'wrap' }}>
+          <label style={{ color: '#888', fontSize: 10 }}>X</label>
+          <input type="number" style={NUM} value={npc.tx} onChange={e => onUpdate({ tx: Number(e.target.value) })} />
+          <label style={{ color: '#888', fontSize: 10 }}>Y</label>
+          <input type="number" style={NUM} value={npc.ty} onChange={e => onUpdate({ ty: Number(e.target.value) })} />
+          {onPickLocation && (
+            <button style={BTN_PICK} onClick={onPickLocation}>📍 Pick on map</button>
+          )}
+        </div>
+        {npc.building && <div style={{ color: '#888', fontSize: 10, marginTop: 2 }}>interior: {npc.building}</div>}
       </Field>
       <Field label="Ghost NPC">
         <label style={{ display: 'flex', alignItems: 'center', gap: 6, cursor: 'pointer', fontSize: 11 }}>
@@ -266,83 +291,139 @@ function NpcFullEditor({ npc, questIds, onUpdate }: {
 
 // ── NpcEditor (main export) ──────────────────────────────────────────────────
 
-export function NpcEditor({ configData, questDefsData, focusedIndex, onAddNpc, onUpdateNpc }: Props) {
-  const [expandedIndex, setExpandedIndex] = useState<number | null>(null)
-  const rowRefs = useRef<Record<number, HTMLDivElement | null>>({})
+export function NpcEditor({
+  configData, questDefsData, focusedIndex,
+  onAddNpc, onUpdateNpc, onAddAnimal, onUpdateAnimal, onDeleteAnimal, onPickLocation,
+}: Props) {
+  // Selection is keyed by kind so NPC and animal rows don't collide.
+  const [expanded, setExpanded] = useState<{ kind: PickKind; index: number } | null>(null)
+  const rowRefs = useRef<Record<string, HTMLDivElement | null>>({})
   const containerRef = useRef<HTMLDivElement | null>(null)
-  const pendingScrollIndex = useRef<number | null>(null)
+  const pendingScroll = useRef<string | null>(null)
 
   useEffect(() => {
     if (focusedIndex === null) return
-    setExpandedIndex(focusedIndex)
+    setExpanded({ kind: 'npc', index: focusedIndex })
     setTimeout(() => {
-      rowRefs.current[focusedIndex]?.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+      rowRefs.current[`npc:${focusedIndex}`]?.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
     }, 50)
   }, [focusedIndex])
 
   const npcs = configData.npcs ?? []
+  const animals = configData.animals ?? []
   const questIds = ((questDefsData.quests as Array<{ id: string }> | undefined) ?? []).map(q => q.id)
 
-  // Scroll to newly added NPC after the render that includes it
+  // Scroll to a newly added row after the render that includes it
   useEffect(() => {
-    if (pendingScrollIndex.current === null) return
-    const idx = pendingScrollIndex.current
-    pendingScrollIndex.current = null
+    if (pendingScroll.current === null) return
+    const key = pendingScroll.current
+    pendingScroll.current = null
     setTimeout(() => {
-      rowRefs.current[idx]?.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+      rowRefs.current[key]?.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
     }, 50)
-  }, [npcs.length])
+  }, [npcs.length, animals.length])
 
   function handleAddNpc() {
-    console.log("add npc")
-    const defaultLocation = configData.avatarStart ?? {tx:5, ty:5} as {tx: Number, ty: number}
-    const tx = defaultLocation.tx
-    const ty = defaultLocation.ty
+    const loc = configData.avatarStart ?? { tx: 5, ty: 5 }
     const newIndex = npcs.length
-    pendingScrollIndex.current = newIndex
+    pendingScroll.current = `npc:${newIndex}`
     onAddNpc({
       id: `npc_${Date.now()}`,
       name: 'New NPC',
       sprite: '',
-      tx,
-      ty,
+      tx: loc.tx,
+      ty: loc.ty,
       dialogue: ['Hello!'],
     })
-    setExpandedIndex(newIndex)
+    setExpanded({ kind: 'npc', index: newIndex })
   }
+
+  function handleAddAnimal() {
+    const loc = configData.avatarStart ?? { tx: 5, ty: 5 }
+    const newIndex = animals.length
+    pendingScroll.current = `animal:${newIndex}`
+    onAddAnimal({
+      id: `animal-${Date.now()}`,
+      type: 'cat',
+      tx: loc.tx,
+      ty: loc.ty,
+    })
+    setExpanded({ kind: 'animal', index: newIndex })
+  }
+
+  const isExpanded = (kind: PickKind, i: number) => expanded?.kind === kind && expanded.index === i
+  const toggle = (kind: PickKind, i: number) =>
+    setExpanded(isExpanded(kind, i) ? null : { kind, index: i })
 
   return (
     <div ref={containerRef} style={{ flex: 1, overflowY: 'auto', padding: 8, color: '#ccc' }}>
-      <div style={{ marginBottom: 8 }}>
+      <div style={{ marginBottom: 8, display: 'flex', gap: 6 }}>
         <button style={BTN_ADD} onClick={handleAddNpc}>+ Add NPC</button>
+        <button style={{ ...BTN_ADD, background: '#1a2e1a', border: '1px solid #3a6a3a', color: '#88ffaa' }} onClick={handleAddAnimal}>+ Add Animal</button>
       </div>
-      {npcs.length === 0 && (
-        <div style={{ color: '#555', fontSize: 11, textAlign: 'center', marginTop: 8 }}>No NPCs on this map.</div>
+
+      {npcs.length === 0 && animals.length === 0 && (
+        <div style={{ color: '#555', fontSize: 11, textAlign: 'center', marginTop: 8 }}>No NPCs or animals on this map.</div>
       )}
+
       {npcs.map((npc, i) => (
-        <div key={npc.id} ref={el => { rowRefs.current[i] = el }}>
+        <div key={npc.id} ref={el => { rowRefs.current[`npc:${i}`] = el }}>
           <div
-            onClick={() => setExpandedIndex(expandedIndex === i ? null : i)}
+            onClick={() => toggle('npc', i)}
             style={{
               padding: '5px 8px', cursor: 'pointer', borderRadius: 3, marginBottom: 2,
-              background: expandedIndex === i ? '#2a2a4e' : '#1e1e3e',
-              border: `1px solid ${expandedIndex === i ? '#4a4aae' : '#2a2a4a'}`,
+              background: isExpanded('npc', i) ? '#2a2a4e' : '#1e1e3e',
+              border: `1px solid ${isExpanded('npc', i) ? '#4a4aae' : '#2a2a4a'}`,
               display: 'flex', justifyContent: 'space-between', alignItems: 'center',
             }}
           >
-            <span style={{ fontWeight: expandedIndex === i ? 'bold' : 'normal', fontSize: 12 }}>{npc.name}</span>
+            <span style={{ fontWeight: isExpanded('npc', i) ? 'bold' : 'normal', fontSize: 12 }}>{npc.name}</span>
             <div style={{ display: 'flex', gap: 4, alignItems: 'center' }}>
               {npc.questGive && <span style={{ fontSize: 10, color: '#f0c040' }} title="questGive">Q↑</span>}
               {npc.questReceive && <span style={{ fontSize: 10, color: '#40d0f0' }} title="questReceive">Q↓</span>}
-              <span style={{ color: '#555', fontSize: 10 }}>{npc.sprite}</span>
-              <span style={{ color: '#666', fontSize: 11 }}>{expandedIndex === i ? '▾' : '▸'}</span>
+              <span style={{ color: '#555', fontSize: 10 }}>{npc.sprite || '(default)'}</span>
+              <span style={{ color: '#666', fontSize: 11 }}>{isExpanded('npc', i) ? '▾' : '▸'}</span>
             </div>
           </div>
-          {expandedIndex === i && (
+          {isExpanded('npc', i) && (
             <NpcFullEditor
               npc={npc}
               questIds={questIds}
               onUpdate={partial => onUpdateNpc(i, partial)}
+              onPickLocation={() => onPickLocation('npc', i)}
+            />
+          )}
+        </div>
+      ))}
+
+      {animals.length > 0 && (
+        <div style={{ color: '#88ffaa', fontSize: 10, textTransform: 'uppercase', letterSpacing: 1, margin: '10px 0 4px' }}>Animals</div>
+      )}
+      {animals.map((animal, i) => (
+        <div key={animal.id} ref={el => { rowRefs.current[`animal:${i}`] = el }}>
+          <div
+            onClick={() => toggle('animal', i)}
+            style={{
+              padding: '5px 8px', cursor: 'pointer', borderRadius: 3, marginBottom: 2,
+              background: isExpanded('animal', i) ? '#1e3a1e' : '#1a2a1a',
+              border: `1px solid ${isExpanded('animal', i) ? '#3a6a3a' : '#234023'}`,
+              display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+            }}
+          >
+            <span style={{ fontWeight: isExpanded('animal', i) ? 'bold' : 'normal', fontSize: 12 }}>{animal.name || animal.type}</span>
+            <div style={{ display: 'flex', gap: 4, alignItems: 'center' }}>
+              {animal.questGive && <span style={{ fontSize: 10, color: '#f0c040' }} title="questGive">Q↑</span>}
+              {animal.questReceive && <span style={{ fontSize: 10, color: '#40d0f0' }} title="questReceive">Q↓</span>}
+              <span style={{ color: '#558855', fontSize: 10 }}>{animal.type}</span>
+              <span style={{ color: '#666', fontSize: 11 }}>{isExpanded('animal', i) ? '▾' : '▸'}</span>
+            </div>
+          </div>
+          {isExpanded('animal', i) && (
+            <AnimalEditor
+              animal={animal}
+              onUpdate={partial => onUpdateAnimal(i, partial)}
+              onDelete={() => { onDeleteAnimal(i); setExpanded(null) }}
+              onPickLocation={() => onPickLocation('animal', i)}
             />
           )}
         </div>

--- a/web/src/components/mapEditor/npcQuestDrawer/NpcQuestDrawer.tsx
+++ b/web/src/components/mapEditor/npcQuestDrawer/NpcQuestDrawer.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
 import type { DrawerTab } from './npcQuestDrawerTypes'
-import type { RawMapConfig, RawNpc } from '../mapEditorTypes'
+import type { RawMapConfig, RawNpc, RawAnimal } from '../mapEditorTypes'
 import type { QuestDefsJson } from '../../../data/hub/hubWorldFactory'
-import { NpcEditor } from './NpcEditor'
+import { NpcEditor, type PickKind } from './NpcEditor'
 import { QuestEditor } from './QuestEditor'
 
 interface Props {
@@ -13,6 +13,10 @@ interface Props {
   onTabChange: (tab: DrawerTab) => void
   onAddNpc: (npc: RawNpc) => void
   onUpdateNpc: (index: number, partial: Partial<RawNpc>) => void
+  onAddAnimal: (animal: RawAnimal) => void
+  onUpdateAnimal: (index: number, partial: Partial<RawAnimal>) => void
+  onDeleteAnimal: (index: number) => void
+  onPickLocation: (kind: PickKind, index: number) => void
   onQuestDefsChange: (updater: (prev: QuestDefsJson) => QuestDefsJson) => void
 }
 
@@ -27,7 +31,7 @@ const TAB_INACTIVE: React.CSSProperties = {
 
 export function NpcQuestDrawer({
   tab, focusedNpcIndex, configData, questDefsData,
-  onTabChange, onAddNpc, onUpdateNpc, onQuestDefsChange,
+  onTabChange, onAddNpc, onUpdateNpc, onAddAnimal, onUpdateAnimal, onDeleteAnimal, onPickLocation, onQuestDefsChange,
 }: Props) {
   return (
     <div style={{ display: 'flex', flexDirection: 'column', height: '100%', background: '#12122a', borderTop: '1px solid #333' }}>
@@ -47,6 +51,10 @@ export function NpcQuestDrawer({
             focusedIndex={focusedNpcIndex}
             onAddNpc={onAddNpc}
             onUpdateNpc={onUpdateNpc}
+            onAddAnimal={onAddAnimal}
+            onUpdateAnimal={onUpdateAnimal}
+            onDeleteAnimal={onDeleteAnimal}
+            onPickLocation={onPickLocation}
           />
         )}
         {tab === 'quests' && (

--- a/web/src/components/mapEditor/spriteList.ts
+++ b/web/src/components/mapEditor/spriteList.ts
@@ -29,3 +29,7 @@ export function npcSpriteUrl(slug: string): string {
   const base = (import.meta as { env: { BASE_URL: string } }).env.BASE_URL
   return `${base}sprites/${slug}.svg`
 }
+
+// NPC sprite default + resolver live in game/sprites.ts (no import.meta.glob, so
+// they're safe to import from the game bundle); re-exported here for editor use.
+export { DEFAULT_NPC_SPRITE, resolveNpcSprite } from '../../game/sprites'

--- a/web/src/game/sprites.ts
+++ b/web/src/game/sprites.ts
@@ -21,3 +21,13 @@ export function spriteSlug(name: string): string {
   if (NAME_MAP[name]) return NAME_MAP[name]
   return name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '')
 }
+
+// Fallback sprite for NPCs with no sprite assigned — a neutral townsperson, so
+// sprite-less NPCs still render (editor preview and in-game) instead of
+// vanishing / showing a placeholder dot.
+export const DEFAULT_NPC_SPRITE = 'hub-npc-elder'
+
+/** Returns the NPC's sprite slug, or the default when none is set. */
+export function resolveNpcSprite(slug?: string): string {
+  return slug?.trim() || DEFAULT_NPC_SPRITE
+}


### PR DESCRIPTION
Four map-editor NPC/animal authoring improvements.

## 1. Pick location on the map
NPC and animal editors (drawer **and** inspector) get a **"📍 Pick on map"** button. Clicking it shows a banner; the next click on the canvas stores that tile as the entity's `tx`/`ty`. When done inside an interior, the entity's `building` is set to that interior (coords interior-local); in the exterior it's cleared. A transparent full-canvas catcher overlay makes the pick land on whatever tile is under the cursor, even over an existing sprite.

## 2. Default sprite fallback
New `resolveNpcSprite()` returns `hub-npc-elder` when an NPC has no sprite. Applied in the editor preview/canvas **and** in-game (`HubTownCanvas`), so sprite-less NPCs (some already ship in town data) render a neutral townsperson instead of a pink dot / nothing. Helper lives in `game/sprites.ts` (no `import.meta.glob`, safe for the game bundle) and is re-exported from `spriteList.ts`.

## 3. Searchable sprite picker
New `SpriteSearchPicker` — a thumbnail + filter box over `NPC_SPRITE_SLUGS`, which already enumerates every `/public/sprites/*.svg`, i.e. all NPC **and** card/unit character sprites (~1500). Replaces the free-text box in the drawer and the long `<select>` in the inspector. Supports a custom-slug passthrough.

## 4. Animals in the NPC drawer
Animals are already NPC-like (name/dialogue/quests). Added a **"+ Add Animal"** button beside "+ Add NPC" and an inline `AnimalEditor` (type, variant, name, dialogue, quest give/receive, building, roam + area, location + pick, delete). Removed the now-duplicate footer "+ Add Animal" button and a stray `console.log` in `handleAddNpc`.

## Files
- `game/sprites.ts`, `mapEditor/spriteList.ts` — default + `resolveNpcSprite`
- `mapEditor/SpritePicker.tsx` — `SpriteSearchPicker`
- `mapEditor/npcQuestDrawer/` — `NpcEditor`, `NpcQuestDrawer`, new `AnimalEditor`
- `mapEditor/MapEditor.tsx` — pick state/banner + wiring; `MapEditorCanvas.tsx` — pick overlay + fallback; `EntityInspector.tsx` — search picker + pick buttons
- `components/hub/HubTownCanvas.tsx` — in-game sprite fallback

## Verification
- `npm run build` ✅ and `npx vitest run` ✅ (190/190).
- Manual: add an NPC, "Pick on map", click a tile → x/y update; do it inside an interior → `building` set. Leave sprite blank → renders `hub-npc-elder` (editor + in-game). Search "merchant"/"mage" in the sprite picker. "+ Add Animal" → edit inline → appears on canvas and round-trips on Save.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011f8gD7RAP6taye8wz8GfFs)_