### PR TITLE
Use the fanned-cards sprite as the card-pack interactable's icon

### DIFF
--- a/web/public/sprites/hub-item-cards.svg
+++ b/web/public/sprites/hub-item-cards.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- shadow -->
+  <ellipse cx="16" cy="27" rx="9" ry="2" fill="rgba(0,0,0,0.2)"/>
+  <!-- small display stand -->
+  <rect x="9" y="24" width="14" height="3" rx="1" fill="#6a4a2a"/>
+  <!-- fanned cards, same palette as Gildwyn's hand -->
+  <g transform="translate(16 16)">
+    <rect x="-9" y="-9" width="9" height="13" rx="1" fill="#fff" stroke="#c8b8d8" stroke-width="0.5" transform="rotate(-16)"/>
+    <rect x="-5" y="-10" width="9" height="13" rx="1" fill="#f0c0f0" stroke="#c878c8" stroke-width="0.5"/>
+    <rect x="0"  y="-9"  width="9" height="13" rx="1" fill="#c0c0ff" stroke="#7878d8" stroke-width="0.5" transform="rotate(16)"/>
+  </g>
+  <!-- pip marks -->
+  <circle cx="9" cy="9" r="1.1" fill="#7a4aaa"/>
+  <circle cx="16" cy="6.5" r="1.1" fill="#b855b8"/>
+  <circle cx="22.5" cy="10" r="1.1" fill="#5555c0"/>
+</svg>

