### PR TITLE
Curate relationship content for Appleford & Harrowfield

### DIFF
--- a/docs/hubworld.md
+++ b/docs/hubworld.md
@@ -777,9 +777,10 @@ Applied in `grantQuestReward` via `addHubItem`, mirroring the `giveItem`
 reaction's `hubItem` field (§7) and `BountyReward`'s fields (§7e). Live
 example: Ravenwatch's `merchants-contempt` quest (prerequisite
 `hatred:merchant:1`) rewards a `mouldy-slipper` — see below. Reused (not
-re-minted) for Millhaven's `regattas-scorn` (Regatta Master Coll) and
-Gravemoor's `pedlars-grudge` (The Spectral Pedlar) hate-quests — all three
-funnel to the same buyer, James in Ravenwatch (`james-junk-trade`), per §16's
+re-minted) for Millhaven's `regattas-scorn` (Regatta Master Coll),
+Gravemoor's `pedlars-grudge` (The Spectral Pedlar), Appleford's `hobs-grudge`
+(Hob the Picker), and Harrowfield's `rooks-toll` (Miller Rook) hate-quests —
+all funnel to the same buyer, James in Ravenwatch (`james-junk-trade`), per §16's
 "items are reused across multiple grant points" philosophy.
 
 ### Authoring checklist: friendship-extreme quest with a joke-item reward

--- a/web/src/data/hub/appleford/config.json
+++ b/web/src/data/hub/appleford/config.json
@@ -1288,7 +1288,10 @@
       "questReceive": [
         "appleford-honey-harvest",
         "appleford-honey-harvest-2"
-      ]
+      ],
+      "favoriteGiftItemId": "lavender-tonic",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": ["bog-salve"]
     },
     {
       "id": "cooper-wend",
@@ -1303,7 +1306,8 @@
         "Staves, hoops, and patience — that's a barrel. Rush any of the three and you've a puddle."
       ],
       "questGive": "appleford-coopers-order",
-      "questReceive": "appleford-coopers-order"
+      "questReceive": "appleford-coopers-order",
+      "dislikes": ["cider-brewer-tom"]
     },
     {
       "id": "market-trader-posy",
@@ -2098,6 +2102,33 @@
     }
   },
   "interactables": [
+    {
+      "id": "appleford-forage-tree-1",
+      "tx": 28,
+      "ty": 22,
+      "reactions": [
+        { "type": "dialogue", "text": "One of the orchard's older trees — something might be tucked among its roots." },
+        { "type": "forage" }
+      ]
+    },
+    {
+      "id": "appleford-forage-tree-2",
+      "tx": 1,
+      "ty": 26,
+      "reactions": [
+        { "type": "dialogue", "text": "An autumn-gold tree at the orchard's edge, worth a closer look." },
+        { "type": "forage" }
+      ]
+    },
+    {
+      "id": "appleford-forage-flower-1",
+      "tx": 13,
+      "ty": 22,
+      "reactions": [
+        { "type": "dialogue", "text": "A patch of pink wildflowers growing between the rows." },
+        { "type": "forage" }
+      ]
+    },
     {
       "id": "apiary-honey-shelf",
       "tx": 8,

--- a/web/src/data/hub/appleford/questDefs.json
+++ b/web/src/data/hub/appleford/questDefs.json
@@ -486,6 +486,41 @@
           "desc": "A token of thanks from the folk of Appleford whose treasures you returned."
         }
       }
