### PR TITLE
Add coat patterns for pets (tuxedo/tabby/calico cats, brindle/black-and-tan/spotted dogs)

### DIFF
--- a/web/public/sprites/pattern-cat-calico-base-1.svg
+++ b/web/public/sprites/pattern-cat-calico-base-1.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- walk frame 1 -->
+  <ellipse cx="14" cy="18.5" rx="5.85" ry="3" fill="#ffffff"/>
+</svg>

--- a/web/public/sprites/pattern-cat-calico-base-2.svg
+++ b/web/public/sprites/pattern-cat-calico-base-2.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- walk frame 2 — mid stride, body 1px higher -->
+  <ellipse cx="14" cy="17.5" rx="5.85" ry="3" fill="#ffffff"/>
+</svg>

--- a/web/public/sprites/pattern-cat-calico-base-3.svg
+++ b/web/public/sprites/pattern-cat-calico-base-3.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- walk frame 3 — stride B -->
+  <ellipse cx="14" cy="18.5" rx="5.85" ry="3" fill="#ffffff"/>
+</svg>

--- a/web/public/sprites/pattern-cat-calico-base-sleep.svg
+++ b/web/public/sprites/pattern-cat-calico-base-sleep.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- curled, sleeping -->
+  <ellipse cx="16" cy="22.85" rx="6.5" ry="3.3" fill="#ffffff"/>
+</svg>

--- a/web/public/sprites/pattern-cat-calico-base.svg
+++ b/web/public/sprites/pattern-cat-calico-base.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- calico base patch: back "saddle", tinted with the pet's own picked colour -->
+  <ellipse cx="14" cy="18.5" rx="5.85" ry="3" fill="#ffffff"/>
+</svg>

--- a/web/public/sprites/pattern-cat-calico-ginger-1.svg
+++ b/web/public/sprites/pattern-cat-calico-ginger-1.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- walk frame 1 -->
+  <circle cx="24.38" cy="15.08" r="2.3" fill="#ffffff"/>
+  <circle cx="7" cy="22" r="1.8" fill="#ffffff"/>
+</svg>

--- a/web/public/sprites/pattern-cat-calico-ginger-2.svg
+++ b/web/public/sprites/pattern-cat-calico-ginger-2.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- walk frame 2 — mid stride, body 1px higher -->
+  <circle cx="24.38" cy="14.08" r="2.3" fill="#ffffff"/>
+  <circle cx="7" cy="21" r="1.8" fill="#ffffff"/>
+</svg>

--- a/web/public/sprites/pattern-cat-calico-ginger-3.svg
+++ b/web/public/sprites/pattern-cat-calico-ginger-3.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- walk frame 3 — stride B -->
+  <circle cx="24.38" cy="15.08" r="2.3" fill="#ffffff"/>
+  <circle cx="7" cy="22" r="1.8" fill="#ffffff"/>
+</svg>

--- a/web/public/sprites/pattern-cat-calico-ginger-sleep.svg
+++ b/web/public/sprites/pattern-cat-calico-ginger-sleep.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- curled, sleeping -->
+  <circle cx="10.32" cy="21.12" r="2.2" fill="#ffffff"/>
+  <circle cx="7" cy="23" r="1.8" fill="#ffffff"/>
+</svg>

--- a/web/public/sprites/pattern-cat-calico-ginger.svg
+++ b/web/public/sprites/pattern-cat-calico-ginger.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- calico ginger patch: head + tail-base — fixed ginger tint -->
+  <circle cx="24.38" cy="15.08" r="2.3" fill="#ffffff"/>
+  <circle cx="7" cy="22" r="1.8" fill="#ffffff"/>
+</svg>

--- a/web/public/sprites/pattern-cat-calico-white-1.svg
+++ b/web/public/sprites/pattern-cat-calico-white-1.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- walk frame 1 -->
+  <ellipse cx="17.6" cy="22.5" rx="3" ry="2" fill="#ffffff"/>
+  <rect x="7" y="26" width="2.6" height="2" rx="1" fill="#ffffff"/>
+  <rect x="21" y="26" width="2.6" height="2" rx="1" fill="#ffffff"/>
+  <circle cx="22" cy="18.8" r="1.3" fill="#ffffff"/>
+</svg>

--- a/web/public/sprites/pattern-cat-calico-white-2.svg
+++ b/web/public/sprites/pattern-cat-calico-white-2.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- walk frame 2 — mid stride, body 1px higher -->
+  <ellipse cx="17.6" cy="21.5" rx="3" ry="2" fill="#ffffff"/>
+  <rect x="9" y="26" width="2.6" height="2" rx="1" fill="#ffffff"/>
+  <rect x="19" y="26" width="2.6" height="2" rx="1" fill="#ffffff"/>
+  <circle cx="22" cy="17.8" r="1.3" fill="#ffffff"/>
+</svg>

--- a/web/public/sprites/pattern-cat-calico-white-3.svg
+++ b/web/public/sprites/pattern-cat-calico-white-3.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- walk frame 3 — stride B -->
+  <ellipse cx="17.6" cy="22.5" rx="3" ry="2" fill="#ffffff"/>
+  <rect x="11" y="26" width="2.6" height="2" rx="1" fill="#ffffff"/>
+  <rect x="17" y="26" width="2.6" height="2" rx="1" fill="#ffffff"/>
+  <circle cx="22" cy="18.8" r="1.3" fill="#ffffff"/>
+</svg>

--- a/web/public/sprites/pattern-cat-calico-white-sleep.svg
+++ b/web/public/sprites/pattern-cat-calico-white-sleep.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- curled, sleeping -->
+  <ellipse cx="16" cy="27.3" rx="4" ry="1.8" fill="#ffffff"/>
+  <circle cx="8" cy="24.6" r="1.3" fill="#ffffff"/>
+</svg>

