### PR TITLE
Hub secrets: harrowfield — author secrets + lore notes

### DIFF
--- a/web/src/data/hub/harrowfield/config.json
+++ b/web/src/data/hub/harrowfield/config.json
@@ -2554,6 +2554,94 @@
       "building": "market-shed",
       "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 2 }],
       "reactions": [{ "type": "buy", "slotIndex": 2 }]
+    },
+    {
+      "id": "harrowfield-secret-green-hymnal",
+      "tx": 17,
+      "ty": 7,
+      "reactions": [
+        {
+          "type": "dialogue",
+          "text": "Wedged between the chapel wall and the village hall, a small scrap of paper is tucked out of the wind."
+        },
+        {
+          "type": "giveItem",
+          "collectible": {
+            "id": "harrowfield-hymnal-page",
+            "name": "Torn Hymnal Page",
+            "icon": "📜",
+            "desc": "A page torn from a chapel hymnal, the ink smudged with rain.",
+            "lore": "Sister Bell would recognize the hand — one of the harvest blessing verses, with a line scratched out and rewritten: 'watch the fields, watch what walks them.'"
+          },
+          "message": "You found a torn page from a hymnal."
+        }
+      ]
+    },
+    {
+      "id": "harrowfield-secret-strawman-button",
+      "tx": 10,
+      "ty": 15,
+      "reactions": [
+        {
+          "type": "dialogue",
+          "text": "Caught in the straw between the barn and the windmill, something small and metal glints."
+        },
+        {
+          "type": "giveItem",
+          "collectible": {
+            "id": "harrowfield-strawman-button",
+            "name": "Straw-Stuffed Button",
+            "icon": "🔘",
+            "desc": "A plain button, still trailing a bit of straw and thread.",
+            "lore": "Pip swears the scarecrows have been moving. This button looks like it came off one of their coats — and it's warm, somehow, though it's been lying in the dirt."
+          },
+          "message": "You found a strange warm button. The scarecrows might be missing it."
+        }
+      ]
+    },
+    {
+      "id": "harrowfield-secret-millpond-gear",
+      "tx": 28,
+      "ty": 15,
+      "reactions": [
+        {
+          "type": "dialogue",
+          "text": "Half-buried near the mill lane, a small brass gear turns faintly on its own, though nothing drives it."
+        },
+        {
+          "type": "giveItem",
+          "collectible": {
+            "id": "harrowfield-mill-gear",
+            "name": "Ever-Turning Gear",
+            "icon": "⚙️",
+            "desc": "A small brass gear that never quite stops spinning.",
+            "lore": "Miller Rook would swear his windmill's never lost a gear — and yet here one is, still turning, far from any mechanism that could drive it."
+          },
+          "message": "You found a small gear that keeps turning on its own."
+        }
+      ]
+    },
+    {
+      "id": "harrowfield-hidden-scarecrow-post-loot",
+      "tx": 9,
+      "ty": 10,
+      "reactions": [
+        {
+          "type": "dialogue",
+          "text": "Where the wandering scarecrow used to stand, only a small chest remains, half-sunk in the dirt."
+        },
+        {
+          "type": "giveItem",
+          "collectible": {
+            "id": "harrowfield-scarecrow-cache",
+            "name": "Scarecrow's Cache",
+            "icon": "📦",
+            "desc": "A small chest, straw-lined, tucked where a scarecrow once stood.",
+            "lore": "Whatever walks in Harrowfield's fields at night, it seems to leave things behind as often as it takes them. Best not to ask why."
+          },
+          "message": "You found the scarecrow's hidden cache!"
+        }
+      ]
     }
   ],
   "festivalDecor": [

--- a/web/src/data/hub/harrowfield/questDefs.json
+++ b/web/src/data/hub/harrowfield/questDefs.json
@@ -814,7 +814,25 @@
       "questId": "harrowfield-produce-to-ravenwatch"
     }
   ],
-  "blockedPaths": [],
+  "blockedPaths": [
+    {
+      "id": "harrowfield-hidden-scarecrow-post",
+      "blockedTiles": [[9, 10]],
+      "unlockedByInteractable": "harrowfield-secret-strawman-button",
+      "blocked": {
+        "decor": [
+          { "tx": 9, "ty": 10, "tileId": "scarecrowBottom" }
+        ],
+        "npcs": []
+      },
+      "cleared": {
+        "decor": [
+          { "tx": 9, "ty": 10, "tileId": "chest" }
+        ],
+        "npcs": []
+      }
+    }
+  ],
   "relationshipDialogue": {
     "pedlar-quill": {
       "rival": {


### PR DESCRIPTION
## Summary

Applies the secret/dig-spot pattern established in PR #1832 (Ravenwatch), PR #1894 (Appleford), PR #1895 (Capitalcity), PR #1896 (Gearford), and PR #1897 (Gravemoor) to harrowfield, per #1838. Harrowfield had zero existing secrets — clean slate.

- 3 secret interactables in `web/src/data/hub/harrowfield/config.json` — no owned `decor`, no `indicator`, each with a `dialogue` reaction for discovery flavor and a `giveItem` reaction granting a themed collectible with `lore` text:
  - `harrowfield-secret-green-hymnal` (17,7) — a torn hymnal page wedged between the chapel and village hall, tying to Sister Bell.
  - `harrowfield-secret-strawman-button` (10,15) — a warm button between the barn and windmill, tying into Harrowfield's existing "the scarecrows have been moving" NPC dialogue thread.
  - `harrowfield-secret-millpond-gear` (28,15) — an ever-turning brass gear near the mill lane, tying to Miller Rook.
- One hidden-area reveal: a `blockedPaths` entry (`harrowfield-hidden-scarecrow-post`) in `web/src/data/hub/harrowfield/questDefs.json`, gated on `unlockedByInteractable: "harrowfield-secret-strawman-button"` — finding the button reveals a hidden cache where a scarecrow used to stand (`scarecrowBottom` → `chest`, reusing the town's own scarecrow tile rather than a generic bush, and paying off the "moving scarecrow" mystery already present in the town's dialogue), via a companion `giveItem` interactable (`harrowfield-hidden-scarecrow-post-loot`).

All picked tiles were cross-checked against every existing `buildings`, `streets`, `pondTiles`, `exteriorDecor` (including `bundleID` hedgerow/ploughed-field entries), `npcs`, `animals`, `chickenZones`, `interactables`, and `pickupItems` entry to avoid collisions. The blocked tile (9,10) sits inside a 33-tile-wide street rect, so blocking it doesn't sever the only route.

Closes #1838.

## Test plan

- [x] `cd web && npx tsc --noEmit` — passes
- [x] `cd web && npm run test` — all 383 tests pass (37 files); the loader tests parse every `config.json`/`questDefs.json`, including these changes
- [x] `cd web && npm run build` — passes
- [x] Verified via a small script driving the real `hubWorldFactory`/loader pipeline that all 4 new interactables parse with a 1×1 invisible hit area, and that the `blockedPaths` entry resolves `scarecrowBottom`/`chest` tile IDs correctly with `unlockedByInteractable` wired to the right id


---
_Generated by [Claude Code](https://claude.ai/code/session_01FyBT2YntXqaKDymc5mPEQ8)_