### PR TITLE
Hub secrets: hollowmere — author secrets + lore notes

### DIFF
--- a/web/src/data/hub/hollowmere/config.json
+++ b/web/src/data/hub/hollowmere/config.json
@@ -2074,6 +2074,94 @@
       "building": "bonepile-curio",
       "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 2 }],
       "reactions": [{ "type": "buy", "slotIndex": 2 }]
+    },
+    {
+      "id": "hollowmere-secret-hollow-charm",
+      "tx": 15,
+      "ty": 14,
+      "reactions": [
+        {
+          "type": "dialogue",
+          "text": "Half-buried near the old crossroads stump, something small catches the torchlight."
+        },
+        {
+          "type": "giveItem",
+          "collectible": {
+            "id": "hollowmere-ward-charm",
+            "name": "Cracked Ward Charm",
+            "icon": "🔮",
+            "desc": "A small charm, its warding rune cracked clean through.",
+            "lore": "Hedge-Witch Morwen would say a broken ward is worse than none at all — it tells you something got past it, not that nothing tried."
+          },
+          "message": "You found a cracked ward charm."
+        }
+      ]
+    },
+    {
+      "id": "hollowmere-secret-mire-boot",
+      "tx": 10,
+      "ty": 23,
+      "reactions": [
+        {
+          "type": "dialogue",
+          "text": "Sunk deep in the muck, a single boot pokes up out of the mire."
+        },
+        {
+          "type": "giveItem",
+          "collectible": {
+            "id": "hollowmere-lost-boot",
+            "name": "Waterlogged Boot",
+            "icon": "👢",
+            "desc": "A single boot, heavy with mire water and long since abandoned by its owner.",
+            "lore": "Mother Sump did say the marsh keeps what it takes. Whoever this belonged to, the mire isn't giving the other one back either."
+          },
+          "message": "You found a waterlogged boot stuck in the muck."
+        }
+      ]
+    },
+    {
+      "id": "hollowmere-secret-darkwood-tooth",
+      "tx": 41,
+      "ty": 14,
+      "reactions": [
+        {
+          "type": "dialogue",
+          "text": "Wedged in the bark of a dead tree at the wood's edge, something long and sharp glints."
+        },
+        {
+          "type": "giveItem",
+          "collectible": {
+            "id": "hollowmere-fang-fragment",
+            "name": "Broken Fang",
+            "icon": "🦷",
+            "desc": "A broken tooth, far too large to have come from anything friendly.",
+            "lore": "Ogrim would probably want this back. Or maybe he wouldn't. Best not to ask which werewolf lost it, or why."
+          },
+          "message": "You found a broken fang wedged in the bark."
+        }
+      ]
+    },
+    {
+      "id": "hollowmere-hidden-mire-cache-loot",
+      "tx": 35,
+      "ty": 21,
+      "reactions": [
+        {
+          "type": "dialogue",
+          "text": "Behind the stump the boot's trail led to, something round and metal sits half-sunk in the mud."
+        },
+        {
+          "type": "giveItem",
+          "collectible": {
+            "id": "hollowmere-sunken-lockbox",
+            "name": "Sunken Lockbox",
+            "icon": "📦",
+            "desc": "A small lockbox, pried open long ago and refilled by someone since.",
+            "lore": "Mother Sump's handwriting, if you know to look for it: 'Finders keepers. The mire agrees.'"
+          },
+          "message": "You found a sunken lockbox in the mud!"
+        }
+      ]
     }
   ]
 }

--- a/web/src/data/hub/hollowmere/questDefs.json
+++ b/web/src/data/hub/hollowmere/questDefs.json
@@ -435,7 +435,25 @@
 
     { "id": "medicine-vial", "tx": 3, "ty": 2, "tileId": "potions", "building": "witch-hut-brewing", "questId": "hollowmere-marsh-medicine" }
   ],
-  "blockedPaths": [],
+  "blockedPaths": [
+    {
+      "id": "hollowmere-hidden-mire-cache",
+      "blockedTiles": [[35, 21]],
+      "unlockedByInteractable": "hollowmere-secret-mire-boot",
+      "blocked": {
+        "decor": [
+          { "tx": 35, "ty": 21, "tileId": "largeStump" }
+        ],
+        "npcs": []
+      },
+      "cleared": {
+        "decor": [
+          { "tx": 35, "ty": 21, "tileId": "chest" }
+        ],
+        "npcs": []
+      }
+    }
+  ],
   "relationshipDialogue": {
     "fang-the-fence": {
       "rival": {


### PR DESCRIPTION
## Summary

Applies the secret/dig-spot pattern established in PR #1832 (Ravenwatch), PR #1894 (Appleford), PR #1895 (Capitalcity), PR #1896 (Gearford), PR #1897 (Gravemoor), and PR #1898 (Harrowfield) to hollowmere, per #1839. Hollowmere had zero existing secret interactables (a quest named "A Secret of the Craft" turned up in a grep but is unrelated) — clean slate.

- 3 secret interactables in `web/src/data/hub/hollowmere/config.json` — no owned `decor`, no `indicator`, each with a `dialogue` reaction for discovery flavor and a `giveItem` reaction granting a themed collectible with `lore` text, tied to Hollowmere's monster-town cast:
  - `hollowmere-secret-hollow-charm` (15,14) — a cracked ward charm near the central crossroads, tying to Hedge-Witch Morwen.
  - `hollowmere-secret-mire-boot` (10,23) — a waterlogged boot sunk in the mire, tying to Mother Sump's "the marsh keeps what it takes" dialogue.
  - `hollowmere-secret-darkwood-tooth` (41,14) — a broken fang wedged in a dead tree, tying to Ogrim the Bouncer.
- One hidden-area reveal: a `blockedPaths` entry (`hollowmere-hidden-mire-cache`) in `web/src/data/hub/hollowmere/questDefs.json`, gated on `unlockedByInteractable: "hollowmere-secret-mire-boot"` — finding the boot reveals a sunken lockbox behind an old stump (`largeStump` → `chest`, reusing a tile already used elsewhere in this same swampy area), via a companion `giveItem` interactable (`hollowmere-hidden-mire-cache-loot`) whose note ("Finders keepers. The mire agrees.") continues Mother Sump's voice.

All picked tiles were cross-checked against every existing `buildings`, `streets`, `pondTiles`, `exteriorDecor` (including `bundleID` tree entries), `npcs`, `animals`, `interactables`, and `pickupItems` entry to avoid collisions. The blocked tile (35,21) sits inside a 37-tile-wide street rect, so blocking it doesn't sever the only route.

Closes #1839.

## Test plan

- [x] `cd web && npx tsc --noEmit` — passes
- [x] `cd web && npm run test` — all 383 tests pass (37 files); the loader tests parse every `config.json`/`questDefs.json`, including these changes
- [x] `cd web && npm run build` — passes
- [x] Verified via a small script driving the real `hubWorldFactory`/loader pipeline that all 4 new interactables parse with a 1×1 invisible hit area, and that the `blockedPaths` entry resolves `largeStump`/`chest` tile IDs correctly with `unlockedByInteractable` wired to the right id


---
_Generated by [Claude Code](https://claude.ai/code/session_01FyBT2YntXqaKDymc5mPEQ8)_