### PR TITLE
Royalpalace and dreadspirecitadel specialist traders (new buildings)

### DIFF
--- a/web/src/data/hub/dreadspirecitadel/config.json
+++ b/web/src/data/hub/dreadspirecitadel/config.json
@@ -109,6 +109,14 @@
         18,
         29
       ]
+    },
+    {
+      "rect": [
+        29,
+        33,
+        31,
+        33
+      ]
     }
   ],
   "buildings": [
@@ -224,6 +232,25 @@
           "tx": 3,
           "ty": 1,
           "buildingId": "gatehouse"
+        }
+      ]
+    },
+    {
+      "id": "spellwright-den",
+      "upgradeKind": "shop",
+      "rect": [
+        28,
+        26,
+        32,
+        32
+      ],
+      "wall": "darkStone",
+      "roof": "greySlateRoof",
+      "doors": [
+        {
+          "tx": 2,
+          "ty": 1,
+          "buildingId": "spellwright-den"
         }
       ]
     }
@@ -732,6 +759,19 @@
             "ty": 4
           }
         }
+      ]
+    },
+    {
+      "id": "grimoire-peddler-ashka",
+      "name": "Ashka the Grimoire-Peddler",
+      "sprite": "hub-npc-warlock",
+      "tx": 2,
+      "ty": 3,
+      "building": "spellwright-den",
+      "dialogue": [
+        "Every hex has a price, and every price has a hex attached. Fair trade, I call it.",
+        "The towers hoard their secrets. I sell mine — cheaper, and with fewer curses attached. Usually.",
+        "One spell, properly cast, is worth a hundred swords poorly swung."
       ]
     }
   ],
@@ -1910,8 +1950,64 @@
           "label": "Up to the Cells"
         }
       ]
+    },
+    "spellwright-den": {
+      "name": "The Spellwright's Den",
+      "width": 8,
+      "height": 7,
+      "floorTileId": "stoneFloor",
+      "wallTileId": "darkStone",
+      "decor": [
+        {
+          "tx": 1,
+          "ty": 1,
+          "bundleID": "bookshelf"
+        },
+        {
+          "tx": 3,
+          "ty": 1,
+          "bundleID": "candelabra"
+        },
+        {
+          "tx": 2,
+          "ty": 4,
+          "tileId": "blackopenBook"
+        },
+        {
+          "tx": 4,
+          "ty": 4,
+          "tileId": "summoningCircle"
+        }
+      ],
+      "exits": []
     }
   },
+  "interactables": [
+    {
+      "id": "spellwright-den-item-0",
+      "tx": 7,
+      "ty": 2,
+      "building": "spellwright-den",
+      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 0 }],
+      "reactions": [{ "type": "buy", "slotIndex": 0 }]
+    },
+    {
+      "id": "spellwright-den-item-1",
+      "tx": 7,
+      "ty": 3,
+      "building": "spellwright-den",
+      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 1 }],
+      "reactions": [{ "type": "buy", "slotIndex": 1 }]
+    },
+    {
+      "id": "spellwright-den-item-2",
+      "tx": 7,
+      "ty": 4,
+      "building": "spellwright-den",
+      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 2 }],
+      "reactions": [{ "type": "buy", "slotIndex": 2 }]
+    }
+  ],
   "animals": [
     {
       "id": "citadel-raven",

--- a/web/src/data/hub/royalpalace/config.json
+++ b/web/src/data/hub/royalpalace/config.json
@@ -981,6 +981,25 @@
           "minLevel": 3
         }
       ]
+    },
+    {
+      "id": "treasury-annex",
+      "upgradeKind": "shop",
+      "rect": [
+        25,
+        28,
+        32,
+        35
+      ],
+      "wall": "reinforcedStone",
+      "roof": "greySlateRoof",
+      "doors": [
+        {
+          "tx": 4,
+          "ty": 1,
+          "buildingId": "treasury-annex"
+        }
+      ]
     }
   ],
   "exteriorDecor": [
@@ -2506,6 +2525,19 @@
       "dialogue": [
         "Hello!"
       ]
+    },
+    {
+      "id": "master-of-coin-aldric",
+      "name": "Master of Coin Aldric",
+      "sprite": "hub-npc-merchant",
+      "tx": 4,
+      "ty": 3,
+      "building": "treasury-annex",
+      "dialogue": [
+        "The crown's finest — kept safe in the annex until a worthy buyer comes along.",
+        "Every coin in this room has a ledger entry. Every sale, too.",
+        "The vault proper is for the king's treasures. This room is for yours."
+      ]
     }
   ],
   "interiors": {
@@ -3651,6 +3683,51 @@
         }
       ]
     },
+    "treasury-annex": {
+      "name": "The Treasury Annex",
+      "width": 10,
+      "height": 8,
+      "floorTileId": "goldSmallTileFloor",
+      "wallTileId": "reinforcedStone",
+      "decor": [
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "chest"
+        },
+        {
+          "tx": 2,
+          "ty": 1,
+          "tileId": "strongChest"
+        },
+        {
+          "tx": 7,
+          "ty": 1,
+          "bundleID": "candelabra"
+        },
+        {
+          "tx": 4,
+          "ty": 3,
+          "tileId": "deskTop"
+        },
+        {
+          "tx": 4,
+          "ty": 4,
+          "tileId": "stool"
+        },
+        {
+          "tx": 1,
+          "ty": 5,
+          "tileId": "pileOfGoldCoins"
+        },
+        {
+          "tx": 7,
+          "ty": 5,
+          "tileId": "pileOfSilverCoins"
+        }
+      ],
+      "exits": []
+    },
     "treasury-vault-inner": {
       "name": "The Inner Vault",
       "width": 10,
@@ -4201,6 +4278,30 @@
           "tileId": "messageBoardBottomRight"
         }
       ]
