### PR TITLE
Add pet interactions: Give a Treat (fetch), Pet, Belly Rubs, Brush

### DIFF
--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -81,6 +81,7 @@ interface Props {
   onAnimalSeen?:    (type: AnimalType, variant?: string) => void
   interiorEnterRef?: React.MutableRefObject<((buildingId: string) => void) | null>
   interiorExitRef?:  React.MutableRefObject<(() => void) | null>
+  petActionRef?:     React.MutableRefObject<{ sendPetFetching: (onReturn: () => void) => boolean; givePetAffection: () => void } | null>
   onEnterInterior?:  () => void
   onExitInterior?:   () => void
   onTileTap?:        (tx: number, ty: number) => void
@@ -117,7 +118,7 @@ interface Props {
 export function HubTownCanvas({
   onAreaEnter, onNodeInteract, onAvatarMove,
   returnRef, unitCards, commander, onNpcTap, onAnimalTap, onAnimalSeen,
-  interiorEnterRef, interiorExitRef, onEnterInterior, onExitInterior, onTileTap,
+  interiorEnterRef, interiorExitRef, petActionRef, onEnterInterior, onExitInterior, onTileTap,
   pickedUpIds, onItemPickup, doorKeys, onDoorLocked, questNpcState, activeQuestIdsRef,
   completedQuestIdsRef, collectedTreasureIds, onTreasureStep,
   gameHour, isNight, npcProximityDialogue,
@@ -2447,6 +2448,7 @@ export function HubTownCanvas({
       },
     })
     getAnimalsInBuildingFn = animalSystem.getAnimalsInBuilding
+    if (petActionRef) petActionRef.current = { sendPetFetching: animalSystem.sendPetFetching, givePetAffection: animalSystem.givePetAffection }
 
     // Spawn the player's adopted follower pet (if any) near their spawn tile.
     const activePet = getActivePet()

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -33,7 +33,7 @@ import { QuestsModal } from './QuestsModal'
 import { BountyBoardModal } from './BountyBoardModal'
 import { hasUnclaimedBounties, getPendingBountyReport, getPendingBountyCollect, advanceBountyStep, getActiveBountyStep } from '../../game/hub/bounties'
 import { PetModal } from './PetModal'
-import { getActivePet } from '../../game/hub/pet'
+import { getActivePet, getTreatsRemainingToday, canGiveTreat, recordTreatGiven } from '../../game/hub/pet'
 import { PLAYER_PET_ANIMAL_ID } from './hubAnimals'
 import { TownDirectory } from './TownDirectory'
 import { TownJournal } from './TownJournal'
@@ -355,6 +355,7 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onEndless, onWorldMap
   const returnRef        = useRef(null) as React.MutableRefObject<(() => void) | null>
   const interiorEnterRef = useRef<((buildingId: string) => void) | null>(null)
   const interiorExitRef  = useRef<(() => void) | null>(null)
+  const petActionRef     = useRef<{ sendPetFetching: (onReturn: () => void) => boolean; givePetAffection: () => void } | null>(null)
   const playerName = loadPlayerName()
 
   const unitCards = useMemo(() => {
@@ -541,6 +542,28 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onEndless, onWorldMap
     setPickedUpIds(getPickedUpIds())
     refreshState()
   }, [refreshState])
+
+  // Give-a-Treat reward: one of crystals / a random common-or-uncommon card /
+  // a flavor trinket, mirroring handleTreasureStep's reward-application shapes.
+  const grantRandomPetReward = useCallback((petName: string): string => {
+    const roll = Math.random()
+    if (roll < 0.4) {
+      const amount = 10 + Math.floor(Math.random() * 21) // 10-30
+      saveCrystals(loadCrystals() + amount)
+      onCrystalsChange?.(loadCrystals())
+      return `${petName} drops ${amount} crystals at your feet!`
+    }
+    if (roll < 0.8) {
+      const catalog = getCardCatalog().filter(c => c.rarity === 'common' || c.rarity === 'uncommon')
+      const card = catalog[Math.floor(Math.random() * catalog.length)]
+      if (card) {
+        addCardsToCollection([{ cardName: card.name, count: 1 }])
+        return `${petName} comes trotting back with a card: ${card.name}!`
+      }
+    }
+    addCollectible('pet-fetch-trinket', { name: 'Shiny Trinket', icon: '✨', desc: `A shiny bauble ${petName} dug up while out on a walk.` })
+    return `${petName} found a shiny trinket and brought it back!`
+  }, [onCrystalsChange])
 
   const handleTreasureStep = useCallback((id: string) => {
     const treasure = locationData.HUB_TREASURES.find(t => t.id === id)
@@ -1012,11 +1035,42 @@ function hasOfferableQuest(giverId: string): boolean {
 
   // Placed/quest animals route through the same handler as NPCs.
   const handleAnimalTap = useCallback((animalId: string) => {
-    if (animalId === PLAYER_PET_ANIMAL_ID) { setPetModalOpen(true); return }
+    if (animalId === PLAYER_PET_ANIMAL_ID) {
+      const pet = getActivePet()
+      if (!pet) { setPetModalOpen(true); return }
+      const remaining = getTreatsRemainingToday()
+      const choices: DialogueChoice[] = [
+        {
+          label: `Give a Treat (${remaining}/2 today)`,
+          primary: true,
+          onClick: () => {
+            if (!canGiveTreat()) {
+              setDialogueEvent({ speakerName: pet.name, text: `${pet.name} has had plenty for today. Come back tomorrow!` })
+              return
+            }
+            const sent = petActionRef.current?.sendPetFetching(() => {
+              recordTreatGiven()
+              const message = grantRandomPetReward(pet.name)
+              refreshState()
+              setDialogueEvent({ speakerName: pet.name, text: message })
+            })
+            if (!sent) { setDialogueEvent({ speakerName: pet.name, text: `${pet.name} seems busy right now.` }); return }
+            setDialogueEvent(null)
+          },
+        },
+        { label: 'Pet', onClick: () => { petActionRef.current?.givePetAffection(); setDialogueEvent({ speakerName: pet.name, text: `${pet.name} leans into your hand, tail wagging.` }) } },
+        { label: 'Belly Rubs', onClick: () => { petActionRef.current?.givePetAffection(); setDialogueEvent({ speakerName: pet.name, text: `${pet.name} flops over for belly rubs, completely delighted.` }) } },
+        { label: 'Brush', onClick: () => { petActionRef.current?.givePetAffection(); setDialogueEvent({ speakerName: pet.name, text: `${pet.name}'s coat looks extra shiny now.` }) } },
+        { label: 'Manage', onClick: () => setPetModalOpen(true) },
+        { label: 'Never mind', onClick: () => setDialogueEvent(null) },
+      ]
+      setDialogueEvent({ speakerName: pet.name, text: 'What would you like to do?', choices })
+      return
+    }
     const a = locationData.HUB_ANIMALS.find(an => an.id === animalId)
     const line = a?.dialogue && a.dialogue.length > 0 ? a.dialogue[0] : ''
     handleNpcTap(line, animalId)
-  }, [handleNpcTap, locationData])
+  }, [handleNpcTap, locationData, refreshState, grantRandomPetReward])
 
   const handleAreaEnter = useCallback((areaName: string | null) => {
     setCurrentArea(areaName)
@@ -1239,6 +1293,7 @@ function hasOfferableQuest(giverId: string): boolean {
             onAnimalSeen={recordAnimalSeen}
             interiorEnterRef={interiorEnterRef}
             interiorExitRef={interiorExitRef}
+            petActionRef={petActionRef}
             onEnterInterior={() => setInteriorActive(true)}
             onExitInterior={() => setInteriorActive(false)}
             onTileTap={onTileTap}

--- a/web/src/components/hub/hubAnimals.ts
+++ b/web/src/components/hub/hubAnimals.ts
@@ -143,6 +143,11 @@ export interface AnimalSystem {
   spawnFollowerPet: (variant: string, tx: number, ty: number) => void
   /** Best-effort removal of an animal by id. No-op if not found. */
   removeAnimal: (id: string) => void
+  /** Sends the player's pet off to fetch something; fires onReturn once it's
+   *  back near the player. Returns false if there's no pet or it's already fetching. */
+  sendPetFetching: (onReturn: () => void) => boolean
+  /** Cosmetic affection reaction (wag + heart bubble) for the player's pet. */
+  givePetAffection: () => void
   destroy: () => void
 }
 
@@ -165,6 +170,8 @@ const isFloating = (t: AnimalType) => t === 'fish' || t === 'butterfly' || t ===
 export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
   const { app, T, spriteSize } = opts
   const animals: Animal[] = []
+  // Set by sendPetFetching(); fired once the fetching pet is back near the player.
+  let fetchCallback: (() => void) | null = null
 
   const overlayAnimLayer = new PIXI.Container()   // birds + butterflies (above buildings)
   const fishLayer = new PIXI.Container()
@@ -464,6 +471,30 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
       a.state = 'chase'; a.stateTimer = 3000; a.goal = [prey.tx, prey.ty]; return true
     }
     return false
+  }
+
+  // Forced (never idle-picked) two-phase state for the player's "give a treat"
+  // interaction: walk out to a.goal (grass-stepping, same as chase-prey), pause
+  // briefly on arrival, then follow the player home exactly like follow-owner.
+  function tickFetching(a: Animal, walkable: Set<string>, npcs: { id?: string; x: number; y: number }[]) {
+    if (a.state === 'fetching-out') {
+      if (a.goal) { if (!isMoving(a)) stepToward(a, walkable, 'grass'); return }
+      if (!isMoving(a) && a.stateTimer <= 0) a.state = 'fetching-return'
+      return
+    }
+    // fetching-return
+    const owner = npcs.find(n => n.id === PLAYER_OWNER_ID)
+    if (!owner) return
+    const dist = Math.hypot(a.sprite.x - owner.x, a.sprite.y - owner.y)
+    if (dist <= 3 * T) {
+      const cb = fetchCallback
+      fetchCallback = null
+      a.state = 'sit'; a.stateTimer = randomDuration('sit')
+      showStatic(a)
+      cb?.()
+      return
+    }
+    if (!isMoving(a)) followToward(a, owner, walkable)
   }
 
   // ── behaviour: birds ─────────────────────────────────────────────────────────
@@ -844,6 +875,8 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
         rabbitTick(a, dt, avatar, walkable)
       } else if (a.type === 'chicken') {
         chickenTick(a, dt, avatar, walkable, night)
+      } else if (a.state === 'fetching-out' || a.state === 'fetching-return') {
+        tickFetching(a, walkable, npcs)
       } else {
         dogSocial(a, dt, npcs)
         dogChasePrey(a, dt)
@@ -1061,5 +1094,27 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
       })
   }
 
-  return { tick, getAnimalsInBuilding, getGlowSources, spawnFollowerPet, removeAnimal, destroy }
+  function sendPetFetching(onReturn: () => void): boolean {
+    const a = animals.find(x => x.id === PLAYER_PET_ANIMAL_ID)
+    if (!a || a.state === 'fetching-out' || a.state === 'fetching-return') return false
+    const walkable = opts.getWalkable()
+    const far = tilesWithin(walkable, a.tx, a.ty, 8)
+      .filter(([x, y]) => Math.max(Math.abs(x - a.tx), Math.abs(y - a.ty)) >= 4)
+    const dest = randOf(far) ?? randOf(tilesWithin(walkable, a.tx, a.ty, 8))
+    if (!dest) return false
+    fetchCallback = onReturn
+    a.state = 'fetching-out'
+    a.stateTimer = 800
+    a.goal = dest
+    return true
+  }
+
+  function givePetAffection(): void {
+    const a = animals.find(x => x.id === PLAYER_PET_ANIMAL_ID)
+    if (!a) return
+    speak(a, '♥')
+    a.wagTimer = 1300
+  }
+
+  return { tick, getAnimalsInBuilding, getGlowSources, spawnFollowerPet, removeAnimal, sendPetFetching, givePetAffection, destroy }
 }

--- a/web/src/game/hub/animals.ts
+++ b/web/src/game/hub/animals.ts
@@ -177,8 +177,11 @@ export function variantKeyForTint(type: AnimalType, tint: number): string | unde
 
 // ── Behaviour transition tables ─────────────────────────────────────────────
 export type CatState = 'sleep' | 'sit' | 'flee' | 'chase-bird' | 'play' | 'approach-npc' | 'go-home' | 'inside'
-export type DogState = 'follow-owner' | 'roam' | 'bark' | 'wag' | 'chase-cat'
+export type DogState = 'follow-owner' | 'roam' | 'bark' | 'wag' | 'chase-cat' | 'fetching-out' | 'fetching-return'
 
+// 'fetching-out'/'fetching-return' are deliberately absent — they're only
+// ever entered via a forced call (AnimalSystem.sendPetFetching), never picked
+// randomly by dogIdle().
 export const DOG_IDLE_WEIGHTS: Record<string, number> = {
   'follow-owner': 5,
   roam:           3,

--- a/web/src/game/hub/pet.test.ts
+++ b/web/src/game/hub/pet.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest'
-import { getActivePet, hasActivePet, adoptPet, renamePet, dismissPet } from './pet'
+import { getActivePet, hasActivePet, adoptPet, renamePet, dismissPet, getTreatsRemainingToday, canGiveTreat, recordTreatGiven } from './pet'
 
 // In-memory localStorage mock (tests run in node environment)
 const store = new Map<string, string>()
@@ -72,5 +72,58 @@ describe('pet store', () => {
   it('a blank adoption name falls back to a default', () => {
     adoptPet('dog', 'brown', '   ')
     expect(getActivePet()?.name).toBe('Pup')
+  })
+
+  it('adopting a new pet preserves the daily treat count', () => {
+    adoptPet('dog', 'golden', 'Rex')
+    recordTreatGiven()
+    adoptPet('dog', 'black', 'Shadow')
+    expect(getTreatsRemainingToday()).toBe(1)
+  })
+
+  it('dismissing preserves the daily treat count', () => {
+    adoptPet('dog', 'golden', 'Rex')
+    recordTreatGiven()
+    dismissPet()
+    expect(getTreatsRemainingToday()).toBe(1)
+  })
+})
+
+describe('treat cooldown', () => {
+  it('starts with 2 treats remaining and no active pet means canGiveTreat is false', () => {
+    expect(getTreatsRemainingToday()).toBe(2)
+    expect(canGiveTreat()).toBe(false)
+  })
+
+  it('decrements remaining count on each treat given', () => {
+    adoptPet('dog', 'golden', 'Rex')
+    expect(canGiveTreat()).toBe(true)
+    recordTreatGiven()
+    expect(getTreatsRemainingToday()).toBe(1)
+    expect(canGiveTreat()).toBe(true)
+    recordTreatGiven()
+    expect(getTreatsRemainingToday()).toBe(0)
+    expect(canGiveTreat()).toBe(false)
+  })
+
+  it('floors at 0 and does not go negative', () => {
+    adoptPet('dog', 'golden', 'Rex')
+    recordTreatGiven()
+    recordTreatGiven()
+    recordTreatGiven()
+    expect(getTreatsRemainingToday()).toBe(0)
+  })
+
+  it('resets to the max on a new day', () => {
+    adoptPet('dog', 'golden', 'Rex')
+    recordTreatGiven()
+    recordTreatGiven()
+    expect(getTreatsRemainingToday()).toBe(0)
+    // Simulate a day change by rewriting the backing store with a stale date.
+    const raw = JSON.parse(store.get('jarv_hub_pet')!)
+    raw.treats.date = '2000-01-01'
+    store.set('jarv_hub_pet', JSON.stringify(raw))
+    expect(getTreatsRemainingToday()).toBe(2)
+    expect(canGiveTreat()).toBe(true)
   })
 })

--- a/web/src/game/hub/pet.ts
+++ b/web/src/game/hub/pet.ts
@@ -1,13 +1,21 @@
 const KEY = 'jarv_hub_pet'
 
+const MAX_TREATS_PER_DAY = 2
+
 export interface PetRecord {
   type:    string  // 'dog' for now; kept generic for future pet types
   variant: string  // palette key from ANIMAL_SPECS[type].palette
   name:    string
 }
 
+interface TreatState {
+  date:  string  // YYYY-MM-DD
+  count: number
+}
+
 interface Store {
-  pet: PetRecord | null
+  pet:    PetRecord | null
+  treats?: TreatState
 }
 
 function load(): Store {
@@ -25,6 +33,10 @@ function save(data: Store): void {
   } catch { /* ignore */ }
 }
 
+function todayKey(): string {
+  return new Date().toISOString().slice(0, 10)
+}
+
 export function getActivePet(): PetRecord | null {
   return load().pet
 }
@@ -33,10 +45,11 @@ export function hasActivePet(): boolean {
   return getActivePet() != null
 }
 
-/** Adopts a pet, replacing any currently active one. */
+/** Adopts a pet, replacing any currently active one. Preserves the daily treat count. */
 export function adoptPet(type: string, variant: string, name: string): PetRecord {
+  const data = load()
   const pet: PetRecord = { type, variant, name: name.trim() || 'Pup' }
-  save({ pet })
+  save({ ...data, pet })
   return pet
 }
 
@@ -49,6 +62,27 @@ export function renamePet(name: string): PetRecord | null {
   return data.pet
 }
 
+/** Dismisses the active pet. Preserves the daily treat count. */
 export function dismissPet(): void {
-  save({ pet: null })
+  const data = load()
+  save({ ...data, pet: null })
+}
+
+/** How many treats can still be given today (resets to the max on a new day). */
+export function getTreatsRemainingToday(): number {
+  const data = load()
+  if (!data.treats || data.treats.date !== todayKey()) return MAX_TREATS_PER_DAY
+  return Math.max(0, MAX_TREATS_PER_DAY - data.treats.count)
+}
+
+export function canGiveTreat(): boolean {
+  return hasActivePet() && getTreatsRemainingToday() > 0
+}
+
+/** Records that a treat was given, decrementing today's remaining count. */
+export function recordTreatGiven(): void {
+  const data = load()
+  const today = todayKey()
+  const count = data.treats && data.treats.date === today ? data.treats.count + 1 : 1
+  save({ ...data, treats: { date: today, count } })
 }


### PR DESCRIPTION
## Summary

Tapping the adopted pet in-world previously always opened the manage modal (rename/dismiss/swap) with no way to actually interact with it day-to-day. This adds a small interaction menu with four options:

- **Give a Treat** — the dog wanders off, "finds" something, and returns with a reward (crystals, a random common/uncommon card, or a flavor trinket). Capped at twice a day; the player isn't blocked from playing while the pet is out.
- **Pet** / **Belly Rubs** / **Brush** — free, unlimited affection actions that trigger a quick wag + heart-bubble reaction with different flavor text each time. No reward, no cooldown.
- **Manage** — unchanged, still opens the existing rename/dismiss/swap modal.

Everything reuses existing building blocks rather than adding new infrastructure:

- The interaction menu itself reuses the dialogue-choice system (`QuestEvent.choices`/`HubDialogue`) already used for NPC and quest branching — no new modal component.
- The "walk out, find something, walk back" behavior reuses the dog state machine's existing `goal`/`stepToward` primitives (the same ones dogs already use to chase prey or walk to a den) and `followToward` (the exact call `follow-owner` already makes every tick to track the player via the `PLAYER_OWNER_ID` sentinel). Two new forced states, `fetching-out`/`fetching-return`, are added to the dog tick dispatch — deliberately excluded from the idle-weight table so they're only ever entered via the new `AnimalSystem.sendPetFetching()` call, never picked randomly.
- Pet/Belly Rubs/Brush all call one new `AnimalSystem.givePetAffection()` method that reuses the exact cosmetic `wagTimer`/heart-bubble hook ambient dogs already use when they like a nearby NPC — just triggered on demand instead.
- The reward-application code mirrors `HubWorld.tsx`'s existing `handleTreasureStep` handler (`saveCrystals`/`addCollectible`/`addCardsToCollection`) — one more caller, no new reward system.
- The twice-a-day cap mirrors the existing date-reset pattern used by `bounties.ts`/`dailyLogin.ts` (store an ISO date + counter, reset when the date isn't today).

### Files touched
- `web/src/game/hub/pet.ts` (+ tests) — treat-cooldown state (`getTreatsRemainingToday`/`canGiveTreat`/`recordTreatGiven`), preserved across adopt/dismiss
- `web/src/components/hub/hubAnimals.ts` — `fetching-out`/`fetching-return` dog states, `sendPetFetching`/`givePetAffection` on `AnimalSystem`
- `web/src/game/hub/animals.ts` — `DogState` union documentation only (not idle-weighted)
- `web/src/components/hub/HubTownCanvas.tsx` — new `petActionRef` prop exposing the two new methods, mirroring the existing `interiorEnterRef` pattern
- `web/src/components/hub/HubWorld.tsx` — replaces the pet-tap handler's hardcoded modal-open with the choice menu, plus the reward-granting helper

## Test plan
- [x] `cd web && npx tsc --noEmit` — passes
- [x] `cd web && npm run test` — 311/311 tests pass (6 new: treat-cooldown decrement/floor/reset-at-new-day, preserved across adopt/dismiss)
- [x] `cd web && npm run build` — passes
- [ ] Manual in-game walkthrough (tap the pet, try each option, confirm the dog visibly walks off and back for Give a Treat, confirm the daily cap and reset) — blocked in this sandbox by a pre-existing, unrelated issue: `firebase.ts` calls `getAuth()` eagerly with no env-var guard, so any component importing it (including `HubWorld`) crashes here without Firebase credentials configured, in both Storybook and `npm run dev`. Recommend a quick manual pass in an environment with Firebase configured before merge — same caveat as the previous two PRs on this branch.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EnyZvxsgU7oxX33zFTr7cT)_