### PR TITLE
Round 7: Trade Journal + fog-gated grave-moss/wraith-tonic chain

### DIFF
--- a/docs/hubworld.md
+++ b/docs/hubworld.md
@@ -291,7 +291,7 @@ bounds, else a single tile.
 | `buy` | `slotIndex` | Sells the interactable's building's Nth daily-rotating shop-stock item (`getTodaysShopItems`, `SHOP_TRADER_REGISTRY`). Shares `DailyShopState` with `ShopScreen`, so both draw down the same stock. Requires `building`. |
 | `buyPack` | — | Crystal-pack purchase flow (delegates to `onBuyCrystalPack`). Requires `building`. |
 | `buyHubItem` | `itemId`, `price`, `currency?`, `speakerName?`, `prerequisite?`, `lockedText?` | Always-available hub-item purchase (no daily rotation) — see §16. `itemId` must exist in `hubItems.json`; `currency` is `'crystals'` (default) or `'tickets'`. Unique items (e.g. the fishing rod) re-offer as "already owned" once bought. `speakerName` overrides the building-NPC speaker (useful for exterior stalls). `prerequisite` (§14 syntax, including `reputation:<tier>`) gates the offer — unmet shows `lockedText` (or a default refusal) instead. |
-| `dig` | `requiresItemId?`, `nightOnly?`, `weatherOnly?`, `lootTable?` | Once-per-day dig spot (see §16), gated on holding the tool hub-item (default `'spade'`). `nightOnly: true` makes it a **dark hollow** that refuses by day; `weatherOnly` (e.g. `"rain"`) makes it refuse unless the town's resolved weather (§12) matches — used by **rain barrels**. `lootTable: 'earth'` (default) rolls 50% worms (+2 fish bait) / 30% crystals (10–25) / 20% a dug-up trinket; `'hollow'` rolls 50% glowcap mushroom / 25% crystals (15–35) / 25% a firefly; `'rain'` always yields 1 rainwater. Cooldown persists per spot per real day in `jarv_hub_digs` (`web/src/game/hub/digs.ts`). Pair with a `mediumDirt` decor tile (`zlayer: "below"`) for an earth patch, or `barrel` for a rain barrel. |
+| `dig` | `requiresItemId?`, `nightOnly?`, `weatherOnly?`, `lootTable?` | Once-per-day dig spot (see §16), gated on holding the tool hub-item (default `'spade'`). `nightOnly: true` makes it a **dark hollow** that refuses by day; `weatherOnly` (e.g. `"rain"`) makes it refuse unless the town's resolved weather (§12) matches — used by **rain barrels**. `lootTable: 'earth'` (default) rolls 50% worms (+2 fish bait) / 30% crystals (10–25) / 20% a dug-up trinket; `'hollow'` rolls 50% glowcap mushroom / 25% crystals (15–35) / 25% a firefly; `'rain'` always yields 1 rainwater; `'fog'` always yields 1 grave moss. Cooldown persists per spot per real day in `jarv_hub_digs` (`web/src/game/hub/digs.ts`). Pair with a `mediumDirt` decor tile (`zlayer: "below"`) for an earth patch, or `barrel` for a rain barrel. |
 
 Reactions run in order; `dialogue` (and `message`-bearing reactions) chain the
 remainder through the dialogue's close. Conventions: at most one `screen` or
@@ -1400,7 +1400,11 @@ Ravenwatch and Harrowfield in wet seasons) scoop `rainwater` with the
 bucket; Sister Nettle (Hollowmere) pays 30💎 per two. The honey-pie chain:
 Beekeeper Mabe's honey + an egg → Cook Mabel's (Ironhold) hearty pie →
 Warden Rell (Thornwood) 50💎, or Shepherd Nan (Harrowfield) 75💎 **while it
-snows** (`requireWeather`).
+snows** (`requireWeather`). The fog chain: Gravemoor's permanently-foggy
+weather (`ashen` environment default, §12) lets a spade dig up `grave-moss`
+year-round → Alchemist Sythe (Dreadspire Citadel `alchemy-lab`) brews 2 moss
+into a `wraith-tonic` → the Spectral Pedlar (Gravemoor) buys it back for
+65💎.
 
 The longest chain: lantern (Chandlery) → dark hollow at night → glowcaps →
 Morwen's moon draught → the Restless Soldier's first sleep in centuries —