+    },
+    {
+      "id": "treasury-annex-item-0",
+      "tx": 9,
+      "ty": 2,
+      "building": "treasury-annex",
+      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 0 }],
+      "reactions": [{ "type": "buy", "slotIndex": 0 }]
+    },
+    {
+      "id": "treasury-annex-item-1",
+      "tx": 9,
+      "ty": 3,
+      "building": "treasury-annex",
+      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 1 }],
+      "reactions": [{ "type": "buy", "slotIndex": 1 }]
+    },
+    {
+      "id": "treasury-annex-item-2",
+      "tx": 9,
+      "ty": 4,
+      "building": "treasury-annex",
+      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 2 }],
+      "reactions": [{ "type": "buy", "slotIndex": 2 }]
     }
   ],
   "chickenZones": [

--- a/web/src/game/hub/shopStock.ts
+++ b/web/src/game/hub/shopStock.ts
@@ -47,8 +47,10 @@ export const SHOP_TRADER_REGISTRY: Record<string, ShopTraderConfig> = {
   'quartermasters-store': { kind: 'card', cardFilter: { cardType: 'unit' } },                 // ironholdkeep — Quartermaster Sella, Warmonger
 
   // Tier 3 specialist traders (see epic #1814)
-  'grand-bank': { kind: 'card', cardFilter: { rarities: ['epic', 'legendary'] } },  // capitalcity — Banker Sterling, Vaultkeeper
-  'jeweller':   { kind: 'card', cardFilter: { rarity: 'uncommon' } },               // capitalcity — Jeweller Isolde, Curio Dealer
+  'grand-bank':      { kind: 'card', cardFilter: { rarities: ['epic', 'legendary'] } },  // capitalcity — Banker Sterling, Vaultkeeper
+  'jeweller':        { kind: 'card', cardFilter: { rarity: 'uncommon' } },               // capitalcity — Jeweller Isolde, Curio Dealer
+  'treasury-annex':  { kind: 'card', cardFilter: { rarities: ['epic', 'legendary'] } },  // royalpalace — Master of Coin Aldric, Vaultkeeper
+  'spellwright-den': { kind: 'card', cardFilter: { cardType: 'upgrade' } },              // dreadspirecitadel — Ashka the Grimoire-Peddler, Spellwright
 }
 
 export type ShopStockGrant =


### PR DESCRIPTION
## Summary

Second (and final town-content) half of Tier 3 of the specialist trader rollout (epic #1814), following #1827/#1828/#1829. Unlike every earlier PR in this rollout, neither town had an existing empty shop building, so this adds a genuinely new building to each:

- **royalpalace** — new `treasury-annex` building (rect `[25,28,32,35]`, 8×8), home to new NPC **Master of Coin Aldric**, selling **epic/legendary** cards only (Vaultkeeper — "royal treasury" flavor). Its door resolves to `(29,36)`, landing on the town's **existing** street — no new street tiles needed. Placed in the empty gap between `servants-quarters` and `royal-kitchens`.
- **dreadspirecitadel** — new `spellwright-den` building (rect `[28,26,32,32]`, 5×7), home to new NPC **Ashka the Grimoire-Peddler**, selling **upgrade-type** cards only (Spellwright — "dark ritual" flavor). No existing street reaches this spot, so a small new street stub (`[29,33,31,33]`) was added for its door — the same pattern every other building in this town already uses (each has its own dedicated door-facing stub).

Both new buildings follow the exact door-to-street convention already used by every building in both towns: a door `{tx, ty}` resolves to the absolute tile `[rect[0]+tx, rect[3]+ty]` — I computed and verified all 17 pre-existing doors in both towns against this rule before placing the 2 new ones, then verified the new placements are collision-free against every existing building rect, street rect/tile, and decor entry in both files (both manually and via a small script, given new map geometry carries more risk than the registry-only changes in earlier tiers).

Closes #1824, #1825. Only `thornwoodcamp` remains in the epic (#1814) — no new engineering needed there per the plan (fixed layout, flavor-only for now).

## Test plan

- [x] `npx tsc --noEmit` passes with no errors
- [x] `npx vitest run` — 292 tests pass across 28 files (no regressions)
- [x] `npm run build` succeeds
- [x] Programmatically verified both new building doors resolve to a tile covered by a street entry in their town's `streets` array
- [x] Programmatically verified both new building rects have zero overlap with any other building rect, street rect, or `exteriorDecor`/`levelDecor` entry in their respective town files
- [x] Spot-checked `getTodaysShopItems('treasury-annex')` → epic/legendary only, `getTodaysShopItems('spellwright-den')` → upgrade-type only
- [x] Loaded both towns' configs through `createHubLocationData` to confirm the new NPCs and interactables parse cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QnsGzNHipADhR2mtNLabxZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01QnsGzNHipADhR2mtNLabxZ)_