### PR TITLE
Add rhythm cue and adaptive difficulty to Harbour Regatta

### DIFF
--- a/web/src/components/minigames/HarbourRegatta.physics.test.ts
+++ b/web/src/components/minigames/HarbourRegatta.physics.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import {
-  createRowState, applyStroke, decayLateral,
-  TARGET_STROKE_MS, MAX_LATERAL,
+  createRowState, applyStroke, decayLateral, aiDifficultyMultiplier,
+  TARGET_STROKE_MS, MAX_LATERAL, AI_DIFFICULTY_EASY, AI_DIFFICULTY_HARD,
 } from './HarbourRegatta.physics'
 
 describe('Harbour Regatta physics', () => {
@@ -83,5 +83,39 @@ describe('Harbour Regatta physics', () => {
   it('decayLateral is a no-op for non-positive dt', () => {
     const state = applyStroke(createRowState(), 'left', 1000)
     expect(decayLateral(state, 0)).toEqual(state)
+  })
+
+  it('skillEma trends toward 1 over consecutive well-timed alternating strokes', () => {
+    let state = createRowState()
+    const startEma = state.skillEma
+    let now = 1000
+    const sides: Array<'left' | 'right'> = ['left', 'right', 'left', 'right', 'left', 'right', 'left', 'right']
+    for (const side of sides) {
+      state = applyStroke(state, side, now)
+      now += TARGET_STROKE_MS
+    }
+    expect(state.skillEma).toBeGreaterThan(startEma)
+    expect(state.skillEma).toBeGreaterThan(0.9)
+  })
+
+  it('skillEma trends downward over consistently mistimed alternating strokes', () => {
+    let state = createRowState()
+    const startEma = state.skillEma
+    let now = 1000
+    const sides: Array<'left' | 'right'> = ['left', 'right', 'left', 'right', 'left', 'right', 'left', 'right']
+    for (const side of sides) {
+      state = applyStroke(state, side, now)
+      now += 40 // way faster than TARGET_STROKE_MS, well outside tolerance
+    }
+    expect(state.skillEma).toBeLessThan(startEma)
+  })
+
+  it('aiDifficultyMultiplier interpolates between the easy and hard bounds', () => {
+    expect(aiDifficultyMultiplier(0)).toBeCloseTo(AI_DIFFICULTY_EASY)
+    expect(aiDifficultyMultiplier(1)).toBeCloseTo(AI_DIFFICULTY_HARD)
+    expect(aiDifficultyMultiplier(0.5)).toBeCloseTo((AI_DIFFICULTY_EASY + AI_DIFFICULTY_HARD) / 2)
+    // clamps out-of-range input
+    expect(aiDifficultyMultiplier(-1)).toBeCloseTo(AI_DIFFICULTY_EASY)
+    expect(aiDifficultyMultiplier(2)).toBeCloseTo(AI_DIFFICULTY_HARD)
   })
 })

--- a/web/src/components/minigames/HarbourRegatta.physics.ts
+++ b/web/src/components/minigames/HarbourRegatta.physics.ts
@@ -11,21 +11,23 @@ export interface RowState {
   progress: number            // distance rowed so far
   lastSide: OarSide | null
   lastTapAt: number | null    // ms timestamp of the previous stroke
+  skillEma: number            // 0..1 rolling average of recent alternating-stroke timing quality
 }
 
 export const COURSE_LENGTH      = 700    // progress units at the finish line
 export const MAX_LATERAL        = 60     // clamp before hitting the buoy line / bank
 export const TARGET_STROKE_MS   = 420    // ideal interval between alternating strokes
-export const STROKE_TOLERANCE_MS = 180   // timing window for full thrust
+export const STROKE_TOLERANCE_MS = 260   // timing window for full thrust
 export const MIN_TIMING_FACTOR  = 0.2    // ragged timing never drops thrust to zero
 export const BASE_THRUST        = 16     // progress gained per well-timed alternating stroke
 export const REPEAT_THRUST_FACTOR = 0.35 // thrust penalty for hammering the same oar
 export const VEER_STEP          = 14     // lateral push per stroke, signed by oar side
 export const BANK_PENALTY_FACTOR = 0.4   // thrust penalty when the clamp is hit
 export const DRAG_PER_MS        = 0.0016 // exponential decay pulling lateralOffset to 0
+export const SKILL_EMA_ALPHA    = 0.25   // smoothing factor for the rolling skill average
 
 export function createRowState(): RowState {
-  return { lateralOffset: 0, progress: 0, lastSide: null, lastTapAt: null }
+  return { lateralOffset: 0, progress: 0, lastSide: null, lastTapAt: null, skillEma: 0.5 }
 }
 
 // Apply one oar tap. Each side always pushes the skiff toward that side (left
@@ -39,6 +41,7 @@ export function applyStroke(state: RowState, side: OarSide, now: number): RowSta
   let lateralOffset = state.lateralOffset + veerDelta
 
   let thrust: number
+  let skillEma = state.skillEma
   if (isRepeat) {
     thrust = BASE_THRUST * REPEAT_THRUST_FACTOR
   } else {
@@ -46,6 +49,7 @@ export function applyStroke(state: RowState, side: OarSide, now: number): RowSta
     const timingError = Math.abs(interval - TARGET_STROKE_MS)
     const timingFactor = Math.max(MIN_TIMING_FACTOR, 1 - timingError / STROKE_TOLERANCE_MS)
     thrust = BASE_THRUST * timingFactor
+    skillEma = skillEma + (timingFactor - skillEma) * SKILL_EMA_ALPHA
   }
 
   let hitBank = false
@@ -58,6 +62,7 @@ export function applyStroke(state: RowState, side: OarSide, now: number): RowSta
     progress: state.progress + thrust,
     lastSide: side,
     lastTapAt: now,
+    skillEma,
   }
 }
 
