### PR TITLE
Hub bounties: bounty-board interactable + modal UI + story

### DIFF
--- a/web/src/components/hub/BountyBoardModal.stories.tsx
+++ b/web/src/components/hub/BountyBoardModal.stories.tsx
@@ -1,0 +1,60 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { BountyBoardModal } from './BountyBoardModal'
+import { getDailyBounties, acceptBounty, turnInBounty } from '../../game/hub/bounties'
+
+const meta = {
+  component: BountyBoardModal,
+  parameters: { layout: 'fullscreen' },
+  decorators: [
+    (Story) => (
+      <div className="game-container">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof BountyBoardModal>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    onClose: () => {},
+  },
+  decorators: [
+    (Story) => {
+      localStorage.removeItem('jarv_hub_bounties')
+      return <Story />
+    },
+  ],
+}
+
+export const WithAcceptedBounty: Story = {
+  args: {
+    onClose: () => {},
+  },
+  decorators: [
+    (Story) => {
+      localStorage.removeItem('jarv_hub_bounties')
+      const [bounty] = getDailyBounties()
+      acceptBounty(bounty.id)
+      return <Story />
+    },
+  ],
+}
+
+export const AllCompleted: Story = {
+  args: {
+    onClose: () => {},
+  },
+  decorators: [
+    (Story) => {
+      localStorage.removeItem('jarv_hub_bounties')
+      for (const bounty of getDailyBounties()) {
+        acceptBounty(bounty.id)
+        turnInBounty(bounty.id)
+      }
+      return <Story />
+    },
+  ],
+}

--- a/web/src/components/hub/BountyBoardModal.tsx
+++ b/web/src/components/hub/BountyBoardModal.tsx
@@ -1,0 +1,81 @@
+import React, { useState } from 'react'
+import { ModalBackdrop } from '../ui/ModalBackdrop'
+import { getDailyBounties, isBountyAccepted, isBountyCompleted, acceptBounty, turnInBounty } from '../../game/hub/bounties'
+
+interface Props {
+  onClose: () => void
+}
+
+export function BountyBoardModal({ onClose }: Props) {
+  const [, setTick] = useState(0)
+  const refresh = () => setTick(t => t + 1)
+
+  const bounties  = getDailyBounties()
+  const available = bounties.filter(b => !isBountyAccepted(b.id) && !isBountyCompleted(b.id))
+  const accepted  = bounties.filter(b => isBountyAccepted(b.id))
+  const completed = bounties.filter(b => isBountyCompleted(b.id))
+
+  return (
+    <ModalBackdrop onClose={onClose}>
+      <div className="bounty-board-modal">
+        <div className="bounty-board-modal__header">
+          <span>📋 Bounty Board</span>
+          <span className="bounty-board-modal__meta">
+            {completed.length} of {bounties.length}
+            <button className="bounty-board-modal__close" onClick={onClose}>✕</button>
+          </span>
+        </div>
+
+        {available.length > 0 && (
+          <>
+            <div className="bounty-board-modal__section-label">Available</div>
+            {available.map(bounty => (
+              <div key={bounty.id} className="bounty-board-modal__card">
+                <div className="bounty-board-modal__title-row">
+                  <span className="bounty-board-modal__title">{bounty.icon} {bounty.title}</span>
+                  <button
+                    className="action-btn"
+                    onClick={() => { acceptBounty(bounty.id); refresh() }}
+                  >Accept</button>
+                </div>
+                <div className="bounty-board-modal__desc">{bounty.desc}</div>
+                <div className="bounty-board-modal__reward">+{bounty.reward.crystals} 💎</div>
+              </div>
+            ))}
+          </>
+        )}
+
+        {accepted.length > 0 && (
+          <>
+            <div className="bounty-board-modal__section-label">Accepted</div>
+            {accepted.map(bounty => (
+              <div key={bounty.id} className="bounty-board-modal__card bounty-board-modal__card--accepted">
+                <div className="bounty-board-modal__title-row">
+                  <span className="bounty-board-modal__title">{bounty.icon} {bounty.title}</span>
+                  <button
+                    className="action-btn action-btn--gold"
+                    onClick={() => { turnInBounty(bounty.id); refresh() }}
+                  >Turn In</button>
+                </div>
+                <div className="bounty-board-modal__desc">{bounty.desc}</div>
+                <div className="bounty-board-modal__reward">+{bounty.reward.crystals} 💎</div>
+              </div>
+            ))}
+          </>
+        )}
+
+        {completed.length > 0 && (
+          <>
+            <div className="bounty-board-modal__section-label">Completed</div>
+            {completed.map(bounty => (
+              <div key={bounty.id} className="bounty-board-modal__card bounty-board-modal__card--completed">
+                <div className="bounty-board-modal__title">✅ {bounty.icon} {bounty.title}</div>
+                <div className="bounty-board-modal__reward">+{bounty.reward.crystals} 💎</div>
+              </div>
+            ))}
+          </>
+        )}
+      </div>
+    </ModalBackdrop>
+  )
+}

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -30,6 +30,8 @@ import { loadPlayerName } from '../../game/questline'
 import { LoginButton } from '../ui/LoginButton'
 import { addCollectible, addConsumable, getCollectibles } from '../../game/itemStore'
 import { QuestsModal } from './QuestsModal'
+import { BountyBoardModal } from './BountyBoardModal'
+import { hasUnclaimedBounties } from '../../game/hub/bounties'
 import { TownDirectory } from './TownDirectory'
 import { TownJournal } from './TownJournal'
 import { HubTownUpgrades, type UpgradeRow } from './HubTownUpgrades'
@@ -175,6 +177,7 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onEndless, onWorldMap
   const [interiorActive, setInteriorActive] = useState(false)
   const [pickedUpIds,    setPickedUpIds]    = useState<Set<string>>(() => getPickedUpIds())
   const [questsOpen,          setQuestsOpen]          = useState(false)
+  const [bountyBoardOpen,     setBountyBoardOpen]     = useState(false)
   const [directoryOpen,       setDirectoryOpen]       = useState(false)
   const [journalOpen,         setJournalOpen]         = useState(false)
   const [upgradesOpen,        setUpgradesOpen]        = useState(false)
@@ -311,6 +314,7 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onEndless, onWorldMap
       .then(n => { indicatorConditionsRef.current.set('unread-news', n > 0) })
       .catch(e => rollbar.error('[HubWorld] getUnreadCount failed', { error: String(e) }))
   }, [])
