### PR TITLE
Consolidate NPC dialogues to a single, trailing exit choice

### DIFF
--- a/docs/hubworld.md
+++ b/docs/hubworld.md
@@ -390,8 +390,10 @@ Authored in `questDefs.json` under a top-level `dialogues` array and attached to
 an NPC via `dialogueTree` (the id of the tree). When such an NPC is tapped and has
 no higher-priority interaction (quest offer/completion, screen, friendship-tier
 line), `HubWorld.tsx` walks the tree instead of the linear `dialogue` cycle. The
-tree's entry (root) node also gets Talk/Give (§7d) appended to its authored
-choices; later nodes reached by picking a choice do not.
+tree's entry (root) node also gets Talk/Give (§7d) inserted ahead of the
+node's exit — its own authored `end`-effect "leave" choice if it has one, or
+else a generic trailing "Farewell" — so there is always exactly one exit,
+last; later nodes reached by picking a choice do not get Talk/Give at all.
 
 Types live in `web/src/data/hub/questDefs.ts`; the walker (`runDialogueNode` /
 `applyChoice`) lives in `web/src/components/hub/HubWorld.tsx`. Reuses the existing
@@ -610,20 +612,28 @@ rivalry (no chains).
 Every named NPC gets two always-available dialogue choices — no authoring
 required — so the Town Directory's 💗 Relationship button has a real way to
 move even for the ~5 in 6 NPCs with no `dialogueTree` (§7b) and no active
-quest. Talk/Give is appended as the closing section of every **top-level**
-NPC dialogue (the modal shown as the direct result of a tap) — after any
-screen-enter choice, quest offer/turn-in choice, dialogue-tree root node's
-authored choices, or a relationship/friendship flavor line — so it always
-coexists with an NPC's other content in the same modal (built by the shared
-`buildTalkGiveChoices` helper in `HubWorld.tsx`). Follow-up dialogueEvents
-reached by tapping an earlier choice — a dialogue tree's later nodes, the
-gift-item picker, a quest offer's Accept/Not-now decision reached mid-tree,
-or the reward text shown after a quest completes — do **not** get Talk/Give
-re-appended, since the player already made their choice for this
-interaction. Two exceptions keep the old plain-text/auto-dismiss behavior
-and never gain Talk/Give: a bounty-report tick (§7e) and Innkeeper Rosie's
-inn-rumour reveal, since both are automatic incidental side effects of a tap
-rather than a real conversation turn.
+quest. Talk/Give is inserted into every **top-level** NPC dialogue (the modal
+shown as the direct result of a tap) — after any screen-enter choice, quest
+offer/turn-in choice, dialogue-tree root node's authored choices, or a
+relationship/friendship flavor line — so it always coexists with an NPC's
+other content in the same modal. Follow-up dialogueEvents reached by tapping
+an earlier choice — a dialogue tree's later nodes, the gift-item picker, a
+quest offer's Accept/Not-now decision reached mid-tree, or the reward text
+shown after a quest completes — do **not** get Talk/Give re-appended, since
+the player already made their choice for this interaction. Two exceptions
+keep the old plain-text/auto-dismiss behavior and never gain Talk/Give: a
+bounty-report tick (§7e) and Innkeeper Rosie's inn-rumour reveal, since both
+are automatic incidental side effects of a tap rather than a real
+conversation turn.
+
+The dialogue always ends with **exactly one** trailing exit choice. Where the
+NPC's own flow already supplies a decline/exit — a quest offer's "Not now",
+or a dialogue tree root node's authored `end`-effect "leave" choice — that
+existing choice is reused as the single trailing exit, and only the
+🗣️/🎁 options are inserted ahead of it (`buildTalkGiveOptions` in
+`HubWorld.tsx`). Only when nothing already provides an exit does the closing
+section add its own generic "Farewell" (`buildTalkGiveChoices`, a thin
+wrapper around `buildTalkGiveOptions` that appends Farewell).
 
 - **🗣️ Make conversation** — grants a small flat friendship XP + 1 `ally`
   relationship point. Limited to once per real day per NPC

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -846,16 +846,17 @@ function clearHeldQuestItems(quest: HubQuestDef): void {
   }
 }
 
-// Generic Talk / Give-a-gift choices, available on every named NPC regardless
+// Generic Talk / Give-a-gift options, available on every named NPC regardless
 // of whatever else is showing (screen, quest, dialogue tree, relationship or
-// friendship greeting) — appended as the closing section of the top-level
-// dialogue shown on an NPC tap. `onFarewell` lets a caller chain a follow-up
-// dialogueEvent (e.g. quest-reward text) once the player dismisses via Farewell.
-function buildTalkGiveChoices(
+// friendship greeting) — inserted ahead of whichever choice serves as the
+// dialogue's single trailing exit. Split out from buildTalkGiveChoices below
+// so callers whose flow already has its own exit (a quest offer's "Not now",
+// a dialogue tree's authored end-effect choice) can insert just the options
+// without also getting a second, competing "Farewell".
+function buildTalkGiveOptions(
   npcId: string,
   npcDef: NpcTapDef | undefined,
   speakerName: string,
-  onFarewell?: () => void,
 ): DialogueChoice[] {
   const choices: DialogueChoice[] = []
   const talkable = canTalkToday(npcId)
@@ -885,8 +886,23 @@ function buildTalkGiveChoices(
       },
     })
   }
-  choices.push({ label: 'Farewell', onClick: () => { setDialogueEvent(null); onFarewell?.() } })
   return choices
