### PR TITLE
Config-driven building upgrade decor + per-level building visuals in map editor

### DIFF
--- a/web/scripts/migrateUpgradeDecor.ts
+++ b/web/scripts/migrateUpgradeDecor.ts
@@ -1,0 +1,82 @@
+// ─── One-off migration: shared upgrade-track decor → per-building levelDecor ──
+//
+// Historically, exterior upgrade decor was placed programmatically by a shared,
+// per-kind track (buildingUpgrades.json → decor dx/dy offsets from the door).
+// That generic placement was unreliable, so we now author decor per building in
+// config.json (`levelDecor`, absolute tx/ty, minLevel).
+//
+// This script preserves each town's current look: for every upgradeable building
+// without existing levelDecor, it resolves the building's door tile (exactly as
+// the live loader does) and writes out the track decor at absolute positions.
+//
+// Run once from web/:  npx tsx scripts/migrateUpgradeDecor.ts
+// Afterwards, delete the `decor` field from buildingUpgrades.json.
+
+import { readFileSync, writeFileSync, readdirSync, existsSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import { createHubLocationData } from '../src/data/hub/loader'
+import { getUpgradeTrack } from '../src/data/hub/buildingUpgrades'
+import type { RawConfig } from '../src/data/hub/config'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const HUB_DIR = join(__dirname, '..', 'src', 'data', 'hub')
+
+interface LevelDecorItem { tx: number; ty: number; tileId: string; minLevel: number }
+
+let totalBuildings = 0
+let totalItems = 0
+
+for (const town of readdirSync(HUB_DIR, { withFileTypes: true })) {
+  if (!town.isDirectory()) continue
+  const configPath = join(HUB_DIR, town.name, 'config.json')
+  if (!existsSync(configPath)) continue
+
+  const raw = JSON.parse(readFileSync(configPath, 'utf8')) as RawConfig & {
+    buildings: Array<Record<string, unknown> & { id?: string; upgradeKind?: string; rect?: number[]; rects?: number[][]; levelDecor?: unknown[] }>
+  }
+
+  let bundle
+  try {
+    bundle = createHubLocationData(raw as RawConfig)
+  } catch (e) {
+    console.warn(`[skip] ${town.name}: failed to load (${String(e)})`)
+    continue
+  }
+
+  let townItems = 0
+  for (const b of raw.buildings ?? []) {
+    if (!b.id || !b.upgradeKind) continue
+    if (Array.isArray(b.levelDecor) && b.levelDecor.length) continue   // already authored
+
+    const track = getUpgradeTrack(b.upgradeKind)
+    if (!track.length || !track.some(l => (l.decor ?? []).length)) continue
+
+    // Resolve the door tile the same way the live renderer did.
+    const door = bundle.HUB_DOORS.find(d => d.buildingId === b.id)
+    const rect = (b.rects?.[0] ?? b.rect) as number[] | undefined
+    if (!door && !rect) continue
+    const anchor = door ?? { tx: Math.floor(((rect![0]) + (rect![2])) / 2), ty: rect![3] + 1 }
+
+    const levelDecor: LevelDecorItem[] = []
+    track.forEach((lvl, levelIndex) => {
+      for (const d of lvl.decor ?? [])
+        levelDecor.push({ tx: anchor.tx + d.dx, ty: anchor.ty + d.dy, tileId: d.tileId, minLevel: levelIndex + 1 })
+    })
+    if (!levelDecor.length) continue
+
+    b.levelDecor = levelDecor
+    townItems += levelDecor.length
+    totalBuildings++
+  }
+
+  if (townItems > 0) {
+    writeFileSync(configPath, JSON.stringify(raw, null, 2) + '\n', 'utf8')
+    totalItems += townItems
+    console.log(`[ok]   ${town.name}: +${townItems} levelDecor items`)
+  } else {
+    console.log(`[--]   ${town.name}: nothing to migrate`)
+  }
+}
+
+console.log(`\nDone. ${totalItems} items across ${totalBuildings} buildings.`)

--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -10,19 +10,18 @@ import { findPath, nearestWalkable } from '../../utils/hubPathfinder'
 import { isBuildingOpen, getNpcLocation, getNpcActivity } from '../../game/hub/hubNpcSchedule'
 import { getGameHour, getGameMinute } from '../../game/hub/hubClock'
 import { emitSound, startInteriorAudio, stopInteriorAudio, setNightAmbiance } from '../../game/sound'
-import { getWallTile, ROOF_TILES, WALL_TILES, ROOF_ROWS } from '../../data/tiles/buildingMaterials'
+import { WALL_TILES } from '../../data/tiles/buildingMaterials'
 import type { WallMaterial, RoofMaterial } from '../../data/tiles/buildingMaterials'
+import { placeBuildingTiles, resolveBuildingVisual } from '../../data/tiles/buildingRender'
 import { loadPlayerAvatar } from '../../game/questline'
 import { createChunkCuller } from '../../utils/chunkCull'
 import { CommanderState } from '../../game/commander'
 import rollbar from '../../rollbar'
-import { HubInteractable, HubInteriorExit, HubLocationBundle, HubNpc, HubQuestBundle, HubStreetGroup, NpcScheduleEntry } from '../../data/hub/loader'
+import { HubInteractable, HubInteriorExit, HubLocationBundle, HubNpc, HubQuestBundle, HubStreetGroup, NpcScheduleEntry, isVisibleAtLevel } from '../../data/hub/loader'
 import { createAnimalSystem, AnimalSystem, GlowSource } from './hubAnimals'
 import { createWeatherSystem } from './hubWeather'
 import { resolveWeather } from '../../game/hub/weather'
 import { getActiveFestival } from '../../game/hub/hubCalendar'
-import { BASE_CHIP_TILES } from '../../data/tiles/baseChipIndex'
-import { getUpgradeTrack } from '../../data/hub/buildingUpgrades'
 
 
 const T                 = 32
@@ -293,26 +292,46 @@ export function HubTownCanvas({
     }
 
     // Building tile set — derived from HUB_BUILDINGS, used for tap routing
+    // Tap-routing footprint — union of every level's footprint so a building stays
+    // tappable/enterable at any upgrade level (grown footprints are over-included).
+    const buildingFootprints = (b: typeof HUB_BUILDINGS[number]): [number, number, number, number][] =>
+      [b.rect, ...((b.levelVisuals ?? []).map(v => v.rect).filter(Boolean) as [number, number, number, number][])]
     const buildingSet = new Set<string>()
     for (const b of HUB_BUILDINGS)
-      for (let tx = b.rect[0]; tx <= b.rect[2]; tx++)
-        for (let ty = b.rect[1]; ty <= b.rect[3]; ty++)
-          buildingSet.add(`${tx},${ty}`)
+      for (const [x1, y1, x2, y2] of buildingFootprints(b))
+        for (let tx = x1; tx <= x2; tx++)
+          for (let ty = y1; ty <= y2; ty++)
+            buildingSet.add(`${tx},${ty}`)
 
     // ── Buildings ──────────────────────────────────────────────────────────────
+    // Each building is drawn as one or more *visual variants* (a base variant plus
+    // one per level threshold from `levelVisuals`). Variants live in their own
+    // containers and the active one is toggled each frame against the building's
+    // current upgrade level (see the variant toggle in the ticker below).
+    const buildingVariants: { buildingId: string; minLevel: number; nextLevel: number; container: PIXI.Container }[] = []
     {
-
-      // Collect placements: tileId → [(tx, ty), …]
-      // Insertion order determines render order — wall tiles first, door tiles
-      // last so they overdraw the wall tiles at shared positions.
-      const placements = new Map<number, [number, number][]>()
-      const place = (tileId: number, tx: number, ty: number) => {
-        const list = placements.get(tileId) ?? []
-        list.push([tx, ty])
-        placements.set(tileId, list)
-      }
-
       const fallbackPromises: Promise<void>[] = []
+
+      const renderVariant = (
+        rect: [number, number, number, number],
+        wall: WallMaterial,
+        roof: RoofMaterial,
+        doors: { tx: number; ty: number; tyAdjust?: number }[],
+        container: PIXI.Container,
+      ) => {
+        const placements = placeBuildingTiles(rect, wall, roof, doors)
+        for (const [tileId, positions] of placements) {
+          loadTileRef(tileId).then(tex => {
+            if (app.renderer == null) return
+            for (const [tx, ty] of positions) {
+              const s = new PIXI.Sprite(tex)
+              s.position.set(tx * T, ty * T)
+              s.width = T; s.height = T
+              container.addChild(s)
+            }
+          }).catch(() => {})
+        }
+      }
 
       for (const building of HUB_BUILDINGS) {
         const [x1, y1, x2, y2] = building.rect
@@ -326,61 +345,32 @@ export function HubTownCanvas({
           continue
         }
 
-        const wall = building.wall as WallMaterial
-        const roof = building.roof as RoofMaterial
-        const roofTileIds = ROOF_TILES[roof]
-        const width = x2 - x1 + 1
+        // Pass every door; placeBuildingTiles matches them to a footprint by
+        // position (south edge), mirroring the original renderer — door buildingId
+        // does not always equal the building's id, so we must not filter by id.
+        const doors = HUB_DOORS.map(d => ({ tx: d.tx, ty: d.ty, tyAdjust: d.tyAdjust }))
 
-        // Roof pass — top 4 rows
-        for (let row = 1; row < ROOF_ROWS; row++)
-          for (let tx = x1; tx <= x2; tx++)
-            place(roofTileIds[row], tx, y1 + row)
+        // Distinct visual thresholds: base (0) plus each levelVisuals minLevel.
+        const thresholds = [0, ...((building.levelVisuals ?? []).map(v => v.minLevel))]
+          .filter((v, i, a) => a.indexOf(v) === i)
+          .sort((a, b) => a - b)
 
-        // Wall pass — remaining rows (top tiles repeat for middle rows)
-        const firstWallRow = y1 + ROOF_ROWS
-        for (let ty = firstWallRow; ty <= y2; ty++) {
-          for (let tx = x1; tx <= x2; tx++) {
-            const isPillarCol      = tx === x1 + 1 || tx === x2 - 1
-            const isShadowCol      = width >= 5 && tx === x1 + 2
-            const isShadowRightCol = width >= 5 && tx === x2 
-            const isBottomRow =  ty === y2
-            const drawRow = true
-            if (drawRow){
-              const tileId = getWallTile(
-                wall, isBottomRow,
-                tx === x1,
-                isPillarCol,
-                isShadowCol,
-                tx === x2,
-                isShadowRightCol,
-              )
-              place(tileId, tx, ty)
-            }
-          }
-        }
-
-        // Door pass — south-facing doors, inserted after wall tiles so they overdraw
-        const wallTiles = WALL_TILES[wall]
-        for (const door of HUB_DOORS) {
-          if (door.ty !== y2 + 1 || door.tx < x1 || door.tx > x2) continue
-          const adj = door.tyAdjust ?? 0
-          place(wallTiles.doorArchTop, door.tx, y2 - 1 - adj)
-          place(wallTiles.doorTop,     door.tx, y2 - 1 - adj)
-          place(wallTiles.doorBottom,  door.tx, y2 - 0 - adj)
-        }
-      }
-
-      // Render: load each unique tileId once, reuse texture for all positions
-      for (const [tileId, positions] of placements) {
-        loadTileRef(tileId).then(tex => {
-          if (app.renderer == null) return
-          for (const [tx, ty] of positions) {
-            const s = new PIXI.Sprite(tex)
-            s.position.set(tx * T, ty * T)
-            s.width = T; s.height = T
-            buildingLayer.addChild(s)
-          }
-        }).catch(() => {})
+        thresholds.forEach((minLevel, ti) => {
+          const nextLevel = ti + 1 < thresholds.length ? thresholds[ti + 1] : Infinity
+          const vis = resolveBuildingVisual(
+            { rect: building.rect, wall: building.wall, roof: building.roof },
+            building.levelVisuals, minLevel,
+          )
+          if (!vis.wall || !vis.roof) return
+          const container = new PIXI.Container()
+          // Single-variant buildings are always shown; multi-variant ones start
+          // hidden and are toggled to the matching level in the ticker.
+          container.visible = thresholds.length === 1
+          buildingLayer.addChild(container)
+          renderVariant(vis.rect, vis.wall, vis.roof, doors, container)
+          if (thresholds.length > 1 && building.id)
+            buildingVariants.push({ buildingId: building.id, minLevel, nextLevel, container })
+        })
       }
 
       Promise.all(fallbackPromises).catch(e => rollbar.error('[HubTownCanvas] building tiles failed', { error: String(e) }))
@@ -757,7 +747,7 @@ export function HubTownCanvas({
         if (!b.id || !b.levelDecor?.length) continue
         const buildingLevel = upgradeLevels[b.id] ?? 0
         for (const d of b.levelDecor) {
-          if (d.zlayer === 'solid' && buildingLevel >= (d.minLevel ?? 0))
+          if (d.zlayer === 'solid' && isVisibleAtLevel(d, buildingLevel))
             s.delete(`${d.tx},${d.ty}`)
         }
       }
@@ -768,63 +758,28 @@ export function HubTownCanvas({
       return s
     }
 
-    // ── Building upgrade decor (revealed as the player upgrades buildings) ─────
-    // Each upgrade level may add decor at offsets relative to the building's
-    // primary door tile. Sprites are created once and toggled each frame against
-    // buildingUpgradeLevelsRef (mirrors the blocked-path visibility pattern).
-    const upgradeDecorSprites: { buildingId: string; levelIndex: number; sprite: PIXI.Sprite }[] = []
+    // ── Building upgrade decor (revealed/retired as the player upgrades buildings) ─
+    // Per-building level decor is authored in the map editor at absolute tile
+    // positions. Each item carries a minLevel (and optional hideAtLevel) so it can
+    // appear — and later be replaced — as the building is upgraded. Sprites are
+    // created once and toggled each frame against buildingUpgradeLevelsRef.
+    const upgradeDecorSprites: { buildingId: string; minLevel?: number; hideAtLevel?: number; sprite: PIXI.Sprite }[] = []
     {
       for (const b of HUB_BUILDINGS) {
-        if (!b.id) continue
+        if (!b.id || !b.levelDecor?.length) continue
         const buildingLevel = buildingUpgradeLevelsRef?.current[b.id] ?? 0
-
-        // Per-building level decor (absolute tile positions, authored in the map
-        // editor). When present it replaces the shared kind-track visuals for
-        // this building. Each item carries minLevel and reveals cumulatively.
-        if (b.levelDecor?.length) {
-          for (const d of b.levelDecor) {
-            const min = d.minLevel ?? 0
-            const layer = d.zlayer === 'above' ? aboveAvatarLayer : belowAvatarLayer
-            loadTileRef(d.tileId).then(tex => {
-              if (app.renderer == null) return
-              const s = new PIXI.Sprite(tex)
-              s.position.set(d.tx * T, d.ty * T)
-              s.width = T; s.height = T
-              s.visible = buildingLevel >= min
-              layer.addChild(s)
-              upgradeDecorSprites.push({ buildingId: b.id as string, levelIndex: min - 1, sprite: s })
-            }).catch(() => {})
-          }
-          continue
+        for (const d of b.levelDecor) {
+          const layer = d.zlayer === 'above' ? aboveAvatarLayer : belowAvatarLayer
+          loadTileRef(d.tileId).then(tex => {
+            if (app.renderer == null) return
+            const s = new PIXI.Sprite(tex)
+            s.position.set(d.tx * T, d.ty * T)
+            s.width = T; s.height = T
+            s.visible = isVisibleAtLevel(d, buildingLevel)
+            layer.addChild(s)
+            upgradeDecorSprites.push({ buildingId: b.id as string, minLevel: d.minLevel, hideAtLevel: d.hideAtLevel, sprite: s })
+          }).catch(() => {})
         }
-
-        if (!b.upgradeKind) continue
-        // Anchor decor at the building's primary door; fall back to the front
-        // centre of its footprint when the door comes from a bundle/elsewhere.
-        const foundDoor = HUB_DOORS.find(d => d.buildingId === b.id)
-        const door = foundDoor ?? {
-          tx: Math.floor((b.rect[0] + b.rect[2]) / 2),
-          ty: b.rect[3] + 1,
-        }
-        const track = getUpgradeTrack(b.upgradeKind)
-        track.forEach((lvl, levelIndex) => {
-          for (const d of lvl.decor ?? []) {
-            const tileId = (BASE_CHIP_TILES as Record<string, number>)[d.tileId]
-            if (tileId == null) continue
-            const tx = door.tx + d.dx
-            const ty = door.ty + d.dy
-            const buildingId = b.id as string
-            loadTileRef(tileId).then(tex => {
-              if (app.renderer == null) return
-              const s = new PIXI.Sprite(tex)
-              s.position.set(tx * T, ty * T)
-              s.width = T; s.height = T
-              s.visible = buildingLevel >= levelIndex + 1
-              belowAvatarLayer.addChild(s)
-              upgradeDecorSprites.push({ buildingId, levelIndex, sprite: s })
-            }).catch(() => {})
-          }
-        })
       }
     }
 
@@ -971,6 +926,9 @@ export function HubTownCanvas({
     const questIndicatorBaseY = new Map<string, number>()
     // Named NPC containers: keyed by npcId for schedule-driven visibility
     const namedNpcContainers  = new Map<string, PIXI.Container>()
+    // Exterior NPCs gated by a building's upgrade level — force-hidden until the
+    // building reaches minLevel (and again past hideAtLevel). Toggled in the ticker.
+    const levelGatedNpcs: { buildingId: string; minLevel?: number; hideAtLevel?: number; container: PIXI.Container }[] = []
     // Walk state for named NPCs — tracks current tile and in-progress walk queue
     interface NamedNpcWalkState {
       currentTx: number
@@ -1026,6 +984,14 @@ export function HubTownCanvas({
       npcLayer.addChild(npcContainer)
       namedNpcContainers.set(npc.id, npcContainer)
       if (walkState.isInside) npcContainer.visible = false
+      // Gate exterior NPCs that only appear once an associated building is upgraded.
+      if (npc.levelBuildingId) {
+        const min = npc.minLevel ?? 1
+        const gateLevel = buildingUpgradeLevelsRef?.current[npc.levelBuildingId] ?? 0
+        if (!isVisibleAtLevel({ minLevel: min, hideAtLevel: npc.hideAtLevel }, gateLevel))
+          npcContainer.visible = false
+        levelGatedNpcs.push({ buildingId: npc.levelBuildingId, minLevel: min, hideAtLevel: npc.hideAtLevel, container: npcContainer })
+      }
       if (npc.dialogue.length > 0) npcBubbleTargets.push({ npc, cx, cy })
 
       if (npc.questGive || npc.questReceive) {
@@ -1494,7 +1460,7 @@ export function HubTownCanvas({
       // prefixes this interior's id.
       const levelKey = HUB_BUILDINGS.find(b => b.id && buildingId.startsWith(b.id) && b.upgradeKind)?.id ?? buildingId
       const currentLevel = buildingUpgradeLevelsRef?.current[levelKey] ?? 0
-      const visibleDecor   = interior.decor.filter(d => (d.minLevel ?? 0) <= currentLevel)
+      const visibleDecor   = interior.decor.filter(d => isVisibleAtLevel(d, currentLevel))
       const availableExits = (interior.exits ?? []).filter(e => (e.minLevel ?? 0) <= currentLevel)
 
       // Building hours check — block entry if closed
@@ -1772,7 +1738,7 @@ export function HubTownCanvas({
       }
 
       // Interior NPCs — rendered inside the room, tappable
-      const interiorNpcList: HubNpc[] = (INTERIOR_NPCS[buildingId] ?? []).filter(n => (n.minLevel ?? 0) <= currentLevel)
+      const interiorNpcList: HubNpc[] = (INTERIOR_NPCS[buildingId] ?? []).filter(n => isVisibleAtLevel(n, currentLevel))
       for (const npc of interiorNpcList) {
         loadTextureUrl(`${base}sprites/${resolveNpcSprite(npc.sprite)}.svg`).then(tex => {
           if (!interiorActive || currentInteriorId !== buildingId) return
@@ -2501,11 +2467,30 @@ export function HubTownCanvas({
           }
         }
 
-        // Building upgrade decor visibility (reveals on purchase)
+        // Building upgrade decor visibility (reveals/retires on purchase)
         if (upgradeDecorSprites.length > 0) {
           const levels = buildingUpgradeLevelsRef?.current ?? {}
           for (const u of upgradeDecorSprites) {
-            u.sprite.visible = (levels[u.buildingId] ?? 0) >= u.levelIndex + 1
+            u.sprite.visible = isVisibleAtLevel(u, levels[u.buildingId] ?? 0)
+          }
+        }
+
+        // Building visual variants — show the variant matching the current level
+        if (buildingVariants.length > 0) {
+          const levels = buildingUpgradeLevelsRef?.current ?? {}
+          for (const v of buildingVariants) {
+            const lvl = levels[v.buildingId] ?? 0
+            v.container.visible = lvl >= v.minLevel && lvl < v.nextLevel
+          }
+        }
+
+        // Level-gated exterior NPCs — hide until their building reaches the level
+        // (and again once hideAtLevel passes). When visible the normal schedule /
+        // walk logic governs the container, so only force-hide here.
+        if (levelGatedNpcs.length > 0) {
+          const levels = buildingUpgradeLevelsRef?.current ?? {}
+          for (const g of levelGatedNpcs) {
+            if (!isVisibleAtLevel(g, levels[g.buildingId] ?? 0)) g.container.visible = false
           }
         }
       }

--- a/web/src/components/mapEditor/EntityInspector.tsx
+++ b/web/src/components/mapEditor/EntityInspector.tsx
@@ -5,7 +5,8 @@ import { EntityRefPicker } from './EntityRefPicker'
 import { buildingRefOptions, allQuestOptions, type RefOption } from './entityRefs'
 import { BASE_CHIP_TILES } from '../../data/tiles/baseChipIndex'
 import { resolveTileRef, PATH_TILE } from '../../data/tiles/tileIndex'
-import type { WallMaterial } from '../../data/tiles/buildingMaterials'
+import type { WallMaterial, RoofMaterial } from '../../data/tiles/buildingMaterials'
+import { ROOF_TILES } from '../../data/tiles/buildingMaterials'
 import { RawQuestPickupItem } from '../../data/hub/hubWorldFactory'
 import { SpriteSearchPicker, AnimalTypePicker } from './SpritePicker'
 import { ANIMAL_SPECS } from '../../game/hub/animals'
@@ -47,6 +48,8 @@ const WALL_MATERIALS: WallMaterial[] = [
   'interiorWallWhite', 'prisonRailings', 'ironholdKeep',
 ]
 
+const ROOF_MATERIALS = Object.keys(ROOF_TILES) as RoofMaterial[]
+
 const SHEET_URL = '/world/SampleMap/[Base]BaseChip_pipo.png'
 const COLS = 8
 const T = 32
@@ -64,7 +67,9 @@ interface Props {
   activeLevel:      number
   onSetActiveLevel:      (level: number) => void
   onUpdateBuilding:      (index: number, patch: Partial<RawBuilding>) => void
+  onUpdateBuildingLevelVisual: (buildingIndex: number, minLevel: number, patch: Partial<{ rect: [number, number, number, number]; wall: WallMaterial; roof: RoofMaterial }>) => void
   onUpdateDecorMinLevel: (entity: SelectedEntity, minLevel: number | undefined) => void
+  onUpdateDecorHideAtLevel: (entity: SelectedEntity, hideAtLevel: number | undefined) => void
   onDelete:              (entity: SelectedEntity) => void
   onMoveEntity:          (entity: SelectedEntity, tx: number, ty: number) => void
   onZlayerChange:        (entity: SelectedEntity, z: Zlayer) => void
@@ -324,7 +329,7 @@ function GlowControls({ glow, glowRadius, pulse, onChange }: {
 }
 
 function DecorInspector({
-  item, entity, onMove, onZlayer, onGlow, onDelete, onMinLevel, maxLevel, onTileChange, onReorder,
+  item, entity, onMove, onZlayer, onGlow, onDelete, onMinLevel, onHideAtLevel, maxLevel, onTileChange, onReorder,
 }: {
   item: RawDecorItem
   entity: SelectedEntity
@@ -333,6 +338,7 @@ function DecorInspector({
   onGlow?: (patch: GlowPatch) => void
   onDelete: () => void
   onMinLevel?: (minLevel: number | undefined) => void
+  onHideAtLevel?: (hideAtLevel: number | undefined) => void
   maxLevel?: number
   onTileChange?: (tileId: string) => void
   onReorder?: (direction: 'forward' | 'back') => void
@@ -376,6 +382,19 @@ function DecorInspector({
               style={{ width: 56, padding: '3px 5px', background: '#111', border: '1px solid #444', color: '#eee', borderRadius: 3, fontSize: 12 }}
             />
             <span style={{ fontSize: 10, color: '#666' }}>0 = always visible</span>
+          </div>
+        </Field>
+      )}
+      {onHideAtLevel && (
+        <Field label="Hides at level">
+          <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+            <input
+              type="number" min={0} max={maxLevel ?? 9}
+              value={item.hideAtLevel ?? 0}
+              onChange={e => { const v = Number(e.target.value); onHideAtLevel(v > 0 ? v : undefined) }}
+              style={{ width: 56, padding: '3px 5px', background: '#111', border: '1px solid #444', color: '#eee', borderRadius: 3, fontSize: 12 }}
+            />
+            <span style={{ fontSize: 10, color: '#666' }}>0 = never hides (e.g. swap to an upgraded version)</span>
           </div>
         </Field>
       )}
@@ -440,10 +459,11 @@ function DecorInspector({
 }
 
 function NpcInspector({
-  npc, entity, onMove, onDelete, onDialogueChange, onUpdate, onPickLocation,
+  npc, entity, buildingIds, onMove, onDelete, onDialogueChange, onUpdate, onPickLocation,
 }: {
   npc: RawNpc
   entity: SelectedEntity & { type: 'npc' }
+  buildingIds: string[]
   onMove: (tx: number, ty: number) => void
   onDelete: () => void
   onDialogueChange: (d: string[]) => void
@@ -502,6 +522,32 @@ function NpcInspector({
           </div>
         )}
       </Field>
+      <Field label="Hide at level">
+        <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+          <input
+            type="number" min={0}
+            value={npc.hideAtLevel ?? 0}
+            onChange={e => { const v = Math.max(0, Number(e.target.value)); onUpdate({ hideAtLevel: v > 0 ? v : undefined }) }}
+            style={{ width: 56, padding: '3px 5px', background: '#111', border: '1px solid #444', color: '#eee', borderRadius: 3, fontSize: 12 }}
+          />
+          <span style={{ fontSize: 10, color: '#666' }}>0 = never hides</span>
+        </div>
+      </Field>
+      {!npc.building && (
+        <Field label="Gated by building">
+          <select
+            value={npc.levelBuildingId ?? ''}
+            onChange={e => onUpdate({ levelBuildingId: e.target.value || undefined })}
+            style={{ width: '100%', padding: '3px 5px', background: '#111', border: '1px solid #444', color: '#eee', borderRadius: 3, fontSize: 11, boxSizing: 'border-box' }}
+          >
+            <option value="">— none (always visible) —</option>
+            {buildingIds.map(id => <option key={id} value={id}>{id}</option>)}
+          </select>
+          <div style={{ color: '#666', fontSize: 10, marginTop: 2 }}>
+            This exterior NPC appears only once the chosen building reaches the level(s) set above.
+          </div>
+        </Field>
+      )}
       <button
         onClick={onDelete}
         style={{
@@ -777,7 +823,7 @@ function StreetInspector({
 }
 
 function BuildingInspector({
-  building, buildingIndex, activeLevel, onSetActiveLevel, onUpdateBuilding,
+  building, buildingIndex, activeLevel, onSetActiveLevel, onUpdateBuilding, onUpdateBuildingLevelVisual,
   onOpenInterior, interiorIds, existingInteriorIds, onAddInterior,
 }: {
   building: RawBuilding
@@ -785,6 +831,7 @@ function BuildingInspector({
   activeLevel: number
   onSetActiveLevel: (level: number) => void
   onUpdateBuilding: (index: number, patch: Partial<RawBuilding>) => void
+  onUpdateBuildingLevelVisual: (buildingIndex: number, minLevel: number, patch: Partial<{ rect: [number, number, number, number]; wall: WallMaterial; roof: RoofMaterial }>) => void
   onOpenInterior: (id: string) => void
   interiorIds: string[]
   existingInteriorIds: string[]
@@ -852,16 +899,6 @@ function BuildingInspector({
           ({tx1},{ty1}) → ({tx2},{ty2}) — {tx2 - tx1 + 1}×{ty2 - ty1 + 1} tiles
         </span>
       </Field>
-      {building.wall && (
-        <Field label="Wall">
-          <span style={{ fontFamily: 'monospace', fontSize: 11, color: '#aaa' }}>{building.wall}</span>
-        </Field>
-      )}
-      {building.roof && (
-        <Field label="Roof">
-          <span style={{ fontFamily: 'monospace', fontSize: 11, color: '#aaa' }}>{building.roof}</span>
-        </Field>
-      )}
 
       {/* ── Upgrade levels ─────────────────────────────────────────────── */}
       <div style={{ borderTop: '1px solid #333', marginTop: 4, paddingTop: 10 }}>
@@ -886,6 +923,66 @@ function BuildingInspector({
         <Field label="Editing Level">
           <LevelStepper level={activeLevel} max={buildingMaxLevel(building)} onChange={onSetActiveLevel} />
         </Field>
+
+        {/* Per-level look — base (level 0) edits the building; higher levels write
+            a levelVisuals override that kicks in once the building is upgraded. */}
+        {(() => {
+          const baseRect = (building.rect ?? building.rects?.[0] ?? [0, 0, 0, 0]) as [number, number, number, number]
+          const lv = (building.levelVisuals ?? []).find(v => v.minLevel === activeLevel)
+          const wallValue = activeLevel === 0 ? (building.wall ?? '') : (lv?.wall ?? '')
+          const roofValue = activeLevel === 0 ? (building.roof ?? '') : (lv?.roof ?? '')
+          const rectValue = (activeLevel === 0 ? baseRect : (lv?.rect ?? baseRect)) as [number, number, number, number]
+          const setWall = (w: string) => activeLevel === 0
+            ? onUpdateBuilding(buildingIndex, { wall: (w || undefined) as WallMaterial | undefined })
+            : onUpdateBuildingLevelVisual(buildingIndex, activeLevel, { wall: (w || undefined) as WallMaterial | undefined })
+          const setRoof = (r: string) => activeLevel === 0
+            ? onUpdateBuilding(buildingIndex, { roof: (r || undefined) as RoofMaterial | undefined })
+            : onUpdateBuildingLevelVisual(buildingIndex, activeLevel, { roof: (r || undefined) as RoofMaterial | undefined })
+          const setRectAt = (i: number, val: number) => {
+            const next = [...rectValue] as [number, number, number, number]
+            next[i] = val
+            onUpdateBuildingLevelVisual(buildingIndex, activeLevel, { rect: next })
+          }
+          const inherit = (label: string) => activeLevel === 0 ? label : `— inherit base —`
+          return (
+            <div style={{ background: '#16161e', border: '1px solid #2a2a3a', borderRadius: 4, padding: 8, marginBottom: 8 }}>
+              <div style={{ color: '#8af', fontSize: 10, marginBottom: 6 }}>
+                {activeLevel === 0 ? 'Base look' : `Look at level ${activeLevel}`}
+              </div>
+              <Field label="Wall">
+                <select value={wallValue} onChange={e => setWall(e.target.value)} style={inputStyle}>
+                  <option value="">{inherit('— none —')}</option>
+                  {WALL_MATERIALS.map(w => <option key={w} value={w}>{w}</option>)}
+                </select>
+              </Field>
+              <Field label="Roof">
+                <select value={roofValue} onChange={e => setRoof(e.target.value)} style={inputStyle}>
+                  <option value="">{inherit('— none —')}</option>
+                  {ROOF_MATERIALS.map(r => <option key={r} value={r}>{r}</option>)}
+                </select>
+              </Field>
+              {activeLevel > 0 && (
+                <Field label="Footprint">
+                  <div style={{ display: 'flex', gap: 4, alignItems: 'center', flexWrap: 'wrap' }}>
+                    {(['x1', 'y1', 'x2', 'y2'] as const).map((lbl, i) => (
+                      <span key={lbl} style={{ display: 'inline-flex', alignItems: 'center', gap: 2 }}>
+                        <label style={{ fontSize: 10, color: '#888' }}>{lbl}</label>
+                        <input type="number" value={rectValue[i]} onChange={e => setRectAt(i, Number(e.target.value))} style={numStyle} />
+                      </span>
+                    ))}
+                  </div>
+                  {lv?.rect && (
+                    <button
+                      onClick={() => onUpdateBuildingLevelVisual(buildingIndex, activeLevel, { rect: undefined })}
+                      style={{ marginTop: 4, padding: '2px 8px', background: '#2a2a3a', border: '1px solid #444', color: '#aaa', borderRadius: 3, fontSize: 10, cursor: 'pointer' }}
+                    >Reset to base footprint</button>
+                  )}
+                </Field>
+              )}
+            </div>
+          )
+        })()}
+
         <div style={{ color: '#777', fontSize: 10, marginBottom: 8 }}>
           {(building.levelDecor ?? []).filter(d => (d.minLevel ?? 0) === activeLevel).length} decor item(s) added at {activeLevel === 0 ? 'base' : `level ${activeLevel}`}.
           {' '}Pick a tile and use the Place tool to add decor for this level. Items from lower levels stay visible; higher-level items are dimmed.
@@ -964,7 +1061,7 @@ function BuildingInspector({
 
 function InteriorInspector({
   interiorId, interior, selectedEntity, allInteriors,
-  activeLevel, levelMax, onSetActiveLevel, onUpdateDecorMinLevel,
+  activeLevel, levelMax, onSetActiveLevel, onUpdateDecorMinLevel, onUpdateDecorHideAtLevel,
   panelStyle, headerStyle, bodyStyle,
   onCloseInterior, onOpenInterior, onResizeInterior,
   onAddInteriorExit, onUpdateInteriorProps, onUpdateInteriorExit, onRemoveInteriorExit,
@@ -978,6 +1075,7 @@ function InteriorInspector({
   levelMax: number
   onSetActiveLevel: (level: number) => void
   onUpdateDecorMinLevel: (entity: SelectedEntity, minLevel: number | undefined) => void
+  onUpdateDecorHideAtLevel: (entity: SelectedEntity, hideAtLevel: number | undefined) => void
   panelStyle: React.CSSProperties
   headerStyle: React.CSSProperties
   bodyStyle: React.CSSProperties
@@ -1251,6 +1349,7 @@ function InteriorInspector({
               entity={selectedEntity}
               maxLevel={levelMax}
               onMinLevel={ml => onUpdateDecorMinLevel(selectedEntity, ml)}
+              onHideAtLevel={hl => onUpdateDecorHideAtLevel(selectedEntity, hl)}
               onMove={(tx, ty) => onMoveEntity(selectedEntity, tx, ty)}
               onZlayer={z => onZlayerChange(selectedEntity, z)}
               onDelete={() => onDelete(selectedEntity)}
@@ -2075,7 +2174,7 @@ function SpawnTileInspector({
 
 export function EntityInspector({
   selectedEntities, mapId, configData, activeInteriorId, activeLevel, viewMode,
-  onSetActiveLevel, onUpdateBuilding, onUpdateDecorMinLevel,
+  onSetActiveLevel, onUpdateBuilding, onUpdateBuildingLevelVisual, onUpdateDecorMinLevel, onUpdateDecorHideAtLevel,
   onDelete, onMoveEntity, onZlayerChange, onUpdateGlow, onUpdatePickupGlow, onDialogueChange,
   onOpenInterior, onCloseInterior, onUpdateStreetEntry,
   onResizeInterior, onAddInterior, onAddInteriorExit, onUpdateInteriorProps, onUpdateInteriorExit,
@@ -2177,6 +2276,7 @@ export function EntityInspector({
         levelMax={levelMax}
         onSetActiveLevel={onSetActiveLevel}
         onUpdateDecorMinLevel={onUpdateDecorMinLevel}
+        onUpdateDecorHideAtLevel={onUpdateDecorHideAtLevel}
         panelStyle={panelStyle}
         headerStyle={headerStyle}
         bodyStyle={bodyStyle}
@@ -2269,6 +2369,7 @@ export function EntityInspector({
             entity={selectedEntity}
             maxLevel={building ? buildingMaxLevel(building) : undefined}
             onMinLevel={ml => onUpdateDecorMinLevel(selectedEntity, ml)}
+            onHideAtLevel={hl => onUpdateDecorHideAtLevel(selectedEntity, hl)}
             onMove={(tx, ty) => onMoveEntity(selectedEntity, tx, ty)}
             onZlayer={z => onZlayerChange(selectedEntity, z)}
             onGlow={onUpdateGlow ? patch => onUpdateGlow(selectedEntity, patch) : undefined}
@@ -2290,6 +2391,7 @@ export function EntityInspector({
           <NpcInspector
             npc={npc}
             entity={selectedEntity}
+            buildingIds={(configData.buildings ?? []).map(b => b.id).filter((id): id is string => !!id)}
             onMove={(tx, ty) => onMoveEntity(selectedEntity, tx, ty)}
             onDelete={() => onDelete(selectedEntity)}
             onDialogueChange={d => onDialogueChange(selectedEntity.index, d)}
@@ -2455,6 +2557,7 @@ export function EntityInspector({
             activeLevel={activeLevel}
             onSetActiveLevel={onSetActiveLevel}
             onUpdateBuilding={onUpdateBuilding}
+            onUpdateBuildingLevelVisual={onUpdateBuildingLevelVisual}
             onOpenInterior={onOpenInterior}
             interiorIds={interiorIds}
             existingInteriorIds={Object.keys(configData.interiors ?? {})}

--- a/web/src/components/mapEditor/MapEditor.tsx
+++ b/web/src/components/mapEditor/MapEditor.tsx
@@ -23,6 +23,7 @@ interface Props {
 
 export function MapEditor({ initialMapId = 'ravenwatch', initialFestival = undefined }: Props) {
   const [showGrid, setShowGrid] = useState(true)
+  const [showBuildingArt, setShowBuildingArt] = useState(true)
   const [showQuestItems, setShowQuestItems] = useState(false)
   const [showBlockedPaths, setShowBlockedPaths] = useState(false)
   const [showAreas, setShowAreas] = useState(false)
@@ -45,7 +46,7 @@ export function MapEditor({ initialMapId = 'ravenwatch', initialFestival = undef
     addPondTile, updatePondEntry, addNpcSpawnTile, addChickenZone, addArea,
     convertStreetToPond, convertPondToStreet,
     batchUpdateZlayer, batchUpdateStreetPathType,
-    updateDecorZlayer, updateDecorTileId, reorderDecor, updateGlow, updateDecorMinLevel, updateBuilding, addNpc, updateNpcDialogue, updateNpc,
+    updateDecorZlayer, updateDecorTileId, reorderDecor, updateGlow, updateDecorMinLevel, updateDecorHideAtLevel, updateBuildingLevelVisual, updateBuilding, addNpc, updateNpcDialogue, updateNpc,
     addAnimal, updateAnimal,
     updateTreasure, updateConfig,
     updateArea, updateMapProps, resizeMap,
@@ -254,6 +255,7 @@ export function MapEditor({ initialMapId = 'ravenwatch', initialFestival = undef
         canRedo={state.redoStack.length > 0}
         isDirty={state.isDirty}
         showGrid={showGrid}
+        showBuildingArt={showBuildingArt}
         showQuestItems={showQuestItems}
         showBlockedPaths={showBlockedPaths}
         showAreas={showAreas}
@@ -268,6 +270,7 @@ export function MapEditor({ initialMapId = 'ravenwatch', initialFestival = undef
         onUndo={undo}
         onRedo={redo}
         onGridToggle={() => setShowGrid(g => !g)}
+        onBuildingArtToggle={() => setShowBuildingArt(a => !a)}
         onQuestItemsToggle={() => setShowQuestItems(q => !q)}
         onBlockedPathsToggle={() => setShowBlockedPaths(b => !b)}
         onAreasToggle={() => setShowAreas(a => !a)}
@@ -311,6 +314,7 @@ export function MapEditor({ initialMapId = 'ravenwatch', initialFestival = undef
             previewFestivalId={state.previewFestivalId}
             tool={state.tool}
             showGrid={showGrid}
+            showBuildingArt={showBuildingArt}
             showQuestItems={showQuestItems}
             showBlockedPaths={showBlockedPaths}
             showAreas={showAreas}
@@ -349,7 +353,9 @@ export function MapEditor({ initialMapId = 'ravenwatch', initialFestival = undef
               viewMode={state.viewMode}
               onSetActiveLevel={setActiveLevel}
               onUpdateBuilding={updateBuilding}
+              onUpdateBuildingLevelVisual={updateBuildingLevelVisual}
               onUpdateDecorMinLevel={updateDecorMinLevel}
+              onUpdateDecorHideAtLevel={updateDecorHideAtLevel}
               onPickLocation={handlePickLocation}
               onDelete={entity => handleDeleteEntities([entity])}
               onMoveEntity={(entity, tx, ty) => handleMoveEntities([{ entity, tx, ty }])}

--- a/web/src/components/mapEditor/MapEditorCanvas.tsx
+++ b/web/src/components/mapEditor/MapEditorCanvas.tsx
@@ -6,7 +6,9 @@ import { BASE_CHIP_TILES } from '../../data/tiles/baseChipIndex'
 import type { RawMapConfig, RawDecorItem, RawBlockedPath, RawLockedDoor, SelectedEntity, ToolMode, Zlayer } from './mapEditorTypes'
 import { resolveVariantTint, AnimalType } from '../../game/hub/animals'
 import { WALL_TILES } from '../../data/tiles/buildingMaterials'
-import type { WallMaterial } from '../../data/tiles/buildingMaterials'
+import type { WallMaterial, RoofMaterial } from '../../data/tiles/buildingMaterials'
+import { placeBuildingTiles, resolveBuildingVisual } from '../../data/tiles/buildingRender'
+import { isVisibleAtLevel } from '../../data/hub/loader'
 import { expandBundleDecor } from '../../data/bundles/bundleLoader'
 import { RawQuestPickupItem } from '../../data/hub/hubWorldFactory'
 import { resolveNpcSprite } from './spriteList'
@@ -54,22 +56,23 @@ function expandEntries(entries: Array<{ rect?: number[]; tile?: number[] }>): [n
   return out
 }
 
-type FlatDecorItem = { tx: number; ty: number; tileId: string; zlayer: Zlayer; sourceIndex: number; minLevel: number }
+type FlatDecorItem = { tx: number; ty: number; tileId: string; zlayer: Zlayer; sourceIndex: number; minLevel: number; hideAtLevel?: number }
 
 function flattenDecor(items: RawDecorItem[]): FlatDecorItem[] {
   const out: FlatDecorItem[] = []
   items.forEach((item, sourceIndex) => {
     if (item.tx === undefined) return // comment-only entry
     const minLevel = item.minLevel ?? 0
+    const hideAtLevel = item.hideAtLevel
     if (item.bundleID) {
       const expanded = expandBundleDecor(item.bundleID, item.tx, item.ty ?? 0)
       expanded.forEach(e => {
         const tileKey = Object.keys(BASE_CHIP_TILES as Record<string, number>)
           .find(k => (BASE_CHIP_TILES as Record<string, number>)[k] === e.tileId) ?? ''
-        if (tileKey) out.push({ tx: e.tx, ty: e.ty, tileId: tileKey, zlayer: (e.zlayer as Zlayer) ?? 'solid', sourceIndex, minLevel })
+        if (tileKey) out.push({ tx: e.tx, ty: e.ty, tileId: tileKey, zlayer: (e.zlayer as Zlayer) ?? 'solid', sourceIndex, minLevel, hideAtLevel })
       })
     } else if (item.tileId) {
-      out.push({ tx: item.tx, ty: item.ty ?? 0, tileId: item.tileId, zlayer: item.zlayer ?? 'solid', sourceIndex, minLevel })
+      out.push({ tx: item.tx, ty: item.ty ?? 0, tileId: item.tileId, zlayer: item.zlayer ?? 'solid', sourceIndex, minLevel, hideAtLevel })
     }
   })
   return out
@@ -79,6 +82,7 @@ interface Props {
   configData:       RawMapConfig
   tool:             ToolMode
   showGrid:         boolean
+  showBuildingArt?: boolean   // render buildings as real tiles (default) vs flat colour blocks
   selectedEntities: SelectedEntity[]
   viewMode:         'exterior' | 'interior'
   activeInteriorId: string | null
@@ -109,7 +113,7 @@ interface Props {
 
 export function MapEditorCanvas(props: Props) {
   const {
-    configData, tool, showGrid, selectedEntities, viewMode, activeInteriorId, activeLevel, previewFestivalId,
+    configData, tool, showGrid, showBuildingArt = true, selectedEntities, viewMode, activeInteriorId, activeLevel, previewFestivalId,
     activeTileId, activeBundleId, activeZlayer, pickActive, showQuestItems, showBlockedPaths, showAreas, showInteractables, blockedPaths, questPickupItems,
     onPlaceDecor, onAddStreet,
   } = props
@@ -432,23 +436,57 @@ export function MapEditorCanvas(props: Props) {
       streetLayer.addChild(gfx)
     })
 
-    // Buildings
+    // Buildings — rendered with real wall/roof tiles for the *current editing
+    // level* (resolveBuildingVisual applies any levelVisuals overrides), so the
+    // editor preview matches the in-game look. Falls back to flat colour blocks
+    // when art is toggled off or the building has no wall/roof material.
     const buildings = configData.buildings ?? []
     buildings.forEach((b, bIdx) => {
-      const rects = b.rects ?? (b.rect ? [b.rect] : [])
-      const col   = WALL_COLORS[b.wall ?? ''] ?? 0x556677
+      const allRects = (b.rects ?? (b.rect ? [b.rect] : [])) as [number, number, number, number][]
+      const baseRect = allRects[0] ?? [0, 0, 0, 0]
+      const vis = resolveBuildingVisual(
+        { rect: baseRect, wall: b.wall as WallMaterial | undefined, roof: b.roof as RoofMaterial | undefined },
+        b.levelVisuals as Array<{ minLevel: number; rect?: [number, number, number, number]; wall?: WallMaterial; roof?: RoofMaterial }> | undefined,
+        activeLevel,
+      )
+      // A level footprint override replaces the whole footprint; otherwise keep
+      // the building's (possibly multi-rect) base footprint.
+      const levelRectActive = (b.levelVisuals ?? []).some(v => v.rect && v.minLevel <= activeLevel)
+      const renderRects = levelRectActive ? [vis.rect] : allRects
       const isSel = isEntitySelected({ type: 'building', index: bIdx })
-      const gfx   = new PIXI.Graphics()
-      for (const [tx1, ty1, tx2, ty2] of rects) {
-        gfx.rect(tx1 * T, ty1 * T, (tx2 - tx1 + 1) * T, (ty2 - ty1 + 1) * T).fill(col)
-        if (isSel)
-          gfx.rect(tx1 * T, ty1 * T, (tx2 - tx1 + 1) * T, (ty2 - ty1 + 1) * T)
+
+      const useArt = showBuildingArt && vis.wall && vis.roof && WALL_TILES[vis.wall as WallMaterial]
+      if (useArt) {
+        for (const rect of renderRects) {
+          const placements = placeBuildingTiles(rect, vis.wall as WallMaterial, vis.roof as RoofMaterial, [])
+          for (const [tileId, positions] of placements) {
+            loadTileRef(tileId).then(tex => {
+              if (renderVersionRef.current !== version) return
+              for (const [tx, ty] of positions) {
+                const s = new PIXI.Sprite(tex)
+                s.position.set(tx * T, ty * T)
+                s.width = T; s.height = T
+                buildingLayer.addChild(s)
+              }
+            }).catch(() => {})
+          }
+        }
+      } else {
+        const col = WALL_COLORS[vis.wall ?? ''] ?? 0x556677
+        const gfx = new PIXI.Graphics()
+        for (const [tx1, ty1, tx2, ty2] of renderRects)
+          gfx.rect(tx1 * T, ty1 * T, (tx2 - tx1 + 1) * T, (ty2 - ty1 + 1) * T).fill(col)
+        buildingLayer.addChild(gfx)
+      }
+
+      if (isSel) {
+        for (const [tx1, ty1, tx2, ty2] of renderRects)
+          selLayer.rect(tx1 * T, ty1 * T, (tx2 - tx1 + 1) * T, (ty2 - ty1 + 1) * T)
             .stroke({ color: 0xf0c040, width: 2 })
       }
-      buildingLayer.addChild(gfx)
-      if (b.id && rects[0]) {
-        const [tx1, ty1, tx2, ty2] = rects[0]
-        const lbl = new PIXI.Text({ text: b.id, style: { fontSize: 9, fill: 0xeeeecc } })
+      if (b.id && renderRects[0]) {
+        const [tx1, ty1, tx2, ty2] = renderRects[0]
+        const lbl = new PIXI.Text({ text: b.id, style: { fontSize: 9, fill: 0xeeeecc, stroke: { color: 0x1a1a1a, width: 2 } } })
         lbl.x = (tx1 + (tx2 - tx1 + 1) / 2) * T - lbl.width / 2
         lbl.y = (ty1 + (ty2 - ty1 + 1) / 2) * T - lbl.height / 2
         buildingLayer.addChild(lbl)
@@ -721,7 +759,7 @@ export function MapEditorCanvas(props: Props) {
     ;(configData.npcs ?? []).forEach((npc, nIdx) => {
       if (npc.building !== iid) return
       const isSel = isEntitySelected({ type: 'npc', index: nIdx })
-      const dimmed = (npc.minLevel ?? 0) > activeLevel  // NPC only present at a higher upgrade level
+      const dimmed = !isVisibleAtLevel(npc, activeLevel)  // NPC absent at this upgrade level (below minLevel or past hideAtLevel)
       loadSpriteTexture(resolveNpcSprite(npc.sprite)).then(tex => {
         if (renderVersionRef.current !== version) return
         const sp = new PIXI.Sprite(tex)
@@ -813,10 +851,10 @@ export function MapEditorCanvas(props: Props) {
     interiorId: string,
     selLayer: PIXI.Graphics,
   ) {
-    items.forEach(({ tx, ty, tileId, zlayer, sourceIndex, minLevel }) => {
+    items.forEach(({ tx, ty, tileId, zlayer, sourceIndex, minLevel, hideAtLevel }) => {
       const numId = tileNumericId(tileId)
       const layer = zlayer === 'below' ? decorBLayer : zlayer === 'above' ? decorALayer : decorLayer
-      const dimmed = minLevel > activeLevel  // decor that only appears at a higher upgrade level
+      const dimmed = !isVisibleAtLevel({ minLevel, hideAtLevel }, activeLevel)  // absent at this upgrade level
       const entity: SelectedEntity = entityType === 'exteriorDecor'
         ? { type: 'exteriorDecor', index: sourceIndex }
         : { type: 'interiorDecor', index: sourceIndex, interiorId }
@@ -852,10 +890,10 @@ export function MapEditorCanvas(props: Props) {
     decorBLayer: PIXI.Container, decorLayer: PIXI.Container, decorALayer: PIXI.Container,
     selLayer: PIXI.Graphics,
   ) {
-    items.forEach(({ tx, ty, tileId, zlayer, sourceIndex, minLevel }) => {
+    items.forEach(({ tx, ty, tileId, zlayer, sourceIndex, minLevel, hideAtLevel }) => {
       const numId = tileNumericId(tileId)
       const layer = zlayer === 'below' ? decorBLayer : zlayer === 'above' ? decorALayer : decorLayer
-      const dimmed = minLevel > activeLevel
+      const dimmed = !isVisibleAtLevel({ minLevel, hideAtLevel }, activeLevel)
       const entity: SelectedEntity = { type: 'buildingLevelDecor', buildingIndex, index: sourceIndex }
       const isSel = isEntitySelected(entity)
 

--- a/web/src/components/mapEditor/MapEditorToolbar.tsx
+++ b/web/src/components/mapEditor/MapEditorToolbar.tsx
@@ -28,6 +28,7 @@ interface Props {
   canRedo:     boolean
   isDirty:     boolean
   showGrid:             boolean
+  showBuildingArt:      boolean
   showQuestItems:       boolean
   showBlockedPaths:     boolean
   showAreas:            boolean
@@ -42,6 +43,7 @@ interface Props {
   onUndo:               () => void
   onRedo:               () => void
   onGridToggle:         () => void
+  onBuildingArtToggle:  () => void
   onQuestItemsToggle:   () => void
   onBlockedPathsToggle: () => void
   onAreasToggle:        () => void
@@ -63,9 +65,9 @@ const TOOLS: { mode: ToolMode; label: string; title: string }[] = [
 ]
 
 export function MapEditorToolbar({
-  mapId, tool, canUndo, canRedo, isDirty, showGrid, showQuestItems, showBlockedPaths, showAreas, showInteractables, drawerOpen, hasDuplicateQuestIds,
+  mapId, tool, canUndo, canRedo, isDirty, showGrid, showBuildingArt, showQuestItems, showBlockedPaths, showAreas, showInteractables, drawerOpen, hasDuplicateQuestIds,
   configData, questDefsData, previewFestivalId, onPreviewFestivalChange, onMapChange, onToolChange, onUndo, onRedo,
-  onGridToggle, onQuestItemsToggle, onBlockedPathsToggle, onAreasToggle, onInteractablesToggle, onDrawerToggle, onSaved,
+  onGridToggle, onBuildingArtToggle, onQuestItemsToggle, onBlockedPathsToggle, onAreasToggle, onInteractablesToggle, onDrawerToggle, onSaved,
 }: Props) {
   const [saveState, setSaveState] = useState<'idle' | 'saving' | 'ok' | 'error'>('idle')
   const [saveError, setSaveError] = useState('')
@@ -180,6 +182,20 @@ export function MapEditorToolbar({
         }}
       >
         ⊞
+      </button>
+
+      {/* Building art toggle — real tiles vs flat colour blocks */}
+      <button
+        title="Toggle building art — render buildings as tiles vs colour blocks"
+        onClick={onBuildingArtToggle}
+        style={{
+          ...btnBase,
+          background: showBuildingArt ? '#1e2e1e' : '#1e1e3e',
+          color:      showBuildingArt ? '#6f6' : '#666',
+          borderColor: showBuildingArt ? '#4a7a4a' : '#444',
+        }}
+      >
+        🏠
       </button>
 
       {/* Quest items toggle */}

--- a/web/src/components/mapEditor/mapEditorTypes.ts
+++ b/web/src/components/mapEditor/mapEditorTypes.ts
@@ -24,6 +24,15 @@ export interface RawDecorItem {
   glowRadius?: number   // glow radius in tiles
   pulse?: boolean       // animate the glow radius
   minLevel?: number     // building upgrade level at which this decor first appears (0/undefined = base)
+  hideAtLevel?: number  // building upgrade level at which this decor disappears (undefined = never)
+}
+
+/** Per-level visual override for a building (footprint / wall / roof). */
+export interface RawBuildingLevelVisual {
+  minLevel: number
+  rect?: [number, number, number, number]
+  wall?: WallMaterial
+  roof?: RoofMaterial
 }
 
 export interface RawBuildingDoor {
@@ -48,9 +57,10 @@ export interface RawBuilding {
   doors?: RawBuildingDoor[]
   windows?: RawBuildingWindow[]
   decor?: RawDecorItem[]
-  upgradeKind?: string         // shared upgrade track key (shop/inn/…) — drives costs & default decor
+  upgradeKind?: string         // shared upgrade track key (shop/inn/…) — drives costs & reputation gates
   maxLevel?: number            // highest upgrade level this building can reach (defaults to its track length)
   levelDecor?: RawDecorItem[]  // per-building exterior decor revealed by upgrade level (each item carries minLevel)
+  levelVisuals?: RawBuildingLevelVisual[]  // per-level footprint/wall/roof overrides
 }
 
 export interface RawAnimal {
@@ -82,6 +92,8 @@ export interface RawNpc {
   isGhost?: boolean
   dialogueTree?: string   // id of a branching dialogue tree (questDefs.json `dialogues`)
   minLevel?: number   // building upgrade level at which this NPC first appears (0/undefined = always)
+  hideAtLevel?: number // building upgrade level at which this NPC disappears (undefined = never)
+  levelBuildingId?: string // exterior NPCs: building whose upgrade level gates this NPC's visibility
   schedule?: Array<{
     startHour: number
     endHour: number

--- a/web/src/components/mapEditor/useMapEditorState.ts
+++ b/web/src/components/mapEditor/useMapEditorState.ts
@@ -17,6 +17,7 @@ import gravemoorConfig from '../../data/hub/gravemoor/config.json'
 import hollowmereConfig from '../../data/hub/hollowmere/config.json'
 import dreadspirecitadelConfig from '../../data/hub/dreadspirecitadel/config.json'
 import { MapId } from '../../data/hub/hubWorldFactory'
+import type { WallMaterial, RoofMaterial } from '../../data/tiles/buildingMaterials'
 
 // Exported so cross-town reference pickers (entityRefs.ts) can read every town's
 // NPCs / buildings / interiors without re-importing all the config JSON.
@@ -669,6 +670,83 @@ export function useMapEditorState(initialMapId: MapId = 'ravenwatch', initialFes
     })
   }, [])
 
+  // Patch the hideAtLevel of a level-aware decor item (building level-decor or interior decor).
+  const updateDecorHideAtLevel = useCallback((entity: SelectedEntity, hideAtLevel: number | undefined) => {
+    setState(s => {
+      const prevConfig = s.configData
+      let newConfig = prevConfig
+      const clean = (item: RawDecorItem): RawDecorItem => {
+        const next = { ...item, hideAtLevel }
+        if (hideAtLevel === undefined || hideAtLevel <= 0) delete next.hideAtLevel
+        return next
+      }
+
+      if (entity.type === 'buildingLevelDecor' && prevConfig.buildings?.[entity.buildingIndex]?.levelDecor) {
+        const buildings = [...prevConfig.buildings]
+        const b = buildings[entity.buildingIndex]
+        const levelDecor = [...(b.levelDecor ?? [])]
+        if (!levelDecor[entity.index]) return s
+        levelDecor[entity.index] = clean(levelDecor[entity.index])
+        buildings[entity.buildingIndex] = { ...b, levelDecor }
+        newConfig = { ...prevConfig, buildings }
+      } else if (entity.type === 'interiorDecor' && prevConfig.interiors?.[entity.interiorId]) {
+        const interior = prevConfig.interiors[entity.interiorId]
+        const decor = [...interior.decor]
+        if (!decor[entity.index]) return s
+        decor[entity.index] = clean(decor[entity.index])
+        newConfig = {
+          ...prevConfig,
+          interiors: { ...prevConfig.interiors, [entity.interiorId]: { ...interior, decor } },
+        }
+      }
+
+      if (newConfig === prevConfig) return s
+      return {
+        ...s,
+        configData: newConfig,
+        undoStack:  [...s.undoStack, prevConfig].slice(-MAX_UNDO),
+        redoStack:  [],
+        isDirty:    true,
+      }
+    })
+  }, [])
+
+  // Create/patch/remove a per-level visual override (footprint/wall/roof) for a building.
+  const updateBuildingLevelVisual = useCallback((
+    buildingIndex: number,
+    minLevel: number,
+    patch: Partial<{ rect: [number, number, number, number]; wall: WallMaterial; roof: RoofMaterial }>,
+  ) => {
+    setState(s => {
+      const prevConfig = s.configData
+      const buildings = [...(prevConfig.buildings ?? [])]
+      const b = buildings[buildingIndex]
+      if (!b) return s
+      const levelVisuals = [...(b.levelVisuals ?? [])]
+      const idx = levelVisuals.findIndex(v => v.minLevel === minLevel)
+      const merged = { ...(idx >= 0 ? levelVisuals[idx] : { minLevel }), ...patch }
+      // Drop fields cleared to undefined so they fall back to the base building.
+      for (const k of ['rect', 'wall', 'roof'] as const)
+        if (merged[k] === undefined) delete (merged as Record<string, unknown>)[k]
+      const hasOverride = merged.rect !== undefined || merged.wall !== undefined || merged.roof !== undefined
+      if (idx >= 0) {
+        if (hasOverride) levelVisuals[idx] = merged
+        else levelVisuals.splice(idx, 1)                 // nothing left to override — remove entry
+      } else if (hasOverride) {
+        levelVisuals.push(merged)
+      }
+      levelVisuals.sort((a, c) => a.minLevel - c.minLevel)
+      buildings[buildingIndex] = { ...b, levelVisuals: levelVisuals.length ? levelVisuals : undefined }
+      return {
+        ...s,
+        configData: { ...prevConfig, buildings },
+        undoStack:  [...s.undoStack, prevConfig].slice(-MAX_UNDO),
+        redoStack:  [],
+        isDirty:    true,
+      }
+    })
+  }, [])
+
   // Patch building-level fields (upgradeKind / maxLevel) on a building.
   const updateBuilding = useCallback((index: number, patch: Partial<RawBuilding>) => {
     setState(s => {
@@ -1245,6 +1323,8 @@ export function useMapEditorState(initialMapId: MapId = 'ravenwatch', initialFes
     reorderDecor,
     updateGlow,
     updateDecorMinLevel,
+    updateDecorHideAtLevel,
+    updateBuildingLevelVisual,
     updateBuilding,
     addNpc,
     updateNpcDialogue,

--- a/web/src/data/hub/appleford/config.json
+++ b/web/src/data/hub/appleford/config.json
@@ -170,6 +170,44 @@
           "hideSign": true,
           "buildingId": "cider-house"
         }
+      ],
+      "levelDecor": [
+        {
+          "tx": 5,
+          "ty": 9,
+          "tileId": "barrel",
+          "minLevel": 1
+        },
+        {
+          "tx": 7,
+          "ty": 9,
+          "tileId": "bottlesOfLiquor",
+          "minLevel": 1
+        },
+        {
+          "tx": 4,
+          "ty": 9,
+          "tileId": "barrel",
+          "minLevel": 2
+        },
+        {
+          "tx": 8,
+          "ty": 9,
+          "tileId": "barrel",
+          "minLevel": 2
+        },
+        {
+          "tx": 6,
+          "ty": 11,
+          "tileId": "drinkSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 5,
+          "ty": 10,
+          "tileId": "bottlesOfLiquor",
+          "minLevel": 3
+        }
       ]
     },
     {
@@ -189,6 +227,44 @@
           "ty": 1,
           "hideSign": true,
           "buildingId": "chapel"
+        }
+      ],
+      "levelDecor": [
+        {
+          "tx": 13,
+          "ty": 9,
+          "tileId": "floorLantern",
+          "minLevel": 1
+        },
+        {
+          "tx": 15,
+          "ty": 9,
+          "tileId": "floorLantern",
+          "minLevel": 1
+        },
+        {
+          "tx": 12,
+          "ty": 9,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 16,
+          "ty": 9,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 14,
+          "ty": 11,
+          "tileId": "largeSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 13,
+          "ty": 10,
+          "tileId": "goldChest",
+          "minLevel": 3
         }
       ]
     },
@@ -210,6 +286,44 @@
           "hideSign": true,
           "buildingId": "keepers-cottage"
         }
+      ],
+      "levelDecor": [
+        {
+          "tx": 23,
+          "ty": 9,
+          "tileId": "pinkFlower",
+          "minLevel": 1
+        },
+        {
+          "tx": 25,
+          "ty": 9,
+          "tileId": "blueFlower",
+          "minLevel": 1
+        },
+        {
+          "tx": 22,
+          "ty": 9,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 26,
+          "ty": 9,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 24,
+          "ty": 11,
+          "tileId": "floorLantern",
+          "minLevel": 3
+        },
+        {
+          "tx": 25,
+          "ty": 10,
+          "tileId": "potOfFlowers",
+          "minLevel": 3
+        }
       ]
     },
     {
@@ -229,6 +343,44 @@
           "ty": 1,
           "hideSign": true,
           "buildingId": "coopers-shed"
+        }
+      ],
+      "levelDecor": [
+        {
+          "tx": 31,
+          "ty": 9,
+          "tileId": "crate",
+          "minLevel": 1
+        },
+        {
+          "tx": 33,
+          "ty": 9,
+          "tileId": "crate",
+          "minLevel": 1
+        },
+        {
+          "tx": 30,
+          "ty": 9,
+          "tileId": "chest",
+          "minLevel": 2
+        },
+        {
+          "tx": 34,
+          "ty": 9,
+          "tileId": "barrel",
+          "minLevel": 2
+        },
+        {
+          "tx": 32,
+          "ty": 11,
+          "tileId": "armourSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 31,
+          "ty": 10,
+          "tileId": "chest",
+          "minLevel": 3
         }
       ]
     },
@@ -250,6 +402,44 @@
           "hideSign": true,
           "buildingId": "bottling-barn"
         }
+      ],
+      "levelDecor": [
+        {
+          "tx": 5,
+          "ty": 19,
+          "tileId": "crate",
+          "minLevel": 1
+        },
+        {
+          "tx": 7,
+          "ty": 19,
+          "tileId": "crate",
+          "minLevel": 1
+        },
+        {
+          "tx": 4,
+          "ty": 19,
+          "tileId": "chest",
+          "minLevel": 2
+        },
+        {
+          "tx": 8,
+          "ty": 19,
+          "tileId": "barrel",
+          "minLevel": 2
+        },
+        {
+          "tx": 6,
+          "ty": 21,
+          "tileId": "armourSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 5,
+          "ty": 20,
+          "tileId": "chest",
+          "minLevel": 3
+        }
       ]
     },
     {
@@ -269,6 +459,44 @@
           "ty": 1,
           "hideSign": true,
           "buildingId": "apiary"
+        }
+      ],
+      "levelDecor": [
+        {
+          "tx": 13,
+          "ty": 19,
+          "tileId": "pinkFlower",
+          "minLevel": 1
+        },
+        {
+          "tx": 15,
+          "ty": 19,
+          "tileId": "blueFlower",
+          "minLevel": 1
+        },
+        {
+          "tx": 12,
+          "ty": 19,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 16,
+          "ty": 19,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 14,
+          "ty": 21,
+          "tileId": "floorLantern",
+          "minLevel": 3
+        },
+        {
+          "tx": 15,
+          "ty": 20,
+          "tileId": "potOfFlowers",
+          "minLevel": 3
         }
       ]
     },
@@ -290,6 +518,44 @@
           "hideSign": true,
           "buildingId": "orchard-cottage"
         }
+      ],
+      "levelDecor": [
+        {
+          "tx": 23,
+          "ty": 19,
+          "tileId": "pinkFlower",
+          "minLevel": 1
+        },
+        {
+          "tx": 25,
+          "ty": 19,
+          "tileId": "blueFlower",
+          "minLevel": 1
+        },
+        {
+          "tx": 22,
+          "ty": 19,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 26,
+          "ty": 19,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 24,
+          "ty": 21,
+          "tileId": "floorLantern",
+          "minLevel": 3
+        },
+        {
+          "tx": 25,
+          "ty": 20,
+          "tileId": "potOfFlowers",
+          "minLevel": 3
+        }
       ]
     },
     {
@@ -309,6 +575,44 @@
           "ty": 1,
           "hideSign": true,
           "buildingId": "market-barn"
+        }
+      ],
+      "levelDecor": [
+        {
+          "tx": 31,
+          "ty": 19,
+          "tileId": "crate",
+          "minLevel": 1
+        },
+        {
+          "tx": 33,
+          "ty": 19,
+          "tileId": "barrel",
+          "minLevel": 1
+        },
+        {
+          "tx": 30,
+          "ty": 19,
+          "tileId": "pileOfSacks",
+          "minLevel": 2
+        },
+        {
+          "tx": 34,
+          "ty": 19,
+          "tileId": "crate",
+          "minLevel": 2
+        },
+        {
+          "tx": 32,
+          "ty": 21,
+          "tileId": "goldSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 31,
+          "ty": 20,
+          "tileId": "goldChest",
+          "minLevel": 3
         }
       ]
     }
@@ -958,7 +1262,7 @@
       "ty": 3,
       "building": "cider-house",
       "dialogue": [
-        "Appleford cider \u2014 pressed here, drunk everywhere, remembered fondly nowhere near here.",
+        "Appleford cider — pressed here, drunk everywhere, remembered fondly nowhere near here.",
         "The toll road's made deliveries a nightmare. Bandits drink my profits, literally.",
         "First mug's full price. So's the second. I'm a brewer, not a charity."
       ],
@@ -977,7 +1281,7 @@
       "building": "apiary",
       "dialogue": [
         "Mind the hives. The bees know a thief from a friend, and they vote with their stings.",
-        "Honey, wax, mead \u2014 one little bee gives you all three and asks only for flowers.",
+        "Honey, wax, mead — one little bee gives you all three and asks only for flowers.",
         "Bess grows the blossom, I keep the bees. Between us we keep Appleford sweet."
       ],
       "questGive": "appleford-honey-harvest",
@@ -996,7 +1300,7 @@
       "dialogue": [
         "No barrel, no cider. No cider, no Appleford. I'd say I'm the most important person here, but Tom would sulk.",
         "A good cask is watertight, sweet-grained, and never argues. Unlike apprentices.",
-        "Staves, hoops, and patience \u2014 that's a barrel. Rush any of the three and you've a puddle."
+        "Staves, hoops, and patience — that's a barrel. Rush any of the three and you've a puddle."
       ],
       "questGive": "appleford-coopers-order",
       "questReceive": "appleford-coopers-order"
@@ -1009,7 +1313,7 @@
       "ty": 4,
       "building": "market-barn",
       "dialogue": [
-        "Apples, cider, honey, jam \u2014 if it grows in Appleford, it sells through me.",
+        "Apples, cider, honey, jam — if it grows in Appleford, it sells through me.",
         "Ravenwatch pays double for our cider. Getting it there in one piece is the trick.",
         "Buy low, sell ripe. That's the whole of it, traveller."
       ],
@@ -1181,7 +1485,7 @@
       ]
     },
     "cider-house-press": {
-      "name": "The Cider House \u2014 Press Room",
+      "name": "The Cider House — Press Room",
       "width": 11,
       "height": 8,
       "floorTileId": "woodFloor",
@@ -1246,7 +1550,7 @@
       ]
     },
     "cider-house-cellar": {
-      "name": "The Cider House \u2014 Cellar",
+      "name": "The Cider House — Cellar",
       "width": 10,
       "height": 8,
       "floorTileId": "stoneFloor",
@@ -1443,7 +1747,7 @@
       ]
     },
     "keepers-cottage-back": {
-      "name": "The Keeper's Cottage \u2014 Pantry",
+      "name": "The Keeper's Cottage — Pantry",
       "width": 10,
       "height": 8,
       "floorTileId": "woodFloor",

--- a/web/src/data/hub/buildingUpgrades.json
+++ b/web/src/data/hub/buildingUpgrades.json
@@ -1,79 +1,184 @@
 {
   "shop": [
-    { "label": "Stocked Shelves", "cost": 120, "repReward": 40, "repRequired": 0,
-      "benefit": "Wider, deeper shop stock.", "service": "shop-stock",
-      "decor": [{ "dx": -1, "dy": 0, "tileId": "crate" }, { "dx": 1, "dy": 0, "tileId": "barrel" }] },
-    { "label": "Trade Counter", "cost": 280, "repReward": 80, "repRequired": 150,
-      "benefit": "A standing daily discount on purchases.", "service": "shop-discount",
-      "decor": [{ "dx": -2, "dy": 0, "tileId": "pileOfSacks" }, { "dx": 2, "dy": 0, "tileId": "crate" }] },
-    { "label": "Guild Charter", "cost": 600, "repReward": 160, "repRequired": 350,
-      "benefit": "Premium rare stock and the best prices in the shard.", "service": "shop-premium",
-      "decor": [{ "dx": 0, "dy": 2, "tileId": "goldSign" }, { "dx": -1, "dy": 1, "tileId": "goldChest" }] }
+    {
+      "label": "Stocked Shelves",
+      "cost": 120,
+      "repReward": 40,
+      "repRequired": 0,
+      "benefit": "Wider, deeper shop stock.",
+      "service": "shop-stock"
+    },
+    {
+      "label": "Trade Counter",
+      "cost": 280,
+      "repReward": 80,
+      "repRequired": 150,
+      "benefit": "A standing daily discount on purchases.",
+      "service": "shop-discount"
+    },
+    {
+      "label": "Guild Charter",
+      "cost": 600,
+      "repReward": 160,
+      "repRequired": 350,
+      "benefit": "Premium rare stock and the best prices in the shard.",
+      "service": "shop-premium"
+    }
   ],
   "inn": [
-    { "label": "Fresh Linens", "cost": 110, "repReward": 40, "repRequired": 0,
-      "benefit": "A more comfortable common room.", "service": "inn-rest",
-      "decor": [{ "dx": -1, "dy": 0, "tileId": "barrel" }, { "dx": 1, "dy": 0, "tileId": "barrel" }] },
-    { "label": "Hearth & Bench", "cost": 260, "repReward": 80, "repRequired": 150,
-      "benefit": "More rumours and traveller gossip.", "service": "inn-rumours",
-      "decor": [{ "dx": -2, "dy": 0, "tileId": "floorLantern" }, { "dx": 2, "dy": 0, "tileId": "potOfFlowers" }] },
-    { "label": "Grand Sign", "cost": 560, "repReward": 160, "repRequired": 350,
-      "benefit": "A renowned inn that draws notable guests.", "service": "inn-guests",
-      "decor": [{ "dx": 0, "dy": 2, "tileId": "innSign" }, { "dx": -1, "dy": 1, "tileId": "floorLantern" }] }
+    {
+      "label": "Fresh Linens",
+      "cost": 110,
+      "repReward": 40,
+      "repRequired": 0,
+      "benefit": "A more comfortable common room.",
+      "service": "inn-rest"
+    },
+    {
+      "label": "Hearth & Bench",
+      "cost": 260,
+      "repReward": 80,
+      "repRequired": 150,
+      "benefit": "More rumours and traveller gossip.",
+      "service": "inn-rumours"
+    },
+    {
+      "label": "Grand Sign",
+      "cost": 560,
+      "repReward": 160,
+      "repRequired": 350,
+      "benefit": "A renowned inn that draws notable guests.",
+      "service": "inn-guests"
+    }
   ],
   "tavern": [
-    { "label": "Full Cellar", "cost": 110, "repReward": 40, "repRequired": 0,
-      "benefit": "Better brews on tap.", "service": "tavern-brews",
-      "decor": [{ "dx": -1, "dy": 0, "tileId": "barrel" }, { "dx": 1, "dy": 0, "tileId": "bottlesOfLiquor" }] },
-    { "label": "Bottle Rack", "cost": 250, "repReward": 80, "repRequired": 150,
-      "benefit": "Rare vintages and louder revelry.", "service": "tavern-rare",
-      "decor": [{ "dx": -2, "dy": 0, "tileId": "barrel" }, { "dx": 2, "dy": 0, "tileId": "barrel" }] },
-    { "label": "Tavern Sign", "cost": 540, "repReward": 160, "repRequired": 350,
-      "benefit": "A landmark tavern known across the shard.", "service": "tavern-landmark",
-      "decor": [{ "dx": 0, "dy": 2, "tileId": "drinkSign" }, { "dx": -1, "dy": 1, "tileId": "bottlesOfLiquor" }] }
+    {
+      "label": "Full Cellar",
+      "cost": 110,
+      "repReward": 40,
+      "repRequired": 0,
+      "benefit": "Better brews on tap.",
+      "service": "tavern-brews"
+    },
+    {
+      "label": "Bottle Rack",
+      "cost": 250,
+      "repReward": 80,
+      "repRequired": 150,
+      "benefit": "Rare vintages and louder revelry.",
+      "service": "tavern-rare"
+    },
+    {
+      "label": "Tavern Sign",
+      "cost": 540,
+      "repReward": 160,
+      "repRequired": 350,
+      "benefit": "A landmark tavern known across the shard.",
+      "service": "tavern-landmark"
+    }
   ],
   "cottage": [
-    { "label": "Window Box", "cost": 90, "repReward": 35, "repRequired": 0,
-      "benefit": "A cheerier, well-kept home.", "service": "cottage-decor",
-      "decor": [{ "dx": -1, "dy": 0, "tileId": "pinkFlower" }, { "dx": 1, "dy": 0, "tileId": "blueFlower" }] },
-    { "label": "Flower Pots", "cost": 220, "repReward": 70, "repRequired": 120,
-      "benefit": "A blooming garden the whole street admires.", "service": "cottage-garden",
-      "decor": [{ "dx": -2, "dy": 0, "tileId": "potOfFlowers" }, { "dx": 2, "dy": 0, "tileId": "potOfFlowers" }] },
-    { "label": "Lantern Post", "cost": 480, "repReward": 140, "repRequired": 300,
-      "benefit": "Warm lantern-light that keeps the lane lively after dark.", "service": "cottage-lantern",
-      "decor": [{ "dx": 0, "dy": 2, "tileId": "floorLantern" }, { "dx": 1, "dy": 1, "tileId": "potOfFlowers" }] }
+    {
+      "label": "Window Box",
+      "cost": 90,
+      "repReward": 35,
+      "repRequired": 0,
+      "benefit": "A cheerier, well-kept home.",
+      "service": "cottage-decor"
+    },
+    {
+      "label": "Flower Pots",
+      "cost": 220,
+      "repReward": 70,
+      "repRequired": 120,
+      "benefit": "A blooming garden the whole street admires.",
+      "service": "cottage-garden"
+    },
+    {
+      "label": "Lantern Post",
+      "cost": 480,
+      "repReward": 140,
+      "repRequired": 300,
+      "benefit": "Warm lantern-light that keeps the lane lively after dark.",
+      "service": "cottage-lantern"
+    }
   ],
   "workshop": [
-    { "label": "Tool Crates", "cost": 130, "repReward": 40, "repRequired": 0,
-      "benefit": "Faster, sturdier craftwork.", "service": "workshop-craft",
-      "decor": [{ "dx": -1, "dy": 0, "tileId": "crate" }, { "dx": 1, "dy": 0, "tileId": "crate" }] },
-    { "label": "Strongbox", "cost": 300, "repReward": 80, "repRequired": 150,
-      "benefit": "Commissions completed more quickly.", "service": "workshop-speed",
-      "decor": [{ "dx": -2, "dy": 0, "tileId": "chest" }, { "dx": 2, "dy": 0, "tileId": "barrel" }] },
-    { "label": "Master's Mark", "cost": 620, "repReward": 160, "repRequired": 350,
-      "benefit": "Masterwork goods bearing the guild mark.", "service": "workshop-master",
-      "decor": [{ "dx": 0, "dy": 2, "tileId": "armourSign" }, { "dx": -1, "dy": 1, "tileId": "chest" }] }
+    {
+      "label": "Tool Crates",
+      "cost": 130,
+      "repReward": 40,
+      "repRequired": 0,
+      "benefit": "Faster, sturdier craftwork.",
+      "service": "workshop-craft"
+    },
+    {
+      "label": "Strongbox",
+      "cost": 300,
+      "repReward": 80,
+      "repRequired": 150,
+      "benefit": "Commissions completed more quickly.",
+      "service": "workshop-speed"
+    },
+    {
+      "label": "Master's Mark",
+      "cost": 620,
+      "repReward": 160,
+      "repRequired": 350,
+      "benefit": "Masterwork goods bearing the guild mark.",
+      "service": "workshop-master"
+    }
   ],
   "shrine": [
-    { "label": "Votive Candles", "cost": 100, "repReward": 40, "repRequired": 0,
-      "benefit": "A tended, welcoming shrine.", "service": "shrine-blessing",
-      "decor": [{ "dx": -1, "dy": 0, "tileId": "floorLantern" }, { "dx": 1, "dy": 0, "tileId": "floorLantern" }] },
-    { "label": "Sacred Brazier", "cost": 240, "repReward": 80, "repRequired": 150,
-      "benefit": "Stronger blessings for travellers.", "service": "shrine-ward",
-      "decor": [{ "dx": -2, "dy": 0, "tileId": "potOfFlowers" }, { "dx": 2, "dy": 0, "tileId": "potOfFlowers" }] },
-    { "label": "Reliquary", "cost": 520, "repReward": 160, "repRequired": 350,
-      "benefit": "A hallowed reliquary that draws pilgrims.", "service": "shrine-relic",
-      "decor": [{ "dx": 0, "dy": 2, "tileId": "largeSign" }, { "dx": -1, "dy": 1, "tileId": "goldChest" }] }
+    {
+      "label": "Votive Candles",
+      "cost": 100,
+      "repReward": 40,
+      "repRequired": 0,
+      "benefit": "A tended, welcoming shrine.",
+      "service": "shrine-blessing"
+    },
+    {
+      "label": "Sacred Brazier",
+      "cost": 240,
+      "repReward": 80,
+      "repRequired": 150,
+      "benefit": "Stronger blessings for travellers.",
+      "service": "shrine-ward"
+    },
+    {
+      "label": "Reliquary",
+      "cost": 520,
+      "repReward": 160,
+      "repRequired": 350,
+      "benefit": "A hallowed reliquary that draws pilgrims.",
+      "service": "shrine-relic"
+    }
   ],
   "default": [
-    { "label": "Tidy Frontage", "cost": 100, "repReward": 35, "repRequired": 0,
-      "benefit": "A cared-for building the town is proud of.", "service": "decor",
-      "decor": [{ "dx": -1, "dy": 0, "tileId": "lightBush" }, { "dx": 1, "dy": 0, "tileId": "lightBush" }] },
-    { "label": "Planters", "cost": 240, "repReward": 70, "repRequired": 120,
-      "benefit": "Greenery that brightens the whole street.", "service": "decor",
-      "decor": [{ "dx": -2, "dy": 0, "tileId": "potOfFlowers" }, { "dx": 2, "dy": 0, "tileId": "potOfFlowers" }] },
-    { "label": "Proud Sign", "cost": 500, "repReward": 140, "repRequired": 300,
-      "benefit": "A landmark frontage known across town.", "service": "decor",
-      "decor": [{ "dx": 0, "dy": 2, "tileId": "largeSign" }, { "dx": -1, "dy": 1, "tileId": "potOfFlowers" }] }
+    {
+      "label": "Tidy Frontage",
+      "cost": 100,
+      "repReward": 35,
+      "repRequired": 0,
+      "benefit": "A cared-for building the town is proud of.",
+      "service": "decor"
+    },
+    {
+      "label": "Planters",
+      "cost": 240,
+      "repReward": 70,
+      "repRequired": 120,
+      "benefit": "Greenery that brightens the whole street.",
+      "service": "decor"
+    },
+    {
+      "label": "Proud Sign",
+      "cost": 500,
+      "repReward": 140,
+      "repRequired": 300,
+      "benefit": "A landmark frontage known across town.",
+      "service": "decor"
+    }
   ]
 }

--- a/web/src/data/hub/buildingUpgrades.ts
+++ b/web/src/data/hub/buildingUpgrades.ts
@@ -3,19 +3,15 @@
 // Shared, data-driven upgrade tracks keyed by building *kind* (shop, inn,
 // cottage, workshop, shrine, tavern, default…). Each town building is tagged
 // with an `upgradeKind` in its config.json; the reputation store reads the
-// matching track here. Decor offsets (`dx`/`dy`) are relative to the building's
-// primary door tile and are revealed once that upgrade level is reached.
+// matching track here for costs, reputation gates and unlocked services.
+//
+// Exterior upgrade decor is no longer placed by these tracks — it is authored
+// per building in each town's config.json (`levelDecor`, with minLevel/hideAtLevel)
+// via the map editor, so placement can be tuned per building.
 //
 // Authored data lives in ./buildingUpgrades.json — edit costs/benefits there.
 
 import raw from './buildingUpgrades.json'
-
-export interface UpgradeDecor {
-  dx: number
-  dy: number
-  /** Constant name from baseChipIndex.ts (resolved by the canvas, not here). */
-  tileId: string
-}
 
 export interface BuildingUpgradeLevel {
   /** Short title for this level (shown in the upgrade panel). */
@@ -30,8 +26,6 @@ export interface BuildingUpgradeLevel {
   benefit: string
   /** Optional service id other systems can read via getTownServiceLevel. */
   service?: string
-  /** Decor revealed at the building's door when this level is reached. */
-  decor?: UpgradeDecor[]
 }
 
 export type UpgradeCatalog = Record<string, BuildingUpgradeLevel[]>

--- a/web/src/data/hub/capitalcity/config.json
+++ b/web/src/data/hub/capitalcity/config.json
@@ -212,6 +212,44 @@
           "hideSign": true,
           "buildingId": "market-hall-crownhaven"
         }
+      ],
+      "levelDecor": [
+        {
+          "tx": 32,
+          "ty": 14,
+          "tileId": "crate",
+          "minLevel": 1
+        },
+        {
+          "tx": 34,
+          "ty": 14,
+          "tileId": "barrel",
+          "minLevel": 1
+        },
+        {
+          "tx": 31,
+          "ty": 14,
+          "tileId": "pileOfSacks",
+          "minLevel": 2
+        },
+        {
+          "tx": 35,
+          "ty": 14,
+          "tileId": "crate",
+          "minLevel": 2
+        },
+        {
+          "tx": 33,
+          "ty": 16,
+          "tileId": "goldSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 32,
+          "ty": 15,
+          "tileId": "goldChest",
+          "minLevel": 3
+        }
       ]
     },
     {
@@ -231,6 +269,44 @@
           "ty": 1,
           "hideSign": true,
           "buildingId": "bakery"
+        }
+      ],
+      "levelDecor": [
+        {
+          "tx": 44,
+          "ty": 14,
+          "tileId": "crate",
+          "minLevel": 1
+        },
+        {
+          "tx": 46,
+          "ty": 14,
+          "tileId": "barrel",
+          "minLevel": 1
+        },
+        {
+          "tx": 43,
+          "ty": 14,
+          "tileId": "pileOfSacks",
+          "minLevel": 2
+        },
+        {
+          "tx": 47,
+          "ty": 14,
+          "tileId": "crate",
+          "minLevel": 2
+        },
+        {
+          "tx": 45,
+          "ty": 16,
+          "tileId": "goldSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 44,
+          "ty": 15,
+          "tileId": "goldChest",
+          "minLevel": 3
         }
       ]
     },
@@ -252,6 +328,44 @@
           "hideSign": true,
           "buildingId": "jeweller"
         }
+      ],
+      "levelDecor": [
+        {
+          "tx": 61,
+          "ty": 14,
+          "tileId": "crate",
+          "minLevel": 1
+        },
+        {
+          "tx": 63,
+          "ty": 14,
+          "tileId": "barrel",
+          "minLevel": 1
+        },
+        {
+          "tx": 60,
+          "ty": 14,
+          "tileId": "pileOfSacks",
+          "minLevel": 2
+        },
+        {
+          "tx": 64,
+          "ty": 14,
+          "tileId": "crate",
+          "minLevel": 2
+        },
+        {
+          "tx": 62,
+          "ty": 16,
+          "tileId": "goldSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 61,
+          "ty": 15,
+          "tileId": "goldChest",
+          "minLevel": 3
+        }
       ]
     },
     {
@@ -271,6 +385,44 @@
           "ty": 1,
           "hideSign": true,
           "buildingId": "tailor"
+        }
+      ],
+      "levelDecor": [
+        {
+          "tx": 72,
+          "ty": 14,
+          "tileId": "crate",
+          "minLevel": 1
+        },
+        {
+          "tx": 74,
+          "ty": 14,
+          "tileId": "barrel",
+          "minLevel": 1
+        },
+        {
+          "tx": 71,
+          "ty": 14,
+          "tileId": "pileOfSacks",
+          "minLevel": 2
+        },
+        {
+          "tx": 75,
+          "ty": 14,
+          "tileId": "crate",
+          "minLevel": 2
+        },
+        {
+          "tx": 73,
+          "ty": 16,
+          "tileId": "goldSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 72,
+          "ty": 15,
+          "tileId": "goldChest",
+          "minLevel": 3
         }
       ]
     },
@@ -292,6 +444,44 @@
           "hideSign": true,
           "buildingId": "cathedral"
         }
+      ],
+      "levelDecor": [
+        {
+          "tx": 15,
+          "ty": 28,
+          "tileId": "floorLantern",
+          "minLevel": 1
+        },
+        {
+          "tx": 17,
+          "ty": 28,
+          "tileId": "floorLantern",
+          "minLevel": 1
+        },
+        {
+          "tx": 14,
+          "ty": 28,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 18,
+          "ty": 28,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 16,
+          "ty": 30,
+          "tileId": "largeSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 15,
+          "ty": 29,
+          "tileId": "goldChest",
+          "minLevel": 3
+        }
       ]
     },
     {
@@ -311,6 +501,44 @@
           "ty": 1,
           "hideSign": true,
           "buildingId": "library"
+        }
+      ],
+      "levelDecor": [
+        {
+          "tx": 30,
+          "ty": 28,
+          "tileId": "lightBush",
+          "minLevel": 1
+        },
+        {
+          "tx": 32,
+          "ty": 28,
+          "tileId": "lightBush",
+          "minLevel": 1
+        },
+        {
+          "tx": 29,
+          "ty": 28,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 33,
+          "ty": 28,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 31,
+          "ty": 30,
+          "tileId": "largeSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 30,
+          "ty": 29,
+          "tileId": "potOfFlowers",
+          "minLevel": 3
         }
       ]
     },
@@ -332,6 +560,44 @@
           "hideSign": true,
           "buildingId": "academy"
         }
+      ],
+      "levelDecor": [
+        {
+          "tx": 47,
+          "ty": 28,
+          "tileId": "lightBush",
+          "minLevel": 1
+        },
+        {
+          "tx": 49,
+          "ty": 28,
+          "tileId": "lightBush",
+          "minLevel": 1
+        },
+        {
+          "tx": 46,
+          "ty": 28,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 50,
+          "ty": 28,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 48,
+          "ty": 30,
+          "tileId": "largeSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 47,
+          "ty": 29,
+          "tileId": "potOfFlowers",
+          "minLevel": 3
+        }
       ]
     },
     {
@@ -351,6 +617,44 @@
           "ty": 1,
           "hideSign": true,
           "buildingId": "grand-inn"
+        }
+      ],
+      "levelDecor": [
+        {
+          "tx": 95,
+          "ty": 28,
+          "tileId": "barrel",
+          "minLevel": 1
+        },
+        {
+          "tx": 97,
+          "ty": 28,
+          "tileId": "barrel",
+          "minLevel": 1
+        },
+        {
+          "tx": 94,
+          "ty": 28,
+          "tileId": "floorLantern",
+          "minLevel": 2
+        },
+        {
+          "tx": 98,
+          "ty": 28,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 96,
+          "ty": 30,
+          "tileId": "innSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 95,
+          "ty": 29,
+          "tileId": "floorLantern",
+          "minLevel": 3
         }
       ]
     },
@@ -372,6 +676,44 @@
           "hideSign": true,
           "buildingId": "apothecary"
         }
+      ],
+      "levelDecor": [
+        {
+          "tx": 13,
+          "ty": 42,
+          "tileId": "crate",
+          "minLevel": 1
+        },
+        {
+          "tx": 15,
+          "ty": 42,
+          "tileId": "barrel",
+          "minLevel": 1
+        },
+        {
+          "tx": 12,
+          "ty": 42,
+          "tileId": "pileOfSacks",
+          "minLevel": 2
+        },
+        {
+          "tx": 16,
+          "ty": 42,
+          "tileId": "crate",
+          "minLevel": 2
+        },
+        {
+          "tx": 14,
+          "ty": 44,
+          "tileId": "goldSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 13,
+          "ty": 43,
+          "tileId": "goldChest",
+          "minLevel": 3
+        }
       ]
     },
     {
@@ -391,6 +733,44 @@
           "ty": 1,
           "hideSign": true,
           "buildingId": "theatre"
+        }
+      ],
+      "levelDecor": [
+        {
+          "tx": 63,
+          "ty": 42,
+          "tileId": "lightBush",
+          "minLevel": 1
+        },
+        {
+          "tx": 65,
+          "ty": 42,
+          "tileId": "lightBush",
+          "minLevel": 1
+        },
+        {
+          "tx": 62,
+          "ty": 42,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 66,
+          "ty": 42,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 64,
+          "ty": 44,
+          "tileId": "largeSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 63,
+          "ty": 43,
+          "tileId": "potOfFlowers",
+          "minLevel": 3
         }
       ]
     },
@@ -412,6 +792,44 @@
           "hideSign": true,
           "buildingId": "noble-manor-1"
         }
+      ],
+      "levelDecor": [
+        {
+          "tx": 94,
+          "ty": 42,
+          "tileId": "pinkFlower",
+          "minLevel": 1
+        },
+        {
+          "tx": 96,
+          "ty": 42,
+          "tileId": "blueFlower",
+          "minLevel": 1
+        },
+        {
+          "tx": 93,
+          "ty": 42,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 97,
+          "ty": 42,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 95,
+          "ty": 44,
+          "tileId": "floorLantern",
+          "minLevel": 3
+        },
+        {
+          "tx": 96,
+          "ty": 43,
+          "tileId": "potOfFlowers",
+          "minLevel": 3
+        }
       ]
     },
     {
@@ -431,6 +849,44 @@
           "ty": 1,
           "hideSign": true,
           "buildingId": "blacksmith"
+        }
+      ],
+      "levelDecor": [
+        {
+          "tx": 13,
+          "ty": 64,
+          "tileId": "crate",
+          "minLevel": 1
+        },
+        {
+          "tx": 15,
+          "ty": 64,
+          "tileId": "crate",
+          "minLevel": 1
+        },
+        {
+          "tx": 12,
+          "ty": 64,
+          "tileId": "chest",
+          "minLevel": 2
+        },
+        {
+          "tx": 16,
+          "ty": 64,
+          "tileId": "barrel",
+          "minLevel": 2
+        },
+        {
+          "tx": 14,
+          "ty": 66,
+          "tileId": "armourSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 13,
+          "ty": 65,
+          "tileId": "chest",
+          "minLevel": 3
         }
       ]
     },
@@ -452,6 +908,44 @@
           "hideSign": true,
           "buildingId": "senate"
         }
+      ],
+      "levelDecor": [
+        {
+          "tx": 47,
+          "ty": 64,
+          "tileId": "lightBush",
+          "minLevel": 1
+        },
+        {
+          "tx": 49,
+          "ty": 64,
+          "tileId": "lightBush",
+          "minLevel": 1
+        },
+        {
+          "tx": 46,
+          "ty": 64,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 50,
+          "ty": 64,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 48,
+          "ty": 66,
+          "tileId": "largeSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 47,
+          "ty": 65,
+          "tileId": "potOfFlowers",
+          "minLevel": 3
+        }
       ]
     },
     {
@@ -471,6 +965,44 @@
           "ty": 1,
           "hideSign": true,
           "buildingId": "noble-manor-2"
+        }
+      ],
+      "levelDecor": [
+        {
+          "tx": 94,
+          "ty": 64,
+          "tileId": "pinkFlower",
+          "minLevel": 1
+        },
+        {
+          "tx": 96,
+          "ty": 64,
+          "tileId": "blueFlower",
+          "minLevel": 1
+        },
+        {
+          "tx": 93,
+          "ty": 64,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 97,
+          "ty": 64,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 95,
+          "ty": 66,
+          "tileId": "floorLantern",
+          "minLevel": 3
+        },
+        {
+          "tx": 96,
+          "ty": 65,
+          "tileId": "potOfFlowers",
+          "minLevel": 3
         }
       ]
     },
@@ -492,6 +1024,44 @@
           "hideSign": true,
           "buildingId": "grand-bank"
         }
+      ],
+      "levelDecor": [
+        {
+          "tx": 62,
+          "ty": 80,
+          "tileId": "crate",
+          "minLevel": 1
+        },
+        {
+          "tx": 64,
+          "ty": 80,
+          "tileId": "barrel",
+          "minLevel": 1
+        },
+        {
+          "tx": 61,
+          "ty": 80,
+          "tileId": "pileOfSacks",
+          "minLevel": 2
+        },
+        {
+          "tx": 65,
+          "ty": 80,
+          "tileId": "crate",
+          "minLevel": 2
+        },
+        {
+          "tx": 63,
+          "ty": 82,
+          "tileId": "goldSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 62,
+          "ty": 81,
+          "tileId": "goldChest",
+          "minLevel": 3
+        }
       ]
     },
     {
@@ -512,6 +1082,44 @@
           "hideSign": true,
           "buildingId": "royal-mint"
         }
+      ],
+      "levelDecor": [
+        {
+          "tx": 74,
+          "ty": 80,
+          "tileId": "crate",
+          "minLevel": 1
+        },
+        {
+          "tx": 76,
+          "ty": 80,
+          "tileId": "crate",
+          "minLevel": 1
+        },
+        {
+          "tx": 73,
+          "ty": 80,
+          "tileId": "chest",
+          "minLevel": 2
+        },
+        {
+          "tx": 77,
+          "ty": 80,
+          "tileId": "barrel",
+          "minLevel": 2
+        },
+        {
+          "tx": 75,
+          "ty": 82,
+          "tileId": "armourSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 74,
+          "ty": 81,
+          "tileId": "chest",
+          "minLevel": 3
+        }
       ]
     },
     {
@@ -531,6 +1139,44 @@
           "ty": 1,
           "hideSign": true,
           "buildingId": "guardhouse"
+        }
+      ],
+      "levelDecor": [
+        {
+          "tx": 95,
+          "ty": 80,
+          "tileId": "crate",
+          "minLevel": 1
+        },
+        {
+          "tx": 97,
+          "ty": 80,
+          "tileId": "crate",
+          "minLevel": 1
+        },
+        {
+          "tx": 94,
+          "ty": 80,
+          "tileId": "chest",
+          "minLevel": 2
+        },
+        {
+          "tx": 98,
+          "ty": 80,
+          "tileId": "barrel",
+          "minLevel": 2
+        },
+        {
+          "tx": 96,
+          "ty": 82,
+          "tileId": "armourSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 95,
+          "ty": 81,
+          "tileId": "chest",
+          "minLevel": 3
         }
       ]
     }
@@ -1145,7 +1791,7 @@
       ]
     },
     "grand-inn-upstairs": {
-      "name": "The Gilded Goose \u2014 Rooms",
+      "name": "The Gilded Goose — Rooms",
       "width": 14,
       "height": 9,
       "floorTileId": "woodFloor",
@@ -3073,7 +3719,7 @@
       "tx": 5,
       "ty": 3,
       "dialogue": [
-        "Crownhaven watch. State your business \u2014 or don't, you look harmless enough.",
+        "Crownhaven watch. State your business — or don't, you look harmless enough.",
         "The old postern gate key went missing on patrol. If it falls into the wrong hands, the palace will have my head.",
         "Keep your nose clean in my city, traveller."
       ],
@@ -3192,7 +3838,7 @@
       "dialogue": [
         "Forty years I've run this market. Kings come and go; turnips are forever.",
         "You want gossip, try the inn. You want a fair price, you talk to me.",
-        "Mind the fountain \u2014 the pigeons have opinions."
+        "Mind the fountain — the pigeons have opinions."
       ],
       "questGive": "crownhaven-market-day",
       "questReceive": [
@@ -3367,7 +4013,7 @@
       "dialogue": [
         "Every coin in the realm starts its life right here, under my hammer.",
         "Lose a mint die and you may as well hand a forger the keys to the treasury.",
-        "Gold is heavy for a reason \u2014 it keeps honest folk grounded."
+        "Gold is heavy for a reason — it keeps honest folk grounded."
       ],
       "questGive": "crownhaven-mint-dies",
       "questReceive": "crownhaven-mint-dies",
@@ -3422,7 +4068,7 @@
       "dialogue": [
         "The Grand Bank of Crownhaven. Your crystals are safer here than in the palace itself.",
         "A noble's debt is a delicate thing. Discretion is half my trade.",
-        "Vault's sealed tight \u2014 only the watch and I hold a key."
+        "Vault's sealed tight — only the watch and I hold a key."
       ],
       "questGive": "crownhaven-stolen-coin",
       "questReceive": [
@@ -3534,7 +4180,7 @@
       "tx": 4,
       "ty": 3,
       "dialogue": [
-        "Diamonds, sapphires, the crown's own regalia \u2014 all pass across my bench.",
+        "Diamonds, sapphires, the crown's own regalia — all pass across my bench.",
         "Raw gems are dull little pebbles until I coax the fire out of them.",
         "Careful where you tread; I've dropped stones worth more than your boots."
       ],
@@ -3765,7 +4411,7 @@
       "dialogue": [
         "Old Town remembers when Crownhaven was but a fort on a hill. I remember it too.",
         "My family's locket was lost in the gardens. It is all I have of my mother.",
-        "Debts and lockets \u2014 a noblewoman's life is keeping track of what she's misplaced."
+        "Debts and lockets — a noblewoman's life is keeping track of what she's misplaced."
       ],
       "questGive": "crownhaven-lost-locket",
       "questReceive": "crownhaven-lost-locket",
@@ -3921,7 +4567,7 @@
       "tx": 60,
       "ty": 47,
       "dialogue": [
-        "Hear ye! By order of the Chancellor \u2014 mind the proclamations.",
+        "Hear ye! By order of the Chancellor — mind the proclamations.",
         "Lost half my scrolls to the wind. A herald with no words is just a loud nuisance.",
         "Stand for the crown, traveller. The capital is watching."
       ],
@@ -4087,7 +4733,7 @@
       "screen": "casino",
       "dialogue": [
         "Care for a flutter? The capital's tables never close.",
-        "Fortune favours the bold \u2014 and occasionally the lucky.",
+        "Fortune favours the bold — and occasionally the lucky.",
         "Crowns won, crowns lost. Pull up a chair."
       ]
     },
@@ -4099,7 +4745,7 @@
       "ty": 81,
       "screen": "crystalcatch",
       "dialogue": [
-        "Quick hands at the mint? Test them \u2014 catch the falling crystals.",
+        "Quick hands at the mint? Test them — catch the falling crystals.",
         "Every coin starts as a tumble of raw crystal. Catch what you can.",
         "Sharp eyes, sharp reflexes, full purse."
       ]
@@ -4113,7 +4759,7 @@
       "screen": "quickbattle",
       "dialogue": [
         "The coronation tournament wants challengers. Step into the ring?",
-        "A quick battle to prove your mettle \u2014 no excuses.",
+        "A quick battle to prove your mettle — no excuses.",
         "Win in the arena and the whole capital hears your name."
       ]
     },
@@ -4137,7 +4783,7 @@
       "tx": 60,
       "ty": 43,
       "dialogue": [
-        "The Crown Theatre will dazzle the realm \u2014 once the stage is ready.",
+        "The Crown Theatre will dazzle the realm — once the stage is ready.",
         "Rehearsals, ropes, and a thousand candles. Come back for the grand premiere!",
         "A performance worthy of a coronation takes time. Patience, friend."
       ]
@@ -4145,7 +4791,7 @@
   ],
   "exteriorDecor": [
     {
-      "comment": "Coronation Plaza \u2014 grand fountain & monuments"
+      "comment": "Coronation Plaza — grand fountain & monuments"
     },
     {
       "tx": 56,
@@ -4828,7 +5474,7 @@
       "tileId": "lampPostBottom"
     },
     {
-      "comment": "Grand Market \u2014 stalls & wares"
+      "comment": "Grand Market — stalls & wares"
     },
     {
       "tx": 28,
@@ -5095,7 +5741,7 @@
       "tileId": "leafBasket"
     },
     {
-      "comment": "Temple Quarter \u2014 graves, candles & greenery"
+      "comment": "Temple Quarter — graves, candles & greenery"
     },
     {
       "tx": 6,
@@ -5177,7 +5823,7 @@
       "tileId": "stoneWell"
     },
     {
-      "comment": "Old Town \u2014 manor gardens & lamps"
+      "comment": "Old Town — manor gardens & lamps"
     },
     {
       "tx": 86,
@@ -5286,7 +5932,7 @@
       "tileId": "washingLineClothesBottomLeft"
     },
     {
-      "comment": "Guard Quarter \u2014 braziers, walls & banners"
+      "comment": "Guard Quarter — braziers, walls & banners"
     },
     {
       "tx": 88,
@@ -5506,7 +6152,7 @@
       "zlayer": "above"
     },
     {
-      "comment": "Riverside \u2014 pond edge, reeds & gardens"
+      "comment": "Riverside — pond edge, reeds & gardens"
     },
     {
       "tx": 12,
@@ -5773,7 +6419,7 @@
       "tileId": "potOfFlowers"
     },
     {
-      "comment": "South gate \u2014 road sign & approach"
+      "comment": "South gate — road sign & approach"
     },
     {
       "tx": 52,

--- a/web/src/data/hub/config.ts
+++ b/web/src/data/hub/config.ts
@@ -45,6 +45,8 @@ export interface RawDecor {
   glow?: boolean        // emit a night light glow (reuses the night overlay)
   glowRadius?: number   // glow radius in tiles
   pulse?: boolean       // animate the glow radius
+  minLevel?: number     // building upgrade level at which this item first appears (0/undefined = base)
+  hideAtLevel?: number  // building upgrade level at which this item disappears (undefined = never)
 }
 
 export interface RawCoordinate {  tx: number
@@ -61,9 +63,22 @@ export interface BaseBuilding {
   /** Upgrade track key (buildingUpgrades.json). Tags the building as upgradeable. */
   upgradeKind?: string
 
+  /** Highest upgrade level this building can reach (defaults to its track length). */
+  maxLevel?: number
+
   doors?: RawDoor[]
   windows?: RawWindow[]
   decor?: RawDecor[]
+
+  /** Per-building exterior decor revealed/retired by upgrade level (absolute tx/ty). */
+  levelDecor?: RawDecor[]
+
+  /**
+   * Per-level visual overrides. As the building is upgraded, the highest entry
+   * whose `minLevel <= currentLevel` replaces the base footprint/wall/roof.
+   * Omitted fields inherit from the base building.
+   */
+  levelVisuals?: Array<{ minLevel: number; rect?: RawTileRectCoord['rect']; wall?: string; roof?: string }>
 }
 
 export interface RawBuildingRect extends BaseBuilding {
@@ -168,6 +183,11 @@ export interface RawNpc {
   }>
 
   isGhost?: boolean
+
+  minLevel?: number        // building upgrade level at which this NPC first appears (0/undefined = always)
+  hideAtLevel?: number     // building upgrade level at which this NPC disappears (undefined = never)
+  /** For exterior NPCs: id of the building whose upgrade level gates this NPC's visibility. */
+  levelBuildingId?: string
 
   schedule?: RawNpcScheduleEntry[]
 

--- a/web/src/data/hub/gearford/config.json
+++ b/web/src/data/hub/gearford/config.json
@@ -202,6 +202,44 @@
           "hideSign": true,
           "buildingId": "foundry"
         }
+      ],
+      "levelDecor": [
+        {
+          "tx": 6,
+          "ty": 10,
+          "tileId": "crate",
+          "minLevel": 1
+        },
+        {
+          "tx": 8,
+          "ty": 10,
+          "tileId": "crate",
+          "minLevel": 1
+        },
+        {
+          "tx": 5,
+          "ty": 10,
+          "tileId": "chest",
+          "minLevel": 2
+        },
+        {
+          "tx": 9,
+          "ty": 10,
+          "tileId": "barrel",
+          "minLevel": 2
+        },
+        {
+          "tx": 7,
+          "ty": 12,
+          "tileId": "armourSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 6,
+          "ty": 11,
+          "tileId": "chest",
+          "minLevel": 3
+        }
       ]
     },
     {
@@ -221,6 +259,44 @@
           "ty": 1,
           "hideSign": true,
           "buildingId": "coal-yard-store"
+        }
+      ],
+      "levelDecor": [
+        {
+          "tx": 16,
+          "ty": 10,
+          "tileId": "lightBush",
+          "minLevel": 1
+        },
+        {
+          "tx": 18,
+          "ty": 10,
+          "tileId": "lightBush",
+          "minLevel": 1
+        },
+        {
+          "tx": 15,
+          "ty": 10,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 19,
+          "ty": 10,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 17,
+          "ty": 12,
+          "tileId": "largeSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 16,
+          "ty": 11,
+          "tileId": "potOfFlowers",
+          "minLevel": 3
         }
       ]
     },
@@ -242,6 +318,44 @@
           "hideSign": true,
           "buildingId": "machine-workshop"
         }
+      ],
+      "levelDecor": [
+        {
+          "tx": 28,
+          "ty": 10,
+          "tileId": "crate",
+          "minLevel": 1
+        },
+        {
+          "tx": 30,
+          "ty": 10,
+          "tileId": "crate",
+          "minLevel": 1
+        },
+        {
+          "tx": 27,
+          "ty": 10,
+          "tileId": "chest",
+          "minLevel": 2
+        },
+        {
+          "tx": 31,
+          "ty": 10,
+          "tileId": "barrel",
+          "minLevel": 2
+        },
+        {
+          "tx": 29,
+          "ty": 12,
+          "tileId": "armourSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 28,
+          "ty": 11,
+          "tileId": "chest",
+          "minLevel": 3
+        }
       ]
     },
     {
@@ -261,6 +375,44 @@
           "ty": 1,
           "hideSign": true,
           "buildingId": "gearwright-hall"
+        }
+      ],
+      "levelDecor": [
+        {
+          "tx": 39,
+          "ty": 10,
+          "tileId": "crate",
+          "minLevel": 1
+        },
+        {
+          "tx": 41,
+          "ty": 10,
+          "tileId": "crate",
+          "minLevel": 1
+        },
+        {
+          "tx": 38,
+          "ty": 10,
+          "tileId": "chest",
+          "minLevel": 2
+        },
+        {
+          "tx": 42,
+          "ty": 10,
+          "tileId": "barrel",
+          "minLevel": 2
+        },
+        {
+          "tx": 40,
+          "ty": 12,
+          "tileId": "armourSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 39,
+          "ty": 11,
+          "tileId": "chest",
+          "minLevel": 3
         }
       ]
     },
@@ -282,6 +434,44 @@
           "hideSign": true,
           "buildingId": "miners-inn"
         }
+      ],
+      "levelDecor": [
+        {
+          "tx": 5,
+          "ty": 23,
+          "tileId": "barrel",
+          "minLevel": 1
+        },
+        {
+          "tx": 7,
+          "ty": 23,
+          "tileId": "barrel",
+          "minLevel": 1
+        },
+        {
+          "tx": 4,
+          "ty": 23,
+          "tileId": "floorLantern",
+          "minLevel": 2
+        },
+        {
+          "tx": 8,
+          "ty": 23,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 6,
+          "ty": 25,
+          "tileId": "innSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 5,
+          "ty": 24,
+          "tileId": "floorLantern",
+          "minLevel": 3
+        }
       ]
     },
     {
@@ -301,6 +491,44 @@
           "ty": 1,
           "hideSign": true,
           "buildingId": "tool-shop"
+        }
+      ],
+      "levelDecor": [
+        {
+          "tx": 15,
+          "ty": 23,
+          "tileId": "crate",
+          "minLevel": 1
+        },
+        {
+          "tx": 17,
+          "ty": 23,
+          "tileId": "barrel",
+          "minLevel": 1
+        },
+        {
+          "tx": 14,
+          "ty": 23,
+          "tileId": "pileOfSacks",
+          "minLevel": 2
+        },
+        {
+          "tx": 18,
+          "ty": 23,
+          "tileId": "crate",
+          "minLevel": 2
+        },
+        {
+          "tx": 16,
+          "ty": 25,
+          "tileId": "goldSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 15,
+          "ty": 24,
+          "tileId": "goldChest",
+          "minLevel": 3
         }
       ]
     },
@@ -322,6 +550,44 @@
           "hideSign": true,
           "buildingId": "warehouse"
         }
+      ],
+      "levelDecor": [
+        {
+          "tx": 28,
+          "ty": 23,
+          "tileId": "lightBush",
+          "minLevel": 1
+        },
+        {
+          "tx": 30,
+          "ty": 23,
+          "tileId": "lightBush",
+          "minLevel": 1
+        },
+        {
+          "tx": 27,
+          "ty": 23,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 31,
+          "ty": 23,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 29,
+          "ty": 25,
+          "tileId": "largeSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 28,
+          "ty": 24,
+          "tileId": "potOfFlowers",
+          "minLevel": 3
+        }
       ]
     },
     {
@@ -341,6 +607,44 @@
           "ty": 1,
           "hideSign": true,
           "buildingId": "mine-entrance"
+        }
+      ],
+      "levelDecor": [
+        {
+          "tx": 39,
+          "ty": 23,
+          "tileId": "lightBush",
+          "minLevel": 1
+        },
+        {
+          "tx": 41,
+          "ty": 23,
+          "tileId": "lightBush",
+          "minLevel": 1
+        },
+        {
+          "tx": 38,
+          "ty": 23,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 42,
+          "ty": 23,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 40,
+          "ty": 25,
+          "tileId": "largeSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 39,
+          "ty": 24,
+          "tileId": "potOfFlowers",
+          "minLevel": 3
         }
       ]
     },
@@ -362,6 +666,44 @@
           "hideSign": true,
           "buildingId": "pump-house"
         }
+      ],
+      "levelDecor": [
+        {
+          "tx": 27,
+          "ty": 32,
+          "tileId": "lightBush",
+          "minLevel": 1
+        },
+        {
+          "tx": 29,
+          "ty": 32,
+          "tileId": "lightBush",
+          "minLevel": 1
+        },
+        {
+          "tx": 26,
+          "ty": 32,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 30,
+          "ty": 32,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 28,
+          "ty": 34,
+          "tileId": "largeSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 27,
+          "ty": 33,
+          "tileId": "potOfFlowers",
+          "minLevel": 3
+        }
       ]
     },
     {
@@ -381,6 +723,44 @@
           "ty": 1,
           "hideSign": true,
           "buildingId": "worker-house-1"
+        }
+      ],
+      "levelDecor": [
+        {
+          "tx": 5,
+          "ty": 32,
+          "tileId": "pinkFlower",
+          "minLevel": 1
+        },
+        {
+          "tx": 7,
+          "ty": 32,
+          "tileId": "blueFlower",
+          "minLevel": 1
+        },
+        {
+          "tx": 4,
+          "ty": 32,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 8,
+          "ty": 32,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 6,
+          "ty": 34,
+          "tileId": "floorLantern",
+          "minLevel": 3
+        },
+        {
+          "tx": 7,
+          "ty": 33,
+          "tileId": "potOfFlowers",
+          "minLevel": 3
         }
       ]
     },
@@ -402,6 +782,44 @@
           "hideSign": true,
           "buildingId": "worker-house-2"
         }
+      ],
+      "levelDecor": [
+        {
+          "tx": 14,
+          "ty": 32,
+          "tileId": "pinkFlower",
+          "minLevel": 1
+        },
+        {
+          "tx": 16,
+          "ty": 32,
+          "tileId": "blueFlower",
+          "minLevel": 1
+        },
+        {
+          "tx": 13,
+          "ty": 32,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 17,
+          "ty": 32,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 15,
+          "ty": 34,
+          "tileId": "floorLantern",
+          "minLevel": 3
+        },
+        {
+          "tx": 16,
+          "ty": 33,
+          "tileId": "potOfFlowers",
+          "minLevel": 3
+        }
       ]
     },
     {
@@ -421,6 +839,44 @@
           "ty": 1,
           "hideSign": true,
           "buildingId": "gear-shop"
+        }
+      ],
+      "levelDecor": [
+        {
+          "tx": 36,
+          "ty": 32,
+          "tileId": "crate",
+          "minLevel": 1
+        },
+        {
+          "tx": 38,
+          "ty": 32,
+          "tileId": "barrel",
+          "minLevel": 1
+        },
+        {
+          "tx": 35,
+          "ty": 32,
+          "tileId": "pileOfSacks",
+          "minLevel": 2
+        },
+        {
+          "tx": 39,
+          "ty": 32,
+          "tileId": "crate",
+          "minLevel": 2
+        },
+        {
+          "tx": 37,
+          "ty": 34,
+          "tileId": "goldSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 36,
+          "ty": 33,
+          "tileId": "goldChest",
+          "minLevel": 3
         }
       ]
     }
@@ -1457,7 +1913,7 @@
       "ty": 12,
       "dialogue": [
         "Coal in, slag out, all day long. My back's a clockwork of aches by sundown.",
-        "The old depot south of town's still half-full. Nobody hauls it \u2014 too lazy, too scared.",
+        "The old depot south of town's still half-full. Nobody hauls it — too lazy, too scared.",
         "A full barrow and an empty road. That's all a hauler wants out of life."
       ],
       "schedule": [
@@ -2363,7 +2819,7 @@
       ]
     },
     "miners-inn-bunkrooms": {
-      "name": "The Pickaxe Rest \u2014 Bunkrooms",
+      "name": "The Pickaxe Rest — Bunkrooms",
       "width": 12,
       "height": 9,
       "floorTileId": "woodFloor",

--- a/web/src/data/hub/gravemoor/config.json
+++ b/web/src/data/hub/gravemoor/config.json
@@ -183,6 +183,44 @@
           "hideSign": true,
           "buildingId": "mourning-hall"
         }
+      ],
+      "levelDecor": [
+        {
+          "tx": 7,
+          "ty": 10,
+          "tileId": "floorLantern",
+          "minLevel": 1
+        },
+        {
+          "tx": 9,
+          "ty": 10,
+          "tileId": "floorLantern",
+          "minLevel": 1
+        },
+        {
+          "tx": 6,
+          "ty": 10,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 10,
+          "ty": 10,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 8,
+          "ty": 12,
+          "tileId": "largeSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 7,
+          "ty": 11,
+          "tileId": "goldChest",
+          "minLevel": 3
+        }
       ]
     },
     {
@@ -202,6 +240,44 @@
           "ty": 1,
           "hideSign": true,
           "buildingId": "crypt-keep"
+        }
+      ],
+      "levelDecor": [
+        {
+          "tx": 21,
+          "ty": 10,
+          "tileId": "lightBush",
+          "minLevel": 1
+        },
+        {
+          "tx": 23,
+          "ty": 10,
+          "tileId": "lightBush",
+          "minLevel": 1
+        },
+        {
+          "tx": 20,
+          "ty": 10,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 24,
+          "ty": 10,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 22,
+          "ty": 12,
+          "tileId": "largeSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 21,
+          "ty": 11,
+          "tileId": "potOfFlowers",
+          "minLevel": 3
         }
       ]
     },
@@ -223,6 +299,44 @@
           "hideSign": true,
           "buildingId": "gravedigger-shed"
         }
+      ],
+      "levelDecor": [
+        {
+          "tx": 30,
+          "ty": 10,
+          "tileId": "lightBush",
+          "minLevel": 1
+        },
+        {
+          "tx": 32,
+          "ty": 10,
+          "tileId": "lightBush",
+          "minLevel": 1
+        },
+        {
+          "tx": 29,
+          "ty": 10,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 33,
+          "ty": 10,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 31,
+          "ty": 12,
+          "tileId": "largeSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 30,
+          "ty": 11,
+          "tileId": "potOfFlowers",
+          "minLevel": 3
+        }
       ]
     },
     {
@@ -242,6 +356,44 @@
           "ty": 1,
           "hideSign": true,
           "buildingId": "undertaker"
+        }
+      ],
+      "levelDecor": [
+        {
+          "tx": 5,
+          "ty": 26,
+          "tileId": "crate",
+          "minLevel": 1
+        },
+        {
+          "tx": 7,
+          "ty": 26,
+          "tileId": "barrel",
+          "minLevel": 1
+        },
+        {
+          "tx": 4,
+          "ty": 26,
+          "tileId": "pileOfSacks",
+          "minLevel": 2
+        },
+        {
+          "tx": 8,
+          "ty": 26,
+          "tileId": "crate",
+          "minLevel": 2
+        },
+        {
+          "tx": 6,
+          "ty": 28,
+          "tileId": "goldSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 5,
+          "ty": 27,
+          "tileId": "goldChest",
+          "minLevel": 3
         }
       ]
     },