--- a/web/public/sprites/pattern-cat-calico-white.svg
+++ b/web/public/sprites/pattern-cat-calico-white.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- calico white patch: chest, paws, chin — fixed white -->
+  <ellipse cx="17.6" cy="22.5" rx="3" ry="2" fill="#ffffff"/>
+  <rect x="9" y="26" width="2.6" height="2" rx="1" fill="#ffffff"/>
+  <rect x="19" y="26" width="2.6" height="2" rx="1" fill="#ffffff"/>
+  <circle cx="22" cy="18.8" r="1.3" fill="#ffffff"/>
+</svg>

--- a/web/public/sprites/pattern-cat-tabby-stripes-1.svg
+++ b/web/public/sprites/pattern-cat-tabby-stripes-1.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- walk frame 1 -->
+  <path d="M11,16 Q12,19.5 11,22.5" stroke="#ffffff" stroke-width="1.3" fill="none" stroke-linecap="round"/>
+  <path d="M14.5,15.5 Q15.5,19 14.5,22" stroke="#ffffff" stroke-width="1.3" fill="none" stroke-linecap="round"/>
+  <path d="M18,16 Q19,19.5 18,22.5" stroke="#ffffff" stroke-width="1.3" fill="none" stroke-linecap="round"/>
+  <path d="M21.5,13.2 L23,11.6 L24.5,13.2" stroke="#ffffff" stroke-width="1.1" fill="none" stroke-linecap="round"/>
+  <path d="M6.5,22 L7.5,21" stroke="#ffffff" stroke-width="1.1" fill="none" stroke-linecap="round"/>
+  <path d="M5.3,16.5 L6.3,15.3" stroke="#ffffff" stroke-width="1.1" fill="none" stroke-linecap="round"/>
+</svg>

--- a/web/public/sprites/pattern-cat-tabby-stripes-2.svg
+++ b/web/public/sprites/pattern-cat-tabby-stripes-2.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- walk frame 2 — mid stride, body 1px higher -->
+  <path d="M11,15 Q12,18.5 11,21.5" stroke="#ffffff" stroke-width="1.3" fill="none" stroke-linecap="round"/>
+  <path d="M14.5,14.5 Q15.5,18 14.5,21" stroke="#ffffff" stroke-width="1.3" fill="none" stroke-linecap="round"/>
+  <path d="M18,15 Q19,18.5 18,21.5" stroke="#ffffff" stroke-width="1.3" fill="none" stroke-linecap="round"/>
+  <path d="M21.5,12.2 L23,10.6 L24.5,12.2" stroke="#ffffff" stroke-width="1.1" fill="none" stroke-linecap="round"/>
+  <path d="M6.5,21 L7.5,20" stroke="#ffffff" stroke-width="1.1" fill="none" stroke-linecap="round"/>
+  <path d="M4.3,15.5 L5.3,14.3" stroke="#ffffff" stroke-width="1.1" fill="none" stroke-linecap="round"/>
+</svg>

--- a/web/public/sprites/pattern-cat-tabby-stripes-3.svg
+++ b/web/public/sprites/pattern-cat-tabby-stripes-3.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- walk frame 3 — stride B -->
+  <path d="M11,16 Q12,19.5 11,22.5" stroke="#ffffff" stroke-width="1.3" fill="none" stroke-linecap="round"/>
+  <path d="M14.5,15.5 Q15.5,19 14.5,22" stroke="#ffffff" stroke-width="1.3" fill="none" stroke-linecap="round"/>
+  <path d="M18,16 Q19,19.5 18,22.5" stroke="#ffffff" stroke-width="1.3" fill="none" stroke-linecap="round"/>
+  <path d="M21.5,13.2 L23,11.6 L24.5,13.2" stroke="#ffffff" stroke-width="1.1" fill="none" stroke-linecap="round"/>
+  <path d="M6.5,22 L7.5,21" stroke="#ffffff" stroke-width="1.1" fill="none" stroke-linecap="round"/>
+  <path d="M3.3,17.5 L4.3,16.3" stroke="#ffffff" stroke-width="1.1" fill="none" stroke-linecap="round"/>
+</svg>

--- a/web/public/sprites/pattern-cat-tabby-stripes-sleep.svg
+++ b/web/public/sprites/pattern-cat-tabby-stripes-sleep.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- curled, sleeping: stripes across the curled back + tucked-head forehead mark -->
+  <path d="M13,20 Q14,23 13,27" stroke="#ffffff" stroke-width="1.3" fill="none" stroke-linecap="round"/>
+  <path d="M16.5,20.1 Q17.5,23.5 16.5,27.5" stroke="#ffffff" stroke-width="1.3" fill="none" stroke-linecap="round"/>
+  <path d="M20,20 Q21,23 20,27" stroke="#ffffff" stroke-width="1.3" fill="none" stroke-linecap="round"/>
+  <path d="M7.6,19.4 L9,17.8 L10.4,19.4" stroke="#ffffff" stroke-width="1.1" fill="none" stroke-linecap="round"/>
+</svg>

--- a/web/public/sprites/pattern-cat-tabby-stripes.svg
+++ b/web/public/sprites/pattern-cat-tabby-stripes.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- tabby stripes: back stripes, forehead "M" mark, tail rings — neutral white, tinted at runtime -->
+  <path d="M11,16 Q12,19.5 11,22.5" stroke="#ffffff" stroke-width="1.3" fill="none" stroke-linecap="round"/>
+  <path d="M14.5,15.5 Q15.5,19 14.5,22" stroke="#ffffff" stroke-width="1.3" fill="none" stroke-linecap="round"/>
+  <path d="M18,16 Q19,19.5 18,22.5" stroke="#ffffff" stroke-width="1.3" fill="none" stroke-linecap="round"/>
+  <path d="M21.5,13.2 L23,11.6 L24.5,13.2" stroke="#ffffff" stroke-width="1.1" fill="none" stroke-linecap="round"/>
+  <path d="M6.5,22 L7.5,21" stroke="#ffffff" stroke-width="1.1" fill="none" stroke-linecap="round"/>
+  <path d="M4.3,16.5 L5.3,15.3" stroke="#ffffff" stroke-width="1.1" fill="none" stroke-linecap="round"/>
+</svg>

