### PR TITLE
Fix rock/mountain scenery corner-fragment blending

### DIFF
--- a/web/src/utils/terrainLayer.ts
+++ b/web/src/utils/terrainLayer.ts
@@ -248,10 +248,14 @@ async function renderSceneryPatch(
   const tileH = tileW
   for (const key of pathSet) {
     const [c, r] = key.split(',').map(Number)
-    const nw = pathSet.has(`${c - 1},${r - 1}`) ? 8 : 0
-    const ne = pathSet.has(`${c + 1},${r - 1}`) ? 4 : 0
-    const se = pathSet.has(`${c + 1},${r + 1}`) ? 2 : 0
-    const sw = pathSet.has(`${c - 1},${r + 1}`) ? 1 : 0
+    const N = pathSet.has(`${c},${r - 1}`)
+    const E = pathSet.has(`${c + 1},${r}`)
+    const S = pathSet.has(`${c},${r + 1}`)
+    const W = pathSet.has(`${c - 1},${r}`)
+    const nw = (N && W && pathSet.has(`${c - 1},${r - 1}`)) ? 8 : 0
+    const ne = (N && E && pathSet.has(`${c + 1},${r - 1}`)) ? 4 : 0
+    const se = (S && E && pathSet.has(`${c + 1},${r + 1}`)) ? 2 : 0
+    const sw = (S && W && pathSet.has(`${c - 1},${r + 1}`)) ? 1 : 0
     const frame    = SCENERY_LOOKUP[nw | ne | se | sw]
     const frameCol = frame % 8
     const frameRow = Math.floor(frame / 8)


### PR DESCRIPTION
## Summary
- Following up on #1800 (Scenery Sortie + cluster-shape fix), a real-battle screenshot showed two remaining rock/mountain scenery issues: standalone fragment-looking tiles, and rectangular rock/mountain blocks not blending into one cohesive formation.
- Root cause: `renderSceneryPatch` (`web/src/utils/terrainLayer.ts`) picked a `SCENERY_LOOKUP` corner frame whenever a *lone* diagonal neighbor cell was present, without requiring the two adjacent cardinal cells to also be present — so isolated diagonal touches at ring/cluster boundaries rendered standalone fragments with no partner tiles to complete them, and solid blocks picked inconsistent corner frames.
- Fix: require both adjacent cardinal cells before setting a diagonal bit, matching the rule `tileLookup.ts` already uses for water/path tiles and the corner-completion design documented in `tileIndex.ts`'s `SCENERY` comment.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] Verified visually via the dev-only Scenery Sortie tool (`?dev` → Settings → Dev Tools → Scenery Sortie) across volcano/ashen/forest/frost/farmland environments and multiple seeds at the largest lane-height preset — rock/mountain/tree clusters now blend cohesively with no standalone fragments
- [x] Ran a real Quick Battle via Playwright — terrain renders cleanly, no console errors beyond expected offline-network noise

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01L9CB12o2r6T5hGq5LeeiMW)_