### PR TITLE
Tier 2 specialist traders: gearford, saltmereport, harrowfield, hollowmere, ironholdkeep

### DIFF
--- a/web/src/data/hub/gearford/config.json
+++ b/web/src/data/hub/gearford/config.json
@@ -2141,6 +2141,62 @@
         "tx": 2,
         "ty": 2
       }
+    },
+    {
+      "id": "engineer-torvald",
+      "name": "Engineer Torvald",
+      "sprite": "hub-npc-merchant",
+      "tx": 4,
+      "ty": 3,
+      "building": "tool-shop",
+      "dialogue": [
+        "Foundations, walls, towers — nothing stands without good bones under it.",
+        "Half of Gearford's collapsed twice over. I keep the plans for what worked.",
+        "You don't build a keep in a day. You build it in a thousand right decisions."
+      ],
+      "schedule": [
+        {
+          "startHour": 0,
+          "endHour": 7,
+          "activity": "sleep",
+          "location": { "type": "interior", "buildingId": "miners-inn-bunkrooms", "tx": 1, "ty": 2 }
+        },
+        {
+          "startHour": 7,
+          "endHour": 24,
+          "activity": "work",
+          "location": { "type": "interior", "buildingId": "tool-shop", "tx": 4, "ty": 3 }
+        }
+      ],
+      "homeBed": { "buildingId": "miners-inn-bunkrooms", "tx": 1, "ty": 2 }
+    },
+    {
+      "id": "sergeant-coldiron",
+      "name": "Sergeant Coldiron",
+      "sprite": "hub-npc-soldier",
+      "tx": 4,
+      "ty": 3,
+      "building": "gear-shop",
+      "dialogue": [
+        "Levies, veterans, the odd conscript who'd rather be anywhere else — I've fielded them all.",
+        "A war's won by whoever counts their troops correctly. I count carefully.",
+        "Gear's cheap. The people who wear it into a fight are what costs you."
+      ],
+      "schedule": [
+        {
+          "startHour": 0,
+          "endHour": 7,
+          "activity": "sleep",
+          "location": { "type": "interior", "buildingId": "miners-inn-bunkrooms", "tx": 3, "ty": 2 }
+        },
+        {
+          "startHour": 7,
+          "endHour": 24,
+          "activity": "work",
+          "location": { "type": "interior", "buildingId": "gear-shop", "tx": 4, "ty": 3 }
+        }
+      ],
+      "homeBed": { "buildingId": "miners-inn-bunkrooms", "tx": 3, "ty": 2 }
     }
   ],
   "interiors": {
@@ -3489,5 +3545,55 @@
       ],
       "exits": []
     }
-  }
+  },
+  "interactables": [
+    {
+      "id": "tool-shop-item-0",
+      "tx": 9,
+      "ty": 3,
+      "building": "tool-shop",
+      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 0 }],
+      "reactions": [{ "type": "buy", "slotIndex": 0 }]
+    },
+    {
+      "id": "tool-shop-item-1",
+      "tx": 9,
+      "ty": 4,
+      "building": "tool-shop",
+      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 1 }],
+      "reactions": [{ "type": "buy", "slotIndex": 1 }]
+    },
+    {
+      "id": "tool-shop-item-2",
+      "tx": 9,
+      "ty": 5,
+      "building": "tool-shop",
+      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 2 }],
+      "reactions": [{ "type": "buy", "slotIndex": 2 }]
+    },
+    {
+      "id": "gear-shop-item-0",
+      "tx": 9,
+      "ty": 3,
+      "building": "gear-shop",
+      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 0 }],
+      "reactions": [{ "type": "buy", "slotIndex": 0 }]
+    },
+    {
+      "id": "gear-shop-item-1",
+      "tx": 9,
+      "ty": 4,
+      "building": "gear-shop",
+      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 1 }],
+      "reactions": [{ "type": "buy", "slotIndex": 1 }]
+    },
+    {
+      "id": "gear-shop-item-2",
+      "tx": 9,
+      "ty": 5,
+      "building": "gear-shop",
+      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 2 }],
+      "reactions": [{ "type": "buy", "slotIndex": 2 }]
+    }
+  ]
 }

