### PR TITLE
feat(quests): show accepted bounties in the Quests modal

### DIFF
--- a/web/src/components/hub/BountyBoardModal.tsx
+++ b/web/src/components/hub/BountyBoardModal.tsx
@@ -1,21 +1,11 @@
 import React, { useState } from 'react'
 import { ModalBackdrop } from '../ui/ModalBackdrop'
-import type { BountyDef } from '../../game/hub/bounties'
-import { getDailyBounties, isBountyAccepted, isBountyCompleted, acceptBounty, turnInBounty, getActiveBountyStep } from '../../game/hub/bounties'
+import { getDailyBounties, isBountyAccepted, isBountyCompleted, acceptBounty, turnInBounty, getActiveBountyStepHint } from '../../game/hub/bounties'
 
 interface Props {
   onClose: () => void
   /** Resolve an NPC/animal id to its display name (for report-step hints). */
   resolveNpcName?: (id: string) => string
-}
-
-/** Human-readable hint for a bounty's current step, or null once fully done. */
-function activeStepHint(bounty: BountyDef, resolveNpcName: (id: string) => string): string | null {
-  const step = getActiveBountyStep(bounty.id)
-  if (!step) return null
-  if (step.type === 'report' && step.targetNpcId) return `Report to ${resolveNpcName(step.targetNpcId)}`
-  if (step.type === 'collect') return 'Find the item out in the world to advance this bounty'
-  return null
 }
 
 export function BountyBoardModal({ onClose, resolveNpcName = (id) => id }: Props) {
@@ -61,7 +51,7 @@ export function BountyBoardModal({ onClose, resolveNpcName = (id) => id }: Props
           <>
             <div className="bounty-board-modal__section-label">Accepted</div>
             {accepted.map(bounty => {
-              const hint = activeStepHint(bounty, resolveNpcName)
+              const hint = getActiveBountyStepHint(bounty, resolveNpcName)
               return (
                 <div key={bounty.id} className="bounty-board-modal__card bounty-board-modal__card--accepted">
                   <div className="bounty-board-modal__title-row">

--- a/web/src/components/hub/QuestsModal.tsx
+++ b/web/src/components/hub/QuestsModal.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react'
 import { ModalBackdrop } from '../ui/ModalBackdrop'
 import type { HubQuestDef } from '../../data/hub/questDefs'
 import { getQuestState, getQuestProgress } from '../../game/hub/quests'
+import { getDailyBounties, isBountyAccepted, isBountyCompleted, getActiveBountyStepHint } from '../../game/hub/bounties'
 
 interface Props {
   onClose: () => void
@@ -45,6 +46,8 @@ export function QuestsModal({ onClose, onAbandon, questDefs, resolveNpcName = (i
   const discovered = active.length + completed.length
   const total      = questDefs.length
 
+  const acceptedBounties = getDailyBounties().filter(b => isBountyAccepted(b.id) && !isBountyCompleted(b.id))
+
   return (
     <ModalBackdrop onClose={onClose}>
       <div className="quests-modal">
@@ -56,7 +59,7 @@ export function QuestsModal({ onClose, onAbandon, questDefs, resolveNpcName = (i
           </span>
         </div>
 
-        {discovered === 0 && (
+        {discovered === 0 && acceptedBounties.length === 0 && (
           <div className="quests-modal__empty">No quests active yet — talk to the townsfolk.</div>
         )}
 
@@ -96,6 +99,25 @@ export function QuestsModal({ onClose, onAbandon, questDefs, resolveNpcName = (i
                 )}
               </div>
             ))}
+          </>
+        )}
+
+        {acceptedBounties.length > 0 && (
+          <>
+            <div className="quests-modal__section-label">Bounties</div>
+            {acceptedBounties.map(bounty => {
+              const hint = getActiveBountyStepHint(bounty, resolveNpcName)
+              return (
+                <div key={bounty.id} className="quests-modal__card quests-modal__card--active">
+                  <div className="quests-modal__title-row">
+                    <span className="quests-modal__title">{bounty.icon} {bounty.title}</span>
+                  </div>
+                  <div className="quests-modal__desc">{bounty.desc}</div>
+                  {hint && <div className="quests-modal__hint">{hint}</div>}
+                  <div className="quests-modal__reward">+{bounty.reward.crystals} 💎</div>
+                </div>
+              )
+            })}
           </>
         )}
 

--- a/web/src/game/hub/bounties.test.ts
+++ b/web/src/game/hub/bounties.test.ts
@@ -15,6 +15,7 @@ import {
   getPendingBountyCollect,
   isBountyCollectPickup,
   reconcileBountyPickups,
+  getActiveBountyStepHint,
 } from './bounties'
 import { saveCrystals, loadCrystals } from '../collection'
 import { markPickedUp, isPickedUp } from './pickups'
@@ -272,5 +273,26 @@ describe('reconcileBountyPickups', () => {
     markPickedUp('some-unrelated-pickup')
     reconcileBountyPickups(FISH_DAY)
     expect(isPickedUp('some-unrelated-pickup')).toBe(true)
+  })
+})
+
+describe('getActiveBountyStepHint', () => {
+  it('names the resolved NPC for a report step', () => {
+    const reportBounty = getDailyBounties(FISH_DAY).find(b => b.steps[0].type === 'report')!
+    const npcId = reportBounty.steps[0].targetNpcId!
+    expect(getActiveBountyStepHint(reportBounty, id => `NPC(${id})`)).toBe(`Report to NPC(${npcId})`)
+  })
+
+  it('gives a generic hint for a collect step', () => {
+    const collectBounty = getDailyBounties(FISH_DAY).find(b => b.steps[0].type === 'collect')!
+    expect(getActiveBountyStepHint(collectBounty, id => id))
+      .toBe('Find the item out in the world to advance this bounty')
+  })
+
+  it('is null once every step is complete', () => {
+    const reportBounty = getDailyBounties(FISH_DAY).find(b => b.steps[0].type === 'report')!
+    acceptBounty(reportBounty.id)
+    completeAllSteps(reportBounty.id)
+    expect(getActiveBountyStepHint(reportBounty, id => id)).toBeNull()
   })
 })

--- a/web/src/game/hub/bounties.ts
+++ b/web/src/game/hub/bounties.ts
@@ -207,6 +207,15 @@ export function getActiveBountyStep(id: string): HubQuestStep | null {
   return null
 }
 
+/** Human-readable hint for a bounty's current step, or null once fully done. */
+export function getActiveBountyStepHint(bounty: BountyDef, resolveNpcName: (id: string) => string): string | null {
+  const step = getActiveBountyStep(bounty.id)
+  if (!step) return null
+  if (step.type === 'report' && step.targetNpcId) return `Report to ${resolveNpcName(step.targetNpcId)}`
+  if (step.type === 'collect') return 'Find the item out in the world to advance this bounty'
+  return null
+}
+
 /** Advances the current active step of an accepted, not-yet-completed bounty.
  *  No-op if the bounty isn't accepted, is already completed, or has no active step. */
 export function advanceBountyStep(id: string): void {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -15260,6 +15260,7 @@ html.light-mode .action-btn {
   justify-content: space-between;
   align-items: center;
 }
+.quests-modal__desc   { font-size: 10px; color: #667766; font-style: italic; }
 .quests-modal__hint   { font-size: 10px; color: #667766; margin-top: 6px; font-style: italic; }
 .quests-modal__reward { font-size: 10px; color: #88cc88; margin-top: 4px; }
 .quests-modal__title-row { display: flex; justify-content: space-between; align-items: center; margin-bottom: 4px; }


### PR DESCRIPTION
## Summary
- Prompted by debugging the fish bounty: there was no way to check an accepted bounty's status without walking back to the Bounty Board. Bounties are intentionally a separate, lighter-weight system from quests ("quests without a giver" — daily rotation, board-based accept/turn-in), so this doesn't merge their data models — it surfaces accepted-bounty status as a new read-only "Bounties" section inside the existing Quests modal (`web/src/components/hub/QuestsModal.tsx`): icon, title, description, current-step hint, and reward. No action buttons — accepting/turning in bounties still happens at the board/NPC as before.
- Extracted the per-bounty step-hint logic (previously a private `activeStepHint` function inside `BountyBoardModal.tsx`) into an exported `getActiveBountyStepHint()` in `web/src/game/hub/bounties.ts`, so both modals share one implementation instead of duplicating it.
- Updated the modal's empty-state check so an accepted bounty with no discovered quests doesn't show the misleading "No quests active yet" message.
- Added `.quests-modal__desc` styling (mirrors the existing `.bounty-board-modal__desc` rule).

## Test plan
- [x] `npm run build` passes clean
- [x] `npx vitest run` — 339 tests passed (1 unrelated pre-existing browser-mode config error, not from this change)
- [x] Scripted browser verification: accepted the fish bounty, opened the Quests modal, confirmed the new "Bounties" section renders the bounty with its description and the "Find the item..." hint; advanced the collect step and confirmed the hint updates to "Report to Innkeeper Rosie"
- [x] New unit tests for `getActiveBountyStepHint` (report step, collect step, completed/no-active-step) in `web/src/game/hub/bounties.test.ts`


---
_Generated by [Claude Code](https://claude.ai/code/session_01JmL3qeSTNCcJM12PA67nMv)_