### PR TITLE
Hub housing: decoration/edit mode UI extending HomeShelf

### DIFF
--- a/docs/hubworld.md
+++ b/docs/hubworld.md
@@ -1841,12 +1841,34 @@ error, matching every other hub store. Occupancy checks are region-based
 (every cell of a multi-cell footprint blocks placement, not just its
 origin cell) via the internal `footprintFor`/`overlaps` helpers.
 
-### Dependencies not yet built
+### UI — `web/src/components/hub/HomeShelf.tsx`
 
-- **Decoration UI**: not yet implemented. Will extend `HomeShelf.tsx` with
-  an edit mode that calls `placeFurniture`/`moveFurniture`/`removeFurniture`
-  and renders `loadHomeLayout()` on a grid, and a shop/earn flow that calls
-  `grantFurniture` (§19).
+`HomeShelf` (the `home-shelf` screen, reached with only an `onBack` prop —
+no new `App.tsx` routing was needed) gained a **SHELF / DECORATE** tab row
+(reusing `HallOfAchievements`/`TownJournal`'s `.hoa-tabs`/`.hoa-tab` CSS).
+SHELF is the original read-only relic/keepsake display, unchanged. DECORATE
+renders the grid, using three pure-visual pieces under
+`web/src/components/hub/home-shelf/` (each with a `.stories.tsx`):
+
+- `HomeGrid.tsx` — the `HOME_GRID_COLS × HOME_GRID_ROWS` grid; placed pieces
+  span their (rotation-aware) footprint via `gridColumn`/`gridRow`.
+- `FurniturePicker.tsx` — a horizontal strip over the full catalog; owned
+  pieces are plain, unowned ones show a price tag.
+- `PieceActionBar.tsx` — Rotate / Move / Remove for the selected piece.
+
+**Interaction** is tap-to-arm, tap-to-place — no drag-and-drop (none exists
+anywhere else in this codebase, and touch/tap matches every other hub
+interaction): tapping an owned picker item arms it, then tapping an empty
+grid cell calls `placeFurniture`; tapping a placed piece selects it and
+shows `PieceActionBar` (Rotate re-calls `moveFurniture` with the next
+rotation; Move arms the piece for relocation; Remove is a two-tap confirm,
+copying `TowerDefence.tsx`'s sell-arm timeout pattern). Tapping an unowned
+picker item opens a buy-confirm dialog (reusing `ShopScreen.tsx`'s
+`.shop-confirm-*` classes) showing price vs. `loadCrystals()`; confirming
+spends crystals inline (`saveCrystals`) then calls `grantFurniture`, same
+as `HubWorld.tsx`'s `buyHubItem` case. A failed `placeFurniture`/
+`moveFurniture` call (out of bounds/overlap) surfaces a brief inline
+message rather than failing silently.
 
 ---
 

--- a/web/src/components/hub/HomeShelf.stories.tsx
+++ b/web/src/components/hub/HomeShelf.stories.tsx
@@ -1,11 +1,24 @@
-import { fn } from 'storybook/test'
+import { fn, within, userEvent } from 'storybook/test'
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { HomeShelf } from './HomeShelf'
 import type { ItemEntry } from '../../game/itemStore'
+import { saveCrystals } from '../../game/collection'
 
 // Seed the localStorage-backed item store the shelf reads (relics + items).
 function seedItemStore(items: ItemEntry[]): void {
   localStorage.setItem('jarv_item_store', JSON.stringify(items))
+}
+
+// Seed the decorate-tab stores: placed furniture, owned furniture ids, crystals.
+function seedDecorate(opts: { placed?: unknown[]; owned?: string[]; crystals?: number } = {}): void {
+  localStorage.setItem('jarv_hub_home_layout', JSON.stringify({ placed: opts.placed ?? [] }))
+  localStorage.setItem('jarv_hub_furniture_owned', JSON.stringify(opts.owned ?? []))
+  saveCrystals(opts.crystals ?? 100)
+}
+
+async function clickDecorateTab({ canvasElement }: { canvasElement: HTMLElement }) {
+  const canvas = within(canvasElement)
+  await userEvent.click(await canvas.findByRole('button', { name: 'DECORATE' }))
 }
 
 const meta = {
@@ -81,4 +94,31 @@ export const Populated: Story = {
       return <Story />
     },
   ],
+}
+
+export const DecorateEmpty: Story = {
+  args: { onBack: fn() },
+  decorators: [
+    (Story) => { seedItemStore([]); seedDecorate(); return <Story /> },
+  ],
+  play: clickDecorateTab,
+}
+
+export const DecoratePopulated: Story = {
+  args: { onBack: fn() },
+  decorators: [
+    (Story) => {
+      seedItemStore([])
+      seedDecorate({
+        owned: ['reading-lamp', 'cozy-rug', 'round-table'],
+        placed: [
+          { id: 'lamp-1', itemId: 'reading-lamp', x: 0, y: 0, rotation: 0 },
+          { id: 'rug-1', itemId: 'cozy-rug', x: 2, y: 1, rotation: 0 },
+        ],
+        crystals: 42,
+      })
+      return <Story />
+    },
+  ],
+  play: clickDecorateTab,
 }

--- a/web/src/components/hub/HomeShelf.tsx
+++ b/web/src/components/hub/HomeShelf.tsx
@@ -1,7 +1,17 @@
-import React, { useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { UselessItem, loadInventory } from '../../game/dailyLogin'
 import { loadEarnedRelics, getRelicDef, RelicDef } from '../../game/relics'
 import { OverlayScreen } from '../ui/OverlayScreen'
+import { HomeGrid } from './home-shelf/HomeGrid'
+import { FurniturePicker } from './home-shelf/FurniturePicker'
+import { PieceActionBar } from './home-shelf/PieceActionBar'
+import {
+  PlacedFurniture, loadHomeLayout, placeFurniture, moveFurniture, removeFurniture,
+} from '../../game/hub/homeLayout'
+import {
+  FurnitureDef, getFurnitureDef, getAllFurnitureDefs, getOwnedFurnitureIds, grantFurniture,
+} from '../../game/hub/furniture'
+import { loadCrystals, saveCrystals } from '../../game/collection'
 
 interface Props {
   onBack: () => void
@@ -26,7 +36,17 @@ function buildRows(entries: ShelfEntry[], minRows = 0): Array<Array<ShelfEntry |
   return rows
 }
 
+const ROTATION_ORDER = [0, 90, 180, 270] as const
+function nextRotation(r: 0 | 90 | 180 | 270): 0 | 90 | 180 | 270 {
+  return ROTATION_ORDER[(ROTATION_ORDER.indexOf(r) + 1) % ROTATION_ORDER.length]
+}
+
+const REMOVE_ARM_MS = 2500
+
 export function HomeShelf({ onBack }: Props) {
+  const [tab, setTab] = useState<'shelf' | 'decorate'>('shelf')
+
+  // ── Shelf tab (existing, unchanged) ──
   const items  = loadInventory()
   const relics = loadEarnedRelics()
     .map(name => getRelicDef(name))
@@ -48,47 +68,221 @@ export function HomeShelf({ onBack }: Props) {
 
   const [detail, setDetail] = useState<ShelfEntry | null>(null)
 
+  // ── Decorate tab ──
+  const [placed, setPlaced] = useState<PlacedFurniture[]>(() => loadHomeLayout())
+  const [ownedIds, setOwnedIds] = useState<string[]>(() => getOwnedFurnitureIds())
+  const [crystals, setCrystals] = useState(() => loadCrystals())
+  const [armedItemId, setArmedItemId] = useState<string | null>(null)
+  const [selectedPieceId, setSelectedPieceId] = useState<string | null>(null)
+  const [moveArmed, setMoveArmed] = useState(false)
+  const [removeArmedId, setRemoveArmedId] = useState<string | null>(null)
+  const [pendingBuy, setPendingBuy] = useState<FurnitureDef | null>(null)
+  const [message, setMessage] = useState<string | null>(null)
+  const removeArmTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const messageTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  function clearRemoveArm() {
+    if (removeArmTimeoutRef.current) { clearTimeout(removeArmTimeoutRef.current); removeArmTimeoutRef.current = null }
+    setRemoveArmedId(null)
+  }
+
+  // A remove request is disarmed whenever the selection changes, so "confirm"
+  // state never leaks onto a different piece.
+  useEffect(() => { clearRemoveArm() }, [selectedPieceId])
+  useEffect(() => () => clearRemoveArm(), [])
+
+  function showMessage(text: string) {
+    if (messageTimeoutRef.current) clearTimeout(messageTimeoutRef.current)
+    setMessage(text)
+    messageTimeoutRef.current = setTimeout(() => { messageTimeoutRef.current = null; setMessage(null) }, 2200)
+  }
+
+  const selectedPiece = selectedPieceId ? placed.find(p => p.id === selectedPieceId) ?? null : null
+  const selectedDef = selectedPiece ? getFurnitureDef(selectedPiece.itemId) : null
+
+  function handlePickFurniture(itemId: string) {
+    setSelectedPieceId(null)
+    setMoveArmed(false)
+    if (ownedIds.includes(itemId)) {
+      setArmedItemId(prev => (prev === itemId ? null : itemId))
+      return
+    }
+    const def = getFurnitureDef(itemId)
+    if (def) setPendingBuy(def)
+  }
+
+  function handleCancelBuy() {
+    setPendingBuy(null)
+  }
+
+  function handleConfirmBuy() {
+    if (!pendingBuy) return
+    if (crystals < pendingBuy.price) {
+      showMessage("That's more crystals than you have.")
+      return
+    }
+    const next = crystals - pendingBuy.price
+    saveCrystals(next)
+    setCrystals(next)
+    grantFurniture(pendingBuy.id)
+    setOwnedIds(getOwnedFurnitureIds())
+    setArmedItemId(pendingBuy.id)
+    setPendingBuy(null)
+  }
+
+  function handleCellTap(x: number, y: number) {
+    if (moveArmed && selectedPieceId) {
+      if (moveFurniture(selectedPieceId, x, y)) {
+        setPlaced(loadHomeLayout())
+        setMoveArmed(false)
+      } else {
+        showMessage("That won't fit there.")
+      }
+      return
+    }
+    if (armedItemId) {
+      const piece = placeFurniture(armedItemId, x, y)
+      if (piece) {
+        setPlaced(loadHomeLayout())
+        setArmedItemId(null)
+      } else {
+        showMessage("That won't fit there.")
+      }
+    }
+  }
+
+  function handlePieceTap(id: string) {
+    setArmedItemId(null)
+    setSelectedPieceId(prev => (prev === id ? null : id))
+    setMoveArmed(false)
+  }
+
+  function handleRotate() {
+    if (!selectedPiece) return
+    const rotation = nextRotation(selectedPiece.rotation)
+    if (moveFurniture(selectedPiece.id, selectedPiece.x, selectedPiece.y, rotation)) {
+      setPlaced(loadHomeLayout())
+    } else {
+      showMessage("Can't rotate — no room.")
+    }
+  }
+
+  function handleMove() {
+    setMoveArmed(true)
+  }
+
+  function handleRemove() {
+    if (!selectedPieceId) return
+    if (removeArmedId === selectedPieceId) {
+      removeFurniture(selectedPieceId)
+      setPlaced(loadHomeLayout())
+      setSelectedPieceId(null)
+      return
+    }
+    if (removeArmTimeoutRef.current) clearTimeout(removeArmTimeoutRef.current)
+    setRemoveArmedId(selectedPieceId)
+    removeArmTimeoutRef.current = setTimeout(() => {
+      removeArmTimeoutRef.current = null
+      setRemoveArmedId(null)
+    }, REMOVE_ARM_MS)
+  }
+
+  // While a piece is armed to move, hide it from the grid so its own cells
+  // read as empty/tappable (matching moveFurniture's own self-exclusion).
+  const displayedPlaced = moveArmed && selectedPieceId
+    ? placed.filter(p => p.id !== selectedPieceId)
+    : placed
+
   return (
-    <OverlayScreen title="HOME" onBack={onBack}>
-      <div className="shelf-room">
-        {isEmpty && (
-          <div className="shelf-empty-msg">Your shelves are bare. Collect items to fill them.</div>
-        )}
-        {sections.map((section, sectioni) => (
-          <div key={sectioni}>
-            {section.label && <div className="shelf-section-label">{section.label}</div>}
-            {section.rows.map((row, ri) => (
-              <div key={ri} className="shelf-row">
-                <div className="shelf-items">
-                  {row.map((entry, si) => (
-                    <button
-                      key={si}
-                      className={`shelf-slot${entry ? ' shelf-slot--filled' : ' shelf-slot--empty'}`}
-                      onClick={() => entry && setDetail(entry)}
-                      disabled={!entry}
-                      aria-label={entry ? (entry.kind === 'item' ? entry.item.name : entry.relic.name) : 'Empty slot'}
-                    >
-                      {entry ? (
-                        <>
-                          <span className="shelf-slot-icon">
-                            {entry.kind === 'item' ? entry.item.icon : entry.relic.icon}
-                          </span>
-                          <span className="shelf-slot-name">
-                            {entry.kind === 'item' ? entry.item.name : entry.relic.name}
-                          </span>
-                        </>
-                      ) : (
-                        <span className="shelf-slot-dust" />
-                      )}
-                    </button>
-                  ))}
-                </div>
-                <div className="shelf-plank" />
-              </div>
-            ))}
-          </div>
-        ))}
+    <OverlayScreen
+      title="HOME"
+      onBack={onBack}
+      right={tab === 'decorate' ? <span className="crystal-count">💎 {crystals.toLocaleString()}</span> : undefined}
+    >
+      <div className="hoa-tabs">
+        <button className={`hoa-tab${tab === 'shelf' ? ' hoa-tab--active' : ''}`} onClick={() => setTab('shelf')}>SHELF</button>
+        <button className={`hoa-tab${tab === 'decorate' ? ' hoa-tab--active' : ''}`} onClick={() => setTab('decorate')}>DECORATE</button>
       </div>
+
+      {tab === 'shelf' && (
+        <div className="shelf-room">
+          {isEmpty && (
+            <div className="shelf-empty-msg">Your shelves are bare. Collect items to fill them.</div>
+          )}
+          {sections.map((section, sectioni) => (
+            <div key={sectioni}>
+              {section.label && <div className="shelf-section-label">{section.label}</div>}
+              {section.rows.map((row, ri) => (
+                <div key={ri} className="shelf-row">
+                  <div className="shelf-items">
+                    {row.map((entry, si) => (
+                      <button
+                        key={si}
+                        className={`shelf-slot${entry ? ' shelf-slot--filled' : ' shelf-slot--empty'}`}
+                        onClick={() => entry && setDetail(entry)}
+                        disabled={!entry}
+                        aria-label={entry ? (entry.kind === 'item' ? entry.item.name : entry.relic.name) : 'Empty slot'}
+                      >
+                        {entry ? (
+                          <>
+                            <span className="shelf-slot-icon">
+                              {entry.kind === 'item' ? entry.item.icon : entry.relic.icon}
+                            </span>
+                            <span className="shelf-slot-name">
+                              {entry.kind === 'item' ? entry.item.name : entry.relic.name}
+                            </span>
+                          </>
+                        ) : (
+                          <span className="shelf-slot-dust" />
+                        )}
+                      </button>
+                    ))}
+                  </div>
+                  <div className="shelf-plank" />
+                </div>
+              ))}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {tab === 'decorate' && (
+        <div className="shelf-room">
+          {message && <div className="home-decorate-msg">{message}</div>}
+          {armedItemId && !message && (
+            <div className="home-decorate-hint">Tap an empty spot to place {getFurnitureDef(armedItemId)?.name ?? 'it'}.</div>
+          )}
+          {moveArmed && !message && (
+            <div className="home-decorate-hint">Tap an empty spot to move it there.</div>
+          )}
+
+          <HomeGrid
+            placed={displayedPlaced}
+            getDef={getFurnitureDef}
+            selectedId={selectedPieceId}
+            tappable={!!armedItemId || moveArmed}
+            onCellTap={handleCellTap}
+            onPieceTap={handlePieceTap}
+          />
+
+          {selectedPiece && selectedDef && (
+            <PieceActionBar
+              pieceName={selectedDef.name}
+              removeArmed={removeArmedId === selectedPiece.id}
+              onRotate={handleRotate}
+              onMove={handleMove}
+              onRemove={handleRemove}
+            />
+          )}
+
+          <FurniturePicker
+            defs={getAllFurnitureDefs()}
+            ownedIds={ownedIds}
+            armedId={armedItemId}
+            onPick={handlePickFurniture}
+          />
+        </div>
+      )}
 
       {detail && (
         <div className="shelf-modal-backdrop" onClick={() => setDetail(null)}>
@@ -115,6 +309,26 @@ export function HomeShelf({ onBack }: Props) {
               <div className="shelf-modal-date">Acquired: {detail.item.acquiredDate}</div>
             )}
             <button className="action-btn" onClick={() => setDetail(null)}>CLOSE</button>
+          </div>
+        </div>
+      )}
+
+      {pendingBuy && (
+        <div className="shop-confirm-backdrop" onClick={handleCancelBuy}>
+          <div className="shop-confirm-modal" onClick={e => e.stopPropagation()}>
+            <div className="shop-confirm-title">{pendingBuy.icon} {pendingBuy.name}</div>
+            <div className="shop-confirm-body">
+              Buy for {pendingBuy.price} 💎? You have {crystals.toLocaleString()} 💎.
+            </div>
+            <div className="shop-confirm-actions">
+              <button className="action-btn" onClick={handleCancelBuy}>Cancel</button>
+              <button
+                className={`action-btn action-btn--gold shop-card-buy-btn${crystals < pendingBuy.price ? ' shop-card-buy-btn--poor' : ''}`}
+                onClick={handleConfirmBuy}
+              >
+                Buy for {pendingBuy.price} 💎
+              </button>
+            </div>
           </div>
         </div>
       )}

--- a/web/src/components/hub/home-shelf/FurniturePicker.stories.tsx
+++ b/web/src/components/hub/home-shelf/FurniturePicker.stories.tsx
@@ -1,0 +1,38 @@
+import { fn } from 'storybook/test'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { FurniturePicker } from './FurniturePicker'
+import type { FurnitureDef } from '../../../game/hub/furniture'
+
+const DEFS: FurnitureDef[] = [
+  { id: 'reading-lamp', name: 'Reading Lamp', icon: '💡', desc: 'Warm light.', footprint: { w: 1, h: 1 }, price: 20 },
+  { id: 'cozy-rug', name: 'Cozy Rug', icon: '🟥', desc: 'A thick rug.', footprint: { w: 2, h: 2 }, price: 30 },
+  { id: 'oak-bookshelf', name: 'Oak Bookshelf', icon: '📚', desc: 'A library.', footprint: { w: 1, h: 2 }, price: 45 },
+  { id: 'round-table', name: 'Round Table', icon: '🟤', desc: 'A table.', footprint: { w: 2, h: 1 }, price: 35 },
+]
+
+const meta = {
+  component: FurniturePicker,
+  parameters: { layout: 'fullscreen' },
+  decorators: [
+    (Story) => (
+      <div className="game-container">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof FurniturePicker>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const AllLocked: Story = {
+  args: { defs: DEFS, ownedIds: [], armedId: null, onPick: fn() },
+}
+
+export const MixedOwnership: Story = {
+  args: { defs: DEFS, ownedIds: ['reading-lamp', 'round-table'], armedId: null, onPick: fn() },
+}
+
+export const ItemArmed: Story = {
+  args: { defs: DEFS, ownedIds: ['reading-lamp', 'round-table'], armedId: 'reading-lamp', onPick: fn() },
+}

--- a/web/src/components/hub/home-shelf/FurniturePicker.tsx
+++ b/web/src/components/hub/home-shelf/FurniturePicker.tsx
@@ -1,0 +1,34 @@
+import { FurnitureDef } from '../../../game/hub/furniture'
+
+export interface FurniturePickerProps {
+  defs: FurnitureDef[]
+  ownedIds: string[]
+  armedId: string | null
+  onPick(id: string): void
+}
+
+export function FurniturePicker({ defs, ownedIds, armedId, onPick }: FurniturePickerProps) {
+  return (
+    <div className="furniture-picker">
+      {defs.map(def => {
+        const owned = ownedIds.includes(def.id)
+        return (
+          <button
+            key={def.id}
+            className={[
+              'furniture-picker-item',
+              owned ? 'furniture-picker-item--owned' : 'furniture-picker-item--locked',
+              armedId === def.id ? 'furniture-picker-item--armed' : '',
+            ].filter(Boolean).join(' ')}
+            onClick={() => onPick(def.id)}
+            aria-label={owned ? def.name : `${def.name} — ${def.price} crystals`}
+          >
+            <span className="furniture-picker-item-icon">{def.icon}</span>
+            <span className="furniture-picker-item-name">{def.name}</span>
+            {!owned && <span className="furniture-picker-item-price">💎{def.price}</span>}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/web/src/components/hub/home-shelf/HomeGrid.stories.tsx
+++ b/web/src/components/hub/home-shelf/HomeGrid.stories.tsx
@@ -1,0 +1,80 @@
+import { fn } from 'storybook/test'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { HomeGrid } from './HomeGrid'
+import type { FurnitureDef } from '../../../game/hub/furniture'
+import type { PlacedFurniture } from '../../../game/hub/homeLayout'
+
+const DEFS: Record<string, FurnitureDef> = {
+  'reading-lamp': { id: 'reading-lamp', name: 'Reading Lamp', icon: '💡', desc: '', footprint: { w: 1, h: 1 }, price: 20 },
+  'cozy-rug': { id: 'cozy-rug', name: 'Cozy Rug', icon: '🟥', desc: '', footprint: { w: 2, h: 2 }, price: 30 },
+  'round-table': { id: 'round-table', name: 'Round Table', icon: '🟤', desc: '', footprint: { w: 2, h: 1 }, price: 35 },
+}
+
+function getDef(itemId: string): FurnitureDef | undefined {
+  return DEFS[itemId]
+}
+
+const meta = {
+  component: HomeGrid,
+  parameters: { layout: 'fullscreen' },
+  decorators: [
+    (Story) => (
+      <div className="game-container">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof HomeGrid>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Empty: Story = {
+  args: {
+    placed: [],
+    getDef,
+    selectedId: null,
+    tappable: true,
+    onCellTap: fn(),
+    onPieceTap: fn(),
+  },
+}
+
+const populated: PlacedFurniture[] = [
+  { id: 'lamp-1', itemId: 'reading-lamp', x: 0, y: 0, rotation: 0 },
+  { id: 'rug-1', itemId: 'cozy-rug', x: 2, y: 1, rotation: 0 },
+  { id: 'table-1', itemId: 'round-table', x: 5, y: 4, rotation: 90 },
+]
+
+export const Populated: Story = {
+  args: {
+    placed: populated,
+    getDef,
+    selectedId: null,
+    tappable: false,
+    onCellTap: fn(),
+    onPieceTap: fn(),
+  },
+}
+
+export const PieceSelected: Story = {
+  args: {
+    placed: populated,
+    getDef,
+    selectedId: 'rug-1',
+    tappable: false,
+    onCellTap: fn(),
+    onPieceTap: fn(),
+  },
+}
+
+export const ArmedForPlacement: Story = {
+  args: {
+    placed: populated,
+    getDef,
+    selectedId: null,
+    tappable: true,
+    onCellTap: fn(),
+    onPieceTap: fn(),
+  },
+}

--- a/web/src/components/hub/home-shelf/HomeGrid.tsx
+++ b/web/src/components/hub/home-shelf/HomeGrid.tsx
@@ -1,0 +1,64 @@
+import { PlacedFurniture, HOME_GRID_COLS, HOME_GRID_ROWS } from '../../../game/hub/homeLayout'
+import { FurnitureDef } from '../../../game/hub/furniture'
+
+export interface HomeGridProps {
+  placed: PlacedFurniture[]
+  getDef(itemId: string): FurnitureDef | undefined
+  selectedId: string | null
+  /** Whether empty cells should respond to taps (armed-to-place or armed-to-move). */
+  tappable: boolean
+  onCellTap(x: number, y: number): void
+  onPieceTap(id: string): void
+}
+
+function footprintFor(def: FurnitureDef | undefined, rotation: 0 | 90 | 180 | 270): { w: number; h: number } {
+  const { w, h } = def?.footprint ?? { w: 1, h: 1 }
+  return rotation === 90 || rotation === 270 ? { w: h, h: w } : { w, h }
+}
+
+export function HomeGrid({ placed, getDef, selectedId, tappable, onCellTap, onPieceTap }: HomeGridProps) {
+  const occupied = new Set<string>()
+  for (const p of placed) {
+    const { w, h } = footprintFor(getDef(p.itemId), p.rotation)
+    for (let dx = 0; dx < w; dx++)
+      for (let dy = 0; dy < h; dy++)
+        occupied.add(`${p.x + dx},${p.y + dy}`)
+  }
+
+  const cells = []
+  for (let y = 0; y < HOME_GRID_ROWS; y++) {
+    for (let x = 0; x < HOME_GRID_COLS; x++) {
+      if (occupied.has(`${x},${y}`)) continue
+      cells.push(
+        <div
+          key={`cell-${x}-${y}`}
+          className={`home-grid-cell${tappable ? ' home-grid-cell--tappable' : ''}`}
+          style={{ gridColumn: x + 1, gridRow: y + 1 }}
+          onClick={() => tappable && onCellTap(x, y)}
+        />
+      )
+    }
+  }
+
+  return (
+    <div className="home-grid">
+      {cells}
+      {placed.map(p => {
+        const def = getDef(p.itemId)
+        const { w, h } = footprintFor(def, p.rotation)
+        return (
+          <button
+            key={p.id}
+            className={`home-grid-piece${p.id === selectedId ? ' home-grid-piece--selected' : ''}`}
+            style={{ gridColumn: `${p.x + 1} / span ${w}`, gridRow: `${p.y + 1} / span ${h}` }}
+            onClick={() => onPieceTap(p.id)}
+            aria-label={def?.name ?? p.itemId}
+          >
+            <span>{def?.icon ?? '❓'}</span>
+            <span className="home-grid-piece-name">{def?.name ?? p.itemId}</span>
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/web/src/components/hub/home-shelf/PieceActionBar.stories.tsx
+++ b/web/src/components/hub/home-shelf/PieceActionBar.stories.tsx
@@ -1,0 +1,26 @@
+import { fn } from 'storybook/test'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { PieceActionBar } from './PieceActionBar'
+
+const meta = {
+  component: PieceActionBar,
+  parameters: { layout: 'fullscreen' },
+  decorators: [
+    (Story) => (
+      <div className="game-container">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof PieceActionBar>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: { pieceName: 'Cozy Rug', removeArmed: false, onRotate: fn(), onMove: fn(), onRemove: fn() },
+}
+
+export const RemoveArmed: Story = {
+  args: { pieceName: 'Cozy Rug', removeArmed: true, onRotate: fn(), onMove: fn(), onRemove: fn() },
+}

--- a/web/src/components/hub/home-shelf/PieceActionBar.tsx
+++ b/web/src/components/hub/home-shelf/PieceActionBar.tsx
@@ -1,0 +1,23 @@
+export interface PieceActionBarProps {
+  pieceName: string
+  removeArmed: boolean
+  onRotate(): void
+  onMove(): void
+  onRemove(): void
+}
+
+export function PieceActionBar({ pieceName, removeArmed, onRotate, onMove, onRemove }: PieceActionBarProps) {
+  return (
+    <div className="piece-action-bar">
+      <span className="piece-action-bar-name">{pieceName}</span>
+      <button className="action-btn action-btn--sm" onClick={onRotate}>⟳ Rotate</button>
+      <button className="action-btn action-btn--sm" onClick={onMove}>✥ Move</button>
+      <button
+        className={`action-btn action-btn--sm action-btn--danger${removeArmed ? ' action-btn--remove-armed' : ''}`}
+        onClick={onRemove}
+      >
+        {removeArmed ? 'Confirm remove?' : 'Remove'}
+      </button>
+    </div>
+  )
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -7909,6 +7909,151 @@ body {
   font-family: monospace;
 }
 
+/* ── Home decoration grid (§18/§19 hubworld.md) ── */
+
+.home-decorate-hint {
+  font-size: 11px;
+  color: #9ab89a;
+  font-family: monospace;
+  text-align: center;
+  padding: 4px 8px;
+}
+
+.home-decorate-msg {
+  font-size: 11px;
+  color: #ff8866;
+  font-family: monospace;
+  text-align: center;
+  padding: 4px 8px;
+}
+
+.home-grid {
+  display: grid;
+  grid-template-columns: repeat(8, 1fr);
+  grid-template-rows: repeat(6, 1fr);
+  gap: 3px;
+  aspect-ratio: 8 / 6;
+  background: rgba(20,30,20,0.4);
+  border: 1px solid #2a3a2a;
+  border-radius: 3px;
+  padding: 6px;
+  margin: 0 12px;
+}
+
+.home-grid-cell {
+  background: rgba(255,255,255,0.03);
+  border: 1px solid rgba(255,255,255,0.06);
+  border-radius: 2px;
+  padding: 0;
+  cursor: default;
+}
+
+.home-grid-cell--tappable {
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s;
+}
+.home-grid-cell--tappable:hover {
+  border-color: #446644;
+  background: rgba(120,200,120,0.12);
+}
+
+.home-grid-piece {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1px;
+  background: rgba(20,36,20,0.75);
+  border: 1px solid #446644;
+  border-radius: 3px;
+  cursor: pointer;
+  font-size: 20px;
+  line-height: 1;
+  padding: 2px;
+  overflow: hidden;
+  transition: border-color 0.15s;
+}
+.home-grid-piece:hover { border-color: #6a9a6a; }
+.home-grid-piece--selected {
+  border-color: #ffcc00;
+  box-shadow: 0 0 6px rgba(255,204,0,0.6);
+}
+
+.home-grid-piece-name {
+  font-size: 7px;
+  color: #9ab89a;
+  font-family: monospace;
+  text-align: center;
+  line-height: 1.1;
+}
+
+.furniture-picker {
+  display: flex;
+  gap: 6px;
+  overflow-x: auto;
+  padding: 8px 12px;
+}
+
+.furniture-picker-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 3px;
+  min-width: 60px;
+  flex-shrink: 0;
+  padding: 6px 4px;
+  background: none;
+  border: 1px solid transparent;
+  border-radius: 3px;
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s;
+}
+.furniture-picker-item--owned:hover {
+  border-color: #446644;
+  background: rgba(20,36,20,0.5);
+}
+.furniture-picker-item--armed {
+  border-color: #ffcc00;
+  background: rgba(60,50,10,0.4);
+}
+.furniture-picker-item--locked { opacity: 0.6; }
+
+.furniture-picker-item-icon { font-size: 24px; line-height: 1; }
+
+.furniture-picker-item-name {
+  font-size: 8px;
+  color: #9ab89a;
+  font-family: monospace;
+  text-align: center;
+  line-height: 1.1;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.furniture-picker-item-price {
+  font-size: 9px;
+  color: #88ccff;
+  font-family: monospace;
+}
+
+.piece-action-bar {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+  padding: 10px 12px;
+}
+
+.action-btn--remove-armed {
+  background: #f44336;
+  color: #fff;
+  border-color: #f44336;
+  animation: td-sell-armed-pulse 0.6s ease-in-out infinite alternate;
+}
+.action-btn--remove-armed:hover { background: #d32f2f; }
+
 /* ── Battery / reduced-motion optimisations ────────────────────────────── */
 /* Disable infinite decorative animations for users who prefer reduced motion
    or on any device where the browser opts in via the media query. This also

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -8041,9 +8041,18 @@ body {
 
 .piece-action-bar {
   display: flex;
+  align-items: center;
   gap: 8px;
   justify-content: center;
   padding: 10px 12px;
+}
+
+.piece-action-bar-name {
+  font-size: 11px;
+  color: #c8e8c8;
+  font-family: monospace;
+  letter-spacing: 0.04em;
+  margin-right: 4px;
 }
 
 .action-btn--remove-armed {


### PR DESCRIPTION
## Summary
- Adds a **SHELF / DECORATE** tab row to `web/src/components/hub/HomeShelf.tsx` (existing shelf content unchanged under SHELF).
- New `web/src/components/hub/home-shelf/` subfolder with three pure-visual components, each with a `.stories.tsx`: `HomeGrid.tsx` (renders the 8×6 grid + placed pieces spanning their rotation-aware footprint), `FurniturePicker.tsx` (catalog strip, owned vs. priced/locked), `PieceActionBar.tsx` (Rotate/Move/Remove for a selected piece).
- Interaction is tap-to-arm, tap-to-place (no drag-and-drop — none exists elsewhere in this codebase, and tap matches every other hub interaction): pick an owned item, tap an empty cell to place it; pick an unowned item to open a buy-confirm dialog (reuses `ShopScreen.tsx`'s `.shop-confirm-*` classes) that spends crystals then grants ownership; tap a placed piece to rotate/move/remove it (two-tap confirm on remove, copying `TowerDefence.tsx`'s sell-arm pattern).
- New CSS in `web/src/styles.css` for the grid/picker/action-bar, reusing `.action-btn`, `.hoa-tabs`, `.shop-confirm-*`, and `.crystal-count` wherever possible.
- `docs/hubworld.md` §18 documents the new UI.

## Scope
This closes #1646, the last of #1620's three sub-issues (state layer #1644 and furniture catalog #1649 were merged earlier), completing player housing customization — part of the Hub World epic #1602.

## Test plan
- [x] `npm run build` — typecheck + build pass
- [x] `npm run test` — full pure-logic suite (319 tests) passes; no regressions. This repo has no React component test setup (`@testing-library` isn't installed), so visual verification is via Storybook stories, consistent with the existing `HomeShelf.stories.tsx` convention.
- [x] Interactive visual verification via Storybook + the pre-installed Chromium (`/opt/pw-browsers/chromium`): confirmed the grid/picker/tab row render correctly, and the full buy → place → select → rotate flow works end-to-end (screenshots taken locally during development).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DJkZU7w3kDSwTph6ShXFCP

---
_Generated by [Claude Code](https://claude.ai/code/session_01DJkZU7w3kDSwTph6ShXFCP)_