### PR TITLE
Add pet adoption & follower companion

### DIFF
--- a/docs/hubworld.md
+++ b/docs/hubworld.md
@@ -29,6 +29,8 @@
 | `web/src/components/hub/HubWorld.tsx` | React orchestrator — quest flow, dialogue, state | — |
 | `web/src/game/hub/journal.ts` | Discovery store for the Town Journal — met NPCs, seen animal species/variants, seen named areas (localStorage) — see §15 | `recordNpcMet`, `hasMetNpc`, `getMetNpcIds`, `recordAnimalSeen`, `hasSeenAnimal`, `getSeenAnimalVariants`, `getSeenAnimalTypes`, `recordAreaSeen`, `hasSeenArea`, `getSeenAreaKeys` |
 | `web/src/components/hub/TownJournal.tsx` | Journal UI — Animals / People / Places tabs with completion % — see §15 | `TownJournal` |
+| `web/src/game/hub/pet.ts` | Player's adopted follower-pet persistence (localStorage) — see §8 | `getActivePet`, `hasActivePet`, `adoptPet`, `renamePet`, `dismissPet` |
+| `web/src/components/hub/PetModal.tsx` | Pet adoption / rename / swap / dismiss UI — see §8 | `PetModal` |
 
 ---
 
@@ -276,7 +278,7 @@ bounds, else a single tile.
 | Type | Fields | Behaviour |
 |---|---|---|
 | `dialogue` | `speakerName?`, `text` (string or string[]) | Shows the dialogue modal. A string[] cycles one entry per tap. |
-| `screen` | `screen` | Opens a screen via the same routing as NPC `screen` (e.g. `news`, `shop`, `interior:<id>`, minigame ids). |
+| `screen` | `screen` | Opens a screen via the same routing as NPC `screen` (e.g. `news`, `shop`, `interior:<id>`, `bounty-board`, `town-upgrades`, `adopt-pet` — see §8, minigame ids). |
 | `giveItem` | `collectible?`, `consumables?`, `crystals?`, `message?`, `alreadyGrantedText?` | One-time grant (persisted). Re-taps show `alreadyGrantedText` if set. Reward shapes match treasure rewards. |
 | `quest` | `questId`, `speakerName?` | Offers the quest with Accept / Not now. The quest's `giverNpcId` in `questDefs.json` **must equal the interactable's id**. Honours prerequisites and the 2-active-quest cap. |
 | `move` | `to: {tx, ty}`, `message?` | Moves the owned decor to the target tile, live and persisted across reloads. Requires owned `decor`. |
@@ -655,6 +657,39 @@ A `!`/`?` quest indicator floats above placed animals that have
 3. Add any `collect`-step `pickupItems` (tile constants from `baseChipIndex.ts`).
 4. Run `npm run test` and `npm run build`; verify the `!` shows, the quest
    offers, pickups collect, and tapping the animal completes it.