@@ -263,6 +415,44 @@
           "hideSign": true,
           "buildingId": "mausoleum-chapel"
         }
+      ],
+      "levelDecor": [
+        {
+          "tx": 21,
+          "ty": 26,
+          "tileId": "floorLantern",
+          "minLevel": 1
+        },
+        {
+          "tx": 23,
+          "ty": 26,
+          "tileId": "floorLantern",
+          "minLevel": 1
+        },
+        {
+          "tx": 20,
+          "ty": 26,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 24,
+          "ty": 26,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 22,
+          "ty": 28,
+          "tileId": "largeSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 21,
+          "ty": 27,
+          "tileId": "goldChest",
+          "minLevel": 3
+        }
       ]
     },
     {
@@ -283,6 +473,44 @@
           "hideSign": true,
           "buildingId": "ruined-town-hall"
         }
+      ],
+      "levelDecor": [
+        {
+          "tx": 29,
+          "ty": 26,
+          "tileId": "lightBush",
+          "minLevel": 1
+        },
+        {
+          "tx": 31,
+          "ty": 26,
+          "tileId": "lightBush",
+          "minLevel": 1
+        },
+        {
+          "tx": 28,
+          "ty": 26,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 32,
+          "ty": 26,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 30,
+          "ty": 28,
+          "tileId": "largeSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 29,
+          "ty": 27,
+          "tileId": "potOfFlowers",
+          "minLevel": 3
+        }
       ]
     },
     {
@@ -302,6 +530,44 @@
           "ty": 1,
           "hideSign": true,
           "buildingId": "haunted-inn"
+        }
+      ],
+      "levelDecor": [
+        {
+          "tx": 37,
+          "ty": 26,
+          "tileId": "barrel",
+          "minLevel": 1
+        },
+        {
+          "tx": 39,
+          "ty": 26,
+          "tileId": "barrel",
+          "minLevel": 1
+        },
+        {
+          "tx": 36,
+          "ty": 26,
+          "tileId": "floorLantern",
+          "minLevel": 2
+        },
+        {
+          "tx": 40,
+          "ty": 26,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 38,
+          "ty": 28,
+          "tileId": "innSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 37,
+          "ty": 27,
+          "tileId": "floorLantern",
+          "minLevel": 3
         }
       ]
     }

