### PR TITLE
Hub World: disliked gifts cost friendship, plus max-friendship and hate quests

### DIFF
--- a/docs/hubworld.md
+++ b/docs/hubworld.md
@@ -16,7 +16,7 @@
 | `web/src/data/hub/questDefs.ts` | Parses `questDefs.json`; exports quest definitions and dialogue | `HUB_QUEST_DEFS`, `INN_RUMOURS`, `FRIENDSHIP_DIALOGUE` |
 | `web/src/game/hub/quests.ts` | Quest progress/status persistence (localStorage) | `getQuestState`, `setQuestStatus`, `incrementQuestProgress`, `getQuestProgress`, `resetQuest` |
 | `web/src/game/hub/pickups.ts` | Pickup state persistence (localStorage) | `getPickedUpIds`, `markPickedUp`, `isPickedUp`, `unmarkPickedUp` |
-| `web/src/game/hub/friendship.ts` | NPC friendship XP/level persistence (localStorage) | `getFriendshipLevel`, `addFriendshipXp`, `getFriendshipData` |
+| `web/src/game/hub/friendship.ts` | NPC friendship XP/level persistence (localStorage) — signed ladder, see §7f | `getFriendshipLevel`, `addFriendshipXp`, `getFriendshipData`, `MAX_FRIENDSHIP_LEVEL` |
 | `web/src/game/hub/reputation.ts` | Per-town reputation + per-building upgrade levels (localStorage) — see §10 | `getTownReputation`, `getUpgradeLevel`, `nextUpgrade`, `purchaseUpgrade`, `getUnlockedServices`, `hasTownService` |
 | `web/src/data/hub/buildingUpgrades.json` / `.ts` | Shared upgrade tracks keyed by building *kind* (costs, benefits, services, decor) — see §10 | `getUpgradeTrack`, `getReputationTier`, `REPUTATION_TIERS` |
 | `web/src/game/hub/relationships.ts` | NPC relationship-track (ally/rival/romance) persistence (localStorage) — see §7c | `getRelationship`, `getRelationshipTrack`, `getRelationshipLevel`, `addRelationshipPoints`, `grantRelationshipWithRivalry`, `relationshipProgress` |
@@ -719,6 +719,79 @@ import). An ungated bounty (no `prerequisite`) is always eligible, as before.
 5. Verify by reading the flow: raise the NPC's track/level until the bounty
    appears in the daily pool, confirm turn-in grants the reward and (for an
    `ally`/`romance` grant) still correctly feeds any configured rivalry.
