### PR TITLE
Add Millhaven Harbour Regatta minigame

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2825,7 +2825,7 @@ export default function App() {
           onNavigate={(s, buildingId) => {
             setReturnScreen('hubworld')
             setShopBuildingId(buildingId)
-            const HUB_MINIGAME_IDS: SubScreen[] = ['marble', 'tileflip', 'crystalcatch', 'spinner', 'marblerace', 'higherOrLower', 'fruitMachine', 'videoPoker', 'fishing', 'towerDefence', 'citybuilder', 'prizes']
+            const HUB_MINIGAME_IDS: SubScreen[] = ['marble', 'tileflip', 'crystalcatch', 'spinner', 'marblerace', 'regatta', 'higherOrLower', 'fruitMachine', 'videoPoker', 'fishing', 'towerDefence', 'citybuilder', 'prizes']
             if (HUB_MINIGAME_IDS.includes(s as SubScreen)) {
               setHubMiniGameEntry(s as SubScreen)
               setScreen('hub-minigame')

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -143,6 +143,7 @@ const SCREEN_ENTER_LABEL: Record<string, string> = {
   'hub-fishing':     'Cast a line?',
   marble:            'Play marbles?',
   marblerace:        'Watch a marble race?',
+  regatta:           'Race a skiff in the regatta?',
   tileflip:          'Play tile flip?',
   crystalcatch:      'Play crystal catch?',
   spinner:           'Give it a spin?',

--- a/web/src/components/minigames/HarbourRegatta.physics.test.ts
+++ b/web/src/components/minigames/HarbourRegatta.physics.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest'
+import {
+  createRowState, applyStroke, decayLateral,
+  TARGET_STROKE_MS, MAX_LATERAL,
+} from './HarbourRegatta.physics'
+
+describe('Harbour Regatta physics', () => {
+  it('perfect alternation cancels lateral drift and keeps rowing straight', () => {
+    let state = createRowState()
+    let now = 1000
+    const sides: Array<'left' | 'right'> = ['left', 'right', 'left', 'right', 'left', 'right']
+    for (const side of sides) {
+      state = applyStroke(state, side, now)
+      now += TARGET_STROKE_MS
+    }
+    expect(state.lateralOffset).toBe(0)
+    expect(state.progress).toBeGreaterThan(0)
+  })
+
+  it('hammering the same oar drifts the skiff toward that side and eventually clamps', () => {
+    let state = createRowState()
+    let now = 1000
+    for (let i = 0; i < 3; i++) {
+      state = applyStroke(state, 'right', now)
+      now += TARGET_STROKE_MS
+    }
+    expect(state.lateralOffset).toBeGreaterThan(0)
+    expect(state.lateralOffset).toBeLessThanOrEqual(MAX_LATERAL)
+
+    for (let i = 0; i < 10; i++) {
+      state = applyStroke(state, 'right', now)
+      now += TARGET_STROKE_MS
+    }
+    expect(state.lateralOffset).toBe(MAX_LATERAL)
+  })
+
+  it('steady-interval alternating strokes yield more progress than ragged timing', () => {
+    let steady = createRowState()
+    let now = 1000
+    const sides: Array<'left' | 'right'> = ['left', 'right', 'left', 'right', 'left', 'right']
+    for (const side of sides) {
+      steady = applyStroke(steady, side, now)
+      now += TARGET_STROKE_MS
+    }
+
+    let ragged = createRowState()
+    now = 1000
+    const raggedIntervals = [50, 900, 60, 1200, 40, 950]
+    for (let i = 0; i < sides.length; i++) {
+      ragged = applyStroke(ragged, sides[i], now)
+      now += raggedIntervals[i]
+    }
+
+    expect(steady.progress).toBeGreaterThan(ragged.progress)
+  })
+
+  it('repeated-oar strokes give reduced thrust compared to well-timed alternation', () => {
+    let now = 1000
+    let alternating = createRowState()
+    alternating = applyStroke(alternating, 'left', now)
+    now += TARGET_STROKE_MS
+    const alternatingResult = applyStroke(alternating, 'right', now)
+
+    now = 1000
+    let repeating = createRowState()
+    repeating = applyStroke(repeating, 'left', now)
+    now += TARGET_STROKE_MS
+    const repeatingResult = applyStroke(repeating, 'left', now)
+
+    const alternatingGain = alternatingResult.progress - alternating.progress
+    const repeatingGain = repeatingResult.progress - repeating.progress
+    expect(alternatingGain).toBeGreaterThan(repeatingGain)
+  })
+
+  it('decayLateral pulls lateralOffset back toward the centreline over time', () => {
+    let state = applyStroke(createRowState(), 'right', 1000)
+    const offsetBefore = state.lateralOffset
+    state = decayLateral(state, 2000)
+    expect(state.lateralOffset).toBeGreaterThan(0)
+    expect(state.lateralOffset).toBeLessThan(offsetBefore)
+  })
+
+  it('decayLateral is a no-op for non-positive dt', () => {
+    const state = applyStroke(createRowState(), 'left', 1000)
+    expect(decayLateral(state, 0)).toEqual(state)
+  })
+})

--- a/web/src/components/minigames/HarbourRegatta.physics.ts
+++ b/web/src/components/minigames/HarbourRegatta.physics.ts
@@ -1,0 +1,83 @@
+// ─── Harbour Regatta physics ──────────────────────────────────────────────────
+// Pure functions for the skill-based rowing mechanic: alternate LEFT/RIGHT oar
+// taps in a steady rhythm to row straight; favour one oar and the skiff veers
+// that way. Kept separate from the component so the stroke/drift/AI-pacing
+// math can be unit tested without rendering.
+
+export type OarSide = 'left' | 'right'
+
+export interface RowState {
+  lateralOffset: number       // drift from centreline; clamped to +/- MAX_LATERAL
+  progress: number            // distance rowed so far
+  lastSide: OarSide | null
+  lastTapAt: number | null    // ms timestamp of the previous stroke
+}
+
+export const COURSE_LENGTH      = 700    // progress units at the finish line
+export const MAX_LATERAL        = 60     // clamp before hitting the buoy line / bank
+export const TARGET_STROKE_MS   = 420    // ideal interval between alternating strokes
+export const STROKE_TOLERANCE_MS = 180   // timing window for full thrust
+export const MIN_TIMING_FACTOR  = 0.2    // ragged timing never drops thrust to zero
+export const BASE_THRUST        = 16     // progress gained per well-timed alternating stroke
+export const REPEAT_THRUST_FACTOR = 0.35 // thrust penalty for hammering the same oar
+export const VEER_STEP          = 14     // lateral push per stroke, signed by oar side
+export const BANK_PENALTY_FACTOR = 0.4   // thrust penalty when the clamp is hit
+export const DRAG_PER_MS        = 0.0016 // exponential decay pulling lateralOffset to 0
+
+export function createRowState(): RowState {
+  return { lateralOffset: 0, progress: 0, lastSide: null, lastTapAt: null }
+}
+
+// Apply one oar tap. Each side always pushes the skiff toward that side (left
+// oar -> veer left, right oar -> veer right); alternating sides cancels the
+// push out over a pair of strokes, so a steady L-R-L-R rhythm rows straight.
+// Repeating the same oar skips the thrust-timing bonus (rhythm requires
+// alternation), and drifting past MAX_LATERAL costs a landing/bank penalty.
+export function applyStroke(state: RowState, side: OarSide, now: number): RowState {
+  const isRepeat = state.lastSide === side
+  const veerDelta = VEER_STEP * (side === 'right' ? 1 : -1)
+  let lateralOffset = state.lateralOffset + veerDelta
+
+  let thrust: number
+  if (isRepeat) {
+    thrust = BASE_THRUST * REPEAT_THRUST_FACTOR
+  } else {
+    const interval = state.lastTapAt === null ? TARGET_STROKE_MS : now - state.lastTapAt
+    const timingError = Math.abs(interval - TARGET_STROKE_MS)
+    const timingFactor = Math.max(MIN_TIMING_FACTOR, 1 - timingError / STROKE_TOLERANCE_MS)
+    thrust = BASE_THRUST * timingFactor
+  }
+
+  let hitBank = false
+  if (lateralOffset > MAX_LATERAL) { lateralOffset = MAX_LATERAL; hitBank = true }
+  if (lateralOffset < -MAX_LATERAL) { lateralOffset = -MAX_LATERAL; hitBank = true }
+  if (hitBank) thrust *= BANK_PENALTY_FACTOR
+
+  return {
+    lateralOffset,
+    progress: state.progress + thrust,
+    lastSide: side,
+    lastTapAt: now,
+  }
+}
+
+// Self-righting drag pulling lateralOffset back toward the centreline each frame.
+export function decayLateral(state: RowState, dtMs: number): RowState {
+  if (dtMs <= 0) return state
+  const decay = Math.exp(-DRAG_PER_MS * dtMs)
+  return { ...state, lateralOffset: state.lateralOffset * decay }
+}
+
+const AI_BASE_SPEED_PER_MS = 0.035 // tuned so a well-rowed player finishes around the same time
+const AI_STALL_CHANCE_PER_SEC = 0.12
+const AI_SPEED_JITTER = 0.3 // +/- fraction of base speed per frame
+
+// Advance an AI skiff's progress by dtMs, with light randomised pacing/stalls
+// echoing MarbleRace's obstacle-chance drama (not deterministic — not unit tested).
+export function advanceAiProgress(progress: number, dtMs: number): number {
+  if (dtMs <= 0) return progress
+  const stallChance = AI_STALL_CHANCE_PER_SEC * (dtMs / 1000)
+  if (Math.random() < stallChance) return progress
+  const jitter = 1 + (Math.random() * 2 - 1) * AI_SPEED_JITTER
+  return progress + AI_BASE_SPEED_PER_MS * dtMs * jitter
+}

--- a/web/src/components/minigames/HarbourRegatta.stories.tsx
+++ b/web/src/components/minigames/HarbourRegatta.stories.tsx
@@ -1,0 +1,19 @@
+import { fn } from 'storybook/test';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { HarbourRegatta } from './HarbourRegatta';
+
+const meta = {
+  component: HarbourRegatta,
+  parameters: { layout: 'fullscreen' },
+} satisfies Meta<typeof HarbourRegatta>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    onDone: fn(),
+  },
+};

--- a/web/src/components/minigames/HarbourRegatta.tsx
+++ b/web/src/components/minigames/HarbourRegatta.tsx
@@ -1,0 +1,310 @@
+// ─── Harbour Regatta ──────────────────────────────────────────────────────────
+// Row a skiff round the Millhaven harbour buoys against 3 crewed rivals. Tap the
+// LEFT and RIGHT oar buttons in a steady alternating rhythm to row straight —
+// favour one oar and the skiff veers that way. Prize is based on finishing place.
+
+import React, { useState, useEffect, useRef, useCallback } from 'react'
+import {
+  createRowState, applyStroke, decayLateral, advanceAiProgress,
+  COURSE_LENGTH, type RowState, type OarSide,
+} from './HarbourRegatta.physics'
+
+interface Props {
+  onDone: (ticketsEarned: number) => void
+}
+
+const PLAYER_IDX  = 0
+const BOAT_NAMES  = ['You', 'Gale', 'Tern', 'Reef'] as const
+const BOAT_COLORS = ['#ffcc00', '#ff4444', '#4488ff', '#44cc44'] as const
+const PLACE_PRIZES = [40, 20, 10, 5]
+const PLACE_LABELS = ['1st 🥇', '2nd 🥈', '3rd 🥉', '4th']
+
+const RENDER_INTERVAL_MS = 50
+const MAX_RACE_TIME_MS   = 60000
+
+// ── SVG layout ────────────────────────────────────────────────────────────────
+const SVG_W  = 380
+const SVG_H  = 640
+const LANE_XS = [65, 145, 225, 305]
+const START_Y  = 40
+const FINISH_Y = 600
+const LATERAL_PX_PER_UNIT = 1.1
+const OPEN_WATER_FRAC  = 0.30
+const WINDWARD_FRAC    = 0.55
+const SPINNAKER_FRAC   = 0.85
+
+function progressToY(progress: number): number {
+  const t = Math.max(0, Math.min(1, progress / COURSE_LENGTH))
+  return START_Y + (FINISH_Y - START_Y) * t
+}
+
+interface Display {
+  progress: number[]        // [player, ai1, ai2, ai3]
+  lateralOffset: number
+}
+
+type Phase = 'intro' | 'racing' | 'result'
+
+export function HarbourRegatta({ onDone }: Props) {
+  const [phase, setPhase]     = useState<Phase>('intro')
+  const [display, setDisplay] = useState<Display>({ progress: [0, 0, 0, 0], lateralOffset: 0 })
+  const [finishOrder, setFinishOrder]     = useState<number[]>([])
+  const [ticketsEarned, setTicketsEarned] = useState(0)
+
+  const rowStateRef    = useRef<RowState>(createRowState())
+  const aiProgressRef  = useRef<number[]>([0, 0, 0])
+  const finishedRef    = useRef(false)
+  const rafRef         = useRef<number | null>(null)
+  const lastFrameRef   = useRef(0)
+  const raceStartRef   = useRef(0)
+  const lastCommitRef  = useRef(0)
+
+  function startRace() {
+    rowStateRef.current   = createRowState()
+    aiProgressRef.current = [0, 0, 0]
+    finishedRef.current   = false
+    const now = performance.now()
+    raceStartRef.current  = now
+    lastFrameRef.current  = now
+    lastCommitRef.current = 0
+    setDisplay({ progress: [0, 0, 0, 0], lateralOffset: 0 })
+    setFinishOrder([])
+    setPhase('racing')
+  }
+
+  const tapOar = useCallback((side: OarSide) => {
+    if (finishedRef.current) return
+    rowStateRef.current = applyStroke(rowStateRef.current, side, performance.now())
+  }, [])
+
+  function finishRace(progresses: number[]) {
+    finishedRef.current = true
+    const order = [0, 1, 2, 3].sort((a, b) => progresses[b] - progresses[a])
+    const place = order.indexOf(PLAYER_IDX)
+    const tickets = PLACE_PRIZES[place]
+    setFinishOrder(order)
+    setTicketsEarned(tickets)
+    setDisplay({
+      progress: progresses.map(p => Math.min(p, COURSE_LENGTH)),
+      lateralOffset: rowStateRef.current.lateralOffset,
+    })
+    setPhase('result')
+  }
+
+  useEffect(() => {
+    if (phase !== 'racing') return
+
+    function frame(now: number) {
+      const dt = now - lastFrameRef.current
+      lastFrameRef.current = now
+
+      rowStateRef.current = decayLateral(rowStateRef.current, dt)
+      const ai = aiProgressRef.current
+      for (let i = 0; i < ai.length; i++) ai[i] = advanceAiProgress(ai[i], dt)
+
+      const progresses = [rowStateRef.current.progress, ai[0], ai[1], ai[2]]
+      const timedOut = now - raceStartRef.current >= MAX_RACE_TIME_MS
+
+      if (!finishedRef.current && (progresses.some(p => p >= COURSE_LENGTH) || timedOut)) {
+        finishRace(progresses)
+        return
+      }
+
+      if (now - lastCommitRef.current > RENDER_INTERVAL_MS) {
+        lastCommitRef.current = now
+        setDisplay({
+          progress: progresses.map(p => Math.min(p, COURSE_LENGTH)),
+          lateralOffset: rowStateRef.current.lateralOffset,
+        })
+      }
+      rafRef.current = requestAnimationFrame(frame)
+    }
+
+    rafRef.current = requestAnimationFrame(frame)
+    return () => { if (rafRef.current !== null) cancelAnimationFrame(rafRef.current) }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [phase])
+
+  // Optional keyboard support for desktop play.
+  useEffect(() => {
+    if (phase !== 'racing') return
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === 'ArrowLeft' || e.key === 'a' || e.key === 'A') tapOar('left')
+      if (e.key === 'ArrowRight' || e.key === 'd' || e.key === 'D') tapOar('right')
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [phase, tapOar])
+
+  // ── Intro phase ────────────────────────────────────────────────────────────
+  if (phase === 'intro') {
+    return (
+      <div className="minigame-screen">
+        <div className="minigame-title">⛵ HARBOUR REGATTA</div>
+        <p className="minigame-subtitle">
+          Row your skiff round the harbour buoys! Tap LEFT and RIGHT oars in a
+          steady alternating rhythm to go straight — favour one oar and you'll veer that way.
+        </p>
+
+        <div className="race-prize-table">
+          {PLACE_LABELS.map((label, i) => (
+            <div key={i} className="race-prize-row u-flex u-just-sb u-gap-7">
+              <span className="race-prize-place">{label}</span>
+              <span className="race-prize-tickets">+{PLACE_PRIZES[i]} 🎫</span>
+            </div>
+          ))}
+        </div>
+
+        <div className="minigame-result-panel u-col u-items-c u-gap-5">
+          <button className="action-btn action-btn--gold" onClick={startRace}>
+            ROW OUT!
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  // ── Racing / result phase ────────────────────────────────────────────────────
+  const place      = finishOrder.indexOf(PLAYER_IDX)
+  const placeLabel = phase === 'result' ? PLACE_LABELS[place] : null
+
+  const openWaterY  = progressToY(OPEN_WATER_FRAC * COURSE_LENGTH)
+  const windwardY   = progressToY(WINDWARD_FRAC * COURSE_LENGTH)
+  const spinnakerY  = progressToY(SPINNAKER_FRAC * COURSE_LENGTH)
+
+  return (
+    <div className="minigame-screen">
+      <div className="minigame-title">⛵ HARBOUR REGATTA</div>
+
+      {phase === 'racing' && (
+        <p className="minigame-subtitle">Racing… keep a steady L-R-L-R rhythm!</p>
+      )}
+      {phase === 'result' && (
+        <p className="minigame-subtitle">You finished {placeLabel}!</p>
+      )}
+
+      {/* SVG Course */}
+      <div className="race-svg-wrap">
+        <svg viewBox={`0 0 ${SVG_W} ${SVG_H}`} className="race-svg" aria-label="Harbour regatta course">
+
+          {/* ── Section labels ── */}
+          <text x="6" y={openWaterY - 10} className="race-section-label">OPEN WATER</text>
+          <text x="6" y={windwardY - 10} className="race-section-label">WINDWARD MARK</text>
+          <text x="6" y={spinnakerY - 10} className="race-section-label">SPINNAKER RUN</text>
+
+          {/* ── Lane tracks ── */}
+          {LANE_XS.map((lx, i) => (
+            <line key={i} x1={lx} y1={START_Y} x2={lx} y2={FINISH_Y} className="race-lane-track" />
+          ))}
+
+          {/* ── Windward buoy marker ── */}
+          <polygon
+            points={`${SVG_W / 2},${windwardY - 8} ${SVG_W / 2 + 8},${windwardY} ${SVG_W / 2},${windwardY + 8} ${SVG_W / 2 - 8},${windwardY}`}
+            className="regatta-buoy"
+          />
+
+          {/* ── Start line ── */}
+          <line x1={LANE_XS[0] - 22} y1={START_Y} x2={LANE_XS[3] + 22} y2={START_Y}
+                className="race-start-line" />
+          <text x={SVG_W / 2} y={START_Y - 7} textAnchor="middle" className="race-line-label">
+            QUAY START
+          </text>
+
+          {/* ── Finish line (striped) ── */}
+          {Array.from({ length: 10 }, (_, k) => {
+            const segW = (LANE_XS[3] + 22 - (LANE_XS[0] - 22)) / 10
+            const x1 = LANE_XS[0] - 22 + k * segW
+            return (
+              <rect key={k} x={x1} y={FINISH_Y - 4} width={segW} height={8}
+                    fill={k % 2 === 0 ? '#ffffff18' : '#00000030'} />
+            )
+          })}
+          <line x1={LANE_XS[0] - 22} y1={FINISH_Y} x2={LANE_XS[3] + 22} y2={FINISH_Y}
+                className="race-finish-line-svg" />
+          <text x={SVG_W / 2} y={FINISH_Y + 13} textAnchor="middle" className="race-line-label">
+            FINISH
+          </text>
+
+          {/* ── Lane headers ── */}
+          {LANE_XS.map((lx, i) => (
+            <text
+              key={i}
+              x={lx} y={START_Y - 16}
+              textAnchor="middle"
+              className={`race-lane-label${i === PLAYER_IDX ? ' race-lane-label--chosen' : ''}`}
+            >
+              {i === PLAYER_IDX ? '⛵ YOU' : BOAT_NAMES[i]}
+            </text>
+          ))}
+
+          {/* ── Skiffs ── */}
+          {LANE_XS.map((lx, i) => {
+            const x = lx + (i === PLAYER_IDX ? display.lateralOffset * LATERAL_PX_PER_UNIT : 0)
+            const y = progressToY(display.progress[i])
+            return (
+              <g
+                key={i}
+                style={{
+                  transform: `translate(${x}px, ${y}px)`,
+                  transition: `transform ${i === PLAYER_IDX ? 60 : Math.round(RENDER_INTERVAL_MS * 1.2)}ms linear`,
+                }}
+              >
+                {i === PLAYER_IDX && <circle r={13} className="regatta-boat-glow" style={{ stroke: BOAT_COLORS[i] }} />}
+                <polygon
+                  points="0,-9 6,7 0,4 -6,7"
+                  className={`regatta-boat-hull${i === PLAYER_IDX ? ' regatta-boat-hull--player' : ''}`}
+                  style={{ fill: BOAT_COLORS[i] }}
+                />
+              </g>
+            )
+          })}
+
+        </svg>
+      </div>
+
+      {/* ── Oar controls ── */}
+      {phase === 'racing' && (
+        <div className="regatta-oars u-flex u-gap-6 u-just-c">
+          <button className="action-btn action-btn--large regatta-oar-btn" onClick={() => tapOar('left')}>
+            ⬅ LEFT OAR
+          </button>
+          <button className="action-btn action-btn--large regatta-oar-btn" onClick={() => tapOar('right')}>
+            RIGHT OAR ➡
+          </button>
+        </div>
+      )}
+
+      {/* ── Finishing order ── */}
+      {phase === 'result' && finishOrder.length > 0 && (
+        <div className="race-results u-col u-gap-2">
+          {finishOrder.map((boatIdx, pos) => (
+            <div
+              key={boatIdx}
+              className={`race-result-row${boatIdx === PLAYER_IDX ? ' race-result-row--chosen' : ''}`}
+            >
+              <span className="race-result-place">{PLACE_LABELS[pos]}</span>
+              <span className="race-result-marble u-grow">
+                {boatIdx === PLAYER_IDX ? '⛵' : '🚣'} {BOAT_NAMES[boatIdx]}
+              </span>
+              {boatIdx === PLAYER_IDX && (
+                <span className="race-result-prize">+{ticketsEarned} 🎫</span>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {phase === 'result' && (
+        <div className="minigame-result-panel u-col u-items-c u-gap-5">
+          <div className="minigame-result-headline">
+            You earned {ticketsEarned} ticket{ticketsEarned !== 1 ? 's' : ''}!
+          </div>
+          <button className="action-btn action-btn--gold" onClick={() => onDone(ticketsEarned)}>
+            COLLECT &amp; EXIT
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}
+

--- a/web/src/components/screens/MiniGamesMenu.tsx
+++ b/web/src/components/screens/MiniGamesMenu.tsx
@@ -25,6 +25,7 @@ import { VideoPoker } from '../minigames/VideoPoker'
 import { CityBuilder } from '../minigames/CityBuilder'
 import { Fishing } from '../minigames/Fishing'
 import { TowerDefence, TowerPool } from '../minigames/TowerDefence'
+import { HarbourRegatta } from '../minigames/HarbourRegatta'
 import { PageHeader } from '../ui/PageHeader'
 import { OverlayScreen } from '../ui/OverlayScreen'
 
@@ -142,6 +143,8 @@ export function MiniGamesMenu({ crystals, onCrystalsChange, user, characterName,
       if (opts?.score) setAchievementProgress('miniGame:fishing:bestWeightG', opts.score)
     } else if (gameId === 'towerDefence') {
       setAchievementProgress('miniGame:towerDefence:bestScore', newBest)
+    } else if (gameId === 'regatta') {
+      setAchievementProgress('miniGame:regatta:bestScore', newBest)
     }
 
     // Publish to leaderboard if signed in
@@ -237,6 +240,9 @@ export function MiniGamesMenu({ crystals, onCrystalsChange, user, characterName,
   if (subScreen === 'marblerace') {
     return <MarbleRace onDone={(t) => handleGameDone('marblerace', t)} />
   }
+  if (subScreen === 'regatta') {
+    return <HarbourRegatta onDone={(t) => handleGameDone('regatta', t)} />
+  }
   if (subScreen === 'higherOrLower') {
     return <HigherOrLower onDone={(t) => handleGameDone('higherOrLower', t)} />
   }
@@ -295,7 +301,7 @@ export function MiniGamesMenu({ crystals, onCrystalsChange, user, characterName,
 
             {/* Game grid */}
             <div className="minigame-grid">
-              {(['marble', 'tileflip', 'crystalcatch', 'spinner', 'marblerace', 'higherOrLower', 'fruitMachine', 'videoPoker', 'fishing', 'towerDefence'] as MiniGameId[]).map(id => {
+              {(['marble', 'tileflip', 'crystalcatch', 'spinner', 'marblerace', 'regatta', 'higherOrLower', 'fruitMachine', 'videoPoker', 'fishing', 'towerDefence'] as MiniGameId[]).map(id => {
                 const cost = MINI_GAME_COSTS[id]
                 const locked = currentCrystals < cost
                 const best = loadLocalHighScore(id)
@@ -380,7 +386,7 @@ export function MiniGamesMenu({ crystals, onCrystalsChange, user, characterName,
 
             <div className="lb-controls u-col u-gap-3">
               <div className="lb-game-tabs">
-                {(['marble', 'tileflip', 'crystalcatch', 'spinner', 'marblerace', 'higherOrLower', 'fruitMachine', 'videoPoker', 'fishing', 'towerDefence'] as MiniGameId[]).map(id => (
+                {(['marble', 'tileflip', 'crystalcatch', 'spinner', 'marblerace', 'regatta', 'higherOrLower', 'fruitMachine', 'videoPoker', 'fishing', 'towerDefence'] as MiniGameId[]).map(id => (
                   <button
                     key={id}
                     className={`filter-btn${lbGame === id ? ' filter-btn--active' : ''}`}

--- a/web/src/data/economy.json
+++ b/web/src/data/economy.json
@@ -33,7 +33,8 @@
     "fruitMachine": 50,
     "videoPoker": 0,
     "fishing": 15,
-    "towerDefence": 50
+    "towerDefence": 50,
+    "regatta": 25
   },
   "ticketPrizes": [
     {

--- a/web/src/data/hub/millhaven/config.json
+++ b/web/src/data/hub/millhaven/config.json
@@ -2023,9 +2023,10 @@
       "ty": 33,
       "dialogue": [
         "One day Millhaven will host a proper boat regatta — skiffs racing the harbour buoys, crowds on the quay!",
-        "I'm still rigging the course and finding crews. Come back soon and you'll be able to race.",
+        "Rigging's done and the buoys are set — care to race a skiff?",
         "Mark my words: the Millhaven Regatta will be the finest sport on the coast."
-      ]
+      ],
+      "screen": "regatta"
     }
   ],
   "interiors": {

--- a/web/src/game/achievements.ts
+++ b/web/src/game/achievements.ts
@@ -2147,6 +2147,38 @@ export const ACHIEVEMENT_DEFS: AchievementDef[] = [
     tier: 2,
   },
 
+  // ─── Harbour Regatta Achievements ─────────────────────────
+  {
+    id: 'miniGame:regatta_first',
+    name: 'Cast Off',
+    description: 'Score at least 1 ticket in Harbour Regatta.',
+    category: 'misc',
+    progressKey: 'miniGame:regatta:bestScore',
+    target: 1,
+    reward: { type: 'crystals', crystals: 25 },
+    tier: 1,
+  },
+  {
+    id: 'miniGame:regatta_50',
+    name: 'Photo Finish at the Quay',
+    description: 'Score 50 tickets in a single Harbour Regatta.',
+    category: 'misc',
+    progressKey: 'miniGame:regatta:bestScore',
+    target: 50,
+    reward: { type: 'cards', count: 1 },
+    tier: 1,
+  },
+  {
+    id: 'miniGame:regatta_200',
+    name: 'Regatta Champion',
+    description: 'Score 200 tickets in a single Harbour Regatta.',
+    category: 'misc',
+    progressKey: 'miniGame:regatta:bestScore',
+    target: 200,
+    reward: { type: 'cards', count: 3 },
+    tier: 2,
+  },
+
   // ─── Higher or Lower Achievements ────────────────────────
   {
     id: 'miniGame:hol_first',

--- a/web/src/game/miniGames.ts
+++ b/web/src/game/miniGames.ts
@@ -20,7 +20,7 @@ export { getTickets as loadTickets, addTickets, spendTickets }
 
 // ── Game Costs ────────────────────────────────────────────────────────────────
 
-export type MiniGameId = 'marble' | 'tileflip' | 'crystalcatch' | 'spinner' | 'marblerace' | 'higherOrLower' | 'fruitMachine' | 'videoPoker' | 'fishing' | 'towerDefence'
+export type MiniGameId = 'marble' | 'tileflip' | 'crystalcatch' | 'spinner' | 'marblerace' | 'higherOrLower' | 'fruitMachine' | 'videoPoker' | 'fishing' | 'towerDefence' | 'regatta'
 
 export const MINI_GAME_COSTS = _MINI_GAME_COSTS as Record<MiniGameId, number>
 
@@ -35,6 +35,7 @@ export const MINI_GAME_LABELS: Record<MiniGameId, string> = {
   videoPoker:     'Video Poker',
   fishing:        'Fishing',
   towerDefence:   'Tower Defence',
+  regatta:        'Harbour Regatta',
 }
 
 export const MINI_GAME_DESCRIPTIONS: Record<MiniGameId, string> = {
@@ -48,6 +49,7 @@ export const MINI_GAME_DESCRIPTIONS: Record<MiniGameId, string> = {
   videoPoker:     'Jacks or Better. Hold your best cards, draw, and win big!',
   fishing:        'Cast your line and reel in a catch. Rare fish earn big tickets — and sometimes treasure!',
   towerDefence:   'Place your cards as towers and defend your base from 10 waves of enemies!',
+  regatta:        'Row your skiff round the harbour buoys! Keep a steady oar rhythm to stay on course.',
 }
 
 export const MINI_GAME_ICONS: Record<MiniGameId, string> = {
@@ -61,6 +63,7 @@ export const MINI_GAME_ICONS: Record<MiniGameId, string> = {
   videoPoker:     '♠',
   fishing:        '🎣',
   towerDefence:   '🏰',
+  regatta:        '⛵',
 }
 
 // ── Ticket Prizes ─────────────────────────────────────────────────────────────

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -12861,6 +12861,38 @@ html.light-mode .action-btn {
   white-space: nowrap;
 }
 
+/* ── Harbour Regatta ──────────────────────────────────────────────────────── */
+
+.regatta-buoy {
+  fill: #ff8800;
+  stroke: #3a2000;
+  stroke-width: 1.5;
+}
+
+.regatta-boat-hull {
+  stroke: #00000066;
+  stroke-width: 1.5;
+}
+
+.regatta-boat-hull--player {
+  stroke: var(--color-gold);
+  stroke-width: 2.5;
+}
+
+.regatta-boat-glow {
+  fill: none;
+  stroke-width: 2;
+  opacity: 0.35;
+}
+
+.regatta-oars {
+  margin: 10px 0 4px;
+}
+
+.regatta-oar-btn {
+  min-width: 130px;
+}
+
 /* ── Higher or Lower minigame ── */
 
 .hol-cards-row {


### PR DESCRIPTION
## Summary

- Closes #1750 — builds the Millhaven Harbour Regatta minigame and wires the existing `regatta-master` placeholder NPC into it
- Rather than a MarbleRace-style "pick a boat and watch," this is a **skill-based rowing minigame**: tap **LEFT OAR** / **RIGHT OAR** in a steady alternating rhythm to row straight. Favour one oar and the skiff veers that way; a steady cadence (not just correct alternation) maximizes forward speed
- Races against 3 AI-crewed skiffs down a harbour buoy course (open water → windward mark → spinnaker run → finish), rendered as inline SVG (no PixiJS, no new sprite assets)
- The stroke/veer/thrust physics live in a pure module (`HarbourRegatta.physics.ts`) driven by `requestAnimationFrame`, separate from rendering, with unit tests covering: alternation cancels drift, hammering one oar drifts and clamps, steady timing beats ragged timing, and repeated strokes give reduced thrust
- Wired into the existing arcade/ticket economy the same way `marblerace` is: new `MiniGameId` `'regatta'`, cost + labels + icon + achievements, `regatta-master`'s dialogue now offers `"screen": "regatta"` instead of "coming soon"

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run test` — full suite passes (379 tests, including 6 new physics unit tests)
- [x] `npm run build` — production build succeeds
- [x] Manually drove the `HarbourRegatta.stories.tsx` story in a headless browser: intro → racing → result phases all render correctly, steady L-R-L-R rowing keeps the skiff centred, hammering the right oar visibly veers it right, race completes and awards a ticket prize by finishing place, no console errors


---
_Generated by [Claude Code](https://claude.ai/code/session_01B8U5iQd17GU8wpq3hbnKTi)_