### PR TITLE
Map editor: toggleable overlays, multi-tile pickups, NPC schedule preview & editing

### DIFF
--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -246,6 +246,8 @@ export function HubTownCanvas({
 
     // Keyed by pickupId; used to imperatively show/hide sprites when items are collected
     const pickupSprites  = new Map<string, PIXI.Sprite>()
+    // Supplementary visual-only tiles (pickup.extraTiles) — hidden/shown together with the primary sprite above.
+    const pickupExtraSprites = new Map<string, PIXI.Sprite[]>()
     const pickupQuestIds = new Map<string, string>()  // pickupId → questId, for ticker gating
 
     // Night-glow sources flagged on decor / quest items (carved by the night overlay).
@@ -344,7 +346,7 @@ export function HubTownCanvas({
         rect: [number, number, number, number],
         wall: WallMaterial,
         roof: RoofMaterial,
-        doors: { tx: number; ty: number }[],
+        doors: { tx: number; ty: number; hideSprite?: boolean }[],
         track: { buildingId: string; minLevel: number; nextLevel: number } | null,
         initiallyVisible: boolean,
       ) => {
@@ -379,7 +381,7 @@ export function HubTownCanvas({
         // Pass every door; placeBuildingTiles matches them to a footprint by
         // position (south edge), mirroring the original renderer — door buildingId
         // does not always equal the building's id, so we must not filter by id.
-        const doors = HUB_DOORS.map(d => ({ tx: d.tx, ty: d.ty }))
+        const doors = HUB_DOORS.map(d => ({ tx: d.tx, ty: d.ty, hideSprite: d.hideSprite }))
 
         // Distinct visual thresholds: base (0) plus each levelVisuals minLevel.
         const thresholds = [0, ...((building.levelVisuals ?? []).map(v => v.minLevel))]
@@ -984,10 +986,11 @@ export function HubTownCanvas({
             // Skip already-collected items; also skip chain items whose prerequisite isn't done
             if (pickedUpRef.current.has(pickup.id)) continue
             if (pickup.chain && !pickedUpRef.current.has(pickup.chain)) continue
+            const initiallyVisible = !pickup.questId || (activeQuestIdsRef?.current.has(pickup.questId) ?? true)
             const s = new PIXI.Sprite(tex)
             s.position.set(pickup.tx * T, pickup.ty * T)
             s.width = T; s.height = T
-            s.visible = !pickup.questId || (activeQuestIdsRef?.current.has(pickup.questId) ?? true)
+            s.visible = initiallyVisible
             if (pickup.questId) pickupQuestIds.set(pickup.id, pickup.questId)
             if (!pickup.requireTouch) {
               s.eventMode = 'static'
@@ -995,11 +998,15 @@ export function HubTownCanvas({
               s.on('pointerdown', (e: PIXI.FederatedPointerEvent) => {
                 e.stopPropagation()
                 s.visible = false
+                for (const extra of pickupExtraSprites.get(pickup.id) ?? []) extra.visible = false
                 pickedUpRef.current.add(pickup.id)
                 // Reveal any chained item now that this one is collected
                 for (const [pid, sprite] of pickupSprites) {
                   const def = HUB_PICKUP_ITEMS.find(p => p.id === pid)
-                  if (def?.chain === pickup.id) sprite.visible = true
+                  if (def?.chain === pickup.id) {
+                    sprite.visible = true
+                    for (const extra of pickupExtraSprites.get(pid) ?? []) extra.visible = true
+                  }
                 }
                 onItemPickupRef.current?.(pickup.id, pickup.questId)
               })
@@ -1007,6 +1014,19 @@ export function HubTownCanvas({
             pickupLayer.addChild(s)
             pickupSprites.set(pickup.id, s)
             if (pickup.glow) pickupGlows.push({ id: pickup.id, radius: (pickup.glowRadius ?? 2) * T, pulse: !!pickup.pulse })
+            for (const extra of pickup.extraTiles ?? []) {
+              loadTileRef(extra.tileId).then(extraTex => {
+                if (app.renderer == null) return
+                const es = new PIXI.Sprite(extraTex)
+                es.position.set((pickup.tx + extra.dx) * T, (pickup.ty + extra.dy) * T)
+                es.width = T; es.height = T
+                es.visible = initiallyVisible && !pickedUpRef.current.has(pickup.id)
+                pickupLayer.addChild(es)
+                const list = pickupExtraSprites.get(pickup.id) ?? []
+                list.push(es)
+                pickupExtraSprites.set(pickup.id, list)
+              }).catch(() => {})
+            }
           }
         }).catch(() => {})
       }
@@ -1874,10 +1894,11 @@ export function HubTownCanvas({
             for (const pickup of pickups) {
               if (pickedUpRef.current.has(pickup.id)) continue
               if (pickup.chain && !pickedUpRef.current.has(pickup.chain)) continue
+              const initiallyVisible = !pickup.questId || (activeQuestIdsRef?.current.has(pickup.questId) ?? true)
               const s = new PIXI.Sprite(tex)
               s.position.set(pickup.tx * T, pickup.ty * T)
               s.width = T; s.height = T
-              s.visible = !pickup.questId || (activeQuestIdsRef?.current.has(pickup.questId) ?? true)
+              s.visible = initiallyVisible
               if (pickup.questId) pickupQuestIds.set(pickup.id, pickup.questId)
               if (!pickup.requireTouch) {
                 s.eventMode = 'static'
@@ -1885,17 +1906,34 @@ export function HubTownCanvas({
                 s.on('pointerdown', (e: PIXI.FederatedPointerEvent) => {
                   e.stopPropagation()
                   s.visible = false
+                  for (const extra of pickupExtraSprites.get(pickup.id) ?? []) extra.visible = false
                   pickedUpRef.current.add(pickup.id)
                   // Reveal chained exterior pickups if applicable
                   for (const [pid, sprite] of pickupSprites) {
                     const def = HUB_PICKUP_ITEMS.find(p => p.id === pid)
-                    if (def?.chain === pickup.id) sprite.visible = true
+                    if (def?.chain === pickup.id) {
+                      sprite.visible = true
+                      for (const extra of pickupExtraSprites.get(pid) ?? []) extra.visible = true
+                    }
                   }
                   onItemPickupRef.current?.(pickup.id, pickup.questId)
                 })
               }
               decorBelowContainer.addChild(s)
               pickupSprites.set(pickup.id, s)
+              for (const extra of pickup.extraTiles ?? []) {
+                loadTileRef(extra.tileId).then(extraTex => {
+                  if (!interiorActive || currentInteriorId !== buildingId) return
+                  const es = new PIXI.Sprite(extraTex)
+                  es.position.set((pickup.tx + extra.dx) * T, (pickup.ty + extra.dy) * T)
+                  es.width = T; es.height = T
+                  es.visible = initiallyVisible && !pickedUpRef.current.has(pickup.id)
+                  decorBelowContainer.addChild(es)
+                  const list = pickupExtraSprites.get(pickup.id) ?? []
+                  list.push(es)
+                  pickupExtraSprites.set(pickup.id, list)
+                }).catch(() => {})
+              }
             }
           }).catch(() => {})
         }

--- a/web/src/components/mapEditor/EntityInspector.tsx
+++ b/web/src/components/mapEditor/EntityInspector.tsx
@@ -514,11 +514,14 @@ function DecorInspector({
 }
 
 function NpcInspector({
-  npc, entity, buildingIds, onMove, onDelete, onDialogueChange, onUpdate, onPickLocation,
+  npc, entity, buildingIds, interiorIds, onMove, onDelete, onDialogueChange, onUpdate, onPickLocation,
 }: {
   npc: RawNpc
   entity: SelectedEntity & { type: 'npc' }
   buildingIds: string[]
+  /** Interior room ids (configData.interiors keys) — distinct from building ids:
+   *  multi-room buildings have extra rooms whose id differs from the building's own id. */
+  interiorIds: string[]
   onMove: (tx: number, ty: number) => void
   onDelete: () => void
   onDialogueChange: (d: string[]) => void
@@ -568,7 +571,7 @@ function NpcInspector({
         />
         <div style={{ color: '#666', fontSize: 10, marginTop: 2 }}>Opens a screen/modal (e.g. 'adopt-pet') via a dialogue choice, in addition to dialogue.</div>
       </Field>
-      <NpcScheduleEditor npc={npc} buildingIds={buildingIds} onUpdate={onUpdate} />
+      <NpcScheduleEditor npc={npc} interiorIds={interiorIds} onUpdate={onUpdate} />
       <Field label="Min Building Level">
         <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
           <input
@@ -632,10 +635,10 @@ const NPC_ACTIVITIES: NpcActivity[] = ['work', 'eat', 'idle-chat', 'sleep', 'swe
 type NpcScheduleEntry = NonNullable<RawNpc['schedule']>[number]
 
 function NpcScheduleEditor({
-  npc, buildingIds, onUpdate,
+  npc, interiorIds, onUpdate,
 }: {
   npc: RawNpc
-  buildingIds: string[]
+  interiorIds: string[]
   onUpdate: (partial: Partial<RawNpc>) => void
 }) {
   const inp: React.CSSProperties = {
@@ -678,7 +681,7 @@ function NpcScheduleEditor({
                   updateEntry(i, {
                     location: type === 'exterior'
                       ? { type: 'exterior', tx: entry.location.tx, ty: entry.location.ty }
-                      : { type: 'interior', buildingId: buildingIds[0] ?? '', tx: entry.location.tx, ty: entry.location.ty },
+                      : { type: 'interior', buildingId: interiorIds[0] ?? '', tx: entry.location.tx, ty: entry.location.ty },
                   })
                 }}
               >
@@ -691,7 +694,10 @@ function NpcScheduleEditor({
                   style={{ ...inp, flex: 1 }}
                   onChange={e => updateEntry(i, { location: { ...entry.location, type: 'interior', buildingId: e.target.value } as NpcScheduleEntry['location'] })}
                 >
-                  {buildingIds.map(id => <option key={id} value={id}>{id}</option>)}
+                  {!interiorIds.includes(entry.location.buildingId) && entry.location.buildingId && (
+                    <option value={entry.location.buildingId}>{entry.location.buildingId} (unknown room)</option>
+                  )}
+                  {interiorIds.map(id => <option key={id} value={id}>{id}</option>)}
                 </select>
               )}
               <label style={{ fontSize: 10, color: '#888' }}>X</label>
@@ -3061,6 +3067,7 @@ export function EntityInspector({
             npc={npc}
             entity={selectedEntity}
             buildingIds={(configData.buildings ?? []).map(b => b.id).filter((id): id is string => !!id)}
+            interiorIds={Object.keys(configData.interiors ?? {})}
             onMove={(tx, ty) => onMoveEntity(selectedEntity, tx, ty)}
             onDelete={() => onDelete(selectedEntity)}
             onDialogueChange={d => onDialogueChange(selectedEntity.index, d)}

--- a/web/src/components/mapEditor/EntityInspector.tsx
+++ b/web/src/components/mapEditor/EntityInspector.tsx
@@ -14,6 +14,9 @@ import type { AnimalType } from '../../game/hub/animals'
 import { BUILDING_MUSIC_IDS, AMBIANCE_IDS } from '../../game/sound'
 import { getUpgradeTrack, UPGRADE_CATALOG } from '../../data/hub/buildingUpgrades'
 import type { BundleTileRaw } from '../../data/bundles/bundleEditorApi'
+import type { NpcActivity } from '../../data/hub/loader'
+
+type ReorderDirection = 'forward' | 'back' | 'toFront' | 'toBack'
 
 /** Swap two elements' positions, returning a new array. */
 function swap<T>(arr: T[], i: number, j: number): T[] {
@@ -83,6 +86,7 @@ interface Props {
   onZlayerChange:        (entity: SelectedEntity, z: Zlayer) => void
   onUpdateGlow?:         (entity: SelectedEntity, patch: GlowPatch) => void
   onUpdatePickupGlow?:   (index: number, patch: GlowPatch) => void
+  onUpdatePickupExtraTiles?: (index: number, tiles: Array<{ dx: number; dy: number; tileId: string }>) => void
   onDialogueChange:      (index: number, dialogue: string[]) => void
   onOpenInterior:        (id: string) => void
   onCloseInterior:       () => void
@@ -123,7 +127,7 @@ interface Props {
   onBatchUpdateStreetPathType?: (entities: SelectedEntity[], pathType: string | undefined) => void
   onSaveAsBundle?:              (bundleId: string, tiles: BundleTileRaw[]) => Promise<void>
   onUpdateDecorTileId?:         (entity: SelectedEntity, tileId: string) => void
-  onReorderDecor?:              (entity: SelectedEntity, direction: 'forward' | 'back') => void
+  onReorderDecor?:              (entity: SelectedEntity, direction: ReorderDirection) => void
   onConvertDecorToInteractable?: (entity: SelectedEntity) => void
   onConvertStreetToPond?:       (index: number) => void
   onConvertPondToStreet?:       (index: number) => void
@@ -343,7 +347,7 @@ function GlowControls({ glow, glowRadius, pulse, onChange }: {
 }
 
 function DecorInspector({
-  item, entity, onMove, onZlayer, onGlow, onDelete, onMinLevel, onHideAtLevel, maxLevel, onTileChange, onReorder, onConvertToInteractable,
+  item, entity, onMove, onZlayer, onGlow, onDelete, onMinLevel, onHideAtLevel, maxLevel, onTileChange, onReorder, listLength, onConvertToInteractable,
 }: {
   item: RawDecorItem
   entity: SelectedEntity
@@ -355,7 +359,9 @@ function DecorInspector({
   onHideAtLevel?: (hideAtLevel: number | undefined) => void
   maxLevel?: number
   onTileChange?: (tileId: string) => void
-  onReorder?: (direction: 'forward' | 'back') => void
+  onReorder?: (direction: ReorderDirection) => void
+  /** Length of the decor array this item lives in — used to show its z-order position. */
+  listLength?: number
   onConvertToInteractable?: () => void
 }) {
   const [pickingTile, setPickingTile] = useState(false)
@@ -442,20 +448,42 @@ function DecorInspector({
       {onGlow && <GlowControls glow={item.glow} glowRadius={item.glowRadius} pulse={item.pulse} onChange={onGlow} />}
       {onReorder && (
         <Field label="Draw Order">
-          <div style={{ display: 'flex', gap: 4 }}>
+          {listLength != null && (
+            <div style={{ fontSize: 11, color: '#aaa', marginBottom: 4 }}>
+              Layer <span style={{ color: '#f0c040', fontFamily: 'monospace' }}>{entity.index + 1}</span> of {listLength}
+              {' '}({entity.index === 0 ? 'back-most' : entity.index === listLength - 1 ? 'front-most' : 'middle'})
+            </div>
+          )}
+          <div style={{ display: 'flex', gap: 4, marginBottom: 4 }}>
             <button
               onClick={() => onReorder('back')}
-              title="Draw behind (move earlier in list)"
+              title="Draw behind (move one step earlier)"
               style={{ flex: 1, padding: '4px 0', background: '#1e2a1e', border: '1px solid #3a5a3a', color: '#8d8', borderRadius: 3, fontSize: 11, cursor: 'pointer' }}
             >
               ↓ Send Back
             </button>
             <button
               onClick={() => onReorder('forward')}
-              title="Draw in front (move later in list)"
+              title="Draw in front (move one step later)"
               style={{ flex: 1, padding: '4px 0', background: '#1e2a4e', border: '1px solid #3a5a8e', color: '#8af', borderRadius: 3, fontSize: 11, cursor: 'pointer' }}
             >
               ↑ Bring Forward
+            </button>
+          </div>
+          <div style={{ display: 'flex', gap: 4 }}>
+            <button
+              onClick={() => onReorder('toBack')}
+              title="Push to the very back (lowest layer)"
+              style={{ flex: 1, padding: '4px 0', background: '#141e14', border: '1px solid #2a3a2a', color: '#6a6', borderRadius: 3, fontSize: 10, cursor: 'pointer' }}
+            >
+              ⇊ Push to Back
+            </button>
+            <button
+              onClick={() => onReorder('toFront')}
+              title="Bring to the very front (highest layer)"
+              style={{ flex: 1, padding: '4px 0', background: '#141e30', border: '1px solid #2a3a5a', color: '#69c', borderRadius: 3, fontSize: 10, cursor: 'pointer' }}
+            >
+              ⇈ Bring to Front
             </button>
           </div>
         </Field>
@@ -530,6 +558,17 @@ function NpcInspector({
         />
         <div style={{ color: '#666', fontSize: 10, marginTop: 2 }}>One line = one dialogue entry</div>
       </Field>
+      <Field label="Screen">
+        <input
+          type="text"
+          value={npc.screen ?? ''}
+          placeholder="e.g. adopt-pet"
+          onChange={e => onUpdate({ screen: e.target.value || undefined })}
+          style={{ width: '100%', padding: '3px 5px', background: '#111', border: '1px solid #444', color: '#eee', borderRadius: 3, fontSize: 12, boxSizing: 'border-box' }}
+        />
+        <div style={{ color: '#666', fontSize: 10, marginTop: 2 }}>Opens a screen/modal (e.g. 'adopt-pet') via a dialogue choice, in addition to dialogue.</div>
+      </Field>
+      <NpcScheduleEditor npc={npc} buildingIds={buildingIds} onUpdate={onUpdate} />
       <Field label="Min Building Level">
         <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
           <input
@@ -585,6 +624,98 @@ function NpcInspector({
         Delete NPC
       </button>
     </div>
+  )
+}
+
+const NPC_ACTIVITIES: NpcActivity[] = ['work', 'eat', 'idle-chat', 'sleep', 'sweep', 'fish']
+
+type NpcScheduleEntry = NonNullable<RawNpc['schedule']>[number]
+
+function NpcScheduleEditor({
+  npc, buildingIds, onUpdate,
+}: {
+  npc: RawNpc
+  buildingIds: string[]
+  onUpdate: (partial: Partial<RawNpc>) => void
+}) {
+  const inp: React.CSSProperties = {
+    background: '#111', border: '1px solid #444', color: '#eee',
+    borderRadius: 3, fontSize: 11, padding: '3px 5px', boxSizing: 'border-box',
+  }
+  const addBtn: React.CSSProperties = { padding: '2px 8px', background: '#1e2e1e', border: '1px solid #3a5a3a', color: '#6d6', borderRadius: 3, fontSize: 10, cursor: 'pointer', alignSelf: 'flex-start' }
+  const delBtn: React.CSSProperties = { padding: '2px 6px', background: '#3a1a1a', border: '1px solid #622', color: '#f88', borderRadius: 3, fontSize: 10, cursor: 'pointer' }
+
+  const entries = npc.schedule ?? []
+  const setEntries = (next: NpcScheduleEntry[]) => onUpdate({ schedule: next.length ? next : undefined })
+  const updateEntry = (i: number, partial: Partial<NpcScheduleEntry>) =>
+    setEntries(entries.map((e, j) => j === i ? { ...e, ...partial } : e))
+
+  return (
+    <Field label="Schedule">
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+        {entries.map((entry, i) => (
+          <div key={i} style={{ border: '1px solid #333', borderRadius: 4, padding: 6, background: '#181818' }}>
+            <div style={{ display: 'flex', gap: 6, alignItems: 'center', marginBottom: 4 }}>
+              <label style={{ fontSize: 10, color: '#888' }}>Start</label>
+              <input type="number" min={0} max={23} value={entry.startHour} style={{ ...inp, width: 44 }}
+                onChange={e => updateEntry(i, { startHour: Number(e.target.value) })} />
+              <label style={{ fontSize: 10, color: '#888' }}>End</label>
+              <input type="number" min={0} max={24} value={entry.endHour} style={{ ...inp, width: 44 }}
+                onChange={e => updateEntry(i, { endHour: Number(e.target.value) })} />
+              <select value={entry.activity ?? ''} style={{ ...inp, flex: 1 }}
+                onChange={e => updateEntry(i, { activity: (e.target.value || undefined) as NpcActivity | undefined })}>
+                <option value="">— activity —</option>
+                {NPC_ACTIVITIES.map(a => <option key={a} value={a}>{a}</option>)}
+              </select>
+              <button style={delBtn} onClick={() => setEntries(entries.filter((_, j) => j !== i))}>✕</button>
+            </div>
+            <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+              <select
+                value={entry.location.type}
+                style={{ ...inp, width: 76 }}
+                onChange={e => {
+                  const type = e.target.value as 'exterior' | 'interior'
+                  updateEntry(i, {
+                    location: type === 'exterior'
+                      ? { type: 'exterior', tx: entry.location.tx, ty: entry.location.ty }
+                      : { type: 'interior', buildingId: buildingIds[0] ?? '', tx: entry.location.tx, ty: entry.location.ty },
+                  })
+                }}
+              >
+                <option value="exterior">exterior</option>
+                <option value="interior">interior</option>
+              </select>
+              {entry.location.type === 'interior' && (
+                <select
+                  value={entry.location.buildingId}
+                  style={{ ...inp, flex: 1 }}
+                  onChange={e => updateEntry(i, { location: { ...entry.location, type: 'interior', buildingId: e.target.value } as NpcScheduleEntry['location'] })}
+                >
+                  {buildingIds.map(id => <option key={id} value={id}>{id}</option>)}
+                </select>
+              )}
+              <label style={{ fontSize: 10, color: '#888' }}>X</label>
+              <input type="number" value={entry.location.tx} style={{ ...inp, width: 44 }}
+                onChange={e => updateEntry(i, { location: { ...entry.location, tx: Number(e.target.value) } as NpcScheduleEntry['location'] })} />
+              <label style={{ fontSize: 10, color: '#888' }}>Y</label>
+              <input type="number" value={entry.location.ty} style={{ ...inp, width: 44 }}
+                onChange={e => updateEntry(i, { location: { ...entry.location, ty: Number(e.target.value) } as NpcScheduleEntry['location'] })} />
+            </div>
+          </div>
+        ))}
+        <button
+          style={addBtn}
+          onClick={() => setEntries([...entries, {
+            startHour: 8, endHour: 12, location: { type: 'exterior', tx: npc.tx, ty: npc.ty },
+          }])}
+        >
+          + Add schedule entry
+        </button>
+      </div>
+      <div style={{ color: '#666', fontSize: 10, marginTop: 3 }}>
+        Time-of-day locations (interior entries can move this NPC inside a building). Use the toolbar's preview-hour control to see this rendered on the canvas.
+      </div>
+    </Field>
   )
 }
 
@@ -667,9 +798,9 @@ function AnimalInspector({
         />
       </Field>
       {animal.roam && (
-        <Field label="Area Rect">
+        <Field label="Wander Area (offset from this animal)">
           <div style={{ display: 'flex', gap: 4 }}>
-            {(['x', 'y', 'w', 'h'] as const).map((k, ki) => (
+            {(['dx', 'dy', 'w', 'h'] as const).map((k, ki) => (
               <input
                 key={k}
                 type="number"
@@ -766,6 +897,40 @@ function QuestItemInspector({
         Delete {label}
       </button>
     </div>
+  )
+}
+
+/** Editable list of supplementary visual-only tiles offset from a parent
+ *  item's anchor — e.g. a pickup's extraTiles (a lantern's second tile). */
+function ExtraTilesEditor({ tiles, onChange }: {
+  tiles: Array<{ dx: number; dy: number; tileId: string }>
+  onChange: (tiles: Array<{ dx: number; dy: number; tileId: string }>) => void
+}) {
+  const [pickingIndex, setPickingIndex] = useState<number | null>(null)
+  const numSm: React.CSSProperties = { width: 44, padding: '2px 4px', background: '#111', border: '1px solid #444', color: '#eee', borderRadius: 3, fontSize: 11 }
+  return (
+    <Field label={`Extra tiles (${tiles.length}) — offset from anchor`}>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+        {tiles.map((t, i) => (
+          <div key={i} style={{ background: '#16161e', border: '1px solid #2a2a3a', borderRadius: 3, padding: 4 }}>
+            <div style={{ display: 'flex', gap: 4, alignItems: 'center' }}>
+              <div onClick={() => setPickingIndex(p => p === i ? null : i)} style={{ cursor: 'pointer', display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+                <TilePreview tileId={t.tileId} /><span style={{ fontSize: 10, color: '#666' }}>✎</span>
+              </div>
+              <label style={{ fontSize: 9, color: '#888' }}>dx</label>
+              <input type="number" style={numSm} value={t.dx} onChange={e => onChange(tiles.map((x, j) => j === i ? { ...x, dx: Number(e.target.value) } : x))} />
+              <label style={{ fontSize: 9, color: '#888' }}>dy</label>
+              <input type="number" style={numSm} value={t.dy} onChange={e => onChange(tiles.map((x, j) => j === i ? { ...x, dy: Number(e.target.value) } : x))} />
+              <button style={{ marginLeft: 'auto', padding: '1px 5px', background: '#4a1a1a', border: '1px solid #922', color: '#f88', borderRadius: 3, fontSize: 10, cursor: 'pointer' }}
+                onClick={() => onChange(tiles.filter((_, j) => j !== i))}>✕</button>
+            </div>
+            {pickingIndex === i && <TilePicker current={t.tileId} onChange={tileId => onChange(tiles.map((x, j) => j === i ? { ...x, tileId } : x))} onClose={() => setPickingIndex(null)} />}
+          </div>
+        ))}
+        <button style={{ padding: '2px 8px', background: '#1e2e1e', border: '1px solid #3a5a3a', color: '#6d6', borderRadius: 3, fontSize: 10, cursor: 'pointer', alignSelf: 'flex-start' }}
+          onClick={() => onChange([...tiles, { dx: 0, dy: 1, tileId: 'signpost' }])}>+ Add tile</button>
+      </div>
+    </Field>
   )
 }
 
@@ -930,6 +1095,14 @@ function BuildingInspector({
           <span style={{ fontFamily: 'monospace', fontSize: 11, color: '#aaa' }}>{building.id}</span>
         </Field>
       )}
+      <Field label="Name (authoring only, not shown to players)">
+        <input
+          style={inputStyle}
+          value={building.comment ?? ''}
+          placeholder="e.g. Blacksmith's forge"
+          onChange={e => onUpdateBuilding(buildingIndex, { comment: e.target.value || undefined })}
+        />
+      </Field>
       <Field label="Rect">
         <span style={{ fontFamily: 'monospace', fontSize: 11, color: '#aaa' }}>
           ({tx1},{ty1}) → ({tx2},{ty2}) — {tx2 - tx1 + 1}×{ty2 - ty1 + 1} tiles
@@ -965,6 +1138,40 @@ function BuildingInspector({
           Multi-rect buildings can't be resized here — edit the rects directly in JSON.
         </div>
       )}
+
+      {/* ── Doors list ──────────────────────────────────────────────────── */}
+      <Field label={`Doors (${(building.doors ?? []).length})`}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+          {(building.doors ?? []).map((d, i) => {
+            const doorRects = (building.rects ?? (building.rect ? [building.rect] : [])) as [number, number, number, number][]
+            const doorOx = Math.min(...doorRects.map(r => r[0]))
+            const doorOy = Math.max(...doorRects.map(r => r[3]))
+            const doorAbsTx = doorOx + d.tx
+            const doorAbsTy = doorOy + d.ty
+            return (
+              <div key={i} style={{ display: 'flex', gap: 4, alignItems: 'center', background: '#16161e', border: '1px solid #2a2a3a', borderRadius: 3, padding: 4 }}>
+                <label style={{ fontSize: 9, color: '#888' }}>X</label>
+                <input type="number" style={numStyle} value={doorAbsTx} onChange={e => {
+                  const doors = (building.doors ?? []).map((x, j) => j === i ? { ...x, tx: Number(e.target.value) - doorOx } : x)
+                  onUpdateBuilding(buildingIndex, { doors })
+                }} />
+                <label style={{ fontSize: 9, color: '#888' }}>Y</label>
+                <input type="number" style={numStyle} value={doorAbsTy} onChange={e => {
+                  const doors = (building.doors ?? []).map((x, j) => j === i ? { ...x, ty: Number(e.target.value) - doorOy } : x)
+                  onUpdateBuilding(buildingIndex, { doors })
+                }} />
+                <button
+                  style={{ marginLeft: 'auto', padding: '1px 5px', background: '#4a1a1a', border: '1px solid #922', color: '#f88', borderRadius: 3, fontSize: 10, cursor: 'pointer' }}
+                  onClick={() => onUpdateBuilding(buildingIndex, { doors: (building.doors ?? []).filter((_, j) => j !== i) })}
+                >✕</button>
+              </div>
+            )
+          })}
+          <div style={{ color: '#666', fontSize: 9 }}>
+            Place tool + no tile selected, click a wall tile to add a door — the sprite (if shown) renders one tile north of it; hidden doors are marked with 🚪 here.
+          </div>
+        </div>
+      </Field>
 
       {/* ── Upgrade levels ─────────────────────────────────────────────── */}
       <div style={{ borderTop: '1px solid #333', marginTop: 4, paddingTop: 10 }}>
@@ -1179,7 +1386,7 @@ function InteriorInspector({
   onMoveEntity: (entity: SelectedEntity, tx: number, ty: number) => void
   onZlayerChange: (entity: SelectedEntity, z: Zlayer) => void
   onDelete: (entity: SelectedEntity) => void
-  onReorderInteriorDecor?: (entity: SelectedEntity, direction: 'forward' | 'back') => void
+  onReorderInteriorDecor?: (entity: SelectedEntity, direction: ReorderDirection) => void
   onUpdateDecorTileId?: (entity: SelectedEntity, tileId: string) => void
 }) {
   const [showExitForm, setShowExitForm] = useState(false)
@@ -1453,6 +1660,7 @@ function InteriorInspector({
               onDelete={() => onDelete(selectedEntity)}
               onTileChange={onUpdateDecorTileId ? tileId => onUpdateDecorTileId(selectedEntity, tileId) : undefined}
               onReorder={onReorderInteriorDecor ? dir => onReorderInteriorDecor(selectedEntity, dir) : undefined}
+              listLength={interior.decor.length}
             />
           </div>
         )}
@@ -1834,9 +2042,15 @@ function InteractableInspector({ it, onUpdate, onMove, onDelete, onPick, buildin
           {decor.map((d, i) => (
             <div key={i} style={{ background: '#16161e', border: '1px solid #2a2a3a', borderRadius: 3, padding: 4 }}>
               <div style={{ display: 'flex', gap: 4, alignItems: 'center' }}>
-                <div onClick={() => setPickingDecor(p => p === i ? null : i)} style={{ cursor: 'pointer', display: 'inline-flex', alignItems: 'center', gap: 4 }}>
-                  <TilePreview tileId={d.tileId} /><span style={{ fontSize: 10, color: '#666' }}>✎</span>
-                </div>
+                {d.shopArtSlot != null ? (
+                  <span style={{ fontSize: 10, color: '#8af', whiteSpace: 'nowrap' }} title="Renders today's live shop-stock art at runtime — not previewable here">🛒 shop slot #{d.shopArtSlot}</span>
+                ) : d.spriteId != null ? (
+                  <span style={{ fontSize: 10, color: '#8af', whiteSpace: 'nowrap' }} title={`web/public/sprites/${d.spriteId}.svg`}>🖼 {d.spriteId}</span>
+                ) : (
+                  <div onClick={() => setPickingDecor(p => p === i ? null : i)} style={{ cursor: 'pointer', display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+                    <TilePreview tileId={d.tileId ?? ''} /><span style={{ fontSize: 10, color: '#666' }}>✎</span>
+                  </div>
+                )}
                 <label style={{ fontSize: 9, color: '#888' }}>dx</label>
                 <input type="number" style={numSm} value={d.dx} onChange={e => onUpdate({ decor: decor.map((x, j) => j === i ? { ...x, dx: Number(e.target.value) } : x) })} />
                 <label style={{ fontSize: 9, color: '#888' }}>dy</label>
@@ -1844,7 +2058,9 @@ function InteractableInspector({ it, onUpdate, onMove, onDelete, onPick, buildin
                 <button style={{ marginLeft: 'auto', padding: '1px 5px', background: '#4a1a1a', border: '1px solid #922', color: '#f88', borderRadius: 3, fontSize: 10, cursor: 'pointer' }}
                   onClick={() => onUpdate({ decor: decor.filter((_, j) => j !== i) })}>✕</button>
               </div>
-              {pickingDecor === i && <TilePicker current={d.tileId} onChange={tileId => onUpdate({ decor: decor.map((x, j) => j === i ? { ...x, tileId } : x) })} onClose={() => setPickingDecor(null)} />}
+              {pickingDecor === i && d.shopArtSlot == null && d.spriteId == null && (
+                <TilePicker current={d.tileId ?? ''} onChange={tileId => onUpdate({ decor: decor.map((x, j) => j === i ? { ...x, tileId } : x) })} onClose={() => setPickingDecor(null)} />
+              )}
               <div style={{ display: 'flex', gap: 4, alignItems: 'center', marginTop: 4 }}>
                 {(['solid', 'below', 'above'] as const).map(z => (
                   <button
@@ -2403,7 +2619,7 @@ function SpawnTileInspector({
 export function EntityInspector({
   selectedEntities, mapId, configData, activeInteriorId, activeBuildingIndex, activeLevel, viewMode,
   onSetActiveLevel, onUpdateBuilding, onResizeBuilding, onUpdateBuildingLevelVisual, onUpdateDecorMinLevel, onUpdateDecorHideAtLevel,
-  onDelete, onMoveEntity, onZlayerChange, onUpdateGlow, onUpdatePickupGlow, onDialogueChange,
+  onDelete, onMoveEntity, onZlayerChange, onUpdateGlow, onUpdatePickupGlow, onUpdatePickupExtraTiles, onDialogueChange,
   onOpenInterior, onCloseInterior, onOpenBuildingEditor, onCloseBuildingEditor, onUpdateStreetEntry,
   onResizeInterior, onAddInterior, onAddInteriorExit, onUpdateInteriorProps, onUpdateInteriorExit,
   onRemoveInteriorExit,
@@ -2485,9 +2701,14 @@ export function EntityInspector({
     )
   }
 
-  const isQuestItemSelected = selectedEntity?.type === 'treasure'
+  // Entity types with their own dedicated inspector panel below — selecting one
+  // of these inside an interior should reach that panel instead of the interior
+  // overview (InteriorInspector) that would otherwise swallow the selection.
+  const hasOwnInspectorPanel = selectedEntity?.type === 'treasure'
     || selectedEntity?.type === 'pickupItem'
     || selectedEntity?.type === 'animal'
+    || selectedEntity?.type === 'npc'
+    || selectedEntity?.type === 'interactable'
 
   if (viewMode === 'building' && activeBuildingIndex != null) {
     const b = (configData.buildings ?? [])[activeBuildingIndex]
@@ -2534,6 +2755,7 @@ export function EntityInspector({
           onHideAtLevel={v => onUpdateDecorHideAtLevel(sel, v)}
           onTileChange={onUpdateDecorTileId ? (tid: string) => onUpdateDecorTileId(sel, tid) : undefined}
           onReorder={onReorderDecor ? dir => onReorderDecor(sel, dir) : undefined}
+          listLength={b?.decor?.length}
           onDelete={() => onDelete(sel)}
         />
       )
@@ -2550,6 +2772,7 @@ export function EntityInspector({
           onHideAtLevel={v => onUpdateDecorHideAtLevel(sel, v)}
           onTileChange={onUpdateDecorTileId ? (tid: string) => onUpdateDecorTileId(sel, tid) : undefined}
           onReorder={onReorderDecor ? dir => onReorderDecor(sel, dir) : undefined}
+          listLength={b?.levelDecor?.length}
           onDelete={() => onDelete(sel)}
         />
       )
@@ -2608,7 +2831,7 @@ export function EntityInspector({
               {numInput(absTy, ty => onMoveEntity(sel, absTx, ty))}
             </div>
             <div style={{ color: '#666', fontSize: 9, marginTop: 2 }}>
-              Only doors on a building's south face get a visible sprite — elsewhere the door is an invisible walk-in trigger.
+              (X, Y) is where the player walks in. The door sprite (if shown) always renders one tile north of it.
             </div>
           </Field>
           <Field label="Links to interior (optional)">
@@ -2618,6 +2841,26 @@ export function EntityInspector({
               placeholder="Search buildings…"
               onChange={v => onUpdateBuilding(activeBuildingIndex, { doors: (b.doors ?? []).map((x, i) => i === sel.index ? { ...x, buildingId: v || undefined } : x) })}
             />
+          </Field>
+          <Field label="Appearance">
+            <label style={{ display: 'flex', alignItems: 'center', gap: 6, cursor: 'pointer', fontSize: 11 }}>
+              <input
+                type="checkbox"
+                checked={!d.hideSprite}
+                onChange={e => onUpdateBuilding(activeBuildingIndex, { doors: (b.doors ?? []).map((x, i) => i === sel.index ? { ...x, hideSprite: e.target.checked ? undefined : true } : x) })}
+              />
+              Show door sprite
+            </label>
+            {!d.hideSprite && (
+              <label style={{ display: 'flex', alignItems: 'center', gap: 6, cursor: 'pointer', fontSize: 11, marginTop: 4 }}>
+                <input
+                  type="checkbox"
+                  checked={!d.hideSign}
+                  onChange={e => onUpdateBuilding(activeBuildingIndex, { doors: (b.doors ?? []).map((x, i) => i === sel.index ? { ...x, hideSign: e.target.checked ? undefined : true } : x) })}
+                />
+                Show door sign
+              </label>
+            )}
           </Field>
           <button
             onClick={() => onDelete(sel)}
@@ -2637,16 +2880,50 @@ export function EntityInspector({
         </div>
         <div style={bodyStyle}>
           <div style={{ color: '#777', fontSize: 10, marginBottom: 8 }}>
-            Select tool to select/delete items. Place tool + tile to add decor, or no tile selected to toggle a door (any tile — only south-face doors get a visible sprite). Window tool + tile places a window.
+            Select tool to select/delete items. Place tool + tile to add decor, or no tile selected to toggle a door (any tile — shows a sprite one tile north by default; toggle it off in the door's inspector for a hidden trigger, marked with 🚪). Window tool + tile places a window.
           </div>
           {levelSlider}
+          {b && (
+            <Field label={`Doors (${(b.doors ?? []).length})`}>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+                {(b.doors ?? []).map((d, i) => {
+                  const doorRects = (b.rects ?? (b.rect ? [b.rect] : [])) as [number, number, number, number][]
+                  const doorOx = Math.min(...doorRects.map(r => r[0]))
+                  const doorOy = Math.max(...doorRects.map(r => r[3]))
+                  const doorAbsTx = doorOx + d.tx
+                  const doorAbsTy = doorOy + d.ty
+                  const isThisSel = sel?.type === 'buildingDoor' && sel.index === i
+                  return (
+                    <div key={i} style={{ display: 'flex', gap: 4, alignItems: 'center', background: isThisSel ? '#2a2410' : '#16161e', border: isThisSel ? '1px solid #f0c040' : '1px solid #2a2a3a', borderRadius: 3, padding: 4 }}>
+                      <label style={{ fontSize: 9, color: '#888' }}>X</label>
+                      <input type="number" style={{ width: 44, padding: '2px 4px', background: '#111', border: '1px solid #444', color: '#eee', borderRadius: 3, fontSize: 11 }} value={doorAbsTx} onChange={e => {
+                        const doors = (b.doors ?? []).map((x, j) => j === i ? { ...x, tx: Number(e.target.value) - doorOx } : x)
+                        onUpdateBuilding(activeBuildingIndex, { doors })
+                      }} />
+                      <label style={{ fontSize: 9, color: '#888' }}>Y</label>
+                      <input type="number" style={{ width: 44, padding: '2px 4px', background: '#111', border: '1px solid #444', color: '#eee', borderRadius: 3, fontSize: 11 }} value={doorAbsTy} onChange={e => {
+                        const doors = (b.doors ?? []).map((x, j) => j === i ? { ...x, ty: Number(e.target.value) - doorOy } : x)
+                        onUpdateBuilding(activeBuildingIndex, { doors })
+                      }} />
+                      {d.buildingId && <span style={{ fontSize: 9, color: '#666', marginLeft: 4 }}>→ {d.buildingId}</span>}
+                      <button
+                        style={{ marginLeft: 'auto', padding: '1px 5px', background: '#4a1a1a', border: '1px solid #922', color: '#f88', borderRadius: 3, fontSize: 10, cursor: 'pointer' }}
+                        onClick={() => onUpdateBuilding(activeBuildingIndex, { doors: (b.doors ?? []).filter((_, j) => j !== i) })}
+                      >✕</button>
+                    </div>
+                  )
+                })}
+                {(b.doors ?? []).length === 0 && <div style={{ color: '#666', fontSize: 10 }}>No doors yet.</div>}
+              </div>
+            </Field>
+          )}
           {body}
         </div>
       </div>
     )
   }
 
-  if (viewMode === 'interior' && activeInteriorId && !isQuestItemSelected) {
+  if (viewMode === 'interior' && activeInteriorId && !hasOwnInspectorPanel) {
     const interior = configData.interiors?.[activeInteriorId]
     // Resolve the owning building so the level stepper matches what's reachable in-game.
     const ownerBuilding = (configData.buildings ?? []).find(b => {
@@ -2740,6 +3017,7 @@ export function EntityInspector({
             onDelete={() => onDelete(selectedEntity)}
             onTileChange={onUpdateDecorTileId ? tileId => onUpdateDecorTileId(selectedEntity, tileId) : undefined}
             onReorder={onReorderDecor ? dir => onReorderDecor(selectedEntity, dir) : undefined}
+            listLength={items.length}
             onConvertToInteractable={onConvertDecorToInteractable ? () => onConvertDecorToInteractable(selectedEntity) : undefined}
           />
         </div>
@@ -2864,6 +3142,12 @@ export function EntityInspector({
             <GlowControls
               glow={p.glow} glowRadius={p.glowRadius} pulse={p.pulse}
               onChange={patch => onUpdatePickupGlow(selectedEntity.index, patch)}
+            />
+          )}
+          {onUpdatePickupExtraTiles && (
+            <ExtraTilesEditor
+              tiles={p.extraTiles ?? []}
+              onChange={tiles => onUpdatePickupExtraTiles(selectedEntity.index, tiles)}
             />
           )}
         </div>

--- a/web/src/components/mapEditor/MapEditor.tsx
+++ b/web/src/components/mapEditor/MapEditor.tsx
@@ -28,6 +28,9 @@ export function MapEditor({ initialMapId = 'ravenwatch', initialFestival = undef
   const [showBlockedPaths, setShowBlockedPaths] = useState(false)
   const [showAreas, setShowAreas] = useState(false)
   const [showInteractables, setShowInteractables] = useState(false)
+  const [showExitTiles, setShowExitTiles] = useState(false)
+  const [showAnimalAreas, setShowAnimalAreas] = useState(false)
+  const [previewHour, setPreviewHour] = useState<number | null>(null)
   const [questDefsData, setQuestDefsData] = useState<QuestDefsJson | null>(
     () => QUEST_DEFS_BY_MAP[initialMapId] ? structuredClone(QUEST_DEFS_BY_MAP[initialMapId]!) : null,
   )
@@ -276,11 +279,15 @@ export function MapEditor({ initialMapId = 'ravenwatch', initialFestival = undef
         showBlockedPaths={showBlockedPaths}
         showAreas={showAreas}
         showInteractables={showInteractables}
+        showExitTiles={showExitTiles}
+        showAnimalAreas={showAnimalAreas}
+        previewHour={previewHour}
         drawerOpen={drawerOpen}
         hasDuplicateQuestIds={hasDuplicateQuestIds}
         configData={state.configData}
         previewFestivalId={state.previewFestivalId}
         onPreviewFestivalChange={setPreviewFestival}
+        onPreviewHourChange={setPreviewHour}
         onMapChange={setMapId}
         onToolChange={setTool}
         onUndo={undo}
@@ -291,6 +298,8 @@ export function MapEditor({ initialMapId = 'ravenwatch', initialFestival = undef
         onBlockedPathsToggle={() => setShowBlockedPaths(b => !b)}
         onAreasToggle={() => setShowAreas(a => !a)}
         onInteractablesToggle={() => setShowInteractables(i => !i)}
+        onExitTilesToggle={() => setShowExitTiles(e => !e)}
+        onAnimalAreasToggle={() => setShowAnimalAreas(a => !a)}
         onDrawerToggle={() => setDrawerOpen(o => !o)}
         questDefsData={questDefsData as Record<string, unknown> | null}
         onSaved={markSaved}
@@ -335,6 +344,9 @@ export function MapEditor({ initialMapId = 'ravenwatch', initialFestival = undef
             showBlockedPaths={showBlockedPaths}
             showAreas={showAreas}
             showInteractables={showInteractables}
+            showExitTiles={showExitTiles}
+            showAnimalAreas={showAnimalAreas}
+            previewHour={previewHour}
             blockedPaths={(questDefsData?.blockedPaths as RawBlockedPath[]) ?? []}
             selectedEntities={state.selectedEntities}
             viewMode={state.viewMode}
@@ -389,6 +401,13 @@ export function MapEditor({ initialMapId = 'ravenwatch', initialFestival = undef
                 const items = [...(prev.pickupItems ?? [])]
                 if (!items[index]) return prev
                 items[index] = { ...items[index], ...patch }
+                return { ...prev, pickupItems: items }
+              })}
+              onUpdatePickupExtraTiles={(index, extraTiles) => setQuestDefsData(prev => {
+                if (!prev) return prev
+                const items = [...(prev.pickupItems ?? [])]
+                if (!items[index]) return prev
+                items[index] = { ...items[index], extraTiles: extraTiles.length > 0 ? extraTiles : undefined }
                 return { ...prev, pickupItems: items }
               })}
               onDialogueChange={updateNpcDialogue}

--- a/web/src/components/mapEditor/MapEditorCanvas.tsx
+++ b/web/src/components/mapEditor/MapEditorCanvas.tsx
@@ -3,7 +3,8 @@ import * as PIXI from 'pixi.js'
 import { usePixiApp } from '../../hooks/usePixiApp'
 import { loadTileRef, loadSpriteTexture } from '../../utils/pixiHelpers'
 import { BASE_CHIP_TILES } from '../../data/tiles/baseChipIndex'
-import type { RawMapConfig, RawDecorItem, RawBlockedPath, RawLockedDoor, SelectedEntity, ToolMode, Zlayer } from './mapEditorTypes'
+import type { RawMapConfig, RawDecorItem, RawBlockedPath, RawLockedDoor, RawNpc, SelectedEntity, ToolMode, Zlayer } from './mapEditorTypes'
+import { hourInRange } from '../../game/hub/hubClock'
 import { resolveVariantTint, AnimalType } from '../../game/hub/animals'
 import { WALL_TILES } from '../../data/tiles/buildingMaterials'
 import type { WallMaterial, RoofMaterial } from '../../data/tiles/buildingMaterials'
@@ -17,6 +18,17 @@ import { isSameEntityRef } from './multiSelectHelpers'
 
 const T           = 32
 const INTERIOR_PAD = 10  // tiles of surrounding space around active room in interior view
+
+/** Where a scheduled NPC would be at `hour` — mirrors getNpcLocation in
+ *  web/src/game/hub/hubNpcSchedule.ts, reimplemented against the editor's
+ *  RawNpc (structurally close to HubNpc but not identical) to avoid a cast. */
+function getScheduledLocation(npc: RawNpc, hour: number): NonNullable<RawNpc['schedule']>[number]['location'] | null {
+  if (!npc.schedule?.length) return null
+  for (const entry of npc.schedule) {
+    if (hourInRange(hour, entry.startHour, entry.endHour)) return entry.location
+  }
+  return null
+}
 
 const WALL_COLORS: Record<string, number> = {
   brick:               0x8b5e4a,
@@ -113,6 +125,9 @@ interface Props {
   showBlockedPaths:   boolean
   showAreas:          boolean
   showInteractables:  boolean
+  showExitTiles:      boolean
+  showAnimalAreas:    boolean
+  previewHour:        number | null
   blockedPaths:       RawBlockedPath[]
   questPickupItems:   RawQuestPickupItem[]
 }
@@ -120,7 +135,7 @@ interface Props {
 export function MapEditorCanvas(props: Props) {
   const {
     configData, tool, showGrid, showBuildingArt = true, selectedEntities, viewMode, activeInteriorId, activeBuildingIndex, activeLevel, previewFestivalId,
-    activeTileId, activeBundleId, activeZlayer, pickActive, showQuestItems, showBlockedPaths, showAreas, showInteractables, blockedPaths, questPickupItems,
+    activeTileId, activeBundleId, activeZlayer, pickActive, showQuestItems, showBlockedPaths, showAreas, showInteractables, showExitTiles, showAnimalAreas, previewHour, blockedPaths, questPickupItems,
     onPlaceDecor, onAddStreet,
   } = props
 
@@ -253,8 +268,8 @@ export function MapEditorCanvas(props: Props) {
         }
       } else if (t === 'place' && vm === 'building' && abIdx != null && !tid && !bid) {
         // In building mode with no active tile: toggle a door (any tile —
-        // only doors on the south face render a sprite; elsewhere they're
-        // invisible walk-in triggers).
+        // shows a sprite one tile north by default; hidden via the door's
+        // inspector for an invisible walk-in trigger).
         propsRef.current.onPlaceBuildingDoor(abIdx, tx, ty)
       } else if (t === 'buildingWindow' && vm === 'building' && abIdx != null && tid) {
         propsRef.current.onPlaceBuildingWindow(abIdx, tx, ty, tid)
@@ -397,6 +412,12 @@ export function MapEditorCanvas(props: Props) {
     if (!isBuilding && showInteractables) {
       renderInteractablesOverlay(version, questLayer, selLayer)
     }
+    if (!isInterior && !isBuilding && showExitTiles) {
+      renderExitTilesOverlay(questLayer, selLayer)
+    }
+    if (!isBuilding && showAnimalAreas) {
+      renderAnimalAreaRectsOverlay(questLayer, selLayer)
+    }
 
     if (showGrid) drawGrid(gridLayer)
     drawSelection(selLayer)
@@ -538,10 +559,9 @@ export function MapEditorCanvas(props: Props) {
       const useArt = showBuildingArt && vis.wall && vis.roof && WALL_TILES[vis.wall as WallMaterial]
       const ox = Math.min(...allRects.map(r => r[0]))
       const oy = Math.max(...allRects.map(r => r[3]))
-      // Authored position is used as-is — placeBuildingTiles only draws a door
-      // sprite when it lands exactly on a south face (rect.y2 + 1); doors
-      // elsewhere are invisible walk-in triggers, matching runtime behavior.
-      const absDoors: BuildingDoorTile[] = (b.doors ?? []).map(d => ({ tx: ox + d.tx, ty: oy + d.ty }))
+      // Authored position is used as-is — placeBuildingTiles renders the door
+      // sprite one tile north of it unless hideSprite keeps it invisible.
+      const absDoors: BuildingDoorTile[] = (b.doors ?? []).map(d => ({ tx: ox + d.tx, ty: oy + d.ty, hideSprite: d.hideSprite }))
       if (useArt) {
         for (const rect of renderRects) {
           const placements = placeBuildingTiles(rect, vis.wall as WallMaterial, vis.roof as RoofMaterial, absDoors)
@@ -646,17 +666,32 @@ export function MapEditorCanvas(props: Props) {
     // NPCs
     const npcs = configData.npcs ?? []
     npcs.forEach((npc, nIdx) => {
-      if (npc.building) return
+      // With a preview hour set, a scheduled NPC's exterior/interior split for
+      // THIS pass is driven by its schedule, not the static `building` field —
+      // it overrides where the NPC would normally show.
+      const scheduled = previewHour != null ? getScheduledLocation(npc, previewHour) : null
+      let px: number, py: number, isPreview: boolean
+      if (scheduled) {
+        if (scheduled.type !== 'exterior') return  // inside a building right now
+        px = scheduled.tx; py = scheduled.ty; isPreview = true
+      } else {
+        if (npc.building) return
+        px = npc.tx; py = npc.ty; isPreview = false
+      }
       const isSel = isEntitySelected({ type: 'npc', index: nIdx })
       loadSpriteTexture(resolveNpcSprite(npc.sprite)).then(tex => {
         if (renderVersionRef.current !== version) return
         const sp = new PIXI.Sprite(tex)
         sp.width  = T * 1.5; sp.height = T * 1.5
-        sp.x      = npc.tx * T - T * 0.25
-        sp.y      = npc.ty * T - T * 0.5
-        sp.eventMode = 'static'; sp.cursor = 'pointer'
-        sp.on('pointerdown', (e: PIXI.FederatedPointerEvent) =>
-          handleEntityPointerDown(e, { type: 'npc', index: nIdx }, npc.tx, npc.ty))
+        sp.x      = px * T - T * 0.25
+        sp.y      = py * T - T * 0.5
+        if (isPreview) {
+          sp.alpha = 0.85
+        } else {
+          sp.eventMode = 'static'; sp.cursor = 'pointer'
+          sp.on('pointerdown', (e: PIXI.FederatedPointerEvent) =>
+            handleEntityPointerDown(e, { type: 'npc', index: nIdx }, npc.tx, npc.ty))
+        }
         if (isSel) {
           selLayer.rect(sp.x - 2, sp.y - 2, sp.width + 4, sp.height + 4)
             .stroke({ color: 0xf0c040, width: 2 })
@@ -665,7 +700,7 @@ export function MapEditorCanvas(props: Props) {
       }).catch(() => {
         if (renderVersionRef.current !== version) return
         const g = new PIXI.Graphics()
-        g.circle(npc.tx * T + T / 2, npc.ty * T + T / 2, T / 3).fill(0xff88aa)
+        g.circle(px * T + T / 2, py * T + T / 2, T / 3).fill(0xff88aa)
         npcLayer.addChild(g)
       })
     })
@@ -803,7 +838,7 @@ export function MapEditorCanvas(props: Props) {
 
     // Building tiles
     const useArt = showBuildingArt && b.wall && b.roof && WALL_TILES[b.wall as WallMaterial]
-    const absDoors: BuildingDoorTile[] = (b.doors ?? []).map(d => ({ tx: ox + d.tx, ty: oy + d.ty }))
+    const absDoors: BuildingDoorTile[] = (b.doors ?? []).map(d => ({ tx: ox + d.tx, ty: oy + d.ty, hideSprite: d.hideSprite }))
 
     if (useArt) {
       for (const rect of allRects) {
@@ -839,18 +874,26 @@ export function MapEditorCanvas(props: Props) {
       buildingLayer.addChild(gfx)
     }
 
-    // Doors — interactive hit zones at their rendered positions
+    // Doors — always show a marker at the entry (trigger) tile. Doors with a
+    // sprite already get real door art drawn one tile north; hidden ones
+    // (hideSprite) get a clearly visible marker so authors can still find them.
     for (let di = 0; di < (b.doors ?? []).length; di++) {
       const d = b.doors![di]
       const absTx = ox + d.tx
-      const absTy = oy + d.ty  // rendered tile row (south face + 1)
+      const absTy = oy + d.ty
       const entity: SelectedEntity = { type: 'buildingDoor', buildingIndex: bIdx, index: di }
       const isSel = isEntitySelected(entity)
       const hitGfx = new PIXI.Graphics()
-      hitGfx.rect(absTx * T, absTy * T, T, T).fill({ color: 0xffffff, alpha: 0.01 })
+      hitGfx.rect(absTx * T, absTy * T, T, T).fill({ color: 0xffcc44, alpha: d.hideSprite ? 0.35 : 0.02 })
+        .stroke({ color: isSel ? 0xf0c040 : 0xcc9922, width: d.hideSprite ? 1 : 0 })
       hitGfx.eventMode = 'static'; hitGfx.cursor = 'pointer'
       hitGfx.on('pointerdown', (e: PIXI.FederatedPointerEvent) => handleEntityPointerDown(e, entity, absTx, absTy))
       buildingLayer.addChild(hitGfx)
+      if (d.hideSprite) {
+        const lbl = new PIXI.Text({ text: '🚪', style: { fontSize: 14 } })
+        lbl.x = absTx * T + 8; lbl.y = absTy * T + 4
+        buildingLayer.addChild(lbl)
+      }
       if (isSel) selLayer.rect(absTx * T - 1, absTy * T - 1, T + 2, T + 2).stroke({ color: 0xf0c040, width: 2 })
     }
 
@@ -1024,25 +1067,40 @@ export function MapEditorCanvas(props: Props) {
 
     // ── Interior NPCs ────────────────────────────────────────────────────────
     ;(configData.npcs ?? []).forEach((npc, nIdx) => {
-      if (npc.building !== iid) return
+      // A scheduled NPC shows up here if its schedule places it in THIS
+      // building at the preview hour, even if its static `building` field
+      // points elsewhere (a traveling NPC) — schedule wins over the static field.
+      const scheduled = previewHour != null ? getScheduledLocation(npc, previewHour) : null
+      let px: number, py: number, isPreview: boolean
+      if (scheduled) {
+        if (scheduled.type !== 'interior' || scheduled.buildingId !== iid) return
+        px = scheduled.tx; py = scheduled.ty; isPreview = true
+      } else {
+        if (npc.building !== iid) return
+        px = npc.tx; py = npc.ty; isPreview = false
+      }
       const isSel = isEntitySelected({ type: 'npc', index: nIdx })
       const dimmed = !isVisibleAtLevel(npc, activeLevel)  // NPC absent at this upgrade level (below minLevel or past hideAtLevel)
       loadSpriteTexture(resolveNpcSprite(npc.sprite)).then(tex => {
         if (renderVersionRef.current !== version) return
         const sp = new PIXI.Sprite(tex)
         sp.width = T * 1.5; sp.height = T * 1.5
-        sp.x = npc.tx * T - T * 0.25
-        sp.y = npc.ty * T - T * 0.5
+        sp.x = px * T - T * 0.25
+        sp.y = py * T - T * 0.5
         if (dimmed) sp.alpha = 0.3
-        sp.eventMode = 'static'; sp.cursor = 'pointer'
-        sp.on('pointerdown', (e: PIXI.FederatedPointerEvent) =>
-          handleEntityPointerDown(e, { type: 'npc', index: nIdx }, npc.tx, npc.ty))
+        if (isPreview) {
+          sp.alpha = (sp.alpha ?? 1) * 0.85
+        } else {
+          sp.eventMode = 'static'; sp.cursor = 'pointer'
+          sp.on('pointerdown', (e: PIXI.FederatedPointerEvent) =>
+            handleEntityPointerDown(e, { type: 'npc', index: nIdx }, npc.tx, npc.ty))
+        }
         if (isSel) selLayer.rect(sp.x - 2, sp.y - 2, sp.width + 4, sp.height + 4).stroke({ color: 0xf0c040, width: 2 })
         npcLayer.addChild(sp)
       }).catch(() => {
         if (renderVersionRef.current !== version) return
         const g = new PIXI.Graphics()
-        g.circle(npc.tx * T + T / 2, npc.ty * T + T / 2, T / 3).fill(0xff88aa)
+        g.circle(px * T + T / 2, py * T + T / 2, T / 3).fill(0xff88aa)
         npcLayer.addChild(g)
       })
     })
@@ -1259,7 +1317,18 @@ export function MapEditorCanvas(props: Props) {
     })
     // Quest pickup items come from questDefs.json (passed via prop), not configData
     questPickupItems.forEach((p, i) => {
-      if (!p.building) renderItem(p.tx, p.ty, p.tileId, { type: 'pickupItem', index: i }, PICKUP_COLOR)
+      if (p.building) return
+      renderItem(p.tx, p.ty, p.tileId, { type: 'pickupItem', index: i }, PICKUP_COLOR)
+      // Extra tiles are visual-only previews — no separate hit area/selection.
+      for (const extra of p.extraTiles ?? []) {
+        loadTileRef(tileNumericId(extra.tileId)).then(tex => {
+          if (renderVersionRef.current !== version) return
+          const sp = new PIXI.Sprite(tex)
+          sp.x = (p.tx + extra.dx) * T; sp.y = (p.ty + extra.dy) * T
+          sp.tint = PICKUP_COLOR
+          questLayer.addChild(sp)
+        }).catch(() => {})
+      }
     })
   }
 
@@ -1278,6 +1347,54 @@ export function MapEditorCanvas(props: Props) {
       layer.addChild(gfx)
       const lbl = new PIXI.Text({ text: area.name, style: { fontSize: 9, fill: isSel ? 0xf0c040 : 0xaa66ff } })
       lbl.x = area.tx * T + 4; lbl.y = area.ty * T + 4
+      layer.addChild(lbl)
+    })
+  }
+
+  // ── Exit tiles overlay ───────────────────────────────────────────────────────
+  function renderExitTilesOverlay(layer: PIXI.Container, selLayer: PIXI.Graphics) {
+    ;(propsRef.current.configData.exitTiles ?? []).forEach((exit, eIdx) => {
+      const isSel = isEntitySelected({ type: 'exitTile', index: eIdx })
+      const gfx = new PIXI.Graphics()
+      gfx.rect(exit.tx * T, exit.ty * T, T, T)
+        .fill({ color: 0x44dd88, alpha: 0.18 })
+        .stroke({ color: isSel ? 0xf0c040 : 0x44dd88, width: isSel ? 2 : 1 })
+      gfx.eventMode = 'static'; gfx.cursor = 'pointer'
+      gfx.on('pointerdown', (e: PIXI.FederatedPointerEvent) =>
+        handleEntityPointerDown(e, { type: 'exitTile', index: eIdx }, exit.tx, exit.ty))
+      layer.addChild(gfx)
+      const lbl = new PIXI.Text({ text: exit.screen, style: { fontSize: 9, fill: isSel ? 0xf0c040 : 0x44dd88 } })
+      lbl.x = exit.tx * T + 2; lbl.y = exit.ty * T - 10
+      layer.addChild(lbl)
+    })
+  }
+
+  // ── Animal wander-area overlay ──────────────────────────────────────────────────
+  function renderAnimalAreaRectsOverlay(layer: PIXI.Container, selLayer: PIXI.Graphics) {
+    const { configData: cfg, viewMode: vm, activeInteriorId: iid } = propsRef.current
+    const iidCtx = vm === 'interior' ? iid : undefined
+    ;(cfg.animals ?? []).forEach((animal, aIdx) => {
+      if (!animal.areaRect) return
+      if ((animal.building ?? undefined) !== iidCtx) return
+      const isSel = isEntitySelected({ type: 'animal', index: aIdx })
+      // areaRect is [dx, dy, w, h] relative to the animal's own (tx, ty) — confirmed
+      // from existing data (e.g. Kipper [0,0,10,10], Ralph [-1,-1,4,2]), not an
+      // absolute world rect. w/h can be negative (authoring quirk), so normalize.
+      const [dx, dy, w, h] = animal.areaRect
+      const x = animal.tx + Math.min(dx, dx + w)
+      const y = animal.ty + Math.min(dy, dy + h)
+      const rw = Math.abs(w)
+      const rh = Math.abs(h)
+      const gfx = new PIXI.Graphics()
+      gfx.rect(x * T, y * T, rw * T, rh * T)
+        .fill({ color: 0x66cc33, alpha: 0.10 })
+        .stroke({ color: isSel ? 0xf0c040 : 0x66cc33, width: isSel ? 2 : 1 })
+      gfx.eventMode = 'static'; gfx.cursor = 'pointer'
+      gfx.on('pointerdown', (e: PIXI.FederatedPointerEvent) =>
+        handleEntityPointerDown(e, { type: 'animal', index: aIdx }, animal.tx, animal.ty))
+      layer.addChild(gfx)
+      const lbl = new PIXI.Text({ text: `🐾 ${animal.name ?? animal.id}`, style: { fontSize: 9, fill: isSel ? 0xf0c040 : 0x66cc33 } })
+      lbl.x = x * T + 4; lbl.y = y * T + 4
       layer.addChild(lbl)
     })
   }
@@ -1310,7 +1427,18 @@ export function MapEditorCanvas(props: Props) {
       if (isInterior ? it.building !== iid : !!it.building) return
       const isSel = isEntitySelected({ type: 'interactable', index: idx })
       // Render the owned decor tiles (so the object is visible like in-game).
+      // shopArtSlot/spriteId entries don't have an atlas tileId to preview —
+      // show a placeholder marker instead of resolving to the wrong tile (id 0).
       for (const d of it.decor ?? []) {
+        if (d.tileId == null) {
+          const ph = new PIXI.Graphics()
+          ph.rect((it.tx + d.dx) * T, (it.ty + d.dy) * T, T, T).fill({ color: 0x33bbee, alpha: 0.25 })
+          layer.addChild(ph)
+          const phLbl = new PIXI.Text({ text: d.shopArtSlot != null ? '🛒' : '🖼', style: { fontSize: 14 } })
+          phLbl.x = (it.tx + d.dx) * T + 8; phLbl.y = (it.ty + d.dy) * T + 4
+          layer.addChild(phLbl)
+          continue
+        }
         const numId = tileNumericId(d.tileId)
         loadTileRef(numId).then(tex => {
           if (renderVersionRef.current !== version) return
@@ -1508,7 +1636,7 @@ function hitTest(
       if (ox + windows[i].tx === tx && oy + windows[i].ty + 1 === ty)
         return { type: 'buildingWindow', buildingIndex: activeBuildingIndex, index: i }
     }
-    // Doors (relative coords, stored as south-face relative)
+    // Doors (relative coords; hit-test matches the entry/trigger tile itself)
     const doors = b.doors ?? []
     for (let i = doors.length - 1; i >= 0; i--) {
       if (ox + doors[i].tx === tx && oy + doors[i].ty === ty)

--- a/web/src/components/mapEditor/MapEditorToolbar.tsx
+++ b/web/src/components/mapEditor/MapEditorToolbar.tsx
@@ -34,11 +34,15 @@ interface Props {
   showBlockedPaths:     boolean
   showAreas:            boolean
   showInteractables:    boolean
+  showExitTiles:        boolean
+  showAnimalAreas:      boolean
+  previewHour:          number | null
   drawerOpen:           boolean
   hasDuplicateQuestIds: boolean
   configData:           RawMapConfig
   previewFestivalId:    string | null
   onPreviewFestivalChange: (id: string | null) => void
+  onPreviewHourChange:  (hour: number | null) => void
   onMapChange:          (id: MapId) => void
   onToolChange:         (t: ToolMode) => void
   onUndo:               () => void
@@ -49,6 +53,8 @@ interface Props {
   onBlockedPathsToggle: () => void
   onAreasToggle:        () => void
   onInteractablesToggle: () => void
+  onExitTilesToggle:    () => void
+  onAnimalAreasToggle:  () => void
   onDrawerToggle:       () => void
   questDefsData:        Record<string, unknown> | null
   onSaved:              () => void
@@ -69,9 +75,9 @@ const TOOLS: { mode: ToolMode; label: string; title: string }[] = [
 ]
 
 export function MapEditorToolbar({
-  mapId, tool, canUndo, canRedo, isDirty, showGrid, showBuildingArt, showQuestItems, showBlockedPaths, showAreas, showInteractables, drawerOpen, hasDuplicateQuestIds,
-  configData, questDefsData, previewFestivalId, onPreviewFestivalChange, onMapChange, onToolChange, onUndo, onRedo,
-  onGridToggle, onBuildingArtToggle, onQuestItemsToggle, onBlockedPathsToggle, onAreasToggle, onInteractablesToggle, onDrawerToggle, onSaved,
+  mapId, tool, canUndo, canRedo, isDirty, showGrid, showBuildingArt, showQuestItems, showBlockedPaths, showAreas, showInteractables, showExitTiles, showAnimalAreas, previewHour, drawerOpen, hasDuplicateQuestIds,
+  configData, questDefsData, previewFestivalId, onPreviewFestivalChange, onPreviewHourChange, onMapChange, onToolChange, onUndo, onRedo,
+  onGridToggle, onBuildingArtToggle, onQuestItemsToggle, onBlockedPathsToggle, onAreasToggle, onInteractablesToggle, onExitTilesToggle, onAnimalAreasToggle, onDrawerToggle, onSaved,
 }: Props) {
   const [saveState, setSaveState] = useState<'idle' | 'saving' | 'ok' | 'error'>('idle')
   const [saveError, setSaveError] = useState('')
@@ -258,6 +264,49 @@ export function MapEditorToolbar({
       >
         ⊡
       </button>
+
+      {/* Exit tiles overlay toggle */}
+      <button
+        title="Toggle exit tiles (warps to other screens)"
+        onClick={onExitTilesToggle}
+        style={{
+          ...btnBase,
+          background:  showExitTiles ? '#0e2a1a' : '#1e1e3e',
+          color:       showExitTiles ? '#44dd88' : '#666',
+          borderColor: showExitTiles ? '#1a7a4a' : '#444',
+        }}
+      >
+        ⇥
+      </button>
+
+      {/* Animal wander-area overlay toggle */}
+      <button
+        title="Toggle animal wander areas"
+        onClick={onAnimalAreasToggle}
+        style={{
+          ...btnBase,
+          background:  showAnimalAreas ? '#2a2a0e' : '#1e1e3e',
+          color:       showAnimalAreas ? '#cccc44' : '#666',
+          borderColor: showAnimalAreas ? '#7a7a1a' : '#444',
+        }}
+      >
+        🐾
+      </button>
+
+      {/* Preview hour control */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 4, marginLeft: 4 }} title="Preview NPC schedule positions at a given hour">
+        <span style={{ fontSize: 11, color: '#888' }}>🕐</span>
+        <input
+          type="number" min={0} max={23}
+          value={previewHour ?? ''}
+          placeholder="off"
+          onChange={e => onPreviewHourChange(e.target.value === '' ? null : Math.max(0, Math.min(23, Number(e.target.value))))}
+          style={{ width: 44, padding: '3px 5px', background: '#111', border: '1px solid #444', color: '#eee', borderRadius: 3, fontSize: 11 }}
+        />
+        {previewHour != null && (
+          <button onClick={() => onPreviewHourChange(null)} title="Clear preview hour" style={{ padding: '2px 6px', background: '#333', border: '1px solid #555', color: '#aaa', cursor: 'pointer', borderRadius: 3, fontSize: 10 }}>✕</button>
+        )}
+      </div>
 
       {/* NPC & Quest drawer toggle */}
       <button

--- a/web/src/components/mapEditor/mapEditorTypes.ts
+++ b/web/src/components/mapEditor/mapEditorTypes.ts
@@ -39,6 +39,12 @@ export interface RawBuildingDoor {
   tx: number
   ty: number
   buildingId?: string
+  /** Hide the door-sign label at runtime (still walkable) — HubTownCanvas.tsx skips drawing the sign when true. */
+  hideSign?: boolean
+  /** Keep this door a fully invisible walk-in trigger (e.g. a hidden side/back
+   *  entrance) instead of rendering door art (always one tile north of the
+   *  entry tile). Doors render by default. */
+  hideSprite?: boolean
 }
 
 export interface RawBuildingWindow {
@@ -51,6 +57,8 @@ export interface RawBuilding {
   rect?: [number, number, number, number]
   rects?: [number, number, number, number][]
   id?: string
+  /** Free-text authoring label — never shown to players, just for editor bookkeeping. */
+  comment?: string
   wall?: WallMaterial
   roof?: RoofMaterial
   bundleID?: string
@@ -152,7 +160,13 @@ export interface RawLockedDoor {
 export interface RawInteractableDecor {
   dx: number
   dy: number
-  tileId: string
+  /** Tile-atlas tile. Mutually exclusive with spriteId/shopArtSlot. */
+  tileId?: string
+  /** web/public/sprites/<spriteId>.svg — a fixed decorative sprite. */
+  spriteId?: string
+  /** Renders today's live shop-stock art for this shop's Nth for-sale slot
+   *  (resolved at runtime from getTodaysShopItems — not previewable in the editor). */
+  shopArtSlot?: number
   zlayer?: string
   glow?: boolean        // emit a night light glow
   glowRadius?: number   // glow radius in tiles

--- a/web/src/components/mapEditor/npcQuestDrawer/AnimalEditor.tsx
+++ b/web/src/components/mapEditor/npcQuestDrawer/AnimalEditor.tsx
@@ -98,9 +98,9 @@ export function AnimalEditor({ animal, onUpdate, onDelete, onPickLocation }: {
         </label>
       </Field>
       {animal.roam && (
-        <Field label="Area Rect (x, y, w, h)">
+        <Field label="Wander Area (dx, dy, w, h — offset from this animal)">
           <div style={{ display: 'flex', gap: 4 }}>
-            {(['x', 'y', 'w', 'h'] as const).map((k, ki) => (
+            {(['dx', 'dy', 'w', 'h'] as const).map((k, ki) => (
               <input
                 key={k}
                 type="number"

--- a/web/src/components/mapEditor/npcQuestDrawer/NpcEditor.tsx
+++ b/web/src/components/mapEditor/npcQuestDrawer/NpcEditor.tsx
@@ -6,7 +6,7 @@ import { SpriteSearchPicker } from '../SpritePicker'
 import { AnimalEditor } from './AnimalEditor'
 import type { MapId } from '../../../data/hub/hubWorldFactory'
 import { EntityRefPicker } from '../EntityRefPicker'
-import { buildingRefOptions, questRefOptions, dialogueTreeRefOptions, type RefOption } from '../entityRefs'
+import { buildingRefOptions, interiorRefOptions, questRefOptions, dialogueTreeRefOptions, type RefOption } from '../entityRefs'
 import { SCREEN_IDS } from '../EntityInspector'
 
 // Screens reachable from an NPC's dialogue: the standard SCREEN_IDS list, plus
@@ -34,6 +34,7 @@ interface Props {
 // Reference options threaded into the NPC sub-editors.
 interface NpcRefOpts {
   buildings: RefOption[]
+  interiors: RefOption[]
   questGive: RefOption[]
   questReceive: RefOption[]
   dialogueTrees: RefOption[]
@@ -74,10 +75,13 @@ const BTN_PICK: React.CSSProperties = {
 
 type ScheduleRow = NonNullable<RawNpc['schedule']>[number]
 
-function ScheduleEditor({ schedule, onChange, buildings }: {
+function ScheduleEditor({ schedule, onChange, interiors }: {
   schedule: ScheduleRow[]
   onChange: (s: ScheduleRow[]) => void
-  buildings: RefOption[]
+  /** Interior room ids (not building ids) — a schedule's interior location is
+   *  matched against configData.interiors keys at runtime, and multi-room
+   *  buildings have extra rooms whose id differs from the building's own id. */
+  interiors: RefOption[]
 }) {
   function update(i: number, partial: Partial<ScheduleRow>) {
     onChange(schedule.map((r, idx) => idx === i ? { ...r, ...partial } as ScheduleRow : r))
@@ -117,7 +121,7 @@ function ScheduleEditor({ schedule, onChange, buildings }: {
             </select>
             {row.location.type === 'interior' && (
               <div style={{ width: 110 }}>
-                <EntityRefPicker value={row.location.buildingId} options={buildings} placeholder="building…"
+                <EntityRefPicker value={row.location.buildingId} options={interiors} placeholder="room…"
                   onChange={v => setLocation(i, { ...row.location, type: 'interior', buildingId: v })} />
               </div>
             )}
@@ -297,7 +301,7 @@ function NpcFullEditor({ npc, opts, onUpdate, onPickLocation }: {
       <Field label="Schedule">
         <ScheduleEditor
           schedule={npc.schedule ?? []}
-          buildings={opts.buildings}
+          interiors={opts.interiors}
           onChange={s => onUpdate({ schedule: s.length > 0 ? s : undefined })}
         />
       </Field>
@@ -339,6 +343,7 @@ export function NpcEditor({
   const localQuests = (questDefsData.quests as Array<{ id: string; title?: string }> | undefined) ?? []
   const refOpts: NpcRefOpts = {
     buildings: buildingRefOptions(mapId, configData.buildings ?? []),
+    interiors: interiorRefOptions(mapId, configData.interiors),
     questGive: questRefOptions(mapId, localQuests, false),     // this NPC gives quests from its own town
     questReceive: questRefOptions(mapId, localQuests, true),   // may receive cross-town deliveries
     dialogueTrees: dialogueTreeRefOptions(mapId, (questDefsData.dialogues as Array<{ id: string }> | undefined) ?? []),

--- a/web/src/components/mapEditor/useMapEditorState.ts
+++ b/web/src/components/mapEditor/useMapEditorState.ts
@@ -560,9 +560,12 @@ export function useMapEditorState(initialMapId: MapId = 'ravenwatch', initialFes
       const id = nextBuildingId(prevConfig.buildings ?? [])
       const rect: [number, number, number, number] = [tx1, ty1, tx2, ty2]
       const doorRelTx = Math.floor((tx2 - tx1) / 2)
+      // Relative to this single-rect building's origin (ox = tx1, oy = ty2), the
+      // south face — the only row that renders a visible door sprite — is at
+      // absolute ty2 + 1, i.e. relative ty = 1 (not 0, which sits on the wall itself).
       const newBuilding: RawBuilding = {
         id, rect, wall: 'brick' as WallMaterial, roof: 'redSlateRoof' as RoofMaterial,
-        doors: [{ tx: doorRelTx, ty: 0 }],
+        doors: [{ tx: doorRelTx, ty: 1 }],
       }
       const buildings = [...(prevConfig.buildings ?? []), newBuilding]
       const width  = Math.max(4, tx2 - tx1 + 1)
@@ -691,30 +694,47 @@ export function useMapEditorState(initialMapId: MapId = 'ravenwatch', initialFes
     })
   }, [])
 
-  const reorderDecor = useCallback((entity: SelectedEntity, direction: 'forward' | 'back') => {
+  const reorderDecor = useCallback((entity: SelectedEntity, direction: 'forward' | 'back' | 'toFront' | 'toBack') => {
     setState(s => {
       const prevConfig = s.configData
       const i = entity.index
-      const swapWith = direction === 'forward' ? i + 1 : i - 1
       let newConfig = prevConfig
 
+      // Moves the item at index `i` to index `dest` within `arr`, preserving the
+      // relative order of everything else (a swap only works for single-step moves).
+      const moveTo = <T,>(arr: T[], dest: number): T[] | null => {
+        if (dest < 0 || dest >= arr.length || dest === i) return null
+        const next = [...arr]
+        const [item] = next.splice(i, 1)
+        next.splice(dest, 0, item)
+        return next
+      }
+      const destOf = (len: number) => {
+        if (direction === 'forward') return i + 1
+        if (direction === 'back') return i - 1
+        if (direction === 'toFront') return len - 1
+        return 0
+      }
+
+      let dest = -1
       if (entity.type === 'exteriorDecor') {
-        const decor = [...(prevConfig.exteriorDecor ?? [])]
-        if (swapWith < 0 || swapWith >= decor.length) return s
-        ;[decor[i], decor[swapWith]] = [decor[swapWith], decor[i]]
+        const arr = prevConfig.exteriorDecor ?? []
+        dest = destOf(arr.length)
+        const decor = moveTo(arr, dest)
+        if (!decor) return s
         newConfig = { ...prevConfig, exteriorDecor: decor }
       } else if (entity.type === 'interiorDecor' && prevConfig.interiors?.[entity.interiorId]) {
         const interior = prevConfig.interiors[entity.interiorId]
-        const decor = [...interior.decor]
-        if (swapWith < 0 || swapWith >= decor.length) return s
-        ;[decor[i], decor[swapWith]] = [decor[swapWith], decor[i]]
+        dest = destOf(interior.decor.length)
+        const decor = moveTo(interior.decor, dest)
+        if (!decor) return s
         newConfig = { ...prevConfig, interiors: { ...prevConfig.interiors, [entity.interiorId]: { ...interior, decor } } }
       } else {
         return s
       }
 
       const newSelected = s.selectedEntities.map(e =>
-        e.type === entity.type && e.index === i ? { ...e, index: swapWith } : e
+        e.type === entity.type && e.index === i ? { ...e, index: dest } : e
       )
       return {
         ...s,

--- a/web/src/data/hub/config.ts
+++ b/web/src/data/hub/config.ts
@@ -341,7 +341,7 @@ export interface RawAnimal {
   questGive?: string
   questReceive?: string | string[]
   roam?: boolean                     // default false for placed animals
-  areaRect?: number[]  // [tx, ty, w, h] roam bounds (JSON infers number[])
+  areaRect?: number[]  // [dx, dy, w, h] roam bounds, relative to this animal's own (tx, ty) (JSON infers number[])
   dialogueTree?: string              // id of a branching dialogue tree (questDefs.json `dialogues`)
 }
 

--- a/web/src/data/hub/hubWorldFactory.ts
+++ b/web/src/data/hub/hubWorldFactory.ts
@@ -75,6 +75,9 @@ export interface RawQuestPickupItem {
   tx: number
   ty: number
   tileId: string
+  /** Extra visual-only tiles offset from (tx, ty) — e.g. a lantern split across
+   *  a top/bottom tile pair. Share the primary tile's collection/visibility. */
+  extraTiles?: Array<{ dx: number; dy: number; tileId: string }>
   questId?: string
   building?: string
   chain?: string

--- a/web/src/data/hub/loader.ts
+++ b/web/src/data/hub/loader.ts
@@ -85,6 +85,9 @@ export interface HubDoor {
   tx: number
   ty: number
   hideSign?: boolean
+  /** Keep this door a fully invisible walk-in trigger. Doors render by default
+   *  (one tile north of the entry tile). */
+  hideSprite?: boolean
 }
 
 export interface DecorGlow {
@@ -205,6 +208,7 @@ export interface HubPickupItem extends DecorGlow {
   tx: number
   ty: number
   tileId: number
+  extraTiles?: Array<{ dx: number; dy: number; tileId: number }>
   building?: string
   questId?: string
   chain?: string
@@ -458,7 +462,7 @@ type RawBuilding = {
   bundleID?: string;
   upgradeKind?: string;
   requiresOwnership?: boolean;
-  doors?:   Array<{ tx: number; ty: number; buildingId?: string, hideSign?: boolean }>
+  doors?:   Array<{ tx: number; ty: number; buildingId?: string, hideSign?: boolean, hideSprite?: boolean }>
   windows?: Array<{ tx: number; ty: number; tileId: string }>
   decor?:   Array<{ tx: number; ty: number; tileId?: string; bundleID?: string; zlayer?: string }>
   levelDecor?: Array<{ tx?: number; ty?: number; tileId?: string; zlayer?: string; minLevel?: number; hideAtLevel?: number }>
@@ -518,10 +522,10 @@ for (const b of rawConfig.buildings as RawBuilding[]) {
     continue
   }
   for (const d of b.doors ?? []) {
-    // The authored position is used as-is: doors on a building's south face
-    // (ty2+1) get a rendered sprite (see buildingRender.ts); doors elsewhere
-    // are invisible walk-in triggers only. No position snapping.
-    _nestedDoors.push({ buildingId: d.buildingId ?? b.id ?? '', tx: ox + d.tx, ty: oy + d.ty, hideSign: d.hideSign })
+    // The authored position is used as-is, anywhere relative to the building —
+    // the door sprite always renders one tile north of it (see
+    // buildingRender.ts) unless hideSprite keeps it a fully invisible trigger.
+    _nestedDoors.push({ buildingId: d.buildingId ?? b.id ?? '', tx: ox + d.tx, ty: oy + d.ty, hideSign: d.hideSign, hideSprite: d.hideSprite })
   }
   for (const w of b.windows ?? [])
     _nestedWindows.push({ tx: ox + w.tx, ty: oy + w.ty, tileId: resolveTileId(w.tileId) })
@@ -824,7 +828,7 @@ const HUB_BLOCKED_PATHS: BlockedPath[] = (
   cleared:               resolveBlockedPathState(bp.cleared),
 }))
 
-type RawPickup = { id: string; tx: number; ty: number; tileId: string; building?: string; questId?: string; chain?: string; requireTouch?: boolean; glow?: boolean; glowRadius?: number; pulse?: boolean }
+type RawPickup = { id: string; tx: number; ty: number; tileId: string; extraTiles?: Array<{ dx: number; dy: number; tileId: string }>; building?: string; questId?: string; chain?: string; requireTouch?: boolean; glow?: boolean; glowRadius?: number; pulse?: boolean }
 const HUB_PICKUP_ITEMS: HubPickupItem[] = (
   (rawQuestConfig as unknown as { pickupItems?: RawPickup[] }).pickupItems ?? []
 ).map(p => ({
@@ -832,6 +836,7 @@ const HUB_PICKUP_ITEMS: HubPickupItem[] = (
   tx:           p.tx,
   ty:           p.ty,
   tileId:       resolveTileId(p.tileId),
+  extraTiles:   p.extraTiles?.map(t => ({ dx: t.dx, dy: t.dy, tileId: resolveTileId(t.tileId) })),
   building:     p.building,
   questId:      p.questId,
   chain:        p.chain,

--- a/web/src/data/hub/millhaven/config.json
+++ b/web/src/data/hub/millhaven/config.json
@@ -1596,6 +1596,28 @@
             "tx": 23,
             "ty": 13
           }
+        },
+        {
+          "startHour": 20,
+          "endHour": 24,
+          "location": {
+            "type": "interior",
+            "buildingId": "inn-millhaven",
+            "tx": 5,
+            "ty": 3
+          },
+          "activity": "eat"
+        },
+        {
+          "startHour": 0,
+          "endHour": 6,
+          "location": {
+            "type": "interior",
+            "buildingId": "fishmonger",
+            "tx": 5,
+            "ty": 3
+          },
+          "activity": "sleep"
         }
       ],
       "favoriteGiftItemId": "fish-trophy",
@@ -3060,8 +3082,8 @@
     {
       "id": "kipper",
       "type": "cat",
-      "tx": 17,
-      "ty": 14,
+      "tx": 18,
+      "ty": 15,
       "variant": "orange",
       "name": "Kipper",
       "dialogue": [
@@ -3069,10 +3091,10 @@
       ],
       "roam": true,
       "areaRect": [
-        0,
-        0,
+        -5,
+        -5,
         10,
-        10
+        11
       ],
       "questGive": "kippers-kipper",
       "dialogueTree": "kipper-truth"

--- a/web/src/data/hub/ravenwatch/config.json
+++ b/web/src/data/hub/ravenwatch/config.json
@@ -340,22 +340,22 @@
   "exitTiles": [
     {
       "tx": 36,
-      "ty": 67,
+      "ty": 69,
       "screen": "worldmap"
     },
     {
       "tx": 37,
-      "ty": 67,
+      "ty": 69,
       "screen": "worldmap"
     },
     {
       "tx": 38,
-      "ty": 67,
+      "ty": 69,
       "screen": "worldmap"
     },
     {
       "tx": 39,
-      "ty": 67,
+      "ty": 69,
       "screen": "worldmap"
     }
   ],
@@ -1137,17 +1137,17 @@
     {
       "rect": [
         39,
-        66,
+        65,
         40,
-        66
+        65
       ]
     },
     {
       "rect": [
         34,
-        66,
+        65,
         35,
-        66
+        65
       ]
     },
     {
@@ -2089,8 +2089,10 @@
       "doors": [
         {
           "tx": 6,
-          "ty": 0,
-          "buildingId": "town-hall"
+          "ty": -1,
+          "buildingId": "town-hall",
+          "tyAdjust": 1,
+          "hideSign": true
         }
       ],
       "windows": [
@@ -2380,9 +2382,11 @@
       "roof": "greySlateRoof",
       "doors": [
         {
-          "tx": 34,
-          "ty": 1,
-          "buildingId": "gatehouse-west"
+          "tx": 35,
+          "ty": -1,
+          "buildingId": "gatehouse-west",
+          "hideSign": true,
+          "hideSprite": true
         }
       ],
       "decor": [
@@ -2520,9 +2524,11 @@
       "roof": "greySlateRoof",
       "doors": [
         {
-          "tx": 0,
-          "ty": 1,
-          "buildingId": "gatehouse-east"
+          "tx": -1,
+          "ty": -1,
+          "buildingId": "gatehouse-east",
+          "hideSign": true,
+          "hideSprite": true
         }
       ],
       "decor": [
@@ -2660,8 +2666,8 @@
       "roof": "strawRoof",
       "doors": [
         {
-          "tx": 2,
-          "ty": -1
+          "tx": 3,
+          "ty": 1
         }
       ],
       "windows": [
@@ -2697,7 +2703,8 @@
           "zlayer": "solid"
         }
       ],
-      "requiresOwnership": true
+      "requiresOwnership": true,
+      "comment": "Lakeside Cottage"
     }
   ],
   "exteriorDecor": [
@@ -2939,7 +2946,8 @@
     {
       "tx": 46,
       "ty": 2,
-      "bundleID": "dark-tree"
+      "bundleID": "dark-tree",
+      "zlayer": "above"
     },
     {
       "tx": 68,
@@ -2959,11 +2967,6 @@
     {
       "tx": 61,
       "ty": 7,
-      "bundleID": "dark-tree"
-    },
-    {
-      "tx": 52,
-      "ty": 9,
       "bundleID": "dark-tree"
     },
     {
@@ -3028,6 +3031,12 @@
       "tx": 35,
       "ty": 32,
       "tileId": "darkTreeColumnRight"
+    },
+    {
+      "tx": 48,
+      "ty": 4,
+      "bundleID": "dark-tree",
+      "zlayer": "above"
     },
     {
       "tx": 34,
@@ -4377,37 +4386,37 @@
       "tx": 46,
       "ty": 3,
       "bundleID": "light-tree",
-      "zlayer": "solid"
+      "zlayer": "above"
     },
     {
       "tx": 46,
       "ty": 4,
       "bundleID": "dark-tree",
-      "zlayer": "solid"
+      "zlayer": "above"
     },
     {
       "tx": 46,
       "ty": 5,
       "bundleID": "light-tree",
-      "zlayer": "solid"
+      "zlayer": "above"
     },
     {
       "tx": 46,
       "ty": 6,
       "bundleID": "dark-tree",
-      "zlayer": "solid"
+      "zlayer": "above"
     },
     {
       "tx": 46,
       "ty": 7,
       "bundleID": "light-tree",
-      "zlayer": "solid"
+      "zlayer": "above"
     },
     {
       "tx": 46,
       "ty": 8,
       "bundleID": "dark-tree",
-      "zlayer": "solid"
+      "zlayer": "above"
     },
     {
       "tx": 63,
@@ -4470,6 +4479,12 @@
       "zlayer": "solid"
     },
     {
+      "tx": 49,
+      "ty": 4,
+      "tileId": "stoneWallTopBotton",
+      "zlayer": "solid"
+    },
+    {
       "tx": 62,
       "ty": 8,
       "tileId": "stoneWallLeftRight",
@@ -4527,7 +4542,7 @@
       "tx": 54,
       "ty": 9,
       "tileId": "darkBush",
-      "zlayer": "solid"
+      "zlayer": "below"
     },
     {
       "tx": 60,
@@ -4779,43 +4794,43 @@
       "tx": 44,
       "ty": 8,
       "bundleID": "light-tree",
-      "zlayer": "solid"
+      "zlayer": "above"
     },
     {
       "tx": 44,
       "ty": 2,
       "bundleID": "light-tree",
-      "zlayer": "solid"
+      "zlayer": "above"
     },
     {
       "tx": 44,
       "ty": 3,
       "bundleID": "dark-tree",
-      "zlayer": "solid"
+      "zlayer": "above"
     },
     {
       "tx": 44,
       "ty": 4,
       "bundleID": "light-tree",
-      "zlayer": "solid"
+      "zlayer": "above"
     },
     {
       "tx": 44,
       "ty": 5,
       "bundleID": "dark-tree",
-      "zlayer": "solid"
+      "zlayer": "above"
     },
     {
       "tx": 44,
       "ty": 6,
       "bundleID": "light-tree",
-      "zlayer": "solid"
+      "zlayer": "above"
     },
     {
       "tx": 44,
       "ty": 7,
       "bundleID": "dark-tree",
-      "zlayer": "solid"
+      "zlayer": "above"
     },
     {
       "tx": 51,
@@ -4850,12 +4865,6 @@
     {
       "tx": 49,
       "ty": 5,
-      "tileId": "stoneWallTopBotton",
-      "zlayer": "solid"
-    },
-    {
-      "tx": 49,
-      "ty": 4,
       "tileId": "stoneWallTopBotton",
       "zlayer": "solid"
     },
@@ -4981,7 +4990,7 @@
     },
     {
       "tx": 22,
-      "ty": 26,
+      "ty": 27,
       "bundleID": "dark-tree",
       "zlayer": "solid"
     },
@@ -5073,66 +5082,60 @@
       "tx": 52,
       "ty": 10,
       "bundleID": "light-tree",
-      "zlayer": "solid"
+      "zlayer": "above"
     },
     {
       "tx": 50,
       "ty": 10,
       "bundleID": "dark-tree",
-      "zlayer": "solid"
+      "zlayer": "above"
     },
     {
-      "tx": 50,
-      "ty": 9,
+      "tx": 48,
+      "ty": 6,
       "bundleID": "light-tree",
-      "zlayer": "solid"
+      "zlayer": "above"
     },
     {
       "tx": 48,
       "ty": 10,
       "bundleID": "light-tree",
-      "zlayer": "solid"
+      "zlayer": "above"
     },
     {
       "tx": 48,
-      "ty": 9,
+      "ty": 8,
       "bundleID": "dark-tree",
-      "zlayer": "solid"
+      "zlayer": "above"
     },
     {
       "tx": 46,
       "ty": 9,
       "bundleID": "light-tree",
-      "zlayer": "solid"
+      "zlayer": "above"
     },
     {
       "tx": 46,
       "ty": 10,
       "bundleID": "dark-tree",
-      "zlayer": "solid"
+      "zlayer": "above"
     },
     {
       "tx": 44,
       "ty": 9,
       "bundleID": "dark-tree",
-      "zlayer": "solid"
+      "zlayer": "above"
     },
     {
       "tx": 44,
       "ty": 10,
       "bundleID": "light-tree",
-      "zlayer": "solid"
+      "zlayer": "above"
     },
     {
       "tx": 53,
       "ty": 18,
       "tileId": "mushroomBasket",
-      "zlayer": "solid"
-    },
-    {
-      "tx": 52,
-      "ty": 18,
-      "tileId": "crate",
       "zlayer": "solid"
     },
     {
@@ -8477,10 +8480,23 @@
     },
     "card-shop-bldg-1": {
       "name": "Stock Room",
-      "width": 11,
+      "width": 13,
       "height": 8,
       "floorTileId": "woodFloor",
-      "decor": [],
+      "decor": [
+        {
+          "tx": 1,
+          "ty": 3,
+          "bundleID": "simple-bed",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 1,
+          "ty": 3,
+          "bundleID": "simple-bed",
+          "zlayer": "solid"
+        }
+      ],
       "exits": [
         {
           "tx": 5,
@@ -9036,8 +9052,8 @@
       "name": "Gildwyn",
       "sprite": "hub-npc-card-shop",
       "building": "card-shop",
-      "tx": 6,
-      "ty": 3,
+      "tx": 4,
+      "ty": 5,
       "screen": "shop-cards",
       "dialogue": [
         "Welcome to my emporium! Finest cards in the realm.",
@@ -9086,8 +9102,8 @@
       "name": "Vorn",
       "sprite": "hub-npc-vorn",
       "building": "card-shop",
-      "tx": 6,
-      "ty": 3,
+      "tx": 8,
+      "ty": 5,
       "screen": "shop-cards",
       "dialogue": [
         "I only come out at night. And I only deal in the extraordinary.",
@@ -9112,8 +9128,8 @@
           "activity": "sleep",
           "location": {
             "type": "interior",
-            "buildingId": "inn-building-upstairs",
-            "tx": 6,
+            "buildingId": "card-shop-bldg",
+            "tx": 1,
             "ty": 1
           }
         }
@@ -9134,8 +9150,8 @@
       "name": "Mira the Enchantress",
       "sprite": "hub-npc-augment-shop",
       "building": "augment-shop",
-      "tx": 3,
-      "ty": 1,
+      "tx": 7,
+      "ty": 5,
       "screen": "shop-augments",
       "dialogue": [
         "Enchantments can turn the tide of battle. Let me show you.",
@@ -10492,7 +10508,7 @@
     {
       "id": "ravenwatch-secret-pond-note",
       "tx": 54,
-      "ty": 52,
+      "ty": 51,
       "reactions": [
         {
           "type": "dialogue",
@@ -10601,8 +10617,8 @@
     },
     {
       "id": "card-shop-item-0",
-      "tx": 12,
-      "ty": 4,
+      "tx": 2,
+      "ty": 6,
       "building": "card-shop",
       "decor": [
         {
@@ -10620,8 +10636,8 @@
     },
     {
       "id": "card-shop-item-1",
-      "tx": 12,
-      "ty": 5,
+      "tx": 10,
+      "ty": 4,
       "building": "card-shop",
       "decor": [
         {
@@ -10639,7 +10655,7 @@
     },
     {
       "id": "card-shop-item-2",
-      "tx": 12,
+      "tx": 10,
       "ty": 6,
       "building": "card-shop",
       "decor": [
@@ -10658,8 +10674,8 @@
     },
     {
       "id": "card-shop-pack",
-      "tx": 12,
-      "ty": 7,
+      "tx": 2,
+      "ty": 4,
       "building": "card-shop",
       "decor": [
         {
@@ -10676,8 +10692,8 @@
     },
     {
       "id": "augment-shop-item-0",
-      "tx": 8,
-      "ty": 4,
+      "tx": 3,
+      "ty": 2,
       "building": "augment-shop",
       "decor": [
         {
@@ -10829,8 +10845,8 @@
     },
     {
       "id": "interactable-1783854145276",
-      "tx": 34,
-      "ty": 15,
+      "tx": 39,
+      "ty": 13,
       "decor": [
         {
           "dx": 0,
@@ -10841,6 +10857,25 @@
       "reactions": [
         {
           "type": "forage"
+        }
+      ]
+    },
+    {
+      "id": "interactable-1783855868980",
+      "tx": 52,
+      "ty": 18,
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "tileId": "crate",
+          "zlayer": "solid"
+        }
+      ],
+      "reactions": [
+        {
+          "type": "dialogue",
+          "text": "What's in the box?"
         }
       ]
     }

--- a/web/src/data/tiles/buildingRender.ts
+++ b/web/src/data/tiles/buildingRender.ts
@@ -7,12 +7,16 @@
 import { WALL_TILES, ROOF_TILES, ROOF_ROWS, getWallTile } from './buildingMaterials'
 import type { WallMaterial, RoofMaterial } from './buildingMaterials'
 
-/** A door tile, in absolute tile coords. Only doors sitting at `rect.y2 + 1`
- *  (the south face) get a rendered sprite; doors elsewhere are invisible
- *  walk-in triggers only (see the door-pass skip check below). */
+/** A door tile, in absolute tile coords — `(tx, ty)` is the player's walk-in
+ *  trigger tile. The door sprite always renders one tile north (up) of that,
+ *  for any door whose tx falls within a rect's horizontal span (used only to
+ *  pick the matching wall's door-tile art). Set `hideSprite` for a door that
+ *  should stay a fully invisible walk-in trigger (e.g. a hidden side/back
+ *  entrance). */
 export interface BuildingDoorTile {
   tx: number
   ty: number
+  hideSprite?: boolean
 }
 
 /**
@@ -62,13 +66,17 @@ export function placeBuildingTiles(
     }
   }
 
-  // Door pass — south-facing doors, inserted after wall tiles so they overdraw
+  // Door pass — inserted after wall tiles so they overdraw. Anchored on the
+  // door's own tile (its walk-in trigger), not the rect's south edge, so a
+  // door can sit anywhere relative to the building (e.g. above a flight of
+  // steps) and still render — matching tx to this rect only picks which
+  // wall's door art to use.
   const wallTiles = WALL_TILES[wall]
   for (const door of doors) {
-    if (door.ty !== y2 + 1 || door.tx < x1 || door.tx > x2) continue
-    place(wallTiles.doorArchTop, door.tx, y2 - 1)
-    place(wallTiles.doorTop,     door.tx, y2 - 1)
-    place(wallTiles.doorBottom,  door.tx, y2 - 0)
+    if (door.hideSprite || door.tx < x1 || door.tx > x2) continue
+    place(wallTiles.doorArchTop, door.tx, door.ty - 2)
+    place(wallTiles.doorTop,     door.tx, door.ty - 2)
+    place(wallTiles.doorBottom,  door.tx, door.ty - 1)
   }
 
   return placements


### PR DESCRIPTION
## Summary
- Toggleable exit-tile and animal wander-area overlays on the editor canvas
- Multi-tile pickup items (`extraTiles`) so split-sprite pickups (e.g. the midsummer lantern) render both halves — applied to the Ravenwatch lantern chain
- Preview NPC positions at a chosen hour, including inside buildings, using existing `schedule` data
- Building doors can be placed anywhere relative to the building (not just the south face), dragged to reposition, listed/edited/deleted from the building inspector, and toggled between a visible sprite or a hidden trigger-only entrance
- Windows placeable via a dedicated toolbar tool
- Interactables/NPCs inside building interiors are now selectable and open their own inspector panel instead of falling through to the generic interior overview
- Interactable decor entries using `shopArtSlot`/`spriteId` render placeholder markers instead of silently resolving to the wrong tile
- NPC inspector gains an editable **Screen** field and an editable **Schedule** list (add/remove entries, exterior/interior location, activity)
- Decor **Draw Order** control now shows the item's current layer position live and adds Bring to Front / Push to Back buttons alongside step forward/back
- Map editor Save no longer triggers a full page reload, preserving view/selection state

## Test plan
- [x] `npx tsc --noEmit -p .` clean (only pre-existing unrelated `HubWeather` casing error)
- [x] Loaded the Millhaven map editor story in Storybook, no console errors
- [x] Clicked an NPC, confirmed Screen field and Schedule editor render with existing data
- [x] Verified door repositioning/visibility fix against the Ravenwatch town hall regression (door now renders relative to its own trigger tile, matching original staircase alignment)
- [x] Verified interactable/NPC selection inside interiors reaches its own inspector panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)