+
+---
+
+## §7f — Disliked Gifts, Negative Friendship & Friendship-Extreme Quests
+
+Friendship (`web/src/game/hub/friendship.ts`) is signed — an NPC's standing
+can go negative ("hated"), not just sit at zero. This backs three related
+features: gifts an NPC dislikes cost friendship, quests that only open at max
+friendship, and quests that only open once an NPC hates the player.
+
+### Signed friendship ladder
+
+`XP_THRESHOLDS = [0, 10, 25, 50, 100]` is now mirrored below zero.
+`addFriendshipXp(npcId, xp)` recomputes the level from the running xp total
+every call (not an increment-only counter), so a negative delta correctly
+lowers the level, including past zero into negative territory. `getFriendshipLevel`
+is unchanged in shape — it just now returns something in roughly `[-5, 5]`
+instead of always `[0, 5]`. `MAX_FRIENDSHIP_LEVEL` (`= 5`) is exported for
+gating "as high as it goes" content.
+
+### Gift tiers (extends §7d)
+
+`HubNpc.dislikedGiftItemIds?: string[]` — hub-item ids (must be `category:
+'material'` to ever appear in the Give list) this NPC dislikes. `giveGiftToNpc`
+now has three tiers:
+
+| Tier | Condition | Effect |
+|---|---|---|
+| Favorite | `itemId === favoriteGiftItemId` | `+10` friendship, `+8` configured relationship track, "light up" line |
+| Disliked | `itemId` in `dislikedGiftItemIds` | `-8` friendship, **no** relationship change, a rejection line naming the item |
+| Neutral | anything else | `+3` friendship, `+2` ally relationship, an unenthusiastic acceptance line |
+
+The item is consumed in all three tiers — a disliked gift is still handed
+over, the NPC just isn't happy about it.
+
+### `hatred:<npcId>:<level>` prerequisite
+
+Mirrors `friendship:<npcId>:<level>` but checks the negative direction:
+`getFriendshipLevel(npcId) <= -<level>`. Implemented alongside the existing
+`friendship:`/`relationship:` clauses in both `checkPrerequisite`
+(`HubWorld.tsx`, for quests) and `checkBountyPrerequisite` (`bounties.ts`, for
+bounties). "Max friendship" gating needs no new syntax — use the existing
+`friendship:<npcId>:<level>` form with `<level>` set to `MAX_FRIENDSHIP_LEVEL`.
+
+### Hub-item quest rewards (`HubQuestReward.hubItem`)
+
+```ts
+export interface HubQuestReward {
+  // …
+  /** Hub-item id (hubItems.json) + count granted on quest completion. */
+  hubItem?: { itemId: string; count?: number }
+}
+```
+
+Applied in `grantQuestReward` via `addHubItem`, mirroring the `giveItem`
+reaction's `hubItem` field (§7) and `BountyReward`'s fields (§7e). Live
+example: Ravenwatch's `merchants-contempt` quest (prerequisite
+`hatred:merchant:1`) rewards a `mouldy-slipper` — see below.
+
+### Authoring checklist: friendship-extreme quest with a joke-item reward
+
+1. Gate the quest with `prerequisite: "friendship:<npc>:5"` (max) or
+   `"hatred:<npc>:<level>"` (hated), same syntax as any other quest
+   prerequisite (§14).
+2. For a hate-quest reward, prefer a flavorful junk item over crystals —
+   grant it via `reward.hubItem: { itemId, count? }`.
+3. **Give that item a real trade chain** (§16) rather than a dead end: author
+   a `tradeHubItem` buyer for it on some other NPC (a new one-node
+   `dialogueTree` is enough if that NPC doesn't have one yet). Live example:
+   Ravenwatch's `james-junk-trade` tree buys `mouldy-slipper` for 20💎.
+4. Run `npm run test` and `npm run build`.
+5. Verify by reading the flow: the quest only offers once the prerequisite is
+   met, turn-in grants the item, and the trade-chain buyer accepts it.
 
 ---
 
@@ -1578,7 +1651,8 @@ Harvest only** · Sailor Bess (Saltmere) ← 2 smoked herring → 60💎
 **during Midwinter only** (every festival now has a trade) · Net-Maker
 Quill (Saltmere) ← 3 feathers → feather pillow · The Prisoner
 (Ironhold dungeon) ← feather pillow → 55💎 + friendship · Grunda the
-Soaker (Hollowmere) ← music box → 170💎.
+Soaker (Hollowmere) ← music box → 170💎 · James (Ravenwatch) ← mouldy
+slipper → 20💎 (the reward from the `merchants-contempt` hate-quest, §7f).
 
 Reputation-gated premium stock: gilded compass (Ravenwatch Guild Hall,
 120💎) and music box (capital Grand Market Hall, 130💎), both

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -86,6 +86,12 @@ function checkPrerequisite(prereq: string, town?: string): boolean {
       const parts = part.split(':')
       return getFriendshipLevel(parts[1]) >= parseInt(parts[2] ?? '1')
     }
+    if (part.startsWith('hatred:')) {
+      // hatred:<npcId>:<level> — friendship at or below the negated level
+      // (e.g. hatred:merchant:2 requires friendship level <= -2).
+      const parts = part.split(':')
+      return getFriendshipLevel(parts[1]) <= -parseInt(parts[2] ?? '1')
+    }
     if (part.startsWith('relationship:')) {
       // relationship:<npcId>:<track>:<level>
       const [, npcId, track, lvl] = part.split(':')
@@ -767,6 +773,10 @@ function formatQuestReward(reward: HubQuestDef['reward']): string {
       parts.push(`+${grant.points} ${grant.track} with ${getNpcDisplayName(npcId)}`)
     }
   }
+  if (reward.hubItem) {
+    const catalog = getHubItemCatalogEntry(reward.hubItem.itemId)
+    parts.push(`${catalog?.icon ?? '📦'} ${catalog?.name ?? reward.hubItem.itemId}`)
+  }
   return parts.length > 0 ? `You received: ${parts.join('  ·  ')}` : ''
 }
 
