### PR TITLE
Retroactively repair stale collectible icons on the Home Shelf

### DIFF
--- a/web/src/components/hub/HomeShelf.stories.tsx
+++ b/web/src/components/hub/HomeShelf.stories.tsx
@@ -49,11 +49,14 @@ export const Populated: Story = {
     (Story) => {
       seedItemStore([
         { id: 'Bark Shield', type: 'relic', count: 1 },
+        // Stale entry stored before the questDefs.json icon fix, with the old
+        // broken icon string baked in and no isKeepsake flag (granted before
+        // that flag existed either) — resolved against the current known-
+        // collectible catalog by loadInventory(), not the stale stored fields.
         {
           id: 'hearthstone', type: 'item', count: 1, acquiredDate: '2026-01-01',
-          name: 'The Hearthstone', icon: '🔥',
+          name: 'The Hearthstone', icon: 'goldChest',
           desc: 'The reunified Hearthstone — three fragments made whole.',
-          isKeepsake: true,
         },
         {
           id: 'ravenwatch-church-key', type: 'item', count: 1, acquiredDate: '2026-01-02',

--- a/web/src/game/collectiblesCatalog.ts
+++ b/web/src/game/collectiblesCatalog.ts
@@ -1,0 +1,83 @@
+// ─── Known Narrative Collectibles ─────────────────────────────────────────────
+//
+// A self-healing catalog of every narrative-reward collectible (hub quest
+// rewards, world-exploration finds, treasure chests, barter trades, Chronicle
+// act rewards), aggregated from the current town/quest data by id.
+//
+// loadInventory() (dailyLogin.ts) prefers this catalog over a player's stored
+// display fields for matching ids, so a later data fix (e.g. a corrected icon)
+// takes effect immediately for players who already own the item — not just
+// for future grants. Without this, a bug fixed in questDefs.json would only
+// apply to items collected after the fix shipped; anyone who already earned
+// "The Hearthstone" would keep seeing the old broken icon forever, because the
+// display fields are captured inline into the player's save at grant time.
+
+import { ALL_QUEST_DEFS, ALL_QUESTS, LOCATION_REGISTRY } from '../data/hub/hubWorldFactory'
+import chronicleData from '../data/chronicle.json'
+
+export interface KnownCollectible {
+  name: string
+  icon: string
+  desc: string
+  lore?: string
+}
+
+function buildKnownCollectibles(): Record<string, KnownCollectible> {
+  const known: Record<string, KnownCollectible> = {}
+
+  // Quest-completion rewards (HubWorld.tsx grantQuestReward)
+  for (const quest of ALL_QUEST_DEFS) {
+    const c = quest.reward.collectible
+    if (c) known[c.id] = { name: c.name, icon: c.icon, desc: c.desc }
+  }
+
+  for (const { locationData } of Object.values(LOCATION_REGISTRY)) {
+    // World-exploration finds (HubWorld.tsx giveItem reaction)
+    for (const interactable of locationData.HUB_INTERACTABLES) {
+      for (const reaction of interactable.reactions) {
+        if (reaction.type === 'giveItem' && reaction.collectible) {
+          const c = reaction.collectible
+          known[c.id] = { name: c.name, icon: c.icon, desc: c.desc, lore: c.lore }
+        }
+      }
+    }
+    // Treasure-chest rewards (HubWorld.tsx handleTreasureStep)
+    for (const treasure of locationData.HUB_TREASURES) {
+      const c = treasure.reward.collectible
+      if (c) known[c.id] = { name: c.name, icon: c.icon, desc: c.desc }
+    }
+  }
+
+  // Barter-trade rewards (HubWorld.tsx tradeHubItem dialogue effect)
+  for (const tree of Object.values(ALL_QUESTS.HUB_DIALOGUES)) {
+    for (const node of Object.values(tree.nodes)) {
+      for (const choice of node.choices ?? []) {
+        for (const effect of choice.effects ?? []) {
+          if (effect.type === 'tradeHubItem' && effect.giveCollectible) {
+            const c = effect.giveCollectible
+            known[c.id] = { name: c.name, icon: c.icon, desc: c.desc }
+          }
+        }
+      }
+    }
+  }
+
+  // Chronicle act-completion rewards (chronicle.ts grantReward)
+  for (const entry of chronicleData as Array<{
+    reward?: { type: string; itemId?: string; name?: string; icon?: string; desc?: string; lore?: string }
+  }>) {
+    const r = entry.reward
+    if (r?.type === 'collectible' && r.itemId && r.name && r.icon && r.desc) {
+      known[r.itemId] = { name: r.name, icon: r.icon, desc: r.desc, lore: r.lore }
+    }
+  }
+
+  return known
+}
+
+const KNOWN_COLLECTIBLES = buildKnownCollectibles()
+
+/** Look up the current authoritative definition for a narrative-reward collectible id. */
+export function getKnownCollectible(id: string): KnownCollectible | undefined {
+  return KNOWN_COLLECTIBLES[id]
+}

--- a/web/src/game/dailyLogin.ts
+++ b/web/src/game/dailyLogin.ts
@@ -6,6 +6,7 @@ import rewardsJson      from '../data/rewards.json'
 import brokenRelicsJson from '../data/broken-relics.json'
 import { CardRarity } from './types'
 import { addCollectible, removeCollectible, getCollectibles, ItemDisplayFields } from './itemStore'
+import { getKnownCollectible } from './collectiblesCatalog'
 
 const DAILY_KEY = 'jarv_daily_login'
 const SEEN_COLLECTIBLES_KEY = 'jarv_seen_collectibles'
@@ -223,16 +224,21 @@ function isKeepsakeEntry(e: { id: string; name?: string; isKeepsake?: boolean })
 export function loadInventory(): UselessItem[] {
   const entries = getCollectibles()
   return entries.map(e => {
-    const isKeepsake = isKeepsakeEntry(e)
     // 1. Catalog (static items.json)
     const def = ALL_ITEMS.find(i => i.id === e.id)
-    if (def) return { id: e.id, name: def.name, icon: def.icon, desc: def.desc, lore: def.lore, acquiredDate: e.acquiredDate ?? '', isKeepsake }
-    // 2. Stored display fields (items added after the display-field fix)
+    if (def) return { id: e.id, name: def.name, icon: def.icon, desc: def.desc, lore: def.lore, acquiredDate: e.acquiredDate ?? '', isKeepsake: false }
+    // 2. Known narrative collectible — always resolved against the current
+    // definition, so a later data fix (e.g. a corrected icon) applies
+    // immediately for players who already own the item, not just future grants.
+    const known = getKnownCollectible(e.id)
+    if (known) return { id: e.id, name: known.name, icon: known.icon, desc: known.desc, lore: known.lore ?? '', acquiredDate: e.acquiredDate ?? '', isKeepsake: true }
+    const isKeepsake = isKeepsakeEntry(e)
+    // 3. Stored display fields (items added after the display-field fix)
     if (e.name) return { id: e.id, name: e.name, icon: e.icon ?? '❓', desc: e.desc ?? '', lore: e.lore ?? '', acquiredDate: e.acquiredDate ?? '', isKeepsake }
-    // 3. Reconstruct broken relic display from the dynamic id
+    // 4. Reconstruct broken relic display from the dynamic id
     const broken = resolveBrokenRelic(e.id)
     if (broken) return { id: e.id, ...broken, lore: '', acquiredDate: e.acquiredDate ?? '', isKeepsake }
-    // 4. Unknown item — show raw id as placeholder
+    // 5. Unknown item — show raw id as placeholder
     return { id: e.id, name: e.id, icon: '❓', desc: '', lore: '', acquiredDate: e.acquiredDate ?? '', isKeepsake }
   })
 }


### PR DESCRIPTION
## Summary
- After #1909 fixed the broken icon strings in `ravenwatch/questDefs.json`, players who had already completed those quests still saw the old broken text (`pendant`, `goldChest`, `blueclosedBook`, etc.) under the new **KEEPSAKES** section. The data fix only affects future grants — `HubWorld.tsx`'s `grantQuestReward` captures `name`/`icon`/`desc` inline into the player's own save at grant time, so a corrected value in `questDefs.json` never reaches an item a player already owns.
- Added `web/src/game/collectiblesCatalog.ts`: a self-healing catalog aggregated from the *current* town/quest data — quest-completion rewards, world-exploration `giveItem` finds, treasure-chest rewards, barter-trade rewards (all towns, via the existing `hubWorldFactory.ts` aggregator), and Chronicle act-completion rewards — keyed by item id.
- `loadInventory()` (`dailyLogin.ts`) now resolves a matching id against this catalog *before* falling back to a player's stored display fields, so a later data fix (icon, name, or desc) takes effect immediately for everyone, not just new grants.
- Updated the `HomeShelf.stories.tsx` `Populated` fixture to include a stale entry (old broken `goldChest` icon, no `isKeepsake` flag — exactly what a pre-fix player's save looks like) and confirmed it now renders correctly.

## Test plan
- [x] `npx tsc --noEmit` — no type errors.
- [x] `npx vitest run` — all 383 existing tests pass.
- [x] Manually verified via a scratch test that seeding stale broken-icon entries (`pendant`, `blackclosedBook`, `goldChest`) for real Ravenwatch quest-reward ids now resolves to the correct current icon and `isKeepsake: true`.
- [x] Verified visually via Storybook + Playwright: the `Populated` story's stale "Hearthstone" entry (stored with the old `goldChest` string) now renders 🔥 correctly on the shelf.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TyzZE9AiBqmVFfRVqGiQGr)_