### PR TITLE
Use dedicated tileset art for water corner/T-junction tiles instead of compositing

### DIFF
--- a/web/src/data/tiles/tileIndex.ts
+++ b/web/src/data/tiles/tileIndex.ts
@@ -34,24 +34,48 @@ export const PATH = {
   leftOnly:         3,   // l
   bottomOnly:       4,   // b
   quadBottomRight:  5,   // b + r  (grass top + left)
-  edgeTop:          6,   // l + b + r  (grass border along top edge)
+  edgeTop:          6,   // l + b + r, missing N — both free diagonals (SW,SE) water (smooth)
   quadBottomLeft:   7,   // l + b  (grass top + right)
   turnBottomRight:  8,   // b + r  (road curves)
   turnBottomLeft:   9,   // l + b
-  tJuncLeft:        10,  // b + r + t  (grass left only)
-  tJuncTop:         11,  // l + b + r  (proper T-junction)
+  tJuncLeft:        10,  // t + r + b, missing W — both free diagonals (NE,SE) grass (sharp)
+  tJuncTop:         11,  // l + t + r, missing S — both free diagonals (NW,NE) grass (sharp)
   vertical:         12,  // t + b  (straight)
-  tJuncRight:       13,  // t + r + b  (grass left only... wait: "t,r,b")
+  tJuncRight:       13,  // t + r + b, missing W — both free diagonals (NE,SE) water (smooth)
   allSidesNoGrass:  14,  // all exits, fully filled (no grass corners)
-  tJuncLeft2:       15,  // t + l + b  (grass right only)
+  tJuncLeft2:       15,  // t + l + b, missing E — both free diagonals (NW,SW) water (smooth)
   turnTopRight:     16,  // t + r
   turnTopLeft:      17,  // t + l
-  tJuncBottom:      18,  // l + t + r  (proper T-junction)
-  tJuncRight2:      19,  // l + t + b
+  tJuncBottom:      18,  // l + b + r, missing N — both free diagonals (SW,SE) grass (sharp)
+  tJuncRight2:      19,  // t + l + b, missing E — both free diagonals (NW,SW) grass (sharp)
   topOnly:          20,  // t
   quadTopRight:     21,  // t + r  (grass bottom + left)
-  edgeBottom:       22,  // l + t + r  (grass border along bottom edge)
+  edgeBottom:       22,  // l + t + r, missing S — both free diagonals (NW,NE) water (smooth)
   quadTopLeft:      23,  // l + t  (grass bottom + right)
+  // ── T-junction mixed-diagonal variants — one free diagonal water, the other grass ──
+  missingWGrassSE:  24,  // t + r + b, missing W — NE water, SE grass
+  missingEGrassSW:  25,  // t + l + b, missing E — NW water, SW grass
+  missingNGrassSE:  26,  // l + b + r, missing N — SW water, SE grass
+  missingNGrassSW:  27,  // l + b + r, missing N — SW grass, SE water
+  // ── all-4-cardinal family — exactly one diagonal corner solid (grass) ──
+  allSidesGrassSE:  28,  // all exits, grass only at SE corner
+  allSidesGrassSW:  29,  // all exits, grass only at SW corner
+  allSidesWaterNW:  30,  // all exits, grass at NE+SE+SW (only NW corner still water)
+  allSidesWaterNE:  31,  // all exits, grass at NW+SE+SW (only NE corner still water)
+  missingWGrassNE:  32,  // t + r + b, missing W — NE grass, SE water
+  missingEGrassNW:  33,  // t + l + b, missing E — NW grass, SW water
+  missingSGrassNE:  34,  // l + t + r, missing S — NW water, NE grass
+  missingSGrassNW:  35,  // l + t + r, missing S — NW grass, NE water
+  allSidesGrassNE:  36,  // all exits, grass only at NE corner
+  allSidesGrassNW:  37,  // all exits, grass only at NW corner
+  allSidesWaterSW:  38,  // all exits, grass at NW+NE+SE (only SW corner still water)
+  allSidesWaterSE:  39,  // all exits, grass at NW+NE+SW (only SE corner still water)
+  allSidesGrassN:   40,  // all exits, grass at NW+NE
+  allSidesGrassS:   41,  // all exits, grass at SW+SE
+  allSidesGrassE:   42,  // all exits, grass at NE+SE
+  allSidesGrassW:   43,  // all exits, grass at NW+SW
+  allSidesGrassNESW: 44, // all exits, grass at NE+SW (diagonal)
+  allSidesGrassNWSE: 45, // all exits, grass at NW+SE (diagonal)
   allSides:         46,  // l + r + t + b (with grass corners — use near grass)
 } as const
 