@@ -809,6 +819,9 @@ function grantQuestReward(quest: HubQuestDef, townNpcs: HubNpc[]): void {
   }
   if (reward.accessory) {
     grantAccessory(reward.accessory)
+  }
+  if (reward.hubItem) {
+    addHubItem(reward.hubItem.itemId, reward.hubItem.count ?? 1)
   }
 }
 
@@ -1012,6 +1025,7 @@ function hasOfferableQuest(giverId: string): boolean {
       innRumours?: Array<{ id: string; text: string }>
       dialogueTree?: string
       favoriteGiftItemId?: string; favoriteGiftTrack?: string
+      dislikedGiftItemIds?: string[]
     } | undefined =
       namedNpc ??
       locationData.HUB_ANIMALS.find(a => a.id === npcId)
@@ -1242,17 +1256,33 @@ function hasOfferableQuest(giverId: string): boolean {
 
   // Gifting a held material to an NPC — the generic counterpart to the
   // curated `tradeHubItem` dialogue-tree effect (docs/hubworld.md §16), but
-  // available on every named NPC with zero authoring required. A favorite
-  // gift (optional per-NPC `favoriteGiftItemId`) grants a bigger bonus on its
-  // configured track (default 'ally').
+  // available on every named NPC with zero authoring required. Three tiers:
+  // a favorite gift (`favoriteGiftItemId`) grants a bigger bonus on its
+  // configured track (default 'ally'); a disliked gift (`dislikedGiftItemIds`)
+  // costs friendship instead of gaining it; anything else is accepted but
+  // unenthusiastically (small bonus, no fanfare).
   const giveGiftToNpc = useCallback((
     npcId: string,
     speakerName: string,
-    npcDef: { favoriteGiftItemId?: string; favoriteGiftTrack?: string } | undefined,
+    npcDef: { favoriteGiftItemId?: string; favoriteGiftTrack?: string; dislikedGiftItemIds?: string[] } | undefined,
     itemId: string,
   ) => {
     if (!removeHubItem(itemId, 1)) { setDialogueEvent(null); return }
     const isFavorite = !!npcDef?.favoriteGiftItemId && npcDef.favoriteGiftItemId === itemId
+    const isDisliked = !isFavorite && !!npcDef?.dislikedGiftItemIds?.includes(itemId)
+    const who = speakerName || 'They'
+
+    if (isDisliked) {
+      const itemName = getHubItemCatalogEntry(itemId)?.name ?? 'gift'
+      addFriendshipXp(npcId, -8)
+      refreshState()
+      setDialogueEvent({
+        speakerName,
+        text: `${who} wrinkles their nose at the ${itemName}. "I really didn't want this."`,
+      })
+      return
+    }
+
     const track: RelationshipTrack =
       isFavorite && npcDef?.favoriteGiftTrack && (RELATIONSHIP_TRACKS as string[]).includes(npcDef.favoriteGiftTrack)
         ? (npcDef.favoriteGiftTrack as RelationshipTrack)
@@ -1263,8 +1293,8 @@ function hasOfferableQuest(giverId: string): boolean {
     setDialogueEvent({
       speakerName,
       text: isFavorite
-        ? `${speakerName || 'They'} light up. "This is exactly what I wanted — thank you!"`
-        : `${speakerName || 'They'} accept the gift graciously.`,
+        ? `${who} light up. "This is exactly what I wanted — thank you!"`
+        : `${who} accept the gift, though it doesn't seem to mean much to them.`,
     })
   }, [refreshState])
 

--- a/web/src/data/hub/config.ts
+++ b/web/src/data/hub/config.ts
@@ -201,6 +201,8 @@ export interface RawNpc {
   favoriteGiftItemId?: string
   /** Relationship track the favorite-gift bonus applies to. Defaults to 'ally' if favoriteGiftItemId is set. */
   favoriteGiftTrack?: string
+  /** Hub-item ids (hubItems.json) this NPC dislikes being gifted — costs friendship instead of gaining it. */
+  dislikedGiftItemIds?: string[]
 
   /** Ids of other same-town NPCs this NPC dislikes — befriending one raises this NPC's own 'rival' track. */
   dislikes?: string[]

--- a/web/src/data/hub/gearford/config.json
+++ b/web/src/data/hub/gearford/config.json
@@ -1863,7 +1863,8 @@
         "ty": 2
       },
       "favoriteGiftItemId": "pressed-flower",
-      "favoriteGiftTrack": "ally"
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": ["smoked-herring"]
     },
     {
       "id": "gearwright-orin",

--- a/web/src/data/hub/loader.ts
+++ b/web/src/data/hub/loader.ts
@@ -171,6 +171,8 @@ export interface HubNpc {
   favoriteGiftItemId?: string
   /** Relationship track ('ally' | 'rival' | 'romance') the favorite-gift bonus applies to. Defaults to 'ally'. */
   favoriteGiftTrack?: string
+  /** Hub-item ids (hubItems.json) this NPC dislikes being gifted — costs friendship instead of gaining it. */
+  dislikedGiftItemIds?: string[]
   /** Ids of other same-town NPCs this NPC dislikes — befriending one raises this NPC's own 'rival' track. */
   dislikes?: string[]
 }

--- a/web/src/data/hub/questDefs.ts
+++ b/web/src/data/hub/questDefs.ts
@@ -29,6 +29,8 @@ export interface HubQuestReward {
   unlock?: string
   /** Pet accessory id (from petAccessories.ts) granted on quest completion. */
   accessory?: string
+  /** Hub-item id (hubItems.json) + count granted on quest completion. */
+  hubItem?: { itemId: string; count?: number }
 }
 
 /** npcId -> track -> levelString -> line shown when that track is active. */

--- a/web/src/data/hub/ravenwatch/config.json
+++ b/web/src/data/hub/ravenwatch/config.json
@@ -9233,7 +9233,8 @@
       "ty": 22,
       "dialogue": [
         "Hello!"
-      ]
+      ],
+      "dialogueTree": "james-junk-trade"
     },
     {
       "id": "npc_1781726431819",

--- a/web/src/data/hub/ravenwatch/questDefs.json
+++ b/web/src/data/hub/ravenwatch/questDefs.json
@@ -3798,6 +3798,41 @@
         }
       ],
       "reward": {}