--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -593,6 +593,16 @@ export function HubTownCanvas({
         }
         for (const d of decor) {
           const parent = d.zlayer === 'above' ? above! : root
+          if (d.spriteId) {
+            loadTextureUrl(`${base}sprites/${d.spriteId}.svg`).then(tex => {
+              if (app.renderer == null || !stillCurrent()) return
+              const s = new PIXI.Sprite(tex)
+              s.position.set(d.dx * T, d.dy * T)
+              s.width = T; s.height = T
+              parent.addChild(s)
+            }).catch(() => {})
+            continue
+          }
           if (d.shopArtSlot != null && def.building) {
             const items = getTodaysShopItems(def.building as ShopBuildingId)
             const item  = items[d.shopArtSlot]

--- a/web/src/data/hub/config.ts
+++ b/web/src/data/hub/config.ts
@@ -237,8 +237,11 @@ export interface RawTreasure {
 export interface RawInteractableDecor {
   dx: number
   dy: number
-  /** Tile-atlas tile, e.g. "crate". Mutually exclusive with shopArtSlot. */
+  /** Tile-atlas tile, e.g. "crate". Mutually exclusive with spriteId/shopArtSlot. */
   tileId?: string
+  /** web/public/sprites/<spriteId>.svg — a fixed decorative sprite, for decor
+   *  that isn't in the tile atlas and isn't live shop-stock art. */
+  spriteId?: string
   /** Renders today's live shop-stock art (card face / augment slot icon /
    *  consumable emoji badge) for this shop's Nth for-sale slot; the kind is
    *  resolved from getTodaysShopItems()[slot].grant.kind at render time. */

--- a/web/src/data/hub/loader.test.ts
+++ b/web/src/data/hub/loader.test.ts
@@ -78,11 +78,24 @@ describe('interactables parsing', () => {
     expect(decor?.tileId).toBeUndefined()
   })
 
+  it('passes spriteId decor through without resolving a tileId', () => {
+    const bundle = createHubLocationData(minimalConfig({
+      interactables: [{
+        id: 'card-shop-pack', tx: 12, ty: 7, building: 'card-shop',
+        decor: [{ dx: 0, dy: 0, spriteId: 'hub-item-cards' }],
+        reactions: [{ type: 'buyPack' }],
+      }],
+    }))
+    const decor = bundle.HUB_INTERACTABLES[0].decor?.[0]
+    expect(decor?.spriteId).toBe('hub-item-cards')
+    expect(decor?.tileId).toBeUndefined()
+  })
+
   it('passes a buyPack reaction through unchanged', () => {
     const bundle = createHubLocationData(minimalConfig({
       interactables: [{
         id: 'card-shop-pack', tx: 12, ty: 7, building: 'card-shop',
-        decor: [{ dx: 0, dy: 0, tileId: 'crate' }],
+        decor: [{ dx: 0, dy: 0, spriteId: 'hub-item-cards' }],
         reactions: [{ type: 'buyPack' }],
       }],
     }))

--- a/web/src/data/hub/loader.ts
+++ b/web/src/data/hub/loader.ts
@@ -246,8 +246,10 @@ export interface HubTreasure {
 export interface HubInteractableDecor {
   dx: number
   dy: number
-  /** Resolved tile-atlas id. Mutually exclusive with shopArtSlot. */
+  /** Resolved tile-atlas id. Mutually exclusive with spriteId/shopArtSlot. */
   tileId?: number
+  /** web/public/sprites/<spriteId>.svg — a fixed decorative sprite. */
+  spriteId?: string
   /** Renders today's live shop-stock art (card/augment/consumable, dispatched
    *  by grant.kind) for this shop's Nth for-sale slot. */
   shopArtSlot?: number
@@ -623,7 +625,8 @@ const HUB_INTERACTABLES: HubInteractable[] = (
   const decor: HubInteractableDecor[] | undefined = i.decor?.map(d => ({
     dx:          d.dx,
     dy:          d.dy,
-    tileId:      d.shopArtSlot != null ? undefined : resolveTileId(d.tileId ?? ''),
+    tileId:      (d.spriteId || d.shopArtSlot != null) ? undefined : resolveTileId(d.tileId ?? ''),
+    spriteId:    d.spriteId,
     shopArtSlot: d.shopArtSlot,
     zlayer:      d.zlayer as HubInteractableDecor['zlayer'],
   }))

--- a/web/src/data/hub/ravenwatch/config.json
+++ b/web/src/data/hub/ravenwatch/config.json
@@ -9561,7 +9561,7 @@
       "tx": 12,
       "ty": 7,
       "building": "card-shop",
-      "decor": [{ "dx": 0, "dy": 0, "tileId": "crate" }],
+      "decor": [{ "dx": 0, "dy": 0, "spriteId": "hub-item-cards" }],
       "reactions": [{ "type": "buyPack" }]
     },
     {


### PR DESCRIPTION
## Summary

Small follow-up to #1811. The card shop's "buy a pack" interactable was using the generic tile-atlas `crate` icon as a placeholder. Restores `hub-item-cards.svg` — a small fanned stack of 3 cards on a display stand, originally made for this exact purpose in #1810 but removed once individual card items switched to showing each card's own live art — and uses it for the pack icon instead, where a generic "cards" image is the right fit (a pack isn't any one card).

- `web/src/data/hub/config.ts`, `web/src/data/hub/loader.ts` — re-added a generic `spriteId` decor option (`web/public/sprites/<spriteId>.svg`), distinct from `tileId` (tile atlas) and `shopArtSlot` (live per-slot stock art added in #1811) — for decor that's simply a fixed sprite.
- `web/src/components/hub/HubTownCanvas.tsx` — new render branch for `spriteId` decor.
- `web/src/data/hub/ravenwatch/config.json` — `card-shop-pack`'s decor changed from `tileId: "crate"` to `spriteId: "hub-item-cards"`.
- `web/public/sprites/hub-item-cards.svg` — restored (recovered byte-for-byte from git history).

## Test plan

- [x] `cd web && npx tsc --noEmit` — passes
- [x] `cd web && npm run test` — 280/280 unit tests pass (added a `spriteId` pass-through assertion mirroring the existing `shopArtSlot` one)
- [x] `cd web && npm run build` — production build succeeds
- [x] Confirmed the sprite is served correctly at `/sprites/hub-item-cards.svg`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QnsGzNHipADhR2mtNLabxZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01QnsGzNHipADhR2mtNLabxZ)_