### PR TITLE
Expand Hollowmere to Tier C (issue #1744)

### DIFF
--- a/web/src/data/hub/hollowmere/config.json
+++ b/web/src/data/hub/hollowmere/config.json
@@ -1,20 +1,31 @@
 {
-  "mapW": 896,
-  "mapH": 640,
+  "mapW": 1408,
+  "mapH": 960,
   "townName": "Hollowmere",
   "environment": "ruins",
   "avatarStart": { "tx": 13, "ty": 17 },
   "exitTiles": [
-    { "tx": 12, "ty": 18, "screen": "worldmap" },
-    { "tx": 13, "ty": 18, "screen": "worldmap" }
+    { "tx": 10, "ty": 18, "screen": "worldmap" },
+    { "tx": 11, "ty": 18, "screen": "worldmap" }
   ],
   "areas": [
-    { "id": "hollowmere-hollow", "name": "The Hollow", "tx": 10, "ty": 10, "tw": 8, "th": 5 }
+    { "id": "hollowmere-hollow", "name": "The Hollow", "tx": 7, "ty": 10, "tw": 12, "th": 6 },
+    { "id": "hollowmere-mire", "name": "The Mire", "tx": 2, "ty": 22, "tw": 36, "th": 7 },
+    { "id": "hollowmere-darkwood", "name": "The Dark Wood", "tx": 33, "ty": 11, "tw": 10, "th": 10 }
   ],
   "streets": [
-    { "rect": [12, 2, 14, 18] },
-    { "rect": [4, 10, 24, 11] },
-    { "rect": [6, 12, 7, 14] }
+    { "rect": [12, 2, 14, 27] },
+    { "rect": [10, 18, 11, 18] },
+    { "rect": [4, 10, 40, 11] },
+    { "rect": [4, 21, 40, 22] },
+    { "rect": [8, 9, 8, 9] },
+    { "rect": [30, 9, 30, 9] },
+    { "rect": [38, 9, 38, 9] },
+    { "rect": [5, 20, 5, 20] },
+    { "rect": [19, 20, 19, 20] },
+    { "rect": [29, 20, 29, 20] },
+    { "rect": [16, 22, 17, 26] },
+    { "rect": [8, 26, 30, 27] }
   ],
   "buildings": [
     {
@@ -29,44 +40,229 @@
     },
     {
       "id": "fang-den",
-      "upgradeKind": "default",
+      "upgradeKind": "inn",
       "rect": [17, 3, 24, 9],
       "wall": "darkStone",
       "roof": "greySlateRoof",
       "doors": [
         { "tx": 3, "ty": 1, "hideSign": true, "buildingId": "fang-den" }
       ]
+    },
+    {
+      "id": "apothecary",
+      "upgradeKind": "shop",
+      "rect": [27, 2, 33, 8],
+      "wall": "woodenSlats",
+      "roof": "strawRoof",
+      "doors": [
+        { "tx": 3, "ty": 1, "hideSign": true, "buildingId": "apothecary" }
+      ]
+    },
+    {
+      "id": "bonepile-curio",
+      "upgradeKind": "shop",
+      "rect": [35, 2, 41, 8],
+      "wall": "darkStone",
+      "roof": "greySlateRoof",
+      "doors": [
+        { "tx": 3, "ty": 1, "hideSign": true, "buildingId": "bonepile-curio" }
+      ]
+    },
+    {
+      "id": "witch-hut",
+      "upgradeKind": "default",
+      "rect": [2, 13, 8, 19],
+      "wall": "woodenSlats",
+      "roof": "strawRoof",
+      "doors": [
+        { "tx": 3, "ty": 1, "hideSign": true, "buildingId": "witch-hut" }
+      ]
+    },
+    {
+      "id": "beast-pens",
+      "upgradeKind": "default",
+      "rect": [16, 14, 22, 19],
+      "wall": "woodenSlats",
+      "roof": "strawRoof",
+      "doors": [
+        { "tx": 3, "ty": 1, "hideSign": true, "buildingId": "beast-pens" }
+      ]
+    },
+    {
+      "id": "bathhouse",
+      "upgradeKind": "default",
+      "rect": [26, 14, 32, 19],
+      "wall": "darkStone",
+      "roof": "greySlateRoof",
+      "doors": [
+        { "tx": 3, "ty": 1, "hideSign": true, "buildingId": "bathhouse" }
+      ]
     }
   ],
+  "pondTiles": [
+    { "rect": [3, 27, 6, 28] },
+    { "rect": [33, 26, 36, 28] }
+  ],
   "exteriorDecor": [
-    { "comment": "the witch's corner" },
-    { "tx": 8, "ty": 13, "tileId": "cauldren" },
+    { "comment": "=== the dark wood: left edge ===" },
+    { "tx": 0, "ty": 2, "bundleID": "dark-tree-column-4", "zlayer": "solid" },
+    { "tx": 0, "ty": 7, "bundleID": "dark-tree", "zlayer": "solid" },
+    { "tx": 0, "ty": 13, "bundleID": "dead-tree", "zlayer": "solid" },
+    { "tx": 0, "ty": 17, "bundleID": "dark-tree", "zlayer": "solid" },
+    { "tx": 0, "ty": 22, "bundleID": "dead-tree", "zlayer": "solid" },
+    { "comment": "=== the dark wood: top edge ===" },
+    { "tx": 4, "ty": 0, "bundleID": "dark-tree", "zlayer": "solid" },
+    { "tx": 9, "ty": 0, "bundleID": "dead-tree", "zlayer": "solid" },
+    { "tx": 18, "ty": 0, "bundleID": "dark-tree", "zlayer": "solid" },
+    { "tx": 23, "ty": 0, "bundleID": "dead-tree", "zlayer": "solid" },
+    { "tx": 27, "ty": 0, "bundleID": "dark-tree", "zlayer": "solid" },
+    { "tx": 31, "ty": 0, "bundleID": "dead-tree", "zlayer": "solid" },
+    { "tx": 35, "ty": 0, "bundleID": "dark-tree", "zlayer": "solid" },
+    { "tx": 40, "ty": 0, "bundleID": "dead-tree", "zlayer": "solid" },
+    { "comment": "=== the dark wood: right edge + eastern grove ===" },
+    { "tx": 42, "ty": 3, "bundleID": "dead-tree", "zlayer": "solid" },
+    { "tx": 42, "ty": 7, "bundleID": "dark-tree", "zlayer": "solid" },
+    { "tx": 42, "ty": 12, "bundleID": "dead-tree", "zlayer": "solid" },
+    { "tx": 42, "ty": 16, "bundleID": "dark-tree", "zlayer": "solid" },
+    { "tx": 42, "ty": 23, "bundleID": "dead-tree", "zlayer": "solid" },
+    { "tx": 35, "ty": 13, "bundleID": "dark-tree-cluster-V", "zlayer": "solid" },
+    { "tx": 39, "ty": 16, "bundleID": "dark-tree", "zlayer": "solid" },
+    { "tx": 34, "ty": 18, "bundleID": "dead-tree", "zlayer": "solid" },
+    { "tx": 38, "ty": 19, "bundleID": "dark-tree", "zlayer": "solid" },
+    { "comment": "=== the hollow: central crossroads ===" },
+    { "tx": 10, "ty": 12, "tileId": "stoneWell" },
+    { "tx": 8, "ty": 10, "bundleID": "brazier", "zlayer": "solid", "glow": true, "glowRadius": 3 },
+    { "tx": 16, "ty": 12, "bundleID": "brazier", "zlayer": "solid", "glow": true, "glowRadius": 3 },
+    { "tx": 9, "ty": 13, "tileId": "skull" },
+    { "tx": 15, "ty": 13, "tileId": "largeStump" },
+    { "tx": 11, "ty": 14, "tileId": "brownMushroom" },
+    { "tx": 7, "ty": 12, "tileId": "logPile" },
+    { "tx": 17, "ty": 14, "tileId": "purpleMushroom" },
+    { "comment": "=== the witch's corner (beside her hut) ===" },
+    { "tx": 1, "ty": 12, "tileId": "cauldren", "glow": true, "glowRadius": 2 },
     { "tx": 9, "ty": 14, "tileId": "bottlesOfLiquor" },
-    { "tx": 7, "ty": 15, "tileId": "bunchOfHerbs" },
-    { "comment": "monster-town clutter" },
-    { "tx": 16, "ty": 12, "tileId": "skull" },
-    { "tx": 20, "ty": 13, "tileId": "barrel" },
-    { "tx": 21, "ty": 12, "tileId": "openCrate" },
-    { "tx": 4, "ty": 9, "tileId": "logPile" },
-    { "tx": 23, "ty": 16, "tileId": "smallRock" },
-    { "tx": 16, "ty": 16, "tileId": "largeStump" },
-    { "comment": "the dark wood presses close" },
-    { "tx": 2, "ty": 4, "bundleID": "dark-tree-cluster-V", "zlayer": "solid" },
-    { "tx": 14, "ty": 4, "bundleID": "dark-tree", "zlayer": "solid" },
-    { "tx": 25, "ty": 12, "bundleID": "dark-tree-cluster-V", "zlayer": "solid" },
-    { "tx": 2, "ty": 14, "bundleID": "dark-tree", "zlayer": "solid" },
-    { "tx": 19, "ty": 17, "bundleID": "dead-tree", "zlayer": "solid" },
-    { "tx": 0, "ty": 9, "bundleID": "dark-tree-column-4", "zlayer": "solid" }
+    { "tx": 9, "ty": 15, "tileId": "bunchOfHerbs" },
+    { "tx": 1, "ty": 11, "tileId": "purpleMushroom" },
+    { "tx": 2, "ty": 11, "tileId": "brownMushroom" },
+    { "tx": 9, "ty": 16, "tileId": "potions" },
+    { "comment": "=== fang-den / tavern frontage ===" },
+    { "tx": 16, "ty": 11, "tileId": "barrel" },
+    { "tx": 25, "ty": 11, "tileId": "openCrate" },
+    { "tx": 22, "ty": 11, "tileId": "skull" },
+    { "tx": 18, "ty": 12, "tileId": "logPile" },
+    { "comment": "=== apothecary + curio frontage / fang's stall (NE) ===" },
+    { "tx": 26, "ty": 10, "tileId": "bunchOfHerbs" },
+    { "tx": 34, "ty": 10, "tileId": "counterTop" },
+    { "tx": 35, "ty": 10, "tileId": "counterTop" },
+    { "tx": 34, "ty": 9, "tileId": "skullSign", "zlayer": "above" },
+    { "tx": 33, "ty": 11, "tileId": "barrel" },
+    { "tx": 36, "ty": 11, "tileId": "openCrate" },
+    { "tx": 40, "ty": 10, "tileId": "skull" },
+    { "comment": "=== beast pens yard ===" },
+    { "tx": 16, "ty": 20, "tileId": "hayStack" },
+    { "tx": 22, "ty": 20, "tileId": "barrel" },
+    { "tx": 20, "ty": 19, "tileId": "logPile" },
+    { "tx": 23, "ty": 19, "tileId": "sack" },
+    { "comment": "=== bathhouse / mud-wallow frontage ===" },
+    { "tx": 26, "ty": 20, "tileId": "barrel" },
+    { "tx": 32, "ty": 20, "tileId": "bottlesOfLiquor" },
+    { "tx": 27, "ty": 19, "tileId": "greenPuddle", "zlayer": "below" },
+    { "tx": 31, "ty": 19, "tileId": "darkPuddle", "zlayer": "below" },
+    { "comment": "=== the mire: muck, lilypads & fungus ===" },
+    { "tx": 2, "ty": 26, "tileId": "darkPuddle", "zlayer": "below" },
+    { "tx": 7, "ty": 27, "tileId": "greenPuddle", "zlayer": "below" },
+    { "tx": 8, "ty": 28, "tileId": "lightPuddle", "zlayer": "below" },
+    { "tx": 5, "ty": 26, "tileId": "smallLilypad", "zlayer": "below" },
+    { "tx": 4, "ty": 28, "tileId": "largeLilypad", "zlayer": "below" },
+    { "tx": 34, "ty": 27, "tileId": "smallLilypad", "zlayer": "below" },
+    { "tx": 35, "ty": 26, "tileId": "largeLilypad", "zlayer": "below" },
+    { "tx": 10, "ty": 28, "tileId": "brownMushroom" },
+    { "tx": 11, "ty": 28, "tileId": "purpleMushroom" },
+    { "tx": 12, "ty": 28, "tileId": "brownMushroom" },
+    { "tx": 22, "ty": 28, "tileId": "purpleMushroom" },
+    { "tx": 23, "ty": 28, "tileId": "brownMushroom" },
+    { "tx": 24, "ty": 28, "tileId": "purpleMushroom" },
+    { "tx": 9, "ty": 26, "tileId": "skull" },
+    { "tx": 27, "ty": 26, "tileId": "skull" },
+    { "tx": 14, "ty": 28, "tileId": "bunchOfHerbs" },
+    { "tx": 19, "ty": 28, "tileId": "bunchOfHerbs" },
+    { "tx": 6, "ty": 25, "tileId": "largeStump" },
+    { "tx": 30, "ty": 25, "tileId": "largeStump" },
+    { "tx": 25, "ty": 26, "tileId": "smallRock" },
+    { "tx": 13, "ty": 26, "tileId": "largeRock" },
+    { "tx": 18, "ty": 27, "tileId": "floorLantern", "glow": true, "glowRadius": 2 },
+    { "tx": 26, "ty": 27, "tileId": "floorLantern", "glow": true, "glowRadius": 2 },
+    { "comment": "=== the mire: gnarled trees ringing the marsh ===" },
+    { "tx": 1, "ty": 24, "bundleID": "dead-tree", "zlayer": "solid" },
+    { "tx": 4, "ty": 23, "bundleID": "dark-tree", "zlayer": "solid" },
+    { "tx": 31, "ty": 23, "bundleID": "dead-tree", "zlayer": "solid" },
+    { "tx": 36, "ty": 24, "bundleID": "dark-tree", "zlayer": "solid" },
+    { "tx": 38, "ty": 26, "bundleID": "dead-tree", "zlayer": "solid" },
+    { "comment": "=== bottom-edge fringe ===" },
+    { "tx": 2, "ty": 29, "tileId": "purpleMushroom" },
+    { "tx": 16, "ty": 29, "tileId": "skull" },
+    { "tx": 33, "ty": 29, "tileId": "brownMushroom" }
   ],
   "npcSpawnTiles": [],
   "ambientNpcSprites": [],
+  "animals": [
+    {
+      "id": "hollowmere-old-croaker",
+      "type": "frog",
+      "variant": "green",
+      "tx": 6,
+      "ty": 27,
+      "name": "Old Croaker",
+      "dialogue": [
+        "*an enormous warty frog the size of a footstool regards you*",
+        "*BRRRT. ...he seems deeply unimpressed.*"
+      ],
+      "roam": true
+    },
+    {
+      "id": "hollowmere-mire-pip",
+      "type": "frog",
+      "variant": "brown",
+      "tx": 34,
+      "ty": 27,
+      "name": "Pip the Peeper",
+      "dialogue": ["*peep! peep!*", "*a tiny frog hops hopefully toward your boot*"],
+      "roam": true
+    },
+    {
+      "id": "hollowmere-bog-hound",
+      "type": "dog",
+      "variant": "#5a6048",
+      "tx": 18,
+      "ty": 26,
+      "name": "Bogweather",
+      "dialogue": [
+        "*a mud-caked hound lopes over, tail thumping*",
+        "*he drops a slimy stick at your feet, very pleased with himself*"
+      ],
+      "roam": true
+    },
+    {
+      "id": "hollowmere-marsh-crow",
+      "type": "bird",
+      "variant": "black",
+      "tx": 36,
+      "ty": 14,
+      "name": "The Marsh Crow",
+      "dialogue": [
+        "*a glossy crow watches you from a dead branch*",
+        "*it tilts its head, as if it knows something you don't*"
+      ],
+      "roam": true
+    }
+  ],
   "npcs": [
     {
       "id": "ogrim-the-bouncer",
       "name": "Ogrim the Bouncer",
       "sprite": "hub-npc-soldier",
-      "tx": 15,
-      "ty": 11,
+      "tx": 6,
+      "ty": 5,
       "dialogue": [
         "Rules of Hollowmere: no biting before sundown, no howling indoors, no heroes.",
         "You smell like a hero. Lucky for you, I'm off duty.",
@@ -78,8 +274,8 @@
       "id": "fang-the-fence",
       "name": "Fang the Fence",
       "sprite": "hub-npc-merchant",
-      "tx": 19,
-      "ty": 11,
+      "tx": 33,
+      "ty": 10,
       "dialogue": [
         "Buying, selling, no questions. Especially no questions about the inventory.",
         "The undead up at Gravemoor are lovely neighbours. Quiet. Very quiet.",
@@ -90,43 +286,307 @@
       "id": "hedge-witch-morwen",
       "name": "Hedge-Witch Morwen",
       "sprite": "hub-npc-scholar",
-      "tx": 8,
-      "ty": 12,
+      "tx": 5,
+      "ty": 4,
       "dialogue": [
         "The cauldron's gone cold and my joints know it. I need moonherb, and plenty of it.",
         "Hollowmere takes in what other towns turn away. Werewolves, ogres, tax dodgers.",
         "Don't touch the bottles. Some of them are potions. Some of them are relatives."
       ],
+      "building": "witch-hut",
       "questGive": "hollowmere-witch-brew",
-      "questReceive": "hollowmere-witch-brew"
+      "questReceive": ["hollowmere-witch-brew", "morwen-speak-with-animals", "hollowmere-witch-brew-2", "dreadspire-moon-herbs"]
+    },
+    {
+      "id": "apothecary-herbalist",
+      "name": "Sister Nettle",
+      "sprite": "soulrend-witch",
+      "tx": 5,
+      "ty": 4,
+      "dialogue": [
+        "Salves, simples, and the occasional curse — all reasonably priced, all reasonably safe.",
+        "A swamp is just an apothecary that hasn't been organised yet. Mind where you step.",
+        "Morwen brews the showy stuff. I do the work that actually keeps Hollowmere on its feet. Or tentacles."
+      ],
+      "building": "apothecary",
+      "questGive": "apothecary-ingredients-1",
+      "questReceive": ["apothecary-ingredients-1", "apothecary-ingredients-2"]
+    },
+    {
+      "id": "goblin-curio-keep",
+      "name": "Snægg the Collector",
+      "sprite": "goblin",
+      "tx": 5,
+      "ty": 4,
+      "dialogue": [
+        "Bones! Buttons! A jar of teeth, only slightly used! Everything has a story and a price!",
+        "One monster's rubbish is another monster's treasure. Mostly it's just rubbish, but you never know.",
+        "You break the merchandise, you marry the merchandise. Those are the rules. I don't make them. I do."
+      ],
+      "building": "bonepile-curio",
+      "questGive": "curio-oddities",
+      "questReceive": "curio-oddities"
+    },
+    {
+      "id": "bog-troll-attendant",
+      "name": "Grunda the Soaker",
+      "sprite": "troll",
+      "tx": 5,
+      "ty": 4,
+      "dialogue": [
+        "Welcome to the wallow! Mud's warm, mud's deep, mud's GOOD for the complexion. Probably.",
+        "A troll without a good wallow is just a grumpy troll. And nobody wants that.",
+        "First soak's on the house. After that it's two crystals, or one decent rumour."
+      ],
+      "building": "bathhouse",
+      "questGive": "mud-wallow",
+      "questReceive": "mud-wallow"
+    },
+    {
+      "id": "tame-ogre-keeper",
+      "name": "Big Mott",
+      "sprite": "ogre",
+      "tx": 19,
+      "ty": 21,
+      "dialogue": [
+        "These are MY beasts. Gentle as lambs, once you know how to ask nicely.",
+        "Folk think monsters can't be kind. Folk never met Mott, or Mott's pens.",
+        "You want to learn beast-taming? Start small. Start with the ones that bite least."
+      ],
+      "questGive": "beast-taming-1",
+      "questReceive": ["beast-taming-1", "beast-taming-2", "beast-taming-3"],
+      "schedule": [
+        { "startHour": 6, "endHour": 20, "activity": "work", "location": { "type": "exterior", "tx": 19, "ty": 21 } },
+        { "startHour": 20, "endHour": 6, "activity": "sleep", "location": { "type": "interior", "buildingId": "beast-pens", "tx": 5, "ty": 4 } }
+      ]
+    },
+    {
+      "id": "swamp-hag",
+      "name": "Mother Sump",
+      "sprite": "sea-witch",
+      "tx": 20,
+      "ty": 26,
+      "dialogue": [
+        "The mire keeps what it takes, dearie. But it'll trade, if you're polite and bring it something shiny.",
+        "Lost your way? Lost your boots? The marsh has both, somewhere down in the muck.",
+        "I've sat in this bog longer than your town's had a name. I remember when it had three."
+      ],
+      "questGive": "mire-lost-items-1",
+      "questReceive": ["mire-lost-items-1", "mire-lost-items-2"]
     }
   ],
   "interiors": {
     "broken-hall": {
       "name": "The Broken Hall",
-      "width": 8,
-      "height": 5,
+      "width": 12,
+      "height": 9,
       "floorTileId": "woodFloor",
       "wallTileId": "woodenSlats",
       "decor": [
         { "tx": 1, "ty": 1, "tileId": "barrel" },
         { "tx": 2, "ty": 1, "tileId": "skull" },
-        { "tx": 5, "ty": 2, "tileId": "roundTable" },
+        { "tx": 10, "ty": 1, "tileId": "barrel" },
+        { "tx": 5, "ty": 1, "tileId": "logPile" },
+        { "tx": 4, "ty": 4, "tileId": "roundTable" },
+        { "tx": 7, "ty": 4, "tileId": "roundTable" },
+        { "tx": 3, "ty": 4, "tileId": "stool" },
+        { "tx": 5, "ty": 4, "tileId": "stool" },
+        { "tx": 8, "ty": 4, "tileId": "stool" },
+        { "tx": 1, "ty": 6, "tileId": "logBottom" },
+        { "tx": 10, "ty": 6, "tileId": "candlestickUnlit" }
+      ],
+      "exits": [
+        { "tx": 6, "ty": 0, "toInteriorId": "broken-hall-back", "entryTx": 5, "entryTy": 6, "direction": "back", "label": "Back Room" }
+      ]
+    },
+    "broken-hall-back": {
+      "name": "The Broken Hall — Back Room",
+      "width": 11,
+      "height": 8,
+      "floorTileId": "woodFloor",
+      "wallTileId": "woodenSlats",
+      "decor": [
+        { "tx": 1, "ty": 1, "tileId": "pileOfSacks" },
+        { "tx": 2, "ty": 1, "tileId": "sack" },
+        { "tx": 9, "ty": 1, "tileId": "openCrate" },
+        { "tx": 8, "ty": 1, "tileId": "crate" },
+        { "tx": 1, "ty": 5, "tileId": "barrel" },
+        { "tx": 9, "ty": 5, "tileId": "skull" },
+        { "tx": 4, "ty": 3, "tileId": "roundTable" },
         { "tx": 6, "ty": 3, "tileId": "stool" }
       ],
-      "exits": []
+      "exits": [
+        { "tx": 5, "ty": 7, "toInteriorId": "broken-hall", "entryTx": 6, "entryTy": 1, "direction": "front", "label": "Common Room" }
+      ]
     },
     "fang-den": {
       "name": "The Fang & Flagon",
-      "width": 8,
-      "height": 5,
+      "width": 12,
+      "height": 9,
       "floorTileId": "woodFloor",
       "wallTileId": "darkStone",
+      "musicId": "inn",
+      "ambianceId": "hearth",
       "decor": [
+        { "tx": 1, "ty": 1, "bundleID": "fireplace" },
         { "tx": 1, "ty": 1, "tileId": "bottlesOfLiquor" },
-        { "tx": 2, "ty": 1, "tileId": "barrel" },
         { "tx": 5, "ty": 1, "tileId": "skull" },
-        { "tx": 4, "ty": 2, "tileId": "roundTable" }
+        { "tx": 6, "ty": 1, "tileId": "barrel" },
+        { "tx": 7, "ty": 1, "tileId": "barrel" },
+        { "tx": 3, "ty": 4, "tileId": "roundTable" },
+        { "tx": 2, "ty": 4, "tileId": "stool" },
+        { "tx": 4, "ty": 4, "tileId": "stool" },
+        { "tx": 7, "ty": 4, "tileId": "roundTableWithCloth" },
+        { "tx": 8, "ty": 4, "tileId": "stool" },
+        { "tx": 10, "ty": 5, "tileId": "counterTop" },
+        { "tx": 9, "ty": 5, "tileId": "counterTop" },
+        { "tx": 9, "ty": 1, "tileId": "ladderBottom", "zlayer": "below" }
+      ],
+      "exits": [
+        { "tx": 9, "ty": 1, "toInteriorId": "fang-den-cellar", "entryTx": 5, "entryTy": 5, "direction": "down", "label": "Down to the cellar" }
+      ]
+    },
+    "fang-den-cellar": {
+      "name": "The Fang & Flagon — Cellar",
+      "width": 10,
+      "height": 8,
+      "floorTileId": "stoneFloor",
+      "wallTileId": "darkStone",
+      "decor": [
+        { "tx": 1, "ty": 1, "tileId": "barrel" },
+        { "tx": 2, "ty": 1, "tileId": "barrel" },
+        { "tx": 8, "ty": 1, "tileId": "bottlesOfLiquor" },
+        { "tx": 7, "ty": 1, "tileId": "crate" },
+        { "tx": 1, "ty": 5, "tileId": "openCrate" },
+        { "tx": 8, "ty": 5, "tileId": "skull" },
+        { "tx": 3, "ty": 3, "tileId": "barrel" },
+        { "tx": 2, "ty": 3, "tileId": "candlestickLitTop", "glow": true, "glowRadius": 2 },
+        { "tx": 5, "ty": 5, "tileId": "ladderBottom", "zlayer": "below" }
+      ],
+      "exits": [
+        { "tx": 5, "ty": 5, "toInteriorId": "fang-den", "entryTx": 9, "entryTy": 2, "direction": "up", "label": "Up to the tavern" }
+      ]
+    },
+    "witch-hut": {
+      "name": "Morwen's Hut",
+      "width": 11,
+      "height": 8,
+      "floorTileId": "woodFloor",
+      "wallTileId": "woodenSlats",
+      "decor": [
+        { "tx": 1, "ty": 1, "tileId": "bookshelfTop" },
+        { "tx": 1, "ty": 2, "tileId": "bookshelfBottom" },
+        { "tx": 9, "ty": 1, "tileId": "bottlesOfLiquor" },
+        { "tx": 3, "ty": 1, "tileId": "skull" },
+        { "tx": 2, "ty": 5, "tileId": "potions" },
+        { "tx": 9, "ty": 5, "tileId": "bunchOfHerbs" },
+        { "tx": 5, "ty": 3, "tileId": "roundTableWithCloth" },
+        { "tx": 7, "ty": 3, "tileId": "candlestickLitTop", "glow": true, "glowRadius": 2 }
+      ],
+      "exits": [
+        { "tx": 5, "ty": 0, "toInteriorId": "witch-hut-brewing", "entryTx": 5, "entryTy": 6, "direction": "back", "label": "Brewing Room" }
+      ]
+    },
+    "witch-hut-brewing": {
+      "name": "Morwen's Brewing Room",
+      "width": 11,
+      "height": 8,
+      "floorTileId": "stoneFloor",
+      "wallTileId": "darkStone",
+      "ambianceId": "hearth",
+      "decor": [
+        { "tx": 5, "ty": 1, "tileId": "cauldren", "glow": true, "glowRadius": 2 },
+        { "tx": 1, "ty": 1, "bundleID": "dark-altar" },
+        { "tx": 9, "ty": 1, "tileId": "bookshelfTop" },
+        { "tx": 9, "ty": 2, "tileId": "bookshelfBottom" },
+        { "tx": 2, "ty": 4, "tileId": "bottlesOfLiquor" },
+        { "tx": 3, "ty": 4, "tileId": "potions" },
+        { "tx": 8, "ty": 4, "tileId": "bunchOfHerbs" },
+        { "tx": 7, "ty": 5, "tileId": "purpleMushroom" },
+        { "tx": 1, "ty": 5, "tileId": "skull" }
+      ],
+      "exits": [
+        { "tx": 5, "ty": 7, "toInteriorId": "witch-hut", "entryTx": 5, "entryTy": 1, "direction": "front", "label": "Front Room" }
+      ]
+    },
+    "apothecary": {
+      "name": "Sister Nettle's Apothecary",
+      "width": 10,
+      "height": 8,
+      "floorTileId": "woodFloor",
+      "wallTileId": "woodenSlats",
+      "decor": [
+        { "tx": 1, "ty": 1, "tileId": "bookshelfTop" },
+        { "tx": 1, "ty": 2, "tileId": "bookshelfBottom" },
+        { "tx": 8, "ty": 1, "tileId": "bookshelfTop" },
+        { "tx": 8, "ty": 2, "tileId": "bookshelfBottom" },
+        { "tx": 3, "ty": 1, "tileId": "potions" },
+        { "tx": 5, "ty": 1, "tileId": "bottlesOfLiquor" },
+        { "tx": 6, "ty": 1, "tileId": "bunchOfHerbs" },
+        { "tx": 2, "ty": 5, "tileId": "mushroomBasket" },
+        { "tx": 7, "ty": 5, "tileId": "purpleMushroom" },
+        { "tx": 4, "ty": 3, "tileId": "roundTable" },
+        { "tx": 5, "ty": 3, "tileId": "cauldren" }
+      ],
+      "exits": []
+    },
+    "bonepile-curio": {
+      "name": "The Bonepile Curio",
+      "width": 10,
+      "height": 8,
+      "floorTileId": "stoneFloor",
+      "wallTileId": "darkStone",
+      "decor": [
+        { "tx": 1, "ty": 1, "tileId": "skull" },
+        { "tx": 2, "ty": 1, "tileId": "skull" },
+        { "tx": 8, "ty": 1, "tileId": "skull" },
+        { "tx": 3, "ty": 1, "tileId": "crate" },
+        { "tx": 7, "ty": 1, "tileId": "openCrate" },
+        { "tx": 1, "ty": 5, "tileId": "pileOfSacks" },
+        { "tx": 8, "ty": 5, "tileId": "chest" },
+        { "tx": 4, "ty": 3, "tileId": "counterTop" },
+        { "tx": 5, "ty": 3, "tileId": "counterTop" },
+        { "tx": 6, "ty": 5, "tileId": "candlestickLitTop", "glow": true, "glowRadius": 2 }
+      ],
+      "exits": []
+    },
+    "beast-pens": {
+      "name": "Big Mott's Beast Pens",
+      "width": 11,
+      "height": 8,
+      "floorTileId": "darkWoodFloor",
+      "wallTileId": "woodenSlats",
+      "decor": [
+        { "tx": 1, "ty": 1, "tileId": "hayStack" },
+        { "tx": 2, "ty": 1, "tileId": "hayStack" },
+        { "tx": 9, "ty": 1, "tileId": "hayStack" },
+        { "tx": 4, "ty": 1, "tileId": "sack" },
+        { "tx": 5, "ty": 1, "tileId": "pileOfSacks" },
+        { "tx": 1, "ty": 5, "tileId": "barrel" },
+        { "tx": 9, "ty": 5, "tileId": "barrel" },
+        { "tx": 6, "ty": 3, "tileId": "logPile" },
+        { "tx": 8, "ty": 5, "tileId": "smallRock" }
+      ],
+      "exits": []
+    },
+    "bathhouse": {
+      "name": "The Mud-Wallow",
+      "width": 10,
+      "height": 8,
+      "floorTileId": "stoneFloor",
+      "wallTileId": "darkStone",
+      "ambianceId": "hearth",
+      "decor": [
+        { "tx": 2, "ty": 2, "tileId": "greenPuddle", "zlayer": "below" },
+        { "tx": 3, "ty": 2, "tileId": "greenPuddle", "zlayer": "below" },
+        { "tx": 2, "ty": 3, "tileId": "darkPuddle", "zlayer": "below" },
+        { "tx": 3, "ty": 3, "tileId": "darkPuddle", "zlayer": "below" },
+        { "tx": 7, "ty": 2, "tileId": "lightPuddle", "zlayer": "below" },
+        { "tx": 8, "ty": 2, "tileId": "lightPuddle", "zlayer": "below" },
+        { "tx": 1, "ty": 1, "tileId": "barrel" },
+        { "tx": 9, "ty": 1, "tileId": "bottlesOfLiquor" },
+        { "tx": 5, "ty": 5, "tileId": "candlestickLitTop", "glow": true, "glowRadius": 2 },
+        { "tx": 1, "ty": 5, "tileId": "smallLilypad", "zlayer": "below" }
       ],
       "exits": []
     }

--- a/web/src/data/hub/hollowmere/questDefs.json
+++ b/web/src/data/hub/hollowmere/questDefs.json
@@ -10,18 +10,30 @@
       "activeDialogue": "Three bunches of moonherb, growing around the edges of town. It glows faintly. Or hums. Sometimes both.",
       "completeDialogue": "Fresh moonherb! The cauldron bubbles tonight. Here — your cut, and some free advice: if Ogrim offers you a drink, ask what's in it FIRST.",
       "steps": [
-        {
-          "key": "herbs",
-          "type": "collect",
-          "pickupIds": ["moonherb-1", "moonherb-2", "moonherb-3"],
-          "required": 3
-        }
+        { "key": "herbs", "type": "collect", "pickupIds": ["moonherb-1", "moonherb-2", "moonherb-3"], "required": 3 }
       ],
       "reward": {
         "crystals": 65,
-        "friendship": {
-          "hedge-witch-morwen": 15
-        }
+        "friendship": { "hedge-witch-morwen": 15 }
+      }
+    },
+    {
+      "id": "hollowmere-witch-brew-2",
+      "title": "The Bubbling Cure",
+      "type": "chain",
+      "giverNpcId": "hedge-witch-morwen",
+      "receiverNpcId": "hedge-witch-morwen",
+      "prerequisite": "quest:hollowmere-witch-brew",
+      "offerDialogue": "The joint-ease worked a treat, so now the whole town wants a dose — and half the marsh has a cough besides. I need to brew a proper batch. Bring me a moon-cap from my own brewing room shelf, a bunch of marsh-herb, and a stoppered bottle from the bog. Then stand back; this one bubbles over.",
+      "activeDialogue": "Gather a moon-cap from Morwen's brewing room, a marsh-herb bunch, and a bog bottle, then return to Morwen.",
+      "completeDialogue": "Perfect — cap, herb and bottle, just so. The cure's bubbling. Cough's cured, joints eased, and one fellow's grown a SECOND nose, but that's a feature where he's from. Well done.",
+      "steps": [
+        { "key": "ingredients", "type": "collect", "pickupIds": ["brew-cap-1", "brew-herb-2", "brew-bottle-3"], "required": 3 }
+      ],
+      "reward": {
+        "crystals": 85,
+        "friendship": { "hedge-witch-morwen": 20 },
+        "collectible": { "id": "hollowmere-bubbling-cure", "name": "Bubbling Cure", "icon": "🧪", "desc": "A vial of Morwen's marsh-remedy. Cures most coughs, some curses, and one persistent case of extra nose." }
       }
     },
     {
@@ -35,12 +47,7 @@
       "activeDialogue": "A crow's feather, a moon-cap mushroom, and a thornless rose — all fall or grow around Hollowmere. Bring me all three.",
       "completeDialogue": "Feather, cap, and rose. Good. Now hold still — this tingles. *she mutters, and the air fills with chatter* ...There. You will hear them now: every cat, crow, and complaining frog. Go and listen to that wretched, kipper-loathing cat. And mind — knowing what a beast wants is the easy part. GIVING it to them is on you.",
       "steps": [
-        {
-          "key": "components",
-          "type": "collect",
-          "pickupIds": ["spell-feather", "spell-mooncap", "spell-rose"],
-          "required": 3
-        }
+        { "key": "components", "type": "collect", "pickupIds": ["spell-feather", "spell-mooncap", "spell-rose"], "required": 3 }
       ],
       "reward": {
         "crystals": 80,
@@ -50,21 +57,243 @@
           "icon": "🐾",
           "desc": "Hedge-Witch Morwen's beast-tongue — you can understand any animal's speech."
         },
-        "friendship": {
-          "hedge-witch-morwen": 20
-        }
+        "friendship": { "hedge-witch-morwen": 20 }
+      }
+    },
+    {
+      "id": "apothecary-ingredients-1",
+      "title": "Marsh Remedies",
+      "type": "fetch",
+      "giverNpcId": "apothecary-herbalist",
+      "receiverNpcId": "apothecary-herbalist",
+      "offerDialogue": "My shelves are bare and my patients are getting creative about their ailments. I need stock: two good fungus caps and a bunch of marsh-herb, all fresh from the mire. Watch the deep puddles — they bite back, and not always metaphorically.",
+      "activeDialogue": "Gather two fungus caps and a marsh-herb bunch from around the mire for Sister Nettle.",
+      "completeDialogue": "Fresh and potent — exactly right. Now I can mix something for the troll's rash that won't, you know, dissolve him. My thanks, and a small cut of the profits.",
+      "steps": [
+        { "key": "stock", "type": "collect", "pickupIds": ["apo-mush-1", "apo-mush-2", "apo-herb-3"], "required": 3 }
+      ],
+      "reward": {
+        "crystals": 60,
+        "friendship": { "apothecary-herbalist": 12 }
+      }
+    },
+    {
+      "id": "apothecary-ingredients-2",
+      "title": "Stronger Stuff",
+      "type": "chain",
+      "giverNpcId": "apothecary-herbalist",
+      "receiverNpcId": "apothecary-herbalist",
+      "prerequisite": "quest:apothecary-ingredients-1",
+      "offerDialogue": "Word's got round that I mix the good stuff, and now a swamp-drake's taken a chunk out of a regular. For THAT I need the rarer caps — the ones that only fruit in the deep muck where sensible folk don't go. You're not sensible, are you? Splendid. Three of them, if you please.",
+      "activeDialogue": "Find three rare deep-muck caps from the far reaches of the mire for Sister Nettle.",
+      "completeDialogue": "Deep-muck caps, every one. The drake-bite poultice practically mixes itself now. You've a steady hand and a stronger stomach — both rare, both welcome here.",
+      "steps": [
+        { "key": "rare", "type": "collect", "pickupIds": ["apo2-1", "apo2-2", "apo2-3"], "required": 3 }
+      ],
+      "reward": {
+        "crystals": 80,
+        "friendship": { "apothecary-herbalist": 18 },
+        "collectible": { "id": "hollowmere-drake-poultice", "name": "Drake-Bite Poultice", "icon": "🩹", "desc": "Sister Nettle's strongest remedy. Knits flesh, neutralises venom, smells absolutely dreadful." }
+      }
+    },
+    {
+      "id": "beast-taming-1",
+      "title": "Feeding Time",
+      "type": "fetch",
+      "giverNpcId": "tame-ogre-keeper",
+      "receiverNpcId": "tame-ogre-keeper",
+      "offerDialogue": "Pens are hungry and Mott's hands are full. Gather up the feed sacks and a haystack that got scattered round the yard, would you? Beast-taming starts with a full belly — theirs, not yours.",
+      "activeDialogue": "Collect the scattered feed sacks and hay from around the beast pens for Big Mott.",
+      "completeDialogue": "Good lad, good lad. See how they settle when they're fed? That's lesson one. You've a gentle way about you — the pens like that. So does Mott.",
+      "steps": [
+        { "key": "feed", "type": "collect", "pickupIds": ["feed-1", "feed-2", "feed-3"], "required": 3 }
+      ],
+      "reward": {
+        "crystals": 55,
+        "friendship": { "tame-ogre-keeper": 12 }
+      }
+    },
+    {
+      "id": "beast-taming-2",
+      "title": "Gentle Hands",
+      "type": "chain",
+      "giverNpcId": "tame-ogre-keeper",
+      "receiverNpcId": "tame-ogre-keeper",
+      "prerequisite": "quest:beast-taming-1",
+      "offerDialogue": "Now the harder part. The skittish ones won't come for food alone — they want their own bedding, their own smell about the place. Fetch the right hay and sacks from the yard so I can make each pen feel like home. Slow and patient, mind.",
+      "activeDialogue": "Gather proper bedding — hay and sacks — from the yard so Big Mott can settle the skittish beasts.",
+      "completeDialogue": "Look at that — the nervy one's stopped trembling. Took years off my worrying, you have. You've the patience for this work. Most folk don't.",
+      "steps": [
+        { "key": "bedding", "type": "collect", "pickupIds": ["gentle-1", "gentle-2", "gentle-3"], "required": 3 }
+      ],
+      "reward": {
+        "crystals": 75,
+        "friendship": { "tame-ogre-keeper": 16 }
+      }
+    },
+    {
+      "id": "beast-taming-3",
+      "title": "Best in Show",
+      "type": "chain",
+      "giverNpcId": "tame-ogre-keeper",
+      "receiverNpcId": "tame-ogre-keeper",
+      "prerequisite": "quest:beast-taming-2",
+      "offerDialogue": "The pens are calm enough now to show off. Gather a couple of proper treats — the herbs and caps the beasts go daft for — and bring them back to me. Then we'll see if these darlings can behave in front of company.",
+      "activeDialogue": "Collect two prize treats from around town, then bring them back to Big Mott at the pens.",
+      "completeDialogue": "They sat. They STAYED. Big Mott has not been this proud since... ever, really. You're a beast-tamer now, and no mistake. The pens will always have a place for you.",
+      "steps": [
+        { "key": "treats", "type": "collect", "pickupIds": ["show-1", "show-2"], "required": 2 },
+        { "key": "deliver", "type": "deliver", "targetNpcId": "tame-ogre-keeper", "required": 1 }
+      ],
+      "reward": {
+        "crystals": 110,
+        "friendship": { "tame-ogre-keeper": 25 },
+        "collectible": { "id": "hollowmere-beast-whistle", "name": "Mott's Beast-Whistle", "icon": "🎺", "desc": "A bone whistle that no human ear can hear. Big Mott's beasts come running every time." }
+      }
+    },
+    {
+      "id": "curio-oddities",
+      "title": "Bits and Bones",
+      "type": "lost-items",
+      "giverNpcId": "goblin-curio-keep",
+      "receiverNpcId": "goblin-curio-keep",
+      "offerDialogue": "Disaster! Half my best oddments have walked off — a skull, a book, a lovely tarnished pendant. Stock doesn't sell itself, especially when it's gone wandering. Round it up for Snægg and there's coin in it for you. Probably.",
+      "activeDialogue": "Recover Snægg's three lost curios — a skull, a book and a pendant — from around Hollowmere.",
+      "completeDialogue": "All three! And barely chewed! You've a collector's eye, you have. Tell you what — keep the coin AND a little something from the bargain bin. Don't open the jar. Just... don't.",
+      "steps": [
+        { "key": "oddments", "type": "collect", "pickupIds": ["odd-1", "odd-2", "odd-3"], "required": 3 }
+      ],
+      "reward": {
+        "crystals": 70,
+        "friendship": { "goblin-curio-keep": 15 }
+      }
+    },
+    {
+      "id": "mud-wallow",
+      "title": "A Good Soak",
+      "type": "fetch",
+      "giverNpcId": "bog-troll-attendant",
+      "receiverNpcId": "bog-troll-attendant",
+      "offerDialogue": "The wallow's gone flat and sad. Needs proper supplies to bubble right — a bottle of bog-oil, a bunch of soothing herb, and a jar of Nettle's salts. Fetch 'em and Grunda'll throw in a soak that'll make your skin GLOW. Possibly literally.",
+      "activeDialogue": "Gather bog-oil, soothing herb and salts from around town for Grunda's mud-wallow.",
+      "completeDialogue": "Ahhh, smell that? That's a wallow with PRIDE again. First soak's on the house, friend. Mind the deep end — that's where we lost the last health inspector.",
+      "steps": [
+        { "key": "supplies", "type": "collect", "pickupIds": ["wallow-1", "wallow-2", "wallow-3"], "required": 3 }
+      ],
+      "reward": {
+        "crystals": 60,
+        "friendship": { "bog-troll-attendant": 14 }
+      }
+    },
+    {
+      "id": "mire-lost-items-1",
+      "title": "Lost in the Mire",
+      "type": "lost-items",
+      "giverNpcId": "swamp-hag",
+      "receiverNpcId": "swamp-hag",
+      "offerDialogue": "The mire's a magpie, dearie — it takes the pretty things and the precious things alike, then sulks in the muck with them. Three trinkets it swallowed of late: a pendant, an old book, a little pot of physic. Fetch them up and Mother Sump won't forget a kindness.",
+      "activeDialogue": "Recover three trinkets the mire has swallowed — a pendant, a book and a pot of physic.",
+      "completeDialogue": "All three, dredged from the deep muck. The mire grumbles, but it'll forgive you — and so will the folk who lost them. You've a fine eye for what the bog hides, child.",
+      "steps": [
+        { "key": "trinkets", "type": "collect", "pickupIds": ["lost-1", "lost-2", "lost-3"], "required": 3 }
+      ],
+      "reward": {
+        "crystals": 65,
+        "friendship": { "swamp-hag": 15 }
+      }
+    },
+    {
+      "id": "mire-lost-items-2",
+      "title": "Deeper in the Muck",
+      "type": "lost-items",
+      "giverNpcId": "swamp-hag",
+      "receiverNpcId": "swamp-hag",
+      "prerequisite": "quest:mire-lost-items-1",
+      "offerDialogue": "You've a knack, so I'll trust you with the deep finds — the things the mire took LONG ago and guards jealous. Out past the gnarled trees, where the muck goes black. Bring back what you find, and mind it doesn't bring something back with it.",
+      "activeDialogue": "Search the deepest, blackest reaches of the mire for three long-lost treasures.",
+      "completeDialogue": "From the black muck itself! Two hundred years that pendant lay down there. You've earned the mire's grudging respect, dearie — and Mother Sump's, which is rarer and worth more.",
+      "steps": [
+        { "key": "deep", "type": "collect", "pickupIds": ["lost2-1", "lost2-2", "lost2-3"], "required": 3 }
+      ],
+      "reward": {
+        "crystals": 90,
+        "friendship": { "swamp-hag": 20 },
+        "collectible": { "id": "hollowmere-mire-pearl", "name": "Mire Pearl", "icon": "⚪", "desc": "A black pearl the marsh guarded for centuries. Mother Sump let you keep it — that means something." }
+      }
+    },
+    {
+      "id": "hollowmere-marsh-medicine",
+      "title": "A Favour for Dreadspire",
+      "type": "chain",
+      "giverNpcId": "hedge-witch-morwen",
+      "receiverNpcId": "alchemist-sythe",
+      "prerequisite": "quest:hollowmere-witch-brew",
+      "offerDialogue": "That sour old alchemist Sythe, up at Dreadspire Citadel, sent word he's out of marsh-physic again. We feud, he and I, but a sick town's a sick town. Take a vial of my best from the brewing room and carry it to him. Tell him Morwen says he STILL owes her a cauldron.",
+      "activeDialogue": "Collect a vial of marsh-physic from Morwen's brewing room, then carry it to Alchemist Sythe at Dreadspire Citadel.",
+      "completeDialogue": "Morwen's marsh-physic, fresh as the bog. And a message about a cauldron — yes, yes, she's mentioned it. Frequently. Across two decades. Tell the old crow her debt is noted and her physic is, infuriatingly, excellent.",
+      "steps": [
+        { "key": "vial", "type": "collect", "pickupIds": ["medicine-vial"], "required": 1 },
+        { "key": "deliver", "type": "deliver", "targetNpcId": "alchemist-sythe", "required": 1 }
+      ],
+      "reward": {
+        "crystals": 95,
+        "friendship": { "hedge-witch-morwen": 15 },
+        "collectible": { "id": "hollowmere-feud-token", "name": "The Cauldron I.O.U.", "icon": "📜", "desc": "A note acknowledging Sythe's twenty-year-old cauldron debt to Morwen. She will treasure this forever." }
       }
     }
   ],
   "pickupItems": [
     { "id": "moonherb-1", "tx": 3, "ty": 12, "tileId": "bunchOfHerbs", "questId": "hollowmere-witch-brew" },
-    { "id": "moonherb-2", "tx": 16, "ty": 14, "tileId": "bunchOfHerbs", "questId": "hollowmere-witch-brew" },
+    { "id": "moonherb-2", "tx": 15, "ty": 13, "tileId": "bunchOfHerbs", "questId": "hollowmere-witch-brew" },
     { "id": "moonherb-3", "tx": 24, "ty": 17, "tileId": "bunchOfHerbs", "questId": "hollowmere-witch-brew" },
-    { "id": "moon-herb-1", "tx": 7, "ty": 16, "tileId": "bunchOfHerbs", "questId": "dreadspire-moon-herbs" },
-    { "id": "moon-herb-2", "tx": 11, "ty": 17, "tileId": "bunchOfHerbs", "questId": "dreadspire-moon-herbs" },
-    { "id": "spell-feather", "tx": 5, "ty": 12, "tileId": "feather", "questId": "morwen-speak-with-animals" },
-    { "id": "spell-mooncap", "tx": 18, "ty": 14, "tileId": "purpleMushroom", "questId": "morwen-speak-with-animals" },
-    { "id": "spell-rose", "tx": 22, "ty": 17, "tileId": "cropRose", "questId": "morwen-speak-with-animals" }
+
+    { "id": "moon-herb-1", "tx": 5, "ty": 28, "tileId": "bunchOfHerbs", "questId": "dreadspire-moon-herbs" },
+    { "id": "moon-herb-2", "tx": 28, "ty": 28, "tileId": "bunchOfHerbs", "questId": "dreadspire-moon-herbs" },
+
+    { "id": "spell-feather", "tx": 36, "ty": 15, "tileId": "feather", "questId": "morwen-speak-with-animals" },
+    { "id": "spell-mooncap", "tx": 12, "ty": 28, "tileId": "purpleMushroom", "questId": "morwen-speak-with-animals" },
+    { "id": "spell-rose", "tx": 9, "ty": 16, "tileId": "cropRose", "questId": "morwen-speak-with-animals" },
+
+    { "id": "brew-cap-1", "tx": 7, "ty": 2, "tileId": "purpleMushroom", "building": "witch-hut-brewing", "questId": "hollowmere-witch-brew-2" },
+    { "id": "brew-herb-2", "tx": 22, "ty": 28, "tileId": "bunchOfHerbs", "questId": "hollowmere-witch-brew-2" },
+    { "id": "brew-bottle-3", "tx": 30, "ty": 28, "tileId": "bottle", "questId": "hollowmere-witch-brew-2" },
+
+    { "id": "apo-mush-1", "tx": 2, "ty": 25, "tileId": "brownMushroom", "questId": "apothecary-ingredients-1" },
+    { "id": "apo-mush-2", "tx": 37, "ty": 25, "tileId": "purpleMushroom", "questId": "apothecary-ingredients-1" },
+    { "id": "apo-herb-3", "tx": 15, "ty": 28, "tileId": "bunchOfHerbs", "questId": "apothecary-ingredients-1" },
+
+    { "id": "apo2-1", "tx": 9, "ty": 24, "tileId": "purpleMushroom", "questId": "apothecary-ingredients-2" },
+    { "id": "apo2-2", "tx": 29, "ty": 24, "tileId": "brownMushroom", "questId": "apothecary-ingredients-2" },
+    { "id": "apo2-3", "tx": 20, "ty": 29, "tileId": "purpleMushroom", "questId": "apothecary-ingredients-2" },
+
+    { "id": "feed-1", "tx": 15, "ty": 19, "tileId": "sack", "questId": "beast-taming-1" },
+    { "id": "feed-2", "tx": 23, "ty": 20, "tileId": "hayStack", "questId": "beast-taming-1" },
+    { "id": "feed-3", "tx": 15, "ty": 20, "tileId": "sack", "questId": "beast-taming-1" },
+
+    { "id": "gentle-1", "tx": 24, "ty": 19, "tileId": "sack", "questId": "beast-taming-2" },
+    { "id": "gentle-2", "tx": 24, "ty": 20, "tileId": "hayStack", "questId": "beast-taming-2" },
+    { "id": "gentle-3", "tx": 22, "ty": 21, "tileId": "sack", "questId": "beast-taming-2" },
+
+    { "id": "show-1", "tx": 18, "ty": 20, "tileId": "bunchOfHerbs", "questId": "beast-taming-3" },
+    { "id": "show-2", "tx": 20, "ty": 20, "tileId": "brownMushroom", "questId": "beast-taming-3" },
+
+    { "id": "odd-1", "tx": 9, "ty": 12, "tileId": "closedBook", "questId": "curio-oddities" },
+    { "id": "odd-2", "tx": 40, "ty": 12, "tileId": "pendant", "questId": "curio-oddities" },
+    { "id": "odd-3", "tx": 2, "ty": 5, "tileId": "skull", "building": "bonepile-curio", "questId": "curio-oddities" },
+
+    { "id": "wallow-1", "tx": 27, "ty": 21, "tileId": "bottle", "questId": "mud-wallow" },
+    { "id": "wallow-2", "tx": 32, "ty": 21, "tileId": "bunchOfHerbs", "questId": "mud-wallow" },
+    { "id": "wallow-3", "tx": 28, "ty": 20, "tileId": "potions", "questId": "mud-wallow" },
+
+    { "id": "lost-1", "tx": 4, "ty": 26, "tileId": "pendant", "questId": "mire-lost-items-1" },
+    { "id": "lost-2", "tx": 33, "ty": 27, "tileId": "closedBook", "questId": "mire-lost-items-1" },
+    { "id": "lost-3", "tx": 13, "ty": 28, "tileId": "potions", "questId": "mire-lost-items-1" },
+
+    { "id": "lost2-1", "tx": 7, "ty": 28, "tileId": "pendant", "questId": "mire-lost-items-2" },
+    { "id": "lost2-2", "tx": 25, "ty": 28, "tileId": "closedBook", "questId": "mire-lost-items-2" },
+    { "id": "lost2-3", "tx": 35, "ty": 27, "tileId": "potOfFlowers", "questId": "mire-lost-items-2" },
+
+    { "id": "medicine-vial", "tx": 3, "ty": 2, "tileId": "potions", "building": "witch-hut-brewing", "questId": "hollowmere-marsh-medicine" }
   ],
   "blockedPaths": []
 }


### PR DESCRIPTION
Bring the friendly-monster swamp town up toward the Ravenwatch gold
standard, per the per-town target in epic #1732.

Map: grow east + south (896x640 -> 1408x960 / 28x20 -> 44x30 tiles) so
all existing coordinates stay valid; relocate exit tiles onto a dead-end
spur so south-bound travel to the new Mire doesn't trigger a town exit.

Buildings: 2 -> 7, all furnished. New apothecary, bonepile curio,
witch's hut, beast pens and mud-wallow bathhouse, each >=6x6 with a
street stub at every door (door->street audit passes for all 7).

Interiors: 2 single rooms -> 10 rooms, 3 multi-room via exits
(broken-hall + back room, fang-den tavern + cellar, witch-hut + brewing
room). Resize fang-den interior and relocate the out-of-bounds
ogrim-the-bouncer inside it with interior-local coords (#1734).

NPCs: 3 -> 8 (goblin curio-keep, troll bathhouse attendant, swamp hag,
tame-ogre keeper, apothecary herbalist) plus 4 placed animals (frogs,
bog hound, marsh crow). Areas: 1 -> 3 (The Hollow, The Mire, The Dark
Wood) with a marsh pond.

Quests: 2 -> 13 (brewing chain, apothecary ingredient chain,
beast-taming chain, curio + mud-wallow + mire lost-items lines) plus a
cross-town hand-in to Alchemist Sythe at Dreadspire (#1735). ~86
exterior + ~98 interior decor items.

cd web && npm run test (238 pass) + npm run build both green.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01D75RQNJ1UfVwLFWDRd1sVH