### PR TITLE
Expand Gearford to Tier B (issue #1741)

### DIFF
--- a/web/src/data/hub/gearford/config.json
+++ b/web/src/data/hub/gearford/config.json
@@ -1,21 +1,21 @@
 {
-  "mapW": 1088,
-  "mapH": 832,
+  "mapW": 1472,
+  "mapH": 1152,
   "townName": "Gearford",
   "environment": "vault",
   "avatarStart": {
-    "tx": 16,
-    "ty": 24
+    "tx": 22,
+    "ty": 34
   },
   "exitTiles": [
     {
-      "tx": 16,
-      "ty": 25,
+      "tx": 22,
+      "ty": 35,
       "screen": "worldmap"
     },
     {
-      "tx": 17,
-      "ty": 25,
+      "tx": 23,
+      "ty": 35,
       "screen": "worldmap"
     }
   ],
@@ -23,59 +23,163 @@
     {
       "id": "gearford-foundry-yard",
       "name": "Foundry Yard",
-      "tx": 3,
-      "ty": 2,
-      "tw": 14,
-      "th": 12
+      "tx": 2,
+      "ty": 1,
+      "tw": 20,
+      "th": 11
     },
     {
       "id": "gearford-works",
       "name": "The Works",
-      "tx": 19,
-      "ty": 2,
-      "tw": 12,
-      "th": 10
+      "tx": 25,
+      "ty": 1,
+      "tw": 20,
+      "th": 11
+    },
+    {
+      "id": "gearford-worker-rows",
+      "name": "Worker Rows",
+      "tx": 2,
+      "ty": 14,
+      "tw": 18,
+      "th": 11
+    },
+    {
+      "id": "gearford-mine-approach",
+      "name": "Mine Approach",
+      "tx": 25,
+      "ty": 14,
+      "tw": 20,
+      "th": 11
     }
   ],
   "streets": [
     {
       "rect": [
+        22,
         2,
+        23,
+        35
+      ]
+    },
+    {
+      "rect": [
+        3,
         12,
-        31,
+        44,
         13
       ]
     },
     {
       "rect": [
-        16,
-        2,
-        17,
+        3,
+        24,
+        44,
         25
       ]
     },
     {
       "rect": [
-        24,
-        14,
-        25,
-        16
+        3,
+        33,
+        44,
+        34
       ]
     },
     {
       "rect": [
-        8,
+        7,
         10,
-        9,
+        7,
         11
       ]
     },
     {
       "rect": [
+        17,
+        10,
+        17,
+        11
+      ]
+    },
+    {
+      "rect": [
+        29,
+        10,
+        29,
+        11
+      ]
+    },
+    {
+      "rect": [
+        40,
+        10,
+        40,
+        11
+      ]
+    },
+    {
+      "rect": [
+        6,
         23,
-        10,
-        24,
-        11
+        6,
+        23
+      ]
+    },
+    {
+      "rect": [
+        16,
+        23,
+        16,
+        23
+      ]
+    },
+    {
+      "rect": [
+        29,
+        23,
+        29,
+        23
+      ]
+    },
+    {
+      "rect": [
+        40,
+        23,
+        40,
+        23
+      ]
+    },
+    {
+      "rect": [
+        6,
+        32,
+        6,
+        32
+      ]
+    },
+    {
+      "rect": [
+        15,
+        32,
+        15,
+        32
+      ]
+    },
+    {
+      "rect": [
+        28,
+        32,
+        28,
+        32
+      ]
+    },
+    {
+      "rect": [
+        37,
+        32,
+        37,
+        32
       ]
     }
   ],
@@ -83,12 +187,17 @@
     {
       "id": "foundry",
       "upgradeKind": "workshop",
-      "rect": [4, 2, 15, 9],
+      "rect": [
+        3,
+        2,
+        12,
+        9
+      ],
       "wall": "brick",
       "roof": "metalRoof",
       "doors": [
         {
-          "tx": 5,
+          "tx": 4,
           "ty": 1,
           "hideSign": true,
           "buildingId": "foundry"
@@ -96,24 +205,74 @@
       ]
     },
     {
-      "id": "workshop",
+      "id": "coal-yard-store",
+      "upgradeKind": "default",
+      "rect": [
+        14,
+        2,
+        20,
+        9
+      ],
+      "wall": "darkStone",
+      "roof": "greySlateRoof",
+      "doors": [
+        {
+          "tx": 3,
+          "ty": 1,
+          "hideSign": true,
+          "buildingId": "coal-yard-store"
+        }
+      ]
+    },
+    {
+      "id": "machine-workshop",
       "upgradeKind": "workshop",
-      "rect": [20, 3, 27, 9],
+      "rect": [
+        26,
+        2,
+        34,
+        9
+      ],
       "wall": "woodenSlats",
+      "roof": "metalRoof",
+      "doors": [
+        {
+          "tx": 3,
+          "ty": 1,
+          "hideSign": true,
+          "buildingId": "machine-workshop"
+        }
+      ]
+    },
+    {
+      "id": "gearwright-hall",
+      "upgradeKind": "workshop",
+      "rect": [
+        36,
+        2,
+        44,
+        9
+      ],
+      "wall": "brick",
       "roof": "greySlateRoof",
       "doors": [
         {
           "tx": 4,
           "ty": 1,
           "hideSign": true,
-          "buildingId": "workshop"
+          "buildingId": "gearwright-hall"
         }
       ]
     },
     {
       "id": "miners-inn",
       "upgradeKind": "inn",
-      "rect": [21, 15, 29, 21],
+      "rect": [
+        3,
+        15,
+        11,
+        22
+      ],
       "wall": "tudorFrame",
       "roof": "strawRoof",
       "doors": [
@@ -124,212 +283,1789 @@
           "buildingId": "miners-inn"
         }
       ]
+    },
+    {
+      "id": "tool-shop",
+      "upgradeKind": "shop",
+      "rect": [
+        13,
+        15,
+        19,
+        22
+      ],
+      "wall": "woodenSlats",
+      "roof": "greySlateRoof",
+      "doors": [
+        {
+          "tx": 3,
+          "ty": 1,
+          "hideSign": true,
+          "buildingId": "tool-shop"
+        }
+      ]
+    },
+    {
+      "id": "warehouse",
+      "upgradeKind": "default",
+      "rect": [
+        26,
+        15,
+        34,
+        22
+      ],
+      "wall": "woodenSlats",
+      "roof": "metalRoof",
+      "doors": [
+        {
+          "tx": 3,
+          "ty": 1,
+          "hideSign": true,
+          "buildingId": "warehouse"
+        }
+      ]
+    },
+    {
+      "id": "mine-entrance",
+      "upgradeKind": "default",
+      "rect": [
+        36,
+        15,
+        44,
+        22
+      ],
+      "wall": "darkStone",
+      "roof": "greySlateRoof",
+      "doors": [
+        {
+          "tx": 4,
+          "ty": 1,
+          "hideSign": true,
+          "buildingId": "mine-entrance"
+        }
+      ]
+    },
+    {
+      "id": "pump-house",
+      "upgradeKind": "default",
+      "rect": [
+        25,
+        26,
+        31,
+        31
+      ],
+      "wall": "brick",
+      "roof": "metalRoof",
+      "doors": [
+        {
+          "tx": 3,
+          "ty": 1,
+          "hideSign": true,
+          "buildingId": "pump-house"
+        }
+      ]
+    },
+    {
+      "id": "worker-house-1",
+      "upgradeKind": "cottage",
+      "rect": [
+        3,
+        26,
+        9,
+        31
+      ],
+      "wall": "woodWall",
+      "roof": "redSlateRoof",
+      "doors": [
+        {
+          "tx": 3,
+          "ty": 1,
+          "hideSign": true,
+          "buildingId": "worker-house-1"
+        }
+      ]
+    },
+    {
+      "id": "worker-house-2",
+      "upgradeKind": "cottage",
+      "rect": [
+        12,
+        26,
+        18,
+        31
+      ],
+      "wall": "woodWall",
+      "roof": "greySlateRoof",
+      "doors": [
+        {
+          "tx": 3,
+          "ty": 1,
+          "hideSign": true,
+          "buildingId": "worker-house-2"
+        }
+      ]
+    },
+    {
+      "id": "gear-shop",
+      "upgradeKind": "shop",
+      "rect": [
+        34,
+        26,
+        40,
+        31
+      ],
+      "wall": "woodenSlats",
+      "roof": "greySlateRoof",
+      "doors": [
+        {
+          "tx": 3,
+          "ty": 1,
+          "hideSign": true,
+          "buildingId": "gear-shop"
+        }
+      ]
     }
   ],
   "exteriorDecor": [
     {
-      "comment": "foundry yard braziers"
+      "comment": "=== foundry yard: smokestack + forge braziers ==="
+    },
+    {
+      "tx": 1,
+      "ty": 11,
+      "tileId": "chimneyBottom"
+    },
+    {
+      "tx": 1,
+      "ty": 10,
+      "tileId": "chimneyMiddle",
+      "zlayer": "above"
+    },
+    {
+      "tx": 1,
+      "ty": 9,
+      "tileId": "chimneyTop",
+      "zlayer": "above"
     },
     {
       "tx": 3,
       "ty": 11,
-      "tileId": "brazierBottom"
+      "bundleID": "brazier",
+      "zlayer": "solid",
+      "glow": true,
+      "glowRadius": 3
     },
     {
-      "tx": 3,
-      "ty": 10,
-      "tileId": "brazierTop",
-      "zlayer": "above"
-    },
-    {
-      "tx": 14,
+      "tx": 11,
       "ty": 11,
-      "tileId": "brazierBottom"
+      "bundleID": "brazier",
+      "zlayer": "solid",
+      "glow": true,
+      "glowRadius": 3
+    },
+    {
+      "comment": "foundry yard clutter"
+    },
+    {
+      "tx": 0,
+      "ty": 11,
+      "tileId": "logPile"
+    },
+    {
+      "tx": 0,
+      "ty": 10,
+      "tileId": "logPile"
+    },
+    {
+      "tx": 4,
+      "ty": 11,
+      "tileId": "crate"
+    },
+    {
+      "tx": 5,
+      "ty": 11,
+      "tileId": "openCrate"
+    },
+    {
+      "tx": 9,
+      "ty": 11,
+      "tileId": "barrel"
+    },
+    {
+      "tx": 10,
+      "ty": 11,
+      "tileId": "barrel"
+    },
+    {
+      "tx": 13,
+      "ty": 11,
+      "tileId": "pileOfSacks"
+    },
+    {
+      "comment": "coal yard: coal heaps + sacks"
+    },
+    {
+      "tx": 15,
+      "ty": 11,
+      "tileId": "smallRock"
+    },
+    {
+      "tx": 16,
+      "ty": 11,
+      "tileId": "smallRock"
+    },
+    {
+      "tx": 16,
+      "ty": 10,
+      "tileId": "smallRock"
+    },
+    {
+      "tx": 18,
+      "ty": 11,
+      "tileId": "pileOfSacks"
+    },
+    {
+      "tx": 19,
+      "ty": 11,
+      "tileId": "sack"
+    },
+    {
+      "tx": 20,
+      "ty": 11,
+      "tileId": "crate"
+    },
+    {
+      "comment": "foundry yard: top-edge framing"
+    },
+    {
+      "tx": 0,
+      "ty": 0,
+      "bundleID": "dead-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 8,
+      "ty": 0,
+      "bundleID": "dark-tree",
+      "zlayer": "solid"
     },
     {
       "tx": 14,
+      "ty": 0,
+      "bundleID": "dead-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 20,
+      "ty": 0,
+      "bundleID": "dark-tree",
+      "zlayer": "solid"
+    },
+    {
+      "comment": "=== the works: smokestack + braziers + parts stalls ==="
+    },
+    {
+      "tx": 25,
+      "ty": 11,
+      "tileId": "chimneyBottom"
+    },
+    {
+      "tx": 25,
       "ty": 10,
-      "tileId": "brazierTop",
+      "tileId": "chimneyMiddle",
       "zlayer": "above"
     },
     {
-      "comment": "industrial clutter"
+      "tx": 25,
+      "ty": 9,
+      "tileId": "chimneyTop",
+      "zlayer": "above"
     },
     {
-      "tx": 2,
+      "tx": 27,
+      "ty": 11,
+      "bundleID": "brazier",
+      "zlayer": "solid",
+      "glow": true,
+      "glowRadius": 3
+    },
+    {
+      "tx": 33,
+      "ty": 11,
+      "bundleID": "brazier",
+      "zlayer": "solid",
+      "glow": true,
+      "glowRadius": 3
+    },
+    {
+      "tx": 38,
+      "ty": 11,
+      "bundleID": "brazier",
+      "zlayer": "solid",
+      "glow": true,
+      "glowRadius": 3
+    },
+    {
+      "tx": 43,
+      "ty": 11,
+      "bundleID": "brazier",
+      "zlayer": "solid",
+      "glow": true,
+      "glowRadius": 3
+    },
+    {
+      "comment": "open-air parts stalls + clutter"
+    },
+    {
+      "tx": 30,
+      "ty": 11,
+      "tileId": "counterTop"
+    },
+    {
+      "tx": 31,
+      "ty": 11,
+      "tileId": "counterTop"
+    },
+    {
+      "tx": 32,
+      "ty": 11,
+      "tileId": "barrel"
+    },
+    {
+      "tx": 26,
+      "ty": 11,
+      "tileId": "openCrate"
+    },
+    {
+      "tx": 35,
+      "ty": 11,
+      "tileId": "crate"
+    },
+    {
+      "tx": 36,
+      "ty": 11,
+      "tileId": "pileOfSacks"
+    },
+    {
+      "tx": 44,
+      "ty": 11,
+      "tileId": "barrel"
+    },
+    {
+      "comment": "the works: top-edge framing"
+    },
+    {
+      "tx": 26,
+      "ty": 0,
+      "bundleID": "dead-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 31,
+      "ty": 0,
+      "bundleID": "dark-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 40,
+      "ty": 0,
+      "bundleID": "dead-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 44,
+      "ty": 0,
+      "bundleID": "dark-tree",
+      "zlayer": "solid"
+    },
+    {
+      "comment": "=== right edge framing ==="
+    },
+    {
+      "tx": 45,
+      "ty": 3,
+      "bundleID": "dead-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 45,
+      "ty": 7,
+      "bundleID": "dark-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 45,
+      "ty": 16,
+      "bundleID": "dead-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 45,
+      "ty": 20,
+      "bundleID": "dark-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 45,
+      "ty": 28,
+      "bundleID": "dead-tree",
+      "zlayer": "solid"
+    },
+    {
+      "comment": "=== left edge framing ==="
+    },
+    {
+      "tx": 0,
+      "ty": 15,
+      "bundleID": "dead-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 0,
+      "ty": 19,
+      "bundleID": "dark-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 0,
+      "ty": 28,
+      "bundleID": "dead-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 0,
+      "ty": 32,
+      "bundleID": "dark-tree",
+      "zlayer": "solid"
+    },
+    {
+      "comment": "=== worker rows: well, lamps, clutter ==="
+    },
+    {
+      "tx": 20,
+      "ty": 14,
+      "tileId": "stoneWell"
+    },
+    {
+      "tx": 12,
+      "ty": 16,
+      "tileId": "lampPostBottom"
+    },
+    {
+      "tx": 12,
+      "ty": 15,
+      "tileId": "lampPostTop",
+      "zlayer": "above",
+      "glow": true,
+      "glowRadius": 2
+    },
+    {
+      "tx": 1,
       "ty": 14,
       "tileId": "crate"
     },
     {
       "tx": 2,
-      "ty": 15,
+      "ty": 14,
       "tileId": "openCrate"
     },
     {
-      "tx": 18,
-      "ty": 10,
+      "tx": 11,
+      "ty": 14,
       "tileId": "barrel"
+    },
+    {
+      "tx": 8,
+      "ty": 14,
+      "tileId": "smallRock"
     },
     {
       "tx": 19,
-      "ty": 11,
-      "tileId": "barrel"
-    },
-    {
-      "tx": 29,
-      "ty": 10,
-      "tileId": "logPile"
-    },
-    {
-      "tx": 30,
-      "ty": 11,
-      "tileId": "logPile"
-    },
-    {
-      "tx": 28,
-      "ty": 14,
-      "tileId": "pileOfSacks"
-    },
-    {
-      "tx": 5,
       "ty": 16,
       "tileId": "smallRock"
     },
     {
       "tx": 12,
       "ty": 18,
+      "tileId": "pileOfSacks"
+    },
+    {
+      "comment": "=== mine approach: ore piles, props, lantern ==="
+    },
+    {
+      "tx": 35,
+      "ty": 14,
+      "tileId": "stoneWell"
+    },
+    {
+      "tx": 26,
+      "ty": 14,
       "tileId": "smallRock"
     },
     {
-      "comment": "what little grows here"
+      "tx": 27,
+      "ty": 14,
+      "tileId": "smallRock"
+    },
+    {
+      "tx": 34,
+      "ty": 14,
+      "tileId": "largeRock"
+    },
+    {
+      "tx": 43,
+      "ty": 14,
+      "tileId": "smallRock"
+    },
+    {
+      "tx": 44,
+      "ty": 16,
+      "tileId": "largeRock"
+    },
+    {
+      "tx": 25,
+      "ty": 14,
+      "tileId": "logPile"
+    },
+    {
+      "tx": 25,
+      "ty": 16,
+      "tileId": "logPile"
+    },
+    {
+      "tx": 35,
+      "ty": 16,
+      "tileId": "lampPostBottom"
+    },
+    {
+      "tx": 35,
+      "ty": 15,
+      "tileId": "lampPostTop",
+      "zlayer": "above",
+      "glow": true,
+      "glowRadius": 2
+    },
+    {
+      "tx": 26,
+      "ty": 18,
+      "tileId": "crate"
+    },
+    {
+      "tx": 27,
+      "ty": 18,
+      "tileId": "openCrate"
+    },
+    {
+      "tx": 44,
+      "ty": 20,
+      "tileId": "barrel"
+    },
+    {
+      "comment": "=== mid-band gaps ==="
+    },
+    {
+      "tx": 12,
+      "ty": 22,
+      "tileId": "smallRock"
+    },
+    {
+      "tx": 35,
+      "ty": 22,
+      "tileId": "barrel"
+    },
+    {
+      "tx": 24,
+      "ty": 14,
+      "tileId": "smallRock"
+    },
+    {
+      "comment": "=== worker housing: gardens, well, lamps ==="
+    },
+    {
+      "tx": 10,
+      "ty": 29,
+      "tileId": "stoneWell"
+    },
+    {
+      "tx": 20,
+      "ty": 31,
+      "tileId": "lampPostBottom"
+    },
+    {
+      "tx": 20,
+      "ty": 30,
+      "tileId": "lampPostTop",
+      "zlayer": "above",
+      "glow": true,
+      "glowRadius": 2
+    },
+    {
+      "tx": 1,
+      "ty": 26,
+      "tileId": "barrel"
+    },
+    {
+      "tx": 1,
+      "ty": 27,
+      "tileId": "crate"
+    },
+    {
+      "tx": 10,
+      "ty": 27,
+      "tileId": "openCrate"
+    },
+    {
+      "tx": 11,
+      "ty": 27,
+      "tileId": "pileOfSacks"
+    },
+    {
+      "tx": 19,
+      "ty": 27,
+      "tileId": "barrel"
+    },
+    {
+      "tx": 24,
+      "ty": 28,
+      "tileId": "crate"
+    },
+    {
+      "tx": 24,
+      "ty": 29,
+      "tileId": "openCrate"
+    },
+    {
+      "tx": 32,
+      "ty": 28,
+      "tileId": "barrel"
+    },
+    {
+      "tx": 33,
+      "ty": 28,
+      "tileId": "pileOfSacks"
+    },
+    {
+      "tx": 41,
+      "ty": 27,
+      "tileId": "crate"
+    },
+    {
+      "tx": 42,
+      "ty": 27,
+      "tileId": "barrel"
+    },
+    {
+      "tx": 44,
+      "ty": 31,
+      "tileId": "smallRock"
+    },
+    {
+      "comment": "worker housing: trees"
+    },
+    {
+      "tx": 0,
+      "ty": 24,
+      "bundleID": "dark-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 20,
+      "ty": 26,
+      "bundleID": "dead-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 32,
+      "ty": 26,
+      "bundleID": "dark-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 42,
+      "ty": 26,
+      "bundleID": "dead-tree",
+      "zlayer": "solid"
+    },
+    {
+      "comment": "=== bottom-edge framing + lamps ==="
     },
     {
       "tx": 3,
-      "ty": 20,
-      "bundleID": "dead-tree",
-      "zlayer": "solid"
+      "ty": 35,
+      "tileId": "smallRock"
     },
     {
       "tx": 9,
-      "ty": 21,
+      "ty": 35,
+      "tileId": "barrel"
+    },
+    {
+      "tx": 18,
+      "ty": 35,
+      "tileId": "crate"
+    },
+    {
+      "tx": 26,
+      "ty": 35,
+      "tileId": "smallRock"
+    },
+    {
+      "tx": 33,
+      "ty": 35,
+      "tileId": "barrel"
+    },
+    {
+      "tx": 0,
+      "ty": 35,
+      "bundleID": "dark-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 44,
+      "ty": 35,
       "bundleID": "dead-tree",
       "zlayer": "solid"
     },
     {
-      "tx": 30,
-      "ty": 22,
-      "bundleID": "dark-tree",
-      "zlayer": "solid"
+      "comment": "=== additional foundry yard clutter ==="
     },
     {
-      "tx": 19,
-      "ty": 19,
-      "bundleID": "dark-tree",
-      "zlayer": "solid"
+      "tx": 2,
+      "ty": 1,
+      "tileId": "smallRock"
     },
     {
-      "comment": "well by the inn"
+      "tx": 6,
+      "ty": 11,
+      "tileId": "smallRock"
     },
     {
-      "tx": 19,
+      "tx": 8,
+      "ty": 11,
+      "tileId": "smallSack"
+    },
+    {
+      "tx": 12,
+      "ty": 11,
+      "tileId": "crate"
+    },
+    {
+      "tx": 15,
+      "ty": 10,
+      "tileId": "smallRock"
+    },
+    {
+      "comment": "=== additional works clutter ==="
+    },
+    {
+      "tx": 28,
+      "ty": 11,
+      "tileId": "openCrate"
+    },
+    {
+      "tx": 34,
+      "ty": 11,
+      "tileId": "smallSack"
+    },
+    {
+      "tx": 37,
+      "ty": 11,
+      "tileId": "crate"
+    },
+    {
+      "tx": 39,
+      "ty": 11,
+      "tileId": "barrel"
+    },
+    {
+      "tx": 41,
+      "ty": 11,
+      "tileId": "pileOfSacks"
+    },
+    {
+      "tx": 42,
+      "ty": 11,
+      "tileId": "smallRock"
+    },
+    {
+      "tx": 26,
+      "ty": 1,
+      "tileId": "smallRock"
+    },
+    {
+      "tx": 44,
+      "ty": 1,
+      "tileId": "crate"
+    },
+    {
+      "comment": "=== additional worker rows clutter ==="
+    },
+    {
+      "tx": 1,
       "ty": 16,
-      "tileId": "stoneWell"
+      "tileId": "barrel"
+    },
+    {
+      "tx": 2,
+      "ty": 16,
+      "tileId": "crate"
+    },
+    {
+      "tx": 1,
+      "ty": 18,
+      "tileId": "smallRock"
+    },
+    {
+      "comment": "=== additional mine approach ore + props ==="
+    },
+    {
+      "tx": 35,
+      "ty": 20,
+      "tileId": "smallRock"
+    },
+    {
+      "comment": "=== additional worker housing clutter ==="
+    },
+    {
+      "tx": 2,
+      "ty": 26,
+      "tileId": "crate"
+    },
+    {
+      "tx": 2,
+      "ty": 28,
+      "tileId": "smallRock"
+    },
+    {
+      "tx": 19,
+      "ty": 29,
+      "tileId": "barrel"
+    },
+    {
+      "tx": 33,
+      "ty": 30,
+      "tileId": "smallRock"
+    },
+    {
+      "tx": 41,
+      "ty": 30,
+      "tileId": "openCrate"
+    },
+    {
+      "tx": 43,
+      "ty": 28,
+      "tileId": "barrel"
+    },
+    {
+      "comment": "=== additional bottom-edge clutter + lamps ==="
+    },
+    {
+      "tx": 6,
+      "ty": 35,
+      "tileId": "smallSack"
+    },
+    {
+      "tx": 15,
+      "ty": 35,
+      "tileId": "smallRock"
+    },
+    {
+      "tx": 28,
+      "ty": 35,
+      "tileId": "crate"
+    },
+    {
+      "tx": 40,
+      "ty": 35,
+      "tileId": "barrel"
+    },
+    {
+      "tx": 45,
+      "ty": 11,
+      "bundleID": "dead-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 45,
+      "ty": 24,
+      "bundleID": "dark-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 45,
+      "ty": 32,
+      "bundleID": "dead-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 0,
+      "ty": 6,
+      "bundleID": "dark-tree",
+      "zlayer": "solid"
     }
   ],
   "npcSpawnTiles": [],
   "ambientNpcSprites": [
-    "hub-npc-supplies"
+    "hub-npc-supplies",
+    "hub-npc-merchant"
+  ],
+  "animals": [
+    {
+      "id": "gearford-soot",
+      "type": "cat",
+      "variant": "grey",
+      "tx": 9,
+      "ty": 14,
+      "name": "Soot",
+      "dialogue": [
+        "*a soot-grey cat curled on a warm anvil cracks one eye*",
+        "*mrrp.*"
+      ],
+      "roam": true
+    }
   ],
   "npcs": [
     {
       "id": "forgemaster-brunn",
       "name": "Forgemaster Brunn",
       "sprite": "hub-npc-supplies",
-      "tx": 10,
-      "ty": 11,
+      "tx": 8,
+      "ty": 12,
       "dialogue": [
         "Gearford runs on three things: coal, iron, and complaints.",
         "Somebody's been lifting tools from the yard. A foundry without tools is just a very warm room.",
         "Hear that hammering? That's the sound of nothing being wrong. I like that sound."
       ],
-      "building": "foundry",
       "questGive": "gearford-stolen-tools",
-      "questReceive": "gearford-stolen-tools"
+      "questReceive": [
+        "gearford-stolen-tools",
+        "gearford-forge-relight",
+        "gearford-quench-the-furnace"
+      ],
+      "schedule": [
+        {
+          "startHour": 6,
+          "endHour": 20,
+          "activity": "work",
+          "location": {
+            "type": "exterior",
+            "tx": 8,
+            "ty": 12
+          }
+        },
+        {
+          "startHour": 20,
+          "endHour": 6,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "foundry",
+            "tx": 3,
+            "ty": 4
+          }
+        }
+      ],
+      "homeBed": {
+        "buildingId": "foundry",
+        "tx": 3,
+        "ty": 4
+      }
     },
     {
       "id": "engineer-vela",
       "name": "Engineer Vela",
       "sprite": "hub-npc-merchant",
-      "tx": 23,
-      "ty": 11,
+      "tx": 28,
+      "ty": 12,
       "dialogue": [
         "The constructs that went rogue out in the smoke fields? Not mine. Mostly not mine.",
         "Every machine wants to work. You just have to convince it the work is yours.",
         "The forge eats coal like a dragon eats... well, everything. We're always short."
       ],
-      "building": "workshop",
       "questGive": "gearford-coal-run",
-      "questReceive": "gearford-coal-run"
+      "questReceive": [
+        "gearford-coal-run",
+        "gearford-broken-pump-1",
+        "gearford-broken-pump-2",
+        "gearford-broken-pump-3"
+      ],
+      "schedule": [
+        {
+          "startHour": 6,
+          "endHour": 20,
+          "activity": "work",
+          "location": {
+            "type": "exterior",
+            "tx": 28,
+            "ty": 12
+          }
+        },
+        {
+          "startHour": 20,
+          "endHour": 6,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "machine-workshop",
+            "tx": 3,
+            "ty": 4
+          }
+        }
+      ],
+      "homeBed": {
+        "buildingId": "machine-workshop",
+        "tx": 3,
+        "ty": 4
+      }
     },
     {
       "id": "foreman-dask",
       "name": "Foreman Dask",
       "sprite": "hub-npc-soldier",
-      "tx": 18,
-      "ty": 14,
+      "tx": 39,
+      "ty": 24,
       "dialogue": [
         "Shift starts at dawn, ends when Brunn stops shouting.",
         "Between the bandits on the toll road and the mine collapse, half my crew won't travel.",
         "You look sturdy. Ever considered honest work? No? Smart."
       ],
-      "building": "miners-inn"
+      "questGive": "gearford-ore-haul",
+      "questReceive": [
+        "gearford-ore-haul",
+        "gearford-cave-in"
+      ],
+      "schedule": [
+        {
+          "startHour": 6,
+          "endHour": 20,
+          "activity": "work",
+          "location": {
+            "type": "exterior",
+            "tx": 39,
+            "ty": 24
+          }
+        },
+        {
+          "startHour": 20,
+          "endHour": 6,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "mine-entrance",
+            "tx": 3,
+            "ty": 4
+          }
+        }
+      ],
+      "homeBed": {
+        "buildingId": "mine-entrance",
+        "tx": 3,
+        "ty": 4
+      }
+    },
+    {
+      "id": "apprentice-tila",
+      "name": "Apprentice Tila",
+      "sprite": "hub-npc-child",
+      "tx": 17,
+      "ty": 12,
+      "dialogue": [
+        "I'm Brunn's apprentice. Mostly that means I carry things and get shouted at.",
+        "I dropped a whole tray of parts in the yard yesterday. They went EVERYWHERE.",
+        "One day I'll forge a blade so fine they'll sing songs. For now: more carrying."
+      ],
+      "questGive": "gearford-scattered-parts",
+      "questReceive": [
+        "gearford-scattered-parts",
+        "gearford-apprentices-errand"
+      ],
+      "schedule": [
+        {
+          "startHour": 7,
+          "endHour": 19,
+          "activity": "idle-chat",
+          "location": {
+            "type": "exterior",
+            "tx": 17,
+            "ty": 12
+          }
+        },
+        {
+          "startHour": 19,
+          "endHour": 7,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "worker-house-1",
+            "tx": 7,
+            "ty": 2
+          }
+        }
+      ],
+      "homeBed": {
+        "buildingId": "worker-house-1",
+        "tx": 7,
+        "ty": 2
+      }
+    },
+    {
+      "id": "gearwright-orin",
+      "name": "Gearwright Orin",
+      "sprite": "hub-npc-trader",
+      "tx": 39,
+      "ty": 12,
+      "dialogue": [
+        "Clockwork is just patience with teeth. Miss one tooth and the whole thing seizes.",
+        "Ravenwatch sent word: their gaol lock's jammed and the guard captain wants a new key forged.",
+        "Bring me good iron and I'll cut you a key that'd open the gates of dawn."
+      ],
+      "questGive": "gearford-forge-the-key",
+      "questReceive": "gearford-forge-the-key",
+      "schedule": [
+        {
+          "startHour": 7,
+          "endHour": 20,
+          "activity": "work",
+          "location": {
+            "type": "exterior",
+            "tx": 39,
+            "ty": 12
+          }
+        },
+        {
+          "startHour": 20,
+          "endHour": 7,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "gearwright-hall",
+            "tx": 3,
+            "ty": 4
+          }
+        }
+      ],
+      "homeBed": {
+        "buildingId": "gearwright-hall",
+        "tx": 3,
+        "ty": 4
+      }
+    },
+    {
+      "id": "coal-hauler-bram",
+      "name": "Coal-Hauler Bram",
+      "sprite": "hub-npc-gardener",
+      "tx": 16,
+      "ty": 12,
+      "dialogue": [
+        "Coal in, slag out, all day long. My back's a clockwork of aches by sundown.",
+        "The old depot south of town's still half-full. Nobody hauls it \u2014 too lazy, too scared.",
+        "A full barrow and an empty road. That's all a hauler wants out of life."
+      ],
+      "schedule": [
+        {
+          "startHour": 6,
+          "endHour": 13,
+          "activity": "work",
+          "location": {
+            "type": "exterior",
+            "tx": 16,
+            "ty": 12
+          }
+        },
+        {
+          "startHour": 13,
+          "endHour": 20,
+          "activity": "work",
+          "location": {
+            "type": "exterior",
+            "tx": 9,
+            "ty": 12
+          }
+        },
+        {
+          "startHour": 20,
+          "endHour": 6,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "miners-inn-bunkrooms",
+            "tx": 3,
+            "ty": 2
+          }
+        }
+      ],
+      "homeBed": {
+        "buildingId": "miners-inn-bunkrooms",
+        "tx": 3,
+        "ty": 2
+      }
+    },
+    {
+      "id": "innkeep-mags",
+      "name": "Innkeep Mags",
+      "sprite": "hub-npc-cook",
+      "tx": 6,
+      "ty": 24,
+      "dialogue": [
+        "Welcome to the Pickaxe Rest. Ale's warm, stew's warmer, and the gossip's free.",
+        "Miners drink like the mine's about to close. Some weeks it nearly is.",
+        "Rats in my store again. Eating better than my guests, the little tyrants."
+      ],
+      "questGive": "gearford-rats-in-the-store",
+      "questReceive": [
+        "gearford-rats-in-the-store",
+        "gearford-innkeeps-order"
+      ],
+      "innRumours": [
+        {
+          "id": "gearford-rumour-mine",
+          "text": "They say the old east drift was sealed for a reason. Tappers in the dark, the night shift swears."
+        },
+        {
+          "id": "gearford-rumour-ravenwatch",
+          "text": "Word from Ravenwatch: their guard captain's after a new gaol key. Orin's the one to forge it."
+        }
+      ],
+      "schedule": [
+        {
+          "startHour": 8,
+          "endHour": 24,
+          "activity": "work",
+          "location": {
+            "type": "interior",
+            "buildingId": "miners-inn",
+            "tx": 6,
+            "ty": 5
+          }
+        },
+        {
+          "startHour": 0,
+          "endHour": 8,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "miners-inn-bunkrooms",
+            "tx": 10,
+            "ty": 2
+          }
+        }
+      ],
+      "homeBed": {
+        "buildingId": "miners-inn-bunkrooms",
+        "tx": 10,
+        "ty": 2
+      }
+    },
+    {
+      "id": "miner-jole",
+      "name": "Miner Jole",
+      "sprite": "hub-npc-gravedigger",
+      "tx": 38,
+      "ty": 24,
+      "dialogue": [
+        "Down the shaft by dawn, up by dusk, if the timbers hold.",
+        "Lost my good lamp in the west drift. Pitch black down there without it.",
+        "The ore's rich this season. Pity the road out is so poor."
+      ],
+      "questGive": "gearford-lost-lamp",
+      "questReceive": "gearford-lost-lamp",
+      "schedule": [
+        {
+          "startHour": 6,
+          "endHour": 14,
+          "activity": "work",
+          "location": {
+            "type": "exterior",
+            "tx": 38,
+            "ty": 24
+          }
+        },
+        {
+          "startHour": 14,
+          "endHour": 20,
+          "activity": "work",
+          "location": {
+            "type": "interior",
+            "buildingId": "mine-tunnel-b",
+            "tx": 5,
+            "ty": 5
+          }
+        },
+        {
+          "startHour": 20,
+          "endHour": 6,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "miners-inn-bunkrooms",
+            "tx": 8,
+            "ty": 2
+          }
+        }
+      ],
+      "homeBed": {
+        "buildingId": "miners-inn-bunkrooms",
+        "tx": 8,
+        "ty": 2
+      }
+    },
+    {
+      "id": "quartermaster-rell",
+      "name": "Quartermaster Rell",
+      "sprite": "hub-npc-harbourmaster",
+      "tx": 28,
+      "ty": 24,
+      "dialogue": [
+        "Every crate in this town passes my ledger. Lose one and you'll hear about it.",
+        "Half the stores went walkabout in the last delivery. Slipshod loading, I call it.",
+        "Order is the only ore that never runs dry. Remember that."
+      ],
+      "questGive": "gearford-missing-stores",
+      "questReceive": "gearford-missing-stores",
+      "schedule": [
+        {
+          "startHour": 7,
+          "endHour": 20,
+          "activity": "work",
+          "location": {
+            "type": "exterior",
+            "tx": 28,
+            "ty": 24
+          }
+        },
+        {
+          "startHour": 20,
+          "endHour": 7,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "warehouse",
+            "tx": 8,
+            "ty": 3
+          }
+        }
+      ]
+    },
+    {
+      "id": "pumpwright-edda",
+      "name": "Pumpwright Edda",
+      "sprite": "hub-npc-scholar",
+      "tx": 28,
+      "ty": 33,
+      "dialogue": [
+        "The great pump keeps the deep workings dry. When it stops, the water wins.",
+        "A valve's seized and a flywheel's cracked. Vela knows the parts I need.",
+        "Keep her turning and Gearford breathes. Let her stop and we drown in the dark."
+      ],
+      "questReceive": "gearford-broken-pump-3",
+      "schedule": [
+        {
+          "startHour": 7,
+          "endHour": 20,
+          "activity": "work",
+          "location": {
+            "type": "exterior",
+            "tx": 28,
+            "ty": 33
+          }
+        },
+        {
+          "startHour": 20,
+          "endHour": 7,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "worker-house-2",
+            "tx": 2,
+            "ty": 2
+          }
+        }
+      ],
+      "homeBed": {
+        "buildingId": "worker-house-2",
+        "tx": 2,
+        "ty": 2
+      }
     }
   ],
   "interiors": {
     "foundry": {
       "name": "The Great Foundry",
-      "width": 12,
-      "height": 6,
+      "width": 13,
+      "height": 9,
       "floorTileId": "stoneFloor",
       "wallTileId": "brick",
       "decor": [
         {
-          "tx": 2,
+          "tx": 1,
           "ty": 1,
-          "tileId": "brazierTop"
+          "bundleID": "fireplace"
+        },
+        {
+          "tx": 4,
+          "ty": 1,
+          "bundleID": "brazier",
+          "zlayer": "solid",
+          "glow": true,
+          "glowRadius": 2
+        },
+        {
+          "tx": 8,
+          "ty": 1,
+          "bundleID": "brazier",
+          "zlayer": "solid",
+          "glow": true,
+          "glowRadius": 2
+        },
+        {
+          "tx": 10,
+          "ty": 1,
+          "tileId": "pileOfSacks"
+        },
+        {
+          "tx": 1,
+          "ty": 4,
+          "tileId": "crate"
         },
         {
           "tx": 2,
-          "ty": 2,
-          "tileId": "brazierBottom"
+          "ty": 4,
+          "tileId": "openCrate"
+        },
+        {
+          "tx": 10,
+          "ty": 4,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 10,
+          "ty": 5,
+          "tileId": "darkPotWithLid"
+        },
+        {
+          "tx": 1,
+          "ty": 7,
+          "tileId": "smallRock"
+        },
+        {
+          "tx": 11,
+          "ty": 7,
+          "tileId": "smallRock"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 6,
+          "ty": 0,
+          "toInteriorId": "foundry-casting-room",
+          "entryTx": 6,
+          "entryTy": 6,
+          "direction": "back",
+          "label": "Casting Hall"
+        },
+        {
+          "tx": 12,
+          "ty": 4,
+          "toInteriorId": "foundry-foreman-office",
+          "entryTx": 1,
+          "entryTy": 4,
+          "direction": "right",
+          "label": "Foreman's Office"
+        }
+      ]
+    },
+    "foundry-casting-room": {
+      "name": "The Casting Hall",
+      "width": 11,
+      "height": 8,
+      "floorTileId": "stoneFloor",
+      "wallTileId": "brick",
+      "decor": [
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "darkPotWithLid"
+        },
+        {
+          "tx": 2,
+          "ty": 1,
+          "tileId": "darkPotWithLid"
+        },
+        {
+          "tx": 8,
+          "ty": 1,
+          "tileId": "chest"
         },
         {
           "tx": 9,
           "ty": 1,
-          "tileId": "brazierTop"
+          "tileId": "chest"
         },
         {
-          "tx": 9,
-          "ty": 2,
-          "tileId": "brazierBottom"
+          "tx": 4,
+          "ty": 1,
+          "tileId": "counterTop"
         },
         {
           "tx": 5,
           "ty": 1,
+          "tileId": "counterTop"
+        },
+        {
+          "tx": 1,
+          "ty": 4,
+          "bundleID": "brazier",
+          "zlayer": "solid",
+          "glow": true,
+          "glowRadius": 2
+        },
+        {
+          "tx": 9,
+          "ty": 4,
           "tileId": "crate"
+        },
+        {
+          "tx": 9,
+          "ty": 5,
+          "tileId": "openCrate"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 6,
+          "ty": 7,
+          "toInteriorId": "foundry",
+          "entryTx": 6,
+          "entryTy": 1,
+          "direction": "front",
+          "label": "Furnace Hall"
+        }
+      ]
+    },
+    "foundry-foreman-office": {
+      "name": "The Foreman's Office",
+      "width": 10,
+      "height": 8,
+      "floorTileId": "woodFloor",
+      "wallTileId": "brick",
+      "decor": [
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "bookshelfTop"
+        },
+        {
+          "tx": 1,
+          "ty": 2,
+          "tileId": "bookshelfBottom"
+        },
+        {
+          "tx": 8,
+          "ty": 1,
+          "tileId": "bookshelfTop"
+        },
+        {
+          "tx": 8,
+          "ty": 2,
+          "tileId": "bookshelfBottom"
+        },
+        {
+          "tx": 4,
+          "ty": 3,
+          "tileId": "roundTableWithCloth"
+        },
+        {
+          "tx": 5,
+          "ty": 3,
+          "tileId": "roundTableWithCloth"
+        },
+        {
+          "tx": 3,
+          "ty": 3,
+          "tileId": "stool"
+        },
+        {
+          "tx": 6,
+          "ty": 3,
+          "tileId": "stool"
+        },
+        {
+          "tx": 8,
+          "ty": 5,
+          "tileId": "candlestickUnlit"
+        },
+        {
+          "tx": 1,
+          "ty": 6,
+          "tileId": "chest"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 0,
+          "ty": 4,
+          "toInteriorId": "foundry",
+          "entryTx": 11,
+          "entryTy": 4,
+          "direction": "left",
+          "label": "Furnace Hall"
+        }
+      ]
+    },
+    "coal-yard-store": {
+      "name": "The Coal Store",
+      "width": 10,
+      "height": 8,
+      "floorTileId": "stoneFloor",
+      "wallTileId": "darkStone",
+      "decor": [
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "pileOfSacks"
+        },
+        {
+          "tx": 2,
+          "ty": 1,
+          "tileId": "pileOfSacks"
+        },
+        {
+          "tx": 8,
+          "ty": 1,
+          "tileId": "pileOfSacks"
+        },
+        {
+          "tx": 5,
+          "ty": 1,
+          "tileId": "smallRock"
         },
         {
           "tx": 6,
           "ty": 1,
+          "tileId": "smallRock"
+        },
+        {
+          "tx": 1,
+          "ty": 4,
+          "tileId": "sack"
+        },
+        {
+          "tx": 2,
+          "ty": 4,
+          "tileId": "sack"
+        },
+        {
+          "tx": 3,
+          "ty": 4,
+          "tileId": "smallSack"
+        },
+        {
+          "tx": 8,
+          "ty": 4,
+          "tileId": "crate"
+        },
+        {
+          "tx": 8,
+          "ty": 5,
+          "tileId": "openCrate"
+        },
+        {
+          "tx": 1,
+          "ty": 6,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 8,
+          "ty": 6,
           "tileId": "barrel"
         }
       ],
       "exits": []
     },
