### PR TITLE
Hub secrets: appleford — author secrets + lore notes

### DIFF
--- a/web/src/data/hub/appleford/config.json
+++ b/web/src/data/hub/appleford/config.json
@@ -2221,6 +2221,94 @@
       "building": "market-barn",
       "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 2 }],
       "reactions": [{ "type": "buy", "slotIndex": 2 }]
+    },
+    {
+      "id": "appleford-secret-old-boundary-stone",
+      "tx": 7,
+      "ty": 12,
+      "reactions": [
+        {
+          "type": "dialogue",
+          "text": "Half-hidden in the grass between the cider house and the chapel, a mossy boundary stone bears a faint carving."
+        },
+        {
+          "type": "giveItem",
+          "collectible": {
+            "id": "appleford-boundary-marker",
+            "name": "Mossy Boundary Stone",
+            "icon": "🪨",
+            "desc": "A worn stone marker, half-swallowed by moss.",
+            "lore": "The carving shows a small arrow pointing into the gap between the buildings — someone wanted this spot remembered."
+          },
+          "message": "You found an old boundary marker! Something nearby might be worth a second look."
+        }
+      ]
+    },
+    {
+      "id": "appleford-hidden-nook-cache",
+      "tx": 10,
+      "ty": 10,
+      "reactions": [
+        {
+          "type": "dialogue",
+          "text": "Tucked in the gap the old stone pointed to, a small chest sits half-buried."
+        },
+        {
+          "type": "giveItem",
+          "collectible": {
+            "id": "appleford-hollow-cache",
+            "name": "Forgotten Harvest Tin",
+            "icon": "📦",
+            "desc": "A rusted tin, wedged between the cider house and the chapel for who knows how long.",
+            "lore": "Inside: a handful of old coins and a note reading 'For the next dry spell — B.' Bess never mentioned burying anything."
+          },
+          "message": "You found a forgotten stash!"
+        }
+      ]
+    },
+    {
+      "id": "appleford-secret-market-ledger",
+      "tx": 37,
+      "ty": 22,
+      "reactions": [
+        {
+          "type": "dialogue",
+          "text": "A torn page flutters against a fence post at the market yard's edge."
+        },
+        {
+          "type": "giveItem",
+          "collectible": {
+            "id": "appleford-ledger-page",
+            "name": "Torn Ledger Page",
+            "icon": "📜",
+            "desc": "A single page torn from a trader's account book.",
+            "lore": "Half the entries are crossed out and marked 'toll road — LOST'. Someone's been keeping track of what the bandits take."
+          },
+          "message": "You found a torn page from someone's ledger!"
+        }
+      ]
+    },
+    {
+      "id": "appleford-secret-pond-frog-charm",
+      "tx": 2,
+      "ty": 24,
+      "reactions": [
+        {
+          "type": "dialogue",
+          "text": "Something small and shiny is caught in the reeds at the pond's edge."
+        },
+        {
+          "type": "giveItem",
+          "collectible": {
+            "id": "appleford-frog-charm",
+            "name": "Little Frog Charm",
+            "icon": "🐸",
+            "desc": "A tiny carved charm shaped like a frog, worn smooth.",
+            "lore": "A child's trinket, most likely — though the local frogs seem oddly fond of sitting near where it was dropped."
+          },
+          "message": "You found a tiny charm hidden in the reeds!"
+        }
+      ]
     }
   ],
   "festivalDecor": [

--- a/web/src/data/hub/appleford/questDefs.json
+++ b/web/src/data/hub/appleford/questDefs.json
@@ -752,7 +752,25 @@
       "questId": "appleford-harvest-blessing"
     }
   ],
-  "blockedPaths": [],
+  "blockedPaths": [
+    {
+      "id": "appleford-hidden-nook",
+      "blockedTiles": [[10, 10]],
+      "unlockedByInteractable": "appleford-secret-old-boundary-stone",
+      "blocked": {
+        "decor": [
+          { "tx": 10, "ty": 10, "tileId": "darkBush" }
+        ],
+        "npcs": []
+      },
+      "cleared": {
+        "decor": [
+          { "tx": 10, "ty": 10, "tileId": "chest" }
+        ],
+        "npcs": []
+      }
+    }
+  ],
   "relationshipDialogue": {
     "cooper-wend": {
       "rival": {


### PR DESCRIPTION
## Summary

Applies the secret/dig-spot pattern established in PR #1832 (Ravenwatch) to appleford, per #1833.

- 3 secret interactables in `web/src/data/hub/appleford/config.json` — no owned `decor`, no `indicator`, each with a `dialogue` reaction for discovery flavor and a `giveItem` reaction granting a themed collectible with `lore` text:
  - `appleford-secret-old-boundary-stone` (7,12) — a mossy marker in the gap between the cider house and chapel.
  - `appleford-secret-market-ledger` (37,22) — a torn ledger page at the market yard's edge.
  - `appleford-secret-pond-frog-charm` (2,24) — a charm caught in the reeds at the pond's edge.
- One hidden-area reveal: a `blockedPaths` entry (`appleford-hidden-nook`) in `web/src/data/hub/appleford/questDefs.json`, gated on `unlockedByInteractable: "appleford-secret-old-boundary-stone"` instead of a quest — finding the boundary stone reveals a small hollow (bush → chest) between the same two buildings, with a companion `giveItem` interactable (`appleford-hidden-nook-cache`) on the revealed tile.

All picked tiles were cross-checked against existing `buildings`, `streets`, `pondTiles`, `exteriorDecor`, `npcs`, `animals`, `interactables`, and `pickupItems` entries in the file to avoid collisions (no automated collision-audit tool exists, per `docs/hubworld.md`).

Closes #1833.

## Test plan

- [x] `cd web && npx tsc --noEmit` — passes
- [x] `cd web && npm run test` — all 383 tests pass (37 files); the loader tests parse every `config.json`/`questDefs.json`, including these changes
- [x] `cd web && npm run build` — passes
- [x] Verified via a small script driving the real `hubWorldFactory`/loader pipeline (not just tests) that all 4 interactables parse with a 1×1 invisible hit area and that the `blockedPaths` entry resolves `darkBush`/`chest` tile IDs correctly and reads `unlockedByInteractable` as expected


---
_Generated by [Claude Code](https://claude.ai/code/session_01FyBT2YntXqaKDymc5mPEQ8)_