### PR TITLE
Make Harbour Regatta AI boats row with the same stroke mechanic as the player

### DIFF
--- a/web/src/components/minigames/HarbourRegatta.physics.test.ts
+++ b/web/src/components/minigames/HarbourRegatta.physics.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import {
-  createRowState, applyStroke, decayLateral, aiDifficultyMultiplier,
+  createRowState, applyStroke, decayLateral, aiDifficultyMultiplier, createAiConfig,
   TARGET_STROKE_MS, MAX_LATERAL, AI_DIFFICULTY_EASY, AI_DIFFICULTY_HARD,
 } from './HarbourRegatta.physics'
 
@@ -117,5 +117,18 @@ describe('Harbour Regatta physics', () => {
     // clamps out-of-range input
     expect(aiDifficultyMultiplier(-1)).toBeCloseTo(AI_DIFFICULTY_EASY)
     expect(aiDifficultyMultiplier(2)).toBeCloseTo(AI_DIFFICULTY_HARD)
+  })
+
+  it('createAiConfig samples timingStdDevMs and mistakeChance within expected ranges, varying per call', () => {
+    const configs = Array.from({ length: 20 }, () => createAiConfig())
+    for (const c of configs) {
+      expect(c.timingStdDevMs).toBeGreaterThanOrEqual(60)
+      expect(c.timingStdDevMs).toBeLessThanOrEqual(220)
+      expect(c.mistakeChance).toBeGreaterThanOrEqual(0.05)
+      expect(c.mistakeChance).toBeLessThanOrEqual(0.15)
+    }
+    // Extremely unlikely all 20 samples land on the exact same value if truly randomised.
+    const distinctStdDevs = new Set(configs.map(c => c.timingStdDevMs)).size
+    expect(distinctStdDevs).toBeGreaterThan(1)
   })
 })

--- a/web/src/components/minigames/HarbourRegatta.physics.ts
+++ b/web/src/components/minigames/HarbourRegatta.physics.ts
@@ -73,27 +73,64 @@ export function decayLateral(state: RowState, dtMs: number): RowState {
   return { ...state, lateralOffset: state.lateralOffset * decay }
 }
 
-const AI_BASE_SPEED_PER_MS = 0.030 // tuned so a well-rowed player finishes around the same time
-const AI_STALL_CHANCE_PER_SEC = 0.12
-const AI_SPEED_JITTER = 0.3 // +/- fraction of base speed per frame
+export const AI_DIFFICULTY_EASY = 0.85 // sharpens AI timing less when the player is struggling
+export const AI_DIFFICULTY_HARD = 1.15 // sharpens AI timing more when the player is rowing near-perfectly
 
-export const AI_DIFFICULTY_EASY = 0.85 // AI pace multiplier when the player is struggling with rhythm
-export const AI_DIFFICULTY_HARD = 1.15 // AI pace multiplier when the player is rowing near-perfectly
-
-// Maps the player's rolling rhythm quality (skillEma, 0..1) to an AI pace
-// multiplier: ease off on a struggling player, speed back up on a skilled one
-// so consistently perfect rowing doesn't trivialise the race.
+// Maps the player's rolling rhythm quality (skillEma, 0..1) to an AI difficulty
+// multiplier: ease off on a struggling player, tighten up on a skilled one so
+// consistently perfect rowing doesn't trivialise the race.
 export function aiDifficultyMultiplier(skillEma: number): number {
   const t = Math.max(0, Math.min(1, skillEma))
   return AI_DIFFICULTY_EASY + (AI_DIFFICULTY_HARD - AI_DIFFICULTY_EASY) * t
 }
 