-    "workshop": {
+    "machine-workshop": {
       "name": "Vela's Workshop",
-      "width": 8,
-      "height": 5,
+      "width": 13,
+      "height": 9,
+      "floorTileId": "woodFloor",
+      "wallTileId": "woodenSlats",
+      "decor": [
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "counterTop"
+        },
+        {
+          "tx": 2,
+          "ty": 1,
+          "tileId": "counterTop"
+        },
+        {
+          "tx": 3,
+          "ty": 1,
+          "tileId": "counterTop"
+        },
+        {
+          "tx": 5,
+          "ty": 1,
+          "tileId": "bookshelfTop"
+        },
+        {
+          "tx": 5,
+          "ty": 2,
+          "tileId": "bookshelfBottom"
+        },
+        {
+          "tx": 11,
+          "ty": 1,
+          "tileId": "ladderBottom",
+          "zlayer": "below"
+        },
+        {
+          "tx": 1,
+          "ty": 4,
+          "tileId": "crate"
+        },
+        {
+          "tx": 2,
+          "ty": 4,
+          "tileId": "openCrate"
+        },
+        {
+          "tx": 1,
+          "ty": 5,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 8,
+          "ty": 5,
+          "tileId": "darkPotWithLid"
+        },
+        {
+          "tx": 9,
+          "ty": 5,
+          "tileId": "crate"
+        },
+        {
+          "tx": 1,
+          "ty": 7,
+          "tileId": "smallRock"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 11,
+          "ty": 1,
+          "toInteriorId": "machine-workshop-loft",
+          "entryTx": 5,
+          "entryTy": 6,
+          "direction": "up",
+          "label": "Up to the parts loft"
+        }
+      ]
+    },
+    "machine-workshop-loft": {
+      "name": "The Parts Loft",
+      "width": 11,
+      "height": 8,
       "floorTileId": "woodFloor",
       "wallTileId": "woodenSlats",
       "decor": [
@@ -344,44 +2080,955 @@
           "tileId": "openCrate"
         },
         {
+          "tx": 8,
+          "ty": 1,
+          "tileId": "crate"
+        },
+        {
+          "tx": 9,
+          "ty": 1,
+          "tileId": "openCrate"
+        },
+        {
           "tx": 5,
+          "ty": 1,
+          "tileId": "ladderBottom",
+          "zlayer": "below"
+        },
+        {
+          "tx": 1,
+          "ty": 4,
+          "tileId": "pileOfSacks"
+        },
+        {
+          "tx": 9,
+          "ty": 4,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 1,
+          "ty": 6,
+          "tileId": "smallRock"
+        },
+        {
+          "tx": 9,
+          "ty": 6,
+          "tileId": "darkPotWithLid"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 5,
+          "ty": 1,
+          "toInteriorId": "machine-workshop",
+          "entryTx": 11,
+          "entryTy": 2,
+          "direction": "down",
+          "label": "Down to the workshop"
+        }
+      ]
+    },
+    "gearwright-hall": {
+      "name": "The Clockwork Hall",
+      "width": 13,
+      "height": 9,
+      "floorTileId": "stoneFloor",
+      "wallTileId": "brick",
+      "decor": [
+        {
+          "tx": 1,
           "ty": 1,
           "tileId": "bookshelfTop"
         },
         {
-          "tx": 5,
+          "tx": 1,
           "ty": 2,
           "tileId": "bookshelfBottom"
+        },
+        {
+          "tx": 11,
+          "ty": 1,
+          "tileId": "bookshelfTop"
+        },
+        {
+          "tx": 11,
+          "ty": 2,
+          "tileId": "bookshelfBottom"
+        },
+        {
+          "tx": 3,
+          "ty": 1,
+          "bundleID": "candelabra",
+          "zlayer": "solid",
+          "glow": true,
+          "glowRadius": 2
+        },
+        {
+          "tx": 9,
+          "ty": 1,
+          "bundleID": "candelabra",
+          "zlayer": "solid",
+          "glow": true,
+          "glowRadius": 2
+        },
+        {
+          "tx": 4,
+          "ty": 4,
+          "tileId": "counterTop"
+        },
+        {
+          "tx": 5,
+          "ty": 4,
+          "tileId": "counterTop"
+        },
+        {
+          "tx": 6,
+          "ty": 4,
+          "tileId": "counterTop"
+        },
+        {
+          "tx": 1,
+          "ty": 6,
+          "tileId": "crate"
+        },
+        {
+          "tx": 11,
+          "ty": 6,
+          "tileId": "barrel"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 6,
+          "ty": 0,
+          "toInteriorId": "gearwright-hall-back",
+          "entryTx": 6,
+          "entryTy": 6,
+          "direction": "back",
+          "label": "Workshop"
+        }
+      ]
+    },
+    "gearwright-hall-back": {
+      "name": "The Gearwright's Workshop",
+      "width": 10,
+      "height": 8,
+      "floorTileId": "stoneFloor",
+      "wallTileId": "brick",
+      "decor": [
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "crate"
+        },
+        {
+          "tx": 2,
+          "ty": 1,
+          "tileId": "openCrate"
+        },
+        {
+          "tx": 8,
+          "ty": 1,
+          "tileId": "darkPotWithLid"
+        },
+        {
+          "tx": 4,
+          "ty": 1,
+          "tileId": "counterTop"
+        },
+        {
+          "tx": 5,
+          "ty": 1,
+          "tileId": "counterTop"
+        },
+        {
+          "tx": 1,
+          "ty": 4,
+          "tileId": "bookshelfTop"
+        },
+        {
+          "tx": 1,
+          "ty": 5,
+          "tileId": "bookshelfBottom"
+        },
+        {
+          "tx": 8,
+          "ty": 4,
+          "tileId": "chest"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 6,
+          "ty": 7,
+          "toInteriorId": "gearwright-hall",
+          "entryTx": 6,
+          "entryTy": 1,
+          "direction": "front",
+          "label": "Clockwork Hall"
+        }
+      ]
+    },
+    "miners-inn": {
+      "name": "The Pickaxe Rest",
+      "width": 13,
+      "height": 9,
+      "floorTileId": "woodFloor",
+      "wallTileId": "woodWall",
+      "musicId": "inn",
+      "ambianceId": "hearth",
+      "decor": [
+        {
+          "tx": 1,
+          "ty": 1,
+          "bundleID": "fireplace"
+        },
+        {
+          "tx": 4,
+          "ty": 3,
+          "tileId": "smallTableTopLeft"
+        },
+        {
+          "tx": 5,
+          "ty": 3,
+          "tileId": "smallTableTopRight"
+        },
+        {
+          "tx": 4,
+          "ty": 4,
+          "tileId": "smallTableBottomLeft"
+        },
+        {
+          "tx": 5,
+          "ty": 4,
+          "tileId": "smallTableBottomRight"
+        },
+        {
+          "tx": 3,
+          "ty": 3,
+          "tileId": "stool"
+        },
+        {
+          "tx": 6,
+          "ty": 3,
+          "tileId": "stool"
+        },
+        {
+          "tx": 8,
+          "ty": 1,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 9,
+          "ty": 1,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 10,
+          "ty": 1,
+          "tileId": "bottlesOfLiquor"
+        },
+        {
+          "tx": 7,
+          "ty": 6,
+          "tileId": "counterTop"
+        },
+        {
+          "tx": 8,
+          "ty": 6,
+          "tileId": "counterTop"
+        },
+        {
+          "tx": 9,
+          "ty": 6,
+          "tileId": "counterTop"
+        },
+        {
+          "tx": 11,
+          "ty": 1,
+          "tileId": "ladderBottom",
+          "zlayer": "below"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 11,
+          "ty": 1,
+          "toInteriorId": "miners-inn-bunkrooms",
+          "entryTx": 6,
+          "entryTy": 7,
+          "direction": "up",
+          "label": "Upstairs"
+        }
+      ]
+    },
+    "miners-inn-bunkrooms": {
+      "name": "The Pickaxe Rest \u2014 Bunkrooms",
+      "width": 12,
+      "height": 9,
+      "floorTileId": "woodFloor",
+      "wallTileId": "woodWall",
+      "decor": [
+        {
+          "tx": 1,
+          "ty": 2,
+          "bundleID": "simple-bed"
+        },
+        {
+          "tx": 3,
+          "ty": 2,
+          "bundleID": "simple-bed"
+        },
+        {
+          "tx": 8,
+          "ty": 2,
+          "bundleID": "simple-bed"
+        },
+        {
+          "tx": 10,
+          "ty": 2,
+          "bundleID": "simple-bed"
+        },
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "candlestickUnlit"
+        },
+        {
+          "tx": 10,
+          "ty": 1,
+          "tileId": "candlestickUnlit"
+        },
+        {
+          "tx": 5,
+          "ty": 1,
+          "tileId": "ladderBottom",
+          "zlayer": "below"
+        },
+        {
+          "tx": 5,
+          "ty": 6,
+          "tileId": "chest"
+        },
+        {
+          "tx": 6,
+          "ty": 6,
+          "tileId": "chest"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 5,
+          "ty": 1,
+          "toInteriorId": "miners-inn",
+          "entryTx": 11,
+          "entryTy": 2,
+          "direction": "down",
+          "label": "Downstairs"
+        }
+      ]
+    },
+    "tool-shop": {
+      "name": "The Tool Shop",
+      "width": 10,
+      "height": 8,
+      "floorTileId": "woodFloor",
+      "wallTileId": "woodenSlats",
+      "decor": [
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "counterTop"
+        },
+        {
+          "tx": 2,
+          "ty": 1,
+          "tileId": "counterTop"
+        },
+        {
+          "tx": 3,
+          "ty": 1,
+          "tileId": "counterTop"
+        },
+        {
+          "tx": 8,
+          "ty": 1,
+          "tileId": "bookshelfTop"
+        },
+        {
+          "tx": 8,
+          "ty": 2,
+          "tileId": "bookshelfBottom"
+        },
+        {
+          "tx": 5,
+          "ty": 1,
+          "tileId": "pileOfSacks"
+        },
+        {
+          "tx": 1,
+          "ty": 4,
+          "tileId": "crate"
+        },
+        {
+          "tx": 2,
+          "ty": 4,
+          "tileId": "openCrate"
+        },
+        {
+          "tx": 8,
+          "ty": 4,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 1,
+          "ty": 6,
+          "tileId": "smallRock"
+        },
+        {
+          "tx": 8,
+          "ty": 6,
+          "tileId": "darkPotWithLid"
         }
       ],
       "exits": []
     },
