### PR TITLE
Hub item economy round 5: seasonal trades, premium stock, first crafting NPC

### DIFF
--- a/docs/hubworld.md
+++ b/docs/hubworld.md
@@ -1382,7 +1382,16 @@ romance points · Hedge-Witch Morwen (Hollowmere) ← 2 glowcap mushrooms →
 moon draught · The Restless Soldier (Gravemoor) ← moon draught → 80💎 +
 friendship · Busker Lyle (capital) ← butterfly → 35💎 **during Midsummer
 only** (`requireFestival`) · Lighthouse Keeper Wren (Saltmere) ← gilded
-compass → 160💎.
+compass → 160💎 · Trader Posy (Appleford) ← 3 eggs → 35💎 **during
+Harvest only** · Sailor Bess (Saltmere) ← 2 smoked herring → 60💎
+**during Midwinter only** (every festival now has a trade) · Net-Maker
+Quill (Saltmere) ← 3 feathers → feather pillow · The Prisoner
+(Ironhold dungeon) ← feather pillow → 55💎 + friendship · Grunda the
+Soaker (Hollowmere) ← music box → 170💎.
+
+Reputation-gated premium stock: gilded compass (Ravenwatch Guild Hall,
+120💎) and music box (capital Grand Market Hall, 130💎), both
+`reputation:2`.
 
 The longest chain: lantern (Chandlery) → dark hollow at night → glowcaps →
 Morwen's moon draught → the Restless Soldier's first sleep in centuries —