-// Advance an AI skiff's progress by dtMs, with light randomised pacing/stalls
-// echoing MarbleRace's obstacle-chance drama (not deterministic — not unit tested).
-export function advanceAiProgress(progress: number, dtMs: number, speedMultiplier = 1): number {
-  if (dtMs <= 0) return progress
-  const stallChance = AI_STALL_CHANCE_PER_SEC * (dtMs / 1000)
-  if (Math.random() < stallChance) return progress
-  const jitter = 1 + (Math.random() * 2 - 1) * AI_SPEED_JITTER
-  return progress + AI_BASE_SPEED_PER_MS * speedMultiplier * dtMs * jitter
+export interface AiConfig {
+  timingStdDevMs: number // this boat's natural rhythm sloppiness
+  mistakeChance: number  // per-stroke chance of fumbling (repeating the same oar)
+}
+
+const AI_TIMING_STDDEV_MIN_MS = 60
+const AI_TIMING_STDDEV_MAX_MS = 220
+const AI_MISTAKE_CHANCE_MIN = 0.05
+const AI_MISTAKE_CHANCE_MAX = 0.15
+
+// Randomised once per race per AI boat, so each rival keeps a distinct pace
+// and consistency for the whole race instead of everyone converging on the
+// same average (which is what a per-frame-random continuous speed model did).
+export function createAiConfig(): AiConfig {
+  return {
+    timingStdDevMs: AI_TIMING_STDDEV_MIN_MS + Math.random() * (AI_TIMING_STDDEV_MAX_MS - AI_TIMING_STDDEV_MIN_MS),
+    mistakeChance: AI_MISTAKE_CHANCE_MIN + Math.random() * (AI_MISTAKE_CHANCE_MAX - AI_MISTAKE_CHANCE_MIN),
+  }
+}
+
+// Cheap roughly-gaussian noise via the sum of two uniforms (no new dependency).
+function sampledTimingErrorMs(stdDevMs: number): number {
+  const u1 = Math.random() - 0.5
+  const u2 = Math.random() - 0.5
+  return (u1 + u2) * stdDevMs
+}
+
+// Simulate one AI oar stroke through the exact same scoring function the
+// player's own taps go through, so AI pace/veer/lateral clamping all come
+// from one code path. The oar side alternates like a real rower, occasionally
+// repeating (a "crab") per `config.mistakeChance`; the next stroke is
+// scheduled around TARGET_STROKE_MS with per-boat timing noise, tightened by
+// `difficultyMultiplier` as the player's own rhythm improves.
+// Non-deterministic — not unit tested, same convention as the model it replaces.
+export function simulateAiStroke(
+  state: RowState, config: AiConfig, now: number, difficultyMultiplier: number,
+): { state: RowState; nextTapAt: number } {
+  const fumble = state.lastSide !== null && Math.random() < config.mistakeChance
+  const side: OarSide = fumble
+    ? state.lastSide as OarSide
+    : (state.lastSide === 'left' ? 'right' : state.lastSide === 'right' ? 'left' : (Math.random() < 0.5 ? 'left' : 'right'))
+
+  const nextState = applyStroke(state, side, now)
+
+  const effectiveStdDev = config.timingStdDevMs / Math.max(0.5, difficultyMultiplier)
+  const interval = TARGET_STROKE_MS + sampledTimingErrorMs(effectiveStdDev)
+  const nextTapAt = now + Math.max(120, interval)
+
+  return { state: nextState, nextTapAt }
 }

--- a/web/src/components/minigames/HarbourRegatta.tsx
+++ b/web/src/components/minigames/HarbourRegatta.tsx
@@ -5,8 +5,10 @@
 
 import React, { useState, useEffect, useRef, useCallback } from 'react'
 import {
-  createRowState, applyStroke, decayLateral, advanceAiProgress, aiDifficultyMultiplier,
-  COURSE_LENGTH, TARGET_STROKE_MS, STROKE_TOLERANCE_MS, type RowState, type OarSide,
+  createRowState, applyStroke, decayLateral, aiDifficultyMultiplier,
+  createAiConfig, simulateAiStroke,
+  COURSE_LENGTH, TARGET_STROKE_MS, STROKE_TOLERANCE_MS,
+  type RowState, type OarSide, type AiConfig,
 } from './HarbourRegatta.physics'
 
 function oppositeSide(side: OarSide | null): OarSide | null {
@@ -52,7 +54,7 @@ function progressToY(progress: number): number {
 
 interface Display {
   progress: number[]        // [player, ai1, ai2, ai3]
-  lateralOffset: number
+  lateralOffsets: number[]  // [player, ai1, ai2, ai3]
 }
 
 interface Cue {
@@ -64,14 +66,16 @@ type Phase = 'intro' | 'racing' | 'result'
 
 export function HarbourRegatta({ onDone }: Props) {
   const [phase, setPhase]     = useState<Phase>('intro')
-  const [display, setDisplay] = useState<Display>({ progress: [0, 0, 0, 0], lateralOffset: 0 })
+  const [display, setDisplay] = useState<Display>({ progress: [0, 0, 0, 0], lateralOffsets: [0, 0, 0, 0] })
   const [finishOrder, setFinishOrder]     = useState<number[]>([])
   const [ticketsEarned, setTicketsEarned] = useState(0)
   const [cue, setCue]           = useState<Cue>({ nextSide: null, tapAt: null })
   const [cueActive, setCueActive] = useState(false)
 
-  const rowStateRef    = useRef<RowState>(createRowState())
-  const aiProgressRef  = useRef<number[]>([0, 0, 0])
+  const rowStateRef      = useRef<RowState>(createRowState())
+  const aiStatesRef      = useRef<RowState[]>([createRowState(), createRowState(), createRowState()])
+  const aiConfigsRef     = useRef<AiConfig[]>([createAiConfig(), createAiConfig(), createAiConfig()])
+  const aiNextTapAtRef   = useRef<number[]>([0, 0, 0])
   const finishedRef    = useRef(false)
   const rafRef         = useRef<number | null>(null)
   const lastFrameRef   = useRef(0)
@@ -79,14 +83,17 @@ export function HarbourRegatta({ onDone }: Props) {
   const lastCommitRef  = useRef(0)
 
   function startRace() {
-    rowStateRef.current   = createRowState()
-    aiProgressRef.current = [0, 0, 0]
-    finishedRef.current   = false
+    rowStateRef.current  = createRowState()
+    aiStatesRef.current  = [createRowState(), createRowState(), createRowState()]
+    aiConfigsRef.current = [createAiConfig(), createAiConfig(), createAiConfig()]
+    finishedRef.current  = false
     const now = performance.now()
+    // Stagger each AI's first stroke so all 3 don't fire on the same frame.
+    aiNextTapAtRef.current = aiConfigsRef.current.map(() => now + Math.random() * 300)
     raceStartRef.current  = now
     lastFrameRef.current  = now
     lastCommitRef.current = 0
-    setDisplay({ progress: [0, 0, 0, 0], lateralOffset: 0 })
+    setDisplay({ progress: [0, 0, 0, 0], lateralOffsets: [0, 0, 0, 0] })
     setFinishOrder([])
     setCue({ nextSide: null, tapAt: null })
     setPhase('racing')
@@ -111,7 +118,7 @@ export function HarbourRegatta({ onDone }: Props) {
     return () => { clearTimeout(readyTimer); clearTimeout(lateTimer) }
   }, [cue.tapAt, cue.nextSide])
 
-  function finishRace(progresses: number[]) {
+  function finishRace(progresses: number[], lateralOffsets: number[]) {
     finishedRef.current = true
     const order = [0, 1, 2, 3].sort((a, b) => progresses[b] - progresses[a])
     const place = order.indexOf(PLAYER_IDX)
@@ -120,7 +127,7 @@ export function HarbourRegatta({ onDone }: Props) {
     setTicketsEarned(tickets)
     setDisplay({
       progress: progresses.map(p => Math.min(p, COURSE_LENGTH)),
-      lateralOffset: rowStateRef.current.lateralOffset,
+      lateralOffsets,
     })
     setPhase('result')
   }
@@ -134,14 +141,25 @@ export function HarbourRegatta({ onDone }: Props) {
 
       rowStateRef.current = decayLateral(rowStateRef.current, dt)
       const difficulty = aiDifficultyMultiplier(rowStateRef.current.skillEma)
-      const ai = aiProgressRef.current
-      for (let i = 0; i < ai.length; i++) ai[i] = advanceAiProgress(ai[i], dt, difficulty)
 
-      const progresses = [rowStateRef.current.progress, ai[0], ai[1], ai[2]]
+      const aiStates = aiStatesRef.current
+      const aiConfigs = aiConfigsRef.current
+      const aiNextTapAt = aiNextTapAtRef.current
+      for (let i = 0; i < aiStates.length; i++) {
+        aiStates[i] = decayLateral(aiStates[i], dt)
+        if (now >= aiNextTapAt[i]) {
+          const { state, nextTapAt } = simulateAiStroke(aiStates[i], aiConfigs[i], now, difficulty)
+          aiStates[i] = state
+          aiNextTapAt[i] = nextTapAt
+        }
+      }
+
+      const progresses = [rowStateRef.current.progress, ...aiStates.map(s => s.progress)]
+      const lateralOffsets = [rowStateRef.current.lateralOffset, ...aiStates.map(s => s.lateralOffset)]
       const timedOut = now - raceStartRef.current >= MAX_RACE_TIME_MS
 
       if (!finishedRef.current && (progresses.some(p => p >= COURSE_LENGTH) || timedOut)) {
-        finishRace(progresses)
+        finishRace(progresses, lateralOffsets)
         return
       }
 
@@ -149,7 +167,7 @@ export function HarbourRegatta({ onDone }: Props) {
         lastCommitRef.current = now
         setDisplay({
           progress: progresses.map(p => Math.min(p, COURSE_LENGTH)),
-          lateralOffset: rowStateRef.current.lateralOffset,
+          lateralOffsets,
         })
       }
       rafRef.current = requestAnimationFrame(frame)
@@ -275,7 +293,7 @@ export function HarbourRegatta({ onDone }: Props) {
 
           {/* ── Skiffs ── */}
           {LANE_XS.map((lx, i) => {
-            const x = lx + (i === PLAYER_IDX ? display.lateralOffset * LATERAL_PX_PER_UNIT : 0)
+            const x = lx + display.lateralOffsets[i] * LATERAL_PX_PER_UNIT
             const y = progressToY(display.progress[i])
             return (
               <g


### PR DESCRIPTION
## Summary

Follow-up to #1892 based on player feedback: all 3 AI skiffs were crossing the finish line at nearly the same time, which didn't look like they were actually "rowing" the way the player does.

**Root cause**: AI progress came from `advanceAiProgress()`, a smooth continuous-speed function with small independent per-frame jitter/stall chance. Over a ~16s race at 60fps, that per-frame noise averages out (law of large numbers), so all 3 boats converged on nearly the same total progress regardless of their random seed.

**Fix**: replaced the continuous model with a per-boat discrete stroke simulation:

- Each AI boat now takes oar strokes through the *exact same* `applyStroke()` function the player's own taps go through — same thrust/veer/lateral-clamp scoring, no separate formula.
- Each AI gets a randomized "personality" once per race (`createAiConfig()`: a timing-consistency spread + a per-stroke chance to fumble/repeat an oar) that persists for the whole race, so paces diverge instead of averaging out.
- AI boats now also get a real `lateralOffset` from the same mechanic, so they visibly wobble/veer off their lane centreline like the player's boat does — no AI buttons are rendered, this is purely an internal simulation change plus applying the resulting offset to their rendered position.
- The existing adaptive-difficulty concept from #1892 (`aiDifficultyMultiplier`/`skillEma`) carries over: it now tightens or loosens each AI's timing-error spread instead of scaling a flat speed number.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run test` — full suite passes (383 tests, including a new `createAiConfig` bounds/randomization test)
- [x] `npm run build` — production build succeeds
- [x] Manually drove `HarbourRegatta.stories.tsx` in a headless browser, sampling all 4 boats' positions over ~8s of racing: the 3 AI boats show clearly divergent total progress (157px / 163px / 194px travelled) with uneven, bursty per-step deltas — a large change from the old model where they'd converge to nearly identical totals. Also confirmed visible lateral wobble on the AI boats in screenshots. No console errors.


---
_Generated by [Claude Code](https://claude.ai/code/session_01B8U5iQd17GU8wpq3hbnKTi)_