-    "miners-inn": {
-      "name": "The Pickaxe Rest",
-      "width": 9,
-      "height": 5,
+    "warehouse": {
+      "name": "The Town Warehouse",
+      "width": 13,
+      "height": 9,
+      "floorTileId": "stoneFloor",
+      "wallTileId": "woodenSlats",
+      "decor": [
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "crate"
+        },
+        {
+          "tx": 2,
+          "ty": 1,
+          "tileId": "crate"
+        },
+        {
+          "tx": 3,
+          "ty": 1,
+          "tileId": "openCrate"
+        },
+        {
+          "tx": 10,
+          "ty": 1,
+          "tileId": "crate"
+        },
+        {
+          "tx": 11,
+          "ty": 1,
+          "tileId": "openCrate"
+        },
+        {
+          "tx": 5,
+          "ty": 1,
+          "tileId": "pileOfSacks"
+        },
+        {
+          "tx": 7,
+          "ty": 1,
+          "tileId": "sack"
+        },
+        {
+          "tx": 1,
+          "ty": 4,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 2,
+          "ty": 4,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 10,
+          "ty": 4,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 11,
+          "ty": 4,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 5,
+          "ty": 5,
+          "tileId": "crate"
+        },
+        {
+          "tx": 6,
+          "ty": 5,
+          "tileId": "crate"
+        },
+        {
+          "tx": 7,
+          "ty": 5,
+          "tileId": "openCrate"
+        },
+        {
+          "tx": 1,
+          "ty": 7,
+          "tileId": "pileOfSacks"
+        },
+        {
+          "tx": 11,
+          "ty": 7,
+          "tileId": "pileOfSacks"
+        }
+      ],
+      "exits": []
+    },
+    "mine-entrance": {
+      "name": "The Headframe",
+      "width": 12,
+      "height": 9,
+      "floorTileId": "darkStoneFloor",
+      "wallTileId": "darkStone",
+      "decor": [
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "crate"
+        },
+        {
+          "tx": 2,
+          "ty": 1,
+          "tileId": "openCrate"
+        },
+        {
+          "tx": 9,
+          "ty": 1,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 3,
+          "ty": 1,
+          "tileId": "floorLantern",
+          "glow": true,
+          "glowRadius": 2
+        },
+        {
+          "tx": 6,
+          "ty": 1,
+          "tileId": "ladderBottom",
+          "zlayer": "below"
+        },
+        {
+          "tx": 1,
+          "ty": 4,
+          "tileId": "pileOfSacks"
+        },
+        {
+          "tx": 10,
+          "ty": 4,
+          "tileId": "sack"
+        },
+        {
+          "tx": 1,
+          "ty": 6,
+          "tileId": "smallRock"
+        },
+        {
+          "tx": 10,
+          "ty": 6,
+          "tileId": "smallRock"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 6,
+          "ty": 1,
+          "toInteriorId": "mine-tunnel-a",
+          "entryTx": 5,
+          "entryTy": 6,
+          "direction": "down",
+          "label": "Down the shaft"
+        }
+      ]
+    },
+    "mine-tunnel-a": {
+      "name": "The Crossing",
+      "width": 11,
+      "height": 8,
+      "floorTileId": "darkStoneFloor",
+      "wallTileId": "darkStone",
+      "decor": [
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "smallRock"
+        },
+        {
+          "tx": 9,
+          "ty": 1,
+          "tileId": "smallRock"
+        },
+        {
+          "tx": 5,
+          "ty": 1,
+          "tileId": "ladderBottom",
+          "zlayer": "below"
+        },
+        {
+          "tx": 2,
+          "ty": 6,
+          "tileId": "largeRock"
+        },
+        {
+          "tx": 8,
+          "ty": 6,
+          "tileId": "largeRock"
+        },
+        {
+          "tx": 3,
+          "ty": 6,
+          "tileId": "floorLantern",
+          "glow": true,
+          "glowRadius": 2
+        }
+      ],
+      "exits": [
+        {
+          "tx": 5,
+          "ty": 1,
+          "toInteriorId": "mine-entrance",
+          "entryTx": 6,
+          "entryTy": 2,
+          "direction": "up",
+          "label": "Up the shaft"
+        },
+        {
+          "tx": 0,
+          "ty": 4,
+          "toInteriorId": "mine-tunnel-b",
+          "entryTx": 9,
+          "entryTy": 4,
+          "direction": "left",
+          "label": "West Drift"
+        },
+        {
+          "tx": 10,
+          "ty": 4,
+          "toInteriorId": "mine-tunnel-c",
+          "entryTx": 1,
+          "entryTy": 4,
+          "direction": "right",
+          "label": "East Drift"
+        }
+      ]
+    },
+    "mine-tunnel-b": {
+      "name": "The West Drift",
+      "width": 10,
+      "height": 8,
+      "floorTileId": "darkStoneFloor",
+      "wallTileId": "darkStone",
+      "decor": [
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "largeRock"
+        },
+        {
+          "tx": 2,
+          "ty": 1,
+          "tileId": "smallRock"
+        },
+        {
+          "tx": 8,
+          "ty": 1,
+          "tileId": "largeRock"
+        },
+        {
+          "tx": 1,
+          "ty": 6,
+          "tileId": "smallRock"
+        },
+        {
+          "tx": 8,
+          "ty": 6,
+          "tileId": "largeRock"
+        },
+        {
+          "tx": 3,
+          "ty": 3,
+          "tileId": "floorLantern",
+          "glow": true,
+          "glowRadius": 2
+        }
+      ],
+      "exits": [
+        {
+          "tx": 9,
+          "ty": 4,
+          "toInteriorId": "mine-tunnel-a",
+          "entryTx": 1,
+          "entryTy": 4,
+          "direction": "right",
+          "label": "The Crossing"
+        }
+      ]
+    },
+    "mine-tunnel-c": {
+      "name": "The East Drift",
+      "width": 10,
+      "height": 8,
+      "floorTileId": "darkStoneFloor",
+      "wallTileId": "darkStone",
+      "decor": [
+        {
+          "tx": 2,
+          "ty": 1,
+          "tileId": "largeRock"
+        },
+        {
+          "tx": 8,
+          "ty": 1,
+          "tileId": "smallRock"
+        },
+        {
+          "tx": 8,
+          "ty": 2,
+          "tileId": "largeRock"
+        },
+        {
+          "tx": 2,
+          "ty": 6,
+          "tileId": "smallRock"
+        },
+        {
+          "tx": 7,
+          "ty": 6,
+          "tileId": "largeRock"
+        },
+        {
+          "tx": 6,
+          "ty": 3,
+          "tileId": "floorLantern",
+          "glow": true,
+          "glowRadius": 2
+        }
+      ],
+      "exits": [
+        {
+          "tx": 0,
+          "ty": 4,
+          "toInteriorId": "mine-tunnel-a",
+          "entryTx": 9,
+          "entryTy": 4,
+          "direction": "left",
+          "label": "The Crossing"
+        }
+      ]
+    },
+    "pump-house": {
+      "name": "The Pump House",
+      "width": 10,
+      "height": 8,
+      "floorTileId": "stoneFloor",
+      "wallTileId": "brick",
+      "decor": [
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "darkPotWithLid"
+        },
+        {
+          "tx": 2,
+          "ty": 1,
+          "tileId": "darkPotWithLid"
+        },
+        {
+          "tx": 8,
+          "ty": 1,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 5,
+          "ty": 1,
+          "tileId": "floorLantern",
+          "glow": true,
+          "glowRadius": 2
+        },
+        {
+          "tx": 1,
+          "ty": 4,
+          "tileId": "counterTop"
+        },
+        {
+          "tx": 2,
+          "ty": 4,
+          "tileId": "counterTop"
+        },
+        {
+          "tx": 8,
+          "ty": 4,
+          "tileId": "crate"
+        },
+        {
+          "tx": 8,
+          "ty": 5,
+          "tileId": "openCrate"
+        },
+        {
+          "tx": 1,
+          "ty": 6,
+          "tileId": "smallRock"
+        }
+      ],
+      "exits": []
+    },
+    "worker-house-1": {
+      "name": "Worker's Cottage",
+      "width": 10,
+      "height": 8,
       "floorTileId": "woodFloor",
       "wallTileId": "woodWall",
       "decor": [
         {
           "tx": 1,
           "ty": 1,
+          "bundleID": "fireplace"
+        },
+        {
+          "tx": 7,
+          "ty": 2,
+          "bundleID": "simple-bed"
+        },
+        {
+          "tx": 4,
+          "ty": 4,
+          "tileId": "roundTable"
+        },
+        {
+          "tx": 3,
+          "ty": 4,
+          "tileId": "stool"
+        },
+        {
+          "tx": 5,
+          "ty": 4,
+          "tileId": "stool"
+        },
+        {
+          "tx": 8,
+          "ty": 5,
+          "tileId": "chest"
+        },
+        {
+          "tx": 1,
+          "ty": 5,
           "tileId": "barrel"
+        }
+      ],
+      "exits": []
+    },
+    "worker-house-2": {
+      "name": "Worker's Cottage",
+      "width": 10,
+      "height": 8,
+      "floorTileId": "woodFloor",
+      "wallTileId": "woodWall",
+      "decor": [
+        {
+          "tx": 7,
+          "ty": 1,
+          "bundleID": "fireplace"
+        },
+        {
+          "tx": 2,
+          "ty": 2,
+          "bundleID": "simple-bed"
+        },
+        {
+          "tx": 5,
+          "ty": 4,
+          "tileId": "roundTableWithCloth"
+        },
+        {
+          "tx": 4,
+          "ty": 4,
+          "tileId": "stool"
+        },
+        {
+          "tx": 6,
+          "ty": 4,
+          "tileId": "stool"
+        },
+        {
+          "tx": 1,
+          "ty": 5,
+          "tileId": "chest"
+        },
+        {
+          "tx": 8,
+          "ty": 5,
+          "tileId": "barrel"
+        }
+      ],
+      "exits": []
+    },
+    "gear-shop": {
+      "name": "The Gear Shop",
+      "width": 10,
+      "height": 8,
+      "floorTileId": "woodFloor",
+      "wallTileId": "woodenSlats",
+      "decor": [
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "counterTop"
         },
         {
           "tx": 2,
           "ty": 1,
-          "tileId": "bottlesOfLiquor"
+          "tileId": "counterTop"
         },
         {
-          "tx": 6,
+          "tx": 3,
+          "ty": 1,
+          "tileId": "counterTop"
+        },
+        {
+          "tx": 8,
+          "ty": 1,
+          "tileId": "bookshelfTop"
+        },
+        {
+          "tx": 8,
           "ty": 2,
-          "tileId": "roundTable"
+          "tileId": "bookshelfBottom"
         },
         {
-          "tx": 7,
-          "ty": 3,
-          "tileId": "stool"
+          "tx": 5,
+          "ty": 1,
+          "tileId": "darkPotWithLid"
+        },
+        {
+          "tx": 1,
+          "ty": 4,
+          "tileId": "crate"
+        },
+        {
+          "tx": 2,
+          "ty": 4,
+          "tileId": "openCrate"
+        },
+        {
+          "tx": 8,
+          "ty": 4,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 1,
+          "ty": 6,
+          "tileId": "smallRock"
         }
       ],
       "exits": []

