### PR TITLE
Fix concave shoreline corners in pond tiles, add tile permutation test harness

### DIFF
--- a/web/src/components/world/TilePermutationGrid.stories.tsx
+++ b/web/src/components/world/TilePermutationGrid.stories.tsx
@@ -1,0 +1,49 @@
+import React from 'react'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { TilePermutationGrid } from './TilePermutationGrid'
+import { PATH_TILE } from '../../data/tiles/tileIndex'
+
+const meta = {
+  component: TilePermutationGrid,
+  parameters: { layout: 'fullscreen' },
+  decorators: [
+    (Story: React.ComponentType) => (
+      <div style={{ overflow: 'auto', width: '100vw', height: '100vh', background: '#0a0a0a' }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof TilePermutationGrid>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+// ── Ponds / canals (wide-path lookup) ─────────────────────────────────────────
+// useCanal:true exercises CANAL_TILE_LOOKUP plus the concave-corner shoreline
+// accent — every missing-diagonal combination of the "fully surrounded by
+// water" mask should now show a shoreline wedge instead of a flat hole.
+
+export const Water1Pond: Story = { name: 'Pond / Water1', args: { tileFile: PATH_TILE.water1, useCanal: true } }
+export const Water2Pond: Story = { name: 'Pond / Water2', args: { tileFile: PATH_TILE.water2, useCanal: true } }
+export const Water3Pond: Story = { name: 'Pond / Water3', args: { tileFile: PATH_TILE.water3, useCanal: true } }
+export const Water4Pond: Story = { name: 'Pond / Water4', args: { tileFile: PATH_TILE.water4, useCanal: true } }
+export const Water5Pond: Story = { name: 'Pond / Water5', args: { tileFile: PATH_TILE.water5, useCanal: true } }
+export const Water6Pond: Story = { name: 'Pond / Water6', args: { tileFile: PATH_TILE.water6, useCanal: true } }
+export const Water7Pond: Story = { name: 'Pond / Water7', args: { tileFile: PATH_TILE.water7, useCanal: true } }
+
+// ── Paths (single-tile-wide lookup, no corner accent) ────────────────────────
+
+export const Dirt1Path: Story        = { name: 'Path / Dirt1',          args: { tileFile: PATH_TILE.dirt1 } }
+export const Dirt4Path: Story        = { name: 'Path / Dirt4',          args: { tileFile: PATH_TILE.dirt4 } }
+export const Dirt1Dirt4Path: Story   = { name: 'Path / Dirt1-Dirt4',    args: { tileFile: PATH_TILE.dirt1Dirt4 } }
+export const Grass1Dirt1Path: Story  = { name: 'Path / Grass1-Dirt1',   args: { tileFile: PATH_TILE.grass1Dirt1 } }
+export const Grass1Dirt2Path: Story  = { name: 'Path / Grass1-Dirt2',   args: { tileFile: PATH_TILE.grass1Dirt2 } }
+export const Grass1Dirt3Path: Story  = { name: 'Path / Grass1-Dirt3',   args: { tileFile: PATH_TILE.grass1Dirt3 } }
+export const Grass1Dirt4Path: Story  = { name: 'Path / Grass1-Dirt4',   args: { tileFile: PATH_TILE.grass1Dirt4 } }
+export const Grass1Grass2Path: Story = { name: 'Path / Grass1-Grass2',  args: { tileFile: PATH_TILE.grass1Grass2 } }
+export const Grass1Grass3Path: Story = { name: 'Path / Grass1-Grass3',  args: { tileFile: PATH_TILE.grass1Grass3 } }
+export const Grass1Grass4Path: Story = { name: 'Path / Grass1-Grass4',  args: { tileFile: PATH_TILE.grass1Grass4 } }
+export const Wall1Path: Story        = { name: 'Path / Wall-Up1',       args: { tileFile: PATH_TILE.wall1 } }
+export const Wall2Path: Story        = { name: 'Path / Wall-Up2',       args: { tileFile: PATH_TILE.wall2 } }
+export const FlowerPath: Story       = { name: 'Path / Flower',         args: { tileFile: PATH_TILE.flower1 } }
+export const LongGrassPath: Story    = { name: 'Path / LongGrass',      args: { tileFile: PATH_TILE.longGrass } }

--- a/web/src/components/world/TilePermutationGrid.tsx
+++ b/web/src/components/world/TilePermutationGrid.tsx
@@ -1,0 +1,120 @@
+import React, { useRef } from 'react'
+import * as PIXI from 'pixi.js'
+import { usePixiApp } from '../../hooks/usePixiApp'
+import { renderPathTiles } from '../../utils/tileLookup'
+import { TILE_SIZE } from '../../data/tiles/tileIndex'
+
+const T = TILE_SIZE
+const STAMP_TILES = 4   // 3×3 neighbor footprint + 1 gap tile between stamps
+const COLS = 8
+
+type Dir = 'N' | 'E' | 'S' | 'W' | 'NE' | 'SE' | 'SW' | 'NW'
+type Scenario = Record<Dir, boolean>
+
+/**
+ * Every canonical 8-neighbor mask buildTileLookup() can ever produce: 16
+ * cardinal combinations × every diagonal combination that's actually reachable
+ * for that combination (a diagonal only varies independently when both of its
+ * adjacent cardinals are present). Always 47 entries — matches the 47 painted
+ * tiles in a `[A]_type3` sheet.
+ */
+function buildAllScenarios(): Scenario[] {
+  const scenarios: Scenario[] = []
+  for (let c = 0; c < 16; c++) {
+    const N = !!(c & 1), E = !!(c & 2), S = !!(c & 4), W = !!(c & 8)
+    const diagSlots: Array<[Dir, boolean]> = [['NE', N && E], ['SE', S && E], ['SW', S && W], ['NW', N && W]]
+    const activeDiags = diagSlots.filter(([, active]) => active).map(([dir]) => dir)
+    for (let d = 0; d < 1 << activeDiags.length; d++) {
+      const s: Scenario = { N, E, S, W, NE: false, SE: false, SW: false, NW: false }
+      activeDiags.forEach((dir, i) => { s[dir] = !!(d & (1 << i)) })
+      scenarios.push(s)
+    }
+  }
+  return scenarios
+}
+
+const SCENARIOS = buildAllScenarios()
+
+const NEIGHBOR_OFFSET: Record<Dir, [number, number]> = {
+  N: [0, -1], S: [0, 1], E: [1, 0], W: [-1, 0],
+  NE: [1, -1], SE: [1, 1], SW: [-1, 1], NW: [-1, -1],
+}
+
+interface Props {
+  /** One of `PATH_TILE.*` — the per-combination 8×6 sheet to exercise. */
+  tileFile: string
+  /** Canal/water mode: wide paths + the concave-corner shoreline accent. */
+  useCanal?: boolean
+  /** CSS pixel scale applied to the whole grid (tiles render at 32px natively). */
+  scale?: number
+}
+
+/**
+ * Renders every reachable 8-neighbor tile shape (isolated, lines, turns,
+ * T-junctions, all-sides, and — in canal mode — every missing-diagonal
+ * combination of the concave shoreline corner) through the real
+ * `renderPathTiles()` so a tileset/lookup-table change can be eyeballed for
+ * regressions across all 47 shapes at once, instead of waiting to encounter
+ * each one in a live map.
+ */
+export function TilePermutationGrid({ tileFile, useCanal, scale = 2 }: Props) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const rows = Math.ceil(SCENARIOS.length / COLS)
+  const width = COLS * STAMP_TILES * T
+  const height = rows * STAMP_TILES * T
+
+  usePixiApp(containerRef, width, height, (app) => {
+    const root = new PIXI.Container()
+    app.stage.addChild(root)
+
+    const bgLayer    = new PIXI.Graphics()
+    const tilesLayer = new PIXI.Container()
+    const labelLayer = new PIXI.Container()
+    root.addChild(bgLayer, tilesLayer, labelLayer)
+
+    const pathSet = new Set<string>()
+    const stamps: Array<{ originX: number; originY: number; cx: number; cy: number; label: string }> = []
+
+    SCENARIOS.forEach((s, i) => {
+      const originX = (i % COLS) * STAMP_TILES
+      const originY = Math.floor(i / COLS) * STAMP_TILES
+      const cx = originX + 1
+      const cy = originY + 1
+      pathSet.add(`${cx},${cy}`)
+      for (const [dir, [dx, dy]] of Object.entries(NEIGHBOR_OFFSET) as Array<[Dir, [number, number]]>) {
+        if (s[dir]) pathSet.add(`${cx + dx},${cy + dy}`)
+      }
+      const label = (Object.keys(NEIGHBOR_OFFSET) as Dir[]).filter(d => s[d]).join(' ') || '(isolated)'
+      stamps.push({ originX, originY, cx, cy, label })
+
+      bgLayer
+        .rect(originX * T, originY * T, 3 * T, 3 * T)
+        .fill({ color: 0x1f3d1f })
+    })
+
+    renderPathTiles(tilesLayer, pathSet, undefined, tileFile, useCanal).then(() => {
+      for (const { originX, originY, label } of stamps) {
+        const text = new PIXI.Text({
+          text: label,
+          style: { fontSize: 9, fill: '#ffe066', fontFamily: 'monospace' },
+        })
+        text.anchor.set(0.5, 0)
+        text.position.set(originX * T + (3 * T) / 2, (originY + 3) * T + 2)
+        labelLayer.addChild(text)
+      }
+    })
+  })
+
+  return (
+    <div
+      ref={containerRef}
+      style={{
+        width: width * scale,
+        height: height * scale,
+        transform: `scale(${scale})`,
+        transformOrigin: 'top left',
+        imageRendering: 'pixelated',
+      }}
+    />
+  )
+}

--- a/web/src/utils/pixiHelpers.ts
+++ b/web/src/utils/pixiHelpers.ts
@@ -83,6 +83,15 @@ export async function loadTileTexture(url: string, tileId: number, columns: numb
 }
 
 /**
+ * Load an arbitrary pixel sub-rectangle from a cached tileset PNG.
+ * Useful for reusing a fragment of an existing tile (e.g. a corner crop) as a decal.
+ */
+export async function loadTileSubRect(url: string, x: number, y: number, w: number, h: number): Promise<PIXI.Texture> {
+  const sheet = await _load(url)
+  return new PIXI.Texture({ source: sheet.source, frame: new PIXI.Rectangle(x, y, w, h) })
+}
+
+/**
  * Load a tile by global tile ID, resolving the correct source file automatically.
  * Supports both legacy baseChip IDs (0–9999) and extended tiles (10000+).
  */

--- a/web/src/utils/tileLookup.ts
+++ b/web/src/utils/tileLookup.ts
@@ -1,6 +1,6 @@
 import * as PIXI from 'pixi.js'
 import { ENV_TILES, PATH, TILE_SIZE, PATH_TILE, EnvTileDef } from '../data/tiles/tileIndex'
-import { loadTileTexture } from './pixiHelpers'
+import { loadTileTexture, loadTileSubRect } from './pixiHelpers'
 
 // ── 8-neighbor tile lookup tables ─────────────────────────────────────────────
 // Normalized 8-bit key: bit0=N, bit1=NE(only if N&&E), bit2=E, bit3=SE(only if S&&E),
@@ -46,6 +46,19 @@ export function buildTileLookup(canal: boolean): number[] {
 export const PATH_TILE_LOOKUP  = buildTileLookup(false)
 export const CANAL_TILE_LOOKUP = buildTileLookup(true)
 
+// ── Concave-corner shoreline accent ───────────────────────────────────────────
+// No tile in the water sheets contains genuine single-diagonal-corner-missing
+// (concave inside-corner) shoreline art — every "fully surrounded by water" mask
+// resolves to the flat PATH.allSidesNoGrass tile regardless of which diagonal
+// neighbors are missing. To avoid a borderless hole at those corners, a small
+// crop of PATH.turnBottomRight's own NW corner (a confirmed-clean shoreline curve)
+// is overlaid, mirrored per missing-diagonal direction, on top of the flat tile.
+type Corner = 'NW' | 'NE' | 'SW' | 'SE'
+const CORNER_ACCENT_SIZE = 14
+const CORNER_FLIP: Record<Corner, [number, number]> = {
+  NW: [1, 1], NE: [-1, 1], SW: [1, -1], SE: [-1, -1],
+}
+
 /**
  * Renders path tiles into `container` for a pre-computed set of tile positions.
  * `pathSet` contains `"tx,ty"` strings; the environment determines tile file and
@@ -65,7 +78,8 @@ export async function renderPathTiles(
   const base = (import.meta as { env: { BASE_URL: string } }).env.BASE_URL
   const tileUrl = `${base}${pathFile.slice(1)}`
   const pathWidth = tileFileOverride ? 1 : (def?.pathWidth ?? 1)
-  const lookup = (useCanal || pathWidth > 1) ? CANAL_TILE_LOOKUP : PATH_TILE_LOOKUP
+  const isCanal = !!useCanal || pathWidth > 1
+  const lookup = isCanal ? CANAL_TILE_LOOKUP : PATH_TILE_LOOKUP
 
   const key = (tx: number, ty: number) => `${tx},${ty}`
   const has = (tx: number, ty: number) => pathSet.has(key(tx, ty))
@@ -84,12 +98,28 @@ export async function renderPathTiles(
     return lookup[mask]
   }
 
+  // Only meaningful when fully surrounded by water — the case currently
+  // collapsed into PATH.allSidesNoGrass regardless of which diagonals are missing.
+  const missingCorners = (tx: number, ty: number): Corner[] => {
+    if (!isCanal) return []
+    const N = has(tx, ty - 1), E = has(tx + 1, ty), S = has(tx, ty + 1), W = has(tx - 1, ty)
+    if (!(N && E && S && W)) return []
+    const out: Corner[] = []
+    if (!has(tx + 1, ty - 1)) out.push('NE')
+    if (!has(tx + 1, ty + 1)) out.push('SE')
+    if (!has(tx - 1, ty + 1)) out.push('SW')
+    if (!has(tx - 1, ty - 1)) out.push('NW')
+    return out
+  }
+
   const byVariant = new Map<number, Array<{ tx: number; ty: number }>>()
+  const accentTiles: Array<{ tx: number; ty: number; corner: Corner }> = []
   for (const k of pathSet) {
     const [tx, ty] = k.split(',').map(Number)
     const v = tileVariant(tx, ty)
     if (!byVariant.has(v)) byVariant.set(v, [])
     byVariant.get(v)!.push({ tx, ty })
+    for (const corner of missingCorners(tx, ty)) accentTiles.push({ tx, ty, corner })
   }
 
   await Promise.all(
@@ -104,4 +134,20 @@ export async function renderPathTiles(
       }
     })
   )
+
+  if (accentTiles.length === 0) return
+  let accentTex: PIXI.Texture
+  try {
+    const cornerX = (PATH.turnBottomRight % 8) * T
+    const cornerY = Math.floor(PATH.turnBottomRight / 8) * T
+    accentTex = await loadTileSubRect(tileUrl, cornerX, cornerY, CORNER_ACCENT_SIZE, CORNER_ACCENT_SIZE)
+  } catch { return }
+  if (container.destroyed) return
+  for (const { tx, ty, corner } of accentTiles) {
+    const s = new PIXI.Sprite(accentTex)
+    const [flipX, flipY] = CORNER_FLIP[corner]
+    s.scale.set(flipX, flipY)
+    s.position.set(tx * T + (flipX < 0 ? T : 0), ty * T + (flipY < 0 ? T : 0))
+    container.addChild(s)
+  }
 }


### PR DESCRIPTION
## Summary

- Follow-up to the merged pond-tile fix (#1795): a new screenshot of Millhaven's "The Harbour" showed that every concave inside-corner — a pond tile surrounded by water on all 4 cardinal sides but missing one diagonal neighbor — rendered as a flat, borderless square. No tile in the water sheets (`[A]Water1_pipo.png`, `[A]Water2_pipo.png`, etc.) contains genuine single-corner-notch shoreline art, so this was a real asset gap rather than a wrong-tile-index bug.
- `web/src/utils/pixiHelpers.ts`: added `loadTileSubRect()`, a small helper to load an arbitrary pixel sub-rectangle from an already-cached tileset PNG (for reusing a fragment of an existing tile as a decal).
- `web/src/utils/tileLookup.ts`: `renderPathTiles()` now does a second pass for canal/wide-path tiles — for every tile that resolves to the full "surrounded on all sides" mask with 1+ missing diagonal, it overlays a small mirrored crop of `PATH.turnBottomRight`'s own NW corner (a confirmed-clean shoreline curve already used correctly for convex turns) onto the flat base tile, oriented per missing corner. `buildTileLookup()` itself is untouched, and the new logic is gated behind the same `isCanal` condition that already selects the canal lookup table, so non-canal (dirt/grass/wall) path rendering is unaffected.
- `web/src/components/world/TilePermutationGrid.tsx` + `.stories.tsx`: new reusable Storybook test harness that renders every reachable 8-neighbor tile shape (all 47 canonical masks, including every missing-diagonal combination) through the real `renderPathTiles()` production function, so future tileset/lookup-table changes can be eyeballed across all shapes at once instead of waiting to encounter each one in a live map. Stories cover all 7 `water*` sheets in pond/canal mode and a representative set of dirt/grass/wall sheets in path mode.

## Test plan

- [x] `npm run build` passes
- [x] Ran Storybook (`npm run storybook`) and visually verified, via headless-browser screenshots of the new stories:
  - Pond/canal stories (`Water1`, `Water2`) show a correct shoreline wedge at every one of the missing-diagonal combinations under the "fully surrounded by water" mask, while the fully-enclosed case (no missing diagonals) still renders the flat tile with no accent.
  - Path/non-canal stories (`Dirt1`, `Grass1-Dirt1`) render normally with no accent artifacts, confirming no regression to existing path rendering.


---
_Generated by [Claude Code](https://claude.ai/code/session_0147WLkcYcec33Ltk6dpWzmN)_