### PR TITLE
Tighten pet leash to 5 tiles and sit it when the player stops moving

### DIFF
--- a/web/src/components/hub/hubAnimals.ts
+++ b/web/src/components/hub/hubAnimals.ts
@@ -143,7 +143,7 @@ export const PLAYER_OWNER_ID = '__player__'
 export const PLAYER_PET_ANIMAL_ID = '__player-pet__'
 /** The player's pet is never allowed to wander more than this many tiles
  *  from the player — enforced by the leash check in the dog tick dispatch. */
-export const PLAYER_LEASH_TILES = 8
+export const PLAYER_LEASH_TILES = 5
 
 export interface AnimalSystem {
   tick: (deltaMS: number) => void
@@ -187,6 +187,11 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
   const animals: Animal[] = []
   // Set by sendPetFetching(); fired once the fetching pet is back near the player.
   let fetchCallback: (() => void) | null = null
+  // Tracks how long the player has been stationary, so the player's pet can
+  // sit rather than roam off — makes it a stable, easy tap target instead of
+  // a constantly-moving one.
+  let ownerLastPx: Pt | null = null
+  let ownerStillMs = 0
 
   const overlayAnimLayer = new PIXI.Container()   // birds + butterflies (above buildings)
   const fishLayer = new PIXI.Container()
@@ -827,6 +832,11 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
     const avatar = opts.getAvatarPx()
     const npcs = opts.getNpcPositions()
     const hour = opts.getGameHour()
+
+    const ownerMoveDist = ownerLastPx ? Math.hypot(avatar.x - ownerLastPx.x, avatar.y - ownerLastPx.y) : Infinity
+    ownerStillMs = ownerMoveDist > 1 ? 0 : ownerStillMs + dt
+    ownerLastPx = { x: avatar.x, y: avatar.y }
+    const ownerIsStill = ownerStillMs > 400   // debounced so brief pauses/collisions don't flicker the pet in and out of sitting
     const night = isNightHour(hour)
 
     // Ambient critter sounds: every few seconds a nearby, visible, vocal animal
@@ -908,6 +918,17 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
         tickFetching(a, walkable, npcs)
       } else {
         dogSocial(a, dt, npcs)
+        // The player's own pet sits still (rather than roaming) whenever the
+        // player is stationary, so it's a stable, easy tap target instead of
+        // a constantly-moving one. Chase/fetch are left uninterrupted since
+        // they're brief and often happen while the player stands still anyway.
+        if (a.ownerId === PLAYER_OWNER_ID && ownerIsStill && a.state !== 'chase' && a.state !== 'fetching-out' && a.state !== 'fetching-return') {
+          if (a.state !== 'sit' || isMoving(a)) {
+            a.path = []; a.movingTo = null; a.target = null
+            a.state = 'sit'; a.stateTimer = randomDuration('sit')
+          }
+          continue
+        }
         dogChasePrey(a, dt)
         if (a.state === 'follow-owner' && !isMoving(a) && a.stateTimer > 0) {
           const owner = npcs.find(n => n.id === a.ownerId)


### PR DESCRIPTION
## Summary

- Follow-up to investigating "I can't interact with my pet" — the tap pipeline itself works correctly end-to-end (verified by instrumenting the real code: sprite `pointerdown` → `onAnimalTap` → `HubWorld`'s `handleAnimalTap` → the "What would you like to do?" menu). The actual friction is that the pet is a small (~34px), continuously-roaming sprite, making it a genuinely hard target to land a tap on.
- `PLAYER_LEASH_TILES` (`web/src/components/hub/hubAnimals.ts`) reduced from 8 to 5, per request.
- The player's pet now sits still — interrupting any in-progress roam/follow path — whenever the player has been stationary for a moment (~400ms debounce, so brief pauses/collisions don't flicker it in and out of sitting). Chase and fetch (Give a Treat) are left uninterrupted since they're brief and often happen while the player is already standing still.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run src/game/hub/pet.test.ts src/game/hub/animals.test.ts` — 40 tests passing
- [x] Scripted browser verification (Storybook, `HubWorld` story): with the player stationary, the pet's `state` reliably becomes `'sit'` and its position holds perfectly fixed across repeated polls; it resumes roaming again once the player moves
- [ ] Manual smoke test in the live game: confirm the pet settles down and stays put shortly after you stop walking, and that it's easy to tap once still

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4YTKsojSAR2xhZjksnFMR)_