### PR TITLE
Hub item economy round 6: weather-gated rain barrels and the honey-pie chain

### DIFF
--- a/docs/hubworld.md
+++ b/docs/hubworld.md
@@ -291,7 +291,7 @@ bounds, else a single tile.
 | `buy` | `slotIndex` | Sells the interactable's building's Nth daily-rotating shop-stock item (`getTodaysShopItems`, `SHOP_TRADER_REGISTRY`). Shares `DailyShopState` with `ShopScreen`, so both draw down the same stock. Requires `building`. |
 | `buyPack` | — | Crystal-pack purchase flow (delegates to `onBuyCrystalPack`). Requires `building`. |
 | `buyHubItem` | `itemId`, `price`, `currency?`, `speakerName?`, `prerequisite?`, `lockedText?` | Always-available hub-item purchase (no daily rotation) — see §16. `itemId` must exist in `hubItems.json`; `currency` is `'crystals'` (default) or `'tickets'`. Unique items (e.g. the fishing rod) re-offer as "already owned" once bought. `speakerName` overrides the building-NPC speaker (useful for exterior stalls). `prerequisite` (§14 syntax, including `reputation:<tier>`) gates the offer — unmet shows `lockedText` (or a default refusal) instead. |
-| `dig` | `requiresItemId?`, `nightOnly?`, `lootTable?` | Once-per-day dig spot (see §16), gated on holding the tool hub-item (default `'spade'`). `nightOnly: true` makes it a **dark hollow** that refuses by day. `lootTable: 'earth'` (default) rolls 50% worms (+2 fish bait) / 30% crystals (10–25) / 20% a dug-up trinket; `'hollow'` rolls 50% glowcap mushroom / 25% crystals (15–35) / 25% a firefly. Cooldown persists per spot per real day in `jarv_hub_digs` (`web/src/game/hub/digs.ts`). Pair with a `mediumDirt` decor tile (`zlayer: "below"`) for a visible earth patch. |
+| `dig` | `requiresItemId?`, `nightOnly?`, `weatherOnly?`, `lootTable?` | Once-per-day dig spot (see §16), gated on holding the tool hub-item (default `'spade'`). `nightOnly: true` makes it a **dark hollow** that refuses by day; `weatherOnly` (e.g. `"rain"`) makes it refuse unless the town's resolved weather (§12) matches — used by **rain barrels**. `lootTable: 'earth'` (default) rolls 50% worms (+2 fish bait) / 30% crystals (10–25) / 20% a dug-up trinket; `'hollow'` rolls 50% glowcap mushroom / 25% crystals (15–35) / 25% a firefly; `'rain'` always yields 1 rainwater. Cooldown persists per spot per real day in `jarv_hub_digs` (`web/src/game/hub/digs.ts`). Pair with a `mediumDirt` decor tile (`zlayer: "below"`) for an earth patch, or `barrel` for a rain barrel. |
 
 Reactions run in order; `dialogue` (and `message`-bearing reactions) chain the
 remainder through the dialogue's close. Conventions: at most one `screen` or
@@ -419,6 +419,7 @@ Then on the NPC (in `config.json`): `"dialogueTree": "scholar-chat"` (keep a
 | `requireFlag` | string? | Choice only shown if the flag is set. |
 | `hideIfFlag` | string? | Choice hidden once the flag is set. |
 | `requireFestival` | string? | Choice only shown while that festival is active (§14 festival ids, e.g. `"midsummer"`). |
+| `requireWeather` | string? | Choice only shown while the town's resolved weather (§12) matches (`"clear"`/`"rain"`/`"snow"`/`"fog"`). Weather is date/season-driven — for QA, force `"weather": {"type": "snow"}` in the town config, or use Millhaven (rains year-round). |
 
 #### `DialogueEffect` types
 | `type` | Fields | Behaviour |
@@ -1354,7 +1355,8 @@ Hall), smoked herring + bones (Saltmere fish market / smokehouse), bog salve
 (Hollowmere apothecary), spice pouch (Ravenwatch Merchant's Guild Hall),
 catching net (Saltmere Net Loft), spade (Gearford Tool Shop), storm lantern
 (Saltmere Chandlery), gilded compass (Ravenwatch Guild Hall,
-`reputation:2`-gated).
+`reputation:2`-gated), harbour bucket (Millhaven stall), honey (Appleford
+apiary).
 
 ### Trading hub items — `tradeHubItem` (§7b dialogue effects)
 
