### PR TITLE
Ironhold Keep: Tier A hub expansion (#1737)

### DIFF
--- a/web/src/data/hub/ironholdkeep/config.json
+++ b/web/src/data/hub/ironholdkeep/config.json
@@ -478,6 +478,188 @@
           "tileId": "roundWindowUnlit"
         }
       ]
+    },
+    {
+      "id": "stables",
+      "rect": [
+        3,
+        37,
+        9,
+        42
+      ],
+      "wall": "woodWall",
+      "roof": "strawRoof",
+      "doors": [
+        {
+          "tx": 3,
+          "ty": 1,
+          "buildingId": "stables"
+        }
+      ]
+    },
+    {
+      "id": "smithy",
+      "upgradeKind": "workshop",
+      "rect": [
+        10,
+        37,
+        15,
+        42
+      ],
+      "wall": "reinforcedStone",
+      "roof": "metalRoof",
+      "doors": [
+        {
+          "tx": 2,
+          "ty": 1,
+          "buildingId": "smithy"
+        }
+      ]
+    },
+    {
+      "id": "chapel",
+      "rect": [
+        22,
+        37,
+        27,
+        42
+      ],
+      "wall": "castleStone",
+      "roof": "greySlateRoof",
+      "doors": [
+        {
+          "tx": 3,
+          "ty": 1,
+          "buildingId": "chapel"
+        }
+      ]
+    },
+    {
+      "id": "great-tower",
+      "rect": [
+        29,
+        37,
+        33,
+        42
+      ],
+      "wall": "castleStone",
+      "roof": "greySlateRoof",
+      "doors": [
+        {
+          "tx": 2,
+          "ty": 1,
+          "buildingId": "great-tower"
+        }
+      ]
+    },
+    {
+      "id": "scriptorium",
+      "rect": [
+        35,
+        37,
+        40,
+        42
+      ],
+      "wall": "castleStone",
+      "roof": "redSlateRoof",
+      "doors": [
+        {
+          "tx": 2,
+          "ty": 1,
+          "buildingId": "scriptorium"
+        }
+      ]
+    },
+    {
+      "id": "granary",
+      "rect": [
+        4,
+        45,
+        9,
+        50
+      ],
+      "wall": "woodWall",
+      "roof": "strawRoof",
+      "doors": [
+        {
+          "tx": 2,
+          "ty": 1,
+          "buildingId": "granary"
+        }
+      ]
+    },
+    {
+      "id": "kitchens",
+      "rect": [
+        10,
+        45,
+        15,
+        50
+      ],
+      "wall": "castleStone",
+      "roof": "redSlateRoof",
+      "doors": [
+        {
+          "tx": 2,
+          "ty": 1,
+          "buildingId": "kitchens"
+        }
+      ]
+    },
+    {
+      "id": "dungeon",
+      "rect": [
+        22,
+        45,
+        27,
+        50
+      ],
+      "wall": "reinforcedStone",
+      "roof": "stoneFloorRoof",
+      "doors": [
+        {
+          "tx": 2,
+          "ty": 1,
+          "buildingId": "dungeon"
+        }
+      ]
+    },
+    {
+      "id": "infirmary",
+      "rect": [
+        29,
+        45,
+        34,
+        50
+      ],
+      "wall": "castleStone",
+      "roof": "greySlateRoof",
+      "doors": [
+        {
+          "tx": 2,
+          "ty": 1,
+          "buildingId": "infirmary"
+        }
+      ]
+    },
+    {
+      "id": "quartermasters-store",
+      "upgradeKind": "shop",
+      "rect": [
+        35,
+        45,
+        39,
+        50
+      ],
+      "wall": "woodWall",
+      "roof": "greySlateRoof",
+      "doors": [
+        {
+          "tx": 2,
+          "ty": 1,
+          "buildingId": "quartermasters-store"
+        }
+      ]
     }
   ],
   "exteriorDecor": [
@@ -1921,6 +2103,426 @@
           "ty": 4,
           "tileId": "stool"
         }
