### PR TITLE
Expand Gravemoor to Tier C (#1743)

### DIFF
--- a/web/public/sprites/hub-npc-child.svg
+++ b/web/public/sprites/hub-npc-child.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- faint shadow -->
+  <ellipse cx="16" cy="29" rx="4" ry="1.5" fill="rgba(0,0,0,0.12)"/>
+  <!-- nightgown (small, tapering to a wispy hem) -->
+  <path d="M11 16 Q16 14 21 16 L22 26 Q16 29 10 26 Z" fill="#dfe6ef"/>
+  <!-- gentle hem wisps -->
+  <path d="M10 26 q2 2 3 0 q1.5 2 3 0 q1.5 2 3 0 q1.5 2 3 0" fill="none" stroke="#c4cdda" stroke-width="1"/>
+  <!-- arms (small) -->
+  <rect x="9"  y="17" width="2.5" height="6" rx="1" fill="#dfe6ef"/>
+  <rect x="20.5" y="17" width="2.5" height="6" rx="1" fill="#dfe6ef"/>
+  <!-- head (small child) -->
+  <circle cx="16" cy="11" r="4.5" fill="#eef2f7"/>
+  <!-- short tousled hair -->
+  <path d="M11.5 9 Q16 4 20.5 9 Q18 7.5 16 8 Q14 7.5 11.5 9 Z" fill="#c8cfd9"/>
+  <!-- big sad eyes -->
+  <rect x="13.5" y="10" width="2" height="2.5" rx="1" fill="#3a4a5a"/>
+  <rect x="16.5" y="10" width="2" height="2.5" rx="1" fill="#3a4a5a"/>
+</svg>

--- a/web/public/sprites/hub-npc-gravedigger.svg
+++ b/web/public/sprites/hub-npc-gravedigger.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- shadow -->
+  <ellipse cx="16" cy="29" rx="5" ry="2" fill="rgba(0,0,0,0.2)"/>
+  <!-- shovel handle -->
+  <rect x="23" y="6" width="2" height="20" rx="1" fill="#6b4020"/>
+  <!-- shovel blade -->
+  <rect x="21" y="24" width="6" height="5" rx="1" fill="#8a8f96"/>
+  <rect x="23" y="4" width="2" height="3" rx="1" fill="#6b4020"/>
+  <!-- coat -->
+  <rect x="10" y="13" width="12" height="15" rx="2" fill="#4a4036"/>
+  <!-- mud-stained apron -->
+  <rect x="12" y="16" width="8" height="11" rx="1" fill="#5e5346"/>
+  <!-- arms -->
+  <rect x="8"  y="14" width="3" height="9" rx="1" fill="#4a4036"/>
+  <rect x="21" y="14" width="3" height="9" rx="1" fill="#4a4036"/>
+  <!-- hands -->
+  <circle cx="9" cy="23" r="2" fill="#c89878"/>
+  <circle cx="23" cy="23" r="2" fill="#c89878"/>
+  <!-- stubble jaw -->
+  <rect x="12" y="11" width="8" height="4" rx="2" fill="#7a6a55"/>
+  <!-- head -->
+  <circle cx="16" cy="9" r="5" fill="#c89878"/>
+  <!-- flat cap -->
+  <rect x="10" y="4" width="12" height="4" rx="2" fill="#3a3128"/>
+  <rect x="10" y="6" width="13" height="2" rx="1" fill="#2c241c"/>
+  <!-- eyes -->
+  <rect x="13" y="8" width="2" height="2" rx="1" fill="#2a1a0a"/>
+  <rect x="17" y="8" width="2" height="2" rx="1" fill="#2a1a0a"/>
+</svg>

--- a/web/src/data/hub/gravemoor/config.json
+++ b/web/src/data/hub/gravemoor/config.json
@@ -1,6 +1,6 @@
 {
-  "mapW": 960,
-  "mapH": 704,
+  "mapW": 1408,
+  "mapH": 960,
   "townName": "Gravemoor",
   "environment": "ashen",
   "avatarStart": { "tx": 15, "ty": 20 },
@@ -9,13 +9,24 @@
     { "tx": 15, "ty": 21, "screen": "worldmap" }
   ],
   "areas": [
-    { "id": "gravemoor-cemetery", "name": "The Old Cemetery", "tx": 3, "ty": 12, "tw": 11, "th": 7 },
-    { "id": "gravemoor-square", "name": "The Quiet Square", "tx": 13, "ty": 10, "tw": 6, "th": 4 }
+    { "id": "gravemoor-cemetery", "name": "The Old Cemetery", "tx": 3, "ty": 13, "tw": 11, "th": 6 },
+    { "id": "gravemoor-square", "name": "The Quiet Square", "tx": 17, "ty": 12, "tw": 9, "th": 5 },
+    { "id": "gravemoor-wood", "name": "The Whispering Wood", "tx": 27, "ty": 12, "tw": 16, "th": 14 },
+    { "id": "gravemoor-gallows", "name": "The Gallows Yard", "tx": 3, "ty": 19, "tw": 22, "th": 7 }
   ],
   "streets": [
-    { "rect": [14, 2, 16, 21] },
-    { "rect": [4, 10, 26, 11] },
-    { "rect": [21, 12, 22, 14] }
+    { "rect": [14, 2, 16, 28] },
+    { "rect": [4, 11, 38, 12] },
+    { "rect": [4, 27, 42, 28] },
+    { "rect": [26, 12, 26, 27] },
+    { "rect": [8, 13, 8, 17] },
+    { "rect": [8, 10, 8, 10] },
+    { "rect": [22, 10, 22, 10] },
+    { "rect": [31, 10, 31, 10] },
+    { "rect": [6, 26, 6, 26] },
+    { "rect": [22, 26, 22, 26] },
+    { "rect": [30, 26, 30, 26] },
+    { "rect": [38, 26, 38, 26] }
   ],
   "buildings": [
     {
@@ -24,64 +35,190 @@
       "rect": [4, 2, 12, 9],
       "wall": "darkStone",
       "roof": "greySlateRoof",
-      "doors": [
-        { "tx": 4, "ty": 1, "hideSign": true, "buildingId": "mourning-hall" }
-      ]
+      "doors": [ { "tx": 4, "ty": 1, "hideSign": true, "buildingId": "mourning-hall" } ]
     },
     {
       "id": "crypt-keep",
       "upgradeKind": "default",
-      "rect": [19, 2, 26, 8],
+      "rect": [18, 2, 25, 9],
       "wall": "darkStone",
       "roof": "greySlateRoof",
-      "doors": [
-        { "tx": 3, "ty": 1, "hideSign": true, "buildingId": "crypt-keep" }
-      ]
+      "doors": [ { "tx": 4, "ty": 1, "hideSign": true, "buildingId": "crypt-keep" } ]
+    },
+    {
+      "id": "gravedigger-shed",
+      "upgradeKind": "default",
+      "rect": [28, 3, 34, 9],
+      "wall": "darkStone",
+      "roof": "greySlateRoof",
+      "doors": [ { "tx": 3, "ty": 1, "hideSign": true, "buildingId": "gravedigger-shed" } ]
+    },
+    {
+      "id": "undertaker",
+      "upgradeKind": "shop",
+      "rect": [3, 19, 9, 25],
+      "wall": "darkStone",
+      "roof": "greySlateRoof",
+      "doors": [ { "tx": 3, "ty": 1, "hideSign": true, "buildingId": "undertaker" } ]
+    },
+    {
+      "id": "mausoleum-chapel",
+      "upgradeKind": "shrine",
+      "rect": [18, 19, 25, 25],
+      "wall": "darkStone",
+      "roof": "greySlateRoof",
+      "doors": [ { "tx": 4, "ty": 1, "hideSign": true, "buildingId": "mausoleum-chapel" } ]
+    },
+    {
+      "id": "ruined-town-hall",
+      "upgradeKind": "default",
+      "rect": [27, 19, 33, 25],
+      "wall": "darkStone",
+      "roof": "greySlateRoof",
+      "doors": [ { "tx": 3, "ty": 1, "hideSign": true, "buildingId": "ruined-town-hall" } ]
+    },
+    {
+      "id": "haunted-inn",
+      "upgradeKind": "inn",
+      "rect": [35, 19, 41, 25],
+      "wall": "darkStone",
+      "roof": "greySlateRoof",
+      "doors": [ { "tx": 3, "ty": 1, "hideSign": true, "buildingId": "haunted-inn" } ]
     }
   ],
   "exteriorDecor": [
-    { "comment": "the old cemetery" },
+    { "comment": "=== woodland: left edge ===" },
+    { "tx": 0, "ty": 3, "bundleID": "dead-tree", "zlayer": "solid" },
+    { "tx": 0, "ty": 6, "bundleID": "dark-tree", "zlayer": "solid" },
+    { "tx": 0, "ty": 9, "bundleID": "dead-tree", "zlayer": "solid" },
+    { "tx": 0, "ty": 14, "bundleID": "dark-tree", "zlayer": "solid" },
+    { "tx": 0, "ty": 17, "bundleID": "dead-tree", "zlayer": "solid" },
+    { "tx": 0, "ty": 21, "bundleID": "dark-tree", "zlayer": "solid" },
+    { "tx": 0, "ty": 24, "bundleID": "dead-tree", "zlayer": "solid" },
+    { "tx": 2, "ty": 6, "bundleID": "dead-tree", "zlayer": "solid" },
+    { "comment": "=== woodland: top edge ===" },
+    { "tx": 4, "ty": 0, "bundleID": "dark-tree", "zlayer": "solid" },
+    { "tx": 9, "ty": 0, "bundleID": "dead-tree", "zlayer": "solid" },
+    { "tx": 18, "ty": 0, "bundleID": "dark-tree", "zlayer": "solid" },
+    { "tx": 22, "ty": 0, "bundleID": "dead-tree", "zlayer": "solid" },
+    { "tx": 27, "ty": 0, "bundleID": "dark-tree", "zlayer": "solid" },
+    { "tx": 31, "ty": 0, "bundleID": "dead-tree", "zlayer": "solid" },
+    { "tx": 36, "ty": 0, "bundleID": "dark-tree", "zlayer": "solid" },
+    { "tx": 40, "ty": 0, "bundleID": "dead-tree", "zlayer": "solid" },
+    { "comment": "=== woodland: right edge ===" },
+    { "tx": 42, "ty": 3, "bundleID": "dead-tree", "zlayer": "solid" },
+    { "tx": 42, "ty": 7, "bundleID": "dark-tree", "zlayer": "solid" },
+    { "tx": 42, "ty": 11, "bundleID": "dead-tree", "zlayer": "solid" },
+    { "tx": 42, "ty": 15, "bundleID": "dark-tree", "zlayer": "solid" },
+    { "tx": 42, "ty": 19, "bundleID": "dead-tree", "zlayer": "solid" },
+    { "tx": 42, "ty": 23, "bundleID": "dark-tree", "zlayer": "solid" },
+    { "comment": "=== woodland: the whispering wood (central-right clusters) ===" },
+    { "tx": 28, "ty": 15, "bundleID": "dark-tree-cluster-V", "zlayer": "solid" },
+    { "tx": 34, "ty": 15, "bundleID": "mixed-tree-cluster-V", "zlayer": "solid" },
+    { "tx": 38, "ty": 13, "bundleID": "dark-tree-cluster-V", "zlayer": "solid" },
+    { "tx": 33, "ty": 13, "bundleID": "dead-tree", "zlayer": "solid" },
+    { "tx": 24, "ty": 13, "bundleID": "dead-tree", "zlayer": "solid" },
+    { "comment": "=== the old cemetery: graves (path spur runs down x8) ===" },
     { "tx": 4, "ty": 13, "tileId": "graveStone" },
-    { "tx": 7, "ty": 13, "tileId": "graveWoodenCross" },
+    { "tx": 6, "ty": 13, "tileId": "graveWoodenCross" },
     { "tx": 10, "ty": 13, "tileId": "graveStone" },
+    { "tx": 12, "ty": 13, "tileId": "graveWoodenCross" },
     { "tx": 5, "ty": 15, "tileId": "graveWoodenCross" },
-    { "tx": 8, "ty": 15, "tileId": "graveStone" },
-    { "tx": 11, "ty": 15, "tileId": "graveWoodenCross" },
+    { "tx": 6, "ty": 15, "tileId": "graveStone" },
+    { "tx": 10, "ty": 15, "tileId": "graveStone" },
+    { "tx": 11, "ty": 15, "tileId": "stoneCross" },
+    { "tx": 13, "ty": 15, "tileId": "graveWoodenCross" },
     { "tx": 4, "ty": 17, "tileId": "graveStone" },
-    { "tx": 9, "ty": 17, "tileId": "graveStone" },
+    { "tx": 6, "ty": 17, "tileId": "graveWoodenCross" },
+    { "tx": 10, "ty": 17, "tileId": "graveStone" },
     { "tx": 12, "ty": 17, "tileId": "graveWoodenCross" },
-    { "comment": "dead trees ring the town" },
-    { "tx": 2, "ty": 4, "bundleID": "dead-tree", "zlayer": "solid" },
-    { "tx": 16, "ty": 4, "bundleID": "dead-tree", "zlayer": "solid" },
-    { "tx": 27, "ty": 12, "bundleID": "dead-tree", "zlayer": "solid" },
-    { "tx": 20, "ty": 17, "bundleID": "dead-tree", "zlayer": "solid" },
-    { "tx": 2, "ty": 19, "bundleID": "dead-tree", "zlayer": "solid" },
-    { "tx": 25, "ty": 19, "bundleID": "dead-tree", "zlayer": "solid" },
-    { "comment": "remains of the living town" },
-    { "tx": 17, "ty": 12, "tileId": "stoneWell" },
-    { "tx": 13, "ty": 9, "tileId": "skull" },
-    { "tx": 24, "ty": 15, "tileId": "smallRock" },
-    { "tx": 18, "ty": 9, "tileId": "barrel" },
-    { "comment": "braziers that no one remembers lighting" },
-    { "tx": 13, "ty": 11, "tileId": "brazierBottom" },
-    { "tx": 13, "ty": 10, "tileId": "brazierTop", "zlayer": "above" },
-    { "tx": 18, "ty": 11, "tileId": "brazierBottom" },
-    { "tx": 18, "ty": 10, "tileId": "brazierTop", "zlayer": "above" }
+    { "tx": 4, "ty": 18, "tileId": "graveStone" },
+    { "tx": 11, "ty": 18, "tileId": "stoneCross" },
+    { "comment": "cemetery monuments" },
+    { "tx": 5, "ty": 14, "tileId": "angelStatueBottom" },
+    { "tx": 5, "ty": 13, "tileId": "angelStatueTop", "zlayer": "above" },
+    { "tx": 12, "ty": 15, "tileId": "memorialTopLeft" },
+    { "tx": 13, "ty": 15, "tileId": "memorialTopRight" },
+    { "tx": 12, "ty": 16, "tileId": "memorialBotLeft" },
+    { "tx": 13, "ty": 16, "tileId": "memorialBotRight" },
+    { "comment": "cemetery iron fence (south + west, gate gap at the spur x8)" },
+    { "tx": 3, "ty": 13, "tileId": "ironFenceTopBotton" },
+    { "tx": 3, "ty": 14, "tileId": "ironFenceTopBotton" },
+    { "tx": 3, "ty": 15, "tileId": "ironFenceTopBotton" },
+    { "tx": 3, "ty": 16, "tileId": "ironFenceTopBotton" },
+    { "tx": 3, "ty": 17, "tileId": "ironFenceTopBotton" },
+    { "tx": 4, "ty": 19, "tileId": "ironFenceLeftRight" },
+    { "tx": 5, "ty": 19, "tileId": "ironFenceLeftRight" },
+    { "tx": 6, "ty": 19, "tileId": "ironFenceLeftRight" },
+    { "tx": 7, "ty": 19, "tileId": "ironFenceLeftRight" },
+    { "tx": 10, "ty": 19, "tileId": "ironFenceLeftRight" },
+    { "tx": 11, "ty": 19, "tileId": "ironFenceLeftRight" },
+    { "tx": 12, "ty": 19, "tileId": "ironFenceLeftRight" },
+    { "comment": "=== the quiet square ===" },
+    { "tx": 18, "ty": 14, "tileId": "stoneWell" },
+    { "tx": 20, "ty": 13, "bundleID": "brazier", "zlayer": "solid", "glow": true, "glowRadius": 3 },
+    { "tx": 23, "ty": 16, "bundleID": "brazier", "zlayer": "solid", "glow": true, "glowRadius": 3 },
+    { "tx": 24, "ty": 14, "tileId": "skull" },
+    { "tx": 17, "ty": 16, "tileId": "smallRock" },
+    { "comment": "=== the spectral market stall (open-air, by the upper road) ===" },
+    { "tx": 19, "ty": 13, "tileId": "counterTop" },
+    { "tx": 21, "ty": 13, "tileId": "counterTop" },
+    { "tx": 21, "ty": 12, "tileId": "skullSign", "zlayer": "above" },
+    { "tx": 22, "ty": 13, "tileId": "barrel", "zlayer": "solid" },
+    { "comment": "=== the gallows yard / lonely graves among the wood ===" },
+    { "tx": 27, "ty": 18, "tileId": "graveWoodenCross" },
+    { "tx": 32, "ty": 17, "tileId": "graveStone" },
+    { "tx": 37, "ty": 17, "tileId": "graveWoodenCross" },
+    { "tx": 40, "ty": 16, "tileId": "stoneCross" },
+    { "tx": 11, "ty": 22, "tileId": "graveStone" },
+    { "tx": 13, "ty": 23, "tileId": "graveWoodenCross" },
+    { "tx": 17, "ty": 23, "tileId": "graveStone" },
+    { "tx": 25, "ty": 22, "tileId": "graveWoodenCross" },
+    { "tx": 10, "ty": 24, "tileId": "skull" },
+    { "tx": 24, "ty": 24, "tileId": "smallRock" },
+    { "tx": 35, "ty": 16, "tileId": "gargoyleBottom" },
+    { "tx": 35, "ty": 15, "tileId": "gargoyleTop", "zlayer": "above" },
+    { "comment": "=== braziers lining the spine ===" },
+    { "tx": 13, "ty": 18, "bundleID": "brazier", "zlayer": "solid", "glow": true, "glowRadius": 3 },
+    { "tx": 17, "ty": 18, "bundleID": "brazier", "zlayer": "solid", "glow": true, "glowRadius": 3 },
+    { "tx": 13, "ty": 25, "bundleID": "brazier", "zlayer": "solid", "glow": true, "glowRadius": 3 },
+    { "tx": 17, "ty": 25, "bundleID": "brazier", "zlayer": "solid", "glow": true, "glowRadius": 3 },
+    { "comment": "=== bottom-edge graves/props ===" },
+    { "tx": 5, "ty": 29, "tileId": "graveStone" },
+    { "tx": 20, "ty": 29, "tileId": "graveWoodenCross" },
+    { "tx": 33, "ty": 29, "tileId": "graveStone" },
+    { "tx": 40, "ty": 29, "tileId": "skull" }
   ],
   "npcSpawnTiles": [],
   "ambientNpcSprites": [],
+  "animals": [
+    {
+      "id": "gravemoor-stray",
+      "type": "cat",
+      "variant": "grey",
+      "tx": 9,
+      "ty": 15,
+      "name": "The Mourner",
+      "dialogue": ["*a thin grey cat watches you from atop a headstone*", "*mrrow.*"],
+      "roam": true
+    }
+  ],
   "npcs": [
     {
       "id": "ghost-mayor-aldous",
       "name": "Mayor Aldous",
       "sprite": "hub-npc-elder",
       "isGhost": true,
-      "tx": 15,
+      "tx": 17,
       "ty": 12,
       "dialogue": [
         "Welcome to Gravemoor! Population: technically zero. Spiritually: thriving.",
         "I was mayor when I died and nobody's run against me since. Democracy at its finest.",
         "We're dead, not rude. Wipe your feet and you're welcome anywhere in town."
+      ],
+      "schedule": [
+        { "startHour": 7, "endHour": 20, "activity": "idle-chat", "location": { "type": "exterior", "tx": 17, "ty": 12 } },
+        { "startHour": 20, "endHour": 7, "location": { "type": "interior", "buildingId": "ruined-town-hall", "tx": 4, "ty": 3 } }
       ]
     },
     {
@@ -89,22 +226,22 @@
       "name": "Merchant Mora",
       "sprite": "hub-npc-merchant",
       "isGhost": true,
-      "tx": 19,
-      "ty": 13,
+      "tx": 5,
+      "ty": 5,
       "dialogue": [
         "Two hundred years of stock and not a single customer. Until you.",
         "Money means little to the dead, but haggling? Haggling is eternal.",
         "The blight took the town, but it couldn't take the market spirit. Literally, in my case."
       ],
-      "building": "mourning-hall"
+      "building": "mourning-hall-reliquary"
     },
     {
       "id": "grave-keeper-finch",
       "name": "Keeper Finch",
       "sprite": "hub-npc-scholar",
       "isGhost": true,
-      "tx": 22,
-      "ty": 10,
+      "tx": 4,
+      "ty": 5,
       "dialogue": [
         "I kept the graves in life. Now I keep them in death. Job security, of a sort.",
         "Some of my neighbours' remains have been... borrowed. Scattered. It's terribly undignified.",
@@ -112,39 +249,460 @@
       ],
       "building": "crypt-keep",
       "questGive": "gravemoor-restless-remains",
-      "questReceive": "gravemoor-restless-remains"
+      "questReceive": ["gravemoor-restless-remains", "gravemoor-restless-remains-2", "gravemoor-rest-in-ravenwatch"]
+    },
+    {
+      "id": "gravedigger-hollis",
+      "name": "Old Hollis",
+      "sprite": "hub-npc-gravedigger",
+      "tx": 7,
+      "ty": 15,
+      "dialogue": [
+        "Only living soul left in Gravemoor, that's me. Somebody's got to keep the holes tidy.",
+        "The dead are good company. Quiet. Never complain about the digging.",
+        "Mind the soft ground by the new plots. You'd not be the first to fall in."
+      ],
+      "questGive": "gravemoor-six-feet-under",
+      "questReceive": ["gravemoor-six-feet-under", "gravemoor-grave-goods"],
+      "schedule": [
+        { "startHour": 6, "endHour": 20, "activity": "work", "location": { "type": "exterior", "tx": 7, "ty": 15 } },
+        { "startHour": 20, "endHour": 6, "activity": "sleep", "location": { "type": "interior", "buildingId": "gravedigger-shed", "tx": 4, "ty": 4 } }
+      ]
+    },
+    {
+      "id": "weeping-widow",
+      "name": "The Weeping Widow",
+      "sprite": "hub-npc-queen",
+      "isGhost": true,
+      "tx": 27,
+      "ty": 15,
+      "dialogue": [
+        "Have you seen my Edric? No... no, of course not. He went under the hill so long ago.",
+        "I drift these woods every night. Old habits outlast the body, it seems.",
+        "Kindness to the dead is never wasted. We remember. It is all we do."
+      ],
+      "questGive": "gravemoor-reunited-in-death",
+      "questReceive": ["gravemoor-reunited-in-death", "gravemoor-wheres-mother"]
+    },
+    {
+      "id": "restless-soldier",
+      "name": "The Restless Soldier",
+      "sprite": "hub-npc-soldier",
+      "isGhost": true,
+      "tx": 40,
+      "ty": 27,
+      "dialogue": [
+        "Still at my post. Nobody sounded the retreat, so here I stand. Two centuries and counting.",
+        "Lost my orders in the rout. A soldier without orders is just a ghost loitering. Ha.",
+        "Find my commission papers and maybe — maybe — I can finally stand down."
+      ],
+      "questGive": "gravemoor-soldiers-orders",
+      "questReceive": "gravemoor-soldiers-orders"
+    },
+    {
+      "id": "spectral-pedlar",
+      "name": "The Spectral Pedlar",
+      "sprite": "hub-npc-trader",
+      "isGhost": true,
+      "tx": 20,
+      "ty": 12,
+      "dialogue": [
+        "Wares! Fine wares! Slightly translucent, but the quality is eternal!",
+        "I sold trinkets in life and I sell them still. Death is no excuse to close up shop.",
+        "My stock's gone walkabout among the graves. Recover it and we'll both profit."
+      ],
+      "questGive": "gravemoor-pedlars-stock",
+      "questReceive": "gravemoor-pedlars-stock"
+    },
+    {
+      "id": "little-pip",
+      "name": "Little Pip",
+      "sprite": "hub-npc-child",
+      "isGhost": true,
+      "tx": 8,
+      "ty": 16,
+      "dialogue": [
+        "Have you seen my mum? It's ever so dark and I can't find her anywhere.",
+        "I'm not scared. I'm NOT. ...Will you help me look? Please?",
+        "She had a sad face and a long grey dress. She used to sing to me."
+      ],
+      "questGive": "gravemoor-wheres-mother",
+      "questReceive": "gravemoor-wheres-mother"
+    },
+    {
+      "id": "brother-mortis",
+      "name": "Brother Mortis",
+      "sprite": "hub-npc-cultist",
+      "isGhost": true,
+      "tx": 3,
+      "ty": 5,
+      "dialogue": [
+        "Peace, traveller. I tend the chapel still, though no living throat has prayed here in an age.",
+        "The bell tolls at midnight. I never ring it. No one does. That... troubles me.",
+        "If you would unravel the mystery of the tolling, I would rest the easier for it."
+      ],
+      "building": "mausoleum-chapel",
+      "questGive": "gravemoor-hollow-tolling-1",
+      "questReceive": ["gravemoor-hollow-tolling-1", "gravemoor-hollow-tolling-2", "gravemoor-hollow-tolling-3"]
     }
   ],
   "interiors": {
     "mourning-hall": {
       "name": "The Mourning Hall",
-      "width": 9,
-      "height": 6,
+      "width": 12,
+      "height": 9,
       "floorTileId": "cobblestoneFloor",
       "wallTileId": "darkStone",
       "decor": [
-        { "tx": 1, "ty": 1, "tileId": "candlestickUnlit" },
-        { "tx": 7, "ty": 1, "tileId": "candlestickUnlit" },
-        { "tx": 4, "ty": 1, "tileId": "bookshelfTop" },
-        { "tx": 4, "ty": 2, "tileId": "bookshelfBottom" },
-        { "tx": 2, "ty": 3, "tileId": "roundTableWithCloth" }
+        { "tx": 1, "ty": 1, "tileId": "bookshelfTop" },
+        { "tx": 1, "ty": 2, "tileId": "bookshelfBottom" },
+        { "tx": 10, "ty": 1, "tileId": "bookshelfTop" },
+        { "tx": 10, "ty": 2, "tileId": "bookshelfBottom" },
+        { "tx": 8, "ty": 1, "tileId": "memorialTopLeft" },
+        { "tx": 9, "ty": 1, "tileId": "memorialTopRight" },
+        { "tx": 8, "ty": 2, "tileId": "memorialBotLeft" },
+        { "tx": 9, "ty": 2, "tileId": "memorialBotRight" },
+        { "tx": 5, "ty": 4, "tileId": "roundTableWithCloth" },
+        { "tx": 6, "ty": 4, "tileId": "roundTableWithCloth" },
+        { "tx": 2, "ty": 4, "tileId": "candlestickUnlit" },
+        { "tx": 9, "ty": 4, "tileId": "candlestickUnlit" },
+        { "tx": 3, "ty": 1, "tileId": "skull" }
       ],
-      "exits": []
+      "exits": [
+        { "tx": 6, "ty": 0, "toInteriorId": "mourning-hall-reliquary", "entryTx": 6, "entryTy": 6, "direction": "back", "label": "Reliquary" }
+      ]
+    },
+    "mourning-hall-reliquary": {
+      "name": "The Reliquary",
+      "width": 10,
+      "height": 8,
+      "floorTileId": "stoneFloor",
+      "wallTileId": "darkStone",
+      "decor": [
+        { "tx": 1, "ty": 1, "tileId": "bookshelfTop" },
+        { "tx": 1, "ty": 2, "tileId": "bookshelfBottom" },
+        { "tx": 2, "ty": 2, "tileId": "chest" },
+        { "tx": 3, "ty": 2, "tileId": "chest" },
+        { "tx": 7, "ty": 2, "tileId": "strongChest" },
+        { "tx": 8, "ty": 1, "tileId": "candlestickLitTop", "glow": true, "glowRadius": 2 },
+        { "tx": 8, "ty": 2, "tileId": "candlestickLitBottom" },
+        { "tx": 4, "ty": 3, "tileId": "darkPotWithLid" },
+        { "tx": 5, "ty": 3, "tileId": "darkPotWithLid" },
+        { "tx": 1, "ty": 5, "tileId": "skull" }
+      ],
+      "exits": [
+        { "tx": 4, "ty": 7, "toInteriorId": "mourning-hall", "entryTx": 6, "entryTy": 1, "direction": "front" }
+      ]
     },
     "crypt-keep": {
       "name": "The Crypt Keep",
-      "width": 8,
-      "height": 5,
+      "width": 11,
+      "height": 8,
       "floorTileId": "stoneFloor",
       "wallTileId": "darkStone",
       "decor": [
         { "tx": 1, "ty": 1, "tileId": "skull" },
-        { "tx": 6, "ty": 1, "tileId": "skull" },
+        { "tx": 9, "ty": 1, "tileId": "skull" },
         { "tx": 3, "ty": 1, "tileId": "bookshelfTop" },
         { "tx": 3, "ty": 2, "tileId": "bookshelfBottom" },
-        { "tx": 5, "ty": 3, "tileId": "chest" }
+        { "tx": 7, "ty": 3, "tileId": "chest" },
+        { "tx": 1, "ty": 4, "tileId": "candlestickLitTop", "glow": true, "glowRadius": 2 },
+        { "tx": 1, "ty": 5, "tileId": "candlestickLitBottom" },
+        { "tx": 5, "ty": 1, "tileId": "ladderBottom", "zlayer": "below" }
+      ],
+      "exits": [
+        { "tx": 5, "ty": 1, "toInteriorId": "crypt-keep-catacombs-a", "entryTx": 4, "entryTy": 4, "direction": "down", "label": "Down to the catacombs" }
+      ]
+    },
+    "crypt-keep-catacombs-a": {
+      "name": "Catacombs — The Crossing",
+      "width": 9,
+      "height": 7,
+      "floorTileId": "darkStoneFloor",
+      "wallTileId": "darkStone",
+      "decor": [
+        { "tx": 1, "ty": 1, "tileId": "skull" },
+        { "tx": 7, "ty": 1, "tileId": "skull" },
+        { "tx": 1, "ty": 5, "tileId": "darkPotWithLid" },
+        { "tx": 7, "ty": 5, "tileId": "darkPotWithLid" },
+        { "tx": 6, "ty": 1, "tileId": "candlestickLitTop", "glow": true, "glowRadius": 2 },
+        { "tx": 4, "ty": 5, "tileId": "ladderBottom", "zlayer": "below" }
+      ],
+      "exits": [
+        { "tx": 4, "ty": 5, "toInteriorId": "crypt-keep", "entryTx": 5, "entryTy": 4, "direction": "up", "label": "Up to the keep" },
+        { "tx": 0, "ty": 3, "toInteriorId": "crypt-keep-catacombs-b", "entryTx": 7, "entryTy": 3, "direction": "left" },
+        { "tx": 8, "ty": 3, "toInteriorId": "crypt-keep-catacombs-c", "entryTx": 1, "entryTy": 3, "direction": "right" },
+        { "tx": 4, "ty": 0, "toInteriorId": "crypt-keep-catacombs-d", "entryTx": 4, "entryTy": 1, "direction": "back" }
+      ]
+    },
+    "crypt-keep-catacombs-b": {
+      "name": "Catacombs — The Ossuary",
+      "width": 9,
+      "height": 7,
+      "floorTileId": "darkStoneFloor",
+      "wallTileId": "darkStone",
+      "decor": [
+        { "tx": 1, "ty": 1, "tileId": "skull" },
+        { "tx": 2, "ty": 1, "tileId": "skull" },
+        { "tx": 3, "ty": 1, "tileId": "skull" },
+        { "tx": 1, "ty": 2, "tileId": "skull" },
+        { "tx": 7, "ty": 1, "tileId": "darkPotWithLid" },
+        { "tx": 7, "ty": 5, "tileId": "darkPotWithLid" },
+        { "tx": 5, "ty": 5, "tileId": "skull" }
+      ],
+      "exits": [
+        { "tx": 8, "ty": 3, "toInteriorId": "crypt-keep-catacombs-a", "entryTx": 1, "entryTy": 3, "direction": "right" },
+        { "tx": 4, "ty": 0, "toInteriorId": "crypt-keep-catacombs-e", "entryTx": 4, "entryTy": 5, "direction": "back" }
+      ]
+    },
+    "crypt-keep-catacombs-e": {
+      "name": "Catacombs — The Deep Ossuary",
+      "width": 9,
+      "height": 7,
+      "floorTileId": "darkStoneFloor",
+      "wallTileId": "darkStone",
+      "decor": [
+        { "tx": 1, "ty": 1, "tileId": "skull" },
+        { "tx": 2, "ty": 1, "tileId": "skull" },
+        { "tx": 6, "ty": 1, "tileId": "skull" },
+        { "tx": 7, "ty": 1, "tileId": "skull" },
+        { "tx": 1, "ty": 5, "tileId": "darkPotWithLid" },
+        { "tx": 7, "ty": 5, "tileId": "darkPotWithLid" },
+        { "tx": 2, "ty": 3, "tileId": "candlestickLitTop", "glow": true, "glowRadius": 2 }
+      ],
+      "exits": [
+        { "tx": 4, "ty": 6, "toInteriorId": "crypt-keep-catacombs-b", "entryTx": 4, "entryTy": 1, "direction": "front" }
+      ]
+    },
+    "crypt-keep-catacombs-c": {
+      "name": "Catacombs — The Long Gallery",
+      "width": 9,
+      "height": 7,
+      "floorTileId": "darkStoneFloor",
+      "wallTileId": "darkStone",
+      "decor": [
+        { "tx": 1, "ty": 1, "tileId": "bookshelfTop" },
+        { "tx": 1, "ty": 2, "tileId": "bookshelfBottom" },
+        { "tx": 7, "ty": 1, "tileId": "darkPotWithLid" },
+        { "tx": 2, "ty": 5, "tileId": "skull" },
+        { "tx": 7, "ty": 5, "tileId": "candlestickLitTop", "glow": true, "glowRadius": 2 },
+        { "tx": 4, "ty": 5, "tileId": "ladderBottom", "zlayer": "below" }
+      ],
+      "exits": [
+        { "tx": 0, "ty": 3, "toInteriorId": "crypt-keep-catacombs-a", "entryTx": 7, "entryTy": 3, "direction": "left" },
+        { "tx": 4, "ty": 5, "toInteriorId": "crypt-keep-catacombs-f", "entryTx": 4, "entryTy": 2, "direction": "down", "label": "Deeper" }
+      ]
+    },
+    "crypt-keep-catacombs-f": {
+      "name": "Catacombs — The Sunken Vault",
+      "width": 9,
+      "height": 7,
+      "floorTileId": "darkStoneFloor",
+      "wallTileId": "darkStone",
+      "decor": [
+        { "tx": 1, "ty": 1, "tileId": "darkPotWithLid" },
+        { "tx": 7, "ty": 1, "tileId": "darkPotWithLid" },
+        { "tx": 7, "ty": 5, "tileId": "skull" },
+        { "tx": 2, "ty": 5, "tileId": "candlestickLitTop", "glow": true, "glowRadius": 2 },
+        { "tx": 4, "ty": 1, "tileId": "ladderBottom", "zlayer": "below" }
+      ],
+      "exits": [
+        { "tx": 4, "ty": 1, "toInteriorId": "crypt-keep-catacombs-c", "entryTx": 4, "entryTy": 4, "direction": "up", "label": "Up" },
+        { "tx": 0, "ty": 3, "toInteriorId": "mausoleum-chapel-undercroft", "entryTx": 8, "entryTy": 3, "direction": "left" }
+      ]
+    },
+    "crypt-keep-catacombs-d": {
+      "name": "Catacombs — The Lower Hall",
+      "width": 11,
+      "height": 8,
+      "floorTileId": "darkStoneFloor",
+      "wallTileId": "darkStone",
+      "decor": [
+        { "tx": 1, "ty": 1, "tileId": "skull" },
+        { "tx": 9, "ty": 1, "tileId": "skull" },
+        { "tx": 3, "ty": 1, "tileId": "bookshelfTop" },
+        { "tx": 3, "ty": 2, "tileId": "bookshelfBottom" },
+        { "tx": 1, "ty": 5, "tileId": "darkPotWithLid" },
+        { "tx": 9, "ty": 5, "tileId": "darkPotWithLid" },
+        { "tx": 5, "ty": 4, "tileId": "altarTopMid" },
+        { "tx": 5, "ty": 5, "tileId": "altarMidMid" },
+        { "tx": 7, "ty": 1, "tileId": "candlestickLitTop", "glow": true, "glowRadius": 2 }
+      ],
+      "exits": [
+        { "tx": 5, "ty": 7, "toInteriorId": "crypt-keep-catacombs-a", "entryTx": 4, "entryTy": 1, "direction": "front" },
+        { "tx": 10, "ty": 4, "toInteriorId": "crypt-keep-vault", "entryTx": 1, "entryTy": 4, "direction": "right", "requiredQuest": "gravemoor-hollow-tolling-2", "lockedBy": "gravemoor-hollow-tolling-2", "label": "Sealed Vault" },
+        { "tx": 0, "ty": 4, "toInteriorId": "mausoleum-chapel-undercroft", "entryTx": 8, "entryTy": 3, "direction": "left" }
+      ]
+    },
+    "crypt-keep-vault": {
+      "name": "Catacombs — The Sealed Vault",
+      "width": 9,
+      "height": 7,
+      "floorTileId": "darkStoneFloor",
+      "wallTileId": "darkStone",
+      "decor": [
+        { "tx": 4, "ty": 1, "tileId": "memorialTopLeft" },
+        { "tx": 5, "ty": 1, "tileId": "memorialTopRight" },
+        { "tx": 4, "ty": 2, "tileId": "memorialBotLeft" },
+        { "tx": 5, "ty": 2, "tileId": "memorialBotRight" },
+        { "tx": 1, "ty": 1, "tileId": "strongChest" },
+        { "tx": 7, "ty": 1, "tileId": "goldChest" },
+        { "tx": 2, "ty": 4, "tileId": "candlestickLitTop", "glow": true, "glowRadius": 3 },
+        { "tx": 6, "ty": 4, "tileId": "candlestickLitTop", "glow": true, "glowRadius": 3 }
+      ],
+      "exits": [
+        { "tx": 0, "ty": 4, "toInteriorId": "crypt-keep-catacombs-d", "entryTx": 9, "entryTy": 4, "direction": "left", "label": "Back" }
+      ]
+    },
+    "mausoleum-chapel": {
+      "name": "The Mausoleum Chapel",
+      "width": 11,
+      "height": 8,
+      "floorTileId": "stoneFloor",
+      "wallTileId": "darkStone",
+      "musicId": "church",
+      "ambianceId": "sacred",
+      "decor": [
+        { "tx": 5, "ty": 0, "tileId": "goldenCross" },
+        { "tx": 5, "ty": 1, "tileId": "altarTopMid" },
+        { "tx": 5, "ty": 2, "tileId": "altarMidMid" },
+        { "tx": 3, "ty": 1, "tileId": "candlestickLitTop", "glow": true, "glowRadius": 2 },
+        { "tx": 3, "ty": 2, "tileId": "candlestickLitBottom" },
+        { "tx": 7, "ty": 1, "tileId": "candlestickLitTop", "glow": true, "glowRadius": 2 },
+        { "tx": 7, "ty": 2, "tileId": "candlestickLitBottom" },
+        { "tx": 2, "ty": 4, "tileId": "benchLeft" },
+        { "tx": 3, "ty": 4, "tileId": "benchMiddle" },
+        { "tx": 4, "ty": 4, "tileId": "benchRight" },
+        { "tx": 6, "ty": 4, "tileId": "benchLeft" },
+        { "tx": 7, "ty": 4, "tileId": "benchMiddle" },
+        { "tx": 8, "ty": 4, "tileId": "benchRight" },
+        { "tx": 9, "ty": 1, "tileId": "ladderBottom", "zlayer": "below" }
+      ],
+      "exits": [
+        { "tx": 9, "ty": 1, "toInteriorId": "mausoleum-chapel-undercroft", "entryTx": 5, "entryTy": 5, "direction": "down", "label": "Down to the undercroft" }
+      ]
+    },
+    "mausoleum-chapel-undercroft": {
+      "name": "The Undercroft",
+      "width": 11,
+      "height": 8,
+      "floorTileId": "darkStoneFloor",
+      "wallTileId": "darkStone",
+      "decor": [
+        { "tx": 5, "ty": 1, "tileId": "ladderBottom", "zlayer": "below" },
+        { "tx": 5, "ty": 4, "tileId": "altarBotMid" },
+        { "tx": 1, "ty": 1, "tileId": "darkPotWithLid" },
+        { "tx": 9, "ty": 1, "tileId": "darkPotWithLid" },
+        { "tx": 1, "ty": 5, "tileId": "skull" },
+        { "tx": 9, "ty": 5, "tileId": "skull" },
+        { "tx": 3, "ty": 5, "tileId": "candlestickLitTop", "glow": true, "glowRadius": 2 },
+        { "tx": 7, "ty": 5, "tileId": "candlestickLitTop", "glow": true, "glowRadius": 2 }
+      ],
+      "exits": [
+        { "tx": 5, "ty": 1, "toInteriorId": "mausoleum-chapel", "entryTx": 9, "entryTy": 2, "direction": "up", "label": "Up to the chapel" },
+        { "tx": 10, "ty": 4, "toInteriorId": "crypt-keep-catacombs-f", "entryTx": 1, "entryTy": 3, "direction": "right" },
+        { "tx": 5, "ty": 0, "toInteriorId": "crypt-keep-catacombs-d", "entryTx": 4, "entryTy": 5, "direction": "back" }
+      ]
+    },
+    "gravedigger-shed": {
+      "name": "The Gravedigger's Shed",
+      "width": 9,
+      "height": 7,
+      "floorTileId": "woodFloor",
+      "wallTileId": "darkStone",
+      "decor": [
+        { "tx": 1, "ty": 1, "tileId": "barrel" },
+        { "tx": 2, "ty": 1, "tileId": "sack" },
+        { "tx": 3, "ty": 1, "tileId": "pileOfSacks" },
+        { "tx": 6, "ty": 1, "tileId": "crate" },
+        { "tx": 7, "ty": 1, "tileId": "openCrate" },
+        { "tx": 1, "ty": 5, "tileId": "smallRock" },
+        { "tx": 7, "ty": 5, "tileId": "candlestickUnlit" },
+        { "tx": 4, "ty": 3, "tileId": "roundTable" }
       ],
       "exits": []
+    },
+    "undertaker": {
+      "name": "The Undertaker's",
+      "width": 9,
+      "height": 7,
+      "floorTileId": "darkStoneFloor",
+      "wallTileId": "darkStone",
+      "decor": [
+        { "tx": 1, "ty": 1, "tileId": "bookshelfTop" },
+        { "tx": 1, "ty": 2, "tileId": "bookshelfBottom" },
+        { "tx": 2, "ty": 2, "tileId": "strongChest" },
+        { "tx": 3, "ty": 2, "tileId": "chest" },
+        { "tx": 6, "ty": 2, "tileId": "chest" },
+        { "tx": 7, "ty": 1, "tileId": "candlestickLitTop", "glow": true, "glowRadius": 2 },
+        { "tx": 7, "ty": 2, "tileId": "candlestickLitBottom" },
+        { "tx": 1, "ty": 5, "tileId": "darkPotWithLid" },
+        { "tx": 7, "ty": 5, "tileId": "darkPotWithLid" },
+        { "tx": 4, "ty": 3, "tileId": "roundTableWithCloth" }
+      ],
+      "exits": []
+    },
+    "ruined-town-hall": {
+      "name": "The Ruined Town Hall",
+      "width": 9,
+      "height": 7,
+      "floorTileId": "cobblestoneFloor",
+      "wallTileId": "darkStone",
+      "decor": [
+        { "tx": 1, "ty": 1, "tileId": "smallRock" },
+        { "tx": 7, "ty": 5, "tileId": "smallRock" },
+        { "tx": 2, "ty": 4, "tileId": "openCrate" },
+        { "tx": 6, "ty": 1, "tileId": "barrel" },
+        { "tx": 1, "ty": 5, "tileId": "skull" },
+        { "tx": 4, "ty": 2, "tileId": "roundTable" },
+        { "tx": 7, "ty": 1, "tileId": "candlestickUnlit" }
+      ],
+      "exits": []
+    },
+    "haunted-inn": {
+      "name": "The Hollow Rest",
+      "width": 11,
+      "height": 8,
+      "floorTileId": "woodFloor",
+      "wallTileId": "darkStone",
+      "musicId": "inn",
+      "ambianceId": "hearth",
+      "decor": [
+        { "tx": 1, "ty": 1, "bundleID": "fireplace" },
+        { "tx": 4, "ty": 3, "tileId": "smallTableTopLeft" },
+        { "tx": 5, "ty": 3, "tileId": "smallTableTopRight" },
+        { "tx": 4, "ty": 4, "tileId": "smallTableBottomLeft" },
+        { "tx": 5, "ty": 4, "tileId": "smallTableBottomRight" },
+        { "tx": 3, "ty": 3, "tileId": "stool" },
+        { "tx": 6, "ty": 3, "tileId": "stool" },
+        { "tx": 8, "ty": 1, "tileId": "barrel" },
+        { "tx": 9, "ty": 1, "tileId": "barrel" },
+        { "tx": 7, "ty": 5, "tileId": "counterTop" },
+        { "tx": 8, "ty": 5, "tileId": "counterTop" },
+        { "tx": 9, "ty": 1, "tileId": "ladderBottom", "zlayer": "below" }
+      ],
+      "exits": [
+        { "tx": 9, "ty": 1, "toInteriorId": "haunted-inn-upstairs", "entryTx": 5, "entryTy": 5, "direction": "up", "label": "Upstairs" }
+      ]
+    },
+    "haunted-inn-upstairs": {
+      "name": "The Hollow Rest — Upstairs",
+      "width": 11,
+      "height": 8,
+      "floorTileId": "woodFloor",
+      "wallTileId": "darkStone",
+      "decor": [
+        { "tx": 2, "ty": 2, "bundleID": "simple-bed" },
+        { "tx": 7, "ty": 2, "bundleID": "simple-bed" },
+        { "tx": 1, "ty": 1, "tileId": "candlestickUnlit" },
+        { "tx": 9, "ty": 1, "tileId": "candlestickUnlit" },
+        { "tx": 4, "ty": 5, "tileId": "chest" },
+        { "tx": 6, "ty": 5, "tileId": "chest" },
+        { "tx": 5, "ty": 1, "tileId": "ladderBottom", "zlayer": "below" }
+      ],
+      "exits": [
+        { "tx": 5, "ty": 1, "toInteriorId": "haunted-inn", "entryTx": 9, "entryTy": 2, "direction": "down", "label": "Downstairs" }
+      ]
     }
   }
 }

