### PR TITLE
Capitalcity specialist traders: Vaultkeeper and Curio Dealer

### DIFF
--- a/web/src/data/hub/capitalcity/config.json
+++ b/web/src/data/hub/capitalcity/config.json
@@ -3772,6 +3772,56 @@
       ]
     }
   },
+  "interactables": [
+    {
+      "id": "grand-bank-item-0",
+      "tx": 11,
+      "ty": 3,
+      "building": "grand-bank",
+      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 0 }],
+      "reactions": [{ "type": "buy", "slotIndex": 0 }]
+    },
+    {
+      "id": "grand-bank-item-1",
+      "tx": 11,
+      "ty": 4,
+      "building": "grand-bank",
+      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 1 }],
+      "reactions": [{ "type": "buy", "slotIndex": 1 }]
+    },
+    {
+      "id": "grand-bank-item-2",
+      "tx": 11,
+      "ty": 5,
+      "building": "grand-bank",
+      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 2 }],
+      "reactions": [{ "type": "buy", "slotIndex": 2 }]
+    },
+    {
+      "id": "jeweller-item-0",
+      "tx": 11,
+      "ty": 3,
+      "building": "jeweller",
+      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 0 }],
+      "reactions": [{ "type": "buy", "slotIndex": 0 }]
+    },
+    {
+      "id": "jeweller-item-1",
+      "tx": 11,
+      "ty": 4,
+      "building": "jeweller",
+      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 1 }],
+      "reactions": [{ "type": "buy", "slotIndex": 1 }]
+    },
+    {
+      "id": "jeweller-item-2",
+      "tx": 11,
+      "ty": 5,
+      "building": "jeweller",
+      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 2 }],
+      "reactions": [{ "type": "buy", "slotIndex": 2 }]
+    }
+  ],
   "ambientNpcSprites": [
     "hub-npc-merchant",
     "hub-npc-scholar",

--- a/web/src/game/hub/shopStock.ts
+++ b/web/src/game/hub/shopStock.ts
@@ -45,6 +45,10 @@ export const SHOP_TRADER_REGISTRY: Record<string, ShopTraderConfig> = {
   'market-shed':          { kind: 'card', cardFilter: { rarity: 'common' } },                 // harrowfield — Pedlar Quill, Bargain Peddler
   'bonepile-curio':       { kind: 'card', cardFilter: { rarities: ['epic', 'legendary'] } },  // hollowmere — Snægg the Collector, Vaultkeeper
   'quartermasters-store': { kind: 'card', cardFilter: { cardType: 'unit' } },                 // ironholdkeep — Quartermaster Sella, Warmonger
+
+  // Tier 3 specialist traders (see epic #1814)
+  'grand-bank': { kind: 'card', cardFilter: { rarities: ['epic', 'legendary'] } },  // capitalcity — Banker Sterling, Vaultkeeper
+  'jeweller':   { kind: 'card', cardFilter: { rarity: 'uncommon' } },               // capitalcity — Jeweller Isolde, Curio Dealer
 }
 
 export type ShopStockGrant =


### PR DESCRIPTION
## Summary

First half of Tier 3 of the specialist trader rollout (epic #1814), built on the shared infra from #1813 and following Tiers 1–2 (#1827, #1828). Capitalcity needed no new building placement — both target buildings already had existing, untouched NPCs:

- **Banker Sterling** (`grand-bank`) now sells **epic/legendary** cards only (Vaultkeeper) — "the realm's treasury" flavor.
- **Jeweller Isolde** (`jeweller`) now sells **uncommon** cards only (Curio Dealer), the optional second trader called for in the plan.

The 3 existing Crownhaven shops (card-vendor, augment-vendor, supplies-vendor) are untouched — new registry entries + physical shelf items only, no regression risk to already-shipped NPCs.

Closes #1823. royalpalace and dreadspirecitadel (the two towns needing genuinely new buildings) will follow as separate PRs.

## Test plan

- [x] `npx tsc --noEmit` passes with no errors
- [x] `npx vitest run` — 292 tests pass across 28 files (no regressions)
- [x] `npm run build` succeeds
- [x] Spot-checked `getTodaysShopItems('grand-bank')` → epic/legendary only, `getTodaysShopItems('jeweller')` → uncommon only
- [x] Loaded the capitalcity config through `createHubLocationData` to confirm it parses cleanly with the new interactables

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QnsGzNHipADhR2mtNLabxZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01QnsGzNHipADhR2mtNLabxZ)_