### PR TITLE
Hub World: secret gift items to boost NPC friendship

### DIFF
--- a/docs/hubworld.md
+++ b/docs/hubworld.md
@@ -286,7 +286,7 @@ bounds, else a single tile.
 |---|---|---|
 | `dialogue` | `speakerName?`, `text` (string or string[]) | Shows the dialogue modal. A string[] cycles one entry per tap. |
 | `screen` | `screen` | Opens a screen via the same routing as NPC `screen` (e.g. `news`, `shop`, `interior:<id>`, `bounty-board`, `town-upgrades`, `adopt-pet` — see §8, minigame ids). |
-| `giveItem` | `collectible?`, `consumables?`, `crystals?`, `message?`, `alreadyGrantedText?` | One-time grant (persisted). Re-taps show `alreadyGrantedText` if set. Reward shapes match treasure rewards. `collectible.lore?` (optional flavor text) is stored on the item and already surfaced by `HomeShelf`/`ItemFoundScreen` — no extra wiring needed for lore notes. |
+| `giveItem` | `collectible?`, `consumables?`, `crystals?`, `hubItem?`, `message?`, `alreadyGrantedText?` | One-time grant (persisted). Re-taps show `alreadyGrantedText` if set. Reward shapes match treasure rewards. `collectible.lore?` (optional flavor text) is stored on the item and already surfaced by `HomeShelf`/`ItemFoundScreen` — no extra wiring needed for lore notes. `hubItem?: { itemId, count? }` grants a hub-item (`hubItems.json`, §16) via `addHubItem` — the only way a secret/discovery interactable can hand over a `'material'` item, e.g. a favorite gift (§7d). |
 | `quest` | `questId`, `speakerName?` | Offers the quest with Accept / Not now. The quest's `giverNpcId` in `questDefs.json` **must equal the interactable's id**. Honours prerequisites and the 2-active-quest cap. |
 | `move` | `to: {tx, ty}`, `message?` | Moves the owned decor to the target tile, live and persisted across reloads. Requires owned `decor`. |
 | `buy` | `slotIndex` | Sells the interactable's building's Nth daily-rotating shop-stock item (`getTodaysShopItems`, `SHOP_TRADER_REGISTRY`). Shares `DailyShopState` with `ShopScreen`, so both draw down the same stock. Requires `building`. |
@@ -341,6 +341,11 @@ be genuinely non-obvious, not flagged with the usual `!`.
 2. Add an interactable entry with **no `decor`** and **no `indicator`**: a
    `dialogue` reaction for discovery flavor, then a `giveItem` reaction
    granting a collectible. Use `collectible.lore` for a lore note's full text.
+   To hide a **secret gift item** instead (§7d — a favorite-gift NPC's
+   `favoriteGiftItemId`), use `giveItem`'s `hubItem: { itemId, count? }` field
+   so the discovery grants a `'material'` hub-item the player can then give
+   away, rather than a `collectible`. Live examples: `gearford-secret-pressed-flower`,
+   `thornwood-secret-river-glass`, `saltmere-secret-tin-whistle`.
 3. *(Optional — hidden-area reveal)* Pair this secret with a hidden area: add
    a `blockedPaths` entry in the town's `questDefs.json` (§2) whose
    `unlockedByInteractable` is this secret's `id`. The blocked/cleared decor
@@ -623,6 +628,11 @@ NPC:
 2. Run `npm run test` (loader tests parse all configs) and `npm run build`.
 3. Verify in-game: gifting the favorite item shows the bigger-bonus flavor
    line and moves the configured track further than a generic material gift.
+
+For an item worth hiding rather than buying, pair the favorite gift with a
+**secret** interactable elsewhere in the same town (§7's "new secret /
+dig-spot" checklist) that discovers the item via `giveItem`'s `hubItem` field
+— see the live examples there (Gearford/Thornwood Camp/Saltmere Port).
 
 ---
 

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -1504,6 +1504,9 @@ function hasOfferableQuest(giverId: string): boolean {
           saveCrystals(loadCrystals() + r.crystals)
           onCrystalsChange?.(loadCrystals())
         }
+        if (r.hubItem) {
+          addHubItem(r.hubItem.itemId, r.hubItem.count ?? 1)
+        }
         refreshState()
         if (r.message) setDialogueEvent({ speakerName: '', text: r.message, onClose: next })
         else next()

--- a/web/src/data/hub/config.ts
+++ b/web/src/data/hub/config.ts
@@ -282,6 +282,10 @@ export interface RawInteractableReaction {
     quantity: number
   }>
   crystals?: number
+  hubItem?: {
+    itemId: string
+    count?: number
+  }
   message?: string
   alreadyGrantedText?: string
 

--- a/web/src/data/hub/gearford/config.json
+++ b/web/src/data/hub/gearford/config.json
@@ -1861,7 +1861,9 @@
         "buildingId": "worker-house-1",
         "tx": 7,
         "ty": 2
-      }
+      },
+      "favoriteGiftItemId": "pressed-flower",
+      "favoriteGiftTrack": "ally"
     },
     {
       "id": "gearwright-orin",
@@ -3614,6 +3616,22 @@
       "building": "gear-shop",
       "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 2 }],
       "reactions": [{ "type": "buy", "slotIndex": 2 }]
+    },
+    {
+      "id": "gearford-secret-pressed-flower",
+      "tx": 19,
+      "ty": 13,
+      "reactions": [
+        {
+          "type": "dialogue",
+          "text": "Tucked behind a loose paving stone, you find a flower pressed flat and dry."
+        },
+        {
+          "type": "giveItem",
+          "hubItem": { "itemId": "pressed-flower", "count": 1 },
+          "message": "You found a pressed flower!"
+        }
+      ]
     }
   ]
 }

