### PR TITLE
Hub world inventory + item economy (chicken feed, gated fishing, trade chains)

### DIFF
--- a/docs/hubworld.md
+++ b/docs/hubworld.md
@@ -31,6 +31,10 @@
 | `web/src/components/hub/TownJournal.tsx` | Journal UI — Animals / People / Places tabs with completion % — see §15 | `TownJournal` |
 | `web/src/game/hub/pet.ts` | Player's adopted follower-pet persistence (localStorage) — see §8 | `getActivePet`, `hasActivePet`, `adoptPet`, `renamePet`, `dismissPet` |
 | `web/src/components/hub/PetModal.tsx` | Pet adoption / rename / swap / dismiss UI — see §8 | `PetModal` |
+| `web/src/data/hubItems.json` | Hub-item catalog: materials (chicken feed, eggs, fish, trade goods) and unique tools (fishing rod) — see §16 | consumed by `itemStore.ts` |
+| `web/src/game/itemStore.ts` (hub-item section) | Hub-item inventory persistence (localStorage, type `'hub-item'`) — see §16 | `addHubItem`, `removeHubItem`, `getHubItemCount`, `hasHubItem`, `getHubItems`, `getHubItemCatalogEntry` |
+| `web/src/game/hub/questItems.ts` | Held-quest-item id helpers (`quest:<questId>:<stepKey>`) — see §16 | `questItemId`, `isQuestItemId`, `questIdFromItemId` |
+| `web/src/components/hub/HubInventoryModal.tsx` | 🎒 Hub Inventory UI — held quest items, materials & tools, pet accessories — see §16 | `HubInventoryModal` |
 
 ---
 
@@ -283,6 +287,9 @@ bounds, else a single tile.
 | `giveItem` | `collectible?`, `consumables?`, `crystals?`, `message?`, `alreadyGrantedText?` | One-time grant (persisted). Re-taps show `alreadyGrantedText` if set. Reward shapes match treasure rewards. `collectible.lore?` (optional flavor text) is stored on the item and already surfaced by `HomeShelf`/`ItemFoundScreen` — no extra wiring needed for lore notes. |
 | `quest` | `questId`, `speakerName?` | Offers the quest with Accept / Not now. The quest's `giverNpcId` in `questDefs.json` **must equal the interactable's id**. Honours prerequisites and the 2-active-quest cap. |
 | `move` | `to: {tx, ty}`, `message?` | Moves the owned decor to the target tile, live and persisted across reloads. Requires owned `decor`. |
+| `buy` | `slotIndex` | Sells the interactable's building's Nth daily-rotating shop-stock item (`getTodaysShopItems`, `SHOP_TRADER_REGISTRY`). Shares `DailyShopState` with `ShopScreen`, so both draw down the same stock. Requires `building`. |
+| `buyPack` | — | Crystal-pack purchase flow (delegates to `onBuyCrystalPack`). Requires `building`. |
+| `buyHubItem` | `itemId`, `price`, `currency?`, `speakerName?` | Always-available hub-item purchase (no daily rotation) — see §16. `itemId` must exist in `hubItems.json`; `currency` is `'crystals'` (default) or `'tickets'`. Unique items (e.g. the fishing rod) re-offer as "already owned" once bought. `speakerName` overrides the building-NPC speaker (useful for exterior stalls). |
 
 Reactions run in order; `dialogue` (and `message`-bearing reactions) chain the
 remainder through the dialogue's close. Conventions: at most one `screen` or
