### PR TITLE
Curate relationship content for Millhaven & Gravemoor

### DIFF
--- a/docs/hubworld.md
+++ b/docs/hubworld.md
@@ -776,7 +776,11 @@ export interface HubQuestReward {
 Applied in `grantQuestReward` via `addHubItem`, mirroring the `giveItem`
 reaction's `hubItem` field (§7) and `BountyReward`'s fields (§7e). Live
 example: Ravenwatch's `merchants-contempt` quest (prerequisite
-`hatred:merchant:1`) rewards a `mouldy-slipper` — see below.
+`hatred:merchant:1`) rewards a `mouldy-slipper` — see below. Reused (not
+re-minted) for Millhaven's `regattas-scorn` (Regatta Master Coll) and
+Gravemoor's `pedlars-grudge` (The Spectral Pedlar) hate-quests — all three
+funnel to the same buyer, James in Ravenwatch (`james-junk-trade`), per §16's
+"items are reused across multiple grant points" philosophy.
 
 ### Authoring checklist: friendship-extreme quest with a joke-item reward
 

--- a/web/src/data/hub/gravemoor/config.json
+++ b/web/src/data/hub/gravemoor/config.json
@@ -1134,6 +1134,9 @@
         "I was mayor when I died and nobody's run against me since. Democracy at its finest.",
         "We're dead, not rude. Wipe your feet and you're welcome anywhere in town."
       ],
+      "favoriteGiftItemId": "grave-moss",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": ["honey-cake"],
       "schedule": [
         {
           "startHour": 7,
@@ -1169,7 +1172,8 @@
         "Money means little to the dead, but haggling? Haggling is eternal.",
         "The blight took the town, but it couldn't take the market spirit. Literally, in my case."
       ],
-      "building": "undertaker"
+      "building": "undertaker",
+      "dislikes": ["brother-mortis"]
     },
     {
       "id": "grave-keeper-finch",
@@ -2561,6 +2565,33 @@
     }
   },
   "interactables": [
+    {
+      "id": "gravemoor-forage-tree-1",
+      "tx": 0,
+      "ty": 3,
+      "reactions": [
+        { "type": "dialogue", "text": "A gnarled dead tree — something might be tucked in its roots." },
+        { "type": "forage" }
+      ]
+    },
+    {
+      "id": "gravemoor-forage-tree-2",
+      "tx": 28,
+      "ty": 15,
+      "reactions": [
+        { "type": "dialogue", "text": "The whispering wood grows thick here. Worth a closer look." },
+        { "type": "forage" }
+      ]
+    },
+    {
+      "id": "gravemoor-forage-tree-3",
+      "tx": 42,
+      "ty": 11,
+      "reactions": [
+        { "type": "dialogue", "text": "A dead tree at the woodland's edge, roots half-exposed." },
+        { "type": "forage" }
+      ]
+    },
     {
       "id": "gravemoor-hollow",
       "tx": 17,

--- a/web/src/data/hub/gravemoor/questDefs.json
+++ b/web/src/data/hub/gravemoor/questDefs.json
@@ -550,6 +550,41 @@
           "desc": "A small token from Minister Fallow. The Gravemoor bell tolls no more — the town sleeps easier, and so do you."
         }
       }
