### PR TITLE
Hub item economy round 4: lantern night hollows, festival & reputation gated trades

### DIFF
--- a/docs/hubworld.md
+++ b/docs/hubworld.md
@@ -290,8 +290,8 @@ bounds, else a single tile.
 | `move` | `to: {tx, ty}`, `message?` | Moves the owned decor to the target tile, live and persisted across reloads. Requires owned `decor`. |
 | `buy` | `slotIndex` | Sells the interactable's building's Nth daily-rotating shop-stock item (`getTodaysShopItems`, `SHOP_TRADER_REGISTRY`). Shares `DailyShopState` with `ShopScreen`, so both draw down the same stock. Requires `building`. |
 | `buyPack` | — | Crystal-pack purchase flow (delegates to `onBuyCrystalPack`). Requires `building`. |
-| `buyHubItem` | `itemId`, `price`, `currency?`, `speakerName?` | Always-available hub-item purchase (no daily rotation) — see §16. `itemId` must exist in `hubItems.json`; `currency` is `'crystals'` (default) or `'tickets'`. Unique items (e.g. the fishing rod) re-offer as "already owned" once bought. `speakerName` overrides the building-NPC speaker (useful for exterior stalls). |
-| `dig` | `requiresItemId?` | Once-per-day dig spot (see §16), gated on holding the tool hub-item (default `'spade'`). Rolls 50% worms (+2 fish bait) / 30% crystals (10–25) / 20% a dug-up trinket collectible. Cooldown persists per spot per real day in `jarv_hub_digs` (`web/src/game/hub/digs.ts`). Pair with a `mediumDirt` decor tile (`zlayer: "below"`) for a visible earth patch. |
+| `buyHubItem` | `itemId`, `price`, `currency?`, `speakerName?`, `prerequisite?`, `lockedText?` | Always-available hub-item purchase (no daily rotation) — see §16. `itemId` must exist in `hubItems.json`; `currency` is `'crystals'` (default) or `'tickets'`. Unique items (e.g. the fishing rod) re-offer as "already owned" once bought. `speakerName` overrides the building-NPC speaker (useful for exterior stalls). `prerequisite` (§14 syntax, including `reputation:<tier>`) gates the offer — unmet shows `lockedText` (or a default refusal) instead. |
+| `dig` | `requiresItemId?`, `nightOnly?`, `lootTable?` | Once-per-day dig spot (see §16), gated on holding the tool hub-item (default `'spade'`). `nightOnly: true` makes it a **dark hollow** that refuses by day. `lootTable: 'earth'` (default) rolls 50% worms (+2 fish bait) / 30% crystals (10–25) / 20% a dug-up trinket; `'hollow'` rolls 50% glowcap mushroom / 25% crystals (15–35) / 25% a firefly. Cooldown persists per spot per real day in `jarv_hub_digs` (`web/src/game/hub/digs.ts`). Pair with a `mediumDirt` decor tile (`zlayer: "below"`) for a visible earth patch. |
 
 Reactions run in order; `dialogue` (and `message`-bearing reactions) chain the
 remainder through the dialogue's close. Conventions: at most one `screen` or
