### PR TITLE
Hub item economy round 3: net & spade tools, dig spots, deeper trades

### DIFF
--- a/docs/hubworld.md
+++ b/docs/hubworld.md
@@ -34,6 +34,7 @@
 | `web/src/data/hubItems.json` | Hub-item catalog: materials (chicken feed, eggs, fish, trade goods) and unique tools (fishing rod) — see §16 | consumed by `itemStore.ts` |
 | `web/src/game/itemStore.ts` (hub-item section) | Hub-item inventory persistence (localStorage, type `'hub-item'`) — see §16 | `addHubItem`, `removeHubItem`, `getHubItemCount`, `hasHubItem`, `getHubItems`, `getHubItemCatalogEntry` |
 | `web/src/game/hub/questItems.ts` | Held-quest-item id helpers (`quest:<questId>:<stepKey>`) — see §16 | `questItemId`, `isQuestItemId`, `questIdFromItemId` |
+| `web/src/game/hub/digs.ts` | Once-per-day dig-spot persistence (localStorage) — see §7 `dig` reaction, §16 | `canDigToday`, `recordDig` |
 | `web/src/components/hub/HubInventoryModal.tsx` | 🎒 Hub Inventory UI — held quest items, materials & tools, pet accessories — see §16 | `HubInventoryModal` |
 
 ---
@@ -290,6 +291,7 @@ bounds, else a single tile.
 | `buy` | `slotIndex` | Sells the interactable's building's Nth daily-rotating shop-stock item (`getTodaysShopItems`, `SHOP_TRADER_REGISTRY`). Shares `DailyShopState` with `ShopScreen`, so both draw down the same stock. Requires `building`. |
 | `buyPack` | — | Crystal-pack purchase flow (delegates to `onBuyCrystalPack`). Requires `building`. |
 | `buyHubItem` | `itemId`, `price`, `currency?`, `speakerName?` | Always-available hub-item purchase (no daily rotation) — see §16. `itemId` must exist in `hubItems.json`; `currency` is `'crystals'` (default) or `'tickets'`. Unique items (e.g. the fishing rod) re-offer as "already owned" once bought. `speakerName` overrides the building-NPC speaker (useful for exterior stalls). |
+| `dig` | `requiresItemId?` | Once-per-day dig spot (see §16), gated on holding the tool hub-item (default `'spade'`). Rolls 50% worms (+2 fish bait) / 30% crystals (10–25) / 20% a dug-up trinket collectible. Cooldown persists per spot per real day in `jarv_hub_digs` (`web/src/game/hub/digs.ts`). Pair with a `mediumDirt` decor tile (`zlayer: "below"`) for a visible earth patch. |
 
 Reactions run in order; `dialogue` (and `message`-bearing reactions) chain the
 remainder through the dialogue's close. Conventions: at most one `screen` or
@@ -424,7 +426,7 @@ Then on the NPC (in `config.json`): `"dialogueTree": "scholar-chat"` (keep a
 | `friendship` | `npcId?`, `xp` | Grant friendship XP (defaults to the speaking NPC). |
 | `relationship` | `npcId?`, `track`, `points` | Add points to a relationship track (`ally`/`rival`/`romance`) — defaults to the speaking NPC. See §7c. |
 | `quest` | `questId` | Offer that quest (Accept / Not now). Resolves the quest's real `giverNpcId`. **Terminates** the walk. |
-| `tradeHubItem` | `wantItemId`, `wantCount?`, `giveCrystals?`, `giveHubItem?`, `giveCollectible?`, `missingText`, `successText` | Repeatable barter — see §16. Takes `wantCount` (default 1) of a hub-item from the player and grants the `give*` rewards, showing `successText` (then advancing to `next` on close, so a sell menu can loop). If the player holds too few, shows `missingText` and **terminates** the walk with no state change. Must be the **only/last** effect on its choice (it terminates the walk either way). |
+| `tradeHubItem` | `wantItemId?`, `wantCount?`, `wantItems?`, `giveCrystals?`, `giveHubItem?`, `giveCollectible?`, `giveFriendship?`, `giveRelationship?`, `missingText`, `successText` | Repeatable barter — see §16. Takes `wantCount` (default 1) of a hub-item — or every entry of `wantItems: [{itemId, count?}]` for multi-item recipes (all-or-nothing, takes precedence over `wantItemId`) — and grants the `give*` rewards (`giveFriendship: {npcId?, xp}` and `giveRelationship: {npcId?, track, points}` default to the speaking NPC), showing `successText` (then advancing to `next` on close, so a sell menu can loop). If the player holds too few of anything, shows `missingText` and **terminates** the walk with no state change. Must be the **only/last** effect on its choice (it terminates the walk either way). |
 | `end` | — | End the conversation. |
 
 If a choice has neither a terminating effect (`quest`/`end`) nor `next`, the
@@ -1344,7 +1346,8 @@ Appleford / Harrowfield / Ironhold Keep / Royal Palace), rod + bait (Millhaven
 harbour stalls), Fancy Hat + Sturdy Boots (capital tailor), honey cake /
 lavender tonic / silk ribbon (capital bakery / apothecary / Grand Market
 Hall), smoked herring + bones (Saltmere fish market / smokehouse), bog salve