--- a/web/public/sprites/pattern-cat-tuxedo-white-1.svg
+++ b/web/public/sprites/pattern-cat-tuxedo-white-1.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- walk frame 1 -->
+  <ellipse cx="17.6" cy="22.5" rx="3" ry="2" fill="#ffffff"/>
+  <rect x="7" y="26" width="2.6" height="2" rx="1" fill="#ffffff"/>
+  <rect x="21" y="26" width="2.6" height="2" rx="1" fill="#ffffff"/>
+  <circle cx="22" cy="18.8" r="1.3" fill="#ffffff"/>
+</svg>

--- a/web/public/sprites/pattern-cat-tuxedo-white-2.svg
+++ b/web/public/sprites/pattern-cat-tuxedo-white-2.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- walk frame 2 — mid stride, body 1px higher -->
+  <ellipse cx="17.6" cy="21.5" rx="3" ry="2" fill="#ffffff"/>
+  <rect x="9" y="26" width="2.6" height="2" rx="1" fill="#ffffff"/>
+  <rect x="19" y="26" width="2.6" height="2" rx="1" fill="#ffffff"/>
+  <circle cx="22" cy="17.8" r="1.3" fill="#ffffff"/>
+</svg>

--- a/web/public/sprites/pattern-cat-tuxedo-white-3.svg
+++ b/web/public/sprites/pattern-cat-tuxedo-white-3.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- walk frame 3 — stride B -->
+  <ellipse cx="17.6" cy="22.5" rx="3" ry="2" fill="#ffffff"/>
+  <rect x="11" y="26" width="2.6" height="2" rx="1" fill="#ffffff"/>
+  <rect x="17" y="26" width="2.6" height="2" rx="1" fill="#ffffff"/>
+  <circle cx="22" cy="18.8" r="1.3" fill="#ffffff"/>
+</svg>

--- a/web/public/sprites/pattern-cat-tuxedo-white-sleep.svg
+++ b/web/public/sprites/pattern-cat-tuxedo-white-sleep.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- curled, sleeping: chest/belly patch + chin, no distinct paws visible -->
+  <ellipse cx="16" cy="27.3" rx="4" ry="1.8" fill="#ffffff"/>
+  <circle cx="8" cy="24.6" r="1.3" fill="#ffffff"/>
+</svg>

--- a/web/public/sprites/pattern-cat-tuxedo-white.svg
+++ b/web/public/sprites/pattern-cat-tuxedo-white.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- tuxedo white patch: chest, paws, chin — neutral white, tinted at runtime -->
+  <ellipse cx="17.6" cy="22.5" rx="3" ry="2" fill="#ffffff"/>
+  <rect x="9" y="26" width="2.6" height="2" rx="1" fill="#ffffff"/>
+  <rect x="19" y="26" width="2.6" height="2" rx="1" fill="#ffffff"/>
+  <circle cx="22" cy="18.8" r="1.3" fill="#ffffff"/>
+</svg>

--- a/web/public/sprites/pattern-dog-black-and-tan-saddle-1.svg
+++ b/web/public/sprites/pattern-dog-black-and-tan-saddle-1.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- walk frame 1 -->
+  <ellipse cx="15" cy="16.9" rx="7.5" ry="3.3" fill="#ffffff"/>
+</svg>

--- a/web/public/sprites/pattern-dog-black-and-tan-saddle-2.svg
+++ b/web/public/sprites/pattern-dog-black-and-tan-saddle-2.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- walk frame 2 — mid stride, body 1px higher -->
+  <ellipse cx="15" cy="15.9" rx="7.5" ry="3.3" fill="#ffffff"/>
+</svg>

--- a/web/public/sprites/pattern-dog-black-and-tan-saddle-3.svg
+++ b/web/public/sprites/pattern-dog-black-and-tan-saddle-3.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- walk frame 3 — stride B -->
+  <ellipse cx="15" cy="16.9" rx="7.5" ry="3.3" fill="#ffffff"/>
+</svg>

--- a/web/public/sprites/pattern-dog-black-and-tan-saddle.svg
+++ b/web/public/sprites/pattern-dog-black-and-tan-saddle.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- black-and-tan saddle: back patch — neutral white, tinted at runtime -->
+  <ellipse cx="15" cy="16.9" rx="7.5" ry="3.3" fill="#ffffff"/>
+</svg>

--- a/web/public/sprites/pattern-dog-brindle-stripes-1.svg
+++ b/web/public/sprites/pattern-dog-brindle-stripes-1.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- walk frame 1 -->
+  <path d="M11.7,14.2 Q12.8,18.4 11.7,22" stroke="#ffffff" stroke-width="1.4" fill="none" stroke-linecap="round"/>
+  <path d="M15.5,13.6 Q16.6,17.8 15.5,21.4" stroke="#ffffff" stroke-width="1.4" fill="none" stroke-linecap="round"/>
+  <path d="M19.5,14.2 Q20.6,18.4 19.5,22" stroke="#ffffff" stroke-width="1.4" fill="none" stroke-linecap="round"/>
+</svg>

--- a/web/public/sprites/pattern-dog-brindle-stripes-2.svg
+++ b/web/public/sprites/pattern-dog-brindle-stripes-2.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- walk frame 2 — mid stride, body 1px higher -->
+  <path d="M11.7,13.2 Q12.8,17.4 11.7,21" stroke="#ffffff" stroke-width="1.4" fill="none" stroke-linecap="round"/>
+  <path d="M15.5,12.6 Q16.6,16.8 15.5,20.4" stroke="#ffffff" stroke-width="1.4" fill="none" stroke-linecap="round"/>
+  <path d="M19.5,13.2 Q20.6,17.4 19.5,21" stroke="#ffffff" stroke-width="1.4" fill="none" stroke-linecap="round"/>
+</svg>

--- a/web/public/sprites/pattern-dog-brindle-stripes-3.svg
+++ b/web/public/sprites/pattern-dog-brindle-stripes-3.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- walk frame 3 — stride B -->
+  <path d="M11.7,14.2 Q12.8,18.4 11.7,22" stroke="#ffffff" stroke-width="1.4" fill="none" stroke-linecap="round"/>
+  <path d="M15.5,13.6 Q16.6,17.8 15.5,21.4" stroke="#ffffff" stroke-width="1.4" fill="none" stroke-linecap="round"/>
+  <path d="M19.5,14.2 Q20.6,18.4 19.5,22" stroke="#ffffff" stroke-width="1.4" fill="none" stroke-linecap="round"/>
+</svg>

