### PR TITLE
fix(hub): respawn in last-visited town instead of always Ravenwatch

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -113,7 +113,7 @@ import { saveBattleState, loadBattleState, clearBattleState } from './game/battl
 import { loadCommander, promoteCommander, CommanderState } from './game/commander'
 
 import { WORLD_MAP_NODES, type WorldNodeDef } from './data/world/worldMapDef'
-import { setCurrentWorldLocation, markNodeCleared, isNodeCleared } from './game/world/worldState'
+import { setCurrentWorldLocation, getCurrentWorldLocation, markNodeCleared, isNodeCleared } from './game/world/worldState'
 import { CommanderScreen } from './components/screens/CommanderScreen'
 import { TrainingScreen }  from './components/screens/TrainingScreen'
 import {
@@ -366,7 +366,13 @@ export default function App() {
 
   const [screen, setScreen]             = useState<Screen>(_startup.screen)
   const [returnScreen, setReturnScreen]  = useState<Screen>('title')
-  const [currentLocationKey, setCurrentLocationKey] = useState<string>('ravenwatch')
+  // Restore the town the player was last in (persisted in worldState). The saved
+  // value is a world-map node id; for town nodes that id equals the LOCATION_REGISTRY
+  // key. Fall back to ravenwatch if the saved id isn't a known town (e.g. a battle node).
+  const [currentLocationKey, setCurrentLocationKey] = useState<string>(() => {
+    const saved = getCurrentWorldLocation()
+    return LOCATION_REGISTRY[saved] ? saved : 'ravenwatch'
+  })
   const [miniGamesEntry, setMiniGamesEntry] = useState<'menu' | 'citybuilder'>('menu')
   const [hubMiniGameEntry, setHubMiniGameEntry] = useState<SubScreen>('menu')
   const [showTitleLoginModal, setShowTitleLoginModal] = useState(false)


### PR DESCRIPTION
## Problem

In the hub world, after travelling to a new town and then leaving/relaunching the game, the player was always respawned in **Ravenwatch** — never the town they were actually in. Curiously, the world-map avatar marker *did* show the correct previous town, which made the inconsistency obvious.

## Root cause

The persisted world location (`currentLocationId` in `worldState` localStorage) was being remembered correctly — that's what drives the world-map avatar marker. But `currentLocationKey`, the React state in `App.tsx` that decides which town `HubWorld` renders, was hard-initialised to `'ravenwatch'` on every launch and never restored from persistence:

```ts
const [currentLocationKey, setCurrentLocationKey] = useState<string>('ravenwatch')
```

On relaunch the startup logic routes straight into the `hubworld` screen, so the player always landed in Ravenwatch regardless of the saved location.

## Fix

Seed `currentLocationKey` from the persisted world location. For town nodes the saved world-map node id equals the `LOCATION_REGISTRY` key, so it maps directly; if the saved id isn't a known town (e.g. a battle node), it falls back to `ravenwatch`.

```ts
const [currentLocationKey, setCurrentLocationKey] = useState<string>(() => {
  const saved = getCurrentWorldLocation()
  return LOCATION_REGISTRY[saved] ? saved : 'ravenwatch'
})
```

## Testing

- `npm run build` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018WUvEteydACBUaMPQHNfxZ

---
_Generated by [Claude Code](https://claude.ai/code/session_018WUvEteydACBUaMPQHNfxZ)_