### PR TITLE
Hub item economy round 2: feather/poetry + bones/dog chains, every empty shop stocked

### DIFF
--- a/docs/hubworld.md
+++ b/docs/hubworld.md
@@ -1341,7 +1341,10 @@ Always-available (no daily rotation). The confirm dialogue shows the catalog
 overrides it. Unique items re-offer as "already owned". Existing sellers:
 chicken feed (Millhaven bakery, Ravenwatch Market Hall, pen-side feed sacks in
 Appleford / Harrowfield / Ironhold Keep / Royal Palace), rod + bait (Millhaven
-harbour stalls), Fancy Hat + Sturdy Boots (capital tailor).
+harbour stalls), Fancy Hat + Sturdy Boots (capital tailor), honey cake /
+lavender tonic / silk ribbon (capital bakery / apothecary / Grand Market
+Hall), smoked herring + bones (Saltmere fish market / smokehouse), bog salve
+(Hollowmere apothecary), spice pouch (Ravenwatch Merchant's Guild Hall).
 
 ### Trading hub items — `tradeHubItem` (§7b dialogue effects)
 
@@ -1351,6 +1354,17 @@ at the same node to build a repeatable sell menu (see Millhaven's
 a one-line barter (Thornwood Camp's `ranger-sable-trade` — sturdy boots for
 90💎). Trades are repeatable by design; use a `flag` effect + `hideIfFlag` on
 the choice if a specific trade should be once-only.
+
+The live trade network (buyer NPC → wants → gives): Weeping Widow (Gravemoor)
+← poetry book, 50💎 · Widow Tamsin (Millhaven) ← lost locket, 60💎 ·
+Harbourmaster Vane (Saltmere) ← fancy hat, 75💎 · Baker Otto (capital) ← 3
+eggs, 20💎 · Little Wren (Appleford) ← honey cake, 25💎 · Old Hollis
+(Gravemoor) ← lavender tonic, 40💎 · Squire Tomas (Ironhold) ← silk ribbon,
+30💎 · Forager Mott (Thornwood) ← smoked herring, 25💎 · Smith Garrick
+(Millhaven) ← bog salve, 35💎 · Innkeeper Cobb (Millhaven) ← spice pouch,
+38💎 · Ranger Sable (Thornwood) ← sturdy boots, 90💎 · Archivist Quill
+(capital) ← feather → poetry book · Fishwife Marta (Millhaven) & Fishwife
+Pearl (Saltmere) ← any caught fish → tier-priced crystals.
 
 ### Feeding ambient animals
 
@@ -1363,6 +1377,8 @@ the default flavour bubble:
 - **Cat** + player holds any `fish-*` → offers the smallest held fish
   (flavour-only reward, by design — ambient animals have no stable id to
   attach friendship to).
+- **Dog** + player holds `bones` → offers to feed (consumes 1): the dog runs
+  off and, 60% of the time, returns with a `lost-locket`.
 
 Placed (named) animals keep their normal §8 quest/dialogue routing.
 
@@ -1390,17 +1406,13 @@ pays tickets.
 4. Run `npm run test` (loader tests parse all configs) and `npm run build`;
    verify buy → carry → trade end-to-end in-game and across a reload.
 
-### Future chains (designed, not yet built)
+### Extending the network
 
-- **Feather → poetry book**: an author NPC whose quill keeps snapping takes a
-  `feather` (`tradeHubItem`) and returns a `poetry-book` hub-item; the book's
-  own use is a further chain.
-- **Bones → dog → lost item**: sell `bones` in a butcher/general store;
-  feeding an ambient dog (same `onAmbientAnimalTap` pattern) sends it
-  fetching and yields a `lost-item` after a cooldown — needs a small
-  "fetching" animal state.
-- **Stock every empty shop**: still-empty shop buildings (capital
-  `market-hall-crownhaven` / `apothecary`, Saltmere Port `fish-market`,
-  Hollowmere `apothecary`, …) are each one `buyHubItem` interactable away
-  from selling a thematic good; pair each new good with a trade partner in
-  another town.
+Every previously-empty shop now sells a good and every good has a buyer (see
+the network list above), but the graph is designed to keep growing: any new
+`hubItems.json` entry only needs one `buyHubItem` seller and one
+`tradeHubItem` buyer (per the authoring checklist above). Natural next links:
+a downstream use for goods that currently dead-end at a crystal payout (e.g.
+the poetry book could also be gifted to a romance-track NPC), multi-item
+recipes (an NPC wanting an egg *and* a spice pouch), and pet-accessory
+rewards on high-value trades.

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -1207,6 +1207,44 @@ function hasOfferableQuest(giverId: string): boolean {
       })
       return true
     }
