### PR TITLE
Rewrite README to reflect current game and clarify AI-generated workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,46 +1,28 @@
 # Jarv's Amazing Web Game
 
-A browser-based strategy card game. Deploy units, build structures, and cast upgrades to destroy the enemy base before yours falls.
+A browser-based campaign roguelike: explore a hub-world town, pick your path through a branching act map, and fight real-time card battles to take down each act's boss.
 
-**Play now:** [https://jarvichi.github.io/jarvs-amazing-web-game/](https://jarvichi.github.io/jarvs-amazing-web-game/)
+> ## 🤖 This project is almost entirely AI-generated
+>
+> The code, content, and this README are built and maintained by an AI coding agent (Claude), working from GitHub Issues. There is no expectation that humans read the code or submit pull requests.
+>
+> **If you want to contribute, please [open a GitHub Issue](https://github.com/Jarvichi/jarvs-amazing-web-game/issues)** — a bug report or a feature request. Don't fork the repo to implement an issue yourself; the agent picks up open issues and does the implementation.
 
-## How to Play
+**Play now:** [https://jawg.uk/](https://jawg.uk/)
 
-- Each turn you have **mana** (starts at 3, grows with Farms)
-- Play cards from your hand to **deploy units**, **build structures**, or **cast upgrades**
-- Click **End Turn** — all units fight simultaneously, then the opponent plays their turn
-- **Win** by reducing the enemy base to 0 HP. **Lose** if your base falls.
+## What is this game
 
-## Units
+- **Hub world** — a walkable town with NPCs, quests, shops, and casino-style minigames.
+- **Campaign map** — each act is a branching map of nodes (battle, elite, boss, rest, event, merchant, mystery) that converge before a boss fight.
+- **Real-time card battles** — mana regenerates continuously (no discrete turns). Play cards to deploy units, build structures, and cast upgrades; units then move and fight automatically, guided by a stance you set (auto / attack / hold / defend).
+- **Relics & progression** — relics, lives, and collection/mastery persist across runs even though your deck resets each act.
+- **Minigames** — Tower Defence, City Builder, Fishing, Farming Sim, and several casino games are all reachable from the hub.
 
-| Unit | Cost | Attack | HP | Notes |
-|------|------|--------|----|-------|
-| Goblin | 1 | 2 | 3 | Melee — targets walls first |
-| Archer | 1 | 2 | 3 | Ranged — bypasses walls |
-| Barbarian | 2 | 4 | 4 | Melee — hard-hitting |
-| Knight | 2 | 3 | 7 | Melee — armored tank |
-| Wizard | 3 | 5 | 3 | Ranged — bypasses walls |
-| Dragon | 4 | 8 | 7 | Ranged — bypasses walls |
+For full mechanical detail, see [`AGENTS.md`](AGENTS.md), [`docs/acts.md`](docs/acts.md) (campaign/act structure), and [`docs/hubworld.md`](docs/hubworld.md) (hub-world schemas).
 
-## Structures
+## Cards
 
-| Structure | Cost | HP | Effect |
-|-----------|------|----|--------|
-| Wall | 1 | 10 | Absorbs melee attacks before other units |
-| Farm | 2 | 6 | +1 max mana per turn while standing |
-| Barracks | 3 | 8 | Draw +1 card at the start of each turn |
-
-## Upgrades
-
-| Card | Cost | Effect |
-|------|------|--------|
-| Sharpen Blades | 2 | All your units permanently gain +2 attack |
-| Fortify | 2 | Heal all your units for 4 HP |
-
-## Targeting Rules
-
-- **Melee units** — attack walls first → then other units/structures → then the base
-- **Ranged units** — skip walls, attack other units/structures → then the base
+The card collection has grown to **610 cards** (441 unit templates, plus hero cards) across rarities from common to legendary, with costs, targeting rules, tags, and affinities between cards. The full list lives in [`web/src/data/cards.json`](web/src/data/cards.json).
 
 ## Run Locally
 
@@ -52,4 +34,4 @@ npm run dev
 
 ## Deploy
 
-The game auto-deploys to GitHub Pages when merged to `main` via GitHub Actions.
+The game auto-deploys to the custom domain [jawg.uk](https://jawg.uk/) when merged to `main` via GitHub Actions.


### PR DESCRIPTION
## Summary
- Add an upfront notice that this project is almost entirely AI-generated and that contributions should be filed as GitHub Issues (bug reports / feature requests), not implemented via PRs — several outside contributors had mistakenly tried to pick up and work issues themselves.
- Replace the outdated single-battle "click End Turn" card game description with an accurate summary of the current game: hub-world town, branching per-act campaign map, real-time (tick-based) card battles, relics/progression, and the minigames menu (Tower Defence, City Builder, Fishing, Farming Sim, casino games).
- Update the "Play Now" link to the live custom domain `jawg.uk` (previously pointed at the stale GitHub Pages URL).
- Drop the hardcoded unit/structure/upgrade stat tables, which no longer matched the 610-card collection in `web/src/data/cards.json`, in favor of a short summary and links to `AGENTS.md`, `docs/acts.md`, and `docs/hubworld.md` for full detail.

## Test plan
- [x] Read through the rewritten `README.md` to confirm the AI-generated/contribution notice appears immediately after the title and the Play Now link points at `jawg.uk`.
- [x] Confirmed `docs/acts.md` and `docs/hubworld.md` exist at the referenced paths.
- No code changes — README/doc-only PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qa3QmSC6PdmYWwyqa8k2fA)_