### PR TITLE
Hub bounties: progress tracking + turn-in payout

### DIFF
--- a/web/src/components/hub/BountyBoardModal.stories.tsx
+++ b/web/src/components/hub/BountyBoardModal.stories.tsx
@@ -1,6 +1,15 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { BountyBoardModal } from './BountyBoardModal'
-import { getDailyBounties, acceptBounty, turnInBounty } from '../../game/hub/bounties'
+import { getDailyBounties, acceptBounty, turnInBounty, advanceBountyStep, getActiveBountyStep, __setBountyNowOverride } from '../../game/hub/bounties'
+
+/** Drives every step of a bounty to completion via advanceBountyStep. */
+function completeAllSteps(id: string): void {
+  let step = getActiveBountyStep(id)
+  while (step) {
+    advanceBountyStep(id)
+    step = getActiveBountyStep(id)
+  }
+}
 
 const meta = {
   component: BountyBoardModal,
@@ -23,11 +32,16 @@ export const Default: Story = {
   },
   decorators: [
     (Story) => {
+      __setBountyNowOverride(undefined)
       localStorage.removeItem('jarv_hub_bounties')
       return <Story />
     },
   ],
 }
+
+// A fixed date whose daily pool deterministically includes both a single-step
+// 'report' bounty and the multi-step 'fresh-fish-for-the-kitchen' bounty.
+const FISH_DAY = new Date('2026-01-08T12:00:00Z')
 
 export const WithAcceptedBounty: Story = {
   args: {
@@ -35,9 +49,45 @@ export const WithAcceptedBounty: Story = {
   },
   decorators: [
     (Story) => {
+      __setBountyNowOverride(undefined)
       localStorage.removeItem('jarv_hub_bounties')
       const [bounty] = getDailyBounties()
       acceptBounty(bounty.id)
+      // Turn In stays disabled until the bounty's report step is satisfied.
+      return <Story />
+    },
+  ],
+}
+
+export const WithMultiStepBounty: Story = {
+  args: {
+    onClose: () => {},
+  },
+  decorators: [
+    (Story) => {
+      // BountyBoardModal itself calls getDailyBounties() with no date, so "today"
+      // must be pinned to FISH_DAY for the fish bounty to actually render.
+      __setBountyNowOverride(FISH_DAY)
+      localStorage.removeItem('jarv_hub_bounties')
+      const fish = getDailyBounties(FISH_DAY).find(b => b.steps.length > 1)!
+      acceptBounty(fish.id)
+      advanceBountyStep(fish.id) // collect step done, report step still pending
+      return <Story />
+    },
+  ],
+}
+
+export const WithReportedBounty: Story = {
+  args: {
+    onClose: () => {},
+  },
+  decorators: [
+    (Story) => {
+      __setBountyNowOverride(undefined)
+      localStorage.removeItem('jarv_hub_bounties')
+      const [bounty] = getDailyBounties()
+      acceptBounty(bounty.id)
+      completeAllSteps(bounty.id)
       return <Story />
     },
   ],
@@ -49,9 +99,11 @@ export const AllCompleted: Story = {
   },
   decorators: [
     (Story) => {
+      __setBountyNowOverride(undefined)
       localStorage.removeItem('jarv_hub_bounties')
       for (const bounty of getDailyBounties()) {
         acceptBounty(bounty.id)
+        completeAllSteps(bounty.id)
         turnInBounty(bounty.id)
       }
       return <Story />

--- a/web/src/components/hub/BountyBoardModal.tsx
+++ b/web/src/components/hub/BountyBoardModal.tsx
@@ -1,12 +1,24 @@
 import React, { useState } from 'react'
 import { ModalBackdrop } from '../ui/ModalBackdrop'
-import { getDailyBounties, isBountyAccepted, isBountyCompleted, acceptBounty, turnInBounty } from '../../game/hub/bounties'
+import type { BountyDef } from '../../game/hub/bounties'
+import { getDailyBounties, isBountyAccepted, isBountyCompleted, acceptBounty, turnInBounty, getActiveBountyStep } from '../../game/hub/bounties'
 
 interface Props {
   onClose: () => void
+  /** Resolve an NPC/animal id to its display name (for report-step hints). */
+  resolveNpcName?: (id: string) => string
 }
 
-export function BountyBoardModal({ onClose }: Props) {
+/** Human-readable hint for a bounty's current step, or null once fully done. */
+function activeStepHint(bounty: BountyDef, resolveNpcName: (id: string) => string): string | null {
+  const step = getActiveBountyStep(bounty.id)
+  if (!step) return null
+  if (step.type === 'report' && step.targetNpcId) return `Report to ${resolveNpcName(step.targetNpcId)}`
+  if (step.type === 'collect') return 'Find the item out in the world to advance this bounty'
+  return null
+}
+
+export function BountyBoardModal({ onClose, resolveNpcName = (id) => id }: Props) {
   const [, setTick] = useState(0)
   const refresh = () => setTick(t => t + 1)
 
@@ -48,19 +60,24 @@ export function BountyBoardModal({ onClose }: Props) {
         {accepted.length > 0 && (
           <>
             <div className="bounty-board-modal__section-label">Accepted</div>
-            {accepted.map(bounty => (
-              <div key={bounty.id} className="bounty-board-modal__card bounty-board-modal__card--accepted">
-                <div className="bounty-board-modal__title-row">
-                  <span className="bounty-board-modal__title">{bounty.icon} {bounty.title}</span>
-                  <button
-                    className="action-btn action-btn--gold"
-                    onClick={() => { turnInBounty(bounty.id); refresh() }}
-                  >Turn In</button>
+            {accepted.map(bounty => {
+              const hint = activeStepHint(bounty, resolveNpcName)
+              return (
+                <div key={bounty.id} className="bounty-board-modal__card bounty-board-modal__card--accepted">
+                  <div className="bounty-board-modal__title-row">
+                    <span className="bounty-board-modal__title">{bounty.icon} {bounty.title}</span>
+                    <button
+                      className={`action-btn action-btn--gold${hint ? ' action-btn--disabled' : ''}`}
+                      disabled={!!hint}
+                      onClick={() => { turnInBounty(bounty.id); refresh() }}
+                    >Turn In</button>
+                  </div>
+                  <div className="bounty-board-modal__desc">{bounty.desc}</div>
+                  {hint && <div className="bounty-board-modal__hint">{hint}</div>}
+                  <div className="bounty-board-modal__reward">+{bounty.reward.crystals} 💎</div>
                 </div>
-                <div className="bounty-board-modal__desc">{bounty.desc}</div>
-                <div className="bounty-board-modal__reward">+{bounty.reward.crystals} 💎</div>
-              </div>
-            ))}
+              )
+            })}
           </>
         )}
 

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -31,7 +31,7 @@ import { LoginButton } from '../ui/LoginButton'
 import { addCollectible, addConsumable, getCollectibles } from '../../game/itemStore'
 import { QuestsModal } from './QuestsModal'
 import { BountyBoardModal } from './BountyBoardModal'
-import { hasUnclaimedBounties } from '../../game/hub/bounties'
+import { hasUnclaimedBounties, getPendingBountyReport, getPendingBountyCollect, advanceBountyStep, getActiveBountyStep } from '../../game/hub/bounties'
 import { TownDirectory } from './TownDirectory'
 import { TownJournal } from './TownJournal'
 import { HubTownUpgrades, type UpgradeRow } from './HubTownUpgrades'
@@ -560,6 +560,15 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onEndless, onWorldMap
     markPickedUp(id)
     setPickedUpIds(getPickedUpIds())
 
+    const pendingBounty = getPendingBountyCollect(id)
+    if (pendingBounty) {
+      advanceBountyStep(pendingBounty.id)
+      const nextStep = getActiveBountyStep(pendingBounty.id)
+      const hint = nextStep?.targetNpcId ? ` Report back to ${getNpcDisplayName(nextStep.targetNpcId)}.` : ''
+      setDialogueEvent({ speakerName: pendingBounty.title, text: `${pendingBounty.icon} Item collected.${hint}` })
+      refreshState()
+    }
+
     if (!questId) return
 
     // Quests are resolved across ALL towns so a pickup collected in one town can
@@ -807,6 +816,21 @@ function hasOfferableQuest(giverId: string): boolean {
     const speakerName = npcDef?.name ?? ''
     if (namedNpc) recordNpcMet(npcId)
 
+    // ── Bounty report (takes priority — a bounty's report step is satisfied
+    // by talking to the named NPC, independent of any quest dialogue). ──────
+    const pendingBounty = getPendingBountyReport(npcId)
+    if (pendingBounty) {
+      advanceBountyStep(pendingBounty.id)
+      const ready = getActiveBountyStep(pendingBounty.id) === null
+      setDialogueEvent({
+        speakerName,
+        text: ready
+          ? `${pendingBounty.icon} ${pendingBounty.title} — ready to turn in at the bounty board!`
+          : `${pendingBounty.icon} ${pendingBounty.title} — noted.`,
+      })
+      return
+    }
+
     // Cross-town deliveries: scan EVERY town's quests (not just the current one)
     // for an active quest with a pending deliver step addressed to this NPC, or
     // one whose receiver is this NPC and is ready to hand in. This lets a quest
@@ -814,7 +838,7 @@ function hasOfferableQuest(giverId: string): boolean {
     const pendingDelivery = () => {
       for (const q of allQuestDefs) {
         if (getQuestState(q.id).status !== 'active') continue
-        const step = q.steps.find(s => s.type === 'deliver' && s.targetNpcId === npcId && getQuestProgress(q.id, s.key) < s.required)
+        const step = q.steps.find(s => (s.type === 'deliver' || s.type === 'report') && s.targetNpcId === npcId && getQuestProgress(q.id, s.key) < s.required)
         if (step) return { quest: q, step }
       }
       return null
@@ -1153,7 +1177,7 @@ function hasOfferableQuest(giverId: string): boolean {
         )}
 
         {questsOpen && <QuestsModal onClose={() => setQuestsOpen(false)} onAbandon={handleQuestAbandon} questDefs={questDefs} resolveNpcName={getNpcDisplayName}/>}
-        {bountyBoardOpen && <BountyBoardModal onClose={() => setBountyBoardOpen(false)}/>}
+        {bountyBoardOpen && <BountyBoardModal onClose={() => setBountyBoardOpen(false)} resolveNpcName={getNpcDisplayName}/>}
         {directoryOpen && <TownDirectory onClose={() => setDirectoryOpen(false)} locationData={locationData} pinnedNpcId={pinnedNpcId} onTogglePin={togglePinnedNpc} onShowRelationship={setRelationshipNpcId} />}
         {journalOpen && <TownJournal onClose={() => setJournalOpen(false)} locationData={locationData} />}
         {upgradesOpen && <HubTownUpgrades onClose={() => setUpgradesOpen(false)} townName={town} reputation={getTownReputation(town)} crystals={loadCrystals()} rows={upgradeRows} onUpgrade={handleUpgrade} tributeAmount={tributeAmount(town)} tributeAvailable={tributeAvailable(town)} onCollectTribute={handleCollectTribute} />}

--- a/web/src/data/hub/millhaven/questDefs.json
+++ b/web/src/data/hub/millhaven/questDefs.json
@@ -606,6 +606,12 @@
       "questId": "millhaven-missing-catch"
     },
     {
+      "id": "fresh-fish-millhaven",
+      "tx": 25,
+      "ty": 10,
+      "tileId": "mushroomBasket"
+    },
+    {
       "id": "nautical-chart",
       "tx": 12,
       "ty": 9,

--- a/web/src/data/hub/questDefs.ts
+++ b/web/src/data/hub/questDefs.ts
@@ -2,7 +2,7 @@ import type { RelationshipTrack } from '../../game/hub/relationships'
 
 export interface HubQuestStep {
   key: string
-  type: 'collect' | 'deliver'
+  type: 'collect' | 'deliver' | 'report'
   pickupIds?: string[]
   targetNpcId?: string
   required: number
@@ -85,6 +85,7 @@ export type Dialogue = Record<string, string | undefined>
 export type QuestStep =
   | CollectStep
   | DeliverStep
+  | ReportStep
 
 export interface CollectStep {
   key: string
@@ -96,6 +97,16 @@ export interface CollectStep {
 export interface DeliverStep {
   key: string
   type: string // 'deliver'
+  targetNpcId: string
+  required: number
+}
+
+/** Like DeliverStep, but doesn't require holding/consuming a collected item —
+ *  tapping targetNpcId while this step is active just advances it. Used for
+ *  "carry word to someone" objectives with no physical item involved. */
+export interface ReportStep {
+  key: string
+  type: string // 'report'
   targetNpcId: string
   required: number
 }

--- a/web/src/game/hub/bounties.test.ts
+++ b/web/src/game/hub/bounties.test.ts
@@ -8,6 +8,11 @@ import {
   isBountyCompleted,
   turnInBounty,
   hasUnclaimedBounties,
+  advanceBountyStep,
+  getActiveBountyStep,
+  getBountyStepProgress,
+  getPendingBountyReport,
+  getPendingBountyCollect,
 } from './bounties'
 import { saveCrystals, loadCrystals } from '../collection'
 
@@ -26,6 +31,18 @@ beforeEach(() => {
 })
 
 const DAY = new Date('2026-06-30T12:00:00Z')
+// A date whose daily pool deterministically includes both a 'report'-only
+// bounty and the multi-step 'fresh-fish-for-the-kitchen' 'collect' bounty.
+const FISH_DAY = new Date('2026-01-08T12:00:00Z')
+
+/** Drives every step of a bounty to completion via advanceBountyStep. */
+function completeAllSteps(id: string): void {
+  let step = getActiveBountyStep(id)
+  while (step) {
+    advanceBountyStep(id)
+    step = getActiveBountyStep(id)
+  }
+}
 
 describe('getDailyBounties', () => {
   it('is deterministic for a fixed date', () => {
@@ -64,10 +81,18 @@ describe('accept / turn-in flow', () => {
     expect(isBountyCompleted(bounty.id)).toBe(false)
   })
 
-  it('turning in an accepted bounty grants crystals and marks completed', () => {
+  it('turning in an accepted bounty before its steps are done grants nothing', () => {
+    const [bounty] = getDailyBounties(DAY)
+    acceptBounty(bounty.id)
+    expect(turnInBounty(bounty.id)).toBe(0)
+    expect(isBountyCompleted(bounty.id)).toBe(false)
+  })
+
+  it('turning in an accepted, fully-stepped bounty grants crystals and marks completed', () => {
     saveCrystals(0)
     const [bounty] = getDailyBounties(DAY)
     acceptBounty(bounty.id)
+    completeAllSteps(bounty.id)
     const granted = turnInBounty(bounty.id)
     expect(granted).toBe(bounty.reward.crystals)
     expect(loadCrystals()).toBe(bounty.reward.crystals)
@@ -79,6 +104,7 @@ describe('accept / turn-in flow', () => {
     saveCrystals(0)
     const [bounty] = getDailyBounties(DAY)
     acceptBounty(bounty.id)
+    completeAllSteps(bounty.id)
     turnInBounty(bounty.id)
     expect(turnInBounty(bounty.id)).toBe(0)
     expect(loadCrystals()).toBe(bounty.reward.crystals)
@@ -89,6 +115,102 @@ describe('accept / turn-in flow', () => {
     acceptBounty(bounty.id)
     // A fresh read goes through localStorage again.
     expect(isBountyAccepted(bounty.id)).toBe(true)
+  })
+})
+
+describe('bounty step progress', () => {
+  it('every bounty template has at least one step', () => {
+    // All 7 templates rotate through getDailyBounties across many dates;
+    // sample a wide spread of dates to touch every template at least once.
+    const seen = new Set<string>()
+    for (let i = 0; i < 60; i++) {
+      const d = new Date(DAY.getTime() + i * 24 * 60 * 60 * 1000)
+      for (const b of getDailyBounties(d)) {
+        seen.add(b.id)
+        expect(b.steps.length).toBeGreaterThan(0)
+      }
+    }
+    expect(seen.size).toBeGreaterThan(3)
+  })
+
+  it('advanceBountyStep is a no-op when not accepted', () => {
+    const [bounty] = getDailyBounties(DAY)
+    advanceBountyStep(bounty.id)
+    expect(getBountyStepProgress(bounty.id, bounty.steps[0].key)).toBe(0)
+  })
+
+  it('single-step bounty becomes turn-in-ready after one advance', () => {
+    const single = getDailyBounties(DAY).find(b => b.steps.length === 1)
+    if (!single) return
+    acceptBounty(single.id)
+    expect(getActiveBountyStep(single.id)?.key).toBe(single.steps[0].key)
+    advanceBountyStep(single.id)
+    expect(getActiveBountyStep(single.id)).toBeNull()
+    expect(turnInBounty(single.id)).toBe(single.reward.crystals)
+  })
+
+  it('multi-step bounty requires every step before turn-in succeeds', () => {
+    const fish = { id: 'fresh-fish-for-the-kitchen', steps: [{ key: 'collect' }, { key: 'report' }] }
+    acceptBounty(fish.id)
+    expect(turnInBounty(fish.id)).toBe(0)
+    advanceBountyStep(fish.id) // collect
+    expect(getActiveBountyStep(fish.id)?.key).toBe('report')
+    expect(turnInBounty(fish.id)).toBe(0)
+    advanceBountyStep(fish.id) // report
+    expect(getActiveBountyStep(fish.id)).toBeNull()
+    expect(turnInBounty(fish.id)).toBeGreaterThan(0)
+  })
+
+  it('progress persists across reloads', () => {
+    const [bounty] = getDailyBounties(DAY)
+    acceptBounty(bounty.id)
+    advanceBountyStep(bounty.id)
+    const progress = getBountyStepProgress(bounty.id, bounty.steps[0].key)
+    expect(progress).toBeGreaterThan(0)
+    // A fresh read goes through localStorage again.
+    expect(getBountyStepProgress(bounty.id, bounty.steps[0].key)).toBe(progress)
+  })
+})
+
+describe('getPendingBountyReport / getPendingBountyCollect', () => {
+  it('getPendingBountyReport returns null when nothing is accepted', () => {
+    expect(getPendingBountyReport('elder', DAY)).toBeNull()
+  })
+
+  it('getPendingBountyReport returns the bounty once accepted and its report step is active', () => {
+    const reportBounty = getDailyBounties(FISH_DAY).find(b => b.steps[0].type === 'report')!
+    const npcId = reportBounty.steps[0].targetNpcId!
+    acceptBounty(reportBounty.id)
+    expect(getPendingBountyReport(npcId, FISH_DAY)?.id).toBe(reportBounty.id)
+    expect(getPendingBountyReport('someone-else', FISH_DAY)).toBeNull()
+  })
+
+  it('getPendingBountyReport returns null once the step has already been reported', () => {
+    const reportBounty = getDailyBounties(FISH_DAY).find(b => b.steps[0].type === 'report')!
+    const npcId = reportBounty.steps[0].targetNpcId!
+    acceptBounty(reportBounty.id)
+    advanceBountyStep(reportBounty.id)
+    expect(getPendingBountyReport(npcId, FISH_DAY)).toBeNull()
+  })
+
+  it('getPendingBountyCollect returns null when nothing is accepted', () => {
+    expect(getPendingBountyCollect('fresh-fish-millhaven', FISH_DAY)).toBeNull()
+  })
+
+  it('getPendingBountyCollect returns the bounty once accepted and its collect step is active', () => {
+    const collectBounty = getDailyBounties(FISH_DAY).find(b => b.steps[0].type === 'collect')!
+    const pickupId = collectBounty.steps[0].pickupIds![0]
+    acceptBounty(collectBounty.id)
+    expect(getPendingBountyCollect(pickupId, FISH_DAY)?.id).toBe(collectBounty.id)
+    expect(getPendingBountyCollect('not-a-real-pickup', FISH_DAY)).toBeNull()
+  })
+
+  it('getPendingBountyCollect returns null once collected (active step has moved to report)', () => {
+    const collectBounty = getDailyBounties(FISH_DAY).find(b => b.steps[0].type === 'collect')!
+    const pickupId = collectBounty.steps[0].pickupIds![0]
+    acceptBounty(collectBounty.id)
+    advanceBountyStep(collectBounty.id)
+    expect(getPendingBountyCollect(pickupId, FISH_DAY)).toBeNull()
   })
 })
 

--- a/web/src/game/hub/bounties.ts
+++ b/web/src/game/hub/bounties.ts
@@ -105,9 +105,19 @@ function dateHash(str: string): number {
   return h
 }
 
+// Story/test-only override for "now", since callers like BountyBoardModal
+// always call getDailyBounties() with no date and have no override prop.
+let nowOverride: Date | undefined
+
+/** Pins "today" for all unparametrized getDailyBounties()/getBountyState() calls.
+ *  Pass undefined to restore the real clock. Story/test use only. */
+export function __setBountyNowOverride(at: Date | undefined): void {
+  nowOverride = at
+}
+
 /** Returns a key identifying the current day's bounty slot. Format: "YYYY-MM-DD". */
 export function getBountySlotKey(at?: Date): string {
-  return (at ?? new Date()).toISOString().slice(0, 10)
+  return (at ?? nowOverride ?? new Date()).toISOString().slice(0, 10)
 }
 
 /** Returns today's 3 active bounties, deterministically chosen for the day. */

--- a/web/src/game/hub/bounties.ts
+++ b/web/src/game/hub/bounties.ts
@@ -1,9 +1,12 @@
 // ─── Hub Bounty Board ───────────────────────────────────────────────────────
 //
-// Date-seeded daily bounty rotation + accept/turn-in persistence. Pairs with
-// BountyBoardModal.tsx and the 'bounty-board' interactable screen.
+// Date-seeded daily bounty rotation + accept/turn-in persistence. Bounty
+// objectives are sequential `HubQuestStep`s — the same step types the hub
+// quest engine uses — so bounties are effectively quests without a giver.
+// Pairs with BountyBoardModal.tsx and the 'bounty-board' interactable screen.
 
 import { saveCrystals, loadCrystals } from '../collection'
+import type { HubQuestStep } from '../../data/hub/questDefs'
 
 const KEY = 'jarv_hub_bounties'
 
@@ -17,15 +20,69 @@ export interface BountyDef {
   desc: string
   icon: string
   reward: BountyReward
+  steps: HubQuestStep[]
 }
 
 const BOUNTY_TEMPLATES: BountyDef[] = [
-  { id: 'clear-the-ratcatchers-debt',  title: "Clear the Ratcatcher's Debt", desc: 'Word is the ratcatcher owes the town a favour. Settle it on his behalf.', icon: '🐀', reward: { crystals: 40 } },
-  { id: 'patrol-the-walls',            title: 'Patrol the Walls',           desc: 'Walk the town walls and report anything out of the ordinary.',          icon: '🛡️', reward: { crystals: 35 } },
-  { id: 'clear-the-old-well',          title: 'Clear the Old Well',         desc: 'The old well has clogged again — someone needs to clear it out.',       icon: '🪣', reward: { crystals: 30 } },
-  { id: 'escort-the-merchant',         title: 'Escort the Merchant',        desc: 'A travelling merchant wants safe passage through town.',                icon: '🧳', reward: { crystals: 50 } },
-  { id: 'quiet-the-crows',             title: 'Quiet the Crows',            desc: "The crows won't stop circling the granary. Scare them off.",            icon: '🐦‍⬛', reward: { crystals: 25 } },
-  { id: 'mend-the-fences',             title: 'Mend the Fences',            desc: 'A few fences on the outskirts could use mending before the storm.',     icon: '🔨', reward: { crystals: 45 } },
+  {
+    id: 'clear-the-ratcatchers-debt',
+    title: 'Word for the Elder',
+    desc: "Tell the Elder the ratcatcher's debt has been settled.",
+    icon: '🐀',
+    reward: { crystals: 40 },
+    steps: [{ key: 'report', type: 'report', targetNpcId: 'elder', required: 1 }],
+  },
+  {
+    id: 'patrol-the-walls',
+    title: 'Report to the Captain',
+    desc: 'Walk the walls, then report what you saw to Guard Captain Thorin.',
+    icon: '🛡️',
+    reward: { crystals: 35 },
+    steps: [{ key: 'report', type: 'report', targetNpcId: 'guard-captain-thorin', required: 1 }],
+  },
+  {
+    id: 'clear-the-old-well',
+    title: 'News for Old Greyfish',
+    desc: "Let Old Greyfish know the old well's been cleared out.",
+    icon: '🪣',
+    reward: { crystals: 30 },
+    steps: [{ key: 'report', type: 'report', targetNpcId: 'fisherman', required: 1 }],
+  },
+  {
+    id: 'escort-the-merchant',
+    title: 'Word for Vex',
+    desc: 'Tell Vex the merchant the road is safe for his caravan.',
+    icon: '🧳',
+    reward: { crystals: 50 },
+    steps: [{ key: 'report', type: 'report', targetNpcId: 'merchant', required: 1 }],
+  },
+  {
+    id: 'quiet-the-crows',
+    title: 'Tell Rosie',
+    desc: "Let Innkeeper Rosie know the granary's crows have quieted down.",
+    icon: '🐦‍⬛',
+    reward: { crystals: 25 },
+    steps: [{ key: 'report', type: 'report', targetNpcId: 'innkeeper-rosie', required: 1 }],
+  },
+  {
+    id: 'mend-the-fences',
+    title: 'Word for the Trader',
+    desc: 'Pass word to the Junk Trader that the outskirts fences are mended.',
+    icon: '🔨',
+    reward: { crystals: 45 },
+    steps: [{ key: 'report', type: 'report', targetNpcId: 'trader', required: 1 }],
+  },
+  {
+    id: 'fresh-fish-for-the-kitchen',
+    title: 'A Fresh Catch for the Inn',
+    desc: "Innkeeper Rosie wants a fresh fish from Millhaven's docks for tonight's stew. Fetch one and bring it back to her.",
+    icon: '🐟',
+    reward: { crystals: 55 },
+    steps: [
+      { key: 'collect', type: 'collect', pickupIds: ['fresh-fish-millhaven'], required: 1 },
+      { key: 'report',  type: 'report',  targetNpcId: 'innkeeper-rosie',     required: 1 },
+    ],
+  },
 ]
 
 const BOUNTIES_PER_DAY = 3
@@ -77,10 +134,12 @@ export interface BountyState {
   date: string
   accepted: string[]
   completed: string[]
+  /** bountyId -> stepKey -> progress count. */
+  progress: Record<string, Record<string, number>>
 }
 
 function freshBountyState(): BountyState {
-  return { date: getBountySlotKey(), accepted: [], completed: [] }
+  return { date: getBountySlotKey(), accepted: [], completed: [], progress: {} }
 }
 
 export function getBountyState(): BountyState {
@@ -89,6 +148,7 @@ export function getBountyState(): BountyState {
     if (!raw) return freshBountyState()
     const parsed = JSON.parse(raw) as BountyState
     if (parsed.date !== getBountySlotKey()) return freshBountyState()
+    if (!parsed.progress) parsed.progress = {}
     return parsed
   } catch {
     return freshBountyState()
@@ -97,6 +157,10 @@ export function getBountyState(): BountyState {
 
 function saveBountyState(state: BountyState): void {
   try { localStorage.setItem(KEY, JSON.stringify(state)) } catch { /* ignore */ }
+}
+
+function findBountyDef(id: string): BountyDef | undefined {
+  return BOUNTY_TEMPLATES.find(b => b.id === id)
 }
 
 export function isBountyAccepted(id: string): boolean {
@@ -114,11 +178,66 @@ export function acceptBounty(id: string): void {
   saveBountyState(state)
 }
 
-/** Turns in an accepted bounty, granting its crystal reward. Returns the crystals granted (0 if not eligible). */
+/** Progress on a single step of a bounty, 0 if untouched. */
+export function getBountyStepProgress(id: string, stepKey: string): number {
+  return getBountyState().progress[id]?.[stepKey] ?? 0
+}
+
+/** The first not-yet-complete step of a bounty, or null once every step is done. */
+export function getActiveBountyStep(id: string): HubQuestStep | null {
+  const def = findBountyDef(id)
+  if (!def) return null
+  for (const step of def.steps) {
+    if (getBountyStepProgress(id, step.key) < step.required) return step
+  }
+  return null
+}
+
+/** Advances the current active step of an accepted, not-yet-completed bounty.
+ *  No-op if the bounty isn't accepted, is already completed, or has no active step. */
+export function advanceBountyStep(id: string): void {
+  const state = getBountyState()
+  if (!state.accepted.includes(id) || state.completed.includes(id)) return
+  const step = getActiveBountyStep(id)
+  if (!step) return
+
+  const bountyProgress = state.progress[id] ?? {}
+  bountyProgress[step.key] = (bountyProgress[step.key] ?? 0) + 1
+  state.progress[id] = bountyProgress
+  saveBountyState(state)
+}
+
+/** The accepted, in-progress bounty (if any, among today's bounties) whose
+ *  active step is a 'report' addressed to this NPC. */
+export function getPendingBountyReport(npcId: string, at?: Date): BountyDef | null {
+  const state = getBountyState()
+  for (const bounty of getDailyBounties(at)) {
+    if (!state.accepted.includes(bounty.id) || state.completed.includes(bounty.id)) continue
+    const step = getActiveBountyStep(bounty.id)
+    if (step && step.type === 'report' && step.targetNpcId === npcId) return bounty
+  }
+  return null
+}
+
+/** The accepted, in-progress bounty (if any, among today's bounties) whose
+ *  active step is a 'collect' that includes this pickup id. */
+export function getPendingBountyCollect(pickupId: string, at?: Date): BountyDef | null {
+  const state = getBountyState()
+  for (const bounty of getDailyBounties(at)) {
+    if (!state.accepted.includes(bounty.id) || state.completed.includes(bounty.id)) continue
+    const step = getActiveBountyStep(bounty.id)
+    if (step && step.type === 'collect' && step.pickupIds?.includes(pickupId)) return bounty
+  }
+  return null
+}
+
+/** Turns in an accepted bounty whose steps are all complete, granting its
+ *  crystal reward. Returns the crystals granted (0 if not eligible). */
 export function turnInBounty(id: string): number {
   const state = getBountyState()
   if (!state.accepted.includes(id) || state.completed.includes(id)) return 0
-  const def = BOUNTY_TEMPLATES.find(b => b.id === id)
+  if (getActiveBountyStep(id) !== null) return 0
+  const def = findBountyDef(id)
   if (!def) return 0
 
   state.accepted  = state.accepted.filter(b => b !== id)

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -15348,6 +15348,7 @@ html.light-mode .action-btn {
 .bounty-board-modal__title-row { display: flex; justify-content: space-between; align-items: center; margin-bottom: 4px; }
 .bounty-board-modal__title-row .bounty-board-modal__title { margin-bottom: 0; }
 .bounty-board-modal__desc   { font-size: 10px; color: #667766; font-style: italic; }
+.bounty-board-modal__hint   { font-size: 10px; color: #667766; margin-top: 6px; font-style: italic; }
 .bounty-board-modal__reward { font-size: 10px; color: #88cc88; margin-top: 4px; }
 
 /* ── Town Directory ("Where is…?") ─────────────────────────────────────────── */


### PR DESCRIPTION
## Summary

Closes #1680, the final sub-task of #1615 (Hub World epic #1602).

Previously, accepting a bounty in `BountyBoardModal` let you immediately Turn It In for the reward — no gameplay requirement in between. This PR closes that gap:

- Adds a new first-class `report` quest step type to the hub quest engine (`HubQuestStep`/`QuestStep` in `questDefs.ts`), alongside the existing `collect`/`deliver`. A `report` step is satisfied by tapping the named NPC — no item is held or consumed, just "you talked to them." `HubWorld`'s `pendingDelivery()` check is widened to recognize both `deliver` and `report` steps, so this is real, reusable quest infrastructure, not a bounty-only hack.
- Bounties now reuse `HubQuestStep[]` directly as `BountyDef.steps`, making them sequential objectives — effectively quests without a giver. `BountyState` gained a `progress` map (`bountyId -> stepKey -> count`), mirroring the existing quest-progress pattern.
- All 6 existing bounty templates are reworded to literally be "carry word to a named Ravenwatch NPC" objectives (Elder, Guard Captain Thorin, Old Greyfish, Vex the merchant, Innkeeper Rosie, the Junk Trader).
- Adds a 7th, multi-step bounty: **"A Fresh Catch for the Inn"** — collect a fish pickup placed in Millhaven, then report back to Innkeeper Rosie in Ravenwatch, demonstrating a cross-town objective.
- `HubWorld.tsx` wires bounty progress into the existing pickup (`handleItemPickup`) and NPC-tap (`handleNpcTap`) handlers, surfacing a short dialogue line when a step advances.
- `BountyBoardModal` shows a step-aware hint for in-progress bounties and disables Turn In until every step is complete; gating is also enforced server-side in `turnInBounty`.

## Test plan

- [x] `npm run test` — full suite green (268 tests passed); the one pre-existing Storybook-browser-mode "Unhandled Error" (missing Playwright browser binary) is an unrelated, pre-existing environment issue, not a regression.
- [x] `npx tsc --noEmit` — clean.
- [x] `npm run build` — production build succeeds.
- [x] `npm run build-storybook` + headless-Chromium screenshot check of all `BountyBoardModal` stories (`Default`, `WithAcceptedBounty`, `WithMultiStepBounty`, `WithReportedBounty`, `AllCompleted`) — all render correctly, including the multi-step fish bounty's progress hint and the disabled→enabled Turn In transition.
- [x] Manual reasoning trace against the code: single-step bounty (accept → tap wrong NPC is a no-op → tap correct NPC advances the step and shows dialogue → Turn In enabled → crystals granted) and the multi-step fish bounty (accept → collect the Millhaven pickup advances the collect step and shows a "report back to Rosie" hint → tap Innkeeper Rosie in Ravenwatch advances the report step → Turn In enabled → crystals granted).


---
_Generated by [Claude Code](https://claude.ai/code/session_01VA9rSaPtUsboasmy2aHw6v)_