### PR TITLE
Telegraph opponent spell casts with a Counter QTE + "Defeated by" callout

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -493,6 +493,8 @@ export default function App() {
   const prevOpponentUnitsRef = useRef<Map<string, string>>(new Map())
   // Commander HP tracking (null = not yet sampled this battle)
   const prevCommanderHpRef   = useRef<number | null>(null)
+  // Opponent spell-cast key tracking, so the speed-drop below fires once per cast
+  const prevPendingCastKeyRef = useRef<string | null>(null)
 
   // Achievement toast notifications
   const { achievementToasts, setAchievementToasts } = useAchievements()
@@ -2242,6 +2244,18 @@ export default function App() {
     prevCommanderHpRef.current = currentHp
   }, [gameState?.field])
 
+  // Drop to 1x speed when the opponent starts casting a spell, so every player
+  // gets the same real-time 5s window to react regardless of fast-forward setting
+  useEffect(() => {
+    if (!gameState || screen !== 'playing') return
+    const cast = gameState.pendingSpellCast
+    const castKey = cast ? `${cast.cardName}:${cast.startedAtMs}` : null
+    if (castKey && castKey !== prevPendingCastKeyRef.current && battle.speedMultiplier > 1) {
+      dispatch({ type: 'SET_SPEED', multiplier: 1 })
+    }
+    prevPendingCastKeyRef.current = castKey
+  }, [gameState?.pendingSpellCast?.cardName, gameState?.pendingSpellCast?.startedAtMs])
+
   // Secret 4 — Tired Game: after midnight, units occasionally yawn
   useEffect(() => {
     if (!gameState || screen !== 'playing') return
@@ -3388,7 +3402,7 @@ export default function App() {
         if (gameState.phase.type === 'celebration') {
           return (
             <>
-              <Battlefield state={gameState} onPlayCard={handlePlayCard} onPlayAoeCard={handlePlayAoeCard} onGiveUp={handleGiveUp} onPause={setIsUserPaused} actTheme={actTheme} activeRelic={run?.activeRelic} showBossSplash={false} activeModifiers={run ? getModifiersByCount(ACTS[run.actId], run.activeModifierCount) : []} isCampaign={isCampaign} stance={gameState.playerStance ?? 'auto'} onSetStance={handleSetStance} speedMultiplier={speedMultiplier} onCycleSpeed={handleCycleSpeed} />
+              <Battlefield state={gameState} onPlayCard={handlePlayCard} onPlayAoeCard={handlePlayAoeCard} onGiveUp={handleGiveUp} onPause={setIsUserPaused} actTheme={actTheme} activeRelic={run?.activeRelic} showBossSplash={false} activeModifiers={run ? getModifiersByCount(ACTS[run.actId], run.activeModifierCount) : []} isCampaign={isCampaign} stance={gameState.playerStance ?? 'auto'} onSetStance={handleSetStance} speedMultiplier={speedMultiplier} onCycleSpeed={handleCycleSpeed} onCounterSpell={() => dispatch({ type: 'COUNTER_SPELL' })} />
               <VictoryPanel
                 playerScore={gameState.playerScore}
                 opponentScore={gameState.opponentScore}
@@ -3405,7 +3419,7 @@ export default function App() {
           const fp = gameState.phase as { type: 'fingerSmash'; wave: number; smashedNames: string[]; rewardDue: boolean }
           return (
             <>
-              <Battlefield state={gameState} onPlayCard={handlePlayCard} onPlayAoeCard={handlePlayAoeCard} onGiveUp={handleGiveUp} onPause={setIsUserPaused} actTheme={actTheme} activeRelic={run?.activeRelic} showBossSplash={showBossSplash} activeModifiers={run ? getModifiersByCount(ACTS[run.actId], run.activeModifierCount) : []} isCampaign={isCampaign} stance={gameState.playerStance ?? 'auto'} onSetStance={handleSetStance} speedMultiplier={speedMultiplier} onCycleSpeed={handleCycleSpeed} />
+              <Battlefield state={gameState} onPlayCard={handlePlayCard} onPlayAoeCard={handlePlayAoeCard} onGiveUp={handleGiveUp} onPause={setIsUserPaused} actTheme={actTheme} activeRelic={run?.activeRelic} showBossSplash={showBossSplash} activeModifiers={run ? getModifiersByCount(ACTS[run.actId], run.activeModifierCount) : []} isCampaign={isCampaign} stance={gameState.playerStance ?? 'auto'} onSetStance={handleSetStance} speedMultiplier={speedMultiplier} onCycleSpeed={handleCycleSpeed} onCounterSpell={() => dispatch({ type: 'COUNTER_SPELL' })} />
               <FingerSmash
                 smashedNames={fingerSmashNames}
                 onDone={() => {
@@ -3467,7 +3481,7 @@ export default function App() {
           />
         ) : (
           <>
-            <Battlefield state={gameState} onPlayCard={handlePlayCard} onPlayAoeCard={handlePlayAoeCard} onGiveUp={handleGiveUp} onPause={setIsUserPaused} actTheme={actTheme} activeRelic={run?.activeRelic} showBossSplash={showBossSplash} activeModifiers={run ? getModifiersByCount(ACTS[run.actId], run.activeModifierCount) : []} isCampaign={isCampaign} stance={gameState.playerStance ?? 'auto'} onSetStance={handleSetStance} speedMultiplier={speedMultiplier} onCycleSpeed={handleCycleSpeed} />
+            <Battlefield state={gameState} onPlayCard={handlePlayCard} onPlayAoeCard={handlePlayAoeCard} onGiveUp={handleGiveUp} onPause={setIsUserPaused} actTheme={actTheme} activeRelic={run?.activeRelic} showBossSplash={showBossSplash} activeModifiers={run ? getModifiersByCount(ACTS[run.actId], run.activeModifierCount) : []} isCampaign={isCampaign} stance={gameState.playerStance ?? 'auto'} onSetStance={handleSetStance} speedMultiplier={speedMultiplier} onCycleSpeed={handleCycleSpeed} onCounterSpell={() => dispatch({ type: 'COUNTER_SPELL' })} />
             {showBossShockwave && <BossShockwave onDone={() => dispatch({ type: 'HIDE_BOSS_SHOCKWAVE' })} />}
             {activeRareEvent === 'fakeCrash'   && <FakeCrashEvent   onDone={handleRareEventDone} />}
             {activeRareEvent === 'blackjack'   && <BlackjackEvent   onDone={handleRareEventDone} />}

--- a/web/src/components/battle/Battlefield.tsx
+++ b/web/src/components/battle/Battlefield.tsx
@@ -9,6 +9,7 @@ import { spriteSlug } from '../../game/sprites'
 import { BattleEventOverlay } from './BattleEventOverlay'
 import { isNoDamageMode, isDebugMode } from '../../game/debug'
 import { MAX_UPGRADE_LEVEL, getEffectiveCardCost } from '../../game/engine/cards'
+import { CAST_WINDUP_MS, COUNTER_WINDOW_AVOID_START_MS, COUNTER_WINDOW_HALVE_START_MS } from '../../game/engine/constants'
 import { SUDDEN_DEATH_FORCE_MS } from '../../game/engine/suddenDeath'
 import { getRelicDef } from '../../game/relics'
 import { getUnitLore, getCardCatalog } from '../../game/cards'
@@ -52,6 +53,7 @@ interface Props {
   onSetStance?: (s: NonNullable<GameState['playerStance']>) => void
   speedMultiplier?: 1 | 2 | 4 | 8
   onCycleSpeed?: () => void
+  onCounterSpell?: () => void
 }
 
 const SPAWN_GROW_MS = 1500
@@ -601,7 +603,7 @@ function opponentPortraitSlug(bossAI: string | undefined, actTheme: string | und
   return 'bandit'
 }
 
-export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPause, actTheme, activeRelic, showBossSplash, activeModifiers, isCampaign, stance = 'auto', onSetStance, speedMultiplier = 1, onCycleSpeed }: Props) {
+export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPause, actTheme, activeRelic, showBossSplash, activeModifiers, isCampaign, stance = 'auto', onSetStance, speedMultiplier = 1, onCycleSpeed, onCounterSpell }: Props) {
   const { openDetail, cardDetailNode } = useCardDetail()
   const [heroLightning, setHeroLightning] = useState<{ owner: 'player' | 'opponent'; key: number } | null>(null)
   const [paused, setPaused] = useState(false)
@@ -637,6 +639,16 @@ export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPaus
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
   }, [pendingAoeCard])
+
+  // Counter an opponent's incoming spell cast via Space/Enter
+  useEffect(() => {
+    if (!state.pendingSpellCast || state.pendingSpellCast.counterGrade) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.code === 'Space' || e.code === 'Enter') { e.preventDefault(); onCounterSpell?.() }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [state.pendingSpellCast?.cardName, state.pendingSpellCast?.counterGrade, onCounterSpell])
 
   // Detect when a new hero unit appears on the field and fire the lightning effect
   useEffect(() => {
@@ -1011,6 +1023,36 @@ export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPaus
             )}
           </>
         )}
+
+        {/* Opponent spell-cast telegraph + Counter QTE */}
+        {state.pendingSpellCast && (() => {
+          const cast = state.pendingSpellCast!
+          const remainingMs = Math.max(0, cast.resolvesAtMs - state.gameTime)
+          const pct = Math.max(0, Math.min(1, remainingMs / CAST_WINDUP_MS))
+          const opCmd = state.field.find(u => u.isCommander && u.owner === 'opponent')
+          const glowTop  = opCmd ? (1 - opCmd.x / LANE_WIDTH) * 100 : 4
+          const glowLeft = opCmd ? 50 + (opCmd.y / 80) * 36 : 50
+          const elapsed = state.gameTime - cast.startedAtMs
+          const inDangerZone = elapsed >= COUNTER_WINDOW_AVOID_START_MS && elapsed < COUNTER_WINDOW_HALVE_START_MS
+          return (
+            <>
+              <div className="spell-cast-glow" style={{ position: 'absolute', top: `${glowTop}%`, left: `${glowLeft}%`, transform: 'translate(-50%,-50%)', pointerEvents: 'none', zIndex: 55 }} aria-hidden />
+              <div className="spell-cast-banner">
+                <span className="spell-cast-banner-name">⚡ {cast.cardName} incoming!</span>
+                <span className="spell-cast-banner-timer">{(remainingMs / 1000).toFixed(1)}s</span>
+                <div className="spell-cast-banner-bar"><div className="spell-cast-banner-bar-fill" style={{ width: `${pct * 100}%` }} /></div>
+              </div>
+              {!cast.counterGrade && (
+                <button className={`spell-cast-counter-btn ${inDangerZone ? 'spell-cast-counter-btn--danger' : ''}`} onClick={() => onCounterSpell?.()}>COUNTER!</button>
+              )}
+              {cast.counterGrade && (
+                <div className={`spell-cast-grade spell-cast-grade--${cast.counterGrade}`}>
+                  {cast.counterGrade === 'avoid' ? 'DODGED!' : cast.counterGrade === 'halve' ? 'PARTIAL BLOCK' : 'TOO SLOW'}
+                </div>
+              )}
+            </>
+          )
+        })()}
       </div>
         )
       })()}

