### PR TITLE
Hub World: friendship/relationship-gated rewards & bounties

### DIFF
--- a/docs/hubworld.md
+++ b/docs/hubworld.md
@@ -19,7 +19,7 @@
 | `web/src/game/hub/friendship.ts` | NPC friendship XP/level persistence (localStorage) | `getFriendshipLevel`, `addFriendshipXp`, `getFriendshipData` |
 | `web/src/game/hub/reputation.ts` | Per-town reputation + per-building upgrade levels (localStorage) — see §10 | `getTownReputation`, `getUpgradeLevel`, `nextUpgrade`, `purchaseUpgrade`, `getUnlockedServices`, `hasTownService` |
 | `web/src/data/hub/buildingUpgrades.json` / `.ts` | Shared upgrade tracks keyed by building *kind* (costs, benefits, services, decor) — see §10 | `getUpgradeTrack`, `getReputationTier`, `REPUTATION_TIERS` |
-| `web/src/game/hub/relationships.ts` | NPC relationship-track (ally/rival/romance) persistence (localStorage) — see §7c | `getRelationship`, `getRelationshipTrack`, `getRelationshipLevel`, `addRelationshipPoints`, `relationshipProgress` |
+| `web/src/game/hub/relationships.ts` | NPC relationship-track (ally/rival/romance) persistence (localStorage) — see §7c | `getRelationship`, `getRelationshipTrack`, `getRelationshipLevel`, `addRelationshipPoints`, `grantRelationshipWithRivalry`, `relationshipProgress` |
 | `web/src/game/hub/dialogueFlags.ts` | Branching-dialogue flag + "seen" branch persistence (localStorage) — see §7b | `setDialogueFlag`, `hasDialogueFlag`, `getDialogueFlags`, `markNodeSeen`, `hasNodeSeen` |
 | `web/src/game/hub/innConvos.ts` | Inn conversation tracking (localStorage) | `getHeardConvoIds`, `markConvoHeard`, `isConvoHeard` |
 | `web/src/game/hub/interactables.ts` | Interactable grant + moved-position persistence (localStorage) | `interactableStoreKey`, `isInteractableGranted`, `markInteractableGranted`, `getInteractableMoves`, `setInteractableMove` |
@@ -536,13 +536,16 @@ greeting:
 
 Some NPCs dislike each other — befriending one sours the player's standing
 with anyone in the same town who dislikes them. This needs **no new points
-concept**: it reuses the existing `rival` track. Every relationship grant in
-`HubWorld.tsx` goes through the module-level `grantRelationship(npcId, track,
-points, townNpcs)` helper (not the raw `addRelationshipPoints` — that stays
-private to this helper). Whenever an `ally`/`romance` grant pushes that NPC's
-dominant track up a **level**, every NPC in the same town whose `dislikes`
-array contains that NPC's id gets `RIVALRY_POINTS` (4) added to their own
-`rival` track. `rival`-track grants never trigger further rivalry (no chains).
+concept**: it reuses the existing `rival` track. Every relationship grant
+(in `HubWorld.tsx` — quests, dialogue-tree effects, Talk/Give — and in
+`bounties.ts`, §7e) goes through the exported
+`grantRelationshipWithRivalry(npcId, track, points, townNpcs)` helper in
+`web/src/game/hub/relationships.ts` (not the raw `addRelationshipPoints` —
+that stays an internal building block). Whenever an `ally`/`romance` grant
+pushes that NPC's dominant track up a **level**, every NPC in the same town
+whose `dislikes` array contains that NPC's id gets `RIVALRY_POINTS` (4) added
+to their own `rival` track. `rival`-track grants never trigger further
+rivalry (no chains).
 
 - `HubNpc.dislikes?: string[]` — ids of other **same-town** NPCs this NPC
   dislikes. Scoped to one town by design — `dislikes` is checked against
@@ -620,6 +623,70 @@ NPC:
 2. Run `npm run test` (loader tests parse all configs) and `npm run build`.
 3. Verify in-game: gifting the favorite item shows the bigger-bonus flavor
    line and moves the configured track further than a generic material gift.
