### PR TITLE
fix(hub): apply sprite fallback to named NPC render path

### DIFF
--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -1012,7 +1012,7 @@ export function HubTownCanvas({
         questIndicatorBaseY.set(npc.id, indBaseY)
       }
 
-      const npcSpriteSlug = isCommanderNpc ? (commander !== undefined ? commander.cardName : avatarSlug) : npc.sprite
+      const npcSpriteSlug = isCommanderNpc ? (commander !== undefined ? commander.cardName : avatarSlug) : resolveNpcSprite(npc.sprite)
 
       // Commander slug is a card name (e.g. "Jarv Knight") — must go through
       // loadSpriteTexture so spriteSlug() converts it to a valid filename.


### PR DESCRIPTION
## Summary
- `HubTownCanvas.tsx` resolved `npc.sprite` through `resolveNpcSprite()` (which falls back to `hub-npc-elder` for blank sprites) everywhere in the file **except** the named/scheduled-NPC render path (line 1015), which read `npc.sprite` raw.
- A blank sprite there requests `sprites/.svg`, 404s, trips the `[HubTownCanvas] NPC sprite failed` Rollbar error, and leaves that NPC invisible in-game — even though the map editor's own canvas already handles this correctly via the same helper.
- Live trigger: Ravenwatch NPC `npc_1781727321393` ("The Wanderer", `tx 17, ty 29`) was saved by the map editor with `"sprite": ""`. This is also why #1577 (closed `not_planned`) resurfaced as #1720 — the underlying code gap was never fixed, only the symptom was dismissed.
- Fix: apply `resolveNpcSprite(npc.sprite)` at that one call site, consistent with the other 4 call sites in the same file. No data file change needed — "The Wanderer" (and any future blank-sprite NPC saved by the editor) now renders with the existing fallback automatically.

Fixes #1720

## Test plan
- [x] `cd web && npm run build` — clean
- [x] `cd web && npm run test` — 238/238 passing (24 files)
- [ ] Manual: run `npm run dev`, visit Ravenwatch tile (17, 29), confirm "The Wanderer" renders with the elder sprite and no new Rollbar error fires


---
_Generated by [Claude Code](https://claude.ai/code/session_01CmjtmUaB8jtGm75uucHLEP)_