### PR TITLE
Crownhaven: add Curtain Call theatre stage-performance minigame

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -64,6 +64,7 @@ import { NodeMap }            from './components/campaign/NodeMap'
 import { HubWorld }           from './components/hub/HubWorld'
 import { HubWorldMap }        from './components/hub/HubWorldMap'
 import { CasinoScreen }       from './components/hub/CasinoScreen'
+import { TheatreScreen }      from './components/hub/TheatreScreen'
 import { PostBattleReward }   from './components/battle/PostBattleReward'
 import { ActComplete }        from './components/battle/ActComplete'
 import { RelicSelectScreen }  from './components/campaign/RelicSelectScreen'
@@ -251,6 +252,7 @@ type Screen =
   | 'hub-minigame'
   | 'hub-fishing'
   | 'casino'
+  | 'theatre'
   | 'worldmap'
   | 'location'
   | 'sceneryPreview'
@@ -3398,6 +3400,12 @@ export default function App() {
       {screen === 'hub-fishing' && (
         <OverlayScreen title="🎣 FISHING" onBack={() => setScreen('hubworld')}>
           <Fishing rewardMode="catch" onDone={() => setScreen('hubworld')} />
+        </OverlayScreen>
+      )}
+
+      {screen === 'theatre' && (
+        <OverlayScreen title="🎭 CROWN THEATRE" onBack={() => setScreen('hubworld')}>
+          <TheatreScreen onBack={() => setScreen('hubworld')} />
         </OverlayScreen>
       )}
 

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -152,6 +152,7 @@ const SCREEN_ENTER_LABEL: Record<string, string> = {
   tileflip:          'Play tile flip?',
   crystalcatch:      'Play crystal catch?',
   spinner:           'Give it a spin?',
+  theatre:           'Watch the performance?',
   'narrator:mira':    'Ask what she remembers?',
   'narrator:vask':    'Ask about her past?',
   'narrator:pilgrim': 'Listen to their words?',

--- a/web/src/components/hub/TheatreScreen.tsx
+++ b/web/src/components/hub/TheatreScreen.tsx
@@ -1,0 +1,184 @@
+// ─── Curtain Call — Crown Theatre stage performance ──────────────────────────
+// A marker sweeps back and forth across the stage; click CUE! to land it in
+// the highlighted zone. 5 acts, each a little faster and narrower than the
+// last. Grade per act: Miss / Good / Perfect. Free to play — rewards tickets.
+
+import React, { useEffect, useRef, useState } from 'react'
+import { playMinigameCorrect, playMinigameWrong } from '../../game/sound'
+import { addTickets } from '../../game/miniGames'
+import { incrementAchievementProgress, setAchievementProgress } from '../../game/achievements'
+
+interface Props {
+  onBack: () => void
+}
+
+type Grade = 'miss' | 'good' | 'perfect'
+
+const TOTAL_ACTS = 5
+const TICKETS: Record<Grade, number> = { miss: 0, good: 10, perfect: 20 }
+const GRADE_LABEL: Record<Grade, string> = { miss: 'MISS', good: 'GOOD', perfect: 'PERFECT!' }
+
+// Zone half-width (% of the 0-100 bar) shrinks each act; sweep period speeds up.
+function actZoneHalfWidth(act: number): number {
+  return 16 - act * 2 // act 0..4 -> 16..8
+}
+function actPeriodMs(act: number): number {
+  return 1600 - act * 150 // act 0..4 -> 1600..1000
+}
+
+function randomZoneCenter(halfWidth: number): number {
+  return halfWidth + 10 + Math.random() * (100 - 2 * (halfWidth + 10))
+}
+
+export function TheatreScreen({ onBack }: Props) {
+  const [phase, setPhase] = useState<'ready' | 'playing' | 'result'>('ready')
+  const [act, setAct] = useState(0)
+  const [markerPos, setMarkerPos] = useState(0)
+  const [zoneCenter, setZoneCenter] = useState(50)
+  const [grades, setGrades] = useState<Grade[]>([])
+  const [flash, setFlash] = useState<Grade | null>(null)
+
+  const startRef = useRef(0)
+  const rafRef = useRef<number | null>(null)
+  const actRef = useRef(0)
+  const zoneCenterRef = useRef(50)
+  const lockedRef = useRef(false)
+
+  const tickRef = useRef<() => void>(() => {})
+  useEffect(() => {
+    tickRef.current = () => {
+      const a = actRef.current
+      const period = actPeriodMs(a)
+      const elapsed = (Date.now() - startRef.current) % period
+      const t = elapsed / period // 0..1
+      // Triangle wave 0 -> 100 -> 0
+      const pos = t < 0.5 ? t * 2 * 100 : (1 - t) * 2 * 100
+      setMarkerPos(pos)
+      rafRef.current = requestAnimationFrame(() => tickRef.current())
+    }
+  })
+
+  useEffect(() => {
+    return () => { if (rafRef.current) cancelAnimationFrame(rafRef.current) }
+  }, [])
+
+  function startAct(actIndex: number) {
+    actRef.current = actIndex
+    const halfWidth = actZoneHalfWidth(actIndex)
+    const center = randomZoneCenter(halfWidth)
+    zoneCenterRef.current = center
+    setZoneCenter(center)
+    setAct(actIndex)
+    lockedRef.current = false
+    startRef.current = Date.now()
+    setPhase('playing')
+    if (rafRef.current) cancelAnimationFrame(rafRef.current)
+    rafRef.current = requestAnimationFrame(() => tickRef.current())
+  }
+
+  function startGame() {
+    setGrades([])
+    startAct(0)
+  }
+
+  function cue() {
+    if (phase !== 'playing' || lockedRef.current) return
+    lockedRef.current = true
+    if (rafRef.current) cancelAnimationFrame(rafRef.current)
+
+    const halfWidth = actZoneHalfWidth(actRef.current)
+    const dist = Math.abs(markerPos - zoneCenterRef.current)
+    let grade: Grade
+    if (dist > halfWidth) grade = 'miss'
+    else if (dist > halfWidth * 0.4) grade = 'good'
+    else grade = 'perfect'
+
+    if (grade === 'miss') playMinigameWrong()
+    else playMinigameCorrect()
+
+    setFlash(grade)
+    setGrades(prev => [...prev, grade])
+    setTimeout(() => {
+      setFlash(null)
+      const nextAct = actRef.current + 1
+      if (nextAct >= TOTAL_ACTS) {
+        finishShow([...grades, grade])
+      } else {
+        startAct(nextAct)
+      }
+    }, 700)
+  }
+
+  function finishShow(finalGrades: Grade[]) {
+    const total = finalGrades.reduce((sum, g) => sum + TICKETS[g], 0)
+    addTickets(total)
+    incrementAchievementProgress('miniGame:gamesPlayed')
+    incrementAchievementProgress('miniGame:ticketsEarned', total)
+    setAchievementProgress('miniGame:theatre:bestScore', total)
+    setPhase('result')
+  }
+
+  const total = grades.reduce((sum, g) => sum + TICKETS[g], 0)
+  const perfectCount = grades.filter(g => g === 'perfect').length
+
+  function applauseHeadline(): string {
+    if (perfectCount === TOTAL_ACTS) return '⭐ STANDING OVATION! ⭐'
+    if (total >= 70) return 'A rousing ovation!'
+    if (total >= 40) return 'Warm applause.'
+    if (total > 0) return 'Scattered, polite applause...'
+    return 'The crowd shuffles out in silence.'
+  }
+
+  const halfWidth = actZoneHalfWidth(act)
+
+  return (
+    <div className="minigame-screen theatre-screen">
+      <div className="minigame-title">🎭 CURTAIN CALL</div>
+
+      {phase === 'ready' && (
+        <div className="minigame-ready u-col u-items-c u-gap-5">
+          <p>Time your cue to land the marker in the golden zone.</p>
+          <p>5 acts — each faster and tighter than the last.</p>
+          <button className="action-btn action-btn--gold" onClick={startGame}>TAKE THE STAGE</button>
+        </div>
+      )}
+
+      {phase === 'playing' && (
+        <>
+          <div className="theatre-act-counter">Act {act + 1} / {TOTAL_ACTS}</div>
+
+          <div className="theatre-stage">
+            <div
+              className="theatre-zone"
+              style={{ left: `${zoneCenter - halfWidth}%`, width: `${halfWidth * 2}%` }}
+            />
+            <div className="theatre-marker" style={{ left: `${markerPos}%` }} />
+          </div>
+
+          {flash && (
+            <div className={`theatre-flash theatre-flash--${flash}`}>{GRADE_LABEL[flash]}</div>
+          )}
+
+          <button className="action-btn action-btn--gold theatre-cue-btn" onClick={cue} disabled={lockedRef.current}>
+            CUE!
+          </button>
+        </>
+      )}
+
+      {phase === 'result' && (
+        <div className="minigame-result-panel u-col u-items-c u-gap-5">
+          <div className="minigame-result-headline">{applauseHeadline()}</div>
+          <div className="minigame-result-breakdown">
+            {grades.map((g, i) => (
+              <div key={i}>Act {i + 1}: {GRADE_LABEL[g]} — +{TICKETS[g]} 🎫</div>
+            ))}
+            <div className="minigame-result-total">Total: {total} 🎫</div>
+          </div>
+          <button className="action-btn action-btn--gold" onClick={onBack}>
+            COLLECT &amp; EXIT
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/data/hub/capitalcity/config.json
+++ b/web/src/data/hub/capitalcity/config.json
@@ -5456,10 +5456,11 @@
       "sprite": "hub-npc-herald",
       "tx": 60,
       "ty": 43,
+      "screen": "theatre",
       "dialogue": [
-        "The Crown Theatre will dazzle the realm — once the stage is ready.",
-        "Rehearsals, ropes, and a thousand candles. Come back for the grand premiere!",
-        "A performance worthy of a coronation takes time. Patience, friend."
+        "Welcome, welcome! The Crown Theatre is open for its first performances!",
+        "Step onto the stage and time your cues — the crowd is a fickle judge.",
+        "Rehearsals, ropes, a thousand candles... and now, an audience!"
       ],
       "favoriteGiftItemId": "fancy-hat",
       "favoriteGiftTrack": "ally",

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -15368,6 +15368,65 @@ html.light-mode .action-btn {
   font-family: monospace;
 }
 
+/* ── Theatre / Curtain Call screen ─────────────────────────────────────── */
+.theatre-act-counter {
+  font-size: 13px;
+  color: #c8a8e8;
+  font-family: monospace;
+}
+
+.theatre-stage {
+  position: relative;
+  width: 100%;
+  max-width: 320px;
+  height: 28px;
+  background: rgba(255,255,255,0.06);
+  border: 1px solid rgba(255,255,255,0.15);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.theatre-zone {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  background: rgba(255,215,0,0.28);
+  border-left: 1px solid #ffd700;
+  border-right: 1px solid #ffd700;
+}
+
+.theatre-marker {
+  position: absolute;
+  top: -2px;
+  bottom: -2px;
+  width: 4px;
+  margin-left: -2px;
+  background: #ff5a5a;
+  box-shadow: 0 0 8px #ff5a5a;
+}
+
+.theatre-cue-btn {
+  min-width: 160px;
+  font-size: 15px;
+}
+
+.theatre-flash {
+  font-size: 16px;
+  font-family: monospace;
+  font-weight: bold;
+  animation: theatre-flash-pop 0.5s ease-out;
+}
+
+.theatre-flash--miss    { color: #ff6a6a; }
+.theatre-flash--good    { color: #88ddff; }
+.theatre-flash--perfect { color: #ffd700; text-shadow: 0 0 12px #ffd700; }
+
+@keyframes theatre-flash-pop {
+  0%   { opacity: 0; transform: scale(0.7); }
+  30%  { opacity: 1; transform: scale(1.15); }
+  100% { opacity: 1; transform: scale(1); }
+}
+
 /* ── Hub World Persistent HUD ──────────────────────────────────────────── */
 .hub-hud {
   position: absolute;


### PR DESCRIPTION
## Summary
- Adds a new **Curtain Call** stage-performance minigame for Crownhaven's Crown Theatre: a 5-act timing game where the player clicks CUE! to land a sweeping marker inside a shrinking golden zone, graded Miss/Good/Perfect per act, with a final applause headline and ticket reward.
- Wires the previously-placeholder `theatre-impresario` NPC (Impresario Vane) to the new screen via `"screen": "theatre"`, and replaces the "coming soon" dialogue with a proper intro leading into a "Watch the performance?" prompt.
- Registers `'theatre'` as a routable `Screen` in `App.tsx`, mounted through `OverlayScreen` following the existing `casino`/`hub-fishing` dedicated-screen pattern (no arcade ticket-cost gating — it's a free performance).

## Implementation notes
- `TheatreScreen.tsx` follows `CasinoScreen.tsx`'s self-contained reward-granting pattern (`addTickets` + achievement calls) and reuses the RAF tick-loop shape from `CrystalCatch.tsx`.
- No new `.stories.tsx` — following the `CasinoScreen.tsx` precedent for top-level stateful game screens.
- Closes #1752.

## Test plan
- [x] `npm run build` (typecheck + vite build) passes
- [x] `npm run test` — 420/420 tests pass (unrelated pre-existing Playwright browser-launch warning in the environment, not caused by this change)
- [ ] Manual click-through in a running game session (not done — reaching a specific hub NPC requires canvas pathfinding, which `AGENTS.md` flags as expensive verification reserved for visual/canvas bugs; this change is plain DOM logic, not canvas)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01R6WXv8WnCpWzuAxcULfuv7)_