### PR TITLE
Millhaven follow-up: 6-row buildings, boathouse path fix, screen-linked NPCs

### DIFF
--- a/web/public/sprites/hub-npc-harbourmaster.svg
+++ b/web/public/sprites/hub-npc-harbourmaster.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Navy harbourmaster coat -->
+  <rect x="11" y="14" width="10" height="11" rx="2" fill="#1f3a5a"/>
+  <!-- Coat buttons -->
+  <circle cx="16" cy="17" r="0.8" fill="#d4b24a"/>
+  <circle cx="16" cy="20" r="0.8" fill="#d4b24a"/>
+  <circle cx="16" cy="23" r="0.8" fill="#d4b24a"/>
+  <!-- Head -->
+  <circle cx="16" cy="10" r="5" fill="#c8a07a"/>
+  <!-- Captain's cap brim -->
+  <ellipse cx="16" cy="7" rx="7" ry="1.8" fill="#0f2336"/>
+  <!-- Cap crown -->
+  <rect x="11" y="3" width="10" height="4" rx="1.5" fill="#16314c"/>
+  <!-- Cap badge -->
+  <rect x="14.5" y="4" width="3" height="2" rx="0.5" fill="#d4b24a"/>
+  <!-- Eyes -->
+  <circle cx="14" cy="10" r="1" fill="#3a2a1a"/>
+  <circle cx="18" cy="10" r="1" fill="#3a2a1a"/>
+  <!-- Grey beard -->
+  <ellipse cx="16" cy="14" rx="3.5" ry="2" fill="#d8d8c8"/>
+  <!-- Spyglass (right hand) -->
+  <rect x="21" y="14" width="8" height="2.4" rx="1" fill="#6a4a2a" transform="rotate(-18 21 15)"/>
+  <!-- Legs -->
+  <rect x="12" y="24" width="4" height="6" rx="1" fill="#13283f"/>
+  <rect x="17" y="24" width="4" height="6" rx="1" fill="#13283f"/>
+  <!-- Boots -->
+  <rect x="11" y="28" width="5" height="3" rx="1" fill="#2a1a0a"/>
+  <rect x="16" y="28" width="5" height="3" rx="1" fill="#2a1a0a"/>
+</svg>

--- a/web/src/data/hub/millhaven/config.json
+++ b/web/src/data/hub/millhaven/config.json
@@ -79,9 +79,28 @@
       ]
     },
     {
+      "comment": "east sea, split to leave room for the boathouse footprint (cols 33-36, rows 12-17)",
       "rect": [
         36,
         0,
+        37,
+        11
+      ],
+      "pathType": "water1"
+    },
+    {
+      "rect": [
+        37,
+        12,
+        37,
+        17
+      ],
+      "pathType": "water1"
+    },
+    {
+      "rect": [
+        36,
+        18,
         37,
         28
       ],
@@ -92,14 +111,14 @@
         35,
         2,
         35,
-        12
+        11
       ],
       "pathType": "water1"
     },
     {
       "rect": [
         35,
-        18,
+        19,
         35,
         25
       ],
@@ -267,16 +286,6 @@
       "pathType": "longGrass"
     },
     {
-      "comment": "bakery door path (door resolves to 8,6)",
-      "rect": [
-        8,
-        6,
-        8,
-        7
-      ],
-      "pathType": "longGrass"
-    },
-    {
       "comment": "smithy door path (door resolves to 1,13) connects to street col 3",
       "rect": [
         1,
@@ -286,12 +295,12 @@
       ]
     },
     {
-      "comment": "harbour quay fronting the boathouse (door resolves to 25,5)",
+      "comment": "boathouse pier (door resolves to 34,18) connects west to the dock walkway at col 32",
       "rect": [
-        23,
-        5,
-        29,
-        5
+        33,
+        18,
+        34,
+        18
       ]
     },
     {
@@ -411,7 +420,7 @@
         6,
         2,
         10,
-        5
+        7
       ],
       "wall": "tudorFrame",
       "roof": "yellowSlateRoof",
@@ -429,7 +438,7 @@
       "upgradeKind": "workshop",
       "rect": [
         0,
-        9,
+        7,
         2,
         12
       ],