@@ -417,6 +424,7 @@ Then on the NPC (in `config.json`): `"dialogueTree": "scholar-chat"` (keep a
 | `friendship` | `npcId?`, `xp` | Grant friendship XP (defaults to the speaking NPC). |
 | `relationship` | `npcId?`, `track`, `points` | Add points to a relationship track (`ally`/`rival`/`romance`) — defaults to the speaking NPC. See §7c. |
 | `quest` | `questId` | Offer that quest (Accept / Not now). Resolves the quest's real `giverNpcId`. **Terminates** the walk. |
+| `tradeHubItem` | `wantItemId`, `wantCount?`, `giveCrystals?`, `giveHubItem?`, `giveCollectible?`, `missingText`, `successText` | Repeatable barter — see §16. Takes `wantCount` (default 1) of a hub-item from the player and grants the `give*` rewards, showing `successText` (then advancing to `next` on close, so a sell menu can loop). If the player holds too few, shows `missingText` and **terminates** the walk with no state change. Must be the **only/last** effect on its choice (it terminates the walk either way). |
 | `end` | — | End the conversation. |
 
 If a choice has neither a terminating effect (`quest`/`end`) nor `next`, the
@@ -1279,3 +1287,120 @@ Discovery fires on **tap**, not mere visibility, matching every other
 Reuses `TownDirectory`'s `ModalBackdrop` + `.town-directory__*` row layout and
 `HallOfAchievements`' `.hoa-tabs`/`.hoa-tab`/`.hoa-tab--active` tab row — no new
 tab CSS was needed. Story: `TownJournal.stories.tsx`.
+
+---
+
+## §16 — Hub Items, Inventory & Item Economy
+
+A hub-world item economy layered on the shared item store: physical **quest
+items** held while a fetch quest is in progress, **materials** bought from
+shops or produced by world interactions (chicken feed, eggs, feathers, caught
+fish, trade goods), and unique **tools** (the fishing rod). Everything
+persists in `jarv_item_store` under its own type tag (`'hub-item'`), so — like
+arcade tickets — it can never be drained into a campaign run.
+
+- Catalog: `web/src/data/hubItems.json` — `{ id, name, icon, desc, category,
+  unique? }`; `category` is `'quest' | 'pet-accessory' | 'material' | 'tool'`.
+  Items flagged `unique: true` never stack (re-buying/re-adding is a no-op).
+- Store API (`web/src/game/itemStore.ts`): `addHubItem(id, count?, display?)`,
+  `removeHubItem(id, count?)` (returns `false` and changes nothing when the
+  player holds too few — always check the return), `getHubItemCount`,
+  `hasHubItem`, `getHubItems`, `getHubItemCatalogEntry`.
+- UI: `HubInventoryModal.tsx`, opened from the 🎒 toolbar button in
+  `HubWorld.tsx`. Sections: Quest Items (per active quest, `held/required`),
+  Materials & Tools, Pet Accessories (owned accessories from `pet.ts` — see §8).
+
+### Held quest items
+
+A collect step (§14 quests) may carry two optional display fields:
+
+```jsonc
+{ "key": "grain", "type": "collect", "pickupIds": ["sack-1","sack-2","sack-3"],
+  "required": 3, "itemName": "Sack", "itemIcon": "🌾" }
+```
+
+When set, each pickup adds one `quest:<questId>:<stepKey>` hub-item
+(`questItemId` in `web/src/game/hub/questItems.ts`) with the step's display
+fields inline; turning the quest in or abandoning it clears the held items
+(`clearHeldQuestItems` in `HubWorld.tsx`). Steps without `itemName` behave as
+before (progress counter only). All existing collect steps were retrofitted
+with these fields, resolved from their pickups' `tileId`s.
+
+### Buying hub items — `buyHubItem` (§7 reactions)
+
+```jsonc
+{ "id": "millhaven-bait-stall", "tx": 32, "ty": 11,
+  "decor": [{ "dx": 0, "dy": 0, "tileId": "bucketAndRope" }],
+  "reactions": [
+    { "type": "buyHubItem", "itemId": "fish-bait", "price": 8, "speakerName": "Harbour Tackle Stall" }
+  ] }
+```
+
+Always-available (no daily rotation). The confirm dialogue shows the catalog
+`desc`; the speaker resolves to the on-duty building NPC unless `speakerName`
+overrides it. Unique items re-offer as "already owned". Existing sellers:
+chicken feed (Millhaven bakery, Ravenwatch Market Hall, pen-side feed sacks in
+Appleford / Harrowfield / Ironhold Keep / Royal Palace), rod + bait (Millhaven
+harbour stalls), Fancy Hat + Sturdy Boots (capital tailor).
+
+### Trading hub items — `tradeHubItem` (§7b dialogue effects)
+
+Attach to a dialogue-tree choice; see the §7b effect table. Point `next` back
+at the same node to build a repeatable sell menu (see Millhaven's
+`marta-fish-trade` tree — Fishwife Marta buys each fish tier for crystals) or
+a one-line barter (Thornwood Camp's `ranger-sable-trade` — sturdy boots for
+90💎). Trades are repeatable by design; use a `flag` effect + `hideIfFlag` on
+the choice if a specific trade should be once-only.
+
+### Feeding ambient animals
+
+Tapping an **ambient** (id-less, procedural) animal routes through
+`onAmbientAnimalTap(type)` (hubAnimals.ts → HubTownCanvas → HubWorld) before
+the default flavour bubble:
+
+- **Chicken** + player holds `chicken-feed` → offers to feed (consumes 1):
+  40% egg, 25% feather, 35% nothing.
+- **Cat** + player holds any `fish-*` → offers the smallest held fish
+  (flavour-only reward, by design — ambient animals have no stable id to
+  attach friendship to).
+
+Placed (named) animals keep their normal §8 quest/dialogue routing.
+
+### Hub fishing (item-gated)
+
+Hub fishing NPCs use `"screen": "hub-fishing"` (Millhaven harbour, Capital
+City riverside, Ravenwatch pond). `handleNodeInteract` (HubWorld.tsx) blocks
+entry without a `fishing-rod` and consumes one `fish-bait` per trip; both are
+global, so one rod works in every town. The screen renders
+`<Fishing rewardMode="catch">` (App.tsx) — the caught fish is added to the
+inventory as a tier-keyed hub-item (`fish-tiddler` … `fish-legendary`) and
+**no tickets are awarded**. The arcade fishing tile (MiniGamesMenu,
+`"screen": "fishing"` nowhere in hub configs anymore) is unchanged and still
+pays tickets.
+
+### Authoring checklist: new shop good + trade chain
+
+1. Add the item to `hubItems.json` (`category: 'material'`, or `'tool'` +
+   `unique: true` for one-of-a-kind gear).
+2. Sell it: add an interactable with a `buyHubItem` reaction — inside a shop
+   building (pure `hitRect` over existing shelf decor, speaker auto-resolves)
+   or as an exterior stall (owned `decor` + `speakerName`).
+3. Give it a use: a `tradeHubItem` choice on another NPC's dialogue tree
+   (ideally in a different town), and/or a world interaction that consumes it.
+4. Run `npm run test` (loader tests parse all configs) and `npm run build`;
+   verify buy → carry → trade end-to-end in-game and across a reload.
+
+### Future chains (designed, not yet built)
+
+- **Feather → poetry book**: an author NPC whose quill keeps snapping takes a
+  `feather` (`tradeHubItem`) and returns a `poetry-book` hub-item; the book's
+  own use is a further chain.
+- **Bones → dog → lost item**: sell `bones` in a butcher/general store;
+  feeding an ambient dog (same `onAmbientAnimalTap` pattern) sends it
+  fetching and yields a `lost-item` after a cooldown — needs a small
+  "fetching" animal state.
+- **Stock every empty shop**: still-empty shop buildings (capital
+  `market-hall-crownhaven` / `apothecary`, Saltmere Port `fish-market`,
+  Hollowmere `apothecary`, …) are each one `buyHubItem` interactable away
+  from selling a thematic good; pair each new good with a trade partner in
+  another town.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -142,6 +142,8 @@ import { ConfirmModal }          from './components/modals/ConfirmModal'
 import { StreakBrokenModal }     from './components/modals/StreakBrokenModal'
 import { EndlessLeaderboardScreen } from './components/screens/EndlessLeaderboardScreen'
 import { MiniGamesMenu, SubScreen } from './components/screens/MiniGamesMenu'
+import { Fishing } from './components/minigames/Fishing'
+import { OverlayScreen } from './components/ui/OverlayScreen'
 import { AugmentCollectionScreen } from './components/screens/AugmentCollectionScreen'
 import { PlayerScreen }            from './components/screens/PlayerScreen'
 import { CollectionTabScreen }     from './components/screens/CollectionTabScreen'
@@ -247,6 +249,7 @@ type Screen =
   | 'home-shelf'
   | 'hubworld'
   | 'hub-minigame'
+  | 'hub-fishing'
   | 'casino'
   | 'worldmap'
   | 'location'
@@ -3382,6 +3385,15 @@ export default function App() {
           onGameDone={() => setScreen('hubworld')}
           initialSubScreen={hubMiniGameEntry}
         />
+      )}
+
+      {/* Hub-world fishing: item-gated (rod + bait, checked in HubWorld's
+          handleNodeInteract) and rewards the caught fish as a hub-item
+          instead of arcade tickets — see docs/hubworld.md. */}
+      {screen === 'hub-fishing' && (
+        <OverlayScreen title="🎣 FISHING" onBack={() => setScreen('hubworld')}>
+          <Fishing rewardMode="catch" onDone={() => setScreen('hubworld')} />
+        </OverlayScreen>
       )}
 
       {relicSpinData && (

--- a/web/src/components/hub/HubInventoryModal.stories.tsx
+++ b/web/src/components/hub/HubInventoryModal.stories.tsx
@@ -1,0 +1,100 @@
+import { fn } from 'storybook/test'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { HubInventoryModal } from './HubInventoryModal'
+import type { HubQuestDef } from '../../data/hub/questDefs'
+import type { ItemEntry } from '../../game/itemStore'
+
+// Seed the localStorage-backed stores the modal reads (item store, quest
+// state, pet accessories) so each story shows a distinct inventory state.
+function seedStores(opts: {
+  items?: ItemEntry[]
+  activeQuestIds?: string[]
+  questProgress?: Record<string, Record<string, number>>
+  ownedAccessories?: string[]
+}): void {
+  localStorage.setItem('jarv_item_store', JSON.stringify(opts.items ?? []))
+  const quests: Record<string, { status: string; progress: Record<string, number> }> = {}
+  for (const id of opts.activeQuestIds ?? []) {
+    quests[id] = { status: 'active', progress: opts.questProgress?.[id] ?? {} }
+  }
+  localStorage.setItem('jarv_hub_quests', JSON.stringify(quests))
+  const pet = opts.ownedAccessories
+    ? { pet: null, accessories: { owned: opts.ownedAccessories, equipped: {} } }
+    : {}
+  localStorage.setItem('jarv_hub_pet', JSON.stringify(pet))
+}
+
+const sampleQuest: HubQuestDef = {
+  id: 'q-grain',
+  type: 'fetch',
+  title: 'The Missing Grain',
+  giverNpcId: 'mill-owner',
+  receiverNpcId: 'mill-owner',
+  offerDialogue: 'Three sacks of grain, scattered by thieves.',
+  activeDialogue: 'Find my grain sacks!',
+  completeDialogue: 'Wonderful!',
+  reward: { crystals: 50 },
+  steps: [
+    { key: 'grain', type: 'collect', required: 3, pickupIds: ['g1', 'g2', 'g3'], itemName: 'Grain Sack', itemIcon: '🌾' },
+  ],
+}
+
+const meta = {
+  component: HubInventoryModal,
+  parameters: { layout: 'fullscreen' },
+  decorators: [
+    (Story) => (
+      <div className="game-container">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof HubInventoryModal>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Empty: Story = {
+  args: { onClose: fn(), questDefs: [] },
+  decorators: [
+    (Story) => { seedStores({}); return <Story /> },
+  ],
+}
+
+export const QuestItemsInProgress: Story = {
+  args: { onClose: fn(), questDefs: [sampleQuest] },
+  decorators: [
+    (Story) => {
+      seedStores({
+        items: [
+          { id: 'quest:q-grain:grain', type: 'hub-item', count: 2, name: 'Grain Sack', icon: '🌾', category: 'quest' },
+        ],
+        activeQuestIds: ['q-grain'],
+        questProgress: { 'q-grain': { grain: 2 } },
+      })
+      return <Story />
+    },
+  ],
+}
+
+export const FullInventory: Story = {
+  args: { onClose: fn(), questDefs: [sampleQuest] },
+  decorators: [
+    (Story) => {
+      seedStores({
+        items: [
+          { id: 'quest:q-grain:grain', type: 'hub-item', count: 1, name: 'Grain Sack', icon: '🌾', category: 'quest' },
+          { id: 'fishing-rod', type: 'hub-item', count: 1, name: 'Fishing Rod', icon: '🎣', category: 'tool' },
+          { id: 'chicken-feed', type: 'hub-item', count: 4, name: 'Chicken Feed', icon: '🌾', category: 'material' },
+          { id: 'egg', type: 'hub-item', count: 2, name: 'Egg', icon: '🥚', category: 'material' },
+          { id: 'feather', type: 'hub-item', count: 1, name: 'Feather', icon: '🪶', category: 'material' },
+          { id: 'fish-medium', type: 'hub-item', count: 1, name: 'Medium Fish', icon: '🐡', category: 'material' },
+        ],
+        activeQuestIds: ['q-grain'],
+        questProgress: { 'q-grain': { grain: 1 } },
+        ownedAccessories: ['top-hat', 'red-bow'],
+      })
+      return <Story />
+    },
+  ],
+}

--- a/web/src/components/hub/HubInventoryModal.tsx
+++ b/web/src/components/hub/HubInventoryModal.tsx
@@ -1,0 +1,117 @@
+import React from 'react'
+import { ModalBackdrop } from '../ui/ModalBackdrop'
+import type { HubQuestDef } from '../../data/hub/questDefs'
+import { getQuestState, getQuestProgress } from '../../game/hub/quests'
+import { getHubItems, getHubItemCount, ItemEntry } from '../../game/itemStore'
+import { questItemId } from '../../game/hub/questItems'
+import { getOwnedAccessoryIds, getEquippedAccessoryId } from '../../game/hub/pet'
+import { getPetAccessoryDef } from '../../data/petAccessories'
+
+interface Props {
+  onClose: () => void
+  /** All towns' quest defs — held quest items may belong to any town's quest. */
+  questDefs: HubQuestDef[]
+}
+
+interface QuestItemRow {
+  questId: string
+  questTitle: string
+  stepKey: string
+  name: string
+  icon: string
+  held: number
+  required: number
+}
+
+function activeQuestItemRows(questDefs: HubQuestDef[]): QuestItemRow[] {
+  const rows: QuestItemRow[] = []
+  for (const quest of questDefs) {
+    if (getQuestState(quest.id).status !== 'active') continue
+    for (const step of quest.steps) {
+      if (step.type !== 'collect' || !step.itemName) continue
+      rows.push({
+        questId: quest.id,
+        questTitle: quest.title,
+        stepKey: step.key,
+        name: step.itemName,
+        icon: step.itemIcon ?? '📦',
+        held: getHubItemCount(questItemId(quest.id, step.key)),
+        required: step.required,
+      })
+    }
+  }
+  return rows
+}
+
+export function HubInventoryModal({ onClose, questDefs }: Props) {
+  const questRows = activeQuestItemRows(questDefs)
+
+  const hubItems = getHubItems()
+  const materials = hubItems.filter(e => e.category === 'material')
+  const tools     = hubItems.filter(e => e.category === 'tool')
+
+  const accessoryIds = getOwnedAccessoryIds()
+  const equippedId   = getEquippedAccessoryId()
+
+  const itemRow = (entry: ItemEntry) => (
+    <div key={entry.id} className="quests-modal__step">
+      <span>{entry.icon ?? '📦'} {entry.name ?? entry.id}</span>
+      <span>{entry.count > 1 ? `×${entry.count}` : ''}</span>
+    </div>
+  )
+
+  return (
+    <ModalBackdrop onClose={onClose}>
+      <div className="quests-modal">
+        <div className="quests-modal__header">
+          <span>🎒 Inventory</span>
+          <span className="quests-modal__meta">
+            <button className="quests-modal__close" onClick={onClose}>✕</button>
+          </span>
+        </div>
+
+        <div className="quests-modal__section-label">Quest Items</div>
+        {questRows.length === 0 ? (
+          <div className="quests-modal__empty">Nothing held for a quest right now.</div>
+        ) : (
+          questRows.map(row => (
+            <div key={`${row.questId}:${row.stepKey}`} className="quests-modal__card quests-modal__card--active">
+              <div className="quests-modal__title">{row.icon} {row.name}</div>
+              <div className="quests-modal__step">
+                <span>{row.questTitle}</span>
+                <span>{row.held}/{row.required}</span>
+              </div>
+            </div>
+          ))
+        )}
+
+        {(materials.length > 0 || tools.length > 0) && (
+          <>
+            <div className="quests-modal__section-label">Materials &amp; Tools</div>
+            <div className="quests-modal__card">
+              {tools.map(itemRow)}
+              {materials.map(itemRow)}
+            </div>
+          </>
+        )}
+
+        <div className="quests-modal__section-label">Pet Accessories</div>
+        {accessoryIds.length === 0 ? (
+          <div className="quests-modal__empty">Nothing yet — Tailor Pell in the capital stocks pet accessories.</div>
+        ) : (
+          <div className="quests-modal__card">
+            {accessoryIds.map(id => {
+              const def = getPetAccessoryDef(id)
+              return (
+                <div key={id} className="quests-modal__step">
+                  <span>🎀 {def?.name ?? id}</span>
+                  <span>{id === equippedId ? 'equipped' : ''}</span>
+                </div>
+              )
+            })}
+          </div>
+        )}
+      </div>
+    </ModalBackdrop>
+  )
+}

--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -79,6 +79,9 @@ interface Props {
   onAnimalTap?:     (animalId: string) => void
   /** Fires for every animal tap (placed or procedural) for journal/bestiary tracking. */
   onAnimalSeen?:    (type: AnimalType, variant?: string) => void
+  /** Lets React intercept a tap on an ambient (id-less) animal, e.g. to offer
+   *  feeding it. Return true if handled (suppresses the flavour bubble). */
+  onAmbientAnimalTap?: (type: AnimalType) => boolean
   interiorEnterRef?: React.MutableRefObject<((buildingId: string) => void) | null>
   interiorExitRef?:  React.MutableRefObject<(() => void) | null>
   petActionRef?:     React.MutableRefObject<{ sendPetFetching: (onReturn: () => void) => boolean; givePetAffection: () => void; setPetAccessory: (assetId: string | null) => void } | null>
@@ -117,7 +120,7 @@ interface Props {
 
 export function HubTownCanvas({
   onAreaEnter, onNodeInteract, onAvatarMove,
-  returnRef, unitCards, commander, onNpcTap, onAnimalTap, onAnimalSeen,
+  returnRef, unitCards, commander, onNpcTap, onAnimalTap, onAnimalSeen, onAmbientAnimalTap,
   interiorEnterRef, interiorExitRef, petActionRef, onEnterInterior, onExitInterior, onTileTap,
   pickedUpIds, onItemPickup, doorKeys, onDoorLocked, questNpcState, activeQuestIdsRef,
   completedQuestIdsRef, collectedTreasureIds, onTreasureStep,
@@ -158,6 +161,8 @@ export function HubTownCanvas({
   onAnimalTapRef.current  = onAnimalTap
   const onAnimalSeenRef   = useRef(onAnimalSeen)
   onAnimalSeenRef.current = onAnimalSeen
+  const onAmbientAnimalTapRef   = useRef(onAmbientAnimalTap)
+  onAmbientAnimalTapRef.current = onAmbientAnimalTap
   const unitCardsRef      = useRef(unitCards)
   unitCardsRef.current    = unitCards
   const onEnterInteriorRef  = useRef(onEnterInterior)
@@ -2435,6 +2440,7 @@ export function HubTownCanvas({
       },
       onAnimalTap: (id) => onAnimalTapRef.current?.(id),
       onAnimalSeen: (type, variant) => onAnimalSeenRef.current?.(type, variant),
+      onAmbientAnimalTap: (type) => onAmbientAnimalTapRef.current?.(type) ?? false,
       getQuestIndicator: (id) => questNpcState?.current.get(id) ?? null,
       isInteriorActive: () => interiorActive,
       isOnScreen: (x, y) => {

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -31,6 +31,7 @@ import { LoginButton } from '../ui/LoginButton'
 import { addCollectible, addConsumable, getCollectibles, addHubItem, removeHubItem, getHubItemCount, hasHubItem } from '../../game/itemStore'
 import { questItemId } from '../../game/hub/questItems'
 import { QuestsModal } from './QuestsModal'
+import { HubInventoryModal } from './HubInventoryModal'
 import { BountyBoardModal } from './BountyBoardModal'
 import { hasUnclaimedBounties, getPendingBountyReport, getPendingBountyCollect, advanceBountyStep, getActiveBountyStep } from '../../game/hub/bounties'
 import { PetModal } from './PetModal'
@@ -184,6 +185,7 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onEndless, onWorldMap
   const [interiorActive, setInteriorActive] = useState(false)
   const [pickedUpIds,    setPickedUpIds]    = useState<Set<string>>(() => getPickedUpIds())
   const [questsOpen,          setQuestsOpen]          = useState(false)
+  const [inventoryOpen,       setInventoryOpen]       = useState(false)
   const [bountyBoardOpen,     setBountyBoardOpen]     = useState(false)
   const [petModalOpen,        setPetModalOpen]        = useState(false)
   const [directoryOpen,       setDirectoryOpen]       = useState(false)
@@ -1271,6 +1273,7 @@ function hasOfferableQuest(giverId: string): boolean {
             <ToolbarLabel className="title-deck-info">{activeFestival.icon} {activeFestival.name}</ToolbarLabel>
           )}
         <ToolbarButton icon="📜" title="Quests" onClick={() => setQuestsOpen(true)} />
+        <ToolbarButton icon="🎒" title="Inventory" onClick={() => setInventoryOpen(true)} />
         <ToolbarButton icon="🧭" title="Where is…?" onClick={() => setDirectoryOpen(true)} />
         <ToolbarButton icon="📖" title="Journal" onClick={() => setJournalOpen(true)} />
         <ToolbarButton icon="🏗️" title="Town Upgrades" onClick={() => setUpgradesOpen(true)} />
@@ -1362,6 +1365,7 @@ function hasOfferableQuest(giverId: string): boolean {
         )}
 
         {questsOpen && <QuestsModal onClose={() => setQuestsOpen(false)} onAbandon={handleQuestAbandon} questDefs={questDefs} resolveNpcName={getNpcDisplayName}/>}
+        {inventoryOpen && <HubInventoryModal onClose={() => setInventoryOpen(false)} questDefs={allQuestDefs} />}
         {bountyBoardOpen && <BountyBoardModal onClose={() => setBountyBoardOpen(false)} resolveNpcName={getNpcDisplayName}/>}
         {petModalOpen && <PetModal onClose={() => setPetModalOpen(false)} petActionRef={petActionRef} />}
         {directoryOpen && <TownDirectory onClose={() => setDirectoryOpen(false)} locationData={locationData} pinnedNpcId={pinnedNpcId} onTogglePin={togglePinnedNpc} onShowRelationship={setRelationshipNpcId} />}

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -28,7 +28,7 @@ import { ToolbarDropdown } from '../ui/Toolbar/ToolbarDropdown'
 import { User } from 'firebase/auth'
 import { loadPlayerName, addToConsumableStash } from '../../game/questline'
 import { LoginButton } from '../ui/LoginButton'
-import { addCollectible, addConsumable, getCollectibles, addHubItem, removeHubItem, getHubItemCount, hasHubItem } from '../../game/itemStore'
+import { addCollectible, addConsumable, getCollectibles, addHubItem, removeHubItem, getHubItemCount, hasHubItem, getHubItemCatalogEntry, spendTickets } from '../../game/itemStore'
 import { questItemId } from '../../game/hub/questItems'
 import { QuestsModal } from './QuestsModal'
 import { HubInventoryModal } from './HubInventoryModal'
@@ -853,6 +853,35 @@ function hasOfferableQuest(giverId: string): boolean {
           if (!tryOfferQuest(giver, speakerName, eff.questId)) setDialogueEvent(null)
           return
         }
+        case 'tradeHubItem': {
+          // Repeatable barter: consume the wanted hub-item(s), grant the
+          // reward(s). If the player holds too few, show missingText and stop
+          // (no navigation — the player can come back with the goods).
+          const want = eff.wantCount ?? 1
+          if (!removeHubItem(eff.wantItemId, want)) {
+            setDialogueEvent({ speakerName, text: eff.missingText })
+            return
+          }
+          if (eff.giveCrystals) {
+            saveCrystals(loadCrystals() + eff.giveCrystals)
+            onCrystalsChange?.(loadCrystals())
+          }
+          if (eff.giveHubItem) {
+            addHubItem(eff.giveHubItem.itemId, eff.giveHubItem.count ?? 1)
+          }
+          if (eff.giveCollectible) {
+            const { id, name, icon, desc } = eff.giveCollectible
+            addCollectible(id, { name, icon, desc })
+          }
+          emitSound('shopPurchase')
+          refreshState()
+          setDialogueEvent({
+            speakerName,
+            text: eff.successText,
+            ...(choice.next ? { onClose: () => runDialogueNode(tree, choice.next!, npcId, speakerName) } : {}),
+          })
+          return
+        }
         case 'end':
           ended = true
           break
@@ -1253,6 +1282,53 @@ function hasOfferableQuest(giverId: string): boolean {
           { label: 'Maybe not', onClick: () => setDialogueEvent(null) },
         ]
         setDialogueEvent({ speakerName, text: 'How many packs would you like?', choices })
+        return
+      }
+      case 'buyHubItem': {
+        const catalog = getHubItemCatalogEntry(r.itemId)
+        if (!catalog) { next(); return }
+
+        const candidates = def.building ? locationData.HUB_NPCS.filter(n => n.building === def.building) : []
+        const onDuty = candidates.find(n => def.building && resolveNpcPlace(n, gameHour, locationData).interiorId === def.building)
+        const speakerName = r.speakerName ?? (onDuty ?? candidates[0])?.name ?? ''
+
+        if (catalog.unique && hasHubItem(r.itemId)) {
+          setDialogueEvent({ speakerName, text: `You already own a ${catalog.name} — one is all you'll ever need.`, onClose: next })
+          return
+        }
+
+        const currency = r.currency ?? 'crystals'
+        const currencyIcon = currency === 'tickets' ? '🎫' : '💎'
+        const confirm: DialogueChoice = {
+          label: `Buy for ${r.price} ${currencyIcon}`,
+          primary: true,
+          onClick: () => {
+            if (currency === 'tickets') {
+              if (!spendTickets(r.price)) {
+                setDialogueEvent({ speakerName, text: "That's more tickets than you're carrying." })
+                return
+              }
+            } else {
+              const balance = loadCrystals()
+              if (balance < r.price) {
+                setDialogueEvent({ speakerName, text: "That's more than you're carrying — come back when you've got the crystals." })
+                return
+              }
+              saveCrystals(balance - r.price)
+              onCrystalsChange?.(balance - r.price)
+            }
+            addHubItem(r.itemId, 1)
+            emitSound('shopPurchase')
+            refreshState()
+            setDialogueEvent({ speakerName, text: `Sold! Enjoy the ${catalog.name}.`, onClose: next })
+          },
+        }
+        const cancel: DialogueChoice = { label: 'Maybe not', onClick: () => setDialogueEvent(null) }
+        setDialogueEvent({
+          speakerName,
+          text: `${catalog.icon} ${catalog.desc} Care to buy a ${catalog.name} for ${r.price} ${currencyIcon}?`,
+          choices: [confirm, cancel],
+        })
         return
       }
     }

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -1130,6 +1130,71 @@ function hasOfferableQuest(giverId: string): boolean {
     handleNpcTap(line, animalId)
   }, [handleNpcTap, locationData, refreshState, grantRandomPetReward])
 
+  // ── Ambient-animal feeding ───────────────────────────────────────────────
+  // Ambient (id-less) chickens can be fed chicken feed for a chance at an egg
+  // or a feather; ambient cats will happily eat a caught fish (smallest held
+  // first — flavour only). Returning false falls back to the canvas-side
+  // flavour bubble.
+  const handleAmbientAnimalTap = useCallback((type: string): boolean => {
+    if (type === 'chicken' && hasHubItem('chicken-feed')) {
+      setDialogueEvent({
+        speakerName: 'Chicken',
+        text: 'The chicken eyes the feed in your pack expectantly.',
+        choices: [
+          {
+            label: 'Scatter some feed (1 🌾)',
+            primary: true,
+            onClick: () => {
+              if (!removeHubItem('chicken-feed', 1)) { setDialogueEvent(null); return }
+              const roll = Math.random()
+              let text: string
+              if (roll < 0.4) {
+                addHubItem('egg', 1)
+                text = 'The chicken pecks up every grain, settles for a moment… and leaves you a fresh egg! 🥚'
+              } else if (roll < 0.65) {
+                addHubItem('feather', 1)
+                text = 'The chicken flaps about in delight — a clean feather drifts down for your trouble. 🪶'
+              } else {
+                text = 'The chicken devours the feed and struts off, deeply satisfied. Nothing for you this time.'
+              }
+              refreshState()
+              setDialogueEvent({ speakerName: 'Chicken', text })
+            },
+          },
+          { label: 'Not now', onClick: () => setDialogueEvent(null) },
+        ],
+      })
+      return true
+    }
+    if (type === 'cat') {
+      const fishId = ['fish-tiddler', 'fish-small', 'fish-medium', 'fish-large', 'fish-trophy', 'fish-legendary']
+        .find(id => hasHubItem(id))
+      if (!fishId) return false
+      const fishName = getHubItemCatalogEntry(fishId)?.name ?? 'fish'
+      setDialogueEvent({
+        speakerName: 'Cat',
+        text: `The cat has smelled the ${fishName} in your pack and is now performing its best starving-orphan impression.`,
+        choices: [
+          {
+            label: `Offer the ${fishName}`,
+            primary: true,
+            onClick: () => {
+              if (!removeHubItem(fishId, 1)) { setDialogueEvent(null); return }
+              refreshState()
+              setDialogueEvent({
+                speakerName: 'Cat',
+                text: 'The cat devours the fish, purrs like a tiny engine, and headbutts your shin in gratitude. You feel richer in spirit, if not in fish.',
+              })
+            },
+          },
+          { label: 'Not this one', onClick: () => setDialogueEvent(null) },
+        ],
+      })
+      return true
+    }
+    return false
+  }, [refreshState])
+
   const handleAreaEnter = useCallback((areaName: string | null) => {
     setCurrentArea(areaName)
     const area = areaName != null ? locationData.HUB_AREAS.find(a => a.name === areaName) : undefined
@@ -1400,6 +1465,7 @@ function hasOfferableQuest(giverId: string): boolean {
             onNpcTap={handleNpcTap}
             onAnimalTap={handleAnimalTap}
             onAnimalSeen={recordAnimalSeen}
+            onAmbientAnimalTap={handleAmbientAnimalTap}
             interiorEnterRef={interiorEnterRef}
             interiorExitRef={interiorExitRef}
             petActionRef={petActionRef}

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -28,7 +28,8 @@ import { ToolbarDropdown } from '../ui/Toolbar/ToolbarDropdown'
 import { User } from 'firebase/auth'
 import { loadPlayerName, addToConsumableStash } from '../../game/questline'
 import { LoginButton } from '../ui/LoginButton'
-import { addCollectible, addConsumable, getCollectibles } from '../../game/itemStore'
+import { addCollectible, addConsumable, getCollectibles, addHubItem, removeHubItem, getHubItemCount, hasHubItem } from '../../game/itemStore'
+import { questItemId } from '../../game/hub/questItems'
 import { QuestsModal } from './QuestsModal'
 import { BountyBoardModal } from './BountyBoardModal'
 import { hasUnclaimedBounties, getPendingBountyReport, getPendingBountyCollect, advanceBountyStep, getActiveBountyStep } from '../../game/hub/bounties'
@@ -538,6 +539,7 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onEndless, onWorldMap
     if (!quest) return
     const pickupIds = quest.steps.flatMap(s => s.pickupIds ?? [])
     unmarkPickedUp(pickupIds)
+    clearHeldQuestItems(quest)
     resetQuest(questId)
     setPickedUpIds(getPickedUpIds())
     refreshState()
@@ -616,6 +618,16 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onEndless, onWorldMap
     for (const step of quest.steps) {
       if (step.type === 'collect' && step.pickupIds?.includes(id)) {
         incrementQuestProgress(questId, step.key)
+        // Steps with display fields place a physical item in the hub
+        // inventory; it is cleared again on turn-in or abandonment.
+        if (step.itemName) {
+          addHubItem(questItemId(questId, step.key), 1, {
+            name: step.itemName,
+            icon: step.itemIcon ?? '📦',
+            desc: `Held for the quest "${quest.title}".`,
+            category: 'quest',
+          })
+        }
         pickedStep = step
         break
       }
@@ -709,6 +721,17 @@ function grantQuestReward(quest: HubQuestDef): void {
   }
 }
 
+// Remove any physical quest items this quest placed in the hub inventory
+// (see handleItemPickup) — called on turn-in and on abandonment.
+function clearHeldQuestItems(quest: HubQuestDef): void {
+  for (const step of quest.steps) {
+    if (step.type !== 'collect' || !step.itemName) continue
+    const id = questItemId(quest.id, step.key)
+    const held = getHubItemCount(id)
+    if (held > 0) removeHubItem(id, held)
+  }
+}
+
 // Offer the first available quest given by `giverId` (an NPC or interactable id).
 // Returns true if an offer dialogue was shown; false if there is nothing to
 // offer (caller falls through to screens / default dialogue).
@@ -767,6 +790,7 @@ function hasOfferableQuest(giverId: string): boolean {
   // Mark a quest completed, grant its reward, and show its completion dialogue.
   function completeQuestFor(quest: HubQuestDef, speakerName: string): void {
     setQuestStatus(quest.id, 'completed')
+    clearHeldQuestItems(quest)
     grantQuestReward(quest)
     if (quest.reward.crystals) onCrystalsChange?.(loadCrystals())
     refreshState()

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -121,6 +121,7 @@ const SCREEN_ENTER_LABEL: Record<string, string> = {
   'hall-of-achievements': 'Visit the hall of achievements?',
   'home-shelf':      'Look at the shelf?',
   fishing:           'Cast a line?',
+  'hub-fishing':     'Cast a line?',
   marble:            'Play marbles?',
   marblerace:        'Watch a marble race?',
   tileflip:          'Play tile flip?',
@@ -523,6 +524,20 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onEndless, onWorldMap
     if (screen === 'commander' && !commander) {
       setDialogueEvent({ speakerName: "Commander's Post", text: "No commander has been assigned yet. Visit the title screen to choose one." })
       return
+    }
+    // Hub fishing is gated on owning a rod and consumes 1 bait per trip.
+    // Both are global hub-items, so a rod bought in Millhaven works at any
+    // town's fishing spot.
+    if (screen === 'hub-fishing') {
+      if (!hasHubItem('fishing-rod')) {
+        setDialogueEvent({ speakerName: '', text: "You can't fish without a rod. Millhaven's harbour stall sells them." })
+        return
+      }
+      if (!removeHubItem('fish-bait', 1)) {
+        setDialogueEvent({ speakerName: '', text: "You're out of bait. Millhaven's harbour stall sells pots of fish bait." })
+        return
+      }
+      refreshState()
     }
     onNavigate?.(screen, buildingId)
   }, [onNavigate, onCampaign, onWorldMap, onNarratorLog, commander])

--- a/web/src/components/hub/hubAnimals.ts
+++ b/web/src/components/hub/hubAnimals.ts
@@ -119,6 +119,10 @@ export interface AnimalSystemOptions {
   onAnimalTap: (animalId: string) => void
   /** Fires for every animal tap (placed or procedural) for journal/bestiary tracking. */
   onAnimalSeen?: (type: AnimalType, variant?: string) => void
+  /** Lets React intercept a tap on an ambient (id-less) animal — e.g. to
+   *  offer feeding it. Return true if handled (suppresses the default
+   *  flavour bubble), false to fall through. */
+  onAmbientAnimalTap?: (type: AnimalType) => boolean
   /** Quest indicator state for a placed animal id ('offer'|'ready'|null). */
   getQuestIndicator?: (animalId: string) => 'offer' | 'ready' | null
   isInteriorActive: () => boolean
@@ -1019,6 +1023,7 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
       e.stopPropagation()
       opts.onAnimalSeen?.(type, variantKeyForTint(type, tint))
       if (a.id) { opts.onAnimalTap(a.id); return }
+      if (opts.onAmbientAnimalTap?.(type)) return
       speak(a, FLAVOUR[type])
       vocalize(a)
       if (type === 'bird' || type === 'butterfly') a.fleeRequested = true

--- a/web/src/components/minigames/Fishing.tsx
+++ b/web/src/components/minigames/Fishing.tsx
@@ -3,7 +3,7 @@
 // the leaderboard. 5% chance to snag an item or card instead of a fish.
 
 import React, { useState, useEffect, useRef, useCallback } from 'react'
-import { addCollectible } from '../../game/itemStore'
+import { addCollectible, addHubItem } from '../../game/itemStore'
 import { addCardsToCollection } from '../../game/collection'
 import { getCardCatalog } from '../../game/cards'
 import ITEMS_DATA from '../../data/items.json'
@@ -115,13 +115,23 @@ function formatWeight(g: number): string {
   return g < 1000 ? `${g}g` : `${(g / 1000).toFixed(1)}kg`
 }
 
+// Hub-mode catches become hub-items, keyed by fish tier (see hubItems.json).
+const TIER_HUB_ITEM: Record<string, string> = {
+  Tiddler: 'fish-tiddler', Small: 'fish-small', Medium: 'fish-medium',
+  Large: 'fish-large', Trophy: 'fish-trophy', Legendary: 'fish-legendary',
+}
+
 // ── Component ─────────────────────────────────────────────────────────────────
 
 interface Props {
   onDone: (ticketsEarned: number, fishWeightGrams: number) => void
+  /** 'tickets' (default): arcade mode — fish pay out tickets via onDone.
+   *  'catch': hub-world mode — the caught fish is added to the hub-item
+   *  inventory instead, and no tickets are ever awarded. */
+  rewardMode?: 'tickets' | 'catch'
 }
 
-export function Fishing({ onDone }: Props) {
+export function Fishing({ onDone, rewardMode = 'tickets' }: Props) {
   const [phase, setPhase]   = useState<Phase>('idle')
   const [result, setResult] = useState<Catch | null>(null)
   const [biteMs, setBiteMs] = useState(BITE_WINDOW_MS)
@@ -189,10 +199,17 @@ export function Fishing({ onDone }: Props) {
       catch (e) { logError('Fishing: addCollectible failed', { error: String(e) }) }
     } else if (c.kind === 'card') {
       addCardsToCollection([{ cardName: c.name, count: 1 }])
+    } else if (rewardMode === 'catch') {
+      const hubItemId = TIER_HUB_ITEM[c.tier]
+      if (hubItemId) {
+        try { addHubItem(hubItemId, 1) }
+        catch (e) { logError('Fishing: addHubItem failed', { error: String(e) }) }
+      }
     }
   }
 
   function catchTickets(): number {
+    if (rewardMode === 'catch') return 0
     if (!result) return 0
     if (result.kind === 'fish')  return result.tickets
     if (result.kind === 'card')  return 10
@@ -290,7 +307,9 @@ export function Fishing({ onDone }: Props) {
               <span className="fishing-result-sep">·</span>
               <span>{result.lengthCm}cm</span>
             </div>
-            <div className="fishing-result-tickets">+{result.tickets} 🎫</div>
+            <div className="fishing-result-tickets">
+              {rewardMode === 'catch' ? `${result.tierIcon} Added to inventory!` : `+${result.tickets} 🎫`}
+            </div>
           </div>
         )}
 
@@ -299,7 +318,7 @@ export function Fishing({ onDone }: Props) {
             <div className="fishing-result-tier">✦ SPECIAL FIND ✦</div>
             <div className="fishing-result-name">{result.icon} {result.name}</div>
             <div className="fishing-result-desc">{result.desc}</div>
-            <div className="fishing-result-tickets">+5 🎫  ·  Added to inventory!</div>
+            <div className="fishing-result-tickets">{rewardMode === 'catch' ? 'Added to inventory!' : '+5 🎫  ·  Added to inventory!'}</div>
           </div>
         )}
 
@@ -308,7 +327,7 @@ export function Fishing({ onDone }: Props) {
             <div className="fishing-result-tier">✦ RARE CARD FOUND ✦</div>
             <div className="fishing-result-name">🃏 {result.name}</div>
             <div className="fishing-result-desc">{result.rarity}</div>
-            <div className="fishing-result-tickets">+10 🎫  ·  Added to collection!</div>
+            <div className="fishing-result-tickets">{rewardMode === 'catch' ? 'Added to collection!' : '+10 🎫  ·  Added to collection!'}</div>
           </div>
         )}
       </div>

--- a/web/src/data/hub/appleford/config.json
+++ b/web/src/data/hub/appleford/config.json
@@ -2097,6 +2097,26 @@
   },
   "interactables": [
     {
+      "id": "appleford-chicken-feed",
+      "tx": 35,
+      "ty": 26,
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "tileId": "sack"
+        }
+      ],
+      "reactions": [
+        {
+          "type": "buyHubItem",
+          "itemId": "chicken-feed",
+          "price": 5,
+          "speakerName": "Feed Stall"
+        }
+      ]
+    },
+    {
       "id": "market-barn-item-0",
       "tx": 11,
       "ty": 2,

--- a/web/src/data/hub/appleford/questDefs.json
+++ b/web/src/data/hub/appleford/questDefs.json
@@ -18,7 +18,9 @@
             "apple-basket-2",
             "apple-basket-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Apple Basket",
+          "itemIcon": "🍎"
         }
       ],
       "reward": {
@@ -52,7 +54,9 @@
             "cider-apple-2",
             "cider-apple-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Apple Basket",
+          "itemIcon": "🍎"
         }
       ],
       "reward": {
@@ -81,7 +85,9 @@
             "empty-bottle-2",
             "empty-bottle-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Bottle",
+          "itemIcon": "🍾"
         }
       ],
       "reward": {
@@ -115,7 +121,9 @@
             "honeycomb-2",
             "honeycomb-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Herb Bundle",
+          "itemIcon": "🌿"
         }
       ],
       "reward": {
@@ -144,7 +152,9 @@
             "beeswax-2",
             "beeswax-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Bottle",
+          "itemIcon": "🍾"
         }
       ],
       "reward": {
@@ -178,7 +188,9 @@
             "stave-2",
             "stave-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Firewood",
+          "itemIcon": "🪵"
         }
       ],
       "reward": {
@@ -206,7 +218,9 @@
             "pick-apple-2",
             "pick-apple-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Apple Basket",
+          "itemIcon": "🍎"
         },
         {
           "key": "deliver",
@@ -239,7 +253,9 @@
           "pickupIds": [
             "picker-crate-1"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Open Crate",
+          "itemIcon": "📦"
         },
         {
           "key": "deliver",
@@ -273,7 +289,9 @@
           "pickupIds": [
             "cider-crate-1"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Supply Crate",
+          "itemIcon": "📦"
         },
         {
           "key": "deliver",
@@ -314,7 +332,9 @@
             "harvest-bloom-2",
             "harvest-bloom-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Candlestick",
+          "itemIcon": "🕯️"
         }
       ],
       "reward": {
@@ -348,7 +368,9 @@
             "wren-2",
             "wren-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Leaf Basket",
+          "itemIcon": "🍂"
         }
       ],
       "reward": {
@@ -377,7 +399,9 @@
             "orchard-lost-2",
             "orchard-lost-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Book",
+          "itemIcon": "📕"
         }
       ],
       "reward": {

--- a/web/src/data/hub/capitalcity/config.json
+++ b/web/src/data/hub/capitalcity/config.json
@@ -4982,7 +4982,7 @@
       "sprite": "hub-npc-fisherman",
       "tx": 12,
       "ty": 79,
-      "screen": "fishing",
+      "screen": "hub-fishing",
       "dialogue": [
         "The riverside pond's full of fish, if you've the patience. Cast a line?",
         "Quiet water, quick catch. Best spot in the capital.",

--- a/web/src/data/hub/capitalcity/config.json
+++ b/web/src/data/hub/capitalcity/config.json
@@ -3774,6 +3774,46 @@
   },
   "interactables": [
     {
+      "id": "tailor-hat-rack",
+      "tx": 11,
+      "ty": 5,
+      "building": "tailor",
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "tileId": "crownOfCushon"
+        }
+      ],
+      "reactions": [
+        {
+          "type": "buyHubItem",
+          "itemId": "fancy-hat",
+          "price": 40
+        }
+      ]
+    },
+    {
+      "id": "tailor-boot-rack",
+      "tx": 11,
+      "ty": 6,
+      "building": "tailor",
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "tileId": "armourSign"
+        }
+      ],
+      "reactions": [
+        {
+          "type": "buyHubItem",
+          "itemId": "sturdy-boots",
+          "price": 60
+        }
+      ]
+    },
+    {
       "id": "grand-bank-item-0",
       "tx": 11,
       "ty": 3,

--- a/web/src/data/hub/capitalcity/questDefs.json
+++ b/web/src/data/hub/capitalcity/questDefs.json
@@ -18,7 +18,9 @@
             "survey-scroll-2",
             "survey-scroll-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Rolled Map",
+          "itemIcon": "🗺️"
         }
       ],
       "reward": {
@@ -44,7 +46,9 @@
             "charter-seal-2",
             "charter-seal-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Letter",
+          "itemIcon": "✉️"
         }
       ],
       "reward": {
@@ -73,7 +77,9 @@
             "tax-ledger-2",
             "tax-ledger-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Papers",
+          "itemIcon": "📄"
         },
         {
           "key": "hand",
@@ -109,7 +115,9 @@
             "proclamation-1",
             "proclamation-2"
           ],
