### PR TITLE
fix(bounties): stop collect-step pickups from being permanently lost

### DIFF
--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -33,7 +33,7 @@ import { questItemId } from '../../game/hub/questItems'
 import { QuestsModal } from './QuestsModal'
 import { HubInventoryModal } from './HubInventoryModal'
 import { BountyBoardModal } from './BountyBoardModal'
-import { hasUnclaimedBounties, getPendingBountyReport, getPendingBountyCollect, advanceBountyStep, getActiveBountyStep } from '../../game/hub/bounties'
+import { hasUnclaimedBounties, getPendingBountyReport, getPendingBountyCollect, advanceBountyStep, getActiveBountyStep, isBountyCollectPickup, reconcileBountyPickups } from '../../game/hub/bounties'
 import { PetModal } from './PetModal'
 import { getActivePet, getTreatsRemainingToday, canGiveTreat, recordTreatGiven, grantAccessory } from '../../game/hub/pet'
 import { PLAYER_PET_ANIMAL_ID } from './hubAnimals'
@@ -193,7 +193,7 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onEndless, onWorldMap
   const [dialogueLine,   setDialogueLine]   = useState<string | null>(null)
   const [dialogueEvent,  setDialogueEvent]  = useState<QuestEvent | null>(null)
   const [interiorActive, setInteriorActive] = useState(false)
-  const [pickedUpIds,    setPickedUpIds]    = useState<Set<string>>(() => getPickedUpIds())
+  const [pickedUpIds,    setPickedUpIds]    = useState<Set<string>>(() => { reconcileBountyPickups(); return getPickedUpIds() })
   const [questsOpen,          setQuestsOpen]          = useState(false)
   const [inventoryOpen,       setInventoryOpen]       = useState(false)
   const [bountyBoardOpen,     setBountyBoardOpen]     = useState(false)
