### PR TITLE
Hub: in-world buyable shop items + day/night shopkeeper shifts (#1622)

### DIFF
--- a/web/public/sprites/hub-npc-grix.svg
+++ b/web/public/sprites/hub-npc-grix.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- shadow -->
+  <ellipse cx="16" cy="29" rx="5" ry="1.8" fill="rgba(0,0,0,0.2)"/>
+  <!-- legs -->
+  <rect x="13" y="22" width="2.5" height="6" rx="1" fill="#3a5a2a"/>
+  <rect x="16.5" y="22" width="2.5" height="6" rx="1" fill="#3a5a2a"/>
+  <!-- tunic -->
+  <rect x="11" y="15" width="10" height="9" rx="2" fill="#7a5a2a"/>
+  <rect x="11" y="15" width="10" height="3" rx="1" fill="#5a3a18"/>
+  <!-- arms -->
+  <rect x="9"  y="16" width="2.5" height="6" rx="1" fill="#5a8a3a"/>
+  <rect x="20.5" y="16" width="2.5" height="6" rx="1" fill="#5a8a3a"/>
+  <!-- coin sack in right hand -->
+  <ellipse cx="22.5" cy="20.5" rx="2.5" ry="3" fill="#c8a040"/>
+  <path d="M21 18.3 Q22.5 17 24 18.3" fill="none" stroke="#8a6a20" stroke-width="0.8"/>
+  <!-- head -->
+  <circle cx="16" cy="10" r="5.2" fill="#6a9a3a"/>
+  <!-- ears -->
+  <polygon points="10.5,9 8,7 10,11.5" fill="#6a9a3a"/>
+  <polygon points="21.5,9 24,7 22,11.5" fill="#6a9a3a"/>
+  <!-- eyes -->
+  <rect x="13.2" y="9.2" width="1.8" height="2" rx="0.9" fill="#fff066"/>
+  <rect x="17" y="9.2" width="1.8" height="2" rx="0.9" fill="#fff066"/>
+  <rect x="13.6" y="9.6" width="0.9" height="1.1" rx="0.4" fill="#1a1a0a"/>
+  <rect x="17.4" y="9.6" width="0.9" height="1.1" rx="0.4" fill="#1a1a0a"/>
+  <!-- toothy grin -->
+  <path d="M13 13 Q16 15 19 13" fill="none" stroke="#1a1a0a" stroke-width="0.8"/>
+</svg>

--- a/web/public/sprites/hub-npc-nox.svg
+++ b/web/public/sprites/hub-npc-nox.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- shadow -->
+  <ellipse cx="16" cy="29" rx="5" ry="2" fill="rgba(0,0,0,0.2)"/>
+  <!-- robe -->
+  <rect x="10" y="13" width="12" height="15" rx="3" fill="#1f3a4a"/>
+  <!-- robe trim -->
+  <path d="M16 13 L16 28" stroke="#3f6a82" stroke-width="1"/>
+  <rect x="10" y="24" width="12" height="2" fill="#3f6a82"/>
+  <!-- arms -->
+  <rect x="8"  y="14" width="3" height="8" rx="1" fill="#1f3a4a"/>
+  <rect x="21" y="14" width="3" height="8" rx="1" fill="#1f3a4a"/>
+  <!-- curated augment crystal in right hand -->
+  <polygon points="23.5,15.5 26,18.5 23.5,21.5 21,18.5" fill="#7fd8e8"/>
+  <polygon points="23.5,15.5 26,18.5 23.5,18.5" fill="#bdf0fa" opacity="0.7"/>
+  <!-- head -->
+  <circle cx="16" cy="9" r="5" fill="#cfa787"/>
+  <!-- hood -->
+  <path d="M10.5 8.5 Q16 1.5 21.5 8.5 Q21.5 6 16 5.5 Q10.5 6 10.5 8.5 Z" fill="#162a36"/>
+  <rect x="10" y="6.5" width="12" height="2" rx="1" fill="#162a36"/>
+  <!-- eyes -->
+  <rect x="13" y="8.4" width="2" height="2" rx="1" fill="#0a1a22"/>
+  <rect x="17" y="8.4" width="2" height="2" rx="1" fill="#0a1a22"/>
+  <!-- calm closed-lip expression -->
+  <path d="M13.5 11.5 Q16 12.5 18.5 11.5" fill="none" stroke="#8b5e3c" stroke-width="0.7"/>
+</svg>

--- a/web/public/sprites/hub-npc-vorn.svg
+++ b/web/public/sprites/hub-npc-vorn.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- shadow -->
+  <ellipse cx="16" cy="29" rx="5" ry="2" fill="rgba(0,0,0,0.25)"/>
+  <!-- cloak -->
+  <path d="M9 28 Q9 14 16 12 Q23 14 23 28 Z" fill="#1a1428"/>
+  <!-- cloak inner shading -->
+  <path d="M16 13 L16 27" stroke="#2e2148" stroke-width="1.5"/>
+  <!-- arms -->
+  <rect x="8"  y="15" width="3" height="8" rx="1" fill="#1a1428"/>
+  <rect x="21" y="15" width="3" height="8" rx="1" fill="#1a1428"/>
+  <!-- glowing legendary card in right hand -->
+  <rect x="21.5" y="17" width="4.5" height="6" rx="0.5" fill="#3a2a5a" transform="rotate(10 21.5 17)"/>
+  <rect x="22" y="17.5" width="3.5" height="5" rx="0.5" fill="#ffcf4d" opacity="0.85" transform="rotate(10 22 17.5)"/>
+  <ellipse cx="24" cy="19.5" rx="2.5" ry="2.5" fill="#ffe28a" opacity="0.35"/>
+  <!-- hood -->
+  <path d="M10.5 9 Q16 1 21.5 9 Q21.5 14 16 14 Q10.5 14 10.5 9 Z" fill="#241a38"/>
+  <!-- face shadow -->
+  <ellipse cx="16" cy="10" rx="4" ry="4.2" fill="#0c0814"/>
+  <!-- glowing eyes -->
+  <rect x="13.4" y="9.2" width="1.8" height="1.6" rx="0.8" fill="#9ad8ff"/>
+  <rect x="16.8" y="9.2" width="1.8" height="1.6" rx="0.8" fill="#9ad8ff"/>
+</svg>

--- a/web/src/components/hub/HubDialogue.stories.tsx
+++ b/web/src/components/hub/HubDialogue.stories.tsx
@@ -75,3 +75,31 @@ export const Branching: Story = {
     )
   },
 }
