### PR TITLE
Add Card Draft Mode via hub NPCs (#881)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5,7 +5,7 @@ import { recordScreen } from './utils/crashSentinel'
 import { useStartupData } from './hooks/useStartupData'
 import { useCloudSync } from './hooks/useCloudSync'
 import { useRegisterSW } from 'virtual:pwa-register/react'
-import { GameState, Card, StanceRules, Archetype } from './game/types'
+import { GameState, Card, StanceRules, Archetype, SECRET_RARITIES } from './game/types'
 import { newGame, MAX_HANDICAP } from './game/engine'
 import { playCard, playAoeCard } from './game/engine/cards'
 import { makeNodeDeck } from './game/cards'
@@ -57,6 +57,7 @@ import { Battlefield }        from './components/battle/Battlefield'
 import { GameOver }           from './components/battle/GameOver'
 import { TitleScreen }        from './components/title/TitleScreen'
 import { QuickBattleMode, QuickBattleScreen }  from './components/screens/QuickBattleScreen'
+import { CardDraftScreen }    from './components/screens/CardDraftScreen'
 import { CollectionScreen }   from './components/screens/CollectionScreen'
 import { DeckBuilder }        from './components/cards/DeckBuilder'
 import { PackOpening }        from './components/cards/PackOpening'
@@ -238,6 +239,7 @@ type Screen =
   | 'minigames'
   | 'playerstats'
   | 'quickbattle'
+  | 'carddraft'
   | 'statupgrade'
   | 'camp'
   | 'codex'
@@ -440,6 +442,7 @@ export default function App() {
   const isDailyChallengeRef = useRef(false)                  // true while playing the daily challenge
   const isWeeklyChallengeRef = useRef(false)                 // true while playing the weekly challenge
   const isTrainingModeRef   = useRef(false)                  // true while playing a training battle
+  const isDraftModeRef      = useRef(false)                  // true while playing a Card Draft battle
    const quickBattleModeRef = useRef<QuickBattleMode>('easy')                //  Quick Battle Mode
   const worldBattleNodeIdRef = useRef<string | null>(null)
 
@@ -824,6 +827,24 @@ export default function App() {
     }
   }, [launchQuickBattle])
 
