### PR TITLE
Map editor: NPC drag-during-preview edits schedule; chicken pens share wander-area toggle

### DIFF
--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -45,7 +45,7 @@ import { TreasureModal } from './TreasureModal'
 import { getCollectedTreasureIds, markTreasureCollected } from '../../game/hub/treasures'
 import { useHubClock } from '../../hooks/useHubClock'
 import { formatGameTime, hourInRange } from '../../game/hub/hubClock'
-import { getActiveFestival } from '../../game/hub/hubCalendar'
+import { Festival, getActiveFestival } from '../../game/hub/hubCalendar'
 import { getDailyChallengeNPCDialogue, getMiniGameChallengeNPCDialogue } from '../../game/hub/npcDialogue'
 import {  ALL_QUESTS, FRIENDSHIP_DIALOGUE, RELATIONSHIP_DIALOGUE, RAVENWATCH } from '../../data/hub/hubWorldFactory'
 import { HubInteractable, HubLocationBundle, HubQuestBundle, HubTreasure, HubNpc } from '../../data/hub/loader'
@@ -1981,42 +1981,8 @@ function hasOfferableQuest(giverId: string): boolean {
   }
 
   return (
-    <OverlayScreen title={`🏠 ${locationData.HUB_TOWN_NAME}`}>
-      <Toolbar>
-          <ToolbarLabel className={`title-deck-info${wrongSave ? ' title-deck-info--glitch' : ''}`}>💎 {wrongSave ? wrongSave.crystals.toLocaleString() : crystals.toLocaleString()}</ToolbarLabel>
-          <ToolbarLabel className={`title-deck-info${wrongSave ? ' title-deck-info--glitch' : ''}`}>🃏 {wrongSave ? wrongSave.cards : collectionCount}/{catalogTotal}</ToolbarLabel>
-          <ToolbarLabel className="title-deck-info">{isGameNight ? '🌙' : '☀️'} {formatGameTime()}</ToolbarLabel>
-          {activeFestival && (
-            <ToolbarLabel className="title-deck-info">{activeFestival.icon} {activeFestival.name}</ToolbarLabel>
-          )}
-        <ToolbarButton icon="📋" title="Menu" onClick={() => setTabbedModalOpen(true)} />
-        <ToolbarButton icon="🗺" title="World Map" onClick={() => onWorldMap?.()}  disabled={getQuestState('thorin-the-last-watch').status !== 'completed'} />
-
-        <ToolbarSpacer/>
-        <div className="toolbar-overflow-inline">
-        <LoginButton onSignIn={() => onLoginToggle?.()} onSignOut={() => onSignOut?.()} onPlayerTap={onPlayerTap} user={user} playerName={playerName} />
-        <ToolbarButton
-          className="title-auth-btn"
-          onClick={onFeedback}
-          title="Send feedback or report a bug"
-          icon={'🗣️'}
-        />
-        <ToolbarButton className="action-btn hub-hud__btn" onClick={onBack} icon={'⚙'}/>          
-        </div>
-        <div className="toolbar-overflow-dropdown">
-          <ToolbarDropdown label="📊" align="right">
-        <LoginButton onSignIn={() => onLoginToggle?.()} onSignOut={() => onSignOut?.()} onPlayerTap={onPlayerTap} user={user} playerName={playerName} />
-        <ToolbarButton
-          className="title-auth-btn"
-          onClick={onFeedback}
-          title="Send feedback or report a bug"
-          icon={'🗣️'}
-        />
-        <ToolbarButton className="action-btn hub-hud__btn" onClick={onBack} icon={'⚙'}/>          </ToolbarDropdown>
-        </div>
-
-
-      </Toolbar>
+    <OverlayScreen title={`🏠 ${locationData.HUB_TOWN_NAME}`} right={activeFestival && `${activeFestival.icon} ${activeFestival.name}`}>
+      {HubWorldToolbar(wrongSave, crystals, collectionCount, catalogTotal, isGameNight,  setTabbedModalOpen, onWorldMap, onLoginToggle, onSignOut, onPlayerTap, user, playerName, onFeedback, onBack)}
 
       <div
         className="nm-map nm-map--camp"
@@ -2144,3 +2110,36 @@ function hasOfferableQuest(giverId: string): boolean {
   )
 }
 
