### PR TITLE
Cap player pet wander at 8 tiles, add equippable pet accessories

### DIFF
--- a/docs/hubworld.md
+++ b/docs/hubworld.md
@@ -713,10 +713,93 @@ machine above with zero changes to its movement/pathing logic.
   animal in the game is re-created per session.
 - **UI** — `PetModal.tsx`, opened either via the `adopt-pet` screen reaction
   on a shelter interactable (see §7), the 🐾 toolbar button (shown only
-  while a pet is active), or by tapping the live pet sprite in-world
-  (`handleAnimalTap` special-cases `PLAYER_PET_ANIMAL_ID` in `HubWorld.tsx`).
-  Offers adopt (variant + name), rename, dismiss, and swap (confirms before
-  replacing an existing pet).
+  while a pet is active), or the **Manage** choice on the tap menu below.
+  Has an **Info** tab (rename, dismiss, swap — confirms before replacing an
+  existing pet) and an **Accessories** tab (below), reusing the
+  `hoa-tabs`/`hoa-tab`/`hoa-tab--active` classes `TownJournal.tsx` also uses.
+- **Wander cap** — the player's pet is never allowed more than
+  `PLAYER_LEASH_TILES` (8) tiles from the player, enforced three ways in
+  `hubAnimals.ts`, all scoped to `a.ownerId === PLAYER_OWNER_ID`: `dogIdle`'s
+  `roam` branch and `sendPetFetching`'s "walk out" destination are both
+  chosen relative to the *player's* live tile (not the dog's own tile, which
+  would let repeated roams/fetches compound drift); and a tick-final
+  safety-net check forces `state = 'follow-owner'` the instant the dog ends
+  up beyond the cap for any reason (chase, etc.), overriding whatever it was
+  doing. This makes "never more than 8 tiles" a true invariant rather than a
+  property of any one behaviour.
+- **Interactions** — tapping the live pet sprite opens a choice menu
+  (`handleAnimalTap` in `HubWorld.tsx`, via the same `QuestEvent.choices`
+  dialogue system used for NPC/quest branching) instead of jumping straight
+  to `PetModal`:
+  - **Give a Treat** — capped at 2/day (`pet.ts`: `getTreatsRemainingToday`/
+    `canGiveTreat`/`recordTreatGiven`, a date-keyed counter mirroring
+    `bounties.ts`'s daily-reset pattern). Calls `AnimalSystem.sendPetFetching
+    (onReturn)`, which drives the dog through two forced (never
+    idle-weighted) states — `fetching-out` (walks to a reachable tile 4-8
+    tiles from the player) then `fetching-return` (walks back via the same
+    `followToward` player-tracking `follow-owner` uses) — and fires
+    `onReturn` once it's back within ~3 tiles. `onReturn` grants one of a
+    small crystal amount, a random common/uncommon card, or a flavour
+    trinket collectible.
+  - **Pet / Belly Rubs / Brush** — free, unlimited, no cooldown. Each calls
+    `AnimalSystem.givePetAffection()` (wag + `♥` bubble, the same cosmetic
+    reaction ambient dogs give a liked NPC) with a different flavour line.
+  - **Manage** opens `PetModal`; **Never mind** dismisses the menu.
+  - `AnimalSystem.sendPetFetching`/`givePetAffection`/`setPetAccessory` (see
+    below) reach `HubWorld.tsx` via `petActionRef`, the same imperative
+    ref-bridging pattern `interiorEnterRef` uses.
+
+#### Pet accessories
+
+Collars, hats, bows, bow ties, boots, and coats — earned from quests,
+bounties, and a shop — with a real **composite sprite** showing the dog
+wearing the equipped item in the world, not just a UI badge.
+
+- **Catalog** — `web/src/data/petAccessories.ts`: `PET_ACCESSORIES`, an
+  array of `{ id, slot, name, price }`. `slot` is one of `'collar' | 'hat' |
+  'bow' | 'bow-tie' | 'boots' | 'coat'`. Adding a second accessory for an
+  existing slot is just one more catalog entry + one more SVG.
+- **Data model** — `pet.ts`'s store gains `accessories?: { owned: string[];
+  equipped: Partial<Record<AccessorySlot, string>> }`. Keying `equipped` by
+  slot (not a single flat id) is what makes "one equipped at a time" cheap
+  to loosen later: `getOwnedAccessoryIds`/`ownsAccessory`/`grantAccessory`
+  manage ownership; `getEquippedAccessoryId` returns the one worn item (if
+  any); `equipAccessory(id)` looks up the accessory's slot and **replaces
+  the entire `equipped` map** with just that one slot — removing that
+  single "clear other slots" line is the only change needed to support
+  multiple simultaneous slots in future; `unequipAccessory(id)` clears it.
+- **Composite sprite** — `hubAnimals.ts`. Every accessory SVG
+  (`web/public/sprites/pet-accessory-<id>.svg`) is authored in the exact
+  same `viewBox="0 0 32 32"` coordinate space as `animal-dog.svg`. Because
+  the dog sprite is bottom-anchored (`anchor.set(0.5, 1)`), giving the
+  accessory sprite the identical `width`/`height`/`anchor`/position every
+  tick lines it up with zero offset math. It's a PIXI **sibling** of the dog
+  sprite (`Animal.accessorySprite`), not a child — the dog's *texture* swaps
+  every animation frame rather than its transform moving, so only per-tick
+  sibling repositioning (mirrored in `advance()`, alongside the dog
+  sprite's own `x`/`y`/`scale.x`/`zIndex`) keeps it aligned.
+  `AnimalSystem.setPetAccessory(assetId | null)` swaps or removes it live;
+  `spawnFollowerPet` applies `getEquippedAccessoryId()` immediately on
+  spawn so it persists across town changes/reloads.
+- **UI** — `PetModal.tsx`'s Accessories tab: a grid of all 6 catalog
+  entries. Owned ones are tappable to equip/unequip (calling
+  `equipAccessory`/`unequipAccessory` + `petActionRef.current?.
+  setPetAccessory(id)` to update the live sprite immediately); un-owned ones
+  show a locked hint pointing at quests/bounties/the shop.
+- **Earning channels** — `HubQuestReward`/`BountyReward` both gained an
+  `accessory?: string` field, applied in `HubWorld.tsx`'s centralized
+  `grantQuestReward()` and `bounties.ts`'s `turnInBounty()` respectively
+  (2 accessories each, wired onto existing Ravenwatch quests/bounty
+  templates). The remaining 2 sell at **Tailor Pell** in Crownhaven
+  (capitalcity's `tailor` building) — a new `'accessory'`
+  `ShopTraderKind` in `shopStock.ts` (`getAccessoryStock()`, a fixed
+  2-item list, unlike the date-rotating card/augment/consumable stock)
+  registered in `SHOP_TRADER_REGISTRY`, with 2 `buy` interactables inside
+  `tailor` mirroring the `grand-bank`/`jeweller` decor+buy pattern (§7).
+  Because accessories are a permanent one-time unlock rather than daily
+  stock, `isShopItemSold()` treats an `'accessory'` grant as sold once
+  `ownsAccessory()` is true — that check never resets, unlike the
+  card/augment "bought today" state it shares a function with.
 
 ---
 

--- a/web/public/sprites/pet-accessory-black-bowtie.svg
+++ b/web/public/sprites/pet-accessory-black-bowtie.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- bow tie: at the neck/throat, distinct from the plain collar band -->
+  <path d="M16.8 16.4 L19.8 18 L16.8 19.6 Z" fill="#1a1a1a"/>
+  <path d="M22.8 16.4 L19.8 18 L22.8 19.6 Z" fill="#1a1a1a"/>
+  <circle cx="19.8" cy="18" r="1" fill="#000000"/>
+</svg>

--- a/web/public/sprites/pet-accessory-blue-coat.svg
+++ b/web/public/sprites/pet-accessory-blue-coat.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- coat: blanket draped over the back, clear of the head -->
+  <path d="M6 17 Q11 13.5 18 15.5 Q19 19 17 21 Q10 22.5 6 19.5 Z" fill="#2f5da0"/>
+  <path d="M6 17 Q11 13.5 18 15.5" stroke="#1e3f70" stroke-width="0.6" fill="none"/>
+</svg>

--- a/web/public/sprites/pet-accessory-brown-boots.svg
+++ b/web/public/sprites/pet-accessory-brown-boots.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- boots: cuffs at the base of both visible legs -->
+  <rect x="19.3" y="25.5" width="4.4" height="3" rx="1" fill="#5a3a1a"/>
+  <rect x="7.3" y="25.5" width="4.4" height="3" rx="1" fill="#5a3a1a"/>
+</svg>

--- a/web/public/sprites/pet-accessory-leather-collar.svg
+++ b/web/public/sprites/pet-accessory-leather-collar.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- collar: wraps the neck where the head meets the body -->
+  <ellipse cx="21" cy="19.5" rx="3.2" ry="2.6" fill="none" stroke="#6b4423" stroke-width="2.2"/>
+  <circle cx="21" cy="22" r="0.9" fill="#d4af37"/>
+</svg>

--- a/web/public/sprites/pet-accessory-red-bow.svg
+++ b/web/public/sprites/pet-accessory-red-bow.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- bow: perched above the ear, atop the head -->
+  <path d="M17.2 9.4 L20.5 11 L17.2 12.6 Z" fill="#c81e3a"/>
+  <path d="M23.8 9.4 L20.5 11 L23.8 12.6 Z" fill="#c81e3a"/>
+  <circle cx="20.5" cy="11" r="1.1" fill="#8f1327"/>
+</svg>

--- a/web/public/sprites/pet-accessory-top-hat.svg
+++ b/web/public/sprites/pet-accessory-top-hat.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- top hat: sits on the crown of the head -->
+  <ellipse cx="23" cy="10.2" rx="4.2" ry="1.1" fill="#1a1a1a"/>
+  <rect x="20.3" y="5.2" width="5.4" height="5.2" rx="0.6" fill="#222222"/>
+  <rect x="20.3" y="8.6" width="5.4" height="1.1" fill="#7a1f2b"/>
+</svg>

--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -81,7 +81,7 @@ interface Props {
   onAnimalSeen?:    (type: AnimalType, variant?: string) => void
   interiorEnterRef?: React.MutableRefObject<((buildingId: string) => void) | null>
   interiorExitRef?:  React.MutableRefObject<(() => void) | null>
-  petActionRef?:     React.MutableRefObject<{ sendPetFetching: (onReturn: () => void) => boolean; givePetAffection: () => void } | null>
+  petActionRef?:     React.MutableRefObject<{ sendPetFetching: (onReturn: () => void) => boolean; givePetAffection: () => void; setPetAccessory: (assetId: string | null) => void } | null>
   onEnterInterior?:  () => void
   onExitInterior?:   () => void
   onTileTap?:        (tx: number, ty: number) => void
@@ -651,6 +651,9 @@ export function HubTownCanvas({
                   parent.addChild(badge)
                   break
                 }
+                case 'accessory':
+                  loadArt(`pet-accessory-${item.grant.id}`)
+                  break
               }
             }
             continue
@@ -2448,7 +2451,7 @@ export function HubTownCanvas({
       },
     })
     getAnimalsInBuildingFn = animalSystem.getAnimalsInBuilding
-    if (petActionRef) petActionRef.current = { sendPetFetching: animalSystem.sendPetFetching, givePetAffection: animalSystem.givePetAffection }
+    if (petActionRef) petActionRef.current = { sendPetFetching: animalSystem.sendPetFetching, givePetAffection: animalSystem.givePetAffection, setPetAccessory: animalSystem.setPetAccessory }
 
     // Spawn the player's adopted follower pet (if any) near their spawn tile.
     const activePet = getActivePet()

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -33,7 +33,7 @@ import { QuestsModal } from './QuestsModal'
 import { BountyBoardModal } from './BountyBoardModal'
 import { hasUnclaimedBounties, getPendingBountyReport, getPendingBountyCollect, advanceBountyStep, getActiveBountyStep } from '../../game/hub/bounties'
 import { PetModal } from './PetModal'
-import { getActivePet, getTreatsRemainingToday, canGiveTreat, recordTreatGiven } from '../../game/hub/pet'
+import { getActivePet, getTreatsRemainingToday, canGiveTreat, recordTreatGiven, grantAccessory } from '../../game/hub/pet'
 import { PLAYER_PET_ANIMAL_ID } from './hubAnimals'
 import { TownDirectory } from './TownDirectory'
 import { TownJournal } from './TownJournal'
@@ -355,7 +355,7 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onEndless, onWorldMap
   const returnRef        = useRef(null) as React.MutableRefObject<(() => void) | null>
   const interiorEnterRef = useRef<((buildingId: string) => void) | null>(null)
   const interiorExitRef  = useRef<(() => void) | null>(null)
-  const petActionRef     = useRef<{ sendPetFetching: (onReturn: () => void) => boolean; givePetAffection: () => void } | null>(null)
+  const petActionRef     = useRef<{ sendPetFetching: (onReturn: () => void) => boolean; givePetAffection: () => void; setPetAccessory: (assetId: string | null) => void } | null>(null)
   const playerName = loadPlayerName()
 
   const unitCards = useMemo(() => {
@@ -703,6 +703,9 @@ function grantQuestReward(quest: HubQuestDef): void {
     for (const [npcId, grant] of Object.entries(reward.relationship)) {
       addRelationshipPoints(npcId, grant.track, grant.points)
     }
+  }
+  if (reward.accessory) {
+    grantAccessory(reward.accessory)
   }
 }
 
@@ -1181,6 +1184,9 @@ function hasOfferableQuest(giverId: string): boolean {
               case 'consumable':
                 addToConsumableStash(item.grant.id)
                 break
+              case 'accessory':
+                grantAccessory(item.grant.id)
+                break
             }
             emitSound('shopPurchase')
             refreshState()
@@ -1333,7 +1339,7 @@ function hasOfferableQuest(giverId: string): boolean {
 
         {questsOpen && <QuestsModal onClose={() => setQuestsOpen(false)} onAbandon={handleQuestAbandon} questDefs={questDefs} resolveNpcName={getNpcDisplayName}/>}
         {bountyBoardOpen && <BountyBoardModal onClose={() => setBountyBoardOpen(false)} resolveNpcName={getNpcDisplayName}/>}
-        {petModalOpen && <PetModal onClose={() => setPetModalOpen(false)} />}
+        {petModalOpen && <PetModal onClose={() => setPetModalOpen(false)} petActionRef={petActionRef} />}
         {directoryOpen && <TownDirectory onClose={() => setDirectoryOpen(false)} locationData={locationData} pinnedNpcId={pinnedNpcId} onTogglePin={togglePinnedNpc} onShowRelationship={setRelationshipNpcId} />}
         {journalOpen && <TownJournal onClose={() => setJournalOpen(false)} locationData={locationData} />}
         {upgradesOpen && <HubTownUpgrades onClose={() => setUpgradesOpen(false)} townName={town} reputation={getTownReputation(town)} crystals={loadCrystals()} rows={upgradeRows} onUpgrade={handleUpgrade} tributeAmount={tributeAmount(town)} tributeAvailable={tributeAvailable(town)} onCollectTribute={handleCollectTribute} />}

--- a/web/src/components/hub/PetModal.tsx
+++ b/web/src/components/hub/PetModal.tsx
@@ -1,11 +1,16 @@
 import React, { useState } from 'react'
 import { ModalBackdrop } from '../ui/ModalBackdrop'
 import { ConfirmModal } from '../modals/ConfirmModal'
-import { getActivePet, adoptPet, renamePet, dismissPet } from '../../game/hub/pet'
+import {
+  getActivePet, adoptPet, renamePet, dismissPet,
+  ownsAccessory, getEquippedAccessoryId, equipAccessory, unequipAccessory,
+} from '../../game/hub/pet'
 import { ANIMAL_SPECS } from '../../game/hub/animals'
+import { PET_ACCESSORIES } from '../../data/petAccessories'
 
 interface Props {
   onClose: () => void
+  petActionRef?: React.MutableRefObject<{ setPetAccessory: (assetId: string | null) => void } | null>
 }
 
 const DOG_VARIANTS = Object.keys(ANIMAL_SPECS.dog.palette)
@@ -40,13 +45,54 @@ function PickerBody({ onAdopt, submitLabel }: { onAdopt: (variant: string, name:
   )
 }
 
-export function PetModal({ onClose }: Props) {
+function AccessoriesTab({ petActionRef, refresh }: {
+  petActionRef?: React.MutableRefObject<{ setPetAccessory: (assetId: string | null) => void } | null>
+  refresh: () => void
+}) {
+  const equippedId = getEquippedAccessoryId()
+
+  const toggle = (id: string) => {
+    if (equippedId === id) {
+      unequipAccessory(id)
+      petActionRef?.current?.setPetAccessory(null)
+    } else {
+      equipAccessory(id)
+      petActionRef?.current?.setPetAccessory(id)
+    }
+    refresh()
+  }
+
+  return (
+    <div className="pet-modal__accessories">
+      {PET_ACCESSORIES.map(acc => {
+        const owned = ownsAccessory(acc.id)
+        const equipped = equippedId === acc.id
+        return (
+          <button
+            key={acc.id}
+            className={`pet-modal__accessory${equipped ? ' pet-modal__accessory--equipped' : ''}${!owned ? ' pet-modal__accessory--locked' : ''}`}
+            disabled={!owned}
+            onClick={() => toggle(acc.id)}
+          >
+            <span className="pet-modal__accessory-name">{acc.name}</span>
+            <span className="pet-modal__accessory-status">
+              {equipped ? 'Equipped' : owned ? 'Tap to equip' : 'Found on quests/bounties, or buy from Tailor Pell in Crownhaven'}
+            </span>
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
+export function PetModal({ onClose, petActionRef }: Props) {
   const [, setTick] = useState(0)
   const refresh = () => setTick(t => t + 1)
   const [renameValue, setRenameValue] = useState<string | null>(null)
   const [swapping, setSwapping] = useState(false)
   const [confirmSwap, setConfirmSwap] = useState<{ variant: string; name: string } | null>(null)
   const [confirmDismiss, setConfirmDismiss] = useState(false)
+  const [tab, setTab] = useState<'info' | 'accessories'>('info')
 
   const pet = getActivePet()
 
@@ -88,28 +134,39 @@ export function PetModal({ onClose }: Props) {
 
         {pet && !swapping && (
           <>
-            <div className="pet-modal__current">
-              <span
-                className="pet-modal__current-swatch"
-                style={{ backgroundColor: `#${(ANIMAL_SPECS.dog.palette[pet.variant] ?? 0x8b5a2b).toString(16).padStart(6, '0')}` }}
-              />
-              <span className="pet-modal__current-name">{pet.name}</span>
+            <div className="hoa-tabs">
+              <button className={`hoa-tab${tab === 'info' ? ' hoa-tab--active' : ''}`} onClick={() => setTab('info')}>Info</button>
+              <button className={`hoa-tab${tab === 'accessories' ? ' hoa-tab--active' : ''}`} onClick={() => setTab('accessories')}>Accessories</button>
             </div>
-            <input
-              className="pet-modal__name-input"
-              placeholder="Rename your pup"
-              value={renameValue ?? pet.name}
-              maxLength={24}
-              onChange={e => setRenameValue(e.target.value)}
-            />
-            <button
-              className="action-btn"
-              onClick={() => { if (renameValue != null) renamePet(renameValue); setRenameValue(null); refresh() }}
-            >Save Name</button>
-            <div className="pet-modal__actions-row">
-              <button className="action-btn" onClick={() => setSwapping(true)}>Adopt a Different Dog</button>
-              <button className="action-btn action-btn--danger" onClick={() => setConfirmDismiss(true)}>Dismiss Pet</button>
-            </div>
+
+            {tab === 'info' && (
+              <>
+                <div className="pet-modal__current">
+                  <span
+                    className="pet-modal__current-swatch"
+                    style={{ backgroundColor: `#${(ANIMAL_SPECS.dog.palette[pet.variant] ?? 0x8b5a2b).toString(16).padStart(6, '0')}` }}
+                  />
+                  <span className="pet-modal__current-name">{pet.name}</span>
+                </div>
+                <input
+                  className="pet-modal__name-input"
+                  placeholder="Rename your pup"
+                  value={renameValue ?? pet.name}
+                  maxLength={24}
+                  onChange={e => setRenameValue(e.target.value)}
+                />
+                <button
+                  className="action-btn"
+                  onClick={() => { if (renameValue != null) renamePet(renameValue); setRenameValue(null); refresh() }}
+                >Save Name</button>
+                <div className="pet-modal__actions-row">
+                  <button className="action-btn" onClick={() => setSwapping(true)}>Adopt a Different Dog</button>
+                  <button className="action-btn action-btn--danger" onClick={() => setConfirmDismiss(true)}>Dismiss Pet</button>
+                </div>
+              </>
+            )}
+
+            {tab === 'accessories' && <AccessoriesTab petActionRef={petActionRef} refresh={refresh} />}
           </>
         )}
 

