### PR TITLE
Hub town expansion: Dreadspire Citadel (Tier B) — #1738

### DIFF
--- a/web/public/sprites/hub-npc-cultist.svg
+++ b/web/public/sprites/hub-npc-cultist.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- shadow -->
+  <ellipse cx="16" cy="29" rx="5" ry="2" fill="rgba(0,0,0,0.25)"/>
+  <!-- hooded robe -->
+  <path d="M9 13 L23 13 L24 28 L8 28 Z" fill="#3a1420"/>
+  <!-- robe seam -->
+  <rect x="15" y="14" width="2" height="14" fill="#260d16"/>
+  <!-- rope belt -->
+  <rect x="9" y="20" width="14" height="1.6" rx="0.8" fill="#7a5a2a"/>
+  <!-- sleeves -->
+  <rect x="7"  y="14" width="3" height="8" rx="1" fill="#3a1420"/>
+  <rect x="22" y="14" width="3" height="8" rx="1" fill="#3a1420"/>
+  <!-- clasped hands holding a red candle -->
+  <rect x="14" y="18" width="4" height="3" rx="1" fill="#b9a7a0"/>
+  <rect x="15.2" y="13" width="1.6" height="5" rx="0.6" fill="#c8b090"/>
+  <circle cx="16" cy="13" r="1.2" fill="#ff8030"/>
+  <!-- deep hood hiding the face -->
+  <path d="M10 12 L16 3 L22 12 L20 13 L12 13 Z" fill="#260d16"/>
+  <ellipse cx="16" cy="10" rx="3.4" ry="3.8" fill="#0a0408"/>
+  <!-- faint red eyes -->
+  <rect x="13.6" y="9" width="1.6" height="1.6" rx="0.8" fill="#e03030"/>
+  <rect x="16.8" y="9" width="1.6" height="1.6" rx="0.8" fill="#e03030"/>
+</svg>

--- a/web/public/sprites/hub-npc-raven-keeper.svg
+++ b/web/public/sprites/hub-npc-raven-keeper.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- shadow -->
+  <ellipse cx="16" cy="29" rx="5" ry="2" fill="rgba(0,0,0,0.25)"/>
+  <!-- feathered cloak -->
+  <path d="M9 14 L23 14 L24 28 L8 28 Z" fill="#23262e"/>
+  <!-- feather layering -->
+  <path d="M9 18 L12 21 L9 21 Z" fill="#15171c"/>
+  <path d="M23 18 L20 21 L23 21 Z" fill="#15171c"/>
+  <path d="M11 22 L16 26 L21 22 L21 28 L11 28 Z" fill="#1a1c22"/>
+  <!-- arms -->
+  <rect x="7"  y="14" width="3" height="8" rx="1" fill="#23262e"/>
+  <rect x="22" y="14" width="3" height="8" rx="1" fill="#23262e"/>
+  <!-- gloved hand as a perch -->
+  <rect x="5" y="15" width="4" height="2.4" rx="1" fill="#4a3a2a"/>
+  <!-- perched raven -->
+  <ellipse cx="5.5" cy="12.5" rx="2.6" ry="2" fill="#0c0e12"/>
+  <path d="M3 12 L1 13 L3 13.6 Z" fill="#0c0e12"/>
+  <path d="M6.4 11.6 L8.4 11 L7 12.4 Z" fill="#d8a020"/>
+  <circle cx="6.2" cy="11.6" r="0.6" fill="#e0c030"/>
+  <!-- head -->
+  <circle cx="16" cy="9" r="5" fill="#c0b0a0"/>
+  <!-- hood with raised cowl -->
+  <path d="M10 9 L16 2 L22 9 L20 10 L12 10 Z" fill="#15171c"/>
+  <!-- grey beard -->
+  <path d="M13 11 L19 11 L17 14 L15 14 Z" fill="#9a9a9a"/>
+  <!-- eyes -->
+  <rect x="13" y="8" width="2" height="2" rx="1" fill="#1a1a1a"/>
+  <rect x="17" y="8" width="2" height="2" rx="1" fill="#1a1a1a"/>
+</svg>

--- a/web/public/sprites/hub-npc-warlock.svg
+++ b/web/public/sprites/hub-npc-warlock.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- shadow -->
+  <ellipse cx="16" cy="29" rx="5" ry="2" fill="rgba(0,0,0,0.25)"/>
+  <!-- long dark robe -->
+  <path d="M9 14 L23 14 L24 28 L8 28 Z" fill="#2a1a3a"/>
+  <!-- robe trim -->
+  <rect x="8" y="26" width="16" height="2" fill="#1a0f26"/>
+  <!-- glowing sigil on chest -->
+  <circle cx="16" cy="19" r="2.4" fill="none" stroke="#9a5ad0" stroke-width="0.8"/>
+  <rect x="15" y="18" width="2" height="2" rx="0.5" fill="#c08aff" opacity="0.85"/>
+  <!-- arms -->
+  <rect x="7"  y="14" width="3" height="9" rx="1" fill="#2a1a3a"/>
+  <rect x="22" y="14" width="3" height="9" rx="1" fill="#2a1a3a"/>
+  <!-- staff -->
+  <rect x="23" y="6" width="1.4" height="20" rx="0.6" fill="#3a2a20"/>
+  <circle cx="23.7" cy="6" r="2.2" fill="#9a5ad0" opacity="0.85"/>
+  <circle cx="23.7" cy="6" r="1" fill="#e0b0ff"/>
+  <!-- head -->
+  <circle cx="16" cy="9" r="5" fill="#b9a7c0"/>
+  <!-- deep pointed hood -->
+  <path d="M10 9 L16 1 L22 9 L20 10 L12 10 Z" fill="#1a0f26"/>
+  <!-- glowing eyes -->
+  <rect x="13" y="8" width="2" height="2" rx="1" fill="#c08aff"/>
+  <rect x="17" y="8" width="2" height="2" rx="1" fill="#c08aff"/>
+</svg>

--- a/web/src/data/bundles/bundles.json
+++ b/web/src/data/bundles/bundles.json
@@ -216,5 +216,48 @@
       { "type": "decor",  "tileID": "lampPostTop",    "x": 0, "y": 0, "zlayer": "solid" },
       { "type": "decor",  "tileID": "lampPostBottom", "x": 0, "y": 1, "zlayer": "solid" }
     ]
+  },
+  {
+    "bundleID": "brazier",
+    "tiles": [
+      { "tileID": "brazierBottom", "x": 0, "y": 0, "zlayer": "solid" },
+      { "tileID": "brazierTop", "x": 0, "y": 1, "zlayer": "above" }
+    ]
+  },
+  {
+    "bundleID": "candelabra",
+    "tiles": [
+      { "tileID": "candlestickLitBottom", "x": 0, "y": 0, "zlayer": "solid" },
+      { "tileID": "candlestickLitTop", "x": 0, "y": 1, "zlayer": "above" }
+    ]
+  },
+  {
+    "bundleID": "suit-of-armour",
+    "tiles": [
+      { "tileID": "suitOfArmourBottom", "x": 0, "y": 0, "zlayer": "solid" },
+      { "tileID": "suitOfArmourTop", "x": 0, "y": 1, "zlayer": "above" }
+    ]
+  },
+  {
+    "bundleID": "bookshelf",
+    "tiles": [
+      { "tileID": "bookshelfBottom", "x": 0, "y": 0, "zlayer": "solid" },
+      { "tileID": "bookshelfTop", "x": 0, "y": 1, "zlayer": "above" }
+    ]
+  },
+  {
+    "bundleID": "gargoyle",
+    "tiles": [
+      { "tileID": "gargoyleBottom", "x": 0, "y": 0, "zlayer": "solid" },
+      { "tileID": "gargoyleTop", "x": 0, "y": 1, "zlayer": "above" }
+    ]
+  },
+  {
+    "bundleID": "dark-altar",
+    "tiles": [
+      { "tileID": "altarBotMid", "x": 0, "y": 0, "zlayer": "solid" },
+      { "tileID": "altarMidMid", "x": 0, "y": 1, "zlayer": "above" },
+      { "tileID": "altarTopMid", "x": 0, "y": 2, "zlayer": "above" }
+    ]
   }
 ]

--- a/web/src/data/hub/dreadspirecitadel/config.json
+++ b/web/src/data/hub/dreadspirecitadel/config.json
@@ -263,7 +263,8 @@
         "One prisoner. Four hundred years. We have, I think, grown fond of each other.",
         "The lower vault stays sealed. Warlock's orders — Vesska's, not the master's. There is a difference, and it troubles me.",
         "If you've business in the deep cells, bring me leave from one who outranks dust. I'll know it when I see it."
-      ]
+      ],
+      "questReceive": "dreadspire-intrigue-2"
     },
     {
       "id": "the-defector",
@@ -276,8 +277,7 @@
         "I served the master once. Then I read what the ritual actually does, and I asked to leave. You can guess how that went.",
         "Get me out and I'll tell you what sleeps under this citadel. It is the only currency I have left."
       ],
