### PR TITLE
Hub World: NPC rivalry — befriending one NPC can sour another

### DIFF
--- a/docs/hubworld.md
+++ b/docs/hubworld.md
@@ -532,6 +532,45 @@ greeting:
    track in the Town Directory → Relationship view, gated quests appear, and
    state survives a reload.
 
+### Rivalry (`HubNpc.dislikes`)
+
+Some NPCs dislike each other — befriending one sours the player's standing
+with anyone in the same town who dislikes them. This needs **no new points
+concept**: it reuses the existing `rival` track. Every relationship grant in
+`HubWorld.tsx` goes through the module-level `grantRelationship(npcId, track,
+points, townNpcs)` helper (not the raw `addRelationshipPoints` — that stays
+private to this helper). Whenever an `ally`/`romance` grant pushes that NPC's
+dominant track up a **level**, every NPC in the same town whose `dislikes`
+array contains that NPC's id gets `RIVALRY_POINTS` (4) added to their own
+`rival` track. `rival`-track grants never trigger further rivalry (no chains).
+
+- `HubNpc.dislikes?: string[]` — ids of other **same-town** NPCs this NPC
+  dislikes. Scoped to one town by design — `dislikes` is checked against
+  `locationData.HUB_NPCS`, not a cross-town registry.
+- The reactive line needs no new plumbing — it's an ordinary
+  `relationshipDialogue` entry for the disliking NPC's `rival` tier (above).
+  It fires automatically the next time that NPC is talked to, exactly like any
+  other relationship-tier greeting.
+- Demo pair (Ravenwatch): `npc_1781727321393` ("The Wanderer") dislikes
+  `npc_1781629843466` ("James"). Both are plain flavor-only NPCs, so
+  befriending James via §7d's Talk/Give raises the Wanderer's `rival` track;
+  once it reaches level 1 the Wanderer's `relationshipDialogue.rival["1"]`
+  line fires.
+
+#### Authoring checklist: new rivalry pair
+
+1. Add `"dislikes": ["<other-npc-id>"]` to the disliking NPC in its town
+   `config.json`.
+2. Author a `relationshipDialogue` entry for that NPC's `rival` tier (this
+   doc's §7c schema, above) in the same town's `questDefs.json` — skip this if
+   the NPC has a `dialogueTree` (relationshipDialogue is shadowed either way).
+3. Run `npm run test` + `npm run build`.
+4. Verify by reading the flow through: repeatedly advance the liked NPC's
+   `ally`/`romance` track (via quests, dialogue-tree effects, or §7d Talk/Give)
+   until it levels up at least `10 / RIVALRY_POINTS` times (3, at the default
+   4 pts/level-up) to cross the disliking NPC's rival level 1 threshold, then
+   confirm the disliking NPC's next tap shows the grudge line.
+
 ---
 
 ## §7d — Generic Talk / Give (every named NPC)

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -11,7 +11,7 @@ import type { HubQuestDef, DialogueTree, DialogueChoiceDef, DialogueEffect } fro
 import { emitSound } from '../../game/sound'
 import { getPickedUpIds, markPickedUp, unmarkPickedUp } from '../../game/hub/pickups'
 import { getFriendshipLevel, addFriendshipXp, getFriendshipData } from '../../game/hub/friendship'
-import { addRelationshipPoints, getRelationship, RELATIONSHIP_TRACKS, type RelationshipTrack } from '../../game/hub/relationships'
+import { addRelationshipPoints, getRelationship, getRelationshipLevel, RELATIONSHIP_TRACKS, type RelationshipTrack } from '../../game/hub/relationships'
 import { canTalkToday, recordTalk } from '../../game/hub/talkCooldown'
 import { setDialogueFlag, hasDialogueFlag, markNodeSeen } from '../../game/hub/dialogueFlags'
 import { getQuestState, setQuestStatus, incrementQuestProgress, getQuestProgress, resetQuest } from '../../game/hub/quests'
@@ -52,7 +52,7 @@ import { formatGameTime, hourInRange } from '../../game/hub/hubClock'
 import { getActiveFestival } from '../../game/hub/hubCalendar'
 import { getDailyChallengeNPCDialogue } from '../../game/hub/npcDialogue'
 import {  ALL_QUESTS, FRIENDSHIP_DIALOGUE, RELATIONSHIP_DIALOGUE, RAVENWATCH } from '../../data/hub/hubWorldFactory'
