### PR TITLE
Fix market-stall counter rendering over tackle-stall interactables

### DIFF
--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -562,7 +562,11 @@ export function HubTownCanvas({
     }
 
     function interactableZIndex(def: HubInteractable, ty: number): number {
-      return (ty + def.hitRect.h - 1) * T + T + 1  // y-sort on the bottom tile row, like decor
+      // y-sort on the bottom tile row, like decor — but +1.5 (not +1) so ties against
+      // same-row solid/default decor (zIndex ty*T+T+1) resolve deterministically in the
+      // interactable's favor instead of depending on async texture-load insertion order
+      // (e.g. the tackle-stall bucket/rod/bait sitting on the market-stall counter).
+      return (ty + def.hitRect.h - 1) * T + T + 1.5
     }
 
     function interactableIndicatorPos(def: HubInteractable, tx: number, ty: number): { x: number; y: number } {


### PR DESCRIPTION
## Summary

- `9a1d16d` moved the Millhaven `bucket`/`rod`/`bait` tackle-stall interactables onto the same tile row as the market-stall bundle's counter-top tiles, expecting them to render on top per the "solid/below decor sits at a lower z-index than interactables" convention.
- They didn't: `interactableZIndex()` and the exterior "solid"/default decor path both compute the identical `zIndex = ty*T + T + 1` for same-row tiles, so the two entries tie. PIXI's stable sort then falls back to insertion order in `spriteLayer`, which is populated by async `loadTileRef(...).then(...)` texture loads — an effectively arbitrary race rather than a guaranteed rule. In practice the counter consistently painted over the interactables.
- Fix: bump `interactableZIndex` by `+1.5` instead of `+1` so interactables deterministically win ties against same-row solid/default decor, without touching the avatar/NPC or cross-row ordering (verified: avatar zIndex has no offset, other rows differ by a full tile size `T`, dwarfing the 0.5 epsilon).

Confirmed by reverting the change and reproducing the bug (counter fully hiding the bucket/rod/bait) in the `HubTownCanvas` Millhaven Storybook story, then re-applying the fix and confirming the items render on top across multiple reloads.

## Test plan

- [x] `tsc --noEmit` passes
- [x] Reproduced the bug pre-fix via the `components-hub-hubtowncanvas--millhaven` Storybook story (counter hid the bucket/rod/bait)
- [x] Confirmed the fix renders bucket/rod/bait on top of the counter, consistently across several reloads
- [ ] Manual smoke test in the live game (blocked in this sandbox by Firebase auth not being configured)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R4YTKsojSAR2xhZjksnFMR

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4YTKsojSAR2xhZjksnFMR)_