### PR TITLE
Hubworld: consolidate toolbar modals into one tabbed Menu

### DIFF
--- a/web/src/components/hub/HubInventoryModal.tsx
+++ b/web/src/components/hub/HubInventoryModal.tsx
@@ -43,7 +43,7 @@ function activeQuestItemRows(questDefs: HubQuestDef[]): QuestItemRow[] {
   return rows
 }
 
-export function HubInventoryModal({ onClose, questDefs }: Props) {
+export function HubInventoryContent({ onClose, questDefs }: Props) {
   const questRows = activeQuestItemRows(questDefs)
 
   const hubItems = getHubItems()
@@ -61,7 +61,6 @@ export function HubInventoryModal({ onClose, questDefs }: Props) {
   )
 
   return (
-    <ModalBackdrop onClose={onClose}>
       <div className="quests-modal">
         <div className="quests-modal__header">
           <span>🎒 Inventory</span>
@@ -112,6 +111,13 @@ export function HubInventoryModal({ onClose, questDefs }: Props) {
           </div>
         )}
       </div>
+  )
+}
+
+export function HubInventoryModal(props: Props) {
+  return (
+    <ModalBackdrop onClose={props.onClose}>
+      <HubInventoryContent {...props} />
     </ModalBackdrop>
   )
 }

--- a/web/src/components/hub/HubTabbedModal.stories.tsx
+++ b/web/src/components/hub/HubTabbedModal.stories.tsx
@@ -1,0 +1,59 @@
+import { useState } from 'react'
+import { fn } from 'storybook/test'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { HubTabbedModal, type HubTabId } from './HubTabbedModal'
+import { RAVENWATCH } from '../../data/hub/hubWorldFactory'
+import { getUpgradeTrack } from '../../data/hub/buildingUpgrades'
+import type { UpgradeRow } from './HubTownUpgrades'
+
+const shop = getUpgradeTrack('shop')
+const upgradeRows: UpgradeRow[] = [
+  {
+    buildingId: 'card-shop', name: 'The Card Emporium', kind: 'shop', level: 1, total: shop.length,
+    next: { def: shop[1], level: 1, total: shop.length, cost: shop[1].cost, repRequired: shop[1].repRequired, repLocked: false, maxed: false },
+  },
+]
+
+function Interactive({ initialTab, hasPet }: { initialTab: HubTabId; hasPet: boolean }) {
+  const [activeTab, setActiveTab] = useState<HubTabId>(initialTab)
+  return (
+    <HubTabbedModal
+      onClose={fn()}
+      activeTab={activeTab}
+      onTabChange={setActiveTab}
+      hasPet={hasPet}
+      onAbandon={fn()}
+      questDefs={[]}
+      allQuestDefs={[]}
+      locationData={RAVENWATCH}
+      pinnedNpcId={null}
+      onTogglePin={fn()}
+      onShowRelationship={fn()}
+      townName="Ravenwatch"
+      reputation={80}
+      crystals={500}
+      rows={upgradeRows}
+      onUpgrade={fn()}
+      tributeAmount={34}
+      tributeAvailable={true}
+      onCollectTribute={fn()}
+    />
+  )
+}
+
+const meta = {
+  component: Interactive,
+  parameters: { layout: 'fullscreen' },
+  decorators: [(Story) => (<div className="game-container"><Story /></div>)],
+} satisfies Meta<typeof Interactive>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: { initialTab: 'quests', hasPet: false },
+}
+
+export const UpgradesTabWithPet: Story = {
+  args: { initialTab: 'upgrades', hasPet: true },
+}