+
+// A shop's "buy" reaction (#1661/#1664): tapping a for-sale item shows the
+// shopkeeper's blurb + price, Buy confirms and sells, Maybe not just closes.
+// Demonstrates both a day shopkeeper (Gildwyn) and his night counterpart
+// (Vorn) — the same purchase flow, different in-character voice.
+function buyStory(speakerName: string, itemName: string, price: number): Story {
+  return {
+    args: { line: `Care to buy ${itemName} for ${price} crystals?`, speakerName, onClose: fn() },
+    render: () => {
+      const [text, setText] = useState<string | null>(`Care to buy ${itemName} for ${price} crystals?`)
+      const [done, setDone] = useState(false)
+      return (
+        <HubDialogue
+          line={text}
+          speakerName={speakerName}
+          onClose={() => setText(null)}
+          choices={done ? undefined : [
+            { label: `Buy for ${price} 💎`, primary: true, onClick: () => { setDone(true); setText(`Sold! Enjoy the ${itemName}.`) } },
+            { label: 'Maybe not', onClick: () => setText(null) },
+          ]}
+        />
+      )
+    },
+  }
+}
+
+export const GildwynShopGreeting: Story = buyStory('Gildwyn', 'Frost Wyrm', 600)
+export const VornShopGreeting: Story = buyStory('Vorn', 'Ashen Sovereign', 1200)

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -15,7 +15,7 @@ import { addRelationshipPoints, getRelationship } from '../../game/hub/relations
 import { setDialogueFlag, hasDialogueFlag, markNodeSeen } from '../../game/hub/dialogueFlags'
 import { getQuestState, setQuestStatus, incrementQuestProgress, getQuestProgress, resetQuest } from '../../game/hub/quests'
 import { getHeardConvoIds, markConvoHeard } from '../../game/hub/innConvos'
