### PR TITLE
Hub town expansion: Millhaven (Tier B light top-up) (#1742)

### DIFF
--- a/web/src/data/hub/millhaven/config.json
+++ b/web/src/data/hub/millhaven/config.json
@@ -265,6 +265,42 @@
         7
       ],
       "pathType": "longGrass"
+    },
+    {
+      "comment": "bakery door path (door resolves to 8,6)",
+      "rect": [
+        8,
+        6,
+        8,
+        7
+      ],
+      "pathType": "longGrass"
+    },
+    {
+      "comment": "smithy door path (door resolves to 1,13) connects to street col 3",
+      "rect": [
+        1,
+        13,
+        2,
+        13
+      ]
+    },
+    {
+      "comment": "harbour quay fronting the boathouse (door resolves to 25,5)",
+      "rect": [
+        23,
+        5,
+        29,
+        5
+      ]
+    },
+    {
+      "comment": "cottage door path (door resolves to 3,23) connects to grass path at ty24",
+      "tile": [
+        3,
+        23
+      ],
+      "pathType": "longGrass"
     }
   ],
   "buildings": [
@@ -365,6 +401,86 @@
           "ty": 1,
           "hideSign": true,
           "buildingId": "town-hall-millhaven"
+        }
+      ]
+    },
+    {
+      "id": "bakery",
+      "upgradeKind": "shop",
+      "rect": [
+        6,
+        2,
+        10,
+        5
+      ],
+      "wall": "tudorFrame",
+      "roof": "yellowSlateRoof",
+      "doors": [
+        {
+          "tx": 2,
+          "ty": 1,
+          "hideSign": true,
+          "buildingId": "bakery"
+        }
+      ]
+    },
+    {
+      "id": "smithy",
+      "upgradeKind": "workshop",
+      "rect": [
+        0,
+        9,
+        2,
+        12
+      ],
+      "wall": "castleStone",
+      "roof": "redSlateRoof",
+      "doors": [
+        {
+          "tx": 1,
+          "ty": 1,
+          "hideSign": true,
+          "buildingId": "smithy"
+        }
+      ]
+    },
+    {
+      "id": "boathouse",
+      "upgradeKind": "workshop",
+      "rect": [
+        23,
+        2,
+        28,
+        4
+      ],
+      "wall": "woodenSlats",
+      "roof": "strawRoof",
+      "doors": [
+        {
+          "tx": 2,
+          "ty": 1,
+          "hideSign": true,
+          "buildingId": "boathouse"
+        }
+      ]
+    },
+    {
+      "id": "fisher-cottage",
+      "upgradeKind": "cottage",
+      "rect": [
+        2,
+        19,
+        4,
+        22
+      ],
+      "wall": "renderedBrick",
+      "roof": "redSlateRoof",
+      "doors": [
+        {
+          "tx": 1,
+          "ty": 1,
+          "hideSign": true,
+          "buildingId": "fisher-cottage"
         }
       ]
     }
@@ -935,8 +1051,8 @@
       "zlayer": "solid"
     },
     {
-      "tx": 24,
-      "ty": 4,
+      "tx": 29,
+      "ty": 3,
       "bundleID": "dark-tree-cluster-V",
       "zlayer": "solid"
     },
@@ -947,7 +1063,7 @@
       "zlayer": "solid"
     },
     {
-      "tx": 7,
+      "tx": 12,
       "ty": 4,
       "bundleID": "dark-tree-cluster-V",
       "zlayer": "solid"
@@ -965,8 +1081,8 @@
       "zlayer": "solid"
     },
     {
-      "tx": 1,
-      "ty": 11,
+      "tx": 0,
+      "ty": 18,
       "bundleID": "dark-tree-column-4",
       "zlayer": "solid"
     },
@@ -986,6 +1102,54 @@
       "tx": 22,
       "ty": 9,
       "tileId": "barrel",
+      "zlayer": "solid"
+    },
+    {
+      "comment": "decor around the new bakery"
+    },
+    {
+      "tx": 6,
+      "ty": 6,
+      "tileId": "barrel",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 10,
+      "ty": 6,
+      "tileId": "pileOfSacks",
+      "zlayer": "solid"
+    },
+    {
+      "comment": "decor around the new smithy"
+    },
+    {
+      "tx": 0,
+      "ty": 13,
+      "tileId": "logPile",
+      "zlayer": "solid"
+    },
+    {
+      "comment": "decor on the boathouse quay"
+    },
+    {
+      "tx": 23,
+      "ty": 6,
+      "tileId": "barrel",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 29,
+      "ty": 5,
+      "tileId": "crate",
+      "zlayer": "above"
+    },
+    {
+      "comment": "decor around the fisher cottage"
+    },
+    {
+      "tx": 4,
+      "ty": 23,
+      "tileId": "potOfFlowers",
       "zlayer": "solid"
     }
   ],
@@ -1007,7 +1171,10 @@
         "If you find those sacks, I'll remember the favour."
       ],
       "questGive": "millhaven-mill-grain",
-      "questReceive": "millhaven-mill-grain"
+      "questReceive": "millhaven-mill-grain",
+      "schedule": [
+        { "startHour": 6, "endHour": 20, "activity": "work", "location": { "type": "exterior", "tx": 4, "ty": 7 } }
+      ]
     },
     {
       "id": "fishmonger-marta",
@@ -1021,14 +1188,17 @@
         "Fresh catch, get your fresh catch! Don't let the gulls beat you to it."
       ],
       "questGive": "millhaven-missing-catch",