--- a/web/src/data/hub/harrowfield/config.json
+++ b/web/src/data/hub/harrowfield/config.json
@@ -170,6 +170,44 @@
           "hideSign": true,
           "buildingId": "farmhouse"
         }
+      ],
+      "levelDecor": [
+        {
+          "tx": 5,
+          "ty": 9,
+          "tileId": "pinkFlower",
+          "minLevel": 1
+        },
+        {
+          "tx": 7,
+          "ty": 9,
+          "tileId": "blueFlower",
+          "minLevel": 1
+        },
+        {
+          "tx": 4,
+          "ty": 9,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 8,
+          "ty": 9,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 6,
+          "ty": 11,
+          "tileId": "floorLantern",
+          "minLevel": 3
+        },
+        {
+          "tx": 7,
+          "ty": 10,
+          "tileId": "potOfFlowers",
+          "minLevel": 3
+        }
       ]
     },
     {
@@ -189,6 +227,44 @@
           "ty": 1,
           "hideSign": true,
           "buildingId": "chapel"
+        }
+      ],
+      "levelDecor": [
+        {
+          "tx": 13,
+          "ty": 9,
+          "tileId": "floorLantern",
+          "minLevel": 1
+        },
+        {
+          "tx": 15,
+          "ty": 9,
+          "tileId": "floorLantern",
+          "minLevel": 1
+        },
+        {
+          "tx": 12,
+          "ty": 9,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 16,
+          "ty": 9,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 14,
+          "ty": 11,
+          "tileId": "largeSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 13,
+          "ty": 10,
+          "tileId": "goldChest",
+          "minLevel": 3
         }
       ]
     },
