### PR TITLE
Scope daily shop stock per trader; generalize the trader registry

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -370,6 +370,7 @@ export default function App() {
 
   const [screen, setScreen]             = useState<Screen>(_startup.screen)
   const [returnScreen, setReturnScreen]  = useState<Screen>('title')
+  const [shopBuildingId, setShopBuildingId] = useState<string | undefined>(undefined)
   // Restore the town the player was last in (persisted in worldState). The saved
   // value is a world-map node id; for town nodes that id equals the LOCATION_REGISTRY
   // key. Fall back to ravenwatch if the saved id isn't a known town (e.g. a battle node).
@@ -2813,8 +2814,9 @@ export default function App() {
       {(screen === 'hubworld' || screen === 'location') && (
         <HubWorld
           onBack={() => setScreen('settings')}
-          onNavigate={(s) => {
+          onNavigate={(s, buildingId) => {
             setReturnScreen('hubworld')
+            setShopBuildingId(buildingId)
             const HUB_MINIGAME_IDS: SubScreen[] = ['marble', 'tileflip', 'crystalcatch', 'spinner', 'marblerace', 'higherOrLower', 'fruitMachine', 'videoPoker', 'fishing', 'towerDefence', 'citybuilder', 'prizes']
             if (HUB_MINIGAME_IDS.includes(s as SubScreen)) {
               setHubMiniGameEntry(s as SubScreen)
@@ -3207,6 +3209,7 @@ export default function App() {
       {screen === 'shop-cards' && (
         <ShopScreen
           category="cards"
+          buildingId={shopBuildingId}
           crystals={crystals}
           onBuyCrystalPack={handleBuyCrystalPack}
           onCrystalsChange={(n: number) => { saveCrystals(n); setCrystals(n) }}
@@ -3217,6 +3220,7 @@ export default function App() {
       {screen === 'shop-augments' && (
         <ShopScreen
           category="augments"
+          buildingId={shopBuildingId}
           crystals={crystals}
           onBuyCrystalPack={handleBuyCrystalPack}
           onCrystalsChange={(n: number) => { saveCrystals(n); setCrystals(n) }}
@@ -3227,6 +3231,7 @@ export default function App() {
       {screen === 'shop-supplies' && (
         <ShopScreen
           category="supplies"
+          buildingId={shopBuildingId}
           crystals={crystals}
           onBuyCrystalPack={handleBuyCrystalPack}
           onCrystalsChange={(n: number) => { saveCrystals(n); setCrystals(n) }}

--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -5,7 +5,7 @@ import { buildTerrainGfx, buildBgTileGfx, buildDecorGfx } from '../../utils/terr
 import { renderPathTiles } from '../../utils/tileLookup'
 import { loadSpriteTexture, loadTextureUrl, loadAnimFrames, loadTileRef } from '../../utils/pixiHelpers'
 import { resolveNpcSprite, spriteSlug } from '../../game/sprites'
-import { getTodaysShopItems, ShopBuildingId } from '../../game/hub/shopStock'
+import { getTodaysShopItems } from '../../game/hub/shopStock'
 import { loadDailyShopState, isShopItemSold } from '../../game/shopSchedule'
 import { PATH_TILE } from '../../data/tiles/tileIndex'
 import { findPath, nearestWalkable } from '../../utils/hubPathfinder'
@@ -604,7 +604,7 @@ export function HubTownCanvas({
             continue
           }
           if (d.shopArtSlot != null && def.building) {
-            const items = getTodaysShopItems(def.building as ShopBuildingId)
+            const items = getTodaysShopItems(def.building)
             const item  = items[d.shopArtSlot]
 
             // White card/tile backing, drawn regardless of whether art loads —
@@ -684,9 +684,9 @@ export function HubTownCanvas({
       // purchase made via the NPC dialogue, or in an earlier visit).
       const buyReaction = def.reactions.find(r => r.type === 'buy') as { type: 'buy'; slotIndex: number } | undefined
       if (buyReaction && def.building) {
-        const items = getTodaysShopItems(def.building as ShopBuildingId)
+        const items = getTodaysShopItems(def.building)
         const item  = items[buyReaction.slotIndex]
-        if (item && item.grant.kind !== 'consumable' && isShopItemSold(loadDailyShopState(), item.grant)) {
+        if (item && item.grant.kind !== 'consumable' && isShopItemSold(loadDailyShopState(), def.building, item.grant)) {
           addSoldBadge(entry)
         }
       }

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -49,8 +49,8 @@ import { HubInteractable, HubLocationBundle, HubQuestBundle, HubTreasure } from 
 import { getUnreadCount } from '../../game/news'
 import { interactableStoreKey, isInteractableGranted, markInteractableGranted, getInteractableMoves, setInteractableMove } from '../../game/hub/interactables'
 import { recordNpcMet, recordAnimalSeen, recordAreaSeen } from '../../game/hub/journal'
-import { getTodaysShopItems, ShopBuildingId } from '../../game/hub/shopStock'
-import { loadDailyShopState, saveDailyShopState, isShopItemSold } from '../../game/shopSchedule'
+import { getTodaysShopItems } from '../../game/hub/shopStock'
+import { loadDailyShopState, saveDailyShopState, isShopItemSold, markCardBought, markAugmentBought } from '../../game/shopSchedule'
 import rollbar from '../../rollbar'
 interface QuestEvent {
   speakerName: string
@@ -145,7 +145,7 @@ function getActiveDialogue(quest: HubQuestDef): string {
 
 export interface Props {
   onBack:             () => void
-  onNavigate?:        (screen: string) => void
+  onNavigate?:        (screen: string, buildingId?: string) => void
   onCampaign?:        () => void
   onEndless?:         () => void
   onWorldMap?:        () => void
@@ -496,7 +496,7 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onEndless, onWorldMap
     el.scrollTop  = py - el.clientHeight / 2
   }, [locationData])
 
-  const handleNodeInteract = useCallback((screen: string) => {
+  const handleNodeInteract = useCallback((screen: string, buildingId?: string) => {
     if (screen.startsWith('interior:')) {
       const buildingId = screen.slice(9)
       interiorEnterRef.current?.(buildingId)
@@ -515,7 +515,7 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onEndless, onWorldMap
       setDialogueEvent({ speakerName: "Commander's Post", text: "No commander has been assigned yet. Visit the title screen to choose one." })
       return
     }
-    onNavigate?.(screen)
+    onNavigate?.(screen, buildingId)
   }, [onNavigate, onCampaign, onWorldMap, onNarratorLog, commander])
 
   const handleReturn = useCallback(() => {
@@ -811,7 +811,7 @@ function hasOfferableQuest(giverId: string): boolean {
     // same id space as quest giverNpcId / receiverNpcId / targetNpcId.
     const namedNpc = locationData.HUB_NPCS.find(n => n.id === npcId)
     const npcDef: {
-      name?: string; dialogue?: string[]; screen?: string
+      name?: string; dialogue?: string[]; screen?: string; building?: string
       questGive?: string; questReceive?: string | string[]
       innRumours?: Array<{ id: string; text: string }>
       dialogueTree?: string
@@ -878,7 +878,7 @@ function hasOfferableQuest(giverId: string): boolean {
       const screen = npcDef.screen
       const enterChoice: DialogueChoice = {
         label: screenEnterLabel(screen),
-        onClick: () => handleNodeInteract(screen),
+        onClick: () => handleNodeInteract(screen, npcDef.building),
       }
       const dismiss: DialogueChoice = { label: 'Maybe later', onClick: () => setDialogueEvent(null) }
 
@@ -1040,7 +1040,7 @@ function hasOfferableQuest(giverId: string): boolean {
         return
       }
       case 'screen':
-        handleNodeInteract(r.screen)
+        handleNodeInteract(r.screen, def.building)
         return
       case 'quest':
         if (!tryOfferQuest(def.id, r.speakerName ?? '', r.questId)) next()
@@ -1077,7 +1077,7 @@ function hasOfferableQuest(giverId: string): boolean {
         return
       }
       case 'buy': {
-        const buildingId = def.building as ShopBuildingId | undefined
+        const buildingId = def.building
         const item = buildingId ? getTodaysShopItems(buildingId)[r.slotIndex] : undefined
         if (!buildingId || !item) { next(); return }
 
@@ -1089,7 +1089,7 @@ function hasOfferableQuest(giverId: string): boolean {
         // fields, so buying via the NPC screen and buying the physical item
         // draw down the same stock. Supplies are never gated here, matching
         // ShopScreen's "always in stock" consumables.
-        if (isShopItemSold(loadDailyShopState(), item.grant)) {
+        if (isShopItemSold(loadDailyShopState(), buildingId, item.grant)) {
           setDialogueEvent({ speakerName, text: 'Sold already, friend — check back next time the stock turns over.', onClose: next })
           return
         }
@@ -1103,7 +1103,7 @@ function hasOfferableQuest(giverId: string): boolean {
               setDialogueEvent({ speakerName, text: "That's more than you're carrying — come back when you've got the crystals." })
               return
             }
-            if (isShopItemSold(loadDailyShopState(), item.grant)) {
+            if (isShopItemSold(loadDailyShopState(), buildingId, item.grant)) {
               setDialogueEvent({ speakerName, text: 'Sold already, friend — check back next time the stock turns over.', onClose: next })
               return
             }
@@ -1112,11 +1112,11 @@ function hasOfferableQuest(giverId: string): boolean {
             switch (item.grant.kind) {
               case 'card':
                 addCardsToCollection([{ cardName: item.grant.cardName, count: 1 }])
-                saveDailyShopState({ ...loadDailyShopState(), boughtCardNames: [...loadDailyShopState().boughtCardNames, item.grant.cardName] })
+                saveDailyShopState(markCardBought(loadDailyShopState(), buildingId, item.grant.cardName))
                 break
               case 'augment':
                 addAugmentInstance(item.grant.augmentName)
-                saveDailyShopState({ ...loadDailyShopState(), boughtAugment: true })
+                saveDailyShopState(markAugmentBought(loadDailyShopState(), buildingId))
                 break
               case 'consumable':
                 addToConsumableStash(item.grant.id)

--- a/web/src/components/screens/ShopScreen.tsx
+++ b/web/src/components/screens/ShopScreen.tsx
@@ -15,6 +15,9 @@ import {
   ShopCardDeal,
   ShopAugmentDeal,
   recordNPCVisit,
+  isShopItemSold,
+  markCardBought,
+  markAugmentBought,
 } from '../../game/shopSchedule'
 import { getAugmentCard, augmentSlotLabel } from '../../game/augments'
 import { addAugmentInstance } from '../../game/collection'
@@ -91,12 +94,17 @@ interface Props {
   onCrystalsChange: (newAmount: number) => void
   onBack: () => void
   category?: ShopCategory
+  /** Which trader's stock this screen represents, for the "already bought today" gate.
+   *  Defaults to Ravenwatch's own card-shop/augment-shop ids, preserving legacy behavior. */
+  buildingId?: string
 }
 
 const PACK_QUANTITIES = [1, 3, 5, 10]
 
-export function ShopScreen({ crystals, onBuyCrystalPack, onCrystalsChange, onBack, category }: Props) {
+export function ShopScreen({ crystals, onBuyCrystalPack, onCrystalsChange, onBack, category, buildingId }: Props) {
   const show = (c: ShopCategory) => !category || category === c
+  const cardBuildingId    = buildingId ?? 'card-shop'
+  const augmentBuildingId = buildingId ?? 'augment-shop'
 
   const [packQty, setPackQty] = useState(1)
   const maxPackQty = Math.max(0, Math.floor((crystals - 100) / CRYSTAL_PACK_COST))
@@ -196,19 +204,19 @@ export function ShopScreen({ crystals, onBuyCrystalPack, onCrystalsChange, onBac
     emitSound('shopPurchase')
     onCrystalsChange(next)
     addCardsToCollection([{ cardName: deal.cardName, count: 1 }])
-    const updated = { ...shopState, boughtCardNames: [...shopState.boughtCardNames, deal.cardName] }
+    const updated = markCardBought(shopState, cardBuildingId, deal.cardName)
     setShopState(updated)
     saveDailyShopState(updated)
   }
 
   function handleBuyAugment() {
     const price = dailyAugment.price
-    if (crystals < price || !dailyAugment.augmentName || shopState.boughtAugment) return
+    if (crystals < price || !dailyAugment.augmentName || isShopItemSold(shopState, augmentBuildingId, { kind: 'augment' })) return
     const next = crystals - price
     emitSound('shopPurchase')
     onCrystalsChange(next)
     addAugmentInstance(dailyAugment.augmentName)
-    const updated = { ...shopState, boughtAugment: true }
+    const updated = markAugmentBought(shopState, augmentBuildingId)
     setShopState(updated)
     saveDailyShopState(updated)
   }
@@ -259,7 +267,7 @@ export function ShopScreen({ crystals, onBuyCrystalPack, onCrystalsChange, onBac
           <div className="shop-section-header">Current Stock 🕐 refreshes in <span className="shop-countdown-time">{formatCountdown(countdown)}</span></div>
           <div className="shop-daily-cards u-flex u-gap-6 u-wrap u-just-c">
             {dailyCards.map(deal => {
-              const bought = shopState.boughtCardNames.includes(deal.cardName)
+              const bought = isShopItemSold(shopState, cardBuildingId, { kind: 'card', cardName: deal.cardName })
               const price = cardPrice(deal)
               const canAfford = crystals >= price && !bought && deal.cardName !== ''
               const discounted = npc.role === 'apprentice' && weekend
@@ -291,7 +299,7 @@ export function ShopScreen({ crystals, onBuyCrystalPack, onCrystalsChange, onBac
         {/* ── Today's Augment ── */}
         {show('augments') && dailyAugment.augmentName !== '' && (() => {
           const aug = getAugmentCard(dailyAugment.augmentName)
-          const bought = shopState.boughtAugment ?? false
+          const bought = isShopItemSold(shopState, augmentBuildingId, { kind: 'augment' })
           const canAfford = crystals >= dailyAugment.price && !bought
           return (
             <div className="shop-section">

--- a/web/src/data/hub/capitalcity/config.json
+++ b/web/src/data/hub/capitalcity/config.json
@@ -4811,6 +4811,7 @@
       "tx": 40,
       "ty": 15,
       "screen": "shop-cards",
+      "building": "card-shop-crownhaven",
       "dialogue": [
         "Cards! Fresh from the capital's own printers. Care to browse the stock?",
         "Every deck tells a story. Build yours here.",
@@ -4837,6 +4838,7 @@
       "tx": 68,
       "ty": 15,
       "screen": "shop-augments",
+      "building": "augment-shop-crownhaven",
       "dialogue": [
         "Augments, enhancements, little edges of power. Step up to the bench.",
         "The jewellers cut stones; I cut destinies. Or near enough.",

--- a/web/src/data/hub/millhaven/config.json
+++ b/web/src/data/hub/millhaven/config.json
@@ -1848,7 +1848,8 @@
         "No need to trek back to Ravenwatch — I deal right here.",
         "Browse the wares, friend. Every deck needs an edge."
       ],
-      "screen": "shop-cards"
+      "screen": "shop-cards",
+      "building": "card-shop-millhaven"
     },
     {
       "id": "regatta-master",

--- a/web/src/game/hub/shopStock.test.ts
+++ b/web/src/game/hub/shopStock.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest'
-import { getTodaysShopItems } from './shopStock'
+import { describe, it, expect, afterEach } from 'vitest'
+import { getTodaysShopItems, SHOP_TRADER_REGISTRY } from './shopStock'
 import { ALL_CONSUMABLES } from '../questline'
 
 const slot = (h: number) => new Date(2026, 5, 30, h, 0, 0)
@@ -41,5 +41,22 @@ describe('getTodaysShopItems', () => {
     const ids = items.map(i => (i.grant as { kind: 'consumable'; id: string }).id)
     expect(new Set(ids).size).toBe(ids.length) // no duplicates within a slot
     for (const item of items) expect(item.grant.kind).toBe('consumable')
+  })
+
+  describe('trader registry', () => {
+    afterEach(() => {
+      delete SHOP_TRADER_REGISTRY['test-spellwright']
+    })
+
+    it('a filtered registry entry returns only matching items', () => {
+      SHOP_TRADER_REGISTRY['test-spellwright'] = { kind: 'card', cardFilter: { cardType: 'upgrade', slotCount: 4 } }
+      const items = getTodaysShopItems('test-spellwright', slot(9))
+      expect(items.length).toBeGreaterThan(0)
+      for (const item of items) expect(item.grant.kind).toBe('card')
+    })
+
+    it('an unregistered building id returns an empty array (fail closed)', () => {
+      expect(getTodaysShopItems('not-a-real-trader', slot(9))).toEqual([])
+    })
   })
 })

--- a/web/src/game/hub/shopStock.ts
+++ b/web/src/game/hub/shopStock.ts
@@ -8,10 +8,31 @@
 // the full fixed ALL_CONSUMABLES catalog there) — a small rotating subset is
 // picked here with the same seeded-rng mechanism so all 3 shops feel alike.
 
-import { getDailyShopCards, getDailyShopAugment, getShopSlotKey, makeSeededRng, dateHash } from '../shopSchedule'
+import { getDailyShopCards, getDailyShopAugment, getShopSlotKey, makeSeededRng, dateHash, ShopCardFilter } from '../shopSchedule'
+import { CardRarity } from '../types'
 import { ALL_CONSUMABLES } from '../questline'
 
-export type ShopBuildingId = 'card-shop' | 'augment-shop' | 'supply-shop'
+/** Widened to a plain string: new traders register under any building id, not just Ravenwatch's 3. */
+export type ShopBuildingId = string
+
+export type ShopTraderKind = 'card' | 'augment' | 'consumable'
+
+export interface ShopTraderConfig {
+  kind: ShopTraderKind
+  /** 'card' traders only: restricts/reshapes the card pool (e.g. cardType/rarity filters). */
+  cardFilter?: ShopCardFilter
+  /** 'augment' traders only: restricts the augment pool to these rarities. */
+  augmentRarities?: CardRarity[]
+  /** 'consumable' traders only: how many items to stock. Defaults to 3. */
+  slotCount?: number
+}
+
+/** One row per trader building. New specialist traders register here. */
+export const SHOP_TRADER_REGISTRY: Record<string, ShopTraderConfig> = {
+  'card-shop':    { kind: 'card' },
+  'augment-shop': { kind: 'augment' },
+  'supply-shop':  { kind: 'consumable' },
+}
 
 export type ShopStockGrant =
   | { kind: 'card'; cardName: string }
@@ -24,15 +45,15 @@ export interface ShopStockItem {
   grant: ShopStockGrant
 }
 
-const SUPPLY_STOCK_COUNT = 3
+const DEFAULT_SUPPLY_STOCK_COUNT = 3
 
-function getSupplyStock(at?: Date): ShopStockItem[] {
+function getSupplyStock(at: Date | undefined, count: number): ShopStockItem[] {
   const slotKey = getShopSlotKey(at)
   const rng     = makeSeededRng(dateHash(slotKey) ^ 0x5a1e5009)
   const pool    = [...ALL_CONSUMABLES]
   const picks: ShopStockItem[] = []
   const used = new Set<number>()
-  while (picks.length < SUPPLY_STOCK_COUNT && picks.length < pool.length) {
+  while (picks.length < count && picks.length < pool.length) {
     const idx = Math.floor(rng() * pool.length)
     if (used.has(idx)) continue
     used.add(idx)
@@ -42,20 +63,23 @@ function getSupplyStock(at?: Date): ShopStockItem[] {
   return picks
 }
 
-/** Today's (current 3-hour slot's) for-sale items for one of the 3 hub shops. */
-export function getTodaysShopItems(buildingId: ShopBuildingId, at?: Date): ShopStockItem[] {
-  switch (buildingId) {
-    case 'card-shop':
-      return getDailyShopCards(at)
+/** Today's (current 3-hour slot's) for-sale items for a registered hub trader. */
+export function getTodaysShopItems(buildingId: string, at?: Date): ShopStockItem[] {
+  const config = SHOP_TRADER_REGISTRY[buildingId]
+  if (!config) return []
+
+  switch (config.kind) {
+    case 'card':
+      return getDailyShopCards(at, config.cardFilter)
         .filter(d => d.cardName !== '')
         .map(d => ({ itemName: d.cardName, price: d.price, grant: { kind: 'card', cardName: d.cardName } }))
-    case 'augment-shop': {
-      const deal = getDailyShopAugment(at)
+    case 'augment': {
+      const deal = getDailyShopAugment(at, config.augmentRarities)
       return deal.augmentName === ''
         ? []
         : [{ itemName: deal.augmentName, price: deal.price, grant: { kind: 'augment', augmentName: deal.augmentName } }]
     }
-    case 'supply-shop':
-      return getSupplyStock(at)
+    case 'consumable':
+      return getSupplyStock(at, config.slotCount ?? DEFAULT_SUPPLY_STOCK_COUNT)
   }
 }

--- a/web/src/game/shopSchedule.test.ts
+++ b/web/src/game/shopSchedule.test.ts
@@ -1,24 +1,130 @@
-import { describe, it, expect } from 'vitest'
-import { isShopItemSold, DailyShopState } from './shopSchedule'
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  isShopItemSold,
+  markCardBought,
+  markAugmentBought,
+  getDailyShopCards,
+  DailyShopState,
+} from './shopSchedule'
 
-const baseState: DailyShopState = { date: '2026-06-30-2', boughtCardNames: [], soldItemIds: [] }
+const baseState: DailyShopState = { date: '2026-06-30-2', buildings: {}, soldItemIds: [] }
 
 describe('isShopItemSold', () => {
-  it('cards are sold once their name is in boughtCardNames', () => {
-    expect(isShopItemSold(baseState, { kind: 'card', cardName: 'Goblin' })).toBe(false)
-    const withPurchase = { ...baseState, boughtCardNames: ['Goblin'] }
-    expect(isShopItemSold(withPurchase, { kind: 'card', cardName: 'Goblin' })).toBe(true)
-    expect(isShopItemSold(withPurchase, { kind: 'card', cardName: 'Ballista Works' })).toBe(false)
+  it('cards are sold once their name is recorded for that building', () => {
+    expect(isShopItemSold(baseState, 'card-shop', { kind: 'card', cardName: 'Goblin' })).toBe(false)
+    const withPurchase = markCardBought(baseState, 'card-shop', 'Goblin')
+    expect(isShopItemSold(withPurchase, 'card-shop', { kind: 'card', cardName: 'Goblin' })).toBe(true)
+    expect(isShopItemSold(withPurchase, 'card-shop', { kind: 'card', cardName: 'Ballista Works' })).toBe(false)
   })
 
-  it('the augment slot is sold via the boughtAugment flag', () => {
-    expect(isShopItemSold(baseState, { kind: 'augment' })).toBe(false)
-    expect(isShopItemSold({ ...baseState, boughtAugment: true }, { kind: 'augment' })).toBe(true)
-    expect(isShopItemSold({ ...baseState, boughtAugment: false }, { kind: 'augment' })).toBe(false)
+  it('the augment slot is sold via the per-building boughtAugment flag', () => {
+    expect(isShopItemSold(baseState, 'augment-shop', { kind: 'augment' })).toBe(false)
+    const bought = markAugmentBought(baseState, 'augment-shop')
+    expect(isShopItemSold(bought, 'augment-shop', { kind: 'augment' })).toBe(true)
   })
 
   it('consumables are never gated', () => {
-    expect(isShopItemSold(baseState, { kind: 'consumable' })).toBe(false)
-    expect(isShopItemSold({ ...baseState, boughtCardNames: ['x'], boughtAugment: true }, { kind: 'consumable' })).toBe(false)
+    expect(isShopItemSold(baseState, 'supply-shop', { kind: 'consumable' })).toBe(false)
+    const withPurchases = markAugmentBought(markCardBought(baseState, 'supply-shop', 'x'), 'supply-shop')
+    expect(isShopItemSold(withPurchases, 'supply-shop', { kind: 'consumable' })).toBe(false)
+  })
+
+  it('buying a card at one building does not mark it sold at a different building (regression)', () => {
+    const withPurchase = markCardBought(baseState, 'card-shop-crownhaven', 'Goblin')
+    expect(isShopItemSold(withPurchase, 'card-shop-crownhaven', { kind: 'card', cardName: 'Goblin' })).toBe(true)
+    expect(isShopItemSold(withPurchase, 'card-shop', { kind: 'card', cardName: 'Goblin' })).toBe(false)
+    expect(isShopItemSold(withPurchase, 'card-shop-millhaven', { kind: 'card', cardName: 'Goblin' })).toBe(false)
+  })
+
+  it('buying an augment at one building does not mark it sold at a different building', () => {
+    const bought = markAugmentBought(baseState, 'augment-shop-crownhaven')
+    expect(isShopItemSold(bought, 'augment-shop-crownhaven', { kind: 'augment' })).toBe(true)
+    expect(isShopItemSold(bought, 'augment-shop', { kind: 'augment' })).toBe(false)
+  })
+})
+
+describe('markCardBought / markAugmentBought', () => {
+  it('are immutable — they return a new state and do not mutate the input', () => {
+    const before = JSON.stringify(baseState)
+    const updated = markCardBought(baseState, 'card-shop', 'Goblin')
+    expect(JSON.stringify(baseState)).toBe(before)
+    expect(updated).not.toBe(baseState)
+    expect(updated.buildings['card-shop'].boughtCardNames).toEqual(['Goblin'])
+  })
+
+  it('accumulate multiple card purchases for the same building', () => {
+    const s1 = markCardBought(baseState, 'card-shop', 'Goblin')
+    const s2 = markCardBought(s1, 'card-shop', 'Ballista Works')
+    expect(s2.buildings['card-shop'].boughtCardNames).toEqual(['Goblin', 'Ballista Works'])
+  })
+
+  it('do not disturb other buildings already recorded on the state', () => {
+    const s1 = markCardBought(baseState, 'card-shop', 'Goblin')
+    const s2 = markAugmentBought(s1, 'augment-shop')
+    expect(s2.buildings['card-shop'].boughtCardNames).toEqual(['Goblin'])
+    expect(s2.buildings['augment-shop'].boughtAugment).toBe(true)
+  })
+})
+
+describe('getDailyShopCards filters', () => {
+  const at = new Date('2026-06-30T12:00:00Z')
+
+  it('with no filter, matches the default 3-slot common/uncommon/rare-or-legendary spread', () => {
+    const deals = getDailyShopCards(at)
+    expect(deals).toHaveLength(3)
+  })
+
+  it('cardType filter restricts every deal to that card type', () => {
+    const deals = getDailyShopCards(at, { cardType: 'upgrade' })
+    expect(deals.length).toBeGreaterThan(0)
+    for (const d of deals) {
+      expect(d.cardName).not.toBe('')
+    }
+  })
+
+  it('rarity filter restricts every deal to a single rarity with no duplicates', () => {
+    const deals = getDailyShopCards(at, { rarity: 'common', slotCount: 5 })
+    expect(deals.length).toBeGreaterThan(0)
+    for (const d of deals) expect(d.rarity).toBe('common')
+    const names = deals.map(d => d.cardName)
+    expect(new Set(names).size).toBe(names.length)
+  })
+
+  it('rarities filter draws from a combined pool with no duplicates', () => {
+    const deals = getDailyShopCards(at, { rarities: ['epic', 'legendary'], slotCount: 4 })
+    expect(deals.length).toBeGreaterThan(0)
+    for (const d of deals) expect(['epic', 'legendary']).toContain(d.rarity)
+    const names = deals.map(d => d.cardName)
+    expect(new Set(names).size).toBe(names.length)
+  })
+})
+
+describe('loadDailyShopState migration', () => {
+  // In-memory localStorage mock (tests run in node environment)
+  const store = new Map<string, string>()
+  beforeEach(() => {
+    store.clear()
+    globalThis.localStorage = {
+      getItem:    (k: string) => store.get(k) ?? null,
+      setItem:    (k: string, v: string) => { store.set(k, v) },
+      removeItem: (k: string) => { store.delete(k) },
+      clear:      () => { store.clear() },
+      key:        (i: number) => [...store.keys()][i] ?? null,
+      get length() { return store.size },
+    } as Storage
+  })
+
+  it('treats an old flat-shape payload as stale and returns a fresh state', async () => {
+    const { getShopSlotKey, loadDailyShopState } = await import('./shopSchedule')
+    const oldFlatPayload = {
+      date: getShopSlotKey(),
+      boughtCardNames: ['Goblin'],
+      soldItemIds: [],
+      boughtAugment: true,
+    }
+    localStorage.setItem('jarv_shop_daily', JSON.stringify(oldFlatPayload))
+    const state = loadDailyShopState()
+    expect(state.buildings).toEqual({})
+    expect(state.soldItemIds).toEqual([])
   })
 })

--- a/web/src/game/shopSchedule.ts
+++ b/web/src/game/shopSchedule.ts
@@ -4,7 +4,7 @@
 // purchase state. NPC definitions live in src/data/shopNpcs.json.
 
 import { getCardCatalog } from './cards'
-import { CardRarity } from './types'
+import { CardRarity, CardType } from './types'
 import { ALL_ITEMS, RewardDef } from './dailyLogin'
 import { getAugmentCatalog } from './augments'
 import shopNpcsJson from '../data/shopNpcs.json'
@@ -181,12 +181,40 @@ export interface ShopCardDeal {
   price: number
 }
 
-/** Returns the current stock's 3 card deals (refreshes every 3 hours). */
-export function getDailyShopCards(at?: Date): ShopCardDeal[] {
+export interface ShopCardFilter {
+  /** Restrict the pool to a single card type (e.g. 'upgrade' for a "spell" trader). */
+  cardType?: CardType
+  /** Restrict every slot to a single rarity, instead of the default
+   *  common/uncommon/rare-or-legendary 3-tier spread. */
+  rarity?: CardRarity
+  /** Restrict every slot to a set of rarities (e.g. epic+legendary). */
+  rarities?: CardRarity[]
+  /** Number of deals to return. Defaults to 3 (Ravenwatch's card-shop). */
+  slotCount?: number
+}
+
+/** Returns the current stock's card deals (refreshes every 3 hours). */
+export function getDailyShopCards(at?: Date, filter?: ShopCardFilter): ShopCardDeal[] {
   const slotKey = getShopSlotKey(at)
   const rng     = makeSeededRng(dateHash(slotKey) ^ 0xcafebabe)
-  const catalog = getCardCatalog()
+  const catalog = getCardCatalog().filter(c => !filter?.cardType || c.cardType === filter.cardType)
   const npc     = getDailyShopNPC(at)
+
+  const rarityFilter = filter?.rarities ?? (filter?.rarity ? [filter.rarity] : undefined)
+  if (rarityFilter) {
+    const pool  = catalog.filter(c => rarityFilter.includes(c.rarity))
+    const count = Math.min(filter?.slotCount ?? 3, pool.length)
+    const used  = new Set<number>()
+    const result: ShopCardDeal[] = []
+    while (result.length < count) {
+      const idx = Math.floor(rng() * pool.length)
+      if (used.has(idx)) continue
+      used.add(idx)
+      const card = pool[idx]
+      result.push({ cardName: card.name, rarity: card.rarity, price: SHOP_CARD_PRICES[card.rarity] })
+    }
+    return result
+  }
 
   const pick = (rarity: CardRarity): ShopCardDeal => {
     const pool = catalog.filter(c => c.rarity === rarity)
@@ -219,13 +247,14 @@ export interface ShopAugmentDeal {
   price: number
 }
 
+const DEFAULT_AUGMENT_RARITIES: CardRarity[] = ['common', 'uncommon', 'rare', 'epic', 'legendary']
+
 /** Returns a single random augment deal for the current stock slot (refreshes every 3 hours). */
-export function getDailyShopAugment(at?: Date): ShopAugmentDeal {
+export function getDailyShopAugment(at?: Date, allowedRarities?: CardRarity[]): ShopAugmentDeal {
   const slotKey = getShopSlotKey(at)
   const rng     = makeSeededRng(dateHash(slotKey) ^ 0xdeadbeef)
-  const catalog = getAugmentCatalog().filter(c =>
-    c.rarity === 'common' || c.rarity === 'uncommon' || c.rarity === 'rare' || c.rarity === 'epic' || c.rarity === 'legendary'
-  )
+  const rarities = allowedRarities ?? DEFAULT_AUGMENT_RARITIES
+  const catalog = getAugmentCatalog().filter(c => rarities.includes(c.rarity as CardRarity))
   if (catalog.length === 0) return { augmentName: '', rarity: 'common', price: SHOP_AUGMENT_PRICES.common }
   const aug = catalog[Math.floor(rng() * catalog.length)]
   return {
@@ -259,15 +288,20 @@ export function getDailyShopSellSlots(at?: Date): RewardDef[] {
 
 // ── Daily shop purchase state ─────────────────────────────────────────────────
 
-export interface DailyShopState {
-  date: string
+export interface DailyShopBuildingState {
   boughtCardNames: string[]
-  soldItemIds: string[]
   boughtAugment?: boolean
 }
 
+export interface DailyShopState {
+  date: string
+  /** Per-trader "already bought today" state, keyed by building id. */
+  buildings: Record<string, DailyShopBuildingState>
+  soldItemIds: string[]
+}
+
 function freshShopState(): DailyShopState {
-  return { date: getShopSlotKey(), boughtCardNames: [], soldItemIds: [] }
+  return { date: getShopSlotKey(), buildings: {}, soldItemIds: [] }
 }
 
 export function loadDailyShopState(): DailyShopState {
@@ -276,6 +310,7 @@ export function loadDailyShopState(): DailyShopState {
     if (!raw) return freshShopState()
     const parsed = JSON.parse(raw) as DailyShopState
     if (parsed.date !== getShopSlotKey()) return freshShopState()
+    if (!parsed.buildings) return freshShopState()
     return parsed
   } catch {
     return freshShopState()
@@ -286,18 +321,47 @@ export function saveDailyShopState(state: DailyShopState): void {
   try { localStorage.setItem(SHOP_STATE_KEY, JSON.stringify(state)) } catch { /* ignore */ }
 }
 
+/** Returns a new state with the given card marked bought for one building's stock. */
+export function markCardBought(state: DailyShopState, buildingId: string, cardName: string): DailyShopState {
+  const existing = state.buildings[buildingId] ?? { boughtCardNames: [] }
+  return {
+    ...state,
+    buildings: {
+      ...state.buildings,
+      [buildingId]: { ...existing, boughtCardNames: [...existing.boughtCardNames, cardName] },
+    },
+  }
+}
+
+/** Returns a new state with the augment marked bought for one building's stock. */
+export function markAugmentBought(state: DailyShopState, buildingId: string): DailyShopState {
+  const existing = state.buildings[buildingId] ?? { boughtCardNames: [] }
+  return {
+    ...state,
+    buildings: {
+      ...state.buildings,
+      [buildingId]: { ...existing, boughtAugment: true },
+    },
+  }
+}
+
 /**
  * Whether a for-sale item is already sold today, per the same state ShopScreen
  * uses — shared by the hub's physical-item purchase path so buying via the
  * shopkeeper NPC or via the placed item both draw down the same stock.
  * Consumables are never gated (ShopScreen sells them unlimited).
+ *
+ * buildingId is required (not optional/defaulted) so a trader's "sold" state
+ * can never silently collide with another trader's stock.
  */
 export function isShopItemSold(
   state: DailyShopState,
+  buildingId: string,
   grant: { kind: 'card' | 'augment' | 'consumable'; cardName?: string },
 ): boolean {
-  if (grant.kind === 'card') return state.boughtCardNames.includes(grant.cardName ?? '')
-  if (grant.kind === 'augment') return state.boughtAugment ?? false
+  const b = state.buildings[buildingId]
+  if (grant.kind === 'card') return b?.boughtCardNames.includes(grant.cardName ?? '') ?? false
+  if (grant.kind === 'augment') return b?.boughtAugment ?? false
   return false
 }
 


### PR DESCRIPTION
## Summary

This is Part 1 (shared infrastructure) of a broader plan to add specialist trader NPCs (e.g. a "spells only" or "common cards only" vendor) across the hub towns, starting with a bug fix that's already live in production.

- **Fixes a confirmed-live bug**: `DailyShopState.boughtCardNames`/`boughtAugment` were flat global fields, so buying a card/augment at one trader could silently mark the same-named item "sold" at a completely different trader. Ravenwatch's card-shop already collided with Crownhaven's Trader Pemberly, Crownhaven's Artificer Garnet, and Millhaven's Dealer Sloane — all routed into the same `ShopScreen` with no per-building scoping.
- `DailyShopState` is now nested per building id (`buildings: Record<string, DailyShopBuildingState>`). `isShopItemSold` takes a **required** `buildingId` parameter (not optional/defaulted, to prevent silently reintroducing the bug). New `markCardBought`/`markAugmentBought` helpers replace manual state spreads.
- Old flat-shape localStorage payloads are treated as stale and degrade to a fresh state instead of crashing.
- The three already-live colliding NPCs (Trader Pemberly, Artificer Garnet, Dealer Sloane) now have explicit, distinct `building` ids, closing the existing collisions.
- `getDailyShopCards`/`getDailyShopAugment` gained optional filters (`cardType`, `rarity`, `rarities`, `slotCount`/`allowedRarities`) so future specialist traders can restrict their stock to a slice of the card catalog, while preserving today's exact behavior when called with no filter.
- `shopStock.ts`'s fixed `ShopBuildingId` union + switch statement is replaced with a declarative `SHOP_TRADER_REGISTRY`, the single place a new trader gets registered. Unregistered building ids fail closed (return `[]`) rather than throwing.

No new town content ships in this PR — it's purely the shared plumbing the per-town trader rollout will build on.

## Test plan

- [x] `npx tsc --noEmit` passes with no errors
- [x] `npx vitest run` — 292 tests pass across 28 files (existing regression suite + new tests below)
- [x] `npm run build` succeeds
- [x] New regression test: buying the same card/augment name at one building does not mark it sold at a different building
- [x] New tests for `markCardBought`/`markAugmentBought` immutability
- [x] New tests for `getDailyShopCards` with `cardType`/`rarity`/`rarities` filters (no duplicate picks within a slot)
- [x] New test: an old flat-shape localStorage payload degrades to a fresh state instead of crashing
- [x] New `shopStock.test.ts` coverage for the registry (filtered entry, unregistered id fails closed, `card-shop`/`augment-shop`/`supply-shop` regression-guarded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QnsGzNHipADhR2mtNLabxZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01QnsGzNHipADhR2mtNLabxZ)_