### PR TITLE
Map editor multi-select, draw tools, road↔pond toggle + Bundle editor

### DIFF
--- a/web/.storybook/main.ts
+++ b/web/.storybook/main.ts
@@ -51,6 +51,20 @@ const config: StorybookConfig = {
       }
     }
 
+    const handleBundleSave = (body: string, res: ServerResponse) => {
+      try {
+        const { data } = JSON.parse(body) as { data: unknown }
+        const filePath = resolve(root, 'src/data/bundles/bundles.json')
+        writeFileSync(filePath, JSON.stringify(data, null, 2))
+        res.setHeader('Content-Type', 'application/json')
+        res.end(JSON.stringify({ ok: true }))
+      } catch (e) {
+        res.statusCode = 500
+        res.setHeader('Content-Type', 'application/json')
+        res.end(JSON.stringify({ error: `bundle save failed: ${String(e)}` }))
+      }
+    }
+
     viteConfig.plugins = viteConfig.plugins ?? []
     viteConfig.plugins.unshift({
       name: 'map-editor-save',
@@ -59,6 +73,12 @@ const config: StorybookConfig = {
       configureServer(server) {
         server.middlewares.use(
           (req: IncomingMessage, res: ServerResponse, next: () => void) => {
+            if (req.method === 'POST' && req.url === '/api/bundle-editor/save') {
+              let body = ''
+              req.on('data', (chunk: Buffer) => { body += chunk.toString() })
+              req.on('end', () => handleBundleSave(body, res))
+              return
+            }
             if (req.method !== 'POST' ||
                 (req.url !== '/api/map-editor/save' && req.url !== '/api/map-editor/save-questdefs')) {
               next()

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -4281,6 +4281,324 @@
         }
       }
     },
+    "node_modules/@vitest/browser-playwright/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@vitest/browser-playwright/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@vitest/browser-playwright/node_modules/@oxc-project/types": {
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@vitest/browser-playwright/node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitest/browser-playwright/node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitest/browser-playwright/node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitest/browser-playwright/node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitest/browser-playwright/node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitest/browser-playwright/node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitest/browser-playwright/node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitest/browser-playwright/node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitest/browser-playwright/node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitest/browser-playwright/node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitest/browser-playwright/node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitest/browser-playwright/node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitest/browser-playwright/node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitest/browser-playwright/node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitest/browser-playwright/node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitest/browser-playwright/node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/@vitest/browser-playwright/node_modules/@vitest/mocker": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.3.tgz",
@@ -4328,6 +4646,456 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "node_modules/@vitest/browser-playwright/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/@vitest/browser-playwright/node_modules/rolldown": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@oxc-project/types": "=0.133.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
+      }
+    },
+    "node_modules/@vitest/browser-playwright/node_modules/vite": {
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/browser/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@vitest/browser/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@vitest/browser/node_modules/@oxc-project/types": {
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@vitest/browser/node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitest/browser/node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitest/browser/node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitest/browser/node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitest/browser/node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitest/browser/node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitest/browser/node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitest/browser/node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitest/browser/node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitest/browser/node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitest/browser/node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitest/browser/node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitest/browser/node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitest/browser/node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitest/browser/node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitest/browser/node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/@vitest/browser/node_modules/@vitest/mocker": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.3.tgz",
@@ -4373,6 +5141,138 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/browser/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/@vitest/browser/node_modules/rolldown": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@oxc-project/types": "=0.133.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
+      }
+    },
+    "node_modules/@vitest/browser/node_modules/vite": {
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
       }
     },
     "node_modules/@vitest/coverage-v8": {

--- a/web/src/components/mapEditor/EntityInspector.tsx
+++ b/web/src/components/mapEditor/EntityInspector.tsx
@@ -43,7 +43,7 @@ type Treasure = NonNullable<RawMapConfig['treasures']>[number]
 export type GlowPatch = Partial<{ glow: boolean; glowRadius: number; pulse: boolean }>
 
 interface Props {
-  selectedEntity:   SelectedEntity | null
+  selectedEntities: SelectedEntity[]
   mapId:            MapId
   configData:       RawMapConfig
   activeInteriorId: string | null
@@ -88,6 +88,14 @@ interface Props {
   onResizeMap?:          (dir: 'n' | 's' | 'e' | 'w', grow: boolean) => void
   onUpdateMapProps?:     (patch: { townName?: string; environment?: string }) => void
   onPickLocation?:       (kind: PickKind, index?: number) => void
+  onDeleteEntities?:            (entities: SelectedEntity[]) => void
+  onBatchUpdateZlayer?:         (entities: SelectedEntity[], z: Zlayer) => void
+  onBatchUpdateStreetPathType?: (entities: SelectedEntity[], pathType: string | undefined) => void
+  onConvertStreetToPond?:       (index: number) => void
+  onConvertPondToStreet?:       (index: number) => void
+  onUpdatePondEntry?:           (index: number, data: { rect?: number[]; tile?: number[] }) => void
+  onDeletePondTile?:            (index: number) => void
+  onDeleteNpcSpawnTile?:        (index: number) => void
 }
 
 const BTN_PICK: React.CSSProperties = {
@@ -626,11 +634,12 @@ function QuestItemInspector({
 }
 
 function StreetInspector({
-  entry, onUpdate, onDelete,
+  entry, onUpdate, onDelete, onConvertToPond,
 }: {
   entry: { rect?: number[]; tile?: number[]; pathType?: string }
   onUpdate: (data: { rect?: number[]; tile?: number[]; pathType?: string }) => void
   onDelete: () => void
+  onConvertToPond?: () => void
 }) {
   const r = entry.rect
   const t = entry.tile
@@ -691,6 +700,14 @@ function StreetInspector({
       >
         Delete Street Entry
       </button>
+      {onConvertToPond && (
+        <button
+          onClick={onConvertToPond}
+          style={{ width: '100%', padding: '5px 0', background: '#1a2e3a', border: '1px solid #2a5a6a', color: '#6ad', cursor: 'pointer', borderRadius: 3, fontSize: 11, marginTop: 4 }}
+        >
+          Convert to Pond
+        </button>
+      )}
     </div>
   )
 }
@@ -1786,8 +1803,160 @@ function PondEditor({ configData, onUpdateConfig, numSm, addBtn, xBtn, anchor }:
   )
 }
 
+function MultiSelectPanel({
+  entities, onDelete, onBatchZlayer, onBatchPathType,
+}: {
+  entities: SelectedEntity[]
+  onDelete?: (e: SelectedEntity[]) => void
+  onBatchZlayer?: (e: SelectedEntity[], z: Zlayer) => void
+  onBatchPathType?: (e: SelectedEntity[], pt: string | undefined) => void
+}) {
+  const type = entities[0].type
+  const decorTypes = ['exteriorDecor', 'interiorDecor', 'buildingLevelDecor', 'festivalDecor']
+  const isDecor = decorTypes.includes(type)
+  const isStreet = type === 'street'
+  const [pathType, setPathType] = useState('')
+
+  return (
+    <div style={{ padding: 12 }}>
+      <div style={{ color: '#f0c040', fontWeight: 'bold', marginBottom: 8 }}>
+        {entities.length} {type} selected
+      </div>
+      {isDecor && onBatchZlayer && (
+        <Field label="Z-Layer (all)">
+          <div style={{ display: 'flex', gap: 4 }}>
+            {(['solid', 'below', 'above'] as Zlayer[]).map(z => (
+              <button
+                key={z}
+                onClick={() => onBatchZlayer(entities, z)}
+                style={{
+                  padding: '3px 8px', fontSize: 11, cursor: 'pointer',
+                  background: '#333', color: '#aaa', border: 'none', borderRadius: 3,
+                }}
+              >{z}</button>
+            ))}
+          </div>
+        </Field>
+      )}
+      {isStreet && onBatchPathType && (
+        <Field label="Path Type (all)">
+          <div style={{ display: 'flex', gap: 4 }}>
+            <input
+              value={pathType}
+              onChange={e => setPathType(e.target.value)}
+              placeholder="e.g. cobblestone"
+              style={{ flex: 1, padding: '3px 5px', background: '#111', border: '1px solid #444', color: '#eee', borderRadius: 3, fontSize: 11 }}
+            />
+            <button
+              onClick={() => onBatchPathType(entities, pathType || undefined)}
+              style={{ padding: '3px 7px', background: '#1a3a1a', border: '1px solid #3a6a3a', color: '#8d8', borderRadius: 3, fontSize: 11, cursor: 'pointer' }}
+            >✓</button>
+          </div>
+        </Field>
+      )}
+      {onDelete && (
+        <button
+          onClick={() => onDelete(entities)}
+          style={{ width: '100%', padding: '6px 0', background: '#5a1a1a', border: '1px solid #922', color: '#f88', cursor: 'pointer', borderRadius: 3, fontSize: 12, marginTop: 4 }}
+        >
+          Delete all ({entities.length})
+        </button>
+      )}
+    </div>
+  )
+}
+
+function PondInspector({
+  entry, onUpdate, onDelete, onConvertToStreet,
+}: {
+  entry: { rect?: number[]; tile?: number[] }
+  onUpdate: (data: { rect?: number[]; tile?: number[] }) => void
+  onDelete: () => void
+  onConvertToStreet: () => void
+}) {
+  const r = entry.rect
+  const t = entry.tile
+  return (
+    <div>
+      {r ? (
+        <>
+          <Field label="Top-left">
+            <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+              <label style={{ fontSize: 11, color: '#888' }}>X</label>
+              {numInput(r[0], v => onUpdate({ rect: [v, r[1], r[2], r[3]] }))}
+              <label style={{ fontSize: 11, color: '#888' }}>Y</label>
+              {numInput(r[1], v => onUpdate({ rect: [r[0], v, r[2], r[3]] }))}
+            </div>
+          </Field>
+          <Field label="Bottom-right">
+            <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+              <label style={{ fontSize: 11, color: '#888' }}>X</label>
+              {numInput(r[2], v => onUpdate({ rect: [r[0], r[1], v, r[3]] }))}
+              <label style={{ fontSize: 11, color: '#888' }}>Y</label>
+              {numInput(r[3], v => onUpdate({ rect: [r[0], r[1], r[2], v] }))}
+            </div>
+          </Field>
+          <Field label="Size">
+            <span style={{ fontFamily: 'monospace', fontSize: 11, color: '#666' }}>
+              {r[2]-r[0]+1} × {r[3]-r[1]+1} tiles
+            </span>
+          </Field>
+        </>
+      ) : t ? (
+        <Field label="Position">
+          <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+            <label style={{ fontSize: 11, color: '#888' }}>X</label>
+            {numInput(t[0], v => onUpdate({ tile: [v, t[1]] }))}
+            <label style={{ fontSize: 11, color: '#888' }}>Y</label>
+            {numInput(t[1], v => onUpdate({ tile: [t[0], v] }))}
+          </div>
+        </Field>
+      ) : null}
+      <button
+        onClick={onConvertToStreet}
+        style={{ width: '100%', padding: '5px 0', background: '#1a2e3a', border: '1px solid #2a5a6a', color: '#6ad', cursor: 'pointer', borderRadius: 3, fontSize: 11, marginTop: 4 }}
+      >
+        Convert to Street
+      </button>
+      <button
+        onClick={onDelete}
+        style={{ width: '100%', padding: '6px 0', background: '#5a1a1a', border: '1px solid #922', color: '#f88', cursor: 'pointer', borderRadius: 3, fontSize: 12, marginTop: 4 }}
+      >
+        Delete Pond Entry
+      </button>
+    </div>
+  )
+}
+
+function SpawnTileInspector({
+  tile, onMove, onDelete,
+}: {
+  tile: [number, number]
+  onMove: (tx: number, ty: number) => void
+  onDelete: () => void
+}) {
+  return (
+    <div>
+      <Field label="Position">
+        <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+          <label style={{ fontSize: 11, color: '#888' }}>X</label>
+          {numInput(tile[0], tx => onMove(tx, tile[1]))}
+          <label style={{ fontSize: 11, color: '#888' }}>Y</label>
+          {numInput(tile[1], ty => onMove(tile[0], ty))}
+        </div>
+      </Field>
+      <button
+        onClick={onDelete}
+        style={{ width: '100%', padding: '6px 0', background: '#5a1a1a', border: '1px solid #922', color: '#f88', cursor: 'pointer', borderRadius: 3, fontSize: 12, marginTop: 4 }}
+      >
+        Delete Spawn Tile
+      </button>
+    </div>
+  )
+}
+
 export function EntityInspector({
-  selectedEntity, mapId, configData, activeInteriorId, activeLevel, viewMode,
+  selectedEntities, mapId, configData, activeInteriorId, activeLevel, viewMode,
   onSetActiveLevel, onUpdateBuilding, onUpdateDecorMinLevel,
   onDelete, onMoveEntity, onZlayerChange, onUpdateGlow, onUpdatePickupGlow, onDialogueChange,
   onOpenInterior, onCloseInterior, onUpdateStreetEntry,
@@ -1801,7 +1970,13 @@ export function EntityInspector({
   onUpdateArea, onResizeMap, onUpdateMapProps, onPickLocation,
   onUpdateTreasure, onUpdateInteractable, onUpdateConfig,
   onAddTreasure, onAddInteractable, onAddBlockedPath,
+  onDeleteEntities, onBatchUpdateZlayer, onBatchUpdateStreetPathType,
+  onConvertStreetToPond, onConvertPondToStreet,
+  onUpdatePondEntry, onDeletePondTile, onDeleteNpcSpawnTile,
 }: Props) {
+  // Existing sub-inspectors operate on a single entity; multi-select shows a
+  // dedicated batch panel instead (handled below).
+  const selectedEntity = selectedEntities[0] ?? null
   // Reference options for the searchable id pickers in the inspectors.
   const buildingOpts = buildingRefOptions(mapId, configData.buildings ?? [])
   const allQuestOpts = allQuestOptions()
@@ -1818,6 +1993,22 @@ export function EntityInspector({
 
   const bodyStyle: React.CSSProperties = {
     flex: 1, overflowY: 'auto', padding: 10,
+  }
+
+  if (selectedEntities.length > 1) {
+    return (
+      <div style={panelStyle}>
+        <div style={headerStyle}>Inspector</div>
+        <div style={bodyStyle}>
+          <MultiSelectPanel
+            entities={selectedEntities}
+            onDelete={onDeleteEntities}
+            onBatchZlayer={onBatchUpdateZlayer}
+            onBatchPathType={onBatchUpdateStreetPathType}
+          />
+        </div>
+      </div>
+    )
   }
 
   const isQuestItemSelected = selectedEntity?.type === 'treasure'
@@ -2052,6 +2243,42 @@ export function EntityInspector({
             entry={entry}
             onUpdate={data => onUpdateStreetEntry(selectedEntity.index, data)}
             onDelete={() => onDelete(selectedEntity)}
+            onConvertToPond={onConvertStreetToPond ? () => onConvertStreetToPond(selectedEntity.index) : undefined}
+          />
+        </div>
+      </div>
+    )
+  }
+
+  if (selectedEntity.type === 'pondTile') {
+    const entry = (configData.pondTiles ?? [])[selectedEntity.index]
+    if (!entry) return null
+    return (
+      <div style={panelStyle}>
+        <div style={headerStyle}>Pond Tile #{selectedEntity.index}</div>
+        <div style={bodyStyle}>
+          <PondInspector
+            entry={entry}
+            onUpdate={data => onUpdatePondEntry?.(selectedEntity.index, data)}
+            onDelete={() => onDeletePondTile?.(selectedEntity.index)}
+            onConvertToStreet={() => onConvertPondToStreet?.(selectedEntity.index)}
+          />
+        </div>
+      </div>
+    )
+  }
+
+  if (selectedEntity.type === 'npcSpawnTile') {
+    const tile = (configData.npcSpawnTiles ?? [])[selectedEntity.index]
+    if (!tile) return null
+    return (
+      <div style={panelStyle}>
+        <div style={headerStyle}>Spawn Tile #{selectedEntity.index}</div>
+        <div style={bodyStyle}>
+          <SpawnTileInspector
+            tile={tile as [number, number]}
+            onMove={(tx, ty) => onMoveEntity(selectedEntity, tx, ty)}
+            onDelete={() => onDeleteNpcSpawnTile?.(selectedEntity.index)}
           />
         </div>
       </div>

--- a/web/src/components/mapEditor/MapEditor.tsx
+++ b/web/src/components/mapEditor/MapEditor.tsx
@@ -38,8 +38,11 @@ export function MapEditor({ initialMapId = 'ravenwatch', initialFestival = undef
 
   const {
     state, setMapId, setTool, setActiveTile, setZlayer, setActiveLevel, setPreviewFestival,
-    openInterior, closeInterior, selectEntity,
-    placeDecor, moveEntity, deleteEntity,
+    openInterior, closeInterior, selectEntities, addToSelection,
+    placeDecor, moveEntities, deleteEntities,
+    addPondTile, updatePondEntry, addNpcSpawnTile, addChickenZone, addArea,
+    convertStreetToPond, convertPondToStreet,
+    batchUpdateZlayer, batchUpdateStreetPathType,
     updateDecorZlayer, updateGlow, updateDecorMinLevel, updateBuilding, addNpc, updateNpcDialogue, updateNpc,
     addAnimal, updateAnimal,
     updateTreasure, updateConfig,
@@ -59,12 +62,13 @@ export function MapEditor({ initialMapId = 'ravenwatch', initialFestival = undef
 
   // Auto-open drawer and focus NPC when one is selected on canvas
   useEffect(() => {
-    if (state.selectedEntity?.type === 'npc') {
-      setFocusedNpcIndex(state.selectedEntity.index)
+    const sel = state.selectedEntities[0]
+    if (state.selectedEntities.length === 1 && sel?.type === 'npc') {
+      setFocusedNpcIndex(sel.index)
       setDrawerOpen(true)
       setDrawerTab('npcs')
     }
-  }, [state.selectedEntity])
+  }, [state.selectedEntities])
 
   const hasDuplicateQuestIds = useMemo(() => {
     if (!questDefsData) return false
@@ -94,31 +98,35 @@ export function MapEditor({ initialMapId = 'ravenwatch', initialFestival = undef
   }, [drawerHeight])
 
   // Intercept pickupItem moves/deletes to update questDefsData instead of configData
-  const handleMoveEntity = useCallback((entity: SelectedEntity, tx: number, ty: number) => {
-    if (entity.type === 'pickupItem') {
+  const handleMoveEntities = useCallback((moves: { entity: SelectedEntity; tx: number; ty: number }[]) => {
+    const pickupMoves = moves.filter(m => m.entity.type === 'pickupItem')
+    const otherMoves  = moves.filter(m => m.entity.type !== 'pickupItem')
+    if (pickupMoves.length > 0) {
       setQuestDefsData(prev => {
         if (!prev) return prev
         const items = [...(prev.pickupItems ?? [])]
-        if (!items[entity.index]) return prev
-        items[entity.index] = { ...items[entity.index], tx, ty }
+        for (const { entity, tx, ty } of pickupMoves) {
+          if (!items[entity.index]) continue
+          items[entity.index] = { ...items[entity.index], tx, ty }
+        }
         return { ...prev, pickupItems: items }
       })
-    } else {
-      moveEntity(entity, tx, ty)
     }
-  }, [moveEntity])
+    if (otherMoves.length > 0) moveEntities(otherMoves)
+  }, [moveEntities])
 
-  const handleDeleteEntity = useCallback((entity: SelectedEntity) => {
-    if (entity.type === 'pickupItem') {
-      setQuestDefsData(prev => {
-        if (!prev) return prev
-        return { ...prev, pickupItems: (prev.pickupItems ?? []).filter((_, i) => i !== entity.index) }
-      })
-      selectEntity(null)
-    } else {
-      deleteEntity(entity)
+  const handleDeleteEntities = useCallback((entities: SelectedEntity[]) => {
+    const pickups = entities.filter(e => e.type === 'pickupItem')
+    const others  = entities.filter(e => e.type !== 'pickupItem')
+    if (pickups.length > 0) {
+      const indices = new Set(pickups.map(e => e.index))
+      setQuestDefsData(prev => prev
+        ? { ...prev, pickupItems: (prev.pickupItems ?? []).filter((_, i) => !indices.has(i)) }
+        : prev)
+      selectEntities([])
     }
-  }, [deleteEntity, selectEntity])
+    if (others.length > 0) deleteEntities(others)
+  }, [deleteEntities, selectEntities])
 
   // Enter "pick a tile" mode for an entity; the next canvas click sets its location.
   const handlePickLocation = useCallback((kind: PickKind, index = 0) => {
@@ -170,16 +178,16 @@ export function MapEditor({ initialMapId = 'ravenwatch', initialFestival = undef
     const list = state.configData.treasures ?? []
     updateConfig({ treasures: [...list, { id: `treasure-${Date.now()}`, tx, ty, tileId: 'chest', collectedTileId: 'openChest', title: 'New treasure', reward: { crystals: 10 } }] })
     setShowQuestItems(true)
-    selectEntity({ type: 'treasure', index: list.length })
-  }, [centreTile, state.configData.treasures, updateConfig, selectEntity])
+    selectEntities([{ type: 'treasure', index: list.length }])
+  }, [centreTile, state.configData.treasures, updateConfig, selectEntities])
 
   const handleAddInteractable = useCallback(() => {
     const { tx, ty } = centreTile()
     const list = state.configData.interactables ?? []
     updateConfig({ interactables: [...list, { id: `interactable-${Date.now()}`, tx, ty, reactions: [{ type: 'screen', screen: '' }] }] })
     setShowInteractables(true)
-    selectEntity({ type: 'interactable', index: list.length })
-  }, [centreTile, state.configData.interactables, updateConfig, selectEntity])
+    selectEntities([{ type: 'interactable', index: list.length }])
+  }, [centreTile, state.configData.interactables, updateConfig, selectEntities])
 
   const handleAddBlockedPath = useCallback(() => {
     const { tx, ty } = centreTile()
@@ -192,8 +200,8 @@ export function MapEditor({ initialMapId = 'ravenwatch', initialFestival = undef
       }],
     } : prev)
     setShowBlockedPaths(true)
-    selectEntity({ type: 'blockedPath', index: list.length })
-  }, [centreTile, questDefsData, selectEntity])
+    selectEntities([{ type: 'blockedPath', index: list.length }])
+  }, [centreTile, questDefsData, selectEntities])
 
   const handleUpdateInteractable = useCallback((index: number, patch: Partial<RawInteractable>) => {
     updateConfig({ interactables: (state.configData.interactables ?? []).map((it, i) => i === index ? { ...it, ...patch } : it) })
@@ -214,8 +222,8 @@ export function MapEditor({ initialMapId = 'ravenwatch', initialFestival = undef
       if (!prev) return prev
       return { ...prev, blockedPaths: ((prev.blockedPaths as RawBlockedPath[]) ?? []).filter((_, i) => i !== index) }
     })
-    selectEntity(null)
-  }, [selectEntity])
+    selectEntities([])
+  }, [selectEntities])
 
   // Keyboard shortcuts
   useEffect(() => {
@@ -228,12 +236,12 @@ export function MapEditor({ initialMapId = 'ravenwatch', initialFestival = undef
       if (e.key === 'd' && !e.ctrlKey && !e.metaKey) setTool('delete')
       if (e.key === 'r') setTool('street')
       if (e.key === 'Delete' || e.key === 'Backspace') {
-        if (state.selectedEntity) handleDeleteEntity(state.selectedEntity)
+        if (state.selectedEntities.length > 0) handleDeleteEntities(state.selectedEntities)
       }
     }
     window.addEventListener('keydown', handleKey)
     return () => window.removeEventListener('keydown', handleKey)
-  }, [undo, redo, setTool, handleDeleteEntity, state.selectedEntity])
+  }, [undo, redo, setTool, handleDeleteEntities, state.selectedEntities])
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', height: '100vh', fontFamily: 'sans-serif', background: '#0f0f22' }}>
@@ -306,7 +314,7 @@ export function MapEditor({ initialMapId = 'ravenwatch', initialFestival = undef
             showAreas={showAreas}
             showInteractables={showInteractables}
             blockedPaths={(questDefsData?.blockedPaths as RawBlockedPath[]) ?? []}
-            selectedEntity={state.selectedEntity}
+            selectedEntities={state.selectedEntities}
             viewMode={state.viewMode}
             activeInteriorId={state.activeInteriorId}
             activeLevel={state.activeLevel}
@@ -315,18 +323,23 @@ export function MapEditor({ initialMapId = 'ravenwatch', initialFestival = undef
             activeZlayer={state.activeZlayer}
             pickActive={pick !== null}
             onPickTile={handlePickTile}
-            onSelectEntity={selectEntity}
+            onSelectEntities={selectEntities}
+            onAddToSelection={addToSelection}
             onPlaceDecor={placeDecor}
-            onMoveEntity={handleMoveEntity}
-            onDeleteEntity={handleDeleteEntity}
+            onMoveEntities={handleMoveEntities}
+            onDeleteEntities={handleDeleteEntities}
             onAddStreet={addStreet}
+            onAddPondTile={addPondTile}
+            onAddNpcSpawnTile={addNpcSpawnTile}
+            onAddChickenZone={addChickenZone}
+            onAddArea={addArea}
             questPickupItems={questDefsData?.pickupItems ?? []}
           />
 
           {/* Right: Inspector */}
           <div style={{ width: 220, flexShrink: 0, borderLeft: '1px solid #333', overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
             <EntityInspector
-              selectedEntity={state.selectedEntity}
+              selectedEntities={state.selectedEntities}
               mapId={state.mapId}
               configData={state.configData}
               activeInteriorId={state.activeInteriorId}
@@ -336,8 +349,8 @@ export function MapEditor({ initialMapId = 'ravenwatch', initialFestival = undef
               onUpdateBuilding={updateBuilding}
               onUpdateDecorMinLevel={updateDecorMinLevel}
               onPickLocation={handlePickLocation}
-              onDelete={handleDeleteEntity}
-              onMoveEntity={handleMoveEntity}
+              onDelete={entity => handleDeleteEntities([entity])}
+              onMoveEntity={(entity, tx, ty) => handleMoveEntities([{ entity, tx, ty }])}
               onZlayerChange={updateDecorZlayer}
               onUpdateGlow={updateGlow}
               onUpdatePickupGlow={(index, patch) => setQuestDefsData(prev => {
@@ -383,6 +396,14 @@ export function MapEditor({ initialMapId = 'ravenwatch', initialFestival = undef
               onAddTreasure={handleAddTreasure}
               onAddInteractable={handleAddInteractable}
               onAddBlockedPath={handleAddBlockedPath}
+              onDeleteEntities={handleDeleteEntities}
+              onBatchUpdateZlayer={batchUpdateZlayer}
+              onBatchUpdateStreetPathType={batchUpdateStreetPathType}
+              onConvertStreetToPond={convertStreetToPond}
+              onConvertPondToStreet={convertPondToStreet}
+              onUpdatePondEntry={updatePondEntry}
+              onDeletePondTile={i => deleteEntities([{ type: 'pondTile', index: i }])}
+              onDeleteNpcSpawnTile={i => deleteEntities([{ type: 'npcSpawnTile', index: i }])}
             />
           </div>
         </div>
@@ -406,7 +427,7 @@ export function MapEditor({ initialMapId = 'ravenwatch', initialFestival = undef
               onUpdateNpc={updateNpc}
               onAddAnimal={addAnimal}
               onUpdateAnimal={updateAnimal}
-              onDeleteAnimal={(index) => handleDeleteEntity({ type: 'animal', index })}
+              onDeleteAnimal={(index) => handleDeleteEntities([{ type: 'animal', index }])}
               onPickLocation={handlePickLocation}
               onQuestDefsChange={handleQuestDefsChange}
             />

--- a/web/src/components/mapEditor/MapEditorCanvas.tsx
+++ b/web/src/components/mapEditor/MapEditorCanvas.tsx
@@ -10,6 +10,7 @@ import type { WallMaterial } from '../../data/tiles/buildingMaterials'
 import { expandBundleDecor } from '../../data/bundles/bundleLoader'
 import { RawQuestPickupItem } from '../../data/hub/hubWorldFactory'
 import { resolveNpcSprite } from './spriteList'
+import { isSameEntityRef } from './multiSelectHelpers'
 
 const T           = 32
 const INTERIOR_PAD = 10  // tiles of surrounding space around active room in interior view
@@ -78,7 +79,7 @@ interface Props {
   configData:       RawMapConfig
   tool:             ToolMode
   showGrid:         boolean
-  selectedEntity:   SelectedEntity | null
+  selectedEntities: SelectedEntity[]
   viewMode:         'exterior' | 'interior'
   activeInteriorId: string | null
   activeLevel:      number
@@ -88,11 +89,16 @@ interface Props {
   activeZlayer:     Zlayer
   pickActive?:      boolean
   onPickTile?:      (tx: number, ty: number) => void
-  onSelectEntity:   (e: SelectedEntity | null) => void
+  onSelectEntities: (e: SelectedEntity[]) => void
+  onAddToSelection: (e: SelectedEntity) => void
   onPlaceDecor:     (tx: number, ty: number) => void
-  onMoveEntity:     (entity: SelectedEntity, tx: number, ty: number) => void
-  onDeleteEntity:   (entity: SelectedEntity) => void
+  onMoveEntities:   (moves: { entity: SelectedEntity; tx: number; ty: number }[]) => void
+  onDeleteEntities: (entities: SelectedEntity[]) => void
   onAddStreet:        (tx1: number, ty1: number, tx2: number, ty2: number) => void
+  onAddPondTile:      (tx1: number, ty1: number, tx2: number, ty2: number) => void
+  onAddNpcSpawnTile:  (tx: number, ty: number) => void
+  onAddChickenZone:   (tx1: number, ty1: number, tx2: number, ty2: number) => void
+  onAddArea:          (tx1: number, ty1: number, tx2: number, ty2: number) => void
   showQuestItems:     boolean
   showBlockedPaths:   boolean
   showAreas:          boolean
@@ -103,34 +109,73 @@ interface Props {
 
 export function MapEditorCanvas(props: Props) {
   const {
-    configData, tool, showGrid, selectedEntity, viewMode, activeInteriorId, activeLevel, previewFestivalId,
+    configData, tool, showGrid, selectedEntities, viewMode, activeInteriorId, activeLevel, previewFestivalId,
     activeTileId, activeBundleId, activeZlayer, pickActive, showQuestItems, showBlockedPaths, showAreas, showInteractables, blockedPaths, questPickupItems,
-    onSelectEntity, onPlaceDecor, onMoveEntity, onDeleteEntity, onAddStreet,
+    onPlaceDecor, onAddStreet,
   } = props
 
   const containerRef = useRef<HTMLDivElement>(null)
+
+  // True if the given entity is part of the current selection.
+  const isEntitySelected = useCallback(
+    (e: SelectedEntity): boolean => selectedEntities.some(s => isSameEntityRef(s, e)),
+    [selectedEntities],
+  )
 
   // Refs that event handlers read so they always get the latest values
   const propsRef = useRef(props)
   propsRef.current = props
 
-  // Drag state — offsetX/Y = click position minus entity anchor, for non-point entities like buildings
-  const dragRef = useRef<{ entity: SelectedEntity; lastTx: number; lastTy: number; offsetX: number; offsetY: number } | null>(null)
+  // Drag state — each selected entity is dragged together, keeping its own offset
+  // from the cursor (offsetX/Y = cursor tile minus that entity's anchor tile).
+  const dragRef = useRef<{
+    entities: { entity: SelectedEntity; offsetX: number; offsetY: number }[]
+    lastTx: number
+    lastTy: number
+  } | null>(null)
 
-  // Street draw state
-  type StreetPreview = { sx: number; sy: number; ex: number; ey: number }
-  const [streetPreview, setStreetPreview] = useState<StreetPreview | null>(null)
-  const setStreetPreviewRef = useRef(setStreetPreview)
-  setStreetPreviewRef.current = setStreetPreview
-  const streetDrawRef = useRef<{ startTx: number; startTy: number; lastTx: number; lastTy: number } | null>(null)
+  // Rect-draw state (shared by all rect-draw tools: street/pond/chickenZone/area)
+  type RectPreview = { sx: number; sy: number; ex: number; ey: number }
+  const [rectPreview, setRectPreview] = useState<RectPreview | null>(null)
+  const setRectPreviewRef = useRef(setRectPreview)
+  setRectPreviewRef.current = setRectPreview
+  const rectDrawRef = useRef<{ startTx: number; startTy: number; lastTx: number; lastTy: number } | null>(null)
 
-  // Clear street draw when tool switches away
+  // Clear rect draw when tool switches away from a rect-draw tool
   useEffect(() => {
-    if (tool !== 'street') {
-      streetDrawRef.current = null
-      setStreetPreview(null)
+    const rectTools: ToolMode[] = ['street', 'pond', 'chickenZone', 'area']
+    if (!rectTools.includes(tool)) {
+      rectDrawRef.current = null
+      setRectPreview(null)
     }
   }, [tool])
+
+  // Shared pointerdown logic for entity sprites/graphics. Shift+click toggles the
+  // entity in/out of the selection; a plain click selects it (or keeps an existing
+  // multi-selection containing it) and, with the select tool, begins a group drag.
+  // anchorTx/anchorTy is the reference tile used to compute per-entity drag offsets.
+  const handleEntityPointerDown = useCallback(
+    (e: PIXI.FederatedPointerEvent, entity: SelectedEntity, anchorTx: number, anchorTy: number) => {
+      e.stopPropagation()
+      if (e.shiftKey) { propsRef.current.onAddToSelection(entity); return }
+      const selEnts = propsRef.current.selectedEntities
+      const isAlreadySelected = selEnts.some(s => isSameEntityRef(s, entity))
+      propsRef.current.onSelectEntities(isAlreadySelected ? selEnts : [entity])
+      if (propsRef.current.tool === 'select') {
+        const cfg = propsRef.current.configData
+        const dragEntities = isAlreadySelected && selEnts.length > 1 ? selEnts : [entity]
+        dragRef.current = {
+          entities: dragEntities.map(ent => ({
+            entity: ent,
+            offsetX: anchorTx - getEntityTx(cfg, ent),
+            offsetY: anchorTy - getEntityTy(cfg, ent),
+          })),
+          lastTx: anchorTx, lastTy: anchorTy,
+        }
+      }
+    },
+    [],
+  )
 
   // Render version counter — incremented on each render, so async sprite loads can detect staleness
   const renderVersionRef = useRef(0)
@@ -165,23 +210,27 @@ export function MapEditorCanvas(props: Props) {
 
       if (t === 'select') {
         const entity = hitTest(cfg, tx, ty, vm, iid, sqI, sbp, bps, sareas)
-        propsRef.current.onSelectEntity(entity)
-        if (entity) {
-          const etx = getEntityTx(cfg, entity)
-          const ety = getEntityTy(cfg, entity)
-          dragRef.current = { entity, lastTx: tx, lastTy: ty, offsetX: tx - etx, offsetY: ty - ety }
+        if (e.shiftKey) {
+          if (entity) propsRef.current.onAddToSelection(entity)
+          // shift+click on empty space: do nothing
+        } else if (entity) {
+          handleEntityPointerDown(e, entity, tx, ty)
+        } else {
+          propsRef.current.onSelectEntities([])
         }
       } else if (t === 'place' && (tid || bid)) {
         propsRef.current.onPlaceDecor(tx, ty)
       } else if (t === 'delete') {
         const entity = hitTest(cfg, tx, ty, vm, iid, sqI, sbp, bps, sareas)
         if (entity) {
-          propsRef.current.onDeleteEntity(entity)
-          propsRef.current.onSelectEntity(null)
+          propsRef.current.onDeleteEntities([entity])
+          propsRef.current.onSelectEntities([])
         }
-      } else if (t === 'street') {
-        streetDrawRef.current = { startTx: tx, startTy: ty, lastTx: tx, lastTy: ty }
-        setStreetPreviewRef.current({ sx: tx, sy: ty, ex: tx, ey: ty })
+      } else if (t === 'street' || t === 'pond' || t === 'chickenZone' || t === 'area') {
+        rectDrawRef.current = { startTx: tx, startTy: ty, lastTx: tx, lastTy: ty }
+        setRectPreviewRef.current({ sx: tx, sy: ty, ex: tx, ey: ty })
+      } else if (t === 'spawn') {
+        propsRef.current.onAddNpcSpawnTile(tx, ty)
       }
     })
 
@@ -192,20 +241,22 @@ export function MapEditorCanvas(props: Props) {
       const ty  = Math.floor((pos.y - oy) / T)
 
       if (dragRef.current) {
-        const { entity, lastTx, lastTy, offsetX, offsetY } = dragRef.current
+        const { entities, lastTx, lastTy } = dragRef.current
         if (tx !== lastTx || ty !== lastTy) {
           dragRef.current.lastTx = tx
           dragRef.current.lastTy = ty
-          propsRef.current.onMoveEntity(entity, tx - offsetX, ty - offsetY)
+          propsRef.current.onMoveEntities(
+            entities.map(({ entity, offsetX, offsetY }) => ({ entity, tx: tx - offsetX, ty: ty - offsetY })),
+          )
         }
       }
 
-      if (streetDrawRef.current) {
-        const { startTx, startTy, lastTx, lastTy } = streetDrawRef.current
+      if (rectDrawRef.current) {
+        const { startTx, startTy, lastTx, lastTy } = rectDrawRef.current
         if (tx !== lastTx || ty !== lastTy) {
-          streetDrawRef.current.lastTx = tx
-          streetDrawRef.current.lastTy = ty
-          setStreetPreviewRef.current({
+          rectDrawRef.current.lastTx = tx
+          rectDrawRef.current.lastTy = ty
+          setRectPreviewRef.current({
             sx: Math.min(tx, startTx), sy: Math.min(ty, startTy),
             ex: Math.max(tx, startTx), ey: Math.max(ty, startTy),
           })
@@ -215,25 +266,28 @@ export function MapEditorCanvas(props: Props) {
 
     stage.on('pointerup', (e: PIXI.FederatedPointerEvent) => {
       dragRef.current = null
-      if (streetDrawRef.current) {
+      if (rectDrawRef.current) {
         const { x: ox, y: oy } = worldOriginRef.current
         const pos = e.getLocalPosition(stage)
-        const tx = Math.floor((pos.x - ox) / T)
-        const ty = Math.floor((pos.y - oy) / T)
-        const { startTx, startTy } = streetDrawRef.current
-        propsRef.current.onAddStreet(
-          Math.min(tx, startTx), Math.min(ty, startTy),
-          Math.max(tx, startTx), Math.max(ty, startTy),
-        )
-        streetDrawRef.current = null
-        setStreetPreviewRef.current(null)
+        const upTx = Math.floor((pos.x - ox) / T)
+        const upTy = Math.floor((pos.y - oy) / T)
+        const { startTx, startTy } = rectDrawRef.current
+        const tx1 = Math.min(upTx, startTx), ty1 = Math.min(upTy, startTy)
+        const tx2 = Math.max(upTx, startTx), ty2 = Math.max(upTy, startTy)
+        const { tool: t } = propsRef.current
+        if      (t === 'street')      propsRef.current.onAddStreet(tx1, ty1, tx2, ty2)
+        else if (t === 'pond')        propsRef.current.onAddPondTile(tx1, ty1, tx2, ty2)
+        else if (t === 'chickenZone') propsRef.current.onAddChickenZone(tx1, ty1, tx2, ty2)
+        else if (t === 'area')        propsRef.current.onAddArea(tx1, ty1, tx2, ty2)
+        rectDrawRef.current = null
+        setRectPreviewRef.current(null)
       }
     })
     stage.on('pointerupoutside', () => {
       dragRef.current = null
-      if (streetDrawRef.current) {
-        streetDrawRef.current = null
-        setStreetPreviewRef.current(null)
+      if (rectDrawRef.current) {
+        rectDrawRef.current = null
+        setRectPreviewRef.current(null)
       }
     })
   }, [mapW, mapH])) // eslint-disable-line react-hooks/exhaustive-deps
@@ -286,6 +340,9 @@ export function MapEditorCanvas(props: Props) {
     if (!isInterior && showAreas) {
       renderAreasOverlay(questLayer, selLayer)
     }
+    if (!isInterior) {
+      renderChickenZonesOverlay(questLayer, selLayer)
+    }
     if (showInteractables) {
       renderInteractablesOverlay(version, questLayer, selLayer)
     }
@@ -293,9 +350,9 @@ export function MapEditorCanvas(props: Props) {
     if (showGrid) drawGrid(gridLayer)
     drawSelection(selLayer)
 
-    // Street draw preview — drawn above all other layers
-    if (!isInterior && streetPreview) {
-      const { sx, sy, ex, ey } = streetPreview
+    // Rect draw preview — drawn above all other layers
+    if (!isInterior && rectPreview) {
+      const { sx, sy, ex, ey } = rectPreview
       const pvGfx = new PIXI.Graphics()
       pvGfx.rect(sx * T, sy * T, (ex - sx + 1) * T, (ey - sy + 1) * T)
         .fill({ color: STREET_COLOR, alpha: 0.4 })
@@ -343,19 +400,43 @@ export function MapEditorCanvas(props: Props) {
         sGfx.rect(tx * T, ty * T, T, T).fill(STREET_COLOR)
     streetLayer.addChild(sGfx)
 
-    // Ponds
-    const pGfx = new PIXI.Graphics()
-    for (const p of configData.pondTiles ?? [])
-      for (const [tx, ty] of expandEntries([p]))
-        pGfx.rect(tx * T, ty * T, T, T).fill(POND_COLOR)
-    streetLayer.addChild(pGfx)
+    // Ponds — per-entry interactive graphics (clickable / selectable / draggable)
+    ;(configData.pondTiles ?? []).forEach((pond, pIdx) => {
+      const isSel = isEntitySelected({ type: 'pondTile', index: pIdx })
+      const gfx = new PIXI.Graphics()
+      for (const [ptx, pty] of expandEntries([pond]))
+        gfx.rect(ptx * T, pty * T, T, T).fill(POND_COLOR)
+      if (isSel) {
+        for (const [ptx, pty] of expandEntries([pond]))
+          selLayer.rect(ptx * T - 1, pty * T - 1, T + 2, T + 2).stroke({ color: 0xf0c040, width: 2 })
+      }
+      const anchorTx = pond.rect?.[0] ?? pond.tile?.[0] ?? 0
+      const anchorTy = pond.rect?.[1] ?? pond.tile?.[1] ?? 0
+      gfx.eventMode = 'static'; gfx.cursor = 'pointer'
+      gfx.on('pointerdown', (e: PIXI.FederatedPointerEvent) =>
+        handleEntityPointerDown(e, { type: 'pondTile', index: pIdx }, anchorTx, anchorTy))
+      streetLayer.addChild(gfx)
+    })
+
+    // Spawn tiles — cyan crosshair, always visible in exterior
+    ;(configData.npcSpawnTiles ?? []).forEach(([stx, sty], idx) => {
+      const isSel = isEntitySelected({ type: 'npcSpawnTile', index: idx })
+      const gfx = new PIXI.Graphics()
+      gfx.rect(stx * T + T / 2 - 2, sty * T + 3, 4, T - 6).fill({ color: 0x40d0f0, alpha: 0.85 })
+      gfx.rect(stx * T + 3, sty * T + T / 2 - 2, T - 6, 4).fill({ color: 0x40d0f0, alpha: 0.85 })
+      gfx.eventMode = 'static'; gfx.cursor = 'pointer'
+      gfx.on('pointerdown', (e: PIXI.FederatedPointerEvent) =>
+        handleEntityPointerDown(e, { type: 'npcSpawnTile', index: idx }, stx, sty))
+      if (isSel) selLayer.rect(stx * T - 2, sty * T - 2, T + 4, T + 4).stroke({ color: 0xf0c040, width: 2 })
+      streetLayer.addChild(gfx)
+    })
 
     // Buildings
     const buildings = configData.buildings ?? []
     buildings.forEach((b, bIdx) => {
       const rects = b.rects ?? (b.rect ? [b.rect] : [])
       const col   = WALL_COLORS[b.wall ?? ''] ?? 0x556677
-      const isSel = selectedEntity?.type === 'building' && selectedEntity.index === bIdx
+      const isSel = isEntitySelected({ type: 'building', index: bIdx })
       const gfx   = new PIXI.Graphics()
       for (const [tx1, ty1, tx2, ty2] of rects) {
         gfx.rect(tx1 * T, ty1 * T, (tx2 - tx1 + 1) * T, (ty2 - ty1 + 1) * T).fill(col)
@@ -394,7 +475,7 @@ export function MapEditorCanvas(props: Props) {
     const npcs = configData.npcs ?? []
     npcs.forEach((npc, nIdx) => {
       if (npc.building) return
-      const isSel = selectedEntity?.type === 'npc' && selectedEntity.index === nIdx
+      const isSel = isEntitySelected({ type: 'npc', index: nIdx })
       loadSpriteTexture(resolveNpcSprite(npc.sprite)).then(tex => {
         if (renderVersionRef.current !== version) return
         const sp = new PIXI.Sprite(tex)
@@ -402,13 +483,8 @@ export function MapEditorCanvas(props: Props) {
         sp.x      = npc.tx * T - T * 0.25
         sp.y      = npc.ty * T - T * 0.5
         sp.eventMode = 'static'; sp.cursor = 'pointer'
-        sp.on('pointerdown', (e: PIXI.FederatedPointerEvent) => {
-          e.stopPropagation()
-          const entity: SelectedEntity = { type: 'npc', index: nIdx }
-          propsRef.current.onSelectEntity(entity)
-          if (propsRef.current.tool === 'select')
-            dragRef.current = { entity, lastTx: npc.tx, lastTy: npc.ty, offsetX: 0, offsetY: 0 }
-        })
+        sp.on('pointerdown', (e: PIXI.FederatedPointerEvent) =>
+          handleEntityPointerDown(e, { type: 'npc', index: nIdx }, npc.tx, npc.ty))
         if (isSel) {
           selLayer.rect(sp.x - 2, sp.y - 2, sp.width + 4, sp.height + 4)
             .stroke({ color: 0xf0c040, width: 2 })
@@ -425,7 +501,7 @@ export function MapEditorCanvas(props: Props) {
     // Animals (exterior — no building field)
     ;(configData.animals ?? []).forEach((animal, aIdx) => {
       if (animal.building) return
-      const isSel = selectedEntity?.type === 'animal' && selectedEntity.index === aIdx
+      const isSel = isEntitySelected({ type: 'animal', index: aIdx })
       const tint = resolveVariantTint(animal.type as AnimalType, animal.variant)
       loadSpriteTexture(`animal-${animal.type}`).then(tex => {
         if (renderVersionRef.current !== version) return
@@ -435,13 +511,8 @@ export function MapEditorCanvas(props: Props) {
         sp.y      = animal.ty * T - T * 0.5
         sp.tint   = tint
         sp.eventMode = 'static'; sp.cursor = 'pointer'
-        sp.on('pointerdown', (e: PIXI.FederatedPointerEvent) => {
-          e.stopPropagation()
-          const entity: SelectedEntity = { type: 'animal', index: aIdx }
-          propsRef.current.onSelectEntity(entity)
-          if (propsRef.current.tool === 'select')
-            dragRef.current = { entity, lastTx: animal.tx, lastTy: animal.ty, offsetX: 0, offsetY: 0 }
-        })
+        sp.on('pointerdown', (e: PIXI.FederatedPointerEvent) =>
+          handleEntityPointerDown(e, { type: 'animal', index: aIdx }, animal.tx, animal.ty))
         if (isSel) {
           selLayer.rect(sp.x - 2, sp.y - 2, sp.width + 4, sp.height + 4)
             .stroke({ color: 0xf0c040, width: 2 })
@@ -648,7 +719,7 @@ export function MapEditorCanvas(props: Props) {
     // ── Interior NPCs ────────────────────────────────────────────────────────
     ;(configData.npcs ?? []).forEach((npc, nIdx) => {
       if (npc.building !== iid) return
-      const isSel = selectedEntity?.type === 'npc' && selectedEntity.index === nIdx
+      const isSel = isEntitySelected({ type: 'npc', index: nIdx })
       const dimmed = (npc.minLevel ?? 0) > activeLevel  // NPC only present at a higher upgrade level
       loadSpriteTexture(resolveNpcSprite(npc.sprite)).then(tex => {
         if (renderVersionRef.current !== version) return
@@ -658,13 +729,8 @@ export function MapEditorCanvas(props: Props) {
         sp.y = npc.ty * T - T * 0.5
         if (dimmed) sp.alpha = 0.3
         sp.eventMode = 'static'; sp.cursor = 'pointer'
-        sp.on('pointerdown', (e: PIXI.FederatedPointerEvent) => {
-          e.stopPropagation()
-          const entity: SelectedEntity = { type: 'npc', index: nIdx }
-          propsRef.current.onSelectEntity(entity)
-          if (propsRef.current.tool === 'select')
-            dragRef.current = { entity, lastTx: npc.tx, lastTy: npc.ty, offsetX: 0, offsetY: 0 }
-        })
+        sp.on('pointerdown', (e: PIXI.FederatedPointerEvent) =>
+          handleEntityPointerDown(e, { type: 'npc', index: nIdx }, npc.tx, npc.ty))
         if (isSel) selLayer.rect(sp.x - 2, sp.y - 2, sp.width + 4, sp.height + 4).stroke({ color: 0xf0c040, width: 2 })
         npcLayer.addChild(sp)
       }).catch(() => {
@@ -678,7 +744,7 @@ export function MapEditorCanvas(props: Props) {
     // Interior animals
     ;(configData.animals ?? []).forEach((animal, aIdx) => {
       if (animal.building !== iid) return
-      const isSel = selectedEntity?.type === 'animal' && selectedEntity.index === aIdx
+      const isSel = isEntitySelected({ type: 'animal', index: aIdx })
       const tint = resolveVariantTint(animal.type as AnimalType, animal.variant)
       loadSpriteTexture(`animal-${animal.type}`).then(tex => {
         if (renderVersionRef.current !== version) return
@@ -688,13 +754,8 @@ export function MapEditorCanvas(props: Props) {
         sp.y      = animal.ty * T - T * 0.5
         sp.tint   = tint
         sp.eventMode = 'static'; sp.cursor = 'pointer'
-        sp.on('pointerdown', (e: PIXI.FederatedPointerEvent) => {
-          e.stopPropagation()
-          const entity: SelectedEntity = { type: 'animal', index: aIdx }
-          propsRef.current.onSelectEntity(entity)
-          if (propsRef.current.tool === 'select')
-            dragRef.current = { entity, lastTx: animal.tx, lastTy: animal.ty, offsetX: 0, offsetY: 0 }
-        })
+        sp.on('pointerdown', (e: PIXI.FederatedPointerEvent) =>
+          handleEntityPointerDown(e, { type: 'animal', index: aIdx }, animal.tx, animal.ty))
         if (isSel) {
           selLayer.rect(sp.x - 2, sp.y - 2, sp.width + 4, sp.height + 4)
             .stroke({ color: 0xf0c040, width: 2 })
@@ -714,13 +775,8 @@ export function MapEditorCanvas(props: Props) {
         itemTx: number, itemTy: number, tileId: string,
         entity: SelectedEntity, tintColor: number,
       ) => {
-        const isSel = selectedEntity?.type === entity.type && selectedEntity.index === entity.index
-        const handler = (e: PIXI.FederatedPointerEvent) => {
-          e.stopPropagation()
-          propsRef.current.onSelectEntity(entity)
-          if (propsRef.current.tool === 'select')
-            dragRef.current = { entity, lastTx: itemTx, lastTy: itemTy, offsetX: 0, offsetY: 0 }
-        }
+        const isSel = isEntitySelected(entity)
+        const handler = (e: PIXI.FederatedPointerEvent) => handleEntityPointerDown(e, entity, itemTx, itemTy)
         const border = new PIXI.Graphics()
         border.rect(itemTx * T, itemTy * T, T, T).stroke({ color: tintColor, width: 2 })
         border.eventMode = 'static'; border.cursor = 'pointer'
@@ -760,11 +816,10 @@ export function MapEditorCanvas(props: Props) {
       const numId = tileNumericId(tileId)
       const layer = zlayer === 'below' ? decorBLayer : zlayer === 'above' ? decorALayer : decorLayer
       const dimmed = minLevel > activeLevel  // decor that only appears at a higher upgrade level
-      const isSel = selectedEntity?.type === entityType &&
-        (entityType === 'exteriorDecor'
-          ? (selectedEntity as { index: number }).index === sourceIndex
-          : (selectedEntity as { index: number; interiorId: string }).index === sourceIndex &&
-            (selectedEntity as { interiorId: string }).interiorId === interiorId)
+      const entity: SelectedEntity = entityType === 'exteriorDecor'
+        ? { type: 'exteriorDecor', index: sourceIndex }
+        : { type: 'interiorDecor', index: sourceIndex, interiorId }
+      const isSel = isEntitySelected(entity)
 
       loadTileRef(numId).then(tex => {
         if (renderVersionRef.current !== version) return
@@ -772,15 +827,8 @@ export function MapEditorCanvas(props: Props) {
         sp.x = tx * T; sp.y = ty * T
         if (dimmed) sp.alpha = 0.3
         sp.eventMode = 'static'; sp.cursor = 'pointer'
-        sp.on('pointerdown', (e: PIXI.FederatedPointerEvent) => {
-          e.stopPropagation()
-          const entity: SelectedEntity = entityType === 'exteriorDecor'
-            ? { type: 'exteriorDecor', index: sourceIndex }
-            : { type: 'interiorDecor', index: sourceIndex, interiorId }
-          propsRef.current.onSelectEntity(entity)
-          if (propsRef.current.tool === 'select')
-            dragRef.current = { entity, lastTx: tx, lastTy: ty, offsetX: 0, offsetY: 0 }
-        })
+        sp.on('pointerdown', (e: PIXI.FederatedPointerEvent) =>
+          handleEntityPointerDown(e, entity, tx, ty))
         if (isSel) {
           selLayer.rect(tx * T - 1, ty * T - 1, T + 2, T + 2)
             .stroke({ color: 0xf0c040, width: 2 })
@@ -807,9 +855,8 @@ export function MapEditorCanvas(props: Props) {
       const numId = tileNumericId(tileId)
       const layer = zlayer === 'below' ? decorBLayer : zlayer === 'above' ? decorALayer : decorLayer
       const dimmed = minLevel > activeLevel
-      const isSel = selectedEntity?.type === 'buildingLevelDecor'
-        && selectedEntity.buildingIndex === buildingIndex && selectedEntity.index === sourceIndex
       const entity: SelectedEntity = { type: 'buildingLevelDecor', buildingIndex, index: sourceIndex }
+      const isSel = isEntitySelected(entity)
 
       loadTileRef(numId).then(tex => {
         if (renderVersionRef.current !== version) return
@@ -817,12 +864,8 @@ export function MapEditorCanvas(props: Props) {
         sp.x = tx * T; sp.y = ty * T
         if (dimmed) sp.alpha = 0.3
         sp.eventMode = 'static'; sp.cursor = 'pointer'
-        sp.on('pointerdown', (e: PIXI.FederatedPointerEvent) => {
-          e.stopPropagation()
-          propsRef.current.onSelectEntity(entity)
-          if (propsRef.current.tool === 'select')
-            dragRef.current = { entity, lastTx: tx, lastTy: ty, offsetX: 0, offsetY: 0 }
-        })
+        sp.on('pointerdown', (e: PIXI.FederatedPointerEvent) =>
+          handleEntityPointerDown(e, entity, tx, ty))
         if (isSel) {
           selLayer.rect(tx * T - 1, ty * T - 1, T + 2, T + 2).stroke({ color: 0xf0c040, width: 2 })
         }
@@ -848,20 +891,15 @@ export function MapEditorCanvas(props: Props) {
     items.forEach(({ tx, ty, tileId, zlayer, sourceIndex }) => {
       const numId = tileNumericId(tileId)
       const layer = zlayer === 'below' ? decorBLayer : zlayer === 'above' ? decorALayer : decorLayer
-      const isSel = selectedEntity?.type === 'festivalDecor'
-        && selectedEntity.festivalId === festivalId && selectedEntity.index === sourceIndex
       const entity: SelectedEntity = { type: 'festivalDecor', festivalId, index: sourceIndex }
+      const isSel = isEntitySelected(entity)
       loadTileRef(numId).then(tex => {
         if (renderVersionRef.current !== version) return
         const sp = new PIXI.Sprite(tex)
         sp.x = tx * T; sp.y = ty * T
         sp.eventMode = 'static'; sp.cursor = 'pointer'
-        sp.on('pointerdown', (e: PIXI.FederatedPointerEvent) => {
-          e.stopPropagation()
-          propsRef.current.onSelectEntity(entity)
-          if (propsRef.current.tool === 'select')
-            dragRef.current = { entity, lastTx: tx, lastTy: ty, offsetX: 0, offsetY: 0 }
-        })
+        sp.on('pointerdown', (e: PIXI.FederatedPointerEvent) =>
+          handleEntityPointerDown(e, entity, tx, ty))
         if (isSel) selLayer.rect(tx * T - 1, ty * T - 1, T + 2, T + 2).stroke({ color: 0xf0c040, width: 2 })
         layer.addChild(sp)
       }).catch(() => {
@@ -882,14 +920,9 @@ export function MapEditorCanvas(props: Props) {
       itemTx: number, itemTy: number, tileId: string,
       entity: SelectedEntity, tintColor: number,
     ) => {
-      const isSel = selectedEntity?.type === entity.type && selectedEntity.index === entity.index
+      const isSel = isEntitySelected(entity)
       const numId = tileNumericId(tileId)
-      const handler = (e: PIXI.FederatedPointerEvent) => {
-        e.stopPropagation()
-        propsRef.current.onSelectEntity(entity)
-        if (propsRef.current.tool === 'select')
-          dragRef.current = { entity, lastTx: itemTx, lastTy: itemTy, offsetX: 0, offsetY: 0 }
-      }
+      const handler = (e: PIXI.FederatedPointerEvent) => handleEntityPointerDown(e, entity, itemTx, itemTy)
 
       // Immediate border (visible before sprite loads)
       const border = new PIXI.Graphics()
@@ -926,21 +959,16 @@ export function MapEditorCanvas(props: Props) {
 
   // ── Areas overlay ──────────────────────────────────────────────────────────────
   function renderAreasOverlay(layer: PIXI.Container, selLayer: PIXI.Graphics) {
-    const { configData: cfg, selectedEntity: sel } = propsRef.current
+    const { configData: cfg } = propsRef.current
     ;(cfg.areas ?? []).forEach((area, aIdx) => {
-      const isSel = sel?.type === 'area' && sel.index === aIdx
+      const isSel = isEntitySelected({ type: 'area', index: aIdx })
       const gfx = new PIXI.Graphics()
       gfx.rect(area.tx * T, area.ty * T, area.tw * T, area.th * T)
         .fill({ color: 0x8855cc, alpha: 0.12 })
         .stroke({ color: isSel ? 0xf0c040 : 0xaa66ff, width: isSel ? 2 : 1 })
       gfx.eventMode = 'static'; gfx.cursor = 'pointer'
-      gfx.on('pointerdown', (e: PIXI.FederatedPointerEvent) => {
-        e.stopPropagation()
-        const entity: SelectedEntity = { type: 'area', index: aIdx }
-        propsRef.current.onSelectEntity(entity)
-        if (propsRef.current.tool === 'select')
-          dragRef.current = { entity, lastTx: area.tx, lastTy: area.ty, offsetX: 0, offsetY: 0 }
-      })
+      gfx.on('pointerdown', (e: PIXI.FederatedPointerEvent) =>
+        handleEntityPointerDown(e, { type: 'area', index: aIdx }, area.tx, area.ty))
       layer.addChild(gfx)
       const lbl = new PIXI.Text({ text: area.name, style: { fontSize: 9, fill: isSel ? 0xf0c040 : 0xaa66ff } })
       lbl.x = area.tx * T + 4; lbl.y = area.ty * T + 4
@@ -948,14 +976,33 @@ export function MapEditorCanvas(props: Props) {
     })
   }
 
+  // ── Chicken zones overlay (always visible in exterior) ─────────────────────────
+  function renderChickenZonesOverlay(layer: PIXI.Container, selLayer: PIXI.Graphics) {
+    ;(propsRef.current.configData.chickenZones ?? []).forEach((zone, zIdx) => {
+      const isSel = isEntitySelected({ type: 'chickenZone', index: zIdx })
+      const [x1, y1, x2, y2] = zone.rect
+      const gfx = new PIXI.Graphics()
+      gfx.rect(x1 * T, y1 * T, (x2 - x1 + 1) * T, (y2 - y1 + 1) * T)
+        .fill({ color: 0xffaa00, alpha: 0.10 })
+        .stroke({ color: isSel ? 0xf0c040 : 0xffaa00, width: isSel ? 2 : 1 })
+      gfx.eventMode = 'static'; gfx.cursor = 'pointer'
+      gfx.on('pointerdown', (e: PIXI.FederatedPointerEvent) =>
+        handleEntityPointerDown(e, { type: 'chickenZone', index: zIdx }, x1, y1))
+      layer.addChild(gfx)
+      const lbl = new PIXI.Text({ text: `🐔×${zone.count ?? 1}`, style: { fontSize: 9, fill: isSel ? 0xf0c040 : 0xffaa00 } })
+      lbl.x = x1 * T + 4; lbl.y = y1 * T + 4
+      layer.addChild(lbl)
+    })
+  }
+
   // ── Interactables overlay ──────────────────────────────────────────────────────
   function renderInteractablesOverlay(version: number, layer: PIXI.Container, selLayer: PIXI.Graphics) {
-    const { configData: cfg, selectedEntity: sel } = propsRef.current
+    const { configData: cfg } = propsRef.current
     const iid = activeInteriorId ?? ''
     ;(cfg.interactables ?? []).forEach((it, idx) => {
       // Exterior view shows world interactables; interior view shows those owned by the open room.
       if (isInterior ? it.building !== iid : !!it.building) return
-      const isSel = sel?.type === 'interactable' && sel.index === idx
+      const isSel = isEntitySelected({ type: 'interactable', index: idx })
       // Render the owned decor tiles (so the object is visible like in-game).
       for (const d of it.decor ?? []) {
         const numId = tileNumericId(d.tileId)
@@ -975,13 +1022,8 @@ export function MapEditorCanvas(props: Props) {
         .fill({ color: 0x33bbee, alpha: 0.10 })
         .stroke({ color: isSel ? 0xf0c040 : 0x33bbee, width: isSel ? 2 : 1 })
       gfx.eventMode = 'static'; gfx.cursor = 'pointer'
-      gfx.on('pointerdown', (e: PIXI.FederatedPointerEvent) => {
-        e.stopPropagation()
-        const entity: SelectedEntity = { type: 'interactable', index: idx }
-        propsRef.current.onSelectEntity(entity)
-        if (propsRef.current.tool === 'select')
-          dragRef.current = { entity, lastTx: it.tx, lastTy: it.ty, offsetX: 0, offsetY: 0 }
-      })
+      gfx.on('pointerdown', (e: PIXI.FederatedPointerEvent) =>
+        handleEntityPointerDown(e, { type: 'interactable', index: idx }, it.tx, it.ty))
       layer.addChild(gfx)
       const lbl = new PIXI.Text({ text: it.id, style: { fontSize: 8, fill: isSel ? 0xf0c040 : 0x66ccff } })
       lbl.x = it.tx * T + 2; lbl.y = it.ty * T + 2
@@ -991,11 +1033,11 @@ export function MapEditorCanvas(props: Props) {
 
   // ── Blocked paths / locked doors overlay ──────────────────────────────────────
   function renderBlockedPathsOverlay(layer: PIXI.Container, selLayer: PIXI.Graphics) {
-    const { blockedPaths: bps, configData: cfg, selectedEntity: sel } = propsRef.current
+    const { blockedPaths: bps, configData: cfg } = propsRef.current
 
     // Blocked path tiles — red overlay
     bps.forEach((bp, bpIdx) => {
-      const isSel = sel?.type === 'blockedPath' && sel.index === bpIdx
+      const isSel = isEntitySelected({ type: 'blockedPath', index: bpIdx })
       const gfx = new PIXI.Graphics()
       for (const [btx, bty] of bp.blockedTiles) {
         gfx.rect(btx * T, bty * T, T, T).fill({ color: 0xff3300, alpha: 0.35 })
@@ -1005,7 +1047,7 @@ export function MapEditorCanvas(props: Props) {
         }
       }
       gfx.eventMode = 'static'; gfx.cursor = 'pointer'
-      gfx.on('pointerdown', () => propsRef.current.onSelectEntity({ type: 'blockedPath', index: bpIdx }))
+      gfx.on('pointerdown', () => propsRef.current.onSelectEntities([{ type: 'blockedPath', index: bpIdx }]))
       layer.addChild(gfx)
       // Label: questId above first tile
       if (bp.blockedTiles[0]) {
@@ -1019,7 +1061,7 @@ export function MapEditorCanvas(props: Props) {
     // Locked doors — orange outline on buildings
     const lockedDoors = cfg.lockedDoors ?? []
     lockedDoors.forEach((door, dIdx) => {
-      const isSel = sel?.type === 'lockedDoor' && sel.index === dIdx
+      const isSel = isEntitySelected({ type: 'lockedDoor', index: dIdx })
       const bIdx = (cfg.buildings ?? []).findIndex(b => b.id === door.buildingId)
       if (bIdx < 0) return
       const b = cfg.buildings![bIdx]
@@ -1030,7 +1072,7 @@ export function MapEditorCanvas(props: Props) {
         gfx.rect(tx1 * T, ty1 * T, (tx2 - tx1 + 1) * T, (ty2 - ty1 + 1) * T)
           .stroke({ color: borderColor, width: 2, alpha: 0.9 })
         gfx.eventMode = 'static'; gfx.cursor = 'pointer'
-        gfx.on('pointerdown', () => propsRef.current.onSelectEntity({ type: 'lockedDoor', index: dIdx }))
+        gfx.on('pointerdown', () => propsRef.current.onSelectEntities([{ type: 'lockedDoor', index: dIdx }]))
         layer.addChild(gfx)
       }
       // Lock label
@@ -1055,63 +1097,66 @@ export function MapEditorCanvas(props: Props) {
 
   // ── Selection highlight ────────────────────────────────────────────────────────
   function drawSelection(gfx: PIXI.Graphics) {
-    if (!selectedEntity) return
-    if (selectedEntity.type === 'street') {
-      const entry = configData.streets?.[selectedEntity.index]
-      if (entry?.rect) {
-        const [tx1, ty1, tx2, ty2] = entry.rect
-        gfx.rect(tx1 * T - 2, ty1 * T - 2, (tx2 - tx1 + 1) * T + 4, (ty2 - ty1 + 1) * T + 4)
-          .stroke({ color: 0xf0c040, width: 2 })
-      } else if (entry?.tile) {
-        gfx.rect(entry.tile[0] * T - 2, entry.tile[1] * T - 2, T + 4, T + 4)
-          .stroke({ color: 0xf0c040, width: 2 })
-      }
-      return
-    }
-    let tx = -1, ty = -1
-    if (selectedEntity.type === 'exteriorDecor') {
-      const item = configData.exteriorDecor?.[selectedEntity.index]
-      if (item?.tx !== undefined) { tx = item.tx; ty = item.ty ?? 0 }
-    } else if (selectedEntity.type === 'npc') {
-      const npc = configData.npcs?.[selectedEntity.index]
-      if (npc) { tx = npc.tx; ty = npc.ty }
-    } else if (selectedEntity.type === 'animal') {
-      const a = configData.animals?.[selectedEntity.index]
-      if (a) { tx = a.tx; ty = a.ty }
-    } else if (selectedEntity.type === 'treasure') {
-      const t = configData.treasures?.[selectedEntity.index]
-      if (t) { tx = t.tx; ty = t.ty }
-    } else if (selectedEntity.type === 'pickupItem') {
-      const p = configData.pickupItems?.[selectedEntity.index]
-      if (p) { tx = p.tx; ty = p.ty }
-    } else if (selectedEntity.type === 'interiorDecor' && selectedEntity.interiorId === activeInteriorId) {
-      const item = configData.interiors?.[selectedEntity.interiorId]?.decor[selectedEntity.index]
-      if (item?.tx !== undefined) { tx = item.tx; ty = item.ty ?? 0 }
-    } else if (selectedEntity.type === 'area') {
-      const area = configData.areas?.[selectedEntity.index]
-      if (area) {
-        gfx.rect(area.tx * T - 2, area.ty * T - 2, area.tw * T + 4, area.th * T + 4)
-          .stroke({ color: 0xf0c040, width: 2 })
-      }
-      return
-    } else if (selectedEntity.type === 'blockedPath') {
-      // Selection drawn per-tile inside renderBlockedPathsOverlay
-      return
-    } else if (selectedEntity.type === 'lockedDoor') {
-      const door = configData.lockedDoors?.[selectedEntity.index]
-      if (door) {
-        const b = (configData.buildings ?? []).find(bd => bd.id === door.buildingId)
-        if (b) {
-          const rects = b.rects ?? (b.rect ? [b.rect] : [])
-          for (const [tx1, ty1, tx2, ty2] of rects)
-            gfx.rect(tx1 * T - 2, ty1 * T - 2, (tx2 - tx1 + 1) * T + 4, (ty2 - ty1 + 1) * T + 4)
-              .stroke({ color: 0xf0c040, width: 2 })
+    for (const selectedEntity of selectedEntities) {
+      if (selectedEntity.type === 'street') {
+        const entry = configData.streets?.[selectedEntity.index]
+        if (entry?.rect) {
+          const [tx1, ty1, tx2, ty2] = entry.rect
+          gfx.rect(tx1 * T - 2, ty1 * T - 2, (tx2 - tx1 + 1) * T + 4, (ty2 - ty1 + 1) * T + 4)
+            .stroke({ color: 0xf0c040, width: 2 })
+        } else if (entry?.tile) {
+          gfx.rect(entry.tile[0] * T - 2, entry.tile[1] * T - 2, T + 4, T + 4)
+            .stroke({ color: 0xf0c040, width: 2 })
         }
+        continue
       }
-      return
-    }
-    if (tx >= 0) {
-      gfx.rect(tx * T - 2, ty * T - 2, T + 4, T + 4).stroke({ color: 0xf0c040, width: 2 })
+      let tx = -1, ty = -1
+      if (selectedEntity.type === 'exteriorDecor') {
+        const item = configData.exteriorDecor?.[selectedEntity.index]
+        if (item?.tx !== undefined) { tx = item.tx; ty = item.ty ?? 0 }
+      } else if (selectedEntity.type === 'npc') {
+        const npc = configData.npcs?.[selectedEntity.index]
+        if (npc) { tx = npc.tx; ty = npc.ty }
+      } else if (selectedEntity.type === 'animal') {
+        const a = configData.animals?.[selectedEntity.index]
+        if (a) { tx = a.tx; ty = a.ty }
+      } else if (selectedEntity.type === 'treasure') {
+        const t = configData.treasures?.[selectedEntity.index]
+        if (t) { tx = t.tx; ty = t.ty }
+      } else if (selectedEntity.type === 'pickupItem') {
+        const p = configData.pickupItems?.[selectedEntity.index]
+        if (p) { tx = p.tx; ty = p.ty }
+      } else if (selectedEntity.type === 'npcSpawnTile') {
+        const s = configData.npcSpawnTiles?.[selectedEntity.index]
+        if (s) { tx = s[0]; ty = s[1] }
+      } else if (selectedEntity.type === 'interiorDecor' && selectedEntity.interiorId === activeInteriorId) {
+        const item = configData.interiors?.[selectedEntity.interiorId]?.decor[selectedEntity.index]
+        if (item?.tx !== undefined) { tx = item.tx; ty = item.ty ?? 0 }
+      } else if (selectedEntity.type === 'area') {
+        const area = configData.areas?.[selectedEntity.index]
+        if (area) {
+          gfx.rect(area.tx * T - 2, area.ty * T - 2, area.tw * T + 4, area.th * T + 4)
+            .stroke({ color: 0xf0c040, width: 2 })
+        }
+        continue
+      } else if (selectedEntity.type === 'lockedDoor') {
+        const door = configData.lockedDoors?.[selectedEntity.index]
+        if (door) {
+          const b = (configData.buildings ?? []).find(bd => bd.id === door.buildingId)
+          if (b) {
+            const rects = b.rects ?? (b.rect ? [b.rect] : [])
+            for (const [tx1, ty1, tx2, ty2] of rects)
+              gfx.rect(tx1 * T - 2, ty1 * T - 2, (tx2 - tx1 + 1) * T + 4, (ty2 - ty1 + 1) * T + 4)
+                .stroke({ color: 0xf0c040, width: 2 })
+          }
+        }
+        continue
+      }
+      // blockedPath, pondTile, npcSpawnTile, chickenZone etc. draw their own
+      // highlight inline in their render functions.
+      if (tx >= 0) {
+        gfx.rect(tx * T - 2, ty * T - 2, T + 4, T + 4).stroke({ color: 0xf0c040, width: 2 })
+      }
     }
   }
 
@@ -1220,6 +1265,26 @@ function hitTest(
       return { type: 'street', index: i }
     }
   }
+  const pondTiles = cfg.pondTiles ?? []
+  for (let i = pondTiles.length - 1; i >= 0; i--) {
+    const entry = pondTiles[i]
+    if (entry.rect) {
+      const [tx1, ty1, tx2, ty2] = entry.rect
+      if (tx >= tx1 && tx <= tx2 && ty >= ty1 && ty <= ty2)
+        return { type: 'pondTile', index: i }
+    } else if (entry.tile && entry.tile[0] === tx && entry.tile[1] === ty) {
+      return { type: 'pondTile', index: i }
+    }
+  }
+  const spawnTiles = cfg.npcSpawnTiles ?? []
+  for (let i = spawnTiles.length - 1; i >= 0; i--) {
+    if (spawnTiles[i][0] === tx && spawnTiles[i][1] === ty) return { type: 'npcSpawnTile', index: i }
+  }
+  const chickenZones = cfg.chickenZones ?? []
+  for (let i = chickenZones.length - 1; i >= 0; i--) {
+    const [x1, y1, x2, y2] = chickenZones[i].rect
+    if (tx >= x1 && tx <= x2 && ty >= y1 && ty <= y2) return { type: 'chickenZone', index: i }
+  }
   if (showAreas) {
     const areas = cfg.areas ?? []
     for (let i = areas.length - 1; i >= 0; i--) {
@@ -1234,7 +1299,13 @@ function hitTest(
 function getEntityTx(cfg: RawMapConfig, entity: SelectedEntity): number {
   if (entity.type === 'exteriorDecor') return cfg.exteriorDecor?.[entity.index]?.tx ?? 0
   if (entity.type === 'npc') return cfg.npcs?.[entity.index]?.tx ?? 0
+  if (entity.type === 'animal') return cfg.animals?.[entity.index]?.tx ?? 0
   if (entity.type === 'interiorDecor') return cfg.interiors?.[entity.interiorId]?.decor[entity.index]?.tx ?? 0
+  if (entity.type === 'buildingLevelDecor') return cfg.buildings?.[entity.buildingIndex]?.levelDecor?.[entity.index]?.tx ?? 0
+  if (entity.type === 'festivalDecor') {
+    const g = cfg.festivalDecor?.find(grp => grp.festivalId === entity.festivalId)
+    return g?.decor[entity.index]?.tx ?? 0
+  }
   if (entity.type === 'building') {
     const b = cfg.buildings?.[entity.index]
     const rects = b?.rects ?? (b?.rect ? [b.rect] : [])
@@ -1244,17 +1315,30 @@ function getEntityTx(cfg: RawMapConfig, entity: SelectedEntity): number {
     const e = cfg.streets?.[entity.index]
     return e?.rect?.[0] ?? e?.tile?.[0] ?? 0
   }
+  if (entity.type === 'pondTile') {
+    const e = cfg.pondTiles?.[entity.index]
+    return e?.rect?.[0] ?? e?.tile?.[0] ?? 0
+  }
+  if (entity.type === 'npcSpawnTile') return cfg.npcSpawnTiles?.[entity.index]?.[0] ?? 0
+  if (entity.type === 'chickenZone') return cfg.chickenZones?.[entity.index]?.rect?.[0] ?? 0
+  if (entity.type === 'interactable') return cfg.interactables?.[entity.index]?.tx ?? 0
+  if (entity.type === 'exitTile') return cfg.exitTiles?.[entity.index]?.tx ?? 0
   if (entity.type === 'treasure') return cfg.treasures?.[entity.index]?.tx ?? 0
   if (entity.type === 'pickupItem') return cfg.pickupItems?.[entity.index]?.tx ?? 0
   if (entity.type === 'area') return cfg.areas?.[entity.index]?.tx ?? 0
-  if (entity.type === 'blockedPath' || entity.type === 'lockedDoor') return 0
   return 0
 }
 
 function getEntityTy(cfg: RawMapConfig, entity: SelectedEntity): number {
   if (entity.type === 'exteriorDecor') return cfg.exteriorDecor?.[entity.index]?.ty ?? 0
   if (entity.type === 'npc') return cfg.npcs?.[entity.index]?.ty ?? 0
+  if (entity.type === 'animal') return cfg.animals?.[entity.index]?.ty ?? 0
   if (entity.type === 'interiorDecor') return cfg.interiors?.[entity.interiorId]?.decor[entity.index]?.ty ?? 0
+  if (entity.type === 'buildingLevelDecor') return cfg.buildings?.[entity.buildingIndex]?.levelDecor?.[entity.index]?.ty ?? 0
+  if (entity.type === 'festivalDecor') {
+    const g = cfg.festivalDecor?.find(grp => grp.festivalId === entity.festivalId)
+    return g?.decor[entity.index]?.ty ?? 0
+  }
   if (entity.type === 'building') {
     const b = cfg.buildings?.[entity.index]
     const rects = b?.rects ?? (b?.rect ? [b.rect] : [])
@@ -1264,6 +1348,14 @@ function getEntityTy(cfg: RawMapConfig, entity: SelectedEntity): number {
     const e = cfg.streets?.[entity.index]
     return e?.rect?.[1] ?? e?.tile?.[1] ?? 0
   }
+  if (entity.type === 'pondTile') {
+    const e = cfg.pondTiles?.[entity.index]
+    return e?.rect?.[1] ?? e?.tile?.[1] ?? 0
+  }
+  if (entity.type === 'npcSpawnTile') return cfg.npcSpawnTiles?.[entity.index]?.[1] ?? 0
+  if (entity.type === 'chickenZone') return cfg.chickenZones?.[entity.index]?.rect?.[1] ?? 0
+  if (entity.type === 'interactable') return cfg.interactables?.[entity.index]?.ty ?? 0
+  if (entity.type === 'exitTile') return cfg.exitTiles?.[entity.index]?.ty ?? 0
   if (entity.type === 'treasure') return cfg.treasures?.[entity.index]?.ty ?? 0
   if (entity.type === 'pickupItem') return cfg.pickupItems?.[entity.index]?.ty ?? 0
   if (entity.type === 'area') return cfg.areas?.[entity.index]?.ty ?? 0

--- a/web/src/components/mapEditor/MapEditorToolbar.tsx
+++ b/web/src/components/mapEditor/MapEditorToolbar.tsx
@@ -52,10 +52,14 @@ interface Props {
 }
 
 const TOOLS: { mode: ToolMode; label: string; title: string }[] = [
-  { mode: 'select', label: '↖', title: 'Select / Move (S)' },
-  { mode: 'place',  label: '✎', title: 'Place tile (P)' },
-  { mode: 'delete', label: '✕', title: 'Delete (D)' },
-  { mode: 'street', label: '⊟', title: 'Draw Street / Path (R)' },
+  { mode: 'select',      label: '↖', title: 'Select / Move (S)' },
+  { mode: 'place',       label: '✎', title: 'Place tile (P)' },
+  { mode: 'delete',      label: '✕', title: 'Delete (D)' },
+  { mode: 'street',      label: '⊟', title: 'Draw Street / Path (R)' },
+  { mode: 'pond',        label: '≈', title: 'Draw Pond Tile' },
+  { mode: 'spawn',       label: '⊕', title: 'Place Spawn Tile' },
+  { mode: 'chickenZone', label: '⊛', title: 'Draw Chicken Zone' },
+  { mode: 'area',        label: '□', title: 'Draw Area' },
 ]
 
 export function MapEditorToolbar({

--- a/web/src/components/mapEditor/mapEditorTypes.ts
+++ b/web/src/components/mapEditor/mapEditorTypes.ts
@@ -3,7 +3,7 @@ import type { WallMaterial, RoofMaterial } from '../../data/tiles/buildingMateri
 import type { NpcActivity } from '../../data/hub/loader'
 
 
-export type ToolMode = 'select' | 'place' | 'delete' | 'street'
+export type ToolMode = 'select' | 'place' | 'delete' | 'street' | 'pond' | 'spawn' | 'chickenZone' | 'area'
 export type Zlayer = 'solid' | 'below' | 'above'
 export type ViewMode = 'exterior' | 'interior'
 
@@ -237,6 +237,8 @@ export type SelectedEntity =
   | { type: 'building'; index: number }
   | { type: 'buildingLevelDecor'; buildingIndex: number; index: number }
   | { type: 'street'; index: number }
+  | { type: 'pondTile'; index: number }
+  | { type: 'npcSpawnTile'; index: number }
   | { type: 'treasure'; index: number }
   | { type: 'pickupItem'; index: number }
   | { type: 'interiorDecor'; interiorId: string; index: number }
@@ -261,7 +263,7 @@ export interface MapEditorState {
   activeLevel: number
   /** Festival being previewed/authored in the editor (null = base / no festival). */
   previewFestivalId: string | null
-  selectedEntity: SelectedEntity | null
+  selectedEntities: SelectedEntity[]
   undoStack: RawMapConfig[]
   redoStack: RawMapConfig[]
   isDirty: boolean

--- a/web/src/components/mapEditor/multiSelectHelpers.test.ts
+++ b/web/src/components/mapEditor/multiSelectHelpers.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest'
+import {
+  isSameType, isSameEntityRef, toggleInSelection, nextAreaId,
+  convertStreetToPond, convertPondToStreet, applyDeleteEntities,
+} from './multiSelectHelpers'
+import type { SelectedEntity, RawMapConfig } from './mapEditorTypes'
+
+const street0: SelectedEntity = { type: 'street', index: 0 }
+const street1: SelectedEntity = { type: 'street', index: 1 }
+const decor0: SelectedEntity  = { type: 'exteriorDecor', index: 0 }
+
+describe('isSameType', () => {
+  it('returns true for same type', () => expect(isSameType(street0, street1)).toBe(true))
+  it('returns false for different types', () => expect(isSameType(street0, decor0)).toBe(false))
+})
+
+describe('isSameEntityRef', () => {
+  it('returns true for identical ref', () => expect(isSameEntityRef(street0, { type: 'street', index: 0 })).toBe(true))
+  it('returns false for same type different index', () => expect(isSameEntityRef(street0, street1)).toBe(false))
+  it('returns false for interiorDecor with different interiorId', () => {
+    const a: SelectedEntity = { type: 'interiorDecor', index: 0, interiorId: 'room-a' }
+    const b: SelectedEntity = { type: 'interiorDecor', index: 0, interiorId: 'room-b' }
+    expect(isSameEntityRef(a, b)).toBe(false)
+  })
+})
+
+describe('toggleInSelection', () => {
+  it('adds entity to empty selection', () => expect(toggleInSelection([], street0)).toEqual([street0]))
+  it('adds same-type entity', () => expect(toggleInSelection([street0], street1)).toEqual([street0, street1]))
+  it('removes entity already present', () => expect(toggleInSelection([street0, street1], street0)).toEqual([street1]))
+  it('ignores different-type when non-empty', () => expect(toggleInSelection([street0], decor0)).toEqual([street0]))
+  it('allows different type when selection is empty', () => expect(toggleInSelection([], decor0)).toEqual([decor0]))
+})
+
+describe('nextAreaId', () => {
+  it('returns area-1 when empty', () => expect(nextAreaId([])).toBe('area-1'))
+  it('increments past existing', () => expect(nextAreaId([{ id: 'area-1' }, { id: 'area-2' }])).toBe('area-3'))
+  it('fills first gap', () => expect(nextAreaId([{ id: 'area-1' }, { id: 'area-3' }])).toBe('area-2'))
+})
+
+const baseConfig = {
+  streets: [{ rect: [0, 0, 2, 2], pathType: 'cobble' }, { tile: [5, 5] }],
+  pondTiles: [{ rect: [3, 3, 4, 4] }],
+  exteriorDecor: [{ tx: 1, ty: 1, tileId: 'barrel', zlayer: 'solid' }, { tx: 2, ty: 2, tileId: 'crate', zlayer: 'solid' }],
+  npcSpawnTiles: [[1, 1], [2, 2]],
+} as unknown as RawMapConfig
+
+describe('convertStreetToPond', () => {
+  it('moves entry to pondTiles and drops pathType', () => {
+    const result = convertStreetToPond(baseConfig, 0)!
+    expect(result.config.streets).toHaveLength(1)
+    expect(result.config.streets![0]).toEqual({ tile: [5, 5] })
+    expect(result.config.pondTiles).toHaveLength(2)
+    expect(result.config.pondTiles![1]).toEqual({ rect: [0, 0, 2, 2] })
+    expect(result.pondIndex).toBe(1)
+  })
+  it('returns null for out-of-bounds index', () => expect(convertStreetToPond(baseConfig, 99)).toBeNull())
+})
+
+describe('convertPondToStreet', () => {
+  it('moves entry to streets', () => {
+    const result = convertPondToStreet(baseConfig, 0)!
+    expect(result.config.pondTiles).toHaveLength(0)
+    expect(result.config.streets).toHaveLength(3)
+    expect(result.streetIndex).toBe(2)
+  })
+  it('returns null for out-of-bounds', () => expect(convertPondToStreet(baseConfig, 99)).toBeNull())
+})
+
+describe('applyDeleteEntities', () => {
+  it('deletes single exteriorDecor', () => {
+    const c = applyDeleteEntities(baseConfig, [decor0])
+    expect(c.exteriorDecor).toHaveLength(1)
+    expect(c.exteriorDecor![0].tileId).toBe('crate')
+  })
+  it('deletes multiple streets in one pass (no index shift)', () => {
+    const c = applyDeleteEntities(baseConfig, [street0, street1])
+    expect(c.streets).toHaveLength(0)
+  })
+  it('deletes npcSpawnTile', () => {
+    const c = applyDeleteEntities(baseConfig, [{ type: 'npcSpawnTile', index: 0 }])
+    expect(c.npcSpawnTiles).toHaveLength(1)
+  })
+  it('leaves unrelated data unchanged', () => {
+    const c = applyDeleteEntities(baseConfig, [street0])
+    expect(c.pondTiles).toHaveLength(1)
+    expect(c.exteriorDecor).toHaveLength(2)
+  })
+})

--- a/web/src/components/mapEditor/multiSelectHelpers.ts
+++ b/web/src/components/mapEditor/multiSelectHelpers.ts
@@ -1,0 +1,222 @@
+import type { SelectedEntity, RawMapConfig, Zlayer } from './mapEditorTypes'
+
+export function isSameType(a: SelectedEntity, b: SelectedEntity): boolean {
+  return a.type === b.type
+}
+
+export function isSameEntityRef(a: SelectedEntity, b: SelectedEntity): boolean {
+  if (a.type !== b.type) return false
+  if ('index' in a && 'index' in b && (a as {index:number}).index !== (b as {index:number}).index) return false
+  if (a.type === 'interiorDecor' && b.type === 'interiorDecor' && a.interiorId !== b.interiorId) return false
+  if (a.type === 'buildingLevelDecor' && b.type === 'buildingLevelDecor' && a.buildingIndex !== b.buildingIndex) return false
+  if (a.type === 'festivalDecor' && b.type === 'festivalDecor' && a.festivalId !== b.festivalId) return false
+  return true
+}
+
+export function toggleInSelection(entities: SelectedEntity[], entity: SelectedEntity): SelectedEntity[] {
+  const idx = entities.findIndex(e => isSameEntityRef(e, entity))
+  if (idx >= 0) return entities.filter((_, i) => i !== idx)
+  if (entities.length > 0 && !isSameType(entities[0], entity)) return entities
+  return [...entities, entity]
+}
+
+export function nextAreaId(areas: { id: string }[]): string {
+  const ids = new Set(areas.map(a => a.id))
+  let n = 1
+  while (ids.has(`area-${n}`)) n++
+  return `area-${n}`
+}
+
+export function convertStreetToPond(
+  config: RawMapConfig, index: number,
+): { config: RawMapConfig; pondIndex: number } | null {
+  const streets = config.streets ?? []
+  const entry = streets[index]
+  if (!entry) return null
+  const { pathType: _dropped, ...rest } = entry as { pathType?: string; rect?: number[]; tile?: number[] }
+  const pondTiles = [...(config.pondTiles ?? []), rest]
+  return {
+    config: { ...config, streets: streets.filter((_, i) => i !== index), pondTiles },
+    pondIndex: pondTiles.length - 1,
+  }
+}
+
+export function convertPondToStreet(
+  config: RawMapConfig, index: number,
+): { config: RawMapConfig; streetIndex: number } | null {
+  const pondTiles = config.pondTiles ?? []
+  const entry = pondTiles[index]
+  if (!entry) return null
+  const streets = [...(config.streets ?? []), entry]
+  return {
+    config: { ...config, pondTiles: pondTiles.filter((_, i) => i !== index), streets },
+    streetIndex: streets.length - 1,
+  }
+}
+
+function indexSet(entities: SelectedEntity[], type: string): Set<number> {
+  return new Set(
+    entities.filter(e => e.type === type && 'index' in e).map(e => (e as { index: number }).index),
+  )
+}
+
+export function applyDeleteEntities(config: RawMapConfig, entities: SelectedEntity[]): RawMapConfig {
+  let c = config
+
+  const extDecor = indexSet(entities, 'exteriorDecor')
+  if (extDecor.size) c = { ...c, exteriorDecor: (c.exteriorDecor ?? []).filter((_, i) => !extDecor.has(i)) }
+
+  const streets = indexSet(entities, 'street')
+  if (streets.size) c = { ...c, streets: (c.streets ?? []).filter((_, i) => !streets.has(i)) }
+
+  const ponds = indexSet(entities, 'pondTile')
+  if (ponds.size) c = { ...c, pondTiles: (c.pondTiles ?? []).filter((_, i) => !ponds.has(i)) }
+
+  const spawns = indexSet(entities, 'npcSpawnTile')
+  if (spawns.size) c = { ...c, npcSpawnTiles: (c.npcSpawnTiles ?? []).filter((_, i) => !spawns.has(i)) }
+
+  const npcs = indexSet(entities, 'npc')
+  if (npcs.size) c = { ...c, npcs: (c.npcs ?? []).filter((_, i) => !npcs.has(i)) }
+
+  const animals = indexSet(entities, 'animal')
+  if (animals.size) c = { ...c, animals: (c.animals ?? []).filter((_, i) => !animals.has(i)) }
+
+  const areas = indexSet(entities, 'area')
+  if (areas.size) c = { ...c, areas: (c.areas ?? []).filter((_, i) => !areas.has(i)) }
+
+  const chickens = indexSet(entities, 'chickenZone')
+  if (chickens.size) c = { ...c, chickenZones: (c.chickenZones ?? []).filter((_, i) => !chickens.has(i)) }
+
+  const interactables = indexSet(entities, 'interactable')
+  if (interactables.size) c = { ...c, interactables: (c.interactables ?? []).filter((_, i) => !interactables.has(i)) }
+
+  const exitTiles = indexSet(entities, 'exitTile')
+  if (exitTiles.size) c = { ...c, exitTiles: (c.exitTiles ?? []).filter((_, i) => !exitTiles.has(i)) }
+
+  const treasures = indexSet(entities, 'treasure')
+  if (treasures.size) c = { ...c, treasures: (c.treasures ?? []).filter((_, i) => !treasures.has(i)) }
+
+  // buildingLevelDecor — group by buildingIndex to avoid index-shift bugs
+  const bldMap = new Map<number, Set<number>>()
+  for (const e of entities) {
+    if (e.type !== 'buildingLevelDecor') continue
+    if (!bldMap.has(e.buildingIndex)) bldMap.set(e.buildingIndex, new Set())
+    bldMap.get(e.buildingIndex)!.add(e.index)
+  }
+  if (bldMap.size) {
+    const buildings = [...(c.buildings ?? [])]
+    for (const [bIdx, idxs] of bldMap) {
+      const b = buildings[bIdx]
+      if (!b) continue
+      buildings[bIdx] = { ...b, levelDecor: (b.levelDecor ?? []).filter((_, i) => !idxs.has(i)) }
+    }
+    c = { ...c, buildings }
+  }
+
+  // interiorDecor — group by interiorId
+  const roomMap = new Map<string, Set<number>>()
+  for (const e of entities) {
+    if (e.type !== 'interiorDecor') continue
+    if (!roomMap.has(e.interiorId)) roomMap.set(e.interiorId, new Set())
+    roomMap.get(e.interiorId)!.add(e.index)
+  }
+  if (roomMap.size) {
+    let interiors = { ...c.interiors }
+    for (const [roomId, idxs] of roomMap) {
+      const room = interiors[roomId]
+      if (!room) continue
+      interiors = { ...interiors, [roomId]: { ...room, decor: room.decor.filter((_, i) => !idxs.has(i)) } }
+    }
+    c = { ...c, interiors }
+  }
+
+  // festivalDecor — group by festivalId
+  const festMap = new Map<string, Set<number>>()
+  for (const e of entities) {
+    if (e.type !== 'festivalDecor') continue
+    if (!festMap.has(e.festivalId)) festMap.set(e.festivalId, new Set())
+    festMap.get(e.festivalId)!.add(e.index)
+  }
+  if (festMap.size) {
+    c = {
+      ...c,
+      festivalDecor: (c.festivalDecor ?? []).map(g => {
+        const idxs = festMap.get(g.festivalId)
+        return idxs ? { ...g, decor: g.decor.filter((_, i) => !idxs.has(i)) } : g
+      }),
+    }
+  }
+
+  return c
+}
+
+export function applyBatchUpdateZlayer(
+  config: RawMapConfig, entities: SelectedEntity[], zlayer: Zlayer,
+): RawMapConfig {
+  let c = config
+  const extIdx = indexSet(entities, 'exteriorDecor')
+  if (extIdx.size) c = { ...c, exteriorDecor: (c.exteriorDecor ?? []).map((d, i) => extIdx.has(i) ? { ...d, zlayer } : d) }
+
+  const bldMap = new Map<number, Set<number>>()
+  for (const e of entities) {
+    if (e.type !== 'buildingLevelDecor') continue
+    if (!bldMap.has(e.buildingIndex)) bldMap.set(e.buildingIndex, new Set())
+    bldMap.get(e.buildingIndex)!.add(e.index)
+  }
+  if (bldMap.size) {
+    const buildings = [...(c.buildings ?? [])]
+    for (const [bIdx, idxs] of bldMap) {
+      const b = buildings[bIdx]
+      if (!b) continue
+      buildings[bIdx] = { ...b, levelDecor: (b.levelDecor ?? []).map((d, i) => idxs.has(i) ? { ...d, zlayer } : d) }
+    }
+    c = { ...c, buildings }
+  }
+
+  const roomMap = new Map<string, Set<number>>()
+  for (const e of entities) {
+    if (e.type !== 'interiorDecor') continue
+    if (!roomMap.has(e.interiorId)) roomMap.set(e.interiorId, new Set())
+    roomMap.get(e.interiorId)!.add(e.index)
+  }
+  if (roomMap.size) {
+    let interiors = { ...c.interiors }
+    for (const [roomId, idxs] of roomMap) {
+      const room = interiors[roomId]
+      if (!room) continue
+      interiors = { ...interiors, [roomId]: { ...room, decor: room.decor.map((d, i) => idxs.has(i) ? { ...d, zlayer } : d) } }
+    }
+    c = { ...c, interiors }
+  }
+
+  const festMap = new Map<string, Set<number>>()
+  for (const e of entities) {
+    if (e.type !== 'festivalDecor') continue
+    if (!festMap.has(e.festivalId)) festMap.set(e.festivalId, new Set())
+    festMap.get(e.festivalId)!.add(e.index)
+  }
+  if (festMap.size) {
+    c = {
+      ...c,
+      festivalDecor: (c.festivalDecor ?? []).map(g => {
+        const idxs = festMap.get(g.festivalId)
+        return idxs ? { ...g, decor: g.decor.map((d, i) => idxs.has(i) ? { ...d, zlayer } : d) } : g
+      }),
+    }
+  }
+  return c
+}
+
+export function applyBatchUpdateStreetPathType(
+  config: RawMapConfig, entities: SelectedEntity[], pathType: string | undefined,
+): RawMapConfig {
+  const idxs = indexSet(entities, 'street')
+  if (!idxs.size) return config
+  const streets = (config.streets ?? []).map((s, i) => {
+    if (!idxs.has(i)) return s
+    const next = { ...s, pathType }
+    if (!pathType) delete next.pathType
+    return next
+  })
+  return { ...config, streets }
+}

--- a/web/src/components/mapEditor/useMapEditorState.ts
+++ b/web/src/components/mapEditor/useMapEditorState.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback } from 'react'
 import type { RawMapConfig, RawNpc, RawAnimal, RawInterior, RawBuilding, RawDecorItem, RawLockedDoor, SelectedEntity, ToolMode, Zlayer, MapEditorState } from './mapEditorTypes'
+import { toggleInSelection, nextAreaId, convertStreetToPond as cSTP, convertPondToStreet as cPTS, applyDeleteEntities, applyBatchUpdateZlayer, applyBatchUpdateStreetPathType } from './multiSelectHelpers'
 
 type InteriorExit = NonNullable<RawInterior['exits']>[number]
 import hubConfig from '../../data/hub/ravenwatch/config.json'
@@ -49,6 +50,121 @@ function patchFestivalDecor(
   }) }
 }
 
+/** Apply a single entity move to a config, returning a new config (or the same if no-op). */
+function applyMove(prevConfig: RawMapConfig, entity: SelectedEntity, tx: number, ty: number): RawMapConfig {
+  let newConfig = prevConfig
+  if (entity.type === 'exteriorDecor') {
+    const decor = [...(prevConfig.exteriorDecor ?? [])]
+    if (!decor[entity.index]) return prevConfig
+    decor[entity.index] = { ...decor[entity.index], tx, ty }
+    newConfig = { ...prevConfig, exteriorDecor: decor }
+  } else if (entity.type === 'festivalDecor') {
+    newConfig = patchFestivalDecor(prevConfig, entity.festivalId, entity.index, { tx, ty })
+  } else if (entity.type === 'npc') {
+    const npcs = [...(prevConfig.npcs ?? [])]
+    if (!npcs[entity.index]) return prevConfig
+    npcs[entity.index] = { ...npcs[entity.index], tx, ty }
+    newConfig = { ...prevConfig, npcs }
+  } else if (entity.type === 'building') {
+    const buildings = [...(prevConfig.buildings ?? [])]
+    if (!buildings[entity.index]) return prevConfig
+    const b = buildings[entity.index]
+    const rects = b.rects ?? (b.rect ? [b.rect] : [])
+    const oldTx1 = rects[0]?.[0] ?? 0
+    const oldTy1 = rects[0]?.[1] ?? 0
+    const dx = tx - oldTx1, dy = ty - oldTy1
+    if (dx === 0 && dy === 0) return prevConfig
+    const newRects = rects.map(([rx1, ry1, rx2, ry2]) => [rx1 + dx, ry1 + dy, rx2 + dx, ry2 + dy] as [number, number, number, number])
+    buildings[entity.index] = b.rects ? { ...b, rects: newRects } : { ...b, rect: newRects[0] }
+    newConfig = { ...prevConfig, buildings }
+  } else if (entity.type === 'treasure') {
+    const treasures = [...(prevConfig.treasures ?? [])]
+    if (!treasures[entity.index]) return prevConfig
+    treasures[entity.index] = { ...treasures[entity.index], tx, ty }
+    newConfig = { ...prevConfig, treasures }
+  } else if (entity.type === 'pickupItem') {
+    const items = [...(prevConfig.pickupItems ?? [])]
+    if (!items[entity.index]) return prevConfig
+    items[entity.index] = { ...items[entity.index], tx, ty }
+    newConfig = { ...prevConfig, pickupItems: items }
+  } else if (entity.type === 'street') {
+    const streets = [...(prevConfig.streets ?? [])]
+    if (!streets[entity.index]) return prevConfig
+    const entry = streets[entity.index]
+    if (entry.rect) {
+      const [tx1, ty1, tx2, ty2] = entry.rect
+      const dx = tx - tx1, dy = ty - ty1
+      if (dx === 0 && dy === 0) return prevConfig
+      streets[entity.index] = { ...entry, rect: [tx1 + dx, ty1 + dy, tx2 + dx, ty2 + dy] }
+    } else if (entry.tile) {
+      streets[entity.index] = { ...entry, tile: [tx, ty] }
+    } else return prevConfig
+    newConfig = { ...prevConfig, streets }
+  } else if (entity.type === 'pondTile') {
+    const pondTiles = [...(prevConfig.pondTiles ?? [])]
+    if (!pondTiles[entity.index]) return prevConfig
+    const entry = pondTiles[entity.index]
+    if (entry.rect) {
+      const [tx1, ty1, tx2, ty2] = entry.rect
+      const dx = tx - tx1, dy = ty - ty1
+      if (dx === 0 && dy === 0) return prevConfig
+      pondTiles[entity.index] = { ...entry, rect: [tx1 + dx, ty1 + dy, tx2 + dx, ty2 + dy] }
+    } else if (entry.tile) {
+      pondTiles[entity.index] = { ...entry, tile: [tx, ty] }
+    } else return prevConfig
+    newConfig = { ...prevConfig, pondTiles }
+  } else if (entity.type === 'npcSpawnTile') {
+    const npcSpawnTiles = [...(prevConfig.npcSpawnTiles ?? [])]
+    if (!npcSpawnTiles[entity.index]) return prevConfig
+    npcSpawnTiles[entity.index] = [tx, ty]
+    newConfig = { ...prevConfig, npcSpawnTiles }
+  } else if (entity.type === 'animal') {
+    const animals = [...(prevConfig.animals ?? [])]
+    if (!animals[entity.index]) return prevConfig
+    animals[entity.index] = { ...animals[entity.index], tx, ty }
+    newConfig = { ...prevConfig, animals }
+  } else if (entity.type === 'area') {
+    const areas = [...(prevConfig.areas ?? [])]
+    if (!areas[entity.index]) return prevConfig
+    areas[entity.index] = { ...areas[entity.index], tx, ty }
+    newConfig = { ...prevConfig, areas }
+  } else if (entity.type === 'interactable') {
+    const items = [...(prevConfig.interactables ?? [])]
+    if (!items[entity.index]) return prevConfig
+    items[entity.index] = { ...items[entity.index], tx, ty }
+    newConfig = { ...prevConfig, interactables: items }
+  } else if (entity.type === 'exitTile') {
+    const tiles = [...(prevConfig.exitTiles ?? [])]
+    if (!tiles[entity.index]) return prevConfig
+    tiles[entity.index] = { ...tiles[entity.index], tx, ty }
+    newConfig = { ...prevConfig, exitTiles: tiles }
+  } else if (entity.type === 'chickenZone') {
+    const zones = [...(prevConfig.chickenZones ?? [])]
+    const z = zones[entity.index]
+    if (!z) return prevConfig
+    const [x1, y1, x2, y2] = z.rect
+    const dx = tx - x1, dy = ty - y1
+    if (dx === 0 && dy === 0) return prevConfig
+    zones[entity.index] = { ...z, rect: [x1 + dx, y1 + dy, x2 + dx, y2 + dy] }
+    newConfig = { ...prevConfig, chickenZones: zones }
+  } else if (entity.type === 'buildingLevelDecor') {
+    const buildings = [...(prevConfig.buildings ?? [])]
+    const b = buildings[entity.buildingIndex]
+    if (!b?.levelDecor?.[entity.index]) return prevConfig
+    const levelDecor = [...b.levelDecor]
+    levelDecor[entity.index] = { ...levelDecor[entity.index], tx, ty }
+    buildings[entity.buildingIndex] = { ...b, levelDecor }
+    newConfig = { ...prevConfig, buildings }
+  } else if (entity.type === 'interiorDecor' && prevConfig.interiors?.[entity.interiorId]) {
+    const interior = prevConfig.interiors[entity.interiorId]
+    const decor = [...interior.decor]
+    if (!decor[entity.index]) return prevConfig
+    decor[entity.index] = { ...decor[entity.index], tx, ty }
+    newConfig = { ...prevConfig, interiors: { ...prevConfig.interiors, [entity.interiorId]: { ...interior, decor } } }
+  }
+  return newConfig
+}
+
 export function useMapEditorState(initialMapId: MapId = 'ravenwatch', initialFestival: string | null = null) {
   const [state, setState] = useState<MapEditorState>(() => ({
     mapId:            initialMapId,
@@ -61,7 +177,7 @@ export function useMapEditorState(initialMapId: MapId = 'ravenwatch', initialFes
     activeInteriorId: null,
     activeLevel:      0,
     previewFestivalId: initialFestival,
-    selectedEntity:   null,
+    selectedEntities: [],
     undoStack:        [],
     redoStack:        [],
     isDirty:          false,
@@ -72,7 +188,7 @@ export function useMapEditorState(initialMapId: MapId = 'ravenwatch', initialFes
       ...s,
       mapId,
       configData:       structuredClone(RAW_CONFIGS[mapId]),
-      selectedEntity:   null,
+      selectedEntities: [],
       viewMode:         'exterior',
       activeInteriorId: null,
       activeLevel:      0,
@@ -87,7 +203,7 @@ export function useMapEditorState(initialMapId: MapId = 'ravenwatch', initialFes
   }, [])
 
   const setPreviewFestival = useCallback((previewFestivalId: string | null) => {
-    setState(s => ({ ...s, previewFestivalId, selectedEntity: null }))
+    setState(s => ({ ...s, previewFestivalId, selectedEntities: [] }))
   }, [])
 
   const setTool = useCallback((tool: ToolMode) => {
@@ -108,15 +224,19 @@ export function useMapEditorState(initialMapId: MapId = 'ravenwatch', initialFes
   }, [])
 
   const openInterior = useCallback((interiorId: string) => {
-    setState(s => ({ ...s, viewMode: 'interior', activeInteriorId: interiorId, activeLevel: 0, selectedEntity: null }))
+    setState(s => ({ ...s, viewMode: 'interior', activeInteriorId: interiorId, activeLevel: 0, selectedEntities: [] }))
   }, [])
 
   const closeInterior = useCallback(() => {
-    setState(s => ({ ...s, viewMode: 'exterior', activeInteriorId: null, activeLevel: 0, selectedEntity: null }))
+    setState(s => ({ ...s, viewMode: 'exterior', activeInteriorId: null, activeLevel: 0, selectedEntities: [] }))
   }, [])
 
-  const selectEntity = useCallback((entity: SelectedEntity | null) => {
-    setState(s => ({ ...s, selectedEntity: entity }))
+  const selectEntities = useCallback((entities: SelectedEntity[]) => {
+    setState(s => ({ ...s, selectedEntities: entities }))
+  }, [])
+
+  const addToSelection = useCallback((entity: SelectedEntity) => {
+    setState(s => ({ ...s, selectedEntities: toggleInSelection(s.selectedEntities, entity) }))
   }, [])
 
   const placeDecor = useCallback((tx: number, ty: number) => {
@@ -142,11 +262,11 @@ export function useMapEditorState(initialMapId: MapId = 'ravenwatch', initialFes
         // When a building is selected, exterior decor belongs to that building's
         // per-level decor (revealed by upgrade level). Otherwise it is ambient
         // exterior decor with no level association.
-        if (s.selectedEntity?.type === 'building') {
+        if (s.selectedEntities[0]?.type === 'building') {
           const buildings = [...(prevConfig.buildings ?? [])]
-          const b = buildings[s.selectedEntity.index]
+          const b = buildings[s.selectedEntities[0].index]
           if (!b) return s
-          buildings[s.selectedEntity.index] = { ...b, levelDecor: [...(b.levelDecor ?? []), newItem] }
+          buildings[s.selectedEntities[0].index] = { ...b, levelDecor: [...(b.levelDecor ?? []), newItem] }
           newConfig = { ...prevConfig, buildings }
         } else {
           newConfig = { ...prevConfig, exteriorDecor: [...(prevConfig.exteriorDecor ?? []), newItem] }
@@ -175,112 +295,13 @@ export function useMapEditorState(initialMapId: MapId = 'ravenwatch', initialFes
     })
   }, [])
 
-  const moveEntity = useCallback((entity: SelectedEntity, tx: number, ty: number) => {
+  const moveEntities = useCallback((moves: { entity: SelectedEntity; tx: number; ty: number }[]) => {
     setState(s => {
       const prevConfig = s.configData
       let newConfig = prevConfig
 
-      if (entity.type === 'exteriorDecor') {
-        const decor = [...(prevConfig.exteriorDecor ?? [])]
-        if (!decor[entity.index]) return s
-        decor[entity.index] = { ...decor[entity.index], tx, ty }
-        newConfig = { ...prevConfig, exteriorDecor: decor }
-      } else if (entity.type === 'festivalDecor') {
-        newConfig = patchFestivalDecor(prevConfig, entity.festivalId, entity.index, { tx, ty })
-      } else if (entity.type === 'npc') {
-        const npcs = [...(prevConfig.npcs ?? [])]
-        if (!npcs[entity.index]) return s
-        npcs[entity.index] = { ...npcs[entity.index], tx, ty }
-        newConfig = { ...prevConfig, npcs }
-      } else if (entity.type === 'building') {
-        const buildings = [...(prevConfig.buildings ?? [])]
-        if (!buildings[entity.index]) return s
-        const b = buildings[entity.index]
-        const rects = b.rects ?? (b.rect ? [b.rect] : [])
-        const oldTx1 = rects[0]?.[0] ?? 0
-        const oldTy1 = rects[0]?.[1] ?? 0
-        const dx = tx - oldTx1
-        const dy = ty - oldTy1
-        if (dx === 0 && dy === 0) return s
-        const newRects = rects.map(([rx1, ry1, rx2, ry2]) =>
-          [rx1 + dx, ry1 + dy, rx2 + dx, ry2 + dy] as [number, number, number, number],
-        )
-        buildings[entity.index] = b.rects
-          ? { ...b, rects: newRects }
-          : { ...b, rect: newRects[0] }
-        newConfig = { ...prevConfig, buildings }
-      } else if (entity.type === 'treasure') {
-        const treasures = [...(prevConfig.treasures ?? [])]
-        if (!treasures[entity.index]) return s
-        treasures[entity.index] = { ...treasures[entity.index], tx, ty }
-        newConfig = { ...prevConfig, treasures }
-      } else if (entity.type === 'pickupItem') {
-        const items = [...(prevConfig.pickupItems ?? [])]
-        if (!items[entity.index]) return s
-        items[entity.index] = { ...items[entity.index], tx, ty }
-        newConfig = { ...prevConfig, pickupItems: items }
-      } else if (entity.type === 'street') {
-        const streets = [...(prevConfig.streets ?? [])]
-        if (!streets[entity.index]) return s
-        const entry = streets[entity.index]
-        if (entry.rect) {
-          const [tx1, ty1, tx2, ty2] = entry.rect
-          const dx = tx - tx1
-          const dy = ty - ty1
-          if (dx === 0 && dy === 0) return s
-          streets[entity.index] = { ...entry, rect: [tx1 + dx, ty1 + dy, tx2 + dx, ty2 + dy] }
-        } else if (entry.tile) {
-          streets[entity.index] = { ...entry, tile: [tx, ty] }
-        } else {
-          return s
-        }
-        newConfig = { ...prevConfig, streets }
-      } else if (entity.type === 'animal') {
-        const animals = [...(prevConfig.animals ?? [])]
-        if (!animals[entity.index]) return s
-        animals[entity.index] = { ...animals[entity.index], tx, ty }
-        newConfig = { ...prevConfig, animals }
-      } else if (entity.type === 'area') {
-        const areas = [...(prevConfig.areas ?? [])]
-        if (!areas[entity.index]) return s
-        areas[entity.index] = { ...areas[entity.index], tx, ty }
-        newConfig = { ...prevConfig, areas }
-      } else if (entity.type === 'interactable') {
-        const items = [...(prevConfig.interactables ?? [])]
-        if (!items[entity.index]) return s
-        items[entity.index] = { ...items[entity.index], tx, ty }
-        newConfig = { ...prevConfig, interactables: items }
-      } else if (entity.type === 'exitTile') {
-        const tiles = [...(prevConfig.exitTiles ?? [])]
-        if (!tiles[entity.index]) return s
-        tiles[entity.index] = { ...tiles[entity.index], tx, ty }
-        newConfig = { ...prevConfig, exitTiles: tiles }
-      } else if (entity.type === 'chickenZone') {
-        const zones = [...(prevConfig.chickenZones ?? [])]
-        const z = zones[entity.index]
-        if (!z) return s
-        const [x1, y1, x2, y2] = z.rect
-        const dx = tx - x1, dy = ty - y1
-        if (dx === 0 && dy === 0) return s
-        zones[entity.index] = { ...z, rect: [x1 + dx, y1 + dy, x2 + dx, y2 + dy] }
-        newConfig = { ...prevConfig, chickenZones: zones }
-      } else if (entity.type === 'buildingLevelDecor') {
-        const buildings = [...(prevConfig.buildings ?? [])]
-        const b = buildings[entity.buildingIndex]
-        if (!b?.levelDecor?.[entity.index]) return s
-        const levelDecor = [...b.levelDecor]
-        levelDecor[entity.index] = { ...levelDecor[entity.index], tx, ty }
-        buildings[entity.buildingIndex] = { ...b, levelDecor }
-        newConfig = { ...prevConfig, buildings }
-      } else if (entity.type === 'interiorDecor' && prevConfig.interiors?.[entity.interiorId]) {
-        const interior = prevConfig.interiors[entity.interiorId]
-        const decor = [...interior.decor]
-        if (!decor[entity.index]) return s
-        decor[entity.index] = { ...decor[entity.index], tx, ty }
-        newConfig = {
-          ...prevConfig,
-          interiors: { ...prevConfig.interiors, [entity.interiorId]: { ...interior, decor } },
-        }
+      for (const { entity, tx, ty } of moves) {
+        newConfig = applyMove(newConfig, entity, tx, ty)
       }
 
       if (newConfig === prevConfig) return s
@@ -294,58 +315,160 @@ export function useMapEditorState(initialMapId: MapId = 'ravenwatch', initialFes
     })
   }, [])
 
-  const deleteEntity = useCallback((entity: SelectedEntity) => {
+  const deleteEntities = useCallback((entities: SelectedEntity[]) => {
     setState(s => {
       const prevConfig = s.configData
-      let newConfig = prevConfig
-
-      if (entity.type === 'exteriorDecor') {
-        newConfig = { ...prevConfig, exteriorDecor: (prevConfig.exteriorDecor ?? []).filter((_, i) => i !== entity.index) }
-      } else if (entity.type === 'festivalDecor') {
-        newConfig = { ...prevConfig, festivalDecor: (prevConfig.festivalDecor ?? []).map(g =>
-          g.festivalId === entity.festivalId ? { ...g, decor: g.decor.filter((_, i) => i !== entity.index) } : g) }
-      } else if (entity.type === 'npc') {
-        newConfig = { ...prevConfig, npcs: (prevConfig.npcs ?? []).filter((_, i) => i !== entity.index) }
-      } else if (entity.type === 'animal') {
-        newConfig = { ...prevConfig, animals: (prevConfig.animals ?? []).filter((_, i) => i !== entity.index) }
-      } else if (entity.type === 'building') {
-        newConfig = { ...prevConfig, buildings: (prevConfig.buildings ?? []).filter((_, i) => i !== entity.index) }
-      } else if (entity.type === 'street') {
-        newConfig = { ...prevConfig, streets: (prevConfig.streets ?? []).filter((_, i) => i !== entity.index) }
-      } else if (entity.type === 'treasure') {
-        newConfig = { ...prevConfig, treasures: (prevConfig.treasures ?? []).filter((_, i) => i !== entity.index) }
-      } else if (entity.type === 'pickupItem') {
-        newConfig = { ...prevConfig, pickupItems: (prevConfig.pickupItems ?? []).filter((_, i) => i !== entity.index) }
-      } else if (entity.type === 'interactable') {
-        newConfig = { ...prevConfig, interactables: (prevConfig.interactables ?? []).filter((_, i) => i !== entity.index) }
-      } else if (entity.type === 'exitTile') {
-        newConfig = { ...prevConfig, exitTiles: (prevConfig.exitTiles ?? []).filter((_, i) => i !== entity.index) }
-      } else if (entity.type === 'chickenZone') {
-        newConfig = { ...prevConfig, chickenZones: (prevConfig.chickenZones ?? []).filter((_, i) => i !== entity.index) }
-      } else if (entity.type === 'buildingLevelDecor' && prevConfig.buildings?.[entity.buildingIndex]?.levelDecor) {
-        const buildings = [...prevConfig.buildings]
-        const b = buildings[entity.buildingIndex]
-        buildings[entity.buildingIndex] = { ...b, levelDecor: (b.levelDecor ?? []).filter((_, i) => i !== entity.index) }
-        newConfig = { ...prevConfig, buildings }
-      } else if (entity.type === 'interiorDecor' && prevConfig.interiors?.[entity.interiorId]) {
-        const interior = prevConfig.interiors[entity.interiorId]
-        newConfig = {
-          ...prevConfig,
-          interiors: {
-            ...prevConfig.interiors,
-            [entity.interiorId]: { ...interior, decor: interior.decor.filter((_, i) => i !== entity.index) },
-          },
-        }
-      }
-
+      const newConfig = applyDeleteEntities(prevConfig, entities)
       if (newConfig === prevConfig) return s
       return {
         ...s,
-        configData:     newConfig,
-        selectedEntity: null,
-        undoStack:      [...s.undoStack, prevConfig].slice(-MAX_UNDO),
-        redoStack:      [],
-        isDirty:        true,
+        configData:       newConfig,
+        selectedEntities: [],
+        undoStack:        [...s.undoStack, prevConfig].slice(-MAX_UNDO),
+        redoStack:        [],
+        isDirty:          true,
+      }
+    })
+  }, [])
+
+  const addPondTile = useCallback((tx1: number, ty1: number, tx2: number, ty2: number) => {
+    setState(s => {
+      const prevConfig = s.configData
+      const entry = tx1 === tx2 && ty1 === ty2 ? { tile: [tx1, ty1] } : { rect: [tx1, ty1, tx2, ty2] }
+      const pondTiles = [...(prevConfig.pondTiles ?? []), entry]
+      const newIndex = pondTiles.length - 1
+      return {
+        ...s,
+        configData: { ...prevConfig, pondTiles },
+        selectedEntities: [{ type: 'pondTile' as const, index: newIndex }],
+        undoStack: [...s.undoStack, prevConfig].slice(-MAX_UNDO),
+        redoStack: [],
+        isDirty: true,
+      }
+    })
+  }, [])
+
+  const updatePondEntry = useCallback((index: number, data: { rect?: number[]; tile?: number[] }) => {
+    setState(s => {
+      const prevConfig = s.configData
+      const pondTiles = [...(prevConfig.pondTiles ?? [])]
+      if (!pondTiles[index]) return s
+      pondTiles[index] = { ...pondTiles[index], ...data }
+      return {
+        ...s,
+        configData: { ...prevConfig, pondTiles },
+        undoStack: [...s.undoStack, prevConfig].slice(-MAX_UNDO),
+        redoStack: [],
+        isDirty: true,
+      }
+    })
+  }, [])
+
+  const addNpcSpawnTile = useCallback((tx: number, ty: number) => {
+    setState(s => {
+      const prevConfig = s.configData
+      const npcSpawnTiles = [...(prevConfig.npcSpawnTiles ?? []), [tx, ty] as [number, number]]
+      const newIndex = npcSpawnTiles.length - 1
+      return {
+        ...s,
+        configData: { ...prevConfig, npcSpawnTiles },
+        selectedEntities: [{ type: 'npcSpawnTile' as const, index: newIndex }],
+        undoStack: [...s.undoStack, prevConfig].slice(-MAX_UNDO),
+        redoStack: [],
+        isDirty: true,
+      }
+    })
+  }, [])
+
+  const addChickenZone = useCallback((tx1: number, ty1: number, tx2: number, ty2: number) => {
+    setState(s => {
+      const prevConfig = s.configData
+      const chickenZones = [...(prevConfig.chickenZones ?? []), { rect: [tx1, ty1, tx2, ty2] as [number, number, number, number], count: 1 }]
+      const newIndex = chickenZones.length - 1
+      return {
+        ...s,
+        configData: { ...prevConfig, chickenZones },
+        selectedEntities: [{ type: 'chickenZone' as const, index: newIndex }],
+        undoStack: [...s.undoStack, prevConfig].slice(-MAX_UNDO),
+        redoStack: [],
+        isDirty: true,
+      }
+    })
+  }, [])
+
+  const addArea = useCallback((tx1: number, ty1: number, tx2: number, ty2: number) => {
+    setState(s => {
+      const prevConfig = s.configData
+      const id = nextAreaId(prevConfig.areas ?? [])
+      const areas = [...(prevConfig.areas ?? []), { id, name: id, tx: tx1, ty: ty1, tw: tx2 - tx1 + 1, th: ty2 - ty1 + 1 }]
+      const newIndex = areas.length - 1
+      return {
+        ...s,
+        configData: { ...prevConfig, areas },
+        selectedEntities: [{ type: 'area' as const, index: newIndex }],
+        undoStack: [...s.undoStack, prevConfig].slice(-MAX_UNDO),
+        redoStack: [],
+        isDirty: true,
+      }
+    })
+  }, [])
+
+  const convertStreetToPond = useCallback((index: number) => {
+    setState(s => {
+      const result = cSTP(s.configData, index)
+      if (!result) return s
+      return {
+        ...s,
+        configData: result.config,
+        selectedEntities: [{ type: 'pondTile' as const, index: result.pondIndex }],
+        undoStack: [...s.undoStack, s.configData].slice(-MAX_UNDO),
+        redoStack: [],
+        isDirty: true,
+      }
+    })
+  }, [])
+
+  const convertPondToStreet = useCallback((index: number) => {
+    setState(s => {
+      const result = cPTS(s.configData, index)
+      if (!result) return s
+      return {
+        ...s,
+        configData: result.config,
+        selectedEntities: [{ type: 'street' as const, index: result.streetIndex }],
+        undoStack: [...s.undoStack, s.configData].slice(-MAX_UNDO),
+        redoStack: [],
+        isDirty: true,
+      }
+    })
+  }, [])
+
+  const batchUpdateZlayer = useCallback((entities: SelectedEntity[], zlayer: Zlayer) => {
+    setState(s => {
+      const prevConfig = s.configData
+      const newConfig = applyBatchUpdateZlayer(prevConfig, entities, zlayer)
+      if (newConfig === prevConfig) return s
+      return {
+        ...s,
+        configData: newConfig,
+        undoStack: [...s.undoStack, prevConfig].slice(-MAX_UNDO),
+        redoStack: [],
+        isDirty: true,
+      }
+    })
+  }, [])
+
+  const batchUpdateStreetPathType = useCallback((entities: SelectedEntity[], pathType: string | undefined) => {
+    setState(s => {
+      const prevConfig = s.configData
+      const newConfig = applyBatchUpdateStreetPathType(prevConfig, entities, pathType)
+      if (newConfig === prevConfig) return s
+      return {
+        ...s,
+        configData: newConfig,
+        undoStack: [...s.undoStack, prevConfig].slice(-MAX_UNDO),
+        redoStack: [],
+        isDirty: true,
       }
     })
   }, [])
@@ -917,9 +1040,9 @@ export function useMapEditorState(initialMapId: MapId = 'ravenwatch', initialFes
         ...s,
         configData:     prevConfig,
         undoStack,
-        redoStack:      [s.configData, ...s.redoStack],
-        selectedEntity: null,
-        isDirty:        undoStack.length > 0,
+        redoStack:        [s.configData, ...s.redoStack],
+        selectedEntities: [],
+        isDirty:          undoStack.length > 0,
       }
     })
   }, [])
@@ -950,7 +1073,7 @@ export function useMapEditorState(initialMapId: MapId = 'ravenwatch', initialFes
       return {
         ...s,
         configData: { ...prevConfig, streets },
-        selectedEntity: { type: 'street' as const, index: newIndex },
+        selectedEntities: [{ type: 'street' as const, index: newIndex }],
         undoStack: [...s.undoStack, prevConfig].slice(-MAX_UNDO),
         redoStack: [],
         isDirty: true,
@@ -1010,8 +1133,8 @@ export function useMapEditorState(initialMapId: MapId = 'ravenwatch', initialFes
       const lockedDoors = (prevConfig.lockedDoors ?? []).filter((_, i) => i !== index)
       return {
         ...s,
-        configData:     { ...prevConfig, lockedDoors },
-        selectedEntity: null,
+        configData:       { ...prevConfig, lockedDoors },
+        selectedEntities: [],
         undoStack:      [...s.undoStack, prevConfig].slice(-MAX_UNDO),
         redoStack:      [],
         isDirty:        true,
@@ -1033,10 +1156,20 @@ export function useMapEditorState(initialMapId: MapId = 'ravenwatch', initialFes
     setPreviewFestival,
     openInterior,
     closeInterior,
-    selectEntity,
+    selectEntities,
+    addToSelection,
     placeDecor,
-    moveEntity,
-    deleteEntity,
+    moveEntities,
+    deleteEntities,
+    addPondTile,
+    updatePondEntry,
+    addNpcSpawnTile,
+    addChickenZone,
+    addArea,
+    convertStreetToPond,
+    convertPondToStreet,
+    batchUpdateZlayer,
+    batchUpdateStreetPathType,
     updateDecorZlayer,
     updateGlow,
     updateDecorMinLevel,

--- a/web/src/data/bundles/BundleEditor.stories.tsx
+++ b/web/src/data/bundles/BundleEditor.stories.tsx
@@ -1,0 +1,477 @@
+import React, { useRef, useState } from 'react'
+import * as PIXI from 'pixi.js'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import rawBundles from './bundles.json'
+import { saveBundles } from './bundleEditorApi'
+import { usePixiApp } from '../../hooks/usePixiApp'
+import { loadTileRef } from '../../utils/pixiHelpers'
+import { BASE_CHIP_TILES } from '../tiles/baseChipIndex'
+import { resolveTileRef } from '../tiles/tileIndex'
+
+const T   = 32
+const PAD = 1
+
+// ── Raw (on-disk) bundle shapes — what bundles.json actually stores ────────────
+
+type TileType = 'decor' | 'window' | 'door'
+type Zlayer   = 'solid' | 'below' | 'above'
+
+interface RawBundleTile {
+  type?:       TileType
+  tileID?:     string
+  x:           number
+  y:           number
+  zlayer?:     Zlayer
+  glow?:       boolean
+  glowRadius?: number
+  pulse?:      boolean
+  buildingId?: string
+  hideSign?:   boolean
+}
+
+interface RawBundle {
+  bundleID: string
+  tiles:    RawBundleTile[]
+}
+
+function resolveTileId(key?: string): number {
+  if (!key) return 0
+  return (BASE_CHIP_TILES as Record<string, number>)[key] ?? 0
+}
+
+// ── Tile thumbnail + picker ────────────────────────────────────────────────────
+
+const S = 22
+
+function TileThumb({ tileId }: { tileId: string }) {
+  const id = (BASE_CHIP_TILES as Record<string, number>)[tileId]
+  if (id === undefined) return <div style={{ width: S, height: S, background: '#311' }} />
+  if (id >= 10000) {
+    let ref: ReturnType<typeof resolveTileRef> | undefined
+    try { ref = resolveTileRef(id) } catch { /* unknown */ }
+    if (!ref) return <div style={{ width: S, height: S, background: '#311' }} />
+    const col = ref.id % ref.columns
+    const row = Math.floor(ref.id / ref.columns)
+    return (
+      <div style={{
+        width: S, height: S, flexShrink: 0, imageRendering: 'pixelated',
+        backgroundImage: `url("${ref.file}")`, backgroundRepeat: 'no-repeat',
+        backgroundSize: ref.columns === 1 ? `${S}px ${S}px` : `${ref.columns * S}px auto`,
+        backgroundPosition: ref.columns === 1 ? '0 0' : `-${col * S}px -${row * S}px`,
+      }} />
+    )
+  }
+  const COLS = 8
+  const col = id % COLS
+  const row = Math.floor(id / COLS)
+  return (
+    <div style={{
+      width: S, height: S, flexShrink: 0, imageRendering: 'pixelated',
+      backgroundImage: 'url("/world/SampleMap/[Base]BaseChip_pipo.png")',
+      backgroundRepeat: 'no-repeat', backgroundSize: `${COLS * S}px auto`,
+      backgroundPosition: `-${col * S}px -${row * S}px`,
+    }} />
+  )
+}
+
+function TilePicker({ current, onChange, onClose }: {
+  current?: string
+  onChange: (tileId: string) => void
+  onClose: () => void
+}) {
+  const [search, setSearch] = useState('')
+  const allIds = Object.keys(BASE_CHIP_TILES as Record<string, number>)
+  const filtered = search ? allIds.filter(id => id.toLowerCase().includes(search.toLowerCase())) : allIds
+  return (
+    <div style={{ marginTop: 4, background: '#0e0e1a', border: '1px solid #555', borderRadius: 4, padding: 6 }}>
+      <input
+        autoFocus value={search} onChange={e => setSearch(e.target.value)} placeholder="Filter tiles…"
+        style={{ width: '100%', padding: '3px 6px', background: '#111', border: '1px solid #444', color: '#eee', borderRadius: 3, fontSize: 11, boxSizing: 'border-box', marginBottom: 4 }}
+      />
+      <div style={{ maxHeight: 180, overflowY: 'auto', display: 'grid', gridTemplateColumns: `repeat(8, ${S}px)`, gap: 2 }}>
+        {filtered.slice(0, 400).map(id => (
+          <button
+            key={id} title={id} onClick={() => { onChange(id); onClose() }}
+            style={{
+              width: S, height: S, padding: 0, cursor: 'pointer', display: 'flex',
+              background: id === current ? '#2a4a7a' : 'transparent',
+              border: id === current ? '1px solid #5a8aee' : '1px solid transparent', borderRadius: 1,
+            }}
+          >
+            <TileThumb tileId={id} />
+          </button>
+        ))}
+      </div>
+      <button onClick={onClose} style={{ marginTop: 4, fontSize: 10, color: '#666', background: 'none', border: 'none', cursor: 'pointer', width: '100%' }}>
+        Cancel
+      </button>
+    </div>
+  )
+}
+
+// ── Canvas preview ──────────────────────────────────────────────────────────────
+
+function BundleCanvas({ bundle, scale }: { bundle: RawBundle; scale: number }) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const maxX = bundle.tiles.length > 0 ? Math.max(0, ...bundle.tiles.map(t => t.x)) : 0
+  const maxY = bundle.tiles.length > 0 ? Math.max(0, ...bundle.tiles.map(t => t.y)) : 0
+  const cols = maxX + 1 + PAD * 2
+  const rows = maxY + 1 + PAD * 2
+
+  usePixiApp(containerRef, cols * T * scale, rows * T * scale, (app) => {
+    app.stage.scale.set(scale)
+
+    const bg = new PIXI.Graphics()
+    for (let cx = 0; cx < cols; cx++)
+      for (let cy = 0; cy < rows; cy++)
+        bg.rect(cx * T, cy * T, T, T).fill({ color: (cx + cy) % 2 === 0 ? 0x1e1e2e : 0x16161f })
+    app.stage.addChild(bg)
+
+    const originG = new PIXI.Graphics()
+    originG.rect(PAD * T, (PAD + maxY) * T, T, T).fill({ color: 0x004400 })
+    app.stage.addChild(originG)
+
+    bundle.tiles.forEach(tile => {
+      const canvasX = (PAD + tile.x) * T
+      const canvasY = (PAD + maxY - tile.y) * T
+
+      if (tile.type === 'door') {
+        const g = new PIXI.Graphics()
+        g.rect(canvasX, canvasY, T, T).fill({ color: 0x663300 })
+        const label = new PIXI.Text({ text: 'D', style: { fontSize: 10, fill: 0xffcc88, fontFamily: 'monospace' } })
+        label.position.set(canvasX + 4, canvasY + 4)
+        app.stage.addChild(g, label)
+        return
+      }
+
+      const numId = resolveTileId(tile.tileID)
+      if (!numId) return
+      loadTileRef(numId).then(tex => {
+        if (!app.renderer) return
+        const s = new PIXI.Sprite(tex)
+        s.position.set(canvasX, canvasY)
+        s.width = T; s.height = T
+        if (tile.zlayer === 'above') s.alpha = 0.65
+        app.stage.addChild(s)
+        if (tile.glow) {
+          const halo = new PIXI.Graphics()
+          halo.circle(canvasX + T / 2, canvasY + T / 2, T / 2).fill({ color: 0xffdd66, alpha: 0.35 })
+          app.stage.addChild(halo)
+        }
+      }).catch(() => {})
+    })
+
+    const grid = new PIXI.Graphics()
+    grid.setStrokeStyle({ width: 0.5, color: 0x333355, alpha: 0.6 })
+    for (let cx = 0; cx <= cols; cx++) grid.moveTo(cx * T, 0).lineTo(cx * T, rows * T)
+    for (let cy = 0; cy <= rows; cy++) grid.moveTo(0, cy * T).lineTo(cols * T, cy * T)
+    grid.stroke()
+    app.stage.addChild(grid)
+  })
+
+  return <div ref={containerRef} />
+}
+
+// ── Per-tile editor row ─────────────────────────────────────────────────────────
+
+const num: React.CSSProperties = {
+  width: 44, padding: '2px 4px', background: '#111', border: '1px solid #444',
+  color: '#eee', borderRadius: 3, fontSize: 11,
+}
+const lbl: React.CSSProperties = { fontSize: 10, color: '#778' }
+
+function TileRow({ tile, onChange, onDelete, onDuplicate }: {
+  tile: RawBundleTile
+  onChange: (patch: Partial<RawBundleTile>) => void
+  onDelete: () => void
+  onDuplicate: () => void
+}) {
+  const [picking, setPicking] = useState(false)
+  const type = tile.type ?? 'decor'
+  const z = tile.zlayer ?? 'solid'
+
+  return (
+    <div style={{ border: '1px solid #2a2a44', borderRadius: 4, padding: 8, marginBottom: 6, background: '#13131f' }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6 }}>
+        <select
+          value={type}
+          onChange={e => onChange({ type: e.target.value as TileType })}
+          style={{ background: '#111', color: '#aaccdd', border: '1px solid #336', padding: '2px 4px', fontSize: 11, borderRadius: 3 }}
+        >
+          <option value="decor">decor</option>
+          <option value="window">window</option>
+          <option value="door">door</option>
+        </select>
+        <label style={lbl}>X<input type="number" value={tile.x} onChange={e => onChange({ x: Number(e.target.value) })} style={{ ...num, marginLeft: 3 }} /></label>
+        <label style={lbl}>Y<input type="number" value={tile.y} onChange={e => onChange({ y: Number(e.target.value) })} style={{ ...num, marginLeft: 3 }} /></label>
+        <div style={{ flex: 1 }} />
+        <button onClick={onDuplicate} title="Duplicate" style={{ background: '#1a2a3a', border: '1px solid #2a4a6a', color: '#8ad', borderRadius: 3, fontSize: 11, cursor: 'pointer', padding: '2px 6px' }}>⧉</button>
+        <button onClick={onDelete} title="Delete" style={{ background: '#3a1a1a', border: '1px solid #922', color: '#f88', borderRadius: 3, fontSize: 11, cursor: 'pointer', padding: '2px 6px' }}>✕</button>
+      </div>
+
+      {type !== 'door' && (
+        <>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6 }}>
+            <div
+              onClick={() => setPicking(p => !p)}
+              style={{ cursor: 'pointer', display: 'inline-flex', alignItems: 'center', gap: 6, padding: '2px 4px', borderRadius: 3, border: picking ? '1px solid #5a8aee' : '1px solid #333' }}
+              title="Click to change tile"
+            >
+              {tile.tileID ? <TileThumb tileId={tile.tileID} /> : <div style={{ width: S, height: S, background: '#222' }} />}
+              <span style={{ fontFamily: 'monospace', fontSize: 11, color: '#9ab' }}>{tile.tileID ?? '(pick tile)'} ✎</span>
+            </div>
+          </div>
+          {picking && <TilePicker current={tile.tileID} onChange={id => onChange({ tileID: id })} onClose={() => setPicking(false)} />}
+
+          <div style={{ display: 'flex', gap: 4, marginBottom: 6 }}>
+            {(['solid', 'below', 'above'] as Zlayer[]).map(zz => (
+              <button
+                key={zz}
+                onClick={() => onChange({ zlayer: zz })}
+                style={{
+                  padding: '3px 8px', fontSize: 11, cursor: 'pointer', borderRadius: 3, border: 'none',
+                  background: z === zz ? '#f0c040' : '#333', color: z === zz ? '#1a1a2e' : '#aaa',
+                }}
+              >{zz}</button>
+            ))}
+          </div>
+
+          {type === 'decor' && (
+            <div style={{ display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap' }}>
+              <label style={{ ...lbl, display: 'flex', alignItems: 'center', gap: 4, cursor: 'pointer' }}>
+                <input type="checkbox" checked={!!tile.glow} onChange={e => onChange({ glow: e.target.checked || undefined })} />
+                glow
+              </label>
+              {tile.glow && (
+                <>
+                  <label style={{ ...lbl, display: 'flex', alignItems: 'center', gap: 4 }}>
+                    radius
+                    <input type="range" min={1} max={8} step={0.5} value={tile.glowRadius ?? 2} onChange={e => onChange({ glowRadius: Number(e.target.value) })} style={{ width: 70 }} />
+                    <span style={{ color: '#aaa', width: 26 }}>{tile.glowRadius ?? 2}t</span>
+                  </label>
+                  <label style={{ ...lbl, display: 'flex', alignItems: 'center', gap: 4, cursor: 'pointer' }}>
+                    <input type="checkbox" checked={!!tile.pulse} onChange={e => onChange({ pulse: e.target.checked || undefined })} />
+                    pulse
+                  </label>
+                </>
+              )}
+            </div>
+          )}
+        </>
+      )}
+
+      {type === 'door' && (
+        <div style={{ display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap' }}>
+          <label style={lbl}>
+            buildingId
+            <input
+              value={tile.buildingId ?? ''}
+              onChange={e => onChange({ buildingId: e.target.value || undefined })}
+              style={{ ...num, width: 110, marginLeft: 4 }}
+            />
+          </label>
+          <label style={{ ...lbl, display: 'flex', alignItems: 'center', gap: 4, cursor: 'pointer' }}>
+            <input type="checkbox" checked={!!tile.hideSign} onChange={e => onChange({ hideSign: e.target.checked || undefined })} />
+            hideSign
+          </label>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ── Editor component ────────────────────────────────────────────────────────────
+
+function cleanTile(t: RawBundleTile): RawBundleTile {
+  const out: RawBundleTile = { x: t.x, y: t.y }
+  const type = t.type ?? 'decor'
+  if (type !== 'decor') out.type = type
+  if (type === 'door') {
+    if (t.buildingId) out.buildingId = t.buildingId
+    if (t.hideSign) out.hideSign = true
+  } else {
+    if (t.tileID) out.tileID = t.tileID
+    if (t.zlayer) out.zlayer = t.zlayer
+    if (type === 'decor') {
+      if (t.glow) out.glow = true
+      if (t.glow && t.glowRadius !== undefined) out.glowRadius = t.glowRadius
+      if (t.glow && t.pulse) out.pulse = true
+    }
+  }
+  return out
+}
+
+function serialize(bundles: RawBundle[]): RawBundle[] {
+  return bundles.map(b => ({ bundleID: b.bundleID, tiles: b.tiles.map(cleanTile) }))
+}
+
+function BundleEditor() {
+  const [bundles, setBundles] = useState<RawBundle[]>(
+    () => structuredClone(rawBundles) as RawBundle[],
+  )
+  const [selectedId, setSelectedId] = useState(bundles[0]?.bundleID ?? '')
+  const [scale, setScale] = useState(4)
+  const [saveState, setSaveState] = useState<'idle' | 'saving' | 'ok' | 'error'>('idle')
+  const [saveMsg, setSaveMsg] = useState('')
+
+  const idx = bundles.findIndex(b => b.bundleID === selectedId)
+  const bundle = idx >= 0 ? bundles[idx] : undefined
+
+  const patchBundle = (next: RawBundle) => {
+    setBundles(bs => bs.map((b, i) => i === idx ? next : b))
+  }
+
+  const updateTile = (tIdx: number, patch: Partial<RawBundleTile>) => {
+    if (!bundle) return
+    patchBundle({ ...bundle, tiles: bundle.tiles.map((t, i) => i === tIdx ? { ...t, ...patch } : t) })
+  }
+  const deleteTile = (tIdx: number) => {
+    if (!bundle) return
+    patchBundle({ ...bundle, tiles: bundle.tiles.filter((_, i) => i !== tIdx) })
+  }
+  const duplicateTile = (tIdx: number) => {
+    if (!bundle) return
+    const copy = { ...bundle.tiles[tIdx], x: bundle.tiles[tIdx].x + 1 }
+    const tiles = [...bundle.tiles]
+    tiles.splice(tIdx + 1, 0, copy)
+    patchBundle({ ...bundle, tiles })
+  }
+  const addTile = () => {
+    if (!bundle) return
+    patchBundle({ ...bundle, tiles: [...bundle.tiles, { type: 'decor', x: 0, y: 0, zlayer: 'solid' }] })
+  }
+
+  const renameBundle = (name: string) => {
+    if (!bundle) return
+    setBundles(bs => bs.map((b, i) => i === idx ? { ...b, bundleID: name } : b))
+    setSelectedId(name)
+  }
+
+  const newBundle = () => {
+    let n = 1
+    while (bundles.some(b => b.bundleID === `new-bundle-${n}`)) n++
+    const id = `new-bundle-${n}`
+    setBundles(bs => [...bs, { bundleID: id, tiles: [{ type: 'decor', x: 0, y: 0, zlayer: 'solid' }] }])
+    setSelectedId(id)
+  }
+
+  const deleteBundle = () => {
+    if (!bundle) return
+    if (!window.confirm(`Delete bundle "${bundle.bundleID}"?`)) return
+    const remaining = bundles.filter((_, i) => i !== idx)
+    setBundles(remaining)
+    setSelectedId(remaining[0]?.bundleID ?? '')
+  }
+
+  const handleSave = async () => {
+    setSaveState('saving'); setSaveMsg('')
+    try {
+      await saveBundles(serialize(bundles))
+      setSaveState('ok')
+      setTimeout(() => setSaveState('idle'), 2000)
+    } catch (e) {
+      setSaveState('error')
+      setSaveMsg(e instanceof Error ? e.message : String(e))
+      setTimeout(() => setSaveState('idle'), 4000)
+    }
+  }
+
+  const exportJson = () => {
+    navigator.clipboard?.writeText(JSON.stringify(serialize(bundles), null, 2))
+    setSaveMsg('Copied JSON to clipboard'); setTimeout(() => setSaveMsg(''), 2000)
+  }
+
+  const dupBundleId = bundles.filter(b => b.bundleID === selectedId).length > 1
+
+  const btn: React.CSSProperties = {
+    padding: '4px 10px', background: '#1e2a4e', border: '1px solid #3a4a8e',
+    color: '#8af', borderRadius: 3, fontSize: 12, cursor: 'pointer',
+  }
+
+  return (
+    <div style={{ background: '#0a0a18', minHeight: '100vh', color: '#aabbcc', fontFamily: 'monospace', padding: 20 }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 16, flexWrap: 'wrap' }}>
+        <strong style={{ fontSize: 13, color: '#88ccff' }}>Bundle Editor</strong>
+        <select
+          value={selectedId}
+          onChange={e => setSelectedId(e.target.value)}
+          style={{ background: '#111', color: '#88ccff', border: '1px solid #336', padding: '4px 10px', fontFamily: 'monospace', fontSize: 12 }}
+        >
+          {bundles.map(b => <option key={b.bundleID} value={b.bundleID}>{b.bundleID}</option>)}
+        </select>
+        <button style={{ ...btn, background: '#1e2e1e', borderColor: '#3a5a3a', color: '#6d6' }} onClick={newBundle}>+ New bundle</button>
+        <button style={{ ...btn, background: '#3a1a1a', borderColor: '#922', color: '#f88' }} onClick={deleteBundle} disabled={!bundle}>Delete bundle</button>
+
+        <label style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 12 }}>
+          Scale
+          <input type="range" min={2} max={6} step={1} value={scale} onChange={e => setScale(Number(e.target.value))} style={{ width: 80 }} />
+          {scale}×
+        </label>
+
+        <div style={{ flex: 1 }} />
+        {saveMsg && <span style={{ color: saveState === 'error' ? '#f66' : '#8d8', fontSize: 11 }}>{saveMsg}</span>}
+        <button style={btn} onClick={exportJson}>Copy JSON</button>
+        <button
+          style={{ ...btn, background: saveState === 'ok' ? '#1e4e1e' : '#2a4e2a', color: '#8d8', fontWeight: 'bold' }}
+          onClick={handleSave}
+          disabled={saveState === 'saving'}
+        >
+          {saveState === 'saving' ? '…' : saveState === 'ok' ? '✓ Saved' : 'Save bundles.json'}
+        </button>
+      </div>
+
+      {bundle ? (
+        <div style={{ display: 'flex', gap: 32, alignItems: 'flex-start', flexWrap: 'wrap' }}>
+          <div>
+            <div style={{ background: '#111122', border: '1px solid #334', display: 'inline-block', marginBottom: 8 }}>
+              <BundleCanvas key={`${selectedId}-${scale}-${bundle.tiles.length}-${JSON.stringify(bundle.tiles)}`} bundle={bundle} scale={scale} />
+            </div>
+            <div style={{ fontSize: 11, color: '#668' }}>
+              Origin (0,0) = <span style={{ color: '#44ff88' }}>■</span> green · above-layer at 65% · glow shown as halo
+            </div>
+          </div>
+
+          <div style={{ minWidth: 360, maxWidth: 440 }}>
+            <label style={{ ...lbl, display: 'block', marginBottom: 10 }}>
+              Bundle ID
+              <input
+                value={bundle.bundleID}
+                onChange={e => renameBundle(e.target.value)}
+                style={{ display: 'block', width: '100%', marginTop: 3, padding: '4px 6px', background: '#111', border: `1px solid ${dupBundleId ? '#922' : '#444'}`, color: '#eee', borderRadius: 3, fontSize: 12, boxSizing: 'border-box' }}
+              />
+              {dupBundleId && <span style={{ color: '#f88' }}>duplicate id — last one wins on load</span>}
+            </label>
+
+            <div style={{ fontSize: 12, color: '#668', marginBottom: 6 }}>{bundle.tiles.length} tiles</div>
+            {bundle.tiles.map((t, i) => (
+              <TileRow
+                key={i}
+                tile={t}
+                onChange={patch => updateTile(i, patch)}
+                onDelete={() => deleteTile(i)}
+                onDuplicate={() => duplicateTile(i)}
+              />
+            ))}
+            <button style={{ ...btn, width: '100%', background: '#1e2e1e', borderColor: '#3a5a3a', color: '#6d6' }} onClick={addTile}>
+              + Add tile
+            </button>
+          </div>
+        </div>
+      ) : (
+        <div style={{ color: '#664444', padding: 20 }}>No bundle selected.</div>
+      )}
+    </div>
+  )
+}
+
+// ── Storybook meta ──────────────────────────────────────────────────────────────
+
+const meta = {
+  component: BundleEditor,
+  parameters: { layout: 'fullscreen' },
+} satisfies Meta<typeof BundleEditor>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Editor: Story = {}

--- a/web/src/data/bundles/bundleEditorApi.ts
+++ b/web/src/data/bundles/bundleEditorApi.ts
@@ -1,0 +1,13 @@
+// Persist the edited bundle registry back to src/data/bundles/bundles.json.
+// Backed by the dev-server middleware registered in .storybook/main.ts.
+export async function saveBundles(data: unknown): Promise<void> {
+  const res = await fetch('/api/bundle-editor/save', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ data }),
+  })
+  if (!res.ok) {
+    const text = await res.text().catch(() => res.statusText)
+    throw new Error(`Save failed: ${text}`)
+  }
+}

--- a/web/src/data/bundles/bundleLoader.ts
+++ b/web/src/data/bundles/bundleLoader.ts
@@ -10,6 +10,9 @@ export interface BundleTileEntry {
   x:           number
   y:           number
   zlayer?:     string
+  glow?:       boolean         // night light glow (decor entries)
+  glowRadius?: number          // glow radius in tiles
+  pulse?:      boolean         // animate the glow radius
   buildingId?: string          // for type="door" entries
   hideSign?: boolean          // for type="door" entries
 }
@@ -37,7 +40,11 @@ for (const raw of rawBundles as Array<Record<string, unknown>>) {
     x:          (t['x'] as number) ?? 0,
     y:          (t['y'] as number) ?? 0,
     zlayer:     t['zlayer'] as string | undefined,
+    glow:       t['glow'] as boolean | undefined,
+    glowRadius: t['glowRadius'] as number | undefined,
+    pulse:      t['pulse'] as boolean | undefined,
     buildingId: t['buildingId'] as string | undefined,
+    hideSign:   t['hideSign'] as boolean | undefined,
   }))
   BUNDLE_REGISTRY.set(id, { bundleID: id, tiles })
 }
@@ -55,12 +62,12 @@ export function expandBundleDecor(
   bundleID: string,
   originTx: number,
   originTy: number,
-): { tx: number; ty: number; tileId: number; zlayer?: string }[] {
+): { tx: number; ty: number; tileId: number; zlayer?: string; glow?: boolean; glowRadius?: number; pulse?: boolean }[] {
   const bundle = BUNDLE_REGISTRY.get(bundleID)
   if (!bundle) { console.warn(`[bundles] Unknown bundleID: "${bundleID}"`); return [] }
   return bundle.tiles
     .filter(t => t.type === 'decor')
-    .map(t => ({ tx: originTx + t.x, ty: originTy - t.y, tileId: t.tileId, zlayer: t.zlayer }))
+    .map(t => ({ tx: originTx + t.x, ty: originTy - t.y, tileId: t.tileId, zlayer: t.zlayer, glow: t.glow, glowRadius: t.glowRadius, pulse: t.pulse }))
 }
 
 /** Expand window tiles from a bundle at the given bottom-left origin. */


### PR DESCRIPTION
Implements issues #1757–#1765.

## Map Editor: multi-select, draw tools & road↔pond toggle (#1757–#1764)

- **#1757 — Types + helpers:** Added `pond | spawn | chickenZone | area` to `ToolMode`, `pondTile` / `npcSpawnTile` to `SelectedEntity`, replaced `selectedEntity` with `selectedEntities: SelectedEntity[]` in `MapEditorState`. New pure `multiSelectHelpers.ts` (`toggleInSelection`, `convertStreetToPond`/`convertPondToStreet`, `applyDeleteEntities`, batch z-layer / path-type, etc.) with full unit tests.
- **#1758 — State hook:** `selectEntities`/`addToSelection`, batched `moveEntities` (single undo step, extracted module-level `applyMove`), `deleteEntities`, and new actions: `addPondTile`, `updatePondEntry`, `addNpcSpawnTile`, `addChickenZone`, `addArea`, `convertStreetToPond`/`convertPondToStreet`, `batchUpdateZlayer`, `batchUpdateStreetPathType`.
- **#1759 — Toolbar:** four new tool buttons (pond / spawn / chickenZone / area).
- **#1760–#1761 — Canvas:** multi-select highlight, shift+click toggle, group drag with per-entity offsets, generic rect-draw (street/pond/chickenZone/area), interactive pond tiles, spawn-tile crosshairs, always-on chicken-zone overlay; `hitTest`/`getEntityTx`/`getEntityTy` extended for all entity types.
- **#1762–#1763 — Inspector:** `MultiSelectPanel` (batch z-layer / path-type / delete), `PondInspector` & `SpawnTileInspector`, and Convert-to-Pond / Convert-to-Street buttons.
- **#1764 — Orchestration:** wired everything in `MapEditor.tsx` (pickupItem moves/deletes still routed to questDefs). `tsc --noEmit` clean, all tests pass.

## Bundle Editor (#1765)

Turned the read-only bundle viewer into a full create/edit tool (`BundleEditor.stories.tsx`): add/rename/delete bundles and tiles, change tile (searchable picker), toggle z-layer (solid/below/above), glow + radius + pulse for decor, door `buildingId`/`hideSign`, live canvas preview with glow halo. Saves back to `bundles.json` via a new dev-server endpoint, plus copy-to-clipboard JSON export. `bundleLoader` now carries glow fields through `expandBundleDecor`.

## Verification

- `cd web && npx tsc --noEmit` → 0 errors
- `cd web && npx vitest run` → 783 tests passed (186 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8a2eFQ4aekp6DK2TSNnCj)_