### PR TITLE
Cap Counter QTE damage instead of negating it, rewarding fast reactions

### DIFF
--- a/web/src/components/battle/Battlefield.tsx
+++ b/web/src/components/battle/Battlefield.tsx
@@ -1034,7 +1034,7 @@ export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPaus
           const glowLeft = opCmd ? 50 + (opCmd.y / 80) * 36 : 50
           const elapsed = state.gameTime - cast.startedAtMs
           // Pressing Counter is never punished for being early — only the final stretch
-          // before resolution (the "closing window") downgrades the press to a half-block.
+          // before resolution (the "closing window") downgrades the press to a higher damage cap.
           const closingWindow = elapsed >= COUNTER_WINDOW_HALVE_START_MS
           return (
             <>
@@ -1049,7 +1049,7 @@ export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPaus
               )}
               {cast.counterGrade && (
                 <div className={`spell-cast-grade spell-cast-grade--${cast.counterGrade}`}>
-                  {cast.counterGrade === 'avoid' ? 'DODGED!' : 'PARTIAL BLOCK'}
+                  {cast.counterGrade === 'avoid' ? 'BLOCKED!' : 'PARTIAL BLOCK'}
                 </div>
               )}
             </>

--- a/web/src/game/engine/cards.test.ts
+++ b/web/src/game/engine/cards.test.ts
@@ -109,6 +109,28 @@ describe('applyAoeDamage', () => {
 
     expect(playerCmd.hp).toBe(hpBefore)
   })