@@ -68,16 +73,27 @@ export function decayLateral(state: RowState, dtMs: number): RowState {
   return { ...state, lateralOffset: state.lateralOffset * decay }
 }
 
-const AI_BASE_SPEED_PER_MS = 0.035 // tuned so a well-rowed player finishes around the same time
+const AI_BASE_SPEED_PER_MS = 0.030 // tuned so a well-rowed player finishes around the same time
 const AI_STALL_CHANCE_PER_SEC = 0.12
 const AI_SPEED_JITTER = 0.3 // +/- fraction of base speed per frame
 
+export const AI_DIFFICULTY_EASY = 0.85 // AI pace multiplier when the player is struggling with rhythm
+export const AI_DIFFICULTY_HARD = 1.15 // AI pace multiplier when the player is rowing near-perfectly
+
+// Maps the player's rolling rhythm quality (skillEma, 0..1) to an AI pace
+// multiplier: ease off on a struggling player, speed back up on a skilled one
+// so consistently perfect rowing doesn't trivialise the race.
+export function aiDifficultyMultiplier(skillEma: number): number {
+  const t = Math.max(0, Math.min(1, skillEma))
+  return AI_DIFFICULTY_EASY + (AI_DIFFICULTY_HARD - AI_DIFFICULTY_EASY) * t
+}
+
 // Advance an AI skiff's progress by dtMs, with light randomised pacing/stalls
 // echoing MarbleRace's obstacle-chance drama (not deterministic — not unit tested).
