### PR TITLE
Hub gifts: enforce daily gift cap per NPC

### DIFF
--- a/docs/hubworld.md
+++ b/docs/hubworld.md
@@ -646,7 +646,10 @@ wrapper around `buildTalkGiveOptions` that appends Farewell).
   pattern used for pet/ambient-animal feeding). Picking one consumes it and
   grants friendship + `ally` relationship points. If the item's id matches the
   NPC's optional `favoriteGiftItemId` (see below), the bonus is bigger and
-  applies to `favoriteGiftTrack` instead (default `'ally'`).
+  applies to `favoriteGiftTrack` instead (default `'ally'`). Limited to once
+  per real day per NPC (`canGiftToday`/`recordGift`,
+  `web/src/game/hub/giftCooldown.ts`, mirroring `talkCooldown.ts`) so
+  friendship/relationship can't be farmed by repeatedly gifting the same NPC.
 
 ### Favorite gift (`HubNpc.favoriteGiftItemId` / `favoriteGiftTrack`)
 

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -13,6 +13,7 @@ import { getPickedUpIds, markPickedUp, unmarkPickedUp } from '../../game/hub/pic
 import { getFriendshipLevel, addFriendshipXp, getFriendshipData } from '../../game/hub/friendship'
 import { getRelationship, grantRelationshipWithRivalry, RELATIONSHIP_TRACKS, type RelationshipTrack } from '../../game/hub/relationships'
 import { canTalkToday, recordTalk } from '../../game/hub/talkCooldown'
+import { canGiftToday, recordGift } from '../../game/hub/giftCooldown'
 import { setDialogueFlag, hasDialogueFlag, markNodeSeen } from '../../game/hub/dialogueFlags'
 import { getQuestState, setQuestStatus, incrementQuestProgress, getQuestProgress, resetQuest } from '../../game/hub/quests'
 import { getHeardConvoIds, markConvoHeard } from '../../game/hub/innConvos'
