### PR TITLE
Split Home Shelf into Relics, Keepsakes, and Odds & Ends

### DIFF
--- a/web/src/components/hub/HomeShelf.stories.tsx
+++ b/web/src/components/hub/HomeShelf.stories.tsx
@@ -1,16 +1,81 @@
 import { fn } from 'storybook/test'
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { HomeShelf } from './HomeShelf'
+import type { ItemEntry } from '../../game/itemStore'
+
+// Seed the localStorage-backed item store the shelf reads (relics + items).
+function seedItemStore(items: ItemEntry[]): void {
+  localStorage.setItem('jarv_item_store', JSON.stringify(items))
+}
 
 const meta = {
   component: HomeShelf,
+  parameters: { layout: 'fullscreen' },
+  decorators: [
+    (Story) => (
+      <div className="game-container">
+        <Story />
+      </div>
+    ),
+  ],
 } satisfies Meta<typeof HomeShelf>
 
 export default meta
 type Story = StoryObj<typeof meta>
 
-export const Default: Story = {
-  args: {
-    onBack: fn(),
-  },
+export const Empty: Story = {
+  args: { onBack: fn() },
+  decorators: [
+    (Story) => { seedItemStore([]); return <Story /> },
+  ],
+}
+
+export const RelicsOnly: Story = {
+  args: { onBack: fn() },
+  decorators: [
+    (Story) => {
+      seedItemStore([
+        { id: 'Bark Shield', type: 'relic', count: 1 },
+        { id: 'Iron Standard', type: 'relic', count: 1 },
+      ])
+      return <Story />
+    },
+  ],
+}
+
+export const Populated: Story = {
+  args: { onBack: fn() },
+  decorators: [
+    (Story) => {
+      seedItemStore([
+        { id: 'Bark Shield', type: 'relic', count: 1 },
+        {
+          id: 'hearthstone', type: 'item', count: 1, acquiredDate: '2026-01-01',
+          name: 'The Hearthstone', icon: '🔥',
+          desc: 'The reunified Hearthstone — three fragments made whole.',
+          isKeepsake: true,
+        },
+        {
+          id: 'ravenwatch-church-key', type: 'item', count: 1, acquiredDate: '2026-01-02',
+          name: 'Church Key', icon: '🗝️', desc: 'A key to the Ravenwatch church.',
+          isKeepsake: true,
+        },
+        // Legacy narrative reward acquired before the isKeepsake flag existed —
+        // should still land in Keepsakes via the shape-based fallback.
+        {
+          id: 'ravenwatch-legacy-note', type: 'item', count: 1, acquiredDate: '2025-12-01',
+          name: 'Weathered Note', icon: '📜', desc: 'A scrap of paper found tucked in an alley.',
+        },
+        {
+          id: 'slippers', type: 'item', count: 1, acquiredDate: '2026-01-03',
+          name: 'Virtual Slippers', icon: '🥿', desc: 'Cozy, but digital. Left one only.',
+        },
+        {
+          id: 'lint', type: 'item', count: 1, acquiredDate: '2026-01-04',
+          name: 'Pocket Lint', icon: '🧶', desc: 'Found in your other pants.',
+        },
+      ])
+      return <Story />
+    },
+  ],
 }

--- a/web/src/components/hub/HomeShelf.tsx
+++ b/web/src/components/hub/HomeShelf.tsx
@@ -13,63 +13,79 @@ type ShelfEntry =
 
 const SLOTS_PER_ROW = 6
 
+/** Pads a list of entries to a full number of rows, filling the remainder with empty slots. */
+function buildRows(entries: ShelfEntry[], minRows = 0): Array<Array<ShelfEntry | null>> {
+  const minSlots = Math.max(SLOTS_PER_ROW * minRows, Math.ceil(entries.length / SLOTS_PER_ROW) * SLOTS_PER_ROW)
+  const slots: Array<ShelfEntry | null> = [
+    ...entries,
+    ...Array(minSlots - entries.length).fill(null),
+  ]
+  const rows: Array<Array<ShelfEntry | null>> = []
+  for (let i = 0; i < slots.length; i += SLOTS_PER_ROW)
+    rows.push(slots.slice(i, i + SLOTS_PER_ROW))
+  return rows
+}
+
 export function HomeShelf({ onBack }: Props) {
   const items  = loadInventory()
   const relics = loadEarnedRelics()
     .map(name => getRelicDef(name))
     .filter((r): r is RelicDef => !!r)
 
-  const entries: ShelfEntry[] = [
-    ...relics.map(r => ({ kind: 'relic' as const, relic: r })),
-    ...items.map(i => ({ kind: 'item'  as const, item:  i })),
-  ]
+  const relicEntries:    ShelfEntry[] = relics.map(r => ({ kind: 'relic' as const, relic: r }))
+  const keepsakeEntries: ShelfEntry[] = items.filter(i => i.isKeepsake).map(i => ({ kind: 'item' as const, item: i }))
+  const junkEntries:     ShelfEntry[] = items.filter(i => !i.isKeepsake).map(i => ({ kind: 'item' as const, item: i }))
 
-  // Pad to a full number of rows (at least 3 rows shown)
-  const minSlots   = Math.max(SLOTS_PER_ROW * 3, Math.ceil(entries.length / SLOTS_PER_ROW) * SLOTS_PER_ROW)
-  const slots: Array<ShelfEntry | null> = [
-    ...entries,
-    ...Array(minSlots - entries.length).fill(null),
-  ]
+  const isEmpty = relicEntries.length === 0 && keepsakeEntries.length === 0 && junkEntries.length === 0
 
-  const rows: Array<Array<ShelfEntry | null>> = []
-  for (let i = 0; i < slots.length; i += SLOTS_PER_ROW)
-    rows.push(slots.slice(i, i + SLOTS_PER_ROW))
+  const sections: Array<{ label: string; rows: Array<Array<ShelfEntry | null>> }> = isEmpty
+    ? [{ label: '', rows: buildRows([], 3) }]
+    : [
+        { label: 'RELICS',       rows: buildRows(relicEntries) },
+        { label: 'KEEPSAKES',    rows: buildRows(keepsakeEntries) },
+        { label: 'ODDS & ENDS',  rows: buildRows(junkEntries) },
+      ].filter(s => s.rows.length > 0)
 
   const [detail, setDetail] = useState<ShelfEntry | null>(null)
 
   return (
     <OverlayScreen title="HOME" onBack={onBack}>
       <div className="shelf-room">
-        {entries.length === 0 && (
+        {isEmpty && (
           <div className="shelf-empty-msg">Your shelves are bare. Collect items to fill them.</div>
         )}
-        {rows.map((row, ri) => (
-          <div key={ri} className="shelf-row">
-            <div className="shelf-items">
-              {row.map((entry, si) => (
-                <button
-                  key={si}
-                  className={`shelf-slot${entry ? ' shelf-slot--filled' : ' shelf-slot--empty'}`}
-                  onClick={() => entry && setDetail(entry)}
-                  disabled={!entry}
-                  aria-label={entry ? (entry.kind === 'item' ? entry.item.name : entry.relic.name) : 'Empty slot'}
-                >
-                  {entry ? (
-                    <>
-                      <span className="shelf-slot-icon">
-                        {entry.kind === 'item' ? entry.item.icon : entry.relic.icon}
-                      </span>
-                      <span className="shelf-slot-name">
-                        {entry.kind === 'item' ? entry.item.name : entry.relic.name}
-                      </span>
-                    </>
-                  ) : (
-                    <span className="shelf-slot-dust" />
-                  )}
-                </button>
-              ))}
-            </div>
-            <div className="shelf-plank" />
+        {sections.map((section, sectioni) => (
+          <div key={sectioni}>
+            {section.label && <div className="shelf-section-label">{section.label}</div>}
+            {section.rows.map((row, ri) => (
+              <div key={ri} className="shelf-row">
+                <div className="shelf-items">
+                  {row.map((entry, si) => (
+                    <button
+                      key={si}
+                      className={`shelf-slot${entry ? ' shelf-slot--filled' : ' shelf-slot--empty'}`}
+                      onClick={() => entry && setDetail(entry)}
+                      disabled={!entry}
+                      aria-label={entry ? (entry.kind === 'item' ? entry.item.name : entry.relic.name) : 'Empty slot'}
+                    >
+                      {entry ? (
+                        <>
+                          <span className="shelf-slot-icon">
+                            {entry.kind === 'item' ? entry.item.icon : entry.relic.icon}
+                          </span>
+                          <span className="shelf-slot-name">
+                            {entry.kind === 'item' ? entry.item.name : entry.relic.name}
+                          </span>
+                        </>
+                      ) : (
+                        <span className="shelf-slot-dust" />
+                      )}
+                    </button>
+                  ))}
+                </div>
+                <div className="shelf-plank" />
+              </div>
+            ))}
           </div>
         ))}
       </div>

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -651,7 +651,7 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onEndless, onWorldMap
     }
     if (reward.collectible) {
       const { id: cid, name, icon, desc } = reward.collectible
-      addCollectible(cid, { name, icon, desc })
+      addCollectible(cid, { name, icon, desc, isKeepsake: true })
     }
     if (reward.consumables) {
       for (const { id, quantity } of reward.consumables) {
@@ -803,7 +803,7 @@ function grantQuestReward(quest: HubQuestDef, townNpcs: HubNpc[]): void {
   }
   if (reward.collectible) {
     const { id, name, icon, desc } = reward.collectible
-    addCollectible(id, { name, icon, desc })
+    addCollectible(id, { name, icon, desc, isKeepsake: true })
   }
   if (reward.card) {
     addCardsToCollection([{ cardName: reward.card.name, count: reward.card.count ?? 1 }])
@@ -1083,7 +1083,7 @@ function hasOfferableQuest(giverId: string): boolean {
           }
           if (eff.giveCollectible) {
             const { id, name, icon, desc } = eff.giveCollectible
-            addCollectible(id, { name, icon, desc })
+            addCollectible(id, { name, icon, desc, isKeepsake: true })
           }
           if (eff.giveFriendship) {
             addFriendshipXp(eff.giveFriendship.npcId ?? npcId, eff.giveFriendship.xp)
@@ -1584,7 +1584,7 @@ function hasOfferableQuest(giverId: string): boolean {
         markInteractableGranted(storeKey)
         if (r.collectible) {
           const { id, name, icon, desc, lore } = r.collectible
-          addCollectible(id, { name, icon, desc, lore })
+          addCollectible(id, { name, icon, desc, lore, isKeepsake: true })
         }
         if (r.consumables) {
           for (const { id, quantity } of r.consumables) addConsumable(id, quantity)

--- a/web/src/game/chronicle.ts
+++ b/web/src/game/chronicle.ts
@@ -172,7 +172,7 @@ function grantReward(r: ChronicleReward): void {
       saveCrystals(loadCrystals() + r.amount)
       break
     case 'collectible':
-      addCollectible(r.itemId, { name: r.name, icon: r.icon, desc: r.desc, lore: r.lore })
+      addCollectible(r.itemId, { name: r.name, icon: r.icon, desc: r.desc, lore: r.lore, isKeepsake: true })
       break
   }
 }

--- a/web/src/game/dailyLogin.ts
+++ b/web/src/game/dailyLogin.ts
@@ -35,6 +35,8 @@ export interface UselessItem {
   desc: string
   lore: string
   acquiredDate: string
+  /** True for meaningful narrative/quest rewards — see loadInventory(). */
+  isKeepsake?: boolean
 }
 
 // ── Reward pool ───────────────────────────────────────────────────────────────
@@ -196,19 +198,42 @@ export function removeFromInventory(id: string): void {
   removeCollectible(id)
 }
 
+// Ids of known flavor/luck loot stored with inline display fields (like keepsakes)
+// but that are not meaningful narrative rewards. Used only as a fallback for
+// entries acquired before the isKeepsake flag existed — see isKeepsakeEntry.
+const LEGACY_JUNK_IDS = new Set([
+  'pet-fetch-trinket', 'dug-old-boot', 'dug-cracked-marble', 'dug-rusty-key', 'dug-clay-whistle', 'four-leaf-clover',
+])
+
+/**
+ * Whether a stored item entry is a meaningful narrative/quest reward ("Keepsake")
+ * rather than daily-login/flavor junk. Trusts the explicit isKeepsake flag set at
+ * grant time when present; otherwise infers it for older entries stored before
+ * that flag existed — a non-catalog id carrying inline display fields, other than
+ * known flavor-loot ids and broken relics, can only have come from a narrative
+ * grant site (HubWorld quest/treasure/trade rewards, Chronicle rewards).
+ */
+function isKeepsakeEntry(e: { id: string; name?: string; isKeepsake?: boolean }): boolean {
+  if (e.isKeepsake !== undefined) return e.isKeepsake
+  if (ALL_ITEMS.some(i => i.id === e.id)) return false
+  if (e.id.startsWith('broken-relic-') || LEGACY_JUNK_IDS.has(e.id)) return false
+  return !!e.name
+}
+
 export function loadInventory(): UselessItem[] {
   const entries = getCollectibles()
   return entries.map(e => {
+    const isKeepsake = isKeepsakeEntry(e)
     // 1. Catalog (static items.json)
     const def = ALL_ITEMS.find(i => i.id === e.id)
-    if (def) return { id: e.id, name: def.name, icon: def.icon, desc: def.desc, lore: def.lore, acquiredDate: e.acquiredDate ?? '' }
+    if (def) return { id: e.id, name: def.name, icon: def.icon, desc: def.desc, lore: def.lore, acquiredDate: e.acquiredDate ?? '', isKeepsake }
     // 2. Stored display fields (items added after the display-field fix)
-    if (e.name) return { id: e.id, name: e.name, icon: e.icon ?? '❓', desc: e.desc ?? '', lore: e.lore ?? '', acquiredDate: e.acquiredDate ?? '' }
+    if (e.name) return { id: e.id, name: e.name, icon: e.icon ?? '❓', desc: e.desc ?? '', lore: e.lore ?? '', acquiredDate: e.acquiredDate ?? '', isKeepsake }
     // 3. Reconstruct broken relic display from the dynamic id
     const broken = resolveBrokenRelic(e.id)
-    if (broken) return { id: e.id, ...broken, lore: '', acquiredDate: e.acquiredDate ?? '' }
+    if (broken) return { id: e.id, ...broken, lore: '', acquiredDate: e.acquiredDate ?? '', isKeepsake }
     // 4. Unknown item — show raw id as placeholder
-    return { id: e.id, name: e.id, icon: '❓', desc: '', lore: '', acquiredDate: e.acquiredDate ?? '' }
+    return { id: e.id, name: e.id, icon: '❓', desc: '', lore: '', acquiredDate: e.acquiredDate ?? '', isKeepsake }
   })
 }
 

--- a/web/src/game/itemStore.ts
+++ b/web/src/game/itemStore.ts
@@ -77,6 +77,9 @@ export interface ItemEntry {
   lore?: string
   /** Hub-items only: inventory grouping (see HubItemCategory). */
   category?: HubItemCategory
+  /** Items only: true for meaningful narrative/quest rewards, shown on the Home
+   *  Shelf as "Keepsakes" rather than grouped with daily-login/flavor junk. */
+  isKeepsake?: boolean
 }
 
 export interface ItemDisplayFields {
@@ -85,6 +88,7 @@ export interface ItemDisplayFields {
   desc?: string
   lore?: string
   category?: HubItemCategory
+  isKeepsake?: boolean
 }
 
 const ITEM_STORE_KEY = 'jarv_item_store'

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -7752,6 +7752,15 @@ body {
   flex: 1;
 }
 
+.shelf-section-label {
+  font-size: 10px;
+  color: #557755;
+  font-family: monospace;
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  margin: 4px 0 8px;
+}
+
 .shelf-empty-msg {
   font-size: 13px;
   color: #5a7a5a;


### PR DESCRIPTION
## Summary
- The Home Shelf (Steward Maren, Ravenwatch) showed every collected "item" in one flat, unsorted grid — daily-login flavor junk (Pocket Lint, Dead Succulent) and meaningful narrative rewards (The Hearthstone, quest lore finds, Chronicle act rewards) were visually indistinguishable.
- Added an `isKeepsake?: boolean` field threaded through the item pipeline (`itemStore.ts`'s `ItemEntry`/`ItemDisplayFields`), set `true` at every narrative-reward grant site: `HubWorld.tsx`'s quest-completion reward, treasure-chest reward, world-exploration `giveItem` reaction, and trade-barter reward, plus `chronicle.ts`'s act-completion collectible reward. Flavor/luck loot (daily login, fishing catches, pet-fetch trinkets, dig-minigame finds, four-leaf clover) is left unflagged.
- For items already owned before this change (no stored flag), `loadInventory()` (`dailyLogin.ts`) falls back to shape-based inference: a non-catalog id carrying inline display fields, excluding known flavor-loot ids and broken relics, must have come from a narrative grant site.
- `HomeShelf.tsx` now renders three labeled sections — **RELICS**, **KEEPSAKES**, **ODDS & ENDS** — each independently padded to full shelf rows, with a heading shown only when non-empty. The bare-shelf empty state is unchanged.
- Added `.shelf-section-label` styling (matches the existing `.quests-modal__section-label` convention) and replaced the trivial `HomeShelf.stories.tsx` story with `Empty` / `RelicsOnly` / `Populated` fixtures (the last including a legacy no-flag narrative item to demonstrate the fallback).

## Test plan
- [x] `npx tsc --noEmit` — no type errors.
- [x] `npx vitest run` — all 383 existing tests pass.
- [x] Verified visually via Storybook + Playwright screenshots: `Empty` renders the original 3-row bare-shelf state; `Populated` renders Relics/Keepsakes/Odds & Ends correctly, including a legacy narrative item (no explicit flag) correctly bucketed into Keepsakes via the fallback; the item detail modal still opens correctly on click.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TyzZE9AiBqmVFfRVqGiQGr)_