### PR TITLE
Expand Crownhaven (capitalcity) to Tier A hub town (#1736)

### DIFF
--- a/web/src/data/hub/capitalcity/config.json
+++ b/web/src/data/hub/capitalcity/config.json
@@ -1,21 +1,21 @@
 {
-  "mapW": 1280,
-  "mapH": 1088,
+  "mapW": 1920,
+  "mapH": 1600,
   "townName": "Crownhaven",
   "environment": "citadel",
   "avatarStart": {
-    "tx": 19,
-    "ty": 30
+    "tx": 56,
+    "ty": 92
   },
   "exitTiles": [
     {
-      "tx": 19,
-      "ty": 31,
+      "tx": 56,
+      "ty": 93,
       "screen": "worldmap"
     },
     {
-      "tx": 20,
-      "ty": 31,
+      "tx": 57,
+      "ty": 93,
       "screen": "worldmap"
     }
   ],
@@ -23,97 +23,191 @@
     {
       "id": "crownhaven-plaza",
       "name": "Coronation Plaza",
-      "tx": 14,
-      "ty": 10,
-      "tw": 12,
-      "th": 8
+      "tx": 30,
+      "ty": 44,
+      "tw": 56,
+      "th": 18
     },
     {
       "id": "crownhaven-market",
       "name": "The Grand Market",
-      "tx": 26,
-      "ty": 2,
-      "tw": 12,
+      "tx": 24,
+      "ty": 4,
+      "tw": 56,
       "th": 14
+    },
+    {
+      "id": "crownhaven-temple",
+      "name": "Temple Quarter",
+      "tx": 6,
+      "ty": 18,
+      "tw": 34,
+      "th": 26
+    },
+    {
+      "id": "crownhaven-oldtown",
+      "name": "Old Town",
+      "tx": 84,
+      "ty": 18,
+      "tw": 30,
+      "th": 26
+    },
+    {
+      "id": "crownhaven-guard",
+      "name": "Guard Quarter",
+      "tx": 54,
+      "ty": 66,
+      "tw": 60,
+      "th": 24
+    },
+    {
+      "id": "crownhaven-river",
+      "name": "Riverside",
+      "tx": 6,
+      "ty": 66,
+      "tw": 34,
+      "th": 24
+    }
+  ],
+  "pondTiles": [
+    {
+      "rect": [
+        10,
+        90,
+        38,
+        97
+      ]
+    },
+    {
+      "rect": [
+        14,
+        88,
+        34,
+        90
+      ]
     }
   ],
   "streets": [
     {
       "rect": [
-        18,
-        2,
-        21,
-        33
+        0,
+        14,
+        119,
+        15
       ]
     },
     {
       "rect": [
-        2,
-        14,
-        37,
-        17
+        0,
+        28,
+        119,
+        29
       ]
     },
     {
       "rect": [
-        14,
-        10,
+        0,
+        42,
+        119,
+        43
+      ]
+    },
+    {
+      "rect": [
+        0,
+        64,
+        119,
+        65
+      ]
+    },
+    {
+      "rect": [
+        0,
+        80,
+        119,
+        81
+      ]
+    },
+    {
+      "rect": [
+        0,
+        88,
+        119,
+        89
+      ]
+    },
+    {
+      "rect": [
+        8,
+        0,
+        9,
+        99
+      ]
+    },
+    {
+      "rect": [
+        24,
+        0,
         25,
-        13
+        99
       ]
     },
     {
       "rect": [
-        6,
-        18,
-        7,
-        22
+        56,
+        0,
+        57,
+        99
       ]
     },
     {
       "rect": [
-        32,
-        18,
-        33,
-        22
+        88,
+        0,
+        89,
+        99
+      ]
+    },
+    {
+      "rect": [
+        110,
+        0,
+        111,
+        99
+      ]
+    },
+    {
+      "rect": [
+        30,
+        48,
+        86,
+        55
+      ]
+    },
+    {
+      "rect": [
+        54,
+        88,
+        59,
+        99
       ]
     }
   ],
   "buildings": [
     {
-      "id": "grand-inn",
-      "upgradeKind": "inn",
-      "rect": [
-        3,
-        2,
-        12,
-        9
-      ],
-      "wall": "whiteStone",
-      "roof": "blueSlateRoof",
-      "doors": [
-        {
-          "tx": 5,
-          "ty": 1,
-          "hideSign": true,
-          "buildingId": "grand-inn"
-        }
-      ]
-    },
-    {
       "id": "market-hall-crownhaven",
       "upgradeKind": "shop",
       "rect": [
-        27,
-        2,
-        36,
-        9
+        26,
+        6,
+        40,
+        13
       ],
       "wall": "brick",
       "roof": "redSlateRoof",
       "doors": [
         {
-          "tx": 4,
+          "tx": 7,
           "ty": 1,
           "hideSign": true,
           "buildingId": "market-hall-crownhaven"
@@ -121,359 +215,5509 @@
       ]
     },
     {
-      "id": "guardhouse",
-      "upgradeKind": "workshop",
+      "id": "bakery",
+      "upgradeKind": "shop",
       "rect": [
-        3,
-        20,
-        10,
-        26
+        42,
+        6,
+        50,
+        13
       ],
-      "wall": "castleStone",
-      "roof": "greySlateRoof",
+      "wall": "renderedBrick",
+      "roof": "yellowSlateRoof",
       "doors": [
         {
           "tx": 3,
           "ty": 1,
           "hideSign": true,
-          "buildingId": "guardhouse"
+          "buildingId": "bakery"
         }
       ]
     },
     {
-      "id": "chapel",
+      "id": "jeweller",
+      "upgradeKind": "shop",
+      "rect": [
+        58,
+        6,
+        67,
+        13
+      ],
+      "wall": "whiteStone",
+      "roof": "blueSlateRoof",
+      "doors": [
+        {
+          "tx": 4,
+          "ty": 1,
+          "hideSign": true,
+          "buildingId": "jeweller"
+        }
+      ]
+    },
+    {
+      "id": "tailor",
+      "upgradeKind": "shop",
+      "rect": [
+        69,
+        6,
+        78,
+        13
+      ],
+      "wall": "tudorFrame",
+      "roof": "redSlateRoof",
+      "doors": [
+        {
+          "tx": 4,
+          "ty": 1,
+          "hideSign": true,
+          "buildingId": "tailor"
+        }
+      ]
+    },
+    {
+      "id": "cathedral",
       "upgradeKind": "shrine",
       "rect": [
-        29,
+        10,
         20,
-        36,
+        23,
         27
       ],
       "wall": "ornateStone",
       "roof": "blueSlateRoof",
       "doors": [
         {
-          "tx": 3,
+          "tx": 6,
           "ty": 1,
           "hideSign": true,
-          "buildingId": "chapel"
+          "buildingId": "cathedral"
+        }
+      ]
+    },
+    {
+      "id": "library",
+      "upgradeKind": "default",
+      "rect": [
+        26,
+        20,
+        37,
+        27
+      ],
+      "wall": "whiteStone",
+      "roof": "greySlateRoof",
+      "doors": [
+        {
+          "tx": 5,
+          "ty": 1,
+          "hideSign": true,
+          "buildingId": "library"
+        }
+      ]
+    },
+    {
+      "id": "academy",
+      "upgradeKind": "default",
+      "rect": [
+        42,
+        20,
+        54,
+        27
+      ],
+      "wall": "castleStone",
+      "roof": "greySlateRoof",
+      "doors": [
+        {
+          "tx": 6,
+          "ty": 1,
+          "hideSign": true,
+          "buildingId": "academy"
+        }
+      ]
+    },
+    {
+      "id": "grand-inn",
+      "upgradeKind": "inn",
+      "rect": [
+        90,
+        20,
+        104,
+        27
+      ],
+      "wall": "whiteStone",
+      "roof": "blueSlateRoof",
+      "doors": [
+        {
+          "tx": 6,
+          "ty": 1,
+          "hideSign": true,
+          "buildingId": "grand-inn"
+        }
+      ]
+    },
+    {
+      "id": "apothecary",
+      "upgradeKind": "shop",
+      "rect": [
+        10,
+        34,
+        18,
+        41
+      ],
+      "wall": "tudorFrame",
+      "roof": "greySlateRoof",
+      "doors": [
+        {
+          "tx": 4,
+          "ty": 1,
+          "hideSign": true,
+          "buildingId": "apothecary"
+        }
+      ]
+    },
+    {
+      "id": "theatre",
+      "upgradeKind": "default",
+      "rect": [
+        58,
+        34,
+        72,
+        41
+      ],
+      "wall": "ornateStone",
+      "roof": "redSlateRoof",
+      "doors": [
+        {
+          "tx": 6,
+          "ty": 1,
+          "hideSign": true,
+          "buildingId": "theatre"
+        }
+      ]
+    },
+    {
+      "id": "noble-manor-1",
+      "upgradeKind": "cottage",
+      "rect": [
+        90,
+        34,
+        100,
+        41
+      ],
+      "wall": "renderedBrick",
+      "roof": "redSlateRoof",
+      "doors": [
+        {
+          "tx": 5,
+          "ty": 1,
+          "hideSign": true,
+          "buildingId": "noble-manor-1"
+        }
+      ]
+    },
+    {
+      "id": "blacksmith",
+      "upgradeKind": "workshop",
+      "rect": [
+        10,
+        56,
+        19,
+        63
+      ],
+      "wall": "castleStone",
+      "roof": "metalRoof",
+      "doors": [
+        {
+          "tx": 4,
+          "ty": 1,
+          "hideSign": true,
+          "buildingId": "blacksmith"
+        }
+      ]
+    },
+    {
+      "id": "senate",
+      "upgradeKind": "default",
+      "rect": [
+        42,
+        56,
+        54,
+        63
+      ],
+      "wall": "ornateStone",
+      "roof": "blueSlateRoof",
+      "doors": [
+        {
+          "tx": 6,
+          "ty": 1,
+          "hideSign": true,
+          "buildingId": "senate"
+        }
+      ]
+    },
+    {
+      "id": "noble-manor-2",
+      "upgradeKind": "cottage",
+      "rect": [
+        90,
+        56,
+        100,
+        63
+      ],
+      "wall": "renderedBrick",
+      "roof": "yellowSlateRoof",
+      "doors": [
+        {
+          "tx": 5,
+          "ty": 1,
+          "hideSign": true,
+          "buildingId": "noble-manor-2"
+        }
+      ]
+    },
+    {
+      "id": "grand-bank",
+      "upgradeKind": "shop",
+      "rect": [
+        58,
+        72,
+        68,
+        79
+      ],
+      "wall": "castleStone",
+      "roof": "greySlateRoof",
+      "doors": [
+        {
+          "tx": 5,
+          "ty": 1,
+          "hideSign": true,
+          "buildingId": "grand-bank"
+        }
+      ]
+    },
+    {
+      "id": "royal-mint",
+      "upgradeKind": "workshop",
+      "rect": [
+        70,
+        72,
+        80,
+        79
+      ],
+      "wall": "reinforcedStone",
+      "roof": "metalRoof",
+      "doors": [
+        {
+          "tx": 5,
+          "ty": 1,
+          "hideSign": true,
+          "buildingId": "royal-mint"
+        }
+      ]
+    },
+    {
+      "id": "guardhouse",
+      "upgradeKind": "workshop",
+      "rect": [
+        90,
+        72,
+        104,
+        79
+      ],
+      "wall": "castleStone",
+      "roof": "greySlateRoof",
+      "doors": [
+        {
+          "tx": 6,
+          "ty": 1,
+          "hideSign": true,
+          "buildingId": "guardhouse"
         }
       ]
     }
   ],
-  "exteriorDecor": [
-    {
-      "comment": "plaza fountain"
+  "interiors": {
+    "cathedral": {
+      "name": "Crownhaven Cathedral",
+      "width": 14,
+      "height": 10,
+      "floorTileId": "cobblestoneFloor",
+      "wallTileId": "castleStone",
+      "decor": [
+        {
+          "tx": 1,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 4,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 7,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 10,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 7,
+          "ty": 0,
+          "tileId": "altarTopMid"
+        },
+        {
+          "tx": 7,
+          "ty": 1,
+          "tileId": "altarMidMid"
+        },
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "candlestickLitTop"
+        },
+        {
+          "tx": 12,
+          "ty": 1,
+          "tileId": "candlestickLitTop"
+        },
+        {
+          "tx": 2,
+          "ty": 8,
+          "tileId": "benchLeft"
+        },
+        {
+          "tx": 3,
+          "ty": 8,
+          "tileId": "benchMiddle"
+        },
+        {
+          "tx": 4,
+          "ty": 8,
+          "tileId": "benchRight"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 2,
+          "ty": 9,
+          "toInteriorId": "cathedral-crypt",
+          "entryTx": 6,
+          "entryTy": 6,
+          "direction": "down"
+        },
+        {
+          "tx": 11,
+          "ty": 0,
+          "toInteriorId": "cathedral-tower",
+          "entryTx": 5,
+          "entryTy": 0,
+          "direction": "up"
+        }
+      ]
     },
-    {
-      "tx": 18,
-      "ty": 11,
-      "bundleID": "fountain",
-      "zlayer": "solid"
+    "cathedral-crypt": {
+      "name": "The Cathedral Crypt",
+      "width": 12,
+      "height": 9,
+      "floorTileId": "darkStoneFloor",
+      "wallTileId": "castleStone",
+      "decor": [
+        {
+          "tx": 1,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 4,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 7,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 10,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "graveStone"
+        },
+        {
+          "tx": 3,
+          "ty": 1,
+          "tileId": "stoneCross"
+        },
+        {
+          "tx": 10,
+          "ty": 1,
+          "tileId": "graveStone"
+        },
+        {
+          "tx": 6,
+          "ty": 7,
+          "tileId": "candlestickLitTop"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 6,
+          "ty": 7,
+          "toInteriorId": "cathedral",
+          "entryTx": 2,
+          "entryTy": 8,
+          "direction": "up"
+        }
+      ]
     },
-    {
-      "comment": "market clutter"
+    "cathedral-tower": {
+      "name": "The Bell Tower",
+      "width": 10,
+      "height": 9,
+      "floorTileId": "stoneFloor",
+      "wallTileId": "castleStone",
+      "decor": [
+        {
+          "tx": 1,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 4,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 7,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 5,
+          "ty": 0,
+          "tileId": "bellTowerTop"
+        },
+        {
+          "tx": 5,
+          "ty": 1,
+          "tileId": "bellTowerBottom"
+        },
+        {
+          "tx": 1,
+          "ty": 7,
+          "tileId": "ladderBottom",
+          "zlayer": "below"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 5,
+          "ty": 1,
+          "toInteriorId": "cathedral",
+          "entryTx": 11,
+          "entryTy": 0,
+          "direction": "down"
+        }
+      ]
     },
-    {
-      "tx": 26,
-      "ty": 11,
-      "tileId": "crate"
+    "senate": {
+      "name": "The Senate Chamber",
+      "width": 14,
+      "height": 10,
+      "floorTileId": "redCarpetFloor",
+      "wallTileId": "castleStone",
+      "decor": [
+        {
+          "tx": 1,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 4,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 7,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 10,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 7,
+          "ty": 1,
+          "tileId": "roundTableWithCloth"
+        },
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "pileOfPapers"
+        },
+        {
+          "tx": 12,
+          "ty": 1,
+          "tileId": "deskTop"
+        },
+        {
+          "tx": 2,
+          "ty": 8,
+          "tileId": "stool"
+        },
+        {
+          "tx": 11,
+          "ty": 8,
+          "tileId": "wallClock"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 12,
+          "ty": 0,
+          "toInteriorId": "senate-archive",
+          "entryTx": 6,
+          "entryTy": 0,
+          "direction": "back"
+        }
+      ]
     },
-    {
-      "tx": 27,
-      "ty": 11,
-      "tileId": "openCrate"
+    "senate-archive": {
+      "name": "The Senate Archive",
+      "width": 12,
+      "height": 9,
+      "floorTileId": "parquetFloor",
+      "wallTileId": "castleStone",
+      "decor": [
+        {
+          "tx": 1,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 4,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 7,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 10,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "bookshelfTop"
+        },
+        {
+          "tx": 1,
+          "ty": 2,
+          "tileId": "bookshelfBottom"
+        },
+        {
+          "tx": 10,
+          "ty": 1,
+          "tileId": "bookshelfTop"
+        },
+        {
+          "tx": 10,
+          "ty": 2,
+          "tileId": "bookshelfBottom"
+        },
+        {
+          "tx": 6,
+          "ty": 2,
+          "tileId": "deskTop"
+        },
+        {
+          "tx": 3,
+          "ty": 7,
+          "tileId": "roundTableWithCloth"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 6,
+          "ty": 1,
+          "toInteriorId": "senate",
+          "entryTx": 12,
+          "entryTy": 0,
+          "direction": "front"
+        }
+      ]
     },
-    {
-      "tx": 35,
-      "ty": 11,
-      "tileId": "barrel"
+    "guardhouse": {
+      "name": "The Watch Barracks",
+      "width": 14,
+      "height": 10,
+      "floorTileId": "stoneFloor",
+      "wallTileId": "castleStone",
+      "decor": [
+        {
+          "tx": 1,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 4,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 7,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 10,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "suitOfArmourTop"
+        },
+        {
+          "tx": 1,
+          "ty": 2,
+          "tileId": "suitOfArmourBottom"
+        },
+        {
+          "tx": 12,
+          "ty": 1,
+          "tileId": "suitOfArmourTop"
+        },
+        {
+          "tx": 12,
+          "ty": 2,
+          "tileId": "suitOfArmourBottom"
+        },
+        {
+          "tx": 7,
+          "ty": 1,
+          "tileId": "swordMountedLeft"
+        },
+        {
+          "tx": 8,
+          "ty": 1,
+          "tileId": "shieldMounted"
+        },
+        {
+          "tx": 2,
+          "ty": 8,
+          "tileId": "roundTable"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 1,
+          "ty": 0,
+          "toInteriorId": "guardhouse-armory",
+          "entryTx": 6,
+          "entryTy": 0,
+          "direction": "back"
+        },
+        {
+          "tx": 12,
+          "ty": 9,
+          "toInteriorId": "guardhouse-cells",
+          "entryTx": 6,
+          "entryTy": 6,
+          "direction": "down"
+        }
+      ]
     },
-    {
-      "tx": 36,
-      "ty": 12,
-      "tileId": "sack"
+    "guardhouse-armory": {
+      "name": "The Armoury",
+      "width": 12,
+      "height": 8,
+      "floorTileId": "stoneFloor",
+      "wallTileId": "castleStone",
+      "decor": [
+        {
+          "tx": 1,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 4,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 7,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 10,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "suitOfArmourTop"
+        },
+        {
+          "tx": 1,
+          "ty": 2,
+          "tileId": "suitOfArmourBottom"
+        },
+        {
+          "tx": 10,
+          "ty": 1,
+          "tileId": "suitOfArmourTop"
+        },
+        {
+          "tx": 10,
+          "ty": 2,
+          "tileId": "suitOfArmourBottom"
+        },
+        {
+          "tx": 6,
+          "ty": 1,
+          "tileId": "swordMountedLeft"
+        },
+        {
+          "tx": 7,
+          "ty": 1,
+          "tileId": "shieldMounted"
+        },
+        {
+          "tx": 2,
+          "ty": 6,
+          "tileId": "roundTable"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 6,
+          "ty": 1,
+          "toInteriorId": "guardhouse",
+          "entryTx": 1,
+          "entryTy": 0,
+          "direction": "front"
+        }
+      ]
     },
-    {
-      "comment": "guardhouse braziers"
+    "guardhouse-cells": {
+      "name": "The Holding Cells",
+      "width": 12,
+      "height": 8,
+      "floorTileId": "darkStoneFloor",
+      "wallTileId": "castleStone",
+      "decor": [
+        {
+          "tx": 1,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 4,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 7,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 10,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "graveStone"
+        },
+        {
+          "tx": 3,
+          "ty": 1,
+          "tileId": "stoneCross"
+        },
+        {
+          "tx": 10,
+          "ty": 1,
+          "tileId": "graveStone"
+        },
+        {
+          "tx": 6,
+          "ty": 6,
+          "tileId": "candlestickLitTop"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 6,
+          "ty": 7,
+          "toInteriorId": "guardhouse",
+          "entryTx": 12,
+          "entryTy": 8,
+          "direction": "up"
+        }
+      ]
     },
-    {
-      "tx": 4,
-      "ty": 28,
-      "tileId": "brazierBottom"
+    "grand-inn": {
+      "name": "The Gilded Goose",
+      "width": 14,
+      "height": 10,
+      "floorTileId": "woodFloor",
+      "wallTileId": "interiorWallWhite",
+      "decor": [
+        {
+          "tx": 1,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 4,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 7,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 10,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 2,
+          "ty": 1,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 11,
+          "ty": 1,
+          "tileId": "roundTableWithCloth"
+        },
+        {
+          "tx": 12,
+          "ty": 2,
+          "tileId": "stool"
+        },
+        {
+          "tx": 10,
+          "ty": 2,
+          "tileId": "stool"
+        },
+        {
+          "tx": 4,
+          "ty": 8,
+          "tileId": "fireplaceBottomMiddle"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 12,
+          "ty": 0,
+          "toInteriorId": "grand-inn-upstairs",
+          "entryTx": 6,
+          "entryTy": 0,
+          "direction": "up"
+        }
+      ]
     },
-    {
-      "tx": 4,
-      "ty": 27,
-      "tileId": "brazierTop",
-      "zlayer": "above"
+    "grand-inn-upstairs": {
+      "name": "The Gilded Goose \u2014 Rooms",
+      "width": 14,
+      "height": 9,
+      "floorTileId": "woodFloor",
+      "wallTileId": "interiorWallWhite",
+      "decor": [
+        {
+          "tx": 1,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 4,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 7,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 10,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "normalBedHead"
+        },
+        {
+          "tx": 1,
+          "ty": 2,
+          "tileId": "normalBedFoot"
+        },
+        {
+          "tx": 3,
+          "ty": 1,
+          "tileId": "normalBedHead"
+        },
+        {
+          "tx": 3,
+          "ty": 2,
+          "tileId": "normalBedFoot"
+        },
+        {
+          "tx": 12,
+          "ty": 1,
+          "tileId": "smallTableTopLeft"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 6,
+          "ty": 1,
+          "toInteriorId": "grand-inn",
+          "entryTx": 12,
+          "entryTy": 0,
+          "direction": "down"
+        }
+      ]
     },
-    {
-      "tx": 9,
-      "ty": 28,
-      "tileId": "brazierBottom"
+    "library": {
+      "name": "The Royal Library",
+      "width": 13,
+      "height": 10,
+      "floorTileId": "parquetFloor",
+      "wallTileId": "interiorWallWhite",
+      "decor": [
+        {
+          "tx": 1,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 4,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 7,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 10,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "bookshelfTop"
+        },
+        {
+          "tx": 1,
+          "ty": 2,
+          "tileId": "bookshelfBottom"
+        },
+        {
+          "tx": 11,
+          "ty": 1,
+          "tileId": "bookshelfTop"
+        },
+        {
+          "tx": 11,
+          "ty": 2,
+          "tileId": "bookshelfBottom"
+        },
+        {
+          "tx": 6,
+          "ty": 2,
+          "tileId": "deskTop"
+        },
+        {
+          "tx": 3,
+          "ty": 8,
+          "tileId": "roundTableWithCloth"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 11,
+          "ty": 0,
+          "toInteriorId": "library-stacks",
+          "entryTx": 6,
+          "entryTy": 0,
+          "direction": "back"
+        }
+      ]
     },
-    {
-      "tx": 9,
-      "ty": 27,
-      "tileId": "brazierTop",
-      "zlayer": "above"
+    "library-stacks": {
+      "name": "The Stacks",
+      "width": 12,
+      "height": 9,
+      "floorTileId": "woodFloor",
+      "wallTileId": "interiorWallWhite",
+      "decor": [
+        {
+          "tx": 1,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 4,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 7,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 10,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "bookshelfTop"
+        },
+        {
+          "tx": 1,
+          "ty": 2,
+          "tileId": "bookshelfBottom"
+        },
+        {
+          "tx": 10,
+          "ty": 1,
+          "tileId": "bookshelfTop"
+        },
+        {
+          "tx": 10,
+          "ty": 2,
+          "tileId": "bookshelfBottom"
+        },
+        {
+          "tx": 6,
+          "ty": 2,
+          "tileId": "deskTop"
+        },
+        {
+          "tx": 3,
+          "ty": 7,
+          "tileId": "roundTableWithCloth"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 6,
+          "ty": 1,
+          "toInteriorId": "library",
+          "entryTx": 11,
+          "entryTy": 0,
+          "direction": "front"
+        }
+      ]
     },
-    {
-      "comment": "city greenery"
+    "academy": {
+      "name": "The Crown Academy",
+      "width": 14,
+      "height": 10,
+      "floorTileId": "checkeredFloor",
+      "wallTileId": "castleStone",
+      "decor": [
+        {
+          "tx": 1,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 4,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 7,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 10,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "bookshelfTop"
+        },
+        {
+          "tx": 1,
+          "ty": 2,
+          "tileId": "bookshelfBottom"
+        },
+        {
+          "tx": 12,
+          "ty": 1,
+          "tileId": "bookshelfTop"
+        },
+        {
+          "tx": 12,
+          "ty": 2,
+          "tileId": "bookshelfBottom"
+        },
+        {
+          "tx": 7,
+          "ty": 2,
+          "tileId": "deskTop"
+        },
+        {
+          "tx": 3,
+          "ty": 8,
+          "tileId": "roundTableWithCloth"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 12,
+          "ty": 0,
+          "toInteriorId": "academy-lecture",
+          "entryTx": 6,
+          "entryTy": 0,
+          "direction": "back"
+        }
+      ]
     },
-    {
-      "tx": 13,
-      "ty": 19,
-      "bundleID": "mixed-tree-cluster-V",
-      "zlayer": "solid"
+    "academy-lecture": {
+      "name": "The Lecture Hall",
+      "width": 12,
+      "height": 9,
+      "floorTileId": "woodFloor",
+      "wallTileId": "castleStone",
+      "decor": [
+        {
+          "tx": 1,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 4,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 7,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 10,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 6,
+          "ty": 1,
+          "tileId": "roundTableWithCloth"
+        },
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "pileOfPapers"
+        },
+        {
+          "tx": 10,
+          "ty": 1,
+          "tileId": "deskTop"
+        },
+        {
+          "tx": 2,
+          "ty": 7,
+          "tileId": "stool"
+        },
+        {
+          "tx": 9,
+          "ty": 7,
+          "tileId": "wallClock"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 6,
+          "ty": 1,
+          "toInteriorId": "academy",
+          "entryTx": 12,
+          "entryTy": 0,
+          "direction": "front"
+        }
+      ]
     },
-    {
-      "tx": 24,
-      "ty": 19,
-      "bundleID": "mixed-tree-cluster-V",
-      "zlayer": "solid"
+    "grand-bank": {
+      "name": "The Grand Bank",
+      "width": 12,
+      "height": 9,
+      "floorTileId": "ornateFloor",
+      "wallTileId": "castleStone",
+      "decor": [
+        {
+          "tx": 1,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 4,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 7,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 10,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 6,
+          "ty": 1,
+          "tileId": "roundTableWithCloth"
+        },
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "pileOfPapers"
+        },
+        {
+          "tx": 10,
+          "ty": 1,
+          "tileId": "deskTop"
+        },
+        {
+          "tx": 2,
+          "ty": 7,
+          "tileId": "stool"
+        },
+        {
+          "tx": 9,
+          "ty": 7,
+          "tileId": "wallClock"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 10,
+          "ty": 0,
+          "toInteriorId": "grand-bank-vault",
+          "entryTx": 5,
+          "entryTy": 6,
+          "direction": "back",
+          "requiredQuest": "crownhaven-stolen-coin"
+        }
+      ]
     },
-    {
-      "tx": 2,
-      "ty": 11,
-      "bundleID": "light-tree",
-      "zlayer": "solid"
+    "grand-bank-vault": {
+      "name": "The Bank Vault",
+      "width": 11,
+      "height": 8,
+      "floorTileId": "darkStoneFloor",
+      "wallTileId": "castleStone",
+      "decor": [
+        {
+          "tx": 1,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 4,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 7,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "goldChest"
+        },
+        {
+          "tx": 2,
+          "ty": 1,
+          "tileId": "chest"
+        },
+        {
+          "tx": 9,
+          "ty": 1,
+          "tileId": "strongChest"
+        },
+        {
+          "tx": 5,
+          "ty": 6,
+          "tileId": "pileOfGoldCoins"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 5,
+          "ty": 7,
+          "toInteriorId": "grand-bank",
+          "entryTx": 10,
+          "entryTy": 1,
+          "direction": "front"
+        }
+      ]
     },
-    {
-      "tx": 36,
-      "ty": 17,
-      "bundleID": "light-tree",
-      "zlayer": "solid"
+    "market-hall-crownhaven": {
+      "name": "The Grand Market Hall",
+      "width": 13,
+      "height": 9,
+      "floorTileId": "woodFloor",
+      "wallTileId": "interiorWallWhite",
+      "decor": [
+        {
+          "tx": 1,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 4,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 7,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 10,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 2,
+          "ty": 2,
+          "tileId": "counterTopHorizontalLeft",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 3,
+          "ty": 2,
+          "tileId": "counterTopHorizontalMiddle",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 4,
+          "ty": 2,
+          "tileId": "counterTopHorizontalRight",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "bookshelfTop"
+        },
+        {
+          "tx": 1,
+          "ty": 7,
+          "tileId": "crate"
+        },
+        {
+          "tx": 11,
+          "ty": 1,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 11,
+          "ty": 7,
+          "tileId": "sack"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 11,
+          "ty": 0,
+          "toInteriorId": "market-hall-crownhaven-back",
+          "entryTx": 6,
+          "entryTy": 0,
+          "direction": "back"
+        }
+      ]
     },
-    {
-      "tx": 14,
-      "ty": 9,
-      "tileId": "whiteFlower"
+    "market-hall-crownhaven-back": {
+      "name": "Market Stockroom",
+      "width": 12,
+      "height": 8,
+      "floorTileId": "woodFloor",
+      "wallTileId": "interiorWallWhite",
+      "decor": [
+        {
+          "tx": 1,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 4,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 7,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 10,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 2,
+          "ty": 2,
+          "tileId": "counterTopHorizontalLeft",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 3,
+          "ty": 2,
+          "tileId": "counterTopHorizontalMiddle",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 4,
+          "ty": 2,
+          "tileId": "counterTopHorizontalRight",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "bookshelfTop"
+        },
+        {
+          "tx": 1,
+          "ty": 6,
+          "tileId": "crate"
+        },
+        {
+          "tx": 10,
+          "ty": 1,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 10,
+          "ty": 6,
+          "tileId": "sack"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 6,
+          "ty": 1,
+          "toInteriorId": "market-hall-crownhaven",
+          "entryTx": 11,
+          "entryTy": 0,
+          "direction": "front"
+        }
+      ]
     },
-    {
-      "tx": 25,
-      "ty": 9,
-      "tileId": "whiteFlower"
+    "bakery": {
+      "name": "Otto's Bakery",
+      "width": 12,
+      "height": 9,
+      "floorTileId": "woodFloor",
+      "wallTileId": "interiorWallWhite",
+      "decor": [
+        {
+          "tx": 1,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 4,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 7,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 10,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 2,
+          "ty": 2,
+          "tileId": "counterTopHorizontalLeft",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 3,
+          "ty": 2,
+          "tileId": "counterTopHorizontalMiddle",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 4,
+          "ty": 2,
+          "tileId": "counterTopHorizontalRight",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "bookshelfTop"
+        },
+        {
+          "tx": 1,
+          "ty": 7,
+          "tileId": "crate"
+        },
+        {
+          "tx": 10,
+          "ty": 1,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 10,
+          "ty": 7,
+          "tileId": "sack"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 10,
+          "ty": 0,
+          "toInteriorId": "bakery-back",
+          "entryTx": 5,
+          "entryTy": 0,
+          "direction": "back"
+        }
+      ]
     },
-    {
-      "comment": "road sign at the south gate"
+    "bakery-back": {
+      "name": "Bakery Kitchen",
+      "width": 11,
+      "height": 8,
+      "floorTileId": "woodFloor",
+      "wallTileId": "interiorWallWhite",
+      "decor": [
+        {
+          "tx": 1,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 4,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 7,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 2,
+          "ty": 2,
+          "tileId": "counterTopHorizontalLeft",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 3,
+          "ty": 2,
+          "tileId": "counterTopHorizontalMiddle",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 4,
+          "ty": 2,
+          "tileId": "counterTopHorizontalRight",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "bookshelfTop"
+        },
+        {
+          "tx": 1,
+          "ty": 6,
+          "tileId": "crate"
+        },
+        {
+          "tx": 9,
+          "ty": 1,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 9,
+          "ty": 6,
+          "tileId": "sack"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 5,
+          "ty": 1,
+          "toInteriorId": "bakery",
+          "entryTx": 10,
+          "entryTy": 0,
+          "direction": "front"
+        }
+      ]
     },
-    {
-      "tx": 16,
-      "ty": 29,
-      "tileId": "roadSignTop",
-      "zlayer": "above"
+    "jeweller": {
+      "name": "Isolde's Fine Gems",
+      "width": 12,
+      "height": 9,
+      "floorTileId": "blueOrnateFloor",
+      "wallTileId": "interiorWallWhite",
+      "decor": [
+        {
+          "tx": 1,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 4,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 7,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 10,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 2,
+          "ty": 2,
+          "tileId": "counterTopHorizontalLeft",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 3,
+          "ty": 2,
+          "tileId": "counterTopHorizontalMiddle",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 4,
+          "ty": 2,
+          "tileId": "counterTopHorizontalRight",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "bookshelfTop"
+        },
+        {
+          "tx": 1,
+          "ty": 7,
+          "tileId": "crate"
+        },
+        {
+          "tx": 10,
+          "ty": 1,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 10,
+          "ty": 7,
+          "tileId": "sack"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 10,
+          "ty": 0,
+          "toInteriorId": "jeweller-back",
+          "entryTx": 5,
+          "entryTy": 0,
+          "direction": "back"
+        }
+      ]
     },
-    {
-      "tx": 16,
-      "ty": 30,
-      "tileId": "roadSignBottom",
-      "zlayer": "above"
+    "jeweller-back": {
+      "name": "Gem Workshop",
+      "width": 11,
+      "height": 8,
+      "floorTileId": "blueOrnateFloor",
+      "wallTileId": "interiorWallWhite",
+      "decor": [
+        {
+          "tx": 1,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 4,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 7,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 2,
+          "ty": 2,
+          "tileId": "counterTopHorizontalLeft",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 3,
+          "ty": 2,
+          "tileId": "counterTopHorizontalMiddle",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 4,
+          "ty": 2,
+          "tileId": "counterTopHorizontalRight",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "bookshelfTop"
+        },
+        {
+          "tx": 1,
+          "ty": 6,
+          "tileId": "crate"
+        },
+        {
+          "tx": 9,
+          "ty": 1,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 9,
+          "ty": 6,
+          "tileId": "sack"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 5,
+          "ty": 1,
+          "toInteriorId": "jeweller",
+          "entryTx": 10,
+          "entryTy": 0,
+          "direction": "front"
+        }
+      ]
+    },
+    "tailor": {
+      "name": "Pell's Tailoring",
+      "width": 12,
+      "height": 9,
+      "floorTileId": "woodFloor",
+      "wallTileId": "interiorWallWhite",
+      "decor": [
+        {
+          "tx": 1,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 4,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 7,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 10,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 2,
+          "ty": 2,
+          "tileId": "counterTopHorizontalLeft",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 3,
+          "ty": 2,
+          "tileId": "counterTopHorizontalMiddle",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 4,
+          "ty": 2,
+          "tileId": "counterTopHorizontalRight",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "bookshelfTop"
+        },
+        {
+          "tx": 1,
+          "ty": 7,
+          "tileId": "crate"
+        },
+        {
+          "tx": 10,
+          "ty": 1,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 10,
+          "ty": 7,
+          "tileId": "sack"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 10,
+          "ty": 0,
+          "toInteriorId": "tailor-back",
+          "entryTx": 5,
+          "entryTy": 0,
+          "direction": "back"
+        }
+      ]
+    },
+    "tailor-back": {
+      "name": "Cutting Room",
+      "width": 11,
+      "height": 8,
+      "floorTileId": "woodFloor",
+      "wallTileId": "interiorWallWhite",
+      "decor": [
+        {
+          "tx": 1,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 4,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 7,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 2,
+          "ty": 2,
+          "tileId": "counterTopHorizontalLeft",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 3,
+          "ty": 2,
+          "tileId": "counterTopHorizontalMiddle",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 4,
+          "ty": 2,
+          "tileId": "counterTopHorizontalRight",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "bookshelfTop"
+        },
+        {
+          "tx": 1,
+          "ty": 6,
+          "tileId": "crate"
+        },
+        {
+          "tx": 9,
+          "ty": 1,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 9,
+          "ty": 6,
+          "tileId": "sack"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 5,
+          "ty": 1,
+          "toInteriorId": "tailor",
+          "entryTx": 10,
+          "entryTy": 0,
+          "direction": "front"
+        }
+      ]
+    },
+    "apothecary": {
+      "name": "Mads' Apothecary",
+      "width": 12,
+      "height": 9,
+      "floorTileId": "stoneFloor",
+      "wallTileId": "interiorWallWhite",
+      "decor": [
+        {
+          "tx": 1,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 4,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 7,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 10,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 2,
+          "ty": 2,
+          "tileId": "counterTopHorizontalLeft",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 3,
+          "ty": 2,
+          "tileId": "counterTopHorizontalMiddle",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 4,
+          "ty": 2,
+          "tileId": "counterTopHorizontalRight",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "bookshelfTop"
+        },
+        {
+          "tx": 1,
+          "ty": 7,
+          "tileId": "crate"
+        },
+        {
+          "tx": 10,
+          "ty": 1,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 10,
+          "ty": 7,
+          "tileId": "sack"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 10,
+          "ty": 0,
+          "toInteriorId": "apothecary-back",
+          "entryTx": 5,
+          "entryTy": 0,
+          "direction": "back"
+        }
+      ]
+    },
+    "apothecary-back": {
+      "name": "Brewing Room",
+      "width": 11,
+      "height": 8,
+      "floorTileId": "stoneFloor",
+      "wallTileId": "interiorWallWhite",
+      "decor": [
+        {
+          "tx": 1,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 4,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 7,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 2,
+          "ty": 2,
+          "tileId": "counterTopHorizontalLeft",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 3,
+          "ty": 2,
+          "tileId": "counterTopHorizontalMiddle",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 4,
+          "ty": 2,
+          "tileId": "counterTopHorizontalRight",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "bookshelfTop"
+        },
+        {
+          "tx": 1,
+          "ty": 6,
+          "tileId": "crate"
+        },
+        {
+          "tx": 9,
+          "ty": 1,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 9,
+          "ty": 6,
+          "tileId": "sack"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 5,
+          "ty": 1,
+          "toInteriorId": "apothecary",
+          "entryTx": 10,
+          "entryTy": 0,
+          "direction": "front"
+        }
+      ]
+    },
+    "theatre": {
+      "name": "The Crown Theatre",
+      "width": 14,
+      "height": 10,
+      "floorTileId": "redCarpetFloor",
+      "wallTileId": "castleStone",
+      "decor": [
+        {
+          "tx": 1,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 4,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 7,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 10,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 7,
+          "ty": 1,
+          "tileId": "roundTableWithCloth"
+        },
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "pileOfPapers"
+        },
+        {
+          "tx": 12,
+          "ty": 1,
+          "tileId": "deskTop"
+        },
+        {
+          "tx": 2,
+          "ty": 8,
+          "tileId": "stool"
+        },
+        {
+          "tx": 11,
+          "ty": 8,
+          "tileId": "wallClock"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 12,
+          "ty": 0,
+          "toInteriorId": "theatre-back",
+          "entryTx": 6,
+          "entryTy": 0,
+          "direction": "back"
+        }
+      ]
+    },
+    "theatre-back": {
+      "name": "Backstage",
+      "width": 13,
+      "height": 9,
+      "floorTileId": "redCarpetFloor",
+      "wallTileId": "castleStone",
+      "decor": [
+        {
+          "tx": 1,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 4,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 7,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 10,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 6,
+          "ty": 1,
+          "tileId": "roundTableWithCloth"
+        },
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "pileOfPapers"
+        },
+        {
+          "tx": 11,
+          "ty": 1,
+          "tileId": "deskTop"
+        },
+        {
+          "tx": 2,
+          "ty": 7,
+          "tileId": "stool"
+        },
+        {
+          "tx": 10,
+          "ty": 7,
+          "tileId": "wallClock"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 6,
+          "ty": 1,
+          "toInteriorId": "theatre",
+          "entryTx": 12,
+          "entryTy": 0,
+          "direction": "front"
+        }
+      ]
+    },
+    "blacksmith": {
+      "name": "Dunn's Forge",
+      "width": 12,
+      "height": 9,
+      "floorTileId": "stoneFloor",
+      "wallTileId": "castleStone",
+      "decor": [
+        {
+          "tx": 1,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 4,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 7,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 10,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "suitOfArmourTop"
+        },
+        {
+          "tx": 1,
+          "ty": 2,
+          "tileId": "suitOfArmourBottom"
+        },
+        {
+          "tx": 10,
+          "ty": 1,
+          "tileId": "suitOfArmourTop"
+        },
+        {
+          "tx": 10,
+          "ty": 2,
+          "tileId": "suitOfArmourBottom"
+        },
+        {
+          "tx": 6,
+          "ty": 1,
+          "tileId": "swordMountedLeft"
+        },
+        {
+          "tx": 7,
+          "ty": 1,
+          "tileId": "shieldMounted"
+        },
+        {
+          "tx": 2,
+          "ty": 7,
+          "tileId": "roundTable"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 10,
+          "ty": 0,
+          "toInteriorId": "blacksmith-back",
+          "entryTx": 5,
+          "entryTy": 0,
+          "direction": "back"
+        }
+      ]
+    },
+    "blacksmith-back": {
+      "name": "The Foundry",
+      "width": 11,
+      "height": 8,
+      "floorTileId": "stoneFloor",
+      "wallTileId": "castleStone",
+      "decor": [
+        {
+          "tx": 1,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 4,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 7,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "suitOfArmourTop"
+        },
+        {
+          "tx": 1,
+          "ty": 2,
+          "tileId": "suitOfArmourBottom"
+        },
+        {
+          "tx": 9,
+          "ty": 1,
+          "tileId": "suitOfArmourTop"
+        },
+        {
+          "tx": 9,
+          "ty": 2,
+          "tileId": "suitOfArmourBottom"
+        },
+        {
+          "tx": 5,
+          "ty": 1,
+          "tileId": "swordMountedLeft"
+        },
+        {
+          "tx": 6,
+          "ty": 1,
+          "tileId": "shieldMounted"
+        },
+        {
+          "tx": 2,
+          "ty": 6,
+          "tileId": "roundTable"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 5,
+          "ty": 1,
+          "toInteriorId": "blacksmith",
+          "entryTx": 10,
+          "entryTy": 0,
+          "direction": "front"
+        }
+      ]
+    },
+    "royal-mint": {
+      "name": "The Royal Mint",
+      "width": 12,
+      "height": 9,
+      "floorTileId": "darkStoneFloor",
+      "wallTileId": "darkStone",
+      "decor": [
+        {
+          "tx": 1,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 4,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 7,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 10,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "goldChest"
+        },
+        {
+          "tx": 2,
+          "ty": 1,
+          "tileId": "chest"
+        },
+        {
+          "tx": 10,
+          "ty": 1,
+          "tileId": "strongChest"
+        },
+        {
+          "tx": 6,
+          "ty": 7,
+          "tileId": "pileOfGoldCoins"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 10,
+          "ty": 0,
+          "toInteriorId": "royal-mint-back",
+          "entryTx": 5,
+          "entryTy": 0,
+          "direction": "back"
+        }
+      ]
+    },
+    "royal-mint-back": {
+      "name": "The Stamping Room",
+      "width": 11,
+      "height": 8,
+      "floorTileId": "darkStoneFloor",
+      "wallTileId": "darkStone",
+      "decor": [
+        {
+          "tx": 1,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 4,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 7,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "goldChest"
+        },
+        {
+          "tx": 2,
+          "ty": 1,
+          "tileId": "chest"
+        },
+        {
+          "tx": 9,
+          "ty": 1,
+          "tileId": "strongChest"
+        },
+        {
+          "tx": 5,
+          "ty": 6,
+          "tileId": "pileOfGoldCoins"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 5,
+          "ty": 1,
+          "toInteriorId": "royal-mint",
+          "entryTx": 10,
+          "entryTy": 0,
+          "direction": "front"
+        }
+      ]
+    },
+    "noble-manor-1": {
+      "name": "Manor of Lady Cora",
+      "width": 13,
+      "height": 9,
+      "floorTileId": "parquetFloor",
+      "wallTileId": "interiorWallWhite",
+      "decor": [
+        {
+          "tx": 1,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 4,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 7,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 10,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 6,
+          "ty": 1,
+          "tileId": "roundTableWithCloth"
+        },
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "pileOfPapers"
+        },
+        {
+          "tx": 11,
+          "ty": 1,
+          "tileId": "deskTop"
+        },
+        {
+          "tx": 2,
+          "ty": 7,
+          "tileId": "stool"
+        },
+        {
+          "tx": 10,
+          "ty": 7,
+          "tileId": "wallClock"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 11,
+          "ty": 0,
+          "toInteriorId": "noble-manor-1-back",
+          "entryTx": 6,
+          "entryTy": 0,
+          "direction": "back"
+        }
+      ]
+    },
+    "noble-manor-1-back": {
+      "name": "Manor Bedchamber",
+      "width": 12,
+      "height": 8,
+      "floorTileId": "parquetFloor",
+      "wallTileId": "interiorWallWhite",
+      "decor": [
+        {
+          "tx": 1,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 4,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 7,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 10,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "normalBedHead"
+        },
+        {
+          "tx": 1,
+          "ty": 2,
+          "tileId": "normalBedFoot"
+        },
+        {
+          "tx": 3,
+          "ty": 1,
+          "tileId": "normalBedHead"
+        },
+        {
+          "tx": 3,
+          "ty": 2,
+          "tileId": "normalBedFoot"
+        },
+        {
+          "tx": 10,
+          "ty": 1,
+          "tileId": "smallTableTopLeft"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 6,
+          "ty": 1,
+          "toInteriorId": "noble-manor-1",
+          "entryTx": 11,
+          "entryTy": 0,
+          "direction": "front"
+        }
+      ]
+    },
+    "noble-manor-2": {
+      "name": "Aldermere Manor",
+      "width": 13,
+      "height": 9,
+      "floorTileId": "parquetFloor",
+      "wallTileId": "interiorWallWhite",
+      "decor": [
+        {
+          "tx": 1,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 4,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 7,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 10,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "bookshelfTop"
+        },
+        {
+          "tx": 1,
+          "ty": 2,
+          "tileId": "bookshelfBottom"
+        },
+        {
+          "tx": 11,
+          "ty": 1,
+          "tileId": "bookshelfTop"
+        },
+        {
+          "tx": 11,
+          "ty": 2,
+          "tileId": "bookshelfBottom"
+        },
+        {
+          "tx": 6,
+          "ty": 2,
+          "tileId": "deskTop"
+        },
+        {
+          "tx": 3,
+          "ty": 7,
+          "tileId": "roundTableWithCloth"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 11,
+          "ty": 0,
+          "toInteriorId": "noble-manor-2-back",
+          "entryTx": 6,
+          "entryTy": 0,
+          "direction": "back"
+        }
+      ]
+    },
+    "noble-manor-2-back": {
+      "name": "Manor Study",
+      "width": 12,
+      "height": 8,
+      "floorTileId": "parquetFloor",
+      "wallTileId": "interiorWallWhite",
+      "decor": [
+        {
+          "tx": 1,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 4,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 7,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 10,
+          "ty": -1,
+          "tileId": "windowTop"
+        },
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "normalBedHead"
+        },
+        {
+          "tx": 1,
+          "ty": 2,
+          "tileId": "normalBedFoot"
+        },
+        {
+          "tx": 3,
+          "ty": 1,
+          "tileId": "normalBedHead"
+        },
+        {
+          "tx": 3,
+          "ty": 2,
+          "tileId": "normalBedFoot"
+        },
+        {
+          "tx": 10,
+          "ty": 1,
+          "tileId": "smallTableTopLeft"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 6,
+          "ty": 1,
+          "toInteriorId": "noble-manor-2",
+          "entryTx": 11,
+          "entryTy": 0,
+          "direction": "front"
+        }
+      ]
     }
-  ],
-  "npcSpawnTiles": [],
+  },
   "ambientNpcSprites": [
     "hub-npc-merchant",
-    "hub-npc-scholar"
+    "hub-npc-scholar",
+    "hub-npc-soldier",
+    "hub-npc-elder"
+  ],
+  "npcSpawnTiles": [
+    [
+      56,
+      91
+    ]
   ],
   "npcs": [
     {
       "id": "innkeeper-crownhaven",
       "name": "Innkeep Rosalind",
       "sprite": "hub-npc-merchant",
-      "tx": 8,
-      "ty": 11,
+      "building": "grand-inn",
+      "tx": 4,
+      "ty": 3,
       "dialogue": [
         "Welcome to The Gilded Goose, finest beds in the capital.",
-        "Half my guests are here for the tournament. The other half are avoiding it.",
+        "Half my guests are here for the coronation. The other half are avoiding it.",
         "If Captain Hale sends you with anything, I'll see it gets where it's going."
       ],
-      "building": "grand-inn",
-      "questReceive": "crownhaven-gate-key"
+      "questReceive": [
+        "crownhaven-gate-key",
+        "crownhaven-feast"
+      ],
+      "questGive": "crownhaven-welcome",
+      "schedule": [
+        {
+          "startHour": 0,
+          "endHour": 7,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "grand-inn",
+            "tx": 1,
+            "ty": 1
+          }
+        },
+        {
+          "startHour": 7,
+          "endHour": 20,
+          "activity": "work",
+          "location": {
+            "type": "interior",
+            "buildingId": "grand-inn",
+            "tx": 4,
+            "ty": 3
+          }
+        },
+        {
+          "startHour": 20,
+          "endHour": 24,
+          "activity": "eat",
+          "location": {
+            "type": "interior",
+            "buildingId": "grand-inn",
+            "tx": 6,
+            "ty": 4
+          }
+        }
+      ],
+      "homeBed": {
+        "buildingId": "grand-inn-upstairs",
+        "tx": 1,
+        "ty": 1
+      }
     },
     {
       "id": "watch-captain-hale",
       "name": "Captain Hale",
       "sprite": "hub-npc-soldier",
-      "tx": 12,
-      "ty": 19,
+      "building": "guardhouse",
+      "tx": 5,
+      "ty": 3,
       "dialogue": [
-        "Crownhaven watch. State your business — or don't, you look harmless enough.",
+        "Crownhaven watch. State your business \u2014 or don't, you look harmless enough.",
         "The old postern gate key went missing on patrol. If it falls into the wrong hands, the palace will have my head.",
         "Keep your nose clean in my city, traveller."
       ],
-      "building": "guardhouse",
-      "questGive": "crownhaven-gate-key"
+      "questGive": "crownhaven-gate-key",
+      "questReceive": [
+        "crownhaven-cutpurse",
+        "crownhaven-armoury",
+        "crownhaven-stolen-coin"
+      ],
+      "schedule": [
+        {
+          "startHour": 0,
+          "endHour": 7,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "guardhouse",
+            "tx": 1,
+            "ty": 1
+          }
+        },
+        {
+          "startHour": 7,
+          "endHour": 20,
+          "activity": "work",
+          "location": {
+            "type": "interior",
+            "buildingId": "guardhouse",
+            "tx": 5,
+            "ty": 3
+          }
+        },
+        {
+          "startHour": 20,
+          "endHour": 24,
+          "activity": "eat",
+          "location": {
+            "type": "interior",
+            "buildingId": "grand-inn",
+            "tx": 6,
+            "ty": 4
+          }
+        }
+      ],
+      "homeBed": {
+        "buildingId": "guardhouse",
+        "tx": 1,
+        "ty": 1
+      }
     },
     {
       "id": "royal-archivist",
       "name": "Archivist Quill",
       "sprite": "hub-npc-scholar",
-      "tx": 24,
-      "ty": 12,
+      "building": "library",
+      "tx": 5,
+      "ty": 4,
       "dialogue": [
         "The royal survey of the outer provinces is three scrolls short. Three!",
         "The couriers dropped them somewhere between here and the gates, I'm certain of it.",
         "History is just paperwork that survived, you know."
       ],
       "questGive": "crownhaven-census",
-      "questReceive": "crownhaven-census"
+      "questReceive": [
+        "crownhaven-census",
+        "crownhaven-anthology"
+      ],
+      "schedule": [
+        {
+          "startHour": 0,
+          "endHour": 7,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "library",
+            "tx": 1,
+            "ty": 1
+          }
+        },
+        {
+          "startHour": 7,
+          "endHour": 20,
+          "activity": "work",
+          "location": {
+            "type": "interior",
+            "buildingId": "library",
+            "tx": 5,
+            "ty": 4
+          }
+        },
+        {
+          "startHour": 20,
+          "endHour": 24,
+          "activity": "eat",
+          "location": {
+            "type": "interior",
+            "buildingId": "grand-inn",
+            "tx": 6,
+            "ty": 4
+          }
+        }
+      ],
+      "homeBed": {
+        "buildingId": "library",
+        "tx": 1,
+        "ty": 1
+      }
     },
     {
       "id": "market-matron",
       "name": "Matron Goldie",
       "sprite": "hub-npc-elder",
-      "tx": 31,
-      "ty": 12,
+      "building": "market-hall-crownhaven",
+      "tx": 5,
+      "ty": 3,
       "dialogue": [
         "Forty years I've run this market. Kings come and go; turnips are forever.",
         "You want gossip, try the inn. You want a fair price, you talk to me.",
-        "Mind the fountain — the pigeons have opinions."
+        "Mind the fountain \u2014 the pigeons have opinions."
       ],
-      "building": "market-hall-crownhaven"
+      "questGive": "crownhaven-market-day",
+      "questReceive": [
+        "crownhaven-market-day",
+        "crownhaven-bread"
+      ],
+      "schedule": [
+        {
+          "startHour": 0,
+          "endHour": 7,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "market-hall-crownhaven",
+            "tx": 1,
+            "ty": 1
+          }
+        },
+        {
+          "startHour": 7,
+          "endHour": 20,
+          "activity": "work",
+          "location": {
+            "type": "interior",
+            "buildingId": "market-hall-crownhaven",
+            "tx": 5,
+            "ty": 3
+          }
+        },
+        {
+          "startHour": 20,
+          "endHour": 24,
+          "activity": "eat",
+          "location": {
+            "type": "interior",
+            "buildingId": "grand-inn",
+            "tx": 6,
+            "ty": 4
+          }
+        }
+      ],
+      "homeBed": {
+        "buildingId": "market-hall-crownhaven",
+        "tx": 1,
+        "ty": 1
+      }
+    },
+    {
+      "id": "chancellor",
+      "name": "Chancellor Vell",
+      "sprite": "hub-npc-scholar",
+      "building": "senate",
+      "tx": 6,
+      "ty": 4,
+      "dialogue": [
+        "The capital does not run on goodwill, traveller. It runs on charters, seals, and very tired clerks.",
+        "Crownhaven looks to Ravenwatch for the old records. We must keep the two cities in step.",
+        "Serve the crown well and the crown remembers."
+      ],
+      "questGive": "crownhaven-charter",
+      "questReceive": [
+        "crownhaven-charter",
+        "crownhaven-statue"
+      ],
+      "schedule": [
+        {
+          "startHour": 0,
+          "endHour": 7,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "senate",
+            "tx": 1,
+            "ty": 1
+          }
+        },
+        {
+          "startHour": 7,
+          "endHour": 20,
+          "activity": "work",
+          "location": {
+            "type": "interior",
+            "buildingId": "senate",
+            "tx": 6,
+            "ty": 4
+          }
+        },
+        {
+          "startHour": 20,
+          "endHour": 24,
+          "activity": "eat",
+          "location": {
+            "type": "interior",
+            "buildingId": "grand-inn",
+            "tx": 6,
+            "ty": 4
+          }
+        }
+      ],
+      "homeBed": {
+        "buildingId": "senate",
+        "tx": 1,
+        "ty": 1
+      }
+    },
+    {
+      "id": "high-priest",
+      "name": "High Priest Aldwin",
+      "sprite": "hub-npc-elder",
+      "building": "cathedral",
+      "tx": 6,
+      "ty": 5,
+      "dialogue": [
+        "Dawn breaks over Crownhaven, and with it, hope. Welcome, child.",
+        "The cathedral's relics were scattered in the troubles. We would see them home.",
+        "The bell has been silent too long. A city should hear its own heart."
+      ],
+      "questGive": "crownhaven-relics",
+      "questReceive": [
+        "crownhaven-relics",
+        "crownhaven-dawn-blessing",
+        "crownhaven-crypt-vigil"
+      ],
+      "schedule": [
+        {
+          "startHour": 0,
+          "endHour": 7,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "cathedral",
+            "tx": 1,
+            "ty": 1
+          }
+        },
+        {
+          "startHour": 7,
+          "endHour": 20,
+          "activity": "work",
+          "location": {
+            "type": "interior",
+            "buildingId": "cathedral",
+            "tx": 6,
+            "ty": 5
+          }
+        },
+        {
+          "startHour": 20,
+          "endHour": 24,
+          "activity": "eat",
+          "location": {
+            "type": "interior",
+            "buildingId": "grand-inn",
+            "tx": 6,
+            "ty": 4
+          }
+        }
+      ],
+      "homeBed": {
+        "buildingId": "cathedral",
+        "tx": 1,
+        "ty": 1
+      }
+    },
+    {
+      "id": "mint-master",
+      "name": "Mintmaster Coyle",
+      "sprite": "hub-npc-merchant",
+      "building": "royal-mint",
+      "tx": 4,
+      "ty": 3,
+      "dialogue": [
+        "Every coin in the realm starts its life right here, under my hammer.",
+        "Lose a mint die and you may as well hand a forger the keys to the treasury.",
+        "Gold is heavy for a reason \u2014 it keeps honest folk grounded."
+      ],
+      "questGive": "crownhaven-mint-dies",
+      "questReceive": "crownhaven-mint-dies",
+      "schedule": [
+        {
+          "startHour": 0,
+          "endHour": 7,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "royal-mint",
+            "tx": 1,
+            "ty": 1
+          }
+        },
+        {
+          "startHour": 7,
+          "endHour": 20,
+          "activity": "work",
+          "location": {
+            "type": "interior",
+            "buildingId": "royal-mint",
+            "tx": 4,
+            "ty": 3
+          }
+        },
+        {
+          "startHour": 20,
+          "endHour": 24,
+          "activity": "eat",
+          "location": {
+            "type": "interior",
+            "buildingId": "grand-inn",
+            "tx": 6,
+            "ty": 4
+          }
+        }
+      ],
+      "homeBed": {
+        "buildingId": "royal-mint",
+        "tx": 1,
+        "ty": 1
+      }
+    },
+    {
+      "id": "banker",
+      "name": "Banker Sterling",
+      "sprite": "hub-npc-merchant",
+      "building": "grand-bank",
+      "tx": 5,
+      "ty": 3,
+      "dialogue": [
+        "The Grand Bank of Crownhaven. Your crystals are safer here than in the palace itself.",
+        "A noble's debt is a delicate thing. Discretion is half my trade.",
+        "Vault's sealed tight \u2014 only the watch and I hold a key."
+      ],
+      "questGive": "crownhaven-stolen-coin",
+      "questReceive": [
+        "crownhaven-tax-records",
+        "crownhaven-noble-debt",
+        "crownhaven-stolen-coin"
+      ],
+      "schedule": [
+        {
+          "startHour": 0,
+          "endHour": 7,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "grand-bank",
+            "tx": 1,
+            "ty": 1
+          }
+        },
+        {
+          "startHour": 7,
+          "endHour": 20,
+          "activity": "work",
+          "location": {
+            "type": "interior",
+            "buildingId": "grand-bank",
+            "tx": 5,
+            "ty": 3
+          }
+        },
+        {
+          "startHour": 20,
+          "endHour": 24,
+          "activity": "eat",
+          "location": {
+            "type": "interior",
+            "buildingId": "grand-inn",
+            "tx": 6,
+            "ty": 4
+          }
+        }
+      ],
+      "homeBed": {
+        "buildingId": "grand-bank",
+        "tx": 1,
+        "ty": 1
+      }
+    },
+    {
+      "id": "tailor-pell",
+      "name": "Tailor Pell",
+      "sprite": "hub-npc-merchant",
+      "building": "tailor",
+      "tx": 4,
+      "ty": 3,
+      "dialogue": [
+        "Coronation season! Every noble in the realm wants new silks, and they want them yesterday.",
+        "A good seam is invisible. Like a good tailor.",
+        "Bring me bolts of silk and I'll dress you fit for the throne room."
+      ],
+      "questGive": "crownhaven-silk",
+      "questReceive": "crownhaven-silk",
+      "schedule": [
+        {
+          "startHour": 0,
+          "endHour": 7,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "tailor",
+            "tx": 1,
+            "ty": 1
+          }
+        },
+        {
+          "startHour": 7,
+          "endHour": 20,
+          "activity": "work",
+          "location": {
+            "type": "interior",
+            "buildingId": "tailor",
+            "tx": 4,
+            "ty": 3
+          }
+        },
+        {
+          "startHour": 20,
+          "endHour": 24,
+          "activity": "eat",
+          "location": {
+            "type": "interior",
+            "buildingId": "grand-inn",
+            "tx": 6,
+            "ty": 4
+          }
+        }
+      ],
+      "homeBed": {
+        "buildingId": "tailor",
+        "tx": 1,
+        "ty": 1
+      }
+    },
+    {
+      "id": "jeweller-isolde",
+      "name": "Jeweller Isolde",
+      "sprite": "hub-npc-merchant",
+      "building": "jeweller",
+      "tx": 4,
+      "ty": 3,
+      "dialogue": [
+        "Diamonds, sapphires, the crown's own regalia \u2014 all pass across my bench.",
+        "Raw gems are dull little pebbles until I coax the fire out of them.",
+        "Careful where you tread; I've dropped stones worth more than your boots."
+      ],
+      "questGive": "crownhaven-gems",
+      "questReceive": "crownhaven-gems",
+      "schedule": [
+        {
+          "startHour": 0,
+          "endHour": 7,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "jeweller",
+            "tx": 1,
+            "ty": 1
+          }
+        },
+        {
+          "startHour": 7,
+          "endHour": 20,
+          "activity": "work",
+          "location": {
+            "type": "interior",
+            "buildingId": "jeweller",
+            "tx": 4,
+            "ty": 3
+          }
+        },
+        {
+          "startHour": 20,
+          "endHour": 24,
+          "activity": "eat",
+          "location": {
+            "type": "interior",
+            "buildingId": "grand-inn",
+            "tx": 6,
+            "ty": 4
+          }
+        }
+      ],
+      "homeBed": {
+        "buildingId": "jeweller",
+        "tx": 1,
+        "ty": 1
+      }
+    },
+    {
+      "id": "apothecary-mads",
+      "name": "Apothecary Mads",
+      "sprite": "hub-npc-scholar",
+      "building": "apothecary",
+      "tx": 4,
+      "ty": 3,
+      "dialogue": [
+        "Tinctures, tonics, and the occasional cure. Mind the green bottles.",
+        "Half of healing is herbs; the other half is convincing the patient they're healed.",
+        "The academy sends me their wildest experiments. I send back the survivors."
+      ],
+      "questGive": "crownhaven-remedy",
+      "questReceive": [
+        "crownhaven-remedy",
+        "crownhaven-experiment"
+      ],
+      "schedule": [
+        {
+          "startHour": 0,
+          "endHour": 7,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "apothecary",
+            "tx": 1,
+            "ty": 1
+          }
+        },
+        {
+          "startHour": 7,
+          "endHour": 20,
+          "activity": "work",
+          "location": {
+            "type": "interior",
+            "buildingId": "apothecary",
+            "tx": 4,
+            "ty": 3
+          }
+        },
+        {
+          "startHour": 20,
+          "endHour": 24,
+          "activity": "eat",
+          "location": {
+            "type": "interior",
+            "buildingId": "grand-inn",
+            "tx": 6,
+            "ty": 4
+          }
+        }
+      ],
+      "homeBed": {
+        "buildingId": "apothecary",
+        "tx": 1,
+        "ty": 1
+      }
+    },
+    {
+      "id": "baker-otto",
+      "name": "Baker Otto",
+      "sprite": "hub-npc-merchant",
+      "building": "bakery",
+      "tx": 4,
+      "ty": 3,
+      "dialogue": [
+        "Fresh bread before the bells, every morning. Smell that?",
+        "Coronation feast's coming. I'll be up to my elbows in flour for a week.",
+        "Grain's dear this season. Bring me sacks and I'll bake you a king's loaf."
+      ],
+      "questGive": "crownhaven-bread",
+      "questReceive": [
+        "crownhaven-bread",
+        "crownhaven-feast"
+      ],
+      "schedule": [
+        {
+          "startHour": 0,
+          "endHour": 7,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "bakery",
+            "tx": 1,
+            "ty": 1
+          }
+        },
+        {
+          "startHour": 7,
+          "endHour": 20,
+          "activity": "work",
+          "location": {
+            "type": "interior",
+            "buildingId": "bakery",
+            "tx": 4,
+            "ty": 3
+          }
+        },
+        {
+          "startHour": 20,
+          "endHour": 24,
+          "activity": "eat",
+          "location": {
+            "type": "interior",
+            "buildingId": "grand-inn",
+            "tx": 6,
+            "ty": 4
+          }
+        }
+      ],
+      "homeBed": {
+        "buildingId": "bakery",
+        "tx": 1,
+        "ty": 1
+      }
+    },
+    {
+      "id": "blacksmith-dunn",
+      "name": "Smith Dunn",
+      "sprite": "hub-npc-soldier",
+      "building": "blacksmith",
+      "tx": 4,
+      "ty": 3,
+      "dialogue": [
+        "Steel for the watch, nails for the masons, and a bell-clapper if the priest ever asks.",
+        "A blade's only as honest as the hand that swings it.",
+        "Bring me steel and I'll give the watch the edge it needs."
+      ],
+      "questGive": "crownhaven-armoury",
+      "questReceive": [
+        "crownhaven-armoury",
+        "crownhaven-tower-bell"
+      ],
+      "schedule": [
+        {
+          "startHour": 0,
+          "endHour": 7,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "blacksmith",
+            "tx": 1,
+            "ty": 1
+          }
+        },
+        {
+          "startHour": 7,
+          "endHour": 20,
+          "activity": "work",
+          "location": {
+            "type": "interior",
+            "buildingId": "blacksmith",
+            "tx": 4,
+            "ty": 3
+          }
+        },
+        {
+          "startHour": 20,
+          "endHour": 24,
+          "activity": "eat",
+          "location": {
+            "type": "interior",
+            "buildingId": "grand-inn",
+            "tx": 6,
+            "ty": 4
+          }
+        }
+      ],
+      "homeBed": {
+        "buildingId": "blacksmith",
+        "tx": 1,
+        "ty": 1
+      }
+    },
+    {
+      "id": "noble-lady-cora",
+      "name": "Lady Cora",
+      "sprite": "hub-npc-elder",
+      "building": "noble-manor-1",
+      "tx": 5,
+      "ty": 4,
+      "dialogue": [
+        "Old Town remembers when Crownhaven was but a fort on a hill. I remember it too.",
+        "My family's locket was lost in the gardens. It is all I have of my mother.",
+        "Debts and lockets \u2014 a noblewoman's life is keeping track of what she's misplaced."
+      ],
+      "questGive": "crownhaven-lost-locket",
+      "questReceive": "crownhaven-lost-locket",
+      "schedule": [
+        {
+          "startHour": 0,
+          "endHour": 7,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "noble-manor-1",
+            "tx": 1,
+            "ty": 1
+          }
+        },
+        {
+          "startHour": 7,
+          "endHour": 20,
+          "activity": "work",
+          "location": {
+            "type": "interior",
+            "buildingId": "noble-manor-1",
+            "tx": 5,
+            "ty": 4
+          }
+        },
+        {
+          "startHour": 20,
+          "endHour": 24,
+          "activity": "eat",
+          "location": {
+            "type": "interior",
+            "buildingId": "grand-inn",
+            "tx": 6,
+            "ty": 4
+          }
+        }
+      ],
+      "homeBed": {
+        "buildingId": "noble-manor-1-back",
+        "tx": 1,
+        "ty": 1
+      }
+    },
+    {
+      "id": "academy-master",
+      "name": "Master Fenwick",
+      "sprite": "hub-npc-scholar",
+      "building": "academy",
+      "tx": 6,
+      "ty": 4,
+      "dialogue": [
+        "The Crown Academy: where the realm's brightest learn just enough to be dangerous.",
+        "My lecture notes have scattered to the four winds. Or four districts, more likely.",
+        "Knowledge, like coin, is only useful in circulation."
+      ],
+      "questGive": "crownhaven-lecture",
+      "questReceive": "crownhaven-lecture",
+      "schedule": [
+        {
+          "startHour": 0,
+          "endHour": 7,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "academy",
+            "tx": 1,
+            "ty": 1
+          }
+        },
+        {
+          "startHour": 7,
+          "endHour": 20,
+          "activity": "work",
+          "location": {
+            "type": "interior",
+            "buildingId": "academy",
+            "tx": 6,
+            "ty": 4
+          }
+        },
+        {
+          "startHour": 20,
+          "endHour": 24,
+          "activity": "eat",
+          "location": {
+            "type": "interior",
+            "buildingId": "grand-inn",
+            "tx": 6,
+            "ty": 4
+          }
+        }
+      ],
+      "homeBed": {
+        "buildingId": "academy",
+        "tx": 1,
+        "ty": 1
+      }
+    },
+    {
+      "id": "busker-lyle",
+      "name": "Busker Lyle",
+      "sprite": "hub-npc-merchant",
+      "tx": 50,
+      "ty": 47,
+      "dialogue": [
+        "A copper for a tune? A crystal for a good one?",
+        "Snapped three lute strings practising for the coronation. Three!",
+        "Every great city deserves a great song. I'm still writing Crownhaven's."
+      ],
+      "questGive": "crownhaven-buskers-strings",
+      "questReceive": "crownhaven-buskers-strings",
+      "schedule": [
+        {
+          "startHour": 0,
+          "endHour": 7,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "grand-inn-upstairs",
+            "tx": 6,
+            "ty": 4
+          }
+        },
+        {
+          "startHour": 7,
+          "endHour": 20,
+          "activity": "idle-chat",
+          "location": {
+            "type": "exterior",
+            "tx": 50,
+            "ty": 47
+          }
+        },
+        {
+          "startHour": 20,
+          "endHour": 24,
+          "activity": "eat",
+          "location": {
+            "type": "interior",
+            "buildingId": "grand-inn",
+            "tx": 8,
+            "ty": 4
+          }
+        }
+      ]
+    },
+    {
+      "id": "herald-jana",
+      "name": "Herald Jana",
+      "sprite": "hub-npc-soldier",
+      "tx": 60,
+      "ty": 47,
+      "dialogue": [
+        "Hear ye! By order of the Chancellor \u2014 mind the proclamations.",
+        "Lost half my scrolls to the wind. A herald with no words is just a loud nuisance.",
+        "Stand for the crown, traveller. The capital is watching."
+      ],
+      "questGive": "crownhaven-proclamation",
+      "questReceive": [
+        "crownhaven-proclamation",
+        "crownhaven-statue"
+      ],
+      "schedule": [
+        {
+          "startHour": 0,
+          "endHour": 7,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "grand-inn-upstairs",
+            "tx": 6,
+            "ty": 4
+          }
+        },
+        {
+          "startHour": 7,
+          "endHour": 20,
+          "activity": "work",
+          "location": {
+            "type": "exterior",
+            "tx": 60,
+            "ty": 47
+          }
+        },
+        {
+          "startHour": 20,
+          "endHour": 24,
+          "activity": "eat",
+          "location": {
+            "type": "interior",
+            "buildingId": "grand-inn",
+            "tx": 8,
+            "ty": 4
+          }
+        }
+      ]
+    },
+    {
+      "id": "guard-bryn",
+      "name": "Guardsman Bryn",
+      "sprite": "hub-npc-soldier",
+      "tx": 95,
+      "ty": 82,
+      "dialogue": [
+        "Captain's got me walking the south wall till my boots wear through.",
+        "See anything suspicious, you tell me first, the captain second.",
+        "Quiet night. Round here, that's the best kind."
+      ],
+      "questGive": "crownhaven-cutpurse",
+      "questReceive": "crownhaven-patrol",
+      "schedule": [
+        {
+          "startHour": 0,
+          "endHour": 7,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "grand-inn-upstairs",
+            "tx": 6,
+            "ty": 4
+          }
+        },
+        {
+          "startHour": 7,
+          "endHour": 20,
+          "activity": "work",
+          "location": {
+            "type": "exterior",
+            "tx": 95,
+            "ty": 82
+          }
+        },
+        {
+          "startHour": 20,
+          "endHour": 24,
+          "activity": "eat",
+          "location": {
+            "type": "interior",
+            "buildingId": "grand-inn",
+            "tx": 8,
+            "ty": 4
+          }
+        }
+      ]
     }
   ],
