### PR TITLE
Hub secrets: gravemoor — author secrets + lore notes

### DIFF
--- a/web/src/data/hub/gravemoor/config.json
+++ b/web/src/data/hub/gravemoor/config.json
@@ -2657,6 +2657,94 @@
       "building": "undertaker",
       "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 2 }],
       "reactions": [{ "type": "buy", "slotIndex": 2 }]
+    },
+    {
+      "id": "gravemoor-secret-cemetery-locket",
+      "tx": 8,
+      "ty": 18,
+      "reactions": [
+        {
+          "type": "dialogue",
+          "text": "Half-sunk in the mist near the cemetery gate, something small glints faintly."
+        },
+        {
+          "type": "giveItem",
+          "collectible": {
+            "id": "gravemoor-mourning-ring",
+            "name": "Tarnished Mourning Ring",
+            "icon": "💍",
+            "desc": "A small ring, its band gone black with age.",
+            "lore": "The Weeping Widow might recognize this — mourning rings were worn to remember the dead, back when Gravemoor still had the living to wear them."
+          },
+          "message": "You found a tarnished mourning ring."
+        }
+      ]
+    },
+    {
+      "id": "gravemoor-secret-square-token",
+      "tx": 23,
+      "ty": 13,
+      "reactions": [
+        {
+          "type": "dialogue",
+          "text": "Beside the spectral stall, a coin unlike any current currency lies forgotten in the fog."
+        },
+        {
+          "type": "giveItem",
+          "collectible": {
+            "id": "gravemoor-spectral-token",
+            "name": "Spectral Market Token",
+            "icon": "🪙",
+            "desc": "A coin stamped with a mark no living mint would recognize.",
+            "lore": "The Spectral Pedlar trades in things stranger than crystals. This token probably still spends, somewhere the fog runs thicker."
+          },
+          "message": "You found a strange spectral token."
+        }
+      ]
+    },
+    {
+      "id": "gravemoor-secret-wood-epitaph",
+      "tx": 30,
+      "ty": 13,
+      "reactions": [
+        {
+          "type": "dialogue",
+          "text": "Carved into a fallen branch deep in the whispering wood, a half-finished epitaph is barely legible."
+        },
+        {
+          "type": "giveItem",
+          "collectible": {
+            "id": "gravemoor-carved-epitaph",
+            "name": "Carved Epitaph Fragment",
+            "icon": "🪵",
+            "desc": "A strip of bark bearing part of a carved inscription.",
+            "lore": "'...and though the fog took my name, it did not take my—' The rest is lost to rot. Brother Mortis might finish the thought."
+          },
+          "message": "You found a fragment of a carved epitaph. Something else in town might complete it."
+        }
+      ]
+    },
+    {
+      "id": "gravemoor-hidden-roadside-cache-loot",
+      "tx": 22,
+      "ty": 27,
+      "reactions": [
+        {
+          "type": "dialogue",
+          "text": "Behind the withered bush where the epitaph pointed, a small chest sits sunken in the ash."
+        },
+        {
+          "type": "giveItem",
+          "collectible": {
+            "id": "gravemoor-epitaph-completion",
+            "name": "Completed Epitaph Stone",
+            "icon": "🪦",
+            "desc": "A small gravestone fragment, the missing half of the carved epitaph.",
+            "lore": "'...and though the fog took my name, it did not take my voice.' Brother Mortis would want to hear this read aloud, just once."
+          },
+          "message": "You found the missing half of the epitaph!"
+        }
+      ]
     }
   ],
   "weather": {

--- a/web/src/data/hub/gravemoor/questDefs.json
+++ b/web/src/data/hub/gravemoor/questDefs.json
@@ -742,7 +742,25 @@
       "questId": "gravemoor-hollow-tolling-3"
     }
   ],
-  "blockedPaths": [],
+  "blockedPaths": [
+    {
+      "id": "gravemoor-hidden-roadside-cache",
+      "blockedTiles": [[22, 27]],
+      "unlockedByInteractable": "gravemoor-secret-wood-epitaph",
+      "blocked": {
+        "decor": [
+          { "tx": 22, "ty": 27, "tileId": "deadBush" }
+        ],
+        "npcs": []
+      },
+      "cleared": {
+        "decor": [
+          { "tx": 22, "ty": 27, "tileId": "chest" }
+        ],
+        "npcs": []
+      }
+    }
+  ],
   "relationshipDialogue": {
     "restless-merchant-mora": {
       "rival": {


### PR DESCRIPTION
## Summary

Applies the secret/dig-spot pattern established in PR #1832 (Ravenwatch), PR #1894 (Appleford), PR #1895 (Capitalcity), and PR #1896 (Gearford) to gravemoor, per #1837. Gravemoor had zero existing secrets — clean slate.

- 3 secret interactables in `web/src/data/hub/gravemoor/config.json` — no owned `decor`, no `indicator`, each with a `dialogue` reaction for discovery flavor and a `giveItem` reaction granting a themed collectible with `lore` text, tied to Gravemoor's ghost/graveyard cast:
  - `gravemoor-secret-cemetery-locket` (8,18) — a tarnished mourning ring near the cemetery gate, tying to the Weeping Widow.
  - `gravemoor-secret-square-token` (23,13) — a spectral market token beside the Spectral Pedlar's stall.
  - `gravemoor-secret-wood-epitaph` (30,13) — a carved epitaph fragment in the whispering wood, deliberately cut off mid-sentence and hinting something completes it.
- One hidden-area reveal: a `blockedPaths` entry (`gravemoor-hidden-roadside-cache`) in `web/src/data/hub/gravemoor/questDefs.json`, gated on `unlockedByInteractable: "gravemoor-secret-wood-epitaph"` — finding the epitaph fragment reveals a roadside cache (`deadBush` → `chest`, fitting the ashen/fog setting better than the grassier towns' bush choice) holding the epitaph's missing half, via a companion `giveItem` interactable (`gravemoor-hidden-roadside-cache-loot`) that completes the inscription started by the wood secret.

All picked tiles were cross-checked against every existing `buildings`, `streets`, `exteriorDecor` (including `bundleID` tree clusters), `npcs`, `animals`, `interactables`, and `pickupItems` entry to avoid collisions. The blocked tile (22,27) sits inside the widest street rect in the file (33 tiles), so blocking it doesn't sever the only route.

Closes #1837.

## Test plan

- [x] `cd web && npx tsc --noEmit` — passes
- [x] `cd web && npm run test` — all 383 tests pass (37 files); the loader tests parse every `config.json`/`questDefs.json`, including these changes
- [x] `cd web && npm run build` — passes
- [x] Verified via a small script driving the real `hubWorldFactory`/loader pipeline that all 4 new interactables parse with a 1×1 invisible hit area, and that the `blockedPaths` entry resolves `deadBush`/`chest` tile IDs correctly with `unlockedByInteractable` wired to the right id


---
_Generated by [Claude Code](https://claude.ai/code/session_01FyBT2YntXqaKDymc5mPEQ8)_