-          "required": 2
+          "required": 2,
+          "itemName": "Rolled Map",
+          "itemIcon": "🗺️"
         }
       ],
       "reward": {
@@ -140,7 +148,9 @@
             "plaque-1",
             "plaque-2"
           ],
-          "required": 2
+          "required": 2,
+          "itemName": "Painting",
+          "itemIcon": "🖼️"
         },
         {
           "key": "hand",
@@ -178,7 +188,9 @@
           "pickupIds": [
             "postern-key"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Key",
+          "itemIcon": "🗝️"
         },
         {
           "key": "deliver",
@@ -217,7 +229,9 @@
             "patrol-token-2",
             "patrol-token-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Coin",
+          "itemIcon": "🪙"
         },
         {
           "key": "deliver",
@@ -253,7 +267,9 @@
           "pickupIds": [
             "stolen-purse"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Small Sack",
+          "itemIcon": "🌾"
         },
         {
           "key": "deliver",
@@ -291,7 +307,9 @@
             "steel-billet-3",
             "steel-billet-4"
           ],
-          "required": 4
+          "required": 4,
+          "itemName": "Sword",
+          "itemIcon": "⚔️"
         },
         {
           "key": "hand",
@@ -326,7 +344,9 @@
             "relic-2",
             "relic-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Golden Cross",
+          "itemIcon": "✝️"
         }
       ],
       "reward": {
@@ -355,7 +375,9 @@
             "dawn-candle-2",
             "dawn-candle-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Candlestick",
+          "itemIcon": "🕯️"
         }
       ],
       "reward": {
@@ -388,7 +410,9 @@
           "pickupIds": [
             "bell-clapper"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Axe",
+          "itemIcon": "🪓"
         },
         {
           "key": "deliver",
@@ -420,7 +444,9 @@
             "vigil-lantern-1",
             "vigil-lantern-2"
           ],
-          "required": 2
+          "required": 2,
+          "itemName": "Lantern",
+          "itemIcon": "🏮"
         }
       ],
       "reward": {
@@ -451,7 +477,9 @@
             "silk-bolt-2",
             "silk-bolt-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Cotton",
+          "itemIcon": "🧶"
         }
       ],
       "reward": {
@@ -479,7 +507,9 @@
             "raw-gem-2",
             "raw-gem-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Diamond",
+          "itemIcon": "💎"
         }
       ],
       "reward": {
@@ -508,7 +538,9 @@
             "herb-2",
             "herb-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Herb Bundle",
+          "itemIcon": "🌿"
         }
       ],
       "reward": {
@@ -539,7 +571,9 @@
             "grain-sack-2",
             "grain-sack-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Sack",
+          "itemIcon": "🌾"
         },
         {
           "key": "hand",
@@ -574,7 +608,9 @@
             "lost-coin-2",
             "lost-coin-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Coins",
+          "itemIcon": "🪙"
         }
       ],
       "reward": {
@@ -604,7 +640,9 @@
           "pickupIds": [
             "anthology-tome-1"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Book",
+          "itemIcon": "📕"
         },
         {
           "key": "tome-2",
@@ -613,7 +651,9 @@
             "anthology-tome-2"
           ],
           "required": 1,
-          "chain": "anthology-tome-1"
+          "chain": "anthology-tome-1",
+          "itemName": "Book",
+          "itemIcon": "📕"
         },
         {
           "key": "tome-3",
@@ -622,7 +662,9 @@
             "anthology-tome-3"
           ],
           "required": 1,