-(Hollowmere apothecary), spice pouch (Ravenwatch Merchant's Guild Hall).
+(Hollowmere apothecary), spice pouch (Ravenwatch Merchant's Guild Hall),
+catching net (Saltmere Net Loft), spade (Gearford Tool Shop).
 
 ### Trading hub items — `tradeHubItem` (§7b dialogue effects)
 
@@ -1364,7 +1367,11 @@ eggs, 20💎 · Little Wren (Appleford) ← honey cake, 25💎 · Old Hollis
 (Millhaven) ← bog salve, 35💎 · Innkeeper Cobb (Millhaven) ← spice pouch,
 38💎 · Ranger Sable (Thornwood) ← sturdy boots, 90💎 · Archivist Quill
 (capital) ← feather → poetry book · Fishwife Marta (Millhaven) & Fishwife
-Pearl (Saltmere) ← any caught fish → tier-priced crystals.
+Pearl (Saltmere) ← any caught fish → tier-priced crystals · Master Fenwick
+(capital) ← butterfly, 20💎 · Little Pip (Gravemoor) ← firefly, 30💎 +
+friendship · Innkeep Rosalind (capital) ← 2 eggs + smoked herring →
+45💎 (multi-item recipe) · Lady Cora (capital) ← poetry book → 20💎 +
+romance points.
 
 ### Feeding ambient animals
 
@@ -1379,6 +1386,9 @@ the default flavour bubble:
   attach friendship to).
 - **Dog** + player holds `bones` → offers to feed (consumes 1): the dog runs
   off and, 60% of the time, returns with a `lost-locket`.
+- **Butterfly / firefly** + player holds the `net` → offers to swing it:
+  60% catches the `butterfly`/`firefly` hub-item, 40% it escapes. Day/night
+  availability follows the species' normal spawn rules (§8).
 
 Placed (named) animals keep their normal §8 quest/dialogue routing.
 

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -53,6 +53,7 @@ import {  ALL_QUESTS, FRIENDSHIP_DIALOGUE, RELATIONSHIP_DIALOGUE, RAVENWATCH } f
 import { HubInteractable, HubLocationBundle, HubQuestBundle, HubTreasure } from '../../data/hub/loader'
 import { getUnreadCount } from '../../game/news'
 import { interactableStoreKey, isInteractableGranted, markInteractableGranted, getInteractableMoves, setInteractableMove } from '../../game/hub/interactables'
+import { canDigToday, recordDig } from '../../game/hub/digs'
 import { recordNpcMet, recordAnimalSeen, recordAreaSeen } from '../../game/hub/journal'
 import { getTodaysShopItems } from '../../game/hub/shopStock'
 import { loadDailyShopState, saveDailyShopState, isShopItemSold, markCardBought, markAugmentBought } from '../../game/shopSchedule'
@@ -872,11 +873,18 @@ function hasOfferableQuest(giverId: string): boolean {
           // Repeatable barter: consume the wanted hub-item(s), grant the
           // reward(s). If the player holds too few, show missingText and stop
           // (no navigation — the player can come back with the goods).
-          const want = eff.wantCount ?? 1
-          if (!removeHubItem(eff.wantItemId, want)) {
+          // Multi-item recipes (wantItems) are all-or-nothing: verify every
+          // count before removing anything.
+          const wanted: Array<{ itemId: string; count: number }> = eff.wantItems
+            ? eff.wantItems.map(w => ({ itemId: w.itemId, count: w.count ?? 1 }))
+            : eff.wantItemId
+              ? [{ itemId: eff.wantItemId, count: eff.wantCount ?? 1 }]
+              : []
+          if (wanted.length === 0 || wanted.some(w => getHubItemCount(w.itemId) < w.count)) {
             setDialogueEvent({ speakerName, text: eff.missingText })
             return
           }
+          for (const w of wanted) removeHubItem(w.itemId, w.count)
           if (eff.giveCrystals) {
             saveCrystals(loadCrystals() + eff.giveCrystals)
             onCrystalsChange?.(loadCrystals())
@@ -887,6 +895,12 @@ function hasOfferableQuest(giverId: string): boolean {
           if (eff.giveCollectible) {
             const { id, name, icon, desc } = eff.giveCollectible
             addCollectible(id, { name, icon, desc })
+          }
+          if (eff.giveFriendship) {
+            addFriendshipXp(eff.giveFriendship.npcId ?? npcId, eff.giveFriendship.xp)
+          }
+          if (eff.giveRelationship) {
+            addRelationshipPoints(eff.giveRelationship.npcId ?? npcId, eff.giveRelationship.track, eff.giveRelationship.points)
           }
           emitSound('shopPurchase')
           refreshState()
@@ -1207,6 +1221,41 @@ function hasOfferableQuest(giverId: string): boolean {
       })
       return true
     }
+    if ((type === 'butterfly' || type === 'firefly') && hasHubItem('net')) {
+      const isFirefly = type === 'firefly'
+      const name = isFirefly ? 'firefly' : 'butterfly'
+      setDialogueEvent({
+        speakerName: isFirefly ? 'Firefly' : 'Butterfly',
+        text: isFirefly
+          ? 'A point of living light drifts lazily within reach of your net.'
+          : 'The butterfly settles on a flower, wings pulsing, entirely unaware of your net.',
+        choices: [
+          {
+            label: 'Swing the net!',
+            primary: true,
+            onClick: () => {
+              if (Math.random() < 0.6) {
+                addHubItem(name, 1)
+                refreshState()
+                setDialogueEvent({
+                  speakerName: isFirefly ? 'Firefly' : 'Butterfly',
+                  text: isFirefly
+                    ? 'Got it! The jar in your pack glows softly from within. ✨'
+                    : 'A clean sweep! The butterfly flutters gently inside your net. 🦋',
+                })
+              } else {
+                setDialogueEvent({
+                  speakerName: isFirefly ? 'Firefly' : 'Butterfly',
+                  text: 'It flits away at the very last moment. Patience — there are always more.',
+                })
+              }
+            },
+          },
+          { label: 'Let it be', onClick: () => setDialogueEvent(null) },
+        ],
+      })
+      return true
+    }
     if (type === 'dog' && hasHubItem('bones')) {
       setDialogueEvent({
         speakerName: 'Dog',
@@ -1446,6 +1495,58 @@ function hasOfferableQuest(giverId: string): boolean {
           speakerName,
           text: `${catalog.icon} ${catalog.desc} Care to buy a ${catalog.name} for ${r.price} ${currencyIcon}?`,
           choices: [confirm, cancel],
+        })
+        return
+      }
+      case 'dig': {
+        // Once-per-day dig spot, gated on holding the required tool.
+        const toolId = r.requiresItemId ?? 'spade'
+        const toolName = getHubItemCatalogEntry(toolId)?.name ?? toolId
+        if (!hasHubItem(toolId)) {
+          setDialogueEvent({ speakerName: '', text: `The earth is soft here… a ${toolName.toLowerCase()} would make short work of it.` })
+          return
+        }
+        if (!canDigToday(storeKey)) {
+          setDialogueEvent({ speakerName: '', text: "You've already turned this earth over today. Let it settle until tomorrow." })
+          return
+        }
+        const confirm: DialogueChoice = {
+          label: 'Dig here',
+          primary: true,
+          onClick: () => {
+            recordDig(storeKey)
+            const roll = Math.random()
+            let text: string
+            if (roll < 0.5) {
+              addHubItem('fish-bait', 2)
+              emitSound('pickup')
+              text = 'The spade turns up a wriggling knot of worms — two pots of fish bait for the taking! 🪱'
+            } else if (roll < 0.8) {
+              const amount = 10 + Math.floor(Math.random() * 16) // 10–25
+              saveCrystals(loadCrystals() + amount)
+              onCrystalsChange?.(loadCrystals())
+              emitSound('treasure')
+              text = `Something glints in the soil — ${amount} crystals, lost long ago and yours now. 💎`
+            } else {
+              const trinkets = [
+                { id: 'dug-old-boot', name: 'Old Boot', icon: '🥾', desc: 'One weathered boot, dug from the earth. Its partner remains at large.' },
+                { id: 'dug-cracked-marble', name: 'Cracked Marble', icon: '🔮', desc: 'A child’s marble with a crack running through it like lightning.' },
+                { id: 'dug-rusty-key', name: 'Rusty Key', icon: '🗝️', desc: 'A key to a lock that probably no longer exists. Probably.' },
+                { id: 'dug-clay-whistle', name: 'Clay Whistle', icon: '🪈', desc: 'An old clay whistle. It still works, to the regret of everyone nearby.' },
+              ]
+              const t = trinkets[Math.floor(Math.random() * trinkets.length)]
+              addCollectible(t.id, { name: t.name, icon: t.icon, desc: t.desc })
+              emitSound('treasure')
+              text = `The spade strikes something odd — ${t.icon} ${t.name}! Added to your collection.`
+            }
+            refreshState()
+            setDialogueEvent({ speakerName: '', text, onClose: next })
+          },
+        }
+        setDialogueEvent({
+          speakerName: '',
+          text: 'A patch of soft, diggable earth.',
+          choices: [confirm, { label: 'Leave it', onClick: () => setDialogueEvent(null) }],
         })
         return
       }

--- a/web/src/data/hub/appleford/config.json
+++ b/web/src/data/hub/appleford/config.json
@@ -2098,6 +2098,42 @@
   },
   "interactables": [
     {
+      "id": "appleford-dig-1",
+      "reactions": [
+        {
+          "type": "dig"
+        }
+      ],
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "tileId": "mediumDirt",
+          "zlayer": "below"
+        }
+      ],
+      "tx": 9,
+      "ty": 12
+    },
+    {
+      "id": "appleford-dig-2",
+      "reactions": [
+        {
+          "type": "dig"
+        }
+      ],
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "tileId": "mediumDirt",
+          "zlayer": "below"
+        }
+      ],
+      "tx": 23,
+      "ty": 19
+    },
+    {
       "id": "appleford-chicken-feed",
       "tx": 35,
       "ty": 26,

--- a/web/src/data/hub/capitalcity/config.json
+++ b/web/src/data/hub/capitalcity/config.json
@@ -3946,6 +3946,7 @@
     {
       "id": "innkeeper-crownhaven",
       "name": "Innkeep Rosalind",
+      "dialogueTree": "rosalind-platter-trade",
       "sprite": "hub-npc-merchant",
       "building": "grand-inn",
       "tx": 4,
@@ -4696,6 +4697,7 @@
     {
       "id": "noble-lady-cora",
       "name": "Lady Cora",
+      "dialogueTree": "cora-poetry-gift",
       "sprite": "hub-npc-elder",
       "building": "noble-manor-1",
       "tx": 5,
@@ -4751,6 +4753,7 @@
     {
       "id": "academy-master",
       "name": "Master Fenwick",
+      "dialogueTree": "fenwick-butterfly-trade",
       "sprite": "hub-npc-scholar",
       "building": "academy",
       "tx": 6,

--- a/web/src/data/hub/capitalcity/questDefs.json
+++ b/web/src/data/hub/capitalcity/questDefs.json
@@ -1,6 +1,117 @@
 {
   "dialogues": [
     {
+      "id": "fenwick-butterfly-trade",
+      "npcId": "academy-master",
+      "start": "greet",
+      "nodes": {
+        "greet": {
+          "text": "The academy's lepidoptery cabinet is a disgrace — half the drawers are empty. I pay 20 crystals per specimen, humanely netted, no questions about technique.",
+          "choices": [
+            {
+              "label": "Offer a butterfly — 20 💎",
+              "next": "greet",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "butterfly",
+                  "giveCrystals": 20,
+                  "missingText": "You have no specimens. The Net Loft in Saltmere Port sells catching nets; the orchards flutter with subjects.",
+                  "successText": "Exquisite wing condition! Into the cabinet it goes. 20 crystals for science."
+                }
+              ]
+            },
+            {
+              "label": "Perhaps later.",
+              "effects": [
+                {
+                  "type": "end"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "rosalind-platter-trade",
+      "npcId": "innkeeper-crownhaven",
+      "start": "greet",
+      "nodes": {
+        "greet": {
+          "text": "My famous coronation breakfast platter needs two fresh eggs and a good smoked herring — and my suppliers have vanished into the festival crowds. Bring me the makings and I'll pay 45 crystals a platter.",
+          "choices": [
+            {
+              "label": "Supply 2 eggs + 1 smoked herring — 45 💎",
+              "next": "greet",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItems": [
+                    {
+                      "itemId": "egg",
+                      "count": 2
+                    },
+                    {
+                      "itemId": "smoked-herring"
+                    }
+                  ],
+                  "giveCrystals": 45,
+                  "missingText": "That's not a full platter's worth. Two eggs — the hens oblige anyone with feed — and a smoked herring from the Saltmere fish market.",
+                  "successText": "Eggs, herring — perfect. The nobles will weep with joy. 45 crystals, and worth every one."
+                }
+              ]
+            },
+            {
+              "label": "I'll see what I can find.",
+              "effects": [
+                {
+                  "type": "end"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "cora-poetry-gift",
+      "npcId": "noble-lady-cora",
+      "start": "greet",
+      "nodes": {
+        "greet": {
+          "text": "Everyone at court gifts jewels — how tediously predictable. Do you know what nobody has ever given me? Poetry. Dreadful, heartfelt, handwritten poetry.",
+          "choices": [
+            {
+              "label": "Gift her the poetry book",
+              "next": "greet",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "poetry-book",
+                  "giveCrystals": 20,
+                  "giveRelationship": {
+                    "track": "romance",
+                    "points": 6
+                  },
+                  "missingText": "You pat your pockets and find no verse. The capital's own archivist writes the worst poetry in the realm — he trades it for feathers.",
+                  "successText": "She reads a stanza, laughs until she cries, and clutches it to her heart. 'It's HORRIBLE. I adore it.' She presses 20 crystals on you and watches you leave."
+                }
+              ]
+            },
+            {
+              "label": "Take your leave",
+              "effects": [
+                {
+                  "type": "end"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    {
       "id": "quill-feather-trade",
       "npcId": "royal-archivist",
       "start": "greet",

--- a/web/src/data/hub/gearford/config.json
+++ b/web/src/data/hub/gearford/config.json
@@ -3548,6 +3548,26 @@
   },
   "interactables": [
     {
+      "id": "tool-shop-spade",
+      "tx": 9,
+      "ty": 6,
+      "building": "tool-shop",
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "tileId": "axe"
+        }
+      ],
+      "reactions": [
+        {
+          "type": "buyHubItem",
+          "itemId": "spade",
+          "price": 80
+        }
+      ]
+    },
+    {
       "id": "tool-shop-item-0",
       "tx": 9,
       "ty": 3,

--- a/web/src/data/hub/gravemoor/config.json
+++ b/web/src/data/hub/gravemoor/config.json
@@ -1284,6 +1284,7 @@
     {
       "id": "little-pip",
       "name": "Little Pip",
+      "dialogueTree": "pip-firefly-trade",
       "sprite": "hub-npc-child",
       "isGhost": true,
       "tx": 7,

--- a/web/src/data/hub/gravemoor/questDefs.json
+++ b/web/src/data/hub/gravemoor/questDefs.json
@@ -1,6 +1,42 @@
 {
   "dialogues": [
     {
+      "id": "pip-firefly-trade",
+      "npcId": "little-pip",
+      "start": "greet",
+      "nodes": {
+        "greet": {
+          "text": "It gets awful dark here at night. Darker than anywhere. If you ever caught one of those little lights in a jar… I'd give you all my treasures for it.",
+          "choices": [
+            {
+              "label": "Give Pip a firefly — 30 💎",
+              "next": "greet",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "firefly",
+                  "giveCrystals": 30,
+                  "giveFriendship": {
+                    "xp": 5
+                  },
+                  "missingText": "You have no captured light to give. Fireflies drift through warmer towns after dark — a net from Saltmere Port would catch one.",
+                  "successText": "Pip cradles the glowing jar like it's the sun itself. 'It's beautiful.' A small hoard of treasures — 30 crystals — is solemnly handed over."
+                }
+              ]
+            },
+            {
+              "label": "Goodnight, Pip.",
+              "effects": [
+                {
+                  "type": "end"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    {
       "id": "widow-poetry-trade",
       "npcId": "weeping-widow",
       "start": "greet",

--- a/web/src/data/hub/loader.ts
+++ b/web/src/data/hub/loader.ts
@@ -276,6 +276,9 @@ export type HubInteractableReaction =
    *  exist in web/src/data/hubItems.json; unique items re-offer as "already
    *  owned" once bought. */
   | { type: 'buyHubItem'; itemId: string; price: number; currency?: 'crystals' | 'tickets'; speakerName?: string }
+  /** Once-per-day dig spot: gated on holding the required tool hub-item
+   *  (default 'spade'); rolls worms (fish bait), crystals, or a trinket. */
+  | { type: 'dig'; requiresItemId?: string }
 
 export interface HubInteractable {
   id: string

--- a/web/src/data/hub/millhaven/config.json
+++ b/web/src/data/hub/millhaven/config.json
@@ -2849,6 +2849,42 @@
   ],
   "interactables": [
     {
+      "id": "millhaven-dig-1",
+      "reactions": [
+        {
+          "type": "dig"
+        }
+      ],
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "tileId": "mediumDirt",
+          "zlayer": "below"
+        }
+      ],
+      "tx": 2,
+      "ty": 21
+    },
+    {
+      "id": "millhaven-dig-2",
+      "reactions": [
+        {
+          "type": "dig"
+        }
+      ],
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "tileId": "mediumDirt",
+          "zlayer": "below"
+        }
+      ],
+      "tx": 23,
+      "ty": 10
+    },
+    {
       "id": "millhaven-rod-stall",
       "tx": 32,
       "ty": 10,

--- a/web/src/data/hub/questDefs.ts
+++ b/web/src/data/hub/questDefs.ts
@@ -218,15 +218,21 @@ export type DialogueEffect =
   | { type: 'friendship'; npcId?: string; xp: number }  // grant friendship XP (defaults to the speaking NPC)
   | { type: 'relationship'; npcId?: string; track: RelationshipTrack; points: number }  // advance a relationship track (defaults to the speaking NPC)
   | { type: 'quest'; questId: string }          // offer a quest (Accept / Not now)
-  // Repeatable barter: take wantCount (default 1) of a hub-item from the
-  // player in exchange for crystals / another hub-item / a collectible.
-  // Shows missingText (no state change) if the player holds too few.
+  // Repeatable barter: take wantCount (default 1) of a hub-item — or, for
+  // multi-item recipes, every entry in wantItems (all-or-nothing) — from the
+  // player in exchange for crystals / another hub-item / a collectible /
+  // friendship XP / relationship points. Shows missingText (no state change)
+  // if the player holds too few of anything.
   | { type: 'tradeHubItem'
-      wantItemId: string
+      wantItemId?: string
       wantCount?: number
+      /** Multi-item recipe. Takes precedence over wantItemId when present. */
+      wantItems?: Array<{ itemId: string; count?: number }>
       giveCrystals?: number
       giveHubItem?: { itemId: string; count?: number }
       giveCollectible?: { id: string; name: string; icon: string; desc: string }
+      giveFriendship?: { npcId?: string; xp: number }
+      giveRelationship?: { npcId?: string; track: RelationshipTrack; points: number }
       missingText: string
       successText: string }
   | { type: 'end' }                             // end the conversation

--- a/web/src/data/hub/saltmereport/config.json
+++ b/web/src/data/hub/saltmereport/config.json
@@ -2468,6 +2468,19 @@
   },
   "interactables": [
     {
+      "id": "net-loft-net",
+      "tx": 6,
+      "ty": 1,
+      "building": "net-maker",
+      "reactions": [
+        {
+          "type": "buyHubItem",
+          "itemId": "net",
+          "price": 60
+        }
+      ]
+    },
+    {
       "id": "fish-market-herring-crate",
       "tx": 8,
       "ty": 1,

--- a/web/src/data/hub/thornwoodcamp/config.json
+++ b/web/src/data/hub/thornwoodcamp/config.json
@@ -529,6 +529,42 @@
   "interiors": {},
   "interactables": [
     {
+      "id": "thornwood-dig-1",
+      "reactions": [
+        {
+          "type": "dig"
+        }
+      ],
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "tileId": "mediumDirt",
+          "zlayer": "below"
+        }
+      ],
+      "tx": 12,
+      "ty": 45
+    },
+    {
+      "id": "thornwood-dig-2",
+      "reactions": [
+        {
+          "type": "dig"
+        }
+      ],
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "tileId": "mediumDirt",
+          "zlayer": "below"
+        }
+      ],
+      "tx": 6,
+      "ty": 29
+    },
+    {
       "id": "interactable-1781887233427",
       "tx": 17,
       "ty": 47,

--- a/web/src/data/hubItems.json
+++ b/web/src/data/hubItems.json
@@ -153,5 +153,35 @@
     "icon": "🧂",
     "desc": "Rare spices from the Ravenwatch trade guild. Innkeepers pay well to liven a stew.",
     "category": "material"
+  },
+  {
+    "id": "net",
+    "name": "Catching Net",
+    "icon": "🥅",
+    "desc": "A fine-meshed net from the Saltmere loft. Quick hands can catch butterflies by day and fireflies by night.",
+    "category": "tool",
+    "unique": true
+  },
+  {
+    "id": "spade",
+    "name": "Spade",
+    "icon": "⛏️",
+    "desc": "A sturdy Gearford spade. Soft earth around the realm hides worms — and sometimes better.",
+    "category": "tool",
+    "unique": true
+  },
+  {
+    "id": "butterfly",
+    "name": "Butterfly",
+    "icon": "🦋",
+    "desc": "Caught gently in the net. The academy in the capital collects specimens.",
+    "category": "material"
+  },
+  {
+    "id": "firefly",
+    "name": "Firefly",
+    "icon": "✨",
+    "desc": "A jar of living light, caught after dark. Someone in a gloomy town might treasure it.",
+    "category": "material"
   }
 ]

--- a/web/src/game/hub/digs.test.ts
+++ b/web/src/game/hub/digs.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { canDigToday, recordDig } from './digs'
+
+function installLocalStorageStub(): void {
+  const store = new Map<string, string>()
+  vi.stubGlobal('localStorage', {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => { store.set(k, v) },
+    removeItem: (k: string) => { store.delete(k) },
+    clear: () => { store.clear() },
+  })
+}
+
+describe('digs', () => {
+  beforeEach(() => {
+    installLocalStorageStub()
+    vi.useRealTimers()
+  })
+
+  it('allows digging a fresh spot, then blocks it for the rest of the day', () => {
+    expect(canDigToday('Millhaven:shore-dig-1')).toBe(true)
+    recordDig('Millhaven:shore-dig-1')
+    expect(canDigToday('Millhaven:shore-dig-1')).toBe(false)
+    // Other spots are unaffected
+    expect(canDigToday('Millhaven:shore-dig-2')).toBe(true)
+  })
+
+  it('allows digging again on a new day', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-01T12:00:00Z'))
+    recordDig('Appleford:orchard-dig-1')
+    expect(canDigToday('Appleford:orchard-dig-1')).toBe(false)
+    vi.setSystemTime(new Date('2026-07-02T12:00:00Z'))
+    expect(canDigToday('Appleford:orchard-dig-1')).toBe(true)
+  })
+
+  it('fails open (diggable) when localStorage throws', () => {
+    vi.stubGlobal('localStorage', {
+      getItem: () => { throw new Error('blocked') },
+      setItem: () => { throw new Error('blocked') },
+    })
+    expect(canDigToday('Anywhere:spot')).toBe(true)
+    expect(() => recordDig('Anywhere:spot')).not.toThrow()
+  })
+})

--- a/web/src/game/hub/digs.ts
+++ b/web/src/game/hub/digs.ts
@@ -1,0 +1,41 @@
+// ─── Dig spots ────────────────────────────────────────────────────────────────
+//
+// Persistence for the `dig` interactable reaction (docs/hubworld.md §7):
+// each dig spot can be dug once per real day. Entries are keyed with
+// interactableStoreKey(town, id) — the same convention as interactable
+// grants — mapping to the YYYY-MM-DD the spot was last dug.
+
+const KEY = 'jarv_hub_digs'
+
+type DigStore = Record<string, string>
+
+function load(): DigStore {
+  try {
+    const raw = localStorage.getItem(KEY)
+    return raw ? (JSON.parse(raw) as DigStore) : {}
+  } catch {
+    return {}
+  }
+}
+
+function save(store: DigStore): void {
+  try {
+    localStorage.setItem(KEY, JSON.stringify(store))
+  } catch { /* ignore */ }
+}
+
+function todayKey(): string {
+  return new Date().toISOString().slice(0, 10)
+}
+
+/** Whether this dig spot can still be dug today. */
+export function canDigToday(storeKey: string): boolean {
+  return load()[storeKey] !== todayKey()
+}
+
+/** Record that this dig spot was dug today. */
+export function recordDig(storeKey: string): void {
+  const store = load()
+  store[storeKey] = todayKey()
+  save(store)
+}


### PR DESCRIPTION
## Summary

Round 3 of the hub item economy (#1847, #1848): two new player tools, a dig mechanic, and the first multi-item and relationship-reward trades.

### 🥅 Catching Net (Saltmere Net Loft, 60💎, unique)
Tapping an ambient **butterfly** (day) or **firefly** (night) while holding the net offers a swing: 60% catches it into the inventory, 40% it escapes. New buyers:
- **Master Fenwick** (capital academy) pays 20💎 per butterfly for the lepidoptery cabinet.
- **Little Pip** (Gravemoor's child ghost) trades his hoard — 30💎 **plus friendship XP** — for a jar of firefly light. First use of the new `giveFriendship` trade reward.

### ⛏️ Spade (Gearford Tool Shop, 80💎, unique)
Unlocks six **once-per-day dig spots** — visible patches of soft earth in Appleford, Millhaven, and Thornwood Camp. Digging rolls: 50% worms (+2 fish bait, feeding the round-1 fishing loop), 30% buried crystals (10–25), 20% a dug-up trinket collectible. New `dig` interactable reaction + `web/src/game/hub/digs.ts` daily-cooldown store (unit-tested).

### Deeper trades — `tradeHubItem` extensions
Backwards-compatible new fields: `wantItems` (all-or-nothing multi-item recipes), `giveFriendship`, `giveRelationship`.
- **Innkeep Rosalind** (capital grand inn): breakfast platter — 2 eggs + 1 smoked herring → 45💎. First multi-item recipe, with cross-town sourcing.
- **Lady Cora** (capital): accepts the poetry book as a gift — 20💎 **plus 6 romance-track points**. The poetry book's second, more interesting use.

### Docs
`docs/hubworld.md`: `dig` added to the §7 reaction table, the new trade fields to §7b, `digs.ts` to the file map, and the §16 network list extended.

## Testing
- `npm run test`: **927 tests passing across 199 files** (new `digs.test.ts`; loader tests parse every modified town config/questDefs).
- `npm run build` (tsc + vite): clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HFBFbZdCft98Dbr1WdRHoT

---
_Generated by [Claude Code](https://claude.ai/code/session_01HFBFbZdCft98Dbr1WdRHoT)_