### PR TITLE
Searchable entity dropdowns + cross-town quest chains

### DIFF
--- a/docs/hubworld.md
+++ b/docs/hubworld.md
@@ -1033,3 +1033,48 @@ festival's group (not `exteriorDecor`). The quest editor has a **Festival**
 dropdown for `festivalId`. The `MapEditor` Storybook stories
 (`Ravenwatch · Midsummer/Harvest/Midwinter`) seed `initialFestival` so each
 festival is previewable regardless of today's date.
+
+---
+
+## §14 — Quests: prerequisites & cross-town chains
+
+### Prerequisite syntax
+A quest's `prerequisite` is a single string of **AND-combined conditions**
+joined with `|` (all must hold), parsed by `checkPrerequisite` in
+`HubWorld.tsx`:
+
+```
+quest:<questId>                       // that quest is completed
+friendship:<npcId>:<level>            // friendship ≥ level
+relationship:<npcId>:<track>:<level>  // relationship track at ≥ level
+```
+
+Example: `"quest:millhaven-mill-grain | friendship:innkeeper-rosie:2"`.
+
+> A **bare** id (no `quest:` prefix) does **not** gate — `checkPrerequisite`
+> treats unknown tokens as satisfied. The map-editor **Prerequisite** builder
+> always writes the `quest:<id>` form, and re-serialises any legacy bare ids on
+> save. Quest state is global, so a prerequisite may reference a quest defined in
+> **any town**.
+
+### Cross-town chains & steps
+Quest progress lives in one global store keyed by quest id
+(`game/hub/quests.ts`), and `ALL_QUEST_DEFS` (`hubWorldFactory.ts`) aggregates
+every town. Therefore:
+
+- **Chains span towns** — a quest in town B can require (`prerequisite`) a quest
+  from town A.
+- **Steps span towns** — a quest's `collect` step may list `pickupIds` that live
+  in another town, and a `deliver` step may target an NPC in another town.
+  `handleItemPickup` resolves the quest via `allQuestDefs`, and the NPC-tap
+  delivery/turn-in logic scans `allQuestDefs` for a pending deliver step
+  addressed to the tapped NPC (or a ready receiver) — so the quest advances and
+  completes wherever the relevant pickup/NPC is. Offers still only appear on the
+  giver in the quest's own town; the active-quest cap (2) counts globally.
+
+### Map editor
+Every id field (NPC, building, quest, pickup, interior, dialogue tree) is a
+**searchable dropdown** (`EntityRefPicker`), and quest / cross-town refs are
+**grouped by town**. The quest editor's deliver-target and pickup steps use
+all-town pickers; the **Prerequisite** field is a structured condition builder
+(quest / friendship / relationship rows).

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -246,18 +246,33 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onEndless, onWorldMap
   // Quest NPC state: maps npcId → 'offer' | 'ready' | null, read imperatively by PixiJS ticker
   const questNpcStateRef = useRef(new Map<string, 'offer' | 'ready' | null>())
   {
+    // NPCs (and animals) physically present in the current town. Offers only
+    // surface on a present giver; 'ready' indicators surface on a present
+    // receiver or deliver-target — including for quests accepted in another town.
+    const presentNpcs = new Set<string>([
+      ...locationData.HUB_NPCS.map(n => n.id),
+      ...locationData.HUB_ANIMALS.map(a => a.id),
+    ])
     const m = new Map<string, 'offer' | 'ready' | null>()
-    const activeCount = questDefs.filter(q => getQuestState(q.id).status === 'active').length
+    const activeCount = allQuestDefs.filter(q => getQuestState(q.id).status === 'active').length
     const atCap = activeCount >= 2
-    for (const quest of questDefs) {
+    for (const quest of allQuestDefs) {
       const state = getQuestState(quest.id)
       if (state.status === 'available') {
+        if (!presentNpcs.has(quest.giverNpcId)) continue
         const prereqMet = !quest.prerequisite || checkPrerequisite(quest.prerequisite)
         const hoursMet  = !quest.availableHours || hourInRange(gameHour, quest.availableHours.start, quest.availableHours.end)
         const festivalMet = !quest.festivalId || quest.festivalId === activeFestival?.id
         if (prereqMet && hoursMet && festivalMet && !atCap) m.set(quest.giverNpcId, 'offer')
       } else if (state.status === 'active') {
-        if (isQuestReadyToComplete(quest)) m.set(quest.receiverNpcId, 'ready')
+        if (isQuestReadyToComplete(quest) && presentNpcs.has(quest.receiverNpcId)) {
+          m.set(quest.receiverNpcId, 'ready')
+        } else {
+          const pend = quest.steps.find(s =>
+            s.type === 'deliver' && !!s.targetNpcId && presentNpcs.has(s.targetNpcId) &&
+            getQuestProgress(quest.id, s.key) < s.required)
+          if (pend?.targetNpcId) m.set(pend.targetNpcId, 'ready')
+        }
       }
     }
     questNpcStateRef.current = m
@@ -528,7 +543,9 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onEndless, onWorldMap
 
     if (!questId) return
 
-    const quest = questDefs.find(q => q.id === questId)
+    // Quests are resolved across ALL towns so a pickup collected in one town can
+    // advance a quest that was accepted in another (cross-town steps).
+    const quest = allQuestDefs.find(q => q.id === questId)
     if (!quest) return
     const state = getQuestState(questId)
     if (state.status !== 'active') return
@@ -767,6 +784,26 @@ function hasOfferableQuest(giverId: string): boolean {
       locationData.HUB_ANIMALS.find(a => a.id === npcId)
     const speakerName = npcDef?.name ?? ''
 
+    // Cross-town deliveries: scan EVERY town's quests (not just the current one)
+    // for an active quest with a pending deliver step addressed to this NPC, or
+    // one whose receiver is this NPC and is ready to hand in. This lets a quest
+    // accepted elsewhere be progressed / completed here.
+    const pendingDelivery = () => {
+      for (const q of allQuestDefs) {
+        if (getQuestState(q.id).status !== 'active') continue
+        const step = q.steps.find(s => s.type === 'deliver' && s.targetNpcId === npcId && getQuestProgress(q.id, s.key) < s.required)
+        if (step) return { quest: q, step }
+      }
+      return null
+    }
+    const readyToHandIn = () => {
+      for (const q of allQuestDefs) {
+        if (getQuestState(q.id).status !== 'active') continue
+        if (q.receiverNpcId === npcId && isQuestReadyToComplete(q)) return q
+      }
+      return null
+    }
+
     // ── Inn rumour handling (Innkeeper Rosie) ───────────────────────────────
     if (npcId === 'innkeeper-rosie' && npcDef?.innRumours) {
       const heard = getHeardConvoIds()
@@ -797,37 +834,20 @@ function hasOfferableQuest(giverId: string): boolean {
       // accept. Shown first (primary) so it reads as the obvious action.
       let questChoice: DialogueChoice | undefined
 
-      // (a) Pending delivery addressed to this NPC (active questReceive quest).
-      const receiveIds = npcDef.questReceive
-        ? (Array.isArray(npcDef.questReceive) ? npcDef.questReceive : [npcDef.questReceive])
-        : []
-      for (const qid of receiveIds) {
-        const quest = questDefs.find(q => q.id === qid)
-        if (!quest || getQuestState(quest.id).status !== 'active') continue
-        const pending = quest.steps.find(s =>
-          s.type === 'deliver' && s.targetNpcId === npcId &&
-          getQuestProgress(quest.id, s.key) < s.required)
-        if (pending) {
-          questChoice = { label: 'Hand over the message', primary: true, onClick: () => {
-            incrementQuestProgress(quest.id, pending.key)
-            refreshState()
-            if (isQuestReadyToComplete(quest)) completeQuestFor(quest, speakerName)
-            else setDialogueEvent({ speakerName, text: getActiveDialogue(quest) })
-          } }
-          break
-        }
-        if (isQuestReadyToComplete(quest)) {
-          questChoice = { label: 'Turn in the quest', primary: true,
-            onClick: () => completeQuestFor(quest, speakerName) }
-          break
-        }
+      // (a) Pending delivery addressed to this NPC (any town's active quest).
+      const del = pendingDelivery()
+      if (del) {
+        questChoice = { label: 'Hand over the message', primary: true, onClick: () => {
+          incrementQuestProgress(del.quest.id, del.step.key)
+          refreshState()
+          if (isQuestReadyToComplete(del.quest)) completeQuestFor(del.quest, speakerName)
+          else setDialogueEvent({ speakerName, text: getActiveDialogue(del.quest) })
+        } }
       }
 
-      // (b) A quest this NPC gives that is ready to be turned in to itself.
+      // (b) A quest whose receiver is this NPC and is ready to hand in.
       if (!questChoice) {
-        const ready = questDefs.find(q =>
-          q.giverNpcId === npcId && q.receiverNpcId === npcId &&
-          getQuestState(q.id).status === 'active' && isQuestReadyToComplete(q))
+        const ready = readyToHandIn()
         if (ready) questChoice = { label: 'Turn in the quest', primary: true,
           onClick: () => completeQuestFor(ready, speakerName) }
       }
@@ -843,33 +863,23 @@ function hasOfferableQuest(giverId: string): boolean {
       return
     }
 
-    // ── Quest delivery / completion (receiver NPC tapped) ───────────────────
-    if (npcDef?.questReceive) {
-      const receiveIds = Array.isArray(npcDef.questReceive) ? npcDef.questReceive : [npcDef.questReceive]
-      for (const questId of receiveIds) {
-        const quest = questDefs.find(q => q.id === questId)
-        if (!quest || getQuestState(quest.id).status !== 'active') continue
-
-        // Register a pending delivery addressed to this NPC (guarded so repeat
-        // taps don't over-count).
-        const pending = quest.steps.find(s =>
-          s.type === 'deliver' && s.targetNpcId === npcId &&
-          getQuestProgress(quest.id, s.key) < s.required)
-        if (pending) {
-          incrementQuestProgress(quest.id, pending.key)
-          refreshState()
-          if (isQuestReadyToComplete(quest)) completeQuestFor(quest, speakerName)
-          // Delivered but the quest still needs more — acknowledge so the player
-          // sees feedback instead of (e.g.) the NPC's screen opening silently.
-          else setDialogueEvent({ speakerName, text: getActiveDialogue(quest) })
-          return
-        }
-
-        // Nothing to deliver here, but the quest may be ready to hand in.
-        if (isQuestReadyToComplete(quest)) {
-          completeQuestFor(quest, speakerName)
-          return
-        }
+    // ── Quest delivery / completion (receiver / deliver-target NPC tapped) ──
+    // Scans every town's active quests so cross-town deliveries resolve here.
+    {
+      const del = pendingDelivery()
+      if (del) {
+        incrementQuestProgress(del.quest.id, del.step.key)
+        refreshState()
+        if (isQuestReadyToComplete(del.quest)) completeQuestFor(del.quest, speakerName)
+        // Delivered but the quest still needs more — acknowledge so the player
+        // sees feedback instead of (e.g.) the NPC's screen opening silently.
+        else setDialogueEvent({ speakerName, text: getActiveDialogue(del.quest) })
+        return
+      }
+      const ready = readyToHandIn()
+      if (ready) {
+        completeQuestFor(ready, speakerName)
+        return
       }
     }
 

--- a/web/src/components/mapEditor/EntityInspector.tsx
+++ b/web/src/components/mapEditor/EntityInspector.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import type { SelectedEntity, RawMapConfig, RawInterior, RawBlockedPath, RawLockedDoor, Zlayer, RawDecorItem, RawNpc, RawBuilding, RawAnimal, RawInteractable, RawInteractableReaction, RawWeather, PickKind } from './mapEditorTypes'
 import type { MapId } from '../../data/hub/hubWorldFactory'
 import { EntityRefPicker } from './EntityRefPicker'
-import { buildingRefOptions, questRefOptions, interiorRefOptions } from './entityRefs'
+import { buildingRefOptions, allQuestOptions, type RefOption } from './entityRefs'
 import { BASE_CHIP_TILES } from '../../data/tiles/baseChipIndex'
 import { resolveTileRef } from '../../data/tiles/tileIndex'
 import type { WallMaterial } from '../../data/tiles/buildingMaterials'
@@ -1213,24 +1213,21 @@ function PathDecorEditor({ label, decor, anchor, onChange }: {
 }
 
 function BlockedPathInspector({
-  bp, onUpdate, onDelete, onPick,
+  bp, onUpdate, onDelete, onPick, questOptions,
 }: {
   bp: RawBlockedPath
   onUpdate: (patch: Partial<RawBlockedPath>) => void
   onDelete: () => void
   onPick?: () => void
+  questOptions: RefOption[]
 }) {
   const anchor = bp.blockedTiles[0] ?? [0, 0]
   return (
     <div>
       <Field label="ID"><span style={{ fontFamily: 'monospace', fontSize: 11, color: '#aaa' }}>{bp.id}</span></Field>
-      <Field label="Quest ID (cleared when complete)">
-        <input
-          value={bp.questId}
-          onChange={e => onUpdate({ questId: e.target.value })}
-          placeholder="quest id"
-          style={{ width: '100%', padding: '3px 5px', background: '#111', border: '1px solid #444', color: '#eee', borderRadius: 3, fontSize: 11, fontFamily: 'monospace', boxSizing: 'border-box' }}
-        />
+      <Field label="Quest (cleared when complete)">
+        <EntityRefPicker value={bp.questId} options={questOptions} placeholder="Search quests…"
+          onChange={v => onUpdate({ questId: v })} />
       </Field>
       <Field label={`Blocked Tiles (${bp.blockedTiles.length})`}>
         <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
@@ -1334,12 +1331,13 @@ function AreaInspector({
   )
 }
 
-function TreasureInspector({ treasure, onUpdate, onMove, onDelete, onPick }: {
+function TreasureInspector({ treasure, onUpdate, onMove, onDelete, onPick, buildingOptions }: {
   treasure: Treasure
   onUpdate: (patch: Partial<Treasure>) => void
   onMove: (tx: number, ty: number) => void
   onDelete: () => void
   onPick?: () => void
+  buildingOptions: RefOption[]
 }) {
   const [picking, setPicking] = useState<null | 'tile' | 'collected'>(null)
   const inputStyle: React.CSSProperties = {
@@ -1370,8 +1368,8 @@ function TreasureInspector({ treasure, onUpdate, onMove, onDelete, onPick }: {
         {picking === 'collected' && <TilePicker current={treasure.collectedTileId ?? ''} onChange={tileId => onUpdate({ collectedTileId: tileId })} onClose={() => setPicking(null)} />}
       </Field>
       <Field label="Building (interior, optional)">
-        <input style={inputStyle} value={treasure.buildingId ?? ''} placeholder="building ID"
-          onChange={e => onUpdate({ buildingId: e.target.value || undefined })} />
+        <EntityRefPicker value={treasure.buildingId ?? ''} options={buildingOptions} placeholder="Search buildings…"
+          onChange={v => onUpdate({ buildingId: v || undefined })} />
       </Field>
       <Field label="Reward — crystals">
         {numInput(crystals, n => onUpdate({ reward: { ...reward, crystals: n } }))}
@@ -1395,9 +1393,10 @@ function TreasureInspector({ treasure, onUpdate, onMove, onDelete, onPick }: {
 // ── Interactables ──────────────────────────────────────────────────────────────
 const REACTION_TYPES = ['dialogue', 'screen', 'giveItem', 'quest', 'move'] as const
 
-function ReactionEditor({ reaction, onChange }: {
+function ReactionEditor({ reaction, onChange, questOptions }: {
   reaction: RawInteractableReaction
   onChange: (r: RawInteractableReaction) => void
+  questOptions: RefOption[]
 }) {
   const inp: React.CSSProperties = { width: '100%', padding: '3px 5px', background: '#111', border: '1px solid #444', color: '#eee', borderRadius: 3, fontSize: 11, boxSizing: 'border-box' }
   const numSm: React.CSSProperties = { width: 50, padding: '2px 4px', background: '#111', border: '1px solid #444', color: '#eee', borderRadius: 3, fontSize: 11 }
@@ -1422,7 +1421,7 @@ function ReactionEditor({ reaction, onChange }: {
 
       {reaction.type === 'quest' && (
         <>
-          <input style={inp} placeholder="quest id" value={reaction.questId ?? ''} onChange={e => onChange({ ...reaction, questId: e.target.value })} />
+          <EntityRefPicker value={reaction.questId ?? ''} options={questOptions} placeholder="Search quests…" onChange={v => onChange({ ...reaction, questId: v })} />
           <input style={inp} placeholder="speaker name (optional)" value={reaction.speakerName ?? ''} onChange={e => onChange({ ...reaction, speakerName: e.target.value || undefined })} />
         </>
       )}
@@ -1459,12 +1458,14 @@ function ReactionEditor({ reaction, onChange }: {
   )
 }
 
-function InteractableInspector({ it, onUpdate, onMove, onDelete, onPick }: {
+function InteractableInspector({ it, onUpdate, onMove, onDelete, onPick, buildingOptions, questOptions }: {
   it: RawInteractable
   onUpdate: (patch: Partial<RawInteractable>) => void
   onMove: (tx: number, ty: number) => void
   onDelete: () => void
   onPick?: () => void
+  buildingOptions: RefOption[]
+  questOptions: RefOption[]
 }) {
   const [pickingDecor, setPickingDecor] = useState<number | null>(null)
   const inp: React.CSSProperties = { width: '100%', padding: '3px 5px', background: '#111', border: '1px solid #444', color: '#eee', borderRadius: 3, fontSize: 11, boxSizing: 'border-box' }
@@ -1486,7 +1487,7 @@ function InteractableInspector({ it, onUpdate, onMove, onDelete, onPick }: {
         {onPick && <button style={BTN_PICK} onClick={onPick}>📍 Pick on map</button>}
       </Field>
       <Field label="Building (interior, optional)">
-        <input style={inp} value={it.building ?? ''} placeholder="building ID" onChange={e => onUpdate({ building: e.target.value || undefined })} />
+        <EntityRefPicker value={it.building ?? ''} options={buildingOptions} placeholder="Search buildings…" onChange={v => onUpdate({ building: v || undefined })} />
       </Field>
       <Field label="Hit area (tiles)">
         <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
@@ -1531,7 +1532,7 @@ function InteractableInspector({ it, onUpdate, onMove, onDelete, onPick }: {
                 <button style={{ padding: '0 6px', background: '#4a1a1a', border: '1px solid #922', color: '#f88', borderRadius: 3, fontSize: 10, cursor: 'pointer' }}
                   onClick={() => onUpdate({ reactions: reactions.filter((_, j) => j !== i) })}>✕</button>
               </div>
-              <ReactionEditor reaction={r} onChange={nr => onUpdate({ reactions: reactions.map((x, j) => j === i ? nr : x) })} />
+              <ReactionEditor reaction={r} questOptions={questOptions} onChange={nr => onUpdate({ reactions: reactions.map((x, j) => j === i ? nr : x) })} />
             </div>
           ))}
           <button style={{ padding: '2px 8px', background: '#1e2e1e', border: '1px solid #3a5a3a', color: '#6d6', borderRadius: 3, fontSize: 10, cursor: 'pointer', alignSelf: 'flex-start' }}
@@ -1801,6 +1802,9 @@ export function EntityInspector({
   onUpdateTreasure, onUpdateInteractable, onUpdateConfig,
   onAddTreasure, onAddInteractable, onAddBlockedPath,
 }: Props) {
+  // Reference options for the searchable id pickers in the inspectors.
+  const buildingOpts = buildingRefOptions(mapId, configData.buildings ?? [])
+  const allQuestOpts = allQuestOptions()
   const panelStyle: React.CSSProperties = {
     display: 'flex', flexDirection: 'column', height: '100%',
     background: '#1a1a2e', color: '#ccc', fontSize: 12,
@@ -1989,6 +1993,7 @@ export function EntityInspector({
           {onUpdateTreasure ? (
             <TreasureInspector
               treasure={t}
+              buildingOptions={buildingOpts}
               onUpdate={patch => onUpdateTreasure(selectedEntity.index, patch)}
               onMove={(tx, ty) => onMoveEntity(selectedEntity, tx, ty)}
               onDelete={() => onDelete(selectedEntity)}
@@ -2115,6 +2120,7 @@ export function EntityInspector({
           <BlockedPathInspector
             key={bp.id}
             bp={bp}
+            questOptions={allQuestOpts}
             onUpdate={patch => onUpdateBlockedPath(selectedEntity.index, patch)}
             onDelete={() => onDeleteBlockedPath(selectedEntity.index)}
             onPick={onPickLocation ? () => onPickLocation('blockedTile', selectedEntity.index) : undefined}
@@ -2168,6 +2174,8 @@ export function EntityInspector({
         <div style={bodyStyle}>
           <InteractableInspector
             it={it}
+            buildingOptions={buildingOpts}
+            questOptions={allQuestOpts}
             onUpdate={patch => onUpdateInteractable(selectedEntity.index, patch)}
             onMove={(tx, ty) => onMoveEntity(selectedEntity, tx, ty)}
             onDelete={() => onDelete(selectedEntity)}

--- a/web/src/components/mapEditor/EntityInspector.tsx
+++ b/web/src/components/mapEditor/EntityInspector.tsx
@@ -1,5 +1,8 @@
 import React, { useState } from 'react'
 import type { SelectedEntity, RawMapConfig, RawInterior, RawBlockedPath, RawLockedDoor, Zlayer, RawDecorItem, RawNpc, RawBuilding, RawAnimal, RawInteractable, RawInteractableReaction, RawWeather, PickKind } from './mapEditorTypes'
+import type { MapId } from '../../data/hub/hubWorldFactory'
+import { EntityRefPicker } from './EntityRefPicker'
+import { buildingRefOptions, questRefOptions, interiorRefOptions } from './entityRefs'
 import { BASE_CHIP_TILES } from '../../data/tiles/baseChipIndex'
 import { resolveTileRef } from '../../data/tiles/tileIndex'
 import type { WallMaterial } from '../../data/tiles/buildingMaterials'
@@ -41,6 +44,7 @@ export type GlowPatch = Partial<{ glow: boolean; glowRadius: number; pulse: bool
 
 interface Props {
   selectedEntity:   SelectedEntity | null
+  mapId:            MapId
   configData:       RawMapConfig
   activeInteriorId: string | null
   activeLevel:      number
@@ -1782,7 +1786,7 @@ function PondEditor({ configData, onUpdateConfig, numSm, addBtn, xBtn, anchor }:
 }
 
 export function EntityInspector({
-  selectedEntity, configData, activeInteriorId, activeLevel, viewMode,
+  selectedEntity, mapId, configData, activeInteriorId, activeLevel, viewMode,
   onSetActiveLevel, onUpdateBuilding, onUpdateDecorMinLevel,
   onDelete, onMoveEntity, onZlayerChange, onUpdateGlow, onUpdatePickupGlow, onDialogueChange,
   onOpenInterior, onCloseInterior, onUpdateStreetEntry,

--- a/web/src/components/mapEditor/EntityRefPicker.tsx
+++ b/web/src/components/mapEditor/EntityRefPicker.tsx
@@ -1,0 +1,114 @@
+import React, { useState, useMemo, useRef, useEffect } from 'react'
+import type { RefOption } from './entityRefs'
+
+const FIELD: React.CSSProperties = {
+  width: '100%', padding: '3px 6px', background: '#111', border: '1px solid #444',
+  color: '#eee', borderRadius: 3, fontSize: 11, boxSizing: 'border-box',
+}
+
+function labelFor(options: RefOption[], value: string): string | undefined {
+  return options.find(o => o.value === value)?.label
+}
+
+/**
+ * Searchable dropdown for picking an entity id (npc / building / quest / pickup
+ * / interior …). Options carry an optional `group` (town) for cross-town refs.
+ * Shows the resolved label for the current value; unknown values still round-trip
+ * (rendered as "(custom)") and can be entered when `allowFreeText`.
+ */
+export function EntityRefPicker({
+  value, onChange, options, placeholder = 'Search…', allowFreeText = true,
+}: {
+  value: string
+  onChange: (value: string) => void
+  options: RefOption[]
+  placeholder?: string
+  allowFreeText?: boolean
+}) {
+  const [open, setOpen] = useState(false)
+  const [search, setSearch] = useState('')
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    const onDoc = (e: MouseEvent) => { if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false) }
+    document.addEventListener('mousedown', onDoc)
+    return () => document.removeEventListener('mousedown', onDoc)
+  }, [open])
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase()
+    const list = q ? options.filter(o => o.value.toLowerCase().includes(q) || o.label.toLowerCase().includes(q) || (o.group ?? '').toLowerCase().includes(q)) : options
+    return list.slice(0, 200)
+  }, [search, options])
+
+  const resolved = labelFor(options, value)
+  const pick = (v: string) => { onChange(v); setOpen(false); setSearch('') }
+
+  return (
+    <div ref={ref} style={{ position: 'relative' }}>
+      <div onClick={() => setOpen(o => !o)} style={{ ...FIELD, cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 4 }}>
+        <span style={{ flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', color: value ? '#eee' : '#666' }}>
+          {value ? (resolved ?? `${value} (custom)`) : placeholder}
+        </span>
+        <span style={{ fontSize: 10, color: '#666' }}>{open ? '▾' : '▸'}</span>
+      </div>
+      {open && (
+        <div style={{ position: 'absolute', zIndex: 50, left: 0, right: 0, marginTop: 2, background: '#0e0e1a', border: '1px solid #555', borderRadius: 4, padding: 6 }}>
+          <input autoFocus value={search} onChange={e => setSearch(e.target.value)} placeholder={placeholder} style={{ ...FIELD, marginBottom: 4 }} />
+          <div style={{ maxHeight: 200, overflowY: 'auto', display: 'flex', flexDirection: 'column', gap: 1 }}>
+            <button onClick={() => pick('')} style={optStyle(value === '')}>— none —</button>
+            {filtered.map(o => (
+              <button key={(o.group ?? '') + o.value} title={o.value} onClick={() => pick(o.value)} style={optStyle(o.value === value)}>
+                <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{o.label}</span>
+                {o.group && <span style={{ marginLeft: 'auto', fontSize: 9, color: '#7af', flexShrink: 0, paddingLeft: 6 }}>{o.group}</span>}
+              </button>
+            ))}
+            {filtered.length === 0 && <span style={{ color: '#666', fontSize: 10, padding: 4 }}>No matches</span>}
+          </div>
+          {allowFreeText && search.trim() && !options.some(o => o.value === search.trim()) && (
+            <button onClick={() => pick(search.trim())} style={{ marginTop: 4, fontSize: 10, color: '#8af', background: 'none', border: 'none', cursor: 'pointer', width: '100%', textAlign: 'left' }}>
+              Use custom id "{search.trim()}"
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function optStyle(active: boolean): React.CSSProperties {
+  return {
+    display: 'flex', alignItems: 'center', width: '100%', textAlign: 'left',
+    padding: '3px 6px', fontSize: 11, cursor: 'pointer', borderRadius: 3,
+    background: active ? '#2a4a7a' : 'transparent',
+    border: active ? '1px solid #5a8aee' : '1px solid transparent',
+    color: '#ccc',
+  }
+}
+
+/** Multi-select variant — manages a list of ids (used for pickupIds). */
+export function EntityRefMultiPicker({
+  values, onChange, options, placeholder = 'Add id…',
+}: {
+  values: string[]
+  onChange: (values: string[]) => void
+  options: RefOption[]
+  placeholder?: string
+}) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+      {values.map((v, i) => (
+        <div key={i} style={{ display: 'flex', gap: 4, alignItems: 'center' }}>
+          <div style={{ flex: 1 }}>
+            <EntityRefPicker value={v} options={options} onChange={nv => onChange(values.map((x, j) => j === i ? nv : x))} placeholder={placeholder} />
+          </div>
+          <button onClick={() => onChange(values.filter((_, j) => j !== i))}
+            style={{ padding: '1px 6px', background: '#4a1a1a', border: '1px solid #922', color: '#f88', borderRadius: 3, fontSize: 10, cursor: 'pointer' }}>✕</button>
+        </div>
+      ))}
+      <button onClick={() => onChange([...values, ''])}
+        style={{ padding: '2px 8px', background: '#1e2e1e', border: '1px solid #3a5a3a', color: '#6d6', borderRadius: 3, fontSize: 10, cursor: 'pointer', alignSelf: 'flex-start' }}>+ Add</button>
+    </div>
+  )
+}

--- a/web/src/components/mapEditor/MapEditor.tsx
+++ b/web/src/components/mapEditor/MapEditor.tsx
@@ -327,6 +327,7 @@ export function MapEditor({ initialMapId = 'ravenwatch', initialFestival = undef
           <div style={{ width: 220, flexShrink: 0, borderLeft: '1px solid #333', overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
             <EntityInspector
               selectedEntity={state.selectedEntity}
+              mapId={state.mapId}
               configData={state.configData}
               activeInteriorId={state.activeInteriorId}
               activeLevel={state.activeLevel}
@@ -396,6 +397,7 @@ export function MapEditor({ initialMapId = 'ravenwatch', initialFestival = undef
             />
             <NpcQuestDrawer
               tab={drawerTab}
+              mapId={state.mapId}
               focusedNpcIndex={focusedNpcIndex}
               configData={state.configData}
               questDefsData={questDefsData}

--- a/web/src/components/mapEditor/entityRefs.ts
+++ b/web/src/components/mapEditor/entityRefs.ts
@@ -1,0 +1,124 @@
+// Reference-option builders for the searchable entity pickers in the map editor.
+//
+// Each builder returns a flat list of { value, label, group? } options. For the
+// CURRENT town the live editor data is passed in (so just-added entities show);
+// other towns are read from the static config / quest maps. Quests are
+// cross-town by default (chains span towns); local entities (npc/building/
+// interior/pickup) only include other towns when `crossTown` is set.
+
+import type { MapId, QuestDefsJson } from '../../data/hub/hubWorldFactory'
+import { QUEST_DEFS_BY_MAP } from '../../data/hub/hubWorldFactory'
+import type { RawMapConfig } from './mapEditorTypes'
+import { RAW_CONFIGS } from './useMapEditorState'
+
+export interface RefOption {
+  value: string
+  label: string
+  group?: string
+}
+
+export const TOWN_LABELS: Record<MapId, string> = {
+  ravenwatch: 'Ravenwatch',
+  millhaven: 'Millhaven',
+  ironholdkeep: 'Ironhold Keep',
+  thornwoodcamp: 'Thornwood Camp',
+  capitalcity: 'Capital City',
+  royalpalace: 'Royal Palace',
+  saltmereport: 'Saltmere Port',
+  gearford: 'Gearford',
+  harrowfield: 'Harrowfield',
+  appleford: 'Appleford',
+  gravemoor: 'Gravemoor',
+  hollowmere: 'Hollowmere',
+  dreadspirecitadel: 'Dreadspire Citadel',
+}
+
+export function townLabel(map: MapId): string {
+  return TOWN_LABELS[map] ?? map
+}
+
+const ALL_MAPS = Object.keys(TOWN_LABELS) as MapId[]
+
+// Run `fn` for the current town (with the live data) and, when crossTown, for
+// every other town (with static data). `group` is the town label, omitted for
+// the current town so its entries read cleanly.
+function eachTown<L, S>(
+  currentMap: MapId,
+  liveCurrent: L,
+  staticFor: (map: MapId) => S,
+  crossTown: boolean,
+  emit: (data: L | S, group: string | undefined, isCurrent: boolean) => void,
+) {
+  emit(liveCurrent, undefined, true)
+  if (!crossTown) return
+  for (const map of ALL_MAPS) {
+    if (map === currentMap) continue
+    emit(staticFor(map), townLabel(map), false)
+  }
+}
+
+type NpcLite = { id: string; name?: string }
+type QuestLite = { id: string; title?: string }
+type PickupLite = { id: string }
+type BuildingLite = { id?: string }
+
+function npcsOf(cfg: RawMapConfig | undefined): NpcLite[] { return (cfg?.npcs ?? []) as NpcLite[] }
+function questsOf(q: QuestDefsJson | undefined): QuestLite[] { return ((q?.quests as QuestLite[] | undefined) ?? []) }
+function pickupsOf(q: QuestDefsJson | undefined): PickupLite[] { return (q?.pickupItems ?? []) as PickupLite[] }
+function dialoguesOf(q: QuestDefsJson | undefined): QuestLite[] { return ((q?.dialogues as QuestLite[] | undefined) ?? []) }
+
+export function npcRefOptions(currentMap: MapId, currentNpcs: NpcLite[], crossTown = false): RefOption[] {
+  const out: RefOption[] = []
+  eachTown<NpcLite[], NpcLite[]>(currentMap, currentNpcs, m => npcsOf(RAW_CONFIGS[m]), crossTown, (npcs, group) => {
+    for (const n of npcs) if (n.id) out.push({ value: n.id, label: n.name ? `${n.name} (${n.id})` : n.id, group })
+  })
+  return out
+}
+
+export function buildingRefOptions(currentMap: MapId, currentBuildings: BuildingLite[], crossTown = false): RefOption[] {
+  const out: RefOption[] = []
+  eachTown<BuildingLite[], BuildingLite[]>(currentMap, currentBuildings, m => (RAW_CONFIGS[m]?.buildings ?? []) as BuildingLite[], crossTown, (bs, group) => {
+    for (const b of bs) if (b.id) out.push({ value: b.id, label: b.id, group })
+  })
+  return out
+}
+
+export function interiorRefOptions(currentMap: MapId, currentInteriors: Record<string, { name?: string }> | undefined, crossTown = false): RefOption[] {
+  const out: RefOption[] = []
+  eachTown(currentMap, currentInteriors ?? {}, m => (RAW_CONFIGS[m]?.interiors ?? {}) as Record<string, { name?: string }>, crossTown, (ints, group) => {
+    for (const [id, i] of Object.entries(ints)) out.push({ value: id, label: i?.name ? `${i.name} (${id})` : id, group })
+  })
+  return out
+}
+
+export function pickupRefOptions(currentMap: MapId, currentPickups: PickupLite[], crossTown = false): RefOption[] {
+  const out: RefOption[] = []
+  eachTown<PickupLite[], PickupLite[]>(currentMap, currentPickups, m => pickupsOf(QUEST_DEFS_BY_MAP[m]), crossTown, (ps, group) => {
+    for (const p of ps) if (p.id) out.push({ value: p.id, label: p.id, group })
+  })
+  return out
+}
+
+export function questRefOptions(currentMap: MapId, currentQuests: QuestLite[], crossTown = true): RefOption[] {
+  const out: RefOption[] = []
+  eachTown<QuestLite[], QuestLite[]>(currentMap, currentQuests, m => questsOf(QUEST_DEFS_BY_MAP[m]), crossTown, (qs, group) => {
+    for (const q of qs) if (q.id) out.push({ value: q.id, label: q.title ? `${q.title} (${q.id})` : q.id, group })
+  })
+  return out
+}
+
+export function dialogueTreeRefOptions(currentMap: MapId, currentDialogues: QuestLite[], crossTown = false): RefOption[] {
+  const out: RefOption[] = []
+  eachTown<QuestLite[], QuestLite[]>(currentMap, currentDialogues, m => dialoguesOf(QUEST_DEFS_BY_MAP[m]), crossTown, (ds, group) => {
+    for (const d of ds) if (d.id) out.push({ value: d.id, label: d.id, group })
+  })
+  return out
+}
+
+/** Town that defines a given quest id (for cross-town badges). */
+export function townOfQuest(questId: string): MapId | undefined {
+  for (const map of ALL_MAPS) {
+    if (questsOf(QUEST_DEFS_BY_MAP[map]).some(q => q.id === questId)) return map
+  }
+  return undefined
+}

--- a/web/src/components/mapEditor/entityRefs.ts
+++ b/web/src/components/mapEditor/entityRefs.ts
@@ -115,6 +115,18 @@ export function dialogueTreeRefOptions(currentMap: MapId, currentDialogues: Ques
   return out
 }
 
+// Quest options across EVERY town (including the current one, from static data).
+// Used by the inspector pickers, which don't have the live questDefs in scope.
+export function allQuestOptions(): RefOption[] {
+  const out: RefOption[] = []
+  for (const map of ALL_MAPS) {
+    for (const q of questsOf(QUEST_DEFS_BY_MAP[map])) {
+      if (q.id) out.push({ value: q.id, label: q.title ? `${q.title} (${q.id})` : q.id, group: townLabel(map) })
+    }
+  }
+  return out
+}
+
 /** Town that defines a given quest id (for cross-town badges). */
 export function townOfQuest(questId: string): MapId | undefined {
   for (const map of ALL_MAPS) {

--- a/web/src/components/mapEditor/mapEditorTypes.ts
+++ b/web/src/components/mapEditor/mapEditorTypes.ts
@@ -79,6 +79,7 @@ export interface RawNpc {
   questGive?: string
   questReceive?: string | string[]
   isGhost?: boolean
+  dialogueTree?: string   // id of a branching dialogue tree (questDefs.json `dialogues`)
   minLevel?: number   // building upgrade level at which this NPC first appears (0/undefined = always)
   schedule?: Array<{
     startHour: number

--- a/web/src/components/mapEditor/npcQuestDrawer/DialogueEditor.tsx
+++ b/web/src/components/mapEditor/npcQuestDrawer/DialogueEditor.tsx
@@ -1,7 +1,12 @@
 import React, { useState } from 'react'
-import type { QuestDefsJson } from '../../../data/hub/hubWorldFactory'
+import type { MapId, QuestDefsJson } from '../../../data/hub/hubWorldFactory'
+import type { RawMapConfig } from '../mapEditorTypes'
+import { EntityRefPicker } from '../EntityRefPicker'
+import { npcRefOptions, type RefOption } from '../entityRefs'
 
 interface Props {
+  mapId: MapId
+  configData: RawMapConfig
   questDefsData: QuestDefsJson
   onQuestDefsChange: (updater: (prev: QuestDefsJson) => QuestDefsJson) => void
 }
@@ -32,16 +37,18 @@ function Section({ title, color, children }: { title: string; color: string; chi
 }
 
 // friendshipDialogue: { npcId: { tier: line } }
-function FriendshipEditor({ data, onChange }: { data: Record<string, Record<string, string>>; onChange: (d: Record<string, Record<string, string>>) => void }) {
+function FriendshipEditor({ data, onChange, npcOptions }: { data: Record<string, Record<string, string>>; onChange: (d: Record<string, Record<string, string>>) => void; npcOptions: RefOption[] }) {
   const npcs = Object.entries(data)
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
       {npcs.map(([npcId, tiers]) => (
         <div key={npcId} style={{ background: '#16161e', border: '1px solid #2a2a3a', borderRadius: 3, padding: 6 }}>
           <div style={{ display: 'flex', gap: 4, marginBottom: 4 }}>
-            <input style={{ ...INPUT, fontFamily: 'monospace' }} value={npcId} onChange={e => {
-              const next = { ...data }; delete next[npcId]; next[e.target.value] = tiers; onChange(next)
-            }} />
+            <div style={{ flex: 1 }}>
+              <EntityRefPicker value={npcId} options={npcOptions} placeholder="Search NPC…" onChange={v => {
+                const next = { ...data }; delete next[npcId]; next[v] = tiers; onChange(next)
+              }} />
+            </div>
             <button style={BTN_X} onClick={() => { const next = { ...data }; delete next[npcId]; onChange(next) }}>✕</button>
           </div>
           {Object.entries(tiers).map(([tier, line]) => (
@@ -62,13 +69,15 @@ function FriendshipEditor({ data, onChange }: { data: Record<string, Record<stri
 }
 
 // relationshipDialogue: { npcId: { relType: { tier: line } } }
-function RelationshipEditor({ data, onChange }: { data: Record<string, Record<string, Record<string, string>>>; onChange: (d: Record<string, Record<string, Record<string, string>>>) => void }) {
+function RelationshipEditor({ data, onChange, npcOptions }: { data: Record<string, Record<string, Record<string, string>>>; onChange: (d: Record<string, Record<string, Record<string, string>>>) => void; npcOptions: RefOption[] }) {
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
       {Object.entries(data).map(([npcId, rels]) => (
         <div key={npcId} style={{ background: '#16161e', border: '1px solid #2a2a3a', borderRadius: 3, padding: 6 }}>
           <div style={{ display: 'flex', gap: 4, marginBottom: 4 }}>
-            <input style={{ ...INPUT, fontFamily: 'monospace' }} value={npcId} onChange={e => { const next = { ...data }; delete next[npcId]; next[e.target.value] = rels; onChange(next) }} />
+            <div style={{ flex: 1 }}>
+              <EntityRefPicker value={npcId} options={npcOptions} placeholder="Search NPC…" onChange={v => { const next = { ...data }; delete next[npcId]; next[v] = rels; onChange(next) }} />
+            </div>
             <button style={BTN_X} onClick={() => { const next = { ...data }; delete next[npcId]; onChange(next) }}>✕</button>
           </div>
           {Object.entries(rels).map(([relType, tiers]) => (
@@ -111,14 +120,16 @@ function RumoursEditor({ data, onChange }: { data: Array<{ id: string; text: str
 }
 
 // dialogues: [{ id, npcId, start, nodes }] — fields + JSON node editor.
-function DialogueTreeRow({ dlg, onChange, onDelete }: { dlg: Record<string, unknown>; onChange: (d: Record<string, unknown>) => void; onDelete: () => void }) {
+function DialogueTreeRow({ dlg, onChange, onDelete, npcOptions }: { dlg: Record<string, unknown>; onChange: (d: Record<string, unknown>) => void; onDelete: () => void; npcOptions: RefOption[] }) {
   const [nodesText, setNodesText] = useState(() => JSON.stringify(dlg.nodes ?? {}, null, 1))
   const [err, setErr] = useState('')
   return (
     <div style={{ background: '#16161e', border: '1px solid #2a2a3a', borderRadius: 3, padding: 6, marginBottom: 6 }}>
       <div style={{ display: 'flex', gap: 4, marginBottom: 4 }}>
         <input style={INPUT} placeholder="id" value={String(dlg.id ?? '')} onChange={e => onChange({ ...dlg, id: e.target.value })} />
-        <input style={INPUT} placeholder="npcId" value={String(dlg.npcId ?? '')} onChange={e => onChange({ ...dlg, npcId: e.target.value })} />
+        <div style={{ flex: 1 }}>
+          <EntityRefPicker value={String(dlg.npcId ?? '')} options={npcOptions} placeholder="npcId…" onChange={v => onChange({ ...dlg, npcId: v })} />
+        </div>
         <input style={{ ...INPUT, width: 70, flex: '0 0 70px' }} placeholder="start" value={String(dlg.start ?? '')} onChange={e => onChange({ ...dlg, start: e.target.value })} />
         <button style={BTN_X} onClick={onDelete}>✕</button>
       </div>
@@ -138,12 +149,13 @@ function DialogueTreeRow({ dlg, onChange, onDelete }: { dlg: Record<string, unkn
   )
 }
 
-export function DialogueEditor({ questDefsData, onQuestDefsChange }: Props) {
+export function DialogueEditor({ mapId, configData, questDefsData, onQuestDefsChange }: Props) {
   const q = questDefsData as unknown as Record<string, unknown>
   const friendship = (q.friendshipDialogue as Record<string, Record<string, string>>) ?? {}
   const relationship = (q.relationshipDialogue as Record<string, Record<string, Record<string, string>>>) ?? {}
   const rumours = (q.innRumours as Array<{ id: string; text: string }>) ?? []
   const dialogues = (q.dialogues as Array<Record<string, unknown>>) ?? []
+  const npcOptions = npcRefOptions(mapId, configData.npcs ?? [], false)
   const patch = (key: string, value: unknown) => onQuestDefsChange(prev => ({ ...(prev as object), [key]: value }) as QuestDefsJson)
 
   return (
@@ -152,16 +164,17 @@ export function DialogueEditor({ questDefsData, onQuestDefsChange }: Props) {
         <RumoursEditor data={rumours} onChange={d => patch('innRumours', d)} />
       </Section>
       <Section title={`Friendship Dialogue (${Object.keys(friendship).length})`} color="#88ffaa">
-        <FriendshipEditor data={friendship} onChange={d => patch('friendshipDialogue', d)} />
+        <FriendshipEditor data={friendship} npcOptions={npcOptions} onChange={d => patch('friendshipDialogue', d)} />
       </Section>
       <Section title={`Relationship Dialogue (${Object.keys(relationship).length})`} color="#ffaa88">
-        <RelationshipEditor data={relationship} onChange={d => patch('relationshipDialogue', d)} />
+        <RelationshipEditor data={relationship} npcOptions={npcOptions} onChange={d => patch('relationshipDialogue', d)} />
       </Section>
       <Section title={`Dialogue Trees (${dialogues.length})`} color="#88aaff">
         {dialogues.map((dlg, i) => (
           <DialogueTreeRow
             key={i}
             dlg={dlg}
+            npcOptions={npcOptions}
             onChange={d => patch('dialogues', dialogues.map((x, j) => j === i ? d : x))}
             onDelete={() => patch('dialogues', dialogues.filter((_, j) => j !== i))}
           />

--- a/web/src/components/mapEditor/npcQuestDrawer/NpcEditor.tsx
+++ b/web/src/components/mapEditor/npcQuestDrawer/NpcEditor.tsx
@@ -4,11 +4,15 @@ import type { QuestDefsJson } from '../../../data/hub/hubWorldFactory'
 import { NPC_ACTIVITIES } from '../../../game/hub/hubNpcSchedule'
 import { SpriteSearchPicker } from '../SpritePicker'
 import { AnimalEditor } from './AnimalEditor'
+import type { MapId } from '../../../data/hub/hubWorldFactory'
+import { EntityRefPicker } from '../EntityRefPicker'
+import { buildingRefOptions, questRefOptions, dialogueTreeRefOptions, type RefOption } from '../entityRefs'
 
 export type { PickKind } from '../mapEditorTypes'
 import type { PickKind } from '../mapEditorTypes'
 
 interface Props {
+  mapId: MapId
   configData: RawMapConfig
   questDefsData: QuestDefsJson
   focusedIndex: number | null
@@ -18,6 +22,14 @@ interface Props {
   onUpdateAnimal: (index: number, partial: Partial<RawAnimal>) => void
   onDeleteAnimal: (index: number) => void
   onPickLocation: (kind: PickKind, index: number) => void
+}
+
+// Reference options threaded into the NPC sub-editors.
+interface NpcRefOpts {
+  buildings: RefOption[]
+  questGive: RefOption[]
+  questReceive: RefOption[]
+  dialogueTrees: RefOption[]
 }
 
 function Field({ label, children }: { label: string; children: React.ReactNode }) {
@@ -55,9 +67,10 @@ const BTN_PICK: React.CSSProperties = {
 
 type ScheduleRow = NonNullable<RawNpc['schedule']>[number]
 
-function ScheduleEditor({ schedule, onChange }: {
+function ScheduleEditor({ schedule, onChange, buildings }: {
   schedule: ScheduleRow[]
   onChange: (s: ScheduleRow[]) => void
+  buildings: RefOption[]
 }) {
   function update(i: number, partial: Partial<ScheduleRow>) {
     onChange(schedule.map((r, idx) => idx === i ? { ...r, ...partial } as ScheduleRow : r))
@@ -96,10 +109,10 @@ function ScheduleEditor({ schedule, onChange }: {
               <option value="interior">Interior</option>
             </select>
             {row.location.type === 'interior' && (
-              <input type="text" placeholder="buildingId"
-                value={row.location.buildingId}
-                onChange={e => setLocation(i, { ...row.location, type: 'interior', buildingId: e.target.value })}
-                style={{ width: 80, padding: '2px 5px', background: '#111', border: '1px solid #444', color: '#eee', borderRadius: 3, fontSize: 10 }} />
+              <div style={{ width: 110 }}>
+                <EntityRefPicker value={row.location.buildingId} options={buildings} placeholder="building…"
+                  onChange={v => setLocation(i, { ...row.location, type: 'interior', buildingId: v })} />
+              </div>
             )}
             <label style={{ color: '#888', fontSize: 10 }}>X</label>
             <input type="number" value={row.location.tx}
@@ -130,9 +143,10 @@ function ScheduleEditor({ schedule, onChange }: {
 
 // ── HomeBed sub-editor ───────────────────────────────────────────────────────
 
-function HomeBedEditor({ homeBed, onChange }: {
+function HomeBedEditor({ homeBed, onChange, buildings }: {
   homeBed: RawNpc['homeBed']
   onChange: (v: RawNpc['homeBed']) => void
+  buildings: RefOption[]
 }) {
   if (!homeBed) {
     return (
@@ -143,9 +157,10 @@ function HomeBedEditor({ homeBed, onChange }: {
   }
   return (
     <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', alignItems: 'center' }}>
-      <input type="text" placeholder="buildingId" value={homeBed.buildingId}
-        onChange={e => onChange({ ...homeBed, buildingId: e.target.value })}
-        style={{ flex: 1, minWidth: 70, padding: '3px 5px', background: '#111', border: '1px solid #444', color: '#eee', borderRadius: 3, fontSize: 11 }} />
+      <div style={{ flex: 1, minWidth: 90 }}>
+        <EntityRefPicker value={homeBed.buildingId} options={buildings} placeholder="building…"
+          onChange={v => onChange({ ...homeBed, buildingId: v })} />
+      </div>
       <label style={{ color: '#888', fontSize: 10 }}>X</label>
       <input type="number" value={homeBed.tx} onChange={e => onChange({ ...homeBed, tx: Number(e.target.value) })} style={NUM} />
       <label style={{ color: '#888', fontSize: 10 }}>Y</label>
@@ -185,17 +200,12 @@ function InnRumoursEditor({ rumours, onChange }: {
 
 // ── NpcFullEditor ─────────────────────────────────────────────────────────────
 
-function NpcFullEditor({ npc, questIds, onUpdate, onPickLocation }: {
+function NpcFullEditor({ npc, opts, onUpdate, onPickLocation }: {
   npc: RawNpc
-  questIds: string[]
+  opts: NpcRefOpts
   onUpdate: (partial: Partial<RawNpc>) => void
   onPickLocation?: () => void
 }) {
-  const questOptions = [
-    { value: '', label: '— none —' },
-    ...questIds.map(id => ({ value: id, label: id })),
-  ]
-
   const questReceiveArr: string[] = Array.isArray(npc.questReceive)
     ? npc.questReceive
     : npc.questReceive ? [npc.questReceive] : []
@@ -234,51 +244,44 @@ function NpcFullEditor({ npc, questIds, onUpdate, onPickLocation }: {
           Is ghost
         </label>
       </Field>
-      <Field label="Building">
-        <input style={INPUT} type="text" value={npc.building ?? ''} placeholder="building ID (optional)"
-          onChange={e => onUpdate({ building: e.target.value || undefined })} />
+      <Field label="Building (interior, optional)">
+        <EntityRefPicker value={npc.building ?? ''} options={opts.buildings} placeholder="Search buildings…"
+          onChange={v => onUpdate({ building: v || undefined })} />
+      </Field>
+      <Field label="Dialogue Tree (optional)">
+        <EntityRefPicker value={npc.dialogueTree ?? ''} options={opts.dialogueTrees} placeholder="Search dialogue trees…"
+          onChange={v => onUpdate({ dialogueTree: v || undefined })} />
       </Field>
       <Field label="Quest Give">
-        <select style={SELECT} value={npc.questGive ?? ''}
-          onChange={e => onUpdate({ questGive: e.target.value || undefined })}>
-          {questOptions.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
-        </select>
+        <EntityRefPicker value={npc.questGive ?? ''} options={opts.questGive} placeholder="Search quests…"
+          onChange={v => onUpdate({ questGive: v || undefined })} />
       </Field>
       <Field label="Quest Receive">
         <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
           {questReceiveArr.map((qid, i) => (
             <div key={i} style={{ display: 'flex', gap: 4 }}>
-              <select
-                value={qid}
-                onChange={e => {
-                  const updated = questReceiveArr.map((x, j) => j === i ? e.target.value : x)
-                  setQuestReceive(updated.filter(Boolean))
-                }}
-                style={{ ...SELECT, flex: 1 }}
-              >
-                {questIds.map(id => <option key={id} value={id}>{id}</option>)}
-              </select>
+              <div style={{ flex: 1 }}>
+                <EntityRefPicker value={qid} options={opts.questReceive} placeholder="Search quests…"
+                  onChange={v => setQuestReceive(questReceiveArr.map((x, j) => j === i ? v : x).filter(Boolean))} />
+              </div>
               <button style={BTN_DANGER} onClick={() => setQuestReceive(questReceiveArr.filter((_, j) => j !== i))}>✕</button>
             </div>
           ))}
           <button
             style={{ ...BTN_ADD, fontSize: 10, padding: '2px 8px' }}
-            disabled={questIds.length === 0}
-            onClick={() => {
-              const first = questIds.find(id => !questReceiveArr.includes(id)) ?? questIds[0]
-              if (first) setQuestReceive([...questReceiveArr, first])
-            }}
+            onClick={() => setQuestReceive([...questReceiveArr, ''])}
           >+ Add</button>
         </div>
       </Field>
       <Field label="Schedule">
         <ScheduleEditor
           schedule={npc.schedule ?? []}
+          buildings={opts.buildings}
           onChange={s => onUpdate({ schedule: s.length > 0 ? s : undefined })}
         />
       </Field>
       <Field label="Home Bed">
-        <HomeBedEditor homeBed={npc.homeBed} onChange={v => onUpdate({ homeBed: v })} />
+        <HomeBedEditor homeBed={npc.homeBed} buildings={opts.buildings} onChange={v => onUpdate({ homeBed: v })} />
       </Field>
       <Field label="Inn Rumours">
         <InnRumoursEditor
@@ -293,7 +296,7 @@ function NpcFullEditor({ npc, questIds, onUpdate, onPickLocation }: {
 // ── NpcEditor (main export) ──────────────────────────────────────────────────
 
 export function NpcEditor({
-  configData, questDefsData, focusedIndex,
+  mapId, configData, questDefsData, focusedIndex,
   onAddNpc, onUpdateNpc, onAddAnimal, onUpdateAnimal, onDeleteAnimal, onPickLocation,
 }: Props) {
   // Selection is keyed by kind so NPC and animal rows don't collide.
@@ -312,7 +315,13 @@ export function NpcEditor({
 
   const npcs = configData.npcs ?? []
   const animals = configData.animals ?? []
-  const questIds = ((questDefsData.quests as Array<{ id: string }> | undefined) ?? []).map(q => q.id)
+  const localQuests = (questDefsData.quests as Array<{ id: string; title?: string }> | undefined) ?? []
+  const refOpts: NpcRefOpts = {
+    buildings: buildingRefOptions(mapId, configData.buildings ?? []),
+    questGive: questRefOptions(mapId, localQuests, false),     // this NPC gives quests from its own town
+    questReceive: questRefOptions(mapId, localQuests, true),   // may receive cross-town deliveries
+    dialogueTrees: dialogueTreeRefOptions(mapId, (questDefsData.dialogues as Array<{ id: string }> | undefined) ?? []),
+  }
 
   // Scroll to a newly added row after the render that includes it
   useEffect(() => {
@@ -389,7 +398,7 @@ export function NpcEditor({
           {isExpanded('npc', i) && (
             <NpcFullEditor
               npc={npc}
-              questIds={questIds}
+              opts={refOpts}
               onUpdate={partial => onUpdateNpc(i, partial)}
               onPickLocation={() => onPickLocation('npc', i)}
             />

--- a/web/src/components/mapEditor/npcQuestDrawer/NpcQuestDrawer.tsx
+++ b/web/src/components/mapEditor/npcQuestDrawer/NpcQuestDrawer.tsx
@@ -1,13 +1,14 @@
 import React from 'react'
 import type { DrawerTab } from './npcQuestDrawerTypes'
 import type { RawMapConfig, RawNpc, RawAnimal } from '../mapEditorTypes'
-import type { QuestDefsJson } from '../../../data/hub/hubWorldFactory'
+import type { MapId, QuestDefsJson } from '../../../data/hub/hubWorldFactory'
 import { NpcEditor, type PickKind } from './NpcEditor'
 import { QuestEditor } from './QuestEditor'
 import { DialogueEditor } from './DialogueEditor'
 
 interface Props {
   tab: DrawerTab
+  mapId: MapId
   focusedNpcIndex: number | null
   configData: RawMapConfig
   questDefsData: QuestDefsJson
@@ -31,7 +32,7 @@ const TAB_INACTIVE: React.CSSProperties = {
 }
 
 export function NpcQuestDrawer({
-  tab, focusedNpcIndex, configData, questDefsData,
+  tab, mapId, focusedNpcIndex, configData, questDefsData,
   onTabChange, onAddNpc, onUpdateNpc, onAddAnimal, onUpdateAnimal, onDeleteAnimal, onPickLocation, onQuestDefsChange,
 }: Props) {
   return (
@@ -50,6 +51,7 @@ export function NpcQuestDrawer({
       <div style={{ flex: 1, overflow: 'hidden', display: 'flex' }}>
         {tab === 'npcs' && (
           <NpcEditor
+            mapId={mapId}
             configData={configData}
             questDefsData={questDefsData}
             focusedIndex={focusedNpcIndex}
@@ -63,6 +65,7 @@ export function NpcQuestDrawer({
         )}
         {tab === 'quests' && (
           <QuestEditor
+            mapId={mapId}
             configData={configData}
             questDefsData={questDefsData}
             onUpdateNpc={onUpdateNpc}
@@ -71,6 +74,8 @@ export function NpcQuestDrawer({
         )}
         {tab === 'dialogue' && (
           <DialogueEditor
+            mapId={mapId}
+            configData={configData}
             questDefsData={questDefsData}
             onQuestDefsChange={onQuestDefsChange}
           />

--- a/web/src/components/mapEditor/npcQuestDrawer/PrerequisiteEditor.tsx
+++ b/web/src/components/mapEditor/npcQuestDrawer/PrerequisiteEditor.tsx
@@ -1,0 +1,123 @@
+import React from 'react'
+import { EntityRefPicker } from '../EntityRefPicker'
+import type { RefOption } from '../entityRefs'
+
+// Quest prerequisites are AND-combined conditions serialised in one string with
+// `|` (see checkPrerequisite in HubWorld.tsx):
+//   quest:<id> | friendship:<npc>:<level> | relationship:<npc>:<track>:<level>
+// A bare token (no prefix, legacy / editor-written) is treated as a completed
+// quest and re-serialised as `quest:<id>` — fixing prereqs that silently never
+// gated.
+
+const RELATIONSHIP_TRACKS = ['ally', 'rival', 'romance']
+
+type Cond =
+  | { type: 'quest'; questId: string }
+  | { type: 'friendship'; npcId: string; level: number }
+  | { type: 'relationship'; npcId: string; track: string; level: number }
+
+function parse(str: string | undefined): Cond[] {
+  if (!str) return []
+  return str.split('|').map(s => s.trim()).filter(Boolean).map<Cond>(part => {
+    if (part.startsWith('friendship:')) {
+      const [, npcId = '', lvl = '1'] = part.split(':')
+      return { type: 'friendship', npcId, level: Number(lvl) || 1 }
+    }
+    if (part.startsWith('relationship:')) {
+      const [, npcId = '', track = 'ally', lvl = '1'] = part.split(':')
+      return { type: 'relationship', npcId, track, level: Number(lvl) || 1 }
+    }
+    if (part.startsWith('quest:')) return { type: 'quest', questId: part.slice(6) }
+    return { type: 'quest', questId: part }  // bare legacy id → quest condition
+  })
+}
+
+function serialise(conds: Cond[]): string | undefined {
+  // Drop incomplete rows (no quest / no npc picked yet) so we never write a
+  // dangling `quest:` token.
+  const clean = conds
+    .filter(c => (c.type === 'quest' ? c.questId : c.npcId))
+    .map(c =>
+      c.type === 'quest' ? `quest:${c.questId}`
+        : c.type === 'friendship' ? `friendship:${c.npcId}:${c.level}`
+          : `relationship:${c.npcId}:${c.track}:${c.level}`,
+    )
+  return clean.length ? clean.join(' | ') : undefined
+}
+
+const SELECT: React.CSSProperties = {
+  padding: '2px 5px', background: '#111', border: '1px solid #444', color: '#eee', borderRadius: 3, fontSize: 10,
+}
+const NUM: React.CSSProperties = {
+  width: 40, padding: '2px 4px', background: '#111', border: '1px solid #444', color: '#eee', borderRadius: 3, fontSize: 11,
+}
+
+/** Structured editor for a quest's `prerequisite` condition string. */
+export function PrerequisiteEditor({ value, onChange, questOptions, npcOptions }: {
+  value: string | undefined
+  onChange: (value: string | undefined) => void
+  questOptions: RefOption[]
+  npcOptions: RefOption[]
+}) {
+  const conds = parse(value)
+  const setConds = (next: Cond[]) => onChange(serialise(next))
+  const update = (i: number, c: Cond) => setConds(conds.map((x, j) => j === i ? c : x))
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
+      {conds.length === 0 && <span style={{ color: '#555', fontSize: 11 }}>No conditions — always available.</span>}
+      {conds.map((c, i) => (
+        <div key={i} style={{ background: '#16161e', border: '1px solid #2a2a3a', borderRadius: 3, padding: 5 }}>
+          <div style={{ display: 'flex', gap: 4, alignItems: 'center', marginBottom: 4 }}>
+            <select style={SELECT} value={c.type} onChange={e => {
+              const type = e.target.value
+              update(i, type === 'quest' ? { type: 'quest', questId: '' }
+                : type === 'friendship' ? { type: 'friendship', npcId: '', level: 2 }
+                  : { type: 'relationship', npcId: '', track: 'ally', level: 2 })
+            }}>
+              <option value="quest">quest complete</option>
+              <option value="friendship">friendship level</option>
+              <option value="relationship">relationship level</option>
+            </select>
+            <button style={{ marginLeft: 'auto', padding: '1px 6px', background: '#4a1a1a', border: '1px solid #922', color: '#f88', borderRadius: 3, fontSize: 10, cursor: 'pointer' }}
+              onClick={() => setConds(conds.filter((_, j) => j !== i))}>✕</button>
+          </div>
+          {c.type === 'quest' && (
+            <EntityRefPicker value={c.questId} options={questOptions} placeholder="Search quests (any town)…"
+              onChange={v => update(i, { type: 'quest', questId: v })} />
+          )}
+          {c.type === 'friendship' && (
+            <div style={{ display: 'flex', gap: 4, alignItems: 'center' }}>
+              <div style={{ flex: 1 }}>
+                <EntityRefPicker value={c.npcId} options={npcOptions} placeholder="Search NPC…" onChange={v => update(i, { ...c, npcId: v })} />
+              </div>
+              <label style={{ fontSize: 9, color: '#888' }}>lvl</label>
+              <input type="number" min={1} style={NUM} value={c.level} onChange={e => update(i, { ...c, level: Number(e.target.value) || 1 })} />
+            </div>
+          )}
+          {c.type === 'relationship' && (
+            <div style={{ display: 'flex', gap: 4, alignItems: 'center', flexWrap: 'wrap' }}>
+              <div style={{ flex: 1, minWidth: 120 }}>
+                <EntityRefPicker value={c.npcId} options={npcOptions} placeholder="Search NPC…" onChange={v => update(i, { ...c, npcId: v })} />
+              </div>
+              <select style={SELECT} value={c.track} onChange={e => update(i, { ...c, track: e.target.value })}>
+                {RELATIONSHIP_TRACKS.map(t => <option key={t} value={t}>{t}</option>)}
+              </select>
+              <label style={{ fontSize: 9, color: '#888' }}>lvl</label>
+              <input type="number" min={1} style={NUM} value={c.level} onChange={e => update(i, { ...c, level: Number(e.target.value) || 1 })} />
+            </div>
+          )}
+        </div>
+      ))}
+      <div style={{ display: 'flex', gap: 4 }}>
+        <button style={addStyle} onClick={() => setConds([...conds, { type: 'quest', questId: '' }])}>+ quest</button>
+        <button style={addStyle} onClick={() => setConds([...conds, { type: 'friendship', npcId: '', level: 2 }])}>+ friendship</button>
+        <button style={addStyle} onClick={() => setConds([...conds, { type: 'relationship', npcId: '', track: 'ally', level: 2 }])}>+ relationship</button>
+      </div>
+    </div>
+  )
+}
+
+const addStyle: React.CSSProperties = {
+  padding: '2px 8px', background: '#1e2e1e', border: '1px solid #3a5a3a', color: '#6d6', borderRadius: 3, fontSize: 10, cursor: 'pointer',
+}

--- a/web/src/components/mapEditor/npcQuestDrawer/QuestEditor.tsx
+++ b/web/src/components/mapEditor/npcQuestDrawer/QuestEditor.tsx
@@ -4,12 +4,25 @@ import type { QuestDefsJson } from '../../../data/hub/hubWorldFactory'
 import type { QuestDefinition, QuestStep, QuestReward, Dialogue } from '../../../data/hub/questDefs'
 import { isQuestIdUnique, generateQuestId } from './questValidation'
 import { FESTIVALS } from '../../../game/hub/hubCalendar'
+import type { MapId } from '../../../data/hub/hubWorldFactory'
+import { EntityRefPicker, EntityRefMultiPicker } from '../EntityRefPicker'
+import { npcRefOptions, questRefOptions, pickupRefOptions, type RefOption } from '../entityRefs'
+import { PrerequisiteEditor } from './PrerequisiteEditor'
 
 interface Props {
+  mapId: MapId
   configData: RawMapConfig
   questDefsData: QuestDefsJson
   onUpdateNpc: (index: number, partial: Partial<RawNpc>) => void
   onQuestDefsChange: (updater: (prev: QuestDefsJson) => QuestDefsJson) => void
+}
+
+// Option bundle threaded through the quest sub-editors.
+interface QuestRefOpts {
+  npcLocal: RefOption[]   // current-town NPCs (giver/receiver/friendship)
+  npcCross: RefOption[]   // all-town NPCs (deliver targets)
+  pickupCross: RefOption[] // all-town pickups (collect / chain)
+  questCross: RefOption[]  // all-town quests (prerequisite)
 }
 
 // ── Shared styles ─────────────────────────────────────────────────────────────
@@ -141,7 +154,7 @@ function makeEmptyQuest(existingIds: string[]): QuestDefinition {
 
 // ── StepsEditor ───────────────────────────────────────────────────────────────
 
-function StepsEditor({ steps, onChange }: { steps: QuestStep[]; onChange: (s: QuestStep[]) => void }) {
+function StepsEditor({ steps, onChange, opts }: { steps: QuestStep[]; onChange: (s: QuestStep[]) => void; opts: QuestRefOpts }) {
   function update(i: number, partial: Partial<QuestStep>) {
     onChange(steps.map((s, j) => j === i ? { ...s, ...partial } as QuestStep : s))
   }
@@ -174,24 +187,34 @@ function StepsEditor({ steps, onChange }: { steps: QuestStep[]; onChange: (s: Qu
           </div>
           {step.type === 'collect' && (
             <div style={{ marginBottom: 4 }}>
-              <div style={{ color: '#666', fontSize: 10, marginBottom: 2 }}>pickupIds (one per line)</div>
-              <textarea rows={2} value={((step as { pickupIds?: string[] }).pickupIds ?? []).join('\n')}
-                onChange={e => update(i, { pickupIds: e.target.value.split('\n').map(s => s.trim()).filter(Boolean) } as Partial<QuestStep>)}
-                style={{ width: '100%', padding: '3px 5px', background: '#111', border: '1px solid #444', color: '#eee', borderRadius: 3, fontSize: 11, resize: 'vertical', fontFamily: 'monospace', boxSizing: 'border-box' }} />
+              <div style={{ color: '#666', fontSize: 10, marginBottom: 2 }}>Pickup items to collect (any town)</div>
+              <EntityRefMultiPicker
+                values={(step as { pickupIds?: string[] }).pickupIds ?? []}
+                options={opts.pickupCross}
+                placeholder="Search pickups…"
+                onChange={ids => update(i, { pickupIds: ids } as Partial<QuestStep>)}
+              />
             </div>
           )}
           {step.type === 'deliver' && (
-            <input type="text" placeholder="targetNpcId"
-              value={(step as { targetNpcId?: string }).targetNpcId ?? ''}
-              onChange={e => update(i, { targetNpcId: e.target.value } as Partial<QuestStep>)}
-              style={{ width: '100%', padding: '3px 5px', background: '#111', border: '1px solid #444', color: '#eee', borderRadius: 3, fontSize: 11, boxSizing: 'border-box' }} />
+            <div style={{ marginBottom: 4 }}>
+              <div style={{ color: '#666', fontSize: 10, marginBottom: 2 }}>Deliver to NPC (any town)</div>
+              <EntityRefPicker
+                value={(step as { targetNpcId?: string }).targetNpcId ?? ''}
+                options={opts.npcCross}
+                placeholder="Search NPCs…"
+                onChange={v => update(i, { targetNpcId: v } as Partial<QuestStep>)}
+              />
+            </div>
           )}
-          <div style={{ display: 'flex', gap: 6, alignItems: 'center', marginTop: 4 }}>
-            <label style={{ color: '#666', fontSize: 10 }}>chain (unlock after):</label>
-            <input type="text" placeholder="pickupId or empty"
+          <div style={{ marginTop: 4 }}>
+            <label style={{ color: '#666', fontSize: 10 }}>Chain — reveal this pickup only after the step before (optional)</label>
+            <EntityRefPicker
               value={(step as { chain?: string }).chain ?? ''}
-              onChange={e => update(i, { chain: e.target.value || undefined } as Partial<QuestStep>)}
-              style={{ flex: 1, padding: '2px 5px', background: '#111', border: '1px solid #444', color: '#eee', borderRadius: 3, fontSize: 10 }} />
+              options={opts.pickupCross}
+              placeholder="Search pickups…"
+              onChange={v => update(i, { chain: v || undefined } as Partial<QuestStep>)}
+            />
           </div>
         </div>
       ))}
@@ -204,19 +227,20 @@ function StepsEditor({ steps, onChange }: { steps: QuestStep[]; onChange: (s: Qu
 
 // ── RewardEditor ──────────────────────────────────────────────────────────────
 
-function FriendshipEditor({ friendship, onChange }: { friendship: Record<string, number>; onChange: (f: Record<string, number>) => void }) {
+function FriendshipEditor({ friendship, onChange, npcOptions }: { friendship: Record<string, number>; onChange: (f: Record<string, number>) => void; npcOptions: RefOption[] }) {
   const entries = Object.entries(friendship)
   return (
     <div>
       {entries.map(([npcId, amount], i) => (
         <div key={i} style={{ display: 'flex', gap: 4, marginBottom: 3, alignItems: 'center' }}>
-          <input type="text" value={npcId} placeholder="npcId"
-            onChange={e => {
-              const updated: Record<string, number> = {}
-              entries.forEach(([k, v], j) => { updated[j === i ? e.target.value : k] = v })
-              onChange(updated)
-            }}
-            style={{ flex: 1, padding: '2px 5px', background: '#111', border: '1px solid #444', color: '#eee', borderRadius: 3, fontSize: 11 }} />
+          <div style={{ flex: 1 }}>
+            <EntityRefPicker value={npcId} options={npcOptions} placeholder="Search NPC…"
+              onChange={v => {
+                const updated: Record<string, number> = {}
+                entries.forEach(([k, val], j) => { updated[j === i ? v : k] = val })
+                onChange(updated)
+              }} />
+          </div>
           <input type="number" value={amount}
             onChange={e => onChange({ ...friendship, [npcId]: Number(e.target.value) })}
             style={{ ...NUM, width: 48 }} />
@@ -230,7 +254,7 @@ function FriendshipEditor({ friendship, onChange }: { friendship: Record<string,
   )
 }
 
-function RewardEditor({ reward, onChange }: { reward: QuestReward; onChange: (r: QuestReward) => void }) {
+function RewardEditor({ reward, onChange, npcOptions }: { reward: QuestReward; onChange: (r: QuestReward) => void; npcOptions: RefOption[] }) {
   return (
     <div>
       <div style={{ display: 'flex', gap: 6, alignItems: 'center', marginBottom: 6 }}>
@@ -243,6 +267,7 @@ function RewardEditor({ reward, onChange }: { reward: QuestReward; onChange: (r:
       <div style={{ marginBottom: 6 }}>
         <div style={{ color: '#888', fontSize: 10, marginBottom: 3 }}>FRIENDSHIP</div>
         <FriendshipEditor
+          npcOptions={npcOptions}
           friendship={reward.friendship as Record<string, number> ?? {}}
           onChange={f => onChange({ ...reward, friendship: Object.keys(f).length > 0 ? f : undefined })} />
       </div>
@@ -282,11 +307,11 @@ function RewardEditor({ reward, onChange }: { reward: QuestReward; onChange: (r:
 // ── QuestFullEditor ───────────────────────────────────────────────────────────
 
 function QuestFullEditor({
-  quest, allQuests, npcIds, onApply, onDiscard,
+  quest, allQuests, opts, onApply, onDiscard,
 }: {
   quest: QuestDefinition
   allQuests: QuestDefinition[]
-  npcIds: string[]
+  opts: QuestRefOpts
   onApply: (updated: QuestDefinition) => void
   onDiscard: () => void
 }) {
@@ -321,10 +346,8 @@ function QuestFullEditor({
     }))
   }
 
-  const prerequisiteOptions = [
-    { value: '', label: '— none —' },
-    ...allQuests.filter(q => q.id !== draft.id).map(q => ({ value: q.id, label: q.id })),
-  ]
+  // Prerequisite quest options exclude this quest itself.
+  const prereqQuestOptions = opts.questCross.filter(o => o.value !== draft.id)
 
   return (
     <div style={{ padding: '8px 10px 12px', borderLeft: '3px solid #7a6aae', marginLeft: 4, marginBottom: 6 }}>
@@ -343,21 +366,19 @@ function QuestFullEditor({
         </select>
       </Field>
       <Field label="Giver NPC">
-        <select style={SELECT} value={draft.giverNpcId} onChange={e => set('giverNpcId', e.target.value)}>
-          <option value="">— none —</option>
-          {npcIds.map(id => <option key={id} value={id}>{id}</option>)}
-        </select>
+        <EntityRefPicker value={draft.giverNpcId} options={opts.npcLocal} placeholder="Search NPCs…"
+          onChange={v => set('giverNpcId', v)} />
       </Field>
       <Field label="Receiver NPC">
-        <select style={SELECT} value={draft.receiverNpcId ?? ''} onChange={e => set('receiverNpcId', e.target.value)}>
-          <option value="">— none —</option>
-          {npcIds.map(id => <option key={id} value={id}>{id}</option>)}
-        </select>
+        <EntityRefPicker value={draft.receiverNpcId ?? ''} options={opts.npcLocal} placeholder="Search NPCs…"
+          onChange={v => set('receiverNpcId', v)} />
       </Field>
-      <Field label="Prerequisite">
-        <select style={SELECT} value={draft.prerequisite ?? ''} onChange={e => set('prerequisite', e.target.value || undefined)}>
-          {prerequisiteOptions.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
-        </select>
+      <Field label="Prerequisite (all conditions must be met)">
+        <PrerequisiteEditor
+          value={draft.prerequisite}
+          questOptions={prereqQuestOptions}
+          npcOptions={opts.npcCross}
+          onChange={v => set('prerequisite', v)} />
       </Field>
       <Field label="Festival (time-limited)">
         <select style={SELECT} value={draft.festivalId ?? ''} onChange={e => set('festivalId', e.target.value || undefined)}>
@@ -397,10 +418,10 @@ function QuestFullEditor({
           style={{ ...INPUT, resize: 'vertical', fontFamily: 'inherit' }} />
       </Field>
       <Field label="Steps">
-        <StepsEditor steps={draft.steps} onChange={setSteps} />
+        <StepsEditor steps={draft.steps} onChange={setSteps} opts={opts} />
       </Field>
       <Field label="Reward">
-        <RewardEditor reward={draft.reward} onChange={r => set('reward', r)} />
+        <RewardEditor reward={draft.reward} onChange={r => set('reward', r)} npcOptions={opts.npcLocal} />
       </Field>
 
       <div style={{ display: 'flex', gap: 8, marginTop: 10, justifyContent: 'flex-end' }}>
@@ -416,13 +437,20 @@ function QuestFullEditor({
 
 // ── QuestEditor (main export) ─────────────────────────────────────────────────
 
-export function QuestEditor({ configData, questDefsData, onUpdateNpc, onQuestDefsChange }: Props) {
+export function QuestEditor({ mapId, configData, questDefsData, onUpdateNpc, onQuestDefsChange }: Props) {
   const [expandedId, setExpandedId] = useState<string | null>(null)
   const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null)
 
   const quests = (questDefsData.quests as QuestDefinition[] | undefined) ?? []
   const npcs = configData.npcs ?? []
-  const npcIds = npcs.map(n => n.id)
+  const pickups = questDefsData.pickupItems ?? []
+
+  const opts: QuestRefOpts = {
+    npcLocal: npcRefOptions(mapId, npcs, false),
+    npcCross: npcRefOptions(mapId, npcs, true),
+    pickupCross: pickupRefOptions(mapId, pickups, true),
+    questCross: questRefOptions(mapId, quests, true),
+  }
 
   function handleApply(original: QuestDefinition, updated: QuestDefinition) {
     onQuestDefsChange(prev => {
@@ -509,7 +537,7 @@ export function QuestEditor({ configData, questDefsData, onUpdateNpc, onQuestDef
             <QuestFullEditor
               quest={quest}
               allQuests={quests}
-              npcIds={npcIds}
+              opts={opts}
               onApply={updated => handleApply(quest, updated)}
               onDiscard={() => setExpandedId(null)}
             />

--- a/web/src/components/mapEditor/useMapEditorState.ts
+++ b/web/src/components/mapEditor/useMapEditorState.ts
@@ -17,7 +17,9 @@ import hollowmereConfig from '../../data/hub/hollowmere/config.json'
 import dreadspirecitadelConfig from '../../data/hub/dreadspirecitadel/config.json'
 import { MapId } from '../../data/hub/hubWorldFactory'
 
-const RAW_CONFIGS: Record<MapId, RawMapConfig> = {
+// Exported so cross-town reference pickers (entityRefs.ts) can read every town's
+// NPCs / buildings / interiors without re-importing all the config JSON.
+export const RAW_CONFIGS: Record<MapId, RawMapConfig> = {
   ravenwatch:    hubConfig    as unknown as RawMapConfig,
   millhaven:  town2Config  as unknown as RawMapConfig,
   ironholdkeep: castleConfig as unknown as RawMapConfig,


### PR DESCRIPTION
Makes every id field in the map editor a searchable dropdown and enables cross-town quest chains.

## 1. Searchable id dropdowns everywhere
New reusable `EntityRefPicker` / `EntityRefMultiPicker` + `entityRefs.ts` option builders. Every id field is now a searchable combobox that resolves to the entity's name and round-trips unknown/custom values:
- **Quest editor:** giver / receiver / friendship NPCs, deliver-target NPC, collect `pickupIds`, chain pickup.
- **NPC editor:** building, home-bed building, schedule building, dialogue tree, questGive/Receive.
- **Dialogue editor:** friendship / relationship / tree NPC refs.
- **Inspector:** treasure & interactable building, blocked-path questId, interactable reaction questId.

Cross-town refs are **grouped by town**; local refs default to the current town.

## 2. Prerequisite condition builder (+ bug fix)
The prerequisite field is now a structured editor with **quest-complete / friendship / relationship** rows (AND-combined). It parses the existing string and re-serialises to the correct `quest:<id>` / `friendship:…` / `relationship:…` form.

This **fixes a real bug**: the old dropdown wrote a *bare* quest id, which `checkPrerequisite` treats as always-satisfied — so the Kipper prereqs (`"kippers-kipper"`) silently never gated. They now show as a quest-complete condition and save as `quest:kippers-kipper`.

## 3. Cross-town quest chains (data + engine)
Quest state is already global, so prerequisites can reference quests in any town. For **full cross-town steps**, the engine now progresses quests over `allQuestDefs` rather than only the current town:
- `handleItemPickup` resolves the quest across all towns → a pickup collected in town B advances a quest accepted in town A.
- NPC-tap delivery / turn-in scans all towns for a pending deliver step addressed to the tapped NPC (or a ready receiver) → you can deliver/complete wherever the NPC is.
- The quest indicator map lights up present givers (offers) and present receivers/deliver-targets (ready) for cross-town active quests; the 2-active cap counts globally.

## Files
- New: `mapEditor/EntityRefPicker.tsx`, `mapEditor/entityRefs.ts`, `npcQuestDrawer/PrerequisiteEditor.tsx`
- `npcQuestDrawer/QuestEditor.tsx`, `NpcEditor.tsx`, `DialogueEditor.tsx`, `NpcQuestDrawer.tsx`, `MapEditor.tsx`, `EntityInspector.tsx`
- `components/hub/HubWorld.tsx` (cross-town progression)
- `docs/hubworld.md` §14

## Verification
- `npm run build` ✅ and `npx vitest run` ✅ (198/198).
- Manual: open a Kipper quest → bare prereq shows as a quest-complete condition and saves as `quest:…`; author a quest in town A with a collect step pointing at a town-B pickup and a deliver to a town-C NPC, then accept in A / collect in B / hand in at C.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011f8gD7RAP6taye8wz8GfFs)_