+
+function HubWorldToolbar(wrongSave: { cards: number; crystals: number; deck: number } | null, crystals: number, collectionCount: number, catalogTotal: number, isGameNight: boolean,  setTabbedModalOpen: React.Dispatch<React.SetStateAction<boolean>>, onWorldMap: (() => void) | undefined, onLoginToggle: (() => void) | undefined, onSignOut: (() => void) | undefined, onPlayerTap: (() => void) | undefined, user: User | null, playerName: string, onFeedback: () => void, onBack: () => void) {
+  return <Toolbar>
+    <ToolbarLabel className={`title-deck-info${wrongSave ? ' title-deck-info--glitch' : ''}`}>💎 {wrongSave ? wrongSave.crystals.toLocaleString() : crystals.toLocaleString()}</ToolbarLabel>
+    <ToolbarLabel className={`title-deck-info${wrongSave ? ' title-deck-info--glitch' : ''}`}>🃏 {wrongSave ? wrongSave.cards : collectionCount}/{catalogTotal}</ToolbarLabel>
+    <ToolbarLabel className="title-deck-info">{isGameNight ? '🌙' : '☀️'} {formatGameTime()}</ToolbarLabel>
+    <ToolbarButton icon="📋" title="Menu" onClick={() => setTabbedModalOpen(true)} />
+    <ToolbarButton icon="🗺" title="World Map" onClick={() => onWorldMap?.()} disabled={getQuestState('thorin-the-last-watch').status !== 'completed'} />
+
+    <ToolbarSpacer />
+    <div className="toolbar-overflow-inline">
+      <LoginButton onSignIn={() => onLoginToggle?.()} onSignOut={() => onSignOut?.()} onPlayerTap={onPlayerTap} user={user} playerName={playerName} />
+      <ToolbarButton
+        className="title-auth-btn"
+        onClick={onFeedback}
+        title="Send feedback or report a bug"
+        icon={'🗣️'} />
+      <ToolbarButton className="action-btn hub-hud__btn" onClick={onBack} icon={'⚙'} />
+    </div>
+    <div className="toolbar-overflow-dropdown">
+      <ToolbarDropdown label="📊" align="right">
+        <LoginButton onSignIn={() => onLoginToggle?.()} onSignOut={() => onSignOut?.()} onPlayerTap={onPlayerTap} user={user} playerName={playerName} />
+        <ToolbarButton
+          className="title-auth-btn"
+          onClick={onFeedback}
+          title="Send feedback or report a bug"
+          icon={'🗣️'} />
+        <ToolbarButton className="action-btn hub-hud__btn" onClick={onBack} icon={'⚙'} />          </ToolbarDropdown>
+    </div>
+
+
+  </Toolbar>
+}

--- a/web/src/components/mapEditor/MapEditor.tsx
+++ b/web/src/components/mapEditor/MapEditor.tsx
@@ -13,6 +13,7 @@ import { NpcQuestDrawer } from './npcQuestDrawer/NpcQuestDrawer'
 import type { DrawerTab } from './npcQuestDrawer/npcQuestDrawerTypes'
 import { appendBundle } from '../../data/bundles/bundleEditorApi'
 import type { BundleTileRaw } from '../../data/bundles/bundleEditorApi'