+
+---
+
+## §7e — Bounty Rewards & Gating (friendship / relationship)
+
+Bounties (`web/src/game/hub/bounties.ts`) can now grant friendship/relationship
+on turn-in, and can themselves be gated behind a relationship/friendship level
+— so a well-liked NPC can offer unique bounty content.
+
+### Reward shape (`BountyReward`)
+
+Mirrors `HubQuestReward` (§7c) exactly:
+
+```ts
+export interface BountyReward {
+  crystals: number
+  accessory?: string
+  friendship?: Record<string, number>            // npcId -> xp
+  relationship?: Record<string, RelationshipGrant> // npcId -> { track, points }
+}
+```
+
+Applied in `turnInBounty(id, townNpcs)` — the same NPC list `HubWorld.tsx`
+passes to `<BountyBoardModal townNpcs={locationData.HUB_NPCS} />`, so
+relationship grants correctly trigger the rivalry reaction (below) exactly
+like quest/dialogue-tree grants do.
+
+### Shared rivalry-aware granting (`relationships.ts`)
+
+The relationship-grant + rivalry logic (§7c "Rivalry") lives in
+`web/src/game/hub/relationships.ts` as `grantRelationshipWithRivalry(npcId,
+track, points, townNpcs)` — a pure function (no React), so both
+`HubWorld.tsx` (quests, dialogue-tree effects, Talk/Give) and `bounties.ts`
+(bounty rewards) call the same code path. Never call the raw
+`addRelationshipPoints` directly from a player-facing grant site — always go
+through `grantRelationshipWithRivalry` so rivalry stays consistent everywhere.
+
+### Gating (`BountyDef.prerequisite`)
+
+Optional `prerequisite?: string` on a bounty template, filtered in
+`getDailyBounties()` before the day's 3 are drawn. Supports the same
+`friendship:<npcId>:<level>` / `relationship:<npcId>:<track>:<level>` forms as
+quest `prerequisite` (§14) — parsed by a small **local**
+`checkBountyPrerequisite` in `bounties.ts` (deliberately not shared with
+`HubWorld.tsx`'s `checkPrerequisite`, since bounties are a plain non-React
+module and this parse is small/stable enough not to warrant a cross-layer
+import). An ungated bounty (no `prerequisite`) is always eligible, as before.
+
+### Authoring checklist: new gated/rewarding bounty
+
+1. Add `friendship`/`relationship` to the bounty's `reward` (either/both,
+   optional) using the shapes above.
+2. Add `prerequisite: "relationship:<npcId>:<track>:<level>"` (or
+   `friendship:<npcId>:<level>`) if this bounty should only appear once the
+   player has reached that standing with the NPC.
+3. **Append** new templates to the end of `BOUNTY_TEMPLATES` rather than
+   inserting them earlier — `getDailyBounties`'s date-seeded draw indexes into
+   the filtered pool, so appending keeps existing fixed-date test/story
+   expectations intact when the new template is filtered out (unmet
+   prerequisite).
+4. Run `npm run test` (`bounties.test.ts`) and `npm run build`.
+5. Verify by reading the flow: raise the NPC's track/level until the bounty
+   appears in the daily pool, confirm turn-in grants the reward and (for an
+   `ally`/`romance` grant) still correctly feeds any configured rivalry.
 
 ---
 

--- a/web/src/components/hub/BountyBoardModal.tsx
+++ b/web/src/components/hub/BountyBoardModal.tsx
@@ -1,14 +1,34 @@
 import React, { useState } from 'react'
 import { ModalBackdrop } from '../ui/ModalBackdrop'
-import { getDailyBounties, isBountyAccepted, isBountyCompleted, acceptBounty, turnInBounty, getActiveBountyStepHint } from '../../game/hub/bounties'
+import { getDailyBounties, isBountyAccepted, isBountyCompleted, acceptBounty, turnInBounty, getActiveBountyStepHint, type BountyReward } from '../../game/hub/bounties'
+import type { RivalNpc } from '../../game/hub/relationships'
 
 interface Props {
   onClose: () => void
-  /** Resolve an NPC/animal id to its display name (for report-step hints). */
+  /** Resolve an NPC/animal id to its display name (for report-step hints and reward lines). */
   resolveNpcName?: (id: string) => string
+  /** Same-town NPCs — threaded into turnInBounty so friendship/relationship rewards trigger rivalry (§7c). */
+  townNpcs?: RivalNpc[]
 }
 
