### PR TITLE
feat(hub): seasonal & festival events — calendar, decor, quests, editor

### DIFF
--- a/docs/hubworld.md
+++ b/docs/hubworld.md
@@ -968,3 +968,68 @@ or unedited keys are preserved).
 spawn, and blocked-path tiles all support a "📍 Pick on map" button that sets
 the location from the next canvas click (records the interior building when used
 inside a room). Dialogue-tree `nodes` are edited as JSON within the Dialogue tab.
+
+---
+
+## §14 — Seasonal & Festival Events
+
+A real-date calendar layer (`web/src/game/hub/hubCalendar.ts`) drives time-limited
+festival content: decor swaps, festival-gated quests, and an "event active" HUD
+badge. Builds on the weather `seasonForDate` helper.
+
+### Festival registry (`FESTIVALS` in `hubCalendar.ts`)
+
+The single source of truth for runtime, the map editor, and Storybook. Each entry:
+
+```ts
+{ id: 'midsummer', name: 'Midsummer Fair', icon: '🏮',
+  start: { month: 6, day: 1 }, end: { month: 7, day: 15 } }
+```
+
+`getActiveFestival(date?)` returns the festival whose window contains the date
+(windows wrap the new year when `start > end`, e.g. Midwinter Dec→Jan), or `null`.
+Add a festival by appending to `FESTIVALS`.
+
+### Festival decor (`config.json` → optional top-level `festivalDecor`)
+
+```jsonc
+{
+  "festivalDecor": [
+    { "festivalId": "midsummer", "decor": [
+      { "tx": 34, "ty": 26, "tileId": "lampPostTop" },
+      { "tx": 35, "ty": 31, "tileId": "flowerPotLeft" }
+    ] }
+  ]
+}
+```
+
+Each group's `decor` uses the same shape as `exteriorDecor` (tile keys from
+`baseChipIndex.ts`, optional `zlayer`). The loader resolves it to
+`HUB_FESTIVAL_DECOR`; `HubTownCanvas` renders the group whose `festivalId` matches
+the active festival, layered in with the base exterior decor.
+
+### Festival-gated quests (`questDefs.json`)
+
+Set `"festivalId": "<id>"` on a quest — it is only offered while that festival is
+active (gated alongside `prerequisite`/`availableHours` in `HubWorld`). Any
+`pickupItems` it references appear only while the quest is active, as usual.
+
+### HUD badge
+
+When a festival is active, `HubWorld` shows an `{icon} {name}` label next to the
+clock.
+
+### QA override (preview any festival on any date)
+
+`setFestivalOverride(id | 'none' | null)` (localStorage `jarv_hub_festival_override`)
+forces a festival, suppresses all festivals (`'none'`), or clears back to
+date-driven (`null`). In dev it is exposed on `window.setFestivalOverride`.
+
+### Map editor & Storybook
+
+The editor toolbar's **Festival** selector previews a festival's decor live;
+while a festival is selected, placing/moving/deleting exterior decor edits that
+festival's group (not `exteriorDecor`). The quest editor has a **Festival**
+dropdown for `festivalId`. The `MapEditor` Storybook stories
+(`Ravenwatch · Midsummer/Harvest/Midwinter`) seed `initialFestival` so each
+festival is previewable regardless of today's date.

