### PR TITLE
Hub town expansion: Royal Palace (Tier B) — #1739

### DIFF
--- a/web/public/sprites/hub-npc-cook.svg
+++ b/web/public/sprites/hub-npc-cook.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- shadow -->
+  <ellipse cx="16" cy="29" rx="6" ry="2" fill="rgba(0,0,0,0.2)"/>
+  <!-- apron / body -->
+  <rect x="9" y="13" width="14" height="15" rx="3" fill="#f0ece2"/>
+  <!-- apron strings -->
+  <rect x="9" y="18" width="14" height="2" fill="#cfc7b6"/>
+  <!-- arms -->
+  <rect x="7"  y="14" width="3" height="9" rx="1" fill="#d8b48a"/>
+  <rect x="22" y="14" width="3" height="9" rx="1" fill="#d8b48a"/>
+  <!-- head -->
+  <circle cx="16" cy="10" r="5" fill="#e8c19a"/>
+  <!-- eyes -->
+  <rect x="13" y="9" width="2" height="2" rx="1" fill="#2a1a0a"/>
+  <rect x="17" y="9" width="2" height="2" rx="1" fill="#2a1a0a"/>
+  <!-- rosy cheeks -->
+  <circle cx="12" cy="11" r="1" fill="#e29a8a"/>
+  <circle cx="20" cy="11" r="1" fill="#e29a8a"/>
+  <!-- chef's hat -->
+  <rect x="11" y="4" width="10" height="3" fill="#ffffff"/>
+  <ellipse cx="16" cy="3" rx="6" ry="3" fill="#ffffff"/>
+</svg>

--- a/web/public/sprites/hub-npc-gardener.svg
+++ b/web/public/sprites/hub-npc-gardener.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- shadow -->
+  <ellipse cx="16" cy="29" rx="5" ry="2" fill="rgba(0,0,0,0.2)"/>
+  <!-- tunic -->
+  <rect x="10" y="13" width="12" height="15" rx="3" fill="#5f7d3a"/>
+  <!-- apron -->
+  <rect x="12" y="16" width="8" height="10" rx="1" fill="#8a6a3a"/>
+  <!-- arms -->
+  <rect x="8"  y="14" width="3" height="9" rx="1" fill="#5f7d3a"/>
+  <rect x="21" y="14" width="3" height="9" rx="1" fill="#5f7d3a"/>
+  <!-- spade -->
+  <rect x="23" y="9" width="2" height="15" rx="1" fill="#6b4020"/>
+  <rect x="22" y="22" width="4" height="3" rx="1" fill="#b8b8b8"/>
+  <!-- head -->
+  <circle cx="16" cy="10" r="5" fill="#d9ad84"/>
+  <!-- eyes -->
+  <rect x="13" y="9" width="2" height="2" rx="1" fill="#2a1a0a"/>
+  <rect x="17" y="9" width="2" height="2" rx="1" fill="#2a1a0a"/>
+  <!-- straw hat -->
+  <ellipse cx="16" cy="6" rx="9" ry="3" fill="#d9b85a"/>
+  <ellipse cx="16" cy="4" rx="5" ry="3" fill="#c7a648"/>
+</svg>

--- a/web/public/sprites/hub-npc-king.svg
+++ b/web/public/sprites/hub-npc-king.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- shadow -->
+  <ellipse cx="16" cy="29" rx="6" ry="2" fill="rgba(0,0,0,0.2)"/>
+  <!-- royal robe -->
+  <rect x="9" y="13" width="14" height="15" rx="3" fill="#8e2230"/>
+  <!-- ermine trim -->
+  <rect x="9" y="13" width="14" height="3" rx="1" fill="#f3efe6"/>
+  <!-- arms -->
+  <rect x="7"  y="14" width="3" height="9" rx="1" fill="#8e2230"/>
+  <rect x="22" y="14" width="3" height="9" rx="1" fill="#8e2230"/>
+  <!-- beard -->
+  <rect x="12" y="11" width="8" height="5" rx="2" fill="#d8d2c4"/>
+  <!-- head -->
+  <circle cx="16" cy="9" r="5" fill="#e0bd97"/>
+  <!-- eyes -->
+  <rect x="13" y="8" width="2" height="2" rx="1" fill="#2a1a0a"/>
+  <rect x="17" y="8" width="2" height="2" rx="1" fill="#2a1a0a"/>
+  <!-- crown -->
+  <rect x="10" y="3" width="12" height="3" fill="#e8c34a"/>
+  <polygon points="10,3 12,0 14,3" fill="#e8c34a"/>
+  <polygon points="14,3 16,0 18,3" fill="#e8c34a"/>
+  <polygon points="18,3 20,0 22,3" fill="#e8c34a"/>
+  <circle cx="16" cy="2" r="1" fill="#cf4b54"/>
+</svg>

--- a/web/public/sprites/hub-npc-princess.svg
+++ b/web/public/sprites/hub-npc-princess.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- shadow -->
+  <ellipse cx="16" cy="29" rx="5" ry="2" fill="rgba(0,0,0,0.2)"/>
+  <!-- gown -->
+  <polygon points="12,15 20,15 23,28 9,28" fill="#d57aa8"/>
+  <!-- bodice trim -->
+  <rect x="12" y="15" width="8" height="2" fill="#f3e1ec"/>
+  <!-- arms -->
+  <rect x="8"  y="16" width="3" height="7" rx="1" fill="#d57aa8"/>
+  <rect x="21" y="16" width="3" height="7" rx="1" fill="#d57aa8"/>
+  <!-- long hair -->
+  <rect x="9" y="7" width="14" height="9" rx="3" fill="#e8b24a"/>
+  <!-- head -->
+  <circle cx="16" cy="9" r="5" fill="#f1d2b4"/>
+  <!-- eyes -->
+  <rect x="13" y="8" width="2" height="2" rx="1" fill="#3a2a1a"/>
+  <rect x="17" y="8" width="2" height="2" rx="1" fill="#3a2a1a"/>
+  <!-- tiara -->
+  <rect x="12" y="4" width="8" height="2" fill="#ffe27a"/>
+  <polygon points="14,4 16,1 18,4" fill="#ffe27a"/>
+  <circle cx="16" cy="3" r="1" fill="#e06aa0"/>
+</svg>

--- a/web/public/sprites/hub-npc-queen.svg
+++ b/web/public/sprites/hub-npc-queen.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- shadow -->
+  <ellipse cx="16" cy="29" rx="6" ry="2" fill="rgba(0,0,0,0.2)"/>
+  <!-- gown -->
+  <polygon points="11,14 21,14 24,28 8,28" fill="#5b3a8e"/>
+  <!-- bodice trim -->
+  <rect x="11" y="14" width="10" height="3" fill="#d9c46a"/>
+  <!-- arms -->
+  <rect x="7"  y="15" width="3" height="8" rx="1" fill="#5b3a8e"/>
+  <rect x="22" y="15" width="3" height="8" rx="1" fill="#5b3a8e"/>
+  <!-- hair -->
+  <rect x="10" y="7" width="12" height="7" rx="3" fill="#7a4a24"/>
+  <!-- head -->
+  <circle cx="16" cy="9" r="5" fill="#ecc6a3"/>
+  <!-- eyes -->
+  <rect x="13" y="8" width="2" height="2" rx="1" fill="#2a1a0a"/>
+  <rect x="17" y="8" width="2" height="2" rx="1" fill="#2a1a0a"/>
+  <!-- crown -->
+  <rect x="11" y="3" width="10" height="3" fill="#e8c34a"/>
+  <polygon points="11,3 13,0 15,3" fill="#e8c34a"/>
+  <polygon points="15,3 16,-1 17,3" fill="#e8c34a"/>
+  <polygon points="17,3 19,0 21,3" fill="#e8c34a"/>
+  <circle cx="16" cy="2" r="1" fill="#6fa0d8"/>
+</svg>