-export function BountyBoardModal({ onClose, resolveNpcName = (id) => id }: Props) {
+// Extra reward lines beyond the ever-present crystals line — mirrors
+// HubWorld.tsx's formatQuestReward for the same reward shape.
+function formatExtraReward(reward: BountyReward, resolveNpcName: (id: string) => string): string | null {
+  const parts: string[] = []
+  if (reward.friendship) {
+    for (const [npcId, xp] of Object.entries(reward.friendship)) {
+      parts.push(`+${xp} friendship with ${resolveNpcName(npcId)}`)
+    }
+  }
+  if (reward.relationship) {
+    for (const [npcId, grant] of Object.entries(reward.relationship)) {
+      parts.push(`+${grant.points} ${grant.track} with ${resolveNpcName(npcId)}`)
+    }
+  }
+  return parts.length > 0 ? parts.join('  ·  ') : null
+}
+
+export function BountyBoardModal({ onClose, resolveNpcName = (id) => id, townNpcs = [] }: Props) {
   const [, setTick] = useState(0)
   const refresh = () => setTick(t => t + 1)
 
@@ -42,6 +62,9 @@ export function BountyBoardModal({ onClose, resolveNpcName = (id) => id }: Props
                 </div>
                 <div className="bounty-board-modal__desc">{bounty.desc}</div>
                 <div className="bounty-board-modal__reward">+{bounty.reward.crystals} 💎</div>
+                {formatExtraReward(bounty.reward, resolveNpcName) && (
+                  <div className="bounty-board-modal__reward">{formatExtraReward(bounty.reward, resolveNpcName)}</div>
+                )}
               </div>
             ))}
           </>
@@ -59,12 +82,15 @@ export function BountyBoardModal({ onClose, resolveNpcName = (id) => id }: Props
                     <button
                       className={`action-btn action-btn--gold${hint ? ' action-btn--disabled' : ''}`}
                       disabled={!!hint}
-                      onClick={() => { turnInBounty(bounty.id); refresh() }}
+                      onClick={() => { turnInBounty(bounty.id, townNpcs); refresh() }}
                     >Turn In</button>
                   </div>
                   <div className="bounty-board-modal__desc">{bounty.desc}</div>
                   {hint && <div className="bounty-board-modal__hint">{hint}</div>}
                   <div className="bounty-board-modal__reward">+{bounty.reward.crystals} 💎</div>
+                  {formatExtraReward(bounty.reward, resolveNpcName) && (
+                    <div className="bounty-board-modal__reward">{formatExtraReward(bounty.reward, resolveNpcName)}</div>
+                  )}
                 </div>
               )
             })}
@@ -78,6 +104,9 @@ export function BountyBoardModal({ onClose, resolveNpcName = (id) => id }: Props
               <div key={bounty.id} className="bounty-board-modal__card bounty-board-modal__card--completed">
                 <div className="bounty-board-modal__title">✅ {bounty.icon} {bounty.title}</div>
                 <div className="bounty-board-modal__reward">+{bounty.reward.crystals} 💎</div>
+                {formatExtraReward(bounty.reward, resolveNpcName) && (
+                  <div className="bounty-board-modal__reward">{formatExtraReward(bounty.reward, resolveNpcName)}</div>
+                )}
               </div>
             ))}
           </>

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -11,7 +11,7 @@ import type { HubQuestDef, DialogueTree, DialogueChoiceDef, DialogueEffect } fro
 import { emitSound } from '../../game/sound'
 import { getPickedUpIds, markPickedUp, unmarkPickedUp } from '../../game/hub/pickups'
 import { getFriendshipLevel, addFriendshipXp, getFriendshipData } from '../../game/hub/friendship'
-import { addRelationshipPoints, getRelationship, getRelationshipLevel, RELATIONSHIP_TRACKS, type RelationshipTrack } from '../../game/hub/relationships'
+import { getRelationship, grantRelationshipWithRivalry, RELATIONSHIP_TRACKS, type RelationshipTrack } from '../../game/hub/relationships'
 import { canTalkToday, recordTalk } from '../../game/hub/talkCooldown'
 import { setDialogueFlag, hasDialogueFlag, markNodeSeen } from '../../game/hub/dialogueFlags'
 import { getQuestState, setQuestStatus, incrementQuestProgress, getQuestProgress, resetQuest } from '../../game/hub/quests'