+      ],
+      "exits": []
+    },
+    "stables": {
+      "name": "The Stables",
+      "width": 12,
+      "height": 8,
+      "floorTileId": "woodFloor",
+      "wallTileId": "woodWall",
+      "decor": [
+        { "comment": "feed barrels and hay sacks along the stalls" },
+        { "tx": 1, "ty": 1, "tileId": "sack" },
+        { "tx": 2, "ty": 1, "tileId": "sack" },
+        { "tx": 1, "ty": 2, "tileId": "barrel" },
+        { "tx": 10, "ty": 1, "tileId": "sack" },
+        { "tx": 10, "ty": 2, "tileId": "barrel" },
+        { "tx": 5, "ty": 1, "tileId": "openCrate" },
+        { "tx": 6, "ty": 1, "tileId": "crate" },
+        { "tx": 3, "ty": 5, "tileId": "barrel" },
+        { "tx": 8, "ty": 5, "tileId": "crate" },
+        { "tx": 5, "ty": 6, "tileId": "chest" }
+      ],
+      "exits": []
+    },
+    "smithy": {
+      "name": "The Forge",
+      "width": 10,
+      "height": 8,
+      "floorTileId": "stoneFloor",
+      "wallTileId": "reinforcedStone",
+      "musicId": "shop",
+      "decor": [
+        { "comment": "forge fire and weapon racks" },
+        { "tx": 4, "ty": 1, "tileId": "brazierTop" },
+        { "tx": 4, "ty": 2, "tileId": "brazierBottom" },
+        { "tx": 1, "ty": 1, "tileId": "swordMountedLeft" },
+        { "tx": 2, "ty": 1, "tileId": "shieldMounted" },
+        { "tx": 7, "ty": 1, "tileId": "swordMountedRight" },
+        { "tx": 8, "ty": 1, "tileId": "suitOfArmourTop" },
+        { "tx": 8, "ty": 2, "tileId": "suitOfArmourBottom" },
+        { "tx": 1, "ty": 5, "tileId": "barrel" },
+        { "tx": 2, "ty": 5, "tileId": "crate" },
+        { "tx": 7, "ty": 5, "tileId": "chest" },
+        { "tx": 4, "ty": 4, "tileId": "barrel" }
+      ],
+      "exits": []
+    },
+    "chapel": {
+      "name": "The Castle Chapel",
+      "width": 12,
+      "height": 9,
+      "floorTileId": "stoneFloor",
+      "wallTileId": "castleStone",
+      "musicId": "church",
+      "ambianceId": "sacred",
+      "decor": [
+        { "comment": "altar on the back wall" },
+        { "tx": 5, "ty": 0, "tileId": "altarTopLeft" },
+        { "tx": 6, "ty": 0, "tileId": "altarTopMid" },
+        { "tx": 7, "ty": 0, "tileId": "altarTopRight" },
+        { "tx": 5, "ty": 1, "tileId": "altarMidLeft" },
+        { "tx": 6, "ty": 1, "tileId": "altarMidMid" },
+        { "tx": 7, "ty": 1, "tileId": "altarMidRight" },
+        { "tx": 5, "ty": 2, "tileId": "altarBotLeft" },
+        { "tx": 6, "ty": 2, "tileId": "altarBotMid" },
+        { "tx": 7, "ty": 2, "tileId": "altarBotRight" },
+        { "comment": "candlesticks flanking the altar" },
+        { "tx": 3, "ty": 1, "tileId": "candlestickLitTop" },
+        { "tx": 9, "ty": 1, "tileId": "candlestickLitTop" },
+        { "comment": "pews" },
+        { "tx": 4, "ty": 4, "tileId": "stool" },
+        { "tx": 5, "ty": 4, "tileId": "stool" },
+        { "tx": 7, "ty": 4, "tileId": "stool" },
+        { "tx": 4, "ty": 6, "tileId": "stool" },
+        { "tx": 5, "ty": 6, "tileId": "stool" },
+        { "tx": 7, "ty": 6, "tileId": "stool" },
+        { "comment": "stairway down to the crypt" },
+        { "tx": 1, "ty": 7, "tileId": "ladderBottom" },
+        { "tx": 1, "ty": 6, "tileId": "fullLadderTop" }
+      ],
+      "exits": [
+        {
+          "tx": 1,
+          "ty": 7,
+          "toInteriorId": "chapel-crypt",
+          "entryTx": 5,
+          "entryTy": 1,
+          "direction": "down",
+          "label": "The Crypt"
+        }
+      ]
+    },
+    "chapel-crypt": {
+      "name": "The Crypt",
+      "width": 12,
+      "height": 8,
+      "floorTileId": "stoneFloor",
+      "wallTileId": "darkStone",
+      "ambianceId": "sacred",
+      "decor": [
+        { "comment": "stone sarcophagi (chests) in rows" },
+        { "tx": 3, "ty": 2, "tileId": "chest" },
+        { "tx": 5, "ty": 2, "tileId": "chest" },
+        { "tx": 7, "ty": 2, "tileId": "chest" },
+        { "tx": 9, "ty": 2, "tileId": "chest" },
+        { "tx": 3, "ty": 5, "tileId": "chest" },
+        { "tx": 5, "ty": 5, "tileId": "chest" },
+        { "tx": 7, "ty": 5, "tileId": "chest" },
+        { "tx": 9, "ty": 5, "tileId": "chest" },
+        { "tx": 1, "ty": 1, "tileId": "candlestickUnlit" },
+        { "tx": 10, "ty": 1, "tileId": "candlestickLitTop" },
+        { "tx": 1, "ty": 6, "tileId": "smallRock" },
+        { "comment": "stairway back up to the chapel" },
+        { "tx": 5, "ty": 1, "tileId": "ladderIntoFloor", "zlayer": "below" },
+        { "tx": 5, "ty": 0, "tileId": "halfLadderTop" }
+      ],
+      "exits": [
+        {
+          "tx": 5,
+          "ty": 1,
+          "toInteriorId": "chapel",
+          "entryTx": 1,
+          "entryTy": 6,
+          "direction": "up",
+          "label": "The Chapel"
+        }
+      ]
+    },
+    "great-tower": {
+      "name": "The Great Tower",
+      "width": 10,
+      "height": 8,
+      "floorTileId": "stoneFloor",
+      "wallTileId": "castleStone",
+      "decor": [
+        { "tx": 1, "ty": 1, "tileId": "brazierTop" },
+        { "tx": 1, "ty": 2, "tileId": "brazierBottom" },
+        { "tx": 8, "ty": 1, "tileId": "brazierTop" },
+        { "tx": 8, "ty": 2, "tileId": "brazierBottom" },
+        { "tx": 3, "ty": 3, "tileId": "barrel" },
+        { "tx": 6, "ty": 3, "tileId": "crate" },
+        { "tx": 4, "ty": 5, "tileId": "chest" },
+        { "tx": 5, "ty": 5, "tileId": "chest" },
+        { "comment": "ladder up to the lookout" },
+        { "tx": 8, "ty": 6, "tileId": "ladderBottom" },
+        { "tx": 8, "ty": 5, "tileId": "fullLadderTop" }
+      ],
+      "exits": [
+        {
+          "tx": 8,
+          "ty": 6,
+          "toInteriorId": "great-tower-top",
+          "entryTx": 5,
+          "entryTy": 6,
+          "direction": "up",
+          "label": "The Lookout"
+        }
+      ]
+    },
+    "great-tower-top": {
+      "name": "The Tower Lookout",
+      "width": 10,
+      "height": 8,
+      "floorTileId": "woodFloor",
+      "wallTileId": "castleStone",
+      "decor": [
+        { "tx": 2, "ty": -1, "tileId": "roundWindowLit" },
+        { "tx": 5, "ty": -1, "tileId": "roundWindowUnlit" },
+        { "tx": 7, "ty": -1, "tileId": "roundWindowUnlit" },
+        { "tx": 1, "ty": 1, "tileId": "swordMountedLeft" },
+        { "tx": 8, "ty": 1, "tileId": "swordMountedRight" },
+        { "tx": 2, "ty": 3, "tileId": "chest" },
+        { "tx": 7, "ty": 3, "tileId": "barrel" },
+        { "tx": 4, "ty": 2, "tileId": "candlestickLitTop" },
+        { "comment": "ladder down into the tower" },
+        { "tx": 5, "ty": 6, "tileId": "ladderIntoFloor", "zlayer": "below" },
+        { "tx": 5, "ty": 5, "tileId": "halfLadderTop" }
+      ],
+      "exits": [
+        {
+          "tx": 5,
+          "ty": 6,
+          "toInteriorId": "great-tower",
+          "entryTx": 8,
+          "entryTy": 5,
+          "direction": "down",
+          "label": "The Tower"
+        }
+      ]
+    },
+    "scriptorium": {
+      "name": "The Scriptorium",
+      "width": 12,
+      "height": 9,
+      "floorTileId": "woodFloor",
+      "wallTileId": "castleStone",
+      "musicId": "church",
+      "decor": [
+        { "comment": "archive shelves along the back wall" },
+        { "tx": 1, "ty": 0, "tileId": "bookshelfTop" },
+        { "tx": 1, "ty": 1, "tileId": "bookshelfBottom" },
+        { "tx": 2, "ty": 0, "tileId": "bookshelfTop" },
+        { "tx": 2, "ty": 1, "tileId": "bookshelfBottom" },
+        { "tx": 9, "ty": 0, "tileId": "bookshelfTop" },
+        { "tx": 9, "ty": 1, "tileId": "bookshelfBottom" },
+        { "tx": 10, "ty": 0, "tileId": "bookshelfTop" },
+        { "tx": 10, "ty": 1, "tileId": "bookshelfBottom" },
+        { "comment": "writing desks" },
+        { "tx": 4, "ty": 3, "tileId": "roundTable" },
+        { "tx": 4, "ty": 4, "tileId": "stool" },
+        { "tx": 7, "ty": 3, "tileId": "roundTable" },
+        { "tx": 7, "ty": 4, "tileId": "stool" },
+        { "tx": 3, "ty": 3, "tileId": "candlestickLitTop" },
+        { "tx": 8, "ty": 3, "tileId": "candlestickLitTop" },
+        { "tx": 1, "ty": 6, "tileId": "chest" },
+        { "tx": 10, "ty": 6, "tileId": "chest" }
+      ],
+      "exits": []
+    },
+    "granary": {
+      "name": "The Granary",
+      "width": 10,
+      "height": 8,
+      "floorTileId": "woodFloor",
+      "wallTileId": "woodWall",
+      "decor": [
+        { "tx": 1, "ty": 1, "tileId": "sack" },
+        { "tx": 2, "ty": 1, "tileId": "sack" },
+        { "tx": 3, "ty": 1, "tileId": "sack" },
+        { "tx": 6, "ty": 1, "tileId": "sack" },
+        { "tx": 7, "ty": 1, "tileId": "sack" },
+        { "tx": 8, "ty": 1, "tileId": "sack" },
+        { "tx": 1, "ty": 5, "tileId": "barrel" },
+        { "tx": 2, "ty": 5, "tileId": "barrel" },
+        { "tx": 7, "ty": 5, "tileId": "openCrate" },
+        { "tx": 8, "ty": 5, "tileId": "crate" },
+        { "tx": 4, "ty": 4, "tileId": "sack" },
+        { "tx": 5, "ty": 4, "tileId": "sack" }
+      ],
+      "exits": []
+    },
+    "kitchens": {
+      "name": "The Castle Kitchens",
+      "width": 12,
+      "height": 8,
+      "floorTileId": "stoneFloor",
+      "wallTileId": "castleStone",
+      "ambianceId": "hearth",
+      "decor": [
+        { "comment": "great hearth" },
+        { "tx": 5, "ty": 0, "tileId": "fireplaceTopLeft" },
+        { "tx": 6, "ty": 0, "tileId": "fireplaceTopMiddle" },
+        { "tx": 7, "ty": 0, "tileId": "fireplaceTopRight" },
+        { "tx": 5, "ty": 1, "tileId": "fireplaceBottomLeft" },
+        { "tx": 6, "ty": 1, "tileId": "fireplaceBottomMiddle" },
+        { "tx": 7, "ty": 1, "tileId": "fireplaceBottomRight" },
+        { "comment": "prep tables and stores" },
+        { "tx": 3, "ty": 4, "tileId": "roundTable" },
+        { "tx": 8, "ty": 4, "tileId": "roundTable" },
+        { "tx": 1, "ty": 5, "tileId": "barrel" },
+        { "tx": 2, "ty": 5, "tileId": "sack" },
+        { "tx": 10, "ty": 5, "tileId": "crate" },
+        { "tx": 10, "ty": 1, "tileId": "barrel" }
+      ],
+      "exits": []
+    },
+    "dungeon": {
+      "name": "The Dungeon",
+      "width": 10,
+      "height": 8,
+      "floorTileId": "stoneFloor",
+      "wallTileId": "reinforcedStone",
+      "decor": [
+        { "tx": 1, "ty": 1, "tileId": "brazierTop" },
+        { "tx": 1, "ty": 2, "tileId": "brazierBottom" },
+        { "tx": 8, "ty": 1, "tileId": "brazierTop" },
+        { "tx": 8, "ty": 2, "tileId": "brazierBottom" },
+        { "tx": 3, "ty": 3, "tileId": "chest" },
+        { "tx": 5, "ty": 3, "tileId": "barrel" },
+        { "tx": 4, "ty": 1, "tileId": "swordMountedLeft" },
+        { "tx": 5, "ty": 1, "tileId": "shieldMounted" },
+        { "comment": "stairway down to the cells" },
+        { "tx": 8, "ty": 6, "tileId": "ladderBottom" },
+        { "tx": 8, "ty": 5, "tileId": "fullLadderTop" }
+      ],
+      "exits": [
+        {
+          "tx": 8,
+          "ty": 6,
+          "toInteriorId": "dungeon-cells",
+          "entryTx": 5,
+          "entryTy": 6,
+          "direction": "down",
+          "label": "The Cells"
+        }
+      ]
+    },
+    "dungeon-cells": {
+      "name": "The Cells",
+      "width": 12,
+      "height": 8,
+      "floorTileId": "stoneFloor",
+      "wallTileId": "darkStone",
+      "decor": [
+        { "comment": "cell railings line the back wall" },
+        { "tx": 2, "ty": -1, "tileId": "cellWindowUnlit" },
+        { "tx": 5, "ty": -1, "tileId": "cellWindowLit" },
+        { "tx": 9, "ty": -1, "tileId": "cellWindowUnlit" },
+        { "tx": 1, "ty": 1, "tileId": "prisonRailingsTopLeft" },
+        { "tx": 2, "ty": 1, "tileId": "prisonRailingsTopMiddle" },
+        { "tx": 3, "ty": 1, "tileId": "prisonRailingsTopRight" },
+        { "tx": 1, "ty": 2, "tileId": "prisonRailingsBottomLeft" },
+        { "tx": 2, "ty": 2, "tileId": "prisonRailingsBottomMiddle" },
+        { "tx": 3, "ty": 2, "tileId": "prisonRailingsBottomRight" },
+        { "tx": 8, "ty": 1, "tileId": "prisonRailingsTopLeft" },
+        { "tx": 9, "ty": 1, "tileId": "prisonRailingsTopMiddle" },
+        { "tx": 10, "ty": 1, "tileId": "prisonRailingsTopRight" },
+        { "tx": 8, "ty": 2, "tileId": "prisonRailingsBottomLeft" },
+        { "tx": 9, "ty": 2, "tileId": "prisonRailingsBottomMiddle" },
+        { "tx": 10, "ty": 2, "tileId": "prisonRailingsBottomRight" },
+        { "tx": 1, "ty": 5, "tileId": "sack" },
+        { "tx": 6, "ty": 4, "tileId": "candlestickLitTop" },
+        { "comment": "stairs up to dungeon; locked door down to the vault" },
+        { "tx": 5, "ty": 1, "tileId": "ladderIntoFloor", "zlayer": "below" },
+        { "tx": 5, "ty": 0, "tileId": "halfLadderTop" },
+        { "tx": 11, "ty": 6, "tileId": "ladderBottom" },
+        { "tx": 11, "ty": 5, "tileId": "fullLadderTop" }
+      ],
+      "exits": [
+        {
+          "tx": 5,
+          "ty": 1,
+          "toInteriorId": "dungeon",
+          "entryTx": 8,
+          "entryTy": 5,
+          "direction": "up",
+          "label": "Up"
+        },
+        {
+          "tx": 11,
+          "ty": 6,
+          "toInteriorId": "dungeon-vault",
+          "entryTx": 5,
+          "entryTy": 6,
+          "direction": "down",
+          "label": "The Lower Vault",
+          "requiredQuest": "castle-prison-key"
+        }
+      ]
+    },
+    "dungeon-vault": {
+      "name": "The Lower Vault",
+      "width": 10,
+      "height": 8,
+      "floorTileId": "stoneFloor",
+      "wallTileId": "reinforcedStone",
+      "decor": [
+        { "tx": 2, "ty": 2, "tileId": "chest" },
+        { "tx": 3, "ty": 2, "tileId": "chest" },
+        { "tx": 6, "ty": 2, "tileId": "chest" },
+        { "tx": 7, "ty": 2, "tileId": "chest" },
+        { "tx": 1, "ty": 4, "tileId": "barrel" },
+        { "tx": 8, "ty": 4, "tileId": "barrel" },
+        { "tx": 4, "ty": 4, "tileId": "candlestickLitTop" },
+        { "comment": "stairway up to the cells" },
+        { "tx": 5, "ty": 6, "tileId": "ladderIntoFloor", "zlayer": "below" },
+        { "tx": 5, "ty": 5, "tileId": "halfLadderTop" }
+      ],
+      "exits": [
+        {
+          "tx": 5,
+          "ty": 6,
+          "toInteriorId": "dungeon-cells",
+          "entryTx": 11,
+          "entryTy": 5,
+          "direction": "up",
+          "label": "The Cells"
+        }
+      ]
+    },
+    "infirmary": {
+      "name": "The Infirmary",
+      "width": 12,
+      "height": 8,
+      "floorTileId": "woodFloor",
+      "wallTileId": "castleStone",
+      "decor": [
+        { "comment": "sick beds" },
+        { "tx": 1, "ty": 1, "bundleID": "simple-bed" },
+        { "tx": 4, "ty": 1, "bundleID": "simple-bed" },
+        { "tx": 7, "ty": 1, "bundleID": "simple-bed" },
+        { "comment": "supplies" },
+        { "tx": 10, "ty": 1, "tileId": "chest" },
+        { "tx": 10, "ty": 2, "tileId": "barrel" },
+        { "tx": 2, "ty": 5, "tileId": "roundTable" },
+        { "tx": 2, "ty": 6, "tileId": "stool" },
+        { "tx": 6, "ty": 5, "tileId": "candlestickLitTop" },
+        { "tx": 9, "ty": 5, "tileId": "barrel" }
+      ],
+      "exits": []
+    },
+    "quartermasters-store": {
+      "name": "The Quartermaster's Store",
+      "width": 10,
+      "height": 8,
+      "floorTileId": "woodFloor",
+      "wallTileId": "woodWall",
+      "musicId": "shop",
+      "ambianceId": "market",
+      "decor": [
+        { "tx": 1, "ty": 1, "tileId": "crate" },
+        { "tx": 2, "ty": 1, "tileId": "crate" },
+        { "tx": 1, "ty": 2, "tileId": "openCrate" },
+        { "tx": 7, "ty": 1, "tileId": "barrel" },
+        { "tx": 8, "ty": 1, "tileId": "barrel" },
+        { "tx": 8, "ty": 2, "tileId": "sack" },
+        { "tx": 4, "ty": 4, "tileId": "roundTableWithCloth" },
+        { "tx": 4, "ty": 5, "tileId": "stool" },
+        { "tx": 2, "ty": 5, "tileId": "chest" },
+        { "tx": 7, "ty": 5, "tileId": "chest" }
       ],
       "exits": []
     }

--- a/web/src/data/hub/ironholdkeep/config.json
+++ b/web/src/data/hub/ironholdkeep/config.json
@@ -1441,37 +1441,243 @@
       ],
       "building": "keep",
       "questGive": "castle-missing-patrol",
