### PR TITLE
Add Mira, Vask, and the Pilgrim as hub-town NPCs with a story-recap screen

### DIFF
--- a/web/public/sprites/hub-npc-mira.svg
+++ b/web/public/sprites/hub-npc-mira.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- shadow -->
+  <ellipse cx="16" cy="29" rx="5" ry="2" fill="rgba(0,0,0,0.2)"/>
+  <!-- archivist robe -->
+  <rect x="10" y="13" width="12" height="15" rx="3" fill="#1f3a4a"/>
+  <!-- silver trim -->
+  <rect x="10" y="25" width="12" height="2" fill="#8aa8b8"/>
+  <!-- arms -->
+  <rect x="8"  y="14" width="3" height="8" rx="1" fill="#1f3a4a"/>
+  <rect x="21" y="14" width="3" height="8" rx="1" fill="#1f3a4a"/>
+  <!-- satchel of scrolls -->
+  <rect x="20" y="17" width="4" height="6" rx="1" fill="#8b6040"/>
+  <circle cx="22" cy="17" r="1.4" fill="#c8a070"/>
+  <!-- head -->
+  <circle cx="16" cy="9" r="5" fill="#d4b090"/>
+  <!-- hair tied back -->
+  <path d="M11 8 Q11 3 16 3 Q21 3 21 8 L20 9 L12 9 Z" fill="#5a4632"/>
+  <circle cx="20" cy="11" r="1.6" fill="#5a4632"/>
+  <!-- spectacles -->
+  <rect x="12" y="8" width="3" height="2" rx="1" fill="none" stroke="#cfd8de" stroke-width="0.7"/>
+  <rect x="17" y="8" width="3" height="2" rx="1" fill="none" stroke="#cfd8de" stroke-width="0.7"/>
+  <line x1="15" y1="9" x2="17" y2="9" stroke="#cfd8de" stroke-width="0.7"/>
+  <!-- eyes -->
+  <rect x="13" y="8" width="2" height="2" rx="1" fill="#2a1a0a"/>
+  <rect x="17" y="8" width="2" height="2" rx="1" fill="#2a1a0a"/>
+</svg>

--- a/web/public/sprites/hub-npc-pilgrim.svg
+++ b/web/public/sprites/hub-npc-pilgrim.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- shadow -->
+  <ellipse cx="16" cy="29" rx="5" ry="2" fill="rgba(0,0,0,0.22)"/>
+  <!-- flowing ash-grey robe -->
+  <path d="M9 14 L23 14 L24 28 L8 28 Z" fill="#5a5868"/>
+  <rect x="8" y="26" width="16" height="2" fill="#454254"/>
+  <!-- arms -->
+  <rect x="7"  y="14" width="3" height="9" rx="1" fill="#5a5868"/>
+  <rect x="22" y="14" width="3" height="9" rx="1" fill="#5a5868"/>
+  <!-- spiral-glass staff -->
+  <rect x="23" y="6" width="1.4" height="20" rx="0.6" fill="#3a3840"/>
+  <circle cx="23.7" cy="6" r="2.2" fill="#b8a8e0" opacity="0.85"/>
+  <circle cx="23.7" cy="6" r="1" fill="#e8e0ff"/>
+  <!-- head -->
+  <circle cx="16" cy="9" r="5" fill="#c0b8c8"/>
+  <!-- deep hood -->
+  <path d="M10 9 L16 1 L22 9 L20 10 L12 10 Z" fill="#3a3844"/>
+  <!-- pale seam-glow eyes -->
+  <rect x="13" y="8" width="2" height="2" rx="1" fill="#d8c8ff"/>
+  <rect x="17" y="8" width="2" height="2" rx="1" fill="#d8c8ff"/>
+</svg>