@@ -210,6 +286,44 @@
           "hideSign": true,
           "buildingId": "village-hall"
         }
+      ],
+      "levelDecor": [
+        {
+          "tx": 23,
+          "ty": 9,
+          "tileId": "lightBush",
+          "minLevel": 1
+        },
+        {
+          "tx": 25,
+          "ty": 9,
+          "tileId": "lightBush",
+          "minLevel": 1
+        },
+        {
+          "tx": 22,
+          "ty": 9,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 26,
+          "ty": 9,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 24,
+          "ty": 11,
+          "tileId": "largeSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 23,
+          "ty": 10,
+          "tileId": "potOfFlowers",
+          "minLevel": 3
+        }
       ]
     },
     {
@@ -229,6 +343,44 @@
           "ty": 1,
           "hideSign": true,
           "buildingId": "granary"
+        }
+      ],
+      "levelDecor": [
+        {
+          "tx": 31,
+          "ty": 9,
+          "tileId": "crate",
+          "minLevel": 1
+        },
+        {
+          "tx": 33,
+          "ty": 9,
+          "tileId": "crate",
+          "minLevel": 1
+        },
+        {
+          "tx": 30,
+          "ty": 9,
+          "tileId": "chest",
+          "minLevel": 2
+        },
+        {
+          "tx": 34,
+          "ty": 9,
+          "tileId": "barrel",
+          "minLevel": 2
+        },
+        {
+          "tx": 32,
+          "ty": 11,
+          "tileId": "armourSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 31,
+          "ty": 10,
+          "tileId": "chest",
+          "minLevel": 3
         }
       ]
     },
@@ -250,6 +402,44 @@
           "hideSign": true,
           "buildingId": "barn"
         }
+      ],
+      "levelDecor": [
+        {
+          "tx": 5,
+          "ty": 19,
+          "tileId": "crate",
+          "minLevel": 1
+        },
+        {
+          "tx": 7,
+          "ty": 19,
+          "tileId": "crate",
+          "minLevel": 1
+        },
+        {
+          "tx": 4,
+          "ty": 19,
+          "tileId": "chest",
+          "minLevel": 2
+        },
+        {
+          "tx": 8,
+          "ty": 19,
+          "tileId": "barrel",
+          "minLevel": 2
+        },
+        {
+          "tx": 6,
+          "ty": 21,
+          "tileId": "armourSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 5,
+          "ty": 20,
+          "tileId": "chest",
+          "minLevel": 3
+        }
       ]
     },
     {
@@ -269,6 +459,44 @@
           "ty": 1,
           "hideSign": true,
           "buildingId": "windmill"
+        }
+      ],
+      "levelDecor": [
+        {
+          "tx": 13,
+          "ty": 19,
+          "tileId": "crate",
+          "minLevel": 1
+        },
+        {
+          "tx": 15,
+          "ty": 19,
+          "tileId": "crate",
+          "minLevel": 1
+        },
+        {
+          "tx": 12,
+          "ty": 19,
+          "tileId": "chest",
+          "minLevel": 2
+        },
+        {
+          "tx": 16,
+          "ty": 19,
+          "tileId": "barrel",
+          "minLevel": 2
+        },
+        {
+          "tx": 14,
+          "ty": 21,
+          "tileId": "armourSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 13,
+          "ty": 20,
+          "tileId": "chest",
+          "minLevel": 3
         }
       ]
     },
@@ -290,6 +518,44 @@
           "hideSign": true,
           "buildingId": "mill-cottage"
         }
+      ],
+      "levelDecor": [
+        {
+          "tx": 23,
+          "ty": 19,
+          "tileId": "pinkFlower",
+          "minLevel": 1
+        },
+        {
+          "tx": 25,
+          "ty": 19,
+          "tileId": "blueFlower",
+          "minLevel": 1
+        },
+        {
+          "tx": 22,
+          "ty": 19,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 26,
+          "ty": 19,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 24,
+          "ty": 21,
+          "tileId": "floorLantern",
+          "minLevel": 3
+        },
+        {
+          "tx": 25,
+          "ty": 20,
+          "tileId": "potOfFlowers",
+          "minLevel": 3
+        }
       ]
     },
     {
@@ -309,6 +575,44 @@
           "ty": 1,
           "hideSign": true,
           "buildingId": "market-shed"
+        }
+      ],
+      "levelDecor": [
+        {
+          "tx": 31,
+          "ty": 19,
+          "tileId": "crate",
+          "minLevel": 1
+        },
+        {
+          "tx": 33,
+          "ty": 19,
+          "tileId": "barrel",
+          "minLevel": 1
+        },
+        {
+          "tx": 30,
+          "ty": 19,
+          "tileId": "pileOfSacks",
+          "minLevel": 2
+        },
+        {
+          "tx": 34,
+          "ty": 19,
+          "tileId": "crate",
+          "minLevel": 2
+        },
+        {
+          "tx": 32,
+          "ty": 21,
+          "tileId": "goldSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 31,
+          "ty": 20,
+          "tileId": "goldChest",
+          "minLevel": 3
         }
       ]
     }

--- a/web/src/data/hub/hollowmere/config.json
+++ b/web/src/data/hub/hollowmere/config.json
@@ -3,205 +3,1088 @@
   "mapH": 960,
   "townName": "Hollowmere",
   "environment": "ruins",
-  "avatarStart": { "tx": 13, "ty": 17 },
+  "avatarStart": {
+    "tx": 13,
+    "ty": 17
+  },
   "exitTiles": [
-    { "tx": 10, "ty": 18, "screen": "worldmap" },
-    { "tx": 11, "ty": 18, "screen": "worldmap" }
+    {
+      "tx": 10,
+      "ty": 18,
+      "screen": "worldmap"
+    },
+    {
+      "tx": 11,
+      "ty": 18,
+      "screen": "worldmap"
+    }
   ],
   "areas": [
-    { "id": "hollowmere-hollow", "name": "The Hollow", "tx": 7, "ty": 10, "tw": 12, "th": 6 },
-    { "id": "hollowmere-mire", "name": "The Mire", "tx": 2, "ty": 22, "tw": 36, "th": 7 },
-    { "id": "hollowmere-darkwood", "name": "The Dark Wood", "tx": 33, "ty": 11, "tw": 10, "th": 10 }
+    {
+      "id": "hollowmere-hollow",
+      "name": "The Hollow",
+      "tx": 7,
+      "ty": 10,
+      "tw": 12,
+      "th": 6
+    },
+    {
+      "id": "hollowmere-mire",
+      "name": "The Mire",
+      "tx": 2,
+      "ty": 22,
+      "tw": 36,
+      "th": 7
+    },
+    {
+      "id": "hollowmere-darkwood",
+      "name": "The Dark Wood",
+      "tx": 33,
+      "ty": 11,
+      "tw": 10,
+      "th": 10
+    }
   ],
   "streets": [
-    { "rect": [12, 2, 14, 27] },
-    { "rect": [10, 18, 11, 18] },
-    { "rect": [4, 10, 40, 11] },
-    { "rect": [4, 21, 40, 22] },
-    { "rect": [8, 9, 8, 9] },
-    { "rect": [30, 9, 30, 9] },
-    { "rect": [38, 9, 38, 9] },
-    { "rect": [5, 20, 5, 20] },
-    { "rect": [19, 20, 19, 20] },
-    { "rect": [29, 20, 29, 20] },
-    { "rect": [16, 22, 17, 26] },
-    { "rect": [8, 26, 30, 27] }
+    {
+      "rect": [
+        12,
+        2,
+        14,
+        27
+      ]
+    },
+    {
+      "rect": [
+        10,
+        18,
+        11,
+        18
+      ]
+    },
+    {
+      "rect": [
+        4,
+        10,
+        40,
+        11
+      ]
+    },
+    {
+      "rect": [
+        4,
+        21,
+        40,
+        22
+      ]
+    },
+    {
+      "rect": [
+        8,
+        9,
+        8,
+        9
+      ]
+    },
+    {
+      "rect": [
+        30,
+        9,
+        30,
+        9
+      ]
+    },
+    {
+      "rect": [
+        38,
+        9,
+        38,
+        9
+      ]
+    },
+    {
+      "rect": [
+        5,
+        20,
+        5,
+        20
+      ]
+    },
+    {
+      "rect": [
+        19,
+        20,
+        19,
+        20
+      ]
+    },
+    {
+      "rect": [
+        29,
+        20,
+        29,
+        20
+      ]
+    },
+    {
+      "rect": [
+        16,
+        22,
+        17,
+        26
+      ]
+    },
+    {
+      "rect": [
+        8,
+        26,
+        30,
+        27
+      ]
+    }
   ],
   "buildings": [
     {
       "id": "broken-hall",
       "upgradeKind": "default",
-      "rect": [4, 2, 11, 8],
+      "rect": [
+        4,
+        2,
+        11,
+        8
+      ],
       "wall": "woodenSlats",
       "roof": "strawRoof",
       "doors": [
-        { "tx": 4, "ty": 1, "hideSign": true, "buildingId": "broken-hall" }
+        {
+          "tx": 4,
+          "ty": 1,
+          "hideSign": true,
+          "buildingId": "broken-hall"
+        }
+      ],
+      "levelDecor": [
+        {
+          "tx": 7,
+          "ty": 9,
+          "tileId": "lightBush",
+          "minLevel": 1
+        },
+        {
+          "tx": 9,
+          "ty": 9,
+          "tileId": "lightBush",
+          "minLevel": 1
+        },
+        {
+          "tx": 6,
+          "ty": 9,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 10,
+          "ty": 9,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 8,
+          "ty": 11,
+          "tileId": "largeSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 7,
+          "ty": 10,
+          "tileId": "potOfFlowers",
+          "minLevel": 3
+        }
       ]
     },
     {
       "id": "fang-den",
       "upgradeKind": "inn",
-      "rect": [17, 3, 24, 9],
+      "rect": [
+        17,
+        3,
+        24,
+        9
+      ],
       "wall": "darkStone",
       "roof": "greySlateRoof",
       "doors": [
-        { "tx": 3, "ty": 1, "hideSign": true, "buildingId": "fang-den" }
+        {
+          "tx": 3,
+          "ty": 1,
+          "hideSign": true,
+          "buildingId": "fang-den"
+        }
+      ],
+      "levelDecor": [
+        {
+          "tx": 19,
+          "ty": 10,
+          "tileId": "barrel",
+          "minLevel": 1
+        },
+        {
+          "tx": 21,
+          "ty": 10,
+          "tileId": "barrel",
+          "minLevel": 1
+        },
+        {
+          "tx": 18,
+          "ty": 10,
+          "tileId": "floorLantern",
+          "minLevel": 2
+        },
+        {
+          "tx": 22,
+          "ty": 10,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 20,
+          "ty": 12,
+          "tileId": "innSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 19,
+          "ty": 11,
+          "tileId": "floorLantern",
+          "minLevel": 3
+        }
       ]
     },
     {
       "id": "apothecary",
       "upgradeKind": "shop",
-      "rect": [27, 2, 33, 8],
+      "rect": [
+        27,
+        2,
+        33,
+        8
+      ],
       "wall": "woodenSlats",
       "roof": "strawRoof",
       "doors": [
-        { "tx": 3, "ty": 1, "hideSign": true, "buildingId": "apothecary" }
+        {
+          "tx": 3,
+          "ty": 1,
+          "hideSign": true,
+          "buildingId": "apothecary"
+        }
+      ],
+      "levelDecor": [
+        {
+          "tx": 29,
+          "ty": 9,
+          "tileId": "crate",
+          "minLevel": 1
+        },
+        {
+          "tx": 31,
+          "ty": 9,
+          "tileId": "barrel",
+          "minLevel": 1
+        },
+        {
+          "tx": 28,
+          "ty": 9,
+          "tileId": "pileOfSacks",
+          "minLevel": 2
+        },
+        {
+          "tx": 32,
+          "ty": 9,
+          "tileId": "crate",
+          "minLevel": 2
+        },
+        {
+          "tx": 30,
+          "ty": 11,
+          "tileId": "goldSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 29,
+          "ty": 10,
+          "tileId": "goldChest",
+          "minLevel": 3
+        }
       ]
     },
     {
       "id": "bonepile-curio",
       "upgradeKind": "shop",
-      "rect": [35, 2, 41, 8],
+      "rect": [
+        35,
+        2,
+        41,
+        8
+      ],
       "wall": "darkStone",
       "roof": "greySlateRoof",
       "doors": [
-        { "tx": 3, "ty": 1, "hideSign": true, "buildingId": "bonepile-curio" }
+        {
+          "tx": 3,
+          "ty": 1,
+          "hideSign": true,
+          "buildingId": "bonepile-curio"
+        }
+      ],
+      "levelDecor": [
+        {
+          "tx": 37,
+          "ty": 9,
+          "tileId": "crate",
+          "minLevel": 1
+        },
+        {
+          "tx": 39,
+          "ty": 9,
+          "tileId": "barrel",
+          "minLevel": 1
+        },
+        {
+          "tx": 36,
+          "ty": 9,
+          "tileId": "pileOfSacks",
+          "minLevel": 2
+        },
+        {
+          "tx": 40,
+          "ty": 9,
+          "tileId": "crate",
+          "minLevel": 2
+        },
+        {
+          "tx": 38,
+          "ty": 11,
+          "tileId": "goldSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 37,
+          "ty": 10,
+          "tileId": "goldChest",
+          "minLevel": 3
+        }
       ]
     },
     {
       "id": "witch-hut",
       "upgradeKind": "default",
-      "rect": [2, 13, 8, 19],
+      "rect": [
+        2,
+        13,
+        8,
+        19
+      ],
       "wall": "woodenSlats",
       "roof": "strawRoof",
       "doors": [
-        { "tx": 3, "ty": 1, "hideSign": true, "buildingId": "witch-hut" }
+        {
+          "tx": 3,
+          "ty": 1,
+          "hideSign": true,
+          "buildingId": "witch-hut"
+        }
+      ],
+      "levelDecor": [
+        {
+          "tx": 4,
+          "ty": 20,
+          "tileId": "lightBush",
+          "minLevel": 1
+        },
+        {
+          "tx": 6,
+          "ty": 20,
+          "tileId": "lightBush",
+          "minLevel": 1
+        },
+        {
+          "tx": 3,
+          "ty": 20,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 7,
+          "ty": 20,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 5,
+          "ty": 22,
+          "tileId": "largeSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 4,
+          "ty": 21,
+          "tileId": "potOfFlowers",
+          "minLevel": 3
+        }
       ]
     },
     {
       "id": "beast-pens",
       "upgradeKind": "default",
-      "rect": [16, 14, 22, 19],
+      "rect": [
+        16,
+        14,
+        22,
+        19
+      ],
       "wall": "woodenSlats",
       "roof": "strawRoof",
       "doors": [
-        { "tx": 3, "ty": 1, "hideSign": true, "buildingId": "beast-pens" }
+        {
+          "tx": 3,
+          "ty": 1,
+          "hideSign": true,
+          "buildingId": "beast-pens"
+        }
+      ],
+      "levelDecor": [
+        {
+          "tx": 18,
+          "ty": 20,
+          "tileId": "lightBush",
+          "minLevel": 1
+        },
+        {
+          "tx": 20,
+          "ty": 20,
+          "tileId": "lightBush",
+          "minLevel": 1
+        },
+        {
+          "tx": 17,
+          "ty": 20,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 21,
+          "ty": 20,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 19,
+          "ty": 22,
+          "tileId": "largeSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 18,
+          "ty": 21,
+          "tileId": "potOfFlowers",
+          "minLevel": 3
+        }
       ]
     },
     {
       "id": "bathhouse",
       "upgradeKind": "default",
-      "rect": [26, 14, 32, 19],
+      "rect": [
+        26,
+        14,
+        32,
+        19
+      ],
       "wall": "darkStone",
       "roof": "greySlateRoof",
       "doors": [
-        { "tx": 3, "ty": 1, "hideSign": true, "buildingId": "bathhouse" }
+        {
+          "tx": 3,
+          "ty": 1,
+          "hideSign": true,
+          "buildingId": "bathhouse"
+        }
+      ],
+      "levelDecor": [
+        {
+          "tx": 28,
+          "ty": 20,
+          "tileId": "lightBush",
+          "minLevel": 1
+        },
+        {
+          "tx": 30,
+          "ty": 20,
+          "tileId": "lightBush",
+          "minLevel": 1
+        },
+        {
+          "tx": 27,
+          "ty": 20,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 31,
+          "ty": 20,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 29,
+          "ty": 22,
+          "tileId": "largeSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 28,
+          "ty": 21,
+          "tileId": "potOfFlowers",
+          "minLevel": 3
+        }
       ]
     }
   ],
   "pondTiles": [
-    { "rect": [3, 27, 6, 28] },
-    { "rect": [33, 26, 36, 28] }
+    {
+      "rect": [
+        3,
+        27,
+        6,
+        28
+      ]
+    },
+    {
+      "rect": [
+        33,
+        26,
+        36,
+        28
+      ]
+    }
   ],
   "exteriorDecor": [
-    { "comment": "=== the dark wood: left edge ===" },
-    { "tx": 0, "ty": 2, "bundleID": "dark-tree-column-4", "zlayer": "solid" },
-    { "tx": 0, "ty": 7, "bundleID": "dark-tree", "zlayer": "solid" },
-    { "tx": 0, "ty": 13, "bundleID": "dead-tree", "zlayer": "solid" },
-    { "tx": 0, "ty": 17, "bundleID": "dark-tree", "zlayer": "solid" },
-    { "tx": 0, "ty": 22, "bundleID": "dead-tree", "zlayer": "solid" },
-    { "comment": "=== the dark wood: top edge ===" },
-    { "tx": 4, "ty": 0, "bundleID": "dark-tree", "zlayer": "solid" },
-    { "tx": 9, "ty": 0, "bundleID": "dead-tree", "zlayer": "solid" },
-    { "tx": 18, "ty": 0, "bundleID": "dark-tree", "zlayer": "solid" },
-    { "tx": 23, "ty": 0, "bundleID": "dead-tree", "zlayer": "solid" },
-    { "tx": 27, "ty": 0, "bundleID": "dark-tree", "zlayer": "solid" },
-    { "tx": 31, "ty": 0, "bundleID": "dead-tree", "zlayer": "solid" },
-    { "tx": 35, "ty": 0, "bundleID": "dark-tree", "zlayer": "solid" },
-    { "tx": 40, "ty": 0, "bundleID": "dead-tree", "zlayer": "solid" },
-    { "comment": "=== the dark wood: right edge + eastern grove ===" },
-    { "tx": 42, "ty": 3, "bundleID": "dead-tree", "zlayer": "solid" },
-    { "tx": 42, "ty": 7, "bundleID": "dark-tree", "zlayer": "solid" },
-    { "tx": 42, "ty": 12, "bundleID": "dead-tree", "zlayer": "solid" },
-    { "tx": 42, "ty": 16, "bundleID": "dark-tree", "zlayer": "solid" },
-    { "tx": 42, "ty": 23, "bundleID": "dead-tree", "zlayer": "solid" },
-    { "tx": 35, "ty": 13, "bundleID": "dark-tree-cluster-V", "zlayer": "solid" },
-    { "tx": 39, "ty": 16, "bundleID": "dark-tree", "zlayer": "solid" },
-    { "tx": 34, "ty": 18, "bundleID": "dead-tree", "zlayer": "solid" },
-    { "tx": 38, "ty": 19, "bundleID": "dark-tree", "zlayer": "solid" },
-    { "comment": "=== the hollow: central crossroads ===" },
-    { "tx": 10, "ty": 12, "tileId": "stoneWell" },
-    { "tx": 8, "ty": 10, "bundleID": "brazier", "zlayer": "solid", "glow": true, "glowRadius": 3 },
-    { "tx": 16, "ty": 12, "bundleID": "brazier", "zlayer": "solid", "glow": true, "glowRadius": 3 },
-    { "tx": 9, "ty": 13, "tileId": "skull" },
-    { "tx": 15, "ty": 13, "tileId": "largeStump" },
-    { "tx": 11, "ty": 14, "tileId": "brownMushroom" },
-    { "tx": 7, "ty": 12, "tileId": "logPile" },
-    { "tx": 17, "ty": 14, "tileId": "purpleMushroom" },
-    { "comment": "=== the witch's corner (beside her hut) ===" },
-    { "tx": 1, "ty": 12, "tileId": "cauldren", "glow": true, "glowRadius": 2 },
-    { "tx": 9, "ty": 14, "tileId": "bottlesOfLiquor" },
-    { "tx": 9, "ty": 15, "tileId": "bunchOfHerbs" },
-    { "tx": 1, "ty": 11, "tileId": "purpleMushroom" },
-    { "tx": 2, "ty": 11, "tileId": "brownMushroom" },
-    { "tx": 9, "ty": 16, "tileId": "potions" },
-    { "comment": "=== fang-den / tavern frontage ===" },
-    { "tx": 16, "ty": 11, "tileId": "barrel" },
-    { "tx": 25, "ty": 11, "tileId": "openCrate" },
-    { "tx": 22, "ty": 11, "tileId": "skull" },
-    { "tx": 18, "ty": 12, "tileId": "logPile" },
-    { "comment": "=== apothecary + curio frontage / fang's stall (NE) ===" },
-    { "tx": 26, "ty": 10, "tileId": "bunchOfHerbs" },
-    { "tx": 34, "ty": 10, "tileId": "counterTop" },
-    { "tx": 35, "ty": 10, "tileId": "counterTop" },
-    { "tx": 34, "ty": 9, "tileId": "skullSign", "zlayer": "above" },
-    { "tx": 33, "ty": 11, "tileId": "barrel" },
-    { "tx": 36, "ty": 11, "tileId": "openCrate" },
-    { "tx": 40, "ty": 10, "tileId": "skull" },
-    { "comment": "=== beast pens yard ===" },
-    { "tx": 16, "ty": 20, "tileId": "hayStack" },
-    { "tx": 22, "ty": 20, "tileId": "barrel" },
-    { "tx": 20, "ty": 19, "tileId": "logPile" },
-    { "tx": 23, "ty": 19, "tileId": "sack" },
-    { "comment": "=== bathhouse / mud-wallow frontage ===" },
-    { "tx": 26, "ty": 20, "tileId": "barrel" },
-    { "tx": 32, "ty": 20, "tileId": "bottlesOfLiquor" },
-    { "tx": 27, "ty": 19, "tileId": "greenPuddle", "zlayer": "below" },
-    { "tx": 31, "ty": 19, "tileId": "darkPuddle", "zlayer": "below" },
-    { "comment": "=== the mire: muck, lilypads & fungus ===" },
-    { "tx": 2, "ty": 26, "tileId": "darkPuddle", "zlayer": "below" },
-    { "tx": 7, "ty": 27, "tileId": "greenPuddle", "zlayer": "below" },
-    { "tx": 8, "ty": 28, "tileId": "lightPuddle", "zlayer": "below" },
-    { "tx": 5, "ty": 26, "tileId": "smallLilypad", "zlayer": "below" },
-    { "tx": 4, "ty": 28, "tileId": "largeLilypad", "zlayer": "below" },
-    { "tx": 34, "ty": 27, "tileId": "smallLilypad", "zlayer": "below" },
-    { "tx": 35, "ty": 26, "tileId": "largeLilypad", "zlayer": "below" },
-    { "tx": 10, "ty": 28, "tileId": "brownMushroom" },
-    { "tx": 11, "ty": 28, "tileId": "purpleMushroom" },
-    { "tx": 12, "ty": 28, "tileId": "brownMushroom" },
-    { "tx": 22, "ty": 28, "tileId": "purpleMushroom" },
-    { "tx": 23, "ty": 28, "tileId": "brownMushroom" },
-    { "tx": 24, "ty": 28, "tileId": "purpleMushroom" },
-    { "tx": 9, "ty": 26, "tileId": "skull" },
-    { "tx": 27, "ty": 26, "tileId": "skull" },
-    { "tx": 14, "ty": 28, "tileId": "bunchOfHerbs" },
-    { "tx": 19, "ty": 28, "tileId": "bunchOfHerbs" },
-    { "tx": 6, "ty": 25, "tileId": "largeStump" },
-    { "tx": 30, "ty": 25, "tileId": "largeStump" },
-    { "tx": 25, "ty": 26, "tileId": "smallRock" },
-    { "tx": 13, "ty": 26, "tileId": "largeRock" },
-    { "tx": 18, "ty": 27, "tileId": "floorLantern", "glow": true, "glowRadius": 2 },
-    { "tx": 26, "ty": 27, "tileId": "floorLantern", "glow": true, "glowRadius": 2 },
-    { "comment": "=== the mire: gnarled trees ringing the marsh ===" },
-    { "tx": 1, "ty": 24, "bundleID": "dead-tree", "zlayer": "solid" },
-    { "tx": 4, "ty": 23, "bundleID": "dark-tree", "zlayer": "solid" },
-    { "tx": 31, "ty": 23, "bundleID": "dead-tree", "zlayer": "solid" },
-    { "tx": 36, "ty": 24, "bundleID": "dark-tree", "zlayer": "solid" },
-    { "tx": 38, "ty": 26, "bundleID": "dead-tree", "zlayer": "solid" },
-    { "comment": "=== bottom-edge fringe ===" },
-    { "tx": 2, "ty": 29, "tileId": "purpleMushroom" },
-    { "tx": 16, "ty": 29, "tileId": "skull" },
-    { "tx": 33, "ty": 29, "tileId": "brownMushroom" }
+    {
+      "comment": "=== the dark wood: left edge ==="
+    },
+    {
+      "tx": 0,
+      "ty": 2,
+      "bundleID": "dark-tree-column-4",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 0,
+      "ty": 7,
+      "bundleID": "dark-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 0,
+      "ty": 13,
+      "bundleID": "dead-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 0,
+      "ty": 17,
+      "bundleID": "dark-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 0,
+      "ty": 22,
+      "bundleID": "dead-tree",
+      "zlayer": "solid"
+    },
+    {
+      "comment": "=== the dark wood: top edge ==="
+    },
+    {
+      "tx": 4,
+      "ty": 0,
+      "bundleID": "dark-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 9,
+      "ty": 0,
+      "bundleID": "dead-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 18,
+      "ty": 0,
+      "bundleID": "dark-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 23,
+      "ty": 0,
+      "bundleID": "dead-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 27,
+      "ty": 0,
+      "bundleID": "dark-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 31,
+      "ty": 0,
+      "bundleID": "dead-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 35,
+      "ty": 0,
+      "bundleID": "dark-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 40,
+      "ty": 0,
+      "bundleID": "dead-tree",
+      "zlayer": "solid"
+    },
+    {
+      "comment": "=== the dark wood: right edge + eastern grove ==="
+    },
+    {
+      "tx": 42,
+      "ty": 3,
+      "bundleID": "dead-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 42,
+      "ty": 7,
+      "bundleID": "dark-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 42,
+      "ty": 12,
+      "bundleID": "dead-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 42,
+      "ty": 16,
+      "bundleID": "dark-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 42,
+      "ty": 23,
+      "bundleID": "dead-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 35,
+      "ty": 13,
+      "bundleID": "dark-tree-cluster-V",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 39,
+      "ty": 16,
+      "bundleID": "dark-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 34,
+      "ty": 18,
+      "bundleID": "dead-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 38,
+      "ty": 19,
+      "bundleID": "dark-tree",
+      "zlayer": "solid"
+    },
+    {
+      "comment": "=== the hollow: central crossroads ==="
+    },
+    {
+      "tx": 10,
+      "ty": 12,
+      "tileId": "stoneWell"
+    },
+    {
+      "tx": 8,
+      "ty": 10,
+      "bundleID": "brazier",
+      "zlayer": "solid",
+      "glow": true,
+      "glowRadius": 3
+    },
+    {
+      "tx": 16,
+      "ty": 12,
+      "bundleID": "brazier",
+      "zlayer": "solid",
+      "glow": true,
+      "glowRadius": 3
+    },
+    {
+      "tx": 9,
+      "ty": 13,
+      "tileId": "skull"
+    },
+    {
+      "tx": 15,
+      "ty": 13,
+      "tileId": "largeStump"
+    },
+    {
+      "tx": 11,
+      "ty": 14,
+      "tileId": "brownMushroom"
+    },
+    {
+      "tx": 7,
+      "ty": 12,
+      "tileId": "logPile"
+    },
+    {
+      "tx": 17,
+      "ty": 14,
+      "tileId": "purpleMushroom"
+    },
+    {
+      "comment": "=== the witch's corner (beside her hut) ==="
+    },
+    {
+      "tx": 1,
+      "ty": 12,
+      "tileId": "cauldren",
+      "glow": true,
+      "glowRadius": 2
+    },
+    {
+      "tx": 9,
+      "ty": 14,
+      "tileId": "bottlesOfLiquor"
+    },
+    {
+      "tx": 9,
+      "ty": 15,
+      "tileId": "bunchOfHerbs"
+    },
+    {
+      "tx": 1,
+      "ty": 11,
+      "tileId": "purpleMushroom"
+    },
+    {
+      "tx": 2,
+      "ty": 11,
+      "tileId": "brownMushroom"
+    },
+    {
+      "tx": 9,
+      "ty": 16,
+      "tileId": "potions"
+    },
+    {
+      "comment": "=== fang-den / tavern frontage ==="
+    },
+    {
+      "tx": 16,
+      "ty": 11,
+      "tileId": "barrel"
+    },
+    {
+      "tx": 25,
+      "ty": 11,
+      "tileId": "openCrate"
+    },
+    {
+      "tx": 22,
+      "ty": 11,
+      "tileId": "skull"
+    },
+    {
+      "tx": 18,
+      "ty": 12,
+      "tileId": "logPile"
+    },
+    {
+      "comment": "=== apothecary + curio frontage / fang's stall (NE) ==="
+    },
+    {
+      "tx": 26,
+      "ty": 10,
+      "tileId": "bunchOfHerbs"
+    },
+    {
+      "tx": 34,
+      "ty": 10,
+      "tileId": "counterTop"
+    },
+    {
+      "tx": 35,
+      "ty": 10,
+      "tileId": "counterTop"
+    },
+    {
+      "tx": 34,
+      "ty": 9,
+      "tileId": "skullSign",
+      "zlayer": "above"
+    },
+    {
+      "tx": 33,
+      "ty": 11,
+      "tileId": "barrel"
+    },
+    {
+      "tx": 36,
+      "ty": 11,
+      "tileId": "openCrate"
+    },
+    {
+      "tx": 40,
+      "ty": 10,
+      "tileId": "skull"
+    },
+    {
+      "comment": "=== beast pens yard ==="
+    },
+    {
+      "tx": 16,
+      "ty": 20,
+      "tileId": "hayStack"
+    },
+    {
+      "tx": 22,
+      "ty": 20,
+      "tileId": "barrel"
+    },
+    {
+      "tx": 20,
+      "ty": 19,
+      "tileId": "logPile"
+    },
+    {
+      "tx": 23,
+      "ty": 19,
+      "tileId": "sack"
+    },
+    {
+      "comment": "=== bathhouse / mud-wallow frontage ==="
+    },
+    {
+      "tx": 26,
+      "ty": 20,
+      "tileId": "barrel"
+    },
+    {
+      "tx": 32,
+      "ty": 20,
+      "tileId": "bottlesOfLiquor"
+    },
+    {
+      "tx": 27,
+      "ty": 19,
+      "tileId": "greenPuddle",
+      "zlayer": "below"
+    },
+    {
+      "tx": 31,
+      "ty": 19,
+      "tileId": "darkPuddle",
+      "zlayer": "below"
+    },
+    {
+      "comment": "=== the mire: muck, lilypads & fungus ==="
+    },
+    {
+      "tx": 2,
+      "ty": 26,
+      "tileId": "darkPuddle",
+      "zlayer": "below"
+    },
+    {
+      "tx": 7,
+      "ty": 27,
+      "tileId": "greenPuddle",
+      "zlayer": "below"
+    },
+    {
+      "tx": 8,
+      "ty": 28,
+      "tileId": "lightPuddle",
+      "zlayer": "below"
+    },
+    {
+      "tx": 5,
+      "ty": 26,
+      "tileId": "smallLilypad",
+      "zlayer": "below"
+    },
+    {
+      "tx": 4,
+      "ty": 28,
+      "tileId": "largeLilypad",
+      "zlayer": "below"
+    },
+    {
+      "tx": 34,
+      "ty": 27,
+      "tileId": "smallLilypad",
+      "zlayer": "below"
+    },
+    {
+      "tx": 35,
+      "ty": 26,
+      "tileId": "largeLilypad",
+      "zlayer": "below"
+    },
+    {
+      "tx": 10,
+      "ty": 28,
+      "tileId": "brownMushroom"
+    },
+    {
+      "tx": 11,
+      "ty": 28,
+      "tileId": "purpleMushroom"
+    },
+    {
+      "tx": 12,
+      "ty": 28,
+      "tileId": "brownMushroom"
+    },
+    {
+      "tx": 22,
+      "ty": 28,
+      "tileId": "purpleMushroom"
+    },
+    {
+      "tx": 23,
+      "ty": 28,
+      "tileId": "brownMushroom"
+    },
+    {
+      "tx": 24,
+      "ty": 28,
+      "tileId": "purpleMushroom"
+    },
+    {
+      "tx": 9,
+      "ty": 26,
+      "tileId": "skull"
+    },
+    {
+      "tx": 27,
+      "ty": 26,
+      "tileId": "skull"
+    },
+    {
+      "tx": 14,
+      "ty": 28,
+      "tileId": "bunchOfHerbs"
+    },
+    {
+      "tx": 19,
+      "ty": 28,
+      "tileId": "bunchOfHerbs"
+    },
+    {
+      "tx": 6,
+      "ty": 25,
+      "tileId": "largeStump"
+    },
+    {
+      "tx": 30,
+      "ty": 25,
+      "tileId": "largeStump"
+    },
+    {
+      "tx": 25,
+      "ty": 26,
+      "tileId": "smallRock"
+    },
+    {
+      "tx": 13,
+      "ty": 26,
+      "tileId": "largeRock"
+    },
+    {
+      "tx": 18,
+      "ty": 27,
+      "tileId": "floorLantern",
+      "glow": true,
+      "glowRadius": 2
+    },
+    {
+      "tx": 26,
+      "ty": 27,
+      "tileId": "floorLantern",
+      "glow": true,
+      "glowRadius": 2
+    },
+    {
+      "comment": "=== the mire: gnarled trees ringing the marsh ==="
+    },
+    {
+      "tx": 1,
+      "ty": 24,
+      "bundleID": "dead-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 4,
+      "ty": 23,
+      "bundleID": "dark-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 31,
+      "ty": 23,
+      "bundleID": "dead-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 36,
+      "ty": 24,
+      "bundleID": "dark-tree",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 38,
+      "ty": 26,
+      "bundleID": "dead-tree",
+      "zlayer": "solid"
+    },
+    {
+      "comment": "=== bottom-edge fringe ==="
+    },
+    {
+      "tx": 2,
+      "ty": 29,
+      "tileId": "purpleMushroom"
+    },
+    {
+      "tx": 16,
+      "ty": 29,
+      "tileId": "skull"
+    },
+    {
+      "tx": 33,
+      "ty": 29,
+      "tileId": "brownMushroom"
+    }
   ],
   "npcSpawnTiles": [],
   "ambientNpcSprites": [],
