### PR TITLE
The Kipper questline (cross-town)

### DIFF
--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -77,6 +77,9 @@ function checkPrerequisite(prereq: string): boolean {
     if (part.startsWith('quest:')) {
       return getQuestState(part.slice(6)).status === 'completed'
     }
+    if (part.startsWith('flag:')) {
+      return hasDialogueFlag(part.slice(5))
+    }
     return true
   })
 }
@@ -722,8 +725,10 @@ function hasOfferableQuest(giverId: string): boolean {
     if (!node) { setDialogueEvent(null); return }
     markNodeSeen(tree.id, nodeId)
     const visible = (node.choices ?? []).filter(c =>
-      (!c.requireFlag || hasDialogueFlag(c.requireFlag)) &&
-      (!c.hideIfFlag  || !hasDialogueFlag(c.hideIfFlag))
+      (!c.requireFlag  || hasDialogueFlag(c.requireFlag)) &&
+      (!c.hideIfFlag   || !hasDialogueFlag(c.hideIfFlag)) &&
+      (!c.requireQuest || getQuestState(c.requireQuest).status === 'completed') &&
+      (!c.hideIfQuest  || getQuestState(c.hideIfQuest).status !== 'completed')
     )
     const choices: DialogueChoice[] = visible.map((c, i) => ({
       label:   c.label,

--- a/web/src/components/mapEditor/mapEditorTypes.ts
+++ b/web/src/components/mapEditor/mapEditorTypes.ts
@@ -66,6 +66,7 @@ export interface RawAnimal {
   roam?: boolean
   areaRect?: [number, number, number, number]
   building?: string
+  dialogueTree?: string
 }
 
 export interface RawNpc {

--- a/web/src/components/mapEditor/npcQuestDrawer/AnimalEditor.tsx
+++ b/web/src/components/mapEditor/npcQuestDrawer/AnimalEditor.tsx
@@ -87,6 +87,10 @@ export function AnimalEditor({ animal, onUpdate, onDelete, onPickLocation }: {
         <input style={INPUT} value={animal.building ?? ''} placeholder="building ID (optional)"
           onChange={e => onUpdate({ building: e.target.value || undefined })} />
       </Field>
+      <Field label="Dialogue Tree (optional)">
+        <input style={INPUT} value={animal.dialogueTree ?? ''} placeholder="dialogue tree id (optional)"
+          onChange={e => onUpdate({ dialogueTree: e.target.value || undefined })} />
+      </Field>
       <Field label="Roam">
         <label style={{ display: 'flex', alignItems: 'center', gap: 6, cursor: 'pointer', fontSize: 11 }}>
           <input type="checkbox" checked={animal.roam ?? false} onChange={e => onUpdate({ roam: e.target.checked || undefined })} />

--- a/web/src/data/hub/config.ts
+++ b/web/src/data/hub/config.ts
@@ -287,6 +287,7 @@ export interface RawAnimal {
   questReceive?: string | string[]
   roam?: boolean                     // default false for placed animals
   areaRect?: number[]  // [tx, ty, w, h] roam bounds (JSON infers number[])
+  dialogueTree?: string              // id of a branching dialogue tree (questDefs.json `dialogues`)
 }
 
 export interface RawConfig {

--- a/web/src/data/hub/hollowmere/questDefs.json
+++ b/web/src/data/hub/hollowmere/questDefs.json
@@ -23,12 +23,46 @@
           "hedge-witch-morwen": 15
         }
       }
+    },
+    {
+      "id": "morwen-speak-with-animals",
+      "title": "The Tongue of Beasts",
+      "type": "fetch",
+      "giverNpcId": "hedge-witch-morwen",
+      "receiverNpcId": "hedge-witch-morwen",
+      "prerequisite": "quest:kipper-marta-hint | quest:hollowmere-witch-brew",
+      "offerDialogue": "So. You want the beast-tongue — to speak with animals, and worse, to LISTEN. It is no parlour trick, and I do not hand it to anyone who wanders in off the marsh. But you fetched my moonherb, and you have Marta's word, so you are not entirely useless. Bring me the three things the speech is made of: a crow's lost feather, a moon-cap mushroom from the deep hollow, and a thornless rose. Then we shall see about your cat.",
+      "activeDialogue": "A crow's feather, a moon-cap mushroom, and a thornless rose — all fall or grow around Hollowmere. Bring me all three.",
+      "completeDialogue": "Feather, cap, and rose. Good. Now hold still — this tingles. *she mutters, and the air fills with chatter* ...There. You will hear them now: every cat, crow, and complaining frog. Go and listen to that wretched, kipper-loathing cat. And mind — knowing what a beast wants is the easy part. GIVING it to them is on you.",
+      "steps": [
+        {
+          "key": "components",
+          "type": "collect",
+          "pickupIds": ["spell-feather", "spell-mooncap", "spell-rose"],
+          "required": 3
+        }
+      ],
+      "reward": {
+        "crystals": 80,
+        "collectible": {
+          "id": "speak-with-animals",
+          "name": "Speak with Animals",
+          "icon": "🐾",
+          "desc": "Hedge-Witch Morwen's beast-tongue — you can understand any animal's speech."
+        },
+        "friendship": {
+          "hedge-witch-morwen": 20
+        }
+      }
     }
   ],
   "pickupItems": [
     { "id": "moonherb-1", "tx": 3, "ty": 12, "tileId": "bunchOfHerbs", "questId": "hollowmere-witch-brew" },
     { "id": "moonherb-2", "tx": 16, "ty": 14, "tileId": "bunchOfHerbs", "questId": "hollowmere-witch-brew" },
-    { "id": "moonherb-3", "tx": 24, "ty": 17, "tileId": "bunchOfHerbs", "questId": "hollowmere-witch-brew" }
+    { "id": "moonherb-3", "tx": 24, "ty": 17, "tileId": "bunchOfHerbs", "questId": "hollowmere-witch-brew" },
+    { "id": "spell-feather", "tx": 5, "ty": 12, "tileId": "feather", "questId": "morwen-speak-with-animals" },
+    { "id": "spell-mooncap", "tx": 18, "ty": 14, "tileId": "purpleMushroom", "questId": "morwen-speak-with-animals" },
+    { "id": "spell-rose", "tx": 22, "ty": 17, "tileId": "cropRose", "questId": "morwen-speak-with-animals" }
   ],
   "blockedPaths": []
 }

--- a/web/src/data/hub/loader.ts
+++ b/web/src/data/hub/loader.ts
@@ -134,6 +134,7 @@ export interface HubAnimal {
   questReceive?: string | string[]
   roam?: boolean
   areaRect?: number[]
+  dialogueTree?: string
 }
 
 export interface HubPickupItem extends DecorGlow {
@@ -580,6 +581,7 @@ const HUB_ANIMALS: HubAnimal[] = (
   questReceive: a.questReceive,
   roam:         a.roam,
   areaRect:     a.areaRect,
+  dialogueTree: a.dialogueTree,
 }))
 
 const HUB_CHICKEN_ZONES = (

--- a/web/src/data/hub/millhaven/config.json
+++ b/web/src/data/hub/millhaven/config.json
@@ -1348,7 +1348,8 @@
         10,
         10
       ],
-      "questGive": "kippers-kipper"
+      "questGive": "kippers-kipper",
+      "dialogueTree": "kipper-truth"
     }
   ],
   "interactables": [],