--- a/web/public/sprites/hub-npc-vask.svg
+++ b/web/public/sprites/hub-npc-vask.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- shadow -->
+  <ellipse cx="16" cy="29" rx="5" ry="2" fill="rgba(0,0,0,0.22)"/>
+  <!-- worn legion armor -->
+  <rect x="10" y="13" width="12" height="15" rx="2" fill="#4a4d52"/>
+  <!-- tattered cloak -->
+  <path d="M9 14 L8 28 L11 27 L11 14 Z" fill="#6b2a2a"/>
+  <path d="M23 14 L24 28 L21 27 L21 14 Z" fill="#6b2a2a"/>
+  <!-- worn spiral sigil on chest -->
+  <circle cx="16" cy="19" r="2.4" fill="none" stroke="#9aa0a8" stroke-width="0.8"/>
+  <circle cx="16" cy="19" r="1.1" fill="none" stroke="#9aa0a8" stroke-width="0.6"/>
+  <!-- arms -->
+  <rect x="8"  y="14" width="3" height="8" rx="1" fill="#4a4d52"/>
+  <rect x="21" y="14" width="3" height="8" rx="1" fill="#4a4d52"/>
+  <!-- sheathed sword on back -->
+  <rect x="22.5" y="6" width="2" height="16" rx="1" fill="#7a7d82"/>
+  <rect x="22" y="5" width="3" height="2" rx="0.6" fill="#5a4020"/>
+  <!-- head -->
+  <circle cx="16" cy="9" r="5" fill="#c8a888"/>
+  <!-- cropped hair -->
+  <rect x="11" y="4" width="10" height="4" rx="2" fill="#2a2420"/>
+  <!-- scar -->
+  <line x1="18" y1="6" x2="19" y2="11" stroke="#8a5a50" stroke-width="0.8"/>
+  <!-- eyes -->
+  <rect x="13" y="8" width="2" height="2" rx="1" fill="#1a1410"/>
+  <rect x="17" y="8" width="2" height="2" rx="1" fill="#1a1410"/>
+</svg>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -46,6 +46,7 @@ import { MysteryScreen } from './components/campaign/MysteryScreen'
 import { MemoryFragmentScreen } from './components/campaign/MemoryFragmentScreen'
 import { MemoryFragment, isFragmentDiscovered, markFragmentDiscovered, isHubWorldUnlocked, unlockHubWorld, areAllCampaignFragmentsDiscovered, loadHubDefault, saveHubDefault } from './game/codex'
 import { CharacterEncounterScreen } from './components/campaign/CharacterEncounterScreen'
+import { NarratorJournalScreen } from './components/hub/NarratorJournalScreen'
 import { CharacterChoice, recordCharacterEncounter, getCharacterEncounterChance, resolveCharacterEncounterId } from './game/characters'
 import memoryFragmentsData from './data/memoryFragments.json'
 import { ItemFoundScreen }    from './components/modals/ItemFoundScreen'
@@ -239,6 +240,7 @@ type Screen =
   | 'codex'
   | 'memory'
   | 'characterEncounter'
+  | 'narratorJournal'
   | 'augments'
   | 'player'
   | 'collection-tabs'
