### PR TITLE
Move Commander/Warlord/Boss Fragment stats into cards.json templates

### DIFF
--- a/web/src/data/cards.json
+++ b/web/src/data/cards.json
@@ -1,5 +1,37 @@
 {
   "templates": {
+    "commander": {
+      "name": "Commander",
+      "attack": 15,
+      "maxHp": 1,
+      "isWall": false,
+      "bypassWall": false,
+      "moveSpeed": 8,
+      "attackRange": 35,
+      "attackCooldownMs": 2000,
+      "size": "large"
+    },
+    "warlord": {
+      "name": "Warlord",
+      "attack": 15,
+      "maxHp": 1,
+      "isWall": false,
+      "bypassWall": false,
+      "moveSpeed": 8,
+      "attackRange": 35,
+      "attackCooldownMs": 2000,
+      "size": "large"
+    },
+    "boss-fragment": {
+      "name": "Boss Fragment",
+      "attack": 4,
+      "maxHp": 1,
+      "isWall": false,
+      "bypassWall": true,
+      "moveSpeed": 0,
+      "attackRange": 140,
+      "attackCooldownMs": 2500
+    },
     "goblin": {
       "name": "Goblin",
       "attack": 3,

--- a/web/src/game/cards.ts
+++ b/web/src/game/cards.ts
@@ -180,6 +180,10 @@ export const GOBLIN_UNIT  = TEMPLATES['goblin']  as UnitTemplate
 export const ARCHER_UNIT  = TEMPLATES['archer']  as UnitTemplate
 export const DRAGON_UNIT  = TEMPLATES['dragon']  as UnitTemplate
 
+export const COMMANDER_UNIT     = TEMPLATES['commander']     as UnitTemplate
+export const WARLORD_UNIT       = TEMPLATES['warlord']       as UnitTemplate
+export const BOSS_FRAGMENT_UNIT = TEMPLATES['boss-fragment'] as UnitTemplate
+
 // ─── Hero Cards ───────────────────────────────────────────
 // One hero is randomly injected into each player's deck per game.
 

--- a/web/src/game/engine/bossTraits.ts
+++ b/web/src/game/engine/bossTraits.ts
@@ -2,6 +2,7 @@ import { GameState, Unit, BossTraitState, LANE_WIDTH } from '../types'
 import { PLAYER_SPAWN_X, OPPONENT_SPAWN_X } from './constants'
 import { LANE_POSITIONS, spawnUnit } from './helpers'
 import { getBossAIDef, BossTraitDef } from './boss'
+import { BOSS_FRAGMENT_UNIT } from '../cards'
 
 export const TRAIT_TILE_PX = 40  // 1 "tile" in trait radius = one lane-spacing in px
 
@@ -105,11 +106,7 @@ function fireSplitTrait(s: GameState, trait: BossTraitDef, log: string[]): void 
   const splitIds: string[] = []
   for (let i = 0; i < count; i++) {
     const pos = positions[i] ?? { x: OPPONENT_SPAWN_X - 40, y: 0 }
-    const frag = spawnUnit({
-      name: 'Boss Fragment', attack: 4, maxHp: hpEach,
-      isWall: false, bypassWall: true,
-      moveSpeed: 0, attackRange: 140, attackCooldownMs: 2500,
-    }, 'opponent')
+    const frag = spawnUnit({ ...BOSS_FRAGMENT_UNIT, maxHp: hpEach }, 'opponent')
     frag.x = pos.x
     frag.y = pos.y
     splitIds.push(frag.id)

--- a/web/src/game/engine/helpers.ts
+++ b/web/src/game/engine/helpers.ts
@@ -1,7 +1,7 @@
 import { logError } from '../../logger';
 import { Card, UnitTemplate, Unit, LANE_WIDTH } from '../types';
 import { rollSecretRarity, makeShinyVariant, makeHolofoilVariant, makeGlassVariant } from '../secretRarities';
-import { getCardCatalog } from '../cards';
+import { getCardCatalog, COMMANDER_UNIT, WARLORD_UNIT } from '../cards';
 import { PLAYER_SPAWN_X, OPPONENT_SPAWN_X, COMMANDER_HOME_X } from './constants';
 
 // ─── Helpers ─────────────────────────────────────────────
@@ -98,12 +98,8 @@ export function spawnUnit(template: UnitTemplate, owner: 'player' | 'opponent'):
 
 export function spawnCommander(owner: 'player' | 'opponent', hp: number): Unit {
   const homeX = owner === 'player' ? COMMANDER_HOME_X : LANE_WIDTH - COMMANDER_HOME_X
-  const unit = spawnUnit(
-    { name: owner === 'player' ? 'Commander' : 'Warlord',
-      attack: 15, maxHp: hp, isWall: false, bypassWall: false,
-      moveSpeed: 8, attackRange: 35, attackCooldownMs: 2000, size: 'large' },
-    owner
-  )
+  const template = owner === 'player' ? COMMANDER_UNIT : WARLORD_UNIT
+  const unit = spawnUnit({ ...template, maxHp: hp }, owner)
   unit.isCommander    = true
   unit.commanderHomeX = homeX
   unit.x              = homeX


### PR DESCRIPTION
## Summary
- Extracts the hardcoded "Commander"/"Warlord" unit stats (`web/src/game/engine/helpers.ts`) and "Boss Fragment" unit stats (`web/src/game/engine/bossTraits.ts`) into named templates in `cards.json`, matching the data-driven pattern every other unit in the game already follows.
- Adds `commander`, `warlord`, and `boss-fragment` entries to the `templates` object in `web/src/data/cards.json`.
- Exports `COMMANDER_UNIT`, `WARLORD_UNIT`, `BOSS_FRAGMENT_UNIT` from `web/src/game/cards.ts`, following the existing `GOBLIN_UNIT`/`ARCHER_UNIT`/`DRAGON_UNIT` export pattern.
- `spawnCommander()` and `fireSplitTrait()` now spread the template and override only `maxHp` (which is computed at runtime), instead of duplicating the full stat block inline.
- Pure data relocation — no gameplay/behavior changes.

Closes #1131

## Test plan
- [x] `npm run build` (TypeScript check + Vite build) passes clean
- [x] `npm run test` — all 329 existing tests pass
- [x] Manual smoke test in the browser (Quick Battle → Play Easy): player Commander and opponent Warlord spawn at their correct home positions with intact health bars, matching pre-change behavior; no console/page errors introduced


---
_Generated by [Claude Code](https://claude.ai/code/session_01B4eWFvqJid4TzZQnYJMXDF)_