@@ -448,16 +457,16 @@
       "id": "boathouse",
       "upgradeKind": "workshop",
       "rect": [
-        23,
-        2,
-        28,
-        4
+        33,
+        12,
+        36,
+        17
       ],
       "wall": "woodenSlats",
       "roof": "strawRoof",
       "doors": [
         {
-          "tx": 2,
+          "tx": 1,
           "ty": 1,
           "hideSign": true,
           "buildingId": "boathouse"
@@ -469,7 +478,7 @@
       "upgradeKind": "cottage",
       "rect": [
         2,
-        19,
+        17,
         4,
         22
       ],
@@ -500,13 +509,13 @@
       "tileId": "smallRock"
     },
     {
-      "tx": 2,
-      "ty": 7,
+      "tx": 24,
+      "ty": 5,
       "tileId": "barrel"
     },
     {
-      "tx": 1,
-      "ty": 7,
+      "tx": 25,
+      "ty": 5,
       "tileId": "barrel"
     },
     {
@@ -1015,7 +1024,7 @@
       "zlayer": "above"
     },
     {
-      "tx": 6,
+      "tx": 5,
       "ty": 7,
       "bundleID": "mixed-tree-cluster-V",
       "zlayer": "solid"
@@ -1039,8 +1048,8 @@
       "zlayer": "solid"
     },
     {
-      "tx": 2,
-      "ty": 18,
+      "tx": 0,
+      "ty": 22,
       "bundleID": "dark-tree-cluster-V",
       "zlayer": "solid"
     },
@@ -1102,21 +1111,6 @@
       "tx": 22,
       "ty": 9,
       "tileId": "barrel",
-      "zlayer": "solid"
-    },
-    {
-      "comment": "decor around the new bakery"
-    },
-    {
-      "tx": 6,
-      "ty": 6,
-      "tileId": "barrel",
-      "zlayer": "solid"
-    },
-    {
-      "tx": 10,
-      "ty": 6,
-      "tileId": "pileOfSacks",
       "zlayer": "solid"
     },
     {
@@ -1315,8 +1309,8 @@
       "id": "dockhand-bram",
       "name": "Dockhand Bram",
       "sprite": "hub-npc-fisherman",
-      "tx": 25,
-      "ty": 6,
+      "tx": 33,
+      "ty": 19,
       "dialogue": [
         "Careful on the boards, they're slick with spray.",
         "Storm last week dragged half our nets out past the moorings.",
@@ -1326,7 +1320,7 @@
       "questReceive": "millhaven-lost-nets",
       "schedule": [
         { "startHour": 0, "endHour": 6, "activity": "sleep", "location": { "type": "interior", "buildingId": "boathouse", "tx": 8, "ty": 5 } },
-        { "startHour": 6, "endHour": 20, "activity": "work", "location": { "type": "exterior", "tx": 25, "ty": 6 } },
+        { "startHour": 6, "endHour": 20, "activity": "work", "location": { "type": "exterior", "tx": 33, "ty": 19 } },
         { "startHour": 20, "endHour": 24, "activity": "idle-chat", "location": { "type": "interior", "buildingId": "boathouse", "tx": 3, "ty": 4 } }
       ],
       "homeBed": { "buildingId": "boathouse", "tx": 8, "ty": 5 }
@@ -1350,6 +1344,57 @@
         { "startHour": 8, "endHour": 24, "activity": "idle-chat", "location": { "type": "interior", "buildingId": "fisher-cottage", "tx": 4, "ty": 4 } }
       ],
       "homeBed": { "buildingId": "fisher-cottage", "tx": 2, "ty": 2 }
+    },
+    {
+      "id": "harbour-angler",
+      "name": "Old Pellan",
+      "sprite": "hub-npc-fisherman",
+      "tx": 31,
+      "ty": 11,
+      "dialogue": [
+        "Best fishing on the coast, right off this dock.",
+        "Cast a line with me — the harbour's always biting.",
+        "Patience and a steady hand, that's all it takes."
+      ],
+      "screen": "fishing"
+    },
+    {
+      "id": "quartermaster-millhaven",
+      "name": "Quartermaster Hale",
+      "sprite": "hub-npc-supplies",
+      "tx": 21,
+      "ty": 13,
+      "dialogue": [
+        "Potions, provisions, the lot — stocked fresh off the boats.",
+        "A traveller far from home still needs to resupply. Take a look.",
+        "Coin for goods, that's the honest trade of Millhaven."
+      ],
+      "screen": "shop-supplies"
+    },
+    {
+      "id": "card-trader-millhaven",
+      "name": "Dealer Sloane",
+      "sprite": "hub-npc-card-shop",
+      "tx": 20,
+      "ty": 16,
+      "dialogue": [
+        "Cards! Rare cards, off the trade ships and into your deck.",
+        "No need to trek back to Ravenwatch — I deal right here.",
+        "Browse the wares, friend. Every deck needs an edge."
+      ],
+      "screen": "shop-cards"
+    },
+    {
+      "id": "regatta-master",
+      "name": "Regatta Master Coll",
+      "sprite": "hub-npc-harbourmaster",
+      "tx": 34,
+      "ty": 19,
+      "dialogue": [
+        "One day Millhaven will host a proper boat regatta — skiffs racing the harbour buoys, crowds on the quay!",
+        "I'm still rigging the course and finding crews. Come back soon and you'll be able to race.",
+        "Mark my words: the Millhaven Regatta will be the finest sport on the coast."
+      ]
     }
   ],
   "interiors": {

--- a/web/src/data/hub/millhaven/questDefs.json
+++ b/web/src/data/hub/millhaven/questDefs.json
@@ -577,15 +577,15 @@
     },
     {
       "id": "grain-sack-2",
-      "tx": 33,
-      "ty": 16,
+      "tx": 31,
+      "ty": 17,
       "tileId": "sack",
       "questId": "millhaven-mill-grain"
     },
     {
       "id": "grain-sack-3",
-      "tx": 10,
-      "ty": 7,
+      "tx": 9,
+      "ty": 8,
       "tileId": "sack",
       "questId": "millhaven-mill-grain"
     },