--- a/web/src/components/hub/hubAnimals.ts
+++ b/web/src/components/hub/hubAnimals.ts
@@ -10,6 +10,7 @@ import * as PIXI from 'pixi.js'
 import { findPath } from '../../utils/hubPathfinder'
 import { loadAnimFrames, loadTextureUrl } from '../../utils/pixiHelpers'
 import { emitSound, SoundId } from '../../game/sound'
+import { getEquippedAccessoryId } from '../../game/hub/pet'
 import type { HubAnimal } from '../../data/hub/loader'
 import {
   AnimalType,
@@ -63,6 +64,10 @@ interface Animal {
   bubble: PIXI.Container | null
   bubbleTimer: number
   indicator: PIXI.Text | null
+  // player's pet: composited equipped-accessory sprite (sibling, not a child —
+  // the dog's texture swaps per animation frame, so only sibling repositioning
+  // every tick keeps it aligned; see advance())
+  accessorySprite: PIXI.Sprite | null
   // dog social memory
   ownerId?: string
   seen: Set<string>
@@ -132,6 +137,9 @@ export interface GlowSource { x: number; y: number; radius: number; pulse: boole
 // no changes to the state machine itself.
 export const PLAYER_OWNER_ID = '__player__'
 export const PLAYER_PET_ANIMAL_ID = '__player-pet__'
+/** The player's pet is never allowed to wander more than this many tiles
+ *  from the player — enforced by the leash check in the dog tick dispatch. */
+export const PLAYER_LEASH_TILES = 8
 
 export interface AnimalSystem {
   tick: (deltaMS: number) => void
@@ -148,6 +156,9 @@ export interface AnimalSystem {
   sendPetFetching: (onReturn: () => void) => boolean
   /** Cosmetic affection reaction (wag + heart bubble) for the player's pet. */
   givePetAffection: () => void
+  /** Equips (or, passing null, unequips) a composited accessory sprite on the
+   *  player's pet — pass an accessory id from petAccessories.ts. */
+  setPetAccessory: (assetId: string | null) => void
   destroy: () => void
 }
 
@@ -249,6 +260,11 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
       a.sprite.y = a.baseY
     }
     if (a.bottomAnchored) a.sprite.zIndex = a.sprite.y
+    if (a.accessorySprite) {
+      a.accessorySprite.position.copyFrom(a.sprite.position)
+      a.accessorySprite.scale.x = a.sprite.scale.x
+      a.accessorySprite.zIndex = a.sprite.zIndex + 0.5
+    }
   }
 
   const isMoving = (a: Animal) => a.target !== null
@@ -434,6 +450,15 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
       const owner = npcs.find(n => n.id === a.ownerId)
       if (owner) followToward(a, owner, walkable)
       else { const d = randOf(tilesWithin(walkable, a.tx, a.ty, 5)); if (d) setPath(a, [a.tx, a.ty], d, walkable) }
+    } else if (a.ownerId === PLAYER_OWNER_ID) {
+      // The player's own pet roams within a leash of the player, not of
+      // wherever it happens to already be — prevents drift compounding
+      // across repeated roam cycles (see the PLAYER_LEASH_TILES cap below).
+      const owner = npcs.find(n => n.id === PLAYER_OWNER_ID)
+      const otx = owner ? Math.floor(owner.x / T) : a.tx
+      const oty = owner ? Math.floor(owner.y / T) : a.ty
+      const d = randOf(tilesWithin(walkable, otx, oty, PLAYER_LEASH_TILES))
+      if (d) setPath(a, [a.tx, a.ty], d, walkable)
     } else {
       const d = randOf(tilesWithin(walkable, a.tx, a.ty, 5))
       if (d) setPath(a, [a.tx, a.ty], d, walkable)
@@ -889,6 +914,20 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
           if (prey) { a.goal = [prey.tx, prey.ty]; stepToward(a, walkable, 'grass') }
           else a.stateTimer = 0
         }
+        // Safety-net leash: whatever pulled the player's pet away (roam,
+        // chase, etc.), never let it end up more than PLAYER_LEASH_TILES
+        // from the player. Runs last so it has the final say each tick.
+        if (a.ownerId === PLAYER_OWNER_ID) {
+          const owner = npcs.find(n => n.id === PLAYER_OWNER_ID)
+          if (owner) {
+            const dtx = Math.abs(a.tx - Math.floor(owner.x / T))
+            const dty = Math.abs(a.ty - Math.floor(owner.y / T))
+            if (Math.max(dtx, dty) > PLAYER_LEASH_TILES) {
+              a.state = 'follow-owner'; a.stateTimer = randomDuration('follow-owner')
+              followToward(a, owner, walkable)
+            }
+          }
+        }
         if (!isMoving(a) && a.stateTimer <= 0) dogIdle(a, walkable, npcs)
       }
     }
