### PR TITLE
fix(millhaven): separate fresh-fish bounty pickup from lookalike counter decor

### DIFF
--- a/web/src/data/hub/millhaven/questDefs.json
+++ b/web/src/data/hub/millhaven/questDefs.json
@@ -641,9 +641,9 @@
     },
     {
       "id": "fresh-fish-millhaven",
-      "tx": 3,
-      "ty": 3,
-      "tileId": "goldFish",
+      "tx": 2,
+      "ty": 6,
+      "tileId": "mushroomBasket",
       "building": "fishmonger"
     },
     {


### PR DESCRIPTION
## Summary
- Follow-up to #1854. After that PR merged, the fish pickup for the "A Fresh Catch for the Inn" bounty (`fresh-fish-millhaven`) was hand-edited (bypassing PR review) to sit inside the fishmonger shop's interior at tile (3,3), using the same `goldFish` sprite as the shop's decorative counter-top fish.
- I verified the collection logic itself was working correctly (confirmed via a scripted in-browser test: entering the shop and clicking the pickup did log "Item collected" and advance the bounty). The real problem was **discoverability**: the collectible fish looked visually identical to the non-interactive decorative fish already sitting on the counter a few tiles away, so it read as scenery rather than something to pick up.
- Moved the pickup to an open floor tile away from both the counter decor and the room's other basket decor, and swapped its sprite from `goldFish` to `mushroomBasket` — matching the container-icon convention every other collectible pickup in this file already uses (crates, sacks, gift boxes, etc.), so it visually reads as "something you can pick up."

## Test plan
- [x] `npm run build` passes clean
- [x] `npx vitest run src/game/hub/bounties.test.ts src/data/hub/loader.test.ts` — 41 tests passed
- [x] Scripted browser verification: entered the fishmonger interior and clicked the relocated pickup — confirmed dialogue "🐟 Item collected. Report back to innkeeper-rosie." and bounty progress (`collect: 1`) recorded correctly


---
_Generated by [Claude Code](https://claude.ai/code/session_01JmL3qeSTNCcJM12PA67nMv)_