### PR TITLE
Add hidden secrets & explorables mechanism

### DIFF
--- a/docs/hubworld.md
+++ b/docs/hubworld.md
@@ -90,10 +90,11 @@ defined in the `blockedPaths` array at the top level of `questDefs.json`.
 | Field | Type | Required | Description |
 |---|---|---|---|
 | `id` | `string` | ✓ | Unique identifier for this block. Only used internally for tracking. |
-| `blockedTiles` | `[number, number][]` | ✓ | Array of `[tx, ty]` hub tile coordinates removed from pathfinding while the quest is incomplete. **Must already exist in `config.json` streets** — they become walkable again on clear. |
-| `questId` | `string` | ✓ | Quest ID from the `quests` array in `questDefs.json`. The path clears the moment this quest reaches `completed` status (checked at walk-start time, so no reload needed). |
-| `blocked` | `BlockedPathState` | ✓ | Visual state while quest is incomplete. |
-| `cleared` | `BlockedPathState` | ✓ | Visual state once quest is complete. Can be empty `{}` if nothing changes visually. |
+| `blockedTiles` | `[number, number][]` | ✓ | Array of `[tx, ty]` hub tile coordinates removed from pathfinding while blocked. **Must already exist in `config.json` streets** — they become walkable again on clear. |
+| `questId` | `string` | one of `questId`/`unlockedByInteractable` | Quest ID from the `quests` array in `questDefs.json`. The path clears the moment this quest reaches `completed` status (checked live every frame, so no reload needed). |
+| `unlockedByInteractable` | `string` | one of `questId`/`unlockedByInteractable` | Alternative gate for **hidden-area reveals** (see §7's secret interactables): the `id` of a `config.json` interactable elsewhere in town. The path clears the moment that interactable's `giveItem` reaction has been granted (checked via `isInteractableGranted`/`interactableStoreKey` from `interactables.ts` — the same one-time-grant persistence secrets already use), live, no reload. Use this instead of authoring a throwaway quest just to gate a reveal. |
+| `blocked` | `BlockedPathState` | ✓ | Visual state while blocked. |
+| `cleared` | `BlockedPathState` | ✓ | Visual state once cleared. Can be empty `{}` if nothing changes visually. |
 
 #### `BlockedPathState` fields
 
@@ -279,7 +280,7 @@ bounds, else a single tile.
 |---|---|---|
 | `dialogue` | `speakerName?`, `text` (string or string[]) | Shows the dialogue modal. A string[] cycles one entry per tap. |
 | `screen` | `screen` | Opens a screen via the same routing as NPC `screen` (e.g. `news`, `shop`, `interior:<id>`, `bounty-board`, `town-upgrades`, `adopt-pet` — see §8, minigame ids). |
-| `giveItem` | `collectible?`, `consumables?`, `crystals?`, `message?`, `alreadyGrantedText?` | One-time grant (persisted). Re-taps show `alreadyGrantedText` if set. Reward shapes match treasure rewards. |
+| `giveItem` | `collectible?`, `consumables?`, `crystals?`, `message?`, `alreadyGrantedText?` | One-time grant (persisted). Re-taps show `alreadyGrantedText` if set. Reward shapes match treasure rewards. `collectible.lore?` (optional flavor text) is stored on the item and already surfaced by `HomeShelf`/`ItemFoundScreen` — no extra wiring needed for lore notes. |
 | `quest` | `questId`, `speakerName?` | Offers the quest with Accept / Not now. The quest's `giverNpcId` in `questDefs.json` **must equal the interactable's id**. Honours prerequisites and the 2-active-quest cap. |
 | `move` | `to: {tx, ty}`, `message?` | Moves the owned decor to the target tile, live and persisted across reloads. Requires owned `decor`. |
 
@@ -316,6 +317,32 @@ localStorage keys, entries keyed `<townName>:<interactableId>`:
 4. For `quest` reactions, set the quest's `giverNpcId` to the interactable id.
 5. Run `npm run test` (loader tests parse all configs) and `npm run build`.
 6. Verify in-game: tap fires the reactions, tap does not also walk the avatar, indicator shows/clears, moves persist after reload.
+
+### Authoring checklist: new secret / dig-spot
+
+A "secret" isn't a distinct schema — it's an ordinary interactable authored
+with **no owned `decor`** (see "Full schema" above: with neither `decor` nor
+`hitRect` given, the hit area defaults to a single invisible tile), so it's
+fully tappable while rendering nothing. No indicator either — secrets should
+be genuinely non-obvious, not flagged with the usual `!`.
+
+1. Pick a tile that's walkable-adjacent but not an obvious landmark (a gap
+   between buildings, a pond edge, a quiet corner).
+2. Add an interactable entry with **no `decor`** and **no `indicator`**: a
+   `dialogue` reaction for discovery flavor, then a `giveItem` reaction
+   granting a collectible. Use `collectible.lore` for a lore note's full text.
+3. *(Optional — hidden-area reveal)* Pair this secret with a hidden area: add
+   a `blockedPaths` entry in the town's `questDefs.json` (§2) whose
+   `unlockedByInteractable` is this secret's `id`. The blocked/cleared decor
+   conceals/reveals the area; put a normal `giveItem` interactable on the
+   newly-walkable tile for the actual reward, since the tile is impassable
+   (and thus untappable) until the path clears.
+4. Run `npm run test` and `npm run build`.
+5. Verify in-game: the secret is invisible but tappable at its tile, the
+   reward grants once (re-tapping does nothing further), the lore text reads
+   correctly wherever the item is displayed, and — if paired with a hidden
+   area — that area opens live (no reload) the moment the secret is found,
+   and all of it persists across a reload.
 
 ---
 