+    if (type === 'dog' && hasHubItem('bones')) {
+      setDialogueEvent({
+        speakerName: 'Dog',
+        text: 'The dog has locked eyes with your pack. It knows about the bones. It has always known.',
+        choices: [
+          {
+            label: 'Toss it a bone (1 🦴)',
+            primary: true,
+            onClick: () => {
+              if (!removeHubItem('bones', 1)) { setDialogueEvent(null); return }
+              const found = Math.random() < 0.6
+              refreshState()
+              setDialogueEvent({
+                speakerName: 'Dog',
+                text: 'The dog snatches the bone and bolts off across town, ears flying…',
+                onClose: () => {
+                  if (found) {
+                    addHubItem('lost-locket', 1)
+                    refreshState()
+                    setDialogueEvent({
+                      speakerName: 'Dog',
+                      text: 'It comes tearing back and drops something at your feet — a weathered locket, caked in mud! 📿',
+                    })
+                  } else {
+                    setDialogueEvent({
+                      speakerName: 'Dog',
+                      text: 'It trots back eventually, boneless and blissful, and flops over for a belly rub. Money well spent.',
+                    })
+                  }
+                },
+              })
+            },
+          },
+          { label: 'Not now', onClick: () => setDialogueEvent(null) },
+        ],
+      })
+      return true
+    }
     return false
   }, [refreshState])
 