-import { loadDeck, loadCollection, loadCrystals, saveCrystals, addCardsToCollection } from '../../game/collection'
+import { loadDeck, loadCollection, loadCrystals, saveCrystals, addCardsToCollection, addAugmentInstance } from '../../game/collection'
 import { getCardCatalog } from '../../game/cards'
 import { CommanderState } from '../../game/commander'
 import { loadSkipIntro } from '../screens/SettingsScreen'
@@ -26,7 +26,7 @@ import { ToolbarButton } from '../ui/Toolbar/ToolbarButton'
 import { ToolbarSpacer } from '../ui/Toolbar/ToolbarSpacer'
 import { ToolbarDropdown } from '../ui/Toolbar/ToolbarDropdown'
 import { User } from 'firebase/auth'
-import { loadPlayerName } from '../../game/questline'
+import { loadPlayerName, addToConsumableStash } from '../../game/questline'
 import { LoginButton } from '../ui/LoginButton'
 import { addCollectible, addConsumable, getCollectibles } from '../../game/itemStore'
 import { QuestsModal } from './QuestsModal'
@@ -49,6 +49,8 @@ import { HubInteractable, HubLocationBundle, HubQuestBundle, HubTreasure } from 
 import { getUnreadCount } from '../../game/news'
 import { interactableStoreKey, isInteractableGranted, markInteractableGranted, getInteractableMoves, setInteractableMove } from '../../game/hub/interactables'
 import { recordNpcMet, recordAnimalSeen, recordAreaSeen } from '../../game/hub/journal'
+import { getTodaysShopItems, ShopBuildingId } from '../../game/hub/shopStock'
+import { hasBoughtToday, markBoughtToday } from '../../game/hub/shopPurchases'
 import rollbar from '../../rollbar'
 interface QuestEvent {
   speakerName: string
@@ -1069,6 +1071,47 @@ function hasOfferableQuest(giverId: string): boolean {
         moveInteractableRef.current?.(def.id, r.to.tx, r.to.ty)
         if (r.message) setDialogueEvent({ speakerName: '', text: r.message, onClose: next })
         else next()
+        return
+      }
+      case 'buy': {
+        const buildingId = def.building as ShopBuildingId | undefined
+        const item = buildingId ? getTodaysShopItems(buildingId)[r.slotIndex] : undefined
+        if (!buildingId || !item) { next(); return }
+
+        const candidates = locationData.HUB_NPCS.filter(n => n.building === buildingId)
+        const onDuty = candidates.find(n => resolveNpcPlace(n, gameHour, locationData).interiorId === buildingId)
+        const speakerName = (onDuty ?? candidates[0])?.name ?? ''
+
+        const slotId = `${buildingId}-item-${r.slotIndex}`
+        if (hasBoughtToday(slotId)) {
+          setDialogueEvent({ speakerName, text: 'Sold already, friend — check back next time the stock turns over.', onClose: next })
+          return
+        }
+
+        const confirm: DialogueChoice = {
+          label: `Buy for ${item.price} 💎`,
+          primary: true,
+          onClick: () => {
+            const balance = loadCrystals()
+            if (balance < item.price) {
+              setDialogueEvent({ speakerName, text: "That's more than you're carrying — come back when you've got the crystals." })
+              return
+            }
+            saveCrystals(balance - item.price)
+            onCrystalsChange?.(balance - item.price)
+            switch (item.grant.kind) {
+              case 'card':       addCardsToCollection([{ cardName: item.grant.cardName, count: 1 }]); break
+              case 'augment':    addAugmentInstance(item.grant.augmentName); break
+              case 'consumable': addToConsumableStash(item.grant.id); break
+            }
+            markBoughtToday(slotId)
+            emitSound('shopPurchase')
+            refreshState()
+            setDialogueEvent({ speakerName, text: `Sold! Enjoy the ${item.itemName}.`, onClose: next })
+          },
+        }
+        const cancel: DialogueChoice = { label: 'Maybe not', onClick: () => setDialogueEvent(null) }
+        setDialogueEvent({ speakerName, text: `Care to buy ${item.itemName} for ${item.price} crystals?`, choices: [confirm, cancel] })
         return
       }
     }

