### PR TITLE
Fix secret-rare cards not being added to collection

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2415,6 +2415,11 @@ export default function App() {
     // Secret rare cards drawn this game
     const obtained = gameState.secretRaresObtained ?? []
     if (obtained.length > 0) {
+      // Drawing a secret-rare card only conjures it into the battle hand — grant it
+      // into the permanent collection too, or the news feed announces a card the
+      // player can never actually see in their collection.
+      addCardsToCollection(obtained.map(cardName => ({ cardName, count: 1 })))
+
       const TYPES_KEY = 'jarv_secret_types_seen'
       let seenTypes: Set<string>
       try {


### PR DESCRIPTION
## Summary
- Reported bug: news feed announced a "mythic Prism Wyrm" win, but the card never showed up in the collection.
- Root cause: `web/src/App.tsx`'s "secret rare cards drawn this game" effect (fires on `gameOver`) tracked achievement progress, recorded seen secret types, and posted the win to the news feed via `publishSecretRareWin` — but never called `addCardsToCollection`. Drawing a mythic/shiny/holofoil/glass card mid-battle only ever conjured it into the temporary battle hand; it vanished once the battle ended.
- Fix: call `addCardsToCollection` for every card name in `secretRaresObtained` so the card is permanently granted, matching every other reward path in the game (packs, gifts, quests, achievements, hub drops).

## Test plan
- [x] `npm run build` passes (tsc + vite build clean)
- [x] Confirmed against the reporter's save data: `jarv_secret_types_seen` contained `"mythic"` (proving the mythic draw fired) while `jarv_collection` had no `Prism Wyrm` entry — matches the bug exactly
- [ ] Manual QA: draw a secret-rare card in a battle, finish the battle, confirm the card appears in the Collection screen


---
_Generated by [Claude Code](https://claude.ai/code/session_013XA5wXwsNXoALR9QgSSE8X)_