--- a/web/src/data/hub/royalpalace/config.json
+++ b/web/src/data/hub/royalpalace/config.json
@@ -1,57 +1,121 @@
 {
-  "mapW": 1056,
-  "mapH": 896,
+  "mapW": 1408,
+  "mapH": 1216,
   "townName": "Royal Palace",
   "environment": "citadel",
+  "weather": {
+    "bySeason": {
+      "spring": "rain",
+      "summer": "clear",
+      "autumn": "fog",
+      "winter": "snow"
+    }
+  },
   "avatarStart": {
-    "tx": 13,
-    "ty": 25
+    "tx": 14,
+    "ty": 36
   },
   "exitTiles": [
     {
       "tx": 13,
-      "ty": 26,
+      "ty": 37,
       "screen": "worldmap"
     },
     {
       "tx": 14,
-      "ty": 26,
+      "ty": 37,
       "screen": "worldmap"
     }
   ],
   "areas": [
     {
-      "id": "palace-gardens",
+      "id": "royal-gardens",
       "name": "The Royal Gardens",
       "tx": 4,
-      "ty": 17,
-      "tw": 20,
+      "ty": 18,
+      "tw": 18,
       "th": 8
+    },
+    {
+      "id": "east-gardens",
+      "name": "The East Gardens",
+      "tx": 24,
+      "ty": 23,
+      "tw": 18,
+      "th": 4
+    },
+    {
+      "id": "outer-court",
+      "name": "The Outer Court",
+      "tx": 9,
+      "ty": 28,
+      "tw": 24,
+      "th": 8
+    },
+    {
+      "id": "servants-yard",
+      "name": "The Servants' Yard",
+      "tx": 1,
+      "ty": 26,
+      "tw": 8,
+      "th": 9
     }
   ],
   "streets": [
     {
       "rect": [
         13,
-        18,
+        17,
         15,
+        37
+      ]
+    },
+    {
+      "rect": [
+        5,
+        17,
+        24,
+        17
+      ]
+    },
+    {
+      "rect": [
+        1,
+        26,
+        24,
         27
       ]
     },
     {
       "rect": [
-        4,
-        18,
+        25,
         23,
-        19
+        41,
+        23
       ]
     },
     {
       "rect": [
-        12,
-        15,
-        16,
-        17
+        24,
+        13,
+        24,
+        23
+      ]
+    },
+    {
+      "rect": [
+        22,
+        13,
+        41,
+        13
+      ]
+    },
+    {
+      "rect": [
+        4,
+        36,
+        41,
+        36
       ]
     }
   ],
@@ -71,138 +135,211 @@
         {
           "tx": 7,
           "ty": 1,
-          "hideSign": true,
-          "buildingId": "palace"
+          "buildingId": "palace",
+          "hideSign": true
         },
         {
           "tx": 8,
           "ty": 1,
-          "hideSign": true,
-          "buildingId": "palace"
+          "buildingId": "palace",
+          "hideSign": true
+        }
+      ]
+    },
+    {
+      "id": "guest-wing",
+      "upgradeKind": "inn",
+      "rect": [
+        25,
+        5,
+        32,
+        12
+      ],
+      "wall": "whiteStone",
+      "roof": "redSlateRoof",
+      "doors": [
+        {
+          "tx": 4,
+          "ty": 1,
+          "buildingId": "guest-wing"
+        }
+      ]
+    },
+    {
+      "id": "royal-library",
+      "upgradeKind": "default",
+      "rect": [
+        34,
+        5,
+        41,
+        12
+      ],
+      "wall": "whiteStone",
+      "roof": "blueSlateRoof",
+      "doors": [
+        {
+          "tx": 4,
+          "ty": 1,
+          "buildingId": "royal-library"
+        }
+      ]
+    },
+    {
+      "id": "royal-chapel",
+      "upgradeKind": "shrine",
+      "rect": [
+        25,
+        15,
+        32,
+        22
+      ],
+      "wall": "whiteStone",
+      "roof": "greySlateRoof",
+      "doors": [
+        {
+          "tx": 4,
+          "ty": 1,
+          "buildingId": "royal-chapel"
+        }
+      ]
+    },
+    {
+      "id": "treasury-vault",
+      "upgradeKind": "default",
+      "rect": [
+        34,
+        15,
+        41,
+        22
+      ],
+      "wall": "reinforcedStone",
+      "roof": "greySlateRoof",
+      "doors": [
+        {
+          "tx": 4,
+          "ty": 1,
+          "buildingId": "treasury-vault"
+        }
+      ]
+    },
+    {
+      "id": "orangery",
+      "upgradeKind": "default",
+      "rect": [
+        1,
+        18,
+        8,
+        25
+      ],
+      "wall": "whiteStone",
+      "roof": "blueSlateRoof",
+      "doors": [
+        {
+          "tx": 3,
+          "ty": 1,
+          "buildingId": "orangery"
+        }
+      ]
+    },
+    {
+      "id": "stables",
+      "upgradeKind": "default",
+      "rect": [
+        17,
+        18,
+        23,
+        25
+      ],
+      "wall": "woodWall",
+      "roof": "strawRoof",
+      "doors": [
+        {
+          "tx": 3,
+          "ty": 1,
+          "buildingId": "stables"
+        }
+      ]
+    },
+    {
+      "id": "servants-quarters",
+      "upgradeKind": "cottage",
+      "rect": [
+        1,
+        28,
+        8,
+        35
+      ],
+      "wall": "renderedBrick",
+      "roof": "redSlateRoof",
+      "doors": [
+        {
+          "tx": 3,
+          "ty": 1,
+          "buildingId": "servants-quarters"
+        }
+      ]
+    },
+    {
+      "id": "gatehouse",
+      "upgradeKind": "default",
+      "rect": [
+        17,
+        28,
+        23,
+        35
+      ],
+      "wall": "castleStone",
+      "roof": "greySlateRoof",
+      "doors": [
+        {
+          "tx": 3,
+          "ty": 1,
+          "buildingId": "gatehouse"
+        }
+      ]
+    },
+    {
+      "id": "armory",
+      "upgradeKind": "workshop",
+      "rect": [
+        25,
+        28,
+        32,
+        35
+      ],
+      "wall": "castleStone",
+      "roof": "greySlateRoof",
+      "doors": [
+        {
+          "tx": 4,
+          "ty": 1,
+          "buildingId": "armory"
+        }
+      ]
+    },
+    {
+      "id": "royal-kitchens",
+      "upgradeKind": "default",
+      "rect": [
+        34,
+        28,
+        41,
+        35
+      ],
+      "wall": "renderedBrick",
+      "roof": "redSlateRoof",
+      "doors": [
+        {
+          "tx": 3,
+          "ty": 1,
+          "buildingId": "royal-kitchens"
         }
       ]
     }
   ],
   "exteriorDecor": [
     {
-      "comment": "garden fountain"
-    },
-    {
-      "tx": 17,
-      "ty": 23,
-      "bundleID": "fountain",
-      "zlayer": "solid"
-    },
-    {
-      "comment": "garden trees and flowers"
-    },
-    {
-      "tx": 4,
-      "ty": 21,
-      "bundleID": "light-tree",
-      "zlayer": "solid"
-    },
-    {
-      "tx": 22,
-      "ty": 21,
-      "bundleID": "light-tree",
-      "zlayer": "solid"
-    },
-    {
-      "tx": 22,
-      "ty": 17,
-      "bundleID": "light-tree",
-      "zlayer": "solid"
-    },
-    {
-      "tx": 2,
-      "ty": 17,
-      "bundleID": "light-tree",
-      "zlayer": "solid"
-    },
-    {
-      "tx": 6,
-      "ty": 20,
-      "tileId": "whiteFlower"
-    },
-    {
-      "tx": 10,
-      "ty": 20,
-      "tileId": "whiteFlower"
-    },
-    {
-      "tx": 16,
-      "ty": 24,
-      "tileId": "whiteFlower"
-    },
-    {
-      "tx": 20,
-      "ty": 20,
-      "tileId": "whiteFlower"
-    },
-    {
-      "comment": "fences along the south garden wall, gap at the gate"
-    },
-    {
-      "tx": 9,
-      "ty": 25,
-      "tileId": "ironFenceLeftRight",
-      "zlayer": "above"
-    },
-    {
-      "tx": 10,
-      "ty": 25,
-      "tileId": "ironFenceLeftRight",
-      "zlayer": "above"
-    },
-    {
-      "tx": 11,
-      "ty": 25,
-      "tileId": "ironFenceLeft",
-      "zlayer": "above"
-    },
-    {
-      "tx": 16,
-      "ty": 25,
-      "tileId": "ironFenceRight",
-      "zlayer": "above"
-    },
-    {
-      "tx": 17,
-      "ty": 25,
-      "tileId": "ironFenceLeftRight",
-      "zlayer": "above"
-    },
-    {
-      "tx": 18,
-      "ty": 25,
-      "tileId": "ironFenceLeftRight",
-      "zlayer": "above"
-    },
-    {
-      "comment": "entrance braziers"
-    },
-    {
-      "tx": 11,
-      "ty": 17,
-      "tileId": "brazierBottom"
-    },
-    {
-      "tx": 11,
-      "ty": 16,
-      "tileId": "brazierTop",
-      "zlayer": "above"
-    },
-    {
-      "tx": 17,
-      "ty": 17,
-      "tileId": "brazierBottom"
-    },
-    {
-      "tx": 17,
-      "ty": 16,
-      "tileId": "brazierTop",
-      "zlayer": "above"
+      "comment": "palace steps and entrance braziers"
     },
     {
       "tx": 12,
@@ -265,29 +402,915 @@
       "zlayer": "solid"
     },
     {
+      "tx": 11,
+      "ty": 17,
+      "tileId": "brazierBottom"
+    },
+    {
+      "tx": 17,
+      "ty": 17,
+      "tileId": "brazierBottom"
+    },
+    {
+      "comment": "perimeter trees"
+    },
+    {
+      "tx": 1,
+      "ty": 5,
+      "bundleID": "light-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 3,
+      "ty": 7,
+      "bundleID": "light-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 1,
+      "ty": 10,
+      "bundleID": "light-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 1,
+      "ty": 14,
+      "bundleID": "light-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 1,
+      "ty": 16,
+      "bundleID": "light-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 42,
+      "ty": 4,
+      "bundleID": "light-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 42,
+      "ty": 8,
+      "bundleID": "light-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 42,
+      "ty": 14,
+      "bundleID": "light-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 42,
+      "ty": 18,
+      "bundleID": "light-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 42,
+      "ty": 22,
+      "bundleID": "light-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 1,
+      "ty": 37,
+      "bundleID": "light-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 10,
+      "ty": 5,
+      "bundleID": "light-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 10,
+      "ty": 26,
+      "bundleID": "light-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 15,
+      "ty": 5,
+      "bundleID": "light-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 33,
+      "ty": 26,
+      "bundleID": "light-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 42,
+      "ty": 26,
+      "bundleID": "light-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 28,
+      "ty": 26,
+      "bundleID": "light-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 42,
+      "ty": 33,
+      "bundleID": "light-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 4,
+      "ty": 4,
+      "bundleID": "autumn-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 42,
+      "ty": 11,
+      "bundleID": "autumn-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 32,
+      "ty": 24,
+      "bundleID": "autumn-tree",
+      "zlayer": "solid"
+    },
+    {
+      "comment": "royal gardens \u2014 fountains, statues, bird baths, benches"
+    },
+    {
       "tx": 9,
-      "ty": 23,
+      "ty": 21,
       "bundleID": "fountain",
       "zlayer": "solid"
+    },
+    {
+      "tx": 18,
+      "ty": 21,
+      "bundleID": "fountain",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 12,
+      "ty": 24,
+      "tileId": "memorialBotLeft",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 12,
+      "ty": 23,
+      "tileId": "memorialTopLeft",
+      "zlayer": "above"
+    },
+    {
+      "tx": 13,
+      "ty": 24,
+      "tileId": "memorialBotRight",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 13,
+      "ty": 23,
+      "tileId": "memorialTopRight",
+      "zlayer": "above"
+    },
+    {
+      "tx": 28,
+      "ty": 25,
+      "tileId": "birdBathBottom",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 28,
+      "ty": 24,
+      "tileId": "birdBathMiddle"
+    },
+    {
+      "tx": 28,
+      "ty": 23,
+      "tileId": "birdBathTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 38,
+      "ty": 25,
+      "tileId": "birdBathBottom",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 38,
+      "ty": 24,
+      "tileId": "birdBathMiddle"
+    },
+    {
+      "tx": 38,
+      "ty": 23,
+      "tileId": "birdBathTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 16,
+      "ty": 24,
+      "tileId": "benchLeft"
+    },
+    {
+      "comment": "flower beds"
+    },
+    {
+      "tx": 10,
+      "ty": 20,
+      "tileId": "blueFlower"
+    },
+    {
+      "tx": 16,
+      "ty": 20,
+      "tileId": "yellowFlower"
+    },
+    {
+      "tx": 10,
+      "ty": 22,
+      "tileId": "whiteFlower"
+    },
+    {
+      "tx": 16,
+      "ty": 22,
+      "tileId": "pinkFlower"
+    },
+    {
+      "tx": 9,
+      "ty": 24,
+      "tileId": "pinkFlower"
+    },
+    {
+      "tx": 26,
+      "ty": 24,
+      "tileId": "whiteFlower"
+    },
+    {
+      "tx": 27,
+      "ty": 25,
+      "tileId": "pinkFlower"
+    },
+    {
+      "tx": 37,
+      "ty": 24,
+      "tileId": "blueFlower"
+    },
+    {
+      "tx": 39,
+      "ty": 24,
+      "tileId": "yellowFlower"
+    },
+    {
+      "tx": 40,
+      "ty": 25,
+      "tileId": "whiteFlower"
+    },
+    {
+      "tx": 10,
+      "ty": 18,
+      "tileId": "pinkFlower"
+    },
+    {
+      "tx": 11,
+      "ty": 18,
+      "tileId": "blueFlower"
+    },
+    {
+      "tx": 16,
+      "ty": 18,
+      "tileId": "yellowFlower"
+    },
+    {
+      "comment": "hedges and ornamental bushes framing the gardens"
+    },
+    {
+      "tx": 9,
+      "ty": 18,
+      "tileId": "tallBushPot",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 16,
+      "ty": 18,
+      "tileId": "tallBushPot",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 25,
+      "ty": 24,
+      "tileId": "tallBushPot",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 26,
+      "ty": 25,
+      "tileId": "tallBushPot",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 40,
+      "ty": 24,
+      "tileId": "tallBushPot",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 41,
+      "ty": 24,
+      "tileId": "tallBushPot",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 24,
+      "ty": 24,
+      "tileId": "darkBush"
+    },
+    {
+      "tx": 33,
+      "ty": 24,
+      "tileId": "darkBush"
+    },
+    {
+      "tx": 33,
+      "ty": 25,
+      "tileId": "lightBush"
+    },
+    {
+      "tx": 42,
+      "ty": 24,
+      "tileId": "lightBush"
+    },
+    {
+      "comment": "rose beds (Queen's roses) and crops in the orangery yard"
+    },
+    {
+      "tx": 9,
+      "ty": 19,
+      "tileId": "cropRose"
+    },
+    {
+      "tx": 16,
+      "ty": 19,
+      "tileId": "cropRose"
+    },
+    {
+      "comment": "iron fencing along the south garden wall, gate gap on the avenue"
+    },
+    {
+      "tx": 6,
+      "ty": 27,
+      "tileId": "ironFenceLeftRight",
+      "zlayer": "above"
+    },
+    {
+      "tx": 7,
+      "ty": 27,
+      "tileId": "ironFenceLeftRight",
+      "zlayer": "above"
+    },
+    {
+      "tx": 8,
+      "ty": 27,
+      "tileId": "ironFenceLeftRight",
+      "zlayer": "above"
+    },
+    {
+      "tx": 9,
+      "ty": 27,
+      "tileId": "ironFenceLeftRight",
+      "zlayer": "above"
+    },
+    {
+      "tx": 10,
+      "ty": 27,
+      "tileId": "ironFenceLeftRight",
+      "zlayer": "above"
+    },
+    {
+      "tx": 11,
+      "ty": 27,
+      "tileId": "ironFenceLeftRight",
+      "zlayer": "above"
+    },
+    {
+      "tx": 16,
+      "ty": 27,
+      "tileId": "ironFenceLeftRight",
+      "zlayer": "above"
+    },
+    {
+      "tx": 17,
+      "ty": 27,
+      "tileId": "ironFenceLeftRight",
+      "zlayer": "above"
+    },
+    {
+      "tx": 18,
+      "ty": 27,
+      "tileId": "ironFenceLeftRight",
+      "zlayer": "above"
+    },
+    {
+      "tx": 19,
+      "ty": 27,
+      "tileId": "ironFenceLeftRight",
+      "zlayer": "above"
+    },
+    {
+      "tx": 20,
+      "ty": 27,
+      "tileId": "ironFenceLeftRight",
+      "zlayer": "above"
+    },
+    {
+      "tx": 21,
+      "ty": 27,
+      "tileId": "ironFenceLeftRight",
+      "zlayer": "above"
+    },
+    {
+      "tx": 22,
+      "ty": 27,
+      "tileId": "ironFenceLeftRight",
+      "zlayer": "above"
+    },
+    {
+      "tx": 23,
+      "ty": 27,
+      "tileId": "ironFenceLeftRight",
+      "zlayer": "above"
+    },
+    {
+      "tx": 24,
+      "ty": 27,
+      "tileId": "ironFenceLeftRight",
+      "zlayer": "above"
+    },
+    {
+      "comment": "lamp posts lining the grand approach and avenues"
+    },
+    {
+      "tx": 12,
+      "ty": 19,
+      "tileId": "lampPostBottom",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 12,
+      "ty": 18,
+      "tileId": "lampPostTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 16,
+      "ty": 19,
+      "tileId": "lampPostBottom",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 16,
+      "ty": 18,
+      "tileId": "lampPostTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 12,
+      "ty": 22,
+      "tileId": "lampPostBottom",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 12,
+      "ty": 21,
+      "tileId": "lampPostTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 16,
+      "ty": 22,
+      "tileId": "lampPostBottom",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 16,
+      "ty": 21,
+      "tileId": "lampPostTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 12,
+      "ty": 25,
+      "tileId": "lampPostBottom",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 12,
+      "ty": 24,
+      "tileId": "lampPostTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 16,
+      "ty": 25,
+      "tileId": "lampPostBottom",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 16,
+      "ty": 24,
+      "tileId": "lampPostTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 12,
+      "ty": 30,
+      "tileId": "lampPostBottom",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 12,
+      "ty": 29,
+      "tileId": "lampPostTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 16,
+      "ty": 30,
+      "tileId": "lampPostBottom",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 16,
+      "ty": 29,
+      "tileId": "lampPostTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 12,
+      "ty": 34,
+      "tileId": "lampPostBottom",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 12,
+      "ty": 33,
+      "tileId": "lampPostTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 16,
+      "ty": 34,
+      "tileId": "lampPostBottom",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 16,
+      "ty": 33,
+      "tileId": "lampPostTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 23,
+      "ty": 14,
+      "tileId": "lampPostBottom",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 23,
+      "ty": 13,
+      "tileId": "lampPostTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 40,
+      "ty": 14,
+      "tileId": "lampPostBottom",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 40,
+      "ty": 13,
+      "tileId": "lampPostTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 40,
+      "ty": 24,
+      "tileId": "lampPostBottom",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 40,
+      "ty": 23,
+      "tileId": "lampPostTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 9,
+      "ty": 28,
+      "tileId": "lampPostBottom",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 9,
+      "ty": 27,
+      "tileId": "lampPostTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 24,
+      "ty": 28,
+      "tileId": "lampPostBottom",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 24,
+      "ty": 27,
+      "tileId": "lampPostTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 33,
+      "ty": 28,
+      "tileId": "lampPostBottom",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 33,
+      "ty": 27,
+      "tileId": "lampPostTop",
+      "zlayer": "above"
+    },
+    {
+      "comment": "outer court \u2014 barrels, crates, sacks near the service buildings"
+    },
+    {
+      "tx": 9,
+      "ty": 30,
+      "tileId": "barrel"
+    },
+    {
+      "tx": 10,
+      "ty": 30,
+      "tileId": "crate"
+    },
+    {
+      "tx": 24,
+      "ty": 30,
+      "tileId": "barrel"
+    },
+    {
+      "tx": 33,
+      "ty": 30,
+      "tileId": "crate"
+    },
+    {
+      "tx": 33,
+      "ty": 31,
+      "tileId": "sack"
+    },
+    {
+      "tx": 10,
+      "ty": 34,
+      "tileId": "pileOfSacks"
+    },
+    {
+      "tx": 24,
+      "ty": 34,
+      "tileId": "logPile"
+    },
+    {
+      "tx": 9,
+      "ty": 33,
+      "tileId": "hayStack"
+    },
+    {
+      "tx": 32,
+      "ty": 27,
+      "tileId": "barrel"
+    },
+    {
+      "tx": 25,
+      "ty": 27,
+      "tileId": "crate"
+    },
+    {
+      "comment": "stable yard \u2014 hay and water"
+    },
+    {
+      "tx": 16,
+      "ty": 24,
+      "tileId": "hayStack"
+    },
+    {
+      "tx": 16,
+      "ty": 25,
+      "tileId": "fullBucket"
+    },
+    {
+      "tx": 24,
+      "ty": 25,
+      "tileId": "hayStack"
+    },
+    {
+      "comment": "servants' yard \u2014 washing line and well"
+    },
+    {
+      "tx": 2,
+      "ty": 26,
+      "tileId": "stoneWell",
+      "zlayer": "solid"
+    },
+    {
+      "comment": "gatehouse braziers framing the entrance"
+    },
+    {
+      "tx": 12,
+      "ty": 35,
+      "tileId": "brazierBottom"
+    },
+    {
+      "tx": 12,
+      "ty": 34,
+      "tileId": "brazierTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 16,
+      "ty": 35,
+      "tileId": "brazierBottom"
+    },
+    {
+      "tx": 16,
+      "ty": 34,
+      "tileId": "brazierTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 12,
+      "ty": 32,
+      "tileId": "wantedPosterBottom"
+    },
+    {
+      "tx": 12,
+      "ty": 31,
+      "tileId": "wantedPosterTop"
+    },
+    {
+      "comment": "notice board in the outer court"
+    },
+    {
+      "tx": 18,
+      "ty": 31,
+      "tileId": "messageBoardTopLeft",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 19,
+      "ty": 31,
+      "tileId": "messageBoardTopRight",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 18,
+      "ty": 32,
+      "tileId": "messageBoardBottomLeft",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 19,
+      "ty": 32,
+      "tileId": "messageBoardBottomRight",
+      "zlayer": "solid"
+    },
+    {
+      "comment": "a quiet ornamental pond in the gardens"
+    },
+    {
+      "tx": 9,
+      "ty": 23,
+      "tileId": "largeLilypad"
+    },
+    {
+      "tx": 10,
+      "ty": 24,
+      "tileId": "smallLilypad"
     }
   ],
   "npcSpawnTiles": [],
   "ambientNpcSprites": [
-    "hub-npc-soldier"
+    "hub-npc-soldier",
+    "hub-npc-scholar"
   ],
   "npcs": [
     {
-      "id": "royal-herald",
-      "name": "Herald Fanshawe",
-      "sprite": "hub-npc-scholar",
+      "id": "royal-steward",
+      "name": "Steward Marigold",
+      "sprite": "hub-npc-elder",
       "tx": 13,
       "ty": 19,
       "dialogue": [
-        "Presenting: you. To no one in particular. It's been a slow morning.",
+        "Oh dear, oh dear. There is always something misplaced, misfiled, or misbehaving at this palace.",
         "Their Majesties are in session. The gardens, however, receive all visitors.",
+        "If you've a strong back and a willing heart, the crown has no end of small disasters for you."
+      ],
+      "questGive": "new-quest-1",
+      "questReceive": [
+        "palace-lost-regalia",
+        "new-quest-1",
+        "palace-happy-cat",
+        "palace-lost-keys"
+      ],
+      "schedule": [
+        {
+          "startHour": 0,
+          "endHour": 7,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "servants-quarters",
+            "tx": 9,
+            "ty": 3
+          }
+        },
+        {
+          "startHour": 7,
+          "endHour": 19,
+          "activity": "idle-chat",
+          "location": {
+            "type": "exterior",
+            "tx": 13,
+            "ty": 19
+          }
+        },
+        {
+          "startHour": 19,
+          "endHour": 24,
+          "activity": "eat",
+          "location": {
+            "type": "interior",
+            "buildingId": "guest-wing",
+            "tx": 6,
+            "ty": 5
+          }
+        }
+      ],
+      "homeBed": {
+        "buildingId": "servants-quarters",
+        "tx": 9,
+        "ty": 3
+      }
+    },
+    {
+      "id": "royal-herald",
+      "name": "Herald Fanshawe",
+      "sprite": "hub-npc-herald",
+      "tx": 10,
+      "ty": 18,
+      "dialogue": [
+        "Presenting: you. To no one in particular. It's been a slow morning.",
+        "Hear ye, hear ye \u2014 the proclamations have gone missing again. A herald with no words is merely a man shouting.",
         "Protocol is the art of standing in the right place while important things happen elsewhere."
       ],
-      "questReceive": "new-quest-1"
+      "questGive": "palace-herald-proclamation",
+      "questReceive": "palace-herald-proclamation",
+      "schedule": [
+        {
+          "startHour": 0,
+          "endHour": 8,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "servants-quarters",
+            "tx": 6,
+            "ty": 3
+          }
+        },
+        {
+          "startHour": 8,
+          "endHour": 18,
+          "location": {
+            "type": "exterior",
+            "tx": 10,
+            "ty": 18
+          }
+        },
+        {
+          "startHour": 18,
+          "endHour": 24,
+          "activity": "idle-chat",
+          "location": {
+            "type": "exterior",
+            "tx": 13,
+            "ty": 19
+          }
+        }
+      ]
     },
     {
       "id": "palace-guard",
@@ -299,37 +1322,538 @@
         "Move along. Or stand there. You're not technically breaking any rules.",
         "Nobody enters the throne room without an appointment. Or a mop. The mop people go everywhere.",
         "Quietest post in the kingdom, this. I've counted the fence railings twice."
+      ],
+      "questGive": "palace-guard-watch",
+      "questReceive": "palace-guard-watch",
+      "schedule": [
+        {
+          "startHour": 0,
+          "endHour": 6,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "gatehouse",
+            "tx": 5,
+            "ty": 5
+          }
+        },
+        {
+          "startHour": 6,
+          "endHour": 14,
+          "location": {
+            "type": "exterior",
+            "tx": 18,
+            "ty": 18
+          }
+        },
+        {
+          "startHour": 14,
+          "endHour": 22,
+          "location": {
+            "type": "exterior",
+            "tx": 20,
+            "ty": 35
+          }
+        },
+        {
+          "startHour": 22,
+          "endHour": 24,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "gatehouse",
+            "tx": 5,
+            "ty": 5
+          }
+        }
+      ],
+      "homeBed": {
+        "buildingId": "gatehouse",
+        "tx": 5,
+        "ty": 5
+      }
+    },
+    {
+      "id": "king",
+      "name": "King Aldric",
+      "sprite": "hub-npc-king",
+      "building": "palace",
+      "tx": 6,
+      "ty": 5,
+      "dialogue": [
+        "Ah, a new face. The court is forever full of old ones, all of them wanting something.",
+        "A crown is heavier than it looks, and most of the weight is other people's problems.",
+        "Serve the realm well and the realm remembers. Mostly. When it isn't distracted."
+      ],
+      "questGive": "palace-court-intrigue-2",
+      "questReceive": [
+        "palace-court-intrigue-1",
+        "palace-court-intrigue-2"
+      ],
+      "schedule": [
+        {
+          "startHour": 0,
+          "endHour": 8,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "palace-3",
+            "tx": 4,
+            "ty": 3
+          }
+        },
+        {
+          "startHour": 8,
+          "endHour": 18,
+          "location": {
+            "type": "interior",
+            "buildingId": "palace",
+            "tx": 6,
+            "ty": 5
+          }
+        },
+        {
+          "startHour": 18,
+          "endHour": 24,
+          "activity": "eat",
+          "location": {
+            "type": "interior",
+            "buildingId": "guest-wing",
+            "tx": 7,
+            "ty": 5
+          }
+        }
+      ],
+      "homeBed": {
+        "buildingId": "palace-3",
+        "tx": 4,
+        "ty": 3
+      }
+    },
+    {
+      "id": "queen",
+      "name": "Queen Maredith",
+      "sprite": "hub-npc-queen",
+      "building": "palace",
+      "tx": 9,
+      "ty": 5,
+      "dialogue": [
+        "Mind the roses on your way through the garden \u2014 they are the one thing here that answers to no one.",
+        "The King rules the realm; I rule the garden. We are each terrified of the other's domain.",
+        "A kingdom is judged by its kindnesses, not its conquests. Remember that, if you remember nothing else."
+      ],
+      "questGive": "palace-queen-roses",
+      "questReceive": "palace-queen-roses",
+      "schedule": [
+        {
+          "startHour": 0,
+          "endHour": 8,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "palace-3",
+            "tx": 6,
+            "ty": 3
+          }
+        },
+        {
+          "startHour": 8,
+          "endHour": 12,
+          "location": {
+            "type": "interior",
+            "buildingId": "palace",
+            "tx": 9,
+            "ty": 5
+          }
+        },
+        {
+          "startHour": 12,
+          "endHour": 18,
+          "activity": "idle-chat",
+          "location": {
+            "type": "exterior",
+            "tx": 9,
+            "ty": 20
+          }
+        },
+        {
+          "startHour": 18,
+          "endHour": 24,
+          "activity": "eat",
+          "location": {
+            "type": "interior",
+            "buildingId": "guest-wing",
+            "tx": 5,
+            "ty": 5
+          }
+        }
+      ],
+      "homeBed": {
+        "buildingId": "palace-3",
+        "tx": 6,
+        "ty": 3
+      }
+    },
+    {
+      "id": "princess",
+      "name": "Princess Elara",
+      "sprite": "hub-npc-princess",
+      "building": "palace-1",
+      "tx": 5,
+      "ty": 4,
+      "dialogue": [
+        "Have you news of Kipper? My dear, dear cat, sent to the seaside and wailing ever since. I cannot bear it.",
+        "Everyone says a princess should be content. I should be content the moment my cat is.",
+        "The goblin and the ogre by the fountain only wish to meet me. Steward Marigold won't allow it. Isn't that sad?"
+      ],
+      "questGive": "palace-princess-gift",
+      "questReceive": [
+        "palace-princess-gift",
+        "palace-kipper-homecoming"
+      ],
+      "schedule": [
+        {
+          "startHour": 0,
+          "endHour": 8,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "palace-3",
+            "tx": 4,
+            "ty": 3
+          }
+        },
+        {
+          "startHour": 8,
+          "endHour": 12,
+          "location": {
+            "type": "interior",
+            "buildingId": "palace-1",
+            "tx": 5,
+            "ty": 4
+          }
+        },
+        {
+          "startHour": 12,
+          "endHour": 18,
+          "activity": "idle-chat",
+          "location": {
+            "type": "exterior",
+            "tx": 16,
+            "ty": 20
+          }
+        },
+        {
+          "startHour": 18,
+          "endHour": 24,
+          "location": {
+            "type": "interior",
+            "buildingId": "palace-1",
+            "tx": 5,
+            "ty": 4
+          }
+        }
+      ],
+      "homeBed": {
+        "buildingId": "palace-3",
+        "tx": 4,
+        "ty": 3
+      }
+    },
+    {
+      "id": "lady-penrose",
+      "name": "Lady Penrose",
+      "sprite": "hub-npc-dealer",
+      "building": "guest-wing",
+      "tx": 8,
+      "ty": 4,
+      "dialogue": [
+        "A guest of the crown, like yourself. Or perhaps not quite like yourself. I keep my purposes close.",
+        "Court is a garden of its own, dear. Every smile is a seed, and not all of them bloom kindly.",
+        "I have a small matter that wants a discreet hand. Are yours discreet?"
+      ],
+      "questGive": "palace-court-intrigue-1",
+      "questReceive": [
+        "palace-court-intrigue-1",
+        "palace-court-intrigue-3"
+      ],
+      "dialogueTree": "penrose-chat"
+    },
+    {
+      "id": "treasurer",
+      "name": "Master Edric",
+      "sprite": "hub-npc-merchant",
+      "building": "treasury-vault",
+      "tx": 8,
+      "ty": 5,
+      "dialogue": [
+        "Every coin accounted for, that is the rule. The trouble is, the coins do not always agree.",
+        "The audit is overdue and the inner vault stays sealed until the ledgers balance.",
+        "Bring me the scattered tallies and I'll open the deep vault myself."
+      ],
+      "questGive": "palace-vault-audit",
+      "questReceive": "palace-vault-audit",
+      "schedule": [
+        {
+          "startHour": 0,
+          "endHour": 8,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "servants-quarters",
+            "tx": 6,
+            "ty": 3
+          }
+        },
+        {
+          "startHour": 8,
+          "endHour": 20,
+          "activity": "work",
+          "location": {
+            "type": "interior",
+            "buildingId": "treasury-vault",
+            "tx": 8,
+            "ty": 5
+          }
+        },
+        {
+          "startHour": 20,
+          "endHour": 24,
+          "activity": "eat",
+          "location": {
+            "type": "interior",
+            "buildingId": "guest-wing",
+            "tx": 6,
+            "ty": 5
+          }
+        }
       ]
     },
     {
-      "id": "royal-steward",
-      "name": "Steward Marigold",
-      "sprite": "hub-npc-elder",
-      "tx": 21,
-      "ty": 18,
+      "id": "chaplain",
+      "name": "Brother Cassian",
+      "sprite": "hub-npc-scholar",
+      "building": "royal-chapel",
+      "tx": 6,
+      "ty": 6,
       "dialogue": [
-        "Oh dear, oh dear. The coronation regalia — misplaced! Again!",
-        "The ceremonial pendant, the jubilee gift, and the vault key. Scattered about the gardens by that dreadful wind.",
-        "If the regalia isn't recovered before the next audience, I shall simply expire."
+        "Peace, traveller. The chapel is open to all, even the road-weary and the regicidal \u2014 though we prefer the former.",
+        "The crypt below holds kings long past. They keep their counsel well.",
+        "Our candles have a way of wandering off. A chapel without light is only a cold stone room."
       ],
-      "questGive": "new-quest-1",
-      "questReceive": "palace-lost-regalia"
+      "questGive": "palace-chapel-candles",
+      "questReceive": "palace-chapel-candles",
+      "schedule": [
+        {
+          "startHour": 0,
+          "endHour": 6,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "royal-chapel-crypt",
+            "tx": 5,
+            "ty": 4
+          }
+        },
+        {
+          "startHour": 6,
+          "endHour": 22,
+          "location": {
+            "type": "interior",
+            "buildingId": "royal-chapel",
+            "tx": 6,
+            "ty": 6
+          }
+        },
+        {
+          "startHour": 22,
+          "endHour": 24,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "royal-chapel-crypt",
+            "tx": 5,
+            "ty": 4
+          }
+        }
+      ]
+    },
+    {
+      "id": "royal-cook",
+      "name": "Cook Bessie",
+      "sprite": "hub-npc-cook",
+      "building": "royal-kitchens",
+      "tx": 6,
+      "ty": 5,
+      "dialogue": [
+        "Out of my kitchen \u2014 unless you've come to help, in which case, in, in, in!",
+        "A royal feast does not cook itself, more's the pity. I've asked the cauldron. It just bubbles at me.",
+        "Fetch me what I need and the court eats like kings. Which, conveniently, they are."
+      ],
+      "questGive": "palace-kitchen-feast",
+      "questReceive": "palace-kitchen-feast",
+      "schedule": [
+        {
+          "startHour": 0,
+          "endHour": 5,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "servants-quarters",
+            "tx": 6,
+            "ty": 3
+          }
+        },
+        {
+          "startHour": 5,
+          "endHour": 21,
+          "activity": "work",
+          "location": {
+            "type": "interior",
+            "buildingId": "royal-kitchens",
+            "tx": 6,
+            "ty": 5
+          }
+        },
+        {
+          "startHour": 21,
+          "endHour": 24,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "servants-quarters",
+            "tx": 6,
+            "ty": 3
+          }
+        }
+      ],
+      "homeBed": {
+        "buildingId": "servants-quarters",
+        "tx": 6,
+        "ty": 3
+      }
+    },
+    {
+      "id": "royal-gardener",
+      "name": "Gardener Thom",
+      "sprite": "hub-npc-gardener",
+      "tx": 9,
+      "ty": 22,
+      "dialogue": [
+        "Mind the beds, mind the beds! A boot in the begonias and I'll have words with you.",
+        "The Queen wants roses, the King wants order, and the rabbits want my lettuces. Everyone wants something.",
+        "If you've a good eye, there's a rare bloom or two I've lost track of out here."
+      ],
+      "questGive": "palace-royal-bloom",
+      "questReceive": [
+        "palace-royal-bloom",
+        "palace-orangery-harvest"
+      ],
+      "schedule": [
+        {
+          "startHour": 0,
+          "endHour": 6,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "servants-quarters",
+            "tx": 9,
+            "ty": 6
+          }
+        },
+        {
+          "startHour": 6,
+          "endHour": 19,
+          "activity": "work",
+          "location": {
+            "type": "exterior",
+            "tx": 9,
+            "ty": 22
+          }
+        },
+        {
+          "startHour": 19,
+          "endHour": 24,
+          "activity": "eat",
+          "location": {
+            "type": "interior",
+            "buildingId": "servants-quarters",
+            "tx": 5,
+            "ty": 5
+          }
+        }
+      ],
+      "homeBed": {
+        "buildingId": "servants-quarters",
+        "tx": 9,
+        "ty": 6
+      }
+    },
+    {
+      "id": "stable-master",
+      "name": "Stable-Master Garrod",
+      "sprite": "hub-npc-trader",
+      "building": "stables",
+      "tx": 6,
+      "ty": 5,
+      "dialogue": [
+        "Easy, easy. The horses spook at strangers, and frankly, so do I.",
+        "One of the ponies slipped its tack and bolted half the gear across the grounds. Royal beasts, royal nuisance.",
+        "Help me round up the lost harness and there's coin in it for you."
+      ],
+      "questGive": "palace-runaway-pony",
+      "questReceive": "palace-runaway-pony",
+      "schedule": [
+        {
+          "startHour": 0,
+          "endHour": 6,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "stables",
+            "tx": 6,
+            "ty": 5
+          }
+        },
+        {
+          "startHour": 6,
+          "endHour": 20,
+          "activity": "work",
+          "location": {
+            "type": "interior",
+            "buildingId": "stables",
+            "tx": 6,
+            "ty": 5
+          }
+        },
+        {
+          "startHour": 20,
+          "endHour": 24,
+          "activity": "eat",
+          "location": {
+            "type": "interior",
+            "buildingId": "servants-quarters",
+            "tx": 5,
+            "ty": 5
+          }
+        }
+      ]
     },
     {
       "id": "npc_1781196539810",
       "name": "Dave the Goblin",
       "sprite": "goblin",
-      "tx": 12,
+      "tx": 11,
       "ty": 20,
       "dialogue": [
-        "Hello!"
+        "Hello! We only want to MEET the princess. Is that so much to ask?"
       ]
     },
     {
       "id": "npc_1781197058836",
       "name": "Nick the Ogre",
       "sprite": "ogre",
-      "tx": 15,
+      "tx": 19,
       "ty": 20,
       "dialogue": [
         "I'm here to see the princess, only she can help me!"
@@ -343,29 +1867,132 @@
       "height": 9,
       "floorTileId": "cobblestoneFloor",
       "wallTileId": "ornateStone",
+      "musicId": "church",
+      "ambianceId": "sacred",
       "decor": [
         {
-          "comment": "honour guard armour flanking the hall"
+          "tx": 7,
+          "ty": 1,
+          "tileId": "redCarpetFloor",
+          "zlayer": "below"
         },
         {
-          "tx": 2,
+          "tx": 7,
+          "ty": 2,
+          "tileId": "redCarpetFloor",
+          "zlayer": "below"
+        },
+        {
+          "tx": 7,
+          "ty": 3,
+          "tileId": "redCarpetFloor",
+          "zlayer": "below"
+        },
+        {
+          "tx": 7,
+          "ty": 4,
+          "tileId": "redCarpetFloor",
+          "zlayer": "below"
+        },
+        {
+          "tx": 7,
+          "ty": 5,
+          "tileId": "redCarpetFloor",
+          "zlayer": "below"
+        },
+        {
+          "tx": 7,
+          "ty": 6,
+          "tileId": "redCarpetFloor",
+          "zlayer": "below"
+        },
+        {
+          "tx": 7,
+          "ty": 7,
+          "tileId": "redCarpetFloor",
+          "zlayer": "below"
+        },
+        {
+          "tx": 8,
           "ty": 1,
-          "tileId": "suitOfArmourTop"
+          "tileId": "redCarpetFloor",
+          "zlayer": "below"
+        },
+        {
+          "tx": 8,
+          "ty": 2,
+          "tileId": "redCarpetFloor",
+          "zlayer": "below"
+        },
+        {
+          "tx": 8,
+          "ty": 3,
+          "tileId": "redCarpetFloor",
+          "zlayer": "below"
+        },
+        {
+          "tx": 8,
+          "ty": 4,
+          "tileId": "redCarpetFloor",
+          "zlayer": "below"
+        },
+        {
+          "tx": 8,
+          "ty": 5,
+          "tileId": "redCarpetFloor",
+          "zlayer": "below"
+        },
+        {
+          "tx": 8,
+          "ty": 6,
+          "tileId": "redCarpetFloor",
+          "zlayer": "below"
+        },
+        {
+          "tx": 8,
+          "ty": 7,
+          "tileId": "redCarpetFloor",
+          "zlayer": "below"
         },
         {
           "tx": 2,
           "ty": 2,
-          "tileId": "suitOfArmourBottom"
-        },
-        {
-          "tx": 13,
-          "ty": 1,
-          "tileId": "suitOfArmourTop"
+          "bundleID": "suit-of-armour"
         },
         {
           "tx": 13,
           "ty": 2,
-          "tileId": "suitOfArmourBottom"
+          "bundleID": "suit-of-armour"
+        },
+        {
+          "tx": 1,
+          "ty": 1,
+          "bundleID": "brazier"
+        },
+        {
+          "tx": 14,
+          "ty": 1,
+          "bundleID": "brazier"
+        },
+        {
+          "tx": 4,
+          "ty": 1,
+          "bundleID": "candelabra"
+        },
+        {
+          "tx": 11,
+          "ty": 1,
+          "bundleID": "candelabra"
+        },
+        {
+          "tx": 7,
+          "ty": 1,
+          "tileId": "crownOfCushon"
+        },
+        {
+          "tx": 8,
+          "ty": 1,
+          "tileId": "crownOfCushon"
         },
         {
           "tx": 6,
@@ -389,13 +2016,23 @@
         },
         {
           "tx": 4,
-          "ty": 3,
+          "ty": 5,
           "tileId": "roundTableWithCloth"
         },
         {
           "tx": 11,
-          "ty": 3,
+          "ty": 5,
           "tileId": "roundTableWithCloth"
+        },
+        {
+          "tx": 3,
+          "ty": 7,
+          "tileId": "potOfFlowers"
+        },
+        {
+          "tx": 12,
+          "ty": 7,
+          "tileId": "potOfFlowers"
         }
       ],
       "exits": [
@@ -405,59 +2042,1528 @@
           "toInteriorId": "palace-1",
           "entryTx": 8,
           "entryTy": 4,
-          "direction": "left"
+          "direction": "left",
+          "label": "West Solar"
+        },
+        {
+          "tx": 15,
+          "ty": 4,
+          "toInteriorId": "palace-2",
+          "entryTx": 1,
+          "entryTy": 4,
+          "direction": "right",
+          "label": "Council Chamber"
+        },
+        {
+          "tx": 5,
+          "ty": 1,
+          "toInteriorId": "palace-stairs-dungeon-to-ground",
+          "entryTx": 3,
+          "entryTy": 1,
+          "direction": "down",
+          "label": "Down to the Vaults"
         }
       ]
     },
     "palace-1": {
-      "name": "palace-1",
+      "name": "The West Solar",
       "width": 10,
       "height": 8,
-      "floorTileId": "woodFloor",
-      "decor": [],
+      "floorTileId": "parquetFloor",
+      "wallTileId": "ornateStone",
+      "decor": [
+        {
+          "tx": 2,
+          "ty": 2,
+          "bundleID": "fireplace"
+        },
+        {
+          "tx": 5,
+          "ty": 4,
+          "tileId": "roundTableWithCloth"
+        },
+        {
+          "tx": 4,
+          "ty": 5,
+          "tileId": "stool"
+        },
+        {
+          "tx": 6,
+          "ty": 5,
+          "tileId": "stool"
+        },
+        {
+          "tx": 8,
+          "ty": 2,
+          "bundleID": "bookshelf"
+        },
+        {
+          "tx": 1,
+          "ty": 6,
+          "tileId": "potOfFlowers"
+        },
+        {
+          "tx": 7,
+          "ty": 6,
+          "tileId": "mirrorBottom"
+        },
+        {
+          "tx": 7,
+          "ty": 5,
+          "tileId": "mirrorTop"
+        },
+        {
+          "tx": 3,
+          "ty": -1,
+          "tileId": "painting"
+        },
+        {
+          "tx": 6,
+          "ty": -1,
+          "tileId": "paintingLandscapeTop"
+        },
+        {
+          "tx": 8,
+          "ty": 6,
+          "tileId": "teddy"
+        }
+      ],
       "exits": [
         {
           "tx": 9,
           "ty": 4,
           "toInteriorId": "palace",
-          "direction": "right",
           "entryTx": 1,
-          "entryTy": 4
+          "entryTy": 4,
+          "direction": "right",
+          "label": "Throne Hall"
+        },
+        {
+          "tx": 4,
+          "ty": 1,
+          "toInteriorId": "palace-3",
+          "entryTx": 5,
+          "entryTy": 6,
+          "direction": "up",
+          "label": "Royal Bedchamber"
         }
       ]
     },
     "palace-2": {
-      "name": "palace-2",
+      "name": "The Council Chamber",
       "width": 10,
       "height": 8,
-      "floorTileId": "woodFloor",
-      "decor": []
+      "floorTileId": "checkeredFloor",
+      "wallTileId": "ornateStone",
+      "decor": [
+        {
+          "tx": 4,
+          "ty": 3,
+          "tileId": "roundTableWithCloth"
+        },
+        {
+          "tx": 5,
+          "ty": 3,
+          "tileId": "roundTableWithCloth"
+        },
+        {
+          "tx": 3,
+          "ty": 2,
+          "tileId": "stool"
+        },
+        {
+          "tx": 6,
+          "ty": 2,
+          "tileId": "stool"
+        },
+        {
+          "tx": 3,
+          "ty": 4,
+          "tileId": "stool"
+        },
+        {
+          "tx": 6,
+          "ty": 4,
+          "tileId": "stool"
+        },
+        {
+          "tx": 1,
+          "ty": 1,
+          "bundleID": "candelabra"
+        },
+        {
+          "tx": 8,
+          "ty": 1,
+          "bundleID": "candelabra"
+        },
+        {
+          "tx": 2,
+          "ty": 6,
+          "tileId": "rolledMap"
+        },
+        {
+          "tx": 7,
+          "ty": 6,
+          "tileId": "pileOfPapers"
+        },
+        {
+          "tx": 4,
+          "ty": -1,
+          "tileId": "worldMapTopLeft"
+        },
+        {
+          "tx": 5,
+          "ty": -1,
+          "tileId": "worldMapTopRight"
+        },
+        {
+          "tx": 8,
+          "ty": 6,
+          "tileId": "wallClock"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 0,
+          "ty": 4,
+          "toInteriorId": "palace",
+          "entryTx": 14,
+          "entryTy": 4,
+          "direction": "left",
+          "label": "Throne Hall"
+        }
+      ]
     },
     "palace-3": {
-      "name": "palace-3",
+      "name": "The Royal Bedchamber",
       "width": 10,
       "height": 8,
-      "floorTileId": "woodFloor",
-      "decor": []
-    },
-    "palace-dungeon": {
-      "name": "palace-dungeon",
-      "width": 10,
-      "height": 8,
-      "floorTileId": "woodFloor",
-      "decor": []
+      "floorTileId": "redCarpetFloor",
+      "wallTileId": "ornateStone",
+      "decor": [
+        {
+          "tx": 4,
+          "ty": 2,
+          "bundleID": "royal-bed"
+        },
+        {
+          "tx": 1,
+          "ty": 1,
+          "bundleID": "candelabra"
+        },
+        {
+          "tx": 8,
+          "ty": 1,
+          "bundleID": "candelabra"
+        },
+        {
+          "tx": 8,
+          "ty": 5,
+          "tileId": "mirrorBottom"
+        },
+        {
+          "tx": 8,
+          "ty": 4,
+          "tileId": "mirrorTop"
+        },
+        {
+          "tx": 1,
+          "ty": 5,
+          "tileId": "chest"
+        },
+        {
+          "tx": 2,
+          "ty": 6,
+          "tileId": "smallChest"
+        },
+        {
+          "tx": 6,
+          "ty": -1,
+          "tileId": "painting"
+        },
+        {
+          "tx": 7,
+          "ty": 6,
+          "tileId": "potOfFlowers"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 5,
+          "ty": 7,
+          "toInteriorId": "palace-1",
+          "entryTx": 4,
+          "entryTy": 1,
+          "direction": "down",
+          "label": "Down to the Solar"
+        }
+      ]
     },
     "palace-stairs-dungeon-to-ground": {
-      "name": "palace-stairs-dungeon-to-ground",
+      "name": "The Vault Stair",
       "width": 6,
       "height": 7,
+      "floorTileId": "stoneFloor",
+      "wallTileId": "castleStone",
+      "decor": [
+        {
+          "tx": 1,
+          "ty": 2,
+          "tileId": "candlestickUnlit"
+        },
+        {
+          "tx": 4,
+          "ty": 2,
+          "tileId": "candlestickUnlit"
+        },
+        {
+          "tx": 1,
+          "ty": 5,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 4,
+          "ty": 5,
+          "tileId": "crate"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 3,
+          "ty": 1,
+          "toInteriorId": "palace",
+          "entryTx": 5,
+          "entryTy": 2,
+          "direction": "up",
+          "label": "Up to the Throne"
+        },
+        {
+          "tx": 2,
+          "ty": 5,
+          "toInteriorId": "palace-dungeon",
+          "entryTx": 5,
+          "entryTy": 1,
+          "direction": "down",
+          "label": "Into the Vaults"
+        }
+      ]
+    },
+    "palace-dungeon": {
+      "name": "The Royal Vaults",
+      "width": 10,
+      "height": 8,
+      "floorTileId": "darkStoneFloor",
+      "wallTileId": "castleStone",
+      "ambianceId": "sacred",
+      "decor": [
+        {
+          "tx": 2,
+          "ty": 1,
+          "tileId": "cellWindowLit"
+        },
+        {
+          "tx": 7,
+          "ty": 1,
+          "tileId": "cellWindowUnlit"
+        },
+        {
+          "tx": 1,
+          "ty": 5,
+          "tileId": "strongChest"
+        },
+        {
+          "tx": 2,
+          "ty": 6,
+          "tileId": "goldChest"
+        },
+        {
+          "tx": 8,
+          "ty": 6,
+          "tileId": "chest"
+        },
+        {
+          "tx": 4,
+          "ty": 6,
+          "tileId": "pileOfGoldCoins"
+        },
+        {
+          "tx": 5,
+          "ty": 6,
+          "tileId": "pileOfSilverCoins"
+        },
+        {
+          "tx": 8,
+          "ty": 1,
+          "tileId": "skull"
+        },
+        {
+          "tx": 3,
+          "ty": 3,
+          "tileId": "candlestickUnlit"
+        },
+        {
+          "tx": 6,
+          "ty": 3,
+          "tileId": "candlestickUnlit"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 5,
+          "ty": 1,
+          "toInteriorId": "palace-stairs-dungeon-to-ground",
+          "entryTx": 2,
+          "entryTy": 5,
+          "direction": "up",
+          "label": "Up the Stair"
+        }
+      ]
+    },
+    "guest-wing": {
+      "name": "The Guest Hall",
+      "width": 12,
+      "height": 9,
       "floorTileId": "woodFloor",
-      "decor": [],
-      "wallTileId": "castleStone"
+      "wallTileId": "whiteStone",
+      "musicId": "inn",
+      "ambianceId": "hearth",
+      "decor": [
+        {
+          "tx": 2,
+          "ty": 2,
+          "bundleID": "fireplace"
+        },
+        {
+          "tx": 6,
+          "ty": 4,
+          "tileId": "roundTableWithCloth"
+        },
+        {
+          "tx": 5,
+          "ty": 5,
+          "tileId": "stool"
+        },
+        {
+          "tx": 7,
+          "ty": 5,
+          "tileId": "stool"
+        },
+        {
+          "tx": 9,
+          "ty": 2,
+          "bundleID": "bookshelf"
+        },
+        {
+          "tx": 1,
+          "ty": 6,
+          "tileId": "potOfFlowers"
+        },
+        {
+          "tx": 10,
+          "ty": 6,
+          "tileId": "potOfFlowers"
+        },
+        {
+          "tx": 4,
+          "ty": -1,
+          "tileId": "painting"
+        },
+        {
+          "tx": 8,
+          "ty": -1,
+          "tileId": "paintingLandscapeTop"
+        },
+        {
+          "tx": 2,
+          "ty": 6,
+          "tileId": "trayOfDrinks"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 6,
+          "ty": 1,
+          "toInteriorId": "guest-wing-upper",
+          "entryTx": 6,
+          "entryTy": 6,
+          "direction": "up",
+          "label": "Guest Bedrooms"
+        }
+      ]
+    },
+    "guest-wing-upper": {
+      "name": "The Guest Bedrooms",
+      "width": 12,
+      "height": 9,
+      "floorTileId": "woodFloor",
+      "wallTileId": "whiteStone",
+      "decor": [
+        {
+          "tx": 1,
+          "ty": 2,
+          "bundleID": "simple-bed"
+        },
+        {
+          "tx": 5,
+          "ty": 2,
+          "bundleID": "simple-bed"
+        },
+        {
+          "tx": 9,
+          "ty": 2,
+          "bundleID": "simple-bed"
+        },
+        {
+          "tx": 3,
+          "ty": 6,
+          "tileId": "mirrorBottom"
+        },
+        {
+          "tx": 3,
+          "ty": 5,
+          "tileId": "mirrorTop"
+        },
+        {
+          "tx": 7,
+          "ty": 6,
+          "tileId": "chest"
+        },
+        {
+          "tx": 10,
+          "ty": 6,
+          "tileId": "smallChest"
+        },
+        {
+          "tx": 2,
+          "ty": 6,
+          "tileId": "candlestickUnlit"
+        },
+        {
+          "tx": 8,
+          "ty": 6,
+          "tileId": "candlestickUnlit"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 6,
+          "ty": 7,
+          "toInteriorId": "guest-wing",
+          "entryTx": 6,
+          "entryTy": 1,
+          "direction": "down",
+          "label": "Down to the Hall"
+        }
+      ]
+    },
+    "royal-library": {
+      "name": "The Royal Library",
+      "width": 14,
+      "height": 10,
+      "floorTileId": "parquetFloor",
+      "wallTileId": "whiteStone",
+      "ambianceId": "sacred",
+      "decor": [
+        {
+          "tx": 1,
+          "ty": 2,
+          "bundleID": "bookshelf"
+        },
+        {
+          "tx": 4,
+          "ty": 2,
+          "bundleID": "bookshelf"
+        },
+        {
+          "tx": 9,
+          "ty": 2,
+          "bundleID": "bookshelf"
+        },
+        {
+          "tx": 12,
+          "ty": 2,
+          "bundleID": "bookshelf"
+        },
+        {
+          "tx": 6,
+          "ty": 5,
+          "tileId": "deskTop"
+        },
+        {
+          "tx": 7,
+          "ty": 5,
+          "tileId": "deskTop"
+        },
+        {
+          "tx": 6,
+          "ty": 6,
+          "tileId": "stool"
+        },
+        {
+          "tx": 2,
+          "ty": 7,
+          "tileId": "openBook"
+        },
+        {
+          "tx": 11,
+          "ty": 7,
+          "tileId": "blueclosedBook"
+        },
+        {
+          "tx": 3,
+          "ty": 5,
+          "bundleID": "candelabra"
+        },
+        {
+          "tx": 10,
+          "ty": 5,
+          "bundleID": "candelabra"
+        },
+        {
+          "tx": 6,
+          "ty": -1,
+          "tileId": "painting"
+        },
+        {
+          "tx": 7,
+          "ty": -1,
+          "tileId": "painting"
+        },
+        {
+          "tx": 1,
+          "ty": 8,
+          "tileId": "rolledMap"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 7,
+          "ty": 1,
+          "toInteriorId": "royal-library-loft",
+          "entryTx": 6,
+          "entryTy": 6,
+          "direction": "up",
+          "label": "Reading Loft"
+        }
+      ]
+    },
+    "royal-library-loft": {
+      "name": "The Reading Loft",
+      "width": 12,
+      "height": 8,
+      "floorTileId": "woodFloor",
+      "wallTileId": "whiteStone",
+      "decor": [
+        {
+          "tx": 1,
+          "ty": 2,
+          "bundleID": "bookshelf"
+        },
+        {
+          "tx": 10,
+          "ty": 2,
+          "bundleID": "bookshelf"
+        },
+        {
+          "tx": 5,
+          "ty": 4,
+          "tileId": "deskTop"
+        },
+        {
+          "tx": 5,
+          "ty": 5,
+          "tileId": "stool"
+        },
+        {
+          "tx": 8,
+          "ty": 6,
+          "tileId": "greenopenBook"
+        },
+        {
+          "tx": 2,
+          "ty": 6,
+          "tileId": "quilAndInk"
+        },
+        {
+          "tx": 3,
+          "ty": 3,
+          "tileId": "candlestickUnlit"
+        },
+        {
+          "tx": 9,
+          "ty": 5,
+          "tileId": "potOfFlowers"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 6,
+          "ty": 7,
+          "toInteriorId": "royal-library",
+          "entryTx": 7,
+          "entryTy": 1,
+          "direction": "down",
+          "label": "Down to the Library"
+        }
+      ]
+    },
+    "royal-chapel": {
+      "name": "The Royal Chapel",
+      "width": 12,
+      "height": 10,
+      "floorTileId": "stoneFloor",
+      "wallTileId": "whiteStone",
+      "musicId": "church",
+      "ambianceId": "sacred",
+      "decor": [
+        {
+          "tx": 5,
+          "ty": 1,
+          "tileId": "altarTopLeft"
+        },
+        {
+          "tx": 6,
+          "ty": 1,
+          "tileId": "altarTopMid"
+        },
+        {
+          "tx": 7,
+          "ty": 1,
+          "tileId": "altarTopRight"
+        },
+        {
+          "tx": 5,
+          "ty": 2,
+          "tileId": "altarMidLeft"
+        },
+        {
+          "tx": 6,
+          "ty": 2,
+          "tileId": "altarMidMid"
+        },
+        {
+          "tx": 7,
+          "ty": 2,
+          "tileId": "altarMidRight"
+        },
+        {
+          "tx": 6,
+          "ty": 0,
+          "tileId": "goldenCross"
+        },
+        {
+          "tx": 4,
+          "ty": -1,
+          "tileId": "stainedGlassWindow1Top"
+        },
+        {
+          "tx": 8,
+          "ty": -1,
+          "tileId": "stainedGlassWindow2Top"
+        },
+        {
+          "tx": 3,
+          "ty": 2,
+          "bundleID": "candelabra"
+        },
+        {
+          "tx": 9,
+          "ty": 2,
+          "bundleID": "candelabra"
+        },
+        {
+          "tx": 4,
+          "ty": 5,
+          "tileId": "benchLeft"
+        },
+        {
+          "tx": 5,
+          "ty": 5,
+          "tileId": "benchMiddle"
+        },
+        {
+          "tx": 6,
+          "ty": 5,
+          "tileId": "benchRight"
+        },
+        {
+          "tx": 4,
+          "ty": 7,
+          "tileId": "benchLeft"
+        },
+        {
+          "tx": 5,
+          "ty": 7,
+          "tileId": "benchMiddle"
+        },
+        {
+          "tx": 6,
+          "ty": 7,
+          "tileId": "benchRight"
+        },
+        {
+          "tx": 8,
+          "ty": 5,
+          "tileId": "benchLeft"
+        },
+        {
+          "tx": 9,
+          "ty": 5,
+          "tileId": "benchRight"
+        },
+        {
+          "tx": 2,
+          "ty": 8,
+          "tileId": "candlestickUnlit"
+        },
+        {
+          "tx": 10,
+          "ty": 8,
+          "tileId": "candlestickUnlit"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 1,
+          "ty": 1,
+          "toInteriorId": "royal-chapel-crypt",
+          "entryTx": 9,
+          "entryTy": 6,
+          "direction": "down",
+          "label": "Royal Crypt"
+        }
+      ]
+    },
+    "royal-chapel-crypt": {
+      "name": "The Royal Crypt",
+      "width": 12,
+      "height": 8,
+      "floorTileId": "darkStoneFloor",
+      "wallTileId": "castleStone",
+      "ambianceId": "sacred",
+      "decor": [
+        {
+          "tx": 2,
+          "ty": 1,
+          "tileId": "graveStone"
+        },
+        {
+          "tx": 4,
+          "ty": 1,
+          "tileId": "stoneCross"
+        },
+        {
+          "tx": 6,
+          "ty": 1,
+          "tileId": "graveStone"
+        },
+        {
+          "tx": 8,
+          "ty": 1,
+          "tileId": "stoneCross"
+        },
+        {
+          "tx": 3,
+          "ty": 5,
+          "tileId": "candlestickUnlit"
+        },
+        {
+          "tx": 7,
+          "ty": 5,
+          "tileId": "candlestickUnlit"
+        },
+        {
+          "tx": 10,
+          "ty": 1,
+          "tileId": "skull"
+        },
+        {
+          "tx": 1,
+          "ty": 6,
+          "tileId": "darkPillarTop"
+        },
+        {
+          "tx": 10,
+          "ty": 6,
+          "tileId": "darkPillarTop"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 9,
+          "ty": 1,
+          "toInteriorId": "royal-chapel",
+          "entryTx": 1,
+          "entryTy": 1,
+          "direction": "up",
+          "label": "Up to the Chapel"
+        }
+      ]
+    },
+    "treasury-vault": {
+      "name": "The Treasury",
+      "width": 12,
+      "height": 9,
+      "floorTileId": "goldSmallTileFloor",
+      "wallTileId": "reinforcedStone",
+      "decor": [
+        {
+          "tx": 2,
+          "ty": 2,
+          "tileId": "chest"
+        },
+        {
+          "tx": 4,
+          "ty": 2,
+          "tileId": "strongChest"
+        },
+        {
+          "tx": 8,
+          "ty": 2,
+          "tileId": "chest"
+        },
+        {
+          "tx": 10,
+          "ty": 2,
+          "tileId": "strongChest"
+        },
+        {
+          "tx": 3,
+          "ty": 6,
+          "tileId": "pileOfGoldCoins"
+        },
+        {
+          "tx": 6,
+          "ty": 6,
+          "tileId": "pileOfSilverCoins"
+        },
+        {
+          "tx": 9,
+          "ty": 6,
+          "tileId": "pileOfGoldCoins"
+        },
+        {
+          "tx": 1,
+          "ty": 1,
+          "bundleID": "candelabra"
+        },
+        {
+          "tx": 10,
+          "ty": 1,
+          "bundleID": "candelabra"
+        },
+        {
+          "tx": 5,
+          "ty": 4,
+          "tileId": "deskTop"
+        },
+        {
+          "tx": 5,
+          "ty": 5,
+          "tileId": "stool"
+        },
+        {
+          "tx": 6,
+          "ty": 4,
+          "tileId": "quilAndInk"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 1,
+          "ty": 1,
+          "toInteriorId": "treasury-vault-inner",
+          "entryTx": 8,
+          "entryTy": 6,
+          "direction": "down",
+          "requiredQuest": "palace-vault-audit",
+          "label": "Inner Vault"
+        }
+      ]
+    },
+    "treasury-vault-inner": {
+      "name": "The Inner Vault",
+      "width": 10,
+      "height": 8,
+      "floorTileId": "goldSmallTileFloor",
+      "wallTileId": "reinforcedStone",
+      "decor": [
+        {
+          "tx": 2,
+          "ty": 2,
+          "tileId": "goldChest"
+        },
+        {
+          "tx": 7,
+          "ty": 2,
+          "tileId": "goldChest"
+        },
+        {
+          "tx": 4,
+          "ty": 2,
+          "tileId": "strongChest"
+        },
+        {
+          "tx": 3,
+          "ty": 5,
+          "tileId": "pileOfGoldCoins"
+        },
+        {
+          "tx": 6,
+          "ty": 5,
+          "tileId": "pileOfGoldCoins"
+        },
+        {
+          "tx": 4,
+          "ty": 4,
+          "tileId": "crownOfCushon"
+        },
+        {
+          "tx": 5,
+          "ty": 4,
+          "tileId": "diamond"
+        },
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "candlestickUnlit"
+        },
+        {
+          "tx": 8,
+          "ty": 1,
+          "tileId": "candlestickUnlit"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 8,
+          "ty": 1,
+          "toInteriorId": "treasury-vault",
+          "entryTx": 1,
+          "entryTy": 1,
+          "direction": "up",
+          "label": "Up to the Treasury"
+        }
+      ]
+    },
+    "orangery": {
+      "name": "The Orangery",
+      "width": 12,
+      "height": 9,
+      "floorTileId": "smallStoneFloor",
+      "wallTileId": "whiteStone",
+      "decor": [
+        {
+          "tx": 2,
+          "ty": 2,
+          "bundleID": "light-tree"
+        },
+        {
+          "tx": 9,
+          "ty": 2,
+          "bundleID": "light-tree"
+        },
+        {
+          "tx": 5,
+          "ty": 5,
+          "tileId": "potOfFlowers"
+        },
+        {
+          "tx": 6,
+          "ty": 5,
+          "tileId": "potOfFlowers"
+        },
+        {
+          "tx": 7,
+          "ty": 5,
+          "tileId": "potOfFlowers"
+        },
+        {
+          "tx": 4,
+          "ty": 6,
+          "tileId": "cropRose"
+        },
+        {
+          "tx": 8,
+          "ty": 6,
+          "tileId": "cropRose"
+        },
+        {
+          "tx": 1,
+          "ty": 6,
+          "tileId": "emptyPotOfFlowers"
+        },
+        {
+          "tx": 10,
+          "ty": 6,
+          "tileId": "emptyPotOfFlowers"
+        },
+        {
+          "tx": 3,
+          "ty": 7,
+          "tileId": "flowerPotLeft"
+        },
+        {
+          "tx": 9,
+          "ty": 7,
+          "tileId": "flowerPotRight"
+        },
+        {
+          "tx": 5,
+          "ty": 7,
+          "tileId": "fullBucket"
+        }
+      ],
+      "exits": []
+    },
+    "stables": {
+      "name": "The Royal Stables",
+      "width": 12,
+      "height": 9,
+      "floorTileId": "woodFloor",
+      "wallTileId": "woodWall",
+      "decor": [
+        {
+          "tx": 2,
+          "ty": 2,
+          "tileId": "hayStack"
+        },
+        {
+          "tx": 9,
+          "ty": 2,
+          "tileId": "hayStack"
+        },
+        {
+          "tx": 5,
+          "ty": 2,
+          "tileId": "hayStack"
+        },
+        {
+          "tx": 1,
+          "ty": 6,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 3,
+          "ty": 6,
+          "tileId": "fullBucket"
+        },
+        {
+          "tx": 10,
+          "ty": 6,
+          "tileId": "logPile"
+        },
+        {
+          "tx": 6,
+          "ty": 6,
+          "tileId": "choppingBlock"
+        },
+        {
+          "tx": 8,
+          "ty": 6,
+          "tileId": "sack"
+        },
+        {
+          "tx": 11,
+          "ty": 2,
+          "tileId": "emptyBasket"
+        },
+        {
+          "tx": 4,
+          "ty": 7,
+          "tileId": "appleBasket"
+        }
+      ],
+      "exits": []
+    },
+    "servants-quarters": {
+      "name": "The Servants' Hall",
+      "width": 12,
+      "height": 9,
+      "floorTileId": "woodFloor",
+      "wallTileId": "renderedBrick",
+      "musicId": "inn",
+      "ambianceId": "hearth",
+      "decor": [
+        {
+          "tx": 2,
+          "ty": 2,
+          "bundleID": "fireplace"
+        },
+        {
+          "tx": 6,
+          "ty": 2,
+          "bundleID": "simple-bed"
+        },
+        {
+          "tx": 9,
+          "ty": 2,
+          "bundleID": "simple-bed"
+        },
+        {
+          "tx": 5,
+          "ty": 5,
+          "tileId": "roundTable"
+        },
+        {
+          "tx": 4,
+          "ty": 6,
+          "tileId": "stool"
+        },
+        {
+          "tx": 6,
+          "ty": 6,
+          "tileId": "stool"
+        },
+        {
+          "tx": 1,
+          "ty": 6,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 10,
+          "ty": 6,
+          "tileId": "pileOfSacks"
+        },
+        {
+          "tx": 5,
+          "ty": 4,
+          "tileId": "mugOfCoffee"
+        },
+        {
+          "tx": 11,
+          "ty": 5,
+          "tileId": "potOfFlowers"
+        }
+      ],
+      "exits": []
+    },
+    "gatehouse": {
+      "name": "The Guard Room",
+      "width": 11,
+      "height": 8,
+      "floorTileId": "stoneFloor",
+      "wallTileId": "castleStone",
+      "decor": [
+        {
+          "tx": 2,
+          "ty": 2,
+          "bundleID": "suit-of-armour"
+        },
+        {
+          "tx": 8,
+          "ty": 2,
+          "bundleID": "suit-of-armour"
+        },
+        {
+          "tx": 4,
+          "ty": -1,
+          "tileId": "swordMountedLeft"
+        },
+        {
+          "tx": 5,
+          "ty": -1,
+          "tileId": "swordMountedRight"
+        },
+        {
+          "tx": 6,
+          "ty": -1,
+          "tileId": "shieldMounted"
+        },
+        {
+          "tx": 1,
+          "ty": 5,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 9,
+          "ty": 5,
+          "tileId": "crate"
+        },
+        {
+          "tx": 3,
+          "ty": 5,
+          "tileId": "roundTable"
+        },
+        {
+          "tx": 3,
+          "ty": 4,
+          "tileId": "playingCard"
+        },
+        {
+          "tx": 1,
+          "ty": 3,
+          "tileId": "wallTorch"
+        },
+        {
+          "tx": 9,
+          "ty": 3,
+          "tileId": "wallTorch"
+        },
+        {
+          "tx": 7,
+          "ty": 5,
+          "tileId": "wantedPosterBottom"
+        },
+        {
+          "tx": 7,
+          "ty": 4,
+          "tileId": "wantedPosterTop"
+        }
+      ],
+      "exits": []
+    },
+    "armory": {
+      "name": "The Royal Armory",
+      "width": 12,
+      "height": 9,
+      "floorTileId": "stoneFloor",
+      "wallTileId": "castleStone",
+      "decor": [
+        {
+          "tx": 1,
+          "ty": 2,
+          "bundleID": "suit-of-armour"
+        },
+        {
+          "tx": 4,
+          "ty": 2,
+          "bundleID": "suit-of-armour"
+        },
+        {
+          "tx": 7,
+          "ty": 2,
+          "bundleID": "suit-of-armour"
+        },
+        {
+          "tx": 10,
+          "ty": 2,
+          "bundleID": "suit-of-armour"
+        },
+        {
+          "tx": 3,
+          "ty": -1,
+          "tileId": "swordMountedLeft"
+        },
+        {
+          "tx": 4,
+          "ty": -1,
+          "tileId": "swordMountedRight"
+        },
+        {
+          "tx": 7,
+          "ty": -1,
+          "tileId": "rapierMountedLeft"
+        },
+        {
+          "tx": 8,
+          "ty": -1,
+          "tileId": "rapierMountedRight"
+        },
+        {
+          "tx": 5,
+          "ty": -1,
+          "tileId": "shieldMounted"
+        },
+        {
+          "tx": 6,
+          "ty": -1,
+          "tileId": "helmetTop"
+        },
+        {
+          "tx": 2,
+          "ty": 6,
+          "tileId": "roundShieldFloor"
+        },
+        {
+          "tx": 9,
+          "ty": 6,
+          "tileId": "axe"
+        },
+        {
+          "tx": 5,
+          "ty": 6,
+          "tileId": "sword"
+        },
+        {
+          "tx": 11,
+          "ty": 6,
+          "tileId": "crate"
+        },
+        {
+          "tx": 1,
+          "ty": 6,
+          "tileId": "barrel"
+        }
+      ],
+      "exits": []
+    },
+    "royal-kitchens": {
+      "name": "The Royal Kitchens",
+      "width": 12,
+      "height": 9,
+      "floorTileId": "stoneFloor",
+      "wallTileId": "renderedBrick",
+      "decor": [
+        {
+          "tx": 2,
+          "ty": 2,
+          "tileId": "counterTopHorizontalLeft"
+        },
+        {
+          "tx": 3,
+          "ty": 2,
+          "tileId": "counterTopHorizontalMiddle"
+        },
+        {
+          "tx": 4,
+          "ty": 2,
+          "tileId": "counterTopHorizontalMiddle"
+        },
+        {
+          "tx": 5,
+          "ty": 2,
+          "tileId": "counterTopHorizontalRight"
+        },
+        {
+          "tx": 8,
+          "ty": 2,
+          "tileId": "cauldren"
+        },
+        {
+          "tx": 2,
+          "ty": 1,
+          "tileId": "eggs"
+        },
+        {
+          "tx": 4,
+          "ty": 1,
+          "tileId": "steak"
+        },
+        {
+          "tx": 5,
+          "ty": 1,
+          "tileId": "garlic"
+        },
+        {
+          "tx": 10,
+          "ty": 5,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 1,
+          "ty": 6,
+          "tileId": "sack"
+        },
+        {
+          "tx": 3,
+          "ty": 6,
+          "tileId": "appleBasket"
+        },
+        {
+          "tx": 6,
+          "ty": 6,
+          "tileId": "mushroomBasket"
+        },
+        {
+          "tx": 9,
+          "ty": 6,
+          "tileId": "pileOfSacks"
+        },
+        {
+          "tx": 7,
+          "ty": 5,
+          "tileId": "plateEmpty"
+        },
+        {
+          "tx": 11,
+          "ty": 5,
+          "tileId": "teapot"
+        },
+        {
+          "tx": 8,
+          "ty": 5,
+          "tileId": "trayOfDrinks"
+        }
+      ],
+      "exits": []
     }
   },
