### PR TITLE
Curate relationship content for Capital City, Dreadspire Citadel & Royal Palace

### DIFF
--- a/docs/hubworld.md
+++ b/docs/hubworld.md
@@ -780,9 +780,11 @@ example: Ravenwatch's `merchants-contempt` quest (prerequisite
 re-minted) for Millhaven's `regattas-scorn` (Regatta Master Coll),
 Gravemoor's `pedlars-grudge` (The Spectral Pedlar), Appleford's `hobs-grudge`
 (Hob the Picker), Harrowfield's `rooks-toll` (Miller Rook), Hollowmere's
-`ogrims-bad-mood` (Ogrim the Bouncer), and Ironhold Keep's `olens-grudge`
-(Gatekeeper Olen) hate-quests — all funnel to the same buyer, James in
-Ravenwatch (`james-junk-trade`), per §16's
+`ogrims-bad-mood` (Ogrim the Bouncer), Ironhold Keep's `olens-grudge`
+(Gatekeeper Olen), Capital City's `bryns-cold-shoulder` (Guardsman Bryn),
+Dreadspire Citadel's `gholls-contempt` (Warden Gholl), and Royal Palace's
+`bricks-cold-post` (Guardsman Brick) hate-quests — all funnel to the same
+buyer, James in Ravenwatch (`james-junk-trade`), per §16's
 "items are reused across multiple grant points" philosophy.
 
 ### Authoring checklist: friendship-extreme quest with a joke-item reward

--- a/web/src/data/hub/capitalcity/config.json
+++ b/web/src/data/hub/capitalcity/config.json
@@ -3774,6 +3774,33 @@
   },
   "interactables": [
     {
+      "id": "capitalcity-forage-flower-1",
+      "tx": 32,
+      "ty": 44,
+      "reactions": [
+        { "type": "dialogue", "text": "A patch of white flowers growing at the plaza's edge." },
+        { "type": "forage" }
+      ]
+    },
+    {
+      "id": "capitalcity-forage-flower-2",
+      "tx": 60,
+      "ty": 62,
+      "reactions": [
+        { "type": "dialogue", "text": "Yellow flowers, planted for the coronation and never uprooted." },
+        { "type": "forage" }
+      ]
+    },
+    {
+      "id": "capitalcity-forage-flower-3",
+      "tx": 98,
+      "ty": 44,
+      "reactions": [
+        { "type": "dialogue", "text": "Pink flowers growing wild near the old noble manors." },
+        { "type": "forage" }
+      ]
+    },
+    {
       "id": "market-hall-music-box",
       "tx": 2,
       "ty": 2,
@@ -4383,6 +4410,7 @@
         "crownhaven-noble-debt",
         "crownhaven-stolen-coin"
       ],
+      "dislikes": ["mint-master"],
       "schedule": [
         {
           "startHour": 0,
@@ -5099,7 +5127,10 @@
         "The Crown Theatre will dazzle the realm — once the stage is ready.",
         "Rehearsals, ropes, and a thousand candles. Come back for the grand premiere!",
         "A performance worthy of a coronation takes time. Patience, friend."
-      ]
+      ],
+      "favoriteGiftItemId": "fancy-hat",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": ["sturdy-boots"]
     }
   ],
   "exteriorDecor": [

--- a/web/src/data/hub/capitalcity/questDefs.json
+++ b/web/src/data/hub/capitalcity/questDefs.json
@@ -1255,6 +1255,41 @@
           "high-priest": 15
         }
       }