--- a/web/src/components/battle/GameOver.tsx
+++ b/web/src/components/battle/GameOver.tsx
@@ -113,6 +113,11 @@ export function GameOver({ state, winner, handicap, onOpenPack, rewardClaimed, o
       )}
       <pre className="gameover-ascii">{art}</pre>
       <div className="gameover-message">{message}</div>
+      {!won && !draw && state.lastPlayerDamageSource && (
+        <div className="gameover-killed-by">
+          Defeated by: {state.lastPlayerDamageSource.kind === 'spell' ? '🔥 ' : ''}{state.lastPlayerDamageSource.name}
+        </div>
+      )}
       {isEndless ? (
         <div className="gameover-endless-stats u-col u-items-c u-gap-2">
           <div className="gameover-endless-wave">WAVE {state.endlessWave ?? 1}</div>

--- a/web/src/game/battleReducer.test.ts
+++ b/web/src/game/battleReducer.test.ts
@@ -52,6 +52,7 @@ function makeGameState(overrides: Partial<GameState> = {}): GameState {
     animEvents: [],
     bloodPools: [],
     hazards: [],
+    pendingSpellCast: null,
     ...overrides,
   }
 }
@@ -394,6 +395,64 @@ describe('battleReducer', () => {
       })
 
       expect(next.summaryStats).toEqual({ stats, gameTime: 120000, playerScore: 850 })
+    })
+  })
+
+  // ── COUNTER_SPELL ──────────────────────────────────────
+
+  describe('COUNTER_SPELL', () => {
+    function makeCast(overrides: Partial<NonNullable<GameState['pendingSpellCast']>> = {}) {
+      return {
+        cardName: 'Roots Burst',
+        effect: { type: 'aoe' as const, damage: 15 },
+        startedAtMs: 0,
+        resolvesAtMs: 5000,
+        ...overrides,
+      }
+    }
+
+    it('grades "full" when pressed in the first 2s', () => {
+      const gs = makeGameState({ gameTime: 1000, pendingSpellCast: makeCast() })
+      const state = withGameState(gs)
+
+      const next = battleReducer(state, { type: 'COUNTER_SPELL' })
+
+      expect(next.gameState!.pendingSpellCast!.counterGrade).toBe('full')
+    })
+
+    it('grades "avoid" when pressed in the 2-4.5s danger zone', () => {
+      const gs = makeGameState({ gameTime: 3000, pendingSpellCast: makeCast() })
+      const state = withGameState(gs)
+
+      const next = battleReducer(state, { type: 'COUNTER_SPELL' })
+
+      expect(next.gameState!.pendingSpellCast!.counterGrade).toBe('avoid')
+    })
+
+    it('grades "halve" when pressed after 4.5s', () => {
+      const gs = makeGameState({ gameTime: 4800, pendingSpellCast: makeCast() })
+      const state = withGameState(gs)
+
+      const next = battleReducer(state, { type: 'COUNTER_SPELL' })
+
+      expect(next.gameState!.pendingSpellCast!.counterGrade).toBe('halve')
+    })
+
+    it('is a no-op when no cast is pending', () => {
+      const state = withGameState(makeGameState({ pendingSpellCast: null }))
+
+      const next = battleReducer(state, { type: 'COUNTER_SPELL' })
+
+      expect(next).toBe(state)
+    })
+
+    it('is a no-op once the cast already has a grade', () => {
+      const gs = makeGameState({ gameTime: 1000, pendingSpellCast: makeCast({ counterGrade: 'avoid' }) })
+      const state = withGameState(gs)
+
+      const next = battleReducer(state, { type: 'COUNTER_SPELL' })
+
+      expect(next).toBe(state)
     })
   })
 