+  indicatorConditionsRef.current.set('bounty-available', hasUnclaimedBounties())
 
   // Persisted interactable position overrides for this location (id → tile)
   const interactableMovesRef = useRef(new Map<string, { tx: number; ty: number }>())
@@ -498,6 +502,7 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onEndless, onWorldMap
       return
     }
     if (screen === 'town-upgrades') { setUpgradesOpen(true); return }
+    if (screen === 'bounty-board') { setBountyBoardOpen(true); return }
     if (screen === 'worldmap') { onWorldMap?.(); return }
     if (screen === 'campaign') { onCampaign?.(); return }
     if (screen === 'endless') { onEndless?.(); return }
@@ -1148,6 +1153,7 @@ function hasOfferableQuest(giverId: string): boolean {
         )}
 
         {questsOpen && <QuestsModal onClose={() => setQuestsOpen(false)} onAbandon={handleQuestAbandon} questDefs={questDefs} resolveNpcName={getNpcDisplayName}/>}
+        {bountyBoardOpen && <BountyBoardModal onClose={() => setBountyBoardOpen(false)}/>}
         {directoryOpen && <TownDirectory onClose={() => setDirectoryOpen(false)} locationData={locationData} pinnedNpcId={pinnedNpcId} onTogglePin={togglePinnedNpc} onShowRelationship={setRelationshipNpcId} />}
         {journalOpen && <TownJournal onClose={() => setJournalOpen(false)} locationData={locationData} />}
         {upgradesOpen && <HubTownUpgrades onClose={() => setUpgradesOpen(false)} townName={town} reputation={getTownReputation(town)} crystals={loadCrystals()} rows={upgradeRows} onUpgrade={handleUpgrade} tributeAmount={tributeAmount(town)} tributeAvailable={tributeAvailable(town)} onCollectTribute={handleCollectTribute} />}

