### PR TITLE
Hub secrets: thornwoodcamp — author secrets + lore notes

### DIFF
--- a/web/src/data/hub/thornwoodcamp/config.json
+++ b/web/src/data/hub/thornwoodcamp/config.json
@@ -627,6 +627,72 @@
           "message": "You found a piece of river glass!"
         }
       ]
+    },
+    {
+      "id": "thornwood-secret-embercharm",
+      "tx": 10,
+      "ty": 17,
+      "reactions": [
+        {
+          "type": "dialogue",
+          "text": "Half-buried in the frost near the north path, a small charm swings from a broken cord."
+        },
+        {
+          "type": "giveItem",
+          "collectible": {
+            "id": "thornwood-ember-charm",
+            "name": "Ember-Warmed Charm",
+            "icon": "🔥",
+            "desc": "A small stone charm, faintly warm to the touch even in the cold.",
+            "lore": "Warden Rell keeps the fire lit against the wolves. This charm feels like it's been sitting near a flame for years — though there's no fire out this far from camp."
+          },
+          "message": "You found a charm that's oddly warm to the touch."
+        }
+      ]
+    },
+    {
+      "id": "thornwood-secret-southpath-tooth",
+      "tx": 13,
+      "ty": 38,
+      "reactions": [
+        {
+          "type": "dialogue",
+          "text": "Wedged between two roots along the south path, something long and sharp catches the light."
+        },
+        {
+          "type": "giveItem",
+          "collectible": {
+            "id": "thornwood-wolf-tooth",
+            "name": "Old Wolf Tooth",
+            "icon": "🦷",
+            "desc": "A large tooth, yellowed with age, worn smooth at the root.",
+            "lore": "Ranger Sable counts the pack every season. By the size of this, whatever wolf it belonged to was old before the bad winter Sable keeps mentioning."
+          },
+          "message": "You found an old wolf tooth."
+        }
+      ]
+    },
+    {
+      "id": "thornwood-hidden-pathside-cache-loot",
+      "tx": 13,
+      "ty": 31,
+      "reactions": [
+        {
+          "type": "dialogue",
+          "text": "Behind the stump the old tooth seemed to point toward, a small chest is wedged into the roots."
+        },
+        {
+          "type": "giveItem",
+          "collectible": {
+            "id": "thornwood-ranger-cache",
+            "name": "Ranger's Hidden Cache",
+            "icon": "📦",
+            "desc": "A small weatherproofed chest, tucked where only someone tracking wolves would think to look.",
+            "lore": "Ranger Sable must have stashed this years ago and forgotten it — or never came back for it. Best not to guess which."
+          },
+          "message": "You found a ranger's hidden cache!"
+        }
+      ]
     }
   ],
   "pondTiles": [

--- a/web/src/data/hub/thornwoodcamp/questDefs.json
+++ b/web/src/data/hub/thornwoodcamp/questDefs.json
@@ -646,6 +646,23 @@
           }
         ]
       }
+    },
+    {
+      "id": "thornwood-hidden-pathside-cache",
+      "blockedTiles": [[13, 31]],
+      "unlockedByInteractable": "thornwood-secret-southpath-tooth",
+      "blocked": {
+        "decor": [
+          { "tx": 13, "ty": 31, "tileId": "largeStump" }
+        ],
+        "npcs": []
+      },
+      "cleared": {
+        "decor": [
+          { "tx": 13, "ty": 31, "tileId": "chest" }
+        ],
+        "npcs": []
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary

Applies the secret/dig-spot pattern established in PR #1832 (Ravenwatch), PR #1894 (Appleford), PR #1895 (Capitalcity), PR #1896 (Gearford), PR #1897 (Gravemoor), PR #1898 (Harrowfield), PR #1899 (Hollowmere), PR #1900 (Ironhold Keep), PR #1901 (Millhaven), PR #1902 (Royal Palace), and PR #1904 (Saltmere Port) to thornwoodcamp, per #1844 — the last town in #1657's batch.

Thornwood Camp already had one secret (`thornwood-secret-river-glass` at 6,31) that hides a favorite-gift hub-item, but no lore-note style secrets. This PR adds two:

- `thornwood-secret-embercharm` (10,17) — an ember-warmed charm on the north path, tying to Warden Rell's fire-watch.
- `thornwood-secret-southpath-tooth` (13,38) — an old wolf tooth on the south path, tying to Ranger Sable's wolf-count dialogue.

Plus one hidden-area reveal: a `blockedPaths` entry (`thornwood-hidden-pathside-cache`) in `web/src/data/hub/thornwoodcamp/questDefs.json`, gated on `unlockedByInteractable: "thornwood-secret-southpath-tooth"` — finding the tooth reveals a ranger's cache behind a fallen stump (`largeStump` → `chest`), via a companion `giveItem` interactable (`thornwood-hidden-pathside-cache-loot`).

Per the hard constraint noted on #1844 (inherited from epic #1732): **Thornwood Camp has a fixed layout with zero new buildings allowed.** This PR adds none — every new entry is an ordinary interactable, and the hidden-area reveal only swaps decor on an already-existing walkable street tile (the same mechanism as the town's pre-existing quest-gated `block-1781886893879` reveal), never a new room or building.

All picked tiles were cross-checked against every existing `streets`, `pondTiles`, `exteriorDecor` (including `bundleID` tree clusters), `npcs`, `animals`, `interactables` (including the existing river-glass secret), `pickupItems`, and the pre-existing `blockedPaths` entry to avoid collisions.

Closes #1844. This closes out the last remaining town in the "author secrets per town" epic (#1657).

## Test plan

- [x] `cd web && npx tsc --noEmit` — passes
- [x] `cd web && npm run test` — all 383 tests pass (37 files); the loader tests parse every `config.json`/`questDefs.json`, including these changes
- [x] `cd web && npm run build` — passes
- [x] Verified via a small script driving the real `hubWorldFactory`/loader pipeline (registry key `'thornwood-camp'`, which diverges from the `thornwoodcamp` folder name) that all 4 interactables (including the pre-existing river-glass one) parse with a 1×1 invisible hit area, and that both `blockedPaths` entries (the pre-existing quest-gated one and the new one) resolve correctly with the new one's `unlockedByInteractable` wired to the right id


---
_Generated by [Claude Code](https://claude.ai/code/session_01FyBT2YntXqaKDymc5mPEQ8)_