--- a/web/src/game/battleReducer.ts
+++ b/web/src/game/battleReducer.ts
@@ -17,6 +17,7 @@
 import { GameState, BattleStats, Card } from './types'
 import { tick as engineTick } from './engine'
 import { playCard as enginePlayCard } from './engine/cards'
+import { COUNTER_WINDOW_AVOID_START_MS, COUNTER_WINDOW_HALVE_START_MS } from './engine/constants'
 import type { DailyChallengeState } from './dailyChallenge'
 import { generateEndlessRewardChoices } from './questline'
 
@@ -98,6 +99,8 @@ export type BattleAction =
   | { type: 'SET_STANCE'; stance: NonNullable<GameState['playerStance']> }
   /** Change the game speed multiplier. */
   | { type: 'SET_SPEED'; multiplier: 1 | 2 | 4 | 8 }
+  /** Player pressed Counter during an opponent spell-cast windup; grades by press timing. */
+  | { type: 'COUNTER_SPELL' }
 
 // ─── Reducer ──────────────────────────────────────────────
 
@@ -217,6 +220,18 @@ export function battleReducer(state: BattleState, action: BattleAction): BattleS
 
     case 'SET_SPEED':
       return { ...state, speedMultiplier: action.multiplier }
+
+    case 'COUNTER_SPELL': {
+      const gs = state.gameState
+      const cast = gs?.pendingSpellCast
+      if (!gs || !cast || cast.counterGrade) return state
+      const elapsed = gs.gameTime - cast.startedAtMs
+      const grade: 'avoid' | 'halve' | 'full' =
+        elapsed < COUNTER_WINDOW_AVOID_START_MS ? 'full'
+        : elapsed < COUNTER_WINDOW_HALVE_START_MS ? 'avoid'
+        : 'halve'
+      return { ...state, gameState: { ...gs, pendingSpellCast: { ...cast, counterGrade: grade } } }
+    }
 
     default:
       return state