--- a/web/public/sprites/pattern-dog-brindle-stripes.svg
+++ b/web/public/sprites/pattern-dog-brindle-stripes.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- brindle stripes: tiger-like body stripes — neutral white, tinted at runtime -->
+  <path d="M11.7,14.2 Q12.8,18.4 11.7,22" stroke="#ffffff" stroke-width="1.4" fill="none" stroke-linecap="round"/>
+  <path d="M15.5,13.6 Q16.6,17.8 15.5,21.4" stroke="#ffffff" stroke-width="1.4" fill="none" stroke-linecap="round"/>
+  <path d="M19.5,14.2 Q20.6,18.4 19.5,22" stroke="#ffffff" stroke-width="1.4" fill="none" stroke-linecap="round"/>
+</svg>

--- a/web/public/sprites/pattern-dog-spotted-spots-1.svg
+++ b/web/public/sprites/pattern-dog-spotted-spots-1.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- walk frame 1 -->
+  <circle cx="10" cy="16" r="1.6" fill="#ffffff"/>
+  <circle cx="16" cy="21.4" r="1.9" fill="#ffffff"/>
+  <circle cx="19" cy="15.4" r="1.4" fill="#ffffff"/>
+  <circle cx="22.44" cy="13.92" r="1.3" fill="#ffffff"/>
+</svg>

--- a/web/public/sprites/pattern-dog-spotted-spots-2.svg
+++ b/web/public/sprites/pattern-dog-spotted-spots-2.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- walk frame 2 — mid stride, body 1px higher -->
+  <circle cx="10" cy="15" r="1.6" fill="#ffffff"/>
+  <circle cx="16" cy="20.4" r="1.9" fill="#ffffff"/>
+  <circle cx="19" cy="14.4" r="1.4" fill="#ffffff"/>
+  <circle cx="22.44" cy="12.92" r="1.3" fill="#ffffff"/>
+</svg>

--- a/web/public/sprites/pattern-dog-spotted-spots-3.svg
+++ b/web/public/sprites/pattern-dog-spotted-spots-3.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- walk frame 3 — stride B -->
+  <circle cx="10" cy="16" r="1.6" fill="#ffffff"/>
+  <circle cx="16" cy="21.4" r="1.9" fill="#ffffff"/>
+  <circle cx="19" cy="15.4" r="1.4" fill="#ffffff"/>
+  <circle cx="22.44" cy="13.92" r="1.3" fill="#ffffff"/>
+</svg>

--- a/web/public/sprites/pattern-dog-spotted-spots.svg
+++ b/web/public/sprites/pattern-dog-spotted-spots.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- spotted: dalmatian-style patches — neutral white, tinted at runtime -->
+  <circle cx="10" cy="16" r="1.6" fill="#ffffff"/>
+  <circle cx="16" cy="21.4" r="1.9" fill="#ffffff"/>
+  <circle cx="19" cy="15.4" r="1.4" fill="#ffffff"/>
+  <circle cx="22.44" cy="13.92" r="1.3" fill="#ffffff"/>
+</svg>