+}
+
+// buildTalkGiveOptions plus a trailing generic "Farewell" exit — for callers
+// whose flow has no exit choice of its own. `onFarewell` lets a caller chain
+// a follow-up dialogueEvent (e.g. quest-reward text) once the player
+// dismisses via Farewell.
+function buildTalkGiveChoices(
+  npcId: string,
+  npcDef: NpcTapDef | undefined,
+  speakerName: string,
+  onFarewell?: () => void,
+): DialogueChoice[] {
+  return [
+    ...buildTalkGiveOptions(npcId, npcDef, speakerName),
+    { label: 'Farewell', onClick: () => { setDialogueEvent(null); onFarewell?.() } },
+  ]
 }
 
 // Offer the first available quest given by `giverId` (an NPC or interactable id).
@@ -919,11 +935,11 @@ function tryOfferQuest(giverId: string, speakerName: string, onlyQuestId?: strin
               setDialogueEvent(null)
             },
           },
+          ...extraChoices,
           {
             label: 'Not now',
             onClick: () => setDialogueEvent(null),
           },
-          ...extraChoices,
         ],
       })
       return true
@@ -986,12 +1002,34 @@ function hasOfferableQuest(giverId: string): boolean {
       (!c.requireWeather || c.requireWeather === currentWeather)
     )
     const speaker = node.speakerName ?? speakerName
-    const choices: DialogueChoice[] = visible.map((c, i) => ({
-      label:   c.label,
-      primary: i === 0,
-      onClick: () => applyChoice(tree, c, npcId, speakerName),
-    }))
-    const finalChoices = topLevel ? [...choices, ...buildTalkGiveChoices(npcId, npcDef, speaker)] : choices
+
+    let finalChoices: DialogueChoice[]
+    if (topLevel) {
+      // Some authored nodes already end in their own terminal "leave" choice
+      // (effects: [{ type: 'end' }], no `next`) — reuse that as the single
+      // trailing exit instead of also appending a generic "Farewell", so the
+      // player never sees two exit-style buttons. Nodes with no authored exit
+      // choice keep getting the full options+Farewell block, as before.
+      const isExitDef = (c: DialogueChoiceDef) => !c.next && (c.effects ?? []).some(e => e.type === 'end')
+      const nonExitDefs = visible.filter(c => !isExitDef(c))
+      const exitDefs    = visible.filter(isExitDef)
+      const toChoice = (c: DialogueChoiceDef, primary: boolean) => ({
+        label:   c.label,
+        primary,
+        onClick: () => applyChoice(tree, c, npcId, speakerName),
+      })
+      const nonExitChoices = nonExitDefs.map((c, i) => toChoice(c, i === 0))
+      finalChoices = exitDefs.length > 0
+        ? [...nonExitChoices, ...buildTalkGiveOptions(npcId, npcDef, speaker), ...exitDefs.map(c => toChoice(c, false))]
+        : [...nonExitChoices, ...buildTalkGiveChoices(npcId, npcDef, speaker)]
+    } else {
+      finalChoices = visible.map((c, i) => ({
+        label:   c.label,
+        primary: i === 0,
+        onClick: () => applyChoice(tree, c, npcId, speakerName),
+      }))
+    }
+
     setDialogueEvent({
       speakerName: speaker,
       text:        node.text,
@@ -1223,7 +1261,7 @@ function hasOfferableQuest(giverId: string): boolean {
     }
 
     // Second pass: first available quest whose prerequisites are met
-    if (tryOfferQuest(npcId, speakerName, undefined, buildTalkGiveChoices(npcId, npcDef, speakerName))) return
+    if (tryOfferQuest(npcId, speakerName, undefined, buildTalkGiveOptions(npcId, npcDef, speakerName))) return
 
     // (Screen NPCs are handled by the screen branch near the top of this
     // function, so there is no screen-navigation fallthrough here.)


### PR DESCRIPTION
## Summary

Follow-up to #1906. Appending the generic Talk/Give-gift block to every top-level NPC dialogue introduced a second exit-style choice wherever the NPC's flow already had one:

- **Quest offers** (`tryOfferQuest`) already show `Accept` / `Not now`. The reported case — Dockhand Bram in Millhaven — ended up with `[Accept, Not now, Make conversation, Give a gift?, Farewell]`, two exits, with "Not now" not even last.
- **Dialogue trees**: scanning every town's `questDefs.json`, ~35 trees author their own terminal "leave" choice (`effects: [{ type: 'end' }]`, no `next` — e.g. "Another time.", "Say nothing", "Mind the sparks."). These got the same double-exit treatment.

Fix:
- Split `buildTalkGiveChoices` into `buildTalkGiveOptions` (Make conversation / Give a gift, no exit) and a thin wrapper that appends a generic "Farewell" only when nothing else already provides one.
- `tryOfferQuest`: insert the options before "Not now" instead of after, so "Not now" is always the single trailing exit.
- `runDialogueNode`'s top-level entry: partition the node's authored choices into non-exit vs. exit-like (`end` effect, no `next`); insert the options before any authored exit choice (kept verbatim, moved to trail) instead of appending a second generic Farewell. Nodes with no authored exit still get the full options+Farewell, unchanged.
- Updated `docs/hubworld.md` §7b/§7d to describe the single-exit rule.

## Test plan

- [x] `tsc --noEmit` — clean
- [x] `npm run test` — 383/383 passing
- [x] `npm run build` — succeeds
- [x] Verified live via Storybook (Millhaven): a quest-offer NPC now shows `[Accept, 🗣️ Make conversation, Not now]` with exactly one trailing exit, no separate "Farewell"
- [x] Manually traced the dialogue-tree branch against all ~35 authored trees with an exit choice, plus the 4 with none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVei2fjQicJvDNBzZH13GB

---
_Generated by [Claude Code](https://claude.ai/code/session_01YVei2fjQicJvDNBzZH13GB)_