### PR TITLE
Scale Counter QTE damage cap continuously with reaction time

### DIFF
--- a/web/src/components/battle/Battlefield.tsx
+++ b/web/src/components/battle/Battlefield.tsx
@@ -9,7 +9,7 @@ import { spriteSlug } from '../../game/sprites'
 import { BattleEventOverlay } from './BattleEventOverlay'
 import { isNoDamageMode, isDebugMode } from '../../game/debug'
 import { MAX_UPGRADE_LEVEL, getEffectiveCardCost } from '../../game/engine/cards'
-import { CAST_WINDUP_MS, COUNTER_WINDOW_HALVE_START_MS } from '../../game/engine/constants'
+import { CAST_WINDUP_MS, COUNTER_DAMAGE_FLOOR_PCT } from '../../game/engine/constants'
 import { SUDDEN_DEATH_FORCE_MS } from '../../game/engine/suddenDeath'
 import { getRelicDef } from '../../game/relics'
 import { getUnitLore, getCardCatalog } from '../../game/cards'
@@ -642,13 +642,13 @@ export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPaus
 
   // Counter an opponent's incoming spell cast via Space/Enter
   useEffect(() => {
-    if (!state.pendingSpellCast || state.pendingSpellCast.counterGrade) return
+    if (!state.pendingSpellCast || state.pendingSpellCast.counterPct != null) return
     const onKey = (e: KeyboardEvent) => {
       if (e.code === 'Space' || e.code === 'Enter') { e.preventDefault(); onCounterSpell?.() }
     }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
-  }, [state.pendingSpellCast?.cardName, state.pendingSpellCast?.counterGrade, onCounterSpell])
+  }, [state.pendingSpellCast?.cardName, state.pendingSpellCast?.counterPct, onCounterSpell])
 
   // Detect when a new hero unit appears on the field and fire the lightning effect
   useEffect(() => {
@@ -1033,9 +1033,10 @@ export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPaus
           const glowTop  = opCmd ? (1 - opCmd.x / LANE_WIDTH) * 100 : 4
           const glowLeft = opCmd ? 50 + (opCmd.y / 80) * 36 : 50
           const elapsed = state.gameTime - cast.startedAtMs
-          // Pressing Counter is never punished for being early — only the final stretch
-          // before resolution (the "closing window") downgrades the press to a higher damage cap.
-          const closingWindow = elapsed >= COUNTER_WINDOW_HALVE_START_MS
+          // The damage cap a press would lock in right now — grows linearly the longer the
+          // player waits, so "waiting for a better moment" is never actually better.
+          const liveCapPct = Math.max(COUNTER_DAMAGE_FLOOR_PCT, Math.min(1, elapsed / CAST_WINDUP_MS))
+          const dangerZone = liveCapPct >= 0.7
           return (
             <>
               <div className="spell-cast-glow" style={{ position: 'absolute', top: `${glowTop}%`, left: `${glowLeft}%`, transform: 'translate(-50%,-50%)', pointerEvents: 'none', zIndex: 55 }} aria-hidden />
@@ -1044,14 +1045,19 @@ export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPaus
                 <span className="spell-cast-banner-timer">{(remainingMs / 1000).toFixed(1)}s</span>
                 <div className="spell-cast-banner-bar"><div className="spell-cast-banner-bar-fill" style={{ width: `${pct * 100}%` }} /></div>
               </div>
-              {!cast.counterGrade && (
-                <button className={`spell-cast-counter-btn ${closingWindow ? 'spell-cast-counter-btn--closing' : ''}`} onClick={() => onCounterSpell?.()}>COUNTER!</button>
+              {cast.counterPct == null && (
+                <button className={`spell-cast-counter-btn ${dangerZone ? 'spell-cast-counter-btn--closing' : ''}`} onClick={() => onCounterSpell?.()}>
+                  COUNTER! <span className="spell-cast-counter-btn-cap">(caps at {Math.round(liveCapPct * 100)}%)</span>
+                </button>
               )}
-              {cast.counterGrade && (
-                <div className={`spell-cast-grade spell-cast-grade--${cast.counterGrade}`}>
-                  {cast.counterGrade === 'avoid' ? 'BLOCKED!' : 'PARTIAL BLOCK'}
-                </div>
-              )}
+              {cast.counterPct != null && (() => {
+                const gradeColor = `hsl(${140 - 110 * cast.counterPct!}, 80%, 65%)`
+                return (
+                  <div className="spell-cast-grade" style={{ borderColor: gradeColor, color: gradeColor }}>
+                    COUNTERED! Capped at {Math.round(cast.counterPct! * 100)}% HP
+                  </div>
+                )
+              })()}
             </>
           )
         })()}

--- a/web/src/game/battleReducer.test.ts
+++ b/web/src/game/battleReducer.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { battleReducer, INITIAL_BATTLE_STATE, TICK_MS, BattleState } from './battleReducer'
 import { GameState, BattleStats, Card } from './types'
+import { COUNTER_DAMAGE_FLOOR_PCT } from './engine/constants'
 
 // ─── Mocks ────────────────────────────────────────────────
 //
@@ -411,33 +412,34 @@ describe('battleReducer', () => {
       }
     }
 
-    it('grades "avoid" when pressed early — reacting fast must never be punished', () => {
+    it('caps at the floor pct when pressed instantly — reacting fast must never be punished', () => {
       // Regression: pressing with 3.5s left (1.5s elapsed) used to grade "full" (no
       // protection at all), letting a high-damage spell one-shot the commander anyway.
-      const gs = makeGameState({ gameTime: 1500, pendingSpellCast: makeCast() })
+      const gs = makeGameState({ gameTime: 0, pendingSpellCast: makeCast() })
       const state = withGameState(gs)
 
       const next = battleReducer(state, { type: 'COUNTER_SPELL' })
 
-      expect(next.gameState!.pendingSpellCast!.counterGrade).toBe('avoid')
+      expect(next.gameState!.pendingSpellCast!.counterPct).toBe(COUNTER_DAMAGE_FLOOR_PCT)
     })
 
-    it('grades "avoid" when pressed anywhere before the 4.5s closing window', () => {
-      const gs = makeGameState({ gameTime: 3000, pendingSpellCast: makeCast() })
+    it('scales the cap linearly with elapsed time out of the windup', () => {
+      // 2500ms elapsed out of a 5000ms windup → 50% cap.
+      const gs = makeGameState({ gameTime: 2500, pendingSpellCast: makeCast() })
       const state = withGameState(gs)
 
       const next = battleReducer(state, { type: 'COUNTER_SPELL' })
 
-      expect(next.gameState!.pendingSpellCast!.counterGrade).toBe('avoid')
+      expect(next.gameState!.pendingSpellCast!.counterPct).toBe(0.5)
     })
 
-    it('grades "halve" when pressed after 4.5s', () => {
-      const gs = makeGameState({ gameTime: 4800, pendingSpellCast: makeCast() })
+    it('caps at 100% when pressed right at the buzzer — no better than not pressing', () => {
+      const gs = makeGameState({ gameTime: 5000, pendingSpellCast: makeCast() })
       const state = withGameState(gs)
 
       const next = battleReducer(state, { type: 'COUNTER_SPELL' })
 
-      expect(next.gameState!.pendingSpellCast!.counterGrade).toBe('halve')
+      expect(next.gameState!.pendingSpellCast!.counterPct).toBe(1)
     })
 
     it('is a no-op when no cast is pending', () => {
@@ -448,8 +450,8 @@ describe('battleReducer', () => {
       expect(next).toBe(state)
     })
 
-    it('is a no-op once the cast already has a grade', () => {
-      const gs = makeGameState({ gameTime: 1000, pendingSpellCast: makeCast({ counterGrade: 'avoid' }) })
+    it('is a no-op once the cast already has a counterPct', () => {
+      const gs = makeGameState({ gameTime: 1000, pendingSpellCast: makeCast({ counterPct: 0.2 }) })
       const state = withGameState(gs)
 
       const next = battleReducer(state, { type: 'COUNTER_SPELL' })

--- a/web/src/game/battleReducer.ts
+++ b/web/src/game/battleReducer.ts
@@ -17,7 +17,7 @@
 import { GameState, BattleStats, Card } from './types'
 import { tick as engineTick } from './engine'
 import { playCard as enginePlayCard } from './engine/cards'
-import { COUNTER_WINDOW_HALVE_START_MS } from './engine/constants'
+import { CAST_WINDUP_MS, COUNTER_DAMAGE_FLOOR_PCT } from './engine/constants'
 import type { DailyChallengeState } from './dailyChallenge'
 import { generateEndlessRewardChoices } from './questline'
 
@@ -224,10 +224,10 @@ export function battleReducer(state: BattleState, action: BattleAction): BattleS
     case 'COUNTER_SPELL': {
       const gs = state.gameState
       const cast = gs?.pendingSpellCast
-      if (!gs || !cast || cast.counterGrade) return state
+      if (!gs || !cast || cast.counterPct != null) return state
       const elapsed = gs.gameTime - cast.startedAtMs
-      const grade: 'avoid' | 'halve' = elapsed < COUNTER_WINDOW_HALVE_START_MS ? 'avoid' : 'halve'
-      return { ...state, gameState: { ...gs, pendingSpellCast: { ...cast, counterGrade: grade } } }
+      const pct = Math.min(1, Math.max(COUNTER_DAMAGE_FLOOR_PCT, elapsed / CAST_WINDUP_MS))
+      return { ...state, gameState: { ...gs, pendingSpellCast: { ...cast, counterPct: pct } } }
     }
 
     default:

--- a/web/src/game/engine/cards.test.ts
+++ b/web/src/game/engine/cards.test.ts
@@ -49,7 +49,7 @@ describe('deployOpponentCard', () => {
     expect(s.pendingSpellCast).not.toBeNull()
     expect(s.pendingSpellCast!.cardName).toBe('Roots Burst')
     expect(s.pendingSpellCast!.resolvesAtMs).toBe(s.gameTime + CAST_WINDUP_MS)
-    expect(s.pendingSpellCast!.counterGrade).toBeUndefined()
+    expect(s.pendingSpellCast!.counterPct).toBeUndefined()
     // No damage applied yet — the commander is untouched
     expect(playerCmd.hp).toBe(hpBefore)
     expect(log.some(l => l.includes('Roots Burst'))).toBe(true)
@@ -170,12 +170,12 @@ describe('resolveSpellCast', () => {
     expect(s.lastPlayerDamageSource).toEqual({ kind: 'spell', name: 'Roots Burst' })
   })
 
-  it('caps damage at 20% of commander max HP when countered with grade "avoid" (quick)', () => {
-    // Commander max HP is 50 by default, so the quick cap is 10 — below the spell's raw 25.
+  it('caps damage at counterPct of commander max HP when countered quickly', () => {
+    // Commander max HP is 50 by default, so a 0.2 cap is 10 — below the spell's raw 25.
     const s = newGame()
     const playerCmd = s.field.find(u => u.isCommander && u.owner === 'player')!
     const hpBefore = playerCmd.hp
-    withPendingCast(s, { counterGrade: 'avoid' })
+    withPendingCast(s, { counterPct: 0.2 })
     s.gameTime = s.pendingSpellCast!.resolvesAtMs
     const log: string[] = []
 
@@ -186,12 +186,12 @@ describe('resolveSpellCast', () => {
     expect(log.some(l => l.includes('counter'))).toBe(true)
   })
 
-  it('caps damage at 40% of commander max HP when countered with grade "halve" (late)', () => {
-    // Commander max HP is 50 by default, so the late cap is 20 — below the spell's raw 25.
+  it('caps damage at a higher counterPct of commander max HP when countered later', () => {
+    // Commander max HP is 50 by default, so a 0.4 cap is 20 — below the spell's raw 25.
     const s = newGame()
     const playerCmd = s.field.find(u => u.isCommander && u.owner === 'player')!
     const hpBefore = playerCmd.hp
-    withPendingCast(s, { counterGrade: 'halve' })
+    withPendingCast(s, { counterPct: 0.4 })
     s.gameTime = s.pendingSpellCast!.resolvesAtMs
     const log: string[] = []
 
@@ -206,7 +206,7 @@ describe('resolveSpellCast', () => {
     const s = newGame()
     const playerCmd = s.field.find(u => u.isCommander && u.owner === 'player')!
     const hpBefore = playerCmd.hp
-    withPendingCast(s, { cardName: "World's End", effect: { type: 'aoe', damage: 180 }, counterGrade: 'avoid' })
+    withPendingCast(s, { cardName: "World's End", effect: { type: 'aoe', damage: 180 }, counterPct: 0.2 })
     s.gameTime = s.pendingSpellCast!.resolvesAtMs
     const log: string[] = []
 
@@ -220,13 +220,13 @@ describe('resolveSpellCast', () => {
   it('rewards a quick counter with less damage than a late counter, on the same lethal spell', () => {
     const quick = newGame()
     const quickCmd = quick.field.find(u => u.isCommander && u.owner === 'player')!
-    withPendingCast(quick, { cardName: "World's End", effect: { type: 'aoe', damage: 180 }, counterGrade: 'avoid' })
+    withPendingCast(quick, { cardName: "World's End", effect: { type: 'aoe', damage: 180 }, counterPct: 0.2 })
     quick.gameTime = quick.pendingSpellCast!.resolvesAtMs
     resolveSpellCast(quick, [])
 
     const late = newGame()
     const lateCmd = late.field.find(u => u.isCommander && u.owner === 'player')!
-    withPendingCast(late, { cardName: "World's End", effect: { type: 'aoe', damage: 180 }, counterGrade: 'halve' })
+    withPendingCast(late, { cardName: "World's End", effect: { type: 'aoe', damage: 180 }, counterPct: 0.4 })
     late.gameTime = late.pendingSpellCast!.resolvesAtMs
     resolveSpellCast(late, [])
 
@@ -235,5 +235,18 @@ describe('resolveSpellCast', () => {
     expect(quickDmg).toBeLessThan(lateDmg)
     expect(quickCmd.hp).toBeGreaterThan(0)
     expect(lateCmd.hp).toBeGreaterThan(0)
+  })
+
+  it('applies full, uncapped damage on timeout even when the spell exceeds commander max HP', () => {
+    // No press at all must remain undefended — 100% raw damage, never clamped to maxHp.
+    const s = newGame()
+    const playerCmd = s.field.find(u => u.isCommander && u.owner === 'player')!
+    withPendingCast(s, { cardName: "World's End", effect: { type: 'aoe', damage: 180 } })
+    s.gameTime = s.pendingSpellCast!.resolvesAtMs
+    const log: string[] = []
+
+    resolveSpellCast(s, log)
+
+    expect(playerCmd.hp).toBe(playerCmd.maxHp - 180)
   })
 })

--- a/web/src/game/engine/cards.ts
+++ b/web/src/game/engine/cards.ts
@@ -9,7 +9,6 @@ import {
   ARCH_STRUCTURE_COST_REDUCTION, ARCH_STRUCTURE_HP_MULT,
   ARCH_SWARM_UNIT_THRESHOLD, ARCH_SWARM_COST_REDUCTION,
   ARCH_SCHOLAR_UPGRADE_MULT, CAST_WINDUP_MS,
-  COUNTER_DAMAGE_CAP_QUICK_PCT, COUNTER_DAMAGE_CAP_LATE_PCT,
 } from './constants';
 import { DEATH_LINGER_MS } from './combat';
 
@@ -351,22 +350,22 @@ export function applyAoeDamage(
 
 /** Resolve a pending opponent spell cast once its windup has elapsed, applying damage
  *  graded by the player's Counter QTE result. A successful counter never fully negates
- *  damage — it caps it at a percentage of the commander's max HP (quick press = lower
- *  cap, late press = higher cap), so a counter always guarantees survival against an
- *  otherwise-lethal spell while still landing some chip damage. No press = full damage. */
+ *  damage — it caps it at counterPct of the commander's max HP (frozen at press time,
+ *  scaling linearly with reaction speed), so a counter always guarantees survival against
+ *  an otherwise-lethal spell while still landing some chip damage. No press = full,
+ *  uncapped damage. */
 export function resolveSpellCast(s: GameState, log: string[]): void {
   const cast = s.pendingSpellCast
   if (!cast || s.gameTime < cast.resolvesAtMs) return
 
   let dmgCap: number | undefined
-  if (cast.counterGrade) {
+  if (cast.counterPct != null) {
     const playerCmd = s.field.find(u => u.isCommander && u.owner === 'player')
-    const capPct = cast.counterGrade === 'avoid' ? COUNTER_DAMAGE_CAP_QUICK_PCT : COUNTER_DAMAGE_CAP_LATE_PCT
-    dmgCap = playerCmd ? Math.round(playerCmd.maxHp * capPct) : undefined
+    dmgCap = playerCmd ? Math.round(playerCmd.maxHp * cast.counterPct) : undefined
   }
   const { targets, dmg } = applyAoeDamage(s, cast.effect, 'opponent', 1, dmgCap)
 
-  if (cast.counterGrade) {
+  if (cast.counterPct != null) {
     log.push(`🛡️ You counter ${cast.cardName} — damage capped at ${dmg}!`)
   } else {
     log.push(`Enemy ${cast.cardName}! ${targets.length} unit${targets.length === 1 ? '' : 's'} hit for ${dmg} damage.`)

--- a/web/src/game/engine/constants.ts
+++ b/web/src/game/engine/constants.ts
@@ -19,17 +19,15 @@ export const COMMANDER_HOME_X    = 15               // player commander's home p
 export const COMMANDER_LEASH_PX  = 40              // max px a commander can stray from home
 
 // ─── Opponent Spell-Cast Telegraph + Counter QTE ──────────
-export const CAST_WINDUP_MS               = 5000  // windup before an opponent AOE spell resolves
-// A Counter press before this is graded "quick"; pressing in the final stretch of the
-// windup (the "closing window") is graded "late" instead. Pressing early is never
-// punished with extra damage — reacting fast always gets the better grade.
-export const COUNTER_WINDOW_HALVE_START_MS = 4500  // elapsed ms after which a Counter press is graded "late"
-// A successful counter never fully negates damage — it caps it, so a quick reaction is
-// rewarded with a lower cap but big spells (e.g. one-shot-capable mythics) still chip in
-// some damage. Damage dealt = min(spell's raw damage, this % of the commander's max HP).
-// Not countering at all still applies the spell's damage in full (100%, uncapped).
-export const COUNTER_DAMAGE_CAP_QUICK_PCT  = 0.2   // "quick" grade: damage capped at 20% of commander max HP
-export const COUNTER_DAMAGE_CAP_LATE_PCT   = 0.4   // "late" grade: damage capped at 40% of commander max HP
+export const CAST_WINDUP_MS          = 5000  // windup before an opponent AOE spell resolves
+// A successful counter never fully negates damage — it caps it at a percentage of the
+// commander's max HP, and that percentage scales linearly with how much of the windup had
+// already elapsed at press time: an instant press caps at the floor below, a press right at
+// the buzzer caps near 100% (no better than not pressing). Damage dealt = min(spell's raw
+// damage, cap% × commander max HP), so a counter always guarantees survival against an
+// otherwise-lethal spell while still landing some chip damage. Not countering at all still
+// applies the spell's damage in full (100%, uncapped — never reduced by the cap).
+export const COUNTER_DAMAGE_FLOOR_PCT = 0.1  // minimum cap %, even for a press at the instant the cast starts
 
 // ─── Archetype Passive Multipliers ────────────────────────
 export const ARCH_STRUCTURE_COST_REDUCTION = 1     // Siege Commander: structures cost 1 less

--- a/web/src/game/types.ts
+++ b/web/src/game/types.ts
@@ -349,9 +349,11 @@ export interface PendingSpellCast {
   startedAtMs: number
   /** gameTime (ms) when the damage resolves. */
   resolvesAtMs: number
-  /** Set once the player has registered a Counter input during the window.
-   *  Absent (undefined) means no press was registered before resolution — full damage applies. */
-  counterGrade?: 'avoid' | 'halve'
+  /** Damage cap, as a fraction (0–1) of the commander's max HP, frozen at the moment the
+   *  player pressed Counter — scales linearly with how much of the windup had already
+   *  elapsed (see COUNTER_DAMAGE_FLOOR_PCT). Absent (undefined) means no press was
+   *  registered before resolution — the spell's full raw damage applies, uncapped. */
+  counterPct?: number
 }
 
 // ─── Battle Events ────────────────────────────────────────

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -6528,6 +6528,12 @@ body {
   color: #ffe8c0;
   animation: spellCastCounterClosing 0.3s ease-in-out infinite;
 }
+.spell-cast-counter-btn-cap {
+  font-size: var(--font-sm);
+  font-weight: normal;
+  letter-spacing: normal;
+  opacity: 0.85;
+}
 @keyframes spellCastCounterPulse {
   0%, 100% { transform: translateX(-50%) scale(1); }
   50%       { transform: translateX(-50%) scale(1.05); }
@@ -6549,9 +6555,8 @@ body {
   padding: 8px 22px;
   border-radius: 8px;
   background: rgba(0, 0, 0, 0.85);
+  border: 2px solid;
 }
-.spell-cast-grade--avoid { color: #80ff90; border: 2px solid rgba(80, 255, 120, 0.9); }
-.spell-cast-grade--halve { color: #ffd980; border: 2px solid rgba(255, 200, 80, 0.9); }
 
 .sudden-death-overlay {
   position: absolute;


### PR DESCRIPTION
## Summary
- Follow-up to #1771: replaces the discrete "quick"/"late" Counter grading with a continuous linear scale.
- Pressing Counter at any moment now locks in a damage cap of `min(spell raw damage, pct × commander max HP)`, where `pct = clamp(elapsed / CAST_WINDUP_MS, 0.10, 1.0)`. An instant press caps at 10%, a press at the 2.5s midpoint of the 5s windup caps at 50%, and a press right at the buzzer caps near 100% (no better than not pressing).
- Not pressing at all (timeout) is unaffected — it still applies the spell's full raw damage, uncapped, so an "uncountered" lethal spell remains lethal.
- `PendingSpellCast.counterGrade?: 'avoid' | 'halve'` → `counterPct?: number` (0–1 fraction, frozen at press time).
- Battlefield UI now shows the live cap percentage on the Counter button (grows the longer you wait) and the locked-in cap percentage once pressed, with color interpolating from green (low cap) to orange (high cap).

## Test plan
- [x] `npx tsc --noEmit` — no type errors
- [x] `npx vitest run` — full suite passes (238 tests)
- [x] Targeted coverage: `cards.test.ts` (`resolveSpellCast` capping math, timeout uncapped-damage case) and `battleReducer.test.ts` (`COUNTER_SPELL` linear scaling at 0ms/2500ms/5000ms elapsed, no-op guards)


---
_Generated by [Claude Code](https://claude.ai/code/session_01EWKtercfK2nWk9oRp8njfY)_