@@ -73,10 +73,6 @@ interface QuestEvent {
 const T = 32
 
 const SPLASH_MS = 10_000
-
-// Rival points granted to an NPC when a same-town NPC it dislikes (§7c) has
-// its ally/romance track level up with the player.
-const RIVALRY_POINTS = 4
 
 let _hubSplashShown = false
 
@@ -788,22 +784,6 @@ function formatTradeReward(eff: Extract<DialogueEffect, { type: 'tradeHubItem' }
   return parts.join('  ·  ')
 }
 
-// Grants relationship points and, if this pushes the NPC's ally/romance track
-// up a level, applies the §7c rivalry reaction: every same-town NPC who
-// dislikes them gains rival points of their own. The reactive flavor line
-// needs no extra plumbing — it's just an ordinary `relationshipDialogue`
-// entry for the disliking NPC's `rival` tier (§7c), which already fires
-// automatically once that NPC's dominant track/level match.
-function grantRelationship(npcId: string, track: RelationshipTrack, points: number, townNpcs: HubNpc[]): void {
-  const before = getRelationshipLevel(npcId)
-  const entry = addRelationshipPoints(npcId, track, points)
-  if ((track === 'ally' || track === 'romance') && entry.level > before) {
-    for (const other of townNpcs) {
-      if (other.dislikes?.includes(npcId)) addRelationshipPoints(other.id, 'rival', RIVALRY_POINTS)
-    }
-  }
-}
-
 function grantQuestReward(quest: HubQuestDef, townNpcs: HubNpc[]): void {
   const { reward } = quest
   if (reward.crystals) {
@@ -823,7 +803,7 @@ function grantQuestReward(quest: HubQuestDef, townNpcs: HubNpc[]): void {
   }
   if (reward.relationship) {
     for (const [npcId, grant] of Object.entries(reward.relationship)) {
-      grantRelationship(npcId, grant.track, grant.points, townNpcs)
+      grantRelationshipWithRivalry(npcId, grant.track, grant.points, townNpcs)
     }
   }
   if (reward.accessory) {
@@ -951,7 +931,7 @@ function hasOfferableQuest(giverId: string): boolean {
           refreshState()
           break
         case 'relationship':
-          grantRelationship(eff.npcId ?? npcId, eff.track, eff.points, locationData.HUB_NPCS)
+          grantRelationshipWithRivalry(eff.npcId ?? npcId, eff.track, eff.points, locationData.HUB_NPCS)
           refreshState()
           break
         case 'quest': {
@@ -1000,7 +980,7 @@ function hasOfferableQuest(giverId: string): boolean {
             addFriendshipXp(eff.giveFriendship.npcId ?? npcId, eff.giveFriendship.xp)
           }
           if (eff.giveRelationship) {
-            grantRelationship(eff.giveRelationship.npcId ?? npcId, eff.giveRelationship.track, eff.giveRelationship.points, locationData.HUB_NPCS)
+            grantRelationshipWithRivalry(eff.giveRelationship.npcId ?? npcId, eff.giveRelationship.track, eff.giveRelationship.points, locationData.HUB_NPCS)
           }
           emitSound('shopPurchase')
           refreshState()
@@ -1231,7 +1211,7 @@ function hasOfferableQuest(giverId: string): boolean {
           if (!talkable) return
           recordTalk(npcId)
           addFriendshipXp(npcId, 2)
-          grantRelationship(npcId, 'ally', 1, locationData.HUB_NPCS)
+          grantRelationshipWithRivalry(npcId, 'ally', 1, locationData.HUB_NPCS)
           refreshState()
           setDialogueEvent({ speakerName, text: 'Always good to catch up.' })
         },
@@ -1277,7 +1257,7 @@ function hasOfferableQuest(giverId: string): boolean {
         ? (npcDef.favoriteGiftTrack as RelationshipTrack)
         : 'ally'
     addFriendshipXp(npcId, isFavorite ? 10 : 3)
-    grantRelationship(npcId, track, isFavorite ? 8 : 2, locationData.HUB_NPCS)
+    grantRelationshipWithRivalry(npcId, track, isFavorite ? 8 : 2, locationData.HUB_NPCS)
     refreshState()
     setDialogueEvent({
       speakerName,
@@ -1943,7 +1923,7 @@ function hasOfferableQuest(giverId: string): boolean {
         {questsOpen && <QuestsModal onClose={() => setQuestsOpen(false)} onAbandon={handleQuestAbandon} questDefs={questDefs} resolveNpcName={getNpcDisplayName}/>}
         {inventoryOpen && <HubInventoryModal onClose={() => setInventoryOpen(false)} questDefs={allQuestDefs} />}
         {tradeJournalOpen && <TradeJournalModal onClose={() => setTradeJournalOpen(false)} />}
-        {bountyBoardOpen && <BountyBoardModal onClose={() => setBountyBoardOpen(false)} resolveNpcName={getNpcDisplayName}/>}
+        {bountyBoardOpen && <BountyBoardModal onClose={() => setBountyBoardOpen(false)} resolveNpcName={getNpcDisplayName} townNpcs={locationData.HUB_NPCS}/>}
         {petModalOpen && <PetModal onClose={() => setPetModalOpen(false)} petActionRef={petActionRef} />}
         {directoryOpen && <TownDirectory onClose={() => setDirectoryOpen(false)} locationData={locationData} pinnedNpcId={pinnedNpcId} onTogglePin={togglePinnedNpc} onShowRelationship={setRelationshipNpcId} />}
         {journalOpen && <TownJournal onClose={() => setJournalOpen(false)} locationData={locationData} />}

--- a/web/src/game/hub/bounties.test.ts
+++ b/web/src/game/hub/bounties.test.ts
@@ -19,6 +19,8 @@ import {
 } from './bounties'
 import { saveCrystals, loadCrystals } from '../collection'
 import { markPickedUp, isPickedUp } from './pickups'
+import { addRelationshipPoints, getRelationship } from './relationships'
+import { getFriendshipLevel } from './friendship'
 
 // In-memory localStorage mock (tests run in node environment)
 const store = new Map<string, string>()
@@ -62,6 +64,18 @@ describe('getDailyBounties', () => {
   it('changes with the date', () => {
     const other = new Date('2026-07-01T12:00:00Z')
     expect(getBountySlotKey(DAY)).not.toBe(getBountySlotKey(other))
+  })
+
+  it('excludes a relationship-gated bounty until its prerequisite is met', () => {
+    const includesGatedBounty = () => {
+      for (let day = 1; day <= 60; day++) {
+        if (getDailyBounties(new Date(2026, 0, day)).some(b => b.id === 'a-favor-for-a-friend')) return true
+      }
+      return false
+    }
+    expect(includesGatedBounty()).toBe(false)
+    addRelationshipPoints('scholar', 'ally', 10) // reaches relationship level 1
+    expect(includesGatedBounty()).toBe(true)
   })
 })
 
@@ -112,6 +126,20 @@ describe('accept / turn-in flow', () => {
     turnInBounty(bounty.id)
     expect(turnInBounty(bounty.id)).toBe(0)
     expect(loadCrystals()).toBe(bounty.reward.crystals)
+  })
+
+  it('turning in a bounty with friendship/relationship reward grants both and triggers rivalry', () => {
+    // 2 points -> relationship level 1 (unlocks the gated bounty's prerequisite).
+    addRelationshipPoints('scholar', 'ally', 2)
+    acceptBounty('a-favor-for-a-friend')
+    completeAllSteps('a-favor-for-a-friend')
+    const townNpcs = [{ id: 'scholar' }, { id: 'rival-npc', dislikes: ['scholar'] }]
+    // The reward's +8 ally points (2 -> 10) crosses into level 2, so scholar's
+    // disliker should gain rival points from the resulting rivalry reaction.
+    turnInBounty('a-favor-for-a-friend', townNpcs)
+    expect(getFriendshipLevel('scholar')).toBeGreaterThan(0)
+    expect(getRelationship('scholar').track).toBe('ally')
+    expect(getRelationship('rival-npc').track).toBe('rival')
   })
 
   it('persists accepted state across reloads', () => {

--- a/web/src/game/hub/bounties.ts
+++ b/web/src/game/hub/bounties.ts
@@ -8,7 +8,9 @@
 import { saveCrystals, loadCrystals } from '../collection'
 import { grantAccessory } from './pet'
 import { isPickedUp, unmarkPickedUp } from './pickups'
-import type { HubQuestStep } from '../../data/hub/questDefs'
+import type { HubQuestStep, RelationshipGrant } from '../../data/hub/questDefs'
+import { addFriendshipXp, getFriendshipLevel } from './friendship'
+import { getRelationship, grantRelationshipWithRivalry, type RivalNpc } from './relationships'
 
 const KEY = 'jarv_hub_bounties'
 
@@ -16,6 +18,10 @@ export interface BountyReward {
   crystals: number
   /** Pet accessory id (from petAccessories.ts) granted on turn-in. */
   accessory?: string
+  /** npcId -> friendship xp granted on turn-in. */
+  friendship?: Record<string, number>
+  /** npcId -> relationship track/points granted on turn-in. */
+  relationship?: Record<string, RelationshipGrant>
 }
 
 export interface BountyDef {
@@ -25,6 +31,8 @@ export interface BountyDef {
   icon: string
   reward: BountyReward
   steps: HubQuestStep[]
+  /** Gates this bounty from the daily pool until met — see checkBountyPrerequisite. */
+  prerequisite?: string
 }
 
 const BOUNTY_TEMPLATES: BountyDef[] = [
@@ -87,6 +95,17 @@ const BOUNTY_TEMPLATES: BountyDef[] = [
       { key: 'report',  type: 'report',  targetNpcId: 'innkeeper-rosie',     required: 1 },
     ],
   },
+  // Relationship-gated: only offered once the scholar considers you an ally.
+  // Demonstrates unique bounty content unlocked by NPC relationship level.
+  {
+    id: 'a-favor-for-a-friend',
+    title: 'A Favor for a Friend',
+    desc: 'Loremaster Caelen trusts you enough to ask a personal favor. Hear him out.',
+    icon: '📜',
+    prerequisite: 'relationship:scholar:ally:1',
+    reward: { crystals: 30, friendship: { scholar: 8 }, relationship: { scholar: { track: 'ally', points: 8 } } },
+    steps: [{ key: 'report', type: 'report', targetNpcId: 'scholar', required: 1 }],
+  },
 ]
 
 const BOUNTIES_PER_DAY = 3
@@ -124,11 +143,31 @@ export function getBountySlotKey(at?: Date): string {
   return (at ?? nowOverride ?? new Date()).toISOString().slice(0, 10)
 }
 
+/** Supports the same `friendship:<npcId>:<level>` / `relationship:<npcId>:<track>:<level>`
+ *  forms as `checkPrerequisite` in HubWorld.tsx — duplicated locally (not
+ *  imported) since bounties are a plain, non-React module and this parse is
+ *  small/stable enough not to warrant a shared cross-layer abstraction. */
+function checkBountyPrerequisite(prereq: string): boolean {
+  return prereq.split('|').every(p => {
+    const part = p.trim()
+    if (part.startsWith('friendship:')) {
+      const parts = part.split(':')
+      return getFriendshipLevel(parts[1]) >= parseInt(parts[2] ?? '1')
+    }
+    if (part.startsWith('relationship:')) {
+      const [, npcId, track, lvl] = part.split(':')
+      const rel = getRelationship(npcId)
+      return rel.track === track && rel.level >= parseInt(lvl ?? '1')
+    }
+    return true
+  })
+}
+
 /** Returns today's 3 active bounties, deterministically chosen for the day. */
 export function getDailyBounties(at?: Date): BountyDef[] {
   const slotKey = getBountySlotKey(at)
   const rng     = makeSeededRng(dateHash(slotKey) ^ 0xfeedbeef)
-  const pool    = [...BOUNTY_TEMPLATES]
+  const pool    = BOUNTY_TEMPLATES.filter(b => !b.prerequisite || checkBountyPrerequisite(b.prerequisite))
   const result: BountyDef[] = []
   const used    = new Set<number>()
 
@@ -284,7 +323,7 @@ export function reconcileBountyPickups(at?: Date): void {
 
 /** Turns in an accepted bounty whose steps are all complete, granting its
  *  crystal reward. Returns the crystals granted (0 if not eligible). */
-export function turnInBounty(id: string): number {
+export function turnInBounty(id: string, townNpcs: RivalNpc[] = []): number {
   const state = getBountyState()
   if (!state.accepted.includes(id) || state.completed.includes(id)) return 0
   if (getActiveBountyStep(id) !== null) return 0
@@ -297,6 +336,14 @@ export function turnInBounty(id: string): number {
 
   saveCrystals(loadCrystals() + def.reward.crystals)
   if (def.reward.accessory) grantAccessory(def.reward.accessory)
+  if (def.reward.friendship) {
+    for (const [npcId, xp] of Object.entries(def.reward.friendship)) addFriendshipXp(npcId, xp)
+  }
+  if (def.reward.relationship) {
+    for (const [npcId, grant] of Object.entries(def.reward.relationship)) {
+      grantRelationshipWithRivalry(npcId, grant.track, grant.points, townNpcs)
+    }
+  }
   return def.reward.crystals
 }
 

--- a/web/src/game/hub/relationships.ts
+++ b/web/src/game/hub/relationships.ts
@@ -109,3 +109,37 @@ export function addRelationshipPoints(
   save(store)
   return entry
 }
+
+// Rival points granted to an NPC when a same-town NPC it dislikes (docs
+// §7c "Rivalry") has its ally/romance track level up with the player.
+export const RIVALRY_POINTS = 4
+
+/** Minimal NPC shape rivalry needs — satisfied structurally by `HubNpc`. */
+export interface RivalNpc {
+  id: string
+  dislikes?: string[]
+}
+
+/**
+ * Grants relationship points and, if this pushes the NPC's ally/romance track
+ * up a level, applies the rivalry reaction: every same-town NPC who dislikes
+ * them gains `RIVALRY_POINTS` of their own `rival` track. The reactive
+ * flavor line needs no extra plumbing — it's just an ordinary
+ * `relationshipDialogue` entry for the disliking NPC's `rival` tier, which
+ * already fires automatically once that NPC's dominant track/level match.
+ */
+export function grantRelationshipWithRivalry(
+  npcId: string,
+  track: RelationshipTrack,
+  points: number,
+  townNpcs: RivalNpc[],
+): RelationshipEntry {
+  const before = getRelationshipLevel(npcId)
+  const entry = addRelationshipPoints(npcId, track, points)
+  if ((track === 'ally' || track === 'romance') && entry.level > before) {
+    for (const other of townNpcs) {
+      if (other.dislikes?.includes(npcId)) addRelationshipPoints(other.id, 'rival', RIVALRY_POINTS)
+    }
+  }
+  return entry
+}


### PR DESCRIPTION
Fixes #1873. Part of #1870 (sub-issue 3 of 5; #1871 and #1872 already merged in #1876/#1877).

## Summary
- Extends `BountyReward` (`bounties.ts`) with optional `friendship?: Record<npcId,xp>` / `relationship?: Record<npcId,RelationshipGrant>` fields, mirroring `HubQuestReward`'s shape exactly.
- Adds an optional `prerequisite?: string` field to `BountyDef`, supporting the same `friendship:<npcId>:<level>` / `relationship:<npcId>:<track>:<level>` syntax as quest prerequisites. `getDailyBounties()` now filters the template pool by this before drawing the day's 3 — so a bounty can be gated behind an NPC relationship, unlocking unique content for players who've built up that bond.
- Relocates the rivalry-aware relationship-granting helper (added in #1872 as `HubWorld.tsx`-local `grantRelationship`) into the pure `relationships.ts` module as exported `grantRelationshipWithRivalry` — `bounties.ts` is a plain non-React module and had no path to the component-scoped version, so this centralizes it somewhere both can reach. `HubWorld.tsx`'s 5 existing call sites are updated to match; pure relocation, no behavior change there.
- `turnInBounty` gains a `townNpcs` parameter (defaulted to `[]`, so nothing else breaks) so relationship rewards correctly trigger rivalry, threaded from `BountyBoardModal.tsx` (new `townNpcs` prop) → `HubWorld.tsx` (`locationData.HUB_NPCS`).
- `BountyBoardModal.tsx` renders the new reward fields alongside the existing crystals line in all three sections (available/accepted/completed).
- Demo bounty **"A Favor for a Friend"**, appended to the template pool, gated on `relationship:scholar:ally:1` and rewarding bonus friendship/relationship with the scholar — demonstrating the full loop end-to-end. Appending (rather than inserting) keeps the existing fixed-date `bounties.test.ts` assertions unchanged.
- Documented in `docs/hubworld.md` (new §7e, plus updates to §7c and the §1 file map).

## Test plan
- [x] `npm run build` — clean TypeScript build
- [x] `npm run test` — 363/363 tests pass; added 2 new bounty tests (prerequisite gating, reward + rivalry granting on turn-in) — all 31 pre-existing `bounties.test.ts` assertions pass unchanged
- [ ] Manual in-game check (deferred — logic/data change verified via build/tests per `AGENTS.md` guidance; not a visual bug)


---
_Generated by [Claude Code](https://claude.ai/code/session_01ECAnvLwwDB5WQRZrGM5R2Y)_