--- a/web/src/data/hub/config.ts
+++ b/web/src/data/hub/config.ts
@@ -242,7 +242,7 @@ export interface RawInteractableDecor {
 }
 
 export interface RawInteractableReaction {
-  // 'dialogue' | 'screen' | 'giveItem' | 'quest' | 'move' — plain string so
+  // 'dialogue' | 'screen' | 'giveItem' | 'quest' | 'move' | 'buy' — plain string so
   // JSON imports don't widen-fail; loader.ts casts to the parsed union
   type: string
 
@@ -273,6 +273,9 @@ export interface RawInteractableReaction {
 
   // move
   to?: RawCoordinate
+
+  // buy — slotIndex into the building's live getTodaysShopItems() stock
+  slotIndex?: number
 }
 
 export interface RawInteractable {

--- a/web/src/data/hub/loader.ts
+++ b/web/src/data/hub/loader.ts
@@ -261,6 +261,7 @@ export type HubInteractableReaction =
       alreadyGrantedText?: string }
   | { type: 'quest'; questId: string; speakerName?: string }
   | { type: 'move'; to: HubCoordinate; message?: string }
+  | { type: 'buy'; slotIndex: number }
 
 export interface HubInteractable {
   id: string

--- a/web/src/data/hub/ravenwatch/config.json
+++ b/web/src/data/hub/ravenwatch/config.json
@@ -8557,7 +8557,31 @@
         "Every card tells a story, wanderer."
       ],
       "questGive": "gildwyns-missing-card",
-      "questReceive": "gildwyn-the-fracture-card"
+      "questReceive": "gildwyn-the-fracture-card",
+      "schedule": [
+        { "startHour": 6, "endHour": 20, "activity": "work", "location": { "type": "interior", "buildingId": "card-shop", "tx": 6, "ty": 3 } },
+        { "startHour": 20, "endHour": 6, "activity": "sleep", "location": { "type": "interior", "buildingId": "inn-building-upstairs", "tx": 1, "ty": 1 } }
+      ],
+      "homeBed": { "buildingId": "inn-building-upstairs", "tx": 1, "ty": 1 }
+    },
+    {
+      "id": "vorn",
+      "name": "Vorn",
+      "sprite": "hub-npc-vorn",
+      "building": "card-shop",
+      "tx": 6,
+      "ty": 3,
+      "screen": "shop-cards",
+      "dialogue": [
+        "I only come out at night. And I only deal in the extraordinary.",
+        "The shadows are patient with rare cards — they wait for the right buyer.",
+        "Gildwyn keeps the day trade. I keep the legends."
+      ],
+      "schedule": [
+        { "startHour": 20, "endHour": 6, "activity": "work", "location": { "type": "interior", "buildingId": "card-shop", "tx": 6, "ty": 3 } },
+        { "startHour": 6, "endHour": 20, "activity": "sleep", "location": { "type": "interior", "buildingId": "inn-building-upstairs", "tx": 6, "ty": 1 } }
+      ],
+      "homeBed": { "buildingId": "inn-building-upstairs", "tx": 6, "ty": 1 }
     },
     {
       "id": "mira",
@@ -8573,7 +8597,31 @@
         "I sense great potential in you, wanderer. Let's refine it."
       ],
       "questGive": "miras-runaway-crystal",
