### PR TITLE
Hub secrets: capitalcity — author secrets + lore notes

### DIFF
--- a/web/src/data/hub/capitalcity/config.json
+++ b/web/src/data/hub/capitalcity/config.json
@@ -3957,6 +3957,94 @@
       "building": "tailor",
       "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 1 }],
       "reactions": [{ "type": "buy", "slotIndex": 1 }]
+    },
+    {
+      "id": "capitalcity-secret-temple-inscription",
+      "tx": 26,
+      "ty": 22,
+      "reactions": [
+        {
+          "type": "dialogue",
+          "text": "A faint inscription is carved into the stone between the cathedral and the library, half-worn by time."
+        },
+        {
+          "type": "giveItem",
+          "collectible": {
+            "id": "capitalcity-relic-shard",
+            "name": "Chipped Relic Shard",
+            "icon": "🪨",
+            "desc": "A fragment of carved stone, clearly once part of something larger.",
+            "lore": "High Priest Aldwin would recognize this — he's spoken of relics scattered in the troubles. This looks like it belongs to one of them. Perhaps there's more nearby."
+          },
+          "message": "You found a chipped relic shard! Something in the plaza might be worth a second look."
+        }
+      ]
+    },
+    {
+      "id": "capitalcity-secret-market-coin",
+      "tx": 43,
+      "ty": 13,
+      "reactions": [
+        {
+          "type": "dialogue",
+          "text": "Wedged in the gap between the market hall and the bakery, a coin glints in the dirt."
+        },
+        {
+          "type": "giveItem",
+          "collectible": {
+            "id": "capitalcity-lost-coin",
+            "name": "Tarnished Crown Coin",
+            "icon": "🪙",
+            "desc": "An old coin, its face worn nearly smooth.",
+            "lore": "Matron Goldie would say it fell from someone's purse on market day — and that whoever dropped it never came back for it."
+          },
+          "message": "You found a tarnished old coin!"
+        }
+      ]
+    },
+    {
+      "id": "capitalcity-secret-riverside-hook",
+      "tx": 21,
+      "ty": 79,
+      "reactions": [
+        {
+          "type": "dialogue",
+          "text": "Something metal glints beneath the reeds at the river's edge."
+        },
+        {
+          "type": "giveItem",
+          "collectible": {
+            "id": "capitalcity-bent-hook",
+            "name": "Bent Fishing Hook",
+            "icon": "🎣",
+            "desc": "An old fishing hook, bent nearly straight.",
+            "lore": "Angler Marsh would wince to see this — a hook lost is a fish story waiting to be told."
+          },
+          "message": "You found an old fishing hook caught in the reeds!"
+        }
+      ]
+    },
+    {
+      "id": "capitalcity-hidden-plaza-cache-loot",
+      "tx": 33,
+      "ty": 51,
+      "reactions": [
+        {
+          "type": "dialogue",
+          "text": "Tucked beneath the garden path where the shard pointed, a small chest sits half-buried in the dirt."
+        },
+        {
+          "type": "giveItem",
+          "collectible": {
+            "id": "capitalcity-relic-casket",
+            "name": "Relic Casket",
+            "icon": "📦",
+            "desc": "A small stone casket, sealed with old wax.",
+            "lore": "Inside: a fragment of parchment reading 'Return to the Cathedral when whole.' Aldwin will want to see this."
+          },
+          "message": "You found a hidden relic casket!"
+        }
+      ]
     }
   ],
   "ambientNpcSprites": [

--- a/web/src/data/hub/capitalcity/questDefs.json
+++ b/web/src/data/hub/capitalcity/questDefs.json
@@ -1800,7 +1800,25 @@
       "questId": "crownhaven-feast"
     }
   ],
-  "blockedPaths": [],
+  "blockedPaths": [
+    {
+      "id": "capitalcity-hidden-plaza-cache",
+      "blockedTiles": [[33, 51]],
+      "unlockedByInteractable": "capitalcity-secret-temple-inscription",
+      "blocked": {
+        "decor": [
+          { "tx": 33, "ty": 51, "tileId": "darkBush" }
+        ],
+        "npcs": []
+      },
+      "cleared": {
+        "decor": [
+          { "tx": 33, "ty": 51, "tileId": "chest" }
+        ],
+        "npcs": []
+      }
+    }
+  ],
   "relationshipDialogue": {
     "banker": {
       "rival": {


### PR DESCRIPTION
## Summary

Applies the secret/dig-spot pattern established in PR #1832 (Ravenwatch) and PR #1894 (Appleford) to capitalcity (in-game town "Crownhaven"), per #1834.

- 3 secret interactables in `web/src/data/hub/capitalcity/config.json` — no owned `decor`, no `indicator`, each with a `dialogue` reaction for discovery flavor and a `giveItem` reaction granting a themed collectible with `lore` text:
  - `capitalcity-secret-temple-inscription` (26,22) — a relic-shard clue between the cathedral and library, tying into High Priest Aldwin's dialogue about relics scattered in "the troubles."
  - `capitalcity-secret-market-coin` (43,13) — a lost coin between the market hall and bakery.
  - `capitalcity-secret-riverside-hook` (21,79) — a bent fishing hook at the riverside pond's edge.
- One hidden-area reveal: a `blockedPaths` entry (`capitalcity-hidden-plaza-cache`) in `web/src/data/hub/capitalcity/questDefs.json`, gated on `unlockedByInteractable: "capitalcity-secret-temple-inscription"` — finding the relic shard reveals a hidden cache in the coronation plaza's garden path (bush → chest), with a companion `giveItem` interactable (`capitalcity-hidden-plaza-cache-loot`) on the revealed tile continuing the relic thread.

All picked tiles were cross-checked against every existing `buildings`, `streets`/`streets.tile`, `pondTiles`, `exteriorDecor` (including multi-tile `bundleID` footprints like the plaza fountains/statues), `npcs`, `interactables`, and `pickupItems` entry in the file to avoid collisions (no automated collision-audit tool exists, per `docs/hubworld.md`). The blocked tile (33,51) sits inside the 58-tile-wide plaza path rect, so blocking it doesn't sever the only route — mirroring how both reference examples picked wide bands rather than single-tile chokepoints.

Closes #1834.

## Test plan

- [x] `cd web && npx tsc --noEmit` — passes
- [x] `cd web && npm run test` — all 383 tests pass (37 files); the loader tests parse every `config.json`/`questDefs.json`, including these changes
- [x] `cd web && npm run build` — passes
- [x] Verified via a small script driving the real `hubWorldFactory`/loader pipeline (not just tests) that all 4 interactables parse with a 1×1 invisible hit area and that the `blockedPaths` entry resolves `darkBush`/`chest` tile IDs correctly and reads `unlockedByInteractable` as expected


---
_Generated by [Claude Code](https://claude.ai/code/session_01FyBT2YntXqaKDymc5mPEQ8)_