-import { HubInteractable, HubLocationBundle, HubQuestBundle, HubTreasure } from '../../data/hub/loader'
+import { HubInteractable, HubLocationBundle, HubQuestBundle, HubTreasure, HubNpc } from '../../data/hub/loader'
 import { getUnreadCount } from '../../game/news'
 import { interactableStoreKey, isInteractableGranted, markInteractableGranted, getInteractableMoves, setInteractableMove } from '../../game/hub/interactables'
 import { canDigToday, recordDig } from '../../game/hub/digs'
@@ -73,6 +73,10 @@ interface QuestEvent {
 const T = 32
 
 const SPLASH_MS = 10_000
+
+// Rival points granted to an NPC when a same-town NPC it dislikes (§7c) has
+// its ally/romance track level up with the player.
+const RIVALRY_POINTS = 4
 
 let _hubSplashShown = false
 
@@ -784,7 +788,23 @@ function formatTradeReward(eff: Extract<DialogueEffect, { type: 'tradeHubItem' }
   return parts.join('  ·  ')
 }
 
-function grantQuestReward(quest: HubQuestDef): void {
+// Grants relationship points and, if this pushes the NPC's ally/romance track
+// up a level, applies the §7c rivalry reaction: every same-town NPC who
+// dislikes them gains rival points of their own. The reactive flavor line
+// needs no extra plumbing — it's just an ordinary `relationshipDialogue`
+// entry for the disliking NPC's `rival` tier (§7c), which already fires
+// automatically once that NPC's dominant track/level match.
+function grantRelationship(npcId: string, track: RelationshipTrack, points: number, townNpcs: HubNpc[]): void {
+  const before = getRelationshipLevel(npcId)
+  const entry = addRelationshipPoints(npcId, track, points)
+  if ((track === 'ally' || track === 'romance') && entry.level > before) {
+    for (const other of townNpcs) {
+      if (other.dislikes?.includes(npcId)) addRelationshipPoints(other.id, 'rival', RIVALRY_POINTS)
+    }
+  }
+}
+
+function grantQuestReward(quest: HubQuestDef, townNpcs: HubNpc[]): void {
   const { reward } = quest
   if (reward.crystals) {
     saveCrystals(loadCrystals() + reward.crystals)
@@ -803,7 +823,7 @@ function grantQuestReward(quest: HubQuestDef): void {
   }
   if (reward.relationship) {
     for (const [npcId, grant] of Object.entries(reward.relationship)) {
-      addRelationshipPoints(npcId, grant.track, grant.points)
+      grantRelationship(npcId, grant.track, grant.points, townNpcs)
     }
   }
   if (reward.accessory) {
@@ -881,7 +901,7 @@ function hasOfferableQuest(giverId: string): boolean {
   function completeQuestFor(quest: HubQuestDef, speakerName: string): void {
     setQuestStatus(quest.id, 'completed')
     clearHeldQuestItems(quest)
-    grantQuestReward(quest)
+    grantQuestReward(quest, locationData.HUB_NPCS)
     if (quest.reward.crystals) onCrystalsChange?.(loadCrystals())
     refreshState()
     const rewardText = formatQuestReward(quest.reward)
@@ -931,7 +951,7 @@ function hasOfferableQuest(giverId: string): boolean {
           refreshState()
           break
         case 'relationship':
-          addRelationshipPoints(eff.npcId ?? npcId, eff.track, eff.points)
+          grantRelationship(eff.npcId ?? npcId, eff.track, eff.points, locationData.HUB_NPCS)
           refreshState()
           break
         case 'quest': {
@@ -980,7 +1000,7 @@ function hasOfferableQuest(giverId: string): boolean {
             addFriendshipXp(eff.giveFriendship.npcId ?? npcId, eff.giveFriendship.xp)
           }
           if (eff.giveRelationship) {
-            addRelationshipPoints(eff.giveRelationship.npcId ?? npcId, eff.giveRelationship.track, eff.giveRelationship.points)
+            grantRelationship(eff.giveRelationship.npcId ?? npcId, eff.giveRelationship.track, eff.giveRelationship.points, locationData.HUB_NPCS)
           }
           emitSound('shopPurchase')
           refreshState()
@@ -1211,7 +1231,7 @@ function hasOfferableQuest(giverId: string): boolean {
           if (!talkable) return
           recordTalk(npcId)
           addFriendshipXp(npcId, 2)
-          addRelationshipPoints(npcId, 'ally', 1)
+          grantRelationship(npcId, 'ally', 1, locationData.HUB_NPCS)
           refreshState()
           setDialogueEvent({ speakerName, text: 'Always good to catch up.' })
         },
@@ -1257,7 +1277,7 @@ function hasOfferableQuest(giverId: string): boolean {
         ? (npcDef.favoriteGiftTrack as RelationshipTrack)
         : 'ally'
     addFriendshipXp(npcId, isFavorite ? 10 : 3)
-    addRelationshipPoints(npcId, track, isFavorite ? 8 : 2)
+    grantRelationship(npcId, track, isFavorite ? 8 : 2, locationData.HUB_NPCS)
     refreshState()
     setDialogueEvent({
       speakerName,

--- a/web/src/data/hub/config.ts
+++ b/web/src/data/hub/config.ts
@@ -201,6 +201,9 @@ export interface RawNpc {
   favoriteGiftItemId?: string
   /** Relationship track the favorite-gift bonus applies to. Defaults to 'ally' if favoriteGiftItemId is set. */
   favoriteGiftTrack?: string
+
+  /** Ids of other same-town NPCs this NPC dislikes — befriending one raises this NPC's own 'rival' track. */
+  dislikes?: string[]
 }
 
 export interface RawLockedDoor {

--- a/web/src/data/hub/loader.ts
+++ b/web/src/data/hub/loader.ts
@@ -171,6 +171,8 @@ export interface HubNpc {
   favoriteGiftItemId?: string
   /** Relationship track ('ally' | 'rival' | 'romance') the favorite-gift bonus applies to. Defaults to 'ally'. */
   favoriteGiftTrack?: string
+  /** Ids of other same-town NPCs this NPC dislikes — befriending one raises this NPC's own 'rival' track. */
+  dislikes?: string[]
 }
 
 export type HubAnimalType =

--- a/web/src/data/hub/ravenwatch/config.json
+++ b/web/src/data/hub/ravenwatch/config.json
@@ -9275,7 +9275,8 @@
         "Hello!"
       ],
       "levelBuildingId": "townhall",
-      "minLevel": 2
+      "minLevel": 2,
+      "dislikes": ["npc_1781629843466"]
     }
   ],
   "ambientNpcSprites": [

--- a/web/src/data/hub/ravenwatch/questDefs.json
+++ b/web/src/data/hub/ravenwatch/questDefs.json
@@ -5629,6 +5629,11 @@
       "rival": {
         "2": "Back again? Every bargain with you is a duel. Do not expect me to blink first."
       }
+    },
+    "npc_1781727321393": {
+      "rival": {
+        "1": "I hear you've been getting friendly with James. Careful who you trust, Commander."
+      }
     }
   },
   "blockedPaths": [


### PR DESCRIPTION
Fixes #1872. Part of #1870 (sub-issue 2 of 5; #1871 already merged in #1876).

## Summary
- Adds an optional `dislikes?: string[]` field to `HubNpc` (same-town NPC ids).
- Centralizes all 5 previously-scattered `addRelationshipPoints` call sites in `HubWorld.tsx` behind a new module-level `grantRelationship(npcId, track, points, townNpcs)` helper.
- Whenever an `ally`/`romance` grant pushes an NPC's dominant track up a **level**, every same-town NPC whose `dislikes` list contains that NPC's id gains `RIVALRY_POINTS` (4) in their own `rival` track. `rival`-track grants never chain into further rivalry.
- No new persistence or UI: this reuses the existing `rival` track and `relationships.ts` store as-is. The reactive "grudge" line needs no new plumbing either — it's an ordinary `relationshipDialogue` entry for the disliking NPC's `rival` tier (§7c), which already fires automatically the next time that NPC is tapped.
- Demo pair wired end-to-end in Ravenwatch: `npc_1781727321393` ("The Wanderer") dislikes `npc_1781629843466` ("James") — both plain flavor-only NPCs, so befriending James via the #1871 Talk/Give mechanism raises the Wanderer's `rival` track, and its `relationshipDialogue.rival["1"]` line fires once it crosses level 1.
- Documented in `docs/hubworld.md` §7c (new "Rivalry" subsection + authoring checklist).

Broader curation of `dislikes` pairs across the other 12 towns is left for a follow-up — this PR ships the mechanism plus one proof-of-concept pair, matching how #1871 shipped `favoriteGiftItemId` without bulk-curating it everywhere.

## Test plan
- [x] `npm run build` — clean TypeScript build
- [x] `npm run test` — 361/361 tests pass
- [ ] Manual in-game check (deferred — logic/data change verified via build/tests per updated `AGENTS.md` guidance; not a visual bug)


---
_Generated by [Claude Code](https://claude.ai/code/session_01ECAnvLwwDB5WQRZrGM5R2Y)_