@@ -1459,3 +1463,39 @@ a downstream use for goods that currently dead-end at a crystal payout (e.g.
 the poetry book could also be gifted to a romance-track NPC), multi-item
 recipes (an NPC wanting an egg *and* a spice pouch), and pet-accessory
 rewards on high-value trades.
+
+## §17 — Trade Journal
+
+A discovery-tracked record of hub-item sellers and buyers the player has
+personally encountered — the item economy (§16) has grown large enough that
+players need an in-game way to recall *where* a good is sold or *who* wants
+it, without re-reading NPC dialogue. Mirrors the Town Journal's (§15)
+shape/conventions exactly, but for trade instead of animals/people/places.
+
+- Store: `web/src/game/hub/tradeJournal.ts`, localStorage key
+  `jarv_hub_trade_journal`. Two lists, deduped by `itemId + town + speaker`:
+  ```ts
+  interface SellerEntry { itemId: string; town: string; speaker: string; price: number; currency: 'crystals' | 'tickets' }
+  interface BuyerEntry  { itemId: string; town: string; speaker: string; rewardSummary: string }
+  recordSellerSeen(entry): boolean   // true if newly recorded
+  recordBuyerSeen(entry): boolean
+  getKnownSellers(): SellerEntry[]
+  getKnownBuyers(): BuyerEntry[]
+  ```
+  Fails closed (empty lists / no-op) if `localStorage` throws.
+- UI: `TradeJournalModal.tsx`, opened from the 💱 toolbar button in
+  `HubWorld.tsx` (next to 🎒 Inventory). Two sections — "Known Sellers" /
+  "Known Buyers" — each row showing the item's catalog icon + name, the
+  town/speaker, and the price or reward summary. Empty-state text per
+  section until the player has discovered anything.
+- Discovery timing (discovery-on-tap, not mere visibility — matches §15's
+  rule for the Town Journal): a `buyHubItem` shelf records its seller the
+  moment it's tapped, **before** any `prerequisite`/reputation check — so a
+  locked shelf still reveals itself in the journal, just not yet
+  purchasable. A `tradeHubItem` dialogue choice records its buyer the moment
+  it's clicked, before the missing-goods check — so an attempted trade you
+  can't yet complete still appears under Known Buyers.
+- Because both hooks live in the two generic reaction/effect handlers, every
+  seller and buyer from every round (§16's network list) populates the
+  journal automatically the first time a player encounters them — no
+  per-item retrofit needed.

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -32,6 +32,7 @@ import { addCollectible, addConsumable, getCollectibles, addHubItem, removeHubIt
 import { questItemId } from '../../game/hub/questItems'
 import { QuestsModal } from './QuestsModal'
 import { HubInventoryModal } from './HubInventoryModal'
+import { TradeJournalModal } from './TradeJournalModal'
 import { BountyBoardModal } from './BountyBoardModal'
 import { hasUnclaimedBounties, getPendingBountyReport, getPendingBountyCollect, advanceBountyStep, getActiveBountyStep, isBountyCollectPickup, reconcileBountyPickups } from '../../game/hub/bounties'
 import { PetModal } from './PetModal'
@@ -197,6 +198,7 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onEndless, onWorldMap
   const [pickedUpIds,    setPickedUpIds]    = useState<Set<string>>(() => { reconcileBountyPickups(); return getPickedUpIds() })
   const [questsOpen,          setQuestsOpen]          = useState(false)
   const [inventoryOpen,       setInventoryOpen]       = useState(false)
+  const [tradeJournalOpen,    setTradeJournalOpen]    = useState(false)
   const [bountyBoardOpen,     setBountyBoardOpen]     = useState(false)
   const [petModalOpen,        setPetModalOpen]        = useState(false)
   const [directoryOpen,       setDirectoryOpen]       = useState(false)
@@ -1698,6 +1700,7 @@ function hasOfferableQuest(giverId: string): boolean {
           )}
         <ToolbarButton icon="📜" title="Quests" onClick={() => setQuestsOpen(true)} />
         <ToolbarButton icon="🎒" title="Inventory" onClick={() => setInventoryOpen(true)} />
+        <ToolbarButton icon="💱" title="Trade Journal" onClick={() => setTradeJournalOpen(true)} />
         <ToolbarButton icon="🧭" title="Where is…?" onClick={() => setDirectoryOpen(true)} />
         <ToolbarButton icon="📖" title="Journal" onClick={() => setJournalOpen(true)} />
         <ToolbarButton icon="🏗️" title="Town Upgrades" onClick={() => setUpgradesOpen(true)} />
@@ -1791,6 +1794,7 @@ function hasOfferableQuest(giverId: string): boolean {
 
         {questsOpen && <QuestsModal onClose={() => setQuestsOpen(false)} onAbandon={handleQuestAbandon} questDefs={questDefs} resolveNpcName={getNpcDisplayName}/>}
         {inventoryOpen && <HubInventoryModal onClose={() => setInventoryOpen(false)} questDefs={allQuestDefs} />}
+        {tradeJournalOpen && <TradeJournalModal onClose={() => setTradeJournalOpen(false)} />}
         {bountyBoardOpen && <BountyBoardModal onClose={() => setBountyBoardOpen(false)} resolveNpcName={getNpcDisplayName}/>}
         {petModalOpen && <PetModal onClose={() => setPetModalOpen(false)} petActionRef={petActionRef} />}
         {directoryOpen && <TownDirectory onClose={() => setDirectoryOpen(false)} locationData={locationData} pinnedNpcId={pinnedNpcId} onTogglePin={togglePinnedNpc} onShowRelationship={setRelationshipNpcId} />}

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -7,7 +7,7 @@ import type { MinimapObjective } from './HubMinimap'
 import { HubReturnButton } from './HubReturnButton'
 import { HubDialogue } from './HubDialogue'
 import type { DialogueChoice } from './HubDialogue'
-import type { HubQuestDef, DialogueTree, DialogueChoiceDef } from '../../data/hub/questDefs'
+import type { HubQuestDef, DialogueTree, DialogueChoiceDef, DialogueEffect } from '../../data/hub/questDefs'
 import { emitSound } from '../../game/sound'
 import { getPickedUpIds, markPickedUp, unmarkPickedUp } from '../../game/hub/pickups'
 import { getFriendshipLevel, addFriendshipXp, getFriendshipData } from '../../game/hub/friendship'
@@ -56,6 +56,7 @@ import { interactableStoreKey, isInteractableGranted, markInteractableGranted, g
 import { canDigToday, recordDig } from '../../game/hub/digs'
 import { getReputationTier } from '../../data/hub/buildingUpgrades'
 import { resolveWeather } from '../../game/hub/weather'
+import { recordSellerSeen, recordBuyerSeen } from '../../game/hub/tradeJournal'
 import { recordNpcMet, recordAnimalSeen, recordAreaSeen } from '../../game/hub/journal'
 import { getTodaysShopItems } from '../../game/hub/shopStock'
 import { loadDailyShopState, saveDailyShopState, isShopItemSold, markCardBought, markAugmentBought } from '../../game/shopSchedule'
@@ -735,6 +736,21 @@ function formatQuestReward(reward: HubQuestDef['reward']): string {
   return parts.length > 0 ? `You received: ${parts.join('  ·  ')}` : ''
 }
 
+// Short reward summary for a tradeHubItem effect, used by the Trade Journal
+// (tradeJournal.ts) to describe what a discovered buyer gives in return.
+function formatTradeReward(eff: Extract<DialogueEffect, { type: 'tradeHubItem' }>): string {
+  const parts: string[] = []
+  if (eff.giveCrystals) parts.push(`+${eff.giveCrystals} 💎`)
+  if (eff.giveHubItem) {
+    const catalog = getHubItemCatalogEntry(eff.giveHubItem.itemId)
+    parts.push(`${catalog?.icon ?? '📦'} ${catalog?.name ?? eff.giveHubItem.itemId}`)
+  }
+  if (eff.giveCollectible) parts.push(`${eff.giveCollectible.icon} ${eff.giveCollectible.name}`)
+  if (eff.giveFriendship) parts.push(`+${eff.giveFriendship.xp} friendship`)
+  if (eff.giveRelationship) parts.push(`+${eff.giveRelationship.points} ${eff.giveRelationship.track}`)
+  return parts.join('  ·  ')
+}
+
 function grantQuestReward(quest: HubQuestDef): void {
   const { reward } = quest
   if (reward.crystals) {
@@ -898,6 +914,12 @@ function hasOfferableQuest(giverId: string): boolean {
           // Repeatable barter: consume the wanted hub-item(s), grant the
           // reward(s). If the player holds too few, show missingText and stop
           // (no navigation — the player can come back with the goods).
+          // Journal the buyer on attempt (even if the trade fails for lack of
+          // goods) — the player has still discovered it exists.
+          const primaryWant = eff.wantItems?.[0]?.itemId ?? eff.wantItemId
+          if (primaryWant) {
+            recordBuyerSeen({ itemId: primaryWant, town, speaker: speakerName, rewardSummary: formatTradeReward(eff) })
+          }
           // Multi-item recipes (wantItems) are all-or-nothing: verify every
           // count before removing anything.
           const wanted: Array<{ itemId: string; count: number }> = eff.wantItems
@@ -1483,6 +1505,10 @@ function hasOfferableQuest(giverId: string): boolean {
         const candidates = def.building ? locationData.HUB_NPCS.filter(n => n.building === def.building) : []
         const onDuty = candidates.find(n => def.building && resolveNpcPlace(n, gameHour, locationData).interiorId === def.building)
         const speakerName = r.speakerName ?? (onDuty ?? candidates[0])?.name ?? ''
+
+        // Journal the seller on sight — even a reputation-locked shelf reveals
+        // itself, so the player learns it exists before they can afford it.
+        recordSellerSeen({ itemId: r.itemId, town, speaker: speakerName, price: r.price, currency: r.currency ?? 'crystals' })
 
         if (r.prerequisite && !checkPrerequisite(r.prerequisite, town)) {
           setDialogueEvent({

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -1567,6 +1567,8 @@ function hasOfferableQuest(giverId: string): boolean {
         if (r.weatherOnly && r.weatherOnly !== currentWeather) {
           setDialogueEvent({ speakerName: '', text: r.weatherOnly === 'rain'
             ? 'The barrel sits bone dry. Come back when the rain does.'
+            : r.weatherOnly === 'fog'
+            ? 'The ground is bare and dry. This moss only grows thick in fog.'
             : 'The weather is all wrong for this. Come back another time.' })
           return
         }
@@ -1603,6 +1605,25 @@ function hasOfferableQuest(giverId: string): boolean {
           setDialogueEvent({
             speakerName: '',
             text: 'The rain barrel brims with fresh water, drumming softly under the downpour.',
+            choices: [confirm, { label: 'Leave it', onClick: () => setDialogueEvent(null) }],
+          })
+          return
+        }
+        if (r.lootTable === 'fog') {
+          const confirm: DialogueChoice = {
+            label: 'Gather the moss',
+            primary: true,
+            onClick: () => {
+              recordDig(storeKey)
+              addHubItem('grave-moss', 1)
+              emitSound('pickup')
+              refreshState()
+              setDialogueEvent({ speakerName: '', text: 'You peel a handful of pale, damp moss from the stones. It only grows this thick in fog. 🌫️', onClose: next })
+            },
+          }
+          setDialogueEvent({
+            speakerName: '',
+            text: 'Thick fog clings low to the ground here, and moss grows fat and pale between the roots.',
             choices: [confirm, { label: 'Leave it', onClick: () => setDialogueEvent(null) }],
           })
           return

--- a/web/src/components/hub/TradeJournalModal.stories.tsx
+++ b/web/src/components/hub/TradeJournalModal.stories.tsx
@@ -1,0 +1,49 @@
+import { fn } from 'storybook/test'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { TradeJournalModal } from './TradeJournalModal'
+
+function seedJournal(sellers: unknown[], buyers: unknown[]): void {
+  localStorage.setItem('jarv_hub_trade_journal', JSON.stringify({ sellers, buyers }))
+}
+
+const meta = {
+  component: TradeJournalModal,
+  parameters: { layout: 'fullscreen' },
+  decorators: [
+    (Story) => (
+      <div className="game-container">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof TradeJournalModal>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Empty: Story = {
+  args: { onClose: fn() },
+  decorators: [
+    (Story) => { seedJournal([], []); return <Story /> },
+  ],
+}
+
+export const WithDiscoveries: Story = {
+  args: { onClose: fn() },
+  decorators: [
+    (Story) => {
+      seedJournal(
+        [
+          { itemId: 'chicken-feed', town: 'Millhaven', speaker: 'Baker Pernel', price: 5, currency: 'crystals' },
+          { itemId: 'net', town: 'Saltmere Port', speaker: 'Net-Maker Quill', price: 60, currency: 'crystals' },
+          { itemId: 'gilded-compass', town: 'Ravenwatch', speaker: 'Guild Master Ferryn', price: 120, currency: 'crystals' },
+        ],
+        [
+          { itemId: 'egg', town: 'Capital City', speaker: 'Baker Otto', rewardSummary: '+20 💎' },
+          { itemId: 'firefly', town: 'Gravemoor', speaker: 'Little Pip', rewardSummary: '+30 💎  ·  +5 friendship' },
+        ],
+      )
+      return <Story />
+    },
+  ],
+}

--- a/web/src/components/hub/TradeJournalModal.tsx
+++ b/web/src/components/hub/TradeJournalModal.tsx
@@ -1,0 +1,72 @@
+import React from 'react'
+import { ModalBackdrop } from '../ui/ModalBackdrop'
+import { getKnownSellers, getKnownBuyers, SellerEntry, BuyerEntry } from '../../game/hub/tradeJournal'
+import { getHubItemCatalogEntry } from '../../game/itemStore'
+
+interface Props {
+  onClose: () => void
+}
+
+function itemDisplay(itemId: string): { name: string; icon: string } {
+  const catalog = getHubItemCatalogEntry(itemId)
+  return { name: catalog?.name ?? itemId, icon: catalog?.icon ?? '📦' }
+}
+
+export function TradeJournalModal({ onClose }: Props) {
+  const sellers = getKnownSellers()
+  const buyers = getKnownBuyers()
+
+  const sellerRow = (entry: SellerEntry) => {
+    const { name, icon } = itemDisplay(entry.itemId)
+    const currencyIcon = entry.currency === 'tickets' ? '🎫' : '💎'
+    return (
+      <div key={`${entry.itemId}:${entry.town}:${entry.speaker}`} className="quests-modal__card">
+        <div className="quests-modal__title">{icon} {name}</div>
+        <div className="quests-modal__step">
+          <span>{entry.speaker} — {entry.town}</span>
+          <span>{entry.price} {currencyIcon}</span>
+        </div>
+      </div>
+    )
+  }
+
+  const buyerRow = (entry: BuyerEntry) => {
+    const { name, icon } = itemDisplay(entry.itemId)
+    return (
+      <div key={`${entry.itemId}:${entry.town}:${entry.speaker}`} className="quests-modal__card">
+        <div className="quests-modal__title">{icon} {name}</div>
+        <div className="quests-modal__step">
+          <span>{entry.speaker} — {entry.town}</span>
+          <span>{entry.rewardSummary}</span>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <ModalBackdrop onClose={onClose}>
+      <div className="quests-modal">
+        <div className="quests-modal__header">
+          <span>💱 Trade Journal</span>
+          <span className="quests-modal__meta">
+            <button className="quests-modal__close" onClick={onClose}>✕</button>
+          </span>
+        </div>
+
+        <div className="quests-modal__section-label">Known Sellers</div>
+        {sellers.length === 0 ? (
+          <div className="quests-modal__empty">You haven't found anyone selling anything yet.</div>
+        ) : (
+          sellers.map(sellerRow)
+        )}
+
+        <div className="quests-modal__section-label">Known Buyers</div>
+        {buyers.length === 0 ? (
+          <div className="quests-modal__empty">You haven't found anyone wanting to trade yet.</div>
+        ) : (
+          buyers.map(buyerRow)
+        )}
+      </div>
+    </ModalBackdrop>
+  )
+}

--- a/web/src/data/hub/dreadspirecitadel/config.json
+++ b/web/src/data/hub/dreadspirecitadel/config.json
@@ -666,6 +666,7 @@
     {
       "id": "alchemist-sythe",
       "name": "Alchemist Sythe",
+      "dialogueTree": "sythe-tonic-brew",
       "sprite": "sea-witch",
       "building": "alchemy-lab",
       "tx": 5,

--- a/web/src/data/hub/dreadspirecitadel/questDefs.json
+++ b/web/src/data/hub/dreadspirecitadel/questDefs.json
@@ -953,6 +953,42 @@
           ]
         }
       }
+    },
+    {
+      "id": "sythe-tonic-brew",
+      "npcId": "alchemist-sythe",
+      "start": "greet",
+      "nodes": {
+        "greet": {
+          "text": "Grave moss, is it? From the fog out past the walls. Bring me two handfuls and I'll brew you something with a bit more bite than tea.",
+          "choices": [
+            {
+              "label": "Brew a wraith tonic (2 grave moss)",
+              "next": "greet",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "grave-moss",
+                  "wantCount": 2,
+                  "giveHubItem": {
+                    "itemId": "wraith-tonic"
+                  },
+                  "missingText": "Two handfuls, I said. The fog only sits thick over Gravemoor \u2014 dig there while it clings low.",
+                  "successText": "She swirls the moss into a simmering flask until it turns the colour of old bruises. One wraith tonic, still warm. Don't drink it yourself."
+                }
+              ]
+            },
+            {
+              "label": "Later, Sythe.",
+              "effects": [
+                {
+                  "type": "end"
+                }
+              ]
+            }
+          ]
+        }
+      }
     }
   ],
   "friendshipDialogue": {

--- a/web/src/data/hub/gravemoor/config.json
+++ b/web/src/data/hub/gravemoor/config.json
@@ -1270,6 +1270,7 @@
     {
       "id": "spectral-pedlar",
       "name": "The Spectral Pedlar",
+      "dialogueTree": "pedlar-tonic-trade",
       "sprite": "hub-npc-trader",
       "isGhost": true,
       "tx": 13,
@@ -2578,6 +2579,27 @@
           "requiresItemId": "lantern",
           "nightOnly": true,
           "lootTable": "hollow"
+        }
+      ]
+    },
+    {
+      "id": "gravemoor-fog-moss",
+      "tx": 13,
+      "ty": 11,
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "tileId": "mediumDirt",
+          "zlayer": "below"
+        }
+      ],
+      "reactions": [
+        {
+          "type": "dig",
+          "requiresItemId": "spade",
+          "weatherOnly": "fog",
+          "lootTable": "fog"
         }
       ]
     },

--- a/web/src/data/hub/gravemoor/questDefs.json
+++ b/web/src/data/hub/gravemoor/questDefs.json
@@ -137,6 +137,39 @@
           ]
         }
       }
+    },
+    {
+      "id": "pedlar-tonic-trade",
+      "npcId": "spectral-pedlar",
+      "start": "greet",
+      "nodes": {
+        "greet": {
+          "text": "A wraith tonic! Now THAT still sells, even among the departed. Sythe brews them over in the citadel, if you've the moss for it.",
+          "choices": [
+            {
+              "label": "Sell a wraith tonic \u2014 65 \ud83d\udc8e",
+              "next": "greet",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "wraith-tonic",
+                  "giveCrystals": 65,
+                  "missingText": "No tonic on you? Alchemist Sythe brews them, over in Dreadspire Citadel \u2014 for a price in grave moss.",
+                  "successText": "He uncorks it, sniffs once, and beams. 'Still got the bite.' 65 crystals, straight from a ghost's own purse."
+                }
+              ]
+            },
+            {
+              "label": "Just browsing.",
+              "effects": [
+                {
+                  "type": "end"
+                }
+              ]
+            }
+          ]
+        }
+      }
     }
   ],
   "quests": [

--- a/web/src/data/hub/loader.ts
+++ b/web/src/data/hub/loader.ts
@@ -281,8 +281,9 @@ export type HubInteractableReaction =
    *  (default 'spade'); `nightOnly` spots open after dark only; `weatherOnly`
    *  spots only work while the town's weather matches (e.g. rain barrels).
    *  lootTable 'earth' (default) rolls worms/crystals/trinket; 'hollow'
-   *  rolls glowcaps/crystals/fireflies; 'rain' always yields rainwater. */
-  | { type: 'dig'; requiresItemId?: string; nightOnly?: boolean; weatherOnly?: string; lootTable?: 'earth' | 'hollow' | 'rain' }
+   *  rolls glowcaps/crystals/fireflies; 'rain' always yields rainwater;
+   *  'fog' always yields grave-moss. */
+  | { type: 'dig'; requiresItemId?: string; nightOnly?: boolean; weatherOnly?: string; lootTable?: 'earth' | 'hollow' | 'rain' | 'fog' }
 
 export interface HubInteractable {
   id: string

--- a/web/src/data/hubItems.json
+++ b/web/src/data/hubItems.json
@@ -255,5 +255,19 @@
     "icon": "🥧",
     "desc": "Cook Mabel's egg-and-honey pie. Best eaten hot; best of all in the snow.",
     "category": "material"
+  },
+  {
+    "id": "grave-moss",
+    "name": "Grave Moss",
+    "icon": "🌫️",
+    "desc": "Pale moss that only grows in deep fog. Alchemists prize it.",
+    "category": "material"
+  },
+  {
+    "id": "wraith-tonic",
+    "name": "Wraith Tonic",
+    "icon": "🧪",
+    "desc": "Sythe's fog-brewed tonic. Even bone-keepers pay well for it.",
+    "category": "material"
   }
 ]