--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -23,6 +23,7 @@ import rollbar from '../../rollbar'
 import { HubInteractable, HubInteriorExit, HubLocationBundle, HubNpc, HubQuestBundle, HubStreetGroup, NpcScheduleEntry, isVisibleAtLevel } from '../../data/hub/loader'
 import { createAnimalSystem, AnimalSystem, GlowSource, PLAYER_OWNER_ID } from './hubAnimals'
 import { getActivePet } from '../../game/hub/pet'
+import { isInteractableGranted, interactableStoreKey } from '../../game/hub/interactables'
 import type { AnimalType } from '../../game/hub/animals'
 import { createWeatherSystem } from './hubWeather'
 import { resolveWeather } from '../../game/hub/weather'
@@ -754,17 +755,25 @@ export function HubTownCanvas({
       lastBubbleText: string | null
     }
     interface BlockedPathEntry {
-      questId: string
+      questId?: string
+      unlockedByInteractable?: string
       blockedDecor: PIXI.Sprite[]
       clearedDecor: PIXI.Sprite[]
       blockedNpcs: BlockedNpcEntry[]
       clearedNpcs: { root: PIXI.Container }[]
     }
+    // A blocked path clears either when its quest completes, or (for hidden
+    // areas revealed by finding a secret) when the paired interactable's
+    // one-time reward has been granted — see interactables.ts.
+    function isBlockedPathCleared(bp: { questId?: string; unlockedByInteractable?: string }): boolean {
+      if (bp.unlockedByInteractable) return isInteractableGranted(interactableStoreKey(locationKey, bp.unlockedByInteractable))
+      return bp.questId ? (completedQuestIdsRef?.current.has(bp.questId) ?? false) : false
+    }
     const blockedPathEntries = new Map<string, BlockedPathEntry>()
     {
       for (const bp of HUB_BLOCKED_PATHS) {
-        const isCleared = completedQuestIdsRef?.current.has(bp.questId) ?? false
-        const entry: BlockedPathEntry = { questId: bp.questId, blockedDecor: [], clearedDecor: [], blockedNpcs: [], clearedNpcs: [] }
+        const isCleared = isBlockedPathCleared(bp)
+        const entry: BlockedPathEntry = { questId: bp.questId, unlockedByInteractable: bp.unlockedByInteractable, blockedDecor: [], clearedDecor: [], blockedNpcs: [], clearedNpcs: [] }
 
         for (const d of bp.blocked.decor ?? []) {
           if (d.tileId === 666) continue
@@ -844,12 +853,12 @@ export function HubTownCanvas({
       }
     }
 
-    // Rebuild blockedPathSolidSet from live quest state: the visible side's
-    // decor + guard-NPC tiles (blocked while incomplete, cleared once done).
+    // Rebuild blockedPathSolidSet from live quest/secret state: the visible
+    // side's decor + guard-NPC tiles (blocked while incomplete, cleared once done).
     function refreshBlockedPathSolids() {
       blockedPathSolidSet.clear()
       for (const bp of HUB_BLOCKED_PATHS) {
-        const cleared = completedQuestIdsRef?.current.has(bp.questId) ?? false
+        const cleared = isBlockedPathCleared(bp)
         const state = cleared ? bp.cleared : bp.blocked
         for (const d of state.decor ?? []) blockedPathSolidSet.add(`${d.tx},${d.ty}`)
         for (const n of state.npcs ?? []) blockedPathSolidSet.add(`${n.tx},${n.ty}`)
@@ -874,7 +883,7 @@ export function HubTownCanvas({
         }
       }
       for (const bp of HUB_BLOCKED_PATHS)
-        if (!(completedQuestIdsRef?.current.has(bp.questId) ?? false))
+        if (!isBlockedPathCleared(bp))
           for (const [btx, bty] of bp.blockedTiles) s.delete(`${btx},${bty}`)
       for (const k of blockedPathSolidSet) s.delete(k)
       return s
@@ -2585,7 +2594,7 @@ export function HubTownCanvas({
         // Blocked path visibility and proximity speech bubbles
         refreshBlockedPathSolids()  // keep solid tiles in sync as quests clear
         for (const [, entry] of blockedPathEntries) {
-          const cleared = completedQuestIdsRef?.current.has(entry.questId) ?? false
+          const cleared = isBlockedPathCleared(entry)
           for (const s of entry.blockedDecor) s.visible = !cleared
           for (const s of entry.clearedDecor) s.visible = cleared
           for (const n of entry.clearedNpcs) n.root.visible = cleared

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -1059,8 +1059,8 @@ function hasOfferableQuest(giverId: string): boolean {
         }
         markInteractableGranted(storeKey)
         if (r.collectible) {
-          const { id, name, icon, desc } = r.collectible
-          addCollectible(id, { name, icon, desc })
+          const { id, name, icon, desc, lore } = r.collectible
+          addCollectible(id, { name, icon, desc, lore })
         }
         if (r.consumables) {
           for (const { id, quantity } of r.consumables) addConsumable(id, quantity)

--- a/web/src/data/hub/config.ts
+++ b/web/src/data/hub/config.ts
@@ -267,6 +267,7 @@ export interface RawInteractableReaction {
     name: string
     icon: string
     desc: string
+    lore?: string
   }
   consumables?: Array<{
     id: string

--- a/web/src/data/hub/loader.test.ts
+++ b/web/src/data/hub/loader.test.ts
@@ -212,11 +212,59 @@ describe('ravenwatch config', () => {
     expect(bundle.EXTERIOR_DECOR.some(d => boardTiles.includes(d.tileId))).toBe(false)
   })
 
+  it('parses a giveItem reaction collectible with lore text', () => {
+    const bundle = createHubLocationData(minimalConfig({
+      interactables: [{
+        id: 'secret-note',
+        tx: 10, ty: 10,
+        reactions: [{
+          type: 'giveItem',
+          collectible: { id: 'weathered-note', name: 'Weathered Note', icon: '📜', desc: 'A scrap of paper.', lore: 'Long ago...' },
+        }],
+      }],
+    }))
+    const secret = bundle.HUB_INTERACTABLES.find(i => i.id === 'secret-note')
+    expect(secret?.decor).toBeUndefined()
+    expect(secret?.hitRect).toEqual({ w: 1, h: 1 })
+    const reaction = secret?.reactions[0] as { type: 'giveItem'; collectible?: { lore?: string } }
+    expect(reaction.collectible?.lore).toBe('Long ago...')
+  })
+
   it('contains the card-shop-pack interactable with a buyPack reaction', () => {
     const bundle = createHubLocationData(ravenwatchConfig as unknown as RawConfig)
     const pack = bundle.HUB_INTERACTABLES.find(i => i.id === 'card-shop-pack')
     expect(pack).toBeDefined()
     expect(pack!.building).toBe('card-shop')
     expect(pack!.reactions).toEqual([{ type: 'buyPack' }])
+  })
+})
+
+function minimalBlockedPath(extra: Record<string, unknown>) {
+  return {
+    id: 'test-block',
+    blockedTiles: [[1, 1]],
+    blocked: { decor: [], npcs: [] },
+    cleared: { decor: [], npcs: [] },
+    ...extra,
+  }
+}
+
+describe('blocked paths parsing', () => {
+  it('parses a quest-gated blocked path (regression)', () => {
+    const bundle = createHubQuestData(minimalQuestConfig({
+      blockedPaths: [minimalBlockedPath({ questId: 'some-quest' })],
+    }))
+    expect(bundle.HUB_BLOCKED_PATHS).toHaveLength(1)
+    expect(bundle.HUB_BLOCKED_PATHS[0].questId).toBe('some-quest')
+    expect(bundle.HUB_BLOCKED_PATHS[0].unlockedByInteractable).toBeUndefined()
+  })
+
+  it('parses a secret-gated blocked path via unlockedByInteractable', () => {
+    const bundle = createHubQuestData(minimalQuestConfig({
+      blockedPaths: [minimalBlockedPath({ unlockedByInteractable: 'ravenwatch-hidden-grove-key' })],
+    }))
+    expect(bundle.HUB_BLOCKED_PATHS).toHaveLength(1)
+    expect(bundle.HUB_BLOCKED_PATHS[0].unlockedByInteractable).toBe('ravenwatch-hidden-grove-key')
+    expect(bundle.HUB_BLOCKED_PATHS[0].questId).toBeUndefined()
   })
 })

--- a/web/src/data/hub/loader.ts
+++ b/web/src/data/hub/loader.ts
@@ -216,7 +216,10 @@ export interface BlockedPathState {
 export interface BlockedPath {
   id: string
   blockedTiles: [number, number][]
-  questId: string
+  /** Exactly one of questId/unlockedByInteractable should be set. */
+  questId?: string
+  /** Alternative gate: cleared once this interactable id has been granted (see interactables.ts). */
+  unlockedByInteractable?: string
   blocked: BlockedPathState
   cleared: BlockedPathState
 }
@@ -260,7 +263,7 @@ export type HubInteractableReaction =
   | { type: 'dialogue'; speakerName?: string; text: string | string[] }
   | { type: 'screen'; screen: string }
   | { type: 'giveItem'
-      collectible?: { id: string; name: string; icon: string; desc: string }
+      collectible?: { id: string; name: string; icon: string; desc: string; lore?: string }
       consumables?: Array<{ id: string; quantity: number }>
       crystals?: number
       message?: string
@@ -768,7 +771,7 @@ type RawBlockedPathNpc = { id: string; sprite: string; tx: number; ty: number; p
 type RawBlockedPathState = { decor?: Array<{ tx: number; ty: number; tileId?: string; bundleID?: string; zlayer?: string }>; npcs?: RawBlockedPathNpc[] }
 
 
-type RawBlockedPath = { id: string; blockedTiles: [number, number][]; questId: string; blocked: RawBlockedPathState; cleared: RawBlockedPathState }
+type RawBlockedPath = { id: string; blockedTiles: [number, number][]; questId?: string; unlockedByInteractable?: string; blocked: RawBlockedPathState; cleared: RawBlockedPathState }
 
 function resolveBlockedPathState(raw: RawBlockedPathState): BlockedPathState {
   return {
@@ -783,11 +786,12 @@ function resolveBlockedPathState(raw: RawBlockedPathState): BlockedPathState {
 const HUB_BLOCKED_PATHS: BlockedPath[] = (
   (rawQuestConfig as unknown as { blockedPaths?: RawBlockedPath[] }).blockedPaths ?? []
 ).map(bp => ({
-  id:           bp.id,
-  blockedTiles: bp.blockedTiles,
-  questId:      bp.questId,
-  blocked:      resolveBlockedPathState(bp.blocked),
-  cleared:      resolveBlockedPathState(bp.cleared),
+  id:                    bp.id,
+  blockedTiles:          bp.blockedTiles,
+  questId:               bp.questId,
+  unlockedByInteractable: bp.unlockedByInteractable,
+  blocked:               resolveBlockedPathState(bp.blocked),
+  cleared:               resolveBlockedPathState(bp.cleared),
 }))
 
 type RawPickup = { id: string; tx: number; ty: number; tileId: string; building?: string; questId?: string; chain?: string; requireTouch?: boolean; glow?: boolean; glowRadius?: number; pulse?: boolean }

--- a/web/src/data/hub/questDefs.ts
+++ b/web/src/data/hub/questDefs.ts
@@ -187,7 +187,10 @@ export interface QuestBlockedPaths {
 
   blockedTiles: number[][]
 
-  questId: string
+  /** Exactly one of questId/unlockedByInteractable should be set. */
+  questId?: string
+  /** Alternative gate: cleared once this interactable id has been granted. */
+  unlockedByInteractable?: string
 
   blocked: BlockedPathState
   cleared: BlockedPathState

--- a/web/src/data/hub/ravenwatch/config.json
+++ b/web/src/data/hub/ravenwatch/config.json
@@ -9529,6 +9529,95 @@
       "building": "townhall-office"
     },
     {
+      "id": "ravenwatch-secret-alley-note",
+      "tx": 34,
+      "ty": 23,
+      "reactions": [
+        {
+          "type": "dialogue",
+          "text": "Wedged between two buildings, a scrap of paper catches your eye."
+        },
+        {
+          "type": "giveItem",
+          "collectible": {
+            "id": "ravenwatch-alley-note",
+            "name": "Weathered Note",
+            "icon": "📜",
+            "desc": "A scrap of paper found tucked in an alley.",
+            "lore": "'...if you're reading this, the watch still doesn't check the gap behind the bakery. Left three crowns under the loose brick for whoever finds this next. Pass it on. — a friend'"
+          },
+          "message": "You found a hidden note!"
+        }
+      ]
+    },
+    {
+      "id": "ravenwatch-secret-pond-note",
+      "tx": 37,
+      "ty": 51,
+      "reactions": [
+        {
+          "type": "dialogue",
+          "text": "Half-buried in the mud at the water's edge, something glints."
+        },
+        {
+          "type": "giveItem",
+          "collectible": {
+            "id": "ravenwatch-pond-note",
+            "name": "Waterlogged Journal Page",
+            "icon": "📜",
+            "desc": "A single page, the ink smeared but still legible.",
+            "lore": "'The carp here have gotten bold enough to steal bait right off the hook. Old Greyfish swears one of them is wearing his lucky lure. I believe him.'"
+          },
+          "message": "You found a hidden journal page!"
+        }
+      ]
+    },
+    {
+      "id": "ravenwatch-secret-old-marker",
+      "tx": 19,
+      "ty": 22,
+      "reactions": [
+        {
+          "type": "dialogue",
+          "text": "A faint carving on an old stone marker catches the light — an arrow, pointing south."
+        },
+        {
+          "type": "giveItem",
+          "collectible": {
+            "id": "ravenwatch-old-marker-clue",
+            "name": "Carved Stone Fragment",
+            "icon": "🪨",
+            "desc": "A chipped stone fragment bearing a directional carving.",
+            "lore": "The carving matches a mark you've seen elsewhere in town — worth following up on."
+          },
+          "message": "You found a strange carved marker! Something nearby might have shifted."
+        }
+      ]
+    },
+    {
+      "id": "ravenwatch-hidden-grove-cache",
+      "tx": 9,
+      "ty": 23,
+      "reactions": [
+        {
+          "type": "dialogue",
+          "text": "The overgrowth here has parted, revealing a small stash tucked against the wall."
+        },
+        {
+          "type": "giveItem",
+          "collectible": {
+            "id": "ravenwatch-grove-cache-relic",
+            "name": "Tarnished Locket",
+            "icon": "🔒",
+            "desc": "A small locket, long hidden away.",
+            "lore": "Whoever hid this clearly meant to come back for it. They never did."
+          },
+          "crystals": 25,
+          "message": "You found a hidden stash! +25 crystals."
+        }
+      ]
+    },
+    {
       "id": "interactable-1782663378757",
       "tx": 28,
       "ty": 53,

--- a/web/src/data/hub/ravenwatch/questDefs.json
+++ b/web/src/data/hub/ravenwatch/questDefs.json
@@ -5892,6 +5892,36 @@
           }
         ]
       }
+    },
+    {
+      "id": "ravenwatch-hidden-grove",
+      "blockedTiles": [
+        [
+          9,
+          23
+        ]
+      ],
+      "unlockedByInteractable": "ravenwatch-secret-old-marker",
+      "blocked": {
+        "decor": [
+          {
+            "tx": 9,
+            "ty": 23,
+            "tileId": "darkBush"
+          }
+        ],
+        "npcs": []
+      },
+      "cleared": {
+        "decor": [
+          {
+            "tx": 9,
+            "ty": 23,
+            "tileId": "chest"
+          }
+        ],
+        "npcs": []
+      }
     }
   ],
   "dialogues": [


### PR DESCRIPTION
## Summary

Closes #1621, #1653, #1654, #1657.

Adds a discoverable "secret/dig-spot" mechanic and an optional hidden-area reveal mechanic, and proves both out with authored content in Ravenwatch.

- **Secrets (#1653)** — no new schema needed. A secret is an ordinary `HubInteractable` authored with **no owned `decor`** and no indicator: it still gets a tappable hit area (defaults to a single invisible tile) but renders nothing, so it blends into the scenery until found. One-time reward + persistence reuses the existing `giveItem` reaction and `web/src/game/hub/interactables.ts` (`isInteractableGranted`/`markInteractableGranted`) verbatim.
- **Lore notes** — `itemStore.ts` already supported a `lore` field on items (shown by `HomeShelf`/`ItemFoundScreen`), but the `giveItem` reaction's `collectible` type and handler didn't pass it through. Threaded `lore?: string` through `loader.ts`'s `HubInteractableReaction`, `config.ts`'s `RawInteractableReaction`, and `HubWorld.tsx`'s `giveItem` case so lore notes actually work end-to-end.
- **Hidden-area reveal (#1654)** — extended the existing "blocked path" system (`docs/hubworld.md` §2) with an alternative gate, `unlockedByInteractable?: string`, alongside the existing `questId?: string` (both now optional; exactly one should be set). When set, the path clears the moment that interactable's `giveItem` reaction has been granted, checked via the same `isInteractableGranted` secrets already use — reusing the existing decor/collision toggle rendering and live per-tick refresh completely unchanged, with no new store and no fake "discovery quest" needed just to gate a reveal.
- **Content (#1657)** — 3 secrets authored in Ravenwatch: two simple lore-note dig-spots, and one whose discovery reveals a small hidden cache via the new `unlockedByInteractable` gate. Scoped to Ravenwatch only for this pass (confirmed with the repo owner) — rolling the same authoring pattern out to the other 12 towns is left as follow-up work, mirroring how the specialist-trader epic (#1814) was tiered across multiple PRs.

### Files touched
- `web/src/data/hub/loader.ts` / `web/src/data/hub/config.ts` / `web/src/data/hub/questDefs.ts` — schema widening (`unlockedByInteractable`, `lore`)
- `web/src/components/hub/HubTownCanvas.tsx` — `isBlockedPathCleared()` gate check (quest OR interactable-grant), used at all 4 existing call sites that previously assumed quest-only
- `web/src/components/hub/HubWorld.tsx` — pass `lore` through the `giveItem` handler
- `web/src/data/hub/ravenwatch/config.json` / `questDefs.json` — the 3 authored secrets + paired hidden-area blocked-path entry
- `docs/hubworld.md` — new `unlockedByInteractable` field docs (§2) and an "Authoring checklist: new secret" section (§7)

## Test plan
- [x] `cd web && npx tsc --noEmit` — passes
- [x] `cd web && npm run test` — 305/305 tests pass (3 new: quest-gated blocked-path regression, `unlockedByInteractable` parsing, `giveItem` collectible `lore` parsing)
- [x] `cd web && npm run build` — passes (also re-validates every other town's `questDefs.json`/`config.json` against the widened shared types)
- [x] Verified the 3 new interactables and the paired blocked-path tile don't collide with any existing building/decor/interactable/pond placement in Ravenwatch (checked programmatically)
- [ ] Manual in-game walkthrough (find each secret, confirm one-time grant + lore text display, confirm the hidden cache reveals live without a reload) — blocked in this sandbox by a pre-existing, unrelated issue: `firebase.ts` calls `getAuth()` eagerly with no env-var guard, so any component importing it (including `HubWorld`) crashes here without Firebase credentials configured, in both Storybook and `npm run dev`. Recommend a quick manual pass in an environment with Firebase configured before merge.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EnyZvxsgU7oxX33zFTr7cT)_