-      "questReceive": "castle-missing-patrol"
+      "questReceive": "castle-missing-patrol",
+      "dialogueTree": "varek-chat",
+      "schedule": [
+        { "startHour": 0, "endHour": 7, "activity": "sleep", "location": { "type": "interior", "buildingId": "keep-solar", "tx": 1, "ty": 2 } },
+        { "startHour": 7, "endHour": 12, "activity": "work", "location": { "type": "interior", "buildingId": "keep-war-room", "tx": 5, "ty": 5 } },
+        { "startHour": 12, "endHour": 14, "activity": "eat", "location": { "type": "interior", "buildingId": "kitchens", "tx": 6, "ty": 5 } },
+        { "startHour": 14, "endHour": 20, "activity": "idle-chat", "location": { "type": "interior", "buildingId": "keep", "tx": 7, "ty": 5 } },
+        { "startHour": 20, "endHour": 0, "activity": "work", "location": { "type": "interior", "buildingId": "keep-war-room", "tx": 5, "ty": 5 } }
+      ],
+      "homeBed": { "buildingId": "keep-solar", "tx": 1, "ty": 2 }
+    },
+    {
+      "id": "castle-guard-master",
+      "name": "Guard-Master Doran",
+      "sprite": "hub-npc-guard",
+      "tx": 20,
+      "ty": 22,
+      "dialogue": [
+        "Discipline wins sieges, not bravado. Drill, drill, and drill again.",
+        "Every soldier here answers to me before they answer to the Commander.",
+        "Stand a watch with us sometime, traveller. You'd learn something."
+      ],
+      "questGive": "castle-watch-rotation",
+      "questReceive": "castle-watch-rotation",
+      "schedule": [
+        { "startHour": 0, "endHour": 6, "activity": "sleep", "location": { "type": "interior", "buildingId": "barracks", "tx": 9, "ty": 6 } },
+        { "startHour": 6, "endHour": 13, "activity": "work", "location": { "type": "exterior", "tx": 20, "ty": 22 } },
+        { "startHour": 13, "endHour": 19, "activity": "work", "location": { "type": "exterior", "tx": 12, "ty": 22 } },
+        { "startHour": 19, "endHour": 22, "activity": "eat", "location": { "type": "interior", "buildingId": "kitchens", "tx": 8, "ty": 4 } },
+        { "startHour": 22, "endHour": 0, "activity": "idle-chat", "location": { "type": "interior", "buildingId": "barracks", "tx": 6, "ty": 6 } }
+      ],
+      "homeBed": { "buildingId": "barracks", "tx": 9, "ty": 6 }
     },
     {
       "id": "castle-blacksmith",
       "name": "Blacksmith Kern",
       "sprite": "hub-npc-supplies",
-      "tx": 8,
-      "ty": 6,
+      "tx": 5,
+      "ty": 4,
       "dialogue": [
         "Every blade that leaves my anvil could save a soldier's life.",
         "The weapon crates haven't been accounted for since the last resupply.",
         "Iron doesn't lie — only men do."
       ],
-      "building": "armoury",
+      "building": "smithy",
       "questGive": "castle-weapon-cache",
-      "questReceive": "castle-weapon-cache"
+      "questReceive": [ "castle-weapon-cache", "castle-forge-the-key" ],
+      "schedule": [
+        { "startHour": 0, "endHour": 6, "activity": "sleep", "location": { "type": "interior", "buildingId": "barracks", "tx": 3, "ty": 6 } },
+        { "startHour": 6, "endHour": 19, "activity": "work", "location": { "type": "interior", "buildingId": "smithy", "tx": 5, "ty": 4 } },
+        { "startHour": 19, "endHour": 22, "activity": "eat", "location": { "type": "interior", "buildingId": "kitchens", "tx": 6, "ty": 5 } },
+        { "startHour": 22, "endHour": 0, "activity": "sleep", "location": { "type": "interior", "buildingId": "barracks", "tx": 3, "ty": 6 } }
+      ],
+      "homeBed": { "buildingId": "barracks", "tx": 3, "ty": 6 }
+    },
+    {
+      "id": "castle-quartermaster",
+      "name": "Quartermaster Sella",
+      "sprite": "hub-npc-merchant",
+      "tx": 5,
+      "ty": 4,
+      "dialogue": [
+        "Nothing enters or leaves these walls without crossing my ledger.",
+        "Grain, iron, arrows, salt — a castle eats as surely as it fights.",
+        "If you're after supplies, mind you sign for them."
+      ],
+      "building": "quartermasters-store",
+      "questGive": "castle-supply-tally",
+      "questReceive": "castle-supply-tally",
+      "schedule": [
+        { "startHour": 0, "endHour": 7, "activity": "sleep", "location": { "type": "interior", "buildingId": "quartermasters-store", "tx": 8, "ty": 5 } },
+        { "startHour": 7, "endHour": 13, "activity": "work", "location": { "type": "interior", "buildingId": "quartermasters-store", "tx": 5, "ty": 4 } },
+        { "startHour": 13, "endHour": 17, "activity": "work", "location": { "type": "interior", "buildingId": "granary", "tx": 4, "ty": 4 } },
+        { "startHour": 17, "endHour": 0, "activity": "work", "location": { "type": "interior", "buildingId": "quartermasters-store", "tx": 5, "ty": 4 } }
+      ],
+      "homeBed": { "buildingId": "quartermasters-store", "tx": 8, "ty": 5 }
+    },
+    {
+      "id": "castle-cook",
+      "name": "Cook Mabel",
+      "sprite": "hub-npc-elder",
+      "tx": 6,
+      "ty": 4,
+      "dialogue": [
+        "An army marches on its stomach, and this lot marches a long way.",
+        "Get out of my kitchen unless you're bringing me something to cook with.",
+        "There's stew on the hearth if the guards have left any."
+      ],
+      "building": "kitchens",
+      "questGive": "castle-feast-preparations",
+      "questReceive": "castle-feast-preparations",
+      "schedule": [
+        { "startHour": 0, "endHour": 5, "activity": "sleep", "location": { "type": "interior", "buildingId": "kitchens", "tx": 10, "ty": 5 } },
+        { "startHour": 5, "endHour": 21, "activity": "work", "location": { "type": "interior", "buildingId": "kitchens", "tx": 6, "ty": 4 } },
+        { "startHour": 21, "endHour": 0, "activity": "sweep", "location": { "type": "interior", "buildingId": "kitchens", "tx": 8, "ty": 5 } }
+      ],
+      "homeBed": { "buildingId": "kitchens", "tx": 10, "ty": 5 }
+    },
+    {
+      "id": "castle-chaplain",
+      "name": "Chaplain Aldwin",
+      "sprite": "hub-npc-scholar",
+      "tx": 6,
+      "ty": 5,
+      "dialogue": [
+        "Even iron men kneel before something, traveller.",
+        "The crypt below holds the lords of Ironhold, back to the first stone laid.",
+        "Light a candle for the fallen. There are always more of them than we'd like."
+      ],
+      "building": "chapel",
+      "questGive": "castle-restless-crypt",
+      "questReceive": "castle-restless-crypt",
+      "schedule": [
+        { "startHour": 0, "endHour": 6, "activity": "sleep", "location": { "type": "interior", "buildingId": "chapel-crypt", "tx": 10, "ty": 4 } },
+        { "startHour": 6, "endHour": 12, "activity": "idle-chat", "location": { "type": "interior", "buildingId": "chapel", "tx": 6, "ty": 5 } },
+        { "startHour": 12, "endHour": 14, "activity": "eat", "location": { "type": "interior", "buildingId": "kitchens", "tx": 6, "ty": 5 } },
+        { "startHour": 14, "endHour": 0, "activity": "idle-chat", "location": { "type": "interior", "buildingId": "chapel", "tx": 6, "ty": 5 } }
+      ],
+      "homeBed": { "buildingId": "chapel-crypt", "tx": 10, "ty": 4 }
     },
     {
       "id": "castle-archivist",
       "name": "Archivist Elwyn",
       "sprite": "hub-npc-scholar",
-      "tx": 8,
-      "ty": 4,
+      "tx": 5,
+      "ty": 5,
       "dialogue": [
         "The keep's records go back to the founding. Most of them, anyway.",
         "A siege chronicle was separated from the archives. It belongs here.",
         "History is the only weapon that never dulls."
       ],
-      "building": "barracks",
+      "building": "scriptorium",
       "questGive": "castle-siege-memory",
-      "questReceive": "castle-siege-memory"
+      "questReceive": [ "castle-siege-memory", "castle-chronicle-for-ravenwatch" ],
+      "schedule": [
+        { "startHour": 0, "endHour": 7, "activity": "sleep", "location": { "type": "interior", "buildingId": "scriptorium", "tx": 1, "ty": 6 } },
+        { "startHour": 7, "endHour": 19, "activity": "work", "location": { "type": "interior", "buildingId": "scriptorium", "tx": 5, "ty": 5 } },
+        { "startHour": 19, "endHour": 0, "activity": "work", "location": { "type": "interior", "buildingId": "scriptorium", "tx": 7, "ty": 4 } }
+      ],
+      "homeBed": { "buildingId": "scriptorium", "tx": 1, "ty": 6 }
+    },
+    {
+      "id": "castle-stablehand",
+      "name": "Stablehand Pip",
+      "sprite": "hub-npc-fisherman",
+      "tx": 5,
+      "ty": 4,
+      "dialogue": [
+        "The destriers know me better than my own mother does.",
+        "Mind where you step — a war horse spooks at less than you'd think.",
+        "If you ride out, I'll have a mount saddled before you reach the gate."
+      ],
+      "building": "stables",
+      "questGive": "castle-lost-foal",
+      "questReceive": "castle-lost-foal",
+      "schedule": [
+        { "startHour": 0, "endHour": 6, "activity": "sleep", "location": { "type": "interior", "buildingId": "stables", "tx": 10, "ty": 6 } },
+        { "startHour": 6, "endHour": 18, "activity": "work", "location": { "type": "interior", "buildingId": "stables", "tx": 5, "ty": 4 } },
+        { "startHour": 18, "endHour": 20, "activity": "eat", "location": { "type": "interior", "buildingId": "kitchens", "tx": 8, "ty": 4 } },
+        { "startHour": 20, "endHour": 0, "activity": "sweep", "location": { "type": "interior", "buildingId": "stables", "tx": 8, "ty": 5 } }
+      ],
+      "homeBed": { "buildingId": "stables", "tx": 10, "ty": 6 }
+    },
+    {
+      "id": "castle-knight",
+      "name": "Sir Garrick",
+      "sprite": "hub-npc-soldier",
+      "tx": 25,
+      "ty": 22,
+      "dialogue": [
+        "I have held this wall through two winters and a siege. I'll hold it through more.",
+        "A knight without a cause is just a man in expensive metal.",
+        "The Guard-Master sets the rotation. Take it up with him."
+      ],
+      "questReceive": "castle-watch-rotation",
+      "schedule": [
+        { "startHour": 0, "endHour": 6, "activity": "sleep", "location": { "type": "interior", "buildingId": "barracks", "tx": 6, "ty": 6 } },
+        { "startHour": 6, "endHour": 12, "activity": "work", "location": { "type": "exterior", "tx": 25, "ty": 22 } },
+        { "startHour": 12, "endHour": 18, "activity": "work", "location": { "type": "exterior", "tx": 31, "ty": 43 } },
+        { "startHour": 18, "endHour": 21, "activity": "eat", "location": { "type": "interior", "buildingId": "kitchens", "tx": 6, "ty": 4 } },
+        { "startHour": 21, "endHour": 0, "activity": "sleep", "location": { "type": "interior", "buildingId": "barracks", "tx": 6, "ty": 6 } }
+      ],
+      "homeBed": { "buildingId": "barracks", "tx": 6, "ty": 6 }
+    },
+    {
+      "id": "castle-squire",
+      "name": "Squire Tomas",
+      "sprite": "hub-npc-soldier",
+      "tx": 17,
+      "ty": 40,
+      "dialogue": [
+        "One day I'll be a knight. For now I muck out stalls and polish armour.",
+        "Sir Garrick says I've a good arm. He says it rarely, mind.",
+        "I dropped a training sword somewhere out here. Don't tell the Guard-Master."
+      ],
+      "questGive": "castle-squires-trial",
+      "questReceive": "castle-squires-trial",
+      "schedule": [
+        { "startHour": 0, "endHour": 6, "activity": "sleep", "location": { "type": "interior", "buildingId": "barracks", "tx": 8, "ty": 6 } },
+        { "startHour": 6, "endHour": 10, "activity": "work", "location": { "type": "interior", "buildingId": "stables", "tx": 8, "ty": 5 } },
+        { "startHour": 10, "endHour": 17, "activity": "work", "location": { "type": "exterior", "tx": 17, "ty": 40 } },
+        { "startHour": 17, "endHour": 20, "activity": "eat", "location": { "type": "interior", "buildingId": "kitchens", "tx": 8, "ty": 4 } },
+        { "startHour": 20, "endHour": 0, "activity": "sleep", "location": { "type": "interior", "buildingId": "barracks", "tx": 8, "ty": 6 } }
+      ],
+      "homeBed": { "buildingId": "barracks", "tx": 8, "ty": 6 }
+    },
+    {
+      "id": "castle-gatekeeper",
+      "name": "Gatekeeper Olen",
+      "sprite": "hub-npc-guard",
+      "tx": 17,
+      "ty": 46,
+      "dialogue": [
+        "The portcullis hasn't jammed on my watch and it never will.",
+        "State your business at the gate or state it elsewhere.",
+        "Safe roads, traveller. The world beyond these walls is less forgiving."
+      ],
+      "schedule": [
+        { "startHour": 0, "endHour": 8, "activity": "work", "location": { "type": "exterior", "tx": 17, "ty": 46 } },
+        { "startHour": 8, "endHour": 20, "activity": "work", "location": { "type": "exterior", "tx": 17, "ty": 30 } },
+        { "startHour": 20, "endHour": 0, "activity": "work", "location": { "type": "exterior", "tx": 17, "ty": 46 } }
+      ]
+    },
+    {
+      "id": "castle-prisoner",
+      "name": "The Prisoner",
+      "sprite": "hub-npc-elder",
+      "tx": 6,
+      "ty": 4,
+      "dialogue": [
+        "Psst. Over here. They've left me to rot for a crime I never committed.",
+        "I know things about this keep that would turn the Commander's beard white.",
+        "Help me prove my innocence and the secret of the lower vault is yours."
+      ],
+      "building": "dungeon-cells",
+      "questGive": "castle-prisoners-plea",
+      "questReceive": "castle-prisoners-plea"
     },
     {
       "id": "castle-guard-1",
@@ -1484,7 +1690,14 @@
         "Three of us dropped our patrol papers during the last drill. Embarrassing.",
         "The south gate is yours to use, traveller."
       ],
