### PR TITLE
Fix pet accessory blocking taps on the follower dog

### DIFF
--- a/web/src/components/hub/hubAnimals.ts
+++ b/web/src/components/hub/hubAnimals.ts
@@ -1174,6 +1174,7 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
       sprite.position.copyFrom(a.sprite.position)
       sprite.scale.x = a.sprite.scale.x
       sprite.zIndex = a.sprite.zIndex + 0.5
+      sprite.eventMode = 'none'  // cosmetic overlay must not block taps on the dog beneath it
       a.sprite.parent?.addChild(sprite)
       a.accessorySprite = sprite
     }).catch(() => {})


### PR DESCRIPTION
The composited accessory sprite defaulted to PixiJS's 'passive' event mode, which relies on children/z-order bookkeeping that the animal system doesn't keep in sync (zIndex re-sorts are only triggered by avatar/NPC movement, not animal or accessory changes). Once an accessory was equipped, it could end up ahead of the dog in hit-test order and silently swallow taps meant for the dog, so the pet interaction menu (and Manage -> Pet Modal) never opened.

Explicitly setting eventMode = 'none' on the accessory sprite (same pattern already used for the night overlay) guarantees it's excluded from hit-testing regardless of sort order.