-          "chain": "anthology-tome-2"
+          "chain": "anthology-tome-2",
+          "itemName": "Book",
+          "itemIcon": "📕"
         }
       ],
       "reward": {
@@ -655,7 +697,9 @@
             "lecture-note-2",
             "lecture-note-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Papers",
+          "itemIcon": "📄"
         }
       ],
       "reward": {
@@ -683,7 +727,9 @@
             "reagent-1",
             "reagent-2"
           ],
-          "required": 2
+          "required": 2,
+          "itemName": "Potion",
+          "itemIcon": "🧪"
         },
         {
           "key": "hand",
@@ -717,7 +763,9 @@
             "mint-die-1",
             "mint-die-2"
           ],
-          "required": 2
+          "required": 2,
+          "itemName": "Small Chest",
+          "itemIcon": "🧰"
         }
       ],
       "reward": {
@@ -747,7 +795,9 @@
           "pickupIds": [
             "coin-pouch"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Gold Coins",
+          "itemIcon": "🪙"
         },
         {
           "key": "deliver",
@@ -778,7 +828,9 @@
             "promissory-1",
             "promissory-2"
           ],
-          "required": 2
+          "required": 2,
+          "itemName": "Letter",
+          "itemIcon": "✉️"
         },
         {
           "key": "hand",
@@ -815,7 +867,9 @@
             "locket-piece-2",
             "locket-piece-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Pendant",
+          "itemIcon": "📿"
         }
       ],
       "reward": {
@@ -843,7 +897,9 @@
             "lute-string-2",
             "lute-string-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Feather",
+          "itemIcon": "🪶"
         }
       ],
       "reward": {
@@ -872,7 +928,9 @@
             "tankard-2",
             "tankard-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Mug",
+          "itemIcon": "☕"
         }
       ],
       "reward": {
@@ -905,7 +963,9 @@
             "provision-3",
             "provision-4"
           ],
-          "required": 4
+          "required": 4,
+          "itemName": "Apple Basket",
+          "itemIcon": "🍎"
         },
         {
           "key": "hand",

--- a/web/src/data/hub/dreadspirecitadel/questDefs.json
+++ b/web/src/data/hub/dreadspirecitadel/questDefs.json
@@ -18,7 +18,9 @@
             "dark-crystal-2",
             "dark-crystal-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Red Crystal",
+          "itemIcon": "💎"
         }
       ],
       "reward": {
@@ -50,7 +52,9 @@
             "dark-crystal-5",
             "dark-crystal-6"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Red Crystal",
+          "itemIcon": "💎"
         }
       ],
       "reward": {
@@ -79,7 +83,9 @@
             "dark-crystal-8",
             "dark-crystal-9"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Red Crystal",
+          "itemIcon": "💎"
         }
       ],
       "reward": {
@@ -116,7 +122,9 @@
             "watch-token-2",
             "watch-token-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Notice",
+          "itemIcon": "🪧"
         }
       ],
       "reward": {
@@ -144,7 +152,9 @@
             "shadow-oil",
             "candle-wax"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Skull",
+          "itemIcon": "💀"
         }
       ],
       "reward": {
@@ -173,7 +183,9 @@
             "femur-3",
             "lost-skull"
           ],
-          "required": 4
+          "required": 4,
+          "itemName": "Skull",
+          "itemIcon": "💀"
         }
       ],
       "reward": {
@@ -204,7 +216,9 @@
             "black-candle-2",
             "black-candle-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Candlestick",
+          "itemIcon": "🕯️"
         }
       ],
       "reward": {
@@ -233,7 +247,9 @@
             "raven-token-3",
             "raven-token-4"
           ],
-          "required": 4
+          "required": 4,
+          "itemName": "Feather",
+          "itemIcon": "🪶"
         }
       ],
       "reward": {
@@ -260,7 +276,9 @@
           "pickupIds": [
             "lost-raven-feather"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Feather",
+          "itemIcon": "🪶"
         }
       ],
       "reward": {
@@ -288,7 +306,9 @@
             "old-key-2",
             "old-key-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Old Key",
+          "itemIcon": "🗝️"
         }
       ],
       "reward": {
@@ -321,7 +341,9 @@
             "moon-herb-1",
             "moon-herb-2"
           ],
-          "required": 2
+          "required": 2,
+          "itemName": "Herb Bundle",
+          "itemIcon": "🌿"
         }
       ],
       "reward": {
@@ -356,7 +378,9 @@
             "test-fungus-1",
             "test-fungus-2"
           ],
-          "required": 2
+          "required": 2,
+          "itemName": "Purple Mushroom",
+          "itemIcon": "🍄"
         }
       ],
       "reward": {
@@ -384,7 +408,9 @@
             "sigil-stone-2",
             "sigil-stone-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Violet Crystal",
+          "itemIcon": "💎"
         }
       ],
       "reward": {
@@ -412,7 +438,9 @@
             "grave-coin-2",
             "grave-coin-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Copper Coins",
+          "itemIcon": "🪙"
         }
       ],
       "reward": {
@@ -440,7 +468,9 @@
             "evidence-2",
             "evidence-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Black Tome",
+          "itemIcon": "📓"
         }
       ],
       "reward": {

--- a/web/src/data/hub/gearford/questDefs.json
+++ b/web/src/data/hub/gearford/questDefs.json
@@ -18,7 +18,9 @@
             "toolbox-2",
             "toolbox-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Supply Crate",
+          "itemIcon": "📦"
         }
       ],
       "reward": {
@@ -43,7 +45,9 @@
             "coal-sack-1",
             "coal-sack-2"
           ],
-          "required": 2
+          "required": 2,
+          "itemName": "Sack",
+          "itemIcon": "🌾"
         }
       ],
       "reward": {
@@ -72,7 +76,9 @@
             "kindling-2",
             "kindling-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Firewood",
+          "itemIcon": "🪵"
         }
       ],
       "reward": {
@@ -100,7 +106,9 @@
             "water-barrel-1",
             "water-barrel-2"
           ],
-          "required": 2
+          "required": 2,
+          "itemName": "Barrel",
+          "itemIcon": "🛢️"
         }
       ],
       "reward": {
@@ -131,7 +139,9 @@
             "ore-2",
             "ore-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Stone",
+          "itemIcon": "🪨"
         }
       ],
       "reward": {
@@ -157,7 +167,9 @@
             "rubble-2",
             "rubble-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Large Stone",
+          "itemIcon": "🪨"
         }
       ],
       "reward": {
@@ -183,7 +195,9 @@
           "pickupIds": [
             "jole-lamp"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Lantern",
+          "itemIcon": "🏮"
         }
       ],
       "reward": {
@@ -211,7 +225,9 @@
             "valve-1",
             "valve-2"
           ],
-          "required": 2
+          "required": 2,
+          "itemName": "Barrel",
+          "itemIcon": "🛢️"
         }
       ],
       "reward": {
@@ -236,7 +252,9 @@
             "flywheel-1",
             "flywheel-2"
           ],
-          "required": 2
+          "required": 2,
+          "itemName": "Supply Crate",
+          "itemIcon": "📦"
         }
       ],
       "reward": {
@@ -260,7 +278,9 @@
           "pickupIds": [
             "pump-fitting"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Cooking Pot",
+          "itemIcon": "🍲"
         },
         {
           "key": "deliver-fitting",
@@ -298,7 +318,9 @@
             "part-3",
             "part-4"
           ],
-          "required": 4
+          "required": 4,
+          "itemName": "Supply Crate",
+          "itemIcon": "📦"
         }
       ],
       "reward": {
@@ -326,7 +348,9 @@
             "errand-1",
             "errand-2"
           ],
-          "required": 2
+          "required": 2,
+          "itemName": "Open Crate",
+          "itemIcon": "📦"
         }
       ],
       "reward": {
@@ -351,7 +375,9 @@
             "rat-sack-2",
             "rat-sack-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Small Sack",
+          "itemIcon": "🌾"
         }
       ],
       "reward": {
@@ -379,7 +405,9 @@
             "ale-barrel-1",
             "ale-barrel-2"
           ],
-          "required": 2
+          "required": 2,
+          "itemName": "Barrel",
+          "itemIcon": "🛢️"
         }
       ],
       "reward": {
@@ -408,7 +436,9 @@
             "store-3",
             "store-4"
           ],