+  const handleDraftComplete = useCallback((pickedCardNames: string[]) => {
+    isCampaignRef.current = false
+    isDailyChallengeRef.current = false
+    isWeeklyChallengeRef.current = false
+    isDraftModeRef.current = true
+    quickBattleModeRef.current = 'draft'
+    battleFlawlessRef.current = true
+    battleUsedStructure.current = false
+    battleUsedMobileUnit.current = false
+    prevOpponentUnitsRef.current = new Map()
+    prevPlayerUnitsRef.current = new Map()
+    const draftedCards = makeNodeDeck(pickedCardNames.flatMap(name => [name, name, name]))
+    const opponentCardPool = getCardCatalog().filter(c => !SECRET_RARITIES.has(c.rarity))
+    battleAllLegendaryRef.current = draftedCards.length > 0 && draftedCards.every(c => c.rarity === 'legendary')
+    startBattle(newGame({ playerCards: draftedCards, opponentHandicap: handicap, opponentCardPool }))
+    rollRareEvent()
+  }, [handicap])
+
   const launchEndless = useCallback(() => {
     clearBattleState()
     isCampaignRef.current = false
@@ -957,6 +978,13 @@ export default function App() {
       isTrainingModeRef.current = false
       dispatch({ type: 'END' })
       setScreen('training')
+      return
+    }
+    // Card Draft: send back to the draft screen for a fresh draft (no persisted deck to replay)
+    if (isDraftModeRef.current) {
+      isDraftModeRef.current = false
+      dispatch({ type: 'END' })
+      setScreen('carddraft')
       return
     }
     isCampaignRef.current       = false
@@ -2481,6 +2509,7 @@ export default function App() {
         break
       case 'normal':
       case 'mirror':
+      case 'draft':
         pack = generatePack()
         break
       case 'unlimited':
@@ -2568,6 +2597,7 @@ export default function App() {
     isCampaignRef.current = false
     isDailyChallengeRef.current = false
     isWeeklyChallengeRef.current = false
+    isDraftModeRef.current = false
     const currentRun = run
 
     const isLoss = gameState?.phase.type === 'gameOver' && gameState.phase.winner !== 'player'
@@ -3313,6 +3343,10 @@ export default function App() {
 
       {screen === 'quickbattle' && (
         <QuickBattleScreen onStartBattle={handlePlay} onBack={() => setScreen(returnScreen)} />
+      )}
+
+      {screen === 'carddraft' && (
+        <CardDraftScreen onComplete={handleDraftComplete} onBack={() => setScreen(returnScreen)} />
       )}
 
       {screen === 'dailychallenge' && (

--- a/web/src/components/screens/CardDraftScreen.stories.tsx
+++ b/web/src/components/screens/CardDraftScreen.stories.tsx
@@ -1,0 +1,20 @@
+import { fn } from 'storybook/test';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { CardDraftScreen } from './CardDraftScreen';
+
+const meta = {
+  component: CardDraftScreen,
+  parameters: { layout: 'fullscreen' },
+} satisfies Meta<typeof CardDraftScreen>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    onComplete: fn(),
+    onBack: fn(),
+  },
+};

--- a/web/src/components/screens/CardDraftScreen.tsx
+++ b/web/src/components/screens/CardDraftScreen.tsx
@@ -1,0 +1,55 @@
+import React, { useMemo, useState } from 'react'
+import { CardTile } from '../cards/CardTile'
+import { getCardCatalog } from '../../game/cards'
+import { SECRET_RARITIES } from '../../game/types'
+
+const ROUNDS = 8
+const CHOICES_PER_ROUND = 3
+
+function pickRoundOffer(): string[] {
+  const pool = getCardCatalog().filter(c => !SECRET_RARITIES.has(c.rarity))
+  const shuffled = [...pool].sort(() => Math.random() - 0.5)
+  return shuffled.slice(0, CHOICES_PER_ROUND).map(c => c.name)
+}
+
+interface Props {
+  onComplete: (pickedCardNames: string[]) => void
+  onBack: () => void
+}
+
+export function CardDraftScreen({ onComplete, onBack }: Props) {
+  const [round, setRound] = useState(0)
+  const [picks, setPicks] = useState<string[]>([])
+  const offer = useMemo(pickRoundOffer, [round])
+  const catalog = useMemo(getCardCatalog, [])
+  const cards = offer.map(name => catalog.find(c => c.name === name)).filter(Boolean) as ReturnType<typeof getCardCatalog>
+
+  function handlePick(cardName: string) {
+    const nextPicks = [...picks, cardName]
+    if (round + 1 >= ROUNDS) {
+      onComplete(nextPicks)
+    } else {
+      setPicks(nextPicks)
+      setRound(round + 1)
+    }
+  }
+
+  return (
+    <div className="qb-screen">
+      <div className="qb-header u-text-c">
+        <div className="qb-title">🃏  CARD DRAFT</div>
+        <div className="qb-subtitle">Pick 1 of 3 cards — round {round + 1}/{ROUNDS}</div>
+      </div>
+
+      <div className="u-flex u-gap-7 u-just-c u-wrap">
+        {cards.map(card => (
+          <CardTile key={card.id} card={card} canAfford={true} onClick={() => handlePick(card.name)} />
+        ))}
+      </div>
+
+      {round === 0 && (
+        <button className="action-btn action-btn--danger" onClick={onBack}>← BACK</button>
+      )}
+    </div>
+  )
+}

--- a/web/src/data/hub/capitalcity/config.json
+++ b/web/src/data/hub/capitalcity/config.json
@@ -5433,6 +5433,24 @@
       ]
     },
     {
+      "id": "draft-master-crownhaven",
+      "name": "Draft Master Wren",
+      "sprite": "hub-npc-arena",
+      "tx": 83,
+      "ty": 81,
+      "screen": "carddraft",
+      "dialogue": [
+        "No collection? No problem. Draft a deck right here and prove your mettle.",
+        "Pick your cards, traveller — eight choices shape a whole army.",
+        "Every draft is a new deck. Every deck is a new war."
+      ],
+      "favoriteGiftItemId": "sturdy-boots",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "lost-locket"
+      ]
+    },
+    {
       "id": "riverside-angler",
       "name": "Angler Marsh",
       "sprite": "hub-npc-fisherman",

--- a/web/src/data/hub/ravenwatch/config.json
+++ b/web/src/data/hub/ravenwatch/config.json
@@ -8573,6 +8573,24 @@
       ]
     },
     {
+      "id": "draft-master-ravenwatch",
+      "name": "Draft Master Corrin",
+      "sprite": "hub-npc-arena",
+      "tx": 37,
+      "ty": 21,
+      "screen": "carddraft",
+      "dialogue": [
+        "No collection? No problem. Draft a deck right here and prove your mettle.",
+        "Pick your cards, Commander — eight choices shape a whole army.",
+        "Every draft is a new deck. Every deck is a new war."
+      ],
+      "favoriteGiftItemId": "sturdy-boots",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "lost-locket"
+      ]
+    },
+    {
       "id": "minigames-npc",
       "name": "Minigame Host",
       "sprite": "hub-npc-merchant",

--- a/web/src/game/campaignHelpers.ts
+++ b/web/src/game/campaignHelpers.ts
@@ -17,6 +17,7 @@ export type QuickBattleMode =
   | 'easy' | 'normal' | 'mirror' | 'unlimited' | 'chaos'
   | 'only-units' | 'only-spells' | 'only-buildings'
   | 'common-only' | 'uncommon-only' | 'rare-only' | 'legendary-only' | 'hero-only'
+  | 'draft'
 
 export function loadCurrentDeckInfo(): { playerCards: Card[]; deckBonus: number } {
   const collection  = loadCollection()


### PR DESCRIPTION
Closes #881.

## Summary

New game mode where the player drafts a 24-card deck (pick 1 of 3 offered cards, 8 times) instead of using their collection, then battles with it in a standard quick battle. No collection required, so it's accessible to new players. Per feedback during planning, this is **not** a title-screen mode — it's entered through the hub world via a new "Draft Master" NPC.

- `game/campaignHelpers.ts`: added `'draft'` to `QuickBattleMode` so the existing mode-keyed machinery (achievements, `GameOver` UI, reward-pack logic) picks it up for free.
- `components/screens/CardDraftScreen.tsx` (+ story): new self-contained pre-battle picker — 8 rounds, 3 random non-secret-rarity cards per round, reuses `CardTile` for rendering.
- `App.tsx`: new `'carddraft'` screen, `isDraftModeRef` (mirrors `isTrainingModeRef`), `handleDraftComplete` builds a 24-card `Card[]` via `makeNodeDeck` (3 copies per pick) and launches a battle directly with it — bypassing the collection/deck in `localStorage` entirely. Reward pack wired into `handleOpenPack`; "Play Again" sends drafters back to a fresh draft instead of incorrectly rebuilding from a (nonexistent) collection deck.
- `data/hub/ravenwatch/config.json` / `data/hub/capitalcity/config.json`: added a "Draft Master" NPC to each town (Ravenwatch and Crownhaven), following the existing `quickbattle-gate`/`guard-arena-master` pattern (exterior NPC, `hub-npc-arena` sprite, `"screen": "carddraft"`) — no changes to `HubWorld.tsx` routing needed, since NPC → full-screen navigation is already generic.

## Test plan
- [x] `npm run build` (typecheck + Vite build) passes clean
- [x] `npm run test` — all 420 existing tests pass
- [x] Verified both edited hub-world JSON configs parse and their new NPC tiles are free, walkable street tiles (checked against `streets` rects and existing NPC/decor coordinates)
- [x] Drove the new `CardDraftScreen` component headlessly via Storybook/Playwright: confirmed all 8 rounds render 3 distinct cards, round counter advances 1/8 → 8/8, picks register, and `onComplete` fires cleanly with no console errors


---
_Generated by [Claude Code](https://claude.ai/code/session_01238Cj1A3nnxFa45TXqyR72)_