### PR TITLE
Fix Counter QTE punishing fast reactions against one-shot spells

### DIFF
--- a/web/src/components/battle/Battlefield.tsx
+++ b/web/src/components/battle/Battlefield.tsx
@@ -9,7 +9,7 @@ import { spriteSlug } from '../../game/sprites'
 import { BattleEventOverlay } from './BattleEventOverlay'
 import { isNoDamageMode, isDebugMode } from '../../game/debug'
 import { MAX_UPGRADE_LEVEL, getEffectiveCardCost } from '../../game/engine/cards'
-import { CAST_WINDUP_MS, COUNTER_WINDOW_AVOID_START_MS, COUNTER_WINDOW_HALVE_START_MS } from '../../game/engine/constants'
+import { CAST_WINDUP_MS, COUNTER_WINDOW_HALVE_START_MS } from '../../game/engine/constants'
 import { SUDDEN_DEATH_FORCE_MS } from '../../game/engine/suddenDeath'
 import { getRelicDef } from '../../game/relics'
 import { getUnitLore, getCardCatalog } from '../../game/cards'
@@ -1033,7 +1033,9 @@ export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPaus
           const glowTop  = opCmd ? (1 - opCmd.x / LANE_WIDTH) * 100 : 4
           const glowLeft = opCmd ? 50 + (opCmd.y / 80) * 36 : 50
           const elapsed = state.gameTime - cast.startedAtMs
