### PR TITLE
Hub secrets: gearford — author secrets + lore notes

### DIFF
--- a/web/src/data/hub/gearford/config.json
+++ b/web/src/data/hub/gearford/config.json
@@ -3633,6 +3633,72 @@
           "message": "You found a pressed flower!"
         }
       ]
+    },
+    {
+      "id": "gearford-secret-forge-mark",
+      "tx": 21,
+      "ty": 11,
+      "reactions": [
+        {
+          "type": "dialogue",
+          "text": "Scratched into a support beam between the coal yard and the machine workshop, a foreman's mark catches the light."
+        },
+        {
+          "type": "giveItem",
+          "collectible": {
+            "id": "gearford-forge-mark-token",
+            "name": "Foreman's Forge-Mark",
+            "icon": "⚙️",
+            "desc": "A small iron token stamped with a foreman's personal mark.",
+            "lore": "Engineer Vela would know this mark — every foreman stamps their own work, and this one's older than anyone currently on shift. Might be worth checking what else carries the same mark."
+          },
+          "message": "You found an old forge-mark token! Something else nearby might carry the same stamp."
+        }
+      ]
+    },
+    {
+      "id": "gearford-secret-miners-logbook",
+      "tx": 9,
+      "ty": 20,
+      "reactions": [
+        {
+          "type": "dialogue",
+          "text": "Half-buried near the worker rows, a scrap of a logbook page flutters in the draft from the mine."
+        },
+        {
+          "type": "giveItem",
+          "collectible": {
+            "id": "gearford-logbook-page",
+            "name": "Torn Logbook Page",
+            "icon": "📓",
+            "desc": "A single page torn from a miner's shift logbook.",
+            "lore": "The handwriting's cramped and the ink's smudged with coal dust, but the entry's clear enough: 'Struck something odd in tunnel four. Told Dask. He didn't believe me either.'"
+          },
+          "message": "You found a torn page from a miner's logbook!"
+        }
+      ]
+    },
+    {
+      "id": "gearford-hidden-works-cache-loot",
+      "tx": 23,
+      "ty": 12,
+      "reactions": [
+        {
+          "type": "dialogue",
+          "text": "Behind the fallen timber prop the mark pointed to, a small strongbox sits wedged against the wall."
+        },
+        {
+          "type": "giveItem",
+          "collectible": {
+            "id": "gearford-strongbox-find",
+            "name": "Foreman's Strongbox",
+            "icon": "📦",
+            "desc": "A dented iron strongbox, foreman-marked like the token that led here.",
+            "lore": "Inside: a handful of crystals and a note in the same cramped hand as the logbook page — 'For whoever finds this before the foreman does. — D.'"
+          },
+          "message": "You found a hidden strongbox!"
+        }
+      ]
     }
   ]
 }

--- a/web/src/data/hub/gearford/questDefs.json
+++ b/web/src/data/hub/gearford/questDefs.json
@@ -770,5 +770,23 @@
       "questId": "gearford-forge-the-key"
     }
   ],
-  "blockedPaths": []
+  "blockedPaths": [
+    {
+      "id": "gearford-hidden-works-cache",
+      "blockedTiles": [[23, 12]],
+      "unlockedByInteractable": "gearford-secret-forge-mark",
+      "blocked": {
+        "decor": [
+          { "tx": 23, "ty": 12, "tileId": "logPile" }
+        ],
+        "npcs": []
+      },
+      "cleared": {
+        "decor": [
+          { "tx": 23, "ty": 12, "tileId": "chest" }
+        ],
+        "npcs": []
+      }
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Applies the secret/dig-spot pattern established in PR #1832 (Ravenwatch), PR #1894 (Appleford), and PR #1895 (Capitalcity) to gearford, per #1836.

Gearford already had one secret (`gearford-secret-pressed-flower` at 19,13) that hides a favorite-gift hub-item, but no lore-note style secrets. This PR adds two:

- `gearford-secret-forge-mark` (21,11) — a foreman's forge-mark token in the yard gap between the coal yard store and machine workshop.
- `gearford-secret-miners-logbook` (9,20) — a torn logbook page near the worker rows, referencing a miner who reported something odd in tunnel four to "Dask" (Foreman Dask, an existing NPC).

Plus one hidden-area reveal: a `blockedPaths` entry (`gearford-hidden-works-cache`) in `web/src/data/hub/gearford/questDefs.json`, gated on `unlockedByInteractable: "gearford-secret-forge-mark"` — finding the forge-mark reveals a hidden strongbox behind a fallen timber prop (`logPile` → `chest`, fitting the industrial setting better than the bush/chest swap used in the grassier towns), with a companion `giveItem` interactable (`gearford-hidden-works-cache-loot`) whose note is signed "D." — tying back to the same Dask named in the logbook page.

All picked tiles were cross-checked against every existing `buildings`, `streets`, `exteriorDecor`, `npcs`, `animals`, `interactables` (including the existing pressed-flower secret), and `pickupItems` entry to avoid collisions. The blocked tile (23,12) sits inside a 42-tile-wide street rect, so blocking it doesn't sever the only route.

Closes #1836.

## Test plan

- [x] `cd web && npx tsc --noEmit` — passes
- [x] `cd web && npm run test` — all 383 tests pass (37 files); the loader tests parse every `config.json`/`questDefs.json`, including these changes
- [x] `cd web && npm run build` — passes
- [x] Verified via a small script driving the real `hubWorldFactory`/loader pipeline that all 4 interactables (including the pre-existing pressed-flower one) parse with a 1×1 invisible hit area, and that the `blockedPaths` entry resolves `logPile`/`chest` tile IDs correctly with `unlockedByInteractable` wired to the right id


---
_Generated by [Claude Code](https://claude.ai/code/session_01FyBT2YntXqaKDymc5mPEQ8)_