-      "questReceive": "castle-missing-patrol"
+      "questReceive": "castle-missing-patrol",
+      "schedule": [
+        { "startHour": 0, "endHour": 6, "activity": "sleep", "location": { "type": "interior", "buildingId": "barracks", "tx": 1, "ty": 6 } },
+        { "startHour": 6, "endHour": 14, "activity": "work", "location": { "type": "exterior", "tx": 10, "ty": 21 } },
+        { "startHour": 14, "endHour": 21, "activity": "work", "location": { "type": "exterior", "tx": 8, "ty": 43 } },
+        { "startHour": 21, "endHour": 0, "activity": "sleep", "location": { "type": "interior", "buildingId": "barracks", "tx": 1, "ty": 6 } }
+      ],
+      "homeBed": { "buildingId": "barracks", "tx": 1, "ty": 6 }
     },
     {
       "id": "castle-guard-2",
@@ -1497,7 +1710,14 @@
         "I lost my patrol report somewhere out in the courtyard. The Commander will have my head.",
         "Ironhold has never fallen. Long may that last."
       ],
-      "questReceive": "castle-missing-patrol"
+      "questReceive": "castle-missing-patrol",
+      "schedule": [
+        { "startHour": 0, "endHour": 7, "activity": "sleep", "location": { "type": "interior", "buildingId": "barracks", "tx": 2, "ty": 6 } },
+        { "startHour": 7, "endHour": 15, "activity": "work", "location": { "type": "exterior", "tx": 25, "ty": 21 } },
+        { "startHour": 15, "endHour": 22, "activity": "work", "location": { "type": "exterior", "tx": 31, "ty": 51 } },
+        { "startHour": 22, "endHour": 0, "activity": "sleep", "location": { "type": "interior", "buildingId": "barracks", "tx": 2, "ty": 6 } }
+      ],
+      "homeBed": { "buildingId": "barracks", "tx": 2, "ty": 6 }
     }
   ],
   "interiors": {

--- a/web/src/data/hub/ironholdkeep/config.json
+++ b/web/src/data/hub/ironholdkeep/config.json
@@ -1,30 +1,30 @@
 {
-  "mapW": 1152,
-  "mapH": 1152,
+  "mapW": 1408,
+  "mapH": 1728,
   "townName": "Ironhold Keep",
   "avatarStart": {
     "tx": 17,
-    "ty": 33
+    "ty": 50
   },
   "exitTiles": [
     {
       "tx": 16,
-      "ty": 35,
+      "ty": 52,
       "screen": "worldmap"
     },
     {
       "tx": 17,
-      "ty": 35,
+      "ty": 52,
       "screen": "worldmap"
     },
     {
       "tx": 18,
-      "ty": 35,
+      "ty": 52,
       "screen": "worldmap"
     },
     {
       "tx": 19,
-      "ty": 35,
+      "ty": 52,
       "screen": "worldmap"
     }
   ],
@@ -60,6 +60,14 @@
       "ty": 25,
       "tw": 4,
       "th": 5
+    },
+    {
+      "id": "castle-bailey",
+      "name": "The Outer Bailey",
+      "tx": 1,
+      "ty": 36,
+      "tw": 41,
+      "th": 16
     }
   ],
   "streets": [
@@ -179,6 +187,51 @@
         13,
         28,
         13
+      ]
+    },
+    {
+      "comment": "Outer Bailey — central road continuing the approach south to the new outer gate",
+      "rect": [
+        16,
+        36,
+        19,
+        52
+      ]
+    },
+    {
+      "comment": "Outer Bailey — north boulevard (buildings front their south doors onto it)",
+      "rect": [
+        2,
+        43,
+        41,
+        44
+      ]
+    },
+    {
+      "comment": "Outer Bailey — south boulevard",
+      "rect": [
+        2,
+        51,
+        41,
+        51
+      ]
+    },
+    {
+      "comment": "Outer Bailey — west spur linking the boulevards",
+      "rect": [
+        2,
+        44,
+        3,
+        51
+      ]
+    },
+    {
+      "comment": "Outer Bailey — east spur linking the boulevards",
+      "rect": [
+        40,
+        44,
+        41,
+        51
       ]
     }
   ],
@@ -1197,8 +1250,8 @@
       "id": "castle-commander",
       "name": "Commander Varek",
       "sprite": "hub-npc-arena",
-      "tx": 11,
-      "ty": 15,
+      "tx": 7,
+      "ty": 5,
       "dialogue": [
         "Ironhold Keep has stood for three centuries. I intend to see it stand for three more.",
         "The patrol routes have been compromised. We need those reports.",
@@ -1212,8 +1265,8 @@
       "id": "castle-blacksmith",
       "name": "Blacksmith Kern",
       "sprite": "hub-npc-supplies",
-      "tx": 9,
-      "ty": 21,
+      "tx": 8,
+      "ty": 6,
       "dialogue": [
         "Every blade that leaves my anvil could save a soldier's life.",
         "The weapon crates haven't been accounted for since the last resupply.",
@@ -1227,8 +1280,8 @@
       "id": "castle-archivist",
       "name": "Archivist Elwyn",
       "sprite": "hub-npc-scholar",
-      "tx": 18,
-      "ty": 21,
+      "tx": 8,
+      "ty": 4,
       "dialogue": [
         "The keep's records go back to the founding. Most of them, anyway.",
         "A siege chronicle was separated from the archives. It belongs here.",
@@ -1480,8 +1533,8 @@
     },
     "armoury": {
       "name": "The Armoury",
-      "width": 8,
-      "height": 8,
+      "width": 12,
+      "height": 9,
       "floorTileId": "stoneFloor",
       "wallTileId": "reinforcedStone",
       "decor": [
@@ -1557,8 +1610,8 @@
     },
     "barracks": {
       "name": "The Barracks",
-      "width": 8,
-      "height": 8,
+      "width": 12,
+      "height": 9,
       "floorTileId": "woodFloor",
       "wallTileId": "castleStone",
       "decor": [

--- a/web/src/data/hub/ironholdkeep/config.json
+++ b/web/src/data/hub/ironholdkeep/config.json
@@ -1423,9 +1423,90 @@
       "ty": 27,
       "tileId": "archStoneDark",
       "zlayer": "above"
-    }
+    },
+    { "comment": "Outer Bailey — braziers flanking the central road, glowing at night" },
+    { "tx": 15, "ty": 42, "tileId": "brazierTop", "glow": true, "glowRadius": 3 },
+    { "tx": 15, "ty": 43, "tileId": "brazierBottom" },
+    { "tx": 20, "ty": 42, "tileId": "brazierTop", "glow": true, "glowRadius": 3 },
+    { "tx": 20, "ty": 43, "tileId": "brazierBottom" },
+    { "tx": 15, "ty": 50, "tileId": "brazierTop", "glow": true, "glowRadius": 3 },
+    { "tx": 15, "ty": 51, "tileId": "brazierBottom" },
+    { "tx": 20, "ty": 50, "tileId": "brazierTop", "glow": true, "glowRadius": 3 },
+    { "tx": 20, "ty": 51, "tileId": "brazierBottom" },
+    { "comment": "Outer Bailey — outer gate braziers" },
+    { "tx": 15, "ty": 52, "tileId": "brazierTop", "glow": true, "glowRadius": 2 },
+    { "tx": 20, "ty": 52, "tileId": "brazierTop", "glow": true, "glowRadius": 2 },
+    { "comment": "drill yard — training gear and a campfire" },
+    { "tx": 22, "ty": 41, "tileId": "crate" },
+    { "tx": 23, "ty": 41, "tileId": "crate" },
+    { "tx": 24, "ty": 42, "tileId": "barrel" },
+    { "tx": 21, "ty": 40, "tileId": "campfireUnlit" },
+    { "tx": 26, "ty": 40, "tileId": "smallRock" },
+    { "comment": "stores stacked by the granary and quartermaster doors" },
+    { "tx": 4, "ty": 51, "tileId": "barrel" },
+    { "tx": 10, "ty": 44, "tileId": "sack" },
+    { "tx": 11, "ty": 44, "tileId": "sack" },
+    { "tx": 34, "ty": 44, "tileId": "crate" },
+    { "tx": 35, "ty": 44, "tileId": "openCrate" },
+    { "tx": 39, "ty": 51, "tileId": "barrel" },
+    { "comment": "supply wagons and stacked siege timber along the boulevard" },
+    { "tx": 3, "ty": 44, "tileId": "crate" },
+    { "tx": 8, "ty": 51, "tileId": "openCrate" },
+    { "tx": 28, "ty": 44, "tileId": "barrel" },
+    { "tx": 29, "ty": 44, "tileId": "barrel" },
+    { "tx": 32, "ty": 51, "tileId": "crate" },
+    { "tx": 33, "ty": 51, "tileId": "sack" },
+    { "comment": "rubble and rocks at the bailey wall lines" },
+    { "tx": 2, "ty": 48, "tileId": "smallRock" },
+    { "tx": 41, "ty": 48, "tileId": "smallRock" },
+    { "tx": 37, "ty": 40, "tileId": "smallRock" }
   ],
   "npcSpawnTiles": [],
+  "chickenZones": [
+    { "rect": [ 13, 17, 16, 20 ], "count": 4, "roost": [ 14, 18 ] }
+  ],
+  "animals": [
+    {
+      "id": "castle-hound-1",
+      "type": "dog",
+      "variant": "brown",
+      "tx": 18,
+      "ty": 45,
+      "name": "Fang",
+      "dialogue": [ "*a low, watchful growl, then a tail-wag*" ],
+      "roam": true
+    },
+    {
+      "id": "castle-hound-2",
+      "type": "dog",
+      "variant": "grey",
+      "tx": 22,
+      "ty": 22,
+      "name": "Wolf",
+      "dialogue": [ "*woof! — the old guard-dog knows a friend*" ],
+      "roam": true
+    },
+    {
+      "id": "castle-raven-1",
+      "type": "bird",
+      "variant": "#222222",
+      "tx": 17,
+      "ty": 30,
+      "name": "Raven",
+      "dialogue": [ "*the keep's raven eyes you, unblinking*" ],
+      "roam": true
+    },
+    {
+      "id": "castle-raven-2",
+      "type": "bird",
+      "variant": "#222222",
+      "tx": 25,
+      "ty": 21,
+      "name": "Raven",
+      "dialogue": [ "*Kraa! It ruffles its black feathers*" ],
+      "roam": true
+    }
+  ],
   "ambientNpcSprites": [],
   "npcs": [
     {

--- a/web/src/data/hub/ironholdkeep/config.json
+++ b/web/src/data/hub/ironholdkeep/config.json
@@ -1529,7 +1529,249 @@
           "tileId": "chest"
         }
       ],
-      "exits": []
+      "exits": [
+        {
+          "tx": 1,
+          "ty": 5,
+          "toInteriorId": "keep-war-room",
+          "entryTx": 10,
+          "entryTy": 4,
+          "direction": "left",
+          "label": "War Room"
+        }
+      ]
+    },
+    "keep-war-room": {
+      "name": "The War Room",
+      "width": 12,
+      "height": 9,
+      "floorTileId": "cobblestoneFloor",
+      "wallTileId": "castleStone",
+      "decor": [
+        {
+          "comment": "great campaign map table at centre"
+        },
+        {
+          "tx": 5,
+          "ty": 3,
+          "tileId": "roundTableWithCloth"
+        },
+        {
+          "tx": 4,
+          "ty": 4,
+          "tileId": "stool"
+        },
+        {
+          "tx": 6,
+          "ty": 4,
+          "tileId": "stool"
+        },
+        {
+          "tx": 5,
+          "ty": 2,
+          "tileId": "stool"
+        },
+        {
+          "comment": "banners and mounted arms on the back wall"
+        },
+        {
+          "tx": 2,
+          "ty": -1,
+          "tileId": "shieldMounted"
+        },
+        {
+          "tx": 5,
+          "ty": -1,
+          "tileId": "swordMountedLeft"
+        },
+        {
+          "tx": 6,
+          "ty": -1,
+          "tileId": "swordMountedRight"
+        },
+        {
+          "tx": 9,
+          "ty": -1,
+          "tileId": "shieldMounted"
+        },
+        {
+          "comment": "braziers flanking the stairs up to the solar"
+        },
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "brazierTop"
+        },
+        {
+          "tx": 1,
+          "ty": 2,
+          "tileId": "brazierBottom"
+        },
+        {
+          "tx": 10,
+          "ty": 1,
+          "tileId": "brazierTop"
+        },
+        {
+          "tx": 10,
+          "ty": 2,
+          "tileId": "brazierBottom"
+        },
+        {
+          "comment": "map chests and supplies"
+        },
+        {
+          "tx": 1,
+          "ty": 7,
+          "tileId": "chest"
+        },
+        {
+          "tx": 2,
+          "ty": 7,
+          "tileId": "chest"
+        },
+        {
+          "tx": 9,
+          "ty": 7,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 10,
+          "ty": 7,
+          "tileId": "crate"
+        },
+        {
+          "comment": "stairs up to the lord's solar"
+        },
+        {
+          "tx": 5,
+          "ty": 0,
+          "tileId": "ladderBottom"
+        },
+        {
+          "tx": 5,
+          "ty": -1,
+          "tileId": "fullLadderTop"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 11,
+          "ty": 4,
+          "toInteriorId": "keep",
+          "entryTx": 2,
+          "entryTy": 5,
+          "direction": "right",
+          "label": "Great Hall"
+        },
+        {
+          "tx": 5,
+          "ty": 0,
+          "toInteriorId": "keep-solar",
+          "entryTx": 5,
+          "entryTy": 6,
+          "direction": "up",
+          "label": "Lord's Solar"
+        }
+      ]
+    },
+    "keep-solar": {
+      "name": "The Lord's Solar",
+      "width": 12,
+      "height": 9,
+      "floorTileId": "woodFloor",
+      "wallTileId": "castleStone",
+      "decor": [
+        {
+          "comment": "stairs down into the war room"
+        },
+        {
+          "tx": 5,
+          "ty": 6,
+          "tileId": "ladderIntoFloor",
+          "zlayer": "below"
+        },
+        {
+          "tx": 5,
+          "ty": 5,
+          "tileId": "halfLadderTop"
+        },
+        {
+          "comment": "lord's bed against the back wall"
+        },
+        {
+          "tx": 1,
+          "ty": 1,
+          "bundleID": "simple-bed"
+        },
+        {
+          "comment": "fireplace and reading nook"
+        },
+        {
+          "tx": 8,
+          "ty": -1,
+          "tileId": "fireplaceTopMiddle"
+        },
+        {
+          "tx": 8,
+          "ty": 0,
+          "tileId": "fireplaceBottomMiddle"
+        },
+        {
+          "tx": 9,
+          "ty": 1,
+          "tileId": "bookshelfTop"
+        },
+        {
+          "tx": 9,
+          "ty": 2,
+          "tileId": "bookshelfBottom"
+        },
+        {
+          "tx": 10,
+          "ty": 1,
+          "tileId": "bookshelfTop"
+        },
+        {
+          "tx": 10,
+          "ty": 2,
+          "tileId": "bookshelfBottom"
+        },
+        {
+          "comment": "writing desk"
+        },
+        {
+          "tx": 3,
+          "ty": 3,
+          "tileId": "roundTable"
+        },
+        {
+          "tx": 3,
+          "ty": 4,
+          "tileId": "stool"
+        },
+        {
+          "tx": 1,
+          "ty": 7,
+          "tileId": "chest"
+        },
+        {
+          "tx": 10,
+          "ty": 7,
+          "tileId": "candlestickLitTop"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 5,
+          "ty": 6,
+          "toInteriorId": "keep-war-room",
+          "entryTx": 5,
+          "entryTy": 1,
+          "direction": "down",
+          "label": "War Room"
+        }
+      ]
     },
     "armoury": {
       "name": "The Armoury",

--- a/web/src/data/hub/ironholdkeep/config.json
+++ b/web/src/data/hub/ironholdkeep/config.json
@@ -1487,7 +1487,7 @@
       ],
       "building": "smithy",
       "questGive": "castle-weapon-cache",