--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -2471,7 +2471,7 @@ export function HubTownCanvas({
       let [ptx, pty] = [AVATAR_START.tx, AVATAR_START.ty + 1]
       if (animalIsSolid(ptx, pty)) [ptx, pty] = [AVATAR_START.tx + 1, AVATAR_START.ty]
       if (animalIsSolid(ptx, pty)) [ptx, pty] = [AVATAR_START.tx, AVATAR_START.ty]
-      animalSystem.spawnFollowerPet(activePet.type as AnimalType, activePet.variant, ptx, pty)
+      animalSystem.spawnFollowerPet(activePet.type as AnimalType, activePet.variant, activePet.pattern, ptx, pty)
     }
 
     // ── Weather overlay (screen-space, above the world incl. night dimming) ────

--- a/web/src/components/hub/PetModal.tsx
+++ b/web/src/components/hub/PetModal.tsx
@@ -7,6 +7,7 @@ import {
 } from '../../game/hub/pet'
 import { ANIMAL_SPECS, type AnimalType } from '../../game/hub/animals'
 import { PET_ACCESSORIES } from '../../data/petAccessories'
+import { getPatternsForSpecies } from '../../data/petPatterns'
 
 interface Props {
   onClose: () => void
@@ -17,15 +18,18 @@ const PET_SPECIES: ('dog' | 'cat')[] = ['dog', 'cat']
 const SPECIES_LABEL: Record<string, string> = { dog: 'Dog', cat: 'Cat' }
 const SPECIES_NAME_PLACEHOLDER: Record<string, string> = { dog: 'Name your pup', cat: 'Name your cat' }
 
-function PickerBody({ onAdopt, submitLabel }: { onAdopt: (type: string, variant: string, name: string) => void; submitLabel: string }) {
+function PickerBody({ onAdopt, submitLabel }: { onAdopt: (type: string, variant: string, name: string, pattern: string) => void; submitLabel: string }) {
   const [species, setSpecies] = useState<'dog' | 'cat'>('dog')
   const variants = Object.keys(ANIMAL_SPECS[species].palette)
   const [variant, setVariant] = useState(variants[0])
+  const patterns = getPatternsForSpecies(species)
+  const [pattern, setPattern] = useState<string>('none')
   const [name, setName] = useState('')
 
   const chooseSpecies = (s: 'dog' | 'cat') => {
     setSpecies(s)
     setVariant(Object.keys(ANIMAL_SPECS[s].palette)[0])
+    setPattern('none')  // dog/cat pattern lists differ — never carry a stale selection across species
   }
 
   return (
@@ -51,6 +55,20 @@ function PickerBody({ onAdopt, submitLabel }: { onAdopt: (type: string, variant:
           />
         ))}
       </div>
+      <div className="pet-modal__section-label">Coat pattern</div>
+      <div className="hoa-tabs">
+        <button
+          className={`hoa-tab${pattern === 'none' ? ' hoa-tab--active' : ''}`}
+          onClick={() => setPattern('none')}
+        >None</button>
+        {patterns.map(p => (
+          <button
+            key={p.id}
+            className={`hoa-tab${pattern === p.id ? ' hoa-tab--active' : ''}`}
+            onClick={() => setPattern(p.id)}
+          >{p.label}</button>
+        ))}
+      </div>
       <input
         className="pet-modal__name-input"
         placeholder={SPECIES_NAME_PLACEHOLDER[species]}
@@ -58,7 +76,7 @@ function PickerBody({ onAdopt, submitLabel }: { onAdopt: (type: string, variant:
         maxLength={24}
         onChange={e => setName(e.target.value)}
       />
-      <button className="action-btn action-btn--gold" onClick={() => onAdopt(species, variant, name)}>{submitLabel}</button>
+      <button className="action-btn action-btn--gold" onClick={() => onAdopt(species, variant, name, pattern)}>{submitLabel}</button>
     </>
   )
 }
@@ -122,7 +140,7 @@ export function PetModal({ onClose, petActionRef }: Props) {
   const refresh = () => setTick(t => t + 1)
   const [renameValue, setRenameValue] = useState<string | null>(null)
   const [swapping, setSwapping] = useState(false)
-  const [confirmSwap, setConfirmSwap] = useState<{ type: string; variant: string; name: string } | null>(null)
+  const [confirmSwap, setConfirmSwap] = useState<{ type: string; variant: string; name: string; pattern: string } | null>(null)
   const [confirmDismiss, setConfirmDismiss] = useState(false)
   const [tab, setTab] = useState<'info' | 'accessories'>('info')
 
@@ -134,7 +152,7 @@ export function PetModal({ onClose, petActionRef }: Props) {
         title="Adopt a new companion?"
         body={`Adopting ${confirmSwap.name} will mean saying goodbye to ${pet?.name ?? 'your current pet'}.`}
         confirmLabel="Adopt"
-        onConfirm={() => { adoptPet(confirmSwap.type, confirmSwap.variant, confirmSwap.name); setConfirmSwap(null); setSwapping(false); refresh() }}
+        onConfirm={() => { adoptPet(confirmSwap.type, confirmSwap.variant, confirmSwap.name, confirmSwap.pattern); setConfirmSwap(null); setSwapping(false); refresh() }}
         onCancel={() => setConfirmSwap(null)}
       />
     )
@@ -161,7 +179,7 @@ export function PetModal({ onClose, petActionRef }: Props) {
         </div>
 
         {!pet && (
-          <PickerBody submitLabel="Adopt" onAdopt={(type, variant, name) => { adoptPet(type, variant, name); refresh() }} />
+          <PickerBody submitLabel="Adopt" onAdopt={(type, variant, name, pattern) => { adoptPet(type, variant, name, pattern); refresh() }} />
         )}
 
         {pet && !swapping && (
@@ -205,7 +223,7 @@ export function PetModal({ onClose, petActionRef }: Props) {
         {pet && swapping && (
           <PickerBody
             submitLabel="Adopt"
-            onAdopt={(type, variant, name) => setConfirmSwap({ type, variant, name })}
+            onAdopt={(type, variant, name, pattern) => setConfirmSwap({ type, variant, name, pattern })}
           />
         )}
       </div>

--- a/web/src/components/hub/hubAnimals.ts
+++ b/web/src/components/hub/hubAnimals.ts
@@ -12,6 +12,7 @@ import { loadAnimFrames, loadTextureUrl } from '../../utils/pixiHelpers'
 import { emitSound, SoundId } from '../../game/sound'
 import { getEquippedAccessoryId } from '../../game/hub/pet'
 import { getPetAccessoryDef } from '../../data/petAccessories'
+import { getPatternDef, type PatternSpecies } from '../../data/petPatterns'
 import type { HubAnimal, HubAnimalType } from '../../data/hub/loader'
 import {
   AnimalType,
@@ -35,12 +36,22 @@ const FIREFLY_GLOW_R = 1.2 * T_PX   // small night light pool each firefly casts
 type Rect = [number, number, number, number]   // tx, ty, w, h
 interface Pt { x: number; y: number }
 
-interface Animal {
+// A sprite that owns its own texture set and swaps frames in lockstep with
+// whatever pose the owning Animal is in (see texLayers()/showStatic/showSleep/
+// animateWalk). The base Animal itself is one (see below); each pattern part
+// is another, layered as a sibling so it can be tinted independently.
+interface TexturedLayer {
+  sprite: PIXI.Sprite
+  staticTex: PIXI.Texture | null
+  sleepTex: PIXI.Texture | null
+  frames: PIXI.Texture[]
+}
+
+interface Animal extends TexturedLayer {
   type: AnimalType
   id?: string                 // placed/quest animals only
   stationary: boolean         // placed animal with roam !== true
   homeTile: [number, number]
-  sprite: PIXI.Sprite
   tint: number
   bottomAnchored: boolean
   baseScale: number
@@ -55,9 +66,6 @@ interface Animal {
   movingTo: [number, number] | null
   target: Pt | null
   goal: [number, number] | null   // beacon tile for grass-capable steppers
-  staticTex: PIXI.Texture | null
-  sleepTex: PIXI.Texture | null
-  frames: PIXI.Texture[]
   frameIdx: number
   frameTimer: number
   state: string
@@ -69,6 +77,10 @@ interface Animal {
   // part (sibling, not a child — the pet's texture swaps per animation frame,
   // so only sibling repositioning every tick keeps them aligned; see advance())
   accessorySprites: PIXI.Sprite[]
+  // coat pattern markings (tabby stripes, calico patches, ...): each part is
+  // its own animated sibling layer, tracking the same pose as the base sprite
+  // (see texLayers()) but tinted independently — see advance() for position sync.
+  patternLayers: TexturedLayer[]
   // dog social memory
   ownerId?: string
   seen: Set<string>
@@ -153,7 +165,7 @@ export interface AnimalSystem {
   /** Night light sources from animals (fireflies) for the night overlay. */
   getGlowSources: () => GlowSource[]
   /** Spawns (or re-spawns) the player's follower pet near (tx,ty). */
-  spawnFollowerPet: (type: AnimalType, variant: string, tx: number, ty: number) => void
+  spawnFollowerPet: (type: AnimalType, variant: string, pattern: string | undefined, tx: number, ty: number) => void
   /** Best-effort removal of an animal by id. No-op if not found. */
   removeAnimal: (id: string) => void
   /** Sends the player's pet off to fetch something; fires onReturn once it's
@@ -270,22 +282,32 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
       a.sprite.y = a.baseY
     }
     if (a.bottomAnchored) a.sprite.zIndex = a.sprite.y
-    a.accessorySprites.forEach((s, i) => {
-      s.position.copyFrom(a.sprite.position)
-      s.scale.x = a.sprite.scale.x
-      s.zIndex = a.sprite.zIndex + 0.5 + i * 0.001
-    })
+    a.patternLayers.forEach((l, i) => syncSibling(a, l.sprite, 0.1 + i * 0.001))
+    a.accessorySprites.forEach((s, i) => syncSibling(a, s, 0.5 + i * 0.001))
+  }
+
+  function syncSibling(a: Animal, s: PIXI.Sprite, zOffset: number) {
+    s.position.copyFrom(a.sprite.position)
+    s.scale.x = a.sprite.scale.x
+    s.zIndex = a.sprite.zIndex + zOffset
   }
 
   const isMoving = (a: Animal) => a.target !== null
 
   // ── textures / pose ──────────────────────────────────────────────────────────
+  // All layers that should show the same pose in lockstep: the base sprite
+  // plus every coat-pattern part. Patterns never get their own frame clock —
+  // a.frameIdx/a.frameTimer are the single source of truth for all of them.
+  function texLayers(a: Animal): TexturedLayer[] {
+    return a.patternLayers.length ? [a, ...a.patternLayers] : [a]
+  }
+
   function showStatic(a: Animal) {
-    if (a.staticTex) a.sprite.texture = a.staticTex
+    for (const l of texLayers(a)) if (l.staticTex) l.sprite.texture = l.staticTex
     a.frameIdx = 0
   }
   function showSleep(a: Animal) {
-    a.sprite.texture = a.sleepTex ?? a.staticTex ?? a.sprite.texture
+    for (const l of texLayers(a)) l.sprite.texture = l.sleepTex ?? l.staticTex ?? l.sprite.texture
   }
 
   function animateWalk(a: Animal, dt: number) {
@@ -294,7 +316,7 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
     if (a.frameTimer <= 0) {
       a.frameTimer = FRAME_MS
       a.frameIdx = (a.frameIdx + 1) % a.frames.length
-      a.sprite.texture = a.frames[a.frameIdx]
+      for (const l of texLayers(a)) if (l.frames.length) l.sprite.texture = l.frames[a.frameIdx % l.frames.length]
     }
   }
 
@@ -1012,7 +1034,7 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
       bubble: null, bubbleTimer: 0,
       seen: new Set(), opinion: new Map(), reactCooldown: 0, wagTimer: 0,
       fleeRequested: false, bobPhase: Math.random() * Math.PI * 2, baseY: c.y,
-      indicator: null, accessorySprites: [],
+      indicator: null, accessorySprites: [], patternLayers: [],
     }
     // Half of the procedural cats & dogs den in a home building at night.
     if (!placed && spec.dens && opts.homes.length > 0 && Math.random() < 0.5) {
@@ -1058,6 +1080,36 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
     }
     if (type === 'cat') {
       loadTextureUrl(`${opts.baseUrl}sprites/animal-cat-sleep.svg`).then(t => { a.sleepTex = t }).catch(() => {})
+    }
+
+    // Coat pattern markings (tabby stripes, calico patches, ...): one animated
+    // sibling layer per part, tinted independently, swapping texture in
+    // lockstep with the base sprite (see texLayers()). Cats/dogs only.
+    if (type === 'cat' || type === 'dog') {
+      const patternDef = getPatternDef(type as PatternSpecies, placed?.pattern)
+      if (patternDef) {
+        for (const part of patternDef.parts) {
+          const partSlug = `pattern-${type}-${patternDef.id}-${part.key}`
+          const partTint = part.useBaseColor ? tint : (part.tint ?? 0xffffff)
+          const layerSprite = new PIXI.Sprite()
+          layerSprite.width = sprite.width
+          layerSprite.height = sprite.height
+          layerSprite.anchor.copyFrom(sprite.anchor)
+          layerSprite.position.copyFrom(sprite.position)
+          layerSprite.zIndex = sprite.zIndex + 0.1
+          layerSprite.tint = partTint
+          layerSprite.eventMode = 'none'  // cosmetic overlay must not block taps on the pet beneath it
+          sprite.parent?.addChild(layerSprite)
+          const patternLayer: TexturedLayer = { sprite: layerSprite, staticTex: null, sleepTex: null, frames: [] }
+          a.patternLayers.push(patternLayer)
+
+          loadTextureUrl(`${opts.baseUrl}sprites/${partSlug}.svg`).then(t => { patternLayer.staticTex = t }).catch(() => {})
+          loadAnimFrames(partSlug, 3).then(f => { patternLayer.frames = f }).catch(() => {})
+          if (type === 'cat') {
+            loadTextureUrl(`${opts.baseUrl}sprites/${partSlug}-sleep.svg`).then(t => { patternLayer.sleepTex = t }).catch(() => {})
+          }
+        }
+      }
     }
 
     // Birds enter by gliding in from the screen edge and landing, rather than
@@ -1136,6 +1188,7 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
       if (a.bubble) opts.bubbleLayer.removeChild(a.bubble)
       if (a.indicator) opts.bubbleLayer.removeChild(a.indicator)
       for (const s of a.accessorySprites) s.destroy()
+      for (const l of a.patternLayers) l.sprite.destroy()
       a.sprite.destroy()
     }
     animals.length = 0
@@ -1150,6 +1203,7 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
     if (a.bubble) opts.bubbleLayer.removeChild(a.bubble)
     if (a.indicator) opts.bubbleLayer.removeChild(a.indicator)
     for (const s of a.accessorySprites) s.destroy()
+    for (const l of a.patternLayers) l.sprite.destroy()
     a.sprite.destroy()
   }
 
@@ -1195,9 +1249,9 @@ export function createAnimalSystem(opts: AnimalSystemOptions): AnimalSystem {
     if (assetId) applyAccessorySprite(a, assetId)
   }
 
-  function spawnFollowerPet(type: AnimalType, variant: string, tx: number, ty: number): void {
+  function spawnFollowerPet(type: AnimalType, variant: string, pattern: string | undefined, tx: number, ty: number): void {
     removeAnimal(PLAYER_PET_ANIMAL_ID)
-    void makeAnimal(type, tx, ty, { id: PLAYER_PET_ANIMAL_ID, type: type as HubAnimalType, variant, tx, ty, roam: true })
+    void makeAnimal(type, tx, ty, { id: PLAYER_PET_ANIMAL_ID, type: type as HubAnimalType, variant, pattern, tx, ty, roam: true })
       .then(() => {
         const a = animals.find(x => x.id === PLAYER_PET_ANIMAL_ID)
         if (!a) return

--- a/web/src/data/hub/config.ts
+++ b/web/src/data/hub/config.ts
@@ -311,6 +311,7 @@ export interface RawAnimal {
   id: string
   type: string                       // 'cat' | 'dog' | 'bird' | 'fish'
   variant?: string                   // palette key (e.g. "orange") or hex ("#e8923c")
+  pattern?: string                   // coat pattern id (petPatterns.ts), cats/dogs only
   tx: number
   ty: number
   name?: string

--- a/web/src/data/hub/loader.ts
+++ b/web/src/data/hub/loader.ts
@@ -177,6 +177,7 @@ export interface HubAnimal {
   id: string
   type: HubAnimalType
   variant?: string
+  pattern?: string
   tx: number
   ty: number
   name?: string
@@ -667,6 +668,7 @@ const HUB_ANIMALS: HubAnimal[] = (
   id:           a.id,
   type:         a.type as HubAnimalType,
   variant:      a.variant,
+  pattern:      a.pattern,
   tx:           a.tx,
   ty:           a.ty,
   name:         a.name,

--- a/web/src/data/petPatterns.test.ts
+++ b/web/src/data/petPatterns.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest'
+import { PET_PATTERNS, getPatternsForSpecies, getPatternDef } from './petPatterns'
+
+describe('getPatternsForSpecies', () => {
+  it('returns exactly the cat patterns', () => {
+    expect(getPatternsForSpecies('cat').map(p => p.id).sort()).toEqual(['calico', 'tabby', 'tuxedo'])
+  })
+
+  it('returns exactly the dog patterns', () => {
+    expect(getPatternsForSpecies('dog').map(p => p.id).sort()).toEqual(['black-and-tan', 'brindle', 'spotted'])
+  })
+})
+
+describe('getPatternDef', () => {
+  it('resolves a pattern for its own species', () => {
+    expect(getPatternDef('cat', 'tabby')?.label).toBe('Tabby')
+  })
+
+  it('returns undefined for a pattern that belongs to a different species', () => {
+    expect(getPatternDef('cat', 'brindle')).toBeUndefined()
+  })
+
+  it('returns undefined for undefined or "none"', () => {
+    expect(getPatternDef('cat', undefined)).toBeUndefined()
+    expect(getPatternDef('cat', 'none')).toBeUndefined()
+  })
+
+  it('returns undefined for an unknown id', () => {
+    expect(getPatternDef('dog', 'not-a-real-pattern')).toBeUndefined()
+  })
+})
+
+describe('PET_PATTERNS shape', () => {
+  it('every part has exactly one of useBaseColor/tint', () => {
+    for (const pattern of PET_PATTERNS) {
+      for (const part of pattern.parts) {
+        const hasBase = part.useBaseColor === true
+        const hasTint = typeof part.tint === 'number'
+        expect(hasBase !== hasTint).toBe(true)
+      }
+    }
+  })
+
+  it('every pattern has at least one part', () => {
+    for (const pattern of PET_PATTERNS) {
+      expect(pattern.parts.length).toBeGreaterThan(0)
+    }
+  })
+})

--- a/web/src/data/petPatterns.ts
+++ b/web/src/data/petPatterns.ts
@@ -1,0 +1,45 @@
+// Pet coat pattern catalog. Each pattern composites one or more animated
+// sprite layers on top of a pet's base body sprite, at
+// web/public/sprites/pattern-<species>-<patternId>-<part.key>[-1/-2/-3/-sleep].svg
+// (mirroring the base animal-<type>[-1/-2/-3/-sleep].svg frame convention —
+// see hubAnimals.ts's patternLayers). A part is either tinted with whatever
+// base colour the player picked (`useBaseColor`) or a fixed marking colour
+// (`tint`) — never both.
+
+export type PatternSpecies = 'cat' | 'dog'
+
+export interface PatternPart {
+  key: string          // sprite filename suffix
+  useBaseColor?: true  // tinted with the pet's picked variant colour
+  tint?: number        // fixed PIXI tint (0xRRGGBB); ignored if useBaseColor is set
+}
+
+export interface AnimalPatternDef {
+  id:      string
+  species: PatternSpecies
+  label:   string
+  parts:   PatternPart[]  // 1 part for most patterns, 3 for calico
+}
+
+export const PET_PATTERNS: AnimalPatternDef[] = [
+  { id: 'tuxedo', species: 'cat', label: 'Tuxedo', parts: [{ key: 'white', tint: 0xf5f5f0 }] },
+  { id: 'tabby', species: 'cat', label: 'Tabby', parts: [{ key: 'stripes', tint: 0x2a2016 }] },
+  { id: 'calico', species: 'cat', label: 'Calico', parts: [
+    { key: 'base', useBaseColor: true },
+    { key: 'white', tint: 0xf5f5f0 },
+    { key: 'ginger', tint: 0xd97b3f },
+  ] },
+
+  { id: 'brindle', species: 'dog', label: 'Brindle', parts: [{ key: 'stripes', tint: 0x1c1712 }] },
+  { id: 'black-and-tan', species: 'dog', label: 'Black & Tan', parts: [{ key: 'saddle', tint: 0x1c1712 }] },
+  { id: 'spotted', species: 'dog', label: 'Spotted', parts: [{ key: 'spots', tint: 0x2a2016 }] },
+]
+
+export function getPatternsForSpecies(species: PatternSpecies): AnimalPatternDef[] {
+  return PET_PATTERNS.filter(p => p.species === species)
+}
+
+export function getPatternDef(species: PatternSpecies, id: string | undefined): AnimalPatternDef | undefined {
+  if (!id || id === 'none') return undefined
+  return PET_PATTERNS.find(p => p.species === species && p.id === id)
+}

--- a/web/src/game/hub/pet.test.ts
+++ b/web/src/game/hub/pet.test.ts
@@ -68,6 +68,28 @@ describe('pet store', () => {
     expect(getActivePet()).toEqual({ type: 'dog', variant: 'black', name: 'Shadow' })
   })
 
+  it('adopts a pet with a coat pattern and persists it', () => {
+    adoptPet('cat', 'orange', 'Mochi', 'tabby')
+    expect(getActivePet()).toEqual({ type: 'cat', variant: 'orange', name: 'Mochi', pattern: 'tabby' })
+  })
+
+  it('omitting a pattern leaves it unset rather than storing "none"', () => {
+    adoptPet('dog', 'brown', 'Rex')
+    expect(getActivePet()?.pattern).toBeUndefined()
+    expect(getActivePet()).toEqual({ type: 'dog', variant: 'brown', name: 'Rex' })
+  })
+
+  it('an explicit "none" pattern is treated the same as omitting it', () => {
+    adoptPet('dog', 'brown', 'Rex', 'none')
+    expect(getActivePet()?.pattern).toBeUndefined()
+  })
+
+  it('adopting again fully replaces the previous pattern', () => {
+    adoptPet('cat', 'orange', 'Mochi', 'tabby')
+    adoptPet('cat', 'black', 'Shadow', 'tuxedo')
+    expect(getActivePet()).toEqual({ type: 'cat', variant: 'black', name: 'Shadow', pattern: 'tuxedo' })
+  })
+
   it('dismissing clears the active pet', () => {
     adoptPet('dog', 'golden', 'Rex')
     dismissPet()

--- a/web/src/game/hub/pet.ts
+++ b/web/src/game/hub/pet.ts
@@ -6,9 +6,10 @@ const MAX_TREATS_PER_DAY = 2
 const TREAT_INTERACTIONS_REQUIRED = 3
 
 export interface PetRecord {
-  type:    string  // 'dog' for now; kept generic for future pet types
+  type:    string  // 'dog'/'cat'; kept generic for future pet types
   variant: string  // palette key from ANIMAL_SPECS[type].palette
   name:    string
+  pattern?: string  // coat pattern id from petPatterns.ts, if any
 }
 
 interface TreatState {
@@ -58,9 +59,12 @@ export function hasActivePet(): boolean {
 const DEFAULT_NAME_BY_TYPE: Record<string, string> = { dog: 'Pup', cat: 'Kitty' }
 
 /** Adopts a pet, replacing any currently active one. Preserves the daily treat count. */
-export function adoptPet(type: string, variant: string, name: string): PetRecord {
+export function adoptPet(type: string, variant: string, name: string, pattern?: string): PetRecord {
   const data = load()
-  const pet: PetRecord = { type, variant, name: name.trim() || DEFAULT_NAME_BY_TYPE[type] || 'Pup' }
+  const pet: PetRecord = {
+    type, variant, name: name.trim() || DEFAULT_NAME_BY_TYPE[type] || 'Pup',
+    ...(pattern && pattern !== 'none' ? { pattern } : {}),
+  }
   save({ ...data, pet })
   return pet
 }


### PR DESCRIPTION
## Summary

- Adds coat patterns, layered on top of any base colour the player picks: **tuxedo, tabby, calico** for cats; **brindle, black-and-tan, spotted** for dogs. `PetModal`'s adopt/swap flow gets a new "Coat pattern" toggle row alongside the existing species/colour pickers.
- New `web/src/data/petPatterns.ts` catalog: each pattern is 1-3 "parts," where a part is either tinted with the player's picked base colour (`useBaseColor`) or a fixed marking colour (`tint`) — e.g. tuxedo's white bib is fixed, calico's third patch colour is driven by whatever base colour was picked.
- Rendering (`hubAnimals.ts`): patterns are layered as animated sibling sprites that swap texture in lockstep with the pet's own idle/walk/sleep frames (via a shared `texLayers()` helper across `showStatic`/`showSleep`/`animateWalk`), so markings track the moving body instead of floating over it — this game's 3 walk frames genuinely shift leg/body/tail position frame-to-frame, so a single static overlay would visibly detach while walking.
- 37 new small marking-only SVGs in `web/public/sprites/` (`pattern-<species>-<patternId>-<part>[-1/-2/-3/-sleep].svg`), neutral-white so the runtime tint recolors them, traced against each existing animal frame's known body coordinates.
- `pattern` threads end-to-end through `PetRecord` → `PetModal` → `HubTownCanvas` → `hubAnimals.ts`'s `spawnFollowerPet`/`makeAnimal`, plus a no-cost parity addition to `HubAnimal`/`RawAnimal` for map-authored animals (no editor UI added, out of scope).

## Test plan

- [x] `npm test` (vitest) — all 358 tests pass, including new `petPatterns.test.ts` and extended `pet.test.ts` coverage for the `pattern` field
- [x] `npx tsc --noEmit` — clean
- [ ] Manual check: adopt patterned cats/dogs, confirm markings track the body through idle/walk/sleep and that switching species resets the pattern choice

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012g8rmEZ7qtNwdmtyHBEzPg

---
_Generated by [Claude Code](https://claude.ai/code/session_012g8rmEZ7qtNwdmtyHBEzPg)_