--- a/web/src/utils/pixiHelpers.ts
+++ b/web/src/utils/pixiHelpers.ts
@@ -83,15 +83,6 @@ export async function loadTileTexture(url: string, tileId: number, columns: numb
 }
 
 /**
- * Load an arbitrary pixel sub-rectangle from a cached tileset PNG.
- * Useful for reusing a fragment of an existing tile (e.g. a corner crop) as a decal.
- */
-export async function loadTileSubRect(url: string, x: number, y: number, w: number, h: number): Promise<PIXI.Texture> {
-  const sheet = await _load(url)
-  return new PIXI.Texture({ source: sheet.source, frame: new PIXI.Rectangle(x, y, w, h) })
-}
-
-/**
  * Load a tile by global tile ID, resolving the correct source file automatically.
  * Supports both legacy baseChip IDs (0–9999) and extended tiles (10000+).
  */

--- a/web/src/utils/tileLookup.ts
+++ b/web/src/utils/tileLookup.ts
@@ -1,12 +1,36 @@
 import * as PIXI from 'pixi.js'
 import { ENV_TILES, PATH, TILE_SIZE, PATH_TILE, EnvTileDef } from '../data/tiles/tileIndex'
-import { loadTileTexture, loadTileSubRect } from './pixiHelpers'
+import { loadTileTexture } from './pixiHelpers'
 
 // ── 8-neighbor tile lookup tables ─────────────────────────────────────────────
 // Normalized 8-bit key: bit0=N, bit1=NE(only if N&&E), bit2=E, bit3=SE(only if S&&E),
 //                       bit4=S, bit5=SW(only if S&&W), bit6=W, bit7=NW(only if N&&W)
 // Diagonals bits are pre-zeroed when adjacent cardinals aren't both set, so any
 // combination that reaches here is already canonical. 256 entries → ~47 tile IDs.
