### PR TITLE
Combine NPC dialogue: specific, quest, and talk/gift options in one modal

### DIFF
--- a/docs/hubworld.md
+++ b/docs/hubworld.md
@@ -389,7 +389,9 @@ Reusable multi-choice NPC conversations that branch to different endings.
 Authored in `questDefs.json` under a top-level `dialogues` array and attached to
 an NPC via `dialogueTree` (the id of the tree). When such an NPC is tapped and has
 no higher-priority interaction (quest offer/completion, screen, friendship-tier
-line), `HubWorld.tsx` walks the tree instead of the linear `dialogue` cycle.
+line), `HubWorld.tsx` walks the tree instead of the linear `dialogue` cycle. The
+tree's entry (root) node also gets Talk/Give (§7d) appended to its authored
+choices; later nodes reached by picking a choice do not.
 
 Types live in `web/src/data/hub/questDefs.ts`; the walker (`runDialogueNode` /
 `applyChoice`) lives in `web/src/components/hub/HubWorld.tsx`. Reuses the existing
@@ -608,9 +610,20 @@ rivalry (no chains).
 Every named NPC gets two always-available dialogue choices — no authoring
 required — so the Town Directory's 💗 Relationship button has a real way to
 move even for the ~5 in 6 NPCs with no `dialogueTree` (§7b) and no active
-quest. These appear on the **default** dialogue branch only — an NPC with a
-screen, an active/offerable quest, a bounty report, or a dialogue tree keeps
-using that flow untouched; Talk/Give only fires once none of those match.
+quest. Talk/Give is appended as the closing section of every **top-level**
+NPC dialogue (the modal shown as the direct result of a tap) — after any
+screen-enter choice, quest offer/turn-in choice, dialogue-tree root node's
+authored choices, or a relationship/friendship flavor line — so it always
+coexists with an NPC's other content in the same modal (built by the shared
+`buildTalkGiveChoices` helper in `HubWorld.tsx`). Follow-up dialogueEvents
+reached by tapping an earlier choice — a dialogue tree's later nodes, the
+gift-item picker, a quest offer's Accept/Not-now decision reached mid-tree,
+or the reward text shown after a quest completes — do **not** get Talk/Give
+re-appended, since the player already made their choice for this
+interaction. Two exceptions keep the old plain-text/auto-dismiss behavior
+and never gain Talk/Give: a bounty-report tick (§7e) and Innkeeper Rosie's
+inn-rumour reveal, since both are automatic incidental side effects of a tap
+rather than a real conversation turn.
 
 - **🗣️ Make conversation** — grants a small flat friendship XP + 1 `ally`
   relationship point. Limited to once per real day per NPC

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -71,6 +71,15 @@ interface QuestEvent {
   onClose?: () => void
 }
 
+interface NpcTapDef {
+  name?: string; dialogue?: string[]; screen?: string; building?: string
+  questGive?: string; questReceive?: string | string[]
+  innRumours?: Array<{ id: string; text: string }>
+  dialogueTree?: string
+  favoriteGiftItemId?: string; favoriteGiftTrack?: string
+  dislikedGiftItemIds?: string[]
+}
+
 const T = 32
 
 const SPLASH_MS = 10_000
@@ -837,10 +846,53 @@ function clearHeldQuestItems(quest: HubQuestDef): void {
   }
 }
 
+// Generic Talk / Give-a-gift choices, available on every named NPC regardless
+// of whatever else is showing (screen, quest, dialogue tree, relationship or
+// friendship greeting) — appended as the closing section of the top-level
+// dialogue shown on an NPC tap. `onFarewell` lets a caller chain a follow-up
+// dialogueEvent (e.g. quest-reward text) once the player dismisses via Farewell.
+function buildTalkGiveChoices(
+  npcId: string,
+  npcDef: NpcTapDef | undefined,
+  speakerName: string,
+  onFarewell?: () => void,
+): DialogueChoice[] {
+  const choices: DialogueChoice[] = []
+  const talkable = canTalkToday(npcId)
+  choices.push({
+    label: talkable ? '🗣️ Make conversation' : '🗣️ Make conversation (already caught up today)',
+    disabled: !talkable,
+    onClick: () => {
+      if (!talkable) return
+      recordTalk(npcId)
+      addFriendshipXp(npcId, 2)
+      grantRelationshipWithRivalry(npcId, 'ally', 1, locationData.HUB_NPCS)
+      refreshState()
+      setDialogueEvent({ speakerName, text: 'Always good to catch up.' })
+    },
+  })
+  const giftable = getHubItems().filter(i => i.category === 'material')
+  if (giftable.length > 0) {
+    choices.push({
+      label: '🎁 Give a gift',
+      onClick: () => {
+        const giftChoices: DialogueChoice[] = giftable.map(item => ({
+          label: `${item.icon ?? '🎁'} ${item.name ?? item.id} ×${item.count}`,
+          onClick: () => giveGiftToNpc(npcId, speakerName, npcDef, item.id),
+        }))
+        giftChoices.push({ label: 'Never mind', onClick: () => setDialogueEvent(null) })
+        setDialogueEvent({ speakerName, text: 'What would you like to give?', choices: giftChoices })
+      },
+    })
+  }
+  choices.push({ label: 'Farewell', onClick: () => { setDialogueEvent(null); onFarewell?.() } })
+  return choices
+}
+
 // Offer the first available quest given by `giverId` (an NPC or interactable id).
 // Returns true if an offer dialogue was shown; false if there is nothing to
 // offer (caller falls through to screens / default dialogue).