+
+  it('clamps damage to dmgCap when the raw damage exceeds it', () => {
+    const s = newGame()
+    const playerCmd = s.field.find(u => u.isCommander && u.owner === 'player')!
+    const hpBefore = playerCmd.hp
+
+    const { dmg } = applyAoeDamage(s, { type: 'aoe', damage: 180 }, 'opponent', 1, 10)
+
+    expect(dmg).toBe(10)
+    expect(playerCmd.hp).toBe(hpBefore - 10)
+  })
+
+  it('leaves damage unclamped when dmgCap exceeds the raw damage', () => {
+    const s = newGame()
+    const playerCmd = s.field.find(u => u.isCommander && u.owner === 'player')!
+    const hpBefore = playerCmd.hp
+
+    const { dmg } = applyAoeDamage(s, { type: 'aoe', damage: 15 }, 'opponent', 1, 20)
+
+    expect(dmg).toBe(15)
+    expect(playerCmd.hp).toBe(hpBefore - 15)
+  })
 })
 
 describe('resolveSpellCast', () => {
@@ -148,7 +170,8 @@ describe('resolveSpellCast', () => {
     expect(s.lastPlayerDamageSource).toEqual({ kind: 'spell', name: 'Roots Burst' })
   })
 
-  it('negates all damage when countered with grade "avoid"', () => {
+  it('caps damage at 20% of commander max HP when countered with grade "avoid" (quick)', () => {
+    // Commander max HP is 50 by default, so the quick cap is 10 — below the spell's raw 25.
     const s = newGame()
     const playerCmd = s.field.find(u => u.isCommander && u.owner === 'player')!
     const hpBefore = playerCmd.hp
@@ -158,12 +181,13 @@ describe('resolveSpellCast', () => {
 
     resolveSpellCast(s, log)
 
-    expect(playerCmd.hp).toBe(hpBefore)
-    expect(s.lastPlayerDamageSource).toBeUndefined()
+    expect(playerCmd.hp).toBe(hpBefore - 10)
+    expect(s.lastPlayerDamageSource).toEqual({ kind: 'spell', name: 'Roots Burst' })
     expect(log.some(l => l.includes('counter'))).toBe(true)
   })
 
-  it('halves damage when countered with grade "halve"', () => {
+  it('caps damage at 40% of commander max HP when countered with grade "halve" (late)', () => {
+    // Commander max HP is 50 by default, so the late cap is 20 — below the spell's raw 25.
     const s = newGame()
     const playerCmd = s.field.find(u => u.isCommander && u.owner === 'player')!
     const hpBefore = playerCmd.hp
@@ -173,12 +197,12 @@ describe('resolveSpellCast', () => {
 
     resolveSpellCast(s, log)
 
-    expect(playerCmd.hp).toBe(hpBefore - Math.round(25 * 0.5))
+    expect(playerCmd.hp).toBe(hpBefore - 20)
   })
 
-  it('survives an otherwise one-shot spell when countered with grade "avoid"', () => {
-    // "World's End" deals 180 damage — well above a full-health commander's max HP.
-    // A countered "avoid" must zero out the damage entirely, not just reduce it.
+  it('survives an otherwise one-shot spell when countered, but still takes some damage', () => {
+    // "World's End" deals 180 damage — well above a full-health commander's max HP (50).
+    // A counter must guarantee survival, but per design should never reduce damage to zero.
     const s = newGame()
     const playerCmd = s.field.find(u => u.isCommander && u.owner === 'player')!
     const hpBefore = playerCmd.hp
@@ -188,7 +212,28 @@ describe('resolveSpellCast', () => {
 
     resolveSpellCast(s, log)
 
-    expect(playerCmd.hp).toBe(hpBefore)
+    expect(playerCmd.hp).toBeLessThan(hpBefore)
+    expect(playerCmd.hp).toBeGreaterThan(0)
     expect(s.phase.type).not.toBe('gameOver')
+  })
+
+  it('rewards a quick counter with less damage than a late counter, on the same lethal spell', () => {
+    const quick = newGame()
+    const quickCmd = quick.field.find(u => u.isCommander && u.owner === 'player')!
+    withPendingCast(quick, { cardName: "World's End", effect: { type: 'aoe', damage: 180 }, counterGrade: 'avoid' })
+    quick.gameTime = quick.pendingSpellCast!.resolvesAtMs
+    resolveSpellCast(quick, [])
+
+    const late = newGame()
+    const lateCmd = late.field.find(u => u.isCommander && u.owner === 'player')!
+    withPendingCast(late, { cardName: "World's End", effect: { type: 'aoe', damage: 180 }, counterGrade: 'halve' })
+    late.gameTime = late.pendingSpellCast!.resolvesAtMs
+    resolveSpellCast(late, [])
+
+    const quickDmg = 50 - quickCmd.hp
+    const lateDmg = 50 - lateCmd.hp
+    expect(quickDmg).toBeLessThan(lateDmg)
+    expect(quickCmd.hp).toBeGreaterThan(0)
+    expect(lateCmd.hp).toBeGreaterThan(0)
   })
 })

--- a/web/src/game/engine/cards.ts
+++ b/web/src/game/engine/cards.ts
@@ -9,6 +9,7 @@ import {
   ARCH_STRUCTURE_COST_REDUCTION, ARCH_STRUCTURE_HP_MULT,
   ARCH_SWARM_UNIT_THRESHOLD, ARCH_SWARM_COST_REDUCTION,
   ARCH_SCHOLAR_UPGRADE_MULT, CAST_WINDUP_MS,
+  COUNTER_DAMAGE_CAP_QUICK_PCT, COUNTER_DAMAGE_CAP_LATE_PCT,
 } from './constants';
 import { DEATH_LINGER_MS } from './combat';
 
@@ -321,14 +322,17 @@ export function playAoeCard(state: GameState, cardId: string, cx: number, cy: nu
 }
 // ─── AOE Damage ───────────────────────────────────────────
 
-/** Apply an 'aoe' UpgradeEffect's damage to the field, scaled by dmgMultiplier (used by the Counter QTE). */
+/** Apply an 'aoe' UpgradeEffect's damage to the field, scaled by dmgMultiplier and
+ *  optionally clamped to dmgCap (both used by the Counter QTE). */
 export function applyAoeDamage(
   s: GameState,
   effect: Extract<UpgradeEffect, { type: 'aoe' }>,
   owner: 'player' | 'opponent',
   dmgMultiplier: number = 1,
+  dmgCap?: number,
 ): { targets: Unit[]; dmg: number } {
-  const dmg = Math.round((effect.damage ?? effect.amount ?? 0) * dmgMultiplier)
+  const rawDmg = Math.round((effect.damage ?? effect.amount ?? 0) * dmgMultiplier)
+  const dmg = dmgCap != null ? Math.min(rawDmg, dmgCap) : rawDmg
   const enemies = s.field.filter(u => u.owner !== owner && !u.isWall)
   const targets = effect.range != null
     ? enemies.filter(e => owner === 'player'
@@ -346,22 +350,29 @@ export function applyAoeDamage(
 }
 
 /** Resolve a pending opponent spell cast once its windup has elapsed, applying damage
- *  graded by the player's Counter QTE result (avoid = 0x, halve = 0.5x, no press = 1x). */
+ *  graded by the player's Counter QTE result. A successful counter never fully negates
+ *  damage — it caps it at a percentage of the commander's max HP (quick press = lower
+ *  cap, late press = higher cap), so a counter always guarantees survival against an
+ *  otherwise-lethal spell while still landing some chip damage. No press = full damage. */
 export function resolveSpellCast(s: GameState, log: string[]): void {
   const cast = s.pendingSpellCast
   if (!cast || s.gameTime < cast.resolvesAtMs) return
 
-  const mult = cast.counterGrade === 'avoid' ? 0 : cast.counterGrade === 'halve' ? 0.5 : 1
-  const { targets, dmg } = applyAoeDamage(s, cast.effect, 'opponent', mult)
-
-  if (mult === 0) {
-    log.push(`🛡️ You counter ${cast.cardName} — no damage taken!`)
-  } else {
-    const qualifier = mult === 0.5 ? ' (halved by your counter!)' : ''
-    log.push(`Enemy ${cast.cardName}! ${targets.length} unit${targets.length === 1 ? '' : 's'} hit for ${dmg} damage${qualifier}.`)
-    const hitCommander = targets.some(u => u.isCommander && u.owner === 'player')
-    if (hitCommander && dmg > 0) s.lastPlayerDamageSource = { kind: 'spell', name: cast.cardName }
+  let dmgCap: number | undefined
+  if (cast.counterGrade) {
+    const playerCmd = s.field.find(u => u.isCommander && u.owner === 'player')
+    const capPct = cast.counterGrade === 'avoid' ? COUNTER_DAMAGE_CAP_QUICK_PCT : COUNTER_DAMAGE_CAP_LATE_PCT
+    dmgCap = playerCmd ? Math.round(playerCmd.maxHp * capPct) : undefined
   }
+  const { targets, dmg } = applyAoeDamage(s, cast.effect, 'opponent', 1, dmgCap)
+
+  if (cast.counterGrade) {
+    log.push(`🛡️ You counter ${cast.cardName} — damage capped at ${dmg}!`)
+  } else {
+    log.push(`Enemy ${cast.cardName}! ${targets.length} unit${targets.length === 1 ? '' : 's'} hit for ${dmg} damage.`)
+  }
+  const hitCommander = targets.some(u => u.isCommander && u.owner === 'player')
+  if (hitCommander && dmg > 0) s.lastPlayerDamageSource = { kind: 'spell', name: cast.cardName }
   s.pendingSpellCast = null
 }
 

--- a/web/src/game/engine/constants.ts
+++ b/web/src/game/engine/constants.ts
@@ -20,10 +20,16 @@ export const COMMANDER_LEASH_PX  = 40              // max px a commander can str
 
 // ─── Opponent Spell-Cast Telegraph + Counter QTE ──────────
 export const CAST_WINDUP_MS               = 5000  // windup before an opponent AOE spell resolves
-// A Counter press fully negates damage any time before this; pressing in the final stretch
-// of the windup (the "closing window") only halves it. Pressing early is never punished —
-// reacting the instant the telegraph appears must be enough to survive a one-shot spell.
-export const COUNTER_WINDOW_HALVE_START_MS = 4500  // elapsed ms after which a Counter press only halves damage
+// A Counter press before this is graded "quick"; pressing in the final stretch of the
+// windup (the "closing window") is graded "late" instead. Pressing early is never
+// punished with extra damage — reacting fast always gets the better grade.
+export const COUNTER_WINDOW_HALVE_START_MS = 4500  // elapsed ms after which a Counter press is graded "late"
+// A successful counter never fully negates damage — it caps it, so a quick reaction is
+// rewarded with a lower cap but big spells (e.g. one-shot-capable mythics) still chip in
+// some damage. Damage dealt = min(spell's raw damage, this % of the commander's max HP).
+// Not countering at all still applies the spell's damage in full (100%, uncapped).
+export const COUNTER_DAMAGE_CAP_QUICK_PCT  = 0.2   // "quick" grade: damage capped at 20% of commander max HP
+export const COUNTER_DAMAGE_CAP_LATE_PCT   = 0.4   // "late" grade: damage capped at 40% of commander max HP
 
 // ─── Archetype Passive Multipliers ────────────────────────
 export const ARCH_STRUCTURE_COST_REDUCTION = 1     // Siege Commander: structures cost 1 less


### PR DESCRIPTION
## Summary

Follow-up to #1770. Feedback: a successful Counter against a one-shot-capable spell ("World's End", 180 dmg) felt like a full dodge with zero reward differentiation for reacting quickly — both a quick press and a late press could fully negate or halve damage depending on timing zone, but there was no incentive to react *immediately* versus just-in-time.

## Change

A successful counter no longer fully negates or halves damage by a flat multiplier — it now **caps** damage at a percentage of the commander's max HP, whichever is lower than the spell's raw damage:

- Quick press (before the closing window): capped at 20% of commander max HP
- Late press (closing window, final 500ms): capped at 40% of commander max HP
- No press at all: full damage (100%, uncapped) — unchanged

This guarantees a counter always prevents an instant kill from an overwhelming spell, while still landing some chip damage — and a quick reaction now visibly takes less damage than a late one on the same spell. Weak spells (already below the cap) are unaffected, since `damage = min(cap, spellDamage)`.

Spell damage values themselves are untouched — this only changes how a successful counter scales the incoming hit.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 237/237 passing (added/rewrote regression tests: quick vs. late cap values, "World's End" countered still deals some damage but never kills, quick counter takes less damage than late on the same spell)
- [x] `npm run build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01EWKtercfK2nWk9oRp8njfY)_