@@ -226,7 +1109,10 @@
       "tx": 34,
       "ty": 27,
       "name": "Pip the Peeper",
-      "dialogue": ["*peep! peep!*", "*a tiny frog hops hopefully toward your boot*"],
+      "dialogue": [
+        "*peep! peep!*",
+        "*a tiny frog hops hopefully toward your boot*"
+      ],
       "roam": true
     },
     {
@@ -295,7 +1181,12 @@
       ],
       "building": "witch-hut",
       "questGive": "hollowmere-witch-brew",
-      "questReceive": ["hollowmere-witch-brew", "morwen-speak-with-animals", "hollowmere-witch-brew-2", "dreadspire-moon-herbs"]
+      "questReceive": [
+        "hollowmere-witch-brew",
+        "morwen-speak-with-animals",
+        "hollowmere-witch-brew-2",
+        "dreadspire-moon-herbs"
+      ]
     },
     {
       "id": "apothecary-herbalist",
@@ -310,7 +1201,10 @@
       ],
       "building": "apothecary",
       "questGive": "apothecary-ingredients-1",
-      "questReceive": ["apothecary-ingredients-1", "apothecary-ingredients-2"]
+      "questReceive": [
+        "apothecary-ingredients-1",
+        "apothecary-ingredients-2"
+      ]
     },
     {
       "id": "goblin-curio-keep",
@@ -354,10 +1248,33 @@
         "You want to learn beast-taming? Start small. Start with the ones that bite least."
       ],
       "questGive": "beast-taming-1",
-      "questReceive": ["beast-taming-1", "beast-taming-2", "beast-taming-3"],
+      "questReceive": [
+        "beast-taming-1",
+        "beast-taming-2",
+        "beast-taming-3"
+      ],
       "schedule": [
-        { "startHour": 6, "endHour": 20, "activity": "work", "location": { "type": "exterior", "tx": 19, "ty": 21 } },
-        { "startHour": 20, "endHour": 6, "activity": "sleep", "location": { "type": "interior", "buildingId": "beast-pens", "tx": 5, "ty": 4 } }
+        {
+          "startHour": 6,
+          "endHour": 20,
+          "activity": "work",
+          "location": {
+            "type": "exterior",
+            "tx": 19,
+            "ty": 21
+          }
+        },
+        {
+          "startHour": 20,
+          "endHour": 6,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "beast-pens",
+            "tx": 5,
+            "ty": 4
+          }
+        }
       ]
     },
     {
@@ -372,7 +1289,10 @@
         "I've sat in this bog longer than your town's had a name. I remember when it had three."
       ],
       "questGive": "mire-lost-items-1",
-      "questReceive": ["mire-lost-items-1", "mire-lost-items-2"]
+      "questReceive": [
+        "mire-lost-items-1",
+        "mire-lost-items-2"
+      ]
     }
   ],
   "interiors": {
@@ -383,20 +1303,72 @@
       "floorTileId": "woodFloor",
       "wallTileId": "woodenSlats",
       "decor": [
-        { "tx": 1, "ty": 1, "tileId": "barrel" },
-        { "tx": 2, "ty": 1, "tileId": "skull" },
-        { "tx": 10, "ty": 1, "tileId": "barrel" },
-        { "tx": 5, "ty": 1, "tileId": "logPile" },
-        { "tx": 4, "ty": 4, "tileId": "roundTable" },
-        { "tx": 7, "ty": 4, "tileId": "roundTable" },
-        { "tx": 3, "ty": 4, "tileId": "stool" },
-        { "tx": 5, "ty": 4, "tileId": "stool" },
-        { "tx": 8, "ty": 4, "tileId": "stool" },
-        { "tx": 1, "ty": 6, "tileId": "logBottom" },
-        { "tx": 10, "ty": 6, "tileId": "candlestickUnlit" }
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 2,
+          "ty": 1,
+          "tileId": "skull"
+        },
+        {
+          "tx": 10,
+          "ty": 1,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 5,
+          "ty": 1,
+          "tileId": "logPile"
+        },
+        {
+          "tx": 4,
+          "ty": 4,
+          "tileId": "roundTable"
+        },
+        {
+          "tx": 7,
+          "ty": 4,
+          "tileId": "roundTable"
+        },
+        {
+          "tx": 3,
+          "ty": 4,
+          "tileId": "stool"
+        },
+        {
+          "tx": 5,
+          "ty": 4,
+          "tileId": "stool"
+        },
+        {
+          "tx": 8,
+          "ty": 4,
+          "tileId": "stool"
+        },
+        {
+          "tx": 1,
+          "ty": 6,
+          "tileId": "logBottom"
+        },
+        {
+          "tx": 10,
+          "ty": 6,
+          "tileId": "candlestickUnlit"
+        }
       ],
       "exits": [
-        { "tx": 6, "ty": 0, "toInteriorId": "broken-hall-back", "entryTx": 5, "entryTy": 6, "direction": "back", "label": "Back Room" }
+        {
+          "tx": 6,
+          "ty": 0,
+          "toInteriorId": "broken-hall-back",
+          "entryTx": 5,
+          "entryTy": 6,
+          "direction": "back",
+          "label": "Back Room"
+        }
       ]
     },
     "broken-hall-back": {
@@ -406,17 +1378,57 @@
       "floorTileId": "woodFloor",
       "wallTileId": "woodenSlats",
       "decor": [
-        { "tx": 1, "ty": 1, "tileId": "pileOfSacks" },
-        { "tx": 2, "ty": 1, "tileId": "sack" },
-        { "tx": 9, "ty": 1, "tileId": "openCrate" },
-        { "tx": 8, "ty": 1, "tileId": "crate" },
-        { "tx": 1, "ty": 5, "tileId": "barrel" },
-        { "tx": 9, "ty": 5, "tileId": "skull" },
-        { "tx": 4, "ty": 3, "tileId": "roundTable" },
-        { "tx": 6, "ty": 3, "tileId": "stool" }
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "pileOfSacks"
+        },
+        {
+          "tx": 2,
+          "ty": 1,
+          "tileId": "sack"
+        },
+        {
+          "tx": 9,
+          "ty": 1,
+          "tileId": "openCrate"
+        },
+        {
+          "tx": 8,
+          "ty": 1,
+          "tileId": "crate"
+        },
+        {
+          "tx": 1,
+          "ty": 5,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 9,
+          "ty": 5,
+          "tileId": "skull"
+        },
+        {
+          "tx": 4,
+          "ty": 3,
+          "tileId": "roundTable"
+        },
+        {
+          "tx": 6,
+          "ty": 3,
+          "tileId": "stool"
+        }
       ],
       "exits": [
-        { "tx": 5, "ty": 7, "toInteriorId": "broken-hall", "entryTx": 6, "entryTy": 1, "direction": "front", "label": "Common Room" }
+        {
+          "tx": 5,
+          "ty": 7,
+          "toInteriorId": "broken-hall",
+          "entryTx": 6,
+          "entryTy": 1,
+          "direction": "front",
+          "label": "Common Room"
+        }
       ]
     },
     "fang-den": {
@@ -428,22 +1440,83 @@
       "musicId": "inn",
       "ambianceId": "hearth",
       "decor": [
-        { "tx": 1, "ty": 1, "bundleID": "fireplace" },
-        { "tx": 1, "ty": 1, "tileId": "bottlesOfLiquor" },
-        { "tx": 5, "ty": 1, "tileId": "skull" },
-        { "tx": 6, "ty": 1, "tileId": "barrel" },
-        { "tx": 7, "ty": 1, "tileId": "barrel" },
-        { "tx": 3, "ty": 4, "tileId": "roundTable" },
-        { "tx": 2, "ty": 4, "tileId": "stool" },
-        { "tx": 4, "ty": 4, "tileId": "stool" },
-        { "tx": 7, "ty": 4, "tileId": "roundTableWithCloth" },
-        { "tx": 8, "ty": 4, "tileId": "stool" },
-        { "tx": 10, "ty": 5, "tileId": "counterTop" },
-        { "tx": 9, "ty": 5, "tileId": "counterTop" },
-        { "tx": 9, "ty": 1, "tileId": "ladderBottom", "zlayer": "below" }
+        {
+          "tx": 1,
+          "ty": 1,
+          "bundleID": "fireplace"
+        },
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "bottlesOfLiquor"
+        },
+        {
+          "tx": 5,
+          "ty": 1,
+          "tileId": "skull"
+        },
+        {
+          "tx": 6,
+          "ty": 1,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 7,
+          "ty": 1,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 3,
+          "ty": 4,
+          "tileId": "roundTable"
+        },
+        {
+          "tx": 2,
+          "ty": 4,
+          "tileId": "stool"
+        },
+        {
+          "tx": 4,
+          "ty": 4,
+          "tileId": "stool"
+        },
+        {
+          "tx": 7,
+          "ty": 4,
+          "tileId": "roundTableWithCloth"
+        },
+        {
+          "tx": 8,
+          "ty": 4,
+          "tileId": "stool"
+        },
+        {
+          "tx": 10,
+          "ty": 5,
+          "tileId": "counterTop"
+        },
+        {
+          "tx": 9,
+          "ty": 5,
+          "tileId": "counterTop"
+        },
+        {
+          "tx": 9,
+          "ty": 1,
+          "tileId": "ladderBottom",
+          "zlayer": "below"
+        }
       ],
       "exits": [
-        { "tx": 9, "ty": 1, "toInteriorId": "fang-den-cellar", "entryTx": 5, "entryTy": 5, "direction": "down", "label": "Down to the cellar" }
+        {
+          "tx": 9,
+          "ty": 1,
+          "toInteriorId": "fang-den-cellar",
+          "entryTx": 5,
+          "entryTy": 5,
+          "direction": "down",
+          "label": "Down to the cellar"
+        }
       ]
     },
     "fang-den-cellar": {
@@ -453,18 +1526,65 @@
       "floorTileId": "stoneFloor",
       "wallTileId": "darkStone",
       "decor": [
-        { "tx": 1, "ty": 1, "tileId": "barrel" },
-        { "tx": 2, "ty": 1, "tileId": "barrel" },
-        { "tx": 8, "ty": 1, "tileId": "bottlesOfLiquor" },
-        { "tx": 7, "ty": 1, "tileId": "crate" },
-        { "tx": 1, "ty": 5, "tileId": "openCrate" },
-        { "tx": 8, "ty": 5, "tileId": "skull" },
-        { "tx": 3, "ty": 3, "tileId": "barrel" },
-        { "tx": 2, "ty": 3, "tileId": "candlestickLitTop", "glow": true, "glowRadius": 2 },
-        { "tx": 5, "ty": 5, "tileId": "ladderBottom", "zlayer": "below" }
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 2,
+          "ty": 1,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 8,
+          "ty": 1,
+          "tileId": "bottlesOfLiquor"
+        },
+        {
+          "tx": 7,
+          "ty": 1,
+          "tileId": "crate"
+        },
+        {
+          "tx": 1,
+          "ty": 5,
+          "tileId": "openCrate"
+        },
+        {
+          "tx": 8,
+          "ty": 5,
+          "tileId": "skull"
+        },
+        {
+          "tx": 3,
+          "ty": 3,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 2,
+          "ty": 3,
+          "tileId": "candlestickLitTop",
+          "glow": true,
+          "glowRadius": 2
+        },
+        {
+          "tx": 5,
+          "ty": 5,
+          "tileId": "ladderBottom",
+          "zlayer": "below"
+        }
       ],
       "exits": [
-        { "tx": 5, "ty": 5, "toInteriorId": "fang-den", "entryTx": 9, "entryTy": 2, "direction": "up", "label": "Up to the tavern" }
+        {
+          "tx": 5,
+          "ty": 5,
+          "toInteriorId": "fang-den",
+          "entryTx": 9,
+          "entryTy": 2,
+          "direction": "up",
+          "label": "Up to the tavern"
+        }
       ]
     },
     "witch-hut": {
@@ -474,17 +1594,59 @@
       "floorTileId": "woodFloor",
       "wallTileId": "woodenSlats",
       "decor": [
-        { "tx": 1, "ty": 1, "tileId": "bookshelfTop" },
-        { "tx": 1, "ty": 2, "tileId": "bookshelfBottom" },
-        { "tx": 9, "ty": 1, "tileId": "bottlesOfLiquor" },
-        { "tx": 3, "ty": 1, "tileId": "skull" },
-        { "tx": 2, "ty": 5, "tileId": "potions" },
-        { "tx": 9, "ty": 5, "tileId": "bunchOfHerbs" },
-        { "tx": 5, "ty": 3, "tileId": "roundTableWithCloth" },
-        { "tx": 7, "ty": 3, "tileId": "candlestickLitTop", "glow": true, "glowRadius": 2 }
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "bookshelfTop"
+        },
+        {
+          "tx": 1,
+          "ty": 2,
+          "tileId": "bookshelfBottom"
+        },
+        {
+          "tx": 9,
+          "ty": 1,
+          "tileId": "bottlesOfLiquor"
+        },
+        {
+          "tx": 3,
+          "ty": 1,
+          "tileId": "skull"
+        },
+        {
+          "tx": 2,
+          "ty": 5,
+          "tileId": "potions"
+        },
+        {
+          "tx": 9,
+          "ty": 5,
+          "tileId": "bunchOfHerbs"
+        },
+        {
+          "tx": 5,
+          "ty": 3,
+          "tileId": "roundTableWithCloth"
+        },
+        {
+          "tx": 7,
+          "ty": 3,
+          "tileId": "candlestickLitTop",
+          "glow": true,
+          "glowRadius": 2
+        }
       ],
       "exits": [
-        { "tx": 5, "ty": 0, "toInteriorId": "witch-hut-brewing", "entryTx": 5, "entryTy": 6, "direction": "back", "label": "Brewing Room" }
+        {
+          "tx": 5,
+          "ty": 0,
+          "toInteriorId": "witch-hut-brewing",
+          "entryTx": 5,
+          "entryTy": 6,
+          "direction": "back",
+          "label": "Brewing Room"
+        }
       ]
     },
     "witch-hut-brewing": {
@@ -495,18 +1657,64 @@
       "wallTileId": "darkStone",
       "ambianceId": "hearth",
       "decor": [
-        { "tx": 5, "ty": 1, "tileId": "cauldren", "glow": true, "glowRadius": 2 },
-        { "tx": 1, "ty": 1, "bundleID": "dark-altar" },
-        { "tx": 9, "ty": 1, "tileId": "bookshelfTop" },
-        { "tx": 9, "ty": 2, "tileId": "bookshelfBottom" },
-        { "tx": 2, "ty": 4, "tileId": "bottlesOfLiquor" },
-        { "tx": 3, "ty": 4, "tileId": "potions" },
-        { "tx": 8, "ty": 4, "tileId": "bunchOfHerbs" },
-        { "tx": 7, "ty": 5, "tileId": "purpleMushroom" },
-        { "tx": 1, "ty": 5, "tileId": "skull" }
+        {
+          "tx": 5,
+          "ty": 1,
+          "tileId": "cauldren",
+          "glow": true,
+          "glowRadius": 2
+        },
+        {
+          "tx": 1,
+          "ty": 1,
+          "bundleID": "dark-altar"
+        },
+        {
+          "tx": 9,
+          "ty": 1,
+          "tileId": "bookshelfTop"
+        },
+        {
+          "tx": 9,
+          "ty": 2,
+          "tileId": "bookshelfBottom"
+        },
+        {
+          "tx": 2,
+          "ty": 4,
+          "tileId": "bottlesOfLiquor"
+        },
+        {
+          "tx": 3,
+          "ty": 4,
+          "tileId": "potions"
+        },
+        {
+          "tx": 8,
+          "ty": 4,
+          "tileId": "bunchOfHerbs"
+        },
+        {
+          "tx": 7,
+          "ty": 5,
+          "tileId": "purpleMushroom"
+        },
+        {
+          "tx": 1,
+          "ty": 5,
+          "tileId": "skull"
+        }
       ],
       "exits": [
-        { "tx": 5, "ty": 7, "toInteriorId": "witch-hut", "entryTx": 5, "entryTy": 1, "direction": "front", "label": "Front Room" }
+        {
+          "tx": 5,
+          "ty": 7,
+          "toInteriorId": "witch-hut",
+          "entryTx": 5,
+          "entryTy": 1,
+          "direction": "front",
+          "label": "Front Room"
+        }
       ]
     },
     "apothecary": {
@@ -516,17 +1724,61 @@
       "floorTileId": "woodFloor",
       "wallTileId": "woodenSlats",
       "decor": [
-        { "tx": 1, "ty": 1, "tileId": "bookshelfTop" },
-        { "tx": 1, "ty": 2, "tileId": "bookshelfBottom" },
-        { "tx": 8, "ty": 1, "tileId": "bookshelfTop" },
-        { "tx": 8, "ty": 2, "tileId": "bookshelfBottom" },
-        { "tx": 3, "ty": 1, "tileId": "potions" },
-        { "tx": 5, "ty": 1, "tileId": "bottlesOfLiquor" },
-        { "tx": 6, "ty": 1, "tileId": "bunchOfHerbs" },
-        { "tx": 2, "ty": 5, "tileId": "mushroomBasket" },
-        { "tx": 7, "ty": 5, "tileId": "purpleMushroom" },
-        { "tx": 4, "ty": 3, "tileId": "roundTable" },
-        { "tx": 5, "ty": 3, "tileId": "cauldren" }
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "bookshelfTop"
+        },
+        {
+          "tx": 1,
+          "ty": 2,
+          "tileId": "bookshelfBottom"
+        },
+        {
+          "tx": 8,
+          "ty": 1,
+          "tileId": "bookshelfTop"
+        },
+        {
+          "tx": 8,
+          "ty": 2,
+          "tileId": "bookshelfBottom"
+        },
+        {
+          "tx": 3,
+          "ty": 1,
+          "tileId": "potions"
+        },
+        {
+          "tx": 5,
+          "ty": 1,
+          "tileId": "bottlesOfLiquor"
+        },
+        {
+          "tx": 6,
+          "ty": 1,
+          "tileId": "bunchOfHerbs"
+        },
+        {
+          "tx": 2,
+          "ty": 5,
+          "tileId": "mushroomBasket"
+        },
+        {
+          "tx": 7,
+          "ty": 5,
+          "tileId": "purpleMushroom"
+        },
+        {
+          "tx": 4,
+          "ty": 3,
+          "tileId": "roundTable"
+        },
+        {
+          "tx": 5,
+          "ty": 3,
+          "tileId": "cauldren"
+        }
       ],
       "exits": []
     },
@@ -537,16 +1789,58 @@
       "floorTileId": "stoneFloor",
       "wallTileId": "darkStone",
       "decor": [
-        { "tx": 1, "ty": 1, "tileId": "skull" },
-        { "tx": 2, "ty": 1, "tileId": "skull" },
-        { "tx": 8, "ty": 1, "tileId": "skull" },
-        { "tx": 3, "ty": 1, "tileId": "crate" },
-        { "tx": 7, "ty": 1, "tileId": "openCrate" },
-        { "tx": 1, "ty": 5, "tileId": "pileOfSacks" },
-        { "tx": 8, "ty": 5, "tileId": "chest" },
-        { "tx": 4, "ty": 3, "tileId": "counterTop" },
-        { "tx": 5, "ty": 3, "tileId": "counterTop" },
-        { "tx": 6, "ty": 5, "tileId": "candlestickLitTop", "glow": true, "glowRadius": 2 }
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "skull"
+        },
+        {
+          "tx": 2,
+          "ty": 1,
+          "tileId": "skull"
+        },
+        {
+          "tx": 8,
+          "ty": 1,
+          "tileId": "skull"
+        },
+        {
+          "tx": 3,
+          "ty": 1,
+          "tileId": "crate"
+        },
+        {
+          "tx": 7,
+          "ty": 1,
+          "tileId": "openCrate"
+        },
+        {
+          "tx": 1,
+          "ty": 5,
+          "tileId": "pileOfSacks"
+        },
+        {
+          "tx": 8,
+          "ty": 5,
+          "tileId": "chest"
+        },
+        {
+          "tx": 4,
+          "ty": 3,
+          "tileId": "counterTop"
+        },
+        {
+          "tx": 5,
+          "ty": 3,
+          "tileId": "counterTop"
+        },
+        {
+          "tx": 6,
+          "ty": 5,
+          "tileId": "candlestickLitTop",
+          "glow": true,
+          "glowRadius": 2
+        }
       ],
       "exits": []
     },
@@ -557,15 +1851,51 @@
       "floorTileId": "darkWoodFloor",
       "wallTileId": "woodenSlats",
       "decor": [
-        { "tx": 1, "ty": 1, "tileId": "hayStack" },
-        { "tx": 2, "ty": 1, "tileId": "hayStack" },
-        { "tx": 9, "ty": 1, "tileId": "hayStack" },
-        { "tx": 4, "ty": 1, "tileId": "sack" },
-        { "tx": 5, "ty": 1, "tileId": "pileOfSacks" },
-        { "tx": 1, "ty": 5, "tileId": "barrel" },
-        { "tx": 9, "ty": 5, "tileId": "barrel" },
-        { "tx": 6, "ty": 3, "tileId": "logPile" },
-        { "tx": 8, "ty": 5, "tileId": "smallRock" }
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "hayStack"
+        },
+        {
+          "tx": 2,
+          "ty": 1,
+          "tileId": "hayStack"
+        },
+        {
+          "tx": 9,
+          "ty": 1,
+          "tileId": "hayStack"
+        },
+        {
+          "tx": 4,
+          "ty": 1,
+          "tileId": "sack"
+        },
+        {
+          "tx": 5,
+          "ty": 1,
+          "tileId": "pileOfSacks"
+        },
+        {
+          "tx": 1,
+          "ty": 5,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 9,
+          "ty": 5,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 6,
+          "ty": 3,
+          "tileId": "logPile"
+        },
+        {
+          "tx": 8,
+          "ty": 5,
+          "tileId": "smallRock"
+        }
       ],
       "exits": []
     },
@@ -577,16 +1907,65 @@
       "wallTileId": "darkStone",
       "ambianceId": "hearth",
       "decor": [
-        { "tx": 2, "ty": 2, "tileId": "greenPuddle", "zlayer": "below" },
-        { "tx": 3, "ty": 2, "tileId": "greenPuddle", "zlayer": "below" },
-        { "tx": 2, "ty": 3, "tileId": "darkPuddle", "zlayer": "below" },
-        { "tx": 3, "ty": 3, "tileId": "darkPuddle", "zlayer": "below" },
-        { "tx": 7, "ty": 2, "tileId": "lightPuddle", "zlayer": "below" },
-        { "tx": 8, "ty": 2, "tileId": "lightPuddle", "zlayer": "below" },
-        { "tx": 1, "ty": 1, "tileId": "barrel" },
-        { "tx": 9, "ty": 1, "tileId": "bottlesOfLiquor" },
-        { "tx": 5, "ty": 5, "tileId": "candlestickLitTop", "glow": true, "glowRadius": 2 },
-        { "tx": 1, "ty": 5, "tileId": "smallLilypad", "zlayer": "below" }
+        {
+          "tx": 2,
+          "ty": 2,
+          "tileId": "greenPuddle",
+          "zlayer": "below"
+        },
+        {
+          "tx": 3,
+          "ty": 2,
+          "tileId": "greenPuddle",
+          "zlayer": "below"
+        },
+        {
+          "tx": 2,
+          "ty": 3,
+          "tileId": "darkPuddle",
+          "zlayer": "below"
+        },
+        {
+          "tx": 3,
+          "ty": 3,
+          "tileId": "darkPuddle",
+          "zlayer": "below"
+        },
+        {
+          "tx": 7,
+          "ty": 2,
+          "tileId": "lightPuddle",
+          "zlayer": "below"
+        },
+        {
+          "tx": 8,
+          "ty": 2,
+          "tileId": "lightPuddle",
+          "zlayer": "below"
+        },
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 9,
+          "ty": 1,
+          "tileId": "bottlesOfLiquor"
+        },
+        {
+          "tx": 5,
+          "ty": 5,
+          "tileId": "candlestickLitTop",
+          "glow": true,
+          "glowRadius": 2
+        },
+        {
+          "tx": 1,
+          "ty": 5,
+          "tileId": "smallLilypad",
+          "zlayer": "below"
+        }
       ],
       "exits": []
     }

--- a/web/src/data/hub/ironholdkeep/config.json
+++ b/web/src/data/hub/ironholdkeep/config.json
@@ -309,6 +309,44 @@
           "tx": 6,
           "ty": 1
         }
+      ],
+      "levelDecor": [
+        {
+          "tx": 16,
+          "ty": 13,
+          "tileId": "lightBush",
+          "minLevel": 1
+        },
+        {
+          "tx": 18,
+          "ty": 13,
+          "tileId": "lightBush",
+          "minLevel": 1
+        },
+        {
+          "tx": 15,
+          "ty": 13,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 19,
+          "ty": 13,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 17,
+          "ty": 15,
+          "tileId": "largeSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 16,
+          "ty": 14,
+          "tileId": "potOfFlowers",
+          "minLevel": 3
+        }
       ]
     },
     {
@@ -327,6 +365,44 @@
           "tx": 2,
           "ty": 1
         }
+      ],
+      "levelDecor": [
+        {
+          "tx": 9,
+          "ty": 21,
+          "tileId": "crate",
+          "minLevel": 1
+        },
+        {
+          "tx": 11,
+          "ty": 21,
+          "tileId": "crate",
+          "minLevel": 1
+        },
+        {
+          "tx": 8,
+          "ty": 21,
+          "tileId": "chest",
+          "minLevel": 2
+        },
+        {
+          "tx": 12,
+          "ty": 21,
+          "tileId": "barrel",
+          "minLevel": 2
+        },
+        {
+          "tx": 10,
+          "ty": 23,
+          "tileId": "armourSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 9,
+          "ty": 22,
+          "tileId": "chest",
+          "minLevel": 3
+        }
       ]
     },
     {
@@ -344,6 +420,44 @@
         {
           "tx": 2,
           "ty": 1
+        }
+      ],
+      "levelDecor": [
+        {
+          "tx": 22,
+          "ty": 21,
+          "tileId": "lightBush",
+          "minLevel": 1
+        },
+        {
+          "tx": 24,
+          "ty": 21,
+          "tileId": "lightBush",
+          "minLevel": 1
+        },
+        {
+          "tx": 21,
+          "ty": 21,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 25,
+          "ty": 21,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 23,
+          "ty": 23,
+          "tileId": "largeSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 22,
+          "ty": 22,
+          "tileId": "potOfFlowers",
+          "minLevel": 3
         }
       ]
     },