-      "questReceive": [ "castle-weapon-cache", "castle-forge-the-key" ],
+      "questReceive": "castle-weapon-cache",
       "schedule": [
         { "startHour": 0, "endHour": 6, "activity": "sleep", "location": { "type": "interior", "buildingId": "barracks", "tx": 3, "ty": 6 } },
         { "startHour": 6, "endHour": 19, "activity": "work", "location": { "type": "interior", "buildingId": "smithy", "tx": 5, "ty": 4 } },
@@ -1574,7 +1574,7 @@
       ],
       "building": "scriptorium",
       "questGive": "castle-siege-memory",
-      "questReceive": [ "castle-siege-memory", "castle-chronicle-for-ravenwatch" ],
+      "questReceive": "castle-siege-memory",
       "schedule": [
         { "startHour": 0, "endHour": 7, "activity": "sleep", "location": { "type": "interior", "buildingId": "scriptorium", "tx": 1, "ty": 6 } },
         { "startHour": 7, "endHour": 19, "activity": "work", "location": { "type": "interior", "buildingId": "scriptorium", "tx": 5, "ty": 5 } },

--- a/web/src/data/hub/ironholdkeep/questDefs.json
+++ b/web/src/data/hub/ironholdkeep/questDefs.json
@@ -667,6 +667,137 @@
       }
     },
     {
+      "id": "castle-forge-the-key",
+      "title": "A Key for Ravenwatch",
+      "type": "fetch",
+      "giverNpcId": "castle-blacksmith",
+      "receiverNpcId": "guard-captain-thorin",
+      "prerequisite": "quest:castle-weapon-cache",
+      "offerDialogue": "Ravenwatch's Guard Captain sent a wax impression and a plea — his armoury lock failed and no smith of his can match the old Ironhold wards. I've forged the key. Will you carry it to Captain Thorin yourself?",
+      "activeDialogue": "The key is for Guard Captain Thorin in Ravenwatch — you'll find him at the barracks. A lock's no good to a man who can't open it.",
+      "completeDialogue": "Ironhold steel, cut to an Ironhold ward — only Kern could have managed it. My thanks, traveller, and my thanks to the old forge. Tell Blacksmith Kern his work still has no equal.",
+      "steps": [
+        {
+          "key": "deliver",
+          "type": "deliver",
+          "targetNpcId": "guard-captain-thorin",
+          "required": 1
+        }
+      ],
+      "reward": {
+        "crystals": 75,
+        "friendship": {
+          "castle-blacksmith": 15
+        }
+      }
+    },
+    {
+      "id": "castle-chronicle-for-ravenwatch",
+      "title": "A Copy for the Chronicler",
+      "type": "fetch",
+      "giverNpcId": "castle-archivist",
+      "receiverNpcId": "chronicler",
+      "prerequisite": "quest:castle-siege-memory",
+      "offerDialogue": "Now that our Siege Chronicle is whole, Ravenwatch's Chronicler deserves a copy — the two towns share that history, and shared history is a kind of treaty. Carry this transcription to them.",
+      "activeDialogue": "The transcribed chronicle belongs in the hands of Ravenwatch's Chronicler. Histories kept apart are histories half-told.",
+      "completeDialogue": "The fall and recapture of Ironhold, in Elwyn's own careful hand — our archive has wanted this for a generation. The two towns are the closer for it. You have my deepest thanks, traveller.",
+      "steps": [
+        {
+          "key": "deliver",
+          "type": "deliver",
+          "targetNpcId": "chronicler",
+          "required": 1
+        }
+      ],
+      "reward": {
+        "crystals": 70,
+        "friendship": {
+          "castle-archivist": 20
+        }
+      }
+    },
+    {
+      "id": "castle-siege-engines",
+      "title": "Plans for the Siege-Master",
+      "type": "fetch",
+      "giverNpcId": "castle-guard-master",
+      "receiverNpcId": "siege-master",
+      "prerequisite": "quest:castle-watch-rotation",
+      "offerDialogue": "Ravenwatch's Siege-Master has forgotten more about trebuchets than I'll ever know — but Ironhold's wall-engine plans are the finest in the realm. Carry them over so they can be matched against his. Two minds, one defence.",
+      "activeDialogue": "The wall-engine plans go to Ravenwatch's Siege-Master. Best you find them before the next muster, traveller.",
+      "completeDialogue": "Ironhold's counterweights and my ranging tables — together these could hold any wall in the realm. Tell Doran the Siege-Master of Ravenwatch is in his debt.",
+      "steps": [
+        {
+          "key": "deliver",
+          "type": "deliver",
+          "targetNpcId": "siege-master",
+          "required": 1
+        }
+      ],
+      "reward": {
+        "crystals": 70,
+        "relationship": {
+          "castle-guard-master": { "track": "ally", "points": 8 }
+        }
+      }
+    },
+    {
+      "id": "castle-warm-welcome",
+      "title": "A Cask for the Inn",
+      "type": "fetch",
+      "giverNpcId": "castle-cook",
+      "receiverNpcId": "innkeeper-rosie",
+      "prerequisite": "quest:castle-feast-preparations",
+      "offerDialogue": "Rosie at the Ravenwatch inn brewed the ale for our last feast and never sent a bill — that's not a debt I'll leave unpaid. Carry this cask of Ironhold mead to her with my compliments.",
+      "activeDialogue": "The mead cask is for Innkeeper Rosie at the Ravenwatch inn. A kindness repaid is a road kept open.",
+      "completeDialogue": "Ironhold mead! And from Mabel, the old badger — tell her the next batch of ale's on the house, and her welcome at my hearth always. Safe travels, love.",
+      "steps": [
+        {
+          "key": "deliver",
+          "type": "deliver",
+          "targetNpcId": "innkeeper-rosie",
+          "required": 1
+        }
+      ],
+      "reward": {
+        "crystals": 55,
+        "friendship": {
+          "castle-cook": 20
+        }
+      }
+    },
+    {
+      "id": "castle-garrison-accord",
+      "title": "The Garrison Accord",
+      "type": "fetch",
+      "giverNpcId": "castle-commander",
+      "receiverNpcId": "commander-post",
+      "prerequisite": "quest:castle-message-ravenwatch",
+      "offerDialogue": "Thorin's reply has decided me. Ironhold and Ravenwatch should bind their garrisons under one accord — mutual relief, shared signals, no town to fall alone. Carry the sealed accord to the Ravenwatch command post.",
+      "activeDialogue": "The Garrison Accord must reach the Ravenwatch command post. This is the work of years, traveller — see it through.",
+      "completeDialogue": "Signed and sealed by both keeps. From this day the two towns answer one horn. You did not carry a letter, traveller — you carried an alliance. Ironhold will remember it.",
+      "steps": [
+        {
+          "key": "deliver",
+          "type": "deliver",
+          "targetNpcId": "commander-post",
+          "required": 1
+        }
+      ],
+      "reward": {
+        "crystals": 100,
+        "collectible": {
+          "id": "garrison-accord",
+          "name": "Garrison Accord",
+          "icon": "🤝",
+          "desc": "The signed pact binding Ironhold Keep and Ravenwatch to mutual defence."
+        },
+        "relationship": {
+          "castle-commander": { "track": "ally", "points": 15 }
+        }
+      }
+    },
+    {
       "id": "castle-message-ravenwatch",
       "title": "Message for the Captain",
       "type": "fetch",

--- a/web/src/data/hub/ironholdkeep/questDefs.json
+++ b/web/src/data/hub/ironholdkeep/questDefs.json
@@ -66,7 +66,7 @@
       "offerDialogue": "A chronicle of the great siege was separated from our archives years ago. Three pages were found and distributed around the keep. If you recover them, our history will be whole again.",
       "activeDialogue": {
         "page-1": "The first page was last seen in the commanders' hall. Worth checking the shelves.",
-        "page-2": "Good, one page found. The second was tucked away in the armory, of all places.",
+        "page-2": "Good, one page found. The second was tucked away in the armoury, of all places.",
         "page-3": "Two pages now — remarkable. The final page was stored in the barracks. Nearly done."
       },
       "completeDialogue": "The chronicle is complete. This account of the siege is irreplaceable. You have done the keep a great service, traveller.",
@@ -108,6 +108,561 @@
         },
         "friendship": {
           "castle-archivist": 30
+        }
+      }
+    },
+    {
+      "id": "castle-watch-rotation",
+      "title": "The Watch Rotation",
+      "type": "fetch",
+      "giverNpcId": "castle-guard-master",
+      "receiverNpcId": "castle-guard-master",
+      "offerDialogue": "A castle is only as strong as its watch. Three watch-tokens went astray when the rotation changed over. Gather them from the wall posts so I can reset the roster.",
+      "activeDialogue": "Three watch-tokens, out along the courtyard and bailey wall posts. Look sharp — a soldier learns to notice what's out of place.",
+      "completeDialogue": "Roster's whole again. You've a soldier's eye, traveller. Stand with us a while and you might earn a place on the wall.",
+      "steps": [
+        {
+          "key": "tokens",
+          "type": "collect",
+          "pickupIds": [
+            "watch-token-1",
+            "watch-token-2",
+            "watch-token-3"
+          ],
+          "required": 3
+        }
+      ],
+      "reward": {
+        "crystals": 50,
+        "relationship": {
+          "castle-guard-master": { "track": "ally", "points": 15 }
+        }
+      }
+    },
+    {
+      "id": "castle-drill-grounds",
+      "title": "Drill Grounds",
+      "type": "fetch",
+      "giverNpcId": "castle-guard-master",
+      "receiverNpcId": "castle-guard-master",
+      "prerequisite": "quest:castle-watch-rotation",
+      "offerDialogue": "The recruits left their drill gear scattered across the bailey like children. Round up three sets before I make them run the walls until dawn.",
+      "activeDialogue": "Drill gear — three sets, somewhere out in the bailey. Discipline starts with tidiness, traveller.",
+      "completeDialogue": "Gear stowed, recruits humbled. You'd make a fair Guard-Master yourself. The wall remembers those who keep it.",
+      "steps": [
+        {
+          "key": "gear",
+          "type": "collect",
+          "pickupIds": [
+            "drill-gear-1",
+            "drill-gear-2",
+            "drill-gear-3"
+          ],
+          "required": 3
+        }
+      ],
+      "reward": {
+        "crystals": 45,
+        "relationship": {
+          "castle-guard-master": { "track": "ally", "points": 12 }
+        }
+      }
+    },
+    {
+      "id": "castle-night-watch",
+      "title": "Orders for the Night Watch",
+      "type": "fetch",
+      "giverNpcId": "castle-guard-master",
+      "receiverNpcId": "castle-knight",
+      "prerequisite": "quest:castle-drill-grounds | relationship:castle-guard-master:ally:2",
+      "offerDialogue": "I trust you now, so I'll trust you with this. Carry the night-watch orders to Sir Garrick on the wall. He'll know what to do with them.",
+      "activeDialogue": "Sir Garrick keeps the eastern wall and the bailey boulevard. Find him and put these orders in his hand.",
+      "completeDialogue": "Orders from Doran himself? And carried by you. The Guard-Master doesn't hand his trust out lightly. My thanks, traveller.",
+      "steps": [
+        {
+          "key": "deliver",
+          "type": "deliver",
+          "targetNpcId": "castle-knight",
+          "required": 1
+        }
+      ],
+      "reward": {
+        "crystals": 60,
+        "relationship": {
+          "castle-guard-master": { "track": "ally", "points": 15 }
+        }
+      }
+    },
+    {
+      "id": "castle-supply-tally",
+      "title": "The Supply Tally",
+      "type": "fetch",
+      "giverNpcId": "castle-quartermaster",
+      "receiverNpcId": "castle-quartermaster",
+      "offerDialogue": "My ledgers have walked off again — one in the store, one in the granary, one left in the kitchens by that careless cook. Bring them back before the audit.",
+      "activeDialogue": "Three ledgers: the store, the granary, the kitchens. A castle that loses count of its grain loses its siege.",
+      "completeDialogue": "All three ledgers, and not a figure smudged. You've a tidy hand, traveller. I'll remember it next time you need supplies.",
+      "steps": [
+        {
+          "key": "ledgers",
+          "type": "collect",
+          "pickupIds": [
+            "supply-ledger-1",
+            "supply-ledger-2",
+            "supply-ledger-3"
+          ],
+          "required": 3
+        }
+      ],
+      "reward": {
+        "crystals": 45,
+        "friendship": {
+          "castle-quartermaster": 20
+        }
+      }
+    },
+    {
+      "id": "castle-grain-stores",
+      "title": "Restock the Granary",
+      "type": "fetch",
+      "giverNpcId": "castle-quartermaster",
+      "receiverNpcId": "castle-quartermaster",
+      "prerequisite": "quest:castle-supply-tally",
+      "offerDialogue": "Four sacks of grain spilled off the supply cart in the bailey. Gather them up — every grain counts when the gates are shut and the larder's all you have.",
+      "activeDialogue": "Four grain sacks, scattered along the bailey boulevard. Mind the rats don't get to them first.",
+      "completeDialogue": "Granary's full again. You've kept a hundred bellies fed without lifting a sword. That's its own kind of soldiering.",
+      "steps": [
+        {
+          "key": "sacks",
+          "type": "collect",
+          "pickupIds": [
+            "grain-sack-1",
+            "grain-sack-2",
+            "grain-sack-3",
+            "grain-sack-4"
+          ],
+          "required": 4
+        }
+      ],
+      "reward": {
+        "crystals": 50
+      }
+    },
+    {
+      "id": "castle-arrow-count",
+      "title": "Count the Quivers",
+      "type": "fetch",
+      "giverNpcId": "castle-quartermaster",
+      "receiverNpcId": "castle-quartermaster",
+      "prerequisite": "quest:castle-grain-stores",
+      "offerDialogue": "Three bundles of arrows never made it to the armoury. Find them around the courtyard before the archers notice they're short.",
+      "activeDialogue": "Three arrow bundles, somewhere in the inner courtyard. An empty quiver is a dead archer.",
+      "completeDialogue": "Counted and stowed. The wall can loose a full volley again, thanks to you.",
+      "steps": [
+        {
+          "key": "arrows",
+          "type": "collect",
+          "pickupIds": [
+            "arrow-bundle-1",
+            "arrow-bundle-2",
+            "arrow-bundle-3"
+          ],
+          "required": 3
+        }
+      ],
+      "reward": {
+        "crystals": 45
+      }
+    },
+    {
+      "id": "castle-forge-repairs",
+      "title": "Blades for Mending",
+      "type": "fetch",
+      "giverNpcId": "castle-blacksmith",
+      "receiverNpcId": "castle-blacksmith",
+      "prerequisite": "quest:castle-weapon-cache",
+      "offerDialogue": "The drill cracked three blades clean through. The recruits dropped them where they stood — find them and I'll reforge the steel before it rusts.",
+      "activeDialogue": "Three broken blades, out along the courtyard. Good steel's too dear to leave in the mud.",
+      "completeDialogue": "Three blades for the fire. I'll have them whole by morning. You've a smith's respect for good iron, traveller.",
+      "steps": [
+        {
+          "key": "blades",
+          "type": "collect",
+          "pickupIds": [
+            "broken-blade-1",
+            "broken-blade-2",
+            "broken-blade-3"
+          ],
+          "required": 3
+        }
+      ],
+      "reward": {
+        "crystals": 50,
+        "friendship": {
+          "castle-blacksmith": 20
+        }
+      }
+    },
+    {
+      "id": "castle-feast-preparations",
+      "title": "Feast Preparations",
+      "type": "fetch",
+      "giverNpcId": "castle-cook",
+      "receiverNpcId": "castle-cook",
+      "offerDialogue": "The Commander wants a feast and gives me a day to make it. Fetch me three things from the stores — salt, a wheel of cheese, and a barrel of ale — or it's gruel for the lot of them.",
+      "activeDialogue": "Salt, cheese, ale — scattered between the granary, the store, and the bailey. A feast doesn't cook itself, traveller.",
+      "completeDialogue": "All three, and just in time. Sit at the low table tonight — you've earned a hot plate, which is more than most around here.",
+      "steps": [
+        {
+          "key": "ingredients",
+          "type": "collect",
+          "pickupIds": [
+            "feast-salt",
+            "feast-cheese",
+            "feast-ale"
+          ],
+          "required": 3
+        }
+      ],
+      "reward": {
+        "crystals": 45,
+        "friendship": {
+          "castle-cook": 25
+        }
+      }
+    },
+    {
+      "id": "castle-missing-cutlery",
+      "title": "The Missing Cutlery",
+      "type": "lost-items",
+      "giverNpcId": "castle-cook",
+      "receiverNpcId": "castle-cook",
+      "prerequisite": "quest:castle-feast-preparations",
+      "offerDialogue": "Half my serving plates vanished after the feast. Soldiers, the lot of them — magpies with swords. Find four and bring them back to my kitchen.",
+      "activeDialogue": "Four serving plates, somewhere between the great hall and the kitchens. They didn't sprout legs and walk.",
+      "completeDialogue": "Four plates returned. I'll not ask which guard's bunk you found them under. Bless you, traveller.",
+      "steps": [
+        {
+          "key": "plates",
+          "type": "collect",
+          "pickupIds": [
+            "plate-1",
+            "plate-2",
+            "plate-3",
+            "plate-4"
+          ],
+          "required": 4
+        }
+      ],
+      "reward": {
+        "crystals": 40
+      }
+    },
+    {
+      "id": "castle-lost-foal",
+      "title": "The Lost Foal",
+      "type": "fetch",
+      "giverNpcId": "castle-stablehand",
+      "receiverNpcId": "castle-stablehand",
+      "offerDialogue": "A foal slipped its stall and bolted into the bailey. I can't leave the other horses to chase it. Find its bell — it'll be wherever the little rascal shook it loose.",
+      "activeDialogue": "The foal's bell came off somewhere in the bailey. Find it and I'll know which way the creature ran.",
+      "completeDialogue": "That's the bell! I can track it now. You've saved me a thrashing from the Quartermaster — a lost horse is a costly horse.",
+      "steps": [
+        {
+          "key": "bell",
+          "type": "collect",
+          "pickupIds": [
+            "foal-bell"
+          ],
+          "required": 1
+        }
+      ],
+      "reward": {
+        "crystals": 35,
+        "friendship": {
+          "castle-stablehand": 15
+        }
+      }
+    },
+    {
+      "id": "castle-fresh-hay",
+      "title": "Fresh Hay for the Stalls",
+      "type": "fetch",
+      "giverNpcId": "castle-stablehand",
+      "receiverNpcId": "castle-stablehand",
+      "prerequisite": "quest:castle-lost-foal",
+      "offerDialogue": "The destriers won't bed down on old straw. Three fresh bales were dropped between the granary and the stables. Haul them over for me?",
+      "activeDialogue": "Three hay bales, between the granary and the stables. The horses are picky as princes, I'm afraid.",
+      "completeDialogue": "Soft beds for fussy horses. They'll sleep better than the Commander tonight. My thanks, traveller.",
+      "steps": [
+        {
+          "key": "hay",
+          "type": "collect",
+          "pickupIds": [
+            "hay-bale-1",
+            "hay-bale-2",
+            "hay-bale-3"
+          ],
+          "required": 3
+        }
+      ],
+      "reward": {
+        "crystals": 40
+      }
+    },
+    {
+      "id": "castle-squires-trial",
+      "title": "The Squire's Trial",
+      "type": "lost-items",
+      "giverNpcId": "castle-squire",
+      "receiverNpcId": "castle-squire",
+      "offerDialogue": "Don't tell the Guard-Master — I lost three training swords during practice and he'll have me scrubbing pots for a month. Help me find them and I'll owe you for life.",
+      "activeDialogue": "Three training swords, out where we drill in the bailey and the courtyard. Quick, before Doran counts the rack.",
+      "completeDialogue": "All three! You're a lifesaver. One day I'll be a knight and I'll remember who kept me out of the kitchens.",
+      "steps": [
+        {
+          "key": "swords",
+          "type": "collect",
+          "pickupIds": [
+            "training-sword-1",
+            "training-sword-2",
+            "training-sword-3"
+          ],
+          "required": 3
+        }
+      ],
+      "reward": {
+        "crystals": 40,
+        "friendship": {
+          "castle-squire": 20
+        }
+      }
+    },
+    {
+      "id": "castle-archivists-index",
+      "title": "The Archivist's Index",
+      "type": "chain",
+      "giverNpcId": "castle-archivist",
+      "receiverNpcId": "castle-archivist",
+      "prerequisite": "quest:castle-siege-memory",
+      "offerDialogue": "Now that the chronicle is whole, I'm rebuilding the index that links it to the rest of our records. Three index cards were filed in the wrong rooms. Recover them in order and the catalogue lives again.",
+      "activeDialogue": {
+        "index-1": "The first index card should be here in the scriptorium, misfiled among the ledgers.",
+        "index-2": "One found. The second was carried up to the keep's great hall — check the shelves there.",
+        "index-3": "Two now. The last was left in the barracks. Soldiers and books — never a happy pairing."
+      },
+      "completeDialogue": "The index is restored. Future archivists will bless your name without ever knowing it. That is the quiet reward of history.",
+      "steps": [
+        {
+          "key": "index-1",
+          "type": "collect",
+          "pickupIds": [ "index-card-1" ],
+          "required": 1
+        },
+        {
+          "key": "index-2",
+          "type": "collect",
+          "pickupIds": [ "index-card-2" ],
+          "required": 1,
+          "chain": "index-card-1"
+        },
+        {
+          "key": "index-3",
+          "type": "collect",
+          "pickupIds": [ "index-card-3" ],
+          "required": 1,
+          "chain": "index-card-2"
+        }
+      ],
+      "reward": {
+        "crystals": 55,
+        "friendship": {
+          "castle-archivist": 25
+        }
+      }
+    },
+    {
+      "id": "castle-restless-crypt",
+      "title": "The Restless Crypt",
+      "type": "fetch",
+      "giverNpcId": "castle-chaplain",
+      "receiverNpcId": "castle-chaplain",
+      "offerDialogue": "The candles in the crypt have guttered out, and the old lords do not rest in the dark. Three grave-candles wait to be relit below. Will you tend the dead with me?",
+      "activeDialogue": "Three grave-candles in the crypt beneath the chapel. Carry the light gently — the dead notice disrespect.",
+      "completeDialogue": "The crypt glows again, and the keep feels lighter for it. The lords of Ironhold thank you in the only way the dead can — with peace.",
+      "steps": [
+        {
+          "key": "candles",
+          "type": "collect",
+          "pickupIds": [
+            "grave-candle-1",
+            "grave-candle-2",
+            "grave-candle-3"
+          ],
+          "required": 3
+        }
+      ],
+      "reward": {
+        "crystals": 45,
+        "friendship": {
+          "castle-chaplain": 25
+        }
+      }
+    },
+    {
+      "id": "castle-prisoners-plea",
+      "title": "The Prisoner's Plea",
+      "type": "fetch",
+      "giverNpcId": "castle-prisoner",
+      "receiverNpcId": "castle-prisoner",
+      "offerDialogue": "You there — with the kind face. I was thrown in here for a theft I never did. There's a letter in the scriptorium that proves it. Find it, and I'll tell you a secret worth more than my freedom.",
+      "activeDialogue": "The letter that clears me is filed somewhere in the scriptorium. The Archivist won't miss one yellowed page.",
+      "completeDialogue": "That's it — the letter, in the steward's own hand. I'm no thief. Now listen: the lower vault holds the truth of why I'm here. Win the Guard-Master's trust and the key is yours.",
+      "steps": [
+        {
+          "key": "letter",
+          "type": "collect",
+          "pickupIds": [
+            "prisoner-letter"
+          ],
+          "required": 1
+        }
+      ],
+      "reward": {
+        "crystals": 30
+      }
+    },
+    {
+      "id": "castle-prison-key",
+      "title": "The Vault Key",
+      "type": "chain",
+      "giverNpcId": "castle-guard-master",
+      "receiverNpcId": "castle-guard-master",
+      "prerequisite": "quest:castle-prisoners-plea | relationship:castle-guard-master:ally:2",
+      "offerDialogue": "The prisoner's letter rings true, and you've earned my trust. The vault key was broken in two and hidden so no one man could open it alone. Recover both halves and I'll have the smith forge them whole.",
+      "activeDialogue": {
+        "half-1": "One key-half was hidden in the dungeon cells themselves. Search where the light from the cell window falls.",
+        "half-2": "Good. The second half went up the great tower, to the lookout. No one climbs there but the watch."
+      },
+      "completeDialogue": "Both halves. Kern will forge them into one. Take the vault key — and whatever truth waits at the bottom of the keep, face it with a clear eye.",
+      "steps": [
+        {
+          "key": "half-1",
+          "type": "collect",
+          "pickupIds": [ "key-half-1" ],
+          "required": 1
+        },
+        {
+          "key": "half-2",
+          "type": "collect",
+          "pickupIds": [ "key-half-2" ],
+          "required": 1,
+          "chain": "key-half-1"
+        }
+      ],
+      "reward": {
+        "crystals": 70,
+        "collectible": {
+          "id": "vault-key",
+          "name": "Vault Key",
+          "icon": "🗝️",
+          "desc": "The reforged key to the lower vault beneath Ironhold Keep."
+        },
+        "relationship": {
+          "castle-guard-master": { "track": "ally", "points": 10 }
+        }
+      }
+    },
+    {
+      "id": "castle-vault-truth",
+      "title": "The Truth in the Vault",
+      "type": "fetch",
+      "giverNpcId": "castle-prisoner",
+      "receiverNpcId": "castle-prisoner",
+      "prerequisite": "quest:castle-prison-key",
+      "offerDialogue": "You have the key. Then go down — the lower vault holds the ledger that names the real thief, the one who put me here. Bring it up and my name is cleared at last.",
+      "activeDialogue": "The ledger is in the lower vault, past the locked door in the cells. The key is yours now — use it.",
+      "completeDialogue": "There — the true thief's name, in black ink. The Commander cannot deny this. I'm a free man because of you, traveller. Take this; it's all I have, and you've earned far more.",
+      "steps": [
+        {
+          "key": "ledger",
+          "type": "collect",
+          "pickupIds": [
+            "vault-ledger"
+          ],
+          "required": 1
+        }
+      ],
+      "reward": {
+        "crystals": 90,
+        "collectible": {
+          "id": "pardon-writ",
+          "name": "Writ of Pardon",
+          "icon": "📜",
+          "desc": "A pardon won by uncovering the truth beneath Ironhold Keep."
+        },
+        "relationship": {
+          "castle-prisoner": { "track": "ally", "points": 20 }
+        }
+      }
+    },
+    {
+      "id": "castle-gate-inspection",
+      "title": "Gate Inspection",
+      "type": "fetch",
+      "giverNpcId": "castle-gatekeeper",
+      "receiverNpcId": "castle-gatekeeper",
+      "offerDialogue": "Can't leave my post, but the outer gate hasn't been inspected since the spring thaw. Three inspection chalks were left at the gate stones. Mark them off for me and the portcullis stays certified.",
+      "activeDialogue": "Three inspection chalks, down by the outer gate and along the approach. A jammed portcullis is a breached castle.",
+      "completeDialogue": "All marked, all sound. The gate'll hold another season. You've a careful eye, traveller — rare in folk just passing through.",
+      "steps": [
+        {
+          "key": "chalks",
+          "type": "collect",
+          "pickupIds": [
+            "gate-chalk-1",
+            "gate-chalk-2",
+            "gate-chalk-3"
+          ],
+          "required": 3
+        }
+      ],
+      "reward": {
+        "crystals": 40
+      }
+    },
+    {
+      "id": "castle-banner-of-ironhold",
+      "title": "The Banner of Ironhold",
+      "type": "fetch",
+      "giverNpcId": "castle-commander",
+      "receiverNpcId": "castle-commander",
+      "prerequisite": "quest:castle-missing-patrol",
+      "offerDialogue": "The great banner of Ironhold was taken down for mending and the pieces were scattered to three trades — the smith, the seamstress, the chapel. Gather the three fragments so it can fly above the keep once more.",
+      "activeDialogue": "Three banner fragments — one near the forge, one in the chapel, one in the great hall. A keep without its banner is just a pile of stones.",
+      "completeDialogue": "The banner is whole, and it will fly at first light. You've given Ironhold back its pride, traveller. That is no small thing.",
+      "steps": [
+        {
+          "key": "fragments",
+          "type": "collect",
+          "pickupIds": [
+            "banner-fragment-1",
+            "banner-fragment-2",
+            "banner-fragment-3"
+          ],
+          "required": 3
+        }
+      ],
+      "reward": {
+        "crystals": 65,
+        "collectible": {
+          "id": "ironhold-banner",
+          "name": "Ironhold Banner",
+          "icon": "🚩",
+          "desc": "The restored grey-and-iron banner of Ironhold Keep."
+        },
+        "friendship": {
+          "castle-commander": 25
         }
       }
     },
