### PR TITLE
Expand Appleford to Tier C (issue #1746)

### DIFF
--- a/web/src/data/hub/appleford/config.json
+++ b/web/src/data/hub/appleford/config.json
@@ -1,71 +1,153 @@
 {
-  "mapW": 896,
-  "mapH": 640,
+  "mapW": 1280,
+  "mapH": 896,
   "townName": "Appleford",
   "environment": "farmland",
+  "weather": {
+    "bySeason": {
+      "spring": "rain",
+      "summer": "clear",
+      "autumn": "fog",
+      "winter": "snow"
+    }
+  },
   "avatarStart": {
-    "tx": 14,
-    "ty": 18
+    "tx": 18,
+    "ty": 23
   },
   "exitTiles": [
     {
-      "tx": 13,
-      "ty": 19,
+      "tx": 16,
+      "ty": 24,
       "screen": "worldmap"
     },
     {
-      "tx": 14,
-      "ty": 19,
+      "tx": 17,
+      "ty": 24,
       "screen": "worldmap"
     }
   ],
   "areas": [
     {
+      "id": "appleford-village",
+      "name": "Village Lane",
+      "tx": 3,
+      "ty": 2,
+      "tw": 33,
+      "th": 9
+    },
+    {
       "id": "appleford-orchard",
       "name": "The Orchards",
-      "tx": 3,
+      "tx": 1,
       "ty": 12,
-      "tw": 22,
-      "th": 6
+      "tw": 37,
+      "th": 14
+    },
+    {
+      "id": "appleford-market",
+      "name": "Market Yard",
+      "tx": 27,
+      "ty": 13,
+      "tw": 11,
+      "th": 12
     }
   ],
   "streets": [
     {
       "rect": [
-        13,
+        18,
         2,
+        19,
+        25
+      ]
+    },
+    {
+      "rect": [
+        4,
+        10,
+        36,
+        11
+      ]
+    },
+    {
+      "rect": [
+        4,
+        20,
+        36,
+        21
+      ]
+    },
+    {
+      "rect": [
+        6,
+        9,
+        6,
+        9
+      ]
+    },
+    {
+      "rect": [
+        14,
+        9,
+        14,
+        9
+      ]
+    },
+    {
+      "rect": [
+        24,
+        9,
+        24,
+        9
+      ]
+    },
+    {
+      "rect": [
+        32,
+        9,
+        32,
+        9
+      ]
+    },
+    {
+      "rect": [
+        6,
+        19,
+        6,
+        19
+      ]
+    },
+    {
+      "rect": [
+        14,
+        19,
         14,
         19
       ]
     },
     {
       "rect": [
-        3,
-        10,
-        25,
-        11
-      ]
-    },
-    {
-      "rect": [
-        7,
-        9,
-        8,
-        9
-      ]
-    },
-    {
-      "rect": [
+        24,
         19,
-        9,
-        20,
-        9
+        24,
+        19
       ]
     },
     {
-      "tile": [
-        21,
-        9
+      "rect": [
+        32,
+        19,
+        32,
+        19
+      ]
+    },
+    {
+      "rect": [
+        16,
+        24,
+        17,
+        24
       ]
     }
   ],
@@ -74,16 +156,16 @@
       "id": "cider-house",
       "upgradeKind": "tavern",
       "rect": [
-        4,
+        3,
         2,
-        11,
+        9,
         8
       ],
       "wall": "woodWall",
       "roof": "redSlateRoof",
       "doors": [
         {
-          "tx": 4,
+          "tx": 3,
           "ty": 1,
           "hideSign": true,
           "buildingId": "cider-house"
@@ -91,12 +173,32 @@
       ]
     },
     {
+      "id": "chapel",
+      "upgradeKind": "shrine",
+      "rect": [
+        11,
+        2,
+        16,
+        8
+      ],
+      "wall": "whiteStone",
+      "roof": "greySlateRoof",
+      "doors": [
+        {
+          "tx": 3,
+          "ty": 1,
+          "hideSign": true,
+          "buildingId": "chapel"
+        }
+      ]
+    },
+    {
       "id": "keepers-cottage",
       "upgradeKind": "cottage",
       "rect": [
-        17,
-        3,
-        23,
+        21,
+        2,
+        27,
         8
       ],
       "wall": "woodWall",
@@ -109,71 +211,345 @@
           "buildingId": "keepers-cottage"
         }
       ]
+    },
+    {
+      "id": "coopers-shed",
+      "upgradeKind": "workshop",
+      "rect": [
+        29,
+        2,
+        35,
+        8
+      ],
+      "wall": "woodWall",
+      "roof": "woodRoof",
+      "doors": [
+        {
+          "tx": 3,
+          "ty": 1,
+          "hideSign": true,
+          "buildingId": "coopers-shed"
+        }
+      ]
+    },
+    {
+      "id": "bottling-barn",
+      "upgradeKind": "workshop",
+      "rect": [
+        3,
+        13,
+        9,
+        18
+      ],
+      "wall": "woodWall",
+      "roof": "strawRoof",
+      "doors": [
+        {
+          "tx": 3,
+          "ty": 1,
+          "hideSign": true,
+          "buildingId": "bottling-barn"
+        }
+      ]
+    },
+    {
+      "id": "apiary",
+      "upgradeKind": "cottage",
+      "rect": [
+        11,
+        13,
+        16,
+        18
+      ],
+      "wall": "woodWall",
+      "roof": "strawRoof",
+      "doors": [
+        {
+          "tx": 3,
+          "ty": 1,
+          "hideSign": true,
+          "buildingId": "apiary"
+        }
+      ]
+    },
+    {
+      "id": "orchard-cottage",
+      "upgradeKind": "cottage",
+      "rect": [
+        21,
+        13,
+        27,
+        18
+      ],
+      "wall": "woodWall",
+      "roof": "strawRoof",
+      "doors": [
+        {
+          "tx": 3,
+          "ty": 1,
+          "hideSign": true,
+          "buildingId": "orchard-cottage"
+        }
+      ]
+    },
+    {
+      "id": "market-barn",
+      "upgradeKind": "shop",
+      "rect": [
+        29,
+        13,
+        35,
+        18
+      ],
+      "wall": "woodWall",
+      "roof": "redSlateRoof",
+      "doors": [
+        {
+          "tx": 3,
+          "ty": 1,
+          "hideSign": true,
+          "buildingId": "market-barn"
+        }
+      ]
+    }
+  ],
+  "pondTiles": [
+    {
+      "rect": [
+        3,
+        24,
+        5,
+        25
+      ]
     }
   ],
   "exteriorDecor": [
     {
-      "comment": "orchard rows"
+      "comment": "=== orchard rows ==="
     },
     {
-      "tx": 4,
-      "ty": 13,
+      "tx": 1,
+      "ty": 0,
       "bundleID": "light-tree",
       "zlayer": "solid"
     },
     {
-      "tx": 8,
-      "ty": 13,
+      "tx": 4,
+      "ty": 0,
+      "bundleID": "autumn-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 7,
+      "ty": 0,
+      "bundleID": "light-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 10,
+      "ty": 0,
+      "bundleID": "autumn-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 13,
+      "ty": 0,
       "bundleID": "light-tree",
       "zlayer": "solid"
     },
     {
       "tx": 16,
-      "ty": 13,
-      "bundleID": "light-tree",
-      "zlayer": "solid"
-    },
-    {
-      "tx": 20,
-      "ty": 13,
-      "bundleID": "light-tree",
-      "zlayer": "solid"
-    },
-    {
-      "tx": 24,
-      "ty": 13,
-      "bundleID": "light-tree",
-      "zlayer": "solid"
-    },
-    {
-      "tx": 4,
-      "ty": 17,
+      "ty": 0,
       "bundleID": "autumn-tree",
       "zlayer": "solid"
     },
     {
-      "tx": 8,
-      "ty": 17,
-      "bundleID": "autumn-tree",
-      "zlayer": "solid"
-    },
-    {
-      "tx": 18,
-      "ty": 17,
-      "bundleID": "autumn-tree",
+      "tx": 19,
+      "ty": 0,
+      "bundleID": "light-tree",
       "zlayer": "solid"
     },
     {
       "tx": 22,
-      "ty": 17,
+      "ty": 0,
       "bundleID": "autumn-tree",
       "zlayer": "solid"
     },
     {
-      "comment": "cider house front"
+      "tx": 25,
+      "ty": 0,
+      "bundleID": "light-tree",
+      "zlayer": "solid"
     },
     {
-      "tx": 3,
+      "tx": 28,
+      "ty": 0,
+      "bundleID": "autumn-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 31,
+      "ty": 0,
+      "bundleID": "light-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 34,
+      "ty": 0,
+      "bundleID": "autumn-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 37,
+      "ty": 0,
+      "bundleID": "light-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 0,
+      "ty": 3,
+      "bundleID": "autumn-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 0,
+      "ty": 6,
+      "bundleID": "light-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 0,
+      "ty": 9,
+      "bundleID": "autumn-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 0,
+      "ty": 12,
+      "bundleID": "light-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 0,
+      "ty": 15,
+      "bundleID": "autumn-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 0,
+      "ty": 18,
+      "bundleID": "light-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 0,
+      "ty": 21,
+      "bundleID": "autumn-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 0,
+      "ty": 24,
+      "bundleID": "light-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 38,
+      "ty": 3,
+      "bundleID": "autumn-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 38,
+      "ty": 6,
+      "bundleID": "light-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 38,
+      "ty": 9,
+      "bundleID": "autumn-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 38,
+      "ty": 12,
+      "bundleID": "light-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 38,
+      "ty": 15,
+      "bundleID": "autumn-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 38,
+      "ty": 18,
+      "bundleID": "light-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 28,
+      "ty": 22,
+      "bundleID": "light-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 34,
+      "ty": 22,
+      "bundleID": "light-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 1,
+      "ty": 26,
+      "bundleID": "autumn-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 4,
+      "ty": 26,
+      "bundleID": "light-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 19,
+      "ty": 26,
+      "bundleID": "autumn-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 34,
+      "ty": 26,
+      "bundleID": "light-tree",
+      "zlayer": "solid"
+    },
+    {
+      "comment": "=== village & frontages ==="
+    },
+    {
+      "tx": 20,
+      "ty": 12,
+      "tileId": "stoneWell"
+    },
+    {
+      "tx": 16,
+      "ty": 12,
+      "tileId": "benchLeft"
+    },
+    {
+      "tx": 17,
+      "ty": 12,
+      "tileId": "benchMiddle"
+    },
+    {
+      "tx": 21,
+      "ty": 12,
+      "tileId": "potOfFlowers"
+    },
+    {
+      "tx": 15,
       "ty": 9,
       "tileId": "appleSign",
       "zlayer": "above"
@@ -181,82 +557,956 @@
     {
       "tx": 12,
       "ty": 9,
-      "tileId": "barrel"
-    },
-    {
-      "tx": 12,
-      "ty": 8,
-      "tileId": "barrel"
-    },
-    {
-      "tx": 6,
-      "ty": 9,
-      "tileId": "appleBasket"
-    },
-    {
-      "comment": "village green"
-    },
-    {
-      "tx": 15,
-      "ty": 9,
-      "tileId": "stoneWell"
+      "tileId": "lampPostBottom"
     },
     {
       "tx": 25,
       "ty": 9,
-      "tileId": "logPile"
-    },
-    {
-      "tx": 16,
-      "ty": 12,
-      "tileId": "whiteFlower"
+      "tileId": "lampPostBottom"
     },
     {
       "tx": 12,
-      "ty": 16,
-      "tileId": "whiteFlower"
+      "ty": 19,
+      "tileId": "lampPostBottom"
+    },
+    {
+      "tx": 25,
+      "ty": 19,
+      "tileId": "lampPostBottom"
+    },
+    {
+      "tx": 3,
+      "ty": 9,
+      "tileId": "barrel"
+    },
+    {
+      "tx": 4,
+      "ty": 9,
+      "tileId": "barrel"
+    },
+    {
+      "tx": 9,
+      "ty": 9,
+      "tileId": "appleBasket"
+    },
+    {
+      "tx": 8,
+      "ty": 9,
+      "tileId": "openCrate"
+    },
+    {
+      "tx": 11,
+      "ty": 9,
+      "tileId": "potOfFlowers"
+    },
+    {
+      "tx": 16,
+      "ty": 9,
+      "tileId": "potOfFlowers"
+    },
+    {
+      "tx": 21,
+      "ty": 9,
+      "tileId": "appleBasket"
+    },
+    {
+      "tx": 27,
+      "ty": 9,
+      "tileId": "hayStack"
+    },
+    {
+      "tx": 29,
+      "ty": 9,
+      "tileId": "barrel"
+    },
+    {
+      "tx": 30,
+      "ty": 9,
+      "tileId": "barrel"
+    },
+    {
+      "tx": 35,
+      "ty": 9,
+      "tileId": "logPile"
+    },
+    {
+      "tx": 3,
+      "ty": 19,
+      "tileId": "barrel"
+    },
+    {
+      "tx": 4,
+      "ty": 19,
+      "tileId": "barrel"
+    },
+    {
+      "tx": 9,
+      "ty": 19,
+      "tileId": "openCrate"
+    },
+    {
+      "tx": 11,
+      "ty": 19,
+      "tileId": "openCrate"
+    },
+    {
+      "tx": 16,
+      "ty": 19,
+      "tileId": "bunchOfHerbs"
+    },
+    {
+      "tx": 21,
+      "ty": 19,
+      "tileId": "appleBasket"
+    },
+    {
+      "tx": 27,
+      "ty": 19,
+      "tileId": "potOfFlowers"
+    },
+    {
+      "tx": 29,
+      "ty": 19,
+      "tileId": "barrel"
+    },
+    {
+      "tx": 35,
+      "ty": 19,
+      "tileId": "openCrate"
+    },
+    {
+      "tx": 30,
+      "ty": 22,
+      "tileId": "stripedShopAwningSupportPillarBot"
+    },
+    {
+      "tx": 31,
+      "ty": 22,
+      "tileId": "counterTop"
+    },
+    {
+      "tx": 32,
+      "ty": 22,
+      "tileId": "counterTop"
+    },
+    {
+      "tx": 31,
+      "ty": 23,
+      "tileId": "appleBasket"
+    },
+    {
+      "tx": 33,
+      "ty": 22,
+      "tileId": "emptyBasket"
+    },
+    {
+      "tx": 28,
+      "ty": 23,
+      "tileId": "sack"
+    },
+    {
+      "tx": 29,
+      "ty": 23,
+      "tileId": "pileOfSacks"
+    },
+    {
+      "tx": 3,
+      "ty": 26,
+      "tileId": "smallLilypad",
+      "zlayer": "below"
+    },
+    {
+      "tx": 5,
+      "ty": 24,
+      "tileId": "largeLilypad",
+      "zlayer": "below"
+    },
+    {
+      "tx": 2,
+      "ty": 25,
+      "tileId": "grassTuft",
+      "zlayer": "below"
+    },
+    {
+      "tx": 6,
+      "ty": 25,
+      "tileId": "grassTuft",
+      "zlayer": "below"
+    },
+    {
+      "tx": 33,
+      "ty": 23,
+      "tileId": "fenceLeftTop"
+    },
+    {
+      "tx": 34,
+      "ty": 23,
+      "tileId": "fenceTop"
+    },
+    {
+      "tx": 35,
+      "ty": 23,
+      "tileId": "fenceTopRight"
+    },
+    {
+      "tx": 33,
+      "ty": 24,
+      "tileId": "fenceLeft"
+    },
+    {
+      "tx": 35,
+      "ty": 24,
+      "tileId": "fenceRight"
+    },
+    {
+      "tx": 35,
+      "ty": 25,
+      "tileId": "fenceRightBottom"
+    },
+    {
+      "tx": 34,
+      "ty": 25,
+      "tileId": "fenceBotton"
+    },
+    {
+      "tx": 36,
+      "ty": 24,
+      "tileId": "hayStack"
+    },
+    {
+      "tx": 7,
+      "ty": 26,
+      "tileId": "scarecrowBottom"
+    },
+    {
+      "tx": 7,
+      "ty": 25,
+      "tileId": "scarecrowTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 23,
+      "ty": 26,
+      "tileId": "scarecrowBottom"
+    },
+    {
+      "tx": 23,
+      "ty": 25,
+      "tileId": "scarecrowTop",
+      "zlayer": "above"
+    },
+    {
+      "tx": 2,
+      "ty": 12,
+      "tileId": "pinkFlower",
+      "zlayer": "below"
+    },
+    {
+      "tx": 17,
+      "ty": 12,
+      "tileId": "pinkFlower",
+      "zlayer": "below"
+    },
+    {
+      "tx": 29,
+      "ty": 12,
+      "tileId": "pinkFlower",
+      "zlayer": "below"
+    },
+    {
+      "tx": 13,
+      "ty": 22,
+      "tileId": "pinkFlower",
+      "zlayer": "below"
+    },
+    {
+      "tx": 20,
+      "ty": 25,
+      "tileId": "pinkFlower",
+      "zlayer": "below"
+    },
+    {
+      "tx": 27,
+      "ty": 22,
+      "tileId": "pinkFlower",
+      "zlayer": "below"
+    },
+    {
+      "tx": 28,
+      "ty": 25,
+      "tileId": "cropCarrot",
+      "zlayer": "below"
+    },
+    {
+      "tx": 29,
+      "ty": 26,
+      "tileId": "cropBeans",
+      "zlayer": "below"
     }
   ],
   "npcSpawnTiles": [],
   "ambientNpcSprites": [
+    "farmer",
     "hub-npc-merchant"
+  ],
+  "chickenZones": [
+    {
+      "rect": [
+        33,
+        23,
+        3,
+        3
+      ],
+      "count": 3,
+      "roost": [
+        34,
+        24
+      ]
+    }
+  ],
+  "animals": [
+    {
+      "id": "appleford-orchard-cat",
+      "type": "cat",
+      "variant": "orange",
+      "tx": 8,
+      "ty": 12,
+      "name": "Pippin",
+      "dialogue": [
+        "*a ginger cat blinks at you from a sunny patch*",
+        "*mrrp.*"
+      ],
+      "roam": true
+    },
+    {
+      "id": "appleford-sheepdog",
+      "type": "dog",
+      "variant": "brown",
+      "tx": 26,
+      "ty": 22,
+      "name": "Bramble",
+      "dialogue": [
+        "*a shaggy dog trots over, tail going like a flag*",
+        "*woof!*"
+      ],
+      "roam": true
+    },
+    {
+      "id": "appleford-robin",
+      "type": "bird",
+      "variant": "brown",
+      "tx": 33,
+      "ty": 12,
+      "name": "The Orchard Robin",
+      "dialogue": [
+        "*a robin watches from a low branch, head cocked*"
+      ],
+      "roam": true
+    }
   ],
   "npcs": [
     {
       "id": "orchard-keeper-bess",
       "name": "Keeper Bess",
       "sprite": "hub-npc-elder",
-      "tx": 16,
-      "ty": 11,
+      "tx": 15,
+      "ty": 12,
       "dialogue": [
         "Every tree in this orchard has a name. Don't ask me to introduce all of them.",
         "Raiders hit the east rows last week. Took apples, baskets, and my best ladder.",
         "An orchard is patience you can eat. Remember that."
       ],
-      "building": "keepers-cottage",
       "questGive": "appleford-scattered-harvest",
-      "questReceive": "appleford-scattered-harvest"
+      "questReceive": [
+        "appleford-scattered-harvest",
+        "appleford-lost-in-orchard"
+      ],
+      "schedule": [
+        {
+          "startHour": 6,
+          "endHour": 20,
+          "activity": "work",
+          "location": {
+            "type": "exterior",
+            "tx": 15,
+            "ty": 12
+          }
+        },
+        {
+          "startHour": 20,
+          "endHour": 6,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "keepers-cottage",
+            "tx": 4,
+            "ty": 3
+          }
+        }
+      ],
+      "homeBed": {
+        "buildingId": "keepers-cottage",
+        "tx": 1,
+        "ty": 3
+      }
     },
     {
       "id": "cider-brewer-tom",
       "name": "Brewer Tom",
       "sprite": "hub-npc-merchant",
-      "tx": 8,
-      "ty": 10,
+      "tx": 5,
+      "ty": 3,
+      "building": "cider-house",
       "dialogue": [
-        "Appleford cider — pressed here, drunk everywhere, remembered fondly nowhere near here.",
+        "Appleford cider \u2014 pressed here, drunk everywhere, remembered fondly nowhere near here.",
         "The toll road's made deliveries a nightmare. Bandits drink my profits, literally.",
         "First mug's full price. So's the second. I'm a brewer, not a charity."
       ],
-      "building": "cider-house"
+      "questGive": "appleford-cider-pressing",
+      "questReceive": [
+        "appleford-cider-pressing",
+        "appleford-cider-pressing-2"
+      ]
+    },
+    {
+      "id": "beekeeper-mabe",
+      "name": "Beekeeper Mabe",
+      "sprite": "hub-npc-gardener",
+      "tx": 4,
+      "ty": 3,
+      "building": "apiary",
+      "dialogue": [
+        "Mind the hives. The bees know a thief from a friend, and they vote with their stings.",
+        "Honey, wax, mead \u2014 one little bee gives you all three and asks only for flowers.",
+        "Bess grows the blossom, I keep the bees. Between us we keep Appleford sweet."
+      ],
+      "questGive": "appleford-honey-harvest",
+      "questReceive": [
+        "appleford-honey-harvest",
+        "appleford-honey-harvest-2"
+      ]
+    },
+    {
+      "id": "cooper-wend",
+      "name": "Cooper Wend",
+      "sprite": "farmer",
+      "tx": 4,
+      "ty": 3,
+      "building": "coopers-shed",
+      "dialogue": [
+        "No barrel, no cider. No cider, no Appleford. I'd say I'm the most important person here, but Tom would sulk.",
+        "A good cask is watertight, sweet-grained, and never argues. Unlike apprentices.",
+        "Staves, hoops, and patience \u2014 that's a barrel. Rush any of the three and you've a puddle."
+      ],
+      "questGive": "appleford-coopers-order",
+      "questReceive": "appleford-coopers-order"
+    },
+    {
+      "id": "market-trader-posy",
+      "name": "Trader Posy",
+      "sprite": "hub-npc-trader",
+      "tx": 5,
+      "ty": 4,
+      "building": "market-barn",
+      "dialogue": [
+        "Apples, cider, honey, jam \u2014 if it grows in Appleford, it sells through me.",
+        "Ravenwatch pays double for our cider. Getting it there in one piece is the trick.",
+        "Buy low, sell ripe. That's the whole of it, traveller."
+      ],
+      "questGive": "appleford-cider-to-ravenwatch",
+      "questReceive": [
+        "appleford-orchard-pickers-2"
+      ]
+    },
+    {
+      "id": "chaplain-hale",
+      "name": "Brother Hale",
+      "sprite": "hub-npc-scholar",
+      "tx": 5,
+      "ty": 4,
+      "building": "chapel",
+      "dialogue": [
+        "The chapel's small, but the harvest's bounty fills it every autumn.",
+        "We bless the first pressing every year. The bees get a thimble of mead for their trouble.",
+        "Quiet hands, full baskets, grateful hearts. That's all the sermon Appleford needs."
+      ],
+      "questGive": "appleford-harvest-blessing",
+      "questReceive": "appleford-harvest-blessing"
+    },
+    {
+      "id": "scrumping-wren",
+      "name": "Little Wren",
+      "sprite": "hub-npc-child",
+      "tx": 9,
+      "ty": 23,
+      "dialogue": [
+        "I wasn't scrumping! I was... rescuing the apples. From the tree. Before they fell.",
+        "I dropped my things running from Keeper Bess. Don't tell her. Please?",
+        "When I grow up I'm going to own the whole orchard. And eat ALL the apples."
+      ],
+      "questGive": "appleford-scrumping",
+      "questReceive": "appleford-scrumping"
+    },
+    {
+      "id": "orchard-hand-hob",
+      "name": "Hob the Picker",
+      "sprite": "farmer",
+      "tx": 31,
+      "ty": 25,
+      "dialogue": [
+        "Up the ladder, down the ladder, basket after basket. My arms have opinions about it.",
+        "Best apples are always the ones just out of reach. Orchard's little joke.",
+        "Fill a crate, haul it to Posy, start again. It's honest work, if you like apples. I'm sick of apples."
+      ],
+      "questGive": "appleford-orchard-pickers",
+      "questReceive": [
+        "appleford-orchard-pickers"
+      ],
+      "schedule": [
+        {
+          "startHour": 6,
+          "endHour": 20,
+          "activity": "work",
+          "location": {
+            "type": "exterior",
+            "tx": 31,
+            "ty": 25
+          }
+        },
+        {
+          "startHour": 20,
+          "endHour": 6,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "orchard-cottage",
+            "tx": 4,
+            "ty": 3
+          }
+        }
+      ],
+      "homeBed": {
+        "buildingId": "orchard-cottage",
+        "tx": 1,
+        "ty": 3
+      }
     }
   ],
   "interiors": {
     "cider-house": {
       "name": "The Cider House",
-      "width": 8,
-      "height": 5,
+      "width": 12,
+      "height": 9,
       "floorTileId": "woodFloor",
+      "wallTileId": "woodWall",
+      "musicId": "inn",
+      "ambianceId": "hearth",
+      "decor": [
+        {
+          "tx": 1,
+          "ty": 1,
+          "bundleID": "fireplace"
+        },
+        {
+          "tx": 5,
+          "ty": 1,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 8,
+          "ty": 1,
+          "tileId": "bottlesOfLiquor"
+        },
+        {
+          "tx": 9,
+          "ty": 5,
+          "tileId": "counterTop"
+        },
+        {
+          "tx": 10,
+          "ty": 5,
+          "tileId": "counterTop"
+        },
+        {
+          "tx": 3,
+          "ty": 4,
+          "tileId": "roundTable"
+        },
+        {
+          "tx": 2,
+          "ty": 4,
+          "tileId": "stool"
+        },
+        {
+          "tx": 4,
+          "ty": 4,
+          "tileId": "stool"
+        },
+        {
+          "tx": 7,
+          "ty": 4,
+          "tileId": "roundTableWithCloth"
+        },
+        {
+          "tx": 8,
+          "ty": 4,
+          "tileId": "stool"
+        },
+        {
+          "tx": 10,
+          "ty": 1,
+          "tileId": "ladderBottom",
+          "zlayer": "below"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 6,
+          "ty": 0,
+          "toInteriorId": "cider-house-press",
+          "entryTx": 5,
+          "entryTy": 6,
+          "direction": "back",
+          "label": "Press Room"
+        },
+        {
+          "tx": 10,
+          "ty": 1,
+          "toInteriorId": "cider-house-cellar",
+          "entryTx": 5,
+          "entryTy": 5,
+          "direction": "down",
+          "label": "Down to the cellar"
+        }
+      ]
+    },
+    "cider-house-press": {
+      "name": "The Cider House \u2014 Press Room",
+      "width": 11,
+      "height": 8,
+      "floorTileId": "woodFloor",
+      "wallTileId": "woodWall",
+      "decor": [
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 2,
+          "ty": 1,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 9,
+          "ty": 1,
+          "tileId": "openCrate"
+        },
+        {
+          "tx": 8,
+          "ty": 1,
+          "tileId": "crate"
+        },
+        {
+          "tx": 4,
+          "ty": 4,
+          "tileId": "counterTop"
+        },
+        {
+          "tx": 5,
+          "ty": 4,
+          "tileId": "counterTop"
+        },
+        {
+          "tx": 1,
+          "ty": 5,
+          "tileId": "appleBasket"
+        },
+        {
+          "tx": 9,
+          "ty": 5,
+          "tileId": "appleBasket"
+        },
+        {
+          "tx": 7,
+          "ty": 5,
+          "tileId": "bottlesOfLiquor"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 5,
+          "ty": 7,
+          "toInteriorId": "cider-house",
+          "entryTx": 6,
+          "entryTy": 1,
+          "direction": "front",
+          "label": "Taproom"
+        }
+      ]
+    },
+    "cider-house-cellar": {
+      "name": "The Cider House \u2014 Cellar",
+      "width": 10,
+      "height": 8,
+      "floorTileId": "stoneFloor",
+      "wallTileId": "woodWall",
+      "decor": [
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 2,
+          "ty": 1,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 8,
+          "ty": 1,
+          "tileId": "bottlesOfLiquor"
+        },
+        {
+          "tx": 7,
+          "ty": 1,
+          "tileId": "crate"
+        },
+        {
+          "tx": 1,
+          "ty": 5,
+          "tileId": "openCrate"
+        },
+        {
+          "tx": 3,
+          "ty": 3,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 2,
+          "ty": 3,
+          "tileId": "candlestickLitTop",
+          "glow": true,
+          "glowRadius": 2
+        },
+        {
+          "tx": 5,
+          "ty": 5,
+          "tileId": "ladderBottom",
+          "zlayer": "below"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 5,
+          "ty": 5,
+          "toInteriorId": "cider-house",
+          "entryTx": 10,
+          "entryTy": 2,
+          "direction": "up",
+          "label": "Up to the taproom"
+        }
+      ]
+    },
+    "chapel": {
+      "name": "The Orchard Chapel",
+      "width": 11,
+      "height": 9,
+      "floorTileId": "stoneFloor",
+      "wallTileId": "whiteStone",
+      "musicId": "church",
+      "ambianceId": "sacred",
+      "decor": [
+        {
+          "tx": 5,
+          "ty": 1,
+          "tileId": "candlestickLitTop",
+          "glow": true,
+          "glowRadius": 2
+        },
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "potOfFlowers"
+        },
+        {
+          "tx": 9,
+          "ty": 1,
+          "tileId": "potOfFlowers"
+        },
+        {
+          "tx": 2,
+          "ty": 4,
+          "tileId": "benchLeft"
+        },
+        {
+          "tx": 3,
+          "ty": 4,
+          "tileId": "benchRight"
+        },
+        {
+          "tx": 7,
+          "ty": 4,
+          "tileId": "benchLeft"
+        },
+        {
+          "tx": 8,
+          "ty": 4,
+          "tileId": "benchRight"
+        },
+        {
+          "tx": 2,
+          "ty": 6,
+          "tileId": "benchLeft"
+        },
+        {
+          "tx": 3,
+          "ty": 6,
+          "tileId": "benchRight"
+        },
+        {
+          "tx": 7,
+          "ty": 6,
+          "tileId": "benchLeft"
+        },
+        {
+          "tx": 8,
+          "ty": 6,
+          "tileId": "benchRight"
+        },
+        {
+          "tx": 1,
+          "ty": 5,
+          "tileId": "candlestickUnlit"
+        },
+        {
+          "tx": 9,
+          "ty": 5,
+          "tileId": "candlestickUnlit"
+        }
+      ],
+      "exits": []
+    },
+    "keepers-cottage": {
+      "name": "The Keeper's Cottage",
+      "width": 11,
+      "height": 8,
+      "floorTileId": "woodFloor",
+      "wallTileId": "woodWall",
+      "decor": [
+        {
+          "tx": 1,
+          "ty": 2,
+          "bundleID": "simple-bed"
+        },
+        {
+          "tx": 9,
+          "ty": 1,
+          "tileId": "bookshelfTop"
+        },
+        {
+          "tx": 9,
+          "ty": 2,
+          "tileId": "bookshelfBottom"
+        },
+        {
+          "tx": 5,
+          "ty": 4,
+          "tileId": "roundTable"
+        },
+        {
+          "tx": 6,
+          "ty": 4,
+          "tileId": "stool"
+        },
+        {
+          "tx": 3,
+          "ty": 1,
+          "tileId": "appleBasket"
+        },
+        {
+          "tx": 8,
+          "ty": 5,
+          "tileId": "potOfFlowers"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 6,
+          "ty": 0,
+          "toInteriorId": "keepers-cottage-back",
+          "entryTx": 5,
+          "entryTy": 6,
+          "direction": "back",
+          "label": "Pantry"
+        }
+      ]
+    },
+    "keepers-cottage-back": {
+      "name": "The Keeper's Cottage \u2014 Pantry",
+      "width": 10,
+      "height": 8,
+      "floorTileId": "woodFloor",
+      "wallTileId": "woodWall",
+      "decor": [
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "appleBasket"
+        },
+        {
+          "tx": 2,
+          "ty": 1,
+          "tileId": "appleBasket"
+        },
+        {
+          "tx": 8,
+          "ty": 1,
+          "tileId": "pileOfSacks"
+        },
+        {
+          "tx": 7,
+          "ty": 1,
+          "tileId": "sack"
+        },
+        {
+          "tx": 1,
+          "ty": 5,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 8,
+          "ty": 5,
+          "tileId": "mushroomBasket"
+        },
+        {
+          "tx": 4,
+          "ty": 3,
+          "tileId": "smallTableTopLeft"
+        },
+        {
+          "tx": 5,
+          "ty": 3,
+          "tileId": "smallTableTopRight"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 5,
+          "ty": 7,
+          "toInteriorId": "keepers-cottage",
+          "entryTx": 6,
+          "entryTy": 1,
+          "direction": "front",
+          "label": "Main Room"
+        }
+      ]
+    },
+    "coopers-shed": {
+      "name": "The Cooper's Shed",
+      "width": 10,
+      "height": 8,
+      "floorTileId": "darkWoodFloor",
       "wallTileId": "woodWall",
       "decor": [
         {
@@ -275,19 +1525,207 @@
           "tileId": "barrel"
         },
         {
-          "tx": 6,
+          "tx": 8,
           "ty": 1,
-          "tileId": "bottlesOfLiquor"
+          "tileId": "logPile"
+        },
+        {
+          "tx": 7,
+          "ty": 1,
+          "tileId": "openCrate"
+        },
+        {
+          "tx": 1,
+          "ty": 5,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 8,
+          "ty": 5,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 4,
+          "ty": 3,
+          "tileId": "counterTop"
+        },
+        {
+          "tx": 5,
+          "ty": 3,
+          "tileId": "logBottom"
         }
       ],
       "exits": []
     },
