### PR TITLE
Hub World: forage mechanic — chance-based item drops from decor

### DIFF
--- a/docs/hubworld.md
+++ b/docs/hubworld.md
@@ -37,6 +37,7 @@
 | `web/src/game/hub/digs.ts` | Once-per-day dig-spot persistence (localStorage) — see §7 `dig` reaction, §16 | `canDigToday`, `recordDig` |
 | `web/src/components/hub/HubInventoryModal.tsx` | 🎒 Hub Inventory UI — held quest items, materials & tools, pet accessories — see §16 | `HubInventoryModal` |
 | `web/src/game/hub/talkCooldown.ts` | Once-per-day "Make conversation" persistence (localStorage) — see §7d | `canTalkToday`, `recordTalk` |
+| `web/src/game/hub/forages.ts` | Once-per-day forage-spot persistence (localStorage) — see §7 `forage` reaction | `canForageToday`, `recordForage` |
 
 ---
 
@@ -293,6 +294,7 @@ bounds, else a single tile.
 | `buyPack` | — | Crystal-pack purchase flow (delegates to `onBuyCrystalPack`). Requires `building`. |
 | `buyHubItem` | `itemId`, `price`, `currency?`, `speakerName?`, `prerequisite?`, `lockedText?` | Always-available hub-item purchase (no daily rotation) — see §16. `itemId` must exist in `hubItems.json`; `currency` is `'crystals'` (default) or `'tickets'`. Unique items (e.g. the fishing rod) re-offer as "already owned" once bought. `speakerName` overrides the building-NPC speaker (useful for exterior stalls). `prerequisite` (§14 syntax, including `reputation:<tier>`) gates the offer — unmet shows `lockedText` (or a default refusal) instead. |
 | `dig` | `requiresItemId?`, `nightOnly?`, `weatherOnly?`, `lootTable?` | Once-per-day dig spot (see §16), gated on holding the tool hub-item (default `'spade'`). `nightOnly: true` makes it a **dark hollow** that refuses by day; `weatherOnly` (e.g. `"rain"`) makes it refuse unless the town's resolved weather (§12) matches — used by **rain barrels**. `lootTable: 'earth'` (default) rolls 50% worms (+2 fish bait) / 30% crystals (10–25) / 20% a dug-up trinket; `'hollow'` rolls 50% glowcap mushroom / 25% crystals (15–35) / 25% a firefly; `'rain'` always yields 1 rainwater; `'fog'` always yields 1 grave moss. Cooldown persists per spot per real day in `jarv_hub_digs` (`web/src/game/hub/digs.ts`). Pair with a `mediumDirt` decor tile (`zlayer: "below"`) for an earth patch, or `barrel` for a rain barrel. |
+| `forage` | — | Once-per-day forage spot, no fields. Unlike `dig`, no tool/night/weather gating — meant to overlay an ordinary tree/bush/flower `exteriorDecor` tile (no owned decor of its own) so any existing scenery can become forageable. Rolls 45% 1 wild berries / 35% crystals (5–15) / 20% a rare four-leaf-clover collectible. Cooldown persists per spot per real day in `jarv_hub_forages` (`web/src/game/hub/forages.ts`), same key convention as `dig`. |
 
 Reactions run in order; `dialogue` (and `message`-bearing reactions) chain the
 remainder through the dialogue's close. Conventions: at most one `screen` or
@@ -358,6 +360,26 @@ be genuinely non-obvious, not flagged with the usual `!`.
    correctly wherever the item is displayed, and — if paired with a hidden
    area — that area opens live (no reload) the moment the secret is found,
    and all of it persists across a reload.