-          "required": 4
+          "required": 4,
+          "itemName": "Supply Crate",
+          "itemIcon": "📦"
         }
       ],
       "reward": {
@@ -434,7 +464,9 @@
           "pickupIds": [
             "key-iron-ingot"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Stone",
+          "itemIcon": "🪨"
         },
         {
           "key": "deliver-key",

--- a/web/src/data/hub/gravemoor/questDefs.json
+++ b/web/src/data/hub/gravemoor/questDefs.json
@@ -18,7 +18,9 @@
             "remains-2",
             "remains-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Skull",
+          "itemIcon": "💀"
         }
       ],
       "reward": {
@@ -50,7 +52,9 @@
             "remains-deep-2",
             "remains-deep-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Skull",
+          "itemIcon": "💀"
         }
       ],
       "reward": {
@@ -79,7 +83,9 @@
           "pickupIds": [
             "widow-locket"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Pendant",
+          "itemIcon": "📿"
         }
       ],
       "reward": {
@@ -111,7 +117,9 @@
           "pickupIds": [
             "soldier-orders"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Book",
+          "itemIcon": "📕"
         }
       ],
       "reward": {
@@ -142,7 +150,9 @@
             "gg-2",
             "gg-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Pendant",
+          "itemIcon": "📿"
         }
       ],
       "reward": {
@@ -166,7 +176,9 @@
           "pickupIds": [
             "pip-keepsake"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Flower Pot",
+          "itemIcon": "🪴"
         },
         {
           "key": "deliver",
@@ -207,7 +219,9 @@
             "ps-2",
             "ps-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Cooking Pot",
+          "itemIcon": "🍲"
         }
       ],
       "reward": {
@@ -238,7 +252,9 @@
             "sfu-2",
             "sfu-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Sack",
+          "itemIcon": "🌾"
         }
       ],
       "reward": {
@@ -267,7 +283,9 @@
           "pickupIds": [
             "ht-1"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Book",
+          "itemIcon": "📕"
         }
       ],
       "reward": {
@@ -291,7 +309,9 @@
           "pickupIds": [
             "ht-2"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Skull",
+          "itemIcon": "💀"
         }
       ],
       "reward": {
@@ -315,7 +335,9 @@
           "pickupIds": [
             "ht-3"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Golden Cross",
+          "itemIcon": "✝️"
         }
       ],
       "reward": {

--- a/web/src/data/hub/harrowfield/config.json
+++ b/web/src/data/hub/harrowfield/config.json
@@ -2460,6 +2460,26 @@
   },
   "interactables": [
     {
+      "id": "harrowfield-chicken-feed",
+      "tx": 4,
+      "ty": 25,
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "tileId": "sack"
+        }
+      ],
+      "reactions": [
+        {
+          "type": "buyHubItem",
+          "itemId": "chicken-feed",
+          "price": 5,
+          "speakerName": "Feed Stall"
+        }
+      ]
+    },
+    {
       "id": "market-shed-item-0",
       "tx": 11,
       "ty": 2,

--- a/web/src/data/hub/harrowfield/questDefs.json
+++ b/web/src/data/hub/harrowfield/questDefs.json
@@ -18,7 +18,9 @@
             "seed-sack-2",
             "seed-sack-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Sack",
+          "itemIcon": "🌾"
         }
       ],
       "reward": {
@@ -47,7 +49,9 @@
             "sheaf-2",
             "sheaf-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Sack Pile",
+          "itemIcon": "🌾"
         },
         {
           "key": "deliver",
@@ -87,7 +91,9 @@
             "fence-rail-2",
             "fence-rail-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Firewood",
+          "itemIcon": "🪵"
         }
       ],
       "reward": {
@@ -116,7 +122,9 @@
             "fleece-2",
             "fleece-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Sack Pile",
+          "itemIcon": "🌾"
         },
         {
           "key": "deliver",
@@ -151,7 +159,9 @@
             "grain-bag-2",
             "grain-bag-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Sack",
+          "itemIcon": "🌾"
         }
       ],
       "reward": {
@@ -178,7 +188,9 @@
           "pickupIds": [
             "flour-sack-1"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Sack",
+          "itemIcon": "🌾"
         },
         {
           "key": "deliver",
@@ -213,7 +225,9 @@
             "ingredient-2",
             "ingredient-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Basket",
+          "itemIcon": "🧺"
         }
       ],
       "reward": {
@@ -240,7 +254,9 @@
           "pickupIds": [
             "bread-basket-1"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Leaf Basket",
+          "itemIcon": "🍂"
         },
         {
           "key": "deliver",
@@ -275,7 +291,9 @@
             "field-lost-2",
             "field-lost-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Book",
+          "itemIcon": "📕"
         }
       ],
       "reward": {
@@ -309,7 +327,9 @@
             "bram-thing-2",
             "bram-thing-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Leaf Basket",
+          "itemIcon": "🍂"
         }
       ],
       "reward": {
@@ -337,7 +357,9 @@
             "linen-2",
             "linen-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Sack",
+          "itemIcon": "🌾"
         }
       ],
       "reward": {
@@ -366,7 +388,9 @@
             "harvest-bloom-2",
             "harvest-bloom-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Candlestick",
+          "itemIcon": "🕯️"
         }
       ],
       "reward": {
@@ -402,7 +426,9 @@
             "supper-2",
             "supper-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Apple Basket",
+          "itemIcon": "🍎"
         }
       ],
       "reward": {
@@ -435,7 +461,9 @@
           "pickupIds": [
             "produce-crate-1"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Supply Crate",
+          "itemIcon": "📦"
         },
         {
           "key": "deliver",

--- a/web/src/data/hub/hollowmere/questDefs.json
+++ b/web/src/data/hub/hollowmere/questDefs.json
@@ -10,7 +10,7 @@
       "activeDialogue": "Three bunches of moonherb, growing around the edges of town. It glows faintly. Or hums. Sometimes both.",
       "completeDialogue": "Fresh moonherb! The cauldron bubbles tonight. Here — your cut, and some free advice: if Ogrim offers you a drink, ask what's in it FIRST.",
       "steps": [
-        { "key": "herbs", "type": "collect", "pickupIds": ["moonherb-1", "moonherb-2", "moonherb-3"], "required": 3 }
+        { "key": "herbs", "type": "collect", "pickupIds": ["moonherb-1", "moonherb-2", "moonherb-3"], "required": 3, "itemName": "Herb Bundle", "itemIcon": "🌿" }
       ],
       "reward": {
         "crystals": 65,
@@ -28,7 +28,7 @@
       "activeDialogue": "Gather a moon-cap from Morwen's brewing room, a marsh-herb bunch, and a bog bottle, then return to Morwen.",
       "completeDialogue": "Perfect — cap, herb and bottle, just so. The cure's bubbling. Cough's cured, joints eased, and one fellow's grown a SECOND nose, but that's a feature where he's from. Well done.",
       "steps": [
-        { "key": "ingredients", "type": "collect", "pickupIds": ["brew-cap-1", "brew-herb-2", "brew-bottle-3"], "required": 3 }
+        { "key": "ingredients", "type": "collect", "pickupIds": ["brew-cap-1", "brew-herb-2", "brew-bottle-3"], "required": 3, "itemName": "Purple Mushroom", "itemIcon": "🍄" }
       ],
       "reward": {
         "crystals": 85,
@@ -47,7 +47,7 @@
       "activeDialogue": "A crow's feather, a moon-cap mushroom, and a thornless rose — all fall or grow around Hollowmere. Bring me all three.",
       "completeDialogue": "Feather, cap, and rose. Good. Now hold still — this tingles. *she mutters, and the air fills with chatter* ...There. You will hear them now: every cat, crow, and complaining frog. Go and listen to that wretched, kipper-loathing cat. And mind — knowing what a beast wants is the easy part. GIVING it to them is on you.",
       "steps": [
-        { "key": "components", "type": "collect", "pickupIds": ["spell-feather", "spell-mooncap", "spell-rose"], "required": 3 }
+        { "key": "components", "type": "collect", "pickupIds": ["spell-feather", "spell-mooncap", "spell-rose"], "required": 3, "itemName": "Feather", "itemIcon": "🪶" }
       ],
       "reward": {
         "crystals": 80,
@@ -70,7 +70,7 @@
       "activeDialogue": "Gather two fungus caps and a marsh-herb bunch from around the mire for Sister Nettle.",
       "completeDialogue": "Fresh and potent — exactly right. Now I can mix something for the troll's rash that won't, you know, dissolve him. My thanks, and a small cut of the profits.",
       "steps": [
-        { "key": "stock", "type": "collect", "pickupIds": ["apo-mush-1", "apo-mush-2", "apo-herb-3"], "required": 3 }
+        { "key": "stock", "type": "collect", "pickupIds": ["apo-mush-1", "apo-mush-2", "apo-herb-3"], "required": 3, "itemName": "Brown Mushroom", "itemIcon": "🍄" }
       ],
       "reward": {
         "crystals": 60,
@@ -88,7 +88,7 @@
       "activeDialogue": "Find three rare deep-muck caps from the far reaches of the mire for Sister Nettle.",
       "completeDialogue": "Deep-muck caps, every one. The drake-bite poultice practically mixes itself now. You've a steady hand and a stronger stomach — both rare, both welcome here.",
       "steps": [
-        { "key": "rare", "type": "collect", "pickupIds": ["apo2-1", "apo2-2", "apo2-3"], "required": 3 }
+        { "key": "rare", "type": "collect", "pickupIds": ["apo2-1", "apo2-2", "apo2-3"], "required": 3, "itemName": "Purple Mushroom", "itemIcon": "🍄" }
       ],
       "reward": {
         "crystals": 80,
@@ -106,7 +106,7 @@
       "activeDialogue": "Collect the scattered feed sacks and hay from around the beast pens for Big Mott.",
       "completeDialogue": "Good lad, good lad. See how they settle when they're fed? That's lesson one. You've a gentle way about you — the pens like that. So does Mott.",
       "steps": [
-        { "key": "feed", "type": "collect", "pickupIds": ["feed-1", "feed-2", "feed-3"], "required": 3 }
+        { "key": "feed", "type": "collect", "pickupIds": ["feed-1", "feed-2", "feed-3"], "required": 3, "itemName": "Sack", "itemIcon": "🌾" }
       ],
       "reward": {
         "crystals": 55,
@@ -124,7 +124,7 @@
       "activeDialogue": "Gather proper bedding — hay and sacks — from the yard so Big Mott can settle the skittish beasts.",
       "completeDialogue": "Look at that — the nervy one's stopped trembling. Took years off my worrying, you have. You've the patience for this work. Most folk don't.",
       "steps": [
-        { "key": "bedding", "type": "collect", "pickupIds": ["gentle-1", "gentle-2", "gentle-3"], "required": 3 }
+        { "key": "bedding", "type": "collect", "pickupIds": ["gentle-1", "gentle-2", "gentle-3"], "required": 3, "itemName": "Sack", "itemIcon": "🌾" }
       ],
       "reward": {
         "crystals": 75,
@@ -142,7 +142,7 @@
       "activeDialogue": "Collect two prize treats from around town, then bring them back to Big Mott at the pens.",
       "completeDialogue": "They sat. They STAYED. Big Mott has not been this proud since... ever, really. You're a beast-tamer now, and no mistake. The pens will always have a place for you.",
       "steps": [
-        { "key": "treats", "type": "collect", "pickupIds": ["show-1", "show-2"], "required": 2 },
+        { "key": "treats", "type": "collect", "pickupIds": ["show-1", "show-2"], "required": 2, "itemName": "Herb Bundle", "itemIcon": "🌿" },
         { "key": "deliver", "type": "deliver", "targetNpcId": "tame-ogre-keeper", "required": 1 }
       ],
       "reward": {
@@ -161,7 +161,7 @@
       "activeDialogue": "Recover Snægg's three lost curios — a skull, a book and a pendant — from around Hollowmere.",
       "completeDialogue": "All three! And barely chewed! You've a collector's eye, you have. Tell you what — keep the coin AND a little something from the bargain bin. Don't open the jar. Just... don't.",
       "steps": [
-        { "key": "oddments", "type": "collect", "pickupIds": ["odd-1", "odd-2", "odd-3"], "required": 3 }
+        { "key": "oddments", "type": "collect", "pickupIds": ["odd-1", "odd-2", "odd-3"], "required": 3, "itemName": "Book", "itemIcon": "📕" }
       ],
       "reward": {
         "crystals": 70,
@@ -178,7 +178,7 @@
       "activeDialogue": "Gather bog-oil, soothing herb and salts from around town for Grunda's mud-wallow.",
       "completeDialogue": "Ahhh, smell that? That's a wallow with PRIDE again. First soak's on the house, friend. Mind the deep end — that's where we lost the last health inspector.",
       "steps": [
-        { "key": "supplies", "type": "collect", "pickupIds": ["wallow-1", "wallow-2", "wallow-3"], "required": 3 }
+        { "key": "supplies", "type": "collect", "pickupIds": ["wallow-1", "wallow-2", "wallow-3"], "required": 3, "itemName": "Bottle", "itemIcon": "🍾" }
       ],
       "reward": {
         "crystals": 60,
@@ -195,7 +195,7 @@
       "activeDialogue": "Recover three trinkets the mire has swallowed — a pendant, a book and a pot of physic.",
       "completeDialogue": "All three, dredged from the deep muck. The mire grumbles, but it'll forgive you — and so will the folk who lost them. You've a fine eye for what the bog hides, child.",
       "steps": [
-        { "key": "trinkets", "type": "collect", "pickupIds": ["lost-1", "lost-2", "lost-3"], "required": 3 }
+        { "key": "trinkets", "type": "collect", "pickupIds": ["lost-1", "lost-2", "lost-3"], "required": 3, "itemName": "Pendant", "itemIcon": "📿" }
       ],
       "reward": {
         "crystals": 65,
@@ -213,7 +213,7 @@
       "activeDialogue": "Search the deepest, blackest reaches of the mire for three long-lost treasures.",
       "completeDialogue": "From the black muck itself! Two hundred years that pendant lay down there. You've earned the mire's grudging respect, dearie — and Mother Sump's, which is rarer and worth more.",
       "steps": [
-        { "key": "deep", "type": "collect", "pickupIds": ["lost2-1", "lost2-2", "lost2-3"], "required": 3 }
+        { "key": "deep", "type": "collect", "pickupIds": ["lost2-1", "lost2-2", "lost2-3"], "required": 3, "itemName": "Pendant", "itemIcon": "📿" }
       ],
       "reward": {
         "crystals": 90,
@@ -232,7 +232,7 @@
       "activeDialogue": "Collect a vial of marsh-physic from Morwen's brewing room, then carry it to Alchemist Sythe at Dreadspire Citadel.",
       "completeDialogue": "Morwen's marsh-physic, fresh as the bog. And a message about a cauldron — yes, yes, she's mentioned it. Frequently. Across two decades. Tell the old crow her debt is noted and her physic is, infuriatingly, excellent.",
       "steps": [
-        { "key": "vial", "type": "collect", "pickupIds": ["medicine-vial"], "required": 1 },
+        { "key": "vial", "type": "collect", "pickupIds": ["medicine-vial"], "required": 1, "itemName": "Potion", "itemIcon": "🧪" },
         { "key": "deliver", "type": "deliver", "targetNpcId": "alchemist-sythe", "required": 1 }
       ],
       "reward": {

--- a/web/src/data/hub/ironholdkeep/config.json
+++ b/web/src/data/hub/ironholdkeep/config.json
@@ -4482,6 +4482,26 @@
   },
   "interactables": [
     {
+      "id": "ironholdkeep-chicken-feed",
+      "tx": 15,
+      "ty": 21,
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "tileId": "sack"
+        }
+      ],
+      "reactions": [
+        {
+          "type": "buyHubItem",
+          "itemId": "chicken-feed",
+          "price": 5,
+          "speakerName": "Feed Stall"
+        }
+      ]
+    },
+    {
       "id": "quartermasters-store-item-0",
       "tx": 9,
       "ty": 2,

--- a/web/src/data/hub/ironholdkeep/questDefs.json
+++ b/web/src/data/hub/ironholdkeep/questDefs.json
@@ -18,7 +18,9 @@
             "patrol-report-2",
             "patrol-report-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Note",
+          "itemIcon": "📝"
         }
       ],
       "reward": {
@@ -44,7 +46,9 @@
             "weapon-crate-2",
             "weapon-crate-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Supply Crate",
+          "itemIcon": "📦"
         }
       ],
       "reward": {
@@ -77,7 +81,9 @@
           "pickupIds": [
             "chronicle-page-1"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Notice",
+          "itemIcon": "🪧"
         },
         {
           "key": "page-2",
@@ -86,7 +92,9 @@
             "chronicle-page-2"
           ],
           "required": 1,
-          "chain": "chronicle-page-1"
+          "chain": "chronicle-page-1",
+          "itemName": "Notice",
+          "itemIcon": "🪧"
         },
         {
           "key": "page-3",
@@ -95,7 +103,9 @@
             "chronicle-page-3"
           ],
           "required": 1,
-          "chain": "chronicle-page-2"
+          "chain": "chronicle-page-2",
+          "itemName": "Notice",
+          "itemIcon": "🪧"
         }
       ],
       "reward": {
@@ -129,7 +139,9 @@
             "watch-token-2",
             "watch-token-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Notice",
+          "itemIcon": "🪧"
         }
       ],
       "reward": {
@@ -158,7 +170,9 @@
             "drill-gear-2",
             "drill-gear-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Supply Crate",
+          "itemIcon": "📦"
         }
       ],
       "reward": {
@@ -211,7 +225,9 @@
             "supply-ledger-2",
             "supply-ledger-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Notice",
+          "itemIcon": "🪧"
         }
       ],
       "reward": {
@@ -241,7 +257,9 @@
             "grain-sack-3",
             "grain-sack-4"
           ],
-          "required": 4
+          "required": 4,
+          "itemName": "Sack",
+          "itemIcon": "🌾"
         }
       ],
       "reward": {
@@ -267,7 +285,9 @@
             "arrow-bundle-2",
             "arrow-bundle-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Supply Crate",
+          "itemIcon": "📦"
         }
       ],
       "reward": {
@@ -293,7 +313,9 @@
             "broken-blade-2",
             "broken-blade-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Notice",
+          "itemIcon": "🪧"
         }
       ],
       "reward": {
@@ -321,7 +343,9 @@
             "feast-cheese",
             "feast-ale"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Sack",
+          "itemIcon": "🌾"
         }
       ],
       "reward": {
@@ -351,7 +375,9 @@
             "plate-3",
             "plate-4"
           ],
-          "required": 4
+          "required": 4,
+          "itemName": "Notice",
+          "itemIcon": "🪧"
         }
       ],
       "reward": {
@@ -374,7 +400,9 @@
           "pickupIds": [
             "foal-bell"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Notice",
+          "itemIcon": "🪧"
         }
       ],
       "reward": {
@@ -403,7 +431,9 @@
             "hay-bale-2",
             "hay-bale-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Sack",
+          "itemIcon": "🌾"
         }
       ],
       "reward": {
@@ -428,7 +458,9 @@
             "training-sword-2",
             "training-sword-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Notice",
+          "itemIcon": "🪧"
         }
       ],
       "reward": {
@@ -457,21 +489,27 @@
           "key": "index-1",
           "type": "collect",
           "pickupIds": [ "index-card-1" ],
-          "required": 1
+          "required": 1,
+          "itemName": "Notice",
+          "itemIcon": "🪧"
         },
         {
           "key": "index-2",
           "type": "collect",
           "pickupIds": [ "index-card-2" ],
           "required": 1,
-          "chain": "index-card-1"
+          "chain": "index-card-1",
+          "itemName": "Notice",
+          "itemIcon": "🪧"
         },
         {
           "key": "index-3",
           "type": "collect",
           "pickupIds": [ "index-card-3" ],
           "required": 1,
-          "chain": "index-card-2"
+          "chain": "index-card-2",
+          "itemName": "Notice",
+          "itemIcon": "🪧"
         }
       ],
       "reward": {
@@ -499,7 +537,9 @@
             "grave-candle-2",
             "grave-candle-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Candlestick",
+          "itemIcon": "🕯️"
         }
       ],
       "reward": {
@@ -525,7 +565,9 @@
           "pickupIds": [
             "prisoner-letter"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Notice",
+          "itemIcon": "🪧"
         }
       ],
       "reward": {
@@ -550,14 +592,18 @@
           "key": "half-1",
           "type": "collect",
           "pickupIds": [ "key-half-1" ],
-          "required": 1
+          "required": 1,
+          "itemName": "Notice",
+          "itemIcon": "🪧"
         },
         {
           "key": "half-2",
           "type": "collect",
           "pickupIds": [ "key-half-2" ],
           "required": 1,
-          "chain": "key-half-1"
+          "chain": "key-half-1",
+          "itemName": "Notice",
+          "itemIcon": "🪧"
         }
       ],
       "reward": {
@@ -590,7 +636,9 @@
           "pickupIds": [
             "vault-ledger"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Notice",
+          "itemIcon": "🪧"
         }
       ],
       "reward": {
@@ -624,7 +672,9 @@
             "gate-chalk-2",
             "gate-chalk-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Notice",
+          "itemIcon": "🪧"
         }
       ],
       "reward": {
@@ -650,7 +700,9 @@
             "banner-fragment-2",
             "banner-fragment-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Notice",
+          "itemIcon": "🪧"
         }
       ],
       "reward": {

--- a/web/src/data/hub/loader.ts
+++ b/web/src/data/hub/loader.ts
@@ -272,6 +272,10 @@ export type HubInteractableReaction =
   | { type: 'move'; to: HubCoordinate; message?: string }
   | { type: 'buy'; slotIndex: number }
   | { type: 'buyPack' }
+  /** Always-available hub-item purchase (no daily stock rotation). itemId must
+   *  exist in web/src/data/hubItems.json; unique items re-offer as "already
+   *  owned" once bought. */
+  | { type: 'buyHubItem'; itemId: string; price: number; currency?: 'crystals' | 'tickets'; speakerName?: string }
 
 export interface HubInteractable {
   id: string

--- a/web/src/data/hub/millhaven/config.json
+++ b/web/src/data/hub/millhaven/config.json
@@ -1414,6 +1414,7 @@
     {
       "id": "fishmonger-marta",
       "name": "Fishwife Marta",
+      "dialogueTree": "marta-fish-trade",
       "sprite": "hub-npc-fisherman",
       "tx": 23,
       "ty": 13,
@@ -1822,7 +1823,7 @@
         "Cast a line with me — the harbour's always biting.",
         "Patience and a steady hand, that's all it takes."
       ],
-      "screen": "fishing"
+      "screen": "hub-fishing"
     },
     {
       "id": "quartermaster-millhaven",
@@ -2844,6 +2845,46 @@
     }
   ],
   "interactables": [
+    {
+      "id": "millhaven-rod-stall",
+      "tx": 32,
+      "ty": 10,
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "tileId": "fishingHook"
+        }
+      ],
+      "reactions": [
+        {
+          "type": "buyHubItem",
+          "itemId": "fishing-rod",
+          "price": 100,
+          "speakerName": "Harbour Tackle Stall"
+        }
+      ]
+    },
+    {
+      "id": "millhaven-bait-stall",
+      "tx": 32,
+      "ty": 11,
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "tileId": "bucketAndRope"
+        }
+      ],
+      "reactions": [
+        {
+          "type": "buyHubItem",
+          "itemId": "fish-bait",
+          "price": 8,
+          "speakerName": "Harbour Tackle Stall"
+        }
+      ]
+    },
     {
       "id": "millhaven-chicken-feed",
       "tx": 9,

--- a/web/src/data/hub/millhaven/config.json
+++ b/web/src/data/hub/millhaven/config.json
@@ -2845,6 +2845,23 @@
   ],
   "interactables": [
     {
+      "id": "millhaven-chicken-feed",
+      "tx": 9,
+      "ty": 1,
+      "building": "bakery",
+      "hitRect": {
+        "w": 1,
+        "h": 2
+      },
+      "reactions": [
+        {
+          "type": "buyHubItem",
+          "itemId": "chicken-feed",
+          "price": 5
+        }
+      ]
+    },
+    {
       "id": "interactable-1782144142080",
       "tx": 7,
       "ty": 13,

--- a/web/src/data/hub/millhaven/questDefs.json
+++ b/web/src/data/hub/millhaven/questDefs.json
@@ -791,6 +791,121 @@
   "blockedPaths": [],
   "dialogues": [
     {
+      "id": "marta-fish-trade",
+      "npcId": "fishmonger-marta",
+      "start": "greet",
+      "nodes": {
+        "greet": {
+          "text": "Fresh fish bought and sold! If you've been out on the water, I pay fair coin for anything with fins.",
+          "choices": [
+            {
+              "label": "I've got fish to sell.",
+              "next": "sell"
+            },
+            {
+              "label": "Just looking.",
+              "effects": [
+                {
+                  "type": "end"
+                }
+              ]
+            }
+          ]
+        },
+        "sell": {
+          "text": "Let's see the catch, then. What are you selling?",
+          "choices": [
+            {
+              "label": "Tiddler — 3 💎",
+              "next": "sell",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "fish-tiddler",
+                  "giveCrystals": 3,
+                  "missingText": "No tiddlers in that pack of yours. Cast a line off the dock first.",
+                  "successText": "Barely a mouthful, but the cats love them. 3 crystals."
+                }
+              ]
+            },
+            {
+              "label": "Small Fish — 6 💎",
+              "next": "sell",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "fish-small",
+                  "giveCrystals": 6,
+                  "missingText": "You've no small fish on you.",
+                  "successText": "Good pan-sized fish, that. 6 crystals."
+                }
+              ]
+            },
+            {
+              "label": "Medium Fish — 12 💎",
+              "next": "sell",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "fish-medium",
+                  "giveCrystals": 12,
+                  "missingText": "You've no medium fish on you.",
+                  "successText": "Now that's a proper catch. 12 crystals."
+                }
+              ]
+            },
+            {
+              "label": "Large Fish — 25 💎",
+              "next": "sell",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "fish-large",
+                  "giveCrystals": 25,
+                  "missingText": "You've no large fish on you.",
+                  "successText": "Heavens, look at the size of it! 25 crystals, and worth every one."
+                }
+              ]
+            },
+            {
+              "label": "Trophy Fish — 45 💎",
+              "next": "sell",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "fish-trophy",
+                  "giveCrystals": 45,
+                  "missingText": "A trophy fish? I'll believe it when I see it.",
+                  "successText": "I'll have this in the window within the hour. 45 crystals!"
+                }
+              ]
+            },
+            {
+              "label": "Legendary Fish — 90 💎",
+              "next": "sell",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "fish-legendary",
+                  "giveCrystals": 90,
+                  "missingText": "A legendary fish? Sailor Finn tells taller tales sober.",
+                  "successText": "By the tides... I've only heard songs about these. 90 crystals — don't tell my husband."
+                }
+              ]
+            },
+            {
+              "label": "That's all for now.",
+              "effects": [
+                {
+                  "type": "end"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    {
       "id": "kipper-truth",
       "npcId": "kipper",
       "start": "meet",

--- a/web/src/data/hub/millhaven/questDefs.json
+++ b/web/src/data/hub/millhaven/questDefs.json
@@ -18,7 +18,9 @@
             "grain-sack-2",
             "grain-sack-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Sack",
+          "itemIcon": "🌾"
         }
       ],
       "reward": {
@@ -45,7 +47,9 @@
             "fish-basket-1",
             "fish-basket-2"
           ],
-          "required": 2
+          "required": 2,
+          "itemName": "Mushroom Basket",
+          "itemIcon": "🍄"
         },
         {
           "key": "deliver",
@@ -85,7 +89,9 @@
           "pickupIds": [
             "nautical-chart"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Rolled Map",
+          "itemIcon": "🗺️"
         }
       ],
       "reward": {
@@ -169,7 +175,9 @@
           "pickupIds": [
             "festival-ribbon"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Gift",
+          "itemIcon": "🎁"
         },
         {
           "key": "candle",
@@ -178,7 +186,9 @@
             "festival-candle"
           ],
           "required": 1,
-          "chain": "festival-ribbon"
+          "chain": "festival-ribbon",
+          "itemName": "Gift",
+          "itemIcon": "🎁"
         },
         {
           "key": "flower",
@@ -187,7 +197,9 @@
             "festival-flower"
           ],
           "required": 1,
-          "chain": "festival-candle"
+          "chain": "festival-candle",
+          "itemName": "White Flower",
+          "itemIcon": "🌼"
         }
       ],
       "reward": {
@@ -216,7 +228,9 @@
           "pickupIds": [
             "kippers-kipper"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Goldfish",
+          "itemIcon": "🐟"
         }
       ],
       "reward": {
@@ -240,7 +254,9 @@
           "pickupIds": [
             "kippers-kipper-2"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Goldfish",
+          "itemIcon": "🐟"
         }
       ],
       "reward": {
@@ -264,7 +280,9 @@
           "pickupIds": [
             "kippers-kipper-3"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Goldfish",
+          "itemIcon": "🐟"
         }
       ],
       "reward": {
@@ -311,7 +329,9 @@
           "pickupIds": [
             "kipper-feather-toy"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Toy",
+          "itemIcon": "🧸"
         }
       ],
       "reward": {
@@ -344,7 +364,9 @@
             "fresh-loaf-1",
             "fresh-loaf-2"
           ],
