### PR TITLE
Hub secrets: ironholdkeep — author secrets + lore notes

### DIFF
--- a/web/src/data/hub/ironholdkeep/config.json
+++ b/web/src/data/hub/ironholdkeep/config.json
@@ -4579,6 +4579,94 @@
       "building": "quartermasters-store",
       "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 2 }],
       "reactions": [{ "type": "buy", "slotIndex": 2 }]
+    },
+    {
+      "id": "ironholdkeep-secret-ward-token",
+      "tx": 6,
+      "ty": 9,
+      "reactions": [
+        {
+          "type": "dialogue",
+          "text": "Tucked into a crack in the west wall's old stonework, something small has been wedged there for ages."
+        },
+        {
+          "type": "giveItem",
+          "collectible": {
+            "id": "ironholdkeep-watch-token",
+            "name": "Tarnished Watch Token",
+            "icon": "🪙",
+            "desc": "A brass token stamped with the keep's old watch rotation mark.",
+            "lore": "Guard-Master Doran would recognize the mark — this rotation was retired decades ago, back when the west wall still had a name of its own."
+          },
+          "message": "You found an old watch token."
+        }
+      ]
+    },
+    {
+      "id": "ironholdkeep-secret-bailey-chalk",
+      "tx": 18,
+      "ty": 44,
+      "reactions": [
+        {
+          "type": "dialogue",
+          "text": "Scratched into a flagstone near the gatehouse tunnel, a tally mark series is barely visible under the dust."
+        },
+        {
+          "type": "giveItem",
+          "collectible": {
+            "id": "ironholdkeep-tally-stone",
+            "name": "Scratched Tally Stone",
+            "icon": "🪨",
+            "desc": "A flagstone fragment scored with dozens of tally marks.",
+            "lore": "Gatekeeper Olen keeps his own count of every watch he's stood. This isn't his hand — someone else was counting something here, a long time before him."
+          },
+          "message": "You found a stone scratched with old tally marks."
+        }
+      ]
+    },
+    {
+      "id": "ironholdkeep-secret-drillyard-key",
+      "tx": 26,
+      "ty": 44,
+      "reactions": [
+        {
+          "type": "dialogue",
+          "text": "Half-buried near the old drill yard, a heavy iron key is nearly rusted through."
+        },
+        {
+          "type": "giveItem",
+          "collectible": {
+            "id": "ironholdkeep-rusted-key",
+            "name": "Rusted Iron Key",
+            "icon": "🗝️",
+            "desc": "A heavy iron key, its teeth worn nearly smooth with rust.",
+            "lore": "Archivist Elwyn might know what it opens — the scriptorium's old ledgers mention a lower vault whose key was 'lost to the drill yard' generations back."
+          },
+          "message": "You found a rusted iron key. The scriptorium's records might explain what it opens."
+        }
+      ]
+    },
+    {
+      "id": "ironholdkeep-hidden-vault-cache-loot",
+      "tx": 9,
+      "ty": 43,
+      "reactions": [
+        {
+          "type": "dialogue",
+          "text": "Behind the rubble the rusted key seemed to point toward, a small chest sits wedged against the boulevard wall."
+        },
+        {
+          "type": "giveItem",
+          "collectible": {
+            "id": "ironholdkeep-vault-relic",
+            "name": "Lower Vault Relic",
+            "icon": "📦",
+            "desc": "A small strongbox, its lock long since sprung.",
+            "lore": "Whatever the scriptorium's ledgers meant by 'the lower vault,' this might be all that's left of it. Archivist Elwyn would want to see this."
+          },
+          "message": "You found a relic from the lower vault!"
+        }
+      ]
     }
   ]
 }

--- a/web/src/data/hub/ironholdkeep/questDefs.json
+++ b/web/src/data/hub/ironholdkeep/questDefs.json
@@ -1510,5 +1510,23 @@
       }
     }
   },
-  "blockedPaths": []
+  "blockedPaths": [
+    {
+      "id": "ironholdkeep-hidden-vault-cache",
+      "blockedTiles": [[9, 43]],
+      "unlockedByInteractable": "ironholdkeep-secret-drillyard-key",
+      "blocked": {
+        "decor": [
+          { "tx": 9, "ty": 43, "tileId": "smallRock" }
+        ],
+        "npcs": []
+      },
+      "cleared": {
+        "decor": [
+          { "tx": 9, "ty": 43, "tileId": "chest" }
+        ],
+        "npcs": []
+      }
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Applies the secret/dig-spot pattern established in PR #1832 (Ravenwatch), PR #1894 (Appleford), PR #1895 (Capitalcity), PR #1896 (Gearford), PR #1897 (Gravemoor), PR #1898 (Harrowfield), and PR #1899 (Hollowmere) to ironholdkeep, per #1840. Ironhold Keep had zero existing secret interactables (a grep for "secret" only turned up narrative quest dialogue about "the secret of the lower vault") — clean slate.

- 3 secret interactables in `web/src/data/hub/ironholdkeep/config.json` — no owned `decor`, no `indicator`, each with a `dialogue` reaction for discovery flavor and a `giveItem` reaction granting a themed collectible with `lore` text, tied to the fortress's siege/prison cast:
  - `ironholdkeep-secret-ward-token` (6,9) — an old watch token in the west wall, tying to Guard-Master Doran.
  - `ironholdkeep-secret-bailey-chalk` (18,44) — a tally-scratched flagstone near the gatehouse tunnel, tying to Gatekeeper Olen.
  - `ironholdkeep-secret-drillyard-key` (26,44) — a rusted key near the drill yard, tying to Archivist Elwyn and the scriptorium's "lower vault" lore already present in the town's existing quest dialogue.
- One hidden-area reveal: a `blockedPaths` entry (`ironholdkeep-hidden-vault-cache`) in `web/src/data/hub/ironholdkeep/questDefs.json`, gated on `unlockedByInteractable: "ironholdkeep-secret-drillyard-key"` — finding the rusted key reveals a vault relic behind rubble (`smallRock` → `chest`), via a companion `giveItem` interactable (`ironholdkeep-hidden-vault-cache-loot`) that pays off the "lower vault" thread without touching the actual `castle-vault-truth` quest.

All picked tiles were cross-checked against every existing `buildings`, `streets`, `ponds`, `exteriorDecor`, `npcs`, `animals`, `chickenZones`, `interactables`, and `pickupItems` entry to avoid collisions. The blocked tile (9,43) sits inside the town's widest street rect (40 tiles, the "north boulevard"), with parallel routes via the south boulevard and both spurs, so blocking it can't sever the only route.

Closes #1840.

## Test plan

- [x] `cd web && npx tsc --noEmit` — passes
- [x] `cd web && npm run test` — all 383 tests pass (37 files); the loader tests parse every `config.json`/`questDefs.json`, including these changes
- [x] `cd web && npm run build` — passes
- [x] Verified via a small script driving the real `hubWorldFactory`/loader pipeline (registry key `'ironhold-keep'`, which diverges from the `ironholdkeep` folder name, same pattern as capitalcity/capital-city) that all 4 new interactables parse with a 1×1 invisible hit area, and that the `blockedPaths` entry resolves `smallRock`/`chest` tile IDs correctly with `unlockedByInteractable` wired to the right id


---
_Generated by [Claude Code](https://claude.ai/code/session_01FyBT2YntXqaKDymc5mPEQ8)_