-      "questReceive": "vex-final-trade"
+      "questReceive": "vex-final-trade",
+      "schedule": [
+        { "startHour": 6, "endHour": 20, "activity": "work", "location": { "type": "interior", "buildingId": "augment-shop", "tx": 3, "ty": 1 } },
+        { "startHour": 20, "endHour": 6, "activity": "sleep", "location": { "type": "interior", "buildingId": "inn-building-upstairs", "tx": 3, "ty": 1 } }
+      ],
+      "homeBed": { "buildingId": "inn-building-upstairs", "tx": 3, "ty": 1 }
+    },
+    {
+      "id": "nox",
+      "name": "Nox",
+      "sprite": "hub-npc-nox",
+      "building": "augment-shop",
+      "tx": 3,
+      "ty": 1,
+      "screen": "shop-augments",
+      "dialogue": [
+        "The serious collectors shop at night. Good to see you.",
+        "A night owl's selection — curated, not cluttered.",
+        "Mira keeps the daylight trade. I keep the connoisseurs."
+      ],
+      "schedule": [
+        { "startHour": 20, "endHour": 6, "activity": "work", "location": { "type": "interior", "buildingId": "augment-shop", "tx": 3, "ty": 1 } },
+        { "startHour": 6, "endHour": 20, "activity": "sleep", "location": { "type": "interior", "buildingId": "inn-building-upstairs", "tx": 8, "ty": 1 } }
+      ],
+      "homeBed": { "buildingId": "inn-building-upstairs", "tx": 8, "ty": 1 }
     },
     {
       "id": "bramble",
@@ -8589,7 +8637,31 @@
         "I've been supplying adventurers for thirty years. I know what keeps folks alive."
       ],
       "questGive": "brambles-first-delivery",
-      "questReceive": "vex-final-trade"
+      "questReceive": "vex-final-trade",
+      "schedule": [
+        { "startHour": 6, "endHour": 20, "activity": "work", "location": { "type": "interior", "buildingId": "supply-shop", "tx": 5, "ty": 5 } },
+        { "startHour": 20, "endHour": 6, "activity": "sleep", "location": { "type": "interior", "buildingId": "inn-building-upstairs", "tx": 5, "ty": 1 } }
+      ],
+      "homeBed": { "buildingId": "inn-building-upstairs", "tx": 5, "ty": 1 }
+    },
+    {
+      "id": "grix",
+      "name": "Grix",
+      "sprite": "hub-npc-grix",
+      "building": "supply-shop",
+      "tx": 5,
+      "ty": 5,
+      "screen": "shop-supplies",
+      "dialogue": [
+        "Psst. Grix open late. Very secret. Very good deals. Mostly.",
+        "Goblin prices — same as everyone else, honest!",
+        "Bramble sleeps, Grix sells. Fair trade for fair hours."
+      ],
+      "schedule": [
+        { "startHour": 20, "endHour": 6, "activity": "work", "location": { "type": "interior", "buildingId": "supply-shop", "tx": 5, "ty": 5 } },
+        { "startHour": 6, "endHour": 20, "activity": "sleep", "location": { "type": "interior", "buildingId": "inn-building-upstairs", "tx": 10, "ty": 1 } }
+      ],
+      "homeBed": { "buildingId": "inn-building-upstairs", "tx": 10, "ty": 1 }
     },
     {
       "id": "trader",
@@ -9468,6 +9540,62 @@
           "tileId": "graveStone"
         }
       ]