@@ -598,8 +598,8 @@
     },
     {
       "id": "fish-basket-2",
-      "tx": 33,
-      "ty": 14,
+      "tx": 31,
+      "ty": 12,
       "tileId": "mushroomBasket",
       "questId": "millhaven-missing-catch"
     },
@@ -724,15 +724,15 @@
     },
     {
       "id": "restock-barrel",
-      "tx": 24,
-      "ty": 5,
+      "tx": 32,
+      "ty": 11,
       "tileId": "barrel",
       "questId": "millhaven-market-restock"
     },
     {
       "id": "restock-sack",
-      "tx": 8,
-      "ty": 7,
+      "tx": 3,
+      "ty": 9,
       "tileId": "sack",
       "questId": "millhaven-market-restock",
       "chain": "restock-barrel"


### PR DESCRIPTION
Follow-up to the merged Millhaven expansion (#1742, #1749), addressing the learnings raised on #1732 and acting on the epic's in-scope directions. JSON-only in the two Millhaven data files, plus one new sprite.

## Fixes
- **Buildings now ≥ 6 rows tall** (the [learning recorded on #1732](https://github.com/Jarvichi/jarvs-amazing-web-game/issues/1732#issuecomment-4762074499) — shorter buildings can't render walls + roof). `bakery`, `smithy` and `fisher-cottage` grown in place to 6 rows; `boathouse` relocated to the east harbour shore (`[33,12,36,17]`), carving the few sea tiles under its footprint. Decor/pickups the larger footprints covered were relocated.
- **Boathouse is now reachable.** The old quay was an isolated street segment (the bug you spotted). The boathouse now sits on a **pier that connects to the reachable dock walkway**, and the pier is kept from leaking onto the harbour water (which is an intentionally non-walkable component).

## In-scope additions (epic #1732)
- **NPCs linking to existing screens**, so players who have left Ravenwatch can still use those features:
  - `harbour-angler` → `fishing` (on the dock)
  - `quartermaster-millhaven` → `shop-supplies`
  - `card-trader-millhaven` → `shop-cards`
- **Placeholder NPC for a new minigame**: `regatta-master` (boat-race), dialogue-only for now, with a **new `hub-npc-harbourmaster.svg` sprite**. New minigame tracked in **#1750**.
- No map offset was needed — the only resize-adjacent change is carving/splitting a few harbour-water tiles for the boathouse footprint and pier.

## Verification
A scripted map validator (run locally) checks, from the avatar's spawn:
- all **9 building doors are reachable** (BFS over the street graph — this is the check that would have caught the original boathouse bug);
- no building rectangles overlap and **every building is ≥ 6 rows**;
- **no walkable sea** (the harbour water stays an isolated component) and no non-water street tile sits under a building;
- all interior NPCs/pickups and quest pickups are in bounds and reachable.

Plus `npm run test` (**198/198**) and `npm run build` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ULijjggBX76o4RPjGLESU9)_