--- a/web/src/data/hub/gravemoor/questDefs.json
+++ b/web/src/data/hub/gravemoor/questDefs.json
@@ -10,28 +10,222 @@
       "activeDialogue": "Three sets of remains, scattered around town. They'll be the suspiciously chatty skulls.",
       "completeDialogue": "Home at last, all three. Listen... silence. Blessed, dignified silence. The dead of Gravemoor thank you — and unlike most, they mean it eternally.",
       "steps": [
-        {
-          "key": "remains",
-          "type": "collect",
-          "pickupIds": ["remains-1", "remains-2", "remains-3"],
-          "required": 3
-        }
+        { "key": "remains", "type": "collect", "pickupIds": ["remains-1", "remains-2", "remains-3"], "required": 3 }
       ],
       "reward": {
         "crystals": 70,
-        "collectible": {
-          "id": "gravemoor-lantern",
-          "name": "Mourner's Lantern",
-          "icon": "🏮",
-          "desc": "A small lantern that burns with a cold blue flame. The dead find it comforting."
-        }
+        "collectible": { "id": "gravemoor-lantern", "name": "Mourner's Lantern", "icon": "🏮", "desc": "A small lantern that burns with a cold blue flame. The dead find it comforting." }
+      }
+    },
+    {
+      "id": "gravemoor-restless-remains-2",
+      "title": "The Restless Remains II: Deeper Still",
+      "type": "chain",
+      "giverNpcId": "grave-keeper-finch",
+      "receiverNpcId": "grave-keeper-finch",
+      "prerequisite": "quest:gravemoor-restless-remains",
+      "offerDialogue": "You did so well with the surface graves that I dare ask more. Three older souls were laid in the catacombs beneath the keep, and their bones have wandered the dark passages. Few would brave the maze below... but you are not most.",
+      "activeDialogue": "Three sets of remains, lost somewhere in the catacombs beneath the crypt keep. Take the ladder down and search the passages.",
+      "completeDialogue": "All three, returned from the deep dark. You have a steady nerve for the underworld, friend. The oldest dead of Gravemoor will sleep sound for centuries more.",
+      "steps": [
+        { "key": "deep-remains", "type": "collect", "pickupIds": ["remains-deep-1", "remains-deep-2", "remains-deep-3"], "required": 3 }
+      ],
+      "reward": {
+        "crystals": 90,
+        "collectible": { "id": "gravemoor-bone-charm", "name": "Bone Charm", "icon": "🦴", "desc": "A charm carved from catacomb bone. It hums faintly when the dead are near." }
+      }
+    },
+    {
+      "id": "gravemoor-reunited-in-death",
+      "title": "Reunited in Death",
+      "type": "fetch",
+      "giverNpcId": "weeping-widow",
+      "receiverNpcId": "weeping-widow",
+      "offerDialogue": "Long ago my Edric gave me a locket, and I lost it the night the blight took us. I have drifted these woods searching ever since. If you should find it among the graves... bring it to me, and I might weep a little less.",
+      "activeDialogue": "Find the Weeping Widow's lost locket somewhere in the old cemetery.",
+      "completeDialogue": "Oh — oh, my locket! His face, just as I remember. Bless you, traveller. For the first time in two hundred years, these are not tears of grief.",
+      "steps": [
+        { "key": "locket", "type": "collect", "pickupIds": ["widow-locket"], "required": 1 }
+      ],
+      "reward": {
+        "crystals": 60,
+        "friendship": { "weeping-widow": 2 },
+        "collectible": { "id": "gravemoor-locket", "name": "Edric's Locket", "icon": "📿", "desc": "A tarnished silver locket. The widow let you keep its twin." }
+      }
+    },
+    {
+      "id": "gravemoor-soldiers-orders",
+      "title": "A Soldier's Last Orders",
+      "type": "fetch",
+      "giverNpcId": "restless-soldier",
+      "receiverNpcId": "restless-soldier",
+      "offerDialogue": "I cannot stand down without orders — it is not done. My commission papers were lost in the rout, somewhere out past the inn. Find them, and perhaps a soldier can finally rest.",
+      "activeDialogue": "Recover the Restless Soldier's commission papers, lost near the haunted inn.",
+      "completeDialogue": "My orders! 'All forces are relieved of duty.' ...Relieved. After all this time. Thank you, traveller. I think I shall sleep now. At ease. At last.",
+      "steps": [
+        { "key": "orders", "type": "collect", "pickupIds": ["soldier-orders"], "required": 1 }
+      ],
+      "reward": {
+        "crystals": 60,
+        "collectible": { "id": "gravemoor-medal", "name": "Tarnished Medal", "icon": "🎖️", "desc": "The soldier pressed his old campaign medal into your hand before he faded." }
+      }
+    },
+    {
+      "id": "gravemoor-grave-goods",
+      "title": "Grave Goods",
+      "type": "lost-items",
+      "giverNpcId": "gravedigger-hollis",
+      "receiverNpcId": "gravedigger-hollis",
+      "offerDialogue": "Folk leave little gifts on the graves — trinkets, books, what have you. The wind and the crows scatter them something terrible. Gather the strays so I can set them back where they belong, eh?",
+      "activeDialogue": "Collect the scattered grave offerings from around the cemetery.",
+      "completeDialogue": "There we are — all back in my keeping. The dead do appreciate their little comforts, even if they'll never say so. Good of you to bother.",
+      "steps": [
+        { "key": "goods", "type": "collect", "pickupIds": ["gg-1", "gg-2", "gg-3"], "required": 3 }
+      ],
+      "reward": { "crystals": 70 }
+    },
+    {
+      "id": "gravemoor-wheres-mother",
+      "title": "Where's Mother?",
+      "type": "chain",
+      "giverNpcId": "little-pip",
+      "receiverNpcId": "weeping-widow",
+      "prerequisite": "quest:gravemoor-reunited-in-death",
+      "offerDialogue": "I picked mum a posy, see? But I can't find her to give it. You found the sad lady's locket — maybe she's my mum! Take her my posy? Please? I'm too little to go in the deep wood.",
+      "activeDialogue": "Pick up Pip's posy from the cemetery, then take it to the Weeping Widow in the wood.",
+      "completeDialogue": "A posy of graveflowers... 'For mum.' ...Pip? My Pip?! He is HERE? Oh, take me to him, quickly — two hundred years I have searched these woods, and he was beside me all along!",
+      "steps": [
+        { "key": "posy", "type": "collect", "pickupIds": ["pip-keepsake"], "required": 1 },
+        { "key": "deliver", "type": "deliver", "targetNpcId": "weeping-widow", "required": 1 }
+      ],
+      "reward": {
+        "crystals": 90,
+        "friendship": { "weeping-widow": 2, "little-pip": 2 },
+        "collectible": { "id": "gravemoor-posy", "name": "Graveflower Posy", "icon": "💐", "desc": "Pale flowers that only grow over graves. A memento of a family reunited." }
+      }
+    },
+    {
+      "id": "gravemoor-pedlars-stock",
+      "title": "The Pedlar's Stock",
+      "type": "fetch",
+      "giverNpcId": "spectral-pedlar",
+      "receiverNpcId": "spectral-pedlar",
+      "offerDialogue": "Disaster! Half my stock has gone walkabout — rolled off into the wood, no doubt. A merchant without wares is merely a ghost with opinions. Round up my goods and I'll cut you in, partner.",
+      "activeDialogue": "Recover the Spectral Pedlar's three lost wares from along the wood path.",
+      "completeDialogue": "My stock, restored! You've a merchant's eye, friend. Slightly translucent goods, full-price profits — that's the Gravemoor way. A pleasure doing business.",
+      "steps": [
+        { "key": "stock", "type": "collect", "pickupIds": ["ps-1", "ps-2", "ps-3"], "required": 3 }
+      ],
+      "reward": {
+        "crystals": 75,
+        "collectible": { "id": "gravemoor-trinket", "name": "Pedlar's Trinket", "icon": "🔔", "desc": "A little brass bell from the pedlar's cart. It rings without a clapper." }
+      }
+    },
+    {
+      "id": "gravemoor-six-feet-under",
+      "title": "Six Feet Under",
+      "type": "fetch",
+      "giverNpcId": "gravedigger-hollis",
+      "receiverNpcId": "gravedigger-hollis",
+      "offerDialogue": "Careless of me — left my tools out and now they're strewn across the yard. A spade, a sack, a good whetstone. Can't dig a decent grave without 'em. Fetch them back and I'll stand you a drink. Well. A memory of one.",
+      "activeDialogue": "Gather Old Hollis's scattered digging tools from around the gallows yard.",
+      "completeDialogue": "All present and accounted for. A gravedigger's only as good as his tools, and these have planted half the town. Much obliged, friend.",
+      "steps": [
+        { "key": "tools", "type": "collect", "pickupIds": ["sfu-1", "sfu-2", "sfu-3"], "required": 3 }
+      ],
+      "reward": {
+        "crystals": 60,
+        "collectible": { "id": "gravemoor-spade", "name": "Hollis's Old Spade", "icon": "⛏️", "desc": "A worn iron spade. Hollis swears it could dig through stone — and has." }
+      }
+    },
+    {
+      "id": "gravemoor-hollow-tolling-1",
+      "title": "The Hollow Tolling",
+      "type": "chain",
+      "giverNpcId": "brother-mortis",
+      "receiverNpcId": "brother-mortis",
+      "offerDialogue": "Every midnight the chapel bell tolls, though no hand rings it. It unsettles even the dead. Search the chapel — there was an old ledger that spoke of the bell. Begin there, and we may yet understand.",
+      "activeDialogue": "Find the old bell ledger somewhere inside the mausoleum chapel.",
+      "completeDialogue": "The ledger... 'The bell answers the one who lies in the sealed vault.' So. The tolling has a cause, and it lies below. We must go deeper. But not yet — gather your nerve first.",
+      "steps": [
+        { "key": "ledger", "type": "collect", "pickupIds": ["ht-1"], "required": 1 }
+      ],
+      "reward": { "crystals": 50 }
+    },
+    {
+      "id": "gravemoor-hollow-tolling-2",
+      "title": "The Hollow Tolling: The Lower Hall",
+      "type": "chain",
+      "giverNpcId": "brother-mortis",
+      "receiverNpcId": "brother-mortis",
+      "prerequisite": "quest:gravemoor-hollow-tolling-1",
+      "offerDialogue": "The ledger spoke of a sealed vault in the lower hall of the catacombs. Find the keystone that holds the vault shut — a marked skull, the ledger said — and the way will open to us.",
+      "activeDialogue": "Descend to the catacombs' lower hall and find the marked keystone skull.",
+      "completeDialogue": "The keystone skull, marked just so. The seal on the vault loosens — I feel it give from here. Whatever rings that bell, it waits beyond. Go when you are ready. I will pray.",
+      "steps": [
+        { "key": "keystone", "type": "collect", "pickupIds": ["ht-2"], "required": 1 }
+      ],
+      "reward": { "crystals": 65 }
+    },
+    {
+      "id": "gravemoor-hollow-tolling-3",
+      "title": "The Hollow Tolling: The Sealed Vault",
+      "type": "chain",
+      "giverNpcId": "brother-mortis",
+      "receiverNpcId": "brother-mortis",
+      "prerequisite": "quest:gravemoor-hollow-tolling-2",
+      "offerDialogue": "The vault is open. Inside lies a reliquary — and within it, the relic that has tolled our bell for two centuries, calling out to a home it was stolen from. Bring it up to the light, traveller.",
+      "activeDialogue": "Enter the now-unsealed vault in the catacombs and recover the tolling reliquary.",
+      "completeDialogue": "So that is the cause — a holy relic, stolen from another town's church and entombed here, ringing out for home every midnight. The bell will not rest until the relic is returned. Speak with Keeper Finch; he knows where it belongs.",
+      "steps": [
+        { "key": "reliquary", "type": "collect", "pickupIds": ["ht-3"], "required": 1 }
+      ],
+      "reward": {
+        "crystals": 120,
+        "collectible": { "id": "gravemoor-reliquary", "name": "The Tolling Reliquary", "icon": "⛪", "desc": "A stolen church relic that rings a phantom bell each midnight, longing for the home it was taken from." }
+      }
+    },
+    {
+      "id": "gravemoor-rest-in-ravenwatch",
+      "title": "Rest in Ravenwatch",
+      "type": "chain",
+      "giverNpcId": "grave-keeper-finch",
+      "receiverNpcId": "npc_1781726431819",
+      "prerequisite": "quest:gravemoor-hollow-tolling-3",
+      "offerDialogue": "That reliquary you found below? Stolen, long ago, from the church at Ravenwatch — and it has been ringing for home ever since. Carry it there and place it in Minister Fallow's keeping. Let the poor thing finally be still.",
+      "activeDialogue": "Take the tolling reliquary to Minister Fallow in the church at Ravenwatch.",
+      "completeDialogue": "Stars above — the lost Ravenwatch reliquary, returned at last! It has not rung since the night it was taken. You have my thanks, traveller, and the gratitude of every soul who ever prayed beneath this roof.",
+      "steps": [
+        { "key": "return", "type": "deliver", "targetNpcId": "npc_1781726431819", "required": 1 }
+      ],
+      "reward": {
+        "crystals": 110,
+        "collectible": { "id": "gravemoor-still-bell", "name": "The Stilled Bell", "icon": "🔔", "desc": "A small token from Minister Fallow. The Gravemoor bell tolls no more — the town sleeps easier, and so do you." }
       }
     }
   ],
   "pickupItems": [
-    { "id": "remains-1", "tx": 3, "ty": 9, "tileId": "skull", "questId": "gravemoor-restless-remains" },
-    { "id": "remains-2", "tx": 26, "ty": 16, "tileId": "skull", "questId": "gravemoor-restless-remains" },
-    { "id": "remains-3", "tx": 10, "ty": 19, "tileId": "skull", "questId": "gravemoor-restless-remains" }
+    { "id": "remains-1", "tx": 6, "ty": 14, "tileId": "skull", "questId": "gravemoor-restless-remains" },
+    { "id": "remains-2", "tx": 25, "ty": 14, "tileId": "skull", "questId": "gravemoor-restless-remains" },
+    { "id": "remains-3", "tx": 12, "ty": 22, "tileId": "skull", "questId": "gravemoor-restless-remains" },
+    { "id": "remains-deep-1", "tx": 4, "ty": 3, "tileId": "skull", "building": "crypt-keep-catacombs-e", "questId": "gravemoor-restless-remains-2" },
+    { "id": "remains-deep-2", "tx": 4, "ty": 3, "tileId": "skull", "building": "crypt-keep-catacombs-b", "questId": "gravemoor-restless-remains-2" },
+    { "id": "remains-deep-3", "tx": 5, "ty": 3, "tileId": "skull", "building": "crypt-keep-catacombs-f", "questId": "gravemoor-restless-remains-2" },
+    { "id": "widow-locket", "tx": 9, "ty": 16, "tileId": "pendant", "questId": "gravemoor-reunited-in-death" },
+    { "id": "soldier-orders", "tx": 40, "ty": 26, "tileId": "closedBook", "questId": "gravemoor-soldiers-orders" },
+    { "id": "gg-1", "tx": 9, "ty": 14, "tileId": "pendant", "questId": "gravemoor-grave-goods" },
+    { "id": "gg-2", "tx": 12, "ty": 14, "tileId": "closedBook", "questId": "gravemoor-grave-goods" },
+    { "id": "gg-3", "tx": 6, "ty": 16, "tileId": "potions", "questId": "gravemoor-grave-goods" },
+    { "id": "pip-keepsake", "tx": 10, "ty": 16, "tileId": "potOfFlowers", "questId": "gravemoor-wheres-mother" },
+    { "id": "ps-1", "tx": 27, "ty": 16, "tileId": "darkPotWithLid", "questId": "gravemoor-pedlars-stock" },
+    { "id": "ps-2", "tx": 27, "ty": 20, "tileId": "closedBook", "questId": "gravemoor-pedlars-stock" },
+    { "id": "ps-3", "tx": 25, "ty": 22, "tileId": "potions", "questId": "gravemoor-pedlars-stock" },
+    { "id": "sfu-1", "tx": 13, "ty": 14, "tileId": "sack", "questId": "gravemoor-six-feet-under" },
+    { "id": "sfu-2", "tx": 13, "ty": 17, "tileId": "smallRock", "questId": "gravemoor-six-feet-under" },
+    { "id": "sfu-3", "tx": 4, "ty": 16, "tileId": "crate", "questId": "gravemoor-six-feet-under" },
+    { "id": "ht-1", "tx": 2, "ty": 3, "tileId": "closedBook", "building": "mausoleum-chapel", "questId": "gravemoor-hollow-tolling-1" },
+    { "id": "ht-2", "tx": 5, "ty": 3, "tileId": "skull", "building": "crypt-keep-catacombs-d", "questId": "gravemoor-hollow-tolling-2" },
+    { "id": "ht-3", "tx": 3, "ty": 4, "tileId": "goldenCross", "building": "crypt-keep-vault", "questId": "gravemoor-hollow-tolling-3" }
   ],
   "blockedPaths": []
 }