-    "keepers-cottage": {
-      "name": "The Keeper's Cottage",
-      "width": 7,
-      "height": 4,
+    "bottling-barn": {
+      "name": "The Bottling Barn",
+      "width": 12,
+      "height": 8,
       "floorTileId": "woodFloor",
       "wallTileId": "woodWall",
+      "decor": [
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 2,
+          "ty": 1,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 10,
+          "ty": 1,
+          "tileId": "bottlesOfLiquor"
+        },
+        {
+          "tx": 3,
+          "ty": 1,
+          "tileId": "crate"
+        },
+        {
+          "tx": 9,
+          "ty": 1,
+          "tileId": "openCrate"
+        },
+        {
+          "tx": 4,
+          "ty": 4,
+          "tileId": "counterTop"
+        },
+        {
+          "tx": 5,
+          "ty": 4,
+          "tileId": "counterTop"
+        },
+        {
+          "tx": 6,
+          "ty": 4,
+          "tileId": "counterTop"
+        },
+        {
+          "tx": 1,
+          "ty": 5,
+          "tileId": "appleBasket"
+        },
+        {
+          "tx": 10,
+          "ty": 5,
+          "tileId": "bottle"
+        }
+      ],
+      "exits": []
+    },
+    "apiary": {
+      "name": "The Beekeeper's Cottage",
+      "width": 10,
+      "height": 8,
+      "floorTileId": "woodFloor",
+      "wallTileId": "woodWall",
+      "ambianceId": "hearth",
+      "decor": [
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "crate"
+        },
+        {
+          "tx": 2,
+          "ty": 1,
+          "tileId": "crate"
+        },
+        {
+          "tx": 8,
+          "ty": 1,
+          "tileId": "bottlesOfLiquor"
+        },
+        {
+          "tx": 3,
+          "ty": 1,
+          "tileId": "bunchOfHerbs"
+        },
+        {
+          "tx": 7,
+          "ty": 1,
+          "tileId": "potOfFlowers"
+        },
+        {
+          "tx": 1,
+          "ty": 5,
+          "tileId": "openCrate"
+        },
+        {
+          "tx": 8,
+          "ty": 5,
+          "tileId": "bunchOfHerbs"
+        },
+        {
+          "tx": 4,
+          "ty": 3,
+          "tileId": "roundTable"
+        },
+        {
+          "tx": 5,
+          "ty": 3,
+          "tileId": "bottle"
+        }
+      ],
+      "exits": []
+    },
+    "orchard-cottage": {
+      "name": "The Orchard Cottage",
+      "width": 10,
+      "height": 8,
+      "floorTileId": "woodFloor",
+      "wallTileId": "woodWall",
+      "decor": [
+        {
+          "tx": 1,
+          "ty": 2,
+          "bundleID": "simple-bed"
+        },
+        {
+          "tx": 8,
+          "ty": 1,
+          "tileId": "bottlesOfLiquor"
+        },
+        {
+          "tx": 3,
+          "ty": 1,
+          "tileId": "appleBasket"
+        },
+        {
+          "tx": 5,
+          "ty": 4,
+          "tileId": "roundTable"
+        },
+        {
+          "tx": 6,
+          "ty": 4,
+          "tileId": "stool"
+        },
+        {
+          "tx": 4,
+          "ty": 4,
+          "tileId": "stool"
+        },
+        {
+          "tx": 8,
+          "ty": 5,
+          "tileId": "potOfFlowers"
+        }
+      ],
+      "exits": []
+    },
+    "market-barn": {
+      "name": "The Market Hall",
+      "width": 12,
+      "height": 9,
+      "floorTileId": "woodFloor",
+      "wallTileId": "woodWall",
+      "musicId": "shop",
+      "ambianceId": "market",
       "decor": [
         {
           "tx": 1,
@@ -295,17 +1733,84 @@
           "tileId": "appleBasket"
         },
         {
-          "tx": 4,
+          "tx": 2,
           "ty": 1,
-          "tileId": "roundTable"
+          "tileId": "appleBasket"
+        },
+        {
+          "tx": 3,
+          "ty": 1,
+          "tileId": "emptyBasket"
+        },
+        {
+          "tx": 9,
+          "ty": 1,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 10,
+          "ty": 1,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 4,
+          "ty": 5,
+          "tileId": "counterTop"
         },
         {
           "tx": 5,
-          "ty": 2,
-          "tileId": "stool"
+          "ty": 5,
+          "tileId": "counterTop"
+        },
+        {
+          "tx": 6,
+          "ty": 5,
+          "tileId": "counterTop"
+        },
+        {
+          "tx": 7,
+          "ty": 5,
+          "tileId": "counterTop"
+        },
+        {
+          "tx": 1,
+          "ty": 5,
+          "tileId": "pileOfSacks"
+        },
+        {
+          "tx": 10,
+          "ty": 5,
+          "tileId": "openCrate"
+        },
+        {
+          "tx": 5,
+          "ty": 1,
+          "tileId": "bottlesOfLiquor"
         }
       ],
       "exits": []
     }