-      "questReceive": "millhaven-missing-catch"
+      "questReceive": "millhaven-missing-catch",
+      "schedule": [
+        { "startHour": 6, "endHour": 20, "activity": "work", "location": { "type": "exterior", "tx": 23, "ty": 13 } }
+      ]
     },
     {
       "id": "innkeeper-millhaven",
       "name": "Innkeeper Cobb",
       "sprite": "hub-npc-merchant",
-      "tx": 14,
-      "ty": 8,
+      "tx": 3,
+      "ty": 4,
       "dialogue": [
         "Welcome to The Anchor, best beds on the Millhaven coast.",
         "A merchant from Ravenwatch left a letter here. Meant for someone called Elder Elara.",
@@ -1036,14 +1206,19 @@
       ],
       "building": "inn-millhaven",
       "questGive": "millhaven-message-to-ravenwatch",
-      "questReceive": "millhaven-message-to-ravenwatch"
+      "questReceive": "millhaven-message-to-ravenwatch",
+      "schedule": [
+        { "startHour": 0, "endHour": 7, "activity": "sleep", "location": { "type": "interior", "buildingId": "inn-millhaven-upstairs", "tx": 2, "ty": 2 } },
+        { "startHour": 7, "endHour": 24, "activity": "work", "location": { "type": "interior", "buildingId": "inn-millhaven", "tx": 3, "ty": 4 } }
+      ],
+      "homeBed": { "buildingId": "inn-millhaven-upstairs", "tx": 2, "ty": 2 }
     },
     {
       "id": "town-elder-millhaven",
       "name": "Elder Bramwell",
       "sprite": "hub-npc-elder",
-      "tx": 13,
-      "ty": 16,
+      "tx": 6,
+      "ty": 4,
       "dialogue": [
         "Millhaven was founded by fisherfolk. We've kept it that way.",
         "The castle to the south needs resupply. We've been meaning to send a courier.",
@@ -1051,7 +1226,13 @@
       ],
       "building": "town-hall-millhaven",
       "questGive": "millhaven-supplies-for-keep",
-      "questReceive": "millhaven-supplies-for-keep"
+      "questReceive": "millhaven-supplies-for-keep",
+      "schedule": [
+        { "startHour": 0, "endHour": 8, "activity": "sleep", "location": { "type": "interior", "buildingId": "inn-millhaven-upstairs", "tx": 4, "ty": 2 } },
+        { "startHour": 8, "endHour": 18, "activity": "idle-chat", "location": { "type": "interior", "buildingId": "town-hall-millhaven", "tx": 6, "ty": 4 } },
+        { "startHour": 18, "endHour": 24, "activity": "idle-chat", "location": { "type": "exterior", "tx": 16, "ty": 13 } }
+      ],
+      "homeBed": { "buildingId": "inn-millhaven-upstairs", "tx": 4, "ty": 2 }
     },
     {
       "id": "sailor-finn",
@@ -1065,14 +1246,17 @@
         "Marta thinks I'm superstitious. Maybe I am."
       ],
       "questGive": "millhaven-lost-at-sea",