+
+### Authoring checklist: new forage spot
+
+Unlike a secret, a forage spot should be **visible and obvious** — it overlays
+an *existing* `exteriorDecor` tile (a tree, bush, flower, or other plant
+scenery already in the town), so no owned `decor` or new art is needed.
+
+1. Pick an existing tree/bush/flower `exteriorDecor` entry's `tx`/`ty` (grep
+   the town's `exteriorDecor` array for a `tileId` containing `tree`, `bush`,
+   `shrub`, or `flower`) that isn't already occupied by another interactable,
+   NPC, or animal.
+2. Add an interactable entry at that same `tx`/`ty` with **no `decor`**: a
+   `dialogue` reaction for flavor, then a `{ "type": "forage" }` reaction (no
+   fields). Live examples: `ravenwatch-forage-bush-1`, `ravenwatch-forage-tree-1`,
+   `ravenwatch-forage-flower-1`/`-2`.
+3. Run `npm run test` and `npm run build`.
+4. Verify by reading the flow: the interactable sits directly on top of
+   already-rendered decor (no visual change needed), tapping it once a day
+   grants wild berries / crystals / a four-leaf clover, and re-tapping the
+   same day shows the "already foraged" line instead.
 
 ---
 

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -56,6 +56,7 @@ import { HubInteractable, HubLocationBundle, HubQuestBundle, HubTreasure, HubNpc
 import { getUnreadCount } from '../../game/news'
 import { interactableStoreKey, isInteractableGranted, markInteractableGranted, getInteractableMoves, setInteractableMove } from '../../game/hub/interactables'
 import { canDigToday, recordDig } from '../../game/hub/digs'
+import { canForageToday, recordForage } from '../../game/hub/forages'
 import { getReputationTier } from '../../data/hub/buildingUpgrades'
 import { resolveWeather } from '../../game/hub/weather'
 import { recordSellerSeen, recordBuyerSeen } from '../../game/hub/tradeJournal'
@@ -1808,6 +1809,47 @@ function hasOfferableQuest(giverId: string): boolean {
         setDialogueEvent({
           speakerName: '',
           text: 'A patch of soft, diggable earth.',
+          choices: [confirm, { label: 'Leave it', onClick: () => setDialogueEvent(null) }],
+        })
+        return
+      }
+      case 'forage': {
+        // Once-per-day forage spot — overlays an ordinary tree/bush/flower
+        // decor tile (docs/hubworld.md §7). Unlike dig, no tool/night/weather
+        // gating: foraging is meant to be low-friction and always available.
+        if (!canForageToday(storeKey)) {
+          setDialogueEvent({ speakerName: '', text: "You've already foraged here today. Let it grow back." })
+          return
+        }
+        const confirm: DialogueChoice = {
+          label: 'Forage here',
+          primary: true,
+          onClick: () => {
+            recordForage(storeKey)
+            const roll = Math.random()
+            let text: string
+            if (roll < 0.45) {
+              addHubItem('wild-berries', 1)
+              emitSound('pickup')
+              text = 'You come away with a handful of ripe wild berries. 🫐'
+            } else if (roll < 0.8) {
+              const amount = 5 + Math.floor(Math.random() * 11) // 5–15
+              saveCrystals(loadCrystals() + amount)
+              onCrystalsChange?.(loadCrystals())
+              emitSound('treasure')
+              text = `Something small and bright is tucked in the leaves — ${amount} crystals. 💎`
+            } else {
+              addCollectible('four-leaf-clover', { name: 'Four-Leaf Clover', icon: '🍀', desc: 'A rare find among the ordinary three-leafed kind. Feels lucky.' })
+              emitSound('treasure')
+              text = 'Tucked in the greenery — a four-leaf clover! Added to your collection. 🍀'
+            }
+            refreshState()
+            setDialogueEvent({ speakerName: '', text, onClose: next })
+          },
+        }
+        setDialogueEvent({
+          speakerName: '',
+          text: 'A patch of wild growth, ripe for foraging.',
           choices: [confirm, { label: 'Leave it', onClick: () => setDialogueEvent(null) }],
         })
         return

--- a/web/src/data/hub/loader.ts
+++ b/web/src/data/hub/loader.ts
@@ -293,6 +293,10 @@ export type HubInteractableReaction =
    *  rolls glowcaps/crystals/fireflies; 'rain' always yields rainwater;
    *  'fog' always yields grave-moss. */
   | { type: 'dig'; requiresItemId?: string; nightOnly?: boolean; weatherOnly?: string; lootTable?: 'earth' | 'hollow' | 'rain' | 'fog' }
+  /** Once-per-day forage spot — overlays an ordinary tree/bush/flower decor
+   *  tile. No tool/night/weather gating (unlike `dig`); rolls wild-berries,
+   *  crystals, or a rare four-leaf-clover collectible. */
+  | { type: 'forage' }
 
 export interface HubInteractable {
   id: string

--- a/web/src/data/hub/ravenwatch/config.json
+++ b/web/src/data/hub/ravenwatch/config.json
@@ -9771,6 +9771,30 @@
       "building": "supply-shop",
       "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 2 }],
       "reactions": [{ "type": "buy", "slotIndex": 2 }]
+    },
+    {
+      "id": "ravenwatch-forage-bush-1",
+      "tx": 0,
+      "ty": 16,
+      "reactions": [{ "type": "dialogue", "text": "A dense, dark bush — worth a closer look." }, { "type": "forage" }]
+    },
+    {
+      "id": "ravenwatch-forage-tree-1",
+      "tx": 34,
+      "ty": 29,
+      "reactions": [{ "type": "dialogue", "text": "Something might be growing at the foot of this old tree." }, { "type": "forage" }]
+    },
+    {
+      "id": "ravenwatch-forage-flower-1",
+      "tx": 33,
+      "ty": 17,
+      "reactions": [{ "type": "dialogue", "text": "A patch of wildflowers grows here." }, { "type": "forage" }]
+    },
+    {
+      "id": "ravenwatch-forage-flower-2",
+      "tx": 34,
+      "ty": 18,
+      "reactions": [{ "type": "dialogue", "text": "More wildflowers, swaying in the breeze." }, { "type": "forage" }]
     }
   ],
   "animals": [

--- a/web/src/data/hubItems.json
+++ b/web/src/data/hubItems.json
@@ -290,5 +290,12 @@
     "icon": "🎵",
     "desc": "A dented little whistle. Still plays a clean note if you blow just right.",
     "category": "material"
+  },
+  {
+    "id": "wild-berries",
+    "name": "Wild Berries",
+    "icon": "🫐",
+    "desc": "A handful of ripe berries, foraged straight from the bush.",
+    "category": "material"
   }
 ]