-          "required": 2
+          "required": 2,
+          "itemName": "Apple Basket",
+          "itemIcon": "🍎"
         },
         {
           "key": "deliver",
@@ -379,7 +401,9 @@
             "scrap-iron-2",
             "scrap-iron-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Axe",
+          "itemIcon": "🪓"
         }
       ],
       "reward": {
@@ -403,7 +427,9 @@
             "lost-net-1",
             "lost-net-2"
           ],
-          "required": 2
+          "required": 2,
+          "itemName": "Cotton",
+          "itemIcon": "🧶"
         }
       ],
       "reward": {
@@ -429,7 +455,9 @@
           "pickupIds": [
             "tamsin-locket"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Gold Necklace",
+          "itemIcon": "📿"
         }
       ],
       "reward": {
@@ -540,7 +568,9 @@
           "pickupIds": [
             "restock-barrel"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Barrel",
+          "itemIcon": "🛢️"
         },
         {
           "key": "sack",
@@ -549,7 +579,9 @@
             "restock-sack"
           ],
           "required": 1,
-          "chain": "restock-barrel"
+          "chain": "restock-barrel",
+          "itemName": "Sack",
+          "itemIcon": "🌾"
         },
         {
           "key": "crate",
@@ -558,7 +590,9 @@
             "restock-crate"
           ],
           "required": 1,
-          "chain": "restock-sack"
+          "chain": "restock-sack",
+          "itemName": "Supply Crate",
+          "itemIcon": "📦"
         }
       ],
       "reward": {

--- a/web/src/data/hub/questDefs.ts
+++ b/web/src/data/hub/questDefs.ts
@@ -218,6 +218,17 @@ export type DialogueEffect =
   | { type: 'friendship'; npcId?: string; xp: number }  // grant friendship XP (defaults to the speaking NPC)
   | { type: 'relationship'; npcId?: string; track: RelationshipTrack; points: number }  // advance a relationship track (defaults to the speaking NPC)
   | { type: 'quest'; questId: string }          // offer a quest (Accept / Not now)
+  // Repeatable barter: take wantCount (default 1) of a hub-item from the
+  // player in exchange for crystals / another hub-item / a collectible.
+  // Shows missingText (no state change) if the player holds too few.
+  | { type: 'tradeHubItem'
+      wantItemId: string
+      wantCount?: number
+      giveCrystals?: number
+      giveHubItem?: { itemId: string; count?: number }
+      giveCollectible?: { id: string; name: string; icon: string; desc: string }
+      missingText: string
+      successText: string }
   | { type: 'end' }                             // end the conversation
 
 export interface DialogueChoiceDef {

--- a/web/src/data/hub/questDefs.ts
+++ b/web/src/data/hub/questDefs.ts
@@ -7,6 +7,11 @@ export interface HubQuestStep {
   targetNpcId?: string
   required: number
   chain?: string
+  /** Collect steps only: display name for the held item shown in the Hub
+   *  Inventory while the quest is active (e.g. "Grain Sack"). */
+  itemName?: string
+  /** Collect steps only: emoji icon for the held item (e.g. "🌾"). */
+  itemIcon?: string
 }
 
 export interface RelationshipGrant {
@@ -94,6 +99,10 @@ export interface CollectStep {
   type: string // 'collect'
   pickupIds: string[]
   required: number
+  /** Display name for the held item shown in the Hub Inventory. */
+  itemName?: string
+  /** Emoji icon for the held item. */
+  itemIcon?: string
 }
 
 export interface DeliverStep {

--- a/web/src/data/hub/ravenwatch/config.json
+++ b/web/src/data/hub/ravenwatch/config.json
@@ -8751,7 +8751,7 @@
       "sprite": "hub-npc-fisherman",
       "tx": 45,
       "ty": 49,
-      "screen": "fishing",
+      "screen": "hub-fishing",
       "dialogue": [
         "Nothings biting today. Maybe try again later?",
         "The fish are shy around here. Patience is key."
@@ -8763,7 +8763,7 @@
       "sprite": "hub-npc-fisherman",
       "tx": 44,
       "ty": 51,
-      "screen": "fishing",
+      "screen": "hub-fishing",
       "dialogue": [
         "The pond is calm today. Care to fish?"
       ]

--- a/web/src/data/hub/ravenwatch/config.json
+++ b/web/src/data/hub/ravenwatch/config.json
@@ -9400,6 +9400,19 @@
   ],
   "interactables": [
     {
+      "id": "ravenwatch-chicken-feed",
+      "tx": 5,
+      "ty": 5,
+      "building": "market-building",
+      "reactions": [
+        {
+          "type": "buyHubItem",
+          "itemId": "chicken-feed",
+          "price": 5
+        }
+      ]
+    },
+    {
       "id": "notice-board",
       "tx": 49,
       "ty": 21,

--- a/web/src/data/hub/ravenwatch/questDefs.json
+++ b/web/src/data/hub/ravenwatch/questDefs.json
@@ -18,7 +18,9 @@
             "stray-fish-2",
             "stray-fish-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Goldfish",
+          "itemIcon": "🐟"
         },
         {
           "key": "deliver",
@@ -52,7 +54,9 @@
           "pickupIds": [
             "naia-rare-tome"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Black Tome",
+          "itemIcon": "📓"
         }
       ],
       "reward": {
@@ -82,7 +86,9 @@
           "pickupIds": [
             "naia-research-glyph"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Yellow Crystal",
+          "itemIcon": "💎"
         }
       ],
       "reward": {
@@ -113,7 +119,9 @@
             "rover-toy-2",
             "rover-toy-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Stick",
+          "itemIcon": "🪵"
         }
       ],
       "reward": {
@@ -139,7 +147,9 @@
             "pip-shiny-2",
             "pip-shiny-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Yellow Crystal",
+          "itemIcon": "💎"
         }
       ],
       "reward": {
@@ -165,7 +175,9 @@
             "pendant-2",
             "pendant-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Gold Necklace",
+          "itemIcon": "📿"
         }
       ],
       "reward": {
@@ -192,7 +204,9 @@
           "pickupIds": [
             "moonleaf-herb"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Herb Bundle",
+          "itemIcon": "🌿"
         }
       ],
       "reward": {
@@ -234,7 +248,9 @@
           "pickupIds": [
             "ancient-tome-1"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Black Tome",
+          "itemIcon": "📓"
         },
         {
           "key": "tome-2",
@@ -243,7 +259,9 @@
             "ancient-tome-2"
           ],
           "required": 1,
-          "chain": "ancient-tome-1"
+          "chain": "ancient-tome-1",
+          "itemName": "Blue Tome",
+          "itemIcon": "📘"
         },
         {
           "key": "tome-3",
@@ -252,7 +270,9 @@
             "ancient-tome-3"
           ],
           "required": 1,
-          "chain": "ancient-tome-2"
+          "chain": "ancient-tome-2",
+          "itemName": "Green Tome",
+          "itemIcon": "📗"
         }
       ],
       "reward": {
@@ -318,7 +338,9 @@
             "bait-jar-2",
             "bait-jar-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Small Sack",
+          "itemIcon": "🌾"
         }
       ],
       "reward": {
@@ -370,7 +392,9 @@
           "pickupIds": [
             "gildwyns-rare-card"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Blue Tome",
+          "itemIcon": "📘"
         }
       ],
       "reward": {
@@ -400,7 +424,9 @@
           "pickupIds": [
             "miras-lost-crystal"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Violet Crystal",
+          "itemIcon": "💎"
         }
       ],
       "reward": {
@@ -427,7 +453,9 @@
           "pickupIds": [
             "aldous-locket"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Pendant",
+          "itemIcon": "📿"
         }
       ],
       "reward": {
@@ -481,7 +509,9 @@
             "ink-bottle-1",
             "ink-bottle-2"
           ],
-          "required": 2
+          "required": 2,
+          "itemName": "Book",
+          "itemIcon": "📕"
         }
       ],
       "reward": {
@@ -510,7 +540,9 @@
             "overdue-book-2",
             "overdue-book-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Book",
+          "itemIcon": "📕"
         }
       ],
       "reward": {
@@ -537,7 +569,9 @@
           "pickupIds": [
             "guild-ledger"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Black Tome",
+          "itemIcon": "📓"
         }
       ],
       "reward": {
@@ -566,7 +600,9 @@
             "survey-note-2",
             "survey-note-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Note",
+          "itemIcon": "📝"
         }
       ],
       "reward": {
@@ -595,7 +631,9 @@
             "weight-2",
             "weight-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Barrel",
+          "itemIcon": "🛢️"
         }
       ],
       "reward": {
@@ -624,7 +662,9 @@
             "patrol-report-2",
             "patrol-report-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Note",
+          "itemIcon": "📝"
         }
       ],
       "reward": {
@@ -653,7 +693,9 @@
             "prize-token-2",
             "prize-token-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Pendant",
+          "itemIcon": "📿"
         }
       ],
       "reward": {
@@ -680,7 +722,9 @@
           "pickupIds": [
             "ironwall-cup"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Gold Chest",
+          "itemIcon": "💰"
         }
       ],
       "reward": {
@@ -713,7 +757,9 @@
             "marsh-thyme",
             "market-peppercorn"
           ],
-          "required": 2
+          "required": 2,
+          "itemName": "Herb Bundle",
+          "itemIcon": "🌿"
         }
       ],
       "reward": {
@@ -773,7 +819,9 @@
             "memory-shard-2",
             "memory-shard-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "White Crystal",
+          "itemIcon": "💎"
         }
       ],
       "reward": {
@@ -800,7 +848,9 @@
           "pickupIds": [
             "strange-catch"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Goldfish",
+          "itemIcon": "🐟"
         }
       ],
       "reward": {
@@ -834,7 +884,9 @@
             "record-page-2",
             "record-page-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Note",
+          "itemIcon": "📝"
         }
       ],
       "reward": {
@@ -863,7 +915,9 @@
             "guard-clue-2",
             "guard-clue-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Note",
+          "itemIcon": "📝"
         }
       ],
       "reward": {
@@ -892,7 +946,9 @@
             "stolen-crate-2",
             "stolen-crate-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Supply Crate",
+          "itemIcon": "📦"
         }
       ],
       "reward": {
@@ -919,7 +975,9 @@
           "pickupIds": [
             "unstable-augment"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Small Sack",
+          "itemIcon": "🌾"
         }
       ],
       "reward": {
@@ -948,7 +1006,9 @@
             "guild-crate-2",
             "guild-crate-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Supply Crate",
+          "itemIcon": "📦"
         }
       ],
       "reward": {
@@ -977,7 +1037,9 @@
             "counterfeit-card-2",
             "counterfeit-card-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Blue Tome",
+          "itemIcon": "📘"
         }
       ],
       "reward": {
@@ -1006,7 +1068,9 @@
             "warning-stamp-2",
             "warning-stamp-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Pendant",
+          "itemIcon": "📿"
         }
       ],
       "reward": {
@@ -1035,7 +1099,9 @@
             "deserter-clue-2",
             "deserter-clue-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Note",
+          "itemIcon": "📝"
         }
       ],
       "reward": {
@@ -1064,7 +1130,9 @@
             "guest-item-2",
             "guest-item-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Pendant",
+          "itemIcon": "📿"
         }
       ],
       "reward": {
@@ -1092,7 +1160,9 @@
             "tampered-map-1",
             "tampered-map-2"
           ],
-          "required": 2
+          "required": 2,
+          "itemName": "Rolled Map",
+          "itemIcon": "🗺️"
         }
       ],
       "reward": {
@@ -1121,7 +1191,9 @@
             "forbidden-text-2",
             "forbidden-text-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Black Tome",
+          "itemIcon": "📓"
         }
       ],
       "reward": {
@@ -1149,7 +1221,9 @@
             "stolen-note-1",
             "stolen-note-2"
           ],
-          "required": 2
+          "required": 2,
+          "itemName": "Green Tome",
+          "itemIcon": "📗"
         }
       ],
       "reward": {
@@ -1177,7 +1251,9 @@
             "intruder-cloth",
             "intruder-tool"
           ],
-          "required": 2
+          "required": 2,
+          "itemName": "Pendant",
+          "itemIcon": "📿"
         }
       ],
       "reward": {
@@ -1206,7 +1282,9 @@
             "buyer-list",
             "buyer-token"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Chest",
+          "itemIcon": "🧰"
         }
       ],
       "reward": {
@@ -1235,7 +1313,9 @@
             "rigging-device-2",
             "rigging-device-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Chest",
+          "itemIcon": "🧰"
         }
       ],
       "reward": {
@@ -1262,7 +1342,9 @@
           "pickupIds": [
             "fake-trophy"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Gold Chest",
+          "itemIcon": "💰"
         },
         {
           "key": "deliver-fake",
@@ -1297,7 +1379,9 @@
             "marked-deck-2",
             "marked-deck-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Blue Tome",
+          "itemIcon": "📘"
         }
       ],
       "reward": {
@@ -1324,7 +1408,9 @@
           "pickupIds": [
             "family-heirloom"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Pendant",
+          "itemIcon": "📿"
         },
         {
           "key": "deliver-heirloom",
@@ -1365,7 +1451,9 @@
             "echo-notice-2",
             "echo-notice-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Book",
+          "itemIcon": "📕"
         }
       ],
       "reward": {
@@ -1392,7 +1480,9 @@
           "pickupIds": [
             "ancient-codex"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Black Tome",
+          "itemIcon": "📓"
         },
         {
           "key": "deliver-codex",
@@ -1428,7 +1518,9 @@
             "echo-record-2",
             "echo-record-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Black Tome",
+          "itemIcon": "📓"
         }
       ],
       "reward": {
@@ -1462,7 +1554,9 @@
             "informant-report-2",
             "informant-report-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Book",
+          "itemIcon": "📕"
         }
       ],
       "reward": {
@@ -1490,7 +1584,9 @@
             "smuggler-cache-1",
             "smuggler-cache-2"
           ],
