### PR TITLE
fix(millhaven): move fresh-fish bounty pickup out of the fishmonger building

### DIFF
--- a/web/src/data/hub/millhaven/questDefs.json
+++ b/web/src/data/hub/millhaven/questDefs.json
@@ -641,7 +641,7 @@
     },
     {
       "id": "fresh-fish-millhaven",
-      "tx": 25,
+      "tx": 31,
       "ty": 10,
       "tileId": "mushroomBasket"
     },


### PR DESCRIPTION
## Summary
- The "A Fresh Catch for the Inn" bounty (`fresh-fish-for-the-kitchen`) requires collecting the `fresh-fish-millhaven` pickup, which was placed at tile (25,10) — inside the fishmonger building's footprint (rect `[24,6,30,12]`).
- Because the pickup layer renders above the building layer, the item appeared floating on the fishmonger's roof instead of on the docks, making it effectively impossible to spot/reach during normal play.
- Moved the pickup to tile (31,10), a clear dock tile beside the fishmonger's storefront awning, consistent with where the other fish-basket pickups in Millhaven are placed.

## Test plan
- [x] `npm run build` passes clean
- [x] `npx vitest run src/game/hub/bounties.test.ts src/data/hub/loader.test.ts` — 41 tests passed
- [ ] Manual: accept "A Fresh Catch for the Inn" bounty, walk to Millhaven docks near the fishmonger, confirm the fish pickup is now visible/clickable and completes the collect step


---
_Generated by [Claude Code](https://claude.ai/code/session_01JmL3qeSTNCcJM12PA67nMv)_