--- a/web/src/data/hub/harrowfield/config.json
+++ b/web/src/data/hub/harrowfield/config.json
@@ -2458,6 +2458,32 @@
       "exits": []
     }
   },
+  "interactables": [
+    {
+      "id": "market-shed-item-0",
+      "tx": 11,
+      "ty": 2,
+      "building": "market-shed",
+      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 0 }],
+      "reactions": [{ "type": "buy", "slotIndex": 0 }]
+    },
+    {
+      "id": "market-shed-item-1",
+      "tx": 11,
+      "ty": 3,
+      "building": "market-shed",
+      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 1 }],
+      "reactions": [{ "type": "buy", "slotIndex": 1 }]
+    },
+    {
+      "id": "market-shed-item-2",
+      "tx": 11,
+      "ty": 4,
+      "building": "market-shed",
+      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 2 }],
+      "reactions": [{ "type": "buy", "slotIndex": 2 }]
+    }
+  ],
   "festivalDecor": [
     {
       "festivalId": "harvest",

--- a/web/src/data/hub/hollowmere/config.json
+++ b/web/src/data/hub/hollowmere/config.json
@@ -1981,5 +1981,31 @@
       ],
       "exits": []
     }
-  }
+  },
+  "interactables": [
+    {
+      "id": "bonepile-curio-item-0",
+      "tx": 9,
+      "ty": 2,
+      "building": "bonepile-curio",
+      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 0 }],
+      "reactions": [{ "type": "buy", "slotIndex": 0 }]
+    },
+    {
+      "id": "bonepile-curio-item-1",
+      "tx": 9,
+      "ty": 3,
+      "building": "bonepile-curio",
+      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 1 }],
+      "reactions": [{ "type": "buy", "slotIndex": 1 }]
+    },
+    {
+      "id": "bonepile-curio-item-2",
+      "tx": 9,
+      "ty": 4,
+      "building": "bonepile-curio",
+      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 2 }],
+      "reactions": [{ "type": "buy", "slotIndex": 2 }]
+    }
+  ]
 }

--- a/web/src/data/hub/ironholdkeep/config.json
+++ b/web/src/data/hub/ironholdkeep/config.json
@@ -4479,5 +4479,31 @@
       ],
       "exits": []
     }
-  }
+  },
+  "interactables": [
+    {
+      "id": "quartermasters-store-item-0",
+      "tx": 9,
+      "ty": 2,
+      "building": "quartermasters-store",
+      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 0 }],
+      "reactions": [{ "type": "buy", "slotIndex": 0 }]
+    },
+    {
+      "id": "quartermasters-store-item-1",
+      "tx": 9,
+      "ty": 3,
+      "building": "quartermasters-store",
+      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 1 }],
+      "reactions": [{ "type": "buy", "slotIndex": 1 }]
+    },
+    {
+      "id": "quartermasters-store-item-2",
+      "tx": 9,
+      "ty": 4,
+      "building": "quartermasters-store",
+      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 2 }],
+      "reactions": [{ "type": "buy", "slotIndex": 2 }]
+    }
+  ]
 }

--- a/web/src/data/hub/saltmereport/config.json
+++ b/web/src/data/hub/saltmereport/config.json
@@ -2464,6 +2464,32 @@
       ]
     }
   },