-  }
+  },
+  "festivalDecor": [
+    {
+      "festivalId": "harvest",
+      "decor": [
+        {
+          "tx": 13,
+          "ty": 12,
+          "tileId": "pumpkin1Lit"
+        },
+        {
+          "tx": 25,
+          "ty": 12,
+          "tileId": "pumpkin1Lit"
+        },
+        {
+          "tx": 20,
+          "ty": 9,
+          "tileId": "hayStack"
+        }
+      ]
+    }
+  ]
 }

--- a/web/src/data/hub/appleford/questDefs.json
+++ b/web/src/data/hub/appleford/questDefs.json
@@ -8,7 +8,7 @@
       "receiverNpcId": "orchard-keeper-bess",
       "offerDialogue": "The raiders dropped half of what they stole running from the village dogs. Three baskets of good apples, scattered through the orchard rows. Bring them in before the wasps claim them, would you? My knees have retired from bending.",
       "activeDialogue": "Three apple baskets, somewhere among the orchard rows. Follow the wasps if you're stuck.",
-      "completeDialogue": "Barely a bruise on them! The pressing's saved. You've a friend in Appleford, traveller — and a discount Tom doesn't know he's offering.",
+      "completeDialogue": "Barely a bruise on them! The pressing's saved. You've a friend in Appleford, traveller \u2014 and a discount Tom doesn't know he's offering.",
       "steps": [
         {
           "key": "apples",
@@ -23,11 +23,373 @@
       ],
       "reward": {
         "crystals": 45,
+        "friendship": {
+          "orchard-keeper-bess": 12
+        },
         "collectible": {
           "id": "appleford-apple",
           "name": "Perfect Apple",
-          "icon": "🍎",
+          "icon": "\ud83c\udf4e",
           "desc": "A flawless apple from the oldest tree in Appleford. Bess named the tree Gerald."
+        }
+      }
+    },
+    {
+      "id": "appleford-cider-pressing",
+      "title": "Pressing Matters",
+      "type": "fetch",
+      "giverNpcId": "cider-brewer-tom",
+      "receiverNpcId": "cider-brewer-tom",
+      "offerDialogue": "Press is hungry and the harvest's late. Gather me three baskets of ripe apples from the rows \u2014 the red ones, mind, the green ones are for vinegar and spite. Then we'll make cider worth the name.",
+      "activeDialogue": "Three baskets of ripe apples from the orchard rows, for Tom's press.",
+      "completeDialogue": "Now THAT'S an apple. Listen to the press sing. First mug of the new batch is yours \u2014 don't tell Bess I said it was free.",
+      "steps": [
+        {
+          "key": "apples",
+          "type": "collect",
+          "pickupIds": [
+            "cider-apple-1",
+            "cider-apple-2",
+            "cider-apple-3"
+          ],
+          "required": 3
+        }
+      ],
+      "reward": {
+        "crystals": 50,
+        "friendship": {
+          "cider-brewer-tom": 12
+        }
+      }
+    },
+    {
+      "id": "appleford-cider-pressing-2",
+      "title": "Bottling Day",
+      "type": "chain",
+      "giverNpcId": "cider-brewer-tom",
+      "receiverNpcId": "cider-brewer-tom",
+      "prerequisite": "quest:appleford-cider-pressing",
+      "offerDialogue": "The press did its part; now we bottle. I need a stoppered jar from the press room shelf and two empty bottles the children left rolling about the lane. Round them up and we'll get this batch sealed before it turns.",
+      "activeDialogue": "A jar from the press room, plus two empty bottles around the lanes, then back to Tom.",
+      "completeDialogue": "Sealed, stacked, and sweet as a summer afternoon. You've a steady hand for this, traveller. Take a bottle of the good stuff.",
+      "steps": [
+        {
+          "key": "bottles",
+          "type": "collect",
+          "pickupIds": [
+            "press-jar-1",
+            "empty-bottle-2",
+            "empty-bottle-3"
+          ],
+          "required": 3
+        }
+      ],
+      "reward": {
+        "crystals": 75,
+        "friendship": {
+          "cider-brewer-tom": 18
+        },
+        "collectible": {
+          "id": "appleford-cider",
+          "name": "Appleford Cider",
+          "icon": "\ud83c\udf7a",
+          "desc": "A bottle of the new pressing. Crisp, golden, and gone too soon."
+        }
+      }
+    },
+    {
+      "id": "appleford-honey-harvest",
+      "title": "The Sweet Harvest",
+      "type": "fetch",
+      "giverNpcId": "beekeeper-mabe",
+      "receiverNpcId": "beekeeper-mabe",
+      "offerDialogue": "The blossom's been good to us, and the hives are heavy. Help me gather three combs from the skeps along the rows \u2014 gently, mind, the bees are particular about strangers. Move slow and they'll let you be.",
+      "activeDialogue": "Three honeycombs from the hives along the orchard rows, for Mabe.",
+      "completeDialogue": "Golden, every one, and not a sting on you \u2014 the bees like you, which is more than they can say for most. Here, a little something for your trouble.",
+      "steps": [
+        {
+          "key": "combs",
+          "type": "collect",
+          "pickupIds": [
+            "honeycomb-1",
+            "honeycomb-2",
+            "honeycomb-3"
+          ],
+          "required": 3
+        }
+      ],
+      "reward": {
+        "crystals": 50,
+        "friendship": {
+          "beekeeper-mabe": 12
+        }
+      }
+    },
+    {
+      "id": "appleford-honey-harvest-2",
+      "title": "Wax and Mead",
+      "type": "chain",
+      "giverNpcId": "beekeeper-mabe",
+      "receiverNpcId": "beekeeper-mabe",
+      "prerequisite": "quest:appleford-honey-harvest",
+      "offerDialogue": "Now for the wax \u2014 it makes candles for the chapel and seals for Tom's bottles. There's a block on my cottage shelf and two more dropped about the rows. Bring them and I'll set a pot of mead bubbling for the festival.",
+      "activeDialogue": "A wax block from Mabe's cottage and two more from the rows, then return to Mabe.",
+      "completeDialogue": "Enough wax for a winter of candles and a barrel of mead besides. You've earned a jar of the first honey, traveller \u2014 straight from Appleford's busiest workers.",
+      "steps": [
+        {
+          "key": "wax",
+          "type": "collect",
+          "pickupIds": [
+            "wax-1",
+            "beeswax-2",
+            "beeswax-3"
+          ],
+          "required": 3
+        }
+      ],
+      "reward": {
+        "crystals": 75,
+        "friendship": {
+          "beekeeper-mabe": 18
+        },
+        "collectible": {
+          "id": "appleford-honey",
+          "name": "Orchard Honey",
+          "icon": "\ud83c\udf6f",
+          "desc": "A jar of Appleford's first honey of the season. Tastes of apple blossom and warm afternoons."
+        }
+      }
+    },
+    {
+      "id": "appleford-coopers-order",
+      "title": "Staves and Hoops",
+      "type": "fetch",
+      "giverNpcId": "cooper-wend",
+      "receiverNpcId": "cooper-wend",
+      "offerDialogue": "Can't make barrels without wood, and the woodpile's scattered halfway to the hedge. Three good bundles of staves, gather them up for me. Tom's already nagging for his casks, and a nagging Tom is a long day.",
+      "activeDialogue": "Three bundles of barrel staves, scattered around the village edges, for Cooper Wend.",
+      "completeDialogue": "Grand, grand. Straight-grained and dry \u2014 that's a cask waiting to happen. You've saved me a bending back and Tom a sulk. Both worth paying for.",
+      "steps": [
+        {
+          "key": "staves",
+          "type": "collect",
+          "pickupIds": [
+            "stave-1",
+            "stave-2",
+            "stave-3"
+          ],
+          "required": 3
+        }
+      ],
+      "reward": {
+        "crystals": 55,
+        "friendship": {
+          "cooper-wend": 14
+        }
+      }
+    },
+    {
+      "id": "appleford-orchard-pickers",
+      "title": "A Picker's Lot",
+      "type": "fetch",
+      "giverNpcId": "orchard-hand-hob",
+      "receiverNpcId": "orchard-hand-hob",
+      "offerDialogue": "My basket-arm's gone dead and there's apples going soft on the high branches. Bring me three baskets from the rows and I'll show you the trick of stacking a crate so it doesn't tip on the cart. Riveting stuff, I know.",
+      "activeDialogue": "Gather three apple baskets from the rows and bring them to Hob.",
+      "completeDialogue": "Look at that \u2014 a proper haul. You've a picker's eye, you have. Stick around; there's always more apples than arms in Appleford.",
+      "steps": [
+        {
+          "key": "apples",
+          "type": "collect",
+          "pickupIds": [
+            "pick-apple-1",
+            "pick-apple-2",
+            "pick-apple-3"
+          ],
+          "required": 3
+        },
+        {
+          "key": "deliver",
+          "type": "deliver",
+          "targetNpcId": "orchard-hand-hob",
+          "required": 1
+        }
+      ],
+      "reward": {
+        "crystals": 50,
+        "friendship": {
+          "orchard-hand-hob": 12
+        }
+      }
+    },
+    {
+      "id": "appleford-orchard-pickers-2",
+      "title": "To Market",
+      "type": "chain",
+      "giverNpcId": "orchard-hand-hob",
+      "receiverNpcId": "market-trader-posy",
+      "prerequisite": "quest:appleford-orchard-pickers",
+      "offerDialogue": "Crate's packed and Posy's waiting at the market hall, tapping her foot no doubt. Haul this lot over to her, would you? My back's filed a formal complaint. Just grab the crate from the lane and carry it to Trader Posy.",
+      "activeDialogue": "Carry the packed apple crate to Trader Posy at the market hall.",
+      "completeDialogue": "Right on time and not a bruise on them \u2014 Hob's trained you well. The cart leaves for Ravenwatch at dawn. My thanks, traveller.",
+      "steps": [
+        {
+          "key": "crate",
+          "type": "collect",
+          "pickupIds": [
+            "picker-crate-1"
+          ],
+          "required": 1
+        },
+        {
+          "key": "deliver",
+          "type": "deliver",
+          "targetNpcId": "market-trader-posy",
+          "required": 1
+        }
+      ],
+      "reward": {
+        "crystals": 70,
+        "friendship": {
+          "market-trader-posy": 12,
+          "orchard-hand-hob": 8
+        }
+      }
+    },
+    {
+      "id": "appleford-cider-to-ravenwatch",
+      "title": "The Ravenwatch Run",
+      "type": "chain",
+      "giverNpcId": "market-trader-posy",
+      "receiverNpcId": "innkeeper-rosie",
+      "prerequisite": "quest:appleford-cider-pressing-2",
+      "offerDialogue": "Now you've bottled with Tom, you'll know good cider when you carry it. Innkeeper Rosie at Ravenwatch pays double for our pressing \u2014 when it arrives unbroken. Take this crate to her at the inn, and mind the toll road. Tell her Appleford sends its best.",
+      "activeDialogue": "Carry the crate of Appleford cider to Innkeeper Rosie at the Ravenwatch inn.",
+      "completeDialogue": "Appleford cider, all the way from the orchards! Rosie will be glad \u2014 half her regulars ask for it by name. Here's your cut, and tell Posy the inn says thank you.",
+      "steps": [
+        {
+          "key": "crate",
+          "type": "collect",
+          "pickupIds": [
+            "cider-crate-1"
+          ],
+          "required": 1
+        },
+        {
+          "key": "deliver",
+          "type": "deliver",
+          "targetNpcId": "innkeeper-rosie",
+          "required": 1
+        }
+      ],
+      "reward": {
+        "crystals": 100,
+        "friendship": {
+          "market-trader-posy": 18
+        },
+        "collectible": {
+          "id": "appleford-trade-seal",
+          "name": "Trade Seal",
+          "icon": "\ud83d\udcdc",
+          "desc": "Proof of an honest cider run from Appleford to Ravenwatch. Posy will remember this."
+        }
+      }
+    },
+    {
+      "id": "appleford-harvest-blessing",
+      "title": "The Harvest Blessing",
+      "type": "fetch",
+      "giverNpcId": "chaplain-hale",
+      "receiverNpcId": "chaplain-hale",
+      "festivalId": "harvest",
+      "offerDialogue": "It's the season of thanks, and the chapel must be ready for the blessing of the first pressing. Fetch me a candle from the chapel store and two harvest blooms from the rows. A small thing \u2014 but the whole village comes, bees and all.",
+      "activeDialogue": "A candle from the chapel and two harvest blooms from the orchard, for Brother Hale's blessing.",
+      "completeDialogue": "The altar's dressed and the candle's lit. Let the bees have their thimble of mead and the village its blessing. Appleford thanks you, traveller \u2014 and so do I.",
+      "steps": [
+        {
+          "key": "blessing",
+          "type": "collect",
+          "pickupIds": [
+            "chapel-candle-1",
+            "harvest-bloom-2",
+            "harvest-bloom-3"
+          ],
+          "required": 3
+        }
+      ],
+      "reward": {
+        "crystals": 65,
+        "friendship": {
+          "chaplain-hale": 15
+        },
+        "collectible": {
+          "id": "appleford-blessing",
+          "name": "Harvest Blessing",
+          "icon": "\ud83d\udd6f\ufe0f",
+          "desc": "Brother Hale's blessing of the first pressing. The orchard will be generous next year \u2014 he's quite sure of it."
+        }
+      }
+    },
+    {
+      "id": "appleford-scrumping",
+      "title": "The Scrumper's Secret",
+      "type": "lost-items",
+      "giverNpcId": "scrumping-wren",
+      "receiverNpcId": "scrumping-wren",
+      "offerDialogue": "I dropped my things running from Keeper Bess \u2014 my lucky basket, the empty one I fill with apples, and... and a shiny thing I DEFINITELY didn't take from the market. Find them before she does? I'll be your best friend forever. Probably.",
+      "activeDialogue": "Recover Wren's three dropped things from around the orchard \u2014 quietly.",
+      "completeDialogue": "You found them ALL! And you didn't tell Bess! You're the best grown-up ever. Here, have my second-favourite apple. It's only got one bruise.",
+      "steps": [
+        {
+          "key": "things",
+          "type": "collect",
+          "pickupIds": [
+            "wren-1",
+            "wren-2",
+            "wren-3"
+          ],
+          "required": 3
+        }
+      ],
+      "reward": {
+        "crystals": 40,
+        "friendship": {
+          "scrumping-wren": 15
+        }
+      }
+    },
+    {
+      "id": "appleford-lost-in-orchard",
+      "title": "Lost Among the Rows",
+      "type": "lost-items",
+      "giverNpcId": "orchard-keeper-bess",
+      "receiverNpcId": "orchard-keeper-bess",
+      "prerequisite": "quest:appleford-scattered-harvest",
+      "offerDialogue": "Folk are forever losing things among my trees \u2014 a book here, a pot of flowers there, somebody's grandmother's pendant. The orchard keeps what it catches. Bring me what you find and I'll see it home to its owner.",
+      "activeDialogue": "Recover three lost belongings from among the orchard rows for Keeper Bess.",
+      "completeDialogue": "A book, a pot, and that pendant old Maery's been weeping over for a week. You've a sharp eye for what the rows hide, traveller. Bless you for it.",
+      "steps": [
+        {
+          "key": "lost",
+          "type": "collect",
+          "pickupIds": [
+            "orchard-lost-1",
+            "orchard-lost-2",
+            "orchard-lost-3"
+          ],
+          "required": 3
+        }
+      ],
+      "reward": {
+        "crystals": 60,
+        "friendship": {
+          "orchard-keeper-bess": 16
+        },
+        "collectible": {
+          "id": "appleford-keepsake",
+          "name": "Orchard Keepsake",
+          "icon": "\ud83c\udf97\ufe0f",
+          "desc": "A token of thanks from the folk of Appleford whose treasures you returned."
         }
       }
     }