-          "required": 2
+          "required": 2,
+          "itemName": "Supply Crate",
+          "itemIcon": "📦"
         }
       ],
       "reward": {
@@ -1517,7 +1613,9 @@
           "pickupIds": [
             "spy-report"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Book",
+          "itemIcon": "📕"
         },
         {
           "key": "deliver-report",
@@ -1553,7 +1651,9 @@
             "agent-map",
             "agent-list"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Note",
+          "itemIcon": "📝"
         }
       ],
       "reward": {
@@ -1580,7 +1680,9 @@
           "pickupIds": [
             "card-layout-plans"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Blue Tome",
+          "itemIcon": "📘"
         },
         {
           "key": "deliver-plans",
@@ -1621,7 +1723,9 @@
             "corrupted-augment-2",
             "corrupted-augment-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Gift",
+          "itemIcon": "🎁"
         }
       ],
       "reward": {
@@ -1648,7 +1752,9 @@
           "pickupIds": [
             "echo-territory-map"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Rolled Map",
+          "itemIcon": "🗺️"
         },
         {
           "key": "deliver-map",
@@ -1682,7 +1788,9 @@
           "pickupIds": [
             "cipher-key-fragment"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Blue Tome",
+          "itemIcon": "📘"
         },
         {
           "key": "deliver-cipher",
@@ -1723,7 +1831,9 @@
             "research-specimen-2",
             "research-specimen-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Yellow Crystal",
+          "itemIcon": "💎"
         }
       ],
       "reward": {
@@ -1752,7 +1862,9 @@
             "glowing-float-2",
             "glowing-float-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Fishing Hook",
+          "itemIcon": "🪝"
         }
       ],
       "reward": {
@@ -1786,7 +1898,9 @@
             "shadow-note",
             "shadow-token"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Coins",
+          "itemIcon": "🪙"
         }
       ],
       "reward": {
@@ -1815,7 +1929,9 @@
             "tainted-trophy-2",
             "tainted-trophy-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Gold Chest",
+          "itemIcon": "💰"
         }
       ],
       "reward": {
@@ -1842,7 +1958,9 @@
           "pickupIds": [
             "echo-suspect-list"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Book",
+          "itemIcon": "📕"
         },
         {
           "key": "deliver-list",
@@ -1878,7 +1996,9 @@
             "fake-badge-2",
             "fake-badge-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Pendant",
+          "itemIcon": "📿"
         }
       ],
       "reward": {
@@ -1905,7 +2025,9 @@
           "pickupIds": [
             "passage-key"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Key",
+          "itemIcon": "🗝️"
         },
         {
           "key": "deliver-key",
@@ -1946,7 +2068,9 @@
             "supplier-stamp",
             "supplier-note"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Book",
+          "itemIcon": "📕"
         }
       ],
       "reward": {
@@ -1973,7 +2097,9 @@
           "pickupIds": [
             "confession-letter"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Note",
+          "itemIcon": "📝"
         },
         {
           "key": "deliver-letter",
@@ -2009,7 +2135,9 @@
             "echo-id-token-2",
             "echo-id-token-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Pendant",
+          "itemIcon": "📿"
         }
       ],
       "reward": {
@@ -2036,7 +2164,9 @@
           "pickupIds": [
             "traitor-confession"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Note",
+          "itemIcon": "📝"
         },
         {
           "key": "deliver-confession",
@@ -2072,7 +2202,9 @@
             "heartstone-fragment-2",
             "heartstone-fragment-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Gold Chest",
+          "itemIcon": "💰"
         }
       ],
       "reward": {
@@ -2106,7 +2238,9 @@
             "safe-route-map-2",
             "safe-route-map-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Rolled Map",
+          "itemIcon": "🗺️"
         }
       ],
       "reward": {
@@ -2135,7 +2269,9 @@
             "guild-doc-2",
             "guild-doc-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Black Tome",
+          "itemIcon": "📓"
         }
       ],
       "reward": {
@@ -2164,7 +2300,9 @@
             "purification-crystal-2",
             "purification-crystal-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Blue Crystal",
+          "itemIcon": "💎"
         }
       ],
       "reward": {
@@ -2193,7 +2331,9 @@
             "echo-card-set-2",
             "echo-card-set-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Blue Tome",
+          "itemIcon": "📘"
         }
       ],
       "reward": {
@@ -2226,7 +2366,9 @@
             "cipher-fragment-a",
             "cipher-fragment-b"
           ],
-          "required": 2
+          "required": 2,
+          "itemName": "Blue Tome",
+          "itemIcon": "📘"
         }
       ],
       "reward": {
@@ -2255,7 +2397,9 @@
             "shelter-package-2",
             "shelter-package-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Supply Crate",
+          "itemIcon": "📦"
         }
       ],
       "reward": {
@@ -2284,7 +2428,9 @@
             "fracture-residue-2",
             "fracture-residue-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Potion",
+          "itemIcon": "🧪"
         }
       ],
       "reward": {
@@ -2316,7 +2462,9 @@
           "pickupIds": [
             "pond-hearthstone-disc"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Round Shield",
+          "itemIcon": "🛡️"
         },
         {
           "key": "deliver-disc",
@@ -2356,7 +2504,9 @@
             "echo-contraband-2",
             "echo-contraband-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Supply Crate",
+          "itemIcon": "📦"
         }
       ],
       "reward": {
@@ -2385,7 +2535,9 @@
             "surveillance-device-2",
             "surveillance-device-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Chest",
+          "itemIcon": "🧰"
         }
       ],
       "reward": {
@@ -2412,7 +2564,9 @@
           "pickupIds": [
             "champions-shield"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Shield",
+          "itemIcon": "🛡️"
         },
         {
           "key": "deliver-shield",
@@ -2452,7 +2606,9 @@
             "intel-note-2",
             "intel-note-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Note",
+          "itemIcon": "📝"
         }
       ],
       "reward": {
@@ -2481,7 +2637,9 @@
             "passage-item-2",
             "passage-item-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Chest",
+          "itemIcon": "🧰"
         }
       ],
       "reward": {
@@ -2514,7 +2672,9 @@
             "absolution-letter-naia",
             "absolution-letter-thorin"
           ],
-          "required": 2
+          "required": 2,
+          "itemName": "Note",
+          "itemIcon": "📝"
         },
         {
           "key": "deliver-naia",
@@ -2555,7 +2715,9 @@
           "pickupIds": [
             "supply-contracts"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Note",
+          "itemIcon": "📝"
         },
         {
           "key": "deliver-contracts",
@@ -2590,7 +2752,9 @@
             "supply-pkg-thorin",
             "supply-pkg-varn"
           ],
-          "required": 2
+          "required": 2,
+          "itemName": "Supply Crate",
+          "itemIcon": "📦"
         },
         {
           "key": "deliver-thorin",
@@ -2633,7 +2797,9 @@
             "vault-casing-2",
             "vault-casing-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Barrel",
+          "itemIcon": "🛢️"
         }
       ],
       "reward": {
@@ -2662,7 +2828,9 @@
             "location-note-2",
             "location-note-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Note",
+          "itemIcon": "📝"
         }
       ],
       "reward": {
@@ -2697,7 +2865,9 @@
             "rally-msg-dealer",
             "rally-msg-fisherman"
           ],
-          "required": 4
+          "required": 4,
+          "itemName": "Book",
+          "itemIcon": "📕"
         },
         {
           "key": "deliver-ferryn",
@@ -2750,7 +2920,9 @@
             "defense-note-2",
             "defense-note-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Book",
+          "itemIcon": "📕"
         }
       ],
       "reward": {
@@ -2779,7 +2951,9 @@
             "training-manual-2",
             "training-manual-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Book",
+          "itemIcon": "📕"
         }
       ],
       "reward": {
@@ -2808,7 +2982,9 @@
             "charm-elder",
             "charm-thorin"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Pendant",
+          "itemIcon": "📿"
         },
         {
           "key": "deliver-naia",
@@ -2855,7 +3031,9 @@
             "evacuation-guide-2",
             "evacuation-guide-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Book",
+          "itemIcon": "📕"
         }
       ],
       "reward": {
@@ -2884,7 +3062,9 @@
             "resource-bundle-2",
             "resource-bundle-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Supply Crate",
+          "itemIcon": "📦"
         }
       ],
       "reward": {
@@ -2913,7 +3093,9 @@
             "harbour-pkg-2",
             "harbour-pkg-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Supply Crate",
+          "itemIcon": "📦"
         }
       ],
       "reward": {
@@ -2940,7 +3122,9 @@
           "pickupIds": [
             "fracture-card"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Gold Chest",
+          "itemIcon": "💰"
         },
         {
           "key": "deliver-card",
@@ -2978,7 +3162,9 @@
           "pickupIds": [
             "cipher-translation"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Blue Tome",
+          "itemIcon": "📘"
         },
         {
           "key": "deliver-translation",
@@ -3013,7 +3199,9 @@
             "analysis-naia",
             "analysis-elder"
           ],
-          "required": 2
+          "required": 2,
+          "itemName": "Green Tome",
+          "itemIcon": "📗"
         },
         {
           "key": "deliver-naia",
@@ -3052,7 +3240,9 @@
           "pickupIds": [
             "pond-sealed-case"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Gold Chest",
+          "itemIcon": "💰"
         },
         {
           "key": "deliver-case",
@@ -3090,7 +3280,9 @@
           "pickupIds": [
             "final-intel-report"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Book",
+          "itemIcon": "📕"
         },
         {
           "key": "deliver-intel",
@@ -3126,7 +3318,9 @@
             "market-cache-2",
             "market-cache-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Supply Crate",
+          "itemIcon": "📦"
         }
       ],
       "reward": {
@@ -3154,7 +3348,9 @@
             "zev-supply-cache",
             "zev-equipment-manifest"
           ],
-          "required": 2
+          "required": 2,
+          "itemName": "Supply Crate",
+          "itemIcon": "📦"
         },
         {
           "key": "deliver-ferryn",
@@ -3193,7 +3389,9 @@
           "pickupIds": [
             "champions-pledge"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Gold Chest",
+          "itemIcon": "💰"
         },
         {
           "key": "deliver-elder",
@@ -3237,7 +3435,9 @@
           "pickupIds": [
             "hearthstone-key"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Key",
+          "itemIcon": "🗝️"
         },
         {
           "key": "deliver-key",
@@ -3278,7 +3478,9 @@
             "reagent-mira",
             "reagent-bramble"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Herb Bundle",
+          "itemIcon": "🌿"
         },
         {
           "key": "deliver-naia",
@@ -3326,7 +3528,9 @@
             "convergence-shard-3",
             "convergence-shard-4"
           ],
-          "required": 4
+          "required": 4,
+          "itemName": "Yellow Crystal",
+          "itemIcon": "💎"
         }
       ],
       "reward": {
@@ -3376,7 +3580,9 @@
           "pickupIds": [
             "hearthstone-final"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Gold Chest",
+          "itemIcon": "💰"
         },
         {
           "key": "bless-elder",
@@ -3553,7 +3759,9 @@
             "midsummer-lantern-2",
             "midsummer-lantern-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Candlestick",
+          "itemIcon": "🕯️"
         }
       ],
       "reward": {

--- a/web/src/data/hub/royalpalace/config.json
+++ b/web/src/data/hub/royalpalace/config.json
@@ -4238,6 +4238,26 @@
   },
   "interactables": [
     {
+      "id": "royalpalace-chicken-feed",
+      "tx": 26,
+      "ty": 26,
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "tileId": "sack"
+        }
+      ],
+      "reactions": [
+        {
+          "type": "buyHubItem",
+          "itemId": "chicken-feed",
+          "price": 5,
+          "speakerName": "Feed Stall"
+        }
+      ]
+    },
+    {
       "id": "court-notice-board",
       "tx": 23,
       "ty": 9,

--- a/web/src/data/hub/royalpalace/questDefs.json
+++ b/web/src/data/hub/royalpalace/questDefs.json
@@ -18,7 +18,9 @@
             "regalia-gift",
             "regalia-key"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Pendant",
+          "itemIcon": "📿"
         }
       ],
       "reward": {
@@ -104,7 +106,9 @@
             "bloom-white",
             "bloom-blue"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Rose",
+          "itemIcon": "🌹"
         }
       ],
       "reward": {
@@ -133,7 +137,9 @@
             "orangery-pot-2",
             "orangery-pot-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Flower Pot",
+          "itemIcon": "🪴"
         }
       ],
       "reward": {
@@ -161,7 +167,9 @@
             "feast-steak",
             "feast-garlic"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Eggs",
+          "itemIcon": "🥚"
         }
       ],
       "reward": {
@@ -189,7 +197,9 @@
             "tack-bucket",
             "tack-harness"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Sack",
+          "itemIcon": "🌾"
         }
       ],
       "reward": {
@@ -217,7 +227,9 @@
             "candle-2",
             "candle-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Candlestick",
+          "itemIcon": "🕯️"
         }
       ],
       "reward": {
@@ -248,7 +260,9 @@
             "tally-2",
             "tally-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Rolled Map",
+          "itemIcon": "🗺️"
         }
       ],
       "reward": {
@@ -325,7 +339,9 @@
           "pickupIds": [
             "penrose-letter"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Letter",
+          "itemIcon": "✉️"
         }
       ],
       "reward": {
@@ -354,7 +370,9 @@
           "pickupIds": [
             "princess-doll"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Doll",
+          "itemIcon": "🪆"
         }
       ],
       "reward": {
@@ -382,7 +400,9 @@
             "kipper-cushion",
             "kipper-feather"
           ],
-          "required": 2
+          "required": 2,
+          "itemName": "Crown",
+          "itemIcon": "👑"
         }
       ],
       "reward": {
@@ -416,7 +436,9 @@
             "steward-key-2",
             "steward-key-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Key",
+          "itemIcon": "🗝️"
         }
       ],
       "reward": {
@@ -444,7 +466,9 @@
             "proclaim-2",
             "proclaim-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Rolled Map",
+          "itemIcon": "🗺️"
         }
       ],
       "reward": {
@@ -472,7 +496,9 @@
             "watch-shield",
             "watch-helm"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Sword",
+          "itemIcon": "⚔️"
         }
       ],
       "reward": {
@@ -500,7 +526,9 @@
             "queen-rose-2",
             "queen-rose-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Rose",
+          "itemIcon": "🌹"
         }
       ],
       "reward": {

--- a/web/src/data/hub/saltmereport/questDefs.json
+++ b/web/src/data/hub/saltmereport/questDefs.json
@@ -18,7 +18,9 @@
             "dock-fish-2",
             "dock-fish-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Apple Basket",
+          "itemIcon": "🍎"
         },
         {
           "key": "deliver",
@@ -52,7 +54,9 @@
             "port-crate-2",
             "port-crate-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Supply Crate",
+          "itemIcon": "📦"
         }
       ],
       "reward": {
@@ -78,7 +82,9 @@
           "pickupIds": [
             "navy-rum-barrel"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Barrel",
+          "itemIcon": "🛢️"
         },
         {
           "key": "deliver",
@@ -114,7 +120,9 @@
             "smoke-scrap-2",
             "smoke-scrap-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Apple Basket",
+          "itemIcon": "🍎"
         },
         {
           "key": "deliver",
@@ -148,7 +156,9 @@
             "manifest-page-1",
             "manifest-page-2"
           ],
-          "required": 2
+          "required": 2,
+          "itemName": "Papers",
+          "itemIcon": "📄"
         }
       ],
       "reward": {
@@ -178,7 +188,9 @@
           "pickupIds": [
             "smugglers-ledger-1"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Book",
+          "itemIcon": "📕"
         },
         {
           "key": "deliver",
@@ -212,7 +224,9 @@
             "torn-net-2",
             "torn-net-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Sack",
+          "itemIcon": "🌾"
         }
       ],
       "reward": {
@@ -240,7 +254,9 @@
             "timber-bundle-2",
             "timber-bundle-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Firewood",
+          "itemIcon": "🪵"
         }
       ],
       "reward": {
@@ -271,7 +287,9 @@
             "ship-supplies-1",
             "ship-supplies-2"
           ],
-          "required": 2
+          "required": 2,
+          "itemName": "Supply Crate",
+          "itemIcon": "📦"
         },
         {
           "key": "deliver",
@@ -306,7 +324,9 @@
             "oil-flask-2",
             "oil-flask-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Barrel",
+          "itemIcon": "🛢️"
         }
       ],
       "reward": {
@@ -334,7 +354,9 @@
             "signal-flare-1",
             "signal-flare-2"
           ],
-          "required": 2
+          "required": 2,
+          "itemName": "Lantern",
+          "itemIcon": "🏮"
         }
       ],
       "reward": {
@@ -363,7 +385,9 @@
             "stray-crate-3",
             "stray-crate-4"
           ],