--- a/web/src/game/engine.ts
+++ b/web/src/game/engine.ts
@@ -10,7 +10,7 @@ import { genericBossAI, getBossAIDef } from './engine/boss'
 import { tickBossTrait } from './engine/bossTraits'
 import { getManaBonus, getManaSpeedMult } from './engine/bonusEffects'
 import { uid, shuffle, spawnUnit, spawnCommander } from './engine/helpers'
-import { MAX_UPGRADE_LEVEL } from './engine/cards'
+import { MAX_UPGRADE_LEVEL, resolveSpellCast } from './engine/cards'
 import { unitDist } from './engine/targeting'
 import { opponentAI } from './engine/opponentAI'
 import { triggerBattleEvent, BATTLE_EVENT_BASE_MS } from './engine/battleEvents'
@@ -335,6 +335,7 @@ export function newGame(
     forgiveManaLimit: forgiveManaLimit ?? false,
     deckMaxMana,
     bossPhase2Hp,
+    pendingSpellCast: null,
   }
 }
 
@@ -508,6 +509,7 @@ export function tick(state: GameState, deltaMs: number): GameState {
     opponentHand:      [...state.opponentHand],
     opponentDeck:      [...state.opponentDeck],
     activeBattleEvent: state.activeBattleEvent ? { ...state.activeBattleEvent } : null,
+    pendingSpellCast: state.pendingSpellCast ? { ...state.pendingSpellCast } : null,
     bossTraitState:    state.bossTraitState ? {
       ...state.bossTraitState,
       firedThresholds: [...state.bossTraitState.firedThresholds],
@@ -549,6 +551,9 @@ export function tick(state: GameState, deltaMs: number): GameState {
 
   // 4. Process per-unit attacks
   processAttacks(s, deltaMs, log)
+
+  // 3c. Resolve any opponent spell cast whose windup has elapsed (must run before HP sync/game-over)
+  resolveSpellCast(s, log)
 
   // 4a. Sync commander/boss HP → base HP so game-over check and UI bars are accurate.
   // find() matches a dying commander (hp 0, dyingTimer running). If the commander is gone

--- a/web/src/game/engine/boss.ts
+++ b/web/src/game/engine/boss.ts
@@ -1,7 +1,7 @@
 import bossAIDefsRaw from '../../data/bossAIs.json'
 import { Card, GameState } from '../types'
 import { BASE_MAX_MANA } from './constants'
-import { deployCard } from './cards'
+import { deployOpponentCard } from './cards'
 import { getManaBonus } from './bonusEffects'
 import { drawCard } from './helpers'
 import { isPlayable } from './opponentAI'
@@ -153,7 +153,7 @@ export function genericBossAI(s: GameState, log: string[], def: BossAIDef): void
       if (!pick) continue
       s.opponentHand.splice(s.opponentHand.indexOf(pick), 1)
       mana -= pick.cost
-      deployCard(s, pick, 'opponent', log)
+      deployOpponentCard(s, pick, log)
       drawCard(s.opponentDeck, s.opponentHand)
       return true
     }

--- a/web/src/game/engine/cards.test.ts
+++ b/web/src/game/engine/cards.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Unit tests for the opponent spell-cast telegraph + Counter QTE mechanics
+ * (deployOpponentCard / applyAoeDamage / resolveSpellCast) in engine/cards.ts.
+ */
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('../sound', () => ({
+  playUnitDeath: vi.fn(),
+  playBuildingDestroyed: vi.fn(),
+  playCardPlay: vi.fn(),
+  playUpgrade: vi.fn(),
+  playBaseHit: vi.fn(),
+  playVictory: vi.fn(),
+  playDefeat: vi.fn(),
+}))
+
+vi.mock('../debug', () => ({
+  isNoDamageMode: () => false,
+}))
+
+import { newGame } from '../engine'
+import { deployOpponentCard, applyAoeDamage, resolveSpellCast } from './cards'
+import { CAST_WINDUP_MS } from './constants'
+import { Card, GameState, PendingSpellCast } from '../types'
+
+function makeAoeCard(overrides: Partial<Card> = {}): Card {
+  return {
+    id: 'test-aoe-card',
+    name: 'Roots Burst',
+    rarity: 'common',
+    cost: 3,
+    cardType: 'upgrade',
+    description: 'AOE damage spell',
+    upgradeEffect: { type: 'aoe', damage: 15 },
+    ...overrides,
+  }
+}
+
+describe('deployOpponentCard', () => {
+  it('telegraphs a damage-AOE card instead of applying damage immediately', () => {
+    const s = newGame()
+    const card = makeAoeCard()
+    const log: string[] = []
+    const playerCmd = s.field.find(u => u.isCommander && u.owner === 'player')!
+    const hpBefore = playerCmd.hp
+
+    deployOpponentCard(s, card, log)
+
+    expect(s.pendingSpellCast).not.toBeNull()
+    expect(s.pendingSpellCast!.cardName).toBe('Roots Burst')
+    expect(s.pendingSpellCast!.resolvesAtMs).toBe(s.gameTime + CAST_WINDUP_MS)
+    expect(s.pendingSpellCast!.counterGrade).toBeUndefined()
+    // No damage applied yet — the commander is untouched
+    expect(playerCmd.hp).toBe(hpBefore)
+    expect(log.some(l => l.includes('Roots Burst'))).toBe(true)
+  })
+
+  it('resolves a second simultaneous cast immediately (single-flight guard)', () => {
+    const s = newGame()
+    const first = makeAoeCard({ id: 'first', name: 'First Spell' })
+    const second = makeAoeCard({ id: 'second', name: 'Second Spell' })
+    const log: string[] = []
+
+    deployOpponentCard(s, first, log)
+    expect(s.pendingSpellCast!.cardName).toBe('First Spell')
+
+    const playerCmd = s.field.find(u => u.isCommander && u.owner === 'player')!
+    const hpBefore = playerCmd.hp
+    deployOpponentCard(s, second, log)
+
+    // Still the first cast pending; the second resolved instantly via deployCard
+    expect(s.pendingSpellCast!.cardName).toBe('First Spell')
+    expect(playerCmd.hp).toBeLessThan(hpBefore)
+  })
+
+  it('deploys non-AOE cards immediately, unaffected by the telegraph path', () => {
+    const s = newGame()
+    const unitCard = s.opponentHand.find(c => c.cardType === 'unit')
+    if (!unitCard) return // skip if opponent hand has no unit card this run
+    const log: string[] = []
+    const fieldCountBefore = s.field.length
+
+    deployOpponentCard(s, unitCard, log)
+
+    expect(s.pendingSpellCast).toBeNull()
+    expect(s.field.length).toBeGreaterThan(fieldCountBefore)
+  })
+})
+
+describe('applyAoeDamage', () => {
+  it('scales damage by the multiplier and reports hit targets', () => {
+    const s = newGame()
+    const playerCmd = s.field.find(u => u.isCommander && u.owner === 'player')!
+    const hpBefore = playerCmd.hp
+
+    const { targets, dmg } = applyAoeDamage(s, { type: 'aoe', damage: 20 }, 'opponent', 0.5)
+
+    expect(dmg).toBe(10)
+    expect(targets).toContain(playerCmd)
+    expect(playerCmd.hp).toBe(hpBefore - 10)
+  })
+
+  it('applies zero damage with a 0 multiplier (full counter)', () => {
+    const s = newGame()
+    const playerCmd = s.field.find(u => u.isCommander && u.owner === 'player')!
+    const hpBefore = playerCmd.hp
+
+    applyAoeDamage(s, { type: 'aoe', damage: 50 }, 'opponent', 0)
+
+    expect(playerCmd.hp).toBe(hpBefore)
+  })
+})
+
+describe('resolveSpellCast', () => {
+  function withPendingCast(s: GameState, overrides: Partial<PendingSpellCast> = {}): void {
+    s.pendingSpellCast = {
+      cardName: 'Roots Burst',
+      effect: { type: 'aoe', damage: 25 },
+      startedAtMs: s.gameTime,
+      resolvesAtMs: s.gameTime + CAST_WINDUP_MS,
+      ...overrides,
+    }
+  }
+
+  it('does nothing before the windup has elapsed', () => {
+    const s = newGame()
+    withPendingCast(s)
+    const log: string[] = []
+
+    resolveSpellCast(s, log)
+
+    expect(s.pendingSpellCast).not.toBeNull()
+    expect(log).toEqual([])
+  })
+
+  it('applies full damage once the windup elapses with no counter', () => {
+    const s = newGame()
+    const playerCmd = s.field.find(u => u.isCommander && u.owner === 'player')!
+    const hpBefore = playerCmd.hp
+    withPendingCast(s)
+    s.gameTime = s.pendingSpellCast!.resolvesAtMs
+    const log: string[] = []
+
+    resolveSpellCast(s, log)
+
+    expect(s.pendingSpellCast).toBeNull()
+    expect(playerCmd.hp).toBe(hpBefore - 25)
+    expect(s.lastPlayerDamageSource).toEqual({ kind: 'spell', name: 'Roots Burst' })
+  })
+
+  it('negates all damage when countered with grade "avoid"', () => {
+    const s = newGame()
+    const playerCmd = s.field.find(u => u.isCommander && u.owner === 'player')!
+    const hpBefore = playerCmd.hp
+    withPendingCast(s, { counterGrade: 'avoid' })
+    s.gameTime = s.pendingSpellCast!.resolvesAtMs
+    const log: string[] = []
+
+    resolveSpellCast(s, log)
+
+    expect(playerCmd.hp).toBe(hpBefore)
+    expect(s.lastPlayerDamageSource).toBeUndefined()
+    expect(log.some(l => l.includes('counter'))).toBe(true)
+  })
+
+  it('halves damage when countered with grade "halve"', () => {
+    const s = newGame()
+    const playerCmd = s.field.find(u => u.isCommander && u.owner === 'player')!
+    const hpBefore = playerCmd.hp
+    withPendingCast(s, { counterGrade: 'halve' })
+    s.gameTime = s.pendingSpellCast!.resolvesAtMs
+    const log: string[] = []
+
+    resolveSpellCast(s, log)
+
+    expect(playerCmd.hp).toBe(hpBefore - Math.round(25 * 0.5))
+  })
+})

--- a/web/src/game/engine/cards.ts
+++ b/web/src/game/engine/cards.ts
@@ -8,7 +8,7 @@ import { playUpgrade } from '../sound';
 import {
   ARCH_STRUCTURE_COST_REDUCTION, ARCH_STRUCTURE_HP_MULT,
   ARCH_SWARM_UNIT_THRESHOLD, ARCH_SWARM_COST_REDUCTION,
-  ARCH_SCHOLAR_UPGRADE_MULT,
+  ARCH_SCHOLAR_UPGRADE_MULT, CAST_WINDUP_MS,
 } from './constants';
 import { DEATH_LINGER_MS } from './combat';
 
@@ -169,7 +169,37 @@ export function deployCard(s: GameState, card: Card, owner: 'player' | 'opponent
   } else if (card.cardType === 'upgrade' && card.upgradeEffect) {
     applyUpgrade(s, card.upgradeEffect, owner, log);
   }
-}// ─── Play Card (immediate deploy + cooldown) ─────────────
+}
+
+// ─── Deploy an opponent card, telegraphing damage-AOE casts ─
+
+/**
+ * Deploy an opponent card, deferring damage resolution if it's an AOE-damage upgrade.
+ * Mana spend / hand removal / draw remain the caller's responsibility (unchanged) —
+ * this only decides whether to telegraph the cast instead of applying it immediately.
+ * Player-played cards never go through here; they always resolve instantly.
+ */
+export function deployOpponentCard(s: GameState, card: Card, log: string[]): void {
+  const isDamageAoe =
+    card.cardType === 'upgrade' &&
+    card.upgradeEffect?.type === 'aoe' &&
+    (card.upgradeEffect.damage ?? card.upgradeEffect.amount ?? 0) > 0;
+
+  // Single-flight guard: if a cast is already pending, resolve this one immediately
+  // instead of queuing a second telegraph.
+  if (isDamageAoe && !s.pendingSpellCast) {
+    s.pendingSpellCast = {
+      cardName: card.name,
+      effect: card.upgradeEffect as Extract<UpgradeEffect, { type: 'aoe' }>,
+      startedAtMs: s.gameTime,
+      resolvesAtMs: s.gameTime + CAST_WINDUP_MS,
+    };
+    log.push(`⚡ Opponent channels ${card.name}!`);
+    return;
+  }
+  deployCard(s, card, 'opponent', log);
+}
+// ─── Play Card (immediate deploy + cooldown) ─────────────
 
 export const MAX_UPGRADE_LEVEL = 4
 
