### PR TITLE
Fix hub-town pond rendering broken tiles at corners/notches

### DIFF
--- a/web/src/data/tiles/tileIndex.ts
+++ b/web/src/data/tiles/tileIndex.ts
@@ -27,7 +27,6 @@ export const BASE_GROUND = {
 //
 // Exits are named by compass direction: t=top, b=bottom, l=left, r=right.
 // "quad" tiles show path only in one corner (grass fills the other 3 quadrants).
-// Tiles 24–45 are corner-grass variations (subtle) — to be indexed later.
 export const PATH = {
   isolated:         0,   // no exits
   rightOnly:        1,   // r
@@ -54,11 +53,6 @@ export const PATH = {
   edgeBottom:       22,  // l + t + r  (grass border along bottom edge)
   quadTopLeft:      23,  // l + t  (grass bottom + right)
   allSides:         46,  // l + r + t + b (with grass corners — use near grass)
-  // Tiles 24–45: corner-grass variations (mostly filled, grass only in one corner)
-  grassCornerBR:    28,  // grass bottom-right corner
-  grassCornerBL:    29,  // grass bottom-left corner
-  grassCornerTR:    36,  // grass top-right corner
-  grassCornerTL:    37,  // grass top-left corner
 } as const
 
 

--- a/web/src/utils/tileLookup.ts
+++ b/web/src/utils/tileLookup.ts
@@ -19,28 +19,21 @@ export function buildTileLookup(canal: boolean): number[] {
     const W  = !!(mask &  64)
     const NW = !!(mask & 128)
 
-    if (N && E && S && W) {
-      if (canal) {
-        const missing = (!NE ? 1 : 0) + (!SE ? 1 : 0) + (!SW ? 1 : 0) + (!NW ? 1 : 0)
-        if (missing === 0)        t[mask] = PATH.allSidesNoGrass
-        else if (missing === 1 && !NE) t[mask] = PATH.grassCornerTR
-        else if (missing === 1 && !SE) t[mask] = PATH.grassCornerBR
-        else if (missing === 1 && !SW) t[mask] = PATH.grassCornerBL
-        else if (missing === 1 && !NW) t[mask] = PATH.grassCornerTL
-        else                      t[mask] = PATH.allSidesNoGrass
-      } else {
-        t[mask] = PATH.allSidesNoGrass
-      }
-    } else if (N && E && S)      t[mask] = PATH.tJuncRight
+    // canal mode used to substitute PATH.grassCornerXX tiles here for single-corner
+    // notches/elbows, but those tile indices only contain a fragment of an unrelated
+    // 2x2 decorative ring motif rather than real corner-notch art — canal and
+    // non-canal now resolve identically for these shapes.
+    if (N && E && S && W)        t[mask] = PATH.allSidesNoGrass
+    else if (N && E && S)      t[mask] = PATH.tJuncRight
     else if (E && S && W)        t[mask] = PATH.edgeTop
     else if (N && S && W)        t[mask] = PATH.tJuncLeft2
     else if (N && E && W)        t[mask] = PATH.edgeBottom
     else if (N && S)             t[mask] = PATH.vertical
     else if (E && W)             t[mask] = PATH.horizontal
-    else if (N && E)             t[mask] = NE ? PATH.quadTopRight    : (canal ? PATH.grassCornerBL : PATH.turnTopRight)
-    else if (N && W)             t[mask] = NW ? PATH.quadTopLeft     : (canal ? PATH.grassCornerBR : PATH.turnTopLeft)
-    else if (S && E)             t[mask] = SE ? PATH.quadBottomRight : (canal ? PATH.grassCornerTL : PATH.turnBottomRight)
-    else if (S && W)             t[mask] = SW ? PATH.quadBottomLeft  : (canal ? PATH.grassCornerTR : PATH.turnBottomLeft)
+    else if (N && E)             t[mask] = NE ? PATH.quadTopRight    : PATH.turnTopRight
+    else if (N && W)             t[mask] = NW ? PATH.quadTopLeft     : PATH.turnTopLeft
+    else if (S && E)             t[mask] = SE ? PATH.quadBottomRight : PATH.turnBottomRight
+    else if (S && W)             t[mask] = SW ? PATH.quadBottomLeft  : PATH.turnBottomLeft
     else if (N)                  t[mask] = PATH.topOnly
     else if (E)                  t[mask] = PATH.rightOnly
     else if (S)                  t[mask] = PATH.bottomOnly


### PR DESCRIPTION
## Summary

- Hub-town pond rendering (`renderPathTiles(..., useCanal=true)` in `HubTownCanvas.tsx`) showed broken/stray tiles at notches and elbow bends in the pond outline — visible seams, missing shoreline borders, and an odd circular blob in open water.
- Root cause: in `buildTileLookup(canal)` (`web/src/utils/tileLookup.ts`), canal mode substituted `PATH.grassCornerBR/BL/TR/TL` (tile indices 28/29/36/37) for single-corner-notch and elbow-bend shapes. Pixel-level inspection of the actual water tilesets (`[A]Water1_pipo.png`, `[A]Water2_pipo.png`) showed these indices don't contain standalone corner-notch shoreline art — they contain a fragment of an unrelated 2x2 decorative ripple/"island" motif that only looks correct when all four tiles are placed together as a fixed block, never individually.
- Fix: canal mode now resolves these shapes the same way non-canal mode already did, using the confirmed-correct `allSidesNoGrass`/`turnTopRight`/`turnTopLeft`/`turnBottomRight`/`turnBottomLeft` tiles. Removed the now fully-unused `grassCornerBR/BL/TR/TL` constants from `tileIndex.ts`.
- Left the `canal` parameter, `PATH_TILE_LOOKUP`/`CANAL_TILE_LOOKUP` dual exports, and `renderPathTiles`'s `useCanal`/`pathWidth` plumbing intact, since other call sites (e.g. `coast`/`reef` world terrain, the towerdefence `GameGrid.tsx`) still rely on them and were unaffected by the bug.

## Test plan

- [x] `npm run build` — type-checks clean, production build succeeds
- [x] `npm run test` — full suite passes (245/245 tests)
- [ ] Visually verify in `npm run dev`: navigate to a hub town with a pond and confirm clean shoreline borders render at every notch/elbow with no stray ring fragments or gaps


---
_Generated by [Claude Code](https://claude.ai/code/session_0147WLkcYcec33Ltk6dpWzmN)_