+    },
+    {
+      "id": "elders-blessing",
+      "title": "A Lifetime's Trust",
+      "type": "fetch",
+      "giverNpcId": "elder",
+      "receiverNpcId": "elder",
+      "prerequisite": "friendship:elder:5",
+      "offerDialogue": "After everything we have shared, there is something I have wanted to ask — will you hear an old man's request?",
+      "activeDialogue": "Take your time. Whatever you decide, you have already given me more than you know.",
+      "completeDialogue": "You have been the truest friend this town has known. Whatever comes next, know you carry my blessing with you.",
+      "steps": [
+        { "key": "report", "type": "report", "targetNpcId": "elder", "required": 1 }
+      ],
+      "reward": {
+        "crystals": 100,
+        "friendship": { "elder": 10 }
+      }
+    },
+    {
+      "id": "merchants-contempt",
+      "title": "A Reluctant Bargain",
+      "type": "fetch",
+      "giverNpcId": "merchant",
+      "receiverNpcId": "merchant",
+      "prerequisite": "hatred:merchant:1",
+      "offerDialogue": "You again. Fine — if you're so desperate to be useful, prove it. Report back once you've groveled enough.",
+      "activeDialogue": "Well? I don't have all day.",
+      "completeDialogue": "There. Take this and get out of my sight — and don't expect a 'thank you'.",
+      "steps": [
+        { "key": "report", "type": "report", "targetNpcId": "merchant", "required": 1 }
+      ],
+      "reward": {
+        "hubItem": { "itemId": "mouldy-slipper", "count": 1 }
+      }
     }
   ],
   "pickupItems": [
@@ -5604,7 +5639,8 @@
   "friendshipDialogue": {
     "elder": {
       "2": "Ah, I remember you. You found my pendants. Come and sit a moment.",
-      "4": "You have become part of this town's story now, traveller. Few earn that."
+      "4": "You have become part of this town's story now, traveller. Few earn that.",
+      "5": "There is nothing left I could teach you that friendship hasn't already."
     },
     "innkeeper-rosie": {
       "2": "Always good to see a friendly face! About that favour I mentioned…",
@@ -6361,6 +6397,48 @@
                   "type": "end"
                 }
               ]
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "james-junk-trade",
+      "npcId": "npc_1781629843466",
+      "start": "greet",
+      "nodes": {
+        "greet": {
+          "text": "Hello! ...wait, do I smell something dreadful? Please tell me you're not carrying a mouldy slipper.",
+          "choices": [
+            {
+              "label": "Actually, I do have one.",
+              "next": "trade"
+            },
+            {
+              "label": "Just saying hi.",
+              "effects": [{ "type": "end" }]
+            }
+          ]
+        },
+        "trade": {
+          "text": "I collect the strangest things, truth be told. I'll take it off your hands.",
+          "choices": [
+            {
+              "label": "Hand it over. (1 mouldy slipper)",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "mouldy-slipper",
+                  "wantCount": 1,
+                  "giveCrystals": 20,
+                  "missingText": "You don't have one of those. Small mercies, I suppose.",
+                  "successText": "James pinches it between two fingers, delighted. \"Magnificent. Truly repulsive.\""
+                }
+              ]
+            },
+            {
+              "label": "Never mind.",
+              "effects": [{ "type": "end" }]
             }
           ]
         }