--- a/web/src/game/hub/forages.test.ts
+++ b/web/src/game/hub/forages.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { canForageToday, recordForage } from './forages'
+
+function installLocalStorageStub(): void {
+  const store = new Map<string, string>()
+  vi.stubGlobal('localStorage', {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => { store.set(k, v) },
+    removeItem: (k: string) => { store.delete(k) },
+    clear: () => { store.clear() },
+  })
+}
+
+describe('forages', () => {
+  beforeEach(() => {
+    installLocalStorageStub()
+    vi.useRealTimers()
+  })
+
+  it('allows foraging a fresh spot, then blocks it for the rest of the day', () => {
+    expect(canForageToday('Ravenwatch:bush-1')).toBe(true)
+    recordForage('Ravenwatch:bush-1')
+    expect(canForageToday('Ravenwatch:bush-1')).toBe(false)
+    // Other spots are unaffected
+    expect(canForageToday('Ravenwatch:bush-2')).toBe(true)
+  })
+
+  it('allows foraging again on a new day', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-01T12:00:00Z'))
+    recordForage('Ravenwatch:tree-1')
+    expect(canForageToday('Ravenwatch:tree-1')).toBe(false)
+    vi.setSystemTime(new Date('2026-07-02T12:00:00Z'))
+    expect(canForageToday('Ravenwatch:tree-1')).toBe(true)
+  })
+
+  it('fails open (forageable) when localStorage throws', () => {
+    vi.stubGlobal('localStorage', {
+      getItem: () => { throw new Error('blocked') },
+      setItem: () => { throw new Error('blocked') },
+    })
+    expect(canForageToday('Anywhere:spot')).toBe(true)
+    expect(() => recordForage('Anywhere:spot')).not.toThrow()
+  })
+})