--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -20,6 +20,7 @@ import { HubInteractable, HubInteriorExit, HubLocationBundle, HubNpc, HubQuestBu
 import { createAnimalSystem, AnimalSystem, GlowSource } from './hubAnimals'
 import { createWeatherSystem } from './hubWeather'
 import { resolveWeather } from '../../game/hub/weather'
+import { getActiveFestival } from '../../game/hub/hubCalendar'
 import { BASE_CHIP_TILES } from '../../data/tiles/baseChipIndex'
 import { getUpgradeTrack } from '../../data/hub/buildingUpgrades'
 
@@ -123,6 +124,7 @@ export function HubTownCanvas({
     HUB_STREET_GROUPS,
     HUB_STREET_TILES,
     EXTERIOR_DECOR, HUB_WINDOWS, HUB_POND_TILES,
+    HUB_FESTIVAL_DECOR,
     HUB_DOORS, HUB_INTERIORS, EXTERIOR_NPCS, INTERIOR_NPCS,
     NPC_SPAWN_TILES, AMBIENT_NPC_SPRITES,
    HUB_LOCKED_DOORS, HUB_TREASURES, HUB_INTERACTABLES, HUB_ANIMALS, HUB_CHICKEN_ZONES,
@@ -434,10 +436,17 @@ export function HubTownCanvas({
 
     // ── Exterior decor (tile sprites over streets/ground) ─────────────────────
     {
+      // Festival decor for the currently-active festival is layered in with the
+      // base exterior decor (festival is date-stable for the session).
+      const _festival = getActiveFestival()
+      const _festivalDecor = _festival
+        ? (HUB_FESTIVAL_DECOR.find(g => g.festivalId === _festival.id)?.decor ?? [])
+        : []
+      const effectiveDecor = [...EXTERIOR_DECOR, ..._festivalDecor]
       const extNormal      = new Map<number, [number, number][]>()
       const extBelowAvatar = new Map<number, [number, number][]>()
       const extAboveAvatar = new Map<number, [number, number][]>()
-      for (const d of EXTERIOR_DECOR) {
+      for (const d of effectiveDecor) {
         if (d.tileId === 666) continue
         const map  = d.zlayer === 'below' ? extBelowAvatar : d.zlayer === 'above' ? extAboveAvatar : extNormal
         const list = map.get(d.tileId) ?? []

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -39,6 +39,7 @@ import { TreasureModal } from './TreasureModal'
 import { getCollectedTreasureIds, markTreasureCollected } from '../../game/hub/treasures'
 import { useHubClock } from '../../hooks/useHubClock'
 import { formatGameTime, hourInRange } from '../../game/hub/hubClock'
+import { getActiveFestival } from '../../game/hub/hubCalendar'
 import { getDailyChallengeNPCDialogue } from '../../game/hub/npcDialogue'
 import {  ALL_QUESTS, FRIENDSHIP_DIALOGUE, RELATIONSHIP_DIALOGUE, RAVENWATCH } from '../../data/hub/hubWorldFactory'
 import { HubInteractable, HubLocationBundle, HubQuestBundle, HubTreasure } from '../../data/hub/loader'
@@ -239,6 +240,9 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onEndless, onWorldMap
   }
 
 
+  // Active festival (real-date driven, with QA override) — gates festival quests + HUD badge.
+  const activeFestival = getActiveFestival()
+
   // Quest NPC state: maps npcId → 'offer' | 'ready' | null, read imperatively by PixiJS ticker
   const questNpcStateRef = useRef(new Map<string, 'offer' | 'ready' | null>())
   {
@@ -250,7 +254,8 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onEndless, onWorldMap
       if (state.status === 'available') {
         const prereqMet = !quest.prerequisite || checkPrerequisite(quest.prerequisite)
         const hoursMet  = !quest.availableHours || hourInRange(gameHour, quest.availableHours.start, quest.availableHours.end)
-        if (prereqMet && hoursMet && !atCap) m.set(quest.giverNpcId, 'offer')
+        const festivalMet = !quest.festivalId || quest.festivalId === activeFestival?.id
+        if (prereqMet && hoursMet && festivalMet && !atCap) m.set(quest.giverNpcId, 'offer')
       } else if (state.status === 'active') {
         if (isQuestReadyToComplete(quest)) m.set(quest.receiverNpcId, 'ready')
       }
@@ -674,6 +679,7 @@ function hasOfferableQuest(giverId: string): boolean {
   return questDefs.some(q =>
     q.giverNpcId === giverId &&
     getQuestState(q.id).status === 'available' &&
+    (!q.festivalId || q.festivalId === activeFestival?.id) &&
     (!q.prerequisite || checkPrerequisite(q.prerequisite)))
 }
 
@@ -1016,6 +1022,9 @@ function hasOfferableQuest(giverId: string): boolean {
           <ToolbarLabel className={`title-deck-info${wrongSave ? ' title-deck-info--glitch' : ''}`}>💎 {wrongSave ? wrongSave.crystals.toLocaleString() : crystals.toLocaleString()}</ToolbarLabel>
           <ToolbarLabel className={`title-deck-info${wrongSave ? ' title-deck-info--glitch' : ''}`}>🃏 {wrongSave ? wrongSave.cards : collectionCount}/{catalogTotal}</ToolbarLabel>
           <ToolbarLabel className="title-deck-info">{isGameNight ? '🌙' : '☀️'} {formatGameTime()}</ToolbarLabel>
+          {activeFestival && (
+            <ToolbarLabel className="title-deck-info">{activeFestival.icon} {activeFestival.name}</ToolbarLabel>
+          )}
         <ToolbarButton icon="📜" title="Quests" onClick={() => setQuestsOpen(true)} />
         <ToolbarButton icon="🧭" title="Where is…?" onClick={() => setDirectoryOpen(true)} />
         <ToolbarButton icon="🏗️" title="Town Upgrades" onClick={() => setUpgradesOpen(true)} />

--- a/web/src/components/mapEditor/MapEditor.stories.tsx
+++ b/web/src/components/mapEditor/MapEditor.stories.tsx
@@ -17,6 +17,23 @@ export const Ravenwatch: Story = {
   args: { initialMapId: 'ravenwatch' },
 }
 
+// Festival previews — force a festival regardless of today's date so its decor
+// can be authored/inspected on the hub canvas year-round.
+export const RavenwatchMidsummer: Story = {
+  name: 'Ravenwatch · Midsummer',
+  args: { initialMapId: 'ravenwatch', initialFestival: 'midsummer' },
+}
+
+export const RavenwatchHarvest: Story = {
+  name: 'Ravenwatch · Harvest',
+  args: { initialMapId: 'ravenwatch', initialFestival: 'harvest' },
+}
+
+export const RavenwatchMidwinter: Story = {
+  name: 'Ravenwatch · Midwinter',
+  args: { initialMapId: 'ravenwatch', initialFestival: 'midwinter' },
+}
+
 export const Millhaven: Story = {
   args: { initialMapId: 'millhaven' },
 }

--- a/web/src/components/mapEditor/MapEditor.tsx
+++ b/web/src/components/mapEditor/MapEditor.tsx
@@ -15,9 +15,11 @@ import type { DrawerTab } from './npcQuestDrawer/npcQuestDrawerTypes'
 
 interface Props {
   initialMapId?: MapId
+  /** Seed the festival preview/authoring mode (e.g. for Storybook). */
+  initialFestival?: string
 }
 
-export function MapEditor({ initialMapId = 'ravenwatch' }: Props) {
+export function MapEditor({ initialMapId = 'ravenwatch', initialFestival = undefined }: Props) {
   const [showGrid, setShowGrid] = useState(true)
   const [showQuestItems, setShowQuestItems] = useState(false)
   const [showBlockedPaths, setShowBlockedPaths] = useState(false)
@@ -35,7 +37,7 @@ export function MapEditor({ initialMapId = 'ravenwatch' }: Props) {
   const drawerDragRef = useRef<{ startY: number; startH: number } | null>(null)
 
   const {
-    state, setMapId, setTool, setActiveTile, setZlayer, setActiveLevel,
+    state, setMapId, setTool, setActiveTile, setZlayer, setActiveLevel, setPreviewFestival,
     openInterior, closeInterior, selectEntity,
     placeDecor, moveEntity, deleteEntity,
     updateDecorZlayer, updateGlow, updateDecorMinLevel, updateBuilding, addNpc, updateNpcDialogue, updateNpc,
@@ -46,7 +48,7 @@ export function MapEditor({ initialMapId = 'ravenwatch' }: Props) {
     addStreet, updateStreetEntry,
     addLockedDoor, updateLockedDoor, deleteLockedDoor,
     undo, redo, markSaved,
-  } = useMapEditorState(initialMapId)
+  } = useMapEditorState(initialMapId, initialFestival ?? null)
 
   // Reset questDefs when map changes
   useEffect(() => {
@@ -249,6 +251,8 @@ export function MapEditor({ initialMapId = 'ravenwatch' }: Props) {
         drawerOpen={drawerOpen}
         hasDuplicateQuestIds={hasDuplicateQuestIds}
         configData={state.configData}
+        previewFestivalId={state.previewFestivalId}
+        onPreviewFestivalChange={setPreviewFestival}
         onMapChange={setMapId}
         onToolChange={setTool}
         onUndo={undo}
@@ -292,8 +296,9 @@ export function MapEditor({ initialMapId = 'ravenwatch' }: Props) {
 
           {/* Center: Map canvas — key forces remount when canvas dimensions change */}
           <MapEditorCanvas
-            key={`${state.mapId}-${state.viewMode}-${state.activeInteriorId ?? ''}`}
+            key={`${state.mapId}-${state.viewMode}-${state.activeInteriorId ?? ''}-${state.previewFestivalId ?? ''}`}
             configData={state.configData}
+            previewFestivalId={state.previewFestivalId}
             tool={state.tool}
             showGrid={showGrid}
             showQuestItems={showQuestItems}

--- a/web/src/components/mapEditor/MapEditorCanvas.tsx
+++ b/web/src/components/mapEditor/MapEditorCanvas.tsx
@@ -82,6 +82,7 @@ interface Props {
   viewMode:         'exterior' | 'interior'
   activeInteriorId: string | null
   activeLevel:      number
+  previewFestivalId?: string | null
   activeTileId:     string | null
   activeBundleId:   string | null
   activeZlayer:     Zlayer
@@ -102,7 +103,7 @@ interface Props {
 
 export function MapEditorCanvas(props: Props) {
   const {
-    configData, tool, showGrid, selectedEntity, viewMode, activeInteriorId, activeLevel,
+    configData, tool, showGrid, selectedEntity, viewMode, activeInteriorId, activeLevel, previewFestivalId,
     activeTileId, activeBundleId, activeZlayer, pickActive, showQuestItems, showBlockedPaths, showAreas, showInteractables, blockedPaths, questPickupItems,
     onSelectEntity, onPlaceDecor, onMoveEntity, onDeleteEntity, onAddStreet,
   } = props
@@ -381,6 +382,13 @@ export function MapEditorCanvas(props: Props) {
       renderBuildingLevelDecor(version, bIdx, flattenDecor(b.levelDecor ?? []),
                                decorBLayer, decorLayer, decorALayer, selLayer)
     })
+
+    // Festival decor for the previewed festival (authoring + preview)
+    if (previewFestivalId) {
+      const group = (configData.festivalDecor ?? []).find(g => g.festivalId === previewFestivalId)
+      if (group) renderFestivalDecor(version, previewFestivalId, flattenDecor(group.decor),
+                                     decorBLayer, decorLayer, decorALayer, selLayer)
+    }
 
     // NPCs
     const npcs = configData.npcs ?? []
@@ -824,6 +832,42 @@ export function MapEditorCanvas(props: Props) {
         const g = new PIXI.Graphics()
         g.rect(tx * T + 4, ty * T + 4, T - 8, T - 8).fill(0x884422)
         if (dimmed) g.alpha = 0.3
+        layer.addChild(g)
+      })
+    })
+  }
+
+  // ── Festival decor rendering (exterior, date-gated; here shown for preview) ────
+  function renderFestivalDecor(
+    version: number,
+    festivalId: string,
+    items: FlatDecorItem[],
+    decorBLayer: PIXI.Container, decorLayer: PIXI.Container, decorALayer: PIXI.Container,
+    selLayer: PIXI.Graphics,
+  ) {
+    items.forEach(({ tx, ty, tileId, zlayer, sourceIndex }) => {
+      const numId = tileNumericId(tileId)
+      const layer = zlayer === 'below' ? decorBLayer : zlayer === 'above' ? decorALayer : decorLayer
+      const isSel = selectedEntity?.type === 'festivalDecor'
+        && selectedEntity.festivalId === festivalId && selectedEntity.index === sourceIndex
+      const entity: SelectedEntity = { type: 'festivalDecor', festivalId, index: sourceIndex }
+      loadTileRef(numId).then(tex => {
+        if (renderVersionRef.current !== version) return
+        const sp = new PIXI.Sprite(tex)
+        sp.x = tx * T; sp.y = ty * T
+        sp.eventMode = 'static'; sp.cursor = 'pointer'
+        sp.on('pointerdown', (e: PIXI.FederatedPointerEvent) => {
+          e.stopPropagation()
+          propsRef.current.onSelectEntity(entity)
+          if (propsRef.current.tool === 'select')
+            dragRef.current = { entity, lastTx: tx, lastTy: ty, offsetX: 0, offsetY: 0 }
+        })
+        if (isSel) selLayer.rect(tx * T - 1, ty * T - 1, T + 2, T + 2).stroke({ color: 0xf0c040, width: 2 })
+        layer.addChild(sp)
+      }).catch(() => {
+        if (renderVersionRef.current !== version) return
+        const g = new PIXI.Graphics()
+        g.rect(tx * T + 4, ty * T + 4, T - 8, T - 8).fill(0xc080d0)
         layer.addChild(g)
       })
     })

--- a/web/src/components/mapEditor/MapEditorToolbar.tsx
+++ b/web/src/components/mapEditor/MapEditorToolbar.tsx
@@ -3,6 +3,7 @@ import type { ToolMode } from './mapEditorTypes'
 import { saveMap, saveQuestDefs } from './mapEditorApi'
 import type { RawMapConfig } from './mapEditorTypes'
 import { MapId } from '../../data/hub/hubWorldFactory'
+import { FESTIVALS } from '../../game/hub/hubCalendar'
 
 const MAP_OPTIONS: { id: MapId; label: string }[] = [
   { id: 'ravenwatch',        label: 'Hub — Ravenwatch' },
@@ -34,6 +35,8 @@ interface Props {
   drawerOpen:           boolean
   hasDuplicateQuestIds: boolean
   configData:           RawMapConfig
+  previewFestivalId:    string | null
+  onPreviewFestivalChange: (id: string | null) => void
   onMapChange:          (id: MapId) => void
   onToolChange:         (t: ToolMode) => void
   onUndo:               () => void
@@ -57,7 +60,7 @@ const TOOLS: { mode: ToolMode; label: string; title: string }[] = [
 
 export function MapEditorToolbar({
   mapId, tool, canUndo, canRedo, isDirty, showGrid, showQuestItems, showBlockedPaths, showAreas, showInteractables, drawerOpen, hasDuplicateQuestIds,
-  configData, questDefsData, onMapChange, onToolChange, onUndo, onRedo,
+  configData, questDefsData, previewFestivalId, onPreviewFestivalChange, onMapChange, onToolChange, onUndo, onRedo,
   onGridToggle, onQuestItemsToggle, onBlockedPathsToggle, onAreasToggle, onInteractablesToggle, onDrawerToggle, onSaved,
 }: Props) {
   const [saveState, setSaveState] = useState<'idle' | 'saving' | 'ok' | 'error'>('idle')
@@ -100,6 +103,22 @@ export function MapEditorToolbar({
       >
         {MAP_OPTIONS.map(o => (
           <option key={o.id} value={o.id}>{o.label}</option>
+        ))}
+      </select>
+
+      {/* Festival preview / authoring — placed decor goes into the selected festival's group */}
+      <select
+        value={previewFestivalId ?? ''}
+        onChange={e => onPreviewFestivalChange(e.target.value || null)}
+        title="Preview / author festival decor"
+        style={{
+          padding: '4px 6px', background: previewFestivalId ? '#3a2e10' : '#1e1e3e',
+          border: '1px solid #444', color: '#eee', borderRadius: 3, fontSize: 12, cursor: 'pointer',
+        }}
+      >
+        <option value="">Festival: none</option>
+        {FESTIVALS.map(f => (
+          <option key={f.id} value={f.id}>{f.icon} {f.name}</option>
         ))}
       </select>
 

--- a/web/src/components/mapEditor/mapEditorTypes.ts
+++ b/web/src/components/mapEditor/mapEditorTypes.ts
@@ -226,6 +226,7 @@ export interface RawMapConfig {
   lockedDoors?: RawLockedDoor[]
   interactables?: RawInteractable[]
   chickenZones?: RawChickenZone[]
+  festivalDecor?: Array<{ festivalId: string; decor: RawDecorItem[] }>
 }
 
 export type SelectedEntity =
@@ -244,6 +245,7 @@ export type SelectedEntity =
   | { type: 'interactable'; index: number }
   | { type: 'exitTile'; index: number }
   | { type: 'chickenZone'; index: number }
+  | { type: 'festivalDecor'; festivalId: string; index: number }
 
 export interface MapEditorState {
   mapId: MapId
@@ -255,6 +257,8 @@ export interface MapEditorState {
   viewMode: ViewMode
   activeInteriorId: string | null
   activeLevel: number
+  /** Festival being previewed/authored in the editor (null = base / no festival). */
+  previewFestivalId: string | null
   selectedEntity: SelectedEntity | null
   undoStack: RawMapConfig[]
   redoStack: RawMapConfig[]

--- a/web/src/components/mapEditor/npcQuestDrawer/QuestEditor.tsx
+++ b/web/src/components/mapEditor/npcQuestDrawer/QuestEditor.tsx
@@ -3,6 +3,7 @@ import type { RawMapConfig, RawNpc } from '../mapEditorTypes'
 import type { QuestDefsJson } from '../../../data/hub/hubWorldFactory'
 import type { QuestDefinition, QuestStep, QuestReward, Dialogue } from '../../../data/hub/questDefs'
 import { isQuestIdUnique, generateQuestId } from './questValidation'
+import { FESTIVALS } from '../../../game/hub/hubCalendar'
 
 interface Props {
   configData: RawMapConfig
@@ -356,6 +357,12 @@ function QuestFullEditor({
       <Field label="Prerequisite">
         <select style={SELECT} value={draft.prerequisite ?? ''} onChange={e => set('prerequisite', e.target.value || undefined)}>
           {prerequisiteOptions.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
+        </select>
+      </Field>
+      <Field label="Festival (time-limited)">
+        <select style={SELECT} value={draft.festivalId ?? ''} onChange={e => set('festivalId', e.target.value || undefined)}>
+          <option value="">none (always available)</option>
+          {FESTIVALS.map(f => <option key={f.id} value={f.id}>{f.icon} {f.name}</option>)}
         </select>
       </Field>
       <Field label="Offer Dialogue">

--- a/web/src/components/mapEditor/useMapEditorState.ts
+++ b/web/src/components/mapEditor/useMapEditorState.ts
@@ -35,7 +35,19 @@ const RAW_CONFIGS: Record<MapId, RawMapConfig> = {
 
 const MAX_UNDO = 50
 
-export function useMapEditorState(initialMapId: MapId = 'ravenwatch') {
+/** Immutably patch one item inside a festival decor group; returns a new config. */
+function patchFestivalDecor(
+  cfg: RawMapConfig, festivalId: string, index: number, patch: Partial<RawDecorItem>,
+): RawMapConfig {
+  return { ...cfg, festivalDecor: (cfg.festivalDecor ?? []).map(g => {
+    if (g.festivalId !== festivalId || !g.decor[index]) return g
+    const decor = [...g.decor]
+    decor[index] = { ...decor[index], ...patch }
+    return { ...g, decor }
+  }) }
+}
+
+export function useMapEditorState(initialMapId: MapId = 'ravenwatch', initialFestival: string | null = null) {
   const [state, setState] = useState<MapEditorState>(() => ({
     mapId:            initialMapId,
     configData:       structuredClone(RAW_CONFIGS[initialMapId]),
@@ -46,6 +58,7 @@ export function useMapEditorState(initialMapId: MapId = 'ravenwatch') {
     viewMode:         'exterior',
     activeInteriorId: null,
     activeLevel:      0,
+    previewFestivalId: initialFestival,
     selectedEntity:   null,
     undoStack:        [],
     redoStack:        [],
@@ -69,6 +82,10 @@ export function useMapEditorState(initialMapId: MapId = 'ravenwatch') {
 
   const setActiveLevel = useCallback((activeLevel: number) => {
     setState(s => ({ ...s, activeLevel: Math.max(0, activeLevel) }))
+  }, [])
+
+  const setPreviewFestival = useCallback((previewFestivalId: string | null) => {
+    setState(s => ({ ...s, previewFestivalId, selectedEntity: null }))
   }, [])
 
   const setTool = useCallback((tool: ToolMode) => {
@@ -112,6 +129,14 @@ export function useMapEditorState(initialMapId: MapId = 'ravenwatch') {
 
       let newConfig: RawMapConfig
       if (s.viewMode === 'exterior') {
+        // When previewing a festival, placed decor belongs to that festival's group.
+        if (s.previewFestivalId) {
+          const groups = [...(prevConfig.festivalDecor ?? [])]
+          const gi = groups.findIndex(g => g.festivalId === s.previewFestivalId)
+          if (gi >= 0) groups[gi] = { ...groups[gi], decor: [...groups[gi].decor, newItem] }
+          else groups.push({ festivalId: s.previewFestivalId, decor: [newItem] })
+          newConfig = { ...prevConfig, festivalDecor: groups }
+        } else
         // When a building is selected, exterior decor belongs to that building's
         // per-level decor (revealed by upgrade level). Otherwise it is ambient
         // exterior decor with no level association.
@@ -158,6 +183,8 @@ export function useMapEditorState(initialMapId: MapId = 'ravenwatch') {
         if (!decor[entity.index]) return s
         decor[entity.index] = { ...decor[entity.index], tx, ty }
         newConfig = { ...prevConfig, exteriorDecor: decor }
+      } else if (entity.type === 'festivalDecor') {
+        newConfig = patchFestivalDecor(prevConfig, entity.festivalId, entity.index, { tx, ty })
       } else if (entity.type === 'npc') {
         const npcs = [...(prevConfig.npcs ?? [])]
         if (!npcs[entity.index]) return s
@@ -272,6 +299,9 @@ export function useMapEditorState(initialMapId: MapId = 'ravenwatch') {
 
       if (entity.type === 'exteriorDecor') {
         newConfig = { ...prevConfig, exteriorDecor: (prevConfig.exteriorDecor ?? []).filter((_, i) => i !== entity.index) }
+      } else if (entity.type === 'festivalDecor') {
+        newConfig = { ...prevConfig, festivalDecor: (prevConfig.festivalDecor ?? []).map(g =>
+          g.festivalId === entity.festivalId ? { ...g, decor: g.decor.filter((_, i) => i !== entity.index) } : g) }
       } else if (entity.type === 'npc') {
         newConfig = { ...prevConfig, npcs: (prevConfig.npcs ?? []).filter((_, i) => i !== entity.index) }
       } else if (entity.type === 'animal') {
@@ -328,6 +358,8 @@ export function useMapEditorState(initialMapId: MapId = 'ravenwatch') {
         if (!decor[entity.index]) return s
         decor[entity.index] = { ...decor[entity.index], zlayer }
         newConfig = { ...prevConfig, exteriorDecor: decor }
+      } else if (entity.type === 'festivalDecor') {
+        newConfig = patchFestivalDecor(prevConfig, entity.festivalId, entity.index, { zlayer })
       } else if (entity.type === 'buildingLevelDecor' && prevConfig.buildings?.[entity.buildingIndex]?.levelDecor) {
         const buildings = [...prevConfig.buildings]
         const b = buildings[entity.buildingIndex]
@@ -369,6 +401,8 @@ export function useMapEditorState(initialMapId: MapId = 'ravenwatch') {
         if (!decor[entity.index]) return s
         decor[entity.index] = { ...decor[entity.index], ...patch }
         newConfig = { ...prevConfig, exteriorDecor: decor }
+      } else if (entity.type === 'festivalDecor') {
+        newConfig = patchFestivalDecor(prevConfig, entity.festivalId, entity.index, patch)
       } else if (entity.type === 'buildingLevelDecor' && prevConfig.buildings?.[entity.buildingIndex]?.levelDecor) {
         const buildings = [...prevConfig.buildings]
         const b = buildings[entity.buildingIndex]
@@ -994,6 +1028,7 @@ export function useMapEditorState(initialMapId: MapId = 'ravenwatch') {
     setActiveTile,
     setZlayer,
     setActiveLevel,
+    setPreviewFestival,
     openInterior,
     closeInterior,
     selectEntity,

--- a/web/src/data/hub/config.ts
+++ b/web/src/data/hub/config.ts
@@ -299,6 +299,9 @@ export interface RawConfig {
   /** Optional per-town weather (loose raw shape; typed `WeatherConfig` at the loader output). */
   weather?: { type?: string; bySeason?: Record<string, string> }
 
+  /** Optional date-gated festival decor groups (rendered when that festival is active). */
+  festivalDecor?: Array<{ festivalId: string; decor: RawDecor[] }>
+
   avatarStart:RawCoordinate
 
   exitTiles?: RawExitTile[]

--- a/web/src/data/hub/loader.ts
+++ b/web/src/data/hub/loader.ts
@@ -262,6 +262,7 @@ export interface HubLocationBundle {
   HUB_BUILDINGS: HubBuilding[]
   HUB_BUILDING_TILES: [number, number][]
   EXTERIOR_DECOR: any[]
+  HUB_FESTIVAL_DECOR: Array<{ festivalId: string; decor: any[] }>
   HUB_WINDOWS: any[]
   HUB_POND_TILES: [number, number][]
   HUB_DOORS: HubDoor[]
@@ -440,6 +441,21 @@ const EXTERIOR_DECOR = [
   }),
   ..._nestedDecor,
 ]
+
+// Date-gated festival decor groups — resolved like EXTERIOR_DECOR; the renderer
+// shows the group whose festivalId matches the active festival (hubCalendar).
+type RawFestivalGroup = { festivalId: string; decor: RawDecorEntry[] }
+const HUB_FESTIVAL_DECOR: Array<{ festivalId: string; decor: typeof EXTERIOR_DECOR }> = (
+  (rawConfig as unknown as { festivalDecor?: RawFestivalGroup[] }).festivalDecor ?? []
+).map(g => ({
+  festivalId: g.festivalId,
+  decor: (g.decor ?? []).flatMap(d => {
+    if (d.tx == null || d.ty == null) return []
+    if (d.bundleID) return expandBundleDecor(d.bundleID, d.tx, d.ty)
+    if (d.tileId) return [{ tx: d.tx, ty: d.ty, tileId: resolveTileId(d.tileId), zlayer: d.zlayer, glow: d.glow, glowRadius: d.glowRadius, pulse: d.pulse }]
+    return []
+  }),
+}))
 
 type RawWindowEntry = { tx: number; ty: number; tileId: string }
 const HUB_WINDOWS = [
@@ -633,6 +649,7 @@ type RawExitTile = { tx: number; ty: number; screen: string }
     HUB_BUILDINGS,
     HUB_BUILDING_TILES,
     EXTERIOR_DECOR,
+    HUB_FESTIVAL_DECOR,
     HUB_WINDOWS,
     HUB_POND_TILES,
     HUB_DOORS,

--- a/web/src/data/hub/questDefs.ts
+++ b/web/src/data/hub/questDefs.ts
@@ -43,6 +43,8 @@ export interface HubQuestDef {
   steps: HubQuestStep[]
   reward: HubQuestReward
   availableHours?: { start: number; end: number }
+  /** If set, the quest is only offered while this festival is active (hubCalendar). */
+  festivalId?: string
 }
 
 
@@ -63,6 +65,9 @@ export interface QuestDefinition {
   steps: QuestStep[]
 
   reward: QuestReward
+
+  /** If set, the quest is only offered while this festival is active (hubCalendar). */
+  festivalId?: string
 }
 
 

--- a/web/src/data/hub/ravenwatch/config.json
+++ b/web/src/data/hub/ravenwatch/config.json
@@ -11,6 +11,21 @@
       "winter": "snow"
     }
   },
+  "festivalDecor": [
+    {
+      "festivalId": "midsummer",
+      "decor": [
+        { "tx": 34, "ty": 26, "tileId": "lampPostTop" },
+        { "tx": 34, "ty": 27, "tileId": "lampPostBottom" },
+        { "tx": 40, "ty": 26, "tileId": "lampPostTop" },
+        { "tx": 40, "ty": 27, "tileId": "lampPostBottom" },
+        { "tx": 35, "ty": 31, "tileId": "flowerPotLeft" },
+        { "tx": 36, "ty": 31, "tileId": "flowerPotRight" },
+        { "tx": 38, "ty": 31, "tileId": "flowerPotLeft" },
+        { "tx": 39, "ty": 31, "tileId": "flowerPotRight" }
+      ]
+    }
+  ],
   "avatarStart": {
     "tx": 37,
     "ty": 29

--- a/web/src/data/hub/ravenwatch/questDefs.json
+++ b/web/src/data/hub/ravenwatch/questDefs.json
@@ -3531,6 +3531,35 @@
       "reward": {
         "unlock": "lost-pendant"
       }
+    },
+    {
+      "id": "midsummer-lanterns",
+      "title": "Light the Midsummer Lanterns",
+      "type": "fetch",
+      "giverNpcId": "merchant",
+      "receiverNpcId": "merchant",
+      "festivalId": "midsummer",
+      "offerDialogue": "The Midsummer Fair is upon us! Be a dear and gather the three festival lanterns scattered round the square — we'll string them up together.",
+      "activeDialogue": "Three Midsummer lanterns, dotted about the square. Bring them back and we'll light the fair!",
+      "completeDialogue": "Wonderful — the square's aglow! Happy Midsummer, traveller.",
+      "steps": [
+        {
+          "key": "lanterns",
+          "type": "collect",
+          "pickupIds": [
+            "midsummer-lantern-1",
+            "midsummer-lantern-2",
+            "midsummer-lantern-3"
+          ],
+          "required": 3
+        }
+      ],
+      "reward": {
+        "crystals": 30,
+        "friendship": {
+          "merchant": 10
+        }
+      }
     }
   ],
   "pickupItems": [
@@ -5259,6 +5288,27 @@
       "ty": 30,
       "tileId": "goldChest",
       "questId": "thorin-the-last-watch"
+    },
+    {
+      "id": "midsummer-lantern-1",
+      "tx": 33,
+      "ty": 30,
+      "tileId": "candlestickLitTop",
+      "questId": "midsummer-lanterns"
+    },
+    {
+      "id": "midsummer-lantern-2",
+      "tx": 41,
+      "ty": 30,
+      "tileId": "candlestickLitTop",
+      "questId": "midsummer-lanterns"
+    },
+    {
+      "id": "midsummer-lantern-3",
+      "tx": 37,
+      "ty": 33,
+      "tileId": "candlestickLitTop",
+      "questId": "midsummer-lanterns"
     }
   ],
   "innRumours": [

--- a/web/src/game/hub/hubCalendar.test.ts
+++ b/web/src/game/hub/hubCalendar.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { getActiveFestival, getFestivalOverride, setFestivalOverride, FESTIVALS } from './hubCalendar'
+
+const d = (month: number, day: number) => new Date(2026, month - 1, day)
+
+// In-memory localStorage mock (tests run in node environment).
+const store = new Map<string, string>()
+beforeEach(() => {
+  store.clear()
+  globalThis.localStorage = {
+    getItem:    (k: string) => store.get(k) ?? null,
+    setItem:    (k: string, v: string) => { store.set(k, v) },
+    removeItem: (k: string) => { store.delete(k) },
+    clear:      () => { store.clear() },
+    key:        (i: number) => [...store.keys()][i] ?? null,
+    get length() { return store.size },
+  } as Storage
+})
+afterEach(() => setFestivalOverride(null))
+
+describe('getActiveFestival (date-driven)', () => {
+  it('returns the festival whose window contains the date', () => {
+    expect(getActiveFestival(d(6, 19))?.id).toBe('midsummer')   // mid-June
+    expect(getActiveFestival(d(10, 1))?.id).toBe('harvest')     // October
+  })
+
+  it('handles the year-wrapping Midwinter window', () => {
+    expect(getActiveFestival(d(12, 25))?.id).toBe('midwinter')  // late December
+    expect(getActiveFestival(d(1, 3))?.id).toBe('midwinter')    // early January
+  })
+
+  it('returns null outside every window', () => {
+    expect(getActiveFestival(d(3, 1))).toBeNull()   // March — no festival
+    expect(getActiveFestival(d(8, 1))).toBeNull()   // August — between midsummer & harvest
+  })
+})
+
+describe('override', () => {
+  it('forces a festival regardless of date', () => {
+    setFestivalOverride('midwinter')
+    expect(getActiveFestival(d(6, 19))?.id).toBe('midwinter')   // June, but forced
+    expect(getFestivalOverride()).toBe('midwinter')
+  })
+
+  it("'none' forces no festival even inside a window", () => {
+    setFestivalOverride('none')
+    expect(getActiveFestival(d(6, 19))).toBeNull()
+  })
+
+  it('clears back to date-driven behaviour', () => {
+    setFestivalOverride('harvest')
+    setFestivalOverride(null)
+    expect(getActiveFestival(d(6, 19))?.id).toBe('midsummer')
+  })
+
+  it('ignores an unknown override id', () => {
+    setFestivalOverride('not-a-festival')
+    expect(getActiveFestival(d(6, 19))).toBeNull()
+  })
+})
+
+describe('FESTIVALS registry', () => {
+  it('every festival has a unique id, name, and icon', () => {
+    const ids = FESTIVALS.map(f => f.id)
+    expect(new Set(ids).size).toBe(ids.length)
+    for (const f of FESTIVALS) { expect(f.name).toBeTruthy(); expect(f.icon).toBeTruthy() }
+  })
+})

--- a/web/src/game/hub/hubCalendar.ts
+++ b/web/src/game/hub/hubCalendar.ts
@@ -1,0 +1,69 @@
+// Hub calendar — pure date→season/festival layer (issue #1605). Drives
+// time-limited festival decor, quests, and the HUD badge. Builds on the
+// date→season helper from the weather work. No PixiJS / React here.
+
+import { seasonForDate, type Season } from './weather'
+
+export type { Season }
+export { seasonForDate }
+
+interface MonthDay { month: number; day: number }   // month is 1–12
+
+export interface Festival {
+  id: string
+  name: string
+  icon: string
+  /** Inclusive window in the calendar year; wraps the new year when start > end. */
+  start: MonthDay
+  end: MonthDay
+}
+
+/**
+ * Festival registry — single source of truth for runtime, the map editor, and
+ * Storybook. Windows are real-date driven; add an entry to introduce a festival.
+ */
+export const FESTIVALS: Festival[] = [
+  { id: 'midsummer', name: 'Midsummer Fair',  icon: '🏮', start: { month: 6, day: 1 },  end: { month: 7, day: 15 } },
+  { id: 'harvest',   name: 'Harvest Festival', icon: '🌾', start: { month: 9, day: 15 }, end: { month: 10, day: 31 } },
+  { id: 'midwinter', name: 'Midwinter Feast',  icon: '❄️', start: { month: 12, day: 18 }, end: { month: 1, day: 6 } },
+]
+
+const OVERRIDE_KEY = 'jarv_hub_festival_override'
+
+/** QA override: a festival id, `'none'` (force no festival), or null (use date). */
+export function getFestivalOverride(): string | null {
+  try { return localStorage.getItem(OVERRIDE_KEY) } catch { return null }
+}
+
+export function setFestivalOverride(idOrNull: string | null): void {
+  try {
+    if (idOrNull == null) localStorage.removeItem(OVERRIDE_KEY)
+    else localStorage.setItem(OVERRIDE_KEY, idOrNull)
+  } catch { /* QA convenience — fire and forget */ }
+}
+
+/** mmdd ordinal so windows compare with simple numeric tests. */
+function ord(m: number, d: number): number { return m * 100 + d }
+
+function inWindow(date: Date, f: Festival): boolean {
+  const v = ord(date.getMonth() + 1, date.getDate())
+  const s = ord(f.start.month, f.start.day)
+  const e = ord(f.end.month, f.end.day)
+  return s <= e ? (v >= s && v <= e) : (v >= s || v <= e)   // wraps the new year
+}
+
+/**
+ * The active festival, honoring the QA override, else the first festival whose
+ * window contains `date`. Returns null when none is active.
+ */
+export function getActiveFestival(date: Date = new Date()): Festival | null {
+  const override = getFestivalOverride()
+  if (override === 'none') return null
+  if (override) return FESTIVALS.find(f => f.id === override) ?? null
+  return FESTIVALS.find(f => inWindow(date, f)) ?? null
+}
+
+// Dev-only console hook so QA can force a festival without changing the date.
+if (typeof window !== 'undefined' && (import.meta as { env?: { DEV?: boolean } }).env?.DEV) {
+  ;(window as unknown as { setFestivalOverride?: typeof setFestivalOverride }).setFestivalOverride = setFestivalOverride
+}


### PR DESCRIPTION
- hubCalendar.ts: FESTIVALS registry + getActiveFestival (date window, wrap-safe)
  with QA localStorage override (setFestivalOverride / dev window hook)
- config.ts/loader.ts: per-town festivalDecor -> HUB_FESTIVAL_DECOR bundle
- HubTownCanvas: render the active festival's decor with the base decor loop
- HubWorld: gate festival quests (festivalId) + 'event active' HUD badge
- questDefs.ts: festivalId on HubQuestDef + QuestDefinition
- map editor: festival preview/author selector (toolbar), render + place/move/
  delete routing into the festival group, quest editor festivalId dropdown
- MapEditor stories: per-festival Ravenwatch previews (any date)
- hubCalendar.test.ts: windows, year-wrap, override precedence

Refs #1605, #1640, #1643, #1647

https://claude.ai/code/session_01NrvfVAXqwHRtawwxQKgXmL