### PR TITLE
feat(hub): per-mini-game daily ticket challenge (#1667)

### DIFF
--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -46,7 +46,7 @@ import { getCollectedTreasureIds, markTreasureCollected } from '../../game/hub/t
 import { useHubClock } from '../../hooks/useHubClock'
 import { formatGameTime, hourInRange } from '../../game/hub/hubClock'
 import { getActiveFestival } from '../../game/hub/hubCalendar'
-import { getDailyChallengeNPCDialogue } from '../../game/hub/npcDialogue'
+import { getDailyChallengeNPCDialogue, getMiniGameChallengeNPCDialogue } from '../../game/hub/npcDialogue'
 import {  ALL_QUESTS, FRIENDSHIP_DIALOGUE, RELATIONSHIP_DIALOGUE, RAVENWATCH } from '../../data/hub/hubWorldFactory'
 import { HubInteractable, HubLocationBundle, HubQuestBundle, HubTreasure, HubNpc } from '../../data/hub/loader'
 import { getUnreadCount } from '../../game/news'
@@ -373,6 +373,25 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onEndless, onWorldMap
   const npcProximityDialogueRef = useRef(new Map<string, { atDistance: number; text: string }[]>())
   npcProximityDialogueRef.current = new Map([
     ['challenge-herald', getDailyChallengeNPCDialogue()],
+    // Arcade NPCs — exterior + interior pairs each announce that game's daily
+    // ticket-score challenge. 'fishing'/'regatta' have no dedicated hub NPC yet.
+    ['marble-master', getMiniGameChallengeNPCDialogue('marble')],
+    ['marble-master-int', getMiniGameChallengeNPCDialogue('marble')],
+    ['the-flipper', getMiniGameChallengeNPCDialogue('tileflip')],
+    ['the-flipper-int', getMiniGameChallengeNPCDialogue('tileflip')],
+    ['crystal-keeper', getMiniGameChallengeNPCDialogue('crystalcatch')],
+    ['crystal-keeper-int', getMiniGameChallengeNPCDialogue('crystalcatch')],
+    ['spinner-sal', getMiniGameChallengeNPCDialogue('spinner')],
+    ['spinner-sal-int', getMiniGameChallengeNPCDialogue('spinner')],
+    ['race-marshal', getMiniGameChallengeNPCDialogue('marblerace')],
+    ['race-marshal-int', getMiniGameChallengeNPCDialogue('marblerace')],
+    ['card-sharp', getMiniGameChallengeNPCDialogue('higherOrLower')],
+    ['card-sharp-int', getMiniGameChallengeNPCDialogue('higherOrLower')],
+    ['reels-remy', getMiniGameChallengeNPCDialogue('fruitMachine')],
+    ['reels-remy-int', getMiniGameChallengeNPCDialogue('fruitMachine')],
+    ['poker-pete', getMiniGameChallengeNPCDialogue('videoPoker')],
+    ['poker-pete-int', getMiniGameChallengeNPCDialogue('videoPoker')],
+    ['siege-master', getMiniGameChallengeNPCDialogue('towerDefence')],
   ])
 
   // Interactable indicator conditions (e.g. 'unread-news'): read imperatively by PixiJS ticker

--- a/web/src/components/screens/MiniGamesMenu.tsx
+++ b/web/src/components/screens/MiniGamesMenu.tsx
@@ -11,6 +11,7 @@ import {
   loadLocalHighScore, saveLocalHighScore,
   publishMiniGameScore, fetchMiniGameLeaderboard, MiniGameLeaderboardEntry,
 } from '../../game/miniGames'
+import { claimDailyChallengeIfEligible, DAILY_CHALLENGE_BONUS_TICKETS } from '../../game/miniGameDailyChallenge'
 import { loadCrystals, saveCrystals, addCardsToCollection, loadCollection, getOwnedCount } from '../../game/collection'
 import { getCardCatalog } from '../../game/cards'
 import { incrementAchievementProgress, setAchievementProgress } from '../../game/achievements'
@@ -109,6 +110,12 @@ export function MiniGamesMenu({ crystals, onCrystalsChange, user, characterName,
     if (ticketsEarned > 0) {
       addTickets(ticketsEarned)
       refreshTickets()
+    }
+
+    if (claimDailyChallengeIfEligible(gameId, ticketsEarned)) {
+      refreshTickets()
+      incrementAchievementProgress('miniGame:dailyChallengesCompleted')
+      showToast(`🎯 Daily Challenge complete! +${DAILY_CHALLENGE_BONUS_TICKETS} bonus tickets!`)
     }
 
     // Track achievements

--- a/web/src/game/achievements.ts
+++ b/web/src/game/achievements.ts
@@ -1822,6 +1822,16 @@ export const ACHIEVEMENT_DEFS: AchievementDef[] = [
     tier: 1,
   },
   {
+    id: 'miniGame:daily_challenge_1',
+    name: 'Challenger',
+    description: 'Beat an arcade mini game\'s daily ticket challenge.',
+    category: 'misc',
+    progressKey: 'miniGame:dailyChallengesCompleted',
+    target: 1,
+    reward: { type: 'crystals', crystals: 75 },
+    tier: 1,
+  },
+  {
     id: 'miniGame:marble_100',
     name: 'Marble Champion',
     description: 'Score 100 tickets in a single Marble Run session.',

--- a/web/src/game/hub/npcDialogue.ts
+++ b/web/src/game/hub/npcDialogue.ts
@@ -1,4 +1,6 @@
 import { getDailyChallengeState } from '../dailyChallenge'
+import { getDailyChallengeTarget, isDailyChallengeClaimed } from '../miniGameDailyChallenge'
+import type { MiniGameId } from '../miniGames'
 
 /** Returns proximity dialogue entries for the daily challenge herald NPC. */
 export function getDailyChallengeNPCDialogue(): { atDistance: number; text: string }[] {
@@ -11,5 +13,14 @@ export function getDailyChallengeNPCDialogue(): { atDistance: number; text: stri
   } else {
     text = 'Daily challenge awaits!'
   }
+  return [{ atDistance: 5, text }]
+}
+
+/** Returns proximity dialogue entries for an arcade mini-game's NPC, announcing
+ *  that game's daily ticket-score challenge. */
+export function getMiniGameChallengeNPCDialogue(gameId: MiniGameId): { atDistance: number; text: string }[] {
+  const text = isDailyChallengeClaimed(gameId)
+    ? "You already beat today's challenge — nice work!"
+    : `🎯 Today's challenge: beat ${getDailyChallengeTarget(gameId)} tickets for a bonus!`
   return [{ atDistance: 5, text }]
 }

--- a/web/src/game/miniGameDailyChallenge.ts
+++ b/web/src/game/miniGameDailyChallenge.ts
@@ -1,0 +1,87 @@
+// ─── Mini-Game Daily Challenges ────────────────────────────────────────────────
+//
+// Per-mini-game, date-seeded high-score target with a small one-time bonus reward.
+// Mirrors game/hub/bounties.ts's date-seeded-daily pattern, but reuses the
+// canonical seeded-RNG helpers from seededRandom.ts (this module has no React
+// dependency either, so there's no need for a local re-implementation).
+
+import { logError } from '../logger'
+import { hashStr, makeSeededRng } from './seededRandom'
+import { addTickets } from './itemStore'
+import { getTodayDate, type MiniGameId } from './miniGames'
+
+const KEY = 'jarv_minigame_daily_challenge'
+
+export const DAILY_CHALLENGE_BONUS_TICKETS = 25
+
+// Per-game target bounds, derived from each game's own reward ceiling (read from
+// its component) so a target sits in roughly the 55-75% band of what's possible —
+// reachable with a good run, not guaranteed on an average one.
+const MINI_GAME_CHALLENGE_RANGE: Record<MiniGameId, [number, number]> = {
+  marble:        [70, 110],
+  tileflip:      [45, 65],
+  crystalcatch:  [12, 25],
+  spinner:       [15, 20],
+  marblerace:    [20, 40],
+  higherOrLower: [35, 55],
+  fruitMachine:  [15, 30],
+  videoPoker:    [20, 40],
+  fishing:       [15, 35],
+  towerDefence:  [40, 80],
+  regatta:       [20, 40],
+}
+
+/** Today's ticket target to beat for a given mini-game, deterministic for the day. */
+export function getDailyChallengeTarget(gameId: MiniGameId, at?: Date): number {
+  const dateKey   = at ? at.toISOString().slice(0, 10) : getTodayDate()
+  const [min, max] = MINI_GAME_CHALLENGE_RANGE[gameId]
+  const rng = makeSeededRng(hashStr(`${dateKey}:${gameId}`))
+  return min + Math.round(rng() * (max - min))
+}
+
+interface DailyChallengeState {
+  date:    string
+  claimed: MiniGameId[]
+}
+
+function freshState(): DailyChallengeState {
+  return { date: getTodayDate(), claimed: [] }
+}
+
+function loadState(): DailyChallengeState {
+  try {
+    const raw = localStorage.getItem(KEY)
+    if (!raw) return freshState()
+    const parsed = JSON.parse(raw) as DailyChallengeState
+    if (parsed.date !== getTodayDate()) return freshState()
+    if (!Array.isArray(parsed.claimed)) parsed.claimed = []
+    return parsed
+  } catch {
+    return freshState()
+  }
+}
+
+function saveState(state: DailyChallengeState): void {
+  try {
+    localStorage.setItem(KEY, JSON.stringify(state))
+  } catch (e) {
+    logError('miniGameDailyChallenge saveState failed', { error: String(e) })
+  }
+}
+
+export function isDailyChallengeClaimed(gameId: MiniGameId): boolean {
+  return loadState().claimed.includes(gameId)
+}
+
+/** If `ticketsEarned` beats today's target and it hasn't been claimed yet today,
+ *  grants the bonus tickets and marks it claimed. Returns true if newly claimed. */
+export function claimDailyChallengeIfEligible(gameId: MiniGameId, ticketsEarned: number): boolean {
+  const state = loadState()
+  if (state.claimed.includes(gameId)) return false
+  if (ticketsEarned < getDailyChallengeTarget(gameId)) return false
+
+  state.claimed.push(gameId)
+  saveState(state)
+  addTickets(DAILY_CHALLENGE_BONUS_TICKETS)
+  return true
+}

--- a/web/src/game/miniGames.ts
+++ b/web/src/game/miniGames.ts
@@ -220,7 +220,7 @@ export interface MiniGameLeaderboardEntry {
   achievedAt:    Date
 }
 
-function getTodayDate(): string {
+export function getTodayDate(): string {
   return new Date().toISOString().slice(0, 10)
 }
 


### PR DESCRIPTION
- miniGameDailyChallenge.ts: date-seeded per-game ticket target (reuses seededRandom.ts) + once-per-day claim state; beating the target grants a 25-ticket bonus via the existing addTickets() flow
- npcDialogue.ts: getMiniGameChallengeNPCDialogue() announces/confirms the challenge as arcade NPC proximity speech, mirroring the existing challenge-herald pattern
- HubWorld.tsx: wire each arcade NPC (marble/tileflip/crystalcatch/spinner/ marblerace/higherOrLower/fruitMachine/videoPoker/towerDefence, exterior + interior) into the proximity dialogue map
- MiniGamesMenu.tsx: check/claim the challenge in handleGameDone, the shared completion handler for both the title-screen and hub-world arcade entries
- achievements.ts: new miniGame:daily_challenge_1 achievement