-      "questReceive": "millhaven-missing-catch"
+      "questReceive": "millhaven-missing-catch",
+      "schedule": [
+        { "startHour": 6, "endHour": 20, "activity": "fish", "location": { "type": "exterior", "tx": 32, "ty": 6 } }
+      ]
     },
     {
       "id": "market-trader",
       "name": "Trader Nessa",
       "sprite": "hub-npc-merchant",
-      "tx": 13,
-      "ty": 11,
+      "tx": 6,
+      "ty": 4,
       "dialogue": [
         "Everything from rope to ribbon, if you've got coin.",
         "Trade's been slow. Travellers don't stop here like they used to.",
@@ -1080,177 +1264,322 @@
       ],
       "building": "market-hall",
       "questGive": "millhaven-festival-prep",
-      "questReceive": "millhaven-festival-prep"
+      "questReceive": ["millhaven-festival-prep", "millhaven-market-restock"],
+      "schedule": [
+        { "startHour": 0, "endHour": 8, "activity": "sleep", "location": { "type": "interior", "buildingId": "inn-millhaven-upstairs", "tx": 7, "ty": 2 } },
+        { "startHour": 8, "endHour": 24, "activity": "work", "location": { "type": "interior", "buildingId": "market-hall", "tx": 6, "ty": 4 } }
+      ],
+      "homeBed": { "buildingId": "inn-millhaven-upstairs", "tx": 7, "ty": 2 }
+    },
+    {
+      "id": "baker-pernel",
+      "name": "Baker Pernel",
+      "sprite": "hub-npc-merchant",
+      "tx": 8,
+      "ty": 7,
+      "dialogue": [
+        "Fresh loaves out of the oven — mind, they're still warm.",
+        "Half the town runs on my bread and the other half on Marta's fish.",
+        "If you're passing the docks, folk down there are always after a delivery."
+      ],
+      "questGive": "millhaven-fresh-bread",
+      "questReceive": "millhaven-fresh-bread",
+      "schedule": [
+        { "startHour": 0, "endHour": 6, "activity": "sleep", "location": { "type": "interior", "buildingId": "inn-millhaven-upstairs", "tx": 9, "ty": 2 } },
+        { "startHour": 6, "endHour": 18, "activity": "work", "location": { "type": "interior", "buildingId": "bakery", "tx": 3, "ty": 4 } },
+        { "startHour": 18, "endHour": 24, "activity": "work", "location": { "type": "exterior", "tx": 8, "ty": 7 } }
+      ],
+      "homeBed": { "buildingId": "inn-millhaven-upstairs", "tx": 9, "ty": 2 }
+    },
+    {
+      "id": "smith-garrick",
+      "name": "Smith Garrick",
+      "sprite": "hub-npc-supplies",
+      "tx": 1,
+      "ty": 14,
+      "dialogue": [
+        "Mind the sparks. Forge runs hot this time of day.",
+        "Net hooks, anchor chain, blades — if it's iron, I've hammered it.",
+        "Scrap's been going missing from my yard. A smith can't work without iron."
+      ],
+      "questGive": "millhaven-scrap-iron",
+      "questReceive": "millhaven-scrap-iron",
+      "schedule": [
+        { "startHour": 0, "endHour": 7, "activity": "sleep", "location": { "type": "interior", "buildingId": "smithy", "tx": 8, "ty": 5 } },
+        { "startHour": 7, "endHour": 20, "activity": "work", "location": { "type": "interior", "buildingId": "smithy", "tx": 3, "ty": 4 } },
+        { "startHour": 20, "endHour": 24, "activity": "work", "location": { "type": "exterior", "tx": 1, "ty": 14 } }
+      ],
+      "homeBed": { "buildingId": "smithy", "tx": 8, "ty": 5 }
+    },
+    {
+      "id": "dockhand-bram",
+      "name": "Dockhand Bram",
+      "sprite": "hub-npc-fisherman",
+      "tx": 25,
+      "ty": 6,
+      "dialogue": [
+        "Careful on the boards, they're slick with spray.",
+        "Storm last week dragged half our nets out past the moorings.",
+        "The boathouse keeps the town's boats — and most of its gossip."
+      ],
+      "questGive": "millhaven-lost-nets",
+      "questReceive": "millhaven-lost-nets",
+      "schedule": [
+        { "startHour": 0, "endHour": 6, "activity": "sleep", "location": { "type": "interior", "buildingId": "boathouse", "tx": 8, "ty": 5 } },
+        { "startHour": 6, "endHour": 20, "activity": "work", "location": { "type": "exterior", "tx": 25, "ty": 6 } },
+        { "startHour": 20, "endHour": 24, "activity": "idle-chat", "location": { "type": "interior", "buildingId": "boathouse", "tx": 3, "ty": 4 } }
+      ],
+      "homeBed": { "buildingId": "boathouse", "tx": 8, "ty": 5 }
+    },
+    {
+      "id": "widow-tamsin",
+      "name": "Widow Tamsin",
+      "sprite": "hub-npc-elder",
+      "tx": 4,
+      "ty": 4,
+      "dialogue": [
+        "Forgive the mess. It's just me in this little cottage now.",
+        "I lost my late husband's locket somewhere out in the town. It's all I have of him.",
+        "You have a kind face. Perhaps you'd keep an eye out for it?"
+      ],
+      "building": "fisher-cottage",
+      "questGive": "millhaven-lost-locket",
+      "questReceive": "millhaven-lost-locket",
+      "schedule": [
+        { "startHour": 0, "endHour": 8, "activity": "sleep", "location": { "type": "interior", "buildingId": "fisher-cottage", "tx": 2, "ty": 2 } },
+        { "startHour": 8, "endHour": 24, "activity": "idle-chat", "location": { "type": "interior", "buildingId": "fisher-cottage", "tx": 4, "ty": 4 } }
+      ],
+      "homeBed": { "buildingId": "fisher-cottage", "tx": 2, "ty": 2 }
     }
   ],
   "interiors": {
     "mill": {
       "name": "Hucks Mill",
-      "width": 9,
-      "height": 5,
+      "width": 11,
+      "height": 8,
       "floorTileId": "woodFloor",
       "wallTileId": "woodWall",
       "decor": [
-        {
-          "tx": 1,
-          "ty": 1,
-          "tileId": "barrel"
-        },
-        {
-          "tx": 2,
-          "ty": 1,
-          "tileId": "barrel"
-        },
-        {
-          "tx": 6,
-          "ty": 1,
-          "tileId": "chest"
-        },
-        {
-          "tx": 7,
-          "ty": 1,
-          "tileId": "chest"
-        }
+        { "tx": 1, "ty": 1, "tileId": "barrel" },
+        { "tx": 2, "ty": 1, "tileId": "barrel" },
+        { "tx": 4, "ty": 1, "tileId": "pileOfSacks" },
+        { "tx": 6, "ty": 1, "tileId": "chest" },
+        { "tx": 7, "ty": 1, "tileId": "chest" },
+        { "tx": 1, "ty": 6, "tileId": "sack" },
+        { "tx": 2, "ty": 6, "tileId": "sack" },
+        { "tx": 9, "ty": 6, "tileId": "barrel" }
       ],
       "exits": []
     },
     "fishmonger": {
       "name": "Fresh Fish!",
-      "width": 9,
-      "height": 5,
+      "width": 11,
+      "height": 8,
       "floorTileId": "woodFloor",
       "wallTileId": "woodWall",
       "decor": [
-        {
-          "tx": 1,
-          "ty": 1,
-          "tileId": "barrel"
-        },
-        {
-          "tx": 2,
-          "ty": 1,
-          "tileId": "barrel"
-        },
-        {
-          "tx": 6,
-          "ty": 1,
-          "tileId": "chest"
-        },
-        {
-          "tx": 7,
-          "ty": 1,
-          "tileId": "chest"
-        }
+        { "tx": 1, "ty": 1, "tileId": "barrel" },
+        { "tx": 2, "ty": 1, "tileId": "barrel" },
+        { "tx": 4, "ty": 1, "tileId": "mushroomBasket" },
+        { "tx": 6, "ty": 1, "tileId": "chest" },
+        { "tx": 7, "ty": 1, "tileId": "chest" },
+        { "tx": 1, "ty": 4, "tileId": "counterTopHorizontalLeft" },
+        { "tx": 2, "ty": 4, "tileId": "counterTopHorizontalMiddle" },
+        { "tx": 3, "ty": 4, "tileId": "counterTopHorizontalRight" },
+        { "tx": 9, "ty": 6, "tileId": "emptyBasket" }
       ],
       "exits": []
     },
     "inn-millhaven": {
       "name": "The Anchor Inn",
-      "width": 9,
-      "height": 5,
+      "width": 12,
+      "height": 8,
       "floorTileId": "woodFloor",
       "wallTileId": "woodWall",
+      "musicId": "inn",
+      "ambianceId": "hearth",
       "decor": [
-        {
-          "tx": 1,
-          "ty": 1,
-          "tileId": "barrel"
-        },
-        {
-          "tx": 2,
-          "ty": 1,
-          "tileId": "barrel"
-        },
-        {
-          "tx": 6,
-          "ty": 1,
-          "tileId": "chest"
-        },
-        {
-          "tx": 7,
-          "ty": 1,
-          "tileId": "chest"
-        }
+        { "tx": 1, "ty": 1, "tileId": "stairsUp" },
+        { "tx": 3, "ty": 1, "tileId": "counterTopHorizontalLeft" },
+        { "tx": 4, "ty": 1, "tileId": "counterTopHorizontalMiddle" },
+        { "tx": 5, "ty": 1, "tileId": "counterTopHorizontalRight" },
+        { "tx": 4, "ty": 2, "tileId": "bottlesOfLiquor" },
+        { "tx": 7, "ty": 2, "tileId": "fireplace", "bundleID": "fireplace" },
+        { "tx": 2, "ty": 5, "tileId": "roundTable" },
+        { "tx": 3, "ty": 5, "tileId": "stool" },
+        { "tx": 6, "ty": 5, "tileId": "roundTable" },
+        { "tx": 7, "ty": 5, "tileId": "stool" },
+        { "tx": 10, "ty": 6, "tileId": "barrel" }
       ],
-      "exits": []
+      "exits": [
+        { "tx": 1, "ty": 1, "toInteriorId": "inn-millhaven-upstairs", "entryTx": 1, "entryTy": 6, "direction": "up", "label": "Go upstairs" }
+      ]
+    },
+    "inn-millhaven-upstairs": {
+      "name": "The Anchor Inn (Upstairs)",
+      "width": 12,
+      "height": 9,
+      "floorTileId": "darkWoodFloor",
+      "wallTileId": "woodWall",
+      "musicId": "inn",
+      "ambianceId": "hearth",
+      "decor": [
+        { "tx": 2, "ty": 2, "bundleID": "simple-bed" },
+        { "tx": 4, "ty": 2, "bundleID": "simple-bed" },
+        { "tx": 7, "ty": 2, "bundleID": "simple-bed" },
+        { "tx": 9, "ty": 2, "bundleID": "simple-bed" },
+        { "tx": 5, "ty": 5, "tileId": "roundTable" },
+        { "tx": 6, "ty": 5, "tileId": "roundTable" },
+        { "tx": 1, "ty": 7, "tileId": "ladderIntoFloor", "zlayer": "below" },
+        { "tx": 1, "ty": 6, "tileId": "halfLadderTop", "zlayer": "solid" }
+      ],
+      "exits": [
+        { "tx": 1, "ty": 7, "toInteriorId": "inn-millhaven", "entryTx": 1, "entryTy": 2, "direction": "down", "label": "Go downstairs" }
+      ]
     },
     "market-hall": {
       "name": "Market Hall",
       "width": 12,
-      "height": 3,
+      "height": 8,
       "floorTileId": "woodFloor",
       "wallTileId": "woodenSlats",
+      "musicId": "shop",
+      "ambianceId": "market",
       "decor": [
-        {
-          "tx": 1,
-          "ty": 1,
-          "tileId": "crate"
-        },
-        {
-          "tx": 2,
-          "ty": 1,
-          "tileId": "openCrate"
-        },
-        {
-          "tx": 9,
-          "ty": 1,
-          "tileId": "crate"
-        },
-        {
-          "tx": 10,
-          "ty": 1,
-          "tileId": "openCrate"
-        }
+        { "tx": 1, "ty": 1, "tileId": "crate" },
+        { "tx": 2, "ty": 1, "tileId": "openCrate" },
+        { "tx": 9, "ty": 1, "tileId": "crate" },
+        { "tx": 10, "ty": 1, "tileId": "openCrate" },
+        { "tx": 1, "ty": 4, "tileId": "counterTopHorizontalLeft" },
+        { "tx": 2, "ty": 4, "tileId": "counterTopHorizontalMiddle" },
+        { "tx": 3, "ty": 4, "tileId": "counterTopHorizontalRight" },
+        { "tx": 8, "ty": 4, "tileId": "appleBasket" },
+        { "tx": 10, "ty": 5, "tileId": "barrel" },
+        { "tx": 1, "ty": 6, "tileId": "pileOfSacks" }
       ],
       "exits": []
     },
     "town-hall-millhaven": {
       "name": "Millhaven Town Hall",
-      "width": 8,
-      "height": 4,
+      "width": 12,
+      "height": 8,
       "floorTileId": "cobblestoneFloor",
       "wallTileId": "renderedBrick",
       "decor": [
-        {
-          "tx": 1,
-          "ty": 1,
-          "tileId": "bookshelfTop"
-        },
-        {
-          "tx": 2,
-          "ty": 1,
-          "tileId": "bookshelfTop"
-        },
-        {
-          "tx": 1,
-          "ty": 2,
-          "tileId": "bookshelfBottom"
-        },
-        {
-          "tx": 2,
-          "ty": 2,
-          "tileId": "bookshelfBottom"
-        },
-        {
-          "tx": 5,
-          "ty": 1,
-          "tileId": "bookshelfTop"
-        },
-        {
-          "tx": 6,
-          "ty": 1,
-          "tileId": "bookshelfTop"
-        },
-        {
-          "tx": 5,
-          "ty": 2,
-          "tileId": "bookshelfBottom"
-        },
-        {
-          "tx": 6,
-          "ty": 2,
-          "tileId": "bookshelfBottom"
-        }
+        { "tx": 1, "ty": 1, "tileId": "bookshelfTop" },
+        { "tx": 2, "ty": 1, "tileId": "bookshelfTop" },
+        { "tx": 1, "ty": 2, "tileId": "bookshelfBottom" },
+        { "tx": 2, "ty": 2, "tileId": "bookshelfBottom" },
+        { "tx": 9, "ty": 1, "tileId": "bookshelfTop" },
+        { "tx": 10, "ty": 1, "tileId": "bookshelfTop" },
+        { "tx": 9, "ty": 2, "tileId": "bookshelfBottom" },
+        { "tx": 10, "ty": 2, "tileId": "bookshelfBottom" },
+        { "tx": 5, "ty": 4, "tileId": "roundTable" },
+        { "tx": 6, "ty": 4, "tileId": "roundTable" },
+        { "tx": 5, "ty": 5, "tileId": "stool" },
+        { "tx": 6, "ty": 5, "tileId": "stool" },
+        { "tx": 11, "ty": 1, "tileId": "stairsUp" }
+      ],
+      "exits": [
+        { "tx": 11, "ty": 1, "toInteriorId": "town-hall-millhaven-office", "entryTx": 1, "entryTy": 6, "direction": "up", "label": "Back office" }
+      ]
+    },
+    "town-hall-millhaven-office": {
+      "name": "Town Hall Office",
+      "width": 10,
+      "height": 8,
+      "floorTileId": "cobblestoneFloor",
+      "wallTileId": "renderedBrick",
+      "decor": [
+        { "tx": 2, "ty": 1, "tileId": "deskTop" },
+        { "tx": 3, "ty": 1, "tileId": "quilAndInk" },
+        { "tx": 4, "ty": 1, "tileId": "pileOfPapers" },
+        { "tx": 7, "ty": 1, "tileId": "bookshelfTop" },
+        { "tx": 8, "ty": 1, "tileId": "bookshelfTop" },
+        { "tx": 7, "ty": 2, "tileId": "bookshelfBottom" },
+        { "tx": 8, "ty": 2, "tileId": "bookshelfBottom" },
+        { "tx": 2, "ty": 4, "tileId": "chest" },
+        { "tx": 4, "ty": 4, "tileId": "stool" },
+        { "tx": 1, "ty": 6, "tileId": "ladderIntoFloor", "zlayer": "below" },
+        { "tx": 1, "ty": 5, "tileId": "halfLadderTop", "zlayer": "solid" }
+      ],
+      "exits": [
+        { "tx": 1, "ty": 6, "toInteriorId": "town-hall-millhaven", "entryTx": 11, "entryTy": 1, "direction": "down", "label": "Return to chamber" }
+      ]
+    },
+    "bakery": {
+      "name": "Millhaven Bakery",
+      "width": 11,
+      "height": 8,
+      "floorTileId": "stoneFloor",
+      "wallTileId": "woodWall",
+      "musicId": "shop",
+      "ambianceId": "hearth",
+      "decor": [
+        { "tx": 1, "ty": 1, "tileId": "fireplace", "bundleID": "fireplace" },
+        { "tx": 5, "ty": 1, "tileId": "counterTopHorizontalLeft" },
+        { "tx": 6, "ty": 1, "tileId": "counterTopHorizontalMiddle" },
+        { "tx": 7, "ty": 1, "tileId": "counterTopHorizontalRight" },
+        { "tx": 9, "ty": 1, "tileId": "pileOfSacks" },
+        { "tx": 9, "ty": 2, "tileId": "sack" },
+        { "tx": 6, "ty": 4, "tileId": "appleBasket" },
+        { "tx": 8, "ty": 4, "tileId": "plateEmpty" },
+        { "tx": 1, "ty": 6, "tileId": "barrel" }
+      ],
+      "exits": []
+    },
+    "smithy": {
+      "name": "Garrick's Forge",
+      "width": 11,
+      "height": 8,
+      "floorTileId": "stoneFloor",
+      "wallTileId": "woodenSlats",
+      "decor": [
+        { "tx": 1, "ty": 1, "tileId": "fireplace", "bundleID": "fireplace" },
+        { "tx": 4, "ty": 1, "tileId": "brazierTop" },
+        { "tx": 4, "ty": 2, "tileId": "brazierBottom" },
+        { "tx": 6, "ty": 1, "tileId": "choppingBlock" },
+        { "tx": 7, "ty": 1, "tileId": "logPile" },
+        { "tx": 9, "ty": 1, "tileId": "crate" },
+        { "tx": 2, "ty": 4, "tileId": "shieldMounted" },
+        { "tx": 9, "ty": 6, "tileId": "barrel" },
+        { "tx": 8, "ty": 5, "bundleID": "simple-bed" }
+      ],
+      "exits": []
+    },
+    "boathouse": {
+      "name": "Millhaven Boathouse",
+      "width": 11,
+      "height": 8,
+      "floorTileId": "woodFloor",
+      "wallTileId": "woodenSlats",
+      "decor": [
+        { "tx": 1, "ty": 1, "tileId": "barrel" },
+        { "tx": 2, "ty": 1, "tileId": "barrel" },
+        { "tx": 4, "ty": 1, "tileId": "mushroomBasket" },
+        { "tx": 5, "ty": 1, "tileId": "mushroomBasket" },
+        { "tx": 7, "ty": 1, "tileId": "crate" },
+        { "tx": 3, "ty": 4, "tileId": "rolledMap" },
+        { "tx": 5, "ty": 4, "tileId": "fishingHook" },
+        { "tx": 9, "ty": 6, "tileId": "pileOfSacks" },
+        { "tx": 8, "ty": 5, "bundleID": "simple-bed" }
+      ],
+      "exits": []
+    },
+    "fisher-cottage": {
+      "name": "Tamsin's Cottage",
+      "width": 10,
+      "height": 8,
+      "floorTileId": "woodFloor",
+      "wallTileId": "woodWall",
+      "decor": [
+        { "tx": 2, "ty": 2, "bundleID": "simple-bed" },
+        { "tx": 7, "ty": 1, "tileId": "bookshelfTop" },
+        { "tx": 7, "ty": 2, "tileId": "bookshelfBottom" },
+        { "tx": 5, "ty": 5, "tileId": "roundTable" },
+        { "tx": 4, "ty": 5, "tileId": "stool" },
+        { "tx": 1, "ty": 6, "tileId": "potOfFlowers" },
+        { "tx": 8, "ty": 6, "tileId": "candlestickLitBottom" }
       ],
       "exits": []
     }

--- a/web/src/data/hub/millhaven/questDefs.json
+++ b/web/src/data/hub/millhaven/questDefs.json
@@ -321,6 +321,250 @@
           "desc": "Proof that you finally understood a very particular cat."
         }
       }