+import { getScheduledEntryIndex } from './npcSchedulePreview'
 
 
 interface Props {
@@ -107,7 +108,13 @@ export function MapEditor({ initialMapId = 'ravenwatch', initialFestival = undef
   // Intercept pickupItem moves/deletes to update questDefsData instead of configData
   const handleMoveEntities = useCallback((moves: { entity: SelectedEntity; tx: number; ty: number }[]) => {
     const pickupMoves = moves.filter(m => m.entity.type === 'pickupItem')
-    const otherMoves  = moves.filter(m => m.entity.type !== 'pickupItem')
+    // While previewing a specific hour, dragging a scheduled NPC should edit
+    // whichever schedule entry is active at that hour (not its static tx/ty) —
+    // otherwise the drag silently edits a position the preview isn't even
+    // showing. NPCs with no matching entry for this hour fall through to the
+    // normal static move, same as when no hour is being previewed.
+    const npcMoves = previewHour != null ? moves.filter(m => m.entity.type === 'npc') : []
+    const otherMoves = moves.filter(m => m.entity.type !== 'pickupItem' && !npcMoves.includes(m))
     if (pickupMoves.length > 0) {
       setQuestDefsData(prev => {
         if (!prev) return prev
@@ -119,8 +126,24 @@ export function MapEditor({ initialMapId = 'ravenwatch', initialFestival = undef
         return { ...prev, pickupItems: items }
       })
     }
-    if (otherMoves.length > 0) moveEntities(otherMoves)
-  }, [moveEntities])
+    const staticMoves: typeof moves = []
+    for (const move of npcMoves) {
+      const npc = state.configData.npcs?.[move.entity.index]
+      const entryIdx = npc ? getScheduledEntryIndex(npc, previewHour!) : -1
+      if (!npc || entryIdx === -1) {
+        staticMoves.push(move)
+        continue
+      }
+      const entry = npc.schedule![entryIdx]
+      const location = entry.location.type === 'interior'
+        ? { ...entry.location, tx: move.tx, ty: move.ty }
+        : { type: 'exterior' as const, tx: move.tx, ty: move.ty }
+      updateNpc(move.entity.index, {
+        schedule: npc.schedule!.map((e, i) => i === entryIdx ? { ...e, location } : e),
+      })
+    }
+    if (otherMoves.length > 0 || staticMoves.length > 0) moveEntities([...otherMoves, ...staticMoves])
+  }, [moveEntities, previewHour, state.configData.npcs, updateNpc])
 
   const handleDeleteEntities = useCallback((entities: SelectedEntity[]) => {
     const pickups = entities.filter(e => e.type === 'pickupItem')

--- a/web/src/components/mapEditor/MapEditorCanvas.tsx
+++ b/web/src/components/mapEditor/MapEditorCanvas.tsx
@@ -4,7 +4,6 @@ import { usePixiApp } from '../../hooks/usePixiApp'
 import { loadTileRef, loadSpriteTexture } from '../../utils/pixiHelpers'
 import { BASE_CHIP_TILES } from '../../data/tiles/baseChipIndex'
 import type { RawMapConfig, RawDecorItem, RawBlockedPath, RawLockedDoor, RawNpc, SelectedEntity, ToolMode, Zlayer } from './mapEditorTypes'
-import { hourInRange } from '../../game/hub/hubClock'
 import { resolveVariantTint, AnimalType } from '../../game/hub/animals'
 import { WALL_TILES } from '../../data/tiles/buildingMaterials'
 import type { WallMaterial, RoofMaterial } from '../../data/tiles/buildingMaterials'
@@ -15,20 +14,10 @@ import { expandBundleDecor } from '../../data/bundles/bundleLoader'
 import { RawQuestPickupItem } from '../../data/hub/hubWorldFactory'
 import { resolveNpcSprite } from './spriteList'
 import { isSameEntityRef } from './multiSelectHelpers'
+import { getScheduledLocation } from './npcSchedulePreview'
 
 const T           = 32
 const INTERIOR_PAD = 10  // tiles of surrounding space around active room in interior view
-
-/** Where a scheduled NPC would be at `hour` — mirrors getNpcLocation in
- *  web/src/game/hub/hubNpcSchedule.ts, reimplemented against the editor's
- *  RawNpc (structurally close to HubNpc but not identical) to avoid a cast. */
-function getScheduledLocation(npc: RawNpc, hour: number): NonNullable<RawNpc['schedule']>[number]['location'] | null {
-  if (!npc.schedule?.length) return null
-  for (const entry of npc.schedule) {
-    if (hourInRange(hour, entry.startHour, entry.endHour)) return entry.location
-  }
-  return null
-}
 
 const WALL_COLORS: Record<string, number> = {
   brick:               0x8b5e4a,
@@ -406,7 +395,7 @@ export function MapEditorCanvas(props: Props) {
     if (!isInterior && !isBuilding && showAreas) {
       renderAreasOverlay(questLayer, selLayer)
     }
-    if (!isInterior && !isBuilding) {
+    if (!isInterior && !isBuilding && showAnimalAreas) {
       renderChickenZonesOverlay(questLayer, selLayer)
     }
     if (!isBuilding && showInteractables) {
@@ -1399,7 +1388,8 @@ export function MapEditorCanvas(props: Props) {
     })
   }
 
-  // ── Chicken zones overlay (always visible in exterior) ─────────────────────────
+  // ── Chicken zones overlay (a pen rect chickens wander within — shown behind
+  //    the same toggle as cat/dog wander areas, since it's the same concept) ──
   function renderChickenZonesOverlay(layer: PIXI.Container, selLayer: PIXI.Graphics) {
     ;(propsRef.current.configData.chickenZones ?? []).forEach((zone, zIdx) => {
       const isSel = isEntitySelected({ type: 'chickenZone', index: zIdx })

--- a/web/src/components/mapEditor/MapEditorToolbar.tsx
+++ b/web/src/components/mapEditor/MapEditorToolbar.tsx
@@ -279,9 +279,9 @@ export function MapEditorToolbar({
         ⇥
       </button>
 
-      {/* Animal wander-area overlay toggle */}
+      {/* Animal wander-area overlay toggle (also covers chicken pen zones) */}
       <button
-        title="Toggle animal wander areas"
+        title="Toggle wander areas (cats/dogs + chicken pens)"
         onClick={onAnimalAreasToggle}
         style={{
           ...btnBase,

--- a/web/src/components/mapEditor/npcSchedulePreview.ts
+++ b/web/src/components/mapEditor/npcSchedulePreview.ts
@@ -1,0 +1,19 @@
+import { hourInRange } from '../../game/hub/hubClock'
+import type { RawNpc } from './mapEditorTypes'
+
+type ScheduleEntry = NonNullable<RawNpc['schedule']>[number]
+
+/** Index of the schedule entry active at `hour`, or -1 if the NPC has no
+ *  schedule or none of its entries cover that hour (static tx/ty applies). */
+export function getScheduledEntryIndex(npc: RawNpc, hour: number): number {
+  if (!npc.schedule?.length) return -1
+  return npc.schedule.findIndex(entry => hourInRange(hour, entry.startHour, entry.endHour))
+}
+
+/** Where a scheduled NPC would be at `hour` — mirrors getNpcLocation in
+ *  web/src/game/hub/hubNpcSchedule.ts, reimplemented against the editor's
+ *  RawNpc (structurally close to HubNpc but not identical) to avoid a cast. */
+export function getScheduledLocation(npc: RawNpc, hour: number): ScheduleEntry['location'] | null {
+  const i = getScheduledEntryIndex(npc, hour)
+  return i === -1 ? null : npc.schedule![i].location
+}

--- a/web/src/data/hub/millhaven/config.json
+++ b/web/src/data/hub/millhaven/config.json
@@ -1592,18 +1592,19 @@
           "endHour": 20,
           "activity": "work",
           "location": {
-            "type": "exterior",
-            "tx": 23,
-            "ty": 13
+            "type": "interior",
+            "buildingId": "fishmonger",
+            "tx": 5,
+            "ty": 3
           }
         },
         {
           "startHour": 20,
-          "endHour": 24,
+          "endHour": 0,
           "location": {
             "type": "interior",
             "buildingId": "inn-millhaven",
-            "tx": 5,
+            "tx": 9,
             "ty": 3
           },
           "activity": "eat"
@@ -1613,9 +1614,9 @@
           "endHour": 6,
           "location": {
             "type": "interior",
-            "buildingId": "fishmonger",
-            "tx": 5,
-            "ty": 3
+            "buildingId": "fishmonger-backroom",
+            "tx": 1,
+            "ty": 2
           },
           "activity": "sleep"
         }
@@ -2351,7 +2352,16 @@
           "zlayer": "solid"
         }
       ],
-      "exits": []
+      "exits": [
+        {
+          "tx": 5,
+          "ty": 0,
+          "toInteriorId": "fishmonger-backroom",
+          "entryTx": 5,
+          "entryTy": 6,
+          "direction": "back"
+        }
+      ]
     },
     "inn-millhaven": {
       "name": "The Anchor Inn",
@@ -3001,6 +3011,36 @@
         }
       ],
       "exits": []
+    },
+    "fishmonger-backroom": {
+      "name": "fishmonger-backroom",
+      "width": 10,
+      "height": 8,
+      "floorTileId": "woodFloor",
+      "decor": [
+        {
+          "tx": 1,
+          "ty": 3,
+          "bundleID": "simple-bed",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 1,
+          "ty": 3,
+          "bundleID": "simple-bed",
+          "zlayer": "solid"
+        }
+      ],
+      "exits": [
+        {
+          "tx": 5,
+          "ty": 7,
+          "toInteriorId": "fishmonger",
+          "direction": "front",
+          "entryTx": 5,
+          "entryTy": 1
+        }
+      ]
     }
   },
   "treasures": [


### PR DESCRIPTION
## Summary
- Dragging an NPC on the canvas while a preview hour is set now edits whichever schedule entry is active at that hour, instead of silently moving the static position the preview isn't even showing
- Chicken pen zones now render behind the same wander-area toggle (🐾) used for cat/dog areas, instead of always being drawn unconditionally
- Extracted the NPC schedule-lookup logic into `npcSchedulePreview.ts`, shared by the canvas renderer and the new drag logic (previously duplicated)
- Includes your own in-progress local commit ("tweaks": HubWorld.tsx toolbar refactor + Millhaven fishmonger-backroom/Sailor Finn schedule additions)

## Test plan
- [x] `npx tsc --noEmit -p .` clean (only pre-existing unrelated `HubWeather` casing error)
- [x] Verified in Storybook: setting a preview hour re-renders a scheduled NPC at its scheduled position
- [x] Verified the wander-area toggle now also reveals a chicken pen's rect (Kipper's area shown when toggled on)

🤖 Generated with [Claude Code](https://claude.com/claude-code)