+  "interactables": [
+    {
+      "id": "court-notice-board",
+      "tx": 18,
+      "ty": 31,
+      "hitRect": {
+        "w": 2,
+        "h": 2
+      },
+      "reactions": [
+        {
+          "type": "dialogue",
+          "speakerName": "Court Notices",
+          "text": [
+            "ROYAL PROCLAMATION: All subjects are reminded that the gardens are for strolling, not stampeding.",
+            "LOST: One ceremonial pendant, one jubilee gift, one vault key. Reward offered by the Steward.",
+            "NOTICE: The Princess's cat Kipper remains at Millhaven. Updates to follow."
+          ]
+        }
+      ]
+    }
+  ],
+  "chickenZones": [
+    {
+      "rect": [
+        25,
+        24,
+        27,
+        25
+      ],
+      "count": 3,
+      "roost": [
+        26,
+        24
+      ]
+    }
+  ],
   "lockedDoors": [],
-  "animals": [],
-  "pondTiles": [],
+  "animals": [
+    {
+      "id": "royal-hound",
+      "type": "dog",
+      "variant": "brown",
+      "tx": 14,
+      "ty": 30,
+      "name": "Baron",
+      "dialogue": [
+        "*woof!*",
+        "The royal hound thumps his tail against the flagstones."
+      ],
+      "roam": true
+    },
+    {
+      "id": "garden-cat",
+      "type": "cat",
+      "variant": "grey",
+      "tx": 8,
+      "ty": 22,
+      "name": "Smoke",
+      "dialogue": [
+        "*mrrp?*",
+        "A palace cat regards you with regal indifference."
+      ],
+      "roam": true
+    }
+  ],
+  "pondTiles": [
+    {
+      "rect": [
+        9,
+        23,
+        10,
+        24
+      ]
+    }
+  ],
   "treasures": []
 }