-          "required": 4
+          "required": 4,
+          "itemName": "Supply Crate",
+          "itemIcon": "📦"
         }
       ],
       "reward": {
@@ -391,7 +415,9 @@
             "sea-trinket-2",
             "sea-trinket-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Coins",
+          "itemIcon": "🪙"
         }
       ],
       "reward": {
@@ -419,7 +445,9 @@
             "rope-coil-2",
             "rope-coil-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Bucket",
+          "itemIcon": "🪣"
         }
       ],
       "reward": {
@@ -448,7 +476,9 @@
           "pickupIds": [
             "duplicate-manifest-1"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Rolled Map",
+          "itemIcon": "🗺️"
         },
         {
           "key": "deliver",

--- a/web/src/data/hub/thornwoodcamp/config.json
+++ b/web/src/data/hub/thornwoodcamp/config.json
@@ -474,6 +474,7 @@
     {
       "id": "ranger-sable",
       "name": "Ranger Sable",
+      "dialogueTree": "ranger-sable-trade",
       "sprite": "hub-npc-guard",
       "tx": 15,
       "ty": 25,

--- a/web/src/data/hub/thornwoodcamp/questDefs.json
+++ b/web/src/data/hub/thornwoodcamp/questDefs.json
@@ -1,4 +1,39 @@
 {
+  "dialogues": [
+      {
+        "id": "ranger-sable-trade",
+        "npcId": "ranger-sable",
+        "start": "greet",
+        "nodes": {
+          "greet": {
+            "text": "Look at the state of these boots \u2014 more hole than leather. The capital's tailor sells sturdy ones, if you ever pass through. I'd pay well over the asking price to save myself the trip.",
+            "choices": [
+              {
+                "label": "I have a pair of sturdy boots right here.",
+                "next": "greet",
+                "effects": [
+                  {
+                    "type": "tradeHubItem",
+                    "wantItemId": "sturdy-boots",
+                    "giveCrystals": 90,
+                    "missingText": "Unless you're hiding them under that cloak, you don't. Pell's Tailoring, in the capital \u2014 sturdy boots, ask for the ones with the double-stitched soles.",
+                    "successText": "Ha! Perfect fit. You've saved me a week's walk and my last good pair of socks. Here \u2014 90 crystals, and cheap at the price."
+                  }
+                ]
+              },
+              {
+                "label": "I'll keep an eye out.",
+                "effects": [
+                  {
+                    "type": "end"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ],
   "quests": [
     {
       "id": "thornwood-embers-low",

--- a/web/src/data/hub/thornwoodcamp/questDefs.json
+++ b/web/src/data/hub/thornwoodcamp/questDefs.json
@@ -18,7 +18,9 @@
             "thornwood-firewood-2",
             "thornwood-firewood-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Firewood",
+          "itemIcon": "🪵"
         }
       ],
       "reward": {
@@ -43,7 +45,9 @@
             "shiny-stone-2",
             "shiny-stone-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Stone",
+          "itemIcon": "🪨"
         }
       ],
       "reward": {
@@ -75,7 +79,9 @@
             "treeline-lost-2",
             "treeline-lost-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Book",
+          "itemIcon": "📕"
         }
       ],
       "reward": {
@@ -103,7 +109,9 @@
             "mushroom-2",
             "mushroom-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Mushroom Basket",
+          "itemIcon": "🍄"
         }
       ],
       "reward": {
@@ -131,7 +139,9 @@
             "ward-2",
             "ward-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Herb Bundle",
+          "itemIcon": "🌿"
         }
       ],
       "reward": {
@@ -158,7 +168,9 @@
           "pickupIds": [
             "warding-draught-1"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Bottle",
+          "itemIcon": "🍾"
         },
         {
           "key": "deliver",
@@ -193,7 +205,9 @@
             "snare-2",
             "snare-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Sack",
+          "itemIcon": "🌾"
         }
       ],
       "reward": {
@@ -221,7 +235,9 @@
             "supply-2",
             "supply-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Berries",
+          "itemIcon": "🫐"
         }
       ],
       "reward": {
@@ -248,7 +264,9 @@
           "pickupIds": [
             "ravenwatch-parcel-1"
           ],
-          "required": 1
+          "required": 1,
+          "itemName": "Supply Crate",
+          "itemIcon": "📦"
         },
         {
           "key": "deliver",
@@ -288,7 +306,9 @@
             "bramble-find-2",
             "bramble-find-3"
           ],
-          "required": 3
+          "required": 3,
+          "itemName": "Stone",
+          "itemIcon": "🪨"
         }
       ],
       "reward": {

--- a/web/src/data/hubItems.json
+++ b/web/src/data/hubItems.json
@@ -1,0 +1,94 @@
+[
+  {
+    "id": "chicken-feed",
+    "name": "Chicken Feed",
+    "icon": "🌾",
+    "desc": "A handful of mixed grain. Chickens go wild for it.",
+    "category": "material"
+  },
+  {
+    "id": "egg",
+    "name": "Egg",
+    "icon": "🥚",
+    "desc": "A fresh egg, still warm. Laid by a well-fed hen.",
+    "category": "material"
+  },
+  {
+    "id": "feather",
+    "name": "Feather",
+    "icon": "🪶",
+    "desc": "A clean, sturdy feather. Someone with a snapped quill might want this.",
+    "category": "material"
+  },
+  {
+    "id": "fish-bait",
+    "name": "Fish Bait",
+    "icon": "🪱",
+    "desc": "A pot of wriggling bait. One pot covers one fishing trip.",
+    "category": "material"
+  },
+  {
+    "id": "fishing-rod",
+    "name": "Fishing Rod",
+    "icon": "🎣",
+    "desc": "A well-balanced rod. With bait in hand, you can fish anywhere in the realm.",
+    "category": "tool",
+    "unique": true
+  },
+  {
+    "id": "fish-tiddler",
+    "name": "Tiddler",
+    "icon": "🐟",
+    "desc": "A tiny fish, barely a mouthful. A cat would still be delighted.",
+    "category": "material"
+  },
+  {
+    "id": "fish-small",
+    "name": "Small Fish",
+    "icon": "🐠",
+    "desc": "A modest catch. Good eating, or good trading.",
+    "category": "material"
+  },
+  {
+    "id": "fish-medium",
+    "name": "Medium Fish",
+    "icon": "🐡",
+    "desc": "A respectable fish. The fishmonger pays fairly for these.",
+    "category": "material"
+  },
+  {
+    "id": "fish-large",
+    "name": "Large Fish",
+    "icon": "🦈",
+    "desc": "A serious catch. Heavy enough to make your arms ache.",
+    "category": "material"
+  },
+  {
+    "id": "fish-trophy",
+    "name": "Trophy Fish",
+    "icon": "🏆",
+    "desc": "A magnificent specimen. Fishmongers' eyes light up at the sight.",
+    "category": "material"
+  },
+  {
+    "id": "fish-legendary",
+    "name": "Legendary Fish",
+    "icon": "✨",
+    "desc": "A fish out of legend. Sailors will sing about this one.",
+    "category": "material"
+  },
+  {
+    "id": "fancy-hat",
+    "name": "Fancy Hat",
+    "icon": "🎩",
+    "desc": "Capital fashion at its finest. Somebody out there would love this.",
+    "category": "material"
+  },
+  {
+    "id": "sturdy-boots",
+    "name": "Sturdy Boots",
+    "icon": "🥾",
+    "desc": "Well-made walking boots. A blessing for anyone who works outdoors.",
+    "category": "material"
+  }
+]

--- a/web/src/game/hub/questItems.ts
+++ b/web/src/game/hub/questItems.ts
@@ -1,0 +1,23 @@
+// ─── Held quest items ─────────────────────────────────────────────────────────
+//
+// Fetch-quest collect steps with `itemName`/`itemIcon` place a physical item
+// in the player's hub-item inventory (itemStore.ts) as each pickup is
+// collected, and clear it again when the quest is turned in or abandoned.
+// Items are keyed per quest step so different quests' items never collide.
+
+/** Hub-item id for a held quest item: `quest:<questId>:<stepKey>`. */
+export function questItemId(questId: string, stepKey: string): string {
+  return `quest:${questId}:${stepKey}`
+}
+
+/** Whether a hub-item id belongs to a held quest item. */
+export function isQuestItemId(id: string): boolean {
+  return id.startsWith('quest:')
+}
+
+/** The quest id embedded in a held-quest-item id, or null. */
+export function questIdFromItemId(id: string): string | null {
+  if (!isQuestItemId(id)) return null
+  const parts = id.split(':')
+  return parts.length >= 3 ? parts[1] : null
+}

--- a/web/src/game/hubItems.test.ts
+++ b/web/src/game/hubItems.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import {
+  addHubItem, removeHubItem, getHubItemCount, hasHubItem, getHubItems,
+  getHubItemCatalogEntry,
+} from './itemStore'
+
+function installLocalStorageStub(): void {
+  const store = new Map<string, string>()
+  vi.stubGlobal('localStorage', {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => { store.set(k, v) },
+    removeItem: (k: string) => { store.delete(k) },
+    clear: () => { store.clear() },
+  })
+}
+
+describe('hub items', () => {
+  beforeEach(() => {
+    installLocalStorageStub()
+  })
+
+  it('stacks catalog items and resolves display fields from the catalog', () => {
+    addHubItem('chicken-feed', 2)
+    addHubItem('chicken-feed')
+    expect(getHubItemCount('chicken-feed')).toBe(3)
+    const entry = getHubItems().find(e => e.id === 'chicken-feed')!
+    expect(entry.name).toBe('Chicken Feed')
+    expect(entry.icon).toBe('🌾')
+    expect(entry.category).toBe('material')
+  })
+
+  it('never stacks unique catalog items (fishing rod)', () => {
+    expect(getHubItemCatalogEntry('fishing-rod')?.unique).toBe(true)
+    addHubItem('fishing-rod')
+    addHubItem('fishing-rod', 5)
+    expect(getHubItemCount('fishing-rod')).toBe(1)
+    expect(hasHubItem('fishing-rod')).toBe(true)
+  })
+
+  it('stores inline display fields for non-catalog quest items', () => {
+    addHubItem('quest:millhaven-mill-grain:grain', 1, {
+      name: 'Grain Sack', icon: '🌾', category: 'quest',
+    })
+    const entry = getHubItems().find(e => e.id === 'quest:millhaven-mill-grain:grain')!
+    expect(entry.name).toBe('Grain Sack')
+    expect(entry.category).toBe('quest')
+  })
+
+  it('removeHubItem fails closed when the balance is insufficient', () => {
+    addHubItem('egg', 2)
+    expect(removeHubItem('egg', 3)).toBe(false)
+    expect(getHubItemCount('egg')).toBe(2)
+    expect(removeHubItem('egg', 2)).toBe(true)
+    expect(getHubItemCount('egg')).toBe(0)
+    expect(hasHubItem('egg')).toBe(false)
+    expect(removeHubItem('egg')).toBe(false)
+  })
+
+  it('removes the store row entirely when count reaches zero', () => {
+    addHubItem('feather')
+    expect(removeHubItem('feather')).toBe(true)
+    expect(getHubItems().some(e => e.id === 'feather')).toBe(false)
+  })
+
+  it('ignores non-positive counts', () => {
+    addHubItem('egg', 0)
+    addHubItem('egg', -3)
+    expect(getHubItemCount('egg')).toBe(0)
+    expect(removeHubItem('egg', 0)).toBe(true)
+  })
+})

--- a/web/src/game/itemStore.ts
+++ b/web/src/game/itemStore.ts
@@ -22,6 +22,12 @@
 // │ item               │ Collectibles from daily logins & events. Allows      │
 // │                    │ duplicates. API: addCollectible / removeCollectible / │
 // │                    │ getCollectibles                                       │
+// ├────────────────────┼──────────────────────────────────────────────────────┤
+// │ hub-item           │ Hub-world economy items: held quest items, materials  │
+// │                    │ (feed, eggs, fish, trade goods), unique tools (rod).  │
+// │                    │ Catalog: data/hubItems.json. API: addHubItem /        │
+// │                    │ removeHubItem / getHubItemCount / hasHubItem /        │
+// │                    │ getHubItems                                           │
 // └────────────────────┴──────────────────────────────────────────────────────┘
 //
 // ⚠️  WARNING — the battle-consumable drain
@@ -48,14 +54,18 @@
 
 import { logError } from '../logger'
 import { validateIntegrity, updateChecksum } from './integrity'
+import HUB_ITEMS_DATA from '../data/hubItems.json'
 
-export type ItemType = 'consumable' | 'relic' | 'item'
+export type ItemType = 'consumable' | 'relic' | 'item' | 'hub-item'
+
+/** Buckets the Hub Inventory UI groups hub-items into. */
+export type HubItemCategory = 'quest' | 'pet-accessory' | 'material' | 'tool'
 
 export interface ItemEntry {
-  /** Consumable id, relic name, or useless-item id */
+  /** Consumable id, relic name, useless-item id, or hub-item id */
   id: string
   type: ItemType
-  /** Stack size — only meaningful for consumables; always 1 for relics/items */
+  /** Stack size — only meaningful for consumables/hub-items; always 1 for relics/items */
   count: number
   /** ISO date string set when the item was first acquired (items only) */
   acquiredDate?: string
@@ -65,6 +75,8 @@ export interface ItemEntry {
   icon?: string
   desc?: string
   lore?: string
+  /** Hub-items only: inventory grouping (see HubItemCategory). */
+  category?: HubItemCategory
 }
 
 export interface ItemDisplayFields {
@@ -72,6 +84,7 @@ export interface ItemDisplayFields {
   icon?: string
   desc?: string
   lore?: string
+  category?: HubItemCategory
 }
 
 const ITEM_STORE_KEY = 'jarv_item_store'
@@ -509,4 +522,97 @@ export function removeCollectible(id: string): void {
 /** Return raw item store entries for all collectibles. */
 export function getCollectibles(): ItemEntry[] {
   return getItemsOfType('item')
+}
+
+// ── HUB ITEMS (hub-world economy: quest items, materials, tools) ──────────────
+//
+// Hub items power the hub-world item economy: physical quest items held while
+// a fetch quest is in progress, materials bought from town shops or produced
+// by world interactions (chicken feed, eggs, feathers, caught fish, trade
+// goods), and unique tools (the fishing rod).
+//
+// They are stored under their own type tag ('hub-item'), so — like arcade
+// tickets and chronicle fragments — they can never be swallowed by
+// drainStashIntoRun (questline.ts), which only drains type: 'consumable'
+// entries whose ids appear in ALL_CONSUMABLES.
+//
+// Display data comes from the web/src/data/hubItems.json catalog. Entries not
+// in the catalog (per-quest items with ids like `quest:<questId>:<stepKey>`)
+// carry their display fields inline, same as arcade tickets do. Catalog items
+// flagged `unique: true` (e.g. the fishing rod) never stack — re-adding one
+// the player already owns is a no-op.
+
+interface HubItemCatalogEntry {
+  id: string
+  name: string
+  icon: string
+  desc: string
+  category: string
+  unique?: boolean
+}
+
+const HUB_ITEM_CATALOG = HUB_ITEMS_DATA as HubItemCatalogEntry[]
+
+export function getHubItemCatalogEntry(id: string): HubItemCatalogEntry | undefined {
+  return HUB_ITEM_CATALOG.find(e => e.id === id)
+}
+
+/**
+ * Add `count` hub items. Catalog items resolve their display fields from
+ * hubItems.json; non-catalog items (quest items) should pass `display`
+ * inline. Unique catalog items never stack — adding an owned unique item is
+ * a no-op.
+ */
+export function addHubItem(id: string, count = 1, display?: ItemDisplayFields): void {
+  if (count <= 0) return
+  const catalog = getHubItemCatalogEntry(id)
+  const store = loadItemStore()
+  const entry = store.find(e => e.type === 'hub-item' && e.id === id)
+  if (entry) {
+    if (catalog?.unique) return
+    entry.count += count
+  } else {
+    const fields: ItemDisplayFields = catalog
+      ? { name: catalog.name, icon: catalog.icon, desc: catalog.desc, category: catalog.category as HubItemCategory }
+      : display ?? {}
+    store.push({
+      id,
+      type: 'hub-item',
+      count: catalog?.unique ? 1 : count,
+      acquiredDate: new Date().toISOString().slice(0, 10),
+      ...fields,
+    })
+  }
+  saveItemStore(store)
+}
+
+/**
+ * Remove `count` hub items. Returns `true` on success, `false` if the player
+ * holds fewer than `count` (no change is made in that case).
+ */
+export function removeHubItem(id: string, count = 1): boolean {
+  if (count <= 0) return true
+  const store = loadItemStore()
+  const entry = store.find(e => e.type === 'hub-item' && e.id === id)
+  if (!entry || entry.count < count) return false
+  entry.count -= count
+  if (entry.count <= 0) store.splice(store.indexOf(entry), 1)
+  saveItemStore(store)
+  return true
+}
+
+/** How many of this hub item the player holds. */
+export function getHubItemCount(id: string): number {
+  const entry = loadItemStore().find(e => e.type === 'hub-item' && e.id === id)
+  return entry ? entry.count : 0
+}
+
+/** Whether the player holds at least one of this hub item. */
+export function hasHubItem(id: string): boolean {
+  return getHubItemCount(id) > 0
+}
+
+/** Return raw item store entries for all hub items. */
+export function getHubItems(): ItemEntry[] {
+  return getItemsOfType('hub-item')
 }


### PR DESCRIPTION
## Summary

Adds a visible hub-world inventory and the first full item-economy loops on top of it.

### Inventory infrastructure
- **New `hub-item` category in `itemStore.ts`** backed by a `web/src/data/hubItems.json` catalog — stackable materials (chicken feed, eggs, feathers, caught fish, trade goods) and unique tools (fishing rod). Excluded from the battle-consumable drain by its own type tag, mirroring arcade tickets. Unit-tested (`hubItems.test.ts`).
- **🎒 Hub Inventory modal** (new toolbar button in `HubWorld`) showing held quest items with live `held/required` counts per active quest, materials & tools, and owned pet accessories. Storybook stories included.
- **Held quest items**: collect steps gain optional `itemName`/`itemIcon`; picking up a quest item now places a physical `quest:<questId>:<stepKey>` item in the inventory, cleared on turn-in or abandonment. **All 297 existing collect steps across the 13 towns were retrofitted**, with names/icons resolved from each pickup's `tileId`.

### Two reusable economy primitives
- **`buyHubItem` interactable reaction** — always-available purchase of a catalog item for crystals or tickets; unique items re-offer as "already owned".
- **`tradeHubItem` dialogue effect** — repeatable barter on a dialogue-tree choice: takes N of a hub-item, grants crystals / another hub-item / a collectible; loops back via `next` for sell menus.

### Content built on them
- **Chicken feeding loop (6 towns)**: chicken feed sold at the Millhaven bakery, Ravenwatch Market Hall, and pen-side feed sacks in Appleford, Harrowfield, Ironhold Keep and the Royal Palace. Tapping an ambient chicken while holding feed offers to feed it — 40% egg, 25% feather. New `onAmbientAnimalTap` hook lets React intercept taps on procedural (id-less) animals; ambient cats will also eat a caught fish (flavour-only).
- **Item-gated hub fishing**: the hub fishing spots (Millhaven, Capital City, Ravenwatch) now route to a new `hub-fishing` screen that requires owning a Fishing Rod and consumes one Fish Bait per trip (both sold at new Millhaven harbour stalls). In this mode the minigame awards the caught fish as a tier-keyed inventory item and **never pays tickets**; the arcade fishing path is unchanged. Fishwife Marta buys each fish tier for crystals via a new dialogue tree, or fish can be fed to cats.
- **First cross-town trade chain**: Pell's Tailoring in the capital sells a Fancy Hat and Sturdy Boots; Ranger Sable in Thornwood Camp trades the boots for 90💎. (The hat's trade partner is documented as a future chain.)

### Docs
- New **§16 — Hub Items, Inventory & Item Economy** in `docs/hubworld.md`: schemas, authoring checklist for new shop goods/trade chains, and the design spec for the future chains (feather → poetry book, bones → dog → lost item, stocking the remaining empty shops).

## Testing
- `npm run test`: **924 tests passing across 198 files** (including loader tests that parse every town's config/questDefs, new hub-item unit tests, and Storybook browser tests for the new modal).
- `npm run build` (tsc + vite): clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HFBFbZdCft98Dbr1WdRHoT

---
_Generated by [Claude Code](https://claude.ai/code/session_01HFBFbZdCft98Dbr1WdRHoT)_