@@ -514,6 +628,44 @@
           "ty": 1,
           "buildingId": "smithy"
         }
+      ],
+      "levelDecor": [
+        {
+          "tx": 11,
+          "ty": 43,
+          "tileId": "crate",
+          "minLevel": 1
+        },
+        {
+          "tx": 13,
+          "ty": 43,
+          "tileId": "crate",
+          "minLevel": 1
+        },
+        {
+          "tx": 10,
+          "ty": 43,
+          "tileId": "chest",
+          "minLevel": 2
+        },
+        {
+          "tx": 14,
+          "ty": 43,
+          "tileId": "barrel",
+          "minLevel": 2
+        },
+        {
+          "tx": 12,
+          "ty": 45,
+          "tileId": "armourSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 11,
+          "ty": 44,
+          "tileId": "chest",
+          "minLevel": 3
+        }
       ]
     },
     {
@@ -658,6 +810,44 @@
           "tx": 2,
           "ty": 1,
           "buildingId": "quartermasters-store"
+        }
+      ],
+      "levelDecor": [
+        {
+          "tx": 36,
+          "ty": 51,
+          "tileId": "crate",
+          "minLevel": 1
+        },
+        {
+          "tx": 38,
+          "ty": 51,
+          "tileId": "barrel",
+          "minLevel": 1
+        },
+        {
+          "tx": 35,
+          "ty": 51,
+          "tileId": "pileOfSacks",
+          "minLevel": 2
+        },
+        {
+          "tx": 39,
+          "ty": 51,
+          "tileId": "crate",
+          "minLevel": 2
+        },
+        {
+          "tx": 37,
+          "ty": 53,
+          "tileId": "goldSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 36,
+          "ty": 52,
+          "tileId": "goldChest",
+          "minLevel": 3
         }
       ]
     }
@@ -1424,46 +1614,202 @@
       "tileId": "archStoneDark",
       "zlayer": "above"
     },
-    { "comment": "Outer Bailey — braziers flanking the central road, glowing at night" },
-    { "tx": 15, "ty": 42, "tileId": "brazierTop", "glow": true, "glowRadius": 3 },
-    { "tx": 15, "ty": 43, "tileId": "brazierBottom" },
-    { "tx": 20, "ty": 42, "tileId": "brazierTop", "glow": true, "glowRadius": 3 },
-    { "tx": 20, "ty": 43, "tileId": "brazierBottom" },
-    { "tx": 15, "ty": 50, "tileId": "brazierTop", "glow": true, "glowRadius": 3 },
-    { "tx": 15, "ty": 51, "tileId": "brazierBottom" },
-    { "tx": 20, "ty": 50, "tileId": "brazierTop", "glow": true, "glowRadius": 3 },
-    { "tx": 20, "ty": 51, "tileId": "brazierBottom" },
-    { "comment": "Outer Bailey — outer gate braziers" },
-    { "tx": 15, "ty": 52, "tileId": "brazierTop", "glow": true, "glowRadius": 2 },
-    { "tx": 20, "ty": 52, "tileId": "brazierTop", "glow": true, "glowRadius": 2 },
-    { "comment": "drill yard — training gear and a campfire" },
-    { "tx": 22, "ty": 41, "tileId": "crate" },
-    { "tx": 23, "ty": 41, "tileId": "crate" },
-    { "tx": 24, "ty": 42, "tileId": "barrel" },
-    { "tx": 21, "ty": 40, "tileId": "campfireUnlit" },
-    { "tx": 26, "ty": 40, "tileId": "smallRock" },
-    { "comment": "stores stacked by the granary and quartermaster doors" },
-    { "tx": 4, "ty": 51, "tileId": "barrel" },
-    { "tx": 10, "ty": 44, "tileId": "sack" },
-    { "tx": 11, "ty": 44, "tileId": "sack" },
-    { "tx": 34, "ty": 44, "tileId": "crate" },
-    { "tx": 35, "ty": 44, "tileId": "openCrate" },
-    { "tx": 39, "ty": 51, "tileId": "barrel" },
-    { "comment": "supply wagons and stacked siege timber along the boulevard" },
-    { "tx": 3, "ty": 44, "tileId": "crate" },
-    { "tx": 8, "ty": 51, "tileId": "openCrate" },
-    { "tx": 28, "ty": 44, "tileId": "barrel" },
-    { "tx": 29, "ty": 44, "tileId": "barrel" },
-    { "tx": 32, "ty": 51, "tileId": "crate" },
-    { "tx": 33, "ty": 51, "tileId": "sack" },
-    { "comment": "rubble and rocks at the bailey wall lines" },
-    { "tx": 2, "ty": 48, "tileId": "smallRock" },
-    { "tx": 41, "ty": 48, "tileId": "smallRock" },
-    { "tx": 37, "ty": 40, "tileId": "smallRock" }
+    {
+      "comment": "Outer Bailey — braziers flanking the central road, glowing at night"
+    },
+    {
+      "tx": 15,
+      "ty": 42,
+      "tileId": "brazierTop",
+      "glow": true,
+      "glowRadius": 3
+    },
+    {
+      "tx": 15,
+      "ty": 43,
+      "tileId": "brazierBottom"
+    },
+    {
+      "tx": 20,
+      "ty": 42,
+      "tileId": "brazierTop",
+      "glow": true,
+      "glowRadius": 3
+    },
+    {
+      "tx": 20,
+      "ty": 43,
+      "tileId": "brazierBottom"
+    },
+    {
+      "tx": 15,
+      "ty": 50,
+      "tileId": "brazierTop",
+      "glow": true,
+      "glowRadius": 3
+    },
+    {
+      "tx": 15,
+      "ty": 51,
+      "tileId": "brazierBottom"
+    },
+    {
+      "tx": 20,
+      "ty": 50,
+      "tileId": "brazierTop",
+      "glow": true,
+      "glowRadius": 3
+    },
+    {
+      "tx": 20,
+      "ty": 51,
+      "tileId": "brazierBottom"
+    },
+    {
+      "comment": "Outer Bailey — outer gate braziers"
+    },
+    {
+      "tx": 15,
+      "ty": 52,
+      "tileId": "brazierTop",
+      "glow": true,
+      "glowRadius": 2
+    },
+    {
+      "tx": 20,
+      "ty": 52,
+      "tileId": "brazierTop",
+      "glow": true,
+      "glowRadius": 2
+    },
+    {
+      "comment": "drill yard — training gear and a campfire"
+    },
+    {
+      "tx": 22,
+      "ty": 41,
+      "tileId": "crate"
+    },
+    {
+      "tx": 23,
+      "ty": 41,
+      "tileId": "crate"
+    },
+    {
+      "tx": 24,
+      "ty": 42,
+      "tileId": "barrel"
+    },
+    {
+      "tx": 21,
+      "ty": 40,
+      "tileId": "campfireUnlit"
+    },
+    {
+      "tx": 26,
+      "ty": 40,
+      "tileId": "smallRock"
+    },
+    {
+      "comment": "stores stacked by the granary and quartermaster doors"
+    },
+    {
+      "tx": 4,
+      "ty": 51,
+      "tileId": "barrel"
+    },
+    {
+      "tx": 10,
+      "ty": 44,
+      "tileId": "sack"
+    },
+    {
+      "tx": 11,
+      "ty": 44,
+      "tileId": "sack"
+    },
+    {
+      "tx": 34,
+      "ty": 44,
+      "tileId": "crate"
+    },
+    {
+      "tx": 35,
+      "ty": 44,
+      "tileId": "openCrate"
+    },
+    {
+      "tx": 39,
+      "ty": 51,
+      "tileId": "barrel"
+    },
+    {
+      "comment": "supply wagons and stacked siege timber along the boulevard"
+    },
+    {
+      "tx": 3,
+      "ty": 44,
+      "tileId": "crate"
+    },
+    {
+      "tx": 8,
+      "ty": 51,
+      "tileId": "openCrate"
+    },
+    {
+      "tx": 28,
+      "ty": 44,
+      "tileId": "barrel"
+    },
+    {
+      "tx": 29,
+      "ty": 44,
+      "tileId": "barrel"
+    },
+    {
+      "tx": 32,
+      "ty": 51,
+      "tileId": "crate"
+    },
+    {
+      "tx": 33,
+      "ty": 51,
+      "tileId": "sack"
+    },
+    {
+      "comment": "rubble and rocks at the bailey wall lines"
+    },
+    {
+      "tx": 2,
+      "ty": 48,
+      "tileId": "smallRock"
+    },
+    {
+      "tx": 41,
+      "ty": 48,
+      "tileId": "smallRock"
+    },
+    {
+      "tx": 37,
+      "ty": 40,
+      "tileId": "smallRock"
+    }
   ],
   "npcSpawnTiles": [],
   "chickenZones": [
-    { "rect": [ 13, 17, 16, 20 ], "count": 4, "roost": [ 14, 18 ] }
+    {
+      "rect": [
+        13,
+        17,
+        16,
+        20
+      ],
+      "count": 4,
+      "roost": [
+        14,
+        18
+      ]
+    }
   ],
   "animals": [
     {
@@ -1473,7 +1819,9 @@
       "tx": 18,
       "ty": 45,
       "name": "Fang",
-      "dialogue": [ "*a low, watchful growl, then a tail-wag*" ],
+      "dialogue": [
+        "*a low, watchful growl, then a tail-wag*"
+      ],
       "roam": true
     },
     {
@@ -1483,7 +1831,9 @@
       "tx": 22,
       "ty": 22,
       "name": "Wolf",
-      "dialogue": [ "*woof! — the old guard-dog knows a friend*" ],
+      "dialogue": [
+        "*woof! — the old guard-dog knows a friend*"
+      ],
       "roam": true
     },
     {
@@ -1493,7 +1843,9 @@
       "tx": 17,
       "ty": 30,
       "name": "Raven",
-      "dialogue": [ "*the keep's raven eyes you, unblinking*" ],
+      "dialogue": [
+        "*the keep's raven eyes you, unblinking*"
+      ],
       "roam": true
     },
     {
@@ -1503,7 +1855,9 @@
       "tx": 25,
       "ty": 21,
       "name": "Raven",
-      "dialogue": [ "*Kraa! It ruffles its black feathers*" ],
+      "dialogue": [
+        "*Kraa! It ruffles its black feathers*"
+      ],
       "roam": true
     }
   ],
@@ -1525,13 +1879,67 @@
       "questReceive": "castle-missing-patrol",
       "dialogueTree": "varek-chat",
       "schedule": [
-        { "startHour": 0, "endHour": 7, "activity": "sleep", "location": { "type": "interior", "buildingId": "keep-solar", "tx": 1, "ty": 2 } },
-        { "startHour": 7, "endHour": 12, "activity": "work", "location": { "type": "interior", "buildingId": "keep-war-room", "tx": 5, "ty": 5 } },
-        { "startHour": 12, "endHour": 14, "activity": "eat", "location": { "type": "interior", "buildingId": "kitchens", "tx": 6, "ty": 5 } },
-        { "startHour": 14, "endHour": 20, "activity": "idle-chat", "location": { "type": "interior", "buildingId": "keep", "tx": 7, "ty": 5 } },
-        { "startHour": 20, "endHour": 0, "activity": "work", "location": { "type": "interior", "buildingId": "keep-war-room", "tx": 5, "ty": 5 } }
+        {
+          "startHour": 0,
+          "endHour": 7,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "keep-solar",
+            "tx": 1,
+            "ty": 2
+          }
+        },
+        {
+          "startHour": 7,
+          "endHour": 12,
+          "activity": "work",
+          "location": {
+            "type": "interior",
+            "buildingId": "keep-war-room",
+            "tx": 5,
+            "ty": 5
+          }
+        },
+        {
+          "startHour": 12,
+          "endHour": 14,
+          "activity": "eat",
+          "location": {
+            "type": "interior",
+            "buildingId": "kitchens",
+            "tx": 6,
+            "ty": 5
+          }
+        },
+        {
+          "startHour": 14,
+          "endHour": 20,
+          "activity": "idle-chat",
+          "location": {
+            "type": "interior",
+            "buildingId": "keep",
+            "tx": 7,
+            "ty": 5
+          }
+        },
+        {
+          "startHour": 20,
+          "endHour": 0,
+          "activity": "work",
+          "location": {
+            "type": "interior",
+            "buildingId": "keep-war-room",
+            "tx": 5,
+            "ty": 5
+          }
+        }
       ],
-      "homeBed": { "buildingId": "keep-solar", "tx": 1, "ty": 2 }
+      "homeBed": {
+        "buildingId": "keep-solar",
+        "tx": 1,
+        "ty": 2
+      }
     },
     {
       "id": "castle-guard-master",
@@ -1547,13 +1955,65 @@
       "questGive": "castle-watch-rotation",
       "questReceive": "castle-watch-rotation",
       "schedule": [
-        { "startHour": 0, "endHour": 6, "activity": "sleep", "location": { "type": "interior", "buildingId": "barracks", "tx": 9, "ty": 6 } },
-        { "startHour": 6, "endHour": 13, "activity": "work", "location": { "type": "exterior", "tx": 20, "ty": 22 } },
-        { "startHour": 13, "endHour": 19, "activity": "work", "location": { "type": "exterior", "tx": 12, "ty": 22 } },
-        { "startHour": 19, "endHour": 22, "activity": "eat", "location": { "type": "interior", "buildingId": "kitchens", "tx": 8, "ty": 4 } },
-        { "startHour": 22, "endHour": 0, "activity": "idle-chat", "location": { "type": "interior", "buildingId": "barracks", "tx": 6, "ty": 6 } }
+        {
+          "startHour": 0,
+          "endHour": 6,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "barracks",
+            "tx": 9,
+            "ty": 6
+          }
+        },
+        {
+          "startHour": 6,
+          "endHour": 13,
+          "activity": "work",
+          "location": {
+            "type": "exterior",
+            "tx": 20,
+            "ty": 22
+          }
+        },
+        {
+          "startHour": 13,
+          "endHour": 19,
+          "activity": "work",
+          "location": {
+            "type": "exterior",
+            "tx": 12,
+            "ty": 22
+          }
+        },
+        {
+          "startHour": 19,
+          "endHour": 22,
+          "activity": "eat",
+          "location": {
+            "type": "interior",
+            "buildingId": "kitchens",
+            "tx": 8,
+            "ty": 4
+          }
+        },
+        {
+          "startHour": 22,
+          "endHour": 0,
+          "activity": "idle-chat",
+          "location": {
+            "type": "interior",
+            "buildingId": "barracks",
+            "tx": 6,
+            "ty": 6
+          }
+        }
       ],
-      "homeBed": { "buildingId": "barracks", "tx": 9, "ty": 6 }
+      "homeBed": {
+        "buildingId": "barracks",
+        "tx": 9,
+        "ty": 6
+      }
     },
     {
       "id": "castle-blacksmith",
@@ -1570,12 +2030,56 @@
       "questGive": "castle-weapon-cache",
       "questReceive": "castle-weapon-cache",
       "schedule": [
-        { "startHour": 0, "endHour": 6, "activity": "sleep", "location": { "type": "interior", "buildingId": "barracks", "tx": 3, "ty": 6 } },
-        { "startHour": 6, "endHour": 19, "activity": "work", "location": { "type": "interior", "buildingId": "smithy", "tx": 5, "ty": 4 } },
-        { "startHour": 19, "endHour": 22, "activity": "eat", "location": { "type": "interior", "buildingId": "kitchens", "tx": 6, "ty": 5 } },
-        { "startHour": 22, "endHour": 0, "activity": "sleep", "location": { "type": "interior", "buildingId": "barracks", "tx": 3, "ty": 6 } }
+        {
+          "startHour": 0,
+          "endHour": 6,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "barracks",
+            "tx": 3,
+            "ty": 6
+          }
+        },
+        {
+          "startHour": 6,
+          "endHour": 19,
+          "activity": "work",
+          "location": {
+            "type": "interior",
+            "buildingId": "smithy",
+            "tx": 5,
+            "ty": 4
+          }
+        },
+        {
+          "startHour": 19,
+          "endHour": 22,
+          "activity": "eat",
+          "location": {
+            "type": "interior",
+            "buildingId": "kitchens",
+            "tx": 6,
+            "ty": 5
+          }
+        },
+        {
+          "startHour": 22,
+          "endHour": 0,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "barracks",
+            "tx": 3,
+            "ty": 6
+          }
+        }
       ],
-      "homeBed": { "buildingId": "barracks", "tx": 3, "ty": 6 }
+      "homeBed": {
+        "buildingId": "barracks",
+        "tx": 3,
+        "ty": 6
+      }
     },
     {
       "id": "castle-quartermaster",
@@ -1592,12 +2096,56 @@
       "questGive": "castle-supply-tally",
       "questReceive": "castle-supply-tally",
       "schedule": [
-        { "startHour": 0, "endHour": 7, "activity": "sleep", "location": { "type": "interior", "buildingId": "quartermasters-store", "tx": 8, "ty": 5 } },
-        { "startHour": 7, "endHour": 13, "activity": "work", "location": { "type": "interior", "buildingId": "quartermasters-store", "tx": 5, "ty": 4 } },
-        { "startHour": 13, "endHour": 17, "activity": "work", "location": { "type": "interior", "buildingId": "granary", "tx": 4, "ty": 4 } },
-        { "startHour": 17, "endHour": 0, "activity": "work", "location": { "type": "interior", "buildingId": "quartermasters-store", "tx": 5, "ty": 4 } }
+        {
+          "startHour": 0,
+          "endHour": 7,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "quartermasters-store",
+            "tx": 8,
+            "ty": 5
+          }
+        },
+        {
+          "startHour": 7,
+          "endHour": 13,
+          "activity": "work",
+          "location": {
+            "type": "interior",
+            "buildingId": "quartermasters-store",
+            "tx": 5,
+            "ty": 4
+          }
+        },
+        {
+          "startHour": 13,
+          "endHour": 17,
+          "activity": "work",
+          "location": {
+            "type": "interior",
+            "buildingId": "granary",
+            "tx": 4,
+            "ty": 4
+          }
+        },
+        {
+          "startHour": 17,
+          "endHour": 0,
+          "activity": "work",
+          "location": {
+            "type": "interior",
+            "buildingId": "quartermasters-store",
+            "tx": 5,
+            "ty": 4
+          }
+        }
       ],
-      "homeBed": { "buildingId": "quartermasters-store", "tx": 8, "ty": 5 }
+      "homeBed": {
+        "buildingId": "quartermasters-store",
+        "tx": 8,
+        "ty": 5
+      }
     },
     {
       "id": "castle-cook",
@@ -1614,11 +2162,45 @@
       "questGive": "castle-feast-preparations",
       "questReceive": "castle-feast-preparations",
       "schedule": [
-        { "startHour": 0, "endHour": 5, "activity": "sleep", "location": { "type": "interior", "buildingId": "kitchens", "tx": 10, "ty": 5 } },
-        { "startHour": 5, "endHour": 21, "activity": "work", "location": { "type": "interior", "buildingId": "kitchens", "tx": 6, "ty": 4 } },
-        { "startHour": 21, "endHour": 0, "activity": "sweep", "location": { "type": "interior", "buildingId": "kitchens", "tx": 8, "ty": 5 } }
+        {
+          "startHour": 0,
+          "endHour": 5,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "kitchens",
+            "tx": 10,
+            "ty": 5
+          }
+        },
+        {
+          "startHour": 5,
+          "endHour": 21,
+          "activity": "work",
+          "location": {
+            "type": "interior",
+            "buildingId": "kitchens",
+            "tx": 6,
+            "ty": 4
+          }
+        },
+        {
+          "startHour": 21,
+          "endHour": 0,
+          "activity": "sweep",
+          "location": {
+            "type": "interior",
+            "buildingId": "kitchens",
+            "tx": 8,
+            "ty": 5
+          }
+        }
       ],
-      "homeBed": { "buildingId": "kitchens", "tx": 10, "ty": 5 }
+      "homeBed": {
+        "buildingId": "kitchens",
+        "tx": 10,
+        "ty": 5
+      }
     },
     {
       "id": "castle-chaplain",
@@ -1635,12 +2217,56 @@
       "questGive": "castle-restless-crypt",
       "questReceive": "castle-restless-crypt",
       "schedule": [
-        { "startHour": 0, "endHour": 6, "activity": "sleep", "location": { "type": "interior", "buildingId": "chapel-crypt", "tx": 10, "ty": 4 } },
-        { "startHour": 6, "endHour": 12, "activity": "idle-chat", "location": { "type": "interior", "buildingId": "chapel", "tx": 6, "ty": 5 } },
-        { "startHour": 12, "endHour": 14, "activity": "eat", "location": { "type": "interior", "buildingId": "kitchens", "tx": 6, "ty": 5 } },
-        { "startHour": 14, "endHour": 0, "activity": "idle-chat", "location": { "type": "interior", "buildingId": "chapel", "tx": 6, "ty": 5 } }
+        {
+          "startHour": 0,
+          "endHour": 6,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "chapel-crypt",
+            "tx": 10,
+            "ty": 4
+          }
+        },
+        {
+          "startHour": 6,
+          "endHour": 12,
+          "activity": "idle-chat",
+          "location": {
+            "type": "interior",
+            "buildingId": "chapel",
+            "tx": 6,
+            "ty": 5
+          }
+        },
+        {
+          "startHour": 12,
+          "endHour": 14,
+          "activity": "eat",
+          "location": {
+            "type": "interior",
+            "buildingId": "kitchens",
+            "tx": 6,
+            "ty": 5
+          }
+        },
+        {
+          "startHour": 14,
+          "endHour": 0,
+          "activity": "idle-chat",
+          "location": {
+            "type": "interior",
+            "buildingId": "chapel",
+            "tx": 6,
+            "ty": 5
+          }
+        }
       ],
-      "homeBed": { "buildingId": "chapel-crypt", "tx": 10, "ty": 4 }
+      "homeBed": {
+        "buildingId": "chapel-crypt",
+        "tx": 10,
+        "ty": 4
+      }
     },
     {
       "id": "castle-archivist",
@@ -1657,11 +2283,45 @@
       "questGive": "castle-siege-memory",
       "questReceive": "castle-siege-memory",
       "schedule": [
-        { "startHour": 0, "endHour": 7, "activity": "sleep", "location": { "type": "interior", "buildingId": "scriptorium", "tx": 1, "ty": 6 } },
-        { "startHour": 7, "endHour": 19, "activity": "work", "location": { "type": "interior", "buildingId": "scriptorium", "tx": 5, "ty": 5 } },
-        { "startHour": 19, "endHour": 0, "activity": "work", "location": { "type": "interior", "buildingId": "scriptorium", "tx": 7, "ty": 4 } }
+        {
+          "startHour": 0,
+          "endHour": 7,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "scriptorium",
+            "tx": 1,
+            "ty": 6
+          }
+        },
+        {
+          "startHour": 7,
+          "endHour": 19,
+          "activity": "work",
+          "location": {
+            "type": "interior",
+            "buildingId": "scriptorium",
+            "tx": 5,
+            "ty": 5
+          }
+        },
+        {
+          "startHour": 19,
+          "endHour": 0,
+          "activity": "work",
+          "location": {
+            "type": "interior",
+            "buildingId": "scriptorium",
+            "tx": 7,
+            "ty": 4
+          }
+        }
       ],
-      "homeBed": { "buildingId": "scriptorium", "tx": 1, "ty": 6 }
+      "homeBed": {
+        "buildingId": "scriptorium",
+        "tx": 1,
+        "ty": 6
+      }
     },
     {
       "id": "castle-stablehand",
@@ -1678,12 +2338,56 @@
       "questGive": "castle-lost-foal",
       "questReceive": "castle-lost-foal",
       "schedule": [
-        { "startHour": 0, "endHour": 6, "activity": "sleep", "location": { "type": "interior", "buildingId": "stables", "tx": 10, "ty": 6 } },
-        { "startHour": 6, "endHour": 18, "activity": "work", "location": { "type": "interior", "buildingId": "stables", "tx": 5, "ty": 4 } },
-        { "startHour": 18, "endHour": 20, "activity": "eat", "location": { "type": "interior", "buildingId": "kitchens", "tx": 8, "ty": 4 } },
-        { "startHour": 20, "endHour": 0, "activity": "sweep", "location": { "type": "interior", "buildingId": "stables", "tx": 8, "ty": 5 } }
+        {
+          "startHour": 0,
+          "endHour": 6,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "stables",
+            "tx": 10,
+            "ty": 6
+          }
+        },
+        {
+          "startHour": 6,
+          "endHour": 18,
+          "activity": "work",
+          "location": {
+            "type": "interior",
+            "buildingId": "stables",
+            "tx": 5,
+            "ty": 4
+          }
+        },
+        {
+          "startHour": 18,
+          "endHour": 20,
+          "activity": "eat",
+          "location": {
+            "type": "interior",
+            "buildingId": "kitchens",
+            "tx": 8,
+            "ty": 4
+          }
+        },
+        {
+          "startHour": 20,
+          "endHour": 0,
+          "activity": "sweep",
+          "location": {
+            "type": "interior",
+            "buildingId": "stables",
+            "tx": 8,
+            "ty": 5
+          }
+        }
       ],
-      "homeBed": { "buildingId": "stables", "tx": 10, "ty": 6 }
+      "homeBed": {
+        "buildingId": "stables",
+        "tx": 10,
+        "ty": 6
+      }
     },
     {
       "id": "castle-knight",
@@ -1698,13 +2402,65 @@
       ],
       "questReceive": "castle-watch-rotation",
       "schedule": [
-        { "startHour": 0, "endHour": 6, "activity": "sleep", "location": { "type": "interior", "buildingId": "barracks", "tx": 6, "ty": 6 } },
-        { "startHour": 6, "endHour": 12, "activity": "work", "location": { "type": "exterior", "tx": 25, "ty": 22 } },
-        { "startHour": 12, "endHour": 18, "activity": "work", "location": { "type": "exterior", "tx": 31, "ty": 43 } },
-        { "startHour": 18, "endHour": 21, "activity": "eat", "location": { "type": "interior", "buildingId": "kitchens", "tx": 6, "ty": 4 } },
-        { "startHour": 21, "endHour": 0, "activity": "sleep", "location": { "type": "interior", "buildingId": "barracks", "tx": 6, "ty": 6 } }
+        {
+          "startHour": 0,
+          "endHour": 6,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "barracks",
+            "tx": 6,
+            "ty": 6
+          }
+        },
+        {
+          "startHour": 6,
+          "endHour": 12,
+          "activity": "work",
+          "location": {
+            "type": "exterior",
+            "tx": 25,
+            "ty": 22
+          }
+        },
+        {
+          "startHour": 12,
+          "endHour": 18,
+          "activity": "work",
+          "location": {
+            "type": "exterior",
+            "tx": 31,
+            "ty": 43
+          }
+        },
+        {
+          "startHour": 18,
+          "endHour": 21,
+          "activity": "eat",
+          "location": {
+            "type": "interior",
+            "buildingId": "kitchens",
+            "tx": 6,
+            "ty": 4
+          }
+        },
+        {
+          "startHour": 21,
+          "endHour": 0,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "barracks",
+            "tx": 6,
+            "ty": 6
+          }
+        }
       ],
-      "homeBed": { "buildingId": "barracks", "tx": 6, "ty": 6 }
+      "homeBed": {
+        "buildingId": "barracks",
+        "tx": 6,
+        "ty": 6
+      }
     },
     {
       "id": "castle-squire",
@@ -1720,13 +2476,66 @@
       "questGive": "castle-squires-trial",
       "questReceive": "castle-squires-trial",
       "schedule": [
-        { "startHour": 0, "endHour": 6, "activity": "sleep", "location": { "type": "interior", "buildingId": "barracks", "tx": 8, "ty": 6 } },
-        { "startHour": 6, "endHour": 10, "activity": "work", "location": { "type": "interior", "buildingId": "stables", "tx": 8, "ty": 5 } },
-        { "startHour": 10, "endHour": 17, "activity": "work", "location": { "type": "exterior", "tx": 17, "ty": 40 } },
-        { "startHour": 17, "endHour": 20, "activity": "eat", "location": { "type": "interior", "buildingId": "kitchens", "tx": 8, "ty": 4 } },
-        { "startHour": 20, "endHour": 0, "activity": "sleep", "location": { "type": "interior", "buildingId": "barracks", "tx": 8, "ty": 6 } }
+        {
+          "startHour": 0,
+          "endHour": 6,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "barracks",
+            "tx": 8,
+            "ty": 6
+          }
+        },
+        {
+          "startHour": 6,
+          "endHour": 10,
+          "activity": "work",
+          "location": {
+            "type": "interior",
+            "buildingId": "stables",
+            "tx": 8,
+            "ty": 5
+          }
+        },
+        {
+          "startHour": 10,
+          "endHour": 17,
+          "activity": "work",
+          "location": {
+            "type": "exterior",
+            "tx": 17,
+            "ty": 40
+          }
+        },
+        {
+          "startHour": 17,
+          "endHour": 20,
+          "activity": "eat",
+          "location": {
+            "type": "interior",
+            "buildingId": "kitchens",
+            "tx": 8,
+            "ty": 4
+          }
+        },
+        {
+          "startHour": 20,
+          "endHour": 0,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "barracks",
+            "tx": 8,
+            "ty": 6
+          }
+        }
       ],
-      "homeBed": { "buildingId": "barracks", "tx": 8, "ty": 6 }
+      "homeBed": {
+        "buildingId": "barracks",
+        "tx": 8,
+        "ty": 6
+      }
     },
     {
       "id": "castle-gatekeeper",
@@ -1740,9 +2549,36 @@
         "Safe roads, traveller. The world beyond these walls is less forgiving."
       ],
       "schedule": [
-        { "startHour": 0, "endHour": 8, "activity": "work", "location": { "type": "exterior", "tx": 17, "ty": 46 } },
-        { "startHour": 8, "endHour": 20, "activity": "work", "location": { "type": "exterior", "tx": 17, "ty": 30 } },
-        { "startHour": 20, "endHour": 0, "activity": "work", "location": { "type": "exterior", "tx": 17, "ty": 46 } }
+        {
+          "startHour": 0,
+          "endHour": 8,
+          "activity": "work",
+          "location": {
+            "type": "exterior",
+            "tx": 17,
+            "ty": 46
+          }
+        },
+        {
+          "startHour": 8,
+          "endHour": 20,
+          "activity": "work",
+          "location": {
+            "type": "exterior",
+            "tx": 17,
+            "ty": 30
+          }
+        },
+        {
+          "startHour": 20,
+          "endHour": 0,
+          "activity": "work",
+          "location": {
+            "type": "exterior",
+            "tx": 17,
+            "ty": 46
+          }
+        }
       ]
     },
     {
@@ -1773,12 +2609,54 @@
       ],
       "questReceive": "castle-missing-patrol",
       "schedule": [
-        { "startHour": 0, "endHour": 6, "activity": "sleep", "location": { "type": "interior", "buildingId": "barracks", "tx": 1, "ty": 6 } },
-        { "startHour": 6, "endHour": 14, "activity": "work", "location": { "type": "exterior", "tx": 10, "ty": 21 } },
-        { "startHour": 14, "endHour": 21, "activity": "work", "location": { "type": "exterior", "tx": 8, "ty": 43 } },
-        { "startHour": 21, "endHour": 0, "activity": "sleep", "location": { "type": "interior", "buildingId": "barracks", "tx": 1, "ty": 6 } }
+        {
+          "startHour": 0,
+          "endHour": 6,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "barracks",
+            "tx": 1,
+            "ty": 6
+          }
+        },
+        {
+          "startHour": 6,
+          "endHour": 14,
+          "activity": "work",
+          "location": {
+            "type": "exterior",
+            "tx": 10,
+            "ty": 21
+          }
+        },
+        {
+          "startHour": 14,
+          "endHour": 21,
+          "activity": "work",
+          "location": {
+            "type": "exterior",
+            "tx": 8,
+            "ty": 43
+          }
+        },
+        {
+          "startHour": 21,
+          "endHour": 0,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "barracks",
+            "tx": 1,
+            "ty": 6
+          }
+        }
       ],
-      "homeBed": { "buildingId": "barracks", "tx": 1, "ty": 6 }
+      "homeBed": {
+        "buildingId": "barracks",
+        "tx": 1,
+        "ty": 6
+      }
     },
     {
       "id": "castle-guard-2",
@@ -1793,12 +2671,54 @@
       ],
       "questReceive": "castle-missing-patrol",
       "schedule": [
-        { "startHour": 0, "endHour": 7, "activity": "sleep", "location": { "type": "interior", "buildingId": "barracks", "tx": 2, "ty": 6 } },
-        { "startHour": 7, "endHour": 15, "activity": "work", "location": { "type": "exterior", "tx": 25, "ty": 21 } },
-        { "startHour": 15, "endHour": 22, "activity": "work", "location": { "type": "exterior", "tx": 31, "ty": 51 } },
-        { "startHour": 22, "endHour": 0, "activity": "sleep", "location": { "type": "interior", "buildingId": "barracks", "tx": 2, "ty": 6 } }
+        {
+          "startHour": 0,
+          "endHour": 7,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "barracks",
+            "tx": 2,
+            "ty": 6
+          }
+        },
+        {
+          "startHour": 7,
+          "endHour": 15,
+          "activity": "work",
+          "location": {
+            "type": "exterior",
+            "tx": 25,
+            "ty": 21
+          }
+        },
+        {
+          "startHour": 15,
+          "endHour": 22,
+          "activity": "work",
+          "location": {
+            "type": "exterior",
+            "tx": 31,
+            "ty": 51
+          }
+        },
+        {
+          "startHour": 22,
+          "endHour": 0,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "barracks",
+            "tx": 2,
+            "ty": 6
+          }
+        }
       ],
-      "homeBed": { "buildingId": "barracks", "tx": 2, "ty": 6 }
+      "homeBed": {
+        "buildingId": "barracks",
+        "tx": 2,
+        "ty": 6
+      }
     }
   ],
   "interiors": {
@@ -2414,17 +3334,59 @@
       "floorTileId": "woodFloor",
       "wallTileId": "woodWall",
       "decor": [
-        { "comment": "feed barrels and hay sacks along the stalls" },
-        { "tx": 1, "ty": 1, "tileId": "sack" },
-        { "tx": 2, "ty": 1, "tileId": "sack" },
-        { "tx": 1, "ty": 2, "tileId": "barrel" },
-        { "tx": 10, "ty": 1, "tileId": "sack" },
-        { "tx": 10, "ty": 2, "tileId": "barrel" },
-        { "tx": 5, "ty": 1, "tileId": "openCrate" },
-        { "tx": 6, "ty": 1, "tileId": "crate" },
-        { "tx": 3, "ty": 5, "tileId": "barrel" },
-        { "tx": 8, "ty": 5, "tileId": "crate" },
-        { "tx": 5, "ty": 6, "tileId": "chest" }
+        {
+          "comment": "feed barrels and hay sacks along the stalls"
+        },
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "sack"
+        },
+        {
+          "tx": 2,
+          "ty": 1,
+          "tileId": "sack"
+        },
+        {
+          "tx": 1,
+          "ty": 2,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 10,
+          "ty": 1,
+          "tileId": "sack"
+        },
+        {
+          "tx": 10,
+          "ty": 2,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 5,
+          "ty": 1,
+          "tileId": "openCrate"
+        },
+        {
+          "tx": 6,
+          "ty": 1,
+          "tileId": "crate"
+        },
+        {
+          "tx": 3,
+          "ty": 5,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 8,
+          "ty": 5,
+          "tileId": "crate"
+        },
+        {
+          "tx": 5,
+          "ty": 6,
+          "tileId": "chest"
+        }
       ],
       "exits": []
     },
@@ -2436,18 +3398,64 @@
       "wallTileId": "reinforcedStone",
       "musicId": "shop",
       "decor": [
-        { "comment": "forge fire and weapon racks" },
-        { "tx": 4, "ty": 1, "tileId": "brazierTop" },
-        { "tx": 4, "ty": 2, "tileId": "brazierBottom" },
-        { "tx": 1, "ty": 1, "tileId": "swordMountedLeft" },
-        { "tx": 2, "ty": 1, "tileId": "shieldMounted" },
-        { "tx": 7, "ty": 1, "tileId": "swordMountedRight" },
-        { "tx": 8, "ty": 1, "tileId": "suitOfArmourTop" },
-        { "tx": 8, "ty": 2, "tileId": "suitOfArmourBottom" },
-        { "tx": 1, "ty": 5, "tileId": "barrel" },
-        { "tx": 2, "ty": 5, "tileId": "crate" },
-        { "tx": 7, "ty": 5, "tileId": "chest" },
-        { "tx": 4, "ty": 4, "tileId": "barrel" }
+        {
+          "comment": "forge fire and weapon racks"
+        },
+        {
+          "tx": 4,
+          "ty": 1,
+          "tileId": "brazierTop"
+        },
+        {
+          "tx": 4,
+          "ty": 2,
+          "tileId": "brazierBottom"
+        },
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "swordMountedLeft"
+        },
+        {
+          "tx": 2,
+          "ty": 1,
+          "tileId": "shieldMounted"
+        },
+        {
+          "tx": 7,
+          "ty": 1,
+          "tileId": "swordMountedRight"
+        },
+        {
+          "tx": 8,
+          "ty": 1,
+          "tileId": "suitOfArmourTop"
+        },
+        {
+          "tx": 8,
+          "ty": 2,
+          "tileId": "suitOfArmourBottom"
+        },
+        {
+          "tx": 1,
+          "ty": 5,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 2,
+          "ty": 5,
+          "tileId": "crate"
+        },
+        {
+          "tx": 7,
+          "ty": 5,
+          "tileId": "chest"
+        },
+        {
+          "tx": 4,
+          "ty": 4,
+          "tileId": "barrel"
+        }
       ],
       "exits": []
     },