@@ -1392,6 +1394,13 @@ Soaker (Hollowmere) ← music box → 170💎.
 Reputation-gated premium stock: gilded compass (Ravenwatch Guild Hall,
 120💎) and music box (capital Grand Market Hall, 130💎), both
 `reputation:2`.
+
+Weather content: rain barrels (Millhaven — rains year-round — plus
+Ravenwatch and Harrowfield in wet seasons) scoop `rainwater` with the
+bucket; Sister Nettle (Hollowmere) pays 30💎 per two. The honey-pie chain:
+Beekeeper Mabe's honey + an egg → Cook Mabel's (Ironhold) hearty pie →
+Warden Rell (Thornwood) 50💎, or Shepherd Nan (Harrowfield) 75💎 **while it
+snows** (`requireWeather`).
 
 The longest chain: lantern (Chandlery) → dark hollow at night → glowcaps →
 Morwen's moon draught → the Restless Soldier's first sleep in centuries —

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -55,6 +55,7 @@ import { getUnreadCount } from '../../game/news'
 import { interactableStoreKey, isInteractableGranted, markInteractableGranted, getInteractableMoves, setInteractableMove } from '../../game/hub/interactables'
 import { canDigToday, recordDig } from '../../game/hub/digs'
 import { getReputationTier } from '../../data/hub/buildingUpgrades'
+import { resolveWeather } from '../../game/hub/weather'
 import { recordNpcMet, recordAnimalSeen, recordAreaSeen } from '../../game/hub/journal'
 import { getTodaysShopItems } from '../../game/hub/shopStock'
 import { loadDailyShopState, saveDailyShopState, isShopItemSold, markCardBought, markAugmentBought } from '../../game/shopSchedule'
@@ -274,6 +275,10 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onEndless, onWorldMap
 
   // Active festival (real-date driven, with QA override) — gates festival quests + HUD badge.
   const activeFestival = getActiveFestival()
+  // Current town weather — gates requireWeather dialogue choices and
+  // weatherOnly dig spots (e.g. rain barrels). Same resolution the canvas
+  // uses for the visual weather overlay (§12).
+  const currentWeather = resolveWeather(locationData.WEATHER, locationData.ENVIRONMENT)
 
   // Quest NPC state: maps npcId → 'offer' | 'ready' | null, read imperatively by PixiJS ticker
   const questNpcStateRef = useRef(new Map<string, 'offer' | 'ready' | null>())