+
+### Player's Follower Pet
+
+A single, global (not per-town), dog-only adoptable pet follows the player's
+avatar around every town, reusing the existing `follow-owner` dog state
+machine above with zero changes to its movement/pathing logic.
+
+- **Store** — `web/src/game/hub/pet.ts` (key `jarv_hub_pet`): holds one
+  `PetRecord { type, variant, name }` or `null`. `adoptPet` replaces any
+  existing pet (a "swap"); `renamePet`/`dismissPet` operate on the active
+  pet. `type` is stored as a plain string for future extension, but only
+  `'dog'` is offered today.
+- **Runtime mechanism** — `hubAnimals.ts` exports two sentinel ids:
+  `PLAYER_OWNER_ID` and `PLAYER_PET_ANIMAL_ID`. `HubTownCanvas.tsx` pushes
+  `{ id: PLAYER_OWNER_ID, x: avatar.x, y: avatar.y }` into the array
+  `getNpcPositions()` returns every tick, so a dog whose `ownerId` is
+  `PLAYER_OWNER_ID` follows the live avatar through the same `dogIdle`/
+  `followToward` logic ambient dogs already use to follow a random NPC.
+  `AnimalSystem.spawnFollowerPet(variant, tx, ty)` spawns (or re-spawns) the
+  pet near the avatar's start tile on every town mount if `getActivePet()`
+  returns non-null; `AnimalSystem.removeAnimal(id)` is the generic
+  best-effort removal used to despawn it.
+- **Ephemeral sprite, persisted record** — the pet's sprite is a fresh
+  runtime-only animal (not listed in any town's static `animals` config),
+  respawned each time a `HubTownCanvas` mounts. Only the `jarv_hub_pet`
+  localStorage record survives a reload, identical to how every other
+  animal in the game is re-created per session.
+- **UI** — `PetModal.tsx`, opened either via the `adopt-pet` screen reaction
+  on a shelter interactable (see §7), the 🐾 toolbar button (shown only
+  while a pet is active), or by tapping the live pet sprite in-world
+  (`handleAnimalTap` special-cases `PLAYER_PET_ANIMAL_ID` in `HubWorld.tsx`).
+  Offers adopt (variant + name), rename, dismiss, and swap (confirms before
+  replacing an existing pet).
 
 ---
 

--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -21,7 +21,8 @@ import { createChunkCuller } from '../../utils/chunkCull'
 import { CommanderState } from '../../game/commander'
 import rollbar from '../../rollbar'
 import { HubInteractable, HubInteriorExit, HubLocationBundle, HubNpc, HubQuestBundle, HubStreetGroup, NpcScheduleEntry, isVisibleAtLevel } from '../../data/hub/loader'
-import { createAnimalSystem, AnimalSystem, GlowSource } from './hubAnimals'
+import { createAnimalSystem, AnimalSystem, GlowSource, PLAYER_OWNER_ID } from './hubAnimals'
+import { getActivePet } from '../../game/hub/pet'
 import type { AnimalType } from '../../game/hub/animals'
 import { createWeatherSystem } from './hubWeather'
 import { resolveWeather } from '../../game/hub/weather'
@@ -2410,6 +2411,7 @@ export function HubTownCanvas({
       getAvatarPx: () => ({ x: avatar?.x ?? COURTYARD_PX.x, y: avatar?.y ?? COURTYARD_PX.y }),
       getNpcPositions: () => {
         const out: { id?: string; x: number; y: number }[] = []
+        out.push({ id: PLAYER_OWNER_ID, x: avatar?.x ?? COURTYARD_PX.x, y: avatar?.y ?? COURTYARD_PX.y })
         for (const [id, container] of namedNpcContainers) {
           if (!container.visible) continue
           const s = container.children[0] as PIXI.Sprite | undefined
@@ -2436,6 +2438,15 @@ export function HubTownCanvas({
       },
     })
     getAnimalsInBuildingFn = animalSystem.getAnimalsInBuilding
+
+    // Spawn the player's adopted follower pet (if any) near their spawn tile.
+    const activePet = getActivePet()
+    if (activePet) {
+      let [ptx, pty] = [AVATAR_START.tx, AVATAR_START.ty + 1]
+      if (animalIsSolid(ptx, pty)) [ptx, pty] = [AVATAR_START.tx + 1, AVATAR_START.ty]
+      if (animalIsSolid(ptx, pty)) [ptx, pty] = [AVATAR_START.tx, AVATAR_START.ty]
+      animalSystem.spawnFollowerPet(activePet.variant, ptx, pty)
+    }
 
     // ── Weather overlay (screen-space, above the world incl. night dimming) ────
     const weatherLayer = new PIXI.Container()

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -32,6 +32,9 @@ import { addCollectible, addConsumable, getCollectibles } from '../../game/itemS
 import { QuestsModal } from './QuestsModal'
 import { BountyBoardModal } from './BountyBoardModal'
 import { hasUnclaimedBounties, getPendingBountyReport, getPendingBountyCollect, advanceBountyStep, getActiveBountyStep } from '../../game/hub/bounties'
+import { PetModal } from './PetModal'
+import { getActivePet } from '../../game/hub/pet'
+import { PLAYER_PET_ANIMAL_ID } from './hubAnimals'
 import { TownDirectory } from './TownDirectory'
 import { TownJournal } from './TownJournal'
 import { HubTownUpgrades, type UpgradeRow } from './HubTownUpgrades'
@@ -181,6 +184,7 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onEndless, onWorldMap
   const [pickedUpIds,    setPickedUpIds]    = useState<Set<string>>(() => getPickedUpIds())
   const [questsOpen,          setQuestsOpen]          = useState(false)
   const [bountyBoardOpen,     setBountyBoardOpen]     = useState(false)
+  const [petModalOpen,        setPetModalOpen]        = useState(false)
   const [directoryOpen,       setDirectoryOpen]       = useState(false)
   const [journalOpen,         setJournalOpen]         = useState(false)
   const [upgradesOpen,        setUpgradesOpen]        = useState(false)
@@ -508,6 +512,7 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onEndless, onWorldMap
     }
     if (screen === 'town-upgrades') { setUpgradesOpen(true); return }
     if (screen === 'bounty-board') { setBountyBoardOpen(true); return }
+    if (screen === 'adopt-pet') { setPetModalOpen(true); return }
     if (screen === 'worldmap') { onWorldMap?.(); return }
     if (screen === 'campaign') { onCampaign?.(); return }
     if (screen === 'endless') { onEndless?.(); return }
@@ -1007,6 +1012,7 @@ function hasOfferableQuest(giverId: string): boolean {
 
   // Placed/quest animals route through the same handler as NPCs.
   const handleAnimalTap = useCallback((animalId: string) => {
+    if (animalId === PLAYER_PET_ANIMAL_ID) { setPetModalOpen(true); return }
     const a = locationData.HUB_ANIMALS.find(an => an.id === animalId)
     const line = a?.dialogue && a.dialogue.length > 0 ? a.dialogue[0] : ''
     handleNpcTap(line, animalId)
@@ -1184,6 +1190,7 @@ function hasOfferableQuest(giverId: string): boolean {
         <ToolbarButton icon="🧭" title="Where is…?" onClick={() => setDirectoryOpen(true)} />
         <ToolbarButton icon="📖" title="Journal" onClick={() => setJournalOpen(true)} />
         <ToolbarButton icon="🏗️" title="Town Upgrades" onClick={() => setUpgradesOpen(true)} />
+        {getActivePet() && <ToolbarButton icon="🐾" title="My Pet" onClick={() => setPetModalOpen(true)} />}
         <ToolbarButton icon="🗺" title="World Map" onClick={() => onWorldMap?.()}  disabled={getQuestState('thorin-the-last-watch').status !== 'completed'} />
 
         <ToolbarSpacer/>
@@ -1271,6 +1278,7 @@ function hasOfferableQuest(giverId: string): boolean {
 
         {questsOpen && <QuestsModal onClose={() => setQuestsOpen(false)} onAbandon={handleQuestAbandon} questDefs={questDefs} resolveNpcName={getNpcDisplayName}/>}
         {bountyBoardOpen && <BountyBoardModal onClose={() => setBountyBoardOpen(false)} resolveNpcName={getNpcDisplayName}/>}
+        {petModalOpen && <PetModal onClose={() => setPetModalOpen(false)} />}
         {directoryOpen && <TownDirectory onClose={() => setDirectoryOpen(false)} locationData={locationData} pinnedNpcId={pinnedNpcId} onTogglePin={togglePinnedNpc} onShowRelationship={setRelationshipNpcId} />}
         {journalOpen && <TownJournal onClose={() => setJournalOpen(false)} locationData={locationData} />}
         {upgradesOpen && <HubTownUpgrades onClose={() => setUpgradesOpen(false)} townName={town} reputation={getTownReputation(town)} crystals={loadCrystals()} rows={upgradeRows} onUpgrade={handleUpgrade} tributeAmount={tributeAmount(town)} tributeAvailable={tributeAvailable(town)} onCollectTribute={handleCollectTribute} />}

--- a/web/src/components/hub/PetModal.stories.tsx
+++ b/web/src/components/hub/PetModal.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { PetModal } from './PetModal'
+import { adoptPet } from '../../game/hub/pet'
+
+const meta = {
+  component: PetModal,
+  parameters: { layout: 'fullscreen' },
+  decorators: [
+    (Story) => (
+      <div className="game-container">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof PetModal>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const NoPet: Story = {
+  args: {
+    onClose: () => {},
+  },
+  decorators: [
+    (Story) => {
+      localStorage.removeItem('jarv_hub_pet')
+      return <Story />
+    },
+  ],
+}
+
+export const WithActivePet: Story = {
+  args: {
+    onClose: () => {},
+  },
+  decorators: [
+    (Story) => {
+      localStorage.removeItem('jarv_hub_pet')
+      adoptPet('dog', 'golden', 'Rex')
+      return <Story />
+    },
+  ],
+}

--- a/web/src/components/hub/PetModal.tsx
+++ b/web/src/components/hub/PetModal.tsx
@@ -1,0 +1,125 @@
+import React, { useState } from 'react'
+import { ModalBackdrop } from '../ui/ModalBackdrop'
+import { ConfirmModal } from '../modals/ConfirmModal'
+import { getActivePet, adoptPet, renamePet, dismissPet } from '../../game/hub/pet'
+import { ANIMAL_SPECS } from '../../game/hub/animals'
+
+interface Props {
+  onClose: () => void
+}
+
+const DOG_VARIANTS = Object.keys(ANIMAL_SPECS.dog.palette)
+
+function PickerBody({ onAdopt, submitLabel }: { onAdopt: (variant: string, name: string) => void; submitLabel: string }) {
+  const [variant, setVariant] = useState(DOG_VARIANTS[0])
+  const [name, setName] = useState('')
+
+  return (
+    <>
+      <div className="pet-modal__section-label">Choose a companion</div>
+      <div className="pet-modal__swatches">
+        {DOG_VARIANTS.map(v => (
+          <button
+            key={v}
+            className={`pet-modal__swatch${v === variant ? ' pet-modal__swatch--selected' : ''}`}
+            style={{ backgroundColor: `#${ANIMAL_SPECS.dog.palette[v].toString(16).padStart(6, '0')}` }}
+            title={v}
+            onClick={() => setVariant(v)}
+          />
+        ))}
+      </div>
+      <input
+        className="pet-modal__name-input"
+        placeholder="Name your pup"
+        value={name}
+        maxLength={24}
+        onChange={e => setName(e.target.value)}
+      />
+      <button className="action-btn action-btn--gold" onClick={() => onAdopt(variant, name)}>{submitLabel}</button>
+    </>
+  )
+}
+
+export function PetModal({ onClose }: Props) {
+  const [, setTick] = useState(0)
+  const refresh = () => setTick(t => t + 1)
+  const [renameValue, setRenameValue] = useState<string | null>(null)
+  const [swapping, setSwapping] = useState(false)
+  const [confirmSwap, setConfirmSwap] = useState<{ variant: string; name: string } | null>(null)
+  const [confirmDismiss, setConfirmDismiss] = useState(false)
+
+  const pet = getActivePet()
+
+  if (confirmSwap) {
+    return (
+      <ConfirmModal
+        title="Adopt a new companion?"
+        body={`Adopting ${confirmSwap.name} will mean saying goodbye to ${pet?.name ?? 'your current pet'}.`}
+        confirmLabel="Adopt"
+        onConfirm={() => { adoptPet('dog', confirmSwap.variant, confirmSwap.name); setConfirmSwap(null); setSwapping(false); refresh() }}
+        onCancel={() => setConfirmSwap(null)}
+      />
+    )
+  }
+
+  if (confirmDismiss) {
+    return (
+      <ConfirmModal
+        title="Dismiss your pet?"
+        body={`${pet?.name ?? 'Your pet'} will no longer follow you around town.`}
+        confirmLabel="Dismiss"
+        onConfirm={() => { dismissPet(); setConfirmDismiss(false); refresh() }}
+        onCancel={() => setConfirmDismiss(false)}
+      />
+    )
+  }
+
+  return (
+    <ModalBackdrop onClose={onClose}>
+      <div className="pet-modal">
+        <div className="pet-modal__header">
+          <span>🐾 {pet ? 'My Pet' : 'Pet Shelter'}</span>
+          <button className="pet-modal__close" onClick={onClose}>✕</button>
+        </div>
+
+        {!pet && (
+          <PickerBody submitLabel="Adopt" onAdopt={(variant, name) => { adoptPet('dog', variant, name); refresh() }} />
+        )}
+
+        {pet && !swapping && (
+          <>
+            <div className="pet-modal__current">
+              <span
+                className="pet-modal__current-swatch"
+                style={{ backgroundColor: `#${(ANIMAL_SPECS.dog.palette[pet.variant] ?? 0x8b5a2b).toString(16).padStart(6, '0')}` }}
+              />
+              <span className="pet-modal__current-name">{pet.name}</span>
+            </div>
+            <input
+              className="pet-modal__name-input"
+              placeholder="Rename your pup"
+              value={renameValue ?? pet.name}
+              maxLength={24}
+              onChange={e => setRenameValue(e.target.value)}
+            />
+            <button
+              className="action-btn"
+              onClick={() => { if (renameValue != null) renamePet(renameValue); setRenameValue(null); refresh() }}
+            >Save Name</button>
+            <div className="pet-modal__actions-row">
+              <button className="action-btn" onClick={() => setSwapping(true)}>Adopt a Different Dog</button>
+              <button className="action-btn action-btn--danger" onClick={() => setConfirmDismiss(true)}>Dismiss Pet</button>
+            </div>
+          </>
+        )}
+
+        {pet && swapping && (
+          <PickerBody
+            submitLabel="Adopt"
+            onAdopt={(variant, name) => setConfirmSwap({ variant, name })}
+          />
+        )}
+      </div>
+    </ModalBackdrop>
+  )
+}

--- a/web/src/components/hub/hubAnimals.ts
+++ b/web/src/components/hub/hubAnimals.ts
@@ -126,12 +126,23 @@ export interface AnimalSystemOptions {
 /** A point light the night overlay should carve into the darkness. */
 export interface GlowSource { x: number; y: number; radius: number; pulse: boolean }
 
+// Sentinel ids for the player's adopted follower pet (see pet.ts / PetModal.tsx).
+// PLAYER_OWNER_ID is injected into getNpcPositions() by HubTownCanvas so the
+// existing follow-owner dog behaviour below "just works" for the player, with
+// no changes to the state machine itself.
+export const PLAYER_OWNER_ID = '__player__'
+export const PLAYER_PET_ANIMAL_ID = '__player-pet__'
+
 export interface AnimalSystem {
   tick: (deltaMS: number) => void
   /** Animals currently denned inside the given building (for interior render). */
   getAnimalsInBuilding: (buildingId: string) => { type: AnimalType; tint: number }[]
   /** Night light sources from animals (fireflies) for the night overlay. */
   getGlowSources: () => GlowSource[]
+  /** Spawns (or re-spawns) the player's follower pet near (tx,ty). */
+  spawnFollowerPet: (variant: string, tx: number, ty: number) => void
+  /** Best-effort removal of an animal by id. No-op if not found. */
+  removeAnimal: (id: string) => void
   destroy: () => void
 }
 
@@ -922,6 +933,10 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
     }
 
     if (type === 'dog' && !a.stationary) {
+      // Ambient flavour: a roaming dog latches onto a random nearby NPC. This
+      // runs synchronously before makeAnimal's returned promise resolves, so
+      // spawnFollowerPet's post-await override (which assigns PLAYER_OWNER_ID
+      // to the player's own pet) always runs after this and wins.
       const named = opts.getNpcPositions().filter(n => n.id)
       a.ownerId = randOf(named)?.id
     }
@@ -1028,5 +1043,23 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
     fishLayer.destroy({ children: true })
   }
 
-  return { tick, getAnimalsInBuilding, getGlowSources, destroy }
+  function removeAnimal(id: string): void {
+    const idx = animals.findIndex(a => a.id === id)
+    if (idx === -1) return
+    const [a] = animals.splice(idx, 1)
+    if (a.bubble) opts.bubbleLayer.removeChild(a.bubble)
+    if (a.indicator) opts.bubbleLayer.removeChild(a.indicator)
+    a.sprite.destroy()
+  }
+
+  function spawnFollowerPet(variant: string, tx: number, ty: number): void {
+    removeAnimal(PLAYER_PET_ANIMAL_ID)
+    void makeAnimal('dog', tx, ty, { id: PLAYER_PET_ANIMAL_ID, type: 'dog', variant, tx, ty, roam: true })
+      .then(() => {
+        const a = animals.find(x => x.id === PLAYER_PET_ANIMAL_ID)
+        if (a) a.ownerId = PLAYER_OWNER_ID
+      })
+  }
+
+  return { tick, getAnimalsInBuilding, getGlowSources, spawnFollowerPet, removeAnimal, destroy }
 }

--- a/web/src/data/hub/ravenwatch/config.json
+++ b/web/src/data/hub/ravenwatch/config.json
@@ -9472,6 +9472,31 @@
       ]
     },
     {
+      "id": "ravenwatch-pet-shelter",
+      "tx": 39,
+      "ty": 21,
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "tileId": "wolfSign"
+        }
+      ],
+      "reactions": [
+        {
+          "type": "dialogue",
+          "speakerName": "Shelter Keeper",
+          "text": [
+            "Looking for a companion? We've got a few dogs here who'd love a home."
+          ]
+        },
+        {
+          "type": "screen",
+          "screen": "adopt-pet"
+        }
+      ]
+    },
+    {
       "id": "ravenwatch-church-key",
       "tx": 5,
       "ty": 5,

--- a/web/src/game/hub/pet.test.ts
+++ b/web/src/game/hub/pet.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { getActivePet, hasActivePet, adoptPet, renamePet, dismissPet } from './pet'
+
+// In-memory localStorage mock (tests run in node environment)
+const store = new Map<string, string>()
+beforeEach(() => {
+  store.clear()
+  globalThis.localStorage = {
+    getItem:    (k: string) => store.get(k) ?? null,
+    setItem:    (k: string, v: string) => { store.set(k, v) },
+    removeItem: (k: string) => { store.delete(k) },
+    clear:      () => { store.clear() },
+    key:        (i: number) => [...store.keys()][i] ?? null,
+    get length() { return store.size },
+  } as Storage
+})
+
+describe('pet store', () => {
+  it('has no active pet by default', () => {
+    expect(getActivePet()).toBeNull()
+    expect(hasActivePet()).toBe(false)
+  })
+
+  it('adopts a pet and persists it', () => {
+    adoptPet('dog', 'golden', 'Rex')
+    expect(getActivePet()).toEqual({ type: 'dog', variant: 'golden', name: 'Rex' })
+    expect(hasActivePet()).toBe(true)
+  })
+
+  it('persists across reloads (re-reads from the same backing store)', () => {
+    adoptPet('dog', 'brown', 'Buddy')
+    // Simulate a reload: nothing in-memory is retained beyond the localStorage mock.
+    expect(getActivePet()).toEqual({ type: 'dog', variant: 'brown', name: 'Buddy' })
+  })
+
+  it('renames the active pet, preserving type/variant', () => {
+    adoptPet('dog', 'black', 'Shadow')
+    const updated = renamePet('Max')
+    expect(updated).toEqual({ type: 'dog', variant: 'black', name: 'Max' })
+    expect(getActivePet()).toEqual({ type: 'dog', variant: 'black', name: 'Max' })
+  })
+
+  it('renaming with no active pet is a no-op', () => {
+    expect(renamePet('Max')).toBeNull()
+    expect(getActivePet()).toBeNull()
+  })
+
+  it('blank rename falls back to the existing name', () => {
+    adoptPet('dog', 'tan', 'Biscuit')
+    const updated = renamePet('   ')
+    expect(updated?.name).toBe('Biscuit')
+  })
+
+  it('adopting again fully replaces the previous pet (swap)', () => {
+    adoptPet('dog', 'golden', 'Rex')
+    adoptPet('dog', 'black', 'Shadow')
+    expect(getActivePet()).toEqual({ type: 'dog', variant: 'black', name: 'Shadow' })
+  })
+
+  it('dismissing clears the active pet', () => {
+    adoptPet('dog', 'golden', 'Rex')
+    dismissPet()
+    expect(getActivePet()).toBeNull()
+    expect(hasActivePet()).toBe(false)
+  })
+
+  it('degrades gracefully on corrupt localStorage data', () => {
+    store.set('jarv_hub_pet', '{not valid json')
+    expect(getActivePet()).toBeNull()
+  })
+
+  it('a blank adoption name falls back to a default', () => {
+    adoptPet('dog', 'brown', '   ')
+    expect(getActivePet()?.name).toBe('Pup')
+  })
+})

--- a/web/src/game/hub/pet.ts
+++ b/web/src/game/hub/pet.ts
@@ -1,0 +1,54 @@
+const KEY = 'jarv_hub_pet'
+
+export interface PetRecord {
+  type:    string  // 'dog' for now; kept generic for future pet types
+  variant: string  // palette key from ANIMAL_SPECS[type].palette
+  name:    string
+}
+
+interface Store {
+  pet: PetRecord | null
+}
+
+function load(): Store {
+  try {
+    const raw = localStorage.getItem(KEY)
+    return raw ? (JSON.parse(raw) as Store) : { pet: null }
+  } catch {
+    return { pet: null }
+  }
+}
+
+function save(data: Store): void {
+  try {
+    localStorage.setItem(KEY, JSON.stringify(data))
+  } catch { /* ignore */ }
+}
+
+export function getActivePet(): PetRecord | null {
+  return load().pet
+}
+
+export function hasActivePet(): boolean {
+  return getActivePet() != null
+}
+
+/** Adopts a pet, replacing any currently active one. */
+export function adoptPet(type: string, variant: string, name: string): PetRecord {
+  const pet: PetRecord = { type, variant, name: name.trim() || 'Pup' }
+  save({ pet })
+  return pet
+}
+
+/** Renames the active pet. No-op (returns null) if there is no active pet. */
+export function renamePet(name: string): PetRecord | null {
+  const data = load()
+  if (!data.pet) return null
+  data.pet = { ...data.pet, name: name.trim() || data.pet.name }
+  save(data)
+  return data.pet
+}
+
+export function dismissPet(): void {
+  save({ pet: null })
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -15351,6 +15351,78 @@ html.light-mode .action-btn {
 .bounty-board-modal__hint   { font-size: 10px; color: #667766; margin-top: 6px; font-style: italic; }
 .bounty-board-modal__reward { font-size: 10px; color: #88cc88; margin-top: 4px; }
 
+/* ── Pet adoption / management ──────────────────────────────────────────────── */
+.pet-modal {
+  background: rgba(8, 14, 8, 0.97);
+  border: 1px solid #446644;
+  color: #c8e8c8;
+  padding: 20px;
+  width: min(360px, 92vw);
+  max-height: 80vh;
+  overflow-y: auto;
+  border-radius: 4px;
+  font-family: monospace;
+}
+.pet-modal__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 16px;
+  font-size: 14px;
+  letter-spacing: 0.1em;
+  color: #88cc88;
+  text-transform: uppercase;
+}
+.pet-modal__close {
+  background: none;
+  border: none;
+  color: #557755;
+  cursor: pointer;
+  font-size: 12px;
+  padding: 0 2px;
+  line-height: 1;
+}
+.pet-modal__close:hover { color: #88cc88; }
+.pet-modal__section-label {
+  font-size: 10px;
+  color: #557755;
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  margin: 12px 0 6px;
+}
+.pet-modal__swatches { display: flex; gap: 10px; margin-bottom: 14px; }
+.pet-modal__swatch {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: 2px solid #2a4a2a;
+  cursor: pointer;
+  padding: 0;
+}
+.pet-modal__swatch--selected { border-color: #88cc88; }
+.pet-modal__name-input {
+  display: block;
+  width: 100%;
+  background: rgba(0, 0, 0, 0.3);
+  border: 1px solid #2a4a2a;
+  color: #c8e8c8;
+  font-family: monospace;
+  font-size: 12px;
+  padding: 8px 10px;
+  margin-bottom: 10px;
+  border-radius: 2px;
+}
+.pet-modal__current { display: flex; align-items: center; gap: 10px; margin-bottom: 12px; }
+.pet-modal__current-swatch {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  border: 2px solid #2a4a2a;
+  display: inline-block;
+}
+.pet-modal__current-name { font-size: 14px; font-weight: bold; }
+.pet-modal__actions-row { display: flex; gap: 8px; margin-top: 10px; flex-wrap: wrap; }
+
 /* ── Town Directory ("Where is…?") ─────────────────────────────────────────── */
 .town-directory {
   background: rgba(8, 14, 8, 0.97);


### PR DESCRIPTION
## Summary

Closes #1616, #1682, #1683, #1684.

Lets the player adopt a dog from a new shelter interactable in Ravenwatch. The adopted pet then follows the player's avatar around every town and persists across reloads. It can be renamed, dismissed, or swapped for a different dog.

- **`web/src/game/hub/pet.ts`** (new) — persisted store (localStorage key `jarv_hub_pet`) holding a single active pet `{ type, variant, name }`. `adoptPet`/`renamePet`/`dismissPet`/`getActivePet`/`hasActivePet`.
- **`web/src/components/hub/hubAnimals.ts`** — adds `PLAYER_OWNER_ID`/`PLAYER_PET_ANIMAL_ID` sentinels and two new `AnimalSystem` methods, `spawnFollowerPet`/`removeAnimal`. Reuses the *existing, unmodified* dog `follow-owner` state machine (previously only used for ambient dogs randomly latching onto a nearby NPC) — no new movement/pathing logic was written.
- **`web/src/components/hub/HubTownCanvas.tsx`** — injects the player's live position into the NPC-position lookup the follow-owner behavior already reads, and spawns the follower pet near the avatar's start tile on mount if a pet is active.
- **`web/src/components/hub/PetModal.tsx`** (new, + Storybook story) — adopt (variant swatch picker + name), rename, dismiss, and swap (with a confirm) UI. Reuses the existing `ModalBackdrop`/`ConfirmModal` primitives.
- **`web/src/components/hub/HubWorld.tsx`** — wires a new `adopt-pet` screen route (same pattern as `bounty-board`/`town-upgrades`), a 🐾 toolbar button shown only while a pet is active, and a tap-on-pet-sprite shortcut into the management modal.
- **`web/src/data/hub/ravenwatch/config.json`** — a new pet-shelter interactable near the town square.
- **`docs/hubworld.md`** — new file-map entries and a "Player's Follower Pet" subsection under §8 (Animals).

Scoped to dog-only and a single active pet for this pass, matching the issue's "reusing the dog follow-owner stepper" framing; the store shape is generic enough to extend later.

### Known limitation (called out per plan)
The follow-owner pathing target is constrained to walkable/street tiles (pre-existing behavior shared with ambient NPC-following dogs). Since the player roams onto grass/off-street tiles more freely than NPCs, the pet may idle near the street edge rather than tuck right next to the player when they're standing off-street. Not a new bug, but worth noting since players will notice it more with their own companion.

## Test plan
- [x] `cd web && npx tsc --noEmit` — passes
- [x] `cd web && npm run test` — 302/302 tests pass (new `pet.test.ts` covers the store: adopt/read-back/persistence/rename/no-op-rename/blank-name-fallback/swap/dismiss/corrupt-data)
- [x] `cd web && npm run build` — passes
- [x] Manually verified both `PetModal` states (adopt picker, manage/rename/dismiss/swap) and the dismiss confirm dialog via Storybook + Playwright screenshots
- [ ] Manual in-game spot check of the follower actually walking around Ravenwatch and persisting across a town change (recommend a quick `npm run dev` pass before merge)


---
_Generated by [Claude Code](https://claude.ai/code/session_01EnyZvxsgU7oxX33zFTr7cT)_