--- a/web/src/data/hub/saltmereport/config.json
+++ b/web/src/data/hub/saltmereport/config.json
@@ -1629,7 +1629,8 @@
       ],
       "questGive": "saltmere-rum-run",
       "favoriteGiftItemId": "tin-whistle",
-      "favoriteGiftTrack": "ally"
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": ["poetry-book"]
     },
     {
       "id": "old-salt",

--- a/web/src/data/hub/thornwoodcamp/config.json
+++ b/web/src/data/hub/thornwoodcamp/config.json
@@ -509,7 +509,8 @@
         "thornwood-river-relay"
       ],
       "favoriteGiftItemId": "river-glass",
-      "favoriteGiftTrack": "ally"
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": ["chicken-feed"]
     }
   ],
   "animals": [

--- a/web/src/data/hubItems.json
+++ b/web/src/data/hubItems.json
@@ -297,5 +297,12 @@
     "icon": "🫐",
     "desc": "A handful of ripe berries, foraged straight from the bush.",
     "category": "material"
+  },
+  {
+    "id": "mouldy-slipper",
+    "name": "Mouldy Slipper",
+    "icon": "🥿",
+    "desc": "One slipper, thoroughly ruined. Its owner is not looking for it back.",
+    "category": "material"
   }
 ]

--- a/web/src/game/hub/bounties.ts
+++ b/web/src/game/hub/bounties.ts
@@ -154,6 +154,10 @@ function checkBountyPrerequisite(prereq: string): boolean {
       const parts = part.split(':')
       return getFriendshipLevel(parts[1]) >= parseInt(parts[2] ?? '1')
     }