@@ -418,6 +418,7 @@ Then on the NPC (in `config.json`): `"dialogueTree": "scholar-chat"` (keep a
 | `effects` | `DialogueEffect[]`? | Run in order before navigation. |
 | `requireFlag` | string? | Choice only shown if the flag is set. |
 | `hideIfFlag` | string? | Choice hidden once the flag is set. |
+| `requireFestival` | string? | Choice only shown while that festival is active (§14 festival ids, e.g. `"midsummer"`). |
 
 #### `DialogueEffect` types
 | `type` | Fields | Behaviour |
@@ -1204,6 +1205,10 @@ joined with `|` (all must hold), parsed by `checkPrerequisite` in
 quest:<questId>                       // that quest is completed
 friendship:<npcId>:<level>            // friendship ≥ level
 relationship:<npcId>:<track>:<level>  // relationship track at ≥ level
+flag:<flag>                           // that dialogue flag is set (§7b)
+reputation:<tier>                     // current town's reputation tier ≥ tier (§10);
+                                      // only meaningful where a town is in scope
+                                      // (quest gates, buyHubItem prerequisites)
 ```
 
 Example: `"quest:millhaven-mill-grain | friendship:innkeeper-rosie:2"`.
@@ -1347,7 +1352,9 @@ harbour stalls), Fancy Hat + Sturdy Boots (capital tailor), honey cake /
 lavender tonic / silk ribbon (capital bakery / apothecary / Grand Market
 Hall), smoked herring + bones (Saltmere fish market / smokehouse), bog salve
 (Hollowmere apothecary), spice pouch (Ravenwatch Merchant's Guild Hall),
-catching net (Saltmere Net Loft), spade (Gearford Tool Shop).
+catching net (Saltmere Net Loft), spade (Gearford Tool Shop), storm lantern
+(Saltmere Chandlery), gilded compass (Ravenwatch Guild Hall,
+`reputation:2`-gated).
 
 ### Trading hub items — `tradeHubItem` (§7b dialogue effects)
 
@@ -1371,7 +1378,15 @@ Pearl (Saltmere) ← any caught fish → tier-priced crystals · Master Fenwick
 (capital) ← butterfly, 20💎 · Little Pip (Gravemoor) ← firefly, 30💎 +
 friendship · Innkeep Rosalind (capital) ← 2 eggs + smoked herring →
 45💎 (multi-item recipe) · Lady Cora (capital) ← poetry book → 20💎 +
-romance points.
+romance points · Hedge-Witch Morwen (Hollowmere) ← 2 glowcap mushrooms →
+moon draught · The Restless Soldier (Gravemoor) ← moon draught → 80💎 +
+friendship · Busker Lyle (capital) ← butterfly → 35💎 **during Midsummer
+only** (`requireFestival`) · Lighthouse Keeper Wren (Saltmere) ← gilded
+compass → 160💎.
+
+The longest chain: lantern (Chandlery) → dark hollow at night → glowcaps →
+Morwen's moon draught → the Restless Soldier's first sleep in centuries —
+4 hops across 3 towns, night-gated.
 
 ### Feeding ambient animals
 

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -54,6 +54,7 @@ import { HubInteractable, HubLocationBundle, HubQuestBundle, HubTreasure } from 
 import { getUnreadCount } from '../../game/news'
 import { interactableStoreKey, isInteractableGranted, markInteractableGranted, getInteractableMoves, setInteractableMove } from '../../game/hub/interactables'
 import { canDigToday, recordDig } from '../../game/hub/digs'
+import { getReputationTier } from '../../data/hub/buildingUpgrades'
 import { recordNpcMet, recordAnimalSeen, recordAreaSeen } from '../../game/hub/journal'
 import { getTodaysShopItems } from '../../game/hub/shopStock'
 import { loadDailyShopState, saveDailyShopState, isShopItemSold, markCardBought, markAugmentBought } from '../../game/shopSchedule'
@@ -73,7 +74,7 @@ let _hubSplashShown = false
 
 
 
-function checkPrerequisite(prereq: string): boolean {
+function checkPrerequisite(prereq: string, town?: string): boolean {
   return prereq.split('|').every(p => {
     const part = p.trim()
     if (part.startsWith('friendship:')) {
@@ -91,6 +92,12 @@ function checkPrerequisite(prereq: string): boolean {
     }
     if (part.startsWith('flag:')) {
       return hasDialogueFlag(part.slice(5))
+    }
+    if (part.startsWith('reputation:')) {
+      // reputation:<tier> — current town's reputation tier (§10) at or above
+      // <tier>. Callers without town context treat it as satisfied.
+      if (!town) return true
+      return getReputationTier(getTownReputation(town)) >= parseInt(part.slice(11) || '1')
     }
     return true
   })
@@ -831,7 +838,8 @@ function hasOfferableQuest(giverId: string): boolean {
       (!c.requireFlag  || hasDialogueFlag(c.requireFlag)) &&
       (!c.hideIfFlag   || !hasDialogueFlag(c.hideIfFlag)) &&
       (!c.requireQuest || getQuestState(c.requireQuest).status === 'completed') &&
-      (!c.hideIfQuest  || getQuestState(c.hideIfQuest).status !== 'completed')
+      (!c.hideIfQuest  || getQuestState(c.hideIfQuest).status !== 'completed') &&
+      (!c.requireFestival || c.requireFestival === activeFestival?.id)
     )
     const choices: DialogueChoice[] = visible.map((c, i) => ({
       label:   c.label,
@@ -1459,6 +1467,15 @@ function hasOfferableQuest(giverId: string): boolean {
         const onDuty = candidates.find(n => def.building && resolveNpcPlace(n, gameHour, locationData).interiorId === def.building)
         const speakerName = r.speakerName ?? (onDuty ?? candidates[0])?.name ?? ''
 
+        if (r.prerequisite && !checkPrerequisite(r.prerequisite, town)) {
+          setDialogueEvent({
+            speakerName,
+            text: r.lockedText ?? "The shopkeeper sizes you up. 'Not for sale — not to you. Not yet.'",
+            onClose: next,
+          })
+          return
+        }
+
         if (catalog.unique && hasHubItem(r.itemId)) {
           setDialogueEvent({ speakerName, text: `You already own a ${catalog.name} — one is all you'll ever need.`, onClose: next })
           return
@@ -1500,14 +1517,58 @@ function hasOfferableQuest(giverId: string): boolean {
       }
       case 'dig': {
         // Once-per-day dig spot, gated on holding the required tool.
+        // nightOnly spots (dark hollows) only open after dark and roll the
+        // 'hollow' loot table instead of the default 'earth' one.
+        if (r.nightOnly && !isGameNight) {
+          setDialogueEvent({ speakerName: '', text: 'Whatever stirs in this hollow only shows itself after dark.' })
+          return
+        }
         const toolId = r.requiresItemId ?? 'spade'
         const toolName = getHubItemCatalogEntry(toolId)?.name ?? toolId
         if (!hasHubItem(toolId)) {
-          setDialogueEvent({ speakerName: '', text: `The earth is soft here… a ${toolName.toLowerCase()} would make short work of it.` })
+          setDialogueEvent({ speakerName: '', text: r.nightOnly
+            ? `The hollow is pitch dark. A ${toolName.toLowerCase()} would reveal what hides inside.`
+            : `The earth is soft here… a ${toolName.toLowerCase()} would make short work of it.` })
           return
         }
         if (!canDigToday(storeKey)) {
-          setDialogueEvent({ speakerName: '', text: "You've already turned this earth over today. Let it settle until tomorrow." })
+          setDialogueEvent({ speakerName: '', text: r.nightOnly
+            ? 'The hollow has given up all it will tonight. Return tomorrow night.'
+            : "You've already turned this earth over today. Let it settle until tomorrow." })
+          return
+        }
+        if (r.lootTable === 'hollow') {
+          const confirm: DialogueChoice = {
+            label: 'Search by lantern-light',
+            primary: true,
+            onClick: () => {
+              recordDig(storeKey)
+              const roll = Math.random()
+              let text: string
+              if (roll < 0.5) {
+                addHubItem('glowcap-mushroom', 1)
+                emitSound('pickup')
+                text = 'Lantern-light catches a soft blue gleam — a glowcap mushroom, plucked whole. 🍄'
+              } else if (roll < 0.75) {
+                const amount = 15 + Math.floor(Math.random() * 21) // 15–35
+                saveCrystals(loadCrystals() + amount)
+                onCrystalsChange?.(loadCrystals())
+                emitSound('treasure')
+                text = `Crystals glitter in the dark of the hollow — ${amount} of them. 💎`
+              } else {
+                addHubItem('firefly', 1)
+                emitSound('pickup')
+                text = 'Something glowing darts straight into your jar — a firefly, saving you the netting. ✨'
+              }
+              refreshState()
+              setDialogueEvent({ speakerName: '', text, onClose: next })
+            },
+          }
+          setDialogueEvent({
+            speakerName: '',
+            text: 'A deep, dark hollow. Your lantern pushes the shadows back just enough.',
+            choices: [confirm, { label: 'Leave it', onClick: () => setDialogueEvent(null) }],
+          })
           return
         }
         const confirm: DialogueChoice = {

--- a/web/src/data/hub/capitalcity/config.json
+++ b/web/src/data/hub/capitalcity/config.json
@@ -4809,6 +4809,7 @@
     {
       "id": "busker-lyle",
       "name": "Busker Lyle",
+      "dialogueTree": "lyle-festival-butterflies",
       "sprite": "hub-npc-merchant",
       "tx": 50,
       "ty": 49,

--- a/web/src/data/hub/capitalcity/questDefs.json
+++ b/web/src/data/hub/capitalcity/questDefs.json
@@ -1,6 +1,40 @@
 {
   "dialogues": [
     {
+      "id": "lyle-festival-butterflies",
+      "npcId": "busker-lyle",
+      "start": "greet",
+      "nodes": {
+        "greet": {
+          "text": "Roll up, roll up! Busker Lyle, entertainer to crowds and occasional pigeons. Come festival season I pay top coin for anything that makes an audience gasp.",
+          "choices": [
+            {
+              "label": "Sell a butterfly for the fair — 35 💎",
+              "requireFestival": "midsummer",
+              "next": "greet",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "butterfly",
+                  "giveCrystals": 35,
+                  "missingText": "No butterflies on you! The fair crowd waits for no one — get netting.",
+                  "successText": "Released at the crescendo of his act — the crowd GASPS. 'Magnifique!' 35 crystals, fair rates."
+                }
+              ]
+            },
+            {
+              "label": "Break a leg, Lyle.",
+              "effects": [
+                {
+                  "type": "end"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    {
       "id": "fenwick-butterfly-trade",
       "npcId": "academy-master",
       "start": "greet",

--- a/web/src/data/hub/gravemoor/config.json
+++ b/web/src/data/hub/gravemoor/config.json
@@ -1254,6 +1254,7 @@
     {
       "id": "restless-soldier",
       "name": "The Restless Soldier",
+      "dialogueTree": "soldier-draught-trade",
       "sprite": "hub-npc-soldier",
       "isGhost": true,
       "tx": 37,
@@ -2559,6 +2560,27 @@
     }
   },
   "interactables": [
+    {
+      "id": "gravemoor-hollow",
+      "tx": 17,
+      "ty": 29,
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "tileId": "mediumDirt",
+          "zlayer": "below"
+        }
+      ],
+      "reactions": [
+        {
+          "type": "dig",
+          "requiresItemId": "lantern",
+          "nightOnly": true,
+          "lootTable": "hollow"
+        }
+      ]
+    },
     {
       "id": "undertaker-item-0",
       "tx": 8,

--- a/web/src/data/hub/gravemoor/questDefs.json
+++ b/web/src/data/hub/gravemoor/questDefs.json
@@ -1,6 +1,42 @@
 {
   "dialogues": [
     {
+      "id": "soldier-draught-trade",
+      "npcId": "restless-soldier",
+      "start": "greet",
+      "nodes": {
+        "greet": {
+          "text": "Three hundred years of watch and no relief has ever come. I don't remember what sleep feels like. The witch across the marsh brews something, they say. Something that works even on… the likes of me.",
+          "choices": [
+            {
+              "label": "Offer the moon draught",
+              "next": "greet",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "moon-draught",
+                  "giveCrystals": 80,
+                  "giveFriendship": {
+                    "xp": 5
+                  },
+                  "missingText": "You carry no such brew. Hedge-Witch Morwen of Hollowmere makes it — for a pair of glowcaps, they say.",
+                  "successText": "He drinks. For the first time in centuries, his shoulders lower. 'Relief… at last.' He presses his entire back-pay — 80 crystals — into your hands and sits down to rest."
+                }
+              ]
+            },
+            {
+              "label": "Stand easy, soldier.",
+              "effects": [
+                {
+                  "type": "end"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    {
       "id": "pip-firefly-trade",
       "npcId": "little-pip",
       "start": "greet",

--- a/web/src/data/hub/hollowmere/config.json
+++ b/web/src/data/hub/hollowmere/config.json
@@ -1183,6 +1183,7 @@
     {
       "id": "hedge-witch-morwen",
       "name": "Hedge-Witch Morwen",
+      "dialogueTree": "morwen-draught-brew",
       "sprite": "hub-npc-scholar",
       "tx": 5,
       "ty": 4,
@@ -1983,6 +1984,27 @@
     }
   },
   "interactables": [
+    {
+      "id": "hollowmere-hollow",
+      "tx": 29,
+      "ty": 12,
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "tileId": "mediumDirt",
+          "zlayer": "below"
+        }
+      ],
+      "reactions": [
+        {
+          "type": "dig",
+          "requiresItemId": "lantern",
+          "nightOnly": true,
+          "lootTable": "hollow"
+        }
+      ]
+    },
     {
       "id": "apothecary-salve-shelf",
       "tx": 3,

--- a/web/src/data/hub/hollowmere/questDefs.json
+++ b/web/src/data/hub/hollowmere/questDefs.json
@@ -1,4 +1,42 @@
 {
+  "dialogues": [
+    {
+      "id": "morwen-draught-brew",
+      "npcId": "hedge-witch-morwen",
+      "start": "greet",
+      "nodes": {
+        "greet": {
+          "text": "You smell of lantern oil and night air. Good. Bring me a matched pair of glowcaps from the dark hollows and I'll brew you a moon draught — sleep in a bottle, potent enough to quiet even the restless dead.",
+          "choices": [
+            {
+              "label": "Brew a moon draught (2 glowcaps)",
+              "next": "greet",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "glowcap-mushroom",
+                  "wantCount": 2,
+                  "giveHubItem": {
+                    "itemId": "moon-draught"
+                  },
+                  "missingText": "That's not a matched pair. Glowcaps grow in the dark hollows — Gravemoor, our own marsh, the Thornwood — but only show by lantern-light, after dark.",
+                  "successText": "The cauldron drinks them down and turns the colour of moonlight. One moon draught, bottled. Mind who you give it to."
+                }
+              ]
+            },
+            {
+              "label": "Another night, Morwen.",
+              "effects": [
+                {
+                  "type": "end"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
   "quests": [
     {
       "id": "hollowmere-witch-brew",

--- a/web/src/data/hub/loader.ts
+++ b/web/src/data/hub/loader.ts
@@ -274,11 +274,14 @@ export type HubInteractableReaction =
   | { type: 'buyPack' }
   /** Always-available hub-item purchase (no daily stock rotation). itemId must
    *  exist in web/src/data/hubItems.json; unique items re-offer as "already
-   *  owned" once bought. */
-  | { type: 'buyHubItem'; itemId: string; price: number; currency?: 'crystals' | 'tickets'; speakerName?: string }
+   *  owned" once bought. `prerequisite` (§14 syntax, incl. reputation:<tier>)
+   *  gates the offer; unmet shows `lockedText`. */
+  | { type: 'buyHubItem'; itemId: string; price: number; currency?: 'crystals' | 'tickets'; speakerName?: string; prerequisite?: string; lockedText?: string }
   /** Once-per-day dig spot: gated on holding the required tool hub-item
-   *  (default 'spade'); rolls worms (fish bait), crystals, or a trinket. */
-  | { type: 'dig'; requiresItemId?: string }
+   *  (default 'spade'); `nightOnly` spots open after dark only. lootTable
+   *  'earth' (default) rolls worms/crystals/trinket; 'hollow' rolls
+   *  glowcaps/crystals/fireflies. */
+  | { type: 'dig'; requiresItemId?: string; nightOnly?: boolean; lootTable?: 'earth' | 'hollow' }
 
 export interface HubInteractable {
   id: string

--- a/web/src/data/hub/questDefs.ts
+++ b/web/src/data/hub/questDefs.ts
@@ -243,6 +243,7 @@ export interface DialogueChoiceDef {
   effects?: DialogueEffect[]
   requireFlag?: string     // only show this choice if the flag is set
   hideIfFlag?: string      // hide this choice once the flag is set
+  requireFestival?: string // only show this choice while that festival is active (hubCalendar)
   requireQuest?: string    // only show this choice once that quest is completed
   hideIfQuest?: string     // hide this choice once that quest is completed
 }

--- a/web/src/data/hub/ravenwatch/config.json
+++ b/web/src/data/hub/ravenwatch/config.json
@@ -9400,6 +9400,21 @@
   ],
   "interactables": [
     {
+      "id": "guild-compass-case",
+      "tx": 11,
+      "ty": 2,
+      "building": "traders-building",
+      "reactions": [
+        {
+          "type": "buyHubItem",
+          "itemId": "gilded-compass",
+          "price": 120,
+          "prerequisite": "reputation:2",
+          "lockedText": "Guild regulations, friend — premium stock is reserved for townsfolk of standing. Raise your name in Ravenwatch first."
+        }
+      ]
+    },
+    {
       "id": "guild-spice-chest",
       "tx": 10,
       "ty": 2,

--- a/web/src/data/hub/saltmereport/config.json
+++ b/web/src/data/hub/saltmereport/config.json
@@ -1673,6 +1673,7 @@
     {
       "id": "lighthouse-keeper",
       "name": "Lighthouse Keeper Wren",
+      "dialogueTree": "wren-compass-trade",
       "sprite": "hub-npc-elder",
       "tx": 30,
       "ty": 14,
@@ -2467,6 +2468,26 @@
     }
   },
   "interactables": [
+    {
+      "id": "chandlery-lantern",
+      "tx": 5,
+      "ty": 1,
+      "building": "chandlers",
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "tileId": "floorLantern"
+        }
+      ],
+      "reactions": [
+        {
+          "type": "buyHubItem",
+          "itemId": "lantern",
+          "price": 90
+        }
+      ]
+    },
     {
       "id": "net-loft-net",
       "tx": 6,

--- a/web/src/data/hub/saltmereport/questDefs.json
+++ b/web/src/data/hub/saltmereport/questDefs.json
@@ -1,6 +1,39 @@
 {
   "dialogues": [
     {
+      "id": "wren-compass-trade",
+      "npcId": "lighthouse-keeper",
+      "start": "greet",
+      "nodes": {
+        "greet": {
+          "text": "Every instrument in this lighthouse is older than my grandmother's grudges. What I'd give for a proper gilded compass — the Ravenwatch guild certifies them, but they won't sell to outsiders.",
+          "choices": [
+            {
+              "label": "Present the gilded compass",
+              "next": "greet",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "gilded-compass",
+                  "giveCrystals": 160,
+                  "missingText": "You've no such instrument. The Merchant's Guild Hall in Ravenwatch keeps them under glass — for those the town holds in high standing.",
+                  "successText": "She checks it against true north and actually smiles. 'Perfect swing. The strait just got safer.' 160 crystals, keeper's honour."
+                }
+              ]
+            },
+            {
+              "label": "Keep the light burning.",
+              "effects": [
+                {
+                  "type": "end"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    {
       "id": "vane-hat-trade",
       "npcId": "harbourmaster-vane",
       "start": "greet",

--- a/web/src/data/hub/thornwoodcamp/config.json
+++ b/web/src/data/hub/thornwoodcamp/config.json
@@ -529,6 +529,27 @@
   "interiors": {},
   "interactables": [
     {
+      "id": "thornwood-hollow",
+      "tx": 17,
+      "ty": 41,
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "tileId": "mediumDirt",
+          "zlayer": "below"
+        }
+      ],
+      "reactions": [
+        {
+          "type": "dig",
+          "requiresItemId": "lantern",
+          "nightOnly": true,
+          "lootTable": "hollow"
+        }
+      ]
+    },
+    {
       "id": "thornwood-dig-1",
       "reactions": [
         {

--- a/web/src/data/hubItems.json
+++ b/web/src/data/hubItems.json
@@ -183,5 +183,34 @@
     "icon": "✨",
     "desc": "A jar of living light, caught after dark. Someone in a gloomy town might treasure it.",
     "category": "material"
+  },
+  {
+    "id": "lantern",
+    "name": "Storm Lantern",
+    "icon": "🏮",
+    "desc": "A chandler's storm lantern. Dark hollows around the realm only give up their secrets by its light.",
+    "category": "tool",
+    "unique": true
+  },
+  {
+    "id": "glowcap-mushroom",
+    "name": "Glowcap Mushroom",
+    "icon": "🍄",
+    "desc": "A softly glowing mushroom from a night hollow. Hedge-witches prize a matched pair.",
+    "category": "material"
+  },
+  {
+    "id": "moon-draught",
+    "name": "Moon Draught",
+    "icon": "🌙",
+    "desc": "Morwen's brew of paired glowcaps. Grants deep, dreamless rest — even to those long past sleeping.",
+    "category": "material"
+  },
+  {
+    "id": "gilded-compass",
+    "name": "Gilded Compass",
+    "icon": "🧭",
+    "desc": "Guild-certified and gimballed in gold. Lighthouse keepers would pay dearly for one.",
+    "category": "material"
   }
 ]


### PR DESCRIPTION
## Summary

Round 4 of the hub item economy (#1847–#1849): night content behind a new lantern tool, the game's longest trade chain, and two new gating primitives (festival- and reputation-gated content).

### 🏮 Storm Lantern → dark hollows → the longest chain
- **The Ship's Chandlery** (Saltmere Port) sells a Storm Lantern (90💎, unique).
- Three **dark hollows** (Gravemoor, Hollowmere, Thornwood Camp) are night-only dig spots — they refuse by day, refuse without the lantern, and once per night roll: 50% glowcap mushroom / 25% crystals (15–35) / 25% a firefly. Implemented as `nightOnly` + `lootTable: 'hollow'` extensions to the round-3 `dig` reaction (cooldown store reused unchanged).
- **Hedge-Witch Morwen** (Hollowmere) brews two glowcaps into a **Moon Draught**; **The Restless Soldier** (Gravemoor) trades 80💎 + friendship for his first sleep in three centuries. Full chain: lantern → hollow at night → glowcaps → witch's brew → soldier's rest — 4 hops across 3 towns, night-gated.

### 🏮 Festival-gated trades
Dialogue choices gain `requireFestival`. **Busker Lyle** (capital) buys butterflies at a premium (35💎 vs Fenwick's 20) — but only while the Midsummer Fair is active. Previewable with the existing `setFestivalOverride('midsummer')` QA hook.

### 🏛️ Reputation-gated shop stock
- `checkPrerequisite` gains a `reputation:<tier>` token (current town's §10 reputation tier).
- `buyHubItem` gains `prerequisite`/`lockedText`: the Ravenwatch Guild Hall's **Gilded Compass** (120💎) refuses to sell below town reputation tier 2 — invest in Ravenwatch upgrades to unlock it. **Lighthouse Keeper Wren** (Saltmere) pays 160💎 for it.

### Docs
`docs/hubworld.md`: §7 `dig`/`buyHubItem` rows extended, §7b gains `requireFestival`, §14 prerequisite syntax gains `flag:`/`reputation:` entries, §16 network list updated with the new chain and trades.

## Testing
- `npm run test`: **929 tests passing across 199 files** (loader tests parse every modified town config/questDefs).
- `npm run build` (tsc + vite): clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HFBFbZdCft98Dbr1WdRHoT

---
_Generated by [Claude Code](https://claude.ai/code/session_01HFBFbZdCft98Dbr1WdRHoT)_