+    },
+    {
+      "id": "millhaven-fresh-bread",
+      "title": "Warm from the Oven",
+      "type": "chain",
+      "giverNpcId": "baker-pernel",
+      "receiverNpcId": "dockhand-bram",
+      "offerDialogue": "Two baskets of fresh loaves are cooling on the racks — gather them up for me, would you? Then run them down to Bram at the boathouse. The dock crew works through their lunch and they'll thank you for it.",
+      "activeDialogue": {
+        "loaf": "The two bread baskets are still about the bakery and market. Mind they're warm.",
+        "deliver": "Both baskets gathered — now take them to Dockhand Bram at the boathouse."
+      },
+      "completeDialogue": "Pernel's loaves! You're a lifesaver — the lads were about to gnaw the mooring rope. Here, a little something for the legs you wore out.",
+      "steps": [
+        {
+          "key": "loaf",
+          "type": "collect",
+          "pickupIds": [
+            "fresh-loaf-1",
+            "fresh-loaf-2"
+          ],
+          "required": 2
+        },
+        {
+          "key": "deliver",
+          "type": "deliver",
+          "targetNpcId": "dockhand-bram",
+          "required": 1
+        }
+      ],
+      "reward": {
+        "crystals": 45,
+        "friendship": {
+          "baker-pernel": 15,
+          "dockhand-bram": 10
+        }
+      }
+    },
+    {
+      "id": "millhaven-scrap-iron",
+      "title": "Scrap for the Forge",
+      "type": "fetch",
+      "giverNpcId": "smith-garrick",
+      "receiverNpcId": "smith-garrick",
+      "offerDialogue": "Someone's been pinching offcuts from my yard — three good lumps of scrap iron, scattered who-knows-where. Bring them back and I can keep the anchor chains coming.",
+      "activeDialogue": "Three lumps of scrap iron, somewhere about the town and the docks. Have a hunt.",
+      "completeDialogue": "All three, and good iron too. That'll keep the forge fed a week. Take this for your trouble — and your sore back.",
+      "steps": [
+        {
+          "key": "scrap",
+          "type": "collect",
+          "pickupIds": [
+            "scrap-iron-1",
+            "scrap-iron-2",
+            "scrap-iron-3"
+          ],
+          "required": 3
+        }
+      ],
+      "reward": {
+        "crystals": 45
+      }
+    },
+    {
+      "id": "millhaven-lost-nets",
+      "title": "Nets on the Tide",
+      "type": "fetch",
+      "giverNpcId": "dockhand-bram",
+      "receiverNpcId": "dockhand-bram",
+      "offerDialogue": "The storm dragged two of our good nets off the moorings. They'll have snagged somewhere along the waterfront. Fish them out before the gulls do?",
+      "activeDialogue": "Two fishing nets, tangled somewhere along the docks and quay. Bring them back to the boathouse.",
+      "completeDialogue": "Both of them, and barely a tear! You've saved us a week's mending. The Millhaven docks owe you one.",
+      "steps": [
+        {
+          "key": "nets",
+          "type": "collect",
+          "pickupIds": [
+            "lost-net-1",
+            "lost-net-2"
+          ],
+          "required": 2
+        }
+      ],
+      "reward": {
+        "crystals": 40,
+        "friendship": {
+          "dockhand-bram": 15
+        }
+      }
+    },
+    {
+      "id": "millhaven-lost-locket",
+      "title": "Tamsin's Locket",
+      "type": "lost-items",
+      "giverNpcId": "widow-tamsin",
+      "receiverNpcId": "widow-tamsin",
+      "offerDialogue": "I dropped my late husband's locket somewhere out in the town — silver, with an anchor etched on the back. I'd search myself, but these old knees won't carry me far. Would you look for me?",
+      "activeDialogue": "A silver locket with an anchor on it, lost somewhere about Millhaven. Bless you for looking.",
+      "completeDialogue": "Oh — oh, that's it! That's the one! You've given me back more than a trinket, traveller. Take this, and my heartfelt thanks.",
+      "steps": [
+        {
+          "key": "locket",
+          "type": "collect",
+          "pickupIds": [
+            "tamsin-locket"
+          ],
+          "required": 1
+        }
+      ],
+      "reward": {
+        "crystals": 50,
+        "collectible": {
+          "id": "anchor-locket",
+          "name": "Anchor Locket",
+          "icon": "🔱",
+          "desc": "A silver locket etched with an anchor — returned to a grateful widow."
+        }
+      }
+    },
+    {
+      "id": "millhaven-herring-for-palace",
+      "title": "Herring for the Palace",
+      "type": "fetch",
+      "giverNpcId": "fishmonger-marta",
+      "receiverNpcId": "royal-steward",
+      "prerequisite": "quest:millhaven-missing-catch",
+      "offerDialogue": "Word came from the Royal Palace — the kitchens want a crate of Millhaven smoked herring for a banquet. There's no finer fish on the coast. Carry it to Steward Marigold at the palace and we'll all stand a little taller for it.",
+      "activeDialogue": "The crate of smoked herring is bound for Steward Marigold at the Royal Palace. She'll know what to do with it.",
+      "completeDialogue": "Millhaven herring? Splendid — the head cook will be delighted, and so will Her Highness. The coast's reputation is safe with fish like this. My thanks to Marta.",
+      "steps": [
+        {
+          "key": "deliver",
+          "type": "deliver",
+          "targetNpcId": "royal-steward",
+          "required": 1
+        }
+      ],
+      "reward": {
+        "crystals": 90,
+        "friendship": {
+          "fishmonger-marta": 20
+        }
+      }
+    },
+    {
+      "id": "millhaven-fresh-produce-ravenwatch",
+      "title": "Produce for Ravenwatch",
+      "type": "fetch",
+      "giverNpcId": "market-trader",
+      "receiverNpcId": "merchant",
+      "prerequisite": "quest:millhaven-festival-prep",
+      "offerDialogue": "Vex the Merchant over in Ravenwatch put in a standing order — a basket of Millhaven's best produce, fresh as I can manage. If you're travelling that way, carry it for me? A good word from Vex opens a lot of doors.",
+      "activeDialogue": "The produce basket is for Vex the Merchant in Ravenwatch. Best deliver it before it wilts.",
+      "completeDialogue": "Straight from Millhaven, and still crisp! Nessa always did send the finest. Tell her Vex says the order stands — and here's your cut for the legwork.",
+      "steps": [
+        {
+          "key": "deliver",
+          "type": "deliver",
+          "targetNpcId": "merchant",
+          "required": 1
+        }
+      ],
+      "reward": {
+        "crystals": 80,
+        "friendship": {
+          "market-trader": 15
+        }
+      }
+    },
+    {
+      "id": "millhaven-kipper-tells-princess",
+      "title": "A Message from a Happy Cat",
+      "type": "fetch",
+      "giverNpcId": "kipper",
+      "receiverNpcId": "royal-steward",
+      "prerequisite": "quest:kipper-true-wish",
+      "offerDialogue": "Mrrp! (Now that you finally understand me: tell the Princess I am happy — truly happy — and that she may keep every last kipper. Carry my purr to the palace, would you?)",
+      "activeDialogue": "Kipper's message of contentment is for the Royal Palace. Steward Marigold can pass it to the Princess.",
+      "completeDialogue": "A message from the Princess's lost cat — that he is happy, and forgives the fish? She will be overjoyed to hear it. You've done a kind thing today, traveller. Her Highness shall know of it.",
+      "steps": [
+        {
+          "key": "deliver",
+          "type": "deliver",
+          "targetNpcId": "royal-steward",
+          "required": 1
+        }
+      ],
+      "reward": {
+        "crystals": 70,
+        "collectible": {
+          "id": "princess-thanks",
+          "name": "Royal Thanks",
+          "icon": "👑",
+          "desc": "The Princess's gratitude for word of her contented cat."
+        }
+      }
+    },
+    {
+      "id": "millhaven-market-restock",
+      "title": "Restocking the Stall",
+      "type": "chain",
+      "giverNpcId": "market-trader",
+      "receiverNpcId": "market-trader",
+      "offerDialogue": "Trade's picking up and my shelves are bare. Help me restock: a barrel from the harbour, a sack from the mill, and a crate from the market store — in that order, mind, or I'll lose track of my tally.",
+      "activeDialogue": {
+        "barrel": "First the harbour barrel — should be down by the quay.",
+        "sack": "Good. Now a grain sack from up by the mill.",
+        "crate": "Almost stocked. Last is a crate from the market store."
+      },
+      "completeDialogue": "Barrel, sack and crate — the stall's full again! Custom will follow. Here's your share of the first day's takings.",
+      "steps": [
+        {
+          "key": "barrel",
+          "type": "collect",
+          "pickupIds": [
+            "restock-barrel"
+          ],
+          "required": 1
+        },
+        {
+          "key": "sack",
+          "type": "collect",
+          "pickupIds": [
+            "restock-sack"
+          ],
+          "required": 1,
+          "chain": "restock-barrel"
+        },
+        {
+          "key": "crate",
+          "type": "collect",
+          "pickupIds": [
+            "restock-crate"
+          ],
+          "required": 1,
+          "chain": "restock-sack"
+        }
+      ],
+      "reward": {
+        "crystals": 55,
+        "friendship": {
+          "market-trader": 15
+        }
+      }
     }
   ],
   "pickupItems": [
@@ -368,8 +612,8 @@
     },
     {
       "id": "festival-ribbon",
-      "tx": 12,
-      "ty": 5,
+      "tx": 9,
+      "ty": 2,
       "tileId": "gift",
       "questId": "millhaven-festival-prep",
       "building": "inn-millhaven"
@@ -421,6 +665,85 @@
       "tileId": "toy",
       "zlayer": "below",
       "questId": "kipper-true-wish"
+    },
+    {
+      "id": "fresh-loaf-1",
+      "tx": 10,
+      "ty": 8,
+      "tileId": "appleBasket",
+      "questId": "millhaven-fresh-bread"
+    },
+    {
+      "id": "fresh-loaf-2",
+      "tx": 16,
+      "ty": 11,
+      "tileId": "appleBasket",
+      "questId": "millhaven-fresh-bread"
+    },
+    {
+      "id": "scrap-iron-1",
+      "tx": 31,
+      "ty": 7,
+      "tileId": "axe",
+      "questId": "millhaven-scrap-iron"
+    },
+    {
+      "id": "scrap-iron-2",
+      "tx": 28,
+      "ty": 15,
+      "tileId": "axe",
+      "questId": "millhaven-scrap-iron"
+    },
+    {
+      "id": "scrap-iron-3",
+      "tx": 15,
+      "ty": 14,
+      "tileId": "axe",
+      "questId": "millhaven-scrap-iron"
+    },
+    {
+      "id": "lost-net-1",
+      "tx": 31,
+      "ty": 11,
+      "tileId": "cotton",
+      "questId": "millhaven-lost-nets"
+    },
+    {
+      "id": "lost-net-2",
+      "tx": 27,
+      "ty": 23,
+      "tileId": "cotton",
+      "questId": "millhaven-lost-nets"
+    },
+    {
+      "id": "tamsin-locket",
+      "tx": 16,
+      "ty": 15,
+      "tileId": "goldNecklace",
+      "questId": "millhaven-lost-locket"
+    },
+    {
+      "id": "restock-barrel",
+      "tx": 24,
+      "ty": 5,
+      "tileId": "barrel",
+      "questId": "millhaven-market-restock"
+    },
+    {
+      "id": "restock-sack",
+      "tx": 8,
+      "ty": 7,
+      "tileId": "sack",
+      "questId": "millhaven-market-restock",
+      "chain": "restock-barrel"
+    },
+    {
+      "id": "restock-crate",
+      "tx": 18,
+      "ty": 16,
+      "tileId": "crate",
+      "questId": "millhaven-market-restock",
+      "chain": "restock-sack"
     }
   ],
   "blockedPaths": [],


