### PR TITLE
fix(hub): stop interior treasure chests rendering on exterior map

### DIFF
--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -800,7 +800,7 @@ export function HubTownCanvas({
     const treasureCollectedTex = new Map<string, PIXI.Texture | null>() // id → collected texture (null = hide)
     const treasureByTile      = new Map<string, string>()               // "tx,ty" → id
     {
-      for (const t of HUB_TREASURES) {
+      for (const t of HUB_TREASURES.filter(tr => !tr.buildingId)) {
         if (collectedTreasureRef.current.has(t.id)) {
           // Already collected — show the collected tile or nothing
           if (t.collectedTileId) {


### PR DESCRIPTION
## Summary
- Two chests were visibly appearing near the top-left corner of the Ravenwatch exterior map, even though no decor placement put them there.
- Root cause: `HUB_TREASURES` holds both exterior treasures and interior-only treasures (tagged with a `buildingId`, e.g. Ravenwatch's `home-building` and `home-barracks-passage` chests). The interior render loop in `HubTownCanvas.tsx` already filtered by `buildingId`, but the exterior render loop iterated the full unfiltered list, so building-only chests were also drawn on the exterior map at their interior tile coordinates — which happened to be small `tx/ty` values, landing them near the map origin.
- Fix: filter the exterior loop to skip `buildingId`-tagged treasures, mirroring the existing interior filter.
- This is a general fix, not Ravenwatch-specific — 11 other towns have `buildingId`-tagged treasures that were affected the same way.

## Test plan
- [x] `npx tsc --noEmit` passes clean
- [x] `npx vitest run` — 245/245 tests pass
- [x] Verified visually via Storybook's `HubTownCanvas` "Ravenwatch" story: reverted the fix, confirmed the two chests render on the exterior map near the same buildings/trees seen in the reported screenshot; reapplied the fix and confirmed both chests disappear from the exterior view while interior treasure data is untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01BvigofYDCJUeQhY4C4PEqv)_