@@ -947,7 +986,7 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
       bubble: null, bubbleTimer: 0,
       seen: new Set(), opinion: new Map(), reactCooldown: 0, wagTimer: 0,
       fleeRequested: false, bobPhase: Math.random() * Math.PI * 2, baseY: c.y,
-      indicator: null,
+      indicator: null, accessorySprite: null,
     }
     // Half of the procedural cats & dogs den in a home building at night.
     if (!placed && spec.dens && opts.homes.length > 0 && Math.random() < 0.5) {
@@ -1069,6 +1108,7 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
     for (const a of animals) {
       if (a.bubble) opts.bubbleLayer.removeChild(a.bubble)
       if (a.indicator) opts.bubbleLayer.removeChild(a.indicator)
+      if (a.accessorySprite) a.accessorySprite.destroy()
       a.sprite.destroy()
     }
     animals.length = 0
@@ -1082,7 +1122,42 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
     const [a] = animals.splice(idx, 1)
     if (a.bubble) opts.bubbleLayer.removeChild(a.bubble)
     if (a.indicator) opts.bubbleLayer.removeChild(a.indicator)
+    if (a.accessorySprite) a.accessorySprite.destroy()
     a.sprite.destroy()
+  }
+
+  function clearAccessorySprite(a: Animal): void {
+    if (a.accessorySprite) {
+      a.accessorySprite.destroy()
+      a.accessorySprite = null
+    }
+  }
+
+  // Composites the equipped accessory as a PIXI sibling of the dog sprite —
+  // same width/height/anchor/position every tick (see advance()) — so an SVG
+  // authored in animal-dog.svg's 32x32 coordinate space lines up automatically.
+  function applyAccessorySprite(a: Animal, assetId: string): void {
+    loadTextureUrl(`${opts.baseUrl}sprites/pet-accessory-${assetId}.svg`).then(tex => {
+      // The pet may have been removed, or the accessory changed again, while this loaded.
+      if (!animals.includes(a)) return
+      clearAccessorySprite(a)
+      const sprite = new PIXI.Sprite(tex)
+      sprite.width = a.sprite.width
+      sprite.height = a.sprite.height
+      sprite.anchor.set(a.sprite.anchor.x, a.sprite.anchor.y)
+      sprite.position.copyFrom(a.sprite.position)
+      sprite.scale.x = a.sprite.scale.x
+      sprite.zIndex = a.sprite.zIndex + 0.5
+      a.sprite.parent?.addChild(sprite)
+      a.accessorySprite = sprite
+    }).catch(() => {})
+  }
+
+  function setPetAccessory(assetId: string | null): void {
+    const a = animals.find(x => x.id === PLAYER_PET_ANIMAL_ID)
+    if (!a) return
+    clearAccessorySprite(a)
+    if (assetId) applyAccessorySprite(a, assetId)
   }
 
   function spawnFollowerPet(variant: string, tx: number, ty: number): void {
@@ -1090,7 +1165,10 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
     void makeAnimal('dog', tx, ty, { id: PLAYER_PET_ANIMAL_ID, type: 'dog', variant, tx, ty, roam: true })
       .then(() => {
         const a = animals.find(x => x.id === PLAYER_PET_ANIMAL_ID)
-        if (a) a.ownerId = PLAYER_OWNER_ID
+        if (!a) return
+        a.ownerId = PLAYER_OWNER_ID
+        const equipped = getEquippedAccessoryId()
+        if (equipped) applyAccessorySprite(a, equipped)
       })
   }
 