+    },
+    {
+      "id": "widows-final-peace",
+      "title": "A Long-Awaited Peace",
+      "type": "fetch",
+      "giverNpcId": "weeping-widow",
+      "receiverNpcId": "weeping-widow",
+      "prerequisite": "friendship:weeping-widow:5",
+      "offerDialogue": "You have listened to an old ghost's grief more than anyone in two centuries. I think... I think I am ready to stop weeping. Will you sit with me a moment longer, one last time?",
+      "activeDialogue": "Take your time. I have waited this long; I can wait a little more.",
+      "completeDialogue": "There. The ache is quieter now — quiet enough to rest. Thank you, dear traveller. You have given a lonely spirit something she thought long lost: peace.",
+      "steps": [
+        { "key": "report", "type": "report", "targetNpcId": "weeping-widow", "required": 1 }
+      ],
+      "reward": {
+        "crystals": 90,
+        "friendship": { "weeping-widow": 10 }
+      }
+    },
+    {
+      "id": "pedlars-grudge",
+      "title": "Bad for Business",
+      "type": "fetch",
+      "giverNpcId": "spectral-pedlar",
+      "receiverNpcId": "spectral-pedlar",
+      "prerequisite": "hatred:spectral-pedlar:1",
+      "offerDialogue": "Oh, it's you. Scared off three customers this week just by existing near my stall. Do something useful for once and report back when you have.",
+      "activeDialogue": "Well? Some of us have wares to move.",
+      "completeDialogue": "Took you long enough. Here — take this and get out of my sightline, you're bad for business.",
+      "steps": [
+        { "key": "report", "type": "report", "targetNpcId": "spectral-pedlar", "required": 1 }
+      ],
+      "reward": {
+        "hubItem": { "itemId": "mouldy-slipper", "count": 1 }
+      }
     }
   ],
   "pickupItems": [
@@ -707,5 +742,12 @@
       "questId": "gravemoor-hollow-tolling-3"
     }
   ],
-  "blockedPaths": []
+  "blockedPaths": [],
+  "relationshipDialogue": {
+    "restless-merchant-mora": {
+      "rival": {
+        "1": "Brother Mortis and his chapel bell, tolling right when I've a customer haggling. Coincidence? I think not. Thick as thieves, the two of you."
+      }
+    }
+  }
 }

--- a/web/src/data/hub/millhaven/config.json
+++ b/web/src/data/hub/millhaven/config.json
@@ -1736,6 +1736,7 @@
         "millhaven-festival-prep",
         "millhaven-market-restock"
       ],
+      "dislikes": ["dockhand-bram"],
       "schedule": [
         {
           "startHour": 0,
@@ -1779,6 +1780,9 @@
       ],
       "questGive": "millhaven-fresh-bread",
       "questReceive": "millhaven-fresh-bread",
+      "favoriteGiftItemId": "honey",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": ["fish-bait"],
       "schedule": [
         {
           "startHour": 0,
@@ -3022,6 +3026,54 @@
     }
   ],
   "interactables": [
+    {
+      "id": "millhaven-forage-bush-1",
+      "tx": 4,
+      "ty": 34,
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "tileId": "lightBush"
+        }
+      ],
+      "reactions": [
+        { "type": "dialogue", "text": "A tangled bush growing wild by the fisher-cottage field." },
+        { "type": "forage" }
+      ]
+    },
+    {
+      "id": "millhaven-forage-bush-2",
+      "tx": 24,
+      "ty": 34,
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "tileId": "darkBush"
+        }
+      ],
+      "reactions": [
+        { "type": "dialogue", "text": "A shaded bush behind the bakery, worth a closer look." },
+        { "type": "forage" }
+      ]
+    },
+    {
+      "id": "millhaven-forage-flower-1",
+      "tx": 10,
+      "ty": 34,
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "tileId": "yellowFlower"
+        }
+      ],
+      "reactions": [
+        { "type": "dialogue", "text": "A patch of wildflowers growing at the field's edge." },
+        { "type": "forage" }
+      ]
+    },
     {
       "id": "millhaven-bucket-stall",
       "tx": 39,

--- a/web/src/data/hub/millhaven/questDefs.json
+++ b/web/src/data/hub/millhaven/questDefs.json
@@ -601,6 +601,41 @@
           "market-trader": 15
         }
       }