--- a/web/src/data/hub/millhaven/questDefs.json
+++ b/web/src/data/hub/millhaven/questDefs.json
@@ -221,7 +221,8 @@
       ],
       "reward": {
         "crystals": 1
-      }
+      },
+      "prerequisite": "quest:new-quest-1"
     },
     {
       "id": "kippers-2nd-kipper",
@@ -245,7 +246,7 @@
       "reward": {
         "crystals": 2
       },
-      "prerequisite": "kippers-kipper"
+      "prerequisite": "quest:kippers-kipper"
     },
     {
       "id": "kippers-3rd-kipper",
@@ -269,7 +270,57 @@
       "reward": {
         "crystals": 3
       },
-      "prerequisite": "kippers-2nd-kipper"
+      "prerequisite": "quest:kippers-2nd-kipper"
+    },
+    {
+      "id": "kipper-marta-hint",
+      "title": "A Word from the Fishwife",
+      "type": "fetch",
+      "giverNpcId": "fishmonger-marta",
+      "receiverNpcId": "hedge-witch-morwen",
+      "prerequisite": "quest:kippers-3rd-kipper",
+      "offerDialogue": "You're the soul fetching kippers for that orange tom? Three lots now, and he wails louder than ever. Between us — fish isn't it. My gran used to swear there was a hedge-witch over in Hollowmere, Morwen by name, who could teach a body to truly SPEAK with animals. Daft, I thought. But that cat is trying to tell us something. Go and ask her — say Marta of Millhaven sent you, about a very unhappy cat.",
+      "activeDialogue": "Hedge-Witch Morwen, in Hollowmere. Tell her the Millhaven fishwife sent you about a yowling cat.",
+      "completeDialogue": "Marta sent you? About a cat that won't stop crying? Hmph. You'll be wanting the beast-tongue, then — to speak with it, and worse, to listen. That is no parlour trick, and I do not teach it to anyone who wanders in off the marsh.",
+      "steps": [
+        {
+          "key": "visit",
+          "type": "deliver",
+          "targetNpcId": "hedge-witch-morwen",
+          "required": 1
+        }
+      ],
+      "reward": { "crystals": 20 }
+    },
+    {
+      "id": "kipper-true-wish",
+      "title": "What Kipper Really Wants",
+      "type": "fetch",
+      "giverNpcId": "kipper",
+      "receiverNpcId": "kipper",
+      "prerequisite": "quest:morwen-speak-with-animals | flag:kipper-confided",
+      "offerDialogue": "Finally, someone who LISTENS. Right, here it is: I cannot STAND fish. The smell, the bones, the eternal slimy kippers — and everyone keeps giving me MORE because some genius named me Kipper. Bring me something — anything — that is not a fish. A feather toy, a ball, anything. Please.",
+      "activeDialogue": "Anything but fish, remember. There is bound to be a proper cat-toy somewhere in this town.",
+      "completeDialogue": "A feather-toy! For ME! *bats it joyfully* You wonderful human — you actually understood. Tell the Princess I am happy, truly happy, and she may keep every last kipper. MEOW! (the good kind.)",
+      "steps": [
+        {
+          "key": "gift",
+          "type": "collect",
+          "pickupIds": [
+            "kipper-feather-toy"
+          ],
+          "required": 1
+        }
+      ],
+      "reward": {
+        "crystals": 60,
+        "collectible": {
+          "id": "kippers-smile",
+          "name": "Kipper's Smile",
+          "icon": "😺",
+          "desc": "Proof that you finally understood a very particular cat."
+        }
+      }
     }
   ],
   "pickupItems": [
@@ -362,7 +413,54 @@
       "tileId": "goldFish",
       "zlayer": "below",
       "questId": "kippers-3rd-kipper"
+    },
+    {
+      "id": "kipper-feather-toy",
+      "tx": 29,
+      "ty": 13,
+      "tileId": "toy",
+      "zlayer": "below",
+      "questId": "kipper-true-wish"
     }
   ],