@@ -461,6 +463,7 @@ export default function App() {
   const [mysteryReward, setMysteryReward] = useState<RewardDef | null>(null)
   const [activeMemoryFragment, setActiveMemoryFragment] = useState<{ fragment: MemoryFragment; alreadyFound: boolean; shardBonus: boolean } | null>(null)
   const [activeCharacterEncounter, setActiveCharacterEncounter] = useState<{ nodeId: string; characterId: string } | null>(null)
+  const [activeNarratorLog, setActiveNarratorLog] = useState<string | null>(null)
   const [campNode, setCampNode] = useState<QuestNode | null>(null)
   const [campResult, setCampResult] = useState<string | null>(null)
   // Replay briefing state — stored so onBegin can proceed with the correct context
@@ -2823,6 +2826,7 @@ export default function App() {
           onCampaign={() => { setReturnScreen('hubworld'); handleCampaign() }}
           onEndless={() => { setReturnScreen('hubworld'); handleEndless() }}
           onWorldMap={() => setScreen('worldmap')}
+          onNarratorLog={(characterId) => { setReturnScreen('hubworld'); setActiveNarratorLog(characterId); setScreen('narratorJournal') }}
           onPlayerTap={() => { setReturnScreen('hubworld'); setScreen('player') }}
           crystals={crystals}
           user={user}
@@ -3023,6 +3027,13 @@ export default function App() {
         <CharacterEncounterScreen
           characterId={activeCharacterEncounter.characterId}
           onDone={handleCharacterDone}
+        />
+      )}
+
+      {screen === 'narratorJournal' && activeNarratorLog && (
+        <NarratorJournalScreen
+          characterId={activeNarratorLog}
+          onBack={() => setScreen(returnScreen)}
         />
       )}
 

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -117,6 +117,9 @@ const SCREEN_ENTER_LABEL: Record<string, string> = {
   tileflip:          'Play tile flip?',
   crystalcatch:      'Play crystal catch?',
   spinner:           'Give it a spin?',
+  'narrator:mira':    'Ask what she remembers?',
+  'narrator:vask':    'Ask about her past?',
+  'narrator:pilgrim': 'Listen to their words?',
 }
 function screenEnterLabel(screen: string): string {
   return SCREEN_ENTER_LABEL[screen] ?? 'Step inside?'
@@ -143,6 +146,7 @@ export interface Props {
   onEndless?:         () => void
   onWorldMap?:        () => void
   onPlayerTap?:       () => void
+  onNarratorLog?:     (characterId: string) => void
   crystals?:          number
   isSignedIn?:        boolean
   commander?: CommanderState
@@ -160,7 +164,7 @@ export interface Props {
   onTileTap?:         (tx: number, ty: number) => void
 }
 
-export function HubWorld({ onBack, onNavigate, onCampaign, onEndless, onWorldMap, onPlayerTap,
+export function HubWorld({ onBack, onNavigate, onCampaign, onEndless, onWorldMap, onPlayerTap, onNarratorLog,
   locationData, locationQuests, questDefs, allQuestDefs,
   crystals = 0, isSignedIn = false, commander, user, onSignIn: onLoginToggle, onSignOut, onFeedback, onCrystalsChange, onTileTap }: Props) {
   const [splashVisible, setSplashVisible] = useState(() => !_hubSplashShown && !loadSkipIntro())
@@ -489,6 +493,10 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onEndless, onWorldMap
       interiorEnterRef.current?.(buildingId)
       return
     }
+    if (screen.startsWith('narrator:')) {
+      onNarratorLog?.(screen.slice(9))
+      return
+    }
     if (screen === 'town-upgrades') { setUpgradesOpen(true); return }
     if (screen === 'worldmap') { onWorldMap?.(); return }
     if (screen === 'campaign') { onCampaign?.(); return }
@@ -498,7 +506,7 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onEndless, onWorldMap
       return
     }
     onNavigate?.(screen)
-  }, [onNavigate, onCampaign, onWorldMap, commander])
+  }, [onNavigate, onCampaign, onWorldMap, onNarratorLog, commander])
 
   const handleReturn = useCallback(() => {
     returnRef.current?.()

--- a/web/src/components/hub/NarratorJournalScreen.tsx
+++ b/web/src/components/hub/NarratorJournalScreen.tsx
@@ -1,0 +1,43 @@
+import React from 'react'
+import { OverlayScreen } from '../ui/OverlayScreen'
+import { getCharacterDef, getCharacterState, CharacterStage } from '../../game/characters'
+
+interface Props {
+  characterId: string
+  onBack: () => void
+}
+
+export function NarratorJournalScreen({ characterId, onBack }: Props) {
+  const def = getCharacterDef(characterId)
+  if (!def) return null
+
+  const { count } = getCharacterState(characterId)
+  const seenEncounters = def.encounters.slice(0, Math.min(count, def.encounters.length))
+  const epilogueVisits = count - def.encounters.length
+  const seenEpilogue = def.epilogue && epilogueVisits > 0
+    ? def.epilogue.slice(0, Math.min(epilogueVisits, def.epilogue.length))
+    : []
+  const seenStages: CharacterStage[] = [...seenEncounters, ...seenEpilogue]
+
+  return (
+    <OverlayScreen title={def.name} subtitle={def.title} onBack={onBack}>
+      <div className="char-screen u-col u-items-c u-gap-6 u-grow">
+        <span className="char-icon">{def.icon}</span>
+
+        {seenStages.length === 0 ? (
+          <p className="char-para">You haven't crossed paths with {def.name} yet.</p>
+        ) : (
+          <div className="char-body u-col u-gap-4">
+            {seenStages.map((stage, i) => (
+              <div key={i} className="narrator-journal-entry">
+                {stage.greeting.split('\n\n').map((para, j) => (
+                  <p key={j} className="char-para">{para}</p>
+                ))}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </OverlayScreen>
+  )
+}

--- a/web/src/data/hub/capitalcity/config.json
+++ b/web/src/data/hub/capitalcity/config.json
@@ -3716,6 +3716,19 @@
   ],
   "npcs": [
     {
+      "id": "mira-archive",
+      "name": "Mira",
+      "sprite": "hub-npc-mira",
+      "building": "senate-archive",
+      "tx": 6,
+      "ty": 5,
+      "screen": "narrator:mira",
+      "dialogue": [
+        "Every record in this archive is a fragment of something larger. I'm still piecing the rest together.",
+        "You've seen things out there I can only read about. Tell me — does it match what's written here?"
+      ]
+    },
+    {
       "id": "innkeeper-crownhaven",
       "name": "Innkeep Rosalind",
       "sprite": "hub-npc-merchant",

--- a/web/src/data/hub/dreadspirecitadel/config.json
+++ b/web/src/data/hub/dreadspirecitadel/config.json
@@ -492,6 +492,18 @@
   "ambientNpcSprites": [],
   "npcs": [
     {
+      "id": "vask-ward",
+      "name": "Vask",
+      "sprite": "hub-npc-vask",
+      "tx": 24,
+      "ty": 27,
+      "screen": "narrator:vask",
+      "dialogue": [
+        "I served this citadel once. I don't talk about that, usually.",
+        "You keep coming back here. Most people don't, once they've seen the Outer Ward."
+      ]
+    },
+    {
       "id": "the-castellan",
       "name": "The Castellan",
       "sprite": "hub-npc-scholar",

--- a/web/src/data/hub/hollowmere/config.json
+++ b/web/src/data/hub/hollowmere/config.json
@@ -1144,6 +1144,18 @@
   ],
   "npcs": [
     {
+      "id": "pilgrim-darkwood",
+      "name": "The Pilgrim",
+      "sprite": "hub-npc-pilgrim",
+      "tx": 38,
+      "ty": 16,
+      "screen": "narrator:pilgrim",
+      "dialogue": [
+        "The wood listens here. So do I, mostly.",
+        "You've walked through a seam or two yourself, I think. It shows, if you know where to look."
+      ]
+    },
+    {
       "id": "ogrim-the-bouncer",
       "name": "Ogrim the Bouncer",
       "sprite": "hub-npc-soldier",

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -5825,6 +5825,15 @@ body {
   color: #aaddff;
   font-style: italic;
 }
+.narrator-journal-entry {
+  width: 100%;
+  padding-bottom: 16px;
+  border-bottom: 1px solid var(--game-border);
+}
+.narrator-journal-entry:last-child {
+  border-bottom: none;
+  padding-bottom: 0;
+}
 .char-choices { width: 100%; max-width: 420px; }
 .char-choice-btn {
   width: 100%;


### PR DESCRIPTION
## Summary
- Adds Mira, Vask, and the Pilgrim (the campaign narrator characters from #1803) as ordinary tappable NPCs in the hub towns, each placed somewhere thematically matched to their lore:
  - **Mira** — inside the Senate Archive in Capital City (`mira-archive`)
  - **Vask** — in the Outer Ward of Dreadspire Citadel (`vask-ward`)
  - **The Pilgrim** — in the Dark Wood of Hollowmere (`pilgrim-darkwood`)
- Tapping any of them opens a new read-only `NarratorJournalScreen` that shows the full conversation history the player has already unlocked for that character through campaign play, in order — encounters first, then epilogue entries.
- Hub interaction is purely a recap: it never calls `recordCharacterEncounter`, so campaign play remains the only way to advance these characters' stories.
- Adds three new 32×32 sprites (`hub-npc-mira.svg`, `hub-npc-vask.svg`, `hub-npc-pilgrim.svg`) matching the existing hub NPC sprite style.
- Wires a new `narrator:<characterId>` screen-string prefix through `HubWorld`'s existing `handleNodeInteract` routing (mirroring the existing `interior:` prefix pattern) so a character id can be passed without adding entries to the closed `Screen` union.

## Test plan
- [x] `npx tsc --noEmit` — clean, no errors
- [x] `npx vitest run` — all 245 tests pass (one unrelated Playwright browser-teardown warning, not a test failure)
- [x] Validated all three edited `config.json` files parse as valid JSON and that new NPC tile coordinates don't collide with existing NPCs or decor
- [ ] Manual in-browser verification of NPC placement/tap flow was not possible in this sandbox (Firebase auth fails with `auth/invalid-api-key` since no Firebase credentials are configured in this remote environment, and the app has no offline fallback before auth resolves) — would appreciate a manual smoke test of tapping each NPC in Capital City, Dreadspire Citadel, and Hollowmere before merge


---
_Generated by [Claude Code](https://claude.ai/code/session_01FnoccLoCZz7NBwKUE9pQM9)_