### PR TITLE
Hub secrets: royalpalace — author secrets + lore notes

### DIFF
--- a/web/src/data/hub/royalpalace/config.json
+++ b/web/src/data/hub/royalpalace/config.json
@@ -4353,6 +4353,94 @@
       "building": "treasury-annex",
       "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 2 }],
       "reactions": [{ "type": "buy", "slotIndex": 2 }]
+    },
+    {
+      "id": "royalpalace-secret-garden-locket",
+      "tx": 15,
+      "ty": 18,
+      "reactions": [
+        {
+          "type": "dialogue",
+          "text": "Half-hidden beneath a rose bush in the royal gardens, something small glints in the dirt."
+        },
+        {
+          "type": "giveItem",
+          "collectible": {
+            "id": "royalpalace-garden-locket",
+            "name": "Garden Locket",
+            "icon": "💍",
+            "desc": "A small locket, its clasp long since rusted shut.",
+            "lore": "Queen Maredith tends these gardens herself. If this is hers, she's never once mentioned losing it."
+          },
+          "message": "You found a small locket buried beneath the roses."
+        }
+      ]
+    },
+    {
+      "id": "royalpalace-secret-eastgarden-seal",
+      "tx": 35,
+      "ty": 24,
+      "reactions": [
+        {
+          "type": "dialogue",
+          "text": "Pressed into the soil near the bird baths, a wax seal has hardened into a small disc."
+        },
+        {
+          "type": "giveItem",
+          "collectible": {
+            "id": "royalpalace-broken-seal",
+            "name": "Broken Wax Seal",
+            "icon": "📜",
+            "desc": "A disc of hardened wax, the royal crest pressed into one side, snapped clean in half.",
+            "lore": "Herald Fanshawe would recognize this crest — it matches the missing proclamations he's still hunting for. Someone broke this seal in a hurry."
+          },
+          "message": "You found half of a broken wax seal."
+        }
+      ]
+    },
+    {
+      "id": "royalpalace-secret-servants-ledger",
+      "tx": 9,
+      "ty": 31,
+      "reactions": [
+        {
+          "type": "dialogue",
+          "text": "Tucked behind a stack of crates in the servants' yard, a torn ledger page flutters."
+        },
+        {
+          "type": "giveItem",
+          "collectible": {
+            "id": "royalpalace-ledger-scrap",
+            "name": "Torn Ledger Scrap",
+            "icon": "📒",
+            "desc": "A scrap of a ledger page, the numbers smudged but the total still legible.",
+            "lore": "Master Edric would want this back — 'every coin accounted for,' he always says. This page accounts for rather fewer coins than the vault claims to hold."
+          },
+          "message": "You found a torn scrap of ledger."
+        }
+      ]
+    },
+    {
+      "id": "royalpalace-hidden-avenue-cache-loot",
+      "tx": 13,
+      "ty": 32,
+      "reactions": [
+        {
+          "type": "dialogue",
+          "text": "Behind the crates someone left blocking the avenue, a gilded chest sits forgotten against the wall."
+        },
+        {
+          "type": "giveItem",
+          "collectible": {
+            "id": "royalpalace-vault-shortfall",
+            "name": "Missing Vault Coin",
+            "icon": "🪙",
+            "desc": "A small pouch of coins, exactly matching the shortfall on the torn ledger page.",
+            "lore": "Master Edric's numbers were right after all. Someone just hid the difference rather than explain it."
+          },
+          "message": "You found the coins the ledger was missing!"
+        }
+      ]
     }
   ],
   "chickenZones": [

--- a/web/src/data/hub/royalpalace/questDefs.json
+++ b/web/src/data/hub/royalpalace/questDefs.json
@@ -852,7 +852,25 @@
       "questId": "palace-queen-roses"
     }
   ],
-  "blockedPaths": [],
+  "blockedPaths": [
+    {
+      "id": "royalpalace-hidden-avenue-cache",
+      "blockedTiles": [[13, 32]],
+      "unlockedByInteractable": "royalpalace-secret-servants-ledger",
+      "blocked": {
+        "decor": [
+          { "tx": 13, "ty": 32, "tileId": "crate" }
+        ],
+        "npcs": []
+      },
+      "cleared": {
+        "decor": [
+          { "tx": 13, "ty": 32, "tileId": "goldChest" }
+        ],
+        "npcs": []
+      }
+    }
+  ],
   "dialogues": [
     {
       "id": "penrose-chat",


### PR DESCRIPTION
## Summary

Applies the secret/dig-spot pattern established in PR #1832 (Ravenwatch), PR #1894 (Appleford), PR #1895 (Capitalcity), PR #1896 (Gearford), PR #1897 (Gravemoor), PR #1898 (Harrowfield), PR #1899 (Hollowmere), PR #1900 (Ironhold Keep), and PR #1901 (Millhaven) to royalpalace, per #1842. Royal Palace had zero existing secret interactables — clean slate.

- 3 secret interactables in `web/src/data/hub/royalpalace/config.json` — no owned `decor`, no `indicator`, each with a `dialogue` reaction for discovery flavor and a `giveItem` reaction granting a themed collectible with `lore` text, tied to the palace's court cast:
  - `royalpalace-secret-garden-locket` (15,18) — a garden locket beneath the rose beds, tying to Queen Maredith.
  - `royalpalace-secret-eastgarden-seal` (35,24) — a broken wax seal near the bird baths, tying to Herald Fanshawe's missing-proclamations thread.
  - `royalpalace-secret-servants-ledger` (9,31) — a torn ledger scrap in the servants' yard, tying to treasurer Master Edric's "every coin accounted for" line.
- One hidden-area reveal: a `blockedPaths` entry (`royalpalace-hidden-avenue-cache`) in `web/src/data/hub/royalpalace/questDefs.json`, gated on `unlockedByInteractable: "royalpalace-secret-servants-ledger"` — finding the ledger scrap reveals a stash of missing vault coins behind crates on the main avenue (`crate` → `goldChest`), via a companion `giveItem` interactable (`royalpalace-hidden-avenue-cache-loot`) that confirms Edric's numbers were right and someone hid the shortfall.

All picked tiles were cross-checked against every existing `buildings`, `streets`, `pondTiles`/`bridgeTiles`, `exteriorDecor` (including `bundleID` clusters), `npcs`, `animals`, `chickenZones`, `interactables`, and `pickupItems` entry to avoid collisions. The blocked tile (13,32) sits inside the town's largest street rect (a 4×46 north–south avenue, 184 tiles), leaving 3 of its 4 columns open at that row, so blocking it can't sever the route.

Closes #1842.

## Test plan

- [x] `cd web && npx tsc --noEmit` — passes
- [x] `cd web && npm run test` — all 383 tests pass (37 files); the loader tests parse every `config.json`/`questDefs.json`, including these changes
- [x] `cd web && npm run build` — passes
- [x] Verified via a small script driving the real `hubWorldFactory`/loader pipeline (registry key `'royal-palace'`, which diverges from the `royalpalace` folder name, same pattern as capitalcity/capital-city and ironholdkeep/ironhold-keep) that all 4 new interactables parse with a 1×1 invisible hit area, and that the `blockedPaths` entry resolves `crate`/`goldChest` tile IDs correctly with `unlockedByInteractable` wired to the right id


---
_Generated by [Claude Code](https://claude.ai/code/session_01FyBT2YntXqaKDymc5mPEQ8)_