-export function advanceAiProgress(progress: number, dtMs: number): number {
+export function advanceAiProgress(progress: number, dtMs: number, speedMultiplier = 1): number {
   if (dtMs <= 0) return progress
   const stallChance = AI_STALL_CHANCE_PER_SEC * (dtMs / 1000)
   if (Math.random() < stallChance) return progress
   const jitter = 1 + (Math.random() * 2 - 1) * AI_SPEED_JITTER
-  return progress + AI_BASE_SPEED_PER_MS * dtMs * jitter
+  return progress + AI_BASE_SPEED_PER_MS * speedMultiplier * dtMs * jitter
 }

--- a/web/src/components/minigames/HarbourRegatta.tsx
+++ b/web/src/components/minigames/HarbourRegatta.tsx
@@ -5,9 +5,14 @@
 
 import React, { useState, useEffect, useRef, useCallback } from 'react'
 import {
-  createRowState, applyStroke, decayLateral, advanceAiProgress,
-  COURSE_LENGTH, type RowState, type OarSide,
+  createRowState, applyStroke, decayLateral, advanceAiProgress, aiDifficultyMultiplier,
+  COURSE_LENGTH, TARGET_STROKE_MS, STROKE_TOLERANCE_MS, type RowState, type OarSide,
 } from './HarbourRegatta.physics'
+
+function oppositeSide(side: OarSide | null): OarSide | null {
+  if (side === null) return null
+  return side === 'left' ? 'right' : 'left'
+}
 
 interface Props {
   onDone: (ticketsEarned: number) => void
@@ -21,6 +26,13 @@ const PLACE_LABELS = ['1st 🥇', '2nd 🥈', '3rd 🥉', '4th']
 
 const RENDER_INTERVAL_MS = 50
 const MAX_RACE_TIME_MS   = 60000
+
+// ── Rhythm cue ────────────────────────────────────────────────────────────────
+// The cue bar sweeps for the full window the scoring code cares about (up to
+// the "late" cutoff), with a marked "sweet spot" matching the tolerance band.
+const CUE_DURATION_MS     = TARGET_STROKE_MS + STROKE_TOLERANCE_MS
+const CUE_SWEET_START_PCT = ((TARGET_STROKE_MS - STROKE_TOLERANCE_MS) / CUE_DURATION_MS) * 100
+const CUE_SWEET_WIDTH_PCT = ((STROKE_TOLERANCE_MS * 2) / CUE_DURATION_MS) * 100
 
 // ── SVG layout ────────────────────────────────────────────────────────────────
 const SVG_W  = 380
@@ -43,6 +55,11 @@ interface Display {
   lateralOffset: number
 }
 
+interface Cue {
+  nextSide: OarSide | null  // which oar the player should tap next
+  tapAt: number | null      // ms timestamp of the stroke that set this cue
+}
+
 type Phase = 'intro' | 'racing' | 'result'
 
 export function HarbourRegatta({ onDone }: Props) {
@@ -50,6 +67,8 @@ export function HarbourRegatta({ onDone }: Props) {
   const [display, setDisplay] = useState<Display>({ progress: [0, 0, 0, 0], lateralOffset: 0 })
   const [finishOrder, setFinishOrder]     = useState<number[]>([])
   const [ticketsEarned, setTicketsEarned] = useState(0)
+  const [cue, setCue]           = useState<Cue>({ nextSide: null, tapAt: null })
+  const [cueActive, setCueActive] = useState(false)
 
   const rowStateRef    = useRef<RowState>(createRowState())
   const aiProgressRef  = useRef<number[]>([0, 0, 0])
@@ -69,13 +88,28 @@ export function HarbourRegatta({ onDone }: Props) {
     lastCommitRef.current = 0
     setDisplay({ progress: [0, 0, 0, 0], lateralOffset: 0 })
     setFinishOrder([])
+    setCue({ nextSide: null, tapAt: null })
     setPhase('racing')
   }
 
   const tapOar = useCallback((side: OarSide) => {
     if (finishedRef.current) return
-    rowStateRef.current = applyStroke(rowStateRef.current, side, performance.now())
+    const newState = applyStroke(rowStateRef.current, side, performance.now())
+    rowStateRef.current = newState
+    setCue({ nextSide: oppositeSide(newState.lastSide), tapAt: newState.lastTapAt })
   }, [])
+
+  // Drives the "tap now" glow: on within the scoring tolerance window around
+  // the ideal next-stroke time, off once that window passes.
+  useEffect(() => {
+    if (cue.tapAt === null || cue.nextSide === null) { setCueActive(false); return }
+    const readyInMs = Math.max(0, TARGET_STROKE_MS - STROKE_TOLERANCE_MS)
+    const lateInMs  = Math.max(0, TARGET_STROKE_MS + STROKE_TOLERANCE_MS)
+    setCueActive(false)
+    const readyTimer = setTimeout(() => setCueActive(true), readyInMs)
+    const lateTimer  = setTimeout(() => setCueActive(false), lateInMs)
+    return () => { clearTimeout(readyTimer); clearTimeout(lateTimer) }
+  }, [cue.tapAt, cue.nextSide])
 
   function finishRace(progresses: number[]) {
     finishedRef.current = true
@@ -99,8 +133,9 @@ export function HarbourRegatta({ onDone }: Props) {
       lastFrameRef.current = now
 
       rowStateRef.current = decayLateral(rowStateRef.current, dt)
+      const difficulty = aiDifficultyMultiplier(rowStateRef.current.skillEma)
       const ai = aiProgressRef.current
-      for (let i = 0; i < ai.length; i++) ai[i] = advanceAiProgress(ai[i], dt)
+      for (let i = 0; i < ai.length; i++) ai[i] = advanceAiProgress(ai[i], dt, difficulty)
 
       const progresses = [rowStateRef.current.progress, ai[0], ai[1], ai[2]]
       const timedOut = now - raceStartRef.current >= MAX_RACE_TIME_MS
@@ -144,6 +179,7 @@ export function HarbourRegatta({ onDone }: Props) {
         <p className="minigame-subtitle">
           Row your skiff round the harbour buoys! Tap LEFT and RIGHT oars in a
           steady alternating rhythm to go straight — favour one oar and you'll veer that way.
+          Watch the oar glow — tap it as the bar fills!
         </p>
 
         <div className="race-prize-table">
@@ -265,12 +301,29 @@ export function HarbourRegatta({ onDone }: Props) {
       {/* ── Oar controls ── */}
       {phase === 'racing' && (
         <div className="regatta-oars u-flex u-gap-6 u-just-c">
-          <button className="action-btn action-btn--large regatta-oar-btn" onClick={() => tapOar('left')}>
-            ⬅ LEFT OAR
-          </button>
-          <button className="action-btn action-btn--large regatta-oar-btn" onClick={() => tapOar('right')}>
-            RIGHT OAR ➡
-          </button>
+          {(['left', 'right'] as const).map(side => (
+            <div key={side} className="regatta-oar-col u-col u-items-c u-gap-2">
+              <button
+                className={`action-btn action-btn--large regatta-oar-btn${cueActive && cue.nextSide === side ? ' regatta-oar-btn--due' : ''}`}
+                onClick={() => tapOar(side)}
+              >
+                {side === 'left' ? '⬅ LEFT OAR' : 'RIGHT OAR ➡'}
+              </button>
+              <div className="regatta-cue-track">
+                <div
+                  className="regatta-cue-sweet"
+                  style={{ left: `${CUE_SWEET_START_PCT}%`, width: `${CUE_SWEET_WIDTH_PCT}%` }}
+                />
+                {cue.nextSide === side && cue.tapAt !== null && (
+                  <div
+                    key={cue.tapAt}
+                    className="regatta-cue-fill"
+                    style={{ animationDuration: `${CUE_DURATION_MS}ms` }}
+                  />
+                )}
+              </div>
+            </div>
+          ))}
         </div>
       )}
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -12893,6 +12893,52 @@ html.light-mode .action-btn {
   min-width: 130px;
 }
 
+.regatta-oar-btn--due {
+  animation: regatta-oar-due-pulse 0.4s ease-in-out infinite;
+}
+
+@keyframes regatta-oar-due-pulse {
+  0%, 100% { box-shadow: 0 0 6px rgba(255, 204, 0, 0.4); }
+  50%       { box-shadow: 0 0 16px rgba(255, 204, 0, 0.9); }
+}
+
+.regatta-oar-col {
+  width: 130px;
+}
+
+.regatta-cue-track {
+  position: relative;
+  width: 100%;
+  height: 6px;
+  background: #10101e;
+  border: 1px solid #2a2a5a;
+  overflow: hidden;
+}
+
+.regatta-cue-sweet {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  background: #ffffff1a;
+}
+
+.regatta-cue-fill {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 0%;
+  background: var(--color-gold);
+  animation-name: regatta-cue-sweep;
+  animation-timing-function: linear;
+  animation-fill-mode: forwards;
+}
+
+@keyframes regatta-cue-sweep {
+  from { width: 0%; }
+  to   { width: 100%; }
+}
+
 /* ── Higher or Lower minigame ── */
 
 .hol-cards-row {


### PR DESCRIPTION
## Summary

Follow-up to #1891 (Harbour Regatta minigame) based on player feedback: the oar rhythm was hard to follow with no visual feedback, and felt unforgiving against the AI pace.

- **Visual rhythm cue**: a filling bar appears under whichever oar should be tapped next, and the button glows gold once the tap is within the scoring tolerance window. The cue is driven by the same `TARGET_STROKE_MS`/`STROKE_TOLERANCE_MS` constants the physics use, so it teaches the actual timing rule rather than an arbitrary metronome.
- **Wider timing tolerance**: `STROKE_TOLERANCE_MS` 180 → 260, so near-miss taps still score well.
- **Slower AI baseline**: `AI_BASE_SPEED_PER_MS` 0.035 → 0.030.
- **Adaptive difficulty**: a new `skillEma` rolling average of the player's recent alternating-stroke timing quality drives an AI pace multiplier (`aiDifficultyMultiplier`, 0.85–1.15×) — the AI eases off if the player is struggling and speeds back up if they're rowing near-perfectly, so consistently great play doesn't trivialise the race.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run test` — full suite passes (382 tests, including 3 new physics unit tests for `skillEma` trending with stroke quality and `aiDifficultyMultiplier` bounds/interpolation)
- [x] `npm run build` — production build succeeds
- [x] Manually drove `HarbourRegatta.stories.tsx` in a headless browser: confirmed the cue bar fills and the correct oar glows gold right as the scoring tolerance window opens (~160ms after the previous stroke), no console errors


---
_Generated by [Claude Code](https://claude.ai/code/session_01B8U5iQd17GU8wpq3hbnKTi)_