@@ -865,9 +866,12 @@ function buildTalkGiveOptions(
   })
   const giftable = getHubItems().filter(i => i.category === 'material')
   if (giftable.length > 0) {
+    const giftableToday = canGiftToday(npcId)
     choices.push({
-      label: '🎁 Give a gift',
+      label: giftableToday ? '🎁 Give a gift' : '🎁 Give a gift (already gifted today)',
+      disabled: !giftableToday,
       onClick: () => {
+        if (!giftableToday) return
         const giftChoices: DialogueChoice[] = giftable.map(item => ({
           label: `${item.icon ?? '🎁'} ${item.name ?? item.id} ×${item.count}`,
           onClick: () => giveGiftToNpc(npcId, speakerName, npcDef, item.id),
@@ -1325,7 +1329,9 @@ function hasOfferableQuest(giverId: string): boolean {
     npcDef: { favoriteGiftItemId?: string; favoriteGiftTrack?: string; dislikedGiftItemIds?: string[] } | undefined,
     itemId: string,
   ) => {
+    if (!canGiftToday(npcId)) { setDialogueEvent(null); return }
     if (!removeHubItem(itemId, 1)) { setDialogueEvent(null); return }
+    recordGift(npcId)
     const isFavorite = !!npcDef?.favoriteGiftItemId && npcDef.favoriteGiftItemId === itemId
     const isDisliked = !isFavorite && !!npcDef?.dislikedGiftItemIds?.includes(itemId)
     const who = speakerName || 'They'

--- a/web/src/game/hub/giftCooldown.test.ts
+++ b/web/src/game/hub/giftCooldown.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { canGiftToday, recordGift } from './giftCooldown'
+
+function installLocalStorageStub(): void {
+  const store = new Map<string, string>()
+  vi.stubGlobal('localStorage', {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => { store.set(k, v) },
+    removeItem: (k: string) => { store.delete(k) },
+    clear: () => { store.clear() },
+  })
+}
+
+describe('giftCooldown', () => {
+  beforeEach(() => {
+    installLocalStorageStub()
+  })
+
+  it('allows a gift to an NPC that has never been gifted', () => {
+    expect(canGiftToday('scholar')).toBe(true)
+  })
+
+  it('blocks a second gift to the same NPC on the same day', () => {
+    recordGift('scholar')
+    expect(canGiftToday('scholar')).toBe(false)
+  })
+
+  it('tracks each NPC independently', () => {
+    recordGift('scholar')
+    expect(canGiftToday('scholar')).toBe(false)
+    expect(canGiftToday('merchant')).toBe(true)
+  })
+
+  it('fails open (gift allowed) when localStorage throws', () => {
+    vi.stubGlobal('localStorage', {
+      getItem: () => { throw new Error('blocked') },
+      setItem: () => { throw new Error('blocked') },
+    })
+    expect(canGiftToday('scholar')).toBe(true)
+    expect(() => recordGift('scholar')).not.toThrow()
+  })
+})

--- a/web/src/game/hub/giftCooldown.ts
+++ b/web/src/game/hub/giftCooldown.ts
@@ -1,0 +1,46 @@
+// ─── Gift cooldown ────────────────────────────────────────────────────────────
+//
+// Persistence for the generic "Give a gift" NPC interaction (§7d/§7f):
+// each NPC can only receive a gift once per real day, mirroring
+// talkCooldown.ts's "Make conversation" gate. Keyed by bare npcId, same
+// convention as friendship.ts/talkCooldown.ts, mapping to the YYYY-MM-DD
+// the NPC was last gifted.
+
+import { logError } from '../../logger'
+
+const KEY = 'jarv_hub_gift_cooldown'
+
+type GiftCooldownStore = Record<string, string>
+
+function load(): GiftCooldownStore {
+  try {
+    const raw = localStorage.getItem(KEY)
+    return raw ? (JSON.parse(raw) as GiftCooldownStore) : {}
+  } catch {
+    return {}
+  }
+}
+
+function save(store: GiftCooldownStore): void {
+  try {
+    localStorage.setItem(KEY, JSON.stringify(store))
+  } catch (e) {
+    logError('giftCooldown save failed', { error: String(e) })
+  }
+}
+
+function todayKey(): string {
+  return new Date().toISOString().slice(0, 10)
+}
+
+/** Whether this NPC can still receive a gift today. */
+export function canGiftToday(npcId: string): boolean {
+  return load()[npcId] !== todayKey()
+}
+
+/** Record that this NPC received a gift today. */
+export function recordGift(npcId: string): void {
+  const store = load()
+  store[npcId] = todayKey()
+  save(store)
+}


### PR DESCRIPTION
## Summary
- Adds `web/src/game/hub/giftCooldown.ts`, a once-per-real-day-per-NPC store mirroring the existing `talkCooldown.ts` pattern exactly.
- Wires it into `HubWorld.tsx`'s gift flow: the "🎁 Give a gift" option shows a disabled "(already gifted today)" state once an NPC has received a gift today (same UX as the neighboring "🗣️ Make conversation" cooldown), and `giveGiftToNpc` records the cooldown right after a successful gift so it applies uniformly across all three reward tiers (favorite/neutral/disliked).
- `docs/hubworld.md` §7d updated with the cooldown note.

## Context
Investigation before starting found gift-giving is already mostly implemented (built under earlier issues #1871/#1874/#1881, not #1612's thread): the gift picker, three XP tiers, and item consumption all already work. The one gap matching #1612's acceptance criteria ("Daily gift cap per NPC; persist given-today state") was a completely open loop — a player could gift-spam one NPC repeatedly for unlimited friendship/relationship farming. This PR closes that gap.

Given that finding:
- **#1651** ("gift picker UI + NPC tap flow") is already fully implemented — no code change needed. Will be closed separately with an explanatory comment.
- **#1655** (this PR's target) is closed by this change.
- **#1648** ("gift preference tables data + docs") still has real work — data coverage is thin (12/212 NPCs have `favoriteGiftItemId`/`dislikedGiftItemIds`) — planned as a follow-up PR.

## Test plan
- [x] `npm run build` — typecheck + build pass
- [x] `npm run test` — new `giftCooldown.test.ts` (4 tests) plus full suite (323 tests) pass
- [x] Verified by code trace against the already-shipped, identical `talkCooldown.ts`/Make-conversation pattern (per `AGENTS.md`, hub-world canvas verification is expensive to drive for a logic-only change like this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DJkZU7w3kDSwTph6ShXFCP

---
_Generated by [Claude Code](https://claude.ai/code/session_01DJkZU7w3kDSwTph6ShXFCP)_