--- a/web/src/game/hub/tradeJournal.test.ts
+++ b/web/src/game/hub/tradeJournal.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { recordSellerSeen, recordBuyerSeen, getKnownSellers, getKnownBuyers } from './tradeJournal'
+
+function installLocalStorageStub(): void {
+  const store = new Map<string, string>()
+  vi.stubGlobal('localStorage', {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => { store.set(k, v) },
+    removeItem: (k: string) => { store.delete(k) },
+    clear: () => { store.clear() },
+  })
+}
+
+describe('tradeJournal', () => {
+  beforeEach(() => {
+    installLocalStorageStub()
+  })
+
+  it('records a new seller and returns it from getKnownSellers', () => {
+    expect(getKnownSellers()).toEqual([])
+    const entry = { itemId: 'chicken-feed', town: 'Millhaven', speaker: 'Baker Pernel', price: 5, currency: 'crystals' as const }
+    expect(recordSellerSeen(entry)).toBe(true)
+    expect(getKnownSellers()).toEqual([entry])
+  })
+
+  it('dedupes sellers by itemId+town+speaker', () => {
+    const entry = { itemId: 'net', town: 'Saltmere Port', speaker: 'Net-Maker Quill', price: 60, currency: 'crystals' as const }
+    expect(recordSellerSeen(entry)).toBe(true)
+    expect(recordSellerSeen(entry)).toBe(false)
+    expect(getKnownSellers()).toHaveLength(1)
+  })
+
+  it('treats the same item from a different speaker/town as a distinct seller', () => {
+    recordSellerSeen({ itemId: 'fish-bait', town: 'Millhaven', speaker: 'Harbour Tackle Stall', price: 8, currency: 'crystals' })
+    recordSellerSeen({ itemId: 'fish-bait', town: 'Saltmere Port', speaker: 'Some Other Stall', price: 10, currency: 'crystals' })
+    expect(getKnownSellers()).toHaveLength(2)
+  })
+
+  it('records buyers and dedupes the same way', () => {
+    const entry = { itemId: 'egg', town: 'Capital City', speaker: 'Baker Otto', rewardSummary: '+20 💎' }
+    expect(recordBuyerSeen(entry)).toBe(true)
+    expect(recordBuyerSeen(entry)).toBe(false)
+    expect(getKnownBuyers()).toEqual([entry])
+  })
+
+  it('fails closed to empty lists when localStorage throws', () => {
+    vi.stubGlobal('localStorage', {
+      getItem: () => { throw new Error('blocked') },
+      setItem: () => { throw new Error('blocked') },
+    })
+    expect(getKnownSellers()).toEqual([])
+    expect(getKnownBuyers()).toEqual([])
+    expect(() => recordSellerSeen({ itemId: 'x', town: 'Y', speaker: 'Z', price: 1, currency: 'crystals' })).not.toThrow()
+  })
+})