--- a/web/src/data/hub/ravenwatch/config.json
+++ b/web/src/data/hub/ravenwatch/config.json
@@ -9373,6 +9373,32 @@
       ]
     },
     {
+      "id": "ravenwatch-bounty-board",
+      "tx": 51,
+      "ty": 21,
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "tileId": "wantedPosterTop"
+        },
+        {
+          "dx": 0,
+          "dy": 1,
+          "tileId": "wantedPosterBottom"
+        }
+      ],
+      "indicator": {
+        "condition": "bounty-available"
+      },
+      "reactions": [
+        {
+          "type": "screen",
+          "screen": "bounty-board"
+        }
+      ]
+    },
+    {
       "id": "ravenwatch-church-key",
       "tx": 5,
       "ty": 5,

--- a/web/src/game/hub/bounties.test.ts
+++ b/web/src/game/hub/bounties.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  getDailyBounties,
+  getBountySlotKey,
+  getBountyState,
+  acceptBounty,
+  isBountyAccepted,
+  isBountyCompleted,
+  turnInBounty,
+  hasUnclaimedBounties,
+} from './bounties'
+import { saveCrystals, loadCrystals } from '../collection'
+
+// In-memory localStorage mock (tests run in node environment)
+const store = new Map<string, string>()
+beforeEach(() => {
+  store.clear()
+  globalThis.localStorage = {
+    getItem:    (k: string) => store.get(k) ?? null,
+    setItem:    (k: string, v: string) => { store.set(k, v) },
+    removeItem: (k: string) => { store.delete(k) },
+    clear:      () => { store.clear() },
+    key:        (i: number) => [...store.keys()][i] ?? null,
+    get length() { return store.size },
+  } as Storage
+})
+
+const DAY = new Date('2026-06-30T12:00:00Z')
+
+describe('getDailyBounties', () => {
+  it('is deterministic for a fixed date', () => {
+    expect(getDailyBounties(DAY)).toEqual(getDailyBounties(DAY))
+  })
+
+  it('returns 3 distinct bounties', () => {
+    const bounties = getDailyBounties(DAY)
+    expect(bounties.length).toBe(3)
+    expect(new Set(bounties.map(b => b.id)).size).toBe(3)
+  })
+
+  it('changes with the date', () => {
+    const other = new Date('2026-07-01T12:00:00Z')
+    expect(getBountySlotKey(DAY)).not.toBe(getBountySlotKey(other))
+  })
+})
+
+describe('accept / turn-in flow', () => {
+  it('starts with nothing accepted or completed', () => {
+    const [bounty] = getDailyBounties(DAY)
+    expect(isBountyAccepted(bounty.id)).toBe(false)
+    expect(isBountyCompleted(bounty.id)).toBe(false)
+  })
+
+  it('accepting marks a bounty accepted', () => {
+    const [bounty] = getDailyBounties(DAY)
+    acceptBounty(bounty.id)
+    expect(isBountyAccepted(bounty.id)).toBe(true)
+    expect(getBountyState().accepted).toContain(bounty.id)
+  })
+
+  it('turning in an unaccepted bounty grants nothing', () => {
+    const [bounty] = getDailyBounties(DAY)
+    expect(turnInBounty(bounty.id)).toBe(0)
+    expect(isBountyCompleted(bounty.id)).toBe(false)
+  })
+
+  it('turning in an accepted bounty grants crystals and marks completed', () => {
+    saveCrystals(0)
+    const [bounty] = getDailyBounties(DAY)
+    acceptBounty(bounty.id)
+    const granted = turnInBounty(bounty.id)
+    expect(granted).toBe(bounty.reward.crystals)
+    expect(loadCrystals()).toBe(bounty.reward.crystals)
+    expect(isBountyAccepted(bounty.id)).toBe(false)
+    expect(isBountyCompleted(bounty.id)).toBe(true)
+  })
+
+  it('turning in twice only pays out once', () => {
+    saveCrystals(0)
+    const [bounty] = getDailyBounties(DAY)
+    acceptBounty(bounty.id)
+    turnInBounty(bounty.id)
+    expect(turnInBounty(bounty.id)).toBe(0)
+    expect(loadCrystals()).toBe(bounty.reward.crystals)
+  })
+
+  it('persists accepted state across reloads', () => {
+    const [bounty] = getDailyBounties(DAY)
+    acceptBounty(bounty.id)
+    // A fresh read goes through localStorage again.
+    expect(isBountyAccepted(bounty.id)).toBe(true)
+  })
+})
+
+describe('hasUnclaimedBounties', () => {
+  it('is true when nothing has been accepted or completed', () => {
+    expect(hasUnclaimedBounties(DAY)).toBe(true)
+  })
+
+  it('is false once every bounty is accepted or completed', () => {
+    for (const b of getDailyBounties(DAY)) acceptBounty(b.id)
+    expect(hasUnclaimedBounties(DAY)).toBe(false)
+  })
+})