--- a/web/src/data/hub/loader.ts
+++ b/web/src/data/hub/loader.ts
@@ -273,6 +273,8 @@ export type HubInteractableReaction =
       collectible?: { id: string; name: string; icon: string; desc: string; lore?: string }
       consumables?: Array<{ id: string; quantity: number }>
       crystals?: number
+      /** Hub-item id (hubItems.json) + count to grant, e.g. a secret 'material' gift item. */
+      hubItem?: { itemId: string; count?: number }
       message?: string
       alreadyGrantedText?: string }
   | { type: 'quest'; questId: string; speakerName?: string }

--- a/web/src/data/hub/saltmereport/config.json
+++ b/web/src/data/hub/saltmereport/config.json
@@ -1627,7 +1627,9 @@
         "Found a barrel of navy rum washed up under the south pier. Above my pay grade, that.",
         "Vane counts the cargo twice. I count my fingers after every shift."
       ],
-      "questGive": "saltmere-rum-run"
+      "questGive": "saltmere-rum-run",
+      "favoriteGiftItemId": "tin-whistle",
+      "favoriteGiftTrack": "ally"
     },
     {
       "id": "old-salt",
@@ -2552,6 +2554,22 @@
       "building": "chandlers",
       "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 2 }],
       "reactions": [{ "type": "buy", "slotIndex": 2 }]
+    },
+    {
+      "id": "saltmere-secret-tin-whistle",
+      "tx": 30,
+      "ty": 18,
+      "reactions": [
+        {
+          "type": "dialogue",
+          "text": "Half-buried under a coil of rope, a little tin whistle catches the light."
+        },
+        {
+          "type": "giveItem",
+          "hubItem": { "itemId": "tin-whistle", "count": 1 },
+          "message": "You found a tin whistle!"
+        }
+      ]
     }
   ],
   "animals": [

--- a/web/src/data/hub/thornwoodcamp/config.json
+++ b/web/src/data/hub/thornwoodcamp/config.json
@@ -507,7 +507,9 @@
       "questReceive": [
         "thornwood-travellers-aid",
         "thornwood-river-relay"
-      ]
+      ],
+      "favoriteGiftItemId": "river-glass",
+      "favoriteGiftTrack": "ally"
     }
   ],
   "animals": [
@@ -606,6 +608,22 @@
           "dx": 0,
           "dy": -1,
           "tileId": "scarecrowTop"
+        }
+      ]
+    },
+    {
+      "id": "thornwood-secret-river-glass",
+      "tx": 6,
+      "ty": 31,
+      "reactions": [
+        {
+          "type": "dialogue",
+          "text": "Something glints in the grass — a shard of river glass, smoothed by years in the current."
+        },
+        {
+          "type": "giveItem",
+          "hubItem": { "itemId": "river-glass", "count": 1 },
+          "message": "You found a piece of river glass!"
         }
       ]
     }

--- a/web/src/data/hubItems.json
+++ b/web/src/data/hubItems.json
@@ -269,5 +269,26 @@
     "icon": "🧪",
     "desc": "Sythe's fog-brewed tonic. Even bone-keepers pay well for it.",
     "category": "material"
+  },
+  {
+    "id": "pressed-flower",
+    "name": "Pressed Flower",
+    "icon": "🌸",
+    "desc": "A wildflower pressed flat between old pages, still faintly fragrant.",
+    "category": "material"
+  },
+  {
+    "id": "river-glass",
+    "name": "River Glass",
+    "icon": "🔷",
+    "desc": "A shard of glass worn smooth and cloudy by years in the current.",
+    "category": "material"
+  },
+  {
+    "id": "tin-whistle",
+    "name": "Tin Whistle",
+    "icon": "🎵",
+    "desc": "A dented little whistle. Still plays a clean note if you blow just right.",
+    "category": "material"
   }
 ]


### PR DESCRIPTION
Fixes #1874. Part of #1870 (sub-issue 4 of 5; #1871, #1872, #1873 already merged in #1876/#1877/#1878).

## Summary
- The `favoriteGiftItemId`/`favoriteGiftTrack` mechanism (from #1871) already works end-to-end, but the generic "Give a gift" flow only ever offers hub-items with `category: 'material'` (`HubWorld.tsx`'s `giftable` filter). The existing "secret" interactable pattern (§7 — a hidden, non-obvious tap discovery) had no way to grant one: its `giveItem` reaction only supported `collectible`/`consumables`/`crystals`.
- Adds an optional `hubItem?: { itemId: string; count?: number }` field to the `giveItem` reaction (`HubInteractableReaction` in `loader.ts`, `RawInteractableReaction` in `config.ts`), applied via the already-imported `addHubItem` in `HubWorld.tsx`'s `runReactions`.
- Curates 3 secret-gift pairs across 3 different towns, each a hidden interactable (no decor, no indicator — genuinely non-obvious) granting a new `material` item, paired with a `favoriteGiftItemId` on a plain NPC with no `dialogueTree` conflict:
  - **Gearford**: Apprentice Tila ← `pressed-flower`
  - **Thornwood Camp**: Trader Pell ← `river-glass`
  - **Saltmere Port**: Dockhand Tam ← `tin-whistle`
- Documented in `docs/hubworld.md` (§7's `giveItem` reaction table + secret-authoring checklist, cross-referenced from §7d's favorite-gift section).

## Test plan
- [x] `npm run build` — clean TypeScript build
- [x] `npm run test` — 363/363 tests pass (loader tests parse all 3 modified town configs + the new hub items)
- [ ] Manual in-game check (deferred — logic/data change verified via build/tests per `AGENTS.md` guidance; not a visual bug)


---
_Generated by [Claude Code](https://claude.ai/code/session_01ECAnvLwwDB5WQRZrGM5R2Y)_