@@ -621,11 +621,22 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onEndless, onWorldMap
   }, [refreshState])
 
   const handleItemPickup = useCallback((id: string, questId?: string) => {
+    const pendingBounty = getPendingBountyCollect(id)
+
+    // Bounty-collect pickups aren't gated behind accepting the bounty first —
+    // the fishmonger (say) is a normal building anyone can wander into. If this
+    // id belongs to a bounty's collect step but no matching bounty is currently
+    // active, don't permanently consume it: there'd be no way to get it back,
+    // silently soft-locking the bounty for whoever accepts it later.
+    if (!pendingBounty && isBountyCollectPickup(id)) {
+      setDialogueEvent({ speakerName: '', text: "Doesn't look like something you need right now." })
+      return
+    }
+
     emitSound('pickup')
     markPickedUp(id)
     setPickedUpIds(getPickedUpIds())
 
-    const pendingBounty = getPendingBountyCollect(id)
     if (pendingBounty) {
       advanceBountyStep(pendingBounty.id)
       const nextStep = getActiveBountyStep(pendingBounty.id)

--- a/web/src/game/hub/bounties.test.ts
+++ b/web/src/game/hub/bounties.test.ts
@@ -13,8 +13,11 @@ import {
   getBountyStepProgress,
   getPendingBountyReport,
   getPendingBountyCollect,
+  isBountyCollectPickup,
+  reconcileBountyPickups,
 } from './bounties'
 import { saveCrystals, loadCrystals } from '../collection'
+import { markPickedUp, isPickedUp } from './pickups'
 
 // In-memory localStorage mock (tests run in node environment)
 const store = new Map<string, string>()
@@ -222,5 +225,52 @@ describe('hasUnclaimedBounties', () => {
   it('is false once every bounty is accepted or completed', () => {
     for (const b of getDailyBounties(DAY)) acceptBounty(b.id)
     expect(hasUnclaimedBounties(DAY)).toBe(false)
+  })
+})
+
+describe('isBountyCollectPickup', () => {
+  it('is true for a pickup used by some bounty collect step, regardless of rotation/accept state', () => {
+    expect(isBountyCollectPickup('fresh-fish-millhaven')).toBe(true)
+  })
+
+  it('is false for an unrelated id', () => {
+    expect(isBountyCollectPickup('not-a-real-pickup')).toBe(false)
+  })
+})
+
+describe('reconcileBountyPickups', () => {
+  it('un-hides a bounty pickup that was marked picked-up before its bounty ever advanced', () => {
+    const collectBounty = getDailyBounties(FISH_DAY).find(b => b.steps[0].type === 'collect')!
+    const pickupId = collectBounty.steps[0].pickupIds![0]
+
+    // Simulate clicking the pickup (e.g. while just exploring the shop) before
+    // the bounty was ever accepted — markPickedUp fires, but nothing advances.
+    markPickedUp(pickupId)
+    expect(isPickedUp(pickupId)).toBe(true)
+
+    // Player accepts the bounty afterwards; its collect step is still at 0.
+    acceptBounty(collectBounty.id)
+    expect(getBountyStepProgress(collectBounty.id, collectBounty.steps[0].key)).toBe(0)
+
+    reconcileBountyPickups(FISH_DAY)
+    expect(isPickedUp(pickupId)).toBe(false)
+  })
+
+  it('leaves a pickup hidden once its bounty step has genuinely been collected', () => {
+    const collectBounty = getDailyBounties(FISH_DAY).find(b => b.steps[0].type === 'collect')!
+    const pickupId = collectBounty.steps[0].pickupIds![0]
+
+    acceptBounty(collectBounty.id)
+    markPickedUp(pickupId)
+    advanceBountyStep(collectBounty.id) // genuine collection: progress advances too
+
+    reconcileBountyPickups(FISH_DAY)
+    expect(isPickedUp(pickupId)).toBe(true)
+  })
+
+  it('leaves unrelated picked-up ids untouched', () => {
+    markPickedUp('some-unrelated-pickup')
+    reconcileBountyPickups(FISH_DAY)
+    expect(isPickedUp('some-unrelated-pickup')).toBe(true)
   })
 })

--- a/web/src/game/hub/bounties.ts
+++ b/web/src/game/hub/bounties.ts
@@ -7,6 +7,7 @@
 
 import { saveCrystals, loadCrystals } from '../collection'
 import { grantAccessory } from './pet'
+import { isPickedUp, unmarkPickedUp } from './pickups'
 import type { HubQuestStep } from '../../data/hub/questDefs'
 
 const KEY = 'jarv_hub_bounties'
@@ -242,6 +243,34 @@ export function getPendingBountyCollect(pickupId: string, at?: Date): BountyDef 
     if (step && step.type === 'collect' && step.pickupIds?.includes(pickupId)) return bounty
   }
   return null
+}
+
+/** Whether this pickup id belongs to any bounty's 'collect' step, across the
+ *  full template pool — not just today's rotation. Used to recognize a
+ *  bounty pickup even before its bounty has been offered/accepted, so it
+ *  isn't treated like an ordinary walk-up-and-grab item. */
+export function isBountyCollectPickup(pickupId: string): boolean {
+  return BOUNTY_TEMPLATES.some(bounty =>
+    bounty.steps.some(step => step.type === 'collect' && step.pickupIds?.includes(pickupId)))
+}
+
+/** Un-hides bounty-collect pickups that were marked "picked up" without ever
+ *  advancing their bounty's progress — the result of clicking one before its
+ *  bounty was accepted (see handleItemPickup). Safe to call unconditionally:
+ *  it only touches pickups tied to a currently accepted, still-incomplete
+ *  collect step, i.e. pickups the player still needs and currently can't see. */
+export function reconcileBountyPickups(at?: Date): void {
+  const state = getBountyState()
+  for (const bounty of getDailyBounties(at)) {
+    if (!state.accepted.includes(bounty.id) || state.completed.includes(bounty.id)) continue
+    for (const step of bounty.steps) {
+      if (step.type !== 'collect' || !step.pickupIds) continue
+      if (getBountyStepProgress(bounty.id, step.key) >= step.required) continue
+      for (const pickupId of step.pickupIds) {
+        if (isPickedUp(pickupId)) unmarkPickedUp([pickupId])
+      }
+    }
+  }
 }
 
 /** Turns in an accepted bounty whose steps are all complete, granting its


### PR DESCRIPTION
## Summary
- Root cause of the ongoing "A Fresh Catch for the Inn" reports (#1854, #1857): `handleItemPickup` marked a clicked pickup as permanently "collected" in `localStorage` *before* checking whether any bounty actually claimed it. Since the fishmonger is a normal, ungated building, clicking its fish pickup at any point before accepting the bounty (or on a day it wasn't in the daily rotation) silently and permanently destroyed it — with no reward and no way to get it back, soft-locking the bounty forever for that save.
- `handleItemPickup` (`web/src/components/hub/HubWorld.tsx`) now checks bounty relevance first: if a pickup belongs to a bounty's `collect` step but isn't currently claimable, it's left in place instead of being consumed.
- Added `reconcileBountyPickups()` (`web/src/game/hub/bounties.ts`), called once on `HubWorld` mount, which un-hides any bounty pickup that's already marked picked-up while its bounty's collect step is still at zero progress. This self-heals saves that hit the bug before this fix shipped — no console access or manual `localStorage` edit needed (confirmed via a scripted browser test reproducing the exact reported state: pickup marked collected with zero bounty progress, then correctly un-hidden and collectible again on next load).

## Test plan
- [x] `npm run build` passes clean
- [x] `npx vitest run` — 336 tests passed (1 unrelated pre-existing browser-mode config error, not from this change)
- [x] Scripted browser verification:
  - Reproduced the exact broken state (bounty accepted, pickup already marked picked-up with 0 collect progress) — confirmed `reconcileBountyPickups` un-hides it on load, and clicking it then correctly logs "Item collected" and advances the bounty
  - Confirmed the preventive guard: clicking the pickup with no bounty accepted at all shows a neutral line and does **not** mark it collected


---
_Generated by [Claude Code](https://claude.ai/code/session_01JmL3qeSTNCcJM12PA67nMv)_