@@ -202,7 +757,424 @@
       "questId": "castle-siege-memory",
       "building": "barracks",
       "chain": "chronicle-page-2"
+    },
+    {
+      "id": "watch-token-1",
+      "tx": 10,
+      "ty": 22,
+      "tileId": "smallSign",
+      "questId": "castle-watch-rotation"
+    },
+    {
+      "id": "watch-token-2",
+      "tx": 25,
+      "ty": 22,
+      "tileId": "smallSign",
+      "questId": "castle-watch-rotation"
+    },
+    {
+      "id": "watch-token-3",
+      "tx": 8,
+      "ty": 43,
+      "tileId": "smallSign",
+      "questId": "castle-watch-rotation"
+    },
+    {
+      "id": "drill-gear-1",
+      "tx": 12,
+      "ty": 44,
+      "tileId": "crate",
+      "questId": "castle-drill-grounds"
+    },
+    {
+      "id": "drill-gear-2",
+      "tx": 31,
+      "ty": 44,
+      "tileId": "crate",
+      "questId": "castle-drill-grounds"
+    },
+    {
+      "id": "drill-gear-3",
+      "tx": 20,
+      "ty": 40,
+      "tileId": "openCrate",
+      "questId": "castle-drill-grounds"
+    },
+    {
+      "id": "supply-ledger-1",
+      "tx": 8,
+      "ty": 6,
+      "tileId": "smallSign",
+      "questId": "castle-supply-tally",
+      "building": "quartermasters-store"
+    },
+    {
+      "id": "supply-ledger-2",
+      "tx": 7,
+      "ty": 6,
+      "tileId": "smallSign",
+      "questId": "castle-supply-tally",
+      "building": "granary"
+    },
+    {
+      "id": "supply-ledger-3",
+      "tx": 1,
+      "ty": 4,
+      "tileId": "smallSign",
+      "questId": "castle-supply-tally",
+      "building": "kitchens"
+    },
+    {
+      "id": "grain-sack-1",
+      "tx": 6,
+      "ty": 44,
+      "tileId": "sack",
+      "questId": "castle-grain-stores"
+    },
+    {
+      "id": "grain-sack-2",
+      "tx": 9,
+      "ty": 44,
+      "tileId": "sack",
+      "questId": "castle-grain-stores"
+    },
+    {
+      "id": "grain-sack-3",
+      "tx": 30,
+      "ty": 44,
+      "tileId": "sack",
+      "questId": "castle-grain-stores"
+    },
+    {
+      "id": "grain-sack-4",
+      "tx": 33,
+      "ty": 44,
+      "tileId": "sack",
+      "questId": "castle-grain-stores"
+    },
+    {
+      "id": "arrow-bundle-1",
+      "tx": 22,
+      "ty": 22,
+      "tileId": "crate",
+      "questId": "castle-arrow-count"
+    },
+    {
+      "id": "arrow-bundle-2",
+      "tx": 24,
+      "ty": 23,
+      "tileId": "crate",
+      "questId": "castle-arrow-count"
+    },
+    {
+      "id": "arrow-bundle-3",
+      "tx": 27,
+      "ty": 22,
+      "tileId": "openCrate",
+      "questId": "castle-arrow-count"
+    },
+    {
+      "id": "broken-blade-1",
+      "tx": 14,
+      "ty": 22,
+      "tileId": "smallSign",
+      "questId": "castle-forge-repairs"
+    },
+    {
+      "id": "broken-blade-2",
+      "tx": 9,
+      "ty": 23,
+      "tileId": "smallSign",
+      "questId": "castle-forge-repairs"
+    },
+    {
+      "id": "broken-blade-3",
+      "tx": 27,
+      "ty": 23,
+      "tileId": "smallSign",
+      "questId": "castle-forge-repairs"
+    },
+    {
+      "id": "feast-salt",
+      "tx": 4,
+      "ty": 4,
+      "tileId": "sack",
+      "questId": "castle-feast-preparations",
+      "building": "granary"
+    },
+    {
+      "id": "feast-cheese",
+      "tx": 2,
+      "ty": 4,
+      "tileId": "crate",
+      "questId": "castle-feast-preparations",
+      "building": "quartermasters-store"
+    },
+    {
+      "id": "feast-ale",
+      "tx": 36,
+      "ty": 44,
+      "tileId": "barrel",
+      "questId": "castle-feast-preparations"
+    },
+    {
+      "id": "plate-1",
+      "tx": 4,
+      "ty": 6,
+      "tileId": "smallSign",
+      "questId": "castle-missing-cutlery",
+      "building": "kitchens"
+    },
+    {
+      "id": "plate-2",
+      "tx": 9,
+      "ty": 6,
+      "tileId": "smallSign",
+      "questId": "castle-missing-cutlery",
+      "building": "kitchens"
+    },
+    {
+      "id": "plate-3",
+      "tx": 3,
+      "ty": 6,
+      "tileId": "smallSign",
+      "questId": "castle-missing-cutlery",
+      "building": "keep"
+    },
+    {
+      "id": "plate-4",
+      "tx": 11,
+      "ty": 6,
+      "tileId": "smallSign",
+      "questId": "castle-missing-cutlery",
+      "building": "keep"
+    },
+    {
+      "id": "foal-bell",
+      "tx": 24,
+      "ty": 44,
+      "tileId": "smallSign",
+      "questId": "castle-lost-foal"
+    },
+    {
+      "id": "hay-bale-1",
+      "tx": 5,
+      "ty": 44,
+      "tileId": "sack",
+      "questId": "castle-fresh-hay"
+    },
+    {
+      "id": "hay-bale-2",
+      "tx": 7,
+      "ty": 51,
+      "tileId": "sack",
+      "questId": "castle-fresh-hay"
+    },
+    {
+      "id": "hay-bale-3",
+      "tx": 4,
+      "ty": 4,
+      "tileId": "sack",
+      "questId": "castle-fresh-hay",
+      "building": "stables"
+    },
+    {
+      "id": "training-sword-1",
+      "tx": 17,
+      "ty": 41,
+      "tileId": "smallSign",
+      "questId": "castle-squires-trial"
+    },
+    {
+      "id": "training-sword-2",
+      "tx": 22,
+      "ty": 44,
+      "tileId": "smallSign",
+      "questId": "castle-squires-trial"
+    },
+    {
+      "id": "training-sword-3",
+      "tx": 20,
+      "ty": 23,
+      "tileId": "smallSign",
+      "questId": "castle-squires-trial"
+    },
+    {
+      "id": "index-card-1",
+      "tx": 10,
+      "ty": 6,
+      "tileId": "smallSign",
+      "questId": "castle-archivists-index",
+      "building": "scriptorium"
+    },
+    {
+      "id": "index-card-2",
+      "tx": 13,
+      "ty": 6,
+      "tileId": "smallSign",
+      "questId": "castle-archivists-index",
+      "building": "keep",
+      "chain": "index-card-1"
+    },
+    {
+      "id": "index-card-3",
+      "tx": 9,
+      "ty": 6,
+      "tileId": "smallSign",
+      "questId": "castle-archivists-index",
+      "building": "barracks",
+      "chain": "index-card-2"
+    },
+    {
+      "id": "grave-candle-1",
+      "tx": 2,
+      "ty": 4,
+      "tileId": "candlestickUnlit",
+      "questId": "castle-restless-crypt",
+      "building": "chapel-crypt"
+    },
+    {
+      "id": "grave-candle-2",
+      "tx": 8,
+      "ty": 4,
+      "tileId": "candlestickUnlit",
+      "questId": "castle-restless-crypt",
+      "building": "chapel-crypt"
+    },
+    {
+      "id": "grave-candle-3",
+      "tx": 11,
+      "ty": 3,
+      "tileId": "candlestickUnlit",
+      "questId": "castle-restless-crypt",
+      "building": "chapel-crypt"
+    },
+    {
+      "id": "prisoner-letter",
+      "tx": 6,
+      "ty": 6,
+      "tileId": "smallSign",
+      "questId": "castle-prisoners-plea",
+      "building": "scriptorium"
+    },
+    {
+      "id": "key-half-1",
+      "tx": 6,
+      "ty": 5,
+      "tileId": "smallSign",
+      "questId": "castle-prison-key",
+      "building": "dungeon-cells"
+    },
+    {
+      "id": "key-half-2",
+      "tx": 3,
+      "ty": 4,
+      "tileId": "smallSign",
+      "questId": "castle-prison-key",
+      "building": "great-tower-top",
+      "chain": "key-half-1"
+    },
+    {
+      "id": "vault-ledger",
+      "tx": 5,
+      "ty": 3,
+      "tileId": "smallSign",
+      "questId": "castle-vault-truth",
+      "building": "dungeon-vault"
+    },
+    {
+      "id": "gate-chalk-1",
+      "tx": 17,
+      "ty": 47,
+      "tileId": "smallSign",
+      "questId": "castle-gate-inspection"
+    },
+    {
+      "id": "gate-chalk-2",
+      "tx": 18,
+      "ty": 49,
+      "tileId": "smallSign",
+      "questId": "castle-gate-inspection"
+    },
+    {
+      "id": "gate-chalk-3",
+      "tx": 17,
+      "ty": 33,
+      "tileId": "smallSign",
+      "questId": "castle-gate-inspection"
+    },
+    {
+      "id": "banner-fragment-1",
+      "tx": 6,
+      "ty": 4,
+      "tileId": "smallSign",
+      "questId": "castle-banner-of-ironhold",
+      "building": "smithy"
+    },
+    {
+      "id": "banner-fragment-2",
+      "tx": 3,
+      "ty": 4,
+      "tileId": "smallSign",
+      "questId": "castle-banner-of-ironhold",
+      "building": "chapel"
+    },
+    {
+      "id": "banner-fragment-3",
+      "tx": 8,
+      "ty": 5,
+      "tileId": "smallSign",
+      "questId": "castle-banner-of-ironhold",
+      "building": "keep"
     }
   ],
