### PR TITLE
Hub: bestiary / town journal (#1617)

### DIFF
--- a/docs/hubworld.md
+++ b/docs/hubworld.md
@@ -27,6 +27,8 @@
 | `web/src/components/hub/hubAnimals.ts` | PixiJS animal manager — spawns & ticks all animal types | `createAnimalSystem` |
 | `web/src/components/hub/HubTownCanvas.tsx` | PixiJS canvas — rendering, pathfinding, walk, interactions | — |
 | `web/src/components/hub/HubWorld.tsx` | React orchestrator — quest flow, dialogue, state | — |
+| `web/src/game/hub/journal.ts` | Discovery store for the Town Journal — met NPCs, seen animal species/variants, seen named areas (localStorage) — see §15 | `recordNpcMet`, `hasMetNpc`, `getMetNpcIds`, `recordAnimalSeen`, `hasSeenAnimal`, `getSeenAnimalVariants`, `getSeenAnimalTypes`, `recordAreaSeen`, `hasSeenArea`, `getSeenAreaKeys` |
+| `web/src/components/hub/TownJournal.tsx` | Journal UI — Animals / People / Places tabs with completion % — see §15 | `TownJournal` |
 
 ---
 
@@ -1078,3 +1080,57 @@ Every id field (NPC, building, quest, pickup, interior, dialogue tree) is a
 **grouped by town**. The quest editor's deliver-target and pickup steps use
 all-town pickers; the **Prerequisite** field is a structured condition builder
 (quest / friendship / relationship rows).
+
+---
+
+## §15 — Town Journal
+
+A bestiary/who's-who/gazetteer screen, opened via the toolbar's 📖 **Journal**
+button. Three tabs, each tracking a different kind of discovery and showing a
+`discovered/total` count plus an overall completion %:
+
+- **Animals** — scoped **globally** (a species is the same animal everywhere,
+  not per-town). Tracks which `AnimalType`s (§8) have been tapped at least
+  once, and which named colour variants of each species have been seen.
+- **People** — scoped to the **current town**: named NPCs from
+  `locationData.HUB_NPCS` (de-duped by id, same filter as `TownDirectory`).
+  Tracks which have been talked to; once met, shows their relationship-track
+  icon (§7c) and friendship level (§1) alongside their own first dialogue line.
+- **Places** — scoped to the **current town**: named areas from
+  `locationData.HUB_AREAS`. Tracks which have been entered.
+
+Undiscovered entries render as `???`, matching the `???` convention used by
+`HallOfAchievements` and `TownDirectory`.
+
+### Persistence — `web/src/game/hub/journal.ts` (key `jarv_hub_journal`)
+
+| Export | Purpose |
+|---|---|
+| `recordNpcMet(npcId)` / `hasMetNpc(npcId)` / `getMetNpcIds()` | Mark/check/list met NPCs, by bare id (global, like `friendship.ts`). |
+| `recordAnimalSeen(type, variant?)` / `hasSeenAnimal(type)` / `getSeenAnimalVariants(type)` / `getSeenAnimalTypes()` | Mark/check/list seen animal species and named tint variants. |
+| `recordAreaSeen(town, areaId)` / `hasSeenArea(town, areaId)` / `getSeenAreaKeys()` | Mark/check/list seen areas, keyed via `interactableStoreKey(town, id)` since area ids are not unique across towns (e.g. Ravenwatch's bare `market`). |
+
+Each `record*` is idempotent and returns whether it added new information,
+mirroring `setDialogueFlag`'s dedup pattern (§7b).
+
+### Wiring discovery events
+
+Discovery fires on **tap**, not mere visibility, matching every other
+"have they met X" signal in the codebase:
+
+- `hubAnimals.ts`'s shared pointerdown handler calls `opts.onAnimalSeen(type,
+  variantKeyForTint(type, tint))` for **every** animal tap (placed or
+  procedural), before the `onAnimalTap` early-return for placed/id'd animals.
+  `variantKeyForTint` (`animals.ts`) reverse-resolves a spawned sprite's
+  numeric tint back to its named palette key for display.
+- `HubWorld.tsx`'s `handleNpcTap` calls `recordNpcMet(npcId)` once the tapped
+  id resolves to a **named** NPC (`HUB_NPCS`, not `HUB_ANIMALS`).
+- `HubWorld.tsx`'s `handleAreaEnter` (passed as `HubTownCanvas`'s
+  `onAreaEnter`) resolves the entered area's `id` from `HUB_AREAS` by name and
+  calls `recordAreaSeen(HUB_TOWN_NAME, area.id)`.
+
+### UI — `web/src/components/hub/TownJournal.tsx`
+
+Reuses `TownDirectory`'s `ModalBackdrop` + `.town-directory__*` row layout and
+`HallOfAchievements`' `.hoa-tabs`/`.hoa-tab`/`.hoa-tab--active` tab row — no new
+tab CSS was needed. Story: `TownJournal.stories.tsx`.

--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -1012,7 +1012,7 @@ export function HubTownCanvas({
         questIndicatorBaseY.set(npc.id, indBaseY)
       }
 
-      const npcSpriteSlug = isCommanderNpc ? (commander !== undefined ? commander.cardName : avatarSlug) : npc.sprite
+      const npcSpriteSlug = isCommanderNpc ? (commander !== undefined ? commander.cardName : avatarSlug) : resolveNpcSprite(npc.sprite)
 
       // Commander slug is a card name (e.g. "Jarv Knight") — must go through
       // loadSpriteTexture so spriteSlug() converts it to a valid filename.

--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -19,6 +19,7 @@ import { CommanderState } from '../../game/commander'
 import rollbar from '../../rollbar'
 import { HubInteractable, HubInteriorExit, HubLocationBundle, HubNpc, HubQuestBundle, HubStreetGroup, NpcScheduleEntry, isVisibleAtLevel } from '../../data/hub/loader'
 import { createAnimalSystem, AnimalSystem, GlowSource } from './hubAnimals'
+import type { AnimalType } from '../../game/hub/animals'
 import { createWeatherSystem } from './hubWeather'
 import { resolveWeather } from '../../game/hub/weather'
 import { getActiveFestival } from '../../game/hub/hubCalendar'
@@ -71,6 +72,8 @@ interface Props {
   commander?:       CommanderState
   onNpcTap?:        (dialogue: string, npcId: string) => void
   onAnimalTap?:     (animalId: string) => void
+  /** Fires for every animal tap (placed or procedural) for journal/bestiary tracking. */
+  onAnimalSeen?:    (type: AnimalType, variant?: string) => void
   interiorEnterRef?: React.MutableRefObject<((buildingId: string) => void) | null>
   interiorExitRef?:  React.MutableRefObject<(() => void) | null>
   onEnterInterior?:  () => void
@@ -106,7 +109,7 @@ interface Props {
 
 export function HubTownCanvas({
   onAreaEnter, onNodeInteract, onAvatarMove,
-  returnRef, unitCards, commander, onNpcTap, onAnimalTap,
+  returnRef, unitCards, commander, onNpcTap, onAnimalTap, onAnimalSeen,
   interiorEnterRef, interiorExitRef, onEnterInterior, onExitInterior, onTileTap,
   pickedUpIds, onItemPickup, doorKeys, onDoorLocked, questNpcState, activeQuestIdsRef,
   completedQuestIdsRef, collectedTreasureIds, onTreasureStep,
@@ -145,6 +148,8 @@ export function HubTownCanvas({
   onNpcTapRef.current     = onNpcTap
   const onAnimalTapRef    = useRef(onAnimalTap)
   onAnimalTapRef.current  = onAnimalTap
+  const onAnimalSeenRef   = useRef(onAnimalSeen)
+  onAnimalSeenRef.current = onAnimalSeen
   const unitCardsRef      = useRef(unitCards)
   unitCardsRef.current    = unitCards
   const onEnterInteriorRef  = useRef(onEnterInterior)
@@ -2298,6 +2303,7 @@ export function HubTownCanvas({
         return out
       },
       onAnimalTap: (id) => onAnimalTapRef.current?.(id),
+      onAnimalSeen: (type, variant) => onAnimalSeenRef.current?.(type, variant),
       getQuestIndicator: (id) => questNpcState?.current.get(id) ?? null,
       isInteriorActive: () => interiorActive,
       isOnScreen: (x, y) => {

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -45,6 +45,7 @@ import {  ALL_QUESTS, FRIENDSHIP_DIALOGUE, RELATIONSHIP_DIALOGUE, RAVENWATCH } f
 import { HubInteractable, HubLocationBundle, HubQuestBundle, HubTreasure } from '../../data/hub/loader'
 import { getUnreadCount } from '../../game/news'
 import { interactableStoreKey, isInteractableGranted, markInteractableGranted, getInteractableMoves, setInteractableMove } from '../../game/hub/interactables'
+import { recordNpcMet, recordAnimalSeen, recordAreaSeen } from '../../game/hub/journal'
 import rollbar from '../../rollbar'
 interface QuestEvent {
   speakerName: string
@@ -779,15 +780,17 @@ function hasOfferableQuest(giverId: string): boolean {
   const handleNpcTap = useCallback((line: string, npcId: string) => {
     // Placed animals (HUB_ANIMALS) reuse all NPC quest logic — they share the
     // same id space as quest giverNpcId / receiverNpcId / targetNpcId.
+    const namedNpc = locationData.HUB_NPCS.find(n => n.id === npcId)
     const npcDef: {
       name?: string; dialogue?: string[]; screen?: string
       questGive?: string; questReceive?: string | string[]
       innRumours?: Array<{ id: string; text: string }>
       dialogueTree?: string
     } | undefined =
-      locationData.HUB_NPCS.find(n => n.id === npcId) ??
+      namedNpc ??
       locationData.HUB_ANIMALS.find(a => a.id === npcId)
     const speakerName = npcDef?.name ?? ''
+    if (namedNpc) recordNpcMet(npcId)
 
     // Cross-town deliveries: scan EVERY town's quests (not just the current one)
     // for an active quest with a pending deliver step addressed to this NPC, or
@@ -965,6 +968,12 @@ function hasOfferableQuest(giverId: string): boolean {
     handleNpcTap(line, animalId)
   }, [handleNpcTap, locationData])
 
+  const handleAreaEnter = useCallback((areaName: string | null) => {
+    setCurrentArea(areaName)
+    const area = areaName != null ? locationData.HUB_AREAS.find(a => a.name === areaName) : undefined
+    if (area) recordAreaSeen(locationData.HUB_TOWN_NAME, area.id)
+  }, [locationData])
+
   // ── Interactable reactions ─────────────────────────────────────────────────
   // Reactions run in order; dialogue-style reactions chain the remainder
   // through the dialogue's onClose (manual close or 15 s auto-dismiss).
@@ -1080,7 +1089,7 @@ function hasOfferableQuest(giverId: string): boolean {
           style={{ overflowX: 'auto', overflowY: 'auto', width: '100%', height: '100%' }}
         >
           <HubTownCanvas
-            onAreaEnter={setCurrentArea}
+            onAreaEnter={handleAreaEnter}
             onNodeInteract={handleNodeInteract}
             onAvatarMove={handleAvatarMove}
             returnRef={returnRef}
@@ -1088,6 +1097,7 @@ function hasOfferableQuest(giverId: string): boolean {
             commander={commander}
             onNpcTap={handleNpcTap}
             onAnimalTap={handleAnimalTap}
+            onAnimalSeen={recordAnimalSeen}
             interiorEnterRef={interiorEnterRef}
             interiorExitRef={interiorExitRef}
             onEnterInterior={() => setInteriorActive(true)}

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -31,6 +31,7 @@ import { LoginButton } from '../ui/LoginButton'
 import { addCollectible, addConsumable, getCollectibles } from '../../game/itemStore'
 import { QuestsModal } from './QuestsModal'
 import { TownDirectory } from './TownDirectory'
+import { TownJournal } from './TownJournal'
 import { HubTownUpgrades, type UpgradeRow } from './HubTownUpgrades'
 import { nextUpgrade, purchaseUpgrade, getTownReputation, getUpgradeLevel, setUpgradeKindResolver, tributeAmount, tributeAvailable, collectTribute } from '../../game/hub/reputation'
 import { RelationshipView } from './RelationshipView'
@@ -171,6 +172,7 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onEndless, onWorldMap
   const [pickedUpIds,    setPickedUpIds]    = useState<Set<string>>(() => getPickedUpIds())
   const [questsOpen,          setQuestsOpen]          = useState(false)
   const [directoryOpen,       setDirectoryOpen]       = useState(false)
+  const [journalOpen,         setJournalOpen]         = useState(false)
   const [upgradesOpen,        setUpgradesOpen]        = useState(false)
   // buildingId → purchased upgrade level; read each frame by the canvas to
   // reveal unlocked decor live, and updated on purchase.
@@ -1051,6 +1053,7 @@ function hasOfferableQuest(giverId: string): boolean {
           )}
         <ToolbarButton icon="📜" title="Quests" onClick={() => setQuestsOpen(true)} />
         <ToolbarButton icon="🧭" title="Where is…?" onClick={() => setDirectoryOpen(true)} />
+        <ToolbarButton icon="📖" title="Journal" onClick={() => setJournalOpen(true)} />
         <ToolbarButton icon="🏗️" title="Town Upgrades" onClick={() => setUpgradesOpen(true)} />
         <ToolbarButton icon="🗺" title="World Map" onClick={() => onWorldMap?.()}  disabled={getQuestState('thorin-the-last-watch').status !== 'completed'} />
 
@@ -1138,6 +1141,7 @@ function hasOfferableQuest(giverId: string): boolean {
 
         {questsOpen && <QuestsModal onClose={() => setQuestsOpen(false)} onAbandon={handleQuestAbandon} questDefs={questDefs} resolveNpcName={getNpcDisplayName}/>}
         {directoryOpen && <TownDirectory onClose={() => setDirectoryOpen(false)} locationData={locationData} pinnedNpcId={pinnedNpcId} onTogglePin={togglePinnedNpc} onShowRelationship={setRelationshipNpcId} />}
+        {journalOpen && <TownJournal onClose={() => setJournalOpen(false)} locationData={locationData} />}
         {upgradesOpen && <HubTownUpgrades onClose={() => setUpgradesOpen(false)} townName={town} reputation={getTownReputation(town)} crystals={loadCrystals()} rows={upgradeRows} onUpgrade={handleUpgrade} tributeAmount={tributeAmount(town)} tributeAvailable={tributeAvailable(town)} onCollectTribute={handleCollectTribute} />}
         {relationshipNpcId && <RelationshipView npcName={getNpcDisplayName(relationshipNpcId)} entry={getRelationship(relationshipNpcId)} onClose={() => setRelationshipNpcId(null)} />}
         {openTreasure && <TreasureModal treasure={openTreasure} onClose={() => setOpenTreasure(null)} />}

--- a/web/src/components/hub/TownJournal.stories.tsx
+++ b/web/src/components/hub/TownJournal.stories.tsx
@@ -1,0 +1,26 @@
+import { fn } from 'storybook/test'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { TownJournal } from './TownJournal'
+import { RAVENWATCH } from '../../data/hub/hubWorldFactory'
+
+const meta = {
+  component: TownJournal,
+  parameters: { layout: 'fullscreen' },
+  decorators: [
+    (Story) => (
+      <div className="game-container">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof TownJournal>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    onClose: fn(),
+    locationData: RAVENWATCH,
+  },
+}

--- a/web/src/components/hub/TownJournal.tsx
+++ b/web/src/components/hub/TownJournal.tsx
@@ -1,0 +1,169 @@
+import React, { useState } from 'react'
+import { ModalBackdrop } from '../ui/ModalBackdrop'
+import type { HubLocationBundle } from '../../data/hub/loader'
+import { ANIMAL_TYPES, TINT_PALETTES, type AnimalType } from '../../game/hub/animals'
+import { getFriendshipLevel } from '../../game/hub/friendship'
+import { getRelationship } from '../../game/hub/relationships'
+import {
+  hasMetNpc, getMetNpcIds,
+  hasSeenAnimal, getSeenAnimalVariants, getSeenAnimalTypes,
+  hasSeenArea,
+} from '../../game/hub/journal'
+
+const TRACK_ICON: Record<string, string> = { ally: '🤝', rival: '⚔️', romance: '💗' }
+
+const ANIMAL_FLAVOUR: Record<AnimalType, string> = {
+  cat:       'Aloof and sun-loving. Naps in doorways, hunts birds for sport.',
+  dog:       'Loyal and loud. Follows its owner everywhere it can.',
+  bird:      'Flits between rooftops. Gone the moment you look up.',
+  fish:      'Quiet pond residents. Easy to miss, easy to startle.',
+  butterfly: 'Drifts between flowerbeds. Scatters if a cat gets close.',
+  rabbit:    'Bolts at the first sign of trouble. Sticks to open grass.',
+  chicken:   'Pecks around its pen, unbothered by most of the town.',
+  frog:      'Hops along the water\'s edge, plopping in when startled.',
+  firefly:   'A night-time glow over the grass. Vanishes by sunrise.',
+  bat:       'Fast, erratic, nocturnal. Rarely sits still long enough to see.',
+}
+
+function capitalize(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1)
+}
+
+type Tab = 'animals' | 'people' | 'places'
+
+interface Props {
+  onClose: () => void
+  locationData: HubLocationBundle
+}
+
+export function TownJournal({ onClose, locationData }: Props) {
+  const [tab, setTab] = useState<Tab>('animals')
+
+  const seenAnimalTypes = getSeenAnimalTypes()
+  const animalsTotal = ANIMAL_TYPES.length
+  const animalsSeen = seenAnimalTypes.size
+
+  const seen = new Set<string>()
+  const namedNpcs = locationData.HUB_NPCS.filter(n => {
+    if (!n.name?.trim() || seen.has(n.id)) return false
+    seen.add(n.id)
+    return true
+  })
+  const metNpcIds = getMetNpcIds()
+  const peopleTotal = namedNpcs.length
+  const peopleMet = namedNpcs.filter(n => metNpcIds.has(n.id)).length
+
+  const areas = locationData.HUB_AREAS
+  const placesTotal = areas.length
+  const placesSeen = areas.filter(a => hasSeenArea(locationData.HUB_TOWN_NAME, a.id)).length
+
+  const TABS: { id: Tab; label: string; discovered: number; total: number }[] = [
+    { id: 'animals', label: 'Animals', discovered: animalsSeen, total: animalsTotal },
+    { id: 'people',  label: 'People',  discovered: peopleMet,   total: peopleTotal },
+    { id: 'places',  label: 'Places',  discovered: placesSeen,  total: placesTotal },
+  ]
+
+  const overallDiscovered = animalsSeen + peopleMet + placesSeen
+  const overallTotal = animalsTotal + peopleTotal + placesTotal
+  const overallPct = overallTotal > 0 ? Math.round((overallDiscovered / overallTotal) * 100) : 0
+
+  return (
+    <ModalBackdrop onClose={onClose}>
+      <div className="town-directory town-journal">
+        <div className="town-directory__header">
+          <span>📖 Town Journal</span>
+          <span className="town-directory__meta">
+            {overallPct}% complete
+            <button className="town-directory__close" onClick={onClose}>✕</button>
+          </span>
+        </div>
+
+        <div className="hoa-tabs">
+          {TABS.map(t => (
+            <button
+              key={t.id}
+              className={`hoa-tab${t.id === tab ? ' hoa-tab--active' : ''}`}
+              onClick={() => setTab(t.id)}
+            >
+              {t.label} ({t.discovered}/{t.total})
+            </button>
+          ))}
+        </div>
+
+        {tab === 'animals' && (
+          <div className="town-directory__list town-journal__list">
+            {ANIMAL_TYPES.map(type => {
+              const known = hasSeenAnimal(type)
+              const variants = getSeenAnimalVariants(type)
+              const totalVariants = Object.keys(TINT_PALETTES[type]).length
+              return (
+                <div key={type} className="town-directory__row">
+                  <div className="town-directory__info">
+                    <span className="town-directory__name">
+                      {known ? capitalize(type) : '???'}
+                    </span>
+                    <span className="town-directory__place">
+                      {known
+                        ? `${ANIMAL_FLAVOUR[type]} (${variants.size}/${totalVariants} variants seen)`
+                        : 'Not yet encountered.'}
+                    </span>
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        )}
+
+        {tab === 'people' && (
+          <div className="town-directory__list town-journal__list">
+            {namedNpcs.length === 0 ? (
+              <div className="town-directory__empty">No one notable lives here yet.</div>
+            ) : (
+              namedNpcs.map(npc => {
+                const met = hasMetNpc(npc.id)
+                const track = getRelationship(npc.id).track
+                const level = getFriendshipLevel(npc.id)
+                return (
+                  <div key={npc.id} className="town-directory__row">
+                    <div className="town-directory__info">
+                      <span className="town-directory__name">
+                        {met ? npc.name : '???'}{met && track ? ` ${TRACK_ICON[track]}` : ''}
+                      </span>
+                      <span className="town-directory__place">
+                        {met
+                          ? `${npc.dialogue[0] ?? ''}${level > 0 ? ` · Friendship Lv ${level}` : ''}`
+                          : 'You haven\'t met them yet.'}
+                      </span>
+                    </div>
+                  </div>
+                )
+              })
+            )}
+          </div>
+        )}
+
+        {tab === 'places' && (
+          <div className="town-directory__list town-journal__list">
+            {areas.length === 0 ? (
+              <div className="town-directory__empty">No named places here yet.</div>
+            ) : (
+              areas.map(area => {
+                const found = hasSeenArea(locationData.HUB_TOWN_NAME, area.id)
+                return (
+                  <div key={area.id} className="town-directory__row">
+                    <div className="town-directory__info">
+                      <span className="town-directory__name">{found ? area.name : '???'}</span>
+                      <span className="town-directory__place">
+                        {found ? 'Discovered' : 'Not yet visited.'}
+                      </span>
+                    </div>
+                  </div>
+                )
+              })
+            )}
+          </div>
+        )}
+      </div>
+    </ModalBackdrop>
+  )
+}

--- a/web/src/components/hub/hubAnimals.ts
+++ b/web/src/components/hub/hubAnimals.ts
@@ -19,6 +19,7 @@ import {
   pickWeighted,
   randomDuration,
   resolveVariantTint,
+  variantKeyForTint,
 } from '../../game/hub/animals'
 
 const FRAME_MS = 160
@@ -111,6 +112,8 @@ export interface AnimalSystemOptions {
   getNpcPositions: () => { id?: string; x: number; y: number }[]
   /** Routes a placed animal tap to quest handling. */
   onAnimalTap: (animalId: string) => void
+  /** Fires for every animal tap (placed or procedural) for journal/bestiary tracking. */
+  onAnimalSeen?: (type: AnimalType, variant?: string) => void
   /** Quest indicator state for a placed animal id ('offer'|'ready'|null). */
   getQuestIndicator?: (animalId: string) => 'offer' | 'ready' | null
   isInteriorActive: () => boolean
@@ -927,6 +930,7 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
     sprite.cursor = 'pointer'
     sprite.on('pointerdown', (e: PIXI.FederatedPointerEvent) => {
       e.stopPropagation()
+      opts.onAnimalSeen?.(type, variantKeyForTint(type, tint))
       if (a.id) { opts.onAnimalTap(a.id); return }
       speak(a, FLAVOUR[type])
       vocalize(a)

--- a/web/src/game/hub/animals.test.ts
+++ b/web/src/game/hub/animals.test.ts
@@ -6,6 +6,7 @@ import {
   SpawnSources,
   computeProceduralCounts,
   resolveVariantTint,
+  variantKeyForTint,
   TINT_PALETTES,
   pickWeighted,
   randomDuration,
@@ -87,6 +88,16 @@ describe('resolveVariantTint', () => {
 
   it('falls back to a palette colour using the supplied rng', () => {
     expect(resolveVariantTint('frog', undefined, () => 0)).toBe(Object.values(TINT_PALETTES.frog)[0])
+  })
+})
+
+describe('variantKeyForTint', () => {
+  it('finds the named key for a known tint', () => {
+    expect(variantKeyForTint('cat', TINT_PALETTES.cat.orange)).toBe('orange')
+  })
+
+  it('returns undefined for an unknown tint', () => {
+    expect(variantKeyForTint('cat', 0x123456)).toBeUndefined()
   })
 })
 

--- a/web/src/game/hub/animals.ts
+++ b/web/src/game/hub/animals.ts
@@ -170,6 +170,11 @@ export function resolveVariantTint(
   return values[Math.floor(rng() * values.length)]
 }
 
+/** Reverse of resolveVariantTint: find the named palette key for a tint, if any. */
+export function variantKeyForTint(type: AnimalType, tint: number): string | undefined {
+  return Object.entries(TINT_PALETTES[type]).find(([, v]) => v === tint)?.[0]
+}
+
 // ── Behaviour transition tables ─────────────────────────────────────────────
 export type CatState = 'sleep' | 'sit' | 'flee' | 'chase-bird' | 'play' | 'approach-npc' | 'go-home' | 'inside'
 export type DogState = 'follow-owner' | 'roam' | 'bark' | 'wag' | 'chase-cat'

--- a/web/src/game/hub/journal.test.ts
+++ b/web/src/game/hub/journal.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import {
+  recordNpcMet, hasMetNpc, getMetNpcIds,
+  recordAnimalSeen, hasSeenAnimal, getSeenAnimalVariants, getSeenAnimalTypes,
+  recordAreaSeen, hasSeenArea, getSeenAreaKeys,
+} from './journal'
+
+function installLocalStorageStub(): void {
+  const store = new Map<string, string>()
+  vi.stubGlobal('localStorage', {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => { store.set(k, v) },
+    removeItem: (k: string) => { store.delete(k) },
+    clear: () => { store.clear() },
+  })
+}
+
+describe('journal', () => {
+  beforeEach(() => {
+    installLocalStorageStub()
+  })
+
+  it('records and reads met NPCs, deduplicating', () => {
+    expect(hasMetNpc('elder')).toBe(false)
+    expect(recordNpcMet('elder')).toBe(true)
+    expect(recordNpcMet('elder')).toBe(false)
+    expect(hasMetNpc('elder')).toBe(true)
+    expect(getMetNpcIds()).toEqual(new Set(['elder']))
+  })
+
+  it('records seen animal species and named variants', () => {
+    expect(hasSeenAnimal('cat')).toBe(false)
+    expect(recordAnimalSeen('cat', 'orange')).toBe(true)
+    expect(hasSeenAnimal('cat')).toBe(true)
+    expect(getSeenAnimalVariants('cat')).toEqual(new Set(['orange']))
+    expect(getSeenAnimalTypes()).toEqual(new Set(['cat']))
+
+    // Same species + same variant again is not new info.
+    expect(recordAnimalSeen('cat', 'orange')).toBe(false)
+    // Same species, a different variant is new info.
+    expect(recordAnimalSeen('cat', 'black')).toBe(true)
+    expect(getSeenAnimalVariants('cat')).toEqual(new Set(['orange', 'black']))
+  })
+
+  it('marks a species seen even without a resolved variant', () => {
+    expect(recordAnimalSeen('dog')).toBe(true)
+    expect(hasSeenAnimal('dog')).toBe(true)
+    expect(getSeenAnimalVariants('dog')).toEqual(new Set())
+    // No new info the second time.
+    expect(recordAnimalSeen('dog')).toBe(false)
+  })
+
+  it('records seen areas scoped per-town, deduplicating', () => {
+    expect(hasSeenArea('ravenwatch', 'market')).toBe(false)
+    expect(recordAreaSeen('ravenwatch', 'market')).toBe(true)
+    expect(recordAreaSeen('ravenwatch', 'market')).toBe(false)
+    expect(hasSeenArea('ravenwatch', 'market')).toBe(true)
+    // Same area id in a different town is a distinct key.
+    expect(hasSeenArea('millhaven', 'market')).toBe(false)
+    expect(getSeenAreaKeys()).toEqual(new Set(['ravenwatch:market']))
+  })
+
+  it('returns empty + false when localStorage throws', () => {
+    vi.stubGlobal('localStorage', {
+      getItem: () => { throw new Error('blocked') },
+      setItem: () => { throw new Error('blocked') },
+    })
+    expect(() => recordNpcMet('x')).not.toThrow()
+    expect(hasMetNpc('x')).toBe(false)
+    expect(getMetNpcIds()).toEqual(new Set())
+    expect(getSeenAreaKeys()).toEqual(new Set())
+  })
+})

--- a/web/src/game/hub/journal.ts
+++ b/web/src/game/hub/journal.ts
@@ -1,0 +1,115 @@
+import { logError } from '../../logger'
+import { interactableStoreKey } from './interactables'
+import type { AnimalType } from './animals'
+
+const KEY = 'jarv_hub_journal'
+
+interface JournalData {
+  npcs: string[]
+  animalTypes: string[]
+  animalVariants: Record<string, string[]>
+  areas: string[]
+}
+
+function emptyData(): JournalData {
+  return { npcs: [], animalTypes: [], animalVariants: {}, areas: [] }
+}
+
+function load(): JournalData {
+  try {
+    const raw = localStorage.getItem(KEY)
+    if (!raw) return emptyData()
+    const parsed = JSON.parse(raw) as Partial<JournalData>
+    return {
+      npcs: parsed.npcs ?? [],
+      animalTypes: parsed.animalTypes ?? [],
+      animalVariants: parsed.animalVariants ?? {},
+      areas: parsed.areas ?? [],
+    }
+  } catch {
+    return emptyData()
+  }
+}
+
+function save(data: JournalData): void {
+  try {
+    localStorage.setItem(KEY, JSON.stringify(data))
+  } catch (e) {
+    logError('journal save failed', { error: String(e) })
+  }
+}
+
+// ── People met ───────────────────────────────────────────────────────────────
+
+/** Record that a named NPC has been talked to. Returns true if newly recorded. */
+export function recordNpcMet(npcId: string): boolean {
+  const data = load()
+  if (data.npcs.includes(npcId)) return false
+  data.npcs.push(npcId)
+  save(data)
+  return true
+}
+
+export function hasMetNpc(npcId: string): boolean {
+  return load().npcs.includes(npcId)
+}
+
+export function getMetNpcIds(): Set<string> {
+  return new Set(load().npcs)
+}
+
+// ── Animals seen ─────────────────────────────────────────────────────────────
+
+/** Record that an animal species (and optionally a named colour variant) has been
+ *  seen. Returns true if this added new information (species or variant). */
+export function recordAnimalSeen(type: AnimalType, variant?: string): boolean {
+  const data = load()
+  let changed = false
+  if (!data.animalTypes.includes(type)) {
+    data.animalTypes.push(type)
+    changed = true
+  }
+  if (variant) {
+    const seen = data.animalVariants[type] ?? []
+    if (!seen.includes(variant)) {
+      data.animalVariants[type] = [...seen, variant]
+      changed = true
+    }
+  }
+  if (changed) save(data)
+  return changed
+}
+
+export function hasSeenAnimal(type: AnimalType): boolean {
+  return load().animalTypes.includes(type)
+}
+
+export function getSeenAnimalVariants(type: AnimalType): Set<string> {
+  return new Set(load().animalVariants[type] ?? [])
+}
+
+export function getSeenAnimalTypes(): Set<AnimalType> {
+  return new Set(load().animalTypes as AnimalType[])
+}
+
+// ── Places discovered ────────────────────────────────────────────────────────
+// Areas are keyed via interactableStoreKey's "<town>:<id>" convention since area
+// ids are not guaranteed unique across towns (e.g. Ravenwatch's bare "market").
+
+/** Record that a named area has been entered. Returns true if newly recorded. */
+export function recordAreaSeen(town: string, areaId: string): boolean {
+  const data = load()
+  const key = interactableStoreKey(town, areaId)
+  if (data.areas.includes(key)) return false
+  data.areas.push(key)
+  save(data)
+  return true
+}
+
+export function hasSeenArea(town: string, areaId: string): boolean {
+  return load().areas.includes(interactableStoreKey(town, areaId))
+}
+
+export function getSeenAreaKeys(): Set<string> {
+  return new Set(load().areas)
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -15369,6 +15369,9 @@ html.light-mode .action-btn {
 .town-directory__pin-btn--on { border-color: #55ddee; color: #55ddee; }
 .town-directory__pin-btn:hover { opacity: 0.85; }
 
+/* ── Town Journal panel (reuses .town-directory layout + .hoa-tabs) ────────── */
+.town-journal__list { margin-top: 12px; }
+
 /* ── Town Upgrades panel (reuses .town-directory layout) ───────────────────── */
 .town-upgrades__rep {
   display: flex;


### PR DESCRIPTION
Closes #1628, #1631, #1633. Closes #1617.

## Summary
Adds a Town Journal screen — a bestiary / who's-who / gazetteer opened from the toolbar's 📖 button — with three tabs:

- **Animals** (global): which animal species (and named colour variants) have been tapped at least once.
- **People** (per-town): which named NPCs have been talked to, with relationship-track icon + friendship level once met.
- **Places** (per-town): which named areas have been entered.

Undiscovered entries show `???`, matching the existing convention in `HallOfAchievements`/`TownDirectory`.

## Implementation
- `game/hub/journal.ts` (+test): new localStorage-backed discovery store — `recordNpcMet`/`recordAnimalSeen`/`recordAreaSeen` and their `has*`/`get*` readers. Follows `interactables.ts`'s error-handling convention (`logError` on write failure). Areas are keyed via the existing `interactableStoreKey(town, id)` convention since area ids collide across towns.
- `game/hub/animals.ts` (+test): added `variantKeyForTint` — reverse-resolves a spawned animal's numeric tint back to its named palette key, needed because procedural spawns only retain the final tint.
- `components/hub/hubAnimals.ts` / `HubTownCanvas.tsx`: new `onAnimalSeen` callback fired on every animal tap (placed or procedural), threaded through the existing ref-bridge prop pattern.
- `components/hub/HubWorld.tsx`: wires `recordNpcMet`/`recordAnimalSeen`/`recordAreaSeen` into the existing tap/area-entry handlers; adds the 📖 Journal toolbar button.
- `components/hub/TownJournal.tsx` (+story): the UI, reusing `TownDirectory`'s modal/row layout and `HallOfAchievements`' tab classes — no new tab CSS needed.
- `docs/hubworld.md`: new §15 section.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 245/245 tests pass (one pre-existing, unrelated Playwright headless-shell environment error)
- [x] `npm run build` clean
- [x] Verified all three tabs in Storybook (seeded localStorage to confirm discovered/undiscovered states, completion %, and persistence across reload)
- [ ] Manual in-game check: tap a named NPC/animal, walk into a named area, open 📖 Journal, confirm it updates and persists after reload


---
_Generated by [Claude Code](https://claude.ai/code/session_01CmjtmUaB8jtGm75uucHLEP)_