### PR TITLE
Map editor: full hub/quest config coverage (treasures, road blocks, interactables + audit)

### DIFF
--- a/docs/hubworld.md
+++ b/docs/hubworld.md
@@ -941,3 +941,30 @@ the viewport, so cost is independent of map size). A standalone
 default (`snow`/`ice`/`tundra` → snow; `swamp`/`marsh`/`graveyard`/`ashen` → fog;
 `forest` → rain; others → clear) → `clear`. Omit `weather` entirely to use the
 environment default. `WEATHER_TYPES` in `weather.ts` is the canonical type list.
+
+---
+
+## §13 — Map Editor config coverage
+
+The in-app **Map Editor** (`web/src/components/mapEditor/`) can author every
+field in a town's `config.json` and `questDefs.json`. Save writes both files
+back whole (the editor `structuredClone`s the full config/questDefs, so unknown
+or unedited keys are preserved).
+
+| Data (file) | Where in the editor |
+|---|---|
+| mapW/H, townName, environment (config) | Town panel (no selection) |
+| avatarStart, exitTiles, weather, ambientNpcSprites, npcSpawnTiles, pondTiles, chickenZones (config) | Town panel → extra sections |
+| buildings, exteriorDecor, interiors, streets, areas, doors (config) | Canvas tools + Building/Interior/Street/Area inspectors |
+| npcs, animals (config) | NPC drawer (NPCs tab) + canvas |
+| treasures (config) | "+ Add Treasure" + Treasure inspector; quest-items overlay |
+| interactables (config) | Interactables overlay toggle + Interactable inspector (incl. reactions) |
+| lockedDoors (config) | Building inspector → locked door |
+| quests, pickupItems (questDefs) | NPC drawer (Quests tab) |
+| blockedPaths (questDefs) | "+ Add Road Block" + Blocked Path inspector; blocked-paths overlay |
+| innRumours, friendshipDialogue, relationshipDialogue, dialogues (questDefs) | NPC drawer (Dialogue tab) |
+
+**Pick-on-map:** NPCs, animals, treasures, interactables, exit tiles, avatar
+spawn, and blocked-path tiles all support a "📍 Pick on map" button that sets
+the location from the next canvas click (records the interior building when used
+inside a room). Dialogue-tree `nodes` are edited as JSON within the Dialogue tab.

--- a/web/src/components/mapEditor/EntityInspector.tsx
+++ b/web/src/components/mapEditor/EntityInspector.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import type { SelectedEntity, RawMapConfig, RawInterior, RawBlockedPath, RawLockedDoor, Zlayer, RawDecorItem, RawNpc, RawBuilding, RawAnimal, RawInteractable, RawInteractableReaction, PickKind } from './mapEditorTypes'
+import type { SelectedEntity, RawMapConfig, RawInterior, RawBlockedPath, RawLockedDoor, Zlayer, RawDecorItem, RawNpc, RawBuilding, RawAnimal, RawInteractable, RawInteractableReaction, RawWeather, PickKind } from './mapEditorTypes'
 import { BASE_CHIP_TILES } from '../../data/tiles/baseChipIndex'
 import { resolveTileRef } from '../../data/tiles/tileIndex'
 import type { WallMaterial } from '../../data/tiles/buildingMaterials'
@@ -1603,7 +1603,181 @@ function TownInspector({
           </div>
         </div>
       </Field>
+
+      {onUpdateConfig && <TownExtraSections configData={configData} onUpdateConfig={onUpdateConfig} onPickLocation={onPickLocation} inputStyle={inputStyle} />}
     </div>
+  )
+}
+
+// Editors for the remaining town config: spawn & exits, terrain & spawn zones,
+// weather & ambient sprites. Whole arrays/values are written via onUpdateConfig.
+function TownExtraSections({ configData, onUpdateConfig, onPickLocation, inputStyle }: {
+  configData: RawMapConfig
+  onUpdateConfig: (patch: Partial<RawMapConfig>) => void
+  onPickLocation?: (kind: PickKind, index?: number) => void
+  inputStyle: React.CSSProperties
+}) {
+  const numSm: React.CSSProperties = { width: 42, padding: '2px 4px', background: '#111', border: '1px solid #444', color: '#eee', borderRadius: 3, fontSize: 11 }
+  const addBtn: React.CSSProperties = { padding: '2px 8px', background: '#1e2e1e', border: '1px solid #3a5a3a', color: '#6d6', borderRadius: 3, fontSize: 10, cursor: 'pointer', alignSelf: 'flex-start' }
+  const xBtn: React.CSSProperties = { padding: '1px 5px', background: '#4a1a1a', border: '1px solid #922', color: '#f88', borderRadius: 3, fontSize: 10, cursor: 'pointer' }
+  const pickBtn: React.CSSProperties = { padding: '1px 6px', background: '#1e2a4e', border: '1px solid #3a4a8e', color: '#8af', borderRadius: 3, fontSize: 10, cursor: 'pointer' }
+  const start = configData.avatarStart ?? { tx: 0, ty: 0 }
+  const exits = configData.exitTiles ?? []
+  const weather = (configData.weather ?? {}) as RawWeather
+  const seasons = Object.entries(weather.bySeason ?? {})
+  const ambient = configData.ambientNpcSprites ?? []
+  const zones = configData.chickenZones ?? []
+  const spawns = configData.npcSpawnTiles ?? []
+
+  return (
+    <>
+      {/* Spawn & exits */}
+      <Field label="Avatar Spawn">
+        <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+          <label style={{ fontSize: 10, color: '#888' }}>X</label>
+          <input type="number" style={numSm} value={start.tx} onChange={e => onUpdateConfig({ avatarStart: { tx: Number(e.target.value), ty: start.ty } })} />
+          <label style={{ fontSize: 10, color: '#888' }}>Y</label>
+          <input type="number" style={numSm} value={start.ty} onChange={e => onUpdateConfig({ avatarStart: { tx: start.tx, ty: Number(e.target.value) } })} />
+          {onPickLocation && <button style={pickBtn} onClick={() => onPickLocation('avatarStart')}>📍 Pick</button>}
+        </div>
+      </Field>
+
+      <Field label={`Exit Tiles (${exits.length})`}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+          {exits.map((e, i) => (
+            <div key={i} style={{ display: 'flex', gap: 4, alignItems: 'center', flexWrap: 'wrap', background: '#16161e', border: '1px solid #2a2a3a', borderRadius: 3, padding: 4 }}>
+              <input type="number" style={numSm} value={e.tx} onChange={ev => onUpdateConfig({ exitTiles: exits.map((x, j) => j === i ? { ...x, tx: Number(ev.target.value) } : x) })} />
+              <input type="number" style={numSm} value={e.ty} onChange={ev => onUpdateConfig({ exitTiles: exits.map((x, j) => j === i ? { ...x, ty: Number(ev.target.value) } : x) })} />
+              <input style={{ ...inputStyle, flex: 1, minWidth: 70 }} placeholder="screen" value={e.screen} onChange={ev => onUpdateConfig({ exitTiles: exits.map((x, j) => j === i ? { ...x, screen: ev.target.value } : x) })} />
+              {onPickLocation && <button style={pickBtn} onClick={() => onPickLocation('exitTile', i)}>📍</button>}
+              <button style={xBtn} onClick={() => onUpdateConfig({ exitTiles: exits.filter((_, j) => j !== i) })}>✕</button>
+            </div>
+          ))}
+          <button style={addBtn} onClick={() => onUpdateConfig({ exitTiles: [...exits, { tx: start.tx, ty: start.ty, screen: '' }] })}>+ Add exit</button>
+        </div>
+      </Field>
+
+      {/* Weather */}
+      <Field label="Weather">
+        <input style={{ ...inputStyle, marginBottom: 4 }} placeholder="type (e.g. rain, snow, fog)" value={weather.type ?? ''}
+          onChange={e => onUpdateConfig({ weather: { ...weather, type: e.target.value || undefined } })} />
+        <div style={{ color: '#888', fontSize: 9, margin: '2px 0' }}>Per-season overrides</div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+          {seasons.map(([season, val], i) => (
+            <div key={i} style={{ display: 'flex', gap: 4 }}>
+              <input style={{ ...inputStyle, flex: 1 }} value={season} placeholder="season" onChange={e => {
+                const next = { ...(weather.bySeason ?? {}) }; delete next[season]; if (e.target.value) next[e.target.value] = val
+                onUpdateConfig({ weather: { ...weather, bySeason: next } })
+              }} />
+              <input style={{ ...inputStyle, flex: 1 }} value={val} placeholder="weather" onChange={e => onUpdateConfig({ weather: { ...weather, bySeason: { ...(weather.bySeason ?? {}), [season]: e.target.value } } })} />
+              <button style={xBtn} onClick={() => { const next = { ...(weather.bySeason ?? {}) }; delete next[season]; onUpdateConfig({ weather: { ...weather, bySeason: next } }) }}>✕</button>
+            </div>
+          ))}
+          <button style={addBtn} onClick={() => onUpdateConfig({ weather: { ...weather, bySeason: { ...(weather.bySeason ?? {}), '': '' } } })}>+ Add season</button>
+        </div>
+      </Field>
+
+      {/* Ambient NPC sprites */}
+      <Field label={`Ambient NPC Sprites (${ambient.length})`}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+          {ambient.map((slug, i) => (
+            <div key={i} style={{ display: 'flex', gap: 4, alignItems: 'flex-start' }}>
+              <div style={{ flex: 1 }}>
+                <SpriteSearchPicker value={slug} onChange={s => onUpdateConfig({ ambientNpcSprites: ambient.map((x, j) => j === i ? s : x) })} />
+              </div>
+              <button style={xBtn} onClick={() => onUpdateConfig({ ambientNpcSprites: ambient.filter((_, j) => j !== i) })}>✕</button>
+            </div>
+          ))}
+          <button style={addBtn} onClick={() => onUpdateConfig({ ambientNpcSprites: [...ambient, 'hub-npc-elder'] })}>+ Add sprite</button>
+        </div>
+      </Field>
+
+      {/* Chicken zones */}
+      <Field label={`Chicken Zones (${zones.length})`}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+          {zones.map((z, i) => (
+            <div key={i} style={{ background: '#16161e', border: '1px solid #2a2a3a', borderRadius: 3, padding: 4 }}>
+              <div style={{ display: 'flex', gap: 3, alignItems: 'center', flexWrap: 'wrap' }}>
+                <span style={{ fontSize: 9, color: '#888' }}>rect</span>
+                {[0, 1, 2, 3].map(k => (
+                  <input key={k} type="number" style={numSm} value={z.rect[k]} onChange={e => {
+                    const rect = [...z.rect] as [number, number, number, number]; rect[k] = Number(e.target.value)
+                    onUpdateConfig({ chickenZones: zones.map((x, j) => j === i ? { ...x, rect } : x) })
+                  }} />
+                ))}
+                <button style={{ ...xBtn, marginLeft: 'auto' }} onClick={() => onUpdateConfig({ chickenZones: zones.filter((_, j) => j !== i) })}>✕</button>
+              </div>
+              <div style={{ display: 'flex', gap: 3, alignItems: 'center', marginTop: 3 }}>
+                <span style={{ fontSize: 9, color: '#888' }}>count</span>
+                <input type="number" style={numSm} value={z.count ?? 0} onChange={e => onUpdateConfig({ chickenZones: zones.map((x, j) => j === i ? { ...x, count: Number(e.target.value) || undefined } : x) })} />
+                <span style={{ fontSize: 9, color: '#888' }}>roost</span>
+                <input type="number" style={numSm} value={z.roost?.[0] ?? ''} placeholder="x" onChange={e => onUpdateConfig({ chickenZones: zones.map((x, j) => j === i ? { ...x, roost: [Number(e.target.value), x.roost?.[1] ?? 0] } : x) })} />
+                <input type="number" style={numSm} value={z.roost?.[1] ?? ''} placeholder="y" onChange={e => onUpdateConfig({ chickenZones: zones.map((x, j) => j === i ? { ...x, roost: [x.roost?.[0] ?? 0, Number(e.target.value)] } : x) })} />
+              </div>
+            </div>
+          ))}
+          <button style={addBtn} onClick={() => onUpdateConfig({ chickenZones: [...zones, { rect: [start.tx, start.ty, start.tx + 3, start.ty + 3], count: 3 }] })}>+ Add zone</button>
+        </div>
+      </Field>
+
+      {/* NPC spawn tiles */}
+      <Field label={`NPC Spawn Tiles (${spawns.length})`}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+          {spawns.map(([tx, ty], i) => (
+            <div key={i} style={{ display: 'flex', gap: 4, alignItems: 'center' }}>
+              <input type="number" style={numSm} value={tx} onChange={e => onUpdateConfig({ npcSpawnTiles: spawns.map((x, j) => j === i ? [Number(e.target.value), x[1]] : x) })} />
+              <input type="number" style={numSm} value={ty} onChange={e => onUpdateConfig({ npcSpawnTiles: spawns.map((x, j) => j === i ? [x[0], Number(e.target.value)] : x) })} />
+              <button style={xBtn} onClick={() => onUpdateConfig({ npcSpawnTiles: spawns.filter((_, j) => j !== i) })}>✕</button>
+            </div>
+          ))}
+          <button style={addBtn} onClick={() => onUpdateConfig({ npcSpawnTiles: [...spawns, [start.tx, start.ty]] })}>+ Add spawn tile</button>
+        </div>
+      </Field>
+
+      {/* Pond tiles */}
+      <PondEditor configData={configData} onUpdateConfig={onUpdateConfig} numSm={numSm} addBtn={addBtn} xBtn={xBtn} anchor={[start.tx, start.ty]} />
+    </>
+  )
+}
+
+function PondEditor({ configData, onUpdateConfig, numSm, addBtn, xBtn, anchor }: {
+  configData: RawMapConfig
+  onUpdateConfig: (patch: Partial<RawMapConfig>) => void
+  numSm: React.CSSProperties
+  addBtn: React.CSSProperties
+  xBtn: React.CSSProperties
+  anchor: [number, number]
+}) {
+  const ponds = configData.pondTiles ?? []
+  const set = (next: typeof ponds) => onUpdateConfig({ pondTiles: next })
+  return (
+    <Field label={`Pond Tiles (${ponds.length})`}>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+        {ponds.map((p, i) => (
+          <div key={i} style={{ display: 'flex', gap: 3, alignItems: 'center', flexWrap: 'wrap' }}>
+            {p.rect ? (
+              <>
+                <span style={{ fontSize: 9, color: '#888' }}>rect</span>
+                {[0, 1, 2, 3].map(k => (
+                  <input key={k} type="number" style={numSm} value={p.rect![k]} onChange={e => { const rect = [...p.rect!]; rect[k] = Number(e.target.value); set(ponds.map((x, j) => j === i ? { rect } : x)) }} />
+                ))}
+              </>
+            ) : (
+              <>
+                <span style={{ fontSize: 9, color: '#888' }}>tile</span>
+                <input type="number" style={numSm} value={p.tile?.[0] ?? 0} onChange={e => set(ponds.map((x, j) => j === i ? { tile: [Number(e.target.value), p.tile?.[1] ?? 0] } : x))} />
+                <input type="number" style={numSm} value={p.tile?.[1] ?? 0} onChange={e => set(ponds.map((x, j) => j === i ? { tile: [p.tile?.[0] ?? 0, Number(e.target.value)] } : x))} />
+              </>
+            )}
+            <button style={{ ...xBtn, marginLeft: 'auto' }} onClick={() => set(ponds.filter((_, j) => j !== i))}>✕</button>
+          </div>
+        ))}
+        <div style={{ display: 'flex', gap: 4 }}>
+          <button style={addBtn} onClick={() => set([...ponds, { tile: [anchor[0], anchor[1]] }])}>+ Tile</button>
+          <button style={addBtn} onClick={() => set([...ponds, { rect: [anchor[0], anchor[1], anchor[0] + 2, anchor[1] + 2] }])}>+ Rect</button>
+        </div>
+      </div>
+    </Field>
   )
 }
 