--- a/web/src/data/hub/royalpalace/questDefs.json
+++ b/web/src/data/hub/royalpalace/questDefs.json
@@ -3,12 +3,12 @@
     {
       "id": "palace-lost-regalia",
       "title": "The Lost Regalia",
-      "type": "fetch",
+      "type": "lost-items",
       "giverNpcId": "royal-steward",
       "receiverNpcId": "royal-steward",
-      "offerDialogue": "The coronation regalia has been scattered across the gardens — the ceremonial pendant, the jubilee gift, and the vault key. The next royal audience is in mere hours. Recover all three and you will have the palace's eternal, slightly flustered gratitude.",
-      "activeDialogue": "The pendant, the gift, and the key — somewhere in the gardens. Do hurry, but mind the flowerbeds.",
-      "completeDialogue": "The pendant! The gift! The key! All accounted for. The audience is saved, and so am I. The crown rewards competence — here, with my compliments.",
+      "offerDialogue": "The coronation regalia has been scattered across the grounds \u2014 the ceremonial pendant, the jubilee gift, and the vault key. The next royal audience is in mere hours. Recover all three and you will have the palace's eternal, slightly flustered gratitude.",
+      "activeDialogue": "The pendant, the gift, and the key \u2014 somewhere out on the grounds. Do hurry, but mind the flowerbeds.",
+      "completeDialogue": "The pendant! The gift! The key! All accounted for. The audience is saved, and so am I. The crown rewards competence \u2014 here, with my compliments.",
       "steps": [
         {
           "key": "regalia",
@@ -26,7 +26,7 @@
         "collectible": {
           "id": "royal-seal",
           "name": "Royal Seal",
-          "icon": "👑",
+          "icon": "\ud83d\udc51",
           "desc": "A wax seal bearing the crown's sigil, given for service to the palace."
         }
       }
@@ -37,9 +37,9 @@
       "type": "fetch",
       "giverNpcId": "royal-steward",
       "receiverNpcId": "kipper",
-      "offerDialogue": "Oh, thank goodness — a capable face. The Princess is inconsolable. Her darling cat, Kipper, was sent down to Millhaven for the sea air, and word comes back that he does nothing but wail, day and night. She cannot eat nor sleep for worry. Please — travel to Millhaven, find Kipper, and discover what ails the poor creature.",
+      "offerDialogue": "Oh, thank goodness \u2014 a capable face. The Princess is inconsolable. Her darling cat, Kipper, was sent down to Millhaven for the sea air, and word comes back that he does nothing but wail, day and night. She cannot eat nor sleep for worry. Please \u2014 travel to Millhaven, find Kipper, and discover what ails the poor creature.",
       "activeDialogue": "Kipper is in Millhaven, down by the waterfront last we heard. Find him, I beg you.",
-      "completeDialogue": "Kipper is curled on the dockside, crying at the grey waves. He looks up at you, wails twice as loud, and presses his face into your hand — something is dreadfully wrong, but for the life of you, you cannot tell what. Perhaps the locals know what ails him.",
+      "completeDialogue": "Kipper is curled on the dockside, crying at the grey waves. He looks up at you, wails twice as loud, and presses his face into your hand \u2014 something is dreadfully wrong, but for the life of you, you cannot tell what. Perhaps the locals know what ails him.",
       "steps": [
         {
           "key": "find",
@@ -50,7 +50,9 @@
       ],
       "reward": {
         "crystals": 30,
-        "friendship": { "royal-steward": 10 }
+        "friendship": {
+          "royal-steward": 10
+        }
       }
     },
     {
@@ -60,8 +62,8 @@
       "giverNpcId": "royal-steward",
       "receiverNpcId": "royal-steward",
       "prerequisite": "quest:kipper-true-wish",
-      "offerDialogue": "You have returned! And the news? ...Kipper hated FISH? All this time? The Princess gave him nothing but the finest kippers because she believed he adored them — oh, the poor darling. Carry the truth up to her, and the crown's gratitude with it.",
-      "activeDialogue": "Carry the good news up to the Princess — Kipper is happy at last.",
+      "offerDialogue": "You have returned! And the news? ...Kipper hated FISH? All this time? The Princess gave him nothing but the finest kippers because she believed he adored them \u2014 oh, the poor darling. Carry the truth up to her, and the crown's gratitude with it.",
+      "activeDialogue": "Carry the good news up to the Princess \u2014 Kipper is happy at last.",
       "completeDialogue": "The Princess is overjoyed. Kipper purrs in her lap as we speak, a feather-toy in his paws and not a fish in sight. You have mended a small heartbreak today, and the crown pays its debts. Well done.",
       "steps": [
         {
@@ -76,35 +78,803 @@
         "collectible": {
           "id": "royal-favour",
           "name": "Royal Favour",
-          "icon": "👑",
+          "icon": "\ud83d\udc51",
           "desc": "The Princess's personal thanks for healing her beloved Kipper."
         },
-        "friendship": { "royal-steward": 25 }
+        "friendship": {
+          "royal-steward": 25
+        }
+      }
+    },
+    {
+      "id": "palace-royal-bloom",
+      "title": "The Royal Bloom",
+      "type": "fetch",
+      "giverNpcId": "royal-gardener",
+      "receiverNpcId": "royal-gardener",
+      "offerDialogue": "I've three prize blooms gone missing from the beds \u2014 slipped their stakes in the night wind, no doubt. Gather them before the slugs do and I'll see you right.",
+      "activeDialogue": "Three rare blooms, somewhere among the gardens. Mind where you tread.",
+      "completeDialogue": "All three, and not a petal bruised! You've a gardener's hands, friend. Take this for your trouble.",
+      "steps": [
+        {
+          "key": "blooms",
+          "type": "collect",
+          "pickupIds": [
+            "bloom-rose",
+            "bloom-white",
+            "bloom-blue"
+          ],
+          "required": 3
+        }
+      ],
+      "reward": {
+        "crystals": 60,
+        "friendship": {
+          "royal-gardener": 15
+        }
+      }
+    },
+    {
+      "id": "palace-orangery-harvest",
+      "title": "Fruits of the Orangery",
+      "type": "fetch",
+      "giverNpcId": "royal-gardener",
+      "receiverNpcId": "royal-gardener",
+      "prerequisite": "quest:palace-royal-bloom",
+      "offerDialogue": "Now I trust your hands \u2014 pop into the orangery and bring me the ripe pots before the frost gets ideas.",
+      "activeDialogue": "Three ripe pots in the orangery, if you'd be so kind.",
+      "completeDialogue": "Lovely, lovely. The Queen will have her winter blooms after all. Here \u2014 you've earned it.",
+      "steps": [
+        {
+          "key": "fruits",
+          "type": "collect",
+          "pickupIds": [
+            "orangery-pot-1",
+            "orangery-pot-2",
+            "orangery-pot-3"
+          ],
+          "required": 3
+        }
+      ],
+      "reward": {
+        "crystals": 75,
+        "friendship": {
+          "royal-gardener": 20
+        }
+      }
+    },
+    {
+      "id": "palace-kitchen-feast",
+      "title": "A Feast for the Court",
+      "type": "fetch",
+      "giverNpcId": "royal-cook",
+      "receiverNpcId": "royal-cook",
+      "offerDialogue": "A state banquet tonight and my larder's half empty! Eggs, a good cut of steak, and garlic \u2014 fetch them quick, before the cauldron and I both boil over.",
+      "activeDialogue": "Eggs, steak, garlic. Run, run! The court does not wait for a slow cook.",
+      "completeDialogue": "Bless you! The banquet is saved and the King shall not go hungry \u2014 a fate worse than dragons, that. Here, a little something from a grateful kitchen.",
+      "steps": [
+        {
+          "key": "ingredients",
+          "type": "collect",
+          "pickupIds": [
+            "feast-eggs",
+            "feast-steak",
+            "feast-garlic"
+          ],
+          "required": 3
+        }
+      ],
+      "reward": {
+        "crystals": 70,
+        "friendship": {
+          "royal-cook": 15
+        }
+      }
+    },
+    {
+      "id": "palace-runaway-pony",
+      "title": "The Runaway Pony",
+      "type": "lost-items",
+      "giverNpcId": "stable-master",
+      "receiverNpcId": "stable-master",
+      "offerDialogue": "One of the ponies slipped its tack and scattered the gear clean across the grounds. Round up the feed sack, the bucket, and the loose harness before the Master of Horse hears of it.",
+      "activeDialogue": "Feed sack, water bucket, harness \u2014 somewhere out on the grounds. Off you go.",
+      "completeDialogue": "All back, and the pony none the wiser. You've saved my hide and my post. Here, with my thanks.",
+      "steps": [
+        {
+          "key": "tack",
+          "type": "collect",
+          "pickupIds": [
+            "tack-sack",
+            "tack-bucket",
+            "tack-harness"
+          ],
+          "required": 3
+        }
+      ],
+      "reward": {
+        "crystals": 55,
+        "friendship": {
+          "stable-master": 15
+        }
+      }
+    },
+    {
+      "id": "palace-chapel-candles",
+      "title": "Candles for the Chapel",
+      "type": "fetch",
+      "giverNpcId": "chaplain",
+      "receiverNpcId": "chaplain",
+      "offerDialogue": "Our candles have wandered again \u2014 three of them, off to who-knows-where. A chapel without light is only a cold stone room. Would you gather them back?",
+      "activeDialogue": "Three candlesticks, lost about the grounds and the crypt. Bring them to the altar.",
+      "completeDialogue": "Light returns to the nave. Bless you, traveller \u2014 the kings below sleep easier for it. Take this small grace.",
+      "steps": [
+        {
+          "key": "candles",
+          "type": "collect",
+          "pickupIds": [
+            "candle-1",
+            "candle-2",
+            "candle-3"
+          ],
+          "required": 3
+        }
+      ],
+      "reward": {
+        "crystals": 65,
+        "collectible": {
+          "id": "blessed-candle",
+          "name": "Blessed Candle",
+          "icon": "\ud83d\udd6f\ufe0f",
+          "desc": "A consecrated candle from the Royal Chapel."
+        }
+      }
+    },
+    {
+      "id": "palace-vault-audit",
+      "title": "The Treasury Audit",
+      "type": "fetch",
+      "giverNpcId": "treasurer",
+      "receiverNpcId": "treasurer",
+      "offerDialogue": "The ledgers won't balance and three tally-rolls have gone astray. Find them \u2014 the inner vault stays sealed until the count is true.",
+      "activeDialogue": "Three tally-rolls, scattered between the treasury and the court. The ledgers await.",
+      "completeDialogue": "The count is true at last! The inner vault is yours to enter. Mind what glitters \u2014 it is all spoken for.",
+      "steps": [
+        {
+          "key": "tallies",
+          "type": "collect",
+          "pickupIds": [
+            "tally-1",
+            "tally-2",
+            "tally-3"
+          ],
+          "required": 3
+        }
+      ],
+      "reward": {
+        "crystals": 100,
+        "friendship": {
+          "treasurer": 20
+        }
+      }
+    },
+    {
+      "id": "palace-court-intrigue-1",
+      "title": "A Discreet Errand",
+      "type": "fetch",
+      "giverNpcId": "lady-penrose",
+      "receiverNpcId": "king",
+      "offerDialogue": "A sealed letter, and a hand discreet enough to carry it. Take this to the King \u2014 to his hand only, mind, and not a word to the Steward.",
+      "activeDialogue": "Carry Lady Penrose's sealed letter to the King in the Throne Hall.",
+      "completeDialogue": "Ah \u2014 Penrose's seal. I wondered when she'd make her move. You did well to bring this straight to me. Wait here; there will be a reply.",
+      "steps": [
+        {
+          "key": "carry",
+          "type": "deliver",
+          "targetNpcId": "king",
+          "required": 1
+        }
+      ],
+      "reward": {
+        "crystals": 40,
+        "friendship": {
+          "lady-penrose": 10
+        }
+      }
+    },
+    {
+      "id": "palace-court-intrigue-2",
+      "title": "The King's Reply",
+      "type": "fetch",
+      "giverNpcId": "king",
+      "receiverNpcId": "lady-penrose",
+      "prerequisite": "quest:palace-court-intrigue-1",
+      "offerDialogue": "Carry my answer back to the Lady Penrose. Tell her the crown is not so easily steered \u2014 but that I admire the attempt.",
+      "activeDialogue": "Take the King's reply back to Lady Penrose in the Guest Hall.",
+      "completeDialogue": "He said THAT? ...Hah. Bold old goat. Very well \u2014 the game continues another day. You've played your part beautifully. Take this.",
+      "steps": [
+        {
+          "key": "reply",
+          "type": "deliver",
+          "targetNpcId": "lady-penrose",
+          "required": 1
+        }
+      ],
+      "reward": {
+        "crystals": 50,
+        "friendship": {
+          "king": 10,
+          "lady-penrose": 10
+        }
+      }
+    },
+    {
+      "id": "palace-court-intrigue-3",
+      "title": "A Matter Settled",
+      "type": "fetch",
+      "giverNpcId": "lady-penrose",
+      "receiverNpcId": "lady-penrose",
+      "prerequisite": "quest:palace-court-intrigue-2",
+      "offerDialogue": "One last thing. There is a letter of mine I'd rather the court never read \u2014 I dropped it in my flurry. Find it in the gardens and bring it to me, and we are square.",
+      "activeDialogue": "Recover Lady Penrose's stray letter from the gardens.",
+      "completeDialogue": "Burned, the moment it touches my hand. You are precisely the sort of friend a Lady needs at court. Consider yourself owed.",
+      "steps": [
+        {
+          "key": "letter",
+          "type": "collect",
+          "pickupIds": [
+            "penrose-letter"
+          ],
+          "required": 1
+        }
+      ],
+      "reward": {
+        "crystals": 80,
+        "relationship": {
+          "lady-penrose": {
+            "track": "ally",
+            "points": 15
+          }
+        }
+      }
+    },
+    {
+      "id": "palace-princess-gift",
+      "title": "A Gift for the Princess",
+      "type": "fetch",
+      "giverNpcId": "princess",
+      "receiverNpcId": "princess",
+      "offerDialogue": "I left my favourite doll somewhere in the West Solar and now I cannot find it anywhere. Would you look for me? I should be ever so grateful.",
+      "activeDialogue": "The Princess's doll is lost somewhere in the palace's West Solar.",
+      "completeDialogue": "You found her! Oh, thank you, thank you. You are the kindest soul to visit this gloomy palace in an age. Here \u2014 a token of my thanks.",
+      "steps": [
+        {
+          "key": "doll",
+          "type": "collect",
+          "pickupIds": [
+            "princess-doll"
+          ],
+          "required": 1
+        }
+      ],
+      "reward": {
+        "crystals": 45,
+        "friendship": {
+          "princess": 15
+        }
+      }
+    },
+    {
+      "id": "palace-kipper-homecoming",
+      "title": "Kipper Comes Home",
+      "type": "fetch",
+      "giverNpcId": "princess",
+      "receiverNpcId": "princess",
+      "prerequisite": "quest:palace-happy-cat",
+      "offerDialogue": "Kipper is coming home at last! But the journey is long and he frightens so easily. Help me ready a welcome \u2014 his favourite cushion and a feather-toy \u2014 and he shall never want for comfort again.",
+      "activeDialogue": "Gather Kipper's cushion and his feather-toy for the homecoming.",
+      "completeDialogue": "He's home. He's HOME \u2014 curled on his cushion, batting his feather, purring like a kettle. The whole palace feels lighter. You gave me back my dearest friend. The crown will not forget it.",
+      "steps": [
+        {
+          "key": "comforts",
+          "type": "collect",
+          "pickupIds": [
+            "kipper-cushion",
+            "kipper-feather"
+          ],
+          "required": 2
+        }
+      ],
+      "reward": {
+        "crystals": 150,
+        "collectible": {
+          "id": "kippers-collar",
+          "name": "Kipper's Spare Collar",
+          "icon": "\ud83d\udc31",
+          "desc": "A tiny bell-collar, given in thanks for bringing Kipper home."
+        },
+        "friendship": {
+          "princess": 30
+        }
+      }
+    },
+    {
+      "id": "palace-lost-keys",
+      "title": "The Steward's Keys",
+      "type": "lost-items",
+      "giverNpcId": "royal-steward",
+      "receiverNpcId": "royal-steward",
+      "offerDialogue": "My ring of keys \u2014 burst its loop and scattered three across the grounds! I cannot lock so much as a broom cupboard until they're found.",
+      "activeDialogue": "Three keys, lost somewhere about the palace grounds.",
+      "completeDialogue": "All three, back on the ring where they belong. You've spared me a most undignified scramble. Here \u2014 well earned.",
+      "steps": [
+        {
+          "key": "keys",
+          "type": "collect",
+          "pickupIds": [
+            "steward-key-1",
+            "steward-key-2",
+            "steward-key-3"
+          ],
+          "required": 3
+        }
+      ],
+      "reward": {
+        "crystals": 60,
+        "friendship": {
+          "royal-steward": 15
+        }
+      }
+    },
+    {
+      "id": "palace-herald-proclamation",
+      "title": "The Royal Proclamation",
+      "type": "lost-items",
+      "giverNpcId": "royal-herald",
+      "receiverNpcId": "royal-herald",
+      "offerDialogue": "The morning's proclamations blew clean off my lectern \u2014 three scrolls, gone with the wind. A herald with no words is merely a man shouting. Fetch them, would you?",
+      "activeDialogue": "Three proclamation scrolls, scattered by the wind across the grounds.",
+      "completeDialogue": "Restored, every word! Now the realm may once again be told what it already suspected. My thanks, crier's-friend.",
+      "steps": [
+        {
+          "key": "scrolls",
+          "type": "collect",
+          "pickupIds": [
+            "proclaim-1",
+            "proclaim-2",
+            "proclaim-3"
+          ],
+          "required": 3
+        }
+      ],
+      "reward": {
+        "crystals": 55,
+        "friendship": {
+          "royal-herald": 15
+        }
+      }
+    },
+    {
+      "id": "palace-guard-watch",
+      "title": "The Night Watch",
+      "type": "fetch",
+      "giverNpcId": "palace-guard",
+      "receiverNpcId": "palace-guard",
+      "offerDialogue": "Some fool of a recruit left the watch-kit lying about \u2014 a sword, a shield, a helm. If the Captain finds them strewn across the court, it's my neck. Gather them up, quietly.",
+      "activeDialogue": "A sword, a shield, and a helm, left about the grounds. Gather them before the Captain's round.",
+      "completeDialogue": "All present and correct. You've a soldier's eye, friend. Here \u2014 don't tell the quartermaster where it came from.",
+      "steps": [
+        {
+          "key": "kit",
+          "type": "collect",
+          "pickupIds": [
+            "watch-sword",
+            "watch-shield",
+            "watch-helm"
+          ],
+          "required": 3
+        }
+      ],
+      "reward": {
+        "crystals": 65,
+        "friendship": {
+          "palace-guard": 15
+        }
+      }
+    },
+    {
+      "id": "palace-queen-roses",
+      "title": "The Queen's Roses",
+      "type": "fetch",
+      "giverNpcId": "queen",
+      "receiverNpcId": "queen",
+      "offerDialogue": "The garden's finest roses bloomed overnight and I would have them for the high table before they fade. Three perfect blooms \u2014 gather them gently, for me.",
+      "activeDialogue": "Three perfect roses, blooming somewhere in the gardens.",
+      "completeDialogue": "Exquisite. Not a thorn out of place. The court shall dine beneath them tonight. You have a gentle touch \u2014 the crown notices such things.",
+      "steps": [
+        {
+          "key": "roses",
+          "type": "collect",
+          "pickupIds": [
+            "queen-rose-1",
+            "queen-rose-2",
+            "queen-rose-3"
+          ],
+          "required": 3
+        }
+      ],
+      "reward": {
+        "crystals": 85,
+        "collectible": {
+          "id": "queens-rose",
+          "name": "The Queen's Rose",
+          "icon": "\ud83c\udf39",
+          "desc": "A perfect bloom from the Royal Gardens, gifted by the Queen herself."
+        },
+        "friendship": {
+          "queen": 20
+        }
       }
     }
   ],
   "pickupItems": [
     {
       "id": "regalia-pendant",
-      "tx": 5,
-      "ty": 19,
+      "tx": 6,
+      "ty": 21,
       "tileId": "pendant",
       "questId": "palace-lost-regalia"
     },
     {
       "id": "regalia-gift",
-      "tx": 21,
-      "ty": 19,
+      "tx": 20,
+      "ty": 22,
       "tileId": "gift",
       "questId": "palace-lost-regalia"
     },
     {
       "id": "regalia-key",
-      "tx": 24,
-      "ty": 16,
+      "tx": 30,
+      "ty": 31,
       "tileId": "key",
       "questId": "palace-lost-regalia"
+    },
+    {
+      "id": "bloom-rose",
+      "tx": 19,
+      "ty": 19,
+      "tileId": "cropRose",
+      "questId": "palace-royal-bloom"
+    },
+    {
+      "id": "bloom-white",
+      "tx": 7,
+      "ty": 24,
+      "tileId": "whiteFlower",
+      "questId": "palace-royal-bloom"
+    },
+    {
+      "id": "bloom-blue",
+      "tx": 17,
+      "ty": 24,
+      "tileId": "blueFlower",
+      "questId": "palace-royal-bloom"
+    },
+    {
+      "id": "orangery-pot-1",
+      "tx": 5,
+      "ty": 5,
+      "tileId": "potOfFlowers",
+      "questId": "palace-orangery-harvest",
+      "building": "orangery"
+    },
+    {
+      "id": "orangery-pot-2",
+      "tx": 7,
+      "ty": 5,
+      "tileId": "potOfFlowers",
+      "questId": "palace-orangery-harvest",
+      "building": "orangery"
+    },
+    {
+      "id": "orangery-pot-3",
+      "tx": 4,
+      "ty": 6,
+      "tileId": "cropRose",
+      "questId": "palace-orangery-harvest",
+      "building": "orangery"
+    },
+    {
+      "id": "feast-eggs",
+      "tx": 2,
+      "ty": 6,
+      "tileId": "eggs",
+      "questId": "palace-kitchen-feast",
+      "building": "royal-kitchens"
+    },
+    {
+      "id": "feast-steak",
+      "tx": 10,
+      "ty": 30,
+      "tileId": "steak",
+      "questId": "palace-kitchen-feast"
+    },
+    {
+      "id": "feast-garlic",
+      "tx": 6,
+      "ty": 6,
+      "tileId": "garlic",
+      "questId": "palace-kitchen-feast",
+      "building": "royal-kitchens"
+    },
+    {
+      "id": "tack-sack",
+      "tx": 16,
+      "ty": 24,
+      "tileId": "sack",
+      "questId": "palace-runaway-pony"
+    },
+    {
+      "id": "tack-bucket",
+      "tx": 9,
+      "ty": 30,
+      "tileId": "fullBucket",
+      "questId": "palace-runaway-pony"
+    },
+    {
+      "id": "tack-harness",
+      "tx": 24,
+      "ty": 30,
+      "tileId": "smallSack",
+      "questId": "palace-runaway-pony"
+    },
+    {
+      "id": "candle-1",
+      "tx": 3,
+      "ty": 5,
+      "tileId": "candlestickUnlit",
+      "questId": "palace-chapel-candles",
+      "building": "royal-chapel-crypt"
+    },
+    {
+      "id": "candle-2",
+      "tx": 28,
+      "ty": 25,
+      "tileId": "candlestickUnlit",
+      "questId": "palace-chapel-candles"
+    },
+    {
+      "id": "candle-3",
+      "tx": 6,
+      "ty": 22,
+      "tileId": "candlestickUnlit",
+      "questId": "palace-chapel-candles"
+    },
+    {
+      "id": "tally-1",
+      "tx": 6,
+      "ty": 4,
+      "tileId": "rolledMap",
+      "questId": "palace-vault-audit",
+      "building": "treasury-vault"
+    },
+    {
+      "id": "tally-2",
+      "tx": 19,
+      "ty": 31,
+      "tileId": "note",
+      "questId": "palace-vault-audit"
+    },
+    {
+      "id": "tally-3",
+      "tx": 33,
+      "ty": 30,
+      "tileId": "pileOfPapers",
+      "questId": "palace-vault-audit"
+    },
+    {
+      "id": "penrose-letter",
+      "tx": 11,
+      "ty": 22,
+      "tileId": "letter",
+      "questId": "palace-court-intrigue-3"
+    },
+    {
+      "id": "princess-doll",
+      "tx": 8,
+      "ty": 6,
+      "tileId": "doll",
+      "questId": "palace-princess-gift",
+      "building": "palace-1"
+    },
+    {
+      "id": "kipper-cushion",
+      "tx": 7,
+      "ty": 1,
+      "tileId": "crownOfCushon",
+      "questId": "palace-kipper-homecoming",
+      "building": "palace-1"
+    },
+    {
+      "id": "kipper-feather",
+      "tx": 16,
+      "ty": 22,
+      "tileId": "feather",
+      "questId": "palace-kipper-homecoming"
+    },
+    {
+      "id": "steward-key-1",
+      "tx": 21,
+      "ty": 24,
+      "tileId": "key",
+      "questId": "palace-lost-keys"
+    },
+    {
+      "id": "steward-key-2",
+      "tx": 10,
+      "ty": 33,
+      "tileId": "oldeKey",
+      "questId": "palace-lost-keys"
+    },
+    {
+      "id": "steward-key-3",
+      "tx": 38,
+      "ty": 25,
+      "tileId": "key",
+      "questId": "palace-lost-keys"
+    },
+    {
+      "id": "proclaim-1",
+      "tx": 12,
+      "ty": 22,
+      "tileId": "rolledMap",
+      "questId": "palace-herald-proclamation"
+    },
+    {
+      "id": "proclaim-2",
+      "tx": 24,
+      "ty": 31,
+      "tileId": "note",
+      "questId": "palace-herald-proclamation"
+    },
+    {
+      "id": "proclaim-3",
+      "tx": 33,
+      "ty": 31,
+      "tileId": "letter",
+      "questId": "palace-herald-proclamation"
+    },
+    {
+      "id": "watch-sword",
+      "tx": 5,
+      "ty": 6,
+      "tileId": "sword",
+      "questId": "palace-guard-watch",
+      "building": "armory"
+    },
+    {
+      "id": "watch-shield",
+      "tx": 9,
+      "ty": 6,
+      "tileId": "roundShieldFloor",
+      "questId": "palace-guard-watch",
+      "building": "armory"
+    },
+    {
+      "id": "watch-helm",
+      "tx": 20,
+      "ty": 31,
+      "tileId": "helmetTop",
+      "questId": "palace-guard-watch"
+    },
+    {
+      "id": "queen-rose-1",
+      "tx": 6,
+      "ty": 19,
+      "tileId": "cropRose",
+      "questId": "palace-queen-roses"
+    },
+    {
+      "id": "queen-rose-2",
+      "tx": 9,
+      "ty": 19,
+      "tileId": "cropRose",
+      "questId": "palace-queen-roses"
+    },
+    {
+      "id": "queen-rose-3",
+      "tx": 16,
+      "ty": 19,
+      "tileId": "cropRose",
+      "questId": "palace-queen-roses"
     }
   ],
-  "blockedPaths": []
+  "blockedPaths": [],
+  "dialogues": [
+    {
+      "id": "penrose-chat",
+      "npcId": "lady-penrose",
+      "start": "greet",
+      "nodes": {
+        "greet": {
+          "text": "Well now. A new face at court \u2014 how refreshingly unspoiled. Tell me, are you the helpful sort, or merely the curious sort?",
+          "choices": [
+            {
+              "label": "The helpful sort.",
+              "next": "errand"
+            },
+            {
+              "label": "What is court like?",
+              "next": "lore"
+            },
+            {
+              "label": "I keep my own counsel.",
+              "effects": [
+                {
+                  "type": "relationship",
+                  "npcId": "lady-penrose",
+                  "track": "rival",
+                  "points": 4
+                }
+              ],
+              "next": "wary"
+            }
+          ]
+        },
+        "lore": {
+          "text": "Court is a garden, dear \u2014 every smile a seed, and not all of them bloom kindly. Tend the right friendships and you may yet flourish here.",
+          "choices": [
+            {
+              "label": "I'll remember that.",
+              "effects": [
+                {
+                  "type": "friendship",
+                  "npcId": "lady-penrose",
+                  "xp": 5
+                },
+                {
+                  "type": "end"
+                }
+              ]
+            }
+          ]
+        },
+        "errand": {
+          "text": "Then we shall get along famously. I have a small, discreet matter that wants exactly such a hand. Interested?",
+          "choices": [
+            {
+              "label": "Tell me more.",
+              "effects": [
+                {
+                  "type": "quest",
+                  "questId": "palace-court-intrigue-1"
+                }
+              ]
+            },
+            {
+              "label": "Perhaps later.",
+              "effects": [
+                {
+                  "type": "end"
+                }
+              ]
+            }
+          ]
+        },
+        "wary": {
+          "text": "Discretion. My favourite virtue, even in a rival. We shall watch each other carefully, you and I.",
+          "choices": [
+            {
+              "label": "As you wish.",
+              "effects": [
+                {
+                  "type": "end"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ]
 }


### PR DESCRIPTION
Expands the **Royal Palace** from a single keep into a full palace estate, bringing it up to **Tier B** per the epic (#1732) and following the Dreadspire/Ravenwatch patterns. Closes #1739.

## Map & buildings
- Enlarged the map to **44×38 tiles** (1408×1216) to give the grounds room.
- **11 furnished buildings**: the multi-room palace + guest wing, royal library, royal chapel, treasury/vault, orangery, stables, servants' quarters, gatehouse, armory and royal kitchens.
- All buildings are **≥6 rows tall** (the epic's hard constraint) with ≥1-tile gaps between them.
- **Every building door resolves onto a street tile**, and a BFS over the street network confirms every door + the exit are reachable from the avatar spawn (#1733).

## Interiors (20 rooms)
- The **palace** is the multi-room showcase: Throne Hall ↔ West Solar, Council Chamber, Royal Bedchamber, Vault Stair → Royal Vaults.
- Guest wing, library, chapel and treasury each gain a **second linked room** (guest bedrooms, reading loft, royal crypt, quest-gated inner vault).
- All interior decor is in bounds; back-wall `ty=-1` mounts kept intentionally (#1734). Rooms sized ~10×8–16×10.

## NPCs (12 named + 2 flavour)
- Steward, herald, palace guard, king, queen, princess, courtier (Lady Penrose), treasurer, chaplain, cook, gardener and stable-master — with dialogue, **schedules** and **homeBeds**. Lady Penrose has a branching **dialogue tree** (court-intrigue / relationship steering). The existing goblin & ogre who long to meet the Princess are retained.

## Quests (18)
- Retained **Lost Regalia / The Sick Princess / A Cat's Contentment** and woven them into a **court-intrigue chain**, service errands, lost-item hunts, the **Queen's Roses**, and a cross-town **Kipper-saga capstone** ("Kipper Comes Home") gated on the existing Millhaven/Hollowmere chain (#1735).

## Ambience
- Expanded **Royal Gardens** plus **Outer Court / Servants' Yard / Stable Yard** areas with fountains, statues, hedges, flower beds, lamps and iron fencing; an ornamental pond, a chicken pen, two placed animals, a court notice board, and seasonal weather.

## New sprites
`hub-npc-king`, `hub-npc-queen`, `hub-npc-princess`, `hub-npc-cook`, `hub-npc-gardener`.

## Verification
- `cd web && npm run test` → **198 passed** (the lone error is a missing Playwright browser binary in this environment, unrelated to the data).
- `cd web && npm run build` → tsc + vite **pass**.

Part of epic #1732.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A7Q28HMpUX8wVZRX8Kub79)_