+    if (part.startsWith('hatred:')) {
+      const parts = part.split(':')
+      return getFriendshipLevel(parts[1]) <= -parseInt(parts[2] ?? '1')
+    }
     if (part.startsWith('relationship:')) {
       const [, npcId, track, lvl] = part.split(':')
       const rel = getRelationship(npcId)

--- a/web/src/game/hub/friendship.test.ts
+++ b/web/src/game/hub/friendship.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { addFriendshipXp, getFriendshipLevel, getFriendshipData, MAX_FRIENDSHIP_LEVEL } from './friendship'
+
+function installLocalStorageStub(): void {
+  const store = new Map<string, string>()
+  vi.stubGlobal('localStorage', {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => { store.set(k, v) },
+    removeItem: (k: string) => { store.delete(k) },
+    clear: () => { store.clear() },
+  })
+}
+
+describe('friendship', () => {
+  beforeEach(() => {
+    installLocalStorageStub()
+  })
+
+  it('starts at level 0 with no data', () => {
+    expect(getFriendshipLevel('scholar')).toBe(0)
+  })
+
+  it('gaining xp raises the level through the ladder', () => {
+    expect(addFriendshipXp('scholar', 5)).toBe(1)   // 5 >= 0
+    expect(addFriendshipXp('scholar', 5)).toBe(2)   // 10 >= 10
+    expect(addFriendshipXp('scholar', 15)).toBe(3)  // 25 >= 25
+  })
+
+  it('losing xp lowers the level, including back through zero into negative', () => {
+    addFriendshipXp('scholar', 12) // xp 12 -> level 2
+    expect(getFriendshipLevel('scholar')).toBe(2)
+    expect(addFriendshipXp('scholar', -20)).toBe(-1) // xp -8 -> level -1
+    expect(addFriendshipXp('scholar', -5)).toBe(-2)  // xp -13 -> level -2
+  })
+
+  it('reaches MAX_FRIENDSHIP_LEVEL at the top of the ladder and no higher', () => {
+    expect(addFriendshipXp('scholar', 1000)).toBe(MAX_FRIENDSHIP_LEVEL)
+    expect(addFriendshipXp('scholar', 1000)).toBe(MAX_FRIENDSHIP_LEVEL)
+  })
+
+  it('is symmetric in the negative direction', () => {
+    expect(addFriendshipXp('scholar', -1000)).toBe(-MAX_FRIENDSHIP_LEVEL)
+  })
+
+  it('tracks each NPC independently and persists across reads', () => {
+    addFriendshipXp('scholar', 12)
+    addFriendshipXp('merchant', -12)
+    const data = getFriendshipData()
+    expect(data.scholar.level).toBe(2)
+    expect(data.merchant.level).toBe(-2)
+  })
+
+  it('fails open (level 0) when localStorage throws', () => {
+    vi.stubGlobal('localStorage', {
+      getItem: () => { throw new Error('blocked') },
+      setItem: () => { throw new Error('blocked') },
+    })
+    expect(getFriendshipLevel('scholar')).toBe(0)
+    expect(() => addFriendshipXp('scholar', 5)).not.toThrow()
+  })
+})

--- a/web/src/game/hub/friendship.ts
+++ b/web/src/game/hub/friendship.ts
@@ -1,6 +1,12 @@
+import { logError } from '../../logger'
+
 const KEY = 'jarv_hub_friendship'
 
-const XP_THRESHOLDS = [0, 10, 25, 50, 100]  // xp needed to reach levels 1-4
+// xp needed to reach levels 1-4 (mirrored below zero for negative/"hated" levels).
+const XP_THRESHOLDS = [0, 10, 25, 50, 100]
+
+/** Max level reachable in either direction (length of the threshold ladder). */
+export const MAX_FRIENDSHIP_LEVEL = XP_THRESHOLDS.length
 
 export interface FriendshipEntry {
   level: number
@@ -19,7 +25,9 @@ function load(): Record<string, FriendshipEntry> {
 function save(data: Record<string, FriendshipEntry>): void {
   try {
     localStorage.setItem(KEY, JSON.stringify(data))
-  } catch { /* ignore */ }
+  } catch (e) {
+    logError('friendship save failed', { error: String(e) })
+  }
 }
 
 export function getFriendshipData(): Record<string, FriendshipEntry> {
@@ -30,14 +38,28 @@ export function getFriendshipLevel(npcId: string): number {
   return load()[npcId]?.level ?? 0
 }
 
-/** Add XP to an NPC's friendship. Returns the new level. */
+/** Recompute a (possibly negative) level from a total xp value. */
+function levelForXp(xp: number): number {
+  const sign = xp < 0 ? -1 : 1
+  const abs = Math.abs(xp)
+  let level = 0
+  while (level < XP_THRESHOLDS.length && abs >= XP_THRESHOLDS[level]) {
+    level += 1
+  }
+  return sign * level
+}
+
+/**
+ * Add (or subtract) XP to an NPC's friendship and recompute its level from
+ * scratch — so a negative delta can lower the level (or push it negative,
+ * representing a "hated" standing), not just fail to raise it. Returns the
+ * new level.
+ */
 export function addFriendshipXp(npcId: string, xp: number): number {
   const data = load()
   const entry = data[npcId] ?? { level: 0, xp: 0 }
   entry.xp += xp
-  while (entry.level < XP_THRESHOLDS.length && entry.xp >= XP_THRESHOLDS[entry.level]) {
-    entry.level += 1
-  }
+  entry.level = levelForXp(entry.xp)
   data[npcId] = entry
   save(data)
   return entry.level


### PR DESCRIPTION
Fixes #1881.

## Summary
- **Signed friendship ladder** (`friendship.ts`): `addFriendshipXp` now recomputes the level from the running xp total every call (instead of an increment-only counter), so a negative delta correctly lowers the level — including past zero into "hated" territory. Added `MAX_FRIENDSHIP_LEVEL`. Behavior-preserving for every existing caller (all previously only added positive xp).
- **Gift-giving is now 3 tiers** (`giveGiftToNpc`, `HubWorld.tsx`):
  - **Favorite** (unchanged): `+10` friendship, `+8` relationship, "light up" line.
  - **Disliked** (new — `HubNpc.dislikedGiftItemIds`): `-8` friendship, no relationship change, a rejection line naming the item.
  - **Neutral** (existing, reworded): `+3` friendship, `+2` relationship — "accept the gift graciously" read too warm for "not grateful," reworded to something genuinely unenthusiastic.
- **New `hatred:<npcId>:<level>` prerequisite** (`checkPrerequisite` in `HubWorld.tsx`, `checkBountyPrerequisite` in `bounties.ts`) checks negative friendship. "Max friendship" gating needs no new syntax — reuses the existing `friendship:<npcId>:<level>` form with `MAX_FRIENDSHIP_LEVEL`.
- **Quest rewards can grant hub-items directly** (`HubQuestReward.hubItem`), mirroring the same pattern already used for the `giveItem` interactable reaction and `BountyReward`.
- **Demo content**:
  - `dislikedGiftItemIds` added to the 3 existing favorite-gift NPCs (Gearford's Apprentice Tila, Thornwood Camp's Trader Pell, Saltmere Port's Dockhand Tam).
  - A max-friendship quest from Ravenwatch's Elder (`elders-blessing`, gated `friendship:elder:5`).
  - A hate-gated quest from the Merchant (`merchants-contempt`, gated `hatred:merchant:1`) rewarding a `mouldy-slipper` — which has a real trade chain (a new `james-junk-trade` dialogue tree buys it for crystals) rather than being a dead end.
- Documented in `docs/hubworld.md` (new §7f, plus §1/§16 updates).

## Test plan
- [x] `npm run build` — clean TypeScript build
- [x] `npm run test` — 373/373 tests pass (added `friendship.test.ts` covering the signed ladder: gaining, losing, crossing zero, reaching `MAX_FRIENDSHIP_LEVEL` in both directions, persistence, and fail-open behavior)
- [ ] Manual in-game check (deferred — logic/data change verified via build/tests per `AGENTS.md` guidance; not a visual bug)


---
_Generated by [Claude Code](https://claude.ai/code/session_01ECAnvLwwDB5WQRZrGM5R2Y)_