@@ -839,7 +844,8 @@ function hasOfferableQuest(giverId: string): boolean {
       (!c.hideIfFlag   || !hasDialogueFlag(c.hideIfFlag)) &&
       (!c.requireQuest || getQuestState(c.requireQuest).status === 'completed') &&
       (!c.hideIfQuest  || getQuestState(c.hideIfQuest).status !== 'completed') &&
-      (!c.requireFestival || c.requireFestival === activeFestival?.id)
+      (!c.requireFestival || c.requireFestival === activeFestival?.id) &&
+      (!c.requireWeather || c.requireWeather === currentWeather)
     )
     const choices: DialogueChoice[] = visible.map((c, i) => ({
       label:   c.label,
@@ -1517,8 +1523,14 @@ function hasOfferableQuest(giverId: string): boolean {
       }
       case 'dig': {
         // Once-per-day dig spot, gated on holding the required tool.
-        // nightOnly spots (dark hollows) only open after dark and roll the
-        // 'hollow' loot table instead of the default 'earth' one.
+        // nightOnly spots (dark hollows) only open after dark; weatherOnly
+        // spots (rain barrels) only work while the town's weather matches.
+        if (r.weatherOnly && r.weatherOnly !== currentWeather) {
+          setDialogueEvent({ speakerName: '', text: r.weatherOnly === 'rain'
+            ? 'The barrel sits bone dry. Come back when the rain does.'
+            : 'The weather is all wrong for this. Come back another time.' })
+          return
+        }
         if (r.nightOnly && !isGameNight) {
           setDialogueEvent({ speakerName: '', text: 'Whatever stirs in this hollow only shows itself after dark.' })
           return
@@ -1535,6 +1547,25 @@ function hasOfferableQuest(giverId: string): boolean {
           setDialogueEvent({ speakerName: '', text: r.nightOnly
             ? 'The hollow has given up all it will tonight. Return tomorrow night.'
             : "You've already turned this earth over today. Let it settle until tomorrow." })
+          return
+        }
+        if (r.lootTable === 'rain') {
+          const confirm: DialogueChoice = {
+            label: 'Scoop from the barrel',
+            primary: true,
+            onClick: () => {
+              recordDig(storeKey)
+              addHubItem('rainwater', 1)
+              emitSound('pickup')
+              refreshState()
+              setDialogueEvent({ speakerName: '', text: 'You skim a bucketful of clean rainwater from the barrel. 💧', onClose: next })
+            },
+          }
+          setDialogueEvent({
+            speakerName: '',
+            text: 'The rain barrel brims with fresh water, drumming softly under the downpour.',
+            choices: [confirm, { label: 'Leave it', onClick: () => setDialogueEvent(null) }],
+          })
           return
         }
         if (r.lootTable === 'hollow') {

--- a/web/src/data/hub/appleford/config.json
+++ b/web/src/data/hub/appleford/config.json
@@ -2099,6 +2099,19 @@
   },
   "interactables": [
     {
+      "id": "apiary-honey-shelf",
+      "tx": 8,
+      "ty": 1,
+      "building": "apiary",
+      "reactions": [
+        {
+          "type": "buyHubItem",
+          "itemId": "honey",
+          "price": 12
+        }
+      ]
+    },
+    {
       "id": "appleford-dig-1",
       "reactions": [
         {

--- a/web/src/data/hub/harrowfield/config.json
+++ b/web/src/data/hub/harrowfield/config.json
@@ -1620,6 +1620,7 @@
     {
       "id": "shepherd-nan",
       "name": "Shepherd Nan",
+      "dialogueTree": "nan-snow-pie-trade",
       "sprite": "hub-npc-gardener",
       "tx": 3,
       "ty": 22,
@@ -2459,6 +2460,26 @@
     }
   },
   "interactables": [
+    {
+      "id": "harrowfield-rain-barrel",
+      "tx": 20,
+      "ty": 6,
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "tileId": "barrel"
+        }
+      ],
+      "reactions": [
+        {
+          "type": "dig",
+          "requiresItemId": "bucket",
+          "weatherOnly": "rain",
+          "lootTable": "rain"
+        }
+      ]
+    },
     {
       "id": "harrowfield-chicken-feed",
       "tx": 4,

--- a/web/src/data/hub/harrowfield/questDefs.json
+++ b/web/src/data/hub/harrowfield/questDefs.json
@@ -1,4 +1,40 @@
 {
+  "dialogues": [
+    {
+      "id": "nan-snow-pie-trade",
+      "npcId": "shepherd-nan",
+      "start": "greet",
+      "nodes": {
+        "greet": {
+          "text": "Shepherding doesn't stop for weather. Summer, I want for nothing. But when the snow sets in and the flock still needs walking… what I'd pay for something hot in my hands.",
+          "choices": [
+            {
+              "label": "Offer a hot hearty pie — 75 💎",
+              "requireWeather": "snow",
+              "next": "greet",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "hearty-pie",
+                  "giveCrystals": 75,
+                  "missingText": "You've no pie on you, and the snow's not getting warmer. Cook Mabel at Ironhold bakes them.",
+                  "successText": "She wraps frozen fingers around the warm crust and closes her eyes. 'Seventy-five, and cheap at twice that.' Snow-day rates."
+                }
+              ]
+            },
+            {
+              "label": "Keep warm, Nan.",
+              "effects": [
+                {
+                  "type": "end"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
   "quests": [
     {
       "id": "harrowfield-seed-grain",

--- a/web/src/data/hub/hollowmere/config.json
+++ b/web/src/data/hub/hollowmere/config.json
@@ -1204,6 +1204,7 @@
     {
       "id": "apothecary-herbalist",
       "name": "Sister Nettle",
+      "dialogueTree": "nettle-rainwater-trade",
       "sprite": "soulrend-witch",
       "tx": 5,
       "ty": 4,

--- a/web/src/data/hub/hollowmere/questDefs.json
+++ b/web/src/data/hub/hollowmere/questDefs.json
@@ -1,6 +1,40 @@
 {
   "dialogues": [
     {
+      "id": "nettle-rainwater-trade",
+      "npcId": "apothecary-herbalist",
+      "start": "greet",
+      "nodes": {
+        "greet": {
+          "text": "Marsh water is fine for salves, but a proper tincture wants rainwater — clean-caught, never touched ground. Two bucketfuls and I'll pay honest coin.",
+          "choices": [
+            {
+              "label": "Sell 2 rainwater — 30 💎",
+              "next": "greet",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "rainwater",
+                  "wantCount": 2,
+                  "giveCrystals": 30,
+                  "missingText": "That's not two bucketfuls. Rain barrels fill in wet weather — Millhaven's rains near year-round.",
+                  "successText": "She holds each jar to the light and nods. 'Never touched ground. Perfect.' 30 crystals."
+                }
+              ]
+            },
+            {
+              "label": "Stay dry, Sister.",
+              "effects": [
+                {
+                  "type": "end"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    {
       "id": "grunda-music-box-trade",
       "npcId": "bog-troll-attendant",
       "start": "greet",

--- a/web/src/data/hub/ironholdkeep/config.json
+++ b/web/src/data/hub/ironholdkeep/config.json
@@ -2150,6 +2150,7 @@
     {
       "id": "castle-cook",
       "name": "Cook Mabel",
+      "dialogueTree": "mabel-pie-craft",
       "sprite": "hub-npc-elder",
       "tx": 6,
       "ty": 4,

--- a/web/src/data/hub/ironholdkeep/questDefs.json
+++ b/web/src/data/hub/ironholdkeep/questDefs.json
@@ -1313,6 +1313,48 @@
   ],
   "dialogues": [
     {
+      "id": "mabel-pie-craft",
+      "npcId": "castle-cook",
+      "start": "greet",
+      "nodes": {
+        "greet": {
+          "text": "Feeding a garrison teaches you one recipe matters above all: the hearty pie. Bring me a fresh egg and good honey and I'll bake you one — the kind that ends arguments.",
+          "choices": [
+            {
+              "label": "Have a pie baked (1 egg + 1 honey)",
+              "next": "greet",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItems": [
+                    {
+                      "itemId": "egg"
+                    },
+                    {
+                      "itemId": "honey"
+                    }
+                  ],
+                  "giveHubItem": {
+                    "itemId": "hearty-pie"
+                  },
+                  "missingText": "That's not a pie's makings. An egg — any well-fed hen obliges — and honey from the Appleford apiary.",
+                  "successText": "Twenty minutes and the whole keep smells of it. One hearty pie, oven-fresh. Guard it well."
+                }
+              ]
+            },
+            {
+              "label": "Smells wonderful, Mabel.",
+              "effects": [
+                {
+                  "type": "end"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    {
       "id": "prisoner-pillow-trade",
       "npcId": "castle-prisoner",
       "start": "greet",

--- a/web/src/data/hub/loader.ts
+++ b/web/src/data/hub/loader.ts
@@ -278,10 +278,11 @@ export type HubInteractableReaction =
    *  gates the offer; unmet shows `lockedText`. */
   | { type: 'buyHubItem'; itemId: string; price: number; currency?: 'crystals' | 'tickets'; speakerName?: string; prerequisite?: string; lockedText?: string }
   /** Once-per-day dig spot: gated on holding the required tool hub-item
-   *  (default 'spade'); `nightOnly` spots open after dark only. lootTable
-   *  'earth' (default) rolls worms/crystals/trinket; 'hollow' rolls
-   *  glowcaps/crystals/fireflies. */
-  | { type: 'dig'; requiresItemId?: string; nightOnly?: boolean; lootTable?: 'earth' | 'hollow' }
+   *  (default 'spade'); `nightOnly` spots open after dark only; `weatherOnly`
+   *  spots only work while the town's weather matches (e.g. rain barrels).
+   *  lootTable 'earth' (default) rolls worms/crystals/trinket; 'hollow'
+   *  rolls glowcaps/crystals/fireflies; 'rain' always yields rainwater. */
+  | { type: 'dig'; requiresItemId?: string; nightOnly?: boolean; weatherOnly?: string; lootTable?: 'earth' | 'hollow' | 'rain' }
 
 export interface HubInteractable {
   id: string

--- a/web/src/data/hub/millhaven/config.json
+++ b/web/src/data/hub/millhaven/config.json
@@ -2849,6 +2849,46 @@
   ],
   "interactables": [
     {
+      "id": "millhaven-bucket-stall",
+      "tx": 32,
+      "ty": 12,
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "tileId": "bucketAndRope"
+        }
+      ],
+      "reactions": [
+        {
+          "type": "buyHubItem",
+          "itemId": "bucket",
+          "price": 25,
+          "speakerName": "Harbour Tackle Stall"
+        }
+      ]
+    },
+    {
+      "id": "millhaven-rain-barrel",
+      "tx": 8,
+      "ty": 13,
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "tileId": "barrel"
+        }
+      ],
+      "reactions": [
+        {
+          "type": "dig",
+          "requiresItemId": "bucket",
+          "weatherOnly": "rain",
+          "lootTable": "rain"
+        }
+      ]
+    },
+    {
       "id": "millhaven-dig-1",
       "reactions": [
         {

--- a/web/src/data/hub/questDefs.ts
+++ b/web/src/data/hub/questDefs.ts
@@ -244,6 +244,7 @@ export interface DialogueChoiceDef {
   requireFlag?: string     // only show this choice if the flag is set
   hideIfFlag?: string      // hide this choice once the flag is set
   requireFestival?: string // only show this choice while that festival is active (hubCalendar)
+  requireWeather?: string  // only show this choice while the town's weather matches ('clear'|'rain'|'snow'|'fog')
   requireQuest?: string    // only show this choice once that quest is completed
   hideIfQuest?: string     // hide this choice once that quest is completed
 }

--- a/web/src/data/hub/ravenwatch/config.json
+++ b/web/src/data/hub/ravenwatch/config.json
@@ -9400,6 +9400,26 @@
   ],
   "interactables": [
     {
+      "id": "ravenwatch-rain-barrel",
+      "tx": 39,
+      "ty": 36,
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "tileId": "barrel"
+        }
+      ],
+      "reactions": [
+        {
+          "type": "dig",
+          "requiresItemId": "bucket",
+          "weatherOnly": "rain",
+          "lootTable": "rain"
+        }
+      ]
+    },
+    {
       "id": "guild-compass-case",
       "tx": 11,
       "ty": 2,

--- a/web/src/data/hub/thornwoodcamp/config.json
+++ b/web/src/data/hub/thornwoodcamp/config.json
@@ -439,6 +439,7 @@
     {
       "id": "warden-rell",
       "name": "Warden Rell",
+      "dialogueTree": "rell-pie-trade",
       "sprite": "hub-npc-soldier",
       "tx": 11,
       "ty": 10,

--- a/web/src/data/hub/thornwoodcamp/questDefs.json
+++ b/web/src/data/hub/thornwoodcamp/questDefs.json
@@ -1,6 +1,39 @@
 {
   "dialogues": [
     {
+      "id": "rell-pie-trade",
+      "npcId": "warden-rell",
+      "start": "greet",
+      "nodes": {
+        "greet": {
+          "text": "Camp rations are bark tea and yesterday's bread. A man my age dreams of exactly one thing: a proper pie, still warm from a real oven.",
+          "choices": [
+            {
+              "label": "Hand over the hearty pie",
+              "next": "greet",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "hearty-pie",
+                  "giveCrystals": 50,
+                  "missingText": "You carry no pie, and now we're both sadder for it. Cook Mabel at Ironhold bakes them, for an egg and some honey.",
+                  "successText": "He eats half of it in reverent silence and wraps the rest for tomorrow. 'Worth every crystal.' 50, gladly."
+                }
+              ]
+            },
+            {
+              "label": "I'll see what I can do.",
+              "effects": [
+                {
+                  "type": "end"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    {
       "id": "mott-herring-trade",
       "npcId": "forager-mott",
       "start": "greet",

--- a/web/src/data/hubItems.json
+++ b/web/src/data/hubItems.json
@@ -226,5 +226,34 @@
     "icon": "🛏️",
     "desc": "Three feathers, down-stuffed and double-stitched by the Net Loft. Softness itself.",
     "category": "material"
+  },
+  {
+    "id": "bucket",
+    "name": "Harbour Bucket",
+    "icon": "🪣",
+    "desc": "A stout harbour bucket. Rain barrels around the realm fill in wet weather.",
+    "category": "tool",
+    "unique": true
+  },
+  {
+    "id": "rainwater",
+    "name": "Rainwater",
+    "icon": "💧",
+    "desc": "Pure rainwater, barrel-caught. Herbalists swear tinctures brewed with it work twice as well.",
+    "category": "material"
+  },
+  {
+    "id": "honey",
+    "name": "Honey",
+    "icon": "🍯",
+    "desc": "Appleford apiary honey, comb-fresh. Bakers and cooks pay well for it.",
+    "category": "material"
+  },
+  {
+    "id": "hearty-pie",
+    "name": "Hearty Pie",
+    "icon": "🥧",
+    "desc": "Cook Mabel's egg-and-honey pie. Best eaten hot; best of all in the snow.",
+    "category": "material"
   }
 ]


### PR DESCRIPTION
## Summary

Round 6 of the hub item economy (#1847–#1855): **weather** joins night, festival, and reputation as the last environmental gate, plus a second crafting chain.

### 🌧️ Weather gating (two small primitives)
- Dialogue choices accept `requireWeather` (`clear`/`rain`/`snow`/`fog`), checked against the town's resolved §12 weather (`resolveWeather` — the same call the visual overlay uses).
- `dig` spots accept `weatherOnly` plus a third loot table `'rain'` (always yields rainwater).

### 🪣 Rain barrels
A third Millhaven harbour stall sells a **Harbour Bucket** (25💎). Rain barrels in **Millhaven** (forest climate — rains year-round, the always-on demo), **Ravenwatch**, and **Harrowfield** (seasonal rain) can each be scooped once a day while it rains. **Sister Nettle** (Hollowmere) pays 30💎 per two bucketfuls of clean rainwater for her tinctures.

### 🥧 The honey-pie chain (second crafting chain)
**Beekeeper Mabe** (Appleford apiary) sells honey (12💎); **Cook Mabel** (Ironhold Keep kitchens) bakes an egg + honey into a **Hearty Pie**; **Warden Rell** (Thornwood Camp) pays 50💎 year-round — and **Shepherd Nan** (Harrowfield) pays a 75💎 snow-day premium, the `requireWeather` showcase (her choice only appears while Harrowfield's weather resolves to snow).

### Docs
`docs/hubworld.md`: §7 `dig` row gains `weatherOnly`/`'rain'`, §7b gains `requireWeather` (with the weather-QA note), §16 network list updated.

## Testing
- `npm run test`: **929 tests passing across 199 files** (loader tests parse every modified town config/questDefs).
- `npm run build` (tsc + vite): clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HFBFbZdCft98Dbr1WdRHoT

---
_Generated by [Claude Code](https://claude.ai/code/session_01HFBFbZdCft98Dbr1WdRHoT)_