### PR TITLE
Hub secrets: millhaven — author secrets + lore notes

### DIFF
--- a/web/src/data/hub/millhaven/config.json
+++ b/web/src/data/hub/millhaven/config.json
@@ -3324,6 +3324,94 @@
           "slotIndex": 2
         }
       ]
+    },
+    {
+      "id": "millhaven-secret-harbour-charm",
+      "tx": 23,
+      "ty": 10,
+      "reactions": [
+        {
+          "type": "dialogue",
+          "text": "Tucked beneath the fishmonger's awning, a small carved charm has been wedged into a support post for years."
+        },
+        {
+          "type": "giveItem",
+          "collectible": {
+            "id": "millhaven-sailors-charm",
+            "name": "Weathered Sailor's Charm",
+            "icon": "⚓",
+            "desc": "A small wooden charm, carved in the shape of an anchor.",
+            "lore": "Sailor Finn would recognize the carving style — sailors used to nail these to the post before a long haul. Whoever left this one never came back to reclaim it."
+          },
+          "message": "You found a weathered sailor's charm."
+        }
+      ]
+    },
+    {
+      "id": "millhaven-secret-pier-buoy",
+      "tx": 38,
+      "ty": 17,
+      "reactions": [
+        {
+          "type": "dialogue",
+          "text": "Half-tangled in old netting near the tackle stalls, a small buoy bobs against the pilings."
+        },
+        {
+          "type": "giveItem",
+          "collectible": {
+            "id": "millhaven-marker-buoy",
+            "name": "Faded Marker Buoy",
+            "icon": "🔴",
+            "desc": "A small buoy, its paint faded past recognition.",
+            "lore": "Dockhand Bram mentioned the storm dragged half the moorings loose last week. This one never made it back to its post."
+          },
+          "message": "You found a faded marker buoy tangled in the nets."
+        }
+      ]
+    },
+    {
+      "id": "millhaven-secret-smithy-tool",
+      "tx": 9,
+      "ty": 32,
+      "reactions": [
+        {
+          "type": "dialogue",
+          "text": "Wedged behind the smithy's log pile, a small hand tool has rusted into the wood."
+        },
+        {
+          "type": "giveItem",
+          "collectible": {
+            "id": "millhaven-forge-tool",
+            "name": "Rusted Forge Tool",
+            "icon": "🔨",
+            "desc": "A small hand tool, its handle long rotted away.",
+            "lore": "Smith Garrick would swear he's never lost a tool in his life. This one's older than his apprenticeship, by the rust on it."
+          },
+          "message": "You found a rusted old forge tool."
+        }
+      ]
+    },
+    {
+      "id": "millhaven-hidden-plaza-cache-loot",
+      "tx": 17,
+      "ty": 16,
+      "reactions": [
+        {
+          "type": "dialogue",
+          "text": "Behind the storm-blown crate the buoy seemed to be marking, a small chest sits half-buried in the mud."
+        },
+        {
+          "type": "giveItem",
+          "collectible": {
+            "id": "millhaven-storm-cache",
+            "name": "Storm-Washed Cache",
+            "icon": "📦",
+            "desc": "A small chest, salt-stained and swollen from the rain.",
+            "lore": "Whatever ship it fell from, the tide brought it all the way into the square. Regatta Master Coll would probably want to hear about this."
+          },
+          "message": "You found a storm-washed cache in the square!"
+        }
+      ]
     }
   ],
   "pondTiles": [

--- a/web/src/data/hub/millhaven/questDefs.json
+++ b/web/src/data/hub/millhaven/questDefs.json
@@ -824,7 +824,25 @@
       "chain": "restock-sack"
     }
   ],
-  "blockedPaths": [],
+  "blockedPaths": [
+    {
+      "id": "millhaven-hidden-plaza-cache",
+      "blockedTiles": [[17, 16]],
+      "unlockedByInteractable": "millhaven-secret-pier-buoy",
+      "blocked": {
+        "decor": [
+          { "tx": 17, "ty": 16, "tileId": "crate" }
+        ],
+        "npcs": []
+      },
+      "cleared": {
+        "decor": [
+          { "tx": 17, "ty": 16, "tileId": "chest" }
+        ],
+        "npcs": []
+      }
+    }
+  ],
   "dialogues": [
     {
       "id": "tamsin-locket-trade",


### PR DESCRIPTION
## Summary

Applies the secret/dig-spot pattern established in PR #1832 (Ravenwatch), PR #1894 (Appleford), PR #1895 (Capitalcity), PR #1896 (Gearford), PR #1897 (Gravemoor), PR #1898 (Harrowfield), PR #1899 (Hollowmere), and PR #1900 (Ironhold Keep) to millhaven, per #1841. Millhaven had zero existing secret interactables (a grep for "secret" only turned up a treasure-chest title, unrelated) — clean slate.

- 3 secret interactables in `web/src/data/hub/millhaven/config.json` — no owned `decor`, no `indicator`, each with a `dialogue` reaction for discovery flavor and a `giveItem` reaction granting a themed collectible with `lore` text, tied to Millhaven's coastal/fishing cast:
  - `millhaven-secret-harbour-charm` (23,10) — a weathered sailor's charm by the fishmonger's stall, tying to Sailor Finn.
  - `millhaven-secret-pier-buoy` (38,17) — a faded marker buoy near the pier tackle stalls, tying to Dockhand Bram's "storm dragged half the moorings loose" dialogue.
  - `millhaven-secret-smithy-tool` (9,32) — a rusted forge tool behind the smithy's log pile, tying to Smith Garrick.
- One hidden-area reveal: a `blockedPaths` entry (`millhaven-hidden-plaza-cache`) in `web/src/data/hub/millhaven/questDefs.json`, gated on `unlockedByInteractable: "millhaven-secret-pier-buoy"` — finding the buoy reveals a storm-washed cache in the market square (`crate` → `chest`, fitting a village that "rains year-round"), via a companion `giveItem` interactable (`millhaven-hidden-plaza-cache-loot`) that continues the storm/lost-ship thread.

Millhaven has no street rect ≥30 tiles wide (unlike prior towns) — the only safe hidden-nook spot is a 2D plaza (`[13,10,22,20]`, 110 tiles) rather than a corridor, so the blocked tile (17,16) sits well inside that plaza with ~109 alternate route tiles around it. All picked tiles were cross-checked against every existing `buildings`, `streets`, `pondTiles`, `exteriorDecor` (including `bundleID` clusters), `npcs`, `animals`, `chickenZones`, `interactables`, `treasures`, and `pickupItems` entry to avoid collisions.

Closes #1841.

## Test plan

- [x] `cd web && npx tsc --noEmit` — passes
- [x] `cd web && npm run test` — all 383 tests pass (37 files); the loader tests parse every `config.json`/`questDefs.json`, including these changes
- [x] `cd web && npm run build` — passes
- [x] Verified via a small script driving the real `hubWorldFactory`/loader pipeline that all 4 new interactables parse with a 1×1 invisible hit area, and that the `blockedPaths` entry resolves `crate`/`chest` tile IDs correctly with `unlockedByInteractable` wired to the right id


---
_Generated by [Claude Code](https://claude.ai/code/session_01FyBT2YntXqaKDymc5mPEQ8)_