+
+// All-4-cardinal family: 16 variants keyed by which diagonal corners are WATER
+// (raw mask bit = 1, i.e. the diagonal neighbor is also in the path/water set),
+// indexed by (NW?1:0)|(NE?2:0)|(SE?4:0)|(SW?8:0). A clear bit means that corner
+// is land/grass poking into an otherwise water-surrounded tile.
+const ALL_SIDES_BY_CORNERS = [
+  PATH.allSides,            // 0000 — no corners water → grass at all 4
+  PATH.allSidesWaterNW,     // 0001 NW water → grass at NE+SE+SW
+  PATH.allSidesWaterNE,     // 0010 NE water → grass at NW+SE+SW
+  PATH.allSidesGrassS,      // 0011 NW+NE water → grass at SW+SE
+  PATH.allSidesWaterSE,     // 0100 SE water → grass at NW+NE+SW
+  PATH.allSidesGrassNESW,   // 0101 NW+SE water (diagonal) → grass at NE+SW
+  PATH.allSidesGrassW,      // 0110 NE+SE water → grass at NW+SW
+  PATH.allSidesGrassSW,     // 0111 NW+NE+SE water → grass at SW only
+  PATH.allSidesWaterSW,     // 1000 SW water → grass at NW+NE+SE
+  PATH.allSidesGrassE,      // 1001 NW+SW water → grass at NE+SE
+  PATH.allSidesGrassNWSE,   // 1010 NE+SW water (diagonal) → grass at NW+SE
+  PATH.allSidesGrassSE,     // 1011 NW+NE+SW water → grass at SE only
+  PATH.allSidesGrassN,      // 1100 SE+SW water → grass at NW+NE
+  PATH.allSidesGrassNE,     // 1101 NW+SE+SW water → grass at NE only
+  PATH.allSidesGrassNW,     // 1110 NE+SE+SW water → grass at NW only
+  PATH.allSidesNoGrass,     // 1111 — all corners water → no grass
+] as const
+
 export function buildTileLookup(canal: boolean): number[] {
   const t = new Array<number>(256)
   for (let mask = 0; mask < 256; mask++) {
@@ -23,11 +47,17 @@ export function buildTileLookup(canal: boolean): number[] {
     // notches/elbows, but those tile indices only contain a fragment of an unrelated
     // 2x2 decorative ring motif rather than real corner-notch art — canal and
     // non-canal now resolve identically for these shapes.
-    if (N && E && S && W)        t[mask] = PATH.allSidesNoGrass
-    else if (N && E && S)      t[mask] = PATH.tJuncRight
-    else if (E && S && W)        t[mask] = PATH.edgeTop
-    else if (N && S && W)        t[mask] = PATH.tJuncLeft2
-    else if (N && E && W)        t[mask] = PATH.edgeBottom
+    if (N && E && S && W) {
+      t[mask] = ALL_SIDES_BY_CORNERS[(NW?1:0) | (NE?2:0) | (SE?4:0) | (SW?8:0)]
+    }
+    else if (N && E && S)        t[mask] = NE ? (SE ? PATH.tJuncRight     : PATH.missingWGrassSE)
+                                               : (SE ? PATH.missingWGrassNE : PATH.tJuncLeft)
+    else if (E && S && W)        t[mask] = SW ? (SE ? PATH.edgeTop        : PATH.missingNGrassSE)
+                                               : (SE ? PATH.missingNGrassSW : PATH.tJuncBottom)
+    else if (N && S && W)        t[mask] = NW ? (SW ? PATH.tJuncLeft2     : PATH.missingEGrassSW)
+                                               : (SW ? PATH.missingEGrassNW : PATH.tJuncRight2)
+    else if (N && E && W)        t[mask] = NW ? (NE ? PATH.edgeBottom     : PATH.missingSGrassNE)
+                                               : (NE ? PATH.missingSGrassNW : PATH.tJuncTop)
     else if (N && S)             t[mask] = PATH.vertical
     else if (E && W)             t[mask] = PATH.horizontal
     else if (N && E)             t[mask] = NE ? PATH.quadTopRight    : PATH.turnTopRight
@@ -45,19 +75,6 @@ export function buildTileLookup(canal: boolean): number[] {
 
 export const PATH_TILE_LOOKUP  = buildTileLookup(false)
 export const CANAL_TILE_LOOKUP = buildTileLookup(true)
-
-// ── Concave-corner shoreline accent ───────────────────────────────────────────
-// No tile in the water sheets contains genuine single-diagonal-corner-missing
-// (concave inside-corner) shoreline art — every "fully surrounded by water" mask
-// resolves to the flat PATH.allSidesNoGrass tile regardless of which diagonal
-// neighbors are missing. To avoid a borderless hole at those corners, a small
-// crop of PATH.turnBottomRight's own NW corner (a confirmed-clean shoreline curve)
-// is overlaid, mirrored per missing-diagonal direction, on top of the flat tile.
-type Corner = 'NW' | 'NE' | 'SW' | 'SE'
-const CORNER_ACCENT_SIZE = 14
-const CORNER_FLIP: Record<Corner, [number, number]> = {
-  NW: [1, 1], NE: [-1, 1], SW: [1, -1], SE: [-1, -1],
-}
 
 /**
  * Renders path tiles into `container` for a pre-computed set of tile positions.
@@ -98,28 +115,12 @@ export async function renderPathTiles(
     return lookup[mask]
   }
 
-  // Only meaningful when fully surrounded by water — the case currently
-  // collapsed into PATH.allSidesNoGrass regardless of which diagonals are missing.
-  const missingCorners = (tx: number, ty: number): Corner[] => {
-    if (!isCanal) return []
-    const N = has(tx, ty - 1), E = has(tx + 1, ty), S = has(tx, ty + 1), W = has(tx - 1, ty)
-    if (!(N && E && S && W)) return []
-    const out: Corner[] = []
-    if (!has(tx + 1, ty - 1)) out.push('NE')
-    if (!has(tx + 1, ty + 1)) out.push('SE')
-    if (!has(tx - 1, ty + 1)) out.push('SW')
-    if (!has(tx - 1, ty - 1)) out.push('NW')
-    return out
-  }
-
   const byVariant = new Map<number, Array<{ tx: number; ty: number }>>()
-  const accentTiles: Array<{ tx: number; ty: number; corner: Corner }> = []
   for (const k of pathSet) {
     const [tx, ty] = k.split(',').map(Number)
     const v = tileVariant(tx, ty)
     if (!byVariant.has(v)) byVariant.set(v, [])
     byVariant.get(v)!.push({ tx, ty })
-    for (const corner of missingCorners(tx, ty)) accentTiles.push({ tx, ty, corner })
   }
 
   await Promise.all(
@@ -134,20 +135,4 @@ export async function renderPathTiles(
       }
     })
   )
-
-  if (accentTiles.length === 0) return
-  let accentTex: PIXI.Texture
-  try {
-    const cornerX = (PATH.turnBottomRight % 8) * T
-    const cornerY = Math.floor(PATH.turnBottomRight / 8) * T
-    accentTex = await loadTileSubRect(tileUrl, cornerX, cornerY, CORNER_ACCENT_SIZE, CORNER_ACCENT_SIZE)
-  } catch { return }
-  if (container.destroyed) return
-  for (const { tx, ty, corner } of accentTiles) {
-    const s = new PIXI.Sprite(accentTex)
-    const [flipX, flipY] = CORNER_FLIP[corner]
-    s.scale.set(flipX, flipY)
-    s.position.set(tx * T + (flipX < 0 ? T : 0), ty * T + (flipY < 0 ? T : 0))
-    container.addChild(s)
-  }
 }


### PR DESCRIPTION
## Summary

PR #1796 fixed a regression at Millhaven's "The Harbour" (tiles fully surrounded by water but with land poking into one diagonal corner rendering as flat, borderless squares) by compositing a small mirrored crop of corner art on top of the flat tile. That fix solved the flat-hole problem but introduced its own visible defect — the composited crop is dominated by solid opaque fill rather than a thin curve, so it pastes as a disconnected, hard-edged patch that doesn't blend with the surrounding shoreline.

This PR replaces that compositing hack with the tileset's **real, dedicated corner art**. The `[A]_type3` water sheets paint a complete 47-tile autotile set, but `buildTileLookup()` only used 31 of them:
- Every diagonal-corner variant of "surrounded by water on all 4 sides" collapsed onto a single flat tile, discarding the diagonal bits entirely.
- T-junction shapes (missing exactly one cardinal direction) ignored their two free diagonal bits and always picked one fixed tile.

Pixel-sampled all 47 tiles on both `[A]Water1_pipo.png` and `[A]Water2_pipo.png` and confirmed a complete, designed 1:1 mapping for every one of the 47 canonical 8-neighbor shapes (15 already-correct simple shapes + 16 all-4-cardinal corner variants + 16 T-junction diagonal variants = 47).

## Changes

- **`web/src/data/tiles/tileIndex.ts`** — add the 22 previously-unused `PATH` tile names (e.g. `allSidesGrassNW`, `missingWGrassSE`), and clarify the existing T-junction comments to match the verified pixel data.
- **`web/src/utils/tileLookup.ts`** — `buildTileLookup()` now selects among the 16 dedicated all-4-cardinal tiles via a new `ALL_SIDES_BY_CORNERS` lookup keyed by the diagonal bits, and the 4 T-junction branches each check their 2 free diagonal bits to pick among 4 tiles instead of 1. Removed the now-unnecessary corner-accent compositing pass from `renderPathTiles()` (the `Corner` type, `CORNER_ACCENT_SIZE`/`CORNER_FLIP` constants, `missingCorners()` helper, and the second render pass).
- **`web/src/utils/pixiHelpers.ts`** — removed `loadTileSubRect()`, which had no remaining callers.

## Test plan

- [x] `npm run build` passes cleanly with no dangling references to the removed compositing code.
- [x] Wrote an exhaustive verification script asserting all 47 canonical 8-neighbor masks resolve to distinct, correct tile IDs against the pixel-sampled ground truth (all 47 IDs 0–46 reachable, no collisions).
- [x] Visually confirmed via the `TilePermutationGrid` Storybook stories (`Water1Pond`, `Water2Pond`) that every one of the 47 reachable tile shapes renders clean, correctly-blended shoreline art — no flat squares, no disconnected patches.
- [x] Spot-checked the non-canal `Dirt1Path` and `Grass1Dirt1Path` stories to confirm no regression on dry-land paths, which share the same lookup table.
- [x] Confirmed `HubTownCanvas.tsx` (used by both the Hub town's Greyfish Pond and Millhaven, via the shared hub world factory) renders ponds through this exact `renderPathTiles(..., PATH_TILE.water1, true)` code path, so the shape-exhaustive Storybook verification covers the live Millhaven Harbour case as well.


---
_Generated by [Claude Code](https://claude.ai/code/session_0147WLkcYcec33Ltk6dpWzmN)_