@@ -2460,29 +3468,113 @@
       "musicId": "church",
       "ambianceId": "sacred",
       "decor": [
-        { "comment": "altar on the back wall" },
-        { "tx": 5, "ty": 0, "tileId": "altarTopLeft" },
-        { "tx": 6, "ty": 0, "tileId": "altarTopMid" },
-        { "tx": 7, "ty": 0, "tileId": "altarTopRight" },
-        { "tx": 5, "ty": 1, "tileId": "altarMidLeft" },
-        { "tx": 6, "ty": 1, "tileId": "altarMidMid" },
-        { "tx": 7, "ty": 1, "tileId": "altarMidRight" },
-        { "tx": 5, "ty": 2, "tileId": "altarBotLeft" },
-        { "tx": 6, "ty": 2, "tileId": "altarBotMid" },
-        { "tx": 7, "ty": 2, "tileId": "altarBotRight" },
-        { "comment": "candlesticks flanking the altar" },
-        { "tx": 3, "ty": 1, "tileId": "candlestickLitTop" },
-        { "tx": 9, "ty": 1, "tileId": "candlestickLitTop" },
-        { "comment": "pews" },
-        { "tx": 4, "ty": 4, "tileId": "stool" },
-        { "tx": 5, "ty": 4, "tileId": "stool" },
-        { "tx": 7, "ty": 4, "tileId": "stool" },
-        { "tx": 4, "ty": 6, "tileId": "stool" },
-        { "tx": 5, "ty": 6, "tileId": "stool" },
-        { "tx": 7, "ty": 6, "tileId": "stool" },
-        { "comment": "stairway down to the crypt" },
-        { "tx": 1, "ty": 7, "tileId": "ladderBottom" },
-        { "tx": 1, "ty": 6, "tileId": "fullLadderTop" }
+        {
+          "comment": "altar on the back wall"
+        },
+        {
+          "tx": 5,
+          "ty": 0,
+          "tileId": "altarTopLeft"
+        },
+        {
+          "tx": 6,
+          "ty": 0,
+          "tileId": "altarTopMid"
+        },
+        {
+          "tx": 7,
+          "ty": 0,
+          "tileId": "altarTopRight"
+        },
+        {
+          "tx": 5,
+          "ty": 1,
+          "tileId": "altarMidLeft"
+        },
+        {
+          "tx": 6,
+          "ty": 1,
+          "tileId": "altarMidMid"
+        },
+        {
+          "tx": 7,
+          "ty": 1,
+          "tileId": "altarMidRight"
+        },
+        {
+          "tx": 5,
+          "ty": 2,
+          "tileId": "altarBotLeft"
+        },
+        {
+          "tx": 6,
+          "ty": 2,
+          "tileId": "altarBotMid"
+        },
+        {
+          "tx": 7,
+          "ty": 2,
+          "tileId": "altarBotRight"
+        },
+        {
+          "comment": "candlesticks flanking the altar"
+        },
+        {
+          "tx": 3,
+          "ty": 1,
+          "tileId": "candlestickLitTop"
+        },
+        {
+          "tx": 9,
+          "ty": 1,
+          "tileId": "candlestickLitTop"
+        },
+        {
+          "comment": "pews"
+        },
+        {
+          "tx": 4,
+          "ty": 4,
+          "tileId": "stool"
+        },
+        {
+          "tx": 5,
+          "ty": 4,
+          "tileId": "stool"
+        },
+        {
+          "tx": 7,
+          "ty": 4,
+          "tileId": "stool"
+        },
+        {
+          "tx": 4,
+          "ty": 6,
+          "tileId": "stool"
+        },
+        {
+          "tx": 5,
+          "ty": 6,
+          "tileId": "stool"
+        },
+        {
+          "tx": 7,
+          "ty": 6,
+          "tileId": "stool"
+        },
+        {
+          "comment": "stairway down to the crypt"
+        },
+        {
+          "tx": 1,
+          "ty": 7,
+          "tileId": "ladderBottom"
+        },
+        {
+          "tx": 1,
+          "ty": 6,
+          "tileId": "fullLadderTop"
+        }
       ],
       "exits": [
         {
@@ -2504,21 +3596,78 @@
       "wallTileId": "darkStone",
       "ambianceId": "sacred",
       "decor": [
-        { "comment": "stone sarcophagi (chests) in rows" },
-        { "tx": 3, "ty": 2, "tileId": "chest" },
-        { "tx": 5, "ty": 2, "tileId": "chest" },
-        { "tx": 7, "ty": 2, "tileId": "chest" },
-        { "tx": 9, "ty": 2, "tileId": "chest" },
-        { "tx": 3, "ty": 5, "tileId": "chest" },
-        { "tx": 5, "ty": 5, "tileId": "chest" },
-        { "tx": 7, "ty": 5, "tileId": "chest" },
-        { "tx": 9, "ty": 5, "tileId": "chest" },
-        { "tx": 1, "ty": 1, "tileId": "candlestickUnlit" },
-        { "tx": 10, "ty": 1, "tileId": "candlestickLitTop" },
-        { "tx": 1, "ty": 6, "tileId": "smallRock" },
-        { "comment": "stairway back up to the chapel" },
-        { "tx": 5, "ty": 1, "tileId": "ladderIntoFloor", "zlayer": "below" },
-        { "tx": 5, "ty": 0, "tileId": "halfLadderTop" }
+        {
+          "comment": "stone sarcophagi (chests) in rows"
+        },
+        {
+          "tx": 3,
+          "ty": 2,
+          "tileId": "chest"
+        },
+        {
+          "tx": 5,
+          "ty": 2,
+          "tileId": "chest"
+        },
+        {
+          "tx": 7,
+          "ty": 2,
+          "tileId": "chest"
+        },
+        {
+          "tx": 9,
+          "ty": 2,
+          "tileId": "chest"
+        },
+        {
+          "tx": 3,
+          "ty": 5,
+          "tileId": "chest"
+        },
+        {
+          "tx": 5,
+          "ty": 5,
+          "tileId": "chest"
+        },
+        {
+          "tx": 7,
+          "ty": 5,
+          "tileId": "chest"
+        },
+        {
+          "tx": 9,
+          "ty": 5,
+          "tileId": "chest"
+        },
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "candlestickUnlit"
+        },
+        {
+          "tx": 10,
+          "ty": 1,
+          "tileId": "candlestickLitTop"
+        },
+        {
+          "tx": 1,
+          "ty": 6,
+          "tileId": "smallRock"
+        },
+        {
+          "comment": "stairway back up to the chapel"
+        },
+        {
+          "tx": 5,
+          "ty": 1,
+          "tileId": "ladderIntoFloor",
+          "zlayer": "below"
+        },
+        {
+          "tx": 5,
+          "ty": 0,
+          "tileId": "halfLadderTop"
+        }
       ],
       "exits": [
         {
@@ -2539,17 +3688,59 @@
       "floorTileId": "stoneFloor",
       "wallTileId": "castleStone",
       "decor": [
-        { "tx": 1, "ty": 1, "tileId": "brazierTop" },
-        { "tx": 1, "ty": 2, "tileId": "brazierBottom" },
-        { "tx": 8, "ty": 1, "tileId": "brazierTop" },
-        { "tx": 8, "ty": 2, "tileId": "brazierBottom" },
-        { "tx": 3, "ty": 3, "tileId": "barrel" },
-        { "tx": 6, "ty": 3, "tileId": "crate" },
-        { "tx": 4, "ty": 5, "tileId": "chest" },
-        { "tx": 5, "ty": 5, "tileId": "chest" },
-        { "comment": "ladder up to the lookout" },
-        { "tx": 8, "ty": 6, "tileId": "ladderBottom" },
-        { "tx": 8, "ty": 5, "tileId": "fullLadderTop" }
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "brazierTop"
+        },
+        {
+          "tx": 1,
+          "ty": 2,
+          "tileId": "brazierBottom"
+        },
+        {
+          "tx": 8,
+          "ty": 1,
+          "tileId": "brazierTop"
+        },
+        {
+          "tx": 8,
+          "ty": 2,
+          "tileId": "brazierBottom"
+        },
+        {
+          "tx": 3,
+          "ty": 3,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 6,
+          "ty": 3,
+          "tileId": "crate"
+        },
+        {
+          "tx": 4,
+          "ty": 5,
+          "tileId": "chest"
+        },
+        {
+          "tx": 5,
+          "ty": 5,
+          "tileId": "chest"
+        },
+        {
+          "comment": "ladder up to the lookout"
+        },
+        {
+          "tx": 8,
+          "ty": 6,
+          "tileId": "ladderBottom"
+        },
+        {
+          "tx": 8,
+          "ty": 5,
+          "tileId": "fullLadderTop"
+        }
       ],
       "exits": [
         {
@@ -2570,17 +3761,60 @@
       "floorTileId": "woodFloor",
       "wallTileId": "castleStone",
       "decor": [
-        { "tx": 2, "ty": -1, "tileId": "roundWindowLit" },
-        { "tx": 5, "ty": -1, "tileId": "roundWindowUnlit" },
-        { "tx": 7, "ty": -1, "tileId": "roundWindowUnlit" },
-        { "tx": 1, "ty": 1, "tileId": "swordMountedLeft" },
-        { "tx": 8, "ty": 1, "tileId": "swordMountedRight" },
-        { "tx": 2, "ty": 3, "tileId": "chest" },
-        { "tx": 7, "ty": 3, "tileId": "barrel" },
-        { "tx": 4, "ty": 2, "tileId": "candlestickLitTop" },
-        { "comment": "ladder down into the tower" },
-        { "tx": 5, "ty": 6, "tileId": "ladderIntoFloor", "zlayer": "below" },
-        { "tx": 5, "ty": 5, "tileId": "halfLadderTop" }
+        {
+          "tx": 2,
+          "ty": -1,
+          "tileId": "roundWindowLit"
+        },
+        {
+          "tx": 5,
+          "ty": -1,
+          "tileId": "roundWindowUnlit"
+        },
+        {
+          "tx": 7,
+          "ty": -1,
+          "tileId": "roundWindowUnlit"
+        },
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "swordMountedLeft"
+        },
+        {
+          "tx": 8,
+          "ty": 1,
+          "tileId": "swordMountedRight"
+        },
+        {
+          "tx": 2,
+          "ty": 3,
+          "tileId": "chest"
+        },
+        {
+          "tx": 7,
+          "ty": 3,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 4,
+          "ty": 2,
+          "tileId": "candlestickLitTop"
+        },
+        {
+          "comment": "ladder down into the tower"
+        },
+        {
+          "tx": 5,
+          "ty": 6,
+          "tileId": "ladderIntoFloor",
+          "zlayer": "below"
+        },
+        {
+          "tx": 5,
+          "ty": 5,
+          "tileId": "halfLadderTop"
+        }
       ],
       "exits": [
         {
@@ -2602,24 +3836,92 @@
       "wallTileId": "castleStone",
       "musicId": "church",
       "decor": [
-        { "comment": "archive shelves along the back wall" },
-        { "tx": 1, "ty": 0, "tileId": "bookshelfTop" },
-        { "tx": 1, "ty": 1, "tileId": "bookshelfBottom" },
-        { "tx": 2, "ty": 0, "tileId": "bookshelfTop" },
-        { "tx": 2, "ty": 1, "tileId": "bookshelfBottom" },
-        { "tx": 9, "ty": 0, "tileId": "bookshelfTop" },
-        { "tx": 9, "ty": 1, "tileId": "bookshelfBottom" },
-        { "tx": 10, "ty": 0, "tileId": "bookshelfTop" },
-        { "tx": 10, "ty": 1, "tileId": "bookshelfBottom" },
-        { "comment": "writing desks" },
-        { "tx": 4, "ty": 3, "tileId": "roundTable" },
-        { "tx": 4, "ty": 4, "tileId": "stool" },
-        { "tx": 7, "ty": 3, "tileId": "roundTable" },
-        { "tx": 7, "ty": 4, "tileId": "stool" },
-        { "tx": 3, "ty": 3, "tileId": "candlestickLitTop" },
-        { "tx": 8, "ty": 3, "tileId": "candlestickLitTop" },
-        { "tx": 1, "ty": 6, "tileId": "chest" },
-        { "tx": 10, "ty": 6, "tileId": "chest" }
+        {
+          "comment": "archive shelves along the back wall"
+        },
+        {
+          "tx": 1,
+          "ty": 0,
+          "tileId": "bookshelfTop"
+        },
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "bookshelfBottom"
+        },
+        {
+          "tx": 2,
+          "ty": 0,
+          "tileId": "bookshelfTop"
+        },
+        {
+          "tx": 2,
+          "ty": 1,
+          "tileId": "bookshelfBottom"
+        },
+        {
+          "tx": 9,
+          "ty": 0,
+          "tileId": "bookshelfTop"
+        },
+        {
+          "tx": 9,
+          "ty": 1,
+          "tileId": "bookshelfBottom"
+        },
+        {
+          "tx": 10,
+          "ty": 0,
+          "tileId": "bookshelfTop"
+        },
+        {
+          "tx": 10,
+          "ty": 1,
+          "tileId": "bookshelfBottom"
+        },
+        {
+          "comment": "writing desks"
+        },
+        {
+          "tx": 4,
+          "ty": 3,
+          "tileId": "roundTable"
+        },
+        {
+          "tx": 4,
+          "ty": 4,
+          "tileId": "stool"
+        },
+        {
+          "tx": 7,
+          "ty": 3,
+          "tileId": "roundTable"
+        },
+        {
+          "tx": 7,
+          "ty": 4,
+          "tileId": "stool"
+        },
+        {
+          "tx": 3,
+          "ty": 3,
+          "tileId": "candlestickLitTop"
+        },
+        {
+          "tx": 8,
+          "ty": 3,
+          "tileId": "candlestickLitTop"
+        },
+        {
+          "tx": 1,
+          "ty": 6,
+          "tileId": "chest"
+        },
+        {
+          "tx": 10,
+          "ty": 6,
+          "tileId": "chest"
+        }
       ],
       "exits": []
     },
@@ -2630,18 +3932,66 @@
       "floorTileId": "woodFloor",
       "wallTileId": "woodWall",
       "decor": [
-        { "tx": 1, "ty": 1, "tileId": "sack" },
-        { "tx": 2, "ty": 1, "tileId": "sack" },
-        { "tx": 3, "ty": 1, "tileId": "sack" },
-        { "tx": 6, "ty": 1, "tileId": "sack" },
-        { "tx": 7, "ty": 1, "tileId": "sack" },
-        { "tx": 8, "ty": 1, "tileId": "sack" },
-        { "tx": 1, "ty": 5, "tileId": "barrel" },
-        { "tx": 2, "ty": 5, "tileId": "barrel" },
-        { "tx": 7, "ty": 5, "tileId": "openCrate" },
-        { "tx": 8, "ty": 5, "tileId": "crate" },
-        { "tx": 4, "ty": 4, "tileId": "sack" },
-        { "tx": 5, "ty": 4, "tileId": "sack" }
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "sack"
+        },
+        {
+          "tx": 2,
+          "ty": 1,
+          "tileId": "sack"
+        },
+        {
+          "tx": 3,
+          "ty": 1,
+          "tileId": "sack"
+        },
+        {
+          "tx": 6,
+          "ty": 1,
+          "tileId": "sack"
+        },
+        {
+          "tx": 7,
+          "ty": 1,
+          "tileId": "sack"
+        },
+        {
+          "tx": 8,
+          "ty": 1,
+          "tileId": "sack"
+        },
+        {
+          "tx": 1,
+          "ty": 5,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 2,
+          "ty": 5,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 7,
+          "ty": 5,
+          "tileId": "openCrate"
+        },
+        {
+          "tx": 8,
+          "ty": 5,
+          "tileId": "crate"
+        },
+        {
+          "tx": 4,
+          "ty": 4,
+          "tileId": "sack"
+        },
+        {
+          "tx": 5,
+          "ty": 4,
+          "tileId": "sack"
+        }
       ],
       "exits": []
     },
@@ -2653,20 +4003,72 @@
       "wallTileId": "castleStone",
       "ambianceId": "hearth",
       "decor": [
-        { "comment": "great hearth" },
-        { "tx": 5, "ty": 0, "tileId": "fireplaceTopLeft" },
-        { "tx": 6, "ty": 0, "tileId": "fireplaceTopMiddle" },
-        { "tx": 7, "ty": 0, "tileId": "fireplaceTopRight" },
-        { "tx": 5, "ty": 1, "tileId": "fireplaceBottomLeft" },
-        { "tx": 6, "ty": 1, "tileId": "fireplaceBottomMiddle" },
-        { "tx": 7, "ty": 1, "tileId": "fireplaceBottomRight" },
-        { "comment": "prep tables and stores" },
-        { "tx": 3, "ty": 4, "tileId": "roundTable" },
-        { "tx": 8, "ty": 4, "tileId": "roundTable" },
-        { "tx": 1, "ty": 5, "tileId": "barrel" },
-        { "tx": 2, "ty": 5, "tileId": "sack" },
-        { "tx": 10, "ty": 5, "tileId": "crate" },
-        { "tx": 10, "ty": 1, "tileId": "barrel" }
+        {
+          "comment": "great hearth"
+        },
+        {
+          "tx": 5,
+          "ty": 0,
+          "tileId": "fireplaceTopLeft"
+        },
+        {
+          "tx": 6,
+          "ty": 0,
+          "tileId": "fireplaceTopMiddle"
+        },
+        {
+          "tx": 7,
+          "ty": 0,
+          "tileId": "fireplaceTopRight"
+        },
+        {
+          "tx": 5,
+          "ty": 1,
+          "tileId": "fireplaceBottomLeft"
+        },
+        {
+          "tx": 6,
+          "ty": 1,
+          "tileId": "fireplaceBottomMiddle"
+        },
+        {
+          "tx": 7,
+          "ty": 1,
+          "tileId": "fireplaceBottomRight"
+        },
+        {
+          "comment": "prep tables and stores"
+        },
+        {
+          "tx": 3,
+          "ty": 4,
+          "tileId": "roundTable"
+        },
+        {
+          "tx": 8,
+          "ty": 4,
+          "tileId": "roundTable"
+        },
+        {
+          "tx": 1,
+          "ty": 5,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 2,
+          "ty": 5,
+          "tileId": "sack"
+        },
+        {
+          "tx": 10,
+          "ty": 5,
+          "tileId": "crate"
+        },
+        {
+          "tx": 10,
+          "ty": 1,
+          "tileId": "barrel"
+        }
       ],
       "exits": []
     },
@@ -2677,17 +4079,59 @@
       "floorTileId": "stoneFloor",
       "wallTileId": "reinforcedStone",
       "decor": [
-        { "tx": 1, "ty": 1, "tileId": "brazierTop" },
-        { "tx": 1, "ty": 2, "tileId": "brazierBottom" },
-        { "tx": 8, "ty": 1, "tileId": "brazierTop" },
-        { "tx": 8, "ty": 2, "tileId": "brazierBottom" },
-        { "tx": 3, "ty": 3, "tileId": "chest" },
-        { "tx": 5, "ty": 3, "tileId": "barrel" },
-        { "tx": 4, "ty": 1, "tileId": "swordMountedLeft" },
-        { "tx": 5, "ty": 1, "tileId": "shieldMounted" },
-        { "comment": "stairway down to the cells" },
-        { "tx": 8, "ty": 6, "tileId": "ladderBottom" },
-        { "tx": 8, "ty": 5, "tileId": "fullLadderTop" }
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "brazierTop"
+        },
+        {
+          "tx": 1,
+          "ty": 2,
+          "tileId": "brazierBottom"
+        },
+        {
+          "tx": 8,
+          "ty": 1,
+          "tileId": "brazierTop"
+        },
+        {
+          "tx": 8,
+          "ty": 2,
+          "tileId": "brazierBottom"
+        },
+        {
+          "tx": 3,
+          "ty": 3,
+          "tileId": "chest"
+        },
+        {
+          "tx": 5,
+          "ty": 3,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 4,
+          "ty": 1,
+          "tileId": "swordMountedLeft"
+        },
+        {
+          "tx": 5,
+          "ty": 1,
+          "tileId": "shieldMounted"
+        },
+        {
+          "comment": "stairway down to the cells"
+        },
+        {
+          "tx": 8,
+          "ty": 6,
+          "tileId": "ladderBottom"
+        },
+        {
+          "tx": 8,
+          "ty": 5,
+          "tileId": "fullLadderTop"
+        }
       ],
       "exits": [
         {
@@ -2708,29 +4152,118 @@
       "floorTileId": "stoneFloor",
       "wallTileId": "darkStone",
       "decor": [
-        { "comment": "cell railings line the back wall" },
-        { "tx": 2, "ty": -1, "tileId": "cellWindowUnlit" },
-        { "tx": 5, "ty": -1, "tileId": "cellWindowLit" },
-        { "tx": 9, "ty": -1, "tileId": "cellWindowUnlit" },
-        { "tx": 1, "ty": 1, "tileId": "prisonRailingsTopLeft" },
-        { "tx": 2, "ty": 1, "tileId": "prisonRailingsTopMiddle" },
-        { "tx": 3, "ty": 1, "tileId": "prisonRailingsTopRight" },
-        { "tx": 1, "ty": 2, "tileId": "prisonRailingsBottomLeft" },
-        { "tx": 2, "ty": 2, "tileId": "prisonRailingsBottomMiddle" },
-        { "tx": 3, "ty": 2, "tileId": "prisonRailingsBottomRight" },
-        { "tx": 8, "ty": 1, "tileId": "prisonRailingsTopLeft" },
-        { "tx": 9, "ty": 1, "tileId": "prisonRailingsTopMiddle" },
-        { "tx": 10, "ty": 1, "tileId": "prisonRailingsTopRight" },
-        { "tx": 8, "ty": 2, "tileId": "prisonRailingsBottomLeft" },
-        { "tx": 9, "ty": 2, "tileId": "prisonRailingsBottomMiddle" },
-        { "tx": 10, "ty": 2, "tileId": "prisonRailingsBottomRight" },
-        { "tx": 1, "ty": 5, "tileId": "sack" },
-        { "tx": 6, "ty": 4, "tileId": "candlestickLitTop" },
-        { "comment": "stairs up to dungeon; locked door down to the vault" },
-        { "tx": 5, "ty": 1, "tileId": "ladderIntoFloor", "zlayer": "below" },
-        { "tx": 5, "ty": 0, "tileId": "halfLadderTop" },
-        { "tx": 11, "ty": 6, "tileId": "ladderBottom" },
-        { "tx": 11, "ty": 5, "tileId": "fullLadderTop" }
+        {
+          "comment": "cell railings line the back wall"
+        },
+        {
+          "tx": 2,
+          "ty": -1,
+          "tileId": "cellWindowUnlit"
+        },
+        {
+          "tx": 5,
+          "ty": -1,
+          "tileId": "cellWindowLit"
+        },
+        {
+          "tx": 9,
+          "ty": -1,
+          "tileId": "cellWindowUnlit"
+        },
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "prisonRailingsTopLeft"
+        },
+        {
+          "tx": 2,
+          "ty": 1,
+          "tileId": "prisonRailingsTopMiddle"
+        },
+        {
+          "tx": 3,
+          "ty": 1,
+          "tileId": "prisonRailingsTopRight"
+        },
+        {
+          "tx": 1,
+          "ty": 2,
+          "tileId": "prisonRailingsBottomLeft"
+        },
+        {
+          "tx": 2,
+          "ty": 2,
+          "tileId": "prisonRailingsBottomMiddle"
+        },
+        {
+          "tx": 3,
+          "ty": 2,
+          "tileId": "prisonRailingsBottomRight"
+        },
+        {
+          "tx": 8,
+          "ty": 1,
+          "tileId": "prisonRailingsTopLeft"
+        },
+        {
+          "tx": 9,
+          "ty": 1,
+          "tileId": "prisonRailingsTopMiddle"
+        },
+        {
+          "tx": 10,
+          "ty": 1,
+          "tileId": "prisonRailingsTopRight"
+        },
+        {
+          "tx": 8,
+          "ty": 2,
+          "tileId": "prisonRailingsBottomLeft"
+        },
+        {
+          "tx": 9,
+          "ty": 2,
+          "tileId": "prisonRailingsBottomMiddle"
+        },
+        {
+          "tx": 10,
+          "ty": 2,
+          "tileId": "prisonRailingsBottomRight"
+        },
+        {
+          "tx": 1,
+          "ty": 5,
+          "tileId": "sack"
+        },
+        {
+          "tx": 6,
+          "ty": 4,
+          "tileId": "candlestickLitTop"
+        },
+        {
+          "comment": "stairs up to dungeon; locked door down to the vault"
+        },
+        {
+          "tx": 5,
+          "ty": 1,
+          "tileId": "ladderIntoFloor",
+          "zlayer": "below"
+        },
+        {
+          "tx": 5,
+          "ty": 0,
+          "tileId": "halfLadderTop"
+        },
+        {
+          "tx": 11,
+          "ty": 6,
+          "tileId": "ladderBottom"
+        },
+        {
+          "tx": 11,
+          "ty": 5,
+          "tileId": "fullLadderTop"
+        }
       ],
       "exits": [
         {
@@ -2761,16 +4294,55 @@
       "floorTileId": "stoneFloor",
       "wallTileId": "reinforcedStone",
       "decor": [
-        { "tx": 2, "ty": 2, "tileId": "chest" },
-        { "tx": 3, "ty": 2, "tileId": "chest" },
-        { "tx": 6, "ty": 2, "tileId": "chest" },
-        { "tx": 7, "ty": 2, "tileId": "chest" },
-        { "tx": 1, "ty": 4, "tileId": "barrel" },
-        { "tx": 8, "ty": 4, "tileId": "barrel" },
-        { "tx": 4, "ty": 4, "tileId": "candlestickLitTop" },
-        { "comment": "stairway up to the cells" },
-        { "tx": 5, "ty": 6, "tileId": "ladderIntoFloor", "zlayer": "below" },
-        { "tx": 5, "ty": 5, "tileId": "halfLadderTop" }
+        {
+          "tx": 2,
+          "ty": 2,
+          "tileId": "chest"
+        },
+        {
+          "tx": 3,
+          "ty": 2,
+          "tileId": "chest"
+        },
+        {
+          "tx": 6,
+          "ty": 2,
+          "tileId": "chest"
+        },
+        {
+          "tx": 7,
+          "ty": 2,
+          "tileId": "chest"
+        },
+        {
+          "tx": 1,
+          "ty": 4,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 8,
+          "ty": 4,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 4,
+          "ty": 4,
+          "tileId": "candlestickLitTop"
+        },
+        {
+          "comment": "stairway up to the cells"
+        },
+        {
+          "tx": 5,
+          "ty": 6,
+          "tileId": "ladderIntoFloor",
+          "zlayer": "below"
+        },
+        {
+          "tx": 5,
+          "ty": 5,
+          "tileId": "halfLadderTop"
+        }
       ],
       "exits": [
         {
@@ -2791,17 +4363,57 @@
       "floorTileId": "woodFloor",
       "wallTileId": "castleStone",
       "decor": [
-        { "comment": "sick beds" },
-        { "tx": 1, "ty": 1, "bundleID": "simple-bed" },
-        { "tx": 4, "ty": 1, "bundleID": "simple-bed" },
-        { "tx": 7, "ty": 1, "bundleID": "simple-bed" },
-        { "comment": "supplies" },
-        { "tx": 10, "ty": 1, "tileId": "chest" },
-        { "tx": 10, "ty": 2, "tileId": "barrel" },
-        { "tx": 2, "ty": 5, "tileId": "roundTable" },
-        { "tx": 2, "ty": 6, "tileId": "stool" },
-        { "tx": 6, "ty": 5, "tileId": "candlestickLitTop" },
-        { "tx": 9, "ty": 5, "tileId": "barrel" }
+        {
+          "comment": "sick beds"
+        },
+        {
+          "tx": 1,
+          "ty": 1,
+          "bundleID": "simple-bed"
+        },
+        {
+          "tx": 4,
+          "ty": 1,
+          "bundleID": "simple-bed"
+        },
+        {
+          "tx": 7,
+          "ty": 1,
+          "bundleID": "simple-bed"
+        },
+        {
+          "comment": "supplies"
+        },
+        {
+          "tx": 10,
+          "ty": 1,
+          "tileId": "chest"
+        },
+        {
+          "tx": 10,
+          "ty": 2,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 2,
+          "ty": 5,
+          "tileId": "roundTable"
+        },
+        {
+          "tx": 2,
+          "ty": 6,
+          "tileId": "stool"
+        },
+        {
+          "tx": 6,
+          "ty": 5,
+          "tileId": "candlestickLitTop"
+        },
+        {
+          "tx": 9,
+          "ty": 5,
+          "tileId": "barrel"
+        }
       ],
       "exits": []
     },
@@ -2814,16 +4426,56 @@
       "musicId": "shop",
       "ambianceId": "market",
       "decor": [
-        { "tx": 1, "ty": 1, "tileId": "crate" },
-        { "tx": 2, "ty": 1, "tileId": "crate" },
-        { "tx": 1, "ty": 2, "tileId": "openCrate" },
-        { "tx": 7, "ty": 1, "tileId": "barrel" },
-        { "tx": 8, "ty": 1, "tileId": "barrel" },
-        { "tx": 8, "ty": 2, "tileId": "sack" },
-        { "tx": 4, "ty": 4, "tileId": "roundTableWithCloth" },
-        { "tx": 4, "ty": 5, "tileId": "stool" },
-        { "tx": 2, "ty": 5, "tileId": "chest" },
-        { "tx": 7, "ty": 5, "tileId": "chest" }
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "crate"
+        },
+        {
+          "tx": 2,
+          "ty": 1,
+          "tileId": "crate"
+        },
+        {
+          "tx": 1,
+          "ty": 2,
+          "tileId": "openCrate"
+        },
+        {
+          "tx": 7,
+          "ty": 1,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 8,
+          "ty": 1,
+          "tileId": "barrel"
+        },
+        {
+          "tx": 8,
+          "ty": 2,
+          "tileId": "sack"
+        },
+        {
+          "tx": 4,
+          "ty": 4,
+          "tileId": "roundTableWithCloth"
+        },
+        {
+          "tx": 4,
+          "ty": 5,
+          "tileId": "stool"
+        },
+        {
+          "tx": 2,
+          "ty": 5,
+          "tileId": "chest"
+        },
+        {
+          "tx": 7,
+          "ty": 5,
+          "tileId": "chest"
+        }
       ],
       "exits": []
     }

--- a/web/src/data/hub/loader.ts
+++ b/web/src/data/hub/loader.ts
@@ -9,6 +9,20 @@ const WALL_MATERIAL_NAMES = new Set<string>(Object.keys(WALL_TILES))
 
 const T = 32
 
+/**
+ * Shared visibility predicate for level-gated items (decor / NPCs). An item is
+ * visible while `minLevel <= level` and (if set) `level < hideAtLevel`. This lets
+ * an author retire an item as its upgraded replacement appears.
+ */
+export function isVisibleAtLevel(
+  item: { minLevel?: number; hideAtLevel?: number },
+  level: number,
+): boolean {
+  if ((item.minLevel ?? 0) > level) return false
+  if (item.hideAtLevel != null && level >= item.hideAtLevel) return false
+  return true
+}
+
 // ── Types ──────────────────────────────────────────────────────────────────────
 
 export interface HubArea {
@@ -27,8 +41,14 @@ export interface HubBuilding {
   roof?: RoofMaterial
   /** Upgrade track key (buildingUpgrades.json); set = building is upgradeable. */
   upgradeKind?: string
-  /** Per-building exterior decor revealed by upgrade level (absolute tx/ty, each carries minLevel). */
-  levelDecor?: Array<{ tx: number; ty: number; tileId: number; zlayer?: 'solid' | 'below' | 'above'; minLevel?: number }>
+  /** Per-building exterior decor revealed/retired by upgrade level (absolute tx/ty). */
+  levelDecor?: Array<{ tx: number; ty: number; tileId: number; zlayer?: 'solid' | 'below' | 'above'; minLevel?: number; hideAtLevel?: number }>
+  /**
+   * Per-level visual overrides (footprint/wall/roof). Sorted ascending by
+   * minLevel. The highest entry whose minLevel <= currentLevel wins; omitted
+   * fields inherit from the base building.
+   */
+  levelVisuals?: Array<{ minLevel: number; rect?: [number, number, number, number]; wall?: WallMaterial; roof?: RoofMaterial }>
 }
 
 export interface HubDoor {
@@ -50,6 +70,7 @@ export interface InteriorDecor extends DecorGlow {
   ty:      number
   tileId:  number
   minLevel?: number   // building upgrade level at which this decor first appears (0/undefined = base)
+  hideAtLevel?: number // building upgrade level at which this decor disappears (undefined = never)
   zlayer?: 'solid' | 'below' | 'above'
   // solid (default): not walkable, renders below avatar
   // below: walkable, renders below avatar (rugs, floor markings)
@@ -112,6 +133,9 @@ export interface HubNpc {
   innRumours?: Array<{ id: string; text: string }>
   isGhost?: boolean
   minLevel?: number   // building upgrade level at which this NPC first appears (0/undefined = always)
+  hideAtLevel?: number // building upgrade level at which this NPC disappears (undefined = never)
+  /** For exterior NPCs: id of the building whose upgrade level gates this NPC's visibility. */
+  levelBuildingId?: string
   schedule?: NpcScheduleEntry[]
   homeBed?: { buildingId: string; tx: number; ty: number }
   /** Id of a branching dialogue tree (questDefs.json `dialogues`) to run on tap. */
@@ -362,7 +386,8 @@ type RawBuilding = {
   doors?:   Array<{ tx: number; ty: number; buildingId?: string, hideSign?: boolean }>
   windows?: Array<{ tx: number; ty: number; tileId: string }>
   decor?:   Array<{ tx: number; ty: number; tileId?: string; bundleID?: string; zlayer?: string }>
-  levelDecor?: Array<{ tx?: number; ty?: number; tileId?: string; zlayer?: string; minLevel?: number }>
+  levelDecor?: Array<{ tx?: number; ty?: number; tileId?: string; zlayer?: string; minLevel?: number; hideAtLevel?: number }>
+  levelVisuals?: Array<{ minLevel: number; rect?: number[]; wall?: string; roof?: string }>
 }
 const HUB_BUILDINGS: HubBuilding[] = (rawConfig.buildings as RawBuilding[]).flatMap(b => {
   const rectList = b.rects ?? (b.rect ? [b.rect] : [])
@@ -371,8 +396,17 @@ const HUB_BUILDINGS: HubBuilding[] = (rawConfig.buildings as RawBuilding[]).flat
   const levelDecor = (b.levelDecor ?? []).flatMap(d =>
     d.tx == null || d.ty == null || !d.tileId
       ? []
-      : [{ tx: d.tx, ty: d.ty, tileId: resolveTileId(d.tileId), zlayer: d.zlayer as 'solid' | 'below' | 'above' | undefined, minLevel: d.minLevel }],
+      : [{ tx: d.tx, ty: d.ty, tileId: resolveTileId(d.tileId), zlayer: d.zlayer as 'solid' | 'below' | 'above' | undefined, minLevel: d.minLevel, hideAtLevel: d.hideAtLevel }],
   )
+  // Per-level visuals attach to the first rect only (variants own a full footprint).
+  const levelVisuals = (b.levelVisuals ?? [])
+    .map(v => ({
+      minLevel: v.minLevel,
+      rect: v.rect && v.rect.length === 4 ? (v.rect as [number, number, number, number]) : undefined,
+      wall: v.wall as WallMaterial | undefined,
+      roof: v.roof as RoofMaterial | undefined,
+    }))
+    .sort((a, c) => a.minLevel - c.minLevel)
   return rectList.map((rect, i) => ({
     rect: rect as [number, number, number, number],
     id:   b.id,
@@ -380,6 +414,7 @@ const HUB_BUILDINGS: HubBuilding[] = (rawConfig.buildings as RawBuilding[]).flat
     roof: b.roof as RoofMaterial | undefined,
     upgradeKind: b.upgradeKind,
     ...(i === 0 && levelDecor.length ? { levelDecor } : {}),
+    ...(i === 0 && levelVisuals.length ? { levelVisuals } : {}),
   }))
 })
 
@@ -486,10 +521,10 @@ const HUB_INTERIORS: Record<string, HubInterior> = Object.fromEntries(
         height:       raw.height,
         floorTileId:  resolveTileId(raw.floorTileId),
         wallMaterial: wallTileIdStr && WALL_MATERIAL_NAMES.has(wallTileIdStr) ? wallTileIdStr as WallMaterial : undefined,
-        decor:        (raw.decor as Array<{ tx: number; ty: number; tileId?: string; bundleID?: string; zlayer?: string; minLevel?: number }>).flatMap(d => {
+        decor:        (raw.decor as Array<{ tx: number; ty: number; tileId?: string; bundleID?: string; zlayer?: string; minLevel?: number; hideAtLevel?: number }>).flatMap(d => {
           if (d.bundleID)
-            return expandBundleDecor(d.bundleID, d.tx, d.ty).map(e => ({ ...e, zlayer: e.zlayer as InteriorDecor['zlayer'], minLevel: d.minLevel }))
-          return [{ tx: d.tx, ty: d.ty, tileId: resolveTileId(d.tileId ?? ''), zlayer: d.zlayer as InteriorDecor['zlayer'], minLevel: d.minLevel }]
+            return expandBundleDecor(d.bundleID, d.tx, d.ty).map(e => ({ ...e, zlayer: e.zlayer as InteriorDecor['zlayer'], minLevel: d.minLevel, hideAtLevel: d.hideAtLevel }))
+          return [{ tx: d.tx, ty: d.ty, tileId: resolveTileId(d.tileId ?? ''), zlayer: d.zlayer as InteriorDecor['zlayer'], minLevel: d.minLevel, hideAtLevel: d.hideAtLevel }]
         }),
         exits: ((rawAny.exits ?? []) as HubInteriorExit[]),
         hours: rawAny.hours as HubInterior['hours'],

--- a/web/src/data/hub/millhaven/config.json
+++ b/web/src/data/hub/millhaven/config.json
@@ -257,6 +257,44 @@
           "hideSign": true,
           "buildingId": "mill"
         }
+      ],
+      "levelDecor": [
+        {
+          "tx": 2,
+          "ty": 7,
+          "tileId": "crate",
+          "minLevel": 1
+        },
+        {
+          "tx": 4,
+          "ty": 7,
+          "tileId": "crate",
+          "minLevel": 1
+        },
+        {
+          "tx": 1,
+          "ty": 7,
+          "tileId": "chest",
+          "minLevel": 2
+        },
+        {
+          "tx": 5,
+          "ty": 7,
+          "tileId": "barrel",
+          "minLevel": 2
+        },
+        {
+          "tx": 3,
+          "ty": 9,
+          "tileId": "armourSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 2,
+          "ty": 8,
+          "tileId": "chest",
+          "minLevel": 3
+        }
       ]
     },
     {
@@ -276,6 +314,44 @@
           "ty": 1,
           "hideSign": true,
           "buildingId": "fishmonger"
+        }
+      ],
+      "levelDecor": [
+        {
+          "tx": 26,
+          "ty": 13,
+          "tileId": "crate",
+          "minLevel": 1
+        },
+        {
+          "tx": 28,
+          "ty": 13,
+          "tileId": "barrel",
+          "minLevel": 1
+        },
+        {
+          "tx": 25,
+          "ty": 13,
+          "tileId": "pileOfSacks",
+          "minLevel": 2
+        },
+        {
+          "tx": 29,
+          "ty": 13,
+          "tileId": "crate",
+          "minLevel": 2
+        },
+        {
+          "tx": 27,
+          "ty": 15,
+          "tileId": "goldSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 26,
+          "ty": 14,
+          "tileId": "goldChest",
+          "minLevel": 3
         }
       ]
     },
@@ -297,6 +373,44 @@
           "hideSign": true,
           "buildingId": "inn-millhaven"
         }
+      ],
+      "levelDecor": [
+        {
+          "tx": 17,
+          "ty": 9,
+          "tileId": "barrel",
+          "minLevel": 1
+        },
+        {
+          "tx": 19,
+          "ty": 9,
+          "tileId": "barrel",
+          "minLevel": 1
+        },
+        {
+          "tx": 16,
+          "ty": 9,
+          "tileId": "floorLantern",
+          "minLevel": 2
+        },
+        {
+          "tx": 20,
+          "ty": 9,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 18,
+          "ty": 11,
+          "tileId": "innSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 17,
+          "ty": 10,
+          "tileId": "floorLantern",
+          "minLevel": 3
+        }
       ]
     },
     {
@@ -316,6 +430,44 @@
           "ty": 1,
           "hideSign": true,
           "buildingId": "market-hall"
+        }
+      ],
+      "levelDecor": [
+        {
+          "tx": 26,
+          "ty": 23,
+          "tileId": "crate",
+          "minLevel": 1
+        },
+        {
+          "tx": 28,
+          "ty": 23,
+          "tileId": "barrel",
+          "minLevel": 1
+        },
+        {
+          "tx": 25,
+          "ty": 23,
+          "tileId": "pileOfSacks",
+          "minLevel": 2
+        },
+        {
+          "tx": 29,
+          "ty": 23,
+          "tileId": "crate",
+          "minLevel": 2
+        },
+        {
+          "tx": 27,
+          "ty": 25,
+          "tileId": "goldSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 26,
+          "ty": 24,
+          "tileId": "goldChest",
+          "minLevel": 3
         }
       ]
     },