-      "questGive": "dreadspire-intrigue-3",
-      "questReceive": "dreadspire-intrigue-2"
+      "questGive": "dreadspire-intrigue-3"
     },
     {
       "id": "ghost-servant-isolde",

--- a/web/src/data/hub/dreadspirecitadel/config.json
+++ b/web/src/data/hub/dreadspirecitadel/config.json
@@ -1,249 +1,142 @@
 {
-  "mapW": 832,
-  "mapH": 672,
+  "mapW": 1280,
+  "mapH": 1088,
   "townName": "Dreadspire Citadel",
   "environment": "ashen",
-  "avatarStart": {
-    "tx": 12,
-    "ty": 18
-  },
+  "avatarStart": { "tx": 18, "ty": 32 },
   "exitTiles": [
-    {
-      "tx": 12,
-      "ty": 19,
-      "screen": "worldmap"
-    },
-    {
-      "tx": 13,
-      "ty": 19,
-      "screen": "worldmap"
-    }
+    { "tx": 18, "ty": 33, "screen": "worldmap" },
+    { "tx": 19, "ty": 33, "screen": "worldmap" }
   ],
   "areas": [
-    {
-      "id": "dreadspire-court",
-      "name": "The Ashen Court",
-      "tx": 8,
-      "ty": 12,
-      "tw": 10,
-      "th": 5
-    }
+    { "id": "dreadspire-court", "name": "The Ashen Court", "tx": 6, "ty": 13, "tw": 28, "th": 5 },
+    { "id": "dreadspire-ward", "name": "The Outer Ward", "tx": 6, "ty": 22, "tw": 28, "th": 9 }
   ],
   "streets": [
-    {
-      "rect": [
-        11,
-        4,
-        14,
-        20
-      ]
-    },
-    {
-      "rect": [
-        5,
-        13,
-        20,
-        14
-      ]
-    }
+    { "rect": [17, 11, 20, 33] },
+    { "rect": [6, 13, 33, 17] },
+    { "rect": [6, 11, 7, 13] },
+    { "rect": [30, 11, 31, 13] },
+    { "rect": [6, 25, 10, 25] },
+    { "rect": [10, 17, 10, 25] },
+    { "rect": [27, 25, 31, 25] },
+    { "rect": [27, 17, 27, 25] },
+    { "rect": [13, 32, 20, 33] }
   ],
   "buildings": [
     {
       "id": "dread-keep",
-      "upgradeKind": "default",
-      "rect": [
-        7,
-        3,
-        18,
-        11
-      ],
+      "rect": [13, 2, 24, 10],
       "wall": "darkStone",
       "roof": "greySlateRoof",
       "doors": [
-        {
-          "tx": 5,
-          "ty": 1,
-          "hideSign": true,
-          "buildingId": "dread-keep"
-        },
-        {
-          "tx": 6,
-          "ty": 1,
-          "hideSign": true,
-          "buildingId": "dread-keep"
-        }
+        { "tx": 5, "ty": 1, "hideSign": true, "buildingId": "dread-keep" },
+        { "tx": 6, "ty": 1, "hideSign": true, "buildingId": "dread-keep" }
       ]
+    },
+    {
+      "id": "warlock-tower-west",
+      "rect": [4, 4, 10, 10],
+      "wall": "darkStone",
+      "roof": "greySlateRoof",
+      "doors": [ { "tx": 3, "ty": 1, "buildingId": "warlock-tower-west" } ]
+    },
+    {
+      "id": "warlock-tower-east",
+      "rect": [27, 4, 33, 10],
+      "wall": "darkStone",
+      "roof": "greySlateRoof",
+      "doors": [ { "tx": 3, "ty": 1, "buildingId": "warlock-tower-east" } ]
+    },
+    {
+      "id": "shadow-shrine",
+      "rect": [3, 18, 9, 24],
+      "wall": "darkStone",
+      "roof": "greySlateRoof",
+      "doors": [ { "tx": 3, "ty": 1, "buildingId": "shadow-shrine" } ]
+    },
+    {
+      "id": "bone-vault",
+      "rect": [28, 18, 34, 24],
+      "wall": "stoneWall",
+      "roof": "greySlateRoof",
+      "doors": [ { "tx": 3, "ty": 1, "buildingId": "bone-vault" } ]
+    },
+    {
+      "id": "gatehouse",
+      "rect": [11, 25, 16, 31],
+      "wall": "darkStone",
+      "roof": "greySlateRoof",
+      "doors": [ { "tx": 3, "ty": 1, "buildingId": "gatehouse" } ]
     }
   ],
   "exteriorDecor": [
-    {
-      "comment": "gate braziers burning cold"
-    },
-    {
-      "tx": 10,
-      "ty": 13,
-      "tileId": "brazierBottom"
-    },
-    {
-      "tx": 10,
-      "ty": 12,
-      "tileId": "brazierTop",
-      "zlayer": "above"
-    },
-    {
-      "tx": 15,
-      "ty": 13,
-      "tileId": "brazierBottom"
-    },
-    {
-      "tx": 15,
-      "ty": 12,
-      "tileId": "brazierTop",
-      "zlayer": "above"
-    },
-    {
-      "comment": "dark crystals growing through the courtyard"
-    },
-    {
-      "tx": 5,
-      "ty": 15,
-      "tileId": "dark_red_crystal1"
-    },
-    {
-      "tx": 19,
-      "ty": 16,
-      "tileId": "dark_red_crystal1"
-    },
-    {
-      "tx": 8,
-      "ty": 17,
-      "tileId": "skull"
-    },
-    {
-      "tx": 17,
-      "ty": 17,
-      "tileId": "smallRock"
-    },
-    {
-      "comment": "iron fence along the court, gap at the gate"
-    },
-    {
-      "tx": 5,
-      "ty": 17,
-      "tileId": "ironFenceLeftRight",
-      "zlayer": "above"
-    },
-    {
-      "tx": 6,
-      "ty": 17,
-      "tileId": "ironFenceLeftRight",
-      "zlayer": "above"
-    },
-    {
-      "tx": 7,
-      "ty": 17,
-      "tileId": "ironFenceLeftRight",
-      "zlayer": "above"
-    },
-    {
-      "tx": 8,
-      "ty": 17,
-      "tileId": "ironFenceLeftRight",
-      "zlayer": "above"
-    },
-    {
-      "tx": 9,
-      "ty": 17,
-      "tileId": "ironFenceLeftRight",
-      "zlayer": "above"
-    },
-    {
-      "tx": 10,
-      "ty": 17,
-      "tileId": "ironFenceLeft",
-      "zlayer": "above"
-    },
-    {
-      "tx": 15,
-      "ty": 17,
-      "tileId": "ironFenceRight",
-      "zlayer": "above"
-    },
-    {
-      "tx": 16,
-      "ty": 17,
-      "tileId": "ironFenceLeftRight",
-      "zlayer": "above"
-    },
-    {
-      "tx": 17,
-      "ty": 17,
-      "tileId": "ironFenceLeftRight",
-      "zlayer": "above"
-    },
-    {
-      "tx": 18,
-      "ty": 17,
-      "tileId": "ironFenceLeftRight",
-      "zlayer": "above"
-    },
-    {
-      "tx": 19,
-      "ty": 17,
-      "tileId": "ironFenceLeftRight",
-      "zlayer": "above"
-    },
-    {
-      "tx": 20,
-      "ty": 17,
-      "tileId": "ironFenceLeftRight",
-      "zlayer": "above"
-    },
-    {
-      "comment": "nothing alive grows here"
-    },
-    {
-      "tx": 2,
-      "ty": 6,
-      "bundleID": "dead-tree",
-      "zlayer": "solid"
-    },
-    {
-      "tx": 21,
-      "ty": 6,
-      "bundleID": "dead-tree",
-      "zlayer": "solid"
-    },
-    {
-      "tx": 3,
-      "ty": 12,
-      "bundleID": "dead-tree",
-      "zlayer": "solid"
-    },
-    {
-      "tx": 22,
-      "ty": 13,
-      "bundleID": "dead-tree",
-      "zlayer": "solid"
-    },
-    {
-      "tx": 18,
-      "ty": 19,
-      "bundleID": "dead-tree",
-      "zlayer": "solid"
-    },
-    {
-      "tx": 4,
-      "ty": 19,
-      "bundleID": "dead-tree",
-      "zlayer": "solid"
-    },
-    {
-      "tx": 17,
-      "ty": 13,
-      "tileId": "wantedSign",
-      "zlayer": "solid"
-    }
+    { "comment": "gate braziers at the south entrance" },
+    { "tx": 16, "ty": 32, "tileId": "brazierBottom" },
+    { "tx": 16, "ty": 31, "tileId": "brazierTop", "zlayer": "above" },
+    { "tx": 21, "ty": 32, "tileId": "brazierBottom" },
+    { "tx": 21, "ty": 31, "tileId": "brazierTop", "zlayer": "above" },
+    { "tx": 17, "ty": 33, "tileId": "skullSign", "zlayer": "above" },
+
+    { "comment": "braziers flanking the keep approach" },
+    { "tx": 16, "ty": 12, "tileId": "brazierBottom" },
+    { "tx": 16, "ty": 11, "tileId": "brazierTop", "zlayer": "above" },
+    { "tx": 21, "ty": 12, "tileId": "brazierBottom" },
+    { "tx": 21, "ty": 11, "tileId": "brazierTop", "zlayer": "above" },
+
+    { "comment": "gargoyles watching from the keep corners" },
+    { "tx": 12, "ty": 10, "tileId": "gargoyleBottom" },
+    { "tx": 12, "ty": 9, "tileId": "gargoyleTop", "zlayer": "above" },
+    { "tx": 25, "ty": 10, "tileId": "gargoyleBottom" },
+    { "tx": 25, "ty": 9, "tileId": "gargoyleTop", "zlayer": "above" },
+
+    { "comment": "dark crystals creeping through the court" },
+    { "tx": 9, "ty": 14, "tileId": "dark_red_crystal1" },
+    { "tx": 13, "ty": 18, "tileId": "dark_red_crystal2" },
+    { "tx": 27, "ty": 14, "tileId": "dark_red_crystal1" },
+    { "tx": 23, "ty": 18, "tileId": "black_crystal1" },
+    { "tx": 32, "ty": 18, "tileId": "black_crystal2" },
+    { "tx": 4, "ty": 16, "tileId": "black_crystal1" },
+
+    { "comment": "bone piles and graves in the wards" },
+    { "tx": 8, "ty": 18, "tileId": "skull" },
+    { "tx": 26, "ty": 18, "tileId": "skull" },
+    { "tx": 12, "ty": 23, "tileId": "graveStone" },
+    { "tx": 14, "ty": 23, "tileId": "graveWoodenCross" },
+    { "tx": 22, "ty": 23, "tileId": "graveStone" },
+    { "tx": 24, "ty": 24, "tileId": "graveWoodenCross" },
+    { "tx": 9, "ty": 28, "tileId": "skull" },
+    { "tx": 25, "ty": 28, "tileId": "graveStone" },
+
+    { "comment": "nothing alive grows here — dead trees along the walls" },
+    { "tx": 2, "ty": 5, "bundleID": "dead-tree", "zlayer": "solid" },
+    { "tx": 35, "ty": 5, "bundleID": "dead-tree", "zlayer": "solid" },
+    { "tx": 2, "ty": 13, "bundleID": "dead-tree", "zlayer": "solid" },
+    { "tx": 36, "ty": 14, "bundleID": "dead-tree", "zlayer": "solid" },
+    { "tx": 2, "ty": 21, "bundleID": "dead-tree", "zlayer": "solid" },
+    { "tx": 36, "ty": 22, "bundleID": "dead-tree", "zlayer": "solid" },
+    { "tx": 3, "ty": 29, "bundleID": "dead-tree", "zlayer": "solid" },
+    { "tx": 35, "ty": 29, "bundleID": "dead-tree", "zlayer": "solid" },
+    { "tx": 22, "ty": 28, "bundleID": "dead-tree", "zlayer": "solid" },
+
+    { "comment": "withered scrub" },
+    { "tx": 9, "ty": 20, "tileId": "deadBush" },
+    { "tx": 28, "ty": 20, "tileId": "deadBush" },
+    { "tx": 4, "ty": 27, "tileId": "deadBush" },
+    { "tx": 33, "ty": 27, "tileId": "deadBush" },
+    { "tx": 19, "ty": 24, "tileId": "deadBush" },
+    { "tx": 8, "ty": 30, "tileId": "cropDead" },
+    { "tx": 27, "ty": 30, "tileId": "cropDead" },
+
+    { "comment": "iron fence stubs framing the court" },
+    { "tx": 11, "ty": 18, "tileId": "ironFenceLeft", "zlayer": "above" },
+    { "tx": 12, "ty": 18, "tileId": "ironFenceLeftRight", "zlayer": "above" },
+    { "tx": 28, "ty": 18, "tileId": "ironFenceLeftRight", "zlayer": "above" },
+    { "tx": 29, "ty": 18, "tileId": "ironFenceRight", "zlayer": "above" },
+
+    { "comment": "the citadel's standing notice" },
+    { "tx": 22, "ty": 13, "tileId": "wantedSign", "zlayer": "solid" },
+    { "tx": 8, "ty": 26, "tileId": "skullSign", "zlayer": "above" }
   ],
   "npcSpawnTiles": [],
   "ambientNpcSprites": [],
@@ -253,100 +146,555 @@
       "name": "The Castellan",
       "sprite": "hub-npc-scholar",
       "isGhost": true,
-      "tx": 12,
-      "ty": 15,
+      "tx": 18, "ty": 15,
       "dialogue": [
         "Welcome to Dreadspire. The master is out. The master has been out for four hundred years.",
         "I maintain the citadel. The dust maintains itself — it's quite industrious.",
-        "The dark crystals in the courtyard keep the walls standing. They've been... wandering off lately."
+        "The dark crystals that anchor these walls have been... wandering off lately. It is most irregular."
       ],
       "questGive": "dreadspire-dark-harvest",
-      "questReceive": "dreadspire-dark-harvest"
+      "questReceive": ["dreadspire-dark-harvest", "dreadspire-harvest-2", "dreadspire-harvest-3"]
     },
     {
       "id": "bound-knight",
       "name": "The Bound Knight",
       "sprite": "hub-npc-soldier",
-      "tx": 14,
-      "ty": 15,
+      "tx": 17, "ty": 30,
       "dialogue": [
         "I swore to guard this gate until my lord returns. He has not returned. I am very good at my job.",
-        "You defeated the garrison at the gate. They'll re-form by morning — death is a poor excuse for missing a shift here.",
+        "Death is a poor excuse for missing a shift here. The garrison re-forms by morning, every morning.",
         "If you mean the citadel harm, I must stop you. If you mean it well, I must watch you suspiciously. Those are the rules."
+      ],
+      "questGive": "dreadspire-lost-watch",
+      "questReceive": "dreadspire-lost-watch"
+    },
+    {
+      "id": "warlock-vesska",
+      "name": "Warlock Vesska",
+      "sprite": "hub-npc-warlock",
+      "building": "keep-warlock-study",
+      "tx": 6, "ty": 3,
+      "dialogue": [
+        "Mind the sigils. The floor ones bite. The ceiling ones are merely judgmental.",
+        "Four centuries of research and I have proven, conclusively, that the dead make poor conversationalists.",
+        "If Ordrin asks, I did NOT borrow his shadow-oil. I liberated it. There is a difference."
+      ],
+      "questGive": "dreadspire-intrigue-1",
+      "questReceive": ["dreadspire-intrigue-1", "dreadspire-intrigue-3"],
+      "dialogueTree": "vesska-chat",
+      "schedule": [
+        { "startHour": 0, "endHour": 8, "activity": "sleep", "location": { "type": "interior", "buildingId": "keep-warlock-study", "tx": 6, "ty": 3 } },
+        { "startHour": 8, "endHour": 20, "activity": "work", "location": { "type": "interior", "buildingId": "keep-warlock-study", "tx": 6, "ty": 3 } },
+        { "startHour": 20, "endHour": 0, "activity": "idle-chat", "location": { "type": "interior", "buildingId": "summoning-chamber", "tx": 5, "ty": 5 } }
+      ]
+    },
+    {
+      "id": "cultist-ordrin",
+      "name": "Cultist Ordrin",
+      "sprite": "hub-npc-cultist",
+      "building": "summoning-chamber",
+      "tx": 5, "ty": 3,
+      "dialogue": [
+        "The circle is hungry. The circle is always hungry. I keep telling it we eat at dusk, like civilised people.",
+        "One bone dust, one measure of shadow-oil, one candle of rendered dread. Is that so much to ask?",
+        "Vesska took my shadow-oil. I can tell. The circle sulks differently when the oil is wrong."
+      ],
+      "questGive": "dreadspire-ritual-ingredients",
+      "questReceive": "dreadspire-ritual-ingredients"
+    },
+    {
+      "id": "bone-keeper-mald",
+      "name": "Bone-Keeper Mald",
+      "sprite": "bone-merchant",
+      "building": "bone-vault",
+      "tx": 4, "ty": 3,
+      "dialogue": [
+        "Every bone in its niche. Every niche labelled. Chaos is for the living.",
+        "We had a thief. Took three femurs and a favourite skull. The skull I shall miss; it was a good listener.",
+        "You want the deep ossuary? Mind the draught. And the things that enjoy the draught."
+      ],
+      "questGive": "dreadspire-bone-tally",
+      "questReceive": "dreadspire-bone-tally"
+    },
+    {
+      "id": "shrine-tender",
+      "name": "The Shrine-Tender",
+      "sprite": "phantom",
+      "isGhost": true,
+      "building": "shrine-inner-sanctum",
+      "tx": 5, "ty": 4,
+      "dialogue": [
+        "The shadow listens, pilgrim. It is a poor talker but an excellent listener.",
+        "Light no honest candles here. The black ones, please — the dark prefers its own.",
+        "Pray if you like. The shadow grants nothing, but it never lies to you either. Rare, these days."
+      ],
+      "questGive": "dreadspire-black-candles",
+      "questReceive": "dreadspire-black-candles"
+    },
+    {
+      "id": "alchemist-sythe",
+      "name": "Alchemist Sythe",
+      "sprite": "sea-witch",
+      "building": "alchemy-lab",
+      "tx": 5, "ty": 4,
+      "dialogue": [
+        "Poison is just medicine with conviction. Sit further away, dear.",
+        "I need moon-herbs — proper ones, from Hollowmere's marsh. The local weeds are all dead, and dead weeds make dull poison.",
+        "Touch nothing green. Touch nothing that ISN'T green either, come to think of it."
+      ],
+      "questGive": "dreadspire-moon-herbs",
+      "questReceive": "dreadspire-moon-herbs"
+    },
+    {
+      "id": "raven-keeper-corvane",
+      "name": "Raven-Keeper Corvane",
+      "sprite": "hub-npc-raven-keeper",
+      "building": "tower-west-top",
+      "tx": 4, "ty": 4,
+      "dialogue": [
+        "Mind the birds. They remember faces. They remember grudges far longer.",
+        "Six ravens I keep, and six I count each dusk. Last night I counted five. The sixth is sulking, or stolen.",
+        "They fly the whole citadel, my birds. Drop me a token from each corner and I'll know my domain is whole."
+      ],
+      "questGive": "dreadspire-raven-tokens",
+      "questReceive": "dreadspire-raven-tokens"
+    },
+    {
+      "id": "dungeon-warden-gholl",
+      "name": "Warden Gholl",
+      "sprite": "hub-npc-guard",
+      "building": "dungeon-cells",
+      "tx": 4, "ty": 4,
+      "dialogue": [
+        "One prisoner. Four hundred years. We have, I think, grown fond of each other.",
+        "The lower vault stays sealed. Warlock's orders — Vesska's, not the master's. There is a difference, and it troubles me.",
+        "If you've business in the deep cells, bring me leave from one who outranks dust. I'll know it when I see it."
+      ]
+    },
+    {
+      "id": "the-defector",
+      "name": "Sera the Defector",
+      "sprite": "hub-npc-scholar",
+      "building": "dungeon-lower-vault",
+      "tx": 5, "ty": 4,
+      "dialogue": [
+        "You're warm. You're BREATHING. Oh, I could weep — do you know how long since I've seen breath?",
+        "I served the master once. Then I read what the ritual actually does, and I asked to leave. You can guess how that went.",
+        "Get me out and I'll tell you what sleeps under this citadel. It is the only currency I have left."
+      ],
+      "questGive": "dreadspire-intrigue-3",
+      "questReceive": "dreadspire-intrigue-2"
+    },
+    {
+      "id": "ghost-servant-isolde",
+      "name": "Isolde",
+      "sprite": "phantom",
+      "isGhost": true,
+      "building": "servants-undercroft",
+      "tx": 5, "ty": 4,
+      "dialogue": [
+        "Dust to sweep, dust to dust. The work is eternal. So, conveniently, am I.",
+        "I dropped the master's old keys somewhere on my rounds. Four centuries of rounds. They could be anywhere.",
+        "Mind the crypt door. It sticks. Everything down here sticks, including time."
+      ],
+      "questGive": "dreadspire-lost-keys",
+      "questReceive": "dreadspire-lost-keys",
+      "schedule": [
+        { "startHour": 6, "endHour": 20, "activity": "sweep", "location": { "type": "interior", "buildingId": "keep-crypt", "tx": 6, "ty": 4 } },
+        { "startHour": 20, "endHour": 6, "activity": "sleep", "location": { "type": "interior", "buildingId": "servants-undercroft", "tx": 5, "ty": 4 } }
       ]
     }
   ],
   "interiors": {
     "dread-keep": {
       "name": "The Dread Throne",
-      "width": 12,
-      "height": 8,
+      "width": 14, "height": 10,
       "floorTileId": "stoneFloor",
       "wallTileId": "darkStone",
       "decor": [
-        {
-          "comment": "the summoning circle before the empty throne"
-        },
-        {
-          "tx": 5,
-          "ty": 3,
-          "tileId": "summoningCircle"
-        },
-        {
-          "tx": 2,
-          "ty": 1,
-          "tileId": "brazierTop"
-        },
-        {
-          "tx": 2,
-          "ty": 2,
-          "tileId": "brazierBottom"
-        },
-        {
-          "tx": 9,
-          "ty": 1,
-          "tileId": "brazierTop"
-        },
-        {
-          "tx": 9,
-          "ty": 2,
-          "tileId": "brazierBottom"
-        },
-        {
-          "tx": 5,
-          "ty": 1,
-          "tileId": "suitOfArmourTop"
-        },
-        {
-          "tx": 5,
-          "ty": 2,
-          "tileId": "suitOfArmourBottom"
-        },
-        {
-          "tx": 6,
-          "ty": 1,
-          "tileId": "suitOfArmourTop"
-        },
-        {
-          "tx": 6,
-          "ty": 2,
-          "tileId": "suitOfArmourBottom"
-        },
-        {
-          "tx": 1,
-          "ty": 5,
-          "tileId": "skull"
-        },
-        {
-          "tx": 10,
-          "ty": 5,
-          "tileId": "dark_red_crystal1"
-        }
+        { "tx": 2, "ty": 1, "tileId": "brazierTop" },
+        { "tx": 2, "ty": 2, "tileId": "brazierBottom" },
+        { "tx": 11, "ty": 1, "tileId": "brazierTop" },
+        { "tx": 11, "ty": 2, "tileId": "brazierBottom" },
+        { "tx": 4, "ty": 1, "tileId": "suitOfArmourTop" },
+        { "tx": 4, "ty": 2, "tileId": "suitOfArmourBottom" },
+        { "tx": 9, "ty": 1, "tileId": "suitOfArmourTop" },
+        { "tx": 9, "ty": 2, "tileId": "suitOfArmourBottom" },
+        { "tx": 6, "ty": 1, "tileId": "summoningCircle" },
+        { "tx": 7, "ty": 5, "tileId": "redCarpetFloor", "zlayer": "below" },
+        { "tx": 7, "ty": 6, "tileId": "redCarpetFloor", "zlayer": "below" },
+        { "tx": 7, "ty": 7, "tileId": "redCarpetFloor", "zlayer": "below" },
+        { "tx": 7, "ty": 8, "tileId": "redCarpetFloor", "zlayer": "below" },
+        { "tx": 1, "ty": 8, "tileId": "skull" },
+        { "tx": 12, "ty": 8, "tileId": "dark_red_crystal1" }
       ],
-      "exits": []
+      "exits": [
+        { "tx": 1, "ty": 4, "toInteriorId": "keep-war-room", "entryTx": 9, "entryTy": 6, "label": "War Room" },
+        { "tx": 12, "ty": 4, "toInteriorId": "keep-warlock-study", "entryTx": 1, "entryTy": 6, "label": "Warlock's Study" },
+        { "tx": 7, "ty": 1, "toInteriorId": "keep-crypt", "entryTx": 6, "entryTy": 6, "direction": "down", "label": "Descend to the Crypt" }
+      ]
+    },
+    "keep-war-room": {
+      "name": "The War Room",
+      "width": 12, "height": 9,
+      "floorTileId": "stoneFloor",
+      "wallTileId": "darkStone",
+      "decor": [
+        { "tx": 5, "ty": 3, "tileId": "wantedSign" },
+        { "tx": 2, "ty": 1, "tileId": "suitOfArmourTop" },
+        { "tx": 2, "ty": 2, "tileId": "suitOfArmourBottom" },
+        { "tx": 9, "ty": 1, "tileId": "suitOfArmourTop" },
+        { "tx": 9, "ty": 2, "tileId": "suitOfArmourBottom" },
+        { "tx": 6, "ty": 1, "tileId": "blackopenBook" },
+        { "tx": 4, "ty": 7, "tileId": "barrel" },
+        { "tx": 10, "ty": 7, "tileId": "crate" },
+        { "tx": 1, "ty": 3, "tileId": "wallTorch" }
+      ],
+      "exits": [
+        { "tx": 8, "ty": 6, "toInteriorId": "dread-keep", "entryTx": 2, "entryTy": 4, "label": "Throne Hall" },
+        { "tx": 1, "ty": 5, "toInteriorId": "warlock-tower-east", "entryTx": 1, "entryTy": 6, "label": "East Tower Passage" }
+      ]
+    },
+    "keep-warlock-study": {
+      "name": "The Warlock's Study",
+      "width": 12, "height": 9,
+      "floorTileId": "stoneFloor",
+      "wallTileId": "darkStone",
+      "decor": [
+        { "tx": 3, "ty": 1, "tileId": "bookshelfTop" },
+        { "tx": 3, "ty": 2, "tileId": "bookshelfBottom" },
+        { "tx": 8, "ty": 1, "tileId": "bookshelfTop" },
+        { "tx": 8, "ty": 2, "tileId": "bookshelfBottom" },
+        { "tx": 5, "ty": 1, "tileId": "candlestickLitTop" },
+        { "tx": 5, "ty": 2, "tileId": "candlestickLitBottom" },
+        { "tx": 10, "ty": 6, "tileId": "blackopenBook" },
+        { "tx": 9, "ty": 7, "tileId": "blackclosedBook" },
+        { "tx": 2, "ty": 7, "tileId": "dark_red_crystal2" },
+        { "tx": 6, "ty": 4, "tileId": "summoningCircle" }
+      ],
+      "exits": [
+        { "tx": 2, "ty": 6, "toInteriorId": "dread-keep", "entryTx": 11, "entryTy": 4, "label": "Throne Hall" }
+      ]
+    },
+    "keep-crypt": {
+      "name": "The Keep Crypt",
+      "width": 12, "height": 9,
+      "floorTileId": "darkStoneFloor",
+      "wallTileId": "darkStone",
+      "ambianceId": "sacred",
+      "decor": [
+        { "tx": 3, "ty": 1, "tileId": "graveStone" },
+        { "tx": 5, "ty": 1, "tileId": "graveWoodenCross" },
+        { "tx": 7, "ty": 1, "tileId": "graveStone" },
+        { "tx": 9, "ty": 1, "tileId": "graveWoodenCross" },
+        { "tx": 2, "ty": 4, "tileId": "candlestickUnlit" },
+        { "tx": 10, "ty": 4, "tileId": "candlestickUnlit" },
+        { "tx": 4, "ty": 7, "tileId": "skull" },
+        { "tx": 8, "ty": 7, "tileId": "black_crystal1" },
+        { "tx": 3, "ty": 5, "tileId": "darkPillarTop" },
+        { "tx": 9, "ty": 5, "tileId": "darkPillarTop" }
+      ],
+      "exits": [
+        { "tx": 6, "ty": 1, "toInteriorId": "dread-keep", "entryTx": 7, "entryTy": 2, "direction": "up", "label": "Up to the Throne" },
+        { "tx": 10, "ty": 6, "toInteriorId": "servants-undercroft", "entryTx": 1, "entryTy": 6, "label": "Servants' Undercroft" },
+        { "tx": 1, "ty": 3, "toInteriorId": "bone-ossuary-deep", "entryTx": 9, "entryTy": 3, "label": "Ossuary Passage" }
+      ]
+    },
+    "servants-undercroft": {
+      "name": "The Servants' Undercroft",
+      "width": 12, "height": 9,
+      "floorTileId": "darkStoneFloor",
+      "wallTileId": "darkStone",
+      "decor": [
+        { "tx": 2, "ty": 1, "bundleID": "simple-bed" },
+        { "tx": 6, "ty": 1, "bundleID": "simple-bed" },
+        { "tx": 9, "ty": 1, "tileId": "barrel" },
+        { "tx": 10, "ty": 1, "tileId": "crate" },
+        { "tx": 3, "ty": 7, "tileId": "candlestickUnlit" },
+        { "tx": 8, "ty": 7, "tileId": "candlestickUnlit" },
+        { "tx": 5, "ty": 4, "tileId": "skull" },
+        { "tx": 10, "ty": 6, "tileId": "deadBush" }
+      ],
+      "exits": [
+        { "tx": 2, "ty": 6, "toInteriorId": "keep-crypt", "entryTx": 9, "entryTy": 6, "label": "Crypt" }
+      ]
+    },
+    "warlock-tower-west": {
+      "name": "Warlock Tower — West",
+      "width": 10, "height": 9,
+      "floorTileId": "stoneFloor",
+      "wallTileId": "darkStone",
+      "decor": [
+        { "tx": 4, "ty": 1, "tileId": "summoningCircle" },
+        { "tx": 2, "ty": 1, "tileId": "candlestickLitTop" },
+        { "tx": 2, "ty": 2, "tileId": "candlestickLitBottom" },
+        { "tx": 6, "ty": 1, "tileId": "candlestickLitTop" },
+        { "tx": 6, "ty": 2, "tileId": "candlestickLitBottom" },
+        { "tx": 7, "ty": 6, "tileId": "bookshelfTop" },
+        { "tx": 7, "ty": 7, "tileId": "bookshelfBottom" },
+        { "tx": 2, "ty": 6, "tileId": "black_crystal2" }
+      ],
+      "exits": [
+        { "tx": 1, "ty": 1, "toInteriorId": "tower-west-top", "entryTx": 1, "entryTy": 6, "direction": "up", "label": "Climb the Stair" },
+        { "tx": 8, "ty": 1, "toInteriorId": "summoning-chamber", "entryTx": 8, "entryTy": 6, "direction": "down", "label": "Descend to the Chamber" }
+      ]
+    },
+    "tower-west-top": {
+      "name": "The Raven Roost",
+      "width": 10, "height": 9,
+      "floorTileId": "stoneFloor",
+      "wallTileId": "darkStone",
+      "decor": [
+        { "tx": 2, "ty": 1, "tileId": "crate" },
+        { "tx": 7, "ty": 1, "tileId": "crate" },
+        { "tx": 4, "ty": 1, "tileId": "skull" },
+        { "tx": 5, "ty": 1, "tileId": "skull" },
+        { "tx": 8, "ty": 6, "tileId": "black_crystal1" },
+        { "tx": 2, "ty": 7, "tileId": "barrel" },
+        { "tx": 6, "ty": 4, "tileId": "candlestickUnlit" }
+      ],
+      "exits": [
+        { "tx": 1, "ty": 1, "toInteriorId": "warlock-tower-west", "entryTx": 1, "entryTy": 6, "direction": "down", "label": "Down the Stair" }
+      ]
+    },
+    "summoning-chamber": {
+      "name": "The Summoning Chamber",
+      "width": 12, "height": 9,
+      "floorTileId": "darkStoneFloor",
+      "wallTileId": "darkStone",
+      "ambianceId": "sacred",
+      "decor": [
+        { "tx": 5, "ty": 4, "tileId": "summoningCircle" },
+        { "tx": 6, "ty": 4, "tileId": "summoningCircle" },
+        { "tx": 2, "ty": 1, "tileId": "brazierTop" },
+        { "tx": 2, "ty": 2, "tileId": "brazierBottom" },
+        { "tx": 9, "ty": 1, "tileId": "brazierTop" },
+        { "tx": 9, "ty": 2, "tileId": "brazierBottom" },
+        { "tx": 4, "ty": 1, "tileId": "candlestickLitTop" },
+        { "tx": 7, "ty": 1, "tileId": "candlestickLitTop" },
+        { "tx": 10, "ty": 7, "tileId": "dark_red_crystal3" },
+        { "tx": 1, "ty": 7, "tileId": "black_crystal2" }
+      ],
+      "exits": [
+        { "tx": 8, "ty": 1, "toInteriorId": "warlock-tower-west", "entryTx": 8, "entryTy": 6, "direction": "up", "label": "Up the Stair" },
+        { "tx": 1, "ty": 3, "toInteriorId": "alchemy-lab", "entryTx": 10, "entryTy": 3, "label": "Alchemy Lab" }
+      ]
+    },
+    "alchemy-lab": {
+      "name": "The Poison Lab",
+      "width": 12, "height": 9,
+      "floorTileId": "stoneFloor",
+      "wallTileId": "darkStone",
+      "decor": [
+        { "tx": 3, "ty": 1, "tileId": "bookshelfTop" },
+        { "tx": 3, "ty": 2, "tileId": "bookshelfBottom" },
+        { "tx": 5, "ty": 1, "tileId": "candlestickLitTop" },
+        { "tx": 5, "ty": 2, "tileId": "candlestickLitBottom" },
+        { "tx": 7, "ty": 1, "tileId": "blackopenBook" },
+        { "tx": 2, "ty": 6, "tileId": "barrel" },
+        { "tx": 4, "ty": 7, "tileId": "crate" },
+        { "tx": 8, "ty": 7, "tileId": "green_crystal1" },
+        { "tx": 6, "ty": 5, "tileId": "cropDead" }
+      ],
+      "exits": [
+        { "tx": 10, "ty": 3, "toInteriorId": "summoning-chamber", "entryTx": 2, "entryTy": 3, "label": "Summoning Chamber" }
+      ]
+    },
+    "warlock-tower-east": {
+      "name": "Warlock Tower — East",
+      "width": 10, "height": 9,
+      "floorTileId": "stoneFloor",
+      "wallTileId": "darkStone",
+      "decor": [
+        { "tx": 4, "ty": 5, "tileId": "summoningCircle" },
+        { "tx": 2, "ty": 1, "tileId": "candlestickLitTop" },
+        { "tx": 2, "ty": 2, "tileId": "candlestickLitBottom" },
+        { "tx": 6, "ty": 1, "tileId": "candlestickLitTop" },
+        { "tx": 6, "ty": 2, "tileId": "candlestickLitBottom" },
+        { "tx": 7, "ty": 6, "tileId": "bookshelfTop" },
+        { "tx": 7, "ty": 7, "tileId": "bookshelfBottom" },
+        { "tx": 3, "ty": 6, "tileId": "dark_red_crystal1" }
+      ],
+      "exits": [
+        { "tx": 8, "ty": 1, "toInteriorId": "tower-east-top", "entryTx": 8, "entryTy": 6, "direction": "up", "label": "Climb the Stair" },
+        { "tx": 1, "ty": 1, "toInteriorId": "keep-war-room", "entryTx": 1, "entryTy": 6, "label": "Keep Passage" },
+        { "tx": 4, "ty": 1, "toInteriorId": "dungeon-cells", "entryTx": 6, "entryTy": 6, "direction": "down", "label": "Descend to the Cells" }
+      ]
+    },
+    "tower-east-top": {
+      "name": "The East Tower Top",
+      "width": 10, "height": 9,
+      "floorTileId": "stoneFloor",
+      "wallTileId": "darkStone",
+      "decor": [
+        { "tx": 2, "ty": 1, "tileId": "gargoyleTop" },
+        { "tx": 2, "ty": 2, "tileId": "gargoyleBottom" },
+        { "tx": 7, "ty": 1, "tileId": "gargoyleTop" },
+        { "tx": 7, "ty": 2, "tileId": "gargoyleBottom" },
+        { "tx": 4, "ty": 1, "tileId": "black_crystal3" },
+        { "tx": 5, "ty": 6, "tileId": "candlestickUnlit" },
+        { "tx": 2, "ty": 7, "tileId": "crate" }
+      ],
+      "exits": [
+        { "tx": 8, "ty": 1, "toInteriorId": "warlock-tower-east", "entryTx": 8, "entryTy": 6, "direction": "down", "label": "Down the Stair" }
+      ]
+    },
+    "shadow-shrine": {
+      "name": "The Shadow Shrine",
+      "width": 11, "height": 9,
+      "floorTileId": "stoneFloor",
+      "wallTileId": "darkStone",
+      "musicId": "church",
+      "ambianceId": "sacred",
+      "decor": [
+        { "tx": 5, "ty": 1, "tileId": "altarTopMid" },
+        { "tx": 5, "ty": 2, "tileId": "altarMidMid" },
+        { "tx": 5, "ty": 3, "tileId": "altarBotMid" },
+        { "tx": 3, "ty": 1, "tileId": "candlestickLitTop" },
+        { "tx": 3, "ty": 2, "tileId": "candlestickLitBottom" },
+        { "tx": 7, "ty": 1, "tileId": "candlestickLitTop" },
+        { "tx": 7, "ty": 2, "tileId": "candlestickLitBottom" },
+        { "tx": 2, "ty": 7, "tileId": "black_crystal1" },
+        { "tx": 8, "ty": 7, "tileId": "black_crystal2" }
+      ],
+      "exits": [
+        { "tx": 1, "ty": 3, "toInteriorId": "shrine-inner-sanctum", "entryTx": 9, "entryTy": 3, "label": "Inner Sanctum" }
+      ]
+    },
+    "shrine-inner-sanctum": {
+      "name": "The Inner Sanctum",
+      "width": 11, "height": 9,
+      "floorTileId": "redCarpetFloor",
+      "wallTileId": "darkStone",
+      "musicId": "church",
+      "ambianceId": "sacred",
+      "decor": [
+        { "tx": 5, "ty": 1, "tileId": "summoningCircle" },
+        { "tx": 3, "ty": 1, "tileId": "brazierTop" },
+        { "tx": 3, "ty": 2, "tileId": "brazierBottom" },
+        { "tx": 7, "ty": 1, "tileId": "brazierTop" },
+        { "tx": 7, "ty": 2, "tileId": "brazierBottom" },
+        { "tx": 2, "ty": 6, "tileId": "candlestickLitTop" },
+        { "tx": 8, "ty": 6, "tileId": "candlestickLitTop" },
+        { "tx": 5, "ty": 6, "tileId": "dark_red_crystal4" }
+      ],
+      "exits": [
+        { "tx": 9, "ty": 3, "toInteriorId": "shadow-shrine", "entryTx": 2, "entryTy": 3, "label": "Shrine" }
+      ]
+    },
+    "bone-vault": {
+      "name": "The Bone Vault",
+      "width": 11, "height": 9,
+      "floorTileId": "darkStoneFloor",
+      "wallTileId": "stoneWall",
+      "decor": [
+        { "tx": 2, "ty": 1, "tileId": "skull" },
+        { "tx": 3, "ty": 1, "tileId": "skull" },
+        { "tx": 7, "ty": 1, "tileId": "skull" },
+        { "tx": 8, "ty": 1, "tileId": "skull" },
+        { "tx": 5, "ty": 1, "tileId": "skullSign" },
+        { "tx": 2, "ty": 6, "tileId": "graveStone" },
+        { "tx": 8, "ty": 6, "tileId": "graveStone" },
+        { "tx": 5, "ty": 4, "tileId": "candlestickUnlit" }
+      ],
+      "exits": [
+        { "tx": 9, "ty": 1, "toInteriorId": "bone-ossuary-deep", "entryTx": 1, "entryTy": 6, "direction": "down", "label": "Into the Ossuary" }
+      ]
+    },
+    "bone-ossuary-deep": {
+      "name": "The Deep Ossuary",
+      "width": 12, "height": 9,
+      "floorTileId": "darkStoneFloor",
+      "wallTileId": "stoneWall",
+      "ambianceId": "sacred",
+      "decor": [
+        { "tx": 2, "ty": 1, "tileId": "skull" },
+        { "tx": 4, "ty": 1, "tileId": "skull" },
+        { "tx": 6, "ty": 1, "tileId": "skull" },
+        { "tx": 8, "ty": 1, "tileId": "skull" },
+        { "tx": 10, "ty": 1, "tileId": "skull" },
+        { "tx": 3, "ty": 7, "tileId": "graveStone" },
+        { "tx": 7, "ty": 7, "tileId": "graveWoodenCross" },
+        { "tx": 5, "ty": 5, "tileId": "black_crystal4" },
+        { "tx": 9, "ty": 5, "tileId": "candlestickUnlit" }
+      ],
+      "exits": [
+        { "tx": 1, "ty": 5, "toInteriorId": "bone-vault", "entryTx": 8, "entryTy": 6, "direction": "up", "label": "Up to the Vault" },
+        { "tx": 10, "ty": 3, "toInteriorId": "keep-crypt", "entryTx": 2, "entryTy": 3, "label": "Crypt Passage" }
+      ]
+    },
+    "gatehouse": {
+      "name": "The Gatehouse Guardroom",
+      "width": 11, "height": 8,
+      "floorTileId": "stoneFloor",
+      "wallTileId": "darkStone",
+      "decor": [
+        { "tx": 2, "ty": 1, "tileId": "suitOfArmourTop" },
+        { "tx": 2, "ty": 2, "tileId": "suitOfArmourBottom" },
+        { "tx": 8, "ty": 1, "tileId": "suitOfArmourTop" },
+        { "tx": 8, "ty": 2, "tileId": "suitOfArmourBottom" },
+        { "tx": 5, "ty": 1, "tileId": "wantedSign" },
+        { "tx": 3, "ty": 5, "tileId": "barrel" },
+        { "tx": 7, "ty": 5, "tileId": "crate" },
+        { "tx": 1, "ty": 3, "tileId": "wallTorch" },
+        { "tx": 9, "ty": 3, "tileId": "wallTorch" }
+      ],
+      "exits": [
+        { "tx": 9, "ty": 1, "toInteriorId": "dungeon-cells", "entryTx": 1, "entryTy": 6, "direction": "down", "label": "Down to the Cells" }
+      ]
+    },
+    "dungeon-cells": {
+      "name": "The Dungeon Cells",
+      "width": 12, "height": 9,
+      "floorTileId": "darkStoneFloor",
+      "wallTileId": "darkStone",
+      "decor": [
+        { "tx": 2, "ty": 1, "tileId": "cellWindowLit" },
+        { "tx": 4, "ty": 1, "tileId": "cellWindowUnlit" },
+        { "tx": 8, "ty": 1, "tileId": "cellWindowUnlit" },
+        { "tx": 10, "ty": 1, "tileId": "cellWindowLit" },
+        { "tx": 2, "ty": 7, "tileId": "skull" },
+        { "tx": 10, "ty": 7, "tileId": "skull" },
+        { "tx": 5, "ty": 3, "tileId": "candlestickUnlit" },
+        { "tx": 7, "ty": 7, "tileId": "barrel" }
+      ],
+      "exits": [
+        { "tx": 6, "ty": 1, "toInteriorId": "warlock-tower-east", "entryTx": 4, "entryTy": 6, "direction": "up", "label": "Up to the East Tower" },
+        { "tx": 1, "ty": 5, "toInteriorId": "gatehouse", "entryTx": 8, "entryTy": 6, "direction": "up", "label": "Up to the Gatehouse" },
+        { "tx": 10, "ty": 6, "toInteriorId": "dungeon-lower-vault", "entryTx": 6, "entryTy": 6, "direction": "down", "requiredQuest": "dreadspire-intrigue-2", "label": "The Sealed Vault" }
+      ]
+    },
+    "dungeon-lower-vault": {
+      "name": "The Lower Vault",
+      "width": 11, "height": 9,
+      "floorTileId": "darkStoneFloor",
+      "wallTileId": "darkStone",
+      "ambianceId": "sacred",
+      "decor": [
+        { "tx": 2, "ty": 1, "tileId": "cellWindowUnlit" },
+        { "tx": 8, "ty": 1, "tileId": "cellWindowUnlit" },
+        { "tx": 5, "ty": 1, "tileId": "summoningCircle" },
+        { "tx": 2, "ty": 6, "tileId": "black_crystal1" },
+        { "tx": 8, "ty": 6, "tileId": "dark_red_crystal2" },
+        { "tx": 3, "ty": 7, "tileId": "skull" },
+        { "tx": 7, "ty": 7, "tileId": "graveStone" }
+      ],
+      "exits": [
+        { "tx": 6, "ty": 1, "toInteriorId": "dungeon-cells", "entryTx": 10, "entryTy": 5, "direction": "up", "label": "Up to the Cells" }
+      ]
     }
   },