### PR DESCRIPTION
Closes #1742. Part of epic #1732.

Brings Millhaven — already the strongest non-Ravenwatch town — up toward the gold standard with a **light top-up**, leaving the existing content (incl. the Kipper saga) intact. All changes are JSON-only in `web/src/data/hub/millhaven/{config.json,questDefs.json}` (the town is already wired in `hubWorldFactory.ts`).

## What changed

**Buildings 5 → 9**
- New **bakery**, **smithy**, **boathouse** and a **fisher cottage**, each with a furnished interior and a street tile placed at its front door (door→street rule, #1733). Placed in clean map pockets; three colliding trees relocated.

**Interiors — sizing & in-bounds placement (#1734)**
- `market-hall` resized **12×3 → 12×8** (its `market-trader` was at OOB local (13,11)); `inn-millhaven` and `town-hall-millhaven` → ~12×8; `mill`/`fishmonger` → 11×8.
- The three out-of-bounds interior NPCs (`market-trader`, `innkeeper-millhaven`, `town-elder-millhaven`) relocated in-bounds.
- Inn `festival-ribbon` pickup moved in-bounds.

**Linked rooms (#1734)**
- Inn ⇄ **upstairs bunkrooms** and town hall ⇄ **back office**, via reciprocal interior `exits` (stairs/ladder). Sub-room ids prefixed by their parent building for level inheritance.

**NPCs 6 → 10**
- Added **baker**, **smith**, **dockhand** and a **cottage widow**, each a quest giver/receiver with a day/night `schedule` + `homeBed`; added light activity schedules to the existing NPCs.

**Quests 11 → 19**
- Local: bakery delivery chain, smithy scrap-iron fetch, harbour lost-nets fetch, a lost-locket (`lost-items`), and a market restock chain.
- Cross-town hooks (#1735): smoked **herring to the Royal Palace** (`royal-steward`), a happy-cat **message to the Palace** deepening the Kipper saga (gated on `kipper-true-wish`), and fresh **produce to Ravenwatch** (`merchant`). These route purely via quest `targetNpcId`/`receiverNpcId`, so no other town's files are touched.
- Modest decor around the new buildings.

## Verification
- `npm run test` — **198/198 pass** (incl. `loader.test.ts`, which parses every town config). The one reported error is a missing Playwright browser binary, unrelated to these changes.
- `npm run build` — **passes** (tsc + vite).
- Script-validated by construction: all 9 building doors resolve onto a street tile; no building rects overlap; all interior NPCs/pickups are within their room bounds; interior exits are reciprocal and resolve; every quest giver/receiver/deliver-target id resolves (incl. cross-town `royal-steward` and `merchant`); all exterior quest pickups sit on/adjacent to a walkable tile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ULijjggBX76o4RPjGLESU9)_