### PR TITLE
Curate relationship content for Hollowmere & Ironhold Keep

### DIFF
--- a/docs/hubworld.md
+++ b/docs/hubworld.md
@@ -779,8 +779,10 @@ example: Ravenwatch's `merchants-contempt` quest (prerequisite
 `hatred:merchant:1`) rewards a `mouldy-slipper` — see below. Reused (not
 re-minted) for Millhaven's `regattas-scorn` (Regatta Master Coll),
 Gravemoor's `pedlars-grudge` (The Spectral Pedlar), Appleford's `hobs-grudge`
-(Hob the Picker), and Harrowfield's `rooks-toll` (Miller Rook) hate-quests —
-all funnel to the same buyer, James in Ravenwatch (`james-junk-trade`), per §16's
+(Hob the Picker), Harrowfield's `rooks-toll` (Miller Rook), Hollowmere's
+`ogrims-bad-mood` (Ogrim the Bouncer), and Ironhold Keep's `olens-grudge`
+(Gatekeeper Olen) hate-quests — all funnel to the same buyer, James in
+Ravenwatch (`james-junk-trade`), per §16's
 "items are reused across multiple grant points" philosophy.
 
 ### Authoring checklist: friendship-extreme quest with a joke-item reward

--- a/web/src/data/hub/hollowmere/config.json
+++ b/web/src/data/hub/hollowmere/config.json
@@ -1178,7 +1178,8 @@
         "Buying, selling, no questions. Especially no questions about the inventory.",
         "The undead up at Gravemoor are lovely neighbours. Quiet. Very quiet.",
         "Everything here fell off a cart. A very specific, very unlucky cart."
-      ]
+      ],
+      "dislikes": ["goblin-curio-keep"]
     },
     {
       "id": "hedge-witch-morwen",
@@ -1307,7 +1308,10 @@
       "questReceive": [
         "mire-lost-items-1",
         "mire-lost-items-2"
-      ]
+      ],
+      "favoriteGiftItemId": "gilded-compass",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": ["honey-cake"]
     }
   ],
   "interiors": {
@@ -1986,6 +1990,33 @@
     }
   },
   "interactables": [
+    {
+      "id": "hollowmere-forage-tree-1",
+      "tx": 9,
+      "ty": 0,
+      "reactions": [
+        { "type": "dialogue", "text": "A dead tree at the wood's edge — something might be nesting in its roots." },
+        { "type": "forage" }
+      ]
+    },
+    {
+      "id": "hollowmere-forage-tree-2",
+      "tx": 42,
+      "ty": 7,
+      "reactions": [
+        { "type": "dialogue", "text": "A dark, gnarled tree, worth a closer look." },
+        { "type": "forage" }
+      ]
+    },
+    {
+      "id": "hollowmere-forage-tree-3",
+      "tx": 31,
+      "ty": 23,
+      "reactions": [
+        { "type": "dialogue", "text": "One of the gnarled trees ringing the marsh — something might be tucked among its roots." },
+        { "type": "forage" }
+      ]
+    },
     {
       "id": "hollowmere-hollow",
       "tx": 29,

--- a/web/src/data/hub/hollowmere/questDefs.json
+++ b/web/src/data/hub/hollowmere/questDefs.json
@@ -345,6 +345,41 @@
         "friendship": { "hedge-witch-morwen": 15 },
         "collectible": { "id": "hollowmere-feud-token", "name": "The Cauldron I.O.U.", "icon": "📜", "desc": "A note acknowledging Sythe's twenty-year-old cauldron debt to Morwen. She will treasure this forever." }
       }
+    },
+    {
+      "id": "morwens-real-secret",
+      "title": "A Secret of the Craft",
+      "type": "fetch",
+      "giverNpcId": "hedge-witch-morwen",
+      "receiverNpcId": "hedge-witch-morwen",
+      "prerequisite": "friendship:hedge-witch-morwen:5",
+      "offerDialogue": "You've earned more than a customer's welcome here, traveller. Sit by the cauldron a moment — there's a real secret of the craft I've never shared with an outsider.",
+      "activeDialogue": "No rush. The cauldron's been simmering longer than you've been alive.",
+      "completeDialogue": "There. Not many earn that from me — least of all someone who still smells of the nice town down south. Consider yourself Hollowmere's, now, as much as mine.",
+      "steps": [
+        { "key": "report", "type": "report", "targetNpcId": "hedge-witch-morwen", "required": 1 }
+      ],
+      "reward": {
+        "crystals": 95,
+        "friendship": { "hedge-witch-morwen": 10 }
+      }
+    },
+    {
+      "id": "ogrims-bad-mood",
+      "title": "Banned From the Den",
+      "type": "fetch",
+      "giverNpcId": "ogrim-the-bouncer",
+      "receiverNpcId": "ogrim-the-bouncer",
+      "prerequisite": "hatred:ogrim-the-bouncer:1",
+      "offerDialogue": "You. I don't like you. Fine — earn your way back off my bad side. Report back once you've done something useful for once.",
+      "activeDialogue": "Well? I'm still not letting you back in until you have.",
+      "completeDialogue": "Took you long enough. Here. Now get out of my doorway before I change my mind about the whole 'not eating heroes' rule.",
+      "steps": [
+        { "key": "report", "type": "report", "targetNpcId": "ogrim-the-bouncer", "required": 1 }
+      ],
+      "reward": {
+        "hubItem": { "itemId": "mouldy-slipper", "count": 1 }
+      }
     }
   ],
   "pickupItems": [
@@ -400,5 +435,12 @@
 
     { "id": "medicine-vial", "tx": 3, "ty": 2, "tileId": "potions", "building": "witch-hut-brewing", "questId": "hollowmere-marsh-medicine" }
   ],