--- a/web/src/components/mapEditor/EntityInspector.tsx
+++ b/web/src/components/mapEditor/EntityInspector.tsx
@@ -1388,6 +1388,159 @@ function TreasureInspector({ treasure, onUpdate, onMove, onDelete, onPick }: {
   )
 }
 
+// ── Interactables ──────────────────────────────────────────────────────────────
+const REACTION_TYPES = ['dialogue', 'screen', 'giveItem', 'quest', 'move'] as const
+
+function ReactionEditor({ reaction, onChange }: {
+  reaction: RawInteractableReaction
+  onChange: (r: RawInteractableReaction) => void
+}) {
+  const inp: React.CSSProperties = { width: '100%', padding: '3px 5px', background: '#111', border: '1px solid #444', color: '#eee', borderRadius: 3, fontSize: 11, boxSizing: 'border-box' }
+  const numSm: React.CSSProperties = { width: 50, padding: '2px 4px', background: '#111', border: '1px solid #444', color: '#eee', borderRadius: 3, fontSize: 11 }
+  const text = Array.isArray(reaction.text) ? reaction.text.join('\n') : (reaction.text ?? '')
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
+      <select value={reaction.type} onChange={e => onChange({ type: e.target.value })} style={inp}>
+        {REACTION_TYPES.map(t => <option key={t} value={t}>{t}</option>)}
+      </select>
+
+      {reaction.type === 'dialogue' && (
+        <>
+          <input style={inp} placeholder="speaker name (optional)" value={reaction.speakerName ?? ''} onChange={e => onChange({ ...reaction, speakerName: e.target.value || undefined })} />
+          <textarea style={{ ...inp, resize: 'vertical', fontFamily: 'inherit' }} rows={3} placeholder="dialogue (one line per entry)" value={text}
+            onChange={e => onChange({ ...reaction, text: e.target.value.includes('\n') ? e.target.value.split('\n') : e.target.value })} />
+        </>
+      )}
+
+      {reaction.type === 'screen' && (
+        <input style={inp} placeholder="screen id (e.g. news, town-upgrades)" value={reaction.screen ?? ''} onChange={e => onChange({ ...reaction, screen: e.target.value })} />
+      )}
+
+      {reaction.type === 'quest' && (
+        <>
+          <input style={inp} placeholder="quest id" value={reaction.questId ?? ''} onChange={e => onChange({ ...reaction, questId: e.target.value })} />
+          <input style={inp} placeholder="speaker name (optional)" value={reaction.speakerName ?? ''} onChange={e => onChange({ ...reaction, speakerName: e.target.value || undefined })} />
+        </>
+      )}
+
+      {reaction.type === 'move' && (
+        <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+          <label style={{ fontSize: 10, color: '#888' }}>To X</label>
+          <input type="number" style={numSm} value={reaction.to?.tx ?? 0} onChange={e => onChange({ ...reaction, to: { tx: Number(e.target.value), ty: reaction.to?.ty ?? 0 } })} />
+          <label style={{ fontSize: 10, color: '#888' }}>Y</label>
+          <input type="number" style={numSm} value={reaction.to?.ty ?? 0} onChange={e => onChange({ ...reaction, to: { tx: reaction.to?.tx ?? 0, ty: Number(e.target.value) } })} />
+        </div>
+      )}
+
+      {reaction.type === 'giveItem' && (
+        <>
+          <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+            <label style={{ fontSize: 10, color: '#888' }}>Crystals</label>
+            <input type="number" style={numSm} value={reaction.crystals ?? 0} onChange={e => onChange({ ...reaction, crystals: Number(e.target.value) || undefined })} />
+          </div>
+          <input style={inp} placeholder="message (optional)" value={reaction.message ?? ''} onChange={e => onChange({ ...reaction, message: e.target.value || undefined })} />
+          <input style={inp} placeholder="already-granted text (optional)" value={reaction.alreadyGrantedText ?? ''} onChange={e => onChange({ ...reaction, alreadyGrantedText: e.target.value || undefined })} />
+          <div style={{ color: '#888', fontSize: 9 }}>Collectible (optional)</div>
+          <div style={{ display: 'flex', gap: 4 }}>
+            <input style={inp} placeholder="id" value={reaction.collectible?.id ?? ''} onChange={e => onChange({ ...reaction, collectible: { id: e.target.value, name: reaction.collectible?.name ?? '', icon: reaction.collectible?.icon ?? '🎁', desc: reaction.collectible?.desc ?? '' } })} />
+            <input style={inp} placeholder="name" value={reaction.collectible?.name ?? ''} onChange={e => onChange({ ...reaction, collectible: { id: reaction.collectible?.id ?? '', name: e.target.value, icon: reaction.collectible?.icon ?? '🎁', desc: reaction.collectible?.desc ?? '' } })} />
+          </div>
+          <div style={{ display: 'flex', gap: 4 }}>
+            <input style={{ ...inp, width: 50, flex: '0 0 50px' }} placeholder="icon" value={reaction.collectible?.icon ?? ''} onChange={e => onChange({ ...reaction, collectible: { id: reaction.collectible?.id ?? '', name: reaction.collectible?.name ?? '', icon: e.target.value, desc: reaction.collectible?.desc ?? '' } })} />
+            <input style={inp} placeholder="desc" value={reaction.collectible?.desc ?? ''} onChange={e => onChange({ ...reaction, collectible: { id: reaction.collectible?.id ?? '', name: reaction.collectible?.name ?? '', icon: reaction.collectible?.icon ?? '🎁', desc: e.target.value } })} />
+          </div>
+        </>
+      )}
+    </div>
+  )
+}
+
+function InteractableInspector({ it, onUpdate, onMove, onDelete, onPick }: {
+  it: RawInteractable
+  onUpdate: (patch: Partial<RawInteractable>) => void
+  onMove: (tx: number, ty: number) => void
+  onDelete: () => void
+  onPick?: () => void
+}) {
+  const [pickingDecor, setPickingDecor] = useState<number | null>(null)
+  const inp: React.CSSProperties = { width: '100%', padding: '3px 5px', background: '#111', border: '1px solid #444', color: '#eee', borderRadius: 3, fontSize: 11, boxSizing: 'border-box' }
+  const numSm: React.CSSProperties = { width: 44, padding: '2px 4px', background: '#111', border: '1px solid #444', color: '#eee', borderRadius: 3, fontSize: 11 }
+  const decor = it.decor ?? []
+  const reactions = it.reactions ?? []
+  return (
+    <div>
+      <Field label="ID">
+        <input style={inp} value={it.id} onChange={e => onUpdate({ id: e.target.value })} />
+      </Field>
+      <Field label="Position (anchor)">
+        <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+          <label style={{ fontSize: 11, color: '#888' }}>X</label>
+          {numInput(it.tx, tx => onMove(tx, it.ty))}
+          <label style={{ fontSize: 11, color: '#888' }}>Y</label>
+          {numInput(it.ty, ty => onMove(it.tx, ty))}
+        </div>
+        {onPick && <button style={BTN_PICK} onClick={onPick}>📍 Pick on map</button>}
+      </Field>
+      <Field label="Building (interior, optional)">
+        <input style={inp} value={it.building ?? ''} placeholder="building ID" onChange={e => onUpdate({ building: e.target.value || undefined })} />
+      </Field>
+      <Field label="Hit area (tiles)">
+        <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+          <label style={{ fontSize: 10, color: '#888' }}>W</label>
+          <input type="number" style={numSm} value={it.hitRect?.w ?? ''} placeholder="auto" onChange={e => onUpdate({ hitRect: e.target.value ? { w: Number(e.target.value), h: it.hitRect?.h ?? 1 } : undefined })} />
+          <label style={{ fontSize: 10, color: '#888' }}>H</label>
+          <input type="number" style={numSm} value={it.hitRect?.h ?? ''} placeholder="auto" onChange={e => onUpdate({ hitRect: e.target.value ? { w: it.hitRect?.w ?? 1, h: Number(e.target.value) } : undefined })} />
+        </div>
+      </Field>
+      <Field label={`Decor tiles (${decor.length}) — offset from anchor`}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+          {decor.map((d, i) => (
+            <div key={i} style={{ background: '#16161e', border: '1px solid #2a2a3a', borderRadius: 3, padding: 4 }}>
+              <div style={{ display: 'flex', gap: 4, alignItems: 'center' }}>
+                <div onClick={() => setPickingDecor(p => p === i ? null : i)} style={{ cursor: 'pointer', display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+                  <TilePreview tileId={d.tileId} /><span style={{ fontSize: 10, color: '#666' }}>✎</span>
+                </div>
+                <label style={{ fontSize: 9, color: '#888' }}>dx</label>
+                <input type="number" style={numSm} value={d.dx} onChange={e => onUpdate({ decor: decor.map((x, j) => j === i ? { ...x, dx: Number(e.target.value) } : x) })} />
+                <label style={{ fontSize: 9, color: '#888' }}>dy</label>
+                <input type="number" style={numSm} value={d.dy} onChange={e => onUpdate({ decor: decor.map((x, j) => j === i ? { ...x, dy: Number(e.target.value) } : x) })} />
+                <button style={{ marginLeft: 'auto', padding: '1px 5px', background: '#4a1a1a', border: '1px solid #922', color: '#f88', borderRadius: 3, fontSize: 10, cursor: 'pointer' }}
+                  onClick={() => onUpdate({ decor: decor.filter((_, j) => j !== i) })}>✕</button>
+              </div>
+              {pickingDecor === i && <TilePicker current={d.tileId} onChange={tileId => onUpdate({ decor: decor.map((x, j) => j === i ? { ...x, tileId } : x) })} onClose={() => setPickingDecor(null)} />}
+            </div>
+          ))}
+          <button style={{ padding: '2px 8px', background: '#1e2e1e', border: '1px solid #3a5a3a', color: '#6d6', borderRadius: 3, fontSize: 10, cursor: 'pointer', alignSelf: 'flex-start' }}
+            onClick={() => onUpdate({ decor: [...decor, { dx: 0, dy: 0, tileId: 'signpost' }] })}>+ Add tile</button>
+        </div>
+      </Field>
+      <Field label="Indicator condition (optional)">
+        <input style={inp} value={it.indicator?.condition ?? ''} placeholder="e.g. unread-news"
+          onChange={e => onUpdate({ indicator: e.target.value ? { condition: e.target.value, dx: it.indicator?.dx, dy: it.indicator?.dy } : undefined })} />
+      </Field>
+      <Field label={`Reactions (${reactions.length})`}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+          {reactions.map((r, i) => (
+            <div key={i} style={{ background: '#12121e', border: '1px solid #2a2a4a', borderRadius: 4, padding: 6 }}>
+              <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 4 }}>
+                <span style={{ fontSize: 9, color: '#888' }}>#{i + 1}</span>
+                <button style={{ padding: '0 6px', background: '#4a1a1a', border: '1px solid #922', color: '#f88', borderRadius: 3, fontSize: 10, cursor: 'pointer' }}
+                  onClick={() => onUpdate({ reactions: reactions.filter((_, j) => j !== i) })}>✕</button>
+              </div>
+              <ReactionEditor reaction={r} onChange={nr => onUpdate({ reactions: reactions.map((x, j) => j === i ? nr : x) })} />
+            </div>
+          ))}
+          <button style={{ padding: '2px 8px', background: '#1e2e1e', border: '1px solid #3a5a3a', color: '#6d6', borderRadius: 3, fontSize: 10, cursor: 'pointer', alignSelf: 'flex-start' }}
+            onClick={() => onUpdate({ reactions: [...reactions, { type: 'dialogue', text: '' }] })}>+ Add reaction</button>
+        </div>
+      </Field>
+      <button onClick={onDelete} style={{ width: '100%', padding: '6px 0', background: '#5a1a1a', border: '1px solid #922', color: '#f88', cursor: 'pointer', borderRadius: 3, fontSize: 12, marginTop: 6 }}>
+        Delete Interactable
+      </button>
+    </div>
+  )
+}
+
 function TownInspector({
   configData, onResizeMap, onUpdateMapProps, onUpdateConfig, onPickLocation,
 }: {
@@ -1822,6 +1975,25 @@ export function EntityInspector({
             area={area}
             onMove={(tx, ty) => onMoveEntity(selectedEntity, tx, ty)}
             onUpdate={patch => onUpdateArea?.(selectedEntity.index, patch)}
+          />
+        </div>
+      </div>
+    )
+  }
+
+  if (selectedEntity.type === 'interactable') {
+    const it = (configData.interactables ?? [])[selectedEntity.index]
+    if (!it || !onUpdateInteractable) return null
+    return (
+      <div style={panelStyle}>
+        <div style={{ ...headerStyle, color: '#33ccee' }}>Interactable</div>
+        <div style={bodyStyle}>
+          <InteractableInspector
+            it={it}
+            onUpdate={patch => onUpdateInteractable(selectedEntity.index, patch)}
+            onMove={(tx, ty) => onMoveEntity(selectedEntity, tx, ty)}
+            onDelete={() => onDelete(selectedEntity)}
+            onPick={onPickLocation ? () => onPickLocation('interactable', selectedEntity.index) : undefined}
           />
         </div>
       </div>

--- a/web/src/components/mapEditor/EntityInspector.tsx
+++ b/web/src/components/mapEditor/EntityInspector.tsx
@@ -35,6 +35,7 @@ const COLS = 8
 const T = 32
 
 type InteriorExit = NonNullable<RawInterior['exits']>[number]
+type Treasure = NonNullable<RawMapConfig['treasures']>[number]
 
 export type GlowPatch = Partial<{ glow: boolean; glowRadius: number; pulse: boolean }>
 
@@ -72,6 +73,12 @@ interface Props {
   onUpdateNpc:           (index: number, partial: Partial<RawNpc>) => void
   onUpdateAnimal:        (index: number, partial: Partial<RawAnimal>) => void
   onUpdateTreasureTile?: (index: number, tileId: string) => void
+  onUpdateTreasure?:     (index: number, patch: Partial<Treasure>) => void
+  onUpdateInteractable?: (index: number, patch: Partial<RawInteractable>) => void
+  onUpdateConfig?:       (patch: Partial<RawMapConfig>) => void
+  onAddTreasure?:        () => void
+  onAddInteractable?:    () => void
+  onAddBlockedPath?:     () => void
   onUpdatePickupItemTile?: (index: number, tileId: string) => void
   onUpdateArea?:         (index: number, patch: Partial<{ name: string; tw: number; th: number }>) => void
   onResizeMap?:          (dir: 'n' | 's' | 'e' | 'w', grow: boolean) => void
@@ -1299,12 +1306,72 @@ function AreaInspector({
   )
 }
 
+function TreasureInspector({ treasure, onUpdate, onMove, onDelete, onPick }: {
+  treasure: Treasure
+  onUpdate: (patch: Partial<Treasure>) => void
+  onMove: (tx: number, ty: number) => void
+  onDelete: () => void
+  onPick?: () => void
+}) {
+  const [picking, setPicking] = useState<null | 'tile' | 'collected'>(null)
+  const inputStyle: React.CSSProperties = {
+    width: '100%', padding: '3px 5px', background: '#111', border: '1px solid #444',
+    color: '#eee', borderRadius: 3, fontSize: 11, boxSizing: 'border-box',
+  }
+  const reward = (treasure.reward ?? {}) as Record<string, unknown>
+  const crystals = typeof reward.crystals === 'number' ? reward.crystals : 0
+  return (
+    <div>
+      <Field label="ID">
+        <span style={{ fontFamily: 'monospace', fontSize: 11, color: '#aaa' }}>{treasure.id}</span>
+      </Field>
+      <Field label="Title">
+        <input style={inputStyle} value={treasure.title ?? ''} onChange={e => onUpdate({ title: e.target.value })} />
+      </Field>
+      <Field label="Tile">
+        <div onClick={() => setPicking(p => p === 'tile' ? null : 'tile')} style={{ cursor: 'pointer', display: 'inline-flex', alignItems: 'center', gap: 6 }}>
+          <TilePreview tileId={treasure.tileId} /><span style={{ fontSize: 10, color: '#666' }}>✎</span>
+        </div>
+        {picking === 'tile' && <TilePicker current={treasure.tileId} onChange={tileId => onUpdate({ tileId })} onClose={() => setPicking(null)} />}
+      </Field>
+      <Field label="Collected Tile">
+        <div onClick={() => setPicking(p => p === 'collected' ? null : 'collected')} style={{ cursor: 'pointer', display: 'inline-flex', alignItems: 'center', gap: 6 }}>
+          {treasure.collectedTileId ? <TilePreview tileId={treasure.collectedTileId} /> : <span style={{ color: '#888', fontSize: 11 }}>(none)</span>}
+          <span style={{ fontSize: 10, color: '#666' }}>✎</span>
+        </div>
+        {picking === 'collected' && <TilePicker current={treasure.collectedTileId ?? ''} onChange={tileId => onUpdate({ collectedTileId: tileId })} onClose={() => setPicking(null)} />}
+      </Field>
+      <Field label="Building (interior, optional)">
+        <input style={inputStyle} value={treasure.buildingId ?? ''} placeholder="building ID"
+          onChange={e => onUpdate({ buildingId: e.target.value || undefined })} />
+      </Field>
+      <Field label="Reward — crystals">
+        {numInput(crystals, n => onUpdate({ reward: { ...reward, crystals: n } }))}
+      </Field>
+      <Field label="Position">
+        <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+          <label style={{ fontSize: 11, color: '#888' }}>X</label>
+          {numInput(treasure.tx, tx => onMove(tx, treasure.ty))}
+          <label style={{ fontSize: 11, color: '#888' }}>Y</label>
+          {numInput(treasure.ty, ty => onMove(treasure.tx, ty))}
+        </div>
+        {onPick && <button style={BTN_PICK} onClick={onPick}>📍 Pick on map</button>}
+      </Field>
+      <button onClick={onDelete} style={{ width: '100%', padding: '6px 0', background: '#5a1a1a', border: '1px solid #922', color: '#f88', cursor: 'pointer', borderRadius: 3, fontSize: 12, marginTop: 4 }}>
+        Delete Treasure
+      </button>
+    </div>
+  )
+}
+
 function TownInspector({
-  configData, onResizeMap, onUpdateMapProps,
+  configData, onResizeMap, onUpdateMapProps, onUpdateConfig, onPickLocation,
 }: {
   configData: RawMapConfig
   onResizeMap: (dir: 'n' | 's' | 'e' | 'w', grow: boolean) => void
   onUpdateMapProps: (patch: { townName?: string; environment?: string }) => void
+  onUpdateConfig?: (patch: Partial<RawMapConfig>) => void
+  onPickLocation?: (kind: PickKind, index?: number) => void
 }) {
   const TILE = 32
   const tileW = configData.mapW / TILE
@@ -1376,6 +1443,8 @@ export function EntityInspector({
   onUpdateNpc, onUpdateAnimal,
   onUpdateTreasureTile, onUpdatePickupItemTile,
   onUpdateArea, onResizeMap, onUpdateMapProps, onPickLocation,
+  onUpdateTreasure, onUpdateInteractable, onUpdateConfig,
+  onAddTreasure, onAddInteractable, onAddBlockedPath,
 }: Props) {
   const panelStyle: React.CSSProperties = {
     display: 'flex', flexDirection: 'column', height: '100%',
@@ -1434,15 +1503,31 @@ export function EntityInspector({
   }
 
   if (!selectedEntity) {
+    const addBtn: React.CSSProperties = {
+      flex: 1, padding: '5px 6px', background: '#1e2a4e', border: '1px solid #3a4a8e',
+      color: '#8af', borderRadius: 3, fontSize: 11, cursor: 'pointer',
+    }
     return (
       <div style={panelStyle}>
         <div style={headerStyle}>Town</div>
         <div style={bodyStyle}>
+          {(onAddTreasure || onAddInteractable || onAddBlockedPath) && (
+            <div style={{ marginBottom: 12, paddingBottom: 12, borderBottom: '1px solid #333' }}>
+              <div style={{ color: '#888', fontSize: 10, marginBottom: 5, textTransform: 'uppercase', letterSpacing: 1 }}>Create object</div>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+                {onAddTreasure && <button style={addBtn} onClick={onAddTreasure}>+ Add Treasure</button>}
+                {onAddInteractable && <button style={addBtn} onClick={onAddInteractable}>+ Add Interactable</button>}
+                {onAddBlockedPath && <button style={addBtn} onClick={onAddBlockedPath}>+ Add Road Block</button>}
+              </div>
+            </div>
+          )}
           {onResizeMap && onUpdateMapProps ? (
             <TownInspector
               configData={configData}
               onResizeMap={onResizeMap}
               onUpdateMapProps={onUpdateMapProps}
+              onUpdateConfig={onUpdateConfig}
+              onPickLocation={onPickLocation}
             />
           ) : (
             <div style={{ color: '#555', fontSize: 11, marginTop: 20, textAlign: 'center' }}>
@@ -1546,17 +1631,22 @@ export function EntityInspector({
       <div style={panelStyle}>
         <div style={{ ...headerStyle, color: '#f0c040' }}>Treasure</div>
         <div style={bodyStyle}>
-          <QuestItemInspector
-            label="Treasure"
-            id={t.id}
-            tileId={t.tileId}
-            tx={t.tx}
-            ty={t.ty}
-            extra={t.title ? <Field label="Title"><span style={{ fontSize: 12 }}>{t.title}</span></Field> : undefined}
-            onMove={(tx, ty) => onMoveEntity(selectedEntity, tx, ty)}
-            onDelete={() => onDelete(selectedEntity)}
-            onTileChange={onUpdateTreasureTile ? tileId => onUpdateTreasureTile(selectedEntity.index, tileId) : undefined}
-          />
+          {onUpdateTreasure ? (
+            <TreasureInspector
+              treasure={t}
+              onUpdate={patch => onUpdateTreasure(selectedEntity.index, patch)}
+              onMove={(tx, ty) => onMoveEntity(selectedEntity, tx, ty)}
+              onDelete={() => onDelete(selectedEntity)}
+              onPick={onPickLocation ? () => onPickLocation('treasure', selectedEntity.index) : undefined}
+            />
+          ) : (
+            <QuestItemInspector
+              label="Treasure" id={t.id} tileId={t.tileId} tx={t.tx} ty={t.ty}
+              onMove={(tx, ty) => onMoveEntity(selectedEntity, tx, ty)}
+              onDelete={() => onDelete(selectedEntity)}
+              onTileChange={onUpdateTreasureTile ? tileId => onUpdateTreasureTile(selectedEntity.index, tileId) : undefined}
+            />
+          )}
         </div>
       </div>
     )

--- a/web/src/components/mapEditor/EntityInspector.tsx
+++ b/web/src/components/mapEditor/EntityInspector.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import type { SelectedEntity, RawMapConfig, RawInterior, RawBlockedPath, RawLockedDoor, Zlayer, RawDecorItem, RawNpc, RawBuilding, RawAnimal } from './mapEditorTypes'
+import type { SelectedEntity, RawMapConfig, RawInterior, RawBlockedPath, RawLockedDoor, Zlayer, RawDecorItem, RawNpc, RawBuilding, RawAnimal, RawInteractable, RawInteractableReaction, PickKind } from './mapEditorTypes'
 import { BASE_CHIP_TILES } from '../../data/tiles/baseChipIndex'
 import { resolveTileRef } from '../../data/tiles/tileIndex'
 import type { WallMaterial } from '../../data/tiles/buildingMaterials'
@@ -76,7 +76,7 @@ interface Props {
   onUpdateArea?:         (index: number, patch: Partial<{ name: string; tw: number; th: number }>) => void
   onResizeMap?:          (dir: 'n' | 's' | 'e' | 'w', grow: boolean) => void
   onUpdateMapProps?:     (patch: { townName?: string; environment?: string }) => void
-  onPickLocation?:       (kind: 'npc' | 'animal', index: number) => void
+  onPickLocation?:       (kind: PickKind, index?: number) => void
 }
 
 const BTN_PICK: React.CSSProperties = {

--- a/web/src/components/mapEditor/EntityInspector.tsx
+++ b/web/src/components/mapEditor/EntityInspector.tsx
@@ -1171,29 +1171,62 @@ function InteriorInspector({
   )
 }
 
+type PathDecor = { tx: number; ty: number; tileId: string }
+
+// Editable {tx,ty,tileId} decor list used for a blocked path's blocked/cleared states.
+function PathDecorEditor({ label, decor, anchor, onChange }: {
+  label: string
+  decor: PathDecor[]
+  anchor: [number, number]
+  onChange: (d: PathDecor[]) => void
+}) {
+  const [pickingIdx, setPickingIdx] = useState<number | null>(null)
+  const numSm: React.CSSProperties = { width: 40, padding: '2px 4px', background: '#111', border: '1px solid #444', color: '#eee', borderRadius: 3, fontSize: 11 }
+  return (
+    <Field label={label}>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+        {decor.map((d, i) => (
+          <div key={i} style={{ background: '#16161e', border: '1px solid #2a2a3a', borderRadius: 3, padding: 4 }}>
+            <div style={{ display: 'flex', gap: 4, alignItems: 'center' }}>
+              <div onClick={() => setPickingIdx(p => p === i ? null : i)} style={{ cursor: 'pointer', display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+                <TilePreview tileId={d.tileId} /><span style={{ fontSize: 10, color: '#666' }}>✎</span>
+              </div>
+              <label style={{ fontSize: 9, color: '#888' }}>X</label>
+              <input type="number" value={d.tx} style={numSm} onChange={e => onChange(decor.map((x, j) => j === i ? { ...x, tx: Number(e.target.value) } : x))} />
+              <label style={{ fontSize: 9, color: '#888' }}>Y</label>
+              <input type="number" value={d.ty} style={numSm} onChange={e => onChange(decor.map((x, j) => j === i ? { ...x, ty: Number(e.target.value) } : x))} />
+              <button style={{ marginLeft: 'auto', padding: '1px 5px', background: '#4a1a1a', border: '1px solid #922', color: '#f88', borderRadius: 3, fontSize: 10, cursor: 'pointer' }}
+                onClick={() => onChange(decor.filter((_, j) => j !== i))}>✕</button>
+            </div>
+            {pickingIdx === i && <TilePicker current={d.tileId} onChange={tileId => onChange(decor.map((x, j) => j === i ? { ...x, tileId } : x))} onClose={() => setPickingIdx(null)} />}
+          </div>
+        ))}
+        <button style={{ padding: '2px 8px', background: '#1e2e1e', border: '1px solid #3a5a3a', color: '#6d6', borderRadius: 3, fontSize: 10, cursor: 'pointer', alignSelf: 'flex-start' }}
+          onClick={() => onChange([...decor, { tx: anchor[0], ty: anchor[1], tileId: 'barrel' }])}>+ Add decor</button>
+      </div>
+    </Field>
+  )
+}
+
 function BlockedPathInspector({
-  bp, onUpdate, onDelete,
+  bp, onUpdate, onDelete, onPick,
 }: {
   bp: RawBlockedPath
   onUpdate: (patch: Partial<RawBlockedPath>) => void
   onDelete: () => void
+  onPick?: () => void
 }) {
-  const [editQuestId, setEditQuestId] = useState(bp.questId)
+  const anchor = bp.blockedTiles[0] ?? [0, 0]
   return (
     <div>
       <Field label="ID"><span style={{ fontFamily: 'monospace', fontSize: 11, color: '#aaa' }}>{bp.id}</span></Field>
-      <Field label="Quest ID">
-        <div style={{ display: 'flex', gap: 4 }}>
-          <input
-            value={editQuestId}
-            onChange={e => setEditQuestId(e.target.value)}
-            style={{ flex: 1, padding: '3px 5px', background: '#111', border: '1px solid #444', color: '#eee', borderRadius: 3, fontSize: 11, fontFamily: 'monospace' }}
-          />
-          <button
-            onClick={() => onUpdate({ questId: editQuestId })}
-            style={{ padding: '3px 7px', background: '#1a3a1a', border: '1px solid #3a6a3a', color: '#8d8', borderRadius: 3, fontSize: 11, cursor: 'pointer' }}
-          >✓</button>
-        </div>
+      <Field label="Quest ID (cleared when complete)">
+        <input
+          value={bp.questId}
+          onChange={e => onUpdate({ questId: e.target.value })}
+          placeholder="quest id"
+          style={{ width: '100%', padding: '3px 5px', background: '#111', border: '1px solid #444', color: '#eee', borderRadius: 3, fontSize: 11, fontFamily: 'monospace', boxSizing: 'border-box' }}
+        />
       </Field>
       <Field label={`Blocked Tiles (${bp.blockedTiles.length})`}>
         <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
@@ -1207,21 +1240,12 @@ function BlockedPathInspector({
             </div>
           ))}
         </div>
+        {onPick && <button style={BTN_PICK} onClick={onPick}>📍 Add tile from map</button>}
       </Field>
-      {bp.blocked.decor && bp.blocked.decor.length > 0 && (
-        <Field label="Blocked Decor">
-          {bp.blocked.decor.map((d, i) => (
-            <div key={i} style={{ fontFamily: 'monospace', fontSize: 10, color: '#888' }}>[{d.tx},{d.ty}] {d.tileId}</div>
-          ))}
-        </Field>
-      )}
-      {bp.cleared.decor && bp.cleared.decor.length > 0 && (
-        <Field label="Cleared Decor">
-          {bp.cleared.decor.map((d, i) => (
-            <div key={i} style={{ fontFamily: 'monospace', fontSize: 10, color: '#888' }}>[{d.tx},{d.ty}] {d.tileId}</div>
-          ))}
-        </Field>
-      )}
+      <PathDecorEditor label="Blocked Decor (shown while blocked)" decor={(bp.blocked.decor ?? []) as PathDecor[]} anchor={anchor as [number, number]}
+        onChange={d => onUpdate({ blocked: { ...bp.blocked, decor: d } })} />
+      <PathDecorEditor label="Cleared Decor (shown once cleared)" decor={(bp.cleared.decor ?? []) as PathDecor[]} anchor={anchor as [number, number]}
+        onChange={d => onUpdate({ cleared: { ...bp.cleared, decor: d } })} />
       <button
         onClick={onDelete}
         style={{ marginTop: 8, padding: '4px 10px', background: '#4a1a1a', border: '1px solid #922', color: '#f88', borderRadius: 3, fontSize: 11, cursor: 'pointer' }}
@@ -1762,6 +1786,7 @@ export function EntityInspector({
             bp={bp}
             onUpdate={patch => onUpdateBlockedPath(selectedEntity.index, patch)}
             onDelete={() => onDeleteBlockedPath(selectedEntity.index)}
+            onPick={onPickLocation ? () => onPickLocation('blockedTile', selectedEntity.index) : undefined}
           />
         </div>
       </div>

--- a/web/src/components/mapEditor/MapEditor.tsx
+++ b/web/src/components/mapEditor/MapEditor.tsx
@@ -245,6 +245,7 @@ export function MapEditor({ initialMapId = 'ravenwatch' }: Props) {
         showQuestItems={showQuestItems}
         showBlockedPaths={showBlockedPaths}
         showAreas={showAreas}
+        showInteractables={showInteractables}
         drawerOpen={drawerOpen}
         hasDuplicateQuestIds={hasDuplicateQuestIds}
         configData={state.configData}
@@ -256,6 +257,7 @@ export function MapEditor({ initialMapId = 'ravenwatch' }: Props) {
         onQuestItemsToggle={() => setShowQuestItems(q => !q)}
         onBlockedPathsToggle={() => setShowBlockedPaths(b => !b)}
         onAreasToggle={() => setShowAreas(a => !a)}
+        onInteractablesToggle={() => setShowInteractables(i => !i)}
         onDrawerToggle={() => setDrawerOpen(o => !o)}
         questDefsData={questDefsData as Record<string, unknown> | null}
         onSaved={markSaved}
@@ -297,6 +299,7 @@ export function MapEditor({ initialMapId = 'ravenwatch' }: Props) {
             showQuestItems={showQuestItems}
             showBlockedPaths={showBlockedPaths}
             showAreas={showAreas}
+            showInteractables={showInteractables}
             blockedPaths={(questDefsData?.blockedPaths as RawBlockedPath[]) ?? []}
             selectedEntity={state.selectedEntity}
             viewMode={state.viewMode}

--- a/web/src/components/mapEditor/MapEditor.tsx
+++ b/web/src/components/mapEditor/MapEditor.tsx
@@ -8,7 +8,7 @@ import type { MapId,  QuestDefsJson } from '../../data/hub/hubWorldFactory'
 import  {  QUEST_DEFS_BY_MAP } from '../../data/hub/hubWorldFactory'
 
 import { SelectedEntity } from './mapEditorTypes'
-import type { RawBlockedPath, PickKind } from './mapEditorTypes'
+import type { RawBlockedPath, RawInteractable, PickKind } from './mapEditorTypes'
 import { NpcQuestDrawer } from './npcQuestDrawer/NpcQuestDrawer'
 import type { DrawerTab } from './npcQuestDrawer/npcQuestDrawerTypes'
 
@@ -22,6 +22,7 @@ export function MapEditor({ initialMapId = 'ravenwatch' }: Props) {
   const [showQuestItems, setShowQuestItems] = useState(false)
   const [showBlockedPaths, setShowBlockedPaths] = useState(false)
   const [showAreas, setShowAreas] = useState(false)
+  const [showInteractables, setShowInteractables] = useState(false)
   const [questDefsData, setQuestDefsData] = useState<QuestDefsJson | null>(
     () => QUEST_DEFS_BY_MAP[initialMapId] ? structuredClone(QUEST_DEFS_BY_MAP[initialMapId]!) : null,
   )
@@ -155,6 +156,46 @@ export function MapEditor({ initialMapId = 'ravenwatch' }: Props) {
     }
     setPick(null)
   }, [pick, state.configData, state.viewMode, state.activeInteriorId, updateNpc, updateAnimal, updateTreasure, updateConfig])
+
+  // Create handlers — drop a new object at map centre, reveal its overlay, and select it.
+  const centreTile = useCallback(() => ({
+    tx: Math.floor(state.configData.mapW / 32 / 2),
+    ty: Math.floor(state.configData.mapH / 32 / 2),
+  }), [state.configData.mapW, state.configData.mapH])
+
+  const handleAddTreasure = useCallback(() => {
+    const { tx, ty } = centreTile()
+    const list = state.configData.treasures ?? []
+    updateConfig({ treasures: [...list, { id: `treasure-${Date.now()}`, tx, ty, tileId: 'chest', collectedTileId: 'openChest', title: 'New treasure', reward: { crystals: 10 } }] })
+    setShowQuestItems(true)
+    selectEntity({ type: 'treasure', index: list.length })
+  }, [centreTile, state.configData.treasures, updateConfig, selectEntity])
+
+  const handleAddInteractable = useCallback(() => {
+    const { tx, ty } = centreTile()
+    const list = state.configData.interactables ?? []
+    updateConfig({ interactables: [...list, { id: `interactable-${Date.now()}`, tx, ty, reactions: [{ type: 'screen', screen: '' }] }] })
+    setShowInteractables(true)
+    selectEntity({ type: 'interactable', index: list.length })
+  }, [centreTile, state.configData.interactables, updateConfig, selectEntity])
+
+  const handleAddBlockedPath = useCallback(() => {
+    const { tx, ty } = centreTile()
+    const list = (questDefsData?.blockedPaths as RawBlockedPath[]) ?? []
+    setQuestDefsData(prev => prev ? {
+      ...prev,
+      blockedPaths: [...((prev.blockedPaths as RawBlockedPath[]) ?? []), {
+        id: `block-${Date.now()}`, blockedTiles: [[tx, ty]], questId: '',
+        blocked: { decor: [] }, cleared: { decor: [] },
+      }],
+    } : prev)
+    setShowBlockedPaths(true)
+    selectEntity({ type: 'blockedPath', index: list.length })
+  }, [centreTile, questDefsData, selectEntity])
+
+  const handleUpdateInteractable = useCallback((index: number, patch: Partial<RawInteractable>) => {
+    updateConfig({ interactables: (state.configData.interactables ?? []).map((it, i) => i === index ? { ...it, ...patch } : it) })
+  }, [state.configData.interactables, updateConfig])
 
   const handleUpdateBlockedPath = useCallback((index: number, patch: Partial<RawBlockedPath>) => {
     setQuestDefsData(prev => {
@@ -327,6 +368,12 @@ export function MapEditor({ initialMapId = 'ravenwatch' }: Props) {
                 items[index] = { ...items[index], tileId }
                 return { ...prev, pickupItems: items }
               })}
+              onUpdateTreasure={updateTreasure}
+              onUpdateInteractable={handleUpdateInteractable}
+              onUpdateConfig={updateConfig}
+              onAddTreasure={handleAddTreasure}
+              onAddInteractable={handleAddInteractable}
+              onAddBlockedPath={handleAddBlockedPath}
             />
           </div>
         </div>

--- a/web/src/components/mapEditor/MapEditor.tsx
+++ b/web/src/components/mapEditor/MapEditor.tsx
@@ -8,7 +8,7 @@ import type { MapId,  QuestDefsJson } from '../../data/hub/hubWorldFactory'
 import  {  QUEST_DEFS_BY_MAP } from '../../data/hub/hubWorldFactory'
 
 import { SelectedEntity } from './mapEditorTypes'
-import type { RawBlockedPath } from './mapEditorTypes'
+import type { RawBlockedPath, PickKind } from './mapEditorTypes'
 import { NpcQuestDrawer } from './npcQuestDrawer/NpcQuestDrawer'
 import type { DrawerTab } from './npcQuestDrawer/npcQuestDrawerTypes'
 
@@ -30,7 +30,7 @@ export function MapEditor({ initialMapId = 'ravenwatch' }: Props) {
   const [drawerHeight, setDrawerHeight] = useState(280)
   const [focusedNpcIndex, setFocusedNpcIndex] = useState<number | null>(null)
   // When set, the next canvas tile click places this NPC/animal there.
-  const [pick, setPick] = useState<{ kind: 'npc' | 'animal'; index: number } | null>(null)
+  const [pick, setPick] = useState<{ kind: PickKind; index: number } | null>(null)
   const drawerDragRef = useRef<{ startY: number; startH: number } | null>(null)
 
   const {
@@ -39,7 +39,7 @@ export function MapEditor({ initialMapId = 'ravenwatch' }: Props) {
     placeDecor, moveEntity, deleteEntity,
     updateDecorZlayer, updateGlow, updateDecorMinLevel, updateBuilding, addNpc, updateNpcDialogue, updateNpc,
     addAnimal, updateAnimal,
-    updateTreasure,
+    updateTreasure, updateConfig,
     updateArea, updateMapProps, resizeMap,
     resizeInterior, addInterior, addInteriorExit, updateInteriorProps, updateInteriorExit, removeInteriorExit,
     addStreet, updateStreetEntry,
@@ -117,20 +117,44 @@ export function MapEditor({ initialMapId = 'ravenwatch' }: Props) {
     }
   }, [deleteEntity, selectEntity])
 
-  // Enter "pick a tile" mode for an NPC/animal; the next canvas click sets its location.
-  const handlePickLocation = useCallback((kind: 'npc' | 'animal', index: number) => {
+  // Enter "pick a tile" mode for an entity; the next canvas click sets its location.
+  const handlePickLocation = useCallback((kind: PickKind, index = 0) => {
     setPick({ kind, index })
   }, [])
 
   const handlePickTile = useCallback((tx: number, ty: number) => {
     if (!pick) return
+    const cfg = state.configData
     // Inside an interior the coords are interior-local and the building is recorded;
     // in the exterior the building association is cleared.
     const building = state.viewMode === 'interior' ? (state.activeInteriorId ?? undefined) : undefined
-    if (pick.kind === 'npc') updateNpc(pick.index, { tx, ty, building })
-    else updateAnimal(pick.index, { tx, ty, building })
+    switch (pick.kind) {
+      case 'npc':    updateNpc(pick.index, { tx, ty, building }); break
+      case 'animal': updateAnimal(pick.index, { tx, ty, building }); break
+      case 'treasure': updateTreasure(pick.index, { tx, ty }); break
+      case 'interactable':
+        updateConfig({ interactables: (cfg.interactables ?? []).map((it, i) => i === pick.index ? { ...it, tx, ty } : it) })
+        break
+      case 'exitTile':
+        updateConfig({ exitTiles: (cfg.exitTiles ?? []).map((e, i) => i === pick.index ? { ...e, tx, ty } : e) })
+        break
+      case 'avatarStart':
+        updateConfig({ avatarStart: { tx, ty } })
+        break
+      case 'blockedTile':
+        setQuestDefsData(prev => {
+          if (!prev) return prev
+          const paths = [...((prev.blockedPaths as RawBlockedPath[]) ?? [])]
+          const bp = paths[pick.index]
+          if (!bp) return prev
+          if (bp.blockedTiles.some(([x, y]) => x === tx && y === ty)) return prev
+          paths[pick.index] = { ...bp, blockedTiles: [...bp.blockedTiles, [tx, ty]] }
+          return { ...prev, blockedPaths: paths }
+        })
+        break
+    }
     setPick(null)
-  }, [pick, state.viewMode, state.activeInteriorId, updateNpc, updateAnimal])
+  }, [pick, state.configData, state.viewMode, state.activeInteriorId, updateNpc, updateAnimal, updateTreasure, updateConfig])
 
   const handleUpdateBlockedPath = useCallback((index: number, patch: Partial<RawBlockedPath>) => {
     setQuestDefsData(prev => {

--- a/web/src/components/mapEditor/MapEditorCanvas.tsx
+++ b/web/src/components/mapEditor/MapEditorCanvas.tsx
@@ -95,6 +95,7 @@ interface Props {
   showQuestItems:     boolean
   showBlockedPaths:   boolean
   showAreas:          boolean
+  showInteractables:  boolean
   blockedPaths:       RawBlockedPath[]
   questPickupItems:   RawQuestPickupItem[]
 }
@@ -102,7 +103,7 @@ interface Props {
 export function MapEditorCanvas(props: Props) {
   const {
     configData, tool, showGrid, selectedEntity, viewMode, activeInteriorId, activeLevel,
-    activeTileId, activeBundleId, activeZlayer, pickActive, showQuestItems, showBlockedPaths, showAreas, blockedPaths, questPickupItems,
+    activeTileId, activeBundleId, activeZlayer, pickActive, showQuestItems, showBlockedPaths, showAreas, showInteractables, blockedPaths, questPickupItems,
     onSelectEntity, onPlaceDecor, onMoveEntity, onDeleteEntity, onAddStreet,
   } = props
 
@@ -283,6 +284,9 @@ export function MapEditorCanvas(props: Props) {
     }
     if (!isInterior && showAreas) {
       renderAreasOverlay(questLayer, selLayer)
+    }
+    if (showInteractables) {
+      renderInteractablesOverlay(version, questLayer, selLayer)
     }
 
     if (showGrid) drawGrid(gridLayer)
@@ -896,6 +900,47 @@ export function MapEditorCanvas(props: Props) {
       layer.addChild(gfx)
       const lbl = new PIXI.Text({ text: area.name, style: { fontSize: 9, fill: isSel ? 0xf0c040 : 0xaa66ff } })
       lbl.x = area.tx * T + 4; lbl.y = area.ty * T + 4
+      layer.addChild(lbl)
+    })
+  }
+
+  // ── Interactables overlay ──────────────────────────────────────────────────────
+  function renderInteractablesOverlay(version: number, layer: PIXI.Container, selLayer: PIXI.Graphics) {
+    const { configData: cfg, selectedEntity: sel } = propsRef.current
+    const iid = activeInteriorId ?? ''
+    ;(cfg.interactables ?? []).forEach((it, idx) => {
+      // Exterior view shows world interactables; interior view shows those owned by the open room.
+      if (isInterior ? it.building !== iid : !!it.building) return
+      const isSel = sel?.type === 'interactable' && sel.index === idx
+      // Render the owned decor tiles (so the object is visible like in-game).
+      for (const d of it.decor ?? []) {
+        const numId = tileNumericId(d.tileId)
+        loadTileRef(numId).then(tex => {
+          if (renderVersionRef.current !== version) return
+          const sp = new PIXI.Sprite(tex)
+          sp.x = (it.tx + d.dx) * T; sp.y = (it.ty + d.dy) * T
+          sp.width = T; sp.height = T
+          layer.addChild(sp)
+        }).catch(() => {})
+      }
+      // Hit-rect box (purple) + click target.
+      const w = it.hitRect?.w ?? (it.decor && it.decor.length ? Math.max(...it.decor.map(d => d.dx)) + 1 : 1)
+      const h = it.hitRect?.h ?? (it.decor && it.decor.length ? Math.max(...it.decor.map(d => d.dy)) + 1 : 1)
+      const gfx = new PIXI.Graphics()
+      gfx.rect(it.tx * T, it.ty * T, w * T, h * T)
+        .fill({ color: 0x33bbee, alpha: 0.10 })
+        .stroke({ color: isSel ? 0xf0c040 : 0x33bbee, width: isSel ? 2 : 1 })
+      gfx.eventMode = 'static'; gfx.cursor = 'pointer'
+      gfx.on('pointerdown', (e: PIXI.FederatedPointerEvent) => {
+        e.stopPropagation()
+        const entity: SelectedEntity = { type: 'interactable', index: idx }
+        propsRef.current.onSelectEntity(entity)
+        if (propsRef.current.tool === 'select')
+          dragRef.current = { entity, lastTx: it.tx, lastTy: it.ty, offsetX: 0, offsetY: 0 }
+      })
+      layer.addChild(gfx)
+      const lbl = new PIXI.Text({ text: it.id, style: { fontSize: 8, fill: isSel ? 0xf0c040 : 0x66ccff } })
+      lbl.x = it.tx * T + 2; lbl.y = it.ty * T + 2
       layer.addChild(lbl)
     })
   }

--- a/web/src/components/mapEditor/MapEditorToolbar.tsx
+++ b/web/src/components/mapEditor/MapEditorToolbar.tsx
@@ -30,6 +30,7 @@ interface Props {
   showQuestItems:       boolean
   showBlockedPaths:     boolean
   showAreas:            boolean
+  showInteractables:    boolean
   drawerOpen:           boolean
   hasDuplicateQuestIds: boolean
   configData:           RawMapConfig
@@ -41,6 +42,7 @@ interface Props {
   onQuestItemsToggle:   () => void
   onBlockedPathsToggle: () => void
   onAreasToggle:        () => void
+  onInteractablesToggle: () => void
   onDrawerToggle:       () => void
   questDefsData:        Record<string, unknown> | null
   onSaved:              () => void
@@ -54,9 +56,9 @@ const TOOLS: { mode: ToolMode; label: string; title: string }[] = [
 ]
 
 export function MapEditorToolbar({
-  mapId, tool, canUndo, canRedo, isDirty, showGrid, showQuestItems, showBlockedPaths, showAreas, drawerOpen, hasDuplicateQuestIds,
+  mapId, tool, canUndo, canRedo, isDirty, showGrid, showQuestItems, showBlockedPaths, showAreas, showInteractables, drawerOpen, hasDuplicateQuestIds,
   configData, questDefsData, onMapChange, onToolChange, onUndo, onRedo,
-  onGridToggle, onQuestItemsToggle, onBlockedPathsToggle, onAreasToggle, onDrawerToggle, onSaved,
+  onGridToggle, onQuestItemsToggle, onBlockedPathsToggle, onAreasToggle, onInteractablesToggle, onDrawerToggle, onSaved,
 }: Props) {
   const [saveState, setSaveState] = useState<'idle' | 'saving' | 'ok' | 'error'>('idle')
   const [saveError, setSaveError] = useState('')
@@ -197,6 +199,20 @@ export function MapEditorToolbar({
         }}
       >
         ▣
+      </button>
+
+      {/* Interactables overlay toggle */}
+      <button
+        title="Toggle interactables (notice boards, signs…)"
+        onClick={onInteractablesToggle}
+        style={{
+          ...btnBase,
+          background:  showInteractables ? '#0e2a2e' : '#1e1e3e',
+          color:       showInteractables ? '#33ccee' : '#666',
+          borderColor: showInteractables ? '#1a6a7a' : '#444',
+        }}
+      >
+        ⊡
       </button>
 
       {/* NPC & Quest drawer toggle */}

--- a/web/src/components/mapEditor/mapEditorTypes.ts
+++ b/web/src/components/mapEditor/mapEditorTypes.ts
@@ -7,6 +7,10 @@ export type ToolMode = 'select' | 'place' | 'delete' | 'street'
 export type Zlayer = 'solid' | 'below' | 'above'
 export type ViewMode = 'exterior' | 'interior'
 
+// Entity kinds whose location can be set by clicking the map ("pick on map").
+export type PickKind =
+  | 'npc' | 'animal' | 'treasure' | 'interactable' | 'exitTile' | 'avatarStart' | 'blockedTile'
+
 
 // Raw JSON shapes — matches what config.json actually stores
 export interface RawDecorItem {
@@ -126,12 +130,62 @@ export interface RawLockedDoor {
   lockedBy: string
 }
 
+// Interactable objects (notice boards, signs, levers…) — `reactions` fire when
+// the player interacts. Mirrors RawInteractable in data/hub/config.ts.
+export interface RawInteractableDecor {
+  dx: number
+  dy: number
+  tileId: string
+  zlayer?: string
+}
+
+export interface RawInteractableReaction {
+  type: string   // 'dialogue' | 'screen' | 'giveItem' | 'quest' | 'move'
+  // dialogue
+  speakerName?: string
+  text?: string | string[]
+  // screen
+  screen?: string
+  // giveItem
+  collectible?: { id: string; name: string; icon: string; desc: string }
+  consumables?: Array<{ id: string; quantity: number }>
+  crystals?: number
+  message?: string
+  alreadyGrantedText?: string
+  // quest
+  questId?: string
+  // move
+  to?: { tx: number; ty: number }
+}
+
+export interface RawInteractable {
+  id: string
+  tx: number
+  ty: number
+  building?: string
+  decor?: RawInteractableDecor[]
+  hitRect?: { w: number; h: number }
+  indicator?: { condition: string; dx?: number; dy?: number }
+  reactions: RawInteractableReaction[]
+}
+
+export interface RawChickenZone {
+  rect: [number, number, number, number]
+  count?: number
+  roost?: [number, number]
+}
+
+export interface RawWeather {
+  type?: string
+  bySeason?: Record<string, string>
+}
+
 export interface RawMapConfig {
   mapW: number
   mapH: number
   townName: string
   environment?: string
-  weather?: unknown
+  weather?: RawWeather
   avatarStart: { tx: number; ty: number }
   exitTiles?: Array<{ tx: number; ty: number; screen: string }>
   areas?: Array<{ id: string; name: string; tx: number; ty: number; tw: number; th: number }>
@@ -170,6 +224,8 @@ export interface RawMapConfig {
   }>
   blockedPaths?: unknown[]
   lockedDoors?: RawLockedDoor[]
+  interactables?: RawInteractable[]
+  chickenZones?: RawChickenZone[]
 }
 
 export type SelectedEntity =
@@ -185,6 +241,9 @@ export type SelectedEntity =
   | { type: 'lockedDoor'; index: number }
   | { type: 'animal'; index: number }
   | { type: 'area'; index: number }
+  | { type: 'interactable'; index: number }
+  | { type: 'exitTile'; index: number }
+  | { type: 'chickenZone'; index: number }
 
 export interface MapEditorState {
   mapId: MapId

--- a/web/src/components/mapEditor/npcQuestDrawer/DialogueEditor.tsx
+++ b/web/src/components/mapEditor/npcQuestDrawer/DialogueEditor.tsx
@@ -1,0 +1,173 @@
+import React, { useState } from 'react'
+import type { QuestDefsJson } from '../../../data/hub/hubWorldFactory'
+
+interface Props {
+  questDefsData: QuestDefsJson
+  onQuestDefsChange: (updater: (prev: QuestDefsJson) => QuestDefsJson) => void
+}
+
+const INPUT: React.CSSProperties = {
+  width: '100%', padding: '3px 6px', background: '#111', border: '1px solid #444',
+  color: '#eee', borderRadius: 3, fontSize: 11, boxSizing: 'border-box',
+}
+const BTN_ADD: React.CSSProperties = {
+  padding: '3px 10px', background: '#1e2e1e', border: '1px solid #3a5a3a',
+  color: '#6d6', borderRadius: 3, fontSize: 11, cursor: 'pointer', alignSelf: 'flex-start',
+}
+const BTN_X: React.CSSProperties = {
+  padding: '1px 6px', background: '#4a1a1a', border: '1px solid #922', color: '#f88', borderRadius: 3, fontSize: 10, cursor: 'pointer',
+}
+
+function Section({ title, color, children }: { title: string; color: string; children: React.ReactNode }) {
+  const [open, setOpen] = useState(false)
+  return (
+    <div style={{ marginBottom: 8, border: '1px solid #2a2a4a', borderRadius: 4 }}>
+      <div onClick={() => setOpen(o => !o)} style={{ padding: '6px 8px', cursor: 'pointer', display: 'flex', justifyContent: 'space-between', background: '#1a1a2e', color }}>
+        <span style={{ fontSize: 12, fontWeight: 'bold' }}>{title}</span>
+        <span style={{ color: '#666' }}>{open ? '▾' : '▸'}</span>
+      </div>
+      {open && <div style={{ padding: 8 }}>{children}</div>}
+    </div>
+  )
+}
+
+// friendshipDialogue: { npcId: { tier: line } }
+function FriendshipEditor({ data, onChange }: { data: Record<string, Record<string, string>>; onChange: (d: Record<string, Record<string, string>>) => void }) {
+  const npcs = Object.entries(data)
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+      {npcs.map(([npcId, tiers]) => (
+        <div key={npcId} style={{ background: '#16161e', border: '1px solid #2a2a3a', borderRadius: 3, padding: 6 }}>
+          <div style={{ display: 'flex', gap: 4, marginBottom: 4 }}>
+            <input style={{ ...INPUT, fontFamily: 'monospace' }} value={npcId} onChange={e => {
+              const next = { ...data }; delete next[npcId]; next[e.target.value] = tiers; onChange(next)
+            }} />
+            <button style={BTN_X} onClick={() => { const next = { ...data }; delete next[npcId]; onChange(next) }}>✕</button>
+          </div>
+          {Object.entries(tiers).map(([tier, line]) => (
+            <div key={tier} style={{ display: 'flex', gap: 4, marginBottom: 3, alignItems: 'flex-start' }}>
+              <input style={{ ...INPUT, width: 40, flex: '0 0 40px' }} value={tier} onChange={e => {
+                const nt = { ...tiers }; delete nt[tier]; nt[e.target.value] = line; onChange({ ...data, [npcId]: nt })
+              }} />
+              <textarea style={{ ...INPUT, resize: 'vertical', fontFamily: 'inherit' }} rows={2} value={line} onChange={e => onChange({ ...data, [npcId]: { ...tiers, [tier]: e.target.value } })} />
+              <button style={BTN_X} onClick={() => { const nt = { ...tiers }; delete nt[tier]; onChange({ ...data, [npcId]: nt }) }}>✕</button>
+            </div>
+          ))}
+          <button style={{ ...BTN_ADD, fontSize: 10, padding: '1px 8px' }} onClick={() => onChange({ ...data, [npcId]: { ...tiers, '2': '' } })}>+ tier line</button>
+        </div>
+      ))}
+      <button style={BTN_ADD} onClick={() => onChange({ ...data, '': {} })}>+ Add NPC</button>
+    </div>
+  )
+}
+
+// relationshipDialogue: { npcId: { relType: { tier: line } } }
+function RelationshipEditor({ data, onChange }: { data: Record<string, Record<string, Record<string, string>>>; onChange: (d: Record<string, Record<string, Record<string, string>>>) => void }) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+      {Object.entries(data).map(([npcId, rels]) => (
+        <div key={npcId} style={{ background: '#16161e', border: '1px solid #2a2a3a', borderRadius: 3, padding: 6 }}>
+          <div style={{ display: 'flex', gap: 4, marginBottom: 4 }}>
+            <input style={{ ...INPUT, fontFamily: 'monospace' }} value={npcId} onChange={e => { const next = { ...data }; delete next[npcId]; next[e.target.value] = rels; onChange(next) }} />
+            <button style={BTN_X} onClick={() => { const next = { ...data }; delete next[npcId]; onChange(next) }}>✕</button>
+          </div>
+          {Object.entries(rels).map(([relType, tiers]) => (
+            <div key={relType} style={{ marginLeft: 6, marginBottom: 4, borderLeft: '2px solid #3a3a5a', paddingLeft: 6 }}>
+              <div style={{ display: 'flex', gap: 4, marginBottom: 2 }}>
+                <input style={{ ...INPUT, width: 80, flex: '0 0 80px' }} value={relType} onChange={e => { const nr = { ...rels }; delete nr[relType]; nr[e.target.value] = tiers; onChange({ ...data, [npcId]: nr }) }} />
+                <button style={BTN_X} onClick={() => { const nr = { ...rels }; delete nr[relType]; onChange({ ...data, [npcId]: nr }) }}>✕</button>
+              </div>
+              {Object.entries(tiers).map(([tier, line]) => (
+                <div key={tier} style={{ display: 'flex', gap: 4, marginBottom: 2 }}>
+                  <input style={{ ...INPUT, width: 36, flex: '0 0 36px' }} value={tier} onChange={e => { const nt = { ...tiers }; delete nt[tier]; nt[e.target.value] = line; onChange({ ...data, [npcId]: { ...rels, [relType]: nt } }) }} />
+                  <textarea style={{ ...INPUT, resize: 'vertical', fontFamily: 'inherit' }} rows={2} value={line} onChange={e => onChange({ ...data, [npcId]: { ...rels, [relType]: { ...tiers, [tier]: e.target.value } } })} />
+                </div>
+              ))}
+              <button style={{ ...BTN_ADD, fontSize: 10, padding: '1px 8px' }} onClick={() => onChange({ ...data, [npcId]: { ...rels, [relType]: { ...tiers, '2': '' } } })}>+ tier</button>
+            </div>
+          ))}
+          <button style={{ ...BTN_ADD, fontSize: 10, padding: '1px 8px' }} onClick={() => onChange({ ...data, [npcId]: { ...rels, ally: {} } })}>+ relationship</button>
+        </div>
+      ))}
+      <button style={BTN_ADD} onClick={() => onChange({ ...data, '': {} })}>+ Add NPC</button>
+    </div>
+  )
+}
+
+// innRumours: [{ id, text }]
+function RumoursEditor({ data, onChange }: { data: Array<{ id: string; text: string }>; onChange: (d: Array<{ id: string; text: string }>) => void }) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+      {data.map((r, i) => (
+        <div key={i} style={{ display: 'flex', gap: 4, alignItems: 'flex-start' }}>
+          <input style={{ ...INPUT, width: 90, flex: '0 0 90px', fontFamily: 'monospace' }} value={r.id} onChange={e => onChange(data.map((x, j) => j === i ? { ...x, id: e.target.value } : x))} />
+          <textarea style={{ ...INPUT, resize: 'vertical', fontFamily: 'inherit' }} rows={2} value={r.text} onChange={e => onChange(data.map((x, j) => j === i ? { ...x, text: e.target.value } : x))} />
+          <button style={BTN_X} onClick={() => onChange(data.filter((_, j) => j !== i))}>✕</button>
+        </div>
+      ))}
+      <button style={BTN_ADD} onClick={() => onChange([...data, { id: '', text: '' }])}>+ Add rumour</button>
+    </div>
+  )
+}
+
+// dialogues: [{ id, npcId, start, nodes }] — fields + JSON node editor.
+function DialogueTreeRow({ dlg, onChange, onDelete }: { dlg: Record<string, unknown>; onChange: (d: Record<string, unknown>) => void; onDelete: () => void }) {
+  const [nodesText, setNodesText] = useState(() => JSON.stringify(dlg.nodes ?? {}, null, 1))
+  const [err, setErr] = useState('')
+  return (
+    <div style={{ background: '#16161e', border: '1px solid #2a2a3a', borderRadius: 3, padding: 6, marginBottom: 6 }}>
+      <div style={{ display: 'flex', gap: 4, marginBottom: 4 }}>
+        <input style={INPUT} placeholder="id" value={String(dlg.id ?? '')} onChange={e => onChange({ ...dlg, id: e.target.value })} />
+        <input style={INPUT} placeholder="npcId" value={String(dlg.npcId ?? '')} onChange={e => onChange({ ...dlg, npcId: e.target.value })} />
+        <input style={{ ...INPUT, width: 70, flex: '0 0 70px' }} placeholder="start" value={String(dlg.start ?? '')} onChange={e => onChange({ ...dlg, start: e.target.value })} />
+        <button style={BTN_X} onClick={onDelete}>✕</button>
+      </div>
+      <div style={{ color: '#888', fontSize: 9, marginBottom: 2 }}>Nodes (JSON)</div>
+      <textarea
+        style={{ ...INPUT, resize: 'vertical', fontFamily: 'monospace', borderColor: err ? '#922' : '#444' }}
+        rows={6}
+        value={nodesText}
+        onChange={e => {
+          setNodesText(e.target.value)
+          try { const parsed = JSON.parse(e.target.value); setErr(''); onChange({ ...dlg, nodes: parsed }) }
+          catch (ex) { setErr(ex instanceof Error ? ex.message : 'invalid JSON') }
+        }}
+      />
+      {err && <div style={{ color: '#f88', fontSize: 9 }}>{err}</div>}
+    </div>
+  )
+}
+
+export function DialogueEditor({ questDefsData, onQuestDefsChange }: Props) {
+  const q = questDefsData as unknown as Record<string, unknown>
+  const friendship = (q.friendshipDialogue as Record<string, Record<string, string>>) ?? {}
+  const relationship = (q.relationshipDialogue as Record<string, Record<string, Record<string, string>>>) ?? {}
+  const rumours = (q.innRumours as Array<{ id: string; text: string }>) ?? []
+  const dialogues = (q.dialogues as Array<Record<string, unknown>>) ?? []
+  const patch = (key: string, value: unknown) => onQuestDefsChange(prev => ({ ...(prev as object), [key]: value }) as QuestDefsJson)
+
+  return (
+    <div style={{ flex: 1, overflowY: 'auto', padding: 8, color: '#ccc' }}>
+      <Section title={`Inn Rumours (${rumours.length})`} color="#f0c040">
+        <RumoursEditor data={rumours} onChange={d => patch('innRumours', d)} />
+      </Section>
+      <Section title={`Friendship Dialogue (${Object.keys(friendship).length})`} color="#88ffaa">
+        <FriendshipEditor data={friendship} onChange={d => patch('friendshipDialogue', d)} />
+      </Section>
+      <Section title={`Relationship Dialogue (${Object.keys(relationship).length})`} color="#ffaa88">
+        <RelationshipEditor data={relationship} onChange={d => patch('relationshipDialogue', d)} />
+      </Section>
+      <Section title={`Dialogue Trees (${dialogues.length})`} color="#88aaff">
+        {dialogues.map((dlg, i) => (
+          <DialogueTreeRow
+            key={i}
+            dlg={dlg}
+            onChange={d => patch('dialogues', dialogues.map((x, j) => j === i ? d : x))}
+            onDelete={() => patch('dialogues', dialogues.filter((_, j) => j !== i))}
+          />
+        ))}
+        <button style={BTN_ADD} onClick={() => patch('dialogues', [...dialogues, { id: '', npcId: '', start: 'greet', nodes: { greet: { text: '' } } }])}>+ Add dialogue tree</button>
+      </Section>
+    </div>
+  )
+}

--- a/web/src/components/mapEditor/npcQuestDrawer/NpcEditor.tsx
+++ b/web/src/components/mapEditor/npcQuestDrawer/NpcEditor.tsx
@@ -5,7 +5,8 @@ import { NPC_ACTIVITIES } from '../../../game/hub/hubNpcSchedule'
 import { SpriteSearchPicker } from '../SpritePicker'
 import { AnimalEditor } from './AnimalEditor'
 
-export type PickKind = 'npc' | 'animal'
+export type { PickKind } from '../mapEditorTypes'
+import type { PickKind } from '../mapEditorTypes'
 
 interface Props {
   configData: RawMapConfig

--- a/web/src/components/mapEditor/npcQuestDrawer/NpcQuestDrawer.tsx
+++ b/web/src/components/mapEditor/npcQuestDrawer/NpcQuestDrawer.tsx
@@ -4,6 +4,7 @@ import type { RawMapConfig, RawNpc, RawAnimal } from '../mapEditorTypes'
 import type { QuestDefsJson } from '../../../data/hub/hubWorldFactory'
 import { NpcEditor, type PickKind } from './NpcEditor'
 import { QuestEditor } from './QuestEditor'
+import { DialogueEditor } from './DialogueEditor'
 
 interface Props {
   tab: DrawerTab
@@ -42,6 +43,9 @@ export function NpcQuestDrawer({
         <button style={tab === 'quests' ? TAB_ACTIVE : TAB_INACTIVE} onClick={() => onTabChange('quests')}>
           Quests
         </button>
+        <button style={tab === 'dialogue' ? TAB_ACTIVE : TAB_INACTIVE} onClick={() => onTabChange('dialogue')}>
+          Dialogue
+        </button>
       </div>
       <div style={{ flex: 1, overflow: 'hidden', display: 'flex' }}>
         {tab === 'npcs' && (
@@ -62,6 +66,12 @@ export function NpcQuestDrawer({
             configData={configData}
             questDefsData={questDefsData}
             onUpdateNpc={onUpdateNpc}
+            onQuestDefsChange={onQuestDefsChange}
+          />
+        )}
+        {tab === 'dialogue' && (
+          <DialogueEditor
+            questDefsData={questDefsData}
             onQuestDefsChange={onQuestDefsChange}
           />
         )}

--- a/web/src/components/mapEditor/npcQuestDrawer/npcQuestDrawerTypes.ts
+++ b/web/src/components/mapEditor/npcQuestDrawer/npcQuestDrawerTypes.ts
@@ -1,1 +1,1 @@
-export type DrawerTab = 'npcs' | 'quests'
+export type DrawerTab = 'npcs' | 'quests' | 'dialogue'

--- a/web/src/components/mapEditor/useMapEditorState.ts
+++ b/web/src/components/mapEditor/useMapEditorState.ts
@@ -216,6 +216,25 @@ export function useMapEditorState(initialMapId: MapId = 'ravenwatch') {
         if (!areas[entity.index]) return s
         areas[entity.index] = { ...areas[entity.index], tx, ty }
         newConfig = { ...prevConfig, areas }
+      } else if (entity.type === 'interactable') {
+        const items = [...(prevConfig.interactables ?? [])]
+        if (!items[entity.index]) return s
+        items[entity.index] = { ...items[entity.index], tx, ty }
+        newConfig = { ...prevConfig, interactables: items }
+      } else if (entity.type === 'exitTile') {
+        const tiles = [...(prevConfig.exitTiles ?? [])]
+        if (!tiles[entity.index]) return s
+        tiles[entity.index] = { ...tiles[entity.index], tx, ty }
+        newConfig = { ...prevConfig, exitTiles: tiles }
+      } else if (entity.type === 'chickenZone') {
+        const zones = [...(prevConfig.chickenZones ?? [])]
+        const z = zones[entity.index]
+        if (!z) return s
+        const [x1, y1, x2, y2] = z.rect
+        const dx = tx - x1, dy = ty - y1
+        if (dx === 0 && dy === 0) return s
+        zones[entity.index] = { ...z, rect: [x1 + dx, y1 + dy, x2 + dx, y2 + dy] }
+        newConfig = { ...prevConfig, chickenZones: zones }
       } else if (entity.type === 'buildingLevelDecor') {
         const buildings = [...(prevConfig.buildings ?? [])]
         const b = buildings[entity.buildingIndex]
@@ -265,6 +284,12 @@ export function useMapEditorState(initialMapId: MapId = 'ravenwatch') {
         newConfig = { ...prevConfig, treasures: (prevConfig.treasures ?? []).filter((_, i) => i !== entity.index) }
       } else if (entity.type === 'pickupItem') {
         newConfig = { ...prevConfig, pickupItems: (prevConfig.pickupItems ?? []).filter((_, i) => i !== entity.index) }
+      } else if (entity.type === 'interactable') {
+        newConfig = { ...prevConfig, interactables: (prevConfig.interactables ?? []).filter((_, i) => i !== entity.index) }
+      } else if (entity.type === 'exitTile') {
+        newConfig = { ...prevConfig, exitTiles: (prevConfig.exitTiles ?? []).filter((_, i) => i !== entity.index) }
+      } else if (entity.type === 'chickenZone') {
+        newConfig = { ...prevConfig, chickenZones: (prevConfig.chickenZones ?? []).filter((_, i) => i !== entity.index) }
       } else if (entity.type === 'buildingLevelDecor' && prevConfig.buildings?.[entity.buildingIndex]?.levelDecor) {
         const buildings = [...prevConfig.buildings]
         const b = buildings[entity.buildingIndex]
@@ -508,7 +533,7 @@ export function useMapEditorState(initialMapId: MapId = 'ravenwatch') {
     })
   }, [])
 
-  const updateTreasure = useCallback((index: number, patch: { tileId?: string }) => {
+  const updateTreasure = useCallback((index: number, patch: Partial<NonNullable<RawMapConfig['treasures']>[number]>) => {
     setState(s => {
       const prevConfig = s.configData
       const treasures = [...(prevConfig.treasures ?? [])]
@@ -522,6 +547,20 @@ export function useMapEditorState(initialMapId: MapId = 'ravenwatch') {
         isDirty: true,
       }
     })
+  }, [])
+
+  // Generic top-level config patch with undo support. Used by the simpler list
+  // editors (treasures, interactables, exitTiles, chickenZones, weather,
+  // ambientNpcSprites, avatarStart, pondTiles, npcSpawnTiles…) which read the
+  // current array/value from configData and write the whole thing back.
+  const updateConfig = useCallback((patch: Partial<RawMapConfig>) => {
+    setState(s => ({
+      ...s,
+      configData: { ...s.configData, ...patch },
+      undoStack:  [...s.undoStack, s.configData].slice(-MAX_UNDO),
+      redoStack:  [],
+      isDirty:    true,
+    }))
   }, [])
 
   const updateArea = useCallback((index: number, patch: Partial<{ name: string; tw: number; th: number }>) => {
@@ -972,6 +1011,7 @@ export function useMapEditorState(initialMapId: MapId = 'ravenwatch') {
     updateAnimal,
     updateTreasure,
     updateArea,
+    updateConfig,
     updateMapProps,
     resizeMap,
     resizeInterior,


### PR DESCRIPTION
Makes the whole town `config.json` and `questDefs.json` authorable from the Map Editor. Covers the three explicit asks plus the full audit.

## The three explicit asks
- **Treasures** — "+ Add Treasure" + a full `TreasureInspector` (title, tile + collected-tile pickers, building, crystal reward, position with pick-on-map, delete).
- **Road blocks** (`blockedPaths`) — "+ Add Road Block"; inspector now edits `questId`, adds blocked tiles via pick-on-map, and add/removes the `blocked`/`cleared` decor tiles.
- **Interactables** (notice board etc., previously invisible) — new **Interactables overlay toggle** rendering each interactable's decor + hit box; full `InteractableInspector` with id, position (pick), building, hit area, decor tiles, indicator condition, and a **structured reactions editor** for all types (dialogue / screen / giveItem / quest / move). "+ Add Interactable" creator.

## Audit — everything else now editable
- **Town panel extra sections:** `avatarStart` (pick), `exitTiles` ({tx,ty,screen} + pick), `weather` (type + per-season), `ambientNpcSprites` (searchable picker), `chickenZones`, `npcSpawnTiles`, `pondTiles`.
- **New "Dialogue" drawer tab:** `innRumours`, `friendshipDialogue`, `relationshipDialogue` (structured), and `dialogues` trees (id/npcId/start fields + JSON node editor).

## How it's built
- Generalised the existing **pick-on-map** infra to treasure/interactable/exit-tile/avatar-spawn/blocked-tile.
- Added a generic `updateConfig` patch action so list editors write whole arrays with undo.
- New raw types (`RawInteractable*`, `RawChickenZone`, `RawWeather`) and selection kinds.
- Save round-trips every key — the editor `structuredClone`s the full config/questDefs, so unedited/unknown keys are preserved.
- `docs/hubworld.md §13`: config/questDefs → UI coverage table.

Built in phases (foundations → treasures → road blocks → interactables → spawn/exits/weather/zones → dialogue → docs), one commit each.

## Verification
- `npm run build` ✅ and `npx vitest run` ✅ (190/190).
- Manual on Ravenwatch: create a treasure/road-block/interactable, edit the notice-board's screen reaction, pick locations on the map, edit spawn/exits/weather/ambient/ponds/zones, and edit dialogue/rumours — then Save and reload to confirm round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011f8gD7RAP6taye8wz8GfFs)_