-  "animals": [],
+  "animals": [
+    {
+      "id": "citadel-raven",
+      "type": "bird",
+      "variant": "#1a1a1a",
+      "tx": 9, "ty": 12,
+      "name": "Citadel Raven",
+      "dialogue": ["*kraa!*", "The raven watches you with one glassy eye."],
+      "roam": false
+    }
+  ],
   "pondTiles": [],
   "treasures": []
 }

--- a/web/src/data/hub/dreadspirecitadel/config.json
+++ b/web/src/data/hub/dreadspirecitadel/config.json
@@ -72,23 +72,17 @@
   ],
   "exteriorDecor": [
     { "comment": "gate braziers at the south entrance" },
-    { "tx": 16, "ty": 32, "tileId": "brazierBottom" },
-    { "tx": 16, "ty": 31, "tileId": "brazierTop", "zlayer": "above" },
-    { "tx": 21, "ty": 32, "tileId": "brazierBottom" },
-    { "tx": 21, "ty": 31, "tileId": "brazierTop", "zlayer": "above" },
+    { "tx": 16, "ty": 32, "bundleID": "brazier" },
+    { "tx": 21, "ty": 32, "bundleID": "brazier" },
     { "tx": 17, "ty": 33, "tileId": "skullSign", "zlayer": "above" },
 
     { "comment": "braziers flanking the keep approach" },
-    { "tx": 16, "ty": 12, "tileId": "brazierBottom" },
-    { "tx": 16, "ty": 11, "tileId": "brazierTop", "zlayer": "above" },
-    { "tx": 21, "ty": 12, "tileId": "brazierBottom" },
-    { "tx": 21, "ty": 11, "tileId": "brazierTop", "zlayer": "above" },
+    { "tx": 16, "ty": 12, "bundleID": "brazier" },
+    { "tx": 21, "ty": 12, "bundleID": "brazier" },
 
     { "comment": "gargoyles watching from the keep corners" },
-    { "tx": 12, "ty": 10, "tileId": "gargoyleBottom" },
-    { "tx": 12, "ty": 9, "tileId": "gargoyleTop", "zlayer": "above" },
-    { "tx": 25, "ty": 10, "tileId": "gargoyleBottom" },
-    { "tx": 25, "ty": 9, "tileId": "gargoyleTop", "zlayer": "above" },
+    { "tx": 12, "ty": 10, "bundleID": "gargoyle" },
+    { "tx": 25, "ty": 10, "bundleID": "gargoyle" },
 
     { "comment": "dark crystals creeping through the court" },
     { "tx": 9, "ty": 14, "tileId": "dark_red_crystal1" },
@@ -312,14 +306,10 @@
       "floorTileId": "stoneFloor",
       "wallTileId": "darkStone",
       "decor": [
-        { "tx": 2, "ty": 1, "tileId": "brazierTop" },
-        { "tx": 2, "ty": 2, "tileId": "brazierBottom" },
-        { "tx": 11, "ty": 1, "tileId": "brazierTop" },
-        { "tx": 11, "ty": 2, "tileId": "brazierBottom" },
-        { "tx": 4, "ty": 1, "tileId": "suitOfArmourTop" },
-        { "tx": 4, "ty": 2, "tileId": "suitOfArmourBottom" },
-        { "tx": 9, "ty": 1, "tileId": "suitOfArmourTop" },
-        { "tx": 9, "ty": 2, "tileId": "suitOfArmourBottom" },
+        { "tx": 2, "ty": 2, "bundleID": "brazier" },
+        { "tx": 11, "ty": 2, "bundleID": "brazier" },
+        { "tx": 4, "ty": 2, "bundleID": "suit-of-armour" },
+        { "tx": 9, "ty": 2, "bundleID": "suit-of-armour" },
         { "tx": 6, "ty": 1, "tileId": "summoningCircle" },
         { "tx": 7, "ty": 5, "tileId": "redCarpetFloor", "zlayer": "below" },
         { "tx": 7, "ty": 6, "tileId": "redCarpetFloor", "zlayer": "below" },
@@ -341,10 +331,8 @@
       "wallTileId": "darkStone",
       "decor": [
         { "tx": 5, "ty": 3, "tileId": "wantedSign" },
-        { "tx": 2, "ty": 1, "tileId": "suitOfArmourTop" },
-        { "tx": 2, "ty": 2, "tileId": "suitOfArmourBottom" },
-        { "tx": 9, "ty": 1, "tileId": "suitOfArmourTop" },
-        { "tx": 9, "ty": 2, "tileId": "suitOfArmourBottom" },
+        { "tx": 2, "ty": 2, "bundleID": "suit-of-armour" },
+        { "tx": 9, "ty": 2, "bundleID": "suit-of-armour" },
         { "tx": 6, "ty": 1, "tileId": "blackopenBook" },
         { "tx": 4, "ty": 7, "tileId": "barrel" },
         { "tx": 10, "ty": 7, "tileId": "crate" },
@@ -361,12 +349,9 @@
       "floorTileId": "stoneFloor",
       "wallTileId": "darkStone",
       "decor": [
-        { "tx": 3, "ty": 1, "tileId": "bookshelfTop" },
-        { "tx": 3, "ty": 2, "tileId": "bookshelfBottom" },
-        { "tx": 8, "ty": 1, "tileId": "bookshelfTop" },
-        { "tx": 8, "ty": 2, "tileId": "bookshelfBottom" },
-        { "tx": 5, "ty": 1, "tileId": "candlestickLitTop" },
-        { "tx": 5, "ty": 2, "tileId": "candlestickLitBottom" },
+        { "tx": 3, "ty": 2, "bundleID": "bookshelf" },
+        { "tx": 8, "ty": 2, "bundleID": "bookshelf" },
+        { "tx": 5, "ty": 2, "bundleID": "candelabra" },
         { "tx": 10, "ty": 6, "tileId": "blackopenBook" },
         { "tx": 9, "ty": 7, "tileId": "blackclosedBook" },
         { "tx": 2, "ty": 7, "tileId": "dark_red_crystal2" },
@@ -412,7 +397,7 @@
         { "tx": 10, "ty": 1, "tileId": "crate" },
         { "tx": 3, "ty": 7, "tileId": "candlestickUnlit" },
         { "tx": 8, "ty": 7, "tileId": "candlestickUnlit" },
-        { "tx": 5, "ty": 4, "tileId": "skull" },
+        { "tx": 4, "ty": 6, "tileId": "skull" },
         { "tx": 10, "ty": 6, "tileId": "deadBush" }
       ],
       "exits": [
@@ -426,12 +411,9 @@
       "wallTileId": "darkStone",
       "decor": [
         { "tx": 4, "ty": 1, "tileId": "summoningCircle" },
-        { "tx": 2, "ty": 1, "tileId": "candlestickLitTop" },
-        { "tx": 2, "ty": 2, "tileId": "candlestickLitBottom" },
-        { "tx": 6, "ty": 1, "tileId": "candlestickLitTop" },
-        { "tx": 6, "ty": 2, "tileId": "candlestickLitBottom" },
-        { "tx": 7, "ty": 6, "tileId": "bookshelfTop" },
-        { "tx": 7, "ty": 7, "tileId": "bookshelfBottom" },
+        { "tx": 2, "ty": 2, "bundleID": "candelabra" },
+        { "tx": 6, "ty": 2, "bundleID": "candelabra" },
+        { "tx": 7, "ty": 7, "bundleID": "bookshelf" },
         { "tx": 2, "ty": 6, "tileId": "black_crystal2" }
       ],
       "exits": [
@@ -466,12 +448,10 @@
       "decor": [
         { "tx": 5, "ty": 4, "tileId": "summoningCircle" },
         { "tx": 6, "ty": 4, "tileId": "summoningCircle" },
-        { "tx": 2, "ty": 1, "tileId": "brazierTop" },
-        { "tx": 2, "ty": 2, "tileId": "brazierBottom" },
-        { "tx": 9, "ty": 1, "tileId": "brazierTop" },
-        { "tx": 9, "ty": 2, "tileId": "brazierBottom" },
-        { "tx": 4, "ty": 1, "tileId": "candlestickLitTop" },
-        { "tx": 7, "ty": 1, "tileId": "candlestickLitTop" },
+        { "tx": 2, "ty": 2, "bundleID": "brazier" },
+        { "tx": 9, "ty": 2, "bundleID": "brazier" },
+        { "tx": 4, "ty": 2, "bundleID": "candelabra" },
+        { "tx": 7, "ty": 2, "bundleID": "candelabra" },
         { "tx": 10, "ty": 7, "tileId": "dark_red_crystal3" },
         { "tx": 1, "ty": 7, "tileId": "black_crystal2" }
       ],
@@ -486,10 +466,8 @@
       "floorTileId": "stoneFloor",
       "wallTileId": "darkStone",
       "decor": [
-        { "tx": 3, "ty": 1, "tileId": "bookshelfTop" },
-        { "tx": 3, "ty": 2, "tileId": "bookshelfBottom" },
-        { "tx": 5, "ty": 1, "tileId": "candlestickLitTop" },
-        { "tx": 5, "ty": 2, "tileId": "candlestickLitBottom" },
+        { "tx": 3, "ty": 2, "bundleID": "bookshelf" },
+        { "tx": 5, "ty": 2, "bundleID": "candelabra" },
         { "tx": 7, "ty": 1, "tileId": "blackopenBook" },
         { "tx": 2, "ty": 6, "tileId": "barrel" },
         { "tx": 4, "ty": 7, "tileId": "crate" },
@@ -507,12 +485,9 @@
       "wallTileId": "darkStone",
       "decor": [
         { "tx": 4, "ty": 5, "tileId": "summoningCircle" },
-        { "tx": 2, "ty": 1, "tileId": "candlestickLitTop" },
-        { "tx": 2, "ty": 2, "tileId": "candlestickLitBottom" },
-        { "tx": 6, "ty": 1, "tileId": "candlestickLitTop" },
-        { "tx": 6, "ty": 2, "tileId": "candlestickLitBottom" },
-        { "tx": 7, "ty": 6, "tileId": "bookshelfTop" },
-        { "tx": 7, "ty": 7, "tileId": "bookshelfBottom" },
+        { "tx": 2, "ty": 2, "bundleID": "candelabra" },
+        { "tx": 6, "ty": 2, "bundleID": "candelabra" },
+        { "tx": 7, "ty": 7, "bundleID": "bookshelf" },
         { "tx": 3, "ty": 6, "tileId": "dark_red_crystal1" }
       ],
       "exits": [
@@ -527,10 +502,8 @@
       "floorTileId": "stoneFloor",
       "wallTileId": "darkStone",
       "decor": [
-        { "tx": 2, "ty": 1, "tileId": "gargoyleTop" },
-        { "tx": 2, "ty": 2, "tileId": "gargoyleBottom" },
-        { "tx": 7, "ty": 1, "tileId": "gargoyleTop" },
-        { "tx": 7, "ty": 2, "tileId": "gargoyleBottom" },
+        { "tx": 2, "ty": 2, "bundleID": "gargoyle" },
+        { "tx": 7, "ty": 2, "bundleID": "gargoyle" },
         { "tx": 4, "ty": 1, "tileId": "black_crystal3" },
         { "tx": 5, "ty": 6, "tileId": "candlestickUnlit" },
         { "tx": 2, "ty": 7, "tileId": "crate" }
@@ -547,13 +520,9 @@
       "musicId": "church",
       "ambianceId": "sacred",
       "decor": [
-        { "tx": 5, "ty": 1, "tileId": "altarTopMid" },
-        { "tx": 5, "ty": 2, "tileId": "altarMidMid" },
-        { "tx": 5, "ty": 3, "tileId": "altarBotMid" },
-        { "tx": 3, "ty": 1, "tileId": "candlestickLitTop" },
-        { "tx": 3, "ty": 2, "tileId": "candlestickLitBottom" },
-        { "tx": 7, "ty": 1, "tileId": "candlestickLitTop" },
-        { "tx": 7, "ty": 2, "tileId": "candlestickLitBottom" },
+        { "tx": 5, "ty": 3, "bundleID": "dark-altar" },
+        { "tx": 3, "ty": 2, "bundleID": "candelabra" },
+        { "tx": 7, "ty": 2, "bundleID": "candelabra" },
         { "tx": 2, "ty": 7, "tileId": "black_crystal1" },
         { "tx": 8, "ty": 7, "tileId": "black_crystal2" }
       ],
@@ -570,12 +539,10 @@
       "ambianceId": "sacred",
       "decor": [
         { "tx": 5, "ty": 1, "tileId": "summoningCircle" },
-        { "tx": 3, "ty": 1, "tileId": "brazierTop" },
-        { "tx": 3, "ty": 2, "tileId": "brazierBottom" },
-        { "tx": 7, "ty": 1, "tileId": "brazierTop" },
-        { "tx": 7, "ty": 2, "tileId": "brazierBottom" },
-        { "tx": 2, "ty": 6, "tileId": "candlestickLitTop" },
-        { "tx": 8, "ty": 6, "tileId": "candlestickLitTop" },
+        { "tx": 3, "ty": 2, "bundleID": "brazier" },
+        { "tx": 7, "ty": 2, "bundleID": "brazier" },
+        { "tx": 2, "ty": 7, "bundleID": "candelabra" },
+        { "tx": 8, "ty": 7, "bundleID": "candelabra" },
         { "tx": 5, "ty": 6, "tileId": "dark_red_crystal4" }
       ],
       "exits": [
@@ -619,7 +586,7 @@
         { "tx": 9, "ty": 5, "tileId": "candlestickUnlit" }
       ],
       "exits": [
-        { "tx": 1, "ty": 5, "toInteriorId": "bone-vault", "entryTx": 8, "entryTy": 6, "direction": "up", "label": "Up to the Vault" },
+        { "tx": 1, "ty": 5, "toInteriorId": "bone-vault", "entryTx": 8, "entryTy": 5, "direction": "up", "label": "Up to the Vault" },
         { "tx": 10, "ty": 3, "toInteriorId": "keep-crypt", "entryTx": 2, "entryTy": 3, "label": "Crypt Passage" }
       ]
     },
@@ -629,10 +596,8 @@
       "floorTileId": "stoneFloor",
       "wallTileId": "darkStone",
       "decor": [
-        { "tx": 2, "ty": 1, "tileId": "suitOfArmourTop" },
-        { "tx": 2, "ty": 2, "tileId": "suitOfArmourBottom" },
-        { "tx": 8, "ty": 1, "tileId": "suitOfArmourTop" },
-        { "tx": 8, "ty": 2, "tileId": "suitOfArmourBottom" },
+        { "tx": 2, "ty": 2, "bundleID": "suit-of-armour" },
+        { "tx": 8, "ty": 2, "bundleID": "suit-of-armour" },
         { "tx": 5, "ty": 1, "tileId": "wantedSign" },
         { "tx": 3, "ty": 5, "tileId": "barrel" },
         { "tx": 7, "ty": 5, "tileId": "crate" },

--- a/web/src/data/hub/dreadspirecitadel/questDefs.json
+++ b/web/src/data/hub/dreadspirecitadel/questDefs.json
@@ -10,50 +10,355 @@
       "activeDialogue": "Three dark crystals, loose somewhere on the grounds. They glow. They hum. Occasionally they sulk.",
       "completeDialogue": "All three, returned and re-anchored. The citadel stands another century. The master would thank you, were he here, which he is not, which is the usual arrangement. Take this from the treasury — the dust won't miss it.",
       "steps": [
-        {
-          "key": "crystals",
-          "type": "collect",
-          "pickupIds": [
-            "dark-crystal-1",
-            "dark-crystal-2",
-            "dark-crystal-3"
-          ],
-          "required": 3
-        }
+        { "key": "crystals", "type": "collect", "pickupIds": ["dark-crystal-1", "dark-crystal-2", "dark-crystal-3"], "required": 3 }
       ],
       "reward": {
         "crystals": 100,
-        "collectible": {
-          "id": "dreadspire-shard",
-          "name": "Dreadspire Shard",
-          "icon": "🔮",
-          "desc": "A sliver of dark crystal from the citadel's foundations. It hums when it thinks no one is listening."
-        }
+        "collectible": { "id": "dreadspire-shard", "name": "Dreadspire Shard", "icon": "🔮", "desc": "A sliver of dark crystal from the citadel's foundations. It hums when it thinks no one is listening." }
+      }
+    },
+    {
+      "id": "dreadspire-harvest-2",
+      "title": "The Deep Anchors",
+      "type": "chain",
+      "giverNpcId": "the-castellan",
+      "receiverNpcId": "the-castellan",
+      "prerequisite": "quest:dreadspire-dark-harvest",
+      "offerDialogue": "The surface crystals were the easy ones. Three more have rolled INTO the citadel — the crypt, the summoning chamber, the deep ossuary. Indoor crystals are bolder. They've learned doors.",
+      "activeDialogue": "Three more anchors, this time within the walls. Mind the stairs; the deep ones are unlit.",
+      "completeDialogue": "Re-seated, all three. The foundations purr. You begin to understand why I never leave — somebody has to chase the masonry.",
+      "steps": [
+        { "key": "crystals", "type": "collect", "pickupIds": ["dark-crystal-4", "dark-crystal-5", "dark-crystal-6"], "required": 3 }
+      ],
+      "reward": { "crystals": 110, "friendship": { "the-castellan": 15 } }
+    },
+    {
+      "id": "dreadspire-harvest-3",
+      "title": "The Wandering Foundations",
+      "type": "chain",
+      "giverNpcId": "the-castellan",
+      "receiverNpcId": "the-castellan",
+      "prerequisite": "quest:dreadspire-harvest-2",
+      "offerDialogue": "Last batch — I hope. The east tower top, the poison lab, the dungeon cells. The crystals are climbing now. I do not like that they are climbing.",
+      "activeDialogue": "Three final anchors, scattered high and low. Bring them home before they learn to fly.",
+      "completeDialogue": "Whole again, root to roof. You have done more for this citadel in a day than its master in four hundred years. The dust is, I think, fond of you.",
+      "steps": [
+        { "key": "crystals", "type": "collect", "pickupIds": ["dark-crystal-7", "dark-crystal-8", "dark-crystal-9"], "required": 3 }
+      ],
+      "reward": {
+        "crystals": 130,
+        "relationship": { "the-castellan": { "track": "ally", "points": 15 } },
+        "collectible": { "id": "dreadspire-keystone", "name": "Citadel Keystone", "icon": "🗝️", "desc": "A re-anchored foundation crystal, gifted in gratitude. The whole citadel leans on stones like this." }
+      }
+    },
+    {
+      "id": "dreadspire-lost-watch",
+      "title": "The Garrison's Effects",
+      "type": "fetch",
+      "giverNpcId": "bound-knight",
+      "receiverNpcId": "bound-knight",
+      "offerDialogue": "When the garrison falls each night, it re-forms by dawn — but lately the men wake without their effects. A coin, a seal, a key, all scattered across the wards. A soldier without his kit is just a sad cold draught. Gather them.",
+      "activeDialogue": "Three of the garrison's lost effects, somewhere in the wards. They are not proud. They will be where they fell.",
+      "completeDialogue": "The men will sleep easier — well, lie easier. Soldiers should die with their boots on, not hunt for them by moonlight. You have my thanks, such as a dead man's thanks are worth.",
+      "steps": [
+        { "key": "effects", "type": "collect", "pickupIds": ["watch-token-1", "watch-token-2", "watch-token-3"], "required": 3 }
+      ],
+      "reward": { "crystals": 80, "friendship": { "bound-knight": 10 } }
+    },
+    {
+      "id": "dreadspire-ritual-ingredients",
+      "title": "Three Measures for the Circle",
+      "type": "fetch",
+      "giverNpcId": "cultist-ordrin",
+      "receiverNpcId": "cultist-ordrin",
+      "offerDialogue": "The circle is hungry and I am out of everything. One measure of bone dust from the vault, one phial of shadow-oil from the study, one black candle's wax from the sanctum. Bring all three before dusk or the circle pouts, and a pouting circle is no use to anyone.",
+      "activeDialogue": "Bone dust, shadow-oil, candle-wax. The vault, the study, the sanctum. The circle waits, hungrily.",
+      "completeDialogue": "Yesss. The circle is fed and the chamber stops sulking. Tell no one the recipe — least of all Vesska, who would only improve it, which is unforgivable.",
+      "steps": [
+        { "key": "ingredients", "type": "collect", "pickupIds": ["bone-dust", "shadow-oil", "candle-wax"], "required": 3 }
+      ],
+      "reward": { "crystals": 90, "friendship": { "cultist-ordrin": 12 } }
+    },
+    {
+      "id": "dreadspire-bone-tally",
+      "title": "The Bone Tally",
+      "type": "lost-items",
+      "giverNpcId": "bone-keeper-mald",
+      "receiverNpcId": "bone-keeper-mald",
+      "offerDialogue": "A thief came through the vault and my tally is short — three femurs and a favourite skull, gone into the deep ossuary where I no longer venture. Follow the gaps in the niches; one missing bone always points to the next. Bring my tally whole.",
+      "activeDialogue": "Three femurs and a skull, lost deeper into the ossuary. Each empty niche points the way to the next.",
+      "completeDialogue": "Every bone home, every niche filled. Order restored. The skull I shall set back in its listening-spot — it has missed our little chats, I think.",
+      "steps": [
+        { "key": "bones", "type": "collect", "pickupIds": ["femur-1", "femur-2", "femur-3", "lost-skull"], "required": 4 }
+      ],
+      "reward": {
+        "crystals": 95,
+        "relationship": { "bone-keeper-mald": { "track": "ally", "points": 12 } }
+      }
+    },
+    {
+      "id": "dreadspire-black-candles",
+      "title": "Candles for the Dark",
+      "type": "fetch",
+      "giverNpcId": "shrine-tender",
+      "receiverNpcId": "shrine-tender",
+      "offerDialogue": "The shadow will not be prayed to by honest flame. I need three black candles — two left in the shrine, one carried off into the sanctum. Gather them and the dark will hold its evening audience.",
+      "activeDialogue": "Three black candles for the shadow's audience. The shrine, and the sanctum beyond.",
+      "completeDialogue": "The dark accepts its candles. It says nothing, as is its way, but the silence is a little warmer now. Go in shadow, pilgrim.",
+      "steps": [
+        { "key": "candles", "type": "collect", "pickupIds": ["black-candle-1", "black-candle-2", "black-candle-3"], "required": 3 }
+      ],
+      "reward": { "crystals": 85, "friendship": { "shrine-tender": 12 } }
+    },
+    {
+      "id": "dreadspire-raven-tokens",
+      "title": "The Ravens' Domain",
+      "type": "lost-items",
+      "giverNpcId": "raven-keeper-corvane",
+      "receiverNpcId": "raven-keeper-corvane",
+      "offerDialogue": "My birds fly the whole citadel and drop their little tokens in its furthest corners — the east tower, the cells, the war room, the poison lab. Bring me one from each corner and I will know my domain is whole, and my count correct.",
+      "activeDialogue": "Four raven tokens, one from each far corner of the citadel.",
+      "completeDialogue": "Four corners, four tokens, one whole domain. The birds settle. They like you — or they have decided not to remember you unkindly, which from a raven is the same as love.",
+      "steps": [
+        { "key": "tokens", "type": "collect", "pickupIds": ["raven-token-1", "raven-token-2", "raven-token-3", "raven-token-4"], "required": 4 }
+      ],
+      "reward": { "crystals": 90, "friendship": { "raven-keeper-corvane": 14 } }
+    },
+    {
+      "id": "dreadspire-ravens-return",
+      "title": "The Sixth Raven",
+      "type": "fetch",
+      "giverNpcId": "raven-keeper-corvane",
+      "receiverNpcId": "raven-keeper-corvane",
+      "prerequisite": "quest:dreadspire-raven-tokens",
+      "offerDialogue": "Five ravens I count, and five return. The sixth has not. I found one black feather caught in the gatehouse — start there. A raven that drops a feather is a raven that is frightened, and mine do not frighten easily.",
+      "activeDialogue": "One lost feather in the gatehouse guardroom — the trail to my sixth raven.",
+      "completeDialogue": "The feather is hers, no doubt of it. She is sulking in the rafters, not stolen. Six ravens, six returned. You have my count and my thanks.",
+      "steps": [
+        { "key": "feather", "type": "collect", "pickupIds": ["lost-raven-feather"], "required": 1 }
+      ],
+      "reward": { "crystals": 70, "friendship": { "raven-keeper-corvane": 10 } }
+    },
+    {
+      "id": "dreadspire-lost-keys",
+      "title": "The Master's Old Keys",
+      "type": "lost-items",
+      "giverNpcId": "ghost-servant-isolde",
+      "receiverNpcId": "ghost-servant-isolde",
+      "offerDialogue": "Four centuries of sweeping and I have dropped the master's old keys on my rounds — undercroft, crypt, war room, in that order, I think. One key always lies near the dust of the next. Bring them back before I have to dust them, too.",
+      "activeDialogue": "Three old keys, dropped along Isolde's eternal rounds. Each lies near the trail to the next.",
+      "completeDialogue": "All three, back on their ring. Now I can lock doors I will only sweep through anyway. Thank you, warm one. It is good to finish a chore for once.",
+      "steps": [
+        { "key": "keys", "type": "collect", "pickupIds": ["old-key-1", "old-key-2", "old-key-3"], "required": 3 }
+      ],
+      "reward": { "crystals": 85, "friendship": { "ghost-servant-isolde": 12 } }
+    },
+    {
+      "id": "dreadspire-moon-herbs",
+      "title": "Moon-Herbs from the Marsh",
+      "type": "fetch",
+      "giverNpcId": "alchemist-sythe",
+      "receiverNpcId": "alchemist-sythe",
+      "offerDialogue": "My poisons are dull because my herbs are dead. The only proper moon-herbs grow in Hollowmere's marsh, under that hedge-witch Morwen's watchful eye. Take her my request, gather two good bunches from the marsh, and bring them back to me. Mind her temper; it is worse than mine, and that is saying something.",
+      "activeDialogue": "Carry my request to Hedge-Witch Morwen in Hollowmere, then gather two bunches of moon-herbs from the marsh.",
+      "completeDialogue": "Fresh moon-herbs, still cold with marsh-dew. NOW we have poison with conviction. Morwen didn't curse you, I hope? She usually saves the good curses for me.",
+      "steps": [
+        { "key": "request", "type": "deliver", "targetNpcId": "hedge-witch-morwen", "required": 1 },
+        { "key": "herbs", "type": "collect", "pickupIds": ["moon-herb-1", "moon-herb-2"], "required": 2 }
+      ],
+      "reward": {
+        "crystals": 120,
+        "friendship": { "alchemist-sythe": 12, "hedge-witch-morwen": 8 },
+        "collectible": { "id": "dreadspire-moon-vial", "name": "Moon-Herb Vial", "icon": "🧪", "desc": "A vial of marsh-cold moon-herb distillate. Medicine with conviction, as Sythe would say." }
+      }
+    },
+    {
+      "id": "dreadspire-poison-tasting",
+      "title": "A Question of Taste",
+      "type": "fetch",
+      "giverNpcId": "alchemist-sythe",
+      "receiverNpcId": "alchemist-sythe",
+      "prerequisite": "quest:dreadspire-moon-herbs",
+      "offerDialogue": "With the moon-herbs working I can finally test the base. I need two test-fungi — one from my own lab shelf, one that grows wild in the deep ossuary. Do not taste them. I mean it. The LAST assistant tasted them.",
+      "activeDialogue": "Two test-fungi: one in the poison lab, one in the deep ossuary. Do not taste them.",
+      "completeDialogue": "Both fungi, untouched, undigested — excellent. You may yet outlive my other assistants, who number, at last count, none.",
+      "steps": [
+        { "key": "fungi", "type": "collect", "pickupIds": ["test-fungus-1", "test-fungus-2"], "required": 2 }
+      ],
+      "reward": { "crystals": 80, "friendship": { "alchemist-sythe": 10 } }
+    },
+    {
+      "id": "dreadspire-cracked-sigils",
+      "title": "Spent Sigil-Stones",
+      "type": "fetch",
+      "giverNpcId": "warlock-vesska",
+      "receiverNpcId": "warlock-vesska",
+      "offerDialogue": "Sigils burn out, like everything. Three spent sigil-stones lie about the towers and the chamber — the study, the west tower, the summoning chamber. Gather them before someone steps on one and learns what a spent sigil does on its way out.",
+      "activeDialogue": "Three cracked sigil-stones: the study, the west tower, the summoning chamber.",
+      "completeDialogue": "Spent, every one, and safely in my jar. A cracked sigil is a small disaster waiting for a bare foot. You have prevented at least three minor catastrophes. Most people manage none.",
+      "steps": [
+        { "key": "sigils", "type": "collect", "pickupIds": ["sigil-stone-1", "sigil-stone-2", "sigil-stone-3"], "required": 3 }
+      ],
+      "reward": { "crystals": 95, "friendship": { "warlock-vesska": 12 } }
+    },
+    {
+      "id": "dreadspire-grave-offerings",
+      "title": "Coins for the Tombs",
+      "type": "fetch",
+      "giverNpcId": "shrine-tender",
+      "receiverNpcId": "shrine-tender",
+      "offerDialogue": "The garrison's graves go without their coins, and the dead grow restless when unpaid. Three grave-coins lie loose among the tombs of the outer ward. Gather them, and we shall lay them properly so the dead may rest and stop their nightly re-forming.",
+      "activeDialogue": "Three grave-coins, loose among the tombs of the outer ward.",
+      "completeDialogue": "Paid in full, the lot of them. The dead are quieter already — they re-form from habit now, not grievance. A small mercy, but mercy is rare currency here.",
+      "steps": [
+        { "key": "coins", "type": "collect", "pickupIds": ["grave-coin-1", "grave-coin-2", "grave-coin-3"], "required": 3 }
+      ],
+      "reward": { "crystals": 75, "friendship": { "shrine-tender": 10 } }
+    },
+    {
+      "id": "dreadspire-intrigue-1",
+      "title": "What the Ritual Does",
+      "type": "chain",
+      "giverNpcId": "warlock-vesska",
+      "receiverNpcId": "warlock-vesska",
+      "offerDialogue": "A confidence, warm one. The master's homecoming ritual does not bring him home — it brings something WEARING him. I have proof scattered as loose pages: one in this study, one in the war room, one beneath the very throne. Bring them to me, quietly. Ordrin must not know I doubt the circle.",
+      "activeDialogue": "Three pages of evidence: the study, the war room, beneath the throne. Quietly, now.",
+      "completeDialogue": "All three pages. Read together they are damning. The ritual is a door, and what knocks on the far side is not our master. I will need leave from the warden to reach the one prisoner who saw it done. Help me get it.",
+      "steps": [
+        { "key": "evidence", "type": "collect", "pickupIds": ["evidence-1", "evidence-2", "evidence-3"], "required": 3 }
+      ],
+      "reward": {
+        "crystals": 100,
+        "relationship": { "warlock-vesska": { "track": "ally", "points": 12 } }
+      }
+    },
+    {
+      "id": "dreadspire-intrigue-2",
+      "title": "Leave from the Warden",
+      "type": "chain",
+      "giverNpcId": "warlock-vesska",
+      "receiverNpcId": "dungeon-warden-gholl",
+      "prerequisite": "quest:dreadspire-intrigue-1 | relationship:warlock-vesska:ally:1",
+      "offerDialogue": "Take my writ to Warden Gholl. He outranks dust — barely — and the sealed lower vault answers to his key. Tell him the pages say what I dared not. He will know my hand, and the door will open.",
+      "activeDialogue": "Carry Vesska's writ down to Warden Gholl in the dungeon cells. His leave unseals the lower vault.",
+      "completeDialogue": "Vesska's hand, right enough. And the pages... gods. The vault is yours, warm one — what's left in it deserves the air. Mind the prisoner. Four hundred years alone does things to a voice.",
+      "steps": [
+        { "key": "writ", "type": "deliver", "targetNpcId": "dungeon-warden-gholl", "required": 1 }
+      ],
+      "reward": { "crystals": 90, "friendship": { "dungeon-warden-gholl": 12 } }
+    },
+    {
+      "id": "dreadspire-intrigue-3",
+      "title": "The Defector's Testimony",
+      "type": "chain",
+      "giverNpcId": "the-defector",
+      "receiverNpcId": "warlock-vesska",
+      "prerequisite": "quest:dreadspire-intrigue-2",
+      "offerDialogue": "Air. Real air. Listen — I SAW the ritual done, and I will swear to it, but my word means nothing from inside a vault. Carry my testimony to Vesska. If anyone can stop the master's homecoming, it is that infuriating, brilliant warlock. Go. Quickly, while I still believe in tomorrow.",
+      "activeDialogue": "Carry Sera's testimony up to Warlock Vesska in the keep study.",
+      "completeDialogue": "Sera's testimony, in her own shaking hand. It is enough. The ritual will not be completed — not while I draw breath, and I intend to draw it spitefully and for a very long time. You have saved this citadel from its own master. Take this, with my regard, which I do not give lightly.",
+      "steps": [
+        { "key": "testimony", "type": "deliver", "targetNpcId": "warlock-vesska", "required": 1 }
+      ],
+      "reward": {
+        "crystals": 160,
+        "relationship": { "warlock-vesska": { "track": "ally", "points": 20 } },
+        "collectible": { "id": "dreadspire-sealed-writ", "name": "The Sealed Writ", "icon": "📜", "desc": "Vesska's order halting the master's homecoming ritual. The citadel keeps its empty throne — and is glad of it." }
       }
     }
   ],
   "pickupItems": [
+    { "id": "dark-crystal-1", "tx": 4, "ty": 15, "tileId": "dark_red_crystal1", "questId": "dreadspire-dark-harvest" },
+    { "id": "dark-crystal-2", "tx": 33, "ty": 16, "tileId": "dark_red_crystal1", "questId": "dreadspire-dark-harvest" },
+    { "id": "dark-crystal-3", "tx": 19, "ty": 26, "tileId": "dark_red_crystal1", "questId": "dreadspire-dark-harvest" },
+
+    { "id": "dark-crystal-4", "tx": 6, "ty": 6, "tileId": "dark_red_crystal1", "building": "keep-crypt", "questId": "dreadspire-harvest-2" },
+    { "id": "dark-crystal-5", "tx": 3, "ty": 5, "tileId": "dark_red_crystal1", "building": "summoning-chamber", "questId": "dreadspire-harvest-2" },
+    { "id": "dark-crystal-6", "tx": 5, "ty": 3, "tileId": "dark_red_crystal1", "building": "bone-ossuary-deep", "questId": "dreadspire-harvest-2" },
+
+    { "id": "dark-crystal-7", "tx": 5, "ty": 4, "tileId": "dark_red_crystal1", "building": "tower-east-top", "questId": "dreadspire-harvest-3" },
+    { "id": "dark-crystal-8", "tx": 6, "ty": 3, "tileId": "dark_red_crystal1", "building": "alchemy-lab", "questId": "dreadspire-harvest-3" },
+    { "id": "dark-crystal-9", "tx": 6, "ty": 4, "tileId": "dark_red_crystal1", "building": "dungeon-cells", "questId": "dreadspire-harvest-3" },
+
+    { "id": "watch-token-1", "tx": 10, "ty": 20, "tileId": "pileOfCopperCoins", "questId": "dreadspire-lost-watch" },
+    { "id": "watch-token-2", "tx": 29, "ty": 21, "tileId": "pendant", "questId": "dreadspire-lost-watch" },
+    { "id": "watch-token-3", "tx": 18, "ty": 28, "tileId": "oldeKey", "questId": "dreadspire-lost-watch" },
+
+    { "id": "bone-dust", "tx": 5, "ty": 5, "tileId": "skull", "building": "bone-vault", "questId": "dreadspire-ritual-ingredients" },
+    { "id": "shadow-oil", "tx": 5, "ty": 5, "tileId": "potions", "building": "keep-warlock-study", "questId": "dreadspire-ritual-ingredients" },
+    { "id": "candle-wax", "tx": 5, "ty": 3, "tileId": "candlestickUnlit", "building": "shrine-inner-sanctum", "questId": "dreadspire-ritual-ingredients" },
+
+    { "id": "femur-1", "tx": 4, "ty": 4, "tileId": "skull", "building": "bone-vault", "questId": "dreadspire-bone-tally" },
+    { "id": "femur-2", "tx": 4, "ty": 4, "tileId": "skull", "building": "bone-ossuary-deep", "questId": "dreadspire-bone-tally", "chain": "femur-1" },
+    { "id": "femur-3", "tx": 8, "ty": 4, "tileId": "skull", "building": "bone-ossuary-deep", "questId": "dreadspire-bone-tally", "chain": "femur-2" },
+    { "id": "lost-skull", "tx": 6, "ty": 6, "tileId": "skull", "building": "bone-ossuary-deep", "questId": "dreadspire-bone-tally", "chain": "femur-3" },
+
+    { "id": "black-candle-1", "tx": 4, "ty": 5, "tileId": "candlestickUnlit", "building": "shadow-shrine", "questId": "dreadspire-black-candles" },
+    { "id": "black-candle-2", "tx": 6, "ty": 5, "tileId": "candlestickUnlit", "building": "shadow-shrine", "questId": "dreadspire-black-candles" },
+    { "id": "black-candle-3", "tx": 6, "ty": 4, "tileId": "candlestickUnlit", "building": "shrine-inner-sanctum", "questId": "dreadspire-black-candles" },
+
+    { "id": "raven-token-1", "tx": 4, "ty": 5, "tileId": "feather", "building": "tower-east-top", "questId": "dreadspire-raven-tokens" },
+    { "id": "raven-token-2", "tx": 8, "ty": 5, "tileId": "feather", "building": "dungeon-cells", "questId": "dreadspire-raven-tokens" },
+    { "id": "raven-token-3", "tx": 5, "ty": 5, "tileId": "feather", "building": "keep-war-room", "questId": "dreadspire-raven-tokens" },
+    { "id": "raven-token-4", "tx": 9, "ty": 5, "tileId": "feather", "building": "alchemy-lab", "questId": "dreadspire-raven-tokens" },
+
+    { "id": "lost-raven-feather", "tx": 5, "ty": 5, "tileId": "feather", "building": "gatehouse", "questId": "dreadspire-ravens-return" },
+
+    { "id": "old-key-1", "tx": 5, "ty": 5, "tileId": "oldeKey", "building": "servants-undercroft", "questId": "dreadspire-lost-keys" },
+    { "id": "old-key-2", "tx": 5, "ty": 3, "tileId": "oldeKey", "building": "keep-crypt", "questId": "dreadspire-lost-keys", "chain": "old-key-1" },
+    { "id": "old-key-3", "tx": 8, "ty": 4, "tileId": "oldeKey", "building": "keep-war-room", "questId": "dreadspire-lost-keys", "chain": "old-key-2" },
+
+    { "id": "evidence-1", "tx": 7, "ty": 5, "tileId": "blackclosedBook", "building": "keep-warlock-study", "questId": "dreadspire-intrigue-1" },
+    { "id": "evidence-2", "tx": 3, "ty": 5, "tileId": "blackclosedBook", "building": "keep-war-room", "questId": "dreadspire-intrigue-1" },
+    { "id": "evidence-3", "tx": 5, "ty": 6, "tileId": "blackclosedBook", "building": "dread-keep", "questId": "dreadspire-intrigue-1" },
+
+    { "id": "sigil-stone-1", "tx": 8, "ty": 5, "tileId": "violet_crystal1", "building": "keep-warlock-study", "questId": "dreadspire-cracked-sigils" },
+    { "id": "sigil-stone-2", "tx": 3, "ty": 4, "tileId": "violet_crystal1", "building": "warlock-tower-west", "questId": "dreadspire-cracked-sigils" },
+    { "id": "sigil-stone-3", "tx": 8, "ty": 5, "tileId": "violet_crystal1", "building": "summoning-chamber", "questId": "dreadspire-cracked-sigils" },
+
+    { "id": "grave-coin-1", "tx": 12, "ty": 24, "tileId": "pileOfCopperCoins", "questId": "dreadspire-grave-offerings" },
+    { "id": "grave-coin-2", "tx": 22, "ty": 24, "tileId": "pileOfCopperCoins", "questId": "dreadspire-grave-offerings" },
+    { "id": "grave-coin-3", "tx": 25, "ty": 29, "tileId": "pileOfCopperCoins", "questId": "dreadspire-grave-offerings" },
+
+    { "id": "test-fungus-1", "tx": 3, "ty": 5, "tileId": "purpleMushroom", "building": "alchemy-lab", "questId": "dreadspire-poison-tasting" },
+    { "id": "test-fungus-2", "tx": 9, "ty": 3, "tileId": "purpleMushroom", "building": "bone-ossuary-deep", "questId": "dreadspire-poison-tasting" }
+  ],
+  "dialogues": [
     {
-      "id": "dark-crystal-1",
-      "tx": 3,
-      "ty": 14,
-      "tileId": "dark_red_crystal1",
-      "questId": "dreadspire-dark-harvest"
-    },
-    {
-      "id": "dark-crystal-2",
-      "tx": 21,
-      "ty": 17,
-      "tileId": "dark_red_crystal1",
-      "questId": "dreadspire-dark-harvest"
-    },
-    {
-      "id": "dark-crystal-3",
-      "tx": 16,
-      "ty": 18,
-      "tileId": "dark_red_crystal1",
-      "questId": "dreadspire-dark-harvest"
+      "id": "vesska-chat",
+      "npcId": "warlock-vesska",
+      "start": "greet",
+      "nodes": {
+        "greet": {
+          "text": "Warm one. You move through my citadel like you belong here. I have not decided whether that pleases me.",
+          "choices": [
+            { "label": "I'm on your side, Vesska.", "effects": [{ "type": "relationship", "npcId": "warlock-vesska", "track": "ally", "points": 6 }], "next": "ally" },
+            { "label": "I answer to no warlock.", "effects": [{ "type": "relationship", "npcId": "warlock-vesska", "track": "rival", "points": 6 }], "next": "rival" },
+            { "label": "What IS the master's ritual?", "next": "lore" }
+          ]
+        },
+        "ally": { "text": "Then we are allies, and I shall pretend that is not a relief. Few here have a pulse, fewer still a spine.", "choices": [{ "label": "Always.", "effects": [{ "type": "end" }] }] },
+        "rival": { "text": "Defiant. Good. A circle needs resistance or it grows lazy. Cross me carefully, then.", "choices": [{ "label": "Count on it.", "effects": [{ "type": "end" }] }] },
+        "lore": { "text": "A door dressed as a homecoming. The master walks in; something else walks out. I would very much like to keep that door shut.", "choices": [{ "label": "Then let's keep it shut.", "effects": [{ "type": "friendship", "npcId": "warlock-vesska", "xp": 5 }, { "type": "end" }] }] }
+      }
     }
   ],
+  "friendshipDialogue": {
+    "the-castellan": {
+      "1": "Ah, the warm one returns. The dust spoke well of you. The dust speaks of little else, frankly.",
+      "2": "You are becoming a fixture, like the braziers, but warmer and less prone to wandering.",
+      "3": "Four hundred years I have kept this citadel alone. It is... less lonely, lately. Do not tell the dust I said so."
+    },
+    "raven-keeper-corvane": {
+      "1": "The birds have stopped warning me when you approach. From a raven, that is a knighthood.",
+      "2": "Six ravens, and all six watch you kindly now. I have never known them to agree on anything."
+    }
+  },
+  "relationshipDialogue": {
+    "bone-keeper-mald": {
+      "ally": { "1": "For a friend of the tally, the deep niches are open. Mind the draught — and the things that enjoy it." },
+      "rival": { "1": "You count bones like a thief counts exits. I am watching you, warm one. Every femur." }
+    }
+  },
   "blockedPaths": []
 }

--- a/web/src/data/hub/hollowmere/questDefs.json
+++ b/web/src/data/hub/hollowmere/questDefs.json
@@ -60,6 +60,8 @@
     { "id": "moonherb-1", "tx": 3, "ty": 12, "tileId": "bunchOfHerbs", "questId": "hollowmere-witch-brew" },
     { "id": "moonherb-2", "tx": 16, "ty": 14, "tileId": "bunchOfHerbs", "questId": "hollowmere-witch-brew" },
     { "id": "moonherb-3", "tx": 24, "ty": 17, "tileId": "bunchOfHerbs", "questId": "hollowmere-witch-brew" },
+    { "id": "moon-herb-1", "tx": 7, "ty": 16, "tileId": "bunchOfHerbs", "questId": "dreadspire-moon-herbs" },
+    { "id": "moon-herb-2", "tx": 11, "ty": 17, "tileId": "bunchOfHerbs", "questId": "dreadspire-moon-herbs" },
     { "id": "spell-feather", "tx": 5, "ty": 12, "tileId": "feather", "questId": "morwen-speak-with-animals" },
     { "id": "spell-mooncap", "tx": 18, "ty": 14, "tileId": "purpleMushroom", "questId": "morwen-speak-with-animals" },
     { "id": "spell-rose", "tx": 22, "ty": 17, "tileId": "cropRose", "questId": "morwen-speak-with-animals" }


### PR DESCRIPTION
Closes #1738 (part of epic #1732).

Expands **Dreadspire Citadel** from a stub (1 building, 1 room, 2 NPCs, 1 quest, ~31 decor) to a Tier-B town, leaning into the dark-citadel theme.

## Design direction
Per discussion on this task, Dreadspire is modelled as **one interconnected castle complex** rather than many separate buildings: a few exterior entrances open into a large warren of linked interior rooms. You enter a tower from the courtyard, a door leads through to a keep room, and stairs go **down** to the dungeon/crypt and **up** to the tower tops. This leans into the linked-rooms engine feature (`exit.toInteriorId` can target any interior, including internal-only rooms with no exterior door).

> **Trade-off (intentional, agreed on the issue):** this puts the *exterior* building count at the low end (**6** entrances) while the *interior* room count goes well above a typical Tier-B town (**18** linked rooms, 12 reachable only from inside). The "~8–12 buildings" target is read as a richness proxy that the deep interior more than satisfies. Happy to split internal rooms back out into doored structures if you'd prefer the literal count.

## What changed
- **Map** enlarged to 40×34 (1280×1088); gate entrance relocated south; connected street network with **every exterior door fronted by a street tile** (#1733).
- **6 exterior entrances**: dread keep, two warlock towers, shadow shrine, bone vault, gatehouse.
- **18 furnished interiors** forming one warren (#1734): keep throne hall → war room / warlock study / crypt; towers with stairs up to tops and down to the dungeon & summoning chamber; crypt ↔ ossuary passage; servants' undercroft; alchemy lab; **gated lower vault** holding the captive defector. Bidirectional exits, no soft-locks (every room can reach an exit-to-world).
- **11 themed NPCs** (warlock, cultist, bone-keeper, shrine-tender, alchemist, raven-keeper, warden, defector, ghost servant + the castellan & bound knight), two on schedules, eerie dialogue, a dialogue tree + friendship/relationship dialogue.
- **17 quests / 41 pickups**: the Dark Harvest 3-part chain, ritual-ingredient & lost-item fetches, raven/bone/keys collections, and a relationship-gated **3-part intrigue chain** whose completion unseals the lower vault.
- **Cross-town hook (#1735)**: Alchemist Sythe's moon-herbs quest sends the player to **Hollowmere's Hedge-Witch Morwen**; herb pickups added to Hollowmere's marsh (no layout change there).
- **~173 decor entries** (245 expanded tiles) across wards and interiors.

## New reusable assets
- 3 new hub NPC sprites: `hub-npc-warlock`, `hub-npc-cultist`, `hub-npc-raven-keeper`.
- 6 new shared decor **bundles** in `bundles.json` (`brazier`, `candelabra`, `suit-of-armour`, `bookshelf`, `gargoyle`, `dark-altar`) so multi-tile props place from one `bundleID` — usable by every town.

## Verification
- `cd web && npm run test` → **198 passed**; `npm run build` → clean.
- A standalone validator checked: every exterior door on a street; all interior decor/NPCs/pickups in bounds and off solid decor & exits; bidirectional exits with no soft-locks; all quest giver/receiver/target/prereq/pickup references resolve (incl. the cross-town Morwen target).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NwwiXiZognrbfP9MTg4b3Z)_