### PR TITLE
fix(hub): repair main build — loosen RawConfig.npcSpawnTiles

### DIFF
--- a/web/src/data/hub/config.ts
+++ b/web/src/data/hub/config.ts
@@ -320,7 +320,9 @@ export interface RawConfig {
 
   npcs: RawNpc[]
 
-  npcSpawnTiles: [number, number][]
+  // Loose raw shape: JSON imports infer number[][]; loader.ts casts to the
+  // strict [number, number][] tuple on output.
+  npcSpawnTiles: number[][]
 
   windows?: RawWindow[]
 


### PR DESCRIPTION
## Problem
`main` is red after #1726 merged. A **clean** `tsc` fails in `web/src/data/hub/hubWorldFactory.ts`:

```
error TS2345: ... npcSpawnTiles: Type 'number[][]' is not assignable to '[number, number][]'
```

`RawConfig.npcSpawnTiles` was the only strict-tuple field (`config.ts`), but JSON imports infer `number[][]`. This was latent — local **incremental** `tsc` reused a cached `.tsbuildinfo` and never re-checked `hubWorldFactory.ts`, so it passed locally while CI's clean build failed.

## Fix
One type-only line: `RawConfig.npcSpawnTiles: [number, number][]` → `number[][]` (matches the loose raw-config convention). The loader already casts back to the strict tuple on output (`loader.ts:516`: `...(rawConfig.npcSpawnTiles as [number, number][])`), so nothing downstream changes. The map editor's separate `RawMapConfig` is unaffected.

## Verification
Reproduced the failure with a clean build, then confirmed green:
```
rm -f *.tsbuildinfo && npm run build   # ✓ built (no TS2345)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NrvfVAXqwHRtawwxQKgXmL

---
_Generated by [Claude Code](https://claude.ai/code/session_01NrvfVAXqwHRtawwxQKgXmL)_