--- a/web/src/game/hub/bounties.ts
+++ b/web/src/game/hub/bounties.ts
@@ -1,0 +1,136 @@
+// ─── Hub Bounty Board ───────────────────────────────────────────────────────
+//
+// Date-seeded daily bounty rotation + accept/turn-in persistence. Pairs with
+// BountyBoardModal.tsx and the 'bounty-board' interactable screen.
+
+import { saveCrystals, loadCrystals } from '../collection'
+
+const KEY = 'jarv_hub_bounties'
+
+export interface BountyReward {
+  crystals: number
+}
+
+export interface BountyDef {
+  id: string
+  title: string
+  desc: string
+  icon: string
+  reward: BountyReward
+}
+
+const BOUNTY_TEMPLATES: BountyDef[] = [
+  { id: 'clear-the-ratcatchers-debt',  title: "Clear the Ratcatcher's Debt", desc: 'Word is the ratcatcher owes the town a favour. Settle it on his behalf.', icon: '🐀', reward: { crystals: 40 } },
+  { id: 'patrol-the-walls',            title: 'Patrol the Walls',           desc: 'Walk the town walls and report anything out of the ordinary.',          icon: '🛡️', reward: { crystals: 35 } },
+  { id: 'clear-the-old-well',          title: 'Clear the Old Well',         desc: 'The old well has clogged again — someone needs to clear it out.',       icon: '🪣', reward: { crystals: 30 } },
+  { id: 'escort-the-merchant',         title: 'Escort the Merchant',        desc: 'A travelling merchant wants safe passage through town.',                icon: '🧳', reward: { crystals: 50 } },
+  { id: 'quiet-the-crows',             title: 'Quiet the Crows',            desc: "The crows won't stop circling the granary. Scare them off.",            icon: '🐦‍⬛', reward: { crystals: 25 } },
+  { id: 'mend-the-fences',             title: 'Mend the Fences',            desc: 'A few fences on the outskirts could use mending before the storm.',     icon: '🔨', reward: { crystals: 45 } },
+]
+
+const BOUNTIES_PER_DAY = 3
+
+// ── Internal helpers ──────────────────────────────────────────────────────────
+
+/** Simple LCG seeded RNG — deterministic for a given seed. */
+function makeSeededRng(seed: number): () => number {
+  let s = seed >>> 0
+  return () => {
+    s = (Math.imul(s, 1664525) + 1013904223) >>> 0
+    return s / 0x100000000
+  }
+}
+
+/** Numeric hash of a string. */
+function dateHash(str: string): number {
+  let h = 0
+  for (let i = 0; i < str.length; i++) h = (h * 31 + str.charCodeAt(i)) >>> 0
+  return h
+}
+
+/** Returns a key identifying the current day's bounty slot. Format: "YYYY-MM-DD". */
+export function getBountySlotKey(at?: Date): string {
+  return (at ?? new Date()).toISOString().slice(0, 10)
+}
+
+/** Returns today's 3 active bounties, deterministically chosen for the day. */
+export function getDailyBounties(at?: Date): BountyDef[] {
+  const slotKey = getBountySlotKey(at)
+  const rng     = makeSeededRng(dateHash(slotKey) ^ 0xfeedbeef)
+  const pool    = [...BOUNTY_TEMPLATES]
+  const result: BountyDef[] = []
+  const used    = new Set<number>()
+
+  while (result.length < BOUNTIES_PER_DAY && result.length < pool.length) {
+    const idx = Math.floor(rng() * pool.length)
+    if (!used.has(idx)) {
+      used.add(idx)
+      result.push(pool[idx])
+    }
+  }
+  return result
+}
+
+// ── Persisted bounty state ────────────────────────────────────────────────────
+
+export interface BountyState {
+  date: string
+  accepted: string[]
+  completed: string[]
+}
+
+function freshBountyState(): BountyState {
+  return { date: getBountySlotKey(), accepted: [], completed: [] }
+}
+
+export function getBountyState(): BountyState {
+  try {
+    const raw = localStorage.getItem(KEY)
+    if (!raw) return freshBountyState()
+    const parsed = JSON.parse(raw) as BountyState
+    if (parsed.date !== getBountySlotKey()) return freshBountyState()
+    return parsed
+  } catch {
+    return freshBountyState()
+  }
+}
+
+function saveBountyState(state: BountyState): void {
+  try { localStorage.setItem(KEY, JSON.stringify(state)) } catch { /* ignore */ }
+}
+
+export function isBountyAccepted(id: string): boolean {
+  return getBountyState().accepted.includes(id)
+}
+
+export function isBountyCompleted(id: string): boolean {
+  return getBountyState().completed.includes(id)
+}
+
+export function acceptBounty(id: string): void {
+  const state = getBountyState()
+  if (state.accepted.includes(id) || state.completed.includes(id)) return
+  state.accepted.push(id)
+  saveBountyState(state)
+}
+
+/** Turns in an accepted bounty, granting its crystal reward. Returns the crystals granted (0 if not eligible). */
+export function turnInBounty(id: string): number {
+  const state = getBountyState()
+  if (!state.accepted.includes(id) || state.completed.includes(id)) return 0
+  const def = BOUNTY_TEMPLATES.find(b => b.id === id)
+  if (!def) return 0
+
+  state.accepted  = state.accepted.filter(b => b !== id)
+  state.completed.push(id)
+  saveBountyState(state)
+
+  saveCrystals(loadCrystals() + def.reward.crystals)
+  return def.reward.crystals
+}
+
+/** True if today's board has at least one bounty not yet accepted or completed. */
+export function hasUnclaimedBounties(at?: Date): boolean {
+  const state = getBountyState()
+  return getDailyBounties(at).some(b => !state.accepted.includes(b.id) && !state.completed.includes(b.id))
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -15290,6 +15290,66 @@ html.light-mode .action-btn {
 .quests-modal__confirm-btns button:first-child { border-color: #cc5544; color: #cc5544; }
 .quests-modal__confirm-btns button:hover { opacity: 0.8; }
 
+/* ── Bounty Board ─────────────────────────────────────────────────────────── */
+.bounty-board-modal {
+  background: rgba(8, 14, 8, 0.97);
+  border: 1px solid #446644;
+  color: #c8e8c8;
+  padding: 20px;
+  width: min(420px, 92vw);
+  max-height: 80vh;
+  overflow-y: auto;
+  border-radius: 4px;
+  font-family: monospace;
+}
+.bounty-board-modal__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 16px;
+  font-size: 14px;
+  letter-spacing: 0.1em;
+  color: #88cc88;
+  text-transform: uppercase;
+}
+.bounty-board-modal__meta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 10px;
+  color: #557755;
+}
+.bounty-board-modal__close {
+  background: none;
+  border: none;
+  color: #557755;
+  cursor: pointer;
+  font-size: 12px;
+  padding: 0 2px;
+  line-height: 1;
+}
+.bounty-board-modal__close:hover { color: #88cc88; }
+.bounty-board-modal__section-label {
+  font-size: 10px;
+  color: #557755;
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  margin: 12px 0 6px;
+}
+.bounty-board-modal__card {
+  border: 1px solid #2a4a2a;
+  padding: 10px 12px;
+  margin-bottom: 6px;
+  border-radius: 2px;
+}
+.bounty-board-modal__card--accepted  { border-color: #668844; }
+.bounty-board-modal__card--completed { opacity: 0.7; }
+.bounty-board-modal__title { font-size: 12px; font-weight: bold; margin-bottom: 4px; }
+.bounty-board-modal__title-row { display: flex; justify-content: space-between; align-items: center; margin-bottom: 4px; }
+.bounty-board-modal__title-row .bounty-board-modal__title { margin-bottom: 0; }
+.bounty-board-modal__desc   { font-size: 10px; color: #667766; font-style: italic; }
+.bounty-board-modal__reward { font-size: 10px; color: #88cc88; margin-top: 4px; }
+
 /* ── Town Directory ("Where is…?") ─────────────────────────────────────────── */
 .town-directory {
   background: rgba(8, 14, 8, 0.97);


### PR DESCRIPTION
## Summary
- Implements #1678 (bounty-board interactable + modal UI + story), plus the minimal slice of #1676 (date-seeded daily rotation + accept/turn-in persistence) needed to back the UI with real data.
- Adds `web/src/game/hub/bounties.ts`: a `localStorage`-backed store with a small `BOUNTY_TEMPLATES` pool, date-seeded daily rotation (3 bounties/day via a local LCG + string hash, following the `shopSchedule.ts` pattern), and `getDailyBounties`/`acceptBounty`/`turnInBounty`/`isBountyAccepted`/`isBountyCompleted`/`hasUnclaimedBounties` APIs. Turn-in grants crystals via the existing `game/collection.ts` `saveCrystals`/`loadCrystals`.
- Adds `BountyBoardModal.tsx` + `BountyBoardModal.stories.tsx`, mirroring `QuestsModal`'s structure/visual language: Available / Accepted / Completed sections, Accept and Turn In actions, reward display.
- Wires a new `ravenwatch-bounty-board` interactable into `web/src/data/hub/ravenwatch/config.json`, reusing the existing `wantedPosterTop`/`wantedPosterBottom` tiles (no new art) and placed so it doesn't collide with the existing `notice-board` interactable or nearby NPCs.
- `HubWorld.tsx`: opens the modal via the existing `handleNodeInteract('bounty-board')` screen-router pattern, and drives the interactable's notification dot off a new synchronous `bounty-available` indicator condition (no toolbar entry point — access is purely in-world, matching the `notice-board`'s precedent).
- Adds `.bounty-board-modal` styles to `styles.css`, reusing the shared `action-btn`/`action-btn--gold` button classes.

Deliberately out of scope (left for #1680): auto-completing bounties by reusing quest/pickup tracking. v1 ships a simple accept → manual turn-in flow.

## Test plan
- [x] `npm run test` — full suite passes (256 tests); one pre-existing, unrelated "Unhandled Error" from a Storybook browser-mode vitest project (missing `chrome-headless-shell` Playwright artifact) reproduces identically on a clean `main`-based tree without these changes, confirmed via `git stash`/`git stash pop` comparison — not a regression.
- [x] `npm run build` — TypeScript + Vite production build succeeds clean.
- [x] `npm run build-storybook` — succeeds clean; `BountyBoardModal`'s three stories (`Default`, `WithAcceptedBounty`, `AllCompleted`) verified visually via headless-Chromium screenshots, matching `QuestsModal`/`AchievementsModal` look and confirming per-story `localStorage` isolation.
- [ ] Manual `npm run dev` click-through in Ravenwatch (walk to the new interactable, confirm indicator dot + open/close/accept/turn-in flow end-to-end) — not yet performed in this session; static analysis, automated tests, and Storybook visual verification all pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VA9rSaPtUsboasmy2aHw6v)_