+    },
+    {
+      "id": "bess-orchards-trust",
+      "title": "The Orchard's Trust",
+      "type": "fetch",
+      "giverNpcId": "orchard-keeper-bess",
+      "receiverNpcId": "orchard-keeper-bess",
+      "prerequisite": "friendship:orchard-keeper-bess:5",
+      "offerDialogue": "You've earned more than my thanks, traveller \u2014 you've earned my trust, and I don't give that lightly. Sit with me a while. There's something I want you to have.",
+      "activeDialogue": "No rush. The trees have waited longer than I have.",
+      "completeDialogue": "There. Not every stranger who walks these rows becomes family. You have. Appleford is glad to have you.",
+      "steps": [
+        { "key": "report", "type": "report", "targetNpcId": "orchard-keeper-bess", "required": 1 }
+      ],
+      "reward": {
+        "crystals": 90,
+        "friendship": { "orchard-keeper-bess": 10 }
+      }
+    },
+    {
+      "id": "hobs-grudge",
+      "title": "Bad Blood in the Rows",
+      "type": "fetch",
+      "giverNpcId": "orchard-hand-hob",
+      "receiverNpcId": "orchard-hand-hob",
+      "prerequisite": "hatred:orchard-hand-hob:1",
+      "offerDialogue": "Oh, it's you. Reckon you've cost me more baskets than the crows have. Fine \u2014 make yourself useful for once and report back when you have.",
+      "activeDialogue": "Well? My arms aren't getting any younger waiting on you.",
+      "completeDialogue": "About time. Here \u2014 take this and get out of my rows before you knock something else over.",
+      "steps": [
+        { "key": "report", "type": "report", "targetNpcId": "orchard-hand-hob", "required": 1 }
+      ],
+      "reward": {
+        "hubItem": { "itemId": "mouldy-slipper", "count": 1 }
+      }
     }
   ],
   "pickupItems": [
@@ -717,5 +752,12 @@
       "questId": "appleford-harvest-blessing"
     }
   ],
-  "blockedPaths": []
+  "blockedPaths": [],
+  "relationshipDialogue": {
+    "cooper-wend": {
+      "rival": {
+        "1": "You've been spending an awful lot of time with Tom lately. Careful — cider talk is cheap, but good barrels take real work."
+      }
+    }
+  }
 }

--- a/web/src/data/hub/harrowfield/config.json
+++ b/web/src/data/hub/harrowfield/config.json
@@ -1713,7 +1713,8 @@
       "questReceive": [
         "harrowfield-produce-to-ravenwatch",
         "harrowfield-shear-day"
-      ]
+      ],
+      "dislikes": ["warden-bell"]
     },
     {
       "id": "warden-bell",
@@ -1744,7 +1745,10 @@
       "questGive": "harrowfield-scarecrow-watch",
       "questReceive": [
         "harrowfield-scarecrow-watch"
-      ]
+      ],
+      "favoriteGiftItemId": "music-box",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": ["sturdy-boots"]
     }
   ],
   "interiors": {
@@ -2460,6 +2464,33 @@
     }
   },
   "interactables": [
+    {
+      "id": "harrowfield-forage-flower-1",
+      "tx": 2,
+      "ty": 9,
+      "reactions": [
+        { "type": "dialogue", "text": "A patch of white wildflowers growing by the field's edge." },
+        { "type": "forage" }
+      ]
+    },
+    {
+      "id": "harrowfield-forage-flower-2",
+      "tx": 17,
+      "ty": 13,
+      "reactions": [
+        { "type": "dialogue", "text": "Pink flowers growing wild among the crop rows." },
+        { "type": "forage" }
+      ]
+    },
+    {
+      "id": "harrowfield-forage-flower-3",
+      "tx": 29,
+      "ty": 12,
+      "reactions": [
+        { "type": "dialogue", "text": "A cluster of blue flowers, swaying in the field wind." },
+        { "type": "forage" }
+      ]
+    },
     {
       "id": "harrowfield-rain-barrel",
       "tx": 20,

--- a/web/src/data/hub/harrowfield/questDefs.json
+++ b/web/src/data/hub/harrowfield/questDefs.json
@@ -520,6 +520,41 @@
           "desc": "Proof of an honest produce run from Harrowfield to Ravenwatch. Quill will remember this."
         }
       }