+    },
+    {
+      "id": "card-shop-item-0",
+      "tx": 12,
+      "ty": 4,
+      "building": "card-shop",
+      "decor": [{ "dx": 0, "dy": 0, "tileId": "closedBook" }],
+      "reactions": [{ "type": "buy", "slotIndex": 0 }]
+    },
+    {
+      "id": "card-shop-item-1",
+      "tx": 12,
+      "ty": 5,
+      "building": "card-shop",
+      "decor": [{ "dx": 0, "dy": 0, "tileId": "closedBook" }],
+      "reactions": [{ "type": "buy", "slotIndex": 1 }]
+    },
+    {
+      "id": "card-shop-item-2",
+      "tx": 12,
+      "ty": 6,
+      "building": "card-shop",
+      "decor": [{ "dx": 0, "dy": 0, "tileId": "closedBook" }],
+      "reactions": [{ "type": "buy", "slotIndex": 2 }]
+    },
+    {
+      "id": "augment-shop-item-0",
+      "tx": 8,
+      "ty": 4,
+      "building": "augment-shop",
+      "decor": [{ "dx": 0, "dy": 0, "tileId": "potions" }],
+      "reactions": [{ "type": "buy", "slotIndex": 0 }]
+    },
+    {
+      "id": "supply-shop-item-0",
+      "tx": 1,
+      "ty": 5,
+      "building": "supply-shop",
+      "decor": [{ "dx": 0, "dy": 0, "tileId": "crate" }],
+      "reactions": [{ "type": "buy", "slotIndex": 0 }]
+    },
+    {
+      "id": "supply-shop-item-1",
+      "tx": 10,
+      "ty": 5,
+      "building": "supply-shop",
+      "decor": [{ "dx": 0, "dy": 0, "tileId": "crate" }],
+      "reactions": [{ "type": "buy", "slotIndex": 1 }]
+    },
+    {
+      "id": "supply-shop-item-2",
+      "tx": 5,
+      "ty": 7,
+      "building": "supply-shop",
+      "decor": [{ "dx": 0, "dy": 0, "tileId": "crate" }],
+      "reactions": [{ "type": "buy", "slotIndex": 2 }]
     }
   ],
   "animals": [

--- a/web/src/game/hub/shopPurchases.ts
+++ b/web/src/game/hub/shopPurchases.ts
@@ -1,0 +1,35 @@
+// ─── Hub Shop Purchases ─────────────────────────────────────────────────────
+//
+// Tracks which shop-item slots have already been bought in the current
+// shopSchedule.ts stock slot (3-hour window), so a tapped item shows "already
+// bought" instead of selling infinitely. Keying by slot means old entries
+// simply stop matching once the slot rotates — no expiry bookkeeping needed.
+
+import { getShopSlotKey } from '../shopSchedule'
+
+const KEY = 'jarv_hub_shop_purchases'
+
+function load(): Set<string> {
+  try {
+    const raw = localStorage.getItem(KEY)
+    return raw ? new Set(JSON.parse(raw) as string[]) : new Set()
+  } catch { return new Set() }
+}
+
+function save(keys: Set<string>): void {
+  try { localStorage.setItem(KEY, JSON.stringify([...keys])) } catch { /* ignore */ }
+}
+
+function slotKeyFor(itemSlotId: string, at?: Date): string {
+  return `${itemSlotId}:${getShopSlotKey(at)}`
+}
+
+export function hasBoughtToday(itemSlotId: string, at?: Date): boolean {
+  return load().has(slotKeyFor(itemSlotId, at))
+}
+
+export function markBoughtToday(itemSlotId: string, at?: Date): void {
+  const keys = load()
+  keys.add(slotKeyFor(itemSlotId, at))
+  save(keys)
+}

--- a/web/src/game/hub/shopStock.test.ts
+++ b/web/src/game/hub/shopStock.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import { getTodaysShopItems } from './shopStock'
+import { ALL_CONSUMABLES } from '../questline'
+
+const slot = (h: number) => new Date(2026, 5, 30, h, 0, 0)
+
+describe('getTodaysShopItems', () => {
+  it('is deterministic for the same 3-hour slot', () => {
+    expect(getTodaysShopItems('card-shop', slot(9))).toEqual(getTodaysShopItems('card-shop', slot(10)))
+    expect(getTodaysShopItems('augment-shop', slot(9))).toEqual(getTodaysShopItems('augment-shop', slot(10)))
+    expect(getTodaysShopItems('supply-shop', slot(9))).toEqual(getTodaysShopItems('supply-shop', slot(10)))
+  })
+
+  it('can rotate across different slots', () => {
+    const days = Array.from({ length: 14 }, (_, i) => new Date(2026, 5, 1 + i, 9))
+    const cardSigs = new Set(days.map(d => JSON.stringify(getTodaysShopItems('card-shop', d))))
+    const supplySigs = new Set(days.map(d => JSON.stringify(getTodaysShopItems('supply-shop', d))))
+    expect(cardSigs.size).toBeGreaterThan(1)
+    expect(supplySigs.size).toBeGreaterThan(1)
+  })
+
+  it('returns 3 card deals with valid grants', () => {
+    const items = getTodaysShopItems('card-shop', slot(9))
+    expect(items.length).toBe(3)
+    for (const item of items) {
+      expect(item.grant.kind).toBe('card')
+      expect(item.itemName).not.toBe('')
+      expect(item.price).toBeGreaterThan(0)
+    }
+  })
+
+  it('returns a single augment deal', () => {
+    const items = getTodaysShopItems('augment-shop', slot(9))
+    expect(items.length).toBe(1)
+    expect(items[0].grant.kind).toBe('augment')
+  })
+
+  it('returns a rotating subset of consumables for supplies', () => {
+    const items = getTodaysShopItems('supply-shop', slot(9))
+    expect(items.length).toBe(Math.min(3, ALL_CONSUMABLES.length))
+    const ids = items.map(i => (i.grant as { kind: 'consumable'; id: string }).id)
+    expect(new Set(ids).size).toBe(ids.length) // no duplicates within a slot
+    for (const item of items) expect(item.grant.kind).toBe('consumable')
+  })
+})

--- a/web/src/game/hub/shopStock.ts
+++ b/web/src/game/hub/shopStock.ts
@@ -1,0 +1,61 @@
+// ─── Hub Shop Stock ─────────────────────────────────────────────────────────
+//
+// Resolves the physical, tappable for-sale items placed inside the 3 Ravenwatch
+// shop interiors (card-shop, augment-shop, supply-shop). Cards/augments reuse
+// shopSchedule.ts's real date-seeded deal generators directly, so a shop's
+// in-world items always match what ShopScreen.tsx sells once you walk in.
+// Supplies has no date-seeded equivalent in shopSchedule.ts (ShopScreen shows
+// the full fixed ALL_CONSUMABLES catalog there) — a small rotating subset is
+// picked here with the same seeded-rng mechanism so all 3 shops feel alike.
+
+import { getDailyShopCards, getDailyShopAugment, getShopSlotKey, makeSeededRng, dateHash } from '../shopSchedule'
+import { ALL_CONSUMABLES } from '../questline'
+
+export type ShopBuildingId = 'card-shop' | 'augment-shop' | 'supply-shop'
+
+export type ShopStockGrant =
+  | { kind: 'card'; cardName: string }
+  | { kind: 'augment'; augmentName: string }
+  | { kind: 'consumable'; id: string }
+
+export interface ShopStockItem {
+  itemName: string
+  price: number
+  grant: ShopStockGrant
+}
+
+const SUPPLY_STOCK_COUNT = 3
+
+function getSupplyStock(at?: Date): ShopStockItem[] {
+  const slotKey = getShopSlotKey(at)
+  const rng     = makeSeededRng(dateHash(slotKey) ^ 0x5a1e5009)
+  const pool    = [...ALL_CONSUMABLES]
+  const picks: ShopStockItem[] = []
+  const used = new Set<number>()
+  while (picks.length < SUPPLY_STOCK_COUNT && picks.length < pool.length) {
+    const idx = Math.floor(rng() * pool.length)
+    if (used.has(idx)) continue
+    used.add(idx)
+    const item = pool[idx]
+    picks.push({ itemName: item.name, price: item.price, grant: { kind: 'consumable', id: item.id } })
+  }
+  return picks
+}
+
+/** Today's (current 3-hour slot's) for-sale items for one of the 3 hub shops. */
+export function getTodaysShopItems(buildingId: ShopBuildingId, at?: Date): ShopStockItem[] {
+  switch (buildingId) {
+    case 'card-shop':
+      return getDailyShopCards(at)
+        .filter(d => d.cardName !== '')
+        .map(d => ({ itemName: d.cardName, price: d.price, grant: { kind: 'card', cardName: d.cardName } }))
+    case 'augment-shop': {
+      const deal = getDailyShopAugment(at)
+      return deal.augmentName === ''
+        ? []
+        : [{ itemName: deal.augmentName, price: deal.price, grant: { kind: 'augment', augmentName: deal.augmentName } }]
+    }
+    case 'supply-shop':
+      return getSupplyStock(at)
+  }
+}

--- a/web/src/game/shopSchedule.ts
+++ b/web/src/game/shopSchedule.ts
@@ -32,7 +32,7 @@ export interface ShopNPC {
 // ── Internal helpers ──────────────────────────────────────────────────────────
 
 /** Simple LCG seeded RNG — deterministic for a given seed. */
-function makeSeededRng(seed: number): () => number {
+export function makeSeededRng(seed: number): () => number {
   let s = seed >>> 0
   return () => {
     s = (Math.imul(s, 1664525) + 1013904223) >>> 0
@@ -41,7 +41,7 @@ function makeSeededRng(seed: number): () => number {
 }
 
 /** Numeric hash of a string. */
-function dateHash(str: string): number {
+export function dateHash(str: string): number {
   let h = 0
   for (let i = 0; i < str.length; i++) h = (h * 31 + str.charCodeAt(i)) >>> 0
   return h


### PR DESCRIPTION
## Summary

Implements #1622 "Hub: living shops (shopkeeper NPCs + rotating stock)" — closes #1660, #1661, #1664, #1622.

- Gildwyn, Mira, and Bramble now sell **physical, tappable for-sale items** placed inside their shop interiors (instead of opening straight to `ShopScreen`). Tapping an item shows a purchase-confirmation dialogue ("Care to buy *Frost Wyrm* for 600 crystals?") with **Buy**/**Maybe not** choices; confirming deducts crystals and grants the card/augment/consumable, and the slot shows as sold until the next stock rotation.
- The for-sale stock reuses `shopSchedule.ts`'s real date-seeded deal generators (`getDailyShopCards`/`getDailyShopAugment`), so what's on display in the shop matches what `ShopScreen` actually sells. Supplies (no date-seeded equivalent there) gets a small rotating subset of the consumables catalog using the same seeded-rng mechanism.
- Each of the three shopkeepers now follows a **day/night schedule** — active in their shop 6:00–20:00, asleep at the inn off-shift — and is relieved by a **new night-shift counterpart** pulled from `shopNpcs.json`'s existing roster: **Vorn** (card shop), **Nox** (augment shop), **Grix** (supply shop), each with a new sprite and dialogue drawn from their existing `shopNpcs.json` flavour text.

Also found and closed several other stale GitHub issues this session (#1807, #1735 + its 7 sub-issues, #1732) whose described work turned out to already be implemented in the codebase — unrelated to this PR's diff, no code changes for those.

## Changes

- `web/src/data/hub/config.ts`, `web/src/data/hub/loader.ts` — new `buy` interactable reaction type.
- `web/src/components/hub/HubWorld.tsx` — `buy` reaction handler: resolves today's stock, shows the confirmation dialogue, handles afford/grant/already-sold.
- `web/src/game/hub/shopStock.ts` (+ test) — resolves today's for-sale items per shop building.
- `web/src/game/hub/shopPurchases.ts` — tracks which item slots are already sold for the current stock rotation.
- `web/src/game/shopSchedule.ts` — exported the existing seeded-rng helpers for reuse.
- `web/src/data/hub/ravenwatch/config.json` — for-sale item interactables in the 3 shop interiors; day schedules for Gildwyn/Mira/Bramble; new NPCs Vorn/Nox/Grix with night schedules.
- `web/public/sprites/hub-npc-{vorn,nox,grix}.svg` — new shopkeeper sprites.
- `web/src/components/hub/HubDialogue.stories.tsx` — purchase-confirmation stories for a day and a night shopkeeper.

## Test plan

- [x] `cd web && npx tsc --noEmit` — passes
- [x] `cd web && npm run test` — 273/273 unit tests pass (a pre-existing, unrelated browser-mode Storybook test runner can't launch in this sandbox due to a missing `chromium_headless_shell` binary)
- [x] `cd web && npm run build` — production build succeeds
- [x] Verified the new `HubDialogue` purchase-confirmation stories render correctly in Storybook (day and night shopkeeper voices, Buy → "Sold!" transition) via screenshots
- [x] Verified the 3 new sprites render correctly
- [ ] Manual in-app walkthrough (enter each shop, tap an item, confirm purchase, advance the clock past the day/night boundary) — not done in this session (the sandboxed dev server lacks Firebase credentials needed to get past the title screen); recommended before merge if possible

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QnsGzNHipADhR2mtNLabxZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01QnsGzNHipADhR2mtNLabxZ)_