--- a/web/src/data/hub/appleford/config.json
+++ b/web/src/data/hub/appleford/config.json
@@ -1340,6 +1340,7 @@
     {
       "id": "scrumping-wren",
       "name": "Little Wren",
+      "dialogueTree": "wren-cake-trade",
       "sprite": "hub-npc-child",
       "tx": 9,
       "ty": 23,

--- a/web/src/data/hub/appleford/questDefs.json
+++ b/web/src/data/hub/appleford/questDefs.json
@@ -1,4 +1,39 @@
 {
+  "dialogues": [
+    {
+      "id": "wren-cake-trade",
+      "npcId": "scrumping-wren",
+      "start": "greet",
+      "nodes": {
+        "greet": {
+          "text": "I've smelled the capital's honey cakes from three towns away, I swear it. I've been saving up my found-coins forever. FOREVER.",
+          "choices": [
+            {
+              "label": "Produce a honey cake",
+              "next": "greet",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "honey-cake",
+                  "giveCrystals": 25,
+                  "missingText": "No cake in that pack — Wren checks twice, thoroughly, just in case. Baker Otto in the capital makes them.",
+                  "successText": "Wren's eyes go perfectly round. She solemnly hands over an entire hoard of found-coins — 25 crystals — and vanishes with the cake."
+                }
+              ]
+            },
+            {
+              "label": "Keep saving, Wren.",
+              "effects": [
+                {
+                  "type": "end"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
   "quests": [
     {
       "id": "appleford-scattered-harvest",

--- a/web/src/data/hub/capitalcity/config.json
+++ b/web/src/data/hub/capitalcity/config.json
@@ -3774,6 +3774,45 @@
   },
   "interactables": [
     {
+      "id": "bakery-cake-counter",
+      "tx": 3,
+      "ty": 2,
+      "building": "bakery",
+      "reactions": [
+        {
+          "type": "buyHubItem",
+          "itemId": "honey-cake",
+          "price": 15
+        }
+      ]
+    },
+    {
+      "id": "apothecary-tonic-counter",
+      "tx": 3,
+      "ty": 2,
+      "building": "apothecary",
+      "reactions": [
+        {
+          "type": "buyHubItem",
+          "itemId": "lavender-tonic",
+          "price": 18
+        }
+      ]
+    },
+    {
+      "id": "market-hall-ribbon-counter",
+      "tx": 3,
+      "ty": 2,
+      "building": "market-hall-crownhaven",
+      "reactions": [
+        {
+          "type": "buyHubItem",
+          "itemId": "silk-ribbon",
+          "price": 12
+        }
+      ]
+    },
+    {
       "id": "tailor-hat-rack",
       "tx": 11,
       "ty": 5,
@@ -4024,6 +4063,7 @@
     {
       "id": "royal-archivist",
       "name": "Archivist Quill",
+      "dialogueTree": "quill-feather-trade",
       "sprite": "hub-npc-scholar",
       "building": "library",
       "tx": 5,
@@ -4539,6 +4579,7 @@
     {
       "id": "baker-otto",
       "name": "Baker Otto",
+      "dialogueTree": "otto-egg-trade",
       "sprite": "hub-npc-merchant",
       "building": "bakery",
       "tx": 4,

--- a/web/src/data/hub/capitalcity/questDefs.json
+++ b/web/src/data/hub/capitalcity/questDefs.json
@@ -1,4 +1,75 @@
 {
+  "dialogues": [
+    {
+      "id": "quill-feather-trade",
+      "npcId": "royal-archivist",
+      "start": "greet",
+      "nodes": {
+        "greet": {
+          "text": "Blast and bother — third quill snapped this morning! How is a man to finish his verse cycle when the instruments betray him? I'd trade one of my published volumes for a single decent feather.",
+          "choices": [
+            {
+              "label": "Offer him a feather",
+              "next": "greet",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "feather",
+                  "giveHubItem": {
+                    "itemId": "poetry-book"
+                  },
+                  "missingText": "You pat your pack theatrically, but there's no feather in it. The hens of the realm may be able to help.",
+                  "successText": "He whittles it to a nib on the spot, eyes shining. 'Magnificent! Here — my collected verse. Treasure it.' You are now holding a book of genuinely awful poetry."
+                }
+              ]
+            },
+            {
+              "label": "Leave him to his suffering",
+              "effects": [
+                {
+                  "type": "end"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "otto-egg-trade",
+      "npcId": "baker-otto",
+      "start": "greet",
+      "nodes": {
+        "greet": {
+          "text": "Coronation orders are burying me and my egg baskets are empty by noon. If you've fresh eggs, I'll pay 20 crystals for every three.",
+          "choices": [
+            {
+              "label": "Sell 3 eggs — 20 💎",
+              "next": "greet",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "egg",
+                  "wantCount": 3,
+                  "giveCrystals": 20,
+                  "missingText": "Fewer than three eggs in that pack. The palace hens are generous to anyone with feed.",
+                  "successText": "He candles each one against the oven light and nods. 'Fine eggs. 20 crystals, and come back with more!'"
+                }
+              ]
+            },
+            {
+              "label": "That's all for now.",
+              "effects": [
+                {
+                  "type": "end"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
   "quests": [
     {
       "id": "crownhaven-census",

--- a/web/src/data/hub/gravemoor/config.json
+++ b/web/src/data/hub/gravemoor/config.json
@@ -1194,6 +1194,7 @@
     {
       "id": "gravedigger-hollis",
       "name": "Old Hollis",
+      "dialogueTree": "hollis-tonic-trade",
       "sprite": "hub-npc-gravedigger",
       "tx": 30,
       "ty": 10,
@@ -1234,6 +1235,7 @@
     {
       "id": "weeping-widow",
       "name": "The Weeping Widow",
+      "dialogueTree": "widow-poetry-trade",
       "sprite": "hub-npc-queen",
       "isGhost": true,
       "tx": 27,

--- a/web/src/data/hub/gravemoor/questDefs.json
+++ b/web/src/data/hub/gravemoor/questDefs.json
@@ -1,4 +1,72 @@
 {
+  "dialogues": [
+    {
+      "id": "widow-poetry-trade",
+      "npcId": "weeping-widow",
+      "start": "greet",
+      "nodes": {
+        "greet": {
+          "text": "The nights here are long, and the silence longer. I would give much for words to fill them — sad ones, preferably. The sadder the better.",
+          "choices": [
+            {
+              "label": "Offer the poetry book",
+              "next": "greet",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "poetry-book",
+                  "giveCrystals": 50,
+                  "missingText": "You have no verse to offer her. Perhaps the capital's archivist could help — if someone brought him a feather.",
+                  "successText": "She reads the first stanza and weeps — with joy, possibly. 'Dreadful. Perfect. I shall read it every night.' She presses 50 crystals into your hand."
+                }
+              ]
+            },
+            {
+              "label": "Leave her in peace",
+              "effects": [
+                {
+                  "type": "end"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "hollis-tonic-trade",
+      "npcId": "gravedigger-hollis",
+      "start": "greet",
+      "nodes": {
+        "greet": {
+          "text": "Forty years of digging and my back's more crooked than the fence rows. The capital apothecary makes a lavender tonic that'd sort me right out, but it's a long walk for an old man.",
+          "choices": [
+            {
+              "label": "Hand over a lavender tonic",
+              "next": "greet",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "lavender-tonic",
+                  "giveCrystals": 40,
+                  "missingText": "You've none on you. Apothecary Mads in the capital brews it.",
+                  "successText": "He uncorks it and breathes deep. 'Ahh. That's the stuff.' 40 crystals, and he stands a little straighter already."
+                }
+              ]
+            },
+            {
+              "label": "Take care, Hollis.",
+              "effects": [
+                {
+                  "type": "end"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
   "quests": [
     {
       "id": "gravemoor-restless-remains",

--- a/web/src/data/hub/hollowmere/config.json
+++ b/web/src/data/hub/hollowmere/config.json
@@ -1984,6 +1984,19 @@
   },
   "interactables": [
     {
+      "id": "apothecary-salve-shelf",
+      "tx": 3,
+      "ty": 1,
+      "building": "apothecary",
+      "reactions": [
+        {
+          "type": "buyHubItem",
+          "itemId": "bog-salve",
+          "price": 14
+        }
+      ]
+    },
+    {
       "id": "bonepile-curio-item-0",
       "tx": 9,
       "ty": 2,

--- a/web/src/data/hub/ironholdkeep/config.json
+++ b/web/src/data/hub/ironholdkeep/config.json
@@ -2465,6 +2465,7 @@
     {
       "id": "castle-squire",
       "name": "Squire Tomas",
+      "dialogueTree": "squire-ribbon-trade",
       "sprite": "hub-npc-soldier",
       "tx": 17,
       "ty": 40,

--- a/web/src/data/hub/ironholdkeep/questDefs.json
+++ b/web/src/data/hub/ironholdkeep/questDefs.json
@@ -1313,6 +1313,39 @@
   ],
   "dialogues": [
     {
+      "id": "squire-ribbon-trade",
+      "npcId": "castle-squire",
+      "start": "greet",
+      "nodes": {
+        "greet": {
+          "text": "There's a girl in the village who— I mean, hypothetically, if a squire wanted a token — a silk ribbon, say, from the capital — what would something like that cost? Asking for a friend.",
+          "choices": [
+            {
+              "label": "Offer the silk ribbon",
+              "next": "greet",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "silk-ribbon",
+                  "giveCrystals": 30,
+                  "missingText": "You've no ribbon on you. The Grand Market Hall in the capital sells them, hypothetically.",
+                  "successText": "He goes scarlet to the ears and pays 30 crystals without haggling. 'For my friend. Obviously.'"
+                }
+              ]
+            },
+            {
+              "label": "Good luck, 'friend'.",
+              "effects": [
+                {
+                  "type": "end"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    {
       "id": "varek-chat",
       "npcId": "castle-commander",
       "start": "greet",

--- a/web/src/data/hub/millhaven/config.json
+++ b/web/src/data/hub/millhaven/config.json
@@ -1441,6 +1441,7 @@
     {
       "id": "innkeeper-millhaven",
       "name": "Innkeeper Cobb",
+      "dialogueTree": "cobb-spice-trade",
       "sprite": "hub-npc-merchant",
       "tx": 3,
       "ty": 4,
@@ -1665,6 +1666,7 @@
     {
       "id": "smith-garrick",
       "name": "Smith Garrick",
+      "dialogueTree": "garrick-salve-trade",
       "sprite": "hub-npc-supplies",
       "tx": 13,
       "ty": 32,
@@ -1771,6 +1773,7 @@
     {
       "id": "widow-tamsin",
       "name": "Widow Tamsin",
+      "dialogueTree": "tamsin-locket-trade",
       "sprite": "hub-npc-elder",
       "tx": 4,
       "ty": 4,

--- a/web/src/data/hub/millhaven/questDefs.json
+++ b/web/src/data/hub/millhaven/questDefs.json
@@ -791,6 +791,105 @@
   "blockedPaths": [],
   "dialogues": [
     {
+      "id": "tamsin-locket-trade",
+      "npcId": "widow-tamsin",
+      "start": "greet",
+      "nodes": {
+        "greet": {
+          "text": "My husband carried a locket like mine, lost when the sea took him. Foolish, but I still watch the tideline for it. If you ever find such a thing… I would pay anything.",
+          "choices": [
+            {
+              "label": "Show her the lost locket",
+              "next": "greet",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "lost-locket",
+                  "giveCrystals": 60,
+                  "missingText": "You have no locket to show her. They say the town dogs dig up all manner of things, for the price of a good bone.",
+                  "successText": "Her hands tremble as she opens it. 'It's not his. But it's… close enough to hold.' She insists you take 60 crystals."
+                }
+              ]
+            },
+            {
+              "label": "Say nothing",
+              "effects": [
+                {
+                  "type": "end"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "garrick-salve-trade",
+      "npcId": "smith-garrick",
+      "start": "greet",
+      "nodes": {
+        "greet": {
+          "text": "Burns are the tax a smith pays. There's a witch's salve out of Hollowmere that works wonders — bog-smelling stuff, but it works.",
+          "choices": [
+            {
+              "label": "Hand over a bog salve",
+              "next": "greet",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "bog-salve",
+                  "giveCrystals": 35,
+                  "missingText": "You've no salve on you. Sister Nettle sells it in Hollowmere, if you dare the marsh.",
+                  "successText": "'That's the one. Reeks like a drowned log — works like a miracle.' 35 crystals, gladly paid."
+                }
+              ]
+            },
+            {
+              "label": "Mind the sparks.",
+              "effects": [
+                {
+                  "type": "end"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "cobb-spice-trade",
+      "npcId": "innkeeper-millhaven",
+      "start": "greet",
+      "nodes": {
+        "greet": {
+          "text": "My stew's honest, but honest doesn't fill tables. The Ravenwatch guild sells a spice pouch that'd make it sing — I'd pay well over guild price to skip the trip.",
+          "choices": [
+            {
+              "label": "Sell him a spice pouch",
+              "next": "greet",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "spice-pouch",
+                  "giveCrystals": 38,
+                  "missingText": "You've no spices on you. The Merchant's Guild Hall in Ravenwatch stocks them.",
+                  "successText": "He takes one sniff and grins ear to ear. 'Tonight the stew SINGS.' 38 crystals, and a free bowl if you stay."
+                }
+              ]
+            },
+            {
+              "label": "Another time.",
+              "effects": [
+                {
+                  "type": "end"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    {
       "id": "marta-fish-trade",
       "npcId": "fishmonger-marta",
       "start": "greet",

--- a/web/src/data/hub/ravenwatch/config.json
+++ b/web/src/data/hub/ravenwatch/config.json
@@ -9400,6 +9400,19 @@
   ],
   "interactables": [
     {
+      "id": "guild-spice-chest",
+      "tx": 10,
+      "ty": 2,
+      "building": "traders-building",
+      "reactions": [
+        {
+          "type": "buyHubItem",
+          "itemId": "spice-pouch",
+          "price": 16
+        }
+      ]
+    },
+    {
       "id": "ravenwatch-chicken-feed",
       "tx": 5,
       "ty": 5,

--- a/web/src/data/hub/saltmereport/config.json
+++ b/web/src/data/hub/saltmereport/config.json
@@ -1560,6 +1560,7 @@
     {
       "id": "harbourmaster-vane",
       "name": "Harbourmaster Vane",
+      "dialogueTree": "vane-hat-trade",
       "sprite": "hub-npc-harbourmaster",
       "tx": 6,
       "ty": 3,
@@ -1604,6 +1605,7 @@
     {
       "id": "fishwife-pearl",
       "name": "Fishwife Pearl",
+      "dialogueTree": "pearl-fish-trade",
       "sprite": "hub-npc-fisherman",
       "tx": 5,
       "ty": 3,
@@ -2465,6 +2467,32 @@
     }
   },
   "interactables": [
+    {
+      "id": "fish-market-herring-crate",
+      "tx": 8,
+      "ty": 1,
+      "building": "fish-market",
+      "reactions": [
+        {
+          "type": "buyHubItem",
+          "itemId": "smoked-herring",
+          "price": 10
+        }
+      ]
+    },
+    {
+      "id": "smokehouse-bone-sack",
+      "tx": 6,
+      "ty": 1,
+      "building": "smokehouse",
+      "reactions": [
+        {
+          "type": "buyHubItem",
+          "itemId": "bones",
+          "price": 6
+        }
+      ]
+    },
     {
       "id": "chandlers-item-0",
       "tx": 8,

--- a/web/src/data/hub/saltmereport/questDefs.json
+++ b/web/src/data/hub/saltmereport/questDefs.json
@@ -1,4 +1,154 @@
 {
+  "dialogues": [
+    {
+      "id": "vane-hat-trade",
+      "npcId": "harbourmaster-vane",
+      "start": "greet",
+      "nodes": {
+        "greet": {
+          "text": "The Admiralty inspection is next month and my ceremonial hat was eaten — EATEN — by a gull. The capital tailor stocks proper ones. I'd pay handsomely to be spared the errand.",
+          "choices": [
+            {
+              "label": "Present the fancy hat",
+              "next": "greet",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "fancy-hat",
+                  "giveCrystals": 75,
+                  "missingText": "You have no hat worth presenting. Pell's Tailoring in the capital keeps them in stock.",
+                  "successText": "He sets it on his head and checks his reflection in the harbour bell. 'Impeccable.' 75 crystals, dispensed with full ceremony."
+                }
+              ]
+            },
+            {
+              "label": "Good luck with the gulls.",
+              "effects": [
+                {
+                  "type": "end"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "pearl-fish-trade",
+      "npcId": "fishwife-pearl",
+      "start": "greet",
+      "nodes": {
+        "greet": {
+          "text": "Fresh off the boat or fresh off your line, makes no difference to me — I pay fair coin for fish, same rates as anywhere on the coast.",
+          "choices": [
+            {
+              "label": "I've got fish to sell.",
+              "next": "sell"
+            },
+            {
+              "label": "Just browsing.",
+              "effects": [
+                {
+                  "type": "end"
+                }
+              ]
+            }
+          ]
+        },
+        "sell": {
+          "text": "Lay it on the slab, then. What have you got?",
+          "choices": [
+            {
+              "label": "Tiddler — 3 💎",
+              "next": "sell",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "fish-tiddler",
+                  "giveCrystals": 3,
+                  "missingText": "Not a tiddler on you.",
+                  "successText": "Bait-box size, but coin's coin. 3 crystals."
+                }
+              ]
+            },
+            {
+              "label": "Small Fish — 6 💎",
+              "next": "sell",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "fish-small",
+                  "giveCrystals": 6,
+                  "missingText": "No small fish in that pack.",
+                  "successText": "Decent pan fish. 6 crystals."
+                }
+              ]
+            },
+            {
+              "label": "Medium Fish — 12 💎",
+              "next": "sell",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "fish-medium",
+                  "giveCrystals": 12,
+                  "missingText": "You've no medium fish on you.",
+                  "successText": "Good weight to it. 12 crystals."
+                }
+              ]
+            },
+            {
+              "label": "Large Fish — 25 💎",
+              "next": "sell",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "fish-large",
+                  "giveCrystals": 25,
+                  "missingText": "You've no large fish on you.",
+                  "successText": "Now that's a fish! 25 crystals."
+                }
+              ]
+            },
+            {
+              "label": "Trophy Fish — 45 💎",
+              "next": "sell",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "fish-trophy",
+                  "giveCrystals": 45,
+                  "missingText": "A trophy fish? Show me first.",
+                  "successText": "The whole dock will hear about this one. 45 crystals!"
+                }
+              ]
+            },
+            {
+              "label": "Legendary Fish — 90 💎",
+              "next": "sell",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "fish-legendary",
+                  "giveCrystals": 90,
+                  "missingText": "Legendary, is it? I'll believe fins when I see them.",
+                  "successText": "By the deep… I'll retire on the story alone. 90 crystals."
+                }
+              ]
+            },
+            {
+              "label": "That's the lot.",
+              "effects": [
+                {
+                  "type": "end"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
   "quests": [
     {
       "id": "saltmere-dockside-cat",

--- a/web/src/data/hub/thornwoodcamp/config.json
+++ b/web/src/data/hub/thornwoodcamp/config.json
@@ -457,6 +457,7 @@
     {
       "id": "forager-mott",
       "name": "Forager Mott",
+      "dialogueTree": "mott-herring-trade",
       "sprite": "hub-npc-supplies",
       "tx": 14,
       "ty": 45,

--- a/web/src/data/hub/thornwoodcamp/questDefs.json
+++ b/web/src/data/hub/thornwoodcamp/questDefs.json
@@ -1,5 +1,38 @@
 {
   "dialogues": [
+    {
+      "id": "mott-herring-trade",
+      "npcId": "forager-mott",
+      "start": "greet",
+      "nodes": {
+        "greet": {
+          "text": "Forage's thin this season and the wolves get bold when a man walks hungry. Smoked fish keeps for weeks — the Saltmere market strings them by the dozen.",
+          "choices": [
+            {
+              "label": "Hand over a smoked herring",
+              "next": "greet",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "smoked-herring",
+                  "giveCrystals": 25,
+                  "missingText": "You've no smoked fish on you. The Fish Market in Saltmere Port strings them fresh from the smoker.",
+                  "successText": "He tucks it into his pack like treasure. 'That's a week of walking safe. 25 crystals, friend.'"
+                }
+              ]
+            },
+            {
+              "label": "Watch the treeline.",
+              "effects": [
+                {
+                  "type": "end"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
       {
         "id": "ranger-sable-trade",
         "npcId": "ranger-sable",

--- a/web/src/data/hubItems.json
+++ b/web/src/data/hubItems.json
@@ -90,5 +90,68 @@
     "icon": "🥾",
     "desc": "Well-made walking boots. A blessing for anyone who works outdoors.",
     "category": "material"
+  },
+  {
+    "id": "poetry-book",
+    "name": "Poetry Book",
+    "icon": "📖",
+    "desc": "Archivist Quill's own verse. Objectively awful — yet somewhere, someone would treasure it.",
+    "category": "material"
+  },
+  {
+    "id": "bones",
+    "name": "Bones",
+    "icon": "🦴",
+    "desc": "Meaty smokehouse leftovers. Any dog in the realm would do anything for these.",
+    "category": "material"
+  },
+  {
+    "id": "lost-locket",
+    "name": "Lost Locket",
+    "icon": "📿",
+    "desc": "A weathered locket dug up by a delighted dog. Someone must miss this terribly.",
+    "category": "material"
+  },
+  {
+    "id": "honey-cake",
+    "name": "Honey Cake",
+    "icon": "🍰",
+    "desc": "Baker Otto's finest. Sweet enough to make a child's eyes go perfectly round.",
+    "category": "material"
+  },
+  {
+    "id": "lavender-tonic",
+    "name": "Lavender Tonic",
+    "icon": "🧴",
+    "desc": "Soothes aching joints and weary backs. Gravediggers swear by it.",
+    "category": "material"
+  },
+  {
+    "id": "silk-ribbon",
+    "name": "Silk Ribbon",
+    "icon": "🎀",
+    "desc": "Capital-spun silk. Just the token a young squire might want for a sweetheart.",
+    "category": "material"
+  },
+  {
+    "id": "smoked-herring",
+    "name": "Smoked Herring",
+    "icon": "🐟",
+    "desc": "Keeps for weeks on the trail. Foragers and rangers buy them by the string.",
+    "category": "material"
+  },
+  {
+    "id": "bog-salve",
+    "name": "Bog Salve",
+    "icon": "🫙",
+    "desc": "Sister Nettle's marsh-herb ointment. Smiths prize it for burns.",
+    "category": "material"
+  },
+  {
+    "id": "spice-pouch",
+    "name": "Spice Pouch",
+    "icon": "🧂",
+    "desc": "Rare spices from the Ravenwatch trade guild. Innkeepers pay well to liven a stew.",
+    "category": "material"
   }
 ]


### PR DESCRIPTION
## Summary

Builds out the full cross-town trade network on the primitives merged in #1847 (`buyHubItem`, `tradeHubItem`, `onAmbientAnimalTap`). Nine new catalog items in `hubItems.json`, twelve new dialogue trees, seven newly stocked shops, and one small code extension — everything else is data.

### The two remaining designed chains
- **Feather → poetry book → reader**: Archivist Quill (capital library) trades any feather for one of his awful poetry books; the Weeping Widow in Gravemoor pays 50💎 for grim verse. Feathers come from feeding chickens (round 1).
- **Bones → dog → lost locket → widow**: the Saltmere Port smokehouse sells bones (6💎); feeding one to any ambient dog (new `dog` branch in `handleAmbientAnimalTap`) sends it fetching — 60% chance it returns with a Lost Locket, which Widow Tamsin in Millhaven buys for 60💎.

### Round-1 loose ends closed
- **Fancy hat** finally has a buyer: Harbourmaster Vane (Saltmere) pays 75💎 before his Admiralty inspection.
- **Eggs** have a buyer: Baker Otto (capital bakery) pays 20💎 per three.

### Every empty shop now sells something, and every good has a use
| Shop | Sells | Cross-town buyer |
|---|---|---|
| Capital bakery | Honey Cake 15💎 | Little Wren (Appleford), 25💎 |
| Capital apothecary | Lavender Tonic 18💎 | Old Hollis (Gravemoor), 40💎 |
| Capital Grand Market Hall | Silk Ribbon 12💎 | Squire Tomas (Ironhold), 30💎 |
| Saltmere fish market | Smoked Herring 10💎 | Forager Mott (Thornwood), 25💎 |
| Saltmere smokehouse | Bones 6💎 | any dog (lost-locket roll) |
| Hollowmere apothecary | Bog Salve 14💎 | Smith Garrick (Millhaven), 35💎 |
| Ravenwatch Guild Hall | Spice Pouch 16💎 | Innkeeper Cobb (Millhaven), 38💎 |

Bonus: Fishwife Pearl (Saltmere fish market) now buys caught fish at the same tier prices as Millhaven's Marta, giving hub fishing a second port of sale.

### Docs
`docs/hubworld.md` §16 updated: full live trade-network list, dog feeding documented, and the "future chains" section replaced with guidance on growing the network.

## Testing
- `npm run test`: 924 tests passing across 198 files (loader tests parse every modified town config/questDefs).
- `npm run build` (tsc + vite): clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HFBFbZdCft98Dbr1WdRHoT

---
_Generated by [Claude Code](https://claude.ai/code/session_01HFBFbZdCft98Dbr1WdRHoT)_