+    },
+    {
+      "id": "bells-quiet-confidence",
+      "title": "A Quiet Confidence",
+      "type": "fetch",
+      "giverNpcId": "warden-bell",
+      "receiverNpcId": "warden-bell",
+      "prerequisite": "friendship:warden-bell:5",
+      "offerDialogue": "You've become someone this chapel trusts, traveller — and trust, once earned, deserves to be honoured. Sit with me a moment. There's something I'd like to share.",
+      "activeDialogue": "Quiet hands, patient heart. I'll be here when you're ready.",
+      "completeDialogue": "There. Not every visitor earns a place in this chapel's quiet keeping. You have. Go well, and go blessed.",
+      "steps": [
+        { "key": "report", "type": "report", "targetNpcId": "warden-bell", "required": 1 }
+      ],
+      "reward": {
+        "crystals": 85,
+        "friendship": { "warden-bell": 10 }
+      }
+    },
+    {
+      "id": "rooks-toll",
+      "title": "Grinding an Axe",
+      "type": "fetch",
+      "giverNpcId": "miller-rook",
+      "receiverNpcId": "miller-rook",
+      "prerequisite": "hatred:miller-rook:1",
+      "offerDialogue": "You again. Every visit of yours costs me flour I can't spare. Fine — earn your keep for once and report back when you have.",
+      "activeDialogue": "Well? The stones don't turn themselves.",
+      "completeDialogue": "Took you long enough. Here — take it and let the mill grind in peace for once.",
+      "steps": [
+        { "key": "report", "type": "report", "targetNpcId": "miller-rook", "required": 1 }
+      ],
+      "reward": {
+        "hubItem": { "itemId": "mouldy-slipper", "count": 1 }
+      }
     }
   ],
   "pickupItems": [
@@ -779,5 +814,12 @@
       "questId": "harrowfield-produce-to-ravenwatch"
     }
   ],
-  "blockedPaths": []
+  "blockedPaths": [],
+  "relationshipDialogue": {
+    "pedlar-quill": {
+      "rival": {
+        "1": "Spending a lot of time up at the chapel these days, aren't you? Quiet hands don't fill a cart, friend. Just something to think about."
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Follow-up to #1870/#1881/#1883: the favorite/disliked gift, NPC rivalry, forage, and friendship-gated quest mechanisms are fully data-driven, but only 6 of 13 towns had any curated content using them. This extends that curation to **Appleford** and **Harrowfield**.

### Appleford
- Gift pair: Beekeeper Mabe (favorite `lavender-tonic`, disliked `bog-salve`)
- Rivalry: Cooper Wend dislikes Cider-Brewer Tom (`relationshipDialogue` rival-tier line), echoing his existing in-fiction joke about Tom sulking
- Forage: 3 new interactables overlaying existing tree/flower decor
- Max-friendship quest: `bess-orchards-trust` (Orchard Keeper Bess, gated `friendship:orchard-keeper-bess:5`)
- Hate quest: `hobs-grudge` (Hob the Picker, gated `hatred:orchard-hand-hob:1`, rewards `mouldy-slipper`)

### Harrowfield
- Gift pair: Little Bram (favorite `music-box`, disliked `sturdy-boots`)
- Rivalry: Pedlar Quill dislikes Sister Bell (`relationshipDialogue` rival-tier line) — commerce vs. quiet devotion
- Forage: 3 new interactables overlaying existing flower decor
- Max-friendship quest: `bells-quiet-confidence` (Sister Bell, gated `friendship:warden-bell:5`)
- Hate quest: `rooks-toll` (Miller Rook, gated `hatred:miller-rook:1`, rewards `mouldy-slipper`)

Both towns' hate-quest rewards reuse the existing `mouldy-slipper` trade chain (buyer: James in Ravenwatch) rather than minting new items/chains, per the established "items are reused across multiple grant points" network philosophy.

Fixes #1885. Pure data/JSON content — no source code changes.

## Test plan
- [x] `npm run build` passes
- [x] `npm run test` — 373/373 tests pass
- [x] All edited JSON files validated with `python3 -c "import json; json.load(...)"`
- [x] Reasoned through each new quest/gift/rivalry/forage flow by reading the JSON + shared mechanism code end-to-end (logic/data change — per AGENTS.md, browser verification is reserved for visual bugs)


---
_Generated by [Claude Code](https://claude.ai/code/session_01ECAnvLwwDB5WQRZrGM5R2Y)_