+    },
+    {
+      "id": "hales-trusted-blade",
+      "title": "A Trusted Blade",
+      "type": "fetch",
+      "giverNpcId": "watch-captain-hale",
+      "receiverNpcId": "watch-captain-hale",
+      "prerequisite": "friendship:watch-captain-hale:5",
+      "offerDialogue": "You've earned more than the watch's thanks, traveller — you've earned my trust, and that's not given lightly in Crownhaven. Stand with me a moment. There's something I want you to have.",
+      "activeDialogue": "No rush. The gates have stood longer than either of us.",
+      "completeDialogue": "There. Not many earn a captain's trust — you have. The watch will remember it.",
+      "steps": [
+        { "key": "report", "type": "report", "targetNpcId": "watch-captain-hale", "required": 1 }
+      ],
+      "reward": {
+        "crystals": 95,
+        "friendship": { "watch-captain-hale": 10 }
+      }
+    },
+    {
+      "id": "bryns-cold-shoulder",
+      "title": "Off the Wall",
+      "type": "fetch",
+      "giverNpcId": "guard-bryn",
+      "receiverNpcId": "guard-bryn",
+      "prerequisite": "hatred:guard-bryn:1",
+      "offerDialogue": "You. I've had my fill of you loitering near my post. Fine — make yourself useful for once and report back when you have.",
+      "activeDialogue": "Well? The wall isn't getting any shorter while I wait.",
+      "completeDialogue": "About time. Here — take it and find somewhere else to loiter.",
+      "steps": [
+        { "key": "report", "type": "report", "targetNpcId": "guard-bryn", "required": 1 }
+      ],
+      "reward": {
+        "hubItem": { "itemId": "mouldy-slipper", "count": 1 }
+      }
     }
   ],
   "pickupItems": [
@@ -1765,5 +1800,12 @@
       "questId": "crownhaven-feast"
     }
   ],
-  "blockedPaths": []
+  "blockedPaths": [],
+  "relationshipDialogue": {
+    "banker": {
+      "rival": {
+        "1": "Spending time up at the mint again? Every coin that leaves Coyle's hammer still has to pass through my ledger, traveller. Don't let his pageantry fool you about who really keeps this city solvent."
+      }
+    }
+  }
 }

--- a/web/src/data/hub/dreadspirecitadel/config.json
+++ b/web/src/data/hub/dreadspirecitadel/config.json
@@ -630,7 +630,8 @@
         "Vesska took my shadow-oil. I can tell. The circle sulks differently when the oil is wrong."
       ],
       "questGive": "dreadspire-ritual-ingredients",
-      "questReceive": "dreadspire-ritual-ingredients"
+      "questReceive": "dreadspire-ritual-ingredients",
+      "dislikes": ["warlock-vesska"]
     },
     {
       "id": "bone-keeper-mald",
@@ -645,7 +646,10 @@
         "You want the deep ossuary? Mind the draught. And the things that enjoy the draught."
       ],
       "questGive": "dreadspire-bone-tally",
-      "questReceive": "dreadspire-bone-tally"
+      "questReceive": "dreadspire-bone-tally",
+      "favoriteGiftItemId": "bones",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": ["honey-cake"]
     },
     {
       "id": "shrine-tender",
@@ -1984,6 +1988,33 @@
     }
   },
   "interactables": [
+    {
+      "id": "dreadspire-forage-tree-1",
+      "tx": 22,
+      "ty": 28,
+      "reactions": [
+        { "type": "dialogue", "text": "A dead tree, twisted and bare — something might be tucked among its roots." },
+        { "type": "forage" }
+      ]
+    },
+    {
+      "id": "dreadspire-forage-bush-1",
+      "tx": 19,
+      "ty": 24,
+      "reactions": [
+        { "type": "dialogue", "text": "A withered bush by the outer ward, worth a closer look." },
+        { "type": "forage" }
+      ]
+    },
+    {
+      "id": "dreadspire-forage-bush-2",
+      "tx": 33,
+      "ty": 27,
+      "reactions": [
+        { "type": "dialogue", "text": "A dead bush near the citadel wall, roots half-exposed." },
+        { "type": "forage" }
+      ]
+    },
     {
       "id": "spellwright-den-item-0",
       "tx": 7,

--- a/web/src/data/hub/dreadspirecitadel/questDefs.json
+++ b/web/src/data/hub/dreadspirecitadel/questDefs.json
@@ -541,6 +541,41 @@
           "desc": "Vesska's order halting the master's homecoming ritual. The citadel keeps its empty throne — and is glad of it."
         }
       }