-  "blockedPaths": []
+  "blockedPaths": [],
+  "relationshipDialogue": {
+    "fang-the-fence": {
+      "rival": {
+        "1": "Heard you've been chatting up Snægg. Careful there — that goblin's 'finds' are worth half what mine are, and twice the trouble."
+      }
+    }
+  }
 }

--- a/web/src/data/hub/ironholdkeep/config.json
+++ b/web/src/data/hub/ironholdkeep/config.json
@@ -2029,6 +2029,9 @@
       "building": "smithy",
       "questGive": "castle-weapon-cache",
       "questReceive": "castle-weapon-cache",
+      "favoriteGiftItemId": "bog-salve",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": ["poetry-book"],
       "schedule": [
         {
           "startHour": 0,
@@ -2095,6 +2098,7 @@
       "building": "quartermasters-store",
       "questGive": "castle-supply-tally",
       "questReceive": "castle-supply-tally",
+      "dislikes": ["castle-blacksmith"],
       "schedule": [
         {
           "startHour": 0,
@@ -4484,6 +4488,54 @@
     }
   },
   "interactables": [
+    {
+      "id": "ironholdkeep-forage-bush-1",
+      "tx": 20,
+      "ty": 45,
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "tileId": "lightBush"
+        }
+      ],
+      "reactions": [
+        { "type": "dialogue", "text": "A scrappy bush growing wild in the Outer Bailey." },
+        { "type": "forage" }
+      ]
+    },
+    {
+      "id": "ironholdkeep-forage-flower-1",
+      "tx": 21,
+      "ty": 47,
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "tileId": "yellowFlower"
+        }
+      ],
+      "reactions": [
+        { "type": "dialogue", "text": "A patch of wildflowers, somehow thriving between the flagstones." },
+        { "type": "forage" }
+      ]
+    },
+    {
+      "id": "ironholdkeep-forage-bush-2",
+      "tx": 20,
+      "ty": 49,
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "tileId": "darkBush"
+        }
+      ],
+      "reactions": [
+        { "type": "dialogue", "text": "A shaded bush near the dungeon wall, worth a closer look." },
+        { "type": "forage" }
+      ]
+    },
     {
       "id": "ironholdkeep-chicken-feed",
       "tx": 15,

--- a/web/src/data/hub/ironholdkeep/questDefs.json
+++ b/web/src/data/hub/ironholdkeep/questDefs.json
@@ -870,6 +870,41 @@
       "reward": {
         "crystals": 80
       }
+    },
+    {
+      "id": "elwyns-sealed-archive",
+      "title": "The Sealed Archive",
+      "type": "fetch",
+      "giverNpcId": "castle-archivist",
+      "receiverNpcId": "castle-archivist",
+      "prerequisite": "friendship:castle-archivist:5",
+      "offerDialogue": "You've earned more than a scholar's thanks, traveller — you've earned a scholar's trust. There is a sealed record I've never shown an outsider. Come, sit. History deserves a witness.",
+      "activeDialogue": "Take your time. The archive has waited centuries; it can wait a moment longer.",
+      "completeDialogue": "There. Not every visitor earns a place in Ironhold's true history — you have. Guard it well.",
+      "steps": [
+        { "key": "report", "type": "report", "targetNpcId": "castle-archivist", "required": 1 }
+      ],
+      "reward": {
+        "crystals": 90,
+        "friendship": { "castle-archivist": 10 }
+      }
+    },
+    {
+      "id": "olens-grudge",
+      "title": "State Your Business",
+      "type": "fetch",
+      "giverNpcId": "castle-gatekeeper",
+      "receiverNpcId": "castle-gatekeeper",
+      "prerequisite": "hatred:castle-gatekeeper:1",
+      "offerDialogue": "You again. I don't like the look of you, and I've said so at this gate before. Fine — prove your business is honest. Report back once it is.",
+      "activeDialogue": "Well? I'm still watching you.",
+      "completeDialogue": "Hmph. Take it and be on your way. Don't linger at my gate.",
+      "steps": [
+        { "key": "report", "type": "report", "targetNpcId": "castle-gatekeeper", "required": 1 }
+      ],
+      "reward": {
+        "hubItem": { "itemId": "mouldy-slipper", "count": 1 }
+      }
     }
   ],
   "pickupItems": [
@@ -1467,6 +1502,11 @@
         "2": "Doran gives a curt nod. \"You've stood enough watches with us. The wall counts you a friend now.\"",
         "3": "\"Half the recruits would follow you over the parapet if you asked. Don't let it go to your head.\"",
         "4": "\"There's a place on this wall for you any day you want it, traveller. That's the highest word I have.\""
+      }
+    },
+    "castle-quartermaster": {
+      "rival": {
+        "1": "\"You've been spending a lot of time with Kern lately. Tell him my ledger has never once been wrong — and I'd thank him to stop implying otherwise to every traveller who'll listen.\""
       }
     }
   },