-function tryOfferQuest(giverId: string, speakerName: string, onlyQuestId?: string): boolean {
+function tryOfferQuest(giverId: string, speakerName: string, onlyQuestId?: string, extraChoices: DialogueChoice[] = []): boolean {
   const giveQuests = questDefs.filter(q => q.giverNpcId === giverId && (!onlyQuestId || q.id === onlyQuestId))
   const atOfferCap = questDefs.filter(q => getQuestState(q.id).status === 'active').length >= 2
   for (const quest of giveQuests) {
@@ -871,6 +923,7 @@ function tryOfferQuest(giverId: string, speakerName: string, onlyQuestId?: strin
             label: 'Not now',
             onClick: () => setDialogueEvent(null),
           },
+          ...extraChoices,
         ],
       })
       return true
@@ -893,24 +946,34 @@ function hasOfferableQuest(giverId: string): boolean {
 }
 
   // Mark a quest completed, grant its reward, and show its completion dialogue.
-  function completeQuestFor(quest: HubQuestDef, speakerName: string): void {
+  // `topLevel` marks this as the direct result of an NPC tap (not a follow-up
+  // click) — only then is Talk/Give appended to the completion choices, with
+  // Farewell chaining to the reward-text follow-up dialogueEvent instead of
+  // the plain onClose/auto-dismiss path (which no longer fires once choices
+  // are present).
+  function completeQuestFor(quest: HubQuestDef, speakerName: string, npcId?: string, npcDef?: NpcTapDef, topLevel = false): void {
     setQuestStatus(quest.id, 'completed')
     clearHeldQuestItems(quest)
     grantQuestReward(quest, locationData.HUB_NPCS)
     if (quest.reward.crystals) onCrystalsChange?.(loadCrystals())
     refreshState()
     const rewardText = formatQuestReward(quest.reward)
+    const afterClose = rewardText ? () => setDialogueEvent({ speakerName: '', text: rewardText }) : undefined
     setDialogueEvent({
       speakerName,
       text: quest.completeDialogue,
-      ...(rewardText ? { onClose: () => setDialogueEvent({ speakerName: '', text: rewardText }) } : {}),
+      ...(topLevel
+        ? { choices: buildTalkGiveChoices(npcId!, npcDef, speakerName, afterClose) }
+        : (afterClose ? { onClose: afterClose } : {})),
     })
   }
 
   // ── Branching dialogue-tree walker ──────────────────────────────────────────
   // Renders a node (text + visible choices) into the shared dialogue UI, then
   // applies a choice's effects and advances to the next node (or ends).
-  function runDialogueNode(tree: DialogueTree, nodeId: string, npcId: string, speakerName: string): void {
+  // `topLevel` marks the entry call (a fresh NPC tap) — only then is Talk/Give
+  // appended, so walking deeper into the tree doesn't re-show it at every node.
+  function runDialogueNode(tree: DialogueTree, nodeId: string, npcId: string, speakerName: string, npcDef?: NpcTapDef, topLevel = false): void {
     const node = tree.nodes[nodeId]
     if (!node) { setDialogueEvent(null); return }
     markNodeSeen(tree.id, nodeId)
@@ -922,15 +985,17 @@ function hasOfferableQuest(giverId: string): boolean {
       (!c.requireFestival || c.requireFestival === activeFestival?.id) &&
       (!c.requireWeather || c.requireWeather === currentWeather)
     )
+    const speaker = node.speakerName ?? speakerName
     const choices: DialogueChoice[] = visible.map((c, i) => ({
       label:   c.label,
       primary: i === 0,
       onClick: () => applyChoice(tree, c, npcId, speakerName),
     }))
+    const finalChoices = topLevel ? [...choices, ...buildTalkGiveChoices(npcId, npcDef, speaker)] : choices
     setDialogueEvent({
-      speakerName: node.speakerName ?? speakerName,
+      speakerName: speaker,
       text:        node.text,
-      ...(choices.length > 0 ? { choices } : {}),
+      ...(finalChoices.length > 0 ? { choices: finalChoices } : {}),
     })
   }
 
@@ -1020,14 +1085,7 @@ function hasOfferableQuest(giverId: string): boolean {
     // Placed animals (HUB_ANIMALS) reuse all NPC quest logic — they share the
     // same id space as quest giverNpcId / receiverNpcId / targetNpcId.
     const namedNpc = locationData.HUB_NPCS.find(n => n.id === npcId)
-    const npcDef: {
-      name?: string; dialogue?: string[]; screen?: string; building?: string
-      questGive?: string; questReceive?: string | string[]
-      innRumours?: Array<{ id: string; text: string }>
-      dialogueTree?: string
-      favoriteGiftItemId?: string; favoriteGiftTrack?: string
-      dislikedGiftItemIds?: string[]
-    } | undefined =
+    const npcDef: NpcTapDef | undefined =
       namedNpc ??
       locationData.HUB_ANIMALS.find(a => a.id === npcId)
     const speakerName = npcDef?.name ?? ''
@@ -1092,7 +1150,6 @@ function hasOfferableQuest(giverId: string): boolean {
         label: screenEnterLabel(screen),
         onClick: () => handleNodeInteract(screen, npcDef.building),
       }
-      const dismiss: DialogueChoice = { label: 'Maybe later', onClick: () => setDialogueEvent(null) }
 
       // Build at most one quest choice, in priority order: deliver → turn in →
       // accept. Shown first (primary) so it reads as the obvious action.
@@ -1122,7 +1179,7 @@ function hasOfferableQuest(giverId: string): boolean {
           onClick: () => { if (!tryOfferQuest(npcId, speakerName)) setDialogueEvent(null) } }
       }
 
-      const choices = [questChoice, enterChoice, dismiss].filter(Boolean) as DialogueChoice[]
+      const choices = [questChoice, enterChoice, ...buildTalkGiveChoices(npcId, npcDef, speakerName)].filter(Boolean) as DialogueChoice[]
       setDialogueEvent({ speakerName, text: line || "What'll it be?", choices })
       return
     }
@@ -1134,15 +1191,15 @@ function hasOfferableQuest(giverId: string): boolean {
       if (del) {
         incrementQuestProgress(del.quest.id, del.step.key)
         refreshState()
-        if (isQuestReadyToComplete(del.quest)) completeQuestFor(del.quest, speakerName)
+        if (isQuestReadyToComplete(del.quest)) completeQuestFor(del.quest, speakerName, npcId, npcDef, true)
         // Delivered but the quest still needs more — acknowledge so the player
         // sees feedback instead of (e.g.) the NPC's screen opening silently.
-        else setDialogueEvent({ speakerName, text: getActiveDialogue(del.quest) })
+        else setDialogueEvent({ speakerName, text: getActiveDialogue(del.quest), choices: buildTalkGiveChoices(npcId, npcDef, speakerName) })
         return
       }
       const ready = readyToHandIn()
       if (ready) {
-        completeQuestFor(ready, speakerName)
+        completeQuestFor(ready, speakerName, npcId, npcDef, true)
         return
       }
     }
@@ -1158,15 +1215,15 @@ function hasOfferableQuest(giverId: string): boolean {
     for (const quest of giveQuests) {
       if (getQuestState(quest.id).status !== 'active') continue
       if (quest.receiverNpcId === npcId && isQuestReadyToComplete(quest)) {
-        completeQuestFor(quest, speakerName)
+        completeQuestFor(quest, speakerName, npcId, npcDef, true)
         return
       }
-      setDialogueEvent({ speakerName, text: getActiveDialogue(quest) })
+      setDialogueEvent({ speakerName, text: getActiveDialogue(quest), choices: buildTalkGiveChoices(npcId, npcDef, speakerName) })
       return
     }
 
     // Second pass: first available quest whose prerequisites are met
-    if (tryOfferQuest(npcId, speakerName)) return
+    if (tryOfferQuest(npcId, speakerName, undefined, buildTalkGiveChoices(npcId, npcDef, speakerName))) return
 
     // (Screen NPCs are handled by the screen branch near the top of this
     // function, so there is no screen-navigation fallthrough here.)
@@ -1184,7 +1241,7 @@ function hasOfferableQuest(giverId: string): boolean {
         .filter(t => rel.level >= t.minLevel)
         .sort((a, b) => b.minLevel - a.minLevel)
       if (lines.length > 0) {
-        setDialogueEvent({ speakerName, text: lines[0].text })
+        setDialogueEvent({ speakerName, text: lines[0].text, choices: buildTalkGiveChoices(npcId, npcDef, speakerName) })
         return
       }
     }
@@ -1198,7 +1255,7 @@ function hasOfferableQuest(giverId: string): boolean {
         .filter(t => level >= t.minLevel)
         .sort((a, b) => b.minLevel - a.minLevel)
       if (tiers.length > 0) {
-        setDialogueEvent({ speakerName, text: tiers[0].text })
+        setDialogueEvent({ speakerName, text: tiers[0].text, choices: buildTalkGiveChoices(npcId, npcDef, speakerName) })
         return
       }
     }
@@ -1208,7 +1265,7 @@ function hasOfferableQuest(giverId: string): boolean {
     if (treeId) {
       const tree = ALL_QUESTS.HUB_DIALOGUES[treeId]
       if (tree) {
-        runDialogueNode(tree, tree.start, npcId, speakerName)
+        runDialogueNode(tree, tree.start, npcId, speakerName, npcDef, true)
         return
       }
     }
@@ -1218,36 +1275,7 @@ function hasOfferableQuest(giverId: string): boolean {
     // a real way to advance friendship/relationship, since simply cycling the
     // plain `dialogue` array otherwise has zero mechanical effect.
     if (namedNpc) {
-      const choices: DialogueChoice[] = []
-      const talkable = canTalkToday(npcId)
-      choices.push({
-        label: talkable ? '🗣️ Make conversation' : '🗣️ Make conversation (already caught up today)',
-        disabled: !talkable,
-        onClick: () => {
-          if (!talkable) return
-          recordTalk(npcId)
-          addFriendshipXp(npcId, 2)
-          grantRelationshipWithRivalry(npcId, 'ally', 1, locationData.HUB_NPCS)
-          refreshState()
-          setDialogueEvent({ speakerName, text: 'Always good to catch up.' })
-        },
-      })
-      const giftable = getHubItems().filter(i => i.category === 'material')
-      if (giftable.length > 0) {
-        choices.push({
-          label: '🎁 Give a gift',
-          onClick: () => {
-            const giftChoices: DialogueChoice[] = giftable.map(item => ({
-              label: `${item.icon ?? '🎁'} ${item.name ?? item.id} ×${item.count}`,
-              onClick: () => giveGiftToNpc(npcId, speakerName, npcDef, item.id),
-            }))
-            giftChoices.push({ label: 'Never mind', onClick: () => setDialogueEvent(null) })
-            setDialogueEvent({ speakerName, text: 'What would you like to give?', choices: giftChoices })
-          },
-        })
-      }
-      choices.push({ label: 'Farewell', onClick: () => setDialogueEvent(null) })
-      setDialogueEvent({ speakerName, text: line, choices })
+      setDialogueEvent({ speakerName, text: line, choices: buildTalkGiveChoices(npcId, npcDef, speakerName) })
       return
     }
 


### PR DESCRIPTION
## Summary

- NPCs with a shop, an active/offerable quest, or a dialogue tree previously never showed the generic 🗣️ Make conversation / 🎁 Give a gift choices, since `handleNpcTap` picked the first matching case in an if/return waterfall (documented as intentional in `docs/hubworld.md` §7d).
- Extracted the Talk/Give logic into a shared `buildTalkGiveChoices` helper and appended it to every **top-level** dialogue branch (screen NPCs, cross-town delivery, active/offerable quests, relationship/friendship overrides, dialogue-tree root node) so all three categories — NPC-specific options, quest options, and talk/give — now combine in the same modal.
- Bounty-report ticks and Innkeeper Rosie's inn-rumour reveal are left unchanged (auto-dismissing plain text), since they're automatic side effects of a tap rather than a real conversation turn.
- Follow-up dialogueEvents reached by tapping an earlier choice (dialogue-tree later nodes, the gift-item picker, a quest offer's Accept/Not-now reached mid-tree, reward text after a quest completes) don't get Talk/Give re-appended.
- Updated `docs/hubworld.md` §7d (and a pointer in §7b) to describe the new behavior.

## Test plan

- [x] `tsc --noEmit` — clean
- [x] `npm run test` — 383/383 passing
- [x] `npm run build` — succeeds
- [x] Verified via Storybook (`HubWorldQuests` stories) that the hub world still renders correctly with the change
- [x] Manually traced every changed branch against the intended combined-choice behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVei2fjQicJvDNBzZH13GB

---
_Generated by [Claude Code](https://claude.ai/code/session_01YVei2fjQicJvDNBzZH13GB)_