@@ -1098,9 +1176,15 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
     const a = animals.find(x => x.id === PLAYER_PET_ANIMAL_ID)
     if (!a || a.state === 'fetching-out' || a.state === 'fetching-return') return false
     const walkable = opts.getWalkable()
-    const far = tilesWithin(walkable, a.tx, a.ty, 8)
-      .filter(([x, y]) => Math.max(Math.abs(x - a.tx), Math.abs(y - a.ty)) >= 4)
-    const dest = randOf(far) ?? randOf(tilesWithin(walkable, a.tx, a.ty, 8))
+    // Fetch destination is relative to the PLAYER (not the dog's own
+    // position) and capped at the same leash radius, so a treat given while
+    // the dog is already near the edge of the leash can't push it further out.
+    const owner = opts.getNpcPositions().find(n => n.id === PLAYER_OWNER_ID)
+    const otx = owner ? Math.floor(owner.x / T) : a.tx
+    const oty = owner ? Math.floor(owner.y / T) : a.ty
+    const far = tilesWithin(walkable, otx, oty, PLAYER_LEASH_TILES)
+      .filter(([x, y]) => Math.max(Math.abs(x - a.tx), Math.abs(y - a.ty)) >= 3)
+    const dest = randOf(far) ?? randOf(tilesWithin(walkable, otx, oty, PLAYER_LEASH_TILES))
     if (!dest) return false
     fetchCallback = onReturn
     a.state = 'fetching-out'
