### PR TITLE
fix(hub): clear scared NPC speech bubble when entering a building

### DIFF
--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -1169,6 +1169,11 @@ export function HubTownCanvas({
         npc.currentTile = [tx, ty]
         // Despawn NPCs that reach a building door — they "go inside"
         if (doorTileSet.has(`${tx},${ty}`)) {
+          if (npc.scaredBubble) {
+            bubbleLayer.removeChild(npc.scaredBubble)
+            npc.scaredBubble = null
+            npc.scaredBubbleTimer = 0
+          }
           npc.sprite.parent?.removeChild(npc.sprite)
           const idx = unitNpcs.indexOf(npc)
           if (idx !== -1) unitNpcs.splice(idx, 1)


### PR DESCRIPTION
## Summary
- Ambient NPCs in the Hub town show a "scared" speech bubble (e.g. "Please no please no", "Run!! RUN!!") when a ghost wanders nearby.
- When such an NPC then reaches a building door and despawns to simulate entering the building, only the sprite was removed — the active scared-bubble container was left behind in `bubbleLayer`, floating at its last position forever (as shown in the reported screenshot, near the Town Hall steps).
- Fix: clear the NPC's `scaredBubble` from `bubbleLayer` at the same despawn site in `processNpcWalkQueue` (`web/src/components/hub/HubTownCanvas.tsx`), mirroring the existing cleanup already done in `doEnterInterior` for the player-enters-building case.

## Test plan
- [x] `npx tsc --noEmit` passes with no errors
- [x] `npx vitest run` — all 245 existing tests pass
- [x] `npm run build` succeeds
- [ ] Manual: spawn a ghost near an ambient NPC in the Hub town, let the scared NPC walk into a building door while its bubble is active, confirm the bubble disappears with the NPC instead of lingering


---
_Generated by [Claude Code](https://claude.ai/code/session_018X3oeRYTFbv1wmfX1Fh7Gw)_