+    },
+    {
+      "id": "castellans-final-record",
+      "title": "The Final Record",
+      "type": "fetch",
+      "giverNpcId": "the-castellan",
+      "receiverNpcId": "the-castellan",
+      "prerequisite": "friendship:the-castellan:5",
+      "offerDialogue": "In four centuries of service, few have earned what you have from me, traveller: trust. There is a record I keep for no one but myself. Sit a while. Let an old dead administrator show you.",
+      "activeDialogue": "Take your time. The citadel has kept its secrets far longer than either of us has drawn breath — or not, in my case.",
+      "completeDialogue": "There. Not every visitor earns a place in Dreadspire's true ledger. You have. The citadel will remember you long after it has forgotten most of the living.",
+      "steps": [
+        { "key": "report", "type": "report", "targetNpcId": "the-castellan", "required": 1 }
+      ],
+      "reward": {
+        "crystals": 100,
+        "friendship": { "the-castellan": 10 }
+      }
+    },
+    {
+      "id": "gholls-contempt",
+      "title": "Out of the Dungeon",
+      "type": "fetch",
+      "giverNpcId": "dungeon-warden-gholl",
+      "receiverNpcId": "dungeon-warden-gholl",
+      "prerequisite": "hatred:dungeon-warden-gholl:1",
+      "offerDialogue": "You. I don't like the look of you skulking near my cells. Fine — prove you're not another prisoner in waiting and report back once you've done something useful.",
+      "activeDialogue": "Well? The cells don't watch themselves.",
+      "completeDialogue": "Hmph. Took you long enough. Take it and stay clear of my dungeon from here on.",
+      "steps": [
+        { "key": "report", "type": "report", "targetNpcId": "dungeon-warden-gholl", "required": 1 }
+      ],
+      "reward": {
+        "hubItem": { "itemId": "mouldy-slipper", "count": 1 }
+      }
     }
   ],
   "pickupItems": [
@@ -1009,6 +1044,11 @@
       },
       "rival": {
         "1": "You count bones like a thief counts exits. I am watching you, warm one. Every femur."
+      }
+    },
+    "cultist-ordrin": {
+      "rival": {
+        "1": "You've been spending time with Vesska, haven't you? I can smell the shadow-oil on you. MY shadow-oil, probably. The circle noticed. The circle is not pleased."
       }
     }
   },

--- a/web/src/data/hub/royalpalace/config.json
+++ b/web/src/data/hub/royalpalace/config.json
@@ -1873,6 +1873,7 @@
         "palace-happy-cat",
         "palace-lost-keys"
       ],
+      "dislikes": ["lady-penrose"],
       "schedule": [
         {
           "startHour": 0,
@@ -2091,6 +2092,9 @@
       ],
       "questGive": "palace-queen-roses",
       "questReceive": "palace-queen-roses",
+      "favoriteGiftItemId": "silk-ribbon",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": ["sturdy-boots"],
       "schedule": [
         {
           "startHour": 0,
@@ -4237,6 +4241,33 @@
     }
   },
   "interactables": [
+    {
+      "id": "royalpalace-forage-tree-1",
+      "tx": 32,
+      "ty": 24,
+      "reactions": [
+        { "type": "dialogue", "text": "An autumn-gold tree in the East Gardens, worth a closer look." },
+        { "type": "forage" }
+      ]
+    },
+    {
+      "id": "royalpalace-forage-flower-1",
+      "tx": 37,
+      "ty": 24,
+      "reactions": [
+        { "type": "dialogue", "text": "A patch of blue flowers growing between the garden's bird baths." },
+        { "type": "forage" }
+      ]
+    },
+    {
+      "id": "royalpalace-forage-bush-1",
+      "tx": 42,
+      "ty": 24,
+      "reactions": [
+        { "type": "dialogue", "text": "A tidy bush along the garden's far edge." },
+        { "type": "forage" }
+      ]
+    },
     {
       "id": "royalpalace-chicken-feed",
       "tx": 26,

--- a/web/src/data/hub/royalpalace/questDefs.json
+++ b/web/src/data/hub/royalpalace/questDefs.json
@@ -543,6 +543,41 @@
           "queen": 20
         }
       }
+    },
+    {
+      "id": "aldrics-quiet-counsel",
+      "title": "A Quiet Counsel",
+      "type": "fetch",
+      "giverNpcId": "king",
+      "receiverNpcId": "king",
+      "prerequisite": "friendship:king:5",
+      "offerDialogue": "A crown is a lonely thing to wear, traveller — but you have made it a little less so. Sit with me a while. There is counsel I give to few, and friendship to fewer still.",
+      "activeDialogue": "No rush. The throne has waited longer than either of us.",
+      "completeDialogue": "There. Not every visitor to this court earns a king's true friendship — you have. The realm is fortunate to have you in it.",
+      "steps": [
+        { "key": "report", "type": "report", "targetNpcId": "king", "required": 1 }
+      ],
+      "reward": {
+        "crystals": 110,
+        "friendship": { "king": 10 }
+      }
+    },
+    {
+      "id": "bricks-cold-post",
+      "title": "Not Technically Breaking Any Rules",
+      "type": "fetch",
+      "giverNpcId": "palace-guard",
+      "receiverNpcId": "palace-guard",
+      "prerequisite": "hatred:palace-guard:1",
+      "offerDialogue": "You again. I've counted the fence railings twice just to avoid looking at you. Fine — make yourself useful for once and report back when you have.",
+      "activeDialogue": "Well? I'm still counting railings.",
+      "completeDialogue": "About time. Take it and find somewhere else to loiter — preferably a different kingdom.",
+      "steps": [
+        { "key": "report", "type": "report", "targetNpcId": "palace-guard", "required": 1 }
+      ],
+      "reward": {
+        "hubItem": { "itemId": "mouldy-slipper", "count": 1 }
+      }
     }
   ],
   "pickupItems": [
@@ -904,5 +939,12 @@
         }
       }
     }
