### PR TITLE
Map editor: "Draw Building" tool for authoring buildings + player houses

### DIFF
--- a/docs/hubworld.md
+++ b/docs/hubworld.md
@@ -1494,6 +1494,16 @@ spawn, and blocked-path tiles all support a "📍 Pick on map" button that sets
 the location from the next canvas click (records the interior building when used
 inside a room). Dialogue-tree `nodes` are edited as JSON within the Dialogue tab.
 
+**Draw Building tool (🏛):** drag a rect on the exterior canvas to create a new
+building — this pushes a `RawBuilding` (default brick/redSlateRoof) plus a
+matching empty interior keyed by the **same id** as the building (required by
+the id-prefix rule — see §10) and a default south-wall door, all as one undo
+step. The Building inspector's "Requires Ownership" checkbox and the "+ New
+room" form's "Player decor" checkbox expose the `requiresOwnership`/
+`playerDecor` fields from §10's player-owned-house mechanism — tick both plus
+`Upgrade Kind: playerHouse` to turn a freshly drawn building into a purchasable,
+player-decorated house.
+
 ---
 
 ## §14 — Seasonal & Festival Events

--- a/web/src/components/mapEditor/EntityInspector.tsx
+++ b/web/src/components/mapEditor/EntityInspector.tsx
@@ -858,6 +858,7 @@ function BuildingInspector({
   const [newW, setNewW]       = useState(10)
   const [newH, setNewH]       = useState(8)
   const [newFloor, setNewFloor] = useState('woodFloor')
+  const [newPlayerDecor, setNewPlayerDecor] = useState(false)
 
   function openForm() {
     setNewId(nextAutoId())
@@ -865,6 +866,7 @@ function BuildingInspector({
     setNewW(10)
     setNewH(8)
     setNewFloor('woodFloor')
+    setNewPlayerDecor(false)
     setShowForm(true)
   }
 
@@ -877,6 +879,7 @@ function BuildingInspector({
       height: newH,
       floorTileId: newFloor.trim() || 'woodFloor',
       decor: [],
+      ...(newPlayerDecor ? { playerDecor: true } : {}),
     }
     onAddInterior(id, interior)
     setShowForm(false)
@@ -928,6 +931,14 @@ function BuildingInspector({
         </Field>
         <Field label="Editing Level">
           <LevelStepper level={activeLevel} max={buildingMaxLevel(building)} onChange={onSetActiveLevel} />
+        </Field>
+        <Field label="Requires Ownership">
+          <input
+            type="checkbox"
+            checked={building.requiresOwnership ?? false}
+            onChange={e => onUpdateBuilding(buildingIndex, { requiresOwnership: e.target.checked || undefined })}
+            title="Door stays locked until purchased via Town Upgrades — e.g. a player house"
+          />
         </Field>
 
         {/* Per-level look — base (level 0) edits the building; higher levels write
@@ -1054,6 +1065,10 @@ function BuildingInspector({
                   {FLOOR_TILES.map(f => <option key={f} value={f}>{f}</option>)}
                 </select>
               </div>
+              <label style={{ display: 'flex', alignItems: 'center', gap: 6, cursor: 'pointer', fontSize: 11, color: '#888' }}>
+                <input type="checkbox" checked={newPlayerDecor} onChange={e => setNewPlayerDecor(e.target.checked)} />
+                Player decor (unfurnished — renders the player's placed furniture)
+              </label>
               <div style={{ display: 'flex', gap: 6 }}>
                 <button
                   onClick={handleSave}

--- a/web/src/components/mapEditor/MapEditor.tsx
+++ b/web/src/components/mapEditor/MapEditor.tsx
@@ -44,7 +44,7 @@ export function MapEditor({ initialMapId = 'ravenwatch', initialFestival = undef
     openInterior, closeInterior, openBuildingEditor, closeBuildingEditor, placeBuildingDoor,
     selectEntities, addToSelection,
     placeDecor, moveEntities, deleteEntities,
-    addPondTile, addBridgeTile, updatePondEntry, updateBridgeEntry, addNpcSpawnTile, addChickenZone, addArea,
+    addPondTile, addBridgeTile, updatePondEntry, updateBridgeEntry, addNpcSpawnTile, addChickenZone, addArea, addBuilding,
     convertStreetToPond, convertPondToStreet,
     batchUpdateZlayer, batchUpdateStreetPathType,
     updateDecorZlayer, updateDecorTileId, reorderDecor, updateGlow, updateDecorMinLevel, updateDecorHideAtLevel, updateBuildingLevelVisual, updateBuilding, addNpc, updateNpcDialogue, updateNpc,
@@ -343,6 +343,7 @@ export function MapEditor({ initialMapId = 'ravenwatch', initialFestival = undef
             onAddNpcSpawnTile={addNpcSpawnTile}
             onAddChickenZone={addChickenZone}
             onAddArea={addArea}
+            onAddBuilding={addBuilding}
             questPickupItems={questDefsData?.pickupItems ?? []}
           />
 

--- a/web/src/components/mapEditor/MapEditorCanvas.tsx
+++ b/web/src/components/mapEditor/MapEditorCanvas.tsx
@@ -106,6 +106,7 @@ interface Props {
   onAddNpcSpawnTile:  (tx: number, ty: number) => void
   onAddChickenZone:   (tx1: number, ty1: number, tx2: number, ty2: number) => void
   onAddArea:           (tx1: number, ty1: number, tx2: number, ty2: number) => void
+  onAddBuilding:       (tx1: number, ty1: number, tx2: number, ty2: number) => void
   onPlaceBuildingDoor: (buildingIndex: number, absTx: number, absTy: number) => void
   showQuestItems:     boolean
   showBlockedPaths:   boolean
@@ -151,7 +152,7 @@ export function MapEditorCanvas(props: Props) {
 
   // Clear rect draw when tool switches away from a rect-draw tool
   useEffect(() => {
-    const rectTools: ToolMode[] = ['street', 'pond', 'bridge', 'chickenZone', 'area']
+    const rectTools: ToolMode[] = ['street', 'pond', 'bridge', 'chickenZone', 'area', 'building']
     if (!rectTools.includes(tool)) {
       rectDrawRef.current = null
       setRectPreview(null)
@@ -260,7 +261,7 @@ export function MapEditorCanvas(props: Props) {
           propsRef.current.onDeleteEntities([entity])
           propsRef.current.onSelectEntities([])
         }
-      } else if (vm !== 'building' && (t === 'street' || t === 'pond' || t === 'bridge' || t === 'chickenZone' || t === 'area')) {
+      } else if (vm !== 'building' && (t === 'street' || t === 'pond' || t === 'bridge' || t === 'chickenZone' || t === 'area' || t === 'building')) {
         rectDrawRef.current = { startTx: tx, startTy: ty, lastTx: tx, lastTy: ty }
         setRectPreviewRef.current({ sx: tx, sy: ty, ex: tx, ey: ty })
       } else if (t === 'spawn') {
@@ -314,6 +315,7 @@ export function MapEditorCanvas(props: Props) {
         else if (t === 'bridge')      propsRef.current.onAddBridgeTile(tx1, ty1, tx2, ty2)
         else if (t === 'chickenZone') propsRef.current.onAddChickenZone(tx1, ty1, tx2, ty2)
         else if (t === 'area')        propsRef.current.onAddArea(tx1, ty1, tx2, ty2)
+        else if (t === 'building')    propsRef.current.onAddBuilding(tx1, ty1, tx2, ty2)
         rectDrawRef.current = null
         setRectPreviewRef.current(null)
       }

--- a/web/src/components/mapEditor/MapEditorToolbar.tsx
+++ b/web/src/components/mapEditor/MapEditorToolbar.tsx
@@ -63,6 +63,7 @@ const TOOLS: { mode: ToolMode; label: string; title: string }[] = [
   { mode: 'spawn',       label: '⊕', title: 'Place Spawn Tile' },
   { mode: 'chickenZone', label: '⊛', title: 'Draw Chicken Zone' },
   { mode: 'area',        label: '□', title: 'Draw Area' },
+  { mode: 'building',    label: '🏛', title: 'Draw Building' },
 ]
 
 export function MapEditorToolbar({

--- a/web/src/components/mapEditor/mapEditorTypes.ts
+++ b/web/src/components/mapEditor/mapEditorTypes.ts
@@ -3,7 +3,7 @@ import type { WallMaterial, RoofMaterial } from '../../data/tiles/buildingMateri
 import type { NpcActivity } from '../../data/hub/loader'
 
 
-export type ToolMode = 'select' | 'place' | 'delete' | 'street' | 'pond' | 'bridge' | 'spawn' | 'chickenZone' | 'area'
+export type ToolMode = 'select' | 'place' | 'delete' | 'street' | 'pond' | 'bridge' | 'spawn' | 'chickenZone' | 'area' | 'building'
 export type Zlayer = 'solid' | 'below' | 'above'
 export type ViewMode = 'exterior' | 'interior' | 'building'
 
@@ -61,6 +61,7 @@ export interface RawBuilding {
   maxLevel?: number            // highest upgrade level this building can reach (defaults to its track length)
   levelDecor?: RawDecorItem[]  // per-building exterior decor revealed by upgrade level (each item carries minLevel)
   levelVisuals?: RawBuildingLevelVisual[]  // per-level footprint/wall/roof overrides
+  requiresOwnership?: boolean  // door stays locked until purchased (getUpgradeLevel >= 1) — e.g. a player house
 }
 
 export interface RawAnimal {
@@ -114,6 +115,7 @@ export interface RawInterior {
   wallTileId?: string
   wallMaterial?: string
   decor: RawDecorItem[]
+  playerDecor?: boolean  // render the player's placed furniture here at runtime (homeLayout.ts) — ships unfurnished
   hours?: { open: number; close: number } | 'always'
   musicId?: string
   ambianceId?: string

--- a/web/src/components/mapEditor/multiSelectHelpers.ts
+++ b/web/src/components/mapEditor/multiSelectHelpers.ts
@@ -27,6 +27,13 @@ export function nextAreaId(areas: { id: string }[]): string {
   return `area-${n}`
 }
 
+export function nextBuildingId(buildings: { id?: string }[]): string {
+  const ids = new Set(buildings.map(b => b.id))
+  let n = 1
+  while (ids.has(`building-${n}`)) n++
+  return `building-${n}`
+}
+
 export function convertStreetToPond(
   config: RawMapConfig, index: number,
 ): { config: RawMapConfig; pondIndex: number } | null {

--- a/web/src/components/mapEditor/useMapEditorState.ts
+++ b/web/src/components/mapEditor/useMapEditorState.ts
@@ -1,6 +1,6 @@
 import { useState, useCallback } from 'react'
 import type { RawMapConfig, RawNpc, RawAnimal, RawInterior, RawBuilding, RawDecorItem, RawLockedDoor, SelectedEntity, ToolMode, Zlayer, MapEditorState } from './mapEditorTypes'
-import { toggleInSelection, nextAreaId, convertStreetToPond as cSTP, convertPondToStreet as cPTS, applyDeleteEntities, applyBatchUpdateZlayer, applyBatchUpdateStreetPathType } from './multiSelectHelpers'
+import { toggleInSelection, nextAreaId, nextBuildingId, convertStreetToPond as cSTP, convertPondToStreet as cPTS, applyDeleteEntities, applyBatchUpdateZlayer, applyBatchUpdateStreetPathType } from './multiSelectHelpers'
 
 type InteriorExit = NonNullable<RawInterior['exits']>[number]
 import hubConfig from '../../data/hub/ravenwatch/config.json'
@@ -491,6 +491,36 @@ export function useMapEditorState(initialMapId: MapId = 'ravenwatch', initialFes
         ...s,
         configData: { ...prevConfig, areas },
         selectedEntities: [{ type: 'area' as const, index: newIndex }],
+        undoStack: [...s.undoStack, prevConfig].slice(-MAX_UNDO),
+        redoStack: [],
+        isDirty: true,
+      }
+    })
+  }, [])
+
+  // Creates a building + a matching (same-id) empty interior + a default south-wall
+  // door, all as one undo step. Same-id building/interior satisfies the id-prefix
+  // rule doEnterInterior relies on to resolve upgrade level (see docs/hubworld.md).
+  const addBuilding = useCallback((tx1: number, ty1: number, tx2: number, ty2: number) => {
+    setState(s => {
+      const prevConfig = s.configData
+      const id = nextBuildingId(prevConfig.buildings ?? [])
+      const rect: [number, number, number, number] = [tx1, ty1, tx2, ty2]
+      const doorRelTx = Math.floor((tx2 - tx1) / 2)
+      const newBuilding: RawBuilding = {
+        id, rect, wall: 'brick' as WallMaterial, roof: 'redSlateRoof' as RoofMaterial,
+        doors: [{ tx: doorRelTx, ty: 0 }],
+      }
+      const buildings = [...(prevConfig.buildings ?? []), newBuilding]
+      const width  = Math.max(4, tx2 - tx1 + 1)
+      const height = Math.max(4, ty2 - ty1 + 1)
+      const interior: RawInterior = { name: id, width, height, floorTileId: 'woodFloor', decor: [] }
+      const interiors = { ...(prevConfig.interiors ?? {}), [id]: interior }
+      const newIndex = buildings.length - 1
+      return {
+        ...s,
+        configData: { ...prevConfig, buildings, interiors },
+        selectedEntities: [{ type: 'building' as const, index: newIndex }],
         undoStack: [...s.undoStack, prevConfig].slice(-MAX_UNDO),
         redoStack: [],
         isDirty: true,
@@ -1470,6 +1500,7 @@ export function useMapEditorState(initialMapId: MapId = 'ravenwatch', initialFes
     addNpcSpawnTile,
     addChickenZone,
     addArea,
+    addBuilding,
     convertStreetToPond,
     convertPondToStreet,
     batchUpdateZlayer,


### PR DESCRIPTION
## Summary

This is the second of two PRs for player-owned houses (issue #1602). The first (mechanism: `requiresOwnership` + `playerDecor`) merged as part of #1927. This PR adds the map editor tooling to actually author buildings — including player houses — visually instead of hand-editing `config.json`.

- New **"Draw Building" (🏛)** tool mode, mirroring the existing rect-draw tools (street/pond/chickenZone/area). Dragging a rect on the exterior canvas creates a building, a matching **same-id** empty interior (required by the id-prefix rule that resolves upgrade levels — see `docs/hubworld.md` §10), and a default south-wall door, all as a single undo step.
- Building inspector gains a **"Requires Ownership"** checkbox (`requiresOwnership`).
- The "+ New room" interior-creation form gains a **"Player decor"** checkbox (`playerDecor`).
- Together with the already-shipped `playerHouse` upgrade track, this makes a fully editor-authored player house possible: draw a building → tick Requires Ownership → set Upgrade Kind to `playerHouse` → tick Player decor on its interior.
- `docs/hubworld.md` §13 (map editor coverage) documents the new tool and checkboxes.

## Files changed

- `web/src/components/mapEditor/mapEditorTypes.ts` — `'building'` tool mode; `requiresOwnership`/`playerDecor` fields on this file's own type set.
- `web/src/components/mapEditor/multiSelectHelpers.ts` — `nextBuildingId` helper (mirrors `nextAreaId`).
- `web/src/components/mapEditor/useMapEditorState.ts` — new `addBuilding` mutator (building + interior + door, one undo step).
- `web/src/components/mapEditor/MapEditorCanvas.tsx` — wires the `'building'` rect-draw tool.
- `web/src/components/mapEditor/MapEditorToolbar.tsx` — new toolbar button.
- `web/src/components/mapEditor/EntityInspector.tsx` — `requiresOwnership` + `playerDecor` checkboxes.
- `web/src/components/mapEditor/MapEditor.tsx` — wiring.
- `docs/hubworld.md` — documents the new tool.

## Test plan

- [x] `npm run build` — clean, no type errors.
- [x] `npm run test` — all relevant suites pass (63 tests across `reputation.test.ts`, `loader.test.ts`, `multiSelectHelpers.test.ts`, etc.); pre-existing unrelated browser-mode failure (`chrome-headless-shell` binary missing in this sandbox) untouched by this change.
- Live canvas-drag verification via Storybook's `MapEditor` → `Ravenwatch` story was attempted but hit known PixiJS-canvas interaction flakiness in headless automation (the same category of costly/unreliable browser verification flagged previously) — abandoned in favor of code-level confidence, since the new mutator is a direct composition of the already-proven `addArea`/`addInterior`/`placeBuildingDoor` patterns (identical undo/redo shape, identical relative-door-coordinate math).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01DJkZU7w3kDSwTph6ShXFCP)_