--- a/web/src/game/hub/tradeJournal.ts
+++ b/web/src/game/hub/tradeJournal.ts
@@ -1,0 +1,87 @@
+// ─── Trade Journal ──────────────────────────────────────────────────────────
+//
+// Discovery-tracked record of hub-item sellers and buyers the player has
+// encountered, mirroring journal.ts's shape/conventions. Fed by the
+// buyHubItem and tradeHubItem reaction handlers (HubWorld.tsx) on tap/attempt
+// — matching journal.ts's "discovery on tap, not mere visibility" rule.
+
+import { logError } from '../../logger'
+
+const KEY = 'jarv_hub_trade_journal'
+
+export interface SellerEntry {
+  itemId: string
+  town: string
+  speaker: string
+  price: number
+  currency: 'crystals' | 'tickets'
+}
+
+export interface BuyerEntry {
+  itemId: string
+  town: string
+  speaker: string
+  rewardSummary: string
+}
+
+interface TradeJournalData {
+  sellers: SellerEntry[]
+  buyers: BuyerEntry[]
+}
+
+function emptyData(): TradeJournalData {
+  return { sellers: [], buyers: [] }
+}
+
+function load(): TradeJournalData {
+  try {
+    const raw = localStorage.getItem(KEY)
+    if (!raw) return emptyData()
+    const parsed = JSON.parse(raw) as Partial<TradeJournalData>
+    return { sellers: parsed.sellers ?? [], buyers: parsed.buyers ?? [] }
+  } catch {
+    return emptyData()
+  }
+}
+
+function save(data: TradeJournalData): void {
+  try {
+    localStorage.setItem(KEY, JSON.stringify(data))
+  } catch (e) {
+    logError('tradeJournal save failed', { error: String(e) })
+  }
+}
+
+function sameSeller(a: SellerEntry, b: SellerEntry): boolean {
+  return a.itemId === b.itemId && a.town === b.town && a.speaker === b.speaker
+}
+
+function sameBuyer(a: BuyerEntry, b: BuyerEntry): boolean {
+  return a.itemId === b.itemId && a.town === b.town && a.speaker === b.speaker
+}
+
+/** Record a discovered seller (itemId+town+speaker deduped). Returns true if newly recorded. */
+export function recordSellerSeen(entry: SellerEntry): boolean {
+  const data = load()
+  if (data.sellers.some(s => sameSeller(s, entry))) return false
+  data.sellers.push(entry)
+  save(data)
+  return true
+}
+
+/** Record a discovered buyer (itemId+town+speaker deduped). Returns true if newly recorded. */
+export function recordBuyerSeen(entry: BuyerEntry): boolean {
+  const data = load()
+  if (data.buyers.some(b => sameBuyer(b, entry))) return false
+  data.buyers.push(entry)
+  save(data)
+  return true
+}
+
+export function getKnownSellers(): SellerEntry[] {
+  return load().sellers
+}
+
+export function getKnownBuyers(): BuyerEntry[] {
+  return load().buyers
+}