+    },
+    {
+      "id": "tamsins-quiet-thanks",
+      "title": "A Quiet Thanks",
+      "type": "fetch",
+      "giverNpcId": "widow-tamsin",
+      "receiverNpcId": "widow-tamsin",
+      "prerequisite": "friendship:widow-tamsin:5",
+      "offerDialogue": "You've sat with an old widow more than anyone had to. I've something small for you, if you'll let me give it.",
+      "activeDialogue": "No rush. I'll still be here, mending nets I can't quite finish.",
+      "completeDialogue": "There. It isn't much, but it's given with a full heart — the first I've had in some time. Thank you, truly.",
+      "steps": [
+        { "key": "report", "type": "report", "targetNpcId": "widow-tamsin", "required": 1 }
+      ],
+      "reward": {
+        "crystals": 80,
+        "friendship": { "widow-tamsin": 10 }
+      }
+    },
+    {
+      "id": "regattas-scorn",
+      "title": "Off the Course",
+      "type": "fetch",
+      "giverNpcId": "regatta-master",
+      "receiverNpcId": "regatta-master",
+      "prerequisite": "hatred:regatta-master:1",
+      "offerDialogue": "You? Wandering my course, gawking at my buoys? Fine — make yourself useful for once and report back when you have.",
+      "activeDialogue": "Well? The regatta won't organize itself.",
+      "completeDialogue": "Hmph. Didn't think you'd bother. Take this and stay off my dock.",
+      "steps": [
+        { "key": "report", "type": "report", "targetNpcId": "regatta-master", "required": 1 }
+      ],
+      "reward": {
+        "hubItem": { "itemId": "mouldy-slipper", "count": 1 }
+      }
     }
   ],
   "pickupItems": [
@@ -1082,5 +1117,12 @@
         }
       }
     }
-  ]
+  ],
+  "relationshipDialogue": {
+    "market-trader": {
+      "rival": {
+        "1": "Setting up shop is hard enough without Dockhand Bram tracking fish guts past my stall every morning. You two are thick as thieves lately, aren't you?"
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Follow-up to #1870/#1881: the favorite/disliked gift, NPC rivalry, forage, and friendship-gated quest mechanisms are fully data-driven, but only 4 of 13 towns had any curated content using them. This extends that curation to **Millhaven** and **Gravemoor**.

### Millhaven
- Gift pair: Baker Pernel (favorite `honey`, disliked `fish-bait`)
- Rivalry: Trader Nessa dislikes Dockhand Bram (`relationshipDialogue` rival-tier line)
- Forage: 3 new bush/flower interactables on previously-undecorated open tiles (Millhaven had no free-standing exterior decor)
- Max-friendship quest: `tamsins-quiet-thanks` (Widow Tamsin, gated `friendship:widow-tamsin:5`)
- Hate quest: `regattas-scorn` (Regatta Master Coll, gated `hatred:regatta-master:1`, rewards `mouldy-slipper`)

### Gravemoor
- Gift pair: Mayor Aldous (favorite `grave-moss`, disliked `honey-cake`)
- Rivalry: Merchant Mora dislikes Brother Mortis (`relationshipDialogue` rival-tier line)
- Forage: 3 new interactables anchored on existing tree-bundle decor coordinates
- Max-friendship quest: `widows-final-peace` (The Weeping Widow, gated `friendship:weeping-widow:5`)
- Hate quest: `pedlars-grudge` (The Spectral Pedlar, gated `hatred:spectral-pedlar:1`, rewards `mouldy-slipper`)

Both towns' hate-quest rewards reuse the existing `mouldy-slipper` trade chain (buyer: James in Ravenwatch, from #1881) rather than minting new items/chains, per the established "items are reused across multiple grant points" network philosophy.

Fixes #1883. Pure data/JSON content — no source code changes.

## Test plan
- [x] `npm run build` passes
- [x] `npm run test` — 373/373 tests pass
- [x] All edited JSON files validated with `python3 -c "import json; json.load(...)"`
- [x] Reasoned through each new quest/gift/rivalry/forage flow by reading the JSON + shared mechanism code end-to-end (logic/data change — per AGENTS.md, browser verification is reserved for visual bugs)


---
_Generated by [Claude Code](https://claude.ai/code/session_01ECAnvLwwDB5WQRZrGM5R2Y)_