--- a/web/src/components/hub/HubTabbedModal.tsx
+++ b/web/src/components/hub/HubTabbedModal.tsx
@@ -1,0 +1,115 @@
+import React from 'react'
+import { ModalBackdrop } from '../ui/ModalBackdrop'
+import type { HubQuestDef } from '../../data/hub/questDefs'
+import type { HubLocationBundle } from '../../data/hub/loader'
+import { QuestsContent } from './QuestsModal'
+import { HubInventoryContent } from './HubInventoryModal'
+import { TradeJournalContent } from './TradeJournalModal'
+import { TownDirectoryContent } from './TownDirectory'
+import { TownJournalContent } from './TownJournal'
+import { HubTownUpgradesContent, type UpgradeRow } from './HubTownUpgrades'
+import { PetContent } from './PetModal'
+
+export type HubTabId = 'quests' | 'inventory' | 'trade-journal' | 'directory' | 'journal' | 'upgrades' | 'pet'
+
+interface Props {
+  onClose: () => void
+  activeTab: HubTabId
+  onTabChange: (tab: HubTabId) => void
+  hasPet: boolean
+
+  // Quests
+  onAbandon: (questId: string) => void
+  questDefs: HubQuestDef[]
+  resolveNpcName?: (id: string) => string
+
+  // Inventory
+  allQuestDefs: HubQuestDef[]
+
+  // Where is / Journal
+  locationData: HubLocationBundle
+  pinnedNpcId: string | null
+  onTogglePin: (npcId: string) => void
+  onShowRelationship: (npcId: string) => void
+
+  // Upgrades
+  townName: string
+  reputation: number
+  crystals: number
+  rows: UpgradeRow[]
+  onUpgrade: (buildingId: string) => void
+  tributeAmount: number
+  tributeAvailable: boolean
+  onCollectTribute: () => void
+
+  // Pet
+  petActionRef?: React.MutableRefObject<{ setPetAccessory: (assetId: string | null) => void } | null>
+}
+
+const ALL_TABS: { id: HubTabId; icon: string; label: string }[] = [
+  { id: 'quests',        icon: '📜',   label: 'Quests' },
+  { id: 'inventory',     icon: '🎒',   label: 'Inventory' },
+  { id: 'trade-journal', icon: '💱',   label: 'Trade Journal' },
+  { id: 'directory',     icon: '🧭',   label: 'Where is…?' },
+  { id: 'journal',       icon: '📖',   label: 'Journal' },
+  { id: 'upgrades',      icon: '🏗️', label: 'Upgrades' },
+  { id: 'pet',           icon: '🐾',   label: 'My Pet' },
+]
+
+export function HubTabbedModal(props: Props) {
+  const {
+    onClose, activeTab, onTabChange, hasPet,
+    onAbandon, questDefs, resolveNpcName,
+    allQuestDefs,
+    locationData, pinnedNpcId, onTogglePin, onShowRelationship,
+    townName, reputation, crystals, rows, onUpgrade, tributeAmount, tributeAvailable, onCollectTribute,
+    petActionRef,
+  } = props
+
+  const tabs = ALL_TABS.filter(t => t.id !== 'pet' || hasPet)
+  const tab = activeTab === 'pet' && !hasPet ? 'quests' : activeTab
+
+  return (
+    <ModalBackdrop onClose={onClose}>
+      <div className="hub-tabbed-modal">
+        <div className="hoa-tabs">
+          {tabs.map(t => (
+            <button
+              key={t.id}
+              className={`hoa-tab${t.id === tab ? ' hoa-tab--active' : ''}`}
+              onClick={() => onTabChange(t.id)}
+            >
+              {t.icon} {t.label}
+            </button>
+          ))}
+        </div>
+        <div className="hub-tabbed-modal__body">
+          {tab === 'quests' && (
+            <QuestsContent onClose={onClose} onAbandon={onAbandon} questDefs={questDefs} resolveNpcName={resolveNpcName} />
+          )}
+          {tab === 'inventory' && (
+            <HubInventoryContent onClose={onClose} questDefs={allQuestDefs} />
+          )}
+          {tab === 'trade-journal' && (
+            <TradeJournalContent onClose={onClose} />
+          )}
+          {tab === 'directory' && (
+            <TownDirectoryContent onClose={onClose} locationData={locationData} pinnedNpcId={pinnedNpcId} onTogglePin={onTogglePin} onShowRelationship={onShowRelationship} />
+          )}
+          {tab === 'journal' && (
+            <TownJournalContent onClose={onClose} locationData={locationData} />
+          )}
+          {tab === 'upgrades' && (
+            <HubTownUpgradesContent
+              onClose={onClose} townName={townName} reputation={reputation} crystals={crystals} rows={rows} onUpgrade={onUpgrade}
+              tributeAmount={tributeAmount} tributeAvailable={tributeAvailable} onCollectTribute={onCollectTribute}
+            />
+          )}
+          {tab === 'pet' && (
+            <PetContent onClose={onClose} petActionRef={petActionRef} />
+          )}
+        </div>
+      </div>
+    </ModalBackdrop>
+  )
+}

