### PR TITLE
Keep Ravenwatch shops open 24/7 now that they have night shopkeepers

### DIFF
--- a/web/src/data/hub/ravenwatch/config.json
+++ b/web/src/data/hub/ravenwatch/config.json
@@ -5521,10 +5521,7 @@
           "zlayer": "solid"
         }
       ],
-      "hours": {
-        "open": 8,
-        "close": 20
-      },
+      "hours": "always",
       "wallTileId": "interiorWallWhite",
       "exits": [
         {
@@ -5680,10 +5677,7 @@
           "tileId": "wizardHatBottom"
         }
       ],
-      "hours": {
-        "open": 8,
-        "close": 20
-      }
+      "hours": "always"
     },
     "supply-shop": {
       "name": "Bramble's Supplies",
@@ -5759,10 +5753,7 @@
           "zlayer": "solid"
         }
       ],
-      "hours": {
-        "open": 8,
-        "close": 20
-      },
+      "hours": "always",
       "wallTileId": "interiorWallWhite",
       "exits": [
         {


### PR DESCRIPTION
## Summary

Follow-up to #1808. The 3 Ravenwatch shops (`card-shop`, `augment-shop`, `supply-shop`) still had `"hours": { "open": 8, "close": 20 }` on their interiors, which `HubTownCanvas.tsx`'s door-entry check (`isBuildingOpen()`) actively enforces — the door locks outside that window. That's exactly the 20:00–6:00 window the new night shopkeepers (Vorn/Nox/Grix, added in #1808) are scheduled to work, so they and their for-sale items were unreachable.

- `web/src/data/hub/ravenwatch/config.json` — set `hours` to `"always"` for `card-shop`, `augment-shop`, `supply-shop` (matching the pattern already used by several other always-open interiors in the same file, e.g. `inn-building`, `trader-den`'s neighbors). No other interiors touched.

## Test plan

- [x] `cd web && npx tsc --noEmit` — passes
- [x] `cd web && npm run test` — 273/273 unit tests pass (same pre-existing, unrelated browser-mode Storybook runner limitation as #1808 — missing `chromium_headless_shell` binary in this sandbox)
- [x] Verified `isBuildingOpen()` now returns `true` at every hour (0–23) for an `"always"` interior
- [x] Confirmed via diff that only the 3 intended shop interiors changed (caught and reverted an earlier stray edit to an unrelated interior, `trader-den`, before committing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QnsGzNHipADhR2mtNLabxZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01QnsGzNHipADhR2mtNLabxZ)_