### PR TITLE
Allow augments to be broken down into souls

### DIFF
--- a/web/src/components/cards/CardDetailModal.tsx
+++ b/web/src/components/cards/CardDetailModal.tsx
@@ -46,6 +46,8 @@ interface Props {
   augmentEquippedTo?: string | null
   canUpgrade?: boolean
   onUpgrade?: () => void
+  breakdownValue?: number
+  onBreakdown?: () => void
 }
 
 const RARITY_COLOUR: Record<string, string> = {
@@ -92,7 +94,7 @@ function affinityEffectText(effectType: string, effectAmount: number): string {
   return `×${effectAmount} ${effectType}`
 }
 
-export function CardDetailModal({ card, collection, deckEntries, onClose, extras = 0, disenchantValue = 0, onDisenchant, onMasterCard, commanderName, promotionsLeft = 0, onPromote, augmentLevel, augmentEquippedTo, canUpgrade, onUpgrade }: Props) {
+export function CardDetailModal({ card, collection, deckEntries, onClose, extras = 0, disenchantValue = 0, onDisenchant, onMasterCard, commanderName, promotionsLeft = 0, onPromote, augmentLevel, augmentEquippedTo, canUpgrade, onUpgrade, breakdownValue = 0, onBreakdown }: Props) {
   const owned  = getOwnedCount(collection, card.name)
   const inDeck = deckEntries?.find(e => e.cardName === card.name)?.count ?? 0
   const xp     = getMasteryXp(collection, card.name)
@@ -526,6 +528,15 @@ export function CardDetailModal({ card, collection, deckEntries, onClose, extras
               title={`Costs ${AUGMENT_UPGRADE_COST} souls`}
             >
               ↑ Upgrade ({AUGMENT_UPGRADE_COST} souls)
+            </button>
+          </div>
+        )}
+
+        {/* Augment breakdown action */}
+        {onBreakdown && (
+          <div className="cdm-actions">
+            <button className="extra-btn extra-btn--disenchant" onClick={onBreakdown}>
+              💀 Break Down (+{breakdownValue} 👻)
             </button>
           </div>
         )}

--- a/web/src/components/screens/AugmentCollectionScreen.tsx
+++ b/web/src/components/screens/AugmentCollectionScreen.tsx
@@ -6,7 +6,9 @@ import {
   upgradeAugment,
   upgradeAugmentStack,
   equipAugmentSet,
+  breakdownAugmentInstance,
   AUGMENT_UPGRADE_COST,
+  AUGMENT_DISENCHANT_VALUE,
   loadCollection,
 } from '../../game/collection'
 import {
@@ -260,6 +262,7 @@ export function AugmentCollectionScreen({ onBack, embedded }: Props) {
   const [groupOpen,     setGroupOpen]     = useState(false)
   const [detailInst,    setDetailInst]    = useState<{ card: Card; inst: AugmentInstance } | null>(null)
   const [upgradeError,  setUpgradeError]  = useState<string | null>(null)
+  const [breakdownMsg,  setBreakdownMsg]  = useState<string | null>(null)
   const [stackErrors,   setStackErrors]   = useState<Record<string, string | null>>({})
   const [detailCardName, setDetailCardName] = useState<string | null>(null)
   const [activeStack,   setActiveStack]   = useState<AugStack | null>(null)
@@ -291,6 +294,14 @@ export function AugmentCollectionScreen({ onBack, embedded }: Props) {
         }
       }
     }
+  }
+
+  function handleBreakdown(inst: AugmentInstance) {
+    const gained = breakdownAugmentInstance(inst.instanceId)
+    setBreakdownMsg(`+${gained} 👻 souls`)
+    setTimeout(() => setBreakdownMsg(null), 2500)
+    forceRefresh()
+    if (detailInst?.inst.instanceId === inst.instanceId) setDetailInst(null)
   }
 
   function handleUpgradeStack(stack: AugStack) {
@@ -467,6 +478,10 @@ export function AugmentCollectionScreen({ onBack, embedded }: Props) {
         <div style={{ color: '#ff6666', textAlign: 'center', fontSize: 12, padding: '4px 0' }}>{upgradeError}</div>
       )}
 
+      {breakdownMsg && (
+        <div style={{ color: '#cc88ff', textAlign: 'center', fontSize: 12, padding: '4px 0' }}>{breakdownMsg}</div>
+      )}
+
       {instances.length === 0 ? (
         <div style={{ textAlign: 'center', opacity: 0.6, marginTop: 48 }}>
           No augments owned yet. Earn augments from packs to equip them to your units.
@@ -541,6 +556,12 @@ export function AugmentCollectionScreen({ onBack, embedded }: Props) {
                             title={`Upgrade · ${AUGMENT_UPGRADE_COST} souls`}
                             style={{ padding: '1px 6px', fontSize: 11 }}
                           >↑</button>
+                          <button
+                            className="action-btn"
+                            onClick={e => { e.stopPropagation(); handleBreakdown(inst) }}
+                            title={`Break down · +${AUGMENT_DISENCHANT_VALUE[displayCard.rarity]} souls`}
+                            style={{ padding: '1px 6px', fontSize: 11 }}
+                          >💀</button>
                         </div>
                       </LazyCell>
                     ))}
@@ -561,6 +582,8 @@ export function AugmentCollectionScreen({ onBack, embedded }: Props) {
           augmentEquippedTo={detailInst.inst.equippedToCardName}
           canUpgrade={souls >= AUGMENT_UPGRADE_COST}
           onUpgrade={() => handleUpgrade(detailInst.inst)}
+          breakdownValue={AUGMENT_DISENCHANT_VALUE[detailInst.card.rarity]}
+          onBreakdown={() => handleBreakdown(detailInst.inst)}
           onClose={() => setDetailInst(null)}
         />
       )}

--- a/web/src/data/economy.json
+++ b/web/src/data/economy.json
@@ -12,6 +12,17 @@
     "holofoil": 250,
     "glass": 200
   },