@@ -289,6 +319,52 @@ export function playAoeCard(state: GameState, cardId: string, cx: number, cy: nu
   }
   return s
 }
+// ─── AOE Damage ───────────────────────────────────────────
+
+/** Apply an 'aoe' UpgradeEffect's damage to the field, scaled by dmgMultiplier (used by the Counter QTE). */
+export function applyAoeDamage(
+  s: GameState,
+  effect: Extract<UpgradeEffect, { type: 'aoe' }>,
+  owner: 'player' | 'opponent',
+  dmgMultiplier: number = 1,
+): { targets: Unit[]; dmg: number } {
+  const dmg = Math.round((effect.damage ?? effect.amount ?? 0) * dmgMultiplier)
+  const enemies = s.field.filter(u => u.owner !== owner && !u.isWall)
+  const targets = effect.range != null
+    ? enemies.filter(e => owner === 'player'
+      ? e.x <= effect.range!
+      : (LANE_WIDTH - e.x) <= effect.range!)
+    : enemies
+  for (const u of targets) {
+    u.hp -= dmg
+    u.damageFlashTimer = 200
+    // Mark mobile kills as dying so they linger for the death animation and aren't
+    // silently purged before the commander/base HP sync + game-over check can see them.
+    if (u.hp <= 0 && u.moveSpeed > 0 && !u.isWall) u.dyingTimer = DEATH_LINGER_MS
+  }
+  return { targets, dmg }
+}
+
+/** Resolve a pending opponent spell cast once its windup has elapsed, applying damage
+ *  graded by the player's Counter QTE result (avoid = 0x, halve = 0.5x, full = 1x). */
+export function resolveSpellCast(s: GameState, log: string[]): void {
+  const cast = s.pendingSpellCast
+  if (!cast || s.gameTime < cast.resolvesAtMs) return
+
+  const mult = cast.counterGrade === 'avoid' ? 0 : cast.counterGrade === 'halve' ? 0.5 : 1
+  const { targets, dmg } = applyAoeDamage(s, cast.effect, 'opponent', mult)
+
+  if (mult === 0) {
+    log.push(`🛡️ You counter ${cast.cardName} — no damage taken!`)
+  } else {
+    const qualifier = mult === 0.5 ? ' (halved by your counter!)' : ''
+    log.push(`Enemy ${cast.cardName}! ${targets.length} unit${targets.length === 1 ? '' : 's'} hit for ${dmg} damage${qualifier}.`)
+    const hitCommander = targets.some(u => u.isCommander && u.owner === 'player')
+    if (hitCommander && dmg > 0) s.lastPlayerDamageSource = { kind: 'spell', name: cast.cardName }
+  }
+  s.pendingSpellCast = null
+}
+
 // ─── Apply Upgrade ────────────────────────────────────────
 
 export function applyUpgrade(s: GameState, effect: UpgradeEffect, owner: 'player' | 'opponent', log: string[]): void {
@@ -314,20 +390,7 @@ export function applyUpgrade(s: GameState, effect: UpgradeEffect, owner: 'player
     for (const u of units) if (u.attackRange > 0) { u.attackRange += effect.amount; addBuff(u, 'range')} 
     log.push(`${label} units gain +${effect.amount} attack range!`)
   } else if (effect.type === 'aoe') {
-    const dmg = effect.damage ?? effect.amount ?? 0
-    const enemies = s.field.filter(u => u.owner !== owner && !u.isWall)
-    const targets = effect.range != null
-      ? enemies.filter(e => owner === 'player'
-        ? e.x <= effect.range!
-        : (LANE_WIDTH - e.x) <= effect.range!)
-      : enemies
-    for (const u of targets) {
-      u.hp -= dmg
-      u.damageFlashTimer = 200
-      // Mark mobile kills as dying so they linger for the death animation and aren't
-      // silently purged before the commander/base HP sync + game-over check can see them.
-      if (u.hp <= 0 && u.moveSpeed > 0 && !u.isWall) u.dyingTimer = DEATH_LINGER_MS
-    }
+    const { targets, dmg } = applyAoeDamage(s, effect, owner)
     log.push(`${label} AOE! ${targets.length} enem${targets.length === 1 ? 'y' : 'ies'} hit for ${dmg} damage.`)
   } else if (effect.type === 'buffHp') {
     for (const u of units) if (u.hp >= 1) u.hp = Math.min(u.maxHp, u.hp + effect.amount)

--- a/web/src/game/engine/combat.ts
+++ b/web/src/game/engine/combat.ts
@@ -81,6 +81,9 @@ export function processAttacks(s: GameState, deltaMs: number, log: string[]): vo
         if (isPlayer) s.playerScore += actualDamage
         else          s.opponentScore += actualDamage
         target.lastAttackerId = unit.id
+        if (target.isCommander && target.owner === 'player' && dmg > 0) {
+          s.lastPlayerDamageSource = { kind: 'unit', name: unit.name }
+        }
         if (target.targetId && target.targetId !== unit.id && target.attack > 0) {
           target.targetId = unit.id
         }
@@ -108,6 +111,9 @@ export function processAttacks(s: GameState, deltaMs: number, log: string[]): vo
             for (const e of aoeTargets) {
               e.hp = Math.max(0, e.hp - dmg)
               e.damageFlashTimer = DAMAGE_FLASH_MS
+              if (e.isCommander && e.owner === 'player' && dmg > 0) {
+                s.lastPlayerDamageSource = { kind: 'unit', name: unit.name }
+              }
               // Mark mobile kills as dying so they linger for the death animation and
               // aren't silently purged before the commander/base HP sync sees them.
               if (e.hp <= 0 && e.moveSpeed > 0 && !e.isWall && !e.dyingTimer) e.dyingTimer = DEATH_LINGER_MS

--- a/web/src/game/engine/constants.ts
+++ b/web/src/game/engine/constants.ts
@@ -18,6 +18,11 @@ export const BASE_STOP_MARGIN    = 0                // units may reach the base 
 export const COMMANDER_HOME_X    = 15               // player commander's home position
 export const COMMANDER_LEASH_PX  = 40              // max px a commander can stray from home
 
+// ─── Opponent Spell-Cast Telegraph + Counter QTE ──────────
+export const CAST_WINDUP_MS               = 5000  // windup before an opponent AOE spell resolves
+export const COUNTER_WINDOW_AVOID_START_MS = 2000  // elapsed ms after which a Counter press fully negates damage
+export const COUNTER_WINDOW_HALVE_START_MS = 4500  // elapsed ms after which a Counter press only halves damage
+
 // ─── Archetype Passive Multipliers ────────────────────────
 export const ARCH_STRUCTURE_COST_REDUCTION = 1     // Siege Commander: structures cost 1 less
 export const ARCH_STRUCTURE_HP_MULT        = 1.2   // Siege Commander: +20% structure max HP

--- a/web/src/game/engine/opponentAI.ts
+++ b/web/src/game/engine/opponentAI.ts
@@ -3,7 +3,7 @@
 
 import { Card, GameState } from "../types"
 import { BASE_MAX_MANA } from "./constants"
-import { deployCard } from "./cards"
+import { deployOpponentCard } from "./cards"
 import { getManaBonus } from "./bonusEffects"
 import { drawCard } from "./helpers"
 
@@ -49,7 +49,7 @@ export function opponentAI(s: GameState, log: string[]): void {
     mana -= card.cost
     played++
 
-    deployCard(s, card, 'opponent', log)
+    deployOpponentCard(s, card, log)
     drawCard(s.opponentDeck, s.opponentHand)
 
     // Turtle only plays 1 card per turn

--- a/web/src/game/types.sample.ts
+++ b/web/src/game/types.sample.ts
@@ -161,6 +161,7 @@ export const exampleGameState: GameState = {
   animEvents: [exampleAnimEvent],
   bloodPools: [{ id: 'bp1', x: 2, y: 3 }],
   hazards: [],
+  pendingSpellCast: null,
 };
 
 

--- a/web/src/game/types.ts
+++ b/web/src/game/types.ts
@@ -337,6 +337,22 @@ export interface BossTraitState {
   splitUnitIds?: string[]
 }
 
+// ─── Pending Spell Cast (opponent AOE telegraph) ──────────
+
+/** A damage-dealing AOE upgrade card the opponent has committed to (mana spent, card
+ *  consumed) but whose damage application is deferred behind a visible windup + Counter QTE. */
+export interface PendingSpellCast {
+  /** Card name, for the telegraph banner and GameOver "Defeated by" callout. */
+  cardName: string
+  effect: Extract<UpgradeEffect, { type: 'aoe' }>
+  /** gameTime (ms) when the cast was started. */
+  startedAtMs: number
+  /** gameTime (ms) when the damage resolves. */
+  resolvesAtMs: number
+  /** Set once the player has registered a Counter input during the window. */
+  counterGrade?: 'avoid' | 'halve' | 'full'
+}
+
 // ─── Battle Events ────────────────────────────────────────
 
 export type BattleEventType = 'bloodMoon' | 'fogOfWar' | 'supplyDrop' | 'earthquake'
@@ -470,6 +486,12 @@ export interface GameState {
   archetypePassive?: Archetype
   /** Current ATK multiplier applied to player mobile units by the Swarm Tactician passive. */
   swarmAtkMult?: number
+  /** Live opponent AOE-spell cast in its windup window. Null when no cast is pending. */
+  pendingSpellCast: PendingSpellCast | null
+  /** Source of the most recent damage dealt to the player's commander — drives the
+   *  GameOver "Defeated by" callout. Never cleared mid-battle, so it always reflects
+   *  the final blow once the battle ends. */
+  lastPlayerDamageSource?: { kind: 'spell'; name: string } | { kind: 'unit'; name: string }
 }
 
 export interface StanceRules {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1227,6 +1227,13 @@ body {
 .gameover--lose .gameover-message { color: var(--color-red); }
 .gameover--draw .gameover-message { color: #00ccff; }
 
+.gameover-killed-by {
+  font-size: var(--font-sm);
+  color: var(--game-text-color-muted);
+  text-align: center;
+  font-style: italic;
+}
+
 .gameover-stats {
   color: var(--game-text-color-dim);
   text-align: center;
@@ -6444,6 +6451,108 @@ body {
   0%, 100% { opacity: 1; }
   50%       { opacity: 0.5; }
 }
+
+/* ── Opponent spell-cast telegraph + Counter QTE ──────────── */
+.spell-cast-glow {
+  width: 90px;
+  height: 90px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(255, 60, 60, 0.55) 0%, rgba(255, 60, 60, 0.15) 55%, transparent 80%);
+  animation: spellCastGlowPulse 0.7s ease-in-out infinite;
+}
+@keyframes spellCastGlowPulse {
+  0%, 100% { opacity: 0.6; transform: translate(-50%, -50%) scale(0.9); }
+  50%       { opacity: 1;   transform: translate(-50%, -50%) scale(1.15); }
+}
+
+.spell-cast-banner {
+  position: absolute;
+  top: 8px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 70;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: rgba(30, 0, 0, 0.92);
+  border: 1px solid rgba(255, 70, 70, 0.85);
+  border-radius: 4px;
+  padding: 5px 14px;
+  color: #ffb0b0;
+  font-size: var(--font-md);
+  font-weight: bold;
+  letter-spacing: 1px;
+  pointer-events: none;
+  animation: spellCastBannerPulse 0.8s ease-in-out infinite;
+}
+.spell-cast-banner-timer {
+  font-variant-numeric: tabular-nums;
+  color: #fff;
+}
+.spell-cast-banner-bar {
+  width: 70px;
+  height: 5px;
+  border-radius: 3px;
+  background: rgba(255, 255, 255, 0.15);
+  overflow: hidden;
+}
+.spell-cast-banner-bar-fill {
+  height: 100%;
+  background: linear-gradient(90deg, #ff4444, #ff9944);
+  transition: width 0.1s linear;
+}
+@keyframes spellCastBannerPulse {
+  0%, 100% { border-color: rgba(255, 70, 70, 0.85); }
+  50%       { border-color: rgba(255, 140, 140, 1); }
+}
+
+.spell-cast-counter-btn {
+  position: absolute;
+  bottom: 14%;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 70;
+  background: rgba(40, 0, 0, 0.9);
+  border: 2px solid rgba(255, 70, 70, 0.9);
+  border-radius: 8px;
+  color: #ffdddd;
+  font-size: var(--font-lg);
+  font-weight: bold;
+  letter-spacing: 2px;
+  padding: 10px 26px;
+  cursor: pointer;
+  animation: spellCastCounterPulse 0.8s ease-in-out infinite;
+}
+.spell-cast-counter-btn--danger {
+  border-color: rgba(80, 255, 120, 0.95);
+  color: #d0ffd8;
+  animation: spellCastCounterDanger 0.4s ease-in-out infinite;
+}
+@keyframes spellCastCounterPulse {
+  0%, 100% { transform: translateX(-50%) scale(1); }
+  50%       { transform: translateX(-50%) scale(1.05); }
+}
+@keyframes spellCastCounterDanger {
+  0%, 100% { box-shadow: 0 0 6px rgba(80, 255, 120, 0.5); }
+  50%       { box-shadow: 0 0 18px rgba(80, 255, 120, 0.9); }
+}
+
+.spell-cast-grade {
+  position: absolute;
+  bottom: 14%;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 70;
+  font-size: var(--font-lg);
+  font-weight: bold;
+  letter-spacing: 2px;
+  padding: 8px 22px;
+  border-radius: 8px;
+  background: rgba(0, 0, 0, 0.85);
+}
+.spell-cast-grade--avoid { color: #80ff90; border: 2px solid rgba(80, 255, 120, 0.9); }
+.spell-cast-grade--halve { color: #ffd980; border: 2px solid rgba(255, 200, 80, 0.9); }
+.spell-cast-grade--full  { color: #ff8080; border: 2px solid rgba(255, 70, 70, 0.9); }
 
 .sudden-death-overlay {
   position: absolute;


### PR DESCRIPTION
## Summary
- Opponent-cast damage-AOE upgrade cards (e.g. "Roots burst") now telegraph a 5s windup instead of resolving instantly — they previously could one-shot the commander/base with zero warning.
- During the windup, the player can press **Counter** (Space/Enter or an on-screen button), graded by timing into avoid (no damage) / halve (50% damage) / full (no benefit, too early or too late).
- Speed multiplier auto-drops to 1x when a cast starts, so every player gets the same real 5 seconds to react regardless of fast-forward setting — applies uniformly across quick play, campaign, endless, and challenge modes.
- The GameOver screen now shows a "Defeated by" line calling out what landed the final blow on the commander — the spell name, or the attacking unit's name.
- Scope: opponent-cast spell (upgrade) cards only. The existing boss "trait" windup/landing-attack system is untouched.

## Test plan
- [x] `npx tsc --noEmit` — no type errors
- [x] `npm test` — 233 tests passing (14 new, covering `deployOpponentCard`, `applyAoeDamage`, `resolveSpellCast`, and the `COUNTER_SPELL` reducer action across all three timing zones)
- [x] `npm run build` — production build succeeds
- [ ] Manual browser run-through (not possible in this sandbox — no browser binary available due to network egress restrictions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01EWKtercfK2nWk9oRp8njfY)_