### PR DESCRIPTION
Closes #1743 (part of epic #1732). Brings the haunted ghost town **Gravemoor** up to **Tier C**, per the confirmed design direction: keep its sparse, lonely feel by enlarging the map and filling the new space with **woodland and graves**, while concentrating the richness in **complex interiors and a large maze-like crypt network**.

## What changed

**Map** — grown east + south to **44×30** (`1408×960`). No existing coordinate needed re-offsetting.

**Buildings (2 → 7, all furnished)**
- mourning hall (+ **reliquary**, multi-room) · crypt keep (entrance to the crypt network) · gravedigger's shed · undertaker's · mausoleum chapel (+ undercroft) · ruined town hall · haunted inn (+ upstairs)

**The crypt network (centerpiece)** — a deliberately maze-like multi-level catacomb: 7 catacomb rooms + the chapel undercroft, linked by up/down ladders and side passages, with a **quest-gated sealed vault** and a **crypt ↔ undercroft loop** the player discovers.

**NPCs (3 → 9)** — gravedigger Old Hollis (living caretaker), the Weeping Widow, the Restless Soldier, the Spectral Pedlar, Little Pip (lost-child ghost), Brother Mortis; schedules where they fit; a placed graveyard stray cat. Two new sprites authored (`hub-npc-gravedigger`, `hub-npc-child`).