+  "dialogues": [
+    {
+      "id": "varek-chat",
+      "npcId": "castle-commander",
+      "start": "greet",
+      "nodes": {
+        "greet": {
+          "text": "Commander Varek looks up from his maps. \"Speak, traveller. The keep's business never sleeps and neither, it seems, do I.\"",
+          "choices": [
+            { "label": "Tell me about Ironhold.", "next": "lore" },
+            { "label": "How do you hold the line?", "next": "defence" },
+            { "label": "I serve Ravenwatch — and the keep.", "effects": [ { "type": "relationship", "npcId": "castle-commander", "track": "ally", "points": 6 }, { "type": "friendship", "npcId": "castle-commander", "xp": 5 } ], "next": "ally" },
+            { "label": "Nothing for now.", "effects": [ { "type": "end" } ] }
+          ]
+        },
+        "lore": {
+          "text": "\"Three centuries this rock has stood. Every stone is a name, every name a grave. We do not lose Ironhold. We simply die before it falls.\"",
+          "choices": [
+            { "label": "A grim creed.", "next": "greet" },
+            { "label": "Understood, Commander.", "effects": [ { "type": "end" } ] }
+          ]
+        },
+        "defence": {
+          "text": "\"Walls, discipline, and men who would rather break than bend. Doran drills them, Kern arms them, and I give them a reason. That is a castle.\"",
+          "choices": [
+            { "label": "And the cross-town pacts?", "next": "ally" },
+            { "label": "Thank you.", "effects": [ { "type": "end" } ] }
+          ]
+        },
+        "ally": {
+          "text": "\"Ravenwatch and Ironhold are two fists of the same arm. Carry word between us and you carry the realm itself. I'll not forget a courier I can trust.\"",
+          "choices": [
+            { "label": "You can count on me.", "effects": [ { "type": "relationship", "npcId": "castle-commander", "track": "ally", "points": 8 }, { "type": "flag", "flag": "varek-sworn" } ] },
+            { "label": "Farewell, Commander.", "effects": [ { "type": "end" } ] }
+          ]
+        }
+      }
+    }
+  ],
+  "relationshipDialogue": {
+    "castle-guard-master": {
+      "ally": {
+        "2": "Doran gives a curt nod. \"You've stood enough watches with us. The wall counts you a friend now.\"",
+        "3": "\"Half the recruits would follow you over the parapet if you asked. Don't let it go to your head.\"",
+        "4": "\"There's a place on this wall for you any day you want it, traveller. That's the highest word I have.\""
+      }
+    }
+  },
   "blockedPaths": []
 }