+  "interactables": [
+    {
+      "id": "chandlers-item-0",
+      "tx": 8,
+      "ty": 2,
+      "building": "chandlers",
+      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 0 }],
+      "reactions": [{ "type": "buy", "slotIndex": 0 }]
+    },
+    {
+      "id": "chandlers-item-1",
+      "tx": 8,
+      "ty": 3,
+      "building": "chandlers",
+      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 1 }],
+      "reactions": [{ "type": "buy", "slotIndex": 1 }]
+    },
+    {
+      "id": "chandlers-item-2",
+      "tx": 8,
+      "ty": 4,
+      "building": "chandlers",
+      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 2 }],
+      "reactions": [{ "type": "buy", "slotIndex": 2 }]
+    }
+  ],
   "animals": [
     {
       "id": "dockside-cat-saltmere",

--- a/web/src/game/hub/shopStock.ts
+++ b/web/src/game/hub/shopStock.ts
@@ -37,6 +37,14 @@ export const SHOP_TRADER_REGISTRY: Record<string, ShopTraderConfig> = {
   'undertaker':   { kind: 'card', cardFilter: { rarity: 'common' } },     // gravemoor — Merchant Mora, Bargain Peddler
   'market-barn':  { kind: 'card', cardFilter: { rarity: 'uncommon' } },   // appleford — Trader Posy, Curio Dealer
   'market-hall':  { kind: 'card', cardFilter: { cardType: 'upgrade' } },  // millhaven — Trader Nessa, Spellwright
+
+  // Tier 2 specialist traders (see epic #1814)
+  'tool-shop':            { kind: 'card', cardFilter: { cardType: 'structure' } },            // gearford — Engineer Torvald, Structural Engineer
+  'gear-shop':            { kind: 'card', cardFilter: { cardType: 'unit' } },                 // gearford — Sergeant Coldiron, Warmonger
+  'chandlers':            { kind: 'card', cardFilter: { rarity: 'rare' } },                   // saltmereport — Chandler Beaumont, Relic Hunter
+  'market-shed':          { kind: 'card', cardFilter: { rarity: 'common' } },                 // harrowfield — Pedlar Quill, Bargain Peddler
+  'bonepile-curio':       { kind: 'card', cardFilter: { rarities: ['epic', 'legendary'] } },  // hollowmere — Snægg the Collector, Vaultkeeper
+  'quartermasters-store': { kind: 'card', cardFilter: { cardType: 'unit' } },                 // ironholdkeep — Quartermaster Sella, Warmonger
 }
 
 export type ShopStockGrant =


### PR DESCRIPTION
## Summary

Tier 2 of the specialist trader rollout (epic #1814), built on the shared infra from #1813 and following Tier 1 (#1827). Five towns, each getting a filtered card trader in a previously-empty (or currently-generic) shop building:

- **gearford** — two brand-new NPCs: **Engineer Torvald** in `tool-shop` (sells **structure** cards only) and **Sergeant Coldiron** in `gear-shop` (sells **unit** cards only). Both have a full day/night schedule, sleeping in the confirmed-available `miners-inn-bunkrooms` (4 free beds there, 2 now used).
- **saltmereport** — **Chandler Beaumont** (existing NPC, `chandlers`) now sells **rare** cards only (Relic Hunter). His original dialogue/quest untouched.
- **harrowfield** — **Pedlar Quill** (existing NPC, `market-shed`) now sells **common** cards only (Bargain Peddler). No inn in this town, so single-shift only, matching his existing behavior.
- **hollowmere** — **Snægg the Collector** (existing NPC, `bonepile-curio`) now sells **epic/legendary** cards only (Vaultkeeper) — his "everything has a story and a price" flavor lines up well.
- **ironholdkeep** — **Quartermaster Sella** (existing NPC, `quartermasters-store`, already fully scheduled) now sells **unit** cards only (Warmonger).

Each building gets 3 new `shopArtSlot`/`buy` interactables placed in a column of each interior not used by existing decor, mirroring the pattern from #1808–#1812/#1827.

Closes #1818, #1819, #1820, #1821, #1822.

## Test plan

- [x] `npx tsc --noEmit` passes with no errors
- [x] `npx vitest run` — 292 tests pass across 28 files (no regressions)
- [x] `npm run build` succeeds
- [x] Spot-checked `getTodaysShopItems()` for all 6 new/updated building ids — each returns only cards matching its filter (structure/unit/rare/common/epic+legendary/unit respectively)
- [x] Loaded all 5 touched towns' configs through `createHubLocationData` to confirm they parse cleanly with the new NPCs/interactables
- [x] Confirmed no building-id collisions with any other town's buildings across all `web/src/data/hub/*/config.json`
- [x] Confirmed the new gearford NPCs' bunkroom beds don't collide with any other NPC's `homeBed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QnsGzNHipADhR2mtNLabxZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01QnsGzNHipADhR2mtNLabxZ)_