### PR DESCRIPTION
## Summary

Follow-up to #1870/#1881/#1883/#1885: the favorite/disliked gift, NPC rivalry, forage, and friendship-gated quest mechanisms are fully data-driven, but only 8 of 13 towns had any curated content using them. This extends that curation to **Hollowmere** and **Ironhold Keep**.

### Hollowmere
- Gift pair: Mother Sump (favorite `gilded-compass` — a direct match for her "trades favors for shiny trinkets" flavor line, disliked `honey-cake`)
- Rivalry: Fang the Fence dislikes Snægg the Collector (`relationshipDialogue` rival-tier line) — two competing "everything has a price" dealers
- Forage: 3 new interactables overlaying existing tree decor
- Max-friendship quest: `morwens-real-secret` (Hedge-Witch Morwen, gated `friendship:hedge-witch-morwen:5`)
- Hate quest: `ogrims-bad-mood` (Ogrim the Bouncer, gated `hatred:ogrim-the-bouncer:1`, rewards `mouldy-slipper`)

### Ironhold Keep
- Gift pair: Blacksmith Kern (favorite `bog-salve` — its catalog description literally says "smiths prize it for burns", disliked `poetry-book`)
- Rivalry: Quartermaster Sella dislikes Blacksmith Kern (`relationshipDialogue` rival-tier line, added as a sibling key in the town's existing `relationshipDialogue` block) — his public suspicion about missing weapon crates needles her ledger-pride
- Forage: 3 new interactables with new standalone decor (this town had no existing tree/bush/flower decor, like Millhaven)
- Max-friendship quest: `elwyns-sealed-archive` (Archivist Elwyn, gated `friendship:castle-archivist:5`)
- Hate quest: `olens-grudge` (Gatekeeper Olen, gated `hatred:castle-gatekeeper:1`, rewards `mouldy-slipper`)

Both towns' hate-quest rewards reuse the existing `mouldy-slipper` trade chain (buyer: James in Ravenwatch) rather than minting new items/chains, per the established "items are reused across multiple grant points" network philosophy.

Fixes #1887. Pure data/JSON content — no source code changes.

## Test plan
- [x] `npm run build` passes
- [x] `npm run test` — 373/373 tests pass
- [x] All edited JSON files validated with `python3 -c "import json; json.load(...)"`
- [x] Reasoned through each new quest/gift/rivalry/forage flow by reading the JSON + shared mechanism code end-to-end (logic/data change — per AGENTS.md, browser verification is reserved for visual bugs)


---
_Generated by [Claude Code](https://claude.ai/code/session_01ECAnvLwwDB5WQRZrGM5R2Y)_