-  "blockedPaths": []
+  "blockedPaths": [],
+  "dialogues": [
+    {
+      "id": "kipper-truth",
+      "npcId": "kipper",
+      "start": "meet",
+      "nodes": {
+        "meet": {
+          "text": "Mrrow? (Kipper looks up at you, tail twitching.)",
+          "choices": [
+            { "label": "\"There there. Hungry? I'll fetch you a nice fish.\"", "hideIfQuest": "morwen-speak-with-animals", "next": "nofish" },
+            { "label": "\"What's the matter, little one?\"", "hideIfQuest": "morwen-speak-with-animals", "next": "nounderstand" },
+            { "label": "\"...Hello? Can you understand me now?\"", "requireQuest": "morwen-speak-with-animals", "next": "talk" }
+          ]
+        },
+        "nofish": {
+          "text": "Kipper hisses, flattens his ears, and pointedly turns his back on you. (He really does not seem to want a fish.)"
+        },
+        "nounderstand": {
+          "text": "He yowls — long and mournful — but you cannot make out a word of it. The fishwife was right: you'd have to truly understand him first."
+        },
+        "talk": {
+          "text": "\"...You can hear me? You can actually HEAR me?! Oh, FINALLY. Do you have ANY idea what I have been trying to say all this time?\"",
+          "choices": [
+            { "label": "\"That you're hungry?\"", "next": "wrong1" },
+            { "label": "\"That you miss the Princess?\"", "next": "wrong2" },
+            { "label": "\"Wait... do you actually HATE fish?\"", "effects": [ { "type": "flag", "flag": "kipper-confided" }, { "type": "quest", "questId": "kipper-true-wish" } ] }
+          ]
+        },
+        "wrong1": {
+          "text": "\"HUNGRY? I am DROWNING in fish — that is the entire PROBLEM!\" He huffs and lashes his tail. \"Think again.\"",
+          "choices": [ { "label": "Think harder.", "next": "talk" } ]
+        },
+        "wrong2": {
+          "text": "\"...Well, yes, obviously I miss her. But that is not the urgent bit. Think about what is RIGHT IN FRONT OF YOU — the thing you keep BRINGING me.\"",
+          "choices": [ { "label": "Think harder.", "next": "talk" } ]
+        }
+      }
+    }
+  ]
 }