+  "augmentDisenchantValue": {
+    "common": 50,
+    "uncommon": 100,
+    "rare": 200,
+    "epic": 350,
+    "legendary": 500,
+    "mythic": 1000,
+    "shiny": 750,
+    "holofoil": 750,
+    "glass": 600
+  },
   "merchantPrices": {
     "common": 40,
     "uncommon": 90,

--- a/web/src/game/collection.ts
+++ b/web/src/game/collection.ts
@@ -93,8 +93,8 @@ export const COPIES_MAX = 4
 import { loadPlayerStats } from './playerStats'
 export function getPlayerMaxDeckSize(): number { return loadPlayerStats().maxDeckSize }
 
-import { CRYSTAL_PACK_COST, DISENCHANT_VALUE } from './economy'
-export { CRYSTAL_PACK_COST, DISENCHANT_VALUE }
+import { CRYSTAL_PACK_COST, DISENCHANT_VALUE, AUGMENT_DISENCHANT_VALUE } from './economy'
+export { CRYSTAL_PACK_COST, DISENCHANT_VALUE, AUGMENT_DISENCHANT_VALUE }
 
 // ─── Starter data ─────────────────────────────────────────
 
@@ -316,6 +316,21 @@ export function unequipAugment(instanceId: string): void {
   if (!target) return
   target.equippedToCardName = null
   saveAugmentInstances(instances)
+}
+
+/** Break down an augment instance (equipped or not) into souls, keyed by its rarity.
+ *  Returns the number of souls gained (0 if the instance/card could not be found). */
+export function breakdownAugmentInstance(instanceId: string): number {
+  const instances = loadAugmentInstances()
+  const target = instances.find(i => i.instanceId === instanceId)
+  if (!target) return 0
+  const card = getAugmentCard(target.cardId)
+  if (!card) return 0
+
+  const gained = AUGMENT_DISENCHANT_VALUE[card.rarity]
+  saveAugmentInstances(instances.filter(i => i.instanceId !== instanceId))
+  incrementAugmentSouls(gained)
+  return gained
 }
 
 /** Upgrade an augment instance by 1 level. Costs AUGMENT_UPGRADE_COST souls.

--- a/web/src/game/economy.test.ts
+++ b/web/src/game/economy.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import {
   CRYSTAL_PACK_COST,
   DISENCHANT_VALUE,
+  AUGMENT_DISENCHANT_VALUE,
   MERCHANT_PRICES,
   MINI_GAME_COSTS,
   bulkCardCost,
@@ -24,6 +25,13 @@ describe('economy.json shape', () => {
     for (const r of RARITIES) {
       expect(typeof DISENCHANT_VALUE[r]).toBe('number')
       expect(DISENCHANT_VALUE[r]).toBeGreaterThan(0)
+    }
+  })
+
+  it('has all four rarities in augmentDisenchantValue', () => {
+    for (const r of RARITIES) {
+      expect(typeof AUGMENT_DISENCHANT_VALUE[r]).toBe('number')
+      expect(AUGMENT_DISENCHANT_VALUE[r]).toBeGreaterThan(0)
     }
   })
 
@@ -68,6 +76,16 @@ describe('merchant prices monotonicity', () => {
     expect(MERCHANT_PRICES.common).toBeLessThan(MERCHANT_PRICES.uncommon)
     expect(MERCHANT_PRICES.uncommon).toBeLessThan(MERCHANT_PRICES.rare)
     expect(MERCHANT_PRICES.rare).toBeLessThan(MERCHANT_PRICES.legendary)
+  })
+})
+
+// ── Augment disenchant value monotonicity ─────────────────────────────────────
+
+describe('augment disenchant value monotonicity', () => {
+  it('a common augment yields fewer souls than a legendary one', () => {
+    expect(AUGMENT_DISENCHANT_VALUE.common).toBeLessThan(AUGMENT_DISENCHANT_VALUE.uncommon)
+    expect(AUGMENT_DISENCHANT_VALUE.uncommon).toBeLessThan(AUGMENT_DISENCHANT_VALUE.rare)
+    expect(AUGMENT_DISENCHANT_VALUE.rare).toBeLessThan(AUGMENT_DISENCHANT_VALUE.legendary)
   })
 })
 

--- a/web/src/game/economy.ts
+++ b/web/src/game/economy.ts
@@ -14,6 +14,9 @@ export const CRYSTAL_PACK_COST: number = raw.crystalPackCost
 export const DISENCHANT_VALUE: Record<CardRarity, number> =
   raw.disenchantValue as Record<CardRarity, number>
 
+export const AUGMENT_DISENCHANT_VALUE: Record<CardRarity, number> =
+  raw.augmentDisenchantValue as Record<CardRarity, number>
+
 export const MERCHANT_PRICES: Record<CardRarity, number> =
   raw.merchantPrices as Record<CardRarity, number>
 


### PR DESCRIPTION
## Summary

- Players can now break down an unwanted augment instance to reclaim augment souls, mirroring the existing card-disenchant flow (`disenchantCard`) rather than inventing a new pattern.
- Soul yield scales with the augment's rarity via a new `augmentDisenchantValue` table in `economy.json` (common → legendary, plus mythic/shiny/holofoil/glass), exposed as `AUGMENT_DISENCHANT_VALUE` in `economy.ts`.
- New `breakdownAugmentInstance(instanceId)` in `collection.ts` removes the instance (equipped or not) and credits souls via the existing `incrementAugmentSouls`.
- UI: a "💀" breakdown button next to the existing "↑ Upgrade" button on individual augment tiles in `AugmentCollectionScreen.tsx`, plus a matching "Break Down" action wired into the shared `CardDetailModal`.
- Complete-set stack tiles are untouched — breakdown applies to individual instances only (including when drilling into a stack, which reuses the same per-instance controls).

Closes #1324

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 385/385 tests pass (added 2 new tests covering the `augmentDisenchantValue` table's shape and rarity monotonicity)
- [ ] Manually break down an individual (non-stack) augment from the Augments screen and confirm the souls counter increases by the rarity-appropriate amount and the augment disappears from the list
- [ ] Manually break down an augment via its detail modal and confirm the modal closes and souls update
- [ ] Confirm breaking down an equipped augment doesn't leave a dangling reference on the unit that had it equipped


---
_Generated by [Claude Code](https://claude.ai/code/session_015YRPySwgCzJ8iPa9m6uoXX)_