--- a/web/src/components/hub/HubTownUpgrades.tsx
+++ b/web/src/components/hub/HubTownUpgrades.tsx
@@ -42,14 +42,13 @@ function reputationToNextTier(rep: number): { tier: number; label: string; progr
   return { tier, label, progress }
 }
 
-export function HubTownUpgrades({
+export function HubTownUpgradesContent({
   onClose, townName, reputation, crystals, rows, onUpgrade,
   tributeAmount, tributeAvailable, onCollectTribute,
 }: Props) {
   const rep = reputationToNextTier(reputation)
 
   return (
-    <ModalBackdrop onClose={onClose}>
       <div className="town-directory town-upgrades">
         <div className="town-directory__header">
           <span>🏗️ {townName} — Standing &amp; Upgrades</span>
@@ -133,6 +132,13 @@ export function HubTownUpgrades({
           </div>
         )}
       </div>
+  )
+}
+
+export function HubTownUpgrades(props: Props) {
+  return (
+    <ModalBackdrop onClose={props.onClose}>
+      <HubTownUpgradesContent {...props} />
     </ModalBackdrop>
   )
 }

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -31,17 +31,12 @@ import { loadPlayerName, addToConsumableStash } from '../../game/questline'
 import { LoginButton } from '../ui/LoginButton'
 import { addCollectible, addConsumable, getCollectibles, addHubItem, removeHubItem, getHubItemCount, hasHubItem, getHubItemCatalogEntry, getHubItems, spendTickets } from '../../game/itemStore'
 import { questItemId } from '../../game/hub/questItems'
-import { QuestsModal } from './QuestsModal'
-import { HubInventoryModal } from './HubInventoryModal'
-import { TradeJournalModal } from './TradeJournalModal'
+import { HubTabbedModal, type HubTabId } from './HubTabbedModal'
 import { BountyBoardModal } from './BountyBoardModal'
 import { hasUnclaimedBounties, getPendingBountyReport, getPendingBountyCollect, advanceBountyStep, getActiveBountyStep, isBountyCollectPickup, reconcileBountyPickups } from '../../game/hub/bounties'
-import { PetModal } from './PetModal'
 import { getActivePet, getTreatsRemainingToday, canGiveTreat, recordAffection, recordTreatGiven, getAffectionRemaining, grantAccessory } from '../../game/hub/pet'
 import { PLAYER_PET_ANIMAL_ID } from './hubAnimals'
-import { TownDirectory } from './TownDirectory'
-import { TownJournal } from './TownJournal'
-import { HubTownUpgrades, type UpgradeRow } from './HubTownUpgrades'
+import type { UpgradeRow } from './HubTownUpgrades'
 import { nextUpgrade, purchaseUpgrade, getTownReputation, getUpgradeLevel, setUpgradeKindResolver, tributeAmount, tributeAvailable, collectTribute } from '../../game/hub/reputation'
 import { RelationshipView } from './RelationshipView'
 import { resolveNpcPlace } from '../../game/hub/npcLocator'
@@ -243,14 +238,10 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onEndless, onWorldMap
   const [dialogueEvent,  setDialogueEvent]  = useState<QuestEvent | null>(null)
   const [interiorActive, setInteriorActive] = useState(false)
   const [pickedUpIds,    setPickedUpIds]    = useState<Set<string>>(() => { reconcileBountyPickups(); return getPickedUpIds() })
-  const [questsOpen,          setQuestsOpen]          = useState(false)
-  const [inventoryOpen,       setInventoryOpen]       = useState(false)
-  const [tradeJournalOpen,    setTradeJournalOpen]    = useState(false)
+  const [tabbedModalOpen,     setTabbedModalOpen]     = useState(false)
+  const [activeHubTab,        setActiveHubTab]        = useState<HubTabId>('quests')
   const [bountyBoardOpen,     setBountyBoardOpen]     = useState(false)
-  const [petModalOpen,        setPetModalOpen]        = useState(false)
-  const [directoryOpen,       setDirectoryOpen]       = useState(false)
-  const [journalOpen,         setJournalOpen]         = useState(false)
-  const [upgradesOpen,        setUpgradesOpen]        = useState(false)
+  function openHubTab(tab: HubTabId) { setActiveHubTab(tab); setTabbedModalOpen(true) }
   // buildingId → purchased upgrade level; read each frame by the canvas to
   // reveal unlocked decor live, and updated on purchase.
   const buildingUpgradeLevelsRef = useRef<Record<string, number>>({})
@@ -578,9 +569,9 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onEndless, onWorldMap
       onNarratorLog?.(screen.slice(9))
       return
     }
-    if (screen === 'town-upgrades') { setUpgradesOpen(true); return }
+    if (screen === 'town-upgrades') { openHubTab('upgrades'); return }
     if (screen === 'bounty-board') { setBountyBoardOpen(true); return }
-    if (screen === 'adopt-pet') { setPetModalOpen(true); return }
+    if (screen === 'adopt-pet') { openHubTab('pet'); return }
     if (screen === 'worldmap') { onWorldMap?.(); return }
     if (screen === 'campaign') { onCampaign?.(); return }
     if (screen === 'endless') { onEndless?.(); return }
@@ -1331,7 +1322,7 @@ function hasOfferableQuest(giverId: string): boolean {
   const handleAnimalTap = useCallback((animalId: string) => {
     if (animalId === PLAYER_PET_ANIMAL_ID) {
       const pet = getActivePet()
-      if (!pet) { setPetModalOpen(true); return }
+      if (!pet) { openHubTab('pet'); return }
       const flavor = petFlavor(pet.type)
       const remaining = getTreatsRemainingToday()
       const affectionRemaining = getAffectionRemaining()
@@ -1364,7 +1355,7 @@ function hasOfferableQuest(giverId: string): boolean {
         { label: 'Pet', onClick: () => { petActionRef.current?.givePetAffection(); recordAffection(); refreshState(); setDialogueEvent({ speakerName: pet.name, text: flavor.pet(pet.name) }) } },
         { label: 'Belly Rubs', onClick: () => { petActionRef.current?.givePetAffection(); recordAffection(); refreshState(); setDialogueEvent({ speakerName: pet.name, text: flavor.bellyRubs(pet.name) }) } },
         { label: 'Brush', onClick: () => { petActionRef.current?.givePetAffection(); recordAffection(); refreshState(); setDialogueEvent({ speakerName: pet.name, text: flavor.brush(pet.name) }) } },
-        { label: 'Manage', onClick: () => setPetModalOpen(true) },
+        { label: 'Manage', onClick: () => openHubTab('pet') },
         { label: 'Never mind', onClick: () => setDialogueEvent(null) },
       ]
       setDialogueEvent({ speakerName: pet.name, text: 'What would you like to do?', choices })
@@ -1930,13 +1921,7 @@ function hasOfferableQuest(giverId: string): boolean {
           {activeFestival && (
             <ToolbarLabel className="title-deck-info">{activeFestival.icon} {activeFestival.name}</ToolbarLabel>
           )}
-        <ToolbarButton icon="📜" title="Quests" onClick={() => setQuestsOpen(true)} />
-        <ToolbarButton icon="🎒" title="Inventory" onClick={() => setInventoryOpen(true)} />
-        <ToolbarButton icon="💱" title="Trade Journal" onClick={() => setTradeJournalOpen(true)} />
-        <ToolbarButton icon="🧭" title="Where is…?" onClick={() => setDirectoryOpen(true)} />
-        <ToolbarButton icon="📖" title="Journal" onClick={() => setJournalOpen(true)} />
-        <ToolbarButton icon="🏗️" title="Town Upgrades" onClick={() => setUpgradesOpen(true)} />
-        {getActivePet() && <ToolbarButton icon="🐾" title="My Pet" onClick={() => setPetModalOpen(true)} />}
+        <ToolbarButton icon="📋" title="Menu" onClick={() => setTabbedModalOpen(true)} />
         <ToolbarButton icon="🗺" title="World Map" onClick={() => onWorldMap?.()}  disabled={getQuestState('thorin-the-last-watch').status !== 'completed'} />
 
         <ToolbarSpacer/>
@@ -2024,14 +2009,21 @@ function hasOfferableQuest(giverId: string): boolean {
           />
         )}
 
-        {questsOpen && <QuestsModal onClose={() => setQuestsOpen(false)} onAbandon={handleQuestAbandon} questDefs={questDefs} resolveNpcName={getNpcDisplayName}/>}
-        {inventoryOpen && <HubInventoryModal onClose={() => setInventoryOpen(false)} questDefs={allQuestDefs} />}
-        {tradeJournalOpen && <TradeJournalModal onClose={() => setTradeJournalOpen(false)} />}
+        {tabbedModalOpen && (
+          <HubTabbedModal
+            onClose={() => setTabbedModalOpen(false)}
+            activeTab={activeHubTab}
+            onTabChange={setActiveHubTab}
+            hasPet={!!getActivePet()}
+            onAbandon={handleQuestAbandon} questDefs={questDefs} resolveNpcName={getNpcDisplayName}
+            allQuestDefs={allQuestDefs}
+            locationData={locationData} pinnedNpcId={pinnedNpcId} onTogglePin={togglePinnedNpc} onShowRelationship={setRelationshipNpcId}
+            townName={town} reputation={getTownReputation(town)} crystals={loadCrystals()} rows={upgradeRows} onUpgrade={handleUpgrade}
+            tributeAmount={tributeAmount(town)} tributeAvailable={tributeAvailable(town)} onCollectTribute={handleCollectTribute}
+            petActionRef={petActionRef}
+          />
+        )}
         {bountyBoardOpen && <BountyBoardModal onClose={() => setBountyBoardOpen(false)} resolveNpcName={getNpcDisplayName} townNpcs={locationData.HUB_NPCS}/>}
-        {petModalOpen && <PetModal onClose={() => setPetModalOpen(false)} petActionRef={petActionRef} />}
-        {directoryOpen && <TownDirectory onClose={() => setDirectoryOpen(false)} locationData={locationData} pinnedNpcId={pinnedNpcId} onTogglePin={togglePinnedNpc} onShowRelationship={setRelationshipNpcId} />}
-        {journalOpen && <TownJournal onClose={() => setJournalOpen(false)} locationData={locationData} />}
-        {upgradesOpen && <HubTownUpgrades onClose={() => setUpgradesOpen(false)} townName={town} reputation={getTownReputation(town)} crystals={loadCrystals()} rows={upgradeRows} onUpgrade={handleUpgrade} tributeAmount={tributeAmount(town)} tributeAvailable={tributeAvailable(town)} onCollectTribute={handleCollectTribute} />}
         {relationshipNpcId && <RelationshipView npcName={getNpcDisplayName(relationshipNpcId)} entry={getRelationship(relationshipNpcId)} onClose={() => setRelationshipNpcId(null)} />}
         {openTreasure && <TreasureModal treasure={openTreasure} onClose={() => setOpenTreasure(null)} />}
 

--- a/web/src/components/hub/PetModal.tsx
+++ b/web/src/components/hub/PetModal.tsx
@@ -135,7 +135,7 @@ function AccessoriesTab({ petActionRef, refresh }: {
   )
 }
 
-export function PetModal({ onClose, petActionRef }: Props) {
+export function PetContent({ onClose, petActionRef }: Props) {
   const [, setTick] = useState(0)
   const refresh = () => setTick(t => t + 1)
   const [renameValue, setRenameValue] = useState<string | null>(null)
@@ -171,7 +171,6 @@ export function PetModal({ onClose, petActionRef }: Props) {
   }
 
   return (
-    <ModalBackdrop onClose={onClose}>
       <div className="pet-modal">
         <div className="pet-modal__header">
           <span>🐾 {pet ? 'My Pet' : 'Pet Shelter'}</span>
@@ -227,6 +226,13 @@ export function PetModal({ onClose, petActionRef }: Props) {
           />
         )}
       </div>
+  )
+}
+
+export function PetModal(props: Props) {
+  return (
+    <ModalBackdrop onClose={props.onClose}>
+      <PetContent {...props} />
     </ModalBackdrop>
   )
 }

--- a/web/src/components/hub/QuestsModal.tsx
+++ b/web/src/components/hub/QuestsModal.tsx
@@ -38,7 +38,7 @@ function getActiveHint(quest: HubQuestDef): string {
   return Object.values(activeDialogue)[Object.values(activeDialogue).length - 1] || "Hello"
 }
 
-export function QuestsModal({ onClose, onAbandon, questDefs, resolveNpcName = (id) => id }: Props) {
+export function QuestsContent({ onClose, onAbandon, questDefs, resolveNpcName = (id) => id }: Props) {
   const [confirmingId, setConfirmingId] = useState<string | null>(null)
 
   const active    = questDefs.filter(q => getQuestState(q.id).status === 'active')
@@ -49,7 +49,6 @@ export function QuestsModal({ onClose, onAbandon, questDefs, resolveNpcName = (i
   const acceptedBounties = getDailyBounties().filter(b => isBountyAccepted(b.id) && !isBountyCompleted(b.id))
 
   return (
-    <ModalBackdrop onClose={onClose}>
       <div className="quests-modal">
         <div className="quests-modal__header">
           <span>📜 Quests</span>
@@ -141,6 +140,13 @@ export function QuestsModal({ onClose, onAbandon, questDefs, resolveNpcName = (i
           </>
         )}
       </div>
+  )
+}
+
+export function QuestsModal(props: Props) {
+  return (
+    <ModalBackdrop onClose={props.onClose}>
+      <QuestsContent {...props} />
     </ModalBackdrop>
   )
 }

--- a/web/src/components/hub/TownDirectory.tsx
+++ b/web/src/components/hub/TownDirectory.tsx
@@ -16,7 +16,7 @@ interface Props {
   onShowRelationship: (npcId: string) => void
 }
 
-export function TownDirectory({ onClose, locationData, pinnedNpcId, onTogglePin, onShowRelationship }: Props) {
+export function TownDirectoryContent({ onClose, locationData, pinnedNpcId, onTogglePin, onShowRelationship }: Props) {
   const { gameHour } = useHubClock()
   const [onlyMet, setOnlyMet] = useState(false)
 
@@ -33,7 +33,6 @@ export function TownDirectory({ onClose, locationData, pinnedNpcId, onTogglePin,
     .sort((a, b) => a.name.localeCompare(b.name))
 
   return (
-    <ModalBackdrop onClose={onClose}>
       <div className="town-directory">
         <div className="town-directory__header">
           <span>🧭 Where is…?</span>
@@ -90,6 +89,13 @@ export function TownDirectory({ onClose, locationData, pinnedNpcId, onTogglePin,
           </div>
         )}
       </div>
+  )
+}
+
+export function TownDirectory(props: Props) {
+  return (
+    <ModalBackdrop onClose={props.onClose}>
+      <TownDirectoryContent {...props} />
     </ModalBackdrop>
   )
 }

--- a/web/src/components/hub/TownJournal.tsx
+++ b/web/src/components/hub/TownJournal.tsx
@@ -36,7 +36,7 @@ interface Props {
   locationData: HubLocationBundle
 }
 
-export function TownJournal({ onClose, locationData }: Props) {
+export function TownJournalContent({ onClose, locationData }: Props) {
   const [tab, setTab] = useState<Tab>('animals')
 
   const seenAnimalTypes = getSeenAnimalTypes()
@@ -68,7 +68,6 @@ export function TownJournal({ onClose, locationData }: Props) {
   const overallPct = overallTotal > 0 ? Math.round((overallDiscovered / overallTotal) * 100) : 0
 
   return (
-    <ModalBackdrop onClose={onClose}>
       <div className="town-directory town-journal">
         <div className="town-directory__header">
           <span>📖 Town Journal</span>
@@ -164,6 +163,13 @@ export function TownJournal({ onClose, locationData }: Props) {
           </div>
         )}
       </div>
+  )
+}
+
+export function TownJournal(props: Props) {
+  return (
+    <ModalBackdrop onClose={props.onClose}>
+      <TownJournalContent {...props} />
     </ModalBackdrop>
   )
 }

--- a/web/src/components/hub/TradeJournalModal.tsx
+++ b/web/src/components/hub/TradeJournalModal.tsx
@@ -12,7 +12,7 @@ function itemDisplay(itemId: string): { name: string; icon: string } {
   return { name: catalog?.name ?? itemId, icon: catalog?.icon ?? '📦' }
 }
 
-export function TradeJournalModal({ onClose }: Props) {
+export function TradeJournalContent({ onClose }: Props) {
   const sellers = getKnownSellers()
   const buyers = getKnownBuyers()
 
@@ -44,7 +44,6 @@ export function TradeJournalModal({ onClose }: Props) {
   }
 
   return (
-    <ModalBackdrop onClose={onClose}>
       <div className="quests-modal">
         <div className="quests-modal__header">
           <span>💱 Trade Journal</span>
@@ -67,6 +66,13 @@ export function TradeJournalModal({ onClose }: Props) {
           buyers.map(buyerRow)
         )}
       </div>
+  )
+}
+
+export function TradeJournalModal(props: Props) {
+  return (
+    <ModalBackdrop onClose={props.onClose}>
+      <TradeJournalContent {...props} />
     </ModalBackdrop>
   )
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -15314,6 +15314,33 @@ html.light-mode .action-btn {
   line-height: 1;
 }
 .quests-modal__close:hover { color: #88cc88; }
+
+/* ─── Hub Tabbed Modal (Menu) ────────────────────────── */
+
+.hub-tabbed-modal {
+  background: rgba(8, 14, 8, 0.97);
+  border: 1px solid #446644;
+  color: #c8e8c8;
+  width: min(460px, 92vw);
+  max-height: 80vh;
+  border-radius: 4px;
+  font-family: monospace;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+.hub-tabbed-modal .hoa-tabs { flex: 0 0 auto; }
+.hub-tabbed-modal__body { flex: 1 1 auto; overflow-y: auto; }
+.hub-tabbed-modal__body > .quests-modal,
+.hub-tabbed-modal__body > .town-directory,
+.hub-tabbed-modal__body > .pet-modal {
+  background: none;
+  border: none;
+  width: auto;
+  max-height: none;
+  overflow: visible;
+  padding: 12px 20px 20px;
+}
 .quests-modal__empty {
   font-size: 11px;
   color: #557755;


### PR DESCRIPTION
## Summary

- Replace the 7 separate hub toolbar buttons/modals (Quests, Inventory, Trade Journal, Where is…?, Journal, Town Upgrades, My Pet) with a single 📋 **Menu** button that opens a tabbed `HubTabbedModal`, so players can cross-reference info (e.g. quests + inventory) without closing/reopening modals.
- Each modal (`QuestsModal`, `HubInventoryModal`, `TradeJournalModal`, `TownDirectory`, `TownJournal`, `HubTownUpgrades`, `PetModal`) now exports its inner content separately from its `ModalBackdrop` wrapper, so the same content renders standalone (unchanged, e.g. `QuestsModal` on the World Map screen) or embedded as a tab.
- In-world triggers (tapping the Town Upgrades building, adopting a pet) now open the Menu directly on the relevant tab; the toolbar button itself reopens on whichever tab was last viewed.
- Added `.hub-tabbed-modal` styling that gives the tabbed view one shared panel instead of stacking each tab's own background/border.

## Test plan

- [x] `tsc --noEmit` passes (pre-existing unrelated `App.tsx` module-resolution errors confirmed present on the base branch too)
- [x] `vitest run` — all 383 tests pass
- [x] Verified visually via Storybook (`HubTabbedModal.stories.tsx`, new): Quests, Upgrades (with My Pet tab shown), Where is…?, and Pet Shelter tabs all render correctly and blend into a single panel
- [ ] Manual in-game click-through of the Menu button and in-world triggers (Town Upgrades building, adopt-pet) — not runnable in this sandbox since the dev server needs real Firebase credentials to mount (confirmed pre-existing, unrelated to this change)


---
_Generated by [Claude Code](https://claude.ai/code/session_01KLs1HgTBbTDqB457DvTaP6)_