@@ -35,24 +397,230 @@
   "pickupItems": [
     {
       "id": "apple-basket-1",
-      "tx": 6,
-      "ty": 15,
+      "tx": 5,
+      "ty": 23,
       "tileId": "appleBasket",
       "questId": "appleford-scattered-harvest"
     },
     {
       "id": "apple-basket-2",
-      "tx": 14,
-      "ty": 14,
+      "tx": 11,
+      "ty": 25,
       "tileId": "appleBasket",
       "questId": "appleford-scattered-harvest"
     },
     {
       "id": "apple-basket-3",
-      "tx": 21,
-      "ty": 16,
+      "tx": 29,
+      "ty": 25,
       "tileId": "appleBasket",
       "questId": "appleford-scattered-harvest"
+    },
+    {
+      "id": "cider-apple-1",
+      "tx": 8,
+      "ty": 23,
+      "tileId": "appleBasket",
+      "questId": "appleford-cider-pressing"
+    },
+    {
+      "id": "cider-apple-2",
+      "tx": 14,
+      "ty": 23,
+      "tileId": "appleBasket",
+      "questId": "appleford-cider-pressing"
+    },
+    {
+      "id": "cider-apple-3",
+      "tx": 20,
+      "ty": 23,
+      "tileId": "appleBasket",
+      "questId": "appleford-cider-pressing"
+    },
+    {
+      "id": "honeycomb-1",
+      "tx": 12,
+      "ty": 23,
+      "tileId": "bunchOfHerbs",
+      "questId": "appleford-honey-harvest"
+    },
+    {
+      "id": "honeycomb-2",
+      "tx": 8,
+      "ty": 25,
+      "tileId": "leafBasket",
+      "questId": "appleford-honey-harvest"
+    },
+    {
+      "id": "honeycomb-3",
+      "tx": 11,
+      "ty": 23,
+      "tileId": "bunchOfHerbs",
+      "questId": "appleford-honey-harvest"
+    },
+    {
+      "id": "stave-1",
+      "tx": 37,
+      "ty": 23,
+      "tileId": "logPile",
+      "questId": "appleford-coopers-order"
+    },
+    {
+      "id": "stave-2",
+      "tx": 32,
+      "ty": 25,
+      "tileId": "logPile",
+      "questId": "appleford-coopers-order"
+    },
+    {
+      "id": "stave-3",
+      "tx": 37,
+      "ty": 25,
+      "tileId": "logPile",
+      "questId": "appleford-coopers-order"
+    },
+    {
+      "id": "pick-apple-1",
+      "tx": 23,
+      "ty": 25,
+      "tileId": "appleBasket",
+      "questId": "appleford-orchard-pickers"
+    },
+    {
+      "id": "pick-apple-2",
+      "tx": 26,
+      "ty": 23,
+      "tileId": "appleBasket",
+      "questId": "appleford-orchard-pickers"
+    },
+    {
+      "id": "pick-apple-3",
+      "tx": 17,
+      "ty": 25,
+      "tileId": "appleBasket",
+      "questId": "appleford-orchard-pickers"
+    },
+    {
+      "id": "wren-1",
+      "tx": 2,
+      "ty": 23,
+      "tileId": "leafBasket",
+      "questId": "appleford-scrumping"
+    },
+    {
+      "id": "wren-2",
+      "tx": 5,
+      "ty": 12,
+      "tileId": "emptyBasket",
+      "questId": "appleford-scrumping"
+    },
+    {
+      "id": "wren-3",
+      "tx": 26,
+      "ty": 25,
+      "tileId": "pendant",
+      "questId": "appleford-scrumping"
+    },
+    {
+      "id": "orchard-lost-1",
+      "tx": 14,
+      "ty": 12,
+      "tileId": "closedBook",
+      "questId": "appleford-lost-in-orchard"
+    },
+    {
+      "id": "orchard-lost-2",
+      "tx": 26,
+      "ty": 12,
+      "tileId": "potOfFlowers",
+      "questId": "appleford-lost-in-orchard"
+    },
+    {
+      "id": "orchard-lost-3",
+      "tx": 38,
+      "ty": 25,
+      "tileId": "pendant",
+      "questId": "appleford-lost-in-orchard"
+    },
+    {
+      "id": "empty-bottle-2",
+      "tx": 3,
+      "ty": 23,
+      "tileId": "bottle",
+      "questId": "appleford-cider-pressing-2"
+    },
+    {
+      "id": "empty-bottle-3",
+      "tx": 6,
+      "ty": 23,
+      "tileId": "bottle",
+      "questId": "appleford-cider-pressing-2"
+    },
+    {
+      "id": "beeswax-2",
+      "tx": 9,
+      "ty": 25,
+      "tileId": "bottle",
+      "questId": "appleford-honey-harvest-2"
+    },
+    {
+      "id": "beeswax-3",
+      "tx": 14,
+      "ty": 25,
+      "tileId": "bottle",
+      "questId": "appleford-honey-harvest-2"
+    },
+    {
+      "id": "picker-crate-1",
+      "tx": 17,
+      "ty": 23,
+      "tileId": "openCrate",
+      "questId": "appleford-orchard-pickers-2"
+    },
+    {
+      "id": "cider-crate-1",
+      "tx": 20,
+      "ty": 22,
+      "tileId": "crate",
+      "questId": "appleford-cider-to-ravenwatch"
+    },
+    {
+      "id": "harvest-bloom-2",
+      "tx": 23,
+      "ty": 23,
+      "tileId": "pinkFlower",
+      "questId": "appleford-harvest-blessing"
+    },
+    {
+      "id": "harvest-bloom-3",
+      "tx": 38,
+      "ty": 22,
+      "tileId": "whiteFlower",
+      "questId": "appleford-harvest-blessing"
+    },
+    {
+      "id": "press-jar-1",
+      "tx": 9,
+      "ty": 5,
+      "tileId": "bottle",
+      "building": "cider-house-press",
+      "questId": "appleford-cider-pressing-2"
+    },
+    {
+      "id": "wax-1",
+      "tx": 5,
+      "ty": 3,
+      "tileId": "bottle",
+      "building": "apiary",
+      "questId": "appleford-honey-harvest-2"
+    },
+    {
+      "id": "chapel-candle-1",
+      "tx": 9,
+      "ty": 5,
+      "tileId": "candlestickUnlit",
+      "building": "chapel",
+      "questId": "appleford-harvest-blessing"
     }
   ],
   "blockedPaths": []