--- a/web/src/game/hub/forages.ts
+++ b/web/src/game/hub/forages.ts
@@ -1,0 +1,46 @@
+// ─── Forage spots ─────────────────────────────────────────────────────────────
+//
+// Persistence for the `forage` interactable reaction (docs/hubworld.md §7):
+// each forage spot can be foraged once per real day. Entries are keyed with
+// interactableStoreKey(town, id) — the same convention as interactable
+// grants and dig spots (digs.ts) — mapping to the YYYY-MM-DD the spot was
+// last foraged.
+
+import { logError } from '../../logger'
+
+const KEY = 'jarv_hub_forages'
+
+type ForageStore = Record<string, string>
+
+function load(): ForageStore {
+  try {
+    const raw = localStorage.getItem(KEY)
+    return raw ? (JSON.parse(raw) as ForageStore) : {}
+  } catch {
+    return {}
+  }
+}
+
+function save(store: ForageStore): void {
+  try {
+    localStorage.setItem(KEY, JSON.stringify(store))
+  } catch (e) {
+    logError('forages save failed', { error: String(e) })
+  }
+}
+
+function todayKey(): string {
+  return new Date().toISOString().slice(0, 10)
+}
+
+/** Whether this forage spot can still be foraged today. */
+export function canForageToday(storeKey: string): boolean {
+  return load()[storeKey] !== todayKey()
+}
+
+/** Record that this forage spot was foraged today. */
+export function recordForage(storeKey: string): void {
+  const store = load()
+  store[storeKey] = todayKey()
+  save(store)
+}


### PR DESCRIPTION
Fixes #1875. Part of #1870 (sub-issue 5 of 5 — the last one; #1871–#1874 already merged in #1876/#1877/#1878/#1879).

## Summary
- Adds a new `forage` interactable reaction, modeled directly on the existing `dig` reaction's default/'earth' loot branch (`runReactions` in `HubWorld.tsx` — a single shared dispatcher switch, so this is a drop-in addition alongside `case 'dig':`).
- Unlike `dig`, `forage` has **no tool/night/weather gating** — it's meant to be a low-friction, always-available action attachable to *ordinary* decor (trees, bushes, flowers), not a scarce dig-spot.
- Rolls on tap (once per real day per spot, via new `forages.ts`, cloned from `digs.ts`): 45% → 1 `wild-berries` (new material item), 35% → crystals (5–15), 20% → a rare `four-leaf-clover` collectible.
- Unlike a **secret** (§7, invisible/undiscoverable), a forage spot overlays an **existing** `exteriorDecor` tile — no owned decor, no new art needed, stays visibly a normal bush/tree/flower.
- Demo content: 4 forage spots in Ravenwatch, placed on already-existing bush/tree/flower decor tiles.
- Documented in `docs/hubworld.md` (§7 reaction table + new "Authoring checklist: new forage spot").

This is the last of the 5 sub-issues split from #1870 — once this merges, I'll close out the parent issue.

## Test plan
- [x] `npm run build` — clean TypeScript build
- [x] `npm run test` — 366/366 tests pass (added `forages.test.ts`, mirroring `digs.test.ts`)
- [ ] Manual in-game check (deferred — logic/data change verified via build/tests per `AGENTS.md` guidance; not a visual bug)


---
_Generated by [Claude Code](https://claude.ai/code/session_01ECAnvLwwDB5WQRZrGM5R2Y)_