### PR TITLE
Hub secrets: saltmereport — author secrets + lore notes

### DIFF
--- a/web/src/data/hub/saltmereport/config.json
+++ b/web/src/data/hub/saltmereport/config.json
@@ -2571,6 +2571,72 @@
           "message": "You found a tin whistle!"
         }
       ]
+    },
+    {
+      "id": "saltmereport-secret-dock-manifest",
+      "tx": 29,
+      "ty": 22,
+      "reactions": [
+        {
+          "type": "dialogue",
+          "text": "Wedged between two mooring posts on the dock, a scrap of paper flutters against the salt spray."
+        },
+        {
+          "type": "giveItem",
+          "collectible": {
+            "id": "saltmereport-manifest-scrap",
+            "name": "Torn Manifest Scrap",
+            "icon": "📜",
+            "desc": "A torn corner of a cargo manifest, half the ink washed away by seawater.",
+            "lore": "Harbourmaster Vane keeps insisting the manifest doesn't lie. This scrap lists a cargo that never once appeared on his official count."
+          },
+          "message": "You found a torn scrap of a cargo manifest."
+        }
+      ]
+    },
+    {
+      "id": "saltmereport-secret-lighthouse-glass",
+      "tx": 44,
+      "ty": 26,
+      "reactions": [
+        {
+          "type": "dialogue",
+          "text": "Tucked into a crack at the end of the jetty, a small piece of sea glass catches the light."
+        },
+        {
+          "type": "giveItem",
+          "collectible": {
+            "id": "saltmereport-sea-glass",
+            "name": "Polished Sea Glass",
+            "icon": "🔷",
+            "desc": "A smooth, sun-bleached piece of green glass, worn round by years in the tide.",
+            "lore": "Lighthouse Keeper Wren says the fog brings strange things ashore some nights. Whatever bottle this glass came from, the sea's had it a long, long time."
+          },
+          "message": "You found a piece of sea glass worn smooth by the tide."
+        }
+      ]
+    },
+    {
+      "id": "saltmereport-hidden-warehouse-cache-loot",
+      "tx": 20,
+      "ty": 35,
+      "reactions": [
+        {
+          "type": "dialogue",
+          "text": "Behind the stack of unclaimed crates the manifest scrap seemed to reference, a small chest sits forgotten."
+        },
+        {
+          "type": "giveItem",
+          "collectible": {
+            "id": "saltmereport-smuggled-cache",
+            "name": "Unclaimed Cargo Chest",
+            "icon": "📦",
+            "desc": "A small chest, its markings scratched off and never claimed.",
+            "lore": "Whatever the Smuggler was moving through here, this crate never made it to its buyer. Vane's manifest was right all along — it just never mentioned this one."
+          },
+          "message": "You found an unclaimed cargo chest!"
+        }
+      ]
     }
   ],
   "animals": [

--- a/web/src/data/hub/saltmereport/questDefs.json
+++ b/web/src/data/hub/saltmereport/questDefs.json
@@ -1016,5 +1016,23 @@
       "questId": "saltmere-lost-manifest"
     }
   ],
-  "blockedPaths": []
+  "blockedPaths": [
+    {
+      "id": "saltmereport-hidden-warehouse-cache",
+      "blockedTiles": [[20, 35]],
+      "unlockedByInteractable": "saltmereport-secret-dock-manifest",
+      "blocked": {
+        "decor": [
+          { "tx": 20, "ty": 35, "tileId": "crate" }
+        ],
+        "npcs": []
+      },
+      "cleared": {
+        "decor": [
+          { "tx": 20, "ty": 35, "tileId": "chest" }
+        ],
+        "npcs": []
+      }
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Applies the secret/dig-spot pattern established in PR #1832 (Ravenwatch), PR #1894 (Appleford), PR #1895 (Capitalcity), PR #1896 (Gearford), PR #1897 (Gravemoor), PR #1898 (Harrowfield), PR #1899 (Hollowmere), PR #1900 (Ironhold Keep), PR #1901 (Millhaven), and PR #1902 (Royal Palace) to saltmereport, per #1843.

Saltmere Port already had one secret (`saltmere-secret-tin-whistle` at 30,18) that hides a favorite-gift hub-item, but no lore-note style secrets. This PR adds two:

- `saltmereport-secret-dock-manifest` (29,22) — a torn cargo manifest scrap wedged between mooring posts on the docks, tying to Harbourmaster Vane's "the manifest doesn't lie" dialogue.
- `saltmereport-secret-lighthouse-glass` (44,26) — a piece of sea glass at the end of the lighthouse jetty, tying to Lighthouse Keeper Wren.

Plus one hidden-area reveal: a `blockedPaths` entry (`saltmereport-hidden-warehouse-cache`) in `web/src/data/hub/saltmereport/questDefs.json`, gated on `unlockedByInteractable: "saltmereport-secret-dock-manifest"` — finding the manifest scrap reveals an unclaimed cargo chest behind warehouse crates (`crate` → `chest`), via a companion `giveItem` interactable (`saltmereport-hidden-warehouse-cache-loot`) that ties the discovery to the town's existing Smuggler NPC and confirms Vane's suspicions.

All picked tiles were cross-checked against every existing `buildings`, `streets`, `pondTiles`, `exteriorDecor` (including `bundleID` tree clusters), `npcs`, `animals`, `interactables` (including the existing tin-whistle secret), and `pickupItems` entry to avoid collisions. The blocked tile (20,35) sits inside the town's largest street rect (38×3, 114 tiles), so blocking it doesn't sever the only route.

Closes #1843.

## Test plan

- [x] `cd web && npx tsc --noEmit` — passes
- [x] `cd web && npm run test` — all 383 tests pass (37 files); the loader tests parse every `config.json`/`questDefs.json`, including these changes
- [x] `cd web && npm run build` — passes
- [x] Verified via a small script driving the real `hubWorldFactory`/loader pipeline (registry key `'saltmere-port'`, which diverges from the `saltmereport` folder name) that all 4 interactables (including the pre-existing tin-whistle one) parse with a 1×1 invisible hit area, and that the `blockedPaths` entry resolves `crate`/`chest` tile IDs correctly with `unlockedByInteractable` wired to the right id


---
_Generated by [Claude Code](https://claude.ai/code/session_01FyBT2YntXqaKDymc5mPEQ8)_