### PR TITLE
Hub gifts: expand gift preference data to all 212 named NPCs

### DIFF
--- a/docs/hubworld.md
+++ b/docs/hubworld.md
@@ -660,10 +660,49 @@ Optional fields on a `config.json` NPC entry:
   "favoriteGiftItemId": "poetry-book", "favoriteGiftTrack": "romance" }
 ```
 
-Both are additive and optional — omitting them (the default for almost every
-NPC today) just means every material gift grants the flat generic bonus.
-`favoriteGiftTrack` must be one of `RELATIONSHIP_TRACKS` (`'ally' | 'rival' |
-'romance'`) or it's ignored and treated as unset (falls back to `'ally'`).
+Both are additive and optional — omitting them just means every material
+gift grants the flat generic bonus. `favoriteGiftTrack` must be one of
+`RELATIONSHIP_TRACKS` (`'ally' | 'rival' | 'romance'`) or it's ignored and
+treated as unset (falls back to `'ally'`).
+
+**Coverage**: as of the #1648 data pass, all 212 named NPCs across every
+town have `favoriteGiftItemId`/`dislikedGiftItemIds` set. NPCs with real
+characterization (dialogue trees, active quests, or an item `desc` in
+`hubItems.json` that names them/their role directly — e.g. `hearty-pie`:
+"Cook Mabel's egg-and-honey pie") got a hand-picked pair; everyone else was
+assigned via a `sprite`-keyed rotation (`sprite` is a cheap, already-
+populated role proxy on every NPC). New NPCs should follow the same
+convention: prefer a hand-picked thematic match when the NPC has any
+personality to draw on, otherwise reuse the fallback for their `sprite`
+below (or grep existing NPCs sharing that sprite for precedent):
+
+| sprite | favorite | disliked |
+|---|---|---|
+| `hub-npc-merchant` | `silk-ribbon` | `mouldy-slipper` |
+| `hub-npc-scholar` | `poetry-book` | `fish-bait` |
+| `hub-npc-elder` | `honey-cake` | `firefly` |
+| `hub-npc-soldier` | `sturdy-boots` | `pressed-flower` |
+| `hub-npc-dealer` | `gilded-compass` | `wild-berries` |
+| `hub-npc-supplies` | `spice-pouch` | `butterfly` |
+| `hub-npc-fisherman` | `fish-trophy` | `silk-ribbon` |
+| `hub-npc-trader` | `river-glass` | `mouldy-slipper` |
+| `hub-npc-arena` | `sturdy-boots` | `lost-locket` |
+| `hub-npc-guard` | `hearty-pie` | `tin-whistle` |
+| `hub-npc-herald` | `music-box` | `bog-salve` |
+| `hub-npc-gardener` | `pressed-flower` | `bones` |
+| `hub-npc-cook` | `honey` | `fish-bait` |
+| `hub-npc-child` | `tin-whistle` | `bog-salve` |
+| `knight` | `sturdy-boots` | `lost-locket` |
+| `hub-npc-harbourmaster` | `gilded-compass` | `wild-berries` |
+| `hub-npc-card-shop` | `silk-ribbon` | `chicken-feed` |
+| `hub-npc-gravedigger` | `lavender-tonic` | `honey-cake` |
+| `hub-npc-warlock` | `moon-draught` | `honey-cake` |
+| `phantom` | `bones` | `honey-cake` |
+| `ogre` | `hearty-pie` | `poetry-book` |
+| `goblin` | `lost-locket` | `pressed-flower` |
+| `hub-npc-cultist` | `grave-moss` | `silk-ribbon` |
+| `hub-npc-augment-shop` | `gilded-compass` | `wild-berries` |
+| `farmer` | `egg` | `silk-ribbon` |
 
 ### Authoring checklist
 
@@ -671,8 +710,9 @@ Nothing is required for the base mechanism — it works for every NPC in
 `HUB_NPCS` with zero JSON changes. To curate a favorite gift for a specific
 NPC:
 
-1. Add `favoriteGiftItemId`/`favoriteGiftTrack` to that NPC in its town
-   `config.json`.
+1. Add `favoriteGiftItemId`/`favoriteGiftTrack`/`dislikedGiftItemIds` to
+   that NPC in its town `config.json` — check other NPCs sharing the same
+   `sprite` for the town's existing convention before picking new items.
 2. Run `npm run test` (loader tests parse all configs) and `npm run build`.
 3. Verify in-game: gifting the favorite item shows the bigger-bonus flavor
    line and moves the configured track further than a generic material gift.

--- a/web/src/data/hub/appleford/config.json
+++ b/web/src/data/hub/appleford/config.json
@@ -1252,7 +1252,12 @@
         "buildingId": "keepers-cottage",
         "tx": 1,
         "ty": 3
-      }
+      },
+      "favoriteGiftItemId": "honey-cake",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "firefly"
+      ]
     },
     {
       "id": "cider-brewer-tom",
@@ -1270,6 +1275,11 @@
       "questReceive": [
         "appleford-cider-pressing",
         "appleford-cider-pressing-2"
+      ],
+      "favoriteGiftItemId": "silk-ribbon",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "mouldy-slipper"
       ]
     },
     {
@@ -1291,7 +1301,9 @@
       ],
       "favoriteGiftItemId": "lavender-tonic",
       "favoriteGiftTrack": "ally",
-      "dislikedGiftItemIds": ["bog-salve"]
+      "dislikedGiftItemIds": [
+        "bog-salve"
+      ]
     },
     {
       "id": "cooper-wend",
@@ -1307,7 +1319,14 @@
       ],
       "questGive": "appleford-coopers-order",
       "questReceive": "appleford-coopers-order",
-      "dislikes": ["cider-brewer-tom"]
+      "dislikes": [
+        "cider-brewer-tom"
+      ],
+      "favoriteGiftItemId": "egg",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "silk-ribbon"
+      ]
     },
     {
       "id": "market-trader-posy",
@@ -1325,6 +1344,11 @@
       "questGive": "appleford-cider-to-ravenwatch",
       "questReceive": [
         "appleford-orchard-pickers-2"
+      ],
+      "favoriteGiftItemId": "river-glass",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "mouldy-slipper"
       ]
     },
     {
@@ -1340,7 +1364,12 @@
         "Quiet hands, full baskets, grateful hearts. That's all the sermon Appleford needs."
       ],
       "questGive": "appleford-harvest-blessing",
-      "questReceive": "appleford-harvest-blessing"
+      "questReceive": "appleford-harvest-blessing",
+      "favoriteGiftItemId": "poetry-book",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "fish-bait"
+      ]
     },
     {
       "id": "scrumping-wren",
@@ -1355,7 +1384,12 @@
         "When I grow up I'm going to own the whole orchard. And eat ALL the apples."
       ],
       "questGive": "appleford-scrumping",
-      "questReceive": "appleford-scrumping"
+      "questReceive": "appleford-scrumping",
+      "favoriteGiftItemId": "tin-whistle",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "bog-salve"
+      ]
     },
     {
       "id": "orchard-hand-hob",
@@ -1399,7 +1433,12 @@
         "buildingId": "orchard-cottage",
         "tx": 1,
         "ty": 3
-      }
+      },
+      "favoriteGiftItemId": "egg",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "silk-ribbon"
+      ]
     }
   ],
   "interiors": {
@@ -2107,8 +2146,13 @@
       "tx": 28,
       "ty": 22,
       "reactions": [
-        { "type": "dialogue", "text": "One of the orchard's older trees — something might be tucked among its roots." },
-        { "type": "forage" }
+        {
+          "type": "dialogue",
+          "text": "One of the orchard's older trees — something might be tucked among its roots."
+        },
+        {
+          "type": "forage"
+        }
       ]
     },
     {
@@ -2116,8 +2160,13 @@
       "tx": 1,
       "ty": 26,
       "reactions": [
-        { "type": "dialogue", "text": "An autumn-gold tree at the orchard's edge, worth a closer look." },
-        { "type": "forage" }
+        {
+          "type": "dialogue",
+          "text": "An autumn-gold tree at the orchard's edge, worth a closer look."
+        },
+        {
+          "type": "forage"
+        }
       ]
     },
     {
@@ -2125,8 +2174,13 @@
       "tx": 13,
       "ty": 22,
       "reactions": [
-        { "type": "dialogue", "text": "A patch of pink wildflowers growing between the rows." },
-        { "type": "forage" }
+        {
+          "type": "dialogue",
+          "text": "A patch of pink wildflowers growing between the rows."
+        },
+        {
+          "type": "forage"
+        }
       ]
     },
     {
@@ -2203,24 +2257,57 @@
       "tx": 11,
       "ty": 2,
       "building": "market-barn",
-      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 0 }],
-      "reactions": [{ "type": "buy", "slotIndex": 0 }]
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "shopArtSlot": 0
+        }
+      ],
+      "reactions": [
+        {
+          "type": "buy",
+          "slotIndex": 0
+        }
+      ]
     },
     {
       "id": "market-barn-item-1",
       "tx": 11,
       "ty": 3,
       "building": "market-barn",
-      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 1 }],
-      "reactions": [{ "type": "buy", "slotIndex": 1 }]
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "shopArtSlot": 1
+        }
+      ],
+      "reactions": [
+        {
+          "type": "buy",
+          "slotIndex": 1
+        }
+      ]
     },
     {
       "id": "market-barn-item-2",
       "tx": 11,
       "ty": 4,
       "building": "market-barn",
-      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 2 }],
-      "reactions": [{ "type": "buy", "slotIndex": 2 }]
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "shopArtSlot": 2
+        }
+      ],
+      "reactions": [
+        {
+          "type": "buy",
+          "slotIndex": 2
+        }
+      ]
     },
     {
       "id": "appleford-secret-old-boundary-stone",

--- a/web/src/data/hub/capitalcity/config.json
+++ b/web/src/data/hub/capitalcity/config.json
@@ -3778,8 +3778,13 @@
       "tx": 32,
       "ty": 44,
       "reactions": [
-        { "type": "dialogue", "text": "A patch of white flowers growing at the plaza's edge." },
-        { "type": "forage" }
+        {
+          "type": "dialogue",
+          "text": "A patch of white flowers growing at the plaza's edge."
+        },
+        {
+          "type": "forage"
+        }
       ]
     },
     {
@@ -3787,8 +3792,13 @@
       "tx": 60,
       "ty": 62,
       "reactions": [
-        { "type": "dialogue", "text": "Yellow flowers, planted for the coronation and never uprooted." },
-        { "type": "forage" }
+        {
+          "type": "dialogue",
+          "text": "Yellow flowers, planted for the coronation and never uprooted."
+        },
+        {
+          "type": "forage"
+        }
       ]
     },
     {
@@ -3796,8 +3806,13 @@
       "tx": 98,
       "ty": 44,
       "reactions": [
-        { "type": "dialogue", "text": "Pink flowers growing wild near the old noble manors." },
-        { "type": "forage" }
+        {
+          "type": "dialogue",
+          "text": "Pink flowers growing wild near the old noble manors."
+        },
+        {
+          "type": "forage"
+        }
       ]
     },
     {
@@ -3899,64 +3914,152 @@
       "tx": 11,
       "ty": 3,
       "building": "grand-bank",
-      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 0 }],
-      "reactions": [{ "type": "buy", "slotIndex": 0 }]
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "shopArtSlot": 0
+        }
+      ],
+      "reactions": [
+        {
+          "type": "buy",
+          "slotIndex": 0
+        }
+      ]
     },
     {
       "id": "grand-bank-item-1",
       "tx": 11,
       "ty": 4,
       "building": "grand-bank",
-      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 1 }],
-      "reactions": [{ "type": "buy", "slotIndex": 1 }]
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "shopArtSlot": 1
+        }
+      ],
+      "reactions": [
+        {
+          "type": "buy",
+          "slotIndex": 1
+        }
+      ]
     },
     {
       "id": "grand-bank-item-2",
       "tx": 11,
       "ty": 5,
       "building": "grand-bank",
-      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 2 }],
-      "reactions": [{ "type": "buy", "slotIndex": 2 }]
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "shopArtSlot": 2
+        }
+      ],
+      "reactions": [
+        {
+          "type": "buy",
+          "slotIndex": 2
+        }
+      ]
     },
     {
       "id": "jeweller-item-0",
       "tx": 11,
       "ty": 3,
       "building": "jeweller",
-      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 0 }],
-      "reactions": [{ "type": "buy", "slotIndex": 0 }]
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "shopArtSlot": 0
+        }
+      ],
+      "reactions": [
+        {
+          "type": "buy",
+          "slotIndex": 0
+        }
+      ]
     },
     {
       "id": "jeweller-item-1",
       "tx": 11,
       "ty": 4,
       "building": "jeweller",
-      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 1 }],
-      "reactions": [{ "type": "buy", "slotIndex": 1 }]
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "shopArtSlot": 1
+        }
+      ],
+      "reactions": [
+        {
+          "type": "buy",
+          "slotIndex": 1
+        }
+      ]
     },
     {
       "id": "jeweller-item-2",
       "tx": 11,
       "ty": 5,
       "building": "jeweller",
-      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 2 }],
-      "reactions": [{ "type": "buy", "slotIndex": 2 }]
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "shopArtSlot": 2
+        }
+      ],
+      "reactions": [
+        {
+          "type": "buy",
+          "slotIndex": 2
+        }
+      ]
     },
     {
       "id": "tailor-item-0",
       "tx": 11,
       "ty": 3,
       "building": "tailor",
-      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 0 }],
-      "reactions": [{ "type": "buy", "slotIndex": 0 }]
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "shopArtSlot": 0
+        }
+      ],
+      "reactions": [
+        {
+          "type": "buy",
+          "slotIndex": 0
+        }
+      ]
     },
     {
       "id": "tailor-item-1",
       "tx": 11,
       "ty": 4,
       "building": "tailor",
-      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 1 }],
-      "reactions": [{ "type": "buy", "slotIndex": 1 }]
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "shopArtSlot": 1
+        }
+      ],
+      "reactions": [
+        {
+          "type": "buy",
+          "slotIndex": 1
+        }
+      ]
     },
     {
       "id": "capitalcity-secret-temple-inscription",
@@ -4071,6 +4174,11 @@
       "dialogue": [
         "Every record in this archive is a fragment of something larger. I'm still piecing the rest together.",
         "You've seen things out there I can only read about. Tell me — does it match what's written here?"
+      ],
+      "favoriteGiftItemId": "poetry-book",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "mouldy-slipper"
       ]
     },
     {
@@ -4130,7 +4238,12 @@
         "buildingId": "grand-inn-upstairs",
         "tx": 1,
         "ty": 1
-      }
+      },
+      "favoriteGiftItemId": "silk-ribbon",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "mouldy-slipper"
+      ]
     },
     {
       "id": "watch-captain-hale",
@@ -4189,7 +4302,12 @@
         "buildingId": "guardhouse",
         "tx": 1,
         "ty": 1
-      }
+      },
+      "favoriteGiftItemId": "sturdy-boots",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "pressed-flower"
+      ]
     },
     {
       "id": "royal-archivist",
@@ -4248,7 +4366,12 @@
         "buildingId": "library",
         "tx": 1,
         "ty": 1
-      }
+      },
+      "favoriteGiftItemId": "poetry-book",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "fish-bait"
+      ]
     },
     {
       "id": "market-matron",
@@ -4306,7 +4429,12 @@
         "buildingId": "market-hall-crownhaven",
         "tx": 1,
         "ty": 1
-      }
+      },
+      "favoriteGiftItemId": "honey-cake",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "firefly"
+      ]
     },
     {
       "id": "chancellor",
@@ -4364,7 +4492,12 @@
         "buildingId": "senate",
         "tx": 1,
         "ty": 1
-      }
+      },
+      "favoriteGiftItemId": "poetry-book",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "fish-bait"
+      ]
     },
     {
       "id": "high-priest",
@@ -4423,7 +4556,12 @@
         "buildingId": "cathedral",
         "tx": 1,
         "ty": 1
-      }
+      },
+      "favoriteGiftItemId": "honey-cake",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "firefly"
+      ]
     },
     {
       "id": "mint-master",
@@ -4478,7 +4616,12 @@
         "buildingId": "royal-mint",
         "tx": 1,
         "ty": 1
-      }
+      },
+      "favoriteGiftItemId": "silk-ribbon",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "mouldy-slipper"
+      ]
     },
     {
       "id": "banker",
@@ -4498,7 +4641,9 @@
         "crownhaven-noble-debt",
         "crownhaven-stolen-coin"
       ],
-      "dislikes": ["mint-master"],
+      "dislikes": [
+        "mint-master"
+      ],
       "schedule": [
         {
           "startHour": 0,
@@ -4538,7 +4683,12 @@
         "buildingId": "grand-bank",
         "tx": 1,
         "ty": 1
-      }
+      },
+      "favoriteGiftItemId": "silk-ribbon",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "mouldy-slipper"
+      ]
     },
     {
       "id": "tailor-pell",
@@ -4593,7 +4743,12 @@
         "buildingId": "tailor",
         "tx": 1,
         "ty": 1
-      }
+      },
+      "favoriteGiftItemId": "silk-ribbon",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "mouldy-slipper"
+      ]
     },
     {
       "id": "jeweller-isolde",
@@ -4648,7 +4803,12 @@
         "buildingId": "jeweller",
         "tx": 1,
         "ty": 1
-      }
+      },
+      "favoriteGiftItemId": "silk-ribbon",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "mouldy-slipper"
+      ]
     },
     {
       "id": "apothecary-mads",
@@ -4706,7 +4866,12 @@
         "buildingId": "apothecary",
         "tx": 1,
         "ty": 1
-      }
+      },
+      "favoriteGiftItemId": "poetry-book",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "fish-bait"
+      ]
     },
     {
       "id": "baker-otto",
@@ -4765,7 +4930,12 @@
         "buildingId": "bakery",
         "tx": 1,
         "ty": 1
-      }
+      },
+      "favoriteGiftItemId": "honey",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "fish-bait"
+      ]
     },
     {
       "id": "blacksmith-dunn",
@@ -4823,7 +4993,12 @@
         "buildingId": "blacksmith",
         "tx": 1,
         "ty": 1
-      }
+      },
+      "favoriteGiftItemId": "sturdy-boots",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "pressed-flower"
+      ]
     },
     {
       "id": "noble-lady-cora",
@@ -4879,7 +5054,12 @@
         "buildingId": "noble-manor-1-back",
         "tx": 1,
         "ty": 1
-      }
+      },
+      "favoriteGiftItemId": "honey-cake",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "firefly"
+      ]
     },
     {
       "id": "academy-master",
@@ -4935,7 +5115,12 @@
         "buildingId": "academy",
         "tx": 1,
         "ty": 1
-      }
+      },
+      "favoriteGiftItemId": "poetry-book",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "fish-bait"
+      ]
     },
     {
       "id": "busker-lyle",
@@ -4984,6 +5169,11 @@
             "ty": 4
           }
         }
+      ],
+      "favoriteGiftItemId": "silk-ribbon",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "mouldy-slipper"
       ]
     },
     {
@@ -5036,6 +5226,11 @@
             "ty": 4
           }
         }
+      ],
+      "favoriteGiftItemId": "sturdy-boots",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "pressed-flower"
       ]
     },
     {
@@ -5084,6 +5279,11 @@
             "ty": 4
           }
         }
+      ],
+      "favoriteGiftItemId": "sturdy-boots",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "pressed-flower"
       ]
     },
     {
@@ -5098,6 +5298,11 @@
         "Cards! Fresh from the capital's own printers. Care to browse the stock?",
         "Every deck tells a story. Build yours here.",
         "The court plays for crowns; you can play for crystals."
+      ],
+      "favoriteGiftItemId": "silk-ribbon",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "chicken-feed"
       ]
     },
     {
@@ -5111,6 +5316,11 @@
         "Potions, provisions, the practical sort of magic. What do you need?",
         "Stock up before you head back out past the walls.",
         "A well-supplied traveller is a living traveller."
+      ],
+      "favoriteGiftItemId": "spice-pouch",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "butterfly"
       ]
     },
     {
@@ -5125,6 +5335,11 @@
         "Augments, enhancements, little edges of power. Step up to the bench.",
         "The jewellers cut stones; I cut destinies. Or near enough.",
         "Bring me crystals and I'll bring out your cards' true potential."
+      ],
+      "favoriteGiftItemId": "gilded-compass",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "wild-berries"
       ]
     },
     {
@@ -5138,6 +5353,11 @@
         "The Academy drills strategy above all. Shall we refine your deck?",
         "A clever deck wins more wars than a sharp sword.",
         "Theory here, practice in the field. Mind your curve."
+      ],
+      "favoriteGiftItemId": "poetry-book",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "fish-bait"
       ]
     },
     {
@@ -5151,6 +5371,11 @@
         "The cathedral keeps a hall of great deeds. Would you see the records?",
         "Every hero's feats are inscribed here, in gold and stone.",
         "Add your name to the hall, traveller. The realm remembers."
+      ],
+      "favoriteGiftItemId": "honey-cake",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "firefly"
       ]
     },
     {
@@ -5164,6 +5389,11 @@
         "Care for a flutter? The capital's tables never close.",
         "Fortune favours the bold — and occasionally the lucky.",
         "Crowns won, crowns lost. Pull up a chair."
+      ],
+      "favoriteGiftItemId": "gilded-compass",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "wild-berries"
       ]
     },
     {
@@ -5177,6 +5407,11 @@
         "Quick hands at the mint? Test them — catch the falling crystals.",
         "Every coin starts as a tumble of raw crystal. Catch what you can.",
         "Sharp eyes, sharp reflexes, full purse."
+      ],
+      "favoriteGiftItemId": "silk-ribbon",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "mouldy-slipper"
       ]
     },
     {
@@ -5190,6 +5425,11 @@
         "The coronation tournament wants challengers. Step into the ring?",
         "A quick battle to prove your mettle — no excuses.",
         "Win in the arena and the whole capital hears your name."
+      ],
+      "favoriteGiftItemId": "sturdy-boots",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "lost-locket"
       ]
     },
     {
@@ -5203,6 +5443,11 @@
         "The riverside pond's full of fish, if you've the patience. Cast a line?",
         "Quiet water, quick catch. Best spot in the capital.",
         "Catch enough and even the palace kitchens will come calling."
+      ],
+      "favoriteGiftItemId": "fish-trophy",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "silk-ribbon"
       ]
     },
     {
@@ -5218,7 +5463,9 @@
       ],
       "favoriteGiftItemId": "fancy-hat",
       "favoriteGiftTrack": "ally",
-      "dislikedGiftItemIds": ["sturdy-boots"]
+      "dislikedGiftItemIds": [
+        "sturdy-boots"
+      ]
     }
   ],
   "exteriorDecor": [

--- a/web/src/data/hub/dreadspirecitadel/config.json
+++ b/web/src/data/hub/dreadspirecitadel/config.json
@@ -528,6 +528,11 @@
       "dialogue": [
         "I served this citadel once. I don't talk about that, usually.",
         "You keep coming back here. Most people don't, once they've seen the Outer Ward."
+      ],
+      "favoriteGiftItemId": "bog-salve",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "silk-ribbon"
       ]
     },
     {
@@ -547,6 +552,11 @@
         "dreadspire-dark-harvest",
         "dreadspire-harvest-2",
         "dreadspire-harvest-3"
+      ],
+      "favoriteGiftItemId": "poetry-book",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "fish-bait"
       ]
     },
     {
@@ -561,7 +571,12 @@
         "If you mean the citadel harm, I must stop you. If you mean it well, I must watch you suspiciously. Those are the rules."
       ],
       "questGive": "dreadspire-lost-watch",
-      "questReceive": "dreadspire-lost-watch"
+      "questReceive": "dreadspire-lost-watch",
+      "favoriteGiftItemId": "sturdy-boots",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "pressed-flower"
+      ]
     },
     {
       "id": "warlock-vesska",
@@ -615,6 +630,11 @@
             "ty": 5
           }
         }
+      ],
+      "favoriteGiftItemId": "moon-draught",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "honey-cake"
       ]
     },
     {
@@ -631,7 +651,14 @@
       ],
       "questGive": "dreadspire-ritual-ingredients",
       "questReceive": "dreadspire-ritual-ingredients",
-      "dislikes": ["warlock-vesska"]
+      "dislikes": [
+        "warlock-vesska"
+      ],
+      "favoriteGiftItemId": "grave-moss",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "silk-ribbon"
+      ]
     },
     {
       "id": "bone-keeper-mald",
@@ -649,7 +676,9 @@
       "questReceive": "dreadspire-bone-tally",
       "favoriteGiftItemId": "bones",
       "favoriteGiftTrack": "ally",
-      "dislikedGiftItemIds": ["honey-cake"]
+      "dislikedGiftItemIds": [
+        "honey-cake"
+      ]
     },
     {
       "id": "shrine-tender",
@@ -665,7 +694,12 @@
         "Pray if you like. The shadow grants nothing, but it never lies to you either. Rare, these days."
       ],
       "questGive": "dreadspire-black-candles",
-      "questReceive": "dreadspire-black-candles"
+      "questReceive": "dreadspire-black-candles",
+      "favoriteGiftItemId": "bones",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "honey-cake"
+      ]
     },
     {
       "id": "alchemist-sythe",
@@ -681,7 +715,12 @@
         "Touch nothing green. Touch nothing that ISN'T green either, come to think of it."
       ],
       "questGive": "dreadspire-moon-herbs",
-      "questReceive": "dreadspire-moon-herbs"
+      "questReceive": "dreadspire-moon-herbs",
+      "favoriteGiftItemId": "grave-moss",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "honey-cake"
+      ]
     },
     {
       "id": "raven-keeper-corvane",
@@ -696,7 +735,12 @@
         "They fly the whole citadel, my birds. Drop me a token from each corner and I'll know my domain is whole."
       ],
       "questGive": "dreadspire-raven-tokens",
-      "questReceive": "dreadspire-raven-tokens"
+      "questReceive": "dreadspire-raven-tokens",
+      "favoriteGiftItemId": "feather",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "silk-ribbon"
+      ]
     },
     {
       "id": "dungeon-warden-gholl",
@@ -710,7 +754,12 @@
         "The lower vault stays sealed. Warlock's orders — Vesska's, not the master's. There is a difference, and it troubles me.",
         "If you've business in the deep cells, bring me leave from one who outranks dust. I'll know it when I see it."
       ],
-      "questReceive": "dreadspire-intrigue-2"
+      "questReceive": "dreadspire-intrigue-2",
+      "favoriteGiftItemId": "hearty-pie",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "tin-whistle"
+      ]
     },
     {
       "id": "the-defector",
@@ -724,7 +773,12 @@
         "I served the master once. Then I read what the ritual actually does, and I asked to leave. You can guess how that went.",
         "Get me out and I'll tell you what sleeps under this citadel. It is the only currency I have left."
       ],
-      "questGive": "dreadspire-intrigue-3"
+      "questGive": "dreadspire-intrigue-3",
+      "favoriteGiftItemId": "poetry-book",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "fish-bait"
+      ]
     },
     {
       "id": "ghost-servant-isolde",
@@ -764,6 +818,11 @@
             "ty": 4
           }
         }
+      ],
+      "favoriteGiftItemId": "bones",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "honey-cake"
       ]
     },
     {
@@ -777,6 +836,11 @@
         "Every hex has a price, and every price has a hex attached. Fair trade, I call it.",
         "The towers hoard their secrets. I sell mine — cheaper, and with fewer curses attached. Usually.",
         "One spell, properly cast, is worth a hundred swords poorly swung."
+      ],
+      "favoriteGiftItemId": "moon-draught",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "honey-cake"
       ]
     }
   ],
@@ -1993,8 +2057,13 @@
       "tx": 22,
       "ty": 28,
       "reactions": [
-        { "type": "dialogue", "text": "A dead tree, twisted and bare — something might be tucked among its roots." },
-        { "type": "forage" }
+        {
+          "type": "dialogue",
+          "text": "A dead tree, twisted and bare — something might be tucked among its roots."
+        },
+        {
+          "type": "forage"
+        }
       ]
     },
     {
@@ -2002,8 +2071,13 @@
       "tx": 19,
       "ty": 24,
       "reactions": [
-        { "type": "dialogue", "text": "A withered bush by the outer ward, worth a closer look." },
-        { "type": "forage" }
+        {
+          "type": "dialogue",
+          "text": "A withered bush by the outer ward, worth a closer look."
+        },
+        {
+          "type": "forage"
+        }
       ]
     },
     {
@@ -2011,8 +2085,13 @@
       "tx": 33,
       "ty": 27,
       "reactions": [
-        { "type": "dialogue", "text": "A dead bush near the citadel wall, roots half-exposed." },
-        { "type": "forage" }
+        {
+          "type": "dialogue",
+          "text": "A dead bush near the citadel wall, roots half-exposed."
+        },
+        {
+          "type": "forage"
+        }
       ]
     },
     {
@@ -2020,31 +2099,67 @@
       "tx": 7,
       "ty": 2,
       "building": "spellwright-den",
-      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 0 }],
-      "reactions": [{ "type": "buy", "slotIndex": 0 }]
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "shopArtSlot": 0
+        }
+      ],
+      "reactions": [
+        {
+          "type": "buy",
+          "slotIndex": 0
+        }
+      ]
     },
     {
       "id": "spellwright-den-item-1",
       "tx": 7,
       "ty": 3,
       "building": "spellwright-den",
-      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 1 }],
-      "reactions": [{ "type": "buy", "slotIndex": 1 }]
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "shopArtSlot": 1
+        }
+      ],
+      "reactions": [
+        {
+          "type": "buy",
+          "slotIndex": 1
+        }
+      ]
     },
     {
       "id": "spellwright-den-item-2",
       "tx": 7,
       "ty": 4,
       "building": "spellwright-den",
-      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 2 }],
-      "reactions": [{ "type": "buy", "slotIndex": 2 }]
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "shopArtSlot": 2
+        }
+      ],
+      "reactions": [
+        {
+          "type": "buy",
+          "slotIndex": 2
+        }
+      ]
     },
     {
       "id": "dreadspire-secret-tower-note",
       "tx": 30,
       "ty": 15,
       "reactions": [
-        { "type": "dialogue", "text": "A scrap of blackened parchment lies half-buried beside the flagstones, easy to miss." },
+        {
+          "type": "dialogue",
+          "text": "A scrap of blackened parchment lies half-buried beside the flagstones, easy to miss."
+        },
         {
           "type": "giveItem",
           "collectible": {
@@ -2063,7 +2178,10 @@
       "tx": 11,
       "ty": 16,
       "reactions": [
-        { "type": "dialogue", "text": "A shard of black stone, half-buried near the shrine wall, bears a carving that wasn't there before." },
+        {
+          "type": "dialogue",
+          "text": "A shard of black stone, half-buried near the shrine wall, bears a carving that wasn't there before."
+        },
         {
           "type": "giveItem",
           "collectible": {
@@ -2082,7 +2200,10 @@
       "tx": 20,
       "ty": 30,
       "reactions": [
-        { "type": "dialogue", "text": "Tucked beneath a loose flagstone near the gate approach, a torn ledger page waits to be found." },
+        {
+          "type": "dialogue",
+          "text": "Tucked beneath a loose flagstone near the gate approach, a torn ledger page waits to be found."
+        },
         {
           "type": "giveItem",
           "collectible": {
@@ -2101,7 +2222,10 @@
       "tx": 10,
       "ty": 23,
       "reactions": [
-        { "type": "dialogue", "text": "The stones behind the shrine wall have shifted, revealing a cache someone left behind." },
+        {
+          "type": "dialogue",
+          "text": "The stones behind the shrine wall have shifted, revealing a cache someone left behind."
+        },
         {
           "type": "giveItem",
           "collectible": {

--- a/web/src/data/hub/gearford/config.json
+++ b/web/src/data/hub/gearford/config.json
@@ -1724,7 +1724,12 @@
         "buildingId": "foundry",
         "tx": 3,
         "ty": 4
-      }
+      },
+      "favoriteGiftItemId": "bog-salve",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "pressed-flower"
+      ]
     },
     {
       "id": "engineer-vela",
@@ -1771,7 +1776,12 @@
         "buildingId": "machine-workshop",
         "tx": 3,
         "ty": 4
-      }
+      },
+      "favoriteGiftItemId": "silk-ribbon",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "mouldy-slipper"
+      ]
     },
     {
       "id": "foreman-dask",
@@ -1816,7 +1826,12 @@
         "buildingId": "mine-entrance",
         "tx": 3,
         "ty": 4
-      }
+      },
+      "favoriteGiftItemId": "sturdy-boots",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "pressed-flower"
+      ]
     },
     {
       "id": "apprentice-tila",
@@ -1864,7 +1879,9 @@
       },
       "favoriteGiftItemId": "pressed-flower",
       "favoriteGiftTrack": "ally",
-      "dislikedGiftItemIds": ["smoked-herring"]
+      "dislikedGiftItemIds": [
+        "smoked-herring"
+      ]
     },
     {
       "id": "gearwright-orin",
@@ -1906,7 +1923,12 @@
         "buildingId": "gearwright-hall",
         "tx": 3,
         "ty": 4
-      }
+      },
+      "favoriteGiftItemId": "river-glass",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "mouldy-slipper"
+      ]
     },
     {
       "id": "coal-hauler-bram",
@@ -1956,7 +1978,12 @@
         "buildingId": "miners-inn-bunkrooms",
         "tx": 3,
         "ty": 2
-      }
+      },
+      "favoriteGiftItemId": "pressed-flower",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "bones"
+      ]
     },
     {
       "id": "innkeep-mags",
@@ -2012,7 +2039,12 @@
         "buildingId": "miners-inn-bunkrooms",
         "tx": 10,
         "ty": 2
-      }
+      },
+      "favoriteGiftItemId": "honey",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "fish-bait"
+      ]
     },
     {
       "id": "miner-jole",
@@ -2065,7 +2097,12 @@
         "buildingId": "miners-inn-bunkrooms",
         "tx": 8,
         "ty": 2
-      }
+      },
+      "favoriteGiftItemId": "lavender-tonic",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "honey-cake"
+      ]
     },
     {
       "id": "quartermaster-rell",
@@ -2102,6 +2139,11 @@
             "ty": 3
           }
         }
+      ],
+      "favoriteGiftItemId": "gilded-compass",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "wild-berries"
       ]
     },
     {
@@ -2143,7 +2185,12 @@
         "buildingId": "worker-house-2",
         "tx": 2,
         "ty": 2
-      }
+      },
+      "favoriteGiftItemId": "poetry-book",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "fish-bait"
+      ]
     },
     {
       "id": "engineer-torvald",
@@ -2162,16 +2209,35 @@
           "startHour": 0,
           "endHour": 7,
           "activity": "sleep",
-          "location": { "type": "interior", "buildingId": "miners-inn-bunkrooms", "tx": 1, "ty": 2 }
+          "location": {
+            "type": "interior",
+            "buildingId": "miners-inn-bunkrooms",
+            "tx": 1,
+            "ty": 2
+          }
         },
         {
           "startHour": 7,
           "endHour": 24,
           "activity": "work",
-          "location": { "type": "interior", "buildingId": "tool-shop", "tx": 4, "ty": 3 }
+          "location": {
+            "type": "interior",
+            "buildingId": "tool-shop",
+            "tx": 4,
+            "ty": 3
+          }
         }
       ],
-      "homeBed": { "buildingId": "miners-inn-bunkrooms", "tx": 1, "ty": 2 }
+      "homeBed": {
+        "buildingId": "miners-inn-bunkrooms",
+        "tx": 1,
+        "ty": 2
+      },
+      "favoriteGiftItemId": "silk-ribbon",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "mouldy-slipper"
+      ]
     },
     {
       "id": "sergeant-coldiron",
@@ -2190,16 +2256,35 @@
           "startHour": 0,
           "endHour": 7,
           "activity": "sleep",
-          "location": { "type": "interior", "buildingId": "miners-inn-bunkrooms", "tx": 3, "ty": 2 }
+          "location": {
+            "type": "interior",
+            "buildingId": "miners-inn-bunkrooms",
+            "tx": 3,
+            "ty": 2
+          }
         },
         {
           "startHour": 7,
           "endHour": 24,
           "activity": "work",
-          "location": { "type": "interior", "buildingId": "gear-shop", "tx": 4, "ty": 3 }
+          "location": {
+            "type": "interior",
+            "buildingId": "gear-shop",
+            "tx": 4,
+            "ty": 3
+          }
         }
       ],
-      "homeBed": { "buildingId": "miners-inn-bunkrooms", "tx": 3, "ty": 2 }
+      "homeBed": {
+        "buildingId": "miners-inn-bunkrooms",
+        "tx": 3,
+        "ty": 2
+      },
+      "favoriteGiftItemId": "sturdy-boots",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "pressed-flower"
+      ]
     }
   ],
   "interiors": {
@@ -3575,48 +3660,114 @@
       "tx": 9,
       "ty": 3,
       "building": "tool-shop",
-      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 0 }],
-      "reactions": [{ "type": "buy", "slotIndex": 0 }]
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "shopArtSlot": 0
+        }
+      ],
+      "reactions": [
+        {
+          "type": "buy",
+          "slotIndex": 0
+        }
+      ]
     },
     {
       "id": "tool-shop-item-1",
       "tx": 9,
       "ty": 4,
       "building": "tool-shop",
-      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 1 }],
-      "reactions": [{ "type": "buy", "slotIndex": 1 }]
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "shopArtSlot": 1
+        }
+      ],
+      "reactions": [
+        {
+          "type": "buy",
+          "slotIndex": 1
+        }
+      ]
     },
     {
       "id": "tool-shop-item-2",
       "tx": 9,
       "ty": 5,
       "building": "tool-shop",
-      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 2 }],
-      "reactions": [{ "type": "buy", "slotIndex": 2 }]
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "shopArtSlot": 2
+        }
+      ],
+      "reactions": [
+        {
+          "type": "buy",
+          "slotIndex": 2
+        }
+      ]
     },
     {
       "id": "gear-shop-item-0",
       "tx": 9,
       "ty": 3,
       "building": "gear-shop",
-      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 0 }],
-      "reactions": [{ "type": "buy", "slotIndex": 0 }]
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "shopArtSlot": 0
+        }
+      ],
+      "reactions": [
+        {
+          "type": "buy",
+          "slotIndex": 0
+        }
+      ]
     },
     {
       "id": "gear-shop-item-1",
       "tx": 9,
       "ty": 4,
       "building": "gear-shop",
-      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 1 }],
-      "reactions": [{ "type": "buy", "slotIndex": 1 }]
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "shopArtSlot": 1
+        }
+      ],
+      "reactions": [
+        {
+          "type": "buy",
+          "slotIndex": 1
+        }
+      ]
     },
     {
       "id": "gear-shop-item-2",
       "tx": 9,
       "ty": 5,
       "building": "gear-shop",
-      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 2 }],
-      "reactions": [{ "type": "buy", "slotIndex": 2 }]
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "shopArtSlot": 2
+        }
+      ],
+      "reactions": [
+        {
+          "type": "buy",
+          "slotIndex": 2
+        }
+      ]
     },
     {
       "id": "gearford-secret-pressed-flower",
@@ -3629,7 +3780,10 @@
         },
         {
           "type": "giveItem",
-          "hubItem": { "itemId": "pressed-flower", "count": 1 },
+          "hubItem": {
+            "itemId": "pressed-flower",
+            "count": 1
+          },
           "message": "You found a pressed flower!"
         }
       ]

--- a/web/src/data/hub/gravemoor/config.json
+++ b/web/src/data/hub/gravemoor/config.json
@@ -1136,7 +1136,9 @@
       ],
       "favoriteGiftItemId": "grave-moss",
       "favoriteGiftTrack": "ally",
-      "dislikedGiftItemIds": ["honey-cake"],
+      "dislikedGiftItemIds": [
+        "honey-cake"
+      ],
       "schedule": [
         {
           "startHour": 7,
@@ -1173,7 +1175,14 @@
         "The blight took the town, but it couldn't take the market spirit. Literally, in my case."
       ],
       "building": "undertaker",
-      "dislikes": ["brother-mortis"]
+      "dislikes": [
+        "brother-mortis"
+      ],
+      "favoriteGiftItemId": "silk-ribbon",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "mouldy-slipper"
+      ]
     },
     {
       "id": "grave-keeper-finch",
@@ -1193,6 +1202,11 @@
         "gravemoor-restless-remains",
         "gravemoor-restless-remains-2",
         "gravemoor-rest-in-ravenwatch"
+      ],
+      "favoriteGiftItemId": "poetry-book",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "fish-bait"
       ]
     },
     {
@@ -1234,6 +1248,11 @@
             "ty": 4
           }
         }
+      ],
+      "favoriteGiftItemId": "lavender-tonic",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "honey-cake"
       ]
     },
     {
@@ -1253,6 +1272,11 @@
       "questReceive": [
         "gravemoor-reunited-in-death",
         "gravemoor-wheres-mother"
+      ],
+      "favoriteGiftItemId": "lost-locket",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "honey-cake"
       ]
     },
     {
@@ -1269,7 +1293,12 @@
         "Find my commission papers and maybe — maybe — I can finally stand down."
       ],
       "questGive": "gravemoor-soldiers-orders",
-      "questReceive": "gravemoor-soldiers-orders"
+      "questReceive": "gravemoor-soldiers-orders",
+      "favoriteGiftItemId": "sturdy-boots",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "pressed-flower"
+      ]
     },
     {
       "id": "spectral-pedlar",
@@ -1285,7 +1314,12 @@
         "My stock's gone walkabout among the graves. Recover it and we'll both profit."
       ],
       "questGive": "gravemoor-pedlars-stock",
-      "questReceive": "gravemoor-pedlars-stock"
+      "questReceive": "gravemoor-pedlars-stock",
+      "favoriteGiftItemId": "river-glass",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "mouldy-slipper"
+      ]
     },
     {
       "id": "little-pip",
@@ -1301,7 +1335,12 @@
         "She had a sad face and a long grey dress. She used to sing to me."
       ],
       "questGive": "gravemoor-wheres-mother",
-      "questReceive": "gravemoor-wheres-mother"
+      "questReceive": "gravemoor-wheres-mother",
+      "favoriteGiftItemId": "tin-whistle",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "bog-salve"
+      ]
     },
     {
       "id": "brother-mortis",
@@ -1321,6 +1360,11 @@
         "gravemoor-hollow-tolling-1",
         "gravemoor-hollow-tolling-2",
         "gravemoor-hollow-tolling-3"
+      ],
+      "favoriteGiftItemId": "grave-moss",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "silk-ribbon"
       ]
     }
   ],
@@ -2570,8 +2614,13 @@
       "tx": 0,
       "ty": 3,
       "reactions": [
-        { "type": "dialogue", "text": "A gnarled dead tree — something might be tucked in its roots." },
-        { "type": "forage" }
+        {
+          "type": "dialogue",
+          "text": "A gnarled dead tree — something might be tucked in its roots."
+        },
+        {
+          "type": "forage"
+        }
       ]
     },
     {
@@ -2579,8 +2628,13 @@
       "tx": 28,
       "ty": 15,
       "reactions": [
-        { "type": "dialogue", "text": "The whispering wood grows thick here. Worth a closer look." },
-        { "type": "forage" }
+        {
+          "type": "dialogue",
+          "text": "The whispering wood grows thick here. Worth a closer look."
+        },
+        {
+          "type": "forage"
+        }
       ]
     },
     {
@@ -2588,8 +2642,13 @@
       "tx": 42,
       "ty": 11,
       "reactions": [
-        { "type": "dialogue", "text": "A dead tree at the woodland's edge, roots half-exposed." },
-        { "type": "forage" }
+        {
+          "type": "dialogue",
+          "text": "A dead tree at the woodland's edge, roots half-exposed."
+        },
+        {
+          "type": "forage"
+        }
       ]
     },
     {
@@ -2639,24 +2698,57 @@
       "tx": 8,
       "ty": 3,
       "building": "undertaker",
-      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 0 }],
-      "reactions": [{ "type": "buy", "slotIndex": 0 }]
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "shopArtSlot": 0
+        }
+      ],
+      "reactions": [
+        {
+          "type": "buy",
+          "slotIndex": 0
+        }
+      ]
     },
     {
       "id": "undertaker-item-1",
       "tx": 8,
       "ty": 4,
       "building": "undertaker",
-      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 1 }],
-      "reactions": [{ "type": "buy", "slotIndex": 1 }]
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "shopArtSlot": 1
+        }
+      ],
+      "reactions": [
+        {
+          "type": "buy",
+          "slotIndex": 1
+        }
+      ]
     },
     {
       "id": "undertaker-item-2",
       "tx": 8,
       "ty": 5,
       "building": "undertaker",
-      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 2 }],
-      "reactions": [{ "type": "buy", "slotIndex": 2 }]
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "shopArtSlot": 2
+        }
+      ],
+      "reactions": [
+        {
+          "type": "buy",
+          "slotIndex": 2
+        }
+      ]
     },
     {
       "id": "gravemoor-secret-cemetery-locket",

--- a/web/src/data/hub/harrowfield/config.json
+++ b/web/src/data/hub/harrowfield/config.json
@@ -1552,7 +1552,12 @@
         "buildingId": "farmhouse",
         "tx": 1,
         "ty": 3
-      }
+      },
+      "favoriteGiftItemId": "honey-cake",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "firefly"
+      ]
     },
     {
       "id": "farmhand-pip",
@@ -1597,7 +1602,12 @@
         "buildingId": "farmhouse",
         "tx": 4,
         "ty": 3
-      }
+      },
+      "favoriteGiftItemId": "spice-pouch",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "butterfly"
+      ]
     },
     {
       "id": "miller-rook",
@@ -1615,6 +1625,11 @@
       "questReceive": [
         "harrowfield-millers-flour",
         "harrowfield-flour-delivery"
+      ],
+      "favoriteGiftItemId": "silk-ribbon",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "mouldy-slipper"
       ]
     },
     {
@@ -1661,7 +1676,12 @@
         "buildingId": "mill-cottage",
         "tx": 4,
         "ty": 3
-      }
+      },
+      "favoriteGiftItemId": "pressed-flower",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "bones"
+      ]
     },
     {
       "id": "baker-tovi",
@@ -1680,6 +1700,11 @@
         "harrowfield-bakers-bread",
         "harrowfield-bread-run",
         "harrowfield-flour-delivery"
+      ],
+      "favoriteGiftItemId": "honey",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "fish-bait"
       ]
     },
     {
@@ -1695,7 +1720,12 @@
         "Mind the lane — the cart ruts'll have your ankle if the mud doesn't."
       ],
       "questGive": "harrowfield-washday",
-      "questReceive": "harrowfield-washday"
+      "questReceive": "harrowfield-washday",
+      "favoriteGiftItemId": "pressed-flower",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "bones"
+      ]
     },
     {
       "id": "pedlar-quill",
@@ -1714,7 +1744,14 @@
         "harrowfield-produce-to-ravenwatch",
         "harrowfield-shear-day"
       ],
-      "dislikes": ["warden-bell"]
+      "dislikes": [
+        "warden-bell"
+      ],
+      "favoriteGiftItemId": "river-glass",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "mouldy-slipper"
+      ]
     },
     {
       "id": "warden-bell",
@@ -1729,7 +1766,12 @@
         "Quiet hands and full barns. That's all the sermon Harrowfield needs."
       ],
       "questGive": "harrowfield-harvest-blessing",
-      "questReceive": "harrowfield-harvest-blessing"
+      "questReceive": "harrowfield-harvest-blessing",
+      "favoriteGiftItemId": "poetry-book",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "fish-bait"
+      ]
     },
     {
       "id": "child-bram",
@@ -1748,7 +1790,9 @@
       ],
       "favoriteGiftItemId": "music-box",
       "favoriteGiftTrack": "ally",
-      "dislikedGiftItemIds": ["sturdy-boots"]
+      "dislikedGiftItemIds": [
+        "sturdy-boots"
+      ]
     }
   ],
   "interiors": {
@@ -2469,8 +2513,13 @@
       "tx": 2,
       "ty": 9,
       "reactions": [
-        { "type": "dialogue", "text": "A patch of white wildflowers growing by the field's edge." },
-        { "type": "forage" }
+        {
+          "type": "dialogue",
+          "text": "A patch of white wildflowers growing by the field's edge."
+        },
+        {
+          "type": "forage"
+        }
       ]
     },
     {
@@ -2478,8 +2527,13 @@
       "tx": 17,
       "ty": 13,
       "reactions": [
-        { "type": "dialogue", "text": "Pink flowers growing wild among the crop rows." },
-        { "type": "forage" }
+        {
+          "type": "dialogue",
+          "text": "Pink flowers growing wild among the crop rows."
+        },
+        {
+          "type": "forage"
+        }
       ]
     },
     {
@@ -2487,8 +2541,13 @@
       "tx": 29,
       "ty": 12,
       "reactions": [
-        { "type": "dialogue", "text": "A cluster of blue flowers, swaying in the field wind." },
-        { "type": "forage" }
+        {
+          "type": "dialogue",
+          "text": "A cluster of blue flowers, swaying in the field wind."
+        },
+        {
+          "type": "forage"
+        }
       ]
     },
     {
@@ -2536,24 +2595,57 @@
       "tx": 11,
       "ty": 2,
       "building": "market-shed",
-      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 0 }],
-      "reactions": [{ "type": "buy", "slotIndex": 0 }]
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "shopArtSlot": 0
+        }
+      ],
+      "reactions": [
+        {
+          "type": "buy",
+          "slotIndex": 0
+        }
+      ]
     },
     {
       "id": "market-shed-item-1",
       "tx": 11,
       "ty": 3,
       "building": "market-shed",
-      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 1 }],
-      "reactions": [{ "type": "buy", "slotIndex": 1 }]
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "shopArtSlot": 1
+        }
+      ],
+      "reactions": [
+        {
+          "type": "buy",
+          "slotIndex": 1
+        }
+      ]
     },
     {
       "id": "market-shed-item-2",
       "tx": 11,
       "ty": 4,
       "building": "market-shed",
-      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 2 }],
-      "reactions": [{ "type": "buy", "slotIndex": 2 }]
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "shopArtSlot": 2
+        }
+      ],
+      "reactions": [
+        {
+          "type": "buy",
+          "slotIndex": 2
+        }
+      ]
     },
     {
       "id": "harrowfield-secret-green-hymnal",

--- a/web/src/data/hub/hollowmere/config.json
+++ b/web/src/data/hub/hollowmere/config.json
@@ -1153,6 +1153,11 @@
       "dialogue": [
         "The wood listens here. So do I, mostly.",
         "You've walked through a seam or two yourself, I think. It shows, if you know where to look."
+      ],
+      "favoriteGiftItemId": "wild-berries",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "fancy-hat"
       ]
     },
     {
@@ -1166,7 +1171,12 @@
         "You smell like a hero. Lucky for you, I'm off duty.",
         "We're monsters, not animals. The animals live in the nice town down south."
       ],
-      "building": "fang-den"
+      "building": "fang-den",
+      "favoriteGiftItemId": "sturdy-boots",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "pressed-flower"
+      ]
     },
     {
       "id": "fang-the-fence",
@@ -1179,7 +1189,14 @@
         "The undead up at Gravemoor are lovely neighbours. Quiet. Very quiet.",
         "Everything here fell off a cart. A very specific, very unlucky cart."
       ],
-      "dislikes": ["goblin-curio-keep"]
+      "dislikes": [
+        "goblin-curio-keep"
+      ],
+      "favoriteGiftItemId": "silk-ribbon",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "mouldy-slipper"
+      ]
     },
     {
       "id": "hedge-witch-morwen",
@@ -1200,6 +1217,11 @@
         "morwen-speak-with-animals",
         "hollowmere-witch-brew-2",
         "dreadspire-moon-herbs"
+      ],
+      "favoriteGiftItemId": "glowcap-mushroom",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "fish-bait"
       ]
     },
     {
@@ -1219,6 +1241,11 @@
       "questReceive": [
         "apothecary-ingredients-1",
         "apothecary-ingredients-2"
+      ],
+      "favoriteGiftItemId": "rainwater",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "mouldy-slipper"
       ]
     },
     {
@@ -1234,7 +1261,12 @@
       ],
       "building": "bonepile-curio",
       "questGive": "curio-oddities",
-      "questReceive": "curio-oddities"
+      "questReceive": "curio-oddities",
+      "favoriteGiftItemId": "lost-locket",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "pressed-flower"
+      ]
     },
     {
       "id": "bog-troll-attendant",
@@ -1250,7 +1282,12 @@
       ],
       "building": "bathhouse",
       "questGive": "mud-wallow",
-      "questReceive": "mud-wallow"
+      "questReceive": "mud-wallow",
+      "favoriteGiftItemId": "music-box",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "bog-salve"
+      ]
     },
     {
       "id": "tame-ogre-keeper",
@@ -1291,6 +1328,11 @@
             "ty": 4
           }
         }
+      ],
+      "favoriteGiftItemId": "hearty-pie",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "poetry-book"
       ]
     },
     {
@@ -1311,7 +1353,9 @@
       ],
       "favoriteGiftItemId": "gilded-compass",
       "favoriteGiftTrack": "ally",
-      "dislikedGiftItemIds": ["honey-cake"]
+      "dislikedGiftItemIds": [
+        "honey-cake"
+      ]
     }
   ],
   "interiors": {
@@ -1995,8 +2039,13 @@
       "tx": 9,
       "ty": 0,
       "reactions": [
-        { "type": "dialogue", "text": "A dead tree at the wood's edge — something might be nesting in its roots." },
-        { "type": "forage" }
+        {
+          "type": "dialogue",
+          "text": "A dead tree at the wood's edge — something might be nesting in its roots."
+        },
+        {
+          "type": "forage"
+        }
       ]
     },
     {
@@ -2004,8 +2053,13 @@
       "tx": 42,
       "ty": 7,
       "reactions": [
-        { "type": "dialogue", "text": "A dark, gnarled tree, worth a closer look." },
-        { "type": "forage" }
+        {
+          "type": "dialogue",
+          "text": "A dark, gnarled tree, worth a closer look."
+        },
+        {
+          "type": "forage"
+        }
       ]
     },
     {
@@ -2013,8 +2067,13 @@
       "tx": 31,
       "ty": 23,
       "reactions": [
-        { "type": "dialogue", "text": "One of the gnarled trees ringing the marsh — something might be tucked among its roots." },
-        { "type": "forage" }
+        {
+          "type": "dialogue",
+          "text": "One of the gnarled trees ringing the marsh — something might be tucked among its roots."
+        },
+        {
+          "type": "forage"
+        }
       ]
     },
     {
@@ -2056,24 +2115,57 @@
       "tx": 9,
       "ty": 2,
       "building": "bonepile-curio",
-      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 0 }],
-      "reactions": [{ "type": "buy", "slotIndex": 0 }]
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "shopArtSlot": 0
+        }
+      ],
+      "reactions": [
+        {
+          "type": "buy",
+          "slotIndex": 0
+        }
+      ]
     },
     {
       "id": "bonepile-curio-item-1",
       "tx": 9,
       "ty": 3,
       "building": "bonepile-curio",
-      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 1 }],
-      "reactions": [{ "type": "buy", "slotIndex": 1 }]
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "shopArtSlot": 1
+        }
+      ],
+      "reactions": [
+        {
+          "type": "buy",
+          "slotIndex": 1
+        }
+      ]
     },
     {
       "id": "bonepile-curio-item-2",
       "tx": 9,
       "ty": 4,
       "building": "bonepile-curio",
-      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 2 }],
-      "reactions": [{ "type": "buy", "slotIndex": 2 }]
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "shopArtSlot": 2
+        }
+      ],
+      "reactions": [
+        {
+          "type": "buy",
+          "slotIndex": 2
+        }
+      ]
     },
     {
       "id": "hollowmere-secret-hollow-charm",

--- a/web/src/data/hub/ironholdkeep/config.json
+++ b/web/src/data/hub/ironholdkeep/config.json
@@ -1939,7 +1939,12 @@
         "buildingId": "keep-solar",
         "tx": 1,
         "ty": 2
-      }
+      },
+      "favoriteGiftItemId": "sturdy-boots",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "lost-locket"
+      ]
     },
     {
       "id": "castle-guard-master",
@@ -2013,7 +2018,12 @@
         "buildingId": "barracks",
         "tx": 9,
         "ty": 6
-      }
+      },
+      "favoriteGiftItemId": "hearty-pie",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "tin-whistle"
+      ]
     },
     {
       "id": "castle-blacksmith",
@@ -2031,7 +2041,9 @@
       "questReceive": "castle-weapon-cache",
       "favoriteGiftItemId": "bog-salve",
       "favoriteGiftTrack": "ally",
-      "dislikedGiftItemIds": ["poetry-book"],
+      "dislikedGiftItemIds": [
+        "poetry-book"
+      ],
       "schedule": [
         {
           "startHour": 0,
@@ -2098,7 +2110,9 @@
       "building": "quartermasters-store",
       "questGive": "castle-supply-tally",
       "questReceive": "castle-supply-tally",
-      "dislikes": ["castle-blacksmith"],
+      "dislikes": [
+        "castle-blacksmith"
+      ],
       "schedule": [
         {
           "startHour": 0,
@@ -2149,7 +2163,12 @@
         "buildingId": "quartermasters-store",
         "tx": 8,
         "ty": 5
-      }
+      },
+      "favoriteGiftItemId": "silk-ribbon",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "mouldy-slipper"
+      ]
     },
     {
       "id": "castle-cook",
@@ -2205,7 +2224,12 @@
         "buildingId": "kitchens",
         "tx": 10,
         "ty": 5
-      }
+      },
+      "favoriteGiftItemId": "honey",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "fish-bait"
+      ]
     },
     {
       "id": "castle-chaplain",
@@ -2271,7 +2295,12 @@
         "buildingId": "chapel-crypt",
         "tx": 10,
         "ty": 4
-      }
+      },
+      "favoriteGiftItemId": "poetry-book",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "fish-bait"
+      ]
     },
     {
       "id": "castle-archivist",
@@ -2326,7 +2355,12 @@
         "buildingId": "scriptorium",
         "tx": 1,
         "ty": 6
-      }
+      },
+      "favoriteGiftItemId": "poetry-book",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "fish-bait"
+      ]
     },
     {
       "id": "castle-stablehand",
@@ -2392,7 +2426,12 @@
         "buildingId": "stables",
         "tx": 10,
         "ty": 6
-      }
+      },
+      "favoriteGiftItemId": "fish-trophy",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "silk-ribbon"
+      ]
     },
     {
       "id": "castle-knight",
@@ -2465,7 +2504,12 @@
         "buildingId": "barracks",
         "tx": 6,
         "ty": 6
-      }
+      },
+      "favoriteGiftItemId": "sturdy-boots",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "pressed-flower"
+      ]
     },
     {
       "id": "castle-squire",
@@ -2541,7 +2585,12 @@
         "buildingId": "barracks",
         "tx": 8,
         "ty": 6
-      }
+      },
+      "favoriteGiftItemId": "sturdy-boots",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "pressed-flower"
+      ]
     },
     {
       "id": "castle-gatekeeper",
@@ -2585,6 +2634,11 @@
             "ty": 46
           }
         }
+      ],
+      "favoriteGiftItemId": "hearty-pie",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "tin-whistle"
       ]
     },
     {
@@ -2601,7 +2655,12 @@
       ],
       "building": "dungeon-cells",
       "questGive": "castle-prisoners-plea",
-      "questReceive": "castle-prisoners-plea"
+      "questReceive": "castle-prisoners-plea",
+      "favoriteGiftItemId": "honey-cake",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "firefly"
+      ]
     },
     {
       "id": "castle-guard-1",
@@ -2663,7 +2722,12 @@
         "buildingId": "barracks",
         "tx": 1,
         "ty": 6
-      }
+      },
+      "favoriteGiftItemId": "sturdy-boots",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "pressed-flower"
+      ]
     },
     {
       "id": "castle-guard-2",
@@ -2725,7 +2789,12 @@
         "buildingId": "barracks",
         "tx": 2,
         "ty": 6
-      }
+      },
+      "favoriteGiftItemId": "sturdy-boots",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "pressed-flower"
+      ]
     }
   ],
   "interiors": {
@@ -4500,8 +4569,13 @@
         }
       ],
       "reactions": [
-        { "type": "dialogue", "text": "A scrappy bush growing wild in the Outer Bailey." },
-        { "type": "forage" }
+        {
+          "type": "dialogue",
+          "text": "A scrappy bush growing wild in the Outer Bailey."
+        },
+        {
+          "type": "forage"
+        }
       ]
     },
     {
@@ -4516,8 +4590,13 @@
         }
       ],
       "reactions": [
-        { "type": "dialogue", "text": "A patch of wildflowers, somehow thriving between the flagstones." },
-        { "type": "forage" }
+        {
+          "type": "dialogue",
+          "text": "A patch of wildflowers, somehow thriving between the flagstones."
+        },
+        {
+          "type": "forage"
+        }
       ]
     },
     {
@@ -4532,8 +4611,13 @@
         }
       ],
       "reactions": [
-        { "type": "dialogue", "text": "A shaded bush near the dungeon wall, worth a closer look." },
-        { "type": "forage" }
+        {
+          "type": "dialogue",
+          "text": "A shaded bush near the dungeon wall, worth a closer look."
+        },
+        {
+          "type": "forage"
+        }
       ]
     },
     {
@@ -4561,24 +4645,57 @@
       "tx": 9,
       "ty": 2,
       "building": "quartermasters-store",
-      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 0 }],
-      "reactions": [{ "type": "buy", "slotIndex": 0 }]
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "shopArtSlot": 0
+        }
+      ],
+      "reactions": [
+        {
+          "type": "buy",
+          "slotIndex": 0
+        }
+      ]
     },
     {
       "id": "quartermasters-store-item-1",
       "tx": 9,
       "ty": 3,
       "building": "quartermasters-store",
-      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 1 }],
-      "reactions": [{ "type": "buy", "slotIndex": 1 }]
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "shopArtSlot": 1
+        }
+      ],
+      "reactions": [
+        {
+          "type": "buy",
+          "slotIndex": 1
+        }
+      ]
     },
     {
       "id": "quartermasters-store-item-2",
       "tx": 9,
       "ty": 4,
       "building": "quartermasters-store",
-      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 2 }],
-      "reactions": [{ "type": "buy", "slotIndex": 2 }]
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "shopArtSlot": 2
+        }
+      ],
+      "reactions": [
+        {
+          "type": "buy",
+          "slotIndex": 2
+        }
+      ]
     },
     {
       "id": "ironholdkeep-secret-ward-token",

--- a/web/src/data/hub/millhaven/config.json
+++ b/web/src/data/hub/millhaven/config.json
@@ -1565,6 +1565,11 @@
             "ty": 7
           }
         }
+      ],
+      "favoriteGiftItemId": "spice-pouch",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "butterfly"
       ]
     },
     {
@@ -1592,6 +1597,11 @@
             "ty": 13
           }
         }
+      ],
+      "favoriteGiftItemId": "fish-trophy",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "silk-ribbon"
       ]
     },
     {
@@ -1637,7 +1647,12 @@
         "buildingId": "inn-millhaven-upstairs",
         "tx": 2,
         "ty": 2
-      }
+      },
+      "favoriteGiftItemId": "silk-ribbon",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "mouldy-slipper"
+      ]
     },
     {
       "id": "town-elder-millhaven",
@@ -1691,7 +1706,12 @@
         "buildingId": "inn-millhaven-upstairs",
         "tx": 4,
         "ty": 2
-      }
+      },
+      "favoriteGiftItemId": "honey-cake",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "firefly"
+      ]
     },
     {
       "id": "sailor-finn",
@@ -1717,6 +1737,11 @@
             "ty": 6
           }
         }
+      ],
+      "favoriteGiftItemId": "fish-trophy",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "silk-ribbon"
       ]
     },
     {
@@ -1736,7 +1761,9 @@
         "millhaven-festival-prep",
         "millhaven-market-restock"
       ],
-      "dislikes": ["dockhand-bram"],
+      "dislikes": [
+        "dockhand-bram"
+      ],
       "schedule": [
         {
           "startHour": 0,
@@ -1765,7 +1792,12 @@
         "buildingId": "inn-millhaven-upstairs",
         "tx": 7,
         "ty": 2
-      }
+      },
+      "favoriteGiftItemId": "silk-ribbon",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "mouldy-slipper"
+      ]
     },
     {
       "id": "baker-pernel",
@@ -1782,7 +1814,9 @@
       "questReceive": "millhaven-fresh-bread",
       "favoriteGiftItemId": "honey",
       "favoriteGiftTrack": "ally",
-      "dislikedGiftItemIds": ["fish-bait"],
+      "dislikedGiftItemIds": [
+        "fish-bait"
+      ],
       "schedule": [
         {
           "startHour": 0,
@@ -1875,7 +1909,12 @@
         "buildingId": "smithy",
         "tx": 8,
         "ty": 5
-      }
+      },
+      "favoriteGiftItemId": "spice-pouch",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "butterfly"
+      ]
     },
     {
       "id": "dockhand-bram",
@@ -1928,7 +1967,12 @@
         "buildingId": "boathouse",
         "tx": 8,
         "ty": 5
-      }
+      },
+      "favoriteGiftItemId": "fish-trophy",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "silk-ribbon"
+      ]
     },
     {
       "id": "widow-tamsin",
@@ -1973,7 +2017,12 @@
         "buildingId": "fisher-cottage",
         "tx": 2,
         "ty": 2
-      }
+      },
+      "favoriteGiftItemId": "honey-cake",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "firefly"
+      ]
     },
     {
       "id": "harbour-angler",
@@ -1986,7 +2035,12 @@
         "Cast a line with me — the harbour's always biting.",
         "Patience and a steady hand, that's all it takes."
       ],
-      "screen": "hub-fishing"
+      "screen": "hub-fishing",
+      "favoriteGiftItemId": "fish-trophy",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "silk-ribbon"
+      ]
     },
     {
       "id": "quartermaster-millhaven",
@@ -1999,7 +2053,12 @@
         "A traveller far from home still needs to resupply. Take a look.",
         "Coin for goods, that's the honest trade of Millhaven."
       ],
-      "screen": "shop-supplies"
+      "screen": "shop-supplies",
+      "favoriteGiftItemId": "spice-pouch",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "butterfly"
+      ]
     },
     {
       "id": "card-trader-millhaven",
@@ -2013,7 +2072,12 @@
         "Browse the wares, friend. Every deck needs an edge."
       ],
       "screen": "shop-cards",
-      "building": "card-shop-millhaven"
+      "building": "card-shop-millhaven",
+      "favoriteGiftItemId": "silk-ribbon",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "chicken-feed"
+      ]
     },
     {
       "id": "regatta-master",
@@ -2026,7 +2090,12 @@
         "Rigging's done and the buoys are set — care to race a skiff?",
         "Mark my words: the Millhaven Regatta will be the finest sport on the coast."
       ],
-      "screen": "regatta"
+      "screen": "regatta",
+      "favoriteGiftItemId": "gilded-compass",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "wild-berries"
+      ]
     }
   ],
   "interiors": {
@@ -3039,8 +3108,13 @@
         }
       ],
       "reactions": [
-        { "type": "dialogue", "text": "A tangled bush growing wild by the fisher-cottage field." },
-        { "type": "forage" }
+        {
+          "type": "dialogue",
+          "text": "A tangled bush growing wild by the fisher-cottage field."
+        },
+        {
+          "type": "forage"
+        }
       ]
     },
     {
@@ -3055,8 +3129,13 @@
         }
       ],
       "reactions": [
-        { "type": "dialogue", "text": "A shaded bush behind the bakery, worth a closer look." },
-        { "type": "forage" }
+        {
+          "type": "dialogue",
+          "text": "A shaded bush behind the bakery, worth a closer look."
+        },
+        {
+          "type": "forage"
+        }
       ]
     },
     {
@@ -3071,8 +3150,13 @@
         }
       ],
       "reactions": [
-        { "type": "dialogue", "text": "A patch of wildflowers growing at the field's edge." },
-        { "type": "forage" }
+        {
+          "type": "dialogue",
+          "text": "A patch of wildflowers growing at the field's edge."
+        },
+        {
+          "type": "forage"
+        }
       ]
     },
     {

--- a/web/src/data/hub/ravenwatch/config.json
+++ b/web/src/data/hub/ravenwatch/config.json
@@ -8234,7 +8234,12 @@
         "buildingId": "inn-building-upstairs",
         "tx": 2,
         "ty": 1
-      }
+      },
+      "favoriteGiftItemId": "honey-cake",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "firefly"
+      ]
     },
     {
       "id": "merchant",
@@ -8287,7 +8292,12 @@
         "buildingId": "inn-building-upstairs",
         "tx": 4,
         "ty": 1
-      }
+      },
+      "favoriteGiftItemId": "silk-ribbon",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "mouldy-slipper"
+      ]
     },
     {
       "id": "scholar",
@@ -8339,7 +8349,12 @@
         "buildingId": "inn-building-upstairs",
         "tx": 9,
         "ty": 1
-      }
+      },
+      "favoriteGiftItemId": "poetry-book",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "fish-bait"
+      ]
     },
     {
       "id": "fisherman",
@@ -8396,7 +8411,12 @@
         "buildingId": "inn-building-upstairs",
         "tx": 7,
         "ty": 1
-      }
+      },
+      "favoriteGiftItemId": "fish-trophy",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "silk-ribbon"
+      ]
     },
     {
       "id": "dealer",
@@ -8414,6 +8434,11 @@
       "questReceive": [
         "elder-rallying-the-hub",
         "dealer-echo-final-bet"
+      ],
+      "favoriteGiftItemId": "gilded-compass",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "wild-berries"
       ]
     },
     {
@@ -8429,6 +8454,11 @@
         "The campaign banners are raised, Commander. Your forces await your orders.",
         "Every great victory began with a single step forward. Ready when you are.",
         "I have delivered the call to arms. The rest is in your hands, Commander."
+      ],
+      "favoriteGiftItemId": "music-box",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "bog-salve"
       ]
     },
     {
@@ -8442,6 +8472,11 @@
         "The endless pits never close, Commander. How long can you last?",
         "Wave after wave. Only the strongest endure.",
         "Glory awaits those who survive the endless onslaught."
+      ],
+      "favoriteGiftItemId": "sturdy-boots",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "pressed-flower"
       ]
     },
     {
@@ -8455,6 +8490,11 @@
         "Today's challenge is set. Every commander faces the same deck.",
         "The daily trial resets at dawn. Will you answer the call?",
         "One challenge, one day. Prove your worth, Commander."
+      ],
+      "favoriteGiftItemId": "music-box",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "bog-salve"
       ]
     },
     {
@@ -8468,6 +8508,11 @@
         "This week's trial carries a story, Commander. The realm remembers those who answer.",
         "Three fragments forge a relic shard. The Chronicle rewards the persistent.",
         "A new trial begins each Monday at dawn. Every commander faces the same fate."
+      ],
+      "favoriteGiftItemId": "music-box",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "bog-salve"
       ]
     },
     {
@@ -8483,6 +8528,11 @@
         "No time for speeches. Pick your opponent and let the cards decide.",
         "The quick battle pits are open. Glory is one match away.",
         "I've seen a thousand commanders step into the pit. How will you fare?"
+      ],
+      "favoriteGiftItemId": "sturdy-boots",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "lost-locket"
       ]
     },
     {
@@ -8497,6 +8547,11 @@
       "dialogue": [
         "Let's plan our strategy for the next battle.",
         "A strong army wins wars!"
+      ],
+      "favoriteGiftItemId": "sturdy-boots",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "lost-locket"
       ]
     },
     {
@@ -8510,6 +8565,11 @@
       "questReceive": "the-password-part-3",
       "dialogue": [
         "Shall we review the troops available to us?"
+      ],
+      "favoriteGiftItemId": "sturdy-boots",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "lost-locket"
       ]
     },
     {
@@ -8521,6 +8581,11 @@
       "screen": "minigames",
       "dialogue": [
         "Welcome to the games quarter! Try your luck."
+      ],
+      "favoriteGiftItemId": "silk-ribbon",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "mouldy-slipper"
       ]
     },
     {
@@ -8532,6 +8597,11 @@
       "screen": "commander",
       "dialogue": [
         "Your forces await your orders, Commander."
+      ],
+      "favoriteGiftItemId": "honey-cake",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "firefly"
       ]
     },
     {
@@ -8550,10 +8620,39 @@
       "questGive": "gildwyns-missing-card",
       "questReceive": "gildwyn-the-fracture-card",
       "schedule": [
-        { "startHour": 6, "endHour": 20, "activity": "work", "location": { "type": "interior", "buildingId": "card-shop", "tx": 6, "ty": 3 } },
-        { "startHour": 20, "endHour": 6, "activity": "sleep", "location": { "type": "interior", "buildingId": "inn-building-upstairs", "tx": 1, "ty": 1 } }
+        {
+          "startHour": 6,
+          "endHour": 20,
+          "activity": "work",
+          "location": {
+            "type": "interior",
+            "buildingId": "card-shop",
+            "tx": 6,
+            "ty": 3
+          }
+        },
+        {
+          "startHour": 20,
+          "endHour": 6,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "inn-building-upstairs",
+            "tx": 1,
+            "ty": 1
+          }
+        }
       ],
-      "homeBed": { "buildingId": "inn-building-upstairs", "tx": 1, "ty": 1 }
+      "homeBed": {
+        "buildingId": "inn-building-upstairs",
+        "tx": 1,
+        "ty": 1
+      },
+      "favoriteGiftItemId": "silk-ribbon",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "chicken-feed"
+      ]
     },
     {
       "id": "vorn",
@@ -8569,10 +8668,39 @@
         "Gildwyn keeps the day trade. I keep the legends."
       ],
       "schedule": [
-        { "startHour": 20, "endHour": 6, "activity": "work", "location": { "type": "interior", "buildingId": "card-shop", "tx": 6, "ty": 3 } },
-        { "startHour": 6, "endHour": 20, "activity": "sleep", "location": { "type": "interior", "buildingId": "inn-building-upstairs", "tx": 6, "ty": 1 } }
+        {
+          "startHour": 20,
+          "endHour": 6,
+          "activity": "work",
+          "location": {
+            "type": "interior",
+            "buildingId": "card-shop",
+            "tx": 6,
+            "ty": 3
+          }
+        },
+        {
+          "startHour": 6,
+          "endHour": 20,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "inn-building-upstairs",
+            "tx": 6,
+            "ty": 1
+          }
+        }
       ],
-      "homeBed": { "buildingId": "inn-building-upstairs", "tx": 6, "ty": 1 }
+      "homeBed": {
+        "buildingId": "inn-building-upstairs",
+        "tx": 6,
+        "ty": 1
+      },
+      "favoriteGiftItemId": "gilded-compass",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "chicken-feed"
+      ]
     },
     {
       "id": "mira",
@@ -8590,10 +8718,39 @@
       "questGive": "miras-runaway-crystal",
       "questReceive": "vex-final-trade",
       "schedule": [
-        { "startHour": 6, "endHour": 20, "activity": "work", "location": { "type": "interior", "buildingId": "augment-shop", "tx": 3, "ty": 1 } },
-        { "startHour": 20, "endHour": 6, "activity": "sleep", "location": { "type": "interior", "buildingId": "inn-building-upstairs", "tx": 3, "ty": 1 } }
+        {
+          "startHour": 6,
+          "endHour": 20,
+          "activity": "work",
+          "location": {
+            "type": "interior",
+            "buildingId": "augment-shop",
+            "tx": 3,
+            "ty": 1
+          }
+        },
+        {
+          "startHour": 20,
+          "endHour": 6,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "inn-building-upstairs",
+            "tx": 3,
+            "ty": 1
+          }
+        }
       ],
-      "homeBed": { "buildingId": "inn-building-upstairs", "tx": 3, "ty": 1 }
+      "homeBed": {
+        "buildingId": "inn-building-upstairs",
+        "tx": 3,
+        "ty": 1
+      },
+      "favoriteGiftItemId": "gilded-compass",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "wild-berries"
+      ]
     },
     {
       "id": "nox",
@@ -8609,10 +8766,39 @@
         "Mira keeps the daylight trade. I keep the connoisseurs."
       ],
       "schedule": [
-        { "startHour": 20, "endHour": 6, "activity": "work", "location": { "type": "interior", "buildingId": "augment-shop", "tx": 3, "ty": 1 } },
-        { "startHour": 6, "endHour": 20, "activity": "sleep", "location": { "type": "interior", "buildingId": "inn-building-upstairs", "tx": 8, "ty": 1 } }
+        {
+          "startHour": 20,
+          "endHour": 6,
+          "activity": "work",
+          "location": {
+            "type": "interior",
+            "buildingId": "augment-shop",
+            "tx": 3,
+            "ty": 1
+          }
+        },
+        {
+          "startHour": 6,
+          "endHour": 20,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "inn-building-upstairs",
+            "tx": 8,
+            "ty": 1
+          }
+        }
       ],
-      "homeBed": { "buildingId": "inn-building-upstairs", "tx": 8, "ty": 1 }
+      "homeBed": {
+        "buildingId": "inn-building-upstairs",
+        "tx": 8,
+        "ty": 1
+      },
+      "favoriteGiftItemId": "wraith-tonic",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "honey-cake"
+      ]
     },
     {
       "id": "bramble",
@@ -8630,10 +8816,39 @@
       "questGive": "brambles-first-delivery",
       "questReceive": "vex-final-trade",
       "schedule": [
-        { "startHour": 6, "endHour": 20, "activity": "work", "location": { "type": "interior", "buildingId": "supply-shop", "tx": 5, "ty": 5 } },
-        { "startHour": 20, "endHour": 6, "activity": "sleep", "location": { "type": "interior", "buildingId": "inn-building-upstairs", "tx": 5, "ty": 1 } }
+        {
+          "startHour": 6,
+          "endHour": 20,
+          "activity": "work",
+          "location": {
+            "type": "interior",
+            "buildingId": "supply-shop",
+            "tx": 5,
+            "ty": 5
+          }
+        },
+        {
+          "startHour": 20,
+          "endHour": 6,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "inn-building-upstairs",
+            "tx": 5,
+            "ty": 1
+          }
+        }
       ],
-      "homeBed": { "buildingId": "inn-building-upstairs", "tx": 5, "ty": 1 }
+      "homeBed": {
+        "buildingId": "inn-building-upstairs",
+        "tx": 5,
+        "ty": 1
+      },
+      "favoriteGiftItemId": "spice-pouch",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "butterfly"
+      ]
     },
     {
       "id": "grix",
@@ -8649,10 +8864,39 @@
         "Bramble sleeps, Grix sells. Fair trade for fair hours."
       ],
       "schedule": [
-        { "startHour": 20, "endHour": 6, "activity": "work", "location": { "type": "interior", "buildingId": "supply-shop", "tx": 5, "ty": 5 } },
-        { "startHour": 6, "endHour": 20, "activity": "sleep", "location": { "type": "interior", "buildingId": "inn-building-upstairs", "tx": 10, "ty": 1 } }
+        {
+          "startHour": 20,
+          "endHour": 6,
+          "activity": "work",
+          "location": {
+            "type": "interior",
+            "buildingId": "supply-shop",
+            "tx": 5,
+            "ty": 5
+          }
+        },
+        {
+          "startHour": 6,
+          "endHour": 20,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "inn-building-upstairs",
+            "tx": 10,
+            "ty": 1
+          }
+        }
       ],
-      "homeBed": { "buildingId": "inn-building-upstairs", "tx": 10, "ty": 1 }
+      "homeBed": {
+        "buildingId": "inn-building-upstairs",
+        "tx": 10,
+        "ty": 1
+      },
+      "favoriteGiftItemId": "spice-pouch",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "silk-ribbon"
+      ]
     },
     {
       "id": "trader",
@@ -8667,6 +8911,11 @@
         "One person's junk is another's treasure. Have a rummage!",
         "I found this stuff all over the Fracture zones. Don't ask how.",
         "Make me an offer — I'm always looking to deal."
+      ],
+      "favoriteGiftItemId": "river-glass",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "mouldy-slipper"
       ]
     },
     {
@@ -8680,6 +8929,11 @@
         "I keep the Fracture Chronicle, Commander. Each chapter brings us closer to the truth.",
         "The story of what shattered our world unfolds piece by piece. Come, read with me.",
         "A new chapter surfaces when the time is right. The Chronicle does not rush its telling."
+      ],
+      "favoriteGiftItemId": "poetry-book",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "fish-bait"
       ]
     },
     {
@@ -8707,6 +8961,11 @@
         "fisherman-depths-secret",
         "vex-final-trade",
         "thorin-the-last-watch"
+      ],
+      "favoriteGiftItemId": "poetry-book",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "fish-bait"
       ]
     },
     {
@@ -8718,6 +8977,11 @@
       "screen": "hall-of-achievements",
       "dialogue": [
         "Your deeds are recorded here, Commander. Come see your legacy."
+      ],
+      "favoriteGiftItemId": "honey-cake",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "firefly"
       ]
     },
     {
@@ -8730,6 +8994,11 @@
       "screen": "hall-of-achievements",
       "dialogue": [
         "Your deeds are recorded here, Commander. Come see your legacy."
+      ],
+      "favoriteGiftItemId": "honey-cake",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "firefly"
       ]
     },
     {
@@ -8743,6 +9012,11 @@
         "Your quarters are just inside, Commander. I keep your things in order.",
         "The shelf holds everything you've gathered on your journey.",
         "Rest is just as important as battle. Your quarters await."
+      ],
+      "favoriteGiftItemId": "honey-cake",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "firefly"
       ]
     },
     {
@@ -8755,6 +9029,11 @@
       "dialogue": [
         "Nothings biting today. Maybe try again later?",
         "The fish are shy around here. Patience is key."
+      ],
+      "favoriteGiftItemId": "fish-trophy",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "silk-ribbon"
       ]
     },
     {
@@ -8766,6 +9045,11 @@
       "screen": "hub-fishing",
       "dialogue": [
         "The pond is calm today. Care to fish?"
+      ],
+      "favoriteGiftItemId": "fish-trophy",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "silk-ribbon"
       ]
     },
     {
@@ -8778,6 +9062,11 @@
       "dialogue": [
         "Steady hands and a keen eye — care to roll?",
         "Every marble tells a story. Shall we write yours?"
+      ],
+      "favoriteGiftItemId": "gilded-compass",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "wild-berries"
       ]
     },
     {
@@ -8790,6 +9079,11 @@
       "dialogue": [
         "Flip a tile, reveal your fate.",
         "Memory is a weapon. How sharp is yours?"
+      ],
+      "favoriteGiftItemId": "silk-ribbon",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "mouldy-slipper"
       ]
     },
     {
@@ -8802,6 +9096,11 @@
       "dialogue": [
         "Crystals falling fast — catch them before they shatter!",
         "Speed and focus. That is all you need."
+      ],
+      "favoriteGiftItemId": "poetry-book",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "fish-bait"
       ]
     },
     {
@@ -8814,6 +9113,11 @@
       "dialogue": [
         "Give it a spin — luck favours the bold.",
         "The wheel knows no favourites. Try your luck!"
+      ],
+      "favoriteGiftItemId": "gilded-compass",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "wild-berries"
       ]
     },
     {
@@ -8826,6 +9130,11 @@
       "dialogue": [
         "On your marks — the race is about to begin!",
         "Place your bets and pick your marble. May the fastest win."
+      ],
+      "favoriteGiftItemId": "sturdy-boots",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "lost-locket"
       ]
     },
     {
@@ -8838,6 +9147,11 @@
       "dialogue": [
         "Higher or lower? Simple question, nerves of steel.",
         "Read the deck — or trust your gut."
+      ],
+      "favoriteGiftItemId": "silk-ribbon",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "mouldy-slipper"
       ]
     },
     {
@@ -8850,6 +9164,11 @@
       "dialogue": [
         "Pull the lever and watch the reels spin!",
         "Three in a row and the jackpot is yours."
+      ],
+      "favoriteGiftItemId": "gilded-compass",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "wild-berries"
       ]
     },
     {
@@ -8862,6 +9181,11 @@
       "dialogue": [
         "Best hand wins. Know when to hold, know when to fold.",
         "Poker face optional. Skill is not."
+      ],
+      "favoriteGiftItemId": "gilded-compass",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "wild-berries"
       ]
     },
     {
@@ -8874,6 +9198,11 @@
       "dialogue": [
         "Got tickets? I've got prizes. Let's make a deal.",
         "Trade in your winning tickets for something special."
+      ],
+      "favoriteGiftItemId": "silk-ribbon",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "mouldy-slipper"
       ]
     },
     {
@@ -8886,6 +9215,11 @@
       "dialogue": [
         "The enemy approaches. Build your defences and hold the line!",
         "Every tower placed is a life saved. Choose wisely."
+      ],
+      "favoriteGiftItemId": "sturdy-boots",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "pressed-flower"
       ]
     },
     {
@@ -8898,6 +9232,11 @@
       "dialogue": [
         "A great city starts with a single road. Shall we begin?",
         "Lay the streets, raise the buildings — this town is yours to shape."
+      ],
+      "favoriteGiftItemId": "honey-cake",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "firefly"
       ]
     },
     {
@@ -8912,6 +9251,11 @@
         "Welcome home, Commander. Your quarters are ready.",
         "I have kept everything in order during your absence.",
         "Rest here. Tomorrow's battles can wait."
+      ],
+      "favoriteGiftItemId": "honey-cake",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "firefly"
       ]
     },
     {
@@ -8926,6 +9270,11 @@
         "I am cataloguing every tome in this wing. It may take years.",
         "The northern library holds records predating the Fracture. Fascinating.",
         "Please keep your voice down — scholars are studying."
+      ],
+      "favoriteGiftItemId": "poetry-book",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "fish-bait"
       ]
     },
     {
@@ -8941,6 +9290,11 @@
         "Every shard of the Fracture has been mapped, but the maps keep changing.",
         "I am charting safe passage routes through the ruins. Come back when it's done.",
         "A good map can save your life, Commander."
+      ],
+      "favoriteGiftItemId": "poetry-book",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "fish-bait"
       ]
     },
     {
@@ -8955,6 +9309,11 @@
         "Welcome to my lecture hall. The next session begins shortly.",
         "The study of Fracture shards is a discipline that demands precision.",
         "Ask your questions, Commander. I have taught armies wiser than you."
+      ],
+      "favoriteGiftItemId": "poetry-book",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "fish-bait"
       ]
     },
     {
@@ -8995,6 +9354,11 @@
           "id": "rumour-pond",
           "text": "Old Greyfish says the pond shimmers at night. Strange glimmers beneath the water, he says…"
         }
+      ],
+      "favoriteGiftItemId": "silk-ribbon",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "mouldy-slipper"
       ]
     },
     {
@@ -9017,6 +9381,11 @@
         "The Merchant's Guild has connections across every shard. We can help.",
         "Trade is the lifeblood of any civilisation. Even one in pieces.",
         "You want something? Name your price, Commander."
+      ],
+      "favoriteGiftItemId": "silk-ribbon",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "mouldy-slipper"
       ]
     },
     {
@@ -9031,6 +9400,11 @@
         "Everything is fairly priced here. No haggling.",
         "The market never closes, Commander. Always something new.",
         "I keep this hall running through chaos and war alike. That's my job."
+      ],
+      "favoriteGiftItemId": "silk-ribbon",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "mouldy-slipper"
       ]
     },
     {
@@ -9049,6 +9423,11 @@
       "questReceive": [
         "orin-champions-shield",
         "orin-fake-trophy"
+      ],
+      "favoriteGiftItemId": "honey-cake",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "firefly"
       ]
     },
     {
@@ -9063,6 +9442,11 @@
         "Step right up! The games never stop here.",
         "Skill, luck, or cunning — what'll it be, Commander?",
         "Every game is a battle. You look like you enjoy battles."
+      ],
+      "favoriteGiftItemId": "gilded-compass",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "wild-berries"
       ]
     },
     {
@@ -9091,6 +9475,11 @@
         "mira-anti-fracture-charms",
         "zev-games-hall-stands",
         "orin-champions-stand"
+      ],
+      "favoriteGiftItemId": "hearty-pie",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "tin-whistle"
       ]
     },
     {
@@ -9106,7 +9495,12 @@
         "Training is the difference between victory and defeat. Remember that."
       ],
       "questGive": "varn-training-weights",
-      "questReceive": "bramble-fortified-supplies"
+      "questReceive": "bramble-fortified-supplies",
+      "favoriteGiftItemId": "sturdy-boots",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "pressed-flower"
+      ]
     },
     {
       "id": "marble-master-int",
@@ -9119,6 +9513,11 @@
       "dialogue": [
         "Steady hands and a keen eye — care to roll?",
         "Every marble tells a story. Shall we write yours?"
+      ],
+      "favoriteGiftItemId": "gilded-compass",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "wild-berries"
       ]
     },
     {
@@ -9132,6 +9531,11 @@
       "dialogue": [
         "Flip a tile, reveal your fate.",
         "Memory is a weapon. How sharp is yours?"
+      ],
+      "favoriteGiftItemId": "silk-ribbon",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "mouldy-slipper"
       ]
     },
     {
@@ -9145,6 +9549,11 @@
       "dialogue": [
         "Crystals falling fast — catch them before they shatter!",
         "Speed and focus. That is all you need."
+      ],
+      "favoriteGiftItemId": "poetry-book",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "fish-bait"
       ]
     },
     {
@@ -9158,6 +9567,11 @@
       "dialogue": [
         "Got tickets? I've got prizes. Let's make a deal.",
         "Trade in your winning tickets for something special."
+      ],
+      "favoriteGiftItemId": "silk-ribbon",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "mouldy-slipper"
       ]
     },
     {
@@ -9171,6 +9585,11 @@
       "dialogue": [
         "Give it a spin — luck favours the bold.",
         "The wheel knows no favourites. Try your luck!"
+      ],
+      "favoriteGiftItemId": "gilded-compass",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "wild-berries"
       ]
     },
     {
@@ -9184,6 +9603,11 @@
       "dialogue": [
         "On your marks — the race is about to begin!",
         "Place your bets and pick your marble. May the fastest win."
+      ],
+      "favoriteGiftItemId": "sturdy-boots",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "lost-locket"
       ]
     },
     {
@@ -9197,6 +9621,11 @@
       "dialogue": [
         "Higher or lower? Simple question, nerves of steel.",
         "Read the deck — or trust your gut."
+      ],
+      "favoriteGiftItemId": "silk-ribbon",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "mouldy-slipper"
       ]
     },
     {
@@ -9210,6 +9639,11 @@
       "dialogue": [
         "Pull the lever and watch the reels spin!",
         "Three in a row and the jackpot is yours."
+      ],
+      "favoriteGiftItemId": "gilded-compass",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "wild-berries"
       ]
     },
     {
@@ -9223,6 +9657,11 @@
       "dialogue": [
         "Best hand wins. Know when to hold, know when to fold.",
         "Poker face optional. Skill is not."
+      ],
+      "favoriteGiftItemId": "gilded-compass",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "wild-berries"
       ]
     },
     {
@@ -9234,7 +9673,12 @@
       "dialogue": [
         "Hello!"
       ],
-      "dialogueTree": "james-junk-trade"
+      "dialogueTree": "james-junk-trade",
+      "favoriteGiftItemId": "sturdy-boots",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "lost-locket"
+      ]
     },
     {
       "id": "npc_1781726431819",
@@ -9264,6 +9708,11 @@
           },
           "activity": "sleep"
         }
+      ],
+      "favoriteGiftItemId": "bones",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "honey-cake"
       ]
     },
     {
@@ -9277,7 +9726,14 @@
       ],
       "levelBuildingId": "townhall",
       "minLevel": 2,
-      "dislikes": ["npc_1781629843466"]
+      "dislikes": [
+        "npc_1781629843466"
+      ],
+      "favoriteGiftItemId": "honey-cake",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "firefly"
+      ]
     }
   ],
   "ambientNpcSprites": [
@@ -9714,88 +10170,207 @@
       "tx": 12,
       "ty": 4,
       "building": "card-shop",
-      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 0 }],
-      "reactions": [{ "type": "buy", "slotIndex": 0 }]
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "shopArtSlot": 0
+        }
+      ],
+      "reactions": [
+        {
+          "type": "buy",
+          "slotIndex": 0
+        }
+      ]
     },
     {
       "id": "card-shop-item-1",
       "tx": 12,
       "ty": 5,
       "building": "card-shop",
-      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 1 }],
-      "reactions": [{ "type": "buy", "slotIndex": 1 }]
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "shopArtSlot": 1
+        }
+      ],
+      "reactions": [
+        {
+          "type": "buy",
+          "slotIndex": 1
+        }
+      ]
     },
     {
       "id": "card-shop-item-2",
       "tx": 12,
       "ty": 6,
       "building": "card-shop",
-      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 2 }],
-      "reactions": [{ "type": "buy", "slotIndex": 2 }]
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "shopArtSlot": 2
+        }
+      ],
+      "reactions": [
+        {
+          "type": "buy",
+          "slotIndex": 2
+        }
+      ]
     },
     {
       "id": "card-shop-pack",
       "tx": 12,
       "ty": 7,
       "building": "card-shop",
-      "decor": [{ "dx": 0, "dy": 0, "spriteId": "hub-item-cards" }],
-      "reactions": [{ "type": "buyPack" }]
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "spriteId": "hub-item-cards"
+        }
+      ],
+      "reactions": [
+        {
+          "type": "buyPack"
+        }
+      ]
     },
     {
       "id": "augment-shop-item-0",
       "tx": 8,
       "ty": 4,
       "building": "augment-shop",
-      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 0 }],
-      "reactions": [{ "type": "buy", "slotIndex": 0 }]
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "shopArtSlot": 0
+        }
+      ],
+      "reactions": [
+        {
+          "type": "buy",
+          "slotIndex": 0
+        }
+      ]
     },
     {
       "id": "supply-shop-item-0",
       "tx": 1,
       "ty": 5,
       "building": "supply-shop",
-      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 0 }],
-      "reactions": [{ "type": "buy", "slotIndex": 0 }]
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "shopArtSlot": 0
+        }
+      ],
+      "reactions": [
+        {
+          "type": "buy",
+          "slotIndex": 0
+        }
+      ]
     },
     {
       "id": "supply-shop-item-1",
       "tx": 10,
       "ty": 5,
       "building": "supply-shop",
-      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 1 }],
-      "reactions": [{ "type": "buy", "slotIndex": 1 }]
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "shopArtSlot": 1
+        }
+      ],
+      "reactions": [
+        {
+          "type": "buy",
+          "slotIndex": 1
+        }
+      ]
     },
     {
       "id": "supply-shop-item-2",
       "tx": 5,
       "ty": 7,
       "building": "supply-shop",
-      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 2 }],
-      "reactions": [{ "type": "buy", "slotIndex": 2 }]
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "shopArtSlot": 2
+        }
+      ],
+      "reactions": [
+        {
+          "type": "buy",
+          "slotIndex": 2
+        }
+      ]
     },
     {
       "id": "ravenwatch-forage-bush-1",
       "tx": 0,
       "ty": 16,
-      "reactions": [{ "type": "dialogue", "text": "A dense, dark bush — worth a closer look." }, { "type": "forage" }]
+      "reactions": [
+        {
+          "type": "dialogue",
+          "text": "A dense, dark bush — worth a closer look."
+        },
+        {
+          "type": "forage"
+        }
+      ]
     },
     {
       "id": "ravenwatch-forage-tree-1",
       "tx": 34,
       "ty": 29,
-      "reactions": [{ "type": "dialogue", "text": "Something might be growing at the foot of this old tree." }, { "type": "forage" }]
+      "reactions": [
+        {
+          "type": "dialogue",
+          "text": "Something might be growing at the foot of this old tree."
+        },
+        {
+          "type": "forage"
+        }
+      ]
     },
     {
       "id": "ravenwatch-forage-flower-1",
       "tx": 33,
       "ty": 17,
-      "reactions": [{ "type": "dialogue", "text": "A patch of wildflowers grows here." }, { "type": "forage" }]
+      "reactions": [
+        {
+          "type": "dialogue",
+          "text": "A patch of wildflowers grows here."
+        },
+        {
+          "type": "forage"
+        }
+      ]
     },
     {
       "id": "ravenwatch-forage-flower-2",
       "tx": 34,
       "ty": 18,
-      "reactions": [{ "type": "dialogue", "text": "More wildflowers, swaying in the breeze." }, { "type": "forage" }]
+      "reactions": [
+        {
+          "type": "dialogue",
+          "text": "More wildflowers, swaying in the breeze."
+        },
+        {
+          "type": "forage"
+        }
+      ]
     }
   ],
   "animals": [

--- a/web/src/data/hub/royalpalace/config.json
+++ b/web/src/data/hub/royalpalace/config.json
@@ -1873,7 +1873,9 @@
         "palace-happy-cat",
         "palace-lost-keys"
       ],
-      "dislikes": ["lady-penrose"],
+      "dislikes": [
+        "lady-penrose"
+      ],
       "schedule": [
         {
           "startHour": 0,
@@ -1912,7 +1914,12 @@
         "buildingId": "servants-quarters",
         "tx": 9,
         "ty": 3
-      }
+      },
+      "favoriteGiftItemId": "honey-cake",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "firefly"
+      ]
     },
     {
       "id": "royal-herald",
@@ -1958,6 +1965,11 @@
             "ty": 19
           }
         }
+      ],
+      "favoriteGiftItemId": "music-box",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "bog-salve"
       ]
     },
     {
@@ -2019,7 +2031,12 @@
         "buildingId": "gatehouse",
         "tx": 5,
         "ty": 5
-      }
+      },
+      "favoriteGiftItemId": "sturdy-boots",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "pressed-flower"
+      ]
     },
     {
       "id": "king",
@@ -2076,7 +2093,12 @@
         "buildingId": "palace-3",
         "tx": 4,
         "ty": 3
-      }
+      },
+      "favoriteGiftItemId": "gilded-compass",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "mouldy-slipper"
+      ]
     },
     {
       "id": "queen",
@@ -2094,7 +2116,9 @@
       "questReceive": "palace-queen-roses",
       "favoriteGiftItemId": "silk-ribbon",
       "favoriteGiftTrack": "ally",
-      "dislikedGiftItemIds": ["sturdy-boots"],
+      "dislikedGiftItemIds": [
+        "sturdy-boots"
+      ],
       "schedule": [
         {
           "startHour": 0,
@@ -2209,7 +2233,12 @@
         "buildingId": "palace-3",
         "tx": 4,
         "ty": 3
-      }
+      },
+      "favoriteGiftItemId": "feather",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "bones"
+      ]
     },
     {
       "id": "lady-penrose",
@@ -2228,7 +2257,12 @@
         "palace-court-intrigue-1",
         "palace-court-intrigue-3"
       ],
-      "dialogueTree": "penrose-chat"
+      "dialogueTree": "penrose-chat",
+      "favoriteGiftItemId": "gilded-compass",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "wild-berries"
+      ]
     },
     {
       "id": "treasurer",
@@ -2278,6 +2312,11 @@
             "ty": 5
           }
         }
+      ],
+      "favoriteGiftItemId": "silk-ribbon",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "mouldy-slipper"
       ]
     },
     {
@@ -2327,6 +2366,11 @@
             "ty": 4
           }
         }
+      ],
+      "favoriteGiftItemId": "poetry-book",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "fish-bait"
       ]
     },
     {
@@ -2382,7 +2426,12 @@
         "buildingId": "servants-quarters",
         "tx": 6,
         "ty": 3
-      }
+      },
+      "favoriteGiftItemId": "honey",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "fish-bait"
+      ]
     },
     {
       "id": "royal-gardener",
@@ -2438,7 +2487,12 @@
         "buildingId": "servants-quarters",
         "tx": 9,
         "ty": 6
-      }
+      },
+      "favoriteGiftItemId": "pressed-flower",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "bones"
+      ]
     },
     {
       "id": "stable-master",
@@ -2488,6 +2542,11 @@
             "ty": 5
           }
         }
+      ],
+      "favoriteGiftItemId": "river-glass",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "mouldy-slipper"
       ]
     },
     {
@@ -2498,6 +2557,11 @@
       "ty": 20,
       "dialogue": [
         "Hello! We only want to MEET the princess. Is that so much to ask?"
+      ],
+      "favoriteGiftItemId": "lost-locket",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "pressed-flower"
       ]
     },
     {
@@ -2508,6 +2572,11 @@
       "ty": 18,
       "dialogue": [
         "I'm here to see the princess, only she can help me!"
+      ],
+      "favoriteGiftItemId": "hearty-pie",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "poetry-book"
       ]
     },
     {
@@ -2518,6 +2587,11 @@
       "ty": 54,
       "dialogue": [
         "Hello!"
+      ],
+      "favoriteGiftItemId": "sturdy-boots",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "lost-locket"
       ]
     },
     {
@@ -2528,6 +2602,11 @@
       "ty": 54,
       "dialogue": [
         "Hello!"
+      ],
+      "favoriteGiftItemId": "sturdy-boots",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "lost-locket"
       ]
     },
     {
@@ -2541,6 +2620,11 @@
         "The crown's finest — kept safe in the annex until a worthy buyer comes along.",
         "Every coin in this room has a ledger entry. Every sale, too.",
         "The vault proper is for the king's treasures. This room is for yours."
+      ],
+      "favoriteGiftItemId": "silk-ribbon",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "mouldy-slipper"
       ]
     }
   ],
@@ -4246,8 +4330,13 @@
       "tx": 32,
       "ty": 24,
       "reactions": [
-        { "type": "dialogue", "text": "An autumn-gold tree in the East Gardens, worth a closer look." },
-        { "type": "forage" }
+        {
+          "type": "dialogue",
+          "text": "An autumn-gold tree in the East Gardens, worth a closer look."
+        },
+        {
+          "type": "forage"
+        }
       ]
     },
     {
@@ -4255,8 +4344,13 @@
       "tx": 37,
       "ty": 24,
       "reactions": [
-        { "type": "dialogue", "text": "A patch of blue flowers growing between the garden's bird baths." },
-        { "type": "forage" }
+        {
+          "type": "dialogue",
+          "text": "A patch of blue flowers growing between the garden's bird baths."
+        },
+        {
+          "type": "forage"
+        }
       ]
     },
     {
@@ -4264,8 +4358,13 @@
       "tx": 42,
       "ty": 24,
       "reactions": [
-        { "type": "dialogue", "text": "A tidy bush along the garden's far edge." },
-        { "type": "forage" }
+        {
+          "type": "dialogue",
+          "text": "A tidy bush along the garden's far edge."
+        },
+        {
+          "type": "forage"
+        }
       ]
     },
     {
@@ -4335,24 +4434,57 @@
       "tx": 9,
       "ty": 2,
       "building": "treasury-annex",
-      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 0 }],
-      "reactions": [{ "type": "buy", "slotIndex": 0 }]
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "shopArtSlot": 0
+        }
+      ],
+      "reactions": [
+        {
+          "type": "buy",
+          "slotIndex": 0
+        }
+      ]
     },
     {
       "id": "treasury-annex-item-1",
       "tx": 9,
       "ty": 3,
       "building": "treasury-annex",
-      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 1 }],
-      "reactions": [{ "type": "buy", "slotIndex": 1 }]
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "shopArtSlot": 1
+        }
+      ],
+      "reactions": [
+        {
+          "type": "buy",
+          "slotIndex": 1
+        }
+      ]
     },
     {
       "id": "treasury-annex-item-2",
       "tx": 9,
       "ty": 4,
       "building": "treasury-annex",
-      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 2 }],
-      "reactions": [{ "type": "buy", "slotIndex": 2 }]
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "shopArtSlot": 2
+        }
+      ],
+      "reactions": [
+        {
+          "type": "buy",
+          "slotIndex": 2
+        }
+      ]
     },
     {
       "id": "royalpalace-secret-garden-locket",

--- a/web/src/data/hub/saltmereport/config.json
+++ b/web/src/data/hub/saltmereport/config.json
@@ -1600,7 +1600,12 @@
         "buildingId": "harbourmaster-records",
         "tx": 2,
         "ty": 4
-      }
+      },
+      "favoriteGiftItemId": "gilded-compass",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "wild-berries"
+      ]
     },
     {
       "id": "fishwife-pearl",
@@ -1614,7 +1619,12 @@
         "The reef's been restless. Old Salt says it's the kraken. Old Salt says a lot of things.",
         "You buy, or you're blocking the stall."
       ],
-      "building": "fish-market"
+      "building": "fish-market",
+      "favoriteGiftItemId": "fish-trophy",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "silk-ribbon"
+      ]
     },
     {
       "id": "dockhand-tam",
@@ -1630,7 +1640,9 @@
       "questGive": "saltmere-rum-run",
       "favoriteGiftItemId": "tin-whistle",
       "favoriteGiftTrack": "ally",
-      "dislikedGiftItemIds": ["poetry-book"]
+      "dislikedGiftItemIds": [
+        "poetry-book"
+      ]
     },
     {
       "id": "old-salt",
@@ -1643,7 +1655,12 @@
         "There's a cove east of here no chart will show you. The pirates make sure of that.",
         "The tide takes and the tide gives back. Rarely the same things, mind."
       ],
-      "questGive": "saltmere-lost-at-sea"
+      "questGive": "saltmere-lost-at-sea",
+      "favoriteGiftItemId": "honey-cake",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "firefly"
+      ]
     },
     {
       "id": "shipwright",
@@ -1657,7 +1674,12 @@
         "She'll float. Whether she floats *well* is a different conversation."
       ],
       "building": "shipwright",
-      "questGive": "saltmere-keel-repair"
+      "questGive": "saltmere-keel-repair",
+      "favoriteGiftItemId": "spice-pouch",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "butterfly"
+      ]
     },
     {
       "id": "customs-officer",
@@ -1671,7 +1693,12 @@
         "I've seen smugglers, thieves, and men who simply can't count. I'm still deciding which this is."
       ],
       "building": "customs-house",
-      "questGive": "saltmere-customs-discrepancy"
+      "questGive": "saltmere-customs-discrepancy",
+      "favoriteGiftItemId": "hearty-pie",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "tin-whistle"
+      ]
     },
     {
       "id": "lighthouse-keeper",
@@ -1713,7 +1740,12 @@
         "tx": 4,
         "ty": 4
       },
-      "questGive": "saltmere-oil-for-the-lamp"
+      "questGive": "saltmere-oil-for-the-lamp",
+      "favoriteGiftItemId": "honey-cake",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "firefly"
+      ]
     },
     {
       "id": "net-maker",
@@ -1728,7 +1760,12 @@
         "Good nets outlast the boats they're tied to. Mine, anyway."
       ],
       "building": "net-maker",
-      "questGive": "saltmere-net-gains"
+      "questGive": "saltmere-net-gains",
+      "favoriteGiftItemId": "river-glass",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "mouldy-slipper"
+      ]
     },
     {
       "id": "chandler",
@@ -1742,7 +1779,12 @@
         "Buy local. The alternative is rowing to Ravenwatch, and nobody wants that."
       ],
       "building": "chandlers",
-      "questGive": "saltmere-ships-stores"
+      "questGive": "saltmere-ships-stores",
+      "favoriteGiftItemId": "silk-ribbon",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "mouldy-slipper"
+      ]
     },
     {
       "id": "smokehouse-master",
@@ -1756,7 +1798,12 @@
         "Nothing wrong with a few scraps for a hungry mouth, so long as it's not from MY rack."
       ],
       "building": "smokehouse",
-      "questGive": "saltmere-smokehouse-scraps"
+      "questGive": "saltmere-smokehouse-scraps",
+      "favoriteGiftItemId": "honey",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "fish-bait"
+      ]
     },
     {
       "id": "tavern-sailor",
@@ -1799,7 +1846,12 @@
         "buildingId": "sailors-inn-upstairs",
         "tx": 7,
         "ty": 2
-      }
+      },
+      "favoriteGiftItemId": "smoked-herring",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "fancy-hat"
+      ]
     },
     {
       "id": "smuggler",
@@ -1811,6 +1863,11 @@
         "...Didn't see me. You didn't see anything, in fact.",
         "Rum's a victimless trade until the watch starts counting barrels.",
         "Whatever Vane thinks he knows, he can't prove. Keep it that way and we'll get along fine."
+      ],
+      "favoriteGiftItemId": "gilded-compass",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "wild-berries"
       ]
     }
   ],
@@ -2537,24 +2594,57 @@
       "tx": 8,
       "ty": 2,
       "building": "chandlers",
-      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 0 }],
-      "reactions": [{ "type": "buy", "slotIndex": 0 }]
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "shopArtSlot": 0
+        }
+      ],
+      "reactions": [
+        {
+          "type": "buy",
+          "slotIndex": 0
+        }
+      ]
     },
     {
       "id": "chandlers-item-1",
       "tx": 8,
       "ty": 3,
       "building": "chandlers",
-      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 1 }],
-      "reactions": [{ "type": "buy", "slotIndex": 1 }]
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "shopArtSlot": 1
+        }
+      ],
+      "reactions": [
+        {
+          "type": "buy",
+          "slotIndex": 1
+        }
+      ]
     },
     {
       "id": "chandlers-item-2",
       "tx": 8,
       "ty": 4,
       "building": "chandlers",
-      "decor": [{ "dx": 0, "dy": 0, "shopArtSlot": 2 }],
-      "reactions": [{ "type": "buy", "slotIndex": 2 }]
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "shopArtSlot": 2
+        }
+      ],
+      "reactions": [
+        {
+          "type": "buy",
+          "slotIndex": 2
+        }
+      ]
     },
     {
       "id": "saltmere-secret-tin-whistle",
@@ -2567,7 +2657,10 @@
         },
         {
           "type": "giveItem",
-          "hubItem": { "itemId": "tin-whistle", "count": 1 },
+          "hubItem": {
+            "itemId": "tin-whistle",
+            "count": 1
+          },
           "message": "You found a tin whistle!"
         }
       ]

--- a/web/src/data/hub/thornwoodcamp/config.json
+++ b/web/src/data/hub/thornwoodcamp/config.json
@@ -453,6 +453,11 @@
         "thornwood-embers-low",
         "thornwood-snare-line",
         "thornwood-wolf-watch-2"
+      ],
+      "favoriteGiftItemId": "sturdy-boots",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "pressed-flower"
       ]
     },
     {
@@ -471,6 +476,11 @@
       "questReceive": [
         "shiny-stones",
         "thornwood-lost-treeline"
+      ],
+      "favoriteGiftItemId": "spice-pouch",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "butterfly"
       ]
     },
     {
@@ -490,6 +500,11 @@
         "thornwood-forage-mushrooms",
         "thornwood-wolf-watch",
         "thornwood-wolf-watch-2"
+      ],
+      "favoriteGiftItemId": "hearty-pie",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "tin-whistle"
       ]
     },
     {
@@ -510,7 +525,9 @@
       ],
       "favoriteGiftItemId": "river-glass",
       "favoriteGiftTrack": "ally",
-      "dislikedGiftItemIds": ["chicken-feed"]
+      "dislikedGiftItemIds": [
+        "chicken-feed"
+      ]
     }
   ],
   "animals": [
@@ -623,7 +640,10 @@
         },
         {
           "type": "giveItem",
-          "hubItem": { "itemId": "river-glass", "count": 1 },
+          "hubItem": {
+            "itemId": "river-glass",
+            "count": 1
+          },
           "message": "You found a piece of river glass!"
         }
       ]


### PR DESCRIPTION
## Summary
- Adds `favoriteGiftItemId`/`favoriteGiftTrack`/`dislikedGiftItemIds` to every named NPC that was missing them — 200 of 212 across all 13 towns (Ravenwatch, the largest town at 62 NPCs, previously had zero coverage). The pre-existing 12 hand-authored entries are untouched.
- **Hand-picked** for NPCs with real characterization (dialogue trees, active quests, or an item `desc` in `hubItems.json` that names them/their role directly — e.g. `hearty-pie`: "Cook Mabel's egg-and-honey pie"): Mira, Vask, Alchemist Sythe, Raven-Keeper Corvane, The Weeping Widow, The Pilgrim, Sister Nettle, Grunda the Soaker, Vorn, Nox, Grix, Minister Fallow, King Aldric, Princess Elara, Sailor Bess, Baker Otto, Forgemaster Brunn, Hedge-Witch Morwen, Cook Mabel (19 total).
- **Sprite-based rotation** for the remaining ~180 NPCs, keyed off the already-populated `sprite` field as a cheap role proxy (merchant → silk ribbon, fisherman → trophy fish, guard → hearty pie, etc.) — documented in `docs/hubworld.md` §7d as a table for future NPC authoring to follow.
- Data was applied via a one-off Node script (not committed) validated against the real `hubItems.json` catalog (every assigned id is a real `category: 'material'` item, no favorite/disliked collisions) — a deliberate exception to hand-editing given the mechanical, rule-driven scale (~180 insertions across 13 files).

## Scope
Follow-up to #1655 (daily gift cap, merged). Together they close the remaining gaps found in #1612's gift-giving epic — #1651 (picker UI) was already resolved separately before either of these PRs. Closes #1648 and #1612.

## Test plan
- [x] `npm run build` — typecheck + build pass
- [x] `npm run test` — full suite (413 tests, incl. the hub config loader tests that parse every town) passes
- [x] Verified programmatically: all 212 NPCs now have `favoriteGiftItemId` set, zero favorite/disliked collisions, every assigned item id is a real giftable `material` catalog entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DJkZU7w3kDSwTph6ShXFCP

---
_Generated by [Claude Code](https://claude.ai/code/session_01DJkZU7w3kDSwTph6ShXFCP)_