--- a/web/src/data/hub/gearford/questDefs.json
+++ b/web/src/data/hub/gearford/questDefs.json
@@ -6,9 +6,9 @@
       "type": "fetch",
       "giverNpcId": "forgemaster-brunn",
       "receiverNpcId": "forgemaster-brunn",
-      "offerDialogue": "Three toolboxes lifted from the yard in one week. The whole foundry grinds to a halt without them. Whoever took them stashed them around town — find the crates and bring them back before the furnace goes cold.",
-      "activeDialogue": "Three toolbox crates, stashed somewhere around town. Thieves are lazy — check the quiet corners.",
-      "completeDialogue": "Every wrench accounted for. The furnace stays lit and so does my temper — barely. You've earned this, traveller.",
+      "offerDialogue": "Three toolboxes lifted from the yard in one week. The whole foundry grinds to a halt without them. Whoever took them stashed them around town \u2014 find the crates and bring them back before the furnace goes cold.",
+      "activeDialogue": "Three toolbox crates, stashed somewhere around town. Thieves are lazy \u2014 check the quiet corners.",
+      "completeDialogue": "Every wrench accounted for. The furnace stays lit and so does my temper \u2014 barely. You've earned this, traveller.",
       "steps": [
         {
           "key": "tools",
@@ -32,9 +32,9 @@
       "giverNpcId": "engineer-vela",
       "receiverNpcId": "engineer-vela",
       "prerequisite": "quest:gearford-stolen-tools",
-      "offerDialogue": "The forge is down to its last scuttle of coal and the next caravan is a week out. Two sacks from the old depot would keep us running. The depot's abandoned — the coal isn't doing anyone any good sitting there.",
+      "offerDialogue": "The forge is down to its last scuttle of coal and the next caravan is a week out. Two sacks from the old depot would keep us running. The depot's abandoned \u2014 the coal isn't doing anyone any good sitting there.",
       "activeDialogue": "Two coal sacks from the old depot, south side of town. Heavy, but you look like you lift.",
-      "completeDialogue": "Coal! Beautiful, filthy coal. The forge eats tonight. You've kept Gearford working, friend — that's worth more here than gold. Have some gold anyway.",
+      "completeDialogue": "Coal! Beautiful, filthy coal. The forge eats tonight. You've kept Gearford working, friend \u2014 that's worth more here than gold. Have some gold anyway.",
       "steps": [
         {
           "key": "coal",
@@ -52,43 +52,690 @@
           "engineer-vela": 15
         }
       }
+    },
+    {
+      "id": "gearford-forge-relight",
+      "title": "Relight the Furnace",
+      "type": "chain",
+      "giverNpcId": "forgemaster-brunn",
+      "receiverNpcId": "forgemaster-brunn",
+      "prerequisite": "quest:gearford-coal-run",
+      "offerDialogue": "Coal's no good if the furnace has gone stone cold. To relight her I need dry kindling \u2014 good split logs, not the damp rubbish from the yard. Three bundles should catch her.",
+      "activeDialogue": "Three bundles of dry kindling, scattered about the town. Look for stacked log piles.",
+      "completeDialogue": "There she goes \u2014 roaring like the old days. Feel that heat? That's Gearford's heart beating again. Good work.",
+      "steps": [
+        {
+          "key": "kindling",
+          "type": "collect",
+          "pickupIds": [
+            "kindling-1",
+            "kindling-2",
+            "kindling-3"
+          ],
+          "required": 3
+        }
+      ],
+      "reward": {
+        "crystals": 70,
+        "friendship": {
+          "forgemaster-brunn": 15
+        }
+      }
+    },
+    {
+      "id": "gearford-quench-the-furnace",
+      "title": "Quench the Casting",
+      "type": "chain",
+      "giverNpcId": "forgemaster-brunn",
+      "receiverNpcId": "forgemaster-brunn",
+      "prerequisite": "quest:gearford-forge-relight",
+      "offerDialogue": "First casting since the relight, and I've no water to quench it. Two barrels from the well rounds, quick as you can \u2014 a casting cooled wrong is a casting cracked.",
+      "activeDialogue": "Two water barrels for the quench. The wells are by the worker rows and the mine approach.",
+      "completeDialogue": "Hissssss \u2014 perfect. Tempered true, not a crack in it. You've the makings of a smith, traveller. Don't let it go to your head.",
+      "steps": [
+        {
+          "key": "water",
+          "type": "collect",
+          "pickupIds": [
+            "water-barrel-1",
+            "water-barrel-2"
+          ],
+          "required": 2
+        }
+      ],
+      "reward": {
+        "crystals": 90,
+        "collectible": {
+          "id": "gearford-forge-token",
+          "name": "Forge Token",
+          "icon": "\ud83d\udd25",
+          "desc": "A still-warm iron token stamped with the Gearford anvil. The forgemaster's mark of trust."
+        }
+      }
+    },
+    {
+      "id": "gearford-ore-haul",
+      "title": "Ore by the Barrowload",
+      "type": "fetch",
+      "giverNpcId": "foreman-dask",
+      "receiverNpcId": "foreman-dask",
+      "offerDialogue": "Quota's due and we're three loads short. The drifts are full of cut ore the night shift never hauled up. Take the shaft down, fill your arms, and bring it to the surface.",
+      "activeDialogue": "Three loads of ore, down the mine shaft. Take the ladder in the headframe, then work the drifts off the crossing.",
+      "completeDialogue": "Quota met, and a day to spare. The crew can drink easy tonight. You'd make a fair miner, if the smith ever lets you go.",
+      "steps": [
+        {
+          "key": "ore",
+          "type": "collect",
+          "pickupIds": [
+            "ore-1",
+            "ore-2",
+            "ore-3"
+          ],
+          "required": 3
+        }
+      ],
+      "reward": {
+        "crystals": 70
+      }
+    },
+    {
+      "id": "gearford-cave-in",
+      "title": "Clear the Cave-In",
+      "type": "chain",
+      "giverNpcId": "foreman-dask",
+      "receiverNpcId": "foreman-dask",
+      "prerequisite": "quest:gearford-ore-haul",
+      "offerDialogue": "A timber gave in the drifts and brought half the roof with it. Nobody's hurt, but the way's blocked with rubble. Shift the worst of it so my crew can get back to the seam.",
+      "activeDialogue": "Three heaps of fallen rubble to clear, down in the drifts off the crossing.",
+      "completeDialogue": "Passage clear and the timbers reset. You don't flinch in the dark \u2014 rarer than ore, that. The crew owes you a round.",
+      "steps": [
+        {
+          "key": "rubble",
+          "type": "collect",
+          "pickupIds": [
+            "rubble-1",
+            "rubble-2",
+            "rubble-3"
+          ],
+          "required": 3
+        }
+      ],
+      "reward": {
+        "crystals": 85,
+        "friendship": {
+          "foreman-dask": 15
+        }
+      }
+    },
+    {
+      "id": "gearford-lost-lamp",
+      "title": "A Light in the Dark",
+      "type": "fetch",
+      "giverNpcId": "miner-jole",
+      "receiverNpcId": "miner-jole",
+      "offerDialogue": "Dropped my good lamp somewhere in the west drift and I'll not go back down blind. Fetch it for me, would you? A miner without a light is just a fellow waiting for the roof.",
+      "activeDialogue": "Jole's miner's lamp, lost in the west drift. Take the shaft down and head left from the crossing.",
+      "completeDialogue": "There she is! Burned the whole time, the stubborn thing. Bless you \u2014 I'll sleep easier knowing I can see my own feet again.",
+      "steps": [
+        {
+          "key": "lamp",
+          "type": "collect",
+          "pickupIds": [
+            "jole-lamp"
+          ],
+          "required": 1
+        }
+      ],
+      "reward": {
+        "crystals": 50,
+        "friendship": {
+          "miner-jole": 10
+        }
+      }
+    },
+    {
+      "id": "gearford-broken-pump-1",
+      "title": "The Failing Pump I: Valves",
+      "type": "chain",
+      "giverNpcId": "engineer-vela",
+      "receiverNpcId": "engineer-vela",
+      "prerequisite": "quest:gearford-coal-run",
+      "offerDialogue": "The great pump that drains the deep workings is failing, and if she stops the mine floods. First trouble: two valves blown clean off. Spares should be lying about the works and the mine approach \u2014 round them up.",
+      "activeDialogue": "Two pump valves, somewhere about the works and the mine approach.",
+      "completeDialogue": "Both valves, good as new. That buys us time, but not much. Come back when you've the stomach for the next part.",
+      "steps": [
+        {
+          "key": "valves",
+          "type": "collect",
+          "pickupIds": [
+            "valve-1",
+            "valve-2"
+          ],
+          "required": 2
+        }
+      ],
+      "reward": {
+        "crystals": 60
+      }
+    },
+    {
+      "id": "gearford-broken-pump-2",
+      "title": "The Failing Pump II: Flywheels",
+      "type": "chain",
+      "giverNpcId": "engineer-vela",
+      "receiverNpcId": "engineer-vela",
+      "prerequisite": "quest:gearford-broken-pump-1",
+      "offerDialogue": "Valves hold, but the flywheel's cracked through. There are cast spares in the workshop loft and another in the warehouse \u2014 both heavy as sin. Bring them and I'll true them on the lathe.",
+      "activeDialogue": "Two cast flywheels \u2014 one in the workshop loft, one in the town warehouse.",
+      "completeDialogue": "Trued and balanced. She'll spin smooth now. One last part and the old pump lives again \u2014 Edda at the pump house has the rest of it.",
+      "steps": [
+        {
+          "key": "flywheels",
+          "type": "collect",
+          "pickupIds": [
+            "flywheel-1",
+            "flywheel-2"
+          ],
+          "required": 2
+        }
+      ],
+      "reward": {
+        "crystals": 75
+      }
+    },
+    {
+      "id": "gearford-broken-pump-3",
+      "title": "The Failing Pump III: The Fitting",
+      "type": "chain",
+      "giverNpcId": "engineer-vela",
+      "receiverNpcId": "pumpwright-edda",
+      "prerequisite": "quest:gearford-broken-pump-2",
+      "offerDialogue": "Here \u2014 the rebuilt fitting, valves and flywheel and all. I'm too old for the climb down to the pump house. Carry it to Pumpwright Edda and she'll set the old girl running.",
+      "activeDialogue": "Carry the rebuilt pump fitting down to Pumpwright Edda at the pump house.",
+      "completeDialogue": "By the Fracture, it turns! Listen to her \u2014 drinking the deep water down. You've saved the whole lower seam, traveller. Gearford won't forget it.",
+      "steps": [
+        {
+          "key": "fitting",
+          "type": "collect",
+          "pickupIds": [
+            "pump-fitting"
+          ],
+          "required": 1
+        },
+        {
+          "key": "deliver-fitting",
+          "type": "deliver",
+          "targetNpcId": "pumpwright-edda",
+          "required": 1
+        }
+      ],
+      "reward": {
+        "crystals": 110,
+        "collectible": {
+          "id": "gearford-pump-cog",
+          "name": "Pumpwright's Cog",
+          "icon": "\u2699\ufe0f",
+          "desc": "A polished brass cog from the great pump. It turns smoothly between your fingers, a token of the deep workings saved."
+        }
+      }
+    },
+    {
+      "id": "gearford-scattered-parts",
+      "title": "Scattered to the Four Winds",
+      "type": "lost-items",
+      "giverNpcId": "apprentice-tila",
+      "receiverNpcId": "apprentice-tila",
+      "offerDialogue": "I dropped a whole tray of parts in the yard and the wind took half of them! If Brunn finds out I'll be sweeping ash till midwinter. Help me find four before he notices \u2014 please?",
+      "activeDialogue": "Four scattered parts to recover before Brunn notices. They blew across the yard and the works.",
+      "completeDialogue": "All four! Oh, thank the gears. You're a proper hero, you are. Don't tell Brunn it ever happened, all right? Our secret.",
+      "steps": [
+        {
+          "key": "parts",
+          "type": "collect",
+          "pickupIds": [
+            "part-1",
+            "part-2",
+            "part-3",
+            "part-4"
+          ],
+          "required": 4
+        }
+      ],
+      "reward": {
+        "crystals": 60,
+        "friendship": {
+          "apprentice-tila": 15
+        }
+      }
+    },
+    {
+      "id": "gearford-apprentices-errand",
+      "title": "The Apprentice's Errand",
+      "type": "fetch",
+      "giverNpcId": "apprentice-tila",
+      "receiverNpcId": "apprentice-tila",
+      "prerequisite": "quest:gearford-scattered-parts",
+      "offerDialogue": "Brunn's got me running errands again. He wants two crates of finished fittings collected from the works before the bell. I can't carry both \u2014 would you grab them for me?",
+      "activeDialogue": "Two crates of finished fittings to collect from around the works.",
+      "completeDialogue": "Both crates, right on the bell! Brunn even said 'good lad' \u2014 well, near enough. Couldn't have done it without you.",
+      "steps": [
+        {
+          "key": "errand",
+          "type": "collect",
+          "pickupIds": [
+            "errand-1",
+            "errand-2"
+          ],
+          "required": 2
+        }
+      ],
+      "reward": {
+        "crystals": 55
+      }
+    },
+    {
+      "id": "gearford-rats-in-the-store",
+      "title": "Rats in the Store",
+      "type": "fetch",
+      "giverNpcId": "innkeep-mags",
+      "receiverNpcId": "innkeep-mags",
+      "offerDialogue": "Rats again, eating through my sacks faster than the miners eat my stew. Find the three gnawed sacks and pull them before the whole store's spoiled. Mind your fingers \u2014 they bite.",
+      "activeDialogue": "Three gnawed sacks to clear from the inn. They'll be the chewed-up ones.",
+      "completeDialogue": "Cleared the lot, and not a moment too soon. The pantry's saved and so's my reputation for clean stew. First ale's on the house, traveller.",
+      "steps": [
+        {
+          "key": "sacks",
+          "type": "collect",
+          "pickupIds": [
+            "rat-sack-1",
+            "rat-sack-2",
+            "rat-sack-3"
+          ],
+          "required": 3
+        }
+      ],
+      "reward": {
+        "crystals": 50,
+        "friendship": {
+          "innkeep-mags": 10
+        }
+      }
+    },
+    {
+      "id": "gearford-innkeeps-order",
+      "title": "The Innkeep's Order",
+      "type": "fetch",
+      "giverNpcId": "innkeep-mags",
+      "receiverNpcId": "innkeep-mags",
+      "prerequisite": "quest:gearford-rats-in-the-store",
+      "offerDialogue": "Pay day tomorrow and every miner in Gearford'll be thirsty as the deep drift. My ale order's sitting in the warehouse and Rell won't deliver. Two barrels \u2014 fetch them before the rush?",
+      "activeDialogue": "Two ale barrels waiting in the town warehouse. Mags needs them before pay day.",
+      "completeDialogue": "Both barrels, tapped and ready. Tomorrow this place'll be roaring. You've a stool by the fire any night you like, traveller.",
+      "steps": [
+        {
+          "key": "ale",
+          "type": "collect",
+          "pickupIds": [
+            "ale-barrel-1",
+            "ale-barrel-2"
+          ],
+          "required": 2
+        }
+      ],
+      "reward": {
+        "crystals": 65,
+        "friendship": {
+          "innkeep-mags": 15
+        }
+      }
+    },
+    {
+      "id": "gearford-missing-stores",
+      "title": "The Quartermaster's Ledger",
+      "type": "lost-items",
+      "giverNpcId": "quartermaster-rell",
+      "receiverNpcId": "quartermaster-rell",
+      "offerDialogue": "Four crates short on the last delivery and my ledger won't balance. Slipshod loading, scattered between here and the rows. Find them and my books \u2014 and my temper \u2014 are set right.",
+      "activeDialogue": "Four missing supply crates, scattered between the warehouse and the worker rows.",
+      "completeDialogue": "Four, four, and the ledger balances at last. Order restored. You've a quartermaster's eye, traveller \u2014 I mean that as the highest praise I own.",
+      "steps": [
+        {
+          "key": "stores",
+          "type": "collect",
+          "pickupIds": [
+            "store-1",
+            "store-2",
+            "store-3",
+            "store-4"
+          ],
+          "required": 4
+        }
+      ],
+      "reward": {
+        "crystals": 70,
+        "friendship": {
+          "quartermaster-rell": 10
+        }
+      }
+    },
+    {
+      "id": "gearford-forge-the-key",
+      "title": "A Key for Ravenwatch",
+      "type": "fetch",
+      "giverNpcId": "gearwright-orin",
+      "receiverNpcId": "guard-captain-thorin",
+      "offerDialogue": "Word came by raven: Ravenwatch's gaol lock has seized and their guard captain needs a new key forged. I'll cut it \u2014 but I need good iron first. Fetch me an ingot from the coal store, then carry the finished key to Captain Thorin in Ravenwatch yourself.",
+      "activeDialogue": "Fetch an iron ingot from the coal store for Orin to forge the key, then deliver the finished key to Guard Captain Thorin over in Ravenwatch.",
+      "completeDialogue": "Forged in Gearford, turned in Ravenwatch \u2014 fits like it was born to the lock. You've the captain's thanks, and mine. Safe roads between our towns, traveller.",
+      "steps": [
+        {
+          "key": "iron",
+          "type": "collect",
+          "pickupIds": [
+            "key-iron-ingot"
+          ],
+          "required": 1
+        },
+        {
+          "key": "deliver-key",
+          "type": "deliver",
+          "targetNpcId": "guard-captain-thorin",
+          "required": 1
+        }
+      ],
+      "reward": {
+        "crystals": 100,
+        "collectible": {
+          "id": "gearford-master-key",
+          "name": "Gearford Iron Key",
+          "icon": "\ud83d\udddd\ufe0f",
+          "desc": "A spare of the key you forged for Ravenwatch's gaol \u2014 kept as a token of two towns bound by good iron."
+        }
+      }
     }
   ],
   "pickupItems": [
     {
       "id": "toolbox-1",
-      "tx": 2,
-      "ty": 17,
+      "tx": 4,
+      "ty": 14,
       "tileId": "crate",
       "questId": "gearford-stolen-tools"
     },
     {
       "id": "toolbox-2",
-      "tx": 30,
-      "ty": 4,
+      "tx": 33,
+      "ty": 14,
       "tileId": "crate",
       "questId": "gearford-stolen-tools"
     },
     {
       "id": "toolbox-3",
-      "tx": 12,
-      "ty": 21,
+      "tx": 10,
+      "ty": 27,
       "tileId": "crate",
       "questId": "gearford-stolen-tools"
     },
     {
       "id": "coal-sack-1",
-      "tx": 6,
-      "ty": 23,
+      "tx": 24,
+      "ty": 28,
       "tileId": "sack",
       "questId": "gearford-coal-run"
     },
     {
       "id": "coal-sack-2",
-      "tx": 28,
-      "ty": 23,
+      "tx": 33,
+      "ty": 29,
       "tileId": "sack",
       "questId": "gearford-coal-run"
+    },
+    {
+      "id": "kindling-1",
+      "tx": 5,
+      "ty": 14,
+      "tileId": "logPile",
+      "questId": "gearford-forge-relight"
+    },
+    {
+      "id": "kindling-2",
+      "tx": 35,
+      "ty": 16,
+      "tileId": "logPile",
+      "questId": "gearford-forge-relight"
+    },
+    {
+      "id": "kindling-3",
+      "tx": 12,
+      "ty": 18,
+      "tileId": "logPile",
+      "questId": "gearford-forge-relight"
+    },
+    {
+      "id": "water-barrel-1",
+      "tx": 20,
+      "ty": 16,
+      "tileId": "barrel",
+      "questId": "gearford-quench-the-furnace"
+    },
+    {
+      "id": "water-barrel-2",
+      "tx": 35,
+      "ty": 18,
+      "tileId": "barrel",
+      "questId": "gearford-quench-the-furnace"
+    },
+    {
+      "id": "ore-1",
+      "tx": 5,
+      "ty": 2,
+      "tileId": "smallRock",
+      "building": "mine-tunnel-b",
+      "questId": "gearford-ore-haul"
+    },
+    {
+      "id": "ore-2",
+      "tx": 7,
+      "ty": 3,
+      "tileId": "smallRock",
+      "building": "mine-tunnel-c",
+      "questId": "gearford-ore-haul"
+    },
+    {
+      "id": "ore-3",
+      "tx": 8,
+      "ty": 2,
+      "tileId": "smallRock",
+      "building": "mine-tunnel-a",
+      "questId": "gearford-ore-haul"
+    },
+    {
+      "id": "rubble-1",
+      "tx": 4,
+      "ty": 5,
+      "tileId": "largeRock",
+      "building": "mine-tunnel-b",
+      "questId": "gearford-cave-in"
+    },
+    {
+      "id": "rubble-2",
+      "tx": 5,
+      "ty": 5,
+      "tileId": "largeRock",
+      "building": "mine-tunnel-c",
+      "questId": "gearford-cave-in"
+    },
+    {
+      "id": "rubble-3",
+      "tx": 5,
+      "ty": 5,
+      "tileId": "largeRock",
+      "building": "mine-tunnel-a",
+      "questId": "gearford-cave-in"
+    },
+    {
+      "id": "jole-lamp",
+      "tx": 6,
+      "ty": 4,
+      "tileId": "floorLantern",
+      "building": "mine-tunnel-b",
+      "questId": "gearford-lost-lamp"
+    },
+    {
+      "id": "valve-1",
+      "tx": 21,
+      "ty": 18,
+      "tileId": "barrel",
+      "questId": "gearford-broken-pump-1"
+    },
+    {
+      "id": "valve-2",
+      "tx": 12,
+      "ty": 20,
+      "tileId": "barrel",
+      "questId": "gearford-broken-pump-1"
+    },
+    {
+      "id": "flywheel-1",
+      "tx": 8,
+      "ty": 4,
+      "tileId": "crate",
+      "building": "machine-workshop-loft",
+      "questId": "gearford-broken-pump-2"
+    },
+    {
+      "id": "flywheel-2",
+      "tx": 6,
+      "ty": 7,
+      "tileId": "crate",
+      "building": "warehouse",
+      "questId": "gearford-broken-pump-2"
+    },
+    {
+      "id": "pump-fitting",
+      "tx": 9,
+      "ty": 7,
+      "tileId": "darkPotWithLid",
+      "building": "machine-workshop",
+      "questId": "gearford-broken-pump-3"
+    },
+    {
+      "id": "part-1",
+      "tx": 6,
+      "ty": 14,
+      "tileId": "crate",
+      "questId": "gearford-scattered-parts"
+    },
+    {
+      "id": "part-2",
+      "tx": 28,
+      "ty": 14,
+      "tileId": "crate",
+      "questId": "gearford-scattered-parts"
+    },
+    {
+      "id": "part-3",
+      "tx": 30,
+      "ty": 14,
+      "tileId": "crate",
+      "questId": "gearford-scattered-parts"
+    },
+    {
+      "id": "part-4",
+      "tx": 32,
+      "ty": 14,
+      "tileId": "crate",
+      "questId": "gearford-scattered-parts"
+    },
+    {
+      "id": "errand-1",
+      "tx": 7,
+      "ty": 14,
+      "tileId": "openCrate",
+      "questId": "gearford-apprentices-errand"
+    },
+    {
+      "id": "errand-2",
+      "tx": 31,
+      "ty": 14,
+      "tileId": "openCrate",
+      "questId": "gearford-apprentices-errand"
+    },
+    {
+      "id": "rat-sack-1",
+      "tx": 2,
+      "ty": 6,
+      "tileId": "smallSack",
+      "building": "miners-inn",
+      "questId": "gearford-rats-in-the-store"
+    },
+    {
+      "id": "rat-sack-2",
+      "tx": 11,
+      "ty": 6,
+      "tileId": "smallSack",
+      "building": "miners-inn",
+      "questId": "gearford-rats-in-the-store"
+    },
+    {
+      "id": "rat-sack-3",
+      "tx": 3,
+      "ty": 6,
+      "tileId": "smallSack",
+      "building": "miners-inn",
+      "questId": "gearford-rats-in-the-store"
+    },
+    {
+      "id": "ale-barrel-1",
+      "tx": 8,
+      "ty": 7,
+      "tileId": "barrel",
+      "building": "warehouse",
+      "questId": "gearford-innkeeps-order"
+    },
+    {
+      "id": "ale-barrel-2",
+      "tx": 4,
+      "ty": 5,
+      "tileId": "barrel",
+      "building": "warehouse",
+      "questId": "gearford-innkeeps-order"
+    },
+    {
+      "id": "store-1",
+      "tx": 10,
+      "ty": 14,
+      "tileId": "crate",
+      "questId": "gearford-missing-stores"
+    },
+    {
+      "id": "store-2",
+      "tx": 20,
+      "ty": 28,
+      "tileId": "crate",
+      "questId": "gearford-missing-stores"
+    },
+    {
+      "id": "store-3",
+      "tx": 21,
+      "ty": 28,
+      "tileId": "crate",
+      "questId": "gearford-missing-stores"
+    },
+    {
+      "id": "store-4",
+      "tx": 19,
+      "ty": 28,
+      "tileId": "crate",
+      "questId": "gearford-missing-stores"
+    },
+    {
+      "id": "key-iron-ingot",
+      "tx": 5,
+      "ty": 4,
+      "tileId": "smallRock",
+      "building": "coal-yard-store",
+      "questId": "gearford-forge-the-key"
     }
   ],
   "blockedPaths": []


