### PR TITLE
Tower defence: require confirm click before selling a tower

### DIFF
--- a/web/src/components/minigames/TowerDefence.tsx
+++ b/web/src/components/minigames/TowerDefence.tsx
@@ -95,6 +95,21 @@ export function TowerDefence({ pool, mode, onDone, environment }: Props) {
   const [selectedTowerId, setSelectedTowerId] = useState<number | null>(null)
   const [hoveredCell, setHoveredCell] = useState<{ col: number; row: number } | null>(null)
   const [gridScale, setGridScale] = useState(1)
+  const [sellArmedId, setSellArmedId] = useState<number | null>(null)
+  const sellArmTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  function clearSellArm() {
+    if (sellArmTimeoutRef.current) {
+      clearTimeout(sellArmTimeoutRef.current)
+      sellArmTimeoutRef.current = null
+    }
+    setSellArmedId(null)
+  }
+
+  // A sell request is disarmed whenever the selection changes (deselect,
+  // pick a different tower) so "confirm" state never leaks onto another tower.
+  useEffect(() => { clearSellArm() }, [selectedTowerId])
+  useEffect(() => () => clearSellArm(), [])
 
   // Always derived from game state so it stays in sync after upgrades/moves
   const selectedTower = selectedTowerId !== null
@@ -254,6 +269,23 @@ export function TowerDefence({ pool, mode, onDone, environment }: Props) {
     setGame(prev => removeTower(prev, tower.id))
     setSelectedTowerId(null)
     setHoveredTower(null)
+    clearSellArm()
+  }
+
+  // First click arms a short-lived confirmation; a second click on the same
+  // tower within the window actually sells. Guards against accidental taps
+  // since SELL sits right next to the upgrade/cancel buttons.
+  function handleSellButtonClick(tower: TDTower) {
+    if (sellArmedId === tower.id) {
+      handleSellTower(tower)
+      return
+    }
+    if (sellArmTimeoutRef.current) clearTimeout(sellArmTimeoutRef.current)
+    setSellArmedId(tower.id)
+    sellArmTimeoutRef.current = setTimeout(() => {
+      sellArmTimeoutRef.current = null
+      setSellArmedId(null)
+    }, 2500)
   }
 
   function handleUpgradeTower(tower: TDTower, type: TDUpgradeType) {
@@ -494,9 +526,10 @@ export function TowerDefence({ pool, mode, onDone, environment }: Props) {
                 <span className="td-selected-panel-stats"> · {activeUnits.length}/{unitCount} units · {dps.toFixed(1)} dps · {rangeInCells.toFixed(1)}r</span>
               </div>
               <div className="td-selected-panel-row-actions">
-                <button className="td-selected-action-btn td-selected-action-btn--sell"
-                  onClick={() => handleSellTower(t)}>
-                  SELL +💧{refund}
+                <button
+                  className={`td-selected-action-btn td-selected-action-btn--sell${sellArmedId === t.id ? ' td-selected-action-btn--sell-armed' : ''}`}
+                  onClick={() => handleSellButtonClick(t)}>
+                  {sellArmedId === t.id ? 'Confirm sell?' : `SELL +💧${refund}`}
                 </button>
                 <button className="td-selected-action-btn td-selected-action-btn--cancel"
                   onClick={() => setSelectedTowerId(null)}>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -14375,7 +14375,18 @@ html.light-mode .action-btn {
 .td-selected-action-btn:hover:not(.td-selected-action-btn--disabled) { background: #252525; }
 .td-selected-action-btn--sell    { border-color: #f44336; color: #f44336; }
 .td-selected-action-btn--sell:hover { background: rgba(244,67,54,0.12); }
+.td-selected-action-btn--sell-armed {
+  background: #f44336;
+  color: #fff;
+  animation: td-sell-armed-pulse 0.6s ease-in-out infinite alternate;
+}
+.td-selected-action-btn--sell-armed:hover { background: #d32f2f; }
 .td-selected-action-btn--cancel  { border-color: #444; color: #777; padding: 6px 10px; }
+
+@keyframes td-sell-armed-pulse {
+  from { box-shadow: 0 0 0 rgba(244,67,54,0.6); }
+  to   { box-shadow: 0 0 8px rgba(244,67,54,0.9); }
+}
 
 /* 2×2 upgrade option grid */
 .td-upgrade-options {


### PR DESCRIPTION
## Summary
- The SELL button in the tower defence selected-tower panel sold instantly on click, and sat as the leftmost button right next to the upgrade grid — easy to hit by accident.
- First click now arms a "Confirm sell?" state (solid red, pulsing) instead of selling immediately; only a second click on the same tower within ~2.5s actually sells it. The arm state clears automatically on timeout, on deselect, or when a different tower is selected.

## Test plan
- [x] `tsc --noEmit` passes
- [x] Manually drove the `TowerDefence` Storybook story with a headless Playwright script: placed a tower, selected it, clicked SELL once (armed, tower still present, mana unchanged), waited for the arm to expire (reverted to normal label, no sale), then clicked once to re-arm and again to confirm (tower removed, mana refunded, log shows "Sold Goblin (+5 mana).")


---
_Generated by [Claude Code](https://claude.ai/code/session_01W7tF4Raf7hvRhMhudPfEWN)_