### PR TITLE
Add Scenery Sortie preview and fix battlefield terrain cluster rendering

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -90,6 +90,7 @@ import { applyGiftRewards, GiftDef } from './game/gifts'
 import { NewsScreen }      from './components/screens/NewsScreen'
 import { NewsAdminScreen } from './components/admin/NewsAdminScreen'
 import { CampaignAdminScreen } from './components/admin/CampaignAdminScreen'
+import { SceneryAdminScreen } from './components/admin/SceneryAdminScreen'
 import { FeedbackModal } from './components/modals/FeedbackModal'
 import { FeedbackAdminScreen } from './components/admin/FeedbackAdminScreen'
 import { DeckSelectorModal } from './components/cards/DeckSelectorModal'
@@ -247,6 +248,7 @@ type Screen =
   | 'casino'
   | 'worldmap'
   | 'location'
+  | 'sceneryPreview'
 
 
 const STANCE_RULES_BY_NODE_TYPE: Partial<Record<string, StanceRules>> = {
@@ -2784,6 +2786,7 @@ export default function App() {
           onFeedbackAdmin={() => setScreen('feedbackAdmin')}
           onHubWorld={() => setScreen('hubworld')}
           onTitleScreen={() => setScreen('title')}
+          onSceneryPreview={() => setScreen('sceneryPreview')}
           onCheckForUpdates={async () => {
             if (needRefresh) {
               updateServiceWorker(true)
@@ -2913,6 +2916,10 @@ export default function App() {
 
       {screen === 'feedbackAdmin' && (
         <FeedbackAdminScreen onBack={() => setScreen('settings')} />
+      )}
+
+      {screen === 'sceneryPreview' && (
+        <SceneryAdminScreen onBack={() => setScreen('settings')} />
       )}
 
       {screen === 'nodemap' && run && actData && (

--- a/web/src/components/admin/DevMenu.stories.tsx
+++ b/web/src/components/admin/DevMenu.stories.tsx
@@ -15,5 +15,6 @@ export const Default: Story = {
   args: {
     onCrystalsChanged: fn(),
     onHandicapChanged: fn(),
+    onSceneryPreview: fn(),
   },
 };

--- a/web/src/components/admin/DevMenu.tsx
+++ b/web/src/components/admin/DevMenu.tsx
@@ -16,6 +16,7 @@ const RUN_KEY      = 'jarv_run'
 interface Props {
   onCrystalsChanged: (n: number) => void
   onHandicapChanged: (n: number) => void
+  onSceneryPreview: () => void
 }
 
 const RARE_EVENT_LABELS: Record<RareEventKind, string> = {
@@ -30,7 +31,7 @@ const RARE_EVENT_LABELS: Record<RareEventKind, string> = {
   confusedTourist: 'Confused Tourist',
 }
 
-export function DevMenu({ onCrystalsChanged, onHandicapChanged }: Props) {
+export function DevMenu({ onCrystalsChanged, onHandicapChanged, onSceneryPreview }: Props) {
   const [config,      setConfig]      = useState(loadDevConfig)
   const [crystalAmt,  setCrystalAmt]  = useState(100)
   const [handicapVal, setHandicapVal] = useState(0)
@@ -205,6 +206,15 @@ export function DevMenu({ onCrystalsChanged, onHandicapChanged }: Props) {
             <option key={id} value={id}>{act.title ?? id}</option>
           ))}
         </select>
+      </div>
+
+      {/* Scenery sortie */}
+      <div className="settings-row u-flex u-items-c u-just-sb u-gap-7">
+        <div>
+          <div className="settings-label">Scenery Sortie</div>
+          <div className="settings-sublabel">Preview battlefield terrain layouts without starting a battle</div>
+        </div>
+        <button className="action-btn" onClick={onSceneryPreview}>OPEN</button>
       </div>
 
       {/* Unlock chronicle chapters */}

--- a/web/src/components/admin/SceneryAdminScreen.tsx
+++ b/web/src/components/admin/SceneryAdminScreen.tsx
@@ -1,0 +1,168 @@
+import React, { useMemo, useState } from 'react'
+import { OverlayScreen } from '../ui/OverlayScreen'
+import { Section } from '../ui/Section'
+import { BattlefieldTerrainCanvas } from '../battle/battlefield/BattlefieldTerrainCanvas'
+import { generateTerrain } from '../../game/engine/terrain'
+import { TERRAIN_AVOID_SHAPE, LANE_WIDTH } from '../../game/types'
+import { ENV_TILES, TILE_SIZE } from '../../data/tiles/tileIndex'
+import { TILE_RADIUS_SCALE } from '../../utils/terrainLayer'
+
+interface Props {
+  onBack: () => void
+}
+
+const ENVIRONMENTS = Object.keys(ENV_TILES)
+
+// Derived from real .lane CSS (--bf-top-buffer/--bf-bottom-buffer) across representative
+// viewport heights — covers the device range where the size-scaling bug actually shows up.
+const HEIGHT_PRESETS = [
+  { label: 'Mobile (~370px)',        value: 370 },
+  { label: 'Tablet / Laptop (~520px)', value: 520 },
+  { label: 'Large Desktop (~840px)', value: 840 },
+]
+
+const LANE_PREVIEW_WIDTH = 360
+
+function randomSeed(): string {
+  return Math.random().toString(36).slice(2, 10)
+}
+
+export function SceneryAdminScreen({ onBack }: Props) {
+  const [environment, setEnvironment] = useState(ENVIRONMENTS[0])
+  const [seed, setSeed] = useState(randomSeed)
+  const [heightPx, setHeightPx] = useState(HEIGHT_PRESETS[1].value)
+  const [showAvoidance, setShowAvoidance] = useState(false)
+
+  const terrain = useMemo(() => generateTerrain(seed, environment), [seed, environment])
+
+  return (
+    <OverlayScreen title="SCENERY SORTIE" subtitle="Dev-only battlefield terrain preview" onBack={onBack} className="settings-screen u-col u-grow">
+      <Section bordered title="CONTROLS">
+        <div className="settings-row u-flex u-items-c u-just-sb u-gap-7">
+          <div className="settings-label">Environment</div>
+          <select className="settings-select" value={environment} onChange={e => setEnvironment(e.target.value)}>
+            {ENVIRONMENTS.map(env => (
+              <option key={env} value={env}>{env}</option>
+            ))}
+          </select>
+        </div>
+
+        <div className="settings-row u-flex u-items-c u-just-sb u-gap-7">
+          <div className="settings-label">Seed</div>
+          <div style={{ display: 'flex', gap: '6px', alignItems: 'center' }}>
+            <input
+              type="text"
+              className="settings-number-input"
+              style={{ width: '120px' }}
+              value={seed}
+              onChange={e => setSeed(e.target.value)}
+            />
+            <button className="action-btn" onClick={() => setSeed(randomSeed())}>REROLL</button>
+          </div>
+        </div>
+
+        <div className="settings-row u-flex u-items-c u-just-sb u-gap-7">
+          <div className="settings-label">Lane height preset</div>
+          <select
+            className="settings-select"
+            value={heightPx}
+            onChange={e => setHeightPx(parseInt(e.target.value, 10))}
+          >
+            {HEIGHT_PRESETS.map(p => (
+              <option key={p.value} value={p.value}>{p.label}</option>
+            ))}
+          </select>
+        </div>
+
+        <div className="settings-row u-flex u-items-c u-just-sb u-gap-7">
+          <div className="settings-label">Show avoidance ellipses</div>
+          <button
+            className={`action-btn${showAvoidance ? ' action-btn--gold' : ''}`}
+            onClick={() => setShowAvoidance(v => !v)}
+          >
+            {showAvoidance ? 'ON' : 'OFF'}
+          </button>
+        </div>
+      </Section>
+
+      <Section bordered title="PREVIEW">
+        <div style={{ display: 'flex', justifyContent: 'center', padding: '12px 0' }}>
+          <div
+            className="lane"
+            style={{
+              position: 'relative', top: 'auto', bottom: 'auto', left: 'auto', right: 'auto',
+              width: LANE_PREVIEW_WIDTH, height: heightPx, flexShrink: 0,
+            }}
+          >
+            <div className="lane-ground" />
+            <BattlefieldTerrainCanvas environment={environment} id={seed} terrain={terrain} />
+            {showAvoidance && terrain.map(obs => {
+              // Avoidance ellipse matching TERRAIN_AVOID_SHAPE used by the engine (Battlefield.tsx).
+              const shape   = TERRAIN_AVOID_SHAPE[obs.type]
+              const ax      = obs.radius * shape.fx + 4
+              const ay      = obs.radius * shape.fy + 4
+              const topPct  = (1 - obs.x / LANE_WIDTH) * 100
+              const leftPct = 50 + (obs.y / 80) * 36
+              const wPct    = ay * 2 * (36 / 80)
+              const hPct    = ax * 2 * (100 / 500)
+              return (
+                <div
+                  key={`dbg-${obs.id}`}
+                  style={{
+                    position: 'absolute',
+                    top: `${topPct}%`,
+                    left: `${leftPct}%`,
+                    width: `${wPct}%`,
+                    height: `${hPct}%`,
+                    transform: 'translate(-50%, -50%)',
+                    borderRadius: '50%',
+                    background: 'rgba(255, 0, 0, 0.25)',
+                    border: '1px solid rgba(255, 80, 80, 0.7)',
+                    pointerEvents: 'none',
+                    zIndex: 50,
+                    boxSizing: 'border-box',
+                  }}
+                  title={`Avoidance ellipse: ax=${ax.toFixed(1)} ay=${ay.toFixed(1)} (${obs.type} r=${obs.radius})`}
+                />
+              )
+            })}
+          </div>
+        </div>
+      </Section>
+
+      <Section bordered title={`OBSTACLES (${terrain.length})`}>
+        {terrain.length === 0 ? (
+          <div className="settings-sublabel">No obstacles generated for this seed.</div>
+        ) : (
+          <table style={{ width: '100%', fontSize: '11px', borderCollapse: 'collapse' }}>
+            <thead>
+              <tr style={{ textAlign: 'left', opacity: 0.6 }}>
+                <th style={{ padding: '4px 6px' }}>id</th>
+                <th style={{ padding: '4px 6px' }}>type</th>
+                <th style={{ padding: '4px 6px' }}>x</th>
+                <th style={{ padding: '4px 6px' }}>y</th>
+                <th style={{ padding: '4px 6px' }}>radius</th>
+                <th style={{ padding: '4px 6px' }}>tileRadius</th>
+              </tr>
+            </thead>
+            <tbody>
+              {terrain.map(obs => {
+                const tileRadius = Math.max(1, Math.round(obs.radius * heightPx / (TILE_RADIUS_SCALE * TILE_SIZE)))
+                return (
+                  <tr key={obs.id} style={{ borderTop: '1px solid rgba(255,255,255,0.07)' }}>
+                    <td style={{ padding: '4px 6px' }}>{obs.id}</td>
+                    <td style={{ padding: '4px 6px' }}>{obs.type}</td>
+                    <td style={{ padding: '4px 6px' }}>{obs.x.toFixed(1)}</td>
+                    <td style={{ padding: '4px 6px' }}>{obs.y.toFixed(1)}</td>
+                    <td style={{ padding: '4px 6px' }}>{obs.radius.toFixed(1)}</td>
+                    <td style={{ padding: '4px 6px' }}>{tileRadius}</td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        )}
+      </Section>
+    </OverlayScreen>
+  )
+}

--- a/web/src/components/battle/battlefield/BattlefieldTerrainCanvas.tsx
+++ b/web/src/components/battle/battlefield/BattlefieldTerrainCanvas.tsx
@@ -78,8 +78,10 @@ export function BattlefieldTerrainCanvas({ environment, id, terrain }: Props) {
       ref={wrapRef}
       style={{ position: 'absolute', inset: 0, overflow: 'hidden', zIndex: 0, pointerEvents: 'none' }}
     >
-      {/* Re-key on size so the Pixi scene remounts and rebuilds at the new dimensions. */}
-      {dims && <TerrainPixi key={`${dims.w}x${dims.h}`} environment={environment} id={id} terrain={terrain} w={dims.w} h={dims.h} />}
+      {/* Re-key on size/environment/id so the Pixi scene remounts and rebuilds — usePixiApp's
+          onReady closure only runs once per mount, so changing terrain/environment/id alone
+          (with the same dimensions) would otherwise silently keep rendering the stale scene. */}
+      {dims && <TerrainPixi key={`${dims.w}x${dims.h}-${environment}-${id}`} environment={environment} id={id} terrain={terrain} w={dims.w} h={dims.h} />}
     </div>
   )
 }

--- a/web/src/components/screens/SettingsScreen.tsx
+++ b/web/src/components/screens/SettingsScreen.tsx
@@ -29,6 +29,7 @@ interface Props {
   onHubWorld?: () => void
   onTitleScreen?: () => void
   onCheckForUpdates?: () => Promise<void>
+  onSceneryPreview?: () => void
 }
 
 const TEXT_SIZE_KEY      = 'jarv_text_size'
@@ -161,7 +162,7 @@ function exportLocalStorage(): void {
   URL.revokeObjectURL(url)
 }
 
-export function SettingsScreen({ onBack, onResetGame, user, authLoading, onDevCrystalsChanged, onDevHandicapChanged, onGiftAdmin, onNewsAdmin, onCampaignAdmin, onFeedbackAdmin, onHubWorld, onTitleScreen, onCheckForUpdates }: Props) {
+export function SettingsScreen({ onBack, onResetGame, user, authLoading, onDevCrystalsChanged, onDevHandicapChanged, onGiftAdmin, onNewsAdmin, onCampaignAdmin, onFeedbackAdmin, onHubWorld, onTitleScreen, onCheckForUpdates, onSceneryPreview }: Props) {
   const [soundOn,       setSoundOn]       = useState(isSoundEnabled)
   const [soundVolume,   setSoundVolumeState]   = useState(getSoundVolume)
   const [musicVolume,   setMusicVolumeState]   = useState(getMusicVolume)
@@ -731,10 +732,11 @@ export function SettingsScreen({ onBack, onResetGame, user, authLoading, onDevCr
           </Section>
         )}
 
-        {isDevMode() && onDevCrystalsChanged && onDevHandicapChanged && (
+        {isDevMode() && onDevCrystalsChanged && onDevHandicapChanged && onSceneryPreview && (
           <DevMenu
             onCrystalsChanged={onDevCrystalsChanged}
             onHandicapChanged={onDevHandicapChanged}
+            onSceneryPreview={onSceneryPreview}
           />
         )}
 

--- a/web/src/utils/terrainLayer.ts
+++ b/web/src/utils/terrainLayer.ts
@@ -7,6 +7,11 @@ import { seededRand, hashStr, getTerrainItems, type TerrainItem } from './mapUti
 import { renderPathTiles } from './tileLookup'
 import type { TerrainObstacle } from '../game/engine/terrain'
 
+// Divisor controlling how obstacle radius (game units) maps to tile-ring radius (tiles).
+// Tuned against the realistic range of obstacle radius (20-32) and lane CSS height (~318-842px)
+// so clusters show real size variety instead of always rounding to a single uniform "plus" shape.
+export const TILE_RADIUS_SCALE = 220
+
 export interface TerrainLayerOptions {
   environment?: string
   envDef?: EnvTileDef
@@ -295,7 +300,7 @@ export async function buildTerrainDecorGfx(
     // SCENERY/PATH tiles fill the ring; center cell is reserved for WORLD_DECOR.
     const patchFile = envPatchMap[obs.type] ?? TERRAIN_PATCH_MAP._default?.[obs.type]
     if (patchFile) {
-      const tileRadius = Math.max(1, Math.round(obs.radius * h / (500 * TILE_SIZE)))
+      const tileRadius = Math.max(1, Math.round(obs.radius * h / (TILE_RADIUS_SCALE * TILE_SIZE)))
       const tcx = Math.round(cx / TILE_SIZE)
       const tcy = Math.round(cy / TILE_SIZE)
       const pathSet = new Set<string>()

--- a/web/src/utils/terrainLayer.ts
+++ b/web/src/utils/terrainLayer.ts
@@ -290,10 +290,28 @@ export async function buildTerrainDecorGfx(
   const envPatchMap = TERRAIN_PATCH_MAP[env] ?? {}
   const envDecorMap = TERRAIN_DECOR_MAP[env] ?? {}
 
+  const toTile = (obs: TerrainObstacle) => ({
+    tcx: Math.round(((0.5 + (obs.y / 80) * 0.36) * w) / TILE_SIZE),
+    tcy: Math.round(((1 - obs.x / 500) * h) / TILE_SIZE),
+  })
+
+  // terrain.ts only guarantees a minimum *game-unit* separation between obstacle
+  // centers, but the canvas projection below doesn't scale 1:1 with tile distance —
+  // so two obstacles' tile-rings can still end up overlapping (more often than not,
+  // across types too — confirmed by brute-force search across seeds). Reserve every
+  // obstacle's center cell up front so a neighboring ring can never swallow its decor
+  // icon, then have each ring claim cells first-come so overlapping rings carve cleanly
+  // around each other (and around centers) instead of later obstacles' tiles
+  // overwriting earlier ones into a single illegible blob.
+  const claimedCells = new Set<string>()
+  for (const obs of terrain) {
+    const { tcx, tcy } = toTile(obs)
+    claimedCells.add(`${tcx},${tcy}`)
+  }
+
   for (const obs of terrain) {
     if (container.destroyed) return
-    const cx = (0.5 + (obs.y / 80) * 0.36) * w
-    const cy = (1 - obs.x / 500) * h
+    const { tcx, tcy } = toTile(obs)
     const idNum = parseInt(obs.id.replace('t', ''), 10)
 
     // ── TYPE3 adjacency-tiled patch (tree / rock / water) ───────────────────
@@ -301,20 +319,16 @@ export async function buildTerrainDecorGfx(
     const patchFile = envPatchMap[obs.type] ?? TERRAIN_PATCH_MAP._default?.[obs.type]
     if (patchFile) {
       const tileRadius = Math.max(1, Math.round(obs.radius * h / (TILE_RADIUS_SCALE * TILE_SIZE)))
-      const tcx = Math.round(cx / TILE_SIZE)
-      const tcy = Math.round(cy / TILE_SIZE)
-      const pathSet = new Set<string>()
+      const ringSet = new Set<string>()
       for (let dr = -tileRadius; dr <= tileRadius; dr++) {
         for (let dc = -tileRadius; dc <= tileRadius; dc++) {
-          if (dr * dr + dc * dc <= tileRadius * tileRadius) {
-            pathSet.add(`${tcx + dc},${tcy + dr}`)
-          }
+          if (dr * dr + dc * dc > tileRadius * tileRadius) continue
+          const key = `${tcx + dc},${tcy + dr}`
+          if (claimedCells.has(key)) continue
+          ringSet.add(key)
         }
       }
-      // Remove center cell so SCENERY/PATH tiles don't occupy it
-      const centerKey = `${tcx},${tcy}`
-      const ringSet = new Set(pathSet)
-      ringSet.delete(centerKey)
+      for (const key of ringSet) claimedCells.add(key)
 
       const patchContainer = new PIXI.Container()
       container.addChild(patchContainer)
@@ -348,7 +362,7 @@ export async function buildTerrainDecorGfx(
       const tex = await loadTileTexture(decorUrl, tileId, 8)
       if (container.destroyed) return
       const s = new PIXI.Sprite(tex)
-      s.position.set(Math.round(cx / TILE_SIZE) * TILE_SIZE, Math.round(cy / TILE_SIZE) * TILE_SIZE)
+      s.position.set(tcx * TILE_SIZE, tcy * TILE_SIZE)
       container.addChild(s)
     }
   }


### PR DESCRIPTION
## Summary

Battlefield obstacles (rocks/trees/water) always rendered as the same uniform 5-tile "plus" shape, and nearby obstacles' independently-rendered tile-rings could overlap into illegible multi-icon blobs (e.g. several overlapping ponds). This adds a dev-only tool to inspect terrain layouts and fixes both rendering bugs.

- **New "Scenery Sortie" dev screen** (`SceneryAdminScreen.tsx`, wired into `DevMenu` → `SettingsScreen` → `App.tsx`): lets you pick an environment, type/reroll a seed, and pick a lane-height preset to preview real battlefield terrain rendering (via the actual production `BattlefieldTerrainCanvas`/`generateTerrain` code path) without starting a battle. Includes an obstacle table and an avoidance-ellipse overlay toggle.
- **Fixed `tileRadius` scaling formula** (`terrainLayer.ts`): the old divisor made `tileRadius` round to `1` for virtually every realistic obstacle radius / lane height, so obstacle size never visibly varied. Tuned divisor now produces real size variety across the supported device range.
- **Fixed overlapping obstacle clusters** (`buildTerrainDecorGfx` in `terrainLayer.ts`): obstacles whose tile-rings would overlap (confirmed via brute-force search to happen for both same-type *and*, more often, cross-type obstacle pairs) now claim tile cells first-come, with every obstacle's center cell reserved up front for its decor icon. Adjacent clusters carve cleanly around each other instead of one obstacle's tiles overwriting another's.
- **Fixed a latent remount bug** in `BattlefieldTerrainCanvas.tsx`: the inner Pixi scene was keyed only on container size, so changing environment/seed/terrain without a size change silently kept rendering the first-render scene. Never visible in production (real battle screens always fully remount), but it blocked the new Sortie tool's reroll/environment-switch from working.

## Test plan

- [x] `npx tsc --noEmit` passes with no errors
- [x] Verified via Playwright screenshots across multiple environments, seeds, and lane-height presets in the new Sortie screen: obstacle cluster sizes now vary (no longer always a uniform plus), and previously-overlapping same-type and cross-type clusters now render as clean, non-overlapping shapes with all decor icons visible
- [x] Started a real Quick Battle and confirmed battlefield terrain renders correctly with no terrain-related console/runtime errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01L9CB12o2r6T5hGq5LeeiMW)_