@@ -1116,5 +1200,5 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
     a.wagTimer = 1300
   }
 
-  return { tick, getAnimalsInBuilding, getGlowSources, spawnFollowerPet, removeAnimal, sendPetFetching, givePetAffection, destroy }
+  return { tick, getAnimalsInBuilding, getGlowSources, spawnFollowerPet, removeAnimal, sendPetFetching, givePetAffection, setPetAccessory, destroy }
 }

--- a/web/src/data/hub/capitalcity/config.json
+++ b/web/src/data/hub/capitalcity/config.json
@@ -3820,6 +3820,22 @@
       "building": "jeweller",
       "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 2 }],
       "reactions": [{ "type": "buy", "slotIndex": 2 }]
+    },
+    {
+      "id": "tailor-item-0",
+      "tx": 11,
+      "ty": 3,
+      "building": "tailor",
+      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 0 }],
+      "reactions": [{ "type": "buy", "slotIndex": 0 }]
+    },
+    {
+      "id": "tailor-item-1",
+      "tx": 11,
+      "ty": 4,
+      "building": "tailor",
+      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 1 }],
+      "reactions": [{ "type": "buy", "slotIndex": 1 }]
     }
   ],
   "ambientNpcSprites": [

--- a/web/src/data/hub/questDefs.ts
+++ b/web/src/data/hub/questDefs.ts
@@ -22,6 +22,8 @@ export interface HubQuestReward {
   /** Per-NPC relationship-track points granted on quest completion. */
   relationship?: Record<string, RelationshipGrant>
   unlock?: string
+  /** Pet accessory id (from petAccessories.ts) granted on quest completion. */
+  accessory?: string
 }
 
 /** npcId -> track -> levelString -> line shown when that track is active. */

--- a/web/src/data/hub/ravenwatch/questDefs.json
+++ b/web/src/data/hub/ravenwatch/questDefs.json
@@ -31,7 +31,8 @@
         "crystals": 40,
         "friendship": {
           "fisherman": 15
-        }
+        },
+        "accessory": "red-bow"
       }
     },
     {
@@ -116,7 +117,8 @@
         }
       ],
       "reward": {
-        "crystals": 35
+        "crystals": 35,
+        "accessory": "leather-collar"
       }
     },
     {

--- a/web/src/data/petAccessories.ts
+++ b/web/src/data/petAccessories.ts
@@ -1,0 +1,27 @@
+// Pet accessory catalog. Each entry maps 1:1 to a composited sprite asset at
+// web/public/sprites/pet-accessory-<id>.svg (see hubAnimals.ts's
+// setPetAccessory/AnimalSystem). Adding a second accessory for an existing
+// slot (e.g. a second hat) just needs one more entry here + one more SVG —
+// no structural change.
+
+export type AccessorySlot = 'collar' | 'hat' | 'bow' | 'bow-tie' | 'boots' | 'coat'
+
+export interface PetAccessoryDef {
+  id:    string
+  slot:  AccessorySlot
+  name:  string
+  price: number  // crystals, for the Tailor Pell shop listing
+}
+
+export const PET_ACCESSORIES: PetAccessoryDef[] = [
+  { id: 'leather-collar', slot: 'collar',  name: 'Leather Collar',  price: 40 },
+  { id: 'top-hat',        slot: 'hat',     name: 'Top Hat',         price: 60 },
+  { id: 'red-bow',        slot: 'bow',     name: 'Red Bow',         price: 35 },
+  { id: 'black-bowtie',   slot: 'bow-tie', name: 'Black Bow Tie',   price: 45 },
+  { id: 'brown-boots',    slot: 'boots',   name: 'Brown Boots',     price: 50 },
+  { id: 'blue-coat',      slot: 'coat',    name: 'Blue Coat',       price: 65 },
+]
+
+export function getPetAccessoryDef(id: string): PetAccessoryDef | undefined {
+  return PET_ACCESSORIES.find(a => a.id === id)
+}

--- a/web/src/game/hub/bounties.ts
+++ b/web/src/game/hub/bounties.ts
@@ -6,12 +6,15 @@
 // Pairs with BountyBoardModal.tsx and the 'bounty-board' interactable screen.
 
 import { saveCrystals, loadCrystals } from '../collection'
+import { grantAccessory } from './pet'
 import type { HubQuestStep } from '../../data/hub/questDefs'
 
 const KEY = 'jarv_hub_bounties'
 
 export interface BountyReward {
   crystals: number
+  /** Pet accessory id (from petAccessories.ts) granted on turn-in. */
+  accessory?: string
 }
 
 export interface BountyDef {
@@ -37,7 +40,7 @@ const BOUNTY_TEMPLATES: BountyDef[] = [
     title: 'Report to the Captain',
     desc: 'Walk the walls, then report what you saw to Guard Captain Thorin.',
     icon: '🛡️',
-    reward: { crystals: 35 },
+    reward: { crystals: 35, accessory: 'brown-boots' },
     steps: [{ key: 'report', type: 'report', targetNpcId: 'guard-captain-thorin', required: 1 }],
   },
   {
@@ -69,7 +72,7 @@ const BOUNTY_TEMPLATES: BountyDef[] = [
     title: 'Word for the Trader',
     desc: 'Pass word to the Junk Trader that the outskirts fences are mended.',
     icon: '🔨',
-    reward: { crystals: 45 },
+    reward: { crystals: 45, accessory: 'black-bowtie' },
     steps: [{ key: 'report', type: 'report', targetNpcId: 'trader', required: 1 }],
   },
   {
@@ -255,6 +258,7 @@ export function turnInBounty(id: string): number {
   saveBountyState(state)
 
   saveCrystals(loadCrystals() + def.reward.crystals)
+  if (def.reward.accessory) grantAccessory(def.reward.accessory)
   return def.reward.crystals
 }
 

--- a/web/src/game/hub/pet.test.ts
+++ b/web/src/game/hub/pet.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, beforeEach } from 'vitest'
-import { getActivePet, hasActivePet, adoptPet, renamePet, dismissPet, getTreatsRemainingToday, canGiveTreat, recordTreatGiven } from './pet'
+import {
+  getActivePet, hasActivePet, adoptPet, renamePet, dismissPet,
+  getTreatsRemainingToday, canGiveTreat, recordTreatGiven,
+  getOwnedAccessoryIds, ownsAccessory, grantAccessory,
+  getEquippedAccessoryId, equipAccessory, unequipAccessory,
+} from './pet'
 
 // In-memory localStorage mock (tests run in node environment)
 const store = new Map<string, string>()
@@ -125,5 +130,70 @@ describe('treat cooldown', () => {
     store.set('jarv_hub_pet', JSON.stringify(raw))
     expect(getTreatsRemainingToday()).toBe(2)
     expect(canGiveTreat()).toBe(true)
+  })
+})
+
+describe('pet accessories', () => {
+  it('owns nothing and has nothing equipped by default', () => {
+    expect(getOwnedAccessoryIds()).toEqual([])
+    expect(ownsAccessory('leather-collar')).toBe(false)
+    expect(getEquippedAccessoryId()).toBeNull()
+  })
+
+  it('grants an accessory and it becomes owned', () => {
+    expect(grantAccessory('leather-collar')).toBe(true)
+    expect(ownsAccessory('leather-collar')).toBe(true)
+    expect(getOwnedAccessoryIds()).toEqual(['leather-collar'])
+  })
+
+  it('granting the same accessory twice is a no-op the second time', () => {
+    expect(grantAccessory('leather-collar')).toBe(true)
+    expect(grantAccessory('leather-collar')).toBe(false)
+    expect(getOwnedAccessoryIds()).toEqual(['leather-collar'])
+  })
+
+  it('cannot equip an unowned or unknown accessory', () => {
+    expect(equipAccessory('leather-collar')).toBe(false)
+    expect(equipAccessory('not-a-real-accessory')).toBe(false)
+    expect(getEquippedAccessoryId()).toBeNull()
+  })
+
+  it('equips an owned accessory', () => {
+    grantAccessory('leather-collar')
+    expect(equipAccessory('leather-collar')).toBe(true)
+    expect(getEquippedAccessoryId()).toBe('leather-collar')
+  })
+
+  it('equipping a different accessory replaces the previous one (one at a time)', () => {
+    grantAccessory('leather-collar')
+    grantAccessory('top-hat')
+    equipAccessory('leather-collar')
+    equipAccessory('top-hat')
+    expect(getEquippedAccessoryId()).toBe('top-hat')
+  })
+
+  it('unequips the currently-equipped accessory', () => {
+    grantAccessory('leather-collar')
+    equipAccessory('leather-collar')
+    unequipAccessory('leather-collar')
+    expect(getEquippedAccessoryId()).toBeNull()
+  })
+
+  it('unequipping an accessory that is not the equipped one is a no-op', () => {
+    grantAccessory('leather-collar')
+    grantAccessory('top-hat')
+    equipAccessory('top-hat')
+    unequipAccessory('leather-collar')
+    expect(getEquippedAccessoryId()).toBe('top-hat')
+  })
+
+  it('accessory state persists across adopt/dismiss', () => {
+    adoptPet('dog', 'golden', 'Rex')
+    grantAccessory('leather-collar')
+    equipAccessory('leather-collar')
+    dismissPet()
+    adoptPet('dog', 'black', 'Shadow')
+    expect(getEquippedAccessoryId()).toBe('leather-collar')
+    expect(ownsAccessory('leather-collar')).toBe(true)
   })
 })

--- a/web/src/game/hub/pet.ts
+++ b/web/src/game/hub/pet.ts
@@ -1,3 +1,5 @@
+import { getPetAccessoryDef, type AccessorySlot } from '../../data/petAccessories'
+
 const KEY = 'jarv_hub_pet'
 
 const MAX_TREATS_PER_DAY = 2
@@ -13,9 +15,15 @@ interface TreatState {
   count: number
 }
 
+interface AccessoryState {
+  owned:    string[]                                // accessory ids owned
+  equipped: Partial<Record<AccessorySlot, string>>   // slot -> accessory id
+}
+
 interface Store {
-  pet:    PetRecord | null
-  treats?: TreatState
+  pet:          PetRecord | null
+  treats?:      TreatState
+  accessories?: AccessoryState
 }
 
 function load(): Store {
@@ -85,4 +93,60 @@ export function recordTreatGiven(): void {
   const today = todayKey()
   const count = data.treats && data.treats.date === today ? data.treats.count + 1 : 1
   save({ ...data, treats: { date: today, count } })
+}
+
+function loadAccessories(): AccessoryState {
+  return load().accessories ?? { owned: [], equipped: {} }
+}
+
+export function getOwnedAccessoryIds(): string[] {
+  return loadAccessories().owned
+}
+
+export function ownsAccessory(id: string): boolean {
+  return loadAccessories().owned.includes(id)
+}
+
+/** Grants an accessory (idempotent). Returns true if newly granted. */
+export function grantAccessory(id: string): boolean {
+  const data = load()
+  const accessories = data.accessories ?? { owned: [], equipped: {} }
+  if (accessories.owned.includes(id)) return false
+  accessories.owned = [...accessories.owned, id]
+  save({ ...data, accessories })
+  return true
+}
+
+/** The currently-equipped accessory id, if any (any slot). */
+export function getEquippedAccessoryId(): string | null {
+  const equipped = loadAccessories().equipped
+  return Object.values(equipped)[0] ?? null
+}
+
+/**
+ * Equips an owned accessory. For now, exactly one accessory can be equipped
+ * at a time overall, so equipping one clears every other slot first — that
+ * single line is the only change needed to later support wearing one
+ * accessory per slot simultaneously. Returns false if the accessory isn't
+ * owned or doesn't exist in the catalog.
+ */
+export function equipAccessory(id: string): boolean {
+  const def = getPetAccessoryDef(id)
+  if (!def || !ownsAccessory(id)) return false
+  const data = load()
+  const accessories = data.accessories ?? { owned: [], equipped: {} }
+  accessories.equipped = { [def.slot]: id }
+  save({ ...data, accessories })
+  return true
+}
+
+export function unequipAccessory(id: string): void {
+  const def = getPetAccessoryDef(id)
+  if (!def) return
+  const data = load()
+  const accessories = data.accessories ?? { owned: [], equipped: {} }
+  if (accessories.equipped[def.slot] !== id) return
+  const equipped = { ...accessories.equipped }
+  delete equipped[def.slot]
+  save({ ...data, accessories: { ...accessories, equipped } })
 }

--- a/web/src/game/hub/shopStock.ts
+++ b/web/src/game/hub/shopStock.ts
@@ -11,11 +11,12 @@
 import { getDailyShopCards, getDailyShopAugment, getShopSlotKey, makeSeededRng, dateHash, ShopCardFilter } from '../shopSchedule'
 import { CardRarity } from '../types'
 import { ALL_CONSUMABLES } from '../questline'
+import { getPetAccessoryDef } from '../../data/petAccessories'
 
 /** Widened to a plain string: new traders register under any building id, not just Ravenwatch's 3. */
 export type ShopBuildingId = string
 
-export type ShopTraderKind = 'card' | 'augment' | 'consumable'
+export type ShopTraderKind = 'card' | 'augment' | 'consumable' | 'accessory'
 
 export interface ShopTraderConfig {
   kind: ShopTraderKind
@@ -51,12 +52,16 @@ export const SHOP_TRADER_REGISTRY: Record<string, ShopTraderConfig> = {
   'jeweller':        { kind: 'card', cardFilter: { rarity: 'uncommon' } },               // capitalcity — Jeweller Isolde, Curio Dealer
   'treasury-annex':  { kind: 'card', cardFilter: { rarities: ['epic', 'legendary'] } },  // royalpalace — Master of Coin Aldric, Vaultkeeper
   'spellwright-den': { kind: 'card', cardFilter: { cardType: 'upgrade' } },              // dreadspirecitadel — Ashka the Grimoire-Peddler, Spellwright
+
+  // Pet accessories (see #1845 follow-up)
+  'tailor':          { kind: 'accessory' },  // capitalcity — Tailor Pell
 }
 
 export type ShopStockGrant =
   | { kind: 'card'; cardName: string }
   | { kind: 'augment'; augmentName: string }
   | { kind: 'consumable'; id: string }
+  | { kind: 'accessory'; id: string }
 
 export interface ShopStockItem {
   itemName: string
@@ -82,6 +87,17 @@ function getSupplyStock(at: Date | undefined, count: number): ShopStockItem[] {
   return picks
 }
 
+// Fixed (not date-rotating) accessory catalog for the Tailor Pell shop — the 2
+// accessories not already covered by a quest or a bounty reward.
+const ACCESSORY_SHOP_IDS = ['top-hat', 'blue-coat']
+
+function getAccessoryStock(): ShopStockItem[] {
+  return ACCESSORY_SHOP_IDS.map(id => {
+    const def = getPetAccessoryDef(id)!
+    return { itemName: def.name, price: def.price, grant: { kind: 'accessory', id } }
+  })
+}
+
 /** Today's (current 3-hour slot's) for-sale items for a registered hub trader. */
 export function getTodaysShopItems(buildingId: string, at?: Date): ShopStockItem[] {
   const config = SHOP_TRADER_REGISTRY[buildingId]
@@ -100,5 +116,7 @@ export function getTodaysShopItems(buildingId: string, at?: Date): ShopStockItem
     }
     case 'consumable':
       return getSupplyStock(at, config.slotCount ?? DEFAULT_SUPPLY_STOCK_COUNT)
+    case 'accessory':
+      return getAccessoryStock()
   }
 }

--- a/web/src/game/shopSchedule.ts
+++ b/web/src/game/shopSchedule.ts
@@ -7,6 +7,7 @@ import { getCardCatalog } from './cards'
 import { CardRarity, CardType } from './types'
 import { ALL_ITEMS, RewardDef } from './dailyLogin'
 import { getAugmentCatalog } from './augments'
+import { ownsAccessory } from './hub/pet'
 import shopNpcsJson from '../data/shopNpcs.json'
 
 const SHOP_STATE_KEY  = 'jarv_shop_daily'
@@ -357,11 +358,14 @@ export function markAugmentBought(state: DailyShopState, buildingId: string): Da
 export function isShopItemSold(
   state: DailyShopState,
   buildingId: string,
-  grant: { kind: 'card' | 'augment' | 'consumable'; cardName?: string },
+  grant: { kind: 'card' | 'augment' | 'consumable' | 'accessory'; cardName?: string; id?: string },
 ): boolean {
   const b = state.buildings[buildingId]
   if (grant.kind === 'card') return b?.boughtCardNames.includes(grant.cardName ?? '') ?? false
   if (grant.kind === 'augment') return b?.boughtAugment ?? false
+  // Accessories are a permanent one-time unlock, not part of the daily
+  // rotation — "sold" means "already owned", which never resets.
+  if (grant.kind === 'accessory') return ownsAccessory(grant.id ?? '')
   return false
 }
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -15422,6 +15422,31 @@ html.light-mode .action-btn {
 }
 .pet-modal__current-name { font-size: 14px; font-weight: bold; }
 .pet-modal__actions-row { display: flex; gap: 8px; margin-top: 10px; flex-wrap: wrap; }
+.pet-modal__accessories {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+  margin-top: 12px;
+}
+.pet-modal__accessory {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  background: rgba(0, 0, 0, 0.3);
+  border: 1px solid #2a4a2a;
+  color: #c8e8c8;
+  font-family: monospace;
+  padding: 8px 10px;
+  border-radius: 2px;
+  cursor: pointer;
+  text-align: left;
+}
+.pet-modal__accessory:hover:not(:disabled) { border-color: #446644; }
+.pet-modal__accessory--equipped { border-color: #88cc88; background: rgba(60, 120, 60, 0.25); }
+.pet-modal__accessory--locked { opacity: 0.5; cursor: default; }
+.pet-modal__accessory-name { font-size: 12px; font-weight: bold; }
+.pet-modal__accessory-status { font-size: 9px; color: #557755; letter-spacing: 0.05em; }
 
 /* ── Town Directory ("Where is…?") ─────────────────────────────────────────── */
 .town-directory {


### PR DESCRIPTION
Pins the follower pet's roam/fetch destinations and a tick-final safety net to the player's live position so it never wanders more than 8 tiles away, regardless of which behavior (roam, chase, fetch) pulled it out.

Adds a pet accessory system: collars, hats, bows, bow ties, boots, and coats rendered as a real composite sprite on the dog (a PIXI sibling repositioned every tick to match the dog's transform), with one slot equipped at a time via a slot-keyed data model that's ready for multiple simultaneous slots later. Accessories are earned from two Ravenwatch quests, two bounty templates, and a new Tailor Pell shop in Crownhaven (capitalcity).