### PR TITLE
Fix minimap NPC pins for virtual sub-rooms (upstairs, crypts, etc.)

### DIFF
--- a/web/src/game/hub/npcLocator.test.ts
+++ b/web/src/game/hub/npcLocator.test.ts
@@ -12,8 +12,11 @@ const loc = {
     { rect: [20, 20, 24, 24], id: 'smithy' }, // no door → footprint centre
   ],
   HUB_INTERIORS: {
-    inn:    { id: 'inn',    name: 'The Sleepy Inn', width: 6, height: 6, decor: [] },
+    inn:    { id: 'inn',    name: 'The Sleepy Inn', width: 6, height: 6, decor: [],
+              exits: [{ tx: 5, ty: 5, toInteriorId: 'inn-upstairs' }] },
     smithy: { id: 'smithy', name: "Smith's Forge",  width: 6, height: 6, decor: [] },
+    'inn-upstairs': { id: 'inn-upstairs', name: 'Inn — Upstairs', width: 6, height: 6, decor: [],
+                      exits: [{ tx: 0, ty: 0, toInteriorId: 'inn' }] },
   },
 } as unknown as HubLocationBundle
 
@@ -28,6 +31,9 @@ describe('buildingWorldTile', () => {
   })
   it('returns null for an unknown building', () => {
     expect(buildingWorldTile('nope', loc)).toBeNull()
+  })
+  it('walks up to the parent building for a virtual sub-room with no footprint of its own', () => {
+    expect(buildingWorldTile('inn-upstairs', loc)).toEqual({ tx: 10, ty: 12 })
   })
 })
 
@@ -44,6 +50,11 @@ describe('resolveNpcPlace', () => {
   it('maps a scheduled interior NPC to the building world door, not interior-local coords', () => {
     const npc: HubNpc = { ...base, schedule: [{ startHour: 6, endHour: 20, location: { type: 'interior', buildingId: 'inn', tx: 1, ty: 1 } }] }
     expect(resolveNpcPlace(npc, 12, loc)).toEqual({ name: 'The Sleepy Inn', tx: 10, ty: 12, interiorId: 'inn' })
+  })
+
+  it('maps a scheduled NPC in a virtual sub-room to the parent building door, not the sub-room local coords', () => {
+    const npc: HubNpc = { ...base, schedule: [{ startHour: 0, endHour: 8, location: { type: 'interior', buildingId: 'inn-upstairs', tx: 1, ty: 1 } }] }
+    expect(resolveNpcPlace(npc, 2, loc)).toEqual({ name: 'Inn — Upstairs', tx: 10, ty: 12, interiorId: 'inn-upstairs' })
   })
 
   it('maps a building NPC with no schedule to the building world position', () => {

--- a/web/src/game/hub/npcLocator.ts
+++ b/web/src/game/hub/npcLocator.ts
@@ -25,15 +25,27 @@ export function areaNameForTile(tx: number, ty: number, areas: HubArea[]): strin
  * World-map tile to point at for a building interior. Interior schedule/base
  * coordinates are local to the interior grid, not the town map, so for map pins we
  * use the building's exterior position: its door (entrance) if known, otherwise the
- * footprint centre. Returns null if the building can't be located on the map.
+ * footprint centre. Some interiors are "virtual" sub-rooms (an inn's upstairs floor,
+ * a keep's crypt, ...) with no footprint/door of their own — only reachable via a
+ * parent interior's `exits`. For those we walk up to the owning interior instead.
+ * Returns null if no real building can be found anywhere up the chain.
  */
 export function buildingWorldTile(buildingId: string, loc: HubLocationBundle): { tx: number; ty: number } | null {
-  const door = loc.HUB_DOORS.find(d => d.buildingId === buildingId)
-  if (door) return { tx: door.tx, ty: door.ty }
-  const building = loc.HUB_BUILDINGS.find(b => b.id === buildingId)
-  if (building) {
-    const [tx1, ty1, tx2, ty2] = building.rect
-    return { tx: Math.round((tx1 + tx2) / 2), ty: Math.round((ty1 + ty2) / 2) }
+  const seen = new Set<string>()
+  let current = buildingId
+  while (!seen.has(current)) {
+    seen.add(current)
+    const door = loc.HUB_DOORS.find(d => d.buildingId === current)
+    if (door) return { tx: door.tx, ty: door.ty }
+    const building = loc.HUB_BUILDINGS.find(b => b.id === current)
+    if (building) {
+      const [tx1, ty1, tx2, ty2] = building.rect
+      return { tx: Math.round((tx1 + tx2) / 2), ty: Math.round((ty1 + ty2) / 2) }
+    }
+    const parent = Object.entries(loc.HUB_INTERIORS)
+      .find(([id, interior]) => id !== current && interior.exits?.some(e => e.toInteriorId === current))
+    if (!parent) return null
+    current = parent[0]
   }
   return null
 }


### PR DESCRIPTION
## Summary
- Reported bug: after finishing the collect-items part of Millhaven's "Restocking the Stall" quest, the minimap showed Trader Nessa's pin near the top-left corner of the town instead of over the building she's actually in.
- Root cause: `buildingWorldTile()` (`web/src/game/hub/npcLocator.ts`) only resolves an NPC's map position for buildings that are placed on the town map (via `HUB_DOORS`/`HUB_BUILDINGS`). Many NPC schedules/`homeBed`s point at "virtual" sub-rooms — an inn's upstairs floor, a keep's crypt, a back office — that exist only as `HUB_INTERIORS` entries reached through a parent building's `exits`, with no footprint or door of their own. For those, the lookup returned `null` and the code fell back to treating the sub-room's **local room coordinates** as **absolute world tile coordinates**, pinning the NPC near the map origin (top-left). This is a long-standing latent bug affecting ~30 NPCs across every town whenever their schedule puts them in such a sub-room (e.g. asleep upstairs).
- Fix: `buildingWorldTile` now walks up to the owning parent interior (the one whose `exits` lead into the requested sub-room) until it finds a real placed building, reusing the existing door/footprint resolution. A `seen` set guards against any accidental cycle in the exits graph. This is a single shared fix — no per-town JSON data needed to change.

## Test plan
- [x] `cd web && npm run test` — all 331 tests pass (added 2 new cases to `npcLocator.test.ts` covering a virtual sub-room resolving to its parent building's door, both directly via `buildingWorldTile` and through `resolveNpcPlace`)
- [x] `cd web && npm run build` — TypeScript check + Vite build pass clean
- [ ] Manual in-game check: load Millhaven, observe Trader Nessa's minimap/Town Directory pin during her sleep hours (now over `inn-millhaven`'s door) vs. work hours (over `market-hall`, unaffected)

https://claude.ai/code/session_01S62bEdoqeEv4F5xMSVhPpT


---
_Generated by [Claude Code](https://claude.ai/code/session_01S62bEdoqeEv4F5xMSVhPpT)_