### PR DESCRIPTION
## Summary

Brings **Appleford** up to Tier C parity per the hub-locations epic (#1732). Closes #1746.

- Map resized **28×20 → 40×28** tiles, with three areas (**Village Lane**, **The Orchards**, **Market Yard**), a village pond and a fenced hen pen (`chickenZones`)
- **6 new buildings** (`chapel`, `coopers-shed`, `bottling-barn`, `apiary`, `orchard-cottage`, `market-barn`) on top of the existing 2 — **8 total**. All ≥6×6. `cider-house` is now **multi-room** (taproom → press room → cellar, via a back exit and a ladder-down) and `keepers-cottage` gains a **pantry**. **11 interiors**, all furnished and in-bounds
- **6 new NPCs (8 total)** with warm orchard dialogue; `orchard-keeper-bess` and `orchard-hand-hob` have **day/night schedules** + `homeBed`s. Plus 3 placed animals (orchard cat, sheepdog, robin)
- **~93 exterior-decor entries** (orchard tree rows, building frontages, market stalls, scarecrows, pond edge, flowers/crops) — bundles expand to many more rendered tiles — plus a **harvest-festival** `festivalDecor` group
- **11 new quests (12 total)**, **32 pickups**: cider-pressing & honey chains, a cooper's order, an orchard-pickers → market chain, a scrumping child's lost-items quest, a `harvest`-festival blessing quest, and a **cross-town hook** — *The Ravenwatch Run* delivers a crate of cider to `innkeeper-rosie` at the Ravenwatch inn (#1735)
- **Fixes #1734:** `cider-brewer-tom` and `orchard-keeper-bess` were placed at out-of-bounds interior coordinates. Tom now sits inside a resized `cider-house`; Bess works the orchard by day and sleeps in her cottage at night

All changes are **data-only** (`config.json` / `questDefs.json`); the town was already wired into `hubWorldFactory.ts`, and no Ravenwatch files are touched (the cross-town delivery resolves via the deliver step's `targetNpcId`).

## Test plan

- [x] A custom geometry validator (run during authoring) confirms: all 8 building doors resolve onto street tiles and are reachable from `avatarStart` via the street network; the spawn/exit tiles connect; no building/decor/NPC/pickup coordinate collisions; ≥1-tile gaps between buildings; every interior's decor/NPC/exit/pickup is in-bounds with reciprocal linked-room exits and ladders on vertical links; every quest pickup id is referenced and every giver/receiver/deliver-target is a known NPC
- [x] `npm run test` — **238/238 passing** (the single reported `Unhandled Error` is the pre-existing missing-Playwright-Chromium issue for the Storybook browser-mode runner in this sandbox — unrelated to this change, same as noted in #1775)
- [x] `npm run build` — `tsc && vite build` succeeds
- [ ] Manual in-browser spot-check (walk to every door, tavern stairs/cellar ladder, complete the quest chains, confirm the Ravenwatch cider hand-in) — **not performed**: this is a headless remote sandbox with no GUI browser. Flagging rather than claiming a manual check that didn't happen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U9CbjmhzGwaBwCViUhoxcD

---
_Generated by [Claude Code](https://claude.ai/code/session_01U9CbjmhzGwaBwCViUhoxcD)_