### PR TITLE
Tier 1 specialist traders: gravemoor, appleford, millhaven

### DIFF
--- a/web/src/data/hub/appleford/config.json
+++ b/web/src/data/hub/appleford/config.json
@@ -2095,6 +2095,32 @@
       "exits": []
     }
   },
+  "interactables": [
+    {
+      "id": "market-barn-item-0",
+      "tx": 11,
+      "ty": 2,
+      "building": "market-barn",
+      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 0 }],
+      "reactions": [{ "type": "buy", "slotIndex": 0 }]
+    },
+    {
+      "id": "market-barn-item-1",
+      "tx": 11,
+      "ty": 3,
+      "building": "market-barn",
+      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 1 }],
+      "reactions": [{ "type": "buy", "slotIndex": 1 }]
+    },
+    {
+      "id": "market-barn-item-2",
+      "tx": 11,
+      "ty": 4,
+      "building": "market-barn",
+      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 2 }],
+      "reactions": [{ "type": "buy", "slotIndex": 2 }]
+    }
+  ],
   "festivalDecor": [
     {
       "festivalId": "harvest",

--- a/web/src/data/hub/gravemoor/config.json
+++ b/web/src/data/hub/gravemoor/config.json
@@ -1162,14 +1162,14 @@
       "name": "Merchant Mora",
       "sprite": "hub-npc-merchant",
       "isGhost": true,
-      "tx": 5,
+      "tx": 4,
       "ty": 5,
       "dialogue": [
         "Two hundred years of stock and not a single customer. Until you.",
         "Money means little to the dead, but haggling? Haggling is eternal.",
         "The blight took the town, but it couldn't take the market spirit. Literally, in my case."
       ],
-      "building": "mourning-hall-reliquary"
+      "building": "undertaker"
     },
     {
       "id": "grave-keeper-finch",
@@ -2555,6 +2555,32 @@
       ]
     }
   },
+  "interactables": [
+    {
+      "id": "undertaker-item-0",
+      "tx": 8,
+      "ty": 3,
+      "building": "undertaker",
+      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 0 }],
+      "reactions": [{ "type": "buy", "slotIndex": 0 }]
+    },
+    {
+      "id": "undertaker-item-1",
+      "tx": 8,
+      "ty": 4,
+      "building": "undertaker",
+      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 1 }],
+      "reactions": [{ "type": "buy", "slotIndex": 1 }]
+    },
+    {
+      "id": "undertaker-item-2",
+      "tx": 8,
+      "ty": 5,
+      "building": "undertaker",
+      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 2 }],
+      "reactions": [{ "type": "buy", "slotIndex": 2 }]
+    }
+  ],
   "weather": {
     "type": "fog"
   }

--- a/web/src/data/hub/millhaven/config.json
+++ b/web/src/data/hub/millhaven/config.json
@@ -2903,6 +2903,30 @@
           "tileId": "stoneWell"
         }
       ]
+    },
+    {
+      "id": "market-hall-item-0",
+      "tx": 11,
+      "ty": 2,
+      "building": "market-hall",
+      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 0 }],
+      "reactions": [{ "type": "buy", "slotIndex": 0 }]
+    },
+    {
+      "id": "market-hall-item-1",
+      "tx": 11,
+      "ty": 3,
+      "building": "market-hall",
+      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 1 }],
+      "reactions": [{ "type": "buy", "slotIndex": 1 }]
+    },
+    {
+      "id": "market-hall-item-2",
+      "tx": 11,
+      "ty": 4,
+      "building": "market-hall",
+      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 2 }],
+      "reactions": [{ "type": "buy", "slotIndex": 2 }]
     }
   ],
   "pondTiles": [

--- a/web/src/game/hub/shopStock.ts
+++ b/web/src/game/hub/shopStock.ts
@@ -32,6 +32,11 @@ export const SHOP_TRADER_REGISTRY: Record<string, ShopTraderConfig> = {
   'card-shop':    { kind: 'card' },
   'augment-shop': { kind: 'augment' },
   'supply-shop':  { kind: 'consumable' },
+
+  // Tier 1 specialist traders (see epic #1814)
+  'undertaker':   { kind: 'card', cardFilter: { rarity: 'common' } },     // gravemoor — Merchant Mora, Bargain Peddler
+  'market-barn':  { kind: 'card', cardFilter: { rarity: 'uncommon' } },   // appleford — Trader Posy, Curio Dealer
+  'market-hall':  { kind: 'card', cardFilter: { cardType: 'upgrade' } },  // millhaven — Trader Nessa, Spellwright
 }
 
 export type ShopStockGrant =


### PR DESCRIPTION
## Summary

Tier 1 of the specialist trader rollout (epic #1814), built on the shared infra merged in #1813. Registers three existing town NPCs as filtered card traders — no new buildings or NPCs, just registry entries + physical shelf items:

- **gravemoor** — Merchant Mora relocates from `mourning-hall-reliquary` (a nested sub-room with no street door — not a viable shop entrance) to the existing empty, street-accessible `undertaker` building. Sells **common cards only** (Bargain Peddler).
- **appleford** — Trader Posy, already homed in `market-barn`, now sells **uncommon cards only** (Curio Dealer).
- **millhaven** — Trader Nessa, already fully scheduled day/night, now sells **upgrade-type cards only** (Spellwright), via her existing `market-hall` building.

Each town gets 3 new `shopArtSlot`/`buy` interactables inside the trader's interior, mirroring Ravenwatch's card-shop layout (tappable shelf items in addition to the NPC's flavor dialogue) — the same physical-purchase pattern from #1808–#1812, now filtered per-trader via the `SHOP_TRADER_REGISTRY` added in #1813.

Closes #1815, #1816, #1817.

## Test plan

- [x] `npx tsc --noEmit` passes with no errors
- [x] `npx vitest run` — 292 tests pass across 28 files (no regressions)
- [x] `npm run build` succeeds
- [x] Spot-checked `getTodaysShopItems()` for all 3 new building ids: `undertaker` → common-only, `market-barn` → uncommon-only, `market-hall` → upgrade-type-only
- [x] Confirmed no building-id collisions with any other town's buildings (`undertaker`, `market-barn`, `market-hall` are each unique across all `web/src/data/hub/*/config.json`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QnsGzNHipADhR2mtNLabxZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01QnsGzNHipADhR2mtNLabxZ)_