**Quests (1 → 12)** — Restless Remains chain (surface I + deep-crypt II), reuniting-spirits fetches (Reunited in Death, A Soldier's Last Orders, Where's Mother?), **Grave Goods** (lost-items), and **The Hollow Tolling** — a 3-step prerequisite-gated mystery chain ending in the vault — plus the cross-town hook **Rest in Ravenwatch** (#1735), returning the tolling reliquary to Minister Fallow in Ravenwatch's church (global quest state, no Ravenwatch config change).

**Decor & areas** — 4 areas; ~70 exterior + ~85 interior decor (graves, wrought-iron fences, braziers, candelabra, angel/gargoyle statues, memorials, woodland tree clusters).

## Cross-cutting fixes folded in
- **#1734** — every interior resized in-bounds; relocated the two out-of-bounds interior NPCs (Mora → reliquary, Finch → keep); key buildings now multi-room.
- **#1733** — street network with a path tile directly in front of **every** door, including the previously broken crypt-keep door; a cemetery path spur for reachability (exterior movement is street-only).

## Verification
- `npm run build` (tsc + vite) — ✅ clean
- `npm run test` — ✅ **783 passed (186 files)**, incl. `loader.test.ts`
- Interior entry tiles verified to land on inner walkable floor (not on ladder/exit tiles); all tileIds/bundleIDs validated against `baseChipIndex.ts` / `bundles.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ChT7mMSQ8gc9BpCNwMF9PA)_