--- a/web/src/data/hub/questDefs.ts
+++ b/web/src/data/hub/questDefs.ts
@@ -201,6 +201,8 @@ export interface DialogueChoiceDef {
   effects?: DialogueEffect[]
   requireFlag?: string     // only show this choice if the flag is set
   hideIfFlag?: string      // hide this choice once the flag is set
+  requireQuest?: string    // only show this choice once that quest is completed
+  hideIfQuest?: string     // hide this choice once that quest is completed
 }
 
 export interface DialogueNode {

--- a/web/src/data/hub/royalpalace/questDefs.json
+++ b/web/src/data/hub/royalpalace/questDefs.json
@@ -34,14 +34,53 @@
     {
       "id": "new-quest-1",
       "title": "The Sick Princess",
-      "type": "chain",
+      "type": "fetch",
       "giverNpcId": "royal-steward",
-      "receiverNpcId": "royal-herald",
-      "offerDialogue": "",
-      "activeDialogue": {},
-      "completeDialogue": "",
-      "steps": [],
-      "reward": {}
+      "receiverNpcId": "kipper",
+      "offerDialogue": "Oh, thank goodness — a capable face. The Princess is inconsolable. Her darling cat, Kipper, was sent down to Millhaven for the sea air, and word comes back that he does nothing but wail, day and night. She cannot eat nor sleep for worry. Please — travel to Millhaven, find Kipper, and discover what ails the poor creature.",
+      "activeDialogue": "Kipper is in Millhaven, down by the waterfront last we heard. Find him, I beg you.",
+      "completeDialogue": "Kipper is curled on the dockside, crying at the grey waves. He looks up at you, wails twice as loud, and presses his face into your hand — something is dreadfully wrong, but for the life of you, you cannot tell what. Perhaps the locals know what ails him.",
+      "steps": [
+        {
+          "key": "find",
+          "type": "deliver",
+          "targetNpcId": "kipper",
+          "required": 1
+        }
+      ],
+      "reward": {
+        "crystals": 30,
+        "friendship": { "royal-steward": 10 }
+      }
+    },
+    {
+      "id": "palace-happy-cat",
+      "title": "A Cat's Contentment",
+      "type": "fetch",
+      "giverNpcId": "royal-steward",
+      "receiverNpcId": "royal-steward",
+      "prerequisite": "quest:kipper-true-wish",
+      "offerDialogue": "You have returned! And the news? ...Kipper hated FISH? All this time? The Princess gave him nothing but the finest kippers because she believed he adored them — oh, the poor darling. Carry the truth up to her, and the crown's gratitude with it.",
+      "activeDialogue": "Carry the good news up to the Princess — Kipper is happy at last.",
+      "completeDialogue": "The Princess is overjoyed. Kipper purrs in her lap as we speak, a feather-toy in his paws and not a fish in sight. You have mended a small heartbreak today, and the crown pays its debts. Well done.",
+      "steps": [
+        {
+          "key": "report",
+          "type": "deliver",
+          "targetNpcId": "royal-steward",
+          "required": 1
+        }
+      ],
+      "reward": {
+        "crystals": 120,
+        "collectible": {
+          "id": "royal-favour",
+          "name": "Royal Favour",
+          "icon": "👑",
+          "desc": "The Princess's personal thanks for healing her beloved Kipper."
+        },
+        "friendship": { "royal-steward": 25 }
+      }
     }
   ],
   "pickupItems": [


### PR DESCRIPTION
A multi-town storyline built on the cross-town quest engine. The Princess's beloved cat **Kipper** is miserable in Millhaven — everyone keeps feeding him "kippers" (fish) because of his name, and he secretly *hates* fish.

## The arc
1. **Royal Palace** — Steward Marigold's "The Sick Princess" (was an empty stub): go to Millhaven and find out what ails Kipper.
2. **Millhaven** — the 3 existing fish quests (now properly chained); bring Kipper fish → he only yowls louder.
3. **Hint** — Fishwife Marta: "fish isn't it… the Hedge-Witch of Hollowmere can teach you to *speak with animals*." → points to Morwen.
4. **Hollowmere** — Hedge-Witch Morwen teaches "Speak with Animals", but only after you've proven yourself (gated behind her Witch-Brew quest + the hint).
5. **The reveal (dialogue puzzle)** — back at Kipper: before the spell he only meows; after it, a *say-the-right-thing* puzzle — guess wrong and he huffs; the right line ("do you actually HATE fish?") makes him confide and offers the final quest.
6. **What Kipper Really Wants** — bring him a non-fish gift (a feather-toy).
7. **Royal Palace** — "A Cat's Contentment" closes the arc with the Princess.

## Engine hooks (small, reusable — first commit)
- Animals can carry a `dialogueTree` (config/loader/editor).
- `checkPrerequisite` supports `flag:<name>` conditions.
- Dialogue choices support `requireQuest` / `hideIfQuest` gating.

These let "spell learned" (a completed quest) gate the dialogue puzzle, and the puzzle's flag gate the reveal quest — no new ability system needed.

## Notes
- Fixed the existing Kipper fish-quest prereqs from bare ids to `quest:<id>` (they previously didn't gate).
- New pickups reuse existing tile ids (`feather`, `purpleMushroom`, `cropRose`, `toy`) — no new sprites.

## Verification
- `npm run build` ✅ and `npx vitest run` ✅ (198/198; the loader tests parse every town's data).
- Logic traced end-to-end (cross-town deliver/collect, prereq gating, puzzle → flag → reveal). A manual playthrough (palace → Millhaven → Hollowmere → back) is recommended to tune pickup tile placement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011f8gD7RAP6taye8wz8GfFs)_