--- a/web/src/data/hub/ironholdkeep/questDefs.json
+++ b/web/src/data/hub/ironholdkeep/questDefs.json
@@ -183,7 +183,7 @@
       "ty": 2,
       "tileId": "smallSign",
       "questId": "castle-siege-memory",
-      "building": "commanders-hall"
+      "building": "keep"
     },
     {
       "id": "chronicle-page-2",
@@ -191,7 +191,7 @@
       "ty": 2,
       "tileId": "smallSign",
       "questId": "castle-siege-memory",
-      "building": "armory",
+      "building": "armoury",
       "chain": "chronicle-page-1"
     },
     {


### PR DESCRIPTION
Brings **Ironhold Keep** up to Tier A richness (epic #1732, issue #1737), rivalling the gold-standard Ravenwatch.

## Approach
- **Enlarged the map** by extending **south + east only** (36×36 → 44×54 tiles) so no existing coordinate was offset — a new **Outer Bailey** district hosts the new service buildings.
- **Heavy cross-town web** linking Ironhold ↔ Ravenwatch (per #1735).

## Result (before → after)
| | Before | After |
|---|---|---|
| Map (tiles) | 36×36 | 44×54 |
| Buildings | 12 | 22 |
| Furnished interiors | 3 (single-room) | 19 (multi-room key buildings) |
| NPCs | 5 | 14 (all scheduled, homeBeds) |
| Quests | 4 | 28 (6 cross-town) |
| Decor | ~133 | ~410 |

## Phases (all complete)
- [x] **Phase 1** — Enlarge map; Outer Bailey area + street grid; move south exit; relocate 3 out-of-bounds interior NPCs; resize armoury/barracks interiors; fix two chronicle pickup `building` ids (cross-cutting #1733/#1734 fixes).
- [x] **Phase 2** — Keep multi-room interior (Great Hall → war room → lord's solar).
- [x] **Phase 3** — 10 new furnished bailey buildings, incl. multi-room chapel + crypt, multi-level great tower, and multi-level dungeon (cells + locked lower vault).
- [x] **Phase 4** — 14 NPCs with 24h schedules (work/sleep/eat/sweep/idle-chat poses, guard patrols) + homeBeds.
- [x] **Phase 5** — 23 internal quests + 58 pickups; `varek-chat` branching dialogue tree; guard-master relationship dialogue; prison/intrigue chain gated by `relationship:castle-guard-master:ally:2` + the locked vault.
- [x] **Phase 6** — 6 cross-town delivery quests to existing Ravenwatch NPCs (guard captain, chronicler, siege-master, innkeeper, command post). No Ravenwatch layout changes.
- [x] **Phase 7** — Outer Bailey decor (~30 items: braziers, drill/siege gear, stores), chicken pen + placed hounds/ravens.

## Acceptance criteria
- ✅ ~12–20 furnished interior buildings (19), key ones multi-room incl. multi-level dungeon + tower.
- ✅ ~25–40 quests (28); 12–20 NPCs (14).
- ✅ Every real building's door resolves onto a street tile; all ≥6 rows tall; no interior decor/NPC out of bounds (back-wall `ty=-1/-2` excepted).
- ✅ All quests reference valid NPCs/pickups (incl. cross-town); bidirectional sub-room exits.
- ✅ `cd web && npm run test` (loader tests) + `npm run build` pass.

Part of epic #1732.

🤖 Generated with [Claude Code](https://claude.com/claude-code)