-  ]
+  ],
+  "relationshipDialogue": {
+    "royal-steward": {
+      "rival": {
+        "1": "Oh dear — you've been keeping company with Lady Penrose, haven't you? Mind yourself around her. Some of us have quite enough intrigue keeping this palace running without adding hers to the pile."
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Follow-up to #1870/#1881/#1883/#1885/#1887: the favorite/disliked gift, NPC rivalry, forage, and friendship-gated quest mechanisms are fully data-driven, but only 10 of 13 towns had any curated content using them. This extends that curation to the final 3 towns — **Capital City** (Crownhaven), **Dreadspire Citadel**, and **Royal Palace** — completing coverage across all 13 hub-world towns.

### Capital City (Crownhaven)
- Gift pair: Impresario Vane (favorite `fancy-hat`, disliked `sturdy-boots`)
- Rivalry: Banker Sterling dislikes Mintmaster Coyle (`relationshipDialogue` rival-tier line) — a competitive "who really controls the money" tension
- Forage: 3 new interactables overlaying existing flower decor
- Max-friendship quest: `hales-trusted-blade` (Captain Hale, gated `friendship:watch-captain-hale:5`)
- Hate quest: `bryns-cold-shoulder` (Guardsman Bryn, gated `hatred:guard-bryn:1`, rewards `mouldy-slipper`)

### Dreadspire Citadel
- Gift pair: Bone-Keeper Mald (favorite `bones`, disliked `honey-cake`)
- Rivalry: Cultist Ordrin dislikes Warlock Vesska (`relationshipDialogue` rival-tier line, added as a sibling key in the town's existing `relationshipDialogue` block) — builds directly on an existing in-fiction hook where Ordrin already suspects Vesska of stealing his shadow-oil
- Forage: 3 new interactables overlaying existing tree/bush decor
- Max-friendship quest: `castellans-final-record` (The Castellan, gated `friendship:the-castellan:5`)
- Hate quest: `gholls-contempt` (Warden Gholl, gated `hatred:dungeon-warden-gholl:1`, rewards `mouldy-slipper`)

### Royal Palace
- Gift pair: Queen Maredith (favorite `silk-ribbon`, disliked `sturdy-boots`)
- Rivalry: Royal Steward Marigold dislikes Lady Penrose (new `relationshipDialogue` block) — the flustered administrator resenting the court schemer's intrigue
- Forage: 3 new interactables overlaying existing tree/flower/bush decor
- Max-friendship quest: `aldrics-quiet-counsel` (King Aldric, gated `friendship:king:5`)
- Hate quest: `bricks-cold-post` (Guardsman Brick, gated `hatred:palace-guard:1`, rewards `mouldy-slipper`)

All three towns' hate-quest rewards reuse the existing `mouldy-slipper` trade chain (buyer: James in Ravenwatch) rather than minting new items/chains, per the established "items are reused across multiple grant points" network philosophy.

Fixes #1889. Pure data/JSON content — no source code changes. This completes the town-by-town relationship-content curation effort across all 13 hub towns.

## Test plan
- [x] `npm run build` passes
- [x] `npm run test` — 373/373 tests pass
- [x] All edited JSON files validated with `python3 -c "import json; json.load(...)"`
- [x] Reasoned through each new quest/gift/rivalry/forage flow by reading the JSON + shared mechanism code end-to-end (logic/data change — per AGENTS.md, browser verification is reserved for visual bugs)


---
_Generated by [Claude Code](https://claude.ai/code/session_01ECAnvLwwDB5WQRZrGM5R2Y)_