-  "interiors": {
-    "grand-inn": {
-      "name": "The Gilded Goose",
-      "width": 10,
-      "height": 6,
-      "floorTileId": "woodFloor",
-      "wallTileId": "whiteStone",
-      "decor": [
-        {
-          "tx": 1,
-          "ty": 1,
-          "tileId": "barrel"
-        },
-        {
-          "tx": 2,
-          "ty": 1,
-          "tileId": "barrel"
-        },
-        {
-          "tx": 7,
-          "ty": 1,
-          "tileId": "roundTableWithCloth"
-        },
-        {
-          "tx": 8,
-          "ty": 2,
-          "tileId": "stool"
-        },
-        {
-          "tx": 6,
-          "ty": 2,
-          "tileId": "stool"
-        }
-      ],
-      "exits": []
+  "exteriorDecor": [
+    {
+      "comment": "Coronation Plaza \u2014 grand fountain & monuments"
     },
-    "market-hall-crownhaven": {
-      "name": "The Grand Market Hall",
-      "width": 10,
-      "height": 5,
-      "floorTileId": "woodFloor",
-      "wallTileId": "brick",
-      "decor": [
-        {
-          "tx": 1,
-          "ty": 1,
-          "tileId": "crate"
-        },
-        {
-          "tx": 2,
-          "ty": 1,
-          "tileId": "openCrate"
-        },
-        {
-          "tx": 7,
-          "ty": 1,
-          "tileId": "sack"
-        },
-        {
-          "tx": 8,
-          "ty": 1,
-          "tileId": "crate"
-        }
-      ],
-      "exits": []
+    {
+      "tx": 56,
+      "ty": 50,
+      "bundleID": "fountain",
+      "zlayer": "solid"
     },
-    "guardhouse": {
-      "name": "The Watch House",
-      "width": 8,
-      "height": 5,
-      "floorTileId": "stoneFloor",
-      "wallTileId": "castleStone",
-      "decor": [
-        {
-          "tx": 1,
-          "ty": 1,
-          "tileId": "suitOfArmourTop"
-        },
-        {
-          "tx": 1,
-          "ty": 2,
-          "tileId": "suitOfArmourBottom"
-        },
-        {
-          "tx": 6,
-          "ty": 1,
-          "tileId": "suitOfArmourTop"
-        },
-        {
-          "tx": 6,
-          "ty": 2,
-          "tileId": "suitOfArmourBottom"
-        },
-        {
-          "tx": 3,
-          "ty": 1,
-          "tileId": "swordMountedLeft"
-        },
-        {
-          "tx": 4,
-          "ty": 1,
-          "tileId": "shieldMounted"
-        }
-      ],
-      "exits": []
+    {
+      "tx": 40,
+      "ty": 46,
+      "tileId": "angelStatueTop",
+      "zlayer": "above"
     },
-    "chapel": {
-      "name": "Chapel of the Dawn",
-      "width": 8,
-      "height": 6,
-      "floorTileId": "cobblestoneFloor",
-      "wallTileId": "ornateStone",
-      "decor": [
-        {
-          "tx": 1,
-          "ty": 1,
-          "tileId": "bookshelfTop"
-        },
-        {
-          "tx": 1,
-          "ty": 2,
-          "tileId": "bookshelfBottom"
-        },
-        {
-          "tx": 6,
-          "ty": 1,
-          "tileId": "bookshelfTop"
-        },
-        {
-          "tx": 6,
-          "ty": 2,
-          "tileId": "bookshelfBottom"
-        },
-        {
-          "tx": 3,
-          "ty": 1,
-          "tileId": "roundTableWithCloth"
-        }
-      ],
-      "exits": []
+    {
+      "tx": 40,
+      "ty": 47,
+      "tileId": "angelStatueBottom"
+    },
+    {
+      "tx": 72,
+      "ty": 46,
+      "tileId": "angelStatueTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 72,
+      "ty": 47,
+      "tileId": "angelStatueBottom"
+    },
+    {
+      "tx": 34,
+      "ty": 56,
+      "tileId": "benchLeft"
+    },
+    {
+      "tx": 35,
+      "ty": 56,
+      "tileId": "benchMiddle"
+    },
+    {
+      "tx": 36,
+      "ty": 56,
+      "tileId": "benchRight"
+    },
+    {
+      "tx": 40,
+      "ty": 56,
+      "tileId": "benchLeft"
+    },
+    {
+      "tx": 41,
+      "ty": 56,
+      "tileId": "benchMiddle"
+    },
+    {
+      "tx": 42,
+      "ty": 56,
+      "tileId": "benchRight"
+    },
+    {
+      "tx": 46,
+      "ty": 56,
+      "tileId": "benchLeft"
+    },
+    {
+      "tx": 47,
+      "ty": 56,
+      "tileId": "benchMiddle"
+    },
+    {
+      "tx": 48,
+      "ty": 56,
+      "tileId": "benchRight"
+    },
+    {
+      "tx": 52,
+      "ty": 56,
+      "tileId": "benchLeft"
+    },
+    {
+      "tx": 53,
+      "ty": 56,
+      "tileId": "benchMiddle"
+    },
+    {
+      "tx": 54,
+      "ty": 56,
+      "tileId": "benchRight"
+    },
+    {
+      "tx": 58,
+      "ty": 56,
+      "tileId": "benchLeft"
+    },
+    {
+      "tx": 59,
+      "ty": 56,
+      "tileId": "benchMiddle"
+    },
+    {
+      "tx": 60,
+      "ty": 56,
+      "tileId": "benchRight"
+    },
+    {
+      "tx": 64,
+      "ty": 56,
+      "tileId": "benchLeft"
+    },
+    {
+      "tx": 65,
+      "ty": 56,
+      "tileId": "benchMiddle"
+    },
+    {
+      "tx": 66,
+      "ty": 56,
+      "tileId": "benchRight"
+    },
+    {
+      "tx": 70,
+      "ty": 56,
+      "tileId": "benchLeft"
+    },
+    {
+      "tx": 71,
+      "ty": 56,
+      "tileId": "benchMiddle"
+    },
+    {
+      "tx": 72,
+      "ty": 56,
+      "tileId": "benchRight"
+    },
+    {
+      "tx": 76,
+      "ty": 56,
+      "tileId": "benchLeft"
+    },
+    {
+      "tx": 77,
+      "ty": 56,
+      "tileId": "benchMiddle"
+    },
+    {
+      "tx": 78,
+      "ty": 56,
+      "tileId": "benchRight"
+    },
+    {
+      "tx": 82,
+      "ty": 56,
+      "tileId": "benchLeft"
+    },
+    {
+      "tx": 83,
+      "ty": 56,
+      "tileId": "benchMiddle"
+    },
+    {
+      "tx": 84,
+      "ty": 56,
+      "tileId": "benchRight"
+    },
+    {
+      "tx": 32,
+      "ty": 44,
+      "tileId": "whiteFlower"
+    },
+    {
+      "tx": 32,
+      "ty": 62,
+      "tileId": "yellowFlower"
+    },
+    {
+      "tx": 36,
+      "ty": 44,
+      "tileId": "whiteFlower"
+    },
+    {
+      "tx": 36,
+      "ty": 62,
+      "tileId": "yellowFlower"
+    },
+    {
+      "tx": 40,
+      "ty": 44,
+      "tileId": "whiteFlower"
+    },
+    {
+      "tx": 40,
+      "ty": 62,
+      "tileId": "yellowFlower"
+    },
+    {
+      "tx": 44,
+      "ty": 44,
+      "tileId": "whiteFlower"
+    },
+    {
+      "tx": 44,
+      "ty": 62,
+      "tileId": "yellowFlower"
+    },
+    {
+      "tx": 48,
+      "ty": 44,
+      "tileId": "whiteFlower"
+    },
+    {
+      "tx": 48,
+      "ty": 62,
+      "tileId": "yellowFlower"
+    },
+    {
+      "tx": 52,
+      "ty": 44,
+      "tileId": "whiteFlower"
+    },
+    {
+      "tx": 52,
+      "ty": 62,
+      "tileId": "yellowFlower"
+    },
+    {
+      "tx": 56,
+      "ty": 44,
+      "tileId": "whiteFlower"
+    },
+    {
+      "tx": 56,
+      "ty": 62,
+      "tileId": "yellowFlower"
+    },
+    {
+      "tx": 60,
+      "ty": 44,
+      "tileId": "whiteFlower"
+    },
+    {
+      "tx": 60,
+      "ty": 62,
+      "tileId": "yellowFlower"
+    },
+    {
+      "tx": 64,
+      "ty": 44,
+      "tileId": "whiteFlower"
+    },
+    {
+      "tx": 64,
+      "ty": 62,
+      "tileId": "yellowFlower"
+    },
+    {
+      "tx": 68,
+      "ty": 44,
+      "tileId": "whiteFlower"
+    },
+    {
+      "tx": 68,
+      "ty": 62,
+      "tileId": "yellowFlower"
+    },
+    {
+      "tx": 72,
+      "ty": 44,
+      "tileId": "whiteFlower"
+    },
+    {
+      "tx": 72,
+      "ty": 62,
+      "tileId": "yellowFlower"
+    },
+    {
+      "tx": 76,
+      "ty": 44,
+      "tileId": "whiteFlower"
+    },
+    {
+      "tx": 76,
+      "ty": 62,
+      "tileId": "yellowFlower"
+    },
+    {
+      "tx": 80,
+      "ty": 44,
+      "tileId": "whiteFlower"
+    },
+    {
+      "tx": 80,
+      "ty": 62,
+      "tileId": "yellowFlower"
+    },
+    {
+      "tx": 84,
+      "ty": 44,
+      "tileId": "whiteFlower"
+    },
+    {
+      "tx": 84,
+      "ty": 62,
+      "tileId": "yellowFlower"
+    },
+    {
+      "comment": "avenue lamp posts"
+    },
+    {
+      "tx": 7,
+      "ty": 7,
+      "tileId": "lampPostTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 7,
+      "ty": 8,
+      "tileId": "lampPostBottom"
+    },
+    {
+      "tx": 26,
+      "ty": 7,
+      "tileId": "lampPostTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 26,
+      "ty": 8,
+      "tileId": "lampPostBottom"
+    },
+    {
+      "tx": 55,
+      "ty": 7,
+      "tileId": "lampPostTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 55,
+      "ty": 8,
+      "tileId": "lampPostBottom"
+    },
+    {
+      "tx": 90,
+      "ty": 7,
+      "tileId": "lampPostTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 90,
+      "ty": 8,
+      "tileId": "lampPostBottom"
+    },
+    {
+      "tx": 109,
+      "ty": 7,
+      "tileId": "lampPostTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 109,
+      "ty": 8,
+      "tileId": "lampPostBottom"
+    },
+    {
+      "tx": 7,
+      "ty": 19,
+      "tileId": "lampPostTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 7,
+      "ty": 20,
+      "tileId": "lampPostBottom"
+    },
+    {
+      "tx": 26,
+      "ty": 19,
+      "tileId": "lampPostTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 26,
+      "ty": 20,
+      "tileId": "lampPostBottom"
+    },
+    {
+      "tx": 55,
+      "ty": 19,
+      "tileId": "lampPostTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 55,
+      "ty": 20,
+      "tileId": "lampPostBottom"
+    },
+    {
+      "tx": 90,
+      "ty": 19,
+      "tileId": "lampPostTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 90,
+      "ty": 20,
+      "tileId": "lampPostBottom"
+    },
+    {
+      "tx": 109,
+      "ty": 19,
+      "tileId": "lampPostTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 109,
+      "ty": 20,
+      "tileId": "lampPostBottom"
+    },
+    {
+      "tx": 7,
+      "ty": 31,
+      "tileId": "lampPostTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 7,
+      "ty": 32,
+      "tileId": "lampPostBottom"
+    },
+    {
+      "tx": 26,
+      "ty": 31,
+      "tileId": "lampPostTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 26,
+      "ty": 32,
+      "tileId": "lampPostBottom"
+    },
+    {
+      "tx": 55,
+      "ty": 31,
+      "tileId": "lampPostTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 55,
+      "ty": 32,
+      "tileId": "lampPostBottom"
+    },
+    {
+      "tx": 90,
+      "ty": 31,
+      "tileId": "lampPostTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 90,
+      "ty": 32,
+      "tileId": "lampPostBottom"
+    },
+    {
+      "tx": 109,
+      "ty": 31,
+      "tileId": "lampPostTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 109,
+      "ty": 32,
+      "tileId": "lampPostBottom"
+    },
+    {
+      "tx": 7,
+      "ty": 43,
+      "tileId": "lampPostTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 7,
+      "ty": 44,
+      "tileId": "lampPostBottom"
+    },
+    {
+      "tx": 26,
+      "ty": 43,
+      "tileId": "lampPostTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 26,
+      "ty": 44,
+      "tileId": "lampPostBottom"
+    },
+    {
+      "tx": 55,
+      "ty": 43,
+      "tileId": "lampPostTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 55,
+      "ty": 44,
+      "tileId": "lampPostBottom"
+    },
+    {
+      "tx": 90,
+      "ty": 43,
+      "tileId": "lampPostTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 90,
+      "ty": 44,
+      "tileId": "lampPostBottom"
+    },
+    {
+      "tx": 109,
+      "ty": 43,
+      "tileId": "lampPostTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 109,
+      "ty": 44,
+      "tileId": "lampPostBottom"
+    },
+    {
+      "tx": 7,
+      "ty": 55,
+      "tileId": "lampPostTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 7,
+      "ty": 56,
+      "tileId": "lampPostBottom"
+    },
+    {
+      "tx": 26,
+      "ty": 55,
+      "tileId": "lampPostTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 26,
+      "ty": 56,
+      "tileId": "lampPostBottom"
+    },
+    {
+      "tx": 55,
+      "ty": 55,
+      "tileId": "lampPostTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 55,
+      "ty": 56,
+      "tileId": "lampPostBottom"
+    },
+    {
+      "tx": 90,
+      "ty": 55,
+      "tileId": "lampPostTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 90,
+      "ty": 56,
+      "tileId": "lampPostBottom"
+    },
+    {
+      "tx": 109,
+      "ty": 55,
+      "tileId": "lampPostTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 109,
+      "ty": 56,
+      "tileId": "lampPostBottom"
+    },
+    {
+      "tx": 7,
+      "ty": 67,
+      "tileId": "lampPostTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 7,
+      "ty": 68,
+      "tileId": "lampPostBottom"
+    },
+    {
+      "tx": 26,
+      "ty": 67,
+      "tileId": "lampPostTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 26,
+      "ty": 68,
+      "tileId": "lampPostBottom"
+    },
+    {
+      "tx": 55,
+      "ty": 67,
+      "tileId": "lampPostTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 55,
+      "ty": 68,
+      "tileId": "lampPostBottom"
+    },
+    {
+      "tx": 90,
+      "ty": 67,
+      "tileId": "lampPostTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 90,
+      "ty": 68,
+      "tileId": "lampPostBottom"
+    },
+    {
+      "tx": 109,
+      "ty": 67,
+      "tileId": "lampPostTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 109,
+      "ty": 68,
+      "tileId": "lampPostBottom"
+    },
+    {
+      "tx": 7,
+      "ty": 91,
+      "tileId": "lampPostTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 7,
+      "ty": 92,
+      "tileId": "lampPostBottom"
+    },
+    {
+      "tx": 26,
+      "ty": 91,
+      "tileId": "lampPostTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 26,
+      "ty": 92,
+      "tileId": "lampPostBottom"
+    },
+    {
+      "tx": 90,
+      "ty": 91,
+      "tileId": "lampPostTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 90,
+      "ty": 92,
+      "tileId": "lampPostBottom"
+    },
+    {
+      "tx": 109,
+      "ty": 91,
+      "tileId": "lampPostTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 109,
+      "ty": 92,
+      "tileId": "lampPostBottom"
+    },
+    {
+      "comment": "Grand Market \u2014 stalls & wares"
+    },
+    {
+      "tx": 28,
+      "ty": 17,
+      "tileId": "stripedShopAwningTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 28,
+      "ty": 18,
+      "tileId": "stripedShopAwningBottom"
+    },
+    {
+      "tx": 28,
+      "ty": 19,
+      "tileId": "crate"
+    },
+    {
+      "tx": 29,
+      "ty": 19,
+      "tileId": "barrel"
+    },
+    {
+      "tx": 30,
+      "ty": 19,
+      "tileId": "sack"
+    },
+    {
+      "tx": 34,
+      "ty": 17,
+      "tileId": "stripedShopAwningTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 34,
+      "ty": 18,
+      "tileId": "stripedShopAwningBottom"
+    },
+    {
+      "tx": 34,
+      "ty": 19,
+      "tileId": "crate"
+    },
+    {
+      "tx": 35,
+      "ty": 19,
+      "tileId": "barrel"
+    },
+    {
+      "tx": 36,
+      "ty": 19,
+      "tileId": "sack"
+    },
+    {
+      "tx": 40,
+      "ty": 17,
+      "tileId": "stripedShopAwningTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 40,
+      "ty": 18,
+      "tileId": "stripedShopAwningBottom"
+    },
+    {
+      "tx": 40,
+      "ty": 19,
+      "tileId": "crate"
+    },
+    {
+      "tx": 41,
+      "ty": 19,
+      "tileId": "barrel"
+    },
+    {
+      "tx": 42,
+      "ty": 19,
+      "tileId": "sack"
+    },
+    {
+      "tx": 46,
+      "ty": 17,
+      "tileId": "stripedShopAwningTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 46,
+      "ty": 18,
+      "tileId": "stripedShopAwningBottom"
+    },
+    {
+      "tx": 46,
+      "ty": 19,
+      "tileId": "crate"
+    },
+    {
+      "tx": 47,
+      "ty": 19,
+      "tileId": "barrel"
+    },
+    {
+      "tx": 48,
+      "ty": 19,
+      "tileId": "sack"
+    },
+    {
+      "tx": 52,
+      "ty": 17,
+      "tileId": "stripedShopAwningTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 52,
+      "ty": 18,
+      "tileId": "stripedShopAwningBottom"
+    },
+    {
+      "tx": 52,
+      "ty": 19,
+      "tileId": "crate"
+    },
+    {
+      "tx": 53,
+      "ty": 19,
+      "tileId": "barrel"
+    },
+    {
+      "tx": 54,
+      "ty": 19,
+      "tileId": "sack"
+    },
+    {
+      "tx": 58,
+      "ty": 17,
+      "tileId": "stripedShopAwningTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 58,
+      "ty": 18,
+      "tileId": "stripedShopAwningBottom"
+    },
+    {
+      "tx": 58,
+      "ty": 19,
+      "tileId": "crate"
+    },
+    {
+      "tx": 59,
+      "ty": 19,
+      "tileId": "barrel"
+    },
+    {
+      "tx": 60,
+      "ty": 19,
+      "tileId": "sack"
+    },
+    {
+      "tx": 64,
+      "ty": 17,
+      "tileId": "stripedShopAwningTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 64,
+      "ty": 18,
+      "tileId": "stripedShopAwningBottom"
+    },
+    {
+      "tx": 64,
+      "ty": 19,
+      "tileId": "crate"
+    },
+    {
+      "tx": 65,
+      "ty": 19,
+      "tileId": "barrel"
+    },
+    {
+      "tx": 66,
+      "ty": 19,
+      "tileId": "sack"
+    },
+    {
+      "tx": 70,
+      "ty": 17,
+      "tileId": "stripedShopAwningTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 70,
+      "ty": 18,
+      "tileId": "stripedShopAwningBottom"
+    },
+    {
+      "tx": 70,
+      "ty": 19,
+      "tileId": "crate"
+    },
+    {
+      "tx": 71,
+      "ty": 19,
+      "tileId": "barrel"
+    },
+    {
+      "tx": 72,
+      "ty": 19,
+      "tileId": "sack"
+    },
+    {
+      "tx": 76,
+      "ty": 17,
+      "tileId": "stripedShopAwningTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 76,
+      "ty": 18,
+      "tileId": "stripedShopAwningBottom"
+    },
+    {
+      "tx": 76,
+      "ty": 19,
+      "tileId": "crate"
+    },
+    {
+      "tx": 77,
+      "ty": 19,
+      "tileId": "barrel"
+    },
+    {
+      "tx": 78,
+      "ty": 19,
+      "tileId": "sack"
+    },
+    {
+      "tx": 30,
+      "ty": 16,
+      "tileId": "appleBasket"
+    },
+    {
+      "tx": 34,
+      "ty": 16,
+      "tileId": "mushroomBasket"
+    },
+    {
+      "tx": 60,
+      "ty": 16,
+      "tileId": "emptyBasket"
+    },
+    {
+      "tx": 64,
+      "ty": 16,
+      "tileId": "pileOfSacks"
+    },
+    {
+      "tx": 70,
+      "ty": 16,
+      "tileId": "openCrate"
+    },
+    {
+      "tx": 76,
+      "ty": 16,
+      "tileId": "leafBasket"
+    },
+    {
+      "comment": "Temple Quarter \u2014 graves, candles & greenery"
+    },
+    {
+      "tx": 6,
+      "ty": 30,
+      "tileId": "graveStone"
+    },
+    {
+      "tx": 6,
+      "ty": 32,
+      "tileId": "graveWoodenCross"
+    },
+    {
+      "tx": 8,
+      "ty": 30,
+      "tileId": "graveStone"
+    },
+    {
+      "tx": 8,
+      "ty": 32,
+      "tileId": "graveWoodenCross"
+    },
+    {
+      "tx": 36,
+      "ty": 30,
+      "tileId": "graveStone"
+    },
+    {
+      "tx": 36,
+      "ty": 32,
+      "tileId": "graveWoodenCross"
+    },
+    {
+      "tx": 38,
+      "ty": 30,
+      "tileId": "graveStone"
+    },
+    {
+      "tx": 38,
+      "ty": 32,
+      "tileId": "graveWoodenCross"
+    },
+    {
+      "tx": 7,
+      "ty": 31,
+      "tileId": "birdBathTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 7,
+      "ty": 32,
+      "tileId": "birdBathMiddle"
+    },
+    {
+      "tx": 7,
+      "ty": 33,
+      "tileId": "birdBathBottom"
+    },
+    {
+      "tx": 28,
+      "ty": 31,
+      "bundleID": "light-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 31,
+      "ty": 31,
+      "bundleID": "light-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 34,
+      "ty": 31,
+      "bundleID": "light-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 12,
+      "ty": 30,
+      "tileId": "stoneWell"
+    },
+    {
+      "comment": "Old Town \u2014 manor gardens & lamps"
+    },
+    {
+      "tx": 86,
+      "ty": 31,
+      "bundleID": "mixed-tree-cluster-V",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 92,
+      "ty": 31,
+      "bundleID": "mixed-tree-cluster-V",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 98,
+      "ty": 31,
+      "bundleID": "mixed-tree-cluster-V",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 106,
+      "ty": 31,
+      "bundleID": "mixed-tree-cluster-V",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 112,
+      "ty": 31,
+      "bundleID": "mixed-tree-cluster-V",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 86,
+      "ty": 44,
+      "tileId": "pinkFlower"
+    },
+    {
+      "tx": 89,
+      "ty": 44,
+      "tileId": "pinkFlower"
+    },
+    {
+      "tx": 92,
+      "ty": 44,
+      "tileId": "pinkFlower"
+    },
+    {
+      "tx": 95,
+      "ty": 44,
+      "tileId": "pinkFlower"
+    },
+    {
+      "tx": 98,
+      "ty": 44,
+      "tileId": "pinkFlower"
+    },
+    {
+      "tx": 101,
+      "ty": 44,
+      "tileId": "pinkFlower"
+    },
+    {
+      "tx": 104,
+      "ty": 44,
+      "tileId": "pinkFlower"
+    },
+    {
+      "tx": 107,
+      "ty": 44,
+      "tileId": "pinkFlower"
+    },
+    {
+      "tx": 110,
+      "ty": 44,
+      "tileId": "pinkFlower"
+    },
+    {
+      "tx": 113,
+      "ty": 44,
+      "tileId": "pinkFlower"
+    },
+    {
+      "tx": 108,
+      "ty": 30,
+      "tileId": "mailBox"
+    },
+    {
+      "tx": 86,
+      "ty": 46,
+      "tileId": "potOfFlowers"
+    },
+    {
+      "tx": 112,
+      "ty": 46,
+      "tileId": "potOfFlowers"
+    },
+    {
+      "tx": 104,
+      "ty": 31,
+      "tileId": "washingLineEmptyTopLeft",
+      "zlayer": "above"
+    },
+    {
+      "tx": 104,
+      "ty": 32,
+      "tileId": "washingLineClothesBottomLeft"
+    },
+    {
+      "comment": "Guard Quarter \u2014 braziers, walls & banners"
+    },
+    {
+      "tx": 88,
+      "ty": 81,
+      "tileId": "brazierTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 88,
+      "ty": 82,
+      "tileId": "brazierBottom"
+    },
+    {
+      "tx": 106,
+      "ty": 81,
+      "tileId": "brazierTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 106,
+      "ty": 82,
+      "tileId": "brazierBottom"
+    },
+    {
+      "tx": 70,
+      "ty": 81,
+      "tileId": "brazierTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 70,
+      "ty": 82,
+      "tileId": "brazierBottom"
+    },
+    {
+      "tx": 80,
+      "ty": 81,
+      "tileId": "brazierTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 80,
+      "ty": 82,
+      "tileId": "brazierBottom"
+    },
+    {
+      "tx": 54,
+      "ty": 90,
+      "tileId": "stoneCityWallTop"
+    },
+    {
+      "tx": 56,
+      "ty": 90,
+      "tileId": "stoneCityWallTop"
+    },
+    {
+      "tx": 58,
+      "ty": 90,
+      "tileId": "stoneCityWallTop"
+    },
+    {
+      "tx": 60,
+      "ty": 90,
+      "tileId": "stoneCityWallTop"
+    },
+    {
+      "tx": 62,
+      "ty": 90,
+      "tileId": "stoneCityWallTop"
+    },
+    {
+      "tx": 64,
+      "ty": 90,
+      "tileId": "stoneCityWallTop"
+    },
+    {
+      "tx": 66,
+      "ty": 90,
+      "tileId": "stoneCityWallTop"
+    },
+    {
+      "tx": 68,
+      "ty": 90,
+      "tileId": "stoneCityWallTop"
+    },
+    {
+      "tx": 70,
+      "ty": 90,
+      "tileId": "stoneCityWallTop"
+    },
+    {
+      "tx": 72,
+      "ty": 90,
+      "tileId": "stoneCityWallTop"
+    },
+    {
+      "tx": 74,
+      "ty": 90,
+      "tileId": "stoneCityWallTop"
+    },
+    {
+      "tx": 76,
+      "ty": 90,
+      "tileId": "stoneCityWallTop"
+    },
+    {
+      "tx": 78,
+      "ty": 90,
+      "tileId": "stoneCityWallTop"
+    },
+    {
+      "tx": 80,
+      "ty": 90,
+      "tileId": "stoneCityWallTop"
+    },
+    {
+      "tx": 82,
+      "ty": 90,
+      "tileId": "stoneCityWallTop"
+    },
+    {
+      "tx": 84,
+      "ty": 90,
+      "tileId": "stoneCityWallTop"
+    },
+    {
+      "tx": 86,
+      "ty": 90,
+      "tileId": "stoneCityWallTop"
+    },
+    {
+      "tx": 88,
+      "ty": 90,
+      "tileId": "stoneCityWallTop"
+    },
+    {
+      "tx": 90,
+      "ty": 90,
+      "tileId": "stoneCityWallTop"
+    },
+    {
+      "tx": 92,
+      "ty": 90,
+      "tileId": "stoneCityWallTop"
+    },
+    {
+      "tx": 94,
+      "ty": 90,
+      "tileId": "stoneCityWallTop"
+    },
+    {
+      "tx": 96,
+      "ty": 90,
+      "tileId": "stoneCityWallTop"
+    },
+    {
+      "tx": 98,
+      "ty": 90,
+      "tileId": "stoneCityWallTop"
+    },
+    {
+      "tx": 100,
+      "ty": 90,
+      "tileId": "stoneCityWallTop"
+    },
+    {
+      "tx": 102,
+      "ty": 90,
+      "tileId": "stoneCityWallTop"
+    },
+    {
+      "tx": 104,
+      "ty": 90,
+      "tileId": "stoneCityWallTop"
+    },
+    {
+      "tx": 106,
+      "ty": 90,
+      "tileId": "stoneCityWallTop"
+    },
+    {
+      "tx": 108,
+      "ty": 90,
+      "tileId": "stoneCityWallTop"
+    },
+    {
+      "tx": 110,
+      "ty": 90,
+      "tileId": "stoneCityWallTop"
+    },
+    {
+      "tx": 112,
+      "ty": 90,
+      "tileId": "stoneCityWallTop"
+    },
+    {
+      "tx": 72,
+      "ty": 70,
+      "tileId": "wantedPosterTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 72,
+      "ty": 71,
+      "tileId": "wantedPosterBottom"
+    },
+    {
+      "tx": 90,
+      "ty": 70,
+      "tileId": "swordMountedLeft",
+      "zlayer": "above"
+    },
+    {
+      "tx": 92,
+      "ty": 70,
+      "tileId": "shieldMounted",
+      "zlayer": "above"
+    },
+    {
+      "comment": "Riverside \u2014 pond edge, reeds & gardens"
+    },
+    {
+      "tx": 12,
+      "ty": 91,
+      "tileId": "largeLilypad"
+    },
+    {
+      "tx": 13,
+      "ty": 93,
+      "tileId": "smallLilypad"
+    },
+    {
+      "tx": 15,
+      "ty": 91,
+      "tileId": "largeLilypad"
+    },
+    {
+      "tx": 16,
+      "ty": 93,
+      "tileId": "smallLilypad"
+    },
+    {
+      "tx": 18,
+      "ty": 91,
+      "tileId": "largeLilypad"
+    },
+    {
+      "tx": 19,
+      "ty": 93,
+      "tileId": "smallLilypad"
+    },
+    {
+      "tx": 21,
+      "ty": 91,
+      "tileId": "largeLilypad"
+    },
+    {
+      "tx": 22,
+      "ty": 93,
+      "tileId": "smallLilypad"
+    },
+    {
+      "tx": 24,
+      "ty": 91,
+      "tileId": "largeLilypad"
+    },
+    {
+      "tx": 25,
+      "ty": 93,
+      "tileId": "smallLilypad"
+    },
+    {
+      "tx": 27,
+      "ty": 91,
+      "tileId": "largeLilypad"
+    },
+    {
+      "tx": 28,
+      "ty": 93,
+      "tileId": "smallLilypad"
+    },
+    {
+      "tx": 30,
+      "ty": 91,
+      "tileId": "largeLilypad"
+    },
+    {
+      "tx": 31,
+      "ty": 93,
+      "tileId": "smallLilypad"
+    },
+    {
+      "tx": 33,
+      "ty": 91,
+      "tileId": "largeLilypad"
+    },
+    {
+      "tx": 34,
+      "ty": 93,
+      "tileId": "smallLilypad"
+    },
+    {
+      "tx": 10,
+      "ty": 88,
+      "tileId": "spikyPlantTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 10,
+      "ty": 89,
+      "tileId": "spikyPlantBottom"
+    },
+    {
+      "tx": 14,
+      "ty": 88,
+      "tileId": "spikyPlantTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 14,
+      "ty": 89,
+      "tileId": "spikyPlantBottom"
+    },
+    {
+      "tx": 18,
+      "ty": 88,
+      "tileId": "spikyPlantTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 18,
+      "ty": 89,
+      "tileId": "spikyPlantBottom"
+    },
+    {
+      "tx": 22,
+      "ty": 88,
+      "tileId": "spikyPlantTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 22,
+      "ty": 89,
+      "tileId": "spikyPlantBottom"
+    },
+    {
+      "tx": 26,
+      "ty": 88,
+      "tileId": "spikyPlantTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 26,
+      "ty": 89,
+      "tileId": "spikyPlantBottom"
+    },
+    {
+      "tx": 30,
+      "ty": 88,
+      "tileId": "spikyPlantTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 30,
+      "ty": 89,
+      "tileId": "spikyPlantBottom"
+    },
+    {
+      "tx": 34,
+      "ty": 88,
+      "tileId": "spikyPlantTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 34,
+      "ty": 89,
+      "tileId": "spikyPlantBottom"
+    },
+    {
+      "tx": 6,
+      "ty": 70,
+      "bundleID": "autumn-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 40,
+      "ty": 70,
+      "bundleID": "autumn-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 22,
+      "ty": 87,
+      "tileId": "boardwalkHorizontal"
+    },
+    {
+      "tx": 23,
+      "ty": 87,
+      "tileId": "boardwalkHorizontal"
+    },
+    {
+      "tx": 24,
+      "ty": 87,
+      "tileId": "boardwalkHorizontal"
+    },
+    {
+      "tx": 8,
+      "ty": 68,
+      "tileId": "cropRose"
+    },
+    {
+      "tx": 9,
+      "ty": 70,
+      "tileId": "potOfFlowers"
+    },
+    {
+      "tx": 10,
+      "ty": 68,
+      "tileId": "cropRose"
+    },
+    {
+      "tx": 11,
+      "ty": 70,
+      "tileId": "potOfFlowers"
+    },
+    {
+      "tx": 12,
+      "ty": 68,
+      "tileId": "cropRose"
+    },
+    {
+      "tx": 13,
+      "ty": 70,
+      "tileId": "potOfFlowers"
+    },
+    {
+      "tx": 14,
+      "ty": 68,
+      "tileId": "cropRose"
+    },
+    {
+      "tx": 15,
+      "ty": 70,
+      "tileId": "potOfFlowers"
+    },
+    {
+      "tx": 16,
+      "ty": 68,
+      "tileId": "cropRose"
+    },
+    {
+      "tx": 17,
+      "ty": 70,
+      "tileId": "potOfFlowers"
+    },
+    {
+      "tx": 18,
+      "ty": 68,
+      "tileId": "cropRose"
+    },
+    {
+      "tx": 19,
+      "ty": 70,
+      "tileId": "potOfFlowers"
+    },
+    {
+      "tx": 20,
+      "ty": 68,
+      "tileId": "cropRose"
+    },
+    {
+      "tx": 21,
+      "ty": 70,
+      "tileId": "potOfFlowers"
+    },
+    {
+      "tx": 22,
+      "ty": 68,
+      "tileId": "cropRose"
+    },
+    {
+      "tx": 23,
+      "ty": 70,
+      "tileId": "potOfFlowers"
+    },
+    {
+      "comment": "South gate \u2014 road sign & approach"
+    },
+    {
+      "tx": 52,
+      "ty": 90,
+      "tileId": "roadSignTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 52,
+      "ty": 91,
+      "tileId": "roadSignBottom"
+    },
+    {
+      "tx": 61,
+      "ty": 90,
+      "tileId": "largeSign",
+      "zlayer": "above"
+    },
+    {
+      "tx": 52,
+      "ty": 85,
+      "bundleID": "dark-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 62,
+      "ty": 85,
+      "bundleID": "dark-tree",
+      "zlayer": "solid"
+    },
+    {
+      "comment": "scattered city greenery"
+    },
+    {
+      "tx": 20,
+      "ty": 18,
+      "bundleID": "light-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 44,
+      "ty": 30,
+      "bundleID": "light-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 50,
+      "ty": 30,
+      "bundleID": "light-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 78,
+      "ty": 30,
+      "bundleID": "light-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 44,
+      "ty": 66,
+      "bundleID": "light-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 78,
+      "ty": 66,
+      "bundleID": "light-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 30,
+      "ty": 66,
+      "bundleID": "light-tree",
+      "zlayer": "solid"
     }
-  }
+  ]
 }

--- a/web/src/data/hub/capitalcity/questDefs.json
+++ b/web/src/data/hub/capitalcity/questDefs.json
@@ -6,9 +6,9 @@
       "type": "fetch",
       "giverNpcId": "royal-archivist",
       "receiverNpcId": "royal-archivist",
-      "offerDialogue": "The survey of the outer provinces is missing three scrolls — dropped by careless couriers somewhere in the city. Without them, the census is a work of fiction. Find them, please. The crown's records depend on it.",
+      "offerDialogue": "The survey of the outer provinces is missing three scrolls \u2014 dropped by careless couriers somewhere in the city. Without them, the census is a work of fiction. Find them, please.",
       "activeDialogue": "Three survey scrolls, somewhere in the streets. Check near the gates and the market.",
-      "completeDialogue": "All three, and barely smudged! The census lives. You have done the kingdom's paperwork a great service — which is to say, the kingdom itself.",
+      "completeDialogue": "All three, and barely smudged! The census lives. You have done the kingdom's paperwork a great service.",
       "steps": [
         {
           "key": "scrolls",
@@ -26,17 +26,151 @@
       }
     },
     {
+      "id": "crownhaven-charter",
+      "title": "The City Charter",
+      "type": "fetch",
+      "giverNpcId": "chancellor",
+      "receiverNpcId": "chancellor",
+      "prerequisite": "quest:crownhaven-census",
+      "offerDialogue": "Crownhaven's founding charter must be re-sealed for the coronation. Three wax seals were sent out for signing and never returned. Recover them before the ceremony.",
+      "activeDialogue": "Three charter seals, scattered among the districts. The clerks are hopeless.",
+      "completeDialogue": "The charter is whole again. The coronation may proceed with the law on its side. The crown thanks you.",
+      "steps": [
+        {
+          "key": "seals",
+          "type": "collect",
+          "pickupIds": [
+            "charter-seal-1",
+            "charter-seal-2",
+            "charter-seal-3"
+          ],
+          "required": 3
+        }
+      ],
+      "reward": {
+        "crystals": 90,
+        "friendship": {
+          "chancellor": 15
+        }
+      }
+    },
+    {
+      "id": "crownhaven-tax-records",
+      "title": "The Missing Ledgers",
+      "type": "lost-items",
+      "giverNpcId": "chancellor",
+      "receiverNpcId": "banker",
+      "prerequisite": "quest:crownhaven-charter",
+      "offerDialogue": "The treasury ledgers have gone astray \u2014 three of them. Banker Sterling will have my head if the accounts don't balance by dusk. Find them and take them to the Grand Bank.",
+      "activeDialogue": "Three ledgers, lost between the senate and the bank. Sterling is waiting.",
+      "completeDialogue": "Balanced to the last crystal. Sterling will sleep easy, and so will the crown's accountants.",
+      "steps": [
+        {
+          "key": "ledgers",
+          "type": "collect",
+          "pickupIds": [
+            "tax-ledger-1",
+            "tax-ledger-2",
+            "tax-ledger-3"
+          ],
+          "required": 3
+        },
+        {
+          "key": "hand",
+          "type": "deliver",
+          "targetNpcId": "banker",
+          "required": 1
+        }
+      ],
+      "reward": {
+        "crystals": 80,
+        "collectible": {
+          "id": "crown-ledger",
+          "name": "Crown Ledger",
+          "icon": "\ud83d\udcd2",
+          "desc": "The reconciled treasury ledger of Crownhaven."
+        }
+      }
+    },
+    {
+      "id": "crownhaven-proclamation",
+      "title": "The Herald's Proclamations",
+      "type": "fetch",
+      "giverNpcId": "herald-jana",
+      "receiverNpcId": "herald-jana",
+      "offerDialogue": "The wind stole two of my proclamation scrolls clean off the board. A herald with no words is just a loud nuisance. Fetch them back?",
+      "activeDialogue": "Two proclamation scrolls, blown somewhere down the plaza.",
+      "completeDialogue": "My voice is restored! The capital shall hear its decrees after all. Bless you.",
+      "steps": [
+        {
+          "key": "scrolls",
+          "type": "collect",
+          "pickupIds": [
+            "proclamation-1",
+            "proclamation-2"
+          ],
+          "required": 2
+        }
+      ],
+      "reward": {
+        "crystals": 50,
+        "friendship": {
+          "herald-jana": 10
+        }
+      }
+    },
+    {
+      "id": "crownhaven-statue",
+      "title": "A Monument for the Square",
+      "type": "chain",
+      "giverNpcId": "herald-jana",
+      "receiverNpcId": "chancellor",
+      "prerequisite": "quest:crownhaven-proclamation",
+      "offerDialogue": "The Chancellor wants two commemorative plaques set on the new plaza monument. Gather them, then bring them to the senate for inscription.",
+      "activeDialogue": {
+        "plaques": "Two commemorative plaques \u2014 one was left at the cathedral, one at the academy.",
+        "hand": "Both plaques? Splendid. Carry them to the Chancellor at the senate."
+      },
+      "completeDialogue": "Inscribed and mounted. Crownhaven will remember this coronation for a hundred years.",
+      "steps": [
+        {
+          "key": "plaques",
+          "type": "collect",
+          "pickupIds": [
+            "plaque-1",
+            "plaque-2"
+          ],
+          "required": 2
+        },
+        {
+          "key": "hand",
+          "type": "deliver",
+          "targetNpcId": "chancellor",
+          "required": 1
+        }
+      ],
+      "reward": {
+        "crystals": 70,
+        "relationship": {
+          "chancellor": {
+            "track": "ally",
+            "points": 10
+          }
+        }
+      }
+    },
+    {
       "id": "crownhaven-gate-key",
       "title": "The Postern Key",
       "type": "chain",
       "giverNpcId": "watch-captain-hale",
       "receiverNpcId": "innkeeper-crownhaven",
-      "offerDialogue": "One of my watchmen dropped the old postern gate key on patrol last night. Find it before someone less honest does, and leave it with Rosalind at The Gilded Goose — I'll collect it at end of shift, and the fewer hands it passes through, the better.",
+      "offerDialogue": "One of my watchmen dropped the old postern gate key on patrol last night. Find it before someone less honest does, and leave it with Rosalind at The Gilded Goose.",
       "activeDialogue": {
-        "key": "The key went missing somewhere along the east wall, near the chapel. Look sharp.",
+        "key": "The key went missing somewhere along the east wall, near the cathedral. Look sharp.",
         "deliver": "You found it? Good. Now get it to Rosalind at the inn, quiet-like."
       },
-      "completeDialogue": "From Captain Hale? Say no more. It'll be under the counter until shift change. You've done the watch a favour — here, for your discretion.",
+      "completeDialogue": "From Captain Hale? Say no more. It'll be under the counter until shift change. Here, for your discretion.",
       "steps": [
         {
           "key": "key",
@@ -60,36 +194,1299 @@
           "innkeeper-crownhaven": 10
         }
       }
+    },
+    {
+      "id": "crownhaven-patrol",
+      "title": "Walking the Walls",
+      "type": "chain",
+      "giverNpcId": "watch-captain-hale",
+      "receiverNpcId": "guard-bryn",
+      "prerequisite": "quest:crownhaven-gate-key",
+      "offerDialogue": "New patrol tokens need distributing to the wall posts. Collect the three I've had struck and run them out to Guardsman Bryn on the south wall.",
+      "activeDialogue": {
+        "tokens": "Three patrol tokens, left at the guard posts around the city.",
+        "deliver": "Got all three? Bryn's pacing the south wall. He'll be glad of them."
+      },
+      "completeDialogue": "Tokens received. The watch runs like clockwork again. The Captain chose his runner well.",
+      "steps": [
+        {
+          "key": "tokens",
+          "type": "collect",
+          "pickupIds": [
+            "patrol-token-1",
+            "patrol-token-2",
+            "patrol-token-3"
+          ],
+          "required": 3
+        },
+        {
+          "key": "deliver",
+          "type": "deliver",
+          "targetNpcId": "guard-bryn",
+          "required": 1
+        }
+      ],
+      "reward": {
+        "crystals": 70,
+        "friendship": {
+          "watch-captain-hale": 15
+        }
+      }
+    },
+    {
+      "id": "crownhaven-cutpurse",
+      "title": "The Coronation Cutpurse",
+      "type": "chain",
+      "giverNpcId": "guard-bryn",
+      "receiverNpcId": "watch-captain-hale",
+      "prerequisite": "quest:crownhaven-patrol",
+      "offerDialogue": "A cutpurse has been working the coronation crowds. We found his dropped purse of stolen goods \u2014 recover it and bring the evidence to the Captain.",
+      "activeDialogue": {
+        "purse": "The stolen purse was dropped near the market in the scuffle. Find it.",
+        "deliver": "Evidence in hand? Take it straight to Captain Hale at the barracks."
+      },
+      "completeDialogue": "Caught red-handed thanks to you. Crownhaven's purses are a little safer tonight.",
+      "steps": [
+        {
+          "key": "purse",
+          "type": "collect",
+          "pickupIds": [
+            "stolen-purse"
+          ],
+          "required": 1
+        },
+        {
+          "key": "deliver",
+          "type": "deliver",
+          "targetNpcId": "watch-captain-hale",
+          "required": 1
+        }
+      ],
+      "reward": {
+        "crystals": 90,
+        "relationship": {
+          "watch-captain-hale": {
+            "track": "ally",
+            "points": 10
+          }
+        }
+      }
+    },
+    {
+      "id": "crownhaven-armoury",
+      "title": "Steel for the Watch",
+      "type": "fetch",
+      "giverNpcId": "blacksmith-dunn",
+      "receiverNpcId": "watch-captain-hale",
+      "offerDialogue": "The watch armoury is bare. I've four blades nearly finished \u2014 gather the steel billets I left cooling about the forge yard and I'll deliver the Captain his edge.",
+      "activeDialogue": "Four steel billets, somewhere around the Guard Quarter. Mind the heat.",
+      "completeDialogue": "Sharp work. Take these to the Captain with my compliments \u2014 the watch owes you.",
+      "steps": [
+        {
+          "key": "billets",
+          "type": "collect",
+          "pickupIds": [
+            "steel-billet-1",
+            "steel-billet-2",
+            "steel-billet-3",
+            "steel-billet-4"
+          ],
+          "required": 4
+        },
+        {
+          "key": "hand",
+          "type": "deliver",
+          "targetNpcId": "watch-captain-hale",
+          "required": 1
+        }
+      ],
+      "reward": {
+        "crystals": 60,
+        "card": {
+          "name": "Ironclad Sentinel",
+          "count": 1
+        }
+      }
+    },
+    {
+      "id": "crownhaven-relics",
+      "title": "The Scattered Relics",
+      "type": "lost-items",
+      "giverNpcId": "high-priest",
+      "receiverNpcId": "high-priest",
+      "offerDialogue": "Three holy relics were hidden away during the troubles and never recovered. The cathedral feels hollow without them. Will you search?",
+      "activeDialogue": "Three relics, hidden across the Temple Quarter and beyond.",
+      "completeDialogue": "All three, home at last. The cathedral breathes again. Bless you, child.",
+      "steps": [
+        {
+          "key": "relics",
+          "type": "collect",
+          "pickupIds": [
+            "relic-1",
+            "relic-2",
+            "relic-3"
+          ],
+          "required": 3
+        }
+      ],
+      "reward": {
+        "crystals": 70,
+        "friendship": {
+          "high-priest": 20
+        }
+      }
+    },
+    {
+      "id": "crownhaven-dawn-blessing",
+      "title": "The Dawn Blessing",
+      "type": "fetch",
+      "giverNpcId": "high-priest",
+      "receiverNpcId": "high-priest",
+      "prerequisite": "quest:crownhaven-relics",
+      "offerDialogue": "For the coronation dawn we need three blessed candles set about the nave. They were left to cool at the chandler's stalls. Gather them, would you?",
+      "activeDialogue": "Three blessed candles, left around the market and plaza.",
+      "completeDialogue": "The nave glows as it should. The dawn blessing will be radiant. Take this with my thanks.",
+      "steps": [
+        {
+          "key": "candles",
+          "type": "collect",
+          "pickupIds": [
+            "dawn-candle-1",
+            "dawn-candle-2",
+            "dawn-candle-3"
+          ],
+          "required": 3
+        }
+      ],
+      "reward": {
+        "crystals": 60,
+        "collectible": {
+          "id": "dawn-reliquary",
+          "name": "Dawn Reliquary",
+          "icon": "\ud83d\udd6f\ufe0f",
+          "desc": "A gilded reliquary blessed at the Crownhaven dawn rite."
+        }
+      }
+    },
+    {
+      "id": "crownhaven-tower-bell",
+      "title": "The Silent Bell",
+      "type": "chain",
+      "giverNpcId": "high-priest",
+      "receiverNpcId": "blacksmith-dunn",
+      "prerequisite": "quest:crownhaven-dawn-blessing",
+      "offerDialogue": "The great bell has hung silent for years \u2014 its clapper was lost. Recover it and take it to Smith Dunn, who alone can re-hang it.",
+      "activeDialogue": {
+        "clapper": "The bell clapper was last seen near the forge in the Guard Quarter.",
+        "deliver": "You have it? Take it to Dunn at the forge \u2014 he'll know what to do."
+      },
+      "completeDialogue": "Listen \u2014 the bell tolls again over Crownhaven! Dunn says the tower is yours to climb now.",
+      "steps": [
+        {
+          "key": "clapper",
+          "type": "collect",
+          "pickupIds": [
+            "bell-clapper"
+          ],
+          "required": 1
+        },
+        {
+          "key": "deliver",
+          "type": "deliver",
+          "targetNpcId": "blacksmith-dunn",
+          "required": 1
+        }
+      ],
+      "reward": {
+        "crystals": 100,
+        "unlock": "cathedral-tower"
+      }
+    },
+    {
+      "id": "crownhaven-crypt-vigil",
+      "title": "Vigil in the Crypt",
+      "type": "fetch",
+      "giverNpcId": "high-priest",
+      "receiverNpcId": "high-priest",
+      "prerequisite": "quest:crownhaven-tower-bell",
+      "offerDialogue": "The crypt vigil requires two lanterns kept burning through the night. They were borrowed and never returned. Find them and the vigil can be kept.",
+      "activeDialogue": "Two vigil lanterns, somewhere in the Temple Quarter.",
+      "completeDialogue": "The vigil is kept and the dead rest easy. You have a quiet strength, child.",
+      "steps": [
+        {
+          "key": "lanterns",
+          "type": "collect",
+          "pickupIds": [
+            "vigil-lantern-1",
+            "vigil-lantern-2"
+          ],
+          "required": 2
+        }
+      ],
+      "reward": {
+        "crystals": 60,
+        "relationship": {
+          "high-priest": {
+            "track": "ally",
+            "points": 10
+          }
+        }
+      }
+    },
+    {
+      "id": "crownhaven-silk",
+      "title": "Silks for the Coronation",
+      "type": "fetch",
+      "giverNpcId": "tailor-pell",
+      "receiverNpcId": "tailor-pell",
+      "offerDialogue": "Three bolts of imported silk were left about the market when the cart overturned. Gather them so I can dress the court in time.",
+      "activeDialogue": "Three silk bolts, lost around the Grand Market.",
+      "completeDialogue": "Exquisite. The court will shimmer. You've a good eye \u2014 here, a little something.",
+      "steps": [
+        {
+          "key": "silk",
+          "type": "collect",
+          "pickupIds": [
+            "silk-bolt-1",
+            "silk-bolt-2",
+            "silk-bolt-3"
+          ],
+          "required": 3
+        }
+      ],
+      "reward": {
+        "crystals": 50,
+        "friendship": {
+          "tailor-pell": 15
+        }
+      }
+    },
+    {
+      "id": "crownhaven-gems",
+      "title": "Rough Diamonds",
+      "type": "fetch",
+      "giverNpcId": "jeweller-isolde",
+      "receiverNpcId": "jeweller-isolde",
+      "offerDialogue": "Three raw gems spilled from my pouch in the crowd. Dull little pebbles to most eyes \u2014 find them before someone kicks them down a drain.",
+      "activeDialogue": "Three raw gems, scattered across the plaza and market.",
+      "completeDialogue": "There's the fire I was after! Cut and polished, these will crown a duchess. Take a card for your trouble.",
+      "steps": [
+        {
+          "key": "gems",
+          "type": "collect",
+          "pickupIds": [
+            "raw-gem-1",
+            "raw-gem-2",
+            "raw-gem-3"
+          ],
+          "required": 3
+        }
+      ],
+      "reward": {
+        "crystals": 60,
+        "card": {
+          "name": "Gemcutter's Prize",
+          "count": 1
+        }
+      }
+    },
+    {
+      "id": "crownhaven-remedy",
+      "title": "The Apothecary's Remedy",
+      "type": "fetch",
+      "giverNpcId": "apothecary-mads",
+      "receiverNpcId": "apothecary-mads",
+      "offerDialogue": "I'm short three rare herbs for a coronation tonic the Chancellor swears by. They grow wild about the city's edges. Gather them?",
+      "activeDialogue": "Three rare herbs, growing around Riverside and the Temple Quarter.",
+      "completeDialogue": "Perfect potency. The Chancellor will be insufferably energetic. Take my compendium \u2014 you've earned it.",
+      "steps": [
+        {
+          "key": "herbs",
+          "type": "collect",
+          "pickupIds": [
+            "herb-1",
+            "herb-2",
+            "herb-3"
+          ],
+          "required": 3
+        }
+      ],
+      "reward": {
+        "crystals": 50,
+        "collectible": {
+          "id": "apothecary-compendium",
+          "name": "Apothecary's Compendium",
+          "icon": "\ud83d\udcd7",
+          "desc": "Apothecary Mads' annotated book of Crownhaven remedies."
+        }
+      }
+    },
+    {
+      "id": "crownhaven-bread",
+      "title": "The King's Loaf",
+      "type": "fetch",
+      "giverNpcId": "baker-otto",
+      "receiverNpcId": "market-matron",
+      "offerDialogue": "Three sacks of milling grain went missing off my cart. Find them and run them to Matron Goldie at the market \u2014 she's holding my oven's worth of orders hostage.",
+      "activeDialogue": "Three grain sacks, lost between the market and the mill road.",
+      "completeDialogue": "Grain at last! Tell Otto his loaf is saved. And here \u2014 a little something for the legwork.",
+      "steps": [
+        {
+          "key": "grain",
+          "type": "collect",
+          "pickupIds": [
+            "grain-sack-1",
+            "grain-sack-2",
+            "grain-sack-3"
+          ],
+          "required": 3
+        },
+        {
+          "key": "hand",
+          "type": "deliver",
+          "targetNpcId": "market-matron",
+          "required": 1
+        }
+      ],
+      "reward": {
+        "crystals": 40,
+        "friendship": {
+          "baker-otto": 10,
+          "market-matron": 10
+        }
+      }
+    },
+    {
+      "id": "crownhaven-market-day",
+      "title": "Market Day Muddle",
+      "type": "lost-items",
+      "giverNpcId": "market-matron",
+      "receiverNpcId": "market-matron",
+      "offerDialogue": "Three purses of takings got knocked off my stall in the coronation rush. Forty years and I've never lost a copper \u2014 until today. Help an old woman out?",
+      "activeDialogue": "Three coin purses, dropped around the Grand Market.",
+      "completeDialogue": "Every copper back where it belongs. You're a rare honest soul. Don't tell the pigeons.",
+      "steps": [
+        {
+          "key": "coins",
+          "type": "collect",
+          "pickupIds": [
+            "lost-coin-1",
+            "lost-coin-2",
+            "lost-coin-3"
+          ],
+          "required": 3
+        }
+      ],
+      "reward": {
+        "crystals": 60,
+        "friendship": {
+          "market-matron": 15
+        }
+      }
+    },
+    {
+      "id": "crownhaven-anthology",
+      "title": "The Crownhaven Anthology",
+      "type": "chain",
+      "giverNpcId": "royal-archivist",
+      "receiverNpcId": "royal-archivist",
+      "offerDialogue": "A three-volume anthology of the realm's history was scattered ages ago. The first tome surfaced in the library stacks, if my notes are right.",
+      "activeDialogue": {
+        "tome-1": "The first tome is in the library stacks. Look on the shelves.",
+        "tome-2": "Excellent! The second volume was lent to the academy. Check there.",
+        "tome-3": "Almost there! The final volume ended up near the cathedral, I believe."
+      },
+      "completeDialogue": "The trilogy is whole! This is extraordinary scholarship. Please, take this anthology as thanks.",
+      "steps": [
+        {
+          "key": "tome-1",
+          "type": "collect",
+          "pickupIds": [
+            "anthology-tome-1"
+          ],
+          "required": 1
+        },
+        {
+          "key": "tome-2",
+          "type": "collect",
+          "pickupIds": [
+            "anthology-tome-2"
+          ],
+          "required": 1,
+          "chain": "anthology-tome-1"
+        },
+        {
+          "key": "tome-3",
+          "type": "collect",
+          "pickupIds": [
+            "anthology-tome-3"
+          ],
+          "required": 1,
+          "chain": "anthology-tome-2"
+        }
+      ],
+      "reward": {
+        "collectible": {
+          "id": "crownhaven-anthology",
+          "name": "Crownhaven Anthology",
+          "icon": "\ud83d\udcda",
+          "desc": "A complete three-volume history of the capital."
+        },
+        "friendship": {
+          "royal-archivist": 30
+        }
+      }
+    },
+    {
+      "id": "crownhaven-lecture",
+      "title": "Scattered Lectures",
+      "type": "fetch",
+      "giverNpcId": "academy-master",
+      "receiverNpcId": "academy-master",
+      "offerDialogue": "My lecture notes blew across three districts during a window mishap. Gather them before a student finds them and learns something dangerous.",
+      "activeDialogue": "Three bundles of lecture notes, scattered across the city.",
+      "completeDialogue": "All present and correct! The next generation of clever fools is saved. My thanks.",
+      "steps": [
+        {
+          "key": "notes",
+          "type": "collect",
+          "pickupIds": [
+            "lecture-note-1",
+            "lecture-note-2",
+            "lecture-note-3"
+          ],
+          "required": 3
+        }
+      ],
+      "reward": {
+        "crystals": 60,
+        "friendship": {
+          "academy-master": 15
+        }
+      }
+    },
+    {
+      "id": "crownhaven-experiment",
+      "title": "A Delicate Experiment",
+      "type": "fetch",
+      "giverNpcId": "academy-master",
+      "receiverNpcId": "apothecary-mads",
+      "prerequisite": "quest:crownhaven-lecture",
+      "offerDialogue": "The academy needs two volatile reagents from the apothecary's stock, but they must be carried carefully. Gather them and deliver them to Mads \u2014 gently.",
+      "activeDialogue": "Two reagents, set out around the academy and market. Don't shake them.",
+      "completeDialogue": "Intact! Marvellous. Tell Fenwick his experiment lives \u2014 and take a card for steady hands.",
+      "steps": [
+        {
+          "key": "reagents",
+          "type": "collect",
+          "pickupIds": [
+            "reagent-1",
+            "reagent-2"
+          ],
+          "required": 2
+        },
+        {
+          "key": "hand",
+          "type": "deliver",
+          "targetNpcId": "apothecary-mads",
+          "required": 1
+        }
+      ],
+      "reward": {
+        "crystals": 70,
+        "card": {
+          "name": "Arcane Scholar",
+          "count": 1
+        }
+      }
+    },
+    {
+      "id": "crownhaven-mint-dies",
+      "title": "The Mint Dies",
+      "type": "fetch",
+      "giverNpcId": "mint-master",
+      "receiverNpcId": "mint-master",
+      "offerDialogue": "Two coining dies went missing from the mint floor \u2014 in the wrong hands they could forge the realm's coin. Recover both before word gets out.",
+      "activeDialogue": "Two mint dies, lost about the Guard Quarter.",
+      "completeDialogue": "Both dies, safe. You've spared the treasury a forger's nightmare. Quietly done \u2014 I like that.",
+      "steps": [
+        {
+          "key": "dies",
+          "type": "collect",
+          "pickupIds": [
+            "mint-die-1",
+            "mint-die-2"
+          ],
+          "required": 2
+        }
+      ],
+      "reward": {
+        "crystals": 70,
+        "friendship": {
+          "mint-master": 15
+        }
+      }
+    },
+    {
+      "id": "crownhaven-stolen-coin",
+      "title": "The Vault Breach",
+      "type": "chain",
+      "giverNpcId": "banker",
+      "receiverNpcId": "watch-captain-hale",
+      "prerequisite": "quest:crownhaven-mint-dies",
+      "offerDialogue": "A pouch of newly minted coin was lifted from the vault antechamber. Recover it and take it to Captain Hale \u2014 the watch must know we were breached.",
+      "activeDialogue": {
+        "pouch": "The stolen coin pouch was dropped in the getaway, near the bank.",
+        "deliver": "Recovered? Take it to Captain Hale at the barracks at once."
+      },
+      "completeDialogue": "The watch has the evidence and the vault is sealed once more. With the breach closed, the vault is open to you.",
+      "steps": [
+        {
+          "key": "pouch",
+          "type": "collect",
+          "pickupIds": [
+            "coin-pouch"
+          ],
+          "required": 1
+        },
+        {
+          "key": "deliver",
+          "type": "deliver",
+          "targetNpcId": "watch-captain-hale",
+          "required": 1
+        }
+      ],
+      "reward": {
+        "crystals": 90,
+        "unlock": "grand-bank-vault"
+      }
+    },
+    {
+      "id": "crownhaven-noble-debt",
+      "title": "A Noble Debt",
+      "type": "fetch",
+      "giverNpcId": "noble-lady-cora",
+      "receiverNpcId": "banker",
+      "offerDialogue": "Two promissory notes of mine must reach the Grand Bank discreetly before they fall due. Carry them to Banker Sterling for me, would you?",
+      "activeDialogue": "Two promissory notes, to be gathered and taken to the bank.",
+      "completeDialogue": "Settled, and not a whisper of scandal. You have a noblewoman's gratitude \u2014 and perhaps a little more.",
+      "steps": [
+        {
+          "key": "notes",
+          "type": "collect",
+          "pickupIds": [
+            "promissory-1",
+            "promissory-2"
+          ],
+          "required": 2
+        },
+        {
+          "key": "hand",
+          "type": "deliver",
+          "targetNpcId": "banker",
+          "required": 1
+        }
+      ],
+      "reward": {
+        "crystals": 60,
+        "relationship": {
+          "noble-lady-cora": {
+            "track": "romance",
+            "points": 10
+          }
+        }
+      }
+    },
+    {
+      "id": "crownhaven-lost-locket",
+      "title": "Lady Cora's Locket",
+      "type": "lost-items",
+      "giverNpcId": "noble-lady-cora",
+      "receiverNpcId": "noble-lady-cora",
+      "offerDialogue": "My mother's locket broke and scattered in three pieces across the gardens and squares. It is all I have of her. Please \u2014 find them.",
+      "activeDialogue": "Three locket pieces, lost across the districts.",
+      "completeDialogue": "Whole again, and so is my heart. You cannot know what this means. Bless you, traveller.",
+      "steps": [
+        {
+          "key": "pieces",
+          "type": "collect",
+          "pickupIds": [
+            "locket-piece-1",
+            "locket-piece-2",
+            "locket-piece-3"
+          ],
+          "required": 3
+        }
+      ],
+      "reward": {
+        "crystals": 70,
+        "friendship": {
+          "noble-lady-cora": 20
+        }
+      }
+    },
+    {
+      "id": "crownhaven-buskers-strings",
+      "title": "The Busker's Strings",
+      "type": "lost-items",
+      "giverNpcId": "busker-lyle",
+      "receiverNpcId": "busker-lyle",
+      "offerDialogue": "Snapped three lute strings and they pinged off who-knows-where across the plaza. No strings, no coronation song. Help a poor musician?",
+      "activeDialogue": "Three lute strings, sprung loose around the plaza and market.",
+      "completeDialogue": "Re-strung and ready! Crownhaven shall have its anthem after all. Here \u2014 a card from a grateful bard.",
+      "steps": [
+        {
+          "key": "strings",
+          "type": "collect",
+          "pickupIds": [
+            "lute-string-1",
+            "lute-string-2",
+            "lute-string-3"
+          ],
+          "required": 3
+        }
+      ],
+      "reward": {
+        "crystals": 40,
+        "card": {
+          "name": "Wandering Minstrel",
+          "count": 1
+        }
+      }
+    },
+    {
+      "id": "crownhaven-welcome",
+      "title": "A Round on the House",
+      "type": "fetch",
+      "giverNpcId": "innkeeper-crownhaven",
+      "receiverNpcId": "innkeeper-crownhaven",
+      "offerDialogue": "The coronation crowd drank me out of clean mugs and three rolled off who-knows-where. Round them up and the next ale's on me.",
+      "activeDialogue": "Three tankards, lost around the inn and market.",
+      "completeDialogue": "Spotless and accounted for! You're always welcome at the Goose. First ale's free, mind.",
+      "steps": [
+        {
+          "key": "mugs",
+          "type": "collect",
+          "pickupIds": [
+            "tankard-1",
+            "tankard-2",
+            "tankard-3"
+          ],
+          "required": 3
+        }
+      ],
+      "reward": {
+        "crystals": 40,
+        "friendship": {
+          "innkeeper-crownhaven": 15
+        }
+      }
+    },
+    {
+      "id": "crownhaven-feast",
+      "title": "The Coronation Feast",
+      "type": "chain",
+      "giverNpcId": "innkeeper-crownhaven",
+      "receiverNpcId": "baker-otto",
+      "prerequisite": "quest:crownhaven-welcome",
+      "offerDialogue": "The coronation feast needs four crates of provisions gathered from the market and run to Baker Otto, who's coordinating the kitchens. Big night, big appetite.",
+      "activeDialogue": {
+        "provisions": "Four crates of provisions, scattered about the Grand Market.",
+        "hand": "All four? Take them to Otto at the bakery \u2014 the feast depends on it."
+      },
+      "completeDialogue": "The feast is saved and the capital will dine like royalty. Otto sends his thanks \u2014 and so do I.",
+      "steps": [
+        {
+          "key": "provisions",
+          "type": "collect",
+          "pickupIds": [
+            "provision-1",
+            "provision-2",
+            "provision-3",
+            "provision-4"
+          ],
+          "required": 4
+        },
+        {
+          "key": "hand",
+          "type": "deliver",
+          "targetNpcId": "baker-otto",
+          "required": 1
+        }
+      ],
+      "reward": {
+        "crystals": 60,
+        "collectible": {
+          "id": "feast-menu",
+          "name": "Coronation Feast Menu",
+          "icon": "\ud83c\udf72",
+          "desc": "The grand menu of the Crownhaven coronation feast."
+        }
+      }
+    },
+    {
+      "id": "crownhaven-ravenwatch-census",
+      "title": "Word to Ravenwatch",
+      "type": "fetch",
+      "giverNpcId": "chancellor",
+      "receiverNpcId": "elder",
+      "prerequisite": "quest:crownhaven-charter",
+      "offerDialogue": "Crownhaven's charter must be copied to Ravenwatch's elder for the old records. Take this sealed copy across the realm and place it in the Elder's hands yourself.",
+      "activeDialogue": "Carry the charter copy to the Elder of Ravenwatch.",
+      "completeDialogue": "From Crownhaven's Chancellor? The old bonds hold firm. Tell Vell the records are kept. Safe travels, friend.",
+      "steps": [
+        {
+          "key": "deliver",
+          "type": "deliver",
+          "targetNpcId": "elder",
+          "required": 1
+        }
+      ],
+      "reward": {
+        "crystals": 100,
+        "friendship": {
+          "chancellor": 20
+        },
+        "collectible": {
+          "id": "royal-charter-copy",
+          "name": "Royal Charter Copy",
+          "icon": "\ud83d\udcdc",
+          "desc": "A sealed copy of Crownhaven's charter, witnessed in Ravenwatch."
+        }
+      }
+    },
+    {
+      "id": "crownhaven-ravenwatch-relic",
+      "title": "A Relic Returned",
+      "type": "fetch",
+      "giverNpcId": "high-priest",
+      "receiverNpcId": "guard-captain-thorin",
+      "prerequisite": "quest:crownhaven-relics",
+      "offerDialogue": "One of our recovered relics belongs by right to Ravenwatch's keep. Bear it to Guard-Captain Thorin there, and let the two cities be at peace over it.",
+      "activeDialogue": "Bear the relic to Guard-Captain Thorin in Ravenwatch.",
+      "completeDialogue": "Crownhaven returns what was borrowed? Thorin accepts it gladly. The realm is the stronger for it.",
+      "steps": [
+        {
+          "key": "deliver",
+          "type": "deliver",
+          "targetNpcId": "guard-captain-thorin",
+          "required": 1
+        }
+      ],
+      "reward": {
+        "crystals": 90,
+        "friendship": {
+          "high-priest": 15
+        }
+      }
     }
   ],
   "pickupItems": [
     {
       "id": "survey-scroll-1",
-      "tx": 4,
-      "ty": 13,
+      "tx": 10,
+      "ty": 15,
       "tileId": "rolledMap",
       "questId": "crownhaven-census"
     },
     {
       "id": "survey-scroll-2",
-      "tx": 33,
-      "ty": 18,
+      "tx": 14,
+      "ty": 15,
       "tileId": "rolledMap",
       "questId": "crownhaven-census"
     },
     {
       "id": "survey-scroll-3",
-      "tx": 25,
-      "ty": 28,
+      "tx": 18,
+      "ty": 15,
       "tileId": "rolledMap",
       "questId": "crownhaven-census"
     },
     {
+      "id": "charter-seal-1",
+      "tx": 22,
+      "ty": 15,
+      "tileId": "letter",
+      "questId": "crownhaven-charter"
+    },
+    {
+      "id": "charter-seal-2",
+      "tx": 26,
+      "ty": 15,
+      "tileId": "letter",
+      "questId": "crownhaven-charter"
+    },
+    {
+      "id": "charter-seal-3",
+      "tx": 30,
+      "ty": 15,
+      "tileId": "letter",
+      "questId": "crownhaven-charter"
+    },
+    {
+      "id": "tax-ledger-1",
+      "tx": 34,
+      "ty": 15,
+      "tileId": "pileOfPapers",
+      "questId": "crownhaven-tax-records"
+    },
+    {
+      "id": "tax-ledger-2",
+      "tx": 38,
+      "ty": 15,
+      "tileId": "pileOfPapers",
+      "questId": "crownhaven-tax-records"
+    },
+    {
+      "id": "tax-ledger-3",
+      "tx": 42,
+      "ty": 15,
+      "tileId": "pileOfPapers",
+      "questId": "crownhaven-tax-records"
+    },
+    {
+      "id": "proclamation-1",
+      "tx": 46,
+      "ty": 15,
+      "tileId": "rolledMap",
+      "questId": "crownhaven-proclamation"
+    },
+    {
+      "id": "proclamation-2",
+      "tx": 50,
+      "ty": 15,
+      "tileId": "rolledMap",
+      "questId": "crownhaven-proclamation"
+    },
+    {
+      "id": "plaque-1",
+      "tx": 54,
+      "ty": 15,
+      "tileId": "painting",
+      "questId": "crownhaven-statue"
+    },
+    {
+      "id": "plaque-2",
+      "tx": 58,
+      "ty": 15,
+      "tileId": "painting",
+      "questId": "crownhaven-statue"
+    },
+    {
       "id": "postern-key",
-      "tx": 27,
-      "ty": 19,
+      "tx": 62,
+      "ty": 15,
       "tileId": "key",
       "questId": "crownhaven-gate-key"
+    },
+    {
+      "id": "patrol-token-1",
+      "tx": 66,
+      "ty": 15,
+      "tileId": "coin",
+      "questId": "crownhaven-patrol"
+    },
+    {
+      "id": "patrol-token-2",
+      "tx": 70,
+      "ty": 15,
+      "tileId": "coin",
+      "questId": "crownhaven-patrol"
+    },
+    {
+      "id": "patrol-token-3",
+      "tx": 74,
+      "ty": 15,
+      "tileId": "coin",
+      "questId": "crownhaven-patrol"
+    },
+    {
+      "id": "stolen-purse",
+      "tx": 78,
+      "ty": 15,
+      "tileId": "smallSack",
+      "questId": "crownhaven-cutpurse"
+    },
+    {
+      "id": "steel-billet-1",
+      "tx": 82,
+      "ty": 15,
+      "tileId": "sword",
+      "questId": "crownhaven-armoury"
+    },
+    {
+      "id": "steel-billet-2",
+      "tx": 86,
+      "ty": 15,
+      "tileId": "sword",
+      "questId": "crownhaven-armoury"
+    },
+    {
+      "id": "steel-billet-3",
+      "tx": 90,
+      "ty": 15,
+      "tileId": "sword",
+      "questId": "crownhaven-armoury"
+    },
+    {
+      "id": "steel-billet-4",
+      "tx": 94,
+      "ty": 15,
+      "tileId": "sword",
+      "questId": "crownhaven-armoury"
+    },
+    {
+      "id": "relic-1",
+      "tx": 98,
+      "ty": 15,
+      "tileId": "goldenCross",
+      "questId": "crownhaven-relics"
+    },
+    {
+      "id": "relic-2",
+      "tx": 102,
+      "ty": 15,
+      "tileId": "goldenCross",
+      "questId": "crownhaven-relics"
+    },
+    {
+      "id": "relic-3",
+      "tx": 106,
+      "ty": 15,
+      "tileId": "goldenCross",
+      "questId": "crownhaven-relics"
+    },
+    {
+      "id": "dawn-candle-1",
+      "tx": 110,
+      "ty": 15,
+      "tileId": "candlestickUnlit",
+      "questId": "crownhaven-dawn-blessing"
+    },
+    {
+      "id": "dawn-candle-2",
+      "tx": 10,
+      "ty": 29,
+      "tileId": "candlestickUnlit",
+      "questId": "crownhaven-dawn-blessing"
+    },
+    {
+      "id": "dawn-candle-3",
+      "tx": 14,
+      "ty": 29,
+      "tileId": "candlestickUnlit",
+      "questId": "crownhaven-dawn-blessing"
+    },
+    {
+      "id": "bell-clapper",
+      "tx": 18,
+      "ty": 29,
+      "tileId": "axe",
+      "questId": "crownhaven-tower-bell"
+    },
+    {
+      "id": "vigil-lantern-1",
+      "tx": 22,
+      "ty": 29,
+      "tileId": "floorLantern",
+      "questId": "crownhaven-crypt-vigil"
+    },
+    {
+      "id": "vigil-lantern-2",
+      "tx": 26,
+      "ty": 29,
+      "tileId": "floorLantern",
+      "questId": "crownhaven-crypt-vigil"
+    },
+    {
+      "id": "silk-bolt-1",
+      "tx": 30,
+      "ty": 29,
+      "tileId": "cotton",
+      "questId": "crownhaven-silk"
+    },
+    {
+      "id": "silk-bolt-2",
+      "tx": 34,
+      "ty": 29,
+      "tileId": "cotton",
+      "questId": "crownhaven-silk"
+    },
+    {
+      "id": "silk-bolt-3",
+      "tx": 38,
+      "ty": 29,
+      "tileId": "cotton",
+      "questId": "crownhaven-silk"
+    },
+    {
+      "id": "raw-gem-1",
+      "tx": 42,
+      "ty": 29,
+      "tileId": "diamond",
+      "questId": "crownhaven-gems"
+    },
+    {
+      "id": "raw-gem-2",
+      "tx": 46,
+      "ty": 29,
+      "tileId": "diamond",
+      "questId": "crownhaven-gems"
+    },
+    {
+      "id": "raw-gem-3",
+      "tx": 50,
+      "ty": 29,
+      "tileId": "diamond",
+      "questId": "crownhaven-gems"
+    },
+    {
+      "id": "herb-1",
+      "tx": 54,
+      "ty": 29,
+      "tileId": "bunchOfHerbs",
+      "questId": "crownhaven-remedy"
+    },
+    {
+      "id": "herb-2",
+      "tx": 58,
+      "ty": 29,
+      "tileId": "bunchOfHerbs",
+      "questId": "crownhaven-remedy"
+    },
+    {
+      "id": "herb-3",
+      "tx": 62,
+      "ty": 29,
+      "tileId": "bunchOfHerbs",
+      "questId": "crownhaven-remedy"
+    },
+    {
+      "id": "grain-sack-1",
+      "tx": 66,
+      "ty": 29,
+      "tileId": "sack",
+      "questId": "crownhaven-bread"
+    },
+    {
+      "id": "grain-sack-2",
+      "tx": 70,
+      "ty": 29,
+      "tileId": "sack",
+      "questId": "crownhaven-bread"
+    },
+    {
+      "id": "grain-sack-3",
+      "tx": 74,
+      "ty": 29,
+      "tileId": "sack",
+      "questId": "crownhaven-bread"
+    },
+    {
+      "id": "lost-coin-1",
+      "tx": 78,
+      "ty": 29,
+      "tileId": "pileOfCoins",
+      "questId": "crownhaven-market-day"
+    },
+    {
+      "id": "lost-coin-2",
+      "tx": 82,
+      "ty": 29,
+      "tileId": "pileOfCoins",
+      "questId": "crownhaven-market-day"
+    },
+    {
+      "id": "lost-coin-3",
+      "tx": 86,
+      "ty": 29,
+      "tileId": "pileOfCoins",
+      "questId": "crownhaven-market-day"
+    },
+    {
+      "id": "anthology-tome-1",
+      "tx": 90,
+      "ty": 29,
+      "tileId": "closedBook",
+      "questId": "crownhaven-anthology"
+    },
+    {
+      "id": "anthology-tome-2",
+      "tx": 94,
+      "ty": 29,
+      "tileId": "closedBook",
+      "questId": "crownhaven-anthology",
+      "chain": "anthology-tome-1"
+    },
+    {
+      "id": "anthology-tome-3",
+      "tx": 98,
+      "ty": 29,
+      "tileId": "closedBook",
+      "questId": "crownhaven-anthology",
+      "chain": "anthology-tome-2"
+    },
+    {
+      "id": "lecture-note-1",
+      "tx": 102,
+      "ty": 29,
+      "tileId": "pileOfPapers",
+      "questId": "crownhaven-lecture"
+    },
+    {
+      "id": "lecture-note-2",
+      "tx": 106,
+      "ty": 29,
+      "tileId": "pileOfPapers",
+      "questId": "crownhaven-lecture"
+    },
+    {
+      "id": "lecture-note-3",
+      "tx": 110,
+      "ty": 29,
+      "tileId": "pileOfPapers",
+      "questId": "crownhaven-lecture"
+    },
+    {
+      "id": "reagent-1",
+      "tx": 10,
+      "ty": 43,
+      "tileId": "potions",
+      "questId": "crownhaven-experiment"
+    },
+    {
+      "id": "reagent-2",
+      "tx": 14,
+      "ty": 43,
+      "tileId": "potions",
+      "questId": "crownhaven-experiment"
+    },
+    {
+      "id": "mint-die-1",
+      "tx": 18,
+      "ty": 43,
+      "tileId": "smallChest",
+      "questId": "crownhaven-mint-dies"
+    },
+    {
+      "id": "mint-die-2",
+      "tx": 22,
+      "ty": 43,
+      "tileId": "smallChest",
+      "questId": "crownhaven-mint-dies"
+    },
+    {
+      "id": "coin-pouch",
+      "tx": 26,
+      "ty": 43,
+      "tileId": "pileOfGoldCoins",
+      "questId": "crownhaven-stolen-coin"
+    },
+    {
+      "id": "promissory-1",
+      "tx": 30,
+      "ty": 43,
+      "tileId": "letter",
+      "questId": "crownhaven-noble-debt"
+    },
+    {
+      "id": "promissory-2",
+      "tx": 34,
+      "ty": 43,
+      "tileId": "letter",
+      "questId": "crownhaven-noble-debt"
+    },
+    {
+      "id": "locket-piece-1",
+      "tx": 38,
+      "ty": 43,
+      "tileId": "pendant",
+      "questId": "crownhaven-lost-locket"
+    },
+    {
+      "id": "locket-piece-2",
+      "tx": 42,
+      "ty": 43,
+      "tileId": "pendant",
+      "questId": "crownhaven-lost-locket"
+    },
+    {
+      "id": "locket-piece-3",
+      "tx": 46,
+      "ty": 43,
+      "tileId": "pendant",
+      "questId": "crownhaven-lost-locket"
+    },
+    {
+      "id": "lute-string-1",
+      "tx": 50,
+      "ty": 43,
+      "tileId": "feather",
+      "questId": "crownhaven-buskers-strings"
+    },
+    {
+      "id": "lute-string-2",
+      "tx": 54,
+      "ty": 43,
+      "tileId": "feather",
+      "questId": "crownhaven-buskers-strings"
+    },
+    {
+      "id": "lute-string-3",
+      "tx": 58,
+      "ty": 43,
+      "tileId": "feather",
+      "questId": "crownhaven-buskers-strings"
+    },
+    {
+      "id": "tankard-1",
+      "tx": 62,
+      "ty": 43,
+      "tileId": "mugOfCoffee",
+      "questId": "crownhaven-welcome"
+    },
+    {
+      "id": "tankard-2",
+      "tx": 66,
+      "ty": 43,
+      "tileId": "mugOfCoffee",
+      "questId": "crownhaven-welcome"
+    },
+    {
+      "id": "tankard-3",
+      "tx": 70,
+      "ty": 43,
+      "tileId": "mugOfCoffee",
+      "questId": "crownhaven-welcome"
+    },
+    {
+      "id": "provision-1",
+      "tx": 74,
+      "ty": 43,
+      "tileId": "appleBasket",
+      "questId": "crownhaven-feast"
+    },
+    {
+      "id": "provision-2",
+      "tx": 78,
+      "ty": 43,
+      "tileId": "appleBasket",
+      "questId": "crownhaven-feast"
+    },
+    {
+      "id": "provision-3",
+      "tx": 82,
+      "ty": 43,
+      "tileId": "appleBasket",
+      "questId": "crownhaven-feast"
+    },
+    {
+      "id": "provision-4",
+      "tx": 86,
+      "ty": 43,
+      "tileId": "appleBasket",
+      "questId": "crownhaven-feast"
     }
   ],
   "blockedPaths": []


### PR DESCRIPTION
Closes #1736. Part of the hub locations expansion epic #1732.

Brings the realm's capital **Crownhaven** up toward Ravenwatch's richness at **Tier A**, and fixes the two cross-cutting bugs that affect this town (#1733 path-to-door, #1734 interiors). JSON-only — capitalcity was already wired in `hubWorldFactory.ts`.

## What changed
**Map & districts**
- Enlarged map to **1920×1600 (120×100 tiles)** with a connected street grid (full-width bands + full-height avenues, a plaza concourse, and a south-gate apron).
- **6 named districts**: Coronation Plaza, Grand Market, Temple Quarter, Old Town, Guard Quarter, Riverside (with a riverside pond).

**Buildings & interiors (#1734)**
- **17 buildings** (was 4): cathedral, senate, royal mint, grand bank, library, theatre, academy, tailor, jeweller, apothecary, bakery, blacksmith, two noble manors, plus expanded inn / market hall / guard barracks.
- **36 interior rooms**, all furnished and resized (~12×9–14×10). Marquee buildings are **multi-room via linked `exits[]`**: cathedral (nave + crypt + tower), senate (chamber + archive), barracks (hall + armoury + cells), inn (common + upstairs), library (hall + stacks), academy (hall + lecture), bank (lobby + quest-gated vault), and back/store rooms for every shop.
- Relocated the out-of-bounds interior NPCs (`innkeeper-crownhaven`, `market-matron`, `watch-captain-hale`) into valid in-bounds interior coordinates.

**Path-to-door (#1733)**
- Every building's door tile `(rect.x1 + door.tx, rect.y2 + 1)` now sits on a street tile — verified by an automated audit during authoring.

**NPCs & quests**
- **18 NPCs** with schedules + homeBeds (chancellor, high priest, mint-master, banker, archivist, captain + guard, shopkeepers, noble, academy master, busker, herald, innkeeper, market matron).
- **30 quests** across civic, guard, temple, market, scholarly, mint/bank, lost-items and social chains — with `prerequisite` gating and the full reward variety (crystals, friendship, relationship, collectible, card, unlock). Includes **2 cross-town hooks** that deliver to existing Ravenwatch NPCs (#1735) without modifying Ravenwatch.
- 72 quest pickup items, all placed on walkable street tiles.

**Decor**: ~319 exterior decor items clustered by district (fountain, statues, lamps, market stalls, temple/garden greenery, guard braziers/walls, riverside pond & boardwalk).

## Verification
- `cd web && npm run test` → **198 passed** (incl. `loader.test.ts` 11/11). The only error is an environmental Playwright/chromium-download failure for the browser test project, unrelated to this change.
- `cd web && npm run build` → tsc + vite **pass**.
- Authoring-time audits enforced by construction: door→street connectivity, interior NPC/decor in-bounds, schedule/homeBed in-bounds, every `collect` pickup id present, quest giver/receiver/target ids valid (Crownhaven or verified Ravenwatch), prerequisites reference real quests, all `tileId`/`bundleID` values valid.

## Acceptance criteria (#1736)
- [x] Targets met: 17 buildings, 30 quests, ~319 decor, 18 NPCs, 6 areas.
- [x] Every building has a street tile at/in front of its door.
- [x] Interiors Ravenwatch-sized & multi-room; no interior decor/NPC out of bounds (back-wall `ty=-1/-2` excepted).
- [x] All quests reference valid NPCs/pickups; tests + build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kt2NGKtSQRmWSuH1vh16Y5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kt2NGKtSQRmWSuH1vh16Y5)_