@@ -337,6 +489,44 @@
           "hideSign": true,
           "buildingId": "town-hall-millhaven"
         }
+      ],
+      "levelDecor": [
+        {
+          "tx": 8,
+          "ty": 23,
+          "tileId": "lightBush",
+          "minLevel": 1
+        },
+        {
+          "tx": 10,
+          "ty": 23,
+          "tileId": "lightBush",
+          "minLevel": 1
+        },
+        {
+          "tx": 7,
+          "ty": 23,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 11,
+          "ty": 23,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 9,
+          "ty": 25,
+          "tileId": "largeSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 8,
+          "ty": 24,
+          "tileId": "potOfFlowers",
+          "minLevel": 3
+        }
       ]
     },
     {
@@ -356,6 +546,44 @@
           "ty": 1,
           "hideSign": true,
           "buildingId": "bakery"
+        }
+      ],
+      "levelDecor": [
+        {
+          "tx": 22,
+          "ty": 32,
+          "tileId": "crate",
+          "minLevel": 1
+        },
+        {
+          "tx": 24,
+          "ty": 32,
+          "tileId": "barrel",
+          "minLevel": 1
+        },
+        {
+          "tx": 21,
+          "ty": 32,
+          "tileId": "pileOfSacks",
+          "minLevel": 2
+        },
+        {
+          "tx": 25,
+          "ty": 32,
+          "tileId": "crate",
+          "minLevel": 2
+        },
+        {
+          "tx": 23,
+          "ty": 34,
+          "tileId": "goldSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 22,
+          "ty": 33,
+          "tileId": "goldChest",
+          "minLevel": 3
         }
       ]
     },
@@ -377,6 +605,44 @@
           "hideSign": true,
           "buildingId": "smithy"
         }
+      ],
+      "levelDecor": [
+        {
+          "tx": 9,
+          "ty": 32,
+          "tileId": "crate",
+          "minLevel": 1
+        },
+        {
+          "tx": 11,
+          "ty": 32,
+          "tileId": "crate",
+          "minLevel": 1
+        },
+        {
+          "tx": 8,
+          "ty": 32,
+          "tileId": "chest",
+          "minLevel": 2
+        },
+        {
+          "tx": 12,
+          "ty": 32,
+          "tileId": "barrel",
+          "minLevel": 2
+        },
+        {
+          "tx": 10,
+          "ty": 34,
+          "tileId": "armourSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 9,
+          "ty": 33,
+          "tileId": "chest",
+          "minLevel": 3
+        }
       ]
     },
     {
@@ -397,6 +663,44 @@
           "hideSign": true,
           "buildingId": "boathouse"
         }
+      ],
+      "levelDecor": [
+        {
+          "tx": 33,
+          "ty": 33,
+          "tileId": "crate",
+          "minLevel": 1
+        },
+        {
+          "tx": 35,
+          "ty": 33,
+          "tileId": "crate",
+          "minLevel": 1
+        },
+        {
+          "tx": 32,
+          "ty": 33,
+          "tileId": "chest",
+          "minLevel": 2
+        },
+        {
+          "tx": 36,
+          "ty": 33,
+          "tileId": "barrel",
+          "minLevel": 2
+        },
+        {
+          "tx": 34,
+          "ty": 35,
+          "tileId": "armourSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 33,
+          "ty": 34,
+          "tileId": "chest",
+          "minLevel": 3
+        }
       ]
     },
     {
@@ -416,6 +720,44 @@
           "ty": 1,
           "hideSign": true,
           "buildingId": "fisher-cottage"
+        }
+      ],
+      "levelDecor": [
+        {
+          "tx": 1,
+          "ty": 32,
+          "tileId": "pinkFlower",
+          "minLevel": 1
+        },
+        {
+          "tx": 3,
+          "ty": 32,
+          "tileId": "blueFlower",
+          "minLevel": 1
+        },
+        {
+          "tx": 0,
+          "ty": 32,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 4,
+          "ty": 32,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 2,
+          "ty": 34,
+          "tileId": "floorLantern",
+          "minLevel": 3
+        },
+        {
+          "tx": 3,
+          "ty": 33,
+          "tileId": "potOfFlowers",
+          "minLevel": 3
         }
       ]
     }

--- a/web/src/data/hub/ravenwatch/config.json
+++ b/web/src/data/hub/ravenwatch/config.json
@@ -1001,6 +1001,44 @@
           "ty": -1,
           "tileId": "windowBottom"
         }
+      ],
+      "levelDecor": [
+        {
+          "tx": 4,
+          "ty": 11,
+          "tileId": "crate",
+          "minLevel": 1
+        },
+        {
+          "tx": 6,
+          "ty": 11,
+          "tileId": "barrel",
+          "minLevel": 1
+        },
+        {
+          "tx": 3,
+          "ty": 11,
+          "tileId": "pileOfSacks",
+          "minLevel": 2
+        },
+        {
+          "tx": 7,
+          "ty": 11,
+          "tileId": "crate",
+          "minLevel": 2
+        },
+        {
+          "tx": 5,
+          "ty": 13,
+          "tileId": "goldSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 4,
+          "ty": 12,
+          "tileId": "goldChest",
+          "minLevel": 3
+        }
       ]
     },
     {
@@ -1041,6 +1079,44 @@
           "tx": 4,
           "ty": -1,
           "tileId": "windowBottom2"
+        }
+      ],
+      "levelDecor": [
+        {
+          "tx": 13,
+          "ty": 11,
+          "tileId": "crate",
+          "minLevel": 1
+        },
+        {
+          "tx": 15,
+          "ty": 11,
+          "tileId": "barrel",
+          "minLevel": 1
+        },
+        {
+          "tx": 12,
+          "ty": 11,
+          "tileId": "pileOfSacks",
+          "minLevel": 2
+        },
+        {
+          "tx": 16,
+          "ty": 11,
+          "tileId": "crate",
+          "minLevel": 2
+        },
+        {
+          "tx": 14,
+          "ty": 13,
+          "tileId": "goldSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 13,
+          "ty": 12,
+          "tileId": "goldChest",
+          "minLevel": 3
         }
       ]
     },
@@ -1305,6 +1381,44 @@
           "ty": -1,
           "tileId": "windowBottom2"
         }
+      ],
+      "levelDecor": [
+        {
+          "tx": 25,
+          "ty": 21,
+          "tileId": "barrel",
+          "minLevel": 1
+        },
+        {
+          "tx": 27,
+          "ty": 21,
+          "tileId": "barrel",
+          "minLevel": 1
+        },
+        {
+          "tx": 24,
+          "ty": 21,
+          "tileId": "floorLantern",
+          "minLevel": 2
+        },
+        {
+          "tx": 28,
+          "ty": 21,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 26,
+          "ty": 23,
+          "tileId": "innSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 25,
+          "ty": 22,
+          "tileId": "floorLantern",
+          "minLevel": 3
+        }
       ]
     },
     {
@@ -1337,6 +1451,44 @@
           "ty": -1,
           "tileId": "windowBottom3"
         }
+      ],
+      "levelDecor": [
+        {
+          "tx": 23,
+          "ty": 34,
+          "tileId": "crate",
+          "minLevel": 1
+        },
+        {
+          "tx": 25,
+          "ty": 34,
+          "tileId": "barrel",
+          "minLevel": 1
+        },
+        {
+          "tx": 22,
+          "ty": 34,
+          "tileId": "pileOfSacks",
+          "minLevel": 2
+        },
+        {
+          "tx": 26,
+          "ty": 34,
+          "tileId": "crate",
+          "minLevel": 2
+        },
+        {
+          "tx": 24,
+          "ty": 36,
+          "tileId": "goldSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 23,
+          "ty": 35,
+          "tileId": "goldChest",
+          "minLevel": 3
+        }
       ]
     },
     {
@@ -1367,6 +1519,44 @@
           "tx": 1,
           "ty": -1,
           "tileId": "windowBottom4"
+        }
+      ],
+      "levelDecor": [
+        {
+          "tx": 45,
+          "ty": 18,
+          "tileId": "crate",
+          "minLevel": 1
+        },
+        {
+          "tx": 47,
+          "ty": 18,
+          "tileId": "barrel",
+          "minLevel": 1
+        },
+        {
+          "tx": 44,
+          "ty": 18,
+          "tileId": "pileOfSacks",
+          "minLevel": 2
+        },
+        {
+          "tx": 48,
+          "ty": 18,
+          "tileId": "crate",
+          "minLevel": 2
+        },
+        {
+          "tx": 46,
+          "ty": 20,
+          "tileId": "goldSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 45,
+          "ty": 19,
+          "tileId": "goldChest",
+          "minLevel": 3
         }
       ]
     },
@@ -1741,6 +1931,44 @@
           "tx": 12,
           "ty": -1,
           "tileId": "windowBottom3"
+        }
+      ],
+      "levelDecor": [
+        {
+          "tx": 18,
+          "ty": 47,
+          "tileId": "floorLantern",
+          "minLevel": 1
+        },
+        {
+          "tx": 20,
+          "ty": 47,
+          "tileId": "floorLantern",
+          "minLevel": 1
+        },
+        {
+          "tx": 17,
+          "ty": 47,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 21,
+          "ty": 47,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 19,
+          "ty": 49,
+          "tileId": "largeSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 18,
+          "ty": 48,
+          "tileId": "goldChest",
+          "minLevel": 3
         }
       ]
     },

--- a/web/src/data/hub/royalpalace/config.json
+++ b/web/src/data/hub/royalpalace/config.json
@@ -144,6 +144,44 @@
           "buildingId": "palace",
           "hideSign": true
         }
+      ],
+      "levelDecor": [
+        {
+          "tx": 12,
+          "ty": 17,
+          "tileId": "lightBush",
+          "minLevel": 1
+        },
+        {
+          "tx": 14,
+          "ty": 17,
+          "tileId": "lightBush",
+          "minLevel": 1
+        },
+        {
+          "tx": 11,
+          "ty": 17,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 15,
+          "ty": 17,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 13,
+          "ty": 19,
+          "tileId": "largeSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 12,
+          "ty": 18,
+          "tileId": "potOfFlowers",
+          "minLevel": 3
+        }
       ]
     },
     {
@@ -162,6 +200,44 @@
           "tx": 4,
           "ty": 1,
           "buildingId": "guest-wing"
+        }
+      ],
+      "levelDecor": [
+        {
+          "tx": 28,
+          "ty": 13,
+          "tileId": "barrel",
+          "minLevel": 1
+        },
+        {
+          "tx": 30,
+          "ty": 13,
+          "tileId": "barrel",
+          "minLevel": 1
+        },
+        {
+          "tx": 27,
+          "ty": 13,
+          "tileId": "floorLantern",
+          "minLevel": 2
+        },
+        {
+          "tx": 31,
+          "ty": 13,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 29,
+          "ty": 15,
+          "tileId": "innSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 28,
+          "ty": 14,
+          "tileId": "floorLantern",
+          "minLevel": 3
         }
       ]
     },
@@ -182,6 +258,44 @@
           "ty": 1,
           "buildingId": "royal-library"
         }
+      ],
+      "levelDecor": [
+        {
+          "tx": 37,
+          "ty": 13,
+          "tileId": "lightBush",
+          "minLevel": 1
+        },
+        {
+          "tx": 39,
+          "ty": 13,
+          "tileId": "lightBush",
+          "minLevel": 1
+        },
+        {
+          "tx": 36,
+          "ty": 13,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 40,
+          "ty": 13,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 38,
+          "ty": 15,
+          "tileId": "largeSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 37,
+          "ty": 14,
+          "tileId": "potOfFlowers",
+          "minLevel": 3
+        }
       ]
     },
     {
@@ -200,6 +314,44 @@
           "tx": 4,
           "ty": 1,
           "buildingId": "royal-chapel"
+        }
+      ],
+      "levelDecor": [
+        {
+          "tx": 28,
+          "ty": 23,
+          "tileId": "floorLantern",
+          "minLevel": 1
+        },
+        {
+          "tx": 30,
+          "ty": 23,
+          "tileId": "floorLantern",
+          "minLevel": 1
+        },
+        {
+          "tx": 27,
+          "ty": 23,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 31,
+          "ty": 23,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 29,
+          "ty": 25,
+          "tileId": "largeSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 28,
+          "ty": 24,
+          "tileId": "goldChest",
+          "minLevel": 3
         }
       ]
     },
@@ -220,6 +372,44 @@
           "ty": 1,
           "buildingId": "treasury-vault"
         }
+      ],
+      "levelDecor": [
+        {
+          "tx": 37,
+          "ty": 23,
+          "tileId": "lightBush",
+          "minLevel": 1
+        },
+        {
+          "tx": 39,
+          "ty": 23,
+          "tileId": "lightBush",
+          "minLevel": 1
+        },
+        {
+          "tx": 36,
+          "ty": 23,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 40,
+          "ty": 23,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 38,
+          "ty": 25,
+          "tileId": "largeSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 37,
+          "ty": 24,
+          "tileId": "potOfFlowers",
+          "minLevel": 3
+        }
       ]
     },
     {
@@ -238,6 +428,44 @@
           "tx": 3,
           "ty": 1,
           "buildingId": "orangery"
+        }
+      ],
+      "levelDecor": [
+        {
+          "tx": 3,
+          "ty": 26,
+          "tileId": "lightBush",
+          "minLevel": 1
+        },
+        {
+          "tx": 5,
+          "ty": 26,
+          "tileId": "lightBush",
+          "minLevel": 1
+        },
+        {
+          "tx": 2,
+          "ty": 26,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 6,
+          "ty": 26,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 4,
+          "ty": 28,
+          "tileId": "largeSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 3,
+          "ty": 27,
+          "tileId": "potOfFlowers",
+          "minLevel": 3
         }
       ]
     },
@@ -258,6 +486,44 @@
           "ty": 1,
           "buildingId": "stables"
         }
+      ],
+      "levelDecor": [
+        {
+          "tx": 19,
+          "ty": 26,
+          "tileId": "lightBush",
+          "minLevel": 1
+        },
+        {
+          "tx": 21,
+          "ty": 26,
+          "tileId": "lightBush",
+          "minLevel": 1
+        },
+        {
+          "tx": 18,
+          "ty": 26,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 22,
+          "ty": 26,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 20,
+          "ty": 28,
+          "tileId": "largeSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 19,
+          "ty": 27,
+          "tileId": "potOfFlowers",
+          "minLevel": 3
+        }
       ]
     },
     {
@@ -276,6 +542,44 @@
           "tx": 3,
           "ty": 1,
           "buildingId": "servants-quarters"
+        }
+      ],
+      "levelDecor": [
+        {
+          "tx": 3,
+          "ty": 36,
+          "tileId": "pinkFlower",
+          "minLevel": 1
+        },
+        {
+          "tx": 5,
+          "ty": 36,
+          "tileId": "blueFlower",
+          "minLevel": 1
+        },
+        {
+          "tx": 2,
+          "ty": 36,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 6,
+          "ty": 36,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 4,
+          "ty": 38,
+          "tileId": "floorLantern",
+          "minLevel": 3
+        },
+        {
+          "tx": 5,
+          "ty": 37,
+          "tileId": "potOfFlowers",
+          "minLevel": 3
         }
       ]
     },
@@ -296,6 +600,44 @@
           "ty": 1,
           "buildingId": "gatehouse"
         }
+      ],
+      "levelDecor": [
+        {
+          "tx": 19,
+          "ty": 36,
+          "tileId": "lightBush",
+          "minLevel": 1
+        },
+        {
+          "tx": 21,
+          "ty": 36,
+          "tileId": "lightBush",
+          "minLevel": 1
+        },
+        {
+          "tx": 18,
+          "ty": 36,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 22,
+          "ty": 36,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 20,
+          "ty": 38,
+          "tileId": "largeSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 19,
+          "ty": 37,
+          "tileId": "potOfFlowers",
+          "minLevel": 3
+        }
       ]
     },
     {
@@ -315,6 +657,44 @@
           "ty": 1,
           "buildingId": "armory"
         }
+      ],
+      "levelDecor": [
+        {
+          "tx": 28,
+          "ty": 36,
+          "tileId": "crate",
+          "minLevel": 1
+        },
+        {
+          "tx": 30,
+          "ty": 36,
+          "tileId": "crate",
+          "minLevel": 1
+        },
+        {
+          "tx": 27,
+          "ty": 36,
+          "tileId": "chest",
+          "minLevel": 2
+        },
+        {
+          "tx": 31,
+          "ty": 36,
+          "tileId": "barrel",
+          "minLevel": 2
+        },
+        {
+          "tx": 29,
+          "ty": 38,
+          "tileId": "armourSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 28,
+          "ty": 37,
+          "tileId": "chest",
+          "minLevel": 3
+        }
       ]
     },
     {
@@ -333,6 +713,44 @@
           "tx": 3,
           "ty": 1,
           "buildingId": "royal-kitchens"
+        }
+      ],
+      "levelDecor": [
+        {
+          "tx": 36,
+          "ty": 36,
+          "tileId": "lightBush",
+          "minLevel": 1
+        },
+        {
+          "tx": 38,
+          "ty": 36,
+          "tileId": "lightBush",
+          "minLevel": 1
+        },
+        {
+          "tx": 35,
+          "ty": 36,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 39,
+          "ty": 36,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 37,
+          "ty": 38,
+          "tileId": "largeSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 36,
+          "ty": 37,
+          "tileId": "potOfFlowers",
+          "minLevel": 3
         }
       ]
     }

--- a/web/src/data/hub/saltmereport/config.json
+++ b/web/src/data/hub/saltmereport/config.json
@@ -138,6 +138,44 @@
           "hideSign": true,
           "buildingId": "harbourmaster"
         }
+      ],
+      "levelDecor": [
+        {
+          "tx": 23,
+          "ty": 11,
+          "tileId": "lightBush",
+          "minLevel": 1
+        },
+        {
+          "tx": 25,
+          "ty": 11,
+          "tileId": "lightBush",
+          "minLevel": 1
+        },
+        {
+          "tx": 22,
+          "ty": 11,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 26,
+          "ty": 11,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 24,
+          "ty": 13,
+          "tileId": "largeSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 23,
+          "ty": 12,
+          "tileId": "potOfFlowers",
+          "minLevel": 3
+        }
       ]
     },
     {
@@ -157,6 +195,44 @@
           "ty": 1,
           "hideSign": true,
           "buildingId": "fish-market"
+        }
+      ],
+      "levelDecor": [
+        {
+          "tx": 6,
+          "ty": 11,
+          "tileId": "crate",
+          "minLevel": 1
+        },
+        {
+          "tx": 8,
+          "ty": 11,
+          "tileId": "barrel",
+          "minLevel": 1
+        },
+        {
+          "tx": 5,
+          "ty": 11,
+          "tileId": "pileOfSacks",
+          "minLevel": 2
+        },
+        {
+          "tx": 9,
+          "ty": 11,
+          "tileId": "crate",
+          "minLevel": 2
+        },
+        {
+          "tx": 7,
+          "ty": 13,
+          "tileId": "goldSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 6,
+          "ty": 12,
+          "tileId": "goldChest",
+          "minLevel": 3
         }
       ]
     },
@@ -178,6 +254,44 @@
           "hideSign": true,
           "buildingId": "sailors-inn"
         }
+      ],
+      "levelDecor": [
+        {
+          "tx": 13,
+          "ty": 25,
+          "tileId": "barrel",
+          "minLevel": 1
+        },
+        {
+          "tx": 15,
+          "ty": 25,
+          "tileId": "barrel",
+          "minLevel": 1
+        },
+        {
+          "tx": 12,
+          "ty": 25,
+          "tileId": "floorLantern",
+          "minLevel": 2
+        },
+        {
+          "tx": 16,
+          "ty": 25,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 14,
+          "ty": 27,
+          "tileId": "innSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 13,
+          "ty": 26,
+          "tileId": "floorLantern",
+          "minLevel": 3
+        }
       ]
     },
     {
@@ -197,6 +311,44 @@
           "ty": 1,
           "hideSign": true,
           "buildingId": "customs-house"
+        }
+      ],
+      "levelDecor": [
+        {
+          "tx": 13,
+          "ty": 10,
+          "tileId": "lightBush",
+          "minLevel": 1
+        },
+        {
+          "tx": 15,
+          "ty": 10,
+          "tileId": "lightBush",
+          "minLevel": 1
+        },
+        {
+          "tx": 12,
+          "ty": 10,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 16,
+          "ty": 10,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 14,
+          "ty": 12,
+          "tileId": "largeSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 13,
+          "ty": 11,
+          "tileId": "potOfFlowers",
+          "minLevel": 3
         }
       ]
     },
@@ -218,6 +370,44 @@
           "hideSign": true,
           "buildingId": "warehouse"
         }
+      ],
+      "levelDecor": [
+        {
+          "tx": 5,
+          "ty": 35,
+          "tileId": "lightBush",
+          "minLevel": 1
+        },
+        {
+          "tx": 7,
+          "ty": 35,
+          "tileId": "lightBush",
+          "minLevel": 1
+        },
+        {
+          "tx": 4,
+          "ty": 35,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 8,
+          "ty": 35,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 6,
+          "ty": 37,
+          "tileId": "largeSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 5,
+          "ty": 36,
+          "tileId": "potOfFlowers",
+          "minLevel": 3
+        }
       ]
     },
     {
@@ -237,6 +427,44 @@
           "ty": 1,
           "hideSign": true,
           "buildingId": "shipwright"
+        }
+      ],
+      "levelDecor": [
+        {
+          "tx": 14,
+          "ty": 35,
+          "tileId": "crate",
+          "minLevel": 1
+        },
+        {
+          "tx": 16,
+          "ty": 35,
+          "tileId": "crate",
+          "minLevel": 1
+        },
+        {
+          "tx": 13,
+          "ty": 35,
+          "tileId": "chest",
+          "minLevel": 2
+        },
+        {
+          "tx": 17,
+          "ty": 35,
+          "tileId": "barrel",
+          "minLevel": 2
+        },
+        {
+          "tx": 15,
+          "ty": 37,
+          "tileId": "armourSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 14,
+          "ty": 36,
+          "tileId": "chest",
+          "minLevel": 3
         }
       ]
     },
@@ -258,6 +486,44 @@
           "hideSign": true,
           "buildingId": "chandlers"
         }
+      ],
+      "levelDecor": [
+        {
+          "tx": 22,
+          "ty": 35,
+          "tileId": "crate",
+          "minLevel": 1
+        },
+        {
+          "tx": 24,
+          "ty": 35,
+          "tileId": "barrel",
+          "minLevel": 1
+        },
+        {
+          "tx": 21,
+          "ty": 35,
+          "tileId": "pileOfSacks",
+          "minLevel": 2
+        },
+        {
+          "tx": 25,
+          "ty": 35,
+          "tileId": "crate",
+          "minLevel": 2
+        },
+        {
+          "tx": 23,
+          "ty": 37,
+          "tileId": "goldSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 22,
+          "ty": 36,
+          "tileId": "goldChest",
+          "minLevel": 3
+        }
       ]
     },
     {
@@ -277,6 +543,44 @@
           "ty": 1,
           "hideSign": true,
           "buildingId": "net-maker"
+        }
+      ],
+      "levelDecor": [
+        {
+          "tx": 29,
+          "ty": 35,
+          "tileId": "crate",
+          "minLevel": 1
+        },
+        {
+          "tx": 31,
+          "ty": 35,
+          "tileId": "crate",
+          "minLevel": 1
+        },
+        {
+          "tx": 28,
+          "ty": 35,
+          "tileId": "chest",
+          "minLevel": 2
+        },
+        {
+          "tx": 32,
+          "ty": 35,
+          "tileId": "barrel",
+          "minLevel": 2
+        },
+        {
+          "tx": 30,
+          "ty": 37,
+          "tileId": "armourSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 29,
+          "ty": 36,
+          "tileId": "chest",
+          "minLevel": 3
         }
       ]
     },
@@ -298,6 +602,44 @@
           "hideSign": true,
           "buildingId": "smokehouse"
         }
+      ],
+      "levelDecor": [
+        {
+          "tx": 36,
+          "ty": 35,
+          "tileId": "lightBush",
+          "minLevel": 1
+        },
+        {
+          "tx": 38,
+          "ty": 35,
+          "tileId": "lightBush",
+          "minLevel": 1
+        },
+        {
+          "tx": 35,
+          "ty": 35,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 39,
+          "ty": 35,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 37,
+          "ty": 37,
+          "tileId": "largeSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 36,
+          "ty": 36,
+          "tileId": "potOfFlowers",
+          "minLevel": 3
+        }
       ]
     },
     {
@@ -317,6 +659,44 @@
           "ty": 1,
           "hideSign": true,
           "buildingId": "lighthouse"
+        }
+      ],
+      "levelDecor": [
+        {
+          "tx": 43,
+          "ty": 26,
+          "tileId": "lightBush",
+          "minLevel": 1
+        },
+        {
+          "tx": 45,
+          "ty": 26,
+          "tileId": "lightBush",
+          "minLevel": 1
+        },
+        {
+          "tx": 42,
+          "ty": 26,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 46,
+          "ty": 26,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 44,
+          "ty": 28,
+          "tileId": "largeSign",
+          "minLevel": 3
+        },
+        {
+          "tx": 43,
+          "ty": 27,
+          "tileId": "potOfFlowers",
+          "minLevel": 3
         }
       ]
     }

--- a/web/src/data/tiles/buildingRender.ts
+++ b/web/src/data/tiles/buildingRender.ts
@@ -1,0 +1,101 @@
+// ─── Shared building-tile placement ──────────────────────────────────────────
+//
+// Computes the roof / wall / door tile placements for a single building
+// footprint. Shared by the live hub canvas (HubTownCanvas) and the map editor
+// (MapEditorCanvas) so editor previews match the in-game look exactly.
+
+import { WALL_TILES, ROOF_TILES, ROOF_ROWS, getWallTile } from './buildingMaterials'
+import type { WallMaterial, RoofMaterial } from './buildingMaterials'
+
+/** A south-facing door tile, in absolute tile coords, sitting at `rect.y2 + 1`. */
+export interface BuildingDoorTile {
+  tx: number
+  ty: number
+  /** Tiles to shift the rendered door upward (0 = standard south face). */
+  tyAdjust?: number
+}
+
+/**
+ * Returns a `tileId → [(tx, ty), …]` map of every tile needed to draw a
+ * building. Insertion order matters: wall tiles are emitted before door tiles so
+ * doors overdraw the wall at shared positions (mirror the live renderer).
+ */
+export function placeBuildingTiles(
+  rect: [number, number, number, number],
+  wall: WallMaterial,
+  roof: RoofMaterial,
+  doors: BuildingDoorTile[] = [],
+): Map<number, [number, number][]> {
+  const placements = new Map<number, [number, number][]>()
+  const place = (tileId: number, tx: number, ty: number) => {
+    const list = placements.get(tileId) ?? []
+    list.push([tx, ty])
+    placements.set(tileId, list)
+  }
+
+  const [x1, y1, x2, y2] = rect
+  const roofTileIds = ROOF_TILES[roof]
+  const width = x2 - x1 + 1
+
+  // Roof pass — top rows
+  for (let row = 1; row < ROOF_ROWS; row++)
+    for (let tx = x1; tx <= x2; tx++)
+      place(roofTileIds[row], tx, y1 + row)
+
+  // Wall pass — remaining rows (top tiles repeat for middle rows)
+  const firstWallRow = y1 + ROOF_ROWS
+  for (let ty = firstWallRow; ty <= y2; ty++) {
+    for (let tx = x1; tx <= x2; tx++) {
+      const isPillarCol      = tx === x1 + 1 || tx === x2 - 1
+      const isShadowCol      = width >= 5 && tx === x1 + 2
+      const isShadowRightCol = width >= 5 && tx === x2
+      const isBottomRow      = ty === y2
+      const tileId = getWallTile(
+        wall, isBottomRow,
+        tx === x1,
+        isPillarCol,
+        isShadowCol,
+        tx === x2,
+        isShadowRightCol,
+      )
+      place(tileId, tx, ty)
+    }
+  }
+
+  // Door pass — south-facing doors, inserted after wall tiles so they overdraw
+  const wallTiles = WALL_TILES[wall]
+  for (const door of doors) {
+    if (door.ty !== y2 + 1 || door.tx < x1 || door.tx > x2) continue
+    const adj = door.tyAdjust ?? 0
+    place(wallTiles.doorArchTop, door.tx, y2 - 1 - adj)
+    place(wallTiles.doorTop,     door.tx, y2 - 1 - adj)
+    place(wallTiles.doorBottom,  door.tx, y2 - 0 - adj)
+  }
+
+  return placements
+}
+
+/**
+ * Resolves the effective footprint/wall/roof for a building at a given upgrade
+ * level. The highest `levelVisuals` entry whose `minLevel <= level` wins; each
+ * omitted field inherits from the base building.
+ */
+export function resolveBuildingVisual(
+  base: { rect: [number, number, number, number]; wall?: WallMaterial; roof?: RoofMaterial },
+  levelVisuals: Array<{ minLevel: number; rect?: [number, number, number, number]; wall?: WallMaterial; roof?: RoofMaterial }> | undefined,
+  level: number,
+): { rect: [number, number, number, number]; wall?: WallMaterial; roof?: RoofMaterial } {
+  let rect = base.rect
+  let wall = base.wall
+  let roof = base.roof
+  // Apply cumulatively in ascending level order: a later level's overrides win,
+  // while fields it leaves unset keep whatever an earlier level (or the base) set.
+  const sorted = [...(levelVisuals ?? [])].sort((a, b) => a.minLevel - b.minLevel)
+  for (const v of sorted) {
+    if (v.minLevel > level) continue
+    if (v.rect) rect = v.rect
+    if (v.wall) wall = v.wall
+    if (v.roof) roof = v.roof
+  }
+  return { rect, wall, roof }
+}


### PR DESCRIPTION
## Why

When a hub building was upgraded, exterior decoration was placed **programmatically** by a shared, per-*kind* upgrade track (`buildingUpgrades.json` → `dx`/`dy` offsets from the building's door). Because the offsets were generic across every building of a kind and anchored off the door, placement was unreliable. This makes upgrade visuals fully **config-driven and authorable** in the map editor.

## What changed

**Removed the programmatic placement.** The kind-track decor renderer in `HubTownCanvas` is gone. `buildingUpgrades.json` now only carries costs / reputation gates / services. The existing track decor was migrated into each town's `config.json` at the same absolute positions via a one-off script (`web/scripts/migrateUpgradeDecor.ts`), so towns keep their current look — now editable per building. *(dreadspirecitadel / thornwoodcamp had nothing to migrate.)*

**Per-level building visuals (footprint / wall / roof).** New `building.levelVisuals` lets a building change shape and materials as it upgrades. Shared helpers `placeBuildingTiles` / `resolveBuildingVisual` (`data/tiles/buildingRender.ts`) compute tile placements; the live canvas renders one variant container per level threshold and toggles the active one against the building's upgrade level.

**Decor & NPCs associated with a building + level.**
- Decor: existing `building.levelDecor` (absolute tx/ty + `minLevel`) is now the only path.
- Exterior NPCs can be gated by a building via `npc.levelBuildingId`, matching how interior NPCs already gate.
- New `hideAtLevel` on decor and NPCs so an item *disappears* at a level (e.g. swap a plain chair for an upgraded one). A shared `isVisibleAtLevel` predicate enforces `minLevel`/`hideAtLevel` everywhere (runtime + editor preview).

**Map editor.**
- Buildings now render as **real wall/roof tiles** for the current editing level (not grey blocks), with a toolbar toggle to fall back to colour blocks.
- Building inspector: per-level **wall / roof / footprint** controls (base level edits the building; higher levels write a `levelVisuals` override).
- NPC inspector: **"Gated by building"** selector + **"Hide at level"**.
- Decor inspector: **"Hides at level"** field alongside "Appears at level".

## Verification

- `tsc --noEmit` clean
- `vitest run` — 238/238 unit tests pass (the lone error is a pre-existing Playwright browser-launch env issue, unrelated)
- `vite build` succeeds
- Spot-checked migrated `levelDecor` positions against the old door-anchored placement (faithful, including the door-fallback the old runtime used)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DqfdaCML82j3BxV7Qy33kN

---
_Generated by [Claude Code](https://claude.ai/code/session_01DqfdaCML82j3BxV7Qy33kN)_