### PR DESCRIPTION
## Summary

- Adds a **Trade Journal** — a discovery-tracked in-game record of hub-item sellers/buyers the player has personally encountered, mirroring the existing Town Journal (`journal.ts`) pattern. New localStorage-backed store (`tradeJournal.ts`), a 💱 toolbar button, and a `TradeJournalModal` UI with "Known Sellers" / "Known Buyers" sections.
- Wires discovery into the two existing generic handlers (`buyHubItem`, `tradeHubItem`) so **every seller/buyer from all six prior rounds populates the journal automatically** the first time a player encounters them — no per-item retrofit needed. Sellers record even when reputation-locked; buyers record even on a failed trade attempt (discovery-on-tap, not mere visibility).
- Adds a new **fog-gated content chain**, using the last unused weather value (`fog`, permanently active in Gravemoor/Dreadspire Citadel per the `ashen` environment default): a new `dig` `lootTable: 'fog'` branch (mirrors `'rain'` — always yields one item) lets players dig up `grave-moss` with a spade in Gravemoor's permanent fog. Alchemist Sythe (Dreadspire Citadel) brews 2 moss into a `wraith-tonic`, which the Spectral Pedlar (Gravemoor) buys back for 65💎.
- Documents both additions in `docs/hubworld.md` (new §17 — Trade Journal; §7/§16 updates for the fog loot table and network chain).

## Test plan

- [x] `npm run test` — 944/944 tests passing (including new `tradeJournal.test.ts`: record/dedupe sellers & buyers, fail-closed on corrupt storage)
- [x] `npm run build` — clean
- [x] `npx tsc --noEmit` — clean
- [ ] In-game: tap a `buyHubItem` shelf (including a reputation-locked one) → confirm it appears under Known Sellers in the 💱 Trade Journal. Attempt a `tradeHubItem` trade → confirm it appears under Known Buyers. Buy a spade (Gearford), dig the Gravemoor fog spot for grave-moss, carry 2 to Alchemist Sythe (Dreadspire Citadel) for a wraith-tonic, sell it to the Spectral Pedlar (Gravemoor) for 65💎 — verify persistence across reload.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HFBFbZdCft98Dbr1WdRHoT)_