### PR TITLE
Curtain Call: show performer avatar + audience reactions

### DIFF
--- a/web/src/components/hub/TheatreScreen.tsx
+++ b/web/src/components/hub/TheatreScreen.tsx
@@ -7,6 +7,7 @@ import React, { useEffect, useRef, useState } from 'react'
 import { playMinigameCorrect, playMinigameWrong } from '../../game/sound'
 import { addTickets } from '../../game/miniGames'
 import { incrementAchievementProgress, setAchievementProgress } from '../../game/achievements'
+import { loadPlayerAvatar } from '../../game/questline'
 
 interface Props {
   onBack: () => void
@@ -14,9 +15,20 @@ interface Props {
 
 type Grade = 'miss' | 'good' | 'perfect'
 
+interface Reaction {
+  id:    number
+  x:     number
+  y:     number
+  label: string
+}
+
 const TOTAL_ACTS = 5
 const TICKETS: Record<Grade, number> = { miss: 0, good: 10, perfect: 20 }
 const GRADE_LABEL: Record<Grade, string> = { miss: 'MISS', good: 'GOOD', perfect: 'PERFECT!' }
+const CHEER_EMOJI = ['👏', '👏', '🙌', '💐']
+const BOO_EMOJI   = ['👎', '🍅', '😒']
+
+let nextReactionId = 1
 
 // Zone half-width (% of the 0-100 bar) shrinks each act; sweep period speeds up.
 function actZoneHalfWidth(act: number): number {
@@ -31,12 +43,16 @@ function randomZoneCenter(halfWidth: number): number {
 }
 
 export function TheatreScreen({ onBack }: Props) {
+  const [avatarSlug] = useState(() => loadPlayerAvatar())
+  const avatarSrc = `${(import.meta as { env: { BASE_URL: string } }).env.BASE_URL}sprites/${avatarSlug}.svg`
+
   const [phase, setPhase] = useState<'ready' | 'playing' | 'result'>('ready')
   const [act, setAct] = useState(0)
   const [markerPos, setMarkerPos] = useState(0)
   const [zoneCenter, setZoneCenter] = useState(50)
   const [grades, setGrades] = useState<Grade[]>([])
   const [flash, setFlash] = useState<Grade | null>(null)
+  const [reactions, setReactions] = useState<Reaction[]>([])
 
   const startRef = useRef(0)
   const rafRef = useRef<number | null>(null)
@@ -81,6 +97,21 @@ export function TheatreScreen({ onBack }: Props) {
     startAct(0)
   }
 
+  function spawnReactions(kind: 'cheer' | 'boo', count: number, big = false) {
+    const pool = kind === 'cheer' ? CHEER_EMOJI : BOO_EMOJI
+    const batch: Reaction[] = Array.from({ length: count }, () => ({
+      id:    nextReactionId++,
+      x:     40 + Math.random() * 20,
+      y:     Math.random() * 20,
+      label: pool[Math.floor(Math.random() * pool.length)],
+    }))
+    setReactions(prev => [...prev, ...batch])
+    const ids = batch.map(r => r.id)
+    setTimeout(() => {
+      setReactions(prev => prev.filter(r => !ids.includes(r.id)))
+    }, big ? 1400 : 900)
+  }
+
   function cue() {
     if (phase !== 'playing' || lockedRef.current) return
     lockedRef.current = true
@@ -98,6 +129,8 @@ export function TheatreScreen({ onBack }: Props) {
 
     setFlash(grade)
     setGrades(prev => [...prev, grade])
+    if (grade === 'miss') spawnReactions('boo', 3)
+    else spawnReactions('cheer', grade === 'perfect' ? 4 : 3)
     setTimeout(() => {
       setFlash(null)
       const nextAct = actRef.current + 1
@@ -111,11 +144,15 @@ export function TheatreScreen({ onBack }: Props) {
 
   function finishShow(finalGrades: Grade[]) {
     const total = finalGrades.reduce((sum, g) => sum + TICKETS[g], 0)
+    const perfects = finalGrades.filter(g => g === 'perfect').length
     addTickets(total)
     incrementAchievementProgress('miniGame:gamesPlayed')
     incrementAchievementProgress('miniGame:ticketsEarned', total)
     setAchievementProgress('miniGame:theatre:bestScore', total)
     setPhase('result')
+    if (perfects === TOTAL_ACTS || total >= 40) spawnReactions('cheer', total >= 70 ? 8 : 5, true)
+    else if (total === 0) spawnReactions('boo', 6, true)
+    else spawnReactions('cheer', 3, true)
   }
 
   const total = grades.reduce((sum, g) => sum + TICKETS[g], 0)
@@ -134,6 +171,23 @@ export function TheatreScreen({ onBack }: Props) {
   return (
     <div className="minigame-screen theatre-screen">
       <div className="minigame-title">🎭 CURTAIN CALL</div>
+
+      {phase !== 'ready' && (
+        <div className="theatre-stage-wrap">
+          <div className="theatre-avatar-platform">
+            <img className="theatre-avatar-img" src={avatarSrc} alt="Your performer" />
+          </div>
+          {reactions.map(r => (
+            <div
+              key={r.id}
+              className="theatre-reaction-pop"
+              style={{ left: `${r.x}%`, top: `${r.y}%` }}
+            >
+              {r.label}
+            </div>
+          ))}
+        </div>
+      )}
 
       {phase === 'ready' && (
         <div className="minigame-ready u-col u-items-c u-gap-5">

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -15427,6 +15427,66 @@ html.light-mode .action-btn {
   100% { opacity: 1; transform: scale(1); }
 }
 
+.theatre-stage-wrap {
+  position: relative;
+  width: 100%;
+  max-width: 320px;
+  height: 96px;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+}
+
+.theatre-avatar-platform {
+  position: relative;
+  width: 72px;
+  height: 72px;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  padding-bottom: 6px;
+}
+
+.theatre-avatar-platform::before {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  width: 84px;
+  height: 84px;
+  transform: translateX(-50%);
+  background: radial-gradient(ellipse at center, rgba(255,215,0,0.28) 0%, rgba(255,215,0,0) 70%);
+  pointer-events: none;
+}
+
+.theatre-avatar-platform::after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  width: 60px;
+  height: 10px;
+  transform: translateX(-50%);
+  background: rgba(0,0,0,0.55);
+  border-radius: 50%;
+  filter: blur(1px);
+}
+
+.theatre-avatar-img {
+  position: relative;
+  width: 56px;
+  height: 56px;
+  z-index: 1;
+}
+
+.theatre-reaction-pop {
+  position: absolute;
+  font-size: 20px;
+  pointer-events: none;
+  animation: pop-float 0.9s ease-out forwards;
+  transform: translate(-50%, -50%);
+}
+
 /* ── Hub World Persistent HUD ──────────────────────────────────────────── */
 .hub-hud {
   position: absolute;


### PR DESCRIPTION
## Summary
Follow-up to #1752 / PR #1930 (the Curtain Call theatre minigame). The minigame worked but was visually bare — just a timing bar and a button, no sense of performing for a crowd.

- The player's own hub avatar (`loadPlayerAvatar()`, same lookup `CharacterScreen.tsx`/`CasinoScreen.tsx` already use) now stands on a small spotlit stage platform above the timing bar, visible throughout the `playing` and `result` phases.
- Each act's grade now spawns floating emoji reactions from the crowd — cheers (👏🙌💐) for Good/Perfect, boos (👎🍅😒) for Miss — using the same floating-particle pattern `CrystalCatch.tsx` already established (and reusing its existing `pop-float` keyframe rather than duplicating it).
- A bigger finale reaction burst plays on the result screen, keyed off the same score tiers the existing `applauseHeadline()` text already uses (standing ovation → big cheer burst, a shutout → boo burst, everything else → a modest cheer).

## Test plan
- [x] `npm run build` (typecheck + vite build) passes
- [x] `npm run test` — 420/420 tests pass (pre-existing unrelated Playwright browser-launch warning in this environment)
- [ ] Manual click-through not performed — this is plain DOM/CSS logic (no canvas), consistent with why the original Curtain Call PR (#1930) also skipped browser verification per `AGENTS.md`'s guidance to reserve that for visual/canvas bugs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01R6WXv8WnCpWzuAxcULfuv7)_