-          const inDangerZone = elapsed >= COUNTER_WINDOW_AVOID_START_MS && elapsed < COUNTER_WINDOW_HALVE_START_MS
+          // Pressing Counter is never punished for being early — only the final stretch
+          // before resolution (the "closing window") downgrades the press to a half-block.
+          const closingWindow = elapsed >= COUNTER_WINDOW_HALVE_START_MS
           return (
             <>
               <div className="spell-cast-glow" style={{ position: 'absolute', top: `${glowTop}%`, left: `${glowLeft}%`, transform: 'translate(-50%,-50%)', pointerEvents: 'none', zIndex: 55 }} aria-hidden />
@@ -1043,11 +1045,11 @@ export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPaus
                 <div className="spell-cast-banner-bar"><div className="spell-cast-banner-bar-fill" style={{ width: `${pct * 100}%` }} /></div>
               </div>
               {!cast.counterGrade && (
-                <button className={`spell-cast-counter-btn ${inDangerZone ? 'spell-cast-counter-btn--danger' : ''}`} onClick={() => onCounterSpell?.()}>COUNTER!</button>
+                <button className={`spell-cast-counter-btn ${closingWindow ? 'spell-cast-counter-btn--closing' : ''}`} onClick={() => onCounterSpell?.()}>COUNTER!</button>
               )}
               {cast.counterGrade && (
                 <div className={`spell-cast-grade spell-cast-grade--${cast.counterGrade}`}>
-                  {cast.counterGrade === 'avoid' ? 'DODGED!' : cast.counterGrade === 'halve' ? 'PARTIAL BLOCK' : 'TOO SLOW'}
+                  {cast.counterGrade === 'avoid' ? 'DODGED!' : 'PARTIAL BLOCK'}
                 </div>
               )}
             </>

--- a/web/src/game/battleReducer.test.ts
+++ b/web/src/game/battleReducer.test.ts
@@ -411,16 +411,18 @@ describe('battleReducer', () => {
       }
     }
 
-    it('grades "full" when pressed in the first 2s', () => {
-      const gs = makeGameState({ gameTime: 1000, pendingSpellCast: makeCast() })
+    it('grades "avoid" when pressed early — reacting fast must never be punished', () => {
+      // Regression: pressing with 3.5s left (1.5s elapsed) used to grade "full" (no
+      // protection at all), letting a high-damage spell one-shot the commander anyway.
+      const gs = makeGameState({ gameTime: 1500, pendingSpellCast: makeCast() })
       const state = withGameState(gs)
 
       const next = battleReducer(state, { type: 'COUNTER_SPELL' })
 
-      expect(next.gameState!.pendingSpellCast!.counterGrade).toBe('full')
+      expect(next.gameState!.pendingSpellCast!.counterGrade).toBe('avoid')
     })
 
-    it('grades "avoid" when pressed in the 2-4.5s danger zone', () => {
+    it('grades "avoid" when pressed anywhere before the 4.5s closing window', () => {
       const gs = makeGameState({ gameTime: 3000, pendingSpellCast: makeCast() })
       const state = withGameState(gs)
 

--- a/web/src/game/battleReducer.ts
+++ b/web/src/game/battleReducer.ts
@@ -17,7 +17,7 @@
 import { GameState, BattleStats, Card } from './types'
 import { tick as engineTick } from './engine'
 import { playCard as enginePlayCard } from './engine/cards'
-import { COUNTER_WINDOW_AVOID_START_MS, COUNTER_WINDOW_HALVE_START_MS } from './engine/constants'
+import { COUNTER_WINDOW_HALVE_START_MS } from './engine/constants'
 import type { DailyChallengeState } from './dailyChallenge'
 import { generateEndlessRewardChoices } from './questline'
 
@@ -226,10 +226,7 @@ export function battleReducer(state: BattleState, action: BattleAction): BattleS
       const cast = gs?.pendingSpellCast
       if (!gs || !cast || cast.counterGrade) return state
       const elapsed = gs.gameTime - cast.startedAtMs
-      const grade: 'avoid' | 'halve' | 'full' =
-        elapsed < COUNTER_WINDOW_AVOID_START_MS ? 'full'
-        : elapsed < COUNTER_WINDOW_HALVE_START_MS ? 'avoid'
-        : 'halve'
+      const grade: 'avoid' | 'halve' = elapsed < COUNTER_WINDOW_HALVE_START_MS ? 'avoid' : 'halve'
       return { ...state, gameState: { ...gs, pendingSpellCast: { ...cast, counterGrade: grade } } }
     }
 

--- a/web/src/game/engine/cards.test.ts
+++ b/web/src/game/engine/cards.test.ts
@@ -175,4 +175,20 @@ describe('resolveSpellCast', () => {
 
     expect(playerCmd.hp).toBe(hpBefore - Math.round(25 * 0.5))
   })
+
+  it('survives an otherwise one-shot spell when countered with grade "avoid"', () => {
+    // "World's End" deals 180 damage — well above a full-health commander's max HP.
+    // A countered "avoid" must zero out the damage entirely, not just reduce it.
+    const s = newGame()
+    const playerCmd = s.field.find(u => u.isCommander && u.owner === 'player')!
+    const hpBefore = playerCmd.hp
+    withPendingCast(s, { cardName: "World's End", effect: { type: 'aoe', damage: 180 }, counterGrade: 'avoid' })
+    s.gameTime = s.pendingSpellCast!.resolvesAtMs
+    const log: string[] = []
+
+    resolveSpellCast(s, log)
+
+    expect(playerCmd.hp).toBe(hpBefore)
+    expect(s.phase.type).not.toBe('gameOver')
+  })
 })

--- a/web/src/game/engine/cards.ts
+++ b/web/src/game/engine/cards.ts
@@ -346,7 +346,7 @@ export function applyAoeDamage(
 }
 
 /** Resolve a pending opponent spell cast once its windup has elapsed, applying damage
- *  graded by the player's Counter QTE result (avoid = 0x, halve = 0.5x, full = 1x). */
+ *  graded by the player's Counter QTE result (avoid = 0x, halve = 0.5x, no press = 1x). */
 export function resolveSpellCast(s: GameState, log: string[]): void {
   const cast = s.pendingSpellCast
   if (!cast || s.gameTime < cast.resolvesAtMs) return

--- a/web/src/game/engine/constants.ts
+++ b/web/src/game/engine/constants.ts
@@ -20,7 +20,9 @@ export const COMMANDER_LEASH_PX  = 40              // max px a commander can str
 
 // ─── Opponent Spell-Cast Telegraph + Counter QTE ──────────
 export const CAST_WINDUP_MS               = 5000  // windup before an opponent AOE spell resolves
-export const COUNTER_WINDOW_AVOID_START_MS = 2000  // elapsed ms after which a Counter press fully negates damage
+// A Counter press fully negates damage any time before this; pressing in the final stretch
+// of the windup (the "closing window") only halves it. Pressing early is never punished —
+// reacting the instant the telegraph appears must be enough to survive a one-shot spell.
 export const COUNTER_WINDOW_HALVE_START_MS = 4500  // elapsed ms after which a Counter press only halves damage
 
 // ─── Archetype Passive Multipliers ────────────────────────

--- a/web/src/game/types.ts
+++ b/web/src/game/types.ts
@@ -349,8 +349,9 @@ export interface PendingSpellCast {
   startedAtMs: number
   /** gameTime (ms) when the damage resolves. */
   resolvesAtMs: number
-  /** Set once the player has registered a Counter input during the window. */
-  counterGrade?: 'avoid' | 'halve' | 'full'
+  /** Set once the player has registered a Counter input during the window.
+   *  Absent (undefined) means no press was registered before resolution — full damage applies. */
+  counterGrade?: 'avoid' | 'halve'
 }
 
 // ─── Battle Events ────────────────────────────────────────

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -6523,18 +6523,18 @@ body {
   cursor: pointer;
   animation: spellCastCounterPulse 0.8s ease-in-out infinite;
 }
-.spell-cast-counter-btn--danger {
-  border-color: rgba(80, 255, 120, 0.95);
-  color: #d0ffd8;
-  animation: spellCastCounterDanger 0.4s ease-in-out infinite;
+.spell-cast-counter-btn--closing {
+  border-color: rgba(255, 180, 40, 0.95);
+  color: #ffe8c0;
+  animation: spellCastCounterClosing 0.3s ease-in-out infinite;
 }
 @keyframes spellCastCounterPulse {
   0%, 100% { transform: translateX(-50%) scale(1); }
   50%       { transform: translateX(-50%) scale(1.05); }
 }
-@keyframes spellCastCounterDanger {
-  0%, 100% { box-shadow: 0 0 6px rgba(80, 255, 120, 0.5); }
-  50%       { box-shadow: 0 0 18px rgba(80, 255, 120, 0.9); }
+@keyframes spellCastCounterClosing {
+  0%, 100% { box-shadow: 0 0 6px rgba(255, 180, 40, 0.5); }
+  50%       { box-shadow: 0 0 20px rgba(255, 180, 40, 0.95); }
 }
 
 .spell-cast-grade {
@@ -6552,7 +6552,6 @@ body {
 }
 .spell-cast-grade--avoid { color: #80ff90; border: 2px solid rgba(80, 255, 120, 0.9); }
 .spell-cast-grade--halve { color: #ffd980; border: 2px solid rgba(255, 200, 80, 0.9); }
-.spell-cast-grade--full  { color: #ff8080; border: 2px solid rgba(255, 70, 70, 0.9); }
 
 .sudden-death-overlay {
   position: absolute;


### PR DESCRIPTION
## Summary

Follow-up to the telegraphed opponent spell-cast + Counter QTE feature (#1769). Reported bug: pressing Counter with several seconds still left on the windup ("3.5s left") still took full damage — the daily challenge's mythic spell **World's End** (180 dmg) one-shot a full-health commander even when the player reacted.

Root cause: the QTE graded any press in the first 2s of the 5s windup as `'full'` (zero damage reduction), an anti-spam measure that backfired — a player who reacted *immediately* to the telegraph got no protection at all.

## Fix

- A Counter press now fully negates the spell (`'avoid'`) any time before the final 500ms of the windup. Only pressing in that closing window (or never pressing) yields a worse outcome (`'halve'` or full damage, respectively).
- Removed the now-unreachable `'full'` counter-grade value, the `COUNTER_WINDOW_AVOID_START_MS` constant, and the dead "TOO SLOW" / green "danger zone" UI states tied to it.
- Renamed the late-window button highlight from `--danger` (confusingly styled green) to `--closing` (amber, signaling "hurry, diminishing returns").

Spell damage values are untouched — this is purely a QTE-fairness fix, not a balance nerf.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 234/234 passing (added a regression test: pressing at 1.5s elapsed now grades `'avoid'`, and a 180-dmg "World's End"-style cast countered with `'avoid'` leaves the commander at full HP)
- [x] `npm run build` — succeeds
- [ ] Manual browser run-through — not possible in this sandbox (Playwright browser download is blocked by network egress policy)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01EWKtercfK2nWk9oRp8njfY)_