### PR DESCRIPTION
Closes #1741. Part of epic #1732.

Rebuilds the **Gearford** hub as a substantial industrial forge-and-mine town, bringing it up toward the Ravenwatch gold standard at **Tier B**.

## Before → After

| | Before | After | Tier B target |
|---|---|---|---|
| Buildings | 3 | **12** | ~8–12 |
| Interior rooms | 3 (single-room) | **20** (key buildings multi-room) | furnished + multi-room |
| NPCs | 3 | **10** (schedules + homeBeds) | 8–12 |
| Quests | 2 | **16** | ~15–25 |
| Exterior decor | ~22 | **131** | ~120–200 |
| Map | 34×26 | **46×36** | enlarge as needed |

## What changed (`web/src/data/hub/gearford/`)

**config.json**
- Enlarged map; a spine + two cross streets + bottom street, with a street stub in front of **every** building door — fixes #1733 (the `miners-inn` door is now reachable). All buildings ≥6×6 with a 1-tile gap.
- 12 buildings: foundry, coal store, machine workshop, gearwright hall, miners' inn, tool shop, warehouse, mine entrance, pump house, two worker cottages, gear shop.
- 20 furnished interior rooms. Multi-room buildings with linked rooms and up/down ladders: foundry → casting hall + foreman's office; workshop + parts loft; gearwright hall + workshop; inn bar + bunkrooms; mine headframe → crossing → west/east drifts.
- Relocated the three out-of-bounds interior NPCs (`forgemaster-brunn`, `engineer-vela`, `foreman-dask`) into the resized interiors — fixes #1734.
- 10 NPCs with day/night schedules and `homeBed`s (reusing existing `hub-npc-*` sprites), plus a stray cat for ambience.
- 131 decor items grouped across four areas: Foundry Yard, The Works, Mine Approach, Worker Rows.

**questDefs.json**
- Extended forge chain (relight → quench), mining quests (ore haul, cave-in, lost lamp), a **prerequisite-gated machine-repair chain** (broken pump I–III, ending at the pump house), parts-fetch / lost-items, inn & warehouse errands.
- **Cross-town hook (#1735):** *A Key for Ravenwatch* — Gearwright Orin has you forge a gaol key delivered to `guard-captain-thorin` in Ravenwatch. Uses the existing global cross-town turn-in scan, so **no Ravenwatch changes are needed**.
- 38 pickup items, all validated off streets/buildings; interior pickups for the mine drifts and stores.

## Verification
- `cd web && npm run test` → **238 passing** (incl. `loader.test.ts`).
- `cd web && npm run build` → passes (tsc + vite).
- A constraint script confirms: every door has a street tile in front, no building/street overlaps, all interior exits are reciprocal and in-bounds, NPC schedule/homeBed coords in-bounds, and no exterior pickup sits on a building or street.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01An3G6znX8wLQAm8ttjcgN8

---
_Generated by [Claude Code](https://claude.ai/code/session_01An3G6znX8wLQAm8ttjcgN8)_