--- a/web/src/data/hub/appleford/config.json
+++ b/web/src/data/hub/appleford/config.json
@@ -1308,6 +1308,7 @@
     {
       "id": "market-trader-posy",
       "name": "Trader Posy",
+      "dialogueTree": "posy-harvest-eggs",
       "sprite": "hub-npc-trader",
       "tx": 5,
       "ty": 4,

--- a/web/src/data/hub/appleford/questDefs.json
+++ b/web/src/data/hub/appleford/questDefs.json
@@ -1,6 +1,41 @@
 {
   "dialogues": [
     {
+      "id": "posy-harvest-eggs",
+      "npcId": "market-trader-posy",
+      "start": "greet",
+      "nodes": {
+        "greet": {
+          "text": "Trader Posy, purveyor of whatever the orchard gives and a few things it doesn't. Come Harvest Festival, the market barn pays silly money for fresh eggs — festival cakes wait for no hen.",
+          "choices": [
+            {
+              "label": "Sell 3 eggs — 35 💎 (harvest rate)",
+              "requireFestival": "harvest",
+              "next": "greet",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "egg",
+                  "wantCount": 3,
+                  "giveCrystals": 35,
+                  "missingText": "Fewer than three eggs in that pack. Every pen in the realm is clucking — bring feed.",
+                  "successText": "Festival rates, as promised — 35 crystals. The cake tent thanks you."
+                }
+              ]
+            },
+            {
+              "label": "Just browsing, Posy.",
+              "effects": [
+                {
+                  "type": "end"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    {
       "id": "wren-cake-trade",
       "npcId": "scrumping-wren",
       "start": "greet",

--- a/web/src/data/hub/capitalcity/config.json
+++ b/web/src/data/hub/capitalcity/config.json
@@ -3774,6 +3774,21 @@
   },
   "interactables": [
     {
+      "id": "market-hall-music-box",
+      "tx": 2,
+      "ty": 2,
+      "building": "market-hall-crownhaven",
+      "reactions": [
+        {
+          "type": "buyHubItem",
+          "itemId": "music-box",
+          "price": 130,
+          "prerequisite": "reputation:2",
+          "lockedText": "Guild-grade goods, dear — the capital only trusts its own. Earn your standing first."
+        }
+      ]
+    },
+    {
       "id": "bakery-cake-counter",
       "tx": 3,
       "ty": 2,

--- a/web/src/data/hub/hollowmere/config.json
+++ b/web/src/data/hub/hollowmere/config.json
@@ -1237,6 +1237,7 @@
     {
       "id": "bog-troll-attendant",
       "name": "Grunda the Soaker",
+      "dialogueTree": "grunda-music-box-trade",
       "sprite": "troll",
       "tx": 5,
       "ty": 4,

--- a/web/src/data/hub/hollowmere/questDefs.json
+++ b/web/src/data/hub/hollowmere/questDefs.json
@@ -1,6 +1,39 @@
 {
   "dialogues": [
     {
+      "id": "grunda-music-box-trade",
+      "npcId": "bog-troll-attendant",
+      "start": "greet",
+      "nodes": {
+        "greet": {
+          "text": "Grunda run best bathhouse in three marshes. Only thing missing: nice sound. Patrons soak better with nice sound. Capital sells singing boxes, but capital not sell to troll.",
+          "choices": [
+            {
+              "label": "Present the music box",
+              "next": "greet",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "music-box",
+                  "giveCrystals": 170,
+                  "missingText": "You have no singing box. Grand Market Hall in capital keeps them — for fancy-standing folk only.",
+                  "successText": "Grunda winds it with impossible gentleness. The bathhouse fills with tinkling song. 'Perfect. Grunda pay top mud.' 170 crystals, slightly damp."
+                }
+              ]
+            },
+            {
+              "label": "Enjoy the soak, Grunda.",
+              "effects": [
+                {
+                  "type": "end"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    {
       "id": "morwen-draught-brew",
       "npcId": "hedge-witch-morwen",
       "start": "greet",

--- a/web/src/data/hub/ironholdkeep/config.json
+++ b/web/src/data/hub/ironholdkeep/config.json
@@ -2585,6 +2585,7 @@
     {
       "id": "castle-prisoner",
       "name": "The Prisoner",
+      "dialogueTree": "prisoner-pillow-trade",
       "sprite": "hub-npc-elder",
       "tx": 6,
       "ty": 4,

--- a/web/src/data/hub/ironholdkeep/questDefs.json
+++ b/web/src/data/hub/ironholdkeep/questDefs.json
@@ -1313,6 +1313,42 @@
   ],
   "dialogues": [
     {
+      "id": "prisoner-pillow-trade",
+      "npcId": "castle-prisoner",
+      "start": "greet",
+      "nodes": {
+        "greet": {
+          "text": "Twelve years on this stone shelf. I've made peace with the bars, the damp, the gruel. But stone under the head, every night… that I never got used to.",
+          "choices": [
+            {
+              "label": "Pass the feather pillow through the bars",
+              "next": "greet",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "feather-pillow",
+                  "giveCrystals": 55,
+                  "giveFriendship": {
+                    "xp": 5
+                  },
+                  "missingText": "You have nothing soft to offer. The Net Loft in Saltmere Port sews pillows, for those with feathers to spare.",
+                  "successText": "He holds it like something holy. 'I'd forgotten soft existed.' From under a loose stone, 55 crystals — saved for a bribe he never spent."
+                }
+              ]
+            },
+            {
+              "label": "Keep your head up.",
+              "effects": [
+                {
+                  "type": "end"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    {
       "id": "squire-ribbon-trade",
       "npcId": "castle-squire",
       "start": "greet",

--- a/web/src/data/hub/saltmereport/config.json
+++ b/web/src/data/hub/saltmereport/config.json
@@ -1715,6 +1715,7 @@
     {
       "id": "net-maker",
       "name": "Net-Maker Quill",
+      "dialogueTree": "quill-pillow-craft",
       "sprite": "hub-npc-trader",
       "tx": 4,
       "ty": 3,
@@ -1757,6 +1758,7 @@
     {
       "id": "tavern-sailor",
       "name": "Sailor Bess",
+      "dialogueTree": "bess-midwinter-feast",
       "sprite": "hub-npc-sailor",
       "tx": 9,
       "ty": 5,

--- a/web/src/data/hub/saltmereport/questDefs.json
+++ b/web/src/data/hub/saltmereport/questDefs.json
@@ -1,6 +1,81 @@
 {
   "dialogues": [
     {
+      "id": "bess-midwinter-feast",
+      "npcId": "tavern-sailor",
+      "start": "greet",
+      "nodes": {
+        "greet": {
+          "text": "Sailor Bess — retired from the sea, promoted to the feast committee. At Midwinter this inn feeds every soul in port, and the kitchen inhales smoked herring faster than the smoker can hang them.",
+          "choices": [
+            {
+              "label": "Supply 2 smoked herring — 60 💎",
+              "requireFestival": "midwinter",
+              "next": "greet",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItems": [
+                    {
+                      "itemId": "smoked-herring",
+                      "count": 2
+                    }
+                  ],
+                  "giveCrystals": 60,
+                  "missingText": "That's not a pair of herring. The Fish Market strings them fresh — hurry, the feast won't wait.",
+                  "successText": "Straight to the feast table! 60 crystals, and a seat by the fire if you stay."
+                }
+              ]
+            },
+            {
+              "label": "Happy Midwinter, Bess.",
+              "effects": [
+                {
+                  "type": "end"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "quill-pillow-craft",
+      "npcId": "net-maker",
+      "start": "greet",
+      "nodes": {
+        "greet": {
+          "text": "Nets, sails, hammocks — if it's stitched, I've stitched it. Bring me three good feathers and I'll sew you a pillow soft enough to make a harbourmaster weep.",
+          "choices": [
+            {
+              "label": "Have a pillow sewn (3 feathers)",
+              "next": "greet",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "feather",
+                  "wantCount": 3,
+                  "giveHubItem": {
+                    "itemId": "feather-pillow"
+                  },
+                  "missingText": "That's not three feathers. Well-fed chickens shed them all over the realm.",
+                  "successText": "Needle, thread, and done — one feather pillow, double-stitched. Someone out there needs this more than you know."
+                }
+              ]
+            },
+            {
+              "label": "Another time, Quill.",
+              "effects": [
+                {
+                  "type": "end"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    {
       "id": "wren-compass-trade",
       "npcId": "lighthouse-keeper",
       "start": "greet",

--- a/web/src/data/hubItems.json
+++ b/web/src/data/hubItems.json
@@ -212,5 +212,19 @@
     "icon": "🧭",
     "desc": "Guild-certified and gimballed in gold. Lighthouse keepers would pay dearly for one.",
     "category": "material"
+  },
+  {
+    "id": "music-box",
+    "name": "Music Box",
+    "icon": "🎵",
+    "desc": "A gilded music box from the Grand Market Hall. Its tune soothes even bathhouse patrons.",
+    "category": "material"
+  },
+  {
+    "id": "feather-pillow",
+    "name": "Feather Pillow",
+    "icon": "🛏️",
+    "desc": "Three feathers, down-stuffed and double-stitched by the Net Loft. Softness itself.",
+    "category": "material"
   }
 ]


### PR DESCRIPTION
## Summary

Round 5 of the hub item economy (#1847–#1849, #1853) — **pure content, zero new code**, built entirely on the merged primitives (`requireFestival`, `reputation:<tier>` prerequisites, multi-item recipes, `giveHubItem` crafting).

### 🌾 Every festival now has a trade
- **Harvest Festival** — Trader Posy (Appleford market barn) pays 35💎 per 3 eggs, a festival premium over Baker Otto's year-round 20.
- **Midwinter Feast** — Sailor Bess (Saltmere sailors' inn) pays 60💎 for a pair of smoked herring for the feast table.
- (Midsummer already had Busker Lyle's butterfly act from round 4.)

### 🎵 Second reputation-gated premium good
The capital's Grand Market Hall sells a **Music Box** (130💎) only to players with capital reputation tier 2+; **Grunda the Soaker**'s Hollowmere bathhouse pays 170💎 for it.

### 🛏️ First crafting NPC
**Net-Maker Quill** (Saltmere) sews 3 feathers into a **Feather Pillow**; **The Prisoner** in Ironhold Keep's dungeon trades 55💎 + friendship for the first soft thing his cell has seen in twelve years. Chain: feed chickens → 3 feathers → Quill's pillow → the Prisoner.

### Docs
`docs/hubworld.md` §16 network list updated (2 new items: `music-box`, `feather-pillow`; 5 new dialogue trees; 1 gated shelf).

## Testing
- `npm run test`: **929 tests passing across 199 files** (loader tests parse every modified town config/questDefs).
- `npm run build` (tsc + vite): clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HFBFbZdCft98Dbr1WdRHoT

---
_Generated by [Claude Code](https://claude.ai/code/session_01HFBFbZdCft98Dbr1WdRHoT)_