### PR TITLE
ci: run build (tsc + vite) on PRs to catch type errors pre-merge

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on:
     branches-ignore:
       - main
     paths:
-      - web/src/**
+      - web/**
       - .github/workflows/test.yml
 
 jobs:
@@ -23,6 +23,19 @@ jobs:
       - name: Install dependencies
         run: npm install
         working-directory: web
+
+      - name: Build (tsc + vite)
+        run: npm run build
+        working-directory: web
+        env:
+          VITE_FIREBASE_API_KEY: ${{ secrets.VITE_FIREBASE_API_KEY }}
+          VITE_FIREBASE_AUTH_DOMAIN: ${{ secrets.VITE_FIREBASE_AUTH_DOMAIN }}
+          VITE_FIREBASE_PROJECT_ID: ${{ secrets.VITE_FIREBASE_PROJECT_ID }}
+          VITE_FIREBASE_STORAGE_BUCKET: ${{ secrets.VITE_FIREBASE_STORAGE_BUCKET }}
+          VITE_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.VITE_FIREBASE_MESSAGING_SENDER_ID }}
+          VITE_FIREBASE_APP_ID: ${{ secrets.VITE_FIREBASE_APP_ID }}
+          VITE_CLOUDINARY_CLOUD_NAME: ${{ secrets.VITE_CLOUDINARY_CLOUD_NAME }}
+          VITE_CLOUDINARY_UPLOAD_PRESET: ${{ secrets.VITE_CLOUDINARY_UPLOAD_PRESET }}
 
       - name: Cache Playwright browsers
         uses: actions/cache@v4


### PR DESCRIPTION
## Why
PR #1726 merged a type error (`npcSpawnTiles` tuple mismatch) that reached `main` and only failed the **post-merge Deploy** build — because the PR **Test** workflow runs `npm test` (vitest) only, never `tsc && vite build`. This adds the build to the PR workflow so type errors are caught **before** merge.

## Changes (`.github/workflows/test.yml`)
- **New "Build (tsc + vite)" step** — runs `npm run build` in `web/`, placed after `Install dependencies` and **before** the Playwright steps so a type error fails fast without paying for the browser install. Uses the same `VITE_FIREBASE_*` + `VITE_CLOUDINARY_*` env block as the Deploy build.
- **Broadened `paths` trigger** `web/src/**` → `web/**` so changes to `tsconfig*.json` / `vite.config.ts` / `package.json` also run CI (a src-only trigger would miss a config-driven type break).

No app code changes. `main`'s build is already green (fixed in #1728), so the new step passes — and this PR's own run is the proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NrvfVAXqwHRtawwxQKgXmL

---
_Generated by [Claude Code](https://claude.ai/code/session_01NrvfVAXqwHRtawwxQKgXmL)_